### PR TITLE
feat(wizard): #169 — StepDomain three-mode (pool / byo-manual / byo-api)

### DIFF
--- a/core/pool-domain-manager/internal/handler/handler.go
+++ b/core/pool-domain-manager/internal/handler/handler.go
@@ -59,6 +59,11 @@ func (h *Handler) Routes() *chi.Mux {
 		})
 		r.Route("/registrar/{registrar}", func(r chi.Router) {
 			r.Post("/set-ns", h.SetNS)
+			// /validate is the read-only twin of /set-ns — checks that the
+			// supplied token CAN reach the registrar and CAN see the named
+			// domain, without flipping any nameservers. The wizard's BYO
+			// Flow B uses this before letting the customer hit Continue.
+			r.Post("/validate", h.Validate)
 		})
 	})
 	return r

--- a/core/pool-domain-manager/internal/handler/registrar.go
+++ b/core/pool-domain-manager/internal/handler/registrar.go
@@ -44,6 +44,104 @@ func (h *Handler) SetRegistry(r registrar.Registry) {
 	h.Registry = r
 }
 
+// ValidateRequest is the JSON body for POST /api/v1/registrar/{r}/validate.
+//
+// The validate endpoint is the read-only twin of /set-ns: it asks the
+// adapter to confirm credentials work and the domain is in the account,
+// without flipping any nameservers. The wizard's BYO Flow B (#169) uses
+// this before letting the customer continue, so a typo in the token
+// surfaces at the prompt instead of mid-provisioning.
+//
+// Same hygiene rules as SetNSRequest — the Token field never gets logged
+// (we never call h.Log with the whole struct).
+type ValidateRequest struct {
+	Domain string `json:"domain"`
+	Token  string `json:"token"`
+}
+
+// ValidateResponse is the JSON reply on success.
+type ValidateResponse struct {
+	Valid     bool   `json:"valid"`
+	Registrar string `json:"registrar"`
+	Domain    string `json:"domain"`
+}
+
+// Validate handles POST /api/v1/registrar/{registrar}/validate.
+//
+// Closes #169 ([I] wizard: StepDomain — BYO with two delegation flows).
+// The wizard calls this BEFORE letting the customer hit Continue so a
+// bad token surfaces at the prompt, not during provisioning. The endpoint
+// performs adapter.ValidateToken only — no writes, no NS flip, nothing
+// the customer hasn't yet consented to.
+func (h *Handler) Validate(w http.ResponseWriter, r *http.Request) {
+	registrarName := strings.ToLower(strings.TrimSpace(chi.URLParam(r, "registrar")))
+
+	if h.Registry == nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]string{
+			"error":  "no-registrars-configured",
+			"detail": "this PDM build has no registrar adapters wired in",
+		})
+		return
+	}
+
+	adapter, err := h.Registry.Lookup(registrarName)
+	if err != nil {
+		writeJSON(w, http.StatusNotFound, map[string]any{
+			"error":     "unsupported-registrar",
+			"detail":    "no adapter for registrar " + registrarName,
+			"supported": h.Registry.Names(),
+		})
+		return
+	}
+
+	var req ValidateRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{
+			"error":  "invalid-body",
+			"detail": "request body must be JSON {domain, token}",
+		})
+		return
+	}
+	domain := strings.ToLower(strings.TrimSpace(req.Domain))
+	token := req.Token
+
+	if domain == "" {
+		writeJSON(w, http.StatusUnprocessableEntity, map[string]string{
+			"error":  "missing-domain",
+			"detail": "domain is required",
+		})
+		return
+	}
+	if token == "" {
+		writeJSON(w, http.StatusUnprocessableEntity, map[string]string{
+			"error":  "missing-token",
+			"detail": "registrar API credentials are required",
+		})
+		return
+	}
+
+	if err := adapter.ValidateToken(r.Context(), token, domain); err != nil {
+		h.Log.Info("registrar validate: failed",
+			"registrar", registrarName,
+			"domain", domain,
+			"outcome", classifyOutcome(err),
+		)
+		writeRegistrarErr(w, err, registrarName, domain)
+		return
+	}
+
+	h.Log.Info("registrar validate: ok",
+		"registrar", registrarName,
+		"domain", domain,
+		"outcome", "ok",
+	)
+	writeJSON(w, http.StatusOK, ValidateResponse{
+		Valid:     true,
+		Registrar: registrarName,
+		Domain:    domain,
+	})
+}
+
 // SetNSRequest is the JSON body for POST /api/v1/registrar/{r}/set-ns.
 //
 // IMPORTANT: do NOT add struct tags that mark Token as loggable. The

--- a/core/pool-domain-manager/internal/handler/registrar_test.go
+++ b/core/pool-domain-manager/internal/handler/registrar_test.go
@@ -78,6 +78,21 @@ func doSetNS(t *testing.T, h *Handler, registrarName string, body string) *httpt
 	return rec
 }
 
