### PR TITLE
fix(catalyst-api): legacy batchId migration + synthesize missing parent groups (#351)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/jobs/store.go
+++ b/products/catalyst/bootstrap/api/internal/jobs/store.go
@@ -152,6 +152,26 @@ func (s *Store) loadIndex(deploymentID string) (*Index, error) {
 		idx.Executions = []Execution{}
 	}
 	idx.DeploymentID = deploymentID
+
+	// Legacy migration (#351). Pre-refactor indexes persist `batchId`
+	// where the new shape uses `parentId`. Hoist non-empty legacy
+	// values into ParentID so deriveTreeView sees the relationship
+	// without a separate one-shot data migration. The legacy field is
+	// then cleared so persistIndex doesn't echo it on disk — next
+	// write produces a canonical record.
+	for i := range idx.Jobs {
+		if idx.Jobs[i].ParentID == "" && idx.Jobs[i].LegacyBatchID != "" {
+			idx.Jobs[i].ParentID = JobID(deploymentID, idx.Jobs[i].LegacyBatchID)
+		}
+		idx.Jobs[i].LegacyBatchID = ""
+		// Pre-refactor leaves also have empty Type — every persisted
+		// job before #351 was a leaf install. Default to install so
+		// the recursive Job model contracts (childIds derivation,
+		// status rollup) hold.
+		if idx.Jobs[i].Type == "" {
+			idx.Jobs[i].Type = JobTypeInstall
+		}
+	}
 	return &idx, nil
 }
 
