### PR TITLE
feat(bp-external-dns): umbrella chart + add to bootstrap-kit Kustomization

### DIFF
--- a/clusters/_template/bootstrap-kit/12-external-dns.yaml
+++ b/clusters/_template/bootstrap-kit/12-external-dns.yaml
@@ -1,0 +1,73 @@
+# bp-external-dns — Catalyst Blueprint #12 of 13. Per-Sovereign DNS sync —
+# ExternalDNS reconciles Service/Ingress hostnames into the per-Sovereign
+# PowerDNS authoritative server via the native `pdns` provider. Geo +
+# health-checked failover responses are owned by PowerDNS lua-records,
+# NOT by ExternalDNS.
+#
+# Wrapper chart: platform/external-dns/chart/
+#
+# dependsOn:
+#   - bp-cert-manager — ExternalDNS HelmRelease only after TLS issuers
+#     are reconciled, so any cert-manager-fronted webhook endpoints in
+#     downstream overlays come up cleanly.
+#   - bp-powerdns — native `pdns` provider points at the in-cluster
+#     bp-powerdns Service and reads the `powerdns-api-credentials` Secret
+#     it renders. Without bp-powerdns the ExternalDNS pod CrashLoops
+#     trying to dial a non-existent DNS API.
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: external-dns
+  labels:
+    catalyst.openova.io/sovereign: SOVEREIGN_FQDN_PLACEHOLDER
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: bp-external-dns
+  namespace: flux-system
+spec:
+  type: oci
+  interval: 15m
+  url: oci://ghcr.io/openova-io
+  secretRef:
+    name: ghcr-pull
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: bp-external-dns
+  namespace: flux-system
+spec:
+  interval: 15m
+  releaseName: external-dns
+  targetNamespace: external-dns
+  dependsOn:
+    - name: bp-cert-manager
+    - name: bp-powerdns
+  chart:
+    spec:
+      chart: bp-external-dns
+      version: 1.1.0
+      sourceRef:
+        kind: HelmRepository
+        name: bp-external-dns
+        namespace: flux-system
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+  # Per-Sovereign overrides — txtOwnerId MUST be the Sovereign FQDN so two
+  # Sovereigns sharing a parent zone don't fight over the same record set.
+  # domainFilters narrow the zones ExternalDNS will manage; per-Sovereign
+  # cluster overlays patch this with the actual zone list.
+  values:
+    external-dns:
+      txtOwnerId: SOVEREIGN_FQDN_PLACEHOLDER
+      txtPrefix: _externaldns.
+      domainFilters:
+        - SOVEREIGN_FQDN_PLACEHOLDER

--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1,4 +1,4 @@
-# bp-catalyst-platform — Catalyst Blueprint #11 of 11. The umbrella
+# bp-catalyst-platform — Catalyst Blueprint #13 of 13. The umbrella
 # Blueprint that brings up the Catalyst control plane: console, marketplace,
 # admin, catalog-svc, projector, provisioning, environment-controller,
 # blueprint-controller, billing.

--- a/clusters/_template/bootstrap-kit/kustomization.yaml
+++ b/clusters/_template/bootstrap-kit/kustomization.yaml
@@ -15,4 +15,5 @@ resources:
   - 08-openbao.yaml
   - 09-keycloak.yaml
   - 10-gitea.yaml
-  - 11-bp-catalyst-platform.yaml
+  - 12-external-dns.yaml
+  - 13-bp-catalyst-platform.yaml

