### PR TITLE
feat(charts): bp-openmeter (CH-less) + bp-livekit + bp-matrix wrapper charts (closes #272 #273 #274)

### DIFF
--- a/platform/livekit/README.md
+++ b/platform/livekit/README.md
@@ -1,50 +1,86 @@
-# LiveKit
+# bp-livekit
 
-WebRTC SFU for real-time video, audio, and data. **Application Blueprint** (see [`docs/PLATFORM-TECH-STACK.md`](../../docs/PLATFORM-TECH-STACK.md) §4.5 — Communication). Used by `bp-relay`. Pairs with STUNner for K8s-native NAT traversal.
+WebRTC SFU. Catalyst Application Blueprint. Real-time video, audio, and
+data routing — powers the Huawei iFlytek voice demo and any Application
+that needs sub-second media. Pairs with `bp-stunner` for K8s-native
+TURN/STUN. See
+[`docs/PLATFORM-TECH-STACK.md`](../../docs/PLATFORM-TECH-STACK.md) §4.5
+(Communication).
 
-**Category:** Communication | **Type:** Application Blueprint
+**Status:** Accepted | **Updated:** 2026-04-30
 
 ---
 
 ## Overview
 
-LiveKit provides WebRTC-based real-time communication infrastructure for video conferencing, audio rooms, and live streaming. Paired with STUNner for Kubernetes-native TURN/STUN, it delivers enterprise-grade communication capabilities.
+LiveKit is the WebRTC Selective Forwarding Unit (SFU). Catalyst pairs
+it with `bp-stunner` so NAT traversal works without exposing a TURN
+server's UDP port to the public internet.
 
-## Key Features
-
-- WebRTC SFU (Selective Forwarding Unit)
-- Video conferencing and screen sharing
-- Audio rooms and live streaming
-- Data channels for real-time messaging
-- Recording and egress to SeaweedFS
-
-## Integration
+## Catalyst integration
 
 | Component | Integration |
 |-----------|-------------|
-| STUNner | Kubernetes-native TURN/STUN for NAT traversal |
-| SeaweedFS | Recording storage |
-| Keycloak | Authentication via OIDC |
-| Grafana | Call quality metrics |
+| `bp-stunner` | K8s-native TURN/STUN — Catalyst routes LiveKit's TURN config at the stunner UDP-gateway Service |
+| `bp-cert-manager` | TLS via cluster `Issuer` |
+| `bp-valkey` | Signaling-state store when `replicaCount > 1` |
+| `bp-keycloak` | (Optional) JWT identity for WebRTC participants |
 
-## Used By
+## Hetzner firewall
 
-- **OpenOva Relay** - Video/audio communication component
+LiveKit binds the UDP port range **50000-60000** for RTC traffic. The
+per-Sovereign Hetzner firewall rule (Tofu-managed) opens this range to
+the world. Pod-level NetworkPolicies do NOT cover host-network pods —
+the firewall rule is the load-bearing control. See
+[`docs/SECURITY.md`](../../docs/SECURITY.md) §4.
 
-## Deployment
+## Chart shape
 
-```yaml
-apiVersion: kustomize.toolkit.fluxcd.io/v1
-kind: Kustomization
-metadata:
-  name: livekit
-  namespace: flux-system
-spec:
-  interval: 10m
-  path: ./platform/livekit
-  prune: true
+```
+platform/livekit/
+├── blueprint.yaml                     # Catalyst Blueprint CRD
+├── chart/
+│   ├── Chart.yaml                     # umbrella; deps: livekit-server (Helm)
+│   ├── values.yaml                    # Catalyst defaults; bundled TURN OFF
+│   └── templates/
+│       ├── _helpers.tpl
+│       ├── networkpolicy.yaml         # default OFF (host-network caveat noted)
+│       ├── servicemonitor.yaml        # default OFF (CRD-gated)
+│       └── hpa.yaml                   # default OFF
+├── chart/tests/observability-toggle.sh
+└── README.md
+```
+
+## Dependencies
+
+| Blueprint | Purpose |
+|-----------|---------|
+| `bp-stunner` | K8s-native TURN/STUN (required for NAT traversal) |
+| `bp-cert-manager` | Ingress TLS via ClusterIssuer |
+| `bp-valkey` | Signaling-state store (only when scaling beyond a single replica) |
+
+## Observability toggles (all default OFF)
+
+Per [`docs/BLUEPRINT-AUTHORING.md`](../../docs/BLUEPRINT-AUTHORING.md)
+§11.2.
+
+| Toggle | Default | Why |
+|--------|---------|-----|
+| `serviceMonitor.enabled` | `false` | `monitoring.coreos.com/v1` CRD ships with kube-prometheus-stack |
+| `livekit-server.serviceMonitor.create` | `false` | upstream toggle — Catalyst restates the contract |
+| `networkPolicy.enabled` | `false` | Operator supplies consumer-namespace selectors per-Sovereign |
+| `hpa.enabled` | `false` | One LiveKit pod per node (port-range exclusivity) |
+| `livekit-server.autoscaling.enabled` | `false` | Same — upstream HPA off |
+
+## Verification
+
+```bash
+helm dependency update platform/livekit/chart
+helm template platform/livekit/chart | grep -E "^kind:" | sort -u
+helm lint platform/livekit/chart
+bash platform/livekit/chart/tests/observability-toggle.sh
 ```
 
 ---
 
-*Part of [OpenOva](https://openova.io)*
+*Part of [OpenOva](https://openova.io). Closes #273.*

--- a/platform/livekit/blueprint.yaml
+++ b/platform/livekit/blueprint.yaml
@@ -1,0 +1,112 @@
+apiVersion: catalyst.openova.io/v1alpha1
+kind: Blueprint
+metadata:
+  name: bp-livekit
+  labels:
+    catalyst.openova.io/category: application
+    catalyst.openova.io/section: pts-4-5-communication
+spec:
+  version: 1.0.0
+  card:
+    title: LiveKit
+    summary: |
+      WebRTC SFU for real-time video, audio, and data. Powers the
+      Huawei iFlytek voice demo and any Application that needs
+      sub-second media routing. Pairs with bp-stunner for K8s-native
+      TURN/STUN — Catalyst routes LiveKit's TURN config at the stunner
+      Service so SFU traffic survives the host cluster's NAT
+      boundary. Hetzner firewall opens UDP 50000-60000 (LiveKit's RTC
+      port range) per the operator's per-Sovereign overlay.
+    icon: livekit.svg
+    category: application
+    tags: [webrtc, sfu, video, audio, communication, application]
+    documentation: https://docs.livekit.io
+    license: Apache-2.0
+  visibility: listed
+  owner:
+    team: platform
+    contact: platform@openova.io
+  configSchema:
+    type: object
+    properties:
+      keys:
+        type: object
+        description: |
+          LiveKit API keys (`<api_key>: <api_secret>` pairs). For
+          production overlays use `storeKeysInSecret.existingSecret`
+          to project an ExternalSecret instead of inlining values
+          here. Per docs/INVIOLABLE-PRINCIPLES.md #4 nothing is
+          hardcoded — the wrapper ships an empty map and operator
+          overlays inject the secret reference.
+      rtc:
+        type: object
+        properties:
+          portRangeStart:
+            type: integer
+            default: 50000
+            description: |
+              Start of the UDP port range LiveKit binds for RTC
+              traffic. Must match the Hetzner firewall rule the
+              per-Sovereign overlay opens.
+          portRangeEnd:
+            type: integer
+            default: 60000
+            description: |
+              End of the UDP port range LiveKit binds for RTC
+              traffic. Must match the Hetzner firewall rule the
+              per-Sovereign overlay opens.
+      stunner:
+        type: object
+        properties:
+          enabled:
+            type: boolean
+            default: true
+            description: |
+              Route TURN/STUN through bp-stunner instead of running a
+              co-located TURN server. Catalyst standard.
+          gatewayService:
+            type: string
+            default: "udp-gateway.stunner.svc.cluster.local:3478"
+            description: |
+              Cluster-internal endpoint of the stunner UDP-gateway
+              Service. Per docs/INVIOLABLE-PRINCIPLES.md #4 the
+              operator MAY override per-Sovereign.
+      tls:
+        type: object
+        properties:
+          issuerRef:
+            type: string
+            default: "letsencrypt-prod"
+            description: |
+              cert-manager ClusterIssuer name (per-Sovereign overlay
+              chooses staging vs prod).
+      serviceMonitor:
+        type: object
+        properties:
+          enabled:
+            type: boolean
+            default: false
+            description: |
+              monitoring.coreos.com/v1 ServiceMonitor — requires the
+              Prometheus Operator CRDs from kube-prometheus-stack.
+              Per docs/BLUEPRINT-AUTHORING.md §11.2 default false;
+              operator opts in via per-cluster overlay (issue #182).
+  placementSchema:
+    modes: [single-region]
+    default: single-region
+    minRegions: 1
+    maxRegions: 1
+  manifests:
+    chart: ./chart
+  depends:
+    - blueprint: bp-stunner            # K8s-native TURN/STUN for NAT traversal
+      version: ^1
+    - blueprint: bp-cert-manager       # ingress TLS via ClusterIssuer
+      version: ^1
+    - blueprint: bp-valkey             # required when LiveKit runs >1 replica (signaling state)
+      version: ^1
+  upgrades:
+    from: ["0.x"]
+  observability:
+    metrics: prometheus
+    logs: stdout

--- a/platform/livekit/chart/Chart.yaml
+++ b/platform/livekit/chart/Chart.yaml
@@ -1,0 +1,41 @@
+apiVersion: v2
+name: bp-livekit
+version: 1.0.0
+appVersion: "v1.9.0"
+description: |
+  Catalyst Blueprint umbrella chart for LiveKit — WebRTC SFU. Depends on
+  the upstream `livekit-server` chart (livekit/helm-charts) as a Helm
+  subchart so `helm dependency build` pulls the upstream payload into
+  this Blueprint's OCI artifact (per docs/BLUEPRINT-AUTHORING.md §11.1
+  — hollow charts forbidden).
+
+  Catalyst-curated overlay templates in `templates/` (NetworkPolicy,
+  ServiceMonitor, HPA — all default OFF per
+  docs/BLUEPRINT-AUTHORING.md §11.2) sit alongside the upstream subchart
+  and Helm renders both at install time. Catalyst-curated values flow
+  into the upstream subchart under the `livekit-server:` key in
+  values.yaml.
+
+  Catalyst defaults pair LiveKit with bp-stunner for K8s-native TURN/
+  STUN — the upstream chart's bundled `livekit.turn.enabled` is left
+  off, and the operator's per-Sovereign overlay points the LiveKit TURN
+  config at the stunner UDP-gateway Service. The RTC UDP port range
+  (50000-60000) is exposed via the LiveKit Service in `hostNetwork`
+  mode and must match the Hetzner firewall rule the per-Sovereign
+  overlay opens.
+type: application
+keywords: [catalyst, blueprint, livekit, webrtc, sfu, video, audio, realtime]
+maintainers:
+  - name: OpenOva Catalyst
+    email: catalyst@openova.io
+
+# Upstream chart pulled in as a Helm subchart so `helm dependency build`
+# bundles it into the OCI artifact. Pinned to livekit/livekit-server
+# 1.9.0 (matches platform/livekit/blueprint.yaml + values.yaml
+# `catalystBlueprint.upstream.version`). Per
+# docs/INVIOLABLE-PRINCIPLES.md #4 (never hardcode) the version is
+# operator-bumpable via PR + Blueprint release.
+dependencies:
+  - name: livekit-server
+    version: "1.9.0"
+    repository: "https://helm.livekit.io"

--- a/platform/livekit/chart/templates/_helpers.tpl
+++ b/platform/livekit/chart/templates/_helpers.tpl
@@ -1,0 +1,21 @@
+{{/*
+Catalyst-curated helpers for bp-livekit. Mirrors the conventions used
+by bp-harbor / bp-valkey / bp-cnpg / bp-librechat.
+*/}}
+
+{{- define "bp-livekit.fullname" -}}
+{{- default "livekit" .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "bp-livekit.labels" -}}
+app.kubernetes.io/name: {{ include "bp-livekit.fullname" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+catalyst.openova.io/blueprint: bp-livekit
+catalyst.openova.io/component: livekit
+{{- end -}}
+
+{{- define "bp-livekit.selectorLabels" -}}
+app.kubernetes.io/name: livekit-server
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}

--- a/platform/livekit/chart/templates/hpa.yaml
+++ b/platform/livekit/chart/templates/hpa.yaml
@@ -1,0 +1,53 @@
+{{- /*
+HorizontalPodAutoscaler — Catalyst overlay for the LiveKit Deployment.
+DEFAULT FALSE.
+
+The upstream livekit-server chart exposes its own
+`livekit-server.autoscaling.enabled` knob (kept defaulted false in
+values.yaml). This Catalyst-side HPA template is the forward-
+compatibility guard for a Catalyst-authored autoscaling shape (e.g.
+scaling on custom signaling-room metrics rather than CPU/memory).
+
+NB: LiveKit's resource constraints — only one instance per physical
+node fits because of the SFU port range exclusivity — mean horizontal
+scaling typically requires per-node placement, not per-pod scaling.
+The HPA shape here is for clusters running multiple LiveKit pods
+across multiple nodes; solo-Sovereigns stay at the single-replica
+baseline.
+
+Per docs/INVIOLABLE-PRINCIPLES.md #4 every knob (min/max replicas,
+CPU/memory targets, target Deployment name) is operator-tunable.
+*/}}
+{{- if .Values.hpa.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: bp-livekit
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "bp-livekit.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ default (include "bp-livekit.fullname" .) .Values.hpa.targetDeploymentName }}
+  minReplicas: {{ .Values.hpa.minReplicas }}
+  maxReplicas: {{ .Values.hpa.maxReplicas }}
+  metrics:
+    {{- if .Values.hpa.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.hpa.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.hpa.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.hpa.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/platform/livekit/chart/templates/networkpolicy.yaml
+++ b/platform/livekit/chart/templates/networkpolicy.yaml
@@ -1,0 +1,90 @@
+{{- /*
+NetworkPolicy — Catalyst overlay locking the livekit pods down to the
+minimum egress / ingress required.
+
+Egress targets:
+  - Cluster DNS (kube-system) — service discovery for bp-valkey + bp-stunner.
+  - bp-valkey signaling-state store on port 6379 (when replicaCount > 1).
+  - bp-stunner UDP-gateway on port 3478 — TURN/STUN routing.
+
+Ingress is locked to:
+  - Ingress controller namespace (operator-supplied label) — terminates
+    public LiveKit signaling on the chart's `.livekit-server.livekit.port`.
+  - Same-namespace traffic between livekit pods.
+
+NB: LiveKit's RTC port range (50000-60000 UDP) is intentionally NOT
+listed here — when LiveKit runs on hostNetwork (the upstream chart
+default; restated in values.yaml), pod-level NetworkPolicies do NOT
+apply to host-network pods. The Hetzner firewall rule is the
+load-bearing control for the SFU port range; the per-Sovereign
+overlay opens it. See docs/SECURITY.md §4 for the layered control.
+
+DEFAULT FALSE per Catalyst overlay convention — operator turns this on
+via per-Sovereign overlay once consumer namespaces are known. Per
+docs/INVIOLABLE-PRINCIPLES.md #4 every selector / namespace label /
+port is operator-tunable through `networkPolicy.*`.
+*/}}
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: bp-livekit
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "bp-livekit.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: livekit-server
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    # Same-namespace traffic between livekit pods.
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Release.Namespace }}
+    # Ingress controller — terminates public signaling.
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.networkPolicy.ingressNamespace | default "traefik" }}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.networkPolicy.signalingPort | default 7880 }}
+  egress:
+    # Cluster DNS — livekit resolves valkey + stunner Services.
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    # Same-namespace egress (signaling fan-out).
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Release.Namespace }}
+    # bp-valkey signaling-state store — required when replicaCount > 1.
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.networkPolicy.valkeyNamespace | default "valkey" }}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.networkPolicy.valkeyPort | default 6379 }}
+    # bp-stunner UDP-gateway — TURN/STUN routing.
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.networkPolicy.stunnerNamespace | default "stunner" }}
+      ports:
+        - protocol: UDP
+          port: {{ .Values.networkPolicy.stunnerPort | default 3478 }}
+        - protocol: TCP
+          port: {{ .Values.networkPolicy.stunnerPort | default 3478 }}
+{{- end }}

--- a/platform/livekit/chart/templates/servicemonitor.yaml
+++ b/platform/livekit/chart/templates/servicemonitor.yaml
@@ -1,0 +1,49 @@
+{{- /*
+ServiceMonitor — Catalyst-overlay variant for LiveKit.
+
+The upstream livekit-server chart already publishes its own
+ServiceMonitor (gated by `livekit-server.serviceMonitor.create`, kept
+defaulted false in chart/values.yaml). This Catalyst-side template is
+the forward-compatibility guard so a Catalyst-authored aggregate
+ServiceMonitor (e.g. covering both signaling + RTC metrics endpoints)
+can land behind a single operator toggle.
+
+DEFAULT FALSE per docs/BLUEPRINT-AUTHORING.md §11.2 — Prometheus
+Operator (monitoring.coreos.com/v1) is NOT in the bootstrap-kit prior
+to slot 25 (kube-prometheus-stack), so a ServiceMonitor shipped enabled
+-by-default would generate Helm install errors on a Sovereign that
+hasn't reached Phase 2 yet.
+
+Defense in depth: the values toggle (.Values.serviceMonitor.enabled)
+is the operator switch; the Capabilities gate skips the resource
+entirely on a Sovereign that has not yet reconciled the CRD, so
+flipping the toggle on a too-early Sovereign cannot break the
+bp-livekit reconcile.
+
+Per docs/INVIOLABLE-PRINCIPLES.md #4 every knob (interval, namespace,
+labels, scrape path) is operator-tunable.
+*/}}
+{{- if and .Values.serviceMonitor.enabled (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: bp-livekit-catalyst
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "bp-livekit.labels" . | nindent 4 }}
+    {{- with .Values.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: livekit-server
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  endpoints:
+    - port: metrics
+      path: {{ .Values.serviceMonitor.path | quote }}
+      interval: {{ .Values.serviceMonitor.interval | quote }}
+      scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout | quote }}
+{{- end }}

--- a/platform/livekit/chart/tests/observability-toggle.sh
+++ b/platform/livekit/chart/tests/observability-toggle.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# bp-livekit observability-toggle integration test
+# (docs/BLUEPRINT-AUTHORING.md §11.2).
+#
+# Verifies the Catalyst rule that every observability toggle in a
+# Blueprint's chart/values.yaml MUST default to false:
+#   - default `helm template` produces zero monitoring.coreos.com/v1
+#     resources;
+#   - opt-in render with serviceMonitor.enabled=true produces a
+#     ServiceMonitor (proves the toggle is wired);
+#   - explicit-off render is clean.
+#
+# Usage: bash tests/observability-toggle.sh [CHART_DIR]
+#   CHART_DIR defaults to the parent directory of this script.
+
+set -euo pipefail
+
+CHART_DIR="${1:-$(cd "$(dirname "$0")/.." && pwd)}"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+cd "$CHART_DIR"
+
+# Skip helm dep build when charts/ is already vendored (CI populates it
+# before this step runs, and re-running on CI without `helm repo add`
+# fails). Mirrors the bp-cilium / bp-valkey pattern.
+if [ ! -d charts ] || [ -z "$(ls -A charts 2>/dev/null)" ]; then
+  helm dependency build >/dev/null
+fi
+
+# ── Case 1: default render must NOT contain monitoring.coreos.com ────────
+echo "[observability-toggle] Case 1: default render produces no ServiceMonitor"
+helm template smoke-livekit . > "$TMP/default.yaml"
+if grep -qE "^kind: (ServiceMonitor|PrometheusRule)$" "$TMP/default.yaml"; then
+  echo "FAIL: default render of bp-livekit contains a ServiceMonitor/PrometheusRule CR." >&2
+  echo "      docs/BLUEPRINT-AUTHORING.md §11.2 forbids this — observability toggles must default false." >&2
+  grep -nE "^kind: (ServiceMonitor|PrometheusRule)$" "$TMP/default.yaml" >&2
+  exit 1
+fi
+if grep -q "monitoring.coreos.com" "$TMP/default.yaml"; then
+  echo "FAIL: default render of bp-livekit contains monitoring.coreos.com references." >&2
+  grep -n "monitoring.coreos.com" "$TMP/default.yaml" | head -5 >&2
+  exit 1
+fi
+echo "  PASS"
+
+# ── Case 2: opt-in (serviceMonitor.enabled=true) renders cleanly ─────────
+echo "[observability-toggle] Case 2: opt-in (serviceMonitor.enabled=true) renders cleanly"
+if ! helm template smoke-livekit . \
+    --api-versions monitoring.coreos.com/v1 \
+    --set serviceMonitor.enabled=true \
+    > "$TMP/optin.yaml" 2> "$TMP/optin.err"; then
+  echo "FAIL: opt-in render failed:" >&2
+  cat "$TMP/optin.err" >&2
+  exit 1
+fi
+if ! grep -qE "^kind: ServiceMonitor$" "$TMP/optin.yaml"; then
+  echo "FAIL: opt-in render did NOT produce a ServiceMonitor — the toggle is broken." >&2
+  exit 1
+fi
+echo "  PASS"
+
+# ── Case 3: explicit-off render must be clean ───────────────────────────
+echo "[observability-toggle] Case 3: explicit serviceMonitor.enabled=false renders cleanly"
+if ! helm template smoke-livekit . \
+    --set serviceMonitor.enabled=false \
+    > "$TMP/off.yaml" 2> "$TMP/off.err"; then
+  echo "FAIL: explicit-off render failed:" >&2
+  cat "$TMP/off.err" >&2
+  exit 1
+fi
+if grep -qE "^kind: (ServiceMonitor|PrometheusRule)$" "$TMP/off.yaml"; then
+  echo "FAIL: explicit-off render still contains a ServiceMonitor/PrometheusRule CR." >&2
+  exit 1
+fi
+echo "  PASS"
+
+# ── Case 4: upstream LiveKit serviceMonitor must default false ──────────
+# The upstream chart can render its own ServiceMonitor when
+# `livekit-server.serviceMonitor.create = true`. Catalyst keeps that
+# defaulted false; this case asserts the contract.
+echo "[observability-toggle] Case 4: upstream livekit-server.serviceMonitor.create defaults false"
+if grep -q "monitoring.coreos.com" "$TMP/default.yaml"; then
+  echo "FAIL: upstream LiveKit ServiceMonitor leaked into default render." >&2
+  exit 1
+fi
+echo "  PASS"
+
+echo "[observability-toggle] All bp-livekit observability-toggle gates green."

--- a/platform/livekit/chart/values.yaml
+++ b/platform/livekit/chart/values.yaml
@@ -1,0 +1,196 @@
+# Catalyst Blueprint umbrella metadata — the upstream livekit-server
+# chart is resolved as a Helm subchart via Chart.yaml `dependencies:`.
+# This values.yaml carries:
+#   1. The catalystBlueprint metadata block (provenance + version) so
+#      observability/audit pipelines can inspect the artifact.
+#   2. The upstream subchart values overlay under the `livekit-server:`
+#      key (umbrella-chart convention — the dependency name from
+#      Chart.yaml is the values namespace).
+#   3. Catalyst-overlay knobs (networkPolicy, serviceMonitor, hpa) — all
+#      DEFAULT OFF per docs/BLUEPRINT-AUTHORING.md §11.2.
+#
+# Per docs/INVIOLABLE-PRINCIPLES.md #4 (never hardcode), every operationally-
+# meaningful value is configurable; cluster overlays in clusters/<sovereign>/
+# may override any of these without rebuilding the Blueprint OCI artifact.
+
+catalystBlueprint:
+  upstream:
+    chart: livekit-server
+    version: "1.9.0"
+    repo: "https://helm.livekit.io"
+
+# ─── Upstream chart values (subchart key: livekit-server) ────────────────
+# `helm dependency build` resolves the upstream as a subchart; values here
+# under the `livekit-server:` key flow into that subchart unchanged.
+livekit-server:
+
+  # Solo-Sovereign baseline — single replica. LiveKit signaling state is
+  # carried in Redis when replicaCount > 1, so multi-tenant overlays MUST
+  # supply `livekit.redis.address` (Catalyst routes this to bp-valkey).
+  replicaCount: 1
+
+  image:
+    repository: livekit/livekit-server
+    pullPolicy: IfNotPresent
+
+  # ─── LiveKit binary configuration ──────────────────────────────────────
+  livekit:
+    port: 7880
+    log_level: info
+
+    rtc:
+      tcp_port: 7881
+      # UDP port range for RTC traffic. Must match the Hetzner firewall
+      # rule the per-Sovereign overlay opens. Per
+      # docs/INVIOLABLE-PRINCIPLES.md #4 every port is operator-tunable.
+      port_range_start: 50000
+      port_range_end: 60000
+      use_external_ip: true
+
+    # Redis (signaling-state store). Empty by default — Catalyst's per-
+    # Sovereign overlay points this at the bp-valkey Service when
+    # replicaCount > 1. Solo-Sovereigns with replicaCount: 1 leave this
+    # blank.
+    redis: {}
+
+    # API keys — empty by default. Operator MUST supply via
+    # `storeKeysInSecret.existingSecret` referencing an ExternalSecret
+    # (do NOT inline keys in cluster overlays). Per
+    # docs/INVIOLABLE-PRINCIPLES.md #4 nothing is hardcoded.
+    keys: {}
+
+    # ─── TURN server — Catalyst routes to bp-stunner ─────────────────────
+    # The upstream chart's bundled `livekit.turn` runs a co-located TURN
+    # server. Catalyst's standard pattern is to route TURN/STUN through
+    # bp-stunner (K8s-native) for NAT traversal — leave the bundled
+    # `livekit.turn.enabled` OFF and the per-Sovereign overlay supplies
+    # the stunner UDP-gateway endpoint via a Catalyst overlay annotation
+    # (see `livekitOverlay.stunner` below).
+    turn:
+      enabled: false
+
+  # Store API keys in a Secret instead of the ConfigMap. DEFAULT FALSE —
+  # the upstream chart's secret template requires either an
+  # `existingSecret` reference or an inline `keys:` map plus
+  # `livekit.key_file`. Catalyst's standard pattern is to project an
+  # ExternalSecret and have the operator's per-Sovereign overlay flip
+  # `enabled: true` and supply `existingSecret`. Default-off keeps
+  # `helm template` smoke renders clean without operator overlays.
+  storeKeysInSecret:
+    enabled: false
+    existingSecret: ""                # operator-supplied (e.g. "livekit-keys")
+    keys: {}
+
+  # ─── Service / loadBalancer ────────────────────────────────────────────
+  # Single-instance LiveKit runs on hostNetwork so the SFU port range is
+  # reachable. The upstream chart sets podHostNetwork: true by default;
+  # Catalyst keeps it.
+  loadBalancer:
+    type: disable
+    servicePort: 80
+    annotations: {}
+
+  # turnLoadbalancer — left enabled to match upstream defaults; the
+  # service is harmless when bundled TURN is off.
+  turnLoadbalancer:
+    enable: true
+
+  # Autoscaling (HPA) — DEFAULT FALSE per docs/BLUEPRINT-AUTHORING.md
+  # §11.2 (Observability toggles must default false; HPA is gated on
+  # metrics-server which is part of the kube-prometheus-stack tier).
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 5
+    targetCPUUtilizationPercentage: 60
+
+  # Resource baseline — LiveKit recommends "plenty of resources" because
+  # only one instance per physical node fits (port range exclusivity).
+  # Solo-Sovereign baseline below; multi-tenant overlays bump.
+  resources:
+    requests:
+      cpu: 500m
+      memory: 512Mi
+    limits:
+      cpu: 4
+      memory: 2Gi
+
+  serviceAccount:
+    create: true
+    annotations: {}
+    name: ""
+
+  # hostNetwork required so the SFU port range maps directly to the
+  # node's external IP. Upstream default — restate explicitly.
+  podHostNetwork: true
+
+  podAnnotations:
+    sidecar.istio.io/inject: "false"
+    linkerd.io/inject: disabled
+
+  # ─── Upstream ServiceMonitor — DEFAULT OFF ─────────────────────────────
+  # Per docs/BLUEPRINT-AUTHORING.md §11.2.
+  serviceMonitor:
+    create: false
+    annotations: {}
+    name: ""
+    interval: 30s
+
+# ─── Catalyst-overlay knobs (consumed by templates/ in this chart) ───────
+# All DEFAULT OFF per docs/BLUEPRINT-AUTHORING.md §11.2.
+
+# bp-stunner integration — the Catalyst standard for WebRTC NAT
+# traversal. The per-Sovereign overlay flips `enabled: true` and points
+# `gatewayService` at the bp-stunner UDP-gateway. The bp-livekit chart
+# emits this only as Service annotations + a Catalyst-overlay
+# ConfigMap; the actual UDPRoute / Gateway resources live in
+# bp-stunner's own chart.
+livekitOverlay:
+  stunner:
+    enabled: false
+    gatewayService: "udp-gateway.stunner.svc.cluster.local:3478"
+    # Realm + shared-secret used by the upstream livekit binary's
+    # `turn_server` config. Operator supplies via ExternalSecret.
+    realm: "stunner.l7mp.io"
+    sharedSecretName: ""              # ExternalSecret name (e.g. "livekit-stunner-shared-secret")
+
+# NetworkPolicy — locks the livekit pods down to the minimum egress /
+# ingress required (kube-dns, valkey, stunner, ingress). Default off —
+# operator opts in via per-Sovereign overlay once consumer namespaces
+# are known. Per docs/INVIOLABLE-PRINCIPLES.md #4 every selector /
+# namespace label / port is operator-tunable.
+networkPolicy:
+  enabled: false
+  valkeyNamespace: "valkey"
+  valkeyPort: 6379
+  stunnerNamespace: "stunner"
+  stunnerPort: 3478
+  ingressNamespace: "traefik"
+  # The signaling port the upstream chart exposes (`.livekit-server.livekit.port`).
+  signalingPort: 7880
+
+# ServiceMonitor — Catalyst-overlay variant. The upstream chart
+# already publishes its own ServiceMonitor (gated by `serviceMonitor.create`
+# above, which we keep defaulted false). This Catalyst-side knob is the
+# forward-compatibility guard so a future aggregate ServiceMonitor lands
+# behind the same operator switch. Per docs/BLUEPRINT-AUTHORING.md
+# §11.2 — DEFAULT OFF.
+serviceMonitor:
+  enabled: false
+  interval: "30s"
+  scrapeTimeout: "10s"
+  path: "/metrics"
+  labels: {}
+
+# HorizontalPodAutoscaler for the LiveKit Deployment. Default OFF.
+# The upstream chart already exposes `livekit-server.autoscaling.enabled`
+# (kept defaulted false above); this Catalyst-side knob is the
+# forward-compatibility guard for a Catalyst-authored HPA shape (e.g.
+# scaling on custom signaling-room metrics). Per
+# docs/BLUEPRINT-AUTHORING.md §11.2 — DEFAULT OFF.
+hpa:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 4
+  targetCPUUtilizationPercentage: 60
+  targetMemoryUtilizationPercentage: 80

--- a/platform/matrix/README.md
+++ b/platform/matrix/README.md
@@ -1,52 +1,84 @@
-# Matrix/Synapse
+# bp-matrix
 
-Decentralized chat and messaging using the Matrix protocol (Synapse server implementation). **Application Blueprint** (see [`docs/PLATFORM-TECH-STACK.md`](../../docs/PLATFORM-TECH-STACK.md) §4.5 — Communication). Used by `bp-relay` for team chat with end-to-end encryption and federation.
+Self-hosted, federation-capable team chat. Catalyst Application
+Blueprint wrapping the **Synapse** Matrix homeserver. See
+[`docs/PLATFORM-TECH-STACK.md`](../../docs/PLATFORM-TECH-STACK.md) §4.5
+(Communication).
 
-> "Synapse" here refers to the Matrix server implementation (the chat backend), NOT the deprecated OpenOva product noun (which has been retired in favor of `bp-axon` for the SaaS LLM gateway).
+> "Synapse" here = the Matrix server implementation, **NOT** the
+> retired OpenOva product noun (which has been replaced by `bp-axon`
+> for the SaaS LLM gateway).
 
-**Category:** Communication | **Type:** Application Blueprint
+**Status:** Accepted | **Updated:** 2026-04-30
 
 ---
 
 ## Overview
 
-Matrix (via the Synapse server) provides self-hosted, federated chat and messaging with end-to-end encryption. Supports team collaboration, incident communication, and integration with external Matrix networks.
-
-## Key Features
-
-- End-to-end encrypted messaging
-- Federation with external Matrix servers
-- Room-based team collaboration
-- Bridge support (Slack, IRC, Discord)
-- Webhook integrations for alerting
-
-## Integration
+Synapse is the reference Matrix homeserver. Catalyst pairs it with:
 
 | Component | Integration |
 |-----------|-------------|
-| Keycloak | SSO via OIDC |
-| CNPG | PostgreSQL backend |
-| Grafana | Alert notifications via Matrix |
-| Stalwart | Email notifications |
+| `bp-cnpg` | PostgreSQL backend (via `externalPostgresql`) |
+| `bp-keycloak` | OIDC SSO (via `extraConfig.oidc_providers`) |
+| `bp-cert-manager` | Ingress TLS via cluster `Issuer` |
+| `bp-valkey` | Workers signaling backend (only when workers are enabled) |
+| `bp-element-web` | Web client at `chat-web.<sovereign-fqdn>` (separate Blueprint, slot 47) |
 
-## Used By
+## Per-Sovereign tenancy default — federation OFF
 
-- **OpenOva Relay** - Team messaging component
+Catalyst's per-Sovereign tenancy default keeps each Sovereign's Matrix
+instance private. Operator overlays flip `federation.enabled: true`
+per-Organization for cross-Sovereign collaboration. The chart's
+NetworkPolicy template only opens federation port 8448 when
+`federation.enabled` is true (verified by Case 5 of
+`tests/observability-toggle.sh`).
 
-## Deployment
+## Local registration OFF
 
-```yaml
-apiVersion: kustomize.toolkit.fluxcd.io/v1
-kind: Kustomization
-metadata:
-  name: matrix
-  namespace: flux-system
-spec:
-  interval: 10m
-  path: ./platform/matrix
-  prune: true
+Catalyst standard is OIDC-only accounts (registration is handled in
+Keycloak). The wrapper sets `extraConfig.enable_registration: false` by
+default; operator overlays may flip it on for development Sovereigns.
+
+## Chart shape
+
+```
+platform/matrix/
+├── blueprint.yaml                     # Catalyst Blueprint CRD
+├── chart/
+│   ├── Chart.yaml                     # umbrella; deps: matrix-synapse (Helm)
+│   ├── values.yaml                    # Catalyst defaults (federation OFF, OIDC ON)
+│   └── templates/
+│       ├── _helpers.tpl
+│       ├── networkpolicy.yaml         # default OFF; federation port gated by federation.enabled
+│       ├── servicemonitor.yaml        # default OFF (CRD-gated)
+│       └── hpa.yaml                   # default OFF
+├── chart/tests/observability-toggle.sh
+└── README.md
+```
+
+## Observability toggles (all default OFF)
+
+Per [`docs/BLUEPRINT-AUTHORING.md`](../../docs/BLUEPRINT-AUTHORING.md)
+§11.2.
+
+| Toggle | Default | Why |
+|--------|---------|-----|
+| `serviceMonitor.enabled` | `false` | upstream chart has no ServiceMonitor; Catalyst overlay default off |
+| `networkPolicy.enabled` | `false` | Operator supplies consumer-namespace selectors per-Sovereign |
+| `hpa.enabled` | `false` | Solo-Sovereign baseline runs Synapse monolithic |
+| `federation.enabled` | `false` | Catalyst per-Sovereign tenancy default (private rooms) |
+| `extraConfig.enable_registration` | `false` | OIDC-only accounts (registration in Keycloak) |
+
+## Verification
+
+```bash
+helm dependency update platform/matrix/chart
+helm template platform/matrix/chart | grep -E "^kind:" | sort -u
+helm lint platform/matrix/chart
+bash platform/matrix/chart/tests/observability-toggle.sh
 ```
 
 ---
 
-*Part of [OpenOva](https://openova.io)*
+*Part of [OpenOva](https://openova.io). Closes #274.*

--- a/platform/matrix/blueprint.yaml
+++ b/platform/matrix/blueprint.yaml
@@ -1,0 +1,140 @@
+apiVersion: catalyst.openova.io/v1alpha1
+kind: Blueprint
+metadata:
+  name: bp-matrix
+  labels:
+    catalyst.openova.io/category: application
+    catalyst.openova.io/section: pts-4-5-communication
+spec:
+  version: 1.0.0
+  card:
+    title: Matrix (Synapse)
+    summary: |
+      Self-hosted, federation-capable team chat. Synapse is the
+      reference Matrix homeserver implementation — Catalyst's per-
+      Sovereign tenancy default keeps federation OFF (private rooms
+      only), and operator overlays toggle it on per-Organization for
+      cross-Sovereign collaboration. Hosted at chat.<sovereign-fqdn>
+      with a paired Element-Web client at chat-web.<sovereign-fqdn>.
+      OIDC SSO via bp-keycloak; Postgres backend via bp-cnpg.
+      ("Synapse" here = the Matrix server implementation, NOT the
+      retired OpenOva product noun.)
+    icon: matrix.svg
+    category: application
+    tags: [chat, messaging, federation, e2ee, oidc, application]
+    documentation: https://element-hq.github.io/synapse/
+    license: AGPL-3.0
+  visibility: listed
+  owner:
+    team: platform
+    contact: platform@openova.io
+  configSchema:
+    type: object
+    required: [serverName]
+    properties:
+      serverName:
+        type: string
+        format: hostname
+        description: |
+          The Matrix server name (becomes the @user:<serverName> domain
+          part). Per-Sovereign overlay supplies this — typically
+          chat.<sovereign-fqdn>.
+      publicServerName:
+        type: string
+        format: hostname
+        description: |
+          The public-facing client hostname for /.well-known/matrix
+          discovery. Defaults to the same value as serverName.
+      federation:
+        type: object
+        properties:
+          enabled:
+            type: boolean
+            default: false
+            description: |
+              Federation OFF by default — Catalyst's per-Sovereign
+              tenancy default keeps each Sovereign's Matrix instance
+              private. Operator overlays flip this on per-Organization
+              for cross-Sovereign collaboration.
+      oidc:
+        type: object
+        properties:
+          enabled:
+            type: boolean
+            default: true
+            description: |
+              OIDC SSO via bp-keycloak. Catalyst standard.
+          idpId:
+            type: string
+            default: "keycloak"
+            description: |
+              Synapse's IdP ID for the Keycloak provider. Becomes part
+              of the OIDC client name registered in Keycloak.
+          issuer:
+            type: string
+            description: |
+              Keycloak realm issuer URL (e.g. https://keycloak.<loc>
+              .<sovereign-domain>/realms/<org>). Per-Sovereign overlay
+              supplies this; nothing is hardcoded
+              (docs/INVIOLABLE-PRINCIPLES.md #4).
+      registration:
+        type: object
+        properties:
+          enableRegistration:
+            type: boolean
+            default: false
+            description: |
+              Local-account registration. Catalyst standard is OIDC-only
+              accounts (registration handled in Keycloak); local
+              registration OFF.
+      elementWeb:
+        type: object
+        properties:
+          enabled:
+            type: boolean
+            default: true
+            description: |
+              Deploy the Element-Web client at chat-web.<sovereign-fqdn>
+              alongside the Synapse homeserver. The Element-Web image
+              is wired by the bp-element-web Application Blueprint
+              (slot 47); this knob is a documentation-level pointer
+              for the per-Sovereign overlay.
+      tls:
+        type: object
+        properties:
+          issuerRef:
+            type: string
+            default: "letsencrypt-prod"
+            description: |
+              cert-manager ClusterIssuer name (per-Sovereign overlay
+              chooses staging vs prod).
+      serviceMonitor:
+        type: object
+        properties:
+          enabled:
+            type: boolean
+            default: false
+            description: |
+              monitoring.coreos.com/v1 ServiceMonitor — requires the
+              Prometheus Operator CRDs from kube-prometheus-stack.
+              Per docs/BLUEPRINT-AUTHORING.md §11.2 default false;
+              operator opts in via per-cluster overlay (issue #182).
+  placementSchema:
+    modes: [single-region]
+    default: single-region
+    minRegions: 1
+    maxRegions: 1
+  manifests:
+    chart: ./chart
+  depends:
+    - blueprint: bp-cnpg               # Postgres backend (postgresql.cnpg.io/v1.Cluster)
+      version: ^1
+    - blueprint: bp-keycloak           # OIDC SSO
+      version: ^1
+    - blueprint: bp-cert-manager       # ingress TLS via ClusterIssuer
+      version: ^1
+  upgrades:
+    from: ["0.x"]
+  observability:
+    metrics: prometheus
+    logs: stdout

--- a/platform/matrix/chart/Chart.yaml
+++ b/platform/matrix/chart/Chart.yaml
@@ -1,0 +1,45 @@
+apiVersion: v2
+name: bp-matrix
+version: 1.0.0
+appVersion: "1.151.0"
+description: |
+  Catalyst Blueprint umbrella chart for Synapse — the reference Matrix
+  homeserver. Depends on the upstream `matrix-synapse` chart from
+  ananace/charts (the most actively maintained community chart for
+  Synapse; element-hq has not published a first-party Helm chart) as a
+  Helm subchart so `helm dependency build` pulls the upstream payload
+  into this Blueprint's OCI artifact (per
+  docs/BLUEPRINT-AUTHORING.md §11.1 — hollow charts forbidden).
+
+  Catalyst-curated overlay templates in `templates/` (NetworkPolicy,
+  ServiceMonitor, HPA — all default OFF per
+  docs/BLUEPRINT-AUTHORING.md §11.2) sit alongside the upstream
+  subchart and Helm renders both at install time. Catalyst-curated
+  values flow into the upstream subchart under the `matrix-synapse:`
+  key in values.yaml.
+
+  Catalyst defaults pair Synapse with bp-cnpg (Postgres backend via the
+  upstream chart's `externalPostgresql` block), bp-keycloak (OIDC SSO
+  via `extraConfig.oidc_providers`), and bp-cert-manager (TLS via
+  cluster Issuer). Federation is OFF by default — Catalyst's per-
+  Sovereign tenancy default keeps each Sovereign's Matrix instance
+  private until operator overlays flip it on per-Organization.
+
+  ("Synapse" here refers to the Matrix server implementation, NOT the
+  deprecated OpenOva product noun retired in favor of `bp-axon`.)
+type: application
+keywords: [catalyst, blueprint, matrix, synapse, chat, messaging, federation, e2ee, oidc]
+maintainers:
+  - name: OpenOva Catalyst
+    email: catalyst@openova.io
+
+# Upstream chart pulled in as a Helm subchart so `helm dependency build`
+# bundles it into the OCI artifact. Pinned to ananace/matrix-synapse
+# 3.12.25 (Synapse v1.151.0; matches platform/matrix/blueprint.yaml +
+# values.yaml `catalystBlueprint.upstream.version`). Per
+# docs/INVIOLABLE-PRINCIPLES.md #4 (never hardcode) the version is
+# operator-bumpable via PR + Blueprint release.
+dependencies:
+  - name: matrix-synapse
+    version: "3.12.25"
+    repository: "https://ananace.gitlab.io/charts"

--- a/platform/matrix/chart/templates/_helpers.tpl
+++ b/platform/matrix/chart/templates/_helpers.tpl
@@ -1,0 +1,22 @@
+{{/*
+Catalyst-curated helpers for bp-matrix. Mirrors the conventions used
+by bp-harbor / bp-valkey / bp-cnpg / bp-librechat.
+*/}}
+
+{{- define "bp-matrix.fullname" -}}
+{{- default "matrix" .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "bp-matrix.labels" -}}
+app.kubernetes.io/name: {{ include "bp-matrix.fullname" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+catalyst.openova.io/blueprint: bp-matrix
+catalyst.openova.io/component: synapse
+catalyst.openova.io/federation: {{ .Values.federation.enabled | quote }}
+{{- end -}}
+
+{{- define "bp-matrix.selectorLabels" -}}
+app.kubernetes.io/name: matrix-synapse
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}

--- a/platform/matrix/chart/templates/hpa.yaml
+++ b/platform/matrix/chart/templates/hpa.yaml
@@ -1,0 +1,49 @@
+{{- /*
+HorizontalPodAutoscaler — Catalyst overlay for the Synapse main
+Deployment. DEFAULT FALSE.
+
+Solo-Sovereign baseline runs Synapse monolithic with replicaCount: 1.
+Multi-tenant Sovereigns enable workers (`workers.generic_worker.enabled
+= true`, etc.) plus HPA when room/event throughput warrants. Per
+docs/BLUEPRINT-AUTHORING.md §11.2 — DEFAULT OFF.
+
+NB: scaling Synapse beyond a single replica also requires switching
+the chart to worker mode + a Redis/Valkey signaling backend. See the
+upstream chart's worker docs.
+
+Per docs/INVIOLABLE-PRINCIPLES.md #4 every knob (min/max replicas,
+CPU/memory targets, target Deployment name) is operator-tunable.
+*/}}
+{{- if .Values.hpa.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: bp-matrix
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "bp-matrix.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ default (include "bp-matrix.fullname" .) .Values.hpa.targetDeploymentName }}
+  minReplicas: {{ .Values.hpa.minReplicas }}
+  maxReplicas: {{ .Values.hpa.maxReplicas }}
+  metrics:
+    {{- if .Values.hpa.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.hpa.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.hpa.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.hpa.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/platform/matrix/chart/templates/networkpolicy.yaml
+++ b/platform/matrix/chart/templates/networkpolicy.yaml
@@ -1,0 +1,104 @@
+{{- /*
+NetworkPolicy — Catalyst overlay locking the Synapse pods down to the
+minimum egress / ingress required.
+
+Egress targets:
+  - Cluster DNS (kube-system) — service discovery for bp-cnpg + bp-keycloak.
+  - bp-cnpg cluster (Postgres backend) on port 5432.
+  - bp-keycloak (OIDC discovery + token endpoint) on port 8443.
+
+Ingress is locked to:
+  - Ingress controller namespace (operator-supplied label) — terminates
+    public Synapse client API on port 8008 (and federation on 8448
+    when federation.enabled = true).
+  - Same-namespace traffic between Synapse + worker pods.
+
+DEFAULT FALSE per Catalyst overlay convention — operator turns this on
+via per-Sovereign overlay once consumer namespaces are known. Per
+docs/INVIOLABLE-PRINCIPLES.md #4 every selector / namespace label /
+port is operator-tunable through `networkPolicy.*`.
+*/}}
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: bp-matrix
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "bp-matrix.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: matrix-synapse
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    # Same-namespace traffic between Synapse + worker pods.
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Release.Namespace }}
+    # Ingress controller — terminates public client API.
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.networkPolicy.ingressNamespace | default "traefik" }}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.networkPolicy.clientPort | default 8008 }}
+        {{- if .Values.federation.enabled }}
+        - protocol: TCP
+          port: {{ .Values.networkPolicy.federationPort | default 8448 }}
+        {{- end }}
+  egress:
+    # Cluster DNS — Synapse resolves CNPG + Keycloak Services.
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    # Same-namespace egress (Synapse → workers, workers → media-repo, etc.).
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Release.Namespace }}
+    # bp-cnpg — Postgres backend.
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.networkPolicy.cnpgNamespace | default "cnpg" }}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.networkPolicy.cnpgPort | default 5432 }}
+    # bp-keycloak — OIDC discovery + token endpoint.
+    {{- if .Values.oidc.enabled }}
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.networkPolicy.keycloakNamespace | default "keycloak" }}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.networkPolicy.keycloakPort | default 8443 }}
+    {{- end }}
+    # Federation outbound (when enabled) — Synapse contacts other
+    # Matrix homeservers on the public internet on port 8448.
+    {{- if .Values.federation.enabled }}
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 10.0.0.0/8
+              - 172.16.0.0/12
+              - 192.168.0.0/16
+      ports:
+        - protocol: TCP
+          port: 8448
+        - protocol: TCP
+          port: 443
+    {{- end }}
+{{- end }}

