### PR TITLE
fix(bootstrap-kit): drop disableTakeOwnership (not in HelmRelease v2 schema)

### DIFF
--- a/clusters/_template/bootstrap-kit/03-flux.yaml
+++ b/clusters/_template/bootstrap-kit/03-flux.yaml
@@ -21,7 +21,6 @@
 #      2.4.0) which matches cloud-init's v2.4.0 install.yaml.
 #   2. spec.upgrade.preserveValues: true — never silently overwrite
 #      operator overlays on upgrade.
-#   3. spec.install.disableTakeOwnership: false (explicit) — helm-
 #      controller adopts the cloud-init-installed objects rather than
 #      re-creating, so install is non-destructive when objects already
 #      exist with matching apiVersion/kind/name.
@@ -70,7 +69,6 @@ spec:
     # ownership conflict (the objects exist before the HelmRelease ever
     # reconciles). Without this, the very first reconcile would error
     # with "object already exists" on every Flux controller Deployment.
-    disableTakeOwnership: false
     remediation:
       retries: 3
   upgrade:
@@ -80,6 +78,5 @@ spec:
     # reset the chart to default values, masking operator state.
     preserveValues: true
     # Match install behaviour — adopt rather than fail on conflict.
-    disableTakeOwnership: false
     remediation:
       retries: 3

--- a/clusters/otech.omani.works/bootstrap-kit/03-flux.yaml
+++ b/clusters/otech.omani.works/bootstrap-kit/03-flux.yaml
@@ -21,7 +21,6 @@
 #      2.4.0) which matches cloud-init's v2.4.0 install.yaml.
 #   2. spec.upgrade.preserveValues: true — never silently overwrite
 #      operator overlays on upgrade.
-#   3. spec.install.disableTakeOwnership: false (explicit) — helm-
 #      controller adopts the cloud-init-installed objects rather than
 #      re-creating, so install is non-destructive when objects already
 #      exist with matching apiVersion/kind/name.
@@ -70,7 +69,6 @@ spec:
     # ownership conflict (the objects exist before the HelmRelease ever
     # reconciles). Without this, the very first reconcile would error
     # with "object already exists" on every Flux controller Deployment.
-    disableTakeOwnership: false
     remediation:
       retries: 3
   upgrade:
@@ -80,6 +78,5 @@ spec:
     # reset the chart to default values, masking operator state.
     preserveValues: true
     # Match install behaviour — adopt rather than fail on conflict.
-    disableTakeOwnership: false
     remediation:
       retries: 3


### PR DESCRIPTION
Flux on otech rejects bp-flux HelmRelease with: '.spec.install.disableTakeOwnership: field not declared in schema'. The field exists on .spec but not nested under install/upgrade. Default behaviour is identical. Removing the comment+stanza pair on both _template and the otech tree.