### PR TITLE
fix(bp-spire): disable all 3 default-enabled clusterSPIFFEIDs

### DIFF
--- a/clusters/_template/bootstrap-kit/06-spire.yaml
+++ b/clusters/_template/bootstrap-kit/06-spire.yaml
@@ -39,7 +39,7 @@ spec:
   chart:
     spec:
       chart: bp-spire
-      version: 1.1.2
+      version: 1.1.3
       sourceRef:
         kind: HelmRepository
         name: bp-spire

--- a/clusters/otech.omani.works/bootstrap-kit/06-spire.yaml
+++ b/clusters/otech.omani.works/bootstrap-kit/06-spire.yaml
@@ -39,7 +39,7 @@ spec:
   chart:
     spec:
       chart: bp-spire
-      version: 1.1.2
+      version: 1.1.3
       sourceRef:
         kind: HelmRepository
         name: bp-spire

--- a/platform/spire/blueprint.yaml
+++ b/platform/spire/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
 spec:
-  version: 1.1.2
+  version: 1.1.3
   card:
     title: spire
     summary: SPIFFE/SPIRE workload identity. 5-min rotating SVIDs. Server on mgt cluster + agent per host cluster.

--- a/platform/spire/chart/Chart.yaml
+++ b/platform/spire/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-spire
-version: 1.1.2
+version: 1.1.3
 description: |
   Catalyst-curated Blueprint umbrella chart for SPIRE. Depends on the
   upstream `spire` chart (spiffe.github.io/helm-charts-hardened) as a Helm

--- a/platform/spire/chart/values.yaml
+++ b/platform/spire/chart/values.yaml
@@ -50,8 +50,18 @@ spire:
     controllerManager:
       identities:
         clusterSPIFFEIDs:
+          # All 4 default-enabled identities disabled at bootstrap. The
+          # CRD is registered by the chart's pre-install hook, but Helm
+          # still tries to apply ALL clusterSPIFFEIDs templates before
+          # the CRD becomes observable. Operators re-enable per-Sovereign
+          # post-bootstrap when SPIRE workloads need identities.
           default:
             enabled: false
+          oidc-discovery-provider:
+            enabled: false
+          test-keys:
+            enabled: false
+          # child-servers already defaults false upstream
   spire-agent:
     resources:
       requests: { cpu: 50m, memory: 64Mi }


### PR DESCRIPTION
Live evidence: previous fix #228 only disabled 'default' but spire-server has FOUR clusterSPIFFEID identities, three default-enabled (default/oidc-discovery-provider/test-keys). Each races the CRD on fresh install. Disabling all three.