### PR TITLE
ci(catalyst-build): watch infra/hetzner/** so tftpl fixes rebuild catalyst-api

### DIFF
--- a/.github/workflows/catalyst-build.yaml
+++ b/.github/workflows/catalyst-build.yaml
@@ -15,6 +15,7 @@ on:
       - 'core/marketplace-api/**'
       - 'products/catalyst/bootstrap/**'
       - 'products/catalyst/chart/**'
+      - 'infra/hetzner/**'
       - '.github/workflows/catalyst-build.yaml'
   workflow_dispatch:
 


### PR DESCRIPTION
Phase-8a follow-on to #471. catalyst-api image bakes infra/hetzner/cloudinit-control-plane.tftpl but the build workflow didn't watch that path, so fixes wouldn't trigger rebuilds.