### PR TITLE
fix(wizard): wire pixel-port testids (admin-sidebar, job-row-*, job-expansion-*)

### DIFF
--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/AppsPage.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/AppsPage.test.tsx
@@ -77,7 +77,7 @@ describe('AppsPage — header', () => {
   it('mounts inside the PortalShell (sidebar present)', async () => {
     renderProvision('d-1')
     expect(await screen.findByTestId('sov-portal-shell')).toBeTruthy()
-    expect(screen.getByTestId('sov-sidebar')).toBeTruthy()
+    expect(screen.getByTestId('admin-sidebar')).toBeTruthy()
   })
 })
 

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/JobCard.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/JobCard.test.tsx
@@ -113,7 +113,7 @@ describe('JobCard — chrome', () => {
 describe('JobCard — expand / collapse', () => {
   it('default-expands a running job', async () => {
     renderWithRouter(<JobCard job={RUNNING_JOB} deploymentId="d-1" />)
-    const panel = await screen.findByTestId(`sov-job-panel-${RUNNING_JOB.id}`)
+    const panel = await screen.findByTestId(`job-expansion-${RUNNING_JOB.id}`)
     expect(panel).toBeTruthy()
     // All three steps render
     expect(within(panel).getByTestId('sov-step-0')).toBeTruthy()
@@ -124,21 +124,21 @@ describe('JobCard — expand / collapse', () => {
   it('default-collapses a pending job', async () => {
     renderWithRouter(<JobCard job={PENDING_INFRA_JOB} deploymentId="d-1" />)
     expect(await screen.findByTestId(`sov-job-card-${PENDING_INFRA_JOB.id}`)).toBeTruthy()
-    expect(screen.queryByTestId(`sov-job-panel-${PENDING_INFRA_JOB.id}`)).toBeNull()
+    expect(screen.queryByTestId(`job-expansion-${PENDING_INFRA_JOB.id}`)).toBeNull()
   })
 
   it('clicking the row toggles expansion', async () => {
     renderWithRouter(<JobCard job={PENDING_INFRA_JOB} deploymentId="d-1" />)
-    const row = await screen.findByTestId(`sov-job-row-${PENDING_INFRA_JOB.id}`)
+    const row = await screen.findByTestId(`job-row-${PENDING_INFRA_JOB.id}`)
     fireEvent.click(row)
-    expect(screen.queryByTestId(`sov-job-panel-${PENDING_INFRA_JOB.id}`)).toBeTruthy()
+    expect(screen.queryByTestId(`job-expansion-${PENDING_INFRA_JOB.id}`)).toBeTruthy()
     fireEvent.click(row)
-    expect(screen.queryByTestId(`sov-job-panel-${PENDING_INFRA_JOB.id}`)).toBeNull()
+    expect(screen.queryByTestId(`job-expansion-${PENDING_INFRA_JOB.id}`)).toBeNull()
   })
 
   it('respects defaultExpanded={true}', async () => {
     renderWithRouter(<JobCard job={PENDING_INFRA_JOB} deploymentId="d-1" defaultExpanded />)
-    expect(await screen.findByTestId(`sov-job-panel-${PENDING_INFRA_JOB.id}`)).toBeTruthy()
+    expect(await screen.findByTestId(`job-expansion-${PENDING_INFRA_JOB.id}`)).toBeTruthy()
   })
 })
 
@@ -162,7 +162,7 @@ describe('JobCard — app-name link', () => {
 describe('JobCard — empty steps', () => {
   it('shows a placeholder when an expanded job has no steps yet', async () => {
     renderWithRouter(<JobCard job={PENDING_INFRA_JOB} deploymentId="d-1" defaultExpanded />)
-    const panel = await screen.findByTestId(`sov-job-panel-${PENDING_INFRA_JOB.id}`)
+    const panel = await screen.findByTestId(`job-expansion-${PENDING_INFRA_JOB.id}`)
     expect(panel.textContent).toContain('No steps yet')
   })
 })

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/JobCard.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/JobCard.tsx
@@ -54,7 +54,7 @@ export function JobCard({ job, deploymentId, defaultExpanded }: JobCardProps) {
         data-job-kind={job.app === 'infrastructure' ? 'provision' : job.app === 'cluster-bootstrap' ? 'bootstrap' : 'install'}
         data-job-status={job.status}
         aria-expanded={expanded}
-        data-testid={`sov-job-row-${job.id}`}
+        data-testid={`job-row-${job.id}`}
       >
         {/* Status icon (running spinner / success check / failed X / pending clock) */}
         <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-[var(--color-accent)]/10">
@@ -132,7 +132,7 @@ export function JobCard({ job, deploymentId, defaultExpanded }: JobCardProps) {
       {expanded ? (
         <div
           className="border-t border-[var(--color-border)] p-4"
-          data-testid={`sov-job-panel-${job.id}`}
+          data-testid={`job-expansion-${job.id}`}
         >
           {job.steps.length === 0 ? (
             <p className="text-xs text-[var(--color-text-dimmer)]">

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/Sidebar.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/Sidebar.test.tsx
@@ -58,7 +58,7 @@ beforeEach(() => {})
 describe('Sidebar — chrome', () => {
   it('renders the OpenOva mark + wordmark in the header', async () => {
     renderSidebarAt('/provision/d-test-1234')
-    const sidebar = await screen.findByTestId('sov-sidebar')
+    const sidebar = await screen.findByTestId('admin-sidebar')
     // SVG logo present
     expect(sidebar.querySelector('svg')).toBeTruthy()
     expect(within(sidebar).getByText('OpenOva')).toBeTruthy()
@@ -113,7 +113,7 @@ describe('Sidebar — navigation', () => {
 describe('Sidebar — operator card', () => {
   it('renders Operator + "Provisioning session" footer text', async () => {
     renderSidebarAt('/provision/d-test-1234')
-    const sidebar = await screen.findByTestId('sov-sidebar')
+    const sidebar = await screen.findByTestId('admin-sidebar')
     expect(within(sidebar).getByText('Operator')).toBeTruthy()
     expect(within(sidebar).getByText('Provisioning session')).toBeTruthy()
   })

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/Sidebar.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/Sidebar.tsx
@@ -87,7 +87,7 @@ export function Sidebar({ deploymentId, sovereignFQDN }: SidebarProps) {
   return (
     <aside
       className="fixed left-0 top-0 flex h-screen w-56 flex-col border-r border-[var(--color-border)] bg-[var(--color-bg-2)]"
-      data-testid="sov-sidebar"
+      data-testid="admin-sidebar"
     >
       {/* Logo + Sovereign label (replaces canonical Tenant switcher) */}
       <div className="border-b border-[var(--color-border)]">


### PR DESCRIPTION
## Summary

Renames three testids on the Sovereign-provision surfaces to match the canonical anchors the upcoming `e2e/cosmetic-guards.spec.ts` regression suite expects:

| File | Old | New |
|---|---|---|
| `products/catalyst/bootstrap/ui/src/pages/sovereign/Sidebar.tsx` (aside root) | `sov-sidebar` | `admin-sidebar` |
| `products/catalyst/bootstrap/ui/src/pages/sovereign/JobCard.tsx` (row button) | `sov-job-row-${job.id}` | `job-row-${job.id}` |
| `products/catalyst/bootstrap/ui/src/pages/sovereign/JobCard.tsx` (expansion panel) | `sov-job-panel-${job.id}` | `job-expansion-${job.id}` |

Pre-existing in-tree unit tests that referenced the old testids (`Sidebar.test.tsx`, `AppsPage.test.tsx`, `JobCard.test.tsx`) are updated to use the new names — **all 238 unit tests still pass locally** (`npm test`).

## Why a separate PR

Wiring testid plumbing in its own PR keeps the upcoming `feat/cosmetic-regression-guards` PR (#179 logo tile + #187 pixel-port admin/jobs guards) reviewable as just the spec definitions. Mixing source-of-truth testid renames with the spec that consumes them muddies the diff.

## Refs

- #187 — pixel-port core/console (apps + app detail + jobs expand-in-place); merged at a894b54a — these testids unblock the cosmetic guards for that work.
- #179 — logo tile — covered by the same upcoming regression-guards PR.

## Test plan

- [x] `cd products/catalyst/bootstrap/ui && npm test` — 238/238 unit tests pass on this branch
- [ ] CI manifest-validation green (only required check; the Playwright UI smoke 60s flake is known + non-blocking)
- [ ] After merge: rebase `feat/cosmetic-regression-guards` onto fresh `origin/main`; the 15 cosmetic guard Playwright tests must all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)