### PR TITLE
fix(bp-seaweedfs): vendor upstream chart, drop fromToml-using template (#340)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,15 @@ platform/*/chart/Chart.lock
 products/*/chart/charts/
 products/*/chart/Chart.lock
 
+# Vendored upstream subcharts — exception to the above (issue #340).
+# bp-seaweedfs vendors seaweedfs/seaweedfs 4.22.0 with templates/shared/
+# security-configmap.yaml DELETED because it uses fromToml (Helm 3.13+)
+# which Flux helm-controller's bundled SDK doesn't have. The chart has
+# annotations.catalyst.openova.io/no-upstream=true to signal this to the
+# blueprint-release workflow's hollow-chart guard.
+!platform/seaweedfs/chart/charts/
+!platform/seaweedfs/chart/charts/**
+
 # Node + dev artifacts (untracked already, listed here for clarity).
 **/node_modules/
 **/dist/

--- a/platform/seaweedfs/chart/Chart.yaml
+++ b/platform/seaweedfs/chart/Chart.yaml
@@ -1,10 +1,10 @@
 apiVersion: v2
 name: bp-seaweedfs
 description: |
-  Catalyst Blueprint umbrella chart for SeaweedFS. Depends on the upstream
-  `seaweedfs` chart (seaweedfs/seaweedfs) as a Helm subchart so
-  `helm dependency build` pulls the upstream payload into this artifact.
-  Catalyst-curated values flow into the upstream subchart under the
+  Catalyst Blueprint umbrella chart for SeaweedFS. The upstream
+  `seaweedfs/seaweedfs` 4.22.0 chart is VENDORED (committed bytes under
+  `chart/charts/seaweedfs/`) rather than declared as a `dependencies:`
+  entry. Catalyst-curated values flow into the vendored subchart under the
   `seaweedfs:` key in values.yaml.
 
   SeaweedFS is the unified S3-compatible storage layer per
@@ -15,18 +15,42 @@ description: |
   hot→warm→cold and offloads cold objects to a cloud archival backend
   (Cloudflare R2 / AWS S3 Glacier / Hetzner Object Storage) configured at
   Sovereign provisioning time.
+
+  Why vendored (issue #340):
+    Upstream 4.22.0 ships templates/shared/security-configmap.yaml that
+    calls `fromToml` (Sprig function added in Helm 3.13). Flux v1.x
+    helm-controller bundles a Helm SDK older than 3.13 and PARSES every
+    template before any `{{- if .Values.global.seaweedfs.enableSecurity }}`
+    gate fires — so the chart fails install with `function "fromToml" not
+    defined` even though enableSecurity defaults to false. Vendoring the
+    chart and deleting the offending template removes the dependency on a
+    Helm runtime feature we don't control. The deleted file is only
+    referenced by other templates inside `{{- if enableSecurity }}` blocks,
+    so removing it is a no-op for our default deployment shape (Catalyst
+    SeaweedFS does not enable JWT/TLS — auth happens at the S3 layer via
+    IAM credentials sourced from External Secrets, not via the upstream
+    chart's TLS/JWT machinery).
 type: application
-version: 1.0.1
+version: 1.1.0
 appVersion: "4.22"
 keywords: [catalyst, blueprint, seaweedfs, s3, object-storage, storage]
 maintainers:
   - name: OpenOva Catalyst
     email: catalyst@openova.io
 
-# Pinned to seaweedfs/seaweedfs 4.22.0 (appVersion 4.22) — current stable
-# on 2026-04-30. Per docs/INVIOLABLE-PRINCIPLES.md #4 (never hardcode) the
-# version is operator-bumpable via PR + Blueprint release.
-dependencies:
-  - name: seaweedfs
-    version: "4.22.0"
-    repository: "https://seaweedfs.github.io/seaweedfs/helm"
+# The vendored subchart at chart/charts/seaweedfs/ is not auto-pulled at
+# build time — it's committed bytes. The blueprint-release workflow's
+# hollow-chart guard (issue #181) requires either a `dependencies:` block
+# OR this annotation; we use the annotation because re-pulling at build
+# time would re-introduce the broken `security-configmap.yaml` (mutable
+# upstream Helm repo). To bump SeaweedFS:
+#   1. helm pull seaweedfs --version <X.Y.Z> --repo https://seaweedfs.github.io/seaweedfs/helm
+#   2. tar -xzf seaweedfs-<X.Y.Z>.tgz -C chart/charts/ (replacing seaweedfs/)
+#   3. rm chart/charts/seaweedfs/templates/shared/security-configmap.yaml
+#      (until upstream stops using fromToml or we move to Helm 3.13+ in
+#      helm-controller — track via fluxcd/helm-controller releases)
+#   4. Bump version: in this Chart.yaml + open PR
+annotations:
+  catalyst.openova.io/no-upstream: "true"
+  catalyst.openova.io/vendored-subchart: "seaweedfs@4.22.0"
+  catalyst.openova.io/vendored-reason: "issue #340 — upstream uses fromToml (Helm 3.13+)"

--- a/platform/seaweedfs/chart/charts/seaweedfs/.helmignore
+++ b/platform/seaweedfs/chart/charts/seaweedfs/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/platform/seaweedfs/chart/charts/seaweedfs/Chart.yaml
+++ b/platform/seaweedfs/chart/charts/seaweedfs/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "4.22"
+description: SeaweedFS
+name: seaweedfs
+version: 4.22.0

--- a/platform/seaweedfs/chart/charts/seaweedfs/README.md
+++ b/platform/seaweedfs/chart/charts/seaweedfs/README.md
@@ -1,0 +1,387 @@
+# SEAWEEDFS - helm chart (2.x+)
+
+
+### Add the helm repo
+
+```bash
+helm repo add seaweedfs https://seaweedfs.github.io/seaweedfs/helm
+```
+
+### Install the helm chart
+
+```bash
+helm install seaweedfs seaweedfs/seaweedfs
+```
+
+### (Recommended) Provide `values.yaml`
+
+```bash
+helm install --values=values.yaml seaweedfs seaweedfs/seaweedfs
+```
+
+## Info:
+* master/filer/volume are stateful sets with anti-affinity on the hostname,
+so your deployment will be spread/HA.
+* chart is using memsql(mysql) as the filer backend to enable HA (multiple filer instances) and backup/HA memsql can provide.
+* mysql user/password are created in a k8s secret (default: `<release>-seaweedfs-db-secret`) and injected to the filer with ENV.
+* cert config exists and can be enabled, but not been tested, requires cert-manager to be installed.
+
+## Prerequisites
+### Database
+
+leveldb is the default database, this supports multiple filer replicas that will [sync automatically](https://github.com/seaweedfs/seaweedfs/wiki/Filer-Store-Replication), with some [limitations](https://github.com/seaweedfs/seaweedfs/wiki/Filer-Store-Replication#limitation).
+
+When the [limitations](https://github.com/seaweedfs/seaweedfs/wiki/Filer-Store-Replication#limitation) apply, or for a large number of filer replicas, an external datastore is recommended.
+
+Such as MySQL-compatible database, as specified in the `values.yaml` at `filer.extraEnvironmentVars`.
+This database should be pre-configured and initialized. If using the default `db-init-config`, the configmap name is now dynamic (e.g., `<release>-seaweedfs-db-init-config`). You can override this name via `filer.dbInitConfigName`.
+
+To initialize manually:
+```sql
+CREATE TABLE IF NOT EXISTS `filemeta` (
+  `dirhash`   BIGINT NOT NULL       COMMENT 'first 64 bits of MD5 hash value of directory field',
+  `name`      VARCHAR(766) NOT NULL COMMENT 'directory or file name',
+  `directory` TEXT NOT NULL         COMMENT 'full path to parent directory',
+  `meta`      LONGBLOB,
+  PRIMARY KEY (`dirhash`, `name`)
+) DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+```
+
+Alternative database can also be configured (e.g. leveldb, postgres) following the instructions at `filer.extraEnvironmentVars`.
+
+#### RocksDB variant
+
+The `_large_disk_rocksdb` image tag ships with RocksDB pre-configured as the filer backend.
+To use this image with the Helm chart, override the image on all three components and disable
+the chart's default `WEED_LEVELDB2_ENABLED`, which would otherwise re-enable LevelDB2 and
+override the image's built-in RocksDB configuration:
+
+```yaml
+# Replace <VERSION> with the desired seaweedfs version, e.g. 3.80_large_disk_rocksdb.
+master:
+  imageOverride: chrislusf/seaweedfs:<VERSION>_large_disk_rocksdb
+
+volume:
+  imageOverride: chrislusf/seaweedfs:<VERSION>_large_disk_rocksdb
+
+filer:
+  enablePVC: true
+  imageOverride: chrislusf/seaweedfs:<VERSION>_large_disk_rocksdb
+  extraEnvironmentVars:
+    WEED_LEVELDB2_ENABLED: "false"
+```
+
+Notes:
+
+* `master` and `volume` use the same image tag so that all components share a consistent
+  SeaweedFS build; RocksDB itself is only used by the filer.
+* `filer.enablePVC: true` (or another form of persistent storage for the filer) is required
+  so that the RocksDB metadata store survives pod restarts — otherwise metadata will be lost.
+
+### Node Labels
+Kubernetes nodes can have labels which help to define which node(Host) will run which pod:
+
+Here is an example:
+* s3/filer/master needs the label **sw-backend=true**
+* volume need the label **sw-volume=true**
+
+to label a node to be able to run all pod types in k8s:
+```
+kubectl label node YOUR_NODE_NAME sw-volume=true sw-backend=true
+```
+
+on production k8s deployment you will want each pod to have a different host,
+especially the volume server and the masters, all pods (master/volume/filer)
+should have anti-affinity rules to disallow running multiple component pods  on the same host.
+
+If you still want to run multiple pods of the same component (master/volume/filer) on the same host please set/update the corresponding affinity rule in values.yaml to an empty one:
+
+```affinity: ""```
+
+## PVC - storage class ###
+
+On the volume stateful set added support for k8s PVC, currently example
+with the simple local-path-provisioner from Rancher (comes included with k3d / k3s)
+https://github.com/rancher/local-path-provisioner
+
+you can use ANY storage class you like, just update the correct storage-class
+for your deployment.
+
+## current instances config (AIO):
+
+1 instance for each type (master/filer+s3/volume)
+
+You can update the replicas count for each node type in values.yaml,
+need to add more nodes with the corresponding labels if applicable.
+
+Most of the configuration are available through values.yaml any pull requests to expand functionality or usability are greatly appreciated. Any pull request must pass [chart-testing](https://github.com/helm/chart-testing).
+
+## S3 configuration
+
+To enable an s3 endpoint for your filer with a default install add the following to your values.yaml:
+
+```yaml
+filer:
+  s3:
+    enabled: true
+```
+
+### Enabling Authentication to S3
+
+To enable authentication for S3, you have two options:
+
+- let the helm chart create an admin user as well as a read only user
+- provide your own s3 config.json file via an existing Kubernetes Secret
+
+#### Use the default credentials for S3
+
+Example parameters for your values.yaml:
+
+```yaml
+filer:
+  s3:
+    enabled: true
+    enableAuth: true
+```
+
+#### Provide your own credentials for S3
+
+Example parameters for your values.yaml:
+
+```yaml
+filer:
+  s3:
+    enabled: true
+    enableAuth: true
+    existingConfigSecret: my-s3-secret
+```
+
+Example existing secret with your s3 config to create an admin user and readonly user, both with credentials:
+
+```yaml
+---
+# Source: seaweedfs/templates/seaweedfs-s3-secret.yaml
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: my-s3-secret
+  namespace: seaweedfs
+  labels:
+    app.kubernetes.io/name: seaweedfs
+    app.kubernetes.io/component: s3
+stringData:
+  # this key must be an inline json config file
+  seaweedfs_s3_config: '{"identities":[{"name":"anvAdmin","credentials":[{"accessKey":"snu8yoP6QAlY0ne4","secretKey":"PNzBcmeLNEdR0oviwm04NQAicOrDH1Km"}],"actions":["Admin","Read","Write"]},{"name":"anvReadOnly","credentials":[{"accessKey":"SCigFee6c5lbi04A","secretKey":"kgFhbT38R8WUYVtiFQ1OiSVOrYr3NKku"}],"actions":["Read"]}]}'
+```
+
+## Admin Component
+
+The admin component provides a modern web-based administration interface for managing SeaweedFS clusters. It includes:
+
+- **Dashboard**: Real-time cluster status and metrics
+- **Volume Management**: Monitor volume servers, capacity, and health
+- **File Browser**: Browse and manage files in the filer
+- **Maintenance Operations**: Trigger maintenance tasks via workers
+- **Object Store Management**: Create and manage buckets with web interface
+
+### Enabling Admin
+
+To enable the admin interface, add the following to your values.yaml:
+
+```yaml
+admin:
+  enabled: true
+  port: 23646
+  grpcPort: 33646  # For worker connections
+  secret:
+    adminUser: "admin"
+    adminPassword: "your-secure-password"  # Leave empty to disable auth
+  
+  # Optional: persist admin data
+  data:
+    type: "persistentVolumeClaim"
+    size: "10Gi"
+    storageClass: "your-storage-class"
+  
+  # Optional: enable ingress
+  ingress:
+    enabled: true
+    host: "admin.seaweedfs.local"
+    className: "nginx"
+```
+
+The admin interface will be available at `http://<admin-service>:23646` (or via ingress). Workers connect to the admin server via gRPC on port `33646`.
+
+### Admin Authentication
+
+If `adminPassword` is set, the admin interface requires authentication:
+- Username: Value of `adminUser` (default: `admin`)
+- Password: Value of `adminPassword`
+
+If `adminPassword` is empty or not set, the admin interface runs without authentication (not recommended for production).
+
+As an alternative, a kubernetes Secret can be used (`admin.secret.existingSecret`).
+
+### Admin Data Persistence
+
+The admin component can store configuration and maintenance data. You can configure storage in several ways:
+
+- **emptyDir** (default): Data is lost when pod restarts
+- **persistentVolumeClaim**: Data persists across pod restarts
+- **hostPath**: Data stored on the host filesystem
+- **existingClaim**: Use an existing PVC
+
+## Worker Component
+
+Workers are maintenance agents that execute cluster maintenance tasks such as vacuum, volume balancing, and erasure coding. Workers connect to the admin server via gRPC and receive task assignments.
+
+### Enabling Workers
+
+To enable workers, add the following to your values.yaml:
+
+```yaml
+worker:
+  enabled: true
+  replicas: 2  # Scale based on workload
+  jobType: "vacuum,volume_balance,erasure_coding"  # Job types this worker can handle
+  maxDetect: 1  # Maximum concurrent detection requests
+  maxExecute: 4  # Maximum concurrent execution jobs per worker
+  
+  # Working directory for task execution
+  # Default: "/tmp/seaweedfs-worker"
+  # Note: /tmp is ephemeral - use persistent storage (hostPath/existingClaim) for long-running tasks
+  workingDir: "/tmp/seaweedfs-worker"
+  
+  # Optional: configure admin server address
+  # If not specified, auto-discovers from admin service in the same namespace by looking for
+  # a service named "<release-name>-admin" (e.g., "seaweedfs-admin").
+  # Auto-discovery only works if the admin is in the same namespace and same Helm release.
+  # For cross-namespace or separate release scenarios, explicitly set this value.
+  # Example: If main SeaweedFS is deployed in "production" namespace:
+  #   adminServer: "seaweedfs-admin.production.svc:33646"
+  adminServer: ""
+  
+  # Workers need storage for task execution
+  # Note: Workers use a Deployment, which does not support `volumeClaimTemplates` 
+  # for dynamic PVC creation per pod. To use persistent storage, you must 
+  # pre-provision a PersistentVolumeClaim and use `type: "existingClaim"`.
+  data:
+    type: "emptyDir"  # Options: "emptyDir", "hostPath", or "existingClaim"
+    hostPathPrefix: /storage  # For hostPath
+    # claimName: "worker-pvc"  # For existingClaim with pre-provisioned PVC
+  
+  # Resource limits for worker pods
+  resources:
+    requests:
+      cpu: "500m"
+      memory: "512Mi"
+    limits:
+      cpu: "2"
+      memory: "2Gi"
+```
+
+### Worker Job Types
+
+Workers can be configured with different job types:
+- **vacuum**: Reclaim deleted file space
+- **volume_balance**: Balance volumes across volume servers
+- **erasure_coding**: Handle erasure coding operations
+
+You can configure workers with all job types or create specialized worker pools with specific job types.
+
+### Worker Deployment Strategy
+
+For production deployments, consider:
+
+1. **Multiple Workers**: Deploy 2+ worker replicas for high availability
+2. **Resource Allocation**: Workers need sufficient CPU/memory for maintenance tasks
+3. **Storage**: Workers need temporary storage for vacuum and balance operations (size depends on volume size)
+4. **Specialized Workers**: Create separate worker deployments for different job types if needed
+
+Example specialized worker configuration:
+
+For specialized worker pools, deploy separate Helm releases with different job types:
+
+**values-worker-vacuum.yaml** (for vacuum operations):
+```yaml
+# Disable all other components, enable only workers
+master:
+  enabled: false
+volume:
+  enabled: false
+filer:
+  enabled: false
+s3:
+  enabled: false
+admin:
+  enabled: false
+
+worker:
+  enabled: true
+  replicas: 2
+  jobType: "vacuum"
+  maxExecute: 2
+  # REQUIRED: Point to the admin service of your main SeaweedFS release
+  # Replace <namespace> with the namespace where your main seaweedfs is deployed
+  # Example: If deploying in namespace "production":
+  #   adminServer: "seaweedfs-admin.production.svc:33646"
+  adminServer: "seaweedfs-admin.<namespace>.svc:33646"
+```
+
+**values-worker-balance.yaml** (for balance operations):
+```yaml
+# Disable all other components, enable only workers
+master:
+  enabled: false
+volume:
+  enabled: false
+filer:
+  enabled: false
+s3:
+  enabled: false
+admin:
+  enabled: false
+
+worker:
+  enabled: true
+  replicas: 1
+  jobType: "volume_balance"
+  maxExecute: 1
+  # REQUIRED: Point to the admin service of your main SeaweedFS release
+  # Replace <namespace> with the namespace where your main seaweedfs is deployed
+  # Example: If deploying in namespace "production":
+  #   adminServer: "seaweedfs-admin.production.svc:33646"
+  adminServer: "seaweedfs-admin.<namespace>.svc:33646"
+```
+
+Deploy the specialized workers as separate releases:
+### Specialized Worker Deployment
+```bash
+# Deploy vacuum workers
+helm install seaweedfs-worker-vacuum seaweedfs/seaweedfs -f values-worker-vacuum.yaml
+
+# Deploy balance workers
+helm install seaweedfs-worker-balance seaweedfs/seaweedfs -f values-worker-balance.yaml
+```
+
+## OpenShift Support
+
+SeaweedFS can be deployed on OpenShift or any cluster enforcing the Kubernetes "restricted" Pod Security Standard. By default, OpenShift blocks containers that run as root or use `hostPath` volumes.
+
+To deploy on OpenShift, use the provided `openshift-values.yaml` which overrides the default configuration to:
+1. Use `PersistentVolumeClaims` instead of `hostPath`.
+2. Enable `runAsNonRoot` and omit hardcoded UIDs to allow OpenShift to assign valid UIDs automatically.
+3. Apply appropriate `seccompProfile` and drop capabilities.
+
+Usage:
+```bash
+helm install seaweedfs seaweedfs/seaweedfs \
+  -n seaweedfs --create-namespace \
+  -f openshift-values.yaml
+```
+
+## Enterprise
+
+For enterprise users, please visit [seaweedfs.com](https://seaweedfs.com) for the SeaweedFS Enterprise Edition, 
+which has a self-healing storage format with better data protection.

--- a/platform/seaweedfs/chart/charts/seaweedfs/dashboards/seaweedfs-grafana-dashboard.json
+++ b/platform/seaweedfs/chart/charts/seaweedfs/dashboards/seaweedfs-grafana-dashboard.json
@@ -1,0 +1,3759 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "limit": 100,
+        "name": "Annotations & Alerts",
+        "showIn": 0,
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "gnetId": 10423,
+  "graphTooltip": 0,
+  "id": 160,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "collapsed": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 67,
+      "panels": [],
+      "title": "Master",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Whether master is leader or not",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "bool_yes_no",
+          "unitScale": true
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 0,
+        "y": 1
+      },
+      "id": 57,
+      "links": [],
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "last"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "text": {},
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "10.3.1",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum by (pod) (SeaweedFS_master_is_leader{job=\"seaweedfs-master\", namespace=\"$NAMESPACE\"})",
+          "format": "time_series",
+          "hide": false,
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "{{pod}}",
+          "refId": "A",
+          "step": 60
+        }
+      ],
+      "title": "Raft leader",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Count times leader changed",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 4,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none",
+          "unitScale": true
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 8,
+        "y": 1
+      },
+      "id": 68,
+      "links": [],
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "8.1.2",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum by (pod) (SeaweedFS_master_leader_changes{job=\"seaweedfs-master\", type=~\".+\", namespace=\"$NAMESPACE\"})",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "{{pod}}",
+          "refId": "A",
+          "step": 60
+        }
+      ],
+      "title": "Master leader changes",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Heartbeats received from components",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 4,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none",
+          "unitScale": true
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 16,
+        "y": 1
+      },
+      "id": 69,
+      "links": [],
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "8.1.2",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum by (type) (increase(SeaweedFS_master_received_heartbeats{job=\"seaweedfs-master\", namespace=\"$NAMESPACE\"}[$__rate_interval]))",
+          "format": "time_series",
+          "hide": false,
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "{{type}}",
+          "refId": "A",
+          "step": 60
+        }
+      ],
+      "title": "Received heartbeats",
+      "type": "timeseries"
+    },
+    {
+      "alert": {
+        "alertRuleTags": {},
+        "conditions": [
+          {
+            "evaluator": {
+              "params": [
+                0
+              ],
+              "type": "gt"
+            },
+            "operator": {
+              "type": "and"
+            },
+            "query": {
+              "params": [
+                "A",
+                "5m",
+                "now"
+              ]
+            },
+            "reducer": {
+              "params": [],
+              "type": "avg"
+            },
+            "type": "query"
+          }
+        ],
+        "executionErrorState": "alerting",
+        "for": "5m",
+        "frequency": "1m",
+        "handler": 1,
+        "message": "",
+        "name": "Replica Placement Mismatch alert",
+        "noDataState": "ok",
+        "notifications": []
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Count replica placement mismatch",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 4,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none",
+          "unitScale": true
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 0,
+        "y": 7
+      },
+      "id": 70,
+      "links": [],
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "8.1.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum (SeaweedFS_master_replica_placement_mismatch{job=\"seaweedfs-master\", namespace=\"$NAMESPACE\"} > 0) by (pod)",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "{{pod}}",
+          "refId": "A",
+          "step": 60
+        }
+      ],
+      "thresholds": [
+        {
+          "colorMode": "critical",
+          "op": "gt",
+          "value": 0,
+          "visible": true
+        }
+      ],
+      "title": "Replica Placement Mismatch",
+      "type": "timeseries"
+    },
+    {
+      "alert": {
+        "alertRuleTags": {},
+        "conditions": [
+          {
+            "evaluator": {
+              "params": [
+                1,
+                1
+              ],
+              "type": "outside_range"
+            },
+            "operator": {
+              "type": "and"
+            },
+            "query": {
+              "params": [
+                "A",
+                "5m",
+                "now"
+              ]
+            },
+            "reducer": {
+              "params": [],
+              "type": "avg"
+            },
+            "type": "query"
+          }
+        ],
+        "executionErrorState": "alerting",
+        "for": "5m",
+        "frequency": "1m",
+        "handler": 1,
+        "message": "Raft leader count of master-servers not equal to 1",
+        "name": "Raft leader alert",
+        "noDataState": "no_data",
+        "notifications": []
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Total count of raft leaders",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none",
+          "unitScale": true
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 8,
+        "y": 7
+      },
+      "id": 71,
+      "links": [],
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "8.1.2",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum (SeaweedFS_master_is_leader{job=\"seaweedfs-master\", namespace=\"$NAMESPACE\"})",
+          "format": "time_series",
+          "hide": false,
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "Leaders",
+          "refId": "A",
+          "step": 60
+        }
+      ],
+      "thresholds": [
+        {
+          "colorMode": "critical",
+          "op": "lt",
+          "value": 1,
+          "visible": true
+        },
+        {
+          "colorMode": "critical",
+          "op": "gt",
+          "value": 1,
+          "visible": true
+        }
+      ],
+      "title": "Raft leader count",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Whether cluster locked or not",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "bool_yes_no",
+          "unitScale": true
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 16,
+        "y": 7
+      },
+      "id": 74,
+      "links": [],
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "last"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "text": {},
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "10.3.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "SeaweedFS_master_admin_lock{job=\"seaweedfs-master\", namespace=\"$NAMESPACE\"}",
+          "format": "time_series",
+          "hide": false,
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "Client IP: {{client}}",
+          "range": true,
+          "refId": "A",
+          "step": 60
+        }
+      ],
+      "title": "Admin lock",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 13
+      },
+      "id": 60,
+      "panels": [],
+      "title": "Filer",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s",
+          "unitScale": true
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 14
+      },
+      "id": 46,
+      "links": [],
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "10.3.1",
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.90, sum(rate(SeaweedFS_filer_request_seconds_bucket{namespace=\"$NAMESPACE\"}[$__rate_interval])) by (le))",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 2,
+          "legendFormat": "average",
+          "refId": "A",
+          "step": 60
+        },
+        {
+          "expr": "histogram_quantile(0.90, sum(rate(SeaweedFS_filer_request_seconds_bucket{namespace=\"$NAMESPACE\"}[$__rate_interval])) by (le, type))",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 2,
+          "legendFormat": "{{type}}",
+          "refId": "B",
+          "step": 60
+        }
+      ],
+      "title": "Filer Request Duration 90th percentile",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s",
+          "unitScale": true
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 8,
+        "y": 14
+      },
+      "id": 49,
+      "links": [],
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "10.3.1",
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(SeaweedFS_filer_request_seconds_bucket{namespace=\"$NAMESPACE\"}[$__rate_interval])) by (le))",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 2,
+          "legendFormat": "average",
+          "refId": "A",
+          "step": 60
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(SeaweedFS_filer_request_seconds_bucket{namespace=\"$NAMESPACE\"}[$__rate_interval])) by (le, type))",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 2,
+          "legendFormat": "{{type}}",
+          "refId": "B",
+          "step": 60
+        },
+        {
+          "expr": "",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "refId": "C"
+        }
+      ],
+      "title": "Filer Request Duration 95th percentile",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s",
+          "unitScale": true
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 16,
+        "y": 14
+      },
+      "id": 45,
+      "links": [],
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "10.3.1",
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.99, sum(rate(SeaweedFS_filer_request_seconds_bucket{namespace=\"$NAMESPACE\"}[$__rate_interval])) by (le))",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 2,
+          "legendFormat": "average",
+          "refId": "A",
+          "step": 60
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum(rate(SeaweedFS_filer_request_seconds_bucket{namespace=\"$NAMESPACE\"}[$__rate_interval])) by (le, type))",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 2,
+          "legendFormat": "{{type}}",
+          "refId": "B",
+          "step": 60
+        },
+        {
+          "expr": "",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "refId": "C"
+        }
+      ],
+      "title": "Filer Request Duration 99th percentile",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short",
+          "unitScale": true
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "total"
+            },
+            "properties": [
+              {
+                "id": "custom.lineWidth",
+                "value": 0
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byValue",
+              "options": {
+                "op": "gte",
+                "reducer": "allIsZero",
+                "value": 0
+              }
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": true,
+                  "tooltip": true,
+                  "viz": false
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byValue",
+              "options": {
+                "op": "gte",
+                "reducer": "allIsNull",
+                "value": 0
+              }
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": true,
+                  "tooltip": true,
+                  "viz": false
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 21
+      },
+      "id": 2,
+      "links": [],
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "width": 250
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "10.3.1",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum by (type) (rate(SeaweedFS_filer_request_total{namespace=\"$NAMESPACE\"}[$__rate_interval]))",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "{{type}}",
+          "refId": "A",
+          "step": 30
+        }
+      ],
+      "title": "Filer QPS",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short",
+          "unitScale": true
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 28
+      },
+      "id": 91,
+      "links": [],
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "width": 250
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "10.3.1",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum by (code) (rate(SeaweedFS_upload_error_total{namespace=\"$NAMESPACE\"}[$__rate_interval]))",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "{{code}}",
+          "refId": "A",
+          "step": 30
+        }
+      ],
+      "title": "Upload Errors",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 35
+      },
+      "id": 61,
+      "panels": [],
+      "title": "S3 Gateway",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s",
+          "unitScale": true
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 36
+      },
+      "id": 65,
+      "links": [],
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "10.3.1",
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.90, sum(rate(SeaweedFS_s3_request_seconds_bucket{namespace=\"$NAMESPACE\"}[$__rate_interval])) by (le))",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 2,
+          "legendFormat": "average",
+          "refId": "A",
+          "step": 60
+        },
+        {
+          "expr": "histogram_quantile(0.90, sum(rate(SeaweedFS_s3_request_seconds_bucket{namespace=\"$NAMESPACE\"}[$__rate_interval])) by (le, type))",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 2,
+          "legendFormat": "{{type}}",
+          "refId": "B",
+          "step": 60
+        }
+      ],
+      "title": "S3 Request Duration 90th percentile",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s",
+          "unitScale": true
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 8,
+        "y": 36
+      },
+      "id": 56,
+      "links": [],
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "10.3.1",
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(SeaweedFS_s3_request_seconds_bucket{namespace=\"$NAMESPACE\"}[$__rate_interval])) by (le))",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 2,
+          "legendFormat": "average",
+          "refId": "A",
+          "step": 60
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(SeaweedFS_s3_request_seconds_bucket{namespace=\"$NAMESPACE\"}[$__rate_interval])) by (le, type))",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 2,
+          "legendFormat": "{{type}}",
+          "refId": "B",
+          "step": 60
+        }
+      ],
+      "title": "S3 Request Duration 95th percentile",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s",
+          "unitScale": true
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 16,
+        "y": 36
+      },
+      "id": 58,
+      "links": [],
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "10.3.1",
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.99, sum(rate(SeaweedFS_s3_request_seconds_bucket{namespace=\"$NAMESPACE\"}[$__rate_interval])) by (le))",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 2,
+          "legendFormat": "average",
+          "refId": "A",
+          "step": 60
+        },
+        {
+          "exemplar": true,
+          "expr": "histogram_quantile(0.99, sum(rate(SeaweedFS_s3_request_seconds_bucket{namespace=\"$NAMESPACE\"}[$__rate_interval])) by (le, type))",
+          "format": "time_series",
+          "hide": false,
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "{{type}}",
+          "refId": "B",
+          "step": 60
+        }
+      ],
+      "title": "S3 Request Duration 99th percentile",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "decbytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 43
+      },
+      "id": 84,
+      "links": [],
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "10.3.1",
+      "targets": [
+        {
+          "expr": "sum(rate(SeaweedFS_s3_bucket_traffic_received_bytes_total{namespace=\"$NAMESPACE\"}[$__rate_interval])) by (bucket)",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 2,
+          "legendFormat": "{{bucket}}",
+          "refId": "A"
+        }
+      ],
+      "title": "S3 Bucket Traffic Received",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "decbytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 43
+      },
+      "id": 85,
+      "links": [],
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "10.3.1",
+      "targets": [
+        {
+          "expr": "sum(rate(SeaweedFS_s3_bucket_traffic_sent_bytes_total{namespace=\"$NAMESPACE\"}[$__rate_interval])) by (bucket)",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 2,
+          "legendFormat": "{{bucket}}",
+          "refId": "A"
+        }
+      ],
+      "title": "S3 Bucket Traffic Sent",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "reqps",
+          "unitScale": true
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 48
+      },
+      "id": 86,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "10.3.1",
+      "targets": [
+        {
+          "expr": "sum(rate(SeaweedFS_s3_request_total{namespace=\"$NAMESPACE\"}[$__rate_interval])) by (bucket)",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 2,
+          "legendFormat": "{{bucket}}",
+          "refId": "A"
+        }
+      ],
+      "title": "S3 API Calls per Bucket",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s",
+          "unitScale": true
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 48
+      },
+      "id": 72,
+      "links": [],
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "10.3.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "exemplar": true,
+          "expr": "histogram_quantile(0.99, sum(rate(SeaweedFS_s3_request_seconds_bucket{namespace=\"$NAMESPACE\"}[$__rate_interval])) by (le))",
+          "format": "time_series",
+          "hide": false,
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "average",
+          "refId": "A",
+          "step": 60
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "exemplar": true,
+          "expr": "histogram_quantile(0.99, sum(rate(SeaweedFS_s3_request_seconds_bucket{namespace=\"$NAMESPACE\"}[$__rate_interval])) by (le, type, pod))",
+          "format": "time_series",
+          "hide": false,
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "{{type}}-{{pod}}",
+          "refId": "B",
+          "step": 60
+        }
+      ],
+      "title": "S3 Request. Duration 99th percentile per instance",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s",
+          "unitScale": true
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 57
+      },
+      "id": 73,
+      "links": [],
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "10.3.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "exemplar": true,
+          "expr": "histogram_quantile(0.99, sum(rate(SeaweedFS_s3_request_seconds_bucket{namespace=\"$NAMESPACE\"}[$__rate_interval])) by (le, type, bucket))",
+          "format": "time_series",
+          "hide": false,
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "{{type}}-{{bucket}}",
+          "refId": "B",
+          "step": 60
+        }
+      ],
+      "title": "S3 Request Duration 99th percentile per bucket",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short",
+          "unitScale": true
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "total"
+            },
+            "properties": [
+              {
+                "id": "custom.lineWidth",
+                "value": 0
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byValue",
+              "options": {
+                "op": "gte",
+                "reducer": "allIsZero",
+                "value": 0
+              }
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": true,
+                  "tooltip": true,
+                  "viz": false
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byValue",
+              "options": {
+                "op": "gte",
+                "reducer": "allIsNull",
+                "value": 0
+              }
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": true,
+                  "tooltip": true,
+                  "viz": false
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 64
+      },
+      "id": 55,
+      "links": [],
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "width": 250
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "10.3.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum (rate(SeaweedFS_s3_request_total{namespace=\"$NAMESPACE\"}[$__rate_interval])) by (type)",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "{{type}}",
+          "refId": "A",
+          "step": 30
+        }
+      ],
+      "title": "S3 API QPS",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "Cost in US$",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "currencyUSD",
+          "unitScale": true
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "total"
+            },
+            "properties": [
+              {
+                "id": "custom.lineWidth",
+                "value": 0
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byValue",
+              "options": {
+                "op": "gte",
+                "reducer": "allIsZero",
+                "value": 0
+              }
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": true,
+                  "tooltip": true,
+                  "viz": false
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byValue",
+              "options": {
+                "op": "gte",
+                "reducer": "allIsNull",
+                "value": 0
+              }
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": true,
+                  "tooltip": true,
+                  "viz": false
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 71
+      },
+      "hideTimeOverride": false,
+      "id": 59,
+      "links": [],
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "width": 250
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "10.3.1",
+      "targets": [
+        {
+          "expr": "sum by (type) (SeaweedFS_s3_request_total{type=~'PUT|COPY|POST|LIST', namespace=\"$NAMESPACE\"})*0.000005",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 2,
+          "legendFormat": "{{type}} requests",
+          "refId": "A",
+          "step": 30
+        },
+        {
+          "expr": "sum (SeaweedFS_s3_request_total{type=~'PUT|COPY|POST|LIST', namespace=\"$NAMESPACE\"})*0.000005",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 2,
+          "legendFormat": "All PUT, COPY, POST, LIST",
+          "refId": "C",
+          "step": 30
+        },
+        {
+          "expr": "sum (SeaweedFS_s3_request_total{type!~'PUT|COPY|POST|LIST', namespace=\"$NAMESPACE\"})*0.0000004",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 2,
+          "legendFormat": "GET and all other",
+          "refId": "B"
+        },
+        {
+          "expr": "sum by (type) (SeaweedFS_s3_request_total{type!~'PUT|COPY|POST|LIST', namespace=\"$NAMESPACE\"})*0.0000004",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 2,
+          "legendFormat": "{{type}} requests",
+          "refId": "D"
+        }
+      ],
+      "timeFrom": "1M",
+      "title": "S3 API Monthly Cost if on AWS",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 78
+      },
+      "id": 62,
+      "panels": [],
+      "title": "Volume Server",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s",
+          "unitScale": true
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 79
+      },
+      "id": 47,
+      "links": [],
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "10.3.1",
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.99, sum(rate(SeaweedFS_volumeServer_request_seconds_bucket{namespace=\"$NAMESPACE\"}[$__rate_interval])) by (le, exported_instance))",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 2,
+          "legendFormat": "{{exported_instance}}",
+          "refId": "B"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum(rate(SeaweedFS_volumeServer_request_seconds_bucket{namespace=\"$NAMESPACE\"}[$__rate_interval])) by (le))",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "average",
+          "refId": "C"
+        }
+      ],
+      "title": "Volume Server Request Duration 99th percentile",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short",
+          "unitScale": true
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byValue",
+              "options": {
+                "op": "gte",
+                "reducer": "allIsZero",
+                "value": 0
+              }
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": true,
+                  "tooltip": true,
+                  "viz": false
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byValue",
+              "options": {
+                "op": "gte",
+                "reducer": "allIsNull",
+                "value": 0
+              }
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": true,
+                  "tooltip": true,
+                  "viz": false
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 79
+      },
+      "id": 40,
+      "links": [],
+      "options": {
+        "legend": {
+          "calcs": [
+            "sum"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "10.3.1",
+      "targets": [
+        {
+          "expr": "sum(rate(SeaweedFS_volumeServer_request_total{namespace=\"$NAMESPACE\"}[$__rate_interval])) by (type)",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "{{type}}",
+          "refId": "A",
+          "step": 4
+        }
+      ],
+      "title": "Volume Server QPS",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short",
+          "unitScale": true
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 86
+      },
+      "id": 48,
+      "links": [],
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "10.3.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum(SeaweedFS_volumeServer_volumes{namespace=\"$NAMESPACE\"}) by (collection, type)",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 2,
+          "legendFormat": "{{collection}} {{type}}",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum(SeaweedFS_volumeServer_volumes{namespace=\"$NAMESPACE\"})",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "Total",
+          "refId": "B"
+        }
+      ],
+      "title": "Volume Count",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "bytes",
+          "unitScale": true
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 93
+      },
+      "id": 50,
+      "links": [],
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "10.3.1",
+      "targets": [
+        {
+          "expr": "sum(SeaweedFS_volumeServer_total_disk_size{namespace=\"$NAMESPACE\"}) by (collection, type)",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 2,
+          "legendFormat": "{{collection}} {{type}}",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(SeaweedFS_volumeServer_total_disk_size{namespace=\"$NAMESPACE\"})",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "Total",
+          "refId": "B"
+        }
+      ],
+      "title": "Used Disk Space by Collection and Type",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "bytes",
+          "unitScale": true
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 100
+      },
+      "id": 51,
+      "links": [],
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "10.3.1",
+      "targets": [
+        {
+          "expr": "sum(SeaweedFS_volumeServer_total_disk_size{namespace=\"$NAMESPACE\"}) by (exported_instance)",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 2,
+          "legendFormat": "{{exported_instance}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Used Disk Space by Host",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 100
+      },
+      "id": 63,
+      "panels": [],
+      "title": "Filer Store",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s",
+          "unitScale": true
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 108
+      },
+      "id": 12,
+      "links": [],
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "10.3.1",
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.99, sum(rate(SeaweedFS_filerStore_request_seconds_bucket{namespace=\"$NAMESPACE\"}[$__rate_interval])) by (le, type))",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "{{type}}",
+          "refId": "B"
+        }
+      ],
+      "title": "Filer Store Request Duration 99th percentile",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short",
+          "unitScale": true
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 108
+      },
+      "id": 14,
+      "links": [],
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "10.3.1",
+      "targets": [
+        {
+          "expr": "sum(rate(SeaweedFS_filerStore_request_total{namespace=\"$NAMESPACE\"}[$__rate_interval])) by (type)",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "{{type}}",
+          "refId": "B"
+        }
+      ],
+      "title": "Filer Store QPS",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 115
+      },
+      "id": 64,
+      "panels": [],
+      "title": "Filer Instances",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "bytes",
+          "unitScale": true
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 116
+      },
+      "id": 52,
+      "links": [],
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "10.3.1",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "go_memstats_alloc_bytes{job=\"seaweedfs-filer\", namespace=\"$NAMESPACE\"}",
+          "format": "time_series",
+          "hide": false,
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "bytes allocated",
+          "refId": "B"
+        },
+        {
+          "exemplar": true,
+          "expr": "rate(go_memstats_alloc_bytes_total{job=\"seaweedfs-filer\", namespace=\"$NAMESPACE\"}[$__rate_interval])",
+          "format": "time_series",
+          "hide": false,
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "alloc rate",
+          "refId": "A"
+        },
+        {
+          "exemplar": true,
+          "expr": "go_memstats_stack_inuse_bytes{job=\"seaweedfs-filer\", namespace=\"$NAMESPACE\"}",
+          "format": "time_series",
+          "hide": false,
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "stack inuse",
+          "refId": "C"
+        },
+        {
+          "exemplar": true,
+          "expr": "go_memstats_heap_inuse_bytes{job=\"seaweedfs-filer\", namespace=\"$NAMESPACE\"}",
+          "format": "time_series",
+          "hide": false,
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "heap inuse",
+          "refId": "D"
+        }
+      ],
+      "title": "Filer Go Memory Stats",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s",
+          "unitScale": true
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 116
+      },
+      "id": 54,
+      "links": [],
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "10.3.1",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "go_gc_duration_seconds{job=\"seaweedfs-filer\", namespace=\"$NAMESPACE\"}",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "{{quantile}}",
+          "refId": "B"
+        }
+      ],
+      "title": "Filer Go GC duration quantiles",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none",
+          "unitScale": true
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 123
+      },
+      "id": 53,
+      "links": [],
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "10.3.1",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "go_goroutines{job=\"seaweedfs-filer\", namespace=\"$NAMESPACE\"}",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "{{exported_instance}}",
+          "refId": "B"
+        }
+      ],
+      "title": "Filer Go Routines",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "decbytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 55
+      },
+      "id": 89,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "10.3.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "max(SeaweedFS_s3_bucket_size_bytes{namespace=\"$NAMESPACE\"}) by (bucket)",
+          "legendFormat": "{{bucket}} (logical)",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "max(SeaweedFS_s3_bucket_physical_size_bytes{namespace=\"$NAMESPACE\"}) by (bucket)",
+          "legendFormat": "{{bucket}} (physical)",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "S3 Bucket Size",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 55
+      },
+      "id": 90,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "10.3.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "max(SeaweedFS_s3_bucket_object_count{namespace=\"$NAMESPACE\"}) by (bucket)",
+          "legendFormat": "{{bucket}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "S3 Bucket Object Count",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "",
+  "schemaVersion": 39,
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "Prometheus",
+          "value": "PBFA97CFB590B2093"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Datasource",
+        "multi": false,
+        "name": "DS_PROMETHEUS",
+        "options": [],
+        "query": "prometheus",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "mes",
+          "value": "mes"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "definition": "label_values(SeaweedFS_master_is_leader,namespace)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Namespace",
+        "multi": false,
+        "name": "NAMESPACE",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(SeaweedFS_master_is_leader,namespace)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 2,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-1d",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "browser",
+  "title": "SeaweedFS",
+  "uid": "a24009d7-cbda-4443-a132-1cc1c4677304",
+  "version": 1,
+  "weekStart": ""
+}

--- a/platform/seaweedfs/chart/charts/seaweedfs/openshift-values.yaml
+++ b/platform/seaweedfs/chart/charts/seaweedfs/openshift-values.yaml
@@ -1,0 +1,132 @@
+# openshift-values.yaml
+#
+# Example overrides for deploying SeaweedFS on OpenShift (or any cluster
+# enforcing the Kubernetes "restricted" Pod Security Standard).
+#
+# OpenShift's default "restricted" SCC blocks containers that:
+#   - Run as UID 0 (root)
+#   - Request privilege escalation
+#   - Use hostPath volumes
+#   - Omit a seccompProfile
+#
+# These overrides satisfy all four requirements by:
+#   1. Replacing hostPath volumes with PersistentVolumeClaims (or emptyDir for logs)
+#   2. Enabling runAsNonRoot: true. By omitting runAsUser, OpenShift will
+#      automatically assign a valid UID from the namespace's allocated range.
+#   3. Dropping all Linux capabilities and setting allowPrivilegeEscalation: false
+#   4. Enabling RuntimeDefault seccompProfile
+#
+# Usage:
+#   helm install seaweedfs seaweedfs/seaweedfs \
+#     -n seaweedfs --create-namespace \
+#     -f openshift-values.yaml
+#
+# Adjust storageClass and sizes to match your cluster's available StorageClasses.
+# On OpenShift you can discover them with: oc get storageclass
+global:
+  enableReplication: true
+  #  replication type is XYZ:
+  # X number of replica in other data centers
+  # Y number of replica in other racks in the same data center
+  # Z number of replica in other servers in the same rack
+  replicationPlacement: "000" # no data replica
+master:
+  replicas: 1
+  data:
+    type: "persistentVolumeClaim"
+    size: "10Gi"
+    storageClass: ""        # leave empty to use the cluster default StorageClass
+
+  logs:
+    type: "emptyDir"        # avoids hostPath; use persistentVolumeClaim if you need log persistence
+
+  podSecurityContext:
+    enabled: true
+    # On OpenShift, we omit runAsUser/runAsGroup/fsGroup to let the admission
+    # controller assign them automatically based on the namespace's SCC.
+    runAsNonRoot: true
+
+  containerSecurityContext:
+    enabled: true
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop: ["ALL"]
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+
+volume:
+  replicas: 1
+  dataDirs:
+    - name: data1
+      type: "persistentVolumeClaim"
+      size: "100Gi"
+      storageClass: ""      # leave empty to use the cluster default StorageClass
+      maxVolumes: 0
+
+  logs:
+    type: "emptyDir"
+
+  podSecurityContext:
+    enabled: true
+    # On OpenShift, we omit runAsUser/runAsGroup/fsGroup to let the admission
+    # controller assign them automatically based on the namespace's SCC.
+    runAsNonRoot: true
+
+  containerSecurityContext:
+    enabled: true
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop: ["ALL"]
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+
+filer:
+  replicas: 1
+  data:
+    type: "persistentVolumeClaim"
+    size: "25Gi"
+    storageClass: ""        # leave empty to use the cluster default StorageClass
+
+  logs:
+    type: "emptyDir"
+
+  podSecurityContext:
+    enabled: true
+    # On OpenShift, we omit runAsUser/runAsGroup/fsGroup to let the admission
+    # controller assign them automatically based on the namespace's SCC.
+    runAsNonRoot: true
+
+  containerSecurityContext:
+    enabled: true
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop: ["ALL"]
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+
+# S3 gateway (if enabled)
+s3:
+  enabled: true
+  replicas: 1
+  port: 8333
+  enableAuth: true
+  podSecurityContext:
+    enabled: true
+    # On OpenShift, we omit runAsUser/runAsGroup/fsGroup to let the admission
+    # controller assign them automatically based on the namespace's SCC.
+    runAsNonRoot: true
+
+  logs:
+    type: "emptyDir"
+
+  containerSecurityContext:
+    enabled: true
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop: ["ALL"]
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault

--- a/platform/seaweedfs/chart/charts/seaweedfs/templates/admin/admin-ingress.yaml
+++ b/platform/seaweedfs/chart/charts/seaweedfs/templates/admin/admin-ingress.yaml
@@ -1,0 +1,52 @@
+{{- if and .Values.admin.enabled .Values.admin.ingress.enabled }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion }}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion }}
+apiVersion: networking.k8s.io/v1beta1
+{{- else }}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: ingress-{{ include "seaweedfs.fullname" . }}-admin
+  namespace: {{ .Release.Namespace }}
+  annotations:
+  {{- if and (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) .Values.admin.ingress.className }}
+    kubernetes.io/ingress.class: {{ .Values.admin.ingress.className }}
+  {{- end }}
+  {{- with .Values.admin.ingress.annotations }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: admin
+spec:
+  {{- if and (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) .Values.admin.ingress.className }}
+  ingressClassName: {{ .Values.admin.ingress.className | quote }}
+  {{- end }}
+  tls:
+    {{ .Values.admin.ingress.tls | default list | toYaml | nindent 6}}
+  rules:
+  - {{- if .Values.admin.ingress.host }}
+    host: {{ .Values.admin.ingress.host | quote }}
+    {{- end }}
+    http:
+      paths:
+      - path: {{ .Values.admin.ingress.path | quote }}
+        {{- if semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion }}
+        pathType: {{ .Values.admin.ingress.pathType | quote }}
+        {{- end }}
+        backend:
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion }}
+          service:
+            name: {{ include "seaweedfs.componentName" (list . "admin") }}
+            port:
+              number: {{ .Values.admin.port }}
+{{- else }}
+          serviceName: {{ include "seaweedfs.componentName" (list . "admin") }}
+          servicePort: {{ .Values.admin.port }}
+{{- end }}
+{{- end }}

--- a/platform/seaweedfs/chart/charts/seaweedfs/templates/admin/admin-secret.yaml
+++ b/platform/seaweedfs/chart/charts/seaweedfs/templates/admin/admin-secret.yaml
@@ -1,0 +1,20 @@
+{{- if and .Values.admin.enabled .Values.admin.secret.adminPassword (not .Values.admin.secret.existingSecret) }}
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: {{ include "seaweedfs.fullname" . }}-admin-secret
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/resource-policy": keep
+    "helm.sh/hook": "pre-install,pre-upgrade"
+  labels:
+    app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: admin
+data:
+  adminUser: {{ .Values.admin.secret.adminUser | b64enc }}
+  adminPassword: {{ .Values.admin.secret.adminPassword | b64enc }}
+{{- end}}

--- a/platform/seaweedfs/chart/charts/seaweedfs/templates/admin/admin-service.yaml
+++ b/platform/seaweedfs/chart/charts/seaweedfs/templates/admin/admin-service.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.admin.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "seaweedfs.componentName" (list . "admin") }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: admin
+{{- if .Values.admin.service.annotations }}
+  annotations:
+    {{- toYaml .Values.admin.service.annotations | nindent 4 }}
+{{- end }}
+spec:
+  type: {{ .Values.admin.service.type }}
+  ports:
+  - name: "http"
+    port: {{ .Values.admin.port }}
+    targetPort: {{ .Values.admin.port }}
+    protocol: TCP
+  - name: "grpc"
+    port: {{ .Values.admin.grpcPort }}
+    targetPort: {{ .Values.admin.grpcPort }}
+    protocol: TCP
+  selector:
+    app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: admin
+{{- end }}
+

--- a/platform/seaweedfs/chart/charts/seaweedfs/templates/admin/admin-servicemonitor.yaml
+++ b/platform/seaweedfs/chart/charts/seaweedfs/templates/admin/admin-servicemonitor.yaml
@@ -1,0 +1,33 @@
+{{- include "seaweedfs.compat" . -}}
+{{- if .Values.admin.enabled }}
+{{- if .Values.global.seaweedfs.monitoring.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "seaweedfs.fullname" . }}-admin
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: admin
+    {{- with .Values.global.seaweedfs.monitoring.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+{{- with .Values.admin.serviceMonitor.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+{{- end }}
+spec:
+  endpoints:
+    - interval: 30s
+      port: http
+      scrapeTimeout: 5s
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/component: admin
+{{- end }}
+{{- end }}

--- a/platform/seaweedfs/chart/charts/seaweedfs/templates/admin/admin-statefulset.yaml
+++ b/platform/seaweedfs/chart/charts/seaweedfs/templates/admin/admin-statefulset.yaml
@@ -1,0 +1,338 @@
+{{- include "seaweedfs.compat" . -}}
+{{- if .Values.admin.enabled }}
+{{- if gt (.Values.admin.replicas | int) 1 }}
+{{- fail "admin.replicas must be 0 or 1" -}}
+{{- end }}
+{{- if and (not .Values.admin.masters) (not .Values.global.seaweedfs.masterServer) (not .Values.master.enabled) }}
+{{- fail "admin.masters or global.seaweedfs.masterServer must be set if master.enabled is false" -}}
+{{- end }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "seaweedfs.componentName" (list . "admin") }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: admin
+{{- if .Values.admin.annotations }}
+  annotations:
+    {{- toYaml .Values.admin.annotations | nindent 4 }}
+{{- end }}
+spec:
+  serviceName: {{ include "seaweedfs.componentName" (list . "admin") }}
+  podManagementPolicy: {{ .Values.admin.podManagementPolicy }}
+  replicas: {{ .Values.admin.replicas }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/component: admin
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
+        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/component: admin
+      {{ with .Values.podLabels }}
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.admin.podLabels }}
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+      annotations:
+      {{ with .Values.podAnnotations }}
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.admin.podAnnotations }}
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      restartPolicy: {{ default .Values.global.seaweedfs.restartPolicy .Values.admin.restartPolicy }}
+      {{- if .Values.admin.affinity }}
+      affinity:
+        {{ tpl .Values.admin.affinity . | nindent 8 | trim }}
+      {{- end }}
+      {{- if .Values.admin.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{ tpl .Values.admin.topologySpreadConstraints . | nindent 8 | trim }}
+      {{- end }}
+      {{- if .Values.admin.tolerations }}
+      tolerations:
+        {{ tpl .Values.admin.tolerations . | nindent 8 | trim }}
+      {{- end }}
+      {{- include "seaweedfs.imagePullSecrets" . | nindent 6 }}
+      terminationGracePeriodSeconds: 30
+      {{- if .Values.admin.priorityClassName }}
+      priorityClassName: {{ .Values.admin.priorityClassName | quote }}
+      {{- end }}
+      enableServiceLinks: false
+      {{- if .Values.admin.serviceAccountName }}
+      serviceAccountName: {{ .Values.admin.serviceAccountName | quote }}
+      {{- end }}
+      {{- if .Values.admin.initContainers }}
+      initContainers:
+        {{ tpl .Values.admin.initContainers . | nindent 8 | trim }}
+      {{- end }}
+      {{- if .Values.admin.podSecurityContext.enabled }}
+      securityContext: {{- omit .Values.admin.podSecurityContext "enabled" | toYaml | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: seaweedfs
+          image: {{ template "seaweedfs.admin.image" . }}
+          imagePullPolicy: {{ default "IfNotPresent" .Values.global.seaweedfs.imagePullPolicy }}
+          {{- $adminAuthEnabled := or .Values.admin.secret.existingSecret .Values.admin.secret.adminPassword }}
+          {{- $urlPrefix := .Values.admin.urlPrefix }}
+          {{- if and (not $urlPrefix) .Values.admin.ingress.enabled (ne .Values.admin.ingress.path "/") }}
+          {{- $urlPrefix = trimSuffix "/" .Values.admin.ingress.path }}
+          {{- end }}
+          {{- if and .Values.admin.secret.existingSecret (not .Values.admin.secret.userKey) -}}
+          {{-   fail "admin.secret.userKey must be set when admin.secret.existingSecret is provided" -}}
+          {{- end -}}
+          {{- if and .Values.admin.secret.existingSecret (not .Values.admin.secret.pwKey) -}}
+          {{-   fail "admin.secret.pwKey must be set when admin.secret.existingSecret is provided" -}}
+          {{- end -}}
+          {{- $adminSecretName := .Values.admin.secret.existingSecret | default (printf "%s-admin-secret" (include "seaweedfs.fullname" .)) }}
+          env:
+            {{- if $adminAuthEnabled }}
+            - name: WEED_ADMIN_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $adminSecretName }}
+                  key: {{ if .Values.admin.secret.existingSecret }}{{ .Values.admin.secret.userKey }}{{ else }}adminUser{{ end }}
+            - name: WEED_ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $adminSecretName }}
+                  key: {{ if .Values.admin.secret.existingSecret }}{{ .Values.admin.secret.pwKey }}{{ else }}adminPassword{{ end }}
+            {{- end }}
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: SEAWEEDFS_FULLNAME
+              value: "{{ include "seaweedfs.fullname" . }}"
+            {{- $mergedExtraEnvironmentVars := dict }}
+            {{- include "seaweedfs.mergeExtraEnvironmentVars" (dict "global" .Values.global.seaweedfs "component" .Values.admin "target" $mergedExtraEnvironmentVars) }}
+            {{- range $key := keys $mergedExtraEnvironmentVars | sortAlpha }}
+            {{- $value := index $mergedExtraEnvironmentVars $key }}
+            - name: {{ $key }}
+            {{- if kindIs "string" $value }}
+              value: {{ tpl $value $ | quote }}
+            {{- else }}
+              valueFrom:
+                {{ toYaml $value | nindent 16 | trim }}
+            {{- end -}}
+            {{- end }}
+          command:
+            - "/bin/sh"
+            - "-ec"
+            - |
+              exec /usr/bin/weed \
+              {{- if or (eq .Values.admin.logs.type "hostPath") (eq .Values.admin.logs.type "persistentVolumeClaim") (eq .Values.admin.logs.type "emptyDir") (eq .Values.admin.logs.type "existingClaim") }}
+              -logdir=/logs \
+              {{- else }}
+              -logtostderr=true \
+              {{- end }}
+              {{- if .Values.admin.loggingOverrideLevel }}
+              -v={{ .Values.admin.loggingOverrideLevel }} \
+              {{- else }}
+              -v={{ .Values.global.seaweedfs.loggingLevel }} \
+              {{- end }}
+              admin \
+              -port={{ .Values.admin.port }} \
+              -port.grpc={{ .Values.admin.grpcPort }} \
+              {{- if or (eq .Values.admin.data.type "hostPath") (eq .Values.admin.data.type "persistentVolumeClaim") (eq .Values.admin.data.type "emptyDir") (eq .Values.admin.data.type "existingClaim") }}
+              -dataDir=/data \
+              {{- else if .Values.admin.dataDir }}
+              -dataDir={{ .Values.admin.dataDir }} \
+              {{- end }}
+              {{- if .Values.admin.masters }}
+              -masters={{ .Values.admin.masters }}{{- if or $urlPrefix .Values.admin.extraArgs }} \{{ end }}
+              {{- else if .Values.global.seaweedfs.masterServer }}
+              -masters={{ .Values.global.seaweedfs.masterServer }}{{- if or $urlPrefix .Values.admin.extraArgs }} \{{ end }}
+              {{- else }}
+              -masters={{ range $index := until (.Values.master.replicas | int) }}${SEAWEEDFS_FULLNAME}-master-{{ $index }}.${SEAWEEDFS_FULLNAME}-master.{{ $.Release.Namespace }}:{{ $.Values.master.port }}{{ if lt $index (sub ($.Values.master.replicas | int) 1) }},{{ end }}{{ end }}{{- if or $urlPrefix .Values.admin.extraArgs }} \{{ end }}
+              {{- end }}
+              {{- if $urlPrefix }}
+              -urlPrefix={{ $urlPrefix }}{{- if .Values.admin.extraArgs }} \{{ end }}
+              {{- end }}
+              {{- range $index, $arg := .Values.admin.extraArgs }}
+              {{ $arg }}{{- if lt $index (sub (len $.Values.admin.extraArgs) 1) }} \{{ end }}
+              {{- end }}
+          volumeMounts:
+            {{- if or (eq .Values.admin.data.type "hostPath") (eq .Values.admin.data.type "persistentVolumeClaim") (eq .Values.admin.data.type "emptyDir") (eq .Values.admin.data.type "existingClaim") }}
+            - name: admin-data
+              mountPath: /data
+            {{- end }}
+            {{- if or (eq .Values.admin.logs.type "hostPath") (eq .Values.admin.logs.type "persistentVolumeClaim") (eq .Values.admin.logs.type "emptyDir") (eq .Values.admin.logs.type "existingClaim") }}
+            - name: admin-logs
+              mountPath: /logs
+            {{- end }}
+            {{- if .Values.global.seaweedfs.enableSecurity }}
+            - name: security-config
+              readOnly: true
+              mountPath: /etc/seaweedfs/security.toml
+              subPath: security.toml
+            - name: ca-cert
+              readOnly: true
+              mountPath: /usr/local/share/ca-certificates/ca/
+            - name: master-cert
+              readOnly: true
+              mountPath: /usr/local/share/ca-certificates/master/
+            - name: volume-cert
+              readOnly: true
+              mountPath: /usr/local/share/ca-certificates/volume/
+            - name: filer-cert
+              readOnly: true
+              mountPath: /usr/local/share/ca-certificates/filer/
+            - name: client-cert
+              readOnly: true
+              mountPath: /usr/local/share/ca-certificates/client/
+            - name: admin-cert
+              readOnly: true
+              mountPath: /usr/local/share/ca-certificates/admin/
+            {{- end }}
+            {{ tpl .Values.admin.extraVolumeMounts . | nindent 12 | trim }}
+          ports:
+            - containerPort: {{ .Values.admin.port }}
+              name: http
+            - containerPort: {{ .Values.admin.grpcPort }}
+              name: grpc
+          {{- if .Values.admin.readinessProbe.enabled }}
+          readinessProbe:
+            httpGet:
+              path: {{ if $urlPrefix }}{{ $urlPrefix }}{{ end }}{{ .Values.admin.readinessProbe.httpGet.path }}
+              port: http
+              scheme: {{ .Values.admin.readinessProbe.httpGet.scheme }}
+            initialDelaySeconds: {{ .Values.admin.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.admin.readinessProbe.periodSeconds }}
+            successThreshold: {{ .Values.admin.readinessProbe.successThreshold }}
+            failureThreshold: {{ .Values.admin.readinessProbe.failureThreshold }}
+            timeoutSeconds: {{ .Values.admin.readinessProbe.timeoutSeconds }}
+          {{- end }}
+          {{- if .Values.admin.livenessProbe.enabled }}
+          livenessProbe:
+            httpGet:
+              path: {{ if $urlPrefix }}{{ $urlPrefix }}{{ end }}{{ .Values.admin.livenessProbe.httpGet.path }}
+              port: http
+              scheme: {{ .Values.admin.livenessProbe.httpGet.scheme }}
+            initialDelaySeconds: {{ .Values.admin.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.admin.livenessProbe.periodSeconds }}
+            successThreshold: {{ .Values.admin.livenessProbe.successThreshold }}
+            failureThreshold: {{ .Values.admin.livenessProbe.failureThreshold }}
+            timeoutSeconds: {{ .Values.admin.livenessProbe.timeoutSeconds }}
+          {{- end }}
+          {{- with .Values.admin.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- if .Values.admin.containerSecurityContext.enabled }}
+          securityContext: {{- omit .Values.admin.containerSecurityContext "enabled" | toYaml | nindent 12 }}
+          {{- end }}
+      {{- if .Values.admin.sidecars }}
+      {{- include "seaweedfs.tplvalues.render" (dict "value" .Values.admin.sidecars "context" $) | nindent 8 }}
+      {{- end }}
+      volumes:
+        {{- if eq .Values.admin.data.type "hostPath" }}
+        - name: admin-data
+          hostPath:
+            path: {{ .Values.admin.data.hostPathPrefix }}/seaweedfs-admin-data
+            type: DirectoryOrCreate
+        {{- end }}
+        {{- if eq .Values.admin.data.type "emptyDir" }}
+        - name: admin-data
+          emptyDir: {}
+        {{- end }}
+        {{- if eq .Values.admin.data.type "existingClaim" }}
+        - name: admin-data
+          persistentVolumeClaim:
+            claimName: {{ .Values.admin.data.claimName }}
+        {{- end }}
+        {{- if eq .Values.admin.logs.type "hostPath" }}
+        - name: admin-logs
+          hostPath:
+            path: {{ .Values.admin.logs.hostPathPrefix }}/logs/seaweedfs/admin
+            type: DirectoryOrCreate
+        {{- end }}
+        {{- if eq .Values.admin.logs.type "emptyDir" }}
+        - name: admin-logs
+          emptyDir: {}
+        {{- end }}
+        {{- if eq .Values.admin.logs.type "existingClaim" }}
+        - name: admin-logs
+          persistentVolumeClaim:
+            claimName: {{ .Values.admin.logs.claimName }}
+        {{- end }}
+        {{- if .Values.global.seaweedfs.enableSecurity }}
+        - name: security-config
+          configMap:
+            name: {{ include "seaweedfs.fullname" . }}-security-config
+        - name: ca-cert
+          secret:
+            secretName: {{ include "seaweedfs.fullname" . }}-ca-cert
+        - name: master-cert
+          secret:
+            secretName: {{ include "seaweedfs.fullname" . }}-master-cert
+        - name: volume-cert
+          secret:
+            secretName: {{ include "seaweedfs.fullname" . }}-volume-cert
+        - name: filer-cert
+          secret:
+            secretName: {{ include "seaweedfs.fullname" . }}-filer-cert
+        - name: client-cert
+          secret:
+            secretName: {{ include "seaweedfs.fullname" . }}-client-cert
+        - name: admin-cert
+          secret:
+            secretName: {{ include "seaweedfs.fullname" . }}-admin-cert
+        {{- end }}
+        {{ tpl .Values.admin.extraVolumes . | indent 8 | trim }}
+      {{- if .Values.admin.nodeSelector }}
+      nodeSelector:
+        {{ tpl .Values.admin.nodeSelector . | indent 8 | trim }}
+      {{- end }}
+  {{- $pvc_exists := include "seaweedfs.admin.pvc_exists" . -}}
+  {{- if $pvc_exists }}
+  volumeClaimTemplates:
+    {{- if eq .Values.admin.data.type "persistentVolumeClaim" }}
+    - metadata:
+        name: admin-data
+        {{- with .Values.admin.data.annotations }}
+        annotations:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+      spec:
+        accessModes: [ "ReadWriteOnce" ]
+        storageClassName: {{ .Values.admin.data.storageClass }}
+        resources:
+          requests:
+            storage: {{ .Values.admin.data.size }}
+    {{- end }}
+    {{- if eq .Values.admin.logs.type "persistentVolumeClaim" }}
+    - metadata:
+        name: admin-logs
+        {{- with .Values.admin.logs.annotations }}
+        annotations:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+      spec:
+        accessModes: [ "ReadWriteOnce" ]
+        storageClassName: {{ .Values.admin.logs.storageClass }}
+        resources:
+          requests:
+            storage: {{ .Values.admin.logs.size }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/platform/seaweedfs/chart/charts/seaweedfs/templates/all-in-one/all-in-one-deployment.yaml
+++ b/platform/seaweedfs/chart/charts/seaweedfs/templates/all-in-one/all-in-one-deployment.yaml
@@ -1,0 +1,492 @@
+{{- include "seaweedfs.compat" . -}}
+{{- if .Values.allInOne.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "seaweedfs.fullname" . }}-all-in-one
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: seaweedfs-all-in-one
+  {{- if .Values.allInOne.annotations }}
+  annotations:
+    {{- toYaml .Values.allInOne.annotations | nindent 4 }}
+  {{- end }}
+spec:
+  replicas: {{ .Values.allInOne.replicas | default 1 }}
+  strategy:
+    type: {{ .Values.allInOne.updateStrategy.type | default "Recreate" }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/component: seaweedfs-all-in-one
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
+        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/component: seaweedfs-all-in-one
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.allInOne.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.allInOne.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      restartPolicy: {{ default .Values.global.seaweedfs.restartPolicy .Values.allInOne.restartPolicy }}
+      {{- if .Values.allInOne.affinity }}
+      affinity:
+        {{ tpl .Values.allInOne.affinity . | nindent 8 | trim }}
+      {{- end }}
+      {{- if .Values.allInOne.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{ tpl .Values.allInOne.topologySpreadConstraints . | nindent 8 | trim }}
+      {{- end }}
+      {{- if .Values.allInOne.tolerations }}
+      tolerations:
+        {{- tpl .Values.allInOne.tolerations . | nindent 8 }}
+      {{- end }}
+      {{- include "seaweedfs.imagePullSecrets" . | nindent 6 }}
+      terminationGracePeriodSeconds: 60
+      enableServiceLinks: false
+      {{- if .Values.allInOne.priorityClassName }}
+      priorityClassName: {{ .Values.allInOne.priorityClassName | quote }}
+      {{- end }}
+      {{- if .Values.allInOne.serviceAccountName }}
+      serviceAccountName: {{ .Values.allInOne.serviceAccountName | quote }}
+      {{- end }}
+      {{- if .Values.allInOne.initContainers }}
+      initContainers:
+        {{- tpl .Values.allInOne.initContainers . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.allInOne.podSecurityContext.enabled }}
+      securityContext:
+        {{- omit .Values.allInOne.podSecurityContext "enabled" | toYaml | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: seaweedfs
+          image: {{ template "seaweedfs.master.image" . }}
+          imagePullPolicy: {{ default "IfNotPresent" .Values.global.seaweedfs.imagePullPolicy }}
+          env:
+            {{- /* Determine default cluster alias and the corresponding env var keys to avoid conflicts */}}
+            {{- $envMerged := merge (.Values.global.seaweedfs.extraEnvironmentVars | default dict) (.Values.allInOne.extraEnvironmentVars | default dict) }}
+            {{- $clusterDefault := default "sw" (index $envMerged "WEED_CLUSTER_DEFAULT") }}
+            {{- $clusterUpper := upper $clusterDefault }}
+            {{- $clusterMasterKey := printf "WEED_CLUSTER_%s_MASTER" $clusterUpper }}
+            {{- $clusterFilerKey := printf "WEED_CLUSTER_%s_FILER" $clusterUpper }}
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: SEAWEEDFS_FULLNAME
+              value: "{{ include "seaweedfs.fullname" . }}"
+            {{- if .Values.allInOne.extraEnvironmentVars }}
+            {{- range $key, $value := .Values.allInOne.extraEnvironmentVars }}
+            {{- if and (ne $key $clusterMasterKey) (ne $key $clusterFilerKey) }}
+            - name: {{ $key }}
+              {{- if kindIs "string" $value }}
+              value: {{ tpl $value $ | quote }}
+              {{- else }}
+              valueFrom:
+                {{ toYaml $value | nindent 16 }}
+              {{- end }}
+            {{- end }}
+            {{- end }}
+            {{- end }}
+            {{- if .Values.global.seaweedfs.extraEnvironmentVars }}
+            {{- range $key, $value := .Values.global.seaweedfs.extraEnvironmentVars }}
+            {{- if and (ne $key $clusterMasterKey) (ne $key $clusterFilerKey) }}
+            - name: {{ $key }}
+              {{- if kindIs "string" $value }}
+              value: {{ tpl $value $ | quote }}
+              {{- else }}
+              valueFrom:
+                {{ toYaml $value | nindent 16 }}
+              {{- end }}
+            {{- end }}
+            {{- end }}
+            {{- end }}
+            # Inject computed cluster endpoints for the default cluster
+            - name: {{ $clusterMasterKey }}
+              value: {{ include "seaweedfs.cluster.masterAddress" . | quote }}
+            - name: {{ $clusterFilerKey }}
+              value: {{ include "seaweedfs.cluster.filerAddress" . | quote }}
+            {{- if .Values.allInOne.secretExtraEnvironmentVars }}
+            {{- range $key, $value := .Values.allInOne.secretExtraEnvironmentVars }}
+            - name: {{ $key }}
+              valueFrom:
+                {{ toYaml $value | nindent 16 }}
+            {{- end }}
+            {{- end }}
+          command:
+            - "/bin/sh"
+            - "-ec"
+            - |
+              /usr/bin/weed \
+              {{- if .Values.allInOne.loggingOverrideLevel }}
+              -v={{ .Values.allInOne.loggingOverrideLevel }} \
+              {{- else }}
+              -v={{ .Values.global.seaweedfs.loggingLevel }} \
+              {{- end }}
+              server \
+              -dir=/data \
+              -master \
+              -volume \
+              -ip=${POD_IP} \
+              -ip.bind=0.0.0.0 \
+              {{- if .Values.allInOne.idleTimeout }}
+              -idleTimeout={{ .Values.allInOne.idleTimeout }} \
+              {{- end }}
+              {{- if .Values.allInOne.dataCenter }}
+              -dataCenter={{ .Values.allInOne.dataCenter }} \
+              {{- end }}
+              {{- if .Values.allInOne.rack }}
+              -rack={{ .Values.allInOne.rack }} \
+              {{- end }}
+              {{- if .Values.allInOne.whiteList }}
+              -whiteList={{ .Values.allInOne.whiteList }} \
+              {{- end }}
+              {{- if .Values.allInOne.disableHttp }}
+              -disableHttp={{ .Values.allInOne.disableHttp }} \
+              {{- end }}
+              {{- if .Values.volume.dataDirs }}
+              {{- with (first .Values.volume.dataDirs) }}
+              {{- if and (hasKey . "maxVolumes") (ne .maxVolumes nil) }}
+              -volume.max={{ .maxVolumes }} \
+              {{- end }}
+              {{- end }}
+              {{- end }}
+              -master.port={{ .Values.master.port }} \
+              {{- if .Values.global.seaweedfs.enableReplication }}
+              -master.defaultReplication={{ .Values.global.seaweedfs.replicationPlacement }} \
+              {{- else }}
+              -master.defaultReplication={{ .Values.master.defaultReplication }} \
+              {{- end }}
+              {{- if .Values.master.volumePreallocate }}
+              -master.volumePreallocate \
+              {{- end }}
+              -master.volumeSizeLimitMB={{ .Values.master.volumeSizeLimitMB }} \
+              {{- if .Values.master.garbageThreshold }}
+              -master.garbageThreshold={{ .Values.master.garbageThreshold }} \
+              {{- end }}
+              -volume.port={{ .Values.volume.port }} \
+              -volume.readMode={{ .Values.volume.readMode }} \
+              {{- if .Values.volume.imagesFixOrientation }}
+              -volume.images.fix.orientation \
+              {{- end }}
+              {{- if .Values.volume.index }}
+              -volume.index={{ .Values.volume.index }} \
+              {{- end }}
+              {{- if .Values.volume.fileSizeLimitMB }}
+              -volume.fileSizeLimitMB={{ .Values.volume.fileSizeLimitMB }} \
+              {{- end }}
+              -volume.minFreeSpacePercent={{ .Values.volume.minFreeSpacePercent }} \
+              -volume.compactionMBps={{ .Values.volume.compactionMBps }} \
+              {{- if .Values.allInOne.metricsPort }}
+              -metricsPort={{ .Values.allInOne.metricsPort }} \
+              {{- else if .Values.master.metricsPort }}
+              -metricsPort={{ .Values.master.metricsPort }} \
+              {{- end }}
+              {{- if .Values.allInOne.metricsIp }}
+              -metricsIp={{ .Values.allInOne.metricsIp }} \
+              {{- end }}
+              -filer \
+              -filer.port={{ .Values.filer.port }} \
+              {{- if .Values.filer.disableDirListing }}
+              -filer.disableDirListing \
+              {{- end }}
+              -filer.dirListLimit={{ .Values.filer.dirListLimit }} \
+              {{- if .Values.global.seaweedfs.enableReplication }}
+              -filer.defaultReplicaPlacement={{ .Values.global.seaweedfs.replicationPlacement }} \
+              {{- else }}
+              -filer.defaultReplicaPlacement={{ .Values.filer.defaultReplicaPlacement }} \
+              {{- end }}
+              {{- if .Values.filer.maxMB }}
+              -filer.maxMB={{ .Values.filer.maxMB }} \
+              {{- end }}
+              {{- if .Values.filer.encryptVolumeData }}
+              -filer.encryptVolumeData \
+              {{- end }}
+              {{- if .Values.filer.filerGroup}}
+              -filer.filerGroup={{ .Values.filer.filerGroup}} \
+              {{- end }}
+              {{- if .Values.filer.rack }}
+              -filer.rack={{ .Values.filer.rack }} \
+              {{- end }}
+              {{- if .Values.filer.dataCenter }}
+              -filer.dataCenter={{ .Values.filer.dataCenter }} \
+              {{- end }}
+              {{- if .Values.allInOne.s3.enabled }}
+              -s3 \
+              -s3.port={{ .Values.allInOne.s3.port | default .Values.s3.port }} \
+              {{- $domainName := .Values.allInOne.s3.domainName | default .Values.s3.domainName }}
+              {{- if $domainName }}
+              -s3.domainName={{ $domainName }} \
+              {{- end }}
+              {{- if .Values.global.seaweedfs.enableSecurity }}
+              {{- $httpsPort := .Values.allInOne.s3.httpsPort | default .Values.s3.httpsPort }}
+              {{- if $httpsPort }}
+              -s3.port.https={{ $httpsPort }} \
+              {{- include "seaweedfs.s3.tlsArgs" (dict "root" . "prefix" "s3.") | nindent 14 }}
+              {{- end }}
+              {{- end }}
+              {{- if or .Values.allInOne.s3.enableAuth .Values.s3.enableAuth .Values.filer.s3.enableAuth }}
+              -s3.config=/etc/sw/s3/seaweedfs_s3_config \
+              {{- end }}
+              {{- $auditLogConfig := .Values.allInOne.s3.auditLogConfig | default .Values.s3.auditLogConfig }}
+              {{- if $auditLogConfig }}
+              -s3.auditLogConfig=/etc/sw/s3/s3_auditLogConfig.json \
+              {{- end }}
+              {{- end }}
+              {{- if .Values.allInOne.sftp.enabled }}
+              -sftp \
+              -sftp.port={{ .Values.allInOne.sftp.port | default .Values.sftp.port }} \
+              {{- $sshPrivateKey := .Values.allInOne.sftp.sshPrivateKey | default .Values.sftp.sshPrivateKey }}
+              {{- if $sshPrivateKey }}
+              -sftp.sshPrivateKey={{ $sshPrivateKey }} \
+              {{- end }}
+              {{- $hostKeysFolder := .Values.allInOne.sftp.hostKeysFolder | default .Values.sftp.hostKeysFolder }}
+              {{- if $hostKeysFolder }}
+              -sftp.hostKeysFolder={{ $hostKeysFolder }} \
+              {{- end }}
+              {{- $authMethods := .Values.allInOne.sftp.authMethods | default .Values.sftp.authMethods }}
+              {{- if $authMethods }}
+              -sftp.authMethods={{ $authMethods }} \
+              {{- end }}
+              {{- $maxAuthTries := .Values.allInOne.sftp.maxAuthTries | default .Values.sftp.maxAuthTries }}
+              {{- if $maxAuthTries }}
+              -sftp.maxAuthTries={{ $maxAuthTries }} \
+              {{- end }}
+              {{- $bannerMessage := .Values.allInOne.sftp.bannerMessage | default .Values.sftp.bannerMessage }}
+              {{- if $bannerMessage }}
+              -sftp.bannerMessage="{{ $bannerMessage }}" \
+              {{- end }}
+              {{- $loginGraceTime := .Values.allInOne.sftp.loginGraceTime | default .Values.sftp.loginGraceTime }}
+              {{- if $loginGraceTime }}
+              -sftp.loginGraceTime={{ $loginGraceTime }} \
+              {{- end }}
+              {{- $clientAliveInterval := .Values.allInOne.sftp.clientAliveInterval | default .Values.sftp.clientAliveInterval }}
+              {{- if $clientAliveInterval }}
+              -sftp.clientAliveInterval={{ $clientAliveInterval }} \
+              {{- end }}
+              {{- $clientAliveCountMax := .Values.allInOne.sftp.clientAliveCountMax | default .Values.sftp.clientAliveCountMax }}
+              {{- if $clientAliveCountMax }}
+              -sftp.clientAliveCountMax={{ $clientAliveCountMax }} \
+              {{- end }}
+              {{- if or .Values.allInOne.sftp.enableAuth .Values.sftp.enableAuth }}
+              -sftp.userStoreFile=/etc/sw/sftp/seaweedfs_sftp_config \
+              {{- end }}
+              {{- end }}
+              {{- $extraArgsCount := len .Values.allInOne.extraArgs }}
+              {{- range $i, $arg := .Values.allInOne.extraArgs }}
+              {{ $arg | quote }}{{ if ne (add1 $i) $extraArgsCount }} \{{ end }}
+              {{- end }}
+
+          volumeMounts:
+            - name: data
+              mountPath: /data
+            {{- if and .Values.allInOne.s3.enabled (or .Values.allInOne.s3.enableAuth .Values.s3.enableAuth .Values.filer.s3.enableAuth) }}
+            - name: config-s3-users
+              mountPath: /etc/sw/s3
+              readOnly: true
+            {{- end }}
+            {{- if .Values.allInOne.sftp.enabled }}
+            - name: config-ssh
+              mountPath: /etc/sw/ssh
+              readOnly: true
+            {{- if or .Values.allInOne.sftp.enableAuth .Values.sftp.enableAuth }}
+            - mountPath: /etc/sw/sftp
+              name: config-users
+              readOnly: true
+            {{- end }}
+            {{- end }}
+            {{- if .Values.filer.notificationConfig }}
+            - name: notification-config
+              mountPath: /etc/seaweedfs/notification.toml
+              subPath: notification.toml
+              readOnly: true
+            {{- end }}
+            - name: master-config
+              mountPath: /etc/seaweedfs/master.toml
+              subPath: master.toml
+              readOnly: true
+            {{- if .Values.global.seaweedfs.enableSecurity }}
+            - name: security-config
+              mountPath: /etc/seaweedfs/security.toml
+              subPath: security.toml
+              readOnly: true
+            - name: ca-cert
+              mountPath: /usr/local/share/ca-certificates/ca/
+              readOnly: true
+            - name: master-cert
+              mountPath: /usr/local/share/ca-certificates/master/
+              readOnly: true
+            - name: volume-cert
+              mountPath: /usr/local/share/ca-certificates/volume/
+              readOnly: true
+            - name: filer-cert
+              mountPath: /usr/local/share/ca-certificates/filer/
+              readOnly: true
+            - name: client-cert
+              mountPath: /usr/local/share/ca-certificates/client/
+              readOnly: true
+            {{- if .Values.allInOne.s3.enabled }}
+            {{- include "seaweedfs.s3.tlsVolumeMount" . | nindent 12 }}
+            {{- end }}
+            {{- end }}
+            {{ tpl .Values.allInOne.extraVolumeMounts . | nindent 12 }}
+          ports:
+            - containerPort: {{ .Values.master.port }}
+              name: swfs-mas
+            - containerPort: {{ .Values.master.grpcPort }}
+              name: swfs-mas-grpc
+            - containerPort: {{ .Values.volume.port }}
+              name: swfs-vol
+            - containerPort: {{ .Values.volume.grpcPort }}
+              name: swfs-vol-grpc
+            - containerPort: {{ .Values.filer.port }}
+              name: swfs-fil
+            - containerPort: {{ .Values.filer.grpcPort }}
+              name: swfs-fil-grpc
+            {{- if .Values.allInOne.s3.enabled }}
+            - containerPort: {{ .Values.allInOne.s3.port | default .Values.s3.port }}
+              name: swfs-s3
+              {{- $httpsPort := .Values.allInOne.s3.httpsPort | default .Values.s3.httpsPort }}
+              {{- if $httpsPort }}
+            - containerPort: {{ $httpsPort }}
+              name: swfs-s3-tls
+              {{- end }}
+            {{- end }}
+            {{- if .Values.allInOne.sftp.enabled }}
+            - containerPort: {{ .Values.allInOne.sftp.port | default .Values.sftp.port }}
+              name: swfs-sftp
+            {{- end }}
+            {{- if .Values.allInOne.metricsPort }}
+            - containerPort: {{ .Values.allInOne.metricsPort }}
+              name: server-metrics
+            {{- end }}
+          {{- if .Values.allInOne.readinessProbe.enabled }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.allInOne.readinessProbe.httpGet.path }}
+              port: {{ .Values.master.port }}
+              scheme: {{ .Values.allInOne.readinessProbe.httpGet.scheme }}
+            initialDelaySeconds: {{ .Values.allInOne.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.allInOne.readinessProbe.periodSeconds }}
+            successThreshold: {{ .Values.allInOne.readinessProbe.successThreshold }}
+            failureThreshold: {{ .Values.allInOne.readinessProbe.failureThreshold }}
+            timeoutSeconds: {{ .Values.allInOne.readinessProbe.timeoutSeconds }}
+          {{- end }}
+          {{- if .Values.allInOne.livenessProbe.enabled }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.allInOne.livenessProbe.httpGet.path }}
+              port: {{ .Values.master.port }}
+              scheme: {{ .Values.allInOne.livenessProbe.httpGet.scheme }}
+            initialDelaySeconds: {{ .Values.allInOne.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.allInOne.livenessProbe.periodSeconds }}
+            successThreshold: {{ .Values.allInOne.livenessProbe.successThreshold }}
+            failureThreshold: {{ .Values.allInOne.livenessProbe.failureThreshold }}
+            timeoutSeconds: {{ .Values.allInOne.livenessProbe.timeoutSeconds }}
+          {{- end }}
+          {{- with .Values.allInOne.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- if .Values.allInOne.containerSecurityContext.enabled }}
+          securityContext:
+            {{- omit .Values.allInOne.containerSecurityContext "enabled" | toYaml | nindent 12 }}
+          {{- end }}
+      {{- if .Values.allInOne.sidecars }}
+      {{- include "seaweedfs.tplvalues.render" (dict "value" .Values.allInOne.sidecars "context" $) | nindent 8 }}
+      {{- end }}
+      volumes:
+        - name: data
+          {{- if eq .Values.allInOne.data.type "hostPath" }}
+          hostPath:
+            path: {{ .Values.allInOne.data.hostPathPrefix }}/seaweedfs-all-in-one-data/
+            type: DirectoryOrCreate
+          {{- else if eq .Values.allInOne.data.type "persistentVolumeClaim" }}
+          persistentVolumeClaim:
+            claimName: {{ include "seaweedfs.fullname" . }}-all-in-one-data
+          {{- else if eq .Values.allInOne.data.type "existingClaim" }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.allInOne.data.claimName }}
+          {{- else if eq .Values.allInOne.data.type "emptyDir" }}
+          emptyDir: {}
+          {{- end }}
+        {{- if and .Values.allInOne.s3.enabled (or .Values.allInOne.s3.enableAuth .Values.s3.enableAuth .Values.filer.s3.enableAuth) }}
+        - name: config-s3-users
+          secret:
+            defaultMode: 420
+            secretName: {{ default (printf "%s-s3-secret" (include "seaweedfs.fullname" .)) (or .Values.allInOne.s3.existingConfigSecret .Values.s3.existingConfigSecret .Values.filer.s3.existingConfigSecret) }}
+        {{- end }}
+        {{- if .Values.allInOne.sftp.enabled }}
+        - name: config-ssh
+          secret:
+            defaultMode: 420
+            secretName: {{ default (printf "%s-sftp-ssh-secret" (include "seaweedfs.fullname" .)) (or .Values.allInOne.sftp.existingSshConfigSecret .Values.sftp.existingSshConfigSecret) }}
+        {{- if or .Values.allInOne.sftp.enableAuth .Values.sftp.enableAuth }}
+        - name: config-users
+          secret:
+            defaultMode: 420
+            secretName: {{ default (printf "%s-sftp-secret" (include "seaweedfs.fullname" .)) (or .Values.allInOne.sftp.existingConfigSecret .Values.sftp.existingConfigSecret) }}
+        {{- end }}
+        {{- end }}
+        {{- if .Values.filer.notificationConfig }}
+        - name: notification-config
+          configMap:
+            name: {{ include "seaweedfs.fullname" . }}-notification-config
+        {{- end }}
+        - name: master-config
+          configMap:
+            name: {{ include "seaweedfs.fullname" . }}-master-config
+        {{- if .Values.global.seaweedfs.enableSecurity }}
+        - name: security-config
+          configMap:
+            name: {{ include "seaweedfs.fullname" . }}-security-config
+        - name: ca-cert
+          secret:
+            secretName: {{ include "seaweedfs.fullname" . }}-ca-cert
+        - name: master-cert
+          secret:
+            secretName: {{ include "seaweedfs.fullname" . }}-master-cert
+        - name: volume-cert
+          secret:
+            secretName: {{ include "seaweedfs.fullname" . }}-volume-cert
+        - name: filer-cert
+          secret:
+            secretName: {{ include "seaweedfs.fullname" . }}-filer-cert
+        - name: client-cert
+          secret:
+            secretName: {{ include "seaweedfs.fullname" . }}-client-cert
+        {{- if .Values.allInOne.s3.enabled }}
+        {{- include "seaweedfs.s3.tlsVolume" . | nindent 8 }}
+        {{- end }}
+        {{- end }}
+        {{ tpl .Values.allInOne.extraVolumes . | nindent 8 }}
+      {{- if .Values.allInOne.nodeSelector }}
+      nodeSelector:
+        {{ tpl .Values.allInOne.nodeSelector . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/platform/seaweedfs/chart/charts/seaweedfs/templates/all-in-one/all-in-one-pvc.yaml
+++ b/platform/seaweedfs/chart/charts/seaweedfs/templates/all-in-one/all-in-one-pvc.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.allInOne.enabled }}
+{{- if eq .Values.allInOne.data.type "persistentVolumeClaim" }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "seaweedfs.fullname" . }}-all-in-one-data
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: seaweedfs-all-in-one
+  {{- with .Values.allInOne.data.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  accessModes:
+  {{- toYaml (.Values.allInOne.data.accessModes | default (list "ReadWriteOnce")) | nindent 4 }}
+  {{- if .Values.allInOne.data.storageClass }}
+  storageClassName: {{ .Values.allInOne.data.storageClass }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.allInOne.data.size | default "10Gi" }}
+{{- end }}
+{{- end }}

--- a/platform/seaweedfs/chart/charts/seaweedfs/templates/all-in-one/all-in-one-service.yml
+++ b/platform/seaweedfs/chart/charts/seaweedfs/templates/all-in-one/all-in-one-service.yml
@@ -1,0 +1,89 @@
+{{- if .Values.allInOne.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "seaweedfs.componentName" (list . "all-in-one") }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: seaweedfs-all-in-one
+  {{- if .Values.allInOne.service.annotations }}
+  annotations:
+    {{- toYaml .Values.allInOne.service.annotations | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.allInOne.service.type | default "ClusterIP" }}
+  internalTrafficPolicy: {{ .Values.allInOne.service.internalTrafficPolicy | default "Cluster" }}
+  {{- if and (semverCompare ">=1.31-0" .Capabilities.KubeVersion.GitVersion) .Values.allInOne.s3.trafficDistribution }}
+  trafficDistribution: {{ include "seaweedfs.trafficDistribution" (dict "value" .Values.allInOne.s3.trafficDistribution "Capabilities" .Capabilities) }}
+  {{- end }}
+  ports:
+  # Master ports
+  - name: "swfs-master"
+    port: {{ .Values.master.port }}
+    targetPort: {{ .Values.master.port }}
+    protocol: TCP
+  - name: "swfs-master-grpc"
+    port: {{ .Values.master.grpcPort }}
+    targetPort: {{ .Values.master.grpcPort }}
+    protocol: TCP
+  
+  # Volume ports
+  - name: "swfs-volume"
+    port: {{ .Values.volume.port }}
+    targetPort: {{ .Values.volume.port }}
+    protocol: TCP
+  - name: "swfs-volume-grpc"
+    port: {{ .Values.volume.grpcPort }}
+    targetPort: {{ .Values.volume.grpcPort }}
+    protocol: TCP
+  
+  # Filer ports
+  - name: "swfs-filer"
+    port: {{ .Values.filer.port }}
+    targetPort: {{ .Values.filer.port }}
+    protocol: TCP
+  - name: "swfs-filer-grpc"
+    port: {{ .Values.filer.grpcPort }}
+    targetPort: {{ .Values.filer.grpcPort }}
+    protocol: TCP
+  
+  # S3 ports (if enabled)
+  {{- if .Values.allInOne.s3.enabled }}
+  - name: "swfs-s3"
+    port: {{ .Values.allInOne.s3.port | default .Values.s3.port }}
+    targetPort: {{ .Values.allInOne.s3.port | default .Values.s3.port }}
+    protocol: TCP
+  {{- $httpsPort := .Values.allInOne.s3.httpsPort | default .Values.s3.httpsPort }}
+  {{- if $httpsPort }}
+  - name: "swfs-s3-tls"
+    port: {{ $httpsPort }}
+    targetPort: {{ $httpsPort }}
+    protocol: TCP
+  {{- end }}
+  {{- end }}
+  
+  # SFTP ports (if enabled)
+  {{- if .Values.allInOne.sftp.enabled }}
+  - name: "swfs-sftp"
+    port: {{ .Values.allInOne.sftp.port | default .Values.sftp.port }}
+    targetPort: {{ .Values.allInOne.sftp.port | default .Values.sftp.port }}
+    protocol: TCP
+  {{- end }}
+
+  # Server metrics port (single metrics endpoint for all services)
+  {{- if .Values.allInOne.metricsPort }}
+  - name: "server-metrics"
+    port: {{ .Values.allInOne.metricsPort }}
+    targetPort: {{ .Values.allInOne.metricsPort }}
+    protocol: TCP
+  {{- end }}
+  
+  selector:
+    app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: seaweedfs-all-in-one
+{{- end }}

--- a/platform/seaweedfs/chart/charts/seaweedfs/templates/all-in-one/all-in-one-servicemonitor.yaml
+++ b/platform/seaweedfs/chart/charts/seaweedfs/templates/all-in-one/all-in-one-servicemonitor.yaml
@@ -1,0 +1,31 @@
+{{- include "seaweedfs.compat" . -}}
+{{- if .Values.allInOne.enabled }}
+{{- if .Values.global.seaweedfs.monitoring.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "seaweedfs.fullname" . }}-all-in-one
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: all-in-one
+    {{- with .Values.global.seaweedfs.monitoring.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  endpoints:
+    {{- if .Values.allInOne.metricsPort }}
+    - interval: 30s
+      port: server-metrics
+      scrapeTimeout: 5s
+    {{- end }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/component: seaweedfs-all-in-one
+{{- end }}
+{{- end }}

--- a/platform/seaweedfs/chart/charts/seaweedfs/templates/cert/admin-cert.yaml
+++ b/platform/seaweedfs/chart/charts/seaweedfs/templates/cert/admin-cert.yaml
@@ -1,0 +1,44 @@
+{{- include "seaweedfs.compat" . -}}
+{{- if and .Values.global.seaweedfs.enableSecurity (not .Values.certificates.externalCertificates.enabled)}}
+apiVersion: cert-manager.io/v1{{ if .Values.global.seaweedfs.certificates.alphacrds }}alpha1{{ end }}
+kind: Certificate
+metadata:
+  name: {{ include "seaweedfs.fullname" . }}-admin-cert
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: admin
+  {{- if .Values.admin.annotations }}
+  annotations:
+    {{- toYaml .Values.admin.annotations | nindent 4 }}
+  {{- end }}
+spec:
+  secretName: {{ include "seaweedfs.fullname" . }}-admin-cert
+  issuerRef:
+    name: {{ include "seaweedfs.fullname" . }}-ca-issuer
+    kind: Issuer
+  commonName: {{ .Values.certificates.commonName }}
+  subject:
+    organizations:
+    - "SeaweedFS CA"
+  dnsNames:
+    - '*.{{ include "seaweedfs.fullname" . }}-admin'
+    - '*.{{ include "seaweedfs.fullname" . }}-admin.{{ .Release.Namespace }}'
+    - '*.{{ include "seaweedfs.fullname" . }}-admin.{{ .Release.Namespace }}.svc'
+    - '*.{{ include "seaweedfs.fullname" . }}-admin.{{ .Release.Namespace }}.svc.cluster.local'
+{{- if .Values.certificates.ipAddresses }}
+  ipAddresses:
+    {{- range .Values.certificates.ipAddresses }}
+    - {{ . }}
+    {{- end }}
+{{- end }}
+  privateKey:
+    algorithm: {{ .Values.certificates.keyAlgorithm }}
+    size: {{ .Values.certificates.keySize }}
+  duration: {{ .Values.certificates.duration }}
+  renewBefore: {{ .Values.certificates.renewBefore }}
+{{- end }}
+

--- a/platform/seaweedfs/chart/charts/seaweedfs/templates/cert/ca-cert.yaml
+++ b/platform/seaweedfs/chart/charts/seaweedfs/templates/cert/ca-cert.yaml
@@ -1,0 +1,26 @@
+{{- include "seaweedfs.compat" . -}}
+{{- if and .Values.global.seaweedfs.enableSecurity (not .Values.certificates.externalCertificates.enabled)}}
+apiVersion: cert-manager.io/v1{{ if .Values.global.seaweedfs.certificates.alphacrds }}alpha1{{ end }}
+kind: Certificate
+metadata:
+  name: {{ include "seaweedfs.fullname" . }}-ca-cert
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  secretName: {{ include "seaweedfs.fullname" . }}-ca-cert
+  commonName: "{{ include "seaweedfs.fullname" . }}-root-ca"
+  isCA: true
+  {{- if .Values.certificates.ca.duration }}
+  duration: {{ .Values.certificates.ca.duration }}
+  {{- end }}
+  {{- if .Values.certificates.ca.renewBefore }}
+  renewBefore: {{ .Values.certificates.ca.renewBefore }}
+  {{- end }}
+  issuerRef:
+    name: {{ include "seaweedfs.fullname" . }}-issuer
+    kind: Issuer
+{{- end }}

--- a/platform/seaweedfs/chart/charts/seaweedfs/templates/cert/cert-caissuer.yaml
+++ b/platform/seaweedfs/chart/charts/seaweedfs/templates/cert/cert-caissuer.yaml
@@ -1,0 +1,16 @@
+{{- include "seaweedfs.compat" . -}}
+{{- if and .Values.global.seaweedfs.enableSecurity (not .Values.certificates.externalCertificates.enabled)}}
+apiVersion: cert-manager.io/v1{{ if .Values.global.seaweedfs.certificates.alphacrds }}alpha1{{ end }}
+kind: Issuer
+metadata:
+  name: {{ include "seaweedfs.fullname" . }}-ca-issuer
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  ca:
+    secretName: {{ include "seaweedfs.fullname" . }}-ca-cert
+{{- end }}

--- a/platform/seaweedfs/chart/charts/seaweedfs/templates/cert/cert-issuer.yaml
+++ b/platform/seaweedfs/chart/charts/seaweedfs/templates/cert/cert-issuer.yaml
@@ -1,0 +1,14 @@
+{{- include "seaweedfs.compat" . -}}
+{{- if and .Values.global.seaweedfs.enableSecurity (not .Values.certificates.externalCertificates.enabled)}}
+apiVersion: cert-manager.io/v1{{ if .Values.global.seaweedfs.certificates.alphacrds }}alpha1{{ end }}
+kind: Issuer
+metadata:
+  name: {{ include "seaweedfs.fullname" . }}-issuer
+  labels:
+    app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  selfSigned: {}
+{{- end }}

--- a/platform/seaweedfs/chart/charts/seaweedfs/templates/cert/client-cert.yaml
+++ b/platform/seaweedfs/chart/charts/seaweedfs/templates/cert/client-cert.yaml
@@ -1,0 +1,41 @@
+{{- include "seaweedfs.compat" . -}}
+{{- if and .Values.global.seaweedfs.enableSecurity (not .Values.certificates.externalCertificates.enabled)}}
+apiVersion: cert-manager.io/v1{{ if .Values.global.seaweedfs.certificates.alphacrds }}alpha1{{ end }}
+kind: Certificate
+metadata:
+  name: {{ include "seaweedfs.fullname" . }}-client-cert
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  secretName: {{ include "seaweedfs.fullname" . }}-client-cert
+  issuerRef:
+    name: {{ include "seaweedfs.fullname" . }}-ca-issuer
+    kind: Issuer
+  commonName: {{ .Values.certificates.commonName }}
+  subject:
+    organizations:
+    - "SeaweedFS CA"
+  dnsNames:
+    - '*.{{ .Release.Namespace }}'
+    - '*.{{ .Release.Namespace }}.svc'
+    - '*.{{ .Release.Namespace }}.svc.cluster.local'
+    - '*.{{ include "seaweedfs.fullname" . }}-master'
+    - '*.{{ include "seaweedfs.fullname" . }}-master.{{ .Release.Namespace }}'
+    - '*.{{ include "seaweedfs.fullname" . }}-master.{{ .Release.Namespace }}.svc'
+    - '*.{{ include "seaweedfs.fullname" . }}-master.{{ .Release.Namespace }}.svc.cluster.local'
+{{- if .Values.certificates.ipAddresses }}
+  ipAddresses:
+    {{- range .Values.certificates.ipAddresses }}
+    - {{ . }}
+    {{- end }}
+{{- end }}
+  privateKey:
+    algorithm: {{ .Values.certificates.keyAlgorithm }}
+    size: {{ .Values.certificates.keySize }}
+  duration: {{ .Values.certificates.duration }}
+  renewBefore: {{ .Values.certificates.renewBefore }}
+{{- end }}

--- a/platform/seaweedfs/chart/charts/seaweedfs/templates/cert/filer-cert.yaml
+++ b/platform/seaweedfs/chart/charts/seaweedfs/templates/cert/filer-cert.yaml
@@ -1,0 +1,46 @@
+{{- include "seaweedfs.compat" . -}}
+{{- if and .Values.global.seaweedfs.enableSecurity (not .Values.certificates.externalCertificates.enabled)}}
+apiVersion: cert-manager.io/v1{{ if .Values.global.seaweedfs.certificates.alphacrds }}alpha1{{ end }}
+kind: Certificate
+metadata:
+  name: {{ include "seaweedfs.fullname" . }}-filer-cert
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: filer
+  {{- if .Values.filer.annotations }}
+  annotations:
+    {{- toYaml .Values.filer.annotations | nindent 4 }}
+  {{- end }}
+spec:
+  secretName: {{ include "seaweedfs.fullname" . }}-filer-cert
+  issuerRef:
+    name: {{ include "seaweedfs.fullname" . }}-ca-issuer
+    kind: Issuer
+  commonName: {{ .Values.certificates.commonName }}
+  subject:
+    organizations:
+    - "SeaweedFS CA"
+  dnsNames:
+    - '*.{{ .Release.Namespace }}'
+    - '*.{{ .Release.Namespace }}.svc'
+    - '*.{{ .Release.Namespace }}.svc.cluster.local'
+    - '*.{{ include "seaweedfs.fullname" . }}-master'
+    - '*.{{ include "seaweedfs.fullname" . }}-master.{{ .Release.Namespace }}'
+    - '*.{{ include "seaweedfs.fullname" . }}-master.{{ .Release.Namespace }}.svc'
+    - '*.{{ include "seaweedfs.fullname" . }}-master.{{ .Release.Namespace }}.svc.cluster.local'
+{{- if .Values.certificates.ipAddresses }}
+  ipAddresses:
+    {{- range .Values.certificates.ipAddresses }}
+    - {{ . }}
+    {{- end }}
+{{- end }}
+  privateKey:
+    algorithm: {{ .Values.certificates.keyAlgorithm }}
+    size: {{ .Values.certificates.keySize }}
+  duration: {{ .Values.certificates.duration }}
+  renewBefore: {{ .Values.certificates.renewBefore }}
+{{- end }}

--- a/platform/seaweedfs/chart/charts/seaweedfs/templates/cert/master-cert.yaml
+++ b/platform/seaweedfs/chart/charts/seaweedfs/templates/cert/master-cert.yaml
@@ -1,0 +1,46 @@
+{{- include "seaweedfs.compat" . -}}
+{{- if and .Values.global.seaweedfs.enableSecurity (not .Values.certificates.externalCertificates.enabled)}}
+apiVersion: cert-manager.io/v1{{ if .Values.global.seaweedfs.certificates.alphacrds }}alpha1{{ end }}
+kind: Certificate
+metadata:
+  name: {{ include "seaweedfs.fullname" . }}-master-cert
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: master
+{{- if .Values.master.annotations }}
+  annotations:
+    {{- toYaml .Values.master.annotations | nindent 4 }}
+{{- end }}
+spec:
+  secretName: {{ include "seaweedfs.fullname" . }}-master-cert
+  issuerRef:
+    name: {{ include "seaweedfs.fullname" . }}-ca-issuer
+    kind: Issuer
+  commonName: {{ .Values.certificates.commonName }}
+  subject:
+    organizations:
+    - "SeaweedFS CA"
+  dnsNames:
+    - '*.{{ .Release.Namespace }}'
+    - '*.{{ .Release.Namespace }}.svc'
+    - '*.{{ .Release.Namespace }}.svc.cluster.local'
+    - '*.{{ include "seaweedfs.fullname" . }}-master'
+    - '*.{{ include "seaweedfs.fullname" . }}-master.{{ .Release.Namespace }}'
+    - '*.{{ include "seaweedfs.fullname" . }}-master.{{ .Release.Namespace }}.svc'
+    - '*.{{ include "seaweedfs.fullname" . }}-master.{{ .Release.Namespace }}.svc.cluster.local'
+{{- if .Values.certificates.ipAddresses }}
+  ipAddresses:
+    {{- range .Values.certificates.ipAddresses }}
+    - {{ . }}
+    {{- end }}
+{{- end }}
+  privateKey:
+    algorithm: {{ .Values.certificates.keyAlgorithm }}
+    size: {{ .Values.certificates.keySize }}
+  duration: {{ .Values.certificates.duration }}
+  renewBefore: {{ .Values.certificates.renewBefore }}
+{{- end }}

--- a/platform/seaweedfs/chart/charts/seaweedfs/templates/cert/volume-cert.yaml
+++ b/platform/seaweedfs/chart/charts/seaweedfs/templates/cert/volume-cert.yaml
@@ -1,0 +1,46 @@
+{{- include "seaweedfs.compat" . -}}
+{{- if and .Values.global.seaweedfs.enableSecurity (not .Values.certificates.externalCertificates.enabled)}}
+apiVersion: cert-manager.io/v1{{ if .Values.global.seaweedfs.certificates.alphacrds }}alpha1{{ end }}
+kind: Certificate
+metadata:
+  name: {{ include "seaweedfs.fullname" . }}-volume-cert
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: volume
+{{- if .Values.volume.annotations }}
+  annotations:
+    {{- toYaml .Values.volume.annotations | nindent 4 }}
+{{- end }}
+spec:
+  secretName: {{ include "seaweedfs.fullname" . }}-volume-cert
+  issuerRef:
+    name: {{ include "seaweedfs.fullname" . }}-ca-issuer
+    kind: Issuer
+  commonName: {{ .Values.certificates.commonName }}
+  subject:
+    organizations:
+    - "SeaweedFS CA"
+  dnsNames:
+    - '*.{{ .Release.Namespace }}'
+    - '*.{{ .Release.Namespace }}.svc'
+    - '*.{{ .Release.Namespace }}.svc.cluster.local'
+    - '*.{{ include "seaweedfs.fullname" . }}-master'
+    - '*.{{ include "seaweedfs.fullname" . }}-master.{{ .Release.Namespace }}'
+    - '*.{{ include "seaweedfs.fullname" . }}-master.{{ .Release.Namespace }}.svc'
+    - '*.{{ include "seaweedfs.fullname" . }}-master.{{ .Release.Namespace }}.svc.cluster.local'
+{{- if .Values.certificates.ipAddresses }}
+  ipAddresses:
+    {{- range .Values.certificates.ipAddresses }}
+    - {{ . }}
+    {{- end }}
+{{- end }}
+  privateKey:
+    algorithm: {{ .Values.certificates.keyAlgorithm }}
+    size: {{ .Values.certificates.keySize }}
+  duration: {{ .Values.certificates.duration }}
+  renewBefore: {{ .Values.certificates.renewBefore }}
+{{- end }}

--- a/platform/seaweedfs/chart/charts/seaweedfs/templates/cert/worker-cert.yaml
+++ b/platform/seaweedfs/chart/charts/seaweedfs/templates/cert/worker-cert.yaml
@@ -1,0 +1,44 @@
+{{- include "seaweedfs.compat" . -}}
+{{- if and .Values.global.seaweedfs.enableSecurity (not .Values.certificates.externalCertificates.enabled)}}
+apiVersion: cert-manager.io/v1{{ if .Values.global.seaweedfs.certificates.alphacrds }}alpha1{{ end }}
+kind: Certificate
+metadata:
+  name: {{ include "seaweedfs.fullname" . }}-worker-cert
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: worker
+  {{- if .Values.worker.annotations }}
+  annotations:
+    {{- toYaml .Values.worker.annotations | nindent 4 }}
+  {{- end }}
+spec:
+  secretName: {{ include "seaweedfs.fullname" . }}-worker-cert
+  issuerRef:
+    name: {{ include "seaweedfs.fullname" . }}-ca-issuer
+    kind: Issuer
+  commonName: {{ .Values.certificates.commonName }}
+  subject:
+    organizations:
+    - "SeaweedFS CA"
+  dnsNames:
+    - '*.{{ include "seaweedfs.fullname" . }}-worker'
+    - '*.{{ include "seaweedfs.fullname" . }}-worker.{{ .Release.Namespace }}'
+    - '*.{{ include "seaweedfs.fullname" . }}-worker.{{ .Release.Namespace }}.svc'
+    - '*.{{ include "seaweedfs.fullname" . }}-worker.{{ .Release.Namespace }}.svc.cluster.local'
+{{- if .Values.certificates.ipAddresses }}
+  ipAddresses:
+    {{- range .Values.certificates.ipAddresses }}
+    - {{ . }}
+    {{- end }}
+{{- end }}
+  privateKey:
+    algorithm: {{ .Values.certificates.keyAlgorithm }}
+    size: {{ .Values.certificates.keySize }}
+  duration: {{ .Values.certificates.duration }}
+  renewBefore: {{ .Values.certificates.renewBefore }}
+{{- end }}
+

--- a/platform/seaweedfs/chart/charts/seaweedfs/templates/cosi/cosi-bucket-class.yaml
+++ b/platform/seaweedfs/chart/charts/seaweedfs/templates/cosi/cosi-bucket-class.yaml
@@ -1,0 +1,20 @@
+{{- if and .Values.cosi.enabled .Values.cosi.bucketClassName }}
+---
+kind: BucketClass
+apiVersion: objectstorage.k8s.io/v1alpha1
+metadata:
+  name: {{ .Values.cosi.bucketClassName }}
+driverName: {{ .Values.cosi.driverName }}
+deletionPolicy: Delete
+{{- with .Values.cosi.bucketClassParameters }}
+parameters:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+---
+kind: BucketAccessClass
+apiVersion: objectstorage.k8s.io/v1alpha1
+metadata:
+  name: {{ .Values.cosi.bucketClassName }}
+driverName: {{ .Values.cosi.driverName }}
+authenticationType: KEY
+{{- end }}

--- a/platform/seaweedfs/chart/charts/seaweedfs/templates/cosi/cosi-cluster-role.yaml
+++ b/platform/seaweedfs/chart/charts/seaweedfs/templates/cosi/cosi-cluster-role.yaml
@@ -1,0 +1,70 @@
+{{- include "seaweedfs.compat" . -}}
+{{- if .Values.cosi.enabled }}
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "seaweedfs.fullname" . }}-objectstorage-provisioner
+  labels:
+    app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+rules:
+- apiGroups: ["objectstorage.k8s.io"]
+  resources:
+    - "buckets"
+    - "bucketaccesses"
+    - "bucketclaims"
+    - "bucketaccessclasses"
+    - "buckets/status"
+    - "bucketaccesses/status"
+    - "bucketclaims/status"
+    - "bucketaccessclasses/status"
+  verbs:
+    - "get"
+    - "list"
+    - "watch"
+    - "update"
+    - "create"
+    - "delete"
+- apiGroups: ["coordination.k8s.io"]
+  resources: ["leases"]
+  verbs:
+    - "get"
+    - "watch"
+    - "list"
+    - "delete"
+    - "update"
+    - "create"
+- apiGroups: [""]
+  resources:
+    - "secrets"
+    - "events"
+  verbs:
+    - "get"
+    - "list"
+    - "watch"
+    - "update"
+    - "create"
+    - "delete"
+    - "patch"
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "seaweedfs.fullname" . }}-objectstorage-provisioner
+  labels:
+    app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.global.seaweedfs.serviceAccountName }}-objectstorage-provisioner
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ include "seaweedfs.fullname" . }}-objectstorage-provisioner
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/platform/seaweedfs/chart/charts/seaweedfs/templates/cosi/cosi-deployment.yaml
+++ b/platform/seaweedfs/chart/charts/seaweedfs/templates/cosi/cosi-deployment.yaml
@@ -1,0 +1,207 @@
+{{- include "seaweedfs.compat" . -}}
+{{- if .Values.cosi.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "seaweedfs.fullname" . }}-objectstorage-provisioner
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: objectstorage-provisioner
+spec:
+  replicas: {{ .Values.cosi.replicas }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/component: objectstorage-provisioner
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
+        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/component: objectstorage-provisioner
+      {{ with .Values.podLabels }}
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.cosi.podLabels }}
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+      annotations:
+      {{ with .Values.podAnnotations }}
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.cosi.podAnnotations }}
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      restartPolicy: {{ default .Values.global.seaweedfs.restartPolicy .Values.cosi.restartPolicy }}
+      {{- if .Values.cosi.affinity }}
+      affinity:
+        {{ tpl .Values.cosi.affinity . | nindent 8 | trim }}
+      {{- end }}
+      {{- if .Values.cosi.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{ tpl .Values.cosi.topologySpreadConstraint . | nindent 8 | trim }}
+      {{- end }}
+      {{- if .Values.cosi.tolerations }}
+      tolerations:
+        {{ tpl .Values.cosi.tolerations . | nindent 8 | trim }}
+      {{- end }}
+      {{- include "seaweedfs.imagePullSecrets" . | nindent 6 }}
+      terminationGracePeriodSeconds: 10
+      {{- if .Values.cosi.priorityClassName }}
+      priorityClassName: {{ .Values.cosi.priorityClassName | quote }}
+      {{- end }}
+      enableServiceLinks: false
+      serviceAccountName: {{ include "seaweedfs.componentName" (list . "objectstorage-provisioner") }}
+      {{- if .Values.cosi.initContainers }}
+      initContainers:
+        {{ tpl .Values.cosi.initContainers . | nindent 8 | trim }}
+      {{- end }}
+      {{- if .Values.cosi.podSecurityContext.enabled }}
+      securityContext: {{- omit .Values.cosi.podSecurityContext "enabled" | toYaml | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: seaweedfs-cosi-driver
+          image: "{{ .Values.cosi.image }}"
+          imagePullPolicy: {{ default "IfNotPresent" .Values.global.seaweedfs.imagePullPolicy }}
+          env:
+            - name: DRIVERNAME
+              value: "{{ .Values.cosi.driverName }}"
+            - name: ENDPOINT
+              {{- if .Values.cosi.endpoint }}
+              value: "{{ .Values.cosi.endpoint }}"
+              {{- else if .Values.s3.ingress.enabled }}
+              value: "{{ printf "https://%s" .Values.s3.ingress.host }}"
+              {{- else if .Values.s3.enabled }}
+              value: "{{ printf "https://%s.%s.svc" (include "seaweedfs.componentName" (list . "s3")) .Release.Namespace }}"
+              {{- else }}
+              value: "{{ printf "https://%s.%s.svc" (include "seaweedfs.componentName" (list . "filer")) .Release.Namespace }}"
+              {{- end }}
+            {{- with .Values.cosi.region }}
+            - name: REGION
+              value: "{{ . }}"
+            {{- end }}
+            - name: SEAWEEDFS_FILER
+              value: "{{ include "seaweedfs.componentName" (list . "filer") }}:{{ .Values.filer.grpcPort }}"
+            {{- if .Values.global.seaweedfs.enableSecurity }}
+            - name: WEED_GRPC_CLIENT_KEY
+              value: /usr/local/share/ca-certificates/client/tls.key
+            - name: WEED_GRPC_CLIENT_CERT
+              value: /usr/local/share/ca-certificates/client/tls.crt
+            - name: WEED_GRPC_CA
+              value: /usr/local/share/ca-certificates/client/ca.crt
+            {{- end }}
+            {{- $mergedExtraEnvironmentVars := dict }}
+            {{- include "seaweedfs.mergeExtraEnvironmentVars" (dict "global" .Values.global.seaweedfs "component" .Values.cosi "target" $mergedExtraEnvironmentVars) }}
+            {{- range $key := keys $mergedExtraEnvironmentVars | sortAlpha }}
+            {{- $value := index $mergedExtraEnvironmentVars $key }}
+            - name: {{ $key }}
+            {{- if kindIs "string" $value }}
+              value: {{ tpl $value $ | quote }}
+            {{- else }}
+              valueFrom:
+                {{ toYaml $value | nindent 16 | trim }}
+            {{- end -}}
+            {{- end }}
+          volumeMounts:
+            - mountPath: /var/lib/cosi
+              name: socket
+            {{- if .Values.cosi.enableAuth }}
+            - mountPath: /etc/sw
+              name: config-users
+              readOnly: true
+            {{- end }}
+            {{- if .Values.global.seaweedfs.enableSecurity }}
+            - name: security-config
+              readOnly: true
+              mountPath: /etc/seaweedfs/security.toml
+              subPath: security.toml
+            - name: ca-cert
+              readOnly: true
+              mountPath: /usr/local/share/ca-certificates/ca/
+            - name: master-cert
+              readOnly: true
+              mountPath: /usr/local/share/ca-certificates/master/
+            - name: volume-cert
+              readOnly: true
+              mountPath: /usr/local/share/ca-certificates/volume/
+            - name: filer-cert
+              readOnly: true
+              mountPath: /usr/local/share/ca-certificates/filer/
+            - name: client-cert
+              readOnly: true
+              mountPath: /usr/local/share/ca-certificates/client/
+            {{- end }}
+            {{ tpl .Values.cosi.extraVolumeMounts . | nindent 12 | trim }}
+          {{- with .Values.cosi.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+        - name: seaweedfs-cosi-sidecar
+          image: "{{ .Values.cosi.sidecar.image }}"
+          imagePullPolicy: {{ default "IfNotPresent" .Values.global.seaweedfs.imagePullPolicy }}
+          args:
+            - {{ printf "--v=%s" (default "5" .Values.cosi.sidecar.logLevel) }}
+          env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          volumeMounts:
+            - mountPath: /var/lib/cosi
+              name: socket
+          {{- with .Values.cosi.sidecar.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- if .Values.cosi.containerSecurityContext.enabled }}
+          securityContext: {{- omit .Values.cosi.containerSecurityContext "enabled" | toYaml | nindent 12 }}
+          {{- end }}
+      {{- if .Values.cosi.sidecars }}
+      {{- include "seaweedfs.tplvalues.render" (dict "value" .Values.cosi.sidecars "context" $) | nindent 8 }}
+      {{- end }}
+      volumes:
+        - name: socket
+          emptyDir: {}
+        {{- if .Values.cosi.enableAuth }}
+        - name: config-users
+          secret:
+            defaultMode: 420
+            {{- if .Values.cosi.existingConfigSecret }}
+            secretName: {{ .Values.cosi.existingConfigSecret }}
+            {{- else }}
+            secretName: {{ include "seaweedfs.fullname" . }}-s3-secret
+            {{- end }}
+        {{- end }}
+        {{- if .Values.global.seaweedfs.enableSecurity }}
+        - name: security-config
+          configMap:
+            name: {{ include "seaweedfs.fullname" . }}-security-config
+        - name: ca-cert
+          secret:
+            secretName: {{ include "seaweedfs.fullname" . }}-ca-cert
+        - name: master-cert
+          secret:
+            secretName: {{ include "seaweedfs.fullname" . }}-master-cert
+        - name: volume-cert
+          secret:
+            secretName: {{ include "seaweedfs.fullname" . }}-volume-cert
+        - name: filer-cert
+          secret:
+            secretName: {{ include "seaweedfs.fullname" . }}-filer-cert
+        - name: client-cert
+          secret:
+            secretName: {{ include "seaweedfs.fullname" . }}-client-cert
+        {{- end }}
+        {{ tpl .Values.cosi.extraVolumes . | indent 8 | trim }}
+      {{- if .Values.cosi.nodeSelector }}
+      nodeSelector:
+        {{ tpl .Values.cosi.nodeSelector . | indent 8 | trim }}
+      {{- end }}
+{{- end }}

--- a/platform/seaweedfs/chart/charts/seaweedfs/templates/cosi/cosi-service-account.yaml
+++ b/platform/seaweedfs/chart/charts/seaweedfs/templates/cosi/cosi-service-account.yaml
@@ -1,0 +1,14 @@
+{{- include "seaweedfs.compat" . -}}
+{{- if .Values.cosi.enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.global.seaweedfs.serviceAccountName }}-objectstorage-provisioner
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+automountServiceAccountToken: {{ .Values.global.seaweedfs.automountServiceAccountToken }}
+{{- end }}

--- a/platform/seaweedfs/chart/charts/seaweedfs/templates/filer/filer-ingress.yaml
+++ b/platform/seaweedfs/chart/charts/seaweedfs/templates/filer/filer-ingress.yaml
@@ -1,0 +1,49 @@
+{{- /* Filer ingress works for both normal mode (filer.enabled) and all-in-one mode (allInOne.enabled) */}}
+{{- $filerEnabled := or .Values.filer.enabled .Values.allInOne.enabled }}
+{{- if and $filerEnabled .Values.filer.ingress.enabled }}
+{{- /* Determine service name based on deployment mode */}}
+{{- $serviceName := ternary (include "seaweedfs.componentName" (list . "all-in-one")) (include "seaweedfs.componentName" (list . "filer")) .Values.allInOne.enabled }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion }}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion }}
+apiVersion: networking.k8s.io/v1beta1
+{{- else }}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: ingress-{{ include "seaweedfs.fullname" . }}-filer
+  namespace: {{ .Release.Namespace }}
+  {{- with .Values.filer.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: filer
+spec:
+  ingressClassName: {{ .Values.filer.ingress.className | quote }}
+  tls:
+    {{ .Values.filer.ingress.tls | default list | toYaml | nindent 6}}
+  rules:
+  - http:
+      paths:
+      - path: {{ .Values.filer.ingress.path | quote }}
+        pathType: {{ .Values.filer.ingress.pathType | quote }}
+        backend:
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion }}
+          service:
+            name: {{ $serviceName }}
+            port:
+              number: {{ .Values.filer.port }}
+{{- else }}
+          serviceName: {{ $serviceName }}
+          servicePort: {{ .Values.filer.port }}
+{{- end }}
+{{- if .Values.filer.ingress.host }}
+    host: {{ .Values.filer.ingress.host }}
+{{- end }}
+{{- end }}

--- a/platform/seaweedfs/chart/charts/seaweedfs/templates/filer/filer-service-client.yaml
+++ b/platform/seaweedfs/chart/charts/seaweedfs/templates/filer/filer-service-client.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.filer.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "seaweedfs.componentName" (list . "filer-client") }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: filer
+{{- if .Values.filer.metricsPort }}
+    monitoring: "true"
+{{- end }}
+{{- if .Values.filer.annotations }}
+  annotations:
+    {{- toYaml .Values.filer.annotations | nindent 4 }}
+{{- end }}
+spec:
+  clusterIP: None
+  ports:
+  - name: "swfs-filer"
+    port: {{ .Values.filer.port }}
+    targetPort: {{ .Values.filer.port }}
+    protocol: TCP
+  - name: "swfs-filer-grpc"
+    port: {{ .Values.filer.grpcPort }}
+    targetPort: {{ .Values.filer.grpcPort }}
+    protocol: TCP
+{{- if .Values.filer.metricsPort }}
+  - name: "metrics"
+    port: {{ .Values.filer.metricsPort }}
+    targetPort: {{ .Values.filer.metricsPort }}
+    protocol: TCP
+{{- end }}
+  selector:
+    app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: filer
+{{- end }}

--- a/platform/seaweedfs/chart/charts/seaweedfs/templates/filer/filer-service.yaml
+++ b/platform/seaweedfs/chart/charts/seaweedfs/templates/filer/filer-service.yaml
@@ -1,0 +1,53 @@
+{{- if .Values.filer.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
+  name: {{ include "seaweedfs.componentName" (list . "filer") }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: filer
+{{- if .Values.filer.annotations }}
+  annotations:
+    {{- toYaml .Values.filer.annotations | nindent 4 }}
+{{- end }}
+spec:
+  clusterIP: None
+  publishNotReadyAddresses: true
+  ports:
+  - name: "swfs-filer"
+    port: {{ .Values.filer.port }}
+    targetPort: {{ .Values.filer.port }}
+    protocol: TCP
+  - name: "swfs-filer-grpc"
+    port: {{ .Values.filer.grpcPort }}
+    targetPort: {{ .Values.filer.grpcPort }}
+    protocol: TCP
+  {{- if .Values.filer.s3.enabled }}
+  - name: "swfs-s3"
+    port: {{ .Values.filer.s3.port }}
+    targetPort: {{ .Values.filer.s3.port }}
+    protocol: TCP
+  {{- if .Values.filer.s3.httpsPort }}
+  - name: "swfs-s3-tls"
+    port: {{ .Values.filer.s3.httpsPort }}
+    targetPort: {{ .Values.filer.s3.httpsPort }}
+    protocol: TCP
+  {{- end }}
+  {{- end }}
+  {{- if .Values.filer.metricsPort }}
+  - name: "metrics"
+    port: {{ .Values.filer.metricsPort }}
+    targetPort: {{ .Values.filer.metricsPort }}
+    protocol: TCP
+  {{- end }}
+  selector:
+    app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: filer
+{{- end }}

--- a/platform/seaweedfs/chart/charts/seaweedfs/templates/filer/filer-servicemonitor.yaml
+++ b/platform/seaweedfs/chart/charts/seaweedfs/templates/filer/filer-servicemonitor.yaml
@@ -1,0 +1,35 @@
+{{- include "seaweedfs.compat" . -}}
+{{- if .Values.filer.enabled }}
+{{- if .Values.filer.metricsPort }}
+{{- if .Values.global.seaweedfs.monitoring.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "seaweedfs.fullname" . }}-filer
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: filer
+    {{- with .Values.global.seaweedfs.monitoring.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+{{- if .Values.filer.annotations }}
+  annotations:
+    {{- toYaml .Values.filer.annotations | nindent 4 }}
+{{- end }}
+spec:
+  endpoints:
+    - interval: 30s
+      port: metrics
+      scrapeTimeout: 5s
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/component: filer
+{{- end }}
+{{- end }}
+{{- end }}

--- a/platform/seaweedfs/chart/charts/seaweedfs/templates/filer/filer-statefulset.yaml
+++ b/platform/seaweedfs/chart/charts/seaweedfs/templates/filer/filer-statefulset.yaml
@@ -1,0 +1,452 @@
+{{- include "seaweedfs.compat" . -}}
+{{- if .Values.filer.enabled }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "seaweedfs.componentName" (list . "filer") }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: filer
+{{- if .Values.filer.annotations }}
+  annotations:
+    {{- toYaml .Values.filer.annotations | nindent 4 }}
+{{- end }}
+spec:
+  serviceName: {{ include "seaweedfs.componentName" (list . "filer") }}
+  podManagementPolicy: {{ .Values.filer.podManagementPolicy }}
+  replicas: {{ .Values.filer.replicas }}
+  {{- if (gt (int .Values.filer.updatePartition) 0) }}
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      partition: {{ .Values.filer.updatePartition }}
+  {{- end }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/component: filer
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
+        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/component: filer
+      {{- with .Values.podLabels }}
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.filer.podLabels }}
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+      annotations:
+      {{- with .Values.podAnnotations }}
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.filer.podAnnotations }}
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.filer.s3.existingConfigSecret }}
+        {{- $configSecret := (lookup "v1" "Secret" .Release.Namespace .Values.filer.s3.existingConfigSecret) | default dict }}
+        checksum/s3config: {{ $configSecret | toYaml | sha256sum }}
+      {{- else }}
+        checksum/s3config: {{ include (print .Template.BasePath "/s3/s3-secret.yaml") . | sha256sum }}
+      {{- end }}
+    spec:
+      restartPolicy: {{ default .Values.global.seaweedfs.restartPolicy .Values.filer.restartPolicy }}
+      {{- if .Values.filer.affinity }}
+      affinity:
+        {{ tpl .Values.filer.affinity . | nindent 8 | trim }}
+      {{- end }}
+      {{- if .Values.filer.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{ tpl .Values.filer.topologySpreadConstraints . | nindent 8 | trim }}
+      {{- end }}
+      {{- if .Values.filer.tolerations }}
+      tolerations:
+        {{ tpl .Values.filer.tolerations . | nindent 8 | trim }}
+      {{- end }}
+      {{- include "seaweedfs.imagePullSecrets" . | nindent 6 }}
+      serviceAccountName: {{ .Values.filer.serviceAccountName | default (include "seaweedfs.serviceAccountName" .) | quote }} # for deleting statefulset pods after migration
+      terminationGracePeriodSeconds: 60
+      {{- if .Values.filer.priorityClassName }}
+      priorityClassName: {{ .Values.filer.priorityClassName | quote }}
+      {{- end }}
+      enableServiceLinks: false
+      {{- if .Values.filer.initContainers }}
+      initContainers:
+        {{ tpl .Values.filer.initContainers . | nindent 8 | trim }}
+      {{- end }}
+      {{- if .Values.filer.podSecurityContext.enabled }}
+      securityContext: {{- omit .Values.filer.podSecurityContext "enabled" | toYaml | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: seaweedfs
+          image: {{ template "seaweedfs.filer.image" . }}
+          imagePullPolicy: {{ default "IfNotPresent" .Values.global.seaweedfs.imagePullPolicy }}
+          env:
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: WEED_MYSQL_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "seaweedfs.fullname" . }}-db-secret
+                  key: user
+                  optional: true
+            - name: WEED_MYSQL_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "seaweedfs.fullname" . }}-db-secret
+                  key: password
+                  optional: true
+            - name: SEAWEEDFS_FULLNAME
+              value: "{{ include "seaweedfs.fullname" . }}"
+            {{- $mergedExtraEnvironmentVars := dict }}
+            {{- include "seaweedfs.mergeExtraEnvironmentVars" (dict "global" .Values.global.seaweedfs "component" .Values.filer "target" $mergedExtraEnvironmentVars) }}
+            {{- range $key := keys $mergedExtraEnvironmentVars | sortAlpha }}
+            {{- $value := index $mergedExtraEnvironmentVars $key }}
+            - name: {{ $key }}
+            {{- if kindIs "string" $value }}
+              value: {{ tpl $value $ | quote }}
+            {{- else }}
+              valueFrom:
+                {{ toYaml $value | nindent 16 | trim }}
+            {{- end -}}
+            {{- end }}
+            {{- if .Values.filer.secretExtraEnvironmentVars }}
+            {{- range $key, $value := .Values.filer.secretExtraEnvironmentVars }}
+            - name: {{ $key }}
+              valueFrom: {{ toYaml $value | nindent 16 }}
+            {{- end }}
+            {{- end }}
+          command:
+            - "/bin/sh"
+            - "-ec"
+            - |
+              exec /usr/bin/weed \
+              {{- if or (eq .Values.filer.logs.type "hostPath") (eq .Values.filer.logs.type "persistentVolumeClaim") (eq .Values.filer.logs.type "emptyDir") }}
+              -logdir=/logs \
+              {{- else }}
+              -logtostderr=true \
+              {{- end }}
+              {{- if .Values.filer.loggingOverrideLevel }}
+              -v={{ .Values.filer.loggingOverrideLevel }} \
+              {{- else }}
+              -v={{ .Values.global.seaweedfs.loggingLevel }} \
+              {{- end }}
+              filer \
+              -port={{ .Values.filer.port }} \
+              {{- if .Values.filer.metricsPort }}
+              -metricsPort={{ .Values.filer.metricsPort }} \
+              {{- end }}
+              {{- if .Values.filer.metricsIp }}
+              -metricsIp={{ .Values.filer.metricsIp }} \
+              {{- end }}
+              {{- if .Values.filer.redirectOnRead }}
+              -redirectOnRead \
+              {{- end }}
+              {{- if .Values.filer.disableHttp }}
+              -disableHttp \
+              {{- end }}
+              {{- if .Values.filer.disableDirListing }}
+              -disableDirListing \
+              {{- end }}
+              -dirListLimit={{ .Values.filer.dirListLimit }} \
+              {{- if .Values.global.seaweedfs.enableReplication }}
+              -defaultReplicaPlacement={{ .Values.global.seaweedfs.replicationPlacement }} \
+              {{- else }}
+              -defaultReplicaPlacement={{ .Values.filer.defaultReplicaPlacement }} \
+              {{- end }}
+              {{- if .Values.filer.disableDirListing }}
+              -disableDirListing \
+              {{- end }}
+              {{- if .Values.filer.maxMB }}
+              -maxMB={{ .Values.filer.maxMB }} \
+              {{- end }}
+              {{- if .Values.filer.encryptVolumeData }}
+              -encryptVolumeData \
+              {{- end }}
+              -ip=${POD_IP} \
+              -ip.bind={{ .Values.filer.ipBind }} \
+              {{- if .Values.filer.filerGroup}}
+              -filerGroup={{ .Values.filer.filerGroup}} \
+              {{- end }}
+              {{- if .Values.filer.rack }}
+              -rack={{ .Values.filer.rack }} \
+              {{- end }}
+              {{- if .Values.filer.dataCenter }}
+              -dataCenter={{ .Values.filer.dataCenter }} \
+              {{- end }}
+              {{- if .Values.filer.s3.enabled }}
+              -s3 \
+              -s3.port={{ .Values.filer.s3.port }} \
+              {{- if .Values.filer.s3.domainName }}
+              -s3.domainName={{ .Values.filer.s3.domainName }} \
+              {{- end }}
+              {{- if .Values.global.seaweedfs.enableSecurity }}
+              {{- if .Values.filer.s3.httpsPort }}
+              -s3.port.https={{ .Values.filer.s3.httpsPort }} \
+              {{- include "seaweedfs.s3.tlsArgs" (dict "root" . "prefix" "s3.") | nindent 14 }}
+              {{- end }}
+              {{- end }}
+              {{- if .Values.filer.s3.enableAuth }}
+              -s3.config=/etc/sw/seaweedfs_s3_config \
+              {{- end }}
+              {{- if .Values.filer.s3.auditLogConfig }}
+              -s3.auditLogConfig=/etc/sw/filer_s3_auditLogConfig.json \
+              {{- end }}
+              {{- end }}
+              -master={{ include "seaweedfs.masterServerArg" . }} \
+              {{- range .Values.filer.extraArgs }}
+              {{ . }} \
+              {{- end }}
+          volumeMounts:
+            {{- if (or (eq .Values.filer.logs.type "hostPath") (eq .Values.filer.logs.type "persistentVolumeClaim") (eq .Values.filer.logs.type "emptyDir")) }}
+            - name: seaweedfs-filer-log-volume
+              mountPath: "/logs/"
+            {{- end }}
+            {{- if and .Values.filer.s3.enabled .Values.filer.s3.enableAuth }}
+            - name: config-users
+              mountPath: /etc/sw
+              readOnly: true
+            {{- end }}
+            {{- if (or .Values.filer.enablePVC (or (eq .Values.filer.data.type "hostPath") (eq .Values.filer.data.type "persistentVolumeClaim") (eq .Values.filer.data.type "emptyDir"))) }}
+            - name: data-filer
+              mountPath: /data
+            {{- end }}
+            {{- if .Values.filer.notificationConfig }}
+            - name: notification-config
+              readOnly: true
+              mountPath: /etc/seaweedfs/notification.toml
+              subPath: notification.toml
+            {{- end }}
+            {{- if .Values.global.seaweedfs.enableSecurity }}
+            - name: security-config
+              readOnly: true
+              mountPath: /etc/seaweedfs/security.toml
+              subPath: security.toml
+            - name: ca-cert
+              readOnly: true
+              mountPath: /usr/local/share/ca-certificates/ca/
+            - name: master-cert
+              readOnly: true
+              mountPath: /usr/local/share/ca-certificates/master/
+            - name: volume-cert
+              readOnly: true
+              mountPath: /usr/local/share/ca-certificates/volume/
+            - name: filer-cert
+              readOnly: true
+              mountPath: /usr/local/share/ca-certificates/filer/
+            - name: client-cert
+              readOnly: true
+              mountPath: /usr/local/share/ca-certificates/client
+            {{- if .Values.filer.s3.enabled }}
+            {{- include "seaweedfs.s3.tlsVolumeMount" . | nindent 12 }}
+            {{- end }}
+            {{- end }}
+            {{ tpl .Values.filer.extraVolumeMounts . | nindent 12 | trim }}
+          ports:
+            - containerPort: {{ .Values.filer.port }}
+              name: swfs-filer
+            - containerPort: {{ .Values.filer.metricsPort }}
+              name: metrics
+            - containerPort: {{ .Values.filer.grpcPort }}
+              #name: swfs-filer-grpc
+            {{- if .Values.filer.s3.enabled }}
+            - containerPort: {{ .Values.filer.s3.port }}
+              name: swfs-s3
+            {{- if .Values.filer.s3.httpsPort }}
+            - containerPort: {{ .Values.filer.s3.httpsPort }}
+              name: swfs-s3-tls
+            {{- end }}
+            {{- end }}
+          {{- $isJwtEnabled := or .Values.global.seaweedfs.securityConfig.jwtSigning.filerWrite .Values.global.seaweedfs.securityConfig.jwtSigning.filerRead }}
+          {{- if .Values.filer.readinessProbe.enabled }}
+          readinessProbe:
+          {{- if or $isJwtEnabled .Values.filer.readinessProbe.tcpSocket }}
+            tcpSocket:
+              port: {{ if $isJwtEnabled }}{{ .Values.filer.port }}{{ else }}{{ .Values.filer.readinessProbe.tcpSocket.port }}{{ end }}
+          {{- else }}
+            httpGet:
+              path: {{ .Values.filer.readinessProbe.httpGet.path }}
+              port: {{ .Values.filer.port }}
+              scheme: {{ .Values.filer.readinessProbe.httpGet.scheme }}
+          {{- end }}
+            initialDelaySeconds: {{ .Values.filer.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.filer.readinessProbe.periodSeconds }}
+            successThreshold: {{ .Values.filer.readinessProbe.successThreshold }}
+            failureThreshold: {{ .Values.filer.readinessProbe.failureThreshold }}
+            timeoutSeconds: {{ .Values.filer.readinessProbe.timeoutSeconds }}
+          {{- end }}
+          {{- if .Values.filer.livenessProbe.enabled }}
+          livenessProbe:
+          {{- if or $isJwtEnabled .Values.filer.livenessProbe.tcpSocket }}
+            tcpSocket:
+              port: {{ if $isJwtEnabled }}{{ .Values.filer.port }}{{ else }}{{ .Values.filer.livenessProbe.tcpSocket.port }}{{ end }}
+          {{- else }}
+            httpGet:
+              path: {{ .Values.filer.livenessProbe.httpGet.path }}
+              port: {{ .Values.filer.port }}
+              scheme: {{ .Values.filer.livenessProbe.httpGet.scheme }}
+          {{- end }}
+            initialDelaySeconds: {{ .Values.filer.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.filer.livenessProbe.periodSeconds }}
+            successThreshold: {{ .Values.filer.livenessProbe.successThreshold }}
+            failureThreshold: {{ .Values.filer.livenessProbe.failureThreshold }}
+            timeoutSeconds: {{ .Values.filer.livenessProbe.timeoutSeconds }}
+          {{- end }}
+          {{- with .Values.filer.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- if .Values.filer.containerSecurityContext.enabled }}
+          securityContext: {{- omit .Values.filer.containerSecurityContext "enabled" | toYaml | nindent 12 }}
+          {{- end }}
+        {{- if .Values.filer.sidecars }}
+        {{- include "seaweedfs.tplvalues.render" (dict "value" .Values.filer.sidecars "context" $) | nindent 8 }}
+        {{- end }}
+      volumes:
+        {{- if eq .Values.filer.logs.type "hostPath" }}
+        - name: seaweedfs-filer-log-volume
+          hostPath:
+            path: {{ .Values.filer.logs.hostPathPrefix }}/logs/seaweedfs/filer
+            type: DirectoryOrCreate
+        {{- end }}
+        {{- if eq .Values.filer.logs.type "existingClaim" }}
+        - name: seaweedfs-filer-log-volume
+          persistentVolumeClaim:
+            claimName: {{ .Values.filer.logs.claimName }}
+        {{- end }}
+        {{- if eq .Values.filer.logs.type "emptyDir" }}
+        - name: seaweedfs-filer-log-volume
+          emptyDir: {}
+        {{- end }}
+        {{- if eq .Values.filer.data.type "hostPath" }}
+        - name: data-filer
+          hostPath:
+            path: {{ .Values.filer.data.hostPathPrefix }}/filer_store
+            type: DirectoryOrCreate
+        {{- end }}
+        {{- if eq .Values.filer.data.type "existingClaim" }}
+        - name: data-filer
+          persistentVolumeClaim:
+            claimName: {{ .Values.filer.data.claimName }}
+        {{- end }}
+        {{- if eq .Values.filer.data.type "emptyDir" }}
+        - name: data-filer
+          emptyDir: {}
+        {{- end }}
+        - name: db-schema-config-volume
+          configMap:
+            name: {{ default (printf "%s-db-init-config" (include "seaweedfs.fullname" .)) .Values.filer.dbInitConfigName }}
+        {{- if and .Values.filer.s3.enabled .Values.filer.s3.enableAuth }}
+        - name: config-users
+          secret:
+            defaultMode: 420
+            {{- if .Values.filer.s3.existingConfigSecret }}
+            secretName: {{ .Values.filer.s3.existingConfigSecret }}
+            {{- else }}
+            secretName: {{ include "seaweedfs.fullname" . }}-s3-secret
+            {{- end }}
+        {{- end }}
+        {{- if .Values.filer.notificationConfig }}
+        - name: notification-config
+          configMap:
+            name: {{ include "seaweedfs.fullname" . }}-notification-config
+        {{- end }}
+        {{- if .Values.global.seaweedfs.enableSecurity }}
+        - name: security-config
+          configMap:
+            name: {{ include "seaweedfs.fullname" . }}-security-config
+        - name: ca-cert
+          secret:
+            secretName: {{ include "seaweedfs.fullname" . }}-ca-cert
+        - name: master-cert
+          secret:
+            secretName: {{ include "seaweedfs.fullname" . }}-master-cert
+        - name: volume-cert
+          secret:
+            secretName: {{ include "seaweedfs.fullname" . }}-volume-cert
+        - name: filer-cert
+          secret:
+            secretName: {{ include "seaweedfs.fullname" . }}-filer-cert
+        - name: client-cert
+          secret:
+            secretName: {{ include "seaweedfs.fullname" . }}-client-cert
+        {{- if .Values.filer.s3.enabled }}
+        {{- include "seaweedfs.s3.tlsVolume" . | nindent 8 }}
+        {{- end }}
+        {{- end }}
+        {{ tpl .Values.filer.extraVolumes . | indent 8 | trim }}
+      {{- if .Values.filer.nodeSelector }}
+      nodeSelector:
+        {{ tpl .Values.filer.nodeSelector . | indent 8 | trim }}
+      {{- end }}
+  {{- if and (.Values.filer.enablePVC) (not .Values.filer.data) }}
+  # DEPRECATION: Deprecate in favor of filer.data section below
+  volumeClaimTemplates:
+  - apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
+      name: data-filer
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: {{ .Values.filer.storage }}
+      {{- if .Values.filer.storageClass }}
+      storageClassName: {{ .Values.filer.storageClass }}
+      {{- end }}
+  {{- end }}
+  {{- $pvc_exists := include "seaweedfs.filer.pvc_exists" . -}}
+  {{- if $pvc_exists }}
+  volumeClaimTemplates:
+    {{- if eq .Values.filer.data.type "persistentVolumeClaim" }}
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
+        name: data-filer
+        {{- with .Values.filer.data.annotations }}
+        annotations:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+      spec:
+        accessModes: [ "ReadWriteOnce" ]
+        storageClassName: {{ .Values.filer.data.storageClass }}
+        resources:
+          requests:
+            storage: {{ .Values.filer.data.size }}
+    {{- end }}
+    {{- if eq .Values.filer.logs.type "persistentVolumeClaim" }}
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
+        name: seaweedfs-filer-log-volume
+        {{- with .Values.filer.logs.annotations }}
+        annotations:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+      spec:
+        accessModes: [ "ReadWriteOnce" ]
+        storageClassName: {{ .Values.filer.logs.storageClass }}
+        resources:
+          requests:
+            storage: {{ .Values.filer.logs.size }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/platform/seaweedfs/chart/charts/seaweedfs/templates/master/master-configmap.yaml
+++ b/platform/seaweedfs/chart/charts/seaweedfs/templates/master/master-configmap.yaml
@@ -1,0 +1,19 @@
+{{- if or .Values.master.enabled .Values.allInOne.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "seaweedfs.fullname" . }}-master-config
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+{{- if .Values.master.annotations }}
+  annotations:
+    {{- toYaml .Values.master.annotations | nindent 4 }}
+{{- end }}
+data:
+  master.toml: |-
+    {{ .Values.master.config | nindent 4 }}
+{{- end }}

--- a/platform/seaweedfs/chart/charts/seaweedfs/templates/master/master-ingress.yaml
+++ b/platform/seaweedfs/chart/charts/seaweedfs/templates/master/master-ingress.yaml
@@ -1,0 +1,48 @@
+{{- if .Values.master.enabled }}
+{{- if .Values.master.ingress.enabled }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion }}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion }}
+apiVersion: networking.k8s.io/v1beta1
+{{- else }}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: ingress-{{ include "seaweedfs.fullname" . }}-master
+  namespace: {{ .Release.Namespace }}
+  {{- with .Values.master.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: master
+spec:
+  ingressClassName: {{ .Values.master.ingress.className | quote }}
+  tls:
+    {{ .Values.master.ingress.tls | default list | toYaml | nindent 6 }}
+  rules:
+    - http:
+        paths:
+          - path: {{ .Values.master.ingress.path | quote }}
+            pathType: {{ .Values.master.ingress.pathType | quote }}
+            backend:
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ include "seaweedfs.componentName" (list . "master") }}
+                port:
+                  number: {{ .Values.master.port }}
+                  #name:
+{{- else }}
+              serviceName: {{ include "seaweedfs.componentName" (list . "master") }}
+              servicePort: {{ .Values.master.port }}
+{{- end }}
+{{- if .Values.master.ingress.host }}
+      host: {{ .Values.master.ingress.host }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/platform/seaweedfs/chart/charts/seaweedfs/templates/master/master-service.yaml
+++ b/platform/seaweedfs/chart/charts/seaweedfs/templates/master/master-service.yaml
@@ -1,0 +1,40 @@
+{{- if .Values.master.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "seaweedfs.componentName" (list . "master") }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
+    app.kubernetes.io/component: master
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  annotations:
+    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
+{{- if .Values.master.annotations }}
+    {{- toYaml .Values.master.annotations | nindent 4 }}
+{{- end }}
+spec:
+  clusterIP: None
+  publishNotReadyAddresses: true
+  ports:
+  - name: "swfs-master"
+    port: {{ .Values.master.port }}
+    targetPort: {{ .Values.master.port }}
+    protocol: TCP
+  - name: "swfs-master-grpc"
+    port: {{ .Values.master.grpcPort }}
+    targetPort: {{ .Values.master.grpcPort }}
+    protocol: TCP
+  {{- if .Values.master.metricsPort }}
+  - name: "metrics"
+    port: {{ .Values.master.metricsPort }}
+    targetPort: {{ .Values.master.metricsPort }}
+    protocol: TCP
+  {{- end }}
+  selector:
+    app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: master
+{{- end }}

--- a/platform/seaweedfs/chart/charts/seaweedfs/templates/master/master-servicemonitor.yaml
+++ b/platform/seaweedfs/chart/charts/seaweedfs/templates/master/master-servicemonitor.yaml
@@ -1,0 +1,35 @@
+{{- include "seaweedfs.compat" . -}}
+{{- if .Values.master.enabled }}
+{{- if .Values.master.metricsPort }}
+{{- if .Values.global.seaweedfs.monitoring.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "seaweedfs.fullname" . }}-master
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: master
+    {{- with .Values.global.seaweedfs.monitoring.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+{{- if .Values.master.annotations }}
+  annotations:
+    {{- toYaml .Values.master.annotations | nindent 4 }}
+{{- end }}
+spec:
+  endpoints:
+    - interval: 30s
+      port: metrics
+      scrapeTimeout: 5s
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/component: master
+{{- end }}
+{{- end }}
+{{- end }}

--- a/platform/seaweedfs/chart/charts/seaweedfs/templates/master/master-statefulset.yaml
+++ b/platform/seaweedfs/chart/charts/seaweedfs/templates/master/master-statefulset.yaml
@@ -1,0 +1,351 @@
+{{- include "seaweedfs.compat" . -}}
+{{- if .Values.master.enabled }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "seaweedfs.componentName" (list . "master") }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: master
+{{- if .Values.master.annotations }}
+  annotations:
+    {{- toYaml .Values.master.annotations | nindent 4 }}
+{{- end }}
+spec:
+  serviceName: {{ include "seaweedfs.componentName" (list . "master") }}
+  podManagementPolicy: {{ .Values.master.podManagementPolicy }}
+  replicas: {{ .Values.master.replicas }}
+  {{- if (gt (int .Values.master.updatePartition) 0) }}
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      partition: {{ .Values.master.updatePartition }}
+  {{- end }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/component: master
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
+        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/component: master
+      {{ with .Values.podLabels }}
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.master.podLabels }}
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+      annotations:
+      {{ with .Values.podAnnotations }}
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.master.podAnnotations }}
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      restartPolicy: {{ default .Values.global.seaweedfs.restartPolicy .Values.master.restartPolicy }}
+      {{- if .Values.master.affinity }}
+      affinity:
+        {{ tpl .Values.master.affinity . | nindent 8 | trim }}
+      {{- end }}
+      {{- if .Values.master.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{ tpl .Values.master.topologySpreadConstraints . | nindent 8 | trim }}
+      {{- end }}
+      {{- if .Values.master.tolerations }}
+      tolerations:
+        {{ tpl .Values.master.tolerations . | nindent 8 | trim }}
+      {{- end }}
+      {{- include "seaweedfs.imagePullSecrets" . | nindent 6 }}
+      terminationGracePeriodSeconds: 60
+      {{- if .Values.master.priorityClassName }}
+      priorityClassName: {{ .Values.master.priorityClassName | quote }}
+      {{- end }}
+      enableServiceLinks: false
+      serviceAccountName: {{ .Values.master.serviceAccountName | default (include "seaweedfs.serviceAccountName" .) | quote }} # for deleting statefulset pods after migration
+      {{- if .Values.master.initContainers }}
+      initContainers:
+        {{ tpl .Values.master.initContainers . | nindent 8 | trim }}
+      {{- end }}
+      {{- if .Values.master.podSecurityContext.enabled }}
+      securityContext: {{- omit .Values.master.podSecurityContext "enabled" | toYaml | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: seaweedfs
+          image: {{ template "seaweedfs.master.image" . }}
+          imagePullPolicy: {{ default "IfNotPresent" .Values.global.seaweedfs.imagePullPolicy }}
+          env:
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: SEAWEEDFS_FULLNAME
+              value: "{{ include "seaweedfs.fullname" . }}"
+            {{- $mergedExtraEnvironmentVars := dict }}
+            {{- include "seaweedfs.mergeExtraEnvironmentVars" (dict "global" .Values.global.seaweedfs "component" .Values.master "target" $mergedExtraEnvironmentVars) }}
+            {{- range $key := keys $mergedExtraEnvironmentVars | sortAlpha }}
+            {{- $value := index $mergedExtraEnvironmentVars $key }}
+            - name: {{ $key }}
+            {{- if kindIs "string" $value }}
+              value: {{ tpl $value $ | quote }}
+            {{- else }}
+              valueFrom:
+                {{ toYaml $value | nindent 16 | trim }}
+            {{- end -}}
+            {{- end }}
+          command:
+            - "/bin/sh"
+            - "-ec"
+            - |
+              exec /usr/bin/weed \
+              {{- if or (eq .Values.master.logs.type "hostPath") (eq .Values.master.logs.type "persistentVolumeClaim") (eq .Values.master.logs.type "emptyDir") }}
+              -logdir=/logs \
+              {{- else }}
+              -logtostderr=true \
+              {{- end }}
+              {{- if .Values.master.loggingOverrideLevel }}
+              -v={{ .Values.master.loggingOverrideLevel }} \
+              {{- else }}
+              -v={{ .Values.global.seaweedfs.loggingLevel }} \
+              {{- end }}
+              master \
+              -port={{ .Values.master.port }} \
+              -mdir=/data \
+              -ip.bind={{ .Values.master.ipBind }} \
+              {{- if .Values.global.seaweedfs.enableReplication }}
+              -defaultReplication={{ .Values.global.seaweedfs.replicationPlacement }} \
+              {{- else }}
+              -defaultReplication={{ .Values.master.defaultReplication }} \
+              {{- end }}
+              {{- if .Values.master.volumePreallocate }}
+              -volumePreallocate \
+              {{- end }}
+              {{- if .Values.global.seaweedfs.monitoring.enabled }}
+              {{- if and .Values.global.seaweedfs.monitoring.gatewayHost .Values.global.seaweedfs.monitoring.gatewayPort }}
+              -metrics.address="{{ .Values.global.seaweedfs.monitoring.gatewayHost }}:{{ .Values.global.seaweedfs.monitoring.gatewayPort }}" \
+              {{- if .Values.master.metricsIntervalSec }}
+              -metrics.intervalSeconds={{ .Values.master.metricsIntervalSec }} \
+              {{- end }}
+              {{- end }}
+              {{- end }}
+              {{- if .Values.master.metricsPort }}
+              -metricsPort={{ .Values.master.metricsPort }} \
+              {{- end }}
+              {{- if .Values.master.metricsIp }}
+              -metricsIp={{ .Values.master.metricsIp }} \
+              {{- end }}
+              -volumeSizeLimitMB={{ .Values.master.volumeSizeLimitMB }} \
+              {{- if .Values.master.disableHttp }}
+              -disableHttp \
+              {{- end }}
+              {{- if .Values.master.resumeState }}
+              -resumeState \
+              {{- end }}
+              {{- if .Values.master.raftHashicorp }}
+              -raftHashicorp \
+              {{- end }}
+              {{- if .Values.master.raftBootstrap }}
+              -raftBootstrap \
+              {{- end }}
+              {{- if .Values.master.electionTimeout }}
+              -electionTimeout={{ .Values.master.electionTimeout }} \
+              {{- end }}
+              {{- if .Values.master.heartbeatInterval }}
+              -heartbeatInterval={{ .Values.master.heartbeatInterval }} \
+              {{- end }}
+              {{- if .Values.master.garbageThreshold }}
+              -garbageThreshold={{ .Values.master.garbageThreshold }} \
+              {{- end }}
+              -ip=${POD_NAME}.{{ include "seaweedfs.componentName" (list . "master") }}.{{ .Release.Namespace }} \
+              -peers={{ include "seaweedfs.masterServers" . }} \
+              {{- range .Values.master.extraArgs }}
+              {{ . }} \
+              {{- end }}
+          volumeMounts:
+            - name : data-{{ .Release.Namespace }}
+              mountPath: /data
+            {{- if or (eq .Values.master.logs.type "hostPath") (eq .Values.master.logs.type "persistentVolumeClaim") (eq .Values.master.logs.type "emptyDir") }}
+            - name: seaweedfs-master-log-volume
+              mountPath: "/logs/"
+            {{- end }}
+            - name: master-config
+              readOnly: true
+              mountPath: /etc/seaweedfs/master.toml
+              subPath: master.toml
+            {{- if .Values.global.seaweedfs.enableSecurity }}
+            - name: security-config
+              readOnly: true
+              mountPath: /etc/seaweedfs/security.toml
+              subPath: security.toml
+            - name: ca-cert
+              readOnly: true
+              mountPath: /usr/local/share/ca-certificates/ca/
+            - name: master-cert
+              readOnly: true
+              mountPath: /usr/local/share/ca-certificates/master/
+            - name: volume-cert
+              readOnly: true
+              mountPath: /usr/local/share/ca-certificates/volume/
+            - name: filer-cert
+              readOnly: true
+              mountPath: /usr/local/share/ca-certificates/filer/
+            - name: client-cert
+              readOnly: true
+              mountPath: /usr/local/share/ca-certificates/client/
+            {{- end }}
+            {{ tpl .Values.master.extraVolumeMounts . | nindent 12 | trim }}
+          ports:
+            - containerPort: {{ .Values.master.port }}
+              name: swfs-master
+            {{- if and .Values.global.seaweedfs.monitoring.enabled .Values.master.metricsPort }}
+            - containerPort: {{ .Values.master.metricsPort }}
+              name: metrics
+            {{- end }}
+            - containerPort: {{ .Values.master.grpcPort }}
+              #name: swfs-master-grpc
+          {{- if .Values.master.readinessProbe.enabled }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.master.readinessProbe.httpGet.path }}
+              port: {{ .Values.master.port }}
+              scheme: {{ .Values.master.readinessProbe.httpGet.scheme }}
+            initialDelaySeconds: {{ .Values.master.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.master.readinessProbe.periodSeconds }}
+            successThreshold: {{ .Values.master.readinessProbe.successThreshold }}
+            failureThreshold: {{ .Values.master.readinessProbe.failureThreshold }}
+            timeoutSeconds: {{ .Values.master.readinessProbe.timeoutSeconds }}
+          {{- end }}
+          {{- if .Values.master.livenessProbe.enabled }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.master.livenessProbe.httpGet.path }}
+              port: {{ .Values.master.port }}
+              scheme: {{ .Values.master.livenessProbe.httpGet.scheme }}
+            initialDelaySeconds: {{ .Values.master.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.master.livenessProbe.periodSeconds }}
+            successThreshold: {{ .Values.master.livenessProbe.successThreshold }}
+            failureThreshold: {{ .Values.master.livenessProbe.failureThreshold }}
+            timeoutSeconds: {{ .Values.master.livenessProbe.timeoutSeconds }}
+          {{- end }}
+          {{- with .Values.master.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- if .Values.master.containerSecurityContext.enabled }}
+          securityContext: {{- omit .Values.master.containerSecurityContext "enabled" | toYaml | nindent 12 }}
+          {{- end }}
+        {{- if .Values.master.sidecars }}
+        {{- include "seaweedfs.tplvalues.render" (dict "value" .Values.master.sidecars "context" $) | nindent 8 }}
+        {{- end }}
+      volumes:
+        {{- if eq .Values.master.logs.type "hostPath" }}
+        - name: seaweedfs-master-log-volume
+          hostPath:
+            path: {{ .Values.master.logs.hostPathPrefix }}/logs/seaweedfs/master
+            type: DirectoryOrCreate
+        {{- end }}
+        {{- if eq .Values.master.logs.type "existingClaim" }}
+        - name: seaweedfs-master-log-volume
+          persistentVolumeClaim:
+            claimName: {{ .Values.master.logs.claimName }}
+        {{- end }}
+        {{- if eq .Values.master.logs.type "emptyDir" }}
+        - name: seaweedfs-master-log-volume
+          emptyDir: {}
+        {{- end }}
+        {{- if eq .Values.master.data.type "hostPath" }}
+        - name: data-{{ .Release.Namespace }}
+          hostPath:
+            path: {{ .Values.master.data.hostPathPrefix }}/seaweed-master/
+            type: DirectoryOrCreate
+        {{- end }}
+        {{- if eq .Values.master.data.type "existingClaim" }}
+        - name: data-{{ .Release.Namespace }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.master.data.claimName }}
+        {{- end }}
+        {{- if eq .Values.master.data.type "emptyDir" }}
+        - name: data-{{ .Release.Namespace }}
+          emptyDir: {}
+        {{- end }}
+        - name: master-config
+          configMap:
+            name: {{ include "seaweedfs.fullname" . }}-master-config
+        {{- if .Values.global.seaweedfs.enableSecurity }}
+        - name: security-config
+          configMap:
+            name: {{ include "seaweedfs.fullname" . }}-security-config
+        - name: ca-cert
+          secret:
+            secretName: {{ include "seaweedfs.fullname" . }}-ca-cert
+        - name: master-cert
+          secret:
+            secretName: {{ include "seaweedfs.fullname" . }}-master-cert
+        - name: volume-cert
+          secret:
+            secretName: {{ include "seaweedfs.fullname" . }}-volume-cert
+        - name: filer-cert
+          secret:
+            secretName: {{ include "seaweedfs.fullname" . }}-filer-cert
+        - name: client-cert
+          secret:
+            secretName: {{ include "seaweedfs.fullname" . }}-client-cert
+        {{- end }}
+        {{ tpl .Values.master.extraVolumes . | indent 8 | trim }}
+      {{- if .Values.master.nodeSelector }}
+      nodeSelector:
+        {{ tpl .Values.master.nodeSelector . | indent 8 | trim }}
+      {{- end }}
+  {{- $pvc_exists := include "seaweedfs.master.pvc_exists" . -}}
+  {{- if $pvc_exists }}
+  volumeClaimTemplates:
+    {{- if eq .Values.master.data.type "persistentVolumeClaim"}}
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
+        name: data-{{ .Release.Namespace }}
+        {{- with .Values.master.data.annotations }}
+        annotations:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+      spec:
+        accessModes: [ "ReadWriteOnce" ]
+        storageClassName: {{ .Values.master.data.storageClass }}
+        resources:
+          requests:
+            storage: {{ .Values.master.data.size }}
+    {{- end }}
+    {{- if eq .Values.master.logs.type "persistentVolumeClaim"}}
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
+        name: seaweedfs-master-log-volume
+        {{- with .Values.master.logs.annotations }}
+        annotations:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+      spec:
+        accessModes: [ "ReadWriteOnce" ]
+        storageClassName: {{ .Values.master.logs.storageClass }}
+        resources:
+          requests:
+            storage: {{ .Values.master.logs.size }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/platform/seaweedfs/chart/charts/seaweedfs/templates/s3/s3-deployment.yaml
+++ b/platform/seaweedfs/chart/charts/seaweedfs/templates/s3/s3-deployment.yaml
@@ -1,0 +1,278 @@
+{{- include "seaweedfs.compat" . -}}
+{{- if .Values.s3.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "seaweedfs.fullname" . }}-s3
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: s3
+{{- if .Values.s3.annotations }}
+  annotations:
+    {{- toYaml .Values.s3.annotations | nindent 4 }}
+{{- end }}
+spec:
+  replicas: {{ .Values.s3.replicas }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/component: s3
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
+        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/component: s3
+      {{ with .Values.podLabels }}
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.s3.podLabels }}
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+      annotations:
+      {{ with .Values.podAnnotations }}
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.s3.podAnnotations }}
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      restartPolicy: {{ default .Values.global.seaweedfs.restartPolicy .Values.s3.restartPolicy }}
+      {{- if .Values.s3.affinity }}
+      affinity:
+        {{ tpl .Values.s3.affinity . | nindent 8 | trim }}
+      {{- end }}
+      {{- if .Values.s3.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{ tpl .Values.s3.topologySpreadConstraints . | nindent 8 | trim }}
+      {{- end }}
+      {{- if .Values.s3.tolerations }}
+      tolerations:
+        {{ tpl .Values.s3.tolerations . | nindent 8 | trim }}
+      {{- end }}
+      {{- include "seaweedfs.imagePullSecrets" . | nindent 6 }}
+      terminationGracePeriodSeconds: 10
+      {{- if .Values.s3.priorityClassName }}
+      priorityClassName: {{ .Values.s3.priorityClassName | quote }}
+      {{- end }}
+      enableServiceLinks: false
+      {{- if .Values.s3.serviceAccountName }}
+      serviceAccountName: {{ .Values.s3.serviceAccountName | quote }}
+      {{- end }}
+      {{- if .Values.s3.initContainers }}
+      initContainers:
+        {{ tpl .Values.s3.initContainers . | nindent 8 | trim }}
+      {{- end }}
+      {{- if .Values.s3.podSecurityContext.enabled }}
+      securityContext: {{- omit .Values.s3.podSecurityContext "enabled" | toYaml | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: seaweedfs
+          image: {{ template "seaweedfs.s3.image" . }}
+          imagePullPolicy: {{ default "IfNotPresent" .Values.global.seaweedfs.imagePullPolicy }}
+          env:
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: SEAWEEDFS_FULLNAME
+              value: "{{ include "seaweedfs.fullname" . }}"
+            {{- $mergedExtraEnvironmentVars := dict }}
+            {{- include "seaweedfs.mergeExtraEnvironmentVars" (dict "global" .Values.global.seaweedfs "component" .Values.s3 "target" $mergedExtraEnvironmentVars) }}
+            {{- range $key := keys $mergedExtraEnvironmentVars | sortAlpha }}
+            {{- $value := index $mergedExtraEnvironmentVars $key }}
+            - name: {{ $key }}
+            {{- if kindIs "string" $value }}
+              value: {{ tpl $value $ | quote }}
+            {{- else }}
+              valueFrom:
+                {{ toYaml $value | nindent 16 | trim }}
+            {{- end -}}
+            {{- end }}
+          command:
+            - "/bin/sh"
+            - "-ec"
+            - |
+              exec /usr/bin/weed \
+              {{- if or (eq .Values.s3.logs.type "hostPath") (eq .Values.s3.logs.type "emptyDir") }}
+              -logdir=/logs \
+              {{- else }}
+              -logtostderr=true \
+              {{- end }}
+              {{- if .Values.s3.loggingOverrideLevel }}
+              -v={{ .Values.s3.loggingOverrideLevel }} \
+              {{- else }}
+              -v={{ .Values.global.seaweedfs.loggingLevel }} \
+              {{- end }}
+              s3 \
+              -ip.bind={{ .Values.s3.bindAddress }} \
+              -port={{ .Values.s3.port }} \
+              {{- if .Values.s3.metricsPort }}
+              -metricsPort {{ .Values.s3.metricsPort }} \
+              {{- end }}
+              {{- if .Values.global.seaweedfs.enableSecurity }}
+              {{- if .Values.s3.httpsPort }}
+              -port.https={{ .Values.s3.httpsPort }} \
+              {{- include "seaweedfs.s3.tlsArgs" (dict "root" . "prefix" "") | nindent 14 }}
+              {{- end }}
+              {{- end }}
+              {{- if .Values.s3.domainName }}
+              -domainName={{ .Values.s3.domainName }} \
+              {{- end }}
+              {{- if .Values.s3.enableAuth }}
+              -config=/etc/sw/seaweedfs_s3_config \
+              {{- end }}
+              {{- if .Values.s3.auditLogConfig }}
+              -auditLogConfig=/etc/sw/s3_auditLogConfig.json \
+              {{- end }}
+              -filer={{ include "seaweedfs.componentName" (list . "filer-client") }}.{{ .Release.Namespace }}:{{ .Values.filer.port }} \
+              {{- if .Values.s3.icebergPort }}
+              -port.iceberg={{ .Values.s3.icebergPort }} \
+              {{- end }}
+              {{- range .Values.s3.extraArgs }}
+              {{ . }} \
+              {{- end }}
+          volumeMounts:
+            {{- if or (eq .Values.s3.logs.type "hostPath") (eq .Values.s3.logs.type "emptyDir") }}
+            - name: logs
+              mountPath: "/logs/"
+            {{- end }}
+            {{- if .Values.s3.enableAuth }}
+            - mountPath: /etc/sw
+              name: config-users
+              readOnly: true
+            {{- end }}
+            {{- if .Values.global.seaweedfs.enableSecurity }}
+            - name: security-config
+              readOnly: true
+              mountPath: /etc/seaweedfs/security.toml
+              subPath: security.toml
+            - name: ca-cert
+              readOnly: true
+              mountPath: /usr/local/share/ca-certificates/ca/
+            - name: master-cert
+              readOnly: true
+              mountPath: /usr/local/share/ca-certificates/master/
+            - name: volume-cert
+              readOnly: true
+              mountPath: /usr/local/share/ca-certificates/volume/
+            - name: filer-cert
+              readOnly: true
+              mountPath: /usr/local/share/ca-certificates/filer/
+            - name: client-cert
+              readOnly: true
+              mountPath: /usr/local/share/ca-certificates/client/
+            {{- include "seaweedfs.s3.tlsVolumeMount" . | nindent 12 }}
+            {{- end }}
+            {{ tpl .Values.s3.extraVolumeMounts . | nindent 12 | trim }}
+          ports:
+            - containerPort: {{ .Values.s3.port }}
+              name: swfs-s3
+            {{- if .Values.s3.httpsPort }}
+            - containerPort: {{ .Values.s3.httpsPort }}
+              name: swfs-s3-tls
+            {{- end }}
+            {{- if .Values.s3.icebergPort }}
+            - containerPort: {{ .Values.s3.icebergPort }}
+              name: swfs-iceberg
+            {{- end }}
+            {{- if .Values.s3.metricsPort }}
+            - containerPort: {{ .Values.s3.metricsPort }}
+              name: metrics
+            {{- end }}
+          {{- if .Values.s3.readinessProbe.enabled }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.s3.readinessProbe.httpGet.path }}
+              port: {{ .Values.s3.port }}
+              scheme: {{ .Values.s3.readinessProbe.httpGet.scheme }}
+            initialDelaySeconds: {{ .Values.s3.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.s3.readinessProbe.periodSeconds }}
+            successThreshold: {{ .Values.s3.readinessProbe.successThreshold }}
+            failureThreshold: {{ .Values.s3.readinessProbe.failureThreshold }}
+            timeoutSeconds: {{ .Values.s3.readinessProbe.timeoutSeconds }}
+          {{- end }}
+          {{- if .Values.s3.livenessProbe.enabled }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.s3.livenessProbe.httpGet.path }}
+              port: {{ .Values.s3.port }}
+              scheme: {{ .Values.s3.livenessProbe.httpGet.scheme }}
+            initialDelaySeconds: {{ .Values.s3.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.s3.livenessProbe.periodSeconds }}
+            successThreshold: {{ .Values.s3.livenessProbe.successThreshold }}
+            failureThreshold: {{ .Values.s3.livenessProbe.failureThreshold }}
+            timeoutSeconds: {{ .Values.s3.livenessProbe.timeoutSeconds }}
+          {{- end }}
+          {{- with .Values.s3.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- if .Values.s3.containerSecurityContext.enabled }}
+          securityContext: {{- omit .Values.s3.containerSecurityContext "enabled" | toYaml | nindent 12 }}
+          {{- end }}
+      {{- if .Values.s3.sidecars }}
+      {{- include "seaweedfs.tplvalues.render" (dict "value" .Values.s3.sidecars "context" $) | nindent 8 }}
+      {{- end }}
+      volumes:
+        {{- if .Values.s3.enableAuth }}
+        - name: config-users
+          secret:
+            defaultMode: 420
+            {{- if .Values.s3.existingConfigSecret }}
+            secretName: {{ .Values.s3.existingConfigSecret }}
+            {{- else }}
+            secretName: {{ include "seaweedfs.fullname" . }}-s3-secret
+            {{- end }}
+        {{- end }}
+        {{- if eq .Values.s3.logs.type "hostPath" }}
+        - name: logs
+          hostPath:
+            path: {{ .Values.s3.logs.hostPathPrefix }}/logs/seaweedfs/s3
+            type: DirectoryOrCreate
+        {{- end }}
+        {{- if eq .Values.s3.logs.type "emptyDir" }}
+        - name: logs
+          emptyDir: {}
+        {{- end }}
+        {{- if .Values.global.seaweedfs.enableSecurity }}
+        - name: security-config
+          configMap:
+            name: {{ include "seaweedfs.fullname" . }}-security-config
+        - name: ca-cert
+          secret:
+            secretName: {{ include "seaweedfs.fullname" . }}-ca-cert
+        - name: master-cert
+          secret:
+            secretName: {{ include "seaweedfs.fullname" . }}-master-cert
+        - name: volume-cert
+          secret:
+            secretName: {{ include "seaweedfs.fullname" . }}-volume-cert
+        - name: filer-cert
+          secret:
+            secretName: {{ include "seaweedfs.fullname" . }}-filer-cert
+        - name: client-cert
+          secret:
+            secretName: {{ include "seaweedfs.fullname" . }}-client-cert
+        {{- include "seaweedfs.s3.tlsVolume" . | nindent 8 }}
+        {{- end }}
+        {{ tpl .Values.s3.extraVolumes . | indent 8 | trim }}
+      {{- if .Values.s3.nodeSelector }}
+      nodeSelector:
+        {{ tpl .Values.s3.nodeSelector . | indent 8 | trim }}
+      {{- end }}
+{{- end }}

--- a/platform/seaweedfs/chart/charts/seaweedfs/templates/s3/s3-iceberg-ingress.yaml
+++ b/platform/seaweedfs/chart/charts/seaweedfs/templates/s3/s3-iceberg-ingress.yaml
@@ -1,0 +1,61 @@
+{{- define "seaweedfs.s3.iceberg.ingress.paths" -}}
+paths:
+- path: {{ .Values.s3.icebergIngress.path | quote }}
+  pathType: {{ .Values.s3.icebergIngress.pathType | quote }}
+  backend:
+    {{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion }}
+    service:
+      name: {{ include "seaweedfs.componentName" (list . "s3") }}
+      port:
+        number: {{ .Values.s3.icebergPort }}
+    {{- else }}
+    serviceName: {{ include "seaweedfs.componentName" (list . "s3") }}
+    servicePort: {{ .Values.s3.icebergPort }}
+    {{- end }}
+{{- end -}}
+{{- if and .Values.s3.enabled .Values.s3.icebergPort .Values.s3.icebergIngress.enabled }}
+{{- $hosts := list }}
+{{- if kindIs "slice" .Values.s3.icebergIngress.host }}
+  {{- $hosts = .Values.s3.icebergIngress.host }}
+{{- else if .Values.s3.icebergIngress.host }}
+  {{- $hosts = list .Values.s3.icebergIngress.host }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion }}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion }}
+apiVersion: networking.k8s.io/v1beta1
+{{- else }}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: ingress-{{ include "seaweedfs.fullname" . }}-s3-iceberg
+  namespace: {{ .Release.Namespace }}
+  {{- with .Values.s3.icebergIngress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: s3-iceberg
+spec:
+  {{- if .Values.s3.icebergIngress.className }}
+  ingressClassName: {{ .Values.s3.icebergIngress.className | quote }}
+  {{- end }}
+  tls:
+    {{ .Values.s3.icebergIngress.tls | default list | toYaml | nindent 6}}
+  rules:
+{{- if $hosts }}
+{{- range $host := $hosts }}
+  - host: {{ $host | quote }}
+    http:
+      {{- include "seaweedfs.s3.iceberg.ingress.paths" $ | nindent 6 }}
+{{- end }}
+{{- else }}
+  - http:
+      {{- include "seaweedfs.s3.iceberg.ingress.paths" . | nindent 4 }}
+{{- end }}
+{{- end }}

--- a/platform/seaweedfs/chart/charts/seaweedfs/templates/s3/s3-ingress.yaml
+++ b/platform/seaweedfs/chart/charts/seaweedfs/templates/s3/s3-ingress.yaml
@@ -1,0 +1,74 @@
+{{- /* S3 ingress works for standalone S3 gateway (s3.enabled), S3 on Filer (filer.s3.enabled), and all-in-one mode (allInOne.s3.enabled) */}}
+{{- $s3Enabled := or .Values.s3.enabled (and .Values.filer.s3.enabled (not .Values.allInOne.enabled)) (and .Values.allInOne.enabled .Values.allInOne.s3.enabled) }}
+{{- if and $s3Enabled .Values.s3.ingress.enabled }}
+{{- /* Determine service name based on deployment mode */}}
+{{- $serviceName := ternary (include "seaweedfs.componentName" (list . "all-in-one")) (include "seaweedfs.componentName" (list . "s3")) .Values.allInOne.enabled }}
+{{- $s3Port := .Values.allInOne.s3.port | default .Values.s3.port }}
+{{- /* Build hosts list - support both legacy .host (string) and new .hosts (array) for backwards compatibility */}}
+{{- $hosts := list }}
+{{- if kindIs "slice" .Values.s3.ingress.host }}
+  {{- $hosts = .Values.s3.ingress.host }}
+{{- else if .Values.s3.ingress.host }}
+  {{- $hosts = list .Values.s3.ingress.host }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion }}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion }}
+apiVersion: networking.k8s.io/v1beta1
+{{- else }}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: ingress-{{ include "seaweedfs.fullname" . }}-s3
+  namespace: {{ .Release.Namespace }}
+  {{- with .Values.s3.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: s3
+spec:
+  ingressClassName: {{ .Values.s3.ingress.className | quote }}
+  tls:
+    {{ .Values.s3.ingress.tls | default list | toYaml | nindent 6}}
+  rules:
+{{- if $hosts }}
+{{- range $hosts }}
+  - host: {{ . | quote }}
+    http:
+      paths:
+      - path: {{ $.Values.s3.ingress.path | quote }}
+        pathType: {{ $.Values.s3.ingress.pathType | quote }}
+        backend:
+{{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+          service:
+            name: {{ $serviceName }}
+            port:
+              number: {{ $s3Port }}
+{{- else }}
+          serviceName: {{ $serviceName }}
+          servicePort: {{ $s3Port }}
+{{- end }}
+{{- end }}
+{{- else }}
+  - http:
+      paths:
+      - path: {{ .Values.s3.ingress.path | quote }}
+        pathType: {{ .Values.s3.ingress.pathType | quote }}
+        backend:
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion }}
+          service:
+            name: {{ $serviceName }}
+            port:
+              number: {{ $s3Port }}
+{{- else }}
+          serviceName: {{ $serviceName }}
+          servicePort: {{ $s3Port }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/platform/seaweedfs/chart/charts/seaweedfs/templates/s3/s3-secret.yaml
+++ b/platform/seaweedfs/chart/charts/seaweedfs/templates/s3/s3-secret.yaml
@@ -1,0 +1,57 @@
+{{- if or (and (or .Values.s3.enabled .Values.allInOne.enabled) .Values.s3.enableAuth (not .Values.s3.existingConfigSecret)) (and .Values.filer.s3.enabled .Values.filer.s3.enableAuth (not .Values.filer.s3.existingConfigSecret)) }}
+{{- $secretName := printf "%s-s3-secret" (include "seaweedfs.fullname" .) }}
+{{- $legacySecretName := "seaweedfs-s3-secret" }}
+{{- $lookupName := $secretName }}
+{{- if .Values.s3.reuseLegacySecret }}
+{{-   $lookupName = default $legacySecretName .Values.s3.legacySecretName }}
+{{- end }}
+{{- $existingSecret := lookup "v1" "Secret" .Release.Namespace $lookupName }}
+{{- $reuse := false }}
+{{- if and .Values.s3.reuseLegacySecret $existingSecret }}
+{{- $reuse = true }}
+{{- end }}
+{{- $creds := .Values.s3.credentials | default dict -}}
+{{- $adminCreds := $creds.admin | default dict -}}
+{{- $access_key_admin := $adminCreds.accessKey -}}
+{{- $secret_key_admin := $adminCreds.secretKey -}}
+{{- if not (and $access_key_admin $secret_key_admin) -}}
+  {{- $access_key_admin = include "seaweedfs.getOrGeneratePassword" (dict "namespace" .Release.Namespace "secretName" $secretName "key" "admin_access_key_id" "length" 20 "existingSecret" (ternary $existingSecret nil $reuse)) -}}
+  {{- $secret_key_admin = include "seaweedfs.getOrGeneratePassword" (dict "namespace" .Release.Namespace "secretName" $secretName "key" "admin_secret_access_key" "length" 40 "existingSecret" (ternary $existingSecret nil $reuse)) -}}
+{{- end -}}
+{{- $readCreds := $creds.read | default dict -}}
+{{- $access_key_read := $readCreds.accessKey -}}
+{{- $secret_key_read := $readCreds.secretKey -}}
+{{- if not (and $access_key_read $secret_key_read) -}}
+  {{- $access_key_read = include "seaweedfs.getOrGeneratePassword" (dict "namespace" .Release.Namespace "secretName" $secretName "key" "read_access_key_id" "length" 20 "existingSecret" (ternary $existingSecret nil $reuse)) -}}
+  {{- $secret_key_read = include "seaweedfs.getOrGeneratePassword" (dict "namespace" .Release.Namespace "secretName" $secretName "key" "read_secret_access_key" "length" 40 "existingSecret" (ternary $existingSecret nil $reuse)) -}}
+{{- end -}}
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: {{ $secretName }}
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/resource-policy": keep
+    "helm.sh/hook": "pre-install,pre-upgrade"
+  labels:
+    app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: s3
+stringData:
+  admin_access_key_id: {{ $access_key_admin }}
+  admin_secret_access_key: {{ $secret_key_admin }}
+  read_access_key_id: {{ $access_key_read }}
+  read_secret_access_key: {{ $secret_key_read }}
+  seaweedfs_s3_config: '{"identities":[{"name":"anvAdmin","credentials":[{"accessKey":"{{ $access_key_admin }}","secretKey":"{{ $secret_key_admin }}"}],"actions":["Admin","Read","Write"]},{"name":"anvReadOnly","credentials":[{"accessKey":"{{ $access_key_read }}","secretKey":"{{ $secret_key_read }}"}],"actions":["Read"]}]}'
+  {{- if .Values.filer.s3.auditLogConfig }}
+  filer_s3_auditLogConfig.json: |
+    {{ toJson .Values.filer.s3.auditLogConfig | nindent 4 }}
+  {{- end }}
+  {{- if .Values.s3.auditLogConfig }}
+  s3_auditLogConfig.json: |
+    {{ toJson .Values.s3.auditLogConfig | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/platform/seaweedfs/chart/charts/seaweedfs/templates/s3/s3-service.yaml
+++ b/platform/seaweedfs/chart/charts/seaweedfs/templates/s3/s3-service.yaml
@@ -1,0 +1,51 @@
+{{- if or .Values.s3.enabled .Values.filer.s3.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "seaweedfs.componentName" (list . "s3") }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
+    app.kubernetes.io/component: s3
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+{{- if .Values.s3.annotations }}
+  annotations:
+    {{- toYaml .Values.s3.annotations | nindent 4 }}
+{{- end }}
+spec:
+  type: {{ .Values.s3.service.type }}
+  internalTrafficPolicy: {{ .Values.s3.internalTrafficPolicy | default "Cluster" }}
+  {{- $td := .Values.s3.trafficDistribution | default .Values.filer.s3.trafficDistribution }}
+  {{- if and (semverCompare ">=1.31-0" .Capabilities.KubeVersion.GitVersion) $td }}
+  trafficDistribution: {{ include "seaweedfs.trafficDistribution" (dict "value" $td "Capabilities" .Capabilities) }}
+  {{- end }}
+  ports:
+  - name: "swfs-s3"
+    port: {{ if .Values.s3.enabled }}{{ .Values.s3.port }}{{ else }}{{ .Values.filer.s3.port }}{{ end }}
+    targetPort: {{ if .Values.s3.enabled }}{{ .Values.s3.port }}{{ else }}{{ .Values.filer.s3.port }}{{ end }}
+    protocol: TCP
+{{- if and .Values.s3.enabled .Values.s3.icebergPort }}
+  - name: "swfs-iceberg"
+    port: {{ .Values.s3.icebergPort }}
+    targetPort: {{ .Values.s3.icebergPort }}
+    protocol: TCP
+{{- end }}
+{{- if and .Values.s3.enabled .Values.s3.httpsPort }}
+  - name: "swfs-s3-tls"
+    port: {{ .Values.s3.httpsPort }}
+    targetPort: {{ .Values.s3.httpsPort }}
+    protocol: TCP
+{{- end }}
+{{- if and .Values.s3.enabled .Values.s3.metricsPort }}
+  - name: "metrics"
+    port: {{ .Values.s3.metricsPort }}
+    targetPort: {{ .Values.s3.metricsPort }}
+    protocol: TCP
+{{- end }}
+  selector:
+    app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: {{ if .Values.s3.enabled }}s3{{ else }}filer{{ end }}
+{{- end }}

--- a/platform/seaweedfs/chart/charts/seaweedfs/templates/s3/s3-servicemonitor.yaml
+++ b/platform/seaweedfs/chart/charts/seaweedfs/templates/s3/s3-servicemonitor.yaml
@@ -1,0 +1,36 @@
+{{- include "seaweedfs.compat" . -}}
+{{- /*
+  The seaweedfs-s3 Service only gains a "metrics" port when the standalone S3
+  gateway is enabled. With only the embedded filer S3 gateway, metrics live on
+  the filer process and are already scraped by the filer ServiceMonitor.
+*/ -}}
+{{- if and .Values.s3.enabled .Values.s3.metricsPort .Values.global.seaweedfs.monitoring.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "seaweedfs.fullname" . }}-s3
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: s3
+    {{- with .Values.global.seaweedfs.monitoring.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+{{- if .Values.s3.annotations }}
+  annotations:
+    {{- toYaml .Values.s3.annotations | nindent 4 }}
+{{- end }}
+spec:
+  endpoints:
+    - interval: 30s
+      port: metrics
+      scrapeTimeout: 5s
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/component: s3
+{{- end }}

--- a/platform/seaweedfs/chart/charts/seaweedfs/templates/sftp/sftp-deployment.yaml
+++ b/platform/seaweedfs/chart/charts/seaweedfs/templates/sftp/sftp-deployment.yaml
@@ -1,0 +1,292 @@
+{{- include "seaweedfs.compat" . -}}
+{{- if .Values.sftp.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "seaweedfs.fullname" . }}-sftp
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: sftp
+{{- if .Values.sftp.annotations }}
+  annotations:
+    {{- toYaml .Values.sftp.annotations | nindent 4 }}
+{{- end }}
+spec:
+  replicas: {{ .Values.sftp.replicas }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/component: sftp
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
+        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/component: sftp
+      {{ with .Values.podLabels }}
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.sftp.podLabels }}
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+      annotations:
+      {{ with .Values.podAnnotations }}
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.sftp.podAnnotations }}
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      restartPolicy: {{ default .Values.global.seaweedfs.restartPolicy .Values.sftp.restartPolicy }}
+      {{- if .Values.sftp.affinity }}
+      affinity:
+        {{ tpl .Values.sftp.affinity . | nindent 8 | trim }}
+      {{- end }}
+      {{- if .Values.sftp.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{ tpl .Values.sftp.topologySpreadConstraints . | nindent 8 | trim }}
+      {{- end }}
+      {{- if .Values.sftp.tolerations }}
+      tolerations:
+        {{ tpl .Values.sftp.tolerations . | nindent 8 | trim }}
+      {{- end }}
+      {{- include "seaweedfs.imagePullSecrets" . | nindent 6 }}
+      terminationGracePeriodSeconds: 10
+      {{- if .Values.sftp.priorityClassName }}
+      priorityClassName: {{ .Values.sftp.priorityClassName | quote }}
+      {{- end }}
+      enableServiceLinks: false
+      {{- if .Values.sftp.serviceAccountName }}
+      serviceAccountName: {{ .Values.sftp.serviceAccountName | quote }}
+      {{- end }}
+      {{- if .Values.sftp.initContainers }}
+      initContainers:
+        {{ tpl .Values.sftp.initContainers . | nindent 8 | trim }}
+      {{- end }}
+      {{- if .Values.sftp.podSecurityContext.enabled }}
+      securityContext: {{- omit .Values.sftp.podSecurityContext "enabled" | toYaml | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: seaweedfs
+          image: {{ template "seaweedfs.sftp.image" . }}
+          imagePullPolicy: {{ default "IfNotPresent" .Values.global.seaweedfs.imagePullPolicy }}
+          env:
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: SEAWEEDFS_FULLNAME
+              value: "{{ include "seaweedfs.fullname" . }}"
+            {{- $mergedExtraEnvironmentVars := dict }}
+            {{- include "seaweedfs.mergeExtraEnvironmentVars" (dict "global" .Values.global.seaweedfs "component" .Values.sftp "target" $mergedExtraEnvironmentVars) }}
+            {{- range $key := keys $mergedExtraEnvironmentVars | sortAlpha }}
+            {{- $value := index $mergedExtraEnvironmentVars $key }}
+            - name: {{ $key }}
+            {{- if kindIs "string" $value }}
+              value: {{ tpl $value $ | quote }}
+            {{- else }}
+              valueFrom:
+                {{ toYaml $value | nindent 16 | trim }}
+            {{- end -}}
+            {{- end }}
+          command:
+            - "/bin/sh"
+            - "-ec"
+            - |
+              exec /usr/bin/weed \
+              {{- if or (eq .Values.sftp.logs.type "hostPath") (eq .Values.sftp.logs.type "emptyDir") }}
+              -logdir=/logs \
+              {{- else }}
+              -logtostderr=true \
+              {{- end }}
+              {{- if .Values.sftp.loggingOverrideLevel }}
+              -v={{ .Values.sftp.loggingOverrideLevel }} \
+              {{- else }}
+              -v={{ .Values.global.seaweedfs.loggingLevel }} \
+              {{- end }}
+              sftp \
+              -ip.bind={{ .Values.sftp.bindAddress }} \
+              -port={{ .Values.sftp.port }} \
+              {{- if .Values.sftp.metricsPort }}
+              -metricsPort={{ .Values.sftp.metricsPort }} \
+              {{- end }}
+              {{- if .Values.sftp.metricsIp }}
+              -metricsIp={{ .Values.sftp.metricsIp }} \
+              {{- end }}
+              {{- if .Values.sftp.sshPrivateKey }}
+              -sshPrivateKey={{ .Values.sftp.sshPrivateKey }} \
+              {{- end }}
+              {{- if .Values.sftp.hostKeysFolder }}
+              -hostKeysFolder={{ .Values.sftp.hostKeysFolder }} \
+              {{- end }}
+              {{- if .Values.sftp.authMethods }}
+              -authMethods={{ .Values.sftp.authMethods }} \
+              {{- end }}
+              {{- if .Values.sftp.maxAuthTries }}
+              -maxAuthTries={{ .Values.sftp.maxAuthTries }} \
+              {{- end }}
+              {{- if .Values.sftp.bannerMessage }}
+              -bannerMessage="{{ .Values.sftp.bannerMessage }}" \
+              {{- end }}
+              {{- if .Values.sftp.loginGraceTime }}
+              -loginGraceTime={{ .Values.sftp.loginGraceTime }} \
+              {{- end }}
+              {{- if .Values.sftp.clientAliveInterval }}
+              -clientAliveInterval={{ .Values.sftp.clientAliveInterval }} \
+              {{- end }}
+              {{- if .Values.sftp.clientAliveCountMax }}
+              -clientAliveCountMax={{ .Values.sftp.clientAliveCountMax }} \
+              {{- end }}
+              {{- if .Values.sftp.dataCenter }}
+              -dataCenter={{ .Values.sftp.dataCenter }} \
+              {{- end }}
+              {{- if .Values.sftp.localSocket }}
+              -localSocket={{ .Values.sftp.localSocket }} \
+              {{- end }}
+              {{- if .Values.global.seaweedfs.enableSecurity }}
+              -cert.file=/usr/local/share/ca-certificates/client/tls.crt \
+              -key.file=/usr/local/share/ca-certificates/client/tls.key \
+              {{- end }}
+              -userStoreFile=/etc/sw/seaweedfs_sftp_config \
+              -filer={{ include "seaweedfs.componentName" (list . "filer-client") }}.{{ .Release.Namespace }}:{{ .Values.filer.port }}
+          volumeMounts:
+            {{- if or (eq .Values.sftp.logs.type "hostPath") (eq .Values.sftp.logs.type "emptyDir") }}
+            - name: logs
+              mountPath: "/logs/"
+            {{- end }}
+            {{- if .Values.sftp.enableAuth }}
+            - mountPath: /etc/sw
+              name: config-users
+              readOnly: true
+            {{- end }}
+            - mountPath: /etc/sw/ssh
+              name: config-ssh
+              readOnly: true
+            {{- if .Values.global.seaweedfs.enableSecurity }}
+            - name: security-config
+              readOnly: true
+              mountPath: /etc/seaweedfs/security.toml
+              subPath: security.toml
+            - name: ca-cert
+              readOnly: true
+              mountPath: /usr/local/share/ca-certificates/ca/
+            - name: master-cert
+              readOnly: true
+              mountPath: /usr/local/share/ca-certificates/master/
+            - name: volume-cert
+              readOnly: true
+              mountPath: /usr/local/share/ca-certificates/volume/
+            - name: filer-cert
+              readOnly: true
+              mountPath: /usr/local/share/ca-certificates/filer/
+            - name: client-cert
+              readOnly: true
+              mountPath: /usr/local/share/ca-certificates/client/
+            {{- end }}
+            {{ tpl .Values.sftp.extraVolumeMounts . | nindent 12 | trim }}
+          ports:
+            - containerPort: {{ .Values.sftp.port }}
+              name: swfs-sftp
+            {{- if .Values.sftp.metricsPort }}
+            - containerPort: {{ .Values.sftp.metricsPort }}
+              name: metrics
+            {{- end }}
+          {{- if .Values.sftp.readinessProbe.enabled }}
+          readinessProbe:
+            tcpSocket:
+              port: {{ .Values.sftp.port }}
+            initialDelaySeconds: {{ .Values.sftp.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.sftp.readinessProbe.periodSeconds }}
+            successThreshold: {{ .Values.sftp.readinessProbe.successThreshold }}
+            failureThreshold: {{ .Values.sftp.readinessProbe.failureThreshold }}
+            timeoutSeconds: {{ .Values.sftp.readinessProbe.timeoutSeconds }}
+          {{- end }}
+          {{- if .Values.sftp.livenessProbe.enabled }}
+          livenessProbe:
+            tcpSocket:
+              port: {{ .Values.sftp.port }}
+            initialDelaySeconds: {{ .Values.sftp.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.sftp.livenessProbe.periodSeconds }}
+            successThreshold: {{ .Values.sftp.livenessProbe.successThreshold }}
+            failureThreshold: {{ .Values.sftp.livenessProbe.failureThreshold }}
+            timeoutSeconds: {{ .Values.sftp.livenessProbe.timeoutSeconds }}
+          {{- end }}
+          {{- with .Values.sftp.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- if .Values.sftp.containerSecurityContext.enabled }}
+          securityContext: {{- omit .Values.sftp.containerSecurityContext "enabled" | toYaml | nindent 12 }}
+          {{- end }}
+      {{- if .Values.sftp.sidecars }}
+      {{- include "seaweedfs.tplvalues.render" (dict "value" .Values.sftp.sidecars "context" $) | nindent 8 }}
+      {{- end }}
+      volumes:
+        {{- if .Values.sftp.enableAuth }}
+        - name: config-users
+          secret:
+            defaultMode: 420
+            {{- if .Values.sftp.existingConfigSecret }}
+            secretName: {{ .Values.sftp.existingConfigSecret }}
+            {{- else }}
+            secretName: {{ include "seaweedfs.fullname" . }}-sftp-secret
+            {{- end }}
+        {{- end }}
+        - name: config-ssh
+          secret:
+            defaultMode: 420
+            {{- if .Values.sftp.existingSshConfigSecret }}
+            secretName: {{ .Values.sftp.existingSshConfigSecret }}
+            {{- else }}
+            secretName: {{ include "seaweedfs.fullname" . }}-sftp-ssh-secret
+            {{- end }}
+        {{- if eq .Values.sftp.logs.type "hostPath" }}
+        - name: logs
+          hostPath:
+            path: {{ .Values.sftp.logs.hostPathPrefix }}/logs/seaweedfs/sftp
+            type: DirectoryOrCreate
+        {{- end }}
+        {{- if eq .Values.sftp.logs.type "emptyDir" }}
+        - name: logs
+          emptyDir: {}
+        {{- end }}
+        {{- if .Values.global.seaweedfs.enableSecurity }}
+        - name: security-config
+          configMap:
+            name: {{ include "seaweedfs.fullname" . }}-security-config
+        - name: ca-cert
+          secret:
+            secretName: {{ include "seaweedfs.fullname" . }}-ca-cert
+        - name: master-cert
+          secret:
+            secretName: {{ include "seaweedfs.fullname" . }}-master-cert
+        - name: volume-cert
+          secret:
+            secretName: {{ include "seaweedfs.fullname" . }}-volume-cert
+        - name: filer-cert
+          secret:
+            secretName: {{ include "seaweedfs.fullname" . }}-filer-cert
+        - name: client-cert
+          secret:
+            secretName: {{ include "seaweedfs.fullname" . }}-client-cert
+        {{- end }}
+        {{ tpl .Values.sftp.extraVolumes . | indent 8 | trim }}
+      {{- if .Values.sftp.nodeSelector }}
+      nodeSelector:
+        {{ tpl .Values.sftp.nodeSelector . | indent 8 | trim }}
+      {{- end }}
+{{- end }}

--- a/platform/seaweedfs/chart/charts/seaweedfs/templates/sftp/sftp-secret.yaml
+++ b/platform/seaweedfs/chart/charts/seaweedfs/templates/sftp/sftp-secret.yaml
@@ -1,0 +1,34 @@
+{{- if or .Values.sftp.enabled .Values.allInOne.enabled }}
+{{- $secretName := printf "%s-sftp-secret" (include "seaweedfs.fullname" .) }}
+{{- $admin_pwd := include "seaweedfs.getOrGeneratePassword" (dict "namespace" .Release.Namespace "secretName" $secretName "key" "admin_password" "length" 20) -}}
+{{- $read_user_pwd := include "seaweedfs.getOrGeneratePassword" (dict "namespace" .Release.Namespace "secretName" $secretName "key" "readonly_password" "length" 20) -}}
+{{- $public_user_pwd := include "seaweedfs.getOrGeneratePassword" (dict "namespace" .Release.Namespace "secretName" $secretName "key" "public_user_password" "length" 20) -}}
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: {{ $secretName }}
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/resource-policy": keep
+    "helm.sh/hook": "pre-install,pre-upgrade"
+  labels:
+    app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: sftp
+stringData:
+  admin_password: {{ $admin_pwd }}
+  readonly_password: {{ $read_user_pwd }}
+  public_user_password: {{ $public_user_pwd }}
+  seaweedfs_sftp_config: '[{"Username":"admin","Password":"{{ $admin_pwd }}","PublicKeys":[],"HomeDir":"/","Permissions":{"/":["read","write","list"]},"Uid":0,"Gid":0},{"Username":"readonly_user","Password":"{{ $read_user_pwd }}","PublicKeys":[],"HomeDir":"/","Permissions":{"/":["read","list"]},"Uid":1112,"Gid":1112},{"Username":"public_user","Password":"{{ $public_user_pwd }}","PublicKeys":[],"HomeDir":"/public","Permissions":{"/public":["write","read","list"]},"Uid":1113,"Gid":1113}]'
+  seaweedfs_sftp_ssh_private_key: |
+    -----BEGIN OPENSSH PRIVATE KEY-----
+    b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW
+    QyNTUxOQAAACDH4McwcDphteXVullu6q7ephEN1N60z+w0qZw0UVW8OwAAAJDjxkmk48ZJ
+    pAAAAAtzc2gtZWQyNTUxOQAAACDH4McwcDphteXVullu6q7ephEN1N60z+w0qZw0UVW8Ow
+    AAAEAeVy/4+gf6rjj2jla/AHqJpC1LcS5hn04IUs4q+iVq/MfgxzBwOmG15dW6WW7qrt6m
+    EQ3U3rTP7DSpnDRRVbw7AAAADHNla291ckAwMDY2NwE=
+    -----END OPENSSH PRIVATE KEY-----
+{{- end }}

--- a/platform/seaweedfs/chart/charts/seaweedfs/templates/sftp/sftp-service.yaml
+++ b/platform/seaweedfs/chart/charts/seaweedfs/templates/sftp/sftp-service.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.sftp.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "seaweedfs.componentName" (list . "sftp") }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: sftp
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- if .Values.sftp.annotations }}
+  annotations:
+    {{- toYaml .Values.sftp.annotations | nindent 4 }}
+{{- end }}
+spec:
+  type: {{ .Values.sftp.service.type }}
+  internalTrafficPolicy: {{ .Values.sftp.internalTrafficPolicy | default "Cluster" }}
+  ports:
+  - name: "swfs-sftp"
+    port: {{ .Values.sftp.port }}
+    targetPort: {{ .Values.sftp.port }}
+    protocol: TCP
+{{- if .Values.sftp.metricsPort }}
+  - name: "metrics"
+    port: {{ .Values.sftp.metricsPort }}
+    targetPort: {{ .Values.sftp.metricsPort }}
+    protocol: TCP
+{{- end }}
+  selector:
+    app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: sftp
+{{- end }}

--- a/platform/seaweedfs/chart/charts/seaweedfs/templates/sftp/sftp-servicemonitor.yaml
+++ b/platform/seaweedfs/chart/charts/seaweedfs/templates/sftp/sftp-servicemonitor.yaml
@@ -1,0 +1,35 @@
+{{- include "seaweedfs.compat" . -}}
+{{- if .Values.sftp.enabled }}
+{{- if .Values.sftp.metricsPort }}
+{{- if .Values.global.seaweedfs.monitoring.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "seaweedfs.fullname" . }}-sftp
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: sftp
+    {{- with .Values.global.seaweedfs.monitoring.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+{{- if .Values.sftp.annotations }}
+  annotations:
+    {{- toYaml .Values.sftp.annotations | nindent 4 }}
+{{- end }}
+spec:
+  endpoints:
+    - interval: 30s
+      port: metrics
+      scrapeTimeout: 5s
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/component: sftp
+{{- end }}
+{{- end }}
+{{- end }}

--- a/platform/seaweedfs/chart/charts/seaweedfs/templates/shared/_compat.tpl
+++ b/platform/seaweedfs/chart/charts/seaweedfs/templates/shared/_compat.tpl
@@ -1,0 +1,59 @@
+{{/*
+Backward-compatibility shim for the global.* → global.seaweedfs.* migration.
+
+When the chart is used as a subchart, .Values.global is shared with sibling
+charts.  To avoid namespace pollution, app-specific values were moved under
+global.seaweedfs.* (and global.registry was renamed to global.imageRegistry).
+
+If a user still passes the OLD key paths (e.g. --set global.enableSecurity=true),
+those keys will no longer have defaults in values.yaml, so their mere presence in
+.Values.global means the user explicitly provided them.  This helper merges them
+into global.seaweedfs.* so the rest of the templates see a single, canonical
+location.
+
+The helper mutates .Values.global.seaweedfs in-place via `set` and produces no
+output.  It is idempotent (safe to call more than once in the same render).
+
+Usage:  {{- include "seaweedfs.compat" . -}}
+*/}}
+{{- define "seaweedfs.compat" -}}
+{{- $g  := .Values.global -}}
+{{- $sw := $g.seaweedfs | default dict -}}
+
+{{/* --- image-related renames --- */}}
+{{- if hasKey $g "registry" -}}
+{{-   $_ := set $g "imageRegistry" (default $g.imageRegistry $g.registry) -}}
+{{- end -}}
+{{- if hasKey $g "repository" -}}
+{{-   $img := $sw.image | default dict -}}
+{{-   $_ := set $img "repository" (default $img.repository $g.repository) -}}
+{{-   $_ := set $sw "image" $img -}}
+{{- end -}}
+{{- if hasKey $g "imageName" -}}
+{{-   $img := $sw.image | default dict -}}
+{{-   $_ := set $img "name" (default $img.name $g.imageName) -}}
+{{-   $_ := set $sw "image" $img -}}
+{{- end -}}
+
+{{/* --- scalar keys that moved 1:1 under global.seaweedfs --- */}}
+{{- range $key := list "createClusterRole" "imagePullPolicy" "restartPolicy" "loggingLevel" "enableSecurity" "masterServer" "serviceAccountName" "automountServiceAccountToken" "enableReplication" "replicationPlacement" -}}
+{{-   if hasKey $g $key -}}
+{{-     $_ := set $sw $key (index $g $key) -}}
+{{-   end -}}
+{{- end -}}
+
+{{/* --- nested dict keys: deep-merge so partial overrides work --- */}}
+{{- range $key := list "securityConfig" "certificates" "monitoring" "serviceAccountAnnotations" "extraEnvironmentVars" -}}
+{{-   if hasKey $g $key -}}
+{{-     $old := index $g $key | default dict -}}
+{{-     $new := index $sw $key | default dict -}}
+{{-     if and (kindIs "map" $old) (kindIs "map" $new) -}}
+{{-       $_ := set $sw $key (merge $old $new) -}}
+{{-     else -}}
+{{-       $_ := set $sw $key $old -}}
+{{-     end -}}
+{{-   end -}}
+{{- end -}}
+
+{{- $_ := set $g "seaweedfs" $sw -}}
+{{- end -}}

--- a/platform/seaweedfs/chart/charts/seaweedfs/templates/shared/_helpers.tpl
+++ b/platform/seaweedfs/chart/charts/seaweedfs/templates/shared/_helpers.tpl
@@ -1,0 +1,372 @@
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to
+this (by the DNS naming spec). If release name contains chart name it will
+be used as a full name.
+*/}}
+{{- define "seaweedfs.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create a truncated component name.
+Usage: {{ include "seaweedfs.componentName" (list . "component-suffix") }}
+*/}}
+{{- define "seaweedfs.componentName" -}}
+{{- $context := index . 0 -}}
+{{- $suffix := index . 1 -}}
+{{- if gt (len $suffix) 61 -}}
+{{-   fail (printf "Suffix '%s' is too long for componentName helper. Max length is 61." $suffix) -}}
+{{- end -}}
+{{- $fullname := include "seaweedfs.fullname" $context -}}
+{{- $maxLen := sub 62 (len $suffix) | int -}}
+{{- $truncatedFullname := trunc $maxLen $fullname | trimSuffix "-" -}}
+{{- printf "%s-%s" $truncatedFullname $suffix -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "seaweedfs.chart" -}}
+{{- printf "%s-helm" .Chart.Name | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "seaweedfs.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Inject extra environment vars in the format key:value, if populated
+*/}}
+{{- define "seaweedfs.extraEnvironmentVars" -}}
+{{- if .extraEnvironmentVars -}}
+{{- range $key, $value := .extraEnvironmentVars }}
+- name: {{ $key }}
+  value: {{ $value | quote }}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "seaweedfs.mergeExtraEnvironmentVars" -}}
+{{- $global := ((.global | default dict).extraEnvironmentVars | default dict) -}}
+{{- $component := ((.component | default dict).extraEnvironmentVars | default dict) -}}
+{{- $target := .target -}}
+{{- range $key, $value := $global }}
+{{- $_ := set $target $key $value }}
+{{- end }}
+{{- range $key, $value := $component }}
+{{- $_ := set $target $key $value }}
+{{- end }}
+{{- end -}}
+
+{{/* Return the proper filer image */}}
+{{- define "seaweedfs.filer.image" -}}
+{{- if .Values.filer.imageOverride -}}
+{{- $imageOverride := .Values.filer.imageOverride -}}
+{{- printf "%s" $imageOverride -}}
+{{- else -}}
+{{- include "seaweedfs.image" . }}
+{{- end -}}
+{{- end -}}
+
+{{/* Return the proper master image */}}
+{{- define "seaweedfs.master.image" -}}
+{{- if .Values.master.imageOverride -}}
+{{- $imageOverride := .Values.master.imageOverride -}}
+{{- printf "%s" $imageOverride -}}
+{{- else -}}
+{{- include "seaweedfs.image" . }}
+{{- end -}}
+{{- end -}}
+
+{{/* Return the proper s3 image */}}
+{{- define "seaweedfs.s3.image" -}}
+{{- if .Values.s3.imageOverride -}}
+{{- $imageOverride := .Values.s3.imageOverride -}}
+{{- printf "%s" $imageOverride -}}
+{{- else -}}
+{{- include "seaweedfs.image" . }}
+{{- end -}}
+{{- end -}}
+
+{{/* Return the proper sftp image */}}
+{{- define "seaweedfs.sftp.image" -}}
+{{- if .Values.sftp.imageOverride -}}
+{{- $imageOverride := .Values.sftp.imageOverride -}}
+{{- printf "%s" $imageOverride -}}
+{{- else -}}
+{{- include "seaweedfs.image" . }}
+{{- end -}}
+{{- end -}}
+
+{{/* Return the proper admin image */}}
+{{- define "seaweedfs.admin.image" -}}
+{{- if .Values.admin.imageOverride -}}
+{{- $imageOverride := .Values.admin.imageOverride -}}
+{{- printf "%s" $imageOverride -}}
+{{- else -}}
+{{- include "seaweedfs.image" . }}
+{{- end -}}
+{{- end -}}
+
+{{/* Return the proper worker image */}}
+{{- define "seaweedfs.worker.image" -}}
+{{- if .Values.worker.imageOverride -}}
+{{- $imageOverride := .Values.worker.imageOverride -}}
+{{- printf "%s" $imageOverride -}}
+{{- else -}}
+{{- include "seaweedfs.image" . }}
+{{- end -}}
+{{- end -}}
+
+{{/* Return the proper volume image */}}
+{{- define "seaweedfs.volume.image" -}}
+{{- if .Values.volume.imageOverride -}}
+{{- $imageOverride := .Values.volume.imageOverride -}}
+{{- printf "%s" $imageOverride -}}
+{{- else -}}
+{{- include "seaweedfs.image" . }}
+{{- end -}}
+{{- end -}}
+
+{{/* Computes the container image name for all components (if they are not overridden) */}}
+{{- define "seaweedfs.image" -}}
+{{- $registryName := default .Values.image.registry .Values.global.imageRegistry | toString -}}
+{{- $repositoryName := default .Values.image.repository .Values.global.seaweedfs.image.repository | toString -}}
+{{- $name := .Values.global.seaweedfs.image.name | toString -}}
+{{- $tag := default .Chart.AppVersion .Values.image.tag  | toString -}}
+{{- if .Values.image.repository -}}
+{{-   $name = $repositoryName -}}
+{{- else if $repositoryName -}}
+{{-   $name = printf "%s/%s" (trimSuffix "/" $repositoryName) (base $name) -}}
+{{- end -}}
+{{- if $registryName -}}
+{{-   printf "%s/%s:%s" $registryName $name $tag -}}
+{{- else -}}
+{{-   printf "%s:%s" $name $tag -}}
+{{- end -}}
+{{- end -}}
+
+{{/* check if any Volume PVC exists */}}
+{{- define "seaweedfs.volume.pvc_exists" -}}
+{{- if or (or (eq .Values.volume.data.type "persistentVolumeClaim") (and (eq .Values.volume.idx.type "persistentVolumeClaim") .Values.volume.dir_idx )) (eq .Values.volume.logs.type "persistentVolumeClaim") -}}
+{{- printf "true" -}}
+{{- else -}}
+{{- printf "" -}}
+{{- end -}}
+{{- end -}}
+
+{{/* check if any Filer PVC exists */}}
+{{- define "seaweedfs.filer.pvc_exists" -}}
+{{- if or (eq .Values.filer.data.type "persistentVolumeClaim") (eq .Values.filer.logs.type "persistentVolumeClaim") -}}
+{{- printf "true" -}}
+{{- else -}}
+{{- printf "" -}}
+{{- end -}}
+{{- end -}}
+
+{{/* check if any Master PVC exists */}}
+{{- define "seaweedfs.master.pvc_exists" -}}
+{{- if or (eq .Values.master.data.type "persistentVolumeClaim") (eq .Values.master.logs.type "persistentVolumeClaim") -}}
+{{- printf "true" -}}
+{{- else -}}
+{{- printf "" -}}
+{{- end -}}
+{{- end -}}
+
+{{/* check if any Admin PVC exists */}}
+{{- define "seaweedfs.admin.pvc_exists" -}}
+{{- if or (eq .Values.admin.data.type "persistentVolumeClaim") (eq .Values.admin.logs.type "persistentVolumeClaim") -}}
+{{- printf "true" -}}
+{{- else -}}
+{{- printf "" -}}
+{{- end -}}
+{{- end -}}
+
+{{/* check if any InitContainers exist for Volumes */}}
+{{- define "seaweedfs.volume.initContainers_exists" -}}
+{{- if or (not (empty .Values.volume.idx )) (not (empty .Values.volume.initContainers )) -}}
+{{- printf "true" -}}
+{{- else -}}
+{{- printf "" -}}
+{{- end -}}
+{{- end -}}
+
+{{/* Return the proper imagePullSecrets */}}
+{{- define "seaweedfs.imagePullSecrets" -}}
+{{- with .Values.global.imagePullSecrets }}
+imagePullSecrets:
+{{- if kindIs "string" . }}
+  - name: {{ . }}
+{{- else }}
+{{- range . }}
+  {{- if kindIs "string" . }}
+  - name: {{ . }}
+  {{- else }}
+  - {{ toYaml . }}
+  {{- end}}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end -}}
+
+{{/*
+Renders a value that contains template perhaps with scope if the scope is present.
+Usage:
+{{ include "seaweedfs.tplvalues.render" ( dict "value" .Values.path.to.the.Value "context" $ ) }}
+{{ include "seaweedfs.tplvalues.render" ( dict "value" .Values.path.to.the.Value "context" $ "scope" $app ) }}
+*/}}
+{{- define "seaweedfs.tplvalues.render" -}}
+{{- $value := typeIs "string" .value | ternary .value (.value | toYaml) }}
+{{- if contains "{{" (toJson .value) }}
+  {{- if .scope }}
+      {{- tpl (cat "{{- with $.RelativeScope -}}" $value "{{- end }}") (merge (dict "RelativeScope" .scope) .context) }}
+  {{- else }}
+    {{- tpl $value .context }}
+  {{- end }}
+{{- else }}
+    {{- $value }}
+{{- end }}
+{{- end -}}
+
+{{/*
+Converts a Kubernetes quantity like "256Mi" or "2G" to a float64 in base units,
+handling both binary (Ki, Mi, Gi) and decimal (m, k, M) suffixes; numeric inputs
+Usage:
+{{ include "seaweedfs.resource-quantity" "10Gi" }}
+*/}}
+{{- define "seaweedfs.resource-quantity" -}}
+    {{- $value := . -}}
+    {{- $unit := 1.0 -}}
+    {{- if typeIs "string" . -}}
+        {{- $base2 := dict "Ki" 0x1p10 "Mi" 0x1p20 "Gi" 0x1p30 "Ti" 0x1p40 "Pi" 0x1p50 "Ei" 0x1p60 -}}
+        {{- $base10 := dict "m" 1e-3 "k" 1e3 "M" 1e6 "G" 1e9 "T" 1e12 "P" 1e15 "E" 1e18 -}}
+        {{- range $k, $v := merge $base2 $base10 -}}
+            {{- if hasSuffix $k $ -}}
+                {{- $value = trimSuffix $k $ -}}
+                {{- $unit = $v -}}
+            {{- end -}}
+        {{- end -}}
+    {{- end -}}
+    {{- mulf (float64 $value) $unit -}}
+{{- end -}}
+
+{{/*
+getOrGeneratePassword will check if a password exists in a secret and return it,
+or generate a new random password if it doesn't exist.
+*/}}
+{{- define "seaweedfs.getOrGeneratePassword" -}}
+{{- $params := . -}}
+{{- $namespace := $params.namespace -}}
+{{- $secretName := $params.secretName -}}
+{{- $key := $params.key -}}
+{{- $length := default 16 $params.length -}}
+
+{{- $existingSecret := default (lookup "v1" "Secret" $namespace $secretName) $params.existingSecret -}}
+{{- if and $existingSecret (index $existingSecret.data $key) -}}
+  {{- index $existingSecret.data $key | b64dec -}}
+{{- else -}}
+  {{- randAlphaNum $length -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Compute the master service address to be used in cluster env vars.
+If allInOne is enabled, point to the all-in-one service; otherwise, point to the master service.
+*/}}
+{{- define "seaweedfs.cluster.masterAddress" -}}
+{{- $component := ternary "all-in-one" "master" .Values.allInOne.enabled -}}
+{{- printf "%s.%s:%d" (include "seaweedfs.componentName" (list . $component)) .Release.Namespace (int .Values.master.port) -}}
+{{- end -}}
+
+{{/*
+Compute the filer service address to be used in cluster env vars.
+If allInOne is enabled, point to the all-in-one service; otherwise, point to the filer-client service.
+*/}}
+{{- define "seaweedfs.cluster.filerAddress" -}}
+{{- $component := ternary "all-in-one" "filer-client" .Values.allInOne.enabled -}}
+{{- printf "%s.%s:%d" (include "seaweedfs.componentName" (list . $component)) .Release.Namespace (int .Values.filer.port) -}}
+{{- end -}}
+
+{{/*
+Generate comma-separated list of master server addresses.
+Usage: {{ include "seaweedfs.masterServers" . }}
+Output example: my-release-master-0.my-release-master.namespace:9333,my-release-master-1...
+*/}}
+{{- define "seaweedfs.masterServers" -}}
+{{- $masterName := include "seaweedfs.componentName" (list . "master") -}}
+{{- range $index := until (.Values.master.replicas | int) -}}
+{{- if $index }},{{ end -}}
+{{ $masterName }}-{{ $index }}.{{ $masterName }}.{{ $.Release.Namespace }}:{{ $.Values.master.port }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Generate master server argument value, using global.masterServer if set, otherwise the generated list.
+Usage: {{ include "seaweedfs.masterServerArg" . }}
+*/}}
+{{- define "seaweedfs.masterServerArg" -}}
+{{- if .Values.global.seaweedfs.masterServer -}}
+{{- .Values.global.seaweedfs.masterServer -}}
+{{- else -}}
+{{- include "seaweedfs.masterServers" . -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "seaweedfs.serviceAccountName" -}}
+{{- .Values.global.seaweedfs.serviceAccountName | default "seaweedfs" -}}
+{{- end -}}
+
+{{/* S3 TLS cert/key arguments, using custom secret if s3.tlsSecret is set */}}
+{{- define "seaweedfs.s3.tlsArgs" -}}
+{{- $prefix := .prefix -}}
+{{- $root := .root -}}
+{{- if $root.Values.s3.tlsSecret -}}
+-{{ $prefix }}cert.file=/usr/local/share/ca-certificates/s3/tls.crt \
+-{{ $prefix }}key.file=/usr/local/share/ca-certificates/s3/tls.key \
+{{- else -}}
+-{{ $prefix }}cert.file=/usr/local/share/ca-certificates/client/tls.crt \
+-{{ $prefix }}key.file=/usr/local/share/ca-certificates/client/tls.key \
+{{- end -}}
+{{- end -}}
+
+{{/* S3 custom TLS volume mount */}}
+{{- define "seaweedfs.s3.tlsVolumeMount" -}}
+{{- if .Values.s3.tlsSecret }}
+- name: s3-tls-cert
+  readOnly: true
+  mountPath: /usr/local/share/ca-certificates/s3/
+{{- end }}
+{{- end -}}
+
+{{/* S3 custom TLS volume */}}
+{{- define "seaweedfs.s3.tlsVolume" -}}
+{{- if .Values.s3.tlsSecret }}
+- name: s3-tls-cert
+  secret:
+    secretName: {{ .Values.s3.tlsSecret }}
+{{- end }}
+{{- end -}}
+
+{{/* Generate a compatible trafficDistribution value due to "PreferClose" fast deprecation in k8s v1.35.
+     Accepts a dict with "value" (the trafficDistribution string) and "Capabilities". */}}
+{{- define "seaweedfs.trafficDistribution" -}}
+{{- if .value -}}
+{{- and (eq .value "PreferClose") (semverCompare ">=1.35-0" .Capabilities.KubeVersion.GitVersion) | ternary "PreferSameZone" .value -}}
+{{- end -}}
+{{- end -}}

--- a/platform/seaweedfs/chart/charts/seaweedfs/templates/shared/cluster-role.yaml
+++ b/platform/seaweedfs/chart/charts/seaweedfs/templates/shared/cluster-role.yaml
@@ -1,0 +1,36 @@
+{{- include "seaweedfs.compat" . -}}
+{{- if .Values.global.seaweedfs.createClusterRole }}
+#hack for delete pod master after migration
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "seaweedfs.fullname" . }}-rw-cr
+  labels:
+    app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "seaweedfs.fullname" . }}-rw-crb
+  labels:
+    app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "seaweedfs.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "seaweedfs.fullname" . }}-rw-cr
+{{- end }}

--- a/platform/seaweedfs/chart/charts/seaweedfs/templates/shared/notification-configmap.yaml
+++ b/platform/seaweedfs/chart/charts/seaweedfs/templates/shared/notification-configmap.yaml
@@ -1,0 +1,19 @@
+{{- if and .Values.filer.enabled .Values.filer.notificationConfig }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "seaweedfs.fullname" . }}-notification-config
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+{{- if .Values.filer.annotations }}
+  annotations:
+    {{- toYaml .Values.filer.annotations | nindent 4 }}
+{{- end }}
+data:
+  notification.toml: |-
+    {{ .Values.filer.notificationConfig | nindent 4 }}
+{{- end }}

--- a/platform/seaweedfs/chart/charts/seaweedfs/templates/shared/post-install-bucket-hook.yaml
+++ b/platform/seaweedfs/chart/charts/seaweedfs/templates/shared/post-install-bucket-hook.yaml
@@ -1,0 +1,211 @@
+{{- include "seaweedfs.compat" . -}}
+{{- /* Support bucket creation for both standalone filer.s3 and allInOne modes */}}
+{{- $createBuckets := list }}
+{{- $s3Enabled := false }}
+{{- $enableAuth := false }}
+{{- $existingConfigSecret := "" }}
+{{- $bucketsFolder := "/buckets" }}
+{{- $bucketEnvVars := merge (dict) (.Values.global.seaweedfs.extraEnvironmentVars | default dict) }}
+{{- if .Values.allInOne.enabled }}
+  {{- $bucketEnvVars = merge (.Values.allInOne.extraEnvironmentVars | default dict) $bucketEnvVars }}
+{{- else }}
+  {{- $bucketEnvVars = merge (.Values.filer.extraEnvironmentVars | default dict) $bucketEnvVars }}
+{{- end }}
+{{- $bucketsFolder = default $bucketsFolder (get $bucketEnvVars "WEED_FILER_BUCKETS_FOLDER") }}
+{{- $bucketsFolder = trimSuffix "/" $bucketsFolder }}
+
+{{- /* Check allInOne mode first */}}
+{{- if .Values.allInOne.enabled }}
+  {{- if .Values.allInOne.s3.enabled }}
+    {{- $s3Enabled = true }}
+    {{- if .Values.allInOne.s3.createBuckets }}
+      {{- $createBuckets = .Values.allInOne.s3.createBuckets }}
+    {{- end }}
+    {{- $enableAuth = or .Values.allInOne.s3.enableAuth .Values.s3.enableAuth .Values.filer.s3.enableAuth }}
+    {{- $existingConfigSecret = or .Values.allInOne.s3.existingConfigSecret .Values.s3.existingConfigSecret .Values.filer.s3.existingConfigSecret }}
+  {{- end }}
+{{- else if .Values.master.enabled }}
+  {{- /* Check if embedded (in filer) or standalone S3 gateway is enabled */}}
+  {{- if or .Values.filer.s3.enabled .Values.s3.enabled }}
+    {{- $s3Enabled = true }}
+    {{- if .Values.s3.createBuckets }}
+      {{- $createBuckets = .Values.s3.createBuckets }}
+      {{- $enableAuth = .Values.s3.enableAuth }}
+      {{- $existingConfigSecret = .Values.s3.existingConfigSecret }}
+    {{- else if .Values.filer.s3.createBuckets }}
+      {{- $createBuckets = .Values.filer.s3.createBuckets }}
+      {{- $enableAuth = .Values.filer.s3.enableAuth }}
+      {{- $existingConfigSecret = .Values.filer.s3.existingConfigSecret }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+
+{{- if and $s3Enabled $createBuckets }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "{{ $.Release.Name }}-bucket-hook"
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  template:
+    metadata:
+      name: "{{ .Release.Name }}"
+      labels:
+        app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+        app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    spec:
+      restartPolicy: Never
+      {{- if .Values.filer.podSecurityContext.enabled }}
+      securityContext: {{- omit .Values.filer.podSecurityContext "enabled" | toYaml | nindent 8 }}
+      {{- end }}
+      {{- include "seaweedfs.imagePullSecrets" $ | nindent 6 }}
+      containers:
+      - name: post-install-job
+        image: {{ template "seaweedfs.master.image" . }}
+        imagePullPolicy: {{ $.Values.global.seaweedfs.imagePullPolicy | default "IfNotPresent" }}
+        env:
+          - name: WEED_CLUSTER_DEFAULT
+            value: "sw"
+          - name: WEED_CLUSTER_SW_MASTER
+            value: {{ include "seaweedfs.cluster.masterAddress" . | quote }}
+          - name: WEED_CLUSTER_SW_FILER
+            value: {{ include "seaweedfs.cluster.filerAddress" . | quote }}
+          - name: POD_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: SEAWEEDFS_FULLNAME
+            value: "{{ include "seaweedfs.fullname" . }}"
+        command:
+          - "/bin/sh"
+          - "-ec"
+          - |
+            set -o pipefail
+            wait_for_service() {
+              local url=$1
+              local max_attempts=60  # 5 minutes total (5s * 60)
+              local attempt=1
+              
+              echo "Waiting for service at $url..."
+              while [ $attempt -le $max_attempts ]; do
+                if wget -q --spider "$url" >/dev/null 2>&1; then
+                  echo "Service at $url is up!"
+                  return 0
+                fi
+                echo "Attempt $attempt: Service not ready yet, retrying in 5s..."
+                sleep 5
+                attempt=$((attempt + 1))
+              done
+              echo "Service at $url failed to become ready within 5 minutes"
+              exit 1
+            }
+            {{- if .Values.allInOne.enabled }}
+            wait_for_service "http://$WEED_CLUSTER_SW_MASTER{{ .Values.allInOne.readinessProbe.httpGet.path }}"
+            wait_for_service "http://$WEED_CLUSTER_SW_FILER{{ .Values.filer.readinessProbe.httpGet.path }}"
+            {{- else }}
+            wait_for_service "http://$WEED_CLUSTER_SW_MASTER{{ .Values.master.readinessProbe.httpGet.path }}"
+            wait_for_service "http://$WEED_CLUSTER_SW_FILER{{ .Values.filer.readinessProbe.httpGet.path }}"
+            {{- end }}
+            {{- range $createBuckets }}
+            {{- $bucketName := .name }}
+            {{- $bucketLock := or .lock .objectLock .withLock }}
+            bucket_list=$(/bin/echo 's3.bucket.list' | /usr/bin/weed shell) || { echo "Error listing s3 buckets"; exit 1; }
+            if echo "$bucket_list" | awk '{print $1}' | grep -Fxq "{{ $bucketName }}"; then
+              echo "Bucket '{{ $bucketName }}' already exists, skipping creation."
+            else
+              echo "Creating bucket '{{ $bucketName }}'..."
+              /bin/echo 's3.bucket.create --name {{ $bucketName }}{{- if $bucketLock }} --withLock{{- end }}' | /usr/bin/weed shell
+            fi
+          {{- end }}
+          {{- range $createBuckets }}
+          {{- $bucketLock := or .lock .objectLock .withLock }}
+          {{- if $bucketLock }}
+            /bin/echo 's3.bucket.lock -name {{ .name }} -enable' | /usr/bin/weed shell
+          {{- end }}
+          {{- end }}
+          {{- range $createBuckets }}
+          {{- $bucketVersioning := "" }}
+          {{- if kindIs "bool" .versioning }}
+            {{- if .versioning }}
+              {{- $bucketVersioning = "Enabled" }}
+            {{- end }}
+          {{- else if kindIs "string" .versioning }}
+            {{- $versioningLower := lower .versioning }}
+            {{- if eq $versioningLower "enabled" "enable" "true" }}
+              {{- $bucketVersioning = "Enabled" }}
+            {{- else if eq $versioningLower "suspended" "disable" "false" }}
+              {{- $bucketVersioning = "Suspended" }}
+            {{- else if or (eq .versioning "Enabled") (eq .versioning "Suspended") }}
+              {{- $bucketVersioning = .versioning }}
+            {{- else }}
+              {{- fail (printf "Invalid versioning value for bucket %s: %s. Must be 'Enabled' or 'Suspended'" .name .versioning) }}
+            {{- end }}
+          {{- end }}
+          {{- if $bucketVersioning }}
+            /bin/echo 's3.bucket.versioning -name {{ .name }} -status {{ $bucketVersioning }}' | /usr/bin/weed shell
+          {{- end }}
+          {{- end }}
+          {{- range $createBuckets }}
+          {{- if .ttl }}
+            /bin/echo 'fs.configure -locationPrefix={{ $bucketsFolder }}/{{ .name }}/ -ttl={{ .ttl }} -apply' | /usr/bin/weed shell
+          {{- end }}
+          {{- end }}
+          {{- range $createBuckets }}
+          {{- if .anonymousRead }}
+            /bin/echo \
+            "s3.configure --user anonymous \
+                --buckets {{ .name }} \
+                --actions Read \
+                --apply true" |\
+                /usr/bin/weed shell
+          {{- end }}  
+          {{- end }}
+        {{- if $enableAuth }}
+        volumeMounts:
+          - name: config-users
+            mountPath: /etc/sw
+            readOnly: true
+        {{- end }}
+        ports:
+          - containerPort: {{ .Values.master.port }}
+            name: swfs-master
+          {{- if and .Values.global.seaweedfs.monitoring.enabled .Values.master.metricsPort }}
+          - containerPort: {{ .Values.master.metricsPort }}
+            name: metrics
+          {{- end }}
+          - containerPort: {{ .Values.master.grpcPort }}
+            #name: swfs-master-grpc
+        {{- with coalesce .Values.allInOne.s3.createBucketsHook.resources .Values.s3.createBucketsHook.resources .Values.filer.s3.createBucketsHook.resources }}
+        resources:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- if .Values.filer.containerSecurityContext.enabled }}
+        securityContext: {{- omit .Values.filer.containerSecurityContext "enabled" | toYaml | nindent 12 }}
+        {{- end }}
+    {{- if $enableAuth }}
+      volumes:
+        - name: config-users
+          secret:
+            defaultMode: 420
+            {{- if $existingConfigSecret }}
+            secretName: {{ $existingConfigSecret }}
+            {{- else }}
+            secretName: {{ include "seaweedfs.fullname" . }}-s3-secret
+            {{- end }}
+    {{- end }}
+{{- end }}

--- a/platform/seaweedfs/chart/charts/seaweedfs/templates/shared/seaweedfs-grafana-dashboard.yaml
+++ b/platform/seaweedfs/chart/charts/seaweedfs/templates/shared/seaweedfs-grafana-dashboard.yaml
@@ -1,0 +1,20 @@
+{{- include "seaweedfs.compat" . -}}
+{{- if .Values.global.seaweedfs.monitoring.enabled }}
+{{- $files := .Files.Glob "dashboards/*.json" }}
+{{- if $files }}
+{{- range $path, $file := $files }}
+{{- $dashboardName := regexReplaceAll "(^.*/)(.*)\\.json$" $path "${2}" }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "seaweedfs.fullname" $ }}-{{ printf "%s" $dashboardName | lower | replace "_" "-" }}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    grafana_dashboard: "1"
+data:
+  {{ $dashboardName }}.json: |-
+{{ toString $file | indent 4 }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/platform/seaweedfs/chart/charts/seaweedfs/templates/shared/secret-seaweedfs-db.yaml
+++ b/platform/seaweedfs/chart/charts/seaweedfs/templates/shared/secret-seaweedfs-db.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.filer.enabled }}
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: {{ include "seaweedfs.fullname" . }}-db-secret
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/resource-policy": keep
+    "helm.sh/hook": "pre-install"
+  labels:
+    app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+stringData:
+  user: "YourSWUser"
+  # auto-generated password
+  password: {{ randAlphaNum 10 | sha256sum | b64enc | trunc 32 }}
+{{- end }}

--- a/platform/seaweedfs/chart/charts/seaweedfs/templates/shared/service-account.yaml
+++ b/platform/seaweedfs/chart/charts/seaweedfs/templates/shared/service-account.yaml
@@ -1,0 +1,16 @@
+{{- include "seaweedfs.compat" . -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "seaweedfs.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  {{- with .Values.global.seaweedfs.serviceAccountAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+automountServiceAccountToken: {{ .Values.global.seaweedfs.automountServiceAccountToken }}

--- a/platform/seaweedfs/chart/charts/seaweedfs/templates/volume/volume-ingress.yaml
+++ b/platform/seaweedfs/chart/charts/seaweedfs/templates/volume/volume-ingress.yaml
@@ -1,0 +1,56 @@
+{{- /* Volume ingress works for both normal mode (volume.enabled) and all-in-one mode (allInOne.enabled) */}}
+{{- $volumeEnabled := or .Values.volume.enabled .Values.allInOne.enabled }}
+{{- if and $volumeEnabled .Values.volume.ingress.enabled }}
+{{- /* Determine service name based on deployment mode */}}
+{{- $serviceName := ternary (include "seaweedfs.componentName" (list . "all-in-one")) (include "seaweedfs.componentName" (list . "volume")) .Values.allInOne.enabled }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion }}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion }}
+apiVersion: networking.k8s.io/v1beta1
+{{- else }}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: ingress-{{ include "seaweedfs.fullname" . }}-volume
+  namespace: {{ .Release.Namespace }}
+  annotations:
+  {{- if and (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) .Values.volume.ingress.className }}
+    kubernetes.io/ingress.class: {{ .Values.volume.ingress.className }}
+  {{- end }}
+  {{- with .Values.volume.ingress.annotations }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: volume
+spec:
+  {{- if and (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) .Values.volume.ingress.className }}
+  ingressClassName: {{ .Values.volume.ingress.className | quote }}
+  {{- end }}
+  tls:
+    {{ .Values.volume.ingress.tls | default list | toYaml | nindent 6}}
+  rules:
+  - {{- if .Values.volume.ingress.host }}
+    host: {{ .Values.volume.ingress.host | quote }}
+    {{- end }}
+    http:
+      paths:
+      - path: {{ .Values.volume.ingress.path | quote }}
+        {{- if semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion }}
+        pathType: {{ .Values.volume.ingress.pathType | quote }}
+        {{- end }}
+        backend:
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion }}
+          service:
+            name: {{ $serviceName }}
+            port:
+              number: {{ .Values.volume.port }}
+{{- else }}
+          serviceName: {{ $serviceName }}
+          servicePort: {{ .Values.volume.port }}
+{{- end }}
+{{- end }}

--- a/platform/seaweedfs/chart/charts/seaweedfs/templates/volume/volume-resize-hook.yaml
+++ b/platform/seaweedfs/chart/charts/seaweedfs/templates/volume/volume-resize-hook.yaml
@@ -1,0 +1,117 @@
+{{- $seaweedfsName := include "seaweedfs.fullname" $ }}
+{{- $volumes := deepCopy .Values.volumes | mergeOverwrite (dict "" .Values.volume)  }}
+
+
+{{- if .Values.volume.resizeHook.enabled }}
+{{-   $commands := list }}
+{{-   range $vname, $volume := $volumes }}
+{{-     $volumeName := trimSuffix "-" (printf "volume-%s" $vname) }}
+{{-     $volume := mergeOverwrite (deepCopy $.Values.volume) (dict "enabled" true) $volume }}
+
+{{-     if $volume.enabled }}
+{{-       $replicas := int $volume.replicas -}}
+{{-       $statefulsetName := printf "%s-%s" $seaweedfsName $volumeName -}}
+{{-       $statefulset := (lookup "apps/v1" "StatefulSet" $.Release.Namespace $statefulsetName) -}}
+
+{{/*      Check for changes in volumeClaimTemplates */}}
+{{-       if $statefulset }}
+{{-         range $dir := $volume.dataDirs }}
+{{-           if eq .type "persistentVolumeClaim" }}
+{{-             $desiredSize := .size }}
+{{-             range $statefulset.spec.volumeClaimTemplates }}
+{{-               if and (eq .metadata.name $dir.name) (ne .spec.resources.requests.storage $desiredSize) }}
+{{-                 $commands = append $commands (printf "kubectl delete statefulset %s --cascade=orphan" $statefulsetName) }}
+{{-               end }}
+{{-             end }}
+{{-           end }}
+{{-         end }}
+{{-       end }}
+
+{{/*      Check for the need for patching existing PVCs */}}
+{{-       range $dir := $volume.dataDirs }}
+{{-         if eq .type "persistentVolumeClaim" }}
+{{-           $desiredSize := .size }}
+{{-           range $i, $e := until $replicas }}
+{{-             $pvcName := printf "%s-%s-%s-%d" $dir.name $seaweedfsName $volumeName $e }}
+{{-             $currentPVC := (lookup "v1" "PersistentVolumeClaim" $.Release.Namespace $pvcName) }}
+{{-             if and $currentPVC }}
+{{-             $oldSize := include "seaweedfs.resource-quantity" $currentPVC.spec.resources.requests.storage }}
+{{-             $newSize := include "seaweedfs.resource-quantity" $desiredSize }}
+{{-               if gt $newSize $oldSize }}
+{{-               $commands = append $commands (printf "kubectl patch pvc %s-%s-%s-%d -p '{\"spec\":{\"resources\":{\"requests\":{\"storage\":\"%s\"}}}}'" $dir.name $seaweedfsName $volumeName $e $desiredSize) }}
+{{-               end }}
+{{-             end }}
+{{-           end }}
+{{-         end }}
+{{-       end }}
+
+{{-     end }}
+{{-   end }}
+
+{{-   if $commands }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "{{ $seaweedfsName }}-volume-resize-hook"
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "0"
+    helm.sh/hook-delete-policy: hook-succeeded,before-hook-creation
+spec:
+  backoffLimit: 1
+  template:
+    spec:
+      serviceAccountName: {{ $seaweedfsName }}-volume-resize-hook
+      restartPolicy: Never
+      containers:
+        - name: resize
+          image: {{ .Values.volume.resizeHook.image }}
+          command: ["sh", "-xec"]
+          args:
+            - |
+              {{- range $commands }}
+              {{ . }}
+              {{- end }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ $seaweedfsName }}-volume-resize-hook
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "-5"
+    helm.sh/hook-delete-policy: before-hook-creation
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ $seaweedfsName }}-volume-resize-hook
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "-5"
+    helm.sh/hook-delete-policy: before-hook-creation
+rules:
+  - apiGroups: ["apps"]
+    resources: ["statefulsets"]
+    verbs: ["delete", "get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["patch", "get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ $seaweedfsName }}-volume-resize-hook
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "-5"
+    helm.sh/hook-delete-policy: before-hook-creation
+subjects:
+  - kind: ServiceAccount
+    name: {{ $seaweedfsName }}-volume-resize-hook
+roleRef:
+  kind: Role
+  name: {{ $seaweedfsName }}-volume-resize-hook
+  apiGroup: rbac.authorization.k8s.io
+{{-   end }}
+{{- end }}

--- a/platform/seaweedfs/chart/charts/seaweedfs/templates/volume/volume-service.yaml
+++ b/platform/seaweedfs/chart/charts/seaweedfs/templates/volume/volume-service.yaml
@@ -1,0 +1,46 @@
+{{ $volumes := deepCopy .Values.volumes | mergeOverwrite (dict "" .Values.volume)  }}
+{{- range $vname, $volume := $volumes }}
+{{- $volumeName := trimSuffix "-" (printf "volume-%s" $vname) }}
+{{- $volume := mergeOverwrite (deepCopy $.Values.volume) (dict "enabled" true) $volume }}
+
+{{- if $volume.enabled }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "seaweedfs.componentName" (list $ $volumeName) }}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ template "seaweedfs.name" $ }}
+    app.kubernetes.io/instance: {{ $.Release.Name }}
+    app.kubernetes.io/component: {{ $volumeName }}
+    helm.sh/chart: {{ $.Chart.Name }}-{{ $.Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/managed-by: {{ $.Release.Service }}
+{{- if $volume.annotations }}
+  annotations:
+    {{- toYaml $volume.annotations | nindent 4 }}
+{{- end }}
+spec:
+  clusterIP: None
+  internalTrafficPolicy: {{ $volume.internalTrafficPolicy | default "Cluster" }}
+  ports:
+  - name: "swfs-volume"
+    port: {{ $volume.port }}
+    targetPort: {{ $volume.port }}
+    protocol: TCP
+  - name: "swfs-volume-18080"
+    port: {{ $volume.grpcPort }}
+    targetPort: {{ $volume.grpcPort }}
+    protocol: TCP
+{{- if $volume.metricsPort }}
+  - name: "metrics"
+    port: {{ $volume.metricsPort }}
+    targetPort: {{ $volume.metricsPort }}
+    protocol: TCP
+{{- end }}
+  selector:
+    app.kubernetes.io/name: {{ template "seaweedfs.name" $ }}
+    app.kubernetes.io/instance: {{ $.Release.Name }}
+    app.kubernetes.io/component: {{ $volumeName }}
+{{- end }}
+{{- end }}

--- a/platform/seaweedfs/chart/charts/seaweedfs/templates/volume/volume-servicemonitor.yaml
+++ b/platform/seaweedfs/chart/charts/seaweedfs/templates/volume/volume-servicemonitor.yaml
@@ -1,0 +1,42 @@
+{{- include "seaweedfs.compat" . -}}
+{{ $volumes := deepCopy .Values.volumes | mergeOverwrite (dict "" .Values.volume)  }}
+{{- range $vname, $volume := $volumes }}
+{{- $volumeName := trimSuffix "-" (printf "volume-%s" $vname) }}
+{{- $volume := mergeOverwrite (deepCopy $.Values.volume) (dict "enabled" true) $volume }}
+
+{{- if $volume.enabled }}
+{{- if $volume.metricsPort }}
+{{- if $.Values.global.seaweedfs.monitoring.enabled }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "seaweedfs.fullname" $ }}-{{ $volumeName }}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ template "seaweedfs.name" $ }}
+    helm.sh/chart: {{ $.Chart.Name }}-{{ $.Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/managed-by: {{ $.Release.Service }}
+    app.kubernetes.io/instance: {{ $.Release.Name }}
+    app.kubernetes.io/component: {{ $volumeName }}
+    {{- with $.Values.global.seaweedfs.monitoring.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+{{- with $volume.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+{{- end }}
+spec:
+  endpoints:
+    - interval: 30s
+      port: metrics
+      scrapeTimeout: 5s
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ template "seaweedfs.name" $ }}
+      app.kubernetes.io/instance: {{ $.Release.Name }}
+      app.kubernetes.io/component: {{ $volumeName }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/platform/seaweedfs/chart/charts/seaweedfs/templates/volume/volume-statefulset.yaml
+++ b/platform/seaweedfs/chart/charts/seaweedfs/templates/volume/volume-statefulset.yaml
@@ -1,0 +1,416 @@
+{{- include "seaweedfs.compat" . -}}
+{{ $volumes := deepCopy .Values.volumes | mergeOverwrite (dict "" .Values.volume)  }}
+{{- range $vname, $volume := $volumes }}
+{{- $volumeName := trimSuffix "-" (printf "volume-%s" $vname) }}
+{{- $volume := mergeOverwrite (deepCopy $.Values.volume) (dict "enabled" true) $volume }}
+
+{{- if $volume.enabled }}
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "seaweedfs.componentName" (list $ $volumeName) }}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ template "seaweedfs.name" $ }}
+    helm.sh/chart: {{ $.Chart.Name }}-{{ $.Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/managed-by: {{ $.Release.Service }}
+    app.kubernetes.io/instance: {{ $.Release.Name }}
+    app.kubernetes.io/component: {{ $volumeName }}
+{{- if $volume.annotations }}
+  annotations:
+    {{- toYaml $volume.annotations | nindent 4 }}
+{{- end }}
+spec:
+  serviceName: {{ include "seaweedfs.componentName" (list $ $volumeName) }}
+  replicas: {{ $volume.replicas }}
+  podManagementPolicy: {{ $volume.podManagementPolicy }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ template "seaweedfs.name" $ }}
+      app.kubernetes.io/instance: {{ $.Release.Name }}
+      app.kubernetes.io/component: {{ $volumeName }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ template "seaweedfs.name" $ }}
+        helm.sh/chart: {{ $.Chart.Name }}-{{ $.Chart.Version | replace "+" "_" }}
+        app.kubernetes.io/instance: {{ $.Release.Name }}
+        app.kubernetes.io/component: {{ $volumeName }}
+      {{ with $.Values.podLabels }}
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $volume.podLabels }}
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+      annotations:
+      {{ with $.Values.podAnnotations }}
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $volume.podAnnotations }}
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- if $volume.affinity }}
+      affinity:
+        {{ tpl (printf "{{ $volumeName := \"%s\" }}%s" $volumeName $volume.affinity) $ | indent 8 | trim }}
+      {{- end }}
+      {{- if $volume.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{ tpl (printf "{{ $volumeName := \"%s\" }}%s" $volumeName $volume.topologySpreadConstraints) $ | nindent 8 | trim }}
+      {{- end }}
+      restartPolicy: {{ default $.Values.global.seaweedfs.restartPolicy $volume.restartPolicy }}
+      {{- if $volume.tolerations }}
+      tolerations:
+        {{ tpl (printf "{{ $volumeName := \"%s\" }}%s" $volumeName $volume.tolerations) $ | indent 8 | trim }}
+      {{- end }}
+      {{- include "seaweedfs.imagePullSecrets" $ | nindent 6 }}
+      terminationGracePeriodSeconds: 150
+      {{- if $volume.priorityClassName }}
+      priorityClassName: {{ $volume.priorityClassName | quote }}
+      {{- end }}
+      enableServiceLinks: false
+      serviceAccountName: {{ $volume.serviceAccountName | default (include "seaweedfs.serviceAccountName" $) | quote }} # for deleting statefulset pods after migration
+      {{- $initContainers_exists := include "seaweedfs.volume.initContainers_exists" $ -}}
+      {{- if $initContainers_exists }}
+      initContainers:
+        {{- if $volume.idx }}
+        - name: seaweedfs-vol-move-idx
+          image: {{ template "seaweedfs.volume.image" $ }}
+          imagePullPolicy: {{ $.Values.global.seaweedfs.imagePullPolicy | default "IfNotPresent" }}
+          command: [ '/bin/sh', '-c' ]
+          args: [ '{{range $dir :=  $volume.dataDirs }}if ls /{{$dir.name}}/*.idx  >/dev/null 2>&1; then mv /{{$dir.name}}/*.idx /idx/ ; fi; {{end}}' ]
+          volumeMounts:
+            - name: idx
+              mountPath: /idx
+          {{- range $dir :=  $volume.dataDirs }}
+            - name: {{ $dir.name }}
+              mountPath: /{{ $dir.name }}
+          {{- end }}
+          {{- with $volume.idxVolMoveResources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- if $volume.containerSecurityContext.enabled }}
+          securityContext: {{- omit $volume.containerSecurityContext "enabled" | toYaml | nindent 12 }}
+          {{- end }}
+        {{- end }}
+        {{- if $volume.initContainers }}
+        {{ tpl (printf "{{ $volumeName := \"%s\" }}%s" $volumeName $volume.initContainers) $ | indent 8 | trim }}
+        {{- end }}
+      {{- end }}
+      {{- if $volume.podSecurityContext.enabled }}
+      securityContext: {{- omit $volume.podSecurityContext "enabled" | toYaml | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: seaweedfs
+          image: {{ template "seaweedfs.volume.image" $ }}
+          imagePullPolicy: {{ default "IfNotPresent" $.Values.global.seaweedfs.imagePullPolicy }}
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: HOST_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: SEAWEEDFS_FULLNAME
+              value: "{{ include "seaweedfs.fullname" $ }}"
+            {{- $mergedExtraEnvironmentVars := dict }}
+            {{- include "seaweedfs.mergeExtraEnvironmentVars" (dict "global" $.Values.global.seaweedfs "component" $volume "target" $mergedExtraEnvironmentVars) }}
+            {{- range $key := keys $mergedExtraEnvironmentVars | sortAlpha }}
+            {{- $value := index $mergedExtraEnvironmentVars $key }}
+            - name: {{ $key }}
+            {{- if kindIs "string" $value }}
+              value: {{ tpl $value $ | quote }}
+            {{- else }}
+              valueFrom:
+                {{ toYaml $value | nindent 16 | trim }}
+            {{- end -}}
+            {{- end }}
+          command:
+            - "/bin/sh"
+            - "-ec"
+            - |
+              exec /usr/bin/weed \
+                {{- if $volume.logs }}
+                -logdir=/logs \
+                {{- else }}
+                -logtostderr=true \
+                {{- end }}
+                {{- if $volume.loggingOverrideLevel }}
+                -v={{ $volume.loggingOverrideLevel }} \
+                {{- else }}
+                -v={{ $.Values.global.seaweedfs.loggingLevel }} \
+                {{- end }}
+                volume \
+                -port={{ $volume.port }} \
+                {{- if $volume.metricsPort }}
+                -metricsPort={{ $volume.metricsPort }} \
+                {{- end }}
+                {{- if $volume.metricsIp }}
+                -metricsIp={{ $volume.metricsIp }} \
+                {{- end }}
+                -dir {{range $index, $dir :=  $volume.dataDirs }}{{if ne $index 0}},{{end}}/{{$dir.name}}{{end}} \
+                {{- if $volume.idx }}
+                -dir.idx=/idx \
+                {{- end }}
+                -max {{range $index, $dir :=  $volume.dataDirs }}{{if ne $index 0}},{{end}}
+                {{- if eq ($dir.maxVolumes | toString) "0" }}0{{ else if not $dir.maxVolumes }}7{{ else }}{{$dir.maxVolumes}}{{ end }}
+                {{- end }} \
+                {{- if $volume.rack }}
+                -rack={{ $volume.rack }} \
+                {{- end }}
+                {{- if $volume.dataCenter }}
+                -dataCenter={{ $volume.dataCenter }} \
+                {{- end }}
+                {{- if $volume.id }}
+                -id={{ $volume.id }} \
+                {{- end }}
+                -ip.bind={{ $volume.ipBind }} \
+                -readMode={{ $volume.readMode }} \
+                {{- if $volume.whiteList }}
+                -whiteList={{ $volume.whiteList }} \
+                {{- end }}
+                {{- if $volume.imagesFixOrientation }}
+                -images.fix.orientation \
+                {{- end }}
+                {{- if $volume.pulseSeconds }}
+                -pulseSeconds={{ $volume.pulseSeconds }} \
+                {{- end }}
+                {{- if $volume.index }}
+                -index={{ $volume.index }} \
+                {{- end }}
+                {{- if $volume.fileSizeLimitMB }}
+                -fileSizeLimitMB={{ $volume.fileSizeLimitMB }} \
+                {{- end }}
+                -minFreeSpacePercent={{ $volume.minFreeSpacePercent }} \
+                -ip=${POD_NAME}.{{ include "seaweedfs.componentName" (list $ $volumeName) }}.{{ $.Release.Namespace }} \
+                -compactionMBps={{ $volume.compactionMBps }} \
+                -master={{ include "seaweedfs.masterServerArg" $ }} \
+                {{- range $volume.extraArgs }}
+                {{ . }} \
+                {{- end }}
+          volumeMounts:
+            {{- range $dir := $volume.dataDirs }}
+            {{- if not ( eq $dir.type "custom" ) }}
+            - name: {{ $dir.name }}
+              mountPath: "/{{ $dir.name }}/"
+            {{- end }}
+            {{- end }}
+            {{- if $volume.logs }}
+            - name: logs
+              mountPath: "/logs/"
+            {{- end }}
+            {{- if $volume.idx }}
+            - name: idx
+              mountPath: "/idx/"
+            {{- end }}
+            {{- if $.Values.global.seaweedfs.enableSecurity }}
+            - name: security-config
+              readOnly: true
+              mountPath: /etc/seaweedfs/security.toml
+              subPath: security.toml
+            - name: ca-cert
+              readOnly: true
+              mountPath: /usr/local/share/ca-certificates/ca/
+            - name: master-cert
+              readOnly: true
+              mountPath: /usr/local/share/ca-certificates/master/
+            - name: volume-cert
+              readOnly: true
+              mountPath: /usr/local/share/ca-certificates/volume/
+            - name: filer-cert
+              readOnly: true
+              mountPath: /usr/local/share/ca-certificates/filer/
+            - name: client-cert
+              readOnly: true
+              mountPath: /usr/local/share/ca-certificates/client/
+            {{- end }}
+            {{ tpl (printf "{{ $volumeName := \"%s\" }}%s" $volumeName $volume.extraVolumeMounts) $ | indent 12 | trim }}
+          ports:
+            - containerPort: {{ $volume.port }}
+              name: swfs-vol
+            {{- if $volume.metricsPort }}
+            - containerPort: {{ $volume.metricsPort }}
+              name: metrics
+            {{- end }}
+            - containerPort: {{ $volume.grpcPort }}
+              name: swfs-vol-grpc
+          {{- if $volume.readinessProbe.enabled }}
+          readinessProbe:
+            httpGet:
+              path: {{ $volume.readinessProbe.httpGet.path }}
+              port: {{ $volume.port }}
+              scheme: {{ $volume.readinessProbe.httpGet.scheme }}
+            initialDelaySeconds: {{ $volume.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ $volume.readinessProbe.periodSeconds }}
+            successThreshold: {{ $volume.readinessProbe.successThreshold }}
+            failureThreshold: {{ $volume.readinessProbe.failureThreshold }}
+            timeoutSeconds: {{ $volume.readinessProbe.timeoutSeconds }}
+          {{- end }}
+          {{- if $volume.livenessProbe.enabled }}
+          livenessProbe:
+            httpGet:
+              path: {{ $volume.livenessProbe.httpGet.path }}
+              port: {{ $volume.port }}
+              scheme: {{ $volume.livenessProbe.httpGet.scheme }}
+            initialDelaySeconds: {{ $volume.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ $volume.livenessProbe.periodSeconds }}
+            successThreshold: {{ $volume.livenessProbe.successThreshold }}
+            failureThreshold: {{ $volume.livenessProbe.failureThreshold }}
+            timeoutSeconds: {{ $volume.livenessProbe.timeoutSeconds }}
+          {{- end }}
+          {{- with $volume.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- if $volume.containerSecurityContext.enabled }}
+          securityContext: {{- omit $volume.containerSecurityContext "enabled" | toYaml | nindent 12 }}
+          {{- end }}
+      {{- if $volume.sidecars }}
+      {{- include "seaweedfs.tplvalues.render" (dict "value" (printf "{{ $volumeName := \"%s\" }}%s" $volumeName $volume.sidecars) "context" $) | nindent 8 }}
+      {{- end }}
+      volumes:
+
+     {{- range $dir := $volume.dataDirs }}
+
+      {{- if eq $dir.type "hostPath" }}
+        - name: {{ $dir.name }}
+          hostPath:
+            path: {{ $dir.hostPathPrefix }}/object_store/
+            type: DirectoryOrCreate
+      {{- end }}
+      {{- if eq $dir.type "existingClaim" }}
+        - name: {{ $dir.name }}
+          persistentVolumeClaim:
+            claimName: {{ $dir.claimName }}
+      {{- end }}
+      {{- if eq $dir.type "emptyDir" }}
+        - name: {{ $dir.name }}
+          emptyDir: {}
+      {{- end }}
+
+     {{- end }}
+
+     {{- if $volume.idx }}
+       {{- if eq $volume.idx.type "hostPath" }}
+        - name: idx
+          hostPath:
+            path: {{ $volume.idx.hostPathPrefix }}/seaweedfs-volume-idx/
+            type: DirectoryOrCreate
+       {{- end }}
+       {{- if eq $volume.idx.type "existingClaim" }}
+        - name: idx
+          persistentVolumeClaim:
+            claimName: {{ $volume.idx.claimName }}
+       {{- end }}
+       {{- if eq $volume.idx.type "emptyDir" }}
+        - name: idx
+          emptyDir: {}
+       {{- end }}
+     {{- end }}
+
+     {{- if $volume.logs }}
+       {{- if eq $volume.logs.type "hostPath" }}
+        - name: logs
+          hostPath:
+            path: {{ $volume.logs.hostPathPrefix }}/logs/seaweedfs/volume
+            type: DirectoryOrCreate
+       {{- end }}
+       {{- if eq $volume.logs.type "existingClaim" }}
+        - name: logs
+          persistentVolumeClaim:
+            claimName: {{ $volume.logs.claimName }}
+       {{- end }}
+       {{- if eq $volume.logs.type "emptyDir" }}
+        - name: logs
+          emptyDir: {}
+       {{- end }}
+     {{- end }}
+     {{- if $.Values.global.seaweedfs.enableSecurity }}
+        - name: security-config
+          configMap:
+            name: {{ include "seaweedfs.fullname" $ }}-security-config
+        - name: ca-cert
+          secret:
+            secretName: {{ include "seaweedfs.fullname" $ }}-ca-cert
+        - name: master-cert
+          secret:
+            secretName: {{ include "seaweedfs.fullname" $ }}-master-cert
+        - name: volume-cert
+          secret:
+            secretName: {{ include "seaweedfs.fullname" $ }}-volume-cert
+        - name: filer-cert
+          secret:
+            secretName: {{ include "seaweedfs.fullname" $ }}-filer-cert
+        - name: client-cert
+          secret:
+            secretName: {{ include "seaweedfs.fullname" $ }}-client-cert
+      {{- end }}
+      {{- if $volume.extraVolumes }}
+        {{ tpl $volume.extraVolumes $ | indent 8 | trim }}
+      {{- end }}
+      {{- if $volume.nodeSelector }}
+      nodeSelector:
+        {{ tpl (printf "{{ $volumeName := \"%s\" }}%s" $volumeName $volume.nodeSelector) $ | indent 8 | trim }}
+      {{- end }}
+  volumeClaimTemplates:
+    {{- range $dir := $volume.dataDirs }}
+    {{- if eq $dir.type "persistentVolumeClaim" }}
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
+        name: {{ $dir.name }}
+        {{- with $dir.annotations }}
+        annotations:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+      spec:
+        accessModes: [ "ReadWriteOnce" ]
+        storageClassName: {{ $dir.storageClass }}
+        resources:
+          requests:
+            storage: {{ $dir.size }}
+    {{- end }}
+    {{- end }}
+
+    {{- if and $volume.idx (eq $volume.idx.type "persistentVolumeClaim") }}
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
+        name: idx
+        {{- with $volume.idx.annotations }}
+        annotations:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+      spec:
+        accessModes: [ "ReadWriteOnce" ]
+        storageClassName: {{ $volume.idx.storageClass }}
+        resources:
+          requests:
+            storage: {{ $volume.idx.size }}
+    {{- end }}
+    {{- if and $volume.logs (eq $volume.logs.type "persistentVolumeClaim") }}
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
+        name: logs
+        {{- with $volume.logs.annotations }}
+        annotations:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+      spec:
+        accessModes: [ "ReadWriteOnce" ]
+        storageClassName: {{ $volume.logs.storageClass }}
+        resources:
+          requests:
+            storage: {{ $volume.logs.size }}
+    {{- end }}
+{{- end }}
+{{- end }}

--- a/platform/seaweedfs/chart/charts/seaweedfs/templates/worker/worker-deployment.yaml
+++ b/platform/seaweedfs/chart/charts/seaweedfs/templates/worker/worker-deployment.yaml
@@ -1,0 +1,283 @@
+{{- include "seaweedfs.compat" . -}}
+{{- if .Values.worker.enabled }}
+{{- if and (not .Values.worker.adminServer) (not .Values.admin.enabled) }}
+{{- fail "worker.adminServer must be set if admin.enabled is false within the same release" -}}
+{{- end }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "seaweedfs.fullname" . }}-worker
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: worker
+{{- if .Values.worker.annotations }}
+  annotations:
+    {{- toYaml .Values.worker.annotations | nindent 4 }}
+{{- end }}
+spec:
+  replicas: {{ .Values.worker.replicas }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/component: worker
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
+        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/component: worker
+      {{ with .Values.podLabels }}
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.worker.podLabels }}
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+      annotations:
+      {{ with .Values.podAnnotations }}
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.worker.podAnnotations }}
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      restartPolicy: {{ default .Values.global.seaweedfs.restartPolicy .Values.worker.restartPolicy }}
+      {{- if .Values.worker.affinity }}
+      affinity:
+        {{ tpl .Values.worker.affinity . | nindent 8 | trim }}
+      {{- end }}
+      {{- if .Values.worker.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{ tpl .Values.worker.topologySpreadConstraints . | nindent 8 | trim }}
+      {{- end }}
+      {{- if .Values.worker.tolerations }}
+      tolerations:
+        {{ tpl .Values.worker.tolerations . | nindent 8 | trim }}
+      {{- end }}
+      {{- include "seaweedfs.imagePullSecrets" . | nindent 6 }}
+      terminationGracePeriodSeconds: 60
+      {{- if .Values.worker.priorityClassName }}
+      priorityClassName: {{ .Values.worker.priorityClassName | quote }}
+      {{- end }}
+      enableServiceLinks: false
+      {{- if .Values.worker.serviceAccountName }}
+      serviceAccountName: {{ .Values.worker.serviceAccountName | quote }}
+      {{- end }}
+      {{- if .Values.worker.initContainers }}
+      initContainers:
+        {{ tpl .Values.worker.initContainers . | nindent 8 | trim }}
+      {{- end }}
+      {{- if .Values.worker.podSecurityContext.enabled }}
+      securityContext: {{- omit .Values.worker.podSecurityContext "enabled" | toYaml | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: seaweedfs
+          image: {{ template "seaweedfs.worker.image" . }}
+          imagePullPolicy: {{ default "IfNotPresent" .Values.global.seaweedfs.imagePullPolicy }}
+          env:
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: SEAWEEDFS_FULLNAME
+              value: "{{ include "seaweedfs.fullname" . }}"
+            {{- $mergedExtraEnvironmentVars := dict }}
+            {{- include "seaweedfs.mergeExtraEnvironmentVars" (dict "global" .Values.global.seaweedfs "component" .Values.worker "target" $mergedExtraEnvironmentVars) }}
+            {{- range $key := keys $mergedExtraEnvironmentVars | sortAlpha }}
+            {{- $value := index $mergedExtraEnvironmentVars $key }}
+            - name: {{ $key }}
+            {{- if kindIs "string" $value }}
+              value: {{ tpl $value $ | quote }}
+            {{- else }}
+              valueFrom:
+                {{ toYaml $value | nindent 16 | trim }}
+            {{- end -}}
+            {{- end }}
+          command:
+            - "/bin/sh"
+            - "-ec"
+            - |
+              exec /usr/bin/weed \
+              {{- if or (eq .Values.worker.logs.type "hostPath") (eq .Values.worker.logs.type "emptyDir") (eq .Values.worker.logs.type "existingClaim") }}
+              -logdir=/logs \
+              {{- else }}
+              -logtostderr=true \
+              {{- end }}
+              {{- if .Values.worker.loggingOverrideLevel }}
+              -v={{ .Values.worker.loggingOverrideLevel }} \
+              {{- else }}
+              -v={{ .Values.global.seaweedfs.loggingLevel }} \
+              {{- end }}
+              worker \
+              {{- if .Values.worker.adminServer }}
+              -admin={{ .Values.worker.adminServer }} \
+              {{- else }}
+              -admin={{ template "seaweedfs.fullname" . }}-admin.{{ .Release.Namespace }}:{{ .Values.admin.port }}{{ if .Values.admin.grpcPort }}.{{ .Values.admin.grpcPort }}{{ end }} \
+              {{- end }}
+              -jobType={{ .Values.worker.jobType }} \
+              -maxDetect={{ .Values.worker.maxDetect }} \
+              -maxExecute={{ .Values.worker.maxExecute }} \
+              -workingDir={{ .Values.worker.workingDir }}{{- if or .Values.worker.metricsPort .Values.worker.metricsIp .Values.worker.extraArgs }} \{{ end }}
+              {{- if .Values.worker.metricsPort }}
+              -metricsPort={{ .Values.worker.metricsPort }}{{- if or .Values.worker.metricsIp .Values.worker.extraArgs }} \{{ end }}
+              {{- end }}
+              {{- if .Values.worker.metricsIp }}
+              -metricsIp={{ .Values.worker.metricsIp }}{{- if .Values.worker.extraArgs }} \{{ end }}
+              {{- end }}
+              {{- range $index, $arg := .Values.worker.extraArgs }}
+              {{ $arg }}{{- if lt $index (sub (len $.Values.worker.extraArgs) 1) }} \{{ end }}
+              {{- end }}
+          volumeMounts:
+            {{- if or (eq .Values.worker.data.type "hostPath") (eq .Values.worker.data.type "emptyDir") (eq .Values.worker.data.type "existingClaim") }}
+            - name: worker-data
+              mountPath: {{ .Values.worker.workingDir }}
+            {{- end }}
+            {{- if or (eq .Values.worker.logs.type "hostPath") (eq .Values.worker.logs.type "emptyDir") (eq .Values.worker.logs.type "existingClaim") }}
+            - name: worker-logs
+              mountPath: /logs
+            {{- end }}
+            {{- if .Values.global.seaweedfs.enableSecurity }}
+            - name: security-config
+              readOnly: true
+              mountPath: /etc/seaweedfs/security.toml
+              subPath: security.toml
+            - name: ca-cert
+              readOnly: true
+              mountPath: /usr/local/share/ca-certificates/ca/
+            - name: master-cert
+              readOnly: true
+              mountPath: /usr/local/share/ca-certificates/master/
+            - name: volume-cert
+              readOnly: true
+              mountPath: /usr/local/share/ca-certificates/volume/
+            - name: filer-cert
+              readOnly: true
+              mountPath: /usr/local/share/ca-certificates/filer/
+            - name: client-cert
+              readOnly: true
+              mountPath: /usr/local/share/ca-certificates/client/
+            - name: worker-cert
+              readOnly: true
+              mountPath: /usr/local/share/ca-certificates/worker/
+            {{- end }}
+            {{ tpl .Values.worker.extraVolumeMounts . | nindent 12 | trim }}
+          ports:
+            {{- if .Values.worker.metricsPort }}
+            - containerPort: {{ .Values.worker.metricsPort }}
+              name: metrics
+            {{- end }}
+          {{- with .Values.worker.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- if .Values.worker.livenessProbe.enabled }}
+          livenessProbe:
+            {{- if .Values.worker.livenessProbe.httpGet }}
+            httpGet:
+              path: {{ .Values.worker.livenessProbe.httpGet.path }}
+              port: {{ .Values.worker.livenessProbe.httpGet.port }}
+            {{- else if .Values.worker.livenessProbe.tcpSocket }}
+            tcpSocket:
+              port: {{ .Values.worker.livenessProbe.tcpSocket.port }}
+            {{- end }}
+            initialDelaySeconds: {{ .Values.worker.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.worker.livenessProbe.periodSeconds }}
+            successThreshold: {{ .Values.worker.livenessProbe.successThreshold }}
+            failureThreshold: {{ .Values.worker.livenessProbe.failureThreshold }}
+            timeoutSeconds: {{ .Values.worker.livenessProbe.timeoutSeconds }}
+          {{- end }}
+          {{- if .Values.worker.readinessProbe.enabled }}
+          readinessProbe:
+            {{- if .Values.worker.readinessProbe.httpGet }}
+            httpGet:
+              path: {{ .Values.worker.readinessProbe.httpGet.path }}
+              port: {{ .Values.worker.readinessProbe.httpGet.port }}
+            {{- else if .Values.worker.readinessProbe.tcpSocket }}
+            tcpSocket:
+              port: {{ .Values.worker.readinessProbe.tcpSocket.port }}
+            {{- end }}
+            initialDelaySeconds: {{ .Values.worker.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.worker.readinessProbe.periodSeconds }}
+            successThreshold: {{ .Values.worker.readinessProbe.successThreshold }}
+            failureThreshold: {{ .Values.worker.readinessProbe.failureThreshold }}
+            timeoutSeconds: {{ .Values.worker.readinessProbe.timeoutSeconds }}
+          {{- end }}
+          {{- if .Values.worker.containerSecurityContext.enabled }}
+          securityContext: {{- omit .Values.worker.containerSecurityContext "enabled" | toYaml | nindent 12 }}
+          {{- end }}
+      {{- if .Values.worker.sidecars }}
+      {{- include "seaweedfs.tplvalues.render" (dict "value" .Values.worker.sidecars "context" $) | nindent 8 }}
+      {{- end }}
+      volumes:
+        {{- if eq .Values.worker.data.type "hostPath" }}
+        - name: worker-data
+          hostPath:
+            path: {{ .Values.worker.data.hostPathPrefix }}/seaweedfs-worker-data
+            type: DirectoryOrCreate
+        {{- end }}
+        {{- if eq .Values.worker.data.type "emptyDir" }}
+        - name: worker-data
+          emptyDir: {}
+        {{- end }}
+        {{- if eq .Values.worker.data.type "existingClaim" }}
+        - name: worker-data
+          persistentVolumeClaim:
+            claimName: {{ .Values.worker.data.claimName }}
+        {{- end }}
+        {{- if eq .Values.worker.logs.type "hostPath" }}
+        - name: worker-logs
+          hostPath:
+            path: {{ .Values.worker.logs.hostPathPrefix }}/logs/seaweedfs/worker
+            type: DirectoryOrCreate
+        {{- end }}
+        {{- if eq .Values.worker.logs.type "emptyDir" }}
+        - name: worker-logs
+          emptyDir: {}
+        {{- end }}
+        {{- if eq .Values.worker.logs.type "existingClaim" }}
+        - name: worker-logs
+          persistentVolumeClaim:
+            claimName: {{ .Values.worker.logs.claimName }}
+        {{- end }}
+        {{- if .Values.global.seaweedfs.enableSecurity }}
+        - name: security-config
+          configMap:
+            name: {{ include "seaweedfs.fullname" . }}-security-config
+        - name: ca-cert
+          secret:
+            secretName: {{ include "seaweedfs.fullname" . }}-ca-cert
+        - name: master-cert
+          secret:
+            secretName: {{ include "seaweedfs.fullname" . }}-master-cert
+        - name: volume-cert
+          secret:
+            secretName: {{ include "seaweedfs.fullname" . }}-volume-cert
+        - name: filer-cert
+          secret:
+            secretName: {{ include "seaweedfs.fullname" . }}-filer-cert
+        - name: client-cert
+          secret:
+            secretName: {{ include "seaweedfs.fullname" . }}-client-cert
+        - name: worker-cert
+          secret:
+            secretName: {{ include "seaweedfs.fullname" . }}-worker-cert
+        {{- end }}
+        {{ tpl .Values.worker.extraVolumes . | indent 8 | trim }}
+      {{- if .Values.worker.nodeSelector }}
+      nodeSelector:
+        {{ tpl .Values.worker.nodeSelector . | indent 8 | trim }}
+      {{- end }}
+{{- end }}

--- a/platform/seaweedfs/chart/charts/seaweedfs/templates/worker/worker-service.yaml
+++ b/platform/seaweedfs/chart/charts/seaweedfs/templates/worker/worker-service.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.worker.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "seaweedfs.componentName" (list . "worker") }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: worker
+spec:
+  clusterIP: None  # Headless service
+  {{- if .Values.worker.metricsPort }}
+  ports:
+  - name: "metrics"
+    port: {{ .Values.worker.metricsPort }}
+    targetPort: {{ .Values.worker.metricsPort }}
+    protocol: TCP
+  {{- end }}
+  selector:
+    app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: worker
+{{- end }}

--- a/platform/seaweedfs/chart/charts/seaweedfs/templates/worker/worker-servicemonitor.yaml
+++ b/platform/seaweedfs/chart/charts/seaweedfs/templates/worker/worker-servicemonitor.yaml
@@ -1,0 +1,35 @@
+{{- include "seaweedfs.compat" . -}}
+{{- if .Values.worker.enabled }}
+{{- if .Values.worker.metricsPort }}
+{{- if .Values.global.seaweedfs.monitoring.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "seaweedfs.fullname" . }}-worker
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: worker
+    {{- with .Values.global.seaweedfs.monitoring.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+{{- with .Values.worker.serviceMonitor.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+{{- end }}
+spec:
+  endpoints:
+    - interval: 30s
+      port: metrics
+      scrapeTimeout: 5s
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/component: worker
+{{- end }}
+{{- end }}
+{{- end }}

--- a/platform/seaweedfs/chart/charts/seaweedfs/values.yaml
+++ b/platform/seaweedfs/chart/charts/seaweedfs/values.yaml
@@ -1,0 +1,1727 @@
+# Available parameters and their default values for the SeaweedFS chart.
+
+global:
+  # global.imageRegistry and global.imagePullSecrets are standard Helm conventions
+  # shared across subcharts. See https://helm.sh/docs/chart_template_guide/subcharts_and_globals/
+  imageRegistry: ""
+  imagePullSecrets: ""
+  # All app-specific global values are namespaced under global.seaweedfs
+  # to avoid polluting the shared global namespace when used as a subchart.
+  seaweedfs:
+    createClusterRole: true
+    image:
+      # if repository is set, it overrides the namespace part of image.name
+      repository: ""
+      name: chrislusf/seaweedfs
+    imagePullPolicy: IfNotPresent
+    restartPolicy: Always
+    loggingLevel: 1
+    enableSecurity: false
+    masterServer: null
+    securityConfig:
+      jwtSigning:
+        volumeWrite: true
+        volumeRead: false
+        filerWrite: false
+        filerRead: false
+    # we will use this serviceAccountName for all ClusterRoles/ClusterRoleBindings
+    serviceAccountName: "seaweedfs"
+    serviceAccountAnnotations: {}
+    automountServiceAccountToken: true
+    certificates:
+      duration: 87600h
+      renewBefore: 720h
+      alphacrds: false
+    monitoring:
+      enabled: false
+      gatewayHost: null
+      gatewayPort: null
+      additionalLabels: {}
+    # if enabled will use global.seaweedfs.replicationPlacement and override master & filer defaultReplicaPlacement config
+    enableReplication: false
+    #  replication type is XYZ:
+    # X number of replica in other data centers
+    # Y number of replica in other racks in the same data center
+    # Z number of replica in other servers in the same rack
+    replicationPlacement: "001"
+    extraEnvironmentVars:
+      WEED_CLUSTER_DEFAULT: "sw"
+      WEED_CLUSTER_SW_MASTER: "{{ include \"seaweedfs.cluster.masterAddress\" . }}"
+      WEED_CLUSTER_SW_FILER: "{{ include \"seaweedfs.cluster.filerAddress\" . }}"
+      # WEED_JWT_SIGNING_KEY:
+      #   secretKeyRef:
+      #     name: seaweedfs-signing-key
+      #     key: signingKey
+
+image:
+  registry: ""
+  repository: ""
+  tag: ""
+
+master:
+  enabled: true
+  imageOverride: null
+  restartPolicy: null
+  replicas: 1
+  port: 9333
+  grpcPort: 19333
+  metricsPort: 9327
+  metricsIp: ""  # Metrics listen IP. If empty, defaults to ipBind
+  ipBind: "0.0.0.0"
+  volumePreallocate: false
+  volumeSizeLimitMB: 1000
+  loggingOverrideLevel: null
+  # threshold to vacuum and reclaim spaces, default 0.3 (30%)
+  garbageThreshold: null
+  # Prometheus push interval in seconds, default 15
+  metricsIntervalSec: 15
+  #  replication type is XYZ:
+  # X number of replica in other data centers
+  # Y number of replica in other racks in the same data center
+  # Z number of replica in other servers in the same rack
+  defaultReplication: "000"
+
+  # Disable http request, only gRpc operations are allowed
+  disableHttp: false
+
+  # Resume previous state on start master server
+  resumeState: false
+  # Use Hashicorp Raft
+  raftHashicorp: false
+  # Whether to bootstrap the Raft cluster. Only use it when use Hashicorp Raft
+  raftBootstrap: false
+
+  # election timeout of master servers
+  electionTimeout: "10s"
+  # heartbeat interval of master servers, and will be randomly multiplied by [1, 1.25)
+  heartbeatInterval: "300ms"
+
+  # Custom command line arguments to add to the master command
+  # Example to fix IPv6 metrics connectivity issues:
+  # extraArgs: ["-metricsIp", "0.0.0.0"]
+  # Example with multiple args:
+  # extraArgs: ["-customFlag", "value", "-anotherFlag"]
+  extraArgs: []
+
+  config: |-
+    # Enter any extra configuration for master.toml here.
+    # It may be a multi-line string.
+
+  # You may use ANY storage-class, example with local-path-provisioner
+  # Annotations are optional.
+  #  data:
+  #    type: "persistentVolumeClaim"
+  #    size: "24Ti"
+  #    storageClass: "local-path-provisioner"
+  #    annotations:
+  #      "key": "value"
+  #
+  # You may also spacify an existing claim:
+  #  data:
+  #    type: "existingClaim"
+  #    claimName: "my-pvc"
+  #
+  # You can also use emptyDir storage:
+  #  data:
+  #    type: "emptyDir"
+  data:
+    type: "hostPath"
+    storageClass: ""
+    hostPathPrefix: /ssd
+
+  # You may use ANY storage-class, example with local-path-provisioner
+  # Annotations are optional.
+  # logs:
+  #   type: "persistentVolumeClaim"
+  #   size: "24Ti"
+  #   storageClass: "local-path-provisioner"
+  #   annotations:
+  #     "key": "value"
+
+  # You can also use emptyDir storage:
+  #  logs:
+  #    type: "emptyDir"
+  logs:
+    type: "hostPath"
+    size: ""
+    storageClass: ""
+    hostPathPrefix: /storage
+
+  ## @param master.sidecars Add additional sidecar containers to the master pod(s)
+  ## e.g:
+  ## sidecars:
+  ##   - name: your-image-name
+  ##     image: your-image
+  ##     imagePullPolicy: Always
+  ##     ports:
+  ##       - name: portname
+  ##         containerPort: 1234
+  ##
+  sidecars: []
+  initContainers: ""
+
+  extraVolumes: ""
+  extraVolumeMounts: ""
+
+  # Labels to be added to the master pods
+  podLabels: {}
+
+  # Annotations to be added to the master pods
+  podAnnotations: {}
+
+  # Annotations to be added to the master resources
+  annotations: {}
+
+  ## Set podManagementPolicy
+  podManagementPolicy: Parallel
+
+  # Resource requests, limits, etc. for the master cluster placement. This
+  # should map directly to the value of the resources field for a PodSpec,
+  # formatted as a multi-line string. By default no direct resource request
+  # is made.
+  resources: {}
+
+  # updatePartition is used to control a careful rolling update of SeaweedFS
+  # masters.
+  updatePartition: 0
+
+  # Affinity Settings
+  # Commenting out or setting as empty the affinity variable, will allow
+  # deployment to single node services such as Minikube
+  affinity: |
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
+              app.kubernetes.io/instance: {{ .Release.Name }}
+              app.kubernetes.io/component: master
+          topologyKey: kubernetes.io/hostname
+
+  # Topology Spread Constraints Settings
+  # This should map directly to the value of the topologySpreadConstraints
+  # for a PodSpec. By Default no constraints are set.
+  topologySpreadConstraints: ""
+
+  # Toleration Settings for master pods
+  # This should be a multi-line string matching the Toleration array
+  # in a PodSpec.
+  tolerations: ""
+
+  # nodeSelector labels for master pod assignment, formatted as a muli-line string.
+  # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
+  # Example:
+  nodeSelector: ""
+  # nodeSelector: |
+  #   sw-backend: "true"
+
+  # used to assign priority to master pods
+  # ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
+  priorityClassName: ""
+
+  # used to assign a service account.
+  # ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+  serviceAccountName: ""
+
+  # Configure security context for Pod
+  # ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+  # Example:
+  # podSecurityContext:
+  #   enabled: true
+  #   runAsUser: 1000
+  #   runAsGroup: 3000
+  #   fsGroup: 2000
+  podSecurityContext: {}
+
+  # Configure security context for Container
+  # ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+  # Example:
+  # containerSecurityContext:
+  #   enabled: true
+  #   runAsUser: 2000
+  #   allowPrivilegeEscalation: false
+  containerSecurityContext: {}
+
+  ingress:
+    enabled: false
+    className: ""
+    # host: false for "*" hostname
+    host: "master.seaweedfs.local"
+    path: "/sw-master/?(.*)"
+    pathType: ImplementationSpecific
+    annotations: {}
+      # nginx.ingress.kubernetes.io/auth-type: "basic"
+      # nginx.ingress.kubernetes.io/auth-secret: "default/ingress-basic-auth-secret"
+      # nginx.ingress.kubernetes.io/auth-realm: 'Authentication Required - SW-Master'
+      # nginx.ingress.kubernetes.io/service-upstream: "true"
+      # nginx.ingress.kubernetes.io/rewrite-target: /$1
+      # nginx.ingress.kubernetes.io/use-regex: "true"
+      # nginx.ingress.kubernetes.io/enable-rewrite-log: "true"
+      # nginx.ingress.kubernetes.io/ssl-redirect: "false"
+      # nginx.ingress.kubernetes.io/force-ssl-redirect: "false"
+      # nginx.ingress.kubernetes.io/configuration-snippet: |
+      #   sub_filter '<head>' '<head> <base href="/sw-master/">'; #add base url
+      #   sub_filter '="/' '="./';                                #make absolute paths to relative
+      #   sub_filter '=/' '=./';
+      #   sub_filter '/seaweedfsstatic' './seaweedfsstatic';
+      #   sub_filter_once off;
+    tls: []
+
+  extraEnvironmentVars:
+    WEED_MASTER_VOLUME_GROWTH_COPY_1: "7"
+    WEED_MASTER_VOLUME_GROWTH_COPY_2: "6"
+    WEED_MASTER_VOLUME_GROWTH_COPY_3: "3"
+    WEED_MASTER_VOLUME_GROWTH_COPY_OTHER: "1"
+
+  # used to configure livenessProbe on master-server containers
+  #
+  livenessProbe:
+    enabled: true
+    httpGet:
+      path: /cluster/status
+      scheme: HTTP
+    initialDelaySeconds: 20
+    periodSeconds: 30
+    successThreshold: 1
+    failureThreshold: 4
+    timeoutSeconds: 10
+
+  # used to configure readinessProbe on master-server containers
+  #
+  readinessProbe:
+    enabled: true
+    httpGet:
+      path: /cluster/status
+      scheme: HTTP
+    initialDelaySeconds: 10
+    periodSeconds: 45
+    successThreshold: 2
+    failureThreshold: 100
+    timeoutSeconds: 10
+
+volume:
+  enabled: true
+  imageOverride: null
+  restartPolicy: null
+  port: 8080
+  grpcPort: 18080
+  metricsPort: 9327
+  metricsIp: ""  # Metrics listen IP. If empty, defaults to ipBind
+  ipBind: "0.0.0.0"
+  replicas: 1
+  loggingOverrideLevel: null
+  # number of seconds between heartbeats, must be smaller than or equal to the master's setting
+  pulseSeconds: null
+  # Choose [memory|leveldb|leveldbMedium|leveldbLarge] mode for memory~performance balance., default memory
+  index: null
+  # limit file size to avoid out of memory, default 256mb
+  fileSizeLimitMB: null
+  # minimum free disk space(in percents). If free disk space lower this value - all volumes marks as ReadOnly
+  minFreeSpacePercent: 1
+
+  # Custom command line arguments to add to the volume command
+  # Example to fix IPv6 metrics connectivity issues:
+  # extraArgs: ["-metricsIp", "0.0.0.0"]
+  # Example with multiple args:
+  # extraArgs: ["-customFlag", "value", "-anotherFlag"]
+  extraArgs: []
+
+  # For each data disk you may use ANY storage-class, example with local-path-provisioner
+  # Annotations are optional.
+  #  dataDirs:
+  #   - name: data
+  #     type: "persistentVolumeClaim"
+  #     size: "24Ti"
+  #     storageClass: "local-path-provisioner"
+  #     annotations:
+  #      "key": "value"
+  #     maxVolumes: 0  # If set to zero on non-windows OS, the limit will be auto configured. (default "7")
+  #
+  # You may also spacify an existing claim:
+  #   - name: data
+  #     type: "existingClaim"
+  #     claimName: "my-pvc"
+  #     maxVolumes: 0  # If set to zero on non-windows OS, the limit will be auto configured. (default "7")
+  #
+  # You can also use emptyDir storage:
+  #   - name: data
+  #     type: "emptyDir"
+  #     maxVolumes: 0  # If set to zero on non-windows OS, the limit will be auto configured. (default "7")
+  #
+  # If these don't meet your needs, you can use "custom" here along with extraVolumes and extraVolumeMounts
+  # Particularly useful when using more than 1 for the volume server replicas.
+  #   - name: data
+  #     type: "custom"
+  #     maxVolumes: 0  # If set to zero on non-windows OS, the limit will be auto configured. (default "7")
+
+  dataDirs:
+    - name: data1
+      type: "hostPath"
+      hostPathPrefix: /ssd
+      maxVolumes: 0
+
+      # - name: data2
+      #   type: "persistentVolumeClaim"
+      #   storageClass: "yourClassNameOfChoice"
+      #   size: "800Gi"
+      #   maxVolumes: 0
+
+  # This will automatically create a job for patching Kubernetes resources if the dataDirs type is 'persistentVolumeClaim' and the size has changed.
+  resizeHook:
+    enabled: true
+    image: alpine/k8s:1.28.4
+
+  # idx can be defined by:
+  #
+  # idx:
+  #  type: "hostPath"
+  #  hostPathPrefix: /ssd
+  #
+  # or
+  #
+  # idx:
+  #  type: "persistentVolumeClaim"
+  #  size: "20Gi"
+  #  storageClass: "local-path-provisioner"
+  #
+  # or
+  #
+  # idx:
+  #   type: "existingClaim"
+  #   claimName: "myClaim"
+  #
+  # or
+  #
+  # idx:
+  #  type: "emptyDir"
+
+  # same applies to "logs"
+
+  idx: {}
+
+  # Resource requests, limits, etc. for the vol-move-idx initContainer. This
+  # should map directly to the value of the resources field for a PodSpec,
+  # formatted as a multi-line string. By default no direct resource request
+  # is made.
+  idxVolMoveResources: {}
+
+  logs: {}
+
+  # limit background compaction or copying speed in mega bytes per second
+  compactionMBps: "50"
+
+  # Volume server's rack name
+  rack: null
+
+  # Stable identifier for the volume server, independent of IP address
+  # Useful for Kubernetes environments with hostPath volumes to maintain stable identity
+  id: null
+
+  # Volume server's data center name
+  dataCenter: null
+
+  # Redirect moved or non-local volumes. (default proxy)
+  readMode: proxy
+
+  # Comma separated Ip addresses having write permission. No limit if empty.
+  whiteList: null
+
+  # Adjust jpg orientation when uploading.
+  imagesFixOrientation: false
+
+  ## @param volume.sidecars Add additional sidecar containers to the volume pod(s)
+  ## e.g:
+  ## sidecars:
+  ##   - name: your-image-name
+  ##     image: your-image
+  ##     imagePullPolicy: Always
+  ##     ports:
+  ##       - name: portname
+  ##         containerPort: 1234
+  ##
+  sidecars: []
+  initContainers: ""
+
+  # Example for use when using more than 1 volume server replica
+  # extraVolumeMounts: |
+  #   - name: drive
+  #     mountPath: /drive
+  #     subPathExpr: $(POD_NAME)
+  # extraVolumes: |
+  #   - name: drive
+  #     hostPath:
+  #       path: /var/mnt/
+  extraVolumes: ""
+  extraVolumeMounts: ""
+
+  # Labels to be added to the volume pods
+  podLabels: {}
+
+  # Annotations to be added to the volume pods
+  podAnnotations: {}
+
+  # Annotations to be added to the volume resources
+  annotations: {}
+
+  ## Set podManagementPolicy
+  podManagementPolicy: Parallel
+
+  # Affinity Settings
+  # Commenting out or setting as empty the affinity variable, will allow
+  # deployment to single node services such as Minikube
+  affinity: |
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
+              app.kubernetes.io/instance: {{ .Release.Name }}
+              app.kubernetes.io/component: {{ $volumeName }}
+          topologyKey: kubernetes.io/hostname
+
+  # Topology Spread Constraints Settings
+  # This should map directly to the value of the topologySpreadConstraints
+  # for a PodSpec. By Default no constraints are set.
+  topologySpreadConstraints: ""
+
+  # Resource requests, limits, etc. for the server cluster placement. This
+  # should map directly to the value of the resources field for a PodSpec,
+  # formatted as a multi-line string. By default no direct resource request
+  # is made.
+  resources: {}
+
+  # Toleration Settings for server pods
+  # This should be a multi-line string matching the Toleration array
+  # in a PodSpec.
+  tolerations: ""
+
+  # nodeSelector labels for server pod assignment, formatted as a muli-line string.
+  # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
+  # Example:
+  nodeSelector: ""
+  # nodeSelector: |
+  #   sw-volume: "true"
+
+  # used to assign priority to server pods
+  # ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
+  priorityClassName: ""
+
+  # used to assign a service account.
+  # ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+  serviceAccountName: ""
+
+  extraEnvironmentVars:
+
+  # Configure security context for Pod
+  # ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+  # Example:
+  # podSecurityContext:
+  #   enabled: true
+  #   runAsUser: 1000
+  #   runAsGroup: 3000
+  #   fsGroup: 2000
+  podSecurityContext: {}
+
+  # Configure security context for Container
+  # ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+  # Example:
+  # containerSecurityContext:
+  #   enabled: true
+  #   runAsUser: 2000
+  #   allowPrivilegeEscalation: false
+  containerSecurityContext: {}
+
+  # used to configure livenessProbe on volume-server containers
+  #
+  livenessProbe:
+    enabled: true
+    httpGet:
+      path: /healthz
+      scheme: HTTP
+    initialDelaySeconds: 20
+    periodSeconds: 90
+    successThreshold: 1
+    failureThreshold: 4
+    timeoutSeconds: 30
+
+  # used to configure readinessProbe on volume-server containers
+  #
+  readinessProbe:
+    enabled: true
+    httpGet:
+      path: /healthz
+      scheme: HTTP
+    initialDelaySeconds: 15
+    periodSeconds: 15
+    successThreshold: 1
+    failureThreshold: 100
+    timeoutSeconds: 30
+
+  ingress:
+    enabled: false
+    className: ""
+    host: "volume.seaweedfs.local"
+    path: "/"
+    pathType: Prefix
+    annotations:
+      nginx.ingress.kubernetes.io/app-root: /ui/index.html
+      # nginx.ingress.kubernetes.io/use-regex: "true"
+      # nginx.ingress.kubernetes.io/rewrite-target: /$1
+      # nginx.ingress.kubernetes.io/auth-type: "basic"
+      # nginx.ingress.kubernetes.io/auth-secret: "default/ingress-basic-auth-secret"
+      # nginx.ingress.kubernetes.io/auth-realm: 'Authentication Required - SW-Volume'
+      # nginx.ingress.kubernetes.io/service-upstream: "true"
+      # nginx.ingress.kubernetes.io/enable-rewrite-log: "true"
+      # nginx.ingress.kubernetes.io/ssl-redirect: "false"
+      # nginx.ingress.kubernetes.io/force-ssl-redirect: "false"
+      # nginx.ingress.kubernetes.io/configuration-snippet: |
+      #   sub_filter '<head>' '<head> <base href="/sw-volume/">'; #add base url
+      #   sub_filter '="/' '="./';                               #make absolute paths to relative
+      #   sub_filter '=/' '=./';
+      #   sub_filter '/seaweedfsstatic' './seaweedfsstatic';
+      #   sub_filter_once off;
+
+# Map of named volume groups for topology-aware deployments.
+# Each key inherits all fields from the `volume` section but can override
+# them locally—for example, replicas, nodeSelector, dataCenter, etc.
+# To switch entirely to this scheme, set `volume.enabled: false`
+# and define one entry per zone/data-center under `volumes`.
+#
+# volumes:
+#   dc1:
+#     replicas: 2
+#     dataCenter: "dc1"
+#     nodeSelector: |
+#      topology.kubernetes.io/zone: dc1
+#   dc2:
+#     replicas: 2
+#     dataCenter: "dc2"
+#     nodeSelector: |
+#      topology.kubernetes.io/zone: dc2
+#   dc3:
+#     replicas: 2
+#     dataCenter: "dc3"
+#     nodeSelector: |
+#      topology.kubernetes.io/zone: dc3
+#
+volumes: {}
+
+filer:
+  enabled: true
+  imageOverride: null
+  restartPolicy: null
+  replicas: 1
+  port: 8888
+  grpcPort: 18888
+  metricsPort: 9327
+  metricsIp: ""  # Metrics listen IP. If empty, defaults to ipBind
+  ipBind: "0.0.0.0"  # IP address to bind to. Set to 0.0.0.0 to allow external traffic
+  loggingOverrideLevel: null
+  filerGroup: ""
+  # prefer to read and write to volumes in this data center (not set by default)
+  dataCenter: null
+  # prefer to write to volumes in this rack (not set by default)
+  rack: null
+  #  replication type is XYZ:
+  # X number of replica in other data centers
+  # Y number of replica in other racks in the same data center
+  # Z number of replica in other servers in the same rack
+  defaultReplicaPlacement: "000"
+  # turn off directory listing
+  disableDirListing: false
+  # split files larger than the limit, default 32
+  maxMB: null
+  # encrypt data on volume servers
+  encryptVolumeData: false
+
+  # Whether proxy or redirect to volume server during file GET request
+  redirectOnRead: false
+
+  # Limit sub dir listing size (default 100000)
+  dirListLimit: 100000
+
+  # Disable http request, only gRpc operations are allowed
+  disableHttp: false
+
+  # Custom command line arguments to add to the filer command
+  # Example to fix IPv6 metrics connectivity issues:
+  # extraArgs: ["-metricsIp", "0.0.0.0"]
+  # Example with multiple args:
+  # extraArgs: ["-customFlag", "value", "-anotherFlag"]
+  extraArgs: []
+
+  # Add a custom notification.toml to configure filer notifications
+  # Example:
+  # notificationConfig: |-
+  #   [notification.kafka]
+  #   enabled = false
+  #   hosts = [
+  #       "localhost:9092"
+  #   ]
+  #   topic = "seaweedfs_filer"
+  #   offsetFile = "./last.offset"
+  #   offsetSaveIntervalSeconds = 10
+  notificationConfig: ""
+
+  # DEPRECATE: enablePVC, storage, storageClass
+  # Consider replacing with filer.data section below instead.
+
+  # Settings for configuring stateful storage of filer pods.
+  # enablePVC will create a pvc for filer for data persistence.
+  enablePVC: false
+  # storage should be set to the disk size of the attached volume.
+  storage: 25Gi
+  # storageClass is the class of storage which defaults to null (the Kube cluster will pick the default).
+  storageClass: null
+  # You may use ANY storage-class, example with local-path-provisioner
+  # Annotations are optional.
+  #  data:
+  #    type: "persistentVolumeClaim"
+  #    size: "24Ti"
+  #    storageClass: "local-path-provisioner"
+  #    annotations:
+  #      "key": "value"
+  #
+  # You may also specify an existing claim:
+  #  data:
+  #    type: "existingClaim"
+  #    claimName: "my-pvc"
+  #
+  # You can also use emptyDir storage:
+  #  data:
+  #    type: "emptyDir"
+  data:
+    type: "hostPath"
+    size: ""
+    storageClass: ""
+    hostPathPrefix: /storage
+
+  # You may use ANY storage-class, example with local-path-provisioner
+  # Annotations are optional.
+  # logs:
+  #   type: "persistentVolumeClaim"
+  #   size: "24Ti"
+  #   storageClass: "local-path-provisioner"
+  #   annotations:
+  #     "key": "value"
+
+  # You can also use emptyDir storage:
+  #  logs:
+  #    type: "emptyDir"
+  logs:
+    type: "hostPath"
+    size: ""
+    storageClass: ""
+    hostPathPrefix: /storage
+
+  ## @param filer.sidecars Add additional sidecar containers to the filer pod(s)
+  ## e.g:
+  ## sidecars:
+  ##   - name: your-image-name
+  ##     image: your-image
+  ##     imagePullPolicy: Always
+  ##     ports:
+  ##       - name: portname
+  ##         containerPort: 1234
+  ##
+  sidecars: []
+  initContainers: ""
+
+  extraVolumes: ""
+  extraVolumeMounts: ""
+
+  # Labels to be added to the filer pods
+  podLabels: {}
+
+  # Annotations to be added to the filer pods
+  podAnnotations: {}
+
+  # Annotations to be added to the filer resource
+  annotations: {}
+
+  ## Set podManagementPolicy
+  podManagementPolicy: Parallel
+
+  # Affinity Settings
+  # Commenting out or setting as empty the affinity variable, will allow
+  # deployment to single node services such as Minikube
+  affinity: |
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
+              app.kubernetes.io/instance: {{ .Release.Name }}
+              app.kubernetes.io/component: filer
+          topologyKey: kubernetes.io/hostname
+
+  # Topology Spread Constraints Settings
+  # This should map directly to the value of the topologySpreadConstraints
+  # for a PodSpec. By Default no constraints are set.
+  topologySpreadConstraints: ""
+
+  # updatePartition is used to control a careful rolling update of SeaweedFS
+  # masters.
+  updatePartition: 0
+
+  # Resource requests, limits, etc. for the server cluster placement. This
+  # should map directly to the value of the resources field for a PodSpec,
+  # formatted as a multi-line string. By default no direct resource request
+  # is made.
+  resources: {}
+
+  # Toleration Settings for server pods
+  # This should be a multi-line string matching the Toleration array
+  # in a PodSpec.
+  tolerations: ""
+
+  # nodeSelector labels for server pod assignment, formatted as a muli-line string.
+  # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
+  # Example:
+  nodeSelector: ""
+  # nodeSelector: |
+  #   sw-backend: "true"
+
+  # used to assign priority to server pods
+  # ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
+  priorityClassName: ""
+
+  # used to assign a service account.
+  # ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+  serviceAccountName: ""
+
+  # Configure security context for Pod
+  # ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+  # Example:
+  # podSecurityContext:
+  #   enabled: true
+  #   runAsUser: 1000
+  #   runAsGroup: 3000
+  #   fsGroup: 2000
+  podSecurityContext: {}
+
+  # Configure security context for Container
+  # ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+  # Example:
+  # containerSecurityContext:
+  #   enabled: true
+  #   runAsUser: 2000
+  #   allowPrivilegeEscalation: false
+  containerSecurityContext: {}
+
+  ingress:
+    enabled: false
+    className: ""
+    # host: false for "*" hostname
+    host: "seaweedfs.cluster.local"
+    path: "/sw-filer/?(.*)"
+    pathType: ImplementationSpecific
+    annotations: {}
+      # nginx.ingress.kubernetes.io/backend-protocol: GRPC
+      # nginx.ingress.kubernetes.io/auth-type: "basic"
+      # nginx.ingress.kubernetes.io/auth-secret: "default/ingress-basic-auth-secret"
+      # nginx.ingress.kubernetes.io/auth-realm: 'Authentication Required - SW-Filer'
+      # nginx.ingress.kubernetes.io/service-upstream: "true"
+      # nginx.ingress.kubernetes.io/rewrite-target: /$1
+      # nginx.ingress.kubernetes.io/use-regex: "true"
+      # nginx.ingress.kubernetes.io/enable-rewrite-log: "true"
+      # nginx.ingress.kubernetes.io/ssl-redirect: "false"
+      # nginx.ingress.kubernetes.io/force-ssl-redirect: "false"
+      # nginx.ingress.kubernetes.io/configuration-snippet: |
+      #   sub_filter '<head>' '<head> <base href="/sw-filer/">'; #add base url
+      #   sub_filter '="/' '="./';                               #make absolute paths to relative
+      #   sub_filter '=/' '=./';
+      #   sub_filter '/seaweedfsstatic' './seaweedfsstatic';
+      #   sub_filter_once off;
+
+  # extraEnvVars is a list of extra environment variables to set with the stateful set.
+  extraEnvironmentVars:
+    WEED_MYSQL_ENABLED: "false"
+    WEED_MYSQL_HOSTNAME: "mysql-db-host"
+    WEED_MYSQL_PORT: "3306"
+    WEED_MYSQL_DATABASE: "sw_database"
+    WEED_MYSQL_CONNECTION_MAX_IDLE: "5"
+    WEED_MYSQL_CONNECTION_MAX_OPEN: "75"
+    # "refresh" connection every 10 minutes, eliminating mysql closing "old" connections
+    WEED_MYSQL_CONNECTION_MAX_LIFETIME_SECONDS: "600"
+    # enable usage of memsql as filer backend
+    WEED_MYSQL_INTERPOLATEPARAMS: "true"
+    # if you want to use leveldb2, then should enable "enablePVC". or you may lose your data.
+    WEED_LEVELDB2_ENABLED: "true"
+    # with http DELETE, by default the filer would check whether a folder is empty.
+    # recursive_delete will delete all sub folders and files, similar to "rm -Rf"
+    WEED_FILER_OPTIONS_RECURSIVE_DELETE: "false"
+    # directories under this folder will be automatically creating a separate bucket
+    WEED_FILER_BUCKETS_FOLDER: "/buckets"
+
+  # used to configure livenessProbe on filer containers
+  #
+  livenessProbe:
+    enabled: true
+    httpGet:
+      path: /
+      scheme: HTTP
+    initialDelaySeconds: 20
+    periodSeconds: 30
+    successThreshold: 1
+    failureThreshold: 5
+    timeoutSeconds: 10
+
+  # used to configure readinessProbe on filer containers
+  #
+  readinessProbe:
+    enabled: true
+    httpGet:
+      path: /
+      scheme: HTTP
+    initialDelaySeconds: 10
+    periodSeconds: 15
+    successThreshold: 1
+    failureThreshold: 100
+    timeoutSeconds: 10
+
+  # secret env variables
+  secretExtraEnvironmentVars: {}
+    # WEED_POSTGRES_USERNAME:
+    #   secretKeyRef:
+    #     name: postgres-credentials
+    #     key: username
+    # WEED_POSTGRES_PASSWORD:
+    #   secretKeyRef:
+    #     name: postgres-credentials
+    #     key: password
+
+  s3:
+    enabled: false
+    port: 8333
+    # add additional https port
+    httpsPort: 0
+    # Suffix of the host name, {bucket}.{domainName}
+    domainName: ""
+    # enable user & permission to s3 (need to inject to all services)
+    enableAuth: false
+    # set to the name of an existing kubernetes Secret with the s3 json config file
+    # should have a secret key called seaweedfs_s3_config with an inline json configure
+    existingConfigSecret: null
+    # To provide explicit credentials for the S3 gateway, set them under
+    # the top-level s3.credentials key (not filer.s3.credentials).
+    # The s3-secret.yaml template only reads from .Values.s3.credentials.
+    # See: s3.credentials.admin.accessKey, s3.credentials.read.accessKey
+    auditLogConfig: {}
+    # You may specify buckets to be created during the install or upgrade process.
+    # Buckets may be exposed publicly by setting `anonymousRead` to `true`
+    # ttl format: [1-255][m|h|d|w|M|y] (e.g., 7d)
+    # objectLock enables S3 Object Lock (irreversible, forces versioning)
+    # versioning: Enabled or Suspended (or true to enable)
+    # createBuckets:
+    #   - name: bucket-a
+    #     anonymousRead: true
+    #     ttl: 7d
+    #     objectLock: true
+    #     versioning: Enabled
+    #   - name: bucket-b
+    #     anonymousRead: false
+    createBucketsHook:
+      resources: {}
+
+s3:
+  enabled: false
+  imageOverride: null
+  restartPolicy: null
+  replicas: 1
+  bindAddress: 0.0.0.0
+  port: 8333
+  # add additional https port
+  httpsPort: 0
+  # Use a custom TLS certificate secret for the S3 HTTPS endpoint.
+  # When set, this Kubernetes Secret (must contain tls.crt and tls.key) is used
+  # instead of the internal self-signed client certificate generated by cert-manager.
+  # This allows using a publicly trusted certificate (e.g., from Let's Encrypt)
+  # so that S3 clients don't need to trust the internal CA.
+  # Requires global.seaweedfs.enableSecurity to be true.
+  tlsSecret: null
+  metricsPort: 9327
+  # Iceberg catalog REST port (Apache Iceberg REST Catalog API)
+  # Set to a port number to enable, or 0/null to disable
+  icebergPort: null
+  loggingOverrideLevel: null
+  # enable user & permission to s3 (need to inject to all services)
+  enableAuth: false
+  # set to the name of an existing kubernetes Secret with the s3 json config file
+  # should have a secret key called seaweedfs_s3_config with an inline json config
+  existingConfigSecret: null
+  # Optionally provide explicit credentials for the S3 gateway.
+  # When set, these are used in the generated s3 secret instead of
+  # auto-generating random credentials.
+  # credentials:
+  #   admin:
+  #     accessKey: ""
+  #     secretKey: ""
+  #   read:
+  #     accessKey: ""
+  #     secretKey: ""
+  auditLogConfig: {}
+  # You may specify buckets to be created during the install or upgrade process.
+  # Buckets may be exposed publicly by setting `anonymousRead` to `true`
+  # ttl format: [1-255][m|h|d|w|M|y] (e.g., 7d)
+  # objectLock enables S3 Object Lock (irreversible, forces versioning)
+  # versioning: Enabled or Suspended (or true to enable)
+  # createBuckets:
+  #   - name: bucket-a
+  #     anonymousRead: true
+  #     ttl: 7d
+  #     objectLock: true
+  #     versioning: Enabled
+  #   - name: bucket-b
+  #     anonymousRead: false
+
+  # Suffix of the host name, {bucket}.{domainName}
+  domainName: ""
+
+  ## @param s3.sidecars Add additional sidecar containers to the s3 pod(s)
+  ## e.g:
+  ## sidecars:
+  ##   - name: your-image-name
+  ##     image: your-image
+  ##     imagePullPolicy: Always
+  ##     ports:
+  ##       - name: portname
+  ##         containerPort: 1234
+  ##
+  sidecars: []
+  initContainers: ""
+
+  extraVolumes: ""
+  extraVolumeMounts: ""
+
+  # Labels to be added to the s3 pods
+  podLabels: {}
+
+  # Annotations to be added to the s3 pods
+  podAnnotations: {}
+
+  # Annotations to be added to the s3 resources
+  annotations: {}
+
+  # Resource requests, limits, etc. for the server cluster placement. This
+  # should map directly to the value of the resources field for a PodSpec,
+  # formatted as a multi-line string. By default no direct resource request
+  # is made.
+  resources: {}
+
+  # Toleration Settings for server pods
+  # This should be a multi-line string matching the Toleration array
+  # in a PodSpec.
+  tolerations: ""
+
+  # nodeSelector labels for server pod assignment, formatted as a muli-line string.
+  # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
+  # Example:
+  nodeSelector: ""
+  # nodeSelector: |
+  #   sw-backend: "true"
+
+  # used to assign priority to server pods
+  # ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
+  priorityClassName: ""
+
+  # used to assign a service account.
+  # ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+  serviceAccountName: ""
+
+  # Configure security context for Pod
+  # ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+  # Example:
+  # podSecurityContext:
+  #   enabled: true
+  #   runAsUser: 1000
+  #   runAsGroup: 3000
+  #   fsGroup: 2000
+  podSecurityContext: {}
+
+  # Configure security context for Container
+  # ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+  # Example:
+  # containerSecurityContext:
+  #   enabled: true
+  #   runAsUser: 2000
+  #   allowPrivilegeEscalation: false
+  containerSecurityContext: {}
+
+  # You can also use emptyDir storage:
+  #  logs:
+  #    type: "emptyDir"
+  logs:
+    type: "hostPath"
+    size: ""
+    storageClass: ""
+    hostPathPrefix: /storage
+
+  extraEnvironmentVars:
+
+  # Custom command line arguments to add to the s3 command
+  # Default idleTimeout is 120 seconds. Example to customize:
+  # extraArgs: ["-idleTimeout=300"]
+  extraArgs: []
+
+  # used to configure livenessProbe on s3 containers
+  #
+  livenessProbe:
+    enabled: true
+    httpGet:
+      path: /status
+      scheme: HTTP
+    initialDelaySeconds: 20
+    periodSeconds: 60
+    successThreshold: 1
+    failureThreshold: 20
+    timeoutSeconds: 10
+
+  # used to configure readinessProbe on s3 containers
+  #
+  readinessProbe:
+    enabled: true
+    httpGet:
+      path: /status
+      scheme: HTTP
+    initialDelaySeconds: 15
+    periodSeconds: 15
+    successThreshold: 1
+    failureThreshold: 100
+    timeoutSeconds: 10
+
+  createBucketsHook:
+    resources: {}
+
+  ingress:
+    enabled: false
+    className: ""
+    # host: false for "*" hostname, or an array for multiple hostnames
+    host: "seaweedfs.cluster.local"
+    path: "/"
+    pathType: Prefix
+    # additional ingress annotations for the s3 endpoint
+    annotations: {}
+    tls: []
+
+  # Service settings
+  service:
+    type: ClusterIP
+
+  icebergIngress:
+    enabled: false
+    className: ""
+    host: "seaweedfs-iceberg.cluster.local"
+    path: "/"
+    pathType: Prefix
+    annotations: {}
+    tls: []
+
+sftp:
+  enabled: false
+  imageOverride: null
+  restartPolicy: null
+  replicas: 1
+  bindAddress: 0.0.0.0
+  port: 2022  # Default SFTP port
+  metricsPort: 9327
+  metricsIp: ""  # If empty, defaults to bindAddress
+  loggingOverrideLevel: null
+
+  # SSH server configuration
+  sshPrivateKey: "/etc/sw/seaweedfs_sftp_ssh_private_key"  # Path to the SSH private key file for host authentication
+  hostKeysFolder: "/etc/sw/ssh"  # path to folder containing SSH private key files for host authentication
+  authMethods: "password,publickey"  # Comma-separated list of allowed auth methods: password, publickey, keyboard-interactive
+  maxAuthTries: 6  # Maximum number of authentication attempts per connection
+  bannerMessage: "SeaweedFS SFTP Server"  # Message displayed before authentication
+  loginGraceTime: "2m"  # Timeout for authentication
+  clientAliveInterval: "5s"  # Interval for sending keep-alive messages
+  clientAliveCountMax: 3  # Maximum number of missed keep-alive messages before disconnecting
+  dataCenter: ""  # Prefer to read and write to volumes in this data center
+  localSocket: ""  # Default to /tmp/seaweedfs-sftp-<port>.sock
+
+  # User authentication
+  enableAuth: false
+  # Set to the name of an existing kubernetes Secret with the sftp json config file
+  # Should have a secret key called seaweedfs_sftp_config with an inline json config
+  existingConfigSecret: null
+  # Set to the name of an existing kubernetes Secret with the list of ssh private keys for sftp
+  existingSshConfigSecret: null
+
+  # Additional resources
+  sidecars: []
+  initContainers: ""
+  extraVolumes: ""
+  extraVolumeMounts: ""
+  podLabels: {}
+  podAnnotations: {}
+  annotations: {}
+  resources: {}
+  tolerations: ""
+  nodeSelector: ""
+  priorityClassName: ""
+  serviceAccountName: ""
+  podSecurityContext: {}
+  containerSecurityContext: {}
+
+  logs:
+    type: "hostPath"
+    hostPathPrefix: /storage
+
+  extraEnvironmentVars: {}
+
+  # Health checks
+  # Health checks for SFTP - using tcpSocket instead of httpGet
+  livenessProbe:
+    enabled: true
+    initialDelaySeconds: 20
+    periodSeconds: 60
+    successThreshold: 1
+    failureThreshold: 20
+    timeoutSeconds: 10
+
+  # Health checks for SFTP - using tcpSocket instead of httpGet
+  readinessProbe:
+    enabled: true
+    initialDelaySeconds: 15
+    periodSeconds: 15
+    successThreshold: 1
+    failureThreshold: 100
+    timeoutSeconds: 10
+
+  # Service settings
+  service:
+    type: ClusterIP
+
+admin:
+  enabled: false
+  imageOverride: null
+  restartPolicy: null
+  replicas: 1
+  port: 23646  # Default admin port
+  grpcPort: 33646  # Default gRPC port for worker connections
+  loggingOverrideLevel: null
+
+  # Admin authentication
+  secret:
+    # Name of an existing secret containing admin credentials. If set, adminUser and adminPassword below are ignored.
+    existingSecret: ""
+    # Key in the existing secret for the admin username. Required if existingSecret is set.
+    userKey: ""
+    # Key in the existing secret for the admin password. Required if existingSecret is set.
+    pwKey: ""
+    adminUser: "admin"
+    adminPassword: ""  # If empty, authentication is disabled.
+
+  # Data directory for admin configuration and maintenance data
+  dataDir: ""  # If empty, configuration is kept in memory only
+
+  # Master servers to connect to
+  # If empty, uses global.seaweedfs.masterServer or auto-discovers from master statefulset
+  masters: ""
+
+  # URL path prefix when running behind a reverse proxy under a subdirectory
+  # Example: "/seaweedfs-admin" makes the UI available at /seaweedfs-admin/
+  # If empty and ingress is enabled with a non-root path, the ingress path is used automatically
+  urlPrefix: ""
+
+  # Custom command line arguments to add to the admin command
+  # Example: ["-customFlag", "value", "-anotherFlag"]
+  extraArgs: []
+
+  # Storage configuration
+  data:
+    type: "emptyDir"  # Options: "hostPath", "persistentVolumeClaim", "emptyDir", "existingClaim"
+    size: "10Gi"
+    storageClass: ""
+    hostPathPrefix: /storage
+    claimName: ""
+    annotations: {}
+
+  logs:
+    type: "emptyDir"  # Options: "hostPath", "persistentVolumeClaim", "emptyDir", "existingClaim"
+    size: "5Gi"
+    storageClass: ""
+    hostPathPrefix: /storage
+    claimName: ""
+    annotations: {}
+
+  # Additional resources
+  sidecars: []
+  initContainers: ""
+  extraVolumes: ""
+  extraVolumeMounts: ""
+  podLabels: {}
+  podAnnotations: {}
+  annotations: {}
+
+  ## Set podManagementPolicy
+  podManagementPolicy: Parallel
+
+  # Affinity Settings
+  # Commenting out or setting as empty the affinity variable, will allow
+  # deployment to single node services such as Minikube
+  affinity: |
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
+              app.kubernetes.io/instance: {{ .Release.Name }}
+              app.kubernetes.io/component: admin
+          topologyKey: kubernetes.io/hostname
+
+  # Topology Spread Constraints Settings
+  # This should map directly to the value of the topologySpreadConstraints
+  # for a PodSpec. By Default no constraints are set.
+  topologySpreadConstraints: ""
+
+  resources: {}
+  tolerations: ""
+  nodeSelector: ""
+  priorityClassName: ""
+  serviceAccountName: ""
+  podSecurityContext: {}
+  containerSecurityContext: {}
+
+  extraEnvironmentVars: {}
+
+  # Health checks
+  livenessProbe:
+    enabled: true
+    httpGet:
+      path: /health
+      scheme: HTTP
+    initialDelaySeconds: 20
+    periodSeconds: 60
+    successThreshold: 1
+    failureThreshold: 5
+    timeoutSeconds: 10
+
+  readinessProbe:
+    enabled: true
+    httpGet:
+      path: /health
+      scheme: HTTP
+    initialDelaySeconds: 15
+    periodSeconds: 15
+    successThreshold: 1
+    failureThreshold: 3
+    timeoutSeconds: 10
+
+  ingress:
+    enabled: false
+    className: "nginx"
+    # host: false for "*" hostname
+    host: "admin.seaweedfs.local"
+    path: "/"
+    pathType: Prefix
+    annotations: {}
+    tls: []
+
+  service:
+    type: ClusterIP
+    annotations: {}
+
+  # ServiceMonitor annotations (separate from pod/deployment annotations)
+  serviceMonitor:
+    annotations: {}
+
+worker:
+  enabled: false
+  imageOverride: null
+  restartPolicy: null
+  replicas: 1
+  loggingOverrideLevel: null
+  metricsPort: 9327
+  metricsIp: ""  # If empty, defaults to 0.0.0.0
+
+  # Admin server to connect to
+  adminServer: ""
+
+  # Worker job types - categories or comma-separated list of names/aliases
+  # Categories: all, default, heavy
+  #   default: vacuum, volume_balance, ec_balance, admin_script
+  #   heavy: erasure_coding, iceberg_maintenance
+  #   all: every registered job type
+  # Examples: "all", "default", "heavy", "default,iceberg" (default+iceberg), "vacuum,volume_balance"
+  # Refer: https://github.com/seaweedfs/seaweedfs/wiki/Worker
+  jobType: "all"
+
+  # Maximum number of concurrent detection requests
+  maxDetect: 1
+
+  # Maximum number of concurrent execution jobs
+  maxExecute: 4
+
+  # Working directory for task execution
+  workingDir: "/tmp/seaweedfs-worker"
+
+  # Custom command line arguments to add to the worker command
+  # Example: ["-customFlag", "value", "-anotherFlag"]
+  extraArgs: []
+
+  # Storage configuration for working directory
+  # Note: Workers use Deployment, so use "emptyDir", "hostPath", or "existingClaim"
+  # Do NOT use "persistentVolumeClaim" - use "existingClaim" with pre-provisioned PVC instead
+  data:
+    type: "emptyDir"  # Options: "hostPath", "emptyDir", "existingClaim"
+    hostPathPrefix: /storage
+    claimName: ""  # For existingClaim type
+
+  logs:
+    type: "emptyDir"  # Options: "hostPath", "emptyDir", "existingClaim"
+    hostPathPrefix: /storage
+    claimName: ""  # For existingClaim type
+
+  # Additional resources
+  sidecars: []
+  initContainers: ""
+  extraVolumes: ""
+  extraVolumeMounts: ""
+  podLabels: {}
+  podAnnotations: {}
+  annotations: {}
+
+  # Affinity Settings
+  # Commenting out or setting as empty the affinity variable, will allow
+  # deployment to single node services such as Minikube
+  affinity: |
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
+              app.kubernetes.io/instance: {{ .Release.Name }}
+              app.kubernetes.io/component: worker
+          topologyKey: kubernetes.io/hostname
+
+  # Topology Spread Constraints Settings
+  # This should map directly to the value of the topologySpreadConstraints
+  # for a PodSpec. By Default no constraints are set.
+  topologySpreadConstraints: ""
+
+  resources:
+    requests:
+      cpu: "500m"
+      memory: "512Mi"
+    limits:
+      cpu: "2"
+      memory: "2Gi"
+  tolerations: ""
+  nodeSelector: ""
+  priorityClassName: ""
+  serviceAccountName: ""
+  podSecurityContext: {}
+  containerSecurityContext: {}
+
+  extraEnvironmentVars: {}
+
+  # Health checks for worker pods
+  # Workers expose /health (liveness) and /ready (readiness) endpoints on the metricsPort
+  livenessProbe:
+    enabled: true
+    httpGet:
+      path: /health
+      port: metrics
+    initialDelaySeconds: 30
+    periodSeconds: 60
+    successThreshold: 1
+    failureThreshold: 5
+    timeoutSeconds: 10
+
+  readinessProbe:
+    enabled: true
+    httpGet:
+      path: /ready
+      port: metrics
+    initialDelaySeconds: 20
+    periodSeconds: 15
+    successThreshold: 1
+    failureThreshold: 3
+    timeoutSeconds: 10
+
+  # ServiceMonitor annotations (separate from pod/deployment annotations)
+  serviceMonitor:
+    annotations: {}
+
+# All-in-one deployment configuration
+allInOne:
+  enabled: false
+  imageOverride: null
+  restartPolicy: Always
+  replicas: 1  # Number of replicas (note: multiple replicas may require shared storage)
+
+  # Core configuration
+  idleTimeout: 30  # Connection idle seconds
+  dataCenter: ""  # Current volume server's data center name
+  rack: ""  # Current volume server's rack name
+  whiteList: ""  # Comma separated IP addresses having write permission
+  disableHttp: false  # Disable HTTP requests, only gRPC operations are allowed
+  metricsPort: 9324  # Prometheus metrics listen port
+  metricsIp: ""  # Metrics listen IP. If empty, defaults to bindAddress
+  loggingOverrideLevel: null  # Override logging level
+
+  # Custom command line arguments to add to the server command
+  # Example to fix IPv6 metrics connectivity issues:
+  # extraArgs: ["-metricsIp", "0.0.0.0"]
+  # Example with multiple args:
+  # extraArgs: ["-customFlag", "value", "-anotherFlag"]
+  extraArgs: []
+
+  # Update strategy configuration
+  # type: Recreate or RollingUpdate
+  # For single replica, Recreate is recommended to avoid data conflicts.
+  # For multiple replicas with RollingUpdate, you MUST use shared storage
+  # (e.g., data.type: persistentVolumeClaim with ReadWriteMany access mode)
+  # to avoid data loss or inconsistency between pods.
+  updateStrategy:
+    type: Recreate
+
+  # S3 gateway configuration
+  # Note: Most parameters below default to null, which means they inherit from
+  # the global s3.* settings. Set explicit values here to override for allInOne only.
+  s3:
+    enabled: false  # Whether to enable S3 gateway
+    port: null  # S3 gateway port (null inherits from s3.port)
+    httpsPort: null  # S3 gateway HTTPS port (null inherits from s3.httpsPort)
+    domainName: null  # Suffix of the host name (null inherits from s3.domainName)
+    enableAuth: false  # Enable user & permission to S3
+    # Set to the name of an existing kubernetes Secret with the s3 json config file
+    # should have a secret key called seaweedfs_s3_config with an inline json config
+    existingConfigSecret: null
+    # To provide explicit credentials for the S3 gateway, set them under
+    # the top-level s3.credentials key (not allInOne.s3.credentials).
+    # The s3-secret.yaml template only reads from .Values.s3.credentials.
+    # See: s3.credentials.admin.accessKey, s3.credentials.read.accessKey
+    auditLogConfig: null  # S3 audit log configuration (null inherits from s3.auditLogConfig)
+    trafficDistribution: null  # Service traffic distribution (e.g., "PreferClose"); auto-converts to "PreferSameZone" on k8s >=1.35
+    # You may specify buckets to be created during the install process.
+    # Buckets may be exposed publicly by setting `anonymousRead` to `true`
+    # ttl format: [1-255][m|h|d|w|M|y] (e.g., 7d)
+    # objectLock enables S3 Object Lock (irreversible, forces versioning)
+    # versioning: Enabled or Suspended (or true to enable)
+    # createBuckets:
+    #   - name: bucket-a
+    #     anonymousRead: true
+    #     ttl: 7d
+    #     objectLock: true
+    #     versioning: Enabled
+    #   - name: bucket-b
+    #     anonymousRead: false
+    createBucketsHook:
+      resources: {}
+
+  # SFTP server configuration
+  # Note: Most parameters below default to null, which means they inherit from
+  # the global sftp.* settings. Set explicit values here to override for allInOne only.
+  sftp:
+    enabled: false  # Whether to enable SFTP server
+    port: null  # SFTP port (null inherits from sftp.port)
+    sshPrivateKey: null  # Path to SSH private key (null inherits from sftp.sshPrivateKey)
+    hostKeysFolder: null  # Path to SSH host keys folder (null inherits from sftp.hostKeysFolder)
+    authMethods: null  # Comma-separated auth methods (null inherits from sftp.authMethods)
+    maxAuthTries: null  # Maximum authentication attempts (null inherits from sftp.maxAuthTries)
+    bannerMessage: null  # Banner message (null inherits from sftp.bannerMessage)
+    loginGraceTime: null  # Login grace time (null inherits from sftp.loginGraceTime)
+    clientAliveInterval: null  # Client keep-alive interval (null inherits from sftp.clientAliveInterval)
+    clientAliveCountMax: null  # Maximum missed keep-alive messages (null inherits from sftp.clientAliveCountMax)
+    enableAuth: false  # Enable SFTP authentication
+    # Set to the name of an existing kubernetes Secret with the sftp json config file
+    existingConfigSecret: null
+    # Set to the name of an existing kubernetes Secret with the SSH keys
+    existingSshConfigSecret: null
+
+  # Service settings
+  service:
+    annotations: {}  # Annotations for the service
+    type: ClusterIP  # Service type (ClusterIP, NodePort, LoadBalancer)
+    internalTrafficPolicy: Cluster  # Internal traffic policy
+
+  # Note: For ingress in all-in-one mode, use the standard s3.ingress and
+  # filer.ingress settings. The templates automatically detect all-in-one mode
+  # and point to the correct service (seaweedfs-all-in-one instead of
+  # seaweedfs-s3 or seaweedfs-filer).
+
+  # Storage configuration
+  data:
+    type: "emptyDir"  # Options: "hostPath", "persistentVolumeClaim", "emptyDir", "existingClaim"
+    hostPathPrefix: /mnt/data  # Path prefix for hostPath volumes
+    claimName: seaweedfs-data-pvc  # Name of the PVC to use (for existingClaim type)
+    size: null  # Size of the PVC (null defaults to 10Gi for persistentVolumeClaim type)
+    storageClass: null  # Storage class for the PVC (null uses cluster default)
+    # accessModes for the PVC. Default is ["ReadWriteOnce"].
+    # For multi-replica deployments, use ["ReadWriteMany"] with a compatible storage class.
+    accessModes: []
+    annotations: {}  # Annotations for the PVC
+
+  # Health checks
+  readinessProbe:
+    enabled: true
+    httpGet:
+      path: /cluster/status
+      port: 9333
+      scheme: HTTP
+    initialDelaySeconds: 10
+    periodSeconds: 15
+    successThreshold: 1
+    failureThreshold: 3
+    timeoutSeconds: 5
+
+  livenessProbe:
+    enabled: true
+    httpGet:
+      path: /cluster/status
+      port: 9333
+      scheme: HTTP
+    initialDelaySeconds: 20
+    periodSeconds: 30
+    successThreshold: 1
+    failureThreshold: 5
+    timeoutSeconds: 5
+
+  # Additional resources
+  extraEnvironmentVars: {}  # Additional environment variables
+  # Secret environment variables (for database credentials, etc.)
+  # Example:
+  # secretExtraEnvironmentVars:
+  #   WEED_POSTGRES_USERNAME:
+  #     secretKeyRef:
+  #       name: postgres-credentials
+  #       key: username
+  #   WEED_POSTGRES_PASSWORD:
+  #     secretKeyRef:
+  #       name: postgres-credentials
+  #       key: password
+  secretExtraEnvironmentVars: {}
+  extraVolumeMounts: ""  # Additional volume mounts
+  extraVolumes: ""  # Additional volumes
+  initContainers: ""  # Init containers
+  sidecars: ""  # Sidecar containers
+  annotations: {}  # Annotations for the deployment
+  podAnnotations: {}  # Annotations for the pods
+  podLabels: {}  # Labels for the pods
+
+  # Scheduling configuration
+  # Affinity Settings
+  # Commenting out or setting as empty the affinity variable, will allow
+  # deployment to single node services such as Minikube
+  affinity: |
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
+              app.kubernetes.io/instance: {{ .Release.Name }}
+              app.kubernetes.io/component: seaweedfs-all-in-one
+          topologyKey: kubernetes.io/hostname
+
+  # Topology Spread Constraints Settings
+  # This should map directly to the value of the topologySpreadConstraints
+  # for a PodSpec. By Default no constraints are set.
+  topologySpreadConstraints: ""
+
+  # Toleration Settings for pods
+  # This should be a multi-line string matching the Toleration array
+  # in a PodSpec.
+  tolerations: ""
+
+  # nodeSelector labels for pod assignment, formatted as a muli-line string.
+  # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
+  nodeSelector: ""
+
+  # Used to assign priority to pods
+  # ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
+  priorityClassName: ""
+
+  # Used to assign a service account.
+  # ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+  serviceAccountName: ""
+
+  # Configure security context for Pod
+  # ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+  # Example:
+  # podSecurityContext:
+  #   enabled: true
+  #   runAsUser: 1000
+  #   runAsGroup: 3000
+  #   fsGroup: 2000
+  podSecurityContext: {}
+
+  # Configure security context for Container
+  # ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+  # Example:
+  # containerSecurityContext:
+  #   enabled: true
+  #   runAsUser: 2000
+  #   allowPrivilegeEscalation: false
+  containerSecurityContext: {}
+
+  # Resource management
+  resources:
+    limits:
+      cpu: "2"
+      memory: "2Gi"
+    requests:
+      cpu: "500m"
+      memory: "1Gi"
+
+# Deploy Kubernetes COSI Driver for SeaweedFS
+# Requires COSI CRDs and controller to be installed in the cluster
+# For more information, visit: https://container-object-storage-interface.github.io/docs/deployment-guide
+cosi:
+  enabled: false
+  image: "ghcr.io/seaweedfs/seaweedfs-cosi-driver:v0.1.2"
+  driverName: "seaweedfs.objectstorage.k8s.io"
+  bucketClassName: "seaweedfs"
+  # Optional parameters to pass to the default BucketClass (e.g., diskType for tiered storage)
+  bucketClassParameters: {}
+  endpoint: ""
+  region: ""
+
+  sidecar:
+    image: gcr.io/k8s-staging-sig-storage/objectstorage-sidecar:v20250711-controllerv0.2.0-rc1-80-gc2f6e65
+    # Resource requests, limits, etc. for the server cluster placement. This
+    # should map directly to the value of the resources field for a PodSpec,
+    # formatted as a multi-line string. By default no direct resource request
+    # is made.
+    resources: {}
+
+  # enable user & permission to s3 (need to inject to all services)
+  enableAuth: false
+  # set to the name of an existing kubernetes Secret with the s3 json config file
+  # should have a secret key called seaweedfs_s3_config with an inline json configure
+  existingConfigSecret: null
+
+  podSecurityContext: {}
+  containerSecurityContext: {}
+
+  extraVolumes: ""
+  extraVolumeMounts: ""
+
+  # Resource requests, limits, etc. for the server cluster placement. This
+  # should map directly to the value of the resources field for a PodSpec,
+  # formatted as a multi-line string. By default no direct resource request
+  # is made.
+  resources: {}
+
+certificates:
+  commonName: "SeaweedFS CA"
+  ipAddresses: []
+  keyAlgorithm: RSA
+  keySize: 2048
+  duration: 2160h  # 90d
+  renewBefore: 360h  # 15d
+  ca:
+    duration: 87600h  # 10 years
+    renewBefore: 720h  # 30d
+  externalCertificates:
+    # This will avoid the need to use cert-manager and will rely on providing your own external certificates and CA
+    # you will need to store your provided certificates in the secret read by the different services:
+    # seaweedfs-master-cert, seaweedfs-filer-cert, etc. Can see any statefulset definition to see secret names
+    enabled: false
+
+# Labels to be added to all the created pods
+podLabels: {}
+# Annotations to be added to all the created pods
+podAnnotations: {}

--- a/platform/seaweedfs/chart/tests/no-fromtoml.sh
+++ b/platform/seaweedfs/chart/tests/no-fromtoml.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# bp-seaweedfs fromToml-removal integration test (issue #340).
+#
+# Verifies the vendored upstream subchart at charts/seaweedfs/ does NOT
+# contain templates/shared/security-configmap.yaml — that file uses the
+# `fromToml` Sprig function which is only available in Helm 3.13+. Flux
+# helm-controller bundles an older Helm SDK and PARSES every template
+# before any `{{- if .Values.global.seaweedfs.enableSecurity }}` gate
+# fires, so the file's mere presence breaks install on every Sovereign
+# even with enableSecurity=false (the chart's own default).
+#
+# This test is the regression guard: re-vendoring SeaweedFS at a future
+# version MUST re-delete the file (or, if upstream has stopped using
+# fromToml, this test can be removed in the same PR that re-vendors).
+#
+# Usage: bash tests/no-fromtoml.sh [CHART_DIR]
+#   CHART_DIR defaults to the parent directory of this script.
+
+set -euo pipefail
+
+CHART_DIR="${1:-$(cd "$(dirname "$0")/.." && pwd)}"
+cd "$CHART_DIR"
+
+# ── Case 1: vendored subchart present (we are not a hollow chart) ───────
+echo "[no-fromtoml] Case 1: vendored subchart present at charts/seaweedfs/"
+if [ ! -f charts/seaweedfs/Chart.yaml ]; then
+  echo "FAIL: vendored upstream subchart missing at charts/seaweedfs/Chart.yaml." >&2
+  echo "      bp-seaweedfs vendors the upstream chart per issue #340; re-vendor before publishing." >&2
+  exit 1
+fi
+echo "  PASS"
+
+# ── Case 2: offending fromToml-using template MUST be deleted ───────────
+echo "[no-fromtoml] Case 2: charts/seaweedfs/templates/shared/security-configmap.yaml is absent"
+if [ -f charts/seaweedfs/templates/shared/security-configmap.yaml ]; then
+  echo "FAIL: charts/seaweedfs/templates/shared/security-configmap.yaml still present." >&2
+  echo "      That file uses fromToml (Helm 3.13+) and breaks Flux install — see issue #340." >&2
+  echo "      Delete it after every re-vendor of the upstream chart." >&2
+  exit 1
+fi
+echo "  PASS"
+
+# ── Case 3: NO fromToml call site survives anywhere in the vendored sub ─
+echo "[no-fromtoml] Case 3: no fromToml usage anywhere under charts/seaweedfs/templates/"
+if grep -rn 'fromToml' charts/seaweedfs/templates/ 2>/dev/null; then
+  echo "FAIL: at least one fromToml call site remains in the vendored subchart." >&2
+  echo "      Helm 3.12 / Flux helm-controller cannot parse it. Remove the call site." >&2
+  exit 1
+fi
+echo "  PASS"
+
+# ── Case 4: default render with helm 3.12-compatible binary equivalent ──
+# We cannot run helm 3.12 on the runner, but a default `helm template`
+# render that succeeds without --include-crds with default values is the
+# closest proxy. The render fails on parse errors regardless of helm
+# version, so a clean render here is necessary (not sufficient).
+echo "[no-fromtoml] Case 4: default helm template render succeeds"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+if ! helm template smoke-seaweedfs . > "$TMP/default.yaml" 2> "$TMP/err"; then
+  echo "FAIL: default helm template render of bp-seaweedfs failed:" >&2
+  cat "$TMP/err" >&2
+  exit 1
+fi
+echo "  PASS ($(wc -l < "$TMP/default.yaml") lines rendered)"
+
+echo "[no-fromtoml] All bp-seaweedfs fromToml-removal gates green."

--- a/scripts/expected-bootstrap-deps.yaml
+++ b/scripts/expected-bootstrap-deps.yaml
@@ -111,7 +111,11 @@ slots:
     wave: W2.K1
   - slot: 19
     name: bp-harbor
-    depends_on: [bp-cnpg, bp-seaweedfs, bp-cert-manager]
+    # bp-seaweedfs dependency REMOVED per ADR-0001 §13 (cloud-direct).
+    # Harbor on Sovereigns writes blobs directly to cloud Object Storage
+    # (Hetzner / R2 / S3 / Azure / GCS), not via SeaweedFS. See
+    # clusters/_template/bootstrap-kit/19-harbor.yaml lines 35-37.
+    depends_on: [bp-cnpg, bp-cert-manager]
     wave: W2.K1
 
   # ---- Tier 6: observability (W2.K2, slots 20-26) ---------------------------


### PR DESCRIPTION
## Summary
- Vendor upstream `seaweedfs/seaweedfs@4.22.0` into `platform/seaweedfs/chart/charts/seaweedfs/` (committed bytes, not auto-pulled at build time).
- Delete `templates/shared/security-configmap.yaml` from the vendored copy. That template uses `fromToml` (Sprig function added in Helm 3.13) which Flux helm-controller's bundled Helm SDK doesn't have — file's mere presence breaks parse on every Sovereign even with `enableSecurity=false` (the default).
- Drop the `dependencies:` block from `Chart.yaml`; add `annotations.catalyst.openova.io/no-upstream=true` so the blueprint-release workflow's hollow-chart guard (#181) skips the auto-pull/round-trip checks.
- Whitelist `platform/seaweedfs/chart/charts/` in `.gitignore`.
- Bump `bp-seaweedfs` 1.0.1 → 1.1.0 (signal: vendored, not auto-pulled).
- Add `tests/no-fromtoml.sh` — regression guard that asserts the offending file stays deleted across future re-vendors.

## Why vendor (and not just bump helm-controller)
Upstream Helm repo overwrites `4.22.0` in place — re-pulling at CI time would re-introduce the broken file regardless of how many times we delete it locally. Vendoring is the only way to pin against an upstream chart whose tag is mutable.

The deleted ConfigMap is referenced by other templates only inside `{{- if .Values.global.seaweedfs.enableSecurity }}` blocks; Catalyst's SeaweedFS does not enable JWT/TLS (auth is at the S3 layer via IAM creds from External Secrets), so removing it is a no-op for our default deployment shape.

## Test plan
- [x] `bash tests/no-fromtoml.sh` — all 4 cases pass (vendored subchart present, offending file absent, no `fromToml` anywhere, default render succeeds, 876 lines).
- [x] `bash tests/observability-toggle.sh` — all 3 cases pass (default no ServiceMonitor, opt-in produces ServiceMonitor, explicit-off clean).
- [x] `helm package . -d /tmp/charts-test` — produces `bp-seaweedfs-1.1.0.tgz` (72 entries, no `security-configmap.yaml` in package).
- [x] `helm template smoke /tmp/charts-test/bp-seaweedfs-1.1.0.tgz` — 15 K8s resources rendered, 876 lines, exit 0.
- [x] CI `blueprint-release.yaml` will publish to `oci://ghcr.io/openova-io/bp-seaweedfs:1.1.0` on merge.
- [ ] Parent session redeploys to otech10 and confirms `bp-seaweedfs` HR Ready=True (this PR does NOT bump the consuming HelmReleases — that's the parent session's job).

## Unblocks
Phase-8a observability + storage chain on otech: `bp-loki`, `bp-mimir`, `bp-tempo`, `bp-velero`, `bp-harbor`, `bp-grafana` all `dependsOn bp-seaweedfs`.

Closes #340