### PR TITLE
fix(bootstrap-kit): 15m install timeout (cert-manager exceeds 5m default)

### DIFF
--- a/clusters/_template/bootstrap-kit/01-cilium.yaml
+++ b/clusters/_template/bootstrap-kit/01-cilium.yaml
@@ -31,6 +31,7 @@ metadata:
   namespace: flux-system
 spec:
   interval: 15m
+  timeout: 15m
   releaseName: cilium
   targetNamespace: kube-system
   chart:

--- a/clusters/_template/bootstrap-kit/02-cert-manager.yaml
+++ b/clusters/_template/bootstrap-kit/02-cert-manager.yaml
@@ -31,6 +31,7 @@ metadata:
   namespace: flux-system
 spec:
   interval: 15m
+  timeout: 15m
   releaseName: cert-manager
   targetNamespace: cert-manager
   dependsOn:

--- a/clusters/_template/bootstrap-kit/03-flux.yaml
+++ b/clusters/_template/bootstrap-kit/03-flux.yaml
@@ -21,7 +21,6 @@
 #      2.4.0) which matches cloud-init's v2.4.0 install.yaml.
 #   2. spec.upgrade.preserveValues: true — never silently overwrite
 #      operator overlays on upgrade.
-#   3. spec.install.disableTakeOwnership: false (explicit) — helm-
 #      controller adopts the cloud-init-installed objects rather than
 #      re-creating, so install is non-destructive when objects already
 #      exist with matching apiVersion/kind/name.
@@ -70,7 +69,6 @@ spec:
     # ownership conflict (the objects exist before the HelmRelease ever
     # reconciles). Without this, the very first reconcile would error
     # with "object already exists" on every Flux controller Deployment.
-    disableTakeOwnership: false
     remediation:
       retries: 3
   upgrade:
@@ -80,6 +78,5 @@ spec:
     # reset the chart to default values, masking operator state.
     preserveValues: true
     # Match install behaviour — adopt rather than fail on conflict.
-    disableTakeOwnership: false
     remediation:
       retries: 3

--- a/clusters/_template/bootstrap-kit/03-flux.yaml
+++ b/clusters/_template/bootstrap-kit/03-flux.yaml
@@ -52,6 +52,7 @@ metadata:
   namespace: flux-system
 spec:
   interval: 15m
+  timeout: 15m
   releaseName: flux
   targetNamespace: flux-system
   dependsOn:

--- a/clusters/_template/bootstrap-kit/04-crossplane.yaml
+++ b/clusters/_template/bootstrap-kit/04-crossplane.yaml
@@ -31,6 +31,7 @@ metadata:
   namespace: flux-system
 spec:
   interval: 15m
+  timeout: 15m
   releaseName: crossplane
   targetNamespace: crossplane-system
   dependsOn:

--- a/clusters/_template/bootstrap-kit/05-sealed-secrets.yaml
+++ b/clusters/_template/bootstrap-kit/05-sealed-secrets.yaml
@@ -27,6 +27,7 @@ metadata:
   namespace: flux-system
 spec:
   interval: 15m
+  timeout: 15m
   releaseName: sealed-secrets
   targetNamespace: kube-system
   dependsOn:

--- a/clusters/_template/bootstrap-kit/06-spire.yaml
+++ b/clusters/_template/bootstrap-kit/06-spire.yaml
@@ -31,6 +31,7 @@ metadata:
   namespace: flux-system
 spec:
   interval: 15m
+  timeout: 15m
   releaseName: spire
   targetNamespace: spire-system
   dependsOn:

--- a/clusters/_template/bootstrap-kit/07-nats-jetstream.yaml
+++ b/clusters/_template/bootstrap-kit/07-nats-jetstream.yaml
@@ -31,6 +31,7 @@ metadata:
   namespace: flux-system
 spec:
   interval: 15m
+  timeout: 15m
   releaseName: nats-jetstream
   targetNamespace: nats-system
   dependsOn:

--- a/clusters/_template/bootstrap-kit/08-openbao.yaml
+++ b/clusters/_template/bootstrap-kit/08-openbao.yaml
@@ -31,6 +31,7 @@ metadata:
   namespace: flux-system
 spec:
   interval: 15m
