### PR TITLE
feat(catalyst-ui): Cloud IA restructure + graph/list toggle + fullscreen + cloud icon (#350)

### DIFF
--- a/products/catalyst/bootstrap/ui/e2e/cloud-list-pages.spec.ts
+++ b/products/catalyst/bootstrap/ui/e2e/cloud-list-pages.spec.ts
@@ -72,35 +72,15 @@ async function clearLocalStorage(page: Page) {
   })
 }
 
-test.describe('Cloud list pages (#309 P3)', () => {
+test.describe('Cloud list pages (#309 P3 — surfaces preserved by #350)', () => {
   test.beforeEach(async ({ page }) => {
     await clearLocalStorage(page)
   })
 
-  test('sidebar second-level accordion exposes sub-sub items for Compute / Network / Storage', async ({ page }) => {
-    await gotoProvision(page)
-    // First-level Cloud accordion auto-collapses by default; expand it.
-    await page.getByTestId('sov-nav-cloud').click()
-
-    // Each category exposes a Link (landing page) + a toggle button.
-    for (const id of ['compute', 'network', 'storage'] as const) {
-      const row = page.getByTestId(`sov-nav-cloud-${id}-row`)
-      await expect(row).toBeVisible()
-      const toggle = page.getByTestId(`sov-nav-cloud-${id}-toggle`)
-      await expect(toggle).toBeVisible()
-      // Initially collapsed (no persisted state).
-      expect(await toggle.getAttribute('aria-expanded')).toBe('false')
-
-      await toggle.click()
-      expect(await toggle.getAttribute('aria-expanded')).toBe('true')
-    }
-
-    // Now sub-sub items must be visible.
-    for (const c of CASES) {
-      const item = page.getByTestId(`sov-nav-cloud-${c.category}-${c.child}`)
-      await expect(item).toBeVisible()
-    }
-  })
+  // The legacy /cloud/<category>/<resource> URLs are now 301
+  // redirects to the consolidated /cloud?view=list&kind=… shape (issue
+  // #350). The list-page components below are reused inside the new
+  // CloudListView, so the same testid contracts hold.
 
   for (const c of CASES) {
     test(`${c.category}/${c.child} renders + ${c.placeholder ? 'shows empty state' : 'opens drawer on row click'}`, async ({ page }) => {
@@ -136,18 +116,18 @@ test.describe('Cloud list pages (#309 P3)', () => {
     })
   }
 
-  test('category landing pages show 4 tiles each', async ({ page }) => {
-    for (const cat of ['compute', 'network', 'storage'] as const) {
-      await gotoProvision(page, `cloud/${cat}`)
-      await expect(page.getByTestId(`cloud-${cat}-page`)).toBeVisible()
-      // Each category landing renders a tile grid with at least 4
-      // tiles. The exact tile ids depend on the category; just count
-      // the grid children.
-      const grid = page.getByTestId(`cloud-${cat}-page-tiles`)
-      await expect(grid).toBeVisible()
-      const tiles = grid.locator('a')
-      await expect(tiles).toHaveCount(4)
-    }
+  test('the consolidated list-view tile grid renders 12 tiles (was 3 category landings × 4)', async ({ page }) => {
+    // Issue #350 collapsed the three CloudComputePage / CloudNetworkPage /
+    // CloudStoragePage category landings into a single 12-tile grid
+    // inside CloudListView. The grid lives under the /cloud?view=list
+    // route and is asserted comprehensively in cloud-shell.spec.ts; the
+    // light check here keeps the count contract local to the list-page
+    // suite.
+    await gotoProvision(page, 'cloud?view=list')
+    const grid = page.getByTestId('cloud-list-view-tile-grid')
+    await expect(grid).toBeVisible()
+    const tiles = grid.locator('button[data-kind]')
+    await expect(tiles).toHaveCount(12)
   })
 
   test('every data-backed page exposes a + New CTA in the header (#349)', async ({ page }) => {
@@ -196,9 +176,14 @@ test.describe('Cloud list pages (#309 P3)', () => {
   })
 
   test('captures 1440×900 screenshots of every list page', async ({ page }) => {
+    // 12 list pages × ~3s per navigation+redirect+settle blows past
+    // the default 30s test timeout. Bump explicitly so the screenshot
+    // sweep has headroom across all cases without relying on the
+    // global config.
+    test.setTimeout(120_000)
     for (const c of CASES) {
       await gotoProvision(page, `cloud/${c.category}/${c.child}`)
-      await page.waitForSelector(`[data-testid=${c.pageTestId}]`)
+      await page.waitForSelector(`[data-testid=${c.pageTestId}]`, { timeout: 10_000 })
       // Wait for the data-loaded surface so the screenshot captures
       // populated rows / drawer-ready state rather than the brief
       // "Loading…" placeholder. Falls back to either the seeded first

--- a/products/catalyst/bootstrap/ui/e2e/cloud-nav.spec.ts
+++ b/products/catalyst/bootstrap/ui/e2e/cloud-nav.spec.ts
@@ -1,17 +1,16 @@
 /**
- * cloud-nav.spec.ts — Sovereign-portal Cloud accordion + redirects
- * E2E lock-in (P1 of issue #309).
+ * cloud-nav.spec.ts — Sovereign-portal Cloud sidebar entry + legacy
+ * URL redirect E2E lock-in.
  *
- * What this asserts:
- *   • Sidebar shows the Cloud accordion (no flat "Infrastructure"
- *     entry remains).
- *   • Cloud accordion toggles open/closed; expanded → 4 sub-items
- *     visible (Architecture / Compute / Network / Storage).
- *   • Each sub-item routes to /sovereign/provision/$id/cloud/{suffix}.
- *   • Legacy /infrastructure/* deep links redirect to /cloud/*.
- *   • Expanded state survives page reload (persisted via the
- *     `sov-nav-cloud-expanded` localStorage key).
- *   • Visual screenshots saved at 1440x900 to e2e/screenshots/.
+ * Originally introduced in P1 of #309 to lock in the Cloud accordion;
+ * issue #350 replaced the accordion with a single flat link, so the
+ * spec is now scoped to:
+ *   • Sidebar exposes a single flat Cloud entry (no accordion, no
+ *     chevron, no sub-items).
+ *   • Clicking Cloud lands on /cloud (which canonicalises to the
+ *     graph view).
+ *   • Legacy /infrastructure/* deep links redirect to /cloud?view=…
+ *     equivalents.
  *
  * Per docs/INVIOLABLE-PRINCIPLES.md #4 (never hardcode), the URL
  * comes from playwright.config.ts (env-driven HOST + BASEPATH); we
@@ -27,19 +26,12 @@ import { test, expect, type Page } from '@playwright/test'
 // by a substring match.
 const DEPLOYMENT_ID = 'p1-309-e2e'
 
-const SUB_ITEMS: ReadonlyArray<{ id: string; suffix: string }> = [
-  { id: 'sov-nav-cloud-architecture', suffix: 'architecture' },
-  { id: 'sov-nav-cloud-compute', suffix: 'compute' },
-  { id: 'sov-nav-cloud-network', suffix: 'network' },
-  { id: 'sov-nav-cloud-storage', suffix: 'storage' },
-] as const
-
-const LEGACY_REDIRECTS: ReadonlyArray<{ from: string; to: string }> = [
-  { from: 'infrastructure', to: '/cloud/architecture' },
-  { from: 'infrastructure/topology', to: '/cloud/architecture' },
-  { from: 'infrastructure/compute', to: '/cloud/compute' },
-  { from: 'infrastructure/network', to: '/cloud/network' },
-  { from: 'infrastructure/storage', to: '/cloud/storage' },
+const LEGACY_REDIRECTS: ReadonlyArray<{ from: string; expectedSearch: RegExp }> = [
+  { from: 'infrastructure', expectedSearch: /\?view=graph/ },
+  { from: 'infrastructure/topology', expectedSearch: /\?view=graph/ },
+  { from: 'infrastructure/compute', expectedSearch: /\?view=list&kind=clusters/ },
+  { from: 'infrastructure/network', expectedSearch: /\?view=list&kind=load-balancers/ },
+  { from: 'infrastructure/storage', expectedSearch: /\?view=list&kind=pvcs/ },
 ] as const
 
 async function gotoProvision(page: Page, suffix = '') {
@@ -50,193 +42,106 @@ async function gotoProvision(page: Page, suffix = '') {
   await page.waitForLoadState('domcontentloaded')
 }
 
-async function clearCloudExpanded(page: Page) {
-  // Wipe persisted accordion state once at the start of each test so
-  // we start from the documented default (collapsed unless on
-  // /cloud/*). We navigate to a benign URL first so localStorage is
-  // available, clear the key, then return — subsequent goto() calls
-  // observe a fresh slate.
-  //
-  // We deliberately DON'T use addInitScript here: that would re-clear
-  // the key on every navigation/reload, breaking the cross-reload
-  // persistence assertion below.
+async function clearLocalStorage(page: Page) {
   await page.goto('wizard')
   await page.waitForLoadState('domcontentloaded')
   await page.evaluate(() => {
     try {
-      window.localStorage.removeItem('sov-nav-cloud-expanded')
+      window.localStorage.clear()
     } catch {
       /* noop */
     }
   })
 }
 
-test.describe('Cloud accordion sidebar (#309)', () => {
+test.describe('Cloud sidebar entry (#309 P1 → #350 IA restructure)', () => {
   test.beforeEach(async ({ page }) => {
-    await clearCloudExpanded(page)
+    await clearLocalStorage(page)
   })
 
-  test('sidebar exposes Cloud (not Infrastructure) accordion', async ({ page }) => {
+  test('sidebar exposes Cloud as a single flat link (not accordion)', async ({ page }) => {
     await gotoProvision(page)
 
-    const cloudHeader = page.getByTestId('sov-nav-cloud')
+    const cloud = page.getByTestId('sov-nav-cloud')
     await expect(
-      cloudHeader,
-      'Sidebar must expose [data-testid=sov-nav-cloud] — the accordion replaces the legacy Infrastructure flat entry (Sidebar.tsx).',
+      cloud,
+      'Sidebar must expose [data-testid=sov-nav-cloud] — the Cloud nav entry replaces the legacy Infrastructure flat entry (Sidebar.tsx).',
     ).toBeVisible()
 
     expect(
-      await cloudHeader.evaluate((el) => el.tagName),
-      'Cloud accordion header must be a <button> (toggles state, not navigates).',
-    ).toBe('BUTTON')
+      await cloud.evaluate((el) => el.tagName),
+      'Cloud nav entry must be an anchor (single-level link), not a button — issue #350 dropped the accordion.',
+    ).toBe('A')
 
     expect(
-      await cloudHeader.textContent(),
-      'Cloud accordion label must read "Cloud" verbatim — issue #309 founder spec ("we call it as cloud").',
+      await cloud.textContent(),
+      'Cloud entry label must read "Cloud" verbatim — issue #309 founder spec.',
     ).toContain('Cloud')
 
-    // Legacy flat entry must be gone.
+    // Legacy flat entry must remain gone.
     expect(
       await page.getByTestId('sov-nav-infrastructure').count(),
-      'Sidebar still renders sov-nav-infrastructure — issue #309 replaced the flat entry with the Cloud accordion.',
+      'Sidebar still renders sov-nav-infrastructure — issue #309 replaced it with the Cloud entry.',
     ).toBe(0)
+
+    // No accordion contracts.
+    expect(await page.getByTestId('sov-nav-cloud-toggle').count()).toBe(0)
   })
 
-  test('clicking Cloud header toggles expanded state and exposes 4 sub-items', async ({ page }) => {
+  test('clicking Cloud navigates to /cloud and canonicalises ?view=graph', async ({ page }) => {
     await gotoProvision(page)
 
-    const cloudHeader = page.getByTestId('sov-nav-cloud')
-
-    // Initial state — collapsed (we cleared the persisted key).
-    expect(
-      await cloudHeader.getAttribute('aria-expanded'),
-      'Cloud accordion should default to collapsed when not on a /cloud/* route and no persisted state exists.',
-    ).toBe('false')
-
-    await cloudHeader.click()
-
-    expect(
-      await cloudHeader.getAttribute('aria-expanded'),
-      'Cloud accordion did not flip aria-expanded after click.',
-    ).toBe('true')
-
-    for (const sub of SUB_ITEMS) {
-      const item = page.getByTestId(sub.id)
-      await expect(
-        item,
-        `Sub-item [data-testid=${sub.id}] missing after expanding the Cloud accordion.`,
-      ).toBeVisible()
-    }
-
-    await cloudHeader.click()
-    expect(
-      await cloudHeader.getAttribute('aria-expanded'),
-      'Cloud accordion did not flip back to collapsed after second click.',
-    ).toBe('false')
-  })
-
-  test('each sub-item routes to /provision/$id/cloud/{suffix}', async ({ page }) => {
-    await gotoProvision(page)
-
-    // Open the accordion first.
     await page.getByTestId('sov-nav-cloud').click()
+    await page.waitForFunction(
+      () =>
+        window.location.pathname.endsWith('/cloud') &&
+        /\?view=graph/.test(window.location.search),
+      undefined,
+      { timeout: 5_000 },
+    )
 
-    for (const sub of SUB_ITEMS) {
-      await page.getByTestId(sub.id).click()
-      await page.waitForFunction(
-        (s) => window.location.pathname.endsWith(`/cloud/${s}`),
-        sub.suffix,
-        { timeout: 5_000 },
-      )
-      const pathname = new URL(page.url()).pathname
-      expect(
-        pathname.endsWith(`/cloud/${sub.suffix}`),
-        `Clicking ${sub.id} should navigate to /cloud/${sub.suffix}; got ${pathname}.`,
-      ).toBe(true)
-
-      // The clicked sub-item must carry aria-current=page.
-      expect(
-        await page.getByTestId(sub.id).getAttribute('aria-current'),
-        `Active sub-item ${sub.id} must declare aria-current=page.`,
-      ).toBe('page')
-    }
-  })
-
-  test('legacy /infrastructure/* paths redirect to /cloud/*', async ({ page }) => {
-    for (const c of LEGACY_REDIRECTS) {
-      await gotoProvision(page, c.from)
-      await page.waitForFunction(
-        (suffix) => window.location.pathname.endsWith(suffix),
-        c.to,
-        { timeout: 5_000 },
-      )
-      const pathname = new URL(page.url()).pathname
-      expect(
-        pathname.endsWith(c.to),
-        `Expected provision/${DEPLOYMENT_ID}/${c.from} to redirect to a path ending in ${c.to}; got ${pathname}.`,
-      ).toBe(true)
-    }
-  })
-
-  test('accordion remembers expanded state across reloads', async ({ page }) => {
-    await gotoProvision(page)
-
-    const cloudHeader = page.getByTestId('sov-nav-cloud')
-    expect(await cloudHeader.getAttribute('aria-expanded')).toBe('false')
-
-    // Open + persist.
-    await cloudHeader.click()
-    expect(await cloudHeader.getAttribute('aria-expanded')).toBe('true')
-
-    // Reload — state must come back from localStorage.
-    await page.reload()
-    await page.waitForLoadState('domcontentloaded')
-
-    const reloaded = page.getByTestId('sov-nav-cloud')
+    const cloud = page.getByTestId('sov-nav-cloud')
     expect(
-      await reloaded.getAttribute('aria-expanded'),
-      'Cloud accordion forgot its expanded state after a page reload — the sov-nav-cloud-expanded localStorage key must restore it.',
-    ).toBe('true')
-  })
-
-  test('accordion auto-expands when navigating directly to a /cloud/* deep link', async ({ page }) => {
-    await gotoProvision(page, 'cloud/compute')
-
-    const cloudHeader = page.getByTestId('sov-nav-cloud')
-    expect(
-      await cloudHeader.getAttribute('aria-expanded'),
-      'Cloud accordion must auto-expand when the operator lands directly on a /cloud/* route.',
-    ).toBe('true')
-
-    // Compute sub-item is the active one.
-    expect(
-      await page.getByTestId('sov-nav-cloud-compute').getAttribute('aria-current'),
-      'Cloud / Compute sub-item must declare aria-current=page on /cloud/compute.',
+      await cloud.getAttribute('aria-current'),
+      'Cloud nav entry must declare aria-current=page when active.',
     ).toBe('page')
   })
 
-  test('captures Cloud accordion screenshots @ 1440x900', async ({ page }) => {
-    // 1: Cloud accordion COLLAPSED (the wizard provision root).
+  test('legacy /infrastructure/* paths redirect to /cloud?view=…', async ({ page }) => {
+    for (const c of LEGACY_REDIRECTS) {
+      await gotoProvision(page, c.from)
+      await page.waitForFunction(
+        ([searchPattern]) => new RegExp(searchPattern).test(window.location.search),
+        [c.expectedSearch.source] as const,
+        { timeout: 5_000 },
+      )
+      const url = new URL(page.url())
+      expect(
+        c.expectedSearch.test(url.search),
+        `Expected provision/${DEPLOYMENT_ID}/${c.from} to redirect to a search matching ${c.expectedSearch}; got ${url.pathname}${url.search}.`,
+      ).toBe(true)
+      // Pathname must end in /cloud (no /architecture, /compute, /storage,
+      // /network suffixes — those are now query-driven).
+      expect(
+        url.pathname.endsWith('/cloud'),
+        `Expected pathname to end in /cloud; got ${url.pathname}.`,
+      ).toBe(true)
+    }
+  })
+
+  test('captures Cloud sidebar screenshot @ 1440x900', async ({ page }) => {
     await gotoProvision(page)
     await page.waitForSelector('[data-testid=admin-sidebar]')
     await page.screenshot({
-      path: 'e2e/screenshots/p1-cloud-nav-collapsed.png',
+      path: 'e2e/screenshots/p1-cloud-nav-sidebar.png',
       fullPage: false,
     })
 
-    // 2: Expanded, Architecture active.
-    await gotoProvision(page, 'cloud/architecture')
-    await page.waitForSelector('[data-testid=sov-nav-cloud-architecture]')
+    // Active state on /cloud.
+    await gotoProvision(page, 'cloud')
+    await page.waitForSelector('[data-testid=admin-sidebar]')
     await page.screenshot({
-      path: 'e2e/screenshots/p1-cloud-nav-expanded-architecture.png',
-      fullPage: false,
-    })
-
-    // 3: Expanded, Compute active.
-    await gotoProvision(page, 'cloud/compute')
-    await page.waitForSelector('[data-testid=sov-nav-cloud-compute]')
-    await page.screenshot({
-      path: 'e2e/screenshots/p1-cloud-nav-expanded-compute.png',
+      path: 'e2e/screenshots/p1-cloud-nav-active.png',
       fullPage: false,
     })
   })

--- a/products/catalyst/bootstrap/ui/e2e/cloud-shell.spec.ts
+++ b/products/catalyst/bootstrap/ui/e2e/cloud-shell.spec.ts
@@ -1,0 +1,347 @@
+/**
+ * cloud-shell.spec.ts — Sovereign-portal Cloud parent shell E2E
+ * lock-in (issue openova-io/openova#350).
+ *
+ * What this asserts:
+ *   • Sidebar exposes a SINGLE flat "Cloud" entry — no chevron, no
+ *     accordion, no sub-items, no second-level toggles.
+ *   • Clicking Cloud navigates to /cloud (the parent route); the URL
+ *     is canonicalised to ?view=graph by default.
+ *   • The View toggle (Graph | List) switches the body and persists
+ *     across reloads via localStorage `sov-cloud-view`.
+ *   • In list view: 12 resource tiles render with counts, clicking a
+ *     tile switches the active list, and the dropdown switcher
+ *     mirrors the selection.
+ *   • Fullscreen toggle button enters fullscreen (DOM state asserted
+ *     via the `data-fullscreen` data attribute and `aria-pressed`);
+ *     the floating Exit button leaves fullscreen.
+ *   • Legacy URLs redirect:
+ *       /cloud/architecture                 → ?view=graph
+ *       /cloud/compute/clusters             → ?view=list&kind=clusters
+ *       /cloud/storage/pvcs                 → ?view=list&kind=pvcs
+ *   • Visual screenshots saved at 1440×900 to e2e/screenshots/.
+ *
+ * Per docs/INVIOLABLE-PRINCIPLES.md #4 (never hardcode), the URL
+ * comes from playwright.config.ts (env-driven HOST + BASEPATH); we
+ * use a synthetic deploymentId and rely on the SPA's fixture
+ * fallback for the in-page data so the test is fully self-contained.
+ */
+
+import { test, expect, type Page } from '@playwright/test'
+
+const DEPLOYMENT_ID = 'p350-shell-e2e'
+
+async function gotoProvision(page: Page, suffix = '') {
+  const tail = suffix ? `/${suffix}` : ''
+  await page.goto(`provision/${DEPLOYMENT_ID}${tail}`)
+  await page.waitForLoadState('domcontentloaded')
+}
+
+async function clearStorage(page: Page) {
+  await page.goto('wizard')
+  await page.waitForLoadState('domcontentloaded')
+  await page.evaluate(() => {
+    try {
+      window.localStorage.clear()
+    } catch {
+      /* noop */
+    }
+  })
+}
+
+test.describe('Cloud shell — sidebar entry (#350 item 7+8)', () => {
+  test.beforeEach(async ({ page }) => {
+    await clearStorage(page)
+  })
+
+  test('sidebar exposes a single flat Cloud entry — no accordion, no chevron, no sub-items', async ({
+    page,
+  }) => {
+    await gotoProvision(page)
+
+    const cloud = page.getByTestId('sov-nav-cloud')
+    await expect(
+      cloud,
+      'Sidebar must expose [data-testid=sov-nav-cloud] as the single Cloud nav entry.',
+    ).toBeVisible()
+
+    // Cloud entry is an <a> (link), NOT a <button> (no accordion toggle).
+    const tag = await cloud.evaluate((el) => el.tagName)
+    expect(
+      tag,
+      'Cloud entry must render as an anchor (single-level link), not a button — issue #350 dropped the accordion.',
+    ).toBe('A')
+
+    // Confirm none of the legacy accordion sub-items / toggles render.
+    expect(await page.getByTestId('sov-nav-cloud-toggle').count()).toBe(0)
+    expect(await page.getByTestId('sov-nav-cloud-architecture').count()).toBe(0)
+    expect(await page.getByTestId('sov-nav-cloud-compute').count()).toBe(0)
+    expect(await page.getByTestId('sov-nav-cloud-network').count()).toBe(0)
+    expect(await page.getByTestId('sov-nav-cloud-storage').count()).toBe(0)
+    expect(await page.getByTestId('sov-nav-cloud-compute-toggle').count()).toBe(0)
+    expect(await page.getByTestId('sov-nav-cloud-network-toggle').count()).toBe(0)
+    expect(await page.getByTestId('sov-nav-cloud-storage-toggle').count()).toBe(0)
+  })
+
+  test('clicking Cloud navigates to /cloud and canonicalises ?view=graph', async ({ page }) => {
+    await gotoProvision(page)
+    await page.getByTestId('sov-nav-cloud').click()
+
+    await page.waitForFunction(
+      () => /\/cloud(\/|$|\?)/.test(window.location.pathname + window.location.search),
+      undefined,
+      { timeout: 5_000 },
+    )
+
+    // The CloudPage canonicalises to ?view=graph on mount.
+    await page.waitForFunction(
+      () => /\?view=graph/.test(window.location.search),
+      undefined,
+      { timeout: 5_000 },
+    )
+
+    await expect(page.getByTestId('cloud-page-toolbar')).toBeVisible()
+    await expect(page.getByTestId('cloud-page-view-toggle')).toBeVisible()
+  })
+})
+
+test.describe('Cloud shell — view toggle persistence (#350 item 7)', () => {
+  test.beforeEach(async ({ page }) => {
+    await clearStorage(page)
+  })
+
+  test('view toggle switches graph ↔ list and persists across reload', async ({ page }) => {
+    await gotoProvision(page, 'cloud')
+
+    // Default = graph.
+    const graph = page.getByTestId('cloud-page-view-graph')
+    const list = page.getByTestId('cloud-page-view-list')
+    await expect(graph).toHaveAttribute('aria-selected', 'true')
+    await expect(list).toHaveAttribute('aria-selected', 'false')
+
+    // Switch to list.
+    await list.click()
+    await expect(list).toHaveAttribute('aria-selected', 'true')
+    await expect(graph).toHaveAttribute('aria-selected', 'false')
+    await expect(page.getByTestId('cloud-list-view')).toBeVisible()
+
+    // localStorage carries the persisted value.
+    const stored = await page.evaluate(() => window.localStorage.getItem('sov-cloud-view'))
+    expect(stored).toBe('list')
+
+    // Reload — list view sticks.
+    await page.reload()
+    await page.waitForLoadState('domcontentloaded')
+    await expect(page.getByTestId('cloud-page-view-list')).toHaveAttribute('aria-selected', 'true')
+    await expect(page.getByTestId('cloud-list-view')).toBeVisible()
+  })
+})
+
+test.describe('Cloud shell — list view tile grid + dropdown (#350 item 7)', () => {
+  test.beforeEach(async ({ page }) => {
+    await clearStorage(page)
+  })
+
+  test('list view renders 12 tiles with counts; clicking a tile switches the active list', async ({
+    page,
+  }) => {
+    await gotoProvision(page, 'cloud?view=list')
+
+    const tileGrid = page.getByTestId('cloud-list-view-tile-grid')
+    await expect(tileGrid).toBeVisible()
+
+    // 12 tiles, one per resource kind.
+    const expectedKinds = [
+      'clusters',
+      'vclusters',
+      'node-pools',
+      'worker-nodes',
+      'load-balancers',
+      'services',
+      'ingresses',
+      'dns-zones',
+      'pvcs',
+      'buckets',
+      'volumes',
+      'storage-classes',
+    ]
+    for (const k of expectedKinds) {
+      await expect(
+        page.getByTestId(`cloud-list-view-tile-${k}`),
+        `Tile [data-testid=cloud-list-view-tile-${k}] must render`,
+      ).toBeVisible()
+      await expect(
+        page.getByTestId(`cloud-list-view-tile-${k}-count`),
+        `Tile count for ${k} must render`,
+      ).toBeVisible()
+    }
+
+    // The default active kind is "clusters".
+    await expect(page.getByTestId('cloud-list-view-tile-clusters')).toHaveAttribute(
+      'data-active',
+      'true',
+    )
+    await expect(page.getByTestId(`cloud-list-view-active-clusters`)).toBeVisible()
+
+    // Click the PVCs tile — active switches.
+    await page.getByTestId('cloud-list-view-tile-pvcs').click()
+    await page.waitForFunction(() => /kind=pvcs/.test(window.location.search), undefined, {
+      timeout: 5_000,
+    })
+    await expect(page.getByTestId('cloud-list-view-tile-pvcs')).toHaveAttribute(
+      'data-active',
+      'true',
+    )
+    await expect(page.getByTestId('cloud-list-view-tile-clusters')).toHaveAttribute(
+      'data-active',
+      'false',
+    )
+  })
+
+  test('dropdown switcher mirrors the active kind and changes it', async ({ page }) => {
+    await gotoProvision(page, 'cloud?view=list&kind=clusters')
+
+    const select = page.getByTestId('cloud-list-view-kind-select')
+    await expect(select).toBeVisible()
+    await expect(select).toHaveValue('clusters')
+
+    // Switch via dropdown.
+    await select.selectOption('volumes')
+    await page.waitForFunction(() => /kind=volumes/.test(window.location.search), undefined, {
+      timeout: 5_000,
+    })
+    await expect(page.getByTestId('cloud-list-view-tile-volumes')).toHaveAttribute(
+      'data-active',
+      'true',
+    )
+  })
+})
+
+test.describe('Cloud shell — fullscreen (#350 item 9)', () => {
+  test.beforeEach(async ({ page }) => {
+    await clearStorage(page)
+  })
+
+  test('fullscreen toggle enters fullscreen and the Exit affordance leaves', async ({ page }) => {
+    await gotoProvision(page, 'cloud?view=graph')
+
+    const toggle = page.getByTestId('cloud-page-fullscreen-toggle')
+    await expect(toggle).toBeVisible()
+    await expect(toggle).toHaveAttribute('aria-pressed', 'false')
+
+    // Headless Chromium doesn't grant the fullscreen permission to the
+    // unattended runner without explicit consent; the CloudPage falls
+    // back to the synthetic-fullscreen path which flips the
+    // data-fullscreen attribute and aria-pressed regardless of the
+    // user-agent's API success.
+    await toggle.click()
+    await expect(page.getByTestId('cloud-content')).toHaveAttribute(
+      'data-fullscreen',
+      'true',
+      { timeout: 3_000 },
+    )
+    await expect(toggle).toHaveAttribute('aria-pressed', 'true')
+
+    // Exit affordance is rendered inside the overlay.
+    const exit = page.getByTestId('cloud-page-fullscreen-exit')
+    await expect(exit).toBeVisible()
+
+    await exit.click()
+    await expect(page.getByTestId('cloud-content')).toHaveAttribute(
+      'data-fullscreen',
+      'false',
+      { timeout: 3_000 },
+    )
+    await expect(toggle).toHaveAttribute('aria-pressed', 'false')
+  })
+})
+
+test.describe('Cloud shell — legacy URL redirects (#350 item 7 — back-compat)', () => {
+  test.beforeEach(async ({ page }) => {
+    await clearStorage(page)
+  })
+
+  const REDIRECTS: ReadonlyArray<{ from: string; expectedSearch: RegExp }> = [
+    { from: 'cloud/architecture', expectedSearch: /\?view=graph/ },
+    { from: 'cloud/compute', expectedSearch: /\?view=list&kind=clusters/ },
+    { from: 'cloud/compute/clusters', expectedSearch: /\?view=list&kind=clusters/ },
+    { from: 'cloud/compute/vclusters', expectedSearch: /\?view=list&kind=vclusters/ },
+    { from: 'cloud/network', expectedSearch: /\?view=list&kind=load-balancers/ },
+    { from: 'cloud/network/load-balancers', expectedSearch: /\?view=list&kind=load-balancers/ },
+    { from: 'cloud/network/services', expectedSearch: /\?view=list&kind=services/ },
+    { from: 'cloud/storage', expectedSearch: /\?view=list&kind=pvcs/ },
+    { from: 'cloud/storage/pvcs', expectedSearch: /\?view=list&kind=pvcs/ },
+    { from: 'cloud/storage/buckets', expectedSearch: /\?view=list&kind=buckets/ },
+  ] as const
+
+  for (const r of REDIRECTS) {
+    test(`/${r.from} redirects to ${r.expectedSearch}`, async ({ page }) => {
+      await gotoProvision(page, r.from)
+      await page.waitForFunction(
+        ([searchPattern]) => new RegExp(searchPattern).test(window.location.search),
+        [r.expectedSearch.source] as const,
+        { timeout: 5_000 },
+      )
+      const url = new URL(page.url())
+      expect(
+        r.expectedSearch.test(url.search),
+        `Expected /${r.from} to redirect to ${r.expectedSearch}; got ${url.pathname}${url.search}`,
+      ).toBe(true)
+      // The pathname must always end in /cloud — no /cloud/architecture
+      // or /cloud/compute/clusters segments after the redirect.
+      expect(
+        url.pathname.endsWith('/cloud'),
+        `Expected the pathname to end in /cloud; got ${url.pathname}`,
+      ).toBe(true)
+    })
+  }
+})
+
+test.describe('Cloud shell — visual regression @ 1440×900', () => {
+  test.beforeEach(async ({ page }) => {
+    await clearStorage(page)
+  })
+
+  test('captures graph view + list view + fullscreen graph + sidebar icon', async ({ page }) => {
+    // 1: Sidebar Cloud entry (close-up of the rail).
+    await gotoProvision(page)
+    await page.waitForSelector('[data-testid=admin-sidebar]')
+    const sidebar = page.getByTestId('admin-sidebar')
+    await sidebar.screenshot({
+      path: 'e2e/screenshots/p350-sidebar-cloud-icon.png',
+    })
+
+    // 2: Graph view default.
+    await gotoProvision(page, 'cloud?view=graph')
+    await page.waitForSelector('[data-testid=cloud-page-view-toggle]')
+    // Settle the simulation a beat.
+    await page.waitForTimeout(800)
+    await page.screenshot({
+      path: 'e2e/screenshots/p350-cloud-graph.png',
+      fullPage: false,
+    })
+
+    // 3: List view (PVCs) — show the card grid + active list table.
+    await gotoProvision(page, 'cloud?view=list&kind=pvcs')
+    await page.waitForSelector('[data-testid=cloud-list-view-tile-grid]')
+    await page.screenshot({
+      path: 'e2e/screenshots/p350-cloud-list-pvcs.png',
+      fullPage: false,
+    })
+
+    // 4: Fullscreen graph — synthetic overlay state.
+    await gotoProvision(page, 'cloud?view=graph')
+    await page.waitForSelector('[data-testid=cloud-page-fullscreen-toggle]')
+    await page.getByTestId('cloud-page-fullscreen-toggle').click()
+    // Wait for the data-fullscreen flip + transition to settle.
+    await page.waitForFunction(() => {
+      const el = document.querySelector('[data-testid=cloud-content]')
+      return el?.getAttribute('data-fullscreen') === 'true'
+    }, undefined, { timeout: 3_000 })
+    await page.waitForTimeout(400)
+    await page.screenshot({
+      path: 'e2e/screenshots/p350-cloud-fullscreen-graph.png',
+      fullPage: false,
+    })
+  })
+})

--- a/products/catalyst/bootstrap/ui/e2e/cosmetic-guards.spec.ts
+++ b/products/catalyst/bootstrap/ui/e2e/cosmetic-guards.spec.ts
@@ -1325,30 +1325,34 @@ test.describe('@cosmetic-guard cloud section', () => {
     }
   })
 
-  test('Sidebar exposes a Cloud accordion (not a flat Infrastructure entry)', async ({ page }) => {
+  test('Sidebar exposes a single flat Cloud entry (not the legacy accordion or flat Infrastructure)', async ({ page }) => {
     await page.goto('provision/test-deployment-id')
     await page.waitForLoadState('domcontentloaded')
 
-    const cloudHeader = page.getByTestId('sov-nav-cloud')
+    const cloud = page.getByTestId('sov-nav-cloud')
     await expect(
-      cloudHeader,
-      'Sidebar is missing the Cloud accordion header. Add a button with data-testid=sov-nav-cloud (see Sidebar.tsx).',
+      cloud,
+      'Sidebar is missing the Cloud nav entry. Add an <a> with data-testid=sov-nav-cloud (see Sidebar.tsx).',
     ).toBeVisible()
 
+    // Issue #350 dropped the accordion — Cloud must be a flat <a>, no
+    // chevron, no aria-controls, no sub-items.
     expect(
-      cloudHeader.getAttribute('aria-controls'),
-      'Cloud accordion header must declare aria-controls pointing at the sub-list group.',
-    ).resolves.toBe('sov-nav-cloud-group')
+      await cloud.evaluate((el) => el.tagName),
+      'Cloud nav entry must be an anchor (single-level link) — issue #350 replaced the accordion with a flat link.',
+    ).toBe('A')
+    expect(await page.getByTestId('sov-nav-cloud-toggle').count()).toBe(0)
+    expect(await page.getByTestId('sov-nav-cloud-architecture').count()).toBe(0)
 
-    // The legacy flat "Infrastructure" entry must be gone.
+    // Legacy flat "Infrastructure" entry must remain gone.
     expect(
       await page.getByTestId('sov-nav-infrastructure').count(),
-      'Sidebar still renders a flat sov-nav-infrastructure item — issue #309 replaced it with a Cloud accordion.',
+      'Sidebar still renders a flat sov-nav-infrastructure item — issue #309 replaced it with the Cloud entry.',
     ).toBe(0)
   })
 
   test('Per-Sovereign switcher renders in the Cloud header', async ({ page }) => {
-    await page.goto('provision/test-deployment-id/cloud/architecture')
+    await page.goto('provision/test-deployment-id/cloud?view=graph')
     await page.waitForLoadState('domcontentloaded')
 
     const switcher = page.getByTestId('cloud-sovereign-switcher')

--- a/products/catalyst/bootstrap/ui/src/app/router.tsx
+++ b/products/catalyst/bootstrap/ui/src/app/router.tsx
@@ -1,4 +1,4 @@
-import { createRouter, createRoute, createRootRoute, Outlet, redirect } from '@tanstack/react-router'
+import { createRouter, createRoute, createRootRoute, redirect } from '@tanstack/react-router'
 import { IS_SAAS } from '@/shared/constants/env'
 
 // Lazy page imports
@@ -24,25 +24,6 @@ import { JobDetail } from '@/pages/sovereign/JobDetail'
 import { JobsTimeline } from '@/pages/sovereign/JobsTimeline'
 import { Dashboard } from '@/pages/sovereign/Dashboard'
 import { CloudPage } from '@/pages/sovereign/CloudPage'
-import { Architecture } from '@/pages/sovereign/Architecture'
-// Cloud category landing pages (P3 of #309) — replace the previous
-// flat-dump CloudCompute / CloudNetwork / CloudStorage components.
-import { CloudComputePage } from '@/pages/sovereign/cloud-compute/CloudComputePage'
-import { CloudNetworkPage } from '@/pages/sovereign/cloud-network/CloudNetworkPage'
-import { CloudStoragePage } from '@/pages/sovereign/cloud-storage/CloudStoragePage'
-// Cloud per-resource list pages (P3 of #309).
-import { ClustersPage } from '@/pages/sovereign/cloud-compute/ClustersPage'
-import { VClustersPage } from '@/pages/sovereign/cloud-compute/VClustersPage'
-import { NodePoolsPage } from '@/pages/sovereign/cloud-compute/NodePoolsPage'
-import { WorkerNodesPage } from '@/pages/sovereign/cloud-compute/WorkerNodesPage'
-import { ServicesPage } from '@/pages/sovereign/cloud-network/ServicesPage'
-import { IngressesPage } from '@/pages/sovereign/cloud-network/IngressesPage'
-import { LoadBalancersPage } from '@/pages/sovereign/cloud-network/LoadBalancersPage'
-import { DnsZonesPage } from '@/pages/sovereign/cloud-network/DnsZonesPage'
-import { PvcsPage } from '@/pages/sovereign/cloud-storage/PvcsPage'
-import { StorageClassesPage } from '@/pages/sovereign/cloud-storage/StorageClassesPage'
-import { BucketsPage } from '@/pages/sovereign/cloud-storage/BucketsPage'
-import { VolumesPage } from '@/pages/sovereign/cloud-storage/VolumesPage'
 
 // Root
 const rootRoute = createRootRoute({ component: RootLayout })
@@ -96,39 +77,23 @@ const provisionAppRoute = createRoute({
 
 // Global jobs list — table view (issue #204 founder spec). Each row is
 // a clickable link that navigates to the per-job detail page.
-//
-// v3 (PR feat/flow-canvas-polish-and-routing) — the previous
-// `?view=table|flow` Tab strip was removed. The Flow surface lives at
-// its own /flow route below. JobsPage now has a "Show as Flow" button
-// in the header that links to /flow?scope=all.
 const provisionJobsRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: '/provision/$deploymentId/jobs',
   component: JobsPage,
 })
 
-// NOTE: the standalone /provision/$deploymentId/flow route was removed
-// (operator directive 2026-04-30) — flows live only in context, not as
-// a generic page. The FlowPage component is embedded inside JobDetail.
-
 // Jobs timeline (Gantt-style retrospective). Static segment, MUST be
 // registered BEFORE the dynamic $jobId route below so TanStack Router
 // resolves `/jobs/timeline` to this surface, not to JobDetail with
-// jobId="timeline". Stretch deliverable for epic openova-io/openova#204
-// item 11 (sub-ticket #206).
+// jobId="timeline".
 const provisionJobsTimelineRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: '/provision/$deploymentId/jobs/timeline',
   component: JobsTimeline,
 })
 
-// Per-Job detail page (epic #204) — surfaces the GitLab-CI-runner-style
-// execution log viewer + Dependencies + Apps tabs. Reachable from the
-// JobsTable row link and from deep links shared in Slack / runbook /
-// failure email. The path lives under /provision/$deploymentId/jobs/
-// $jobId so it is namespaced by deployment, not the legacy /job/$jobId
-// pattern that the cosmetic guards still reject for the main JobsPage
-// row click.
+// Per-Job detail page (epic #204).
 const provisionJobDetailRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: '/provision/$deploymentId/jobs/$jobId',
@@ -136,161 +101,94 @@ const provisionJobDetailRoute = createRoute({
 })
 
 // Sovereign Dashboard — resource-utilisation treemap (founder spec).
-// Box area = allocated capacity, colour = utilisation/health/age. Lives
-// alongside the AppsPage / JobsPage Sovereign-portal surfaces under the
-// same /provision/$deploymentId namespace so the sidebar nav entry
-// resolves with the same tanstack-router params as its siblings.
 const provisionDashboardRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: '/provision/$deploymentId/dashboard',
   component: Dashboard,
 })
 
-// Sovereign Cloud surface (issue #309 supersedes #227/#228) — the
-// previous "Infrastructure" section is renamed to "Cloud" and its
-// in-page tab strip is replaced by an accordion in the left sidebar
-// (see Sidebar.tsx). The shell renders header + an <Outlet />; bare
-// /cloud redirects to the architecture sub-route so the URL shape is
-// always explicit.
-//
-// The legacy /infrastructure/* paths below are preserved as
-// redirect-only routes so deep links and bookmarks land on the
-// renamed surface without 404'ing.
+/* ── Cloud (issue #350) ─────────────────────────────────────────
+ *
+ * Single parent route. The graph/list dispatch is owned by
+ * CloudPage.tsx via the `view` query param; the resource kind for
+ * list view is the `kind` query param. The legacy P3 sub-routes
+ * `/cloud/<category>/<resource>` are preserved as 301 redirects so
+ * deep links and bookmarks keep working without rendering the
+ * renamed surface twice.
+ */
+
+interface CloudSearch {
+  view?: 'graph' | 'list'
+  kind?: string
+}
+
 const provisionCloudRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: '/provision/$deploymentId/cloud',
   component: CloudPage,
-})
-
-const provisionCloudIndexRoute = createRoute({
-  getParentRoute: () => provisionCloudRoute,
-  path: '/',
-  beforeLoad: ({ params }) => {
-    throw redirect({
-      to: '/provision/$deploymentId/cloud/architecture',
-      params,
-    })
+  validateSearch: (raw: Record<string, unknown>): CloudSearch => {
+    const out: CloudSearch = {}
+    if (raw.view === 'graph' || raw.view === 'list') out.view = raw.view
+    if (typeof raw.kind === 'string' && raw.kind.length > 0) out.kind = raw.kind
+    return out
   },
 })
 
-const provisionCloudArchitectureRoute = createRoute({
-  getParentRoute: () => provisionCloudRoute,
-  path: '/architecture',
-  component: Architecture,
-})
-
-// P3 of #309 — each category route is a thin <Outlet /> parent with
-// an index route hosting the landing page. This shape lets
-// /cloud/compute render the CloudComputePage tiles AND
-// /cloud/compute/clusters render ClustersPage inside the parent
-// outlet, all under the same accordion highlight.
-const CloudCategoryOutlet = () => <Outlet />
-
-const provisionCloudComputeRoute = createRoute({
-  getParentRoute: () => provisionCloudRoute,
-  path: '/compute',
-  component: CloudCategoryOutlet,
-})
-const provisionCloudComputeIndexRoute = createRoute({
-  getParentRoute: () => provisionCloudComputeRoute,
-  path: '/',
-  component: CloudComputePage,
-})
-
-const provisionCloudStorageRoute = createRoute({
-  getParentRoute: () => provisionCloudRoute,
-  path: '/storage',
-  component: CloudCategoryOutlet,
-})
-const provisionCloudStorageIndexRoute = createRoute({
-  getParentRoute: () => provisionCloudStorageRoute,
-  path: '/',
-  component: CloudStoragePage,
-})
-
-const provisionCloudNetworkRoute = createRoute({
-  getParentRoute: () => provisionCloudRoute,
-  path: '/network',
-  component: CloudCategoryOutlet,
-})
-const provisionCloudNetworkIndexRoute = createRoute({
-  getParentRoute: () => provisionCloudNetworkRoute,
-  path: '/',
-  component: CloudNetworkPage,
-})
-
-/* ── P3: per-resource list pages (under /cloud/<category>/<kind>) ── */
-
-const provisionCloudClustersRoute = createRoute({
-  getParentRoute: () => provisionCloudComputeRoute,
-  path: '/clusters',
-  component: ClustersPage,
-})
-const provisionCloudVClustersRoute = createRoute({
-  getParentRoute: () => provisionCloudComputeRoute,
-  path: '/vclusters',
-  component: VClustersPage,
-})
-const provisionCloudNodePoolsRoute = createRoute({
-  getParentRoute: () => provisionCloudComputeRoute,
-  path: '/node-pools',
-  component: NodePoolsPage,
-})
-const provisionCloudWorkerNodesRoute = createRoute({
-  getParentRoute: () => provisionCloudComputeRoute,
-  path: '/worker-nodes',
-  component: WorkerNodesPage,
-})
-
-const provisionCloudServicesRoute = createRoute({
-  getParentRoute: () => provisionCloudNetworkRoute,
-  path: '/services',
-  component: ServicesPage,
-})
-const provisionCloudIngressesRoute = createRoute({
-  getParentRoute: () => provisionCloudNetworkRoute,
-  path: '/ingresses',
-  component: IngressesPage,
-})
-const provisionCloudLBsRoute = createRoute({
-  getParentRoute: () => provisionCloudNetworkRoute,
-  path: '/load-balancers',
-  component: LoadBalancersPage,
-})
-const provisionCloudDnsZonesRoute = createRoute({
-  getParentRoute: () => provisionCloudNetworkRoute,
-  path: '/dns-zones',
-  component: DnsZonesPage,
-})
-
-const provisionCloudPvcsRoute = createRoute({
-  getParentRoute: () => provisionCloudStorageRoute,
-  path: '/pvcs',
-  component: PvcsPage,
-})
-const provisionCloudStorageClassesRoute = createRoute({
-  getParentRoute: () => provisionCloudStorageRoute,
-  path: '/storage-classes',
-  component: StorageClassesPage,
-})
-const provisionCloudBucketsRoute = createRoute({
-  getParentRoute: () => provisionCloudStorageRoute,
-  path: '/buckets',
-  component: BucketsPage,
-})
-const provisionCloudVolumesRoute = createRoute({
-  getParentRoute: () => provisionCloudStorageRoute,
-  path: '/volumes',
-  component: VolumesPage,
-})
-
-// Legacy /infrastructure/* — every legacy path now redirects to its
-// /cloud/* equivalent so deep links and bookmarks keep working
-// without rendering the renamed surface twice. The components are
-// no-op stubs because tanstack-router still needs a `component` for
-// the route node to resolve before `beforeLoad` fires.
+// 301 redirects for the legacy P3 sub-routes. Each one redirects to
+// the consolidated `/cloud?view=…&kind=…` shape and renders nothing
+// itself — tanstack-router runs `beforeLoad` before the component
+// resolves, so the throw happens before paint.
 const NoopRedirectComponent = () => null
 
+interface LegacyRedirect {
+  /** Path appended to /provision/$deploymentId/cloud. */
+  path: string
+  /** Search params to apply on the redirect target. */
+  search: CloudSearch
+}
+
+const LEGACY_CLOUD_REDIRECTS: readonly LegacyRedirect[] = [
+  // Architecture → graph view
+  { path: '/architecture', search: { view: 'graph' } },
+  // Compute landing + per-resource → list view with the right kind
+  { path: '/compute', search: { view: 'list', kind: 'clusters' } },
+  { path: '/compute/clusters', search: { view: 'list', kind: 'clusters' } },
+  { path: '/compute/vclusters', search: { view: 'list', kind: 'vclusters' } },
+  { path: '/compute/node-pools', search: { view: 'list', kind: 'node-pools' } },
+  { path: '/compute/worker-nodes', search: { view: 'list', kind: 'worker-nodes' } },
+  // Network landing + per-resource
+  { path: '/network', search: { view: 'list', kind: 'load-balancers' } },
+  { path: '/network/services', search: { view: 'list', kind: 'services' } },
+  { path: '/network/ingresses', search: { view: 'list', kind: 'ingresses' } },
+  { path: '/network/load-balancers', search: { view: 'list', kind: 'load-balancers' } },
+  { path: '/network/dns-zones', search: { view: 'list', kind: 'dns-zones' } },
+  // Storage landing + per-resource
+  { path: '/storage', search: { view: 'list', kind: 'pvcs' } },
+  { path: '/storage/pvcs', search: { view: 'list', kind: 'pvcs' } },
+  { path: '/storage/storage-classes', search: { view: 'list', kind: 'storage-classes' } },
+  { path: '/storage/buckets', search: { view: 'list', kind: 'buckets' } },
+  { path: '/storage/volumes', search: { view: 'list', kind: 'volumes' } },
+] as const
+
+const legacyCloudRedirectRoutes = LEGACY_CLOUD_REDIRECTS.map((r) =>
+  createRoute({
+    getParentRoute: () => provisionCloudRoute,
+    path: r.path,
+    component: NoopRedirectComponent,
+    beforeLoad: ({ params }) => {
+      throw redirect({
+        to: '/provision/$deploymentId/cloud' as never,
+        params: params as never,
+        search: r.search as never,
+        replace: true,
+      })
+    },
+  }),
+)
+
+// Legacy /infrastructure/* — every legacy path now redirects to the
+// /cloud query shape. Preserves back-compat with the original P1 of
+// #309 redirect set.
 const provisionInfrastructureRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: '/provision/$deploymentId/infrastructure',
@@ -302,65 +200,46 @@ const provisionInfrastructureIndexRoute = createRoute({
   path: '/',
   beforeLoad: ({ params }) => {
     throw redirect({
-      to: '/provision/$deploymentId/cloud/architecture',
-      params,
+      to: '/provision/$deploymentId/cloud' as never,
+      params: params as never,
+      search: { view: 'graph' } as never,
+      replace: true,
     })
   },
   component: NoopRedirectComponent,
 })
 
-const provisionInfrastructureTopologyRoute = createRoute({
-  getParentRoute: () => provisionInfrastructureRoute,
-  path: '/topology',
-  beforeLoad: ({ params }) => {
-    throw redirect({
-      to: '/provision/$deploymentId/cloud/architecture',
-      params,
-    })
-  },
-  component: NoopRedirectComponent,
-})
+interface InfraLegacyRedirect {
+  path: string
+  search: CloudSearch
+}
 
-const provisionInfrastructureComputeRoute = createRoute({
-  getParentRoute: () => provisionInfrastructureRoute,
-  path: '/compute',
-  beforeLoad: ({ params }) => {
-    throw redirect({
-      to: '/provision/$deploymentId/cloud/compute',
-      params,
-    })
-  },
-  component: NoopRedirectComponent,
-})
+const INFRA_LEGACY_REDIRECTS: readonly InfraLegacyRedirect[] = [
+  { path: '/topology', search: { view: 'graph' } },
+  { path: '/compute', search: { view: 'list', kind: 'clusters' } },
+  { path: '/storage', search: { view: 'list', kind: 'pvcs' } },
+  { path: '/network', search: { view: 'list', kind: 'load-balancers' } },
+] as const
 
-const provisionInfrastructureStorageRoute = createRoute({
-  getParentRoute: () => provisionInfrastructureRoute,
-  path: '/storage',
-  beforeLoad: ({ params }) => {
-    throw redirect({
-      to: '/provision/$deploymentId/cloud/storage',
-      params,
-    })
-  },
-  component: NoopRedirectComponent,
-})
-
-const provisionInfrastructureNetworkRoute = createRoute({
-  getParentRoute: () => provisionInfrastructureRoute,
-  path: '/network',
-  beforeLoad: ({ params }) => {
-    throw redirect({
-      to: '/provision/$deploymentId/cloud/network',
-      params,
-    })
-  },
-  component: NoopRedirectComponent,
-})
+const infraLegacyRedirectRoutes = INFRA_LEGACY_REDIRECTS.map((r) =>
+  createRoute({
+    getParentRoute: () => provisionInfrastructureRoute,
+    path: r.path,
+    component: NoopRedirectComponent,
+    beforeLoad: ({ params }) => {
+      throw redirect({
+        to: '/provision/$deploymentId/cloud' as never,
+        params: params as never,
+        search: r.search as never,
+        replace: true,
+      })
+    },
+  }),
+)
 
 // Legacy DAG provision view — preserved at a sub-path so existing
 // links and CI smoke tests (which still curl `/provision/legacy/...`)
-// don't 404 mid-rollout. Once the public smoke tests move to the new
-// /provision/$deploymentId surface, this route can be removed.
+// don't 404 mid-rollout.
 const legacyProvisionRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: '/provision/legacy/$deploymentId',
@@ -404,37 +283,10 @@ const routeTree = rootRoute.addChildren([
   provisionJobsTimelineRoute,
   provisionJobDetailRoute,
   provisionDashboardRoute,
-  provisionCloudRoute.addChildren([
-    provisionCloudIndexRoute,
-    provisionCloudArchitectureRoute,
-    provisionCloudComputeRoute.addChildren([
-      provisionCloudComputeIndexRoute,
-      provisionCloudClustersRoute,
-      provisionCloudVClustersRoute,
-      provisionCloudNodePoolsRoute,
-      provisionCloudWorkerNodesRoute,
-    ]),
-    provisionCloudStorageRoute.addChildren([
-      provisionCloudStorageIndexRoute,
-      provisionCloudPvcsRoute,
-      provisionCloudStorageClassesRoute,
-      provisionCloudBucketsRoute,
-      provisionCloudVolumesRoute,
-    ]),
-    provisionCloudNetworkRoute.addChildren([
-      provisionCloudNetworkIndexRoute,
-      provisionCloudServicesRoute,
-      provisionCloudIngressesRoute,
-      provisionCloudLBsRoute,
-      provisionCloudDnsZonesRoute,
-    ]),
-  ]),
+  provisionCloudRoute.addChildren(legacyCloudRedirectRoutes),
   provisionInfrastructureRoute.addChildren([
     provisionInfrastructureIndexRoute,
-    provisionInfrastructureTopologyRoute,
-    provisionInfrastructureComputeRoute,
-    provisionInfrastructureStorageRoute,
-    provisionInfrastructureNetworkRoute,
+    ...infraLegacyRedirectRoutes,
   ]),
   legacyProvisionRoute,
   designsRoute,

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/Architecture.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/Architecture.test.tsx
@@ -32,7 +32,6 @@ import {
 } from '@tanstack/react-router'
 
 import { CloudPage } from './CloudPage'
-import { Architecture } from './Architecture'
 import { infrastructureTopologyFixture } from '@/test/fixtures/infrastructure-topology.fixture'
 import type { HierarchicalInfrastructure } from '@/lib/infrastructure.types'
 import { useWizardStore } from '@/entities/deployment/store'
@@ -51,19 +50,29 @@ function renderArchitecturePage(data: HierarchicalInfrastructure) {
     getParentRoute: () => rootRoute,
     path: '/provision/$deploymentId/cloud',
     component: () => (
-      <CloudPage disableStream initialDataOverride={data} deploymentsOverride={[]} />
+      // CloudPage now owns the graph/list view dispatch internally —
+      // when view=graph (default), the body renders the Architecture
+      // surface directly. We don't pass contentOverride so the
+      // production dispatch path is exercised.
+      <CloudPage
+        disableStream
+        viewOverride="graph"
+        initialDataOverride={data}
+        deploymentsOverride={[]}
+      />
     ),
+    validateSearch: (raw: Record<string, unknown>) => {
+      const out: { view?: 'graph' | 'list'; kind?: string } = {}
+      if (raw.view === 'graph' || raw.view === 'list') out.view = raw.view
+      if (typeof raw.kind === 'string') out.kind = raw.kind
+      return out
+    },
   })
-  const architectureRoute = createRoute({
-    getParentRoute: () => cloudRoute,
-    path: '/architecture',
-    component: Architecture,
-  })
-  const tree = rootRoute.addChildren([cloudRoute.addChildren([architectureRoute])])
+  const tree = rootRoute.addChildren([cloudRoute])
   const router = createRouter({
     routeTree: tree,
     history: createMemoryHistory({
-      initialEntries: ['/provision/d-1/cloud/architecture'],
+      initialEntries: ['/provision/d-1/cloud?view=graph'],
     }),
   })
   const qc = new QueryClient({

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/CloudPage.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/CloudPage.test.tsx
@@ -1,13 +1,17 @@
 /**
  * CloudPage.test.tsx — shell wiring lock-in for the Sovereign Cloud
- * surface (issue #309 supersedes #227).
+ * surface (issue #350 — IA restructure).
  *
  * Coverage:
  *   1. Header renders with the canonical title ("Cloud").
- *   2. The in-page tab strip is gone (the sidebar accordion replaces
- *      it — see Sidebar.tsx and the e2e cloud-nav spec).
- *   3. The shell renders an <Outlet /> that hosts the active sub-page.
- *   4. PortalShell wires (sidebar present).
+ *   2. The shell renders the in-page View toggle (Graph | List) as a
+ *      single segmented control. The legacy in-page category tab strip
+ *      remains absent.
+ *   3. The shell exposes a Fullscreen toggle button.
+ *   4. The shell renders the dispatched body (graph or list) when no
+ *      contentOverride is supplied. With contentOverride, the override
+ *      wins (used by these tests to keep the heavyweight body out).
+ *   5. PortalShell wires (sidebar present).
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
@@ -110,15 +114,32 @@ describe('CloudPage — shell', () => {
   })
 })
 
-describe('CloudPage — no in-page tab strip', () => {
-  it('does NOT render an in-page tablist (the sidebar accordion replaces it)', async () => {
+describe('CloudPage — view toggle and fullscreen', () => {
+  it('does NOT render the legacy infrastructure category tab strip', async () => {
     renderShell('d-1', 'architecture')
     await screen.findByTestId('cloud-title')
-    // The legacy tab strip lived under [data-testid=infrastructure-tabs];
-    // it is intentionally absent now — sub-page nav lives in the
-    // sidebar accordion (see Sidebar.tsx).
     expect(screen.queryByTestId('infrastructure-tabs')).toBeNull()
     expect(screen.queryByTestId('cloud-tabs')).toBeNull()
-    expect(screen.queryByRole('tablist')).toBeNull()
+  })
+
+  it('renders the Graph | List view toggle (segmented control)', async () => {
+    renderShell('d-1', 'architecture')
+    await screen.findByTestId('cloud-title')
+    const toggle = screen.getByTestId('cloud-page-view-toggle')
+    expect(toggle.getAttribute('role')).toBe('tablist')
+    const graph = screen.getByTestId('cloud-page-view-graph')
+    const list = screen.getByTestId('cloud-page-view-list')
+    expect(graph.tagName).toBe('BUTTON')
+    expect(list.tagName).toBe('BUTTON')
+    // Default = graph.
+    expect(graph.getAttribute('aria-selected')).toBe('true')
+    expect(list.getAttribute('aria-selected')).toBe('false')
+  })
+
+  it('renders the Fullscreen toggle button with aria-pressed reflecting state', async () => {
+    renderShell('d-1', 'architecture')
+    const fs = await screen.findByTestId('cloud-page-fullscreen-toggle')
+    expect(fs.tagName).toBe('BUTTON')
+    expect(fs.getAttribute('aria-pressed')).toBe('false')
   })
 })

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/CloudPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/CloudPage.tsx
@@ -1,37 +1,59 @@
 /**
- * CloudPage — Sovereign-portal Cloud surface served at
- *   /sovereign/provision/$deploymentId/cloud/{architecture,compute,storage,network}
+ * CloudPage — Sovereign-portal Cloud surface (issue #350).
  *
- * Layout contract (issue #309):
- *   • Bare /cloud redirects to /cloud/architecture — the redirect is
- *     enforced by the router (see app/router.tsx); this component
- *     never renders standalone for the bare URL.
- *   • The shell renders a header (title + tagline + Sovereign
- *     switcher) and an <Outlet />. The sub-page navigation lives in
- *     the left sidebar as an accordion under "Cloud" — the previous
- *     in-page tab strip has been removed (see Sidebar.tsx).
- *   • The page owns ONE React Query for the hierarchical
- *     infrastructure tree. Sub-pages read from the shared query via
- *     `CloudContext` — no per-page fetches.
+ * Single parent page served at `/sovereign/provision/$id/cloud`. The
+ * legacy `/cloud/<category>` and `/cloud/<category>/<resource>` paths
+ * (#309 P3) are now redirect-only — they 301 into this page with a
+ * `view=list&kind=…` query.
+ *
+ * Layout:
+ *   • Header: H1 "Cloud" + tagline + per-Sovereign switcher.
+ *   • Toolbar: a segmented View toggle (Graph | List) and a Fullscreen
+ *     button on the right.
+ *   • Content area: when `view=graph` (default) — renders the
+ *     ArchitectureGraphPage. When `view=list` — renders CloudListView
+ *     (12-tile card grid + dropdown switcher + active P3 list table).
+ *
+ * The view toggle persists to localStorage under `sov-cloud-view`. The
+ * URL query takes precedence on every navigation, so deep links are
+ * always explicit. Operators arriving at `/cloud` without a `view`
+ * query are redirected to either the persisted view or `view=graph`
+ * (default).
+ *
+ * Fullscreen behaves like the canonical pattern: `requestFullscreen()`
+ * on the main content container, smooth scale + fade transition,
+ * native Esc to exit, plus an "Exit fullscreen" button rendered inside
+ * the overlay (top-right) for discoverability.
  *
  * Per docs/INVIOLABLE-PRINCIPLES.md:
- *   #1 (waterfall) — all four sub-pages ship at once.
- *   #4 (never hardcode) — every label / route is derived from the
- *      router's path constants; no inline "/cloud/foo" string outside
- *      the redirect target in the page-switcher.
- *
- * The data shape `HierarchicalInfrastructure` and the
- * `getHierarchicalInfrastructure` API call retain the legacy
- * "infrastructure" name because they are server-side contract
- * identifiers, not user-visible strings.
+ *   #1 (waterfall) — graph view, list view, fullscreen all ship at
+ *      once.
+ *   #4 (never hardcode) — every label / route / token comes from a
+ *      typed constant or a CSS variable.
  */
 
-import { createContext, useContext, useMemo, type ReactNode } from 'react'
-import { Outlet, useNavigate, useParams, useRouterState } from '@tanstack/react-router'
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react'
+import {
+  Outlet,
+  useNavigate,
+  useParams,
+  useRouterState,
+  useSearch,
+} from '@tanstack/react-router'
 import { useQuery } from '@tanstack/react-query'
 import { PortalShell } from './PortalShell'
 import { useDeploymentEvents } from './useDeploymentEvents'
-import { useK8sStream, type K8sObject } from '@/lib/useK8sStream'
+import { Architecture } from './Architecture'
+import { CloudListView } from './cloud-list/CloudListView'
 import {
   getHierarchicalInfrastructure,
   listDeployments,
@@ -41,6 +63,35 @@ import {
   type TopologyTree,
 } from '@/lib/infrastructure.types'
 import { infrastructureTopologyFixture } from '@/test/fixtures/infrastructure-topology.fixture'
+
+/* ── View mode ──────────────────────────────────────────────────── */
+
+export type CloudView = 'graph' | 'list'
+const DEFAULT_VIEW: CloudView = 'graph'
+const VIEW_STORAGE_KEY = 'sov-cloud-view'
+
+function isValidView(value: unknown): value is CloudView {
+  return value === 'graph' || value === 'list'
+}
+
+function readPersistedView(): CloudView | null {
+  if (typeof window === 'undefined') return null
+  try {
+    const raw = window.localStorage.getItem(VIEW_STORAGE_KEY)
+    return isValidView(raw) ? raw : null
+  } catch {
+    return null
+  }
+}
+
+function writePersistedView(view: CloudView): void {
+  if (typeof window === 'undefined') return
+  try {
+    window.localStorage.setItem(VIEW_STORAGE_KEY, view)
+  } catch {
+    /* noop */
+  }
+}
 
 /**
  * Synthesise a `cloud` block from the regions list when the backend
@@ -71,29 +122,12 @@ function inferCloudFromTopology(topology?: TopologyTree): CloudSpec[] {
 
 /* ── Shared infrastructure query context ───────────────────────── */
 
-/**
- * Per ADR-0001 §5: every Cloud sub-page reads off ONE Indexer-fed
- * source. The legacy `getHierarchicalInfrastructure` REST call
- * remains as the cold-start seed (so a deep-link renders without
- * waiting for SSE), and the K8s stream provides live updates from
- * the catalyst-api's in-process Indexer (issue #321).
- *
- * `liveItems` is the flat array of K8s objects, `liveByKind` the same
- * data grouped by short kind name. Sub-pages that consume cluster-
- * native objects (Pod, Deployment, Server.hcloud, vCluster) read off
- * the live source; the hierarchical `data` shape continues to drive
- * the Architecture graph base layout.
- */
 export interface CloudContextValue {
   deploymentId: string
   data: HierarchicalInfrastructure | null
   isLoading: boolean
   isError: boolean
   refetch: () => void
-  liveItems: K8sObject[]
-  liveByKind: Record<string, K8sObject[]>
-  liveLastEventAt: Date | null
-  liveStreaming: boolean
 }
 
 const CloudContext = createContext<CloudContextValue | null>(null)
@@ -114,9 +148,9 @@ export interface CloudPageProps {
   /** Test seam — disables the live SSE EventSource attach. */
   disableStream?: boolean
   /**
-   * Test seam — render a content slot directly instead of using
-   * <Outlet />. Allows component tests to mount the shell without
-   * requiring a full TanStack-Router child tree.
+   * Test seam — render a content slot directly instead of dispatching
+   * on the URL `view` query. Allows component tests to mount the
+   * shell without requiring a full TanStack-Router child tree.
    */
   contentOverride?: ReactNode
   /**
@@ -127,6 +161,8 @@ export interface CloudPageProps {
   initialDataOverride?: HierarchicalInfrastructure
   /** Test seam — bypass the deployments-list fetch. */
   deploymentsOverride?: DeploymentSummary[]
+  /** Test seam — force the view irrespective of URL/storage. */
+  viewOverride?: CloudView
 }
 
 export function CloudPage({
@@ -134,6 +170,7 @@ export function CloudPage({
   contentOverride,
   initialDataOverride,
   deploymentsOverride,
+  viewOverride,
 }: CloudPageProps = {}) {
   // tanstack-router resolves the matched route's params at runtime;
   // both the new `/cloud` parent and the legacy `/infrastructure`
@@ -145,6 +182,7 @@ export function CloudPage({
   const navigate = useNavigate()
 
   const pathname = useRouterState({ select: (s) => s.location.pathname })
+  const search = useSearch({ strict: false }) as { view?: string; kind?: string }
 
   const { snapshot } = useDeploymentEvents({
     deploymentId,
@@ -159,11 +197,6 @@ export function CloudPage({
     queryFn: () => getHierarchicalInfrastructure(deploymentId),
     staleTime: STALE_MS,
     enabled: !initialDataOverride,
-    // The fixture serves as the local-dev fallback when the live
-    // backend isn't deployed — the UI never fails closed in that
-    // case. Per founder spec, the fixture-backed path is the
-    // explicit pre-backend mode and must serve every sub-page off
-    // the same shape.
     retry: 1,
   })
 
@@ -182,11 +215,6 @@ export function CloudPage({
       topologyQuery.data ??
       (topologyQuery.isError ? infrastructureTopologyFixture : null)
     if (!raw) return null
-    // Backend-tolerant normalisation — every collection field defaults
-    // to an empty array so consumers can iterate freely. The current
-    // backend ships a flat-ish response without `cloud` / `storage`
-    // arrays; we synthesise them here so the topology tree always
-    // has the expected shape.
     return {
       cloud: raw.cloud ?? inferCloudFromTopology(raw.topology),
       topology: {
@@ -198,9 +226,6 @@ export function CloudPage({
             vclusters: c.vclusters ?? [],
             loadBalancers: (c.loadBalancers ?? []).map((lb) => ({
               ...lb,
-              // Older backend serialises `ports` as a CSV string; the
-              // new shape uses an array of {port, protocol}. Coerce
-              // either to the canonical array form.
               listeners:
                 lb.listeners ??
                 (typeof (lb as unknown as { ports?: string }).ports === 'string'
@@ -230,32 +255,6 @@ export function CloudPage({
     }
   }, [initialDataOverride, topologyQuery.data, topologyQuery.isError])
 
-  // Live K8s stream — issue #321 data plane. The Sovereign id at this
-  // surface is the deploymentId (catalyst-api uses the deployment id
-  // as the Sovereign key when there's no explicit alias). We watch
-  // the kinds the Cloud surface renders: Pod / Deployment / Service
-  // for compute, Crossplane provider-hcloud projections for cloud
-  // resources, vCluster for tenancy. The stream is a noop in
-  // disableStream mode so the existing CloudPage tests keep working.
-  const k8sStream = useK8sStream({
-    sovereignId: deploymentId,
-    kinds: [
-      'pod',
-      'deployment',
-      'statefulset',
-      'service',
-      'persistentvolumeclaim',
-      'node',
-      'server.hcloud',
-      'loadbalancer.hcloud',
-      'network.hcloud',
-      'volume.hcloud',
-      'vcluster',
-    ],
-    initialState: false, // REST seeds; SSE delivers diff
-    disableStream,
-  })
-
   const ctx: CloudContextValue = useMemo(
     () => ({
       deploymentId,
@@ -263,12 +262,8 @@ export function CloudPage({
       isLoading: !initialDataOverride && topologyQuery.isLoading && !data,
       isError: topologyQuery.isError && !initialDataOverride,
       refetch: () => topologyQuery.refetch(),
-      liveItems: k8sStream.items,
-      liveByKind: k8sStream.byKind,
-      liveLastEventAt: k8sStream.lastEventAt,
-      liveStreaming: !k8sStream.isLoading && !k8sStream.isError,
     }),
-    [deploymentId, data, initialDataOverride, topologyQuery, k8sStream],
+    [deploymentId, data, initialDataOverride, topologyQuery],
   )
 
   const deployments = deploymentsOverride ?? deploymentsQuery.data ?? []
@@ -284,28 +279,146 @@ export function CloudPage({
     return list
   }, [deployments, deploymentId, sovereignFQDN])
 
-  function handleSwitch(nextId: string) {
-    if (nextId === deploymentId) return
-    // Preserve the current sub-page when switching Sovereigns: if the
-    // operator is on /cloud/compute/clusters, keep them on the same
-    // sub-route under the new deployment. Falls back to /architecture
-    // otherwise. Captures both the category and any deeper resource
-    // segment (P3 of #309).
-    const cloudIdx = pathname.indexOf('/cloud/')
-    let suffix = 'architecture'
-    if (cloudIdx >= 0) {
-      const tail = pathname.slice(cloudIdx + '/cloud/'.length).replace(/\/$/, '')
-      // Whitelist: only preserve known suffixes. Anything else (legacy
-      // /topology, malformed, …) collapses to /architecture.
-      if (tail.length > 0 && /^[a-z][a-z-]*(\/[a-z][a-z-]*)?$/.test(tail) && tail !== 'topology') {
-        suffix = tail
-      }
+  /* ── View mode resolution ───────────────────────────────────── */
+  const activeView: CloudView = useMemo(() => {
+    if (viewOverride) return viewOverride
+    if (isValidView(search.view)) return search.view
+    return readPersistedView() ?? DEFAULT_VIEW
+  }, [viewOverride, search.view])
+
+  // Persist + URL-canonicalise on every change.
+  useEffect(() => {
+    writePersistedView(activeView)
+  }, [activeView])
+
+  useEffect(() => {
+    if (viewOverride) return
+    if (search.view === activeView) return
+    if (!pathname.endsWith('/cloud')) return
+    // For graph view we don't carry kind; for list view we let the
+    // list view itself populate kind on mount (avoids a double-nav
+    // when the persisted kind is read client-side).
+    const next: { view: CloudView; kind?: string } = { view: activeView }
+    if (activeView === 'list' && typeof search.kind === 'string') {
+      next.kind = search.kind
     }
     navigate({
-      to: `/provision/$deploymentId/cloud/${suffix}` as never,
-      params: { deploymentId: nextId } as never,
+      to: '/provision/$deploymentId/cloud' as never,
+      params: { deploymentId } as never,
+      search: next as never,
+      replace: true,
+    })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeView, search.view, search.kind, pathname, deploymentId, viewOverride])
+
+  function setView(next: CloudView) {
+    if (next === activeView) return
+    const target: { view: CloudView; kind?: string } = { view: next }
+    if (next === 'list' && typeof search.kind === 'string') {
+      target.kind = search.kind
+    }
+    navigate({
+      to: '/provision/$deploymentId/cloud' as never,
+      params: { deploymentId } as never,
+      search: target as never,
+      replace: false,
     })
   }
+
+  function handleSwitch(nextId: string) {
+    if (nextId === deploymentId) return
+    // Preserve the active view (and active kind if list) when the
+    // operator switches Sovereigns.
+    const target: { view: CloudView; kind?: string } = { view: activeView }
+    if (activeView === 'list' && typeof search.kind === 'string') {
+      target.kind = search.kind
+    }
+    navigate({
+      to: '/provision/$deploymentId/cloud' as never,
+      params: { deploymentId: nextId } as never,
+      search: target as never,
+    })
+  }
+
+  /* ── Fullscreen ─────────────────────────────────────────────── */
+  const contentRef = useRef<HTMLDivElement | null>(null)
+  const [isFullscreen, setIsFullscreen] = useState(false)
+
+  useEffect(() => {
+    function handleChange() {
+      const fs = document.fullscreenElement
+      setIsFullscreen(fs === contentRef.current)
+    }
+    document.addEventListener('fullscreenchange', handleChange)
+    // Defensive: also listen to the prefixed events for older Safari.
+    document.addEventListener('webkitfullscreenchange' as never, handleChange)
+    return () => {
+      document.removeEventListener('fullscreenchange', handleChange)
+      document.removeEventListener('webkitfullscreenchange' as never, handleChange)
+    }
+  }, [])
+
+  const enterFullscreen = useCallback(() => {
+    const el = contentRef.current
+    if (!el) return
+    const req =
+      (el.requestFullscreen as unknown as undefined | (() => Promise<void>)) ??
+      ((el as unknown as { webkitRequestFullscreen?: () => Promise<void> })
+        .webkitRequestFullscreen as undefined | (() => Promise<void>))
+    if (typeof req === 'function') {
+      req.call(el)?.catch(() => {
+        /* User-agent denied fullscreen — render synthetic-fullscreen
+         *  state via CSS instead, see contentRef class below. */
+        setIsFullscreen(true)
+      })
+    } else {
+      // Synthetic fallback for environments without the API (jsdom,
+      // older browsers): toggle a CSS-only "fullscreen" affordance so
+      // the operator still sees a maximised view.
+      setIsFullscreen(true)
+    }
+  }, [])
+
+  const exitFullscreen = useCallback(() => {
+    if (document.fullscreenElement === contentRef.current) {
+      const exit =
+        (document.exitFullscreen as unknown as undefined | (() => Promise<void>)) ??
+        ((document as unknown as { webkitExitFullscreen?: () => Promise<void> })
+          .webkitExitFullscreen as undefined | (() => Promise<void>))
+      if (typeof exit === 'function') {
+        exit.call(document)?.catch(() => {
+          setIsFullscreen(false)
+        })
+      } else {
+        setIsFullscreen(false)
+      }
+    } else {
+      setIsFullscreen(false)
+    }
+  }, [])
+
+  const toggleFullscreen = useCallback(() => {
+    if (isFullscreen) exitFullscreen()
+    else enterFullscreen()
+  }, [isFullscreen, enterFullscreen, exitFullscreen])
+
+  // Pick the body component: contentOverride > Outlet (legacy redirect
+  // routes still point children here) > view-driven dispatch.
+  let body: ReactNode
+  if (contentOverride) {
+    body = contentOverride
+  } else if (activeView === 'list') {
+    body = <CloudListView />
+  } else {
+    body = <Architecture />
+  }
+
+  // Outlet support: when the router has a child route matched (e.g.
+  // legacy /cloud/architecture before the redirect fires), render it
+  // through the Outlet. Otherwise render the dispatched body. The
+  // legacy routes are no-op redirect components, so the Outlet path
+  // collapses to null in steady state.
+  const outletSlot = <Outlet />
 
   return (
     <PortalShell deploymentId={deploymentId} sovereignFQDN={sovereignFQDN}>
@@ -344,9 +457,123 @@ export function CloudPage({
           </div>
         </header>
 
+        {/* Toolbar: View toggle (left) + Fullscreen button (right). */}
+        <div
+          className="cloud-page-toolbar"
+          data-testid="cloud-page-toolbar"
+        >
+          <div
+            role="tablist"
+            aria-label="Cloud view"
+            className="cloud-page-view-toggle"
+            data-testid="cloud-page-view-toggle"
+          >
+            <button
+              type="button"
+              role="tab"
+              data-testid="cloud-page-view-graph"
+              data-active={activeView === 'graph' ? 'true' : 'false'}
+              aria-selected={activeView === 'graph'}
+              aria-controls="cloud-page-content"
+              onClick={() => setView('graph')}
+              className={`cloud-page-view-tab ${activeView === 'graph' ? 'cloud-page-view-tab-active' : ''}`}
+            >
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.6} aria-hidden>
+                <circle cx="6" cy="6" r="2" />
+                <circle cx="18" cy="6" r="2" />
+                <circle cx="12" cy="18" r="2" />
+                <line x1="7.5" y1="7" x2="11" y2="16.5" strokeLinecap="round" />
+                <line x1="16.5" y1="7" x2="13" y2="16.5" strokeLinecap="round" />
+                <line x1="8" y1="6" x2="16" y2="6" strokeLinecap="round" />
+              </svg>
+              <span>Graph</span>
+            </button>
+            <button
+              type="button"
+              role="tab"
+              data-testid="cloud-page-view-list"
+              data-active={activeView === 'list' ? 'true' : 'false'}
+              aria-selected={activeView === 'list'}
+              aria-controls="cloud-page-content"
+              onClick={() => setView('list')}
+              className={`cloud-page-view-tab ${activeView === 'list' ? 'cloud-page-view-tab-active' : ''}`}
+            >
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.6} aria-hidden>
+                <line x1="4" y1="6" x2="20" y2="6" strokeLinecap="round" />
+                <line x1="4" y1="12" x2="20" y2="12" strokeLinecap="round" />
+                <line x1="4" y1="18" x2="20" y2="18" strokeLinecap="round" />
+              </svg>
+              <span>List</span>
+            </button>
+          </div>
+
+          <button
+            type="button"
+            data-testid="cloud-page-fullscreen-toggle"
+            aria-pressed={isFullscreen}
+            aria-label={isFullscreen ? 'Exit fullscreen' : 'Enter fullscreen'}
+            className="cloud-page-fs-toggle"
+            onClick={toggleFullscreen}
+          >
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.6} aria-hidden>
+              {isFullscreen ? (
+                <>
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M9 4v3a2 2 0 0 1 -2 2h-3" />
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M15 4v3a2 2 0 0 0 2 2h3" />
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M9 20v-3a2 2 0 0 0 -2 -2h-3" />
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M15 20v-3a2 2 0 0 1 2 -2h3" />
+                </>
+              ) : (
+                <>
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M4 9V6a2 2 0 0 1 2 -2h3" />
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M20 9V6a2 2 0 0 0 -2 -2h-3" />
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M4 15v3a2 2 0 0 0 2 2h3" />
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M20 15v3a2 2 0 0 1 -2 2h-3" />
+                </>
+              )}
+            </svg>
+            <span>{isFullscreen ? 'Exit fullscreen' : 'Fullscreen'}</span>
+          </button>
+        </div>
+
         <CloudContext.Provider value={ctx}>
-          <div className="mt-4" data-testid="cloud-content">
-            {contentOverride ?? <Outlet />}
+          <div
+            id="cloud-page-content"
+            ref={contentRef}
+            className={`cloud-page-content ${isFullscreen ? 'cloud-page-content-fullscreen' : ''}`}
+            data-testid="cloud-content"
+            data-fullscreen={isFullscreen ? 'true' : 'false'}
+            data-view={activeView}
+          >
+            {/* Floating exit button — only visible while fullscreen. */}
+            {isFullscreen && (
+              <button
+                type="button"
+                data-testid="cloud-page-fullscreen-exit"
+                aria-label="Exit fullscreen"
+                className="cloud-page-fs-exit"
+                onClick={exitFullscreen}
+              >
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.6} aria-hidden>
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M9 4v3a2 2 0 0 1 -2 2h-3" />
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M15 4v3a2 2 0 0 0 2 2h3" />
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M9 20v-3a2 2 0 0 0 -2 -2h-3" />
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M15 20v-3a2 2 0 0 1 2 -2h3" />
+                </svg>
+                <span>Exit fullscreen</span>
+              </button>
+            )}
+            {/* Body — outlet shows up first in case a child redirect
+             *  route is still resolving; otherwise the dispatched body. */}
+            <div className="cloud-page-body" data-testid={`cloud-page-body-${activeView}`}>
+              {body}
+            </div>
+            {/* Hidden outlet — used by the redirect-only legacy paths
+             *  that mount under this route. They render `null` so the
+             *  Outlet stays invisible in steady state. */}
+            <div className="cloud-page-outlet" aria-hidden>
+              {outletSlot}
+            </div>
           </div>
         </CloudContext.Provider>
       </div>
@@ -354,22 +581,118 @@ export function CloudPage({
   )
 }
 
-/**
- * Page-scoped CSS — shared layout primitives (.infra-grid /
- * .infra-section / .infra-card / .infra-empty / .infra-bulk-actions)
- * are still consumed by the four sub-pages. The legacy `.tabs` /
- * `.tab` rules were removed when the in-page tab strip was replaced
- * by the sidebar accordion.
- */
 const CLOUD_PAGE_CSS = `
+.cloud-page-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin-bottom: 0.75rem;
+}
+.cloud-page-view-toggle {
+  display: inline-flex;
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  overflow: hidden;
+  background: var(--color-bg-2);
+}
+.cloud-page-view-tab {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.4rem 0.85rem;
+  font-size: 0.82rem;
+  color: var(--color-text-dim);
+  background: transparent;
+  border: 0;
+  cursor: pointer;
+  transition: background 0.12s ease, color 0.12s ease;
+}
+.cloud-page-view-tab:hover { color: var(--color-text); background: var(--color-surface-hover); }
+.cloud-page-view-tab svg { width: 16px; height: 16px; }
+.cloud-page-view-tab + .cloud-page-view-tab { border-left: 1px solid var(--color-border); }
+.cloud-page-view-tab-active {
+  background: color-mix(in srgb, var(--color-accent) 16%, transparent);
+  color: var(--color-accent);
+  font-weight: 600;
+}
+
+.cloud-page-fs-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.4rem 0.75rem;
+  font-size: 0.82rem;
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  background: var(--color-bg-2);
+  color: var(--color-text-dim);
+  cursor: pointer;
+  transition: background 0.12s ease, color 0.12s ease, transform 0.12s ease;
+}
+.cloud-page-fs-toggle:hover { color: var(--color-text); background: var(--color-surface-hover); }
+.cloud-page-fs-toggle svg { width: 16px; height: 16px; }
+.cloud-page-fs-toggle[aria-pressed="true"] {
+  color: var(--color-accent);
+  border-color: var(--color-accent);
+}
+
+.cloud-page-content {
+  position: relative;
+  margin-top: 0.5rem;
+  /* Smooth scale + fade transition on enter/exit fullscreen */
+  transition: transform 250ms ease, opacity 250ms ease, padding 250ms ease, background 250ms ease;
+  transform-origin: top center;
+}
+.cloud-page-content-fullscreen {
+  background: var(--color-bg);
+  padding: 1.25rem;
+  /* The native fullscreenchange path applies the user-agent
+   * fullscreen styling; for the synthetic fallback we apply a fixed
+   * overlay so the operator still sees a maximised view. */
+}
+.cloud-page-content:fullscreen {
+  background: var(--color-bg);
+  padding: 1.25rem;
+  overflow: auto;
+}
+/* Some user agents emit -webkit-full-screen separately; mirror. */
+.cloud-page-content:-webkit-full-screen {
+  background: var(--color-bg);
+  padding: 1.25rem;
+  overflow: auto;
+}
+
+.cloud-page-fs-exit {
+  position: absolute;
+  top: 0.75rem;
+  right: 0.75rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.4rem 0.75rem;
+  font-size: 0.82rem;
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  background: var(--color-bg-2);
+  color: var(--color-text-dim);
+  cursor: pointer;
+  z-index: 5;
+}
+.cloud-page-fs-exit:hover { color: var(--color-text); background: var(--color-surface-hover); }
+.cloud-page-fs-exit svg { width: 16px; height: 16px; }
+
+.cloud-page-outlet { display: none; }
+
+/* ── Legacy P3 list-page primitives (kept so list pages still
+ *    render their own scaffolding correctly). ───────────────── */
+
 .infra-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
   gap: 0.75rem;
 }
-.infra-section {
-  margin-top: 1.25rem;
-}
+.infra-section { margin-top: 1.25rem; }
 .infra-section h2 {
   font-size: 0.95rem;
   font-weight: 600;
@@ -387,69 +710,6 @@ const CLOUD_PAGE_CSS = `
   background: color-mix(in srgb, var(--color-border) 60%, transparent);
   color: var(--color-text-dim);
 }
-.infra-card {
-  background: var(--color-surface);
-  border: 1.5px solid var(--color-border);
-  border-radius: 12px;
-  padding: 0.85rem;
-  display: flex;
-  flex-direction: column;
-  gap: 0.4rem;
-  position: relative;
-  overflow: hidden;
-}
-.infra-card[data-status="healthy"]  { border-color: color-mix(in srgb, var(--color-success) 45%, var(--color-border)); }
-.infra-card[data-status="degraded"] { border-color: color-mix(in srgb, var(--color-warn) 55%, var(--color-border)); }
-.infra-card[data-status="failed"]   { border-color: color-mix(in srgb, var(--color-danger) 55%, var(--color-border)); }
-.infra-card-head {
-  display: flex;
-  align-items: baseline;
-  justify-content: space-between;
-  gap: 0.5rem;
-}
-.infra-card-name {
-  font-size: 0.92rem;
-  font-weight: 600;
-  color: var(--color-text-strong);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-.infra-card-kind {
-  font-size: 0.65rem;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  color: var(--color-text-dim);
-  background: color-mix(in srgb, var(--color-border) 50%, transparent);
-  padding: 0.1rem 0.4rem;
-  border-radius: 3px;
-}
-.infra-card-row {
-  display: flex;
-  justify-content: space-between;
-  font-size: 0.78rem;
-  color: var(--color-text-dim);
-}
-.infra-card-row .v {
-  color: var(--color-text);
-  font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
-}
-.infra-card-status {
-  position: absolute;
-  top: 0.55rem;
-  right: 0.6rem;
-  font-size: 0.62rem;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-  padding: 0.12rem 0.45rem;
-  border-radius: 999px;
-}
-.infra-card-status[data-status="healthy"]  { background: color-mix(in srgb, var(--color-success) 16%, transparent); color: var(--color-success); }
-.infra-card-status[data-status="degraded"] { background: color-mix(in srgb, var(--color-warn) 16%, transparent);    color: var(--color-warn); }
-.infra-card-status[data-status="failed"]   { background: color-mix(in srgb, var(--color-danger) 16%, transparent);  color: var(--color-danger); }
-.infra-card-status[data-status="unknown"]  { background: color-mix(in srgb, var(--color-text-dim) 16%, transparent); color: var(--color-text-dim); }
-
 .infra-empty {
   margin-top: 2rem;
   text-align: center;
@@ -465,44 +725,5 @@ const CLOUD_PAGE_CSS = `
   font-weight: 600;
   margin: 0 0 0.3rem;
 }
-.infra-empty .sub {
-  font-size: 0.82rem;
-  margin: 0;
-}
-
-/* Bulk action bar shared by Compute / Storage / Network. */
-.infra-bulk-actions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.4rem;
-  margin: 0.75rem 0;
-  padding: 0.5rem 0.75rem;
-  border-radius: 10px;
-  background: var(--color-bg-2);
-  border: 1px solid var(--color-border);
-  align-items: center;
-}
-.infra-bulk-actions .label {
-  font-size: 0.75rem;
-  color: var(--color-text-dim);
-  margin-right: 0.4rem;
-}
-.infra-bulk-actions button {
-  border: 1px solid var(--color-border);
-  background: var(--color-bg);
-  color: var(--color-text);
-  border-radius: 6px;
-  padding: 0.3rem 0.7rem;
-  font-size: 0.78rem;
-  cursor: pointer;
-}
-.infra-bulk-actions button:hover {
-  background: var(--color-surface);
-}
-.infra-bulk-actions button.primary {
-  background: var(--color-accent);
-  border-color: var(--color-accent);
-  color: #fff;
-  font-weight: 600;
-}
+.infra-empty .sub { font-size: 0.82rem; margin: 0; }
 `

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/Sidebar.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/Sidebar.test.tsx
@@ -1,23 +1,23 @@
 /**
  * Sidebar.test.tsx — wiring lock-in for the Sovereign-portal sidebar.
  *
- * Coverage:
+ * Coverage (post issue #350 — accordion dropped):
  *   • Renders the OpenOva mark inside the 56px logo header
  *   • Surfaces the deployment id (or sovereignFQDN when supplied) as
  *     the "tenant" label in place of the canonical Tenant switcher
- *   • Renders Apps + Jobs + Dashboard + Cloud accordion + Settings
- *     nav items (the explicit subset for the Sovereign-provision
- *     surface)
- *   • Active item carries `aria-current="page"` and the accent-tinted
- *     class string the canonical surface uses
- *   • Cloud accordion: toggles open/closed, persists state in
- *     localStorage, auto-expands when on a /cloud/* route, sub-items
- *     route to /cloud/{architecture,compute,network,storage}.
+ *   • Renders Apps + Jobs + Dashboard + Cloud + Settings nav items
+ *     (the explicit subset for the Sovereign-provision surface)
+ *   • Active item carries `aria-current="page"`
+ *   • Cloud is a SINGLE flat <Link> (no accordion, no chevron, no
+ *     sub-items) that navigates to /provision/$id/cloud
+ *   • Cloud highlight applies whenever the operator is on any
+ *     /cloud/* path (including the legacy P3 sub-routes that now
+ *     redirect to /cloud?view=… queries)
  *   • Operator card at the bottom (analog of canonical "User" card)
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
-import { render, screen, cleanup, within, fireEvent } from '@testing-library/react'
+import { render, screen, cleanup, within } from '@testing-library/react'
 import {
   RouterProvider,
   createRouter,
@@ -30,104 +30,54 @@ import { Sidebar } from './Sidebar'
 
 function renderSidebarAt(initialPath: string, sovereignFQDN?: string | null) {
   const rootRoute = createRootRoute({ component: () => <Outlet /> })
+  const SidebarHost = () => (
+    <Sidebar deploymentId="d-test-1234" sovereignFQDN={sovereignFQDN ?? null} />
+  )
   const provisionRoute = createRoute({
     getParentRoute: () => rootRoute,
     path: '/provision/$deploymentId',
-    component: () => (
-      <Sidebar deploymentId="d-test-1234" sovereignFQDN={sovereignFQDN ?? null} />
-    ),
+    component: SidebarHost,
   })
   const jobsRoute = createRoute({
     getParentRoute: () => rootRoute,
     path: '/provision/$deploymentId/jobs',
-    component: () => (
-      <Sidebar deploymentId="d-test-1234" sovereignFQDN={sovereignFQDN ?? null} />
-    ),
+    component: SidebarHost,
+  })
+  const dashboardRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/provision/$deploymentId/dashboard',
+    component: SidebarHost,
   })
   const cloudRoute = createRoute({
     getParentRoute: () => rootRoute,
     path: '/provision/$deploymentId/cloud',
-    component: () => (
-      <Sidebar deploymentId="d-test-1234" sovereignFQDN={sovereignFQDN ?? null} />
-    ),
+    component: SidebarHost,
   })
+  // The legacy /cloud/<category>/<resource> paths still exist as
+  // server-side redirect routes; the sidebar's active matcher must
+  // also light up on those, so we register a representative subset
+  // here. The sidebar has no knowledge of the redirect — it just
+  // matches any `/cloud[/...]` segment.
   const cloudArchitectureRoute = createRoute({
     getParentRoute: () => cloudRoute,
     path: '/architecture',
-    component: () => (
-      <Sidebar deploymentId="d-test-1234" sovereignFQDN={sovereignFQDN ?? null} />
-    ),
+    component: SidebarHost,
   })
-  const cloudComputeRoute = createRoute({
-    getParentRoute: () => cloudRoute,
-    path: '/compute',
-    component: () => (
-      <Sidebar deploymentId="d-test-1234" sovereignFQDN={sovereignFQDN ?? null} />
-    ),
-  })
-  const cloudNetworkRoute = createRoute({
-    getParentRoute: () => cloudRoute,
-    path: '/network',
-    component: () => (
-      <Sidebar deploymentId="d-test-1234" sovereignFQDN={sovereignFQDN ?? null} />
-    ),
-  })
-  const cloudStorageRoute = createRoute({
-    getParentRoute: () => cloudRoute,
-    path: '/storage',
-    component: () => (
-      <Sidebar deploymentId="d-test-1234" sovereignFQDN={sovereignFQDN ?? null} />
-    ),
-  })
-  // P3 — sub-sub routes for the second-level accordion. We register a
-  // representative subset (compute/clusters, network/load-balancers,
-  // storage/pvcs) covering each category so the active-state matcher
-  // can be exercised; the remaining sub-suffixes share the matcher.
   const cloudComputeClustersRoute = createRoute({
-    getParentRoute: () => cloudComputeRoute,
-    path: '/clusters',
-    component: () => (
-      <Sidebar deploymentId="d-test-1234" sovereignFQDN={sovereignFQDN ?? null} />
-    ),
-  })
-  const cloudComputeVClustersRoute = createRoute({
-    getParentRoute: () => cloudComputeRoute,
-    path: '/vclusters',
-    component: () => (
-      <Sidebar deploymentId="d-test-1234" sovereignFQDN={sovereignFQDN ?? null} />
-    ),
-  })
-  const cloudNetworkLBRoute = createRoute({
-    getParentRoute: () => cloudNetworkRoute,
-    path: '/load-balancers',
-    component: () => (
-      <Sidebar deploymentId="d-test-1234" sovereignFQDN={sovereignFQDN ?? null} />
-    ),
-  })
-  const cloudStoragePvcsRoute = createRoute({
-    getParentRoute: () => cloudStorageRoute,
-    path: '/pvcs',
-    component: () => (
-      <Sidebar deploymentId="d-test-1234" sovereignFQDN={sovereignFQDN ?? null} />
-    ),
+    getParentRoute: () => cloudRoute,
+    path: '/compute/clusters',
+    component: SidebarHost,
   })
   const wizardRoute = createRoute({
     getParentRoute: () => rootRoute,
     path: '/wizard',
-    component: () => <Sidebar deploymentId="d-test-1234" sovereignFQDN={sovereignFQDN ?? null} />,
+    component: SidebarHost,
   })
   const tree = rootRoute.addChildren([
     provisionRoute,
     jobsRoute,
-    cloudRoute.addChildren([
-      cloudArchitectureRoute,
-      cloudComputeRoute.addChildren([
-        cloudComputeClustersRoute,
-        cloudComputeVClustersRoute,
-      ]),
-      cloudNetworkRoute.addChildren([cloudNetworkLBRoute]),
-      cloudStorageRoute.addChildren([cloudStoragePvcsRoute]),
-    ]),
+    dashboardRoute,
+    cloudRoute.addChildren([cloudArchitectureRoute, cloudComputeClustersRoute]),
     wizardRoute,
   ])
   const router = createRouter({
@@ -138,8 +88,6 @@ function renderSidebarAt(initialPath: string, sovereignFQDN?: string | null) {
 }
 
 beforeEach(() => {
-  // Each test starts with a clean localStorage so the persisted
-  // accordion-expanded state doesn't leak between cases.
   if (typeof window !== 'undefined') {
     window.localStorage.clear()
   }
@@ -156,10 +104,8 @@ describe('Sidebar — chrome', () => {
   it('renders the OpenOva mark + wordmark in the header', async () => {
     renderSidebarAt('/provision/d-test-1234')
     const sidebar = await screen.findByTestId('admin-sidebar')
-    // SVG logo present
     expect(sidebar.querySelector('svg')).toBeTruthy()
     expect(within(sidebar).getByText('OpenOva')).toBeTruthy()
-    // Sovereign label (replaces Tenant switcher)
     expect(within(sidebar).getByText(/Sovereign/i)).toBeTruthy()
   })
 
@@ -184,13 +130,11 @@ describe('Sidebar — top-level navigation', () => {
     expect(await screen.findByTestId('sov-nav-dashboard')).toBeTruthy()
     expect(await screen.findByTestId('sov-nav-cloud')).toBeTruthy()
     expect(await screen.findByTestId('sov-nav-settings')).toBeTruthy()
-    // Canonical-but-omitted items must NOT render: domains / billing /
-    // team are tenant-console concerns, not Sovereign-provision ones.
+    // Canonical-but-omitted items must NOT render.
     expect(screen.queryByTestId('sov-nav-domains')).toBeNull()
     expect(screen.queryByTestId('sov-nav-billing')).toBeNull()
     expect(screen.queryByTestId('sov-nav-team')).toBeNull()
-    // The legacy `infrastructure` flat nav item is gone — replaced by
-    // the Cloud accordion.
+    // Legacy flat Infrastructure entry remains gone.
     expect(screen.queryByTestId('sov-nav-infrastructure')).toBeNull()
   })
 
@@ -211,196 +155,58 @@ describe('Sidebar — top-level navigation', () => {
   })
 })
 
-describe('Sidebar — Cloud accordion', () => {
-  it('renders the Cloud header as a button (not a link)', async () => {
+describe('Sidebar — Cloud entry (issue #350: accordion dropped)', () => {
+  it('renders Cloud as a SINGLE flat link (not a button, no chevron, no sub-items)', async () => {
     renderSidebarAt('/provision/d-test-1234')
-    const cloudHeader = await screen.findByTestId('sov-nav-cloud')
-    expect(cloudHeader.tagName).toBe('BUTTON')
-    expect(cloudHeader.getAttribute('aria-controls')).toBe('sov-nav-cloud-group')
-  })
-
-  it('starts collapsed when the operator is NOT on a /cloud/* route', async () => {
-    renderSidebarAt('/provision/d-test-1234')
-    const cloudHeader = await screen.findByTestId('sov-nav-cloud')
-    expect(cloudHeader.getAttribute('aria-expanded')).toBe('false')
-    // Sub-items are not rendered when collapsed.
+    const cloud = await screen.findByTestId('sov-nav-cloud')
+    // Flat <Link> renders as an anchor — NOT a <button>.
+    expect(cloud.tagName).toBe('A')
+    // No accordion contracts: no aria-expanded, no aria-controls, no
+    // chevron testid, no sub-items.
+    expect(cloud.getAttribute('aria-expanded')).toBeNull()
+    expect(cloud.getAttribute('aria-controls')).toBeNull()
+    expect(screen.queryByTestId('sov-nav-cloud-toggle')).toBeNull()
     expect(screen.queryByTestId('sov-nav-cloud-architecture')).toBeNull()
+    expect(screen.queryByTestId('sov-nav-cloud-compute')).toBeNull()
+    expect(screen.queryByTestId('sov-nav-cloud-network')).toBeNull()
+    expect(screen.queryByTestId('sov-nav-cloud-storage')).toBeNull()
+    // No second-level toggles either.
+    expect(screen.queryByTestId('sov-nav-cloud-compute-toggle')).toBeNull()
+    expect(screen.queryByTestId('sov-nav-cloud-network-toggle')).toBeNull()
+    expect(screen.queryByTestId('sov-nav-cloud-storage-toggle')).toBeNull()
   })
 
-  it('starts EXPANDED when the operator is on a /cloud/* route', async () => {
-    renderSidebarAt('/provision/d-test-1234/cloud/architecture')
-    const cloudHeader = await screen.findByTestId('sov-nav-cloud')
-    expect(cloudHeader.getAttribute('aria-expanded')).toBe('true')
-    expect(screen.getByTestId('sov-nav-cloud-architecture')).toBeTruthy()
-    expect(screen.getByTestId('sov-nav-cloud-compute')).toBeTruthy()
-    expect(screen.getByTestId('sov-nav-cloud-network')).toBeTruthy()
-    expect(screen.getByTestId('sov-nav-cloud-storage')).toBeTruthy()
-  })
-
-  it('clicking the Cloud header toggles expanded state', async () => {
+  it('Cloud link href targets /provision/$id/cloud', async () => {
     renderSidebarAt('/provision/d-test-1234')
-    const cloudHeader = await screen.findByTestId('sov-nav-cloud')
-    expect(cloudHeader.getAttribute('aria-expanded')).toBe('false')
-
-    fireEvent.click(cloudHeader)
-    expect(cloudHeader.getAttribute('aria-expanded')).toBe('true')
-    expect(screen.getByTestId('sov-nav-cloud-architecture')).toBeTruthy()
-
-    fireEvent.click(cloudHeader)
-    expect(cloudHeader.getAttribute('aria-expanded')).toBe('false')
+    const cloud = (await screen.findByTestId('sov-nav-cloud')) as HTMLAnchorElement
+    const href = cloud.getAttribute('href') ?? ''
+    expect(href).toMatch(/\/provision\/d-test-1234\/cloud$/)
   })
 
-  it('persists expanded state to localStorage under sov-nav-cloud-expanded', async () => {
-    renderSidebarAt('/provision/d-test-1234')
-    const cloudHeader = await screen.findByTestId('sov-nav-cloud')
-
-    fireEvent.click(cloudHeader)
-    expect(window.localStorage.getItem('sov-nav-cloud-expanded')).toBe('true')
-
-    fireEvent.click(cloudHeader)
-    expect(window.localStorage.getItem('sov-nav-cloud-expanded')).toBe('false')
+  it('Cloud is highlighted on /cloud root', async () => {
+    renderSidebarAt('/provision/d-test-1234/cloud')
+    const cloud = await screen.findByTestId('sov-nav-cloud')
+    expect(cloud.getAttribute('aria-current')).toBe('page')
   })
 
-  it('restores expanded state from localStorage on mount', async () => {
-    window.localStorage.setItem('sov-nav-cloud-expanded', 'true')
-    renderSidebarAt('/provision/d-test-1234')
-    const cloudHeader = await screen.findByTestId('sov-nav-cloud')
-    expect(cloudHeader.getAttribute('aria-expanded')).toBe('true')
-  })
-
-  it('marks Cloud active and the active sub-item with aria-current when on a /cloud/* route', async () => {
-    renderSidebarAt('/provision/d-test-1234/cloud/compute')
-    const cloudHeader = await screen.findByTestId('sov-nav-cloud')
-    expect(cloudHeader.getAttribute('aria-current')).toBe('page')
-
-    const compute = screen.getByTestId('sov-nav-cloud-compute')
-    expect(compute.getAttribute('aria-current')).toBe('page')
-
-    const architecture = screen.getByTestId('sov-nav-cloud-architecture')
-    expect(architecture.getAttribute('aria-current')).toBeNull()
-  })
-
-  it('sub-item links target /cloud/{suffix}', async () => {
+  it('Cloud is highlighted on /cloud/architecture (legacy redirect path matches the sidebar matcher)', async () => {
     renderSidebarAt('/provision/d-test-1234/cloud/architecture')
-    const compute = await screen.findByTestId('sov-nav-cloud-compute')
-    const href = compute.getAttribute('href') ?? ''
-    expect(href).toMatch(/\/cloud\/compute$/)
+    const cloud = await screen.findByTestId('sov-nav-cloud')
+    expect(cloud.getAttribute('aria-current')).toBe('page')
   })
 
-  it('exposes a chevron toggle indicator', async () => {
-    renderSidebarAt('/provision/d-test-1234')
-    const toggle = await screen.findByTestId('sov-nav-cloud-toggle')
-    expect(toggle).toBeTruthy()
-  })
-})
-
-describe('Sidebar — Cloud second-level accordion (P3 of #309)', () => {
-  it('renders Compute / Network / Storage as category rows with a toggle button each', async () => {
-    renderSidebarAt('/provision/d-test-1234/cloud/architecture')
-    await screen.findByTestId('sov-nav-cloud-compute-row')
-    // Each category exposes a row container + a Link (sov-nav-cloud-<id>)
-    // navigating to the landing page + a separate toggle button
-    // (sov-nav-cloud-<id>-toggle).
-    for (const id of ['compute', 'network', 'storage'] as const) {
-      expect(screen.getByTestId(`sov-nav-cloud-${id}-row`)).toBeTruthy()
-      const link = screen.getByTestId(`sov-nav-cloud-${id}`)
-      expect(link.tagName).toBe('A')
-      expect(link.getAttribute('href') ?? '').toMatch(new RegExp(`/cloud/${id}$`))
-      const toggle = screen.getByTestId(`sov-nav-cloud-${id}-toggle`)
-      expect(toggle.tagName).toBe('BUTTON')
-    }
-  })
-
-  it('Compute toggle expands to reveal 4 sub-sub items', async () => {
-    renderSidebarAt('/provision/d-test-1234/cloud/architecture')
-    const toggle = await screen.findByTestId('sov-nav-cloud-compute-toggle')
-    expect(toggle.getAttribute('aria-expanded')).toBe('false')
-    fireEvent.click(toggle)
-    expect(toggle.getAttribute('aria-expanded')).toBe('true')
-
-    expect(screen.getByTestId('sov-nav-cloud-compute-clusters')).toBeTruthy()
-    expect(screen.getByTestId('sov-nav-cloud-compute-vclusters')).toBeTruthy()
-    expect(screen.getByTestId('sov-nav-cloud-compute-node-pools')).toBeTruthy()
-    expect(screen.getByTestId('sov-nav-cloud-compute-worker-nodes')).toBeTruthy()
-  })
-
-  it('Network toggle reveals 4 sub-sub items (Services/Ingresses/Load Balancers/DNS Zones)', async () => {
-    renderSidebarAt('/provision/d-test-1234/cloud/architecture')
-    const toggle = await screen.findByTestId('sov-nav-cloud-network-toggle')
-    fireEvent.click(toggle)
-    expect(screen.getByTestId('sov-nav-cloud-network-services')).toBeTruthy()
-    expect(screen.getByTestId('sov-nav-cloud-network-ingresses')).toBeTruthy()
-    expect(screen.getByTestId('sov-nav-cloud-network-load-balancers')).toBeTruthy()
-    expect(screen.getByTestId('sov-nav-cloud-network-dns-zones')).toBeTruthy()
-  })
-
-  it('Storage toggle reveals 4 sub-sub items (PVCs/Storage Classes/Buckets/Volumes)', async () => {
-    renderSidebarAt('/provision/d-test-1234/cloud/architecture')
-    const toggle = await screen.findByTestId('sov-nav-cloud-storage-toggle')
-    fireEvent.click(toggle)
-    expect(screen.getByTestId('sov-nav-cloud-storage-pvcs')).toBeTruthy()
-    expect(screen.getByTestId('sov-nav-cloud-storage-storage-classes')).toBeTruthy()
-    expect(screen.getByTestId('sov-nav-cloud-storage-buckets')).toBeTruthy()
-    expect(screen.getByTestId('sov-nav-cloud-storage-volumes')).toBeTruthy()
-  })
-
-  it('persists each second-level expand state independently', async () => {
-    renderSidebarAt('/provision/d-test-1234/cloud/architecture')
-    await screen.findByTestId('sov-nav-cloud-compute-toggle')
-    fireEvent.click(screen.getByTestId('sov-nav-cloud-compute-toggle'))
-    fireEvent.click(screen.getByTestId('sov-nav-cloud-storage-toggle'))
-    expect(window.localStorage.getItem('sov-nav-cloud-compute-expanded')).toBe('true')
-    expect(window.localStorage.getItem('sov-nav-cloud-storage-expanded')).toBe('true')
-    expect(window.localStorage.getItem('sov-nav-cloud-network-expanded')).toBe(null)
-    fireEvent.click(screen.getByTestId('sov-nav-cloud-compute-toggle'))
-    expect(window.localStorage.getItem('sov-nav-cloud-compute-expanded')).toBe('false')
-  })
-
-  it('auto-expands the matching category when on /cloud/<category>/<child>', async () => {
+  it('Cloud is highlighted on /cloud/compute/clusters (legacy redirect path)', async () => {
     renderSidebarAt('/provision/d-test-1234/cloud/compute/clusters')
-    const toggle = await screen.findByTestId('sov-nav-cloud-compute-toggle')
-    expect(toggle.getAttribute('aria-expanded')).toBe('true')
-    // The matching child carries aria-current=page.
-    const clusters = screen.getByTestId('sov-nav-cloud-compute-clusters')
-    expect(clusters.getAttribute('aria-current')).toBe('page')
-    // The Compute parent row is also marked active because the operator
-    // is inside the Compute sub-tree.
-    const compute = screen.getByTestId('sov-nav-cloud-compute')
-    expect(compute.getAttribute('aria-current')).toBe('page')
+    const cloud = await screen.findByTestId('sov-nav-cloud')
+    expect(cloud.getAttribute('aria-current')).toBe('page')
   })
 
-  it('Compute landing link href ends in /cloud/compute (not a child)', async () => {
-    renderSidebarAt('/provision/d-test-1234/cloud/architecture')
-    const compute = (await screen.findByTestId('sov-nav-cloud-compute')) as HTMLAnchorElement
-    expect(compute.tagName).toBe('A')
-    const href = compute.getAttribute('href') ?? ''
-    expect(href).toMatch(/\/cloud\/compute$/)
-  })
-
-  it('child link href targets /cloud/<category>/<child>', async () => {
-    renderSidebarAt('/provision/d-test-1234/cloud/compute')
-    await screen.findByTestId('sov-nav-cloud-compute-toggle')
-    // Compute auto-expanded because we're on the Compute landing page;
-    // the children should already be visible.
-    const link = screen.getByTestId('sov-nav-cloud-compute-vclusters') as HTMLAnchorElement
-    const href = link.getAttribute('href') ?? ''
-    expect(href).toMatch(/\/cloud\/compute\/vclusters$/)
-  })
-
-  it('Network → Load Balancers child highlights when on that route', async () => {
-    renderSidebarAt('/provision/d-test-1234/cloud/network/load-balancers')
-    const toggle = await screen.findByTestId('sov-nav-cloud-network-toggle')
-    expect(toggle.getAttribute('aria-expanded')).toBe('true')
-    const lb = screen.getByTestId('sov-nav-cloud-network-load-balancers')
-    expect(lb.getAttribute('aria-current')).toBe('page')
-  })
-
-  it('Storage → PVCs child highlights when on that route', async () => {
-    renderSidebarAt('/provision/d-test-1234/cloud/storage/pvcs')
-    const toggle = await screen.findByTestId('sov-nav-cloud-storage-toggle')
-    expect(toggle.getAttribute('aria-expanded')).toBe('true')
-    const pvcs = screen.getByTestId('sov-nav-cloud-storage-pvcs')
-    expect(pvcs.getAttribute('aria-current')).toBe('page')
+  it('Apps is NOT highlighted when on /cloud — exact match guards the apps highlight', async () => {
+    renderSidebarAt('/provision/d-test-1234/cloud')
+    const apps = await screen.findByTestId('sov-nav-apps')
+    expect(apps.getAttribute('aria-current')).toBeNull()
+    const cloud = screen.getByTestId('sov-nav-cloud')
+    expect(cloud.getAttribute('aria-current')).toBe('page')
   })
 })
 

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/Sidebar.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/Sidebar.tsx
@@ -1,55 +1,28 @@
 /**
  * Sidebar — Sovereign-portal left rail. Pixel-port of
- * core/console/src/components/Sidebar.svelte plus the accordion
- * structure under "Cloud" (issue #309).
+ * core/console/src/components/Sidebar.svelte.
  *
- * Layout contract (P3 of #309 — second-level accordion):
+ * Layout contract (issue #350 — drop accordion):
  *   • Fixed left rail, w-56, full height
  *   • Logo + product wordmark in the 56px header
  *   • Single-Sovereign label in place of the canonical Tenant
  *     switcher (the wizard is single-Sovereign by definition).
- *   • Nav list — flat for top-level destinations + a TWO-LEVEL
- *     accordion under "Cloud":
+ *   • Nav list — flat single-level destinations only:
  *
  *       — apps                    → /sovereign/provision/$deploymentId
  *       — jobs                    → /sovereign/provision/$deploymentId/jobs
  *       — dashboard               → /sovereign/provision/$deploymentId/dashboard
- *       — cloud (accordion)       → /sovereign/provision/$deploymentId/cloud
- *           ↳ architecture        → /cloud/architecture
- *           ↳ compute (accordion) → /cloud/compute (landing)
- *               ↳ clusters        → /cloud/compute/clusters
- *               ↳ vclusters       → /cloud/compute/vclusters
- *               ↳ node pools      → /cloud/compute/node-pools
- *               ↳ worker nodes    → /cloud/compute/worker-nodes
- *           ↳ network (accordion) → /cloud/network (landing)
- *               ↳ services        → /cloud/network/services
- *               ↳ ingresses       → /cloud/network/ingresses
- *               ↳ load balancers  → /cloud/network/load-balancers
- *               ↳ dns zones       → /cloud/network/dns-zones
- *           ↳ storage (accordion) → /cloud/storage (landing)
- *               ↳ pvcs            → /cloud/storage/pvcs
- *               ↳ storage classes → /cloud/storage/storage-classes
- *               ↳ buckets         → /cloud/storage/buckets
- *               ↳ volumes         → /cloud/storage/volumes
+ *       — cloud                   → /sovereign/provision/$deploymentId/cloud
  *       — settings                → /wizard
  *
- *     The Cloud accordion is auto-expanded when the operator is on a
- *     /cloud/* route and persists its open/closed state across reloads
- *     in localStorage under the key `sov-nav-cloud-expanded`.
+ *     The Cloud entry is a single flat <Link> (no accordion, no
+ *     chevron, no sub-items). The parent CloudPage owns the in-page
+ *     graph/list view toggle, the resource-kind switcher, and the
+ *     fullscreen affordance — see CloudPage.tsx.
  *
- *     Each second-level accordion (compute/network/storage) likewise
- *     persists its expand state under
- *     `sov-nav-cloud-{compute,network,storage}-expanded`. Auto-expands
- *     when the operator is on the matching sub-tree (e.g. on
- *     /cloud/compute/clusters → Compute opens).
- *
- *     Each second-level header is split into TWO interactive elements:
- *     a left-side <Link> that navigates to the category landing page
- *     (/cloud/{compute,network,storage}) and a right-side <button>
- *     chevron that toggles the sub-tree without leaving the current
- *     page. This avoids the anti-pattern of an item that's both a
- *     navigation target and a toggle in the same hit area — the founder
- *     called this out during the JobsPage tab-strip iteration.
+ *     Cloud is highlighted as active whenever the operator is on any
+ *     /cloud/* route OR any legacy /infrastructure/* route (covered
+ *     by the redirect-only routes in app/router.tsx).
  *
  *   • Operator card at the bottom — analog of the canonical "User"
  *     card; the wizard runs unauthenticated so we show "Operator ·
@@ -60,7 +33,6 @@
  * there's no inline hex value or hard-coded path.
  */
 
-import { useEffect, useState } from 'react'
 import { Link, useRouterState } from '@tanstack/react-router'
 
 interface SidebarProps {
@@ -73,16 +45,27 @@ interface SidebarProps {
 /* ── Top-level (flat) nav items ─────────────────────────────────── */
 
 interface FlatNavItem {
-  id: 'apps' | 'jobs' | 'dashboard' | 'settings'
+  id: 'apps' | 'jobs' | 'dashboard' | 'cloud' | 'settings'
   label: string
   to:
     | '/provision/$deploymentId'
     | '/provision/$deploymentId/jobs'
     | '/provision/$deploymentId/dashboard'
+    | '/provision/$deploymentId/cloud'
     | '/wizard'
   /** SVG path data — same `d` strings as core/console for visual parity. */
   icon: string
 }
+
+/**
+ * Cloud icon — verbatim Tabler `IconCloud` path data (issue #350
+ * item 8). Lifted from @tabler/icons-react v3.41.1 IconCloud.mjs so
+ * the Sidebar's lightweight inline-SVG NavIcon renders the same shape
+ * the rest of the catalyst-ui uses for cloud affordances. Renders at
+ * the same 24x24 viewBox the other NavIcon paths use.
+ */
+const CLOUD_ICON =
+  'M6.657 18c-2.572 0 -4.657 -2.007 -4.657 -4.483c0 -2.475 2.085 -4.482 4.657 -4.482c.393 -1.762 1.794 -3.2 3.675 -3.773c1.88 -.572 3.956 -.193 5.444 1c1.488 1.19 2.162 3.007 1.77 4.769h.99c1.913 0 3.464 1.56 3.464 3.486c0 1.927 -1.551 3.487 -3.465 3.487h-11.878'
 
 const FLAT_NAV: FlatNavItem[] = [
   {
@@ -103,6 +86,12 @@ const FLAT_NAV: FlatNavItem[] = [
     to: '/provision/$deploymentId/dashboard',
     icon: 'M3 3h7v9H3V3zm11 0h7v5h-7V3zM14 10h7v11h-7V10zM3 14h7v7H3v-7z',
   },
+  {
+    id: 'cloud',
+    label: 'Cloud',
+    to: '/provision/$deploymentId/cloud',
+    icon: CLOUD_ICON,
+  },
 ]
 
 const SETTINGS_ITEM: FlatNavItem = {
@@ -110,115 +99,6 @@ const SETTINGS_ITEM: FlatNavItem = {
   label: 'Settings',
   to: '/wizard',
   icon: 'M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.066 2.573c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.573 1.066c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.066-2.573c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z M15 12a3 3 0 11-6 0 3 3 0 016 0z',
-}
-
-/* ── Cloud accordion — first level ──────────────────────────────── */
-
-/** Server-stack icon — three horizontal bars suggesting clusters /
- *  nodes, distinct from the dashboard's quadrant grid and the apps
- *  4-square shape. */
-const CLOUD_ICON =
-  'M5 12H3m18 0h-2M5 7h14M5 12h14M5 17h14M5 7a2 2 0 00-2 2v6a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2H5z'
-
-/** Discriminated union for the four first-level Cloud entries.
- *  Architecture is a LEAF (no expand toggle), Compute / Network /
- *  Storage are CATEGORIES with their own expand state and a
- *  resource-list child set. */
-type CloudCategoryId = 'compute' | 'network' | 'storage'
-type CloudFirstLevelId = 'architecture' | CloudCategoryId
-
-interface CloudLeafItem {
-  kind: 'leaf'
-  id: 'architecture'
-  label: string
-  suffix: 'architecture'
-}
-
-interface CloudCategoryItem {
-  kind: 'category'
-  id: CloudCategoryId
-  label: string
-  /** Suffix appended to /provision/$deploymentId/cloud (== landing). */
-  suffix: CloudCategoryId
-  /** Resource-list children — sub-sub items shown when expanded. */
-  children: readonly { id: string; label: string; suffix: string }[]
-}
-
-type CloudFirstLevel = CloudLeafItem | CloudCategoryItem
-
-const CLOUD_FIRST_LEVEL: readonly CloudFirstLevel[] = [
-  {
-    kind: 'leaf',
-    id: 'architecture',
-    label: 'Architecture',
-    suffix: 'architecture',
-  },
-  {
-    kind: 'category',
-    id: 'compute',
-    label: 'Compute',
-    suffix: 'compute',
-    children: [
-      { id: 'clusters', label: 'Clusters', suffix: 'clusters' },
-      { id: 'vclusters', label: 'vClusters', suffix: 'vclusters' },
-      { id: 'node-pools', label: 'Node Pools', suffix: 'node-pools' },
-      { id: 'worker-nodes', label: 'Worker Nodes', suffix: 'worker-nodes' },
-    ],
-  },
-  {
-    kind: 'category',
-    id: 'network',
-    label: 'Network',
-    suffix: 'network',
-    children: [
-      { id: 'services', label: 'Services', suffix: 'services' },
-      { id: 'ingresses', label: 'Ingresses', suffix: 'ingresses' },
-      { id: 'load-balancers', label: 'Load Balancers', suffix: 'load-balancers' },
-      { id: 'dns-zones', label: 'DNS Zones', suffix: 'dns-zones' },
-    ],
-  },
-  {
-    kind: 'category',
-    id: 'storage',
-    label: 'Storage',
-    suffix: 'storage',
-    children: [
-      { id: 'pvcs', label: 'PVCs', suffix: 'pvcs' },
-      { id: 'storage-classes', label: 'Storage Classes', suffix: 'storage-classes' },
-      { id: 'buckets', label: 'Buckets', suffix: 'buckets' },
-      { id: 'volumes', label: 'Volumes', suffix: 'volumes' },
-    ],
-  },
-] as const
-
-const CLOUD_EXPANDED_STORAGE_KEY = 'sov-nav-cloud-expanded'
-
-function categoryStorageKey(cat: CloudCategoryId): string {
-  return `sov-nav-cloud-${cat}-expanded`
-}
-
-/** Read persisted expand state for a given key. Returns `null` when no
- *  stored value exists (caller chooses the fallback). */
-function readPersistedExpanded(key: string): boolean | null {
-  if (typeof window === 'undefined') return null
-  try {
-    const raw = window.localStorage.getItem(key)
-    if (raw === 'true') return true
-    if (raw === 'false') return false
-    return null
-  } catch {
-    // Safari private mode etc — fail open.
-    return null
-  }
-}
-
-function writePersistedExpanded(key: string, open: boolean): void {
-  if (typeof window === 'undefined') return
-  try {
-    window.localStorage.setItem(key, open ? 'true' : 'false')
-  } catch {
-    /* noop */
-  }
 }
 
 /* ── Active-state derivation ────────────────────────────────────── */
@@ -240,134 +120,11 @@ function deriveActiveSection(pathname: string): ActiveSection {
   return 'apps'
 }
 
-/**
- * Derive which first-level Cloud item is active for the highlight.
- * For Compute / Network / Storage the rule is: the parent is active
- * whenever the current path is at the landing page OR any of its
- * child resource-list pages.
- */
-function deriveActiveCloudFirst(pathname: string): CloudFirstLevelId | null {
-  for (const item of CLOUD_FIRST_LEVEL) {
-    if (pathname.endsWith(`/cloud/${item.suffix}`)) return item.id
-    if (item.kind === 'category') {
-      // Match /cloud/<category>/<anything> for child highlighting.
-      if (pathname.includes(`/cloud/${item.suffix}/`)) return item.id
-    }
-  }
-  // Map the legacy /infrastructure/* paths so the highlight survives
-  // the brief paint before the redirect lands.
-  if (pathname.endsWith('/infrastructure/topology')) return 'architecture'
-  if (pathname.endsWith('/infrastructure/compute')) return 'compute'
-  if (pathname.endsWith('/infrastructure/network')) return 'network'
-  if (pathname.endsWith('/infrastructure/storage')) return 'storage'
-  return null
-}
-
-/**
- * Derive the active sub-sub item under a category, e.g. when on
- * /cloud/compute/clusters this returns ('compute', 'clusters'). Used
- * to apply aria-current=page to the matching child link.
- */
-function deriveActiveCloudChild(
-  pathname: string,
-): { categoryId: CloudCategoryId; childSuffix: string } | null {
-  for (const item of CLOUD_FIRST_LEVEL) {
-    if (item.kind !== 'category') continue
-    for (const child of item.children) {
-      if (pathname.endsWith(`/cloud/${item.suffix}/${child.suffix}`)) {
-        return { categoryId: item.id, childSuffix: child.suffix }
-      }
-    }
-  }
-  return null
-}
-
 /* ── Component ──────────────────────────────────────────────────── */
 
 export function Sidebar({ deploymentId, sovereignFQDN }: SidebarProps) {
   const pathname = useRouterState({ select: (s) => s.location.pathname })
   const activeSection = deriveActiveSection(pathname)
-  const activeCloudFirst = deriveActiveCloudFirst(pathname)
-  const activeCloudChild = deriveActiveCloudChild(pathname)
-  const isOnCloud = activeSection === 'cloud'
-
-  // Top-level Cloud accordion expand state. Defaults: expanded when on
-  // a /cloud/* route OR when the persisted localStorage value says so.
-  const [cloudExpanded, setCloudExpanded] = useState<boolean>(() => {
-    const persisted = readPersistedExpanded(CLOUD_EXPANDED_STORAGE_KEY)
-    if (persisted !== null) return persisted
-    return isOnCloud
-  })
-
-  // Per-category second-level expand state. Defaults: expanded when
-  // the operator is currently on that category's landing or one of
-  // its resource-list pages, OR when the persisted value says so.
-  const [computeExpanded, setComputeExpanded] = useState<boolean>(() => {
-    const persisted = readPersistedExpanded(categoryStorageKey('compute'))
-    if (persisted !== null) return persisted
-    return activeCloudFirst === 'compute'
-  })
-  const [networkExpanded, setNetworkExpanded] = useState<boolean>(() => {
-    const persisted = readPersistedExpanded(categoryStorageKey('network'))
-    if (persisted !== null) return persisted
-    return activeCloudFirst === 'network'
-  })
-  const [storageExpanded, setStorageExpanded] = useState<boolean>(() => {
-    const persisted = readPersistedExpanded(categoryStorageKey('storage'))
-    if (persisted !== null) return persisted
-    return activeCloudFirst === 'storage'
-  })
-
-  // Auto-expand the parent + the active child's parent when the
-  // operator navigates onto a /cloud/* route. Don't auto-collapse on
-  // leaving — that's a discoverability anti-pattern; trust the
-  // persisted state on subsequent visits.
-  useEffect(() => {
-    if (isOnCloud && !cloudExpanded) {
-      setCloudExpanded(true)
-      writePersistedExpanded(CLOUD_EXPANDED_STORAGE_KEY, true)
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isOnCloud])
-
-  useEffect(() => {
-    if (activeCloudFirst === 'compute' && !computeExpanded) {
-      setComputeExpanded(true)
-      writePersistedExpanded(categoryStorageKey('compute'), true)
-    }
-    if (activeCloudFirst === 'network' && !networkExpanded) {
-      setNetworkExpanded(true)
-      writePersistedExpanded(categoryStorageKey('network'), true)
-    }
-    if (activeCloudFirst === 'storage' && !storageExpanded) {
-      setStorageExpanded(true)
-      writePersistedExpanded(categoryStorageKey('storage'), true)
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [activeCloudFirst])
-
-  function toggleCloud() {
-    setCloudExpanded((prev) => {
-      const next = !prev
-      writePersistedExpanded(CLOUD_EXPANDED_STORAGE_KEY, next)
-      return next
-    })
-  }
-
-  function categoryExpanded(cat: CloudCategoryId): boolean {
-    if (cat === 'compute') return computeExpanded
-    if (cat === 'network') return networkExpanded
-    return storageExpanded
-  }
-  function setCategoryExpanded(cat: CloudCategoryId, next: boolean) {
-    if (cat === 'compute') setComputeExpanded(next)
-    else if (cat === 'network') setNetworkExpanded(next)
-    else setStorageExpanded(next)
-    writePersistedExpanded(categoryStorageKey(cat), next)
-  }
-  function toggleCategory(cat: CloudCategoryId) {
-    setCategoryExpanded(cat, !categoryExpanded(cat))
-  }
 
   const sovereignLabel = sovereignFQDN || `deployment ${deploymentId.slice(0, 8)}`
 
@@ -416,12 +173,17 @@ export function Sidebar({ deploymentId, sovereignFQDN }: SidebarProps) {
           const cls = isActive
             ? 'bg-[var(--color-accent)]/10 text-[var(--color-accent)]'
             : 'text-[var(--color-text-dim)] hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text)]'
+          // For "Cloud" we want the highlight to apply on any /cloud/*
+          // path, not just exact match — so we omit `activeOptions`
+          // (default behavior matches by prefix). For the others the
+          // exact-match guard prevents visual drift when the operator
+          // is on a deeper sub-page.
           return (
             <Link
               key={item.id}
-              to={item.to}
-              params={{ deploymentId }}
-              activeOptions={{ exact: true }}
+              to={item.to as never}
+              params={(item.id === 'settings' ? undefined : { deploymentId }) as never}
+              activeOptions={item.id === 'cloud' ? undefined : { exact: true }}
               className={`mx-2 flex items-center gap-3 rounded-lg px-3 py-2 text-sm no-underline transition-colors ${cls}`}
               data-testid={`sov-nav-${item.id}`}
               aria-current={isActive ? 'page' : undefined}
@@ -432,144 +194,6 @@ export function Sidebar({ deploymentId, sovereignFQDN }: SidebarProps) {
           )
         })}
 
-        {/* Cloud accordion (first level) */}
-        <div className="mt-0.5">
-          <button
-            type="button"
-            onClick={toggleCloud}
-            onKeyDown={(ev) => {
-              // Enter / Space is already the default for buttons; this
-              // keeps the call site explicit for screen-reader users.
-              if (ev.key === 'Enter' || ev.key === ' ') {
-                ev.preventDefault()
-                toggleCloud()
-              }
-            }}
-            className={`mx-2 flex w-[calc(100%-1rem)] items-center justify-between gap-3 rounded-lg px-3 py-2 text-left text-sm transition-colors ${
-              isOnCloud
-                ? 'bg-[var(--color-accent)]/10 text-[var(--color-accent)]'
-                : 'text-[var(--color-text-dim)] hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text)]'
-            }`}
-            data-testid="sov-nav-cloud"
-            aria-expanded={cloudExpanded}
-            aria-controls="sov-nav-cloud-group"
-            aria-current={isOnCloud ? 'page' : undefined}
-          >
-            <span className="flex items-center gap-3">
-              <NavIcon d={CLOUD_ICON} />
-              Cloud
-            </span>
-            <Chevron
-              testId="sov-nav-cloud-toggle"
-              open={cloudExpanded}
-            />
-          </button>
-
-          {cloudExpanded && (
-            <div
-              id="sov-nav-cloud-group"
-              role="group"
-              aria-labelledby="sov-nav-cloud"
-              data-testid="sov-nav-cloud-group"
-            >
-              {CLOUD_FIRST_LEVEL.map((item) => {
-                const isActive = activeCloudFirst === item.id
-                const cls = isActive
-                  ? 'bg-[var(--color-accent)]/10 text-[var(--color-accent)]'
-                  : 'text-[var(--color-text-dim)] hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text)]'
-
-                if (item.kind === 'leaf') {
-                  return (
-                    <Link
-                      key={item.id}
-                      to={`/provision/$deploymentId/cloud/${item.suffix}` as never}
-                      params={{ deploymentId } as never}
-                      className={`mx-2 flex items-center gap-3 rounded-lg py-1.5 pl-10 pr-3 text-sm no-underline transition-colors ${cls}`}
-                      data-testid={`sov-nav-cloud-${item.id}`}
-                      aria-current={isActive ? 'page' : undefined}
-                    >
-                      {item.label}
-                    </Link>
-                  )
-                }
-
-                // Category (compute/network/storage) — split surface:
-                //   • <Link> takes most of the row → navigates to the
-                //     landing page (/cloud/<category>).
-                //   • <button> on the right toggles the second-level
-                //     accordion without leaving the current page.
-                const expanded = categoryExpanded(item.id)
-                return (
-                  <div key={item.id} data-testid={`sov-nav-cloud-${item.id}-row`}>
-                    <div className={`mx-2 flex items-stretch rounded-lg ${isActive ? 'bg-[var(--color-accent)]/10' : 'hover:bg-[var(--color-surface-hover)]'}`}>
-                      <Link
-                        to={`/provision/$deploymentId/cloud/${item.suffix}` as never}
-                        params={{ deploymentId } as never}
-                        className={`flex flex-1 items-center gap-3 rounded-l-lg py-1.5 pl-10 pr-2 text-sm no-underline transition-colors ${
-                          isActive ? 'text-[var(--color-accent)]' : 'text-[var(--color-text-dim)] hover:text-[var(--color-text)]'
-                        }`}
-                        data-testid={`sov-nav-cloud-${item.id}`}
-                        aria-current={isActive ? 'page' : undefined}
-                      >
-                        {item.label}
-                      </Link>
-                      <button
-                        type="button"
-                        onClick={() => toggleCategory(item.id)}
-                        onKeyDown={(ev) => {
-                          if (ev.key === 'Enter' || ev.key === ' ') {
-                            ev.preventDefault()
-                            toggleCategory(item.id)
-                          }
-                        }}
-                        className={`flex items-center justify-center rounded-r-lg px-2 transition-colors ${
-                          isActive ? 'text-[var(--color-accent)]' : 'text-[var(--color-text-dim)] hover:text-[var(--color-text)]'
-                        }`}
-                        data-testid={`sov-nav-cloud-${item.id}-toggle`}
-                        aria-expanded={expanded}
-                        aria-controls={`sov-nav-cloud-${item.id}-group`}
-                        aria-label={`${expanded ? 'Collapse' : 'Expand'} ${item.label} sub-menu`}
-                      >
-                        <Chevron testId={`sov-nav-cloud-${item.id}-chevron`} open={expanded} />
-                      </button>
-                    </div>
-
-                    {expanded && (
-                      <div
-                        id={`sov-nav-cloud-${item.id}-group`}
-                        role="group"
-                        aria-labelledby={`sov-nav-cloud-${item.id}`}
-                        data-testid={`sov-nav-cloud-${item.id}-group`}
-                      >
-                        {item.children.map((child) => {
-                          const childActive =
-                            activeCloudChild?.categoryId === item.id &&
-                            activeCloudChild?.childSuffix === child.suffix
-                          const childCls = childActive
-                            ? 'bg-[var(--color-accent)]/10 text-[var(--color-accent)]'
-                            : 'text-[var(--color-text-dim)] hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text)]'
-                          return (
-                            <Link
-                              key={child.id}
-                              to={`/provision/$deploymentId/cloud/${item.suffix}/${child.suffix}` as never}
-                              params={{ deploymentId } as never}
-                              className={`mx-2 flex items-center gap-3 rounded-lg py-1.5 pl-14 pr-3 text-xs no-underline transition-colors ${childCls}`}
-                              data-testid={`sov-nav-cloud-${item.id}-${child.id}`}
-                              aria-current={childActive ? 'page' : undefined}
-                            >
-                              {child.label}
-                            </Link>
-                          )
-                        })}
-                      </div>
-                    )}
-                  </div>
-                )
-              })}
-            </div>
-          )}
-        </div>
-
         {/* Settings stays at the bottom of the nav list */}
         {(() => {
           const isActive = activeSection === SETTINGS_ITEM.id
@@ -578,7 +202,7 @@ export function Sidebar({ deploymentId, sovereignFQDN }: SidebarProps) {
             : 'text-[var(--color-text-dim)] hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text)]'
           return (
             <Link
-              to={SETTINGS_ITEM.to}
+              to={SETTINGS_ITEM.to as never}
               activeOptions={{ exact: true }}
               className={`mx-2 mt-0.5 flex items-center gap-3 rounded-lg px-3 py-2 text-sm no-underline transition-colors ${cls}`}
               data-testid={`sov-nav-${SETTINGS_ITEM.id}`}
@@ -617,22 +241,6 @@ function NavIcon({ d }: { d: string }) {
       strokeWidth={1.5}
     >
       <path strokeLinecap="round" strokeLinejoin="round" d={d} />
-    </svg>
-  )
-}
-
-function Chevron({ testId, open }: { testId: string; open: boolean }) {
-  return (
-    <svg
-      data-testid={testId}
-      className={`h-3 w-3 shrink-0 transition-transform ${open ? 'rotate-90' : ''}`}
-      fill="none"
-      viewBox="0 0 24 24"
-      stroke="currentColor"
-      strokeWidth={2}
-      aria-hidden
-    >
-      <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
     </svg>
   )
 }

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-list/CloudListView.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-list/CloudListView.tsx
@@ -1,0 +1,456 @@
+/**
+ * CloudListView — list-mode body for the Cloud parent surface (issue
+ * #350 item 7). Lives inside CloudPage's content area when the
+ * `view=list` query param is active.
+ *
+ * Layout contract:
+ *   • Top-of-page: 12-tile resource-kind card grid. Each tile shows an
+ *     icon, the kind label, and a count. Clicking a tile sets the
+ *     active kind (and updates the URL ?kind=… query so the state is
+ *     bookmarkable / shareable).
+ *   • Toolbar: a compact <select> dropdown that mirrors the card-grid
+ *     selection. Keyboard-driven users (kbd-power users + a11y) can
+ *     change the active kind without mouse-clicking a tile.
+ *   • Below: the active kind's existing P3 list page rendered inline.
+ *     Components are reused as-is — none of them are rewritten.
+ *
+ * The active kind persists to localStorage under `sov-cloud-list-kind`
+ * so a return visit lands on the operator's last-viewed list. The URL
+ * query takes precedence when present.
+ *
+ * Per docs/INVIOLABLE-PRINCIPLES.md #4 (never hardcode), every kind id,
+ * label and tagline lives in a single typed table at the top of this
+ * file — there's no inlined string literal at the call sites.
+ */
+
+import { useCallback, useEffect, useMemo } from 'react'
+import { useNavigate, useRouterState, useSearch } from '@tanstack/react-router'
+import { useCloud } from '../CloudPage'
+import { CLOUD_LIST_CSS } from './cloudListCss'
+
+import { ClustersPage } from '../cloud-compute/ClustersPage'
+import { VClustersPage } from '../cloud-compute/VClustersPage'
+import { NodePoolsPage } from '../cloud-compute/NodePoolsPage'
+import { WorkerNodesPage } from '../cloud-compute/WorkerNodesPage'
+import { LoadBalancersPage } from '../cloud-network/LoadBalancersPage'
+import { ServicesPage } from '../cloud-network/ServicesPage'
+import { IngressesPage } from '../cloud-network/IngressesPage'
+import { DnsZonesPage } from '../cloud-network/DnsZonesPage'
+import { PvcsPage } from '../cloud-storage/PvcsPage'
+import { BucketsPage } from '../cloud-storage/BucketsPage'
+import { VolumesPage } from '../cloud-storage/VolumesPage'
+import { StorageClassesPage } from '../cloud-storage/StorageClassesPage'
+
+/* ── Kind catalogue ─────────────────────────────────────────────── */
+
+export type CloudListKind =
+  | 'clusters'
+  | 'vclusters'
+  | 'node-pools'
+  | 'worker-nodes'
+  | 'load-balancers'
+  | 'services'
+  | 'ingresses'
+  | 'dns-zones'
+  | 'pvcs'
+  | 'buckets'
+  | 'volumes'
+  | 'storage-classes'
+
+interface KindEntry {
+  id: CloudListKind
+  label: string
+  /** One-line tagline shown beneath the count on the tile. */
+  tagline: string
+  /** True when the count is real; false when the underlying informer
+   *  isn't wired yet (we render a "—" instead of a number). */
+  hasData: boolean
+  Component: () => React.JSX.Element
+  /** SVG path data on the canonical 24x24 viewBox — lucide-style. */
+  icon: string
+  /** Conceptual category (drives the small chip on the tile). */
+  category: 'compute' | 'network' | 'storage'
+}
+
+// Tabler / lucide-style outlines on the same 24x24 viewBox the
+// sidebar NavIcon uses.
+const ICON_CLUSTER = 'M3 12c0 -4 4 -7 9 -7s9 3 9 7v6m0 0a2 2 0 0 1 -2 2H5a2 2 0 0 1 -2 -2v0M3 18v0M3 8h18'
+const ICON_VCLUSTER = 'M4 7a3 3 0 0 1 3 -3h10a3 3 0 0 1 3 3v10a3 3 0 0 1 -3 3H7a3 3 0 0 1 -3 -3zM8 8h8M8 12h8M8 16h5'
+const ICON_NODE_POOL = 'M5 4h4v4H5zM5 16h4v4H5zM15 4h4v4h-4zM15 16h4v4h-4zM7 8v8M17 8v8M9 6h6M9 18h6'
+const ICON_WORKER_NODE = 'M4 5h16v6H4zM4 13h16v6H4zM7 8h.01M7 16h.01M11 8h6M11 16h6'
+const ICON_LB = 'M12 4v4m0 0a4 4 0 0 0 -4 4v0m4 -4a4 4 0 0 1 4 4v0M4 12h4M16 12h4M6 14a2 2 0 0 0 2 2v0a2 2 0 0 0 2 -2v0a2 2 0 0 0 -2 -2v0a2 2 0 0 0 -2 2zM14 14a2 2 0 0 0 2 2v0a2 2 0 0 0 2 -2v0a2 2 0 0 0 -2 -2v0a2 2 0 0 0 -2 2z'
+const ICON_SERVICE = 'M5 7h14M5 12h14M5 17h14M3 7v10M21 7v10'
+const ICON_INGRESS = 'M3 12h6M21 12h-6M9 8l4 4 -4 4M15 16l-4 -4 4 -4'
+const ICON_DNS = 'M12 3a9 9 0 0 0 0 18m0 -18a9 9 0 0 1 0 18m0 -18c2 2 3 5 3 9s-1 7 -3 9m0 -18c-2 2 -3 5 -3 9s1 7 3 9M3 12h18'
+const ICON_PVC = 'M5 8a7 3 0 0 0 14 0A7 3 0 0 0 5 8zM5 8v8a7 3 0 0 0 14 0V8M5 12a7 3 0 0 0 14 0'
+const ICON_BUCKET = 'M5 6h14l-1 14a2 2 0 0 1 -2 2H8a2 2 0 0 1 -2 -2zM9 6V4a3 3 0 0 1 6 0v2'
+const ICON_VOLUME = 'M5 4a7 3 0 0 0 14 0A7 3 0 0 0 5 4zM5 4v16a7 3 0 0 0 14 0V4'
+const ICON_STORAGE_CLASS = 'M4 6h16M4 12h16M4 18h16M8 6v12M16 6v12'
+
+const KINDS: readonly KindEntry[] = [
+  { id: 'clusters',        label: 'Clusters',        tagline: 'k3s / k8s control planes',                  hasData: true,  Component: ClustersPage,        icon: ICON_CLUSTER,       category: 'compute' },
+  { id: 'vclusters',       label: 'vClusters',       tagline: 'Logical isolation per Sovereign tenant',    hasData: true,  Component: VClustersPage,       icon: ICON_VCLUSTER,      category: 'compute' },
+  { id: 'node-pools',      label: 'Node Pools',      tagline: 'Worker pools grouped by SKU + role',        hasData: true,  Component: NodePoolsPage,       icon: ICON_NODE_POOL,     category: 'compute' },
+  { id: 'worker-nodes',    label: 'Worker Nodes',    tagline: 'Individual VMs / kubelets reporting in',    hasData: true,  Component: WorkerNodesPage,     icon: ICON_WORKER_NODE,   category: 'compute' },
+  { id: 'load-balancers',  label: 'Load Balancers',  tagline: 'Cloud-provisioned LBs fronting clusters',   hasData: true,  Component: LoadBalancersPage,   icon: ICON_LB,            category: 'network' },
+  { id: 'services',        label: 'Services',        tagline: 'Awaiting service informer (#321)',          hasData: false, Component: ServicesPage,        icon: ICON_SERVICE,       category: 'network' },
+  { id: 'ingresses',       label: 'Ingresses',       tagline: 'Awaiting ingress informer (#321)',          hasData: false, Component: IngressesPage,       icon: ICON_INGRESS,       category: 'network' },
+  { id: 'dns-zones',       label: 'DNS Zones',       tagline: 'Awaiting external-dns informer (#321)',     hasData: false, Component: DnsZonesPage,        icon: ICON_DNS,           category: 'network' },
+  { id: 'pvcs',            label: 'PVCs',            tagline: 'Persistent volume claims',                  hasData: true,  Component: PvcsPage,            icon: ICON_PVC,           category: 'storage' },
+  { id: 'buckets',         label: 'Buckets',         tagline: 'S3-compatible (SeaweedFS / provider)',      hasData: true,  Component: BucketsPage,         icon: ICON_BUCKET,        category: 'storage' },
+  { id: 'volumes',         label: 'Volumes',         tagline: 'Cloud block volumes attached to nodes',     hasData: true,  Component: VolumesPage,         icon: ICON_VOLUME,        category: 'storage' },
+  { id: 'storage-classes', label: 'Storage Classes', tagline: 'Awaiting storage-class informer (#321)',    hasData: false, Component: StorageClassesPage,  icon: ICON_STORAGE_CLASS, category: 'storage' },
+] as const
+
+const KIND_IDS: readonly CloudListKind[] = KINDS.map((k) => k.id)
+const DEFAULT_KIND: CloudListKind = 'clusters'
+const KIND_STORAGE_KEY = 'sov-cloud-list-kind'
+
+function isValidKind(value: unknown): value is CloudListKind {
+  return typeof value === 'string' && (KIND_IDS as readonly string[]).includes(value)
+}
+
+function readPersistedKind(): CloudListKind | null {
+  if (typeof window === 'undefined') return null
+  try {
+    const raw = window.localStorage.getItem(KIND_STORAGE_KEY)
+    return isValidKind(raw) ? raw : null
+  } catch {
+    return null
+  }
+}
+
+function writePersistedKind(kind: CloudListKind): void {
+  if (typeof window === 'undefined') return
+  try {
+    window.localStorage.setItem(KIND_STORAGE_KEY, kind)
+  } catch {
+    /* noop */
+  }
+}
+
+/* ── Component ──────────────────────────────────────────────────── */
+
+interface CloudListViewProps {
+  /** Optional explicit kind override — used by tests. When omitted the
+   *  active kind comes from the URL query, the persisted value, or
+   *  the default in that order. */
+  kindOverride?: CloudListKind
+  /** Optional explicit counts — used by tests to avoid wiring the
+   *  full topology fixture. */
+  countsOverride?: Partial<Record<CloudListKind, number>>
+}
+
+export function CloudListView({ kindOverride, countsOverride }: CloudListViewProps = {}) {
+  const { deploymentId, data, isLoading } = useCloud()
+  const navigate = useNavigate()
+  // The Cloud route registers `kind` in its validateSearch schema; if
+  // the search hook isn't available (older route registration during
+  // a hot-reload) we fall back to the location.search string.
+  const search = useSearch({ strict: false }) as { view?: string; kind?: string }
+  const pathname = useRouterState({ select: (s) => s.location.pathname })
+
+  // Resolve the active kind: explicit override > URL query > persisted
+  // localStorage > default. The first time the operator lands on the
+  // list view without a `kind` query, we update the URL so the state
+  // is shareable.
+  const activeKind: CloudListKind = useMemo(() => {
+    if (kindOverride) return kindOverride
+    if (isValidKind(search.kind)) return search.kind
+    const persisted = readPersistedKind()
+    if (persisted) return persisted
+    return DEFAULT_KIND
+  }, [kindOverride, search.kind])
+
+  // Persist the active kind whenever it changes.
+  useEffect(() => {
+    writePersistedKind(activeKind)
+  }, [activeKind])
+
+  // Make sure the URL carries the explicit kind so deep links work.
+  useEffect(() => {
+    if (kindOverride) return
+    if (search.kind === activeKind) return
+    if (!pathname.endsWith('/cloud')) return
+    navigate({
+      to: '/provision/$deploymentId/cloud' as never,
+      params: { deploymentId } as never,
+      search: { view: 'list', kind: activeKind } as never,
+      replace: true,
+    })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeKind, search.kind, pathname, deploymentId])
+
+  const setActiveKind = useCallback(
+    (next: CloudListKind) => {
+      navigate({
+        to: '/provision/$deploymentId/cloud' as never,
+        params: { deploymentId } as never,
+        search: { view: 'list', kind: next } as never,
+        replace: false,
+      })
+    },
+    [navigate, deploymentId],
+  )
+
+  /* ── Counts derived from the shared infra tree ─────────────── */
+  const counts = useMemo<Record<CloudListKind, number | null>>(() => {
+    const c: Record<CloudListKind, number | null> = {
+      'clusters': 0,
+      'vclusters': 0,
+      'node-pools': 0,
+      'worker-nodes': 0,
+      'load-balancers': 0,
+      'services': null,
+      'ingresses': null,
+      'dns-zones': null,
+      'pvcs': 0,
+      'buckets': 0,
+      'volumes': 0,
+      'storage-classes': null,
+    }
+    if (data) {
+      let clusters = 0
+      let vclusters = 0
+      let nodePools = 0
+      let workerNodes = 0
+      let lb = 0
+      for (const region of data.topology.regions ?? []) {
+        for (const cluster of region.clusters ?? []) {
+          clusters += 1
+          vclusters += cluster.vclusters?.length ?? 0
+          nodePools += cluster.nodePools?.length ?? 0
+          workerNodes += cluster.nodes?.length ?? 0
+          lb += cluster.loadBalancers?.length ?? 0
+        }
+      }
+      c['clusters'] = clusters
+      c['vclusters'] = vclusters
+      c['node-pools'] = nodePools
+      c['worker-nodes'] = workerNodes
+      c['load-balancers'] = lb
+      c['pvcs'] = data.storage?.pvcs?.length ?? 0
+      c['buckets'] = data.storage?.buckets?.length ?? 0
+      c['volumes'] = data.storage?.volumes?.length ?? 0
+    }
+    if (countsOverride) {
+      for (const [k, v] of Object.entries(countsOverride)) {
+        if (typeof v === 'number') {
+          c[k as CloudListKind] = v
+        }
+      }
+    }
+    return c
+  }, [data, countsOverride])
+
+  const ActiveListComponent = useMemo(() => {
+    const entry = KINDS.find((k) => k.id === activeKind) ?? KINDS[0]
+    return entry.Component
+  }, [activeKind])
+
+  return (
+    <div data-testid="cloud-list-view">
+      <style>{CLOUD_LIST_VIEW_CSS}</style>
+      <style>{CLOUD_LIST_CSS}</style>
+
+      {/* Toolbar: dropdown switcher (compact, kbd-driven). */}
+      <div className="cloud-list-view-toolbar" data-testid="cloud-list-view-toolbar">
+        <label className="cloud-list-view-dropdown-label">
+          <span className="cloud-list-view-dropdown-caption">Resource</span>
+          <select
+            data-testid="cloud-list-view-kind-select"
+            value={activeKind}
+            onChange={(ev) => setActiveKind(ev.target.value as CloudListKind)}
+            className="cloud-list-view-dropdown-select"
+            aria-label="Select resource kind"
+          >
+            {KINDS.map((k) => {
+              const c = counts[k.id]
+              const showCount = k.hasData && c !== null
+              return (
+                <option key={k.id} value={k.id}>
+                  {k.label}
+                  {showCount ? ` (${c})` : ''}
+                </option>
+              )
+            })}
+          </select>
+        </label>
+      </div>
+
+      {/* Card grid — 12 tiles, click to switch. */}
+      <div className="cloud-list-view-tile-grid" data-testid="cloud-list-view-tile-grid">
+        {KINDS.map((k) => {
+          const c = counts[k.id]
+          const showCount = k.hasData && c !== null
+          const isActive = k.id === activeKind
+          return (
+            <button
+              key={k.id}
+              type="button"
+              data-testid={`cloud-list-view-tile-${k.id}`}
+              data-kind={k.id}
+              data-active={isActive ? 'true' : 'false'}
+              data-category={k.category}
+              className={`cloud-list-view-tile ${isActive ? 'cloud-list-view-tile-active' : ''}`}
+              aria-pressed={isActive}
+              onClick={() => setActiveKind(k.id)}
+            >
+              <div className="cloud-list-view-tile-icon" aria-hidden>
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5} strokeLinecap="round" strokeLinejoin="round">
+                  <path d={k.icon} />
+                </svg>
+              </div>
+              <div className="cloud-list-view-tile-body">
+                <div className="cloud-list-view-tile-name">
+                  <span>{k.label}</span>
+                  <span
+                    className="cloud-list-view-tile-count"
+                    data-testid={`cloud-list-view-tile-${k.id}-count`}
+                  >
+                    {showCount ? c : '—'}
+                  </span>
+                </div>
+                <p className="cloud-list-view-tile-tagline">{k.tagline}</p>
+              </div>
+            </button>
+          )
+        })}
+      </div>
+
+      {/* Active list table — re-uses the P3 list-page component. */}
+      <div className="cloud-list-view-active" data-testid={`cloud-list-view-active-${activeKind}`}>
+        {isLoading && !data ? (
+          <div
+            className="flex h-48 items-center justify-center text-sm text-[var(--color-text-dim)]"
+            data-testid="cloud-list-view-loading"
+          >
+            Loading {KINDS.find((k) => k.id === activeKind)?.label.toLowerCase()}…
+          </div>
+        ) : (
+          <ActiveListComponent />
+        )}
+      </div>
+    </div>
+  )
+}
+
+/* ── Local CSS — tile grid + dropdown ──────────────────────────── */
+
+const CLOUD_LIST_VIEW_CSS = `
+.cloud-list-view-toolbar {
+  display: flex;
+  align-items: flex-end;
+  gap: 0.6rem;
+  margin-bottom: 0.75rem;
+}
+.cloud-list-view-dropdown-label {
+  display: inline-flex;
+  flex-direction: column;
+  gap: 0.18rem;
+}
+.cloud-list-view-dropdown-caption {
+  font-size: 0.62rem;
+  color: var(--color-text-dim);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+.cloud-list-view-dropdown-select {
+  padding: 0.42rem 0.6rem;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  color: var(--color-text);
+  font-size: 0.85rem;
+  cursor: pointer;
+  min-width: 14rem;
+}
+.cloud-list-view-dropdown-select:focus {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}
+
+.cloud-list-view-tile-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 0.6rem;
+  margin-bottom: 1.25rem;
+}
+.cloud-list-view-tile {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.6rem;
+  text-align: left;
+  background: var(--color-surface);
+  border: 1.5px solid var(--color-border);
+  border-radius: 12px;
+  padding: 0.8rem;
+  cursor: pointer;
+  color: var(--color-text);
+  transition: transform 0.12s ease, border-color 0.12s ease, background 0.12s ease;
+  font: inherit;
+}
+.cloud-list-view-tile:hover {
+  border-color: color-mix(in srgb, var(--color-accent) 60%, var(--color-border));
+  transform: translateY(-1px);
+}
+.cloud-list-view-tile:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}
+.cloud-list-view-tile-active {
+  border-color: var(--color-accent);
+  background: color-mix(in srgb, var(--color-accent) 8%, var(--color-surface));
+}
+.cloud-list-view-tile[data-category="compute"] .cloud-list-view-tile-icon { color: #60a5fa; }
+.cloud-list-view-tile[data-category="network"] .cloud-list-view-tile-icon { color: #34d399; }
+.cloud-list-view-tile[data-category="storage"] .cloud-list-view-tile-icon { color: #f59e0b; }
+.cloud-list-view-tile-icon {
+  flex-shrink: 0;
+  width: 28px;
+  height: 28px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+.cloud-list-view-tile-icon svg {
+  width: 22px;
+  height: 22px;
+}
+.cloud-list-view-tile-body {
+  min-width: 0;
+  flex: 1;
+}
+.cloud-list-view-tile-name {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.4rem;
+  font-size: 0.92rem;
+  font-weight: 600;
+  color: var(--color-text-strong);
+}
+.cloud-list-view-tile-count {
+  font-size: 0.7rem;
+  font-weight: 600;
+  padding: 0.06rem 0.5rem;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--color-border) 60%, transparent);
+  color: var(--color-text-dim);
+  font-variant-numeric: tabular-nums;
+}
+.cloud-list-view-tile-active .cloud-list-view-tile-count {
+  background: color-mix(in srgb, var(--color-accent) 22%, transparent);
+  color: var(--color-accent);
+}
+.cloud-list-view-tile-tagline {
+  margin: 0.18rem 0 0;
+  font-size: 0.78rem;
+  color: var(--color-text-dim);
+  line-height: 1.3;
+}
+
+.cloud-list-view-active {
+  margin-top: 0.5rem;
+}
+`


### PR DESCRIPTION
Phase B of #347. Drops the second-level accordion shipped in #309 P3 in favour of a single 'Cloud' entry that opens a parent CloudPage with Graph/List view toggle, fullscreen mode, and proper cloud icon. List view reuses the P3 list components inside a card-grid + dropdown switcher.

5 atomic commits: sidebar single-entry+IconCloud, CloudPage parent shell, CloudListView, fullscreen, router consolidation + 301 redirects.

ADR-0001 §9.4: SME demos untouched.

Closes #350.