### PR TITLE
fix(bootstrap-kit): renumber #373 webhook 36→49 + register in expected DAG

### DIFF
--- a/clusters/_template/bootstrap-kit/49-bp-cert-manager-powerdns-webhook.yaml
+++ b/clusters/_template/bootstrap-kit/49-bp-cert-manager-powerdns-webhook.yaml
@@ -1,4 +1,8 @@
-# bp-cert-manager-powerdns-webhook — Catalyst bootstrap-kit Blueprint #36.
+# bp-cert-manager-powerdns-webhook — Catalyst bootstrap-kit Blueprint #49.
+# (Slot 36 was reserved in the W2.K0 forward-declared DAG for `bp-stunner`;
+# this Phase-2 webhook lands at slot 49 — first free slot after the W2.K4
+# forward declarations end at 48. Source of truth: scripts/expected-
+# bootstrap-deps.yaml.)
 # DNS-01 ACME solver against the Sovereign's OWN PowerDNS for wildcard
 # TLS post-handover. Closes openova#373; gates #319 (post-handover renewals).
 #

--- a/clusters/_template/bootstrap-kit/kustomization.yaml
+++ b/clusters/_template/bootstrap-kit/kustomization.yaml
@@ -40,4 +40,4 @@ resources:
   - 33-syft-grype.yaml
   - 34-velero.yaml
   - 35-coraza.yaml
-  - 36-bp-cert-manager-powerdns-webhook.yaml
+  - 49-bp-cert-manager-powerdns-webhook.yaml

--- a/scripts/expected-bootstrap-deps.yaml
+++ b/scripts/expected-bootstrap-deps.yaml
@@ -226,3 +226,12 @@ slots:
     name: bp-librechat
     depends_on: [bp-llm-gateway, bp-vllm, bp-bge, bp-keycloak]
     wave: W2.K4
+
+  # ---- Phase-2 (handover) — DNS-01 webhook against Sovereign's own PowerDNS -
+  # Authored under #373; lands at slot 49 because slots 36-48 were already
+  # forward-declared by the W2.K4 batch. Wave is "present" because the HR
+  # exists on disk now (chart-released; runtime exercise deferred to Phase 8).
+  - slot: 49
+    name: bp-cert-manager-powerdns-webhook
+    depends_on: [bp-cert-manager, bp-powerdns]
+    wave: present


### PR DESCRIPTION
## Summary
- PR #410 (#373 chart) landed at slot 36, which was reserved for `bp-stunner` in the W2.K4 forward-declared DAG. Bootstrap-kit dependency audit failed on the merge SHA \`04308af7\`.
- Renames the slot file 36→49 (first free slot after the W2.K4 forward declarations end at 48) and registers it in \`scripts/expected-bootstrap-deps.yaml\` as \`wave: present\` with \`depends_on: [bp-cert-manager, bp-powerdns]\`.
- CI-only fix — chart + runtime semantics from #410 unchanged.

## Local audit evidence
\`\`\`
$ bash scripts/check-bootstrap-deps.sh
Present on disk:       36
Declared expected:     49
Deferred (W2.K1-K4):   13
Drift:                 0
Cycles:                0
OK: bootstrap-kit dependency graph audit PASSED
\`\`\`

## Test plan
- [x] Local \`scripts/check-bootstrap-deps.sh\` → PASSED
- [ ] CI \`Test — Bootstrap Kit\` → green on merge SHA

🤖 Generated with [Claude Code](https://claude.com/claude-code)