### PR TITLE
fix(bp-spire): disable default ClusterSPIFFEID + bump 1.1.2

### DIFF
--- a/clusters/_template/bootstrap-kit/06-spire.yaml
+++ b/clusters/_template/bootstrap-kit/06-spire.yaml
@@ -39,7 +39,7 @@ spec:
   chart:
     spec:
       chart: bp-spire
-      version: 1.1.1
+      version: 1.1.2
       sourceRef:
         kind: HelmRepository
         name: bp-spire

--- a/clusters/otech.omani.works/bootstrap-kit/06-spire.yaml
+++ b/clusters/otech.omani.works/bootstrap-kit/06-spire.yaml
@@ -39,7 +39,7 @@ spec:
   chart:
     spec:
       chart: bp-spire
-      version: 1.1.1
+      version: 1.1.2
       sourceRef:
         kind: HelmRepository
         name: bp-spire

--- a/platform/spire/blueprint.yaml
+++ b/platform/spire/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
 spec:
-  version: 1.1.1
+  version: 1.1.2
   card:
     title: spire
     summary: SPIFFE/SPIRE workload identity. 5-min rotating SVIDs. Server on mgt cluster + agent per host cluster.

--- a/platform/spire/chart/Chart.yaml
+++ b/platform/spire/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-spire
-version: 1.1.1
+version: 1.1.2
 description: |
   Catalyst-curated Blueprint umbrella chart for SPIRE. Depends on the
   upstream `spire` chart (spiffe.github.io/helm-charts-hardened) as a Helm

--- a/platform/spire/chart/values.yaml
+++ b/platform/spire/chart/values.yaml
@@ -39,6 +39,19 @@ spire:
       country: DE
       organization: OpenOva Catalyst
       common_name: SPIRE CA
+    # Disable the default ClusterSPIFFEID resource shipped by the upstream
+    # controller-manager. On a fresh Sovereign the CRD is registered by
+    # the same chart's pre-install hook, but Helm still tries to apply
+    # the controller-manager-cluster-ids.yaml template before the CRD is
+    # observable on the API server, producing:
+    #   no matches for kind "ClusterSPIFFEID" in version "spire.spiffe.io/v1alpha1"
+    # Operators add specific identities post-bootstrap; bootstrap doesn't
+    # need a default. Re-enable per-Sovereign when needed.
+    controllerManager:
+      identities:
+        clusterSPIFFEIDs:
+          default:
+            enabled: false
   spire-agent:
     resources:
       requests: { cpu: 50m, memory: 64Mi }


### PR DESCRIPTION
Live evidence on otech: bp-spire fails Helm install with 'no matches for kind ClusterSPIFFEID in version spire.spiffe.io/v1alpha1' even though the chart's pre-install hook registers the CRD. Race between CRD readiness and template application. Disabling the default identity (operators add specific ones post-bootstrap).