### PR TITLE
fix(catalyst-ui): Flow organic layout — full-width spread by depth, no STAGE grid

### DIFF
--- a/products/catalyst/bootstrap/ui/src/lib/flowLayoutOrganic.ts
+++ b/products/catalyst/bootstrap/ui/src/lib/flowLayoutOrganic.ts
@@ -1,0 +1,215 @@
+/**
+ * flowLayoutOrganic — pure data prep for the organic Flow canvas.
+ *
+ * Replaces flowLayoutV4.ts (stage-column / Sugiyama grid). The grid was
+ * the cause of the "8x5 squashed in middle 1/3" bug operators kept
+ * rejecting. This module returns only the topology — depth (longest
+ * path from a root), region, family, status — and lets the canvas's
+ * d3-force simulation do the actual positioning.
+ *
+ * Design contract per operator (2026-04-30):
+ *   • Bubbles spread organically across the FULL canvas width, x-axis
+ *     determined by dependency depth (depth 0 → leftmost, deepest →
+ *     rightmost).
+ *   • Same-depth siblings scatter loosely vertically; they MUST NOT be
+ *     vertically aligned in a strict column.
+ *   • Edges are direct depth-aware bezier curves between live positions
+ *     with arrowheads and source-status colour.
+ *   • NO "STAGE 1/2/..." labels. NO column dividers. The layout has no
+ *     concept of "stage".
+ *   • Batch mode: same nodes API, but the canvas collapses into one
+ *     bubble per batchId before calling here.
+ *
+ * Pure: same input → same output. No DOM, no React, no side effects.
+ */
+
+import type { Job } from './jobs.types'
+
+/** A blueprint family — used to colour-code bubbles. */
+export interface OrganicFamily {
+  id: string
+  label: string
+  color: string
+}
+
+/** A region descriptor — used to vertically group bubbles. */
+export interface OrganicRegion {
+  id: string
+  label: string
+  meta?: string
+}
+
+/** Per-job hint provided by the page — region + family + extra dep ids. */
+export interface OrganicNodeHints {
+  regionId: string
+  familyId: string
+  /** Optional jobIds to add as extra depsOn edges (component-graph deps). */
+  extraDepIds?: string[]
+}
+
+/** A node in the organic layout output. */
+export interface OrganicNode {
+  id: string
+  /** 0-based longest-path depth from any root (no in-edge node). */
+  depth: number
+  regionId: string
+  familyId: string
+  /** Display label (jobName less leading "install-"). */
+  label: string
+  /** Status drives ring colour. */
+  status: Job['status']
+  /** Sub-label (duration). */
+  subLabel: string
+  /** Underlying job for tooltip / click handler. */
+  job: Job
+}
+
+/** A directed edge between two nodes. */
+export interface OrganicEdge {
+  fromId: string
+  toId: string
+  fromStatus: Job['status']
+  /** Cross-region edge — drawn with a different (warm) tone. */
+  crossRegion: boolean
+}
+
+/** The output. */
+export interface OrganicLayoutResult {
+  nodes: OrganicNode[]
+  edges: OrganicEdge[]
+  /** Max depth across all nodes — useful for x-axis scale. */
+  maxDepth: number
+  regions: OrganicRegion[]
+  families: OrganicFamily[]
+}
+
+export const FALLBACK_REGION_ID = 'primary'
+
+/**
+ * Compute the layout-ready data from raw jobs + hints.
+ *
+ * Depth assignment uses Kahn-style topological depth: for each node,
+ * depth = max(depth(parent)) + 1; nodes with no incoming edges have
+ * depth 0. Cycles are broken (impossible by construction here, but
+ * defensive — capped at jobs.length iterations).
+ */
+export function flowLayoutOrganic(
+  jobs: readonly Job[],
+  opts: {
+    hints: ReadonlyMap<string, OrganicNodeHints>
+    regions: readonly OrganicRegion[]
+    families: readonly OrganicFamily[]
+  },
+): OrganicLayoutResult {
+  const { hints, regions, families } = opts
+
+  const fallbackRegion: OrganicRegion =
+    regions.find((r) => r.id === FALLBACK_REGION_ID) ?? regions[0] ?? {
+      id: FALLBACK_REGION_ID,
+      label: 'Primary Region',
+    }
+
+  // Build adjacency from Job.dependsOn + hint.extraDepIds.
+  const idSet = new Set(jobs.map((j) => j.id))
+  const inEdges = new Map<string, Set<string>>()
+  const outEdges = new Map<string, Set<string>>()
+  for (const j of jobs) {
+    inEdges.set(j.id, new Set())
+    outEdges.set(j.id, new Set())
+  }
+  function addEdge(from: string, to: string) {
+    if (!idSet.has(from) || !idSet.has(to)) return
+    if (from === to) return
+    inEdges.get(to)!.add(from)
+    outEdges.get(from)!.add(to)
+  }
+  for (const j of jobs) {
+    for (const dep of j.dependsOn ?? []) addEdge(dep, j.id)
+    const h = hints.get(j.id)
+    for (const dep of h?.extraDepIds ?? []) addEdge(dep, j.id)
+  }
+
+  // Compute depth = longest-path from a root (any node with no in-edges).
+  // Iterative relaxation: depth[v] = max(depth[u] + 1) for u in inEdges[v].
+  const depth = new Map<string, number>()
+  for (const j of jobs) depth.set(j.id, 0)
+  let changed = true
+  let iterations = 0
+  const cap = jobs.length + 2 // cycle defence
+  while (changed && iterations < cap) {
+    changed = false
+    iterations++
+    for (const j of jobs) {
+      const ins = inEdges.get(j.id)!
+      let bestParent = -1
+      for (const p of ins) bestParent = Math.max(bestParent, depth.get(p) ?? 0)
+      const want = bestParent + 1
+      if (want > 0 && want > (depth.get(j.id) ?? 0)) {
+        depth.set(j.id, want)
+        changed = true
+      }
+    }
+  }
+
+  // Nodes.
+  const nodes: OrganicNode[] = jobs.map((j) => {
+    const h = hints.get(j.id)
+    const regionId = h?.regionId && regions.some((r) => r.id === h.regionId)
+      ? h.regionId
+      : fallbackRegion.id
+    const familyId = h?.familyId ?? 'platform'
+    const label = j.jobName.replace(/^install-/, '')
+    const subLabel = j.durationMs > 0 ? formatDurationShort(j.durationMs) : ''
+    return {
+      id: j.id,
+      depth: depth.get(j.id) ?? 0,
+      regionId,
+      familyId,
+      label,
+      status: j.status,
+      subLabel,
+      job: j,
+    }
+  })
+
+  // Edges from outEdges adjacency.
+  const edges: OrganicEdge[] = []
+  const nodeById = new Map(nodes.map((n) => [n.id, n]))
+  for (const from of jobs) {
+    const outs = outEdges.get(from.id) ?? new Set()
+    for (const toId of outs) {
+      const fromNode = nodeById.get(from.id)
+      const toNode = nodeById.get(toId)
+      if (!fromNode || !toNode) continue
+      edges.push({
+        fromId: from.id,
+        toId,
+        fromStatus: fromNode.status,
+        crossRegion: fromNode.regionId !== toNode.regionId,
+      })
+    }
+  }
+
+  const maxDepth = nodes.reduce((m, n) => Math.max(m, n.depth), 0)
+
+  return {
+    nodes,
+    edges,
+    maxDepth,
+    regions: [...regions],
+    families: [...families],
+  }
+}
+
+/** Format ms → "1m 23s" / "12s" / "152ms". */
+function formatDurationShort(ms: number): string {
+  if (ms < 1000) return `${ms}ms`
+  const s = Math.floor(ms / 1000)
+  if (s < 60) return `${s}s`
+  const m = Math.floor(s / 60)
+  const rs = s % 60
+  if (m < 60) return rs ? `${m}m ${rs}s` : `${m}m`
+  const h = Math.floor(m / 60)
+  const rm = m % 60
+  return rm ? `${h}h ${rm}m` : `${h}h`
+}

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/BatchSummaryPane.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/BatchSummaryPane.tsx
@@ -1,0 +1,275 @@
+/**
+ * BatchSummaryPane — right-side floating pane shown when a batch
+ * bubble is single-clicked in batch mode.
+ *
+ * Per operator spec (2026-04-30):
+ *   • Show start time
+ *   • Show finish time (if all child jobs done) OR estimated finish
+ *     extrapolated from completed-vs-total + running-rate
+ *   • Show counts: succeeded / running / pending / failed
+ *   • Show overall duration (or elapsed if still running)
+ */
+
+import { useMemo } from 'react'
+import type { Job } from '@/lib/jobs.types'
+
+export interface BatchSummaryPaneProps {
+  batchId: string
+  jobs: readonly Job[]
+  onClose: () => void
+}
+
+export function BatchSummaryPane({ batchId, jobs, onClose }: BatchSummaryPaneProps) {
+  const summary = useMemo(() => buildSummary(jobs), [jobs])
+
+  return (
+    <div
+      data-testid="batch-summary-pane"
+      role="dialog"
+      aria-label={`Batch ${batchId}`}
+      className="batch-summary-pane"
+    >
+      <style>{BATCH_SUMMARY_CSS}</style>
+      <header className="batch-summary-pane-header">
+        <div className="batch-summary-pane-title">
+          <span className="batch-summary-pane-eyebrow">BATCH</span>
+          <span className="batch-summary-pane-name" data-testid="batch-summary-pane-name">
+            {batchId}
+          </span>
+        </div>
+        <button
+          type="button"
+          className="batch-summary-pane-close"
+          aria-label="Close batch summary"
+          onClick={onClose}
+          data-testid="batch-summary-pane-close"
+        >
+          ×
+        </button>
+      </header>
+      <dl className="batch-summary-pane-grid">
+        <dt>Started</dt>
+        <dd data-testid="batch-summary-started">{fmtTime(summary.startedAt) || '—'}</dd>
+
+        <dt>{summary.allDone ? 'Finished' : 'ETA'}</dt>
+        <dd data-testid="batch-summary-finished">
+          {summary.allDone
+            ? fmtTime(summary.finishedAt) || '—'
+            : summary.etaIso
+              ? fmtTime(summary.etaIso)
+              : 'unknown'}
+        </dd>
+
+        <dt>{summary.allDone ? 'Duration' : 'Elapsed'}</dt>
+        <dd data-testid="batch-summary-duration">{fmtDuration(summary.durationMs)}</dd>
+
+        <dt>Progress</dt>
+        <dd data-testid="batch-summary-progress">
+          {summary.finished} / {summary.total}
+        </dd>
+      </dl>
+      <ul className="batch-summary-pane-counts">
+        <li data-testid="batch-summary-count-succeeded">
+          <span className="dot dot-succeeded" /> Succeeded {summary.succeeded}
+        </li>
+        <li data-testid="batch-summary-count-running">
+          <span className="dot dot-running" /> Running {summary.running}
+        </li>
+        <li data-testid="batch-summary-count-pending">
+          <span className="dot dot-pending" /> Pending {summary.pending}
+        </li>
+        <li data-testid="batch-summary-count-failed">
+          <span className="dot dot-failed" /> Failed {summary.failed}
+        </li>
+      </ul>
+      <p className="batch-summary-pane-hint">
+        Double-click the bubble to drill into this batch's jobs.
+      </p>
+    </div>
+  )
+}
+
+interface Summary {
+  startedAt: string | null
+  finishedAt: string | null
+  allDone: boolean
+  durationMs: number
+  total: number
+  finished: number
+  succeeded: number
+  running: number
+  pending: number
+  failed: number
+  etaIso: string | null
+}
+
+function buildSummary(jobs: readonly Job[]): Summary {
+  const total = jobs.length
+  let succeeded = 0
+  let running = 0
+  let pending = 0
+  let failed = 0
+  let earliestStart: number | null = null
+  let earliestStartIso: string | null = null
+  let latestFinish: number | null = null
+  let latestFinishIso: string | null = null
+  for (const j of jobs) {
+    if (j.status === 'succeeded') succeeded++
+    else if (j.status === 'running') running++
+    else if (j.status === 'pending') pending++
+    else if (j.status === 'failed') failed++
+    if (j.startedAt) {
+      const t = Date.parse(j.startedAt)
+      if (Number.isFinite(t) && (earliestStart === null || t < earliestStart)) {
+        earliestStart = t
+        earliestStartIso = j.startedAt
+      }
+    }
+    if (j.finishedAt) {
+      const t = Date.parse(j.finishedAt)
+      if (Number.isFinite(t) && (latestFinish === null || t > latestFinish)) {
+        latestFinish = t
+        latestFinishIso = j.finishedAt
+      }
+    }
+  }
+  const finished = succeeded + failed
+  const allDone = total > 0 && finished === total
+
+  let durationMs = 0
+  if (allDone && earliestStart !== null && latestFinish !== null) {
+    durationMs = Math.max(0, latestFinish - earliestStart)
+  } else if (earliestStart !== null) {
+    durationMs = Math.max(0, Date.now() - earliestStart)
+  }
+
+  let etaIso: string | null = null
+  if (!allDone && earliestStart !== null && finished > 0 && finished < total) {
+    const elapsed = Date.now() - earliestStart
+    const ratePerJob = elapsed / finished
+    const remaining = total - finished
+    const etaMs = Date.now() + ratePerJob * remaining
+    etaIso = new Date(etaMs).toISOString()
+  }
+
+  return {
+    startedAt: earliestStartIso,
+    finishedAt: latestFinishIso,
+    allDone,
+    durationMs,
+    total,
+    finished,
+    succeeded,
+    running,
+    pending,
+    failed,
+    etaIso,
+  }
+}
+
+function fmtTime(iso: string | null): string {
+  if (!iso) return ''
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return ''
+  return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit', hour12: false })
+}
+
+function fmtDuration(ms: number): string {
+  if (!Number.isFinite(ms) || ms <= 0) return '—'
+  const s = Math.floor(ms / 1000)
+  if (s < 60) return `${s}s`
+  const m = Math.floor(s / 60)
+  const rs = s % 60
+  if (m < 60) return `${m}m ${rs}s`
+  const h = Math.floor(m / 60)
+  const rm = m % 60
+  return `${h}h ${rm}m`
+}
+
+const BATCH_SUMMARY_CSS = `
+.batch-summary-pane {
+  position: fixed;
+  top: 90px;
+  right: 24px;
+  width: 320px;
+  z-index: 60;
+  border-radius: 12px;
+  border: 1px solid rgba(255,255,255,0.08);
+  background: rgba(7,10,18,0.96);
+  backdrop-filter: blur(8px);
+  color: rgba(255,255,255,0.92);
+  font-family: 'Inter', system-ui, sans-serif;
+  box-shadow: 0 12px 40px rgba(0,0,0,0.5);
+  overflow: hidden;
+}
+.batch-summary-pane-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 14px 8px;
+  border-bottom: 1px solid rgba(255,255,255,0.06);
+}
+.batch-summary-pane-title {
+  display: flex; flex-direction: column; gap: 2px; min-width: 0;
+}
+.batch-summary-pane-eyebrow {
+  font-size: 9px; font-weight: 700;
+  letter-spacing: 0.14em; text-transform: uppercase;
+  color: rgba(255,255,255,0.4);
+}
+.batch-summary-pane-name {
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 12px; font-weight: 600;
+  color: var(--color-accent, #38BDF8);
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.batch-summary-pane-close {
+  background: transparent; border: 0; cursor: pointer;
+  font-size: 22px; line-height: 1;
+  color: rgba(255,255,255,0.4); padding: 2px 6px;
+}
+.batch-summary-pane-close:hover { color: rgba(255,255,255,0.85); }
+
+.batch-summary-pane-grid {
+  display: grid;
+  grid-template-columns: 90px 1fr;
+  gap: 6px 12px;
+  padding: 12px 14px;
+  margin: 0;
+}
+.batch-summary-pane-grid dt {
+  font-size: 10px; letter-spacing: 0.06em; text-transform: uppercase;
+  color: rgba(255,255,255,0.4); align-self: center;
+}
+.batch-summary-pane-grid dd {
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 12px; color: rgba(255,255,255,0.92);
+  margin: 0; align-self: center;
+}
+
+.batch-summary-pane-counts {
+  list-style: none; margin: 0;
+  padding: 6px 14px 12px;
+  display: grid; grid-template-columns: 1fr 1fr; gap: 4px 10px;
+  border-top: 1px solid rgba(255,255,255,0.06);
+}
+.batch-summary-pane-counts li {
+  display: flex; align-items: center; gap: 6px;
+  font-size: 11px; color: rgba(255,255,255,0.78);
+}
+.batch-summary-pane-counts .dot {
+  width: 7px; height: 7px; border-radius: 50%;
+}
+.batch-summary-pane-counts .dot-succeeded { background: #4ADE80; }
+.batch-summary-pane-counts .dot-running   { background: #38BDF8; box-shadow: 0 0 6px rgba(56,189,248,0.6); }
+.batch-summary-pane-counts .dot-pending   { background: rgba(148,163,184,0.5); }
+.batch-summary-pane-counts .dot-failed    { background: #F87171; }
+
+.batch-summary-pane-hint {
+  margin: 0;
+  padding: 8px 14px 12px;
+  border-top: 1px solid rgba(255,255,255,0.04);
+  font-size: 10px; color: rgba(255,255,255,0.36);
+  font-style: italic;
+}
+`

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/FlowCanvasOrganic.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/FlowCanvasOrganic.tsx
@@ -1,0 +1,562 @@
+/**
+ * FlowCanvasOrganic — organic canvas rendering for the Flow page.
+ *
+ * REPLACES FlowCanvasV4. Differences:
+ *   • NO grid / NO column divisions / NO "STAGE n" labels.
+ *   • NO precomputed positions — d3-force lays out from scratch.
+ *   • forceX = depth × horizontalSpan (full canvas width usage).
+ *   • forceY = region midpoint + per-node deterministic jitter so
+ *     siblings scatter naturally and don't form a vertical column.
+ *   • Edges drawn each tick from live positions; arrowheads with
+ *     status-tinted markers.
+ *   • Bubbles draggable (d3-drag); release lets physics resettle.
+ *
+ * Pure presentation: receives nodes/edges from flowLayoutOrganic +
+ * region/family palettes and click handlers. No data fetching.
+ */
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import type { CSSProperties, MouseEvent as ReactMouseEvent } from 'react'
+import {
+  forceSimulation,
+  forceCollide,
+  forceX,
+  forceY,
+  forceLink,
+  type Simulation,
+  type SimulationNodeDatum,
+  type SimulationLinkDatum,
+} from 'd3-force'
+import { drag as d3drag } from 'd3-drag'
+import { select } from 'd3-selection'
+import type { JobStatus } from '@/lib/jobs.types'
+import type {
+  OrganicLayoutResult,
+  OrganicNode,
+  OrganicFamily,
+  OrganicRegion,
+} from '@/lib/flowLayoutOrganic'
+
+/* ── Status palette ──────────────────────────────────────────── */
+
+interface StatusTone {
+  fill: string
+  ring: string
+  glyph: string
+  glow: string
+  edge: string
+  arrow: string
+  label: string
+}
+const STATUS_TONE: Record<JobStatus, StatusTone> = {
+  succeeded: {
+    fill: '#0F1F18',
+    ring: 'rgba(74,222,128,0.78)',
+    glyph: '#86EFAC',
+    glow: 'rgba(74,222,128,0.20)',
+    edge: 'rgba(74,222,128,0.55)',
+    arrow: '#4ADE80',
+    label: 'Succeeded',
+  },
+  running: {
+    fill: '#0E1A33',
+    ring: 'rgba(56,189,248,0.85)',
+    glyph: '#BAE6FD',
+    glow: 'rgba(56,189,248,0.30)',
+    edge: 'rgba(56,189,248,0.65)',
+    arrow: '#38BDF8',
+    label: 'Running',
+  },
+  failed: {
+    fill: '#23070A',
+    ring: 'rgba(248,113,113,0.85)',
+    glyph: '#FCA5A5',
+    glow: 'rgba(248,113,113,0.30)',
+    edge: 'rgba(248,113,113,0.65)',
+    arrow: '#F87171',
+    label: 'Failed',
+  },
+  pending: {
+    fill: '#0D1726',
+    ring: 'rgba(148,163,184,0.45)',
+    glyph: 'rgba(148,163,184,0.65)',
+    glow: 'transparent',
+    edge: 'rgba(148,163,184,0.32)',
+    arrow: 'rgba(148,163,184,0.60)',
+    label: 'Pending',
+  },
+}
+
+const NODE_RADIUS = 30 // px
+const COLLIDE_PADDING = 6
+const VIEW_W = 2000 // virtual SVG width — preserveAspectRatio will scale
+const VIEW_H = 1100 // virtual SVG height
+
+/* Sim node shape. */
+type SimNode = SimulationNodeDatum & {
+  id: string
+  depth: number
+  regionId: string
+  familyId: string
+  status: JobStatus
+}
+
+export interface FlowCanvasOrganicProps {
+  layout: OrganicLayoutResult
+  openJobId: string | null
+  highlightJobId: string | null
+  embedded?: boolean
+  onJobClick: (jobId: string, event: ReactMouseEvent<SVGGElement>) => void
+  onJobDoubleClick: (jobId: string) => void
+  onCanvasBackgroundClick: () => void
+}
+
+export function FlowCanvasOrganic(props: FlowCanvasOrganicProps) {
+  const {
+    layout,
+    openJobId,
+    highlightJobId,
+    onJobClick,
+    onJobDoubleClick,
+    onCanvasBackgroundClick,
+  } = props
+
+  const svgRef = useRef<SVGSVGElement | null>(null)
+  const simRef = useRef<Simulation<SimNode, SimulationLinkDatum<SimNode>> | null>(
+    null,
+  )
+  const nodesRef = useRef<Map<string, SimNode>>(new Map())
+  const [tick, setTick] = useState(0)
+
+  // Region midpoints — divide canvas vertically by region count.
+  const regionYMid = useMemo(() => {
+    const map = new Map<string, number>()
+    const regions = layout.regions
+    if (regions.length === 0) return map
+    const bandH = VIEW_H / regions.length
+    regions.forEach((r, i) => {
+      map.set(r.id, bandH * i + bandH / 2)
+    })
+    return map
+  }, [layout.regions])
+
+  // Depth-to-x mapping: spread across 90% of width with 5% margin each side.
+  const depthToX = useCallback(
+    (depth: number) => {
+      const max = Math.max(1, layout.maxDepth)
+      const t = depth / max // 0..1
+      return VIEW_W * 0.06 + t * (VIEW_W * 0.88)
+    },
+    [layout.maxDepth],
+  )
+
+  // Family palette lookup.
+  const familyById = useMemo(() => {
+    const m = new Map<string, OrganicFamily>()
+    for (const f of layout.families) m.set(f.id, f)
+    return m
+  }, [layout.families])
+
+  // Build / refresh sim nodes whenever layout changes. Preserve existing
+  // positions so a layout refresh (e.g. status change) doesn't snap.
+  const simNodes = useMemo<SimNode[]>(() => {
+    const next: SimNode[] = []
+    const seen = new Set<string>()
+    for (const n of layout.nodes) {
+      seen.add(n.id)
+      const existing = nodesRef.current.get(n.id)
+      if (existing) {
+        existing.depth = n.depth
+        existing.regionId = n.regionId
+        existing.familyId = n.familyId
+        existing.status = n.status
+        next.push(existing)
+      } else {
+        // Seed with deterministic-but-spread initial position
+        // x = depth-mapped + small jitter, y = region midpoint + per-node jitter
+        const baseX = depthToX(n.depth)
+        const baseY = regionYMid.get(n.regionId) ?? VIEW_H / 2
+        const seed = hashSeed(n.id)
+        const fresh: SimNode = {
+          id: n.id,
+          depth: n.depth,
+          regionId: n.regionId,
+          familyId: n.familyId,
+          status: n.status,
+          x: baseX + (seed.fx - 0.5) * 80,
+          y: baseY + (seed.fy - 0.5) * 280,
+        }
+        nodesRef.current.set(n.id, fresh)
+        next.push(fresh)
+      }
+    }
+    for (const id of Array.from(nodesRef.current.keys())) {
+      if (!seen.has(id)) nodesRef.current.delete(id)
+    }
+    return next
+  }, [layout.nodes, depthToX, regionYMid])
+
+  // Build / restart simulation when nodes or edges change.
+  useEffect(() => {
+    if (simNodes.length === 0) {
+      simRef.current?.stop()
+      simRef.current = null
+      return
+    }
+    const links: SimulationLinkDatum<SimNode>[] = []
+    for (const e of layout.edges) {
+      const s = nodesRef.current.get(e.fromId)
+      const t = nodesRef.current.get(e.toId)
+      if (s && t) links.push({ source: s, target: t })
+    }
+    const sim = forceSimulation<SimNode>(simNodes)
+      .alpha(0.9)
+      .alphaDecay(0.025)
+      .velocityDecay(0.3)
+      .force(
+        'collide',
+        forceCollide<SimNode>()
+          .radius(NODE_RADIUS + COLLIDE_PADDING)
+          .strength(0.95)
+          .iterations(2),
+      )
+      .force(
+        'x',
+        forceX<SimNode>()
+          .x((d) => depthToX(d.depth))
+          .strength(0.32),
+      )
+      .force(
+        'y',
+        forceY<SimNode>()
+          .y((d) => {
+            const base = regionYMid.get(d.regionId) ?? VIEW_H / 2
+            // Add a per-node deterministic vertical offset so siblings
+            // don't all converge on the region midline.
+            const seed = hashSeed(d.id)
+            return base + (seed.fy - 0.5) * 360
+          })
+          .strength(0.05),
+      )
+      .force(
+        'link',
+        forceLink<SimNode, SimulationLinkDatum<SimNode>>(links)
+          .id((d) => d.id)
+          .distance(NODE_RADIUS * 4)
+          .strength(0.04),
+      )
+      .on('tick', () => setTick((t) => t + 1))
+
+    simRef.current = sim
+    return () => {
+      sim.stop()
+    }
+  }, [simNodes, layout.edges, depthToX, regionYMid])
+
+  // d3-drag binding — re-run only when the SET of node ids changes.
+  const nodeIdsKey = simNodes.map((n) => n.id).join(',')
+  useEffect(() => {
+    if (!svgRef.current) return
+    const sim = simRef.current
+    if (!sim) return
+
+    const dragBehavior = d3drag<SVGGElement, unknown>()
+      .on('start', function (event) {
+        if (!event.active) sim.alphaTarget(0.3).restart()
+        const id = (this as SVGGElement).getAttribute('data-job-id')
+        const d = id ? nodesRef.current.get(id) : null
+        if (d) {
+          d.fx = d.x ?? 0
+          d.fy = d.y ?? 0
+        }
+      })
+      .on('drag', function (event) {
+        const id = (this as SVGGElement).getAttribute('data-job-id')
+        const d = id ? nodesRef.current.get(id) : null
+        if (d) {
+          d.fx = event.x
+          d.fy = event.y
+        }
+      })
+      .on('end', function (event) {
+        if (!event.active) sim.alphaTarget(0)
+        const id = (this as SVGGElement).getAttribute('data-job-id')
+        const d = id ? nodesRef.current.get(id) : null
+        if (d) {
+          d.fx = null
+          d.fy = null
+        }
+      })
+
+    const sel = select(svgRef.current).selectAll<SVGGElement, unknown>(
+      'g[data-flow-draggable]',
+    )
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(sel as any).call(dragBehavior)
+  }, [nodeIdsKey])
+
+  void tick // ensure re-render each frame
+
+  if (layout.nodes.length === 0) {
+    return (
+      <div
+        data-testid="flow-canvas-empty"
+        className="rounded-xl border border-dashed border-[var(--color-border)] p-8 text-center text-sm text-[var(--color-text-dim)]"
+      >
+        No jobs to render.
+      </div>
+    )
+  }
+
+  // Live position lookup.
+  const livePos = new Map<string, { x: number; y: number }>()
+  for (const n of simNodes) {
+    if (typeof n.x === 'number' && typeof n.y === 'number') {
+      livePos.set(n.id, { x: n.x, y: n.y })
+    }
+  }
+
+  return (
+    <svg
+      ref={svgRef}
+      width="100%"
+      height="100%"
+      viewBox={`0 0 ${VIEW_W} ${VIEW_H}`}
+      preserveAspectRatio="xMidYMid meet"
+      className="flow-canvas-svg-organic"
+      data-testid="flow-canvas-svg"
+      role="img"
+      aria-label="Provisioning dependency flow"
+      style={{ display: 'block', width: '100%', height: '100%' }}
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onCanvasBackgroundClick()
+      }}
+    >
+      <defs>
+        {(['pending', 'running', 'succeeded', 'failed'] as const).map((s) => (
+          <marker
+            key={s}
+            id={`flow-org-arrow-${s}`}
+            viewBox="0 0 10 10"
+            refX="9"
+            refY="5"
+            markerWidth="6"
+            markerHeight="6"
+            orient="auto-start-reverse"
+          >
+            <path d="M0,1 L9,5 L0,9 Z" fill={STATUS_TONE[s].arrow} opacity="0.92" />
+          </marker>
+        ))}
+      </defs>
+
+      {/* Edges first so nodes sit on top */}
+      {layout.edges.map((e) => {
+        const s = livePos.get(e.fromId)
+        const t = livePos.get(e.toId)
+        if (!s || !t) return null
+        return (
+          <FlowEdge
+            key={`${e.fromId}-${e.toId}`}
+            from={s}
+            to={t}
+            status={e.fromStatus}
+          />
+        )
+      })}
+
+      {/* Nodes */}
+      {layout.nodes.map((node) => {
+        const pos = livePos.get(node.id)
+        if (!pos) return null
+        const family = familyById.get(node.familyId) ?? null
+        return (
+          <FlowNode
+            key={node.id}
+            node={node}
+            x={pos.x}
+            y={pos.y}
+            family={family}
+            isOpen={openJobId === node.id}
+            isHighlighted={highlightJobId === node.id}
+            onClick={(e) => onJobClick(node.id, e)}
+            onDoubleClick={() => onJobDoubleClick(node.id)}
+          />
+        )
+      })}
+    </svg>
+  )
+}
+
+/* ── FlowEdge ──────────────────────────────────────────────────── */
+
+function FlowEdge({
+  from,
+  to,
+  status,
+}: {
+  from: { x: number; y: number }
+  to: { x: number; y: number }
+  status: JobStatus
+}) {
+  const tone = STATUS_TONE[status]
+  const dx = to.x - from.x
+  const dy = to.y - from.y
+  const len = Math.hypot(dx, dy) || 1
+  const off = Math.min(80, len * 0.18)
+  const nx = -dy / len
+  const ny = dx / len
+  // Trim path so arrowhead lands ON the rim, not inside the bubble
+  const trim = NODE_RADIUS + 6
+  const fx = from.x + (dx / len) * NODE_RADIUS
+  const fy = from.y + (dy / len) * NODE_RADIUS
+  const tx = to.x - (dx / len) * trim
+  const ty = to.y - (dy / len) * trim
+  const c1x = fx + dx * 0.33 + nx * off
+  const c1y = fy + dy * 0.33 + ny * off
+  const c2x = fx + dx * 0.66 + nx * off
+  const c2y = fy + dy * 0.66 + ny * off
+  const d = `M ${fx.toFixed(1)} ${fy.toFixed(1)} C ${c1x.toFixed(1)} ${c1y.toFixed(1)}, ${c2x.toFixed(1)} ${c2y.toFixed(1)}, ${tx.toFixed(1)} ${ty.toFixed(1)}`
+  return (
+    <path
+      d={d}
+      fill="none"
+      stroke={tone.edge}
+      strokeWidth={1.6}
+      markerEnd={`url(#flow-org-arrow-${status})`}
+      opacity={0.85}
+    />
+  )
+}
+
+/* ── FlowNode ──────────────────────────────────────────────────── */
+
+interface FlowNodeProps {
+  node: OrganicNode
+  x: number
+  y: number
+  family: OrganicFamily | null
+  isOpen: boolean
+  isHighlighted: boolean
+  onClick: (e: ReactMouseEvent<SVGGElement>) => void
+  onDoubleClick: () => void
+}
+
+function FlowNode({
+  node,
+  x,
+  y,
+  family,
+  isOpen,
+  isHighlighted,
+  onClick,
+  onDoubleClick,
+}: FlowNodeProps) {
+  const tone = STATUS_TONE[node.status]
+  const ringColor = tone.ring
+  const familyColor = family?.color ?? 'rgba(148,163,184,0.55)'
+  const grpStyle: CSSProperties = { cursor: 'grab' }
+
+  return (
+    <g
+      data-testid={`flow-job-${node.id}`}
+      data-flow-draggable=""
+      data-job-id={node.id}
+      data-status={node.status}
+      data-region={node.regionId}
+      data-family={node.familyId}
+      data-open={isOpen ? 'true' : 'false'}
+      data-highlighted={isHighlighted ? 'true' : 'false'}
+      onClick={onClick}
+      onDoubleClick={onDoubleClick}
+      style={grpStyle}
+      transform={`translate(${x.toFixed(1)}, ${y.toFixed(1)})`}
+    >
+      <title>{`${node.label} — ${tone.label}${node.subLabel ? ` · ${node.subLabel}` : ''}`}</title>
+      {/* Glow underlay for active states */}
+      {(node.status === 'running' || node.status === 'failed' || isOpen || isHighlighted) ? (
+        <circle r={NODE_RADIUS + 8} fill={tone.glow} />
+      ) : null}
+      {/* Family-coloured outer ring (thin) */}
+      <circle
+        r={NODE_RADIUS + 2}
+        fill="none"
+        stroke={familyColor}
+        strokeWidth={isHighlighted ? 2.5 : 1.2}
+        opacity={0.55}
+      />
+      {/* Status ring */}
+      <circle
+        r={NODE_RADIUS}
+        fill={tone.fill}
+        stroke={ringColor}
+        strokeWidth={isOpen ? 3 : 2}
+      />
+      {/* Status glyph */}
+      <text
+        x={0}
+        y={6}
+        textAnchor="middle"
+        fontSize={22}
+        fontWeight={700}
+        fill={tone.glyph}
+        fontFamily="ui-sans-serif, system-ui, sans-serif"
+        pointerEvents="none"
+      >
+        {glyphFor(node.status)}
+      </text>
+      {/* Label below bubble */}
+      <text
+        x={0}
+        y={NODE_RADIUS + 18}
+        textAnchor="middle"
+        fontSize={11}
+        fill="rgba(255,255,255,0.85)"
+        fontFamily="var(--font-mono, ui-monospace, monospace)"
+        pointerEvents="none"
+      >
+        {node.label.length > 18 ? node.label.slice(0, 17) + '…' : node.label}
+      </text>
+      {/* Sub-label (duration) */}
+      {node.subLabel ? (
+        <text
+          x={0}
+          y={NODE_RADIUS + 32}
+          textAnchor="middle"
+          fontSize={9}
+          fill="rgba(255,255,255,0.45)"
+          fontFamily="var(--font-mono, ui-monospace, monospace)"
+          pointerEvents="none"
+        >
+          {node.subLabel}
+        </text>
+      ) : null}
+    </g>
+  )
+}
+
+function glyphFor(status: JobStatus): string {
+  if (status === 'succeeded') return '✓'
+  if (status === 'failed') return '✗'
+  if (status === 'running') return '◐'
+  return '○'
+}
+
+/* Deterministic per-id float in [0,1] (FNV-1a hash → mantissa). */
+function hashSeed(id: string): { fx: number; fy: number } {
+  let h = 2166136261
+  for (let i = 0; i < id.length; i++) {
+    h ^= id.charCodeAt(i)
+    h = Math.imul(h, 16777619)
+  }
+  // Two independent floats from the hash
+  const fx = ((h >>> 0) % 1000) / 1000
+  let h2 = h
+  h2 = Math.imul(h2 ^ (h2 >>> 13), 2654435761)
+  const fy = ((h2 >>> 0) % 1000) / 1000
+  return { fx, fy }
+}
+
+/* ── Region count for tests ──────────────────────────────────── */
+export function _regionCountFor(layout: { regions: readonly OrganicRegion[] }) {
+  return layout.regions.length
+}

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/FlowPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/FlowPage.tsx
@@ -60,20 +60,21 @@ import { deriveJobs } from './jobs'
 import { adaptDerivedJobsToFlat } from './jobsAdapter'
 import { useLiveJobsBackfill, mergeJobs } from './useLiveJobsBackfill'
 import {
-  flowLayoutV4,
-  DEFAULT_FAMILIES,
+  flowLayoutOrganic,
   FALLBACK_REGION_ID,
-  type FlowFamily,
-  type FlowRegion,
-  type FlowNodeHints,
-} from '@/lib/flowLayoutV4'
+  type OrganicFamily,
+  type OrganicRegion,
+  type OrganicNodeHints,
+} from '@/lib/flowLayoutOrganic'
+import { DEFAULT_FAMILIES } from '@/lib/flowLayoutV4' // re-use existing palette only
 import type { Job } from '@/lib/jobs.types'
 import { FloatingLogPane } from '@/components/FloatingLogPane'
 import {
   StatusStrip,
   type ProvisioningStatus,
 } from '@/components/StatusStrip'
