### PR TITLE
fix(bp-openbao): use busybox-compatible wget flag in init Job (refs #517)

### DIFF
--- a/platform/openbao/chart/templates/init-job.yaml
+++ b/platform/openbao/chart/templates/init-job.yaml
@@ -143,7 +143,7 @@ spec:
                 TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
                 CACERT=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
                 APISERVER="https://kubernetes.default.svc"
-                SEED_B64=$(wget -qO- --ca-certificate=$CACERT \
+                SEED_B64=$(wget -qO- --no-check-certificate \
                   --header="Authorization: Bearer $TOKEN" \
                   "$APISERVER/api/v1/namespaces/$NAMESPACE/secrets/$SEED_SECRET_NAME" \
                   | grep -E "\"$SEED_SECRET_KEY\"" | head -1 | sed -E 's/.*"'"$SEED_SECRET_KEY"'"[[:space:]]*:[[:space:]]*"([^"]*)".*/\1/' )
@@ -182,7 +182,7 @@ spec:
                 "$NAMESPACE" "$(date -u +%Y-%m-%dT%H:%M:%SZ | base64 | tr -d '\n')")
               # Try create; if it exists, patch.
               CREATE_RC=0
-              echo "$MARKER_PAYLOAD" | wget -qO- --ca-certificate=$CACERT \
+              echo "$MARKER_PAYLOAD" | wget -qO- --no-check-certificate \
                 --header="Authorization: Bearer $TOKEN" \
                 --header="Content-Type: application/json" \
                 --post-data="$MARKER_PAYLOAD" \
@@ -194,7 +194,7 @@ spec:
               # ─── Step 5: delete seed Secret ─────────────────────────────
               if [ -z "${SKIP_INIT:-}" ]; then
                 echo "[openbao-init] deleting seed Secret (single-use consumed)"
-                wget -qO- --ca-certificate=$CACERT \
+                wget -qO- --no-check-certificate \
                   --header="Authorization: Bearer $TOKEN" \
                   --method=DELETE \
                   "$APISERVER/api/v1/namespaces/$NAMESPACE/secrets/$SEED_SECRET_NAME" >/dev/null 2>&1 || true


### PR DESCRIPTION
## Summary

The chart's init Job runs inside the openbao image which has busybox wget — does not support \`--ca-certificate=\$CACERT\`. wget prints usage page; script reports \"seed Secret has no key recovery-seed\" (false negative). Replace with \`--no-check-certificate\`.

This is a chart-render bug in the upstream chart; CHART REBUILD REQUIRED via Sovereign-build pipeline. Until \`bp-openbao:1.2.1\` is published, the live cluster init Job will keep crashlooping. After build → push → Flux pulls new version → install retries should succeed.

Refs #517

## Test plan

- [ ] bp-openbao chart re-built + tagged 1.2.1 (or 1.2.0+ovr)
- [ ] HR chart.spec.version bumped, init Job re-rendered with --no-check-certificate
- [ ] init Job completes successfully
- [ ] auth-bootstrap Job completes
- [ ] HR Ready=True

Generated with [Claude Code](https://claude.com/claude-code)