### PR TITLE
fix(bp-*): event-driven HR install (drop blanket 15m timeout, use disableWait)

### DIFF
--- a/clusters/_template/bootstrap-kit/01-cilium.yaml
+++ b/clusters/_template/bootstrap-kit/01-cilium.yaml
@@ -31,7 +31,6 @@ metadata:
   namespace: flux-system
 spec:
   interval: 15m
-  timeout: 15m
   releaseName: cilium
   targetNamespace: kube-system
   chart:
@@ -42,10 +41,16 @@ spec:
         kind: HelmRepository
         name: bp-cilium
         namespace: flux-system
+  # Event-driven install: Helm completes when manifests apply, not when
+  # cilium-agent reaches Ready (agent waits for envoyconfig CRDs that the
+  # SAME chart installs — legitimate slow-Ready). Replaces blanket
+  # spec.timeout: 15m band-aid from PR #221.
   install:
+    disableWait: true
     remediation:
       retries: 3
   upgrade:
+    disableWait: true
     remediation:
       retries: 3
   values:

--- a/clusters/_template/bootstrap-kit/02-cert-manager.yaml
+++ b/clusters/_template/bootstrap-kit/02-cert-manager.yaml
@@ -31,7 +31,6 @@ metadata:
   namespace: flux-system
 spec:
   interval: 15m
-  timeout: 15m
   releaseName: cert-manager
   targetNamespace: cert-manager
   dependsOn:
@@ -44,10 +43,17 @@ spec:
         kind: HelmRepository
         name: bp-cert-manager
         namespace: flux-system
+  # Event-driven install: cert-manager installs CRDs + 3 deployments
+  # (controller, webhook, cainjector). Webhook readiness depends on the
+  # cainjector mutating the Secret — multi-minute path on cold start.
+  # Helm install completes when manifests apply; subsequent dependsOn
+  # checks Ready=True independently. Replaces PR #221 spec.timeout: 15m.
   install:
+    disableWait: true
     remediation:
       retries: 3
   upgrade:
+    disableWait: true
     remediation:
       retries: 3
   values:

--- a/clusters/_template/bootstrap-kit/03-flux.yaml
+++ b/clusters/_template/bootstrap-kit/03-flux.yaml
@@ -52,7 +52,6 @@ metadata:
   namespace: flux-system
 spec:
   interval: 15m
-  timeout: 15m
   releaseName: flux
   targetNamespace: flux-system
   dependsOn:
@@ -65,7 +64,12 @@ spec:
         kind: HelmRepository
         name: bp-flux
         namespace: flux-system
+  # Event-driven install: bp-flux adopts the cloud-init-installed Flux
+  # controllers; the helm-controller pod that reconciles THIS HR is itself
+  # a target of the chart, so blocking on Ready=True is structurally
+  # impossible. disableWait avoids the deadlock. Replaces PR #221 timeout.
   install:
+    disableWait: true
     # Adopt cloud-init-installed Flux objects rather than fail on
     # ownership conflict (the objects exist before the HelmRelease ever
     # reconciles). Without this, the very first reconcile would error
@@ -73,6 +77,7 @@ spec:
     remediation:
       retries: 3
   upgrade:
+    disableWait: true
     # Keep operator-supplied values (e.g. resource overrides applied via
     # helm-controller out-of-band, or dry-run patches during incident
     # response) on chart upgrades. Without this, every upgrade would

--- a/clusters/_template/bootstrap-kit/05-sealed-secrets.yaml
+++ b/clusters/_template/bootstrap-kit/05-sealed-secrets.yaml
@@ -27,7 +27,6 @@ metadata:
   namespace: flux-system
 spec:
   interval: 15m
-  timeout: 15m
   releaseName: sealed-secrets
   targetNamespace: kube-system
   dependsOn:
@@ -40,9 +39,13 @@ spec:
         kind: HelmRepository
         name: bp-sealed-secrets
         namespace: flux-system
+  # Event-driven install: single-replica controller + CRD; install
+  # completes when manifests apply. Replaces PR #221 spec.timeout: 15m.
   install:
