### PR TITLE
fix(catalyst-ui): JobDetail uses merged backend+reducer jobs (resolves not-found regression from #245)

### DIFF
--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/JobDetail.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/JobDetail.test.tsx
@@ -7,10 +7,16 @@
  *   • Dependencies + Apps tabs are GONE (removed in v3).
  *   • Flow tab renders the embedded FlowPage (data-testid='flow-page-embedded').
  *   • Exec Log tab renders the ExecutionLogs viewer.
+ *   • [Regression] When the URL jobId is in the BACKEND format
+ *     (`<deploymentId>:install-cilium`), JobDetail looks it up via
+ *     mergeJobs(reducerJobs, liveJobs) — NOT deriveJobs alone — and
+ *     renders the populated job view rather than the not-found state.
+ *     This locks in the fix for the regression where every Flow-canvas
+ *     double-click landed on "is not part of this deployment".
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
-import { render, screen, cleanup, fireEvent } from '@testing-library/react'
+import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react'
 import {
   RouterProvider,
   createRouter,
@@ -23,13 +29,14 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { JobDetail } from './JobDetail'
 import { useWizardStore } from '@/entities/deployment/store'
 import { INITIAL_WIZARD_STATE } from '@/entities/deployment/model'
+import type { Job } from '@/lib/jobs.types'
 
 function renderDetail(deploymentId: string, jobId: string) {
   const rootRoute = createRootRoute({ component: () => <Outlet /> })
   const detailRoute = createRoute({
     getParentRoute: () => rootRoute,
     path: '/provision/$deploymentId/jobs/$jobId',
-    component: () => <JobDetail disableStream />,
+    component: () => <JobDetail disableStream disableJobsBackfill />,
   })
   const flowRoute = createRoute({
     getParentRoute: () => rootRoute,
@@ -74,6 +81,73 @@ beforeEach(() => {
 
 afterEach(() => cleanup())
 
+/**
+ * Regression-test helper — renders JobDetail with the live-jobs backfill
+ * ENABLED, plus a fetch stub that returns the supplied liveJobs on the
+ * `/jobs` URL and an empty event slice on the `/events` URL. Lets us
+ * assert that backend-format ids (e.g. `d1:install-cilium`) resolve via
+ * mergeJobs() rather than falling through to the not-found state.
+ */
+function renderDetailWithLiveJobs(
+  deploymentId: string,
+  jobId: string,
+  liveJobs: Job[],
+) {
+  const rootRoute = createRootRoute({ component: () => <Outlet /> })
+  const detailRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/provision/$deploymentId/jobs/$jobId',
+    // Live backfill ENABLED so useLiveJobsBackfill fetches the stubbed
+    // jobs payload. SSE is still disabled (jsdom can't drive it).
+    component: () => <JobDetail disableStream />,
+  })
+  const flowRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/provision/$deploymentId/flow',
+    component: () => <div data-testid="flow-target" />,
+  })
+  const jobsRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/provision/$deploymentId/jobs',
+    component: () => <div data-testid="jobs-target" />,
+  })
+  const homeRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/provision/$deploymentId',
+    component: () => <div data-testid="apps-target" />,
+  })
+  const tree = rootRoute.addChildren([detailRoute, flowRoute, jobsRoute, homeRoute])
+  const router = createRouter({
+    routeTree: tree,
+    history: createMemoryHistory({
+      initialEntries: [`/provision/${deploymentId}/jobs/${jobId}`],
+    }),
+  })
+  // URL-aware fetch stub: /jobs → liveJobs; everything else → empty
+  // events slice (matches the default useDeploymentEvents shape).
+  globalThis.fetch = ((input: RequestInfo | URL) => {
+    const url = typeof input === 'string' ? input : input.toString()
+    if (url.endsWith(`/v1/deployments/${encodeURIComponent(deploymentId)}/jobs`)) {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ jobs: liveJobs }),
+      } as unknown as Response)
+    }
+    return Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve({ events: [], state: undefined, done: false }),
+    } as unknown as Response)
+  }) as typeof fetch
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  })
+  return render(
+    <QueryClientProvider client={qc}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>,
+  )
+}
+
 describe('JobDetail — v3 tab strip', () => {
   it('renders exactly 2 tabs labeled Flow + Exec Log', async () => {
     // Use a known fixture job id — `bp-cilium` lives in the bootstrap-kit
@@ -116,5 +190,56 @@ describe('JobDetail — v3 tab strip', () => {
     expect(logTab.getAttribute('aria-selected')).toBe('true')
     expect(screen.queryByTestId('job-detail-logs-panel')).toBeTruthy()
     expect(screen.queryByTestId('job-detail-flow-panel')).toBeNull()
+  })
+})
+
+describe('JobDetail — backend-format jobId lookup (regression for #245 not-found)', () => {
+  // Without the fix, the FlowPage navigated to JobDetail with a
+  // backend-format id ("d1:install-cilium") and JobDetail looked it up
+  // against deriveJobs() output only — which uses catalog ids
+  // ("bp-cilium"). The lookup missed and JobDetail rendered the
+  // not-found state for every Flow-canvas double-click.
+  //
+  // The fix mirrors JobsPage / FlowPage: deriveJobs → adaptDerivedJobsToFlat
+  // → mergeJobs(reducerJobs, liveJobs). When the live API returns a row
+  // whose id matches the URL jobId, mergeJobs surfaces it.
+  it('renders the populated job view when jobId is in the backend "<deploymentId>:install-<x>" format', async () => {
+    const deploymentId = 'd1'
+    const jobId = `${deploymentId}:install-cilium`
+    const liveJobs: Job[] = [
+      {
+        id: jobId,
+        jobName: 'Install Cilium',
+        appId: 'bp-cilium',
+        batchId: 'applications',
+        dependsOn: ['cluster-bootstrap'],
+        status: 'running',
+        startedAt: '2026-04-29T10:00:00Z',
+        finishedAt: null,
+        durationMs: 5_000,
+      },
+    ]
+    renderDetailWithLiveJobs(deploymentId, jobId, liveJobs)
+
+    // Header populated → NOT the not-found state.
+    await waitFor(() => {
+      expect(screen.queryByTestId('job-detail-not-found')).toBeNull()
+      expect(screen.queryByTestId(`job-detail-${jobId}`)).toBeTruthy()
+    })
+    expect(screen.getByTestId('job-detail-title').textContent).toBe('Install Cilium')
+    // Tablist still mounts (Flow + Exec Log).
+    const tablist = screen.getByTestId('job-detail-tablist')
+    const tabs = tablist.querySelectorAll('[role="tab"]')
+    expect(tabs.length).toBe(2)
+  })
+
+  it('still renders not-found when no live job AND no reducer-derived job matches', async () => {
+    const deploymentId = 'd1'
+    // Backend format id but the live API has no rows; reducer derives
+    // catalog ids only — no match either way.
+    renderDetailWithLiveJobs(deploymentId, `${deploymentId}:install-cilium`, [])
+    await waitFor(() => {
+      expect(screen.queryByTestId('job-detail-not-found')).toBeTruthy()
+    })
   })
 })

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/JobDetail.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/JobDetail.tsx
@@ -29,7 +29,10 @@ import { PortalShell } from './PortalShell'
 import { resolveApplications } from './applicationCatalog'
 import { useDeploymentEvents } from './useDeploymentEvents'
 import { deriveJobs, fmtTime, statusBadge } from './jobs'
-import type { Job } from './jobs'
+import type { JobUiStatus } from './jobs'
+import { adaptDerivedJobsToFlat } from './jobsAdapter'
+import { useLiveJobsBackfill, mergeJobs } from './useLiveJobsBackfill'
+import type { Job } from '@/lib/jobs.types'
 import { ExecutionLogs } from '@/components/ExecutionLogs'
 import { FlowPage } from './FlowPage'
 
@@ -43,11 +46,17 @@ const TABS: { key: TabKey; label: string; testid: string }[] = [
 interface JobDetailProps {
   /** Test seam — disables the live SSE EventSource attach. */
   disableStream?: boolean
+  /** Test seam — disables the live-jobs backfill polling. */
+  disableJobsBackfill?: boolean
   /** Test seam — initial tab override. */
   initialTab?: TabKey
 }
 
-export function JobDetail({ disableStream = false, initialTab = 'flow' }: JobDetailProps = {}) {
+export function JobDetail({
+  disableStream = false,
+  disableJobsBackfill = false,
+  initialTab = 'flow',
+}: JobDetailProps = {}) {
   const params = useParams({
     from: '/provision/$deploymentId/jobs/$jobId' as never,
   }) as { deploymentId: string; jobId: string }
@@ -60,7 +69,7 @@ export function JobDetail({ disableStream = false, initialTab = 'flow' }: JobDet
   )
   const applicationIds = useMemo(() => applications.map((a) => a.id), [applications])
 
-  const { state, snapshot } = useDeploymentEvents({
+  const { state, snapshot, streamStatus } = useDeploymentEvents({
     deploymentId,
     applicationIds,
     disableStream,
@@ -68,8 +77,30 @@ export function JobDetail({ disableStream = false, initialTab = 'flow' }: JobDet
 
   const sovereignFQDN = snapshot?.sovereignFQDN ?? snapshot?.result?.sovereignFQDN ?? null
 
-  // Derive the full job set + index by id.
-  const jobs = useMemo(() => deriveJobs(state, applications), [state, applications])
+  // Mirror JobsPage / FlowPage data-source:
+  //   deriveJobs (reducer)  →  adaptDerivedJobsToFlat  →  reducerJobs
+  //   useLiveJobsBackfill   →  liveJobs (backend Jobs API)
+  //   mergeJobs(reducer, live) — backend wins as soon as it returns ≥1 row.
+  //
+  // Why this matters: FlowPage navigates with the BACKEND-format id
+  // (`<deploymentId>:install-cilium`) the moment the backend has data.
+  // The reducer-only deriveJobs() output uses catalog ids
+  // (`bp-cilium`, `cluster-bootstrap`, `infrastructure:tofu-init`) that
+  // never match — so without the merge, every double-click on a Flow
+  // bubble lands on the not-found state. See useLiveJobsBackfill.ts:142
+  // for the divergence comment.
+  const derivedJobs = useMemo(() => deriveJobs(state, applications), [state, applications])
+  const reducerJobs = useMemo(() => adaptDerivedJobsToFlat(derivedJobs), [derivedJobs])
+  const inFlight = streamStatus !== 'completed' && streamStatus !== 'failed'
+  const { liveJobs } = useLiveJobsBackfill({
+    deploymentId,
+    enabled: !disableJobsBackfill,
+    disablePolling: disableJobsBackfill || !inFlight,
+  })
+  const jobs = useMemo(
+    () => mergeJobs(reducerJobs, liveJobs),
+    [reducerJobs, liveJobs],
+  )
   const jobsById = useMemo<Record<string, Job>>(() => {
     const out: Record<string, Job> = {}
     for (const j of jobs) out[j.id] = j
@@ -108,15 +139,15 @@ export function JobDetail({ disableStream = false, initialTab = 'flow' }: JobDet
     )
   }
 
-  const badge = statusBadge(job.status)
-  const completedN = job.steps.filter((s) => s.status === 'succeeded').length
-  const total = job.steps.length
+  // statusBadge accepts the legacy JobUiStatus union; JobStatus shares
+  // the same four string literals so the cast is a no-op at runtime.
+  const badge = statusBadge(job.status as JobUiStatus)
+  const lastUpdate = job.finishedAt ?? job.startedAt
 
-  // Resolve the parent batch id for the embedded FlowPage. The
-  // `batchId` field is added by the eventReducer/jobsAdapter pipeline;
-  // fall back to the legacy phase-derived id when missing so the Flow
-  // tab never fails to mount.
-  const batchId = (job as unknown as { batchId?: string }).batchId ?? deriveBatchIdFromJob(job)
+  // Resolve the parent batch id for the embedded FlowPage. The flat Job
+  // shape always carries `batchId` (assigned by the backend Jobs API or
+  // by adaptDerivedJobsToFlat for reducer-only fallback rows).
+  const batchId = job.batchId
 
   return (
     <PortalShell deploymentId={deploymentId} sovereignFQDN={sovereignFQDN}>
@@ -140,17 +171,17 @@ export function JobDetail({ disableStream = false, initialTab = 'flow' }: JobDet
               className="truncate text-2xl font-bold text-[var(--color-text-strong)]"
               data-testid="job-detail-title"
             >
-              {job.title}
+              {job.jobName}
             </h1>
             <p className="mt-1 truncate font-mono text-xs text-[var(--color-text-dim)]">
               {job.id}
-              {job.app && job.app !== 'infrastructure' && job.app !== 'cluster-bootstrap'
-                ? ` · ${job.app}`
+              {job.appId && job.appId !== 'infrastructure' && job.appId !== 'cluster-bootstrap'
+                ? ` · ${job.appId}`
                 : ''}
             </p>
             <p className="mt-2 text-xs text-[var(--color-text-dim)]">
-              {completedN}/{total} steps
-              {fmtTime(job.updatedAt) ? ` · last update ${fmtTime(job.updatedAt)}` : ''}
+              <span data-testid="job-detail-batch">{job.batchId}</span>
+              {fmtTime(lastUpdate) ? ` · last update ${fmtTime(lastUpdate)}` : ''}
             </p>
           </div>
           <span
@@ -202,7 +233,7 @@ export function JobDetail({ disableStream = false, initialTab = 'flow' }: JobDet
             >
               <FlowPage
                 disableStream={disableStream}
-                disableJobsBackfill={disableStream}
+                disableJobsBackfill={disableJobsBackfill || disableStream}
                 embedded
                 deploymentIdOverride={deploymentId}
                 scopeOverride={{ kind: 'batch', batchId }}
@@ -224,17 +255,4 @@ export function JobDetail({ disableStream = false, initialTab = 'flow' }: JobDet
       </div>
     </PortalShell>
   )
-}
-
-/**
- * Fallback batch derivation — mirrors the jobsAdapter `batchOf()`
- * mapping: infrastructure → phase-0-infra, cluster-bootstrap → its
- * own batch, everything else → 'applications'. Keeps the Flow tab
- * from failing to mount when the Job model only surfaces the legacy
- * `app` classification.
- */
-function deriveBatchIdFromJob(job: Job): string {
-  if (job.id.startsWith('infrastructure:')) return 'phase-0-infra'
-  if (job.id === 'cluster-bootstrap') return 'cluster-bootstrap'
-  return 'applications'
 }


### PR DESCRIPTION
## Summary

PR #245 (commit `52085db4`, deployed live as `:52085db` on contabo-mkt) restructured the Flow canvas. It introduced an ID-format regression: when a user double-clicks a job bubble on `/sovereign/provision/<deploymentId>/flow`, the new `JobDetail` page renders the not-found empty state with message:

```
ce476aaf80731a46:install-cilium is not part of this deployment.
```

Every job exhibits this — not just `install-cilium`.

## Root cause

Three pages derived jobs differently:

| File | Job source | jobId format produced |
|---|---|---|
| `FlowPage.tsx:212` | `mergeJobs(reducerJobs, liveJobs)` | backend wins → `<deploymentId>:install-<x>` |
| `JobsPage.tsx:91` | `mergeJobs(reducerJobs, liveJobs)` | same backend format |
| `JobDetail.tsx:72` | **only `deriveJobs(state, applications)`** | reducer-only → `bp-cilium`, `cluster-bootstrap`, `infrastructure:tofu-init` |

`useLiveJobsBackfill.ts:142–150` literally documents this divergence in a comment ("Reducer-derived jobs use catalog ids ... that don't match the backend's `<deploymentId>:install-cilium` canonical id"). Backend wins as the authoritative source the moment it returns ≥1 row.

When FlowPage navigates with the backend id, JobDetail looked it up in the reducer-only list, didn't find it, → not-found state.

## Fix

`JobDetail.tsx` now mirrors the JobsPage / FlowPage data-source:

```
deriveJobs (reducer)  →  adaptDerivedJobsToFlat  →  reducerJobs
useLiveJobsBackfill   →  liveJobs (catalyst-api Jobs endpoint)
mergeJobs(reducer, live)   — backend wins as soon as it returns ≥1 row
```

The page also switches from the rich `DerivedJob` shape (`title`, `app`, `steps`, `updatedAt`) to the flat `Job` shape (`jobName`, `appId`, `batchId`, `finishedAt`, `startedAt`) since that's what `mergeJobs` returns. Header copy preserved; the dead `deriveBatchIdFromJob()` helper is removed because flat `Job`s always carry `batchId`.

The `executionId` synthesis is kept as `${jobId}:latest` — same placeholder pattern `FlowPage` uses for the `FloatingLogPane` (`${openJob.id}:latest`). The backend executions endpoint isn't wired to job ids yet; whichever id format flows through will 404 the same way until #205 catches up.

## Before / After (relevant diff)

```diff
- const jobs = useMemo(() => deriveJobs(state, applications), [state, applications])
+ const derivedJobs = useMemo(() => deriveJobs(state, applications), [state, applications])
+ const reducerJobs = useMemo(() => adaptDerivedJobsToFlat(derivedJobs), [derivedJobs])
+ const inFlight = streamStatus !== 'completed' && streamStatus !== 'failed'
+ const { liveJobs } = useLiveJobsBackfill({
+   deploymentId,
+   enabled: !disableJobsBackfill,
+   disablePolling: disableJobsBackfill || !inFlight,
+ })
+ const jobs = useMemo(
+   () => mergeJobs(reducerJobs, liveJobs),
+   [reducerJobs, liveJobs],
+ )
```

## Test plan

- [x] `npm run test` in `products/catalyst/bootstrap/ui/` — all 35 files / 479 tests pass
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — no new lint errors in changed files (pre-existing repo-wide warnings unchanged)
- [x] New unit test: when live API returns `[{id: 'd1:install-cilium', appId: 'bp-cilium', ...}]` and URL jobId is `d1:install-cilium`, JobDetail renders populated job view (NOT not-found)
- [x] Reciprocal test: when neither live nor reducer has a matching row, the not-found state still renders
- [x] Existing v3 tab strip tests continue to pass (5 tests preserved, mounted with `disableJobsBackfill` so React Query timer doesn't outlive teardown)
- [ ] Live E2E on `https://console.openova.io/sovereign/provision/ce476aaf80731a46/flow` after CI build + Flux roll: double-click any `install-*` bubble → JobDetail renders header + tabs (NOT empty state) — pending CI build + image roll

## Live error this resolves

otech.omani.works deployment id `ce476aaf80731a46`:
> `ce476aaf80731a46:install-<x>` is not part of this deployment.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>