### PR TITLE
feat(bootstrap-kit): security+policy batch — slots 27-34 (W2.K3)

### DIFF
--- a/clusters/_template/bootstrap-kit/27-kyverno.yaml
+++ b/clusters/_template/bootstrap-kit/27-kyverno.yaml
@@ -1,0 +1,73 @@
+# bp-kyverno — Catalyst bootstrap-kit Blueprint #27 (W2.K3, Tier 7 — Security/Policy).
+# Kubernetes-native admission policy engine. Validating/mutating/generating
+# admission control via ClusterPolicy/Policy CRDs. HA mode with separate
+# admission/background/cleanup/reports controllers. The first guardrail
+# downstream Catalyst Apps land behind once the platform is bootstrapped.
+#
+# Wrapper chart: platform/kyverno/chart/ (umbrella over upstream
+# kyverno/kyverno chart, Catalyst-curated values under the `kyverno:` key).
+# Reconciled by: Flux on the new Sovereign's k3s control plane.
+#
+# dependsOn:
+#   - bp-cilium — Kyverno admission webhooks need a working CNI + Service
+#     mesh substrate to receive AdmissionReview requests from the apiserver.
+#     Cilium is the root of the Catalyst-Zero DAG; until it is Ready the
+#     apiserver→webhook path is not reachable and Kyverno install is racy.
+#
+# No further dependsOn: Kyverno installs its own CRDs and does not require
+# cert-manager (it auto-generates admission webhook TLS via its built-in
+# certificate controller).
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kyverno
+  labels:
+    catalyst.openova.io/sovereign: ${SOVEREIGN_FQDN}
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: bp-kyverno
+  namespace: flux-system
+spec:
+  type: oci
+  interval: 15m
+  url: oci://ghcr.io/openova-io
+  secretRef:
+    name: ghcr-pull
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: bp-kyverno
+  namespace: flux-system
+spec:
+  interval: 15m
+  releaseName: kyverno
+  targetNamespace: kyverno
+  dependsOn:
+    - name: bp-cilium
+  chart:
+    spec:
+      chart: bp-kyverno
+      version: 1.0.0
+      sourceRef:
+        kind: HelmRepository
+        name: bp-kyverno
+        namespace: flux-system
+  # Event-driven install: Kyverno HA mode brings up four controller
+  # Deployments (admission, background, cleanup, reports) plus the
+  # admission webhook TLS bootstrap. Pod Ready is multi-minute on a
+  # cold cluster; Helm `--wait` would hold the HR's Ready=True signal
+  # past the point where downstream HRs could legitimately reconcile.
+  # disableWait lets Flux mark this Ready as soon as manifests apply.
+  install:
+    disableWait: true
+    remediation:
+      retries: 3
+  upgrade:
+    disableWait: true
+    remediation:
+      retries: 3

--- a/clusters/_template/bootstrap-kit/28-reloader.yaml
+++ b/clusters/_template/bootstrap-kit/28-reloader.yaml
@@ -1,0 +1,67 @@
+# bp-reloader — Catalyst bootstrap-kit Blueprint #28 (W2.K3, Tier 7 — Security/Policy).
+# Stakater Reloader watches ConfigMap/Secret changes and triggers rolling
+# restarts of dependent Deployments/StatefulSets/DaemonSets that opt in
+# via annotations. The secret/configmap-rotation glue across Catalyst —
+# bp-* workloads pick up rotated TLS material and rotated bootstrap
+# credentials without manual rollouts.
+#
+# Wrapper chart: platform/reloader/chart/ (umbrella over upstream
+# stakater/reloader chart, Catalyst-curated values under the `reloader:`
+# key).
+# Reconciled by: Flux on the new Sovereign's k3s control plane.
+#
+# dependsOn: (none) — Reloader is independent infrastructure. It only
+# watches Kubernetes API resources and triggers rollouts; it does not
+# require any sibling Blueprint. Listed at slot 28 for numeric grouping
+# with the security/policy cohort but Flux will install it as soon as
+# the cluster is reachable.
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: reloader
+  labels:
+    catalyst.openova.io/sovereign: ${SOVEREIGN_FQDN}
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: bp-reloader
+  namespace: flux-system
+spec:
+  type: oci
+  interval: 15m
+  url: oci://ghcr.io/openova-io
+  secretRef:
+    name: ghcr-pull
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: bp-reloader
+  namespace: flux-system
+spec:
+  interval: 15m
+  releaseName: reloader
+  targetNamespace: reloader
+  chart:
+    spec:
+      chart: bp-reloader
+      version: 1.0.0
+      sourceRef:
+        kind: HelmRepository
+        name: bp-reloader
+        namespace: flux-system
+  # Event-driven install (Catalyst convention) — Reloader's single
+  # Deployment Ready path is fast in practice but disableWait keeps the
+  # HR Ready signal aligned with manifest apply rather than runtime
+  # convergence, matching the rest of the bootstrap-kit.
+  install:
+    disableWait: true
+    remediation:
+      retries: 3
+  upgrade:
+    disableWait: true
+    remediation:
+      retries: 3

--- a/clusters/_template/bootstrap-kit/29-vpa.yaml
+++ b/clusters/_template/bootstrap-kit/29-vpa.yaml
@@ -1,0 +1,66 @@
+# bp-vpa — Catalyst bootstrap-kit Blueprint #29 (W2.K3, Tier 7 — Security/Policy).
+# Vertical Pod Autoscaler. Per-host-cluster automated resource right-sizing
+# (Recommender + Updater + Admission Controller). Pairs with HPA/KEDA on
+# the horizontal axis. Provides recommendations even if not auto-applying;
+# Catalyst-default mode is `Off` (recommend only) until SRE opts a
+# workload into `Auto` via VerticalPodAutoscaler resources.
+#
+# Wrapper chart: platform/vpa/chart/ (umbrella over upstream
+# autoscaler/vertical-pod-autoscaler chart, Catalyst-curated values under
+# the `vertical-pod-autoscaler:` key).
+# Reconciled by: Flux on the new Sovereign's k3s control plane.
+#
+# dependsOn: (none) — VPA is independent infrastructure. The Recommender
+# reads from metrics-server (a k3s fixture) and Prometheus/Mimir when
+# present, but neither is a hard sibling-Blueprint dep at install time;
+# the controllers tolerate metrics endpoints appearing late. Listed at
+# slot 29 for numeric grouping with the security/policy cohort.
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: vpa
+  labels:
+    catalyst.openova.io/sovereign: ${SOVEREIGN_FQDN}
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: bp-vpa
+  namespace: flux-system
+spec:
+  type: oci
+  interval: 15m
+  url: oci://ghcr.io/openova-io
+  secretRef:
+    name: ghcr-pull
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: bp-vpa
+  namespace: flux-system
+spec:
+  interval: 15m
+  releaseName: vpa
+  targetNamespace: vpa
+  chart:
+    spec:
+      chart: bp-vpa
+      version: 1.0.0
+      sourceRef:
+        kind: HelmRepository
+        name: bp-vpa
+        namespace: flux-system
+  # Event-driven install: VPA brings up three Deployments (recommender,
+  # updater, admission-controller) plus admission webhook TLS bootstrap.
+  # disableWait keeps Flux's Ready signal aligned with manifest apply.
+  install:
+    disableWait: true
+    remediation:
+      retries: 3
+  upgrade:
+    disableWait: true
+    remediation:
+      retries: 3

