### PR TITLE
fix(infra): dedupe labels in bp-cert-manager-powerdns-webhook (Phase-8a #506)

### DIFF
--- a/clusters/_template/bootstrap-kit/49-bp-cert-manager-powerdns-webhook.yaml
+++ b/clusters/_template/bootstrap-kit/49-bp-cert-manager-powerdns-webhook.yaml
@@ -82,7 +82,7 @@ spec:
   chart:
     spec:
       chart: bp-cert-manager-powerdns-webhook
-      version: 1.0.0
+      version: 1.0.1
       sourceRef:
         kind: HelmRepository
         name: bp-cert-manager-powerdns-webhook

--- a/platform/cert-manager-powerdns-webhook/chart/Chart.yaml
+++ b/platform/cert-manager-powerdns-webhook/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-cert-manager-powerdns-webhook
-version: 1.0.0
+version: 1.0.1
 appVersion: "v2.5.5"
 description: |
   Catalyst-authored Blueprint chart wrapping the upstream

--- a/platform/cert-manager-powerdns-webhook/chart/templates/deployment.yaml
+++ b/platform/cert-manager-powerdns-webhook/chart/templates/deployment.yaml
@@ -13,7 +13,11 @@ spec:
   template:
     metadata:
       labels:
-        {{- include "bp-cert-manager-powerdns-webhook.selectorLabels" . | nindent 8 }}
+        # `labels` helper already contains the selectorLabels keys
+        # (app.kubernetes.io/name + app.kubernetes.io/instance), so we
+        # only emit it once. Duplicating both blocks produces invalid
+        # YAML ("mapping key already defined") which Helm v3 post-render
+        # rejects. See openova#506.
         {{- include "bp-cert-manager-powerdns-webhook.labels" . | nindent 8 }}
       {{- with .Values.webhook.podAnnotations }}
       annotations:


### PR DESCRIPTION
## Summary

The pod template's `metadata.labels` block in `bp-cert-manager-powerdns-webhook/templates/deployment.yaml` included BOTH the `selectorLabels` helper AND the `labels` helper. Since `labels` already emits `app.kubernetes.io/name` and `app.kubernetes.io/instance`, the rendered YAML had those keys twice in a single mapping. Helm v3 post-render rejected this with:

```
yaml: unmarshal errors:
  line 29: mapping key "app.kubernetes.io/name" already defined at line 26
  line 30: mapping key "app.kubernetes.io/instance" already defined at line 27
```

Surfaced live on Phase-8a-preflight otech11 (`ac90a3ea12954e7d`, on `catalyst-api:c148ef3`, 2026-05-01).

## Changes

- Drop the redundant `selectorLabels` include from the pod template — `labels` is a superset.
- Bump chart version `1.0.0` → `1.0.1`.
- Update `clusters/_template/bootstrap-kit/49-bp-cert-manager-powerdns-webhook.yaml` HR `version` reference to `1.0.1`.

Closes #506.

## Test plan

- [x] `helm template platform/cert-manager-powerdns-webhook/chart/` renders cleanly
- [x] Output passes `yaml.safe_load_all` (no duplicate-key errors)
- [x] Pod template now has exactly one `app.kubernetes.io/name` and one `app.kubernetes.io/instance` key
- [ ] blueprint-release workflow publishes `bp-cert-manager-powerdns-webhook:1.0.1` to OCI
- [ ] Live re-deploy succeeds on next provision (parent session triggers)