### PR TITLE
feat(catalyst): user-access editor REST + console UI for Sovereign IAM (closes #323)

### DIFF
--- a/products/catalyst/bootstrap/api/cmd/api/main.go
+++ b/products/catalyst/bootstrap/api/cmd/api/main.go
@@ -224,6 +224,18 @@ func main() {
 	r.Post("/api/v1/deployments/{depId}/infrastructure/nodes/{id}/{action}", h.CreateInfrastructureNodeAction)
 	r.Delete("/api/v1/deployments/{depId}/infrastructure/{kind}/{id}", h.DeleteInfrastructureResource)
 
+	// Sovereign IAM — UserAccess CR editor (issue #323). The UI's
+	// /sovereign/users page calls these endpoints to list / create /
+	// update / delete UserAccess CRs against the Sovereign cluster.
+	// The CRD shape (`access.openova.io/v1alpha1`) is shipped by
+	// issue #322's chart; catalyst-api consumes it via dynamic
+	// client so there's no Go-type build dependency between the
+	// two PRs.
+	r.Get("/api/v1/deployments/{depId}/admin/user-access", h.ListUserAccess)
+	r.Post("/api/v1/deployments/{depId}/admin/user-access", h.CreateUserAccess)
+	r.Put("/api/v1/deployments/{depId}/admin/user-access/{name}", h.UpdateUserAccess)
+	r.Delete("/api/v1/deployments/{depId}/admin/user-access/{name}", h.DeleteUserAccess)
+
 	log.Info("catalyst api listening", "port", port)
 	if err := http.ListenAndServe(":"+port, r); err != nil {
 		log.Error("server error", "err", err)

--- a/products/catalyst/bootstrap/api/internal/handler/user_access.go
+++ b/products/catalyst/bootstrap/api/internal/handler/user_access.go
@@ -1,0 +1,506 @@
+// Package handler — user_access.go: REST surface for the Sovereign IAM
+// User-Access editor (issue #323).
+//
+// CRUD endpoints over the UserAccess Claim shape shipped by issue
+// #322 (`access.openova.io/v1alpha1`):
+//
+//	GET    /api/v1/deployments/{depId}/admin/user-access
+//	POST   /api/v1/deployments/{depId}/admin/user-access
+//	PUT    /api/v1/deployments/{depId}/admin/user-access/{name}
+//	DELETE /api/v1/deployments/{depId}/admin/user-access/{name}
+//
+// Per docs/INVIOLABLE-PRINCIPLES.md #3 (Crossplane is the ONLY day-2
+// IaC, no bespoke kubectl-apply of RoleBindings) every mutation
+// is expressed as a UserAccess Claim write against the SOVEREIGN
+// cluster's dynamic client. The Crossplane Composition shipped by
+// #322 (useraccess.compose.openova.io) reconciles the claim into
+// per-(application × namespace × role) RoleBindings via
+// provider-kubernetes.
+//
+// # Shape (canonical, post #322 merge)
+//
+//	apiVersion: access.openova.io/v1alpha1
+//	kind: UserAccess          # cluster-scoped
+//	spec:
+//	  user:
+//	    keycloakSubject: <oidc-sub>     # one OR
+//	    keycloakGroups: [<group>, ...]  # the other (or both)
+//	  sovereignRef: <slug>              # selects provider-kubernetes ProviderConfig
+//	  applications:
+//	    - app: helmwatch
+//	      role: editor                  # admin | editor | viewer
+//	      namespaces: [...]             # optional; api expands when empty
+//	      vClusters: [...]              # optional; rendered as vcluster-<name>
+//
+// # Why dynamic, not typed
+//
+// The CRD shape (#322) is consumed cross-repo via dynamic client by
+// API path so catalyst-api carries no Go-type dependency on #322's
+// chart. This matches the same seam infrastructure.go uses for the
+// XRC kinds.
+//
+// # Anti-duplication seam
+//
+// This handler reuses the `sovereignDynamicClient(dep)` seam already
+// established in infrastructure.go (line 1557). It does NOT duplicate
+// the kubeconfig-read logic. Same `dynamicFactory` test injection
+// path infrastructure_crud_test.go uses.
+package handler
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+)
+
+// UserAccess CR group/version/resource (#322 shape — the Claim
+// surface, not the underlying XR).
+const (
+	userAccessGroup    = "access.openova.io"
+	userAccessVersion  = "v1alpha1"
+	userAccessResource = "useraccesses"
+)
+
+// UserAccessGVR — exposed for tests so the fake dynamic client can
+// register the matching list-kind.
+func UserAccessGVR() schema.GroupVersionResource {
+	return schema.GroupVersionResource{
+		Group:    userAccessGroup,
+		Version:  userAccessVersion,
+		Resource: userAccessResource,
+	}
+}
+
+// userAccessRoles — the three role short-forms the CRD's openAPIV3
+// `enum` allows. The Composition (#322) rewrites these to the
+// canonical openova:application-<role> ClusterRole names; the
+// catalyst-api accepts only the short form on writes.
+var userAccessRoles = map[string]struct{}{
+	"admin":  {},
+	"editor": {},
+	"viewer": {},
+}
+
+/* ── Wire shapes — match the CRD .spec verbatim ─────────────────── */
+
+type userAccessRequest struct {
+	Name string             `json:"name"`
+	Spec userAccessSpecBody `json:"spec"`
+}
+
+type userAccessSpecBody struct {
+	User         userAccessUserBody       `json:"user"`
+	SovereignRef string                   `json:"sovereignRef"`
+	Applications []userAccessAppGrantBody `json:"applications"`
+}
+
+type userAccessUserBody struct {
+	KeycloakSubject string   `json:"keycloakSubject,omitempty"`
+	KeycloakGroups  []string `json:"keycloakGroups,omitempty"`
+}
+
+type userAccessAppGrantBody struct {
+	App        string   `json:"app"`
+	Role       string   `json:"role"`
+	Namespaces []string `json:"namespaces,omitempty"`
+	VClusters  []string `json:"vClusters,omitempty"`
+}
+
+type userAccessItem struct {
+	Name              string                  `json:"name"`
+	Spec              userAccessSpecBody      `json:"spec"`
+	Status            *userAccessStatusBody   `json:"status,omitempty"`
+	CreationTimestamp string                  `json:"creationTimestamp,omitempty"`
+}
+
+type userAccessStatusBody struct {
+	RolebindingsCreated int    `json:"rolebindingsCreated"`
+	ProviderConfigRef   string `json:"providerConfigRef,omitempty"`
+}
+
+type userAccessListResponse struct {
+	Items []userAccessItem `json:"items"`
+}
+
+/* ── HTTP handlers ──────────────────────────────────────────────── */
+
+// ListUserAccess — GET .../admin/user-access
+func (h *Handler) ListUserAccess(w http.ResponseWriter, r *http.Request) {
+	depID := chi.URLParam(r, "depId")
+	dep, ok := h.lookupDeploymentForInfra(depID)
+	if !ok {
+		writeNotFound(w, depID)
+		return
+	}
+	client, err := h.sovereignDynamicClient(dep)
+	if err != nil {
+		writeUserAccessUnavailable(w, err)
+		return
+	}
+	// UserAccess Claims are cluster-scoped per the CRD definition
+	// (`spec.scope` is the default `Namespaced`-equivalent for
+	// Crossplane Claims, but the XRD declares it cluster-scoped via
+	// the absence of a `Namespaced` claim type — see the chart's
+	// xrds/useraccess.yaml). We list across the cluster and namespace
+	// is preserved in the metadata for any caller that wants it.
+	listIface, err := client.Resource(UserAccessGVR()).Namespace("").List(r.Context(), metav1.ListOptions{})
+	if err != nil {
+		h.log.Warn("user-access: list failed", "depId", depID, "err", err)
+		writeJSON(w, http.StatusInternalServerError, map[string]string{
+			"error":  "list-failed",
+			"detail": err.Error(),
+		})
+		return
+	}
+	out := userAccessListResponse{Items: make([]userAccessItem, 0, len(listIface.Items))}
+	for i := range listIface.Items {
+		out.Items = append(out.Items, unstructuredToUserAccess(&listIface.Items[i]))
+	}
+	writeJSON(w, http.StatusOK, out)
+}
+
+// CreateUserAccess — POST .../admin/user-access
+func (h *Handler) CreateUserAccess(w http.ResponseWriter, r *http.Request) {
+	depID := chi.URLParam(r, "depId")
+	dep, ok := h.lookupDeploymentForInfra(depID)
+	if !ok {
+		writeNotFound(w, depID)
+		return
+	}
+	var body userAccessRequest
+	if !decodeMutationBody(w, r, &body) {
+		return
+	}
+	if msg, ok := validateUserAccess(body); !ok {
+		writeBadRequest(w, "invalid-user-access", msg)
+		return
+	}
+	client, err := h.sovereignDynamicClient(dep)
+	if err != nil {
+		writeUserAccessUnavailable(w, err)
+		return
+	}
+	obj := userAccessToUnstructured(body)
+	created, err := client.Resource(UserAccessGVR()).Namespace("").Create(r.Context(), obj, metav1.CreateOptions{})
+	if err != nil {
+		if apierrors.IsAlreadyExists(err) {
+			writeJSON(w, http.StatusConflict, map[string]string{
+				"error":  "user-access-name-conflict",
+				"detail": "useraccess " + body.Name + " already exists",
+			})
+			return
+		}
+		h.log.Warn("user-access: create failed", "depId", depID, "err", err)
+		writeJSON(w, http.StatusInternalServerError, map[string]string{
+			"error":  "create-failed",
+			"detail": err.Error(),
+		})
+		return
+	}
+	writeJSON(w, http.StatusCreated, unstructuredToUserAccess(created))
+}
+
+// UpdateUserAccess — PUT .../admin/user-access/{name}
+//
+// Replace-style update: the handler reads the current Claim, swaps
+// in the request's spec (preserving resourceVersion so concurrent
+// edits surface as 409), and writes back.
+func (h *Handler) UpdateUserAccess(w http.ResponseWriter, r *http.Request) {
+	depID := chi.URLParam(r, "depId")
+	name := chi.URLParam(r, "name")
+	dep, ok := h.lookupDeploymentForInfra(depID)
+	if !ok {
+		writeNotFound(w, depID)
+		return
+	}
+	if strings.TrimSpace(name) == "" {
+		writeBadRequest(w, "name-required", "useraccess name is required")
+		return
+	}
+	var body userAccessRequest
+	if !decodeMutationBody(w, r, &body) {
+		return
+	}
+	body.Name = name
+	if msg, ok := validateUserAccess(body); !ok {
+		writeBadRequest(w, "invalid-user-access", msg)
+		return
+	}
+	client, err := h.sovereignDynamicClient(dep)
+	if err != nil {
+		writeUserAccessUnavailable(w, err)
+		return
+	}
+	current, err := client.Resource(UserAccessGVR()).Namespace("").Get(r.Context(), name, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			writeJSON(w, http.StatusNotFound, map[string]string{
+				"error":  "user-access-not-found",
+				"detail": "no useraccess with name " + name,
+			})
+			return
+		}
+		writeJSON(w, http.StatusInternalServerError, map[string]string{
+			"error":  "get-failed",
+			"detail": err.Error(),
+		})
+		return
+	}
+	desired := userAccessToUnstructured(body)
+	desired.SetResourceVersion(current.GetResourceVersion())
+	desired.SetUID(current.GetUID())
+	updated, err := client.Resource(UserAccessGVR()).Namespace("").Update(r.Context(), desired, metav1.UpdateOptions{})
+	if err != nil {
+		if apierrors.IsConflict(err) {
+			writeJSON(w, http.StatusConflict, map[string]string{
+				"error":  "concurrent-edit",
+				"detail": "the useraccess was modified by another writer; refresh and retry",
+			})
+			return
+		}
+		writeJSON(w, http.StatusInternalServerError, map[string]string{
+			"error":  "update-failed",
+			"detail": err.Error(),
+		})
+		return
+	}
+	writeJSON(w, http.StatusOK, unstructuredToUserAccess(updated))
+}
+
+// DeleteUserAccess — DELETE .../admin/user-access/{name}
+func (h *Handler) DeleteUserAccess(w http.ResponseWriter, r *http.Request) {
+	depID := chi.URLParam(r, "depId")
+	name := chi.URLParam(r, "name")
+	dep, ok := h.lookupDeploymentForInfra(depID)
+	if !ok {
+		writeNotFound(w, depID)
+		return
+	}
+	if strings.TrimSpace(name) == "" {
+		writeBadRequest(w, "name-required", "useraccess name is required")
+		return
+	}
+	client, err := h.sovereignDynamicClient(dep)
+	if err != nil {
+		writeUserAccessUnavailable(w, err)
+		return
+	}
+	if err := tryDeleteUserAccess(r.Context(), client, name); err != nil {
+		if errors.Is(err, errUserAccessNotFound) {
+			writeJSON(w, http.StatusNotFound, map[string]string{
+				"error":  "user-access-not-found",
+				"detail": "no useraccess with name " + name,
+			})
+			return
+		}
+		h.log.Warn("user-access: delete failed", "depId", depID, "err", err)
+		writeJSON(w, http.StatusInternalServerError, map[string]string{
+			"error":  "delete-failed",
+			"detail": err.Error(),
+		})
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+/* ── helpers ───────────────────────────────────────────────────── */
+
+var errUserAccessNotFound = errors.New("user-access: not found")
+
+// tryDeleteUserAccess deletes the named cluster-scoped Claim.
+// Returns errUserAccessNotFound on miss so the caller can map onto
+// HTTP 404. We do not need to walk the list since the Claim is
+// cluster-scoped — the apiserver returns NotFound directly for an
+// unknown name.
+func tryDeleteUserAccess(ctx context.Context, client dynamic.Interface, name string) error {
+	policy := metav1.DeletePropagationForeground
+	err := client.Resource(UserAccessGVR()).Namespace("").Delete(ctx, name, metav1.DeleteOptions{
+		PropagationPolicy: &policy,
+	})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return errUserAccessNotFound
+		}
+		return err
+	}
+	return nil
+}
+
+func validateUserAccess(req userAccessRequest) (string, bool) {
+	if strings.TrimSpace(req.Name) == "" {
+		return "name is required", false
+	}
+	// At least one of keycloakSubject or keycloakGroups must be set
+	// (mirrors the CRD's "either or both" semantics).
+	subject := strings.TrimSpace(req.Spec.User.KeycloakSubject)
+	hasGroups := false
+	for _, g := range req.Spec.User.KeycloakGroups {
+		if strings.TrimSpace(g) != "" {
+			hasGroups = true
+			break
+		}
+	}
+	if subject == "" && !hasGroups {
+		return "spec.user must set keycloakSubject and/or keycloakGroups", false
+	}
+	if strings.TrimSpace(req.Spec.SovereignRef) == "" {
+		return "spec.sovereignRef is required", false
+	}
+	if len(req.Spec.Applications) == 0 {
+		return "spec.applications must contain at least one entry", false
+	}
+	for i, app := range req.Spec.Applications {
+		if strings.TrimSpace(app.App) == "" {
+			return "spec.applications[*].app is required", false
+		}
+		if _, ok := userAccessRoles[app.Role]; !ok {
+			return "spec.applications[" + itoa(i) + "].role must be one of admin, editor, viewer", false
+		}
+	}
+	return "", true
+}
+
+// userAccessToUnstructured composes the dynamic-client payload from
+// the request body.
+func userAccessToUnstructured(req userAccessRequest) *unstructured.Unstructured {
+	obj := &unstructured.Unstructured{}
+	obj.SetAPIVersion(userAccessGroup + "/" + userAccessVersion)
+	obj.SetKind("UserAccess")
+	obj.SetName(req.Name)
+
+	user := map[string]any{}
+	if s := strings.TrimSpace(req.Spec.User.KeycloakSubject); s != "" {
+		user["keycloakSubject"] = s
+	}
+	if len(req.Spec.User.KeycloakGroups) > 0 {
+		groups := make([]any, 0, len(req.Spec.User.KeycloakGroups))
+		for _, g := range req.Spec.User.KeycloakGroups {
+			if g = strings.TrimSpace(g); g != "" {
+				groups = append(groups, g)
+			}
+		}
+		if len(groups) > 0 {
+			user["keycloakGroups"] = groups
+		}
+	}
+
+	apps := make([]any, 0, len(req.Spec.Applications))
+	for _, app := range req.Spec.Applications {
+		entry := map[string]any{
+			"app":  app.App,
+			"role": app.Role,
+		}
+		if len(app.Namespaces) > 0 {
+			ns := make([]any, 0, len(app.Namespaces))
+			for _, n := range app.Namespaces {
+				if n = strings.TrimSpace(n); n != "" {
+					ns = append(ns, n)
+				}
+			}
+			if len(ns) > 0 {
+				entry["namespaces"] = ns
+			}
+		}
+		if len(app.VClusters) > 0 {
+			vcs := make([]any, 0, len(app.VClusters))
+			for _, v := range app.VClusters {
+				if v = strings.TrimSpace(v); v != "" {
+					vcs = append(vcs, v)
+				}
+			}
+			if len(vcs) > 0 {
+				entry["vClusters"] = vcs
+			}
+		}
+		apps = append(apps, entry)
+	}
+
+	spec := map[string]any{
+		"user":         user,
+		"sovereignRef": req.Spec.SovereignRef,
+		"applications": apps,
+	}
+	_ = unstructured.SetNestedMap(obj.Object, spec, "spec")
+	return obj
+}
+
+func unstructuredToUserAccess(u *unstructured.Unstructured) userAccessItem {
+	out := userAccessItem{
+		Name: u.GetName(),
+	}
+	if ts := u.GetCreationTimestamp(); !ts.IsZero() {
+		out.CreationTimestamp = ts.UTC().Format("2006-01-02T15:04:05Z")
+	}
+	if user, ok, _ := unstructured.NestedMap(u.Object, "spec", "user"); ok {
+		if v, ok := user["keycloakSubject"].(string); ok {
+			out.Spec.User.KeycloakSubject = v
+		}
+		if raw, ok := user["keycloakGroups"].([]any); ok {
+			groups := make([]string, 0, len(raw))
+			for _, g := range raw {
+				if gs, ok := g.(string); ok {
+					groups = append(groups, gs)
+				}
+			}
+			out.Spec.User.KeycloakGroups = groups
+		}
+	}
+	if v, ok, _ := unstructured.NestedString(u.Object, "spec", "sovereignRef"); ok {
+		out.Spec.SovereignRef = v
+	}
+	if rawApps, ok, _ := unstructured.NestedSlice(u.Object, "spec", "applications"); ok {
+		apps := make([]userAccessAppGrantBody, 0, len(rawApps))
+		for _, raw := range rawApps {
+			m, ok := raw.(map[string]any)
+			if !ok {
+				continue
+			}
+			entry := userAccessAppGrantBody{}
+			if v, ok := m["app"].(string); ok {
+				entry.App = v
+			}
+			if v, ok := m["role"].(string); ok {
+				entry.Role = v
+			}
+			if rawNs, ok := m["namespaces"].([]any); ok {
+				for _, n := range rawNs {
+					if ns, ok := n.(string); ok {
+						entry.Namespaces = append(entry.Namespaces, ns)
+					}
+				}
+			}
+			if rawVcs, ok := m["vClusters"].([]any); ok {
+				for _, v := range rawVcs {
+					if vs, ok := v.(string); ok {
+						entry.VClusters = append(entry.VClusters, vs)
+					}
+				}
+			}
+			apps = append(apps, entry)
+		}
+		out.Spec.Applications = apps
+	}
+	if rb, ok, _ := unstructured.NestedInt64(u.Object, "status", "rolebindingsCreated"); ok {
+		st := userAccessStatusBody{RolebindingsCreated: int(rb)}
+		if pcr, ok, _ := unstructured.NestedString(u.Object, "status", "providerConfigRef"); ok {
+			st.ProviderConfigRef = pcr
+		}
+		out.Status = &st
+	}
+	return out
+}
+
+func writeUserAccessUnavailable(w http.ResponseWriter, err error) {
+	writeJSON(w, http.StatusServiceUnavailable, map[string]string{
+		"error":  "sovereign-cluster-unreachable",
+		"detail": err.Error(),
+	})
+}

--- a/products/catalyst/bootstrap/api/internal/handler/user_access_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/user_access_test.go
@@ -1,0 +1,576 @@
+// user_access_test.go — coverage for the UserAccess Claim CRUD
+// endpoints (issue #323). Mirrors the infrastructure_crud_test.go
+// pattern: a fake dynamic client seeded with the UserAccess GVR's
+// list-kind, an installed Deployment with a temp-file kubeconfig
+// path so sovereignDynamicClient resolves, and a per-test chi router
+// that registers only the endpoint under test.
+package handler
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/provisioner"
+)
+
+func userAccessListKinds() map[schema.GroupVersionResource]string {
+	return map[schema.GroupVersionResource]string{
+		UserAccessGVR(): "UserAccessList",
+	}
+}
+
+func fakeUserAccessDynamicFactory(seed ...runtime.Object) (func(string) (dynamic.Interface, error), *dynamicfake.FakeDynamicClient) {
+	scheme := runtime.NewScheme()
+	client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, userAccessListKinds(), seed...)
+	return func(_ string) (dynamic.Interface, error) {
+		return client, nil
+	}, client
+}
+
+func installUserAccessDeployment(t *testing.T, h *Handler, id string) *Deployment {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), id+".yaml")
+	if err := os.WriteFile(path, []byte("apiVersion: v1\nkind: Config"), 0o600); err != nil {
+		t.Fatalf("write kubeconfig: %v", err)
+	}
+	dep := &Deployment{
+		ID:     id,
+		Status: "ready",
+		Request: provisioner.Request{
+			SovereignFQDN: "omantel.omani.works",
+		},
+		Result: &provisioner.Result{
+			SovereignFQDN:  "omantel.omani.works",
+			KubeconfigPath: path,
+		},
+		mu: sync.Mutex{},
+	}
+	h.deployments.Store(id, dep)
+	return dep
+}
+
+// newUserAccessUnstructured composes a sample UserAccess Claim
+// matching the canonical #322 shape — sovereignRef + applications
+// list with one app/role/namespaces grant.
+func newUserAccessUnstructured(name, sovereign, subject, app, role, ns string) *unstructured.Unstructured {
+	u := &unstructured.Unstructured{}
+	u.SetAPIVersion("access.openova.io/v1alpha1")
+	u.SetKind("UserAccess")
+	u.SetName(name)
+	user := map[string]any{}
+	if subject != "" {
+		user["keycloakSubject"] = subject
+	}
+	apps := []any{
+		map[string]any{
+			"app":        app,
+			"role":       role,
+			"namespaces": []any{ns},
+		},
+	}
+	_ = unstructured.SetNestedMap(u.Object, map[string]any{
+		"user":         user,
+		"sovereignRef": sovereign,
+		"applications": apps,
+	}, "spec")
+	return u
+}
+
+func callUserAccess(t *testing.T, h *Handler, method, path string, body any, register func(r chi.Router, h *Handler)) *httptest.ResponseRecorder {
+	t.Helper()
+	r := chi.NewRouter()
+	register(r, h)
+	var buf *bytes.Buffer
+	if body != nil {
+		raw, err := json.Marshal(body)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		buf = bytes.NewBuffer(raw)
+	} else {
+		buf = bytes.NewBuffer(nil)
+	}
+	req := httptest.NewRequest(method, path, buf)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	return rec
+}
+
+func registerUserAccessRoutes(r chi.Router, h *Handler) {
+	r.Get("/api/v1/deployments/{depId}/admin/user-access", h.ListUserAccess)
+	r.Post("/api/v1/deployments/{depId}/admin/user-access", h.CreateUserAccess)
+	r.Put("/api/v1/deployments/{depId}/admin/user-access/{name}", h.UpdateUserAccess)
+	r.Delete("/api/v1/deployments/{depId}/admin/user-access/{name}", h.DeleteUserAccess)
+}
+
+/* ── GET (list) ────────────────────────────────────────────────── */
+
+func TestListUserAccess_Empty(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	factory, _ := fakeUserAccessDynamicFactory()
+	h.dynamicFactory = factory
+	dep := installUserAccessDeployment(t, h, "dep-ua-list-empty")
+
+	rec := callUserAccess(t, h, http.MethodGet,
+		"/api/v1/deployments/"+dep.ID+"/admin/user-access", nil, registerUserAccessRoutes)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	var out userAccessListResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(out.Items) != 0 {
+		t.Fatalf("expected empty list; got %d items", len(out.Items))
+	}
+}
+
+func TestListUserAccess_Populated(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	seed := []runtime.Object{
+		newUserAccessUnstructured("alice-helmwatch", "omantel", "alice", "helmwatch", "editor", "tenant-foo"),
+		newUserAccessUnstructured("bob-platform", "omantel", "bob", "catalyst", "admin", "catalyst"),
+	}
+	factory, _ := fakeUserAccessDynamicFactory(seed...)
+	h.dynamicFactory = factory
+	dep := installUserAccessDeployment(t, h, "dep-ua-list-populated")
+
+	rec := callUserAccess(t, h, http.MethodGet,
+		"/api/v1/deployments/"+dep.ID+"/admin/user-access", nil, registerUserAccessRoutes)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	var out userAccessListResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(out.Items) != 2 {
+		t.Fatalf("expected 2 items; got %d", len(out.Items))
+	}
+	hasAlice := false
+	hasBob := false
+	for _, it := range out.Items {
+		if it.Name == "alice-helmwatch" && it.Spec.SovereignRef == "omantel" && len(it.Spec.Applications) == 1 && it.Spec.Applications[0].App == "helmwatch" {
+			hasAlice = true
+		}
+		if it.Name == "bob-platform" && it.Spec.User.KeycloakSubject == "bob" {
+			hasBob = true
+		}
+	}
+	if !hasAlice {
+		t.Fatalf("alice-helmwatch missing from list: %+v", out.Items)
+	}
+	if !hasBob {
+		t.Fatalf("bob-platform missing from list: %+v", out.Items)
+	}
+}
+
+func TestListUserAccess_404UnknownDeployment(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	factory, _ := fakeUserAccessDynamicFactory()
+	h.dynamicFactory = factory
+	rec := callUserAccess(t, h, http.MethodGet,
+		"/api/v1/deployments/ghost/admin/user-access", nil, registerUserAccessRoutes)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status: got %d want 404; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestListUserAccess_503WhenKubeconfigMissing(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	factory, _ := fakeUserAccessDynamicFactory()
+	h.dynamicFactory = factory
+	dep := &Deployment{
+		ID:      "dep-ua-no-kubeconfig",
+		Status:  "ready",
+		Request: provisioner.Request{SovereignFQDN: "x.example"},
+		Result:  &provisioner.Result{},
+		mu:      sync.Mutex{},
+	}
+	h.deployments.Store(dep.ID, dep)
+
+	rec := callUserAccess(t, h, http.MethodGet,
+		"/api/v1/deployments/"+dep.ID+"/admin/user-access", nil, registerUserAccessRoutes)
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status: got %d want 503; body=%s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "sovereign-cluster-unreachable") {
+		t.Fatalf("expected sovereign-cluster-unreachable; got %s", rec.Body.String())
+	}
+}
+
+/* ── POST (create) ─────────────────────────────────────────────── */
+
+func TestCreateUserAccess_Happy(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	factory, client := fakeUserAccessDynamicFactory()
+	h.dynamicFactory = factory
+	dep := installUserAccessDeployment(t, h, "dep-ua-create-happy")
+
+	body := map[string]any{
+		"name": "alice-helmwatch",
+		"spec": map[string]any{
+			"user": map[string]any{
+				"keycloakSubject": "alice",
+			},
+			"sovereignRef": "omantel",
+			"applications": []map[string]any{
+				{
+					"app":        "helmwatch",
+					"role":       "editor",
+					"namespaces": []string{"tenant-foo"},
+				},
+			},
+		},
+	}
+	rec := callUserAccess(t, h, http.MethodPost,
+		"/api/v1/deployments/"+dep.ID+"/admin/user-access", body, registerUserAccessRoutes)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status: got %d want 201; body=%s", rec.Code, rec.Body.String())
+	}
+	got, err := client.Resource(UserAccessGVR()).Namespace("").Get(context.Background(), "alice-helmwatch", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get after create: %v", err)
+	}
+	role, _, _ := unstructured.NestedString(got.Object, "spec", "applications")
+	_ = role
+	apps, ok, _ := unstructured.NestedSlice(got.Object, "spec", "applications")
+	if !ok || len(apps) != 1 {
+		t.Fatalf("expected 1 application; got %v", apps)
+	}
+	first, _ := apps[0].(map[string]any)
+	if r, _ := first["role"].(string); r != "editor" {
+		t.Fatalf("role: got %q want editor", r)
+	}
+	if a, _ := first["app"].(string); a != "helmwatch" {
+		t.Fatalf("app: got %q want helmwatch", a)
+	}
+}
+
+func TestCreateUserAccess_KeycloakGroupsOnly(t *testing.T) {
+	// keycloakSubject + keycloakGroups are "either or both" per
+	// CRD; the api accepts a Claim with only groups.
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	factory, _ := fakeUserAccessDynamicFactory()
+	h.dynamicFactory = factory
+	dep := installUserAccessDeployment(t, h, "dep-ua-groups-only")
+
+	body := map[string]any{
+		"name": "ops-team",
+		"spec": map[string]any{
+			"user": map[string]any{
+				"keycloakGroups": []string{"sovereign-ops"},
+			},
+			"sovereignRef": "omantel",
+			"applications": []map[string]any{
+				{"app": "helmwatch", "role": "viewer"},
+			},
+		},
+	}
+	rec := callUserAccess(t, h, http.MethodPost,
+		"/api/v1/deployments/"+dep.ID+"/admin/user-access", body, registerUserAccessRoutes)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status: got %d want 201; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestCreateUserAccess_BadRoleRejected(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	factory, _ := fakeUserAccessDynamicFactory()
+	h.dynamicFactory = factory
+	dep := installUserAccessDeployment(t, h, "dep-ua-bad-role")
+
+	body := map[string]any{
+		"name": "alice-bogus",
+		"spec": map[string]any{
+			"user":         map[string]any{"keycloakSubject": "alice"},
+			"sovereignRef": "omantel",
+			"applications": []map[string]any{
+				{"app": "helmwatch", "role": "superuser"},
+			},
+		},
+	}
+	rec := callUserAccess(t, h, http.MethodPost,
+		"/api/v1/deployments/"+dep.ID+"/admin/user-access", body, registerUserAccessRoutes)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status: got %d want 400; body=%s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "must be one of admin, editor, viewer") {
+		t.Fatalf("expected role validation error; got %s", rec.Body.String())
+	}
+}
+
+func TestCreateUserAccess_MissingUserRejected(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	factory, _ := fakeUserAccessDynamicFactory()
+	h.dynamicFactory = factory
+	dep := installUserAccessDeployment(t, h, "dep-ua-no-user")
+
+	body := map[string]any{
+		"name": "noone",
+		"spec": map[string]any{
+			"user":         map[string]any{},
+			"sovereignRef": "omantel",
+			"applications": []map[string]any{
+				{"app": "helmwatch", "role": "viewer"},
+			},
+		},
+	}
+	rec := callUserAccess(t, h, http.MethodPost,
+		"/api/v1/deployments/"+dep.ID+"/admin/user-access", body, registerUserAccessRoutes)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status: got %d want 400; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestCreateUserAccess_409Conflict(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	existing := newUserAccessUnstructured("alice-existing", "omantel", "alice", "helmwatch", "editor", "tenant-foo")
+	factory, _ := fakeUserAccessDynamicFactory(existing)
+	h.dynamicFactory = factory
+	dep := installUserAccessDeployment(t, h, "dep-ua-409")
+
+	body := map[string]any{
+		"name": "alice-existing",
+		"spec": map[string]any{
+			"user":         map[string]any{"keycloakSubject": "alice"},
+			"sovereignRef": "omantel",
+			"applications": []map[string]any{
+				{"app": "helmwatch", "role": "editor", "namespaces": []string{"tenant-foo"}},
+			},
+		},
+	}
+	rec := callUserAccess(t, h, http.MethodPost,
+		"/api/v1/deployments/"+dep.ID+"/admin/user-access", body, registerUserAccessRoutes)
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("status: got %d want 409; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+/* ── PUT (update) ──────────────────────────────────────────────── */
+
+func TestUpdateUserAccess_Happy(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	existing := newUserAccessUnstructured("alice-helmwatch", "omantel", "alice", "helmwatch", "viewer", "tenant-foo")
+	existing.SetResourceVersion("1")
+	factory, client := fakeUserAccessDynamicFactory(existing)
+	h.dynamicFactory = factory
+	dep := installUserAccessDeployment(t, h, "dep-ua-update-happy")
+
+	// Promote alice from viewer → editor.
+	body := map[string]any{
+		"name": "alice-helmwatch",
+		"spec": map[string]any{
+			"user":         map[string]any{"keycloakSubject": "alice"},
+			"sovereignRef": "omantel",
+			"applications": []map[string]any{
+				{"app": "helmwatch", "role": "editor", "namespaces": []string{"tenant-foo"}},
+			},
+		},
+	}
+	rec := callUserAccess(t, h, http.MethodPut,
+		"/api/v1/deployments/"+dep.ID+"/admin/user-access/alice-helmwatch",
+		body, registerUserAccessRoutes)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	got, err := client.Resource(UserAccessGVR()).Namespace("").Get(context.Background(), "alice-helmwatch", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get after update: %v", err)
+	}
+	apps, _, _ := unstructured.NestedSlice(got.Object, "spec", "applications")
+	if len(apps) != 1 {
+		t.Fatalf("expected 1 app; got %d", len(apps))
+	}
+	first, _ := apps[0].(map[string]any)
+	if r, _ := first["role"].(string); r != "editor" {
+		t.Fatalf("role: got %q want editor", r)
+	}
+}
+
+func TestUpdateUserAccess_404Missing(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	factory, _ := fakeUserAccessDynamicFactory()
+	h.dynamicFactory = factory
+	dep := installUserAccessDeployment(t, h, "dep-ua-update-missing")
+
+	body := map[string]any{
+		"name": "ghost",
+		"spec": map[string]any{
+			"user":         map[string]any{"keycloakSubject": "ghost"},
+			"sovereignRef": "omantel",
+			"applications": []map[string]any{
+				{"app": "helmwatch", "role": "viewer"},
+			},
+		},
+	}
+	rec := callUserAccess(t, h, http.MethodPut,
+		"/api/v1/deployments/"+dep.ID+"/admin/user-access/ghost",
+		body, registerUserAccessRoutes)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status: got %d want 404; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+/* ── DELETE ────────────────────────────────────────────────────── */
+
+func TestDeleteUserAccess_Happy(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	existing := newUserAccessUnstructured("alice-helmwatch", "omantel", "alice", "helmwatch", "editor", "tenant-foo")
+	factory, client := fakeUserAccessDynamicFactory(existing)
+	h.dynamicFactory = factory
+	dep := installUserAccessDeployment(t, h, "dep-ua-delete-happy")
+
+	rec := callUserAccess(t, h, http.MethodDelete,
+		"/api/v1/deployments/"+dep.ID+"/admin/user-access/alice-helmwatch",
+		nil, registerUserAccessRoutes)
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("status: got %d want 204; body=%s", rec.Code, rec.Body.String())
+	}
+	if _, err := client.Resource(UserAccessGVR()).Namespace("").Get(context.Background(), "alice-helmwatch", metav1.GetOptions{}); err == nil {
+		t.Fatalf("expected error after delete; got nil")
+	}
+}
+
+func TestDeleteUserAccess_404Missing(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	factory, _ := fakeUserAccessDynamicFactory()
+	h.dynamicFactory = factory
+	dep := installUserAccessDeployment(t, h, "dep-ua-delete-missing")
+
+	rec := callUserAccess(t, h, http.MethodDelete,
+		"/api/v1/deployments/"+dep.ID+"/admin/user-access/ghost",
+		nil, registerUserAccessRoutes)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status: got %d want 404; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+/* ── Validation unit tests (table-driven) ──────────────────────── */
+
+func TestValidateUserAccess_Cases(t *testing.T) {
+	cases := []struct {
+		name    string
+		req     userAccessRequest
+		wantOK  bool
+		wantSub string
+	}{
+		{
+			name: "happy-path-keycloak-subject",
+			req: userAccessRequest{
+				Name: "alice-foo",
+				Spec: userAccessSpecBody{
+					User:         userAccessUserBody{KeycloakSubject: "alice"},
+					SovereignRef: "omantel",
+					Applications: []userAccessAppGrantBody{
+						{App: "helmwatch", Role: "editor", Namespaces: []string{"tenant-foo"}},
+					},
+				},
+			},
+			wantOK: true,
+		},
+		{
+			name: "happy-path-keycloak-groups-only",
+			req: userAccessRequest{
+				Name: "ops-team",
+				Spec: userAccessSpecBody{
+					User:         userAccessUserBody{KeycloakGroups: []string{"sovereign-ops"}},
+					SovereignRef: "omantel",
+					Applications: []userAccessAppGrantBody{
+						{App: "helmwatch", Role: "viewer"},
+					},
+				},
+			},
+			wantOK: true,
+		},
+		{
+			name:    "missing-name",
+			req:     userAccessRequest{},
+			wantOK:  false,
+			wantSub: "name",
+		},
+		{
+			name: "missing-user-identity",
+			req: userAccessRequest{
+				Name: "alice",
+				Spec: userAccessSpecBody{
+					SovereignRef: "omantel",
+					Applications: []userAccessAppGrantBody{
+						{App: "helmwatch", Role: "viewer"},
+					},
+				},
+			},
+			wantOK:  false,
+			wantSub: "keycloakSubject",
+		},
+		{
+			name: "missing-sovereign-ref",
+			req: userAccessRequest{
+				Name: "alice",
+				Spec: userAccessSpecBody{
+					User: userAccessUserBody{KeycloakSubject: "alice"},
+					Applications: []userAccessAppGrantBody{
+						{App: "helmwatch", Role: "viewer"},
+					},
+				},
+			},
+			wantOK:  false,
+			wantSub: "sovereignRef",
+		},
+		{
+			name: "no-applications",
+			req: userAccessRequest{
+				Name: "alice",
+				Spec: userAccessSpecBody{
+					User:         userAccessUserBody{KeycloakSubject: "alice"},
+					SovereignRef: "omantel",
+				},
+			},
+			wantOK:  false,
+			wantSub: "applications",
+		},
+		{
+			name: "bad-role",
+			req: userAccessRequest{
+				Name: "alice",
+				Spec: userAccessSpecBody{
+					User:         userAccessUserBody{KeycloakSubject: "alice"},
+					SovereignRef: "omantel",
+					Applications: []userAccessAppGrantBody{
+						{App: "helmwatch", Role: "superuser"},
+					},
+				},
+			},
+			wantOK:  false,
+			wantSub: "admin",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			msg, ok := validateUserAccess(c.req)
+			if ok != c.wantOK {
+				t.Fatalf("ok: got %v want %v (msg=%s)", ok, c.wantOK, msg)
+			}
+			if !ok && c.wantSub != "" && !strings.Contains(msg, c.wantSub) {
+				t.Fatalf("msg %q must contain %q", msg, c.wantSub)
+			}
+		})
+	}
+}

--- a/products/catalyst/bootstrap/ui/src/app/router.tsx
+++ b/products/catalyst/bootstrap/ui/src/app/router.tsx
@@ -26,6 +26,8 @@ import { JobsTimeline } from '@/pages/sovereign/JobsTimeline'
 import { Dashboard } from '@/pages/sovereign/Dashboard'
 import { CloudPage } from '@/pages/sovereign/CloudPage'
 import { DecommissionPage } from '@/pages/sovereign/DecommissionPage'
+import { UserAccessListPage } from '@/pages/admin/user-access/UserAccessListPage'
+import { UserAccessEditPage } from '@/pages/admin/user-access/UserAccessEditPage'
 
 // Root
 const rootRoute = createRootRoute({ component: RootLayout })
@@ -302,6 +304,29 @@ const infraLegacyRedirectRoutes = INFRA_LEGACY_REDIRECTS.map((r) =>
   }),
 )
 
+/* ── Sovereign IAM — User Access editor (issue #323) ─────────────
+ *
+ * Three routes under /provision/$deploymentId/users:
+ *   • list     → /users           (UserAccessListPage)
+ *   • new      → /users/new       (UserAccessEditPage with no name)
+ *   • edit     → /users/$name     (UserAccessEditPage with name)
+ */
+const provisionUsersListRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/provision/$deploymentId/users',
+  component: UserAccessListPage,
+})
+const provisionUsersNewRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/provision/$deploymentId/users/new',
+  component: UserAccessEditPage,
+})
+const provisionUsersEditRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/provision/$deploymentId/users/$name',
+  component: UserAccessEditPage,
+})
+
 // Legacy DAG provision view — preserved at a sub-path so existing
 // links and CI smoke tests (which still curl `/provision/legacy/...`)
 // don't 404 mid-rollout.
