### PR TITLE
fix: hide CRD-emitting resources behind Capabilities gates (closes #190)

### DIFF
--- a/platform/external-dns/chart/Chart.yaml
+++ b/platform/external-dns/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-external-dns
-version: 1.1.0
+version: 1.1.2
 description: |
   Catalyst-curated Blueprint umbrella chart for ExternalDNS. Depends on the
   upstream `external-dns` chart (kubernetes-sigs) as a Helm subchart so

--- a/platform/external-dns/chart/templates/externalsecret.yaml
+++ b/platform/external-dns/chart/templates/externalsecret.yaml
@@ -20,7 +20,18 @@ secretStoreRef, remoteRef path) is operator-tunable; the remoteRef.key
 is overridden by the per-Sovereign Composition that creates this
 HelmRelease at provision time.
 */}}
-{{- if .Values.externalDns.externalSecret.enabled }}
+{{- /*
+Capabilities gate: bp-external-secrets ships the
+`external-secrets.io/v1beta1` CRD that backs ExternalSecret — it is NOT
+in the bootstrap-kit. On a cold install of a fresh Sovereign before
+external-secrets-operator is reconciling, the apiserver rejects
+ExternalSecret with `no matches for kind ExternalSecret in version
+external-secrets.io/v1beta1`. The Capabilities check skips this template
+until the CRD is registered, at which point the gate is a no-op. This
+is the architectural pattern from issue #190 — defense in depth alongside
+the values-toggle (`externalDns.externalSecret.enabled`).
+*/}}
+{{- if and .Values.externalDns.externalSecret.enabled (.Capabilities.APIVersions.Has "external-secrets.io/v1beta1") }}
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:

--- a/platform/external-dns/chart/templates/servicemonitor.yaml
+++ b/platform/external-dns/chart/templates/servicemonitor.yaml
@@ -17,7 +17,20 @@ this on once kube-prometheus-stack is installed.
 Per docs/INVIOLABLE-PRINCIPLES.md #4 every knob (interval, namespace,
 labels) is operator-tunable.
 */}}
-{{- if .Values.externalDns.serviceMonitor.enabled }}
+{{- /*
+Capabilities gate: bp-kube-prometheus-stack ships the
+`monitoring.coreos.com/v1` CRD that backs ServiceMonitor — it is NOT in
+the bootstrap-kit. On a cold install of a fresh Sovereign the apiserver
+rejects ServiceMonitor resources with `no matches for kind ServiceMonitor
+in version monitoring.coreos.com/v1`. The Capabilities check skips this
+template entirely until the observability tier is reconciled, at which
+point the CRD is registered and the gate becomes a no-op. This is the
+architectural pattern from issue #190 — defense in depth alongside the
+values-toggle (`externalDns.serviceMonitor.enabled`) so an operator
+flipping the toggle on a Sovereign that hasn't reached Phase 2 doesn't
+break the bp-external-dns reconcile.
+*/}}
+{{- if and .Values.externalDns.serviceMonitor.enabled (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:

--- a/platform/powerdns/blueprint.yaml
+++ b/platform/powerdns/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/category: per-host-cluster-infrastructure
     catalyst.openova.io/section: pts-3-2-gitops-and-iac
 spec:
-  version: 1.1.1
+  version: 1.1.2
   card:
     title: PowerDNS
     summary: |

--- a/platform/powerdns/chart/Chart.yaml
+++ b/platform/powerdns/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-powerdns
-version: 1.1.1
+version: 1.1.2
 description: |
   Catalyst-curated Blueprint wrapper for PowerDNS Authoritative.
   Carries Catalyst-specific values.yaml + templates (CNPG cluster, dnsdist

--- a/platform/powerdns/chart/templates/api-ingress.yaml
+++ b/platform/powerdns/chart/templates/api-ingress.yaml
@@ -12,6 +12,18 @@ or commits) the basicAuth Secret is created out-of-band by the
 private-repo cluster manifest at clusters/contabo-mkt/apps/powerdns/.
 */}}
 {{- if .Values.api.enabled }}
+{{- /*
+Capabilities gate (issue #190): the `traefik.io/v1alpha1` Middleware CRD
+ships with the Traefik ingress controller. k3s ships Traefik by default
+on most Sovereigns, but a Sovereign overlay MAY disable Traefik (e.g. in
+favour of cilium-only ingress) — in that case the CRD is absent and the
+apiserver rejects this Middleware with `no matches for kind Middleware
+in version traefik.io/v1alpha1`. The Capabilities check skips the
+Middleware while still rendering the Ingress below, so the auth posture
+must then be supplied by the cluster overlay's chosen ingress controller
+(per docs/INVIOLABLE-PRINCIPLES.md #4 — never hardcode ingress class).
+*/}}
+{{- if .Capabilities.APIVersions.Has "traefik.io/v1alpha1" }}
 apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
@@ -22,6 +34,7 @@ metadata:
 spec:
   basicAuth:
     secret: {{ .Values.api.basicAuth.secretName | default "powerdns-api-basicauth" | quote }}
+{{- end }}
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
@@ -32,7 +45,12 @@ metadata:
     {{- include "bp-powerdns.labels" . | nindent 4 }}
   annotations:
     cert-manager.io/cluster-issuer: {{ .Values.api.tls.issuer | default "letsencrypt-prod" | quote }}
+    {{- /* Traefik router middleware annotation only renders when the Traefik
+    Middleware CRD is present (gated above). When Traefik is absent the
+    auth posture moves to the Sovereign's chosen ingress controller. */}}
+    {{- if .Capabilities.APIVersions.Has "traefik.io/v1alpha1" }}
     traefik.ingress.kubernetes.io/router.middlewares: {{ printf "%s-%s@kubernetescrd" .Release.Namespace (.Values.api.middlewareName | default "powerdns-api-auth") | quote }}
+    {{- end }}
 spec:
   ingressClassName: {{ .Values.api.ingressClassName | default "traefik" | quote }}
   {{- if .Values.api.tls.enabled }}

--- a/platform/powerdns/chart/templates/cnpg-cluster.yaml
+++ b/platform/powerdns/chart/templates/cnpg-cluster.yaml
@@ -18,7 +18,19 @@ password}.secretRef).
 `enableSuperuserAccess: true` so that operators can run `pdnsutil`
 schema-altering commands inside the database during DNSSEC key
 rotations and zone imports.
