### PR TITLE
fix(bootstrap-kit): nest bp-openbao single-replica overrides under openbao subchart key

### DIFF
--- a/clusters/_template/bootstrap-kit/08-openbao.yaml
+++ b/clusters/_template/bootstrap-kit/08-openbao.yaml
@@ -91,13 +91,24 @@ spec:
       host: bao.${SOVEREIGN_FQDN}
     autoUnseal:
       enabled: true
-    # Issue #(filed inline 2026-05-02): openbao 3-replica StatefulSet uses
-    # required pod-anti-affinity by hostname. On single-node Phase-8a
-    # Sovereigns this leaves 2/3 pods Pending forever, the openbao-init
-    # Job's wait-for-Ready loop times out, and the entire HR fails post-
-    # install. Drop to 1 replica until the workerCount > 0 path is wired
-    # — the autoUnseal flow does not require a quorum to bootstrap.
-    server:
-      ha:
-        replicas: 1
-      affinity: ""
+    # Issue #517 (Phase-8a single-node): openbao upstream chart's
+    # 3-replica StatefulSet uses required pod-anti-affinity by hostname.
+    # On single-node Phase-8a Sovereigns this leaves 2/3 pods Pending
+    # forever, the openbao-init Job's wait-for-Ready loop times out, and
+    # the entire HR fails post-install. Drop to 1 replica until the
+    # workerCount > 0 path is wired — the autoUnseal flow does not
+    # require a quorum to bootstrap (Raft is still enabled, just one
+    # voter).
+    #
+    # CRITICAL — schema nesting (issue #517 root cause): platform/openbao/
+    # chart/Chart.yaml declares the upstream openbao chart as a Helm
+    # SUBCHART under `dependencies:`. Helm umbrella-chart convention
+    # requires subchart values to be nested under the dependency name
+    # (`openbao:`). Putting `server.ha.replicas` / `server.affinity` at
+    # the top level here is SILENTLY IGNORED — the upstream subchart
+    # never sees them and renders 3-replica + pod-anti-affinity.
+    openbao:
+      server:
+        ha:
+          replicas: 1
+        affinity: ""


### PR DESCRIPTION
## Summary

- PR #5e0646e0 attempted to drop bp-openbao to 1 replica on single-node Phase-8a Sovereigns by setting `server.ha.replicas: 1` + `server.affinity: ""` at the TOP LEVEL of the HR `values` block — silently ignored by Helm because the upstream openbao chart is a SUBCHART (per `platform/openbao/chart/Chart.yaml` `dependencies:`), so values must be nested under the `openbao:` key.
- Result on otech17: StatefulSet stayed at 3 replicas, openbao-1/openbao-2 Pending forever (required pod-anti-affinity by hostname), openbao-init Job DeadlineExceeded, HR Stalled with MissingRollbackTarget.
- This PR moves the overrides under `openbao:` per umbrella-chart convention.

Closes #517

## Verification (helm template)

```
$ helm template . --set 'server.ha.replicas=1'
StatefulSet replicas: 3   # WRONG — top-level ignored

$ helm template . -f vals.yaml   # openbao.server.ha.replicas: 1
StatefulSet replicas: 1   # CORRECT
```

## Test plan

- [ ] Sovereign-build re-deploys with new chart values
- [ ] Wipe failed Helm release secrets on otech17 (`sh.helm.release.v1.openbao.v1..v4` in flux-system) so helm-controller does a fresh install
- [ ] openbao-0 pod 1/1 Running, no Pending pods
- [ ] openbao-init Job Complete
- [ ] bp-openbao HR Ready=True
- [ ] bp-external-secrets cascades to Ready

Generated with [Claude Code](https://claude.com/claude-code)