### PR TITLE
feat(scripts): bootstrap-kit dependency-graph audit script (W2.K0)

### DIFF
--- a/.github/workflows/test-bootstrap-kit.yaml
+++ b/.github/workflows/test-bootstrap-kit.yaml
@@ -13,6 +13,8 @@ on:
       - 'platform/**/blueprint.yaml'
       - 'platform/**/chart/**'
       - 'clusters/**'
+      - 'scripts/check-bootstrap-deps.sh'
+      - 'scripts/expected-bootstrap-deps.yaml'
       - '.github/workflows/test-bootstrap-kit.yaml'
     branches: [main]
   pull_request:
@@ -21,14 +23,39 @@ on:
       - 'platform/**/blueprint.yaml'
       - 'platform/**/chart/**'
       - 'clusters/**'
+      - 'scripts/check-bootstrap-deps.sh'
+      - 'scripts/expected-bootstrap-deps.yaml'
       - '.github/workflows/test-bootstrap-kit.yaml'
   workflow_dispatch:
 
 jobs:
+  dependency-graph-audit:
+    # Audit the bootstrap-kit dependency graph against the expected DAG declared
+    # in scripts/expected-bootstrap-deps.yaml. Mechanically verifies every HR's
+    # spec.dependsOn matches the design contract in
+    # docs/BOOTSTRAP-KIT-EXPANSION-PLAN.md §2 + §3, and detects cycles. Runs on
+    # every PR that touches a bootstrap-kit HR or the audit data files. Owned by
+    # W2.K0; consumed by W2.K1-K4 PRs to validate slot 15-48 additions.
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install yq
+        run: |
+          sudo wget -qO /usr/local/bin/yq \
+            https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
+          sudo chmod +x /usr/local/bin/yq
+          yq --version
+
+      - name: Run bootstrap-kit dependency audit
+        run: bash scripts/check-bootstrap-deps.sh
+
   manifest-validation:
     # Static-only validation: blueprint.yaml + chart Chart.yaml + clusters/_template
     # parsing + dependency order check. Runs on every push.
     runs-on: ubuntu-latest
+    needs: dependency-graph-audit
     defaults:
       run:
         working-directory: tests/e2e/bootstrap-kit

