### PR TITLE
feat(bootstrap-kit): observability batch — slots 20-26 (W2.K2)

### DIFF
--- a/clusters/_template/bootstrap-kit/20-opentelemetry.yaml
+++ b/clusters/_template/bootstrap-kit/20-opentelemetry.yaml
@@ -1,0 +1,74 @@
+# bp-opentelemetry — Catalyst Blueprint #20 (W2.K2 Observability batch).
+# OpenTelemetry Collector — pipeline source for the LGTM stack
+# (Loki / Mimir / Tempo). Receives OTLP from workloads and fans out
+# logs → Loki, metrics → Mimir, traces → Tempo.
+#
+# Wrapper chart:  platform/opentelemetry/chart/
+# Reconciled by:  Flux on the new Sovereign's k3s control plane, AFTER
+#                 bp-cert-manager is Ready (the Collector's webhook /
+#                 OTLP-HTTPS receiver request TLS certs from the cluster
+#                 ClusterIssuer).
+#
+# dependsOn:
+#   - bp-cert-manager (slot 02) — TLS for OTLP-HTTPS receiver and any
+#     Collector webhooks.
+#
+# Hard-but-implicit dependencies (CRDs, NOT sibling Blueprints):
+#   - opentelemetry.io/v1beta1.OpenTelemetryCollector — provided by the
+#     OpenTelemetry Operator subchart bundled in this Blueprint.
+#
+# disableWait: the OTel Collector chart deploys multiple components
+# (operator, collector DaemonSet/Deployment, instrumentation CR). Helm
+# `--wait` would block on every Pod becoming Ready, which can't happen
+# until downstream backends (Loki/Mimir/Tempo, slots 22–24) are up to
+# accept exports. The HelmRelease itself reports Ready as soon as
+# manifests apply cleanly; runtime convergence is observed via kubectl.
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: opentelemetry
+  labels:
+    catalyst.openova.io/sovereign: ${SOVEREIGN_FQDN}
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: bp-opentelemetry
+  namespace: flux-system
+spec:
+  type: oci
+  interval: 15m
+  url: oci://ghcr.io/openova-io
+  secretRef:
+    name: ghcr-pull
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: bp-opentelemetry
+  namespace: flux-system
+spec:
+  interval: 15m
+  timeout: 15m
+  releaseName: opentelemetry
+  targetNamespace: opentelemetry
+  dependsOn:
+    - name: bp-cert-manager
+  chart:
+    spec:
+      chart: bp-opentelemetry
+      version: 1.0.0
+      sourceRef:
+        kind: HelmRepository
+        name: bp-opentelemetry
+        namespace: flux-system
+  install:
+    disableWait: true
+    remediation:
+      retries: 3
+  upgrade:
+    disableWait: true
+    remediation:
+      retries: 3

--- a/clusters/_template/bootstrap-kit/21-alloy.yaml
+++ b/clusters/_template/bootstrap-kit/21-alloy.yaml
@@ -1,0 +1,71 @@
+# bp-alloy — Catalyst Blueprint #21 (W2.K2 Observability batch).
+# Grafana Alloy — the unified telemetry collector for the LGTM stack.
+# Runs as a DaemonSet on every node; tails container logs, scrapes
+# Prometheus metrics, and forwards traces. Co-resident with bp-opentelemetry
+# (slot 20) — Alloy handles host-level collection (kubelet, journald,
+# node_exporter) while OTel handles app-level OTLP.
+#
+# Wrapper chart:  platform/alloy/chart/
+# Reconciled by:  Flux on the new Sovereign's k3s control plane, AFTER
+#                 bp-opentelemetry is Ready (Alloy's default config
+#                 forwards OTLP to the Collector's gRPC endpoint).
+#
+# dependsOn:
+#   - bp-opentelemetry (slot 20) — Alloy forwards OTLP to the Collector.
+#     Without the Collector Service in place, Alloy retries forever on a
+#     non-existent upstream.
+#
+# disableWait: Alloy is a DaemonSet — Helm `--wait` would block on
+# every node's Alloy Pod becoming Ready. On larger Sovereigns this can
+# legitimately take >5min during a cold-start image pull; the HelmRelease
+# reports Ready when manifests apply, runtime convergence observed via
+# kubectl.
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: alloy
+  labels:
+    catalyst.openova.io/sovereign: ${SOVEREIGN_FQDN}
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: bp-alloy
+  namespace: flux-system
+spec:
+  type: oci
+  interval: 15m
+  url: oci://ghcr.io/openova-io
+  secretRef:
+    name: ghcr-pull
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: bp-alloy
+  namespace: flux-system
+spec:
+  interval: 15m
+  timeout: 15m
+  releaseName: alloy
+  targetNamespace: alloy
+  dependsOn:
+    - name: bp-opentelemetry
+  chart:
+    spec:
+      chart: bp-alloy
+      version: 1.0.0
+      sourceRef:
+        kind: HelmRepository
+        name: bp-alloy
+        namespace: flux-system
+  install:
+    disableWait: true
+    remediation:
+      retries: 3
+  upgrade:
+    disableWait: true
+    remediation:
+      retries: 3

--- a/clusters/_template/bootstrap-kit/22-loki.yaml
+++ b/clusters/_template/bootstrap-kit/22-loki.yaml
@@ -1,0 +1,68 @@
+# bp-loki — Catalyst Blueprint #22 (W2.K2 Observability batch).
+# Grafana Loki — log storage tier of the LGTM stack. Default deployment
+# shape is SingleBinary (one Loki StatefulSet) — minimum operational
+# cost for a Solo Sovereign; per-Sovereign overlays scale to
+# distributor/ingester/querier StatefulSets when load warrants.
+#
+# Wrapper chart:  platform/loki/chart/
+# Reconciled by:  Flux on the new Sovereign's k3s control plane, AFTER
+#                 bp-seaweedfs is Ready (Loki chunks/index live on S3).
+#
+# dependsOn:
+#   - bp-seaweedfs (slot 18) — Loki uses SeaweedFS S3 for chunks and
+#     index storage. Without SeaweedFS Ready, Loki cannot persist logs.
+#
+# disableWait: Loki SingleBinary becomes Ready only after creating the
+# S3 bucket and writing the first WAL block — both of which require
+# bp-seaweedfs to be fully reconciled (not just HelmRelease=Ready).
+# Helm `--wait` would block waiting for the StatefulSet rollout, which
+# the HelmRelease cannot influence.
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: loki
+  labels:
+    catalyst.openova.io/sovereign: ${SOVEREIGN_FQDN}
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: bp-loki
+  namespace: flux-system
+spec:
+  type: oci
+  interval: 15m
+  url: oci://ghcr.io/openova-io
+  secretRef:
+    name: ghcr-pull
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: bp-loki
+  namespace: flux-system
+spec:
+  interval: 15m
+  timeout: 15m
+  releaseName: loki
+  targetNamespace: loki
+  dependsOn:
+    - name: bp-seaweedfs
+  chart:
+    spec:
+      chart: bp-loki
+      version: 1.0.0
+      sourceRef:
+        kind: HelmRepository
+        name: bp-loki
+        namespace: flux-system
+  install:
+    disableWait: true
+    remediation:
+      retries: 3
+  upgrade:
+    disableWait: true
+    remediation:
+      retries: 3