--- a/clusters/_template/bootstrap-kit/30-trivy.yaml
+++ b/clusters/_template/bootstrap-kit/30-trivy.yaml
@@ -1,0 +1,71 @@
+# bp-trivy — Catalyst bootstrap-kit Blueprint #30 (W2.K3, Tier 7 — Security/Policy).
+# Trivy Operator. Static-scanning half of the Catalyst security stack:
+# vulnerability + misconfiguration scanning of running workloads, images,
+# RBAC, and rendered manifests. Pairs with bp-falco (runtime, slot 31)
+# and bp-kyverno (admission, slot 27).
+#
+# Wrapper chart: platform/trivy/chart/ (umbrella over upstream
+# aquasecurity/trivy-operator chart, Catalyst-curated values under the
+# `trivy-operator:` key).
+# Reconciled by: Flux on the new Sovereign's k3s control plane.
+#
+# dependsOn:
+#   - bp-cert-manager — Trivy Operator's admission webhook (and its
+#     ConfigAuditReport mutating-webhook in HA mode) requires a TLS cert
+#     from the cluster's letsencrypt-prod / internal CA ClusterIssuer
+#     before the apiserver will route AdmissionReview traffic. Without
+#     bp-cert-manager Ready, the Certificate resource sits Pending and
+#     the webhook serves stale or no certs.
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: trivy-system
+  labels:
+    catalyst.openova.io/sovereign: ${SOVEREIGN_FQDN}
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: bp-trivy
+  namespace: flux-system
+spec:
+  type: oci
+  interval: 15m
+  url: oci://ghcr.io/openova-io
+  secretRef:
+    name: ghcr-pull
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: bp-trivy
+  namespace: flux-system
+spec:
+  interval: 15m
+  releaseName: trivy
+  targetNamespace: trivy-system
+  dependsOn:
+    - name: bp-cert-manager
+  chart:
+    spec:
+      chart: bp-trivy
+      version: 1.0.0
+      sourceRef:
+        kind: HelmRepository
+        name: bp-trivy
+        namespace: flux-system
+  # Event-driven install: Trivy Operator pulls a multi-hundred-MB
+  # vulnerability database on first run; pod Ready is dominated by
+  # initial DB hydration, not manifest apply. disableWait lets Flux
+  # mark this Ready as soon as manifests apply; runtime convergence
+  # (DB hydration, first scan reports landing) is observed via kubectl.
+  install:
+    disableWait: true
+    remediation:
+      retries: 3
+  upgrade:
+    disableWait: true
+    remediation:
+      retries: 3

--- a/clusters/_template/bootstrap-kit/31-falco.yaml
+++ b/clusters/_template/bootstrap-kit/31-falco.yaml
@@ -1,0 +1,69 @@
+# bp-falco — Catalyst bootstrap-kit Blueprint #31 (W2.K3, Tier 7 — Security/Policy).
+# Runtime threat detection (CNCF Graduated). eBPF kernel-level syscall
+# monitoring for container escapes, privilege escalation, anomalous
+# behavior. Runs as a DaemonSet on every host of the Sovereign;
+# Falcosidekick fans events into the SIEM pipeline (Loki/JetStream).
+#
+# Wrapper chart: platform/falco/chart/ (umbrella over upstream
+# falcosecurity/falco chart, Catalyst-curated values under the `falco:`
+# key — modern_ebpf driver, falcosidekick enabled).
+# Reconciled by: Flux on the new Sovereign's k3s control plane.
+#
+# dependsOn:
+#   - bp-cilium — Falco's modern_ebpf probe loads alongside Cilium's
+#     eBPF programs on the same kernel hook points. Bringing Falco up
+#     before the CNI is finalised has produced flaky probe-load races
+#     in field testing; sequencing after bp-cilium Ready avoids that.
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: falco
+  labels:
+    catalyst.openova.io/sovereign: ${SOVEREIGN_FQDN}
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: bp-falco
+  namespace: flux-system
+spec:
+  type: oci
+  interval: 15m
+  url: oci://ghcr.io/openova-io
+  secretRef:
+    name: ghcr-pull
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: bp-falco
+  namespace: flux-system
+spec:
+  interval: 15m
+  releaseName: falco
+  targetNamespace: falco
+  dependsOn:
+    - name: bp-cilium
+  chart:
+    spec:
+      chart: bp-falco
+      version: 1.0.0
+      sourceRef:
+        kind: HelmRepository
+        name: bp-falco
+        namespace: flux-system
+  # Event-driven install: Falco's DaemonSet rolls out per-node and the
+  # eBPF probe load is sensitive to kernel headers / module presence.
+  # Per-node Ready is properly observed via DaemonSet status, not via
+  # Helm `--wait`. disableWait keeps Flux's signal aligned with
+  # manifest apply.
+  install:
+    disableWait: true
+    remediation:
+      retries: 3
+  upgrade:
+    disableWait: true
+    remediation:
+      retries: 3

--- a/clusters/_template/bootstrap-kit/32-sigstore.yaml
+++ b/clusters/_template/bootstrap-kit/32-sigstore.yaml
@@ -1,0 +1,71 @@
+# bp-sigstore — Catalyst bootstrap-kit Blueprint #32 (W2.K3, Tier 7 — Security/Policy).
+# Sigstore Policy Controller. Admission gate for signed-image enforcement —
+# verifies Cosign signatures + attestations on container images before
+# admission. Pairs with bp-harbor (registry, slot 19) and the CI-side
+# Cosign signing path to close the supply-chain trust loop on the
+# Sovereign.
+#
+# Wrapper chart: platform/sigstore/chart/ (umbrella over upstream
+# sigstore/policy-controller chart, Catalyst-curated values under the
+# `policy-controller:` key).
+# Reconciled by: Flux on the new Sovereign's k3s control plane.
+#
+# dependsOn:
+#   - bp-cert-manager — Policy Controller is an admission webhook; the
+#     apiserver requires a valid TLS cert on the webhook Service before
+#     it will route AdmissionReview traffic. Without bp-cert-manager
+#     Ready, the Certificate sits Pending and admission fails open or
+#     fails closed (depending on FailurePolicy), neither of which is
+#     the intended security posture.
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: sigstore-system
+  labels:
+    catalyst.openova.io/sovereign: ${SOVEREIGN_FQDN}
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: bp-sigstore
+  namespace: flux-system
+spec:
+  type: oci
+  interval: 15m
+  url: oci://ghcr.io/openova-io
+  secretRef:
+    name: ghcr-pull
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: bp-sigstore
+  namespace: flux-system
+spec:
+  interval: 15m
+  releaseName: sigstore
+  targetNamespace: sigstore-system
+  dependsOn:
+    - name: bp-cert-manager
+  chart:
+    spec:
+      chart: bp-sigstore
+      version: 1.0.0
+      sourceRef:
+        kind: HelmRepository
+        name: bp-sigstore
+        namespace: flux-system
+  # Event-driven install: Policy Controller bootstraps its admission
+  # webhook TLS via cert-manager and reaches Ready only after the
+  # Certificate is issued + bound. disableWait avoids holding the HR
+  # signal on a runtime-convergence event.
+  install:
+    disableWait: true
+    remediation:
+      retries: 3
+  upgrade:
+    disableWait: true
+    remediation:
+      retries: 3

--- a/clusters/_template/bootstrap-kit/33-syft-grype.yaml
+++ b/clusters/_template/bootstrap-kit/33-syft-grype.yaml
@@ -1,0 +1,68 @@
+# bp-syft-grype — Catalyst bootstrap-kit Blueprint #33 (W2.K3, Tier 7 — Security/Policy).
+# Anchore Syft + Grype as a scheduled CronJob. SBOM generation (Syft)
+# paired with vulnerability matching (Grype) — the offline / scheduled
+# half of the supply-chain stack. Anchore does not publish a Helm chart
+# for the open-source CLIs, so this Blueprint is a scratch chart that
+# wires the official ghcr.io/anchore/syft and ghcr.io/anchore/grype
+# containers into a CronJob that scans the Sovereign's image inventory.
+#
+# Wrapper chart: platform/syft-grype/chart/ (Catalyst-authored scratch
+# chart — no upstream subchart).
+# Reconciled by: Flux on the new Sovereign's k3s control plane.
+#
+# dependsOn:
+#   - bp-cert-manager — the result-export sidecar publishes SBOMs over
+#     mTLS to the central scan-result store; cert-manager issues the
+#     workload's TLS material via the cluster's ClusterIssuer.
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: syft-grype
+  labels:
+    catalyst.openova.io/sovereign: ${SOVEREIGN_FQDN}
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: bp-syft-grype
+  namespace: flux-system
+spec:
+  type: oci
+  interval: 15m
+  url: oci://ghcr.io/openova-io
+  secretRef:
+    name: ghcr-pull
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: bp-syft-grype
+  namespace: flux-system
+spec:
+  interval: 15m
+  releaseName: syft-grype
+  targetNamespace: syft-grype
+  dependsOn:
+    - name: bp-cert-manager
+  chart:
+    spec:
+      chart: bp-syft-grype
+      version: 1.0.0
+      sourceRef:
+        kind: HelmRepository
+        name: bp-syft-grype
+        namespace: flux-system
+  # Event-driven install: the Blueprint is mostly a CronJob + RBAC
+  # surface. There is no long-running Deployment whose Ready=True is
+  # meaningful — disableWait is the correct shape so Flux marks Ready
+  # as soon as manifests apply.
+  install:
+    disableWait: true
+    remediation:
+      retries: 3
+  upgrade:
+    disableWait: true
+    remediation:
+      retries: 3

