### PR TITLE
fix(helmwatch): logtailer parses flux v2.4 nested-object HelmRelease format (#305 follow-up 2)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/helmwatch/logtailer.go
+++ b/products/catalyst/bootstrap/api/internal/helmwatch/logtailer.go
@@ -34,20 +34,37 @@ import (
 )
 
 // helmControllerNameRe — extracts the bp-<name> token from a
-// helm-controller log line. helm-controller's log format varies by
-// version + the configured logger; we observe two stable shapes
-// against flux v2.4 (the version Catalyst-Zero pins):
+// helm-controller log line. helm-controller's log shape varies by
+// version + the configured logger; we observe THREE stable formats
+// in production against flux v2.4 (the version Catalyst-Zero pins):
 //
-//   - logr/klog text: `... helmrelease="flux-system/bp-cilium" ...`
-//   - structured JSON: `... "helmrelease":"flux-system/bp-cilium" ...`
+//   - flat-string structured JSON:
+//       `... "helmrelease":"flux-system/bp-cilium" ...`
+//   - flat-string logr/klog text:
+//       `... helmrelease="flux-system/bp-cilium" ...`
+//   - NESTED-OBJECT structured JSON (live shape on otech.omani.works):
+//       `... "HelmRelease":{"name":"bp-cilium","namespace":"flux-system"}, ...`
 //
-// The regex tolerates either separator (`=` or `":` with surrounding
-// quotes) and either casing of the key. A future helm-controller
-// release that switches to a third shape lands here as a test
-// failure on the structured/text fixtures in logtailer_test.go.
+// The third shape is what flux v2.4's helm-controller actually emits
+// in production. The first two are still observed in legacy / debug
+// modes and on older fluxes. The regex alternates across all three so
+// every line is parsed correctly. A future helm-controller release
+// that switches to a fourth shape lands here as a test failure on the
+// fixtures in logtailer_test.go.
+//
+// Issue #305: without the nested-object alternation, every raw
+// helm-controller line was silently dropped — the GitLab-style log
+// viewer only ever rendered synthetic [seeded] / [<state>] anchor
+// lines.
 var helmControllerNameRe = regexp.MustCompile(
-	`(?:helmrelease|HelmRelease)["']?\s*[:=]\s*["']?` +
-		regexp.QuoteMeta(FluxNamespace) + `/(bp-[a-z0-9-]+)`,
+	// Alternative 1+2 — flat string `helmrelease[":=]flux-system/bp-X`
+	`(?:` +
+		`(?:helmrelease|HelmRelease)["']?\s*[:=]\s*["']?` +
+		regexp.QuoteMeta(FluxNamespace) + `/(bp-[a-z0-9-]+)` +
+		`)|(?:` +
+		// Alternative 3 — nested object `"HelmRelease":{...,"name":"bp-X",...}`
+		`["']?HelmRelease["']?\s*:\s*\{[^}]*?["']?name["']?\s*:\s*["'](bp-[a-z0-9-]+)["']` +
+		`)`,
 )
 
 type logTailer struct {
@@ -164,7 +181,7 @@ func (t *logTailer) pumpLines(ctx context.Context, stream io.Reader) error {
 			continue
 		}
 		match := helmControllerNameRe.FindStringSubmatch(line)
-		if len(match) < 2 {
+		if len(match) < 3 {
 			// Not associated with a bp-* HelmRelease — skip. The
 			// Sovereign Admin's Logs tab filters by component, so
 			// noise from the helm-controller's leader-election or
@@ -172,7 +189,17 @@ func (t *logTailer) pumpLines(ctx context.Context, stream io.Reader) error {
 			// component," which is not useful.
 			continue
 		}
-		componentID := ComponentIDFromHelmRelease(match[1])
+		// The regex has two alternatives, each with its own capture
+		// group; exactly one is populated per match. Pick whichever
+		// fired so the downstream emit doesn't see an empty string.
+		bpName := match[1]
+		if bpName == "" {
+			bpName = match[2]
+		}
+		if bpName == "" {
+			continue
+		}
+		componentID := ComponentIDFromHelmRelease(bpName)
 		t.emit(provisioner.Event{
 			Time:      t.now().UTC().Format(time.RFC3339),
 			Phase:     PhaseComponentLog,

--- a/products/catalyst/bootstrap/api/internal/helmwatch/logtailer_test.go
+++ b/products/catalyst/bootstrap/api/internal/helmwatch/logtailer_test.go
@@ -20,10 +20,19 @@ func TestPumpLines_ExtractsBPNameAndEmitsComponentLog(t *testing.T) {
 	tailer := newLogTailer(nil, rec.emit, time.Now)
 
 	input := strings.Join([]string{
+		// Flat-string structured JSON (legacy)
 		`{"level":"info","ts":"2026-04-29T10:00:00Z","logger":"controllers.HelmRelease","msg":"running install","helmrelease":"flux-system/bp-cilium"}`,
+		// Flat-string structured JSON, capitalised key (legacy)
 		`{"level":"error","ts":"2026-04-29T10:00:05Z","msg":"chart pull failed","HelmRelease":"flux-system/bp-cert-manager"}`,
-		`{"level":"info","msg":"leader election lost"}`, // no bp- token → must be skipped
-		`{"level":"warn","msg":"reconcile took too long","helmrelease":"flux-system/bp-keycloak"}`,
+		// Leader-election noise — no bp- token, must be skipped.
+		`{"level":"info","msg":"leader election lost"}`,
+		// logr/klog text shape (legacy)
+		`level=warn msg="reconcile took too long" helmrelease="flux-system/bp-keycloak"`,
+		// Real flux v2.4 NESTED-OBJECT shape — the production format
+		// (regression for #305 — was silently dropped before the
+		// alternation was added).
+		`{"level":"info","ts":"2026-04-30T18:37:49.961Z","msg":"dependencies do not meet ready condition","HelmRelease":{"name":"bp-mimir","namespace":"flux-system"},"name":"bp-mimir","namespace":"flux-system"}`,
+		`{"level":"error","ts":"2026-04-30T18:37:49.962Z","msg":"chart pull error","HelmRelease":{"name":"bp-seaweedfs","namespace":"flux-system"}}`,
 	}, "\n") + "\n"
 
 	if err := tailer.pumpLines(context.Background(), strings.NewReader(input)); err != nil {
@@ -31,8 +40,8 @@ func TestPumpLines_ExtractsBPNameAndEmitsComponentLog(t *testing.T) {
 	}
 
 	events := rec.snapshot()
-	if got, want := len(events), 3; got != want {
-		t.Fatalf("expected %d events (3 with bp-*, 1 leader-election skipped), got %d:\n%+v", want, got, events)
+	if got, want := len(events), 5; got != want {
+		t.Fatalf("expected %d events (5 with bp-*, 1 leader-election skipped), got %d:\n%+v", want, got, events)
 	}
 
 	// Component derivation + level classification.
@@ -43,6 +52,8 @@ func TestPumpLines_ExtractsBPNameAndEmitsComponentLog(t *testing.T) {
 		"cilium":       {level: "info", state: ""},
 		"cert-manager": {level: "error", state: ""},
 		"keycloak":     {level: "warn", state: ""},
+		"mimir":        {level: "info", state: ""},
+		"seaweedfs":    {level: "error", state: ""},
 	}
 	for _, ev := range events {
 		if ev.Phase != PhaseComponentLog {


### PR DESCRIPTION
Second follow-up to #307. Even with #311's CoreFactory wiring in place, every helm-controller stdout line was still being silently dropped because the parser regex didn't match the format flux v2.4 actually emits.

## Live evidence (otech cluster, helm-controller-86c6b84dcd-t58td)
```
{"level":"info","ts":"2026-04-30T18:37:49Z","msg":"reconciling","HelmRelease":{"name":"bp-mimir","namespace":"flux-system"},"name":"bp-mimir","namespace":"flux-system"}
```

## What the old regex expected
`(?:helmrelease|HelmRelease)[":=]flux-system/(bp-...)` — i.e. a flat-string format like `"helmrelease":"flux-system/bp-cilium"`. flux v2.4 doesn't emit that.

## Fix
Regex alternates across all three observed shapes (flat-string colon, flat-string equals, nested-object name+namespace). pumpLines picks whichever capture group fired.

## Tests
Existing TestPumpLines_ExtractsBPNameAndEmitsComponentLog extended with two flux v2.4 fixtures copied verbatim from otech's helm-controller stdout — proves the regex now picks them up.

After this PR: the GitLab-style log viewer on `/sovereign/provision/{id}/jobs/{jobId}` actually renders real helm-controller output for every active `bp-*` HelmRelease, not just the synthetic anchor lines. Closes the raw-log-capture half of #305 in production.