--- a/clusters/omantel.omani.works/bootstrap-kit/12-external-dns.yaml
+++ b/clusters/omantel.omani.works/bootstrap-kit/12-external-dns.yaml
@@ -1,0 +1,72 @@
+# bp-external-dns — Catalyst Blueprint #12 of 13. Per-Sovereign DNS sync —
+# ExternalDNS reconciles Service/Ingress hostnames into the per-Sovereign
+# PowerDNS authoritative server via the native `pdns` provider. Geo +
+# health-checked failover responses are owned by PowerDNS lua-records,
+# NOT by ExternalDNS.
+#
+# Wrapper chart: platform/external-dns/chart/
+#
+# dependsOn:
+#   - bp-cert-manager — ExternalDNS HelmRelease only after TLS issuers
+#     are reconciled, so any cert-manager-fronted webhook endpoints in
+#     downstream overlays come up cleanly.
+#   - bp-powerdns — native `pdns` provider points at the in-cluster
+#     bp-powerdns Service and reads the `powerdns-api-credentials` Secret
+#     it renders. Without bp-powerdns the ExternalDNS pod CrashLoops
+#     trying to dial a non-existent DNS API.
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: external-dns
+  labels:
+    catalyst.openova.io/sovereign: omantel.omani.works
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: bp-external-dns
+  namespace: flux-system
+spec:
+  type: oci
+  interval: 15m
+  url: oci://ghcr.io/openova-io
+  secretRef:
+    name: ghcr-pull
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: bp-external-dns
+  namespace: flux-system
+spec:
+  interval: 15m
+  releaseName: external-dns
+  targetNamespace: external-dns
+  dependsOn:
+    - name: bp-cert-manager
+    - name: bp-powerdns
+  chart:
+    spec:
+      chart: bp-external-dns
+      version: 1.1.0
+      sourceRef:
+        kind: HelmRepository
+        name: bp-external-dns
+        namespace: flux-system
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+  # Per-Sovereign overrides — txtOwnerId MUST be the Sovereign FQDN so two
+  # Sovereigns sharing a parent zone don't fight over the same record set.
+  # domainFilters narrow the zones ExternalDNS will manage.
+  values:
+    external-dns:
+      txtOwnerId: omantel.omani.works
+      txtPrefix: _externaldns.
+      domainFilters:
+        - omantel.omani.works

--- a/clusters/omantel.omani.works/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/omantel.omani.works/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1,4 +1,4 @@
-# bp-catalyst-platform — Catalyst Blueprint #11 of 11. The umbrella
+# bp-catalyst-platform — Catalyst Blueprint #13 of 13. The umbrella
 # Blueprint that brings up the Catalyst control plane: console, marketplace,
 # admin, catalog-svc, projector, provisioning, environment-controller,
 # blueprint-controller, billing.

--- a/clusters/omantel.omani.works/bootstrap-kit/kustomization.yaml
+++ b/clusters/omantel.omani.works/bootstrap-kit/kustomization.yaml
@@ -15,4 +15,5 @@ resources:
   - 08-openbao.yaml
   - 09-keycloak.yaml
   - 10-gitea.yaml
-  - 11-bp-catalyst-platform.yaml
+  - 12-external-dns.yaml
+  - 13-bp-catalyst-platform.yaml

