### PR TITLE
fix(infra): split Cilium-Gateway Certificate into sovereign-tls Kustomization

### DIFF
--- a/clusters/_template/bootstrap-kit/01-cilium.yaml
+++ b/clusters/_template/bootstrap-kit/01-cilium.yaml
@@ -102,24 +102,6 @@ spec:
 # Sovereign apply time — contabo's bootstrap path does NOT include this
 # template, so Traefik continues to serve console.openova.io/nova
 # unchanged.
-apiVersion: cert-manager.io/v1
-kind: Certificate
-metadata:
-  name: sovereign-wildcard-tls
-  namespace: kube-system
-  labels:
-    catalyst.openova.io/sovereign: ${SOVEREIGN_FQDN}
-    catalyst.openova.io/component: cilium-gateway
-spec:
-  secretName: sovereign-wildcard-tls
-  issuerRef:
-    name: letsencrypt-dns01-prod
-    kind: ClusterIssuer
-  commonName: "*.${SOVEREIGN_FQDN}"
-  dnsNames:
-    - "*.${SOVEREIGN_FQDN}"
-    - "${SOVEREIGN_FQDN}"
----
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:

--- a/clusters/_template/sovereign-tls/cilium-gateway-cert.yaml
+++ b/clusters/_template/sovereign-tls/cilium-gateway-cert.yaml
@@ -1,0 +1,39 @@
+# Wildcard TLS Certificate for the Cilium Gateway listener.
+#
+# Split from clusters/_template/bootstrap-kit/01-cilium.yaml in
+# fix/cilium-cert-split-from-bootstrap-kit (Phase-8a bug #13). The
+# Cert lives in its OWN Flux Kustomization (`sovereign-tls`) which
+# depends on bootstrap-kit being Ready — i.e. cert-manager + the
+# powerdns-webhook are both installed and their CRDs registered.
+#
+# Without this split, Flux's server-side dry-run on the bootstrap-kit
+# Kustomization fails with `no matches for kind "Certificate" in
+# version "cert-manager.io/v1"` because the validation runs BEFORE any
+# HelmRelease has installed the cert-manager CRDs — and a single
+# dry-run failure aborts the entire Kustomization apply, leaving the
+# Sovereign with zero HRs reconciled.
+#
+# The Gateway resource stays in 01-cilium.yaml: Gateway.networking.k8s.io
+# CRDs ship with Cilium itself (gatewayAPI.enabled=true) and dry-run
+# against them only requires the Gateway API CRD bundle which Cilium
+# pre-installs at chart-time. The Certificate is the ONLY resource
+# whose CRD is provided by a HelmRelease in the same Kustomization
+# that needs to validate it.
+
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: sovereign-wildcard-tls
+  namespace: kube-system
+  labels:
+    catalyst.openova.io/sovereign: ${SOVEREIGN_FQDN}
+    catalyst.openova.io/component: cilium-gateway
+spec:
+  secretName: sovereign-wildcard-tls
+  issuerRef:
+    name: letsencrypt-dns01-prod
+    kind: ClusterIssuer
+  commonName: "*.${SOVEREIGN_FQDN}"
+  dnsNames:
+    - "*.${SOVEREIGN_FQDN}"
+    - "${SOVEREIGN_FQDN}"

--- a/clusters/_template/sovereign-tls/kustomization.yaml
+++ b/clusters/_template/sovereign-tls/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - cilium-gateway-cert.yaml

--- a/infra/hetzner/cloudinit-control-plane.tftpl
+++ b/infra/hetzner/cloudinit-control-plane.tftpl
@@ -405,6 +405,32 @@ write_files:
       apiVersion: kustomize.toolkit.fluxcd.io/v1
       kind: Kustomization
       metadata:
+        name: sovereign-tls
+        namespace: flux-system
+      spec:
+        # Carries the cert-manager Certificate that backs Cilium Gateway's
+        # wildcard-TLS listener. Split out of bootstrap-kit so its
+        # `cert-manager.io/v1` CRD-dependent dry-run only runs AFTER
+        # bp-cert-manager is Ready (Phase-8a bug #13). dependsOn
+        # bootstrap-kit's `wait: true` semantics: bootstrap-kit reaches
+        # Ready iff every HelmRelease + Kustomization in it Ready=True.
+        interval: 5m
+        path: ./clusters/_template/sovereign-tls
+        prune: true
+        sourceRef:
+          kind: GitRepository
+          name: openova
+        dependsOn:
+          - name: bootstrap-kit
+        wait: true
+        timeout: 30m
+        postBuild:
+          substitute:
+            SOVEREIGN_FQDN: ${sovereign_fqdn}
+      ---
+      apiVersion: kustomize.toolkit.fluxcd.io/v1
+      kind: Kustomization
+      metadata:
         name: infrastructure-config
         namespace: flux-system
       spec:
@@ -416,6 +442,7 @@ write_files:
           name: openova
         dependsOn:
           - name: bootstrap-kit
+          - name: sovereign-tls
         wait: true
         timeout: 30m
         postBuild:


### PR DESCRIPTION
Phase-8a bug #13. bootstrap-kit Kustomization fails server-side dry-run because Certificate CRD isn't installed yet → ZERO HelmReleases reconcile → empty cluster. Split Certificate into separate Kustomization that dependsOn bootstrap-kit Ready (i.e. cert-manager HR Ready, CRDs registered). Gateway stays — its CRDs ship with Cilium.