### PR TITLE
fix(jobs): backend-only when live data — kills duplicate rows + log 404

### DIFF
--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/useLiveJobsBackfill.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/useLiveJobsBackfill.test.tsx
@@ -51,12 +51,12 @@ describe('mergeJobs — pure helper', () => {
     expect(merged[0]!.durationMs).toBe(12_345)
   })
 
-  it('union of ids when reducer and live disagree', () => {
+  it('backend wins entirely when live has data', () => {
     const reducer = [makeJob({ id: 'a' })]
     const live = [makeJob({ id: 'b' }), makeJob({ id: 'c' })]
     const merged = mergeJobs(reducer, live)
     const ids = merged.map((j) => j.id).sort()
-    expect(ids).toEqual(['a', 'b', 'c'])
+    expect(ids).toEqual(['b', 'c'])
   })
 
   it('fixes the omantel symptom — 0 reducer jobs + 5 backend jobs renders 5 rows', () => {

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/useLiveJobsBackfill.ts
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/useLiveJobsBackfill.ts
@@ -139,10 +139,14 @@ export function mergeJobs(
   reducerJobs: readonly Job[],
   liveJobs: readonly Job[],
 ): Job[] {
-  if (liveJobs.length === 0) return [...reducerJobs]
-  const byId = new Map<string, Job>()
-  for (const j of reducerJobs) byId.set(j.id, j)
-  // Live wins on conflict — overwrite the reducer entry.
-  for (const j of liveJobs) byId.set(j.id, j)
-  return Array.from(byId.values())
+  // Backend is authoritative once it has any data. Reducer-derived
+  // jobs use catalog ids ("bp-cilium") that don't match the backend's
+  // "<deploymentId>:install-cilium" canonical id, so dedup-by-id
+  // produces duplicates. Reducer-derived rows are also missing the
+  // appId/batchId shape the backend uses, and clicking them navigates
+  // to a route the backend can't resolve (→ 404 → "Failed to load
+  // log page"). Switch to backend-only the moment it returns ≥1 row;
+  // reducer-derived stays as the empty-state fallback.
+  if (liveJobs.length > 0) return [...liveJobs]
+  return [...reducerJobs]
 }


### PR DESCRIPTION
47 rows in /jobs (34 reducer-derived + 13 backend) — IDs don't dedup. Reducer rows click → /jobs/bp-cilium → 404 'Failed to load log page'. Switch to backend-only when live.length > 0; reducer stays as empty-state fallback.