### PR TITLE
fix(catalyst-ui): wire FlowPage openJob state into JobDetail's LogPane (#351)

### DIFF
--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/FlowPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/FlowPage.tsx
@@ -272,6 +272,13 @@ interface FlowPageProps {
    * shows the host's logs immediately.
    */
   hostJobId?: string | null
+  /**
+   * Notifies the parent (JobDetail) every time the canvas's selected
+   * job changes. The host stays put across single-click selections;
+   * the parent uses this hook to keep its LogPane in sync with the
+   * currently-clicked node.
+   */
+  onOpenJobChange?: (jobId: string | null) => void
   /** Override the global default fold depth (test seam). */
   initialDepth?: FoldDepth
 }
@@ -282,6 +289,7 @@ export function FlowPage({
   embedded = false,
   deploymentIdOverride,
   hostJobId = null,
+  onOpenJobChange,
   initialDepth,
 }: FlowPageProps = {}) {
   const looseParams = useParams({ strict: false }) as { deploymentId?: string }
@@ -425,7 +433,7 @@ export function FlowPage({
 
   /* ── Click semantics (single vs double, debounced 220ms) ────── */
 
-  const [openJobId, setOpenJobId] = useState<string | null>(hostJobId)
+  const [openJobId, setOpenJobIdState] = useState<string | null>(hostJobId)
   // Keep `openJobId` synced with `hostJobId` when the host changes
   // (e.g. operator navigated to a different /jobs/{id}). Only on
   // entry — once the operator clicks another job, we don't snap them
@@ -434,9 +442,17 @@ export function FlowPage({
   useEffect(() => {
     if (hostJobId !== prevHostRef.current) {
       prevHostRef.current = hostJobId
-      setOpenJobId(hostJobId)
+      setOpenJobIdState(hostJobId)
+      onOpenJobChange?.(hostJobId)
     }
-  }, [hostJobId])
+  }, [hostJobId, onOpenJobChange])
+  const setOpenJobId = useCallback(
+    (next: string | null) => {
+      setOpenJobIdState(next)
+      onOpenJobChange?.(next)
+    },
+    [onOpenJobChange],
+  )
 
   const clickTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const cancelPendingClick = useCallback(() => {

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/JobDetail.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/JobDetail.tsx
@@ -123,9 +123,15 @@ export function JobDetail({
   const executionId = detail.latestExecutionId
   const detailJobStatus = detail.job?.status
 
-  const onCanvasJobSelect = useCallback((id: string) => {
-    setSelectedJobId(id)
-  }, [])
+  const onCanvasJobSelect = useCallback(
+    (id: string | null) => {
+      // Empty / null — operator clicked the canvas background; restore
+      // the host as the selected job so the LogPane never goes
+      // contextless.
+      setSelectedJobId(id ?? jobId)
+    },
+    [jobId],
+  )
 
   if (!job) {
     return (
@@ -219,6 +225,7 @@ export function JobDetail({
             embedded
             deploymentIdOverride={deploymentId}
             hostJobId={job.id}
+            onOpenJobChange={onCanvasJobSelect}
           />
         </div>
       </div>
@@ -231,7 +238,6 @@ export function JobDetail({
         jobTitle={logPaneJob.displayName ?? logPaneJob.jobName}
         jobStatus={logPaneStatus}
         onClose={() => setSelectedJobId(jobId)}
-        onSelectExternal={onCanvasJobSelect}
       />
     </PortalShell>
   )
@@ -250,8 +256,6 @@ interface CanvasLogBridgeProps {
   jobTitle: string
   jobStatus: string
   onClose: () => void
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  onSelectExternal: (jobId: string) => void
 }
 
 function CanvasLogBridge({ executionId, jobTitle, jobStatus, onClose }: CanvasLogBridgeProps) {


### PR DESCRIPTION
Follow-up for #351 — caught during live verification at https://console.openova.io/sovereign/provision/ce476aaf80731a46/jobs/ce476aaf80731a46:install-grafana.

**Symptom:** clicking another job in the canvas correctly flipped the data attributes (\`data-host=\"true\"\` on the URL job, \`data-open=\"true\"\` on the clicked job, neighbours lit, others dimmed) but the LogPane title kept rendering the host's name.

**Root cause:** FlowPage owned \`openJobId\` as internal state and didn't emit changes upward. JobDetail's \`onCanvasJobSelect\` callback existed but was wired into a removed prop (\`onSelectExternal\`) on the legacy bridge instead of FlowPage.

**Fix:** add \`onOpenJobChange?: (jobId: string | null) => void\` prop to FlowPage; route every internal state mutation (host-sync effect + the canvas's \`setOpenJobId\` callback) through the new callback. JobDetail subscribes via \`onOpenJobChange={onCanvasJobSelect}\`. Background click restores the host as the selection so the LogPane never goes contextless.

\`tsc --noEmit\` clean. Will re-verify live with Playwright after merge + deploy.

Refs #351

🤖 Generated with [Claude Code](https://claude.com/claude-code)