### PR TITLE
feat(jobs): Flow tab — two-level Sugiyama (batches as meta-stages, jobs as inner stages)

### DIFF
--- a/products/catalyst/bootstrap/ui/e2e/cosmetic-guards.spec.ts
+++ b/products/catalyst/bootstrap/ui/e2e/cosmetic-guards.spec.ts
@@ -864,6 +864,142 @@ test.describe('@cosmetic-guard jobs surface (issue #204 — table view)', () => 
       `sov-app-tab-jobs label is "${text}"; issue #204 item #9 requires the tab to be labelled "Jobs".`,
     ).toBe(true)
   })
+
+  /* ────────────────────────────────────────────────────────────────
+   * Tests 5-8 — Flow tab (founder urgent spec, two-level Sugiyama)
+   *
+   * The Jobs page MUST expose two view tabs: Table (default) and Flow.
+   * Switching tabs updates the URL ?view= search param so deep links
+   * preserve the operator's chosen view, browser-back works, and the
+   * choice is bookmarkable.
+   *
+   * The Flow tab renders a two-level Sugiyama layered DAG (batches as
+   * meta-stages, jobs as inner stages). Default zoom is "expanded" for
+   * batches with in-flight jobs; "collapsed" for all-succeeded batches.
+   * ──────────────────────────────────────────────────────────────── */
+
+  test('5. Flow tab exists alongside Table tab in the Jobs view tabstrip', async ({ page }) => {
+    await page.goto('provision/test-deployment-id/jobs')
+    await page.waitForLoadState('domcontentloaded')
+
+    const tabstrip = page.locator('[data-testid="jobs-view-tabs"]')
+    await expect(
+      tabstrip,
+      'JobsPage is missing [data-testid=jobs-view-tabs] — the founder urgent spec requires a tab strip with Table + Flow tabs at the top of the Jobs page. See JobsPage.tsx.',
+    ).toBeVisible({ timeout: 10_000 })
+
+    const tableTab = page.locator('[data-testid="jobs-view-tab-table"]')
+    const flowTab = page.locator('[data-testid="jobs-view-tab-flow"]')
+    await expect(tableTab, 'Table tab is missing from the Jobs view tabstrip.').toBeVisible()
+    await expect(
+      flowTab,
+      'Flow tab is missing from the Jobs view tabstrip — two-level Sugiyama DAG visualisation must be a peer of the Table tab.',
+    ).toBeVisible()
+
+    // Default landing — Table is the active tab.
+    expect(
+      await tableTab.getAttribute('aria-selected'),
+      'Table tab is not aria-selected by default. The default landing for /sovereign/provision/$id/jobs must be the Table view.',
+    ).toBe('true')
+  })
+
+  test('6. clicking Flow tab updates URL to ?view=flow and renders the DAG canvas', async ({ page }) => {
+    await page.goto('provision/test-deployment-id/jobs')
+    await page.waitForLoadState('domcontentloaded')
+
+    const flowTab = page.locator('[data-testid="jobs-view-tab-flow"]')
+    await expect(flowTab).toBeVisible({ timeout: 10_000 })
+    await flowTab.click()
+
+    // URL must now carry ?view=flow.
+    await page.waitForFunction(
+      () => window.location.search.includes('view=flow'),
+      { timeout: 5_000 },
+    )
+
+    const url = new URL(page.url())
+    expect(
+      url.searchParams.get('view'),
+      `Clicking the Flow tab did not push ?view=flow into the URL. Got search="${url.search}". The JobsPage must mirror the active tab into the search param so deep links + browser-back work.`,
+    ).toBe('flow')
+
+    // Flow DAG canvas mounts.
+    const svg = page.locator('[data-testid="jobs-flow-svg"]')
+    await expect(
+      svg,
+      'Flow tab is active but the [data-testid=jobs-flow-svg] canvas is missing. JobsFlowView must render an SVG with that testid.',
+    ).toBeVisible({ timeout: 10_000 })
+
+    // Switching back to Table drops the search param.
+    const tableTab = page.locator('[data-testid="jobs-view-tab-table"]')
+    await tableTab.click()
+    await page.waitForFunction(
+      () => !window.location.search.includes('view=flow'),
+      { timeout: 5_000 },
+    )
+  })
+
+  test('7. expanded batch shows job cards, collapse toggle shrinks to supernode', async ({ page }) => {
+    await page.goto('provision/test-deployment-id/jobs?view=flow')
+    await page.waitForLoadState('domcontentloaded')
+
+    const svg = page.locator('[data-testid="jobs-flow-svg"]')
+    await expect(svg, 'Flow tab did not mount on a deep link to ?view=flow.').toBeVisible({
+      timeout: 10_000,
+    })
+
+    // At least one batch must be on screen (the bootstrap-kit batch is
+    // always present once the catalog resolves; in test env without an
+    // SSE stream, every job is pending → batches stay expanded).
+    const batches = page.locator('[data-testid^="flow-batch-"]')
+    const nBatches = await batches.count()
+    expect(
+      nBatches,
+      'Flow canvas rendered with zero batch swimlanes — the bootstrap-kit batch alone must produce at least one. Check pipelineLayout.ts grouping.',
+    ).toBeGreaterThan(0)
+
+    // At least one job card must be rendered (in-flight batches stay
+    // expanded by the default-collapse policy).
+    const jobs = page.locator('[data-testid^="flow-job-"]')
+    const nJobs = await jobs.count()
+    expect(
+      nJobs,
+      'Expanded batch did not render any [data-testid^=flow-job-] cards. Check JobsFlowView.tsx <JobCardNode /> rendering.',
+    ).toBeGreaterThan(0)
+
+    // Click the collapse toggle on the first batch — its job cards
+    // disappear and its supernode glyph appears.
+    const firstBatch = batches.first()
+    const batchTestId = await firstBatch.getAttribute('data-testid')
+    const batchId = batchTestId!.replace(/^flow-batch-/, '')
+    const toggle = page.locator(`[data-testid="flow-batch-toggle-${batchId}"]`)
+    await toggle.click()
+
+    // Collapsed supernode glyph is visible.
+    const supernode = page.locator(`[data-testid="flow-batch-supernode-${batchId}"]`)
+    await expect(
+      supernode,
+      `Clicking the toggle on batch "${batchId}" did not collapse it. JobsFlowView.tsx onToggleBatch must flip the override set so the layout re-emits the batch as a supernode.`,
+    ).toBeVisible({ timeout: 5_000 })
+  })
+
+  test('8. default-expanded for in-flight batch (visible job cards on first paint)', async ({ page }) => {
+    await page.goto('provision/test-deployment-id/jobs?view=flow')
+    await page.waitForLoadState('domcontentloaded')
+
+    await expect(page.locator('[data-testid="jobs-flow-svg"]')).toBeVisible({ timeout: 10_000 })
+
+    // The default-collapse policy collapses all-succeeded batches and
+    // expands everything else. In a fresh test deployment, every job
+    // is `pending` → no batch should be collapsed → at least one
+    // [data-testid^=flow-job-] card MUST be in the SVG on first paint.
+    const jobs = page.locator('[data-testid^="flow-job-"]')
+    const n = await jobs.count()
+    expect(
+      n,
+      `Flow canvas rendered with zero job cards on first paint, but no batch should be collapsed in the test fixture (every job is pending). defaultCollapsedBatchIds policy regressed — see pipelineLayout.ts.`,
+    ).toBeGreaterThan(0)
+  })
 })
 
 /* ──────────────────────────────────────────────────────────────────

--- a/products/catalyst/bootstrap/ui/src/app/router.tsx
+++ b/products/catalyst/bootstrap/ui/src/app/router.tsx
@@ -83,10 +83,22 @@ const provisionAppRoute = createRoute({
 // Global jobs list — table view (issue #204 founder spec). Each row is
 // a clickable link that navigates to the per-job detail page (owned by
 // the JobDetail sibling agent and merged via #208).
+//
+// `?view` search param drives the active tab in the JobsPage tab strip:
+//   • view=table (default) — JobsTable
+//   • view=flow            — JobsFlowView (two-level Sugiyama DAG)
+// validateSearch coerces unknown values to `undefined` so deep links
+// from older builds keep working without throwing. The Flow tab ships
+// in this PR (urgent founder request).
 const provisionJobsRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: '/provision/$deploymentId/jobs',
   component: JobsPage,
+  validateSearch: (raw: Record<string, unknown>): { view?: 'table' | 'flow' } => {
+    const v = raw?.view
+    if (v === 'flow' || v === 'table') return { view: v }
+    return {}
+  },
 })
 
 // Jobs timeline (Gantt-style retrospective). Static segment, MUST be

--- a/products/catalyst/bootstrap/ui/src/lib/pipelineLayout.test.ts
+++ b/products/catalyst/bootstrap/ui/src/lib/pipelineLayout.test.ts
@@ -1,0 +1,501 @@
+/**
+ * pipelineLayout.test.ts — pure-function tests for the two-level
+ * Sugiyama layout used by the Flow tab on JobsPage.
+ *
+ * Coverage (per founder spec):
+ *   • Empty input is well-formed (no crash, no nodes).
+ *   • Canonical 5-job fan-in example: 4 stages, 4 edges, zero crossings,
+ *     edge `2→5` rendered as a 4-point bezier (skips empty stage-2 col).
+ *   • Real otech bootstrap-kit (13 jobs): 5 stages, fan-in at
+ *     external-dns (2 incoming edges), zero crossings.
+ *   • Two-batch fixture: meta-DAG with 1 meta-edge connecting the LAST
+ *     stage of phase-0-infra to the first stage of bootstrap-kit.
+ *   • Collapsed batch: returns 1 batch supernode, no inner job nodes.
+ *   • Default-collapse policy: all-succeeded batches collapse, others stay
+ *     expanded.
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  pipelineLayout,
+  defaultCollapsedBatchIds,
+  aggregateStatus,
+  edgeToPath,
+  routeEdge,
+  sugiyama,
+} from './pipelineLayout'
+import type { Job } from './jobs.types'
+
+/* ── Fixtures ────────────────────────────────────────────────────── */
+
+/**
+ * 5-job canonical fan-out / fan-in example from the founder brief:
+ *   1, 2(←1), 3(←1), 4(←3), 5(←2,4)
+ * Should produce 4 stages: {1}, {2,3}, {4}, {5}.
+ * Edge 2→5 has span 2 (skips stage-2) → must be a bezier.
+ */
+const FIVE_JOB_FANIN: Job[] = [
+  { id: '1', jobName: 'job-1', appId: 'app', batchId: 'B', dependsOn: [], status: 'pending', startedAt: null, finishedAt: null, durationMs: 0 },
+  { id: '2', jobName: 'job-2', appId: 'app', batchId: 'B', dependsOn: ['1'], status: 'pending', startedAt: null, finishedAt: null, durationMs: 0 },
+  { id: '3', jobName: 'job-3', appId: 'app', batchId: 'B', dependsOn: ['1'], status: 'pending', startedAt: null, finishedAt: null, durationMs: 0 },
+  { id: '4', jobName: 'job-4', appId: 'app', batchId: 'B', dependsOn: ['3'], status: 'pending', startedAt: null, finishedAt: null, durationMs: 0 },
+  { id: '5', jobName: 'job-5', appId: 'app', batchId: 'B', dependsOn: ['2', '4'], status: 'pending', startedAt: null, finishedAt: null, durationMs: 0 },
+]
+
+/**
+ * Real otech bootstrap-kit shape (13 jobs):
+ *   cilium (s0)
+ *   cert-manager (s1, ←cilium)
+ *   spire / sealed-secrets / flux / keycloak / powerdns (s2, ←cert-manager)
+ *   crossplane (s3, ←flux), gitea (s3, ←keycloak), nats-jetstream (s3, ←spire),
+ *     openbao (s3, ←spire), external-dns (s3, ←cert-manager + powerdns)
+ *   catalyst-platform (s4, ←gitea)
+ */
+function makeBootstrapKit(batchId = 'bootstrap-kit'): Job[] {
+  const j = (id: string, deps: string[]): Job => ({
+    id,
+    jobName: id,
+    appId: id,
+    batchId,
+    dependsOn: deps,
+    status: 'pending',
+    startedAt: null,
+    finishedAt: null,
+    durationMs: 0,
+  })
+  return [
+    j('cilium', []),
+    j('cert-manager', ['cilium']),
+    j('spire', ['cert-manager']),
+    j('sealed-secrets', ['cert-manager']),
+    j('flux', ['cert-manager']),
+    j('keycloak', ['cert-manager']),
+    j('powerdns', ['cert-manager']),
+    j('crossplane', ['flux']),
+    j('gitea', ['keycloak']),
+    j('nats-jetstream', ['spire']),
+    j('openbao', ['spire']),
+    j('external-dns', ['cert-manager', 'powerdns']),
+    j('catalyst-platform', ['gitea']),
+  ]
+}
+
+/* ──────────────────────────────────────────────────────────────────
+ * Empty input
+ * ────────────────────────────────────────────────────────────────── */
+
+describe('pipelineLayout — empty', () => {
+  it('returns no nodes / edges / batches and a non-zero canvas', () => {
+    const r = pipelineLayout([])
+    expect(r.nodes).toEqual([])
+    expect(r.edges).toEqual([])
+    expect(r.batches).toEqual([])
+    expect(r.width).toBeGreaterThan(0)
+    expect(r.height).toBeGreaterThan(0)
+  })
+})
+
+/* ──────────────────────────────────────────────────────────────────
+ * Canonical 5-job fan-in
+ * ────────────────────────────────────────────────────────────────── */
+
+describe('pipelineLayout — canonical 5-job fan-in', () => {
+  const r = pipelineLayout(FIVE_JOB_FANIN)
+  const byId = new Map(r.nodes.map((n) => [n.id, n]))
+
+  it('produces 5 job nodes (one batch, all expanded by default)', () => {
+    expect(r.nodes.length).toBe(5)
+    expect(r.nodes.every((n) => n.kind === 'job')).toBe(true)
+  })
+
+  it('produces 5 within-batch edges (1→2, 1→3, 2→5, 3→4, 4→5)', () => {
+    const within = r.edges.filter((e) => e.kind === 'within-batch')
+    expect(within.length).toBe(5)
+    const pairs = within.map((e) => `${e.fromId}→${e.toId}`).sort()
+    expect(pairs).toEqual(['1→2', '1→3', '2→5', '3→4', '4→5'].sort())
+  })
+
+  it('arranges jobs into 4 stages: {1}, {2,3}, {4}, {5}', () => {
+    expect(byId.get('1')!.stage).toBe(0)
+    expect(byId.get('2')!.stage).toBe(1)
+    expect(byId.get('3')!.stage).toBe(1)
+    expect(byId.get('4')!.stage).toBe(2)
+    expect(byId.get('5')!.stage).toBe(3)
+  })
+
+  it('edge 2→5 is a 4-point bezier (skips empty stage-2)', () => {
+    const e25 = r.edges.find((e) => e.fromId === '2' && e.toId === '5')
+    expect(e25, 'edge 2→5 must be present in the within-batch edge set').toBeTruthy()
+    expect(e25!.points.length).toBe(4)
+  })
+
+  it('edges with span=1 are 2-point straight lines', () => {
+    for (const e of r.edges.filter((e) => e.kind === 'within-batch')) {
+      const from = byId.get(e.fromId)!
+      const to = byId.get(e.toId)!
+      const span = (to.stage ?? 0) - (from.stage ?? 0)
+      if (span === 1) {
+        expect(e.points.length, `edge ${e.fromId}→${e.toId} (span=1) must be a 2-point line`).toBe(2)
+      }
+    }
+  })
+
+  it('zero crossings within the single batch', () => {
+    expect(countCrossings(r.edges.filter((e) => e.kind === 'within-batch'), r.nodes)).toBe(0)
+  })
+})
+
+/* ──────────────────────────────────────────────────────────────────
+ * Real otech bootstrap-kit
+ * ────────────────────────────────────────────────────────────────── */
+
+describe('pipelineLayout — bootstrap-kit (13 jobs, 5 stages)', () => {
+  const jobs = makeBootstrapKit()
+  const r = pipelineLayout(jobs)
+  const byId = new Map(r.nodes.map((n) => [n.id, n]))
+
+  it('produces 13 job nodes', () => {
+    expect(r.nodes.length).toBe(13)
+  })
+
+  it('produces 5 distinct inner stages', () => {
+    const stages = new Set(r.nodes.map((n) => n.stage))
+    expect(stages.size).toBe(5)
+  })
+
+  it('cilium is at stage 0; catalyst-platform is at stage 4', () => {
+    expect(byId.get('cilium')!.stage).toBe(0)
+    expect(byId.get('catalyst-platform')!.stage).toBe(4)
+  })
+
+  it('external-dns has fan-in (2 incoming edges)', () => {
+    const incoming = r.edges.filter(
+      (e) => e.kind === 'within-batch' && e.toId === 'external-dns',
+    )
+    expect(incoming.length).toBe(2)
+    const sources = incoming.map((e) => e.fromId).sort()
+    expect(sources).toEqual(['cert-manager', 'powerdns'])
+  })
+
+  it('zero edge crossings across the inner DAG', () => {
+    const within = r.edges.filter((e) => e.kind === 'within-batch')
+    expect(countCrossings(within, r.nodes)).toBe(0)
+  })
+
+  it('every dependency in the dataset is reflected by an emitted edge', () => {
+    let depCount = 0
+    for (const j of jobs) depCount += j.dependsOn.length
+    const within = r.edges.filter((e) => e.kind === 'within-batch')
+    expect(within.length).toBe(depCount)
+  })
+})
+
+/* ──────────────────────────────────────────────────────────────────
+ * Two-batch fixture
+ * ────────────────────────────────────────────────────────────────── */
+
+describe('pipelineLayout — two-batch fixture (meta-DAG)', () => {
+  // phase-0-infra: 4 jobs in series → produces a 4-stage chain.
+  // bootstrap-kit: 3 jobs (cilium → cert-manager → flux), with one
+  //                cross-batch dep cilium ← phase-0-infra's last job.
+  const phase0 = (id: string, deps: string[]): Job => ({
+    id,
+    jobName: id,
+    appId: 'infrastructure',
+    batchId: 'phase-0-infra',
+    dependsOn: deps,
+    status: 'succeeded',
+    startedAt: null,
+    finishedAt: null,
+    durationMs: 0,
+  })
+  const bk = (id: string, deps: string[]): Job => ({
+    id,
+    jobName: id,
+    appId: id,
+    batchId: 'bootstrap-kit',
+    dependsOn: deps,
+    status: 'pending',
+    startedAt: null,
+    finishedAt: null,
+    durationMs: 0,
+  })
+  const jobs: Job[] = [
+    phase0('tofu-init', []),
+    phase0('tofu-plan', ['tofu-init']),
+    phase0('tofu-apply', ['tofu-plan']),
+    phase0('tofu-output', ['tofu-apply']),
+    bk('cilium', ['tofu-output']),
+    bk('cert-manager', ['cilium']),
+    bk('flux', ['cert-manager']),
+  ]
+
+  const r = pipelineLayout(jobs)
+
+  it('produces 2 batch lanes', () => {
+    expect(r.batches.length).toBe(2)
+  })
+
+  it('phase-0-infra is at meta-stage 0; bootstrap-kit at meta-stage 1', () => {
+    const p0 = r.batches.find((b) => b.batchId === 'phase-0-infra')!
+    const bkLane = r.batches.find((b) => b.batchId === 'bootstrap-kit')!
+    expect(p0.metaStage).toBe(0)
+    expect(bkLane.metaStage).toBe(1)
+  })
+
+  it('bootstrap-kit lane sits to the right of phase-0-infra', () => {
+    const p0 = r.batches.find((b) => b.batchId === 'phase-0-infra')!
+    const bkLane = r.batches.find((b) => b.batchId === 'bootstrap-kit')!
+    expect(bkLane.x).toBeGreaterThan(p0.x + p0.width)
+  })
+
+  it('emits exactly 1 cross-batch job edge tofu-output → cilium', () => {
+    const cross = r.edges.filter((e) => e.kind === 'cross-batch-job')
+    expect(cross.length).toBe(1)
+    expect(cross[0]!.fromId).toBe('tofu-output')
+    expect(cross[0]!.toId).toBe('cilium')
+  })
+
+  it('the cross-batch source is the LAST stage of phase-0-infra', () => {
+    const tofuOutput = r.nodes.find((n) => n.id === 'tofu-output')!
+    const phase0Jobs = r.nodes.filter((n) => n.batchId === 'phase-0-infra')
+    const maxStage = Math.max(...phase0Jobs.map((n) => n.stage ?? 0))
+    expect(tofuOutput.stage).toBe(maxStage)
+  })
+
+  it('cross-batch edge is rendered as a bezier (4 points)', () => {
+    const cross = r.edges.find((e) => e.kind === 'cross-batch-job')!
+    expect(cross.points.length).toBe(4)
+  })
+})
+
+/* ──────────────────────────────────────────────────────────────────
+ * Collapsed batches
+ * ────────────────────────────────────────────────────────────────── */
+
+describe('pipelineLayout — collapsed batches', () => {
+  const phase0Job = (id: string, deps: string[]): Job => ({
+    id,
+    jobName: id,
+    appId: 'infrastructure',
+    batchId: 'phase-0-infra',
+    dependsOn: deps,
+    status: 'succeeded',
+    startedAt: null,
+    finishedAt: null,
+    durationMs: 0,
+  })
+  const bkJob = (id: string, deps: string[]): Job => ({
+    id,
+    jobName: id,
+    appId: id,
+    batchId: 'bootstrap-kit',
+    dependsOn: deps,
+    status: 'pending',
+    startedAt: null,
+    finishedAt: null,
+    durationMs: 0,
+  })
+  const jobs: Job[] = [
+    phase0Job('tofu-init', []),
+    phase0Job('tofu-plan', ['tofu-init']),
+    phase0Job('tofu-apply', ['tofu-plan']),
+    phase0Job('tofu-output', ['tofu-apply']),
+    bkJob('cilium', ['tofu-output']),
+    bkJob('cert-manager', ['cilium']),
+    bkJob('flux', ['cert-manager']),
+  ]
+
+  it('collapsed batch returns 1 batch supernode (not 4 job nodes)', () => {
+    const r = pipelineLayout(jobs, {
+      collapsedBatchIds: new Set(['phase-0-infra']),
+    })
+    const phase0Nodes = r.nodes.filter((n) => n.batchId === 'phase-0-infra')
+    expect(phase0Nodes.length).toBe(1)
+    expect(phase0Nodes[0]!.kind).toBe('batch')
+    expect(phase0Nodes[0]!.id).toBe('phase-0-infra')
+  })
+
+  it('cross-batch edge from a collapsed source is a meta arrow', () => {
+    const r = pipelineLayout(jobs, {
+      collapsedBatchIds: new Set(['phase-0-infra']),
+    })
+    const meta = r.edges.filter((e) => e.kind === 'meta')
+    expect(meta.length).toBe(1)
+    expect(meta[0]!.fromId).toBe('phase-0-infra')
+    expect(meta[0]!.toId).toBe('bootstrap-kit')
+  })
+
+  it('jobs in the expanded batch are still rendered individually', () => {
+    const r = pipelineLayout(jobs, {
+      collapsedBatchIds: new Set(['phase-0-infra']),
+    })
+    const bkNodes = r.nodes.filter((n) => n.batchId === 'bootstrap-kit')
+    expect(bkNodes.length).toBe(3)
+    expect(bkNodes.every((n) => n.kind === 'job')).toBe(true)
+  })
+
+  it('default collapse policy collapses all-succeeded batches only', () => {
+    const collapsed = defaultCollapsedBatchIds(jobs)
+    expect(collapsed.has('phase-0-infra')).toBe(true)
+    expect(collapsed.has('bootstrap-kit')).toBe(false)
+  })
+})
+
+/* ──────────────────────────────────────────────────────────────────
+ * Helpers — pure functions that the layout exports
+ * ────────────────────────────────────────────────────────────────── */
+
+describe('aggregateStatus', () => {
+  const j = (status: Job['status']): Job => ({
+    id: 'x',
+    jobName: 'x',
+    appId: 'a',
+    batchId: 'B',
+    dependsOn: [],
+    status,
+    startedAt: null,
+    finishedAt: null,
+    durationMs: 0,
+  })
+
+  it('all-succeeded → "succeeded"', () => {
+    expect(aggregateStatus([j('succeeded'), j('succeeded')])).toBe('succeeded')
+  })
+  it('any failure with running/pending peers → "mixed"', () => {
+    expect(aggregateStatus([j('failed'), j('running')])).toBe('mixed')
+  })
+  it('failed + succeeded (no in-flight peers) → "failed"', () => {
+    // Per founder spec: any failure surfaces as red on the lane;
+    // mixed is reserved for batches that still have in-flight work.
+    expect(aggregateStatus([j('failed'), j('succeeded')])).toBe('failed')
+  })
+  it('only running → "running"', () => {
+    expect(aggregateStatus([j('running'), j('running')])).toBe('running')
+  })
+  it('empty → "pending"', () => {
+    expect(aggregateStatus([])).toBe('pending')
+  })
+})
+
+describe('routeEdge', () => {
+  it('span ≤ 1 → 2-point line', () => {
+    const pts = routeEdge({ x: 0, y: 0, width: 10, height: 10 }, { x: 30, y: 0, width: 10, height: 10 }, 1)
+    expect(pts.length).toBe(2)
+  })
+  it('span > 1 → 4-point bezier', () => {
+    const pts = routeEdge({ x: 0, y: 0, width: 10, height: 10 }, { x: 100, y: 50, width: 10, height: 10 }, 3)
+    expect(pts.length).toBe(4)
+  })
+})
+
+describe('edgeToPath', () => {
+  it('2 points → straight L command', () => {
+    expect(edgeToPath([{ x: 0, y: 0 }, { x: 10, y: 5 }])).toBe('M 0 0 L 10 5')
+  })
+  it('4 points → cubic bezier C command', () => {
+    expect(
+      edgeToPath([
+        { x: 0, y: 0 },
+        { x: 10, y: 0 },
+        { x: 20, y: 5 },
+        { x: 30, y: 5 },
+      ]),
+    ).toBe('M 0 0 C 10 0, 20 5, 30 5')
+  })
+})
+
+describe('sugiyama', () => {
+  it('handles a single root with no edges', () => {
+    const r = sugiyama(['a'], [])
+    expect(r.layer.get('a')).toBe(0)
+    expect(r.position.get('a')).toBe(0)
+    expect(r.layerCount).toBe(1)
+  })
+  it('produces deterministic layering for an isolated DAG', () => {
+    const r1 = sugiyama(['a', 'b', 'c'], [{ from: 'a', to: 'b' }, { from: 'a', to: 'c' }])
+    const r2 = sugiyama(['c', 'b', 'a'], [{ from: 'a', to: 'b' }, { from: 'a', to: 'c' }])
+    expect(r1.layer.get('a')).toBe(r2.layer.get('a'))
+    expect(r1.layer.get('b')).toBe(r2.layer.get('b'))
+    expect(r1.layer.get('c')).toBe(r2.layer.get('c'))
+  })
+})
+
+/* ──────────────────────────────────────────────────────────────────
+ * Test helper — line-segment crossing count.
+ *
+ * For each pair of edges in the same batch, we treat them as
+ * straight segments from source-node-right-mid to target-node-left-mid
+ * (the polyline anchor) and count how many pairs intersect strictly
+ * between their endpoints. Bezier control points are ignored — the
+ * crossing test is a logical check on the underlying graph topology,
+ * not the rendered curve.
+ * ────────────────────────────────────────────────────────────────── */
+
+interface Pt {
+  x: number
+  y: number
+}
+interface Seg {
+  a: Pt
+  b: Pt
+}
+
+function makeSegment(
+  edge: { fromId: string; toId: string },
+  nodes: Array<{ id: string; x: number; y: number; width: number; height: number }>,
+): Seg | null {
+  const from = nodes.find((n) => n.id === edge.fromId)
+  const to = nodes.find((n) => n.id === edge.toId)
+  if (!from || !to) return null
+  return {
+    a: { x: from.x + from.width, y: from.y + from.height / 2 },
+    b: { x: to.x, y: to.y + to.height / 2 },
+  }
+}
+
+function ccw(a: Pt, b: Pt, c: Pt): number {
+  return (b.x - a.x) * (c.y - a.y) - (b.y - a.y) * (c.x - a.x)
+}
+
+function segmentsCross(s1: Seg, s2: Seg): boolean {
+  // Ignore segments that share an endpoint — these aren't crossings,
+  // they're shared sources / fan-ins. Numerical tolerance to dodge
+  // float wobble.
+  const eps = 1e-6
+  const sharesEndpoint = (p: Pt, q: Pt) => Math.abs(p.x - q.x) < eps && Math.abs(p.y - q.y) < eps
+  if (
+    sharesEndpoint(s1.a, s2.a) ||
+    sharesEndpoint(s1.a, s2.b) ||
+    sharesEndpoint(s1.b, s2.a) ||
+    sharesEndpoint(s1.b, s2.b)
+  ) {
+    return false
+  }
+  const d1 = ccw(s2.a, s2.b, s1.a)
+  const d2 = ccw(s2.a, s2.b, s1.b)
+  const d3 = ccw(s1.a, s1.b, s2.a)
+  const d4 = ccw(s1.a, s1.b, s2.b)
+  if (((d1 > 0 && d2 < 0) || (d1 < 0 && d2 > 0)) && ((d3 > 0 && d4 < 0) || (d3 < 0 && d4 > 0))) {
+    return true
+  }
+  return false
+}
+
+function countCrossings(
+  edges: Array<{ fromId: string; toId: string }>,
+  nodes: Array<{ id: string; x: number; y: number; width: number; height: number }>,
+): number {
+  const segs: Seg[] = []
+  for (const e of edges) {
+    const s = makeSegment(e, nodes)
+    if (s) segs.push(s)
+  }
+  let n = 0
+  for (let i = 0; i < segs.length; i++) {
+    for (let j = i + 1; j < segs.length; j++) {
+      if (segmentsCross(segs[i]!, segs[j]!)) n++
+    }
+  }
+  return n
+}

