### PR TITLE
test(catalyst-ui): lock in JobsTable row-id contract — no dead phase slugs

### DIFF
--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/jobsAdapter.test.ts
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/jobsAdapter.test.ts
@@ -51,3 +51,84 @@ describe('jobsAdapter — group-slug ↔ leaf-id collision protection (bug #476)
     expect(found!.parentId).not.toBe(found!.id)
   })
 })
+
+/* ─────────────────────────────────────────────────────────────────
+ * Issue #474 — JobsTable rows must NOT render dead phase slugs
+ *
+ * Phase-8a-preflight first live provision (febeeb888debf477) failed
+ * at tofu plan, so the catalyst-api recorded zero jobs. The wizard
+ * renders synthetic phase rows from the local event stream regardless
+ * (per INVIOLABLE-PRINCIPLES.md #1 — first paint = full list). Pre-fix
+ * the synthetic row IDs collided with bare phase slugs (e.g. id was
+ * `infrastructure` not `infrastructure:tofu-init`), so clicking a row
+ * navigated to /jobs/infrastructure which JobDetail's local jobsById
+ * lookup couldn't resolve → "Job not found" panel.
+ *
+ * The cumulative resolution: PR #480 (rename cluster-bootstrap group
+ * slug to phase-1-bootstrap), PR #498 (catalyst-ui fetch via API_BASE),
+ * and the synthesised IDs in jobs.ts using the `infrastructure:tofu-*`
+ * prefix. This test locks in the contract: every synthesised row's id
+ * is one of the well-known forms JobDetail's jobsById accepts.
+ * ───────────────────────────────────────────────────────────────── */
+describe('jobsAdapter — every synthesised row is a resolvable JobDetail target (issue #474)', () => {
+  it('no synthesised row id is a bare phase slug like "infrastructure" or "phase"', () => {
+    const apps = resolveApplications(INITIAL_WIZARD_STATE.selectedComponents)
+    const state = buildInitialState(apps.map((a) => a.id))
+    const derived = deriveJobs(state, apps)
+    const flat = adaptDerivedJobsToFlat(derived)
+    const FORBIDDEN_BARE_SLUGS = ['infrastructure', 'phase', 'phase-0', 'phase-1', 'cluster']
+    for (const j of flat) {
+      expect(FORBIDDEN_BARE_SLUGS.includes(j.id)).toBe(false)
+    }
+  })
+
+  it('every row’s id is non-empty and either a known group slug, a tofu phase id, the bootstrap leaf, or an application id', () => {
+    const apps = resolveApplications(INITIAL_WIZARD_STATE.selectedComponents)
+    const state = buildInitialState(apps.map((a) => a.id))
+    const derived = deriveJobs(state, apps)
+    const flat = adaptDerivedJobsToFlat(derived)
+    const groupSlugs = new Set([GROUP_PHASE_0, GROUP_CLUSTER_BOOTSTRAP, GROUP_APPLICATIONS])
+    const tofuPhases = new Set([
+      'infrastructure:tofu-init',
+      'infrastructure:tofu-plan',
+      'infrastructure:tofu-apply',
+      'infrastructure:tofu-output',
+    ])
+    const appIds = new Set(apps.map((a) => a.id))
+    for (const j of flat) {
+      expect(j.id).not.toBe('')
+      const ok =
+        groupSlugs.has(j.id) ||
+        tofuPhases.has(j.id) ||
+        j.id === 'cluster-bootstrap' ||
+        appIds.has(j.id)
+      expect(ok, `row id ${j.id} doesn't match any known shape`).toBe(true)
+    }
+  })
+
+  it('no row id contains an unencoded "/" that would break the /jobs/$jobId route param', () => {
+    const apps = resolveApplications(INITIAL_WIZARD_STATE.selectedComponents)
+    const state = buildInitialState(apps.map((a) => a.id))
+    const derived = deriveJobs(state, apps)
+    const flat = adaptDerivedJobsToFlat(derived)
+    for (const j of flat) {
+      expect(j.id).not.toMatch(/\//)
+    }
+  })
+
+  it('every leaf row’s parentId resolves to a row already in the flat list (no orphans)', () => {
+    const apps = resolveApplications(INITIAL_WIZARD_STATE.selectedComponents)
+    const state = buildInitialState(apps.map((a) => a.id))
+    const derived = deriveJobs(state, apps)
+    const flat = adaptDerivedJobsToFlat(derived)
+    const allIds = new Set(flat.map((j) => j.id))
+    for (const j of flat) {
+      if (j.type === 'group') continue
+      // Either the leaf has no parent, or the parent must exist in the
+      // same flat list. An orphan leaf would render as un-clickable.
+      if (j.parentId !== '') {
+        expect(allIds.has(j.parentId), `leaf ${j.id} parent ${j.parentId} not in flat list`).toBe(true)
+      }
+    }
+  })
+})


### PR DESCRIPTION
Closes #474

## Summary
- Original symptom (rows linking to bare `/jobs/infrastructure` or `/jobs/phase`) was fixed cumulatively by PRs #480 (slug rename), #498 (API_BASE routing), and the synthesised `infrastructure:tofu-*` IDs in jobs.ts
- This adds 4 vitest cases that lock the row-id contract going forward, so the regression cannot return silently
- Live verification on `catalyst-ui:141dc9d` deployment d198b513476df186: every row resolves; no bare phase slugs in any URL

## Test plan
- [x] 4 new tests pass; 3 original tests still pass; tsc clean
- [x] Live verification on console.openova.io/sovereign/provision/d198b513476df186/jobs (50+ rows, all clickable, no deadlinks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)