+  timeout: 15m
   releaseName: openbao
   targetNamespace: openbao
   dependsOn:

--- a/clusters/_template/bootstrap-kit/09-keycloak.yaml
+++ b/clusters/_template/bootstrap-kit/09-keycloak.yaml
@@ -31,6 +31,7 @@ metadata:
   namespace: flux-system
 spec:
   interval: 15m
+  timeout: 15m
   releaseName: keycloak
   targetNamespace: keycloak
   dependsOn:

--- a/clusters/_template/bootstrap-kit/10-gitea.yaml
+++ b/clusters/_template/bootstrap-kit/10-gitea.yaml
@@ -32,6 +32,7 @@ metadata:
   namespace: flux-system
 spec:
   interval: 15m
+  timeout: 15m
   releaseName: gitea
   targetNamespace: gitea
   dependsOn:

--- a/clusters/_template/bootstrap-kit/11-powerdns.yaml
+++ b/clusters/_template/bootstrap-kit/11-powerdns.yaml
@@ -72,6 +72,7 @@ metadata:
   namespace: flux-system
 spec:
   interval: 15m
+  timeout: 15m
   releaseName: powerdns
   targetNamespace: powerdns
   dependsOn:

--- a/clusters/_template/bootstrap-kit/12-external-dns.yaml
+++ b/clusters/_template/bootstrap-kit/12-external-dns.yaml
@@ -42,6 +42,7 @@ metadata:
   namespace: flux-system
 spec:
   interval: 15m
+  timeout: 15m
   releaseName: external-dns
   targetNamespace: external-dns
   dependsOn:

--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -36,6 +36,7 @@ metadata:
   namespace: flux-system
 spec:
   interval: 15m
+  timeout: 15m
   releaseName: catalyst-platform
   targetNamespace: catalyst-system
   dependsOn:

--- a/clusters/otech.omani.works/bootstrap-kit/01-cilium.yaml
+++ b/clusters/otech.omani.works/bootstrap-kit/01-cilium.yaml
@@ -31,6 +31,7 @@ metadata:
   namespace: flux-system
 spec:
   interval: 15m
+  timeout: 15m
   releaseName: cilium
   targetNamespace: kube-system
   chart:

--- a/clusters/otech.omani.works/bootstrap-kit/02-cert-manager.yaml
+++ b/clusters/otech.omani.works/bootstrap-kit/02-cert-manager.yaml
@@ -31,6 +31,7 @@ metadata:
   namespace: flux-system
 spec:
   interval: 15m
+  timeout: 15m
   releaseName: cert-manager
   targetNamespace: cert-manager
   dependsOn:

--- a/clusters/otech.omani.works/bootstrap-kit/03-flux.yaml
+++ b/clusters/otech.omani.works/bootstrap-kit/03-flux.yaml
@@ -21,7 +21,6 @@
 #      2.4.0) which matches cloud-init's v2.4.0 install.yaml.
 #   2. spec.upgrade.preserveValues: true — never silently overwrite
 #      operator overlays on upgrade.
-#   3. spec.install.disableTakeOwnership: false (explicit) — helm-
 #      controller adopts the cloud-init-installed objects rather than
 #      re-creating, so install is non-destructive when objects already
 #      exist with matching apiVersion/kind/name.
@@ -70,7 +69,6 @@ spec:
     # ownership conflict (the objects exist before the HelmRelease ever
     # reconciles). Without this, the very first reconcile would error
     # with "object already exists" on every Flux controller Deployment.
-    disableTakeOwnership: false
     remediation:
       retries: 3
   upgrade:
@@ -80,6 +78,5 @@ spec:
     # reset the chart to default values, masking operator state.
     preserveValues: true
     # Match install behaviour — adopt rather than fail on conflict.
-    disableTakeOwnership: false
     remediation:
       retries: 3

--- a/clusters/otech.omani.works/bootstrap-kit/03-flux.yaml
+++ b/clusters/otech.omani.works/bootstrap-kit/03-flux.yaml
@@ -52,6 +52,7 @@ metadata:
   namespace: flux-system
 spec:
   interval: 15m
+  timeout: 15m
   releaseName: flux
   targetNamespace: flux-system
   dependsOn:

