### PR TITLE
fix(bp-seaweedfs): disable enableSecurity to bypass fromToml (helm-controller v1.1.0 doesn't support it)

### DIFF
--- a/clusters/_template/bootstrap-kit/18-seaweedfs.yaml
+++ b/clusters/_template/bootstrap-kit/18-seaweedfs.yaml
@@ -55,7 +55,7 @@ spec:
   chart:
     spec:
       chart: bp-seaweedfs
-      version: 1.0.0
+      version: 1.0.1
       sourceRef:
         kind: HelmRepository
         name: bp-seaweedfs

--- a/clusters/omantel.omani.works/bootstrap-kit/18-seaweedfs.yaml
+++ b/clusters/omantel.omani.works/bootstrap-kit/18-seaweedfs.yaml
@@ -55,7 +55,7 @@ spec:
   chart:
     spec:
       chart: bp-seaweedfs
-      version: 1.0.0
+      version: 1.0.1
       sourceRef:
         kind: HelmRepository
         name: bp-seaweedfs

--- a/clusters/otech.omani.works/bootstrap-kit/18-seaweedfs.yaml
+++ b/clusters/otech.omani.works/bootstrap-kit/18-seaweedfs.yaml
@@ -55,7 +55,7 @@ spec:
   chart:
     spec:
       chart: bp-seaweedfs
-      version: 1.0.0
+      version: 1.0.1
       sourceRef:
         kind: HelmRepository
         name: bp-seaweedfs

--- a/platform/seaweedfs/chart/Chart.yaml
+++ b/platform/seaweedfs/chart/Chart.yaml
@@ -16,7 +16,7 @@ description: |
   (Cloudflare R2 / AWS S3 Glacier / Hetzner Object Storage) configured at
   Sovereign provisioning time.
 type: application
-version: 1.0.0
+version: 1.0.1
 appVersion: "4.22"
 keywords: [catalyst, blueprint, seaweedfs, s3, object-storage, storage]
 maintainers:

--- a/platform/seaweedfs/chart/values.yaml
+++ b/platform/seaweedfs/chart/values.yaml
@@ -22,6 +22,14 @@ seaweedfs:
   enableNamePrefix: true
 
   global:
+    # SECURITY DISABLED for v1.0.x — upstream's templates/shared/security-configmap.yaml
+    # uses Helm template `fromToml` which is unsupported by the helm-controller
+    # v1.1.0 helm SDK on otech.omani.works. Re-enable when fluxcd/helm-controller
+    # is bumped to a version with helm SDK >= 3.13. JWT signing + HTTPS-internal
+    # are off here; the SeaweedFS API is reached internally via cluster-IP only,
+    # so disabling chart-level security is acceptable on Sovereign-1. To enable:
+    # set enableSecurity: true after upgrading helm-controller.
+    enableSecurity: false
     # Pin upstream image tag — DO NOT use floating tags per
     # docs/INVIOLABLE-PRINCIPLES.md #4.
     registry: "chrislusf/"


### PR DESCRIPTION
Cluster-side fromToml not supported by helm-controller v1.1.0; setting enableSecurity:false skips the offending template. Bumps 1.0.1.