### PR TITLE
feat(wizard): drop top batches strip on JobsPage; new BatchDetail page with progress bar

### DIFF
--- a/products/catalyst/bootstrap/ui/src/app/router.tsx
+++ b/products/catalyst/bootstrap/ui/src/app/router.tsx
@@ -22,6 +22,7 @@ import { AppDetail } from '@/pages/sovereign/AppDetail'
 import { JobsPage } from '@/pages/sovereign/JobsPage'
 import { JobDetail } from '@/pages/sovereign/JobDetail'
 import { JobsTimeline } from '@/pages/sovereign/JobsTimeline'
+import { BatchDetail } from '@/pages/sovereign/BatchDetail'
 
 // Root
 const rootRoute = createRootRoute({ component: RootLayout })
@@ -106,6 +107,19 @@ const provisionJobDetailRoute = createRoute({
   component: JobDetail,
 })
 
+// Per-Batch detail page (epic #204 item #4) — surfaces a single batch
+// progress card at the top + a JobsTable filtered to that batch's
+// rows. Reachable from the batch chip in any JobsTable row (both
+// JobsPage and AppDetail's Jobs tab). Founder verbatim:
+//   "the progress bar needs to be shown only when I click a specific
+//    batch and it shows the batch page along with its batch progress
+//    at the top"
+const provisionBatchDetailRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/provision/$deploymentId/batches/$batchId',
+  component: BatchDetail,
+})
+
 // Legacy DAG provision view — preserved at a sub-path so existing
 // links and CI smoke tests (which still curl `/provision/legacy/...`)
 // don't 404 mid-rollout. Once the public smoke tests move to the new