--- a/products/catalyst/bootstrap/ui/src/lib/pipelineLayout.ts
+++ b/products/catalyst/bootstrap/ui/src/lib/pipelineLayout.ts
@@ -1,0 +1,932 @@
+/**
+ * pipelineLayout.ts — pure two-level Sugiyama layered DAG layout for
+ * the JobsPage Flow tab (founder spec, urgent).
+ *
+ * The Flow tab visualises the job dependency graph at TWO scales,
+ * simultaneously:
+ *
+ *   • Outer (meta) — batches arranged as meta-stages, left → right.
+ *     metaStage(B) = max(metaStage(B') for B' that B depends on) + 1,
+ *     where B depends on B' iff ∃ job j∈B with a job j'∈B' in
+ *     j.dependsOn.
+ *
+ *   • Inner — within each batch, jobs arranged as stages, left → right.
+ *     stage(j) = max(stage(d) for d ∈ j.dependsOn that's in same batch)
+ *     + 1. Cross-batch deps are tracked as meta-edges, not inner edges.
+ *
+ * Both axes flow left → right for consistent reading direction.
+ *
+ * This file owns ONE Sugiyama implementation that operates on a
+ * generic node/edge pair; the same function is invoked twice — once
+ * for the meta-DAG (batches), once per expanded batch for the inner
+ * job DAG. Same algorithm, two scales.
+ *
+ * ──────────────────────────────────────────────────────────────────
+ * Algorithm (per founder spec):
+ *   1. Layer assignment — longest-path topological sort
+ *      layer(n) = max(layer(d) + 1) for d in deps(n) or 0.
+ *   2. Crossing minimization — barycenter heuristic, 4 sweep rounds
+ *      (down-then-up = 1 round). Converges for our scales (≤14 jobs
+ *      per batch, ≤8 batches).
+ *   3. Coordinate assignment — x = layer × COLUMN_WIDTH; y = position
+ *      × ROW_HEIGHT (with batch-relative offsets at the outer scale).
+ *   4. Edge routing — straight line for span=1; cubic bezier with 2
+ *      control points at (x1 + (x2-x1)/3, y1) and (x1 + 2(x2-x1)/3,
+ *      y2) for span>1. Bezier produces a smooth curve over empty
+ *      stage columns (e.g. 2→5 spanning empty stage-2).
+ * ──────────────────────────────────────────────────────────────────
+ *
+ * Per docs/INVIOLABLE-PRINCIPLES.md:
+ *   #1 (waterfall, target-state shape) — ships the full two-level
+ *      contract, not a "single-level for now" MVP.
+ *   #2 (no compromise) — pure function, no graph library, deterministic
+ *      output. No simulation, no random tie-breaking.
+ *   #4 (never hardcode) — every dimension is a configurable option;
+ *      the COLUMN_WIDTH / ROW_HEIGHT defaults below can be overridden
+ *      via `opts.geometry`.
+ */
+
+import type { Job } from './jobs.types'
+
+/* ──────────────────────────────────────────────────────────────────
+ * Public types
+ * ────────────────────────────────────────────────────────────────── */
+
+/** A node in the laid-out flow canvas (job card OR collapsed batch). */
+export interface FlowNode {
+  /** Stable id — same as jobs.types.Job#id for jobs; batch id for batches. */
+  id: string
+  /** Owning batch id. For `kind: 'batch'` this equals `id`. */
+  batchId: string
+  /** Top-left corner X (page coords, in pixels). */
+  x: number
+  /** Top-left corner Y (page coords, in pixels). */
+  y: number
+  /** Width in pixels. */
+  width: number
+  /** Height in pixels. */
+  height: number
+  /** What this node represents. */
+  kind: 'job' | 'batch'
+  /** Inner stage of a job within its batch (0-indexed). Undefined for batch supernodes. */
+  stage?: number
+  /** Owning Job for `kind: 'job'`. Undefined for `kind: 'batch'`. */
+  job?: Job
+}
+
+/** A laid-out edge (inner-batch arrow OR cross-batch meta-edge). */
+export interface FlowEdge {
+  /** From-node id. */
+  fromId: string
+  /** To-node id. */
+  toId: string
+  /**
+   * Polyline points for the edge path. ALWAYS at least 2 points
+   * (start, end). Cubic-bezier edges carry exactly 4 points
+   * (start, control1, control2, end) so the SVG renderer can emit
+   * `M x0 y0 C cx1 cy1, cx2 cy2, x1 y1`.
+   */
+  points: { x: number; y: number }[]
+  /** Edge category — drives stroke style + colour. */
+  kind: 'within-batch' | 'meta' | 'cross-batch-job'
+  /** True when the source batch has at least one failed job (renders dashed red). */
+  blocked?: boolean
+  /** Hover tooltip content (e.g. for cross-batch arrows). */
+  tooltip?: string
+}
+
+/** A laid-out swimlane container (batch background card). */
+export interface FlowBatchLane {
+  batchId: string
+  x: number
+  y: number
+  width: number
+  height: number
+  metaStage: number
+  /** Aggregate status — `mixed` when jobs straddle multiple buckets. */
+  status: 'pending' | 'running' | 'succeeded' | 'failed' | 'mixed'
+  /** finished / total across this batch's jobs. */
+  finished: number
+  total: number
+  /** True when the batch is rendered as a single supernode. */
+  collapsed: boolean
+}
+
+/** Full layout result. Width / height are the SVG canvas extents. */
+export interface FlowLayoutResult {
+  nodes: FlowNode[]
+  edges: FlowEdge[]
+  batches: FlowBatchLane[]
+  width: number
+  height: number
+}
+
+/** Geometry knobs — keep in lockstep with the JobsFlowView CSS. */
+export interface FlowGeometry {
+  /** Distance between adjacent stage columns (job inner). */
+  jobColumnWidth: number
+  /** Distance between adjacent rows within a batch (job inner). */
+  jobRowHeight: number
+  /** Job card dimensions (px). */
+  jobWidth: number
+  jobHeight: number
+  /** Distance between adjacent meta-stages (batch outer). */
+  metaColumnGap: number
+  /** Distance between adjacent batch lanes vertically. */
+  metaRowGap: number
+  /** Inner padding between a batch's bounding box and its job grid. */
+  batchPadX: number
+  batchPadTop: number
+  batchPadBottom: number
+  /** Collapsed batch supernode height + width. */
+  collapsedBatchWidth: number
+  collapsedBatchHeight: number
+  /** Outer canvas padding. */
+  canvasPadding: number
+}
+
+export const DEFAULT_GEOMETRY: FlowGeometry = {
+  jobColumnWidth: 200,
+  jobRowHeight: 90,
+  jobWidth: 170,
+  jobHeight: 70,
+  metaColumnGap: 60,
+  metaRowGap: 32,
+  batchPadX: 16,
+  batchPadTop: 56,
+  batchPadBottom: 16,
+  collapsedBatchWidth: 220,
+  collapsedBatchHeight: 90,
+  canvasPadding: 24,
+}
+
+export interface PipelineLayoutOptions {
+  /** Set of batchIds to render as collapsed supernodes (no inner job grid). */
+  collapsedBatchIds?: ReadonlySet<string>
+  /** Geometry overrides; sparse partial — unspecified keys fall back to defaults. */
+  geometry?: Partial<FlowGeometry>
+}
+
+/* ──────────────────────────────────────────────────────────────────
+ * Generic Sugiyama (used for both meta and inner scales)
+ * ────────────────────────────────────────────────────────────────── */
+
+/**
+ * A directed edge in the generic Sugiyama input. We refer to nodes by
+ * their id; the caller maintains the id → payload mapping.
+ */
+interface GenericEdge {
+  from: string
+  to: string
+}
+
+interface SugiyamaResult {
+  /** Layer (column) of each node id. 0 = leftmost. */
+  layer: Map<string, number>
+  /** Within-layer position (row) of each node id. 0 = top. */
+  position: Map<string, number>
+  /** Total number of layers (max layer + 1). */
+  layerCount: number
+  /** Per-layer ordered node id arrays — useful for rendering. */
+  byLayer: string[][]
+}
+
+/**
+ * Run Sugiyama layout on a generic DAG.
+ *
+ *   1. Longest-path layer assignment.
+ *   2. Barycenter crossing minimization (4 sweep rounds).
+ *   3. Coordinate-friendly position assignment (compacted integer Y).
+ *
+ * Stable for repeated calls with identical input. Tied scores break
+ * by node id (lex ascending) — never by Math.random.
+ */
+export function sugiyama(
+  nodeIds: readonly string[],
+  edges: readonly GenericEdge[],
+): SugiyamaResult {
+  // Filter edges to those with both endpoints in the node set —
+  // tolerates external edges (e.g. inner-DAG with cross-batch deps)
+  // without crashing.
+  const idSet = new Set(nodeIds)
+  const validEdges = edges.filter((e) => idSet.has(e.from) && idSet.has(e.to))
+
+  // 1. Longest-path layer assignment.
+  // Build deps: incoming edges per node.
+  const incoming = new Map<string, string[]>()
+  const outgoing = new Map<string, string[]>()
+  for (const id of nodeIds) {
+    incoming.set(id, [])
+    outgoing.set(id, [])
+  }
+  for (const e of validEdges) {
+    incoming.get(e.to)!.push(e.from)
+    outgoing.get(e.from)!.push(e.to)
+  }
+
+  const layer = new Map<string, number>()
+  // Topological order via Kahn's algorithm + memoised longest path.
+  const indeg = new Map<string, number>()
+  for (const id of nodeIds) indeg.set(id, incoming.get(id)!.length)
+  const queue: string[] = []
+  // Pull roots in deterministic id-asc order.
+  for (const id of [...nodeIds].sort((a, b) => a.localeCompare(b))) {
+    if (indeg.get(id) === 0) {
+      queue.push(id)
+      layer.set(id, 0)
+    }
+  }
+  // Standard Kahn — but at each pop, layer(child) is the max over
+  // already-discovered parents.
+  let head = 0
+  while (head < queue.length) {
+    const id = queue[head++]!
+    const myLayer = layer.get(id)!
+    const outs = [...outgoing.get(id)!].sort((a, b) => a.localeCompare(b))
+    for (const child of outs) {
+      const childLayer = Math.max(layer.get(child) ?? 0, myLayer + 1)
+      layer.set(child, childLayer)
+      indeg.set(child, indeg.get(child)! - 1)
+      if (indeg.get(child) === 0) queue.push(child)
+    }
+  }
+
+  // Defensive — a cycle leaves nodes with no layer entry. Floor them
+  // to 0 so the renderer never produces NaN coords.
+  for (const id of nodeIds) {
+    if (!layer.has(id)) layer.set(id, 0)
+  }
+
+  // 2. Crossing minimization — barycenter heuristic with DUMMY nodes
+  //    for long edges so the standard Sugiyama "edge-vs-edge crossings
+  //    only between adjacent layers" assumption holds.
+  //
+  //    For every edge whose endpoints span more than one layer, we
+  //    insert one dummy node per intermediate layer; the dummy
+  //    participates in barycenter ordering and routes the long edge
+  //    through the correct y-position at each stage.
+  const layerCount = Math.max(0, ...layer.values()) + 1
+  const byLayer: string[][] = Array.from({ length: layerCount }, () => [])
+  for (const id of nodeIds) byLayer[layer.get(id)!]!.push(id)
+
+  // Build per-layer adjacency (with dummies). Dummies get synthetic
+  // ids `__dummy:<edgeId>:<layer>` and are stored alongside real ids
+  // in byLayer / incoming / outgoing for the barycenter sweep.
+  const augIncoming = new Map<string, string[]>()
+  const augOutgoing = new Map<string, string[]>()
+  for (const id of nodeIds) {
+    augIncoming.set(id, [])
+    augOutgoing.set(id, [])
+  }
+
+  let dummyCounter = 0
+  for (const e of validEdges) {
+    const lFrom = layer.get(e.from)!
+    const lTo = layer.get(e.to)!
+    const span = lTo - lFrom
+    if (span <= 1) {
+      augIncoming.get(e.to)!.push(e.from)
+      augOutgoing.get(e.from)!.push(e.to)
+    } else {
+      // Chain of dummies: e.from → d1 → d2 → … → e.to
+      let prev = e.from
+      for (let l = lFrom + 1; l < lTo; l++) {
+        const dummyId = `__dummy:${dummyCounter++}:${e.from}->${e.to}@${l}`
+        byLayer[l]!.push(dummyId)
+        augIncoming.set(dummyId, [prev])
+        augOutgoing.set(dummyId, [])
+        augOutgoing.get(prev)!.push(dummyId)
+        prev = dummyId
+      }
+      augIncoming.get(e.to)!.push(prev)
+      augOutgoing.get(prev)!.push(e.to)
+    }
+  }
+
+  // Initial deterministic order — id ascending. Provides the same
+  // starting point on every run so the test fixture is reproducible.
+  for (const lst of byLayer) lst.sort((a, b) => a.localeCompare(b))
+
+  const augPosition = new Map<string, number>()
+  const refreshPositions = () => {
+    for (const lst of byLayer) {
+      lst.forEach((id, i) => augPosition.set(id, i))
+    }
+  }
+  refreshPositions()
+
+  const barycenter = (id: string, neighbours: readonly string[]): number => {
+    if (neighbours.length === 0) return augPosition.get(id) ?? 0
+    let sum = 0
+    for (const n of neighbours) sum += augPosition.get(n) ?? 0
+    return sum / neighbours.length
+  }
+
+  // Count crossings between two adjacent layers — pure pair-wise
+  // inversion count over the augmented edge set. Used to pick the
+  // best ordering across sweep rounds (the barycenter heuristic
+  // alone is not optimal).
+  const crossingsBetween = (lUpper: number, lLower: number): number => {
+    const upper = byLayer[lUpper]!
+    const lower = byLayer[lLower]!
+    const upperIdx = new Map<string, number>()
+    upper.forEach((id, i) => upperIdx.set(id, i))
+    const lowerIdx = new Map<string, number>()
+    lower.forEach((id, i) => lowerIdx.set(id, i))
+    // Collect edges as (upperPos, lowerPos) pairs.
+    const pairs: Array<[number, number]> = []
+    for (const u of upper) {
+      for (const v of augOutgoing.get(u) ?? []) {
+        if (!lowerIdx.has(v)) continue
+        pairs.push([upperIdx.get(u)!, lowerIdx.get(v)!])
+      }
+    }
+    // Crossings = pairs (a, b) and (c, d) with a < c && b > d, plus
+    // a > c && b < d. Equivalent to inversion count by lower index
+    // when sorted by upper index, with stable secondary order on
+    // lower asc.
+    pairs.sort((p, q) => (p[0] !== q[0] ? p[0] - q[0] : p[1] - q[1]))
+    let n = 0
+    for (let i = 0; i < pairs.length; i++) {
+      for (let j = i + 1; j < pairs.length; j++) {
+        if (pairs[i]![0] === pairs[j]![0]) continue
+        if (pairs[i]![1] > pairs[j]![1]) n++
+      }
+    }
+    return n
+  }
+
+  const totalCrossings = (): number => {
+    let n = 0
+    for (let l = 0; l < layerCount - 1; l++) n += crossingsBetween(l, l + 1)
+    return n
+  }
+
+  // Snapshot and restore byLayer state — used to revert when a sweep
+  // makes things worse.
+  const snapshot = (): string[][] => byLayer.map((lst) => [...lst])
+  const restore = (snap: string[][]) => {
+    for (let i = 0; i < snap.length; i++) byLayer[i] = snap[i]!
+  }
+
+  let bestSnapshot = snapshot()
+  let bestCrossings = totalCrossings()
+
+  const SWEEP_ROUNDS = 32
+  for (let round = 0; round < SWEEP_ROUNDS; round++) {
+    // Down sweep — order each layer by barycenter of parents.
+    for (let l = 1; l < layerCount; l++) {
+      const lst = byLayer[l]!
+      const scored = lst.map((id) => ({
+        id,
+        bc: barycenter(id, augIncoming.get(id)!),
+      }))
+      // Stable sort by barycenter; tie-break by id ascending.
+      scored.sort((a, b) => {
+        if (a.bc !== b.bc) return a.bc - b.bc
+        return a.id.localeCompare(b.id)
+      })
+      byLayer[l] = scored.map((s) => s.id)
+    }
+    refreshPositions()
+    // Up sweep — order each layer by barycenter of children.
+    for (let l = layerCount - 2; l >= 0; l--) {
+      const lst = byLayer[l]!
+      const scored = lst.map((id) => ({
+        id,
+        bc: barycenter(id, augOutgoing.get(id)!),
+      }))
+      scored.sort((a, b) => {
+        if (a.bc !== b.bc) return a.bc - b.bc
+        return a.id.localeCompare(b.id)
+      })
+      byLayer[l] = scored.map((s) => s.id)
+    }
+    refreshPositions()
+
+    const c = totalCrossings()
+    if (c < bestCrossings) {
+      bestCrossings = c
+      bestSnapshot = snapshot()
+    }
+  }
+
+  // Restore the best ordering observed across all sweep rounds — the
+  // barycenter heuristic isn't monotonically improving.
+  restore(bestSnapshot)
+  refreshPositions()
+
+  // Median heuristic — for any pair of adjacent layers that still has
+  // crossings, try swapping adjacent same-layer nodes that share a
+  // crossing and accept the swap if total crossings drop. Bounded at
+  // 64 attempts so the layout stays O(N²).
+  for (let pass = 0; pass < 64; pass++) {
+    let improved = false
+    for (let l = 0; l < layerCount; l++) {
+      const lst = byLayer[l]!
+      for (let i = 0; i < lst.length - 1; i++) {
+        const before = totalCrossings()
+        const tmp = lst[i]!
+        lst[i] = lst[i + 1]!
+        lst[i + 1] = tmp
+        refreshPositions()
+        const after = totalCrossings()
+        if (after < before) {
+          improved = true
+        } else {
+          // Revert.
+          lst[i + 1] = lst[i]!
+          lst[i] = tmp
+          refreshPositions()
+        }
+      }
+    }
+    if (!improved) break
+  }
+
+  // 3. Final position assignment — strip dummies, keep real-node
+  //    positions contiguous within each layer.
+  const realByLayer: string[][] = byLayer.map((lst) =>
+    lst.filter((id) => !id.startsWith('__dummy:')),
+  )
+  const position = new Map<string, number>()
+  for (const lst of realByLayer) {
+    lst.forEach((id, i) => position.set(id, i))
+  }
+
+  return { layer, position, layerCount, byLayer: realByLayer }
+}
+
+/* ──────────────────────────────────────────────────────────────────
+ * Edge routing — bezier vs straight
+ * ────────────────────────────────────────────────────────────────── */
+
+/**
+ * Compute the polyline / bezier control points for an edge between
+ * two nodes. Span = number of stage columns spanned. For span ≤ 1 we
+ * emit a 2-point straight line; for span ≥ 2 we emit a cubic-bezier
+ * with 2 control points so the curve clears intermediate empty
+ * columns smoothly.
+ *
+ * Anchor convention: edges leave the right-edge midpoint of the
+ * source and enter the left-edge midpoint of the target.
+ */
+export function routeEdge(
+  fromBox: { x: number; y: number; width: number; height: number },
+  toBox: { x: number; y: number; width: number; height: number },
+  span: number,
+): { x: number; y: number }[] {
+  const x0 = fromBox.x + fromBox.width
+  const y0 = fromBox.y + fromBox.height / 2
+  const x1 = toBox.x
+  const y1 = toBox.y + toBox.height / 2
+  // Span ≤ 1 → straight line. Span ≥ 2 → cubic bezier with 2
+  // control points so the curve clears intermediate empty columns
+  // smoothly. We do NOT collapse to a straight line when y0 === y1
+  // for span ≥ 2 because the founder spec requires a visibly smooth
+  // arc over the empty columns even when source + target sit on
+  // the same row (otherwise long horizontal edges would zigzag
+  // through fan-out targets in adjacent stages).
+  if (span <= 1) {
+    return [
+      { x: x0, y: y0 },
+      { x: x1, y: y1 },
+    ]
+  }
+  const dx = x1 - x0
+  // When y0 === y1 the bezier collapses to a horizontal line — the
+  // operator wouldn't notice the curve. Add a small vertical wiggle
+  // to the control points so the path always reads as a curve.
+  const wiggle = y0 === y1 ? Math.max(8, Math.abs(dx) * 0.04) : 0
+  return [
+    { x: x0, y: y0 },
+    { x: x0 + dx / 3, y: y0 - wiggle },
+    { x: x0 + (dx * 2) / 3, y: y1 + wiggle },
+    { x: x1, y: y1 },
+  ]
+}
+
+/* ──────────────────────────────────────────────────────────────────
+ * Public layout function — two-level (batches + jobs)
+ * ────────────────────────────────────────────────────────────────── */
+
+/**
+ * Compute the full Flow-tab layout from a flat job list.
+ *
+ * Steps:
+ *   1. Group jobs by batchId. Compute the meta-DAG (B depends on B'
+ *      iff there's any cross-batch job dep).
+ *   2. Sugiyama-layout the meta-DAG → batch supernode positions.
+ *   3. For each expanded batch, Sugiyama-layout its inner-batch DAG
+ *      to position jobs within the lane.
+ *   4. For each collapsed batch, render as a single supernode with
+ *      summary geometry.
+ *   5. Route every edge (within-batch + cross-batch + meta).
+ *
+ * Pure function — same input + opts produces the same output.
+ */
+export function pipelineLayout(
+  jobs: readonly Job[],
+  opts: PipelineLayoutOptions = {},
+): FlowLayoutResult {
+  const collapsed = opts.collapsedBatchIds ?? new Set<string>()
+  const geom: FlowGeometry = { ...DEFAULT_GEOMETRY, ...opts.geometry }
+
+  if (jobs.length === 0) {
+    return {
+      nodes: [],
+      edges: [],
+      batches: [],
+      width: geom.canvasPadding * 2 + 100,
+      height: geom.canvasPadding * 2 + 100,
+    }
+  }
+
+  // 1. Group jobs by batch. Preserve discovery order so that, when
+  //    the meta-DAG has no cross-batch edges, the meta-Sugiyama
+  //    position tie-breaker (id ascending) yields a stable layout.
+  const jobById = new Map<string, Job>()
+  for (const j of jobs) jobById.set(j.id, j)
+
+  const batchIds: string[] = []
+  const jobsByBatch = new Map<string, Job[]>()
+  for (const j of jobs) {
+    if (!jobsByBatch.has(j.batchId)) {
+      batchIds.push(j.batchId)
+      jobsByBatch.set(j.batchId, [])
+    }
+    jobsByBatch.get(j.batchId)!.push(j)
+  }
+
+  // 2. Build the meta-DAG.
+  const metaEdgesSet = new Set<string>()
+  const metaEdgesList: GenericEdge[] = []
+  // Track which (sourceJob, targetJob) pair drove each meta-edge for
+  // the cross-batch tooltip. Multiple driving pairs are joined by ", ".
+  const metaEdgeDrivers = new Map<string, Array<{ from: string; to: string }>>()
+  for (const j of jobs) {
+    for (const dep of j.dependsOn) {
+      const depJob = jobById.get(dep)
+      if (!depJob) continue
+      if (depJob.batchId === j.batchId) continue
+      const k = `${depJob.batchId}→${j.batchId}`
+      if (!metaEdgesSet.has(k)) {
+        metaEdgesSet.add(k)
+        metaEdgesList.push({ from: depJob.batchId, to: j.batchId })
+      }
+      const drivers = metaEdgeDrivers.get(k) ?? []
+      drivers.push({ from: dep, to: j.id })
+      metaEdgeDrivers.set(k, drivers)
+    }
+  }
+
+  const metaSugi = sugiyama(batchIds, metaEdgesList)
+
+  // 3. Lay out each batch's inner DAG. We need the batch's content
+  //    bounding box to size the swimlane.
+  interface InnerLayout {
+    /** Inner job nodes positioned RELATIVE to the batch's content origin. */
+    relNodes: Map<string, { x: number; y: number; width: number; height: number; stage: number }>
+    /** Inner edges. Coordinates ALSO relative to the batch content origin. */
+    innerEdges: Array<{ fromId: string; toId: string; span: number }>
+    /** Content width (max relative right edge). */
+    contentWidth: number
+    /** Content height (max relative bottom edge). */
+    contentHeight: number
+  }
+
+  const innerLayouts = new Map<string, InnerLayout>()
+
+  for (const batchId of batchIds) {
+    const batchJobs = jobsByBatch.get(batchId)!
+    if (collapsed.has(batchId)) {
+      // Collapsed batch: skip inner layout entirely.
+      continue
+    }
+    const ids = batchJobs.map((j) => j.id)
+    const inner: GenericEdge[] = []
+    for (const j of batchJobs) {
+      for (const dep of j.dependsOn) {
+        const depJob = jobById.get(dep)
+        if (!depJob) continue
+        if (depJob.batchId !== batchId) continue
+        inner.push({ from: dep, to: j.id })
+      }
+    }
+    const innerSugi = sugiyama(ids, inner)
+    const relNodes = new Map<
+      string,
+      { x: number; y: number; width: number; height: number; stage: number }
+    >()
+    let maxRight = 0
+    let maxBottom = 0
+    for (const id of ids) {
+      const lay = innerSugi.layer.get(id) ?? 0
+      const pos = innerSugi.position.get(id) ?? 0
+      const x = lay * geom.jobColumnWidth
+      const y = pos * geom.jobRowHeight
+      relNodes.set(id, {
+        x,
+        y,
+        width: geom.jobWidth,
+        height: geom.jobHeight,
+        stage: lay,
+      })
+      maxRight = Math.max(maxRight, x + geom.jobWidth)
+      maxBottom = Math.max(maxBottom, y + geom.jobHeight)
+    }
+
+    const innerEdges = inner.map((e) => {
+      const fromLayer = innerSugi.layer.get(e.from) ?? 0
+      const toLayer = innerSugi.layer.get(e.to) ?? 0
+      return { fromId: e.from, toId: e.to, span: toLayer - fromLayer }
+    })
+
+    innerLayouts.set(batchId, {
+      relNodes,
+      innerEdges,
+      contentWidth: maxRight,
+      contentHeight: maxBottom,
+    })
+  }
+
+  // 4. Compute per-batch outer geometry — width/height per batch lane,
+  //    then per-meta-stage column width = max lane width, per-row Y
+  //    = sum of preceding lane heights (in same meta-stage).
+
+  interface BatchOuter {
+    batchId: string
+    metaStage: number
+    metaPos: number
+    /** Width of the batch lane (collapsed: fixed; expanded: derived from inner content). */
+    width: number
+    /** Height of the batch lane. */
+    height: number
+  }
+
+  const outerBoxes = new Map<string, BatchOuter>()
+  for (const batchId of batchIds) {
+    const inner = innerLayouts.get(batchId)
+    let width: number
+    let height: number
+    if (collapsed.has(batchId) || !inner) {
+      width = geom.collapsedBatchWidth
+      height = geom.collapsedBatchHeight
+    } else {
+      width = inner.contentWidth + geom.batchPadX * 2
+      height = inner.contentHeight + geom.batchPadTop + geom.batchPadBottom
+    }
+    outerBoxes.set(batchId, {
+      batchId,
+      metaStage: metaSugi.layer.get(batchId) ?? 0,
+      metaPos: metaSugi.position.get(batchId) ?? 0,
+      width,
+      height,
+    })
+  }
+
+  // Per-meta-column max width.
+  const colWidth: number[] = Array.from({ length: metaSugi.layerCount }, () => 0)
+  for (const ob of outerBoxes.values()) {
+    if (ob.width > colWidth[ob.metaStage]!) colWidth[ob.metaStage] = ob.width
+  }
+
+  // Compute X offsets for each meta-column.
+  const colX: number[] = Array.from({ length: metaSugi.layerCount }, () => 0)
+  for (let i = 0; i < metaSugi.layerCount; i++) {
+    if (i === 0) {
+      colX[i] = geom.canvasPadding
+    } else {
+      colX[i] = (colX[i - 1] ?? 0) + (colWidth[i - 1] ?? 0) + geom.metaColumnGap
+    }
+  }
+
+  // Within each meta-column, walk the column entries in `metaPos` order
+  // and stack them vertically. Lane heights vary, so we accumulate Y.
+  const placedBatches: FlowBatchLane[] = []
+  for (let l = 0; l < metaSugi.layerCount; l++) {
+    const colIds = metaSugi.byLayer[l]!
+    let cursorY = geom.canvasPadding
+    for (const id of colIds) {
+      const ob = outerBoxes.get(id)!
+      const inner = innerLayouts.get(id)
+      const isCollapsed = collapsed.has(id) || !inner
+      const lane: FlowBatchLane = {
+        batchId: id,
+        x: colX[l]!,
+        y: cursorY,
+        width: ob.width,
+        height: ob.height,
+        metaStage: l,
+        status: aggregateStatus(jobsByBatch.get(id)!),
+        finished: jobsByBatch.get(id)!.filter((j) => j.status === 'succeeded' || j.status === 'failed').length,
+        total: jobsByBatch.get(id)!.length,
+        collapsed: isCollapsed,
+      }
+      placedBatches.push(lane)
+      cursorY += ob.height + geom.metaRowGap
+    }
+  }
+
+  // Compute total canvas extents.
+  let canvasW = 0
+  let canvasH = 0
+  for (const b of placedBatches) {
+    canvasW = Math.max(canvasW, b.x + b.width)
+    canvasH = Math.max(canvasH, b.y + b.height)
+  }
+  canvasW += geom.canvasPadding
+  canvasH += geom.canvasPadding
+
+  // Index placed lanes for the edge-routing phase.
+  const laneById = new Map<string, FlowBatchLane>()
+  for (const b of placedBatches) laneById.set(b.batchId, b)
+
+  // 5. Emit nodes — jobs (expanded batches) and batch supernodes
+  //    (collapsed batches).
+  const nodes: FlowNode[] = []
+  const jobNodeAbs = new Map<string, FlowNode>()
+
+  for (const b of placedBatches) {
+    if (b.collapsed) {
+      const supernode: FlowNode = {
+        id: b.batchId,
+        batchId: b.batchId,
+        x: b.x,
+        y: b.y,
+        width: b.width,
+        height: b.height,
+        kind: 'batch',
+      }
+      nodes.push(supernode)
+      jobNodeAbs.set(b.batchId, supernode)
+    } else {
+      const inner = innerLayouts.get(b.batchId)!
+      const contentX = b.x + geom.batchPadX
+      const contentY = b.y + geom.batchPadTop
+      for (const j of jobsByBatch.get(b.batchId)!) {
+        const rel = inner.relNodes.get(j.id)!
+        const absNode: FlowNode = {
+          id: j.id,
+          batchId: b.batchId,
+          x: contentX + rel.x,
+          y: contentY + rel.y,
+          width: rel.width,
+          height: rel.height,
+          kind: 'job',
+          stage: rel.stage,
+          job: j,
+        }
+        nodes.push(absNode)
+        jobNodeAbs.set(j.id, absNode)
+      }
+    }
+  }
+
+  // 6. Emit edges.
+  const edges: FlowEdge[] = []
+
+  // 6a. Within-batch edges (only for expanded batches).
+  for (const [batchId, inner] of innerLayouts.entries()) {
+    const lane = laneById.get(batchId)
+    if (!lane || lane.collapsed) continue
+    for (const e of inner.innerEdges) {
+      const from = jobNodeAbs.get(e.fromId)
+      const to = jobNodeAbs.get(e.toId)
+      if (!from || !to) continue
+      edges.push({
+        fromId: e.fromId,
+        toId: e.toId,
+        points: routeEdge(from, to, e.span),
+        kind: 'within-batch',
+      })
+    }
+  }
+
+  // 6b. Cross-batch edges (job-level when both batches expanded;
+  //     meta when either side is collapsed).
+  for (const e of metaEdgesList) {
+    const fromLane = laneById.get(e.from)!
+    const toLane = laneById.get(e.to)!
+    const drivers = metaEdgeDrivers.get(`${e.from}→${e.to}`) ?? []
+    const blocked = jobsByBatch.get(e.from)!.some((j) => j.status === 'failed')
+    const tooltip =
+      drivers.length > 0
+        ? `via ${drivers.map((d) => `${d.from} → ${d.to}`).join(', ')}`
+        : undefined
+
+    if (fromLane.collapsed || toLane.collapsed) {
+      // Render as a meta arrow lane→lane.
+      edges.push({
+        fromId: e.from,
+        toId: e.to,
+        points: routeEdge(
+          { x: fromLane.x, y: fromLane.y, width: fromLane.width, height: fromLane.height },
+          { x: toLane.x, y: toLane.y, width: toLane.width, height: toLane.height },
+          Math.max(1, toLane.metaStage - fromLane.metaStage),
+        ),
+        kind: 'meta',
+        blocked,
+        tooltip,
+      })
+    } else {
+      // Both expanded — render a job→job arrow per driver.
+      for (const d of drivers) {
+        const from = jobNodeAbs.get(d.from)
+        const to = jobNodeAbs.get(d.to)
+        if (!from || !to) continue
+        edges.push({
+          fromId: d.from,
+          toId: d.to,
+          points: routeEdge(
+            from,
+            to,
+            // Meta-edges always span ≥ 1 meta-column → use a bezier so
+            // the curve clears lane boundaries cleanly.
+            2,
+          ),
+          kind: 'cross-batch-job',
+          blocked,
+          tooltip,
+        })
+      }
+    }
+  }
+
+  return {
+    nodes,
+    edges,
+    batches: placedBatches,
+    width: canvasW,
+    height: canvasH,
+  }
+}
+
+/* ──────────────────────────────────────────────────────────────────
+ * Helpers
+ * ────────────────────────────────────────────────────────────────── */
+
+/**
+ * Roll up a batch's job statuses into a single bucket for the lane
+ * tint. Single-bucket batches return that bucket; mixed batches
+ * return `mixed` so the renderer can paint the amber background.
+ */
+export function aggregateStatus(
+  jobs: readonly Job[],
+): 'pending' | 'running' | 'succeeded' | 'failed' | 'mixed' {
+  if (jobs.length === 0) return 'pending'
+  const buckets = new Set(jobs.map((j) => j.status))
+  if (buckets.size === 1) {
+    return [...buckets][0] as 'pending' | 'running' | 'succeeded' | 'failed'
+  }
+  if (buckets.has('failed')) {
+    // Any failure — surface it. UI will pick this over mixed/running so
+    // the operator's eye is drawn to the failed lane first.
+    return buckets.has('running') || buckets.has('pending') ? 'mixed' : 'failed'
+  }
+  return 'mixed'
+}
+
+/**
+ * Default-collapse policy: every batch where ALL jobs are in a
+ * terminal-success state is collapsed; the rest stay expanded.
+ *
+ * Per founder spec: "batches with ≥1 running/pending job → expanded.
+ * All-succeeded batches → collapsed."
+ */
+export function defaultCollapsedBatchIds(jobs: readonly Job[]): Set<string> {
+  const byBatch = new Map<string, Job[]>()
+  for (const j of jobs) {
+    const arr = byBatch.get(j.batchId) ?? []
+    arr.push(j)
+    byBatch.set(j.batchId, arr)
+  }
+  const out = new Set<string>()
+  for (const [batchId, arr] of byBatch.entries()) {
+    if (arr.length > 0 && arr.every((j) => j.status === 'succeeded')) {
+      out.add(batchId)
+    }
+  }
+  return out
+}
+
+/**
+ * Render a polyline / bezier edge as an SVG path "d" attribute.
+ *
+ *   • 2-point segments → `M x0 y0 L x1 y1`
+ *   • 4-point bezier   → `M x0 y0 C cx1 cy1, cx2 cy2, x1 y1`
+ *   • 3-point fallback → straight L through the middle point
+ *
+ * Pure helper, exported so tests can lock the contract and the
+ * JobsFlowView doesn't have to repeat the if-ladder inline.
+ */
+export function edgeToPath(points: readonly { x: number; y: number }[]): string {
+  if (points.length < 2) return ''
+  const [p0, ...rest] = points
+  const head = `M ${p0!.x} ${p0!.y}`
+  if (points.length === 4) {
+    const [, c1, c2, p1] = points
+    return `${head} C ${c1!.x} ${c1!.y}, ${c2!.x} ${c2!.y}, ${p1!.x} ${p1!.y}`
+  }
+  return `${head}${rest.map((p) => ` L ${p.x} ${p.y}`).join('')}`
+}

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/JobsFlowView.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/JobsFlowView.test.tsx
@@ -1,0 +1,228 @@
+/**
+ * JobsFlowView.test.tsx — component-level tests for the Flow tab on
+ * the Jobs page (urgent founder spec).
+ *
+ * Coverage:
+ *   • Renders without error on empty data.
+ *   • Renders 4 stages for the canonical 5-job fan-in example.
+ *   • Click batch header toggles collapsed state (job nodes
+ *     disappear, supernode glyph appears).
+ *   • Click job card calls navigate with the correct
+ *     /provision/$id/jobs/$jobId target.
+ *   • Default-collapse policy: all-succeeded batches collapsed by
+ *     default; in-flight batches expanded.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { render, screen, cleanup, fireEvent } from '@testing-library/react'
+import {
+  RouterProvider,
+  createRouter,
+  createRootRoute,
+  createRoute,
+  createMemoryHistory,
+  Outlet,
+} from '@tanstack/react-router'
+import { JobsFlowView } from './JobsFlowView'
+import type { Job } from '@/lib/jobs.types'
+
+function renderFlow(jobs: Job[], deploymentId = 'd-1') {
+  const rootRoute = createRootRoute({ component: () => <Outlet /> })
+  const flowRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/provision/$deploymentId/jobs',
+    component: () => <JobsFlowView jobs={jobs} deploymentId={deploymentId} />,
+  })
+  const detailRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/provision/$deploymentId/jobs/$jobId',
+    component: () => <div data-testid="job-detail-target" />,
+  })
+  const tree = rootRoute.addChildren([flowRoute, detailRoute])
+  const router = createRouter({
+    routeTree: tree,
+    history: createMemoryHistory({ initialEntries: [`/provision/${deploymentId}/jobs`] }),
+  })
+  return { ...render(<RouterProvider router={router} />), router }
+}
+
+const mkJob = (id: string, deps: string[], batchId: string, status: Job['status'] = 'pending'): Job => ({
+  id,
+  jobName: id,
+  appId: id,
+  batchId,
+  dependsOn: deps,
+  status,
+  startedAt: null,
+  finishedAt: null,
+  durationMs: 0,
+})
+
+const FIVE_JOB: Job[] = [
+  mkJob('1', [], 'B'),
+  mkJob('2', ['1'], 'B'),
+  mkJob('3', ['1'], 'B'),
+  mkJob('4', ['3'], 'B'),
+  mkJob('5', ['2', '4'], 'B'),
+]
+
+beforeEach(() => {
+  // Quiet unhandled console error from jsdom not implementing
+  // foreignObject layout — the component renders fine, the SVG just
+  // can't compute child boxes in jsdom.
+})
+
+afterEach(() => cleanup())
+
+describe('JobsFlowView — empty state', () => {
+  it('renders an empty placeholder when jobs is empty', async () => {
+    renderFlow([])
+    expect(await screen.findByTestId('jobs-flow-empty')).toBeTruthy()
+  })
+
+  it('does NOT render the SVG canvas when there is no data', async () => {
+    renderFlow([])
+    await screen.findByTestId('jobs-flow-empty')
+    expect(screen.queryByTestId('jobs-flow-svg')).toBeNull()
+  })
+})
+
+describe('JobsFlowView — canonical 5-job fan-in', () => {
+  it('renders the SVG canvas', async () => {
+    renderFlow(FIVE_JOB)
+    expect(await screen.findByTestId('jobs-flow-svg')).toBeTruthy()
+  })
+
+  it('renders one batch swimlane', async () => {
+    renderFlow(FIVE_JOB)
+    expect(await screen.findByTestId('flow-batch-B')).toBeTruthy()
+  })
+
+  it('renders 5 job cards', async () => {
+    renderFlow(FIVE_JOB)
+    await screen.findByTestId('jobs-flow-svg')
+    for (const id of ['1', '2', '3', '4', '5']) {
+      expect(screen.getByTestId(`flow-job-${id}`)).toBeTruthy()
+    }
+  })
+
+  it('renders 5 within-batch edges', async () => {
+    renderFlow(FIVE_JOB)
+    await screen.findByTestId('jobs-flow-svg')
+    const edges = document.querySelectorAll('[data-testid^="flow-edge-"]')
+    expect(edges.length).toBe(5)
+  })
+
+  it('jobs are positioned across 4 distinct stages', async () => {
+    renderFlow(FIVE_JOB)
+    await screen.findByTestId('jobs-flow-svg')
+    const stages = new Set<string>()
+    for (const id of ['1', '2', '3', '4', '5']) {
+      // The job node's <rect> sits at x = stage * COLUMN_WIDTH +
+      // batch padding; we read the x attribute to derive the stage.
+      const node = document.querySelector(`[data-testid="flow-job-${id}"] rect`)
+      const x = node?.getAttribute('x') ?? ''
+      stages.add(x)
+    }
+    expect(stages.size).toBe(4)
+  })
+})
+
+describe('JobsFlowView — batch collapse toggle', () => {
+  it('default-collapses an all-succeeded batch and expands an in-flight one', async () => {
+    const jobs: Job[] = [
+      // all succeeded — should collapse
+      mkJob('a1', [], 'A', 'succeeded'),
+      mkJob('a2', ['a1'], 'A', 'succeeded'),
+      // in flight — should stay expanded
+      mkJob('b1', ['a2'], 'B', 'running'),
+      mkJob('b2', ['b1'], 'B', 'pending'),
+    ]
+    renderFlow(jobs)
+    await screen.findByTestId('jobs-flow-svg')
+    // A's job nodes are NOT rendered (collapsed → supernode only).
+    expect(screen.queryByTestId('flow-job-a1')).toBeNull()
+    expect(screen.queryByTestId('flow-job-a2')).toBeNull()
+    expect(screen.getByTestId('flow-batch-supernode-A')).toBeTruthy()
+    // B's job nodes ARE rendered.
+    expect(screen.getByTestId('flow-job-b1')).toBeTruthy()
+    expect(screen.getByTestId('flow-job-b2')).toBeTruthy()
+  })
+
+  it('clicking the batch toggle flips collapsed state in place', async () => {
+    const jobs: Job[] = [
+      mkJob('b1', [], 'B', 'running'),
+      mkJob('b2', ['b1'], 'B', 'pending'),
+    ]
+    renderFlow(jobs)
+    await screen.findByTestId('jobs-flow-svg')
+    // B starts expanded — both job cards visible.
+    expect(screen.getByTestId('flow-job-b1')).toBeTruthy()
+    expect(screen.getByTestId('flow-job-b2')).toBeTruthy()
+    // Click toggle.
+    fireEvent.click(screen.getByTestId('flow-batch-toggle-B'))
+    // Now collapsed.
+    expect(screen.queryByTestId('flow-job-b1')).toBeNull()
+    expect(screen.queryByTestId('flow-job-b2')).toBeNull()
+    expect(screen.getByTestId('flow-batch-supernode-B')).toBeTruthy()
+    // Click again — back to expanded.
+    fireEvent.click(screen.getByTestId('flow-batch-toggle-B'))
+    expect(screen.getByTestId('flow-job-b1')).toBeTruthy()
+    expect(screen.queryByTestId('flow-batch-supernode-B')).toBeNull()
+  })
+})
+
+describe('JobsFlowView — click navigation', () => {
+  it('clicking a job card navigates to /provision/$id/jobs/$jobId', async () => {
+    const { router } = renderFlow(FIVE_JOB, 'd-42')
+    await screen.findByTestId('jobs-flow-svg')
+    fireEvent.click(screen.getByTestId('flow-job-3'))
+    // After click, the router pathname should match the JobDetail route.
+    expect(router.state.location.pathname).toBe('/provision/d-42/jobs/3')
+  })
+})
+
+describe('JobsFlowView — edge classification', () => {
+  it('cross-batch edge is rendered when both batches are expanded', async () => {
+    const jobs: Job[] = [
+      mkJob('a', [], 'A', 'running'),
+      mkJob('b', ['a'], 'B', 'pending'),
+    ]
+    renderFlow(jobs)
+    await screen.findByTestId('jobs-flow-svg')
+    const edges = document.querySelectorAll('[data-testid^="flow-edge-"]')
+    expect(edges.length).toBeGreaterThan(0)
+    const cross = Array.from(edges).filter(
+      (e) => e.getAttribute('data-kind') === 'cross-batch-job',
+    )
+    expect(cross.length).toBe(1)
+  })
+
+  it('meta edge is rendered when source batch is collapsed', async () => {
+    const jobs: Job[] = [
+      mkJob('a', [], 'A', 'succeeded'),
+      mkJob('b', ['a'], 'B', 'pending'),
+    ]
+    renderFlow(jobs)
+    await screen.findByTestId('jobs-flow-svg')
+    const edges = document.querySelectorAll('[data-testid^="flow-edge-"]')
+    const meta = Array.from(edges).filter(
+      (e) => e.getAttribute('data-kind') === 'meta',
+    )
+    expect(meta.length).toBe(1)
+  })
+
+  it('meta edge from a failed batch carries data-blocked=true', async () => {
+    const jobs: Job[] = [
+      mkJob('a', [], 'A', 'failed'),
+      mkJob('b', ['a'], 'B', 'pending'),
+    ]
+    renderFlow(jobs)
+    await screen.findByTestId('jobs-flow-svg')
+    const edges = document.querySelectorAll('[data-testid^="flow-edge-"]')
+    const blocked = Array.from(edges).filter(
+      (e) => e.getAttribute('data-blocked') === 'true',
+    )
+    expect(blocked.length).toBeGreaterThan(0)
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/JobsFlowView.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/JobsFlowView.tsx
@@ -1,0 +1,617 @@
+/**
+ * JobsFlowView — Flow tab on the Jobs page (founder-locked spec).
+ *
+ * Renders a two-level Sugiyama layered DAG:
+ *   • Outer: batches as meta-stages, left → right.
+ *   • Inner: jobs within each batch, left → right.
+ *
+ * Layout is delegated to `lib/pipelineLayout.ts` (pure function); this
+ * component only owns the SVG rendering + click/collapse interactions.
+ *
+ * Visual contract (per founder spec):
+ *   • Batch swimlane: card with name header, mini progress bar, count,
+ *     collapse toggle, status-tinted background.
+ *   • Job card: name, status badge (pulsing dot if running), duration,
+ *     appId chip. Click → /provision/$id/jobs/$jobId.
+ *   • Within-batch edge: thin gray straight (span 1) or smooth bezier
+ *     (span ≥ 2).
+ *   • Cross-batch edge: bold colored arrow at swimlane boundary;
+ *     dashed red when source batch has failures.
+ *   • Collapsed batch: shrinks to a single supernode with progress bar.
+ *   • Default zoom: in-flight batches expanded; all-succeeded collapsed.
+ *
+ * Per docs/INVIOLABLE-PRINCIPLES.md:
+ *   #1 (waterfall) — full target shape ships in this component.
+ *   #2 (no compromise) — no graph library, pure SVG + computed bezier.
+ *   #4 (never hardcode) — every dimension lives in `pipelineLayout.ts`
+ *      DEFAULT_GEOMETRY; this component only references the result.
+ */
+
+import { useMemo, useState, useCallback } from 'react'
+import { useNavigate } from '@tanstack/react-router'
+import type { Job } from '@/lib/jobs.types'
+import {
+  pipelineLayout,
+  defaultCollapsedBatchIds,
+  edgeToPath,
+  type FlowBatchLane,
+  type FlowEdge,
+  type FlowNode,
+} from '@/lib/pipelineLayout'
+
+/* ──────────────────────────────────────────────────────────────────
+ * Component
+ * ────────────────────────────────────────────────────────────────── */
+
+interface JobsFlowViewProps {
+  /** Job list. Backend populates; UI sorts/filters in place. */
+  jobs: readonly Job[]
+  /** Stable deployment id — embedded in per-job link target. */
+  deploymentId: string
+}
+
+export function JobsFlowView({ jobs, deploymentId }: JobsFlowViewProps) {
+  // Default collapse policy is computed once per `jobs` reference; the
+  // user override is a Set keyed by batchId. Each toggle replaces the
+  // override with a fresh Set so React re-renders.
+  const initialCollapsed = useMemo(() => defaultCollapsedBatchIds(jobs), [jobs])
+  const [overrideSet, setOverrideSet] = useState<Set<string>>(new Set())
+  const [overrideMode, setOverrideMode] = useState<'replace' | 'merge'>('merge')
+
+  const collapsedBatchIds = useMemo<Set<string>>(() => {
+    if (overrideMode === 'replace') return overrideSet
+    // merge mode: start from defaults, then toggle entries the user
+    // explicitly flipped.
+    const out = new Set(initialCollapsed)
+    for (const id of overrideSet) {
+      if (out.has(id)) out.delete(id)
+      else out.add(id)
+    }
+    return out
+  }, [initialCollapsed, overrideSet, overrideMode])
+
+  const layout = useMemo(
+    () => pipelineLayout(jobs, { collapsedBatchIds }),
+    [jobs, collapsedBatchIds],
+  )
+
+  const navigate = useNavigate()
+
+  const onToggleBatch = useCallback((batchId: string) => {
+    setOverrideMode('merge')
+    setOverrideSet((prev) => {
+      const next = new Set(prev)
+      if (next.has(batchId)) next.delete(batchId)
+      else next.add(batchId)
+      return next
+    })
+  }, [])
+
+  const onJobClick = useCallback(
+    (jobId: string) => {
+      navigate({
+        to: '/provision/$deploymentId/jobs/$jobId' as never,
+        params: { deploymentId, jobId } as never,
+      })
+    },
+    [navigate, deploymentId],
+  )
+
+  if (jobs.length === 0) {
+    return (
+      <div
+        data-testid="jobs-flow-empty"
+        className="rounded-xl border border-dashed border-[var(--color-border)] p-8 text-center text-sm text-[var(--color-text-dim)]"
+      >
+        No jobs to render in the dependency graph.
+      </div>
+    )
+  }
+
+  return (
+    <div className="jobs-flow-wrap" data-testid="jobs-flow-wrap">
+      <style>{JOBS_FLOW_CSS}</style>
+      <div className="jobs-flow-scroll">
+        <svg
+          width={layout.width}
+          height={layout.height}
+          viewBox={`0 0 ${layout.width} ${layout.height}`}
+          className="jobs-flow-svg"
+          data-testid="jobs-flow-svg"
+          role="img"
+          aria-label="Job dependency flow"
+        >
+          <defs>
+            <marker
+              id="flow-arrow"
+              viewBox="0 0 10 10"
+              refX="9"
+              refY="5"
+              markerWidth="6"
+              markerHeight="6"
+              orient="auto-start-reverse"
+            >
+              <path d="M0,0 L10,5 L0,10 Z" fill="var(--color-text-dim)" />
+            </marker>
+            <marker
+              id="flow-arrow-meta"
+              viewBox="0 0 10 10"
+              refX="9"
+              refY="5"
+              markerWidth="7"
+              markerHeight="7"
+              orient="auto-start-reverse"
+            >
+              <path d="M0,0 L10,5 L0,10 Z" fill="#38BDF8" />
+            </marker>
+            <marker
+              id="flow-arrow-blocked"
+              viewBox="0 0 10 10"
+              refX="9"
+              refY="5"
+              markerWidth="7"
+              markerHeight="7"
+              orient="auto-start-reverse"
+            >
+              <path d="M0,0 L10,5 L0,10 Z" fill="#F87171" />
+            </marker>
+          </defs>
+
+          {/* 1. Batch swimlanes (drawn first so jobs sit on top) */}
+          {layout.batches.map((b) => (
+            <BatchSwimlane
+              key={b.batchId}
+              lane={b}
+              onToggle={() => onToggleBatch(b.batchId)}
+            />
+          ))}
+
+          {/* 2. Edges */}
+          {layout.edges.map((e, i) => (
+            <FlowEdgePath key={`${e.fromId}-${e.toId}-${i}`} edge={e} />
+          ))}
+
+          {/* 3. Job nodes (cards) */}
+          {layout.nodes.map((n) =>
+            n.kind === 'job' ? (
+              <JobCardNode key={n.id} node={n} onClick={() => onJobClick(n.id)} />
+            ) : null,
+          )}
+        </svg>
+      </div>
+    </div>
+  )
+}
+
+/* ──────────────────────────────────────────────────────────────────
+ * Sub-components
+ * ────────────────────────────────────────────────────────────────── */
+
+interface BatchSwimlaneProps {
+  lane: FlowBatchLane
+  onToggle: () => void
+}
+
+function BatchSwimlane({ lane, onToggle }: BatchSwimlaneProps) {
+  const tone = LANE_TONE[lane.status]
+  const HEADER_HEIGHT = 36
+  const progressPct =
+    lane.total === 0 ? 0 : Math.round((lane.finished / lane.total) * 100)
+
+  return (
+    <g data-testid={`flow-batch-${lane.batchId}`} data-collapsed={lane.collapsed}>
+      <rect
+        x={lane.x}
+        y={lane.y}
+        width={lane.width}
+        height={lane.height}
+        rx={12}
+        ry={12}
+        fill={tone.bg}
+        stroke={tone.border}
+        strokeWidth={1.5}
+      />
+      {/* Header strip */}
+      <rect
+        x={lane.x}
+        y={lane.y}
+        width={lane.width}
+        height={HEADER_HEIGHT}
+        rx={12}
+        ry={12}
+        fill={tone.headerBg}
+        stroke="none"
+      />
+      <foreignObject
+        x={lane.x + 8}
+        y={lane.y + 4}
+        width={lane.width - 16}
+        height={HEADER_HEIGHT - 8}
+      >
+        <div className="flow-batch-header">
+          <button
+            type="button"
+            className="flow-batch-toggle"
+            data-testid={`flow-batch-toggle-${lane.batchId}`}
+            onClick={onToggle}
+            aria-label={lane.collapsed ? 'Expand batch' : 'Collapse batch'}
+          >
+            <svg viewBox="0 0 12 12" width="10" height="10" aria-hidden>
+              {lane.collapsed ? (
+                <path d="M3 2 L9 6 L3 10 Z" fill="currentColor" />
+              ) : (
+                <path d="M2 4 L10 4 L6 10 Z" fill="currentColor" />
+              )}
+            </svg>
+          </button>
+          <span
+            className="flow-batch-name"
+            data-testid={`flow-batch-name-${lane.batchId}`}
+            title={lane.batchId}
+          >
+            {lane.batchId}
+          </span>
+          <span className="flow-batch-count" data-testid={`flow-batch-count-${lane.batchId}`}>
+            {lane.finished}/{lane.total}
+          </span>
+        </div>
+      </foreignObject>
+
+      {/* Mini progress bar */}
+      <rect
+        x={lane.x + 8}
+        y={lane.y + HEADER_HEIGHT - 4}
+        width={lane.width - 16}
+        height={3}
+        rx={1.5}
+        ry={1.5}
+        fill="rgba(148,163,184,0.20)"
+      />
+      <rect
+        x={lane.x + 8}
+        y={lane.y + HEADER_HEIGHT - 4}
+        width={Math.max(0, ((lane.width - 16) * progressPct) / 100)}
+        height={3}
+        rx={1.5}
+        ry={1.5}
+        fill={tone.progress}
+        data-testid={`flow-batch-progress-${lane.batchId}`}
+      />
+
+      {/* Collapsed body — render the supernode glyph in the middle */}
+      {lane.collapsed ? (
+        <foreignObject
+          x={lane.x + 8}
+          y={lane.y + HEADER_HEIGHT + 4}
+          width={lane.width - 16}
+          height={lane.height - HEADER_HEIGHT - 8}
+        >
+          <div
+            className="flow-batch-collapsed"
+            data-testid={`flow-batch-supernode-${lane.batchId}`}
+          >
+            <span className="flow-batch-collapsed-pct">{progressPct}%</span>
+            <span className="flow-batch-collapsed-meta">
+              {lane.total} {lane.total === 1 ? 'job' : 'jobs'}
+            </span>
+          </div>
+        </foreignObject>
+      ) : null}
+    </g>
+  )
+}
+
+interface JobCardNodeProps {
+  node: FlowNode
+  onClick: () => void
+}
+
+function JobCardNode({ node, onClick }: JobCardNodeProps) {
+  if (!node.job) return null
+  const j = node.job
+  const tone = JOB_STATUS_TONE[j.status]
+  return (
+    <g
+      data-testid={`flow-job-${j.id}`}
+      data-status={j.status}
+      onClick={onClick}
+      style={{ cursor: 'pointer' }}
+    >
+      <rect
+        x={node.x}
+        y={node.y}
+        width={node.width}
+        height={node.height}
+        rx={10}
+        ry={10}
+        fill={tone.bg}
+        stroke={tone.border}
+        strokeWidth={1.25}
+        className="flow-job-rect"
+      />
+      <foreignObject x={node.x} y={node.y} width={node.width} height={node.height}>
+        <div className="flow-job-card">
+          <div className="flow-job-row">
+            <span className="flow-job-name" title={j.jobName}>
+              {j.jobName}
+            </span>
+            <span
+              className={`flow-job-badge flow-job-badge-${j.status}`}
+              data-testid={`flow-job-badge-${j.id}`}
+            >
+              {j.status === 'running' ? <span className="flow-job-pulse" aria-hidden /> : null}
+              {tone.label}
+            </span>
+          </div>
+          <div className="flow-job-meta">
+            <span className="flow-job-app" title={j.appId}>
+              {j.appId}
+            </span>
+            <span className="flow-job-duration">{formatDuration(j.durationMs)}</span>
+          </div>
+        </div>
+      </foreignObject>
+    </g>
+  )
+}
+
+interface FlowEdgePathProps {
+  edge: FlowEdge
+}
+
+function FlowEdgePath({ edge }: FlowEdgePathProps) {
+  const d = edgeToPath(edge.points)
+  if (!d) return null
+  let stroke = 'var(--color-text-dim)'
+  let strokeWidth = 1.25
+  let dash: string | undefined
+  let marker = 'url(#flow-arrow)'
+  let opacity = 0.6
+  if (edge.kind === 'meta' || edge.kind === 'cross-batch-job') {
+    stroke = '#38BDF8'
+    strokeWidth = 1.75
+    marker = 'url(#flow-arrow-meta)'
+    opacity = 0.85
+  }
+  if (edge.blocked) {
+    stroke = '#F87171'
+    dash = '4 4'
+    marker = 'url(#flow-arrow-blocked)'
+    opacity = 0.95
+  }
+  return (
+    <path
+      d={d}
+      fill="none"
+      stroke={stroke}
+      strokeWidth={strokeWidth}
+      strokeDasharray={dash}
+      opacity={opacity}
+      markerEnd={marker}
+      data-testid={`flow-edge-${edge.fromId}-${edge.toId}`}
+      data-kind={edge.kind}
+      data-blocked={edge.blocked ? 'true' : 'false'}
+    >
+      {edge.tooltip ? <title>{edge.tooltip}</title> : null}
+    </path>
+  )
+}
+
+/* ──────────────────────────────────────────────────────────────────
+ * Helpers + tone tables
+ * ────────────────────────────────────────────────────────────────── */
+
+function formatDuration(ms: number): string {
+  if (!Number.isFinite(ms) || ms <= 0) return '—'
+  const totalSec = Math.floor(ms / 1000)
+  const h = Math.floor(totalSec / 3600)
+  const m = Math.floor((totalSec % 3600) / 60)
+  const s = totalSec % 60
+  if (h > 0) return `${h}h ${m}m`
+  if (m > 0) return `${m}m ${s}s`
+  return `${s}s`
+}
+
+interface LaneTone {
+  bg: string
+  border: string
+  headerBg: string
+  progress: string
+}
+
+const LANE_TONE: Record<FlowBatchLane['status'], LaneTone> = {
+  succeeded: {
+    bg: 'rgba(74,222,128,0.06)',
+    border: 'rgba(74,222,128,0.45)',
+    headerBg: 'rgba(74,222,128,0.16)',
+    progress: '#4ADE80',
+  },
+  running: {
+    bg: 'rgba(56,189,248,0.06)',
+    border: 'rgba(56,189,248,0.45)',
+    headerBg: 'rgba(56,189,248,0.18)',
+    progress: '#38BDF8',
+  },
+  failed: {
+    bg: 'rgba(248,113,113,0.06)',
+    border: 'rgba(248,113,113,0.55)',
+    headerBg: 'rgba(248,113,113,0.18)',
+    progress: '#F87171',
+  },
+  pending: {
+    bg: 'rgba(148,163,184,0.04)',
+    border: 'rgba(148,163,184,0.35)',
+    headerBg: 'rgba(148,163,184,0.14)',
+    progress: '#94A3B8',
+  },
+  mixed: {
+    bg: 'rgba(245,158,11,0.06)',
+    border: 'rgba(245,158,11,0.45)',
+    headerBg: 'rgba(245,158,11,0.16)',
+    progress: '#F59E0B',
+  },
+}
+
+const JOB_STATUS_TONE: Record<
+  Job['status'],
+  { bg: string; border: string; label: string }
+> = {
+  pending:   { bg: 'rgba(15,23,42,0.55)',     border: 'rgba(148,163,184,0.30)', label: 'Pending'   },
+  running:   { bg: 'rgba(15,23,42,0.55)',     border: 'rgba(56,189,248,0.55)',  label: 'Running'   },
+  succeeded: { bg: 'rgba(15,23,42,0.55)',     border: 'rgba(74,222,128,0.55)',  label: 'Succeeded' },
+  failed:    { bg: 'rgba(15,23,42,0.55)',     border: 'rgba(248,113,113,0.55)', label: 'Failed'    },
+}
+
+/* ──────────────────────────────────────────────────────────────────
+ * Styles — co-located with the component so we don't grow another
+ * CSS module. Mirrors JobsTable's strategy.
+ * ────────────────────────────────────────────────────────────────── */
+
+const JOBS_FLOW_CSS = `
+.jobs-flow-wrap { width: 100%; }
+
+.jobs-flow-scroll {
+  width: 100%;
+  overflow-x: auto;
+  overflow-y: auto;
+  border: 1px solid var(--color-border);
+  border-radius: 12px;
+  background: var(--color-surface);
+  max-height: 78vh;
+}
+.jobs-flow-svg {
+  display: block;
+  font-family: var(--font-sans, system-ui);
+}
+
+.flow-batch-header {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  height: 100%;
+  color: var(--color-text);
+  font-size: 0.78rem;
+  font-weight: 600;
+}
+.flow-batch-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: var(--color-text-dim);
+  cursor: pointer;
+  border-radius: 4px;
+}
+.flow-batch-toggle:hover { color: var(--color-text); background: rgba(148,163,184,0.10); }
+.flow-batch-name {
+  flex: 1 1 auto;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-family: var(--font-mono, ui-monospace, monospace);
+  letter-spacing: 0.02em;
+}
+.flow-batch-count {
+  font-size: 0.7rem;
+  color: var(--color-text-dim);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+.flow-batch-collapsed {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  gap: 0.15rem;
+}
+.flow-batch-collapsed-pct {
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: var(--color-text-strong);
+  font-variant-numeric: tabular-nums;
+}
+.flow-batch-collapsed-meta {
+  font-size: 0.7rem;
+  color: var(--color-text-dim);
+  font-variant-numeric: tabular-nums;
+}
+
+.flow-job-card {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  height: 100%;
+  width: 100%;
+  padding: 0.45rem 0.55rem;
+  box-sizing: border-box;
+  pointer-events: none;
+}
+.flow-job-row {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  justify-content: space-between;
+}
+.flow-job-name {
+  flex: 1 1 auto;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: var(--color-text-strong);
+}
+.flow-job-meta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.4rem;
+  font-size: 0.66rem;
+  color: var(--color-text-dim);
+  font-family: var(--font-mono, ui-monospace, monospace);
+}
+.flow-job-app {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  color: #38BDF8;
+}
+.flow-job-duration {
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+.flow-job-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.08rem 0.4rem;
+  border-radius: 999px;
+  font-size: 0.58rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+.flow-job-badge-pending   { background: rgba(148,163,184,0.10); color: var(--color-text-dim); }
+.flow-job-badge-running   { background: rgba(56,189,248,0.10);  color: #38BDF8; }
+.flow-job-badge-succeeded { background: rgba(74,222,128,0.10);  color: #4ADE80; }
+.flow-job-badge-failed    { background: rgba(248,113,113,0.10); color: #F87171; }
+
+.flow-job-pulse {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: currentColor;
+  animation: flow-pulse 1.6s ease-in-out infinite;
+}
+@keyframes flow-pulse { 0%,100%{opacity:1;transform:scale(1)} 50%{opacity:.4;transform:scale(.6)} }
+
+.flow-job-rect:hover { filter: brightness(1.08); }
+`

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/JobsPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/JobsPage.tsx
@@ -35,32 +35,68 @@
  */
 
 import { useMemo } from 'react'
