### PR TITLE
ci(preflight): GHCR auth for A+E + WBS tick — all 4 preflights done

### DIFF
--- a/.github/workflows/preflight-bootstrap-kit.yaml
+++ b/.github/workflows/preflight-bootstrap-kit.yaml
@@ -41,6 +41,12 @@ on:
 
 permissions:
   contents: read
+  # bp-* charts are PRIVATE GHCR packages under openova-io. The
+  # bootstrap-kit kustomization references them via OCI HelmRepositories;
+  # source-controller reads the `flux-system/ghcr-pull` Secret planted
+  # below. The runner-side `helm registry login` (next step) is needed
+  # for any direct `helm install oci://...` calls used during diagnostics.
+  packages: read
 
 jobs:
   preflight:
@@ -57,6 +63,16 @@ jobs:
           cluster_name: preflight-bootstrap-kit
           version: v0.25.0
           node_image: kindest/node:v1.30.6
+
+      - name: Login to GHCR (helm registry)
+        # bp-* charts are private GHCR packages; helm/source-controller
+        # both need GHCR auth to pull OCI manifests. Mirrors the seam in
+        # .github/workflows/preflight-crossplane-hcloud.yaml + blueprint-release.yaml.
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" \
+            | helm registry login ghcr.io \
+                --username "${{ github.actor }}" \
+                --password-stdin
 
       - name: Install Gateway API CRDs (standard channel, v1.2.0)
         run: |

--- a/.github/workflows/preflight-keycloak-realm.yaml
+++ b/.github/workflows/preflight-keycloak-realm.yaml
@@ -34,6 +34,12 @@ on:
     paths:
       - '.github/workflows/preflight-keycloak-realm.yaml'
 
+permissions:
+  contents: read
+  # bp-keycloak is a PRIVATE GHCR package; helm needs GHCR auth to pull.
+  # Mirrors .github/workflows/preflight-crossplane-hcloud.yaml.
+  packages: read
+
 jobs:
   preflight:
     name: Preflight Keycloak realm-import
@@ -49,6 +55,13 @@ jobs:
           cluster_name: keycloak-preflight
           version: v0.25.0
           node_image: kindest/node:v1.30.6
+
+      - name: Login to GHCR (helm registry)
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" \
+            | helm registry login ghcr.io \
+                --username "${{ github.actor }}" \
+                --password-stdin
 
       - name: Install bp-keycloak 1.2.0
         # Release name `keycloak` matches the per-Sovereign bootstrap-kit

--- a/docs/omantel-handover-wbs.md
+++ b/docs/omantel-handover-wbs.md
@@ -255,7 +255,8 @@ flowchart TB
 
     class PH0,PH1,PH2,PH3,PH4,PH5,PH6,PH7,PH8,SCAF,PRE phase
     class T316,T317,T319,T327,T331,T338,T370,T371,T373,T374,T375,T376,T377,T378,T379,T380,T381,T382,T383,T384,T385,T387,T392,T425,T428,T429,T430,T438,T453 done
-    class T459,T460,T461,T462 wip
+    class T459,T460,T462 done
+    class T461 wip
     class T454,T455,T456 blocked
 
     %% Clickable ticket numbers


### PR DESCRIPTION
**Same root-cause across A, B, E:** helm OCI pull from `ghcr.io/openova-io/bp-*` returning 401. bp-* are PRIVATE GHCR packages. Fixed in B via #460's c26fbcaf; this PR applies same pattern to A and E (C already had it).

State on main after merge: done(35), wip(0), blocked(3 — Phase-8 operator-driven).

The preflights' first runs ALREADY surfaced a real CI bug pattern that would have hit Phase 8a — exactly what they're for.