### PR TITLE
fix(infra): add explicit dependsOn to bp-openbao + bp-catalyst-platform

### DIFF
--- a/clusters/_template/bootstrap-kit/08-openbao.yaml
+++ b/clusters/_template/bootstrap-kit/08-openbao.yaml
@@ -41,6 +41,15 @@ spec:
     # HelmRelease applies or install fails with `no matches for kind
     # HTTPRoute`.
     - name: bp-gateway-api
+    # bp-cnpg (issue #512): the OpenBao 3-node Raft post-install init Job
+    # (Helm hook weight 5) runs `bao operator init` and seals/unseals via
+    # Kubernetes auth; both paths require the cnpg PostgreSQL backing the
+    # OpenBao audit/storage adjuncts to be Ready, otherwise the hook
+    # blocks until Helm's install timeout (15m) expires. Phase-8a-preflight
+    # otech16 (2026-05-02): even with timeout=15m, the hook raced cnpg
+    # coming up. Adding the explicit dep makes Flux wait for bp-cnpg
+    # Ready=True before starting bp-openbao install. See issue #512.
+    - name: bp-cnpg
   chart:
     spec:
       chart: bp-openbao

--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -44,6 +44,17 @@ spec:
     # catalyst-api HTTPRoute templates; gateway.networking.k8s.io/v1
     # CRDs must be registered first.
     - name: bp-gateway-api
+    # bp-keycloak + bp-cnpg (issue #512): the catalyst-platform umbrella
+    # post-install Jobs bootstrap OIDC clients in Keycloak and seed
+    # PostgreSQL schemas for catalog-svc / projector / billing /
+    # provisioning. Both Keycloak and cnpg take 5+ minutes to reach Ready
+    # on a fresh Sovereign — without an explicit dep, the umbrella's
+    # hook starts before they're warm and times out at 15m.
+    # Phase-8a-preflight otech16 (2026-05-02): adding bp-keycloak +
+    # bp-cnpg here makes Flux wait for both Ready=True before starting
+    # the umbrella install, eliminating the race.
+    - name: bp-keycloak
+    - name: bp-cnpg
   chart:
     spec:
       chart: bp-catalyst-platform

--- a/scripts/expected-bootstrap-deps.yaml
+++ b/scripts/expected-bootstrap-deps.yaml
@@ -69,7 +69,10 @@ slots:
     name: bp-openbao
     # bp-gateway-api dep (issue #503): chart ships an HTTPRoute template;
     # gateway.networking.k8s.io/v1 CRDs must be registered before install.
-    depends_on: [bp-spire, bp-gateway-api]
+    # bp-cnpg dep (issue #512): post-install init hook (`bao operator init`)
+    # races cnpg readiness on a fresh Sovereign, hitting the 15m install
+    # timeout. Explicit dep makes Flux wait for cnpg Ready=True first.
+    depends_on: [bp-spire, bp-gateway-api, bp-cnpg]
     wave: present
   - slot: 9
     name: bp-keycloak
@@ -94,7 +97,11 @@ slots:
     name: bp-catalyst-platform
     # bp-gateway-api dep (issue #503): umbrella chart ships catalyst-ui +
     # catalyst-api HTTPRoute templates.
-    depends_on: [bp-gitea, bp-gateway-api]
+    # bp-keycloak + bp-cnpg deps (issue #512): umbrella post-install Jobs
+    # bootstrap OIDC clients + seed PG schemas; both deps take 5+ min to
+    # reach Ready on a fresh Sovereign, racing the 15m install timeout.
+    # Explicit deps make Flux wait for both Ready=True before umbrella starts.
+    depends_on: [bp-gitea, bp-gateway-api, bp-keycloak, bp-cnpg]
     wave: present
   - slot: 14
     name: bp-crossplane-claims


### PR DESCRIPTION
## Summary

Phase-8a-preflight live deployment otech16 (9e14dcc0d2de7586, 2026-05-02): even after bumping install/upgrade timeout to 15m (commit f47948e7), the post-install hooks for `bp-openbao` and `bp-catalyst-platform` STILL race. The hooks need their workload deps Ready before they can do their work:

- **bp-openbao**: 3-node Raft init Job waits for cnpg-postgres + Cilium L7
- **bp-catalyst-platform**: umbrella init Jobs wait for keycloak + cnpg

## Fix shape (Option C — add explicit dependsOn)

- `clusters/_template/bootstrap-kit/08-openbao.yaml` — added `bp-cnpg` (already had bp-spire, bp-gateway-api)
- `clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml` — added `bp-keycloak` + `bp-cnpg` (already had bp-gitea, bp-gateway-api)
- `scripts/expected-bootstrap-deps.yaml` — updated slot 8 + slot 13 deps to match

This makes Flux wait for those HRs `Ready=True` BEFORE starting the install. Post-install hooks then run AFTER deps are warm. Eliminates the race.

## Verification

- `bash scripts/check-bootstrap-deps.sh` — 0 drift, 0 cycles, audit PASSED
- `go test ./tests/e2e/bootstrap-kit/... -run TestBootstrapKit_DependencyOrderMatchesCanonical` — PASS
- `go test ./tests/e2e/bootstrap-kit/...` (all package tests) — PASS

## Test plan

- [x] Static dep audit clean (no cycles, no drift)
- [x] Canonical dep order test passes
- [ ] Live: parent session redeploys otech (e.g. otech17) and verifies bp-openbao + bp-catalyst-platform reach Ready without 15m timeout

Closes #512

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>