### PR TITLE
fix(bp-catalyst-platform): drop 10 foundation subchart deps to stop duplicate source-controller in catalyst-system NS (#510)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -58,7 +58,7 @@ spec:
   chart:
     spec:
       chart: bp-catalyst-platform
-      version: 1.1.8
+      version: 1.1.9
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-catalyst-platform
-version: 1.1.8
+version: 1.1.9
 appVersion: 1.1.6
 description: |
   Catalyst Platform — the unified Catalyst control plane umbrella chart for Catalyst-Zero.
@@ -8,20 +8,16 @@ description: |
   Deployed via Flux on Catalyst-Zero (Contabo k3s) and on every franchised Sovereign provisioned by Catalyst-Zero.
   Per docs/PROVISIONING-PLAN.md — this is the canonical bp-catalyst-platform Helm chart.
 
-  Umbrella that depends on the 10 leaf bootstrap-kit Blueprints
-  (cilium, cert-manager, flux, crossplane, sealed-secrets, spire,
-  nats-jetstream, openbao, keycloak, gitea) — each resolved as an OCI
-  artifact at ghcr.io/openova-io/bp-<name>. As of 1.1.0 each leaf is
-  itself a proper Helm umbrella that depends on its upstream chart
-  (cert-manager, cilium, flux2, crossplane, ...) so installing
-  bp-catalyst-platform brings up the full upstream payload — no
-  Catalyst-side bootstrap installer is required.
+  As of 1.1.9 this umbrella contains ONLY the Catalyst-Zero control-plane
+  workloads (catalyst-ui, catalyst-api, ProvisioningState CRD, Sovereign
+  HTTPRoute). Foundation Blueprints (cilium, cert-manager, flux,
+  crossplane, sealed-secrets, spire, nats-jetstream, openbao, keycloak,
+  gitea) are installed independently by the bootstrap-kit at slots
+  01..10 (see clusters/_template/bootstrap-kit/). Each lands in its own
+  namespace (flux-system, cert-manager, kube-system, etc.) under its own
+  Flux HelmRelease — install order owned by Flux dependsOn rather than
+  this umbrella's Helm dependency graph.
 
-  bp-external-dns is NOT a dep of this umbrella; it is installed
-  separately by the bootstrap-kit Kustomization (12-external-dns.yaml)
-  alongside bp-cert-manager / bp-powerdns / bp-flux / etc. so its
-  install ordering is owned by Flux dependsOn (bp-cert-manager,
-  bp-powerdns) rather than this umbrella's Helm dependency graph.
   Bumped to 1.1.1 in lockstep with bp-external-dns 1.1.0 to reflect the
   dependency removal. Bumped to 1.1.2 to pull in bp-flux:1.1.2 — the
   catastrophic-double-install fix (omantel.omani.works incident,
@@ -67,41 +63,36 @@ description: |
   bp-catalyst-platform Blueprint — they will be re-homed in a
   contabo-mkt-only Kustomization (or a separate `bp-sme` Blueprint)
   if/when SME is re-deployed. Issue #281, 2026-04-30.
+  Bumped to 1.1.9 to remove the 10 foundation-Blueprint subchart
+  dependencies (bp-cilium, bp-cert-manager, bp-flux, bp-crossplane,
+  bp-sealed-secrets, bp-spire, bp-nats-jetstream, bp-openbao,
+  bp-keycloak, bp-gitea). When this umbrella reconciled with
+  `targetNamespace: catalyst-system`, Helm rendered every subchart's
+  `flux2` / `cilium` / etc. controllers into catalyst-system —
+  duplicating the foundation stack the bootstrap-kit had already
+  installed at slots 01..10 in their own canonical namespaces
+  (flux-system, cert-manager, kube-system, ...). On Phase-8a-preflight
+  otech16 (2026-05-02) this manifested as a duplicate source-controller
+  in catalyst-system NS that other HRs (bp-cnpg, bp-spire,
+  bp-crossplane-claims) intermittently routed to via service discovery,
+  failing chart pulls with "i/o timeout" against
+  `source-controller.catalyst-system.svc.cluster.local`. Resolution:
+  the umbrella ships ONLY Catalyst-Zero control-plane workloads; the
+  foundation layer is owned end-to-end by the bootstrap-kit. Issue
+  #510, 2026-05-02.
 type: application
 
-dependencies:
-  - name: bp-cilium
-    version: 1.1.1
-    repository: oci://ghcr.io/openova-io
-  - name: bp-cert-manager
-    version: 1.1.1
-    repository: oci://ghcr.io/openova-io
-  # bp-flux 1.1.2 — version-pinned to upstream Flux v2.4.0 (matches
-  # cloud-init's install.yaml URL). Earlier 1.1.1 shipped flux2 2.13.0
-  # (= upstream v2.3.0), which destroyed cluster Flux on first reconcile
-  # via Helm rollback (omantel.omani.works incident, 2026-04-29). See
-  # docs/RUNBOOK-PROVISIONING.md §"bp-flux double-install".
-  - name: bp-flux
-    version: 1.1.2
-    repository: oci://ghcr.io/openova-io
-  - name: bp-crossplane
-    version: 1.1.1
-    repository: oci://ghcr.io/openova-io
-  - name: bp-sealed-secrets
-    version: 1.1.1
-    repository: oci://ghcr.io/openova-io
-  - name: bp-spire
-    version: 1.1.1
-    repository: oci://ghcr.io/openova-io
-  - name: bp-nats-jetstream
-    version: 1.1.1
-    repository: oci://ghcr.io/openova-io
-  - name: bp-openbao
-    version: 1.1.1
-    repository: oci://ghcr.io/openova-io
-  - name: bp-keycloak
-    version: 1.1.1
-    repository: oci://ghcr.io/openova-io
-  - name: bp-gitea
-    version: 1.1.1
-    repository: oci://ghcr.io/openova-io
+# Opt-out from the blueprint-release hollow-chart guard (issue #181 / #510).
+# This umbrella legitimately ships only Catalyst-authored workloads
+# (catalyst-ui, catalyst-api, ProvisioningState CRD, Sovereign HTTPRoute);
+# the foundation layer is installed independently by the bootstrap-kit
+# and must NOT be re-rendered into catalyst-system as subcharts.
+annotations:
+  catalyst.openova.io/no-upstream: "true"
+
+# No subchart dependencies — see 1.1.9 changelog above. The 10
+# foundation Blueprints are installed by clusters/_template/bootstrap-kit/
+# at their own slots, each as a top-level Flux HelmRelease in its own
+# canonical namespace. This umbrella renders only the Catalyst-Zero
+# control-plane workloads (catalyst-ui, catalyst-api, ProvisioningState
+# CRD, Sovereign HTTPRoute) into targetNamespace: catalyst-system.

--- a/products/catalyst/chart/values.yaml
+++ b/products/catalyst/chart/values.yaml
@@ -1,32 +1,19 @@
 # bp-catalyst-platform umbrella values
 #
-# Catalyst-Zero composes ten Blueprint subcharts (cilium, cert-manager, flux,
-# crossplane, sealed-secrets, spire, nats-jetstream, openbao, keycloak, gitea).
-# Two of them (bp-keycloak, bp-gitea) each pull in the bitnami `postgresql`
-# subchart with no fullnameOverride. Helm renders both as
-# `<release>-postgresql`, which collides on install — Helm post-render
-# rejects the second occurrence with:
-#   "may not add resource with an already registered id:
-#    NetworkPolicy.v1.networking.k8s.io/<release>-postgresql.<namespace>"
-# (and the same collision on Service, Secret, StatefulSet, PDB, ...).
+# As of 1.1.9 this umbrella ships ONLY the Catalyst-Zero control-plane
+# workloads (catalyst-ui, catalyst-api, ProvisioningState CRD, Sovereign
+# HTTPRoute). The 10 foundation Blueprints (cilium, cert-manager, flux,
+# crossplane, sealed-secrets, spire, nats-jetstream, openbao, keycloak,
+# gitea) are installed independently by clusters/_template/bootstrap-kit/
+# at slots 01..10. There are no subchart values to thread here.
 #
-# Fix: give each embedded postgresql a distinct fullnameOverride so the
-# rendered names never collide. The override flows umbrella → bp-<name>
-# → upstream chart → its postgresql subchart via Helm's standard subchart
-# value-namespacing.
-#
-# Resolves openova-io/openova#252 (otech.omani.works HelmRelease
-# `catalyst-system/catalyst-platform` install_failed, 2026-04-30).
-
-bp-keycloak:
-  keycloak:
-    postgresql:
-      fullnameOverride: keycloak-postgresql
-
-bp-gitea:
-  gitea:
-    postgresql:
-      fullnameOverride: gitea-postgresql
+# Historic note: 1.1.4 set `bp-keycloak.keycloak.postgresql.fullnameOverride`
+# and `bp-gitea.gitea.postgresql.fullnameOverride` to deconflict bitnami
+# postgresql `<release>-postgresql` collisions when both Blueprints were
+# subcharts of this umbrella (issue #252). Now that they're top-level
+# Flux HelmReleases under separate namespaces (bp-keycloak →
+# `keycloak`, bp-gitea → `gitea`), the collision is gone and the
+# overrides are unnecessary.
 
 # ProvisioningState CRD — the canonical persistence shape for Sovereign
 # provisioning runs (issue #88). Keeps observability of in-flight wizard


### PR DESCRIPTION
## Summary

Phase-8a-preflight otech16 (2026-05-02) surfaced intermittent chart-pull failures on `bp-cnpg`, `bp-spire`, and `bp-crossplane-claims`:

```
Could not load chart: GET http://source-controller.catalyst-system.svc.cluster.local./helmchart/flux-system/flux-system-bp-cnpg/bp-cnpg-1.0.0.tgz: i/o timeout
```

The URL points at a `source-controller` Service in `catalyst-system` namespace — but the canonical Flux source-controller lives in `flux-system` (installed by cloud-init + bootstrap-kit slot 03).

## Root cause

The `bp-catalyst-platform` umbrella declared 10 foundation Blueprints (bp-cilium, bp-cert-manager, bp-flux, bp-crossplane, bp-sealed-secrets, bp-spire, bp-nats-jetstream, bp-openbao, bp-keycloak, bp-gitea) as Helm **subchart** dependencies. With `targetNamespace: catalyst-system`, helm-controller rendered every subchart into `catalyst-system` — including the entire flux2 stack (source-controller, helm-controller, kustomize-controller, notification-controller). The duplicate source-controller competed via service-discovery and intermittently won, returning timeouts on chart pulls whose `sourceRef.namespace` was `flux-system`.

The bootstrap-kit ALREADY installs each of those 10 Blueprints at slots 01..10 as top-level Flux HelmReleases in their own canonical namespaces. The umbrella's subchart deps were entirely duplicate.

## Fix shape

The umbrella now ships ONLY Catalyst-Zero control-plane workloads:
- `catalyst-ui` Deployment + Service
- `catalyst-api` Deployment + Service + 2 PVCs
- `ProvisioningState` CRD (in `crds/`)
- Sovereign HTTPRoute (when `ingress.hosts.*.host` is set)

The foundation layer is owned end-to-end by `clusters/_template/bootstrap-kit/` at slots 01..10. Install order continues to be enforced by Flux `dependsOn`.

## Changes

- `products/catalyst/chart/Chart.yaml`: bump 1.1.8 -> 1.1.9. Drop all 10 `dependencies:` entries. Add `annotations.catalyst.openova.io/no-upstream: "true"` to opt out of the blueprint-release hollow-chart guard (#181) — this umbrella legitimately ships only Catalyst-authored CRs.
- `products/catalyst/chart/values.yaml`: drop subchart-namespaced `bp-keycloak.keycloak.postgresql` / `bp-gitea.gitea.postgresql` `fullnameOverride` blocks. They're no longer applicable now that bp-keycloak and bp-gitea are top-level HRs in separate namespaces.
- `products/catalyst/chart/Chart.lock` + `charts/*.tgz` removed (no deps to lock).
- `clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml`: bump chart version reference 1.1.8 -> 1.1.9.

## Verification

```
$ helm template products/catalyst/chart/ --namespace catalyst-system | grep -E '^kind:' | sort | uniq -c
      2 kind: Deployment
      2 kind: PersistentVolumeClaim
      2 kind: Service
```

Zero Flux controllers, zero upstream-chart bytes. With `ingress.hosts.*.host` set, two HTTPRoutes are added — also clean.

## Test plan

- [x] `helm lint products/catalyst/chart/` clean
- [x] `helm template` emits only Catalyst-Zero workloads, zero source-controller / helm-controller / kustomize-controller / notification-controller
- [ ] CI blueprint-release builds and publishes 1.1.9 to `oci://ghcr.io/openova-io/bp-catalyst-platform:1.1.9`
- [ ] Parent session redeploys otech and confirms bp-cnpg / bp-spire / bp-crossplane-claims chart pulls succeed against `source-controller.flux-system.svc.cluster.local`

Closes #510

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>