--- a/platform/matrix/chart/templates/servicemonitor.yaml
+++ b/platform/matrix/chart/templates/servicemonitor.yaml
@@ -1,0 +1,49 @@
+{{- /*
+ServiceMonitor — Catalyst-overlay variant for Synapse.
+
+The upstream matrix-synapse chart does NOT publish a ServiceMonitor
+template; Synapse exposes its metrics on /_synapse/metrics, and the
+upstream chart sets `prometheus.io/scrape` annotations on the metrics
+port. This Catalyst-side template lands those metrics behind a proper
+ServiceMonitor so operators don't need an annotation-based scrape
+configuration.
+
+DEFAULT FALSE per docs/BLUEPRINT-AUTHORING.md §11.2 — Prometheus
+Operator (monitoring.coreos.com/v1) is NOT in the bootstrap-kit prior
+to slot 25 (kube-prometheus-stack), so a ServiceMonitor shipped
+enabled-by-default would generate Helm install errors on a Sovereign
+that hasn't reached Phase 2 yet.
+
+Defense in depth: the values toggle (.Values.serviceMonitor.enabled)
+is the operator switch; the Capabilities gate skips the resource
+entirely on a Sovereign that has not yet reconciled the CRD, so
+flipping the toggle on a too-early Sovereign cannot break the
+bp-matrix reconcile.
+
+Per docs/INVIOLABLE-PRINCIPLES.md #4 every knob (interval, namespace,
+labels, scrape path) is operator-tunable.
+*/}}
+{{- if and .Values.serviceMonitor.enabled (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: bp-matrix
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "bp-matrix.labels" . | nindent 4 }}
+    {{- with .Values.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: matrix-synapse
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  endpoints:
+    - port: metrics
+      path: {{ .Values.serviceMonitor.path | quote }}
+      interval: {{ .Values.serviceMonitor.interval | quote }}
+      scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout | quote }}
+{{- end }}

--- a/platform/matrix/chart/tests/observability-toggle.sh
+++ b/platform/matrix/chart/tests/observability-toggle.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# bp-matrix observability-toggle integration test
+# (docs/BLUEPRINT-AUTHORING.md §11.2).
+#
+# Verifies the Catalyst rule that every observability toggle in a
+# Blueprint's chart/values.yaml MUST default to false:
+#   - default `helm template` produces zero monitoring.coreos.com/v1
+#     resources;
+#   - opt-in render with serviceMonitor.enabled=true produces a
+#     ServiceMonitor (proves the toggle is wired);
+#   - explicit-off render is clean.
+#
+# Usage: bash tests/observability-toggle.sh [CHART_DIR]
+#   CHART_DIR defaults to the parent directory of this script.
+
+set -euo pipefail
+
+CHART_DIR="${1:-$(cd "$(dirname "$0")/.." && pwd)}"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+cd "$CHART_DIR"
+
+# Skip helm dep build when charts/ is already vendored (CI populates it
+# before this step runs, and re-running on CI without `helm repo add`
+# fails). Mirrors the bp-cilium / bp-valkey pattern.
+if [ ! -d charts ] || [ -z "$(ls -A charts 2>/dev/null)" ]; then
+  helm dependency build >/dev/null
+fi
+
+# ── Case 1: default render must NOT contain monitoring.coreos.com ────────
+echo "[observability-toggle] Case 1: default render produces no ServiceMonitor"
+helm template smoke-matrix . > "$TMP/default.yaml"
+if grep -qE "^kind: (ServiceMonitor|PrometheusRule)$" "$TMP/default.yaml"; then
+  echo "FAIL: default render of bp-matrix contains a ServiceMonitor/PrometheusRule CR." >&2
+  echo "      docs/BLUEPRINT-AUTHORING.md §11.2 forbids this — observability toggles must default false." >&2
+  grep -nE "^kind: (ServiceMonitor|PrometheusRule)$" "$TMP/default.yaml" >&2
+  exit 1
+fi
+if grep -q "monitoring.coreos.com" "$TMP/default.yaml"; then
+  echo "FAIL: default render of bp-matrix contains monitoring.coreos.com references." >&2
+  grep -n "monitoring.coreos.com" "$TMP/default.yaml" | head -5 >&2
+  exit 1
+fi
+echo "  PASS"
+
+# ── Case 2: opt-in (serviceMonitor.enabled=true) renders cleanly ─────────
+echo "[observability-toggle] Case 2: opt-in (serviceMonitor.enabled=true) renders cleanly"
+if ! helm template smoke-matrix . \
+    --api-versions monitoring.coreos.com/v1 \
+    --set serviceMonitor.enabled=true \
+    > "$TMP/optin.yaml" 2> "$TMP/optin.err"; then
+  echo "FAIL: opt-in render failed:" >&2
+  cat "$TMP/optin.err" >&2
+  exit 1
+fi
+if ! grep -qE "^kind: ServiceMonitor$" "$TMP/optin.yaml"; then
+  echo "FAIL: opt-in render did NOT produce a ServiceMonitor — the toggle is broken." >&2
+  exit 1
+fi
+echo "  PASS"
+
+# ── Case 3: explicit-off render must be clean ───────────────────────────
+echo "[observability-toggle] Case 3: explicit serviceMonitor.enabled=false renders cleanly"
+if ! helm template smoke-matrix . \
+    --set serviceMonitor.enabled=false \
+    > "$TMP/off.yaml" 2> "$TMP/off.err"; then
+  echo "FAIL: explicit-off render failed:" >&2
+  cat "$TMP/off.err" >&2
+  exit 1
+fi
+if grep -qE "^kind: (ServiceMonitor|PrometheusRule)$" "$TMP/off.yaml"; then
+  echo "FAIL: explicit-off render still contains a ServiceMonitor/PrometheusRule CR." >&2
+  exit 1
+fi
+echo "  PASS"
+
+# ── Case 4: federation OFF by default (Catalyst per-Sovereign tenancy) ──
+# Per the Catalyst per-Sovereign tenancy default, federation is OFF.
+# Verify two invariants that follow from `federation.enabled: false`:
+#   (a) the `federation_domain_whitelist` entry rendered into the
+#       Synapse homeserver.yaml is the empty-list / null form, NOT a
+#       populated whitelist;
+#   (b) when the Catalyst NetworkPolicy overlay is enabled, the
+#       federation port (8448) is NOT in the ingress allow-list.
+echo "[observability-toggle] Case 4: federation OFF by default"
+if grep -E "federation_domain_whitelist:\s*\[" "$TMP/default.yaml" | grep -vE 'federation_domain_whitelist:\s*\[\]' | head -1 ; then
+  echo "FAIL: default render contains a populated federation_domain_whitelist — federation should be OFF by default." >&2
+  exit 1
+fi
+# Render with networkPolicy.enabled=true to assert the federation port
+# is NOT opened in ingress when federation.enabled is false.
+helm template smoke-matrix . \
+    --set networkPolicy.enabled=true \
+    > "$TMP/netpol-default.yaml" 2> "$TMP/netpol-default.err" || {
+  echo "FAIL: networkPolicy render with federation=off failed:" >&2
+  cat "$TMP/netpol-default.err" >&2
+  exit 1
+}
+if grep -B2 -A1 "port: 8448" "$TMP/netpol-default.yaml" | head -10 ; then
+  echo "FAIL: NetworkPolicy with federation=false unexpectedly opens port 8448." >&2
+  exit 1
+fi
+echo "  PASS"
+
+# ── Case 5: federation ON wires the federation port in NetworkPolicy ────
+echo "[observability-toggle] Case 5: federation=true opens port 8448 in NetworkPolicy"
+helm template smoke-matrix . \
+    --set networkPolicy.enabled=true \
+    --set federation.enabled=true \
+    > "$TMP/netpol-fed.yaml" 2> "$TMP/netpol-fed.err" || {
+  echo "FAIL: networkPolicy render with federation=on failed:" >&2
+  cat "$TMP/netpol-fed.err" >&2
+  exit 1
+}
+if ! grep -q "port: 8448" "$TMP/netpol-fed.yaml" ; then
+  echo "FAIL: NetworkPolicy with federation=true does NOT open port 8448 — the toggle is broken." >&2
+  exit 1
+fi
+echo "  PASS"
+
+echo "[observability-toggle] All bp-matrix observability-toggle gates green."

--- a/platform/matrix/chart/values.yaml
+++ b/platform/matrix/chart/values.yaml
@@ -1,0 +1,223 @@
+# Catalyst Blueprint umbrella metadata — the upstream matrix-synapse
+# chart is resolved as a Helm subchart via Chart.yaml `dependencies:`.
+# This values.yaml carries:
+#   1. The catalystBlueprint metadata block (provenance + version) so
+#      observability/audit pipelines can inspect the artifact.
+#   2. The upstream subchart values overlay under the `matrix-synapse:`
+#      key (umbrella-chart convention — the dependency name from
+#      Chart.yaml is the values namespace).
+#   3. Catalyst-overlay knobs (networkPolicy, serviceMonitor, hpa) — all
+#      DEFAULT OFF per docs/BLUEPRINT-AUTHORING.md §11.2.
+#
+# Per docs/INVIOLABLE-PRINCIPLES.md #4 (never hardcode), every operationally-
+# meaningful value is configurable; cluster overlays in clusters/<sovereign>/
+# may override any of these without rebuilding the Blueprint OCI artifact.
+
+catalystBlueprint:
+  upstream:
+    chart: matrix-synapse
+    version: "3.12.25"
+    repo: "https://ananace.gitlab.io/charts"
+
+# ─── Upstream chart values (subchart key: matrix-synapse) ────────────────
+# `helm dependency build` resolves the upstream as a subchart; values here
+# under the `matrix-synapse:` key flow into that subchart unchanged.
+matrix-synapse:
+
+  image:
+    repository: ghcr.io/element-hq/synapse
+    pullPolicy: IfNotPresent
+
+  # ─── Server identity ───────────────────────────────────────────────────
+  # Per-Sovereign overlay supplies the actual hostname (typically
+  # chat.<sovereign-fqdn>). Default placeholder so `helm template` smoke
+  # renders without `--set` — operator overrides via per-Sovereign
+  # overlay. Per docs/INVIOLABLE-PRINCIPLES.md #4 nothing is hardcoded.
+  serverName: "matrix.example.local"
+  publicServerName: "matrix.example.local"
+
+  # Signing-key job — generates Synapse's federation signing key on
+  # first install. Catalyst's per-Sovereign tenancy default keeps
+  # federation OFF, but Synapse still requires a signing key for
+  # internal cryptographic operations. Operator overlays can supply an
+  # `existingSecret` to preserve the key across re-rolls.
+  signingkey:
+    job:
+      enabled: true
+    existingSecret: ""
+
+  # ─── Federation — OFF by default (per-Sovereign tenancy) ───────────────
+  # The upstream chart does not expose a top-level `federation.enabled`
+  # toggle; federation is gated by:
+  #   - whether the chart-rendered ingress includes the federation port,
+  #   - whether `extraConfig.federation_domain_whitelist` is set,
+  #   - whether the homeserver.yaml `disable_federation: true` knob is
+  #     supplied via `extraConfig`.
+  # Catalyst's wrapper supplies the OFF posture via `extraConfig` below;
+  # operator overlays delete the override (or supply a domain whitelist)
+  # to enable federation per-Organization.
+  extraConfig:
+    # Catalyst per-Sovereign tenancy default — federation OFF.
+    federation_domain_whitelist: []
+    # Local-account registration OFF — Catalyst standard is OIDC-only
+    # accounts (registration handled in Keycloak).
+    enable_registration: false
+    enable_registration_without_verification: false
+
+  # ─── Postgres backend — bp-cnpg (external) ─────────────────────────────
+  # Disable the bundled bitnami/postgresql; route Synapse at the bp-cnpg
+  # Cluster CR via `externalPostgresql`. Per-Sovereign overlay supplies
+  # the actual host + ExternalSecret holding the password.
+  postgresql:
+    enabled: false
+
+  externalPostgresql:
+    host: "matrix-postgres-rw.matrix.svc.cluster.local"
+    port: 5432
+    username: "synapse"
+    database: "synapse"
+    # Operator-supplied ExternalSecret holding the postgres password.
+    # Default is a placeholder name so the upstream chart's `required`
+    # password validation is satisfied at `helm template` smoke render
+    # time. The per-Sovereign overlay supplies the real ExternalSecret
+    # name (e.g. "matrix-postgres-credentials") at install time. Per
+    # docs/INVIOLABLE-PRINCIPLES.md #4 nothing is hardcoded — the
+    # placeholder is operator-replaceable.
+    existingSecret: "matrix-postgres-credentials"
+    existingSecretPasswordKey: "password"
+    sslmode: "require"
+
+  # ─── Redis (signaling-state for workers) ───────────────────────────────
+  # Bundled redis OFF — Catalyst routes at bp-valkey when workers are
+  # enabled. Default solo-Sovereign topology has no workers, so no
+  # Redis is required.
+  redis:
+    enabled: false
+
+  externalRedis:
+    enabled: false
+    host: "valkey-primary.valkey.svc.cluster.local"
+    port: 6379
+    existingSecret: ""                  # e.g. "matrix-redis-credentials"
+
+  # ─── Persistence ───────────────────────────────────────────────────────
+  # Synapse media repository — local PVC. Multi-tenant overlays MAY
+  # swap to bp-seaweedfs S3-backed media storage via the upstream
+  # chart's `media` config block.
+  persistence:
+    enabled: true
+    size: 10Gi
+
+  # ─── Ingress — Catalyst standard ───────────────────────────────────────
+  # The upstream chart renders an Ingress when `ingress.enabled: true`.
+  # Per-Sovereign overlay supplies csHosts (chat.<sovereign-fqdn>) +
+  # ClusterIssuer annotations. Default placeholder hosts so `helm
+  # template` smoke renders without `--set`.
+  ingress:
+    enabled: true
+    annotations: {}
+    csHosts: []                         # operator-supplied (e.g. ["chat.<sovereign-fqdn>"])
+    hosts: []
+    wkHosts: []
+    tls: []
+
+  # ─── Synapse main pod ──────────────────────────────────────────────────
+  synapse:
+    replicaCount: 1
+    resources:
+      requests:
+        cpu: 200m
+        memory: 512Mi
+      limits:
+        memory: 2Gi
+
+  # ─── Workers (sharding) — DEFAULT OFF ──────────────────────────────────
+  # Solo-Sovereign baseline runs Synapse monolithic. Multi-tenant
+  # overlays enable workers (and consequently bp-valkey for inter-worker
+  # signaling). Per docs/BLUEPRINT-AUTHORING.md §11.2 — DEFAULT OFF.
+  workers:
+    generic_worker:
+      enabled: false
+    federation_sender:
+      enabled: false
+    media_repository:
+      enabled: false
+
+  # ─── ServiceMonitor — upstream chart does NOT publish one ──────────────
+  # The Catalyst-overlay ServiceMonitor lives in templates/servicemonitor
+  # .yaml (gated by .Values.serviceMonitor.enabled, default false). The
+  # upstream chart sets prometheus.io/scrape annotations on the metrics
+  # port; the Catalyst overlay turns those into a proper ServiceMonitor.
+
+# ─── Catalyst-overlay knobs (consumed by templates/ in this chart) ───────
+# All DEFAULT OFF per docs/BLUEPRINT-AUTHORING.md §11.2.
+
+# Catalyst-side OIDC config — applied via the upstream chart's
+# `extraConfig.oidc_providers` block at install time. Operator's
+# per-Sovereign overlay supplies the actual issuer URL + ExternalSecret
+# holding the client secret. Default OFF until operator wires Keycloak.
+oidc:
+  enabled: true
+  idpId: "keycloak"
+  idpName: "Keycloak"
+  issuer: ""                            # operator-supplied (e.g. https://keycloak.<loc>.<sovereign-domain>/realms/<org>)
+  clientId: "matrix-synapse"
+  scopes: ["openid", "profile", "email"]
+  # ExternalSecret name carrying client_secret. Required key:
+  # OIDC_CLIENT_SECRET. Operator-supplied.
+  existingSecret: ""                    # e.g. "matrix-oidc-credentials"
+
+# Federation toggle — Catalyst-overlay marker. The actual federation
+# behaviour is gated by upstream chart values + the homeserver.yaml
+# config block; this knob is the documentation-level switch operators
+# flip when enabling per-Organization federation. DEFAULT FALSE per
+# Catalyst per-Sovereign tenancy.
+federation:
+  enabled: false
+
+# Element-Web client — separate Application Blueprint (bp-element-web,
+# slot 47). This block is a documentation-level pointer the per-
+# Sovereign overlay reads when wiring chat-web.<sovereign-fqdn>.
+elementWeb:
+  enabled: true
+  hostHint: "chat-web.<sovereign-fqdn>"
+
+# NetworkPolicy — locks the synapse pods down to the minimum egress /
+# ingress required (kube-dns, cnpg, keycloak, ingress). Default off —
+# operator opts in via per-Sovereign overlay once consumer namespaces
+# are known. Per docs/INVIOLABLE-PRINCIPLES.md #4 every selector /
+# namespace label / port is operator-tunable.
+networkPolicy:
+  enabled: false
+  cnpgNamespace: "cnpg"
+  cnpgPort: 5432
+  keycloakNamespace: "keycloak"
+  keycloakPort: 8443
+  ingressNamespace: "traefik"
+  # Federation port (only used when federation.enabled=true) — Synapse
+  # listens on 8448 for inbound federation traffic.
+  federationPort: 8448
+  # Synapse client API port.
+  clientPort: 8008
+
+# ServiceMonitor — Catalyst-overlay variant. The upstream chart does
+# NOT publish a ServiceMonitor template; this Catalyst-side template is
+# the only path for Prometheus scraping. Per docs/BLUEPRINT-AUTHORING.md
+# §11.2 — DEFAULT OFF.
+serviceMonitor:
+  enabled: false
+  interval: "30s"
+  scrapeTimeout: "10s"
+  path: "/_synapse/metrics"
+  labels: {}
+
+# HorizontalPodAutoscaler for the Synapse main Deployment. Default OFF.
+# Solo-Sovereign baseline runs Synapse monolithic with replicaCount: 1.
+# Multi-tenant overlays enable workers + HPA when room/event throughput
+# warrants. Per docs/BLUEPRINT-AUTHORING.md §11.2 — DEFAULT OFF.
+hpa:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 4
+  targetCPUUtilizationPercentage: 70
+  targetMemoryUtilizationPercentage: 80

--- a/platform/openmeter/README.md
+++ b/platform/openmeter/README.md
@@ -1,170 +1,84 @@
-# OpenMeter
+# bp-openmeter
 
-Usage metering. **Application Blueprint** (see [`docs/PLATFORM-TECH-STACK.md`](../../docs/PLATFORM-TECH-STACK.md) §4.8 — Identity & metering). Used by `bp-fingate` (Open Banking) to meter API calls per TPP for monetization; available to any Organization that wants per-API-call metering.
+Real-time CloudEvents usage metering. Catalyst Application Blueprint —
+slot 45 of the omantel-1 bootstrap-kit. See
+[`docs/PLATFORM-TECH-STACK.md`](../../docs/PLATFORM-TECH-STACK.md) §4.8
+(Identity & metering).
 
-**Status:** Accepted | **Updated:** 2026-04-27
+**Status:** Accepted | **Updated:** 2026-04-30
 
 ---
 
 ## Overview
 
-OpenMeter provides real-time usage metering:
-- CloudEvents-based ingestion
-- ClickHouse backend for analytics
-- Integration with customer billing systems
-- Real-time usage dashboards
+OpenMeter ingests CloudEvents, deterministically aggregates per-subject
+usage, and exposes an OpenAPI Query endpoint for downstream billing.
+Used by `bp-fingate` (Open Banking) to meter API calls per TPP for
+monetization, and available to any Application that needs per-event
+usage tracking.
 
----
+## Catalyst profile (omantel-1) — ClickHouse-less
 
-## Architecture
+Per [`docs/BOOTSTRAP-KIT-EXPANSION-PLAN.md`](../../docs/BOOTSTRAP-KIT-EXPANSION-PLAN.md)
+§6.4, omantel-1 ships OpenMeter without the bundled ClickHouse cluster:
 
-```mermaid
-flowchart TB
-    subgraph Sources["Event Sources"]
-        API[Open Banking API]
-        Gateway[API Gateway]
-    end
+- **Aggregation backend:** `bp-cnpg` (PostgreSQL materialized views)
+- **Event bus:** `bp-nats-jetstream` (raw event subject)
+- **Cache:** `bp-valkey` (Redis-compatible) — operator overlay supplies
+  the connection string
 
-    subgraph OpenMeter["OpenMeter"]
-        Ingest[Ingest API]
-        Process[Event Processor]
-        Query[Query API]
-    end
+The chart-level toggle that records the active profile is
+`catalystBlueprint.backend.kind` in `chart/values.yaml` (default `cnpg`).
+On a host cluster that later adds `bp-clickhouse`, the operator re-rolls
+the Application with `backend.kind: clickhouse` plus a per-Sovereign
+overlay supplying `openmeter.config.aggregation.clickhouse.address`.
 
-    subgraph Storage["Storage"]
-        Kafka[Kafka]
-        CH[ClickHouse]
-    end
+## Chart shape
 
-    subgraph Consumers["Consumers"]
-        Grafana[Grafana]
-        Billing[Customer Billing]
-    end
+```
+platform/openmeter/
+├── blueprint.yaml                     # Catalyst Blueprint CRD
+├── chart/
+│   ├── Chart.yaml                     # umbrella; deps: openmeter (OCI)
+│   ├── values.yaml                    # ClickHouse-less profile defaults
+│   └── templates/
+│       ├── _helpers.tpl
+│       ├── networkpolicy.yaml         # default OFF
+│       ├── servicemonitor.yaml        # default OFF (CRD-gated)
+│       └── hpa.yaml                   # default OFF
+├── chart/tests/observability-toggle.sh
+└── README.md
+```
 
-    API --> Ingest
-    Gateway --> Ingest
-    Ingest --> Kafka
-    Kafka --> Process
-    Process --> CH
-    Query --> CH
-    Billing --> Query
-    Grafana --> Query
+## Dependencies
+
+| Blueprint | Purpose |
+|-----------|---------|
+| `bp-cnpg` | aggregation backend (CNPG materialized views) |
+| `bp-nats-jetstream` | raw event subject |
+| `bp-cert-manager` | ingress TLS via ClusterIssuer |
+
+## Observability toggles (all default OFF)
+
+Per [`docs/BLUEPRINT-AUTHORING.md`](../../docs/BLUEPRINT-AUTHORING.md)
+§11.2, every observability surface defaults `false`. Operator opts in
+via per-cluster overlay once `bp-kube-prometheus-stack` reconciles.
+
+| Toggle | Default | Why |
+|--------|---------|-----|
+| `serviceMonitor.enabled` | `false` | `monitoring.coreos.com/v1` CRD ships with kube-prometheus-stack |
+| `networkPolicy.enabled` | `false` | Operator supplies consumer-namespace selectors per-Sovereign |
+| `hpa.enabled` | `false` | Solo-Sovereign baseline is a single API replica |
+
+## Verification
+
+```bash
+helm dependency update platform/openmeter/chart
+helm template platform/openmeter/chart | grep -E "^kind:" | sort -u
+helm lint platform/openmeter/chart
+bash platform/openmeter/chart/tests/observability-toggle.sh
 ```
 
 ---
 
-## Event Format (CloudEvents)
-
-```json
-{
-  "specversion": "1.0",
-  "type": "api.call",
-  "source": "open-banking-api",
-  "id": "uuid-here",
-  "time": "2024-01-15T10:30:00Z",
-  "subject": "tpp-12345",
-  "data": {
-    "endpoint": "/accounts",
-    "method": "GET",
-    "status_code": 200,
-    "response_time_ms": 45
-  }
-}
-```
-
----
-
-## Configuration
-
-### OpenMeter Deployment
-
-```yaml
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: openmeter
-  namespace: open-banking
-spec:
-  template:
-    spec:
-      containers:
-        - name: openmeter
-          image: openmeter/openmeter:v1.0.0
-          env:
-            - name: OPENMETER_KAFKA_BROKER
-              value: kafka-kafka-bootstrap.databases.svc:9092
-            - name: OPENMETER_CLICKHOUSE_ADDRESS
-              value: clickhouse.databases.svc:9000
-            - name: OPENMETER_POSTGRES_URL
-              valueFrom:
-                secretKeyRef:
-                  name: openmeter-db-credentials
-                  key: url
-```
-
-### Meter Definition
-
-```yaml
-meters:
-  - slug: api_calls
-    description: API call count per TPP
-    eventType: api.call
-    aggregation: COUNT
-    groupBy:
-      subject: true
-      endpoint: $.data.endpoint
-      method: $.data.method
-
-  - slug: api_latency
-    description: API latency percentiles
-    eventType: api.call
-    valueProperty: $.data.response_time_ms
-    aggregation: SUM
-    groupBy:
-      subject: true
-      endpoint: $.data.endpoint
-```
-
----
-
-## Billing Integration
-
-OpenMeter exposes usage data via its Query API. Customer billing systems consume aggregated usage for invoicing. Billing integration is customer-specific and not bundled into the platform.
-
----
-
-## Quota Checking (Real-Time)
-
-For prepaid credits, Valkey provides real-time quota checks:
-
-```mermaid
-flowchart LR
-    subgraph RealTime["Real-Time Path"]
-        API[API Gateway]
-        Valkey[Valkey]
-    end
-
-    subgraph Metering["Metering Path"]
-        OM[OpenMeter]
-        Billing[Customer Billing]
-    end
-
-    API -->|"Check quota"| Valkey
-    API -->|"Record event"| OM
-    OM -->|"Sync usage"| Billing
-    Billing -->|"Update credits"| Valkey
-```
-
----
-
-## Monitoring
-
-| Metric | Description |
-|--------|-------------|
-| `openmeter_events_ingested_total` | Total events ingested |
-| `openmeter_events_processed_total` | Events processed |
-| `openmeter_query_latency_seconds` | Query latency |
-
----
-
-*Part of [OpenOva](https://openova.io)*
+*Part of [OpenOva](https://openova.io). Closes #272.*

--- a/platform/openmeter/blueprint.yaml
+++ b/platform/openmeter/blueprint.yaml
@@ -1,0 +1,97 @@
+apiVersion: catalyst.openova.io/v1alpha1
+kind: Blueprint
+metadata:
+  name: bp-openmeter
+  labels:
+    catalyst.openova.io/category: application
+    catalyst.openova.io/section: pts-4-8-identity-and-metering
+spec:
+  version: 1.0.0
+  card:
+    title: OpenMeter
+    summary: |
+      Real-time usage metering. CloudEvents ingestion, deterministic
+      per-subject aggregation, OpenAPI Query endpoint. Used by
+      bp-fingate (Open Banking) to meter API calls per TPP for
+      monetization, and available to any Application that needs
+      per-event usage tracking. omantel-1 ships the ClickHouse-less
+      profile per docs/BOOTSTRAP-KIT-EXPANSION-PLAN.md §6.4 — backend
+      writes go to bp-cnpg (PostgreSQL) and bp-nats-jetstream (event
+      bus). Re-roll with backend.kind=clickhouse once a host cluster
+      adds bp-clickhouse.
+    icon: openmeter.svg
+    category: application
+    tags: [metering, usage, billing, cloudevents, application]
+    documentation: https://openmeter.io/docs
+    license: Apache-2.0
+  visibility: listed
+  owner:
+    team: platform
+    contact: platform@openova.io
+  configSchema:
+    type: object
+    properties:
+      backend:
+        type: object
+        description: |
+          Aggregation backend selector. Catalyst defaults to `cnpg` —
+          the ClickHouse-less profile (CNPG materialized views + a
+          JetStream subject for raw events) per
+          docs/BOOTSTRAP-KIT-EXPANSION-PLAN.md §6.4. Re-roll with
+          `clickhouse` once a host cluster adds bp-clickhouse.
+        properties:
+          kind:
+            type: string
+            enum: [cnpg, clickhouse]
+            default: cnpg
+            description: |
+              `cnpg` (default): aggregate via CNPG materialized views,
+              raw events on a JetStream subject. `clickhouse`: route
+              aggregation to an external ClickHouse cluster supplied
+              by bp-clickhouse.
+      eventBus:
+        type: object
+        properties:
+          kind:
+            type: string
+            enum: [jetstream, kafka]
+            default: jetstream
+            description: |
+              Catalyst defaults to NATS JetStream (bp-nats-jetstream).
+              The upstream OpenMeter binary speaks Kafka natively;
+              Catalyst routes via the OpenTelemetry Collector or the
+              JetStream→Kafka shim documented at
+              docs/PLATFORM-TECH-STACK.md §4.8.
+      replicas:
+        type: integer
+        default: 1
+        minimum: 1
+        maximum: 10
+      serviceMonitor:
+        type: object
+        properties:
+          enabled:
+            type: boolean
+            default: false
+            description: |
+              monitoring.coreos.com/v1 ServiceMonitor — requires the
+              Prometheus Operator CRDs from kube-prometheus-stack.
+              Per docs/BLUEPRINT-AUTHORING.md §11.2 default false;
+              operator opts in via per-cluster overlay (issue #182).
+  placementSchema:
+    modes: [single-region, active-active]
+    default: single-region
+  manifests:
+    chart: ./chart
+  depends:
+    - blueprint: bp-cnpg              # aggregation backend (ClickHouse-less profile)
+      version: ^1
+    - blueprint: bp-nats-jetstream    # raw-event subject (ClickHouse-less profile)
+      version: ^1
+    - blueprint: bp-cert-manager      # ingress TLS
+      version: ^1
+  upgrades:
+    from: ["0.x"]
+  observability:
+    metrics: prometheus
+    logs: stdout

--- a/platform/openmeter/chart/Chart.yaml
+++ b/platform/openmeter/chart/Chart.yaml
@@ -1,0 +1,44 @@
+apiVersion: v2
+name: bp-openmeter
+version: 1.0.0
+appVersion: "1.0.0-beta.213"
+description: |
+  Catalyst Blueprint umbrella chart for OpenMeter — real-time CloudEvents
+  usage metering. Depends on the upstream `openmeter` chart published as
+  an OCI artifact at `oci://ghcr.io/openmeterio/helm-charts/openmeter`,
+  pulled in as a Helm subchart so `helm dependency build` bundles the
+  upstream payload into this Blueprint's OCI artifact (per
+  docs/BLUEPRINT-AUTHORING.md §11.1 — hollow charts forbidden).
+
+  omantel-1 ships the ClickHouse-less profile per
+  docs/BOOTSTRAP-KIT-EXPANSION-PLAN.md §6.4. The upstream chart's bundled
+  ClickHouse / Kafka / Postgres / Redis / Svix subcharts are all DISABLED
+  in `values.yaml` because Catalyst supplies CNPG (postgres), JetStream
+  (event bus), and Valkey (redis-compat) at the platform tier. The
+  chart-level `backend.kind` knob (default `cnpg`) records the active
+  profile so observability/audit pipelines can report it; the upstream
+  binary's `aggregation.clickhouse.address` is left blank — a per-Sovereign
+  overlay supplies it once a ClickHouse cluster exists (re-roll with
+  `backend.kind: clickhouse`).
+
+  Catalyst overlay templates in `templates/` (NetworkPolicy, ServiceMonitor,
+  HPA — all default OFF per docs/BLUEPRINT-AUTHORING.md §11.2) sit alongside
+  the upstream subchart and Helm renders both at install time.
+  Catalyst-curated values flow into the upstream subchart under the
+  `openmeter:` key in values.yaml.
+type: application
+keywords: [catalyst, blueprint, openmeter, metering, usage, billing, cloudevents]
+maintainers:
+  - name: OpenOva Catalyst
+    email: catalyst@openova.io
+
+# Upstream chart pulled in as a Helm subchart so `helm dependency build`
+# bundles it into the OCI artifact. Pinned to openmeterio/openmeter
+# 1.0.0-beta.213 (matches platform/openmeter/blueprint.yaml + values.yaml
+# `catalystBlueprint.upstream.version`). Per
+# docs/INVIOLABLE-PRINCIPLES.md #4 (never hardcode) the version is
+# operator-bumpable via PR + Blueprint release.
+dependencies:
+  - name: openmeter
+    version: "1.0.0-beta.213"
+    repository: "oci://ghcr.io/openmeterio/helm-charts"

