### PR TITLE
fix(ci): GHCR auth for bp-crossplane OCI pull in preflight (#460)

### DIFF
--- a/.github/workflows/preflight-crossplane-hcloud.yaml
+++ b/.github/workflows/preflight-crossplane-hcloud.yaml
@@ -41,6 +41,12 @@ on:
 
 permissions:
   contents: read
+  # bp-crossplane is a PRIVATE GHCR package
+  # (`gh api /orgs/openova-io/packages/container/bp-crossplane`), so the
+  # job needs read scope on packages to pull the OCI manifest. Mirrors
+  # the seam in .github/workflows/blueprint-release.yaml (which uses
+  # `packages: write` for push); read is the minimum here.
+  packages: read
 
 jobs:
   preflight:
@@ -57,6 +63,17 @@ jobs:
           cluster_name: preflight-crossplane-hcloud
           version: v0.25.0
           node_image: kindest/node:v1.30.6
+
+      - name: Login to GHCR (helm registry)
+        # Same pattern as .github/workflows/blueprint-release.yaml.
+        # `helm install oci://ghcr.io/...` reads the credential store
+        # populated by `helm registry login`, so this MUST happen before
+        # the install step. `helm` is preinstalled on ubuntu-latest.
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" \
+            | helm registry login ghcr.io \
+                --username "${{ github.actor }}" \
+                --password-stdin
 
       - name: Install bp-crossplane core
         run: |


### PR DESCRIPTION
## Summary

Follow-up to #463. The first run (25221515110) surfaced the exact blocking error the preflight workflow is designed to surface — but at the install step, not the Healthy probe:

\`\`\`
Error: INSTALLATION FAILED: failed to perform "FetchReference" on source:
GET "https://ghcr.io/v2/openova-io/bp-crossplane/manifests/1.1.3": ...
401: unauthorized: authentication required
\`\`\`

\`bp-crossplane\` is a PRIVATE GHCR package (verified via \`gh api /orgs/openova-io/packages/container/bp-crossplane\` returns \`private\`). Fix mirrors the canonical seam in \`.github/workflows/blueprint-release.yaml\`:

- Add \`packages: read\` to job permissions (minimum needed)
- Run \`helm registry login ghcr.io\` against \`GITHUB_TOKEN\` before \`helm install oci://...\`

No new pattern; just reuse of the existing GHCR auth seam. \`helm\` is preinstalled on \`ubuntu-latest\`.

## Anti-duplication audit

- \`docker/login-action\` + \`helm registry login\` pattern lifted directly from \`blueprint-release.yaml\` (lines 142-178)
- No alternative auth mechanism added (no PATs, no service account)

## Test plan

- [ ] Workflow re-runs on this merge push (path filter matches)
- [ ] Helm install succeeds; provider-hcloud Healthy=True within 5 min OR kubectl-describe block surfaces the *actual* Healthy blocker