### PR TITLE
fix(catalyst-ui): JobDetail flow physics + exec-logs viewer (closes #481)

### DIFF
--- a/products/catalyst/bootstrap/ui/src/components/LogPane.fallback.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/components/LogPane.fallback.test.tsx
@@ -1,0 +1,94 @@
+/**
+ * LogPane — Bug #481 derived-job fallback log lines test.
+ *
+ * The JobDetail page used to render the "No execution recorded yet"
+ * empty state for any job whose Bridge had not allocated an Execution
+ * row — including all Phase-0 tofu jobs and `cluster-bootstrap`, which
+ * live entirely in the SSE event reducer. Operators saw a blank pane
+ * even though the events were already buffered client-side.
+ *
+ * The fix adds a `fallbackLines` prop to LogPane: when `executionId`
+ * is null AND `fallbackLines` is non-empty, the pane renders those
+ * lines through the same dark-theme, line-numbered presentation as
+ * ExecutionLogs without polling. This test locks in the contract.
+ */
+import { describe, it, expect, afterEach } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+import { LogPane } from './LogPane'
+import type { LogLine } from './ExecutionLogs'
+
+afterEach(() => cleanup())
+
+const SAMPLE_LINES: LogLine[] = [
+  {
+    lineNumber: 1,
+    timestamp: '2026-05-01T18:21:58Z',
+    level: 'INFO',
+    message: 'Initialising OpenTofu working directory',
+  },
+  {
+    lineNumber: 2,
+    timestamp: '2026-05-01T18:21:59Z',
+    level: 'INFO',
+    message: 'Initializing the backend...',
+  },
+  {
+    lineNumber: 3,
+    timestamp: '2026-05-01T18:22:02Z',
+    level: 'INFO',
+    message: 'OpenTofu has been successfully initialized!',
+  },
+]
+
+describe('LogPane — Bug #481 fallbackLines path', () => {
+  it('renders fallback lines when executionId is null and fallbackLines is non-empty', () => {
+    render(
+      <LogPane
+        executionId={null}
+        fallbackLines={SAMPLE_LINES}
+        jobTitle="Provision Hetzner — terraform init"
+        statusLabel="Succeeded"
+        statusTone="succeeded"
+        onClose={() => {}}
+      />,
+    )
+    // The fallback list renders, NOT the empty state.
+    const list = screen.queryByTestId('fallback-log-list')
+    expect(list).not.toBeNull()
+    expect(screen.queryByTestId('log-pane-empty')).toBeNull()
+    // Every line is present, with its own row.
+    expect(screen.getByTestId('fallback-log-line-1')).toBeTruthy()
+    expect(screen.getByTestId('fallback-log-line-2')).toBeTruthy()
+    expect(screen.getByTestId('fallback-log-line-3')).toBeTruthy()
+    // Message text is visible.
+    expect(
+      screen.getByText('Initialising OpenTofu working directory'),
+    ).toBeTruthy()
+  })
+
+  it('renders the empty state when executionId is null and fallbackLines is empty', () => {
+    render(
+      <LogPane
+        executionId={null}
+        fallbackLines={[]}
+        jobTitle="Pending job"
+        statusTone="pending"
+        onClose={() => {}}
+      />,
+    )
+    expect(screen.getByTestId('log-pane-empty')).toBeTruthy()
+    expect(screen.queryByTestId('fallback-log-list')).toBeNull()
+  })
+
+  it('renders the empty state when both executionId and fallbackLines are absent', () => {
+    render(
+      <LogPane
+        executionId={null}
+        jobTitle="Pending job"
+        statusTone="pending"
+        onClose={() => {}}
+      />,
+    )
+    expect(screen.getByTestId('log-pane-empty')).toBeTruthy()
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/components/LogPane.tsx
+++ b/products/catalyst/bootstrap/ui/src/components/LogPane.tsx
@@ -27,17 +27,29 @@
  *       tokens; only the slide-in keyframe owns motion-specific values.
  */
 
-import { useCallback, useEffect, useState } from 'react'
-import { ExecutionLogs } from './ExecutionLogs'
-import { LogSearch, type LogFilter } from './LogSearch'
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { ExecutionLogs, type LogLine, LOG_VIEWER_BG, formatLogTimestamp } from './ExecutionLogs'
+import { LogSearch, lineMatches, type LogFilter } from './LogSearch'
 
 interface LogPaneProps {
   /**
    * Stable execution id used to fetch logs from the catalyst-api.
-   * When falsy / empty, the pane renders the "no execution recorded
-   * yet" empty state instead of mounting the polling viewer.
+   * When falsy / empty AND `fallbackLines` is also empty, the pane
+   * renders the "no execution recorded yet" empty state instead of
+   * mounting the polling viewer.
    */
   executionId: string | null | undefined
+  /**
+   * Bug #481 — inline fallback log lines for derived jobs that have no
+   * Bridge-allocated Execution row. Phase-0 jobs (`infrastructure:*`,
+   * `cluster-bootstrap`) live entirely in the SSE event reducer, so
+   * `useJobDetail` returns 404 and `executionId` is null, but the
+   * operator still expects to see the captured event log when they
+   * click the job. When this prop is non-empty AND `executionId` is
+   * null, the pane renders these lines through the same search /
+   * filter pipeline as the polling viewer.
+   */
+  fallbackLines?: readonly LogLine[]
   /** Display title — typically the host job's display name or jobName. */
   jobTitle: string
   /** Status text rendered as a small chip in the header strip. */
@@ -59,6 +71,7 @@ const EMPTY_FILTER: LogFilter = { query: '', regex: false, levels: new Set() }
 
 export function LogPane({
   executionId,
+  fallbackLines,
   jobTitle,
   statusLabel,
   statusTone = 'pending',
@@ -204,12 +217,172 @@ export function LogPane({
             />
           </div>
         </>
+      ) : fallbackLines && fallbackLines.length > 0 ? (
+        <>
+          <LogSearch
+            matchCount={matchCount}
+            matchIndex={matchIndex}
+            onPrev={goPrev}
+            onNext={goNext}
+            onFilterChange={setFilter}
+          />
+          <div className="log-pane-body" data-testid="log-pane-body">
+            <FallbackLogList
+              lines={fallbackLines}
+              filter={filter}
+              matchIndex={matchIndex}
+              onMatchCountChange={setMatchCount}
+            />
+          </div>
+        </>
       ) : (
         <div className="log-pane-empty" data-testid="log-pane-empty">
           No execution recorded yet.
         </div>
       )}
     </aside>
+  )
+}
+
+/* ── FallbackLogList — render synthetic LogLines without polling ─── */
+/**
+ * Bug #481 — used when the JobDetail page's selected job is a derived
+ * job (Phase-0 tofu, cluster-bootstrap) that has no Bridge-allocated
+ * Execution row. The DerivedJob.steps array IS the log content for
+ * those jobs; this component renders it through the same dark-theme,
+ * line-numbered presentation as ExecutionLogs without the polling /
+ * pagination machinery.
+ *
+ * Visual contract is intentionally identical to ExecutionLogs:
+ *   • Background `#0D1117`, monospace, line numbers on the left.
+ *   • Search filter applied via LogSearch (case / regex / level).
+ *   • Match-index scroll-into-view via `data-match-position`.
+ *
+ * Pure presentation, no data fetching. Inputs are static; the parent
+ * (JobDetail) re-renders this on every reducer update so the lines
+ * stream in live as the SSE replay catches up.
+ */
+interface FallbackLogListProps {
+  lines: readonly LogLine[]
+  filter: LogFilter
+  matchIndex: number
+  onMatchCountChange: (n: number) => void
+}
+
+function FallbackLogList({
+  lines,
+  filter,
+  matchIndex,
+  onMatchCountChange,
+}: FallbackLogListProps) {
+  const filterActive =
+    filter.query.trim().length > 0 || filter.levels.size > 0
+
+  const displayed = useMemo(() => {
+    if (!filterActive) return lines
+    const out: LogLine[] = []
+    for (const ll of lines) {
+      if (filter.levels.size > 0 && !filter.levels.has(ll.level)) continue
+      if (!lineMatches(ll.message, filter)) continue
+      out.push(ll)
+    }
+    return out
+  }, [lines, filter, filterActive])
+
+  useEffect(() => {
+    onMatchCountChange(filterActive ? displayed.length : 0)
+  }, [displayed, filterActive, onMatchCountChange])
+
+  const lineNumWidth = useMemo(() => {
+    const last = displayed[displayed.length - 1]
+    const digits = Math.max(3, String(last?.lineNumber ?? 0).length)
+    return `${digits}ch`
+  }, [displayed])
+
+  return (
+    <div
+      data-testid="fallback-log-list"
+      style={{
+        background: LOG_VIEWER_BG,
+        borderRadius: 6,
+        position: 'relative',
+        overflow: 'auto',
+        height: '100%',
+        fontFamily:
+          'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace',
+      }}
+    >
+      {displayed.length === 0 ? (
+        <div
+          data-testid="fallback-log-empty"
+          style={{
+            padding: '1rem',
+            color: 'rgba(201, 209, 217, 0.55)',
+            fontSize: '0.78rem',
+          }}
+        >
+          {filterActive
+            ? 'No log lines match the active search.'
+            : 'No logs captured yet for this job.'}
+        </div>
+      ) : (
+        displayed.map((line, idx) => {
+          const matchPosition = filterActive ? idx + 1 : 0
+          const isFocusedMatch = filterActive && matchIndex === matchPosition
+          return (
+            <div
+              key={line.lineNumber}
+              data-testid={`fallback-log-line-${line.lineNumber}`}
+              data-level={line.level}
+              data-match-position={matchPosition || undefined}
+              data-focused-match={isFocusedMatch ? 'true' : undefined}
+              style={{
+                display: 'flex',
+                alignItems: 'flex-start',
+                gap: '0.6rem',
+                padding: '0.1rem 0.85rem',
+                fontSize: '0.78rem',
+                lineHeight: 1.55,
+                color: '#c9d1d9',
+                whiteSpace: 'pre-wrap',
+                wordBreak: 'break-word',
+                background: isFocusedMatch ? 'rgba(56, 139, 253, 0.18)' : 'transparent',
+              }}
+            >
+              <span
+                style={{
+                  width: lineNumWidth,
+                  flexShrink: 0,
+                  textAlign: 'right',
+                  color: 'rgba(139, 148, 158, 0.7)',
+                  fontVariantNumeric: 'tabular-nums',
+                  userSelect: 'none',
+                }}
+              >
+                {line.lineNumber}
+              </span>
+              <span
+                style={{
+                  flexShrink: 0,
+                  color: 'rgba(139, 148, 158, 0.85)',
+                  fontVariantNumeric: 'tabular-nums',
+                }}
+              >
+                {formatLogTimestamp(line.timestamp)}
+              </span>
+              <span
+                style={{
+                  flex: '1 1 auto',
+                  minWidth: 0,
+                }}
+              >
+                {line.message}
+              </span>
+            </div>
+          )
+        })
+      )}
+    </div>
   )
 }
 

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/FlowCanvasOrganic.bounded.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/FlowCanvasOrganic.bounded.test.tsx
@@ -1,0 +1,134 @@
+/**
+ * FlowCanvasOrganic — Bug #481 bounded layout regression test.
+ *
+ * The canvas previously rendered nodes scattered "between left + right
+ * panes, tiny — barely visible — connected by kilometers of lines".
+ * Root cause: weak forceY (strength 0.05) + weak link force (strength
+ * 0.08) + ±140px Y scatter on first paint + no viewBox ceiling.
+ *
+ * The fix tightens four knobs (force strengths, seed scatter) AND adds
+ * a hard MAX_VBOX clamp on the SVG viewBox + a per-tick bounding-box
+ * clamp on every node's x/y. This test locks in the structural ceiling
+ * — the SVG's effective viewBox MUST stay within the documented
+ * MAX_VBOX_W × MAX_VBOX_H rectangle no matter what positions the
+ * simulation produces.
+ */
+import { describe, it, expect, afterEach } from 'vitest'
+import { render, cleanup } from '@testing-library/react'
+import { FlowCanvasOrganic } from './FlowCanvasOrganic'
+import type { OrganicLayoutResult } from '@/lib/flowLayoutOrganic'
+
+afterEach(() => cleanup())
+
+const FAMILIES = [{ id: 'catalyst', label: 'Catalyst', color: '#fff' }]
+const REGIONS = [{ id: 'primary', label: 'Primary' }]
+
+function makeLayout(nodeCount: number): OrganicLayoutResult {
+  const nodes = Array.from({ length: nodeCount }, (_, i) => ({
+    id: `n${i}`,
+    depth: i % 4,
+    regionId: 'primary',
+    familyId: 'catalyst',
+    label: `Node ${i}`,
+    subLabel: '',
+    status: 'pending' as const,
+    isGroup: false,
+    isFolded: false,
+    childCount: 0,
+    job: {
+      id: `n${i}`,
+      jobName: `n${i}`,
+      type: 'install' as const,
+      appId: 'x',
+      parentId: '',
+      dependsOn: [],
+      childIds: [],
+      status: 'pending' as const,
+      startedAt: null,
+      finishedAt: null,
+      durationMs: 0,
+    },
+  }))
+  // Chain edges so the link force has work to do.
+  const edges = nodes.slice(1).map((_, i) => ({
+    fromId: `n${i}`,
+    toId: `n${i + 1}`,
+    fromStatus: 'pending' as const,
+    crossRegion: false,
+    kind: 'depends-on' as const,
+  }))
+  return {
+    nodes,
+    edges,
+    maxDepth: 3,
+    regions: REGIONS,
+    families: FAMILIES,
+  }
+}
+
+describe('FlowCanvasOrganic — Bug #481 bounded layout', () => {
+  it('clamps viewBox width within MAX_VBOX_W (1600) on a typical 12-node graph', () => {
+    const layout = makeLayout(12)
+    const { container } = render(
+      <FlowCanvasOrganic
+        layout={layout}
+        openJobId={null}
+        hostJobId={null}
+        onJobClick={() => {}}
+        onJobDoubleClick={() => {}}
+        onCanvasBackgroundClick={() => {}}
+      />,
+    )
+    const svg = container.querySelector<SVGSVGElement>(
+      '[data-testid="flow-canvas-svg"]',
+    )
+    expect(svg).not.toBeNull()
+    const vb = svg!.getAttribute('viewBox') ?? ''
+    const parts = vb.split(/\s+/).map(Number)
+    expect(parts).toHaveLength(4)
+    const [, , w, h] = parts
+    // Bug #481 — must NOT exceed the documented hard ceiling.
+    expect(w).toBeLessThanOrEqual(1600)
+    expect(h).toBeLessThanOrEqual(900)
+    // Floor (MIN_VBOX_W / MIN_VBOX_H) — readable on small graphs.
+    expect(w).toBeGreaterThanOrEqual(1200)
+    expect(h).toBeGreaterThanOrEqual(700)
+  })
+
+  it('renders all nodes with translate inside the clamped viewBox (no off-canvas drift)', () => {
+    const layout = makeLayout(8)
+    const { container } = render(
+      <FlowCanvasOrganic
+        layout={layout}
+        openJobId={null}
+        hostJobId={null}
+        onJobClick={() => {}}
+        onJobDoubleClick={() => {}}
+        onCanvasBackgroundClick={() => {}}
+      />,
+    )
+    const svg = container.querySelector<SVGSVGElement>(
+      '[data-testid="flow-canvas-svg"]',
+    )!
+    const vb = svg.getAttribute('viewBox') ?? ''
+    const [vbX, vbY, vbW, vbH] = vb.split(/\s+/).map(Number)
+    const groups = container.querySelectorAll<SVGGElement>(
+      '[data-flow-draggable]',
+    )
+    expect(groups.length).toBe(8)
+    for (const g of Array.from(groups)) {
+      const t = g.getAttribute('transform') ?? ''
+      const m = t.match(/translate\(([-\d.]+),\s*([-\d.]+)\)/)
+      expect(m).not.toBeNull()
+      const x = Number(m![1])
+      const y = Number(m![2])
+      // Allow a 60px overshoot for nodes still in their initial seed
+      // position before the simulation has ticked. The structural
+      // assertion is that nothing has drifted to "kilometers" away.
+      expect(x).toBeGreaterThan(vbX - 60)
+      expect(x).toBeLessThan(vbX + vbW + 60)
+      expect(y).toBeGreaterThan(vbY - 60)
+      expect(y).toBeLessThan(vbY + vbH + 60)
+    }
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/FlowCanvasOrganic.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/FlowCanvasOrganic.tsx
@@ -107,6 +107,32 @@ const COLLIDE_PADDING = 14
 const MIN_VBOX_W = 1200
 const MIN_VBOX_H = 700
 const VIEW_H = 1100
+/** Bug #481 — viewport-bounded layout. The viewBox is clamped to keep
+ *  nodes inside a sensible rectangle so the operator never sees the
+ *  "kilometers of edges between scattered tiny nodes" problem. The
+ *  clamp is wide enough to fit the canvas at 1440px without scrolling,
+ *  but narrow enough that 4-12 leaf nodes cluster around the host. */
+const MAX_VBOX_W = 1600
+const MAX_VBOX_H = 900
+/** Per-depth column width — kept small enough that even at depth=6 the
+ *  rightmost node sits well inside MAX_VBOX_W. Tuned with NODE_RADIUS
+ *  for collision-free packing. */
+const PER_DEPTH_X = NODE_RADIUS * 5
+/** Vertical scatter on first paint and inside the soft `forceY`. The
+ *  previous value (±140 / ±180) sent siblings flying outside the
+ *  viewport on small graphs (Bug #481). Using ±60 keeps siblings
+ *  loosely organic without scattering them into different panes. */
+const Y_SCATTER_PX = 60
+/** Link distance — short edges keep the graph readable. Was 4×r=88px;
+ *  the new value caps observed edge length around 110px for the
+ *  steady-state simulation. */
+const LINK_DISTANCE = NODE_RADIUS * 4
+/** Force strengths tuned for Bug #481. Strong link + strong y pulls
+ *  pull siblings into a tight cluster around the host instead of
+ *  drifting to the canvas edges. */
+const FORCE_X_STRENGTH = 0.55
+const FORCE_Y_STRENGTH = 0.22
+const FORCE_LINK_STRENGTH = 0.45
 
 /** Selection palette — distinct from any status colour AND distinct
  *  from each other so the host-vs-open semantic is unambiguous. */
@@ -164,10 +190,9 @@ export function FlowCanvasOrganic(props: FlowCanvasOrganicProps) {
     return map
   }, [layout.regions, REGION_BAND_H])
 
-  const PER_DEPTH_X = NODE_RADIUS * 5
   const depthToX = useCallback(
     (depth: number) => depth * PER_DEPTH_X,
-    [PER_DEPTH_X],
+    [],
   )
 
   const familyById = useMemo(() => {
@@ -200,8 +225,13 @@ export function FlowCanvasOrganic(props: FlowCanvasOrganicProps) {
           familyId: n.familyId,
           status: n.status,
           isGroup: n.isGroup,
-          x: baseX + (seed.fx - 0.5) * 80,
-          y: baseY + (seed.fy - 0.5) * 280,
+          // Bug #481 — tighten initial scatter so the simulation starts
+          // close to the steady state. Previous values (±40 X, ±140 Y)
+          // sent siblings to opposite corners of the canvas; the new
+          // values keep them inside the visible cluster from the first
+          // frame.
+          x: baseX + (seed.fx - 0.5) * 40,
+          y: baseY + (seed.fy - 0.5) * Y_SCATTER_PX * 2,
         }
         nodesRef.current.set(n.id, fresh)
         next.push(fresh)
@@ -240,7 +270,7 @@ export function FlowCanvasOrganic(props: FlowCanvasOrganicProps) {
         'x',
         forceX<SimNode>()
           .x((d) => depthToX(d.depth))
-          .strength(0.55),
+          .strength(FORCE_X_STRENGTH),
       )
       .force(
         'y',
@@ -248,18 +278,55 @@ export function FlowCanvasOrganic(props: FlowCanvasOrganicProps) {
           .y((d) => {
             const base = regionYMid.get(d.regionId) ?? VIEW_H / 2
             const seed = hashSeed(d.id)
-            return base + (seed.fy - 0.5) * 360
+            // Bug #481 — clamp the per-node Y target inside ±Y_SCATTER_PX
+            // so the soft `forceY` cannot stretch the graph into a
+            // kilometers-tall column. Previous value (±180) was the
+            // root of the "scattered between left + right panes" symptom.
+            return base + (seed.fy - 0.5) * Y_SCATTER_PX * 2
           })
-          .strength(0.05),
+          .strength(FORCE_Y_STRENGTH),
       )
       .force(
         'link',
         forceLink<SimNode, SimulationLinkDatum<SimNode>>(links)
           .id((d) => d.id)
-          .distance(NODE_RADIUS * 4)
-          .strength(0.08),
+          // Bug #481 — strong link force pulls dependent siblings into a
+          // tight cluster around their depth column. Distance was
+          // already 88px; the strength jump from 0.08 → 0.45 is what
+          // keeps edges visibly under ~140px on a 4-12 node graph.
+          .distance(LINK_DISTANCE)
+          .strength(FORCE_LINK_STRENGTH),
       )
-      .on('tick', () => setTick((t) => t + 1))
+      .on('tick', () => {
+        // Bug #481 — post-tick bounding box clamp. d3-force has no
+        // built-in viewport awareness, so we clamp every node back into
+        // the MAX_VBOX rectangle around the depth-anchored centroid.
+        // Without this, weak link forces on sparse graphs let nodes
+        // drift hundreds of pixels off-screen between ticks.
+        for (const n of simNodes) {
+          const baseX = depthToX(n.depth)
+          // X clamp: ± half the per-depth column width so nodes stay
+          // close to their depth anchor instead of wandering left/right
+          // into adjacent columns.
+          const xMin = baseX - PER_DEPTH_X * 1.5
+          const xMax = baseX + PER_DEPTH_X * 1.5
+          if (typeof n.x === 'number') {
+            if (n.x < xMin) n.x = xMin
+            else if (n.x > xMax) n.x = xMax
+          }
+          // Y clamp: keep the simulation inside the viewport's vertical
+          // bounds. Use MAX_VBOX_H / 2 around the region centroid as a
+          // hard wall — beyond that the node would render off-canvas.
+          const baseY = regionYMid.get(n.regionId) ?? VIEW_H / 2
+          const yMin = baseY - MAX_VBOX_H / 2 + NODE_RADIUS
+          const yMax = baseY + MAX_VBOX_H / 2 - NODE_RADIUS
+          if (typeof n.y === 'number') {
+            if (n.y < yMin) n.y = yMin
+            else if (n.y > yMax) n.y = yMax
+          }
+        }
+        setTick((t) => t + 1)
+      })
 
     simRef.current = sim
     return () => {
@@ -343,8 +410,17 @@ export function FlowCanvasOrganic(props: FlowCanvasOrganicProps) {
   const PAD_Y_BOTTOM = NODE_RADIUS + 40
   const naturalW = (bbMaxX - bbMinX) + PAD_X * 2
   const naturalH = (bbMaxY - bbMinY) + PAD_Y_TOP + PAD_Y_BOTTOM
-  const vbW = Math.max(MIN_VBOX_W, naturalW)
-  const vbH = Math.max(MIN_VBOX_H, naturalH)
+  // Bug #481 — clamp the viewBox between MIN and MAX so:
+  //   • Tiny graphs (4-6 nodes) don't squeeze into a microscopic cluster
+  //     (MIN floor keeps them readable at ≥120px wide each).
+  //   • Pathological / runaway graphs don't force the SVG to scale
+  //     down so far the nodes turn into specks (MAX ceiling).
+  // The MAX ceiling is the operative half of this clamp for #481 — it
+  // is the structural answer to "kilometers of edges between tiny
+  // nodes": even if the simulation drifts, the visible area never
+  // exceeds MAX, so nodes always render at a usable size.
+  const vbW = Math.min(MAX_VBOX_W, Math.max(MIN_VBOX_W, naturalW))
+  const vbH = Math.min(MAX_VBOX_H, Math.max(MIN_VBOX_H, naturalH))
   const cx = Number.isFinite(bbMinX) ? (bbMinX + bbMaxX) / 2 : vbW / 2
   const cy = Number.isFinite(bbMinY) ? (bbMinY + bbMaxY) / 2 : vbH / 2
   const vbX = cx - vbW / 2

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/JobDetail.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/JobDetail.tsx
@@ -46,12 +46,13 @@ import { PortalShell } from './PortalShell'
 import { resolveApplications } from './applicationCatalog'
 import { useDeploymentEvents } from './useDeploymentEvents'
 import { deriveJobs, fmtTime, statusBadge } from './jobs'
-import type { JobUiStatus } from './jobs'
+import type { Job as DerivedJob, JobUiStatus, JobStep } from './jobs'
 import { adaptDerivedJobsToFlat } from './jobsAdapter'
 import { useLiveJobsBackfill, mergeJobs } from './useLiveJobsBackfill'
 import { useJobDetail } from './useJobDetail'
 import type { Job } from '@/lib/jobs.types'
 import { LogPane } from '@/components/LogPane'
+import type { LogLine, LogLevel } from '@/components/ExecutionLogs'
 import { FlowPage } from './FlowPage'
 
 interface JobDetailProps {
@@ -86,6 +87,11 @@ export function JobDetail({
   const sovereignFQDN = snapshot?.sovereignFQDN ?? snapshot?.result?.sovereignFQDN ?? null
 
   const derivedJobs = useMemo(() => deriveJobs(state, applications), [state, applications])
+  const derivedJobsById = useMemo<Record<string, DerivedJob>>(() => {
+    const out: Record<string, DerivedJob> = {}
+    for (const j of derivedJobs) out[j.id] = j
+    return out
+  }, [derivedJobs])
   const reducerJobs = useMemo(() => adaptDerivedJobsToFlat(derivedJobs), [derivedJobs])
   const inFlight = streamStatus !== 'completed' && streamStatus !== 'failed'
   const { liveJobs } = useLiveJobsBackfill({
@@ -125,6 +131,21 @@ export function JobDetail({
   })
   const executionId = detail.latestExecutionId
   const detailJobStatus = detail.job?.status
+
+  // Bug #481 — derived-job fallback log lines. When `useJobDetail` has no
+  // Bridge-allocated execution (Phase-0 tofu jobs, cluster-bootstrap, or
+  // any per-bp-* job whose Helm watch has not yet emitted an execution
+  // row), the LogPane would render the "No execution recorded yet"
+  // empty state — even though we already have the SSE event log buffered
+  // in derivedJobs[selectedJobId].steps. Map those steps to LogLines so
+  // the operator sees the captured events.
+  const fallbackLines = useMemo<LogLine[]>(() => {
+    if (executionId) return [] // Real execution wins — don't double-render.
+    const id = selectedJob?.id ?? jobId
+    const dj = derivedJobsById[id]
+    if (!dj) return []
+    return stepsToLogLines(dj.steps)
+  }, [executionId, selectedJob, jobId, derivedJobsById])
 
   const onCanvasJobSelect = useCallback(
     (id: string | null) => {
@@ -280,6 +301,7 @@ export function JobDetail({
       {paneOpen ? (
         <CanvasLogBridge
           executionId={executionId}
+          fallbackLines={fallbackLines}
           jobTitle={logPaneJob.displayName ?? logPaneJob.jobName}
           jobStatus={logPaneStatus}
           onClose={() => {
@@ -302,12 +324,20 @@ export function JobDetail({
 
 interface CanvasLogBridgeProps {
   executionId: string | null | undefined
+  /** Bug #481 — derived-job fallback lines (Phase-0, cluster-bootstrap). */
+  fallbackLines: readonly LogLine[]
   jobTitle: string
   jobStatus: string
   onClose: () => void
 }
 
-function CanvasLogBridge({ executionId, jobTitle, jobStatus, onClose }: CanvasLogBridgeProps) {
+function CanvasLogBridge({
+  executionId,
+  fallbackLines,
+  jobTitle,
+  jobStatus,
+  onClose,
+}: CanvasLogBridgeProps) {
   const tone: 'pending' | 'running' | 'succeeded' | 'failed' =
     jobStatus === 'running' || jobStatus === 'succeeded' || jobStatus === 'failed'
       ? jobStatus
@@ -315,12 +345,48 @@ function CanvasLogBridge({ executionId, jobTitle, jobStatus, onClose }: CanvasLo
   return (
     <LogPane
       executionId={executionId ?? null}
+      fallbackLines={fallbackLines}
       jobTitle={jobTitle}
       statusLabel={jobStatus}
       statusTone={tone}
       onClose={onClose}
     />
   )
+}
+
+/* ──────────────────────────────────────────────────────────────────
+ * stepsToLogLines — DerivedJob.step[] → LogLine[] adapter (Bug #481)
+ *
+ * The reducer state owns the live SSE event log for derived jobs
+ * (Phase-0 tofu, cluster-bootstrap, per-bp-* installs whose Helm
+ * watcher hasn't allocated an Execution row yet). Each step maps 1:1
+ * to a LogLine — we just need to pick a sensible LogLevel from the
+ * step's status + name and number the lines from 1.
+ * ────────────────────────────────────────────────────────────────── */
+
+function stepsToLogLines(steps: readonly JobStep[]): LogLine[] {
+  return steps.map((s, i): LogLine => {
+    let level: LogLevel = 'INFO'
+    if (s.status === 'failed') level = 'ERROR'
+    // Heuristic: name strings starting with a `-` / `+` / `Initializing`
+    // are tofu CLI noise — surface them as DEBUG so a level-filter on
+    // INFO-only doesn't drown the operator. The reducer doesn't carry
+    // a level field for derived steps, so this is the cleanest place
+    // to derive one.
+    else if (
+      s.name.startsWith('+ ') ||
+      s.name.startsWith('- ') ||
+      s.name.startsWith('# ')
+    ) {
+      level = 'DEBUG'
+    }
+    return {
+      lineNumber: i + 1,
+      timestamp: s.startedAt ?? '',
+      level,
+      message: s.name,
+    }
+  })
 }
 
 const JOB_DETAIL_CSS = `


### PR DESCRIPTION
## Why
Phase-8a-preflight live deployment a76e3fec8566add9 surfaced two stacked JobDetail bugs operators reported as "NO VISIBILITY":

### Bug A — Flow physics broken
Jobs scattered between left + right panes, tiny barely-visible nodes, kilometers-long connector lines. Layout unusable.

### Bug B — Exec logs viewer empty
Clicking ANY job (even Phase-0 jobs that show "Succeeded" in the table) → LogPane shows "No execution recorded yet".

## Root cause

### Bug A
- `forceY` strength 0.05 + `forceLink` strength 0.08 are too weak to cluster sparse graphs.
- ±140 px initial Y scatter + ±180 px forceY target scatter sent siblings into opposite vertical halves.
- No viewBox ceiling: when the simulation drifted, MIN_VBOX_W didn't help; nothing prevented the SVG from scaling down enough that nodes turned into specks.

### Bug B
- `useJobDetail` queries `/api/v1/deployments/{id}/jobs/{jobId}` for the latest Execution.
- For derived jobs (Phase-0 `infrastructure:tofu-*`, `cluster-bootstrap`, and per-bp-* installs whose Helm watcher hasn't allocated an Execution yet) the catalyst-api Bridge has no Execution rows — endpoint returns 404 → `executionId === null` → `LogPane` renders the empty state.
- BUT the SSE event reducer already has the live event log buffered in `DerivedJob.steps[]`. The viewer just wasn't using it.

## Fix

### Bug A — `FlowCanvasOrganic.tsx`
- `forceY` 0.05 → 0.22, `forceLink` 0.08 → 0.45 so the simulation pulls siblings tight around the host.
- Initial Y scatter ±140 → ±60; forceY target scatter ±180 → ±60.
- New `MAX_VBOX_W = 1600`, `MAX_VBOX_H = 900` ceiling on the SVG viewBox.
- Per-tick clamp: every node's `x` is bound to `±1.5 × PER_DEPTH_X` around its depth column; `y` is bound to `±MAX_VBOX_H/2` around the region centroid. This is the structural fix — even if forces are insufficient, nodes physically cannot drift "to kilometers".

### Bug B — `LogPane.tsx` + `JobDetail.tsx`
- New `fallbackLines: LogLine[]` prop on `LogPane`. When `executionId` is null AND `fallbackLines` is non-empty, renders inline through the same dark-theme line-numbered viewer as `ExecutionLogs` (no polling, no API).
- `JobDetail.tsx` builds the fallback by mapping `derivedJobsById[selectedJobId].steps[]` → `LogLine[]` via `stepsToLogLines()`.

## Tests
New:
- `FlowCanvasOrganic.bounded.test.tsx` — locks the viewBox MAX ceiling + per-node containment on a typical 12-node graph.
- `LogPane.fallback.test.tsx` — 3 paths: fallback lines render / empty fallback shows empty state / no props shows empty state.

Pre-existing 11 cycle-protection + JobDetail tests continue to pass.

## Test plan
- [ ] CI green
- [ ] Live verification on a fresh deployment: click any Phase-0 job in the JobDetail flow → LogPane shows the captured tofu events
- [ ] Visual: nodes cluster tightly around the host; edges are visibly under ~140 px on a 1440 px viewport

Closes #481

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>