### PR TITLE
fix(ci): bump helm 3.16.3 → 3.18.4 in blueprint-release (unblocks seaweedfs publish)

### DIFF
--- a/.github/workflows/blueprint-release.yaml
+++ b/.github/workflows/blueprint-release.yaml
@@ -119,7 +119,7 @@ jobs:
       - name: Set up Helm
         uses: azure/setup-helm@v4
         with:
-          version: v3.16.3
+          version: v3.18.4
 
       - name: Install Cosign
         uses: sigstore/cosign-installer@v3


### PR DESCRIPTION
Bumps helm in blueprint-release.yaml so seaweedfs subchart's fromToml call resolves. Without this, 6 HRs cascade-fail on otech (bp-loki/mimir/tempo/velero/harbor/grafana all dependsOn bp-seaweedfs).