### PR TITLE
fix(bp-openbao): use shamir-compatible init flags + bump 1.2.1→1.2.2 (refs #517)

### DIFF
--- a/clusters/_template/bootstrap-kit/08-openbao.yaml
+++ b/clusters/_template/bootstrap-kit/08-openbao.yaml
@@ -53,7 +53,7 @@ spec:
   chart:
     spec:
       chart: bp-openbao
-      version: 1.2.1
+      version: 1.2.2
       sourceRef:
         kind: HelmRepository
         name: bp-openbao

--- a/platform/openbao/chart/Chart.yaml
+++ b/platform/openbao/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-openbao
-version: 1.2.1
+version: 1.2.2
 description: |
   Catalyst-curated Blueprint umbrella chart for OpenBao. Depends on the
   upstream `openbao` chart as a Helm subchart so `helm dependency build`

--- a/platform/openbao/chart/templates/init-job.yaml
+++ b/platform/openbao/chart/templates/init-job.yaml
@@ -154,10 +154,19 @@ spec:
                 fi
                 # Recovery key file is single-use; deleted in step 5.
                 echo "$SEED_B64" | base64 -d > /tmp/recovery-seed.bin
-                echo "[openbao-init] running bao operator init (recovery-shares=1, recovery-threshold=1)"
+                # Issue #517 (cont): -recovery-shares/-recovery-threshold are
+                # only valid for auto-unseal seal types (gcpckms, awskms,
+                # transit, etc.). The upstream openbao chart's default
+                # config uses `seal "shamir"` (no auto-unseal stanza in
+                # values.standalone.config / values.ha.config), so the
+                # right flags are -key-shares / -key-threshold. With
+                # auto-unseal seal types added later, swap back to
+                # -recovery-* — but per the current chart values this
+                # NEVER worked.
+                echo "[openbao-init] running bao operator init (key-shares=1, key-threshold=1, shamir seal)"
                 bao operator init \
-                  -recovery-shares=1 \
-                  -recovery-threshold=1 \
+                  -key-shares=1 \
+                  -key-threshold=1 \
                   -format=json \
                   > /tmp/init-output.json
                 # Store init outputs INSIDE OpenBao itself via the recovery-key.


### PR DESCRIPTION
## Summary

Chart's init Job called \`bao operator init -recovery-shares=1 -recovery-threshold=1\` which only works with auto-unseal seal types (gcpckms/awskms/transit). The chart's default seal is shamir (no auto-unseal stanza in upstream values), so OpenBao returns 400 \"parameters recovery_shares,recovery_threshold not applicable to seal type shamir\".

Switch to \`-key-shares=1 -key-threshold=1\` which are the correct shamir-seal init flags.

Refs #517

## Test plan

- [ ] blueprint-release builds 1.2.2
- [ ] init Job succeeds on otech17

Generated with [Claude Code](https://claude.com/claude-code)