### PR TITLE
fix(wizard): clear stale phase1-skipped banner + backfill jobs view from live HR state

### DIFF
--- a/products/catalyst/bootstrap/ui/src/components/ExecutionLogs.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/components/ExecutionLogs.test.tsx
@@ -152,6 +152,42 @@ describe('ExecutionLogs — rendering', () => {
     })
   })
 
+  // Issue #232 verbatim: when the API returns
+  //   {lines: [], total: 0, executionFinished: false}
+  // the viewer must show "No logs captured yet for this job."
+  // It must NOT show the error/retry banner (the previous bug — the
+  // generic empty path was indistinguishable from the failure path).
+  it('shows "No logs captured yet" copy on empty success response (issue #232)', async () => {
+    const fetcher = vi.fn(async (): Promise<ExecutionLogsResponse> => ({
+      lines: [],
+      total: 0,
+      executionFinished: false,
+    }))
+    renderViewer({ executionId: 'exec-empty-success', fetcher, disablePolling: true })
+    await waitFor(() => {
+      const empty = screen.getByTestId('execution-logs-empty')
+      expect(empty.textContent).toContain('No logs captured yet')
+    })
+    // Critical anti-regression: NO error banner, NO retry button
+    // when the API returned a successful empty response.
+    expect(screen.queryByTestId('execution-logs-error')).toBeNull()
+    expect(screen.queryByTestId('execution-logs-retry')).toBeNull()
+  })
+
+  // Issue #232 — the error path retains the "Failed to load" banner
+  // and exposes a Retry button (replaces the previous "retrying..."
+  // copy that ran indefinitely without operator agency).
+  it('shows the error banner with a Retry button when the fetcher throws', async () => {
+    const fetcher = vi.fn(async (): Promise<ExecutionLogsResponse> => {
+      throw new Error('500 Internal Server Error')
+    })
+    renderViewer({ executionId: 'exec-failed', fetcher, disablePolling: true })
+    await waitFor(() => {
+      expect(screen.getByTestId('execution-logs-error')).toBeTruthy()
+    })
+    expect(screen.getByTestId('execution-logs-retry')).toBeTruthy()
+  })
+
   it('uses the canonical #0D1117 background colour', async () => {
     const fetcher = vi.fn(async (): Promise<ExecutionLogsResponse> => ({
       lines: [makeLine(1, 'INFO', 'go')],

--- a/products/catalyst/bootstrap/ui/src/components/ExecutionLogs.tsx
+++ b/products/catalyst/bootstrap/ui/src/components/ExecutionLogs.tsx
@@ -250,6 +250,28 @@ export function ExecutionLogs({
     return `${digits}ch`
   }, [allLines])
 
+  // Empty-state copy — see issue #232. The previous "Waiting for log
+  // lines…" / "Connecting to log stream…" copy was indistinguishable
+  // from the error overlay, and the founder's symptom was a backend
+  // returning {lines:[], total:0, executionFinished:false} for jobs
+  // that have no captured logs (most Phase 0 jobs are like this until
+  // the bridge starts recording state-transition lines). The viewer
+  // now distinguishes three states:
+  //
+  //   • isLoading            → "Connecting to log stream…"
+  //   • !isError, no lines   → "No logs captured yet for this job."
+  //                            (the canonical issue-#232 wording)
+  //   • executionFinished    → "Execution finished — no log lines were emitted."
+  //
+  // The error overlay (with a Retry button) only renders on a real
+  // fetch failure (query.isError). A "successful response with empty
+  // lines array" is NOT an error.
+  function emptyCopy(): string {
+    if (query.isLoading) return 'Connecting to log stream…'
+    if (query.data?.executionFinished) return 'Execution finished — no log lines were emitted.'
+    return 'No logs captured yet for this job.'
+  }
+
   return (
     <div
       data-testid="execution-logs-root"
@@ -280,11 +302,7 @@ export function ExecutionLogs({
               fontSize: '0.78rem',
             }}
           >
-            {query.isLoading
-              ? 'Connecting to log stream…'
-              : query.data?.executionFinished
-              ? 'Execution finished — no log lines were emitted.'
-              : 'Waiting for log lines…'}
+            {emptyCopy()}
           </div>
         ) : (
           allLines.map((line) => (
@@ -321,6 +339,10 @@ export function ExecutionLogs({
         <div
           data-testid="execution-logs-error"
           style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            gap: '0.6rem',
             padding: '0.5rem 1rem',
             background: 'rgba(248, 81, 73, 0.15)',
             color: '#f85149',
@@ -328,7 +350,24 @@ export function ExecutionLogs({
             borderTop: '1px solid rgba(248, 81, 73, 0.3)',
           }}
         >
-          Failed to load log page — retrying.
+          <span>Failed to load log page.</span>
+          <button
+            type="button"
+            onClick={() => void query.refetch()}
+            data-testid="execution-logs-retry"
+            style={{
+              background: 'transparent',
+              color: '#f85149',
+              border: '1px solid rgba(248, 81, 73, 0.5)',
+              borderRadius: 4,
+              padding: '0.18rem 0.6rem',
+              fontSize: '0.7rem',
+              fontWeight: 600,
+              cursor: 'pointer',
+            }}
+          >
+            Retry
+          </button>
         </div>
       )}
 

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/JobsPage.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/JobsPage.test.tsx
@@ -23,6 +23,7 @@ import {
   createMemoryHistory,
   Outlet,
 } from '@tanstack/react-router'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { JobsPage } from './JobsPage'
 import { useWizardStore } from '@/entities/deployment/store'
 import { INITIAL_WIZARD_STATE } from '@/entities/deployment/model'
@@ -32,7 +33,7 @@ function renderJobs(deploymentId: string) {
   const jobsRoute = createRoute({
     getParentRoute: () => rootRoute,
     path: '/provision/$deploymentId/jobs',
-    component: () => <JobsPage disableStream />,
+    component: () => <JobsPage disableStream disableJobsBackfill />,
   })
   const homeRoute = createRoute({
     getParentRoute: () => rootRoute,
@@ -71,7 +72,17 @@ function renderJobs(deploymentId: string) {
     routeTree: tree,
     history: createMemoryHistory({ initialEntries: [`/provision/${deploymentId}/jobs`] }),
   })
-  return render(<RouterProvider router={router} />)
+  // Each render gets its own QueryClient so the live-jobs-backfill
+  // query cache never bleeds between tests. Even with backfill
+  // disabled the JobsPage's useQuery() still requires a provider.
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  })
+  return render(
+    <QueryClientProvider client={qc}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>,
+  )
 }
 
 beforeEach(() => {

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/JobsPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/JobsPage.tsx
@@ -43,13 +43,19 @@ import { resolveApplications } from './applicationCatalog'
 import { useDeploymentEvents } from './useDeploymentEvents'
 import { deriveJobs } from './jobs'
 import { adaptDerivedJobsToFlat } from './jobsAdapter'
+import { useLiveJobsBackfill, mergeJobs } from './useLiveJobsBackfill'
 
 interface JobsPageProps {
   /** Test seam — disables the live SSE EventSource attach. */
   disableStream?: boolean
+  /** Test seam — disables the live-jobs backfill polling. */
+  disableJobsBackfill?: boolean
 }
 
-export function JobsPage({ disableStream = false }: JobsPageProps = {}) {
+export function JobsPage({
+  disableStream = false,
+  disableJobsBackfill = false,
+}: JobsPageProps = {}) {
   const params = useParams({
     from: '/provision/$deploymentId/jobs' as never,
   }) as { deploymentId: string }
@@ -62,7 +68,7 @@ export function JobsPage({ disableStream = false }: JobsPageProps = {}) {
   )
   const applicationIds = useMemo(() => applications.map((a) => a.id), [applications])
 
-  const { state, snapshot } = useDeploymentEvents({
+  const { state, snapshot, streamStatus } = useDeploymentEvents({
     deploymentId,
     applicationIds,
     disableStream,
@@ -70,7 +76,31 @@ export function JobsPage({ disableStream = false }: JobsPageProps = {}) {
   const sovereignFQDN = snapshot?.sovereignFQDN ?? snapshot?.result?.sovereignFQDN ?? null
 
   const derivedJobs = useMemo(() => deriveJobs(state, applications), [state, applications])
-  const flatJobs = useMemo(() => adaptDerivedJobsToFlat(derivedJobs), [derivedJobs])
+  const reducerJobs = useMemo(() => adaptDerivedJobsToFlat(derivedJobs), [derivedJobs])
+
+  // Backfill from the catalyst-api Jobs endpoint while the deployment
+  // is in flight. helmwatch only fires on transitions, so a HelmRelease
+  // that's already Ready=True at watch-attach time emits no SSE event;
+  // the backend's Jobs API gives us the current ground-truth list and
+  // the merge below ensures live data wins on conflict. Polling stops
+  // automatically when the deployment reaches a terminal state — by
+  // then `componentStates` on the snapshot already seeded every card.
+  const inFlight = streamStatus !== 'completed' && streamStatus !== 'failed'
+  const { liveJobs } = useLiveJobsBackfill({
+    deploymentId,
+    enabled: !disableJobsBackfill,
+    disablePolling: disableJobsBackfill || !inFlight,
+  })
+
+  const flatJobs = useMemo(
+    () => mergeJobs(reducerJobs, liveJobs),
+    [reducerJobs, liveJobs],
+  )
+
+  // Surface a small banner the first time live data arrives — operators
+  // viewing a stalled-looking page need to know the table is being
+  // refreshed from the backend, not pulled from the local SSE replay.
+  const liveBackfillActive = liveJobs.length > 0
 
   return (
     <PortalShell deploymentId={deploymentId} sovereignFQDN={sovereignFQDN}>
@@ -91,6 +121,17 @@ export function JobsPage({ disableStream = false }: JobsPageProps = {}) {
           ← Back to apps
         </Link>
       </div>
+
+      {liveBackfillActive ? (
+        <div
+          role="status"
+          data-testid="sov-jobs-backfill-banner"
+          className="mt-3 rounded-lg border border-[var(--color-accent)]/35 bg-[var(--color-accent)]/10 p-2 text-xs text-[var(--color-text-dim)]"
+        >
+          <span className="text-[var(--color-accent)] font-semibold">Live state stream re-attached.</span>{' '}
+          Refreshing from the catalyst-api every 5s.
+        </div>
+      ) : null}
 
       <div className="mt-6" data-testid="sov-jobs-list">
         <JobsTable jobs={flatJobs} deploymentId={deploymentId} />

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/JobsTable.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/JobsTable.test.tsx
@@ -263,4 +263,50 @@ describe('JobsTable — render', () => {
     expect(link.tagName.toLowerCase()).toBe('a')
     expect(link.getAttribute('href')).toBe('/provision/d-1/jobs/job-install-cilium')
   })
+
+  // Issue #232 verbatim: "simulates 0 reducer-derived jobs + 5
+  // backend-API jobs, expects 5 rows rendered with backend data".
+  // The JobsPage merges reducer-derived + live-backfill via mergeJobs()
+  // before passing the array to JobsTable; this test exercises the
+  // table's render path with the merged input directly.
+  it('renders all rows when fed exclusively from a backend-jobs API list (issue #232)', async () => {
+    const liveOnly: Job[] = [
+      {
+        id: 'bp-cilium', jobName: 'Install Cilium', appId: 'bp-cilium',
+        batchId: 'applications', dependsOn: [], status: 'succeeded',
+        startedAt: '2026-04-29T10:00:00Z', finishedAt: '2026-04-29T10:01:00Z',
+        durationMs: 60_000,
+      },
+      {
+        id: 'bp-cert-manager', jobName: 'Install cert-manager', appId: 'bp-cert-manager',
+        batchId: 'applications', dependsOn: [], status: 'succeeded',
+        startedAt: '2026-04-29T10:01:00Z', finishedAt: '2026-04-29T10:02:00Z',
+        durationMs: 60_000,
+      },
+      {
+        id: 'bp-flux', jobName: 'Install Flux', appId: 'bp-flux',
+        batchId: 'applications', dependsOn: [], status: 'succeeded',
+        startedAt: '2026-04-29T10:02:00Z', finishedAt: '2026-04-29T10:03:00Z',
+        durationMs: 60_000,
+      },
+      {
+        id: 'bp-crossplane', jobName: 'Install Crossplane', appId: 'bp-crossplane',
+        batchId: 'applications', dependsOn: [], status: 'running',
+        startedAt: '2026-04-29T10:03:00Z', finishedAt: null, durationMs: 0,
+      },
+      {
+        id: 'bp-vault', jobName: 'Install Vault', appId: 'bp-vault',
+        batchId: 'applications', dependsOn: [], status: 'pending',
+        startedAt: null, finishedAt: null, durationMs: 0,
+      },
+    ]
+    renderTable({ jobs: liveOnly, deploymentId: 'd-1' })
+    await screen.findByTestId('jobs-table')
+    const rows = screen.getAllByTestId(/^jobs-table-row-/)
+    expect(rows.length).toBe(5)
+    // Statuses surface verbatim from the backend list (no demotion to pending).
+    expect(screen.getByTestId('jobs-cell-status-bp-cilium').textContent?.toLowerCase()).toContain('succeeded')
+    expect(screen.getByTestId('jobs-cell-status-bp-crossplane').textContent?.toLowerCase()).toContain('running')
+    expect(screen.getByTestId('jobs-cell-status-bp-vault').textContent?.toLowerCase()).toContain('pending')
+  })
 })

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/eventReducer.test.ts
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/eventReducer.test.ts
@@ -213,16 +213,79 @@ describe('eventReducer — reduceEvents + markAllReady', () => {
     expect(s.phase1WatchSkippedReason).toMatch(/Phase-1 watch could not start/)
   })
 
-  // Once flipped, phase1WatchSkipped stays true even if subsequent
-  // events arrive (this is the "stays set for the lifetime of the
-  // deployment" guarantee — operator never sees the banner flicker
-  // off after a stray event).
-  it('phase1WatchSkipped is monotonic — once true, stays true', () => {
+  // Once flipped, phase1WatchSkipped stays true through events that
+  // carry NO ground truth for per-component install state (tofu /
+  // flux-bootstrap / unrelated noise). It only clears when a fresh
+  // per-component event with real `state:` arrives — see the
+  // "clears on fresh component event" test below.
+  it('phase1WatchSkipped survives non-component events (tofu, flux-bootstrap)', () => {
     const s = buildInitialState(APPS)
     applyEvent(s, { phase: 'component', level: 'warn', message: 'kubeconfig missing' })
     expect(s.phase1WatchSkipped).toBe(true)
     applyEvent(s, { phase: 'tofu-output' })
     applyEvent(s, { phase: 'flux-bootstrap' })
+    expect(s.phase1WatchSkipped).toBe(true)
+  })
+
+  // CLEAR-RULE (issue #232) — the AdminPage banner was sticking
+  // permanently because of an old SSE replay event with `state:
+  // skipped` from a transient `status: ready` phase, even though the
+  // deployment record had since transitioned to `phase1-watching` and
+  // the UI was now receiving healthy per-component events. The
+  // monotonic-true guarantee was therefore wrong: a fresh per-
+  // component event with real ground truth must clear the flag.
+  it('phase1WatchSkipped clears on a fresh per-component event with real state', () => {
+    const s = buildInitialState(APPS)
+    // Flip the flag with the kubeconfig-missing warn event.
+    applyEvent(s, { phase: 'component', level: 'warn', message: 'kubeconfig missing' })
+    expect(s.phase1WatchSkipped).toBe(true)
+    // A real installing event arrives — helmwatch IS observing.
+    applyEvent(s, { phase: 'component', component: 'bp-cilium', state: 'installing' })
+    expect(s.phase1WatchSkipped).toBe(false)
+    expect(s.phase1WatchSkippedReason).toBeNull()
+    // Card itself is now installing.
+    expect(s.apps['bp-cilium']?.status).toBe('installing')
+  })
+
+  // Same path, terminal state — `installed` clears the flag too.
+  it('phase1WatchSkipped clears on a per-component installed event', () => {
+    const s = buildInitialState(APPS)
+    applyEvent(s, { phase: 'component', level: 'warn', message: 'kubeconfig missing' })
+    expect(s.phase1WatchSkipped).toBe(true)
+    applyEvent(s, { phase: 'component', component: 'bp-flux', state: 'installed' })
+    expect(s.phase1WatchSkipped).toBe(false)
+  })
+
+  // A `phase: deployment` event with status==='phase1-watching' is
+  // the explicit signal from the catalyst-api that helmwatch is alive.
+  // It clears any stale skipped flag even before per-component events
+  // start arriving.
+  it('phase1WatchSkipped clears on phase: deployment status=phase1-watching', () => {
+    const s = buildInitialState(APPS)
+    applyEvent(s, { phase: 'component', level: 'warn', message: 'kubeconfig missing' })
+    expect(s.phase1WatchSkipped).toBe(true)
+    applyEvent(s, {
+      phase: 'deployment',
+      message: 'helmwatch attached',
+      // status is in the catalyst-api wire shape but not the typed
+      // DeploymentEvent; the reducer reads it via a runtime cast.
+      ...({ status: 'phase1-watching' } as Record<string, string>),
+    } as never)
+    expect(s.phase1WatchSkipped).toBe(false)
+    expect(s.phase1WatchSkippedReason).toBeNull()
+  })
+
+  // A `state: skipped` per-component event does NOT clear the flag —
+  // it's the API's explicit "no data for this slot" marker.
+  it('phase1WatchSkipped does NOT clear when component event carries state=skipped', () => {
+    const s = buildInitialState(APPS)
+    applyEvent(s, { phase: 'component', level: 'warn', message: 'kubeconfig missing' })
+    expect(s.phase1WatchSkipped).toBe(true)
+    applyEvent(s, {
+      phase: 'component',
+      component: 'bp-cilium',
+      ...({ state: 'skipped' } as Record<string, string>),
+    } as never)
     expect(s.phase1WatchSkipped).toBe(true)
   })
 

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/eventReducer.ts
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/eventReducer.ts
@@ -289,8 +289,17 @@ export function applyEvent(state: ReducerState, ev: DeploymentEvent): void {
   // produce the same UI surface — the AdminPage banner — because all
   // three result in zero ground-truth per-component data for this
   // deployment. The message is captured verbatim so the operator sees
-  // the actual reason, and `phase1WatchSkipped` flips to true. Once
-  // set, it stays set for the remainder of this deployment's lifetime.
+  // the actual reason, and `phase1WatchSkipped` flips to true.
+  //
+  // CLEAR-RULE (issue #232): the flag is NO LONGER monotonic. If we
+  // subsequently receive a per-component event carrying real ground-
+  // truth (state ≠ 'skipped' OR a non-empty `component:` field), then
+  // helmwatch IS observing this deployment after all and the banner
+  // must come down. The previous "stays set for lifetime" guarantee
+  // produced a stale banner whenever a single early `state: skipped`
+  // event in the SSE replay buffer contradicted a later stream of
+  // healthy per-component events. Reducer is now the source of truth
+  // for whether ground-truth data has actually arrived.
   if (
     ev.phase === 'component' &&
     (ev.level === 'warn' || ev.level === 'error') &&
@@ -298,6 +307,26 @@ export function applyEvent(state: ReducerState, ev: DeploymentEvent): void {
   ) {
     state.phase1WatchSkipped = true
     if (ev.message) state.phase1WatchSkippedReason = ev.message
+    if (time) state.clusterBootstrap.lastEventTime = time
+    pushEventToBucket(state, CLUSTER_BOOTSTRAP_KEY, ev)
+    return
+  }
+
+  // ── Deployment-level status that contradicts a stale skipped flag ─
+  // The catalyst-api also emits coarse `phase: "deployment"` events
+  // when its overall status transitions. Status `phase1-watching` /
+  // `installing` both prove helmwatch is alive and observing the new
+  // cluster — clear any prior `phase1WatchSkipped` so the AdminPage
+  // banner doesn't shadow live progress. (We do NOT clear on `ready`,
+  // `failed`, or `provisioning` — those are terminal/early phases
+  // where the skipped-flag may legitimately remain set.)
+  if (ev.phase === 'deployment') {
+    const status = (ev as { status?: string }).status
+    if (status === 'phase1-watching' || status === 'installing') {
+      state.phase1WatchSkipped = false
+      state.phase1WatchSkippedReason = null
+    }
+    if (ev.message) state.clusterBootstrap.message = ev.message
     if (time) state.clusterBootstrap.lastEventTime = time
     pushEventToBucket(state, CLUSTER_BOOTSTRAP_KEY, ev)
     return
@@ -325,6 +354,24 @@ export function applyEvent(state: ReducerState, ev: DeploymentEvent): void {
     if (time) app.lastEventTime = time
     app.eventCount += 1
     pushEventToBucket(state, appId, ev)
+    // CLEAR-RULE (issue #232): a real per-component event with a known
+    // state is ground truth from helmwatch. If a previous event flipped
+    // `phase1WatchSkipped` to true (or this is a replay where the
+    // skipped event preceded the live ones), unset it now so the
+    // AdminPage banner reflects the FRESH stream rather than stale
+    // history. We exclude the synthetic `'skipped'` state — that's the
+    // explicit "no data" marker the API emits and should keep the flag
+    // set if it arrives last.
+    //
+    // Note: `'skipped'` is NOT in the DeploymentEvent['state'] union
+    // (mapApiState returns null for it), but the API may emit it as a
+    // free-form string. The check below uses string comparison so we
+    // don't exclude any legitimate state by accident.
+    const evStateStr = ev.state as string | undefined
+    if (apiState !== null && evStateStr !== 'skipped') {
+      state.phase1WatchSkipped = false
+      state.phase1WatchSkippedReason = null
+    }
     return
   }
 

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/useLiveJobsBackfill.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/useLiveJobsBackfill.test.tsx
@@ -1,0 +1,152 @@
+/**
+ * useLiveJobsBackfill.test.tsx — coverage for the live-API jobs
+ * backfill hook + the pure mergeJobs helper (issue #232).
+ *
+ * Coverage:
+ *   • mergeJobs — empty live list → reducer-derived passes through.
+ *   • mergeJobs — non-empty live list with overlapping ids → live wins.
+ *   • mergeJobs — non-overlapping live ids → both rendered.
+ *   • Hook — returns empty list while loading.
+ *   • Hook — returns live jobs once the fetcher resolves.
+ *   • Hook — does NOT poll when `enabled: false`.
+ *   • Hook — silently swallows errors and exposes `isError: true`.
+ */
+
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { renderHook, cleanup, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import type { Job } from '@/lib/jobs.types'
+import { useLiveJobsBackfill, mergeJobs } from './useLiveJobsBackfill'
+
+afterEach(() => cleanup())
+
+function makeJob(partial: Partial<Job>): Job {
+  return {
+    id: partial.id ?? 'job-1',
+    jobName: partial.jobName ?? 'Job 1',
+    appId: partial.appId ?? 'bp-cilium',
+    batchId: partial.batchId ?? 'applications',
+    dependsOn: partial.dependsOn ?? [],
+    status: partial.status ?? 'pending',
+    startedAt: partial.startedAt ?? null,
+    finishedAt: partial.finishedAt ?? null,
+    durationMs: partial.durationMs ?? 0,
+  }
+}
+
+describe('mergeJobs — pure helper', () => {
+  it('returns reducer jobs unchanged when live list is empty', () => {
+    const reducer = [makeJob({ id: 'a' }), makeJob({ id: 'b' })]
+    const merged = mergeJobs(reducer, [])
+    expect(merged).toHaveLength(2)
+    expect(merged.map((j) => j.id)).toEqual(['a', 'b'])
+  })
+
+  it('live wins on conflict (same job.id)', () => {
+    const reducer = [makeJob({ id: 'a', status: 'pending' })]
+    const live = [makeJob({ id: 'a', status: 'succeeded', durationMs: 12_345 })]
+    const merged = mergeJobs(reducer, live)
+    expect(merged).toHaveLength(1)
+    expect(merged[0]!.status).toBe('succeeded')
+    expect(merged[0]!.durationMs).toBe(12_345)
+  })
+
+  it('union of ids when reducer and live disagree', () => {
+    const reducer = [makeJob({ id: 'a' })]
+    const live = [makeJob({ id: 'b' }), makeJob({ id: 'c' })]
+    const merged = mergeJobs(reducer, live)
+    const ids = merged.map((j) => j.id).sort()
+    expect(ids).toEqual(['a', 'b', 'c'])
+  })
+
+  it('fixes the omantel symptom — 0 reducer jobs + 5 backend jobs renders 5 rows', () => {
+    // Reducer-derived list is empty because the SSE buffer's old
+    // events left every card pending. Backend Jobs API has the
+    // ground truth.
+    const reducer: Job[] = []
+    const live: Job[] = [
+      makeJob({ id: 'bp-cilium', status: 'succeeded' }),
+      makeJob({ id: 'bp-cert-manager', status: 'succeeded' }),
+      makeJob({ id: 'bp-flux', status: 'succeeded' }),
+      makeJob({ id: 'bp-crossplane', status: 'running' }),
+      makeJob({ id: 'bp-vault', status: 'pending' }),
+    ]
+    const merged = mergeJobs(reducer, live)
+    expect(merged).toHaveLength(5)
+  })
+})
+
+function wrapper() {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  })
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+  )
+}
+
+describe('useLiveJobsBackfill — hook', () => {
+  it('returns the fetched jobs once the fetcher resolves', async () => {
+    const expected: Job[] = [
+      makeJob({ id: 'bp-cilium', status: 'succeeded' }),
+      makeJob({ id: 'bp-cert-manager', status: 'running' }),
+    ]
+    const fetcher = vi.fn(async (): Promise<Job[]> => expected)
+    const { result } = renderHook(
+      () =>
+        useLiveJobsBackfill({
+          deploymentId: 'd-1',
+          fetcher,
+          disablePolling: true,
+        }),
+      { wrapper: wrapper() },
+    )
+    await waitFor(() => {
+      expect(result.current.liveJobs).toHaveLength(2)
+    })
+    expect(result.current.liveJobs[0]!.id).toBe('bp-cilium')
+    expect(result.current.isError).toBe(false)
+    expect(result.current.lastFetched).not.toBeNull()
+    expect(fetcher).toHaveBeenCalledTimes(1)
+  })
+
+  it('does NOT call the fetcher when enabled: false', async () => {
+    const fetcher = vi.fn(async (): Promise<Job[]> => [])
+    const { result } = renderHook(
+      () =>
+        useLiveJobsBackfill({
+          deploymentId: 'd-1',
+          fetcher,
+          disablePolling: true,
+          enabled: false,
+        }),
+      { wrapper: wrapper() },
+    )
+    // Give React Query a tick to potentially fire — it shouldn't.
+    await new Promise((r) => setTimeout(r, 25))
+    expect(fetcher).toHaveBeenCalledTimes(0)
+    expect(result.current.liveJobs).toEqual([])
+    expect(result.current.lastFetched).toBeNull()
+  })
+
+  it('exposes isError: true when the fetcher throws', async () => {
+    const fetcher = vi.fn(async (): Promise<Job[]> => {
+      throw new Error('500 Internal Server Error')
+    })
+    const { result } = renderHook(
+      () =>
+        useLiveJobsBackfill({
+          deploymentId: 'd-1',
+          fetcher,
+          disablePolling: true,
+        }),
+      { wrapper: wrapper() },
+    )
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true)
+    })
+    // liveJobs is still an empty array — JobsPage falls back to
+    // reducer-derived data.
+    expect(result.current.liveJobs).toEqual([])
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/useLiveJobsBackfill.ts
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/useLiveJobsBackfill.ts
@@ -1,0 +1,148 @@
+/**
+ * useLiveJobsBackfill — bridge from the catalyst-api Jobs endpoint into
+ * the wizard's reducer-derived JobsTable.
+ *
+ * WHY (issue #232):
+ * The wizard's Jobs view is fed by `deriveJobs(reducerState, applications)`,
+ * which folds the SSE event stream into the flat Job[] shape. That works
+ * while the SSE channel is healthy, but two situations leave the table
+ * frozen on `pending`:
+ *
+ *   1. helmwatch only fires on TRANSITIONS — its initial-list events are
+ *      suppressed in some code paths, so a HelmRelease that's already
+ *      Ready=True at watch-attach time emits no event the reducer can
+ *      see.
+ *   2. The SSE replay buffer carries old events that contradict the
+ *      live state. When the reducer folds them in, fresh per-component
+ *      installations get masked by stale `state: skipped` markers.
+ *
+ * Backend (#205) owns the canonical Jobs endpoint:
+ *   GET /api/v1/deployments/{depId}/jobs → { jobs: Job[] }
+ *
+ * This hook polls that endpoint every 5s while the deployment is in
+ * flight. When it returns ≥1 jobs, the JobsPage merges them into the
+ * reducer-derived list (dedupe by job.id; live data wins on conflict).
+ * When it returns [] or the endpoint is unreachable, the reducer-derived
+ * list passes through unchanged.
+ *
+ * Per docs/INVIOLABLE-PRINCIPLES.md #4 (never hardcode), the URL is
+ * built from `API_BASE` (which itself derives from Vite's `BASE_URL`),
+ * never inlined. Per #2 (never compromise), this is NOT an MVP shim —
+ * it's the same React Query patterns used everywhere else in the UI.
+ *
+ * Returns:
+ *   • liveJobs    — Job[] from the live API. Empty array when the
+ *                   endpoint hasn't responded yet or returned no rows.
+ *   • isLoading   — true on the first fetch only.
+ *   • isError     — true on a fetch failure (4xx/5xx/network). The
+ *                   JobsPage falls back to reducer-derived data; no
+ *                   banner is shown to the operator.
+ *   • lastFetched — wall-clock ms of the most recent successful fetch
+ *                   (null until a fetch succeeds). Surfaced for the
+ *                   "live state stream re-attached" banner.
+ */
+
+import { useQuery } from '@tanstack/react-query'
+import { API_BASE } from '@/shared/config/urls'
+import type { Job } from '@/lib/jobs.types'
+
+/** Wire shape of GET /api/v1/deployments/{id}/jobs. */
+interface JobsResponse {
+  jobs?: Job[]
+}
+
+/** Hook return shape — exposed so JobsPage stays typed. */
+export interface UseLiveJobsBackfillResult {
+  liveJobs: Job[]
+  isLoading: boolean
+  isError: boolean
+  lastFetched: number | null
+}
+
+/**
+ * Default fetcher — exposed via parameter so tests can inject a stub
+ * without monkey-patching `globalThis.fetch`.
+ */
+async function defaultFetchJobs(deploymentId: string): Promise<Job[]> {
+  const url = `${API_BASE}/v1/deployments/${encodeURIComponent(deploymentId)}/jobs`
+  const res = await fetch(url, { headers: { Accept: 'application/json' } })
+  if (!res.ok) {
+    throw new Error(`Failed to fetch jobs: ${res.status}`)
+  }
+  const body = (await res.json()) as JobsResponse
+  return Array.isArray(body.jobs) ? body.jobs : []
+}
+
+export interface UseLiveJobsBackfillOptions {
+  /** Stable deployment id from the URL parameter. */
+  deploymentId: string
+  /** Test seam — disables the React Query refetch interval. */
+  disablePolling?: boolean
+  /** Test seam — inject a stub fetcher. */
+  fetcher?: (deploymentId: string) => Promise<Job[]>
+  /**
+   * If true, the hook does NOT mount its query — used when the
+   * deployment has reached a terminal state and further polling is
+   * wasteful. Caller passes `streamStatus !== 'completed' && streamStatus !== 'failed'`.
+   */
+  enabled?: boolean
+}
+
+/** Founder-specified poll cadence — verbatim ("every 5s while the
+ * deployment is in flight"). */
+const POLL_INTERVAL_MS = 5_000
+
+export function useLiveJobsBackfill(
+  opts: UseLiveJobsBackfillOptions,
+): UseLiveJobsBackfillResult {
+  const { deploymentId, disablePolling = false, fetcher = defaultFetchJobs, enabled = true } = opts
+
+  const query = useQuery<Job[]>({
+    queryKey: ['live-jobs-backfill', deploymentId],
+    queryFn: () => fetcher(deploymentId),
+    enabled: enabled && !!deploymentId,
+    refetchInterval: () => {
+      if (disablePolling) return false
+      return POLL_INTERVAL_MS
+    },
+    // Keep last data while a new fetch is in flight — avoids the
+    // table flickering through an empty array between polls.
+    placeholderData: (prev) => prev,
+    // Fail silently — the JobsPage falls back to reducer-derived data
+    // when this query errors. No retry storm; one attempt per interval
+    // is enough.
+    retry: false,
+  })
+
+  const liveJobs = Array.isArray(query.data) ? query.data : []
+  const lastFetched =
+    query.dataUpdatedAt > 0 ? query.dataUpdatedAt : null
+
+  return {
+    liveJobs,
+    isLoading: query.isLoading,
+    isError: query.isError,
+    lastFetched,
+  }
+}
+
+/**
+ * Pure helper — merges reducer-derived jobs with live-API jobs.
+ * Live data wins on conflict (same job.id). Reducer-derived rows that
+ * don't appear in the live list pass through unchanged.
+ *
+ * Stable: re-running on identical inputs produces identical output.
+ * No randomness, no cached state. Exported so unit tests can lock in
+ * the contract.
+ */
+export function mergeJobs(
+  reducerJobs: readonly Job[],
+  liveJobs: readonly Job[],
+): Job[] {
+  if (liveJobs.length === 0) return [...reducerJobs]
+  const byId = new Map<string, Job>()
+  for (const j of reducerJobs) byId.set(j.id, j)
+  // Live wins on conflict — overwrite the reducer entry.
+  for (const j of liveJobs) byId.set(j.id, j)
+  return Array.from(byId.values())
+}


### PR DESCRIPTION
## Summary

Three real-time visibility fixes for the Sovereign provision wizard. Founder was staring at https://console.openova.io/sovereign/provision/ce476aaf80731a46/jobs while 6 HelmReleases were Ready=True on the live cluster — the UI didn't reflect any of that.

- **Reducer clears stale `phase1WatchSkipped`**: a fresh per-component event with real ground-truth state OR a `phase: deployment` event with status `phase1-watching`/`installing` now unsets the flag. The previous "monotonic-true" guarantee left the AdminPage banner stuck on permanently after a single early `state: skipped` SSE replay event.
- **JobsTable backfills from live API**: new `useLiveJobsBackfill` hook polls `GET /api/v1/deployments/{id}/jobs` every 5s while the deployment is in flight. `mergeJobs(reducerJobs, liveJobs)` dedupes by id with live data winning. Stops automatically once streamStatus reaches `completed`/`failed`. Fallback is silent when the endpoint 404s or errors.
- **ExecutionLogs empty success no longer renders as error**: `{lines:[], total:0, executionFinished:false}` now shows "No logs captured yet for this job.", and the error/retry banner only mounts on actual `query.isError`. Retry is now an explicit button replacing the implicit "retrying…" copy.

## Tests

- `eventReducer.test.ts` — 5 new cases: clears on real component event; clears on `phase:deployment status=phase1-watching`; does NOT clear on `state:skipped`; survives unrelated events; `installed` clears too. 18 → 23 cases.
- `useLiveJobsBackfill.test.tsx` — new file: mergeJobs purity (4 cases), hook lifecycle (3 cases including `enabled:false` no-fetch and silent error fallback).
- `JobsTable.test.tsx` — new case: 5 backend-API-only jobs render 5 rows with verbatim statuses.
- `ExecutionLogs.test.tsx` — 2 new cases: empty success → "No logs captured yet" with NO error/retry banner; fetcher throws → error banner + retry button.

Full UI test suite: 390 tests across 30 files all green. Typecheck clean.

## Test plan

- [ ] CI `manifest-validation` passes
- [ ] CI `catalyst-build` rolls a new image SHA != `1a4a54f`
- [ ] After merge, `kubectl -n catalyst rollout status deploy/catalyst-ui` shows the new SHA
- [ ] Playwright 1440px screenshot of `/sovereign/provision/ce476aaf80731a46/jobs` shows banner GONE
- [ ] Playwright 1440px screenshot of any job's detail page shows real text or "No logs captured yet" — never "Failed to load — retrying"

Refs openova-io/openova#232

🤖 Generated with [Claude Code](https://claude.com/claude-code)