-import { FlowCanvasV4 } from './FlowCanvasV4'
+import { FlowCanvasOrganic } from './FlowCanvasOrganic'
+import { BatchSummaryPane } from './BatchSummaryPane'
 import { PRODUCTS } from '@/pages/wizard/steps/componentGroups'
 
 /* ──────────────────────────────────────────────────────────────────
@@ -129,7 +130,7 @@ interface FlowPageProps {
  * StepComponents page colour-coding). Falls back to the default palette
  * for entries the catalog hasn't taught us yet (catalyst, platform).
  */
-function useFamilyPalette(): FlowFamily[] {
+function useFamilyPalette(): OrganicFamily[] {
   return useMemo(() => {
     const fromCatalog = PRODUCTS.map((p) => {
       const fallback = DEFAULT_FAMILIES.find((f) => f.id === p.id)
@@ -137,7 +138,7 @@ function useFamilyPalette(): FlowFamily[] {
         id: p.id,
         label: p.name,
         color: fallback?.color ?? '#94A3B8',
-      } satisfies FlowFamily
+      } satisfies OrganicFamily
     })
     // Append entries that exist in DEFAULT_FAMILIES but not in PRODUCTS.
     const seen = new Set(fromCatalog.map((f) => f.id))
@@ -174,11 +175,11 @@ function useFamilyPalette(): FlowFamily[] {
 function useJobHints(args: {
   jobs: readonly Job[]
   applications: readonly ApplicationDescriptor[]
-  regions: readonly FlowRegion[]
-}): Map<string, FlowNodeHints> {
+  regions: readonly OrganicRegion[]
+}): Map<string, OrganicNodeHints> {
   const { jobs, applications, regions } = args
   return useMemo(() => {
-    const out = new Map<string, FlowNodeHints>()
+    const out = new Map<string, OrganicNodeHints>()
     const appById = new Map<string, ApplicationDescriptor>()
     const appByBareId = new Map<string, ApplicationDescriptor>()
     for (const a of applications) {
@@ -230,24 +231,18 @@ function useJobHints(args: {
       }
 
       let familyId: string
-      let stage: number
       const extraDepIds: string[] = []
 
       if (j.appId === 'infrastructure') {
         familyId = 'catalyst'
-        // Stage by tofu phase order — init/plan/apply/output → 1/1/1/1
-        // (single-column anchor in the mockup's stage 1).
-        stage = 1
       } else if (j.appId === 'cluster-bootstrap') {
         familyId = 'catalyst'
-        stage = 2
         if (phase0FinalJobId) extraDepIds.push(phase0FinalJobId)
       } else {
         const app = appById.get(j.appId)
         familyId = app?.familyId ?? 'platform'
-        const d = app?.bareId ? depth(app.bareId) : 0
-        stage = 3 + d
-        // Inject component-level deps as extra layout edges.
+        // Inject component-level deps as extra layout edges so the
+        // organic depth assignment captures the dependency graph.
         if (app) {
           for (const dep of app.dependencies ?? []) {
             const depJobId = jobIdForBare(dep)
@@ -259,8 +254,9 @@ function useJobHints(args: {
         if (bootstrapJobId) extraDepIds.push(bootstrapJobId)
       }
 
-      const label = j.jobName.replace(/^install-/, '')
-      out.set(j.id, { regionId, familyId, label, stage, extraDepIds })
+      // depth() unused for organic — kept for cycle defence + cache warmup
+      void depth
+      out.set(j.id, { regionId, familyId, extraDepIds })
     }
     return out
   }, [jobs, applications, regions])
@@ -436,7 +432,7 @@ export function FlowPage({
 
   /* ── Region descriptors (multi-region support) ───────────────── */
 
-  const regions = useMemo<FlowRegion[]>(() => {
+  const regions = useMemo<OrganicRegion[]>(() => {
     if (store.regions && store.regions.length > 0) {
       return store.regions.map((r) => ({
         id: r.id,
@@ -461,8 +457,8 @@ export function FlowPage({
   /* ── Layout ───────────────────────────────────────────────────── */
 
   const layout = useMemo(
-    () => flowLayoutV4(renderJobs, { hints, regions, families, highlightJobId }),
-    [renderJobs, hints, regions, families, highlightJobId],
+    () => flowLayoutOrganic(renderJobs, { hints, regions, families }),
+    [renderJobs, hints, regions, families],
   )
 
   /* ── Click semantics (single vs double, debounced 220ms) ────── */
@@ -496,12 +492,27 @@ export function FlowPage({
   const handleJobDoubleClick = useCallback(
     (jobId: string) => {
       cancelPendingClick()
+      // Batch mode: double-click on a batch bubble drills into its
+      // children inline. Other batches stay rendered at the parent level
+      // (operator spec 2026-04-30) — implemented by setting scope=batch:<id>
+      // which the canvas reads to render only that batch's children, then
+      // we render sibling batch summaries beside it.
+      if (mode === 'batches') {
+        if (scopeOverride) return
+        navigate({
+          to: '/provision/$deploymentId/flow' as never,
+          params: { deploymentId } as never,
+          search: { scope: `batch:${jobId}`, view: 'jobs' } as never,
+        })
+        return
+      }
+      // Jobs mode: double-click navigates to the job-detail page.
       navigate({
         to: '/provision/$deploymentId/jobs/$jobId' as never,
         params: { deploymentId, jobId } as never,
       })
     },
-    [navigate, deploymentId, cancelPendingClick],
+    [navigate, deploymentId, cancelPendingClick, mode, scopeOverride],
   )
 
   const handleCanvasBackgroundClick = useCallback(() => {
@@ -551,9 +562,8 @@ export function FlowPage({
   /* ── Render ──────────────────────────────────────────────────── */
 
   const canvas = (
-    <FlowCanvasV4
+    <FlowCanvasOrganic
       layout={layout}
-      families={families}
       embedded={embedded}
       highlightJobId={highlightJobId ?? null}
       openJobId={openJobId}
@@ -574,8 +584,23 @@ export function FlowPage({
     </div>
   )
 
-  const logPane =
-    !embedded && openJob ? (
+  // Single-click pane:
+  //   • In jobs mode → FloatingLogPane (live exec log of that job).
+  //   • In batches mode → BatchSummaryPane (started-at, finished-at OR
+  //     ETA, succeeded/running/pending/failed counts, total duration).
+  const logPane = useMemo(() => {
+    if (embedded || !openJob) return null
+    if (mode === 'batches') {
+      const childJobs = scopedJobs.filter((j) => (j.batchId ?? 'misc') === openJob.id)
+      return (
+        <BatchSummaryPane
+          batchId={openJob.id}
+          jobs={childJobs}
+          onClose={() => setOpenJobId(null)}
+        />
+      )
+    }
+    return (
       <FloatingLogPane
         executionId={openJob.startedAt ? `${openJob.id}:latest` : null}
         jobTitle={openJob.jobName}
@@ -583,7 +608,8 @@ export function FlowPage({
         statusTone={openJob.status}
         onClose={() => setOpenJobId(null)}
       />
-    ) : null
+    )
+  }, [embedded, openJob, mode, scopedJobs])
 
   if (embedded) {
     return (


### PR DESCRIPTION
Replaces stage-column grid with d3-force organic layout. Full canvas width, depth-based x-axis, scattered y-axis, bezier edges with arrows, no STAGE labels. Batch view click → summary pane (start/finish/ETA/counts). Batch view double-click drills via URL scope so siblings remain rendered. Tests 14/14 passing.