+    disableWait: true
     remediation:
       retries: 3
   upgrade:
+    disableWait: true
     remediation:
       retries: 3

--- a/clusters/_template/bootstrap-kit/06-spire.yaml
+++ b/clusters/_template/bootstrap-kit/06-spire.yaml
@@ -31,7 +31,6 @@ metadata:
   namespace: flux-system
 spec:
   interval: 15m
-  timeout: 15m
   releaseName: spire
   targetNamespace: spire-system
   dependsOn:
@@ -39,14 +38,23 @@ spec:
   chart:
     spec:
       chart: bp-spire
-      version: 1.1.3
+      version: 1.1.4
       sourceRef:
         kind: HelmRepository
         name: bp-spire
         namespace: flux-system
+  # Event-driven install: Helm completes when manifests apply, not when
+  # pods reach Ready. spire-server StatefulSet has a multi-minute Ready
+  # path (controller-manager waits for CRD informer cache sync, which is
+  # itself triggered by the spire-crds subchart's CRD install). Flux's
+  # `dependsOn` on downstream HRs (bp-nats-jetstream, bp-openbao) checks
+  # Ready=True on this HR independently, so disableWait is the correct
+  # shape — replaces the blanket spec.timeout: 15m band-aid from PR #221.
   install:
+    disableWait: true
     remediation:
       retries: 3
   upgrade:
+    disableWait: true
     remediation:
       retries: 3

--- a/clusters/_template/bootstrap-kit/07-nats-jetstream.yaml
+++ b/clusters/_template/bootstrap-kit/07-nats-jetstream.yaml
@@ -31,7 +31,6 @@ metadata:
   namespace: flux-system
 spec:
   interval: 15m
-  timeout: 15m
   releaseName: nats-jetstream
   targetNamespace: nats-system
   dependsOn:
@@ -44,9 +43,15 @@ spec:
         kind: HelmRepository
         name: bp-nats-jetstream
         namespace: flux-system
+  # Event-driven install: NATS StatefulSet with JetStream raft initialisation
+  # — quorum formation across N replicas is legitimately multi-minute on
+  # cold start. Helm install completes when manifests apply; downstream
+  # dependsOn checks Ready=True independently. Replaces PR #221 timeout.
   install:
+    disableWait: true
     remediation:
       retries: 3
   upgrade:
+    disableWait: true
     remediation:
       retries: 3

--- a/clusters/_template/bootstrap-kit/08-openbao.yaml
+++ b/clusters/_template/bootstrap-kit/08-openbao.yaml
@@ -31,7 +31,6 @@ metadata:
   namespace: flux-system
 spec:
   interval: 15m
-  timeout: 15m
   releaseName: openbao
   targetNamespace: openbao
   dependsOn:
@@ -44,9 +43,16 @@ spec:
         kind: HelmRepository
         name: bp-openbao
         namespace: flux-system
+  # Event-driven install: OpenBao 3-node Raft cluster requires manual
+  # unseal via `bao operator init` — pods stay sealed (Ready=False) until
+  # an operator runs the unseal flow. Blocking Helm install on Ready=True
+  # is structurally wrong for a sealed-by-default secret backend.
+  # Replaces PR #221 spec.timeout: 15m.
   install:
+    disableWait: true
     remediation:
       retries: 3
   upgrade:
+    disableWait: true
     remediation:
       retries: 3

--- a/clusters/_template/bootstrap-kit/09-keycloak.yaml
+++ b/clusters/_template/bootstrap-kit/09-keycloak.yaml
@@ -31,7 +31,6 @@ metadata:
   namespace: flux-system
 spec:
   interval: 15m
-  timeout: 15m
   releaseName: keycloak
   targetNamespace: keycloak
   dependsOn:
@@ -44,9 +43,16 @@ spec:
         kind: HelmRepository
         name: bp-keycloak
         namespace: flux-system
+  # Event-driven install: Keycloak DB schema migration + realm import is
+  # legitimately multi-minute on first install (PostgreSQL backend +
+  # 100+ Liquibase changesets). Helm install completes when manifests
+  # apply; downstream dependsOn checks Ready=True independently.
+  # Replaces PR #221 spec.timeout: 15m.
   install:
+    disableWait: true
     remediation:
       retries: 3
   upgrade:
+    disableWait: true
     remediation:
       retries: 3

--- a/clusters/_template/bootstrap-kit/10-gitea.yaml
+++ b/clusters/_template/bootstrap-kit/10-gitea.yaml
@@ -32,7 +32,6 @@ metadata:
   namespace: flux-system
 spec:
   interval: 15m
-  timeout: 15m
   releaseName: gitea
   targetNamespace: gitea
   dependsOn:
@@ -45,10 +44,16 @@ spec:
         kind: HelmRepository
         name: bp-gitea
         namespace: flux-system
+  # Event-driven install: Gitea PostgreSQL DB init + admin user creation +
+  # public Blueprint catalog mirror seeding is legitimately multi-minute.
+  # Helm install completes when manifests apply; downstream dependsOn
+  # checks Ready=True independently. Replaces PR #221 spec.timeout: 15m.
   install:
+    disableWait: true
     remediation:
       retries: 3
   upgrade:
+    disableWait: true
     remediation:
       retries: 3
   values:

--- a/clusters/_template/bootstrap-kit/12-external-dns.yaml
+++ b/clusters/_template/bootstrap-kit/12-external-dns.yaml
@@ -42,7 +42,6 @@ metadata:
   namespace: flux-system
 spec:
   interval: 15m
-  timeout: 15m
   releaseName: external-dns
   targetNamespace: external-dns
   dependsOn:
@@ -56,10 +55,17 @@ spec:
         kind: HelmRepository
         name: bp-external-dns
         namespace: flux-system
+  # Event-driven install: ExternalDNS pod readiness depends on a
+  # successful initial reconcile against the per-Sovereign PowerDNS API
+  # (which itself stabilises after pdns-pg CNPG bootstraps) — legitimate
+  # slow-Ready cascade. Helm install completes when manifests apply.
+  # Replaces PR #221 spec.timeout: 15m.
   install:
+    disableWait: true
     remediation:
       retries: 3
   upgrade:
+    disableWait: true
     remediation:
       retries: 3
   # Per-Sovereign overrides — txtOwnerId MUST be the Sovereign FQDN so two

--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -36,7 +36,6 @@ metadata:
   namespace: flux-system
 spec:
   interval: 15m
-  timeout: 15m
   releaseName: catalyst-platform
   targetNamespace: catalyst-system
   dependsOn:
@@ -49,10 +48,17 @@ spec:
         kind: HelmRepository
         name: bp-catalyst-platform
         namespace: flux-system
+  # Event-driven install: umbrella chart deploys ~10 Catalyst services
+  # (console, marketplace, admin, catalog-svc, projector, provisioning,
+  # environment-controller, blueprint-controller, billing). Inter-service
+  # readiness via OTel/NATS subjects is multi-minute and not Helm's
+  # concern. Replaces PR #221 spec.timeout: 15m.
   install:
+    disableWait: true
     remediation:
       retries: 3
   upgrade:
+    disableWait: true
     remediation:
       retries: 3
   # Per-Sovereign overrides for the umbrella — sovereign-FQDN-derived hostnames

--- a/clusters/otech.omani.works/bootstrap-kit/01-cilium.yaml
+++ b/clusters/otech.omani.works/bootstrap-kit/01-cilium.yaml
@@ -31,7 +31,6 @@ metadata:
   namespace: flux-system
 spec:
   interval: 15m
-  timeout: 15m
   releaseName: cilium
   targetNamespace: kube-system
   chart:
@@ -42,10 +41,16 @@ spec:
         kind: HelmRepository
         name: bp-cilium
         namespace: flux-system
+  # Event-driven install: Helm completes when manifests apply, not when
+  # cilium-agent reaches Ready (agent waits for envoyconfig CRDs that the
+  # SAME chart installs — legitimate slow-Ready). Replaces blanket
+  # spec.timeout: 15m band-aid from PR #221.
   install:
+    disableWait: true
     remediation:
       retries: 3
   upgrade:
+    disableWait: true
     remediation:
       retries: 3
   values:

--- a/clusters/otech.omani.works/bootstrap-kit/02-cert-manager.yaml
+++ b/clusters/otech.omani.works/bootstrap-kit/02-cert-manager.yaml
@@ -31,7 +31,6 @@ metadata:
   namespace: flux-system
 spec:
   interval: 15m
-  timeout: 15m
   releaseName: cert-manager
   targetNamespace: cert-manager
   dependsOn:
@@ -44,10 +43,17 @@ spec:
         kind: HelmRepository
         name: bp-cert-manager
         namespace: flux-system
+  # Event-driven install: cert-manager installs CRDs + 3 deployments
+  # (controller, webhook, cainjector). Webhook readiness depends on the
+  # cainjector mutating the Secret — multi-minute path on cold start.
+  # Helm install completes when manifests apply; subsequent dependsOn
+  # checks Ready=True independently. Replaces PR #221 spec.timeout: 15m.
   install:
+    disableWait: true
     remediation:
       retries: 3
   upgrade:
+    disableWait: true
     remediation:
       retries: 3
   values:

--- a/clusters/otech.omani.works/bootstrap-kit/03-flux.yaml
+++ b/clusters/otech.omani.works/bootstrap-kit/03-flux.yaml
@@ -52,7 +52,6 @@ metadata:
   namespace: flux-system
 spec:
   interval: 15m
-  timeout: 15m
   releaseName: flux
   targetNamespace: flux-system
   dependsOn:
@@ -65,7 +64,12 @@ spec:
         kind: HelmRepository
         name: bp-flux
         namespace: flux-system
+  # Event-driven install: bp-flux adopts the cloud-init-installed Flux
+  # controllers; the helm-controller pod that reconciles THIS HR is itself
+  # a target of the chart, so blocking on Ready=True is structurally
+  # impossible. disableWait avoids the deadlock. Replaces PR #221 timeout.
   install:
+    disableWait: true
     # Adopt cloud-init-installed Flux objects rather than fail on
     # ownership conflict (the objects exist before the HelmRelease ever
     # reconciles). Without this, the very first reconcile would error
@@ -73,6 +77,7 @@ spec:
     remediation:
       retries: 3
   upgrade:
+    disableWait: true
     # Keep operator-supplied values (e.g. resource overrides applied via
     # helm-controller out-of-band, or dry-run patches during incident
     # response) on chart upgrades. Without this, every upgrade would

--- a/clusters/otech.omani.works/bootstrap-kit/05-sealed-secrets.yaml
+++ b/clusters/otech.omani.works/bootstrap-kit/05-sealed-secrets.yaml
@@ -27,7 +27,6 @@ metadata:
   namespace: flux-system
 spec:
   interval: 15m
-  timeout: 15m
   releaseName: sealed-secrets
   targetNamespace: kube-system
   dependsOn:
@@ -40,9 +39,13 @@ spec:
         kind: HelmRepository
         name: bp-sealed-secrets
         namespace: flux-system
+  # Event-driven install: single-replica controller + CRD; install
+  # completes when manifests apply. Replaces PR #221 spec.timeout: 15m.
   install:
+    disableWait: true
     remediation:
       retries: 3
   upgrade:
+    disableWait: true
     remediation:
       retries: 3

--- a/clusters/otech.omani.works/bootstrap-kit/06-spire.yaml
+++ b/clusters/otech.omani.works/bootstrap-kit/06-spire.yaml
@@ -31,7 +31,6 @@ metadata:
   namespace: flux-system
 spec:
   interval: 15m
-  timeout: 15m
   releaseName: spire
   targetNamespace: spire-system
   dependsOn:
@@ -39,14 +38,23 @@ spec:
   chart:
     spec:
       chart: bp-spire
-      version: 1.1.3
+      version: 1.1.4
       sourceRef:
         kind: HelmRepository
         name: bp-spire
         namespace: flux-system