--- a/clusters/_template/bootstrap-kit/23-mimir.yaml
+++ b/clusters/_template/bootstrap-kit/23-mimir.yaml
@@ -1,0 +1,68 @@
+# bp-mimir — Catalyst Blueprint #23 (W2.K2 Observability batch).
+# Grafana Mimir — metrics storage tier of the LGTM stack. SeaweedFS-backed
+# blocks-storage; Prometheus-compatible remote-write endpoint.
+#
+# Wrapper chart:  platform/mimir/chart/
+# Reconciled by:  Flux on the new Sovereign's k3s control plane, AFTER
+#                 bp-seaweedfs is Ready (Mimir blocks live on S3).
+#
+# dependsOn:
+#   - bp-seaweedfs (slot 18) — Mimir blocks-storage uses SeaweedFS S3.
+#     Without SeaweedFS Ready, Mimir compactor/ingester StatefulSets
+#     cannot persist metric blocks.
+#
+# disableWait: Mimir is a multi-component distributed system (distributor,
+# ingester, querier, store-gateway, compactor, alertmanager, ruler).
+# Helm `--wait` would block on every StatefulSet rollout, which can
+# legitimately take >5min during a cold-start. The HelmRelease reports
+# Ready when manifests apply; runtime convergence is observed via
+# kubectl rollout status.
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: mimir
+  labels:
+    catalyst.openova.io/sovereign: ${SOVEREIGN_FQDN}
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: bp-mimir
+  namespace: flux-system
+spec:
+  type: oci
+  interval: 15m
+  url: oci://ghcr.io/openova-io
+  secretRef:
+    name: ghcr-pull
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: bp-mimir
+  namespace: flux-system
+spec:
+  interval: 15m
+  timeout: 15m
+  releaseName: mimir
+  targetNamespace: mimir
+  dependsOn:
+    - name: bp-seaweedfs
+  chart:
+    spec:
+      chart: bp-mimir
+      version: 1.0.0
+      sourceRef:
+        kind: HelmRepository
+        name: bp-mimir
+        namespace: flux-system
+  install:
+    disableWait: true
+    remediation:
+      retries: 3
+  upgrade:
+    disableWait: true
+    remediation:
+      retries: 3

--- a/clusters/_template/bootstrap-kit/24-tempo.yaml
+++ b/clusters/_template/bootstrap-kit/24-tempo.yaml
@@ -1,0 +1,66 @@
+# bp-tempo — Catalyst Blueprint #24 (W2.K2 Observability batch).
+# Grafana Tempo — distributed tracing storage tier of the LGTM stack.
+# Default deployment shape is single-binary (one Tempo StatefulSet) —
+# minimum operational cost for a Solo Sovereign.
+#
+# Wrapper chart:  platform/tempo/chart/
+# Reconciled by:  Flux on the new Sovereign's k3s control plane, AFTER
+#                 bp-seaweedfs is Ready (Tempo trace blocks live on S3).
+#
+# dependsOn:
+#   - bp-seaweedfs (slot 18) — Tempo blocks live on SeaweedFS S3.
+#     Without SeaweedFS Ready, Tempo cannot persist spans.
+#
+# disableWait: Tempo single-binary StatefulSet becomes Ready after
+# creating the S3 bucket and initialising the WAL — both require
+# bp-seaweedfs to be fully reconciled. Helm `--wait` would block on
+# the rollout, which the HelmRelease cannot influence.
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: tempo
+  labels:
+    catalyst.openova.io/sovereign: ${SOVEREIGN_FQDN}
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: bp-tempo
+  namespace: flux-system
+spec:
+  type: oci
+  interval: 15m
+  url: oci://ghcr.io/openova-io
+  secretRef:
+    name: ghcr-pull
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: bp-tempo
+  namespace: flux-system
+spec:
+  interval: 15m
+  timeout: 15m
+  releaseName: tempo
+  targetNamespace: tempo
+  dependsOn:
+    - name: bp-seaweedfs
+  chart:
+    spec:
+      chart: bp-tempo
+      version: 1.0.0
+      sourceRef:
+        kind: HelmRepository
+        name: bp-tempo
+        namespace: flux-system
+  install:
+    disableWait: true
+    remediation:
+      retries: 3
+  upgrade:
+    disableWait: true
+    remediation:
+      retries: 3

--- a/clusters/_template/bootstrap-kit/25-grafana.yaml
+++ b/clusters/_template/bootstrap-kit/25-grafana.yaml
@@ -1,0 +1,75 @@
+# bp-grafana — Catalyst Blueprint #25 (W2.K2 Observability batch).
+# Grafana — visualization layer of the LGTM stack. Pairs with bp-loki
+# (logs), bp-mimir (metrics), bp-tempo (traces); CNPG-backed Postgres
+# for dashboard/folder/alert state; Keycloak OIDC for SSO.
+#
+# Wrapper chart:  platform/grafana/chart/
+# Reconciled by:  Flux on the new Sovereign's k3s control plane, AFTER
+#                 bp-cnpg, bp-loki, bp-mimir, bp-tempo, bp-keycloak are
+#                 all Ready.
+#
+# dependsOn:
+#   - bp-cnpg (slot 16)         — Postgres backend for Grafana state.
+#   - bp-loki (slot 22)         — datasource for logs.
+#   - bp-mimir (slot 23)        — datasource for metrics.
+#   - bp-tempo (slot 24)        — datasource for traces.
+#   - bp-keycloak (slot 09)     — OIDC IdP for SSO.
+#
+# disableWait: Grafana waits for its CNPG-managed `grafana-app` Secret
+# (synthesised by bp-cnpg via the chart's Cluster CR), and for upstream
+# datasource endpoints to answer. Helm `--wait` would block on the
+# Deployment rollout, which the HelmRelease cannot influence; runtime
+# convergence is observed via kubectl rollout status.
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: grafana
+  labels:
+    catalyst.openova.io/sovereign: ${SOVEREIGN_FQDN}
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: bp-grafana
+  namespace: flux-system
+spec:
+  type: oci
+  interval: 15m
+  url: oci://ghcr.io/openova-io
+  secretRef:
+    name: ghcr-pull
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: bp-grafana
+  namespace: flux-system
+spec:
+  interval: 15m
+  timeout: 15m
+  releaseName: grafana
+  targetNamespace: grafana
+  dependsOn:
+    - name: bp-cnpg
+    - name: bp-loki
+    - name: bp-mimir
+    - name: bp-tempo
+    - name: bp-keycloak
+  chart:
+    spec:
+      chart: bp-grafana
+      version: 1.0.0
+      sourceRef:
+        kind: HelmRepository
+        name: bp-grafana
+        namespace: flux-system
+  install:
+    disableWait: true
+    remediation:
+      retries: 3
+  upgrade:
+    disableWait: true
+    remediation:
+      retries: 3