--- a/clusters/_template/bootstrap-kit/34-velero.yaml
+++ b/clusters/_template/bootstrap-kit/34-velero.yaml
@@ -1,0 +1,72 @@
+# bp-velero — Catalyst bootstrap-kit Blueprint #34 (W2.K3, Tier 7 — Security/Policy).
+# Per-host-cluster backup engine. Catalyst-Zero pins backups to SeaweedFS
+# (the unified S3 layer, slot 18) so backup data never leaves the
+# Sovereign at install time; per-Sovereign archival to a cloud backend
+# is wired in post-bootstrap via Crossplane.
+#
+# Wrapper chart: platform/velero/chart/ (umbrella over upstream
+# vmware-tanzu/velero chart, Catalyst-curated values under the `velero:`
+# key — `seaweedfs` BackupStorageLocation provider, no cloud plugin
+# pinned at install time).
+# Reconciled by: Flux on the new Sovereign's k3s control plane.
+#
+# dependsOn:
+#   - bp-seaweedfs — Velero's BackupStorageLocation points at the
+#     in-cluster SeaweedFS S3 endpoint (`seaweedfs.seaweedfs.svc:8333`)
+#     and reads the `seaweedfs-s3-credentials` Secret SeaweedFS renders
+#     during install. Without bp-seaweedfs Ready, the BSL Phase sits
+#     `Unavailable` and Velero's first reconcile fails — every backup
+#     CR queues with the same error until the dep lands.
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: velero
+  labels:
+    catalyst.openova.io/sovereign: ${SOVEREIGN_FQDN}
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: bp-velero
+  namespace: flux-system
+spec:
+  type: oci
+  interval: 15m
+  url: oci://ghcr.io/openova-io
+  secretRef:
+    name: ghcr-pull
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: bp-velero
+  namespace: flux-system
+spec:
+  interval: 15m
+  releaseName: velero
+  targetNamespace: velero
+  dependsOn:
+    - name: bp-seaweedfs
+  chart:
+    spec:
+      chart: bp-velero
+      version: 1.0.0
+      sourceRef:
+        kind: HelmRepository
+        name: bp-velero
+        namespace: flux-system
+  # Event-driven install: Velero's Deployment Ready depends on the
+  # node-agent DaemonSet rolling out and the BackupStorageLocation
+  # reaching `Available` — both runtime-convergence events that Flux
+  # observes via the BSL CR phase, not via Helm `--wait`. disableWait
+  # keeps the HR's Ready signal aligned with manifest apply.
+  install:
+    disableWait: true
+    remediation:
+      retries: 3
+  upgrade:
+    disableWait: true
+    remediation:
+      retries: 3

--- a/clusters/_template/bootstrap-kit/kustomization.yaml
+++ b/clusters/_template/bootstrap-kit/kustomization.yaml
@@ -31,3 +31,11 @@ resources:
   - 24-tempo.yaml
   - 25-grafana.yaml
   - 26-langfuse.yaml
+  - 27-kyverno.yaml
+  - 28-reloader.yaml
+  - 29-vpa.yaml
+  - 30-trivy.yaml
+  - 31-falco.yaml
+  - 32-sigstore.yaml
+  - 33-syft-grype.yaml
+  - 34-velero.yaml

--- a/clusters/omantel.omani.works/bootstrap-kit/27-kyverno.yaml
+++ b/clusters/omantel.omani.works/bootstrap-kit/27-kyverno.yaml
@@ -1,0 +1,73 @@
+# bp-kyverno — Catalyst bootstrap-kit Blueprint #27 (W2.K3, Tier 7 — Security/Policy).
+# Kubernetes-native admission policy engine. Validating/mutating/generating
+# admission control via ClusterPolicy/Policy CRDs. HA mode with separate
+# admission/background/cleanup/reports controllers. The first guardrail
+# downstream Catalyst Apps land behind once the platform is bootstrapped.
+#
+# Wrapper chart: platform/kyverno/chart/ (umbrella over upstream
+# kyverno/kyverno chart, Catalyst-curated values under the `kyverno:` key).
+# Reconciled by: Flux on the new Sovereign's k3s control plane.
+#
+# dependsOn:
+#   - bp-cilium — Kyverno admission webhooks need a working CNI + Service
+#     mesh substrate to receive AdmissionReview requests from the apiserver.
+#     Cilium is the root of the Catalyst-Zero DAG; until it is Ready the
+#     apiserver→webhook path is not reachable and Kyverno install is racy.
+#
+# No further dependsOn: Kyverno installs its own CRDs and does not require
+# cert-manager (it auto-generates admission webhook TLS via its built-in
+# certificate controller).
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kyverno
+  labels:
+    catalyst.openova.io/sovereign: omantel.omani.works
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: bp-kyverno
+  namespace: flux-system
+spec:
+  type: oci
+  interval: 15m
+  url: oci://ghcr.io/openova-io
+  secretRef:
+    name: ghcr-pull
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: bp-kyverno
+  namespace: flux-system
+spec:
+  interval: 15m
+  releaseName: kyverno
+  targetNamespace: kyverno
+  dependsOn:
+    - name: bp-cilium
+  chart:
+    spec:
+      chart: bp-kyverno
+      version: 1.0.0
+      sourceRef:
+        kind: HelmRepository
+        name: bp-kyverno
+        namespace: flux-system
+  # Event-driven install: Kyverno HA mode brings up four controller
+  # Deployments (admission, background, cleanup, reports) plus the
+  # admission webhook TLS bootstrap. Pod Ready is multi-minute on a
+  # cold cluster; Helm `--wait` would hold the HR's Ready=True signal
+  # past the point where downstream HRs could legitimately reconcile.
+  # disableWait lets Flux mark this Ready as soon as manifests apply.
+  install:
+    disableWait: true
+    remediation:
+      retries: 3
+  upgrade:
+    disableWait: true
+    remediation:
+      retries: 3

--- a/clusters/omantel.omani.works/bootstrap-kit/28-reloader.yaml
+++ b/clusters/omantel.omani.works/bootstrap-kit/28-reloader.yaml
@@ -1,0 +1,67 @@
+# bp-reloader — Catalyst bootstrap-kit Blueprint #28 (W2.K3, Tier 7 — Security/Policy).
+# Stakater Reloader watches ConfigMap/Secret changes and triggers rolling
+# restarts of dependent Deployments/StatefulSets/DaemonSets that opt in
+# via annotations. The secret/configmap-rotation glue across Catalyst —
+# bp-* workloads pick up rotated TLS material and rotated bootstrap
+# credentials without manual rollouts.
+#
+# Wrapper chart: platform/reloader/chart/ (umbrella over upstream
+# stakater/reloader chart, Catalyst-curated values under the `reloader:`
+# key).
+# Reconciled by: Flux on the new Sovereign's k3s control plane.
+#
+# dependsOn: (none) — Reloader is independent infrastructure. It only
+# watches Kubernetes API resources and triggers rollouts; it does not
+# require any sibling Blueprint. Listed at slot 28 for numeric grouping
+# with the security/policy cohort but Flux will install it as soon as
+# the cluster is reachable.
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: reloader
+  labels:
+    catalyst.openova.io/sovereign: omantel.omani.works
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: bp-reloader
+  namespace: flux-system
+spec:
+  type: oci
+  interval: 15m
+  url: oci://ghcr.io/openova-io
+  secretRef:
+    name: ghcr-pull
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: bp-reloader
+  namespace: flux-system
+spec:
+  interval: 15m
+  releaseName: reloader
+  targetNamespace: reloader
+  chart:
+    spec:
+      chart: bp-reloader
+      version: 1.0.0
+      sourceRef:
+        kind: HelmRepository
+        name: bp-reloader
+        namespace: flux-system
+  # Event-driven install (Catalyst convention) — Reloader's single
+  # Deployment Ready path is fast in practice but disableWait keeps the
+  # HR Ready signal aligned with manifest apply rather than runtime
+  # convergence, matching the rest of the bootstrap-kit.
+  install:
+    disableWait: true
+    remediation:
+      retries: 3
+  upgrade:
+    disableWait: true
+    remediation:
+      retries: 3