+  # Event-driven install: Helm completes when manifests apply, not when
+  # pods reach Ready. spire-server StatefulSet has a multi-minute Ready
+  # path (controller-manager waits for CRD informer cache sync, which is
+  # itself triggered by the spire-crds subchart's CRD install). Flux's
+  # `dependsOn` on downstream HRs (bp-nats-jetstream, bp-openbao) checks
+  # Ready=True on this HR independently, so disableWait is the correct
+  # shape — replaces the blanket spec.timeout: 15m band-aid from PR #221.
   install:
+    disableWait: true
     remediation:
       retries: 3
   upgrade:
+    disableWait: true
     remediation:
       retries: 3

--- a/clusters/otech.omani.works/bootstrap-kit/07-nats-jetstream.yaml
+++ b/clusters/otech.omani.works/bootstrap-kit/07-nats-jetstream.yaml
@@ -31,7 +31,6 @@ metadata:
   namespace: flux-system
 spec:
   interval: 15m
-  timeout: 15m
   releaseName: nats-jetstream
   targetNamespace: nats-system
   dependsOn:
@@ -44,9 +43,15 @@ spec:
         kind: HelmRepository
         name: bp-nats-jetstream
         namespace: flux-system
+  # Event-driven install: NATS StatefulSet with JetStream raft initialisation
+  # — quorum formation across N replicas is legitimately multi-minute on
+  # cold start. Helm install completes when manifests apply; downstream
+  # dependsOn checks Ready=True independently. Replaces PR #221 timeout.
   install:
+    disableWait: true
     remediation:
       retries: 3
   upgrade:
+    disableWait: true
     remediation:
       retries: 3

--- a/clusters/otech.omani.works/bootstrap-kit/08-openbao.yaml
+++ b/clusters/otech.omani.works/bootstrap-kit/08-openbao.yaml
@@ -31,7 +31,6 @@ metadata:
   namespace: flux-system
 spec:
   interval: 15m
-  timeout: 15m
   releaseName: openbao
   targetNamespace: openbao
   dependsOn:
@@ -44,9 +43,16 @@ spec:
         kind: HelmRepository
         name: bp-openbao
         namespace: flux-system
+  # Event-driven install: OpenBao 3-node Raft cluster requires manual
+  # unseal via `bao operator init` — pods stay sealed (Ready=False) until
+  # an operator runs the unseal flow. Blocking Helm install on Ready=True
+  # is structurally wrong for a sealed-by-default secret backend.
+  # Replaces PR #221 spec.timeout: 15m.
   install:
+    disableWait: true
     remediation:
       retries: 3
   upgrade:
+    disableWait: true
     remediation:
       retries: 3

--- a/clusters/otech.omani.works/bootstrap-kit/09-keycloak.yaml
+++ b/clusters/otech.omani.works/bootstrap-kit/09-keycloak.yaml
@@ -31,7 +31,6 @@ metadata:
   namespace: flux-system
 spec:
   interval: 15m
-  timeout: 15m
   releaseName: keycloak
   targetNamespace: keycloak
   dependsOn:
@@ -44,9 +43,16 @@ spec:
         kind: HelmRepository
         name: bp-keycloak
         namespace: flux-system
+  # Event-driven install: Keycloak DB schema migration + realm import is
+  # legitimately multi-minute on first install (PostgreSQL backend +
+  # 100+ Liquibase changesets). Helm install completes when manifests
+  # apply; downstream dependsOn checks Ready=True independently.
+  # Replaces PR #221 spec.timeout: 15m.
   install:
+    disableWait: true
     remediation:
       retries: 3
   upgrade:
+    disableWait: true
     remediation:
       retries: 3

--- a/clusters/otech.omani.works/bootstrap-kit/10-gitea.yaml
+++ b/clusters/otech.omani.works/bootstrap-kit/10-gitea.yaml
@@ -32,7 +32,6 @@ metadata:
   namespace: flux-system
 spec:
   interval: 15m
-  timeout: 15m
   releaseName: gitea
   targetNamespace: gitea
   dependsOn:
@@ -45,10 +44,16 @@ spec:
         kind: HelmRepository
         name: bp-gitea
         namespace: flux-system