@@ -174,7 +194,11 @@ func (s *Store) persistIndex(idx *Index) error {
 	persisted.Jobs = make([]Job, len(idx.Jobs))
 	copy(persisted.Jobs, idx.Jobs)
 	for i := range persisted.Jobs {
+		// ChildIDs is derived; LegacyBatchID is the legacy migration
+		// hook — both must be cleared so the on-disk record stays
+		// canonical (one source of truth: ParentID).
 		persisted.Jobs[i].ChildIDs = nil
+		persisted.Jobs[i].LegacyBatchID = ""
 	}
 
 	raw, err := json.MarshalIndent(&persisted, "", "  ")
@@ -461,7 +485,7 @@ func (s *Store) ListJobs(deploymentID string) ([]Job, error) {
 	}
 	out := make([]Job, len(idx.Jobs))
 	copy(out, idx.Jobs)
-	deriveTreeView(out)
+	out = deriveTreeView(out)
 	sort.SliceStable(out, func(i, j int) bool {
 		// Pending (no StartedAt) sort last.
 		ai, bi := out[i].StartedAt, out[j].StartedAt
@@ -482,9 +506,10 @@ func (s *Store) ListJobs(deploymentID string) ([]Job, error) {
 	return out, nil
 }
 
-// deriveTreeView mutates the supplied slice in place to populate
-// ChildIDs on every Job and to roll up Status / StartedAt /
-// FinishedAt / DurationMs on every group Job from its descendants.
+// deriveTreeView returns the supplied slice (possibly extended with
+// synthesized parent group rows) with ChildIDs populated on every Job
+// and Status / StartedAt / FinishedAt / DurationMs rolled up on every
+// group Job from its descendants.
 //
 // Rollup rules (group jobs only — leaf jobs are untouched):
 //
@@ -498,13 +523,62 @@ func (s *Store) ListJobs(deploymentID string) ([]Job, error) {
 //     failed).
 //   - DurationMs: FinishedAt - StartedAt when both are non-nil; else 0.
 //
+// Synthesis of missing parents (#351 legacy migration): every leaf
+// whose ParentID points at an id without a corresponding on-disk Job
+// row triggers an in-memory synthesized group Job — so old
+// deployments (whose pre-refactor index has no parent rows) still
+// render the parent relationship in the canvas + table without a
+// separate one-shot data migration.
+//
 // The walk is post-order via index lookup so a 3-level tree
 // (root group → mid group → leaf) rolls up correctly without
 // recursion.
-func deriveTreeView(jobs []Job) {
+func deriveTreeView(jobs []Job) []Job {
 	if len(jobs) == 0 {
-		return
+		return jobs
 	}
+
+	// Synthesize a group Job for every ParentID that doesn't already
+	// have an on-disk row. The synthesized rows append to the slice
+	// before the rollup pass so they participate in childIds /
+	// status / timing aggregation just like a real on-disk parent.
+	have := make(map[string]bool, len(jobs))
+	for i := range jobs {
+		have[jobs[i].ID] = true
+	}
+	for i := range jobs {
+		pid := jobs[i].ParentID
+		if pid == "" || have[pid] {
+			continue
+		}
+		// Derive the slug from the canonical "<deploymentId>:<slug>"
+		// id format. Falls back to the full pid when the format
+		// doesn't match (defence-in-depth — should never happen for
+		// helmwatch-bridge writes).
+		slug := pid
+		if c := strings.LastIndex(pid, ":"); c >= 0 && c+1 < len(pid) {
+			slug = pid[c+1:]
+		}
+		display := slug
+		switch slug {
+		case GroupBootstrapKit:
+			display = GroupBootstrapKitDisplay
+		case GroupDay2Mutations:
+			display = GroupDay2MutationsDisplay
+		}
+		jobs = append(jobs, Job{
+			ID:           pid,
+			DeploymentID: jobs[i].DeploymentID,
+			JobName:      slug,
+			DisplayName:  display,
+			Type:         JobTypeGroup,
+			ParentID:     "",
+			DependsOn:    []string{},
+			Status:       StatusPending,
+		})
+		have[pid] = true
+	}
+
 	idx := make(map[string]int, len(jobs))
 	for i := range jobs {
 		idx[jobs[i].ID] = i
@@ -635,6 +709,7 @@ func deriveTreeView(jobs []Job) {
 			jobs[i].DurationMs = 0
 		}
 	}
+	return jobs
 }
 
 // GetJob returns the Job + its Executions list. ErrNotFound if no Job
@@ -653,7 +728,7 @@ func (s *Store) GetJob(deploymentID, jobID string) (Job, []Execution, error) {
 	// returned Job reflects the same derived shape ListJobs emits.
 	view := make([]Job, len(idx.Jobs))
 	copy(view, idx.Jobs)
-	deriveTreeView(view)
+	view = deriveTreeView(view)
 
 	// Lookup accepts EITHER the full "<deploymentId>:<jobName>" id OR
 	// the bare jobName. The colon in the canonical id is path-safe per

--- a/products/catalyst/bootstrap/api/internal/jobs/store_test.go
+++ b/products/catalyst/bootstrap/api/internal/jobs/store_test.go
@@ -44,17 +44,98 @@ func TestStore_UpsertJob_RoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ListJobs: %v", err)
 	}
-	if len(got) != 1 {
-		t.Fatalf("expected 1 job, got %d", len(got))
+	// Persisted leaf + synthesized bootstrap-kit parent group
+	// (deriveTreeView synthesizes a group row in-memory whenever a
+	// leaf points at a ParentID with no on-disk peer — see the
+	// legacy migration path #351).
+	if len(got) != 2 {
+		t.Fatalf("expected 2 jobs (leaf + synthesized parent), got %d (%+v)", len(got), got)
 	}
-	if got[0].ID != JobID(depID, "install-cilium") {
-		t.Fatalf("ID mismatch: %q", got[0].ID)
+	var leaf, group *Job
+	for i := range got {
+		if got[i].ID == JobID(depID, "install-cilium") {
+			leaf = &got[i]
+		}
+		if got[i].ID == parentID {
+			group = &got[i]
+		}
 	}
-	if got[0].AppID != "cilium" || got[0].ParentID != parentID || got[0].Type != JobTypeInstall {
-		t.Fatalf("metadata mismatch: %+v", got[0])
+	if leaf == nil {
+		t.Fatalf("install-cilium leaf missing in %+v", got)
 	}
-	if len(got[0].DependsOn) != 1 || got[0].DependsOn[0] != "install-flux" {
-		t.Fatalf("dependsOn mismatch: %+v", got[0].DependsOn)
+	if leaf.AppID != "cilium" || leaf.ParentID != parentID || leaf.Type != JobTypeInstall {
+		t.Fatalf("leaf metadata mismatch: %+v", leaf)
+	}
+	if len(leaf.DependsOn) != 1 || leaf.DependsOn[0] != "install-flux" {
+		t.Fatalf("dependsOn mismatch: %+v", leaf.DependsOn)
+	}
+	if group == nil || group.Type != JobTypeGroup {
+		t.Fatalf("synthesized bootstrap-kit group missing: %+v", got)
+	}
+	if len(group.ChildIDs) != 1 || group.ChildIDs[0] != leaf.ID {
+		t.Fatalf("synthesized group ChildIDs: want [%s], got %v", leaf.ID, group.ChildIDs)
+	}
+}
+
+// TestStore_LegacyBatchID_HoistedToParentID locks in the #351 legacy
+// migration contract: pre-refactor indexes persisted the deprecated
+// `batchId` JSON field; on read, the store hoists any non-empty
+// legacy value into ParentID and synthesizes a parent group Job
+// in-memory so the recursive Job tree renders correctly even before
+// the next bridge write rewrites the on-disk record.
+func TestStore_LegacyBatchID_HoistedToParentID(t *testing.T) {
+	st := newTestStore(t)
+	depID := "dep-legacy"
+
+	depDir := filepath.Join(st.Dir(), depID)
+	if err := os.MkdirAll(depDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	legacy := `{
+	  "deploymentId": "dep-legacy",
+	  "jobs": [
+	    {"id":"dep-legacy:install-cilium","deploymentId":"dep-legacy","jobName":"install-cilium","appId":"cilium","batchId":"bootstrap-kit","dependsOn":[],"status":"succeeded"},
+	    {"id":"dep-legacy:install-cert-manager","deploymentId":"dep-legacy","jobName":"install-cert-manager","appId":"cert-manager","batchId":"bootstrap-kit","dependsOn":["install-cilium"],"status":"running"}
+	  ],
+	  "executions": []
+	}`
+	if err := os.WriteFile(filepath.Join(depDir, "index.json"), []byte(legacy), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := st.ListJobs(depID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("expected 3 jobs (2 leaves + 1 synthesized group), got %d (%+v)", len(got), got)
+	}
+	parentID := JobID(depID, GroupBootstrapKit)
+	for _, j := range got {
+		switch j.Type {
+		case JobTypeInstall:
+			if j.ParentID != parentID {
+				t.Errorf("leaf %s: ParentID hoist failed — want %q, got %q", j.JobName, parentID, j.ParentID)
+			}
+			if j.LegacyBatchID != "" {
+				t.Errorf("leaf %s: LegacyBatchID NOT cleared on read: %q", j.JobName, j.LegacyBatchID)
+			}
+		case JobTypeGroup:
+			if j.ID != parentID {
+				t.Errorf("synthesized group: id mismatch — want %q, got %q", parentID, j.ID)
+			}
+			if j.DisplayName != GroupBootstrapKitDisplay {
+				t.Errorf("synthesized group: DisplayName — want %q, got %q", GroupBootstrapKitDisplay, j.DisplayName)
+			}
+			if len(j.ChildIDs) != 2 {
+				t.Errorf("synthesized group: ChildIDs — want 2, got %d (%v)", len(j.ChildIDs), j.ChildIDs)
+			}
+			if j.Status != StatusRunning {
+				t.Errorf("synthesized group: rolled-up Status — want running, got %q", j.Status)
+			}
+		default:
+			t.Errorf("unexpected Type %q on %s", j.Type, j.JobName)
+		}
 	}
 }
 

--- a/products/catalyst/bootstrap/api/internal/jobs/types.go
+++ b/products/catalyst/bootstrap/api/internal/jobs/types.go
@@ -200,6 +200,15 @@ type Job struct {
 	// DERIVED at read time by Store.ListJobs / Store.GetJob; never
 	// persisted. Empty for leaf install jobs.
 	ChildIDs []string `json:"childIds,omitempty"`
+
+	// LegacyBatchID — read-only migration field. Pre-#351 indexes
+	// persisted the deprecated `batchId` denormalisation; loadIndex
+	// hoists any non-empty legacy value into ParentID
+	// (= JobID(deploymentID, batchID)) and deriveTreeView synthesizes
+	// the matching parent group Job in-memory when no on-disk row
+	// exists. Stripped from every persistIndex write so the on-disk
+	// record stays canonical (one source of truth: ParentID).
+	LegacyBatchID string `json:"batchId,omitempty"`
 }
 
 // Execution captures one attempt of a Job. The store appends a new


### PR DESCRIPTION
Old deployments (e.g. \`ce476aaf80731a46\`) were provisioned before #351 landed. Their \`index.json\` carries the deprecated \`batchId\` JSON field; after the rename the field is silently dropped, leaving every leaf orphaned with empty \`ParentID\`. The bridge only writes parents on NEW events, so the canvas + table render zero parent relationships for old deployments.

**Three changes:**

1. \`Job.LegacyBatchID\` — read-only \`batchId\` JSON tag, never echoed back to disk
2. \`loadIndex\` — hoists \`LegacyBatchID\` → \`ParentID\` (= \`JobID(depID, batchID)\`); clears \`LegacyBatchID\`; defaults empty \`Type\` to \`JobTypeInstall\`
3. \`deriveTreeView\` — synthesizes an in-memory group Job for any \`ParentID\` without a matching on-disk row; participates in rollup like a real parent

\`go test ./...\` clean. New \`TestStore_LegacyBatchID_HoistedToParentID\` locks in the contract: pre-#351 index.json → 3 jobs (2 leaves + 1 synthesized group) with rolled-up running status.

Refs #351

🤖 Generated with [Claude Code](https://claude.com/claude-code)