--- a/clusters/_template/bootstrap-kit/26-langfuse.yaml
+++ b/clusters/_template/bootstrap-kit/26-langfuse.yaml
@@ -1,0 +1,84 @@
+# bp-langfuse — Catalyst Blueprint #26 (W2.K2 Observability batch).
+# Langfuse — LLM observability platform (traces, evaluations, prompt
+# management, cost attribution). Hooks into the Catalyst LLM gateway
+# (slot 40) once W2.K4 lands. CNPG-backed Postgres; Keycloak OIDC SSO.
+#
+# Wrapper chart:  platform/langfuse/chart/
+# Reconciled by:  Flux on the new Sovereign's k3s control plane, AFTER
+#                 bp-cnpg, bp-keycloak, bp-cert-manager are all Ready.
+#
+# dependsOn:
+#   - bp-cnpg (slot 16)         — Postgres backend for Langfuse traces /
+#                                 prompts / evaluations.
+#   - bp-keycloak (slot 09)     — OIDC IdP for SSO.
+#   - bp-cert-manager (slot 02) — TLS for the Langfuse Ingress.
+#
+# disableWait: Langfuse waits for its CNPG-managed `langfuse-app` Secret
+# and for upstream Bitnami subcharts to be filtered out at template time
+# (the chart sets `postgresql.deploy=false`, `redis.deploy=false`,
+# `clickhouse.deploy=false`, `s3.deploy=false` to route to bp-cnpg /
+# bp-valkey / bp-clickhouse / bp-seaweedfs respectively). Helm `--wait`
+# would block on the Deployment rollout, which the HelmRelease cannot
+# influence.
+#
+# Forward-prep notice — issue #215 (bp-langfuse:1.0.0 GHCR publish 500):
+#   At the time this HR file was authored, bp-langfuse:1.0.0 had not
+#   published to oci://ghcr.io/openova-io due to a Helm v3.16 + GHCR
+#   manifest interaction with langfuse's nested OCI subchart deps. W1.G
+#   is the concurrent track fixing the publish path. Until that lands,
+#   this HelmRelease will fail to install with a chart-pull error; this
+#   is expected and tracked in #215. The HR file is committed now so
+#   the moment the artifact is published, Flux reconciles the SeaweedFS-
+#   /CNPG-/Keycloak-Ready Sovereign to bring Langfuse online without a
+#   second deploy gate.
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: langfuse
+  labels:
+    catalyst.openova.io/sovereign: ${SOVEREIGN_FQDN}
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: bp-langfuse
+  namespace: flux-system
+spec:
+  type: oci
+  interval: 15m
+  url: oci://ghcr.io/openova-io
+  secretRef:
+    name: ghcr-pull
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: bp-langfuse
+  namespace: flux-system
+spec:
+  interval: 15m
+  timeout: 15m
+  releaseName: langfuse
+  targetNamespace: langfuse
+  dependsOn:
+    - name: bp-cnpg
+    - name: bp-keycloak
+    - name: bp-cert-manager
+  chart:
+    spec:
+      chart: bp-langfuse
+      version: 1.0.0
+      sourceRef:
+        kind: HelmRepository
+        name: bp-langfuse
+        namespace: flux-system
+  install:
+    disableWait: true
+    remediation:
+      retries: 3
+  upgrade:
+    disableWait: true
+    remediation:
+      retries: 3

--- a/clusters/_template/bootstrap-kit/kustomization.yaml
+++ b/clusters/_template/bootstrap-kit/kustomization.yaml
@@ -24,3 +24,10 @@ resources:
   - 17-valkey.yaml
   - 18-seaweedfs.yaml
   - 19-harbor.yaml
+  - 20-opentelemetry.yaml
+  - 21-alloy.yaml
+  - 22-loki.yaml
+  - 23-mimir.yaml
+  - 24-tempo.yaml
+  - 25-grafana.yaml
+  - 26-langfuse.yaml

--- a/clusters/omantel.omani.works/bootstrap-kit/20-opentelemetry.yaml
+++ b/clusters/omantel.omani.works/bootstrap-kit/20-opentelemetry.yaml
@@ -1,0 +1,74 @@
+# bp-opentelemetry — Catalyst Blueprint #20 (W2.K2 Observability batch).
+# OpenTelemetry Collector — pipeline source for the LGTM stack
+# (Loki / Mimir / Tempo). Receives OTLP from workloads and fans out
+# logs → Loki, metrics → Mimir, traces → Tempo.
+#
+# Wrapper chart:  platform/opentelemetry/chart/
+# Reconciled by:  Flux on the new Sovereign's k3s control plane, AFTER
+#                 bp-cert-manager is Ready (the Collector's webhook /
+#                 OTLP-HTTPS receiver request TLS certs from the cluster
+#                 ClusterIssuer).
+#
+# dependsOn:
+#   - bp-cert-manager (slot 02) — TLS for OTLP-HTTPS receiver and any
+#     Collector webhooks.
+#
+# Hard-but-implicit dependencies (CRDs, NOT sibling Blueprints):
+#   - opentelemetry.io/v1beta1.OpenTelemetryCollector — provided by the
+#     OpenTelemetry Operator subchart bundled in this Blueprint.
+#
+# disableWait: the OTel Collector chart deploys multiple components
+# (operator, collector DaemonSet/Deployment, instrumentation CR). Helm
+# `--wait` would block on every Pod becoming Ready, which can't happen
+# until downstream backends (Loki/Mimir/Tempo, slots 22–24) are up to
+# accept exports. The HelmRelease itself reports Ready as soon as
+# manifests apply cleanly; runtime convergence is observed via kubectl.
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: opentelemetry
+  labels:
+    catalyst.openova.io/sovereign: omantel.omani.works
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: bp-opentelemetry
+  namespace: flux-system
+spec:
+  type: oci
+  interval: 15m
+  url: oci://ghcr.io/openova-io
+  secretRef:
+    name: ghcr-pull
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: bp-opentelemetry
+  namespace: flux-system
+spec:
+  interval: 15m
+  timeout: 15m
+  releaseName: opentelemetry
+  targetNamespace: opentelemetry
+  dependsOn:
+    - name: bp-cert-manager
+  chart:
+    spec:
+      chart: bp-opentelemetry
+      version: 1.0.0
+      sourceRef:
+        kind: HelmRepository
+        name: bp-opentelemetry
+        namespace: flux-system
+  install:
+    disableWait: true
+    remediation:
+      retries: 3
+  upgrade:
+    disableWait: true
+    remediation:
+      retries: 3

--- a/clusters/omantel.omani.works/bootstrap-kit/21-alloy.yaml
+++ b/clusters/omantel.omani.works/bootstrap-kit/21-alloy.yaml
@@ -1,0 +1,71 @@
+# bp-alloy — Catalyst Blueprint #21 (W2.K2 Observability batch).
+# Grafana Alloy — the unified telemetry collector for the LGTM stack.
+# Runs as a DaemonSet on every node; tails container logs, scrapes
+# Prometheus metrics, and forwards traces. Co-resident with bp-opentelemetry
+# (slot 20) — Alloy handles host-level collection (kubelet, journald,
+# node_exporter) while OTel handles app-level OTLP.
+#
+# Wrapper chart:  platform/alloy/chart/
+# Reconciled by:  Flux on the new Sovereign's k3s control plane, AFTER
+#                 bp-opentelemetry is Ready (Alloy's default config
+#                 forwards OTLP to the Collector's gRPC endpoint).
+#
+# dependsOn:
+#   - bp-opentelemetry (slot 20) — Alloy forwards OTLP to the Collector.
+#     Without the Collector Service in place, Alloy retries forever on a
+#     non-existent upstream.
+#
+# disableWait: Alloy is a DaemonSet — Helm `--wait` would block on
+# every node's Alloy Pod becoming Ready. On larger Sovereigns this can
+# legitimately take >5min during a cold-start image pull; the HelmRelease
+# reports Ready when manifests apply, runtime convergence observed via
+# kubectl.
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: alloy
+  labels:
+    catalyst.openova.io/sovereign: omantel.omani.works
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: bp-alloy
+  namespace: flux-system
+spec:
+  type: oci
+  interval: 15m
+  url: oci://ghcr.io/openova-io
+  secretRef:
+    name: ghcr-pull
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: bp-alloy
+  namespace: flux-system
+spec:
+  interval: 15m
+  timeout: 15m
+  releaseName: alloy
+  targetNamespace: alloy
+  dependsOn:
+    - name: bp-opentelemetry
+  chart:
+    spec:
+      chart: bp-alloy
+      version: 1.0.0
+      sourceRef:
+        kind: HelmRepository
+        name: bp-alloy
+        namespace: flux-system
+  install:
+    disableWait: true
+    remediation:
+      retries: 3
+  upgrade:
+    disableWait: true
+    remediation:
+      retries: 3

