### PR TITLE
fix(catalyst-ui): ExecutionLogs uses API_BASE so the log fetch URL routes correctly (#305 follow-up 4)

### DIFF
--- a/products/catalyst/bootstrap/ui/src/components/ExecutionLogs.tsx
+++ b/products/catalyst/bootstrap/ui/src/components/ExecutionLogs.tsx
@@ -31,6 +31,7 @@
 
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
+import { API_BASE } from '@/shared/config/urls'
 
 /* ── Types ──────────────────────────────────────────────────────── */
 
@@ -99,7 +100,11 @@ async function defaultFetchLogs({
     fromLine: String(fromLine),
     limit: String(limit),
   })
-  const res = await fetch(`/api/v1/actions/executions/${executionId}/logs?${params}`)
+  // API_BASE resolves to `${BASE}api`; under the /sovereign/ Vite
+  // base this becomes `/sovereign/api`, which the Traefik ingress
+  // routes correctly. A bare `/api/v1/...` (the previous shape) was
+  // not routed at all — every log fetch returned 404. See #305.
+  const res = await fetch(`${API_BASE}/v1/actions/executions/${executionId}/logs?${params}`)
   if (!res.ok) {
     throw new Error(`Failed to fetch logs: ${res.status}`)
   }


### PR DESCRIPTION
Fourth and final follow-up to #307. After #311 (CoreFactory wiring), #314 (regex), and #328 (jobId raw colon), the FE was correctly resolving the REAL execution id and hitting the right job-detail route — but the log fetch itself was still 404'ing.

## Live evidence (Playwright network log on otech wizard, 2026-04-30)

```
GET /sovereign/api/v1/deployments/.../jobs/{id}                    → 200 ✓
GET /api/v1/actions/executions/5f59cb0bc9df2c720b4cf07989e4dc4f/logs → 404 ✗
```

The execution id is a real 32-char hex (NOT the synthetic `:latest`), proving #307 + #328 worked. Only the URL prefix on the log fetch was wrong.

## Root cause
`ExecutionLogs.tsx` hardcoded `/api/v1/...` instead of using API_BASE. Under Vite's `/sovereign/` base path, the Traefik ingress only routes `/sovereign/api/...` — bare `/api/...` returns 404.

## Fix
Import API_BASE; use `${API_BASE}/v1/actions/executions/.../logs`. Per `docs/INVIOLABLE-PRINCIPLES.md` #4 (never hardcode URLs).

After this PR: clicking Exec Log on the live wizard hits `/sovereign/api/v1/actions/executions/{realId}/logs` → 200 → renders the GitLab-style log viewer with the actual lines. **End of #305.**