@@ -152,6 +166,7 @@ const routeTree = rootRoute.addChildren([
   provisionJobsRoute,
   provisionJobsTimelineRoute,
   provisionJobDetailRoute,
+  provisionBatchDetailRoute,
   legacyProvisionRoute,
   designsRoute,
   designsJobsDepsVizRoute,

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/BatchDetail.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/BatchDetail.test.tsx
@@ -1,0 +1,169 @@
+/**
+ * BatchDetail.test.tsx — coverage for the per-batch detail surface
+ * served at `/sovereign/provision/$deploymentId/batches/$batchId`
+ * (epic openova-io/openova#204 item #4).
+ *
+ * Asserts:
+ *   • Route renders + back-link points at /provision/$deploymentId/jobs
+ *   • Single-batch progress card renders (batch-progress-single)
+ *   • Progress bar carries the correct aria-valuenow for the picked batch
+ *   • The embedded JobsTable is filtered to the picked batch's rows only
+ *   • Batch filter dropdown is hidden (already pre-filtered)
+ *   • Not-found state renders when the URL batchId has no matching jobs
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+import {
+  RouterProvider,
+  createRouter,
+  createRootRoute,
+  createRoute,
+  createMemoryHistory,
+  Outlet,
+} from '@tanstack/react-router'
+import { BatchDetail } from './BatchDetail'
+import { useWizardStore } from '@/entities/deployment/store'
+import { INITIAL_WIZARD_STATE } from '@/entities/deployment/model'
+
+function renderBatchDetail(deploymentId: string, batchId: string) {
+  const rootRoute = createRootRoute({ component: () => <Outlet /> })
+  const batchRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/provision/$deploymentId/batches/$batchId',
+    component: () => <BatchDetail disableStream />,
+  })
+  const jobsRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/provision/$deploymentId/jobs',
+    component: () => <div data-testid="jobs-target" />,
+  })
+  const homeRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/provision/$deploymentId',
+    component: () => <div data-testid="apps-target" />,
+  })
+  const jobDetailRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/provision/$deploymentId/jobs/$jobId',
+    component: () => <div data-testid="job-detail-target" />,
+  })
+  const wizardRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/wizard',
+    component: () => <div data-testid="wizard-target" />,
+  })
+  const tree = rootRoute.addChildren([
+    batchRoute,
+    jobsRoute,
+    homeRoute,
+    jobDetailRoute,
+    wizardRoute,
+  ])
+  const router = createRouter({
+    routeTree: tree,
+    history: createMemoryHistory({
+      initialEntries: [`/provision/${deploymentId}/batches/${batchId}`],
+    }),
+  })
+  return render(<RouterProvider router={router} />)
+}
+
+beforeEach(() => {
+  useWizardStore.setState({ ...INITIAL_WIZARD_STATE })
+  globalThis.fetch = (() =>
+    Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve({ events: [], state: undefined, done: false }),
+    } as unknown as Response)) as typeof fetch
+})
+
+afterEach(() => cleanup())
+
+describe('BatchDetail — chrome', () => {
+  it('renders the batch title from the URL parameter', async () => {
+    renderBatchDetail('d-1', 'phase-0-infra')
+    const title = await screen.findByTestId('sov-batch-title')
+    expect(title.textContent).toBe('phase-0-infra')
+  })
+
+  it('back-link points at /provision/$deploymentId/jobs', async () => {
+    renderBatchDetail('d-1', 'phase-0-infra')
+    const link = await screen.findByTestId('sov-batch-back-to-jobs')
+    expect(link.getAttribute('href')).toBe('/provision/d-1/jobs')
+  })
+
+  it('mounts inside the PortalShell', async () => {
+    renderBatchDetail('d-1', 'phase-0-infra')
+    expect(await screen.findByTestId('sov-portal-shell')).toBeTruthy()
+  })
+
+  it('renders a breadcrumb above the title', async () => {
+    renderBatchDetail('d-1', 'phase-0-infra')
+    const crumb = await screen.findByTestId('sov-batch-breadcrumb')
+    expect(crumb.textContent).toMatch(/jobs/i)
+    expect(crumb.textContent).toMatch(/batch/i)
+  })
+})
+
+describe('BatchDetail — single batch progress card', () => {
+  it('renders the batch-progress-single card for the picked batch', async () => {
+    // The default Phase 0 batch is auto-derived from the wizard's
+    // bootstrap-kit components — `phase-0-infra` exists from mount.
+    renderBatchDetail('d-1', 'phase-0-infra')
+    const card = await screen.findByTestId('batch-progress-single')
+    expect(card).toBeTruthy()
+    // The progress card renders one progressbar with aria-valuenow.
+    const bar = await screen.findByTestId('batch-card-bar-phase-0-infra')
+    const valuenow = bar.getAttribute('aria-valuenow')
+    expect(valuenow).not.toBeNull()
+    // Value must be an integer 0..100.
+    const n = Number(valuenow)
+    expect(Number.isFinite(n)).toBe(true)
+    expect(n).toBeGreaterThanOrEqual(0)
+    expect(n).toBeLessThanOrEqual(100)
+  })
+
+  it('renders the per-status counters (running / pending / succeeded / failed / total)', async () => {
+    renderBatchDetail('d-1', 'phase-0-infra')
+    expect(await screen.findByTestId('batch-card-stat-running-phase-0-infra')).toBeTruthy()
+    expect(screen.getByTestId('batch-card-stat-pending-phase-0-infra')).toBeTruthy()
+    expect(screen.getByTestId('batch-card-stat-succeeded-phase-0-infra')).toBeTruthy()
+    expect(screen.getByTestId('batch-card-stat-failed-phase-0-infra')).toBeTruthy()
+    expect(screen.getByTestId('batch-card-stat-total-phase-0-infra')).toBeTruthy()
+  })
+})
+
+describe('BatchDetail — filtered JobsTable', () => {
+  it('embeds a JobsTable with no batch filter dropdown (already pre-filtered)', async () => {
+    renderBatchDetail('d-1', 'phase-0-infra')
+    await screen.findByTestId('jobs-table')
+    expect(screen.queryByTestId('jobs-filter-batch')).toBeNull()
+  })
+
+  it('filtered JobsTable shows ONLY rows whose batchId matches the URL param', async () => {
+    renderBatchDetail('d-1', 'phase-0-infra')
+    await screen.findByTestId('jobs-table')
+    const rows = screen.getAllByTestId(/^jobs-table-row-/)
+    expect(rows.length).toBeGreaterThan(0)
+    // Spot-check the four phase-0 rows from deriveJobs are in the
+    // table (they all carry batchId='phase-0-infra').
+    expect(screen.queryByTestId('jobs-table-row-infrastructure:tofu-init')).toBeTruthy()
+    expect(screen.queryByTestId('jobs-table-row-infrastructure:tofu-plan')).toBeTruthy()
+    expect(screen.queryByTestId('jobs-table-row-infrastructure:tofu-apply')).toBeTruthy()
+    expect(screen.queryByTestId('jobs-table-row-infrastructure:tofu-output')).toBeTruthy()
+    // And the cluster-bootstrap row (different batch) is NOT in this
+    // filtered view.
+    expect(screen.queryByTestId('jobs-table-row-cluster-bootstrap')).toBeNull()
+  })
+})
+
+describe('BatchDetail — not-found state', () => {
+  it('renders a not-found notice when the URL batchId has no matching jobs', async () => {
+    renderBatchDetail('d-1', 'no-such-batch')
+    expect(await screen.findByTestId('sov-batch-not-found')).toBeTruthy()
+    // The single-batch progress card is NOT rendered when the batch
+    // is missing — the component falls back to the empty state.
+    expect(screen.queryByTestId('batch-progress-single')).toBeNull()
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/BatchDetail.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/BatchDetail.tsx
@@ -1,0 +1,201 @@
+/**
+ * BatchDetail — per-batch detail surface served at
+ * `/sovereign/provision/$deploymentId/batches/$batchId`.
+ *
+ * Founder requirement (epic #204 item #4, verbatim):
+ *   "On the jobs page the top 3 cards are not required, the progress
+ *    bar needs to be shown only when I click a specific batch and it
+ *    shows the batch page along with its batch progress at the top"
+ *
+ * Layout, top-down:
+ *   • Back-link to JobsPage.
+ *   • Header: batch label + small breadcrumb tag.
+ *   • <BatchProgress singleBatch={batch} /> — ONE full-width card with
+ *     the prominent progress bar + per-status counters.
+ *   • <JobsTable initialBatchFilter={batchId} /> — the same table view
+ *     as JobsPage, pre-pinned to this batch's rows. The Batch filter
+ *     dropdown is hidden (already pre-filtered).
+ *
+ * Per docs/INVIOLABLE-PRINCIPLES.md #4 (never hardcode), the batch
+ * label, counts, and filtered job set are all derived from
+ * `deriveJobs() → adaptDerivedJobsToFlat() → deriveBatches()`. There
+ * is no inlined batch id.
+ */
+
+import { useMemo } from 'react'
+import { useParams, Link } from '@tanstack/react-router'
+import { useWizardStore } from '@/entities/deployment/store'
+import { PortalShell } from './PortalShell'
+import { JobsTable } from './JobsTable'
+import { BatchProgress } from './BatchProgress'
+import { resolveApplications } from './applicationCatalog'
+import { useDeploymentEvents } from './useDeploymentEvents'
+import { deriveJobs } from './jobs'
+import { adaptDerivedJobsToFlat } from './jobsAdapter'
+import { deriveBatches } from '@/test/fixtures/jobs.fixture'
+
+interface BatchDetailProps {
+  /** Test seam — disables the live SSE EventSource attach. */
+  disableStream?: boolean
+}
+
+export function BatchDetail({ disableStream = false }: BatchDetailProps = {}) {
+  const params = useParams({
+    from: '/provision/$deploymentId/batches/$batchId' as never,
+  }) as { deploymentId: string; batchId: string }
+  const { deploymentId, batchId } = params
+  const store = useWizardStore()
+
+  const applications = useMemo(
+    () => resolveApplications(store.selectedComponents),
+    [store.selectedComponents],
+  )
+  const applicationIds = useMemo(() => applications.map((a) => a.id), [applications])
+
+  const { state, snapshot } = useDeploymentEvents({
+    deploymentId,
+    applicationIds,
+    disableStream,
+  })
+  const sovereignFQDN = snapshot?.sovereignFQDN ?? snapshot?.result?.sovereignFQDN ?? null
+
+  const derivedJobs = useMemo(() => deriveJobs(state, applications), [state, applications])
+  const flatJobs = useMemo(() => adaptDerivedJobsToFlat(derivedJobs), [derivedJobs])
+
+  // Recompute batch rollups from the flat job set; pick out the one we
+  // are inspecting. If the batch id from the URL doesn't match any
+  // derived batch (e.g. operator pasted a stale link), surface a small
+  // not-found state — the JobsTable filtered to that batchId would also
+  // be empty, so the page tells the operator why.
+  const batches = useMemo(() => deriveBatches(flatJobs), [flatJobs])
+  const batch = useMemo(() => batches.find((b) => b.batchId === batchId), [batches, batchId])
+
+  return (
+    <PortalShell deploymentId={deploymentId} sovereignFQDN={sovereignFQDN}>
+      <style>{BATCH_DETAIL_CSS}</style>
+
+      <div className="batch-detail-page" data-testid={`sov-batch-detail-${batchId}`}>
+        <Link
+          to="/provision/$deploymentId/jobs"
+          params={{ deploymentId }}
+          className="batch-detail-back"
+          data-testid="sov-batch-back-to-jobs"
+        >
+          &larr; Back to jobs
+        </Link>
+
+        <div className="batch-detail-header">
+          <div>
+            <div
+              className="batch-detail-breadcrumb"
+              data-testid="sov-batch-breadcrumb"
+            >
+              Jobs / Batch
+            </div>
+            <h1
+              className="batch-detail-title"
+              data-testid="sov-batch-title"
+            >
+              {batchId}
+            </h1>
+            <p className="batch-detail-tagline">
+              All jobs in this batch for{' '}
+              {sovereignFQDN || `deployment ${deploymentId.slice(0, 8)}`}
+            </p>
+          </div>
+        </div>
+
+        {batch ? (
+          <BatchProgress singleBatch={batch} />
+        ) : (
+          <div
+            className="batch-detail-empty"
+            data-testid="sov-batch-not-found"
+          >
+            <p>No jobs found for batch <code>{batchId}</code> yet.</p>
+            <p>
+              The batch may not have started, or it may have been removed
+              from the deployment plan.
+            </p>
+          </div>
+        )}
+
+        <div data-testid="sov-batch-jobs-list">
+          <JobsTable
+            jobs={flatJobs}
+            deploymentId={deploymentId}
+            initialBatchFilter={batchId}
+          />
+        </div>
+      </div>
+    </PortalShell>
+  )
+}
+
+const BATCH_DETAIL_CSS = `
+.batch-detail-page {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 0.5rem 0 4rem;
+}
+.batch-detail-back {
+  display: inline-block;
+  margin-bottom: 1rem;
+  color: var(--color-text-dim);
+  font-size: 0.85rem;
+  text-decoration: none;
+}
+.batch-detail-back:hover {
+  color: var(--color-text-strong);
+}
+.batch-detail-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+.batch-detail-breadcrumb {
+  font-size: 0.7rem;
+  color: var(--color-text-dim);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-weight: 600;
+}
+.batch-detail-title {
+  margin: 0.2rem 0 0;
+  font-size: 1.6rem;
+  font-weight: 700;
+  color: var(--color-text-strong);
+  font-family: var(--font-mono, ui-monospace, monospace);
+  letter-spacing: 0.02em;
+}
+.batch-detail-tagline {
+  margin: 0.35rem 0 0;
+  color: var(--color-text-dim);
+  font-size: 0.9rem;
+}
+.batch-detail-empty {
+  padding: 1.4rem 1.2rem;
+  background: var(--color-surface);
+  border: 1px dashed var(--color-border);
+  border-radius: 12px;
+  margin-bottom: 1.2rem;
+}
+.batch-detail-empty p {
+  margin: 0;
+  color: var(--color-text-dim);
+  font-size: 0.88rem;
+}
+.batch-detail-empty p + p {
+  margin-top: 0.4rem;
+}
+.batch-detail-empty code {
+  background: color-mix(in srgb, var(--color-border) 50%, transparent);
+  padding: 0.1rem 0.4rem;
+  border-radius: 4px;
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 0.82rem;
+  color: var(--color-text);
+}
+`

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/BatchProgress.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/BatchProgress.tsx
@@ -1,16 +1,15 @@
 /**
- * BatchProgress — strip rendered ABOVE the JobsTable (item #4 in the
- * issue #204 founder spec). One row per batch, each row shows:
+ * BatchProgress — per-batch progress visualization. Two render modes:
  *
- *   • the batchId label
- *   • a progress bar (`finished / total` proportion)
- *   • a chip row for the four bucket counts (running / pending /
- *     succeeded / failed) so the operator can read the current state
- *     of the batch at a glance without expanding rows.
+ *   1) Strip mode  — `<BatchProgress batches={Batch[]} />`
+ *      Renders one compact row per batch. Originally mounted above the
+ *      JobsTable for the at-a-glance batch rollups.
  *
- * The component is intentionally self-styled with the same CSS-variable
- * tokens the rest of the Sovereign Admin surface uses (`--color-*`,
- * `--wiz-*`) so it slots into JobsPage without a separate visual rework.
+ *   2) Single-batch detail mode — `<BatchProgress singleBatch={Batch} />`
+ *      Renders ONE large card with a prominent progress bar + the four
+ *      bucket counts. Used by the BatchDetail page (epic #204 item 4):
+ *      the founder asked that the progress bar appear only on a batch
+ *      detail page, not on the global JobsPage.
  *
  * Per docs/INVIOLABLE-PRINCIPLES.md #4 (never hardcode), every label
  * comes from the {@link Batch} input — the component never inlines a
@@ -20,11 +19,22 @@
 import type { Batch } from '@/lib/jobs.types'
 
 interface BatchProgressProps {
-  batches: readonly Batch[]
+  /** Strip mode: zero-or-more batch rollup rows. */
+  batches?: readonly Batch[]
+  /** Single-batch detail mode: one large card with prominent progress bar. */
+  singleBatch?: Batch
 }
 
-export function BatchProgress({ batches }: BatchProgressProps) {
-  if (batches.length === 0) {
+export function BatchProgress({ batches, singleBatch }: BatchProgressProps) {
+  if (singleBatch) {
+    return (
+      <div className="batch-progress batch-progress-single" data-testid="batch-progress-single">
+        <style>{BATCH_PROGRESS_CSS}</style>
+        <BatchCard batch={singleBatch} />
+      </div>
+    )
+  }
+  if (!batches || batches.length === 0) {
     return null
   }
   return (
@@ -41,14 +51,24 @@ interface BatchRowProps {
   batch: Batch
 }
 
+/**
+ * Compute the ('done' | 'running' | 'failed' | 'pending') tone for a
+ * batch — extracted so both render modes use the same logic.
+ */
+function batchTone(batch: Batch): 'done' | 'running' | 'failed' | 'pending' {
+  if (batch.failed > 0) return 'failed'
+  if (batch.running > 0) return 'running'
+  if (batch.total > 0 && batch.finished === batch.total) return 'done'
+  return 'pending'
+}
+
+function batchPct(batch: Batch): number {
+  return batch.total > 0 ? Math.round((batch.finished / batch.total) * 100) : 0
+}
+
 function BatchRow({ batch }: BatchRowProps) {
-  // Avoid divide-by-zero when a batch has no jobs (degenerate, but the
-  // backend may emit an empty rollup mid-rollout).
-  const pct = batch.total > 0 ? Math.round((batch.finished / batch.total) * 100) : 0
-  // Failed > 0 colours the bar in danger tone (the founder cares about
-  // surfacing failure prominently — item #1: "current level of details
-  // is very poor, we are almost blind").
-  const tone = batch.failed > 0 ? 'failed' : batch.running > 0 ? 'running' : batch.finished === batch.total ? 'done' : 'pending'
+  const pct = batchPct(batch)
+  const tone = batchTone(batch)
 
   return (
     <div className="batch-row" data-testid={`batch-row-${batch.batchId}`} data-tone={tone}>
@@ -85,6 +105,72 @@ function BatchRow({ batch }: BatchRowProps) {
           </span>
         ) : null}
       </div>
+    </div>
+  )
+}
+
+interface BatchCardProps {
+  batch: Batch
+}
+
+/**
+ * Single-batch detail card — full-width, vertical layout with the
+ * progress bar dominating the visual. Used on the BatchDetail page
+ * (founder spec, epic #204 item 4).
+ */
+function BatchCard({ batch }: BatchCardProps) {
+  const pct = batchPct(batch)
+  const tone = batchTone(batch)
+  const succeeded = batch.finished - batch.failed
+
+  return (
+    <div className="batch-card" data-testid={`batch-card-${batch.batchId}`} data-tone={tone}>
+      <div className="batch-card-header">
+        <div>
+          <div className="batch-card-label" data-testid={`batch-card-label-${batch.batchId}`}>
+            {batch.batchId}
+          </div>
+          <div className="batch-card-sub" data-testid={`batch-card-sub-${batch.batchId}`}>
+            {batch.finished} of {batch.total} jobs finished
+          </div>
+        </div>
+        <div className="batch-card-pct" data-testid={`batch-card-pct-${batch.batchId}`}>
+          {pct}%
+        </div>
+      </div>
+      <div
+        className="batch-bar batch-bar-large"
+        role="progressbar"
+        aria-valuenow={pct}
+        aria-valuemin={0}
+        aria-valuemax={100}
+        data-testid={`batch-card-bar-${batch.batchId}`}
+      >
+        <div className={`batch-bar-fill batch-bar-fill-${tone}`} style={{ width: `${pct}%` }} />
+      </div>
+      <div className="batch-card-stats">
+        <Stat label="Running" value={batch.running} kind="running" testid={`batch-card-stat-running-${batch.batchId}`} />
+        <Stat label="Pending" value={batch.pending} kind="pending" testid={`batch-card-stat-pending-${batch.batchId}`} />
+        <Stat label="Succeeded" value={succeeded} kind="succeeded" testid={`batch-card-stat-succeeded-${batch.batchId}`} />
+        <Stat label="Failed" value={batch.failed} kind="failed" testid={`batch-card-stat-failed-${batch.batchId}`} />
+        <Stat label="Total" value={batch.total} kind="total" testid={`batch-card-stat-total-${batch.batchId}`} />
+      </div>
+    </div>
+  )
+}
+
+interface StatProps {
+  label: string
+  value: number
+  kind: 'running' | 'pending' | 'succeeded' | 'failed' | 'total'
+  testid: string
+}
+
+function Stat({ label, value, kind, testid }: StatProps) {
+  return (
+    <div className={`batch-stat batch-stat-${kind}`} data-testid={testid}>
+      <div className="batch-stat-value">{value}</div>
+      <div className="batch-stat-label">{label}</div>
     </div>
   )
 }
@@ -130,6 +216,9 @@ const BATCH_PROGRESS_CSS = `
   background: var(--color-border);
   overflow: hidden;
 }
+.batch-bar-large {
+  height: 14px;
+}
 .batch-bar-fill {
   height: 100%;
   border-radius: 999px;
@@ -165,5 +254,75 @@ const BATCH_PROGRESS_CSS = `
   width: 6px; height: 6px; border-radius: 50%;
   background: currentColor;
   animation: sov-pulse 1.6s ease-in-out infinite;
+}
+
+/* Single-batch detail card — full width, prominent progress bar. */
+.batch-progress-single {
+  margin-bottom: 1.2rem;
+}
+.batch-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+  padding: 1.1rem 1.2rem;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 12px;
+}
+.batch-card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+}
+.batch-card-label {
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--color-text-strong);
+  font-family: var(--font-mono, ui-monospace, monospace);
+  letter-spacing: 0.02em;
+}
+.batch-card-sub {
+  margin-top: 0.2rem;
+  font-size: 0.82rem;
+  color: var(--color-text-dim);
+}
+.batch-card-pct {
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: var(--color-text-strong);
+  font-variant-numeric: tabular-nums;
+}
+.batch-card-stats {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 0.6rem;
+}
+.batch-stat {
+  padding: 0.55rem 0.7rem;
+  background: color-mix(in srgb, var(--color-border) 30%, transparent);
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  text-align: center;
+}
+.batch-stat-value {
+  font-size: 1.2rem;
+  font-weight: 700;
+  color: var(--color-text-strong);
+  font-variant-numeric: tabular-nums;
+}
+.batch-stat-label {
+  margin-top: 0.15rem;
+  font-size: 0.66rem;
+  color: var(--color-text-dim);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+.batch-stat-running .batch-stat-value   { color: #38BDF8; }
+.batch-stat-pending .batch-stat-value   { color: var(--color-text-dim); }
+.batch-stat-succeeded .batch-stat-value { color: #4ADE80; }
+.batch-stat-failed .batch-stat-value    { color: #F87171; }
+@media (max-width: 720px) {
+  .batch-card-stats { grid-template-columns: repeat(2, minmax(0, 1fr)); }
 }
 `

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/JobsPage.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/JobsPage.test.tsx
@@ -49,12 +49,24 @@ function renderJobs(deploymentId: string) {
     path: '/provision/$deploymentId/jobs/$jobId',
     component: () => <div data-testid="job-detail-target" />,
   })
+  const batchDetailRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/provision/$deploymentId/batches/$batchId',
+    component: () => <div data-testid="batch-detail-target" />,
+  })
   const wizardRoute = createRoute({
     getParentRoute: () => rootRoute,
     path: '/wizard',
     component: () => <div data-testid="wizard-target" />,
   })
-  const tree = rootRoute.addChildren([jobsRoute, homeRoute, detailRoute, jobDetailRoute, wizardRoute])
+  const tree = rootRoute.addChildren([
+    jobsRoute,
+    homeRoute,
+    detailRoute,
+    jobDetailRoute,
+    batchDetailRoute,
+    wizardRoute,
+  ])
   const router = createRouter({
     routeTree: tree,
     history: createMemoryHistory({ initialEntries: [`/provision/${deploymentId}/jobs`] }),
@@ -146,5 +158,28 @@ describe('JobsPage — search', () => {
     renderJobs('d-1')
     const search = await screen.findByTestId('jobs-search')
     expect(search.tagName.toLowerCase()).toBe('input')
+  })
+})
+
+describe('JobsPage — batches strip removed (epic #204 item #4)', () => {
+  it('does NOT render the per-batch progress strip', async () => {
+    // Founder verbatim: "On the jobs page the top 3 cards are not
+    // required, the progress bar needs to be shown only when I click
+    // a specific batch and it shows the batch page along with its
+    // batch progress at the top". This guard locks in the removal.
+    renderJobs('d-1')
+    await screen.findByTestId('jobs-table')
+    expect(screen.queryByTestId('batch-progress')).toBeNull()
+    const batchRows = document.querySelectorAll('[data-testid^="batch-row-"]')
+    expect(batchRows.length).toBe(0)
+  })
+
+  it('batch chip in a row links to the BatchDetail page', async () => {
+    renderJobs('d-1')
+    await screen.findByTestId('jobs-table')
+    const chip = screen.getByTestId('jobs-cell-batch-bp-cilium') as HTMLAnchorElement
+    expect(chip.tagName.toLowerCase()).toBe('a')
+    // Spot-check the route shape — the batch id varies by job.
+    expect(chip.getAttribute('href')).toMatch(/^\/provision\/d-1\/batches\//)
   })
 })

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/JobsPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/JobsPage.tsx
@@ -7,9 +7,17 @@
  *
  * Layout, top-down:
  *   • Header: <h1>Jobs</h1> + tagline + back-to-apps link.
- *   • <BatchProgress /> — one progress bar per batch (item #4).
  *   • <JobsTable /> — table view with search/sort/filter (items #2,
- *     #6, #7, #8a).
+ *     #6, #7, #8a). Each batch chip is a link to the BatchDetail page
+ *     (item #4: progress bar moves to per-batch detail view).
+ *
+ * Per founder feedback for epic #204 item #4 (verbatim):
+ *   "On the jobs page the top 3 cards are not required, the progress
+ *    bar needs to be shown only when I click a specific batch and it
+ *    shows the batch page along with its batch progress at the top"
+ *
+ * Consequently the top BatchProgress strip is intentionally OMITTED on
+ * this surface. Per-batch progress lives at /batches/$batchId only.
  *
  * Data flow:
  *   1. Live SSE events (via useDeploymentEvents) populate the legacy
@@ -31,12 +39,10 @@ import { useParams, Link } from '@tanstack/react-router'
 import { useWizardStore } from '@/entities/deployment/store'
 import { PortalShell } from './PortalShell'
 import { JobsTable } from './JobsTable'
-import { BatchProgress } from './BatchProgress'
 import { resolveApplications } from './applicationCatalog'
 import { useDeploymentEvents } from './useDeploymentEvents'
 import { deriveJobs } from './jobs'
 import { adaptDerivedJobsToFlat } from './jobsAdapter'
-import { deriveBatches } from '@/test/fixtures/jobs.fixture'
 
 interface JobsPageProps {
   /** Test seam — disables the live SSE EventSource attach. */
@@ -65,7 +71,6 @@ export function JobsPage({ disableStream = false }: JobsPageProps = {}) {
 
   const derivedJobs = useMemo(() => deriveJobs(state, applications), [state, applications])
   const flatJobs = useMemo(() => adaptDerivedJobsToFlat(derivedJobs), [derivedJobs])
-  const batches = useMemo(() => deriveBatches(flatJobs), [flatJobs])
 
   return (
     <PortalShell deploymentId={deploymentId} sovereignFQDN={sovereignFQDN}>
@@ -88,7 +93,6 @@ export function JobsPage({ disableStream = false }: JobsPageProps = {}) {
       </div>
 
       <div className="mt-6" data-testid="sov-jobs-list">
-        <BatchProgress batches={batches} />
         <JobsTable jobs={flatJobs} deploymentId={deploymentId} />
       </div>
     </PortalShell>

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/JobsTable.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/JobsTable.tsx
@@ -151,11 +151,19 @@ interface JobsTableProps {
    * (item #8b: AppDetail → Jobs tab filtered to that app's jobs only).
    */
   appIdFilter?: string
+  /**
+   * Optional pre-filter pinned to a single batchId. Used by the
+   * BatchDetail page (epic #204 item #4) to surface only the rows
+   * that belong to the batch the operator drilled into. The Batch
+   * filter dropdown is hidden when this is set, mirroring how
+   * `appIdFilter` hides the App dropdown.
+   */
+  initialBatchFilter?: string
 }
 
 const STATUS_VALUES: readonly JobStatus[] = ['running', 'pending', 'succeeded', 'failed']
 
-export function JobsTable({ jobs, deploymentId, appIdFilter }: JobsTableProps) {
+export function JobsTable({ jobs, deploymentId, appIdFilter, initialBatchFilter }: JobsTableProps) {
   const [search, setSearch] = useState<string>('')
   const [statusFilter, setStatusFilter] = useState<'' | JobStatus>('')
   const [appFilter, setAppFilter] = useState<string>('')
@@ -177,6 +185,7 @@ export function JobsTable({ jobs, deploymentId, appIdFilter }: JobsTableProps) {
   const visibleJobs = useMemo<Job[]>(() => {
     const filtered = jobs.filter((j) => {
       if (appIdFilter && j.appId !== appIdFilter) return false
+      if (initialBatchFilter && j.batchId !== initialBatchFilter) return false
       if (statusFilter && j.status !== statusFilter) return false
       if (appFilter && j.appId !== appFilter) return false
       if (batchFilter && j.batchId !== batchFilter) return false
@@ -185,7 +194,7 @@ export function JobsTable({ jobs, deploymentId, appIdFilter }: JobsTableProps) {
     })
     // Spread to a mutable copy before sort — `jobs` is readonly.
     return [...filtered].sort(compareJobs)
-  }, [jobs, search, statusFilter, appFilter, batchFilter, appIdFilter])
+  }, [jobs, search, statusFilter, appFilter, batchFilter, appIdFilter, initialBatchFilter])
 
   return (
     <div className="jobs-table-wrap" data-testid="jobs-table-wrap">
@@ -247,23 +256,25 @@ export function JobsTable({ jobs, deploymentId, appIdFilter }: JobsTableProps) {
             </label>
           )}
 
-          <label className="jobs-filter-label">
-            <span className="jobs-filter-caption">Batch</span>
-            <select
-              value={batchFilter}
-              onChange={(e) => setBatchFilter(e.target.value)}
-              className="jobs-filter-select"
-              data-testid="jobs-filter-batch"
-              aria-label="Filter by batch"
-            >
-              <option value="">All</option>
-              {batchOptions.map((b) => (
-                <option key={b} value={b}>
-                  {b}
-                </option>
-              ))}
-            </select>
-          </label>
+          {initialBatchFilter ? null : (
+            <label className="jobs-filter-label">
+              <span className="jobs-filter-caption">Batch</span>
+              <select
+                value={batchFilter}
+                onChange={(e) => setBatchFilter(e.target.value)}
+                className="jobs-filter-select"
+                data-testid="jobs-filter-batch"
+                aria-label="Filter by batch"
+              >
+                <option value="">All</option>
+                {batchOptions.map((b) => (
+                  <option key={b} value={b}>
+                    {b}
+                  </option>
+                ))}
+              </select>
+            </label>
+          )}
 
           <span
             className="jobs-result-count"
@@ -296,7 +307,9 @@ export function JobsTable({ jobs, deploymentId, appIdFilter }: JobsTableProps) {
                 </td>
               </tr>
             ) : (
-              visibleJobs.map((j) => <JobRow key={j.id} job={j} deploymentId={deploymentId} />)
+              visibleJobs.map((j) => (
+                <JobRow key={j.id} job={j} deploymentId={deploymentId} />
+              ))
             )}
           </tbody>
         </table>
@@ -343,7 +356,15 @@ function JobRow({ job, deploymentId }: JobRowProps) {
         )}
       </td>
       <td className="jobs-cell jobs-cell-batch">
-        <Chip text={job.batchId} testid={`jobs-cell-batch-${job.id}`} kind="batch" />
+        <Link
+          to="/provision/$deploymentId/batches/$batchId"
+          params={{ deploymentId, batchId: job.batchId }}
+          className="jobs-chip jobs-chip-batch jobs-chip-link"
+          data-testid={`jobs-cell-batch-${job.id}`}
+          title={job.batchId}
+        >
+          {job.batchId}
+        </Link>
       </td>
       <td className="jobs-cell jobs-cell-status">
         <StatusBadge status={job.status} jobId={job.id} />
@@ -561,6 +582,16 @@ const JOBS_TABLE_CSS = `
 .jobs-chip-app   { color: #38BDF8; border-color: rgba(56,189,248,0.25); }
 .jobs-chip-batch { color: #C084FC; border-color: rgba(192,132,252,0.25); }
 .jobs-chip-dep   { color: var(--color-text-dim); }
+.jobs-chip-link {
+  text-decoration: none;
+  cursor: pointer;
+  transition: background-color 0.12s ease, border-color 0.12s ease;
+}
+.jobs-chip-link:hover {
+  text-decoration: underline;
+  background: color-mix(in srgb, currentColor 8%, transparent);
+  border-color: currentColor;
+}
 .jobs-chip-row {
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
## Summary

Implements item #4 of epic #204 (founder verbatim):

> "On the jobs page the top 3 cards are not required, the progress bar needs to be shown only when I click a specific batch and it shows the batch page along with its batch progress at the top"

- Removes the 3-card BatchProgress strip from JobsPage; heading + tagline now sit directly above the JobsTable.
- Makes each batch chip in JobsTable a clickable Link to /batches/$batchId. Adds `initialBatchFilter` prop (mirrors `appIdFilter`) that hides the Batch filter dropdown when set.
- BatchProgress component grows a `singleBatch?: Batch` mode rendering ONE large card: batch label, finished/total summary, big progress bar, and 5 status tiles (Running / Pending / Succeeded / Failed / Total).
- NEW BatchDetail page at /provision/\$deploymentId/batches/\$batchId — back-link, breadcrumb, batch title, single-batch progress card, JobsTable filtered to that batch.
- Router registers /batches/\$batchId.

Closes #222 (sub-ticket of #204).

## Files touched

- products/catalyst/bootstrap/ui/src/pages/sovereign/JobsPage.tsx — strip BatchProgress + unused imports
- products/catalyst/bootstrap/ui/src/pages/sovereign/JobsTable.tsx — batch chip Link + initialBatchFilter prop
- products/catalyst/bootstrap/ui/src/pages/sovereign/BatchProgress.tsx — singleBatch render mode + full-width card
- products/catalyst/bootstrap/ui/src/pages/sovereign/BatchDetail.tsx — NEW
- products/catalyst/bootstrap/ui/src/pages/sovereign/BatchDetail.test.tsx — NEW
- products/catalyst/bootstrap/ui/src/pages/sovereign/JobsPage.test.tsx — cosmetic guards + new route
- products/catalyst/bootstrap/ui/src/app/router.tsx — register /batches/\$batchId

## Test plan

- [x] Vitest: 311 passed (20 files), incl. new BatchDetail.test.tsx + JobsPage cosmetic guards
- [x] tsc -b --noEmit clean
- [x] vite build clean (1.58s)
- [x] Playwright MCP @ 1440px on a live dev server:
  - JobsPage shows NO top batch strip; heading+table only
  - Each batch chip is an anchor linking to /batches/\$batchId (hover underline)
  - BatchDetail/phase-0-infra renders single-batch card (0/4, 0%, 5 tiles) + JobsTable filtered to 4 phase-0 rows; Batch dropdown hidden
  - BatchDetail/cluster-bootstrap renders single-batch card (0/1, 0%) + 1-row table

Screenshots in .playwright-mcp/jobs-redesign/:
- 01-jobs-page-no-top-cards-1440.png
- 02-batch-detail-phase-0-infra-1440.png
- 03-batch-detail-cluster-bootstrap-1440.png

🤖 Generated with [Claude Code](https://claude.com/claude-code)