--- a/clusters/omantel.omani.works/bootstrap-kit/29-vpa.yaml
+++ b/clusters/omantel.omani.works/bootstrap-kit/29-vpa.yaml
@@ -1,0 +1,66 @@
+# bp-vpa — Catalyst bootstrap-kit Blueprint #29 (W2.K3, Tier 7 — Security/Policy).
+# Vertical Pod Autoscaler. Per-host-cluster automated resource right-sizing
+# (Recommender + Updater + Admission Controller). Pairs with HPA/KEDA on
+# the horizontal axis. Provides recommendations even if not auto-applying;
+# Catalyst-default mode is `Off` (recommend only) until SRE opts a
+# workload into `Auto` via VerticalPodAutoscaler resources.
+#
+# Wrapper chart: platform/vpa/chart/ (umbrella over upstream
+# autoscaler/vertical-pod-autoscaler chart, Catalyst-curated values under
+# the `vertical-pod-autoscaler:` key).
+# Reconciled by: Flux on the new Sovereign's k3s control plane.
+#
+# dependsOn: (none) — VPA is independent infrastructure. The Recommender
+# reads from metrics-server (a k3s fixture) and Prometheus/Mimir when
+# present, but neither is a hard sibling-Blueprint dep at install time;
+# the controllers tolerate metrics endpoints appearing late. Listed at
+# slot 29 for numeric grouping with the security/policy cohort.
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: vpa
+  labels:
+    catalyst.openova.io/sovereign: omantel.omani.works
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: bp-vpa
+  namespace: flux-system
+spec:
+  type: oci
+  interval: 15m
+  url: oci://ghcr.io/openova-io
+  secretRef:
+    name: ghcr-pull
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: bp-vpa
+  namespace: flux-system
+spec:
+  interval: 15m
+  releaseName: vpa
+  targetNamespace: vpa
+  chart:
+    spec:
+      chart: bp-vpa
+      version: 1.0.0
+      sourceRef:
+        kind: HelmRepository
+        name: bp-vpa
+        namespace: flux-system
+  # Event-driven install: VPA brings up three Deployments (recommender,
+  # updater, admission-controller) plus admission webhook TLS bootstrap.
+  # disableWait keeps Flux's Ready signal aligned with manifest apply.
+  install:
+    disableWait: true
+    remediation:
+      retries: 3
+  upgrade:
+    disableWait: true
+    remediation:
+      retries: 3

--- a/clusters/omantel.omani.works/bootstrap-kit/30-trivy.yaml
+++ b/clusters/omantel.omani.works/bootstrap-kit/30-trivy.yaml
@@ -1,0 +1,71 @@
+# bp-trivy — Catalyst bootstrap-kit Blueprint #30 (W2.K3, Tier 7 — Security/Policy).
+# Trivy Operator. Static-scanning half of the Catalyst security stack:
+# vulnerability + misconfiguration scanning of running workloads, images,
+# RBAC, and rendered manifests. Pairs with bp-falco (runtime, slot 31)
+# and bp-kyverno (admission, slot 27).
+#
+# Wrapper chart: platform/trivy/chart/ (umbrella over upstream
+# aquasecurity/trivy-operator chart, Catalyst-curated values under the
+# `trivy-operator:` key).
+# Reconciled by: Flux on the new Sovereign's k3s control plane.
+#
+# dependsOn:
+#   - bp-cert-manager — Trivy Operator's admission webhook (and its
+#     ConfigAuditReport mutating-webhook in HA mode) requires a TLS cert
+#     from the cluster's letsencrypt-prod / internal CA ClusterIssuer
+#     before the apiserver will route AdmissionReview traffic. Without
+#     bp-cert-manager Ready, the Certificate resource sits Pending and
+#     the webhook serves stale or no certs.
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: trivy-system
+  labels:
+    catalyst.openova.io/sovereign: omantel.omani.works
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: bp-trivy
+  namespace: flux-system
+spec:
+  type: oci
+  interval: 15m
+  url: oci://ghcr.io/openova-io
+  secretRef:
+    name: ghcr-pull
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: bp-trivy
+  namespace: flux-system
+spec:
+  interval: 15m
+  releaseName: trivy
+  targetNamespace: trivy-system
+  dependsOn:
+    - name: bp-cert-manager
+  chart:
+    spec:
+      chart: bp-trivy
+      version: 1.0.0
+      sourceRef:
+        kind: HelmRepository
+        name: bp-trivy
+        namespace: flux-system
+  # Event-driven install: Trivy Operator pulls a multi-hundred-MB
+  # vulnerability database on first run; pod Ready is dominated by
+  # initial DB hydration, not manifest apply. disableWait lets Flux
+  # mark this Ready as soon as manifests apply; runtime convergence
+  # (DB hydration, first scan reports landing) is observed via kubectl.
+  install:
+    disableWait: true
+    remediation:
+      retries: 3
+  upgrade:
+    disableWait: true
+    remediation:
+      retries: 3

--- a/clusters/omantel.omani.works/bootstrap-kit/31-falco.yaml
+++ b/clusters/omantel.omani.works/bootstrap-kit/31-falco.yaml
@@ -1,0 +1,69 @@
+# bp-falco — Catalyst bootstrap-kit Blueprint #31 (W2.K3, Tier 7 — Security/Policy).
+# Runtime threat detection (CNCF Graduated). eBPF kernel-level syscall
+# monitoring for container escapes, privilege escalation, anomalous
+# behavior. Runs as a DaemonSet on every host of the Sovereign;
+# Falcosidekick fans events into the SIEM pipeline (Loki/JetStream).
+#
+# Wrapper chart: platform/falco/chart/ (umbrella over upstream
+# falcosecurity/falco chart, Catalyst-curated values under the `falco:`
+# key — modern_ebpf driver, falcosidekick enabled).
+# Reconciled by: Flux on the new Sovereign's k3s control plane.
+#
+# dependsOn:
+#   - bp-cilium — Falco's modern_ebpf probe loads alongside Cilium's
+#     eBPF programs on the same kernel hook points. Bringing Falco up
+#     before the CNI is finalised has produced flaky probe-load races
+#     in field testing; sequencing after bp-cilium Ready avoids that.
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: falco
+  labels:
+    catalyst.openova.io/sovereign: omantel.omani.works
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: bp-falco
+  namespace: flux-system
+spec:
+  type: oci
+  interval: 15m
+  url: oci://ghcr.io/openova-io
+  secretRef:
+    name: ghcr-pull
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: bp-falco
+  namespace: flux-system
+spec:
+  interval: 15m
+  releaseName: falco
+  targetNamespace: falco
+  dependsOn:
+    - name: bp-cilium
+  chart:
+    spec:
+      chart: bp-falco
+      version: 1.0.0
+      sourceRef:
+        kind: HelmRepository
+        name: bp-falco
+        namespace: flux-system
+  # Event-driven install: Falco's DaemonSet rolls out per-node and the
+  # eBPF probe load is sensitive to kernel headers / module presence.
+  # Per-node Ready is properly observed via DaemonSet status, not via
+  # Helm `--wait`. disableWait keeps Flux's signal aligned with
+  # manifest apply.
+  install:
+    disableWait: true
+    remediation:
+      retries: 3
+  upgrade:
+    disableWait: true
+    remediation:
+      retries: 3

