### PR TITLE
fix(bp-langfuse): resolve GHCR 500 on manifest PUT (resolves #215)

### DIFF
--- a/platform/langfuse/chart/Chart.yaml
+++ b/platform/langfuse/chart/Chart.yaml
@@ -1,5 +1,20 @@
 apiVersion: v2
 name: bp-langfuse
+
+# WARNING — DO NOT introduce ASCII apostrophes into this `description`
+# block. See issue #215. When Helm packages a chart, the multi-line
+# `description` is collapsed into a single-line OCI manifest annotation
+# named `org.opencontainers.image.description`. The GHCR manifest-PUT
+# validator returns a deterministic `500 Internal Server Error` when
+# that annotation is long AND contains an ASCII apostrophe (the manifest
+# digest changes on each attempt because helm includes a fresh
+# `org.opencontainers.image.created` timestamp, but the failure mode is
+# stable — see runs 25131349972 + 25131742024). Rewording to drop the
+# apostrophe (e.g. "Langfuse persistent state" instead of the possessive
+# form) is the safe in-source fix and does not change runtime behaviour.
+# If you need an apostrophe in the description, also shorten the body
+# below ~600 chars or escape it via &apos;-style HTML entities — but
+# rewording is simpler.
 description: |
   Catalyst Blueprint umbrella chart for Langfuse — LLM observability
   platform (traces, evaluations, prompt management, cost attribution).
@@ -8,9 +23,9 @@ description: |
   into this artifact. Catalyst-curated values flow into the upstream
   subchart under the `langfuse:` key in values.yaml.
 
-  Per docs/CLAUDE.md `langfuse.md` Catalyst routes Langfuse's persistent
-  state through Catalyst-managed dependencies — NOT the bundled Bitnami
-  subcharts:
+  Per docs/CLAUDE.md `langfuse.md` Catalyst routes the Langfuse
+  persistent state through Catalyst-managed dependencies — NOT the
+  bundled Bitnami subcharts:
     - PostgreSQL via cnpg.io/Cluster (Catalyst standard, see bp-cnpg).
     - ClickHouse via bp-clickhouse (when authored).
     - Redis via bp-valkey (when authored).


### PR DESCRIPTION
## Summary

bp-langfuse 1.0.0 publish to GHCR fails with `500 Internal Server Error` on the manifest PUT. The 500 is a GHCR validator quirk — it triggers when the OCI manifest annotation `org.opencontainers.image.description` is long AND contains an ASCII apostrophe. bp-langfuse was the only chart in the observability batch (#214) that carried both characteristics.

## Root cause

When Helm packages a chart, the multi-line `description` field is collapsed into a single-line OCI manifest annotation. GHCR returns a deterministic 500 when that annotation is long and contains an apostrophe (the manifest digest changes per attempt because helm injects a fresh `org.opencontainers.image.created` timestamp, which is why issue #215 reads as transient — the failure mode is actually stable).

## Fix

Reword the description from `"Langfuse's persistent state"` to `"the Langfuse persistent state"`. Drops the apostrophe, preserves the meaning, preserves every byte of the actual chart payload (values, templates, all 350 entries of the upstream `langfuse-1.5.28` subchart with its 4-level-deep Bitnami vendoring). No runtime behavioural change — `helm template` still renders the exact same 6 resources across 490 lines.

A WARNING comment above `description:` documents the trigger so future authors do not reintroduce a possessive form.

## Reproduction

Failing runs (all from the existing chart with the apostrophe):
- https://github.com/openova-io/openova/actions/runs/25131349972 (PR #214 push)
- https://github.com/openova-io/openova/actions/runs/25131742024 (workflow_dispatch)

Manual narrowing (apostrophe-by-apostrophe):
1. `helm push` of original chart → `500 Internal Server Error`
2. Same chart, description shortened to one line → push succeeds
3. Long description without apostrophe → push succeeds
4. Long description with apostrophe → 500 returns
5. Original full chart with the one apostrophe reworded → push succeeds (verified locally against `ghcr.io/openova-io/bp-langfuse:1.0.0` with the bp-langfuse repo deleted between every attempt to rule out registry-side caching)

## Test plan

- [x] Local reproduction: `helm push bp-langfuse-1.0.0.tgz oci://ghcr.io/openova-io` of the original chart returns 500
- [x] Local fix verification: `helm push` of the patched chart returns `Pushed: ghcr.io/openova-io/bp-langfuse:1.0.0` with full upstream subchart payload preserved (13 Chart.yaml entries on round-trip pull)
- [x] CI verification: `workflow_dispatch` on `fix/bp-langfuse-publish-ghcr-500` — https://github.com/openova-io/openova/actions/runs/25168031663
- [ ] Post-merge: `Blueprint Release` push trigger on `main` succeeds for `platform/langfuse`
- [ ] Acceptance criterion from #215: `helm pull oci://ghcr.io/openova-io/bp-langfuse --version 1.0.0` succeeds
- [ ] No regression on the other 7 charts in the observability batch (only `platform/langfuse/chart/Chart.yaml` is touched)

Closes #215