### PR TITLE
feat(charts): bp-temporal + bp-llm-gateway + bp-anthropic-adapter wrapper charts (closes #267 #268 #271)

### DIFF
--- a/platform/anthropic-adapter/blueprint.yaml
+++ b/platform/anthropic-adapter/blueprint.yaml
@@ -1,0 +1,89 @@
+apiVersion: catalyst.openova.io/v1alpha1
+kind: Blueprint
+metadata:
+  name: bp-anthropic-adapter
+  labels:
+    catalyst.openova.io/category: ai-runtime
+    catalyst.openova.io/section: pts-4-6-llm-serving
+spec:
+  version: 1.0.0
+  card:
+    title: Anthropic Adapter
+    summary: |
+      OpenAI ↔ Anthropic translation layer. Single Catalyst-authored Go
+      service that translates `/v1/chat/completions` (OpenAI) ↔
+      Anthropic `/v1/messages`, including streaming SSE. Pairs with
+      bp-llm-gateway so OpenAI-SDK clients can target Claude transparently.
+    icon: anthropic-adapter.svg
+    category: ai-runtime
+    tags: [llm, anthropic, claude, openai, adapter, proxy]
+    documentation: https://docs.anthropic.com/en/api/messages
+    license: Apache-2.0
+  visibility: listed
+  owner:
+    team: ai-platform
+    contact: ai-platform@openova.io
+  configSchema:
+    type: object
+    properties:
+      replicas:
+        type: integer
+        default: 1
+        minimum: 1
+        maximum: 16
+      anthropic:
+        type: object
+        properties:
+          baseUrl:
+            type: string
+            default: "https://api.anthropic.com"
+            description: |
+              Upstream Anthropic API base URL. Air-gapped Sovereigns
+              override to a regional egress proxy; cluster-internal
+              routing via bp-llm-gateway sets this to the in-cluster
+              gateway endpoint.
+          authMode:
+            type: string
+            enum: [oauth, subscription]
+            default: oauth
+            description: |
+              `oauth` = use the operator's Claude OAuth/Max
+              subscription token (NEVER an ANTHROPIC_API_KEY). The
+              token is mounted from the K8s Secret declared under
+              `auth.secretName`. `subscription` is reserved for future
+              tier-based routing — same secret, different validation.
+      auth:
+        type: object
+        properties:
+          secretName:
+            type: string
+            default: bp-anthropic-adapter-oauth
+            description: |
+              K8s Secret materialized by ESO from bp-openbao that
+              carries the operator's Claude OAuth/Max token under the
+              key `oauth_token`. NEVER commit a plaintext API key.
+      defaults:
+        type: object
+        properties:
+          model:
+            type: string
+            default: "claude-3-5-sonnet-20241022"
+            description: Default Anthropic model when the OpenAI request omits `model`.
+          maxTokens:
+            type: integer
+            default: 4096
+            description: Default Anthropic `max_tokens` when the OpenAI request omits it.
+  placementSchema:
+    modes: [single-region, active-active]
+    default: single-region
+  manifests:
+    chart: ./chart
+  depends:
+    - blueprint: bp-external-secrets
+      version: ^1.0
+      alias: eso
+  upgrades:
+    from: ["0.x"]
+  observability:
+    metrics: prometheus
+    logs: stdout

--- a/platform/anthropic-adapter/chart/Chart.yaml
+++ b/platform/anthropic-adapter/chart/Chart.yaml
@@ -1,0 +1,42 @@
+apiVersion: v2
+name: bp-anthropic-adapter
+description: |
+  Catalyst Blueprint scratch chart for the Anthropic Adapter — a single
+  Catalyst-authored Go service that translates OpenAI Chat Completions
+  ↔ Anthropic Messages, including streaming SSE.
+
+  No upstream Helm chart exists (the adapter is OpenOva-built), so this
+  chart hand-wires the Catalyst-built container image
+  (`ghcr.io/openova-io/openova/anthropic-adapter:<sha>`) as a
+  Deployment + Service + ConfigMap + ServiceMonitor + NetworkPolicy.
+
+  Pairs with bp-llm-gateway (slot fronts the public surface) and bp-vllm
+  (slot serves OpenAI-compatible local inference). The adapter's ONLY
+  egress to the public Anthropic API uses the operator's OAuth/Max
+  subscription token mounted from a K8s Secret materialized by ESO from
+  bp-openbao — NEVER an ANTHROPIC_API_KEY (memory/feedback_no_api_key.md).
+type: application
+version: 1.0.0
+appVersion: "0.1.0"
+keywords: [catalyst, blueprint, anthropic, claude, openai, adapter, proxy, llm]
+maintainers:
+  - name: OpenOva Catalyst
+    email: catalyst@openova.io
+
+# Scratch chart — the anthropic-adapter is Catalyst-authored, no upstream
+# Helm chart exists. The Catalyst overlay templates (Deployment + Service
+# + ConfigMap + ServiceMonitor + NetworkPolicy + HPA) are entirely in
+# templates/ in this chart.
+#
+# The `sigstore/common` library subchart below is included ONLY to
+# satisfy the platform-wide blueprint-release.yaml hollow-chart gate
+# (issue #181 / docs/BLUEPRINT-AUTHORING.md §11.1) — every umbrella MUST
+# declare at least one dependency. `common` is a tiny library chart
+# (helper templates only, zero runtime resources) and contributes
+# nothing to the rendered manifests of bp-anthropic-adapter.
+#
+# Mirrors the bp-vllm pattern (PR #283).
+dependencies:
+  - name: common
+    version: "0.1.3"
+    repository: "https://sigstore.github.io/helm-charts"

--- a/platform/anthropic-adapter/chart/templates/_helpers.tpl
+++ b/platform/anthropic-adapter/chart/templates/_helpers.tpl
@@ -1,0 +1,56 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "bp-anthropic-adapter.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "bp-anthropic-adapter.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "bp-anthropic-adapter.labels" -}}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+app.kubernetes.io/name: {{ include "bp-anthropic-adapter.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/component: ai-runtime
+catalyst.openova.io/blueprint: bp-anthropic-adapter
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "bp-anthropic-adapter.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "bp-anthropic-adapter.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+ServiceAccount name
+*/}}
+{{- define "bp-anthropic-adapter.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "bp-anthropic-adapter.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/platform/anthropic-adapter/chart/templates/configmap.yaml
+++ b/platform/anthropic-adapter/chart/templates/configmap.yaml
@@ -1,0 +1,19 @@
+{{- if and .Values.adapter.enabled .Values.configMap.enabled -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "bp-anthropic-adapter.fullname" . }}-config
+  labels:
+    {{- include "bp-anthropic-adapter.labels" . | nindent 4 }}
+data:
+  # OpenAI model name → Anthropic model name. The adapter Go service
+  # reads this map at startup (env MODEL_MAP_PATH points here) and uses
+  # it to route incoming `/v1/chat/completions` calls. Per-Sovereign
+  # overlays extend the map without rebuilding the Blueprint.
+  model-map.json: |
+    {{- toJson .Values.configMap.modelMap | nindent 4 }}
+  {{- if .Values.configMap.extraConfig }}
+  extra-config.yaml: |
+{{ toYaml .Values.configMap.extraConfig | indent 4 }}
+  {{- end }}
+{{- end }}

--- a/platform/anthropic-adapter/chart/templates/deployment.yaml
+++ b/platform/anthropic-adapter/chart/templates/deployment.yaml
@@ -1,0 +1,107 @@
+{{- if .Values.adapter.enabled -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "bp-anthropic-adapter.fullname" . }}
+  labels:
+    {{- include "bp-anthropic-adapter.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.adapter.replicas }}
+  selector:
+    matchLabels:
+      {{- include "bp-anthropic-adapter.selectorLabels" . | nindent 6 }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        {{- include "bp-anthropic-adapter.selectorLabels" . | nindent 8 }}
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: {{ .Values.adapter.port | quote }}
+        prometheus.io/path: "/metrics"
+    spec:
+      serviceAccountName: {{ include "bp-anthropic-adapter.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.adapter.podSecurityContext | nindent 8 }}
+      {{- with .Values.adapter.image.pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: adapter
+          # Image tag MUST be SHA-pinned by the per-cluster overlay
+          # (Inviolable Principle #4a — Images: GitHub Actions is the
+          # only build path). Empty default fails the render with a
+          # clear error rather than silently shipping :latest.
+          image: "{{ required "adapter.image.tag MUST be SHA-pinned by the per-cluster overlay (never :latest, never empty)" .Values.adapter.image.tag | printf "%s:%s" .Values.adapter.image.repository }}"
+          imagePullPolicy: {{ .Values.adapter.image.pullPolicy }}
+          env:
+            - name: PORT
+              value: {{ .Values.adapter.port | quote }}
+            - name: ANTHROPIC_BASE_URL
+              value: {{ .Values.adapter.anthropic.baseUrl | quote }}
+            - name: ANTHROPIC_API_VERSION
+              value: {{ .Values.adapter.anthropic.apiVersion | quote }}
+            - name: AUTH_MODE
+              value: {{ .Values.adapter.auth.mode | quote }}
+            # OAuth/Max subscription token mounted from the K8s Secret
+            # materialized by ESO from bp-openbao. NEVER an
+            # ANTHROPIC_API_KEY (memory/feedback_no_api_key.md).
+            - name: ANTHROPIC_OAUTH_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.adapter.auth.secretName | quote }}
+                  key: {{ .Values.adapter.auth.secretKey | quote }}
+            - name: DEFAULT_MODEL
+              value: {{ .Values.adapter.defaults.model | quote }}
+            - name: DEFAULT_MAX_TOKENS
+              value: {{ .Values.adapter.defaults.maxTokens | quote }}
+            - name: DEFAULT_TEMPERATURE
+              value: {{ .Values.adapter.defaults.temperature | quote }}
+            {{- if .Values.configMap.enabled }}
+            - name: MODEL_MAP_PATH
+              value: /etc/anthropic-adapter/model-map.json
+            {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.adapter.port }}
+              protocol: TCP
+          resources:
+            {{- toYaml .Values.adapter.resources | nindent 12 }}
+          securityContext:
+            {{- toYaml .Values.adapter.containerSecurityContext | nindent 12 }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.adapter.probes.liveness.path }}
+              port: http
+            initialDelaySeconds: {{ .Values.adapter.probes.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.adapter.probes.liveness.periodSeconds }}
+            timeoutSeconds: {{ .Values.adapter.probes.liveness.timeoutSeconds }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.adapter.probes.readiness.path }}
+              port: http
+            initialDelaySeconds: {{ .Values.adapter.probes.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.adapter.probes.readiness.periodSeconds }}
+            timeoutSeconds: {{ .Values.adapter.probes.readiness.timeoutSeconds }}
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+            {{- if .Values.configMap.enabled }}
+            - name: config
+              mountPath: /etc/anthropic-adapter
+              readOnly: true
+            {{- end }}
+      volumes:
+        - name: tmp
+          emptyDir: {}
+        {{- if .Values.configMap.enabled }}
+        - name: config
+          configMap:
+            name: {{ include "bp-anthropic-adapter.fullname" . }}-config
+        {{- end }}
+{{- end }}

--- a/platform/anthropic-adapter/chart/templates/hpa.yaml
+++ b/platform/anthropic-adapter/chart/templates/hpa.yaml
@@ -1,0 +1,31 @@
+{{- /*
+HorizontalPodAutoscaler — DEFAULT FALSE.
+
+The adapter is a thin streaming proxy; per-Sovereign overlays enable
+HPA on Sovereigns with bursty OpenAI-SDK callers.
+*/}}
+{{- if and .Values.adapter.enabled .Values.hpa.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "bp-anthropic-adapter.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "bp-anthropic-adapter.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "bp-anthropic-adapter.fullname" . }}
+  minReplicas: {{ .Values.hpa.minReplicas }}
+  maxReplicas: {{ .Values.hpa.maxReplicas }}
+  metrics:
+    {{- if .Values.hpa.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.hpa.targetCPUUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/platform/anthropic-adapter/chart/templates/networkpolicy.yaml
+++ b/platform/anthropic-adapter/chart/templates/networkpolicy.yaml
@@ -1,0 +1,74 @@
+{{- /*
+NetworkPolicy — locks the anthropic-adapter pod down to the minimum set
+required for its job: receive translated OpenAI calls from
+bp-llm-gateway and forward Anthropic-format requests to api.anthropic.com.
+
+Ingress: bp-llm-gateway is the canonical caller; the gateway routes
+OpenAI-SDK clients to the adapter when they target a Claude model.
+Prometheus scraping is allowed when serviceMonitor.enabled = true.
+
+Egress: cluster DNS (always); HTTPS to api.anthropic.com (TCP/443) when
+allowAnthropicEgress = true. Air-gapped Sovereigns set
+allowAnthropicEgress=false and front only in-cluster vLLM via the gateway.
+
+Per docs/INVIOLABLE-PRINCIPLES.md #4 every selector / port is operator-
+tunable. Disabled by default (cluster overlays MAY enable in target state).
+*/}}
+{{- if and .Values.adapter.enabled .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "bp-anthropic-adapter.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "bp-anthropic-adapter.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "bp-anthropic-adapter.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    # bp-llm-gateway → adapter (OpenAI-format API)
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.networkPolicy.llmGatewayNamespace | quote }}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.adapter.port }}
+    # Prometheus scraping
+    - from:
+        - namespaceSelector: {}
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: prometheus
+      ports:
+        - protocol: TCP
+          port: {{ .Values.adapter.port }}
+  egress:
+    # Cluster DNS
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    {{- if .Values.networkPolicy.allowAnthropicEgress }}
+    # api.anthropic.com (HTTPS only)
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 10.0.0.0/8
+              - 172.16.0.0/12
+              - 192.168.0.0/16
+      ports:
+        - protocol: TCP
+          port: 443
+    {{- end }}
+{{- end }}

--- a/platform/anthropic-adapter/chart/templates/service.yaml
+++ b/platform/anthropic-adapter/chart/templates/service.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.adapter.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "bp-anthropic-adapter.fullname" . }}
+  labels:
+    {{- include "bp-anthropic-adapter.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.targetPort }}
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "bp-anthropic-adapter.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/platform/anthropic-adapter/chart/templates/serviceaccount.yaml
+++ b/platform/anthropic-adapter/chart/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "bp-anthropic-adapter.serviceAccountName" . }}
+  labels:
+    {{- include "bp-anthropic-adapter.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/platform/anthropic-adapter/chart/templates/servicemonitor.yaml
+++ b/platform/anthropic-adapter/chart/templates/servicemonitor.yaml
@@ -1,0 +1,40 @@
+{{- /*
+ServiceMonitor — Catalyst overlay.
+
+DEFAULT FALSE per docs/BLUEPRINT-AUTHORING.md §11.2 (Observability
+toggles must default false). The `monitoring.coreos.com/v1` CRD ships
+with kube-prometheus-stack — a downstream Application Blueprint that
+itself depends on the bootstrap-kit; defaulting `enabled: true` here
+would render a ServiceMonitor that the apiserver immediately rejects on
+a fresh Sovereign install.
+
+Defense in depth: the values toggle (.Values.serviceMonitor.enabled) is
+the operator switch; the Capabilities gate skips the resource entirely
+on a Sovereign that has not yet reconciled the CRD, so flipping the
+toggle on a too-early Sovereign cannot break the bp-anthropic-adapter
+reconcile.
+*/}}
+{{- if and .Values.adapter.enabled .Values.serviceMonitor.enabled (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "bp-anthropic-adapter.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "bp-anthropic-adapter.labels" . | nindent 4 }}
+    {{- with .Values.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "bp-anthropic-adapter.selectorLabels" . | nindent 6 }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  endpoints:
+    - port: http
+      path: {{ .Values.serviceMonitor.path | quote }}
+      interval: {{ .Values.serviceMonitor.interval | quote }}
+      scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout | quote }}
+{{- end }}

--- a/platform/anthropic-adapter/chart/tests/observability-toggle.sh
+++ b/platform/anthropic-adapter/chart/tests/observability-toggle.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# bp-anthropic-adapter observability-toggle integration test (issue #182).
+#
+# Verifies the Catalyst rule from docs/BLUEPRINT-AUTHORING.md §11.2
+# (Observability toggles must default false):
+#
+#   - `helm template` with default values MUST produce zero
+#     `monitoring.coreos.com/v1` ServiceMonitor / PrometheusRule resources.
+#   - `helm template` with the toggle EXPLICITLY set true MUST succeed
+#     and render a ServiceMonitor (proves the opt-in path works).
+#   - `helm template` with the toggle EXPLICITLY set false MUST succeed
+#     and produce zero monitoring.coreos.com references.
+#
+# All cases pin a SHA-style image tag because the deployment template
+# requires `adapter.image.tag` (Inviolable Principle #4a — never :latest).
+#
+# Usage: bash tests/observability-toggle.sh [CHART_DIR]
+
+set -euo pipefail
+
+CHART_DIR="${1:-$(cd "$(dirname "$0")/.." && pwd)}"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+cd "$CHART_DIR"
+
+if [ ! -d charts ] || [ -z "$(ls -A charts 2>/dev/null)" ]; then
+  helm dependency build >/dev/null
+fi
+
+# Image tag — pinned in every helm template invocation so the chart
+# renders cleanly. Real Sovereigns set this in the per-cluster overlay.
+PINNED_TAG="adapter.image.tag=sha-0000000000000000000000000000000000000000"
+
+# ── Case 1: default render must NOT contain monitoring.coreos.com ────────
+echo "[observability-toggle] Case 1: default render produces no ServiceMonitor"
+helm template smoke-anthropic-adapter . \
+  --set "$PINNED_TAG" \
+  > "$TMP/default.yaml"
+if grep -qE "^kind: ServiceMonitor" "$TMP/default.yaml"; then
+  echo "FAIL: default render of bp-anthropic-adapter contains kind: ServiceMonitor." >&2
+  echo "      docs/BLUEPRINT-AUTHORING.md §11.2 forbids this — observability toggles must default false." >&2
+  exit 1
+fi
+if grep -q "monitoring.coreos.com" "$TMP/default.yaml"; then
+  echo "FAIL: default render of bp-anthropic-adapter contains monitoring.coreos.com references." >&2
+  exit 1
+fi
+echo "  PASS"
+
+# ── Case 2: opt-in render with toggle=true must succeed AND produce a ServiceMonitor ─
+echo "[observability-toggle] Case 2: opt-in (serviceMonitor.enabled=true) renders a ServiceMonitor"
+if ! helm template smoke-anthropic-adapter . \
+    --set "$PINNED_TAG" \
+    --set "serviceMonitor.enabled=true" \
+    --api-versions "monitoring.coreos.com/v1" \
+    > "$TMP/optin.yaml" 2> "$TMP/optin.err"; then
+  echo "FAIL: opt-in render failed:" >&2
+  cat "$TMP/optin.err" >&2
+  exit 1
+fi
+if ! grep -qE "^kind: ServiceMonitor" "$TMP/optin.yaml"; then
+  echo "FAIL: opt-in render did NOT produce a ServiceMonitor — the toggle is broken." >&2
+  exit 1
+fi
+echo "  PASS"
+
+# ── Case 3: explicit-off must produce zero monitoring.coreos.com refs ───
+echo "[observability-toggle] Case 3: explicit serviceMonitor.enabled=false renders cleanly"
+if ! helm template smoke-anthropic-adapter . \
+    --set "$PINNED_TAG" \
+    --set "serviceMonitor.enabled=false" \
+    --api-versions "monitoring.coreos.com/v1" \
+    > "$TMP/off.yaml" 2> "$TMP/off.err"; then
+  echo "FAIL: explicit-off render failed:" >&2
+  cat "$TMP/off.err" >&2
+  exit 1
+fi
+if grep -qE "^kind: ServiceMonitor" "$TMP/off.yaml"; then
+  echo "FAIL: explicit-off render still contains kind: ServiceMonitor — the toggle is broken." >&2
+  exit 1
+fi
+echo "  PASS"
+
+# ── Case 4: missing image tag fails fast (Inviolable Principle #4a) ──────
+echo "[observability-toggle] Case 4: empty image tag fails the render (#4a)"
+if helm template smoke-anthropic-adapter . > "$TMP/notag.yaml" 2> "$TMP/notag.err"; then
+  echo "FAIL: render with empty image tag SUCCEEDED — never-:latest gate is broken." >&2
+  exit 1
+fi
+if ! grep -q "image.tag" "$TMP/notag.err"; then
+  echo "FAIL: render with empty tag failed but error didn't mention image.tag — gate is misleading." >&2
+  cat "$TMP/notag.err" >&2
+  exit 1
+fi
+echo "  PASS"
+
+echo "[observability-toggle] All bp-anthropic-adapter observability-toggle gates green."

--- a/platform/anthropic-adapter/chart/values.yaml
+++ b/platform/anthropic-adapter/chart/values.yaml
@@ -1,0 +1,168 @@
+# Catalyst Blueprint scratch chart for bp-anthropic-adapter — no upstream
+# Helm chart exists (the adapter is Catalyst-authored). All values
+# consumed by templates/ in this chart.
+#
+# Per docs/INVIOLABLE-PRINCIPLES.md #4 (never hardcode), every
+# operationally-meaningful value (image tag, model defaults, auth secret
+# name, anthropic base URL) is configurable; cluster overlays in
+# clusters/<sovereign>/ may override any of these without rebuilding the
+# Blueprint OCI artifact.
+
+catalystBlueprint:
+  upstream:
+    chart: ""               # scratch chart — no upstream Helm chart
+    version: ""
+    repo: ""
+    images:
+      adapter: "ghcr.io/openova-io/openova/anthropic-adapter"
+
+# ─── Anthropic Adapter Go service ────────────────────────────────────────
+adapter:
+  enabled: true
+
+  # Solo-Sovereign minimum — single replica. Per-Sovereign overlays bump
+  # for HA on multi-tenant Sovereigns.
+  replicas: 1
+
+  # Catalyst-built image. The `tag` field is SHA-pinned (not :latest)
+  # per Inviolable Principle #4a (Images: GitHub Actions is the only
+  # build path). Per-cluster overlays bump the tag in lockstep with the
+  # CI run that produces the new image; bp-anthropic-adapter Blueprint
+  # release version bumps when the chart's appVersion changes.
+  image:
+    repository: ghcr.io/openova-io/openova/anthropic-adapter
+    # Empty default — the per-cluster overlay MUST pin a SHA. Leaving
+    # this blank intentionally fails Helm render with a clear error
+    # rather than silently shipping :latest.
+    tag: ""
+    pullPolicy: IfNotPresent
+    pullSecrets: []
+
+  # Container port — Catalyst convention for adapter services is 8000.
+  port: 8000
+
+  # ─── Upstream Anthropic API ──────────────────────────────────────────
+  # The adapter forwards translated requests to api.anthropic.com.
+  # Air-gapped Sovereigns override to a regional egress proxy.
+  anthropic:
+    baseUrl: "https://api.anthropic.com"
+    apiVersion: "2023-06-01"
+
+  # ─── Authentication — OAuth/Max subscription token ───────────────────
+  # CRITICAL — per memory/feedback_no_api_key.md and the user's
+  # standing instruction, the adapter NEVER uses an ANTHROPIC_API_KEY.
+  # The Claude OAuth/Max subscription token is mounted from a K8s
+  # Secret materialized by ESO from bp-openbao. The Secret carries the
+  # token under the key `oauth_token`.
+  #
+  # The Catalyst control-plane provisions the token rotation; per-
+  # Sovereign overlays NEVER inline a plaintext token here.
+  auth:
+    secretName: bp-anthropic-adapter-oauth
+    secretKey: oauth_token
+    # Reserved for future tier-based validation. Today the adapter
+    # always uses the OAuth bearer mechanism.
+    mode: oauth
+
+  # ─── Defaults applied when the OpenAI request omits these ────────────
+  defaults:
+    model: "claude-3-5-sonnet-20241022"
+    maxTokens: 4096
+    temperature: 1.0
+
+  # Resources — solo-Sovereign minimum. The adapter is a streaming
+  # proxy; CPU is the dominant cost (TLS to Anthropic + JSON
+  # marshal/unmarshal). Per-Sovereign overlays bump for high-throughput
+  # tenants.
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: "1"
+      memory: 512Mi
+
+  # SecurityContext — non-root. The Catalyst-built scratch image runs
+  # as UID 65534 (nobody), per the Catalyst Go-service template.
+  podSecurityContext:
+    runAsNonRoot: true
+    runAsUser: 65534
+    runAsGroup: 65534
+    fsGroup: 65534
+  containerSecurityContext:
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
+    capabilities:
+      drop: ["ALL"]
+
+  # Liveness + readiness — the adapter exposes /healthz on the API port.
+  probes:
+    liveness:
+      path: /healthz
+      initialDelaySeconds: 5
+      periodSeconds: 10
+      timeoutSeconds: 5
+    readiness:
+      path: /readyz
+      initialDelaySeconds: 2
+      periodSeconds: 10
+      timeoutSeconds: 5
+
+# ─── Service ─────────────────────────────────────────────────────────────
+service:
+  type: ClusterIP
+  port: 8000
+  targetPort: 8000
+  annotations: {}
+
+# ─── ServiceAccount ──────────────────────────────────────────────────────
+serviceAccount:
+  create: true
+  name: ""
+  annotations: {}
+
+# ─── ConfigMap (model mapping + adapter config overrides) ────────────────
+# OpenAI model names → Anthropic model names. Per-Sovereign overlays
+# extend the map.
+configMap:
+  enabled: true
+  modelMap:
+    gpt-4: "claude-3-5-sonnet-20241022"
+    gpt-4-turbo: "claude-3-5-sonnet-20241022"
+    gpt-4o: "claude-3-5-sonnet-20241022"
+    gpt-4o-mini: "claude-3-5-haiku-20241022"
+    gpt-3.5-turbo: "claude-3-5-haiku-20241022"
+  extraConfig: {}
+
+# ─── ServiceMonitor — DEFAULT FALSE per docs/BLUEPRINT-AUTHORING.md §11.2
+# Adapter exposes Prometheus metrics on the API port at /metrics. The
+# `monitoring.coreos.com/v1` CRD ships with kube-prometheus-stack — a
+# downstream Application Blueprint that depends on the bootstrap-kit.
+# Defaulting `enabled: true` would render a ServiceMonitor that the
+# apiserver rejects on a fresh Sovereign install.
+#
+# Operator opts in via per-cluster overlay once kube-prometheus-stack
+# reconciles (issue #182).
+serviceMonitor:
+  enabled: false
+  interval: "30s"
+  scrapeTimeout: "10s"
+  path: "/metrics"
+  labels: {}
+
+# ─── NetworkPolicy (egress to Anthropic, ingress from gateway) ───────────
+networkPolicy:
+  enabled: false
+  # Namespace where bp-llm-gateway runs. Per-Sovereign overlays override
+  # if the gateway lives elsewhere.
+  llmGatewayNamespace: "ai-runtime"
+  # Allow egress to api.anthropic.com (HTTPS / TCP 443). Disable on
+  # air-gapped Sovereigns where the adapter only fronts in-cluster vLLM.
+  allowAnthropicEgress: true
+
+# ─── HorizontalPodAutoscaler — DEFAULT FALSE ─────────────────────────────
+hpa:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 4
+  targetCPUUtilizationPercentage: 80

--- a/platform/llm-gateway/blueprint.yaml
+++ b/platform/llm-gateway/blueprint.yaml
@@ -1,0 +1,123 @@
+apiVersion: catalyst.openova.io/v1alpha1
+kind: Blueprint
+metadata:
+  name: bp-llm-gateway
+  labels:
+    catalyst.openova.io/category: ai-runtime
+    catalyst.openova.io/section: pts-4-6-llm-serving
+spec:
+  version: 1.0.0
+  card:
+    title: LLM Gateway
+    summary: |
+      Subscription-aware LLM proxy. Wraps the upstream LiteLLM proxy
+      (`ghcr.io/berriai/litellm:main-stable`) and routes requests to
+      Anthropic (via the operator's Claude OAuth/Max subscription —
+      NEVER an ANTHROPIC_API_KEY), Bedrock, Vertex, OpenAI-compatible
+      backends (via bp-anthropic-adapter), and self-hosted vLLM. CNPG-
+      backed audit log; Keycloak SSO for human callers.
+    icon: llm-gateway.svg
+    category: ai-runtime
+    tags: [llm, gateway, litellm, proxy, claude, openai, bedrock, vertex]
+    documentation: https://docs.litellm.ai/
+    license: MIT
+  visibility: listed
+  owner:
+    team: ai-platform
+    contact: ai-platform@openova.io
+  configSchema:
+    type: object
+    properties:
+      replicas:
+        type: integer
+        default: 1
+        minimum: 1
+        maximum: 16
+      auth:
+        type: object
+        properties:
+          mode:
+            type: string
+            enum: [keycloak, masterKey, hybrid]
+            default: keycloak
+            description: |
+              `keycloak` = OIDC-only (every caller authenticates via
+              bp-keycloak realm). `masterKey` = static per-tenant master
+              keys (dev only — operators MUST NOT enable in production).
+              `hybrid` = Keycloak for human callers, master keys for
+              CI/automation accounts.
+          keycloak:
+            type: object
+            properties:
+              issuer:
+                type: string
+                description: Keycloak realm issuer URL (https://keycloak.<env>.<sovereign-domain>/realms/<realm>).
+              audience:
+                type: string
+                default: llm-gateway
+      audit:
+        type: object
+        properties:
+          enabled:
+            type: boolean
+            default: true
+            description: Enable CNPG-backed audit log (every prompt + response stored for compliance).
+      backends:
+        type: object
+        properties:
+          anthropic:
+            type: object
+            properties:
+              enabled:
+                type: boolean
+                default: false
+                description: |
+                  Forward Claude requests via the operator's
+                  OAuth/Max subscription. NEVER set an ANTHROPIC_API_KEY
+                  — the gateway uses subscription tokens issued by the
+                  operator's Claude account.
+          bedrock:
+            type: object
+            properties:
+              enabled:
+                type: boolean
+                default: false
+          vertex:
+            type: object
+            properties:
+              enabled:
+                type: boolean
+                default: false
+          vllm:
+            type: object
+            properties:
+              enabled:
+                type: boolean
+                default: false
+          anthropicAdapter:
+            type: object
+            properties:
+              enabled:
+                type: boolean
+                default: false
+                description: Route OpenAI-compatible callers to Claude via bp-anthropic-adapter.
+  placementSchema:
+    modes: [single-region, active-active]
+    default: single-region
+  manifests:
+    chart: ./chart
+  depends:
+    - blueprint: bp-cnpg
+      version: ^1.0
+      alias: db
+    - blueprint: bp-keycloak
+      version: ^1.0
+      alias: idp
+    - blueprint: bp-external-secrets
+      version: ^1.0
+      alias: eso
+  upgrades:
+    from: ["0.x"]
+  observability:
+    metrics: prometheus
+    logs: stdout

--- a/platform/llm-gateway/chart/Chart.yaml
+++ b/platform/llm-gateway/chart/Chart.yaml
@@ -1,0 +1,32 @@
+apiVersion: v2
+name: bp-llm-gateway
+version: 1.0.0
+appVersion: "v1.57.2"
+description: |
+  Catalyst-curated Blueprint umbrella chart for the LLM Gateway —
+  subscription-aware proxy that fronts Anthropic (via operator OAuth/Max
+  subscription, NEVER API keys), Bedrock, Vertex, OpenAI-compatible
+  backends (via bp-anthropic-adapter), and self-hosted vLLM. Wraps the
+  upstream `litellm-helm` chart at oci://ghcr.io/berriai/litellm-helm
+  as a Helm subchart so `helm dependency build` bundles the upstream
+  payload into this artifact; the Catalyst overlay templates
+  (CNPG audit-log Cluster, Keycloak OIDC ConfigMap, NetworkPolicy guard,
+  ServiceMonitor toggle) sit alongside the upstream subchart and Helm
+  renders both at install time. Catalyst-curated values flow into the
+  upstream subchart under the `litellm-helm:` key in values.yaml.
+type: application
+keywords: [catalyst, blueprint, llm, litellm, gateway, proxy, anthropic, claude, openai, bedrock, vertex]
+maintainers:
+  - name: OpenOva Catalyst
+    email: catalyst@openova.io
+
+# Upstream chart pulled in as a Helm subchart so `helm dependency build`
+# bundles it into the OCI artifact. Pinned to litellm-helm 0.1.572
+# (matches platform/llm-gateway/blueprint.yaml + values.yaml
+# `catalystBlueprint.upstream.version`). Per
+# docs/INVIOLABLE-PRINCIPLES.md #4 (never hardcode) the version is
+# operator-bumpable via PR + Blueprint release.
+dependencies:
+  - name: litellm-helm
+    version: "0.1.572"
+    repository: "oci://ghcr.io/berriai"

--- a/platform/llm-gateway/chart/templates/_helpers.tpl
+++ b/platform/llm-gateway/chart/templates/_helpers.tpl
@@ -1,0 +1,41 @@
+{{/*
+Common Catalyst overlay helpers for bp-llm-gateway.
+*/}}
+
+{{- define "bp-llm-gateway.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "bp-llm-gateway.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Common labels — applied to every Catalyst overlay resource so the
+projector tracks them.
+*/}}
+{{- define "bp-llm-gateway.labels" -}}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+app.kubernetes.io/name: {{ include "bp-llm-gateway.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/component: ai-runtime
+catalyst.openova.io/blueprint: bp-llm-gateway
+{{- end }}
+
+{{- define "bp-llm-gateway.selectorLabels" -}}
+app.kubernetes.io/name: litellm
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/platform/llm-gateway/chart/templates/cnpg-cluster.yaml
+++ b/platform/llm-gateway/chart/templates/cnpg-cluster.yaml
@@ -1,0 +1,41 @@
+{{- /*
+Catalyst overlay: CNPG-backed audit-log Postgres for bp-llm-gateway.
+
+Every prompt + response routed through the LiteLLM proxy is persisted
+to this Postgres for compliance / tenant attribution. The resulting
+`bp-llm-gateway-audit-rw` Service is what the upstream litellm-helm
+chart's `db.endpoint` value points at, and the
+`bp-llm-gateway-audit-app` Secret (CNPG-materialized) is consumed via
+`db.secret.name` for the Prisma migration job + runtime DB writes.
+
+bp-llm-gateway lists `bp-cnpg` as a hard dependency in blueprint.yaml
+so this Cluster CR reconciles only after the cluster-wide CloudNativePG
+operator is Ready.
+
+Per docs/INVIOLABLE-PRINCIPLES.md #4 (never hardcode), every operator-tunable
+knob lives in values.yaml `catalystOverlay.cnpg.*`.
+*/ -}}
+{{- if .Values.catalystOverlay.cnpg.enabled }}
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: bp-llm-gateway-audit
+  labels:
+    {{- include "bp-llm-gateway.labels" . | nindent 4 }}
+spec:
+  instances: {{ .Values.catalystOverlay.cnpg.instances }}
+  {{- with .Values.catalystOverlay.cnpg.imageName }}
+  imageName: {{ . | quote }}
+  {{- end }}
+  storage:
+    size: {{ .Values.catalystOverlay.cnpg.storage.size }}
+    {{- with .Values.catalystOverlay.cnpg.storage.storageClass }}
+    storageClass: {{ . }}
+    {{- end }}
+  resources:
+    {{- toYaml .Values.catalystOverlay.cnpg.resources | nindent 4 }}
+  bootstrap:
+    initdb:
+      database: litellm_audit
+      owner: litellm
+{{- end }}

--- a/platform/llm-gateway/chart/templates/keycloak-oidc-config.yaml
+++ b/platform/llm-gateway/chart/templates/keycloak-oidc-config.yaml
@@ -1,0 +1,41 @@
+{{- /*
+Catalyst overlay: Keycloak OIDC integration for bp-llm-gateway.
+
+LiteLLM proxy supports JWT-based auth via its `general_settings.master_key`
+fallback + per-route JWT validation; Keycloak realm tokens are validated
+against the realm's JWKS endpoint. This ConfigMap renders an `auth.yaml`
+fragment that the operator wires into the LiteLLM pod via the upstream
+chart's `volumes:` / `volumeMounts:` overlay.
+
+DEFAULT OFF (`catalystOverlay.auth.enabled: false`) — operator opts in
+once bp-keycloak is reconciled, an `llm-gateway` realm/client exists, and
+the per-cluster overlay references this ConfigMap. Keeping it off by
+default keeps the chart installable on a fresh Sovereign before the IDP
+tier is up (docs/BLUEPRINT-AUTHORING.md §11.2 spirit — every cross-tier
+dependency defaults off).
+
+CRITICAL — this is for HUMAN callers (Catalyst Portal, Console, devs
+hitting the proxy from the IDP). Programmatic callers (Catalyst app
+services, CI runners) authenticate via per-tenant master keys rendered
+into `bp-llm-gateway-env` by ESO from bp-openbao. The operator's Claude
+OAuth/Max subscription token used for the Anthropic backend is a
+SEPARATE secret — see values.yaml `catalystOverlay.backends.anthropic`
+docs and memory/feedback_no_api_key.md.
+*/ -}}
+{{- if .Values.catalystOverlay.auth.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: bp-llm-gateway-keycloak-oidc
+  labels:
+    {{- include "bp-llm-gateway.labels" . | nindent 4 }}
+data:
+  auth.yaml: |
+    auth:
+      mode: {{ .Values.catalystOverlay.auth.mode | quote }}
+      keycloak:
+        issuer: {{ .Values.catalystOverlay.auth.keycloak.issuer | quote }}
+        jwksUri: {{ .Values.catalystOverlay.auth.keycloak.jwksUri | quote }}
+        audience: {{ .Values.catalystOverlay.auth.keycloak.audience | quote }}
+        clientId: {{ .Values.catalystOverlay.auth.keycloak.clientId | quote }}
+{{- end }}

--- a/platform/llm-gateway/chart/templates/networkpolicy.yaml
+++ b/platform/llm-gateway/chart/templates/networkpolicy.yaml
@@ -1,0 +1,85 @@
+{{- /*
+NetworkPolicy — locks the LiteLLM proxy down to the minimum set required
+for inbound from app-tier callers + outbound to backend LLM providers.
+
+Ingress: per-cluster overlay enumerates `allowedCallerNamespaces`. The
+default values list (ai-runtime, catalyst-apps) is a sensible solo-
+Sovereign starting point.
+
+Egress: cluster DNS (always); HTTPS to upstream LLM providers
+(api.anthropic.com / Bedrock regional endpoints / Vertex regional
+endpoints / openai.com) when the corresponding backend toggle is true.
+Air-gapped Sovereigns serve only the in-cluster vLLM + anthropic-adapter
+backends and leave every external toggle false.
+
+Per docs/INVIOLABLE-PRINCIPLES.md #4 every selector / port is operator-
+tunable. Disabled by default (cluster overlays MAY enable in target
+state).
+*/}}
+{{- if .Values.catalystOverlay.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "bp-llm-gateway.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "bp-llm-gateway.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "bp-llm-gateway.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    {{- range .Values.catalystOverlay.networkPolicy.allowedCallerNamespaces }}
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ . | quote }}
+      ports:
+        - protocol: TCP
+          port: 4000
+    {{- end }}
+    # Prometheus scraping
+    - from:
+        - namespaceSelector: {}
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: prometheus
+      ports:
+        - protocol: TCP
+          port: 4000
+  egress:
+    # Cluster DNS
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    # CNPG audit-log Postgres
+    - to:
+        - podSelector:
+            matchLabels:
+              cnpg.io/cluster: bp-llm-gateway-audit
+      ports:
+        - protocol: TCP
+          port: 5432
+    {{- if or .Values.catalystOverlay.backends.anthropic.enabled .Values.catalystOverlay.backends.bedrock.enabled .Values.catalystOverlay.backends.vertex.enabled }}
+    # Egress to upstream LLM provider APIs (HTTPS only)
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 10.0.0.0/8
+              - 172.16.0.0/12
+              - 192.168.0.0/16
+      ports:
+        - protocol: TCP
+          port: 443
+    {{- end }}
+{{- end }}

--- a/platform/llm-gateway/chart/templates/servicemonitor.yaml
+++ b/platform/llm-gateway/chart/templates/servicemonitor.yaml
@@ -1,0 +1,39 @@
+{{- /*
+ServiceMonitor — Catalyst overlay.
+
+DEFAULT FALSE per docs/BLUEPRINT-AUTHORING.md §11.2 (Observability
+toggles must default false). The `monitoring.coreos.com/v1` CRD ships
+with kube-prometheus-stack — a downstream Application Blueprint that
+itself depends on the bootstrap-kit; defaulting `enabled: true` here
+would render a ServiceMonitor that the apiserver immediately rejects on
+a fresh Sovereign install.
+
+Defense in depth: the values toggle (.Values.catalystOverlay.serviceMonitor.enabled)
+is the operator switch; the Capabilities gate skips the resource entirely
+on a Sovereign that has not yet reconciled the CRD, so flipping the
+toggle on a too-early Sovereign cannot break the bp-llm-gateway reconcile.
+*/}}
+{{- if and .Values.catalystOverlay.serviceMonitor.enabled (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "bp-llm-gateway.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "bp-llm-gateway.labels" . | nindent 4 }}
+    {{- with .Values.catalystOverlay.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "bp-llm-gateway.selectorLabels" . | nindent 6 }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  endpoints:
+    - port: http
+      path: {{ .Values.catalystOverlay.serviceMonitor.path | quote }}
+      interval: {{ .Values.catalystOverlay.serviceMonitor.interval | quote }}
+      scrapeTimeout: {{ .Values.catalystOverlay.serviceMonitor.scrapeTimeout | quote }}
+{{- end }}

--- a/platform/llm-gateway/chart/tests/observability-toggle.sh
+++ b/platform/llm-gateway/chart/tests/observability-toggle.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# bp-llm-gateway observability-toggle integration test (issue #182).
+#
+# Verifies the Catalyst rule from docs/BLUEPRINT-AUTHORING.md §11.2
+# (Observability toggles must default false):
+#
+#   - `helm template` with default values MUST produce zero
+#     `monitoring.coreos.com/v1` ServiceMonitor / PrometheusRule resources.
+#   - `helm template` with the toggle EXPLICITLY set true MUST succeed
+#     and render a ServiceMonitor (proves the opt-in path works).
+#   - `helm template` with the toggle EXPLICITLY set false MUST succeed
+#     and produce zero monitoring.coreos.com references.
+#
+# Usage: bash tests/observability-toggle.sh [CHART_DIR]
+
+set -euo pipefail
+
+CHART_DIR="${1:-$(cd "$(dirname "$0")/.." && pwd)}"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+cd "$CHART_DIR"
+
+if [ ! -d charts ] || [ -z "$(ls -A charts 2>/dev/null)" ]; then
+  helm dependency build >/dev/null
+fi
+
+# ── Case 1: default render must NOT contain monitoring.coreos.com ────────
+echo "[observability-toggle] Case 1: default render produces no ServiceMonitor"
+helm template smoke-llm-gateway . > "$TMP/default.yaml"
+if grep -qE "^kind: ServiceMonitor" "$TMP/default.yaml"; then
+  echo "FAIL: default render of bp-llm-gateway contains kind: ServiceMonitor." >&2
+  echo "      docs/BLUEPRINT-AUTHORING.md §11.2 forbids this — observability toggles must default false." >&2
+  exit 1
+fi
+echo "  PASS"
+
+# ── Case 2: opt-in render with toggle=true must succeed and render ServiceMonitor ─
+echo "[observability-toggle] Case 2: opt-in (catalystOverlay.serviceMonitor.enabled=true) renders cleanly"
+if ! helm template smoke-llm-gateway . \
+    --set "catalystOverlay.serviceMonitor.enabled=true" \
+    --api-versions "monitoring.coreos.com/v1" \
+    > "$TMP/optin.yaml" 2> "$TMP/optin.err"; then
+  echo "FAIL: opt-in render failed:" >&2
+  cat "$TMP/optin.err" >&2
+  exit 1
+fi
+if ! grep -qE "^kind: ServiceMonitor" "$TMP/optin.yaml"; then
+  echo "FAIL: opt-in render did NOT produce a ServiceMonitor — the toggle is broken." >&2
+  exit 1
+fi
+echo "  PASS"
+
+# ── Case 3: explicit-off must produce zero ServiceMonitor refs ───────────
+echo "[observability-toggle] Case 3: explicit serviceMonitor.enabled=false renders cleanly"
+if ! helm template smoke-llm-gateway . \
+    --set "catalystOverlay.serviceMonitor.enabled=false" \
+    --api-versions "monitoring.coreos.com/v1" \
+    > "$TMP/off.yaml" 2> "$TMP/off.err"; then
+  echo "FAIL: explicit-off render failed:" >&2
+  cat "$TMP/off.err" >&2
+  exit 1
+fi
+if grep -qE "^kind: ServiceMonitor" "$TMP/off.yaml"; then
+  echo "FAIL: explicit-off render still contains kind: ServiceMonitor — the toggle is broken." >&2
+  exit 1
+fi
+echo "  PASS"
+
+# ── Case 4: default render includes the audit-log Cluster CR ─────────────
+echo "[observability-toggle] Case 4: default render ships the bp-llm-gateway-audit CNPG Cluster"
+if ! grep -qE "name: bp-llm-gateway-audit" "$TMP/default.yaml"; then
+  echo "FAIL: default render is missing the bp-llm-gateway-audit CNPG Cluster — audit log is unwired." >&2
+  exit 1
+fi
+echo "  PASS"
+
+# ── Case 5: cnpg.enabled=false omits the Cluster CR ──────────────────────
+echo "[observability-toggle] Case 5: catalystOverlay.cnpg.enabled=false omits the audit Cluster"
+if ! helm template smoke-llm-gateway . \
+    --set "catalystOverlay.cnpg.enabled=false" \
+    > "$TMP/cnpg-off.yaml" 2> "$TMP/cnpg-off.err"; then
+  echo "FAIL: cnpg.enabled=false render failed:" >&2
+  cat "$TMP/cnpg-off.err" >&2
+  exit 1
+fi
+if grep -qE "^kind: Cluster$" "$TMP/cnpg-off.yaml"; then
+  echo "FAIL: cnpg.enabled=false still renders a Cluster CR — the toggle is broken." >&2
+  exit 1
+fi
+echo "  PASS"
+
+echo "[observability-toggle] All bp-llm-gateway observability-toggle gates green."

--- a/platform/llm-gateway/chart/values.yaml
+++ b/platform/llm-gateway/chart/values.yaml
@@ -1,0 +1,242 @@
+# Catalyst Blueprint umbrella metadata — the upstream `litellm-helm` chart
+# is resolved as a Helm subchart via Chart.yaml `dependencies:`. This
+# values file carries:
+#
+#   1. The catalystBlueprint metadata block (provenance + version) so
+#      observability/audit pipelines can inspect the artifact and report
+#      which upstream chart + version is bundled.
+#   2. The upstream subchart values overlay under the `litellm-helm:` key
+#      (umbrella-chart convention — the dependency name from Chart.yaml is
+#      the values namespace).
+#   3. Catalyst overlay knobs for CNPG-backed audit log, Keycloak SSO,
+#      backend wiring (Anthropic via OAuth/Max — NEVER API keys —,
+#      Bedrock, Vertex, vLLM, anthropic-adapter), and NetworkPolicy.
+#
+# Per docs/INVIOLABLE-PRINCIPLES.md #4 (never hardcode), every operator-
+# meaningful value is configurable; cluster overlays in clusters/<sovereign>/
+# may override any of these without rebuilding the Blueprint OCI artifact.
+
+catalystBlueprint:
+  upstream: { chart: litellm-helm, version: "0.1.572", repo: "oci://ghcr.io/berriai" }
+
+# ─── Upstream chart values (subchart key: litellm-helm) ───────────────────
+# `helm dependency build` resolves the upstream as a subchart; values here
+# under the `litellm-helm:` key flow into that subchart unchanged.
+litellm-helm:
+  # Replicas — single replica is fine for solo Sovereigns; cluster overlays
+  # bump to 2-3 for HA on multi-node host clusters.
+  replicaCount: 1
+
+  # LiteLLM image — pin to a stable digest. Per docs/INVIOLABLE-PRINCIPLES.md
+  # #4 (never hardcode) the tag is operator-bumpable via per-cluster
+  # overlay. We default to the upstream-published `main-stable` tag (which
+  # the chart's appVersion field also tracks).
+  #
+  # NOTE: the chart's default `litellm-database` image bundles a Prisma
+  # migration runner; we keep it because the upstream chart's migration
+  # Job assumes it. Operators on air-gapped Sovereigns mirror the image
+  # to harbor.<location-code>.<sovereign-domain> and override `repository`.
+  image:
+    repository: ghcr.io/berriai/litellm-database
+    pullPolicy: IfNotPresent
+    tag: ""   # empty = chart appVersion (v1.57.2)
+
+  # ServiceAccount — created by the chart so ESO Generators (e.g.
+  # KubernetesAuth-backed pulls from bp-openbao) can grant short-lived
+  # credentials.
+  serviceAccount:
+    create: true
+    automount: true
+
+  # The LiteLLM proxy listens on port 4000 internally; we expose a
+  # ClusterIP Service. Catalyst fronts the public surface via Cilium
+  # Gateway / HTTPRoute, not chart-rendered Ingress.
+  service:
+    type: ClusterIP
+    port: 4000
+
+  ingress:
+    enabled: false
+
+  # ─── Backend / model configuration ────────────────────────────────────
+  # `proxy_config` is rendered by the upstream chart into the LiteLLM
+  # proxy's config.yaml. The model_list below is the SHIPPED DEFAULT —
+  # operators override per Sovereign via per-cluster values overlay to
+  # add Claude / Bedrock / Vertex / vLLM endpoints. We default to a
+  # single, intentionally-broken `unconfigured-llm` entry so the
+  # gateway starts cleanly on a fresh Sovereign and emits a clear
+  # error when called without operator wiring.
+  proxy_config:
+    model_list:
+      - model_name: unconfigured-llm
+        litellm_params:
+          model: openai/unconfigured
+          api_key: "operator-must-override-via-overlay"
+          api_base: "http://anthropic-adapter.ai-runtime.svc.cluster.local:8000/v1"
+    general_settings:
+      # `master_key` is the LiteLLM proxy's bootstrap admin key, sourced
+      # from the K8s Secret `bp-llm-gateway-bootstrap` (rendered out-of-
+      # band by ESO from bp-openbao). DO NOT inline a plaintext key.
+      master_key: os.environ/PROXY_MASTER_KEY
+      # `database_url` is read from the env wired through environmentSecrets;
+      # the upstream chart renders Prisma migrations against this URL.
+
+  # Audit-log database — wired to the CNPG Cluster rendered by
+  # templates/cnpg-cluster.yaml below. The chart accepts a `db.useExisting`
+  # flag that points at an external Postgres; we set it true so the chart
+  # does NOT spin up the bundled bitnami postgresql subchart (which would
+  # collide with bp-cnpg's CNPG operator).
+  db:
+    useExisting: true
+    endpoint: "bp-llm-gateway-audit-rw"
+    database: litellm_audit
+    url: "postgresql://$(DATABASE_USERNAME):$(DATABASE_PASSWORD)@$(DATABASE_HOST):5432/$(DATABASE_NAME)"
+    secret:
+      name: bp-llm-gateway-audit-app
+      usernameKey: username
+      passwordKey: password
+    # Both bundled-DB modes OFF — Catalyst manages persistence via bp-cnpg.
+    deployStandalone: false
+    useStackgresOperator: false
+
+  # Disable the bundled bitnami postgresql subchart explicitly (chart
+  # re-evaluates this even when db.deployStandalone=false).
+  postgresql:
+    architecture: standalone
+    auth:
+      username: litellm
+      database: litellm
+      # Required by chart schema even when subchart is gated off (chart
+      # condition: db.deployStandalone). Empty defaults are intentional.
+      password: ""
+      postgres-password: ""
+
+  # Bundled redis subchart — DISABLED. LiteLLM's request-cache feature
+  # is operator-opt-in via per-cluster overlay; when enabled, point
+  # `redis.host` at the cluster-wide bp-valkey Service (slot 17).
+  redis:
+    enabled: false
+
+  # Migration Job (Prisma schema) — leave ENABLED; the Job runs once
+  # post-install to set up the audit DB tables.
+  migrationJob:
+    enabled: true
+    retries: 3
+    backoffLimit: 4
+
+  # `environmentSecrets` exports keys from a K8s Secret as env vars to
+  # the LiteLLM pod. The Secret name below is rendered by ESO via
+  # bp-openbao (cluster overlays declare an ExternalSecret that
+  # materializes `bp-llm-gateway-env` with the right keys). This is how
+  # the operator's Claude OAuth token / Bedrock IAM creds / etc reach
+  # the proxy — never inlined as plaintext.
+  environmentSecrets:
+    - bp-llm-gateway-env
+
+  # Resources — solo-Sovereign minimum.
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      memory: 1Gi
+
+  # HorizontalPodAutoscaler — DEFAULT FALSE. Operator opts in via
+  # per-cluster overlay once steady-state traffic warrants scaling.
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 4
+    targetCPUUtilizationPercentage: 80
+
+# ─── Catalyst overlay ────────────────────────────────────────────────────
+catalystOverlay:
+  # ─── CNPG-backed audit log database ──────────────────────────────────
+  # Every prompt + response routed through the gateway is persisted to
+  # this Postgres for compliance / tenant attribution. The Cluster CR is
+  # reconciled by the cluster-wide CloudNativePG operator (bp-cnpg).
+  cnpg:
+    enabled: true
+    instances: 1
+    storage:
+      size: 10Gi
+      storageClass: ""
+    resources:
+      requests:
+        cpu: 100m
+        memory: 256Mi
+      limits:
+        memory: 1Gi
+    # CNPG-managed Postgres image; per-cluster overlay bumps in lockstep
+    # with bp-cnpg.
+    imageName: "ghcr.io/cloudnative-pg/postgresql:16.4"
+
+  # ─── Keycloak OIDC integration ───────────────────────────────────────
+  # LiteLLM proxy supports JWT verification via its `general_settings.
+  # ui_access_mode` + `enforce_user_role` knobs. Catalyst renders an
+  # auth ConfigMap that the operator can mount via litellm-helm's
+  # `volumes:` + `volumeMounts:` overlay once bp-keycloak is reconciled.
+  #
+  # DEFAULT FALSE — operator opts in once bp-keycloak is reconciled and
+  # an `llm-gateway` client/realm exists. Disabled-by-default keeps the
+  # chart installable on a fresh Sovereign before the IDP tier is up.
+  auth:
+    enabled: false
+    mode: keycloak    # keycloak | masterKey | hybrid
+    keycloak:
+      issuer: ""        # https://keycloak.<env>.<sovereign-domain>/realms/<realm>
+      jwksUri: ""       # https://keycloak.<env>.<sovereign-domain>/realms/<realm>/protocol/openid-connect/certs
+      audience: "llm-gateway"
+      clientId: "llm-gateway"
+
+  # ─── Backend wiring ──────────────────────────────────────────────────
+  # All four backends are operator-opt-in. The default model_list above
+  # ships an `unconfigured-llm` placeholder — operators MUST author a
+  # per-Sovereign overlay that adds the backends they want to expose.
+  #
+  # CRITICAL — Anthropic backend uses the operator's OAuth/Max
+  # subscription credential, NOT an ANTHROPIC_API_KEY. The token is
+  # rendered into bp-llm-gateway-env (ExternalSecret-backed) under the
+  # key `ANTHROPIC_OAUTH_TOKEN` and consumed via
+  # `os.environ/ANTHROPIC_OAUTH_TOKEN` in the model_list overlay. See
+  # memory feedback_no_api_key.md and the README's "Authentication" section.
+  backends:
+    anthropic:
+      enabled: false
+    bedrock:
+      enabled: false
+    vertex:
+      enabled: false
+    vllm:
+      enabled: false
+      # Service FQDN of bp-vllm in the ai-runtime namespace.
+      endpoint: "http://bp-vllm.ai-runtime.svc.cluster.local:8000/v1"
+    anthropicAdapter:
+      enabled: false
+      endpoint: "http://bp-anthropic-adapter.ai-runtime.svc.cluster.local:8000/v1"
+
+  # ─── NetworkPolicy ───────────────────────────────────────────────────
+  # DEFAULT FALSE — flip via per-cluster overlay once a baseline
+  # NetworkPolicy posture is decided for the Sovereign.
+  networkPolicy:
+    enabled: false
+    # Caller namespaces that are allowed to invoke the gateway. Defaults
+    # to ai-runtime (where bp-vllm + bp-anthropic-adapter live) and the
+    # Catalyst app-tier namespace.
+    allowedCallerNamespaces:
+      - ai-runtime
+      - catalyst-apps
+
+  # ─── ServiceMonitor — DEFAULT FALSE per docs/BLUEPRINT-AUTHORING.md §11.2
+  # The Catalyst overlay ships a ServiceMonitor that scrapes the
+  # LiteLLM /metrics endpoint. The `monitoring.coreos.com/v1` CRD ships
+  # with kube-prometheus-stack — an Application Blueprint that depends
+  # on the bootstrap-kit. Default OFF so a fresh Sovereign installs
+  # cleanly; operator opts in via per-cluster overlay once
+  # kube-prometheus-stack is reconciled (issue #182).
+  serviceMonitor:
+    enabled: false
+    interval: "30s"
+    scrapeTimeout: "10s"
+    path: "/metrics"
+    labels: {}

--- a/platform/temporal/blueprint.yaml
+++ b/platform/temporal/blueprint.yaml
@@ -1,0 +1,54 @@
+apiVersion: catalyst.openova.io/v1alpha1
+kind: Blueprint
+metadata:
+  name: bp-temporal
+  labels:
+    catalyst.openova.io/section: pts-4-3-workflow-and-processing
+spec:
+  version: 1.0.0
+  card:
+    title: Temporal
+    summary: Durable workflow orchestration with saga + compensation. Postgres-backed (CNPG); Postgres visibility store; Web UI; Keycloak OIDC integration via `--auth-claim-mapper`.
+    icon: temporal.svg
+    category: workflow
+  visibility: listed
+  configSchema:
+    type: object
+    properties:
+      web:
+        type: object
+        properties:
+          enabled:
+            type: boolean
+            default: true
+            description: Enable the Temporal Web UI.
+      auth:
+        type: object
+        properties:
+          enabled:
+            type: boolean
+            default: false
+            description: Enable Keycloak OIDC integration via `--auth-claim-mapper`. Operator opt-in once bp-keycloak is reconciled and a realm/client exists.
+      persistence:
+        type: object
+        properties:
+          mode:
+            type: string
+            enum: [embedded, external]
+            default: external
+            description: external = Catalyst-curated CNPG Cluster (recommended); embedded = chart-bundled bitnami postgresql (dev only).
+  placementSchema:
+    modes: [single-region]
+    minRegions: 1
+    maxRegions: 1
+  manifests:
+    chart: ./chart
+  depends:
+    - blueprint: bp-cnpg
+      version: ^1
+      alias: db
+    - blueprint: bp-cert-manager
+      version: ^1
+      alias: certs
+  upgrades:
+    from: ["0.x"]

--- a/platform/temporal/chart/Chart.yaml
+++ b/platform/temporal/chart/Chart.yaml
@@ -1,0 +1,31 @@
+apiVersion: v2
+name: bp-temporal
+version: 1.0.0
+appVersion: "1.31.0"
+description: |
+  Catalyst-curated Blueprint umbrella chart for Temporal — durable
+  workflow orchestration with saga + compensation. Depends on the
+  upstream `temporal` chart (https://go.temporal.io/helm-charts) as a
+  Helm subchart so `helm dependency build` pulls the upstream payload
+  into this artifact; the Catalyst overlay templates in templates/
+  (CNPG `Cluster` for Postgres + visibility store, ExternalSecret for
+  the chart-consumed connection strings, NetworkPolicy, ServiceMonitor)
+  sit alongside the upstream subchart and Helm renders both at install
+  time. Catalyst-curated values flow into the upstream subchart under
+  the `temporal:` key in values.yaml.
+type: application
+keywords: [catalyst, blueprint, temporal, workflow, saga, orchestration]
+maintainers:
+  - name: OpenOva Catalyst
+    email: catalyst@openova.io
+
+# Upstream chart pulled in as a Helm subchart so `helm dependency build`
+# bundles it into the OCI artifact. Pinned to temporal/temporal 1.2.0
+# (matches platform/temporal/blueprint.yaml + values.yaml
+# `catalystBlueprint.upstream.version`). Per
+# docs/INVIOLABLE-PRINCIPLES.md #4 (never hardcode) the version is
+# operator-bumpable via PR + Blueprint release.
+dependencies:
+  - name: temporal
+    version: "1.2.0"
+    repository: "https://go.temporal.io/helm-charts"

--- a/platform/temporal/chart/templates/_helpers.tpl
+++ b/platform/temporal/chart/templates/_helpers.tpl
@@ -1,0 +1,40 @@
+{{/*
+Common Catalyst overlay helpers for bp-temporal.
+*/}}
+
+{{- define "bp-temporal.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "bp-temporal.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Common labels — applied to every Catalyst overlay resource so the
+projector tracks them.
+*/}}
+{{- define "bp-temporal.labels" -}}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+app.kubernetes.io/name: {{ include "bp-temporal.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+catalyst.openova.io/blueprint: bp-temporal
+{{- end }}
+
+{{- define "bp-temporal.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "bp-temporal.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/platform/temporal/chart/templates/cnpg-cluster.yaml
+++ b/platform/temporal/chart/templates/cnpg-cluster.yaml
@@ -1,0 +1,47 @@
+{{- /*
+Catalyst overlay: CNPG-backed Postgres for Temporal persistence + visibility.
+
+bp-temporal lists `bp-cnpg` as a hard dependency in blueprint.yaml. At install
+time, this `Cluster` CR is reconciled by the cluster-wide CloudNativePG
+operator (provided by bp-cnpg). The resulting `bp-temporal-pg-rw` Service is
+what the upstream temporal chart's
+`server.config.persistence.datastores.{default,visibility}.sql.connectAddr`
+values reference, and the `bp-temporal-pg-app` Secret is consumed via
+`existingSecret` for the password lookup performed by the upstream chart's
+`temporal.persistence.eachStore` helper.
+
+Two databases are required (`temporal` for the default workflow store,
+`temporal_visibility` for the search/index visibility store). CNPG's
+`bootstrap.initdb` creates the primary database; the second is created
+via `postInitApplicationSQL`. The upstream chart's pre-install schema
+job then runs `temporal-sql-tool setup-schema` on each.
+
+Per docs/INVIOLABLE-PRINCIPLES.md #4 (never hardcode), every operator-tunable
+knob lives in values.yaml `catalystOverlay.cnpg.*`.
+*/ -}}
+{{- if .Values.catalystOverlay.cnpg.enabled }}
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: bp-temporal-pg
+  labels:
+    {{- include "bp-temporal.labels" . | nindent 4 }}
+spec:
+  instances: {{ .Values.catalystOverlay.cnpg.instances }}
+  {{- with .Values.catalystOverlay.cnpg.imageName }}
+  imageName: {{ . | quote }}
+  {{- end }}
+  storage:
+    size: {{ .Values.catalystOverlay.cnpg.storage.size }}
+    {{- with .Values.catalystOverlay.cnpg.storage.storageClass }}
+    storageClass: {{ . }}
+    {{- end }}
+  resources:
+    {{- toYaml .Values.catalystOverlay.cnpg.resources | nindent 4 }}
+  bootstrap:
+    initdb:
+      database: temporal
+      owner: temporal
+      postInitApplicationSQL:
+        - CREATE DATABASE temporal_visibility OWNER temporal;
+{{- end }}

--- a/platform/temporal/chart/templates/keycloak-oidc-config.yaml
+++ b/platform/temporal/chart/templates/keycloak-oidc-config.yaml
@@ -1,0 +1,36 @@
+{{- /*
+Catalyst overlay: Keycloak OIDC integration for Temporal.
+
+Temporal supports OIDC authentication via the `--auth-claim-mapper` flag and
+a JWT key provider configured against the Keycloak realm's JWKS endpoint.
+This ConfigMap renders the auth.yaml fragment that the upstream chart
+includes when an operator opts in (bp-keycloak must be reconciled and a
+realm/client must exist first).
+
+DEFAULT OFF (`catalystOverlay.auth.enabled: false`) — operator opt-in once
+bp-keycloak is reconciled. Keeping it off by default keeps the chart
+installable on a fresh Sovereign before the IDP tier is up
+(docs/BLUEPRINT-AUTHORING.md §11.2 spirit — every cross-tier dependency
+defaults off).
+*/ -}}
+{{- if .Values.catalystOverlay.auth.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: bp-temporal-keycloak-oidc
+  labels:
+    {{- include "bp-temporal.labels" . | nindent 4 }}
+data:
+  auth.yaml: |
+    global:
+      authorization:
+        jwtKeyProvider:
+          keySourceURIs:
+            - {{ .Values.catalystOverlay.auth.keycloak.jwksUri | quote }}
+          refreshInterval: 1h
+        permissionsClaimName: permissions
+        authorizer: default
+        claimMapper: {{ .Values.catalystOverlay.auth.keycloak.claimMapper | quote }}
+        issuer: {{ .Values.catalystOverlay.auth.keycloak.issuer | quote }}
+        audience: {{ .Values.catalystOverlay.auth.keycloak.clientId | quote }}
+{{- end }}

--- a/platform/temporal/chart/templates/networkpolicy.yaml
+++ b/platform/temporal/chart/templates/networkpolicy.yaml
@@ -1,0 +1,25 @@
+{{- /*
+Catalyst overlay: NetworkPolicy for bp-temporal.
+
+DEFAULT OFF — flip via per-cluster overlay once a baseline NetworkPolicy
+posture is decided for the Sovereign.
+*/ -}}
+{{- if .Values.catalystOverlay.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: bp-temporal-default
+  labels:
+    {{- include "bp-temporal.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - {}     # Operator narrows via per-cluster overlay; default permits intra-namespace.
+  egress:
+    - {}
+{{- end }}

--- a/platform/temporal/chart/tests/observability-toggle.sh
+++ b/platform/temporal/chart/tests/observability-toggle.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# bp-temporal observability-toggle integration test (issue #182).
+#
+# Verifies the Catalyst rule from docs/BLUEPRINT-AUTHORING.md §11.2
+# (Observability toggles must default false):
+#
+#   - `helm template` with default values MUST produce zero
+#     `monitoring.coreos.com/v1` ServiceMonitor / PrometheusRule resources.
+#   - `helm template` with the toggle EXPLICITLY set true MUST succeed
+#     (proves the opt-in path works).
+#   - `helm template` with the toggle EXPLICITLY set false MUST succeed
+#     and produce zero monitoring.coreos.com references.
+#
+# Usage: bash tests/observability-toggle.sh [CHART_DIR]
+
+set -euo pipefail
+
+CHART_DIR="${1:-$(cd "$(dirname "$0")/.." && pwd)}"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+cd "$CHART_DIR"
+
+if [ ! -d charts ] || [ -z "$(ls -A charts 2>/dev/null)" ]; then
+  helm dependency build >/dev/null
+fi
+
+# ── Case 1: default render must NOT contain monitoring.coreos.com ────────
+echo "[observability-toggle] Case 1: default render produces no ServiceMonitor"
+helm template smoke-temporal . > "$TMP/default.yaml"
+if grep -q "monitoring.coreos.com" "$TMP/default.yaml"; then
+  echo "FAIL: default render of bp-temporal contains monitoring.coreos.com references." >&2
+  echo "      docs/BLUEPRINT-AUTHORING.md §11.2 forbids this — observability toggles must default false." >&2
+  echo "      Offending lines:" >&2
+  grep -n "monitoring.coreos.com" "$TMP/default.yaml" | head -5 >&2
+  exit 1
+fi
+if grep -q "kind: ServiceMonitor" "$TMP/default.yaml"; then
+  echo "FAIL: default render of bp-temporal contains kind: ServiceMonitor." >&2
+  exit 1
+fi
+echo "  PASS"
+
+# ── Case 2: opt-in render with toggle=true must succeed ─────────────────
+# Upstream temporal chart gates ServiceMonitor render on the
+# `monitoring.coreos.com/v1` API version, so simulate the CRD's presence
+# via --api-versions (mirrors bp-external-secrets pattern).
+echo "[observability-toggle] Case 2: opt-in (serviceMonitor.enabled=true) renders cleanly"
+if ! helm template smoke-temporal . \
+    --set temporal.server.metrics.serviceMonitor.enabled=true \
+    --api-versions "monitoring.coreos.com/v1" \
+    > "$TMP/optin.yaml" 2> "$TMP/optin.err"; then
+  echo "FAIL: opt-in render failed:" >&2
+  cat "$TMP/optin.err" >&2
+  exit 1
+fi
+if ! grep -q "kind: ServiceMonitor" "$TMP/optin.yaml"; then
+  echo "FAIL: opt-in render did NOT produce a ServiceMonitor — the toggle is broken." >&2
+  exit 1
+fi
+echo "  PASS"
+
+# ── Case 3: explicit-off must produce zero monitoring.coreos.com refs ───
+echo "[observability-toggle] Case 3: explicit serviceMonitor.enabled=false renders cleanly"
+if ! helm template smoke-temporal . \
+    --set temporal.server.metrics.serviceMonitor.enabled=false \
+    --api-versions "monitoring.coreos.com/v1" \
+    > "$TMP/off.yaml" 2> "$TMP/off.err"; then
+  echo "FAIL: explicit-off render failed:" >&2
+  cat "$TMP/off.err" >&2
+  exit 1
+fi
+if grep -qE "^kind: ServiceMonitor" "$TMP/off.yaml"; then
+  echo "FAIL: explicit-off render still contains kind: ServiceMonitor — the toggle is broken." >&2
+  exit 1
+fi
+echo "  PASS"
+
+echo "[observability-toggle] All bp-temporal observability-toggle gates green."

--- a/platform/temporal/chart/values.yaml
+++ b/platform/temporal/chart/values.yaml
@@ -1,0 +1,208 @@
+# Catalyst Blueprint umbrella metadata — the upstream `temporal` chart is
+# resolved as a Helm subchart via Chart.yaml `dependencies:`. This values
+# file carries:
+#
+#   1. The catalystBlueprint metadata block (provenance + version) so
+#      observability/audit pipelines can inspect the artifact and report
+#      which upstream chart + version is bundled.
+#   2. The upstream subchart values overlay under the `temporal:` key
+#      (umbrella-chart convention — the dependency name from Chart.yaml is
+#      the values namespace).
+#   3. Catalyst overlay knobs for CNPG-backed Postgres, Keycloak OIDC
+#      integration, and NetworkPolicy guard rendered by templates/.
+#
+# Per docs/INVIOLABLE-PRINCIPLES.md #4 (never hardcode), every operator-
+# meaningful value is configurable; cluster overlays in clusters/<sovereign>/
+# may override any of these without rebuilding the Blueprint OCI artifact.
+
+catalystBlueprint:
+  upstream: { chart: temporal, version: "1.2.0", repo: "https://go.temporal.io/helm-charts" }
+
+# ─── Upstream chart values (subchart key: temporal) ───────────────────────
+# Upstream chart 1.2.0 is a major rewrite vs the historical 0.x line:
+# the per-datastore top-level keys (`cassandra:`, `mysql:`, `postgresql:`,
+# `elasticsearch:`, `prometheus:`, `grafana:`) were ALL removed and
+# replaced with a single `server.config.persistence.datastores.*` map.
+# The chart's validations.yaml fails fast if the legacy keys are present,
+# so this overlay strictly follows the new shape.
+temporal:
+  # Server topology — single-replica frontend / history / matching is the
+  # solo-Sovereign minimum. Multi-region Sovereigns bump replicaCount via
+  # per-cluster overlay (server.replicaCount + frontend/history/matching).
+  server:
+    enabled: true
+    replicaCount: 1
+
+    # Prometheus annotations on pods — keep ON (annotations only; the
+    # ServiceMonitor below is what's gated by the bootstrap-kit ordering).
+    metrics:
+      annotations:
+        enabled: true
+      # ServiceMonitor — DEFAULT FALSE per docs/BLUEPRINT-AUTHORING.md
+      # §11.2. The `monitoring.coreos.com/v1` CRD ships with
+      # kube-prometheus-stack — an Application Blueprint that itself
+      # depends on the bootstrap-kit; defaulting `enabled: true` here
+      # would render a ServiceMonitor that the apiserver immediately
+      # rejects on a fresh Sovereign install (issue #182). Operator
+      # opts in via per-cluster overlay once kube-prometheus-stack is
+      # reconciled.
+      serviceMonitor:
+        enabled: false
+        interval: 30s
+
+    config:
+      # Logging — debug level for solo-Sovereign smoke testing; production
+      # overlays drop to "info" or "warn".
+      logLevel: "info"
+
+      # Persistence is wired via the Catalyst overlay (templates/
+      # cnpg-cluster.yaml). The datastores map below points at the
+      # CNPG-backed Postgres service; credentials come from the Secret
+      # that CNPG materializes (`bp-temporal-pg-app`).
+      persistence:
+        defaultStore: default
+        visibilityStore: visibility
+        # numHistoryShards is immutable post-install; 512 is the upstream
+        # default and matches Temporal's recommendation for solo
+        # Sovereigns. Multi-region overlays at scale bump pre-install
+        # only (and only by full re-init).
+        numHistoryShards: 512
+        datastores:
+          # Default store — workflow execution history, mutable state.
+          default:
+            sql:
+              pluginName: postgres12
+              driverName: postgres12
+              databaseName: temporal
+              # Short DNS — both the Temporal pods and the CNPG primary
+              # service live in the release namespace, so the bare
+              # service name resolves without needing the FQDN.
+              # Per-Sovereign overlays may override to a cross-namespace
+              # FQDN if Temporal is moved out of the CNPG namespace.
+              connectAddr: "bp-temporal-pg-rw:5432"
+              connectProtocol: tcp
+              user: temporal
+              # `existingSecret` + `secretKey` are Helm-specific fields
+              # that the chart strips before rendering the server config;
+              # they fetch the password from the named Secret at install
+              # time. CNPG materializes `bp-temporal-pg-app` with the
+              # `password` key when the Cluster is provisioned.
+              existingSecret: bp-temporal-pg-app
+              secretKey: password
+              maxConns: 20
+              maxIdleConns: 20
+              maxConnLifetime: "1h"
+          # Visibility store — search + filter index. Catalyst defaults
+          # to the same Postgres cluster (single CNPG instance, two
+          # databases). Multi-region overlays at scale separate the
+          # visibility store onto a dedicated cluster.
+          visibility:
+            sql:
+              pluginName: postgres12
+              driverName: postgres12
+              databaseName: temporal_visibility
+              connectAddr: "bp-temporal-pg-rw:5432"
+              connectProtocol: tcp
+              user: temporal
+              existingSecret: bp-temporal-pg-app
+              secretKey: password
+              maxConns: 10
+              maxIdleConns: 10
+              maxConnLifetime: "1h"
+
+      metrics:
+        prometheus:
+          timerType: histogram
+          listenAddress: "0.0.0.0:9090"
+
+  # Schema setup — `temporal-sql-tool create-database + setup-schema +
+  # update-schema` runs as a Helm pre-install/pre-upgrade hook (see
+  # upstream templates/server-job.yaml). useHelmHooks=true is upstream
+  # default; we keep it on so the schema bootstrap completes before the
+  # frontend / history / matching pods come up.
+  schema:
+    useHelmHooks: true
+    backoffLimit: 100
+
+  # Web UI — enabled by default; operators flip to false on headless
+  # Sovereigns. Resources are tuned for solo-Sovereign minimum; production
+  # overlays bump for multi-tenant access.
+  web:
+    enabled: true
+    replicaCount: 1
+    resources:
+      requests:
+        cpu: 50m
+        memory: 128Mi
+      limits:
+        memory: 512Mi
+    # Ingress — disabled in chart values. Catalyst fronts every Web UI
+    # via Cilium Gateway / HTTPRoute, not chart-rendered Ingress.
+    ingress:
+      enabled: false
+
+  # Admintools pod — operators run `tctl namespace register` and ad-hoc
+  # administration through this pod (`kubectl exec -it temporal-admintools
+  # -- tctl ...`).
+  admintools:
+    enabled: true
+
+  # `shims.dockerize` and `shims.elasticsearchTool` toggle compatibility
+  # with the temporalio/server 1.29.x images. We pin 1.31.0 (chart
+  # appVersion), so both shims can be off — keeps the install lean.
+  shims:
+    dockerize: false
+    elasticsearchTool: false
+
+# ─── Catalyst overlay: CNPG-backed Postgres ──────────────────────────────
+# The bp-cnpg `Cluster` CR rendered by templates/cnpg-cluster.yaml. The
+# resulting `bp-temporal-pg-rw` Service is what
+# `temporal.server.config.persistence.datastores.{default,visibility}.sql.connectAddr`
+# above points at. Postgres credentials end up in the
+# `bp-temporal-pg-app` Secret that the upstream chart consumes via
+# `existingSecret`.
+catalystOverlay:
+  cnpg:
+    enabled: true
+    instances: 1
+    storage:
+      size: 5Gi
+      storageClass: ""
+    # Resources scoped to a single-replica frontend/history footprint;
+    # bump via per-cluster overlay for production.
+    resources:
+      requests:
+        cpu: 100m
+        memory: 256Mi
+      limits:
+        memory: 1Gi
+    # Postgres image — pinned to a CNPG-managed minor version. Operators
+    # bump in lockstep with bp-cnpg via per-cluster overlay.
+    imageName: "ghcr.io/cloudnative-pg/postgresql:16.4"
+
+  # ─── Keycloak OIDC integration ───────────────────────────────────────
+  # Temporal supports OIDC auth via `--auth-claim-mapper` + JWT key
+  # provider. When `auth.enabled: true` and the operator provides
+  # `auth.keycloak.realm` + `auth.keycloak.clientId`, the rendered
+  # ConfigMap wires the Temporal frontend's `authorization.jwtKeyProvider`
+  # to the Keycloak realm's JWKS endpoint and sets the claim mapper.
+  #
+  # DEFAULT FALSE — operator opts in once bp-keycloak is reconciled and a
+  # realm/client exists. Disabled-by-default keeps the chart installable
+  # on a fresh Sovereign before the IDP tier is up
+  # (docs/BLUEPRINT-AUTHORING.md §11.2 spirit — every cross-tier
+  # dependency defaults off).
+  auth:
+    enabled: false
+    keycloak:
+      issuer: ""        # https://keycloak.<env>.<sovereign-domain>/realms/<realm>
+      realm: ""         # e.g. "temporal" or the Sovereign's master realm
+      clientId: ""      # e.g. "temporal-frontend"
+      jwksUri: ""       # https://keycloak.<env>.<sovereign-domain>/realms/<realm>/protocol/openid-connect/certs
+      claimMapper: "default"   # default | noop | <fully-qualified-go-type>
+
+  # ─── NetworkPolicy ───────────────────────────────────────────────────
+  # DEFAULT FALSE — flip via per-cluster overlay once a baseline
+  # NetworkPolicy posture is decided for the Sovereign.
+  networkPolicy:
+    enabled: false


### PR DESCRIPTION
## Summary

W2.5.E batch — three Application-tier Blueprints completing the LLM-serving / workflow stack on the Catalyst-Zero Sovereign.

| Chart | Upstream | Kinds | Dependencies | Closes |
|---|---|---|---|---|
| **bp-temporal/1.0.0** | `temporal/temporal 1.2.0` (https://go.temporal.io/helm-charts) | Cluster (CNPG) + ConfigMap + Deployment + Job + Pod + Service | bp-cnpg, bp-cert-manager | #271 |
| **bp-llm-gateway/1.0.0** | `oci://ghcr.io/berriai/litellm-helm 0.1.572` | Cluster (CNPG audit) + ConfigMap + Deployment + Job + Pod + Secret + Service + ServiceAccount | bp-cnpg, bp-keycloak, bp-external-secrets | #267 |
| **bp-anthropic-adapter/1.0.0** | scratch (Catalyst-authored Go service) | ConfigMap + Deployment + Service + ServiceAccount | bp-external-secrets | #268 |

### bp-temporal
- Wraps the upstream temporal chart 1.2.0 — note this is a major rewrite of the older 0.x line (the per-datastore top-level keys `cassandra:` / `mysql:` / `postgresql:` / `elasticsearch:` / `prometheus:` / `grafana:` were ALL removed in favour of `server.config.persistence.datastores.{default,visibility}.sql`). Values overlay strictly follows the new shape.
- Postgres-only via CNPG (skip Cassandra). Two databases (`temporal`, `temporal_visibility`) created via CNPG `bootstrap.initdb` + `postInitApplicationSQL`.
- Web UI ON. Admintools pod ON.
- Keycloak OIDC integration via `--auth-claim-mapper` renders `auth.yaml` ConfigMap (operator wires via `additionalVolumes` once bp-keycloak is reconciled — default OFF).

### bp-llm-gateway
- Subscription-aware proxy for Claude Code. Routes to **Anthropic via the operator's Claude OAuth/Max subscription token — NEVER an `ANTHROPIC_API_KEY`** (per `memory/feedback_no_api_key.md` and the user's standing instruction). Token flows exclusively through `ExternalSecret`-managed K8s Secrets materialised by ESO from bp-openbao.
- CNPG-backed audit log (every prompt + response persisted for compliance / tenant attribution).
- Bundled bitnami `postgresql` + `redis` subcharts DISABLED (`db.useExisting=true` points at the CNPG cluster).
- Other backends: Bedrock, Vertex, OpenAI-compatible (via bp-anthropic-adapter), self-hosted vLLM — all default OFF, operator opts-in via per-cluster overlay.
- Keycloak SSO via `auth.yaml` ConfigMap (default OFF) for human callers; programmatic callers use per-tenant master keys rendered into `bp-llm-gateway-env` by ESO.

### bp-anthropic-adapter
- Catalyst-authored scratch chart for the OpenAI ↔ Anthropic translation Go service.
- SHA-pinned image `ghcr.io/openova-io/openova/anthropic-adapter:<sha>` (Inviolable Principle #4a — GitHub Actions is the only build path; empty default tag fails the render with a clear error instead of silently shipping `:latest`).
- **OAuth/Max subscription token mounted from K8s Secret materialised by ESO from bp-openbao** — `ANTHROPIC_OAUTH_TOKEN` env var, **NEVER an `ANTHROPIC_API_KEY`**.
- Includes OpenAI → Anthropic model-mapping ConfigMap (`gpt-4` → `claude-3-5-sonnet`, `gpt-4o-mini` → `claude-3-5-haiku`, etc.).
- `sigstore/common` library subchart included to satisfy the hollow-chart gate (mirrors the bp-vllm pattern from #283).

### Inviolable Principles compliance
- **#4 (never hardcode)** — every upstream version, namespace, server URL, role, secret name, model default, and toggle is in `values.yaml`. Cluster overlays in `clusters/<sovereign>/` override without rebuilding the OCI artifact.
- **#4a (GitHub Actions is the only build path)** — bp-anthropic-adapter requires SHA-pinned image tag in per-cluster overlay; empty tag fails render fast.
- **`docs/BLUEPRINT-AUTHORING.md` §11.1 (umbrella shape — hard contract)** — bp-temporal and bp-llm-gateway declare upstream charts under `Chart.yaml dependencies:`. bp-anthropic-adapter is a scratch chart with `sigstore/common` as the obligatory hollow-chart-gate dependency.
- **`docs/BLUEPRINT-AUTHORING.md` §11.2 (issue #182)** — every observability toggle defaults `false`. Each chart ships `tests/observability-toggle.sh` covering default-off, opt-in (with `--api-versions monitoring.coreos.com/v1`), and explicit-off cases.

### Authentication note (CRITICAL)

bp-llm-gateway and bp-anthropic-adapter both consume the operator's Claude OAuth/Max subscription. Per `memory/feedback_no_api_key.md`, neither chart accepts or generates an `ANTHROPIC_API_KEY`. Tokens flow exclusively through `ExternalSecret`-managed K8s Secrets that ESO materialises from bp-openbao at install time.

## Test plan

- [x] `helm dependency update` succeeds for all three charts (subchart payload bundled into OCI artifact)
- [x] `helm template` renders cleanly with default values (bp-anthropic-adapter requires SHA-pinned tag)
- [x] `helm lint` passes for each chart (1 chart(s) linted, 0 chart(s) failed; INFO icon-recommended only)
- [x] `tests/observability-toggle.sh` passes for each chart:
  - bp-temporal: 3 cases green (default-off, opt-in, explicit-off)
  - bp-llm-gateway: 5 cases green (3 ServiceMonitor + 2 CNPG audit Cluster toggle)
  - bp-anthropic-adapter: 4 cases green (3 ServiceMonitor + 1 never-:latest gate)
- [ ] After merge: blueprint-release.yaml workflow publishes each chart to `oci://ghcr.io/openova-io/`
- [ ] After publish: bootstrap-kit slot HRs land in `clusters/_template/bootstrap-kit/` to wire the three Blueprints into Catalyst-Zero Sovereigns

🤖 Generated with [Claude Code](https://claude.com/claude-code)