--- a/platform/external-dns/chart/templates/_helpers.tpl
+++ b/platform/external-dns/chart/templates/_helpers.tpl
@@ -1,0 +1,21 @@
+{{/*
+Catalyst-curated helpers for bp-external-dns. Mirrors the conventions used
+by bp-cilium / bp-keycloak / bp-cert-manager / bp-powerdns.
+*/}}
+
+{{- define "bp-external-dns.fullname" -}}
+{{- default "external-dns" .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "bp-external-dns.labels" -}}
+app.kubernetes.io/name: {{ include "bp-external-dns.fullname" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+catalyst.openova.io/blueprint: bp-external-dns
+catalyst.openova.io/component: external-dns
+{{- end -}}
+
+{{- define "bp-external-dns.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "bp-external-dns.fullname" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}

--- a/platform/external-dns/chart/templates/externalsecret.yaml
+++ b/platform/external-dns/chart/templates/externalsecret.yaml
@@ -1,0 +1,46 @@
+{{- /*
+ExternalSecret — Phase 2+ target state for the PowerDNS API key.
+
+In Phase 0 (bootstrap-kit install on a fresh Sovereign), the
+`powerdns-api-credentials` Secret is rendered by bp-powerdns
+(platform/powerdns/chart/templates/api-credentials-secret.yaml) from a
+helm value. Once OpenBao is provisioned on the Sovereign and
+external-secrets-operator is reconciling, the per-Sovereign overlay
+flips externalDns.externalSecret.enabled = true and the API key flows
+from OpenBao instead — same Secret name, same key, but the source of
+truth becomes the Sovereign's vault.
+
+DEFAULT FALSE — Phase 0 path leaves bp-powerdns as the sole writer of
+the powerdns-api-credentials Secret. Enabling this template before
+OpenBao is reconciling would create an ExternalSecret that the operator
+can't fulfil and the cluster would never reach Ready.
+
+Per docs/INVIOLABLE-PRINCIPLES.md #4 every knob (refreshInterval,
+secretStoreRef, remoteRef path) is operator-tunable; the remoteRef.key
+is overridden by the per-Sovereign Composition that creates this
+HelmRelease at provision time.
+*/}}
+{{- if .Values.externalDns.externalSecret.enabled }}
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: powerdns-api-credentials
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "bp-external-dns.labels" . | nindent 4 }}
+spec:
+  refreshInterval: {{ .Values.externalDns.externalSecret.refreshInterval | default "1h" | quote }}
+  secretStoreRef:
+    name: {{ .Values.externalDns.externalSecret.secretStoreRef.name | quote }}
+    kind: {{ .Values.externalDns.externalSecret.secretStoreRef.kind | quote }}
+  target:
+    name: {{ .Values.externalDns.externalSecret.target.name | default "powerdns-api-credentials" | quote }}
+    creationPolicy: Owner
+  data:
+    {{- range .Values.externalDns.externalSecret.data }}
+    - secretKey: {{ .secretKey | quote }}
+      remoteRef:
+        key: {{ .remoteRef.key | quote }}
+        property: {{ .remoteRef.property | quote }}
+    {{- end }}
+{{- end }}

--- a/platform/external-dns/chart/templates/networkpolicy.yaml
+++ b/platform/external-dns/chart/templates/networkpolicy.yaml
@@ -1,0 +1,79 @@
+{{- /*
+NetworkPolicy — locks the ExternalDNS pod down to the minimum egress set
+required for the native PowerDNS provider:
+
+  - DNS resolution (UDP/TCP 53) to the cluster DNS Service
+  - HTTPS to the Kubernetes API server (apiserver discovery)
+  - HTTP to the in-cluster bp-powerdns webserver (port 8081 by default)
+
+Ingress is locked to Prometheus scraping when serviceMonitor is enabled
+(upstream chart exposes /metrics on its primary port). Per
+docs/INVIOLABLE-PRINCIPLES.md #4 every selector / port is operator-tunable.
+
+Disabled when externalDns.networkPolicy.enabled = false (cluster overlays
+MAY disable for debugging — re-enable in target state).
+*/}}
+{{- if .Values.externalDns.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: bp-external-dns
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "bp-external-dns.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: external-dns
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    # Prometheus scraping on the primary port. The upstream chart's
+    # /metrics endpoint is on http port 7979.
+    - from:
+        - namespaceSelector: {}
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: prometheus
+      ports:
+        - protocol: TCP
+          port: 7979
+  egress:
+    # Cluster DNS — ExternalDNS resolves the PowerDNS Service name as well
+    # as any external DNS provider hostnames listed in extraArgs.
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    # Kubernetes API — ExternalDNS watches Service/Ingress/Gateway-API
+    # resources via the apiserver.
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except: []
+      ports:
+        - protocol: TCP
+          port: 443
+        - protocol: TCP
+          port: 6443
+    # PowerDNS REST API — egress to the in-cluster bp-powerdns Service.
+    # Per-Sovereign overlays may set externalDns.networkPolicy.powerdns*
+    # if PowerDNS lives in a non-default namespace.
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.externalDns.networkPolicy.powerdnsNamespace | quote }}
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: {{ .Values.externalDns.networkPolicy.powerdnsServiceName | quote }}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.externalDns.networkPolicy.powerdnsApiPort }}
+{{- end }}