--- a/clusters/omantel.omani.works/bootstrap-kit/22-loki.yaml
+++ b/clusters/omantel.omani.works/bootstrap-kit/22-loki.yaml
@@ -1,0 +1,68 @@
+# bp-loki — Catalyst Blueprint #22 (W2.K2 Observability batch).
+# Grafana Loki — log storage tier of the LGTM stack. Default deployment
+# shape is SingleBinary (one Loki StatefulSet) — minimum operational
+# cost for a Solo Sovereign; per-Sovereign overlays scale to
+# distributor/ingester/querier StatefulSets when load warrants.
+#
+# Wrapper chart:  platform/loki/chart/
+# Reconciled by:  Flux on the new Sovereign's k3s control plane, AFTER
+#                 bp-seaweedfs is Ready (Loki chunks/index live on S3).
+#
+# dependsOn:
+#   - bp-seaweedfs (slot 18) — Loki uses SeaweedFS S3 for chunks and
+#     index storage. Without SeaweedFS Ready, Loki cannot persist logs.
+#
+# disableWait: Loki SingleBinary becomes Ready only after creating the
+# S3 bucket and writing the first WAL block — both of which require
+# bp-seaweedfs to be fully reconciled (not just HelmRelease=Ready).
+# Helm `--wait` would block waiting for the StatefulSet rollout, which
+# the HelmRelease cannot influence.
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: loki
+  labels:
+    catalyst.openova.io/sovereign: omantel.omani.works
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: bp-loki
+  namespace: flux-system
+spec:
+  type: oci
+  interval: 15m
+  url: oci://ghcr.io/openova-io
+  secretRef:
+    name: ghcr-pull
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: bp-loki
+  namespace: flux-system
+spec:
+  interval: 15m
+  timeout: 15m
+  releaseName: loki
+  targetNamespace: loki
+  dependsOn:
+    - name: bp-seaweedfs
+  chart:
+    spec:
+      chart: bp-loki
+      version: 1.0.0
+      sourceRef:
+        kind: HelmRepository
+        name: bp-loki
+        namespace: flux-system
+  install:
+    disableWait: true
+    remediation:
+      retries: 3
+  upgrade:
+    disableWait: true
+    remediation:
+      retries: 3

--- a/clusters/omantel.omani.works/bootstrap-kit/23-mimir.yaml
+++ b/clusters/omantel.omani.works/bootstrap-kit/23-mimir.yaml
@@ -1,0 +1,68 @@
+# bp-mimir — Catalyst Blueprint #23 (W2.K2 Observability batch).
+# Grafana Mimir — metrics storage tier of the LGTM stack. SeaweedFS-backed
+# blocks-storage; Prometheus-compatible remote-write endpoint.
+#
+# Wrapper chart:  platform/mimir/chart/
+# Reconciled by:  Flux on the new Sovereign's k3s control plane, AFTER
+#                 bp-seaweedfs is Ready (Mimir blocks live on S3).
+#
+# dependsOn:
+#   - bp-seaweedfs (slot 18) — Mimir blocks-storage uses SeaweedFS S3.
+#     Without SeaweedFS Ready, Mimir compactor/ingester StatefulSets
+#     cannot persist metric blocks.
+#
+# disableWait: Mimir is a multi-component distributed system (distributor,
+# ingester, querier, store-gateway, compactor, alertmanager, ruler).
+# Helm `--wait` would block on every StatefulSet rollout, which can
+# legitimately take >5min during a cold-start. The HelmRelease reports
+# Ready when manifests apply; runtime convergence is observed via
+# kubectl rollout status.
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: mimir
+  labels:
+    catalyst.openova.io/sovereign: omantel.omani.works
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: bp-mimir
+  namespace: flux-system
+spec:
+  type: oci
+  interval: 15m
+  url: oci://ghcr.io/openova-io
+  secretRef:
+    name: ghcr-pull
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: bp-mimir
+  namespace: flux-system
+spec:
+  interval: 15m
+  timeout: 15m
+  releaseName: mimir
+  targetNamespace: mimir
+  dependsOn:
+    - name: bp-seaweedfs
+  chart:
+    spec:
+      chart: bp-mimir
+      version: 1.0.0
+      sourceRef:
+        kind: HelmRepository
+        name: bp-mimir
+        namespace: flux-system
+  install:
+    disableWait: true
+    remediation:
+      retries: 3
+  upgrade:
+    disableWait: true
+    remediation:
+      retries: 3

--- a/clusters/omantel.omani.works/bootstrap-kit/24-tempo.yaml
+++ b/clusters/omantel.omani.works/bootstrap-kit/24-tempo.yaml
@@ -1,0 +1,66 @@
+# bp-tempo — Catalyst Blueprint #24 (W2.K2 Observability batch).
+# Grafana Tempo — distributed tracing storage tier of the LGTM stack.
+# Default deployment shape is single-binary (one Tempo StatefulSet) —
+# minimum operational cost for a Solo Sovereign.
+#
+# Wrapper chart:  platform/tempo/chart/
+# Reconciled by:  Flux on the new Sovereign's k3s control plane, AFTER
+#                 bp-seaweedfs is Ready (Tempo trace blocks live on S3).
+#
+# dependsOn:
+#   - bp-seaweedfs (slot 18) — Tempo blocks live on SeaweedFS S3.
+#     Without SeaweedFS Ready, Tempo cannot persist spans.
+#
+# disableWait: Tempo single-binary StatefulSet becomes Ready after
+# creating the S3 bucket and initialising the WAL — both require
+# bp-seaweedfs to be fully reconciled. Helm `--wait` would block on
+# the rollout, which the HelmRelease cannot influence.
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: tempo
+  labels:
+    catalyst.openova.io/sovereign: omantel.omani.works
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: bp-tempo
+  namespace: flux-system
+spec:
+  type: oci
+  interval: 15m
+  url: oci://ghcr.io/openova-io
+  secretRef:
+    name: ghcr-pull
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: bp-tempo
+  namespace: flux-system
+spec:
+  interval: 15m
+  timeout: 15m
+  releaseName: tempo
+  targetNamespace: tempo
+  dependsOn:
+    - name: bp-seaweedfs
+  chart:
+    spec:
+      chart: bp-tempo
+      version: 1.0.0
+      sourceRef:
+        kind: HelmRepository
+        name: bp-tempo
+        namespace: flux-system
+  install:
+    disableWait: true
+    remediation:
+      retries: 3
+  upgrade:
+    disableWait: true
+    remediation:
+      retries: 3

