### PR TITLE
fix(provisioner): cloud-init bootstrap-kit path matches per-FQDN cluster dir (resolves #218)

### DIFF
--- a/clusters/_template/bootstrap-kit/02-cert-manager.yaml
+++ b/clusters/_template/bootstrap-kit/02-cert-manager.yaml
@@ -10,7 +10,7 @@ kind: Namespace
 metadata:
   name: cert-manager
   labels:
-    catalyst.openova.io/sovereign: SOVEREIGN_FQDN_PLACEHOLDER
+    catalyst.openova.io/sovereign: ${SOVEREIGN_FQDN}
 ---
 apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: HelmRepository

--- a/clusters/_template/bootstrap-kit/03-flux.yaml
+++ b/clusters/_template/bootstrap-kit/03-flux.yaml
@@ -31,7 +31,7 @@ kind: Namespace
 metadata:
   name: flux-system
   labels:
-    catalyst.openova.io/sovereign: SOVEREIGN_FQDN_PLACEHOLDER
+    catalyst.openova.io/sovereign: ${SOVEREIGN_FQDN}
 ---
 apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: HelmRepository

--- a/clusters/_template/bootstrap-kit/04-crossplane.yaml
+++ b/clusters/_template/bootstrap-kit/04-crossplane.yaml
@@ -10,7 +10,7 @@ kind: Namespace
 metadata:
   name: crossplane-system
   labels:
-    catalyst.openova.io/sovereign: SOVEREIGN_FQDN_PLACEHOLDER
+    catalyst.openova.io/sovereign: ${SOVEREIGN_FQDN}
 ---
 apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: HelmRepository

--- a/clusters/_template/bootstrap-kit/06-spire.yaml
+++ b/clusters/_template/bootstrap-kit/06-spire.yaml
@@ -10,7 +10,7 @@ kind: Namespace
 metadata:
   name: spire-system
   labels:
-    catalyst.openova.io/sovereign: SOVEREIGN_FQDN_PLACEHOLDER
+    catalyst.openova.io/sovereign: ${SOVEREIGN_FQDN}
 ---
 apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: HelmRepository

--- a/clusters/_template/bootstrap-kit/07-nats-jetstream.yaml
+++ b/clusters/_template/bootstrap-kit/07-nats-jetstream.yaml
@@ -10,7 +10,7 @@ kind: Namespace
 metadata:
   name: nats-system
   labels:
-    catalyst.openova.io/sovereign: SOVEREIGN_FQDN_PLACEHOLDER
+    catalyst.openova.io/sovereign: ${SOVEREIGN_FQDN}
 ---
 apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: HelmRepository

--- a/clusters/_template/bootstrap-kit/08-openbao.yaml
+++ b/clusters/_template/bootstrap-kit/08-openbao.yaml
@@ -10,7 +10,7 @@ kind: Namespace
 metadata:
   name: openbao
   labels:
-    catalyst.openova.io/sovereign: SOVEREIGN_FQDN_PLACEHOLDER
+    catalyst.openova.io/sovereign: ${SOVEREIGN_FQDN}
 ---
 apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: HelmRepository

--- a/clusters/_template/bootstrap-kit/09-keycloak.yaml
+++ b/clusters/_template/bootstrap-kit/09-keycloak.yaml
@@ -10,7 +10,7 @@ kind: Namespace
 metadata:
   name: keycloak
   labels:
-    catalyst.openova.io/sovereign: SOVEREIGN_FQDN_PLACEHOLDER
+    catalyst.openova.io/sovereign: ${SOVEREIGN_FQDN}
 ---
 apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: HelmRepository

--- a/clusters/_template/bootstrap-kit/10-gitea.yaml
+++ b/clusters/_template/bootstrap-kit/10-gitea.yaml
@@ -11,7 +11,7 @@ kind: Namespace
 metadata:
   name: gitea
   labels:
-    catalyst.openova.io/sovereign: SOVEREIGN_FQDN_PLACEHOLDER
+    catalyst.openova.io/sovereign: ${SOVEREIGN_FQDN}
 ---
 apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: HelmRepository
@@ -58,12 +58,12 @@ spec:
       retries: 3
   values:
     global:
-      sovereignFQDN: SOVEREIGN_FQDN_PLACEHOLDER
-    # gitea hostname is gitea.SOVEREIGN_FQDN_PLACEHOLDER. The DNS A record
+      sovereignFQDN: ${SOVEREIGN_FQDN}
+    # gitea hostname is gitea.${SOVEREIGN_FQDN}. The DNS A record
     # was already published by the Phase-0 catalyst-dns helper.
     ingress:
       hosts:
-        - host: gitea.SOVEREIGN_FQDN_PLACEHOLDER
+        - host: gitea.${SOVEREIGN_FQDN}
           paths:
             - path: /
               pathType: Prefix

--- a/clusters/_template/bootstrap-kit/11-powerdns.yaml
+++ b/clusters/_template/bootstrap-kit/11-powerdns.yaml
@@ -51,7 +51,7 @@ kind: Namespace
 metadata:
   name: powerdns
   labels:
-    catalyst.openova.io/sovereign: SOVEREIGN_FQDN_PLACEHOLDER
+    catalyst.openova.io/sovereign: ${SOVEREIGN_FQDN}
 ---
 apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: HelmRepository

--- a/clusters/_template/bootstrap-kit/12-external-dns.yaml
+++ b/clusters/_template/bootstrap-kit/12-external-dns.yaml
@@ -21,7 +21,7 @@ kind: Namespace
 metadata:
   name: external-dns
   labels:
-    catalyst.openova.io/sovereign: SOVEREIGN_FQDN_PLACEHOLDER
+    catalyst.openova.io/sovereign: ${SOVEREIGN_FQDN}
 ---
 apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: HelmRepository
@@ -74,7 +74,7 @@ spec:
   # cluster overlays patch this with the actual zone list.
   values:
     external-dns:
-      txtOwnerId: SOVEREIGN_FQDN_PLACEHOLDER
+      txtOwnerId: ${SOVEREIGN_FQDN}
       txtPrefix: _externaldns.
       domainFilters:
-        - SOVEREIGN_FQDN_PLACEHOLDER
+        - ${SOVEREIGN_FQDN}

--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -5,7 +5,7 @@
 #
 # Per docs/ARCHITECTURE.md §11 (Catalyst-on-Catalyst): once this is Ready,
 # the Sovereign is fully self-sufficient — sovereign-admin can log into
-# console.SOVEREIGN_FQDN_PLACEHOLDER and proceed with Phase 2 day-1 setup.
+# console.${SOVEREIGN_FQDN} and proceed with Phase 2 day-1 setup.
 #
 # Wrapper chart: products/catalyst/chart/
 
@@ -15,7 +15,7 @@ kind: Namespace
 metadata:
   name: catalyst-system
   labels:
-    catalyst.openova.io/sovereign: SOVEREIGN_FQDN_PLACEHOLDER
+    catalyst.openova.io/sovereign: ${SOVEREIGN_FQDN}
 ---
 apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: HelmRepository
@@ -66,14 +66,14 @@ spec:
   # OTel endpoints, NATS subjects) lives in products/catalyst/chart/values.yaml.
   values:
     global:
-      sovereignFQDN: SOVEREIGN_FQDN_PLACEHOLDER
+      sovereignFQDN: ${SOVEREIGN_FQDN}
     ingress:
       hosts:
         console:
-          host: console.SOVEREIGN_FQDN_PLACEHOLDER
+          host: console.${SOVEREIGN_FQDN}
         admin:
-          host: admin.SOVEREIGN_FQDN_PLACEHOLDER
+          host: admin.${SOVEREIGN_FQDN}
         marketplace:
-          host: SOVEREIGN_FQDN_PLACEHOLDER
+          host: ${SOVEREIGN_FQDN}
         api:
-          host: api.SOVEREIGN_FQDN_PLACEHOLDER
+          host: api.${SOVEREIGN_FQDN}

--- a/clusters/_template/kustomization.yaml
+++ b/clusters/_template/kustomization.yaml
@@ -1,10 +1,19 @@
-# Per-Sovereign Flux Kustomization root.
+# Shared Sovereign Flux Kustomization root.
 #
-# Copied from clusters/_template/ → clusters/<sovereign-fqdn>/ at provisioning
-# time, with SOVEREIGN_FQDN_PLACEHOLDER substituted. The Sovereign's k3s
-# control plane (cloud-init bootstrap) installs Flux core, then applies a
-# GitRepository pointing at this Sovereign's directory. From there Flux owns
-# everything.
+# Issue #218: this directory is the canonical bootstrap tree for EVERY
+# Sovereign. The Sovereign's FQDN is interpolated into the manifests at
+# Flux apply time via the cloud-init Kustomization's
+# `postBuild.substitute.SOVEREIGN_FQDN` envsubst hook (see
+# infra/hetzner/cloudinit-control-plane.tftpl). No per-Sovereign copy
+# of this tree is committed to the repo before provisioning.
+#
+# The Sovereign's k3s control plane (cloud-init bootstrap) installs
+# Flux core, then applies a GitRepository selecting this _template
+# tree (`!/clusters/_template`) plus two Kustomizations whose `path`
+# fields point at `clusters/_template/bootstrap-kit` and
+# `clusters/_template/infrastructure`. Flux's envsubst replaces
+# `${SOVEREIGN_FQDN}` in the rendered manifests with the Sovereign's
+# FQDN. From there Flux owns everything.
 
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/infra/hetzner/cloudinit-control-plane.tftpl
+++ b/infra/hetzner/cloudinit-control-plane.tftpl
@@ -6,11 +6,15 @@
 # This script:
 #   1. Installs OS hardening (SSH password-auth off, fail2ban, unattended-upgrades).
 #   2. Installs k3s with --flannel-backend=none (Cilium replaces it).
-#   3. Installs Flux + bootstraps the GitRepository pointing at clusters/${sovereign_fqdn}/
-#      in the public OpenOva monorepo. From this point Flux is the GitOps
-#      reconciler and installs the 11-component bootstrap kit
-#      (Cilium → cert-manager → Crossplane → ... → bp-catalyst-platform) in
-#      dependency order via Kustomizations the cluster directory ships.
+#   3. Installs Flux + bootstraps the GitRepository pointing at the shared
+#      clusters/_template/ tree in the public OpenOva monorepo. The
+#      Sovereign's FQDN is interpolated into the template manifests via
+#      Flux postBuild.substitute (${SOVEREIGN_FQDN}) at apply time, so
+#      no per-Sovereign directory needs to be committed before
+#      provisioning. From this point Flux is the GitOps reconciler and
+#      installs the 11-component bootstrap kit (Cilium → cert-manager →
+#      Crossplane → ... → bp-catalyst-platform) in dependency order via
+#      Kustomizations the _template directory ships.
 #   4. Touches /var/lib/catalyst/cloud-init-complete so the catalyst-api
 #      provisioner can detect cloud-init has finished.
 
@@ -116,7 +120,7 @@ write_files:
 
   # ── flux-system/ghcr-pull Secret ─────────────────────────────────────
   #
-  # Every HelmRepository CR in clusters/${sovereign_fqdn}/bootstrap-kit/
+  # Every HelmRepository CR in clusters/_template/bootstrap-kit/
   # references `secretRef: name: ghcr-pull` because the bp-* OCI artifacts
   # at `ghcr.io/openova-io/` are PRIVATE. Without this Secret, the
   # source-controller logs:
@@ -157,10 +161,29 @@ write_files:
           }
         }))}
 