--- a/clusters/omantel.omani.works/bootstrap-kit/32-sigstore.yaml
+++ b/clusters/omantel.omani.works/bootstrap-kit/32-sigstore.yaml
@@ -1,0 +1,71 @@
+# bp-sigstore — Catalyst bootstrap-kit Blueprint #32 (W2.K3, Tier 7 — Security/Policy).
+# Sigstore Policy Controller. Admission gate for signed-image enforcement —
+# verifies Cosign signatures + attestations on container images before
+# admission. Pairs with bp-harbor (registry, slot 19) and the CI-side
+# Cosign signing path to close the supply-chain trust loop on the
+# Sovereign.
+#
+# Wrapper chart: platform/sigstore/chart/ (umbrella over upstream
+# sigstore/policy-controller chart, Catalyst-curated values under the
+# `policy-controller:` key).
+# Reconciled by: Flux on the new Sovereign's k3s control plane.
+#
+# dependsOn:
+#   - bp-cert-manager — Policy Controller is an admission webhook; the
+#     apiserver requires a valid TLS cert on the webhook Service before
+#     it will route AdmissionReview traffic. Without bp-cert-manager
+#     Ready, the Certificate sits Pending and admission fails open or
+#     fails closed (depending on FailurePolicy), neither of which is
+#     the intended security posture.
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: sigstore-system
+  labels:
+    catalyst.openova.io/sovereign: omantel.omani.works
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: bp-sigstore
+  namespace: flux-system
+spec:
+  type: oci
+  interval: 15m
+  url: oci://ghcr.io/openova-io
+  secretRef:
+    name: ghcr-pull
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: bp-sigstore
+  namespace: flux-system
+spec:
+  interval: 15m
+  releaseName: sigstore
+  targetNamespace: sigstore-system
+  dependsOn:
+    - name: bp-cert-manager
+  chart:
+    spec:
+      chart: bp-sigstore
+      version: 1.0.0
+      sourceRef:
+        kind: HelmRepository
+        name: bp-sigstore
+        namespace: flux-system
+  # Event-driven install: Policy Controller bootstraps its admission
+  # webhook TLS via cert-manager and reaches Ready only after the
+  # Certificate is issued + bound. disableWait avoids holding the HR
+  # signal on a runtime-convergence event.
+  install:
+    disableWait: true
+    remediation:
+      retries: 3
+  upgrade:
+    disableWait: true
+    remediation:
+      retries: 3

--- a/clusters/omantel.omani.works/bootstrap-kit/33-syft-grype.yaml
+++ b/clusters/omantel.omani.works/bootstrap-kit/33-syft-grype.yaml
@@ -1,0 +1,68 @@
+# bp-syft-grype — Catalyst bootstrap-kit Blueprint #33 (W2.K3, Tier 7 — Security/Policy).
+# Anchore Syft + Grype as a scheduled CronJob. SBOM generation (Syft)
+# paired with vulnerability matching (Grype) — the offline / scheduled
+# half of the supply-chain stack. Anchore does not publish a Helm chart
+# for the open-source CLIs, so this Blueprint is a scratch chart that
+# wires the official ghcr.io/anchore/syft and ghcr.io/anchore/grype
+# containers into a CronJob that scans the Sovereign's image inventory.
+#
+# Wrapper chart: platform/syft-grype/chart/ (Catalyst-authored scratch
+# chart — no upstream subchart).
+# Reconciled by: Flux on the new Sovereign's k3s control plane.
+#
+# dependsOn:
+#   - bp-cert-manager — the result-export sidecar publishes SBOMs over
+#     mTLS to the central scan-result store; cert-manager issues the
+#     workload's TLS material via the cluster's ClusterIssuer.
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: syft-grype
+  labels:
+    catalyst.openova.io/sovereign: omantel.omani.works
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: bp-syft-grype
+  namespace: flux-system
+spec:
+  type: oci
+  interval: 15m
+  url: oci://ghcr.io/openova-io
+  secretRef:
+    name: ghcr-pull
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: bp-syft-grype
+  namespace: flux-system
+spec:
+  interval: 15m
+  releaseName: syft-grype
+  targetNamespace: syft-grype
+  dependsOn:
+    - name: bp-cert-manager
+  chart:
+    spec:
+      chart: bp-syft-grype
+      version: 1.0.0
+      sourceRef:
+        kind: HelmRepository
+        name: bp-syft-grype
+        namespace: flux-system
+  # Event-driven install: the Blueprint is mostly a CronJob + RBAC
+  # surface. There is no long-running Deployment whose Ready=True is
+  # meaningful — disableWait is the correct shape so Flux marks Ready
+  # as soon as manifests apply.
+  install:
+    disableWait: true
+    remediation:
+      retries: 3
+  upgrade:
+    disableWait: true
+    remediation:
+      retries: 3

--- a/clusters/omantel.omani.works/bootstrap-kit/34-velero.yaml
+++ b/clusters/omantel.omani.works/bootstrap-kit/34-velero.yaml
@@ -1,0 +1,72 @@
+# bp-velero — Catalyst bootstrap-kit Blueprint #34 (W2.K3, Tier 7 — Security/Policy).
+# Per-host-cluster backup engine. Catalyst-Zero pins backups to SeaweedFS
+# (the unified S3 layer, slot 18) so backup data never leaves the
+# Sovereign at install time; per-Sovereign archival to a cloud backend
+# is wired in post-bootstrap via Crossplane.
+#
+# Wrapper chart: platform/velero/chart/ (umbrella over upstream
+# vmware-tanzu/velero chart, Catalyst-curated values under the `velero:`
+# key — `seaweedfs` BackupStorageLocation provider, no cloud plugin
+# pinned at install time).
+# Reconciled by: Flux on the new Sovereign's k3s control plane.
+#
+# dependsOn:
+#   - bp-seaweedfs — Velero's BackupStorageLocation points at the
+#     in-cluster SeaweedFS S3 endpoint (`seaweedfs.seaweedfs.svc:8333`)
+#     and reads the `seaweedfs-s3-credentials` Secret SeaweedFS renders
+#     during install. Without bp-seaweedfs Ready, the BSL Phase sits
+#     `Unavailable` and Velero's first reconcile fails — every backup
+#     CR queues with the same error until the dep lands.
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: velero
+  labels:
+    catalyst.openova.io/sovereign: omantel.omani.works
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: bp-velero
+  namespace: flux-system
+spec:
+  type: oci
+  interval: 15m
+  url: oci://ghcr.io/openova-io
+  secretRef:
+    name: ghcr-pull
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: bp-velero
+  namespace: flux-system
+spec:
+  interval: 15m
+  releaseName: velero
+  targetNamespace: velero
+  dependsOn:
+    - name: bp-seaweedfs
+  chart:
+    spec:
+      chart: bp-velero
+      version: 1.0.0
+      sourceRef:
+        kind: HelmRepository
+        name: bp-velero
+        namespace: flux-system
+  # Event-driven install: Velero's Deployment Ready depends on the
+  # node-agent DaemonSet rolling out and the BackupStorageLocation
+  # reaching `Available` — both runtime-convergence events that Flux
+  # observes via the BSL CR phase, not via Helm `--wait`. disableWait
+  # keeps the HR's Ready signal aligned with manifest apply.
+  install:
+    disableWait: true
+    remediation:
+      retries: 3
+  upgrade:
+    disableWait: true
+    remediation:
+      retries: 3

--- a/clusters/omantel.omani.works/bootstrap-kit/kustomization.yaml
+++ b/clusters/omantel.omani.works/bootstrap-kit/kustomization.yaml
@@ -31,3 +31,11 @@ resources:
   - 24-tempo.yaml
   - 25-grafana.yaml
   - 26-langfuse.yaml
+  - 27-kyverno.yaml
+  - 28-reloader.yaml
+  - 29-vpa.yaml
+  - 30-trivy.yaml
+  - 31-falco.yaml
+  - 32-sigstore.yaml
+  - 33-syft-grype.yaml
+  - 34-velero.yaml

