### PR TITLE
feat(charts): bp-external-secrets + bp-cnpg + bp-valkey wrapper charts (closes #254)

### DIFF
--- a/platform/cnpg/blueprint.yaml
+++ b/platform/cnpg/blueprint.yaml
@@ -1,0 +1,59 @@
+apiVersion: catalyst.openova.io/v1alpha1
+kind: Blueprint
+metadata:
+  name: bp-cnpg
+  labels:
+    catalyst.openova.io/section: pts-4-1-data-services
+spec:
+  version: 1.0.0
+  card:
+    title: CloudNativePG
+    summary: |
+      Production-grade PostgreSQL operator. Per-Sovereign Postgres-as-a-
+      service via postgresql.cnpg.io/v1.Cluster CRs. Bootstrap-kit slot 16
+      — required by every PG-backed bootstrap component (bp-powerdns,
+      bp-keycloak HA, bp-gitea metadata, bp-langfuse, bp-grafana config DB,
+      bp-temporal, bp-matrix synapse, bp-llm-gateway, bp-bge,
+      bp-nemo-guardrails, bp-openmeter, pool-domain-manager).
+    icon: cnpg.svg
+    category: data
+  visibility: unlisted              # mandatory infra, auto-installed by bootstrap kit
+  configSchema:
+    type: object
+    properties:
+      monitoring:
+        type: object
+        properties:
+          podMonitorEnabled:
+            type: boolean
+            default: false
+            description: |
+              Render PodMonitor for the operator. Requires Prometheus
+              Operator CRDs (kube-prometheus-stack); cluster overlays flip
+              true once that Application Blueprint reconciles.
+      crds:
+        type: object
+        properties:
+          create:
+            type: boolean
+            default: true
+            description: |
+              Install postgresql.cnpg.io CRDs as part of this chart. CNPG's
+              CRDs ship with the upstream chart so consumers of
+              `postgresql.cnpg.io/v1.Cluster` (bp-powerdns, bp-keycloak,
+              bp-gitea, …) gate themselves on bp-cnpg via Flux dependsOn.
+  placementSchema:
+    modes: [single-region, active-active]
+    default: single-region            # operator runs once per host cluster; Cluster CRs handle replication
+  manifests:
+    chart: ./chart
+  # CNPG only needs Flux Ready (its own CRDs ship in the same chart;
+  # consumers of postgresql.cnpg.io/v1.Cluster gate themselves on bp-cnpg).
+  # The Flux HR at clusters/_template/bootstrap-kit/16-cnpg.yaml encodes
+  # this dependsOn. Declared here for documentation parity; the
+  # blueprint-controller does not yet reconcile this field.
+  depends:
+    - blueprint: bp-flux
+      version: ^1.0
+  upgrades:
+    from: ["0.x"]

--- a/platform/cnpg/chart/Chart.yaml
+++ b/platform/cnpg/chart/Chart.yaml
@@ -1,0 +1,27 @@
+apiVersion: v2
+name: bp-cnpg
+version: 1.0.0
+description: |
+  Catalyst-curated Blueprint umbrella chart for CloudNativePG. Depends on
+  the upstream `cloudnative-pg` chart as a Helm subchart so
+  `helm dependency build` pulls the upstream payload into this artifact;
+  the Catalyst overlay templates in templates/ (label propagation,
+  observability toggles defaulted off) sit alongside the upstream subchart
+  and Helm renders both at install time. Catalyst-curated values flow into
+  the upstream subchart under the `cloudnative-pg:` key in values.yaml.
+type: application
+keywords: [catalyst, blueprint, cnpg, cloudnative-pg, postgres, postgresql]
+maintainers:
+  - name: OpenOva Catalyst
+    email: catalyst@openova.io
+
+# Upstream chart pulled in as a Helm subchart so `helm dependency build`
+# bundles it into the OCI artifact. Pinned to cnpg/cloudnative-pg 0.28.0
+# (matches platform/cnpg/blueprint.yaml + values.yaml
+# `catalystBlueprint.upstream.version`). Per
+# docs/INVIOLABLE-PRINCIPLES.md #4 (never hardcode) the version is
+# operator-bumpable via PR + Blueprint release.
+dependencies:
+  - name: cloudnative-pg
+    version: "0.28.0"
+    repository: "https://cloudnative-pg.github.io/charts"

--- a/platform/cnpg/chart/tests/observability-toggle.sh
+++ b/platform/cnpg/chart/tests/observability-toggle.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# bp-cnpg observability-toggle integration test (issue #182).
+#
+# Verifies the Catalyst rule from docs/BLUEPRINT-AUTHORING.md §11.2
+# (Observability toggles must default false): a fresh-Sovereign install
+# of bp-cnpg must NOT render a `monitoring.coreos.com/v1` PodMonitor by
+# default — that CRD ships with kube-prometheus-stack which depends on
+# the bootstrap-kit (circular dependency on a fresh Sovereign).
+#
+# Usage: bash tests/observability-toggle.sh [CHART_DIR]
+
+set -euo pipefail
+
+CHART_DIR="${1:-$(cd "$(dirname "$0")/.." && pwd)}"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+cd "$CHART_DIR"
+# See bp-cilium tests/observability-toggle.sh for rationale: skip helm
+# dep build when charts/ is already vendored (CI populates it before
+# this step runs, and re-running on CI without `helm repo add` fails).
+if [ ! -d charts ] || [ -z "$(ls -A charts 2>/dev/null)" ]; then
+  helm dependency build >/dev/null
+fi
+
+echo "[observability-toggle] Case 1: default render produces no PodMonitor / ServiceMonitor"
+helm template smoke-cnpg . > "$TMP/default.yaml"
+# Match a top-level (column 0) `kind: PodMonitor` or `kind: ServiceMonitor`
+# CR — distinct from the ClusterRole that grants RBAC access to the
+# monitoring.coreos.com apiGroup (which is correct and expected).
+if grep -qE "^kind: (PodMonitor|ServiceMonitor)$" "$TMP/default.yaml"; then
+  echo "FAIL: default render of bp-cnpg contains a PodMonitor/ServiceMonitor CR." >&2
+  echo "      docs/BLUEPRINT-AUTHORING.md §11.2 forbids this — observability toggles must default false." >&2
+  grep -nE "^kind: (PodMonitor|ServiceMonitor)$" "$TMP/default.yaml" >&2
+  exit 1
+fi
+echo "  PASS"
+
+echo "[observability-toggle] Case 2: opt-in (monitoring.podMonitorEnabled=true) renders cleanly"
+# Upstream CNPG chart gates the PodMonitor template behind
+# `.Capabilities.APIVersions.Has "monitoring.coreos.com/v1"`, so we must
+# pass --api-versions on this opt-in render to simulate a cluster on which
+# kube-prometheus-stack has installed the CRD.
+if ! helm template smoke-cnpg . \
+    --set "cloudnative-pg.monitoring.podMonitorEnabled=true" \
+    --api-versions "monitoring.coreos.com/v1" \
+    > "$TMP/optin.yaml" 2> "$TMP/optin.err"; then
+  echo "FAIL: opt-in render failed:" >&2
+  cat "$TMP/optin.err" >&2
+  exit 1
+fi
+if ! grep -qE "^kind: PodMonitor$" "$TMP/optin.yaml"; then
+  echo "FAIL: opt-in render did NOT produce a PodMonitor — the toggle is broken." >&2
+  exit 1
+fi
+echo "  PASS"
+
+echo "[observability-toggle] Case 3: explicit podMonitorEnabled=false renders cleanly"
+if ! helm template smoke-cnpg . \
+    --set "cloudnative-pg.monitoring.podMonitorEnabled=false" \
+    > "$TMP/off.yaml" 2> "$TMP/off.err"; then
+  echo "FAIL: explicit-off render failed:" >&2
+  cat "$TMP/off.err" >&2
+  exit 1
+fi
+if grep -qE "^kind: PodMonitor$" "$TMP/off.yaml"; then
+  echo "FAIL: explicit-off render still contains a PodMonitor CR." >&2
+  exit 1
+fi
+echo "  PASS"
+
+echo "[observability-toggle] All bp-cnpg observability-toggle gates green."

--- a/platform/cnpg/chart/values.yaml
+++ b/platform/cnpg/chart/values.yaml
@@ -1,0 +1,65 @@
+# Catalyst Blueprint umbrella metadata — the upstream chart is now resolved
+# as a Helm subchart via Chart.yaml `dependencies:`. This values.yaml carries
+# both:
+#   1. The catalystBlueprint metadata block (provenance + version) so
+#      observability/audit pipelines can inspect the artifact and report
+#      which upstream chart + version is bundled.
+#   2. The upstream subchart values overlay under the `cloudnative-pg:` key
+#      (umbrella-chart convention — the dependency name from Chart.yaml is
+#      the values namespace).
+#
+# Per docs/INVIOLABLE-PRINCIPLES.md #4 (never hardcode), every operationally-
+# meaningful value is configurable; cluster overlays in clusters/<sovereign>/
+# may override any of these without rebuilding the Blueprint OCI artifact.
+
+catalystBlueprint:
+  upstream: { chart: cloudnative-pg, version: "0.28.0", repo: "https://cloudnative-pg.github.io/charts" }
+
+# ─── Upstream chart values (subchart key: cloudnative-pg) ─────────────────
+# `helm dependency build` resolves the upstream as a subchart; values here
+# under the `cloudnative-pg:` key flow into that subchart unchanged.
+cloudnative-pg:
+  # Install postgresql.cnpg.io CRDs as part of this chart. Required so
+  # consumers of `postgresql.cnpg.io/v1.Cluster` (bp-powerdns,
+  # bp-keycloak, bp-gitea, bp-langfuse, …) can gate themselves on bp-cnpg
+  # via Flux HelmRelease `dependsOn`. The CRDs ship with the upstream
+  # chart so a single Blueprint OCI artifact carries both controller +
+  # CRDs.
+  crds:
+    create: true
+
+  # Operator replicas — single replica is fine for solo Sovereigns;
+  # cluster overlays bump to 2-3 for HA on multi-node host clusters.
+  # CNPG operator is leader-elected, so multiple replicas are passive
+  # standbys.
+  replicaCount: 1
+
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      memory: 512Mi
+
+  # PodMonitor for the operator — DEFAULT OFF.
+  #
+  # Per docs/INVIOLABLE-PRINCIPLES.md #4 and docs/BLUEPRINT-AUTHORING.md
+  # §11.2 (Observability toggles must default false): the
+  # `monitoring.coreos.com/v1` CRDs that back PodMonitor ship with
+  # kube-prometheus-stack — an Application Blueprint installed AFTER the
+  # bootstrap-kit. Defaulting `podMonitorEnabled: true` would render a
+  # PodMonitor on a fresh Sovereign before the CRD exists, and the
+  # apiserver would reject it with "no matches for kind PodMonitor in
+  # version monitoring.coreos.com/v1". Operator opts in via per-cluster
+  # overlay (issue #182).
+  monitoring:
+    podMonitorEnabled: false
+
+  # Webhook is enabled by default in upstream — keep it that way (CNPG
+  # uses the webhook to validate Cluster CRs). cert-manager (bp-cert-
+  # manager) provides the TLS cert per Sovereign convention.
+
+# ─── Catalyst-managed overlay values consumed by templates/ ───────────────
+# (None today — the wrapper currently ships no Catalyst-authored
+# templates. Reserved for future NetworkPolicy / RBAC overlays once the
+# bootstrap-kit security tier (W2.K3) is fully reconciled.)

--- a/platform/external-secrets/blueprint.yaml
+++ b/platform/external-secrets/blueprint.yaml
@@ -1,0 +1,82 @@
+apiVersion: catalyst.openova.io/v1alpha1
+kind: Blueprint
+metadata:
+  name: bp-external-secrets
+  labels:
+    catalyst.openova.io/section: pts-3-3-security-and-policy
+spec:
+  version: 1.0.0
+  card:
+    title: External Secrets Operator
+    summary: |
+      Day-2 secret pipeline. Materializes K8s Secrets from OpenBao
+      (the Catalyst secret backend) via ExternalSecret / PushSecret CRs
+      and ESO Generators. Replaces the bootstrap-only bp-sealed-secrets
+      slot 05 once OpenBao + ESO are Ready.
+    icon: external-secrets.svg
+    category: security
+  visibility: unlisted              # mandatory infra, auto-installed by bootstrap kit
+  configSchema:
+    type: object
+    properties:
+      clusterSecretStore:
+        type: object
+        properties:
+          enabled:
+            type: boolean
+            default: true
+            description: |
+              Render the default `vault-region1` ClusterSecretStore that
+              points at the in-cluster bp-openbao service. Set false if
+              the operator wants to author ClusterSecretStore CRs
+              themselves (e.g. multi-region with explicit primary/replica).
+          name:
+            type: string
+            default: vault-region1
+            description: ClusterSecretStore name.
+          server:
+            type: string
+            default: "http://openbao.openbao-system.svc.cluster.local:8200"
+            description: |
+              In-cluster OpenBao endpoint. Cluster overlays override to
+              the external FQDN (https://openbao.<location-code>.<sovereign-domain>)
+              when ESO is reading from a different region's primary.
+          path:
+            type: string
+            default: secret
+          version:
+            type: string
+            default: v2
+            enum: [v1, v2]
+          kubernetesAuth:
+            type: object
+            properties:
+              mountPath:
+                type: string
+                default: kubernetes
+              role:
+                type: string
+                default: external-secrets
+              serviceAccountName:
+                type: string
+                default: external-secrets
+              serviceAccountNamespace:
+                type: string
+                default: external-secrets-system
+  placementSchema:
+    modes: [single-region, active-active]
+    default: active-active            # ESO runs on every host cluster
+  manifests:
+    chart: ./chart
+  # Per W2.K1 PR #262 the Flux HR at clusters/_template/bootstrap-kit/
+  # 15-external-secrets.yaml gates install on bp-openbao + bp-cert-manager
+  # via dependsOn. Declared here for documentation parity; the
+  # blueprint-controller does not yet reconcile this field — it is the
+  # HR's dependsOn that takes effect at install time.
+  depends:
+    - blueprint: bp-openbao
+      version: ^1.0
+    - blueprint: bp-cert-manager
+      version: ^1.0
+  upgrades:
+    from: ["0.x"]

--- a/platform/external-secrets/chart/Chart.yaml
+++ b/platform/external-secrets/chart/Chart.yaml
@@ -1,0 +1,28 @@
+apiVersion: v2
+name: bp-external-secrets
+version: 1.0.0
+description: |
+  Catalyst-curated Blueprint umbrella chart for External Secrets Operator
+  (ESO). Depends on the upstream `external-secrets` chart as a Helm
+  subchart so `helm dependency build` pulls the upstream payload into
+  this artifact; the Catalyst overlay templates in templates/ (default
+  ClusterSecretStore wired to bp-openbao, NetworkPolicy guard,
+  ServiceMonitor toggle) sit alongside the upstream subchart and Helm
+  renders both at install time. Catalyst-curated values flow into the
+  upstream subchart under the `external-secrets:` key in values.yaml.
+type: application
+keywords: [catalyst, blueprint, external-secrets, eso, openbao, secrets]
+maintainers:
+  - name: OpenOva Catalyst
+    email: catalyst@openova.io
+
+# Upstream chart pulled in as a Helm subchart so `helm dependency build`
+# bundles it into the OCI artifact. Pinned to external-secrets/external-secrets
+# 0.10.7 (matches platform/external-secrets/blueprint.yaml + values.yaml
+# `catalystBlueprint.upstream.version`). Per
+# docs/INVIOLABLE-PRINCIPLES.md #4 (never hardcode) the version is
+# operator-bumpable via PR + Blueprint release.
+dependencies:
+  - name: external-secrets
+    version: "0.10.7"
+    repository: "https://charts.external-secrets.io"

--- a/platform/external-secrets/chart/templates/clustersecretstore-vault-region1.yaml
+++ b/platform/external-secrets/chart/templates/clustersecretstore-vault-region1.yaml
@@ -1,0 +1,76 @@
+# clustersecretstore-vault-region1.yaml — Catalyst-curated default
+# ClusterSecretStore for ESO, wired to the in-cluster bp-openbao service.
+#
+# Why a Catalyst-shipped ClusterSecretStore (not user-authored):
+#   Every Catalyst Sovereign has the SAME default secret-store wiring —
+#   ESO ↔ bp-openbao. Shipping the ClusterSecretStore inside this chart
+#   means a fresh Sovereign reaches "ESO can read from OpenBao" the moment
+#   bp-external-secrets reconciles, with no follow-up CR-application step.
+#
+# Why a Helm post-install hook:
+#   ClusterSecretStore is an external-secrets.io/v1beta1 CRD that ESO
+#   itself installs. Without the hook, Helm renders both the upstream ESO
+#   chart (which installs the CRD) AND this template in the same install
+#   pass, and the apiserver applies them in alphabetical / dependency-
+#   resolution order. If the CRD is registered AFTER this template's
+#   admission attempt, the apply fails with `no matches for kind
+#   "ClusterSecretStore" in version "external-secrets.io/v1beta1"`. The
+#   post-install hook defers application until after the upstream chart's
+#   CRDs + controllers are running.
+#
+# Why ALSO post-upgrade:
+#   On Helm upgrade Helm replays every template; without post-upgrade the
+#   ClusterSecretStore would be deleted+recreated at every upgrade only
+#   when CRDs are reapplied. Including post-upgrade keeps the hook in
+#   sync without stranding.
+#
+# Operator overrides:
+#   - clusterSecretStore.enabled: false  → disable the default and author
+#     ClusterSecretStore CRs out-of-band (e.g. multi-region with explicit
+#     primary/replica).
+#   - clusterSecretStore.server         → point at an external OpenBao FQDN
+#     when ESO is reading from a different region's primary.
+#
+# Per docs/INVIOLABLE-PRINCIPLES.md #4 ("never hardcode") all knobs are
+# runtime-configurable; cluster overlays in clusters/<sovereign>/ may set
+# `clusterSecretStore.*` without rebuilding the Blueprint OCI artifact.
+
+{{- $css := .Values.clusterSecretStore | default dict }}
+{{- if $css.enabled }}
+{{- $name := $css.name | default "vault-region1" }}
+{{- $server := $css.server | default "http://openbao.openbao.svc.cluster.local:8200" }}
+{{- $path := $css.path | default "secret" }}
+{{- $version := $css.version | default "v2" }}
+{{- $kAuth := $css.kubernetesAuth | default dict }}
+{{- $mountPath := $kAuth.mountPath | default "kubernetes" }}
+{{- $role := $kAuth.role | default "external-secrets" }}
+{{- $saName := $kAuth.serviceAccountName | default "external-secrets" }}
+{{- $saNs := $kAuth.serviceAccountNamespace | default "external-secrets-system" }}
+apiVersion: external-secrets.io/v1beta1
+kind: ClusterSecretStore
+metadata:
+  name: {{ $name | quote }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "5"
+    "helm.sh/hook-delete-policy": before-hook-creation
+  labels:
+    catalyst.openova.io/component: external-secrets
+    catalyst.openova.io/secret-backend: openbao
+spec:
+  provider:
+    # ESO provider type stays `vault` because OpenBao is wire-compatible
+    # with HashiCorp Vault (per platform/openbao/README.md). The same
+    # provider config drives both backends.
+    vault:
+      server: {{ $server | quote }}
+      path: {{ $path | quote }}
+      version: {{ $version | quote }}
+      auth:
+        kubernetes:
+          mountPath: {{ $mountPath | quote }}
+          role: {{ $role | quote }}
+          serviceAccountRef:
+            name: {{ $saName | quote }}
+            namespace: {{ $saNs | quote }}
+{{- end }}

--- a/platform/external-secrets/chart/tests/observability-toggle.sh
+++ b/platform/external-secrets/chart/tests/observability-toggle.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# bp-external-secrets observability-toggle integration test (issue #182).
+#
+# Verifies the Catalyst rule from docs/BLUEPRINT-AUTHORING.md §11.2
+# (Observability toggles must default false): a fresh-Sovereign install
+# of bp-external-secrets must NOT render `monitoring.coreos.com/v1`
+# ServiceMonitor by default — those CRDs ship with kube-prometheus-stack
+# which depends on the bootstrap-kit (circular dependency on a fresh
+# Sovereign).
+#
+# Usage: bash tests/observability-toggle.sh [CHART_DIR]
+
+set -euo pipefail
+
+CHART_DIR="${1:-$(cd "$(dirname "$0")/.." && pwd)}"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+cd "$CHART_DIR"
+# See bp-cilium tests/observability-toggle.sh for rationale: skip helm
+# dep build when charts/ is already vendored (CI populates it before
+# this step runs, and re-running on CI without `helm repo add` fails).
+if [ ! -d charts ] || [ -z "$(ls -A charts 2>/dev/null)" ]; then
+  helm dependency build >/dev/null
+fi
+
+echo "[observability-toggle] Case 1: default render produces no ServiceMonitor"
+helm template smoke-eso . > "$TMP/default.yaml"
+if grep -q "monitoring.coreos.com" "$TMP/default.yaml"; then
+  echo "FAIL: default render of bp-external-secrets contains monitoring.coreos.com references." >&2
+  echo "      docs/BLUEPRINT-AUTHORING.md §11.2 forbids this — observability toggles must default false." >&2
+  grep -n "monitoring.coreos.com" "$TMP/default.yaml" | head -5 >&2
+  exit 1
+fi
+if grep -q "kind: ServiceMonitor" "$TMP/default.yaml"; then
+  echo "FAIL: default render of bp-external-secrets contains kind: ServiceMonitor." >&2
+  exit 1
+fi
+echo "  PASS"
+
+echo "[observability-toggle] Case 2: opt-in (serviceMonitor.enabled=true) renders cleanly"
+# Upstream ESO chart gates the ServiceMonitor template behind
+# `.Capabilities.APIVersions.Has "monitoring.coreos.com/v1"`, so we must
+# pass --api-versions on this opt-in render to simulate a cluster on which
+# kube-prometheus-stack has installed the CRD. Without --api-versions
+# the template is skipped (as it correctly is on a fresh Sovereign).
+if ! helm template smoke-eso . \
+    --set "external-secrets.serviceMonitor.enabled=true" \
+    --api-versions "monitoring.coreos.com/v1" \
+    > "$TMP/optin.yaml" 2> "$TMP/optin.err"; then
+  echo "FAIL: opt-in render failed:" >&2
+  cat "$TMP/optin.err" >&2
+  exit 1
+fi
+if ! grep -q "kind: ServiceMonitor" "$TMP/optin.yaml"; then
+  echo "FAIL: opt-in render did NOT produce a ServiceMonitor — the toggle is broken." >&2
+  exit 1
+fi
+echo "  PASS"
+
+echo "[observability-toggle] Case 3: explicit serviceMonitor.enabled=false renders cleanly"
+if ! helm template smoke-eso . \
+    --set "external-secrets.serviceMonitor.enabled=false" \
+    > "$TMP/off.yaml" 2> "$TMP/off.err"; then
+  echo "FAIL: explicit-off render failed:" >&2
+  cat "$TMP/off.err" >&2
+  exit 1
+fi
+if grep -q "monitoring.coreos.com" "$TMP/off.yaml"; then
+  echo "FAIL: explicit-off render still contains monitoring.coreos.com references." >&2
+  exit 1
+fi
+echo "  PASS"
+
+# ── Case 4: default ClusterSecretStore present, opt-out works ────────────
+echo "[observability-toggle] Case 4: default render includes vault-region1 ClusterSecretStore (post-install hook)"
+# The Catalyst-curated wrapper must ship a default ClusterSecretStore CR
+# wired to bp-openbao — distinct from the upstream chart's ClusterSecretStore
+# CRD definition. Match the CR's name field at the metadata indent level.
+if ! grep -qE "^kind: ClusterSecretStore$" "$TMP/default.yaml"; then
+  echo "FAIL: default render of bp-external-secrets is missing the vault-region1 ClusterSecretStore CR." >&2
+  echo "      The Catalyst-curated wrapper must ship a default ClusterSecretStore wired to bp-openbao." >&2
+  exit 1
+fi
+if ! grep -q "name: \"vault-region1\"" "$TMP/default.yaml"; then
+  echo "FAIL: default render of bp-external-secrets is missing the vault-region1 name." >&2
+  exit 1
+fi
+echo "  PASS"
+
+echo "[observability-toggle] Case 5: clusterSecretStore.enabled=false omits the default ClusterSecretStore"
+if ! helm template smoke-eso . \
+    --set "clusterSecretStore.enabled=false" \
+    > "$TMP/css-off.yaml" 2> "$TMP/css-off.err"; then
+  echo "FAIL: clusterSecretStore.enabled=false render failed:" >&2
+  cat "$TMP/css-off.err" >&2
+  exit 1
+fi
+if grep -qE "^kind: ClusterSecretStore$" "$TMP/css-off.yaml"; then
+  # Note: an `^kind: ClusterSecretStore$` line at column 0 is a CR; the
+  # upstream chart's CRD definition mentions ClusterSecretStore inside
+  # the `kind:` field of the CRD spec but at non-zero indentation.
+  echo "FAIL: clusterSecretStore.enabled=false still renders a ClusterSecretStore CR — the toggle is broken." >&2
+  exit 1
+fi
+echo "  PASS"
+
+echo "[observability-toggle] All bp-external-secrets observability-toggle gates green."

--- a/platform/external-secrets/chart/values.yaml
+++ b/platform/external-secrets/chart/values.yaml
@@ -1,0 +1,127 @@
+# Catalyst Blueprint umbrella metadata — the upstream chart is now resolved
+# as a Helm subchart via Chart.yaml `dependencies:`. This values.yaml carries
+# both:
+#   1. The catalystBlueprint metadata block (provenance + version) so
+#      observability/audit pipelines can inspect the artifact and report
+#      which upstream chart + version is bundled.
+#   2. The upstream subchart values overlay under the `external-secrets:` key
+#      (umbrella-chart convention — the dependency name from Chart.yaml is
+#      the values namespace).
+#   3. Catalyst overlay values consumed by templates/ (e.g. `clusterSecretStore:`
+#      governs templates/clustersecretstore-vault-region1.yaml).
+#
+# Per docs/INVIOLABLE-PRINCIPLES.md #4 (never hardcode), every operationally-
+# meaningful value is configurable; cluster overlays in clusters/<sovereign>/
+# may override any of these without rebuilding the Blueprint OCI artifact.
+
+catalystBlueprint:
+  upstream: { chart: external-secrets, version: "0.10.7", repo: "https://charts.external-secrets.io" }
+
+# ─── Upstream chart values (subchart key: external-secrets) ───────────────
+# `helm dependency build` resolves the upstream as a subchart; values here
+# under the `external-secrets:` key flow into that subchart unchanged.
+external-secrets:
+  # Install CRDs as part of this chart. ESO ships its own CRDs
+  # (external-secrets.io/v1beta1, generators.external-secrets.io/v1alpha1)
+  # — they MUST be installed as part of the same Helm release so the
+  # ClusterSecretStore template (templates/clustersecretstore-vault-region1.yaml)
+  # in this chart's post-install hook can be applied without `no matches for
+  # kind` failures.
+  installCRDs: true
+
+  # Replicas — single replica is fine for solo Sovereigns; cluster overlays
+  # bump to 2-3 for HA on multi-node host clusters.
+  replicaCount: 1
+
+  resources:
+    requests:
+      cpu: 50m
+      memory: 64Mi
+    limits:
+      memory: 256Mi
+
+  # ESO webhook — needs a TLS cert from the cluster's ClusterIssuer
+  # (bp-cert-manager). Webhook resources/replicas tuned for solo Sovereign.
+  webhook:
+    replicaCount: 1
+    resources:
+      requests:
+        cpu: 50m
+        memory: 64Mi
+      limits:
+        memory: 128Mi
+    # Prometheus ServiceMonitor for the webhook component — DEFAULT OFF
+    # (operator opts in once kube-prometheus-stack reconciles).
+    serviceMonitor:
+      enabled: false
+    metrics:
+      service:
+        enabled: false
+
+  # Cert controller — manages ESO's own webhook TLS via cert-manager.
+  certController:
+    replicaCount: 1
+    resources:
+      requests:
+        cpu: 50m
+        memory: 64Mi
+      limits:
+        memory: 128Mi
+    serviceMonitor:
+      enabled: false
+    metrics:
+      service:
+        enabled: false
+
+  # Prometheus ServiceMonitor for the main ESO controller — DEFAULT OFF.
+  #
+  # Per docs/INVIOLABLE-PRINCIPLES.md #4 and docs/BLUEPRINT-AUTHORING.md
+  # §11.2 (Observability toggles must default false): the
+  # `monitoring.coreos.com/v1` CRDs that back ServiceMonitor ship with
+  # kube-prometheus-stack — an Application Blueprint installed AFTER the
+  # bootstrap-kit. Defaulting `serviceMonitor.enabled: true` would render a
+  # ServiceMonitor on a fresh Sovereign before the CRD exists, and the
+  # apiserver would reject it with "no matches for kind ServiceMonitor in
+  # version monitoring.coreos.com/v1". Operator opts in via per-cluster
+  # overlay (issue #182).
+  serviceMonitor:
+    enabled: false
+  metrics:
+    service:
+      enabled: false
+
+# ─── Catalyst-managed default ClusterSecretStore (templates/clustersecretstore-vault-region1.yaml) ──
+# The Catalyst-curated wrapper renders ONE default ClusterSecretStore
+# (`vault-region1`) wired to the in-cluster bp-openbao service. Cluster
+# overlays MAY:
+#   - Set `clusterSecretStore.enabled: false` to disable the default and
+#     author their own ClusterSecretStore CRs (e.g. multi-region with
+#     explicit primary/replica).
+#   - Override `clusterSecretStore.server` to point at an external OpenBao
+#     FQDN when ESO is reading from a different region's primary.
+#
+# Per docs/INVIOLABLE-PRINCIPLES.md #4 ("never hardcode") all knobs are
+# runtime-configurable; cluster overlays in clusters/<sovereign>/ may
+# override without rebuilding the Blueprint OCI artifact.
+clusterSecretStore:
+  # Render the default `vault-region1` ClusterSecretStore.
+  enabled: true
+  # ClusterSecretStore name — matches platform/external-secrets/blueprint.yaml.
+  name: vault-region1
+  # In-cluster OpenBao endpoint. Cluster overlays override to the external
+  # FQDN (https://openbao.<location-code>.<sovereign-domain>) when ESO is
+  # reading from a different region's primary.
+  server: "http://openbao.openbao.svc.cluster.local:8200"
+  # KV mount path inside OpenBao (default per platform/openbao/README.md).
+  path: secret
+  # KV engine version (v2 = versioned KV, the OpenBao default).
+  version: v2
+  kubernetesAuth:
+    # Auth mount inside OpenBao for the Kubernetes auth method.
+    mountPath: kubernetes
+    # OpenBao role granted to the ESO ServiceAccount.
+    role: external-secrets
+    # ServiceAccount that ESO uses to authenticate against OpenBao.
+    # Must match external-secrets.serviceAccount.name + targetNamespace.
+    serviceAccountName: external-secrets
+    serviceAccountNamespace: external-secrets-system

--- a/platform/valkey/blueprint.yaml
+++ b/platform/valkey/blueprint.yaml
@@ -1,0 +1,72 @@
+apiVersion: catalyst.openova.io/v1alpha1
+kind: Blueprint
+metadata:
+  name: bp-valkey
+  labels:
+    catalyst.openova.io/section: pts-4-1-data-services
+spec:
+  version: 1.0.0
+  card:
+    title: Valkey
+    summary: |
+      Redis-compatible in-memory cache (BSD-3 fork of Redis 7.2.4 under
+      Linux Foundation governance). Bootstrap-kit slot 17 — used by
+      Catalyst control-plane services for ephemeral session/state, and
+      by Application-tier Apps that need a Redis wire-protocol cache.
+      Replication via REPLICAOF (per-Application choice — see
+      docs/SRE.md §2.5).
+    icon: valkey.svg
+    category: data
+  visibility: unlisted              # mandatory infra, auto-installed by bootstrap kit
+  configSchema:
+    type: object
+    properties:
+      architecture:
+        type: string
+        enum: [standalone, replication]
+        default: replication
+        description: |
+          Standalone (single primary, no replicas) or replication (one
+          primary + N replicas). Solo Sovereigns use replication with
+          replicaCount: 0 to keep the StatefulSet shape stable while
+          paying for only one pod.
+      auth:
+        type: object
+        properties:
+          enabled:
+            type: boolean
+            default: true
+            description: Enforce password auth on the Valkey wire protocol.
+      metrics:
+        type: object
+        properties:
+          enabled:
+            type: boolean
+            default: false
+            description: |
+              Sidecar Prometheus exporter (redis-exporter) on each pod.
+              Cluster overlays flip true once kube-prometheus-stack
+              reconciles (issue #182).
+          serviceMonitor:
+            type: object
+            properties:
+              enabled:
+                type: boolean
+                default: false
+                description: |
+                  monitoring.coreos.com/v1 ServiceMonitor — requires the
+                  Prometheus Operator CRDs from kube-prometheus-stack.
+  placementSchema:
+    modes: [single-region, active-active, active-hotstandby]
+    default: single-region            # Valkey replication is per-Application
+  manifests:
+    chart: ./chart
+  # Valkey is a self-contained cache — only needs Flux Ready. The Flux HR
+  # at clusters/_template/bootstrap-kit/17-valkey.yaml encodes this
+  # dependsOn. Declared here for documentation parity; the
+  # blueprint-controller does not yet reconcile this field.
+  depends:
+    - blueprint: bp-flux
+      version: ^1.0
+  upgrades:
+    from: ["0.x"]

--- a/platform/valkey/chart/Chart.yaml
+++ b/platform/valkey/chart/Chart.yaml
@@ -1,0 +1,28 @@
+apiVersion: v2
+name: bp-valkey
+version: 1.0.0
+description: |
+  Catalyst-curated Blueprint umbrella chart for Valkey (Redis-compatible
+  cache, BSD-3). Depends on the upstream `valkey` chart (Bitnami) as a
+  Helm subchart so `helm dependency build` pulls the upstream payload
+  into this artifact; the Catalyst overlay templates in templates/
+  (label propagation, observability toggles defaulted off) sit alongside
+  the upstream subchart and Helm renders both at install time.
+  Catalyst-curated values flow into the upstream subchart under the
+  `valkey:` key in values.yaml.
+type: application
+keywords: [catalyst, blueprint, valkey, redis, cache]
+maintainers:
+  - name: OpenOva Catalyst
+    email: catalyst@openova.io
+
+# Upstream chart pulled in as a Helm subchart so `helm dependency build`
+# bundles it into the OCI artifact. Pinned to bitnami/valkey 5.5.1
+# (matches platform/valkey/blueprint.yaml + values.yaml
+# `catalystBlueprint.upstream.version`). Per
+# docs/INVIOLABLE-PRINCIPLES.md #4 (never hardcode) the version is
+# operator-bumpable via PR + Blueprint release.
+dependencies:
+  - name: valkey
+    version: "5.5.1"
+    repository: "https://charts.bitnami.com/bitnami"

--- a/platform/valkey/chart/tests/observability-toggle.sh
+++ b/platform/valkey/chart/tests/observability-toggle.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# bp-valkey observability-toggle integration test (issue #182).
+#
+# Verifies the Catalyst rule from docs/BLUEPRINT-AUTHORING.md §11.2
+# (Observability toggles must default false): a fresh-Sovereign install
+# of bp-valkey must NOT render any `monitoring.coreos.com/v1`
+# ServiceMonitor / PrometheusRule by default — those CRDs ship with
+# kube-prometheus-stack which depends on the bootstrap-kit (circular
+# dependency on a fresh Sovereign).
+#
+# Usage: bash tests/observability-toggle.sh [CHART_DIR]
+
+set -euo pipefail
+
+CHART_DIR="${1:-$(cd "$(dirname "$0")/.." && pwd)}"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+cd "$CHART_DIR"
+# See bp-cilium tests/observability-toggle.sh for rationale: skip helm
+# dep build when charts/ is already vendored (CI populates it before
+# this step runs, and re-running on CI without `helm repo add` fails).
+if [ ! -d charts ] || [ -z "$(ls -A charts 2>/dev/null)" ]; then
+  helm dependency build >/dev/null
+fi
+
+echo "[observability-toggle] Case 1: default render produces no ServiceMonitor / PrometheusRule"
+helm template smoke-vk . > "$TMP/default.yaml"
+if grep -qE "^kind: (ServiceMonitor|PrometheusRule)$" "$TMP/default.yaml"; then
+  echo "FAIL: default render of bp-valkey contains a ServiceMonitor/PrometheusRule CR." >&2
+  echo "      docs/BLUEPRINT-AUTHORING.md §11.2 forbids this — observability toggles must default false." >&2
+  grep -nE "^kind: (ServiceMonitor|PrometheusRule)$" "$TMP/default.yaml" >&2
+  exit 1
+fi
+if grep -q "monitoring.coreos.com" "$TMP/default.yaml"; then
+  echo "FAIL: default render of bp-valkey contains monitoring.coreos.com references." >&2
+  grep -n "monitoring.coreos.com" "$TMP/default.yaml" | head -5 >&2
+  exit 1
+fi
+echo "  PASS"
+
+echo "[observability-toggle] Case 2: opt-in (metrics + serviceMonitor) renders cleanly"
+# Upstream bitnami chart gates ServiceMonitor on
+# `.Capabilities.APIVersions.Has "monitoring.coreos.com/v1"`. Pass
+# --api-versions to simulate a cluster with kube-prometheus-stack CRDs.
+if ! helm template smoke-vk . \
+    --set "valkey.metrics.enabled=true" \
+    --set "valkey.metrics.serviceMonitor.enabled=true" \
+    --api-versions "monitoring.coreos.com/v1" \
+    > "$TMP/optin.yaml" 2> "$TMP/optin.err"; then
+  echo "FAIL: opt-in render failed:" >&2
+  cat "$TMP/optin.err" >&2
+  exit 1
+fi
+if ! grep -qE "^kind: ServiceMonitor$" "$TMP/optin.yaml"; then
+  echo "FAIL: opt-in render did NOT produce a ServiceMonitor — the toggle is broken." >&2
+  exit 1
+fi
+echo "  PASS"
+
+echo "[observability-toggle] Case 3: explicit metrics.enabled=false renders cleanly"
+if ! helm template smoke-vk . \
+    --set "valkey.metrics.enabled=false" \
+    --set "valkey.metrics.serviceMonitor.enabled=false" \
+    > "$TMP/off.yaml" 2> "$TMP/off.err"; then
+  echo "FAIL: explicit-off render failed:" >&2
+  cat "$TMP/off.err" >&2
+  exit 1
+fi
+if grep -qE "^kind: (ServiceMonitor|PrometheusRule)$" "$TMP/off.yaml"; then
+  echo "FAIL: explicit-off render still contains a ServiceMonitor/PrometheusRule CR." >&2
+  exit 1
+fi
+echo "  PASS"
+
+# ── Case 4: PrometheusRule toggle separately ─────────────────────────────
+echo "[observability-toggle] Case 4: PrometheusRule opt-in renders a PrometheusRule"
+if ! helm template smoke-vk . \
+    --set "valkey.metrics.enabled=true" \
+    --set "valkey.metrics.prometheusRule.enabled=true" \
+    --api-versions "monitoring.coreos.com/v1" \
+    > "$TMP/pr.yaml" 2> "$TMP/pr.err"; then
+  echo "FAIL: PrometheusRule opt-in render failed:" >&2
+  cat "$TMP/pr.err" >&2
+  exit 1
+fi
+if ! grep -qE "^kind: PrometheusRule$" "$TMP/pr.yaml"; then
+  echo "FAIL: PrometheusRule opt-in render did NOT produce a PrometheusRule — the toggle is broken." >&2
+  exit 1
+fi
+echo "  PASS"
+
+echo "[observability-toggle] All bp-valkey observability-toggle gates green."

--- a/platform/valkey/chart/values.yaml
+++ b/platform/valkey/chart/values.yaml
@@ -1,0 +1,89 @@
+# Catalyst Blueprint umbrella metadata — the upstream chart is now resolved
+# as a Helm subchart via Chart.yaml `dependencies:`. This values.yaml carries
+# both:
+#   1. The catalystBlueprint metadata block (provenance + version) so
+#      observability/audit pipelines can inspect the artifact and report
+#      which upstream chart + version is bundled.
+#   2. The upstream subchart values overlay under the `valkey:` key
+#      (umbrella-chart convention — the dependency name from Chart.yaml is
+#      the values namespace).
+#
+# Per docs/INVIOLABLE-PRINCIPLES.md #4 (never hardcode), every operationally-
+# meaningful value is configurable; cluster overlays in clusters/<sovereign>/
+# may override any of these without rebuilding the Blueprint OCI artifact.
+
+catalystBlueprint:
+  upstream: { chart: valkey, version: "5.5.1", repo: "https://charts.bitnami.com/bitnami" }
+
+# ─── Upstream chart values (subchart key: valkey) ─────────────────────────
+# `helm dependency build` resolves the upstream as a subchart; values here
+# under the `valkey:` key flow into that subchart unchanged.
+valkey:
+  # Replication architecture (one primary + N replicas). Solo Sovereigns
+  # use replicaCount: 0 to keep the StatefulSet shape stable while
+  # paying for only one pod. Multi-node host clusters bump replicaCount
+  # via cluster overlay.
+  architecture: replication
+
+  primary:
+    replicaCount: 1
+    resources:
+      requests:
+        cpu: 100m
+        memory: 128Mi
+      limits:
+        memory: 512Mi
+    # 1Gi PVC — adequate for session/state caches on solo Sovereigns;
+    # cluster overlays bump for higher-volume Applications.
+    persistence:
+      enabled: true
+      size: 1Gi
+
+  replica:
+    # Default 0 replicas for solo Sovereigns. Cluster overlays bump to
+    # 2-3 for HA on multi-node host clusters.
+    replicaCount: 0
+    resources:
+      requests:
+        cpu: 100m
+        memory: 128Mi
+      limits:
+        memory: 512Mi
+    persistence:
+      enabled: true
+      size: 1Gi
+
+  # Password auth ON by default — Catalyst convention. The bitnami chart
+  # auto-generates a random password and exposes it via the
+  # `<release-name>-valkey` Secret. Cluster overlays MAY override the
+  # password via `auth.existingSecret` to hand-roll secret rotation.
+  auth:
+    enabled: true
+
+  # NetworkPolicy from upstream chart — already enabled by default;
+  # restate to make the Catalyst posture explicit. (Default-deny is
+  # appropriate for a cache that should only be consumed in-cluster.)
+  networkPolicy:
+    enabled: true
+
+  # Prometheus exporter sidecar + ServiceMonitor — DEFAULT OFF.
+  #
+  # Per docs/INVIOLABLE-PRINCIPLES.md #4 and docs/BLUEPRINT-AUTHORING.md
+  # §11.2 (Observability toggles must default false): the
+  # `monitoring.coreos.com/v1` CRDs that back ServiceMonitor /
+  # PrometheusRule ship with kube-prometheus-stack — an Application
+  # Blueprint installed AFTER the bootstrap-kit. Defaulting any of these
+  # toggles `true` would render a CR on a fresh Sovereign before the CRD
+  # exists, and the apiserver would reject it. Operator opts in via
+  # per-cluster overlay (issue #182).
+  metrics:
+    enabled: false
+    serviceMonitor:
+      enabled: false
+    prometheusRule:
+      enabled: false
+
+# ─── Catalyst-managed overlay values consumed by templates/ ───────────────
+# (None today — the wrapper currently ships no Catalyst-authored
+# templates. Reserved for future NetworkPolicy / RBAC overlays once the
+# bootstrap-kit security tier (W2.K3) is fully reconciled.)


### PR DESCRIPTION
## Summary

Storage-substrate batch (W2.5.A) — three upstream-subchart umbrella Blueprints that fulfill the Flux HRs at `clusters/_template/bootstrap-kit/{15-external-secrets,16-cnpg,17-valkey}.yaml` (merged via PR #262).

Each chart follows the canonical umbrella pattern from [`docs/BLUEPRINT-AUTHORING.md` §11.1](../blob/main/docs/BLUEPRINT-AUTHORING.md): `Chart.yaml` declares the upstream chart under `dependencies:`, `helm dependency build` bundles the upstream payload, Catalyst-curated overlays sit in `chart/values.yaml` + `chart/templates/`.

### Per-chart kind summary (helm template default render)

| Chart | Version | Upstream | Default-render Kinds |
|---|---|---|---|
| `bp-external-secrets` | `1.0.0` | `external-secrets/external-secrets:0.10.7` | ClusterRole, ClusterRoleBinding, ClusterSecretStore, CustomResourceDefinition, Deployment, Role, RoleBinding, Secret, Service, ServiceAccount, ValidatingWebhookConfiguration |
| `bp-cnpg` | `1.0.0` | `cnpg/cloudnative-pg:0.28.0` | ClusterRole, ClusterRoleBinding, ConfigMap, CustomResourceDefinition, Deployment, MutatingWebhookConfiguration, Service, ServiceAccount, ValidatingWebhookConfiguration |
| `bp-valkey` | `1.0.0` | `bitnami/valkey:5.5.1` | ConfigMap, NetworkPolicy, PodDisruptionBudget, Secret, Service, ServiceAccount, StatefulSet |

### Per-chart highlights

- **bp-external-secrets/1.0.0** — Ships a default `vault-region1` ClusterSecretStore (via Helm `post-install,post-upgrade` hook to defer the CR until the upstream chart's CRDs are registered) wired to the in-cluster `bp-openbao` service. `clusterSecretStore.enabled` toggle lets cluster overlays opt out and author their own multi-region CRs.
- **bp-cnpg/1.0.0** — Operator-only surface (Cluster CRs are per-Application). CRDs ship in-chart so `bp-powerdns` / `bp-keycloak` / `bp-gitea` / `bp-langfuse` / `bp-grafana` / `bp-temporal` / `bp-matrix` / `bp-llm-gateway` / `bp-bge` / `bp-nemo-guardrails` / `bp-openmeter` / `pool-domain-manager` can `dependsOn: bp-cnpg` via Flux — closing #254 (bp-powerdns `CreateContainerConfigError` on `pdns-pg-app` secret).
- **bp-valkey/1.0.0** — BSD-3 Redis-compatible cache. Replication architecture, password auth ON, NetworkPolicy ON, replicas 0 by default for solo Sovereigns (cluster overlays bump for HA). Application-tier cache only — the Catalyst control plane uses NATS JetStream KV.

### Observability discipline (issue #182)

Per [`docs/BLUEPRINT-AUTHORING.md` §11.2](../blob/main/docs/BLUEPRINT-AUTHORING.md): every observability toggle (ServiceMonitor / PodMonitor / PrometheusRule / metrics sidecar) defaults `false` and is operator-tunable via per-cluster overlay once `bp-kube-prometheus-stack` reconciles. Each chart ships `tests/observability-toggle.sh` covering default-off, opt-in (with `--api-versions monitoring.coreos.com/v1` to simulate Prometheus Operator CRDs), and explicit-off cases.

### Inviolable-principle compliance

Per [`docs/INVIOLABLE-PRINCIPLES.md` #4](../blob/main/docs/INVIOLABLE-PRINCIPLES.md) (never hardcode): every upstream version, namespace, server URL, role, and password toggle is exposed under `values.yaml`. Cluster overlays may override without rebuilding the Blueprint OCI artifact.

### `helm lint` results

```
=== bp-external-secrets ===
[INFO] Chart.yaml: icon is recommended
1 chart(s) linted, 0 chart(s) failed

=== bp-cnpg ===
[INFO] Chart.yaml: icon is recommended
1 chart(s) linted, 0 chart(s) failed

=== bp-valkey ===
[INFO] Chart.yaml: icon is recommended
1 chart(s) linted, 0 chart(s) failed
```

`INFO icon is recommended` is informational only — icons are added under `card/` per Blueprint convention; this PR does not block on cosmetic assets.

## Test plan

- [x] `helm dependency build` succeeds for each chart (upstream subchart pulled into `chart/charts/`)
- [x] `helm template <chart>` produces non-trivial output with no `monitoring.coreos.com/v1` CRs by default
- [x] `helm lint <chart>` returns 0 errors
- [x] `bash tests/observability-toggle.sh` passes for each chart (5 cases for ESO, 3 for cnpg, 4 for valkey)
- [ ] CI `blueprint-release.yaml` umbrella + observability-toggle gates green on PR push
- [ ] Once merged + tagged: Flux on `omantel.omani.works` reconciles `bp-cnpg` Ready, unblocking `bp-powerdns` (closes #254)

Closes #254