### PR TITLE
fix(ci) vendor-coupling guardrail path mode-gate (#438)

### DIFF
--- a/scripts/check-vendor-coupling.sh
+++ b/scripts/check-vendor-coupling.sh
@@ -117,7 +117,7 @@ fi
 # remaining vendor-coupled reference is either drift or net-new — both
 # must hard-fail. Until then, we can only warn (the drift IS the WIP).
 HARD_FAIL=0
-if [[ -d "${REPO_ROOT}/internal/objectstorage" ]]; then
+if [[ -d "${REPO_ROOT}/products/catalyst/bootstrap/api/internal/objectstorage" ]]; then
   HARD_FAIL=1
 fi
 if [[ "${FORCE_HARD_FAIL}" -eq 1 ]]; then


### PR DESCRIPTION
## Summary
- Fix the mode-gate check in `scripts/check-vendor-coupling.sh` so hard-fail mode auto-engages on this repo. The check was looking for `${REPO_ROOT}/internal/objectstorage` but the canonical Go package lives at `products/catalyst/bootstrap/api/internal/objectstorage` (post-#425 layout). 1-line path update.

Closes #438. Refs PR #437 (#383) which surfaced the drift.

## Validation
- Clean tree: `bash scripts/check-vendor-coupling.sh` -> banner says `HARD-FAIL mode`, exit 0.
- Synthetic violation: `echo "hetzner-object-storage" > platform/test-violation.txt && bash scripts/check-vendor-coupling.sh` -> exit 1, FAIL banner with line citation.

## Test plan
- [x] Hard-fail mode banner emitted on clean tree
- [x] Exit 0 on clean tree
- [x] Synthetic `hetzner-object-storage` under `platform/` -> exit 1