### PR TITLE
fix(catalyst-api): Phase-1 short-circuit must NOT flip Status to ready

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/phase1_watch.go
+++ b/products/catalyst/bootstrap/api/internal/handler/phase1_watch.go
@@ -115,8 +115,11 @@ func (h *Handler) runPhase1Watch(dep *Deployment) {
 			Level:   "warn",
 			Message: "Phase-1 watch skipped: no kubeconfig is available on the catalyst-api side. The new Sovereign's cloud-init has not yet PUT its kubeconfig to /api/v1/deployments/{id}/kubeconfig — either Phase 0 is still in flight, or cloud-init failed to reach this endpoint. Operator can fetch the kubeconfig via SSH (see docs/RUNBOOK-PROVISIONING.md §Fetch kubeconfig via SSH) and re-run the deployment to observe per-component install state.",
 		})
-		// Short-circuit path — no watch ever ran, so outcome is empty.
-		h.markPhase1Done(dep, nil, "")
+		// Short-circuit path — no watch ever ran. Outcome MUST be
+		// OutcomeKubeconfigMissing (not empty) so markPhase1Done sets
+		// Status to a truthful failed state instead of falling through
+		// to the default "ready" branch — issue #488.
+		h.markPhase1Done(dep, nil, helmwatch.OutcomeKubeconfigMissing)
 		return
 	}
 
@@ -131,8 +134,10 @@ func (h *Handler) runPhase1Watch(dep *Deployment) {
 			Level:   "error",
 			Message: fmt.Sprintf("Phase-1 watch could not start: %v — Sovereign cluster is up (Phase 0 succeeded) but per-component state will not stream from this catalyst-api. Operator may run `kubectl get helmrelease -n flux-system` against the new Sovereign for ad-hoc diagnostics.", err),
 		})
-		// Short-circuit path — no watch ever ran, so outcome is empty.
-		h.markPhase1Done(dep, nil, "")
+		// Short-circuit path — watcher never ran. OutcomeWatcherStartFailed
+		// (not empty) keeps markPhase1Done from defaulting to "ready"
+		// — issue #488.
+		h.markPhase1Done(dep, nil, helmwatch.OutcomeWatcherStartFailed)
 		return
 	}
 
