### PR TITLE
fix(bp-external-secrets): gate ClusterSecretStore on CRD presence (resolves install failure)

### DIFF
--- a/clusters/_template/bootstrap-kit/15-external-secrets.yaml
+++ b/clusters/_template/bootstrap-kit/15-external-secrets.yaml
@@ -57,7 +57,7 @@ spec:
   chart:
     spec:
       chart: bp-external-secrets
-      version: 1.0.0
+      version: 1.0.1
       sourceRef:
         kind: HelmRepository
         name: bp-external-secrets

--- a/clusters/omantel.omani.works/bootstrap-kit/15-external-secrets.yaml
+++ b/clusters/omantel.omani.works/bootstrap-kit/15-external-secrets.yaml
@@ -57,7 +57,7 @@ spec:
   chart:
     spec:
       chart: bp-external-secrets
-      version: 1.0.0
+      version: 1.0.1
       sourceRef:
         kind: HelmRepository
         name: bp-external-secrets

--- a/clusters/otech.omani.works/bootstrap-kit/15-external-secrets.yaml
+++ b/clusters/otech.omani.works/bootstrap-kit/15-external-secrets.yaml
@@ -57,7 +57,7 @@ spec:
   chart:
     spec:
       chart: bp-external-secrets
-      version: 1.0.0
+      version: 1.0.1
       sourceRef:
         kind: HelmRepository
         name: bp-external-secrets

--- a/platform/external-secrets/chart/Chart.yaml
+++ b/platform/external-secrets/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-external-secrets
-version: 1.0.0
+version: 1.0.1
 description: |
   Catalyst-curated Blueprint umbrella chart for External Secrets Operator
   (ESO). Depends on the upstream `external-secrets` chart as a Helm


### PR DESCRIPTION
Live cluster otech: bp-external-secrets@1.0.0 fails post-install with 'no matches for kind ClusterSecretStore'. Fix: Capabilities gate + drop before-hook-creation delete-policy. Bumped 1.0.1.