### PR TITLE
fix(catalyst-ui): X close + host halo + canvas full-screen (#351)

### DIFF
--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/FlowCanvasOrganic.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/FlowCanvasOrganic.tsx
@@ -528,19 +528,24 @@ function FlowNode({
   onDoubleClick,
 }: FlowNodeProps) {
   const tone = STATUS_TONE[node.status]
-  // Outer ring priority: selection (amber) > host (teal) > neighbour > status tone.
-  const outerRing = isOpen
+  // Inner ring priority — drawn on the bubble itself:
+  //   selection (amber) > neighbour (lighter amber) > status tone
+  // The host's teal ring is rendered SEPARATELY as a thicker outer
+  // halo so the host stays distinguishable even when it's also the
+  // currently-selected job (the original bug: amber selection
+  // overrode the teal host ring on the page's home job).
+  const innerRing = isOpen
     ? SELECTION_RING
-    : isHost
-      ? HOST_RING
-      : isNeighbor
-        ? NEIGHBOR_RING
+    : isNeighbor
+      ? NEIGHBOR_RING
+      : isHost
+        ? HOST_RING
         : tone.ring
   const familyColor = family?.color ?? 'rgba(148,163,184,0.55)'
   const radius = node.isGroup ? GROUP_RADIUS : NODE_RADIUS
   const grpStyle: CSSProperties = { cursor: 'grab' }
   const groupOpacity = isDimmed ? 0.35 : 1
-  const ringWidth = isOpen ? 4 : isHost ? 3.5 : isNeighbor ? 3 : 2
+  const innerWidth = isOpen ? 4 : isNeighbor ? 3 : isHost ? 3.5 : 2
 
   return (
     <g
@@ -563,18 +568,34 @@ function FlowNode({
       opacity={groupOpacity}
     >
       <title>
-        {`${node.label} — ${tone.label}${node.subLabel ? ` · ${node.subLabel}` : ''}`}
+        {`${node.label} — ${tone.label}${isHost ? ' · home' : ''}${node.subLabel ? ` · ${node.subLabel}` : ''}`}
       </title>
 
-      {/* Glow underlay — strongest on selection, then host. */}
-      {isOpen ? (
+      {/* Glow underlay — host wins (teal) when also selected so the
+          home node always reads as the page anchor. Otherwise:
+          selection > neighbour > status. */}
+      {isHost ? (
+        <circle r={radius + 12} fill="rgba(20,184,166,0.30)" />
+      ) : isOpen ? (
         <circle r={radius + 10} fill="rgba(251,191,36,0.30)" />
-      ) : isHost ? (
-        <circle r={radius + 10} fill="rgba(20,184,166,0.30)" />
       ) : isNeighbor ? (
         <circle r={radius + 8} fill="rgba(252,211,77,0.18)" />
       ) : node.status === 'running' || node.status === 'failed' ? (
         <circle r={radius + 8} fill={tone.glow} />
+      ) : null}
+
+      {/* HOST halo — always rendered on the page's home job, sits
+          OUTSIDE the inner status/selection ring so it survives the
+          amber selection ring without being overdrawn. Extra-thick
+          stroke so it reads as a halo, not a regular ring. */}
+      {isHost ? (
+        <circle
+          r={radius + 6}
+          fill="none"
+          stroke={HOST_RING}
+          strokeWidth={3.5}
+          opacity={0.95}
+        />
       ) : null}
 
       {/* Family-coloured ring (thin) */}
@@ -586,12 +607,15 @@ function FlowNode({
         opacity={0.55}
       />
 
-      {/* Status fill + selection/host/neighbor ring overlay */}
+      {/* Status fill + selection / neighbour / status ring overlay
+          (the host's distinguishing teal ring is the halo above —
+          this inner ring keeps the operator informed about the
+          job's runtime status + currently-clicked state). */}
       <circle
         r={radius}
         fill={tone.fill}
-        stroke={outerRing}
-        strokeWidth={ringWidth}
+        stroke={innerRing}
+        strokeWidth={innerWidth}
       />
 
       {/* Status glyph or child-count badge */}

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/FlowPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/FlowPage.tsx
@@ -538,6 +538,29 @@ export function FlowPage({
   }, [provisioningStatus])
   const elapsedMs = earliestStarted === null ? 0 : Math.max(0, now - earliestStarted)
 
+  /* ── Canvas full-screen ──────────────────────────────────────── */
+
+  const [canvasFullScreen, setCanvasFullScreen] = useState<boolean>(false)
+  const toggleCanvasFullScreen = useCallback(() => {
+    setCanvasFullScreen((v) => !v)
+  }, [])
+  // Esc exits canvas full-screen — only when no LogPane is mounted
+  // ahead of us in the keydown listener stack. (LogPane attaches its
+  // own Esc listener at document level; React handles dispatch in
+  // mount order, so the LogPane's first-Esc takes priority. When the
+  // pane is dismissed, the canvas's listener takes over.)
+  useEffect(() => {
+    if (!canvasFullScreen) return
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') {
+        e.stopPropagation()
+        setCanvasFullScreen(false)
+      }
+    }
+    document.addEventListener('keydown', onKey)
+    return () => document.removeEventListener('keydown', onKey)
+  }, [canvasFullScreen])
+
   /* ── Render ──────────────────────────────────────────────────── */
 
   const canvas = (
@@ -552,10 +575,39 @@ export function FlowPage({
     />
   )
 
+  const fullScreenButton = (
+    <button
+      type="button"
+      className="flow-fullscreen-btn"
+      data-testid="flow-fullscreen-btn"
+      aria-label={canvasFullScreen ? 'Exit canvas full-screen' : 'Canvas full-screen'}
+      aria-pressed={canvasFullScreen}
+      title={canvasFullScreen ? 'Exit full-screen (Esc)' : 'Full-screen canvas'}
+      onClick={toggleCanvasFullScreen}
+    >
+      {canvasFullScreen ? (
+        <svg width="14" height="14" viewBox="0 0 14 14" aria-hidden>
+          <path d="M5 1 L5 5 L1 5 M9 1 L9 5 L13 5 M5 13 L5 9 L1 9 M9 13 L9 9 L13 9"
+                stroke="currentColor" strokeWidth="1.4" fill="none" strokeLinecap="round" strokeLinejoin="round" />
+        </svg>
+      ) : (
+        <svg width="14" height="14" viewBox="0 0 14 14" aria-hidden>
+          <path d="M1 5 L1 1 L5 1 M9 1 L13 1 L13 5 M13 9 L13 13 L9 13 M5 13 L1 13 L1 9"
+                stroke="currentColor" strokeWidth="1.4" fill="none" strokeLinecap="round" strokeLinejoin="round" />
+        </svg>
+      )}
+    </button>
+  )
+
   const flowSurface = (
-    <div className="flow-surface" data-testid="flow-surface">
+    <div
+      className={`flow-surface${canvasFullScreen ? ' is-fullscreen' : ''}`}
+      data-testid="flow-surface"
+      data-canvas-fullscreen={canvasFullScreen ? 'true' : 'false'}
+    >
       <div className="flow-canvas-host" data-testid="flow-canvas-host">
         {canvas}
+        {fullScreenButton}
       </div>
     </div>
   )
@@ -643,6 +695,31 @@ const FLOW_PAGE_CSS = `
   max-height: none;
 }
 
+/* Canvas full-screen mode — overlays the entire viewport above
+   everything except the LogPane (which has z-index 60 by default
+   and 80 in its own full-screen mode). The canvas occupies 100vw /
+   100vh; the LogPane stays docked on top of it so the operator can
+   still tail logs in the wider canvas. The Esc key exits — the
+   FlowPage's keydown listener handles that. */
+.flow-surface.is-fullscreen {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  width: 100vw;
+  height: 100vh;
+  max-height: none;
+  /* Sits ABOVE the LogPane (z=60 docked / z=80 own full-screen) so
+     the operator gets a true full-viewport canvas without the pane
+     covering 30% of the right edge. */
+  z-index: 90;
+  border-radius: 0;
+  border: 0;
+  padding: 0;
+  background: rgba(2, 6, 15, 0.98);
+}
+
 .flow-canvas-host {
   position: relative;
   min-width: 0;
@@ -654,6 +731,11 @@ const FLOW_PAGE_CSS = `
   display: flex;
   align-items: center;
   justify-content: center;
+}
+
+.flow-surface.is-fullscreen .flow-canvas-host {
+  border-radius: 0;
+  border: 0;
 }
 
 .flow-page-embedded .flow-canvas-host {
@@ -668,5 +750,37 @@ const FLOW_PAGE_CSS = `
   max-width: 100%;
   height: 100%;
   max-height: 100%;
+}
+
+/* Full-screen toggle button — sits in the top-right of the canvas
+   host, mirroring the LogPane's full-screen toggle so the two
+   surfaces feel symmetric. */
+.flow-fullscreen-btn {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  width: 32px;
+  height: 32px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  appearance: none;
+  border: 1px solid var(--color-border);
+  background: var(--color-surface);
+  color: var(--color-text-dim);
+  border-radius: 6px;
+  cursor: pointer;
+  z-index: 50;
+  transition: color 0.12s ease, background-color 0.12s ease, border-color 0.12s ease;
+}
+.flow-fullscreen-btn:hover {
+  color: var(--color-text-strong);
+  border-color: var(--color-text-dim);
+  background: rgba(148, 163, 184, 0.10);
+}
+.flow-fullscreen-btn[aria-pressed='true'] {
+  color: var(--color-accent, #38BDF8);
+  border-color: var(--color-accent, #38BDF8);
+  background: rgba(56, 189, 248, 0.12);
 }
 `

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/JobDetail.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/JobDetail.tsx
@@ -110,6 +110,9 @@ export function JobDetail({
   // around; the host stays put.
   const [selectedJobId, setSelectedJobId] = useState<string>(jobId)
   const selectedJob: Job | null = jobsById[selectedJobId] ?? job ?? null
+  // Pane visibility — open by default. The X / Esc dismisses it;
+  // any explicit canvas-bubble click reopens it.
+  const [paneOpen, setPaneOpen] = useState<boolean>(true)
 
   // Resolve the REAL execution id by polling the per-job detail
   // endpoint. The selected job (NOT the host) drives this so the
@@ -127,8 +130,12 @@ export function JobDetail({
     (id: string | null) => {
       // Empty / null — operator clicked the canvas background; restore
       // the host as the selected job so the LogPane never goes
-      // contextless.
+      // contextless. (Background click does NOT dismiss the pane —
+      // only the explicit X button or Esc does that.)
       setSelectedJobId(id ?? jobId)
+      // Any explicit selection re-opens the pane if the operator had
+      // dismissed it earlier.
+      if (id) setPaneOpen(true)
     },
     [jobId],
   )
@@ -179,7 +186,10 @@ export function JobDetail({
 
   return (
     <PortalShell deploymentId={deploymentId} sovereignFQDN={sovereignFQDN}>
-      <div className="job-detail-page" data-testid={`job-detail-${jobId}`}>
+      <div
+        className={`job-detail-page${paneOpen ? '' : ' is-pane-closed'}`}
+        data-testid={`job-detail-${jobId}`}
+      >
         <style>{JOB_DETAIL_CSS}</style>
 
         {/* Two-line compact header with status chip top-right. */}
@@ -217,8 +227,14 @@ export function JobDetail({
 
         {/* Full-bleed canvas. The embedded FlowPage owns its own
             chrome-less surface; it streams hostJobId so the canvas
-            paints the teal home ring. */}
-        <div className="job-detail-canvas" data-testid="job-detail-canvas">
+            paints the teal home ring. The `paneOpen` flag widens the
+            canvas back out to the full viewport when the operator
+            dismisses the LogPane. */}
+        <div
+          className={`job-detail-canvas${paneOpen ? '' : ' is-pane-closed'}`}
+          data-testid="job-detail-canvas"
+          data-pane-open={paneOpen ? 'true' : 'false'}
+        >
           <FlowPage
             disableStream={disableStream}
             disableJobsBackfill={disableJobsBackfill || disableStream}
@@ -228,17 +244,42 @@ export function JobDetail({
             onOpenJobChange={onCanvasJobSelect}
           />
         </div>
+
+        {/* When the pane is closed, surface a small re-open button so
+            the operator can recover the log surface without having to
+            click a bubble. Stays out of the way (top-right of the
+            canvas area). */}
+        {!paneOpen ? (
+          <button
+            type="button"
+            className="job-detail-reopen-pane"
+            data-testid="job-detail-reopen-pane"
+            aria-label="Show log pane"
+            title="Show log pane"
+            onClick={() => setPaneOpen(true)}
+          >
+            <svg width="14" height="14" viewBox="0 0 14 14" aria-hidden>
+              <path d="M2 3 L12 3 M2 7 L12 7 M2 11 L8 11" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+            </svg>
+            Logs
+          </button>
+        ) : null}
       </div>
 
       {/* Floating log pane — open by default on the host's logs.
-          Hidden when the operator dismisses it; clicking another
-          canvas job re-arms via onJobSelect inside FlowPage. */}
-      <CanvasLogBridge
-        executionId={executionId}
-        jobTitle={logPaneJob.displayName ?? logPaneJob.jobName}
-        jobStatus={logPaneStatus}
-        onClose={() => setSelectedJobId(jobId)}
-      />
+          The X button + Esc dismiss it; the canvas widens to fill
+          the full viewport. Single-click on any bubble re-opens it. */}
+      {paneOpen ? (
+        <CanvasLogBridge
+          executionId={executionId}
+          jobTitle={logPaneJob.displayName ?? logPaneJob.jobName}
+          jobStatus={logPaneStatus}
+          onClose={() => {
+            setPaneOpen(false)
+            setSelectedJobId(jobId)
+          }}
+        />
+      ) : null}
     </PortalShell>
   )
 }
@@ -276,6 +317,7 @@ function CanvasLogBridge({ executionId, jobTitle, jobStatus, onClose }: CanvasLo
 
 const JOB_DETAIL_CSS = `
 .job-detail-page {
+  position: relative;
   display: flex;
   flex-direction: column;
   height: calc(100vh - 56px);
@@ -285,9 +327,40 @@ const JOB_DETAIL_CSS = `
   /* Reserve space for the floating LogPane on the right so the canvas
      centroid lands inside the visible area instead of being hidden
      behind the pane. The LogPane width is also bound to this var via
-     --log-pane-width, set on the root below. */
+     --log-pane-width, set on the root below. When the operator
+     dismisses the pane (paneOpen=false → .is-pane-closed) the canvas
+     reclaims the reserved space. */
   padding-right: calc(var(--log-pane-width, 30vw) + 1rem);
   min-width: 0;
+  transition: padding-right 220ms cubic-bezier(0.4, 0, 0.2, 1);
+}
+.job-detail-page.is-pane-closed {
+  padding-right: 1rem;
+}
+.job-detail-reopen-pane {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.32rem 0.7rem;
+  border-radius: 999px;
+  border: 1px solid var(--color-border);
+  background: var(--color-surface);
+  color: var(--color-text-dim);
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  cursor: pointer;
+  z-index: 50;
+  transition: color 0.12s ease, background-color 0.12s ease, border-color 0.12s ease;
+}
+.job-detail-reopen-pane:hover {
+  color: var(--color-text-strong);
+  border-color: var(--color-text-dim);
+  background: rgba(148, 163, 184, 0.08);
 }
 
 .job-detail-header {


### PR DESCRIPTION
Three live-verification bugs from https://console.openova.io/sovereign/provision/ce476aaf80731a46/jobs/ce476aaf80731a46:install-grafana, all reported by the founder:

1. **LogPane X button never closed the pane.** \`onClose\` restored the host as selected but the pane stayed mounted. Added \`paneOpen\` state in JobDetail; X / Esc dismiss + canvas widens to fill the viewport. Floating \"Logs\" re-open chip appears top-right while closed; any bubble click also re-opens.

2. **Host indistinguishable when also currently selected.** Amber selection ring overrode the teal host ring on first paint (host == selected by default). Fix: render the teal host marker as a separate outer halo at radius+6 that survives the inner amber selection ring. Glow underlay re-prioritised host > selection. Tooltip adds \" · home\" on the host. Result: the home job always reads as the page anchor regardless of click state.

3. **Canvas full-screen toggle missing.** Spec item 8 called for independent full-screen toggles for canvas AND log pane — only the pane half was wired. Added a fullscreen icon-button top-right of the canvas surface (mirroring the LogPane's), overlays the canvas at 100vw/100vh / z-index 90 (above the docked LogPane so the operator gets a true full-viewport canvas). Esc exits.

\`tsc --noEmit\` clean. Will re-verify live with Playwright after merge + deploy.

Refs #351

🤖 Generated with [Claude Code](https://claude.com/claude-code)