-import { useParams, Link } from '@tanstack/react-router'
+import { useParams, Link, useSearch, useNavigate } from '@tanstack/react-router'
 import { useWizardStore } from '@/entities/deployment/store'
 import { PortalShell } from './PortalShell'
 import { JobsTable } from './JobsTable'
+import { JobsFlowView } from './JobsFlowView'
 import { resolveApplications } from './applicationCatalog'
 import { useDeploymentEvents } from './useDeploymentEvents'
 import { deriveJobs } from './jobs'
 import { adaptDerivedJobsToFlat } from './jobsAdapter'
 import { useLiveJobsBackfill, mergeJobs } from './useLiveJobsBackfill'
 
+/** Canonical tabs for the JobsPage view-mode. */
+export type JobsViewKey = 'table' | 'flow'
+
+export const JOBS_VIEW_TABS: ReadonlyArray<{ key: JobsViewKey; label: string }> = [
+  { key: 'table', label: 'Table' },
+  { key: 'flow',  label: 'Flow'  },
+]
+
+/** Resolve a free-form `?view=...` URL value to a known JobsViewKey. */
+export function resolveJobsView(raw: unknown): JobsViewKey {
+  if (raw === 'flow') return 'flow'
+  return 'table'
+}
+
 interface JobsPageProps {
   /** Test seam — disables the live SSE EventSource attach. */
   disableStream?: boolean
   /** Test seam — disables the live-jobs backfill polling. */
   disableJobsBackfill?: boolean
+  /** Test seam — force the active view (bypasses ?view= URL parsing). */
+  initialView?: JobsViewKey
 }
 
 export function JobsPage({
   disableStream = false,
   disableJobsBackfill = false,
+  initialView,
 }: JobsPageProps = {}) {
   const params = useParams({
     from: '/provision/$deploymentId/jobs' as never,
   }) as { deploymentId: string }
   const { deploymentId } = params
   const store = useWizardStore()
+
+  // ?view=table|flow drives the active tab. We read the search params
+  // tolerantly — the Jobs route doesn't declare validateSearch (kept
+  // backward-compatible with existing deep links), so the value is
+  // typed as `unknown` and resolveJobsView() coerces it. The initial
+  // view prop overrides the URL for unit tests / Storybook embeds.
+  const search = useSearch({ strict: false }) as { view?: unknown }
+  const activeView: JobsViewKey = initialView ?? resolveJobsView(search?.view)
+  const navigate = useNavigate()
+  const setView = (next: JobsViewKey) => {
+    navigate({
+      to: '/provision/$deploymentId/jobs' as never,
+      params: { deploymentId } as never,
+      // `table` is the implicit default — keep the URL clean by
+      // dropping the param when the user picks the default.
+      search: (next === 'table' ? {} : { view: next }) as never,
+    })
+  }
 
   const applications = useMemo(
     () => resolveApplications(store.selectedComponents),
@@ -133,9 +169,73 @@ export function JobsPage({
         </div>
       ) : null}
 
+      <nav
+        className="jobs-view-tabs"
+        role="tablist"
+        aria-label="Jobs view"
+        data-testid="jobs-view-tabs"
+      >
+        <style>{JOBS_VIEW_TABS_CSS}</style>
+        {JOBS_VIEW_TABS.map((tab) => {
+          const isActive = tab.key === activeView
+          return (
+            <button
+              key={tab.key}
+              type="button"
+              role="tab"
+              aria-selected={isActive}
+              aria-current={isActive ? 'page' : undefined}
+              className={`jobs-view-tab${isActive ? ' active' : ''}`}
+              data-testid={`jobs-view-tab-${tab.key}`}
+              onClick={() => setView(tab.key)}
+            >
+              {tab.label}
+            </button>
+          )
+        })}
+      </nav>
+
       <div className="mt-6" data-testid="sov-jobs-list">
-        <JobsTable jobs={flatJobs} deploymentId={deploymentId} />
+        {activeView === 'flow' ? (
+          <JobsFlowView jobs={flatJobs} deploymentId={deploymentId} />
+        ) : (
+          <JobsTable jobs={flatJobs} deploymentId={deploymentId} />
+        )}
       </div>
     </PortalShell>
   )
 }
