### PR TITLE
fix(catalyst-ui): JobDetail fetches /jobs/{id} with RAW colon, not %3A (#305 follow-up 3)

### DIFF
--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/JobDetail.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/JobDetail.test.tsx
@@ -296,10 +296,12 @@ describe('JobDetail — Exec Log tab wires the real execution id (regression for
           json: () => Promise.resolve({ jobs: [job] }),
         } as unknown as Response)
       }
-      // /jobs/{jobId} (detail) → emit the executions[].
+      // /jobs/{jobId} (detail) → emit the executions[]. The jobId is
+      // inserted raw (NOT encodeURIComponent'd) so the colon survives
+      // — chi's path matcher rejects %3A. See useJobDetail.ts.
       if (
         url.endsWith(
-          `/v1/deployments/${encodeURIComponent(deploymentId)}/jobs/${encodeURIComponent(jobId)}`,
+          `/v1/deployments/${encodeURIComponent(deploymentId)}/jobs/${jobId}`,
         )
       ) {
         return Promise.resolve({
@@ -376,6 +378,12 @@ describe('JobDetail — Exec Log tab wires the real execution id (regression for
         .toBe(true)
       // Synthetic `:latest` id MUST NOT appear in any URL.
       expect(seenUrls.some((u) => u.includes(`${jobId}:latest`))).toBe(false)
+      // The jobId in the detail-fetch URL must use the RAW colon, not
+      // %3A — chi's path matcher does not decode %3A and would 404
+      // every detail fetch.
+      const detailHits = seenUrls.filter((u) => u.includes('/v1/deployments/') && u.includes('/jobs/'))
+      expect(detailHits.some((u) => u.endsWith(`/jobs/${jobId}`))).toBe(true)
+      expect(detailHits.some((u) => u.includes('%3A'))).toBe(false)
     })
   })
 

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/useJobDetail.ts
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/useJobDetail.ts
@@ -96,9 +96,15 @@ async function defaultFetchJobDetail(
   deploymentId: string,
   jobId: string,
 ): Promise<JobDetailResponse> {
+  // jobId is the canonical "<deploymentId>:<jobName>" string. The colon
+  // is RFC 3986 path-safe, but encodeURIComponent turns it into %3A,
+  // which chi's path matcher does NOT decode before route lookup —
+  // every detail fetch returns 404 with the encoded form. Insert the
+  // jobId raw; deploymentId is a 16-byte hex with no special chars so
+  // encoding it is a no-op.
   const url =
     `${API_BASE}/v1/deployments/${encodeURIComponent(deploymentId)}` +
-    `/jobs/${encodeURIComponent(jobId)}`
+    `/jobs/${jobId}`
   const res = await fetch(url, { headers: { Accept: 'application/json' } })
   if (res.status === 404) {
     throw new JobNotFoundError(deploymentId, jobId)


### PR DESCRIPTION
Third follow-up to #307. Even with #311 (CoreFactory wiring) and #314 (regex fix), the live FE was rendering my new ExecutionLogsPlaceholder "Execution metadata pending" instead of the actual log lines, because the JobDetail fetch URL was 404'ing.

## Live evidence (Playwright network log on otech wizard, 2026-04-30)

```
GET /sovereign/api/v1/deployments/ce476aaf80731a46/jobs/ce476aaf80731a46%3Ainstall-seaweedfs → 404
```

Internal probe with raw colon:
```
wget http://localhost:8080/api/v1/deployments/.../jobs/ce476aaf80731a46:install-seaweedfs → 200
```

## Root cause

`encodeURIComponent` turns `:` into `%3A`. The colon is RFC 3986 path-safe so this is technically over-encoding. Chi's router does NOT decode %3A before matching, so the encoded form 404s.

## Fix

`useJobDetail` inserts jobId raw into the URL template. `deploymentId` stays encoded defensively. Test now asserts the request URL contains the raw `:` and rejects `%3A`.

After this PR: clicking Exec Log on `/sovereign/provision/{id}/jobs/{jobId}` actually hits the right route, gets back `executions[]`, picks `executions[0].id`, and renders the GitLab-style log viewer with the persisted lines. End of #305.