### PR TITLE
fix: correct sme-services/kustomization.yaml corrupted in #297

### DIFF
--- a/products/catalyst/chart/templates/sme-services/kustomization.yaml
+++ b/products/catalyst/chart/templates/sme-services/kustomization.yaml
@@ -1,1 +1,17 @@
-fatal: path 'products/catalyst/chart/templates/sme-services/kustomization.yaml' exists on disk, but not in 'f4a83a27^'
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - configmap.yaml
+  - serviceaccounts.yaml
+  - auth.yaml
+  - catalog.yaml
+  - gateway.yaml
+  - tenant.yaml
+  - domain.yaml
+  - billing.yaml
+  - provisioning.yaml
+  - notification.yaml
+  - marketplace.yaml
+  - console.yaml
+  - admin.yaml
+  - ingress.yaml


### PR DESCRIPTION
PR #297 captured a git stderr error into this file. Kustomize chokes with "unknown field 'fatal'" so contabo flux-system/catalyst-platform Kustomization has been wedged since 16:16 UTC, blocking the catalyst-ui pod roll AND the cert-manager TLS termination ingress.

This is a 14-line correct kustomization.yaml — same content as before PR #246 deleted it.