+
+/* Tab strip CSS — mirrors the InfrastructurePage `.tabs` rhythm so
+ * the visual feel is consistent across Sovereign-portal surfaces. */
+const JOBS_VIEW_TABS_CSS = `
+.jobs-view-tabs {
+  display: inline-flex;
+  gap: 0;
+  margin-top: 0.85rem;
+  border-bottom: 1px solid var(--color-border);
+  padding-bottom: 0;
+  width: 100%;
+}
+.jobs-view-tab {
+  appearance: none;
+  background: transparent;
+  border: none;
+  border-bottom: 2px solid transparent;
+  color: var(--color-text-dim);
+  cursor: pointer;
+  padding: 0.55rem 1rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  letter-spacing: 0.01em;
+  transition: color 0.12s ease, border-color 0.12s ease;
+  margin-bottom: -1px;
+}
+.jobs-view-tab:hover {
+  color: var(--color-text);
+}
+.jobs-view-tab.active {
+  color: var(--color-accent);
+  border-bottom-color: var(--color-accent);
+}
+`


### PR DESCRIPTION
## Summary

Adds a **Flow** tab to `/sovereign/provision/$id/jobs` (peer of the existing Table tab) that renders the dependency chain as a two-level Sugiyama layered DAG.

- **Outer**: batches as meta-stages, left → right.
- **Inner**: jobs within each batch as stages, left → right.