--- a/clusters/otech.omani.works/bootstrap-kit/27-kyverno.yaml
+++ b/clusters/otech.omani.works/bootstrap-kit/27-kyverno.yaml
@@ -1,0 +1,73 @@
+# bp-kyverno — Catalyst bootstrap-kit Blueprint #27 (W2.K3, Tier 7 — Security/Policy).
+# Kubernetes-native admission policy engine. Validating/mutating/generating
+# admission control via ClusterPolicy/Policy CRDs. HA mode with separate
+# admission/background/cleanup/reports controllers. The first guardrail
+# downstream Catalyst Apps land behind once the platform is bootstrapped.
+#
+# Wrapper chart: platform/kyverno/chart/ (umbrella over upstream
+# kyverno/kyverno chart, Catalyst-curated values under the `kyverno:` key).
+# Reconciled by: Flux on the new Sovereign's k3s control plane.
+#
+# dependsOn:
+#   - bp-cilium — Kyverno admission webhooks need a working CNI + Service
+#     mesh substrate to receive AdmissionReview requests from the apiserver.
+#     Cilium is the root of the Catalyst-Zero DAG; until it is Ready the
+#     apiserver→webhook path is not reachable and Kyverno install is racy.
+#
+# No further dependsOn: Kyverno installs its own CRDs and does not require
+# cert-manager (it auto-generates admission webhook TLS via its built-in
+# certificate controller).
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kyverno
+  labels:
+    catalyst.openova.io/sovereign: otech.omani.works
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: bp-kyverno
+  namespace: flux-system
+spec:
+  type: oci
+  interval: 15m
+  url: oci://ghcr.io/openova-io
+  secretRef:
+    name: ghcr-pull
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: bp-kyverno
+  namespace: flux-system
+spec:
+  interval: 15m
+  releaseName: kyverno
+  targetNamespace: kyverno
+  dependsOn:
+    - name: bp-cilium
+  chart:
+    spec:
+      chart: bp-kyverno
+      version: 1.0.0
+      sourceRef:
+        kind: HelmRepository
+        name: bp-kyverno
+        namespace: flux-system
+  # Event-driven install: Kyverno HA mode brings up four controller
+  # Deployments (admission, background, cleanup, reports) plus the
+  # admission webhook TLS bootstrap. Pod Ready is multi-minute on a
+  # cold cluster; Helm `--wait` would hold the HR's Ready=True signal
+  # past the point where downstream HRs could legitimately reconcile.
+  # disableWait lets Flux mark this Ready as soon as manifests apply.
+  install:
+    disableWait: true
+    remediation:
+      retries: 3
+  upgrade:
+    disableWait: true
+    remediation:
+      retries: 3

--- a/clusters/otech.omani.works/bootstrap-kit/28-reloader.yaml
+++ b/clusters/otech.omani.works/bootstrap-kit/28-reloader.yaml
@@ -1,0 +1,67 @@
+# bp-reloader — Catalyst bootstrap-kit Blueprint #28 (W2.K3, Tier 7 — Security/Policy).
+# Stakater Reloader watches ConfigMap/Secret changes and triggers rolling
+# restarts of dependent Deployments/StatefulSets/DaemonSets that opt in
+# via annotations. The secret/configmap-rotation glue across Catalyst —
+# bp-* workloads pick up rotated TLS material and rotated bootstrap
+# credentials without manual rollouts.
+#
+# Wrapper chart: platform/reloader/chart/ (umbrella over upstream
+# stakater/reloader chart, Catalyst-curated values under the `reloader:`
+# key).
+# Reconciled by: Flux on the new Sovereign's k3s control plane.
+#
+# dependsOn: (none) — Reloader is independent infrastructure. It only
+# watches Kubernetes API resources and triggers rollouts; it does not
+# require any sibling Blueprint. Listed at slot 28 for numeric grouping
+# with the security/policy cohort but Flux will install it as soon as
+# the cluster is reachable.
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: reloader
+  labels:
+    catalyst.openova.io/sovereign: otech.omani.works
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: bp-reloader
+  namespace: flux-system
+spec:
+  type: oci
+  interval: 15m
+  url: oci://ghcr.io/openova-io
+  secretRef:
+    name: ghcr-pull
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: bp-reloader
+  namespace: flux-system
+spec:
+  interval: 15m
+  releaseName: reloader
+  targetNamespace: reloader
+  chart:
+    spec:
+      chart: bp-reloader
+      version: 1.0.0
+      sourceRef:
+        kind: HelmRepository
+        name: bp-reloader
+        namespace: flux-system
+  # Event-driven install (Catalyst convention) — Reloader's single
+  # Deployment Ready path is fast in practice but disableWait keeps the
+  # HR Ready signal aligned with manifest apply rather than runtime
+  # convergence, matching the rest of the bootstrap-kit.
+  install:
+    disableWait: true
+    remediation:
+      retries: 3
+  upgrade:
+    disableWait: true
+    remediation:
+      retries: 3

--- a/clusters/otech.omani.works/bootstrap-kit/29-vpa.yaml
+++ b/clusters/otech.omani.works/bootstrap-kit/29-vpa.yaml
@@ -1,0 +1,66 @@
+# bp-vpa — Catalyst bootstrap-kit Blueprint #29 (W2.K3, Tier 7 — Security/Policy).
+# Vertical Pod Autoscaler. Per-host-cluster automated resource right-sizing
+# (Recommender + Updater + Admission Controller). Pairs with HPA/KEDA on
+# the horizontal axis. Provides recommendations even if not auto-applying;
+# Catalyst-default mode is `Off` (recommend only) until SRE opts a
+# workload into `Auto` via VerticalPodAutoscaler resources.
+#
+# Wrapper chart: platform/vpa/chart/ (umbrella over upstream
+# autoscaler/vertical-pod-autoscaler chart, Catalyst-curated values under
+# the `vertical-pod-autoscaler:` key).
+# Reconciled by: Flux on the new Sovereign's k3s control plane.
+#
+# dependsOn: (none) — VPA is independent infrastructure. The Recommender
+# reads from metrics-server (a k3s fixture) and Prometheus/Mimir when
+# present, but neither is a hard sibling-Blueprint dep at install time;
+# the controllers tolerate metrics endpoints appearing late. Listed at
+# slot 29 for numeric grouping with the security/policy cohort.
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: vpa
+  labels:
+    catalyst.openova.io/sovereign: otech.omani.works
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: bp-vpa
+  namespace: flux-system
+spec:
+  type: oci
+  interval: 15m
+  url: oci://ghcr.io/openova-io
+  secretRef:
+    name: ghcr-pull
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: bp-vpa
+  namespace: flux-system
+spec:
+  interval: 15m
+  releaseName: vpa
+  targetNamespace: vpa
+  chart:
+    spec:
+      chart: bp-vpa
+      version: 1.0.0
+      sourceRef:
+        kind: HelmRepository
+        name: bp-vpa
+        namespace: flux-system
+  # Event-driven install: VPA brings up three Deployments (recommender,
+  # updater, admission-controller) plus admission webhook TLS bootstrap.
+  # disableWait keeps Flux's Ready signal aligned with manifest apply.
+  install:
+    disableWait: true
+    remediation:
+      retries: 3
+  upgrade:
+    disableWait: true
+    remediation:
+      retries: 3

--- a/clusters/otech.omani.works/bootstrap-kit/30-trivy.yaml
+++ b/clusters/otech.omani.works/bootstrap-kit/30-trivy.yaml
@@ -1,0 +1,71 @@
+# bp-trivy — Catalyst bootstrap-kit Blueprint #30 (W2.K3, Tier 7 — Security/Policy).
+# Trivy Operator. Static-scanning half of the Catalyst security stack:
+# vulnerability + misconfiguration scanning of running workloads, images,
+# RBAC, and rendered manifests. Pairs with bp-falco (runtime, slot 31)
+# and bp-kyverno (admission, slot 27).
+#
+# Wrapper chart: platform/trivy/chart/ (umbrella over upstream
+# aquasecurity/trivy-operator chart, Catalyst-curated values under the
+# `trivy-operator:` key).
+# Reconciled by: Flux on the new Sovereign's k3s control plane.
+#
+# dependsOn:
+#   - bp-cert-manager — Trivy Operator's admission webhook (and its
+#     ConfigAuditReport mutating-webhook in HA mode) requires a TLS cert
+#     from the cluster's letsencrypt-prod / internal CA ClusterIssuer
+#     before the apiserver will route AdmissionReview traffic. Without
+#     bp-cert-manager Ready, the Certificate resource sits Pending and
+#     the webhook serves stale or no certs.
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: trivy-system
+  labels:
+    catalyst.openova.io/sovereign: otech.omani.works
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: bp-trivy
+  namespace: flux-system
+spec:
+  type: oci
+  interval: 15m
+  url: oci://ghcr.io/openova-io
+  secretRef:
+    name: ghcr-pull
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: bp-trivy
+  namespace: flux-system
+spec:
+  interval: 15m
+  releaseName: trivy
+  targetNamespace: trivy-system
+  dependsOn:
+    - name: bp-cert-manager
+  chart:
+    spec:
+      chart: bp-trivy
+      version: 1.0.0
+      sourceRef:
+        kind: HelmRepository
+        name: bp-trivy
+        namespace: flux-system
+  # Event-driven install: Trivy Operator pulls a multi-hundred-MB
+  # vulnerability database on first run; pod Ready is dominated by
+  # initial DB hydration, not manifest apply. disableWait lets Flux
+  # mark this Ready as soon as manifests apply; runtime convergence
+  # (DB hydration, first scan reports landing) is observed via kubectl.
+  install:
+    disableWait: true
+    remediation:
+      retries: 3
+  upgrade:
+    disableWait: true
+    remediation:
+      retries: 3

