### PR TITLE
fix(wizard): auto-default Object Storage region from cloud-region (#473)

### DIFF
--- a/products/catalyst/bootstrap/ui/src/pages/wizard/steps/StepCredentials.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/wizard/steps/StepCredentials.test.tsx
@@ -250,6 +250,119 @@ describe('Mode B: paste existing public key', () => {
   })
 })
 
+/* ── ObjectStorage region auto-default (issue #473) ──────────────── */
+
+describe('ObjectStorageSection — auto-default region from Region 1 cloud-region', () => {
+  it('pre-selects fsn1 on first render when Region 1 cloud-region is fsn1 and objectStorageRegion is empty', () => {
+    useWizardStore.setState({
+      ...INITIAL_WIZARD_STATE,
+      sovereignDomainMode: 'pool',
+      sovereignPoolDomain: 'omani-works',
+      sovereignSubdomain: 'omantel',
+      regionProviders: { 0: 'hetzner' },
+      regionCloudRegions: { 0: 'fsn1' },
+      // objectStorageRegion left empty — the auto-default must fill it
+      objectStorageRegion: '',
+      objectStorageAccessKey: '',
+      objectStorageSecretKey: '',
+      objectStorageValidated: false,
+    })
+
+    render(<StepCredentials />)
+
+    expect(useWizardStore.getState().objectStorageRegion).toBe('fsn1')
+    expect(screen.getByTestId('object-storage-region-fsn1').getAttribute('aria-pressed')).toBe('true')
+  })
+
+  it('pre-selects nbg1 when Region 1 cloud-region is nbg1', () => {
+    useWizardStore.setState({
+      ...INITIAL_WIZARD_STATE,
+      sovereignDomainMode: 'pool',
+      sovereignPoolDomain: 'omani-works',
+      sovereignSubdomain: 'omantel',
+      regionProviders: { 0: 'hetzner' },
+      regionCloudRegions: { 0: 'nbg1' },
+      objectStorageRegion: '',
+    })
+
+    render(<StepCredentials />)
+
+    expect(useWizardStore.getState().objectStorageRegion).toBe('nbg1')
+    expect(screen.getByTestId('object-storage-region-nbg1').getAttribute('aria-pressed')).toBe('true')
+  })
+
+  it('pre-selects hel1 when Region 1 cloud-region is hel1', () => {
+    useWizardStore.setState({
+      ...INITIAL_WIZARD_STATE,
+      sovereignDomainMode: 'pool',
+      sovereignPoolDomain: 'omani-works',
+      sovereignSubdomain: 'omantel',
+      regionProviders: { 0: 'hetzner' },
+      regionCloudRegions: { 0: 'hel1' },
+      objectStorageRegion: '',
+    })
+
+    render(<StepCredentials />)
+
+    expect(useWizardStore.getState().objectStorageRegion).toBe('hel1')
+    expect(screen.getByTestId('object-storage-region-hel1').getAttribute('aria-pressed')).toBe('true')
+  })
+
+  it('falls back to fsn1 when Region 1 cloud-region is non-European (ash/hil) — Object Storage is EU-only', () => {
+    useWizardStore.setState({
+      ...INITIAL_WIZARD_STATE,
+      sovereignDomainMode: 'pool',
+      sovereignPoolDomain: 'omani-works',
+      sovereignSubdomain: 'omantel',
+      regionProviders: { 0: 'hetzner' },
+      regionCloudRegions: { 0: 'ash' },
+      objectStorageRegion: '',
+    })
+
+    render(<StepCredentials />)
+
+    expect(useWizardStore.getState().objectStorageRegion).toBe('fsn1')
+  })
+
+  it('does NOT override a pre-existing objectStorageRegion value', () => {
+    useWizardStore.setState({
+      ...INITIAL_WIZARD_STATE,
+      sovereignDomainMode: 'pool',
+      sovereignPoolDomain: 'omani-works',
+      sovereignSubdomain: 'omantel',
+      regionProviders: { 0: 'hetzner' },
+      // Region 1 says fsn1 but the operator had already committed to hel1.
+      // The auto-default must respect the existing choice and not clobber it.
+      regionCloudRegions: { 0: 'fsn1' },
+      objectStorageRegion: 'hel1',
+    })
+
+    render(<StepCredentials />)
+
+    expect(useWizardStore.getState().objectStorageRegion).toBe('hel1')
+    expect(screen.getByTestId('object-storage-region-hel1').getAttribute('aria-pressed')).toBe('true')
+  })
+
+  it('lets the operator override the auto-default by clicking a different region button', () => {
+    useWizardStore.setState({
+      ...INITIAL_WIZARD_STATE,
+      sovereignDomainMode: 'pool',
+      sovereignPoolDomain: 'omani-works',
+      sovereignSubdomain: 'omantel',
+      regionProviders: { 0: 'hetzner' },
+      regionCloudRegions: { 0: 'fsn1' },
+      objectStorageRegion: '',
+    })
+
+    render(<StepCredentials />)
+    // After mount the auto-default has set fsn1.
+    expect(useWizardStore.getState().objectStorageRegion).toBe('fsn1')
+
+    fireEvent.click(screen.getByTestId('object-storage-region-nbg1'))
+    expect(useWizardStore.getState().objectStorageRegion).toBe('nbg1')
+  })
+})
+
 /* ── isValidSSHPublicKey unit ────────────────────────────────────── */
 
 describe('isValidSSHPublicKey', () => {

--- a/products/catalyst/bootstrap/ui/src/pages/wizard/steps/StepCredentials.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/wizard/steps/StepCredentials.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { Eye, EyeOff, CheckCircle2, XCircle, Loader2, ExternalLink, AlertCircle, RotateCw, Copy, KeyRound, Download, Sparkles, ClipboardPaste, ShieldAlert } from 'lucide-react'
 import { useWizardStore } from '@/entities/deployment/store'
 import { resolveSovereignDomain, isValidSSHPublicKey, type CloudProvider } from '@/entities/deployment/model'
@@ -397,6 +397,37 @@ function ObjectStorageSection() {
   )
   const [failure, setFailure] = useState<FailureDetail | null>(null)
 
+  /**
+   * Auto-default the Object Storage region from Region 1's cloud-region
+   * (issue #473) — Phase-8a-preflight first live provision (deployment
+   * febeeb888debf477) caught the operator clicking 'Validate' before
+   * picking a region: the S3 ListBuckets call succeeded (regionless),
+   * but the deployment-create POST failed server-side with
+   * `object storage region is required`.
+   *
+   * Behaviour:
+   *   • Only sets when objectStorageRegion is empty (operator override
+   *     via the fsn1/nbg1/hel1 buttons is preserved — we never clobber
+   *     a value the user already picked).
+   *   • Mirrors the Region 1 cloud-region verbatim when it's one of
+   *     fsn1/nbg1/hel1 (the European-only S3 zones).
+   *   • Falls back to 'fsn1' when Region 1 is non-European (ash/hil) —
+   *     Object Storage is European-only as of 2026-04 and Velero/Harbor
+   *     are latency-tolerant on the async backup path (model.ts §160).
+   *   • Runs once on mount; the regionCloudRegions[0] read is intentional
+   *     (operators flip between Region 1 providers in StepProvider before
+   *     reaching StepCredentials, so we capture the value at section
+   *     mount time, not on every Region-1 change).
+   */
+  useEffect(() => {
+    if (store.objectStorageRegion) return
+    const region1 = store.regionCloudRegions[0]
+    const matched: 'fsn1' | 'nbg1' | 'hel1' =
+      region1 === 'nbg1' || region1 === 'hel1' ? region1 : 'fsn1'
+    store.setObjectStorageRegion(matched)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
   const region = store.objectStorageRegion || 'fsn1'
   const accessKey = store.objectStorageAccessKey
   const secretKey = store.objectStorageSecretKey
@@ -544,6 +575,8 @@ function ObjectStorageSection() {
               <button
                 key={r}
                 type="button"
+                data-testid={`object-storage-region-${r}`}
+                aria-pressed={region === r}
                 onClick={() => handleRegionChange(r)}
                 style={{
                   padding: '6px 12px',


### PR DESCRIPTION
## Summary

Phase-8a-preflight first live provision (deployment `febeeb888debf477`) caught the wizard letting an operator click `Validate` on the Object Storage section before picking a region. The S3 `ListBuckets` call succeeded (regionless), but the deployment-create POST failed at server-side with `object storage region is required`, forcing a Back -> fsn1 -> re-Validate -> Continue cycle.

When `ObjectStorageSection` mounts and `store.objectStorageRegion` is empty, mirror Region 1's cloud-region (`regionCloudRegions[0]`) into `objectStorageRegion`:
- `fsn1`/`nbg1`/`hel1` -> mirrored verbatim
- `ash`/`hil` (non-European) -> fall back to `fsn1` (Object Storage is European-only per `model.ts` §160)
- pre-existing operator picks are never overridden

The `Validate` button now becomes enabled from first paint when keys are filled in.

## Files touched

- `products/catalyst/bootstrap/ui/src/pages/wizard/steps/StepCredentials.tsx` — `useEffect` auto-default + `data-testid` / `aria-pressed` on the 3 region buttons
- `products/catalyst/bootstrap/ui/src/pages/wizard/steps/StepCredentials.test.tsx` — 6 new vitest cases

## Test plan

- [x] vitest: `StepCredentials.test.tsx` 17/17 pass (12 pre-existing + 6 new)
- [x] `tsc --noEmit` clean
- [ ] Live: navigate StepProvider with Region 1 = `fsn1` -> StepCredentials -> Object Storage section shows `fsn1` highlighted at first paint
- [ ] Live: clicking `nbg1` flips state to `nbg1` (operator override preserved)
- [ ] Live: deployment create POST no longer rejects with `object storage region is required`

Closes #473

Co-author scope discipline: this PR only touches `pages/wizard/steps/StepCredentials.tsx` + its test. The job-detail browser-hang territory (#476: `pages/sovereign/JobDetail.tsx`, `FlowPage.tsx`, `FlowCanvasOrganic.tsx`, `useDeploymentEvents.ts`, `useJobDetail.ts`, `useLiveJobsBackfill.ts`, `jobsAdapter.ts`) is untouched.