-  # Flux GitRepository + Kustomization that take over after k3s is up.
-  # The clusters/${sovereign_fqdn}/ directory in the public OpenOva monorepo
-  # contains a Kustomization tree that installs the 11-component bootstrap
-  # kit + bp-catalyst-platform umbrella in dependency order.
+  # Flux GitRepository + Kustomizations that take over after k3s is up.
+  #
+  # ── Per-Sovereign tree vs. shared _template (issue #218) ─────────────
+  #
+  # Earlier revisions of this template selected a per-FQDN cluster tree
+  # (`!/clusters/${sovereign_fqdn}`) and pointed the Kustomization
+  # `spec.path` at `./clusters/${sovereign_fqdn}/bootstrap-kit`. That
+  # required a per-Sovereign directory to be committed to the public
+  # openova repo BEFORE provisioning, which the wizard does NOT do —
+  # only `clusters/_template/` is canonical. Result on every fresh
+  # Sovereign was Phase-1 stall:
+  #   kustomization path not found:
+  #     stat /tmp/kustomization-…/clusters/<fqdn>/bootstrap-kit:
+  #     no such file or directory
+  # (live evidence: otech.omani.works deployment ce476aaf80731a46.)
+  #
+  # Canonical fix: GitRepository selects the shared `_template/` tree,
+  # Kustomization paths point at `clusters/_template/{bootstrap-kit,
+  # infrastructure}`, and Flux's `postBuild.substitute` interpolates
+  # `${SOVEREIGN_FQDN}` into the template manifests at apply time. The
+  # per-FQDN copy that prior provisioning depended on becomes a no-op:
+  # one shared tree serves every Sovereign, with the Sovereign's FQDN
+  # injected by Flux on the cluster instead of by sed in the repo.
   - path: /var/lib/catalyst/flux-bootstrap.yaml
     permissions: '0644'
     content: |