--- a/clusters/otech.omani.works/bootstrap-kit/31-falco.yaml
+++ b/clusters/otech.omani.works/bootstrap-kit/31-falco.yaml
@@ -1,0 +1,69 @@
+# bp-falco — Catalyst bootstrap-kit Blueprint #31 (W2.K3, Tier 7 — Security/Policy).
+# Runtime threat detection (CNCF Graduated). eBPF kernel-level syscall
+# monitoring for container escapes, privilege escalation, anomalous
+# behavior. Runs as a DaemonSet on every host of the Sovereign;
+# Falcosidekick fans events into the SIEM pipeline (Loki/JetStream).
+#
+# Wrapper chart: platform/falco/chart/ (umbrella over upstream
+# falcosecurity/falco chart, Catalyst-curated values under the `falco:`
+# key — modern_ebpf driver, falcosidekick enabled).
+# Reconciled by: Flux on the new Sovereign's k3s control plane.
+#
+# dependsOn:
+#   - bp-cilium — Falco's modern_ebpf probe loads alongside Cilium's
+#     eBPF programs on the same kernel hook points. Bringing Falco up
+#     before the CNI is finalised has produced flaky probe-load races
+#     in field testing; sequencing after bp-cilium Ready avoids that.
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: falco
+  labels:
+    catalyst.openova.io/sovereign: otech.omani.works
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: bp-falco
+  namespace: flux-system
+spec:
+  type: oci
+  interval: 15m
+  url: oci://ghcr.io/openova-io
+  secretRef:
+    name: ghcr-pull
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: bp-falco
+  namespace: flux-system
+spec:
+  interval: 15m
+  releaseName: falco
+  targetNamespace: falco
+  dependsOn:
+    - name: bp-cilium
+  chart:
+    spec:
+      chart: bp-falco
+      version: 1.0.0
+      sourceRef:
+        kind: HelmRepository
+        name: bp-falco
+        namespace: flux-system
+  # Event-driven install: Falco's DaemonSet rolls out per-node and the
+  # eBPF probe load is sensitive to kernel headers / module presence.
+  # Per-node Ready is properly observed via DaemonSet status, not via
+  # Helm `--wait`. disableWait keeps Flux's signal aligned with
+  # manifest apply.
+  install:
+    disableWait: true
+    remediation:
+      retries: 3
+  upgrade:
+    disableWait: true
+    remediation:
+      retries: 3

--- a/clusters/otech.omani.works/bootstrap-kit/32-sigstore.yaml
+++ b/clusters/otech.omani.works/bootstrap-kit/32-sigstore.yaml
@@ -1,0 +1,71 @@
+# bp-sigstore — Catalyst bootstrap-kit Blueprint #32 (W2.K3, Tier 7 — Security/Policy).
+# Sigstore Policy Controller. Admission gate for signed-image enforcement —
+# verifies Cosign signatures + attestations on container images before
+# admission. Pairs with bp-harbor (registry, slot 19) and the CI-side
+# Cosign signing path to close the supply-chain trust loop on the
+# Sovereign.
+#
+# Wrapper chart: platform/sigstore/chart/ (umbrella over upstream
+# sigstore/policy-controller chart, Catalyst-curated values under the
+# `policy-controller:` key).
+# Reconciled by: Flux on the new Sovereign's k3s control plane.
+#
+# dependsOn:
+#   - bp-cert-manager — Policy Controller is an admission webhook; the
+#     apiserver requires a valid TLS cert on the webhook Service before
+#     it will route AdmissionReview traffic. Without bp-cert-manager
+#     Ready, the Certificate sits Pending and admission fails open or
+#     fails closed (depending on FailurePolicy), neither of which is
+#     the intended security posture.
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: sigstore-system
+  labels:
+    catalyst.openova.io/sovereign: otech.omani.works
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: bp-sigstore
+  namespace: flux-system
+spec:
+  type: oci
+  interval: 15m
+  url: oci://ghcr.io/openova-io
+  secretRef:
+    name: ghcr-pull
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: bp-sigstore
+  namespace: flux-system
+spec:
+  interval: 15m
+  releaseName: sigstore
+  targetNamespace: sigstore-system
+  dependsOn:
+    - name: bp-cert-manager
+  chart:
+    spec:
+      chart: bp-sigstore
+      version: 1.0.0
+      sourceRef:
+        kind: HelmRepository
+        name: bp-sigstore
+        namespace: flux-system
+  # Event-driven install: Policy Controller bootstraps its admission
+  # webhook TLS via cert-manager and reaches Ready only after the
+  # Certificate is issued + bound. disableWait avoids holding the HR
+  # signal on a runtime-convergence event.
+  install:
+    disableWait: true
+    remediation:
+      retries: 3
+  upgrade:
+    disableWait: true
+    remediation:
+      retries: 3

--- a/clusters/otech.omani.works/bootstrap-kit/33-syft-grype.yaml
+++ b/clusters/otech.omani.works/bootstrap-kit/33-syft-grype.yaml
@@ -1,0 +1,68 @@
+# bp-syft-grype — Catalyst bootstrap-kit Blueprint #33 (W2.K3, Tier 7 — Security/Policy).
+# Anchore Syft + Grype as a scheduled CronJob. SBOM generation (Syft)
+# paired with vulnerability matching (Grype) — the offline / scheduled
+# half of the supply-chain stack. Anchore does not publish a Helm chart
+# for the open-source CLIs, so this Blueprint is a scratch chart that
+# wires the official ghcr.io/anchore/syft and ghcr.io/anchore/grype
+# containers into a CronJob that scans the Sovereign's image inventory.
+#
+# Wrapper chart: platform/syft-grype/chart/ (Catalyst-authored scratch
+# chart — no upstream subchart).
+# Reconciled by: Flux on the new Sovereign's k3s control plane.
+#
+# dependsOn:
+#   - bp-cert-manager — the result-export sidecar publishes SBOMs over
+#     mTLS to the central scan-result store; cert-manager issues the
+#     workload's TLS material via the cluster's ClusterIssuer.
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: syft-grype
+  labels:
+    catalyst.openova.io/sovereign: otech.omani.works
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: bp-syft-grype
+  namespace: flux-system
+spec:
+  type: oci
+  interval: 15m
+  url: oci://ghcr.io/openova-io
+  secretRef:
+    name: ghcr-pull
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: bp-syft-grype
+  namespace: flux-system
+spec:
+  interval: 15m
+  releaseName: syft-grype
+  targetNamespace: syft-grype
+  dependsOn:
+    - name: bp-cert-manager
+  chart:
+    spec:
+      chart: bp-syft-grype
+      version: 1.0.0
+      sourceRef:
+        kind: HelmRepository
+        name: bp-syft-grype
+        namespace: flux-system
+  # Event-driven install: the Blueprint is mostly a CronJob + RBAC
+  # surface. There is no long-running Deployment whose Ready=True is
+  # meaningful — disableWait is the correct shape so Flux marks Ready
+  # as soon as manifests apply.
+  install:
+    disableWait: true
+    remediation:
+      retries: 3
+  upgrade:
+    disableWait: true
+    remediation:
+      retries: 3

