### PR TITLE
feat(bootstrap-kit): add bp-powerdns to per-Sovereign install (closes #192)

### DIFF
--- a/clusters/_template/bootstrap-kit/11-powerdns.yaml
+++ b/clusters/_template/bootstrap-kit/11-powerdns.yaml
@@ -1,0 +1,92 @@
+# bp-powerdns — Catalyst Blueprint #11 of 13. Per-Sovereign authoritative
+# DNS. Every Sovereign owns its own PowerDNS Authoritative server with the
+# Sovereign's zones loaded into a CNPG-backed gpgsql backend; per-zone
+# DNSSEC (ECDSAP256SHA256), lua-records for geo + health-checked failover,
+# and a dnsdist companion for query rate-limiting + DDoS posture.
+#
+# Architectural anchor — per-Sovereign PowerDNS, NOT a shared instance:
+#   This file was added so each Sovereign has its own bp-powerdns release
+#   alongside bp-external-dns (#12). The original Phase-0 dial-tone
+#   PowerDNS used to live as a singleton in the openova-system namespace
+#   on contabo-mkt; #168 ("per-Sovereign PowerDNS zones") flipped that
+#   model so a Sovereign's zones never leave the Sovereign's own cluster.
+#   bp-external-dns's `dependsOn: [bp-powerdns]` therefore must be
+#   satisfied by an in-cluster sibling release — this file IS that
+#   sibling.
+#
+# Wrapper chart: platform/powerdns/chart/
+# Catalyst-curated values: platform/powerdns/chart/values.yaml
+#   - 3 PowerDNS Authoritative replicas behind dnsdist
+#   - CNPG-managed `pdns-pg` Postgres cluster for zone storage
+#   - DNSSEC ON by default (ECDSAP256SHA256)
+#   - Lua-records ON (geo + health-checked failover patterns)
+#   - REST API at pdns.<sovereign>/api behind Traefik basicAuth
+#
+# Reconciled by: Flux on the new Sovereign's k3s control plane.
+#
+# dependsOn:
+#   - bp-cert-manager — the REST API ingress requests a TLS cert from
+#     the cluster's letsencrypt-prod ClusterIssuer; without bp-cert-manager
+#     reconciled first the Certificate resource sits Pending.
+#
+# Hard-but-implicit dependencies (CRDs, NOT sibling Blueprints):
+#   - postgresql.cnpg.io/v1.Cluster — provided by the CNPG operator. The
+#     chart's templates/cnpg-cluster.yaml renders this CR; if CNPG isn't
+#     yet installed on the Sovereign, the HelmRelease will wait. CNPG is
+#     a fixture of Catalyst-Zero (FABRIC group, componentGroups.ts `cnpg`)
+#     and is installed alongside this kit by the bootstrap installer.
+#   - traefik.io/v1alpha1.Middleware — Traefik is the Catalyst-Zero
+#     ingress controller and is a fixture of every Sovereign.
+#
+# Per-Sovereign overrides intentionally NOT set here:
+#   - Zones, API basic-auth credentials, anycast Floating-IP target — all
+#     of those are provisioned by Crossplane / pool-domain-manager (PDM)
+#     after the cluster comes up, NOT baked into the bootstrap kit. This
+#     file installs the chart with defaults so the Sovereign has a working
+#     authoritative DNS surface that PDM can then load zones into.
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: powerdns
+  labels:
+    catalyst.openova.io/sovereign: SOVEREIGN_FQDN_PLACEHOLDER
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: bp-powerdns
+  namespace: flux-system
+spec:
+  type: oci
+  interval: 15m
+  url: oci://ghcr.io/openova-io
+  secretRef:
+    name: ghcr-pull
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: bp-powerdns
+  namespace: flux-system
+spec:
+  interval: 15m
+  releaseName: powerdns
+  targetNamespace: powerdns
+  dependsOn:
+    - name: bp-cert-manager
+  chart:
+    spec:
+      chart: bp-powerdns
+      version: 1.1.1
+      sourceRef:
+        kind: HelmRepository
+        name: bp-powerdns
+        namespace: flux-system
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3

--- a/clusters/_template/bootstrap-kit/kustomization.yaml
+++ b/clusters/_template/bootstrap-kit/kustomization.yaml
@@ -15,5 +15,6 @@ resources:
   - 08-openbao.yaml
   - 09-keycloak.yaml
   - 10-gitea.yaml
+  - 11-powerdns.yaml
   - 12-external-dns.yaml
   - 13-bp-catalyst-platform.yaml


### PR DESCRIPTION
## Summary

- Adds `clusters/_template/bootstrap-kit/11-powerdns.yaml` so every Sovereign installs its own `bp-powerdns@1.1.1` HelmRelease alongside the existing twelve bootstrap-kit Blueprints.
- Inserts `11-powerdns.yaml` into `kustomization.yaml` between `10-gitea.yaml` and `12-external-dns.yaml` so the resource is reconciled before its dependent (bp-external-dns).
- No code, no chart bumps, no per-Sovereign value plumbing — just makes the missing Blueprint present.

## Why this fix

bp-external-dns@1.1.0 (already in the bootstrap kit) declares `dependsOn: [bp-powerdns]`. On the omantel cluster Flux logs show:

```
unable to get 'flux-system/bp-powerdns' dependency: helmreleases.helm.toolkit.fluxcd.io "bp-powerdns" not found
```

The dependency is correct — it's the **Sovereign**, not the dependency, that was missing a release. Per #168 (`per-Sovereign PowerDNS zones`, merged at `9cab9a2`) the architecture is **option 2: every Sovereign runs its own PowerDNS Authoritative**, not a shared singleton on `contabo-mkt`. So the fix is to PROVIDE bp-powerdns in-cluster, not to remove the dependency from bp-external-dns.

The `bp-powerdns@1.1.1` OCI artifact is already published at `ghcr.io/openova-io/bp-powerdns` (verified via `helm pull`); the wrapper chart lives at `platform/powerdns/chart/` with an upstream `pschichtel/powerdns@0.10.0` Helm subchart. No new artifact had to be cut.

## What's intentionally NOT in this change

- **No per-Sovereign zones, API basic-auth, or anycast Floating-IP config.** Those are provisioned by Crossplane / pool-domain-manager (PDM) after the cluster comes up — baking them into bootstrap-kit would re-introduce the singleton model #168 just retired.
- **No bump of `bp-powerdns`'s own version.** Ticket scope was explicit: add it at the currently-published 1.1.x. Future PowerDNS feature work bumps the chart, not this PR.
- **No edit to `bp-external-dns`'s `dependsOn`.** Removing the dependency would mask the symptom; the dependency is correct.

## Test plan

- [x] `kubectl kustomize clusters/_template/bootstrap-kit/` renders cleanly and emits the new `powerdns` Namespace, `bp-powerdns` HelmRepository, and `bp-powerdns` HelmRelease alongside the existing twelve.
- [x] `helm pull oci://ghcr.io/openova-io/bp-powerdns --version 1.1.1` confirms the OCI artifact this PR points at exists.
- [ ] Post-merge — the next `tofu apply` for omantel installs bp-powerdns, after which bp-external-dns reconciles cleanly (no more "dependency not found" Flux event).

Closes #192.