### PR TITLE
fix(bp-gitea): postgresql → bitnamilegacy (Bitnami namespace evacuated)

### DIFF
--- a/clusters/_template/bootstrap-kit/10-gitea.yaml
+++ b/clusters/_template/bootstrap-kit/10-gitea.yaml
@@ -40,7 +40,7 @@ spec:
   chart:
     spec:
       chart: bp-gitea
-      version: 1.1.1
+      version: 1.1.2
       sourceRef:
         kind: HelmRepository
         name: bp-gitea

--- a/clusters/otech.omani.works/bootstrap-kit/10-gitea.yaml
+++ b/clusters/otech.omani.works/bootstrap-kit/10-gitea.yaml
@@ -40,7 +40,7 @@ spec:
   chart:
     spec:
       chart: bp-gitea
-      version: 1.1.1
+      version: 1.1.2
       sourceRef:
         kind: HelmRepository
         name: bp-gitea

--- a/platform/gitea/blueprint.yaml
+++ b/platform/gitea/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
 spec:
-  version: 1.1.1
+  version: 1.1.2
   card:
     title: gitea
     summary: Gitea — per-Sovereign Git server. Catalyst control plane. Hosts catalog (public Blueprint mirror), catalog-sovereign (Sovereign-curated private Blueprints), one Gitea Org per Catalyst Organization, and system (sovereign-admin scope).

--- a/platform/gitea/chart/Chart.yaml
+++ b/platform/gitea/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-gitea
-version: 1.1.1
+version: 1.1.2
 description: |
   Catalyst-curated Blueprint umbrella chart for Gitea. Depends on the
   upstream `gitea` chart (dl.gitea.com) as a Helm subchart so

--- a/platform/gitea/chart/values.yaml
+++ b/platform/gitea/chart/values.yaml
@@ -48,17 +48,25 @@ gitea:
         auth:
           username: gitea
           database: gitea
+    # Bitnami evacuated docker.io/bitnami/postgresql tags around 2025-09;
+    # the chart's default 16.3.0-debian-12-r23 returns 404. bitnamilegacy
+    # is the frozen archive that still serves these tags. Same workaround
+    # as #191 for bp-keycloak. Long-term: cnpg subchart override.
+    image:
+      repository: bitnamilegacy/postgresql
+      tag: 16.3.0-debian-12-r23
     # PostgreSQL exporter + ServiceMonitor + PrometheusRule — DEFAULT OFF.
-    # The bitnami postgresql subchart bundled inside gitea ships a
-    # dedicated metrics exporter container that itself renders a
-    # ServiceMonitor and PrometheusRule. Same circular-CRD reasoning
-    # as above. Operator opts in via per-cluster overlay (issue #182).
     metrics:
       enabled: false
+      image:
+        repository: bitnamilegacy/postgres-exporter
       serviceMonitor:
         enabled: false
       prometheusRule:
         enabled: false
+    volumePermissions:
+      image:
+        repository: bitnamilegacy/os-shell
   redis-cluster:
     enabled: false
   valkey-cluster:


### PR DESCRIPTION
Live on otech: gitea-postgresql-0 ImagePullBackOff on docker.io/bitnami/postgresql:16.3.0-debian-12-r23 → 404. Same Bitnami evacuation as #191/keycloak. Override postgres + exporter + os-shell images to bitnamilegacy/* (frozen archive, still serves the tag).