### PR TITLE
fix(infra): cloud-init strip regex must preserve #cloud-config

### DIFF
--- a/infra/hetzner/main.tf
+++ b/infra/hetzner/main.tf
@@ -209,7 +209,7 @@ locals {
     kubeconfig_bearer_token = var.kubeconfig_bearer_token
     catalyst_api_url        = var.catalyst_api_url
     load_balancer_ipv4      = hcloud_load_balancer.main.ipv4
-  }), "/(?m)^[ ]{0,2}#[^!].*\n/", "")
+  }), "/(?m)^[ ]{0,2}# .*\n/", "")
 
   worker_cloud_init = replace(templatefile("${path.module}/cloudinit-worker.tftpl", {
     sovereign_fqdn             = var.sovereign_fqdn
@@ -218,7 +218,7 @@ locals {
     cp_private_ip              = "10.0.1.2" # First static IP in the subnet — control plane
     enable_unattended_upgrades = var.enable_unattended_upgrades
     enable_fail2ban            = var.enable_fail2ban
-  }), "/(?m)^[ ]{0,2}#[^!].*\n/", "")
+  }), "/(?m)^[ ]{0,2}# .*\n/", "")
 }
 
 resource "hcloud_server" "control_plane" {


### PR DESCRIPTION
**Phase-8a-preflight ROOT CAUSE for every silent boot failure since #477.**

The #477 strip regex `^[ ]{0,2}#[^!].*\\n` excluded shebangs (`#!`) but DID NOT exclude cloud-init directives (`#cloud-config`, `#include`, `#cloud-boothook` — none have `!` after `#`).

Result: cloud-init received user_data with the `#cloud-config` first-line directive stripped, didn't recognise the YAML body, emitted:
```
recoverable_errors:
WARNING: Unhandled non-multipart (text/x-not-multipart) userdata
```

→ k3s never installed → Flux never bootstrapped → kubeconfig never PUT.

Live evidence: SSH'd into deployment a76e3fec8566add9, cloud-init status `degraded done`, k3s.service absent, no flux binary.

Fix: require space after `#` in strip regex. YAML comments are `# foo bar` (with space); directives are `#cloud-config` / `#include` (no space). New regex preserves them.

Verified: render still 13KB (under 32KiB cap), first line is `#cloud-config`.