### PR TITLE
fix(bootstrap-kit): bp-openbao autoUnseal.baoAddress to match actual Service name (refs #517)

### DIFF
--- a/clusters/_template/bootstrap-kit/08-openbao.yaml
+++ b/clusters/_template/bootstrap-kit/08-openbao.yaml
@@ -91,6 +91,14 @@ spec:
       host: bao.${SOVEREIGN_FQDN}
     autoUnseal:
       enabled: true
+      # Issue #517 (cont): the chart's init-job.yaml + auth-bootstrap-job.yaml
+      # default baoAddress to `http://<release>-openbao:8200`, but with
+      # spec.releaseName=openbao the upstream openbao chart's `fullname`
+      # template returns just `openbao` (not `openbao-openbao`) because
+      # Release.Name CONTAINS chart name. The rendered Service is
+      # `openbao` in the openbao namespace. Override the default so the
+      # post-install Jobs can actually reach the server.
+      baoAddress: http://openbao.openbao.svc.cluster.local:8200
     # Issue #517 (Phase-8a single-node): openbao upstream chart's
     # 3-replica StatefulSet uses required pod-anti-affinity by hostname.
     # On single-node Phase-8a Sovereigns this leaves 2/3 pods Pending


### PR DESCRIPTION
## Summary

Fast-follow on #518. The chart's auto-unseal post-install Jobs (init + auth-bootstrap) had a bad default for \`baoAddress\` — \`http://<release>-openbao:8200\` — but with \`spec.releaseName=openbao\` the upstream openbao chart's fullname helper returns just \`openbao\` (Release.Name contains chart name). Service is at \`openbao.openbao.svc.cluster.local\`, not \`openbao-openbao\`. Init Job loops out and the HR fails post-install.

This was latent because previous Phase-8a sessions never reached the auto-unseal step on a working 1-replica cluster.

Refs #517

## Verified live on otech17

After applying \`autoUnseal.baoAddress: http://openbao.openbao.svc.cluster.local:8200\` and reconciling, openbao-init Job reaches the server immediately.

## Test plan

- [ ] openbao-init Job completes successfully
- [ ] openbao-auth-bootstrap Job completes successfully
- [ ] bp-openbao HR Ready=True
- [ ] bp-external-secrets cascades Ready

Generated with [Claude Code](https://claude.com/claude-code)