### PR TITLE
docs(wbs): #375 bp-nats-jetstream chart-verified — smoke OK, close as duplicate

### DIFF
--- a/docs/omantel-handover-wbs.md
+++ b/docs/omantel-handover-wbs.md
@@ -346,7 +346,7 @@ If founder wants to amend ADR-0001 with §13 formalised (S3 vs SeaweedFS rule), 
 | #378 | ✅ chart-verified — bp-crossplane v1.1.3 already published; helm template renders 23 kinds clean; smoke install on contabo reached 2/2 Ready in 26s; `Provider.pkg.crossplane.io/v1` admitted; `provider-hcloud:v0.4.0` Provider CR admitted; smoke torn down clean; bootstrap-kit wiring already present in `_template` | (closed as duplicate) | smoke evidence in #378 thread |
 | #392 | ✅ DoD-met — code shipped (#397, `aa8ed4e7`), catalyst-api:aa8ed4e7 deployed, behavior-verified by fake-Hetzner E2E test (PR #399, `0904f54a`); regression sentinel pins label-key against future drift | #397 + #399 | catalyst-api:aa8ed4e7 + 2 e2e tests passing |
 | #374 | (parked, gates on #373) | | |
-| #375 | 🟡 in-progress (Agent #375) — bp-nats-jetstream install verification | | |
+| #375 | ✅ chart-verified — bp-nats-jetstream v1.1.1 already published (1.0.0, 1.1.0, 1.1.1 on GHCR); helm template renders 8 kinds clean (StatefulSet replicas=3, ConfigMap, headless+client Service, PDB, Secret, nats-box Deployment); smoke install on contabo (`nats-smoke` ns) reached 3/3 Ready in 33s, JetStream R=3 stream `testStream` created with leader+2 replica quorum, pub/sub round-trip verified (5-byte msg, 1 stream message); smoke torn down clean; bootstrap-kit wiring already present in `_template/bootstrap-kit/07-nats-jetstream.yaml` (HelmRelease, dependsOn bp-spire, install/upgrade `disableWait: true` per intra-chart raft-quorum event-driven pattern). No PR needed — closing as duplicate. | (no-PR) | smoke evidence in close comment |
 | #376 | (parked) | | |
 | #379 | (parked) | | |
 | #380 | (parked) | | |


### PR DESCRIPTION
## Summary

- bp-nats-jetstream chart already exists at `platform/nats-jetstream/chart/` and is already published on GHCR (versions 1.0.0, 1.1.0, 1.1.1)
- Helm template renders 8 kinds clean with default values: StatefulSet replicas=3 (per ADR-0001 §9.2 B5 near-zero RPO), ConfigMap, headless + client Service, PDB, Secret, nats-box Deployment
- Smoke-installed on contabo (`nats-smoke` namespace) — 3/3 NATS pods Ready in 33s, JetStream stream `testStream` created with R=3 (leader `t-nats-1` + replicas `t-nats-0`/`t-nats-2`), pub/sub round-trip verified (5-byte message)
- Bootstrap-kit wiring already in place at `clusters/_template/bootstrap-kit/07-nats-jetstream.yaml` — HelmRelease, `dependsOn: bp-spire`, `install/upgrade.disableWait: true` per intra-chart raft-quorum event-driven pattern
- No code change needed; this PR only updates the WBS row for #375 from "(parked)" to "✅ chart-verified". Same verify-and-close pattern as #378.

## Test plan

- [x] `helm dependency build` succeeds
- [x] `helm template` renders 8 kinds with no errors
- [x] Smoke install reaches 3/3 Ready
- [x] `nats stream add` with `--replicas=3` succeeds, JetStream cluster info shows leader + 2 replicas
- [x] `nats pub` + stream-info shows message landed
- [x] `helm uninstall` + `kubectl delete ns` torn down clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)