+  # Event-driven install: Gitea PostgreSQL DB init + admin user creation +
+  # public Blueprint catalog mirror seeding is legitimately multi-minute.
+  # Helm install completes when manifests apply; downstream dependsOn
+  # checks Ready=True independently. Replaces PR #221 spec.timeout: 15m.
   install:
+    disableWait: true
     remediation:
       retries: 3
   upgrade:
+    disableWait: true
     remediation:
       retries: 3
   values:

--- a/clusters/otech.omani.works/bootstrap-kit/12-external-dns.yaml
+++ b/clusters/otech.omani.works/bootstrap-kit/12-external-dns.yaml
@@ -42,7 +42,6 @@ metadata:
   namespace: flux-system
 spec:
   interval: 15m
-  timeout: 15m
   releaseName: external-dns
   targetNamespace: external-dns
   dependsOn:
@@ -56,10 +55,17 @@ spec:
         kind: HelmRepository
         name: bp-external-dns
         namespace: flux-system
+  # Event-driven install: ExternalDNS pod readiness depends on a
+  # successful initial reconcile against the per-Sovereign PowerDNS API
+  # (which itself stabilises after pdns-pg CNPG bootstraps) — legitimate
+  # slow-Ready cascade. Helm install completes when manifests apply.
+  # Replaces PR #221 spec.timeout: 15m.
   install:
+    disableWait: true
     remediation:
       retries: 3
   upgrade:
+    disableWait: true
     remediation:
       retries: 3
   # Per-Sovereign overrides — txtOwnerId MUST be the Sovereign FQDN so two

--- a/clusters/otech.omani.works/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/otech.omani.works/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -36,7 +36,6 @@ metadata:
   namespace: flux-system
 spec:
   interval: 15m
-  timeout: 15m
   releaseName: catalyst-platform
   targetNamespace: catalyst-system
   dependsOn:
@@ -49,10 +48,17 @@ spec:
         kind: HelmRepository
         name: bp-catalyst-platform
         namespace: flux-system
+  # Event-driven install: umbrella chart deploys ~10 Catalyst services
+  # (console, marketplace, admin, catalog-svc, projector, provisioning,
+  # environment-controller, blueprint-controller, billing). Inter-service
+  # readiness via OTel/NATS subjects is multi-minute and not Helm's
+  # concern. Replaces PR #221 spec.timeout: 15m.
   install:
+    disableWait: true
     remediation:
       retries: 3
   upgrade:
+    disableWait: true
     remediation:
       retries: 3
   # Per-Sovereign overrides for the umbrella — sovereign-FQDN-derived hostnames

--- a/platform/spire/blueprint.yaml
+++ b/platform/spire/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
 spec:
-  version: 1.1.3
+  version: 1.1.4
   card:
     title: spire
     summary: SPIFFE/SPIRE workload identity. 5-min rotating SVIDs. Server on mgt cluster + agent per host cluster.

--- a/platform/spire/chart/Chart.yaml
+++ b/platform/spire/chart/Chart.yaml
@@ -1,11 +1,11 @@
 apiVersion: v2
 name: bp-spire
-version: 1.1.3
+version: 1.1.4
 description: |
   Catalyst-curated Blueprint umbrella chart for SPIRE. Depends on the