@@ -354,6 +379,9 @@ const routeTree = rootRoute.addChildren([
     provisionInfrastructureIndexRoute,
     ...infraLegacyRedirectRoutes,
   ]),
+  provisionUsersListRoute,
+  provisionUsersNewRoute,
+  provisionUsersEditRoute,
   legacyProvisionRoute,
   designsRoute,
   designsJobsDepsVizRoute,

--- a/products/catalyst/bootstrap/ui/src/pages/admin/user-access/UserAccessEditPage.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/admin/user-access/UserAccessEditPage.test.tsx
@@ -1,0 +1,236 @@
+/**
+ * UserAccessEditPage.test.tsx — form coverage (issue #323).
+ *
+ *   • Form fields render
+ *   • Validation rejects missing user identity
+ *   • Validation rejects missing sovereignRef / app
+ *   • Submit happy-path calls the override and navigates to /users
+ *   • Edit-mode disables the name field and pre-populates fields
+ */
+
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react'
+import {
+  RouterProvider,
+  createRouter,
+  createRootRoute,
+  createRoute,
+  createMemoryHistory,
+  Outlet,
+} from '@tanstack/react-router'
+import { UserAccessEditPage, validate } from './UserAccessEditPage'
+import type { UserAccessItem, UserAccessRequest } from './userAccess.api'
+
+interface RenderOpts {
+  path: string
+  initialItem?: UserAccessItem | null
+  onSubmitOverride?: (req: UserAccessRequest) => Promise<void>
+}
+
+function renderEdit(opts: RenderOpts) {
+  const rootRoute = createRootRoute({ component: () => <Outlet /> })
+  const newRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/provision/$deploymentId/users/new',
+    component: () => (
+      <UserAccessEditPage
+        initialItem={opts.initialItem ?? null}
+        disableFetch
+        onSubmitOverride={opts.onSubmitOverride}
+      />
+    ),
+  })
+  const editRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/provision/$deploymentId/users/$name',
+    component: () => (
+      <UserAccessEditPage
+        initialItem={opts.initialItem ?? null}
+        disableFetch
+        onSubmitOverride={opts.onSubmitOverride}
+      />
+    ),
+  })
+  const listRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/provision/$deploymentId/users',
+    component: () => <div data-testid="users-list-target" />,
+  })
+  const wizardRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/wizard',
+    component: () => <div data-testid="wizard-target" />,
+  })
+  const tree = rootRoute.addChildren([newRoute, editRoute, listRoute, wizardRoute])
+  const router = createRouter({
+    routeTree: tree,
+    history: createMemoryHistory({ initialEntries: [opts.path] }),
+  })
+  return render(<RouterProvider router={router} />)
+}
+
+afterEach(() => cleanup())
+
+describe('UserAccessEditPage — new', () => {
+  it('renders all form fields', async () => {
+    renderEdit({ path: '/provision/d-1/users/new' })
+    expect(await screen.findByTestId('ua-input-name')).toBeTruthy()
+    expect(screen.getByTestId('ua-input-subject')).toBeTruthy()
+    expect(screen.getByTestId('ua-input-groups')).toBeTruthy()
+    expect(screen.getByTestId('ua-input-sovereign')).toBeTruthy()
+    expect(screen.getByTestId('ua-input-app')).toBeTruthy()
+    expect(screen.getByTestId('ua-input-role')).toBeTruthy()
+    expect(screen.getByTestId('ua-input-namespaces')).toBeTruthy()
+    expect(screen.getByTestId('ua-button-save')).toBeTruthy()
+  })
+
+  it('happy-path submit calls the override + navigates to list', async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined)
+    renderEdit({ path: '/provision/d-1/users/new', onSubmitOverride: onSubmit })
+
+    fireEvent.change(await screen.findByTestId('ua-input-name'), {
+      target: { value: 'alice-helmwatch' },
+    })
+    fireEvent.change(screen.getByTestId('ua-input-subject'), {
+      target: { value: 'alice' },
+    })
+    fireEvent.change(screen.getByTestId('ua-input-sovereign'), {
+      target: { value: 'omantel' },
+    })
+    fireEvent.change(screen.getByTestId('ua-input-app'), {
+      target: { value: 'helmwatch' },
+    })
+    fireEvent.change(screen.getByTestId('ua-input-namespaces'), {
+      target: { value: 'helmwatch-prod, helmwatch-stg' },
+    })
+    fireEvent.click(screen.getByTestId('ua-button-save'))
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledTimes(1)
+    })
+    const req = onSubmit.mock.calls[0][0] as UserAccessRequest
+    expect(req.name).toBe('alice-helmwatch')
+    expect(req.spec.user.keycloakSubject).toBe('alice')
+    expect(req.spec.sovereignRef).toBe('omantel')
+    expect(req.spec.applications).toHaveLength(1)
+    expect(req.spec.applications[0].app).toBe('helmwatch')
+    expect(req.spec.applications[0].role).toBe('editor')
+    expect(req.spec.applications[0].namespaces).toEqual(['helmwatch-prod', 'helmwatch-stg'])
+    // Navigated to list view
+    await screen.findByTestId('users-list-target')
+  })
+})
+
+describe('UserAccessEditPage — edit', () => {
+  it('pre-populates fields from initialItem and disables name', async () => {
+    const item: UserAccessItem = {
+      name: 'alice-helmwatch',
+      spec: {
+        user: { keycloakSubject: 'alice' },
+        sovereignRef: 'omantel',
+        applications: [
+          {
+            app: 'helmwatch',
+            role: 'editor',
+            namespaces: ['helmwatch-prod'],
+          },
+        ],
+      },
+    }
+    renderEdit({
+      path: '/provision/d-1/users/alice-helmwatch',
+      initialItem: item,
+    })
+    const nameInput = (await screen.findByTestId('ua-input-name')) as HTMLInputElement
+    expect(nameInput.value).toBe('alice-helmwatch')
+    expect(nameInput.disabled).toBe(true)
+    const subjectInput = screen.getByTestId('ua-input-subject') as HTMLInputElement
+    expect(subjectInput.value).toBe('alice')
+    const sovInput = screen.getByTestId('ua-input-sovereign') as HTMLInputElement
+    expect(sovInput.value).toBe('omantel')
+    const appInput = screen.getByTestId('ua-input-app') as HTMLInputElement
+    expect(appInput.value).toBe('helmwatch')
+  })
+})
+
+describe('UserAccessEditPage — validation', () => {
+  it('rejects missing user identity', () => {
+    const res = validate(
+      {
+        name: 'alice',
+        keycloakSubject: '',
+        keycloakGroups: '',
+        sovereignRef: 'omantel',
+        app: 'helmwatch',
+        role: 'editor',
+        namespaces: '',
+      },
+      false,
+    )
+    expect(res).toMatch(/subject|group/i)
+  })
+
+  it('rejects missing sovereign ref', () => {
+    const res = validate(
+      {
+        name: 'alice',
+        keycloakSubject: 'alice',
+        keycloakGroups: '',
+        sovereignRef: '',
+        app: 'helmwatch',
+        role: 'editor',
+        namespaces: '',
+      },
+      false,
+    )
+    expect(res).toMatch(/Sovereign/i)
+  })
+
+  it('rejects missing app', () => {
+    const res = validate(
+      {
+        name: 'alice',
+        keycloakSubject: 'alice',
+        keycloakGroups: '',
+        sovereignRef: 'omantel',
+        app: '',
+        role: 'editor',
+        namespaces: '',
+      },
+      false,
+    )
+    expect(res).toMatch(/Application/i)
+  })
+
+  it('happy path returns null', () => {
+    const res = validate(
+      {
+        name: 'alice',
+        keycloakSubject: 'alice',
+        keycloakGroups: '',
+        sovereignRef: 'omantel',
+        app: 'helmwatch',
+        role: 'editor',
+        namespaces: '',
+      },
+      false,
+    )
+    expect(res).toBeNull()
+  })
+
+  it('groups-only is also valid', () => {
+    const res = validate(
+      {
+        name: 'ops',
+        keycloakSubject: '',
+        keycloakGroups: 'sovereign-ops',
+        sovereignRef: 'omantel',
+        app: 'helmwatch',
+        role: 'viewer',
+        namespaces: '',
+      },
+      false,
+    )
+    expect(res).toBeNull()
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/pages/admin/user-access/UserAccessEditPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/admin/user-access/UserAccessEditPage.tsx
@@ -1,0 +1,340 @@
+/**
+ * UserAccessEditPage — create / edit form for a single UserAccess
+ * Claim (issue #323).
+ *
+ * Form fields (matching the canonical CRD shape from #322):
+ *   • Name (DNS-1123 string, immutable on edit)
+ *   • Keycloak subject (free text — OIDC sub claim)
+ *   • Keycloak groups (comma-separated free text)
+ *   • Sovereign reference (free text — slug)
+ *   • For now a single application grant row:
+ *       - app slug
+ *       - role (radio: admin / editor / viewer)
+ *       - namespaces (comma-separated)
+ *
+ * The CRD supports multiple application entries per Claim; v1 of the
+ * editor scopes to a single grant per Claim because that matches the
+ * single-grant shape the catalyst-api expansion produces upstream
+ * (see useraccess-sample.yaml fixture). Multi-grant authoring is a
+ * follow-up; the JSON is still well-formed because applications is
+ * always rendered as a 1-element array.
+ *
+ * Per docs/INVIOLABLE-PRINCIPLES.md #1 the page renders fully on
+ * first paint. Per #4, every URL flows through the central
+ * userAccess.api.ts wrappers.
+ */
+
+import { useEffect, useMemo, useState } from 'react'
+import { useNavigate, useParams } from '@tanstack/react-router'
+import { PortalShell } from '@/pages/sovereign/PortalShell'
+import {
+  createUserAccess,
+  listUserAccess,
+  updateUserAccess,
+  type UserAccessItem,
+  type UserAccessRequest,
+  type UserAccessRole,
+} from './userAccess.api'
+
+export interface UserAccessEditPageProps {
+  /** Test seam — pre-loaded existing entry for the edit path. */
+  initialItem?: UserAccessItem | null
+  /** Test seam — disables the fetch effect entirely. */
+  disableFetch?: boolean
+  /** Test seam — overrides the create/update handler so the form can
+   *  be exercised without a network. */
+  onSubmitOverride?: (req: UserAccessRequest) => Promise<void>
+}
+
+interface FormState {
+  name: string
+  keycloakSubject: string
+  keycloakGroups: string
+  sovereignRef: string
+  app: string
+  role: UserAccessRole
+  namespaces: string
+}
+
+const DEFAULT_FORM: FormState = {
+  name: '',
+  keycloakSubject: '',
+  keycloakGroups: '',
+  sovereignRef: '',
+  app: '',
+  role: 'editor',
+  namespaces: '',
+}
+
+export function UserAccessEditPage({
+  initialItem = null,
+  disableFetch = false,
+  onSubmitOverride,
+}: UserAccessEditPageProps = {}) {
+  const params = useParams({ strict: false }) as {
+    deploymentId: string
+    name?: string
+  }
+  const deploymentId = params.deploymentId
+  const editName = params.name ?? null
+  const isEdit = !!editName
+  const navigate = useNavigate()
+
+  const [form, setForm] = useState<FormState>(() => fromItem(initialItem) ?? DEFAULT_FORM)
+  const [error, setError] = useState<string | null>(null)
+  const [submitting, setSubmitting] = useState(false)
+  const [loading, setLoading] = useState(isEdit && !initialItem && !disableFetch)
+
+  useEffect(() => {
+    if (!isEdit || disableFetch || initialItem) return
+    let cancelled = false
+    setLoading(true)
+    listUserAccess(deploymentId)
+      .then((rows) => {
+        if (cancelled) return
+        const found = rows.find((r) => r.name === editName) ?? null
+        if (!found) {
+          setError(`UserAccess "${editName}" not found`)
+        } else {
+          setForm(fromItem(found) ?? DEFAULT_FORM)
+        }
+      })
+      .catch((err: Error) => {
+        if (!cancelled) setError(err.message)
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [isEdit, disableFetch, deploymentId, editName, initialItem])
+
+  const validationError = useMemo(() => validate(form, isEdit), [form, isEdit])
+
+  async function onSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault()
+    setError(null)
+    if (validationError) {
+      setError(validationError)
+      return
+    }
+    const req = toRequest(form)
+    setSubmitting(true)
+    try {
+      if (onSubmitOverride) {
+        await onSubmitOverride(req)
+      } else if (isEdit) {
+        await updateUserAccess(deploymentId, editName!, req)
+      } else {
+        await createUserAccess(deploymentId, req)
+      }
+      navigate({
+        to: '/provision/$deploymentId/users' as never,
+        params: { deploymentId } as never,
+      })
+    } catch (err) {
+      setError((err as Error).message)
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <PortalShell
+      deploymentId={deploymentId}
+      pageTitle={isEdit ? `Edit User Access — ${editName}` : 'New User Access'}
+    >
+      <div data-testid="user-access-edit-page" className="mx-auto max-w-2xl px-6 py-4">
+        <form onSubmit={onSubmit} className="flex flex-col gap-4">
+          {error ? (
+            <div data-testid="user-access-form-error" className="rounded-md border border-red-500/40 bg-red-500/10 px-3 py-2 text-sm text-red-300">
+              {error}
+            </div>
+          ) : null}
+
+          <Field label="Name (Claim name)">
+            <input
+              data-testid="ua-input-name"
+              type="text"
+              required
+              value={form.name}
+              disabled={isEdit || loading}
+              onChange={(e) => setForm({ ...form, name: e.target.value })}
+              className="w-full rounded border border-[var(--color-border)] bg-[var(--color-bg)] px-2 py-1 text-sm font-mono"
+              placeholder="alice-helmwatch-omantel"
+            />
+          </Field>
+
+          <Field label="Keycloak subject (OIDC sub)">
+            <input
+              data-testid="ua-input-subject"
+              type="text"
+              value={form.keycloakSubject}
+              disabled={loading}
+              onChange={(e) => setForm({ ...form, keycloakSubject: e.target.value })}
+              className="w-full rounded border border-[var(--color-border)] bg-[var(--color-bg)] px-2 py-1 text-sm"
+              placeholder="alice"
+            />
+          </Field>
+
+          <Field label="Keycloak groups (comma-separated)">
+            <input
+              data-testid="ua-input-groups"
+              type="text"
+              value={form.keycloakGroups}
+              disabled={loading}
+              onChange={(e) => setForm({ ...form, keycloakGroups: e.target.value })}
+              className="w-full rounded border border-[var(--color-border)] bg-[var(--color-bg)] px-2 py-1 text-sm"
+              placeholder="sovereign-ops, helmwatch-editors"
+            />
+          </Field>
+
+          <Field label="Sovereign reference">
+            <input
+              data-testid="ua-input-sovereign"
+              type="text"
+              required
+              value={form.sovereignRef}
+              disabled={loading}
+              onChange={(e) => setForm({ ...form, sovereignRef: e.target.value })}
+              className="w-full rounded border border-[var(--color-border)] bg-[var(--color-bg)] px-2 py-1 text-sm font-mono"
+              placeholder="omantel"
+            />
+          </Field>
+
+          <Field label="Application">
+            <input
+              data-testid="ua-input-app"
+              type="text"
+              required
+              value={form.app}
+              disabled={loading}
+              onChange={(e) => setForm({ ...form, app: e.target.value })}
+              className="w-full rounded border border-[var(--color-border)] bg-[var(--color-bg)] px-2 py-1 text-sm font-mono"
+              placeholder="helmwatch"
+            />
+          </Field>
+
+          <Field label="Role">
+            <div data-testid="ua-input-role" className="flex gap-3 text-sm">
+              {(['admin', 'editor', 'viewer'] as const).map((r) => (
+                <label key={r} className="flex items-center gap-1">
+                  <input
+                    type="radio"
+                    name="role"
+                    value={r}
+                    checked={form.role === r}
+                    onChange={() => setForm({ ...form, role: r })}
+                    disabled={loading}
+                  />
+                  <span>{r}</span>
+                </label>
+              ))}
+            </div>
+          </Field>
+
+          <Field label="Namespaces (comma-separated; empty = expand from Application)">
+            <input
+              data-testid="ua-input-namespaces"
+              type="text"
+              value={form.namespaces}
+              disabled={loading}
+              onChange={(e) => setForm({ ...form, namespaces: e.target.value })}
+              className="w-full rounded border border-[var(--color-border)] bg-[var(--color-bg)] px-2 py-1 text-sm font-mono"
+              placeholder="helmwatch-prod, helmwatch-stg"
+            />
+          </Field>
+
+          <div className="flex items-center justify-end gap-2">
+            <button
+              type="button"
+              data-testid="ua-button-cancel"
+              onClick={() =>
+                navigate({
+                  to: '/provision/$deploymentId/users' as never,
+                  params: { deploymentId } as never,
+                })
+              }
+              className="rounded-md border border-[var(--color-border)] px-3 py-1.5 text-sm hover:bg-[var(--color-bg-2)]"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              data-testid="ua-button-save"
+              disabled={submitting || loading || !!validationError}
+              className="rounded-md bg-[var(--color-accent)] px-3 py-1.5 text-sm font-medium text-white hover:opacity-90 disabled:opacity-50"
+            >
+              {submitting ? 'Saving…' : 'Save'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </PortalShell>
+  )
+}
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="flex flex-col gap-1">
+      <span className="text-xs uppercase text-[var(--color-text-dim)]">{label}</span>
+      {children}
+    </div>
+  )
+}
+
+function fromItem(item: UserAccessItem | null): FormState | null {
+  if (!item) return null
+  const firstApp = item.spec.applications[0]
+  const role = firstApp?.role
+  const knownRole: UserAccessRole = role === 'admin' || role === 'editor' || role === 'viewer' ? role : 'viewer'
+  return {
+    name: item.name,
+    keycloakSubject: item.spec.user.keycloakSubject ?? '',
+    keycloakGroups: (item.spec.user.keycloakGroups ?? []).join(', '),
+    sovereignRef: item.spec.sovereignRef,
+    app: firstApp?.app ?? '',
+    role: knownRole,
+    namespaces: (firstApp?.namespaces ?? []).join(', '),
+  }
+}
+
+function splitCSV(s: string): string[] {
+  return s
+    .split(',')
+    .map((p) => p.trim())
+    .filter((p) => p.length > 0)
+}
+
+function toRequest(form: FormState): UserAccessRequest {
+  const groups = splitCSV(form.keycloakGroups)
+  const namespaces = splitCSV(form.namespaces)
+  return {
+    name: form.name,
+    spec: {
+      user: {
+        ...(form.keycloakSubject.trim() ? { keycloakSubject: form.keycloakSubject.trim() } : {}),
+        ...(groups.length > 0 ? { keycloakGroups: groups } : {}),
+      },
+      sovereignRef: form.sovereignRef.trim(),
+      applications: [
+        {
+          app: form.app.trim(),
+          role: form.role,
+          ...(namespaces.length > 0 ? { namespaces } : {}),
+        },
+      ],
+    },
+  }
+}
+
+export function validate(form: FormState, isEdit: boolean): string | null {
+  if (!isEdit && !form.name.trim()) return 'Name is required'
+  if (!form.keycloakSubject.trim() && !splitCSV(form.keycloakGroups).length) {
+    return 'Either Keycloak subject or at least one group is required'
+  }
+  if (!form.sovereignRef.trim()) return 'Sovereign reference is required'
+  if (!form.app.trim()) return 'Application is required'
+  return null
+}

--- a/products/catalyst/bootstrap/ui/src/pages/admin/user-access/UserAccessListPage.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/admin/user-access/UserAccessListPage.test.tsx
@@ -1,0 +1,120 @@
+/**
+ * UserAccessListPage.test.tsx — list view coverage (issue #323).
+ *
+ *   • Page heading + tagline render
+ *   • Empty-state renders when no items
+ *   • Populated table renders one row per item
+ *   • Mounts inside the PortalShell
+ */
+
+import { describe, it, expect, afterEach } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+import {
+  RouterProvider,
+  createRouter,
+  createRootRoute,
+  createRoute,
+  createMemoryHistory,
+  Outlet,
+} from '@tanstack/react-router'
+import { UserAccessListPage } from './UserAccessListPage'
+import type { UserAccessItem } from './userAccess.api'
+
+function renderList(initialItems: UserAccessItem[]) {
+  const rootRoute = createRootRoute({ component: () => <Outlet /> })
+  const listRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/provision/$deploymentId/users',
+    component: () => <UserAccessListPage initialItems={initialItems} disableFetch />,
+  })
+  const newRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/provision/$deploymentId/users/new',
+    component: () => <div data-testid="users-new-target" />,
+  })
+  const editRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/provision/$deploymentId/users/$name',
+    component: () => <div data-testid="users-edit-target" />,
+  })
+  const wizardRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/wizard',
+    component: () => <div data-testid="wizard-target" />,
+  })
+  const tree = rootRoute.addChildren([listRoute, newRoute, editRoute, wizardRoute])
+  const router = createRouter({
+    routeTree: tree,
+    history: createMemoryHistory({ initialEntries: ['/provision/d-1/users'] }),
+  })
+  return render(<RouterProvider router={router} />)
+}
+
+afterEach(() => cleanup())
+
+describe('UserAccessListPage', () => {
+  it('renders page heading + tagline', async () => {
+    renderList([])
+    // Both the PortalShell page-title slot AND the in-content <h1>
+    // render "User Access" — assert there are 1+.
+    expect((await screen.findAllByText('User Access')).length).toBeGreaterThanOrEqual(1)
+    expect(
+      screen.getByText(/Per-user access to Sovereigns/),
+    ).toBeTruthy()
+  })
+
+  it('renders empty-state when no items', async () => {
+    renderList([])
+    expect(await screen.findByTestId('user-access-empty-state')).toBeTruthy()
+  })
+
+  it('renders one row per UserAccess item', async () => {
+    const items: UserAccessItem[] = [
+      {
+        name: 'alice-helmwatch',
+        spec: {
+          user: { keycloakSubject: 'alice' },
+          sovereignRef: 'omantel',
+          applications: [
+            {
+              app: 'helmwatch',
+              role: 'editor',
+              namespaces: ['helmwatch-prod'],
+            },
+          ],
+        },
+        creationTimestamp: '2026-05-01T12:00:00Z',
+      },
+      {
+        name: 'ops-team',
+        spec: {
+          user: { keycloakGroups: ['sovereign-ops'] },
+          sovereignRef: 'omantel',
+          applications: [{ app: 'catalyst', role: 'admin' }],
+        },
+      },
+    ]
+    renderList(items)
+    expect(await screen.findByTestId('user-access-row-alice-helmwatch')).toBeTruthy()
+    expect(screen.getByTestId('user-access-row-ops-team')).toBeTruthy()
+    // grants summary renders the "<app> (<role>)" form
+    expect(screen.getByText(/helmwatch \(editor\)/)).toBeTruthy()
+    expect(screen.getByText(/catalyst \(admin\)/)).toBeTruthy()
+    // user label renders the subject when present, the groups otherwise
+    expect(screen.getByText('alice')).toBeTruthy()
+    expect(screen.getByText('sovereign-ops')).toBeTruthy()
+  })
+
+  it('mounts inside the PortalShell (sidebar present)', async () => {
+    renderList([])
+    expect(await screen.findByTestId('sov-portal-shell')).toBeTruthy()
+    expect(screen.getByTestId('admin-sidebar')).toBeTruthy()
+  })
+
+  it('exposes the + New CTA linking to the create route', async () => {
+    renderList([])
+    const cta = await screen.findByTestId('user-access-new-cta')
+    expect(cta).toBeTruthy()
+    expect(cta.getAttribute('href') || '').toContain('/provision/d-1/users/new')
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/pages/admin/user-access/UserAccessListPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/admin/user-access/UserAccessListPage.tsx
@@ -1,0 +1,179 @@
+/**
+ * UserAccessListPage — Sovereign IAM list view (issue #323).
+ *
+ * Layout:
+ *   • PortalShell wrapper (sidebar + top header band) for visual
+ *     parity with every other admin surface.
+ *   • Page heading "User Access" + tagline + "+ New" CTA.
+ *   • Table: Name | User | Sovereign | Grants | Bindings | Created |
+ *     (Delete) — click a row to navigate to the edit page.
+ *
+ * Per docs/INVIOLABLE-PRINCIPLES.md #1 (waterfall, not iterative
+ * MVP) the page renders the empty-state on first paint while the
+ * fetch runs in the background; the table replaces the empty state
+ * once the response lands.
+ *
+ * Per #4 (never hardcode), the API call goes through the
+ * userAccess.api.ts wrappers which read API_BASE from the central
+ * shared/config/urls module.
+ */
+
+import { useEffect, useState } from 'react'
+import { Link, useParams } from '@tanstack/react-router'
+import { PortalShell } from '@/pages/sovereign/PortalShell'
+import {
+  deleteUserAccess,
+  grantsSummary,
+  listUserAccess,
+  userLabel,
+  type UserAccessItem,
+} from './userAccess.api'
+
+export interface UserAccessListPageProps {
+  /** Test seam — when set, supplies the initial list synchronously
+   *  without firing fetch. */
+  initialItems?: UserAccessItem[]
+  /** Test seam — disables the fetch effect entirely. */
+  disableFetch?: boolean
+}
+
+export function UserAccessListPage({
+  initialItems,
+  disableFetch = false,
+}: UserAccessListPageProps = {}) {
+  const params = useParams({ from: '/provision/$deploymentId/users' as never }) as {
+    deploymentId: string
+  }
+  const deploymentId = params.deploymentId
+
+  const [items, setItems] = useState<UserAccessItem[]>(initialItems ?? [])
+  const [loading, setLoading] = useState<boolean>(!initialItems && !disableFetch)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (disableFetch) return
+    let cancelled = false
+    setLoading(true)
+    listUserAccess(deploymentId)
+      .then((rows) => {
+        if (!cancelled) {
+          setItems(rows)
+          setError(null)
+        }
+      })
+      .catch((err: Error) => {
+        if (!cancelled) setError(err.message)
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [deploymentId, disableFetch])
+
+  async function onDelete(item: UserAccessItem) {
+    const subject = userLabel(item.spec.user)
+    if (!confirm(`Delete UserAccess "${item.name}"? This will revoke ${subject}'s access.`)) {
+      return
+    }
+    try {
+      await deleteUserAccess(deploymentId, item.name)
+      setItems((rows) => rows.filter((r) => r.name !== item.name))
+    } catch (err) {
+      setError((err as Error).message)
+    }
+  }
+
+  return (
+    <PortalShell deploymentId={deploymentId} pageTitle="User Access">
+      <div data-testid="user-access-list-page" className="px-6 py-4">
+        <div className="mb-4 flex items-center justify-between">
+          <div>
+            <h1 className="text-xl font-semibold text-[var(--color-text-strong)]">User Access</h1>
+            <p className="text-sm text-[var(--color-text-dim)]">
+              Per-user access to Sovereigns × Applications × Namespaces × Roles.
+            </p>
+          </div>
+          <Link
+            to={'/provision/$deploymentId/users/new' as never}
+            params={{ deploymentId } as never}
+            data-testid="user-access-new-cta"
+            className="rounded-md bg-[var(--color-accent)] px-3 py-1.5 text-sm font-medium text-white hover:opacity-90"
+          >
+            + New
+          </Link>
+        </div>
+
+        {error ? (
+          <div data-testid="user-access-error" className="mb-3 rounded-md border border-red-500/40 bg-red-500/10 px-3 py-2 text-sm text-red-300">
+            {error}
+          </div>
+        ) : null}
+
+        {loading ? (
+          <div data-testid="user-access-loading" className="text-sm text-[var(--color-text-dim)]">Loading…</div>
+        ) : items.length === 0 ? (
+          <div
+            data-testid="user-access-empty-state"
+            className="rounded-md border border-[var(--color-border)] px-4 py-8 text-center text-sm text-[var(--color-text-dim)]"
+          >
+            No user access entries yet. Click "+ New" to grant access to a Keycloak user or group.
+          </div>
+        ) : (
+          <table data-testid="user-access-table" className="w-full border-collapse text-sm">
+            <thead>
+              <tr className="border-b border-[var(--color-border)] text-left text-xs uppercase text-[var(--color-text-dim)]">
+                <th className="py-2 pr-3">Name</th>
+                <th className="py-2 pr-3">User / Groups</th>
+                <th className="py-2 pr-3">Sovereign</th>
+                <th className="py-2 pr-3">Grants</th>
+                <th className="py-2 pr-3">Bindings</th>
+                <th className="py-2 pr-3">Created</th>
+                <th className="py-2 pr-3" aria-label="actions"></th>
+              </tr>
+            </thead>
+            <tbody>
+              {items.map((item) => (
+                <tr
+                  key={item.name}
+                  data-testid={`user-access-row-${item.name}`}
+                  className="border-b border-[var(--color-border)] hover:bg-[var(--color-bg-2)]"
+                >
+                  <td className="py-2 pr-3 font-mono text-[var(--color-text)]">
+                    <Link
+                      to={'/provision/$deploymentId/users/$name' as never}
+                      params={{ deploymentId, name: item.name } as never}
+                      className="hover:underline"
+                    >
+                      {item.name}
+                    </Link>
+                  </td>
+                  <td className="py-2 pr-3">{userLabel(item.spec.user)}</td>
+                  <td className="py-2 pr-3 font-mono text-xs">{item.spec.sovereignRef}</td>
+                  <td className="py-2 pr-3 text-xs">{grantsSummary(item.spec.applications)}</td>
+                  <td className="py-2 pr-3 text-xs text-[var(--color-text-dim)]">
+                    {item.status?.rolebindingsCreated ?? '—'}
+                  </td>
+                  <td className="py-2 pr-3 text-xs text-[var(--color-text-dim)]">
+                    {item.creationTimestamp ?? '—'}
+                  </td>
+                  <td className="py-2 pr-3 text-right">
+                    <button
+                      type="button"
+                      data-testid={`user-access-delete-${item.name}`}
+                      onClick={() => onDelete(item)}
+                      className="text-xs text-red-400 hover:underline"
+                    >
+                      Delete
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </PortalShell>
+  )
+}

--- a/products/catalyst/bootstrap/ui/src/pages/admin/user-access/userAccess.api.ts
+++ b/products/catalyst/bootstrap/ui/src/pages/admin/user-access/userAccess.api.ts
@@ -1,0 +1,132 @@
+/**
+ * userAccess.api.ts — typed REST client wrappers for the catalyst-api
+ * UserAccess Claim endpoints (issue #323). Wire shape mirrors the
+ * canonical CRD shape shipped by issue #322.
+ *
+ * Per docs/INVIOLABLE-PRINCIPLES.md #4 (never hardcode), every URL
+ * derives from the central `API_BASE` constant — there are no
+ * inline `/api/...` strings in this file.
+ */
+
+import { API_BASE } from '@/shared/config/urls'
+
+export type UserAccessRole = 'admin' | 'editor' | 'viewer'
+
+export interface UserAccessUser {
+  keycloakSubject?: string
+  keycloakGroups?: string[]
+}
+
+export interface UserAccessAppGrant {
+  app: string
+  role: UserAccessRole | string
+  namespaces?: string[]
+  vClusters?: string[]
+}
+
+export interface UserAccessSpec {
+  user: UserAccessUser
+  sovereignRef: string
+  applications: UserAccessAppGrant[]
+}
+
+export interface UserAccessStatus {
+  rolebindingsCreated?: number
+  providerConfigRef?: string
+}
+
+export interface UserAccessItem {
+  name: string
+  spec: UserAccessSpec
+  status?: UserAccessStatus
+  creationTimestamp?: string
+}
+
+export interface UserAccessRequest {
+  name: string
+  spec: UserAccessSpec
+}
+
+export interface UserAccessListResponse {
+  items: UserAccessItem[]
+}
+
+function endpoint(deploymentId: string, name?: string): string {
+  const base = `${API_BASE}/v1/deployments/${encodeURIComponent(deploymentId)}/admin/user-access`
+  return name ? `${base}/${encodeURIComponent(name)}` : base
+}
+
+export async function listUserAccess(deploymentId: string): Promise<UserAccessItem[]> {
+  const res = await fetch(endpoint(deploymentId), {
+    headers: { Accept: 'application/json' },
+  })
+  if (!res.ok) {
+    throw new Error(`list user-access: HTTP ${res.status}`)
+  }
+  const body: UserAccessListResponse = await res.json()
+  return body.items ?? []
+}
+
+export async function createUserAccess(
+  deploymentId: string,
+  req: UserAccessRequest,
+): Promise<UserAccessItem> {
+  const res = await fetch(endpoint(deploymentId), {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+    body: JSON.stringify(req),
+  })
+  if (!res.ok) {
+    const detail = await res.text().catch(() => '')
+    throw new Error(`create user-access: HTTP ${res.status} ${detail}`)
+  }
+  return res.json()
+}
+
+export async function updateUserAccess(
+  deploymentId: string,
+  name: string,
+  req: UserAccessRequest,
+): Promise<UserAccessItem> {
+  const res = await fetch(endpoint(deploymentId, name), {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+    body: JSON.stringify(req),
+  })
+  if (!res.ok) {
+    const detail = await res.text().catch(() => '')
+    throw new Error(`update user-access: HTTP ${res.status} ${detail}`)
+  }
+  return res.json()
+}
+
+export async function deleteUserAccess(deploymentId: string, name: string): Promise<void> {
+  const res = await fetch(endpoint(deploymentId, name), {
+    method: 'DELETE',
+    headers: { Accept: 'application/json' },
+  })
+  if (!res.ok && res.status !== 204) {
+    const detail = await res.text().catch(() => '')
+    throw new Error(`delete user-access: HTTP ${res.status} ${detail}`)
+  }
+}
+
+/**
+ * Render an identifier label for the user — preferring the OIDC
+ * subject, falling back to the comma-joined group list.
+ */
+export function userLabel(user: UserAccessUser): string {
+  if (user.keycloakSubject) return user.keycloakSubject
+  if (user.keycloakGroups && user.keycloakGroups.length > 0) {
+    return user.keycloakGroups.join(', ')
+  }
+  return '—'
+}
+
+/**
+ * Compact summary of an UserAccess Claim's grants for the list view:
+ *   "helmwatch (editor), catalyst (admin)"
+ */
+export function grantsSummary(applications: UserAccessAppGrant[]): string {
+  return applications.map((g) => `${g.app} (${g.role})`).join(', ')
+}

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/Sidebar.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/Sidebar.tsx
@@ -45,13 +45,14 @@ interface SidebarProps {
 /* ── Top-level (flat) nav items ─────────────────────────────────── */
 
 interface FlatNavItem {
-  id: 'apps' | 'jobs' | 'dashboard' | 'cloud' | 'settings'
+  id: 'apps' | 'jobs' | 'dashboard' | 'cloud' | 'users' | 'settings'
   label: string
   to:
     | '/provision/$deploymentId'
     | '/provision/$deploymentId/jobs'
     | '/provision/$deploymentId/dashboard'
     | '/provision/$deploymentId/cloud'
+    | '/provision/$deploymentId/users'
     | '/wizard'
   /** SVG path data — same `d` strings as core/console for visual parity. */
   icon: string
@@ -92,6 +93,13 @@ const FLAT_NAV: FlatNavItem[] = [
     to: '/provision/$deploymentId/cloud',
     icon: CLOUD_ICON,
   },
+  {
+    id: 'users',
+    label: 'Users',
+    to: '/provision/$deploymentId/users',
+    // Tabler IconUsers — verbatim path data, viewBox 24x24.
+    icon: 'M9 7a4 4 0 100 8 4 4 0 000-8zM3 21v-2a4 4 0 014-4h4a4 4 0 014 4v2M16 3.13a4 4 0 010 7.75M21 21v-2a4 4 0 00-3-3.87',
+  },
 ]
 
 const SETTINGS_ITEM: FlatNavItem = {
@@ -103,7 +111,7 @@ const SETTINGS_ITEM: FlatNavItem = {
 
 /* ── Active-state derivation ────────────────────────────────────── */
 
-type ActiveSection = 'apps' | 'jobs' | 'dashboard' | 'cloud' | 'settings'
+type ActiveSection = 'apps' | 'jobs' | 'dashboard' | 'cloud' | 'users' | 'settings'
 
 // Cloud section is active when the path matches any of the
 // `/cloud[/...]` or legacy `/infrastructure[/...]` segments. We use a
@@ -116,6 +124,8 @@ function deriveActiveSection(pathname: string): ActiveSection {
   if (CLOUD_PATH_RE.test(pathname)) return 'cloud'
   if (pathname.endsWith('/dashboard')) return 'dashboard'
   if (pathname.endsWith('/jobs')) return 'jobs'
+  // Users surface — list, /new, and /<name> all count.
+  if (/\/users(\/|$)/.test(pathname)) return 'users'
   if (pathname.startsWith('/sovereign/wizard') || pathname.startsWith('/wizard')) return 'settings'
   return 'apps'
 }


### PR DESCRIPTION
## Summary

- Catalyst-API: REST CRUD surface (`/api/v1/deployments/{depId}/admin/user-access[/{name}]`) over the UserAccess Claim shape from #322, written via the existing `sovereignDynamicClient(dep)` seam — no duplication of kubeconfig-read logic.
- Console UI: list + create/edit pages under `/provision/$deploymentId/users`, wired into the existing PortalShell + Sidebar nav.
- Wire shape mirrors #322's canonical CRD verbatim: `user.keycloakSubject`/`user.keycloakGroups` (either or both), `sovereignRef`, `applications[]` with `app/role/namespaces/vClusters`.

Per docs/INVIOLABLE-PRINCIPLES.md:
- #3 (Crossplane is the ONLY day-2 IaC seam) — handler writes UserAccess Claims; #322's Composition reconciles RBAC.
- #4 (never hardcode) — all URLs flow through `API_BASE`; XRC group/version centralised.

Anti-duplication: reused `sovereignDynamicClient(dep)` (`internal/handler/infrastructure.go:1557`), `dynamicFactory` test injection (`handler.go:94`), `PortalShell`, and `API_BASE`.

## Test plan

- [x] `go build ./products/catalyst/bootstrap/api/...` — clean
- [x] `go test ./internal/handler/ -run UserAccess` — 13 cases PASS (list/create/update/delete + 404/409/503/validation)
- [x] `npx tsc -b --noEmit` — clean
- [x] `npx vitest run src/pages/admin/user-access` — 13 cases PASS
- [x] `npx vitest run src/pages/sovereign/Sidebar` — 13 pre-existing cases PASS (Users entry added without breakage)
- [x] `bash scripts/check-vendor-coupling.sh` — exit 0

Pre-existing failures in `JobsPage.test.tsx` (2) are unrelated to this PR — confirmed they fail on `origin/main` before any of these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)