### PR TITLE
fix(infra): escape SOVEREIGN_FQDN in cloudinit-control-plane.tftpl — Phase-8a critical

### DIFF
--- a/infra/hetzner/cloudinit-control-plane.tftpl
+++ b/infra/hetzner/cloudinit-control-plane.tftpl
@@ -9,7 +9,7 @@
 #   3. Installs Flux + bootstraps the GitRepository pointing at the shared
 #      clusters/_template/ tree in the public OpenOva monorepo. The
 #      Sovereign's FQDN is interpolated into the template manifests via
-#      Flux postBuild.substitute (${SOVEREIGN_FQDN}) at apply time, so
+#      Flux postBuild.substitute ($${SOVEREIGN_FQDN}) at apply time, so
 #      no per-Sovereign directory needs to be committed before
 #      provisioning. From this point Flux is the GitOps reconciler and
 #      installs the 11-component bootstrap kit (Cilium → cert-manager →
@@ -337,7 +337,7 @@ write_files:
   # Canonical fix: GitRepository selects the shared `_template/` tree,
   # Kustomization paths point at `clusters/_template/{bootstrap-kit,
   # infrastructure}`, and Flux's `postBuild.substitute` interpolates
-  # `${SOVEREIGN_FQDN}` into the template manifests at apply time. The
+  # `$${SOVEREIGN_FQDN}` into the template manifests at apply time. The
   # per-FQDN copy that prior provisioning depended on becomes a no-op:
   # one shared tree serves every Sovereign, with the Sovereign's FQDN
   # injected by Flux on the cluster instead of by sed in the repo.
@@ -380,10 +380,10 @@ write_files:
       #   "hcloud.crossplane.io/v1beta1"
       #
       # postBuild.substitute (issue #218): Flux's envsubst runs over the
-      # rendered manifests after kustomize build, replacing ${SOVEREIGN_FQDN}
+      # rendered manifests after kustomize build, replacing $${SOVEREIGN_FQDN}
       # with the Sovereign's FQDN that this cloud-init was rendered for.
       # The template manifests in clusters/_template/bootstrap-kit/*.yaml
-      # use ${SOVEREIGN_FQDN} as the substitution token.
+      # use $${SOVEREIGN_FQDN} as the substitution token.
       apiVersion: kustomize.toolkit.fluxcd.io/v1
       kind: Kustomization
       metadata:
@@ -736,7 +736,7 @@ runcmd:
   - 'kubectl --kubeconfig=/etc/rancher/k3s/k3s.yaml apply -f /var/lib/catalyst/crossplane-provider-hcloud.yaml'
 
   # Apply the Flux bootstrap GitRepository + Kustomization. From here, Flux
-  # owns the cluster: pulls clusters/_template/ (with ${SOVEREIGN_FQDN}
+  # owns the cluster: pulls clusters/_template/ (with $${SOVEREIGN_FQDN}
   # substituted to ${sovereign_fqdn} via postBuild), installs Cilium
   # via bp-cilium, cert-manager via bp-cert-manager, etc., then bp-catalyst-platform.
   - 'kubectl --kubeconfig=/etc/rancher/k3s/k3s.yaml apply -f /var/lib/catalyst/flux-bootstrap.yaml'


### PR DESCRIPTION
**Phase-8a-preflight critical bug surfaced by first live provision attempt** (deployment `febeeb888debf477`, 2026-05-01 16:30 UTC, target `otech.omani.works`). Provisioning failed at `tofu plan` step:

```
Error: Invalid function argument
  on main.tf line 140, in locals:
Invalid value for "vars" parameter: vars map does not contain key
"SOVEREIGN_FQDN", referenced at ./cloudinit-control-plane.tftpl:12,37-51.
```

Tofu's `templatefile()` interprets `${...}` everywhere in the file (including shell `#` comments). 5 documentation comments referenced `${SOVEREIGN_FQDN}` (uppercase, Flux envsubst convention) where Tofu expects lowercase HCL convention.

Fix: escape with `$${...}` so Tofu emits a literal `${...}` in the rendered cloud-init.

Latest reference (line 12) added by #326 commit 20b89607; older 4 predate that — never exercised before this Phase-8a run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)