+
+Capabilities gate (issue #190): bp-cnpg ships the `postgresql.cnpg.io/v1`
+CRD that backs Cluster — it is NOT in the bootstrap-kit. On a cold
+install of a fresh Sovereign before bp-cnpg is reconciling, the apiserver
+rejects this Cluster with `no matches for kind Cluster in version
+postgresql.cnpg.io/v1`. The Capabilities check skips this template until
+the CRD is registered, at which point the gate becomes a no-op. The
+Sovereign's bootstrap order MUST land bp-cnpg before bp-powerdns; the
+gate exists so a misordered cluster overlay surfaces as `no Cluster
+created yet` rather than a hard install failure of the entire bp-powerdns
+release.
 */}}
+{{- if .Capabilities.APIVersions.Has "postgresql.cnpg.io/v1" }}
 apiVersion: postgresql.cnpg.io/v1
 kind: Cluster
 metadata:
@@ -161,3 +173,4 @@ spec:
 
   monitoring:
     enablePodMonitor: false
+{{- end }}

--- a/platform/powerdns/chart/templates/crossplane-floatingip.yaml
+++ b/platform/powerdns/chart/templates/crossplane-floatingip.yaml
@@ -37,7 +37,18 @@ This file is not deleted in the cutover — it stays as the canonical
 target-state shape so a fresh chart install on a new Sovereign produces
 a Floating IP automatically once the composition exists.
 */}}
-{{- if .Values.crossplane.floatingIP.enabled }}
+{{- /*
+Capabilities gate (issue #190): the `compose.openova.io/v1alpha1`
+HetznerFloatingIP CRD is registered by the Catalyst Crossplane
+composition family (platform/crossplane/compositions/xrd-floating-ip.yaml,
+not yet authored — see GAP DISCLOSURE above). On a Sovereign without
+that composition reconciled, the apiserver rejects the XR with `no
+matches for kind HetznerFloatingIP in version compose.openova.io/v1alpha1`.
+The Capabilities check skips this template until the CRD is registered;
+combined with the values toggle (`crossplane.floatingIP.enabled`, default
+false) the placeholder ships safely on every Sovereign.
+*/}}
+{{- if and .Values.crossplane.floatingIP.enabled (.Capabilities.APIVersions.Has "compose.openova.io/v1alpha1") }}
 apiVersion: compose.openova.io/v1alpha1
 kind: HetznerFloatingIP
 metadata:


### PR DESCRIPTION
## Summary

Phase-1 architectural cleanup from #190. Catalyst overlay templates that emit resources whose CRDs ship in OTHER `bp-*` charts now guard with `{{- if .Capabilities.APIVersions.Has "<group>/<version>" }} ... {{- end }}` so a cold install on a fresh Sovereign no longer fails with `no matches for kind X in version Y`.