--- a/clusters/omantel.omani.works/bootstrap-kit/25-grafana.yaml
+++ b/clusters/omantel.omani.works/bootstrap-kit/25-grafana.yaml
@@ -1,0 +1,75 @@
+# bp-grafana — Catalyst Blueprint #25 (W2.K2 Observability batch).
+# Grafana — visualization layer of the LGTM stack. Pairs with bp-loki
+# (logs), bp-mimir (metrics), bp-tempo (traces); CNPG-backed Postgres
+# for dashboard/folder/alert state; Keycloak OIDC for SSO.
+#
+# Wrapper chart:  platform/grafana/chart/
+# Reconciled by:  Flux on the new Sovereign's k3s control plane, AFTER
+#                 bp-cnpg, bp-loki, bp-mimir, bp-tempo, bp-keycloak are
+#                 all Ready.
+#
+# dependsOn:
+#   - bp-cnpg (slot 16)         — Postgres backend for Grafana state.
+#   - bp-loki (slot 22)         — datasource for logs.
+#   - bp-mimir (slot 23)        — datasource for metrics.
+#   - bp-tempo (slot 24)        — datasource for traces.
+#   - bp-keycloak (slot 09)     — OIDC IdP for SSO.
+#
+# disableWait: Grafana waits for its CNPG-managed `grafana-app` Secret
+# (synthesised by bp-cnpg via the chart's Cluster CR), and for upstream
+# datasource endpoints to answer. Helm `--wait` would block on the
+# Deployment rollout, which the HelmRelease cannot influence; runtime
+# convergence is observed via kubectl rollout status.
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: grafana
+  labels:
+    catalyst.openova.io/sovereign: omantel.omani.works
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: bp-grafana
+  namespace: flux-system
+spec:
+  type: oci
+  interval: 15m
+  url: oci://ghcr.io/openova-io
+  secretRef:
+    name: ghcr-pull
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: bp-grafana
+  namespace: flux-system
+spec:
+  interval: 15m
+  timeout: 15m
+  releaseName: grafana
+  targetNamespace: grafana
+  dependsOn:
+    - name: bp-cnpg
+    - name: bp-loki
+    - name: bp-mimir
+    - name: bp-tempo
+    - name: bp-keycloak
+  chart:
+    spec:
+      chart: bp-grafana
+      version: 1.0.0
+      sourceRef:
+        kind: HelmRepository
+        name: bp-grafana
+        namespace: flux-system
+  install:
+    disableWait: true
+    remediation:
+      retries: 3
+  upgrade:
+    disableWait: true
+    remediation:
+      retries: 3

--- a/clusters/omantel.omani.works/bootstrap-kit/26-langfuse.yaml
+++ b/clusters/omantel.omani.works/bootstrap-kit/26-langfuse.yaml
@@ -1,0 +1,84 @@
+# bp-langfuse — Catalyst Blueprint #26 (W2.K2 Observability batch).
+# Langfuse — LLM observability platform (traces, evaluations, prompt
+# management, cost attribution). Hooks into the Catalyst LLM gateway
+# (slot 40) once W2.K4 lands. CNPG-backed Postgres; Keycloak OIDC SSO.
+#
+# Wrapper chart:  platform/langfuse/chart/
+# Reconciled by:  Flux on the new Sovereign's k3s control plane, AFTER
+#                 bp-cnpg, bp-keycloak, bp-cert-manager are all Ready.
+#
+# dependsOn:
+#   - bp-cnpg (slot 16)         — Postgres backend for Langfuse traces /
+#                                 prompts / evaluations.
+#   - bp-keycloak (slot 09)     — OIDC IdP for SSO.
+#   - bp-cert-manager (slot 02) — TLS for the Langfuse Ingress.
+#
+# disableWait: Langfuse waits for its CNPG-managed `langfuse-app` Secret
+# and for upstream Bitnami subcharts to be filtered out at template time
+# (the chart sets `postgresql.deploy=false`, `redis.deploy=false`,
+# `clickhouse.deploy=false`, `s3.deploy=false` to route to bp-cnpg /
+# bp-valkey / bp-clickhouse / bp-seaweedfs respectively). Helm `--wait`
+# would block on the Deployment rollout, which the HelmRelease cannot
+# influence.
+#
+# Forward-prep notice — issue #215 (bp-langfuse:1.0.0 GHCR publish 500):
+#   At the time this HR file was authored, bp-langfuse:1.0.0 had not
+#   published to oci://ghcr.io/openova-io due to a Helm v3.16 + GHCR
+#   manifest interaction with langfuse's nested OCI subchart deps. W1.G
+#   is the concurrent track fixing the publish path. Until that lands,
+#   this HelmRelease will fail to install with a chart-pull error; this
+#   is expected and tracked in #215. The HR file is committed now so
+#   the moment the artifact is published, Flux reconciles the SeaweedFS-
+#   /CNPG-/Keycloak-Ready Sovereign to bring Langfuse online without a
+#   second deploy gate.
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: langfuse
+  labels:
+    catalyst.openova.io/sovereign: omantel.omani.works
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: bp-langfuse
+  namespace: flux-system
+spec:
+  type: oci
+  interval: 15m
+  url: oci://ghcr.io/openova-io
+  secretRef:
+    name: ghcr-pull
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: bp-langfuse
+  namespace: flux-system
+spec:
+  interval: 15m
+  timeout: 15m
+  releaseName: langfuse
+  targetNamespace: langfuse
+  dependsOn:
+    - name: bp-cnpg
+    - name: bp-keycloak
+    - name: bp-cert-manager
+  chart:
+    spec:
+      chart: bp-langfuse
+      version: 1.0.0
+      sourceRef:
+        kind: HelmRepository
+        name: bp-langfuse
+        namespace: flux-system
+  install:
+    disableWait: true
+    remediation:
+      retries: 3
+  upgrade:
+    disableWait: true
+    remediation:
+      retries: 3

--- a/clusters/omantel.omani.works/bootstrap-kit/kustomization.yaml
+++ b/clusters/omantel.omani.works/bootstrap-kit/kustomization.yaml
@@ -24,3 +24,10 @@ resources:
   - 17-valkey.yaml
   - 18-seaweedfs.yaml
   - 19-harbor.yaml
+  - 20-opentelemetry.yaml
+  - 21-alloy.yaml
+  - 22-loki.yaml
+  - 23-mimir.yaml
+  - 24-tempo.yaml
+  - 25-grafana.yaml
+  - 26-langfuse.yaml

--- a/clusters/otech.omani.works/bootstrap-kit/20-opentelemetry.yaml
+++ b/clusters/otech.omani.works/bootstrap-kit/20-opentelemetry.yaml
@@ -1,0 +1,74 @@
+# bp-opentelemetry — Catalyst Blueprint #20 (W2.K2 Observability batch).
+# OpenTelemetry Collector — pipeline source for the LGTM stack
+# (Loki / Mimir / Tempo). Receives OTLP from workloads and fans out
+# logs → Loki, metrics → Mimir, traces → Tempo.
+#
+# Wrapper chart:  platform/opentelemetry/chart/
+# Reconciled by:  Flux on the new Sovereign's k3s control plane, AFTER
+#                 bp-cert-manager is Ready (the Collector's webhook /
+#                 OTLP-HTTPS receiver request TLS certs from the cluster
+#                 ClusterIssuer).
+#
+# dependsOn:
+#   - bp-cert-manager (slot 02) — TLS for OTLP-HTTPS receiver and any
+#     Collector webhooks.
+#
+# Hard-but-implicit dependencies (CRDs, NOT sibling Blueprints):
+#   - opentelemetry.io/v1beta1.OpenTelemetryCollector — provided by the
+#     OpenTelemetry Operator subchart bundled in this Blueprint.
+#
+# disableWait: the OTel Collector chart deploys multiple components
+# (operator, collector DaemonSet/Deployment, instrumentation CR). Helm
+# `--wait` would block on every Pod becoming Ready, which can't happen
+# until downstream backends (Loki/Mimir/Tempo, slots 22–24) are up to
+# accept exports. The HelmRelease itself reports Ready as soon as
+# manifests apply cleanly; runtime convergence is observed via kubectl.
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: opentelemetry
+  labels:
+    catalyst.openova.io/sovereign: otech.omani.works
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: bp-opentelemetry
+  namespace: flux-system
+spec:
+  type: oci
+  interval: 15m
+  url: oci://ghcr.io/openova-io
+  secretRef:
+    name: ghcr-pull
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: bp-opentelemetry
+  namespace: flux-system
+spec:
+  interval: 15m
+  timeout: 15m
+  releaseName: opentelemetry
+  targetNamespace: opentelemetry
+  dependsOn:
+    - name: bp-cert-manager
+  chart:
+    spec:
+      chart: bp-opentelemetry
+      version: 1.0.0
+      sourceRef:
+        kind: HelmRepository
+        name: bp-opentelemetry
+        namespace: flux-system
+  install:
+    disableWait: true
+    remediation:
+      retries: 3
+  upgrade:
+    disableWait: true
+    remediation:
+      retries: 3