+func doValidate(t *testing.T, h *Handler, registrarName string, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	r := chi.NewRouter()
+	r.Route("/api/v1", func(r chi.Router) {
+		r.Route("/registrar/{registrar}", func(r chi.Router) {
+			r.Post("/validate", h.Validate)
+		})
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/registrar/"+registrarName+"/validate", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	return rec
+}
+
 const supersecretToken = "totally-secret-token-7Hf83KjzQ2"
 
 func TestSetNSHappy(t *testing.T) {
@@ -242,6 +257,99 @@ func TestPropagationHint(t *testing.T) {
 	}
 	if propagationHint("unknown") == "" {
 		t.Error("unknown registrar must still get a generic hint")
+	}
+}
+
+// ── /validate (#169) ──────────────────────────────────────────────────
+
+func TestValidateHappy(t *testing.T) {
+	a := &fakeAdapter{name: "cloudflare"}
+	h, logBuf := newTestHandler(t, a)
+	rec := doValidate(t, h, "cloudflare",
+		`{"domain":"example.com","token":"`+supersecretToken+`"}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	var resp ValidateResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	if !resp.Valid || resp.Registrar != "cloudflare" || resp.Domain != "example.com" {
+		t.Fatalf("resp = %+v", resp)
+	}
+	if a.gotToken != supersecretToken {
+		t.Fatalf("adapter did not receive token (got %q)", a.gotToken)
+	}
+	// Crucial — Validate MUST NOT call SetNameservers.
+	if a.gotNS != nil {
+		t.Fatalf("Validate accidentally flipped NS: %v", a.gotNS)
+	}
+	if strings.Contains(logBuf.String(), supersecretToken) {
+		t.Fatalf("LEAKED token in logs: %s", logBuf.String())
+	}
+}
+
+func TestValidateInvalidToken(t *testing.T) {
+	a := &fakeAdapter{name: "cloudflare", validateErr: registrar.ErrInvalidToken}
+	h, _ := newTestHandler(t, a)
+	rec := doValidate(t, h, "cloudflare",
+		`{"domain":"x.com","token":"`+supersecretToken+`"}`)
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d", rec.Code)
+	}
+}
+
+func TestValidateDomainNotInAccount(t *testing.T) {
+	a := &fakeAdapter{name: "cloudflare", validateErr: registrar.ErrDomainNotInAccount}
+	h, _ := newTestHandler(t, a)
+	rec := doValidate(t, h, "cloudflare",
+		`{"domain":"x.com","token":"t"}`)
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status = %d", rec.Code)
+	}
+}
+
+func TestValidateUnsupportedRegistrar(t *testing.T) {
+	a := &fakeAdapter{name: "cloudflare"}
+	h, _ := newTestHandler(t, a)
+	rec := doValidate(t, h, "fakehost",
+		`{"domain":"x.com","token":"t"}`)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d", rec.Code)
+	}
+}
+
+func TestValidateMissingFields(t *testing.T) {
+	a := &fakeAdapter{name: "cloudflare"}
+	h, _ := newTestHandler(t, a)
+	for _, body := range []string{
+		`{"token":"t"}`,
+		`{"domain":"x.com"}`,
+	} {
+		rec := doValidate(t, h, "cloudflare", body)
+		if rec.Code != http.StatusUnprocessableEntity {
+			t.Errorf("body %q → status %d, want 422", body, rec.Code)
+		}
+	}
+}
+
+func TestValidateBadJSON(t *testing.T) {
+	a := &fakeAdapter{name: "cloudflare"}
+	h, _ := newTestHandler(t, a)
+	rec := doValidate(t, h, "cloudflare", `not-json`)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d", rec.Code)
+	}
+}
+
+func TestValidateResponseDoesNotEchoToken(t *testing.T) {
+	a := &fakeAdapter{name: "cloudflare"}
+	h, _ := newTestHandler(t, a)
+	rec := doValidate(t, h, "cloudflare",
+		`{"domain":"x.com","token":"`+supersecretToken+`"}`)
+	body, _ := io.ReadAll(rec.Body)
+	if bytes.Contains(body, []byte(supersecretToken)) {
+		t.Fatalf("response body leaks token: %s", string(body))
 	}
 }
 

--- a/products/catalyst/bootstrap/api/cmd/api/main.go
+++ b/products/catalyst/bootstrap/api/cmd/api/main.go
@@ -41,6 +41,11 @@ func main() {
 	r.Post("/api/v1/deployments", h.CreateDeployment)
 	r.Get("/api/v1/deployments/{id}", h.GetDeployment)
 	r.Get("/api/v1/deployments/{id}/logs", h.StreamLogs)
+	// Registrar proxy — wizard's BYO Flow B (#169). /validate is called
+	// pre-submit so a typo'd token surfaces at the prompt; /set-ns is
+	// called from CreateDeployment when domainMode == byo-api.
+	r.Post("/api/v1/registrar/{registrar}/validate", h.ValidateRegistrar)
+	r.Post("/api/v1/registrar/{registrar}/set-ns", h.SetNSRegistrar)
 	// Phase-retry endpoint for the wizard's failed-phase UX (issue #125).
 	// Phase 0 retries re-run `tofu apply` against the existing workdir;
 	// Phase 1 retries emit operator instructions per the architectural

--- a/products/catalyst/bootstrap/api/internal/handler/registrar.go
+++ b/products/catalyst/bootstrap/api/internal/handler/registrar.go
@@ -1,0 +1,235 @@
+// Package handler — registrar.go: thin proxy to PDM's registrar adapter
+// surface, used by the wizard's BYO Flow B (#169).
+//
+// The wizard never calls PDM directly — it always goes through catalyst-api
+// so a single CORS-allowlist + auth posture covers everything the React
+// app talks to. This file is the proxy seam:
+//
+//	POST /api/v1/registrar/{registrar}/validate
+//	  Body:  {"domain": "...", "token": "..."}
+//	  Reply: {"valid": true, "registrar": "...", "domain": "..."}
+//
+//	POST /api/v1/registrar/{registrar}/set-ns
+//	  (Same shape as PDM's /set-ns; we forward as-is.)
+//
+// Per docs/INVIOLABLE-PRINCIPLES.md #10 (credential hygiene) the Token
+// field never enters a struct that gets logged. We forward bytes verbatim
+// to PDM and stream the response back; the only thing that lands in
+// catalyst-api logs is {registrar, domain, outcome}.
+package handler
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// registrarValidateRequest is what the wizard POSTs to catalyst-api.
+//
+// IMPORTANT: do not add struct tags that mark Token as loggable. The
+// proxy never logs this struct directly — it forwards the bytes to PDM
+// and decodes only the response.
+type registrarValidateRequest struct {
+	Domain string `json:"domain"`
+	Token  string `json:"token"`
+}
+
+// supportedRegistrars lists every adapter the wizard's BYO Flow B
+// dropdown should accept. Keep in sync with the model.ts REGISTRAR_OPTIONS
+// list and PDM's compiled-in adapter set.
+var supportedRegistrars = map[string]struct{}{
+	"cloudflare": {},
+	"namecheap":  {},
+	"godaddy":    {},
+	"ovh":        {},
+	"dynadot":    {},
+}
+
+// ValidateRegistrar handles POST /api/v1/registrar/{registrar}/validate.
+//
+// We don't decode the body to a struct here — we read it once, validate
+// the path param + body shape, then forward the bytes to PDM. This keeps
+// the token's lifetime as short as possible: it never enters a long-lived
+// struct and is GC'd as soon as the http.Client.Do call returns.
+func (h *Handler) ValidateRegistrar(w http.ResponseWriter, r *http.Request) {
+	registrarName := strings.ToLower(strings.TrimSpace(chi.URLParam(r, "registrar")))
+	if _, ok := supportedRegistrars[registrarName]; !ok {
+		writeJSON(w, http.StatusNotFound, map[string]any{
+			"error":  "unsupported-registrar",
+			"detail": "registrar adapter not available",
+		})
+		return
+	}
+
+	raw, err := io.ReadAll(http.MaxBytesReader(w, r.Body, 1<<14))
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{
+			"error":  "request-too-large",
+			"detail": "validation request body must be under 16KB",
+		})
+		return
+	}
+
+	// Sanity check the JSON shape — we want {domain, token} both non-empty.
+	var probe registrarValidateRequest
+	if err := json.Unmarshal(raw, &probe); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{
+			"error":  "invalid-body",
+			"detail": "request body must be JSON {domain, token}",
+		})
+		return
+	}
+	if strings.TrimSpace(probe.Domain) == "" {
+		writeJSON(w, http.StatusUnprocessableEntity, map[string]string{
+			"error":  "missing-domain",
+			"detail": "domain is required",
+		})
+		return
+	}
+	if probe.Token == "" {
+		writeJSON(w, http.StatusUnprocessableEntity, map[string]string{
+			"error":  "missing-token",
+			"detail": "registrar API credentials are required",
+		})
+		return
+	}
+
+	pdmBase := pdmBaseURL()
+	if pdmBase == "" {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]string{
+			"error":  "pdm-unavailable",
+			"detail": "POOL_DOMAIN_MANAGER_URL is not configured",
+		})
+		return
+	}
+
+	target := fmt.Sprintf("%s/api/v1/registrar/%s/validate",
+		strings.TrimRight(pdmBase, "/"),
+		url.PathEscape(registrarName),
+	)
+	ctx, cancel := context.WithTimeout(r.Context(), 15*time.Second)
+	defer cancel()
+
+	pdmReq, err := http.NewRequestWithContext(ctx, http.MethodPost, target, bytes.NewReader(raw))
+	if err != nil {
+		h.log.Error("build pdm validate request", "err", err)
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "proxy-build-failed"})
+		return
+	}
+	pdmReq.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{Timeout: 15 * time.Second}
+	resp, err := client.Do(pdmReq)
+	if err != nil {
+		h.log.Info("pdm validate proxy: network error",
+			"registrar", registrarName,
+			"domain", probe.Domain,
+			"outcome", "pdm-unreachable",
+		)
+		writeJSON(w, http.StatusBadGateway, map[string]string{
+			"error":  "pdm-unreachable",
+			"detail": "pool-domain-manager is temporarily unreachable",
+		})
+		return
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+
+	// Stream PDM's status + body verbatim so the wizard's error mapping
+	// has the same vocabulary it would see talking to PDM directly.
+	h.log.Info("pdm validate proxy: complete",
+		"registrar", registrarName,
+		"domain", probe.Domain,
+		"status", resp.StatusCode,
+	)
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(resp.StatusCode)
+	_, _ = w.Write(body)
+}
+
+// SetNSRegistrar handles POST /api/v1/registrar/{registrar}/set-ns.
+//
+// Mirror of ValidateRegistrar but forwards to PDM's /set-ns. Used by the
+// CreateDeployment branch when sovereignDomainMode == "byo-api". The
+// wizard does NOT call this directly — only catalyst-api does, on submit.
+func (h *Handler) SetNSRegistrar(w http.ResponseWriter, r *http.Request) {
+	registrarName := strings.ToLower(strings.TrimSpace(chi.URLParam(r, "registrar")))
+	if _, ok := supportedRegistrars[registrarName]; !ok {
+		writeJSON(w, http.StatusNotFound, map[string]any{
+			"error":  "unsupported-registrar",
+			"detail": "registrar adapter not available",
+		})
+		return
+	}
+
+	raw, err := io.ReadAll(http.MaxBytesReader(w, r.Body, 1<<14))
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{
+			"error":  "request-too-large",
+			"detail": "set-ns request body must be under 16KB",
+		})
+		return
+	}
+
+	pdmBase := pdmBaseURL()
+	if pdmBase == "" {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]string{
+			"error":  "pdm-unavailable",
+			"detail": "POOL_DOMAIN_MANAGER_URL is not configured",
+		})
+		return
+	}
+
+	target := fmt.Sprintf("%s/api/v1/registrar/%s/set-ns",
+		strings.TrimRight(pdmBase, "/"),
+		url.PathEscape(registrarName),
+	)
+	ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
+	defer cancel()
+
+	pdmReq, err := http.NewRequestWithContext(ctx, http.MethodPost, target, bytes.NewReader(raw))
+	if err != nil {
+		h.log.Error("build pdm set-ns request", "err", err)
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "proxy-build-failed"})
+		return
+	}
+	pdmReq.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Do(pdmReq)
+	if err != nil {
+		h.log.Info("pdm set-ns proxy: network error",
+			"registrar", registrarName,
+			"outcome", "pdm-unreachable",
+		)
+		writeJSON(w, http.StatusBadGateway, map[string]string{
+			"error":  "pdm-unreachable",
+			"detail": "pool-domain-manager is temporarily unreachable",
+		})
+		return
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(resp.StatusCode)
+	_, _ = w.Write(body)
+}
+
+// pdmBaseURL is read every call so a config-map rotation propagates
+// without a Pod restart. Same default as handler.New() so the proxy and
+// the rest of the package agree.
+func pdmBaseURL() string {
+	if v := strings.TrimSpace(os.Getenv("POOL_DOMAIN_MANAGER_URL")); v != "" {
+		return v
+	}
+	return "http://pool-domain-manager.openova-system.svc.cluster.local:8080"
+}

--- a/products/catalyst/bootstrap/ui/src/app/layouts/WizardLayout.tsx
+++ b/products/catalyst/bootstrap/ui/src/app/layouts/WizardLayout.tsx
@@ -8,12 +8,13 @@ import { useTheme } from '@/shared/lib/useTheme'
 import { OOLogo } from '@/shared/ui/OOLogo'
 
 export const WIZARD_STEPS = [
-  { id: 1, label: 'Organisation', desc: 'Name, domain, contact'    },
-  { id: 2, label: 'Topology',     desc: 'Regions and clusters'      },
-  { id: 3, label: 'Provider',     desc: 'Cloud provider per region' },
-  { id: 4, label: 'Credentials',  desc: 'API access tokens'         },
-  { id: 5, label: 'Components',   desc: 'Platform building blocks'  },
-  { id: 6, label: 'Review',       desc: 'Confirm and provision'     },
+  { id: 1, label: 'Organisation', desc: 'Name, domain, contact'         },
+  { id: 2, label: 'Domain',       desc: 'Pool or BYO + delegation'      },
+  { id: 3, label: 'Topology',     desc: 'Regions and clusters'          },
+  { id: 4, label: 'Provider',     desc: 'Cloud provider per region'     },
+  { id: 5, label: 'Credentials',  desc: 'API access tokens'             },
+  { id: 6, label: 'Components',   desc: 'Platform building blocks'      },
+  { id: 7, label: 'Review',       desc: 'Confirm and provision'         },
 ]
 
 /**

--- a/products/catalyst/bootstrap/ui/src/entities/deployment/model.ts
+++ b/products/catalyst/bootstrap/ui/src/entities/deployment/model.ts
@@ -15,7 +15,61 @@ export interface SelectedComponent {
   id: string; name: string; version: string; category: string; required: boolean; dependencies: string[]
 }
 
-export type DomainMode = 'pool' | 'byo'
+/**
+ * Domain delegation mode. Closes #169.
+ *
+ *  - 'pool'       OpenOva-managed pool (e.g. omani.works) — PDM owns DNS.
+ *  - 'byo-manual' Customer brings their own domain. They paste the OpenOva
+ *                 nameservers into their registrar's UI by hand. Wizard
+ *                 polls until propagation completes, then continues.
+ *  - 'byo-api'    Customer brings their own domain AND provides registrar
+ *                 API credentials. catalyst-api/PDM flips the NS records
+ *                 via the registrar's REST API on their behalf.
+ *
+ * Legacy 'byo' is preserved as an alias for 'byo-manual' so persisted
+ * Zustand state from earlier wizard runs still loads cleanly. The store's
+ * merge() coerces the legacy value.
+ */
+export type DomainMode = 'pool' | 'byo-manual' | 'byo-api'
+
+/** Legacy persistence alias. Treat 'byo' as 'byo-manual' on load. */
+export const LEGACY_BYO_MODE = 'byo' as const
+
+/**
+ * Registrar identifier for BYO-api mode. Mirrors the adapter names PDM
+ * exposes via /api/v1/registrar/{registrar}/set-ns. Keep this list in sync
+ * with `core/pool-domain-manager/internal/registrar/` subpackages.
+ */
+export type RegistrarType = 'cloudflare' | 'namecheap' | 'godaddy' | 'ovh' | 'dynadot'
+
+export interface RegistrarOption {
+  id: RegistrarType
+  label: string
+  tokenHint: string
+}
+
+export const REGISTRAR_OPTIONS: RegistrarOption[] = [
+  { id: 'cloudflare', label: 'Cloudflare', tokenHint: 'API token with Zone:Edit + DNS:Edit permission for the domain' },
+  { id: 'namecheap',  label: 'Namecheap',  tokenHint: 'apiUser:apiKey:clientIP — Namecheap requires the calling IP' },
+  { id: 'godaddy',    label: 'GoDaddy',    tokenHint: 'API key:secret (production tier)' },
+  { id: 'ovh',        label: 'OVH',        tokenHint: 'appKey:appSecret:consumerKey' },
+  { id: 'dynadot',    label: 'Dynadot',    tokenHint: 'API key from Dynadot account → Tools → API' },
+]
+
+/**
+ * Default OpenOva nameservers the customer must delegate their BYO domain
+ * to. These are OpenOva-operated PowerDNS instances reachable from the
+ * public internet.
+ *
+ * Per docs/INVIOLABLE-PRINCIPLES.md #4: when a runtime endpoint is wired
+ * (catalyst-api /api/v1/dns/nameservers, future), the wizard will fetch
+ * these instead of importing the constant.
+ */
+export const OPENOVA_NAMESERVERS: readonly string[] = [
+  'ns1.openova.io',
+  'ns2.openova.io',
+  'ns3.openova.io',
+] as const
 
 export interface SovereignPoolDomain {
   /** Pool domain owned by OpenOva (or by a franchised Sovereign owner). Sovereign tenants pick a subdomain under it. */
@@ -27,15 +81,27 @@ export interface SovereignPoolDomain {
 export interface WizardState {
   orgName: string; orgDomain: string; orgEmail: string; orgIndustry: string
   orgSize: string; orgHeadquarters: string; orgCompliance: string[]
-  /** 'pool' = use a shared OpenOva-provided domain like omani.works with a sovereign-chosen subdomain.
-   *  'byo'  = customer brings their own domain. */
+  /** Three-mode selector — see DomainMode docstring. Closes #169. */
   sovereignDomainMode: DomainMode
   /** When sovereignDomainMode='pool', which pool domain to use (id, e.g. 'omani-works'). */
   sovereignPoolDomain: string
   /** When sovereignDomainMode='pool', the subdomain the customer types (e.g. 'omantel' → omantel.omani.works). */
   sovereignSubdomain: string
-  /** When sovereignDomainMode='byo', the full domain the customer brings (e.g. 'sovereign.acme-bank.com'). */
+  /** When sovereignDomainMode in ('byo-manual','byo-api'), the full domain
+   *  the customer brings (e.g. 'acme.com' or 'sovereign.acme-bank.com'). */
   sovereignByoDomain: string
+  /** When sovereignDomainMode='byo-api', the registrar adapter to use. */
+  registrarType: RegistrarType | null
+  /**
+   * When sovereignDomainMode='byo-api', the customer's API token. Held in
+   * memory ONLY — partialize() in the store strips it before localStorage
+   * persist (same hygiene as the SSH private key per
+   * docs/INVIOLABLE-PRINCIPLES.md #10).
+   */
+  registrarToken: string
+  /** True after POST /api/v1/registrar/{r}/validate (validation-only call)
+   *  reports the credentials work and the domain is in the account. */
+  registrarTokenValidated: boolean
   topology: TopologyTemplate | null
   regionProviders: Record<number, CloudProvider>
   regionCloudRegions: Record<number, string>
@@ -288,6 +354,9 @@ export const INITIAL_WIZARD_STATE: WizardState = {
   sovereignPoolDomain: SOVEREIGN_POOL_DOMAINS[0]!.id,
   sovereignSubdomain: '',
   sovereignByoDomain: '',
+  registrarType: null,
+  registrarToken: '',
+  registrarTokenValidated: false,
   topology: 'zoned',
   regionProviders: {}, regionCloudRegions: {},
   providerTokens: {}, providerValidated: {},
@@ -317,7 +386,13 @@ export function resolveSovereignDomain(state: Pick<WizardState, 'sovereignDomain
     if (!pool || !state.sovereignSubdomain) return ''
     return `${state.sovereignSubdomain}.${pool.domain}`
   }
+  // BYO modes both consume the same byoDomain field.
   return state.sovereignByoDomain.trim()
+}
+
+/** Convenience type-guard for the two BYO variants. */
+export function isByoMode(mode: DomainMode): mode is 'byo-manual' | 'byo-api' {
+  return mode === 'byo-manual' || mode === 'byo-api'
 }
 
 /** Validate that the chosen subdomain is a syntactically valid DNS label per RFC 1035. */

--- a/products/catalyst/bootstrap/ui/src/entities/deployment/store.test.ts
+++ b/products/catalyst/bootstrap/ui/src/entities/deployment/store.test.ts
@@ -1,0 +1,111 @@
+/**
+ * store.test.ts — vitest coverage for the wizard store mutations introduced
+ * by #169 (BYO domain).
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import { useWizardStore } from './store'
+import { INITIAL_WIZARD_STATE } from './model'
+
+beforeEach(() => {
+  useWizardStore.setState({ ...INITIAL_WIZARD_STATE })
+})
+
+describe('wizard store — domain mode', () => {
+  it('clears pool subdomain when switching to byo-manual', () => {
+    useWizardStore.setState({
+      ...INITIAL_WIZARD_STATE,
+      sovereignSubdomain: 'omantel-prod',
+    })
+    useWizardStore.getState().setSovereignDomainMode('byo-manual')
+    expect(useWizardStore.getState().sovereignSubdomain).toBe('')
+  })
+
+  it('clears registrar credentials when switching to pool', () => {
+    useWizardStore.setState({
+      ...INITIAL_WIZARD_STATE,
+      sovereignDomainMode: 'byo-api',
+      sovereignByoDomain: 'acme.com',
+      registrarType: 'cloudflare',
+      registrarToken: 'secret-cf-token',
+      registrarTokenValidated: true,
+    })
+    useWizardStore.getState().setSovereignDomainMode('pool')
+    const s = useWizardStore.getState()
+    expect(s.sovereignByoDomain).toBe('')
+    expect(s.registrarType).toBeNull()
+    expect(s.registrarToken).toBe('')
+    expect(s.registrarTokenValidated).toBe(false)
+  })
+
+  it('keeps the typed BYO domain when switching from byo-manual to byo-api', () => {
+    useWizardStore.setState({
+      ...INITIAL_WIZARD_STATE,
+      sovereignDomainMode: 'byo-manual',
+      sovereignByoDomain: 'acme.com',
+    })
+    useWizardStore.getState().setSovereignDomainMode('byo-api')
+    expect(useWizardStore.getState().sovereignByoDomain).toBe('acme.com')
+  })
+})
+
+describe('wizard store — registrar credentials', () => {
+  it('invalidates the validated flag on every token edit', () => {
+    useWizardStore.setState({
+      ...INITIAL_WIZARD_STATE,
+      sovereignDomainMode: 'byo-api',
+      registrarType: 'cloudflare',
+      registrarToken: 'old',
+      registrarTokenValidated: true,
+    })
+    useWizardStore.getState().setRegistrarToken('new')
+    expect(useWizardStore.getState().registrarTokenValidated).toBe(false)
+  })
+
+  it('invalidates the validated flag on registrar swap', () => {
+    useWizardStore.setState({
+      ...INITIAL_WIZARD_STATE,
+      sovereignDomainMode: 'byo-api',
+      registrarType: 'cloudflare',
+      registrarToken: 'cf-token',
+      registrarTokenValidated: true,
+    })
+    useWizardStore.getState().setRegistrarType('godaddy')
+    expect(useWizardStore.getState().registrarTokenValidated).toBe(false)
+  })
+
+  it('clearRegistrarCredentials wipes all three fields', () => {
+    useWizardStore.setState({
+      ...INITIAL_WIZARD_STATE,
+      sovereignDomainMode: 'byo-api',
+      registrarType: 'cloudflare',
+      registrarToken: 'cf-token',
+      registrarTokenValidated: true,
+    })
+    useWizardStore.getState().clearRegistrarCredentials()
+    const s = useWizardStore.getState()
+    expect(s.registrarType).toBeNull()
+    expect(s.registrarToken).toBe('')
+    expect(s.registrarTokenValidated).toBe(false)
+  })
+})
+
+describe('wizard store — persistence hygiene', () => {
+  it('drops registrarToken and registrarTokenValidated from the persist payload', () => {
+    useWizardStore.setState({
+      ...INITIAL_WIZARD_STATE,
+      sovereignDomainMode: 'byo-api',
+      registrarType: 'cloudflare',
+      registrarToken: 'super-secret-token',
+      registrarTokenValidated: true,
+    })
+    const raw = window.localStorage.getItem('openova-catalyst-wizard')
+    expect(raw).toBeTruthy()
+    if (raw) {
+      const parsed = JSON.parse(raw) as { state: Record<string, unknown> }
+      expect('registrarToken' in parsed.state).toBe(false)
+      expect('registrarTokenValidated' in parsed.state).toBe(false)
+      expect(parsed.state.registrarType).toBe('cloudflare')
+    }
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/entities/deployment/store.ts
+++ b/products/catalyst/bootstrap/ui/src/entities/deployment/store.ts
@@ -63,11 +63,17 @@ interface WizardActions {
   setOrgHeadquarters: (hq: string) => void
   setOrgCompliance: (tags: string[]) => void
 
-  // Step 1 — Sovereign domain (pool or BYO)
+  // Step 1 — Sovereign domain (pool, byo-manual, byo-api)
   setSovereignDomainMode: (mode: import('./model').DomainMode) => void
   setSovereignPoolDomain: (id: string) => void
   setSovereignSubdomain: (subdomain: string) => void
   setSovereignByoDomain: (domain: string) => void
+
+  // Step 1 — BYO-api registrar credentials (#169 BYO Flow B)
+  setRegistrarType: (registrar: import('./model').RegistrarType | null) => void
+  setRegistrarToken: (token: string) => void
+  setRegistrarTokenValidated: (validated: boolean) => void
+  clearRegistrarCredentials: () => void
 
   // Step 2 — Topology (resets per-region providers when topology changes)
   setTopology: (topology: TopologyTemplate) => void
@@ -174,16 +180,61 @@ export const useWizardStore = create<WizardStore>()(
 
         // Sovereign-domain setters
         setSovereignDomainMode: (sovereignDomainMode) =>
-          set({ sovereignDomainMode }, false, 'wizard/setSovereignDomainMode'),
+          set(
+            () => {
+              // Switching modes wipes anything that doesn't apply, so the
+              // wizard never carries a stale registrar token into byo-manual
+              // (or vice versa) and never silently keeps the typed BYO
+              // domain when the user switches back to pool.
+              if (sovereignDomainMode === 'pool') {
+                return {
+                  sovereignDomainMode,
+                  sovereignByoDomain: '',
+                  registrarType: null,
+                  registrarToken: '',
+                  registrarTokenValidated: false,
+                }
+              }
+              if (sovereignDomainMode === 'byo-manual') {
+                return {
+                  sovereignDomainMode,
+                  sovereignSubdomain: '',
+                  registrarType: null,
+                  registrarToken: '',
+                  registrarTokenValidated: false,
+                }
+              }
+              // byo-api — keep typed domain; force a re-validation.
+              return {
+                sovereignDomainMode,
+                sovereignSubdomain: '',
+                registrarTokenValidated: false,
+              }
+            },
+            false,
+            'wizard/setSovereignDomainMode',
+          ),
         setSovereignPoolDomain: (sovereignPoolDomain) =>
           set({ sovereignPoolDomain }, false, 'wizard/setSovereignPoolDomain'),
         setSovereignSubdomain: (sovereignSubdomain) =>
-          // normalize: lowercase, strip whitespace; keep validation in the form layer
           set({ sovereignSubdomain: sovereignSubdomain.toLowerCase().replace(/\s+/g, '') },
               false, 'wizard/setSovereignSubdomain'),
         setSovereignByoDomain: (sovereignByoDomain) =>
           set({ sovereignByoDomain: sovereignByoDomain.toLowerCase().trim() },
               false, 'wizard/setSovereignByoDomain'),
+
+        // BYO-api registrar credentials (#169) — token never persists to
+        // localStorage (partialize() strips it). Every mutation invalidates
+        // the validated flag so a typo'd or rotated token must be re-proved.
+        setRegistrarType: (registrarType) =>
+          set({ registrarType, registrarTokenValidated: false }, false, 'wizard/setRegistrarType'),
+        setRegistrarToken: (registrarToken) =>
+          set({ registrarToken, registrarTokenValidated: false }, false, 'wizard/setRegistrarToken'),
+        setRegistrarTokenValidated: (registrarTokenValidated) =>
+          set({ registrarTokenValidated }, false, 'wizard/setRegistrarTokenValidated'),
+        clearRegistrarCredentials: () =>
+          set({ registrarType: null, registrarToken: '', registrarTokenValidated: false },
+              false, 'wizard/clearRegistrarCredentials'),
 
         // Reset regionProviders and regionCloudRegions when topology changes
         setTopology: (topology) =>
@@ -382,14 +433,41 @@ export const useWizardStore = create<WizardStore>()(
         // the user, not assume "I downloaded the .pem already" from a prior
         // session.
         partialize: (state) => {
-          const { sshPrivateKeyOnce: _omitPriv, sshKeyGeneratedThisSession: _omitFlag, ...rest } = state
-          // void to satisfy noUnusedLocals — these names exist solely to be omitted.
-          void _omitPriv; void _omitFlag
+          // Per docs/INVIOLABLE-PRINCIPLES.md #10 (credential hygiene):
+          //   • sshPrivateKeyOnce — Mode-A break-glass private key
+          //   • registrarToken    — BYO Flow B registrar API credential
+          // Both are in-memory only. registrarTokenValidated drops too —
+          // a fresh tab must re-prove the token even if the password
+          // manager re-fills the field.
+          const {
+            sshPrivateKeyOnce: _omitPriv,
+            sshKeyGeneratedThisSession: _omitGenFlag,
+            registrarToken: _omitTok,
+            registrarTokenValidated: _omitTokFlag,
+            ...rest
+          } = state
+          void _omitPriv; void _omitGenFlag; void _omitTok; void _omitTokFlag
           return rest as unknown as WizardState
         },
         // Merge saved state with initial — handles new fields added after first install
         merge: (persisted, current) => {
           const p = { ...(persisted as Partial<WizardState>) }
+          // #169 — legacy 'byo' value from earlier wizard runs maps to
+          // 'byo-manual'. Anything outside the new vocabulary falls back
+          // to 'pool' (safer than carrying a corrupted value forward).
+          const validModes: import('./model').DomainMode[] = ['pool', 'byo-manual', 'byo-api']
+          const persistedMode = (p as { sovereignDomainMode?: string }).sovereignDomainMode
+          if (persistedMode === 'byo') {
+            p.sovereignDomainMode = 'byo-manual'
+          } else if (persistedMode && !validModes.includes(persistedMode as import('./model').DomainMode)) {
+            p.sovereignDomainMode = 'pool'
+          }
+          // Always start with cleared registrar credentials — partialize()
+          // already strips them, this double-protects an older payload that
+          // accidentally retained them.
+          p.registrarType = (p.registrarType ?? null) as import('./model').RegistrarType | null
+          p.registrarToken = ''
+          p.registrarTokenValidated = false
           // Sanitize stale topology values
           const validTopologies: TopologyTemplate[] = ['citadel', 'triangle', 'dual', 'zoned', 'compact', 'solo']
           if (p.topology && !validTopologies.includes(p.topology)) {

--- a/products/catalyst/bootstrap/ui/src/pages/wizard/WizardPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/wizard/WizardPage.tsx
@@ -2,6 +2,7 @@ import { useEffect } from 'react'
 import { AnimatePresence, motion } from 'framer-motion'
 import { useWizardStore } from '@/entities/deployment/store'
 import { StepOrg }         from './steps/StepOrg'
+import { StepDomain }      from './steps/StepDomain'
 import { StepTopology }    from './steps/StepTopology'
 import { StepProvider }    from './steps/StepProvider'
 import { StepCredentials } from './steps/StepCredentials'
@@ -9,7 +10,10 @@ import { StepComponents }  from './steps/StepComponents'
 import { StepReview }      from './steps/StepReview'
 import { StepSuccess }     from './steps/StepSuccess'
 
-const STEPS = [StepOrg, StepTopology, StepProvider, StepCredentials, StepComponents, StepReview, StepSuccess]
+// StepDomain promoted into its own step for #169 — three-mode (pool /
+// byo-manual / byo-api) UX needs more vertical space than fits inside the
+// org-profile step.
+const STEPS = [StepOrg, StepDomain, StepTopology, StepProvider, StepCredentials, StepComponents, StepReview, StepSuccess]
 
 const variants = {
   enter:  (dir: number) => ({ x: dir > 0 ? 32 : -32, opacity: 0 }),

--- a/products/catalyst/bootstrap/ui/src/pages/wizard/steps/StepDomain.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/wizard/steps/StepDomain.test.tsx
@@ -1,0 +1,218 @@
+/**
+ * StepDomain.test.tsx — vitest coverage for the three-mode (pool /
+ * byo-manual / byo-api) domain capture step. Closes #169.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, screen, fireEvent, cleanup, waitFor } from '@testing-library/react'
+import { StepDomain } from './StepDomain'
+import { useWizardStore } from '@/entities/deployment/store'
+import {
+  INITIAL_WIZARD_STATE,
+  OPENOVA_NAMESERVERS,
+  REGISTRAR_OPTIONS,
+} from '@/entities/deployment/model'
+
+beforeEach(() => {
+  useWizardStore.setState({ ...INITIAL_WIZARD_STATE })
+})
+
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+})
+
+describe('StepDomain — mode toggle', () => {
+  it('renders all three radio cards', () => {
+    render(<StepDomain />)
+    expect(screen.getByTestId('domain-mode-pool')).toBeTruthy()
+    expect(screen.getByTestId('domain-mode-byo-manual')).toBeTruthy()
+    expect(screen.getByTestId('domain-mode-byo-api')).toBeTruthy()
+  })
+
+  it('starts in pool mode by default', () => {
+    render(<StepDomain />)
+    expect(useWizardStore.getState().sovereignDomainMode).toBe('pool')
+    expect(screen.getByTestId('pool-subdomain-input')).toBeTruthy()
+  })
+
+  it('switches to byo-manual and clears the pool subdomain', () => {
+    useWizardStore.setState({
+      ...INITIAL_WIZARD_STATE,
+      sovereignSubdomain: 'omantel-prod',
+    })
+    render(<StepDomain />)
+    fireEvent.click(screen.getByTestId('domain-mode-byo-manual'))
+    expect(useWizardStore.getState().sovereignDomainMode).toBe('byo-manual')
+    expect(useWizardStore.getState().sovereignSubdomain).toBe('')
+    expect(screen.getByTestId('byo-domain-input')).toBeTruthy()
+    expect(screen.getByTestId('byo-ns-instructions')).toBeTruthy()
+  })
+
+  it('switches to byo-api and exposes registrar + token fields', () => {
+    render(<StepDomain />)
+    fireEvent.click(screen.getByTestId('domain-mode-byo-api'))
+    expect(useWizardStore.getState().sovereignDomainMode).toBe('byo-api')
+    expect(screen.getByTestId('byo-api-registrar-select')).toBeTruthy()
+    expect(screen.getByTestId('byo-api-token-input')).toBeTruthy()
+    expect(screen.getByTestId('byo-api-validate-button')).toBeTruthy()
+  })
+
+  it('drops registrar credentials when switching away from byo-api', () => {
+    useWizardStore.setState({
+      ...INITIAL_WIZARD_STATE,
+      sovereignDomainMode: 'byo-api',
+      registrarType: 'cloudflare',
+      registrarToken: 'secret-token-do-not-leak',
+      registrarTokenValidated: true,
+    })
+    render(<StepDomain />)
+    fireEvent.click(screen.getByTestId('domain-mode-pool'))
+    const s = useWizardStore.getState()
+    expect(s.registrarType).toBeNull()
+    expect(s.registrarToken).toBe('')
+    expect(s.registrarTokenValidated).toBe(false)
+  })
+})
+
+describe('StepDomain — pool mode', () => {
+  it('writes the subdomain to the store as the user types', () => {
+    render(<StepDomain />)
+    const input = screen.getByTestId('pool-subdomain-input') as HTMLInputElement
+    fireEvent.change(input, { target: { value: 'Omantel-Prod' } })
+    expect(useWizardStore.getState().sovereignSubdomain).toBe('omantel-prod')
+  })
+
+  it('renders the pool dropdown defaulted to omani-works', () => {
+    render(<StepDomain />)
+    const select = screen.getByTestId('pool-domain-select') as HTMLSelectElement
+    expect(select.value).toBe('omani-works')
+  })
+})
+
+describe('StepDomain — byo-manual mode', () => {
+  beforeEach(() => {
+    useWizardStore.setState({
+      ...INITIAL_WIZARD_STATE,
+      sovereignDomainMode: 'byo-manual',
+    })
+  })
+
+  it('writes the typed domain to the store', () => {
+    render(<StepDomain />)
+    const input = screen.getByTestId('byo-domain-input') as HTMLInputElement
+    fireEvent.change(input, { target: { value: 'acme.com' } })
+    expect(useWizardStore.getState().sovereignByoDomain).toBe('acme.com')
+  })
+
+  it('renders all OpenOva nameservers verbatim', () => {
+    render(<StepDomain />)
+    for (const ns of OPENOVA_NAMESERVERS) {
+      expect(screen.getByText(ns)).toBeTruthy()
+    }
+  })
+
+  it('exposes a copy button for each nameserver', () => {
+    render(<StepDomain />)
+    for (let i = 0; i < OPENOVA_NAMESERVERS.length; i++) {
+      expect(screen.getByTestId(`byo-ns-copy-${i}`)).toBeTruthy()
+    }
+  })
+})
+
+describe('StepDomain — byo-api mode', () => {
+  beforeEach(() => {
+    useWizardStore.setState({
+      ...INITIAL_WIZARD_STATE,
+      sovereignDomainMode: 'byo-api',
+    })
+  })
+
+  it('lists every supported registrar in the dropdown', () => {
+    render(<StepDomain />)
+    const select = screen.getByTestId('byo-api-registrar-select') as HTMLSelectElement
+    const optionValues = Array.from(select.options).map(o => o.value).filter(Boolean)
+    expect(optionValues.sort()).toEqual([...REGISTRAR_OPTIONS.map(r => r.id)].sort())
+  })
+
+  it('disables the Validate button until domain + registrar + token are present', () => {
+    render(<StepDomain />)
+    const btn = screen.getByTestId('byo-api-validate-button') as HTMLButtonElement
+    expect(btn.disabled).toBe(true)
+    fireEvent.change(screen.getByTestId('byo-api-domain-input'), { target: { value: 'acme.com' } })
+    expect(btn.disabled).toBe(true)
+    fireEvent.change(screen.getByTestId('byo-api-registrar-select'), { target: { value: 'cloudflare' } })
+    expect(btn.disabled).toBe(true)
+    fireEvent.change(screen.getByTestId('byo-api-token-input'), { target: { value: 'cf-token-123' } })
+    expect(btn.disabled).toBe(false)
+  })
+
+  it('POSTs to /api/v1/registrar/{r}/validate and flips the validated flag on success', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true, status: 200, json: async () => ({ valid: true }),
+    } as Response)
+    vi.stubGlobal('fetch', fetchMock)
+
+    useWizardStore.setState({
+      ...INITIAL_WIZARD_STATE,
+      sovereignDomainMode: 'byo-api',
+      sovereignByoDomain: 'acme.com',
+      registrarType: 'cloudflare',
+      registrarToken: 'cf-token-123',
+    })
+    render(<StepDomain />)
+    fireEvent.click(screen.getByTestId('byo-api-validate-button'))
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled())
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(String(url)).toMatch(/\/api\/v1\/registrar\/cloudflare\/validate$/)
+    expect(init?.method).toBe('POST')
+    const body = JSON.parse(init?.body as string)
+    expect(body.domain).toBe('acme.com')
+    expect(body.token).toBe('cf-token-123')
+
+    await waitFor(() => {
+      expect(useWizardStore.getState().registrarTokenValidated).toBe(true)
+    })
+    expect(screen.getByTestId('byo-api-validated-banner')).toBeTruthy()
+  })
+
+  it('surfaces an error and leaves validated=false on a 401 invalid-token response', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false, status: 401,
+        json: async () => ({ error: 'invalid-token', detail: 'token rejected' }),
+      } as Response),
+    )
+
+    useWizardStore.setState({
+      ...INITIAL_WIZARD_STATE,
+      sovereignDomainMode: 'byo-api',
+      sovereignByoDomain: 'acme.com',
+      registrarType: 'cloudflare',
+      registrarToken: 'wrong-token',
+    })
+    render(<StepDomain />)
+    fireEvent.click(screen.getByTestId('byo-api-validate-button'))
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert').textContent).toMatch(/Token rejected/i)
+    })
+    expect(useWizardStore.getState().registrarTokenValidated).toBe(false)
+  })
+
+  it('invalidates a previously-validated token when the customer edits it', () => {
+    useWizardStore.setState({
+      ...INITIAL_WIZARD_STATE,
+      sovereignDomainMode: 'byo-api',
+      sovereignByoDomain: 'acme.com',
+      registrarType: 'cloudflare',
+      registrarToken: 'old-token',
+      registrarTokenValidated: true,
+    })
+    render(<StepDomain />)
+    fireEvent.change(screen.getByTestId('byo-api-token-input'), { target: { value: 'new-token' } })
+    expect(useWizardStore.getState().registrarTokenValidated).toBe(false)
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/pages/wizard/steps/StepDomain.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/wizard/steps/StepDomain.tsx
@@ -1,0 +1,545 @@
+/**
+ * StepDomain — sovereign-domain capture, three-mode (pool / byo-manual /
+ * byo-api). Closes #169 ([I] wizard: StepDomain — Bring Your Own Domain).
+ *
+ * The wizard's previous "domain" UX lived as a section inside StepOrg. With
+ * BYO bringing two delegation flows (manual NS edit, registrar-API NS flip)
+ * the section grew past what fits beneath the org-profile fields, so #169
+ * promotes it to its own step.
+ *
+ * All three modes end at the SAME outcome: a per-Sovereign zone exists in
+ * OpenOva PowerDNS so cert-manager DNS-01 + the sovereign LB can resolve.
+ *
+ *   pool        ─ existing PDM /reserve flow (unchanged behaviour vs. #163)
+ *   byo-manual  ─ customer types their domain; wizard shows the OpenOva
+ *                 nameservers and tells them to paste those into their
+ *                 registrar's UI; catalyst-api polls until propagation.
+ *   byo-api     ─ customer types their domain + picks registrar + pastes
+ *                 token; wizard validates the token via PDM /validate
+ *                 (read-only) BEFORE letting them continue.
+ *
+ * Per docs/INVIOLABLE-PRINCIPLES.md:
+ *   #4  no hardcoded URLs — API_BASE drives all fetch calls; nameservers
+ *       come from OPENOVA_NAMESERVERS so a future runtime endpoint can
+ *       replace the constant without touching this file
+ *   #10 credential hygiene — registrarToken is in-memory only; the store's
+ *       partialize() omits it from localStorage. Same posture as the SSH
+ *       break-glass private key.
+ */
+
+import { useState } from 'react'
+import {
+  AlertCircle,
+  CheckCircle2,
+  Copy,
+  Eye,
+  EyeOff,
+  KeyRound,
+  Loader2,
+  RefreshCw,
+  Sparkles,
+} from 'lucide-react'
+import { useWizardStore } from '@/entities/deployment/store'
+import {
+  isValidDomain,
+  isValidSubdomain,
+  OPENOVA_NAMESERVERS,
+  REGISTRAR_OPTIONS,
+  resolveSovereignDomain,
+  SOVEREIGN_POOL_DOMAINS,
+  type DomainMode,
+  type RegistrarType,
+} from '@/entities/deployment/model'
+import { useSubdomainAvailability } from '@/shared/lib/useSubdomainAvailability'
+import { API_BASE } from '@/shared/config/urls'
+import { StepShell, useStepNav } from './_shared'
+
+const MODE_OPTIONS: { id: DomainMode; label: string; sub: string }[] = [
+  { id: 'pool',       label: 'OpenOva pool domain',  sub: 'recommended for first deployment' },
+  { id: 'byo-manual', label: "I'll change NS at my registrar manually",
+                                                     sub: 'we show you the records to paste' },
+  { id: 'byo-api',    label: 'Let OpenOva flip NS via my registrar API',
+                                                     sub: 'paste a token, we do the rest' },
+]
+
+export function StepDomain() {
+  const store = useWizardStore()
+  const { next } = useStepNav()
+
+  const pool = SOVEREIGN_POOL_DOMAINS.find(p => p.id === store.sovereignPoolDomain) ?? SOVEREIGN_POOL_DOMAINS[0]!
+  const availability = useSubdomainAvailability(
+    store.sovereignDomainMode === 'pool' ? store.sovereignSubdomain : '',
+    pool.domain,
+  )
+
+  const resolved = resolveSovereignDomain(store)
+  const nextDisabled = computeNextDisabled(store, availability.status)
+
+  return (
+    <StepShell
+      title="Where will your Sovereign live in DNS?"
+      description="Pool gives you a working URL in seconds. BYO lets you keep the domain you already own — pick the manual flow if your registrar isn't on the API list, or the API flow if you'd rather we flip the NS records for you."
+      onNext={next}
+      nextDisabled={nextDisabled}
+    >
+      {resolved && (
+        <div
+          data-testid="domain-preview"
+          style={{
+            display: 'inline-flex', gap: 8, alignItems: 'center',
+            padding: '6px 10px', borderRadius: 8,
+            border: '1px solid rgba(56,189,248,0.25)',
+            background: 'rgba(56,189,248,0.06)',
+            alignSelf: 'flex-start',
+          }}
+        >
+          <span style={{ fontSize: 11, color: 'var(--wiz-text-sub)' }}>Sovereign URL:</span>
+          <code style={{ fontSize: 12, color: '#38BDF8', fontFamily: 'JetBrains Mono, monospace' }}>
+            console.{resolved}
+          </code>
+        </div>
+      )}
+
+      <fieldset style={{ border: 'none', padding: 0, margin: 0, display: 'flex', flexDirection: 'column', gap: 8 }}>
+        <legend style={{ fontSize: 12, fontWeight: 500, color: 'var(--wiz-text-lo)', marginBottom: 4 }}>
+          Choose how to set up your domain <span style={{ fontSize: 11, color: 'var(--wiz-text-hint)' }}>required</span>
+        </legend>
+        {MODE_OPTIONS.map(opt => (
+          <ModeCard
+            key={opt.id}
+            id={opt.id}
+            label={opt.label}
+            sub={opt.sub}
+            active={store.sovereignDomainMode === opt.id}
+            onSelect={() => store.setSovereignDomainMode(opt.id)}
+          />
+        ))}
+      </fieldset>
+
+      {store.sovereignDomainMode === 'pool' && <PoolModeBody availability={availability} />}
+      {store.sovereignDomainMode === 'byo-manual' && <ByoManualBody />}
+      {store.sovereignDomainMode === 'byo-api' && <ByoApiBody />}
+    </StepShell>
+  )
+}
+
+function computeNextDisabled(
+  s: ReturnType<typeof useWizardStore.getState>,
+  availabilityStatus: import('@/shared/lib/useSubdomainAvailability').AvailabilityStatus,
+): boolean {
+  if (s.sovereignDomainMode === 'pool') {
+    if (!s.sovereignSubdomain) return true
+    return availabilityStatus !== 'available'
+  }
+  if (s.sovereignDomainMode === 'byo-manual') {
+    return !isValidDomain(s.sovereignByoDomain)
+  }
+  if (s.sovereignDomainMode === 'byo-api') {
+    if (!isValidDomain(s.sovereignByoDomain)) return true
+    if (!s.registrarType) return true
+    if (!s.registrarToken) return true
+    return !s.registrarTokenValidated
+  }
+  return true
+}
+
+function ModeCard({
+  id, label, sub, active, onSelect,
+}: { id: string; label: string; sub: string; active: boolean; onSelect: () => void }) {
+  return (
+    <button
+      type="button"
+      role="radio"
+      aria-checked={active}
+      data-testid={`domain-mode-${id}`}
+      onClick={onSelect}
+      style={{
+        display: 'flex', alignItems: 'center', gap: 12,
+        padding: '12px 14px', borderRadius: 10,
+        border: `1.5px solid ${active ? 'rgba(56,189,248,0.5)' : 'var(--wiz-border)'}`,
+        background: active ? 'rgba(56,189,248,0.08)' : 'var(--wiz-bg-sub)',
+        cursor: 'pointer', textAlign: 'left',
+        transition: 'all 0.15s', fontFamily: 'Inter, sans-serif',
+      }}
+    >
+      <span
+        aria-hidden
+        style={{
+          width: 16, height: 16, borderRadius: '50%',
+          border: `1.5px solid ${active ? '#38BDF8' : 'var(--wiz-border)'}`,
+          display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0,
+        }}
+      >
+        {active && <span style={{ width: 8, height: 8, borderRadius: '50%', background: '#38BDF8' }} />}
+      </span>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 2, minWidth: 0 }}>
+        <span style={{ fontSize: 13, fontWeight: active ? 600 : 500, color: active ? '#38BDF8' : 'var(--wiz-text-hi)' }}>
+          {label}
+        </span>
+        <span style={{ fontSize: 11, color: 'var(--wiz-text-sub)' }}>{sub}</span>
+      </div>
+    </button>
+  )
+}
+
+function PoolModeBody({ availability }: { availability: import('@/shared/lib/useSubdomainAvailability').AvailabilityResult }) {
+  const store = useWizardStore()
+  const subdomainValid = !store.sovereignSubdomain || isValidSubdomain(store.sovereignSubdomain)
+  const pool = SOVEREIGN_POOL_DOMAINS.find(p => p.id === store.sovereignPoolDomain) ?? SOVEREIGN_POOL_DOMAINS[0]!
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 10, paddingTop: 10 }}>
+      <div style={{ display: 'flex', gap: 8, alignItems: 'flex-end' }}>
+        <div style={{ flex: 1, display: 'flex', flexDirection: 'column', gap: 5 }}>
+          <span style={{ fontSize: 11, color: 'var(--wiz-text-hint)', display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 6 }}>
+            <span>Subdomain</span>
+            <SubdomainAvailabilityIndicator status={availability.status} />
+          </span>
+          <input
+            type="text"
+            data-testid="pool-subdomain-input"
+            placeholder="e.g. omantel-prod"
+            value={store.sovereignSubdomain}
+            onChange={e => store.setSovereignSubdomain(e.target.value)}
+            aria-invalid={availability.status === 'taken' || availability.status === 'invalid' || !subdomainValid}
+            style={inputStyle(
+              availability.status === 'taken' || availability.status === 'invalid' || !subdomainValid
+                ? 'error'
+                : availability.status === 'available'
+                  ? 'success'
+                  : 'idle',
+            )}
+          />
+        </div>
+        <span style={{ fontSize: 14, color: 'var(--wiz-text-md)', fontFamily: 'JetBrains Mono, monospace', paddingBottom: 12 }}>.</span>
+        <div style={{ flex: 1, display: 'flex', flexDirection: 'column', gap: 5 }}>
+          <span style={{ fontSize: 11, color: 'var(--wiz-text-hint)' }}>Pool domain</span>
+          <select
+            data-testid="pool-domain-select"
+            value={store.sovereignPoolDomain}
+            onChange={e => store.setSovereignPoolDomain(e.target.value)}
+            style={{ ...inputStyle('idle'), cursor: 'pointer' }}
+          >
+            {SOVEREIGN_POOL_DOMAINS.map(p => (
+              <option key={p.id} value={p.id} style={{ background: 'var(--wiz-deep-bg)' }}>{p.domain}</option>
+            ))}
+          </select>
+        </div>
+      </div>
+      {(availability.status === 'taken' || availability.status === 'invalid' || availability.status === 'error') && (
+        <ErrorCard
+          title={
+            availability.status === 'taken' && availability.reason === 'exists' ? 'Subdomain is already taken' :
+            availability.status === 'taken' && availability.reason === 'reserved' ? 'Subdomain is reserved' :
+            availability.status === 'taken' && availability.reason === 'unsupported-pool' ? 'Pool domain not supported' :
+            availability.status === 'taken' && availability.reason === 'lookup-error' ? 'DNS lookup failed' :
+            availability.status === 'invalid' ? 'Invalid subdomain format' :
+            'Availability check unavailable'
+          }
+          fqdn={availability.fqdn}
+          detail={availability.detail ?? 'Pick a different subdomain to continue.'}
+        />
+      )}
+      <p style={{ fontSize: 11, color: 'var(--wiz-text-hint)', margin: 0, lineHeight: 1.6 }}>
+        {pool.description} TLS certificates issued automatically via Let's Encrypt DNS-01.
+      </p>
+    </div>
+  )
+}
+
+function ByoManualBody() {
+  const store = useWizardStore()
+  const valid = !store.sovereignByoDomain || isValidDomain(store.sovereignByoDomain)
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 12, paddingTop: 10 }}>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 5 }}>
+        <span style={{ fontSize: 11, color: 'var(--wiz-text-hint)' }}>
+          Your domain (apex like <code style={{ fontFamily: 'JetBrains Mono, monospace' }}>acme.com</code> or a delegated subdomain like{' '}
+          <code style={{ fontFamily: 'JetBrains Mono, monospace' }}>apps.acme.com</code>)
+        </span>
+        <input
+          type="text"
+          data-testid="byo-domain-input"
+          placeholder="acme.com"
+          value={store.sovereignByoDomain}
+          onChange={e => store.setSovereignByoDomain(e.target.value)}
+          aria-invalid={!valid}
+          style={inputStyle(valid ? 'idle' : 'error')}
+        />
+      </div>
+      <NameserverInstructions />
+      <p style={{ fontSize: 11, color: 'var(--wiz-text-hint)', margin: 0, lineHeight: 1.6 }}>
+        After you save the records at your registrar, click Continue. The wizard will hold here until propagation is detected
+        (typically 1–4 hours; up to 48 hours for some TLDs). TLS issued via Let's Encrypt DNS-01 once delegation completes.
+      </p>
+    </div>
+  )
+}
+
+function ByoApiBody() {
+  const store = useWizardStore()
+  const [showToken, setShowToken] = useState(false)
+  const [validating, setValidating] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const valid = !store.sovereignByoDomain || isValidDomain(store.sovereignByoDomain)
+  const reg = REGISTRAR_OPTIONS.find(r => r.id === store.registrarType)
+
+  async function onValidate() {
+    setError(null)
+    if (!isValidDomain(store.sovereignByoDomain) || !store.registrarType || !store.registrarToken) {
+      setError('Domain, registrar, and token are all required before validation.')
+      return
+    }
+    setValidating(true)
+    try {
+      const res = await fetch(`${API_BASE}/v1/registrar/${store.registrarType}/validate`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ domain: store.sovereignByoDomain, token: store.registrarToken }),
+      })
+      if (!res.ok) {
+        const body = (await res.json().catch(() => ({}))) as { error?: string; detail?: string }
+        const map: Record<string, string> = {
+          'invalid-token':         "Token rejected by your registrar — check it's the right token type and not expired.",
+          'rate-limited':          'Your registrar rate-limited the validation request — wait a minute and retry.',
+          'domain-not-in-account': "The domain isn't visible to that token — check you pasted a token that owns the domain.",
+          'api-unavailable':       "Couldn't reach your registrar's API right now — try again in a moment.",
+          'unsupported-registrar': "OpenOva doesn't yet have an adapter for that registrar — switch to manual mode.",
+        }
+        setError(map[body.error ?? ''] ?? body.detail ?? `Validation failed (HTTP ${res.status}).`)
+        store.setRegistrarTokenValidated(false)
+        return
+      }
+      store.setRegistrarTokenValidated(true)
+    } catch (err) {
+      setError(`Network error reaching the validation service: ${String(err)}`)
+      store.setRegistrarTokenValidated(false)
+    } finally {
+      setValidating(false)
+    }
+  }
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 12, paddingTop: 10 }}>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 5 }}>
+        <span style={{ fontSize: 11, color: 'var(--wiz-text-hint)' }}>Your domain</span>
+        <input
+          type="text"
+          data-testid="byo-api-domain-input"
+          placeholder="acme.com"
+          value={store.sovereignByoDomain}
+          onChange={e => store.setSovereignByoDomain(e.target.value)}
+          aria-invalid={!valid}
+          style={inputStyle(valid ? 'idle' : 'error')}
+        />
+      </div>
+
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 5 }}>
+        <span style={{ fontSize: 11, color: 'var(--wiz-text-hint)' }}>Registrar</span>
+        <select
+          data-testid="byo-api-registrar-select"
+          value={store.registrarType ?? ''}
+          onChange={e => store.setRegistrarType((e.target.value || null) as RegistrarType | null)}
+          style={{ ...inputStyle('idle'), cursor: 'pointer' }}
+        >
+          <option value="" style={{ background: 'var(--wiz-deep-bg)' }}>— select registrar —</option>
+          {REGISTRAR_OPTIONS.map(r => (
+            <option key={r.id} value={r.id} style={{ background: 'var(--wiz-deep-bg)' }}>{r.label}</option>
+          ))}
+        </select>
+        {reg && <span style={{ fontSize: 11, color: 'var(--wiz-text-hint)' }}>{reg.tokenHint}</span>}
+      </div>
+
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 5 }}>
+        <span style={{ fontSize: 11, color: 'var(--wiz-text-hint)', display: 'inline-flex', alignItems: 'center', gap: 6 }}>
+          <KeyRound size={12} /> API token
+          <span style={{ fontSize: 10, color: 'var(--wiz-text-sub)', fontStyle: 'italic' }}>
+            held in memory only — not persisted to localStorage
+          </span>
+        </span>
+        <div style={{ display: 'flex', alignItems: 'stretch', gap: 8 }}>
+          <input
+            data-testid="byo-api-token-input"
+            type={showToken ? 'text' : 'password'}
+            placeholder="paste registrar API token"
+            value={store.registrarToken}
+            onChange={e => store.setRegistrarToken(e.target.value)}
+            style={{ ...inputStyle('idle'), flex: 1 }}
+            autoComplete="off"
+            spellCheck={false}
+          />
+          <button
+            type="button"
+            onClick={() => setShowToken(s => !s)}
+            aria-label={showToken ? 'Hide token' : 'Show token'}
+            data-testid="byo-api-token-toggle"
+            style={{
+              padding: '0 12px', borderRadius: 8,
+              border: '1.5px solid var(--wiz-border)', background: 'var(--wiz-bg-sub)',
+              color: 'var(--wiz-text-sub)', cursor: 'pointer',
+            }}
+          >
+            {showToken ? <EyeOff size={14} /> : <Eye size={14} />}
+          </button>
+          <button
+            type="button"
+            onClick={onValidate}
+            disabled={validating || !isValidDomain(store.sovereignByoDomain) || !store.registrarType || !store.registrarToken}
+            data-testid="byo-api-validate-button"
+            style={{
+              padding: '0 14px', borderRadius: 8, border: 'none', cursor: validating ? 'progress' : 'pointer',
+              background: store.registrarTokenValidated ? 'rgba(74,222,128,0.15)' : '#38BDF8',
+              color: store.registrarTokenValidated ? '#4ADE80' : 'var(--wiz-deep-bg)',
+              fontSize: 12, fontWeight: 600,
+              display: 'inline-flex', alignItems: 'center', gap: 6,
+              opacity: (!isValidDomain(store.sovereignByoDomain) || !store.registrarType || !store.registrarToken) ? 0.5 : 1,
+            }}
+          >
+            {validating ? <Loader2 size={12} className="animate-spin" /> :
+              store.registrarTokenValidated ? <CheckCircle2 size={12} /> :
+              <Sparkles size={12} />}
+            {validating ? 'Validating…' : store.registrarTokenValidated ? 'Validated' : 'Validate token'}
+          </button>
+        </div>
+      </div>
+
+      {error && <ErrorCard title="Validation failed" detail={error} />}
+
+      {store.registrarTokenValidated && !error && (
+        <div
+          data-testid="byo-api-validated-banner"
+          role="status"
+          style={{
+            display: 'flex', gap: 8, alignItems: 'flex-start',
+            border: '1px solid rgba(74,222,128,0.35)', background: 'rgba(74,222,128,0.06)',
+            borderRadius: 8, padding: '8px 10px',
+          }}
+        >
+          <CheckCircle2 size={14} style={{ color: '#4ADE80', flexShrink: 0, marginTop: 1 }} />
+          <span style={{ fontSize: 11, color: 'var(--wiz-text-md)' }}>
+            Credentials confirmed. We'll flip the NS records on your behalf when you click Continue.
+          </span>
+        </div>
+      )}
+
+      <NameserverInstructions readOnly />
+
+      <p style={{ fontSize: 11, color: 'var(--wiz-text-hint)', margin: 0, lineHeight: 1.6 }}>
+        Token never leaves the browser's memory or the validation request — we don't write it to disk, send it to logs, or save it
+        anywhere on the server. After validation we keep it just long enough to make the NS-flip call when you submit.
+      </p>
+    </div>
+  )
+}
+
+function NameserverInstructions({ readOnly = false }: { readOnly?: boolean }) {
+  const [copied, setCopied] = useState<number | null>(null)
+  return (
+    <div
+      data-testid="byo-ns-instructions"
+      style={{
+        display: 'flex', flexDirection: 'column', gap: 8,
+        border: '1px solid var(--wiz-border)', background: 'var(--wiz-bg-sub)',
+        borderRadius: 10, padding: 12,
+      }}
+    >
+      <span style={{ fontSize: 11, fontWeight: 600, color: 'var(--wiz-text-hi)', display: 'inline-flex', alignItems: 'center', gap: 6 }}>
+        <RefreshCw size={11} /> {readOnly
+          ? 'OpenOva will set these nameservers at your registrar'
+          : 'Set these as the nameservers for your domain at your registrar'}
+      </span>
+      <table style={{ borderCollapse: 'collapse', fontSize: 11, fontFamily: 'JetBrains Mono, monospace' }}>
+        <tbody>
+          {OPENOVA_NAMESERVERS.map((ns: string, i: number) => (
+            <tr key={ns}>
+              <td style={{ padding: '3px 8px 3px 0', color: 'var(--wiz-text-sub)' }}>NS {i + 1}</td>
+              <td style={{ padding: 3, color: 'var(--wiz-text-hi)' }}>{ns}</td>
+              <td style={{ padding: 3 }}>
+                {!readOnly && (
+                  <button
+                    type="button"
+                    aria-label={`Copy ${ns} to clipboard`}
+                    data-testid={`byo-ns-copy-${i}`}
+                    onClick={() => {
+                      void navigator.clipboard?.writeText(ns)
+                      setCopied(i)
+                      window.setTimeout(() => setCopied(c => (c === i ? null : c)), 1200)
+                    }}
+                    style={{
+                      padding: '2px 6px', borderRadius: 4, border: 'none',
+                      background: copied === i ? 'rgba(74,222,128,0.2)' : 'transparent',
+                      color: copied === i ? '#4ADE80' : 'var(--wiz-text-sub)',
+                      cursor: 'pointer',
+                    }}
+                  >
+                    {copied === i ? <CheckCircle2 size={11} /> : <Copy size={11} />}
+                  </button>
+                )}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+function ErrorCard({ title, detail, fqdn }: { title: string; detail: string; fqdn?: string }) {
+  return (
+    <div
+      role="alert"
+      style={{
+        display: 'flex', gap: 8, alignItems: 'flex-start',
+        borderRadius: 8,
+        border: '1px solid rgba(248,113,113,0.35)',
+        background: 'rgba(248,113,113,0.05)',
+        padding: '8px 10px',
+      }}
+    >
+      <AlertCircle size={13} style={{ color: '#F87171', flexShrink: 0, marginTop: 1 }} />
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{ fontSize: 11, fontWeight: 700, color: '#F87171', display: 'flex', alignItems: 'center', gap: 6, flexWrap: 'wrap' }}>
+          {title}
+          {fqdn && (
+            <code style={{ fontSize: 10, fontFamily: 'JetBrains Mono, monospace', background: 'rgba(248,113,113,0.12)', padding: '1px 5px', borderRadius: 3 }}>
+              {fqdn}
+            </code>
+          )}
+        </div>
+        <p style={{ margin: '3px 0 0', fontSize: 11, color: 'var(--wiz-text-md)', lineHeight: 1.5 }}>{detail}</p>
+      </div>
+    </div>
+  )
+}
+
+function SubdomainAvailabilityIndicator({ status }: { status: import('@/shared/lib/useSubdomainAvailability').AvailabilityStatus }) {
+  if (status === 'idle') return null
+  const palette = {
+    checking:  { fg: 'var(--wiz-text-sub)',  label: 'checking…',    icon: <Loader2 size={10} className="animate-spin" /> },
+    available: { fg: '#4ADE80',              label: 'available',    icon: <CheckCircle2 size={10} /> },
+    taken:     { fg: '#F87171',              label: 'taken',        icon: <AlertCircle size={10} /> },
+    invalid:   { fg: '#F87171',              label: 'invalid',      icon: <AlertCircle size={10} /> },
+    error:     { fg: '#FBBF24',              label: 'check failed', icon: <AlertCircle size={10} /> },
+  } as const
+  const e = palette[status]
+  return (
+    <span style={{ display: 'inline-flex', alignItems: 'center', gap: 4, color: e.fg, fontSize: 10, fontWeight: 600, letterSpacing: '0.04em', textTransform: 'uppercase' }}>
+      {e.icon}
+      {e.label}
+    </span>
+  )
+}
+
+function inputStyle(state: 'idle' | 'success' | 'error'): React.CSSProperties {
+  const border =
+    state === 'error'   ? 'rgba(239,68,68,0.5)' :
+    state === 'success' ? 'rgba(74,222,128,0.5)' :
+                          'var(--wiz-border)'
+  return {
+    height: 40, borderRadius: 8,
+    border: `1.5px solid ${border}`,
+    background: 'var(--wiz-bg-input)',
+    color: 'var(--wiz-text-hi)',
+    fontSize: 13, padding: '0 12px', outline: 'none',
+    fontFamily: 'JetBrains Mono, monospace',
+  }
+}

--- a/products/catalyst/bootstrap/ui/src/pages/wizard/steps/StepOrg.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/wizard/steps/StepOrg.tsx
@@ -1,10 +1,16 @@
 import { useState } from 'react'
-import { CheckCircle2, AlertCircle, Loader2 } from 'lucide-react'
 import { useWizardStore } from '@/entities/deployment/store'
-import { ORG_DEFAULTS, SOVEREIGN_POOL_DOMAINS, isValidSubdomain, isValidDomain, resolveSovereignDomain } from '@/entities/deployment/model'
+import { ORG_DEFAULTS } from '@/entities/deployment/model'
 import { useBreakpoint } from '@/shared/lib/useBreakpoint'
-import { useSubdomainAvailability } from '@/shared/lib/useSubdomainAvailability'
 import { StepShell, useStepNav } from './_shared'
+
+/**
+ * StepOrg — captures the organisation profile.
+ *
+ * The Sovereign-domain capture used to live as a section inside this step;
+ * #169 promoted it to a dedicated StepDomain (next step) so the three-mode
+ * (pool / byo-manual / byo-api) UX can render at full width.
+ */
 
 const INDUSTRIES = [
   'Financial Services', 'Banking', 'Insurance', 'Healthcare',
@@ -97,25 +103,6 @@ export function StepOrg() {
   const col2 = '1fr 1fr'
   const col1 = '1fr'
 
-  // Hoist the availability hook so the Next button can react to it.
-  // Only meaningful in pool mode; in byo mode we pass empty subdomain to
-  // keep the hook idle. Closes #124.
-  const pool = SOVEREIGN_POOL_DOMAINS.find(p => p.id === store.sovereignPoolDomain) ?? SOVEREIGN_POOL_DOMAINS[0]!
-  const availability = useSubdomainAvailability(
-    store.sovereignDomainMode === 'pool' ? store.sovereignSubdomain : '',
-    pool.domain,
-  )
-
-  // Block Next while the subdomain is being checked, when it's taken,
-  // when it's invalid, or when the check itself failed (operator must
-  // resolve the issue or switch to BYO mode).
-  const nextBlocked =
-    store.sovereignDomainMode === 'pool' &&
-    (availability.status === 'taken' ||
-      availability.status === 'invalid' ||
-      availability.status === 'checking' ||
-      availability.status === 'error')
-
   function toggleCompliance(tag: string) {
     store.setOrgCompliance(
       store.orgCompliance.includes(tag)
@@ -129,27 +116,22 @@ export function StepOrg() {
       title="Tell us about your organisation"
       description="We use this profile to recommend the right topology and component defaults. All fields are pre-filled — proceed without changing anything or override what you need."
       onNext={next}
-      nextDisabled={nextBlocked}
     >
-      {/* Row 1: Name · Domain (always 2-col on tablet/desktop, 1-col on mobile) */}
       <div style={{ display: 'grid', gridTemplateColumns: bp === 'mobile' ? col1 : col2, gap: 14 }}>
         <SmartField required label="Organisation name" defaultValue={ORG_DEFAULTS.name}   value={store.orgName}   onChange={store.setOrgName} />
         <SmartField         label="Domain"             defaultValue={ORG_DEFAULTS.domain} value={store.orgDomain} onChange={store.setOrgDomain} />
       </div>
 
-      {/* Row 2: Email · HQ (2-col on tablet/desktop, 1-col mobile stacked) */}
       <div style={{ display: 'grid', gridTemplateColumns: bp === 'mobile' ? col1 : col2, gap: 14 }}>
         <SmartField label="Platform team email" defaultValue={ORG_DEFAULTS.email}         value={store.orgEmail}         onChange={store.setOrgEmail} type="email" />
         <SmartField label="Headquarters"         defaultValue={ORG_DEFAULTS.headquarters} value={store.orgHeadquarters} onChange={store.setOrgHeadquarters} />
       </div>
 
-      {/* Row 3: Industry · Size */}
       <div style={{ display: 'grid', gridTemplateColumns: bp === 'mobile' ? col1 : col2, gap: 14 }}>
         <SelectField label="Industry"          value={store.orgIndustry} options={INDUSTRIES} onChange={store.setOrgIndustry} />
         <SelectField label="Organisation size" value={store.orgSize}     options={SIZES}      onChange={store.setOrgSize} />
       </div>
 
-      {/* Compliance */}
       <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
         <span style={{ fontSize: 12, fontWeight: 500, color: 'var(--wiz-text-lo)' }}>
           Compliance frameworks <span style={{ fontSize: 11, color: 'var(--wiz-text-hint)' }}>optional · shapes component defaults</span>
@@ -178,225 +160,10 @@ export function StepOrg() {
         </div>
       </div>
 
-      {/* Sovereign domain — pool subdomain or BYO. Required to proceed. */}
-      <SovereignDomainSection availability={availability} />
-
       <p style={{ fontSize: 11, color: 'var(--wiz-text-hint)', margin: 0, lineHeight: 1.6 }}>
         Fields marked <span style={{ color: 'var(--wiz-accent)' }}>default</span> are pre-filled.
         Click to focus — all text is selected so you can type a replacement immediately.
       </p>
     </StepShell>
-  )
-}
-
-/**
- * SovereignDomainSection — captures where the new Sovereign will live in DNS.
- *
- * Two modes:
- * - 'pool': customer picks a subdomain under one of OpenOva's pool domains
- *           (default omani.works). Sovereign URL becomes <subdomain>.<pool-domain>.
- *           The provisioner backend writes A/CNAME records via Dynadot's API.
- * - 'byo':  customer brings their own domain (e.g. sovereign.acme-bank.com).
- *           They are responsible for pointing the apex/CNAME at the Sovereign LB.
- *
- * Validation:
- * - subdomain must be a valid DNS label (RFC 1035), 1-63 chars
- * - BYO domain must be a syntactically valid public domain (>= 2 labels)
- * - Cannot proceed to Next until at least one mode resolves to a non-empty domain
- */
-function SovereignDomainSection({ availability }: { availability: import('@/shared/lib/useSubdomainAvailability').AvailabilityResult }) {
-  const store = useWizardStore()
-  const resolved = resolveSovereignDomain(store)
-  const subdomainValid = !store.sovereignSubdomain || isValidSubdomain(store.sovereignSubdomain)
-  const byoValid = !store.sovereignByoDomain || isValidDomain(store.sovereignByoDomain)
-  const pool = SOVEREIGN_POOL_DOMAINS.find(p => p.id === store.sovereignPoolDomain) ?? SOVEREIGN_POOL_DOMAINS[0]!
-
-  return (
-    <div style={{ display: 'flex', flexDirection: 'column', gap: 10, paddingTop: 14, borderTop: '1px solid var(--wiz-border)', marginTop: 6 }}>
-      <div style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between', gap: 12 }}>
-        <span style={{ fontSize: 12, fontWeight: 500, color: 'var(--wiz-text-lo)' }}>
-          Sovereign domain <span style={{ fontSize: 11, color: 'var(--wiz-text-hint)', marginLeft: 6 }}>required · how end-users reach this Sovereign</span>
-        </span>
-        {resolved && (
-          <code style={{ fontSize: 11, color: '#38BDF8', fontFamily: 'JetBrains Mono, monospace' }}>
-            console.{resolved}
-          </code>
-        )}
-      </div>
-
-      {/* Mode toggle */}
-      <div style={{ display: 'inline-flex', gap: 0, border: '1.5px solid var(--wiz-border)', borderRadius: 8, padding: 2, alignSelf: 'flex-start' }}>
-        {(['pool', 'byo'] as const).map(mode => {
-          const active = store.sovereignDomainMode === mode
-          return (
-            <button
-              key={mode}
-              type="button"
-              onClick={() => store.setSovereignDomainMode(mode)}
-              style={{
-                height: 30, padding: '0 14px', borderRadius: 6, border: 'none', cursor: 'pointer',
-                background: active ? 'rgba(56,189,248,0.12)' : 'transparent',
-                color: active ? '#38BDF8' : 'var(--wiz-text-sub)',
-                fontSize: 12, fontWeight: active ? 600 : 400, fontFamily: 'Inter, sans-serif',
-                transition: 'all 0.15s',
-              }}
-            >
-              {mode === 'pool' ? 'OpenOva pool subdomain' : 'Use my own domain'}
-            </button>
-          )
-        })}
-      </div>
-
-      {/* Mode body */}
-      {store.sovereignDomainMode === 'pool' ? (
-        <div style={{ display: 'flex', gap: 8, alignItems: 'flex-end' }}>
-          {/* Subdomain input + availability status */}
-          <div style={{ flex: 1, display: 'flex', flexDirection: 'column', gap: 5 }}>
-            <span style={{ fontSize: 11, color: 'var(--wiz-text-hint)', display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 6 }}>
-              <span>Subdomain</span>
-              <SubdomainAvailabilityIndicator status={availability.status} />
-            </span>
-            <input
-              type="text"
-              placeholder="e.g. omantel"
-              value={store.sovereignSubdomain}
-              onChange={e => store.setSovereignSubdomain(e.target.value)}
-              aria-invalid={availability.status === 'taken' || availability.status === 'invalid' || !subdomainValid}
-              aria-describedby={availability.status === 'taken' || availability.status === 'invalid' || availability.status === 'error' ? 'sovereign-subdomain-err' : undefined}
-              style={{
-                height: 40, borderRadius: 8,
-                border: `1.5px solid ${
-                  availability.status === 'taken' || availability.status === 'invalid' || !subdomainValid
-                    ? 'rgba(239,68,68,0.5)'
-                  : availability.status === 'available'
-                    ? 'rgba(74,222,128,0.5)'
-                  : 'var(--wiz-border)'
-                }`,
-                background: 'var(--wiz-bg-input)', color: 'var(--wiz-text-hi)',
-                fontSize: 13, padding: '0 12px', outline: 'none',
-                fontFamily: 'JetBrains Mono, monospace',
-              }}
-            />
-          </div>
-          <span style={{ fontSize: 14, color: 'var(--wiz-text-md)', fontFamily: 'JetBrains Mono, monospace', paddingBottom: 12 }}>.</span>
-          {/* Pool dropdown */}
-          <div style={{ flex: 1, display: 'flex', flexDirection: 'column', gap: 5 }}>
-            <span style={{ fontSize: 11, color: 'var(--wiz-text-hint)' }}>Pool domain</span>
-            <select
-              value={store.sovereignPoolDomain}
-              onChange={e => store.setSovereignPoolDomain(e.target.value)}
-              style={{
-                height: 40, borderRadius: 8, border: '1.5px solid var(--wiz-border)',
-                background: 'var(--wiz-bg-input)', color: 'var(--wiz-text-md)',
-                fontSize: 13, padding: '0 12px', outline: 'none',
-                fontFamily: 'JetBrains Mono, monospace', cursor: 'pointer',
-              }}
-            >
-              {SOVEREIGN_POOL_DOMAINS.map(p => (
-                <option key={p.id} value={p.id} style={{ background: 'var(--wiz-deep-bg)' }}>{p.domain}</option>
-              ))}
-            </select>
-          </div>
-        </div>
-      ) : (
-        <div style={{ display: 'flex', flexDirection: 'column', gap: 5 }}>
-          <span style={{ fontSize: 11, color: 'var(--wiz-text-hint)' }}>Your domain (you'll need to point a CNAME or A record at the Sovereign load balancer after provisioning)</span>
-          <input
-            type="text"
-            placeholder="e.g. sovereign.acme-bank.com"
-            value={store.sovereignByoDomain}
-            onChange={e => store.setSovereignByoDomain(e.target.value)}
-            style={{
-              height: 40, borderRadius: 8,
-              border: `1.5px solid ${byoValid ? 'var(--wiz-border)' : 'rgba(239,68,68,0.5)'}`,
-              background: 'var(--wiz-bg-input)', color: 'var(--wiz-text-hi)',
-              fontSize: 13, padding: '0 12px', outline: 'none',
-              fontFamily: 'JetBrains Mono, monospace',
-            }}
-          />
-        </div>
-      )}
-
-      {/* Inline availability error — pool mode only.
-          Closes #124: surface a specific reason ("reserved", "exists", etc.)
-          before the user reaches Submit, with a one-line remediation hint
-          straight from the backend's SubdomainCheckResponse.detail field. */}
-      {store.sovereignDomainMode === 'pool' && (availability.status === 'taken' || availability.status === 'invalid' || availability.status === 'error') && (
-        <div
-          id="sovereign-subdomain-err"
-          role="alert"
-          style={{
-            display: 'flex', gap: 8, alignItems: 'flex-start',
-            borderRadius: 8,
-            border: '1px solid rgba(248,113,113,0.35)',
-            background: 'rgba(248,113,113,0.05)',
-            padding: '8px 10px',
-          }}
-        >
-          <AlertCircle size={13} style={{ color: '#F87171', flexShrink: 0, marginTop: 1 }} />
-          <div style={{ flex: 1, minWidth: 0 }}>
-            <div style={{ fontSize: 11, fontWeight: 700, color: '#F87171', display: 'flex', alignItems: 'center', gap: 6, flexWrap: 'wrap' }}>
-              {availability.status === 'taken' && availability.reason === 'exists' && 'Subdomain is already taken'}
-              {availability.status === 'taken' && availability.reason === 'reserved' && 'Subdomain is reserved'}
-              {availability.status === 'taken' && availability.reason === 'unsupported-pool' && 'Pool domain not supported'}
-              {availability.status === 'taken' && availability.reason === 'lookup-error' && 'DNS lookup failed'}
-              {availability.status === 'invalid' && 'Invalid subdomain format'}
-              {availability.status === 'error' && 'Availability check unavailable'}
-              {availability.fqdn && (
-                <code style={{ fontSize: 10, fontFamily: 'JetBrains Mono, monospace', background: 'rgba(248,113,113,0.12)', padding: '1px 5px', borderRadius: 3 }}>
-                  {availability.fqdn}
-                </code>
-              )}
-            </div>
-            <p style={{ margin: '3px 0 0', fontSize: 11, color: 'var(--wiz-text-md)', lineHeight: 1.5 }}>
-              {availability.detail ?? 'Pick a different subdomain to continue.'}
-            </p>
-          </div>
-        </div>
-      )}
-
-      {/* Helper text */}
-      {store.sovereignDomainMode === 'pool' && (
-        <p style={{ fontSize: 11, color: 'var(--wiz-text-hint)', margin: 0, lineHeight: 1.6 }}>
-          {pool.description} TLS certificates issued automatically via Let's Encrypt DNS-01.
-        </p>
-      )}
-      {store.sovereignDomainMode === 'byo' && (
-        <p style={{ fontSize: 11, color: 'var(--wiz-text-hint)', margin: 0, lineHeight: 1.6 }}>
-          After provisioning, point an A record (apex) or CNAME (subdomain) at the Sovereign's load balancer IP — shown in the success screen.
-          TLS issued via Let's Encrypt HTTP-01 once DNS resolves.
-        </p>
-      )}
-    </div>
-  )
-}
-
-/**
- * SubdomainAvailabilityIndicator — small status pill that updates live as
- * useSubdomainAvailability runs. Renders next to the subdomain input label.
- *
- * Closes #124. Visual states match useSubdomainAvailability.AvailabilityStatus:
- *   idle      → nothing shown
- *   checking  → spinner + "checking…"
- *   available → green check + "available"
- *   taken     → red ring + "taken"
- *   invalid   → red ring + "invalid"
- *   error     → red ring + "check failed"
- */
-function SubdomainAvailabilityIndicator({ status }: { status: import('@/shared/lib/useSubdomainAvailability').AvailabilityStatus }) {
-  if (status === 'idle') return null
-  const palette = {
-    checking:  { fg: 'var(--wiz-text-sub)',  label: 'checking…',    icon: <Loader2 size={10} className="animate-spin" /> },
-    available: { fg: '#4ADE80',              label: 'available',    icon: <CheckCircle2 size={10} /> },
-    taken:     { fg: '#F87171',              label: 'taken',        icon: <AlertCircle size={10} /> },
-    invalid:   { fg: '#F87171',              label: 'invalid',      icon: <AlertCircle size={10} /> },
-    error:     { fg: '#FBBF24',              label: 'check failed', icon: <AlertCircle size={10} /> },
-  } as const
-  const e = palette[status]
-  return (
-    <span style={{ display: 'inline-flex', alignItems: 'center', gap: 4, color: e.fg, fontSize: 10, fontWeight: 600, letterSpacing: '0.04em', textTransform: 'uppercase' }}>
-      {e.icon}
-      {e.label}
-    </span>
   )
 }

--- a/products/catalyst/bootstrap/ui/src/pages/wizard/steps/StepSuccess.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/wizard/steps/StepSuccess.test.tsx
@@ -216,7 +216,7 @@ describe('No hardcoded sovereign URL', () => {
   it('every external CTA points at the configured FQDN, not a hardcoded one', () => {
     const newFQDN = 'sovereign.acme-bank.com'
     useWizardStore.setState({
-      sovereignDomainMode: 'byo',
+      sovereignDomainMode: 'byo-manual',
       sovereignByoDomain: newFQDN,
       lastProvisionResult: {
         ...FIXTURE_RESULT,


### PR DESCRIPTION
Closes #169.

## Summary
- New StepDomain wizard step with three radio modes: pool, BYO-manual NS, BYO-api NS-flip
- BYO-manual surfaces ns1-3.openova.io with copy buttons; BYO-api adds registrar dropdown + token + Validate button
- New PDM endpoint `POST /api/v1/registrar/{r}/validate` (read-only twin of /set-ns) + catalyst-api proxy
- Wizard store: `DomainMode = 'pool' | 'byo-manual' | 'byo-api'`, registrar credentials in-memory only (partialize strips token from localStorage)
- Legacy `'byo'` persisted state coerced to `'byo-manual'` on rehydrate

## Test plan
- [x] vitest 103 cases pass (5 test files)
- [x] PDM Go tests pass (incl. 7 new /validate cases — token never leaks in logs/response)
- [x] catalyst-api Go tests pass + builds clean
- [x] tsc strict typecheck passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)