### PR TITLE
fix(ci): tempo + ntfy logos are now .svg (post logo-fix-batch-2)

### DIFF
--- a/.github/workflows/catalyst-build.yaml
+++ b/.github/workflows/catalyst-build.yaml
@@ -89,8 +89,8 @@ jobs:
               component-logos/cnpg.svg \
               component-logos/loki.png \
               component-logos/mimir.png \
-              component-logos/tempo.png \
-              component-logos/ntfy.png \
+              component-logos/tempo.svg \
+              component-logos/ntfy.svg \
               component-logos/ferretdb.png \
               component-logos/openmeter.png \
               component-logos/coraza.png \


### PR DESCRIPTION
Smoke test for catalyst-ui in catalyst-build.yaml hits /component-logos/<id>.<ext>. PR #202 (logo fix batch) replaced tempo.png/ntfy.png with .svg, but the workflow's hard-coded list wasn't updated. Build at SHA 5aee6aa7 failed because of this. One-line fix.