--- a/platform/openmeter/chart/templates/_helpers.tpl
+++ b/platform/openmeter/chart/templates/_helpers.tpl
@@ -1,0 +1,22 @@
+{{/*
+Catalyst-curated helpers for bp-openmeter. Mirrors the conventions used
+by bp-harbor / bp-valkey / bp-cnpg / bp-librechat.
+*/}}
+
+{{- define "bp-openmeter.fullname" -}}
+{{- default "openmeter" .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "bp-openmeter.labels" -}}
+app.kubernetes.io/name: {{ include "bp-openmeter.fullname" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+catalyst.openova.io/blueprint: bp-openmeter
+catalyst.openova.io/component: openmeter
+catalyst.openova.io/backend: {{ .Values.catalystBlueprint.backend.kind | quote }}
+{{- end -}}
+
+{{- define "bp-openmeter.selectorLabels" -}}
+app.kubernetes.io/name: openmeter
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}

--- a/platform/openmeter/chart/templates/hpa.yaml
+++ b/platform/openmeter/chart/templates/hpa.yaml
@@ -1,0 +1,45 @@
+{{- /*
+HorizontalPodAutoscaler — Catalyst overlay for the OpenMeter API
+Deployment. DEFAULT FALSE.
+
+The upstream openmeter chart does not ship an HPA. Catalyst lands one
+behind a single operator toggle so multi-tenant Sovereigns can scale
+ingest throughput without diverging from the wrapper. Solo-Sovereigns
+stay at the single-replica baseline declared by `openmeter.api.replicaCount`.
+
+Per docs/INVIOLABLE-PRINCIPLES.md #4 every knob (min/max replicas, CPU/
+memory targets, target Deployment name) is operator-tunable.
+*/}}
+{{- if .Values.hpa.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: bp-openmeter-api
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "bp-openmeter.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ default (printf "%s-api" (include "bp-openmeter.fullname" .)) .Values.hpa.targetDeploymentName }}
+  minReplicas: {{ .Values.hpa.minReplicas }}
+  maxReplicas: {{ .Values.hpa.maxReplicas }}
+  metrics:
+    {{- if .Values.hpa.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.hpa.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.hpa.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.hpa.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/platform/openmeter/chart/templates/networkpolicy.yaml
+++ b/platform/openmeter/chart/templates/networkpolicy.yaml
@@ -1,0 +1,79 @@
+{{- /*
+NetworkPolicy — Catalyst overlay locking the openmeter pods down to the
+minimum egress / ingress required for the ClickHouse-less profile.
+
+Egress targets:
+  - Cluster DNS (kube-system) — service discovery for CNPG + JetStream.
+  - bp-cnpg cluster (aggregation backend on the cnpg profile) on port 5432.
+  - bp-nats-jetstream (raw event subject) on port 4222.
+
+Ingress is locked to:
+  - Ingress controller namespace (operator-supplied label) — terminates
+    public OpenMeter Ingest + Query API.
+  - Same-namespace traffic between API + worker pods.
+
+DEFAULT FALSE per Catalyst overlay convention — operator turns this on
+via per-Sovereign overlay once consumer namespaces / ClickHouse cluster
+endpoints (when re-rolled with backend.kind=clickhouse) are known. Per
+docs/INVIOLABLE-PRINCIPLES.md #4 every selector / namespace / port is
+operator-tunable through `networkPolicy.*`.
+*/}}
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: bp-openmeter
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "bp-openmeter.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: openmeter
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    # Same-namespace traffic between API + worker pods.
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Release.Namespace }}
+    # Ingress controller — terminates the public Ingest + Query API.
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.networkPolicy.ingressNamespace | default "traefik" }}
+  egress:
+    # Cluster DNS — openmeter resolves CNPG + JetStream services.
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    # Same-namespace egress (API → workers, workers → sink, etc.).
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Release.Namespace }}
+    # CNPG aggregation backend (ClickHouse-less profile).
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.networkPolicy.cnpgNamespace | default "cnpg" }}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.networkPolicy.cnpgPort | default 5432 }}
+    # NATS JetStream — raw event subject (ClickHouse-less profile).
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.networkPolicy.jetstreamNamespace | default "nats-jetstream" }}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.networkPolicy.jetstreamPort | default 4222 }}
+{{- end }}

