### PR TITLE
fix(bp-cilium): set l7Proxy=true to install envoyconfig CRDs

### DIFF
--- a/clusters/_template/bootstrap-kit/01-cilium.yaml
+++ b/clusters/_template/bootstrap-kit/01-cilium.yaml
@@ -50,6 +50,11 @@ spec:
       retries: 3
   values:
     cilium:
+      # Enable L7 proxy so Cilium's chart installs the
+      # ciliumenvoyconfigs / ciliumclusterwideenvoyconfigs CRDs that the
+      # cilium-agent waits for at startup. Without this, agent crash-loops
+      # forever and the node.cilium.io/agent-not-ready taint never lifts.
+      l7Proxy: true
       prometheus:
         enabled: false
         serviceMonitor:

--- a/clusters/otech.omani.works/bootstrap-kit/01-cilium.yaml
+++ b/clusters/otech.omani.works/bootstrap-kit/01-cilium.yaml
@@ -50,6 +50,11 @@ spec:
       retries: 3
   values:
     cilium:
+      # Enable L7 proxy so Cilium's chart installs the
+      # ciliumenvoyconfigs / ciliumclusterwideenvoyconfigs CRDs that the
+      # cilium-agent waits for at startup. Without this, agent crash-loops
+      # forever and the node.cilium.io/agent-not-ready taint never lifts.
+      l7Proxy: true
       prometheus:
         enabled: false
         serviceMonitor:


### PR DESCRIPTION
Live evidence on otech.omani.works: cilium-agent crash-loops with 'Still waiting for Cilium Operator to register CRDs: [crd:ciliumenvoyconfigs.cilium.io crd:ciliumclusterwideenvoyconfigs.cilium.io]'. Node taint node.cilium.io/agent-not-ready never lifts → cert-manager + everything else can't schedule. Cilium chart 1.16.5 gates envoyconfig CRDs behind 'envoy.enabled && (l7Proxy || gatewayAPI.enabled)'. gatewayAPI requires upstream Gateway-API CRDs pre-installed which they're not. Setting l7Proxy:true removes the dependency.