--- a/clusters/otech.omani.works/bootstrap-kit/34-velero.yaml
+++ b/clusters/otech.omani.works/bootstrap-kit/34-velero.yaml
@@ -1,0 +1,72 @@
+# bp-velero — Catalyst bootstrap-kit Blueprint #34 (W2.K3, Tier 7 — Security/Policy).
+# Per-host-cluster backup engine. Catalyst-Zero pins backups to SeaweedFS
+# (the unified S3 layer, slot 18) so backup data never leaves the
+# Sovereign at install time; per-Sovereign archival to a cloud backend
+# is wired in post-bootstrap via Crossplane.
+#
+# Wrapper chart: platform/velero/chart/ (umbrella over upstream
+# vmware-tanzu/velero chart, Catalyst-curated values under the `velero:`
+# key — `seaweedfs` BackupStorageLocation provider, no cloud plugin
+# pinned at install time).
+# Reconciled by: Flux on the new Sovereign's k3s control plane.
+#
+# dependsOn:
+#   - bp-seaweedfs — Velero's BackupStorageLocation points at the
+#     in-cluster SeaweedFS S3 endpoint (`seaweedfs.seaweedfs.svc:8333`)
+#     and reads the `seaweedfs-s3-credentials` Secret SeaweedFS renders
+#     during install. Without bp-seaweedfs Ready, the BSL Phase sits
+#     `Unavailable` and Velero's first reconcile fails — every backup
+#     CR queues with the same error until the dep lands.
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: velero
+  labels:
+    catalyst.openova.io/sovereign: otech.omani.works
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: bp-velero
+  namespace: flux-system
+spec:
+  type: oci
+  interval: 15m
+  url: oci://ghcr.io/openova-io
+  secretRef:
+    name: ghcr-pull
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: bp-velero
+  namespace: flux-system
+spec:
+  interval: 15m
+  releaseName: velero
+  targetNamespace: velero
+  dependsOn:
+    - name: bp-seaweedfs
+  chart:
+    spec:
+      chart: bp-velero
+      version: 1.0.0
+      sourceRef:
+        kind: HelmRepository
+        name: bp-velero
+        namespace: flux-system
+  # Event-driven install: Velero's Deployment Ready depends on the
+  # node-agent DaemonSet rolling out and the BackupStorageLocation
+  # reaching `Available` — both runtime-convergence events that Flux
+  # observes via the BSL CR phase, not via Helm `--wait`. disableWait
+  # keeps the HR's Ready signal aligned with manifest apply.
+  install:
+    disableWait: true
+    remediation:
+      retries: 3
+  upgrade:
+    disableWait: true
+    remediation:
+      retries: 3

--- a/clusters/otech.omani.works/bootstrap-kit/kustomization.yaml
+++ b/clusters/otech.omani.works/bootstrap-kit/kustomization.yaml
@@ -31,3 +31,11 @@ resources:
   - 24-tempo.yaml
   - 25-grafana.yaml
   - 26-langfuse.yaml
+  - 27-kyverno.yaml
+  - 28-reloader.yaml
+  - 29-vpa.yaml
+  - 30-trivy.yaml
+  - 31-falco.yaml
+  - 32-sigstore.yaml
+  - 33-syft-grype.yaml
+  - 34-velero.yaml


### PR DESCRIPTION
## Summary

Implements **W2.K3** of the bootstrap-kit expansion per [`docs/BOOTSTRAP-KIT-EXPANSION-PLAN.md`](docs/BOOTSTRAP-KIT-EXPANSION-PLAN.md) §2.5 — Tier 7 Security/Policy cohort, slots 27–34. Three cluster copies (`_template`, `omantel.omani.works`, `otech.omani.works`).

## Slots & dependsOn

| Slot | File | Blueprint | dependsOn | Notes |
|---:|---|---|---|---|
| 27 | `27-kyverno.yaml` | `bp-kyverno` | `bp-cilium` (01) | Kubernetes-native admission policy engine (validating / mutating / generating). |
| 28 | `28-reloader.yaml` | `bp-reloader` | _(none)_ | Stakater Reloader; rolling-restart on ConfigMap/Secret change. Independent. |
| 29 | `29-vpa.yaml` | `bp-vpa` | _(none)_ | Vertical Pod Autoscaler (Recommender + Updater + Admission). Independent. |
| 30 | `30-trivy.yaml` | `bp-trivy` | `bp-cert-manager` (02) | Trivy Operator — static vulnerability + misconfig scanner. |
| 31 | `31-falco.yaml` | `bp-falco` | `bp-cilium` (01) | Falco runtime threat detection (eBPF, DaemonSet). |
| 32 | `32-sigstore.yaml` | `bp-sigstore` | `bp-cert-manager` (02) | Sigstore Policy Controller — Cosign admission gate. |
| 33 | `33-syft-grype.yaml` | `bp-syft-grype` | `bp-cert-manager` (02) | Syft (SBOM) + Grype (CVE match) CronJob. |
| 34 | `34-velero.yaml` | `bp-velero` | `bp-seaweedfs` (18) | Per-host backup; SeaweedFS-backed BackupStorageLocation. |

`bp-reloader` and `bp-vpa` intentionally carry **no `dependsOn`** — they are fully independent infrastructure helpers per the plan's §2.5; no phantom dependency was added for ordering convenience.

## DependsOn visualization

```
W2.K3 Tier 7 — Security/Policy (slots 27–34)
═════════════════════════════════════════════════════════════════

Tier 0 roots already present in the kit:
   bp-cilium(01)              bp-cert-manager(02)
       │                              │
       │                              │
Tier 7 additions:                     │
       │                              │
       ├──▶ bp-kyverno(27)            ├──▶ bp-trivy(30)
       │                              │
       └──▶ bp-falco(31)              ├──▶ bp-sigstore(32)
                                      │
                                      └──▶ bp-syft-grype(33)

   bp-reloader(28)        ◀── (no dependsOn)
   bp-vpa(29)             ◀── (no dependsOn)

W2.K1 (slot 18, lands first per merge order):
   bp-seaweedfs(18) ──▶ bp-velero(34)
```

## Conventions followed

- **HR shape** mirrors the post-PR-250 event-driven pattern: `install.disableWait: true` + `upgrade.disableWait: true`, no blanket `spec.timeout`. Per-blueprint comments explain why disableWait is correct (admission webhooks, multi-controller HA Deployments, slow DB hydration, DaemonSet rollout).
- **`SOVEREIGN_FQDN` substitution**: `_template` carries the literal `${SOVEREIGN_FQDN}` placeholder; cluster copies have it expanded to `omantel.omani.works` / `otech.omani.works` at provisioning time. Matches the slot 11/12 convention introduced by PR #168.
- **`kustomization.yaml`** entries appended in numeric order. Slots 15–26 intentionally empty in this PR — reserved for W2.K1 (storage+DB) and W2.K2 (observability). Per plan §4, K2/K3/K4 rebase on K1 when it merges; the `resources:` list is order-preserving but Flux honours `dependsOn`, not list order.

## Validation

```
$ kubectl kustomize clusters/_template/bootstrap-kit/           → OK (22 HRs, 22 HelmRepos, 19 Namespaces)
$ kubectl kustomize clusters/omantel.omani.works/bootstrap-kit/ → OK (22 HRs, 22 HelmRepos, 19 Namespaces)
$ kubectl kustomize clusters/otech.omani.works/bootstrap-kit/   → OK (22 HRs, 22 HelmRepos, 19 Namespaces)
```

14 baseline HRs + 8 W2.K3 HRs = 22 per cluster. All 24 new HR YAMLs parse as 3-doc streams (Namespace + HelmRepository + HelmRelease).

## Chart status

Charts already present in `platform/<name>/chart/` (Chart.yaml v1.0.0 each): kyverno, reloader, trivy, falco, sigstore, syft-grype, velero.

**Note**: `platform/vpa/` currently has only `README.md` — the chart skeleton is tracked separately and does not block this HR-shape PR. Flux will retry the OCI pull until the artifact lands; the dependsOn DAG continues to reconcile around it because slot 29 has no dependents.

## Test plan

- [ ] CI green on `feat/bootstrap-kit-security-batch`
- [ ] PR review confirms `dependsOn` matches plan §2.5 verbatim
- [ ] Verify `kubectl kustomize` succeeds on all three cluster paths (covered above)
- [ ] After merge: rebase W2.K2 / W2.K4 PRs per plan §4.2 (mechanical, slot-numeric resolution)
- [ ] Post-merge on omantel: confirm 8 new HRs progress to Ready once their `dependsOn` chain (`bp-cilium`, `bp-cert-manager`, `bp-seaweedfs`) lands; W2.K1 must merge first for slot 34 to converge.

Refs `docs/BOOTSTRAP-KIT-EXPANSION-PLAN.md` §2.5, §3.1 (W2.K3 row), §4.2 (kustomization merge protocol).

🤖 Generated with [Claude Code](https://claude.com/claude-code)