### PR TITLE
fix(clusters): seed otech.omani.works (temporary; canonical in #216)

### DIFF
--- a/clusters/otech.omani.works/bootstrap-kit/01-cilium.yaml
+++ b/clusters/otech.omani.works/bootstrap-kit/01-cilium.yaml
@@ -1,0 +1,64 @@
+# bp-cilium — Catalyst bootstrap-kit Blueprint. CNI must come first; k3s started with --flannel-backend=none precisely so Cilium can take over.
+#
+# Wrapper chart: platform/cilium/chart/
+# Catalyst-curated values: platform/cilium/chart/values.yaml
+# Reconciled by: Flux on the new Sovereign's k3s control plane.
+
+---
+# kube-system is built into every Kubernetes cluster — never re-declare it.
+# Earlier revisions of 01-cilium.yaml AND 05-sealed-secrets.yaml both
+# declared it, which collided when kustomize tried to merge the two:
+#   "may not add resource with an already registered id:
+#    Namespace.v1.[noGrp]/kube-system.[noNs]"
+# This Blueprint installs Cilium INTO kube-system; the HelmRelease's
+# targetNamespace field below is sufficient.
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: bp-cilium
+  namespace: flux-system
+spec:
+  type: oci
+  interval: 15m
+  url: oci://ghcr.io/openova-io
+  secretRef:
+    name: ghcr-pull
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: bp-cilium
+  namespace: flux-system
+spec:
+  interval: 15m
+  releaseName: cilium
+  targetNamespace: kube-system
+  chart:
+    spec:
+      chart: bp-cilium
+      version: 1.1.1
+      sourceRef:
+        kind: HelmRepository
+        name: bp-cilium
+        namespace: flux-system
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+  values:
+    cilium:
+      prometheus:
+        enabled: false
+        serviceMonitor:
+          enabled: false
+      hubble:
+        metrics:
+          enabled: null
+          serviceMonitor:
+            enabled: false
+        relay:
+          enabled: false
+        ui:
+          enabled: false

--- a/clusters/otech.omani.works/bootstrap-kit/02-cert-manager.yaml
+++ b/clusters/otech.omani.works/bootstrap-kit/02-cert-manager.yaml
@@ -1,0 +1,57 @@
+# bp-cert-manager — Catalyst bootstrap-kit Blueprint. TLS for everything below — Lets Encrypt issuer with Dynadot DNS-01 (omani.works pool) or HTTP-01 (BYO domains).
+#
+# Wrapper chart: platform/cert-manager/chart/
+# Catalyst-curated values: platform/cert-manager/chart/values.yaml
+# Reconciled by: Flux on the new Sovereign's k3s control plane.
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cert-manager
+  labels:
+    catalyst.openova.io/sovereign: otech.omani.works
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: bp-cert-manager
+  namespace: flux-system
+spec:
+  type: oci
+  interval: 15m
+  url: oci://ghcr.io/openova-io
+  secretRef:
+    name: ghcr-pull
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: bp-cert-manager
+  namespace: flux-system
+spec:
+  interval: 15m
+  releaseName: cert-manager
+  targetNamespace: cert-manager
+  dependsOn:
+    - name: bp-cilium
+  chart:
+    spec:
+      chart: bp-cert-manager
+      version: 1.1.1
+      sourceRef:
+        kind: HelmRepository
+        name: bp-cert-manager
+        namespace: flux-system
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+  values:
+    cert-manager:
+      prometheus:
+        enabled: false
+        servicemonitor:
+          enabled: false

--- a/clusters/otech.omani.works/bootstrap-kit/03-flux.yaml
+++ b/clusters/otech.omani.works/bootstrap-kit/03-flux.yaml
@@ -1,0 +1,85 @@
+# bp-flux — Catalyst bootstrap-kit Blueprint. Host-level Flux. Per-vcluster Flux is bootstrapped later by environment-controller.
+#
+# Wrapper chart: platform/flux/chart/
+# Catalyst-curated values: platform/flux/chart/values.yaml
+# Reconciled by: Flux on the new Sovereign's k3s control plane.
+#
+# DOUBLE-INSTALL SAFETY (omantel.omani.works incident, 2026-04-29)
+# ----------------------------------------------------------------
+# Cloud-init pre-installs Flux core via
+#   curl https://github.com/fluxcd/flux2/releases/download/v2.4.0/install.yaml
+# so that this very HelmRelease can be reconciled. helm-controller then
+# runs `helm install` for bp-flux on top of the already-running Flux. If
+# the chart's subchart `flux2` version disagrees with the cloud-init
+# install (different upstream Flux release), CRD `storedVersions`
+# mismatches → Helm install fails → rollback → rollback DELETES the
+# running Flux controllers → cluster has no GitOps engine and is
+# unrecoverable in-place.
+#
+# Mitigations applied here:
+#   1. bp-flux:1.1.2 pins the `flux2` subchart at 2.14.1 (= appVersion
+#      2.4.0) which matches cloud-init's v2.4.0 install.yaml.
+#   2. spec.upgrade.preserveValues: true — never silently overwrite
+#      operator overlays on upgrade.
+#   3. spec.install.disableTakeOwnership: false (explicit) — helm-
+#      controller adopts the cloud-init-installed objects rather than
+#      re-creating, so install is non-destructive when objects already
+#      exist with matching apiVersion/kind/name.
+# See docs/RUNBOOK-PROVISIONING.md §"bp-flux double-install".
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: flux-system
+  labels:
+    catalyst.openova.io/sovereign: otech.omani.works
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: bp-flux
+  namespace: flux-system
+spec:
+  type: oci
+  interval: 15m
+  url: oci://ghcr.io/openova-io
+  secretRef:
+    name: ghcr-pull
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: bp-flux
+  namespace: flux-system
+spec:
+  interval: 15m
+  releaseName: flux
+  targetNamespace: flux-system
+  dependsOn:
+    - name: bp-cert-manager
+  chart:
+    spec:
+      chart: bp-flux
+      version: 1.1.2
+      sourceRef:
+        kind: HelmRepository
+        name: bp-flux
+        namespace: flux-system
+  install:
+    # Adopt cloud-init-installed Flux objects rather than fail on
+    # ownership conflict (the objects exist before the HelmRelease ever
+    # reconciles). Without this, the very first reconcile would error
+    # with "object already exists" on every Flux controller Deployment.
+    disableTakeOwnership: false
+    remediation:
+      retries: 3
+  upgrade:
+    # Keep operator-supplied values (e.g. resource overrides applied via
+    # helm-controller out-of-band, or dry-run patches during incident
+    # response) on chart upgrades. Without this, every upgrade would
+    # reset the chart to default values, masking operator state.
+    preserveValues: true
+    # Match install behaviour — adopt rather than fail on conflict.
+    disableTakeOwnership: false
+    remediation:
+      retries: 3

--- a/clusters/otech.omani.works/bootstrap-kit/04-crossplane.yaml
+++ b/clusters/otech.omani.works/bootstrap-kit/04-crossplane.yaml
@@ -1,0 +1,51 @@
+# bp-crossplane — Catalyst bootstrap-kit Blueprint. Day-2 cloud resource control plane. Adopts management of resources OpenTofu created in Phase 0 (Phase 1 hand-off per SOVEREIGN-PROVISIONING.md §4).
+#
+# Wrapper chart: platform/crossplane/chart/
+# Catalyst-curated values: platform/crossplane/chart/values.yaml
+# Reconciled by: Flux on the new Sovereign's k3s control plane.
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: crossplane-system
+  labels:
+    catalyst.openova.io/sovereign: otech.omani.works
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: bp-crossplane
+  namespace: flux-system
+spec:
+  type: oci
+  interval: 15m
+  url: oci://ghcr.io/openova-io
+  secretRef:
+    name: ghcr-pull
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: bp-crossplane
+  namespace: flux-system
+spec:
+  interval: 15m
+  releaseName: crossplane
+  targetNamespace: crossplane-system
+  dependsOn:
+    - name: bp-flux
+  chart:
+    spec:
+      chart: bp-crossplane
+      version: 1.1.1
+      sourceRef:
+        kind: HelmRepository
+        name: bp-crossplane
+        namespace: flux-system
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3

--- a/clusters/otech.omani.works/bootstrap-kit/05-sealed-secrets.yaml
+++ b/clusters/otech.omani.works/bootstrap-kit/05-sealed-secrets.yaml
@@ -1,0 +1,47 @@
+# bp-sealed-secrets — Catalyst bootstrap-kit Blueprint. Transient bootstrap-only — used during Phase 0 to ship initial secrets through GitOps. Replaced by OpenBao + ESO once those land.
+#
+# Wrapper chart: platform/sealed-secrets/chart/
+# Catalyst-curated values: platform/sealed-secrets/chart/values.yaml
+# Reconciled by: Flux on the new Sovereign's k3s control plane.
+
+---
+# kube-system is built into every Kubernetes cluster — never re-declare it.
+# See 01-cilium.yaml for the full incident note. Sealed-Secrets installs
+# INTO kube-system; the HelmRelease's targetNamespace below is sufficient.
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: bp-sealed-secrets
+  namespace: flux-system
+spec:
+  type: oci
+  interval: 15m
+  url: oci://ghcr.io/openova-io
+  secretRef:
+    name: ghcr-pull
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: bp-sealed-secrets
+  namespace: flux-system
+spec:
+  interval: 15m
+  releaseName: sealed-secrets
+  targetNamespace: kube-system
+  dependsOn:
+    - name: bp-cert-manager
+  chart:
+    spec:
+      chart: bp-sealed-secrets
+      version: 1.1.1
+      sourceRef:
+        kind: HelmRepository
+        name: bp-sealed-secrets
+        namespace: flux-system
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3

--- a/clusters/otech.omani.works/bootstrap-kit/06-spire.yaml
+++ b/clusters/otech.omani.works/bootstrap-kit/06-spire.yaml
@@ -1,0 +1,51 @@
+# bp-spire — Catalyst bootstrap-kit Blueprint. Workload identity. SPIFFE/SPIRE issues 5-min rotating SVIDs to every Pod. Required by NATS JetStream and OpenBao below for SVID-based auth.
+#
+# Wrapper chart: platform/spire/chart/
+# Catalyst-curated values: platform/spire/chart/values.yaml
+# Reconciled by: Flux on the new Sovereign's k3s control plane.
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: spire-system
+  labels:
+    catalyst.openova.io/sovereign: otech.omani.works
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: bp-spire
+  namespace: flux-system
+spec:
+  type: oci
+  interval: 15m
+  url: oci://ghcr.io/openova-io
+  secretRef:
+    name: ghcr-pull
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: bp-spire
+  namespace: flux-system
+spec:
+  interval: 15m
+  releaseName: spire
+  targetNamespace: spire-system
+  dependsOn:
+    - name: bp-cert-manager
+  chart:
+    spec:
+      chart: bp-spire
+      version: 1.1.1
+      sourceRef:
+        kind: HelmRepository
+        name: bp-spire
+        namespace: flux-system
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3

--- a/clusters/otech.omani.works/bootstrap-kit/07-nats-jetstream.yaml
+++ b/clusters/otech.omani.works/bootstrap-kit/07-nats-jetstream.yaml
@@ -1,0 +1,51 @@
+# bp-nats-jetstream — Catalyst bootstrap-kit Blueprint. Catalyst's control-plane event spine. Per-Org Account isolation. KV bucket per Environment.
+#
+# Wrapper chart: platform/nats-jetstream/chart/
+# Catalyst-curated values: platform/nats-jetstream/chart/values.yaml
+# Reconciled by: Flux on the new Sovereign's k3s control plane.
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: nats-system
+  labels:
+    catalyst.openova.io/sovereign: otech.omani.works
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: bp-nats-jetstream
+  namespace: flux-system
+spec:
+  type: oci
+  interval: 15m
+  url: oci://ghcr.io/openova-io
+  secretRef:
+    name: ghcr-pull
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: bp-nats-jetstream
+  namespace: flux-system
+spec:
+  interval: 15m
+  releaseName: nats-jetstream
+  targetNamespace: nats-system
+  dependsOn:
+    - name: bp-spire
+  chart:
+    spec:
+      chart: bp-nats-jetstream
+      version: 1.1.1
+      sourceRef:
+        kind: HelmRepository
+        name: bp-nats-jetstream
+        namespace: flux-system
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3

--- a/clusters/otech.omani.works/bootstrap-kit/08-openbao.yaml
+++ b/clusters/otech.omani.works/bootstrap-kit/08-openbao.yaml
@@ -1,0 +1,51 @@
+# bp-openbao — Catalyst bootstrap-kit Blueprint. Secret backend. 3-node Raft, region-local. No stretched cluster (per SECURITY.md §5).
+#
+# Wrapper chart: platform/openbao/chart/
+# Catalyst-curated values: platform/openbao/chart/values.yaml
+# Reconciled by: Flux on the new Sovereign's k3s control plane.
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openbao
+  labels:
+    catalyst.openova.io/sovereign: otech.omani.works
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: bp-openbao
+  namespace: flux-system
+spec:
+  type: oci
+  interval: 15m
+  url: oci://ghcr.io/openova-io
+  secretRef:
+    name: ghcr-pull
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: bp-openbao
+  namespace: flux-system
+spec:
+  interval: 15m
+  releaseName: openbao
+  targetNamespace: openbao
+  dependsOn:
+    - name: bp-spire
+  chart:
+    spec:
+      chart: bp-openbao
+      version: 1.1.1
+      sourceRef:
+        kind: HelmRepository
+        name: bp-openbao
+        namespace: flux-system
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3

--- a/clusters/otech.omani.works/bootstrap-kit/09-keycloak.yaml
+++ b/clusters/otech.omani.works/bootstrap-kit/09-keycloak.yaml
@@ -1,0 +1,51 @@
+# bp-keycloak — Catalyst bootstrap-kit Blueprint. User identity. Topology decided by Sovereign CRD spec.keycloakTopology.
+#
+# Wrapper chart: platform/keycloak/chart/
+# Catalyst-curated values: platform/keycloak/chart/values.yaml
+# Reconciled by: Flux on the new Sovereign's k3s control plane.
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: keycloak
+  labels:
+    catalyst.openova.io/sovereign: otech.omani.works
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: bp-keycloak
+  namespace: flux-system
+spec:
+  type: oci
+  interval: 15m
+  url: oci://ghcr.io/openova-io
+  secretRef:
+    name: ghcr-pull
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: bp-keycloak
+  namespace: flux-system
+spec:
+  interval: 15m
+  releaseName: keycloak
+  targetNamespace: keycloak
+  dependsOn:
+    - name: bp-cert-manager
+  chart:
+    spec:
+      chart: bp-keycloak
+      version: 1.1.2
+      sourceRef:
+        kind: HelmRepository
+        name: bp-keycloak
+        namespace: flux-system
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3

--- a/clusters/otech.omani.works/bootstrap-kit/10-gitea.yaml
+++ b/clusters/otech.omani.works/bootstrap-kit/10-gitea.yaml
@@ -1,0 +1,63 @@
+# bp-gitea — Catalyst Blueprint #10 of 11. Per-Sovereign Git server with
+# the public Blueprint catalog mirror seeded. Catalyst's catalog-svc reads
+# Blueprint metadata from this Gitea (not from the public openova monorepo
+# directly) so the Sovereign is air-gap-ready by construction.
+#
+# Wrapper chart: platform/gitea/chart/
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: gitea
+  labels:
+    catalyst.openova.io/sovereign: otech.omani.works
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: bp-gitea
+  namespace: flux-system
+spec:
+  type: oci
+  interval: 15m
+  url: oci://ghcr.io/openova-io
+  secretRef:
+    name: ghcr-pull
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: bp-gitea
+  namespace: flux-system
+spec:
+  interval: 15m
+  releaseName: gitea
+  targetNamespace: gitea
+  dependsOn:
+    - name: bp-keycloak
+  chart:
+    spec:
+      chart: bp-gitea
+      version: 1.1.1
+      sourceRef:
+        kind: HelmRepository
+        name: bp-gitea
+        namespace: flux-system
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+  values:
+    global:
+      sovereignFQDN: otech.omani.works
+    # gitea hostname is gitea.otech.omani.works. The DNS A record
+    # was already published by the Phase-0 catalyst-dns helper.
+    ingress:
+      hosts:
+        - host: gitea.otech.omani.works
+          paths:
+            - path: /
+              pathType: Prefix

--- a/clusters/otech.omani.works/bootstrap-kit/11-powerdns.yaml
+++ b/clusters/otech.omani.works/bootstrap-kit/11-powerdns.yaml
@@ -1,0 +1,92 @@
+# bp-powerdns — Catalyst Blueprint #11 of 13. Per-Sovereign authoritative
+# DNS. Every Sovereign owns its own PowerDNS Authoritative server with the
+# Sovereign's zones loaded into a CNPG-backed gpgsql backend; per-zone
+# DNSSEC (ECDSAP256SHA256), lua-records for geo + health-checked failover,
+# and a dnsdist companion for query rate-limiting + DDoS posture.
+#
+# Architectural anchor — per-Sovereign PowerDNS, NOT a shared instance:
+#   This file was added so each Sovereign has its own bp-powerdns release
+#   alongside bp-external-dns (#12). The original Phase-0 dial-tone
+#   PowerDNS used to live as a singleton in the openova-system namespace
+#   on contabo-mkt; #168 ("per-Sovereign PowerDNS zones") flipped that
+#   model so a Sovereign's zones never leave the Sovereign's own cluster.
+#   bp-external-dns's `dependsOn: [bp-powerdns]` therefore must be
+#   satisfied by an in-cluster sibling release — this file IS that
+#   sibling.
+#
+# Wrapper chart: platform/powerdns/chart/
+# Catalyst-curated values: platform/powerdns/chart/values.yaml
+#   - 3 PowerDNS Authoritative replicas behind dnsdist
+#   - CNPG-managed `pdns-pg` Postgres cluster for zone storage
+#   - DNSSEC ON by default (ECDSAP256SHA256)
+#   - Lua-records ON (geo + health-checked failover patterns)
+#   - REST API at pdns.<sovereign>/api behind Traefik basicAuth
+#
+# Reconciled by: Flux on the new Sovereign's k3s control plane.
+#
+# dependsOn:
+#   - bp-cert-manager — the REST API ingress requests a TLS cert from
+#     the cluster's letsencrypt-prod ClusterIssuer; without bp-cert-manager
+#     reconciled first the Certificate resource sits Pending.
+#
+# Hard-but-implicit dependencies (CRDs, NOT sibling Blueprints):
+#   - postgresql.cnpg.io/v1.Cluster — provided by the CNPG operator. The
+#     chart's templates/cnpg-cluster.yaml renders this CR; if CNPG isn't
+#     yet installed on the Sovereign, the HelmRelease will wait. CNPG is
+#     a fixture of Catalyst-Zero (FABRIC group, componentGroups.ts `cnpg`)
+#     and is installed alongside this kit by the bootstrap installer.
+#   - traefik.io/v1alpha1.Middleware — Traefik is the Catalyst-Zero
+#     ingress controller and is a fixture of every Sovereign.
+#
+# Per-Sovereign overrides intentionally NOT set here:
+#   - Zones, API basic-auth credentials, anycast Floating-IP target — all
+#     of those are provisioned by Crossplane / pool-domain-manager (PDM)
+#     after the cluster comes up, NOT baked into the bootstrap kit. This
+#     file installs the chart with defaults so the Sovereign has a working
+#     authoritative DNS surface that PDM can then load zones into.
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: powerdns
+  labels:
+    catalyst.openova.io/sovereign: otech.omani.works
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: bp-powerdns
+  namespace: flux-system
+spec:
+  type: oci
+  interval: 15m
+  url: oci://ghcr.io/openova-io
+  secretRef:
+    name: ghcr-pull
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: bp-powerdns
+  namespace: flux-system
+spec:
+  interval: 15m
+  releaseName: powerdns
+  targetNamespace: powerdns
+  dependsOn:
+    - name: bp-cert-manager
+  chart:
+    spec:
+      chart: bp-powerdns
+      version: 1.1.2
+      sourceRef:
+        kind: HelmRepository
+        name: bp-powerdns
+        namespace: flux-system
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3

--- a/clusters/otech.omani.works/bootstrap-kit/12-external-dns.yaml
+++ b/clusters/otech.omani.works/bootstrap-kit/12-external-dns.yaml
@@ -1,0 +1,73 @@
+# bp-external-dns — Catalyst Blueprint #12 of 13. Per-Sovereign DNS sync —
+# ExternalDNS reconciles Service/Ingress hostnames into the per-Sovereign
+# PowerDNS authoritative server via the native `pdns` provider. Geo +
+# health-checked failover responses are owned by PowerDNS lua-records,
+# NOT by ExternalDNS.
+#
+# Wrapper chart: platform/external-dns/chart/
+#
+# dependsOn:
+#   - bp-cert-manager — ExternalDNS HelmRelease only after TLS issuers
+#     are reconciled, so any cert-manager-fronted webhook endpoints in
+#     downstream overlays come up cleanly.
+#   - bp-powerdns — native `pdns` provider points at the in-cluster
+#     bp-powerdns Service and reads the `powerdns-api-credentials` Secret
+#     it renders. Without bp-powerdns the ExternalDNS pod CrashLoops
+#     trying to dial a non-existent DNS API.
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: external-dns
+  labels:
+    catalyst.openova.io/sovereign: otech.omani.works
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: bp-external-dns
+  namespace: flux-system
+spec:
+  type: oci
+  interval: 15m
+  url: oci://ghcr.io/openova-io
+  secretRef:
+    name: ghcr-pull
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: bp-external-dns
+  namespace: flux-system
+spec:
+  interval: 15m
+  releaseName: external-dns
+  targetNamespace: external-dns
+  dependsOn:
+    - name: bp-cert-manager
+    - name: bp-powerdns
+  chart:
+    spec:
+      chart: bp-external-dns
+      version: 1.1.2
+      sourceRef:
+        kind: HelmRepository
+        name: bp-external-dns
+        namespace: flux-system
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+  # Per-Sovereign overrides — txtOwnerId MUST be the Sovereign FQDN so two
+  # Sovereigns sharing a parent zone don't fight over the same record set.
+  # domainFilters narrow the zones ExternalDNS will manage; per-Sovereign
+  # cluster overlays patch this with the actual zone list.
+  values:
+    external-dns:
+      txtOwnerId: otech.omani.works
+      txtPrefix: _externaldns.
+      domainFilters:
+        - otech.omani.works

--- a/clusters/otech.omani.works/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/otech.omani.works/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -1,0 +1,72 @@
+# bp-catalyst-platform — Catalyst Blueprint #13 of 13. The umbrella
+# Blueprint that brings up the Catalyst control plane: console, marketplace,
+# admin, catalog-svc, projector, provisioning, environment-controller,
+# blueprint-controller, billing.
+#
+# Per docs/ARCHITECTURE.md §11 (Catalyst-on-Catalyst): once this is Ready,
+# the Sovereign is fully self-sufficient — sovereign-admin can log into
+# console.otech.omani.works and proceed with Phase 2 day-1 setup.
+#
+# Wrapper chart: products/catalyst/chart/
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: catalyst-system
+  labels:
+    catalyst.openova.io/sovereign: otech.omani.works
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: bp-catalyst-platform
+  namespace: flux-system
+spec:
+  type: oci
+  interval: 15m
+  url: oci://ghcr.io/openova-io
+  secretRef:
+    name: ghcr-pull
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: bp-catalyst-platform
+  namespace: flux-system
+spec:
+  interval: 15m
+  releaseName: catalyst-platform
+  targetNamespace: catalyst-system
+  dependsOn:
+    - name: bp-gitea
+  chart:
+    spec:
+      chart: bp-catalyst-platform
+      version: 1.1.2
+      sourceRef:
+        kind: HelmRepository
+        name: bp-catalyst-platform
+        namespace: flux-system
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+  # Per-Sovereign overrides for the umbrella — sovereign-FQDN-derived hostnames
+  # for console/admin/api. All chart-level Catalyst service config (image refs,
+  # OTel endpoints, NATS subjects) lives in products/catalyst/chart/values.yaml.
+  values:
+    global:
+      sovereignFQDN: otech.omani.works
+    ingress:
+      hosts:
+        console:
+          host: console.otech.omani.works
+        admin:
+          host: admin.otech.omani.works
+        marketplace:
+          host: otech.omani.works
+        api:
+          host: api.otech.omani.works

--- a/clusters/otech.omani.works/bootstrap-kit/kustomization.yaml
+++ b/clusters/otech.omani.works/bootstrap-kit/kustomization.yaml
@@ -1,0 +1,20 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# Order is documented but not enforced here — Flux respects HelmRelease
+# dependsOn declarations for actual install order. Listing in canonical
+# Phase 0 sequence per SOVEREIGN-PROVISIONING.md §3.
+resources:
+  - 01-cilium.yaml
+  - 02-cert-manager.yaml
+  - 03-flux.yaml
+  - 04-crossplane.yaml
+  - 05-sealed-secrets.yaml
+  - 06-spire.yaml
+  - 07-nats-jetstream.yaml
+  - 08-openbao.yaml
+  - 09-keycloak.yaml
+  - 10-gitea.yaml
+  - 11-powerdns.yaml
+  - 12-external-dns.yaml
+  - 13-bp-catalyst-platform.yaml

--- a/clusters/otech.omani.works/flux-system/kustomization.yaml
+++ b/clusters/otech.omani.works/flux-system/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# Flux's own components were applied directly by cloud-init. The
+# GitRepository + Kustomization that point at clusters/<sovereign-fqdn>/
+# (this directory) are what start the GitOps loop and are also written
+# by cloud-init. This entry is a stub for future Flux config customization
+# (pull intervals, registry credentials, etc.) — empty by default.
+resources: []

--- a/clusters/otech.omani.works/infrastructure/kustomization.yaml
+++ b/clusters/otech.omani.works/infrastructure/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - provider-hcloud.yaml
+  - provider-config-hcloud.yaml

--- a/clusters/otech.omani.works/infrastructure/provider-config-hcloud.yaml
+++ b/clusters/otech.omani.works/infrastructure/provider-config-hcloud.yaml
@@ -1,0 +1,15 @@
+# ProviderConfig for provider-hcloud. Token source = the K8s secret
+# `hcloud-credentials` in `crossplane-system`, which the OpenTofu module's
+# cloud-init writes at Phase-0 time so Crossplane can adopt resources
+# immediately after install.
+apiVersion: hcloud.crossplane.io/v1beta1
+kind: ProviderConfig
+metadata:
+  name: default
+spec:
+  credentials:
+    source: Secret
+    secretRef:
+      namespace: crossplane-system
+      name: hcloud-credentials
+      key: token

--- a/clusters/otech.omani.works/infrastructure/provider-hcloud.yaml
+++ b/clusters/otech.omani.works/infrastructure/provider-hcloud.yaml
@@ -1,0 +1,8 @@
+# Crossplane provider-hcloud — installed AFTER bp-crossplane lands core.
+# Adopts Phase-0 OpenTofu-created resources and manages day-2 changes.
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata:
+  name: provider-hcloud
+spec:
+  package: xpkg.upbound.io/crossplane-contrib/provider-hcloud:v0.4.0

--- a/clusters/otech.omani.works/kustomization.yaml
+++ b/clusters/otech.omani.works/kustomization.yaml
@@ -1,0 +1,15 @@
+# Per-Sovereign Flux Kustomization root.
+#
+# Copied from clusters/_template/ → clusters/<sovereign-fqdn>/ at provisioning
+# time, with otech.omani.works substituted. The Sovereign's k3s
+# control plane (cloud-init bootstrap) installs Flux core, then applies a
+# GitRepository pointing at this Sovereign's directory. From there Flux owns
+# everything.
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - flux-system
+  - infrastructure
+  - bootstrap-kit


### PR DESCRIPTION
Temp diagnostic to unblock the live otech.omani.works cluster which has Flux pointing at clusters/otech.omani.works/bootstrap-kit but only clusters/_template/ exists.

Canonical fix tracked in #216 — cloud-init template should point at _template/ with postBuild.substitute.SOVEREIGN_FQDN_PLACEHOLDER. After that lands, this directory will be removed and re-test will validate idempotent behavior.