--- a/scripts/check-bootstrap-deps.sh
+++ b/scripts/check-bootstrap-deps.sh
@@ -1,0 +1,418 @@
+#!/usr/bin/env bash
+# check-bootstrap-deps.sh — bootstrap-kit dependency-graph audit (W2.K0).
+#
+# Authoritative spec: docs/BOOTSTRAP-KIT-EXPANSION-PLAN.md §2 + §3.
+#
+# What this does:
+#   1. Parses every clusters/_template/bootstrap-kit/*.yaml and extracts
+#      metadata.name + spec.dependsOn for the HelmRelease document(s).
+#   2. Compares the actual deps graph against the expected DAG declared in
+#      scripts/expected-bootstrap-deps.yaml.
+#   3. Fails (non-zero exit) on any drift: missing or extra edges, unknown HRs.
+#   4. Detects cycles: asserts no HR transitively depends on itself.
+#   5. On success, prints the rendered DAG as ASCII (per-tier topological view).
+#
+# Exit codes:
+#   0  — actual graph matches expected, no cycles, all present HRs validated
+#   1  — drift (missing/extra deps, unknown HR present, etc.)
+#   2  — cycle detected
+#   3  — input/parse/usage error
+#
+# Behaviour against an in-flight expansion (W2.K1..K4 staggered merges):
+#   HRs declared in expected-bootstrap-deps.yaml but not yet present on disk
+#   are reported as "deferred" (informational, not an error). HRs present on
+#   disk but not declared in expected-bootstrap-deps.yaml are an error — every
+#   new bootstrap-kit slot must update the expected file in the same PR.
+#
+# Usage:
+#   scripts/check-bootstrap-deps.sh
+#   scripts/check-bootstrap-deps.sh --kit-dir clusters/_template/bootstrap-kit \
+#                                   --expected scripts/expected-bootstrap-deps.yaml
+#
+# Dependencies: bash, yq (mikefarah, v4+), find, sort, awk.
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Defaults + arg parsing
+# ---------------------------------------------------------------------------
+
+# Resolve repo root from this script's location so the tool works from any cwd.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+KIT_DIR="${REPO_ROOT}/clusters/_template/bootstrap-kit"
+EXPECTED_FILE="${REPO_ROOT}/scripts/expected-bootstrap-deps.yaml"
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") [--kit-dir DIR] [--expected FILE]
+
+  --kit-dir DIR    Directory containing bootstrap-kit HR yaml files
+                   (default: ${KIT_DIR})
+  --expected FILE  Path to expected-DAG yaml data file
+                   (default: ${EXPECTED_FILE})
+  -h, --help       Show this message
+
+See docs/BOOTSTRAP-KIT-EXPANSION-PLAN.md §2 + §3 for the design contract.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --kit-dir)
+      KIT_DIR="$2"
+      shift 2
+      ;;
+    --expected)
+      EXPECTED_FILE="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "ERROR: unknown argument: $1" >&2
+      usage >&2
+      exit 3
+      ;;
+  esac
+done
+
+if ! command -v yq >/dev/null 2>&1; then
+  echo "ERROR: yq is required but not installed." >&2
+  echo "Install: wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 && chmod +x /usr/local/bin/yq" >&2
+  exit 3
+fi
+
+if [[ ! -d "${KIT_DIR}" ]]; then
+  echo "ERROR: kit directory does not exist: ${KIT_DIR}" >&2
+  exit 3
+fi
+if [[ ! -f "${EXPECTED_FILE}" ]]; then
+  echo "ERROR: expected DAG file does not exist: ${EXPECTED_FILE}" >&2
+  exit 3
+fi
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+# Print a coloured banner if stdout is a TTY; otherwise plain text.
+_banner() {
+  local title="$1"
+  if [[ -t 1 ]]; then
+    printf '\n\033[1;36m== %s ==\033[0m\n' "${title}"
+  else
+    printf '\n== %s ==\n' "${title}"
+  fi
+}
+
+_err() {
+  if [[ -t 2 ]]; then
+    printf '\033[1;31mERROR:\033[0m %s\n' "$*" >&2
+  else
+    printf 'ERROR: %s\n' "$*" >&2
+  fi
+}
+
+_warn() {
+  if [[ -t 1 ]]; then
+    printf '\033[1;33mWARN:\033[0m %s\n' "$*"
+  else
+    printf 'WARN: %s\n' "$*"
+  fi
+}
+
+_ok() {
+  if [[ -t 1 ]]; then
+    printf '\033[1;32mOK:\033[0m %s\n' "$*"
+  else
+    printf 'OK: %s\n' "$*"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Phase 1 — Parse expected DAG
+# ---------------------------------------------------------------------------
+
+_banner "Phase 1: parse expected DAG (${EXPECTED_FILE#"${REPO_ROOT}/"})"
+
+# Build two associative arrays:
+#   EXPECTED_DEPS[name]="dep1 dep2 ..."  (space-separated, sorted)
+#   EXPECTED_SLOT[name]="<int>"
+#   EXPECTED_WAVE[name]="<wave-tag>"
+declare -A EXPECTED_DEPS=()
+declare -A EXPECTED_SLOT=()
+declare -A EXPECTED_WAVE=()
+EXPECTED_NAMES=()
+
+# yq emits one record per line: "<slot>|<name>|<wave>|<dep1,dep2,...>"
+while IFS='|' read -r slot name wave deps_csv; do
+  [[ -z "${name}" ]] && continue
+  EXPECTED_NAMES+=("${name}")
+  EXPECTED_SLOT["${name}"]="${slot}"
+  EXPECTED_WAVE["${name}"]="${wave}"
+  if [[ -z "${deps_csv}" ]]; then
+    EXPECTED_DEPS["${name}"]=""
+  else
+    # Sort deps so set comparison is order-insensitive.
+    EXPECTED_DEPS["${name}"]="$(echo "${deps_csv}" | tr ',' '\n' | sort -u | tr '\n' ' ' | sed 's/ $//')"
+  fi
+done < <(
+  yq -r '
+    .slots[] |
+    [
+      (.slot | tostring),
+      .name,
+      .wave,
+      ((.depends_on // []) | join(","))
+    ] | join("|")
+  ' "${EXPECTED_FILE}"
+)
+
+if [[ ${#EXPECTED_NAMES[@]} -eq 0 ]]; then
+  _err "expected DAG file declared no slots (empty .slots[])"
+  exit 3
+fi
+
+echo "  Loaded ${#EXPECTED_NAMES[@]} expected HRs from ${EXPECTED_FILE#"${REPO_ROOT}/"}"
+
+# ---------------------------------------------------------------------------
+# Phase 2 — Parse actual HR files
+# ---------------------------------------------------------------------------
+
+_banner "Phase 2: parse actual HRs in ${KIT_DIR#"${REPO_ROOT}/"}"
+
+declare -A ACTUAL_DEPS=()
+declare -A ACTUAL_FILE=()
+ACTUAL_NAMES=()
+
+# Iterate in slot order to make the output deterministic.
+shopt -s nullglob
+HR_FILES=()
+while IFS= read -r f; do
+  HR_FILES+=("$f")
+done < <(find "${KIT_DIR}" -maxdepth 1 -type f -name '*.yaml' \
+           ! -name 'kustomization.yaml' | sort)
+shopt -u nullglob
+
+if [[ ${#HR_FILES[@]} -eq 0 ]]; then
+  _err "no HR yaml files found in ${KIT_DIR}"
+  exit 3
+fi
+
+for f in "${HR_FILES[@]}"; do
+  # Each file may contain multiple yaml documents (Namespace, HelmRepository,
+  # HelmRelease). Extract the HelmRelease document(s).
+  while IFS='|' read -r name deps_csv; do
+    [[ -z "${name}" ]] && continue
+    if [[ -n "${ACTUAL_DEPS[${name}]+x}" ]]; then
+      _err "duplicate HelmRelease name '${name}' (in ${f#"${REPO_ROOT}/"} and ${ACTUAL_FILE[${name}]})"
+      exit 3
+    fi
+    ACTUAL_NAMES+=("${name}")
+    ACTUAL_FILE["${name}"]="${f#"${REPO_ROOT}/"}"
+    if [[ -z "${deps_csv}" ]]; then
+      ACTUAL_DEPS["${name}"]=""
+    else
+      ACTUAL_DEPS["${name}"]="$(echo "${deps_csv}" | tr ',' '\n' | sort -u | tr '\n' ' ' | sed 's/ $//')"
+    fi
+  done < <(
+    yq -r '
+      select(.kind == "HelmRelease") |
+      [
+        .metadata.name,
+        ((.spec.dependsOn // []) | map(.name) | join(","))
+      ] | join("|")
+    ' "$f" 2>/dev/null || true
+  )
+done
+
+if [[ ${#ACTUAL_NAMES[@]} -eq 0 ]]; then
+  _err "no HelmRelease resources parsed from any file in ${KIT_DIR}"
+  exit 3
+fi
+
+echo "  Parsed ${#ACTUAL_NAMES[@]} HelmRelease(s) across ${#HR_FILES[@]} file(s)"
+
+# ---------------------------------------------------------------------------
+# Phase 3 — Compare actual vs expected (drift detection)
+# ---------------------------------------------------------------------------
+
+_banner "Phase 3: drift detection"
+
+DRIFT_COUNT=0
+DEFERRED_COUNT=0
+
+# 3a — every actual HR must be declared in expected, with matching deps.
+for name in "${ACTUAL_NAMES[@]}"; do
+  if [[ -z "${EXPECTED_DEPS[${name}]+x}" ]]; then
+    _err "HR '${name}' (file ${ACTUAL_FILE[${name}]}) is present on disk but NOT declared in ${EXPECTED_FILE#"${REPO_ROOT}/"}. Add it to the expected DAG."
+    DRIFT_COUNT=$((DRIFT_COUNT + 1))
+    continue
+  fi
+
+  exp="${EXPECTED_DEPS[${name}]}"
+  got="${ACTUAL_DEPS[${name}]}"
+
+  if [[ "${exp}" != "${got}" ]]; then
+    # Compute set differences for an actionable message.
+    missing=$(comm -23 <(echo "${exp}" | tr ' ' '\n' | sort -u) <(echo "${got}" | tr ' ' '\n' | sort -u) | tr '\n' ' ' | sed 's/ $//')
+    extra=$(  comm -13 <(echo "${exp}" | tr ' ' '\n' | sort -u) <(echo "${got}" | tr ' ' '\n' | sort -u) | tr '\n' ' ' | sed 's/ $//')
+    _err "HR '${name}' (file ${ACTUAL_FILE[${name}]}): dependsOn drift"
+    [[ -n "${missing// /}" ]] && echo "         missing edges (declared expected, NOT in HR): ${missing}" >&2
+    [[ -n "${extra// /}"   ]] && echo "         extra edges   (in HR, NOT declared expected):   ${extra}"   >&2
+    DRIFT_COUNT=$((DRIFT_COUNT + 1))
+  fi
+done
+
+# 3b — expected HRs not yet on disk are reported as deferred (info, not error).
+for name in "${EXPECTED_NAMES[@]}"; do
+  if [[ -z "${ACTUAL_DEPS[${name}]+x}" ]]; then
+    DEFERRED_COUNT=$((DEFERRED_COUNT + 1))
+    _warn "HR '${name}' (slot $(printf '%02d' "${EXPECTED_SLOT[${name}]}"), wave ${EXPECTED_WAVE[${name}]}) declared expected but not yet on disk — will be added by ${EXPECTED_WAVE[${name}]}"
+  fi
+done
+
+if [[ ${DRIFT_COUNT} -gt 0 ]]; then
+  echo "" >&2
+  _err "${DRIFT_COUNT} drift(s) detected. Reconcile HR files with ${EXPECTED_FILE#"${REPO_ROOT}/"} (or vice versa) and re-run."
+  exit 1
+fi
+
+_ok "no drift between actual HRs and expected DAG (${DEFERRED_COUNT} deferred)"
+
+# ---------------------------------------------------------------------------
+# Phase 4 — Cycle detection (Kahn's algorithm)
+# ---------------------------------------------------------------------------
+
+_banner "Phase 4: cycle detection"
+
+# We check the *expected* graph (since it's the authoritative DAG and is the
+# superset of what's currently on disk). A cycle in the expected graph is the
+# bug; any subset on disk inherits the property.
+declare -A INDEGREE=()
+for name in "${EXPECTED_NAMES[@]}"; do
+  INDEGREE["${name}"]=0
+done
+for name in "${EXPECTED_NAMES[@]}"; do
+  for dep in ${EXPECTED_DEPS[${name}]}; do
+    [[ -z "${dep}" ]] && continue
+    if [[ -z "${INDEGREE[${dep}]+x}" ]]; then
+      _err "HR '${name}' depends on unknown HR '${dep}' (not declared in expected DAG)"
+      exit 1
+    fi
+    INDEGREE["${name}"]=$((INDEGREE["${name}"] + 1))
+  done
+done
+
+# Kahn's algorithm: repeatedly drain zero-in-degree nodes.
+declare -a QUEUE=()
+declare -a TOPO_ORDER=()
+for name in "${EXPECTED_NAMES[@]}"; do
+  if [[ "${INDEGREE[${name}]}" -eq 0 ]]; then
+    QUEUE+=("${name}")
+  fi
+done
+
+while [[ ${#QUEUE[@]} -gt 0 ]]; do
+  current="${QUEUE[0]}"
+  QUEUE=("${QUEUE[@]:1}")
+  TOPO_ORDER+=("${current}")
+  # For each n that depends on current, decrement its indegree.
+  for name in "${EXPECTED_NAMES[@]}"; do
+    for dep in ${EXPECTED_DEPS[${name}]}; do
+      if [[ "${dep}" == "${current}" ]]; then
+        INDEGREE["${name}"]=$((INDEGREE["${name}"] - 1))
+        if [[ "${INDEGREE[${name}]}" -eq 0 ]]; then
+          QUEUE+=("${name}")
+        fi
+      fi
+    done
+  done
+done
+
+if [[ "${#TOPO_ORDER[@]}" -ne "${#EXPECTED_NAMES[@]}" ]]; then
+  _err "cycle detected in expected DAG"
+  echo "  Topo-ordered ${#TOPO_ORDER[@]} of ${#EXPECTED_NAMES[@]} HRs before stalling." >&2
+  echo "  Stalled HRs (transitively depend on themselves):" >&2
+  for name in "${EXPECTED_NAMES[@]}"; do
+    if [[ "${INDEGREE[${name}]}" -gt 0 ]]; then
+      echo "    - ${name} (remaining in-degree=${INDEGREE[${name}]})" >&2
+    fi
+  done
+  exit 2
+fi
+
+_ok "no cycles (${#EXPECTED_NAMES[@]} HRs topologically ordered)"
+
+# ---------------------------------------------------------------------------
+# Phase 5 — Render ASCII DAG (per-wave grouping, topological order within wave)
+# ---------------------------------------------------------------------------
+
+_banner "Phase 5: rendered DAG"
+
+cat <<EOF
+Bootstrap-kit dependency graph
+(authoritative spec: docs/BOOTSTRAP-KIT-EXPANSION-PLAN.md §2)
+
+Legend:
+  [P]  present on disk and validated
+  [.]  declared in expected DAG, deferred (file not yet added by W2.Kn)
+
+EOF
+
+# Group nodes by wave for the printout, in slot order.
+declare -A WAVE_HEADERS=(
+  ["present"]="Tier 0-4 — Foundation through Catalyst umbrella (post-PR-247 baseline)"
+  ["W2.K1"]="Tier 5    — Storage + DB (Wave 2 batch K1, slots 15-19)"
+  ["W2.K2"]="Tier 6    — Observability (Wave 2 batch K2, slots 20-26)"
+  ["W2.K3"]="Tier 7    — Security + policy (Wave 2 batch K3, slots 27-34)"
+  ["W2.K4"]="Tier 8+9  — Edge + apps + AI runtime (Wave 2 batch K4, slots 35-48)"
+)
+
+for wave in present W2.K1 W2.K2 W2.K3 W2.K4; do
+  echo "${WAVE_HEADERS[${wave}]}"
+  printf '%.0s-' {1..78}; echo
+  any=0
+  for name in "${EXPECTED_NAMES[@]}"; do
+    if [[ "${EXPECTED_WAVE[${name}]}" != "${wave}" ]]; then
+      continue
+    fi
+    any=1
+    if [[ -n "${ACTUAL_DEPS[${name}]+x}" ]]; then
+      marker="[P]"
+    else
+      marker="[.]"
+    fi
+    slot="$(printf '%02d' "${EXPECTED_SLOT[${name}]}")"
+    deps="${EXPECTED_DEPS[${name}]}"
+    if [[ -z "${deps}" ]]; then
+      printf '  %s slot %s  %-26s (root, no deps)\n' "${marker}" "${slot}" "${name}"
+    else
+      printf '  %s slot %s  %-26s <-- %s\n' "${marker}" "${slot}" "${name}" "${deps}"
+    fi
+  done
+  if [[ "${any}" -eq 0 ]]; then
+    echo "  (none)"
+  fi
+  echo ""
+done
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+
+_banner "Summary"
+present_count=${#ACTUAL_NAMES[@]}
+expected_count=${#EXPECTED_NAMES[@]}
+deferred_count=$((expected_count - present_count))
+echo "  Present on disk:       ${present_count}"
+echo "  Declared expected:     ${expected_count}"
+echo "  Deferred (W2.K1-K4):   ${deferred_count}"
+echo "  Drift:                 0"
+echo "  Cycles:                0"
+echo ""
+_ok "bootstrap-kit dependency graph audit PASSED"

--- a/scripts/expected-bootstrap-deps.yaml
+++ b/scripts/expected-bootstrap-deps.yaml
@@ -1,0 +1,228 @@
+# Expected dependency DAG for clusters/_template/bootstrap-kit/*.yaml
+#
+# Authoritative spec: docs/BOOTSTRAP-KIT-EXPANSION-PLAN.md §2.
+# Consumed by:        scripts/check-bootstrap-deps.sh
+# Updated by:         W2.K0 (slots 01-14 baseline + slots 15-48 forward declarations)
+#                     W2.K1, K2, K3, K4 PRs add the corresponding HR files; this
+#                     file already declares the expected deps for those slots so
+#                     each W2 PR can be mechanically verified at merge time.
+#
+# Schema:
+#   slots:
+#     - slot: <int>             # numeric prefix on the HR file (01..48)
+#       name: <string>          # value of metadata.name on the HelmRelease
+#       depends_on: [<string>]  # ordered or unordered; comparison is set-based
+#       wave: <"present"|"W2.K1"|"W2.K2"|"W2.K3"|"W2.K4">
+#
+# Comparison semantics enforced by check-bootstrap-deps.sh:
+#   - Each HR file present on disk MUST declare exactly the depends_on set listed
+#     here (missing edges -> error, extra edges -> error).
+#   - HRs declared here but not yet present on disk are reported as "deferred"
+#     (info, not an error) so that this file can be the static authoritative list
+#     while W2.K1..K4 land their HR files in series.
+#   - The graph is checked for cycles after merging declared+actual edges.
+#
+# The slot-numbering convention is documented in BOOTSTRAP-KIT-EXPANSION-PLAN.md §3.
+
+slots:
+  # ---- Tier 0-4: present today (post-PR-247 baseline) -----------------------
+  - slot: 1
+    name: bp-cilium
+    depends_on: []
+    wave: present
+  - slot: 2
+    name: bp-cert-manager
+    depends_on: [bp-cilium]
+    wave: present
+  - slot: 3
+    name: bp-flux
+    depends_on: [bp-cert-manager]
+    wave: present
+  - slot: 4
+    name: bp-crossplane
+    depends_on: [bp-flux]
+    wave: present
+  - slot: 5
+    name: bp-sealed-secrets
+    depends_on: [bp-cert-manager]
+    wave: present
+  - slot: 6
+    name: bp-spire
+    depends_on: [bp-cert-manager]
+    wave: present
+  - slot: 7
+    name: bp-nats-jetstream
+    depends_on: [bp-spire]
+    wave: present
+  - slot: 8
+    name: bp-openbao
+    depends_on: [bp-spire]
+    wave: present
+  - slot: 9
+    name: bp-keycloak
+    depends_on: [bp-cert-manager]
+    wave: present
+  - slot: 10
+    name: bp-gitea
+    depends_on: [bp-keycloak]
+    wave: present
+  - slot: 11
+    name: bp-powerdns
+    depends_on: [bp-cert-manager]
+    wave: present
+  - slot: 12
+    name: bp-external-dns
+    depends_on: [bp-cert-manager, bp-powerdns]
+    wave: present
+  - slot: 13
+    name: bp-catalyst-platform
+    depends_on: [bp-gitea]
+    wave: present
+  - slot: 14
+    name: bp-crossplane-claims
+    depends_on: [bp-crossplane]
+    wave: present
+
+  # ---- Tier 5: storage + DB (W2.K1, slots 15-19) ----------------------------
+  - slot: 15
+    name: bp-external-secrets
+    depends_on: [bp-openbao, bp-cert-manager]
+    wave: W2.K1
+  - slot: 16
+    name: bp-cnpg
+    depends_on: [bp-flux]
+    wave: W2.K1
+  - slot: 17
+    name: bp-valkey
+    depends_on: [bp-flux]
+    wave: W2.K1
+  - slot: 18
+    name: bp-seaweedfs
+    depends_on: [bp-flux, bp-cert-manager]
+    wave: W2.K1
+  - slot: 19
+    name: bp-harbor
+    depends_on: [bp-cnpg, bp-seaweedfs, bp-cert-manager]
+    wave: W2.K1
+
+  # ---- Tier 6: observability (W2.K2, slots 20-26) ---------------------------
+  - slot: 20
+    name: bp-opentelemetry
+    depends_on: [bp-cert-manager]
+    wave: W2.K2
+  - slot: 21
+    name: bp-alloy
+    depends_on: [bp-opentelemetry]
+    wave: W2.K2
+  - slot: 22
+    name: bp-loki
+    depends_on: [bp-seaweedfs]
+    wave: W2.K2
+  - slot: 23
+    name: bp-mimir
+    depends_on: [bp-seaweedfs]
+    wave: W2.K2
+  - slot: 24
+    name: bp-tempo
+    depends_on: [bp-seaweedfs]
+    wave: W2.K2
+  - slot: 25
+    name: bp-grafana
+    depends_on: [bp-cnpg, bp-loki, bp-mimir, bp-tempo, bp-keycloak]
+    wave: W2.K2
+  - slot: 26
+    name: bp-langfuse
+    depends_on: [bp-cnpg, bp-keycloak, bp-cert-manager]
+    wave: W2.K2
+
+  # ---- Tier 7: security + policy (W2.K3, slots 27-34) -----------------------
+  - slot: 27
+    name: bp-kyverno
+    depends_on: [bp-cilium]
+    wave: W2.K3
+  - slot: 28
+    name: bp-reloader
+    depends_on: []
+    wave: W2.K3
+  - slot: 29
+    name: bp-vpa
+    depends_on: []
+    wave: W2.K3
+  - slot: 30
+    name: bp-trivy
+    depends_on: [bp-cert-manager]
+    wave: W2.K3
+  - slot: 31
+    name: bp-falco
+    depends_on: [bp-cilium]
+    wave: W2.K3
+  - slot: 32
+    name: bp-sigstore
+    depends_on: [bp-cert-manager]
+    wave: W2.K3
+  - slot: 33
+    name: bp-syft-grype
+    depends_on: [bp-cert-manager]
+    wave: W2.K3
+  - slot: 34
+    name: bp-velero
+    depends_on: [bp-seaweedfs]
+    wave: W2.K3
+
+  # ---- Tier 8 + 9: edge + apps + AI runtime (W2.K4, slots 35-48) ------------
+  - slot: 35
+    name: bp-coraza
+    depends_on: [bp-cilium, bp-cert-manager]
+    wave: W2.K4
+  - slot: 36
+    name: bp-stunner
+    depends_on: [bp-cilium, bp-cert-manager]
+    wave: W2.K4
+  - slot: 37
+    name: bp-knative
+    depends_on: [bp-cert-manager]
+    wave: W2.K4
+  - slot: 38
+    name: bp-kserve
+    depends_on: [bp-knative]
+    wave: W2.K4
+  - slot: 39
+    name: bp-vllm
+    depends_on: [bp-kserve]
+    wave: W2.K4
+  - slot: 40
+    name: bp-llm-gateway
+    depends_on: [bp-cnpg, bp-keycloak]
+    wave: W2.K4
+  - slot: 41
+    name: bp-anthropic-adapter
+    depends_on: [bp-llm-gateway]
+    wave: W2.K4
+  - slot: 42
+    name: bp-bge
+    depends_on: [bp-cnpg]
+    wave: W2.K4
+  - slot: 43
+    name: bp-nemo-guardrails
+    depends_on: [bp-llm-gateway, bp-bge, bp-cnpg]
+    wave: W2.K4
+  - slot: 44
+    name: bp-temporal
+    depends_on: [bp-cnpg, bp-cert-manager]
+    wave: W2.K4
+  - slot: 45
+    name: bp-openmeter
+    depends_on: [bp-cnpg, bp-nats-jetstream]
+    wave: W2.K4
+  - slot: 46
+    name: bp-livekit
+    depends_on: [bp-stunner, bp-cert-manager]
+    wave: W2.K4
+  - slot: 47
+    name: bp-matrix
+    depends_on: [bp-cnpg, bp-keycloak, bp-cert-manager]
+    wave: W2.K4
+  - slot: 48
+    name: bp-librechat
+    depends_on: [bp-llm-gateway, bp-vllm, bp-bge, bp-keycloak]
+    wave: W2.K4


### PR DESCRIPTION
## Summary
Adds `scripts/check-bootstrap-deps.sh` + `scripts/expected-bootstrap-deps.yaml` and wires them into `.github/workflows/test-bootstrap-kit.yaml` as a new `dependency-graph-audit` job. Implements the **W2.K0** deliverable from [`docs/BOOTSTRAP-KIT-EXPANSION-PLAN.md` §2 + §3](https://github.com/openova-io/openova/blob/main/docs/BOOTSTRAP-KIT-EXPANSION-PLAN.md#2-dependency-graph-flux-dependson-semantics) so subsequent W2.K1-K4 PRs can mechanically verify their `dependsOn` declarations match the design contract.

## What the script does
1. Parses every `clusters/_template/bootstrap-kit/*.yaml` and extracts `metadata.name` + `spec.dependsOn` for HelmRelease documents.
2. Compares the actual graph against the expected DAG declared in `scripts/expected-bootstrap-deps.yaml` (the §2 spec, mirrored as a static authoritative list of all 48 slots).
3. Fails (exit 1) with an actionable message if any HR's deps are missing or extra.
4. Detects cycles via Kahn's algorithm (exit 2 if any HR transitively depends on itself).
5. On success, prints the rendered DAG as ASCII grouped per Wave 2 batch.

Exit codes: `0` clean, `1` drift, `2` cycle, `3` input error.

## Behaviour against the in-flight expansion
HRs declared in `expected-bootstrap-deps.yaml` but not yet present on disk are reported as **deferred** (informational, not an error). HRs present on disk but **not** declared in the expected file are an error — every new bootstrap-kit slot must update the expected file in the same PR.

This means:
- W2.K1 PR adds 5 HR files (slots 15-19); audit goes from "34 deferred" to "29 deferred"
- W2.K2 PR adds 7 HR files (slots 20-26); audit goes to "22 deferred"
- W2.K3 PR adds 8 HR files (slots 27-34); audit goes to "14 deferred"
- W2.K4 PR adds 14 HR files (slots 35-48); audit goes to **0 deferred — 100% green**

## How W2.K1-K4 PRs trigger this
The new job lives in the existing `test-bootstrap-kit.yaml` workflow with this path filter:
- `clusters/**` (any HR file)
- `scripts/check-bootstrap-deps.sh`
- `scripts/expected-bootstrap-deps.yaml`
- `.github/workflows/test-bootstrap-kit.yaml`

Every W2.Kn PR will touch `clusters/_template/bootstrap-kit/*.yaml`, so the audit runs automatically. `manifest-validation` and `kind-reconciliation` now `needs: dependency-graph-audit`, so a deps-graph drift fails the whole workflow before it spins up kind.

## Sample output (current 14 HRs on `main`)
```
== Phase 1: parse expected DAG (scripts/expected-bootstrap-deps.yaml) ==
  Loaded 48 expected HRs from scripts/expected-bootstrap-deps.yaml

== Phase 2: parse actual HRs in clusters/_template/bootstrap-kit ==
  Parsed 14 HelmRelease(s) across 14 file(s)

== Phase 3: drift detection ==
WARN: HR 'bp-external-secrets' (slot 15, wave W2.K1) declared expected but not yet on disk — will be added by W2.K1
... (33 more deferred warnings)
OK: no drift between actual HRs and expected DAG (34 deferred)

== Phase 4: cycle detection ==
OK: no cycles (48 HRs topologically ordered)

== Phase 5: rendered DAG ==
Tier 0-4 — Foundation through Catalyst umbrella (post-PR-247 baseline)
  [P] slot 01  bp-cilium                  (root, no deps)
  [P] slot 02  bp-cert-manager            <-- bp-cilium
  [P] slot 03  bp-flux                    <-- bp-cert-manager
  ...
  [P] slot 14  bp-crossplane-claims       <-- bp-crossplane

Tier 5    — Storage + DB (Wave 2 batch K1, slots 15-19)
  [.] slot 15  bp-external-secrets        <-- bp-cert-manager bp-openbao
  [.] slot 16  bp-cnpg                    <-- bp-flux
  ...
== Summary ==
  Present on disk:       14
  Declared expected:     48
  Deferred (W2.K1-K4):   34
  Drift:                 0
  Cycles:                0

OK: bootstrap-kit dependency graph audit PASSED
```

## Test plan
- [x] `bash scripts/check-bootstrap-deps.sh` exits 0 against current 14 HRs
- [x] `shellcheck scripts/check-bootstrap-deps.sh` clean
- [x] Synthetic drift case (modified expected file): exits 1 with actionable diff
- [x] Synthetic cycle case (a→b, b→a): exits 2 with stalled-HR list
- [ ] CI `dependency-graph-audit` job goes green on this PR
- [ ] After W2.K1 merges, audit drops from "34 deferred" to "29 deferred" with no manual intervention
- [ ] After all W2.K1-K4 merge, audit reports "0 deferred — drift 0 — cycles 0"

🤖 Generated with [Claude Code](https://claude.com/claude-code)