This unblocks the bootstrap-kit reconcile order on a brand-new Sovereign: bp-external-dns and bp-powerdns can install before bp-kube-prometheus-stack / bp-external-secrets / bp-cnpg / Crossplane have shipped their CRDs.

## Audit scope

Audited every chart under `platform/*/chart/templates/`. Only three charts ship Catalyst overlay templates:

- `platform/cert-manager/chart/templates/` — only ClusterIssuer, already uses `helm.sh/hook: post-install,post-upgrade` (CRDs ship in the same chart's subchart, so post-install hook is the correct pattern, not a Capabilities gate). No change.
- `platform/external-dns/chart/templates/` — ServiceMonitor + ExternalSecret. **Gated.**
- `platform/powerdns/chart/templates/` — CNPG Cluster + Traefik Middleware + Crossplane HetznerFloatingIP. **Gated.**

Suspect charts (nats-jetstream, openbao, keycloak, gitea) carry no Catalyst overlay templates — they are pure umbrella charts and their upstream-subchart ServiceMonitor / PrometheusRule emissions are already controlled via `values.yaml` defaults set to `false` (per #182). Capabilities gates can only live in templates the Catalyst overlay owns; those charts have none, so nothing to gate here.

`platform/flux/` deliberately untouched (bp-flux 1.1.2 already merged at 73bb5e81 and is fragile).

## Charts modified

| Chart            | Version       | Templates gated                                                 |
| ---------------- | ------------- | --------------------------------------------------------------- |
| bp-external-dns  | 1.1.0 → 1.1.2 | `servicemonitor.yaml`, `externalsecret.yaml`                    |
| bp-powerdns      | 1.1.1 → 1.1.2 | `cnpg-cluster.yaml`, `api-ingress.yaml`, `crossplane-floatingip.yaml` |

## API versions newly gated

| Template                                                            | apiVersion                          | CRD source                                       |
| ------------------------------------------------------------------- | ----------------------------------- | ------------------------------------------------ |
| `bp-external-dns/servicemonitor.yaml`                               | `monitoring.coreos.com/v1`          | bp-kube-prometheus-stack                         |
| `bp-external-dns/externalsecret.yaml`                               | `external-secrets.io/v1beta1`       | bp-external-secrets                              |
| `bp-powerdns/cnpg-cluster.yaml`                                     | `postgresql.cnpg.io/v1`             | bp-cnpg                                          |
| `bp-powerdns/api-ingress.yaml` (Middleware + router annotation)     | `traefik.io/v1alpha1`               | Traefik ingress controller (k3s default; opt-out via Sovereign overlay) |
| `bp-powerdns/crossplane-floatingip.yaml`                            | `compose.openova.io/v1alpha1`       | Catalyst Crossplane composition family (XHetznerFloatingIP — pending authoring per template's GAP DISCLOSURE) |

## Verification

`helm template` run twice per chart — once cold (no `--api-versions`, expects 0 gated resources) and once hot (`--api-versions <each>`, expects 1 of each):

| Chart           | Cold render        | Hot render                          | Result    |
| --------------- | ------------------ | ----------------------------------- | --------- |
| bp-external-dns | 0 ServiceMonitor, 0 ExternalSecret (with toggles ON) | 1 ServiceMonitor, 1 ExternalSecret  | OK        |
| bp-powerdns     | 0 Cluster, 0 Middleware, 0 HetznerFloatingIP | 1 Cluster, 1 Middleware, 1 HetznerFloatingIP | OK        |

`platform/powerdns/chart/tests/observability-toggle.sh` (existing #182 test) — still passes.

Cosmetic: the Traefik `router.middlewares` annotation on the Ingress is also gated to keep the rendered manifest consistent — when Traefik isn't installed, the annotation is omitted and the Sovereign overlay's chosen ingress controller supplies the auth posture.

## Test plan

- [ ] CI: `helm-lint-blueprints` workflow renders all bp-* charts on PR
- [ ] CI: `blueprint-release.yaml` auto-publishes 1.1.2 of bp-external-dns and bp-powerdns on merge to main
- [ ] Cold install on omantel.omani.works confirms bp-external-dns and bp-powerdns reconcile to Ready before bp-kube-prometheus-stack lands
- [ ] After bp-kube-prometheus-stack reconciles, flipping `externalDns.serviceMonitor.enabled=true` in the Sovereign overlay produces a ServiceMonitor

Closes #190.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>