### PR TITLE
fix(cert-manager-powerdns-webhook): cap CA Certificate CN at 64 bytes

### DIFF
--- a/clusters/_template/bootstrap-kit/49-bp-cert-manager-powerdns-webhook.yaml
+++ b/clusters/_template/bootstrap-kit/49-bp-cert-manager-powerdns-webhook.yaml
@@ -82,7 +82,7 @@ spec:
   chart:
     spec:
       chart: bp-cert-manager-powerdns-webhook
-      version: 1.0.1
+      version: 1.0.2
       sourceRef:
         kind: HelmRepository
         name: bp-cert-manager-powerdns-webhook

--- a/platform/cert-manager-powerdns-webhook/chart/Chart.yaml
+++ b/platform/cert-manager-powerdns-webhook/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-cert-manager-powerdns-webhook
-version: 1.0.1
+version: 1.0.2
 appVersion: "v2.5.5"
 description: |
   Catalyst-authored Blueprint chart wrapping the upstream

--- a/platform/cert-manager-powerdns-webhook/chart/templates/certificate.yaml
+++ b/platform/cert-manager-powerdns-webhook/chart/templates/certificate.yaml
@@ -32,7 +32,22 @@ spec:
   secretName: {{ include "bp-cert-manager-powerdns-webhook.rootCACertificate" . }}
   duration: {{ .Values.servingCert.caDuration }}
   isCA: true
-  commonName: "ca.{{ include "bp-cert-manager-powerdns-webhook.fullname" . }}.cert-manager"
+  # X.509 subject CN is capped at 64 bytes (RFC 5280 §4.1.2.4 + the
+  # ub-common-name-length=64 PKIX upper bound). The Helm `fullname`
+  # template prefixes the chart name with the release name, which —
+  # combined with the long `bp-cert-manager-powerdns-webhook` chart name
+  # and the `ca.` + `.cert-manager` decoration — overshoots 64 bytes
+  # whenever the operator gives this release any non-trivial name (e.g.
+  # the bootstrap-kit's `cert-manager-powerdns-webhook` releaseName
+  # produces a 78-char CN). cert-manager's webhook then rejects the
+  # Certificate at admission with `spec.commonName: Too long`. Closes #508.
+  #
+  # Use the chart `name` (always `bp-cert-manager-powerdns-webhook`,
+  # capped at 63 chars by the .name helper) instead of the release-name-
+  # prefixed `fullname`. The CA cert's CN is opaque identity only — no
+  # client validates by hostname against this CN — so collapsing on the
+  # chart name is safe and stable across releaseName variations.
+  commonName: "ca.{{ include "bp-cert-manager-powerdns-webhook.name" . }}.cert-manager"
   privateKey:
     rotationPolicy: Always
     algorithm: ECDSA


### PR DESCRIPTION
## Summary
- The chart's CA `Certificate` template rendered `spec.commonName` as `ca.<fullname>.cert-manager`, where `<fullname>` is the Helm fullname (release name + chart name). Bootstrap-kit's `releaseName: cert-manager-powerdns-webhook` produced a 78-byte CN (`ca.cert-manager-powerdns-webhook-bp-cert-manager-powerdns-webhook.cert-manager`), exceeding the RFC 5280 / PKIX `ub-common-name-length=64` cap. cert-manager's admission webhook rejected the resource at install time, blocking otech11 (ac90a3ea12954e7d, chart 1.0.1, 2026-05-02).
- Collapsed the CN onto the chart `name` helper (always `bp-cert-manager-powerdns-webhook`, ≤63 chars), which is stable across any operator-chosen releaseName. The CA cert's CN is opaque identity only — no client validates by hostname against it — so the shortening is behaviour-preserving.
- Bumped chart `1.0.1 → 1.0.2` and updated the bootstrap-kit slot reference in `clusters/_template/bootstrap-kit/49-bp-cert-manager-powerdns-webhook.yaml`.

## Verification

```
$ helm template cert-manager-powerdns-webhook platform/cert-manager-powerdns-webhook/chart/ \
    --namespace cert-manager --set sovereign.fqdn=otech11.omani.works \
    | grep commonName
  commonName: "ca.bp-cert-manager-powerdns-webhook.cert-manager"

$ echo -n "ca.bp-cert-manager-powerdns-webhook.cert-manager" | wc -c
48
```

| | Before | After |
|---|---|---|
| commonName | `ca.cert-manager-powerdns-webhook-bp-cert-manager-powerdns-webhook.cert-manager` | `ca.bp-cert-manager-powerdns-webhook.cert-manager` |
| length (bytes) | 78 (rejected) | 48 (within 64-byte cap) |

## Test plan
- [ ] `blueprint-release` workflow publishes `bp-cert-manager-powerdns-webhook:1.0.2` to OCI.
- [ ] Re-deploy on otech11+ verifies HelmRelease reaches `Ready=True` and the CA + serving Certificates land without admission rejection.

Closes #508.