@@ -269,6 +274,20 @@ func (h *Handler) markPhase1Done(dep *Deployment, finalStates map[string]string,
 
 	dep.FinishedAt = time.Now()
 	switch {
+	case outcome == helmwatch.OutcomeKubeconfigMissing:
+		// Issue #488 (Phase-8a bug #8): the kubeconfig short-circuit
+		// previously called markPhase1Done with an empty outcome and
+		// fell through to the default "ready" branch — the wizard
+		// then lied to the operator that a Sovereign was Ready when
+		// catalyst-api had never even observed it. Flag it explicitly
+		// as failed so the UI tells the truth.
+		dep.Status = "failed"
+		dep.Error = "Phase 1 watch never ran: the new Sovereign cluster did not PUT its kubeconfig to /api/v1/deployments/{id}/kubeconfig. catalyst-api cannot observe per-HelmRelease state and will not flip status to ready. Operator: SSH to the control-plane and verify cloud-init completed (`cloud-init status`), inspect `/var/log/cloud-init-output.log` for the kubeconfig PUT step (see docs/RUNBOOK-PROVISIONING.md §\"Fetch kubeconfig via SSH\")."
+	case outcome == helmwatch.OutcomeWatcherStartFailed:
+		// Issue #488 (Phase-8a bug #8): same false-ready failure mode,
+		// different upstream cause — informer factory failed to start.
+		dep.Status = "failed"
+		dep.Error = "Phase 1 watch could not start (e.g. malformed kubeconfig or informer factory init failure). catalyst-api has not observed any HelmRelease state and will not flip status to ready. Operator: run `kubectl get helmrelease -n flux-system` directly against the new Sovereign for ad-hoc diagnostics."
 	case outcome == helmwatch.OutcomeFluxNotReconciling:
 		// Watch terminated because zero HelmReleases were ever
 		// observed on the new Sovereign — Flux on that cluster is
@@ -280,6 +299,13 @@ func (h *Handler) markPhase1Done(dep *Deployment, finalStates map[string]string,
 	case failed > 0:
 		dep.Status = "failed"
 		dep.Error = fmt.Sprintf("Phase 1 finished with %d failed component(s); see ComponentStates for the per-component breakdown", failed)
+	case outcome == "" && len(finalStates) == 0:
+		// Defensive guard for any future caller that forgets to pass
+		// a non-empty outcome — better to surface as "failed" with a
+		// loud diagnostic than to silently flip to "ready".
+		// Issue #488 (Phase-8a bug #8).
+		dep.Status = "failed"
+		dep.Error = "Phase 1 watch terminated with no observed components and no terminal outcome — this is a programming error in catalyst-api. Please file an issue with the deployment ID and the catalyst-api logs from this run."
 	default:
 		dep.Status = "ready"
 	}

--- a/products/catalyst/bootstrap/api/internal/handler/phase1_watch_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/phase1_watch_test.go
@@ -261,7 +261,13 @@ func TestRunPhase1Watch_FailedComponentFlipsStatusToFailed(t *testing.T) {
 // TestRunPhase1Watch_EmptyKubeconfigShortCircuits proves that a
 // deployment with no captured kubeconfig surfaces a single warn
 // event and still calls markPhase1Done so Status leaves
-// "phase1-watching".
+// "phase1-watching" — AND, per issue #488 (Phase-8a bug #8), the
+// short-circuit must NOT report Status="ready". Before #488 was
+// fixed the short-circuit fell through to markPhase1Done's default
+// branch which set "ready" — the wizard then lied to the operator
+// that a Sovereign was Ready when catalyst-api had never observed
+// it. The truthful state is "failed" with a kubeconfig-missing
+// outcome and an operator-actionable error message.
 func TestRunPhase1Watch_EmptyKubeconfigShortCircuits(t *testing.T) {
 	h := NewWithPDM(silentLogger(), &fakePDM{})
 	dep := makeDeploymentWithKubeconfig(t, h, "phase1-no-kubeconfig", "")
@@ -273,9 +279,33 @@ func TestRunPhase1Watch_EmptyKubeconfigShortCircuits(t *testing.T) {
 	if dep.Status == "phase1-watching" {
 		t.Errorf("Status stuck at phase1-watching after short-circuit")
 	}
+	// Issue #488: must be "failed", not "ready". Falling through to
+	// "ready" with no observed components means the UI lies about
+	// Sovereign state every single time a kubeconfig PUT is missed.
+	if dep.Status != "failed" {
+		t.Errorf("Status = %q, want %q (kubeconfig short-circuit must fail loudly, not flip ready — issue #488)", dep.Status, "failed")
+	}
+	if dep.Error == "" {
+		t.Errorf("Error must be populated with operator-actionable diagnostic, got empty")
+	}
+	if !strings.Contains(dep.Error, "kubeconfig") {
+		t.Errorf("Error must mention kubeconfig so the operator knows what to investigate; got: %q", dep.Error)
+	}
 	// Result.Phase1FinishedAt is set even though no watch ran.
 	if dep.Result == nil || dep.Result.Phase1FinishedAt == nil {
 		t.Errorf("Phase1FinishedAt should be set even on short-circuit; result=%+v", dep.Result)
+	}
+	// Phase1Outcome must be the explicit kubeconfig-missing string so
+	// the wizard banner can render the right operator-actionable
+	// diagnostic — not empty, which is what triggered the false-ready
+	// fall-through before the fix.
+	if dep.Result == nil || dep.Result.Phase1Outcome != helmwatch.OutcomeKubeconfigMissing {
+		t.Errorf("Phase1Outcome = %q, want %q (issue #488)", func() string {
+			if dep.Result == nil {
+				return "<nil result>"
+			}
+			return dep.Result.Phase1Outcome
+		}(), helmwatch.OutcomeKubeconfigMissing)
 	}
 	// Exactly one warn event in the buffer (the "skipped" message).
 	warns := 0

--- a/products/catalyst/bootstrap/api/internal/helmwatch/helmwatch.go
+++ b/products/catalyst/bootstrap/api/internal/helmwatch/helmwatch.go
@@ -156,6 +156,22 @@ const (
 	// docs/RUNBOOK-PROVISIONING.md §"Phase 1 watch shows 0
 	// HelmReleases".
 	OutcomeFluxNotReconciling = "flux-not-reconciling"
+
+	// OutcomeKubeconfigMissing — Phase-1 watch never ran because no
+	// kubeconfig was available on the catalyst-api side. The new
+	// Sovereign's cloud-init has not yet PUT its kubeconfig to
+	// /api/v1/deployments/{id}/kubeconfig. catalyst-api cannot observe
+	// per-HelmRelease state and MUST NOT report Status=ready: the
+	// cluster's reconciliation could be at any state including total
+	// failure. Issue #488 — Phase-8a bug #8.
+	OutcomeKubeconfigMissing = "kubeconfig-missing"
+
+	// OutcomeWatcherStartFailed — helmwatch.NewWatcher returned an
+	// error before the informer ever ran (e.g. malformed kubeconfig,
+	// dynamic-factory init panic). Treated as a hard failure for the
+	// same reason as OutcomeKubeconfigMissing — without an informer,
+	// no per-component state can be observed.
+	OutcomeWatcherStartFailed = "watcher-start-failed"
 )
 
 // State enums — kept as constants so callers (handler, tests) compare


### PR DESCRIPTION
Closes #488

## Summary
- Phase-1 `markPhase1Done` was called with `outcome=""` from two short-circuit paths (kubeconfig missing + watcher-start failure)
- Empty outcome fell through the switch's default → `Status="ready"` even with zero observed components
- The wizard banner read "Sovereign ready" while catalyst-api had observed precisely zero HelmReleases — the UI lied to the operator on every otech1..otech9 iteration today

## Fix
- New `helmwatch.OutcomeKubeconfigMissing` + `OutcomeWatcherStartFailed` constants
- Both short-circuit `markPhase1Done(...)` calls now pass these explicit outcomes
- Switch in `markPhase1Done` adds explicit cases for both → `Status="failed"` with operator-actionable Error message
- Defensive trap: any future caller that forgets to pass an outcome still surfaces as failed (programming-error diagnostic)
- Strengthened `TestRunPhase1Watch_EmptyKubeconfigShortCircuits` to assert exact failed status + outcome string + error content (the prior assertion was "not stuck at phase1-watching" — too weak to catch the false-ready bug)

## Test plan
- [x] `go test ./products/catalyst/bootstrap/api/... -count=1` — all green (handler 25.7s, helmwatch 32.0s)
- [ ] Live verification on next fresh provision: status MUST stay `provisioning` (or whatever pre-Phase-1 state) until kubeconfig PUT received

🤖 Generated with [Claude Code](https://claude.com/claude-code)