### PR TITLE
feat(bp-keycloak + infra): Sovereign K8s OIDC for kubectl via per-Sovereign Keycloak (closes #326)

### DIFF
--- a/clusters/_template/bootstrap-kit/09-keycloak.yaml
+++ b/clusters/_template/bootstrap-kit/09-keycloak.yaml
@@ -38,7 +38,7 @@ spec:
   chart:
     spec:
       chart: bp-keycloak
-      version: 1.1.2
+      version: 1.2.0
       sourceRef:
         kind: HelmRepository
         name: bp-keycloak

--- a/clusters/omantel.omani.works/bootstrap-kit/09-keycloak.yaml
+++ b/clusters/omantel.omani.works/bootstrap-kit/09-keycloak.yaml
@@ -38,7 +38,7 @@ spec:
   chart:
     spec:
       chart: bp-keycloak
-      version: 1.1.2
+      version: 1.2.0
       sourceRef:
         kind: HelmRepository
         name: bp-keycloak

--- a/clusters/otech.omani.works/bootstrap-kit/09-keycloak.yaml
+++ b/clusters/otech.omani.works/bootstrap-kit/09-keycloak.yaml
@@ -38,7 +38,7 @@ spec:
   chart:
     spec:
       chart: bp-keycloak
-      version: 1.1.2
+      version: 1.2.0
       sourceRef:
         kind: HelmRepository
         name: bp-keycloak

--- a/docs/omantel-handover-wbs.md
+++ b/docs/omantel-handover-wbs.md
@@ -356,7 +356,7 @@ DoD execution checklist:
 
 These are real future work but **not in the minimal omantel handover**:
 
-- **#320 IAM family** (#322, #323, #324, #325, #326): Bastion + pod console + UserAccess editor. Sovereign owner uses static admin kubeconfig in the minimal. Adds Day-2 enrichment.
+- **#320 IAM family** (#322, #323, #324, #325): Bastion + pod console + UserAccess editor. Sovereign owner uses static admin kubeconfig in the minimal. Adds Day-2 enrichment. (#326 was carved out and shipped — k3s api-server OIDC validator + Keycloak `kubectl` realm — so customer admins authenticate kubectl directly against the per-Sovereign Keycloak from Phase 8 onwards. See §11.)
 - **#37**: Catalyst docs overhaul.
 - **#264, #265**: bp-knative, bp-kserve — W2.K4 batch.
 - **#109** (private): Cart-during-initial silent loss — SME-side legacy bug.
@@ -404,6 +404,7 @@ If founder wants to amend ADR-0001 with §13 formalised (S3 vs SeaweedFS rule), 
 | #428 | 🟢 done — CI vendor-coupling guardrail. Mode-gate auto-flips warn-only → hard-fail when `internal/objectstorage/` directory lands (i.e. once #425 merges). Pre-#425: 49 WARN lines on existing hetzner-coupled refs, exit 0. Post-#425: any future re-introduction of vendor coupling fails CI on push or PR. | [#431](https://github.com/openova-io/openova/pull/431) merged `0fdd411e` | scripts/check-vendor-coupling.sh + .github/workflows/check-vendor-coupling.yaml |
 | #429 | 🟢 scaffold-shipped — Phase 8 DoD spec authored at `tests/e2e/playwright/tests/omantel-handover.spec.ts` (mirrors canonical `sovereign-wizard.spec.ts` shape; reuses `_helpers.ts:reachable()`); 6 `test()` blocks 1:1 with §10 acceptance bullets (sovereign Ready+23/23, bp-* HRs Ready, catalyst-platform self-host, vendor-agnostic Object Storage Secret per #425, dig +trace ends at omantel NS, zero contabo dependency). Self-skips when `OMANTEL_BASE_URL`/`OMANTEL_API_BASE`/`OPERATOR_BEARER` unset. Workflow `.github/workflows/omantel-e2e-handover.yaml` is `workflow_dispatch:` only (no cron, per CLAUDE.md). Executes against live omantel only after Phase 4/6/7 land. | [#432](https://github.com/openova-io/openova/pull/432) merged `1e7d1e67` | spec + workflow scaffold; live execution gated on Phase 4/6/7 |
 | #430 | 🟢 done (audit-only) — `.github/workflows/*.yaml` swept; 0 cron triggers found across 18 workflow files; already compliant. No PR needed. | (no PR — already-compliant audit) | audit-only verification |
+| #326 | 🟢 chart + cloud-init shipped — k3s api-server now boots with 6 `--kube-apiserver-arg=oidc-*` flags pointing at `https://auth.${SOVEREIGN_FQDN}/realms/sovereign` (issuer composed from `sovereign_fqdn` per INVIOLABLE-PRINCIPLES #4); bp-keycloak chart bumped 1.1.2 → 1.2.0 with `keycloakConfigCli.enabled=true` + inline `sovereign-realm.json` carrying realm `sovereign`, default groups `sovereign-admins/-ops/-viewers`, `groups` claim mapper, and a public `kubectl` OIDC client with `http://localhost:8000` redirect URI (kubectl-oidc-login default). Realm import runs as the upstream chart's existing post-install/post-upgrade Helm hook Job (canonical seam — no bespoke kubectl-exec script). New chart test `tests/oidc-kubectl-client.sh` (4 cases) green; existing `tests/observability-toggle.sh` still green. Bootstrap-kit slot 09 bumped to `version: 1.2.0` in `_template/`, `omantel.omani.works/`, `otech.omani.works/`. Documentation: §11 "kubectl OIDC for customer admins" runbook section added. NO catalyst-api or UI code touched (those are #322/#323 territories). Live execution against omantel deferred to Phase 8. | (this PR) | bp-keycloak:1.2.0 chart-shipped; cloud-init flags rendered |
 
 ## 10. Phase 8 acceptance criteria (executable DoD)
 
@@ -417,4 +418,83 @@ The Phase 8 acceptance bullets below are 1:1 with `tests/e2e/playwright/tests/om
 6. **Zero contabo dependency** — over a 5-minute window with NO calls to contabo's catalyst-api, omantel's `/api/healthz` keeps returning 200 (every probe). Live Phase 8 run extends `FAULT_INJECT_PROBES=300` (5 min × 1Hz); scaffold uses 5 probes for fast feedback.
 
 The spec self-skips when `OMANTEL_BASE_URL`/`OMANTEL_API_BASE`/`OPERATOR_BEARER` env vars are unset, so it never breaks routine local Playwright runs on contabo. Live execution is on-demand via `workflow_dispatch` — no `schedule:` cron, per CLAUDE.md "every workflow MUST be event-driven".
+
+## 11. kubectl OIDC for customer admins (issue #326)
+
+Every Sovereign K8s api-server is wired to validate id-tokens issued by its own per-Sovereign Keycloak realm `sovereign`. Customer admins authenticate `kubectl` against Keycloak — no static admin kubeconfig handoff, no rotated bearer-token exchange.
+
+**Wiring:**
+
+| Surface | Source of truth |
+|---|---|
+| k3s api-server `--oidc-*` flags | `infra/hetzner/cloudinit-control-plane.tftpl` (rendered at provisioning time, baked into the systemd unit) |
+| Keycloak `sovereign` realm + `kubectl` OIDC client | `platform/keycloak/chart/values.yaml` `keycloak.keycloakConfigCli.configuration` (imported by the upstream `keycloak-config-cli` post-install Job) |
+
+The realm name is invariant per Sovereign (`sovereign`); only the issuer host differs (`https://auth.<sovereign-fqdn>/realms/sovereign`). Keycloak resolves the issuer claim from the request hostname automatically — no per-Sovereign realm rename is needed.
+
+**Customer-admin setup (one-time per workstation):**
+
+```bash
+# 1. Install kubectl-oidc-login plugin (required — k3s api-server only
+#    speaks OIDC, not Keycloak's password grant directly).
+kubectl krew install oidc-login
+
+# 2. Wire kubectl to the Sovereign + the Keycloak realm.
+kubectl config set-cluster <sovereign-id> \
+    --server=https://api.<sovereign-fqdn>:6443
+kubectl config set-credentials <user>@oidc \
+    --exec-api-version=client.authentication.k8s.io/v1beta1 \
+    --exec-command=kubectl \
+    --exec-arg=oidc-login \
+    --exec-arg=get-token \
+    --exec-arg=--oidc-issuer-url=https://auth.<sovereign-fqdn>/realms/sovereign \
+    --exec-arg=--oidc-client-id=kubectl
+kubectl config set-context <sovereign-id>-<user> \
+    --cluster=<sovereign-id> --user=<user>@oidc
+kubectl config use-context <sovereign-id>-<user>
+
+# 3. First call opens the browser, walks the Keycloak login page, and
+#    redirects to http://localhost:8000 with the auth-code. Subsequent
+#    calls reuse the cached id-token until expiry (15 min default,
+#    refresh good for 8h).
+kubectl get pods --all-namespaces
+```
+
+**Sovereign-admin setup (cluster-side RBAC, ONE-time per Sovereign):**
+
+The customer admin's first user lives in the realm's `sovereign-admins` group. Bind that group to a ClusterRole (`cluster-admin` for the bootstrap admin, scoped Roles thereafter):
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: sovereign-admins-cluster-admin
+subjects:
+  - kind: Group
+    name: oidc:sovereign-admins   # `oidc:` prefix matches --oidc-groups-prefix
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: cluster-admin
+  apiGroup: rbac.authorization.k8s.io
+```
+
+For per-user binding, the subject is `oidc:<preferred_username>` (e.g. `oidc:alice@org`) — the api-server's `--oidc-username-prefix=oidc:` flag prepends that namespace so OIDC subjects never collide with local ServiceAccounts or x509 certificates.
+
+**Debugging "401 from api-server":**
+
+| Symptom | Likely root cause |
+|---|---|
+| `error: You must be logged in to the server (Unauthorized)` after a fresh login | Token not yet present in cache — re-run `kubectl` once; the auth-code grant only kicks off when no cached token exists |
+| `error: ...invalid bearer token, oidc: ID Token issued at...` | Issuer URL mismatch — confirm `--oidc-issuer-url` on the api-server matches `https://auth.<sovereign-fqdn>/realms/sovereign` exactly, character-for-character |
+| `error: ...verifier: invalid issuer (got https://..., expected https://...)` | Keycloak chart's hostname (`gateway.host`) is wrong; check `clusters/<sovereign-fqdn>/bootstrap-kit/09-keycloak.yaml` matches `auth.<sovereign-fqdn>` |
+| 200 from api-server but `Forbidden` on every resource | RBAC is missing — bind `oidc:sovereign-admins` (or the user's group) to a Role/ClusterRole as above |
+
+**What's NOT yet shipped (open for follow-up tickets, post-MVP):**
+
+- Per-Sovereign user provisioning UI (#322 / #323 territory) — for now, customer admins create users via the Keycloak admin console at `https://auth.<sovereign-fqdn>/admin/master/console/`.
+- Refresh-token revocation hook on RoleBinding deletion (#324).
+- `provider-kubernetes` Crossplane ProviderConfig per Sovereign (#321).
+
+These are post-handover enhancements; the api-server-side OIDC validator is sufficient for the omantel handover Phase 8 DoD.
 

--- a/infra/hetzner/cloudinit-control-plane.tftpl
+++ b/infra/hetzner/cloudinit-control-plane.tftpl
@@ -447,6 +447,33 @@ runcmd:
   #   --disable-network-policy      Cilium handles NetworkPolicy.
   #   --tls-san=${sovereign_fqdn}   API server cert valid for the sovereign FQDN.
   #
+  # ── kube-apiserver OIDC flags (issue #326) ─────────────────────────────
+  #   --kube-apiserver-arg=oidc-issuer-url=https://auth.<sovereign_fqdn>/realms/sovereign
+  #   --kube-apiserver-arg=oidc-client-id=kubectl
+  #   --kube-apiserver-arg=oidc-username-claim=preferred_username
+  #   --kube-apiserver-arg=oidc-username-prefix=oidc:
+  #   --kube-apiserver-arg=oidc-groups-claim=groups
+  #   --kube-apiserver-arg=oidc-groups-prefix=oidc:
+  # Wire k3s api-server's OIDC validator to the per-Sovereign Keycloak
+  # realm (`sovereign`), shipped by bp-keycloak's keycloakConfigCli realm
+  # import (platform/keycloak/chart/values.yaml). After the Sovereign's
+  # bootstrap kit lands, customer admins authenticate kubectl against
+  # Keycloak (see docs/omantel-handover-wbs.md §11 "kubectl OIDC for
+  # customer admins"). The username/groups prefixes prefix every
+  # OIDC-issued subject with `oidc:` so RoleBindings reference them as
+  # e.g. `subjects[0].name=oidc:alice@org` — distinct from any local
+  # ServiceAccount or x509 subject. Per INVIOLABLE-PRINCIPLES #4 the
+  # issuer URL is composed from sovereign_fqdn — never hardcoded.
+  #
+  # Trust-chain note: the per-Sovereign Keycloak is exposed via the
+  # `cilium-gateway` Gateway (kube-system), whose serving Certificate is
+  # issued by Let's Encrypt via bp-cert-manager. k3s's kube-apiserver
+  # reaches the in-cluster Keycloak Service over plain HTTPS using the
+  # node's system trust store; LE roots are present by default on the
+  # Ubuntu 24.04 control-plane image, so no `--oidc-ca-file` is needed
+  # in this configuration. Air-gapped Sovereigns (deferred Phase 9+)
+  # add a CA-file flag here when their Keycloak fronts a private CA.
+  #
   # NOTE: --disable=local-storage is intentionally NOT passed. k3s ships a
   # built-in local-path-provisioner (Rancher) and registers a `local-path`
   # StorageClass. That is the canonical solo-Sovereign StorageClass:
@@ -467,7 +494,7 @@ runcmd:
   # provisioned hcloud-csi. Result on a fresh Sovereign: every PVC stuck
   # Pending forever, bootstrap-kit deadlocked. Keeping local-path solves
   # the circularity by giving the cluster a default StorageClass at boot.
-  - 'curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION=${k3s_version} K3S_TOKEN=${k3s_token} INSTALL_K3S_EXEC="server --cluster-init --flannel-backend=none --disable-network-policy --disable=traefik --disable=servicelb --tls-san=${sovereign_fqdn} --node-label catalyst.openova.io/role=control-plane --write-kubeconfig-mode=0644" sh -'
+  - 'curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION=${k3s_version} K3S_TOKEN=${k3s_token} INSTALL_K3S_EXEC="server --cluster-init --flannel-backend=none --disable-network-policy --disable=traefik --disable=servicelb --tls-san=${sovereign_fqdn} --kube-apiserver-arg=oidc-issuer-url=https://auth.${sovereign_fqdn}/realms/sovereign --kube-apiserver-arg=oidc-client-id=kubectl --kube-apiserver-arg=oidc-username-claim=preferred_username --kube-apiserver-arg=oidc-username-prefix=oidc: --kube-apiserver-arg=oidc-groups-claim=groups --kube-apiserver-arg=oidc-groups-prefix=oidc: --node-label catalyst.openova.io/role=control-plane --write-kubeconfig-mode=0644" sh -'
 
   # Wait for the API server to be reachable. Cilium needs to come up before
   # nodes Ready, so we wait specifically for the API endpoint.

--- a/platform/keycloak/blueprint.yaml
+++ b/platform/keycloak/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
 spec:
-  version: 1.1.2
+  version: 1.2.0
   card:
     title: keycloak
     summary: Keycloak — user identity. Topology decided by Sovereign CRD spec.keycloakTopology (per-organization for SME, shared-sovereign for corporate).

--- a/platform/keycloak/chart/Chart.yaml
+++ b/platform/keycloak/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-keycloak
-version: 1.1.2
+version: 1.2.0
 description: |
   Catalyst-curated Blueprint umbrella chart for Keycloak. Depends on the
   upstream `keycloak` chart (bitnami) as a Helm subchart so

--- a/platform/keycloak/chart/tests/oidc-kubectl-client.sh
+++ b/platform/keycloak/chart/tests/oidc-kubectl-client.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# bp-keycloak OIDC kubectl-client integration test (issue #326).
+#
+# Verifies the kubectl OIDC client + sovereign realm are wired through
+# the canonical keycloakConfigCli seam:
+#
+#   1. The post-install/post-upgrade/post-rollback Helm hook Job
+#      `*-keycloak-keycloak-config-cli` is rendered (config-cli is enabled).
+#   2. The ConfigMap carrying the realm payload contains a `kubectl`
+#      client with publicClient=true and the localhost:8000 redirect URI
+#      kubectl-oidc-login uses by default.
+#   3. The realm name is `sovereign` — invariant per Sovereign so the
+#      api-server's --oidc-issuer-url flag (in
+#      infra/hetzner/cloudinit-control-plane.tftpl) resolves consistently.
+#   4. The `groups` claim mapper is present so the api-server's
+#      --oidc-groups-claim flag binds id-token groups to RoleBinding
+#      subjects (oidc:<group> per --oidc-groups-prefix).
+#
+# Companion to docs/omantel-handover-wbs.md §11 "kubectl OIDC for
+# customer admins" — those runbook commands assume the realm + client
+# this chart ships, so this test guards against silent drift.
+
+set -euo pipefail
+
+CHART_DIR="${1:-$(cd "$(dirname "$0")/.." && pwd)}"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+cd "$CHART_DIR"
+if [ ! -d charts ] || [ -z "$(ls -A charts 2>/dev/null)" ]; then
+  helm dependency build >/dev/null
+fi
+
+echo "[oidc-kubectl-client] Case 1: default render contains keycloak-config-cli post-install Job"
+helm template smoke-kc . > "$TMP/default.yaml"
+if ! grep -q 'helm.sh/hook: post-install,post-upgrade,post-rollback' "$TMP/default.yaml"; then
+  echo "FAIL: default render does not contain a keycloak-config-cli post-install Helm hook." >&2
+  exit 1
+fi
+if ! grep -q 'name: smoke-kc-keycloak-keycloak-config-cli$' "$TMP/default.yaml"; then
+  echo "FAIL: default render does not contain the keycloak-config-cli Job by expected name." >&2
+  exit 1
+fi
+echo "  PASS"
+
+echo "[oidc-kubectl-client] Case 2: realm 'sovereign' is shipped"
+if ! grep -q '"realm": "sovereign"' "$TMP/default.yaml"; then
+  echo "FAIL: default render does not declare realm 'sovereign'. The k3s api-server" >&2
+  echo "       --oidc-issuer-url flag points at /realms/sovereign so this realm name" >&2
+  echo "       is INVARIANT — do not rename without coordinating with" >&2
+  echo "       infra/hetzner/cloudinit-control-plane.tftpl." >&2
+  exit 1
+fi
+echo "  PASS"
+
+echo "[oidc-kubectl-client] Case 3: kubectl client is shipped with publicClient + localhost:8000 redirect"
+if ! grep -q '"clientId": "kubectl"' "$TMP/default.yaml"; then
+  echo "FAIL: default render does not contain a Keycloak Client with clientId=kubectl." >&2
+  exit 1
+fi
+if ! grep -q '"publicClient": true' "$TMP/default.yaml"; then
+  echo "FAIL: default render's kubectl client is not declared publicClient=true." >&2
+  echo "       kubectl-oidc-login runs locally on the operator's machine and cannot" >&2
+  echo "       safely hold a client secret." >&2
+  exit 1
+fi
+if ! grep -q '"http://localhost:8000"' "$TMP/default.yaml"; then
+  echo "FAIL: default render's kubectl client does not list http://localhost:8000 as a redirect URI." >&2
+  exit 1
+fi
+echo "  PASS"
+
+echo "[oidc-kubectl-client] Case 4: groups claim mapper is wired"
+if ! grep -q '"protocolMapper": "oidc-group-membership-mapper"' "$TMP/default.yaml"; then
+  echo "FAIL: default render does not contain the oidc-group-membership-mapper. The" >&2
+  echo "       api-server's --oidc-groups-claim flag depends on the id-token carrying" >&2
+  echo "       the 'groups' claim." >&2
+  exit 1
+fi
+if ! grep -q '"claim.name": "groups"' "$TMP/default.yaml"; then
+  echo "FAIL: default render's group mapper does not emit the 'groups' claim name." >&2
+  exit 1
+fi
+echo "  PASS"
+
+echo "[oidc-kubectl-client] All bp-keycloak OIDC-kubectl-client gates green."

--- a/platform/keycloak/chart/values.yaml
+++ b/platform/keycloak/chart/values.yaml
@@ -38,11 +38,6 @@ keycloak:
     registry: docker.io
     repository: bitnamilegacy/keycloak
     tag: 26.3.3-debian-12-r0
-  keycloakConfigCli:
-    image:
-      registry: docker.io
-      repository: bitnamilegacy/keycloak-config-cli
-      tag: 6.4.0-debian-12-r11
   postgresql:
     enabled: true
     auth:
@@ -67,6 +62,136 @@ keycloak:
   resources:
     requests: { cpu: 250m, memory: 512Mi }
     limits: { memory: 2Gi }
+  # ─── keycloak-config-cli: Sovereign realm + kubectl OIDC client (issue #326) ──
+  #
+  # Bootstrap a `sovereign` realm with a public OIDC client `kubectl` so
+  # customer admins on the Sovereign can authenticate `kubectl` against
+  # the per-Sovereign K8s api-server (k3s --kube-apiserver-arg=oidc-* in
+  # infra/hetzner/cloudinit-control-plane.tftpl). The k3s api-server
+  # validates id-tokens issued by `https://auth.<sovereign-fqdn>/realms/
+  # sovereign`, so the realm name is invariant per Sovereign — only the
+  # issuer hostname differs (Keycloak resolves the issuer claim from the
+  # request hostname automatically; no per-Sovereign realm rename needed).
+  #
+  # Why this is the canonical seam:
+  #   The bitnami/keycloak chart ships a post-deploy Job
+  #   (templates/keycloak-config-cli-job.yaml) that consumes
+  #   `keycloakConfigCli.configuration` as a ConfigMap and runs upstream
+  #   `keycloak-config-cli` against the Keycloak Admin API to import the
+  #   realm. This is the upstream-supported, idempotent realm-import
+  #   mechanism — re-running the Helm install on the same release is a
+  #   no-op once the realm exists. Per anti-duplication rule + ADR-0001
+  #   §11.3 we MUST NOT replace this with a bespoke kubectl-exec script
+  #   or a custom Admin-API call from catalyst-api.
+  #
+  # `kubectl` client shape:
+  #   - publicClient: true (no client secret — kubectl runs locally)
+  #   - standardFlowEnabled: true (browser auth-code → localhost:8000)
+  #   - directAccessGrantsEnabled: true (allows resource-owner password
+  #     grant for non-interactive CI/CD use; customer admins can disable)
+  #   - redirectUris: ["http://localhost:8000/*", "urn:ietf:wg:oauth:2.0:oob"]
+  #     (kubectl-oidc-login default callback + out-of-band fallback)
+  #   - protocolMappers: include `groups` claim in id-token so api-server
+  #     can apply group-based RoleBindings (oidc:<group> prefix per
+  #     k3s --oidc-groups-prefix flag)
+  keycloakConfigCli:
+    enabled: true
+    # Run the realm-import Job as a Helm post-install hook so the realm
+    # is provisioned exactly once per fresh release. Re-run on upgrade
+    # is idempotent (config-cli reconciles the realm to spec).
+    image:
+      registry: docker.io
+      repository: bitnamilegacy/keycloak-config-cli
+      tag: 6.4.0-debian-12-r11
+    configuration:
+      sovereign-realm.json: |
+        {
+          "realm": "sovereign",
+          "enabled": true,
+          "displayName": "Sovereign",
+          "sslRequired": "external",
+          "registrationAllowed": false,
+          "loginWithEmailAllowed": true,
+          "duplicateEmailsAllowed": false,
+          "resetPasswordAllowed": true,
+          "editUsernameAllowed": false,
+          "bruteForceProtected": true,
+          "accessTokenLifespan": 900,
+          "ssoSessionIdleTimeout": 1800,
+          "ssoSessionMaxLifespan": 28800,
+          "defaultGroups": [
+            "/sovereign-viewers"
+          ],
+          "groups": [
+            { "name": "sovereign-admins" },
+            { "name": "sovereign-ops" },
+            { "name": "sovereign-viewers" }
+          ],
+          "clientScopes": [
+            {
+              "name": "groups",
+              "protocol": "openid-connect",
+              "attributes": {
+                "include.in.token.scope": "true",
+                "display.on.consent.screen": "true"
+              },
+              "protocolMappers": [
+                {
+                  "name": "groups",
+                  "protocol": "openid-connect",
+                  "protocolMapper": "oidc-group-membership-mapper",
+                  "consentRequired": false,
+                  "config": {
+                    "full.path": "false",
+                    "id.token.claim": "true",
+                    "access.token.claim": "true",
+                    "claim.name": "groups",
+                    "userinfo.token.claim": "true"
+                  }
+                }
+              ]
+            }
+          ],
+          "clients": [
+            {
+              "clientId": "kubectl",
+              "name": "kubectl (per-Sovereign K8s api-server OIDC client)",
+              "description": "Public OIDC client used by customer admins to authenticate kubectl against the Sovereign's k3s api-server (issue #326).",
+              "enabled": true,
+              "publicClient": true,
+              "standardFlowEnabled": true,
+              "directAccessGrantsEnabled": true,
+              "implicitFlowEnabled": false,
+              "serviceAccountsEnabled": false,
+              "redirectUris": [
+                "http://localhost:8000",
+                "http://localhost:8000/*",
+                "urn:ietf:wg:oauth:2.0:oob"
+              ],
+              "webOrigins": [
+                "+"
+              ],
+              "defaultClientScopes": [
+                "web-origins",
+                "acr",
+                "profile",
+                "roles",
+                "email",
+                "groups"
+              ],
+              "optionalClientScopes": [
+                "address",
+                "phone",
+                "offline_access",
+                "microprofile-jwt"
+              ],
+              "attributes": {
+                "pkce.code.challenge.method": "S256",
+                "access.token.lifespan": "900"
+              }
+            }
+          ]
+        }
   # Metrics + ServiceMonitor + PrometheusRule — DEFAULT OFF.
   #
   # Per docs/INVIOLABLE-PRINCIPLES.md #4 and docs/BLUEPRINT-AUTHORING.md


### PR DESCRIPTION
## Summary

Wires the per-Sovereign K8s api-server's `--oidc-*` validator to the per-Sovereign Keycloak realm so customer admins authenticate `kubectl` directly against their Sovereign — no static admin-kubeconfig handoff, no rotated bearer-token exchange.

## Scope (per agent brief)

- `infra/hetzner/cloudinit-control-plane.tftpl` — k3s OIDC flags
- `platform/keycloak/chart/` — `kubectl` OIDC client + sovereign realm via canonical `keycloakConfigCli` seam

NOT touched (other agents' territories): `core/pool-domain-manager/` (#319), `platform/crossplane-claims/` (#322), `products/catalyst/bootstrap/{api,ui}/` (#323).

## Changes

**Cloud-init (infra/hetzner/cloudinit-control-plane.tftpl):**
- Append 6 `--kube-apiserver-arg=oidc-*` flags to the k3s `INSTALL_K3S_EXEC` line.
- Issuer URL composed from `sovereign_fqdn` (`https://auth.${sovereign_fqdn}/realms/sovereign`) per INVIOLABLE-PRINCIPLES #4.
- Username/groups prefixes scope OIDC subjects under `oidc:` (api-server enforces this; RoleBindings then reference `oidc:<sub>`/`oidc:<group>`).

**bp-keycloak chart (1.1.2 → 1.2.0):**
- Enable `keycloakConfigCli` + ship inline `sovereign-realm.json` (canonical seam: bitnami chart's existing post-install Helm hook Job).
- Realm `sovereign` (invariant per Sovereign — Keycloak resolves issuer claim from the request hostname).
- Default groups `sovereign-admins`/`sovereign-ops`/`sovereign-viewers`.
- `oidc-group-membership-mapper` emitting `groups` claim.
- Public OIDC client `kubectl` with `http://localhost:8000` + OOB redirect URIs (kubectl-oidc-login defaults), `publicClient: true`, PKCE S256.
- Bump bootstrap-kit slot 09 in `_template/`, `omantel.omani.works/`, `otech.omani.works/`.

**Tests:**
- New `platform/keycloak/chart/tests/oidc-kubectl-client.sh` (4 cases) — all green.
- Existing `tests/observability-toggle.sh` — still green.

**Documentation:**
- `docs/omantel-handover-wbs.md` §11 "kubectl OIDC for customer admins" — runbook + RBAC binding + 401 debugging table.
- §9 status row added; §7 "Out of scope" updated to carve #326 out.

## Validation

```
grep -c 'oidc-issuer-url'       infra/hetzner/cloudinit-control-plane.tftpl  → 2
grep -c 'oidc-username-claim'   infra/hetzner/cloudinit-control-plane.tftpl  → 2
helm template platform/keycloak/chart → kubectl client present (1× clientId match)
bash platform/keycloak/chart/tests/observability-toggle.sh   → PASS (3/3)
bash platform/keycloak/chart/tests/oidc-kubectl-client.sh    → PASS (4/4)
bash scripts/check-vendor-coupling.sh                        → exit 0 (HARD-FAIL mode)
```

## Test plan

- [x] Helm template the chart with default values — kubectl client + sovereign realm rendered
- [x] Vendor-coupling guardrail green (HARD-FAIL mode)
- [x] New oidc-kubectl-client chart test green (4 gates)
- [x] Existing observability-toggle chart test still green
- [ ] Live verification deferred to Phase 8 (first omantel.omani.works run via #429 workflow)

## Out of scope (deferred)

- Per-Sovereign user provisioning UI (#322, #323)
- Refresh-token revocation hook on RoleBinding deletion (#324)
- `provider-kubernetes` Crossplane ProviderConfig per Sovereign (#321)
- Live execution against omantel — Phase 8 DoD