--- a/platform/external-dns/chart/templates/servicemonitor.yaml
+++ b/platform/external-dns/chart/templates/servicemonitor.yaml
@@ -1,0 +1,40 @@
+{{- /*
+ServiceMonitor — Catalyst-overlay variant.
+
+The upstream `external-dns` subchart already renders its own ServiceMonitor
+when `external-dns.serviceMonitor.enabled = true` (see values.yaml). This
+Catalyst-side template is reserved for any auxiliary metrics endpoints that
+per-Sovereign overlays MAY add (e.g. the Dynadot webhook sidecar from
+platform/external-dns/policies/dynadot-multi-domain.yaml when running in
+Dynadot mode).
+
+DEFAULT FALSE per the observability-toggle rule for the bp-* family —
+Prometheus Operator is not part of the bootstrap-kit, so a ServiceMonitor
+shipped enabled-by-default would generate Helm install errors on a
+Sovereign that hasn't reached Phase 2 yet. Per-Sovereign overlays flip
+this on once kube-prometheus-stack is installed.
+
+Per docs/INVIOLABLE-PRINCIPLES.md #4 every knob (interval, namespace,
+labels) is operator-tunable.
+*/}}
+{{- if .Values.externalDns.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: bp-external-dns-catalyst
+  namespace: {{ default .Release.Namespace .Values.externalDns.serviceMonitor.namespace }}
+  labels:
+    {{- include "bp-external-dns.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: external-dns
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  endpoints:
+    - port: http
+      interval: {{ .Values.externalDns.serviceMonitor.interval | default "30s" }}
+      path: /metrics
+{{- end }}

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -10,12 +10,20 @@ description: |
 
   Umbrella that depends on the 10 leaf bootstrap-kit Blueprints
   (cilium, cert-manager, flux, crossplane, sealed-secrets, spire,
-  nats-jetstream, openbao, keycloak, gitea) plus bp-external-dns —
-  each resolved as an OCI artifact at ghcr.io/openova-io/bp-<name>.
-  As of 1.1.0 each leaf is itself a proper Helm umbrella that depends on
-  its upstream chart (cert-manager, cilium, flux2, crossplane, ...) so
-  installing bp-catalyst-platform brings up the full upstream payload —
-  no Catalyst-side bootstrap installer is required.
+  nats-jetstream, openbao, keycloak, gitea) — each resolved as an OCI
+  artifact at ghcr.io/openova-io/bp-<name>. As of 1.1.0 each leaf is
+  itself a proper Helm umbrella that depends on its upstream chart
+  (cert-manager, cilium, flux2, crossplane, ...) so installing
+  bp-catalyst-platform brings up the full upstream payload — no
+  Catalyst-side bootstrap installer is required.
+
+  bp-external-dns is NOT a dep of this umbrella; it is installed
+  separately by the bootstrap-kit Kustomization (12-external-dns.yaml)
+  alongside bp-cert-manager / bp-powerdns / bp-flux / etc. so its
+  install ordering is owned by Flux dependsOn (bp-cert-manager,
+  bp-powerdns) rather than this umbrella's Helm dependency graph.
+  Bumped to 1.1.1 in lockstep with bp-external-dns 1.1.0 to reflect the
+  dependency removal.
 type: application
 
 dependencies:
@@ -48,7 +56,4 @@ dependencies:
     repository: oci://ghcr.io/openova-io
   - name: bp-gitea
     version: 1.1.1
-    repository: oci://ghcr.io/openova-io
-  - name: bp-external-dns
-    version: 1.0.0
     repository: oci://ghcr.io/openova-io


### PR DESCRIPTION
## Summary

- Convert `platform/external-dns/chart/` (already updated to umbrella shape on `main` at 41c7ac13) by adding the missing Catalyst overlay `templates/` (NetworkPolicy default-on, ServiceMonitor default-off, ExternalSecret default-off, _helpers.tpl).
- Add `bp-external-dns:1.1.0` to the per-Sovereign bootstrap-kit Kustomization (`12-external-dns.yaml`) with `dependsOn: [bp-cert-manager, bp-powerdns]`. Renumber legacy `11-bp-catalyst-platform.yaml` → `13-bp-catalyst-platform.yaml` so install ordering reads in canonical Phase-0 sequence. Mirrored in `_template/` and `omantel.omani.works/`.
- Drop `bp-external-dns` from `bp-catalyst-platform` Helm dependencies and bump `1.1.0 → 1.1.1` — install ordering for ExternalDNS now lives at the Flux Kustomization layer rather than this umbrella's Helm dep graph.

Upstream pinned: `kubernetes-sigs/external-dns 1.15.2` (appVersion 0.15.1, k8s 1.31).
Provider: native `pdns` against `powerdns.openova-system.svc.cluster.local:8081`, API key from the `powerdns-api-credentials` Secret rendered by bp-powerdns.

## Local gates

- `helm dependency build` pulls `external-dns-1.15.2.tgz`
- `helm lint` clean
- `helm template smoke …` renders 245 lines / 6 kinds (NetworkPolicy + upstream ServiceAccount/ClusterRole/ClusterRoleBinding/Service/Deployment)
- `helm package` + `tar -tzf` confirms `bp-external-dns/charts/external-dns/Chart.yaml` is inside the packaged tgz (subchart-guard simulation)

## Test plan

- [ ] CI `Blueprint Release` workflow republishes `bp-external-dns:1.1.0` (subchart guards: working-tree, packaged tgz, pulled OCI artifact, helm template smoke)
- [ ] CI `Blueprint Release` workflow publishes `bp-catalyst-platform:1.1.1`
- [ ] On omantel cluster: `kubectl get hr -n flux-system bp-external-dns` reaches Ready=True after dependsOn (`bp-cert-manager`, `bp-powerdns`) reconcile
- [ ] DNS records auto-published to PowerDNS for any Service/Ingress on the Sovereign

🤖 Generated with [Claude Code](https://claude.com/claude-code)