--- a/clusters/otech.omani.works/bootstrap-kit/21-alloy.yaml
+++ b/clusters/otech.omani.works/bootstrap-kit/21-alloy.yaml
@@ -1,0 +1,71 @@
+# bp-alloy — Catalyst Blueprint #21 (W2.K2 Observability batch).
+# Grafana Alloy — the unified telemetry collector for the LGTM stack.
+# Runs as a DaemonSet on every node; tails container logs, scrapes
+# Prometheus metrics, and forwards traces. Co-resident with bp-opentelemetry
+# (slot 20) — Alloy handles host-level collection (kubelet, journald,
+# node_exporter) while OTel handles app-level OTLP.
+#
+# Wrapper chart:  platform/alloy/chart/
+# Reconciled by:  Flux on the new Sovereign's k3s control plane, AFTER
+#                 bp-opentelemetry is Ready (Alloy's default config
+#                 forwards OTLP to the Collector's gRPC endpoint).
+#
+# dependsOn:
+#   - bp-opentelemetry (slot 20) — Alloy forwards OTLP to the Collector.
+#     Without the Collector Service in place, Alloy retries forever on a
+#     non-existent upstream.
+#
+# disableWait: Alloy is a DaemonSet — Helm `--wait` would block on
+# every node's Alloy Pod becoming Ready. On larger Sovereigns this can
+# legitimately take >5min during a cold-start image pull; the HelmRelease
+# reports Ready when manifests apply, runtime convergence observed via
+# kubectl.
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: alloy
+  labels:
+    catalyst.openova.io/sovereign: otech.omani.works
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: bp-alloy
+  namespace: flux-system
+spec:
+  type: oci
+  interval: 15m
+  url: oci://ghcr.io/openova-io
+  secretRef:
+    name: ghcr-pull
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: bp-alloy
+  namespace: flux-system
+spec:
+  interval: 15m
+  timeout: 15m
+  releaseName: alloy
+  targetNamespace: alloy
+  dependsOn:
+    - name: bp-opentelemetry
+  chart:
+    spec:
+      chart: bp-alloy
+      version: 1.0.0
+      sourceRef:
+        kind: HelmRepository
+        name: bp-alloy
+        namespace: flux-system
+  install:
+    disableWait: true
+    remediation:
+      retries: 3
+  upgrade:
+    disableWait: true
+    remediation:
+      retries: 3

--- a/clusters/otech.omani.works/bootstrap-kit/22-loki.yaml
+++ b/clusters/otech.omani.works/bootstrap-kit/22-loki.yaml
@@ -1,0 +1,68 @@
+# bp-loki — Catalyst Blueprint #22 (W2.K2 Observability batch).
+# Grafana Loki — log storage tier of the LGTM stack. Default deployment
+# shape is SingleBinary (one Loki StatefulSet) — minimum operational
+# cost for a Solo Sovereign; per-Sovereign overlays scale to
+# distributor/ingester/querier StatefulSets when load warrants.
+#
+# Wrapper chart:  platform/loki/chart/
+# Reconciled by:  Flux on the new Sovereign's k3s control plane, AFTER
+#                 bp-seaweedfs is Ready (Loki chunks/index live on S3).
+#
+# dependsOn:
+#   - bp-seaweedfs (slot 18) — Loki uses SeaweedFS S3 for chunks and
+#     index storage. Without SeaweedFS Ready, Loki cannot persist logs.
+#
+# disableWait: Loki SingleBinary becomes Ready only after creating the
+# S3 bucket and writing the first WAL block — both of which require
+# bp-seaweedfs to be fully reconciled (not just HelmRelease=Ready).
+# Helm `--wait` would block waiting for the StatefulSet rollout, which
+# the HelmRelease cannot influence.
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: loki
+  labels:
+    catalyst.openova.io/sovereign: otech.omani.works
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: bp-loki
+  namespace: flux-system
+spec:
+  type: oci
+  interval: 15m
+  url: oci://ghcr.io/openova-io
+  secretRef:
+    name: ghcr-pull
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: bp-loki
+  namespace: flux-system
+spec:
+  interval: 15m
+  timeout: 15m
+  releaseName: loki
+  targetNamespace: loki
+  dependsOn:
+    - name: bp-seaweedfs
+  chart:
+    spec:
+      chart: bp-loki
+      version: 1.0.0
+      sourceRef:
+        kind: HelmRepository
+        name: bp-loki
+        namespace: flux-system
+  install:
+    disableWait: true
+    remediation:
+      retries: 3
+  upgrade:
+    disableWait: true
+    remediation:
+      retries: 3

--- a/clusters/otech.omani.works/bootstrap-kit/23-mimir.yaml
+++ b/clusters/otech.omani.works/bootstrap-kit/23-mimir.yaml
@@ -1,0 +1,68 @@
+# bp-mimir — Catalyst Blueprint #23 (W2.K2 Observability batch).
+# Grafana Mimir — metrics storage tier of the LGTM stack. SeaweedFS-backed
+# blocks-storage; Prometheus-compatible remote-write endpoint.
+#
+# Wrapper chart:  platform/mimir/chart/
+# Reconciled by:  Flux on the new Sovereign's k3s control plane, AFTER
+#                 bp-seaweedfs is Ready (Mimir blocks live on S3).
+#
+# dependsOn:
+#   - bp-seaweedfs (slot 18) — Mimir blocks-storage uses SeaweedFS S3.
+#     Without SeaweedFS Ready, Mimir compactor/ingester StatefulSets
+#     cannot persist metric blocks.
+#
+# disableWait: Mimir is a multi-component distributed system (distributor,
+# ingester, querier, store-gateway, compactor, alertmanager, ruler).
+# Helm `--wait` would block on every StatefulSet rollout, which can
+# legitimately take >5min during a cold-start. The HelmRelease reports
+# Ready when manifests apply; runtime convergence is observed via
+# kubectl rollout status.
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: mimir
+  labels:
+    catalyst.openova.io/sovereign: otech.omani.works
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: bp-mimir
+  namespace: flux-system
+spec:
+  type: oci
+  interval: 15m
+  url: oci://ghcr.io/openova-io
+  secretRef:
+    name: ghcr-pull
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: bp-mimir
+  namespace: flux-system
+spec:
+  interval: 15m
+  timeout: 15m
+  releaseName: mimir
+  targetNamespace: mimir
+  dependsOn:
+    - name: bp-seaweedfs
+  chart:
+    spec:
+      chart: bp-mimir
+      version: 1.0.0
+      sourceRef:
+        kind: HelmRepository
+        name: bp-mimir
+        namespace: flux-system
+  install:
+    disableWait: true
+    remediation:
+      retries: 3
+  upgrade:
+    disableWait: true
+    remediation:
+      retries: 3

