### PR TITLE
fix(helmwatch): default CoreFactory so logtailer actually runs in production (#305 follow-up)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/helmwatch/helmwatch.go
+++ b/products/catalyst/bootstrap/api/internal/helmwatch/helmwatch.go
@@ -379,6 +379,15 @@ func NewWatcher(cfg Config, emit Emit) (*Watcher, error) {
 	if cfg.DynamicFactory == nil {
 		cfg.DynamicFactory = NewDynamicClientFromKubeconfig
 	}
+	if cfg.CoreFactory == nil {
+		// Production default: same kubeconfig → typed clientset for the
+		// helm-controller log tailer. Without this fallback, every
+		// `bp-*` HelmRelease's raw helm-controller stdout would be
+		// dropped — the FE log viewer would only ever render synthetic
+		// `[seeded]` / `[<state>]` summary lines. See issue #305.
+		// Tests still inject a fake.NewSimpleClientset via Config.CoreFactory.
+		cfg.CoreFactory = NewKubernetesClientFromKubeconfig
+	}
 	cfg.applyDefaults()
 	return &Watcher{
 		cfg:      cfg,

--- a/products/catalyst/bootstrap/api/internal/helmwatch/helmwatch_test.go
+++ b/products/catalyst/bootstrap/api/internal/helmwatch/helmwatch_test.go
@@ -608,6 +608,33 @@ func TestWatch_NilEmitRejected(t *testing.T) {
 	}
 }
 
+// TestNewWatcher_DefaultsBothFactories locks in the production wiring:
+// when the caller leaves DynamicFactory AND CoreFactory unset, NewWatcher
+// fills them with the real-cluster constructors so the dynamic informer
+// runs AND the helm-controller log tailer runs (issue #305 — without the
+// CoreFactory default, every PhaseComponentLog event would be silently
+// dropped because the tailer never started in production).
+func TestNewWatcher_DefaultsBothFactories(t *testing.T) {
+	rec := &recorder{}
+	// Provide a parseable kubeconfig YAML so NewWatcher doesn't reject
+	// it on the empty-string check; the factories are NOT invoked here
+	// (Watch() invokes them) so the kubeconfig contents don't have to
+	// resolve to a real cluster.
+	cfg := Config{
+		KubeconfigYAML: "apiVersion: v1\nkind: Config\nclusters: []\ncontexts: []\nusers: []\n",
+	}
+	w, err := NewWatcher(cfg, rec.emit)
+	if err != nil {
+		t.Fatalf("NewWatcher: %v", err)
+	}
+	if w.cfg.DynamicFactory == nil {
+		t.Errorf("DynamicFactory must default to NewDynamicClientFromKubeconfig in production")
+	}
+	if w.cfg.CoreFactory == nil {
+		t.Errorf("CoreFactory must default to NewKubernetesClientFromKubeconfig in production (regression for #305 — log tailer was disabled in prod)")
+	}
+}
+
 // TestWatch_OnlyEmitsOnTransition proves the de-dup branch: a second
 // informer Update event for the same HelmRelease with no state change
 // (e.g. a status subresource patch from helm-controller's


### PR DESCRIPTION
Follow-up to #307. Without this, the helm-controller log tailer was silently disabled in production: `handler.New()` never assigns `h.coreFactory`, so `phase1_watch.go` left `cfg.CoreFactory == nil`, and `helmwatch.NewWatcher` had no default for it. Every `PhaseComponentLog` event was dropped. The GitLab-style log viewer only ever rendered the synthetic `[seeded]` / `[<state>]` anchor lines.

Fix: NewWatcher defaults `CoreFactory` to `NewKubernetesClientFromKubeconfig` (mirroring the existing `DynamicFactory` default).

New regression test `TestNewWatcher_DefaultsBothFactories` locks both defaults in.

Closes the raw-log-capture half of #305.