### PR TITLE
fix(bp-crossplane): resolve CHART_DIR to absolute path in composition-validate.sh

### DIFF
--- a/platform/crossplane/chart/tests/composition-validate.sh
+++ b/platform/crossplane/chart/tests/composition-validate.sh
@@ -27,7 +27,13 @@
 
 set -euo pipefail
 
-CHART_DIR="${1:-$(cd "$(dirname "$0")/.." && pwd)}"
+# Resolve CHART_DIR to an ABSOLUTE path BEFORE the cd below — otherwise
+# CI invokes us with the relative path `platform/crossplane/chart` and
+# every later `"$CHART_DIR/<sub>"` reference (notably FIXTURE_DIR) ends
+# up pointing into a non-existent path because we've already chdir'd
+# into the chart dir.
+CHART_DIR_INPUT="${1:-$(cd "$(dirname "$0")/.." && pwd)}"
+CHART_DIR="$(cd "$CHART_DIR_INPUT" && pwd)"
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
 


### PR DESCRIPTION
## Summary

Follow-up to #236 — the new `composition-validate.sh` test script breaks under CI's `Run chart integration tests` step because `$CHART_DIR` is left as a relative path after the script chdirs into it. Resolve to an absolute path via `(cd ... && pwd)` before the chdir.

## Root cause

CI invokes:

```
bash platform/crossplane/chart/tests/composition-validate.sh platform/crossplane/chart
```

The script does `cd "$CHART_DIR"` (success), then later builds `FIXTURE_DIR="$CHART_DIR/tests/fixtures"` — but `$CHART_DIR` is still the literal `platform/crossplane/chart` (relative). After the chdir, that relative path no longer resolves because we've already moved into the chart dir; `[ -d "$FIXTURE_DIR" ]` returns false and Case 6 fails.

## Fix

Two-step resolution before chdir:

```bash
CHART_DIR_INPUT="${1:-$(cd "$(dirname "$0")/.." && pwd)}"
CHART_DIR="$(cd "$CHART_DIR_INPUT" && pwd)"
```

Now `$CHART_DIR` is always absolute and every later reference resolves correctly regardless of the caller's cwd.

## Test plan

- [ ] Blueprint Release workflow `Run chart integration tests` step is green for `platform/crossplane`
- [ ] Local: `bash platform/crossplane/chart/tests/composition-validate.sh platform/crossplane/chart` from repo root passes (verified)
- [ ] bp-crossplane@1.1.2 publishes to `oci://ghcr.io/openova-io/charts/bp-crossplane:1.1.2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)