--- a/clusters/otech.omani.works/bootstrap-kit/24-tempo.yaml
+++ b/clusters/otech.omani.works/bootstrap-kit/24-tempo.yaml
@@ -1,0 +1,66 @@
+# bp-tempo — Catalyst Blueprint #24 (W2.K2 Observability batch).
+# Grafana Tempo — distributed tracing storage tier of the LGTM stack.
+# Default deployment shape is single-binary (one Tempo StatefulSet) —
+# minimum operational cost for a Solo Sovereign.
+#
+# Wrapper chart:  platform/tempo/chart/
+# Reconciled by:  Flux on the new Sovereign's k3s control plane, AFTER
+#                 bp-seaweedfs is Ready (Tempo trace blocks live on S3).
+#
+# dependsOn:
+#   - bp-seaweedfs (slot 18) — Tempo blocks live on SeaweedFS S3.
+#     Without SeaweedFS Ready, Tempo cannot persist spans.
+#
+# disableWait: Tempo single-binary StatefulSet becomes Ready after
+# creating the S3 bucket and initialising the WAL — both require
+# bp-seaweedfs to be fully reconciled. Helm `--wait` would block on
+# the rollout, which the HelmRelease cannot influence.
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: tempo
+  labels:
+    catalyst.openova.io/sovereign: otech.omani.works
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: bp-tempo
+  namespace: flux-system
+spec:
+  type: oci
+  interval: 15m
+  url: oci://ghcr.io/openova-io
+  secretRef:
+    name: ghcr-pull
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: bp-tempo
+  namespace: flux-system
+spec:
+  interval: 15m
+  timeout: 15m
+  releaseName: tempo
+  targetNamespace: tempo
+  dependsOn:
+    - name: bp-seaweedfs
+  chart:
+    spec:
+      chart: bp-tempo
+      version: 1.0.0
+      sourceRef:
+        kind: HelmRepository
+        name: bp-tempo
+        namespace: flux-system
+  install:
+    disableWait: true
+    remediation:
+      retries: 3
+  upgrade:
+    disableWait: true
+    remediation:
+      retries: 3

--- a/clusters/otech.omani.works/bootstrap-kit/25-grafana.yaml
+++ b/clusters/otech.omani.works/bootstrap-kit/25-grafana.yaml
@@ -1,0 +1,75 @@
+# bp-grafana — Catalyst Blueprint #25 (W2.K2 Observability batch).
+# Grafana — visualization layer of the LGTM stack. Pairs with bp-loki
+# (logs), bp-mimir (metrics), bp-tempo (traces); CNPG-backed Postgres
+# for dashboard/folder/alert state; Keycloak OIDC for SSO.
+#
+# Wrapper chart:  platform/grafana/chart/
+# Reconciled by:  Flux on the new Sovereign's k3s control plane, AFTER
+#                 bp-cnpg, bp-loki, bp-mimir, bp-tempo, bp-keycloak are
+#                 all Ready.
+#
+# dependsOn:
+#   - bp-cnpg (slot 16)         — Postgres backend for Grafana state.
+#   - bp-loki (slot 22)         — datasource for logs.
+#   - bp-mimir (slot 23)        — datasource for metrics.
+#   - bp-tempo (slot 24)        — datasource for traces.
+#   - bp-keycloak (slot 09)     — OIDC IdP for SSO.
+#
+# disableWait: Grafana waits for its CNPG-managed `grafana-app` Secret
+# (synthesised by bp-cnpg via the chart's Cluster CR), and for upstream
+# datasource endpoints to answer. Helm `--wait` would block on the
+# Deployment rollout, which the HelmRelease cannot influence; runtime
+# convergence is observed via kubectl rollout status.
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: grafana
+  labels:
+    catalyst.openova.io/sovereign: otech.omani.works
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: bp-grafana
+  namespace: flux-system
+spec:
+  type: oci
+  interval: 15m
+  url: oci://ghcr.io/openova-io
+  secretRef:
+    name: ghcr-pull
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: bp-grafana
+  namespace: flux-system
+spec:
+  interval: 15m
+  timeout: 15m
+  releaseName: grafana
+  targetNamespace: grafana
+  dependsOn:
+    - name: bp-cnpg
+    - name: bp-loki
+    - name: bp-mimir
+    - name: bp-tempo
+    - name: bp-keycloak
+  chart:
+    spec:
+      chart: bp-grafana
+      version: 1.0.0
+      sourceRef:
+        kind: HelmRepository
+        name: bp-grafana
+        namespace: flux-system
+  install:
+    disableWait: true
+    remediation:
+      retries: 3
+  upgrade:
+    disableWait: true
+    remediation:
+      retries: 3

--- a/clusters/otech.omani.works/bootstrap-kit/26-langfuse.yaml
+++ b/clusters/otech.omani.works/bootstrap-kit/26-langfuse.yaml
@@ -1,0 +1,84 @@
+# bp-langfuse — Catalyst Blueprint #26 (W2.K2 Observability batch).
+# Langfuse — LLM observability platform (traces, evaluations, prompt
+# management, cost attribution). Hooks into the Catalyst LLM gateway
+# (slot 40) once W2.K4 lands. CNPG-backed Postgres; Keycloak OIDC SSO.
+#
+# Wrapper chart:  platform/langfuse/chart/
+# Reconciled by:  Flux on the new Sovereign's k3s control plane, AFTER
+#                 bp-cnpg, bp-keycloak, bp-cert-manager are all Ready.
+#
+# dependsOn:
+#   - bp-cnpg (slot 16)         — Postgres backend for Langfuse traces /
+#                                 prompts / evaluations.
+#   - bp-keycloak (slot 09)     — OIDC IdP for SSO.
+#   - bp-cert-manager (slot 02) — TLS for the Langfuse Ingress.
+#
+# disableWait: Langfuse waits for its CNPG-managed `langfuse-app` Secret
+# and for upstream Bitnami subcharts to be filtered out at template time
+# (the chart sets `postgresql.deploy=false`, `redis.deploy=false`,
+# `clickhouse.deploy=false`, `s3.deploy=false` to route to bp-cnpg /
+# bp-valkey / bp-clickhouse / bp-seaweedfs respectively). Helm `--wait`
+# would block on the Deployment rollout, which the HelmRelease cannot
+# influence.
+#
+# Forward-prep notice — issue #215 (bp-langfuse:1.0.0 GHCR publish 500):
+#   At the time this HR file was authored, bp-langfuse:1.0.0 had not
+#   published to oci://ghcr.io/openova-io due to a Helm v3.16 + GHCR
+#   manifest interaction with langfuse's nested OCI subchart deps. W1.G
+#   is the concurrent track fixing the publish path. Until that lands,
+#   this HelmRelease will fail to install with a chart-pull error; this
+#   is expected and tracked in #215. The HR file is committed now so
+#   the moment the artifact is published, Flux reconciles the SeaweedFS-
+#   /CNPG-/Keycloak-Ready Sovereign to bring Langfuse online without a
+#   second deploy gate.
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: langfuse
+  labels:
+    catalyst.openova.io/sovereign: otech.omani.works
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: bp-langfuse
+  namespace: flux-system
+spec:
+  type: oci
+  interval: 15m
+  url: oci://ghcr.io/openova-io
+  secretRef:
+    name: ghcr-pull
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: bp-langfuse
+  namespace: flux-system
+spec:
+  interval: 15m
+  timeout: 15m
+  releaseName: langfuse
+  targetNamespace: langfuse
+  dependsOn:
+    - name: bp-cnpg
+    - name: bp-keycloak
+    - name: bp-cert-manager
+  chart:
+    spec:
+      chart: bp-langfuse
+      version: 1.0.0
+      sourceRef:
+        kind: HelmRepository
+        name: bp-langfuse
+        namespace: flux-system
+  install:
+    disableWait: true
+    remediation:
+      retries: 3
+  upgrade:
+    disableWait: true
+    remediation:
+      retries: 3

