### PR TITLE
fix(bp-crossplane-claims): event-driven HR install — disableWait, drop 15m timeout

### DIFF
--- a/clusters/_template/bootstrap-kit/14-crossplane-claims.yaml
+++ b/clusters/_template/bootstrap-kit/14-crossplane-claims.yaml
@@ -30,7 +30,6 @@ metadata:
   namespace: flux-system
 spec:
   interval: 15m
-  timeout: 15m
   releaseName: crossplane-claims
   targetNamespace: crossplane-system
   # bp-crossplane installs the apiextensions.crossplane.io/v1 CRDs
@@ -50,9 +49,15 @@ spec:
         kind: HelmRepository
         name: bp-crossplane-claims
         namespace: flux-system
+  # Event-driven install: Helm completes when manifests apply, not when the
+  # XRD-backed CRs reach Ready. dependsOn on bp-crossplane already gates this
+  # HR on the upstream CRDs being live; disableWait replaces PR #221's
+  # blanket spec.timeout: 15m band-aid.
   install:
+    disableWait: true
     remediation:
       retries: 3
   upgrade:
+    disableWait: true
     remediation:
       retries: 3


### PR DESCRIPTION
## Summary

Adds the canonical event-driven HelmRelease pattern to `clusters/_template/bootstrap-kit/14-crossplane-claims.yaml`:

```yaml
install:
  disableWait: true
upgrade:
  disableWait: true
# (no spec.timeout)
```

PR #247 authored `bp-crossplane-claims` as the CRD-ordering split off `bp-crossplane`, but the new HelmRelease shipped with `spec.timeout: 15m` — the same blanket-timeout pattern PR #250 was already removing from the rest of bootstrap-kit. This catches slot 14 up.

## Why this PR is now slot-14-only (was 8 files)

Original sweep also touched slots 20–26 (opentelemetry / alloy / loki / mimir / tempo / grafana / langfuse). After verifying against the canonical 15-chart Phase 0 in #310, those Day-1 charts will be removed entirely from `clusters/_template/bootstrap-kit/` — editing files about to be deleted is noise. Trimmed accordingly. If a Day-1 chart resurfaces post-#310 (in a marketplace overlay), the `disableWait` pattern travels via documentation.

## What this PR does NOT cover

- **Slot 04 (`bp-crossplane`)** — separate scope; the controller HR's timeout removal is for Agent A's owner.
- **Slot 11 (`bp-powerdns`)** — covered by PR #329.
- **Slots 20–26** — slated for removal by #310; not touched here.

## Test plan

- [ ] Flux reconciles `bp-crossplane-claims` HR; install completes when manifests apply (not when XRD-backed CRs reach Ready)
- [ ] Downstream HRs that depend on `bp-crossplane-claims` start when its `Ready=True` is achieved (Flux `dependsOn` semantics)
- [ ] No regression on otech.omani.works (`bp-crossplane-claims` already Ready=True at chart 1.0.0)

## Refs

- #310 (Phase 0 trim — slots 20-26 removal upcoming)
- #250 (event-driven pattern established)
- #247 (`bp-crossplane-claims` authored — missed the pattern)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
