### PR TITLE
fix(infra): move Cilium Gateway to sovereign-tls Kustomization (#484 follow-up)

### DIFF
--- a/clusters/_template/bootstrap-kit/01-cilium.yaml
+++ b/clusters/_template/bootstrap-kit/01-cilium.yaml
@@ -102,33 +102,3 @@ spec:
 # Sovereign apply time — contabo's bootstrap path does NOT include this
 # template, so Traefik continues to serve console.openova.io/nova
 # unchanged.
-apiVersion: gateway.networking.k8s.io/v1
-kind: Gateway
-metadata:
-  name: cilium-gateway
-  namespace: kube-system
-  labels:
-    catalyst.openova.io/sovereign: ${SOVEREIGN_FQDN}
-    catalyst.openova.io/component: cilium-gateway
-spec:
-  gatewayClassName: cilium
-  listeners:
-    - name: https
-      port: 443
-      protocol: HTTPS
-      hostname: "*.${SOVEREIGN_FQDN}"
-      tls:
-        mode: Terminate
-        certificateRefs:
-          - kind: Secret
-            name: sovereign-wildcard-tls
-      allowedRoutes:
-        namespaces:
-          from: All
-    - name: http
-      port: 80
-      protocol: HTTP
-      hostname: "*.${SOVEREIGN_FQDN}"
-      allowedRoutes:
-        namespaces:
-          from: All

--- a/clusters/_template/sovereign-tls/cilium-gateway.yaml
+++ b/clusters/_template/sovereign-tls/cilium-gateway.yaml
@@ -1,0 +1,37 @@
+# Cilium Gateway (Phase-8a bug #14 follow-up to #484).
+# Moved out of bootstrap-kit/01-cilium.yaml because gateway.networking.k8s.io/v1
+# CRDs are installed by the Cilium HelmRelease itself; Flux dry-runs the
+# whole Kustomization before applying any HR, so Gateway dry-run fails on
+# a fresh cluster. The sovereign-tls Kustomization dependsOn bootstrap-kit
+# Ready, so by the time Gateway is applied here, Cilium has installed.
+
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: cilium-gateway
+  namespace: kube-system
+  labels:
+    catalyst.openova.io/sovereign: ${SOVEREIGN_FQDN}
+    catalyst.openova.io/component: cilium-gateway
+spec:
+  gatewayClassName: cilium
+  listeners:
+    - name: https
+      port: 443
+      protocol: HTTPS
+      hostname: "*.${SOVEREIGN_FQDN}"
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - kind: Secret
+            name: sovereign-wildcard-tls
+      allowedRoutes:
+        namespaces:
+          from: All
+    - name: http
+      port: 80
+      protocol: HTTP
+      hostname: "*.${SOVEREIGN_FQDN}"
+      allowedRoutes:
+        namespaces:
+          from: All

--- a/clusters/_template/sovereign-tls/kustomization.yaml
+++ b/clusters/_template/sovereign-tls/kustomization.yaml
@@ -2,3 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - cilium-gateway-cert.yaml
+  - cilium-gateway.yaml


### PR DESCRIPTION
Phase-8a bug #14. After #484 split the Cert, the Gateway also fails dry-run for the same reason: gateway.networking.k8s.io/v1 CRDs come from Cilium HR which hasn't installed yet at validation time. Move Gateway into sovereign-tls too.