### PR TITLE
fix: restore templates/kustomization.yaml — PR #246 deleted it, blocks contabo Flux

### DIFF
--- a/products/catalyst/chart/.helmignore
+++ b/products/catalyst/chart/.helmignore
@@ -8,6 +8,7 @@
 
 # Contabo-mkt only — applied by contabo's Flux Kustomization as raw YAML.
 # Excluded from Sovereign chart packaging (Sovereigns use Cilium gateway, no Traefik).
+templates/kustomization.yaml
 templates/ingress.yaml
 templates/ingress-console-tls.yaml
 templates/sme-services/

--- a/products/catalyst/chart/templates/kustomization.yaml
+++ b/products/catalyst/chart/templates/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: catalyst
+resources:
+  - ui-deployment.yaml
+  - ui-service.yaml
+  - api-deployment.yaml
+  - api-deployments-pvc.yaml
+  - api-service.yaml
+  - ingress.yaml
+  - ingress-console-tls.yaml

--- a/products/catalyst/chart/templates/sme-services/kustomization.yaml
+++ b/products/catalyst/chart/templates/sme-services/kustomization.yaml
@@ -1,1 +1,17 @@
-fatal: path 'products/catalyst/chart/templates/sme-services/kustomization.yaml' exists on disk, but not in 'f4a83a27^'
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - configmap.yaml
+  - serviceaccounts.yaml
+  - auth.yaml
+  - catalog.yaml
+  - gateway.yaml
+  - tenant.yaml
+  - domain.yaml
+  - billing.yaml
+  - provisioning.yaml
+  - notification.yaml
+  - marketplace.yaml
+  - console.yaml
+  - admin.yaml
+  - ingress.yaml


### PR DESCRIPTION
PR #301 should have included this file but the push only had the sme-services change.

This adds templates/kustomization.yaml (with `namespace: catalyst`) — without it, contabo's Flux Kustomization fails: `Service/catalyst-api namespace not specified`.

Also adds the file to .helmignore so Sovereigns don't process it as a Helm template.