--- a/clusters/otech.omani.works/bootstrap-kit/kustomization.yaml
+++ b/clusters/otech.omani.works/bootstrap-kit/kustomization.yaml
@@ -24,3 +24,10 @@ resources:
   - 17-valkey.yaml
   - 18-seaweedfs.yaml
   - 19-harbor.yaml
+  - 20-opentelemetry.yaml
+  - 21-alloy.yaml
+  - 22-loki.yaml
+  - 23-mimir.yaml
+  - 24-tempo.yaml
+  - 25-grafana.yaml
+  - 26-langfuse.yaml


### PR DESCRIPTION
## Summary

Implements **W2.K2 — Tier-6 observability batch** of the bootstrap-kit expansion per [`docs/BOOTSTRAP-KIT-EXPANSION-PLAN.md`](docs/BOOTSTRAP-KIT-EXPANSION-PLAN.md) §2.4. Adds 7 HelmRelease files (slots 20–26) to all three cluster directories (`_template`, `omantel.omani.works`, `otech.omani.works`), and appends them to each cluster's `kustomization.yaml` in numeric slot order.

## Slots added

| Slot | Blueprint           | Namespace        | dependsOn                                           |
|-----:|---------------------|------------------|-----------------------------------------------------|
|   20 | `bp-opentelemetry`  | `opentelemetry`  | `bp-cert-manager` (slot 02)                         |
|   21 | `bp-alloy`          | `alloy`          | `bp-opentelemetry` (slot 20)                        |
|   22 | `bp-loki`           | `loki`           | `bp-seaweedfs` (slot 18)                            |
|   23 | `bp-mimir`          | `mimir`          | `bp-seaweedfs` (slot 18)                            |
|   24 | `bp-tempo`          | `tempo`          | `bp-seaweedfs` (slot 18)                            |
|   25 | `bp-grafana`        | `grafana`        | `bp-cnpg` (16), `bp-loki` (22), `bp-mimir` (23), `bp-tempo` (24), `bp-keycloak` (09) |
|   26 | `bp-langfuse`       | `langfuse`       | `bp-cnpg` (16), `bp-keycloak` (09), `bp-cert-manager` (02) |

## DependsOn chain — Tier 6 sub-DAG

```
bp-cert-manager (02) ──► bp-opentelemetry (20) ──► bp-alloy (21)
                          │
bp-seaweedfs (18) ────────┼───────────────────────► bp-loki (22) ─┐
                          ├───────────────────────► bp-mimir (23) ┼─► bp-grafana (25)
                          └───────────────────────► bp-tempo (24) ┘    ▲
                                                                       │
bp-cnpg (16) ──────────────────────────────────────────────────────────┤
bp-keycloak (09) ──────────────────────────────────────────────────────┤
                                                                       │
bp-cert-manager (02) ──┐
bp-cnpg (16) ──────────┼──► bp-langfuse (26)
bp-keycloak (09) ──────┘
```

## Pattern + constraints

Each HR file follows the canonical bootstrap-kit shape (see `11-powerdns.yaml`, `13-bp-catalyst-platform.yaml`):

- `Namespace` with `catalyst.openova.io/sovereign: ${SOVEREIGN_FQDN}` label (substituted per cluster).
- `HelmRepository` of type `oci`, URL `oci://ghcr.io/openova-io`, `secretRef: ghcr-pull`, interval `15m`.
- `HelmRelease` v2 with chart version `1.0.0`, `dependsOn` set, `disableWait: true` on both `install` and `upgrade`, retries `3`.

`disableWait: true` is the locked architectural decision per `MEMORY/session-2026-04-30-handover.md` — avoids the deadlock where Helm `--wait` blocks on downstream backends (Loki/Mimir/Tempo waiting for SeaweedFS, Grafana waiting for CNPG-synthesised secrets) that the HelmRelease itself cannot influence. Runtime convergence is observed via `kubectl rollout status`, not gated on Helm.

## Validation

`scripts/check-bootstrap-deps.sh` (W2.K0, merged at `0289f038`):

```
== Summary ==
  Present on disk:       21
  Declared expected:     48
  Deferred (W2.K1-K4):   27
  Drift:                 0
  Cycles:                0
OK: bootstrap-kit dependency graph audit PASSED
```

Per-slot validation (21/21 PASS — Namespace + HelmRelease parse cleanly via `kubectl apply --dry-run=client`; HelmRepository validation requires `source.toolkit.fluxcd.io/v1beta2` which is not registered on the contabo-mkt validation cluster but is present on every Sovereign):

| File | YAML parse | Namespace+HR resources |
|---|---|---|
| `clusters/_template/bootstrap-kit/{20,21,22,23,24,25,26}-*.yaml` | OK (7/7) | OK (7/7) |
| `clusters/omantel.omani.works/bootstrap-kit/{20,21,22,23,24,25,26}-*.yaml` | OK (7/7) | OK (7/7) |
| `clusters/otech.omani.works/bootstrap-kit/{20,21,22,23,24,25,26}-*.yaml` | OK (7/7) | OK (7/7) |

`kubectl kustomize` builds for all 3 cluster bootstrap-kit dirs: **OK** (1027 lines, 59 docs each).

## Dependency on issue #215 (langfuse OCI publish)

**Slot 26 (`bp-langfuse`) is forward-prep.** `bp-langfuse:1.0.0` is not yet published to `ghcr.io/openova-io` — issue #215 tracks the GHCR 500 on manifest PUT for charts with nested OCI subchart deps. W1.G is the concurrent track fixing the blueprint-release.yaml publish path.

Until #215 closes, the HR `bp-langfuse` will fail to install with a chart-pull error from the OCI source. This is expected and intentional: committing the HR YAML now means the Sovereign reconciles Langfuse automatically the moment the artifact is published, with no second deploy gate.

The 6 sibling charts in this batch (`bp-opentelemetry`, `bp-alloy`, `bp-loki`, `bp-mimir`, `bp-tempo`, `bp-grafana`) all published cleanly first try in the prior PR #214 batch.

## Merge protocol — coordination with W2.K1

This branch was opened off `main` at slot-14 head (post-PR-258, pre-W2.K1 merge). Per `docs/BOOTSTRAP-KIT-EXPANSION-PLAN.md` §4.2, when W2.K1 (slots 15–19) merges first this PR will rebase on `main`. The conflict on `kustomization.yaml` is structural (both branches append to the same `resources:` list); resolution is mechanical — keep both blocks, in slot-number order. K2's HR files do not collide with K1's because slot prefixes are file-isolated (15-19 vs 20-26).

## Test plan

- [ ] CI — `scripts/check-bootstrap-deps.sh` exits 0 on this branch.
- [ ] CI — `kubectl kustomize` succeeds on all 3 cluster bootstrap-kit dirs.
- [ ] Once W2.K1 merges and this branch rebases — `kubectl kustomize` still succeeds.
- [ ] Once #215 closes and `bp-langfuse:1.0.0` (or successor) is published — Flux reconciles slot 26 to Ready on omantel-1.
- [ ] After full kit converges on omantel-1 — readiness probes per `BOOTSTRAP-KIT-EXPANSION-PLAN.md` §5 rows 20-26 all return success.

## Refs

- Plan: `docs/BOOTSTRAP-KIT-EXPANSION-PLAN.md` §2.4 (W2.K2 sub-DAG), §3.1 (slot allocation), §4 (kustomization merge protocol), §5 (readiness probes).
- W2.K0 audit script (merged): #259 — `scripts/check-bootstrap-deps.sh` + `scripts/expected-bootstrap-deps.yaml`.
- Concurrent dependency: #215 — `bp-langfuse:1.0.0` GHCR publish blocked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)