### PR TITLE
fix(jobs): JobDetail uses real exec id; bridge captures raw helm-controller logs (#305)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/jobs/helmwatch_bridge.go
+++ b/products/catalyst/bootstrap/api/internal/jobs/helmwatch_bridge.go
@@ -56,6 +56,14 @@ const (
 	HelmStateFailed     = "failed"
 )
 
+// Phase strings for provisioner.Event routing — duplicated here to
+// avoid the same import-cycle hazard as the HelmState* consts. Kept in
+// lockstep with helmwatch.PhaseComponent / PhaseComponentLog.
+const (
+	phaseComponent    = "component"
+	phaseComponentLog = "component-log"
+)
+
 // Bridge holds the per-deployment cursor the helmwatch consumer needs:
 // which Execution is currently active for which Job. The cursor is
 // memory-only and is discarded on Pod restart — a resumed Phase-1
@@ -240,25 +248,33 @@ func (b *Bridge) SeedJobsFromInformerList(seeds []InformerSeed) (jobsWritten, ex
 		// for every component it covers.
 		b.lastState[comp] = s.State
 
-		// Non-terminal seed: just the Job row, no Execution. The watch
-		// will allocate one when the next transition fires through
-		// OnHelmReleaseEvent.
-		if !isTerminalHelmState(s.State) {
+		// "Pending" seeds remain Job-only: helm-controller has not yet
+		// started reconciling the HR, so allocating an Execution would
+		// leave an empty NDJSON file and confuse the GitLab-CI viewer.
+		// The next transition fires through OnHelmReleaseEvent which
+		// allocates the Execution at the pending → non-pending edge.
+		if s.State == HelmStatePending {
 			continue
 		}
 
-		// Terminal seed: allocate at most one Execution + emit the
-		// synthetic log line. The "already has an Execution" check
-		// reads the persisted Job back so a previous SeedJobsFromInformerList
-		// call (or an OnHelmReleaseEvent run that already allocated)
-		// does not get duplicated. This is what makes the method safe
-		// to call on every helmwatch start.
+		// installing / degraded / installed / failed all need a
+		// non-empty Execution so the FE log viewer has a row to
+		// deep-link to. Idempotency: if the persisted Job already has
+		// a LatestExecutionID, reuse it as the active cursor — the
+		// terminal-finish branch below is gated on a fresh allocation.
 		job, _, getErr := b.store.GetJob(b.deploymentID, jobID)
 		if getErr == nil && job.LatestExecutionID != "" {
 			// Already has an Execution from a prior seed or from a
-			// transition emitted earlier in the same Pod's life —
-			// nothing more to do.
-			b.activeExecID[comp] = "" // cursor cleared because terminal
+			// transition emitted earlier in the same Pod's life. For
+			// non-terminal states we keep the cursor live so subsequent
+			// raw-log forwards land on the same Execution; for terminal
+			// states we clear the cursor (the Execution has already
+			// been finished by the prior call).
+			if isTerminalHelmState(s.State) {
+				b.activeExecID[comp] = ""
+			} else {
+				b.activeExecID[comp] = job.LatestExecutionID
+			}
 			continue
 		}
 
@@ -275,10 +291,10 @@ func (b *Bridge) SeedJobsFromInformerList(seeds []InformerSeed) (jobsWritten, ex
 		}
 		executionsSeeded++
 
-		// One synthetic log line so the GitLab-CI viewer renders a
-		// non-empty Executions tab. Format documented at the call
-		// site so a future grep on production logs surfaces every
-		// seeded execution unambiguously.
+		// Synthetic anchor line so the viewer renders a non-empty
+		// Executions tab even when no helm-controller log lines have
+		// been forwarded yet. The raw lines from the logtailer append
+		// after this anchor as they arrive.
 		message := strings.TrimSpace(s.Message)
 		line := "[seeded] state=" + s.State + " at " + t.Format(time.RFC3339)
 		if message != "" {
@@ -287,6 +303,8 @@ func (b *Bridge) SeedJobsFromInformerList(seeds []InformerSeed) (jobsWritten, ex
 		level := LevelInfo
 		if s.State == HelmStateFailed {
 			level = LevelError
+		} else if s.State == HelmStateDegraded {
+			level = LevelWarn
 		}
 		if appendErr := b.store.AppendLogLines(b.deploymentID, exec.ID, []LogLine{{
 			Timestamp: t,
@@ -296,24 +314,25 @@ func (b *Bridge) SeedJobsFromInformerList(seeds []InformerSeed) (jobsWritten, ex
 			return jobsWritten, executionsSeeded, appendErr
 		}
 
-		// Flip the Execution + parent Job into the right terminal
-		// status. This mirrors what OnHelmReleaseEvent does on a
-		// pending → installed/failed transition; the only difference
-		// is we already wrote the synthetic line so the FinishExecution
-		// call only needs to stamp the timestamps + status.
-		final := StatusSucceeded
-		if s.State == HelmStateFailed {
-			final = StatusFailed
+		// Terminal seeds: stamp Execution + Job with the terminal
+		// status. Non-terminal seeds (installing / degraded) leave
+		// the Execution open so OnHelmReleaseEvent + OnRawComponentLog
+		// can keep appending until the HR reaches a terminal state.
+		if isTerminalHelmState(s.State) {
+			final := StatusSucceeded
+			if s.State == HelmStateFailed {
+				final = StatusFailed
+			}
+			if finishErr := b.store.FinishExecution(b.deploymentID, exec.ID, final, t); finishErr != nil {
+				return jobsWritten, executionsSeeded, finishErr
+			}
+			b.activeExecID[comp] = ""
+		} else {
+			// Keep the cursor pointing at the open Execution so
+			// downstream raw-log lines append here. OnHelmReleaseEvent
+			// will close it when the terminal transition arrives.
+			b.activeExecID[comp] = exec.ID
 		}
-		if finishErr := b.store.FinishExecution(b.deploymentID, exec.ID, final, t); finishErr != nil {
-			return jobsWritten, executionsSeeded, finishErr
-		}
-
-		// The cursor is cleared because the seed has driven the Job
-		// to a terminal state. A future Day-2 retry that re-emits a
-		// "running" event will allocate a fresh Execution row, which
-		// is the documented per-attempt model.
-		b.activeExecID[comp] = ""
 	}
 	return jobsWritten, executionsSeeded, nil
 }
@@ -414,19 +433,140 @@ func (b *Bridge) OnHelmReleaseEvent(componentID, state, level, message string, t
 	return nil
 }
 
-// OnProvisionerEvent is a convenience adapter: the handler's emit
-// path passes provisioner.Event (the same struct the SSE stream
-// carries). Only PhaseComponent events are forwarded — Phase-0 OpenTofu
-// events have no Job analogue and fall through silently.
+// OnProvisionerEvent is the adapter the handler's emit path calls with
+// every provisioner.Event the helmwatch.Watcher emits. Two phase
+// classes have a Job/Execution analogue:
 //
-// The function is allocation-light: it builds no event copies, just
-// translates strings.
+//   - Phase=="component"     — HelmRelease state transition. Routes to
+//     OnHelmReleaseEvent which upserts the Job, allocates an Execution
+//     on the first non-pending edge, and closes the Execution on
+//     terminal transitions.
+//   - Phase=="component-log" — raw helm-controller log line tagged
+//     with the bp-* HR it relates to. Routes to OnRawComponentLog
+//     which appends the line verbatim to the active Execution so the
+//     GitLab-CI-style viewer renders the full helm-controller stdout
+//     for the install attempt.
+//
+// Phase-0 OpenTofu events ("phase-0", "tofu-init", etc.) have no
+// component-Job analogue and fall through silently.
 func (b *Bridge) OnProvisionerEvent(ev provisioner.Event) error {
-	if ev.Phase != "component" || ev.Component == "" || ev.State == "" {
+	if ev.Component == "" {
 		return nil
 	}
 	t := parseEventTime(ev.Time)
-	return b.OnHelmReleaseEvent(ev.Component, ev.State, ev.Level, ev.Message, t)
+	switch ev.Phase {
+	case phaseComponent:
+		if ev.State == "" {
+			return nil
+		}
+		return b.OnHelmReleaseEvent(ev.Component, ev.State, ev.Level, ev.Message, t)
+	case phaseComponentLog:
+		return b.OnRawComponentLog(ev.Component, ev.Level, ev.Message, t)
+	}
+	return nil
+}
+
+// OnRawComponentLog appends a single raw helm-controller log line to
+// the active Execution for the given component. The line is the
+// helmwatch logtailer's stdout payload verbatim — typically a logr
+// text or structured-JSON record from helm-controller pinned to the
+// matching `helmrelease="flux-system/bp-<name>"` token.
+//
+// Resolution policy when no active Execution is recorded for the
+// component:
+//
+//   1. If the persisted Job has a non-empty LatestExecutionID AND that
+//      Execution is still running, the line lands there. Covers the
+//      "Pod restart wiped the in-memory cursor" path.
+//   2. If the persisted Job is non-terminal but has no Execution yet
+//      (e.g. seed wrote a Job-only pending row), allocate a fresh
+//      Execution on the fly so no helm-controller line is dropped.
+//   3. If the Job is in a terminal state OR doesn't exist, the line
+//      is dropped — helm-controller emits maintenance lines after the
+//      install completes (drift checks, observed-generation patches)
+//      that should not extend a closed Execution.
+//
+// The bridge tolerates store errors (returns them) but does not abort
+// the helmwatch event loop — the handler's emit path treats this as
+// a non-fatal best-effort write.
+func (b *Bridge) OnRawComponentLog(componentID, level, message string, t time.Time) error {
+	if strings.TrimSpace(componentID) == "" {
+		return nil
+	}
+	message = strings.TrimRight(message, "\r\n")
+	if message == "" {
+		return nil
+	}
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	jobName := JobNamePrefix + componentID
+	jobID := JobID(b.deploymentID, jobName)
+
+	execID := b.activeExecID[componentID]
+	if execID == "" {
+		// Cursor missing — fall back to the persisted Job's state.
+		job, _, getErr := b.store.GetJob(b.deploymentID, jobID)
+		switch {
+		case getErr != nil:
+			// No persisted Job (yet). Allocate the Job + Execution so
+			// the helm-controller line is captured. State is
+			// approximated as "running" since something is logging
+			// about it; the next OnHelmReleaseEvent fixes the canonical
+			// status.
+			if err := b.store.UpsertJob(Job{
+				DeploymentID: b.deploymentID,
+				JobName:      jobName,
+				AppID:        componentID,
+				BatchID:      BatchBootstrapKit,
+				DependsOn:    []string{},
+				Status:       StatusRunning,
+			}); err != nil {
+				return err
+			}
+			exec, err := b.store.StartExecution(b.deploymentID, jobName, t)
+			if err != nil {
+				return err
+			}
+			execID = exec.ID
+			b.activeExecID[componentID] = execID
+			b.lastState[componentID] = HelmStateInstalling
+		case job.LatestExecutionID != "" && !IsTerminal(job.Status):
+			// In-flight Execution exists but the in-memory cursor was
+			// lost (Pod restart). Re-attach.
+			execID = job.LatestExecutionID
+			b.activeExecID[componentID] = execID
+		case IsTerminal(job.Status):
+			// Job has completed — drop late helm-controller chatter.
+			return nil
+		default:
+			// Job exists but is pending and has no Execution. Allocate.
+			exec, err := b.store.StartExecution(b.deploymentID, jobName, t)
+			if err != nil {
+				return err
+			}
+			execID = exec.ID
+			b.activeExecID[componentID] = execID
+			if err := b.store.UpsertJob(Job{
+				DeploymentID: b.deploymentID,
+				JobName:      jobName,
+				AppID:        componentID,
+				BatchID:      BatchBootstrapKit,
+				DependsOn:    job.DependsOn,
+				Status:       StatusRunning,
+			}); err != nil {
+				return err
+			}
+			b.lastState[componentID] = HelmStateInstalling
+		}
+	}
+
+	return b.store.AppendLogLines(b.deploymentID, execID, []LogLine{{
+		Timestamp: t.UTC(),
+		Level:     mapLevel(level),
+		Message:   message,
+	}})
 }
 
 // dependsOnFromCharts converts a list of dependent chart names (e.g.

--- a/products/catalyst/bootstrap/api/internal/jobs/helmwatch_bridge_test.go
+++ b/products/catalyst/bootstrap/api/internal/jobs/helmwatch_bridge_test.go
@@ -259,11 +259,13 @@ func TestSeedJobsFromInformerList_idempotent(t *testing.T) {
 	if jobsWritten1 != 4 {
 		t.Errorf("first seed jobsWritten: want 4, got %d", jobsWritten1)
 	}
-	// 3 terminal states (cilium installed, cert-manager installed,
-	// crossplane failed) → 3 executions seeded. The "installing" flux
-	// HR is non-terminal so no execution is allocated.
-	if execs1 != 3 {
-		t.Errorf("first seed executionsSeeded: want 3, got %d", execs1)
+	// All four seeds allocate an Execution: 3 terminal (cilium /
+	// cert-manager installed, crossplane failed) + 1 non-terminal
+	// (flux installing). The non-terminal Execution stays open so raw
+	// helm-controller log lines can append to it; terminal Executions
+	// are stamped finished by the seed itself. See issue #305.
+	if execs1 != 4 {
+		t.Errorf("first seed executionsSeeded: want 4, got %d", execs1)
 	}
 
 	gotAfterFirst, err := st.ListJobs(depID)
@@ -332,12 +334,18 @@ func TestSeedJobsFromInformerList_idempotent(t *testing.T) {
 			t.Errorf("%s: want 1 execution after dup seed, got %d", name, len(execs))
 		}
 	}
+	// install-flux was seeded as "installing" — a single open
+	// Execution must exist so the FE log viewer has a row to deep-link
+	// to and the logtailer's raw helm-controller lines can append.
 	_, fluxExecs, err := st.GetJob(depID, JobID(depID, "install-flux"))
 	if err != nil {
 		t.Fatalf("GetJob install-flux: %v", err)
 	}
-	if len(fluxExecs) != 0 {
-		t.Errorf("install-flux: want 0 executions for non-terminal seed, got %d", len(fluxExecs))
+	if len(fluxExecs) != 1 {
+		t.Errorf("install-flux: want 1 open execution for installing seed, got %d", len(fluxExecs))
+	}
+	if len(fluxExecs) == 1 && fluxExecs[0].FinishedAt != nil {
+		t.Errorf("install-flux execution must remain open (no FinishedAt), got %+v", fluxExecs[0].FinishedAt)
 	}
 }
 
@@ -397,15 +405,30 @@ func TestSeedJobsFromInformerList_writesSyntheticLogLine(t *testing.T) {
 		})
 	}
 
-	// The non-terminal install-flux row must NOT have a synthetic log
-	// line — the watch will allocate one when the next transition
-	// fires through OnHelmReleaseEvent.
-	_, fluxExecs, err := st.GetJob(depID, JobID(depID, "install-flux"))
+	// The non-terminal install-flux row gets a single open Execution
+	// with the synthetic anchor "[seeded] state=installing ..." line.
+	// Subsequent raw helm-controller log lines append to this same
+	// Execution; the FinishedAt remains nil until the HR transitions
+	// to a terminal state.
+	job, fluxExecs, err := st.GetJob(depID, JobID(depID, "install-flux"))
 	if err != nil {
 		t.Fatalf("GetJob install-flux: %v", err)
 	}
-	if len(fluxExecs) != 0 {
-		t.Errorf("install-flux must not have a synthetic execution, got %d", len(fluxExecs))
+	if len(fluxExecs) != 1 {
+		t.Fatalf("install-flux: want 1 open execution, got %d", len(fluxExecs))
+	}
+	if fluxExecs[0].FinishedAt != nil {
+		t.Errorf("install-flux execution must remain open (FinishedAt nil), got %v", fluxExecs[0].FinishedAt)
+	}
+	page, err := st.PageLogs(depID, job.LatestExecutionID, 1, 100)
+	if err != nil {
+		t.Fatalf("PageLogs install-flux: %v", err)
+	}
+	if page.Total != 1 {
+		t.Fatalf("install-flux: want exactly 1 anchor LogLine, got %d", page.Total)
+	}
+	if !strings.HasPrefix(page.Lines[0].Message, "[seeded]") || !strings.Contains(page.Lines[0].Message, "state=installing") {
+		t.Errorf("install-flux anchor line shape unexpected: %q", page.Lines[0].Message)
 	}
 }
 
@@ -458,5 +481,173 @@ func TestSeedJobsFromInformerList_skipsEmptyComponent(t *testing.T) {
 	got, _ := st.ListJobs(depID)
 	if len(got) != 1 {
 		t.Errorf("expected 1 job (empty components skipped), got %d", len(got))
+	}
+}
+
+// TestOnRawComponentLog_appendsToActiveExecution proves a raw
+// helm-controller log line forwarded by OnProvisionerEvent (Phase=
+// component-log) lands verbatim on the active Execution allocated by
+// the seed, with the level surfaced via mapLevel.
+func TestOnRawComponentLog_appendsToActiveExecution(t *testing.T) {
+	st, br, depID := newBridgeFixture(t)
+	now := time.Date(2026, 4, 30, 9, 0, 0, 0, time.UTC)
+
+	// Seed a non-terminal "installing" component → allocates an open
+	// Execution + writes the synthetic [seeded] anchor line.
+	if _, _, err := br.SeedJobsFromInformerList([]InformerSeed{
+		{Component: "seaweedfs", State: HelmStateInstalling, Message: "first reconcile", ObservedAt: now},
+	}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	rawLines := []struct {
+		ts    time.Time
+		level string
+		msg   string
+	}{
+		{now.Add(1 * time.Second), "info", `{"ts":"...","level":"info","msg":"reconciling helmrelease","helmrelease":"flux-system/bp-seaweedfs"}`},
+		{now.Add(2 * time.Second), "warn", `level=warn helmrelease="flux-system/bp-seaweedfs" msg="retrying chart pull"`},
+		{now.Add(3 * time.Second), "error", `level=error helmrelease="flux-system/bp-seaweedfs" msg="post-install hook timed out"`},
+	}
+	for _, r := range rawLines {
+		if err := br.OnProvisionerEvent(provisioner.Event{
+			Time:      r.ts.Format(time.RFC3339),
+			Phase:     phaseComponentLog,
+			Level:     r.level,
+			Component: "seaweedfs",
+			Message:   r.msg,
+		}); err != nil {
+			t.Fatalf("OnProvisionerEvent: %v", err)
+		}
+	}
+
+	job, execs, err := st.GetJob(depID, JobID(depID, "install-seaweedfs"))
+	if err != nil {
+		t.Fatalf("GetJob: %v", err)
+	}
+	if len(execs) != 1 {
+		t.Fatalf("want 1 execution, got %d", len(execs))
+	}
+	if execs[0].FinishedAt != nil {
+		t.Errorf("execution must remain open during installing state, got finished=%v", execs[0].FinishedAt)
+	}
+	page, err := st.PageLogs(depID, job.LatestExecutionID, 1, 100)
+	if err != nil {
+		t.Fatalf("PageLogs: %v", err)
+	}
+	// 1 anchor [seeded] line + 3 raw helm-controller lines.
+	if page.Total != 4 {
+		t.Fatalf("want 4 log lines (1 anchor + 3 raw), got %d", page.Total)
+	}
+	for i, want := range []string{LevelInfo, LevelInfo, LevelWarn, LevelError} {
+		if got := page.Lines[i].Level; got != want {
+			t.Errorf("line %d level: got %q, want %q", i, got, want)
+		}
+	}
+	for i := 1; i <= 3; i++ {
+		if page.Lines[i].Message != rawLines[i-1].msg {
+			t.Errorf("line %d message must round-trip verbatim:\n  got  %q\n  want %q",
+				i, page.Lines[i].Message, rawLines[i-1].msg)
+		}
+	}
+}
+
+// TestOnRawComponentLog_allocatesExecutionWhenJobMissing proves a raw
+// helm-controller log line for a component the bridge has never seen
+// before still gets persisted: a Job + Execution are created on the
+// fly. Covers the "Pod restart wiped both the cursor AND the index"
+// edge case that used to drop every line.
+func TestOnRawComponentLog_allocatesExecutionWhenJobMissing(t *testing.T) {
+	st, br, depID := newBridgeFixture(t)
+	t0 := time.Date(2026, 4, 30, 10, 0, 0, 0, time.UTC)
+
+	if err := br.OnProvisionerEvent(provisioner.Event{
+		Time:      t0.Format(time.RFC3339),
+		Phase:     phaseComponentLog,
+		Level:     "info",
+		Component: "openbao",
+		Message:   `helmrelease="flux-system/bp-openbao" msg="installing chart"`,
+	}); err != nil {
+		t.Fatalf("OnProvisionerEvent: %v", err)
+	}
+
+	job, execs, err := st.GetJob(depID, JobID(depID, "install-openbao"))
+	if err != nil {
+		t.Fatalf("GetJob: %v", err)
+	}
+	if job.Status != StatusRunning {
+		t.Errorf("job status: want running, got %q", job.Status)
+	}
+	if len(execs) != 1 {
+		t.Fatalf("want 1 execution, got %d", len(execs))
+	}
+	page, err := st.PageLogs(depID, job.LatestExecutionID, 1, 100)
+	if err != nil {
+		t.Fatalf("PageLogs: %v", err)
+	}
+	if page.Total != 1 {
+		t.Fatalf("want 1 log line, got %d", page.Total)
+	}
+}
+
+// TestOnRawComponentLog_dropsAfterTerminal proves helm-controller's
+// post-install drift-check chatter does NOT extend a closed Execution.
+// Once the Job has reached a terminal status the line is dropped.
+func TestOnRawComponentLog_dropsAfterTerminal(t *testing.T) {
+	st, br, depID := newBridgeFixture(t)
+	now := time.Date(2026, 4, 30, 11, 0, 0, 0, time.UTC)
+
+	// Seed cilium as installed (terminal) so the bridge has a closed
+	// Execution + cleared cursor on record.
+	if _, _, err := br.SeedJobsFromInformerList([]InformerSeed{
+		{Component: "cilium", State: HelmStateInstalled, Message: "ok", ObservedAt: now},
+	}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	if err := br.OnProvisionerEvent(provisioner.Event{
+		Time:      now.Add(time.Hour).Format(time.RFC3339),
+		Phase:     phaseComponentLog,
+		Level:     "info",
+		Component: "cilium",
+		Message:   `helmrelease="flux-system/bp-cilium" msg="reconciliation drift check"`,
+	}); err != nil {
+		t.Fatalf("OnProvisionerEvent: %v", err)
+	}
+
+	job, _, err := st.GetJob(depID, JobID(depID, "install-cilium"))
+	if err != nil {
+		t.Fatalf("GetJob: %v", err)
+	}
+	page, err := st.PageLogs(depID, job.LatestExecutionID, 1, 100)
+	if err != nil {
+		t.Fatalf("PageLogs: %v", err)
+	}
+	// Only the 1 anchor [seeded] line — the post-terminal raw line
+	// must be dropped.
+	if page.Total != 1 {
+		t.Fatalf("want 1 log line (post-terminal raw line dropped), got %d", page.Total)
+	}
+}
+
+// TestOnProvisionerEvent_dropsUnknownPhases keeps the bridge inert for
+// Phase-0 OpenTofu events (Phase="phase-0", Phase="tofu-init") that
+// have no Job analogue — a regression guard against accidentally
+// materialising Jobs for opentofu output.
+func TestOnProvisionerEvent_dropsUnknownPhases(t *testing.T) {
+	st, br, depID := newBridgeFixture(t)
+	for _, ph := range []string{"phase-0", "tofu-init", "tofu-apply", ""} {
+		if err := br.OnProvisionerEvent(provisioner.Event{
+			Time:      time.Now().UTC().Format(time.RFC3339),
+			Phase:     ph,
+			Component: "anything",
+			Message:   "noise",
+		}); err != nil {
+			t.Errorf("phase %q must not error: %v", ph, err)
+		}
+	}
+	got, _ := st.ListJobs(depID)
+	if len(got) != 0 {
+		t.Errorf("non-component phases must not allocate Jobs, got %d", len(got))
 	}
 }

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/JobDetail.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/JobDetail.test.tsx
@@ -243,3 +243,167 @@ describe('JobDetail — backend-format jobId lookup (regression for #245 not-fou
     })
   })
 })
+
+describe('JobDetail — Exec Log tab wires the real execution id (regression for #305)', () => {
+  // Without the fix, the JobDetail page constructed a synthetic
+  // executionId of `${jobId}:latest` and passed it to <ExecutionLogs>.
+  // The catalyst-api never had a `:latest` route — every log fetch
+  // returned 404 and the viewer rendered "Failed to load log page".
+  //
+  // The fix routes JobDetail through useJobDetail() which fetches
+  // `/api/v1/deployments/{depId}/jobs/{jobId}` and uses `executions[0].id`
+  // as the real exec id.
+  function renderDetailWithJobAndExecutions(
+    deploymentId: string,
+    jobId: string,
+    job: Job,
+    executions: Array<{ id: string; jobId: string; deploymentId: string; status: string; startedAt: string; lineCount: number }>,
+  ) {
+    const rootRoute = createRootRoute({ component: () => <Outlet /> })
+    const detailRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/provision/$deploymentId/jobs/$jobId',
+      component: () => <JobDetail disableStream />,
+    })
+    const flowRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/provision/$deploymentId/flow',
+      component: () => <div data-testid="flow-target" />,
+    })
+    const jobsRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/provision/$deploymentId/jobs',
+      component: () => <div data-testid="jobs-target" />,
+    })
+    const homeRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/provision/$deploymentId',
+      component: () => <div data-testid="apps-target" />,
+    })
+    const tree = rootRoute.addChildren([detailRoute, flowRoute, jobsRoute, homeRoute])
+    const router = createRouter({
+      routeTree: tree,
+      history: createMemoryHistory({
+        initialEntries: [`/provision/${deploymentId}/jobs/${jobId}`],
+      }),
+    })
+    globalThis.fetch = ((input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : input.toString()
+      // /jobs (list) → emit the same job so mergeJobs surfaces it.
+      if (url.endsWith(`/v1/deployments/${encodeURIComponent(deploymentId)}/jobs`)) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ jobs: [job] }),
+        } as unknown as Response)
+      }
+      // /jobs/{jobId} (detail) → emit the executions[].
+      if (
+        url.endsWith(
+          `/v1/deployments/${encodeURIComponent(deploymentId)}/jobs/${encodeURIComponent(jobId)}`,
+        )
+      ) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ job, executions }),
+        } as unknown as Response)
+      }
+      // /executions/{execId}/logs → empty page (the test does not exercise
+      // pagination, just that the URL is constructed against the REAL exec id).
+      if (url.includes('/v1/actions/executions/')) {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({ lines: [], total: 0, executionFinished: false }),
+        } as unknown as Response)
+      }
+      return Promise.resolve({
+        ok: true,
+        json: () =>
+          Promise.resolve({ events: [], state: undefined, done: false }),
+      } as unknown as Response)
+    }) as typeof fetch
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: 0 } },
+    })
+    return render(
+      <QueryClientProvider client={qc}>
+        <RouterProvider router={router} />
+      </QueryClientProvider>,
+    )
+  }
+
+  it('uses executions[0].id (NOT `${jobId}:latest`) when fetching log lines', async () => {
+    const deploymentId = 'd1'
+    const jobId = `${deploymentId}:install-seaweedfs`
+    const realExecId = 'df9893393d6cd84da027c4115674c1a0'
+
+    const job: Job = {
+      id: jobId,
+      jobName: 'install-seaweedfs',
+      appId: 'seaweedfs',
+      batchId: 'bootstrap-kit',
+      dependsOn: [],
+      status: 'running',
+      startedAt: '2026-04-30T09:00:00Z',
+      finishedAt: null,
+      durationMs: 0,
+    }
+
+    // Spy on fetch to capture every URL the component requests.
+    const seenUrls: string[] = []
+    renderDetailWithJobAndExecutions(deploymentId, jobId, job, [
+      {
+        id: realExecId,
+        jobId,
+        deploymentId,
+        status: 'running',
+        startedAt: '2026-04-30T09:00:00Z',
+        lineCount: 1,
+      },
+    ])
+    const inner = globalThis.fetch
+    globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input.toString()
+      seenUrls.push(url)
+      return inner(input, init)
+    }) as typeof fetch
+
+    fireEvent.click(await screen.findByTestId('job-detail-tab-logs'))
+
+    await waitFor(() => {
+      // Real exec id appears in at least one log fetch URL.
+      expect(seenUrls.some((u) => u.includes(`/v1/actions/executions/${realExecId}/logs`)))
+        .toBe(true)
+      // Synthetic `:latest` id MUST NOT appear in any URL.
+      expect(seenUrls.some((u) => u.includes(`${jobId}:latest`))).toBe(false)
+    })
+  })
+
+  it('renders the placeholder (not the log viewer) when executions[] is empty', async () => {
+    const deploymentId = 'd1'
+    const jobId = `${deploymentId}:install-seaweedfs`
+    const job: Job = {
+      id: jobId,
+      jobName: 'install-seaweedfs',
+      appId: 'seaweedfs',
+      batchId: 'bootstrap-kit',
+      dependsOn: [],
+      status: 'running',
+      startedAt: null,
+      finishedAt: null,
+      durationMs: 0,
+    }
+    renderDetailWithJobAndExecutions(deploymentId, jobId, job, [])
+    fireEvent.click(await screen.findByTestId('job-detail-tab-logs'))
+    await waitFor(() => {
+      // One of the placeholder testids must be present; the GitLab-CI
+      // viewer must NOT mount with a fake id.
+      const placeholder =
+        screen.queryByTestId('job-detail-logs-pending') ||
+        screen.queryByTestId('job-detail-logs-empty') ||
+        screen.queryByTestId('job-detail-logs-loading')
+      expect(placeholder).toBeTruthy()
+      expect(screen.queryByTestId('execution-logs')).toBeNull()
+    })
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/JobDetail.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/JobDetail.tsx
@@ -32,6 +32,7 @@ import { deriveJobs, fmtTime, statusBadge } from './jobs'
 import type { JobUiStatus } from './jobs'
 import { adaptDerivedJobsToFlat } from './jobsAdapter'
 import { useLiveJobsBackfill, mergeJobs } from './useLiveJobsBackfill'
+import { useJobDetail } from './useJobDetail'
 import type { Job } from '@/lib/jobs.types'
 import { ExecutionLogs } from '@/components/ExecutionLogs'
 import { FlowPage } from './FlowPage'
@@ -110,11 +111,20 @@ export function JobDetail({
 
   const [tab, setTab] = useState<TabKey>(initialTab)
 
-  // Derive a synthetic execution id for the log viewer. Until the
-  // backend surfaces `executions[]` on the Job model, the most-recent
-  // execution is identified as `<jobId>:latest` so the URL the viewer
-  // hits is stable and the backend can route by job id when it lands.
-  const executionId = `${jobId}:latest`
+  // Resolve the REAL execution id by polling the per-job detail
+  // endpoint. The backend returns `executions[]` sorted started-at DESC
+  // server-side, so `executions[0].id` is the most-recent attempt's
+  // hex id. The synthetic `${jobId}:latest` id used previously was
+  // never a route the catalyst-api exposed — every log fetch returned
+  // 404 and the viewer rendered "Failed to load log page". See #305.
+  const detail = useJobDetail({
+    deploymentId,
+    jobId,
+    disablePolling: disableJobsBackfill || !inFlight,
+    enabled: !disableJobsBackfill,
+  })
+  const executionId = detail.latestExecutionId
+  const detailJobStatus = detail.job?.status
 
   if (!job) {
     return (
@@ -248,11 +258,74 @@ export function JobDetail({
               aria-labelledby="job-detail-tab-logs"
               data-testid="job-detail-logs-panel"
             >
-              <ExecutionLogs executionId={executionId} />
+              {executionId ? (
+                <ExecutionLogs executionId={executionId} />
+              ) : (
+                <ExecutionLogsPlaceholder
+                  jobStatus={detailJobStatus ?? job.status}
+                  isLoading={detail.isLoading}
+                  isError={detail.isError}
+                />
+              )}
             </div>
           )}
         </div>
       </div>
     </PortalShell>
+  )
+}
+
+interface ExecutionLogsPlaceholderProps {
+  jobStatus: string
+  isLoading: boolean
+  isError: boolean
+}
+
+/**
+ * ExecutionLogsPlaceholder renders the log panel while the job has no
+ * Execution to deep-link to. Three cases — pending (helm-controller
+ * hasn't started reconciling the HR yet), loading (first fetch in
+ * flight), and error (network/5xx; user can retry by reloading).
+ *
+ * The panel deliberately does NOT render the GitLab-style log viewer
+ * with an empty body — that produced the original "No logs captured"
+ * confusion when the real underlying problem was an unresolved
+ * execution id. Distinguishing the panel surfaces makes the operator's
+ * mental model match reality.
+ */
+function ExecutionLogsPlaceholder({
+  jobStatus,
+  isLoading,
+  isError,
+}: ExecutionLogsPlaceholderProps) {
+  let title = 'Waiting for first execution'
+  let detail =
+    'No execution has been allocated for this job yet. Logs will appear here once helm-controller starts reconciling the HelmRelease.'
+  let testid = 'job-detail-logs-pending'
+
+  if (isLoading) {
+    title = 'Loading execution metadata…'
+    detail = 'Fetching the latest execution id from the catalyst-api.'
+    testid = 'job-detail-logs-loading'
+  } else if (isError) {
+    title = 'Could not load execution metadata'
+    detail =
+      'The catalyst-api is unreachable or returned an error. The page will retry automatically every 5 seconds.'
+    testid = 'job-detail-logs-error'
+  } else if (jobStatus !== 'pending') {
+    title = 'Execution metadata pending'
+    detail =
+      'The catalyst-api has not yet recorded an execution for this job. If this persists past the next poll, the helmwatch bridge may not be running — check catalyst-api logs.'
+    testid = 'job-detail-logs-empty'
+  }
+
+  return (
+    <div
+      data-testid={testid}
+      className="rounded-xl border border-[var(--color-border)] bg-[var(--color-surface)] p-8 text-center"
+    >
+      <h3 className="text-base font-semibold text-[var(--color-text-strong)]">{title}</h3>
+      <p className="mt-2 text-sm text-[var(--color-text-dim)]">{detail}</p>
+    </div>
   )
 }

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/useJobDetail.ts
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/useJobDetail.ts
@@ -1,0 +1,149 @@
+/**
+ * useJobDetail — per-job fetch hook for the JobDetail page's log
+ * viewer.
+ *
+ * WHY (issue #305):
+ * The JobDetail page used to construct a synthetic execution id of the
+ * form `${jobId}:latest` and pass it to <ExecutionLogs>. That synthetic
+ * id is NEVER an actual execution id — real ones are 16-byte hex strings
+ * allocated by the catalyst-api Bridge — so every log fetch returned 404
+ * and the viewer rendered "Failed to load log page" / "No logs captured
+ * for this log".
+ *
+ * The backend already exposes the data the viewer needs:
+ *   GET /api/v1/deployments/{depId}/jobs/{jobId}
+ *     → { job: Job, executions: Execution[] }
+ *
+ * `executions[]` is sorted started-at DESC server-side, so
+ * `executions[0]?.id` is the real id of the most-recent attempt. This
+ * hook polls that endpoint while the deployment is in flight, returning
+ * the (job, executions, latest exec id) triple the JobDetail page wires
+ * into <ExecutionLogs>.
+ *
+ * Per docs/INVIOLABLE-PRINCIPLES.md #4 (never hardcode), the URL is
+ * built from `API_BASE`. Per #2 (never compromise) this is NOT a shim:
+ * it follows the same React Query pattern as useLiveJobsBackfill.
+ */
+
+import { useQuery } from '@tanstack/react-query'
+import { API_BASE } from '@/shared/config/urls'
+import type { Job } from '@/lib/jobs.types'
+
+/** Wire shape of an Execution row — kept local to this module since
+ *  the JobsTable doesn't render Executions and the rest of the UI has
+ *  no need for the type yet. Mirrors `internal/jobs.Execution` in the
+ *  backend. */
+export interface Execution {
+  id: string
+  jobId: string
+  deploymentId: string
+  status: 'running' | 'succeeded' | 'failed'
+  startedAt: string
+  finishedAt?: string | null
+  lineCount: number
+}
+
+/** Wire shape of GET /api/v1/deployments/{id}/jobs/{jobId}. */
+interface JobDetailResponse {
+  job?: Job
+  executions?: Execution[]
+}
+
+export interface UseJobDetailResult {
+  job: Job | null
+  executions: Execution[]
+  /** id of `executions[0]` when present, else null. Stable for use as
+   *  the executionId prop on <ExecutionLogs>. */
+  latestExecutionId: string | null
+  isLoading: boolean
+  isError: boolean
+  /** Distinguishes 404 (job genuinely doesn't exist on this deployment)
+   *  from network/5xx errors. The JobDetail page renders the dedicated
+   *  "Job not found" panel when notFound is true. */
+  notFound: boolean
+}
+
+export interface UseJobDetailOptions {
+  deploymentId: string
+  jobId: string
+  /** Test seam — disables the React Query refetch interval. */
+  disablePolling?: boolean
+  /** Test seam — inject a stub fetcher. */
+  fetcher?: (deploymentId: string, jobId: string) => Promise<JobDetailResponse>
+  /** When false the query is parked — used after the deployment reaches
+   *  a terminal state to avoid wasteful polling. */
+  enabled?: boolean
+}
+
+/** Founder-aligned poll cadence — matches useLiveJobsBackfill. */
+const POLL_INTERVAL_MS = 5_000
+
+/** Sentinel returned by the default fetcher on a 404. The hook
+ *  translates this into `notFound: true` without surfacing it as an
+ *  error to the operator. */
+class JobNotFoundError extends Error {
+  readonly deploymentId: string
+  readonly jobId: string
+  constructor(deploymentId: string, jobId: string) {
+    super(`Job ${jobId} not found in deployment ${deploymentId}`)
+    this.name = 'JobNotFoundError'
+    this.deploymentId = deploymentId
+    this.jobId = jobId
+  }
+}
+
+async function defaultFetchJobDetail(
+  deploymentId: string,
+  jobId: string,
+): Promise<JobDetailResponse> {
+  const url =
+    `${API_BASE}/v1/deployments/${encodeURIComponent(deploymentId)}` +
+    `/jobs/${encodeURIComponent(jobId)}`
+  const res = await fetch(url, { headers: { Accept: 'application/json' } })
+  if (res.status === 404) {
+    throw new JobNotFoundError(deploymentId, jobId)
+  }
+  if (!res.ok) {
+    throw new Error(`Failed to fetch job detail: ${res.status}`)
+  }
+  return (await res.json()) as JobDetailResponse
+}
+
+export function useJobDetail(opts: UseJobDetailOptions): UseJobDetailResult {
+  const {
+    deploymentId,
+    jobId,
+    disablePolling = false,
+    fetcher = defaultFetchJobDetail,
+    enabled = true,
+  } = opts
+
+  const query = useQuery<JobDetailResponse, Error>({
+    queryKey: ['job-detail', deploymentId, jobId],
+    queryFn: () => fetcher(deploymentId, jobId),
+    enabled: enabled && !!deploymentId && !!jobId,
+    refetchInterval: () => {
+      if (disablePolling) return false
+      return POLL_INTERVAL_MS
+    },
+    placeholderData: (prev) => prev,
+    retry: false,
+  })
+
+  const notFound = query.error instanceof JobNotFoundError
+  const data = query.data
+  const job = data?.job ?? null
+  const executions = Array.isArray(data?.executions) ? data!.executions! : []
+  // executions[] is sorted started-at DESC server-side. Take index 0
+  // for the most-recent attempt.
+  const latestExecutionId = executions[0]?.id ?? null
+
+  return {
+    job,
+    executions,
+    latestExecutionId,
+    isLoading: query.isLoading,
+    isError: !!query.error && !notFound,
+    notFound,
+  }
+}


### PR DESCRIPTION
Closes #305 (sub of epic #204).

End-to-end fix for the JobDetail log viewer surface. Three stacked bugs:

## A. Frontend used a fake execution id
`JobDetail.tsx` constructed `\${jobId}:latest` and sent it to `/api/v1/actions/executions/{id}/logs`. The backend resolves execId by exact match against 16-byte hex IDs — there is no `:latest` route. Every log fetch returned 404 → \"Failed to load log page\" / \"No logs captured for this log\".

## B. Non-terminal seeds skipped Execution alloc
`SeedJobsFromInformerList` for `installing` / `degraded` HRs wrote the Job row with `status=running` but skipped `StartExecution` AND set `b.lastState[comp]=state`. The next `OnHelmReleaseEvent` with the same state took the `prev==state` early-return — Execution was never allocated. 7 jobs on the live otech cluster (seaweedfs, velero, mimir, loki, harbor, tempo, grafana) were stuck this way.

## C. Raw helm-controller log lines were silently dropped
`OnProvisionerEvent` filtered `ev.Phase != \"component\"` and dropped every `PhaseComponentLog` event the helmwatch logtailer emitted. Raw helm-controller stdout (one line per reconcile/error/event) never reached the persisted Execution log file. The GitLab-style viewer only ever rendered synthetic `[seeded]` / `[<state>]` summary lines.

## Fixes
- `helmwatch_bridge.go::SeedJobsFromInformerList` allocates an Execution + writes a `[seeded]` anchor line for `installing`/`degraded` states. Execution stays OPEN for non-terminal so subsequent raw lines append to it.
- `helmwatch_bridge.go::OnProvisionerEvent` dispatches on Phase: `component` → `OnHelmReleaseEvent`; `component-log` → new `OnRawComponentLog` (raw line appended verbatim). Resolution policy on missing in-memory cursor: re-attach to persisted `LatestExecutionID` for non-terminal Jobs; allocate fresh for unknown Jobs; drop for terminal Jobs (post-install drift-check chatter).
- `useJobDetail.ts` (new) — React Query hook on `/api/v1/deployments/{id}/jobs/{jobId}`, exposes `executions[0].id` as `latestExecutionId`. 5s poll while in flight.
- `JobDetail.tsx` — replaces synthetic id with `detail.latestExecutionId`. Empty `executions[]` renders `ExecutionLogsPlaceholder` with status-aware copy (pending / loading / empty / error) instead of a viewer with no exec id.

## Tests
- 4 new Go tests on the bridge: `appendsToActiveExecution`, `allocatesExecutionWhenJobMissing`, `dropsAfterTerminal`, `dropsUnknownPhases`.
- Existing seed-idempotency tests updated for the new \"non-terminal seed allocates Execution\" contract.
- 2 new vitest cases on JobDetail asserting the real exec id is used (and the synthetic `:latest` MUST NOT appear in any URL) + the empty-state placeholder renders.
- All 502 vitest pass; all api Go tests pass; production UI build clean.

## Test plan
- [ ] catalyst-build CI green (image roll)
- [ ] Flux reconciles new SHA on contabo-mkt
- [ ] Playwright UAT on `https://console.openova.io/sovereign/provision/ce476aaf80731a46/jobs/install-seaweedfs` → log panel renders raw helm-controller lines for `bp-seaweedfs`, NOT \"Failed to load log page\"
- [ ] Same on a terminal job (e.g. `install-cilium`) → renders the historical log + does not append post-install drift-check chatter

🤖 Generated with [Claude Code](https://claude.com/claude-code)