### PR TITLE
feat(bp-grafana): chart-verified on contabo + per-Sovereign overlay drift fix (#381)

### DIFF
--- a/clusters/omantel.omani.works/bootstrap-kit/25-grafana.yaml
+++ b/clusters/omantel.omani.works/bootstrap-kit/25-grafana.yaml
@@ -73,3 +73,10 @@ spec:
     disableWait: true
     remediation:
       retries: 3
+  # Per-Sovereign overrides — issue #387:
+  # Wire the per-Sovereign hostname into the HTTPRoute template
+  # (platform/grafana/chart/templates/httproute.yaml). The HTTPRoute
+  # attaches to cilium-gateway/kube-system installed by 01-cilium.yaml.
+  values:
+    gateway:
+      host: grafana.omantel.omani.works

--- a/clusters/otech.omani.works/bootstrap-kit/25-grafana.yaml
+++ b/clusters/otech.omani.works/bootstrap-kit/25-grafana.yaml
@@ -73,3 +73,10 @@ spec:
     disableWait: true
     remediation:
       retries: 3
+  # Per-Sovereign overrides — issue #387:
+  # Wire the per-Sovereign hostname into the HTTPRoute template
+  # (platform/grafana/chart/templates/httproute.yaml). The HTTPRoute
+  # attaches to cilium-gateway/kube-system installed by 01-cilium.yaml.
+  values:
+    gateway:
+      host: grafana.otech.omani.works

--- a/docs/omantel-handover-wbs.md
+++ b/docs/omantel-handover-wbs.md
@@ -43,7 +43,7 @@ A handed-over Sovereign must own its own GitOps loop, its own DNS, its own cert 
 | 19 | `bp-velero` | Cluster-state backup → Hetzner Object Storage | ❌ not deployed; chart needs S3 endpoint rework ([#384](https://github.com/openova-io/openova/issues/384)) |
 | 20 | `bp-kyverno` | Admission policy | ❌ not deployed ([#379](https://github.com/openova-io/openova/issues/379)) |
 | 21 | `bp-trivy` | Image CVE scanning | ❌ not deployed ([#380](https://github.com/openova-io/openova/issues/380)) |
-| 22 | `bp-grafana` | Bundle: Alloy + Loki + Mimir + Tempo + Grafana dashboards | ❌ not deployed ([#381](https://github.com/openova-io/openova/issues/381)) |
+| 22 | `bp-grafana` | Grafana visualizer (Alloy/Loki/Mimir/Tempo are sibling slots 21-24) | ✅ chart-verified on contabo ([#381](https://github.com/openova-io/openova/issues/381)) |
 | 23 | `bp-catalyst-platform` | catalyst-api + catalyst-ui + helmwatch (the self-sufficient console) | ✅ deployed; needs single-blueprint verification ([#385](https://github.com/openova-io/openova/issues/385)) |
 
 > **Correction note (2026-05-01):** earlier draft listed `bp-traefik` as #3. That was wrong — Traefik is contabo-only legacy demo infra. Sovereigns ingress through Cilium Gateway API + Envoy. #372 closed; replaced by [#387](https://github.com/openova-io/openova/issues/387) (Gateway API migration audit across all minimal-set blueprint charts).
@@ -349,7 +349,7 @@ If founder wants to amend ADR-0001 with §13 formalised (S3 vs SeaweedFS rule), 
 | #376 | (parked) | | |
 | #379 | (parked) | | |
 | #380 | (parked) | | |
-| #381 | (parked) | | |
+| #381 | ✅ chart-verified — `bp-grafana:1.0.0` published by blueprint-release run `25214143810` on commit `a1bd5502`. Helm template renders cleanly: defaults → 13 kinds (skip-render of HTTPRoute when `gateway.host` empty); with `gateway.host` set → 14 kinds (incl. HTTPRoute). Smoke install on contabo (`grafana-smoke` ns) reached 1/1 Ready in 65s, in-cluster `/login` returned HTTP 200, `/api/health` returned 200, image `docker.io/grafana/grafana:12.3.1` confirmed. Smoke torn down clean. Per-Sovereign overlay drift fixed: `gateway.host: grafana.<sovereign-fqdn>` now wired in `_template/`, `omantel.omani.works/`, and `otech.omani.works/` (parity with bp-keycloak). Wizard catalog already lists bp-grafana at slot 25. NOTE: scope reframed — bp-grafana is the Grafana visualizer only; Alloy/Loki/Mimir/Tempo are separate sibling Blueprints (slots 21-24). Sovereign-impact deferred to Phase 8. | (this PR) | bp-grafana:1.0.0 published; smoke evidence captured |
 | #382 | (parked) | | |
 | #383 | (parked) | | |
 | #384 | (parked) | | |


### PR DESCRIPTION
## Summary
- bp-grafana 1.0.0 was published by blueprint-release run [25214143810](https://github.com/openova-io/openova/actions/runs/25214143810) on commit `a1bd5502` (alongside the #387 Gateway API HTTPRoute templates). This PR verifies the chart on contabo and brings the per-Sovereign overlays in line with `_template` and the bp-keycloak pattern from #377.
- Per-Sovereign overlay drift fixed: `values.gateway.host` was missing from both `omantel.omani.works/` and `otech.omani.works/` 25-grafana.yaml — added with the per-FQDN value (`grafana.<sovereign-fqdn>`) so the #387 HTTPRoute template renders on each Sovereign.
- WBS §9 + §2 row updated. Scope clarification: bp-grafana is the Grafana visualizer only; Alloy/Loki/Mimir/Tempo are sibling Blueprints (slots 21-24), each with their own ticket.

## Verification (smoke evidence on contabo)
- `helm template t platform/grafana/chart/` → 13 kinds (HTTPRoute skip-renders when `gateway.host` empty — per the #387/#402 if-host-emit pattern, no `{{ fail }}`)
- `helm template t platform/grafana/chart/ --set gateway.host=grafana.test.example.com` → 14 kinds (incl. HTTPRoute)
- Smoke install in `grafana-smoke` ns:
  - `smoke-grafana-59c4bdc777-xr4jb` reached 1/1 Ready in **65s**
  - In-cluster `GET http://smoke-grafana/login` → **HTTP 200**
  - In-cluster `GET http://smoke-grafana/api/health` → **HTTP 200**
  - Image: `docker.io/grafana/grafana:12.3.1` confirmed
  - Smoke release uninstalled and namespace deleted clean

## Files
- `clusters/omantel.omani.works/bootstrap-kit/25-grafana.yaml` — add `values.gateway.host`
- `clusters/otech.omani.works/bootstrap-kit/25-grafana.yaml` — add `values.gateway.host`
- `docs/omantel-handover-wbs.md` — §2 row 22 + §9 row #381 status updated

## Test plan
- [x] `helm template` clean with defaults (skip-render HTTPRoute)
- [x] `helm template` with gateway.host renders HTTPRoute
- [x] Smoke install on contabo `grafana-smoke` ns reaches Ready
- [x] In-cluster `/login` and `/api/health` return 200
- [x] Smoke teardown clean
- [x] Per-Sovereign overlay parity with `_template` and bp-keycloak pattern

Closes #381

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>