### PR TITLE
fix(bootstrap-kit): bump keycloak/powerdns/external-dns refs to 1.1.2

### DIFF
--- a/clusters/_template/bootstrap-kit/09-keycloak.yaml
+++ b/clusters/_template/bootstrap-kit/09-keycloak.yaml
@@ -38,7 +38,7 @@ spec:
   chart:
     spec:
       chart: bp-keycloak
-      version: 1.1.1
+      version: 1.1.2
       sourceRef:
         kind: HelmRepository
         name: bp-keycloak

--- a/clusters/_template/bootstrap-kit/11-powerdns.yaml
+++ b/clusters/_template/bootstrap-kit/11-powerdns.yaml
@@ -79,7 +79,7 @@ spec:
   chart:
     spec:
       chart: bp-powerdns
-      version: 1.1.1
+      version: 1.1.2
       sourceRef:
         kind: HelmRepository
         name: bp-powerdns

--- a/clusters/_template/bootstrap-kit/12-external-dns.yaml
+++ b/clusters/_template/bootstrap-kit/12-external-dns.yaml
@@ -50,7 +50,7 @@ spec:
   chart:
     spec:
       chart: bp-external-dns
-      version: 1.1.0
+      version: 1.1.2
       sourceRef:
         kind: HelmRepository
         name: bp-external-dns


### PR DESCRIPTION
## Summary

After PRs #198 (closes #191), #200 (closes #190), and the blueprint-release auto-publish runs, three new chart versions are live in GHCR:
- `bp-keycloak:1.1.2` (bitnamilegacy/keycloak fix)
- `bp-powerdns:1.1.2` (Capabilities gates for cnpg/traefik CRDs)
- `bp-external-dns:1.1.2` (Capabilities gates for ServiceMonitor)

But `clusters/_template/bootstrap-kit/{09-keycloak,11-powerdns,12-external-dns}.yaml` still pin the older versions, so fresh Sovereign provisions install the broken/ungated versions.

This bumps the three references.

## Test plan
- [x] manifest-validation will pass (no Chart.yaml drift introduced)
- [ ] Once merged, next `tofu apply` for a fresh Sovereign installs the gated charts

🤖 Generated with [Claude Code](https://claude.com/claude-code)