### PR TITLE
fix(bp-openbao): bump 1.2.0→1.2.1 carrying busybox-wget fix (refs #517)

### DIFF
--- a/clusters/_template/bootstrap-kit/08-openbao.yaml
+++ b/clusters/_template/bootstrap-kit/08-openbao.yaml
@@ -53,7 +53,7 @@ spec:
   chart:
     spec:
       chart: bp-openbao
-      version: 1.2.0
+      version: 1.2.1
       sourceRef:
         kind: HelmRepository
         name: bp-openbao

--- a/platform/openbao/chart/Chart.yaml
+++ b/platform/openbao/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-openbao
-version: 1.2.0
+version: 1.2.1
 description: |
   Catalyst-curated Blueprint umbrella chart for OpenBao. Depends on the
   upstream `openbao` chart as a Helm subchart so `helm dependency build`


### PR DESCRIPTION
## Summary

Bumps bp-openbao chart to 1.2.1 carrying PR #523's busybox-compatible wget flag fix. Also bumps the HR ref in clusters/_template/bootstrap-kit/08-openbao.yaml so Sovereigns reconciling Flux pull the new bytes from ghcr.io/openova-io/bp-openbao:1.2.1 once blueprint-release publishes the new artifact.

Refs #517

## Test plan

- [ ] blueprint-release builds 1.2.1
- [ ] Sovereigns pull new chart on next reconcile
- [ ] init Job completes successfully on otech17

Generated with [Claude Code](https://claude.com/claude-code)