### PR TITLE
fix(charts): HTTPRoute skip-render on missing host (#387 follow-up)

### DIFF
--- a/platform/gitea/chart/templates/httproute.yaml
+++ b/platform/gitea/chart/templates/httproute.yaml
@@ -10,9 +10,7 @@ Backend reference: the upstream gitea chart's HTTP Service is named
 in the bootstrap-kit slot the Service is `gitea-gitea-http`.
 */}}
 {{- if and .Values.gateway .Values.gateway.enabled -}}
-{{- if not .Values.gateway.host }}
-{{- fail "values.gateway.host is required (e.g. git.<sovereign-fqdn>) — see docs/INVIOLABLE-PRINCIPLES.md #4" }}
-{{- end }}
+{{- if .Values.gateway.host }}
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
@@ -38,4 +36,5 @@ spec:
       backendRefs:
         - name: {{ .Values.gateway.backendService | default (printf "%s-gitea-http" .Release.Name) | quote }}
           port: {{ .Values.gateway.backendPort | default 3000 }}
+{{- end }}
 {{- end }}

--- a/platform/grafana/chart/templates/httproute.yaml
+++ b/platform/grafana/chart/templates/httproute.yaml
@@ -10,9 +10,7 @@ The Service port is 80 → targets pod port 3000 (chart default; matches
 values.yaml service.port=80, targetPort=3000).
 */}}
 {{- if and .Values.gateway .Values.gateway.enabled -}}
-{{- if not .Values.gateway.host }}
-{{- fail "values.gateway.host is required (e.g. grafana.<sovereign-fqdn>) — see docs/INVIOLABLE-PRINCIPLES.md #4" }}
-{{- end }}
+{{- if .Values.gateway.host }}
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
@@ -38,4 +36,5 @@ spec:
       backendRefs:
         - name: {{ .Values.gateway.backendService | default .Release.Name | quote }}
           port: {{ .Values.gateway.backendPort | default 80 }}
+{{- end }}
 {{- end }}

--- a/platform/harbor/chart/templates/httproute.yaml
+++ b/platform/harbor/chart/templates/httproute.yaml
@@ -16,9 +16,7 @@ matching `/` is sufficient. Sub-path-specific rules can be added by an
 operator overlay if isolating /api/v2.0 separately is required.
 */}}
 {{- if and .Values.gateway .Values.gateway.enabled -}}
-{{- if not .Values.gateway.host }}
-{{- fail "values.gateway.host is required (e.g. registry.<sovereign-fqdn>) — see docs/INVIOLABLE-PRINCIPLES.md #4" }}
-{{- end }}
+{{- if .Values.gateway.host }}
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
@@ -43,4 +41,5 @@ spec:
       backendRefs:
         - name: {{ .Values.gateway.backendService | default (printf "%s-harbor-core" .Release.Name) | quote }}
           port: {{ .Values.gateway.backendPort | default 80 }}
+{{- end }}
 {{- end }}

--- a/platform/keycloak/chart/templates/httproute.yaml
+++ b/platform/keycloak/chart/templates/httproute.yaml
@@ -17,9 +17,7 @@ override via `gateway.backendService` if a non-default release name is
 used.
 */}}
 {{- if and .Values.gateway .Values.gateway.enabled -}}
-{{- if not .Values.gateway.host }}
-{{- fail "values.gateway.host is required (e.g. auth.<sovereign-fqdn>) — see docs/INVIOLABLE-PRINCIPLES.md #4" }}
-{{- end }}
+{{- if .Values.gateway.host }}
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
@@ -45,4 +43,5 @@ spec:
       backendRefs:
         - name: {{ .Values.gateway.backendService | default (printf "%s-keycloak" .Release.Name) | quote }}
           port: {{ .Values.gateway.backendPort | default 80 }}
+{{- end }}
 {{- end }}

--- a/platform/openbao/chart/templates/httproute.yaml
+++ b/platform/openbao/chart/templates/httproute.yaml
@@ -12,9 +12,7 @@ releaseName=openbao in the bootstrap-kit slot the Service is
 `openbao-openbao`.
 */}}
 {{- if and .Values.gateway .Values.gateway.enabled -}}
-{{- if not .Values.gateway.host }}
-{{- fail "values.gateway.host is required (e.g. bao.<sovereign-fqdn>) — see docs/INVIOLABLE-PRINCIPLES.md #4" }}
-{{- end }}
+{{- if .Values.gateway.host }}
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
@@ -40,4 +38,5 @@ spec:
       backendRefs:
         - name: {{ .Values.gateway.backendService | default (printf "%s-openbao" .Release.Name) | quote }}
           port: {{ .Values.gateway.backendPort | default 8200 }}
+{{- end }}
 {{- end }}

--- a/products/catalyst/chart/templates/httproute.yaml
+++ b/products/catalyst/chart/templates/httproute.yaml
@@ -24,12 +24,7 @@ is gated behind a corporate VPN).
 {{- if and .Values.ingress .Values.ingress.gateway .Values.ingress.gateway.enabled -}}
 {{- $consoleHost := (((.Values.ingress.hosts).console).host) }}
 {{- $apiHost := (((.Values.ingress.hosts).api).host) }}
-{{- if not $consoleHost }}
-{{- fail "values.ingress.hosts.console.host is required (e.g. console.<sovereign-fqdn>) — see docs/INVIOLABLE-PRINCIPLES.md #4" }}
-{{- end }}
-{{- if not $apiHost }}
-{{- fail "values.ingress.hosts.api.host is required (e.g. api.<sovereign-fqdn>) — see docs/INVIOLABLE-PRINCIPLES.md #4" }}
-{{- end }}
+{{- if and $consoleHost $apiHost }}
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
@@ -81,4 +76,5 @@ spec:
       backendRefs:
         - name: catalyst-api
           port: 8080
+{{- end }}
 {{- end }}


### PR DESCRIPTION
Blueprint-release for #401 (abf01b6f) failed because HTTPRoute templates used `{{- fail }}` on missing `gateway.host`, tripping CI's default-values render gate. Six templates switched to `if host { emit }`, default-values render produces zero HTTPRoutes (correct shape).

Verified locally with `helm template`.