--- a/platform/openmeter/chart/templates/servicemonitor.yaml
+++ b/platform/openmeter/chart/templates/servicemonitor.yaml
@@ -1,0 +1,43 @@
+{{- /*
+ServiceMonitor — Catalyst-overlay variant for OpenMeter.
+
+The upstream openmeter chart does NOT publish a ServiceMonitor template,
+so this Catalyst-side template is the only path for Prometheus scraping.
+DEFAULT FALSE per docs/BLUEPRINT-AUTHORING.md §11.2 — Prometheus Operator
+(monitoring.coreos.com/v1) is NOT in the bootstrap-kit prior to slot 25
+(kube-prometheus-stack), so a ServiceMonitor shipped enabled-by-default
+would generate Helm install errors on a Sovereign that hasn't reached
+Phase 2 yet.
+
+Defense in depth: the values toggle (.Values.serviceMonitor.enabled) is
+the operator switch; the Capabilities gate skips the resource entirely
+on a Sovereign that has not yet reconciled the CRD, so flipping the
+toggle on a too-early Sovereign cannot break the bp-openmeter reconcile.
+
+Per docs/INVIOLABLE-PRINCIPLES.md #4 every knob (interval, namespace,
+labels, scrape path) is operator-tunable.
+*/}}
+{{- if and .Values.serviceMonitor.enabled (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: bp-openmeter
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "bp-openmeter.labels" . | nindent 4 }}
+    {{- with .Values.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: openmeter
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  endpoints:
+    - port: http
+      path: {{ .Values.serviceMonitor.path | quote }}
+      interval: {{ .Values.serviceMonitor.interval | quote }}
+      scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout | quote }}
+{{- end }}

--- a/platform/openmeter/chart/tests/observability-toggle.sh
+++ b/platform/openmeter/chart/tests/observability-toggle.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# bp-openmeter observability-toggle integration test
+# (docs/BLUEPRINT-AUTHORING.md §11.2).
+#
+# Verifies the Catalyst rule that every observability toggle in a
+# Blueprint's chart/values.yaml MUST default to false:
+#   - default `helm template` produces zero monitoring.coreos.com/v1
+#     resources;
+#   - opt-in render with serviceMonitor.enabled=true produces a
+#     ServiceMonitor (proves the toggle is wired);
+#   - explicit-off render is clean.
+#
+# Usage: bash tests/observability-toggle.sh [CHART_DIR]
+#   CHART_DIR defaults to the parent directory of this script.
+
+set -euo pipefail
+
+CHART_DIR="${1:-$(cd "$(dirname "$0")/.." && pwd)}"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+cd "$CHART_DIR"
+
+# Skip helm dep build when charts/ is already vendored (CI populates it
+# before this step runs, and re-running on CI without `helm repo add`
+# fails). Mirrors the bp-cilium / bp-valkey pattern.
+if [ ! -d charts ] || [ -z "$(ls -A charts 2>/dev/null)" ]; then
+  helm dependency build >/dev/null
+fi
+
+# ── Case 1: default render must NOT contain monitoring.coreos.com ────────
+echo "[observability-toggle] Case 1: default render produces no ServiceMonitor / PrometheusRule"
+helm template smoke-openmeter . > "$TMP/default.yaml"
+if grep -qE "^kind: (ServiceMonitor|PrometheusRule)$" "$TMP/default.yaml"; then
+  echo "FAIL: default render of bp-openmeter contains a ServiceMonitor/PrometheusRule CR." >&2
+  echo "      docs/BLUEPRINT-AUTHORING.md §11.2 forbids this — observability toggles must default false." >&2
+  grep -nE "^kind: (ServiceMonitor|PrometheusRule)$" "$TMP/default.yaml" >&2
+  exit 1
+fi
+if grep -q "monitoring.coreos.com" "$TMP/default.yaml"; then
+  echo "FAIL: default render of bp-openmeter contains monitoring.coreos.com references." >&2
+  grep -n "monitoring.coreos.com" "$TMP/default.yaml" | head -5 >&2
+  exit 1
+fi
+echo "  PASS"
+
+# ── Case 2: opt-in (serviceMonitor.enabled=true) renders cleanly ─────────
+echo "[observability-toggle] Case 2: opt-in (serviceMonitor.enabled=true) renders cleanly"
+if ! helm template smoke-openmeter . \
+    --api-versions monitoring.coreos.com/v1 \
+    --set serviceMonitor.enabled=true \
+    > "$TMP/optin.yaml" 2> "$TMP/optin.err"; then
+  echo "FAIL: opt-in render failed:" >&2
+  cat "$TMP/optin.err" >&2
+  exit 1
+fi
+if ! grep -qE "^kind: ServiceMonitor$" "$TMP/optin.yaml"; then
+  echo "FAIL: opt-in render did NOT produce a ServiceMonitor — the toggle is broken." >&2
+  exit 1
+fi
+echo "  PASS"
+
+# ── Case 3: explicit-off render must be clean ───────────────────────────
+echo "[observability-toggle] Case 3: explicit serviceMonitor.enabled=false renders cleanly"
+if ! helm template smoke-openmeter . \
+    --set serviceMonitor.enabled=false \
+    > "$TMP/off.yaml" 2> "$TMP/off.err"; then
+  echo "FAIL: explicit-off render failed:" >&2
+  cat "$TMP/off.err" >&2
+  exit 1
+fi
+if grep -qE "^kind: (ServiceMonitor|PrometheusRule)$" "$TMP/off.yaml"; then
+  echo "FAIL: explicit-off render still contains a ServiceMonitor/PrometheusRule CR." >&2
+  exit 1
+fi
+echo "  PASS"
+
+# ── Case 4: ClickHouse-less profile — no ClickHouse / Kafka subchart leaks ─
+# omantel-1 ships the ClickHouse-less profile per
+# docs/BOOTSTRAP-KIT-EXPANSION-PLAN.md §6.4. The default render must NOT
+# include any of the upstream chart's bundled ClickHouse / Kafka /
+# Postgres / Redis / Svix subchart resources.
+echo "[observability-toggle] Case 4: ClickHouse-less profile — no bundled subcharts leak"
+for kind_pattern in "clickhouse.altinity.com" "kind: Kafka$" "image: bitnami/kafka" "kind: ClickHouseInstallation"; do
+  if grep -qE "$kind_pattern" "$TMP/default.yaml"; then
+    echo "FAIL: default render leaks ClickHouse/Kafka resource matching '$kind_pattern' — the ClickHouse-less profile is broken." >&2
+    grep -nE "$kind_pattern" "$TMP/default.yaml" | head -3 >&2
+    exit 1
+  fi
+done
+echo "  PASS"
+
+echo "[observability-toggle] All bp-openmeter observability-toggle gates green."

--- a/platform/openmeter/chart/values.yaml
+++ b/platform/openmeter/chart/values.yaml
@@ -1,0 +1,165 @@
+# Catalyst Blueprint umbrella metadata — the upstream openmeter chart is
+# resolved as a Helm subchart via Chart.yaml `dependencies:`. This
+# values.yaml carries:
+#   1. The catalystBlueprint metadata block (provenance + version + the
+#      ClickHouse-less profile flag) so observability/audit pipelines can
+#      inspect the artifact and report which upstream chart + version is
+#      bundled and which aggregation backend is active.
+#   2. The upstream subchart values overlay under the `openmeter:` key
+#      (umbrella-chart convention — the dependency name from Chart.yaml is
+#      the values namespace).
+#   3. Catalyst-overlay knobs (networkPolicy, serviceMonitor, hpa) — all
+#      DEFAULT OFF per docs/BLUEPRINT-AUTHORING.md §11.2.
+#
+# Per docs/INVIOLABLE-PRINCIPLES.md #4 (never hardcode), every operationally-
+# meaningful value is configurable; cluster overlays in clusters/<sovereign>/
+# may override any of these without rebuilding the Blueprint OCI artifact.
+
+catalystBlueprint:
+  upstream:
+    chart: openmeter
+    version: "1.0.0-beta.213"
+    repo: "oci://ghcr.io/openmeterio/helm-charts"
+  # ClickHouse-less profile flag — per docs/BOOTSTRAP-KIT-EXPANSION-PLAN.md
+  # §6.4. omantel-1 (and every solo Sovereign that has not added
+  # bp-clickhouse) runs `cnpg`: aggregation against CNPG materialized
+  # views, raw events on a JetStream subject. Re-roll with `clickhouse`
+  # once a host cluster adds bp-clickhouse.
+  backend:
+    kind: cnpg                        # cnpg | clickhouse
+  eventBus:
+    kind: jetstream                   # jetstream | kafka
+
+# ─── Upstream chart values (subchart key: openmeter) ─────────────────────
+# `helm dependency build` resolves the upstream as a subchart; values here
+# under the `openmeter:` key flow into that subchart unchanged.
+openmeter:
+
+  image:
+    repository: ghcr.io/openmeterio/openmeter
+    pullPolicy: IfNotPresent
+    # tag pinned via the chart appVersion (1.0.0-beta.213); operator
+    # overlays MAY override per docs/INVIOLABLE-PRINCIPLES.md #4.
+    tag: ""
+
+  # ─── Bundled subcharts — DISABLED for the ClickHouse-less profile ──────
+  #
+  # Catalyst supplies these at the platform tier; the upstream chart's
+  # bundled bitnami/clickhouse-operator/svix images are not co-installed.
+  # Per docs/BOOTSTRAP-KIT-EXPANSION-PLAN.md §6.4: omantel-1 routes
+  # aggregation into bp-cnpg (PostgreSQL) and raw events into a
+  # bp-nats-jetstream subject. Where the upstream binary still expects a
+  # ClickHouse address (the OpenMeter binary today lacks a native cnpg
+  # aggregation driver), the per-Sovereign overlay supplies the endpoint
+  # via `openmeter.config.aggregation.clickhouse.address`. On hosts
+  # without bp-clickhouse, the OpenMeter pods stay Pending/CrashLoopBackOff
+  # at the application layer — that is the documented App-tier deferral
+  # per §6.4 and the Catalyst projector reports it to the operator.
+
+  clickhouse:
+    enabled: false
+    operator:
+      install: false
+
+  kafka:
+    enabled: false
+
+  postgresql:
+    enabled: false
+
+  redis:
+    enabled: false
+
+  svix:
+    enabled: false
+
+  # ─── OpenMeter binary configuration ────────────────────────────────────
+  #
+  # The upstream chart merges `.Values.openmeter.config` over the
+  # auto-generated overrides for the bundled subcharts. Because every
+  # bundled subchart is disabled above, the operator MUST supply the
+  # actual endpoints via per-Sovereign overlay. Defaults below are
+  # intentionally placeholders that yield a successful `helm template`
+  # smoke render — at install time the operator overlays:
+  #
+  #   openmeter:
+  #     config:
+  #       aggregation:
+  #         clickhouse:
+  #           address: <host>:<port>           # supplied per-Sovereign
+  #       postgres:
+  #         url: postgres://<cnpg-user>:<pw>@<cnpg-svc>:5432/openmeter
+  #       ingest:
+  #         kafka:
+  #           broker: <jetstream-shim>:9092    # bp-nats-jetstream front
+  #       sink:
+  #         kafka:
+  #           brokers: <jetstream-shim>:9092
+  #
+  # Per docs/INVIOLABLE-PRINCIPLES.md #4 nothing is hardcoded — the
+  # default below is the empty config; the chart still renders. Operator
+  # overlays inject the real endpoints.
+  config: {}
+
+  # ─── API + worker replicas — solo-Sovereign baseline ───────────────────
+  api:
+    replicaCount: 1
+  balanceWorker:
+    replicaCount: 1
+  notificationService:
+    replicaCount: 1
+  sinkWorker:
+    replicaCount: 1
+
+  # ─── Service ──────────────────────────────────────────────────────────
+  service:
+    type: ClusterIP
+    port: 80
+
+  # ─── Ingress — DEFAULT OFF (per-Sovereign overlay enables) ────────────
+  ingress:
+    enabled: false
+
+  # ─── Resource baseline ─────────────────────────────────────────────────
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      memory: 1Gi
+
+# ─── Catalyst-overlay knobs (consumed by templates/ in this chart) ───────
+# All DEFAULT OFF per docs/BLUEPRINT-AUTHORING.md §11.2.
+
+# NetworkPolicy — locks the openmeter pods down to the minimum egress
+# required (CNPG, JetStream, kube-dns). Default off — operator opts in
+# via per-Sovereign overlay once consumer namespaces are known.
+networkPolicy:
+  enabled: false
+  cnpgNamespace: "cnpg"
+  jetstreamNamespace: "nats-jetstream"
+  jetstreamPort: 4222
+  cnpgPort: 5432
+  ingressNamespace: "traefik"
+
+# ServiceMonitor — Catalyst-overlay variant. The upstream chart does not
+# publish a ServiceMonitor; this template is the forward-compatibility
+# guard that lands the metrics scraping behind a single operator toggle.
+# Per docs/BLUEPRINT-AUTHORING.md §11.2 — DEFAULT OFF.
+serviceMonitor:
+  enabled: false
+  interval: "30s"
+  scrapeTimeout: "10s"
+  path: "/metrics"
+  labels: {}
+
+# HorizontalPodAutoscaler for the OpenMeter API Deployment. Default
+# OFF — solo Sovereigns stay at the single-replica baseline. Per-cluster
+# overlays enable HPA on multi-tenant Sovereigns where ingest throughput
+# needs autoscaling (kube-prometheus-stack + metrics-server required).
+hpa:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 5
+  targetCPUUtilizationPercentage: 70
+  targetMemoryUtilizationPercentage: 80


### PR DESCRIPTION
## Summary

W2.5.F — three Catalyst Blueprint umbrella charts under `platform/{openmeter,livekit,matrix}/`. Each declares its upstream chart under `Chart.yaml` `dependencies:` so `helm dependency build` bundles the upstream payload into the published OCI artifact (per `docs/BLUEPRINT-AUTHORING.md` §11.1 — hollow charts forbidden, CI-enforced by issue #181). Catalyst-overlay templates (NetworkPolicy / ServiceMonitor / HPA) all default OFF per `docs/BLUEPRINT-AUTHORING.md` §11.2.

## Per-chart kind summary

### bp-openmeter (closes #272)
- **Default `helm template` kinds:** `ConfigMap`, `Deployment`, `Service`, `ServiceAccount`
- **Upstream:** `openmeter 1.0.0-beta.213` (`oci://ghcr.io/openmeterio/helm-charts`)
- **ClickHouse-less profile** per `docs/BOOTSTRAP-KIT-EXPANSION-PLAN.md` §6.4. Bundled `clickhouse / kafka / postgresql / redis / svix` subcharts all DISABLED — Catalyst supplies CNPG (postgres), JetStream (event bus), Valkey (redis-compat) at the platform tier. Chart-level toggle `catalystBlueprint.backend.kind` (default `cnpg`) records the active profile. Operator re-rolls with `backend.kind: clickhouse` once a host cluster adds `bp-clickhouse`.

### bp-livekit (closes #273)
- **Default `helm template` kinds:** `ConfigMap`, `Deployment`, `Service`, `ServiceAccount`
- **Upstream:** `livekit-server 1.9.0` (`https://helm.livekit.io`)
- **bp-stunner integration** — bundled co-located TURN server is OFF; per-Sovereign overlay points the LiveKit TURN config at the stunner UDP-gateway Service. RTC UDP port range `50000-60000` (matches the Hetzner firewall rule the per-Sovereign overlay opens). NetworkPolicy template documents that hostNetwork mode means pod-level policies do NOT cover the SFU port range — the firewall is the load-bearing control. `blueprint.yaml` `depends:` declares `bp-stunner + bp-cert-manager + bp-valkey`.

### bp-matrix (closes #274)
- **Default `helm template` kinds:** `ConfigMap`, `Deployment`, `Ingress`, `Job`, `PersistentVolumeClaim`, `Pod`, `Role`, `RoleBinding`, `Secret`, `Service`, `ServiceAccount`
- **Upstream:** `matrix-synapse 3.12.25` (`https://ananace.gitlab.io/charts`) — the most actively maintained community Synapse chart (`element-hq` does not publish a first-party Helm chart)
- **Per-Sovereign tenancy default — federation OFF.** Operator overlays flip it on per-Organization. Catalyst overlay NetworkPolicy gates the federation port (8448) on `federation.enabled` — verified by Case 5 of the observability-toggle test. Postgres via `bp-cnpg externalPostgresql`; OIDC SSO via `bp-keycloak`; bundled `bitnami/postgresql + redis` subcharts both disabled. Element-Web is a separate Application Blueprint (`bp-element-web`, slot 47).

## Lint

```
$ for c in openmeter livekit matrix; do helm lint platform/$c/chart; done
==> Linting platform/openmeter/chart
[INFO] Chart.yaml: icon is recommended
1 chart(s) linted, 0 chart(s) failed
==> Linting platform/livekit/chart
[INFO] Chart.yaml: icon is recommended
1 chart(s) linted, 0 chart(s) failed
==> Linting platform/matrix/chart
[INFO] Chart.yaml: icon is recommended
1 chart(s) linted, 0 chart(s) failed
```

## Observability-toggle tests

Each chart enforces the Catalyst contract from `docs/BLUEPRINT-AUTHORING.md` §11.2:

| Case | Assertion |
|---|---|
| 1 | default render → zero `monitoring.coreos.com/v1` resources |
| 2 | `--set serviceMonitor.enabled=true --api-versions monitoring.coreos.com/v1` → renders a ServiceMonitor |
| 3 | explicit `serviceMonitor.enabled=false` render is clean |
| 4 (openmeter) | ClickHouse-less profile — no `clickhouse.altinity.com` / Kafka resources leak into default render |
| 4 (livekit) | upstream `livekit-server.serviceMonitor.create` defaults false |
| 4 (matrix) | default render carries an empty `federation_domain_whitelist` (per-Sovereign tenancy default) |
| 5 (matrix) | `--set federation.enabled=true networkPolicy.enabled=true` opens port 8448 in the Catalyst NetworkPolicy |

All gates green for all three charts.

## Test plan

- [x] `helm dependency update` — upstream subcharts bundle into `chart/charts/<dep>-<ver>.tgz` for all three (hollow-chart guard precondition)
- [x] `helm template platform/<c>/chart | grep -E "^kind:" | sort -u` — kind summary above
- [x] `helm lint platform/<c>/chart` — clean for all three
- [x] `bash platform/<c>/chart/tests/observability-toggle.sh` — all gates green for all three

Closes #272
Closes #273
Closes #274