Both axes flow left → right for consistent reading direction.

URL state: `?view=table` (default) | `flow` — bookmarkable, browser-back works.

## Highlights

- `lib/pipelineLayout.ts` — pure layout function. ONE Sugiyama impl invoked at two scales (meta + inner). Crossing-minimising barycenter sweeps + dummy nodes for long edges. Cubic bezier (4 control points) for long-edge routing; straight line for span-1 edges. No graph library — pure SVG + computed beziers.
- `pages/sovereign/JobsFlowView.tsx` — SVG canvas. Batch swimlanes (status-tinted background, mini progress bar, `finished/total` count, collapse toggle), job cards (name + status badge with pulsing dot for running + duration + appId chip). Cross-batch edges fan out into job-level arrows when both lanes expanded; collapse to a single meta-arrow when either side is a supernode. Failed-source batches render dashed red.
- Default zoom: in-flight batches expanded; all-succeeded batches collapsed.
- `pages/sovereign/JobsPage.tsx` — adds tab strip. Reuses `useLiveJobsBackfill` (no new fetch path).
- `app/router.tsx` — `validateSearch` accepts `?view=table|flow`.
- 4 new e2e cosmetic guards.

## Tests (51 new + existing JobsPage stable)

- **34** unit tests for `pipelineLayout`: empty input, canonical 5-job fan-in (4 stages, 5 edges, 2→5 is a 4-point bezier, zero crossings), real otech bootstrap-kit (13 jobs, 5 stages, fan-in at external-dns with 2 incoming edges, zero crossings), two-batch fixture with cross-batch source = last stage of phase-0, collapse semantics, default-collapse policy.
- **13** component tests for `JobsFlowView`: empty state, 5-job render, 4-stage assertion, click toggle collapses in place, click job navigates to `/provision/$id/jobs/$jobId`, edge kind classification, blocked-edge marker.
- **4** new e2e `cosmetic-guards`: Flow tab exists, switching to Flow flips URL to `?view=flow` + canvas mounts, expanded batch shows cards + toggle shrinks to supernode, default-expanded for in-flight batches.

```
Test Files  3 passed (3)
     Tests  58 passed (58)
```

Build: ✓ (bundle hash will change).

## Test plan

- [x] `npx vitest run src/lib/pipelineLayout.test.ts src/pages/sovereign/JobsFlowView.test.tsx src/pages/sovereign/JobsPage.test.tsx` — all green.
- [x] `npx tsc -b --noEmit` clean (Dashboard recharts error pre-exists).
- [x] `npx vite build` succeeds.
- [ ] Playwright MCP screenshots on prod after image roll: Table tab, Flow tab, expanded bootstrap-kit lane with edges, meta-edge between phase-0-infra and bootstrap-kit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)