-  upstream `spire` chart (spiffe.github.io/helm-charts-hardened) as a Helm
-  subchart so `helm dependency build` pulls the upstream payload into this
-  artifact; the Catalyst overlay templates in templates/ (NetworkPolicy,
+  upstream `spire-crds` and `spire` charts (spiffe.github.io/helm-charts-hardened)
+  as Helm subcharts so `helm dependency build` pulls the upstream payload into
+  this artifact; the Catalyst overlay templates in templates/ (NetworkPolicy,
   ExternalSecret, ServiceMonitor) sit alongside the upstream subchart and
   Helm renders both at install time. Catalyst-curated values flow into the
   upstream subchart under the `spire:` key in values.yaml.
@@ -15,12 +15,28 @@ maintainers:
   - name: OpenOva Catalyst
     email: catalyst@openova.io
 
-# Upstream chart pulled in as a Helm subchart so `helm dependency build`
-# bundles it into the OCI artifact. Pinned to spiffe/spire 0.21.0 (matches
-# platform/spire/blueprint.yaml + values.yaml `catalystBlueprint.upstream
-# .version`). Per docs/INVIOLABLE-PRINCIPLES.md #4 (never hardcode) the
-# version is operator-bumpable via PR + Blueprint release.
+# Upstream charts pulled in as Helm subcharts so `helm dependency build`
+# bundles them into the OCI artifact.
+#
+# 1.1.4 (2026-04-30): Added spire-crds 0.5.0 as the FIRST dependency.
+#   Root cause: the upstream `spire` chart does NOT install its own CRDs
+#   (ClusterSPIFFEID / ClusterStaticEntry / ClusterFederatedTrustDomain in
+#   spire.spiffe.io/v1alpha1). Without them registered, spire-controller-
+#   manager crash-loops with "failed to wait for clusterstaticentry caches
+#   to sync: timed out waiting for cache to be synced for Kind
+#   *v1alpha1.ClusterStaticEntry" — observed live on otech.omani.works
+#   (36 restarts, HR Ready=False). Helm installs subcharts in dependency
+#   order, so listing spire-crds first guarantees the CRDs are applied
+#   before the spire subchart's controller-manager Deployment starts.
+#
+# Pinned to spire 0.21.0 + spire-crds 0.5.0 (matches the upstream pairing
+# documented at https://artifacthub.io/packages/helm/spiffe/spire-crds).
+# Per docs/INVIOLABLE-PRINCIPLES.md #4 (never hardcode) the versions are
+# operator-bumpable via PR + Blueprint release.
 dependencies:
+  - name: spire-crds
+    version: "0.5.0"
+    repository: "https://spiffe.github.io/helm-charts-hardened"
   - name: spire
     version: "0.21.0"
     repository: "https://spiffe.github.io/helm-charts-hardened"


### PR DESCRIPTION
## Summary

Founder direction (verbatim): **"always event driven robust jobs"**

Drop the blanket `spec.timeout: 15m` watchdogs added by [PR #221](https://github.com/openova-io/openova/pull/221) on every bootstrap-kit HelmRelease. They were a band-aid that caused cascading HR failures when a slow-Ready workload exceeded 15m: the HR went `Ready=False`, downstream HRs with `dependsOn` never started, and the whole bootstrap stalled.

Helm install completes when the manifests are applied to the API server, **not** when pods reach `Ready`. Flux's `dependsOn` already polls `Ready=True` on each HR independently — so the right shape for slow-Ready workloads is `spec.install.disableWait: true` + `spec.upgrade.disableWait: true`.

Plus a chart fix for the live `bp-spire@1.1.3` failure on `otech.omani.works`: bump to `1.1.4` adding `spire-crds` as a Helm subchart dependency (root cause analysis below).

## HR-by-HR audit

| # | HR | Decision | Reason |
|---|---|---|---|
| 01 | `bp-cilium` | drop timeout, add disableWait | envoyconfig CRD self-wait — agent crash-loops until its own CRDs land |
| 02 | `bp-cert-manager` | drop timeout, add disableWait | webhook readiness depends on cainjector mutating Secret — multi-minute on cold start |
| 03 | `bp-flux` | drop timeout, add disableWait | adopts cloud-init Flux objects; the helm-controller reconciling THIS HR is itself a chart target — Ready deadlock without disableWait |
| 04 | `bp-crossplane` | **untouched** | Agent A owns the chart split for intra-chart CRD-ordering |
| 05 | `bp-sealed-secrets` | drop timeout, add disableWait | single-replica controller + CRD — install completes on manifest apply |
| 06 | `bp-spire` | drop timeout + add disableWait + **chart fix 1.1.3 -> 1.1.4** | CRDs missing root cause (see below) |
| 07 | `bp-nats-jetstream` | drop timeout, add disableWait | JetStream raft quorum formation across N replicas |
| 08 | `bp-openbao` | drop timeout, add disableWait | 3-node Raft sealed-by-default; `Ready=True` only after operator runs `bao operator init` unseal flow |
| 09 | `bp-keycloak` | drop timeout, add disableWait | DB schema migration + 100+ Liquibase changesets on first install |
| 10 | `bp-gitea` | drop timeout, add disableWait | PostgreSQL DB init + admin user + Blueprint catalog mirror seeding |
| 11 | `bp-powerdns` | **untouched** | Agent D owns the post-install hook for intra-chart Job-ordering |
| 12 | `bp-external-dns` | drop timeout, add disableWait | pod readiness depends on PowerDNS API + pdns-pg CNPG cascade |
| 13 | `bp-catalyst-platform` | drop timeout, add disableWait | umbrella ~10 services; inter-service NATS/OTel readiness is not Helm's concern |

11 of 13 HRs converted to event-driven. Both `_template/bootstrap-kit/` and `otech.omani.works/bootstrap-kit/` mirrored.

## bp-spire root-cause investigation

Live state on `otech.omani.works` at PR open time (5h since first reconcile):

```
spire-server-0   1/2  Error  37 (cycling)
spire-spiffe-oidc-discovery-provider-...  0/1  Init:0/1
HelmRelease bp-spire   Ready=False  context deadline exceeded
HelmRelease bp-nats-jetstream  Ready=False  dependency 'bp-spire' is not ready
HelmRelease bp-openbao         Ready=False  dependency 'bp-spire' is not ready
```

`spire-controller-manager` log (definitive):

```
ERROR setup problem running manager
  {"error": "failed to wait for clusterstaticentry caches to sync:
   timed out waiting for cache to be synced for Kind
   *v1alpha1.ClusterStaticEntry"}
```

`kubectl get crd | grep spire` returns **nothing**. The `spire.spiffe.io/v1alpha1` CRDs (`ClusterSPIFFEID`, `ClusterStaticEntry`, `ClusterFederatedTrustDomain`) are not registered.

**Why**: the upstream `spire` chart does not install its own CRDs. Per the spiffe maintainers, CRDs ship via the **separate `spire-crds` chart** (https://artifacthub.io/packages/helm/spiffe/spire-crds), which must be installed first. Our `bp-spire@1.1.3` Chart.yaml only depended on `spire`, so the CRDs never landed.

**Fix**: `platform/spire/chart/Chart.yaml` now declares `spire-crds 0.5.0` as the FIRST `dependencies:` entry. Helm installs subcharts in dependency order, so CRDs are applied before the `spire` subchart's controller-manager Deployment starts. `helm dependency build` (run by `.github/workflows/blueprint-release.yaml`) bundles both subcharts into the OCI artifact.

Version bumps: `Chart.yaml` 1.1.3 -> 1.1.4 + `blueprint.yaml` 1.1.3 -> 1.1.4 + both `06-spire.yaml` cluster references 1.1.3 -> 1.1.4.

## Test plan

- [x] All modified YAMLs validate via `python3 -c "yaml.safe_load_all(...)"` (24/24 OK)
- [x] Spot-checked HRs validate server-side via `kubectl apply --dry-run=server` against live otech (06-spire, 03-flux, 13-catalyst-platform — all `configured (server dry run)`)
- [ ] CI: `blueprint-release.yaml` workflow builds + signs `bp-spire:1.1.4` OCI artifact (auto-triggered by changes under `platform/spire/chart/**`)
- [ ] After bp-spire:1.1.4 is published: Flux on otech.omani.works reconciles the new HR; `kubectl get crd | grep spire` returns the 3 v1alpha1 CRDs; `spire-controller-manager` stops crash-looping; `bp-spire` HR goes `Ready=True`; downstream `bp-nats-jetstream` + `bp-openbao` un-stick

## Coordinated PRs in flight (per parent dispatch session)

- Agent A: `bp-crossplane` chart split for CRD ordering (different files)
- Agent B: `bp-catalyst-platform` Kustomization fix (different files)
- Agent D: `bp-powerdns` post-install hook (different files)

No file-level conflicts expected with sibling PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)