@@ -176,7 +199,7 @@ write_files:
           branch: ${gitops_branch}
         ignore: |
           /*
-          !/clusters/${sovereign_fqdn}
+          !/clusters/_template
           !/platform
           !/products
       ---
@@ -198,6 +221,12 @@ write_files:
       # Kustomization model tripped over with:
       #   no matches for kind "ProviderConfig" in version
       #   "hcloud.crossplane.io/v1beta1"
+      #
+      # postBuild.substitute (issue #218): Flux's envsubst runs over the
+      # rendered manifests after kustomize build, replacing ${SOVEREIGN_FQDN}
+      # with the Sovereign's FQDN that this cloud-init was rendered for.
+      # The template manifests in clusters/_template/bootstrap-kit/*.yaml
+      # use ${SOVEREIGN_FQDN} as the substitution token.
       apiVersion: kustomize.toolkit.fluxcd.io/v1
       kind: Kustomization
       metadata:
@@ -205,13 +234,16 @@ write_files:
         namespace: flux-system
       spec:
         interval: 5m
-        path: ./clusters/${sovereign_fqdn}/bootstrap-kit
+        path: ./clusters/_template/bootstrap-kit
         prune: true
         sourceRef:
           kind: GitRepository
           name: openova
         wait: true
         timeout: 30m
+        postBuild:
+          substitute:
+            SOVEREIGN_FQDN: ${sovereign_fqdn}
       ---
       apiVersion: kustomize.toolkit.fluxcd.io/v1
       kind: Kustomization
@@ -220,7 +252,7 @@ write_files:
         namespace: flux-system
       spec:
         interval: 5m
-        path: ./clusters/${sovereign_fqdn}/infrastructure
+        path: ./clusters/_template/infrastructure
         prune: true
         sourceRef:
           kind: GitRepository
@@ -229,6 +261,9 @@ write_files:
           - name: bootstrap-kit
         wait: true
         timeout: 30m
+        postBuild:
+          substitute:
+            SOVEREIGN_FQDN: ${sovereign_fqdn}
 
 runcmd:
   - swapoff -a
@@ -385,7 +420,8 @@ runcmd:
   - 'kubectl --kubeconfig=/etc/rancher/k3s/k3s.yaml -n kube-system rollout status ds/cilium --timeout=240s'
 
   # Install Flux core. Cilium is now the cluster's CNI, so Flux pods will
-  # actually start. Flux then reconciles clusters/${sovereign_fqdn}/ which
+  # actually start. Flux then reconciles clusters/_template/ (with
+  # SOVEREIGN_FQDN substituted via postBuild — issue #218) which
   # adopts the Helm release above as bp-cilium and continues with
   # bp-cert-manager, bp-flux (which ADOPTS this Flux install rather than
   # reinstalls — see version-pin invariant below), bp-crossplane, etc.
@@ -431,7 +467,8 @@ runcmd:
   - 'kubectl --kubeconfig=/etc/rancher/k3s/k3s.yaml apply -f /var/lib/catalyst/ghcr-pull-secret.yaml'
 
   # Apply the Flux bootstrap GitRepository + Kustomization. From here, Flux
-  # owns the cluster: pulls clusters/${sovereign_fqdn}/, installs Cilium
+  # owns the cluster: pulls clusters/_template/ (with ${SOVEREIGN_FQDN}
+  # substituted to ${sovereign_fqdn} via postBuild), installs Cilium
   # via bp-cilium, cert-manager via bp-cert-manager, etc., then bp-catalyst-platform.
   - 'kubectl --kubeconfig=/etc/rancher/k3s/k3s.yaml apply -f /var/lib/catalyst/flux-bootstrap.yaml'
 
@@ -439,4 +476,4 @@ runcmd:
   - mkdir -p /var/lib/catalyst
   - touch /var/lib/catalyst/cloud-init-complete
 
-final_message: "Catalyst control-plane bootstrap complete after $UPTIME seconds — Flux is now reconciling clusters/${sovereign_fqdn}/"
+final_message: "Catalyst control-plane bootstrap complete after $UPTIME seconds — Flux is now reconciling clusters/_template/ for ${sovereign_fqdn}"

--- a/products/catalyst/bootstrap/api/internal/provisioner/cloudinit_path_test.go
+++ b/products/catalyst/bootstrap/api/internal/provisioner/cloudinit_path_test.go
@@ -1,0 +1,188 @@
+// cloudinit_path_test.go — locks the bootstrap-kit Flux Kustomization
+// path against per-FQDN-directory regression (issue #218).
+//
+// Issue #218 (P0): every fresh Sovereign provision failed Phase-1
+// because the cloud-init template selected a per-FQDN tree
+// (`!/clusters/${sovereign_fqdn}`) and pointed the bootstrap-kit
+// Kustomization at `./clusters/${sovereign_fqdn}/bootstrap-kit` — a
+// directory that was NEVER committed before provisioning. Flux on
+// the new cluster reconciled with:
+//
+//	stat /tmp/kustomization-…/clusters/<fqdn>/bootstrap-kit:
+//	  no such file or directory
+//
+// Canonical fix: GitRepository selects `!/clusters/_template`,
+// Kustomization paths point at `clusters/_template/{bootstrap-kit,
+// infrastructure}`, and Flux's `postBuild.substitute.SOVEREIGN_FQDN`
+// interpolates the Sovereign's FQDN into the template manifests at
+// apply time.
+//
+// These tests pin every part of that fix. A regression that re-
+// introduces per-FQDN paths into the cloud-init template lands here
+// as a test failure, NOT as a stalled Phase-1 on a customer's first
+// Sovereign.
+package provisioner
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// modulePath resolves the canonical OpenTofu module directory from the
+// test binary's CWD. The provisioner package lives at
+// products/catalyst/bootstrap/api/internal/provisioner, so the module
+// is six directories up. We resolve via filepath.Abs to keep the test
+// stable when `go test` runs in different working directories
+// (toolchain default is the package dir).
+func modulePath(t *testing.T) string {
+	t.Helper()
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	// products/catalyst/bootstrap/api/internal/provisioner → repo root
+	repoRoot := filepath.Clean(filepath.Join(cwd, "..", "..", "..", "..", "..", ".."))
+	return filepath.Join(repoRoot, "infra", "hetzner")
+}
+
+// readCloudInit reads the canonical cloud-init control-plane template
+// from infra/hetzner/cloudinit-control-plane.tftpl.
+func readCloudInit(t *testing.T) string {
+	t.Helper()
+	p := filepath.Join(modulePath(t), "cloudinit-control-plane.tftpl")
+	raw, err := os.ReadFile(p)
+	if err != nil {
+		t.Fatalf("read %s: %v", p, err)
+	}
+	return string(raw)
+}
+
+// TestCloudInit_GitRepositoryIgnoreSelectsTemplate proves the
+// GitRepository's `spec.ignore` selects the shared `clusters/_template`
+// tree, NOT a per-FQDN directory. Issue #218's failure mode was the
+// `!/clusters/${sovereign_fqdn}` selector which referenced a
+// directory that no provisioning step ever creates.
+func TestCloudInit_GitRepositoryIgnoreSelectsTemplate(t *testing.T) {
+	tpl := readCloudInit(t)
+
+	if !strings.Contains(tpl, "!/clusters/_template") {
+		t.Errorf("GitRepository.spec.ignore must include `!/clusters/_template` to select the shared template tree")
+	}
+	// The per-FQDN selector that issue #218 identified as the root
+	// cause must NOT reappear in operative YAML. A regression here
+	// would silently send every fresh Sovereign back to the original
+	// failure mode. The pre-fix line was bare in the YAML
+	// `ignore:` block (no leading `#`); the per-issue-218 commit
+	// retains a comment that quotes the old form for context. Scope
+	// the check to non-comment lines so the explanatory text is
+	// allowed.
+	for i, line := range strings.Split(tpl, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		if strings.Contains(line, "!/clusters/${sovereign_fqdn}") {
+			t.Errorf("line %d carries per-FQDN selector `!/clusters/${sovereign_fqdn}` outside a comment — issue #218 regression:\n  %s", i+1, line)
+		}
+	}
+}
+
+// TestCloudInit_BootstrapKitPathPointsAtTemplate proves the
+// bootstrap-kit Kustomization's `spec.path` is the shared
+// `./clusters/_template/bootstrap-kit` directory, not a per-FQDN
+// path that doesn't exist before provisioning runs.
+func TestCloudInit_BootstrapKitPathPointsAtTemplate(t *testing.T) {
+	tpl := readCloudInit(t)
+
+	const want = "path: ./clusters/_template/bootstrap-kit"
+	if !strings.Contains(tpl, want) {
+		t.Errorf("bootstrap-kit Kustomization.spec.path must be %q (was missing — issue #218 fix not in place)", want)
+	}
+	// Per-FQDN regression guard: the pre-fix path string was
+	// `./clusters/${sovereign_fqdn}/bootstrap-kit` and produced
+	//   stat /tmp/kustomization-…/clusters/<fqdn>/bootstrap-kit:
+	//     no such file or directory
+	// on every provision. Lock it out.
+	const banned = "path: ./clusters/${sovereign_fqdn}/bootstrap-kit"
+	if strings.Contains(tpl, banned) {
+		t.Errorf("bootstrap-kit Kustomization.spec.path must NOT be per-FQDN %q (issue #218 regression)", banned)
+	}
+}
+
+// TestCloudInit_InfrastructurePathPointsAtTemplate is the sibling
+// guard for the second Kustomization (infrastructure-config) which
+// installs Provider + ProviderConfig + Compositions and depends on
+// bootstrap-kit. Same shape, same regression class.
+func TestCloudInit_InfrastructurePathPointsAtTemplate(t *testing.T) {
+	tpl := readCloudInit(t)
+
+	const want = "path: ./clusters/_template/infrastructure"
+	if !strings.Contains(tpl, want) {
+		t.Errorf("infrastructure-config Kustomization.spec.path must be %q (was missing — issue #218 fix not in place)", want)
+	}
+	const banned = "path: ./clusters/${sovereign_fqdn}/infrastructure"
+	if strings.Contains(tpl, banned) {
+		t.Errorf("infrastructure-config Kustomization.spec.path must NOT be per-FQDN %q (issue #218 regression)", banned)
+	}
+}
+
+// TestCloudInit_PostBuildSubstituteFQDN proves both Kustomizations
+// declare a `postBuild.substitute.SOVEREIGN_FQDN: ${sovereign_fqdn}`
+// hook, which is what makes the shared template tree usable per-
+// Sovereign. Without this hook the manifests would render with the
+// literal `${SOVEREIGN_FQDN}` placeholder in label values, ingress
+// hostnames, and HelmRelease values — producing pods labelled
+// `catalyst.openova.io/sovereign=${SOVEREIGN_FQDN}` instead of the
+// actual FQDN, and console/admin/api ingress hostnames pointing at
+// `${SOVEREIGN_FQDN}` instead of the real DNS records.
+func TestCloudInit_PostBuildSubstituteFQDN(t *testing.T) {
+	tpl := readCloudInit(t)
+
+	// Cheap structural check: the substitute key must appear with the
+	// correct envsubst-style RHS that pulls the FQDN from the
+	// rendered cloud-init context. The `${sovereign_fqdn}` form is
+	// the OpenTofu template variable; OpenTofu interpolates it
+	// before the cloud-init userdata leaves the catalyst-api Pod.
+	const want = "SOVEREIGN_FQDN: ${sovereign_fqdn}"
+	if !strings.Contains(tpl, want) {
+		t.Errorf("Flux Kustomization postBuild.substitute must include %q so ${SOVEREIGN_FQDN} placeholders in clusters/_template render correctly (issue #218)", want)
+	}
+
+	// Both Kustomizations need the substitute, not just one. The
+	// presence-count is a defence against a partial-fix regression
+	// where one Kustomization gets the postBuild and the other
+	// doesn't (which would manifest as infrastructure-config
+	// rendering provider-hcloud manifests with literal
+	// `${SOVEREIGN_FQDN}` in labels).
+	count := strings.Count(tpl, want)
+	if count < 2 {
+		t.Errorf("expected SOVEREIGN_FQDN substitute on BOTH Kustomizations (got %d occurrences, want ≥2 — issue #218 partial-fix regression)", count)
+	}
+}
+
+// TestCloudInit_NoPerFQDNPathReferences is the catch-all regression
+// guard: NO substring of the form `clusters/${sovereign_fqdn}`
+// appears as an actual Flux resource path/ignore selector anywhere
+// in the rendered cloud-init template. Comments are out-of-scope
+// (we may legitimately reference the prior shape in the
+// "issue #218" explanatory comment), but operative YAML keys
+// (`path:`, `ignore:`) MUST NOT carry that string.
+func TestCloudInit_NoPerFQDNPathReferences(t *testing.T) {
+	tpl := readCloudInit(t)
+
+	// Walk lines; flag any line that is operative YAML (not a
+	// pure-comment line whose first non-whitespace char is `#`)
+	// and contains `clusters/${sovereign_fqdn}`.
+	for i, line := range strings.Split(tpl, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "#") {
+			continue // comment — explanatory references are fine
+		}
+		if !strings.Contains(line, "clusters/${sovereign_fqdn}") {
+			continue
+		}
+		t.Errorf("line %d carries per-FQDN path `clusters/${sovereign_fqdn}` outside a comment — issue #218 regression:\n  %s", i+1, line)
+	}
+}


### PR DESCRIPTION
## Summary

P0: every fresh Sovereign provision stalled Phase-1 because the cloud-init template selected a per-FQDN GitRepository tree and pointed Flux Kustomizations at `clusters/<sovereign-fqdn>/{bootstrap-kit,infrastructure}` — directories the wizard never commits before provisioning. Canonical fix: select the shared `clusters/_template` tree and use `postBuild.substitute.SOVEREIGN_FQDN` to interpolate the per-Sovereign FQDN at apply time.

Closes #218

## Root cause

`infra/hetzner/cloudinit-control-plane.tftpl` rendered:

```yaml
GitRepository.spec.ignore: |
  /*
  !/clusters/${sovereign_fqdn}     # tree never created before provisioning
  !/platform
  !/products

Kustomization (bootstrap-kit).spec.path: ./clusters/${sovereign_fqdn}/bootstrap-kit
Kustomization (infrastructure-config).spec.path: ./clusters/${sovereign_fqdn}/infrastructure
```

Live failure on otech.omani.works deployment ce476aaf80731a46:

```
kustomization.kustomize.toolkit.fluxcd.io/bootstrap-kit  False
  message: kustomization path not found:
    stat /tmp/kustomization-2608026033/clusters/otech.omani.works/bootstrap-kit:
    no such file or directory
```

PR #217 temporarily unblocked otech by committing `clusters/otech.omani.works/` as a sed-substituted copy of `_template`. This PR is the canonical fix; once it lands the per-Sovereign directories become unnecessary.

## Reproduction trace (read-only on otech)

```
$ ssh -i /tmp/omantel-test-key root@178.104.211.206 \
    "kubectl --kubeconfig=/etc/rancher/k3s/k3s.yaml -n flux-system get gitrepository,kustomization -o yaml | grep -A2 'path:|ignore:'"
  spec:
    ignore: |
      /*
      !/clusters/otech.omani.works
  ...
    path: ./clusters/otech.omani.works/bootstrap-kit
  ...
    path: ./clusters/otech.omani.works/infrastructure
```

Both per-FQDN strings are present on the live cluster — exactly as issue #218 described. Phase-1 was unblocked only after #217 seeded the directory; without that, the cluster would still be stuck.

## Fix

### `infra/hetzner/cloudinit-control-plane.tftpl`

**Before:**
```yaml
ignore: |
  /*
  !/clusters/${sovereign_fqdn}
  !/platform
  !/products
...
spec:
  path: ./clusters/${sovereign_fqdn}/bootstrap-kit
  ...
spec:
  path: ./clusters/${sovereign_fqdn}/infrastructure
```

**After:**
```yaml
ignore: |
  /*
  !/clusters/_template
  !/platform
  !/products
...
spec:
  path: ./clusters/_template/bootstrap-kit
  ...
  postBuild:
    substitute:
      SOVEREIGN_FQDN: ${sovereign_fqdn}
---
spec:
  path: ./clusters/_template/infrastructure
  ...
  postBuild:
    substitute:
      SOVEREIGN_FQDN: ${sovereign_fqdn}
```

### `clusters/_template/bootstrap-kit/*.yaml`

Bare `SOVEREIGN_FQDN_PLACEHOLDER` markers (which Flux's envsubst-based postBuild can NOT replace) are switched to `${SOVEREIGN_FQDN}` so the substitute hook actually fires. 12 manifest files touched: cert-manager, flux, crossplane, spire, nats-jetstream, openbao, keycloak, gitea, powerdns, external-dns, bp-catalyst-platform, plus the cluster-root `kustomization.yaml` comment.

## Unit test that locks the fix

`products/catalyst/bootstrap/api/internal/provisioner/cloudinit_path_test.go` — 5 tests that read the rendered template:

| Test | Asserts |
|---|---|
| `TestCloudInit_GitRepositoryIgnoreSelectsTemplate` | `!/clusters/_template` is present; `!/clusters/${sovereign_fqdn}` is NOT in operative YAML |
| `TestCloudInit_BootstrapKitPathPointsAtTemplate` | bootstrap-kit `path:` is `./clusters/_template/bootstrap-kit`; per-FQDN form banned |
| `TestCloudInit_InfrastructurePathPointsAtTemplate` | infrastructure-config `path:` is `./clusters/_template/infrastructure`; per-FQDN form banned |
| `TestCloudInit_PostBuildSubstituteFQDN` | `SOVEREIGN_FQDN: ${sovereign_fqdn}` appears at least twice (both Kustomizations) |
| `TestCloudInit_NoPerFQDNPathReferences` | no operative-YAML line carries `clusters/${sovereign_fqdn}` |

All 5 pass; the existing 12 provisioner tests continue to pass.

```
$ go test ./internal/provisioner/... -run TestCloudInit -v
=== RUN   TestCloudInit_GitRepositoryIgnoreSelectsTemplate
--- PASS: TestCloudInit_GitRepositoryIgnoreSelectsTemplate (0.00s)
=== RUN   TestCloudInit_BootstrapKitPathPointsAtTemplate
--- PASS: TestCloudInit_BootstrapKitPathPointsAtTemplate (0.00s)
=== RUN   TestCloudInit_InfrastructurePathPointsAtTemplate
--- PASS: TestCloudInit_InfrastructurePathPointsAtTemplate (0.00s)
=== RUN   TestCloudInit_PostBuildSubstituteFQDN
--- PASS: TestCloudInit_PostBuildSubstituteFQDN (0.00s)
=== RUN   TestCloudInit_NoPerFQDNPathReferences
--- PASS: TestCloudInit_NoPerFQDNPathReferences (0.00s)
PASS
ok  	.../internal/provisioner	0.012s
```

## Test plan

- [x] Tests pass: `go test ./products/catalyst/bootstrap/api/internal/provisioner/...`
- [x] Read-only verification on otech.omani.works confirms the bug shape (per-FQDN paths in live Flux objects)
- [ ] Next fresh provision exercises the fix end-to-end (no per-Sovereign directory needed)
- [ ] After the next fresh provision Ready=True on bootstrap-kit, the temporary `clusters/otech.omani.works/` (#217) and `clusters/omantel.omani.works/` directories can be removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)