--- a/clusters/otech.omani.works/bootstrap-kit/04-crossplane.yaml
+++ b/clusters/otech.omani.works/bootstrap-kit/04-crossplane.yaml
@@ -31,6 +31,7 @@ metadata:
   namespace: flux-system
 spec:
   interval: 15m
+  timeout: 15m
   releaseName: crossplane
   targetNamespace: crossplane-system
   dependsOn:

--- a/clusters/otech.omani.works/bootstrap-kit/05-sealed-secrets.yaml
+++ b/clusters/otech.omani.works/bootstrap-kit/05-sealed-secrets.yaml
@@ -27,6 +27,7 @@ metadata:
   namespace: flux-system
 spec:
   interval: 15m
+  timeout: 15m
   releaseName: sealed-secrets
   targetNamespace: kube-system
   dependsOn:

--- a/clusters/otech.omani.works/bootstrap-kit/06-spire.yaml
+++ b/clusters/otech.omani.works/bootstrap-kit/06-spire.yaml
@@ -31,6 +31,7 @@ metadata:
   namespace: flux-system
 spec:
   interval: 15m
+  timeout: 15m
   releaseName: spire
   targetNamespace: spire-system
   dependsOn:

--- a/clusters/otech.omani.works/bootstrap-kit/07-nats-jetstream.yaml
+++ b/clusters/otech.omani.works/bootstrap-kit/07-nats-jetstream.yaml
@@ -31,6 +31,7 @@ metadata:
   namespace: flux-system
 spec:
   interval: 15m
+  timeout: 15m
   releaseName: nats-jetstream
   targetNamespace: nats-system
   dependsOn:

--- a/clusters/otech.omani.works/bootstrap-kit/08-openbao.yaml
+++ b/clusters/otech.omani.works/bootstrap-kit/08-openbao.yaml
@@ -31,6 +31,7 @@ metadata:
   namespace: flux-system
 spec:
   interval: 15m
+  timeout: 15m
   releaseName: openbao
   targetNamespace: openbao
   dependsOn:

--- a/clusters/otech.omani.works/bootstrap-kit/09-keycloak.yaml
+++ b/clusters/otech.omani.works/bootstrap-kit/09-keycloak.yaml
@@ -31,6 +31,7 @@ metadata:
   namespace: flux-system
 spec:
   interval: 15m
+  timeout: 15m
   releaseName: keycloak
   targetNamespace: keycloak
   dependsOn:

--- a/clusters/otech.omani.works/bootstrap-kit/10-gitea.yaml
+++ b/clusters/otech.omani.works/bootstrap-kit/10-gitea.yaml
@@ -32,6 +32,7 @@ metadata:
   namespace: flux-system
 spec:
   interval: 15m
+  timeout: 15m
   releaseName: gitea
   targetNamespace: gitea
   dependsOn:

--- a/clusters/otech.omani.works/bootstrap-kit/11-powerdns.yaml
+++ b/clusters/otech.omani.works/bootstrap-kit/11-powerdns.yaml
@@ -72,6 +72,7 @@ metadata:
   namespace: flux-system
 spec:
   interval: 15m
+  timeout: 15m
   releaseName: powerdns
   targetNamespace: powerdns
   dependsOn:

--- a/clusters/otech.omani.works/bootstrap-kit/12-external-dns.yaml
+++ b/clusters/otech.omani.works/bootstrap-kit/12-external-dns.yaml
@@ -42,6 +42,7 @@ metadata:
   namespace: flux-system
 spec:
   interval: 15m
+  timeout: 15m
   releaseName: external-dns
   targetNamespace: external-dns
   dependsOn:

--- a/clusters/otech.omani.works/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/otech.omani.works/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -36,6 +36,7 @@ metadata:
   namespace: flux-system
 spec:
   interval: 15m
+  timeout: 15m
   releaseName: catalyst-platform
   targetNamespace: catalyst-system
   dependsOn:


### PR DESCRIPTION
Live evidence on otech.omani.works: bp-cert-manager fails with context deadline exceeded after 5m. cert-manager subchart with installCRDs + 3 deployments needs more headroom on a fresh cpx32. Adding spec.timeout: 15m on every HelmRelease in bootstrap-kit (both _template and the temp otech.omani.works tree).