### PR TITLE
fix(jobs): extract spec.dependsOn from HelmReleases — Flow view now has edges

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/jobs_backfill.go
+++ b/products/catalyst/bootstrap/api/internal/handler/jobs_backfill.go
@@ -123,6 +123,7 @@ func snapshotsToSeeds(snap []helmwatch.ComponentSnapshot) []jobs.InformerSeed {
 			State:      s.Status,
 			Message:    s.Message,
 			ObservedAt: s.LastTransitionAt,
+			DependsOn:  s.DependsOn,
 		})
 	}
 	return out

--- a/products/catalyst/bootstrap/api/internal/helmwatch/helmwatch.go
+++ b/products/catalyst/bootstrap/api/internal/helmwatch/helmwatch.go
@@ -360,6 +360,10 @@ type ComponentSnapshot struct {
 	Namespace        string    `json:"namespace"`
 	LastTransitionAt time.Time `json:"lastTransitionAt"`
 	Message          string    `json:"message"`
+	// DependsOn — sibling AppIDs this HelmRelease depends on, sourced
+	// from spec.dependsOn[].name with the "bp-" prefix stripped.
+	// Drives the Jobs Flow view's edge graph (issue #204).
+	DependsOn        []string  `json:"dependsOn,omitempty"`
 }
 
 // NewWatcher returns a Watcher with cfg applied. emit must be non-nil
@@ -754,6 +758,44 @@ func ComponentIDFromHelmRelease(name string) string {
 	return strings.TrimPrefix(name, "bp-")
 }
 
+// extractDependsOn pulls spec.dependsOn[].name from an unstructured
+// HelmRelease and returns the sibling AppIDs (with "bp-" prefix
+// stripped). Each dependsOn entry's `namespace` field is ignored —
+// the bootstrap-kit charts all live in flux-system, and the wizard's
+// Flow view shows dependencies by AppID, not namespace-qualified.
+//
+// Returns nil (NOT empty slice) when no dependsOn array is present
+// so the JSON serialiser omits the field cleanly via omitempty.
+//
+// Schema reference: helm.toolkit.fluxcd.io/v2 HelmRelease.spec.dependsOn
+// is `[]CrossNamespaceDependencyReference{ name, namespace? }`.
+func extractDependsOn(u *unstructured.Unstructured) []string {
+	if u == nil {
+		return nil
+	}
+	raw, found, err := unstructured.NestedSlice(u.Object, "spec", "dependsOn")
+	if err != nil || !found || len(raw) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(raw))
+	for _, entry := range raw {
+		m, ok := entry.(map[string]any)
+		if !ok {
+			continue
+		}
+		name, _ := m["name"].(string)
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
+		out = append(out, ComponentIDFromHelmRelease(name))
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
 // DeriveState implements the state machine documented on
 // provisioner.Event. Exported so tests can drive it on synthetic
 // condition slices without spinning a fake informer.
@@ -973,6 +1015,7 @@ func (w *Watcher) SnapshotComponents() []ComponentSnapshot {
 			Namespace:        ns,
 			LastTransitionAt: lastTransitionAt.UTC(),
 			Message:          message,
+			DependsOn:        extractDependsOn(u),
 		})
 	}
 	return out

--- a/products/catalyst/bootstrap/api/internal/jobs/helmwatch_bridge.go
+++ b/products/catalyst/bootstrap/api/internal/jobs/helmwatch_bridge.go
@@ -157,6 +157,11 @@ type InformerSeed struct {
 	State      string
 	Message    string
 	ObservedAt time.Time
+	// DependsOn — sibling AppIDs (bp-prefix stripped) this seed depends
+	// on, sourced from the HelmRelease's spec.dependsOn[].name.
+	// Translated to JobName form (install-<comp>) before being written
+	// to the Job record so the Flow view's edge graph renders.
+	DependsOn  []string
 }
 
 // SeedJobsFromInformerList takes a snapshot of the helmwatch informer's
@@ -205,12 +210,24 @@ func (b *Bridge) SeedJobsFromInformerList(seeds []InformerSeed) (jobsWritten, ex
 		// Status=succeeded Job, exactly as if a transition had been
 		// emitted.
 		nextStatus := jobStatusFromHelmState(s.State)
+		// Translate sibling AppIDs into the JobName form the Flow
+		// view's edge graph keys off ("cilium" → "install-cilium").
+		// This is the load-bearing line for issue #204's pipeline
+		// view: without dependsOn, no edges render between Job rows.
+		deps := make([]string, 0, len(s.DependsOn))
+		for _, d := range s.DependsOn {
+			d = strings.TrimSpace(d)
+			if d == "" {
+				continue
+			}
+			deps = append(deps, JobNamePrefix+d)
+		}
 		if err := b.store.UpsertJob(Job{
 			DeploymentID: b.deploymentID,
 			JobName:      jobName,
 			AppID:        comp,
 			BatchID:      BatchBootstrapKit,
-			DependsOn:    []string{},
+			DependsOn:    deps,
 			Status:       nextStatus,
 		}); err != nil {
 			return jobsWritten, executionsSeeded, err


### PR DESCRIPTION
Live: backend /jobs returned dependsOn:[] for every job → Flow view had nothing to draw. Bridge wasn't reading HR spec.dependsOn. Wire ComponentSnapshot→InformerSeed→Bridge→Job.DependsOn through. Translates bp-cilium → install-cilium.