### PR TITLE
fix(catalyst-ui): UX cosmetics polish — bell, alignment, +more, settings (Closes #531)

### DIFF
--- a/products/catalyst/bootstrap/ui/src/app/router.tsx
+++ b/products/catalyst/bootstrap/ui/src/app/router.tsx
@@ -29,6 +29,7 @@ import { DecommissionPage } from '@/pages/sovereign/DecommissionPage'
 import { UserAccessListPage } from '@/pages/admin/user-access/UserAccessListPage'
 import { UserAccessEditPage } from '@/pages/admin/user-access/UserAccessEditPage'
 import { SettingsPage } from '@/pages/sovereign/SettingsPage'
+import { NotificationsPage } from '@/pages/sovereign/NotificationsPage'
 
 // Root
 const rootRoute = createRootRoute({ component: RootLayout })
@@ -340,6 +341,14 @@ const provisionSettingsRoute = createRoute({
   component: SettingsPage,
 })
 
+// Standalone notifications surface (#531 item 1) — same in-memory list
+// the bell renders, but with room to scroll long error traces.
+const provisionNotificationsRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/provision/$deploymentId/notifications',
+  component: NotificationsPage,
+})
+
 // Legacy DAG provision view — preserved at a sub-path so existing
 // links and CI smoke tests (which still curl `/provision/legacy/...`)
 // don't 404 mid-rollout.
@@ -396,6 +405,7 @@ const routeTree = rootRoute.addChildren([
   provisionUsersNewRoute,
   provisionUsersEditRoute,
   provisionSettingsRoute,
+  provisionNotificationsRoute,
   legacyProvisionRoute,
   designsRoute,
   designsJobsDepsVizRoute,

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/Dashboard.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/Dashboard.test.tsx
@@ -190,9 +190,15 @@ describe('Dashboard — 12-cell flat fixture', () => {
 })
 
 describe('Dashboard — drill-down breadcrumb', () => {
-  it('starts with only the root chip', async () => {
+  it('hides the breadcrumb at root depth (#531 item 4)', async () => {
     renderDashboard('d-1', NESTED_FIXTURE)
-    expect(await screen.findByTestId('dashboard-breadcrumb-root')).toBeTruthy()
+    // Wait for the treemap to mount so we know the page has rendered.
+    await screen.findByTestId('dashboard-treemap-frame')
+    // The breadcrumb (and its standalone "All" chip) only appears once
+    // the operator drills into a parent — root has nothing to pop back
+    // to so the row is hidden to reclaim vertical space.
+    expect(screen.queryByTestId('dashboard-breadcrumb')).toBeNull()
+    expect(screen.queryByTestId('dashboard-breadcrumb-root')).toBeNull()
     expect(screen.queryByTestId('dashboard-breadcrumb-0')).toBeNull()
   })
 })

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/Dashboard.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/Dashboard.tsx
@@ -316,44 +316,45 @@ export function Dashboard({
           setSizeBy={setSizeBy}
         />
 
-        {/* Breadcrumbs — drill stack pop targets. Always visible so the
-         *  operator can see the depth even when at root (root chip is
-         *  shown as the active item). */}
-        <nav
-          className="mt-3 flex flex-wrap items-center gap-1 text-xs"
-          aria-label="Drill path"
-          data-testid="dashboard-breadcrumb"
-        >
-          <button
-            type="button"
-            onClick={() => popDrillTo(0)}
-            className={`rounded-md px-2 py-1 transition-colors ${
-              drillPath.length === 0
-                ? 'bg-[var(--color-accent)]/15 text-[var(--color-accent)]'
-                : 'text-[var(--color-text-dim)] hover:text-[var(--color-text)]'
-            }`}
-            data-testid="dashboard-breadcrumb-root"
+        {/* Breadcrumbs — drill stack pop targets. Hidden at root depth
+         *  (#531 item 4 — the standalone "All" chip wasted vertical
+         *  space and had no functional purpose when nothing was
+         *  drilled). The "All" chip reappears as the leftmost crumb as
+         *  soon as the operator drills into a parent so they can pop
+         *  back to root with one click. */}
+        {drillPath.length > 0 ? (
+          <nav
+            className="mt-3 flex flex-wrap items-center gap-1 text-xs"
+            aria-label="Drill path"
+            data-testid="dashboard-breadcrumb"
           >
-            All
-          </button>
-          {drillPath.map((step, i) => (
-            <span key={`${step.id}-${i}`} className="flex items-center gap-1">
-              <span className="text-[var(--color-text-dimmer)]">/</span>
-              <button
-                type="button"
-                onClick={() => popDrillTo(i + 1)}
-                className={`rounded-md px-2 py-1 transition-colors ${
-                  i === drillPath.length - 1
-                    ? 'bg-[var(--color-accent)]/15 text-[var(--color-accent)]'
-                    : 'text-[var(--color-text-dim)] hover:text-[var(--color-text)]'
-                }`}
-                data-testid={`dashboard-breadcrumb-${i}`}
-              >
-                {step.name}
-              </button>
-            </span>
-          ))}
-        </nav>
+            <button
+              type="button"
+              onClick={() => popDrillTo(0)}
+              className="rounded-md px-2 py-1 text-[var(--color-text-dim)] transition-colors hover:text-[var(--color-text)]"
+              data-testid="dashboard-breadcrumb-root"
+            >
+              All
+            </button>
+            {drillPath.map((step, i) => (
+              <span key={`${step.id}-${i}`} className="flex items-center gap-1">
+                <span className="text-[var(--color-text-dimmer)]">/</span>
+                <button
+                  type="button"
+                  onClick={() => popDrillTo(i + 1)}
+                  className={`rounded-md px-2 py-1 transition-colors ${
+                    i === drillPath.length - 1
+                      ? 'bg-[var(--color-accent)]/15 text-[var(--color-accent)]'
+                      : 'text-[var(--color-text-dim)] hover:text-[var(--color-text)]'
+                  }`}
+                  data-testid={`dashboard-breadcrumb-${i}`}
+                >
+                  {step.name}
+                </button>
+              </span>
+            ))}
+          </nav>
+        ) : null}
 
         {/* Treemap surface */}
         <div

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/JobsTable.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/JobsTable.tsx
@@ -467,7 +467,12 @@ const JOBS_TABLE_CSS = `
   display: flex;
   flex-wrap: wrap;
   gap: 0.75rem;
-  align-items: center;
+  /* #531 item 3: align all controls (search input + filter dropdowns
+     + result count) on the same vertical baseline. Filter labels
+     stack the caption *above* the select; aligning to the bottom
+     keeps every interactive surface on one row regardless of which
+     children carry a caption. */
+  align-items: flex-end;
   margin-bottom: 0.75rem;
 }
 
@@ -488,12 +493,15 @@ const JOBS_TABLE_CSS = `
 }
 .jobs-search-input {
   width: 100%;
-  padding: 0.45rem 0.7rem 0.45rem 1.9rem;
+  /* Match the filter-select height (0.32rem padding + 0.82rem font ≈
+     1.46rem) so the search input and the dropdowns sit on the same
+     baseline once .jobs-toolbar aligns them to flex-end. */
+  padding: 0.32rem 0.7rem 0.32rem 1.9rem;
   background: var(--color-surface);
   border: 1px solid var(--color-border);
-  border-radius: 8px;
+  border-radius: 6px;
   color: var(--color-text);
-  font-size: 0.85rem;
+  font-size: 0.82rem;
   outline: none;
   transition: border-color 0.15s ease;
 }
@@ -504,7 +512,7 @@ const JOBS_TABLE_CSS = `
 .jobs-filters {
   display: flex;
   gap: 0.6rem;
-  align-items: center;
+  align-items: flex-end;
   flex-wrap: wrap;
 }
 .jobs-filter-label {

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/NotificationsPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/NotificationsPage.tsx
@@ -1,0 +1,76 @@
+/**
+ * NotificationsPage — dedicated full-page surface for the in-memory
+ * notification list (#531 item 1).
+ *
+ * Rationale: the bell dropdown shows the same list compactly, but the
+ * page-level surface gives the operator room to scroll long error
+ * traces, review every active notification at once, and clear them in
+ * bulk without juggling a popover.
+ *
+ * Layout contract — same chrome as Apps / Jobs / Cloud / Settings:
+ *   • PortalShell (Sidebar + top header band, page title left-aligned)
+ *   • Body: header row with bulk-clear CTA + the `<NotificationListPanel />`
+ *
+ * Per docs/INVIOLABLE-PRINCIPLES.md #4 (never hardcode), the empty
+ * state copy is centralised in the panel component so the bell and
+ * the page can never drift apart.
+ */
+
+import { useParams } from '@tanstack/react-router'
+import { PortalShell } from './PortalShell'
+import { useDeploymentEvents } from './useDeploymentEvents'
+import {
+  NotificationListPanel,
+  useNotifications,
+} from '@/shared/ui/notifications'
+
+export interface NotificationsPageProps {
+  /** Test seam — disables the live SSE attach. */
+  disableStream?: boolean
+}
+
+export function NotificationsPage({
+  disableStream = false,
+}: NotificationsPageProps = {}) {
+  const params = useParams({
+    from: '/provision/$deploymentId/notifications' as never,
+  }) as { deploymentId: string }
+  const deploymentId = params.deploymentId
+
+  const { snapshot } = useDeploymentEvents({
+    deploymentId,
+    applicationIds: [],
+    disableStream,
+  })
+  const sovereignFQDN = snapshot?.sovereignFQDN ?? snapshot?.result?.sovereignFQDN ?? null
+
+  const { items, dismiss, dismissAll } = useNotifications()
+
+  return (
+    <PortalShell
+      deploymentId={deploymentId}
+      sovereignFQDN={sovereignFQDN}
+      pageTitle="Notifications"
+    >
+      <div className="mx-auto max-w-3xl" data-testid="notifications-page">
+        <header className="mb-4 flex items-center justify-between gap-3">
+          <p className="text-sm text-[var(--color-text-dim)]">
+            Provisioning failures and other status updates emitted by the
+            Sovereign control plane.
+          </p>
+          {items.length > 0 ? (
+            <button
+              type="button"
+              data-testid="notifications-page-clear-all"
+              onClick={() => dismissAll()}
+              className="rounded-md border border-[var(--color-border)] bg-transparent px-3 py-1 text-xs text-[var(--color-text-dim)] hover:border-[var(--color-accent)] hover:text-[var(--color-accent)]"
+            >
+              Clear all
+            </button>
+          ) : null}
+        </header>
+        <NotificationListPanel items={items} dismiss={dismiss} variant="page" />
+      </div>
+    </PortalShell>
+  )
+}

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/PortalShell.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/PortalShell.tsx
@@ -5,16 +5,23 @@
  *   • flex min-h-screen wrapper
  *   • left rail: <Sidebar /> w-56 fixed
  *   • main: ml-56 flex-1 with a 56px sticky header band hosting the
- *     ThemeToggle (top-right) and a 32px main content area.
+ *     NotificationBell + ThemeToggle (top-right) and the page title
+ *     left-aligned at the start of the band.
  *
- * Per issue #366 item 2, the header band is a 3-slot flex grid:
- *   • Left  — optional `headerSlotLeft` (breadcrumb / sub-nav / back-link).
- *   • Centre — `pageTitle` rendered as <h1> at `[data-testid=portal-header-title]`.
- *   • Right — optional `headerSlotRight` (FQDN switcher etc.) +
- *             ThemeToggle.
+ * Per founder mandate #531 (2026-05-02), the page title is left-aligned
+ * (sat in the LEFT slot), and a NotificationBell is rendered to the
+ * LEFT of the ThemeToggle in the right slot. The previous 3-slot
+ * centred-title layout (#366 item 2) has been retired — operators
+ * universally read titles from the upper-left of the surface, and the
+ * centred treatment was cited as one of the polish bugs to remove.
  *
- * Each slot occupies `flex: 1` so the title is visually centred in
- * the page header, regardless of whether the side slots have content.
+ * Header layout (left → right):
+ *   • title (h1, left)            — `pageTitle`
+ *   • optional left slot          — `headerSlotLeft` (breadcrumb / sub-nav)
+ *   • flex spacer
+ *   • optional right slot         — `headerSlotRight` (FQDN switcher etc.)
+ *   • <NotificationBell />        — global notifications affordance
+ *   • <ThemeToggle />             — theme switcher
  *
  * The canonical shell handles auth + tenant resolution; in the
  * Sovereign-provision wizard context that's not relevant — the wizard
@@ -30,18 +37,21 @@
 import type { ReactNode } from 'react'
 import { Sidebar } from './Sidebar'
 import { ThemeToggle } from '@/components/ThemeToggle'
+import { NotificationBell } from '@/shared/ui/notifications'
 
 interface PortalShellProps {
   /** Stable deploymentId from the URL parameter. */
   deploymentId: string
   /** Resolved Sovereign FQDN (passed through to Sidebar's tenant slot). */
   sovereignFQDN?: string | null
-  /** Page title shown in the header centre slot (issue #366 item 2). */
+  /** Page title shown left-aligned at the start of the header. */
   pageTitle?: string
-  /** Optional left slot — breadcrumb / sub-nav / back link. */
+  /** Optional left slot — breadcrumb / sub-nav / back link. Renders to
+   *  the right of the title so a back-link reads as a sub-affordance
+   *  of the page's identity. */
   headerSlotLeft?: ReactNode
   /** Optional right slot — FQDN switcher / page-specific affordances.
-   *  Rendered LEFT of the ThemeToggle. */
+   *  Rendered LEFT of the NotificationBell + ThemeToggle. */
   headerSlotRight?: ReactNode
   children: ReactNode
 }
@@ -61,21 +71,14 @@ export function PortalShell({
     >
       <Sidebar deploymentId={deploymentId} sovereignFQDN={sovereignFQDN} />
       <div className="ml-56 flex flex-1 flex-col">
-        {/* Sovereign portal top header band — 3 equal slots so the page
-            title sits centred regardless of side-slot content (#366). */}
+        {/* Sovereign portal top header band — title-left, controls-right. */}
         <header
           data-testid="portal-header"
           className="sticky top-0 z-40 flex h-14 items-center gap-3 border-b border-[var(--color-border)] bg-[var(--color-bg-2)]/90 px-4 backdrop-blur"
         >
           <div
             data-testid="portal-header-left"
-            className="flex flex-1 min-w-0 items-center justify-start gap-2"
-          >
-            {headerSlotLeft}
-          </div>
-          <div
-            data-testid="portal-header-center"
-            className="flex flex-1 min-w-0 items-center justify-center"
+            className="flex min-w-0 flex-1 items-center gap-3"
           >
             {pageTitle ? (
               <h1
@@ -85,12 +88,14 @@ export function PortalShell({
                 {pageTitle}
               </h1>
             ) : null}
+            {headerSlotLeft}
           </div>
           <div
             data-testid="portal-header-right"
-            className="flex flex-1 min-w-0 items-center justify-end gap-3"
+            className="flex shrink-0 items-center gap-3"
           >
             {headerSlotRight}
+            <NotificationBell />
             <ThemeToggle />
           </div>
         </header>

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/SettingsPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/SettingsPage.tsx
@@ -150,9 +150,17 @@ export function SettingsPage({ disableStream = false }: SettingsPageProps = {}) 
   return (
     <PortalShell deploymentId={deploymentId} sovereignFQDN={sovereignFQDN} pageTitle="Settings">
       <div className="mx-auto max-w-7xl" data-testid="settings-page">
-        <div className="grid grid-cols-12 gap-6">
+        {/* #531 item 6: founder-mandated narrower left rail (~180px).
+            The previous col-span-3 grid carved out ~25% of the page
+            width for nine short labels; flex with a fixed-width aside
+            keeps the rail compact while letting the right pane consume
+            the remaining width. */}
+        <div className="flex flex-col gap-6 sm:flex-row">
           {/* ── In-page left rail ─────────────────────────────── */}
-          <aside className="col-span-3" data-testid="settings-toc">
+          <aside
+            className="w-full shrink-0 sm:w-[180px]"
+            data-testid="settings-toc"
+          >
             <nav className="sticky top-20 flex flex-col gap-1 text-sm">
               {SECTIONS.map((s) => (
                 <a
@@ -168,7 +176,7 @@ export function SettingsPage({ disableStream = false }: SettingsPageProps = {}) 
           </aside>
 
           {/* ── Right pane — sections stacked ─────────────────── */}
-          <main className="col-span-9 flex flex-col gap-6">
+          <main className="flex min-w-0 flex-1 flex-col gap-6">
             {/* 1. Organization */}
             <SectionCard id="organization" title="Organization" description={SECTIONS[0]!.description}>
               <FieldGrid>

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-list/CloudKindChips.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-list/CloudKindChips.tsx
@@ -287,13 +287,22 @@ const CLOUD_KIND_CHIPS_CSS = `
   color: var(--color-accent);
 }
 
-.cloud-kind-chip-more-wrap { position: relative; }
+/* #531 item 5: the More popover used to sit *behind* the page-body
+   header + table because every later sibling on the page (with z-index
+   auto) painted on top of an absolutely-positioned descendant whose
+   parent's stacking context was also auto. Establishing a stacking
+   context on .cloud-kind-chip-more-wrap (and giving the popover an
+   explicit, very-high z-index) guarantees the popover paints above
+   subsequent toolbar / list-table content. */
+.cloud-kind-chip-more-wrap { position: relative; z-index: 50; }
 .cloud-kind-chip-more { color: var(--color-text); }
 .cloud-kind-chip-more-pop {
   position: absolute;
   right: 0;
   top: calc(100% + 6px);
-  z-index: 30;
+  /* High z-index so the popover paints above downstream page sections
+     (cloud header, list table) regardless of their stacking order. */
+  z-index: 2000;
   display: flex;
   flex-direction: column;
   gap: 0.15rem;

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-list/cloudListCss.ts
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-list/cloudListCss.ts
@@ -10,7 +10,12 @@ export const CLOUD_LIST_CSS = `
   display: flex;
   flex-wrap: wrap;
   gap: 0.75rem;
-  align-items: center;
+  /* #531 item 3: align all controls (search input + filter dropdowns
+     + result count) on the same vertical baseline. Filter labels
+     stack the caption above the select; aligning to the bottom keeps
+     every interactive surface on the same row regardless of which
+     children carry a caption. */
+  align-items: flex-end;
   margin-bottom: 0.75rem;
 }
 .cloud-list-search-wrap {
@@ -30,12 +35,14 @@ export const CLOUD_LIST_CSS = `
 }
 .cloud-list-search-input {
   width: 100%;
-  padding: 0.45rem 0.7rem 0.45rem 1.9rem;
+  /* Match the filter-select height so the search input baseline lines
+     up with the dropdown baselines once the toolbar aligns to flex-end. */
+  padding: 0.32rem 0.7rem 0.32rem 1.9rem;
   background: var(--color-surface);
   border: 1px solid var(--color-border);
-  border-radius: 8px;
+  border-radius: 6px;
   color: var(--color-text);
-  font-size: 0.85rem;
+  font-size: 0.82rem;
   outline: none;
   transition: border-color 0.15s ease;
 }
@@ -44,7 +51,7 @@ export const CLOUD_LIST_CSS = `
 .cloud-list-filters {
   display: flex;
   gap: 0.6rem;
-  align-items: center;
+  align-items: flex-end;
   flex-wrap: wrap;
 }
 .cloud-list-filter-label {

--- a/products/catalyst/bootstrap/ui/src/shared/ui/notifications.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/shared/ui/notifications.test.tsx
@@ -1,12 +1,20 @@
 /**
- * notifications.test.tsx — global toast surface (founder #475).
+ * notifications.test.tsx — global notification surface (founder #475 +
+ * #531).
  *
- *   • Provider mounts with no toasts initially → tray DOM is absent
- *   • notify() pushes a toast → renders title + body + raw + actions
- *   • notify() with the same id REPLACES the existing toast in-place
- *   • dismiss(id) removes the toast
+ * Founder #531 retired the bottom-right toast tray in favour of a
+ * top-right bell-icon dropdown + a standalone /notifications page,
+ * both rendering the same in-memory list. The provider itself no
+ * longer renders any visible chrome — its only job is to hold state
+ * and expose `notify` / `dismiss` / `dismissAll` via context.
+ *
+ *   • Provider mounts with no notifications → no visible surface
+ *   • notify() pushes an entry → bell + list panel render it
+ *   • notify() with the same id REPLACES the existing entry in-place
+ *   • dismiss(id) removes the entry, dismissAll() clears the list
  *   • action onClick fires + auto-dismisses unless dismissOnClick=false
  *   • level=error renders role="alert", everything else role="status"
+ *   • Bell exposes an unread-count badge and toggles the dropdown
  */
 
 import { describe, it, expect, afterEach, vi } from 'vitest'
@@ -18,6 +26,8 @@ import {
   act,
 } from '@testing-library/react'
 import {
+  NotificationBell,
+  NotificationListPanel,
   NotificationProvider,
   useNotifications,
   type NotificationLevel,
@@ -87,23 +97,37 @@ function PushButton({ opts }: { opts: PushOpts }) {
   )
 }
 
+/**
+ * List harness — pulls the live items + dismiss out of context and
+ * renders them through the same `<NotificationListPanel />` the bell
+ * dropdown and the standalone /notifications page consume. Asserting
+ * against this surface keeps the tests independent of the bell's
+ * dropdown open/close timing.
+ */
+function ListHarness() {
+  const { items, dismiss } = useNotifications()
+  return <NotificationListPanel items={items} dismiss={dismiss} variant="page" />
+}
+
 function renderHarness(opts: PushOpts = {}) {
   return render(
     <NotificationProvider>
       <PushButton opts={opts} />
+      <ListHarness />
     </NotificationProvider>,
   )
 }
 
 describe('NotificationProvider — empty state', () => {
-  it('does not render the tray when there are no notifications', () => {
+  it('renders the empty-state placeholder when there are no notifications', () => {
     renderHarness()
-    expect(screen.queryByTestId('notification-tray')).toBeNull()
+    expect(screen.getByTestId('notification-list-empty')).toBeTruthy()
+    expect(screen.queryByTestId('notification-list')).toBeNull()
   })
 })
 
 describe('NotificationProvider — push', () => {
-  it('renders a toast with title, body, raw block, and action buttons', () => {
+  it('renders a card with title, body, raw block, and action buttons', () => {
     renderHarness({
       id: 'deployment-failure:d-1',
       level: 'error',
@@ -114,7 +138,7 @@ describe('NotificationProvider — push', () => {
       onWipe: () => undefined,
     })
     fireEvent.click(screen.getByTestId('harness-push'))
-    expect(screen.getByTestId('notification-tray')).toBeTruthy()
+    expect(screen.getByTestId('notification-list')).toBeTruthy()
     expect(screen.getByText('Provisioning failed')).toBeTruthy()
     expect(screen.getByText(/terminal failure for deployment d-1/)).toBeTruthy()
     expect(
@@ -128,6 +152,7 @@ describe('NotificationProvider — push', () => {
     const { rerender } = render(
       <NotificationProvider>
         <PushButton opts={{ id: 't1', level: 'error', title: 'boom' }} />
+        <ListHarness />
       </NotificationProvider>,
     )
     fireEvent.click(screen.getByTestId('harness-push'))
@@ -136,6 +161,7 @@ describe('NotificationProvider — push', () => {
     rerender(
       <NotificationProvider>
         <PushButton opts={{ id: 't2', level: 'warn', title: 'careful' }} />
+        <ListHarness />
       </NotificationProvider>,
     )
     fireEvent.click(screen.getByTestId('harness-push'))
@@ -144,7 +170,7 @@ describe('NotificationProvider — push', () => {
 })
 
 describe('NotificationProvider — id-based replace', () => {
-  it('replaces an existing toast when notify() is called with the same id', () => {
+  it('replaces an existing entry when notify() is called with the same id', () => {
     function Harness() {
       const { notify } = useNotifications()
       return (
@@ -171,6 +197,7 @@ describe('NotificationProvider — id-based replace', () => {
     render(
       <NotificationProvider>
         <Harness />
+        <ListHarness />
       </NotificationProvider>,
     )
     fireEvent.click(screen.getByTestId('push-a'))
@@ -182,7 +209,7 @@ describe('NotificationProvider — id-based replace', () => {
 })
 
 describe('NotificationProvider — dismiss', () => {
-  it('removes the toast when the close button is clicked', () => {
+  it('removes the entry when the close button is clicked', () => {
     renderHarness({ id: 'x', level: 'info', title: 'hi' })
     fireEvent.click(screen.getByTestId('harness-push'))
     expect(screen.queryByTestId('notification-x')).toBeTruthy()
@@ -199,13 +226,103 @@ describe('NotificationProvider — dismiss', () => {
     expect(screen.queryByTestId('notification-y')).toBeNull()
   })
 
-  it('action with dismissOnClick=false fires onClick but keeps the toast', () => {
+  it('action with dismissOnClick=false fires onClick but keeps the entry', () => {
     const onRetry = vi.fn()
     renderHarness({ id: 'z', level: 'error', title: 'failed', onRetry })
     fireEvent.click(screen.getByTestId('harness-push'))
     fireEvent.click(screen.getByTestId('sov-failure-retry'))
     expect(onRetry).toHaveBeenCalledOnce()
     expect(screen.queryByTestId('notification-z')).toBeTruthy()
+  })
+
+  it('dismissAll() clears every entry at once', () => {
+    function Harness() {
+      const { notify, dismissAll } = useNotifications()
+      return (
+        <>
+          <button
+            data-testid="push-1"
+            onClick={() => notify({ id: 'a', level: 'info', title: 'a' })}
+          />
+          <button
+            data-testid="push-2"
+            onClick={() => notify({ id: 'b', level: 'info', title: 'b' })}
+          />
+          <button data-testid="clear" onClick={() => dismissAll()} />
+        </>
+      )
+    }
+    render(
+      <NotificationProvider>
+        <Harness />
+        <ListHarness />
+      </NotificationProvider>,
+    )
+    fireEvent.click(screen.getByTestId('push-1'))
+    fireEvent.click(screen.getByTestId('push-2'))
+    expect(screen.queryByTestId('notification-a')).toBeTruthy()
+    expect(screen.queryByTestId('notification-b')).toBeTruthy()
+    fireEvent.click(screen.getByTestId('clear'))
+    expect(screen.queryByTestId('notification-a')).toBeNull()
+    expect(screen.queryByTestId('notification-b')).toBeNull()
+  })
+})
+
+/* ── Bell icon + dropdown panel ─────────────────────────────────── */
+
+describe('NotificationBell', () => {
+  it('renders without a count badge when there are no notifications', () => {
+    render(
+      <NotificationProvider>
+        <NotificationBell />
+      </NotificationProvider>,
+    )
+    const bell = screen.getByTestId('notification-bell')
+    expect(bell).toBeTruthy()
+    expect(bell.getAttribute('data-count')).toBe('0')
+    expect(screen.queryByTestId('notification-bell-badge')).toBeNull()
+  })
+
+  it('shows the count badge when notifications are present', () => {
+    render(
+      <NotificationProvider>
+        <PushButton opts={{ id: 'one', level: 'error', title: 'boom' }} />
+        <NotificationBell />
+      </NotificationProvider>,
+    )
+    fireEvent.click(screen.getByTestId('harness-push'))
+    expect(screen.getByTestId('notification-bell-badge').textContent).toBe('1')
+  })
+
+  it('toggles the dropdown panel on click and renders the active list', () => {
+    render(
+      <NotificationProvider>
+        <PushButton opts={{ id: 'p1', level: 'info', title: 'tick' }} />
+        <NotificationBell />
+      </NotificationProvider>,
+    )
+    fireEvent.click(screen.getByTestId('harness-push'))
+    // Closed by default — panel not in DOM.
+    expect(screen.queryByTestId('notification-bell-panel')).toBeNull()
+    fireEvent.click(screen.getByTestId('notification-bell'))
+    expect(screen.getByTestId('notification-bell-panel')).toBeTruthy()
+    expect(screen.getByText('tick')).toBeTruthy()
+    // Click again → closes.
+    fireEvent.click(screen.getByTestId('notification-bell'))
+    expect(screen.queryByTestId('notification-bell-panel')).toBeNull()
+  })
+
+  it('clear-all button in the dropdown empties the list', () => {
+    render(
+      <NotificationProvider>
+        <PushButton opts={{ id: 'q', level: 'error', title: 'boom' }} />
+        <NotificationBell />
+      </NotificationProvider>,
+    )
+    fireEvent.click(screen.getByTestId('harness-push'))
+    fireEvent.click(screen.getByTestId('notification-bell'))
+    fireEvent.click(screen.getByTestId('notification-bell-clear-all'))
+    expect(screen.queryByTestId('notification-q')).toBeNull()
   })
 })
 

--- a/products/catalyst/bootstrap/ui/src/shared/ui/notifications.tsx
+++ b/products/catalyst/bootstrap/ui/src/shared/ui/notifications.tsx
@@ -1,23 +1,29 @@
 /**
- * notifications.tsx — global, app-wide toast surface.
+ * notifications.tsx — global, app-wide notification surface.
  *
- * Founder mandate (#475, 2026-05-01): page-level status banners (e.g. the
- * "Provisioning failed" banner that used to render above the apps grid)
- * pollute the surface they're attached to. The Apps page must show ONLY
- * the apps grid; deployment status must surface via a global notification
- * affordance — bottom-right toasts stack here.
+ * Founder mandate (#475, 2026-05-01): page-level status banners pollute
+ * the surface they're attached to. Status must surface via a global
+ * affordance.
  *
- * The provider is mounted once in `RootLayout` so toasts are visible
- * across every tab (Apps / Jobs / Dashboard / Cloud / Users) and survive
- * client-side navigation.
+ * Founder mandate (#531, 2026-05-02): the bottom-right toast tray is
+ * gone. Notifications now appear in a bell icon at the top-right of
+ * the PortalShell header (next to the ThemeToggle); clicking the bell
+ * opens a dropdown panel listing every active notification, and the
+ * same list is permanently visible at the dedicated `/notifications`
+ * page so an operator can step through past failures even when no
+ * toast is on screen.
  *
  * Public API:
- *   • <NotificationProvider>      — wraps the app, renders the toast tray
+ *   • <NotificationProvider>      — wraps the app, holds the in-memory list
+ *   • <NotificationBell />        — bell icon + count badge + dropdown panel
+ *   • <NotificationListPanel />   — full list, used by the bell dropdown AND
+ *                                   the standalone /notifications page
  *   • useNotifications()          — returns { notify, dismiss, items }
  *   • notify({ id?, level, title, body?, actions? })
  *
- * If `id` is supplied, calls with the same id REPLACE the existing toast
- * (so a deployment-failure update doesn't stack — it edits in-place).
+ * If `id` is supplied, calls with the same id REPLACE the existing
+ * notification (so a deployment-failure update doesn't stack — it
+ * edits in-place).
  *
  * Per docs/INVIOLABLE-PRINCIPLES.md #4 (never hardcode), every visual
  * value flows through CSS variables (`--color-danger`, `--color-warn`,
@@ -28,34 +34,37 @@ import {
   createContext,
   useCallback,
   useContext,
+  useEffect,
   useMemo,
+  useRef,
   useState,
   type ReactNode,
 } from 'react'
+import { Bell } from 'lucide-react'
 
 export type NotificationLevel = 'info' | 'warn' | 'error' | 'success'
 
 export interface NotificationAction {
   /** Visible label, e.g. "Retry stream" or "Cancel & Wipe". */
   label: string
-  /** Click handler — triggered before the toast is dismissed. */
+  /** Click handler — triggered before the notification is dismissed. */
   onClick: () => void
   /** Visual emphasis. `primary` matches the canonical accent button. */
   variant?: 'primary' | 'danger' | 'ghost'
-  /** When true (default) the toast is dismissed after `onClick` fires. */
+  /** When true (default) the notification is dismissed after `onClick` fires. */
   dismissOnClick?: boolean
   /** data-testid to expose for E2E. */
   testId?: string
 }
 
 export interface Notification {
-  /** Stable id — pass to replace an existing toast in-place. Auto-assigned if omitted. */
+  /** Stable id — pass to replace an existing notification in-place. Auto-assigned if omitted. */
   id: string
   level: NotificationLevel
   title: string
   /** Optional secondary body (string or pre-formatted error text). */
   body?: string
-  /** Action buttons rendered at the bottom of the toast. */
+  /** Action buttons rendered at the bottom of the card. */
   actions?: NotificationAction[]
   /**
    * Render a `<pre>` raw block (e.g. server error trace). Set this
@@ -63,14 +72,19 @@ export interface Notification {
    * without pre-wrapping arbitrary copy.
    */
   raw?: string
+  /** Wall-clock timestamp the notification was first surfaced. Used by
+   *  the standalone /notifications page to render a relative time. */
+  createdAt: number
 }
 
 interface NotificationsContextValue {
   items: readonly Notification[]
-  /** Push a new toast OR replace an existing one with the same id. */
-  notify: (n: Omit<Notification, 'id'> & { id?: string }) => string
+  /** Push a new notification OR replace an existing one with the same id. */
+  notify: (n: Omit<Notification, 'id' | 'createdAt'> & { id?: string }) => string
   /** Dismiss by id. No-op if the id is unknown. */
   dismiss: (id: string) => void
+  /** Dismiss every notification at once. */
+  dismissAll: () => void
 }
 
 const NotificationsContext = createContext<NotificationsContextValue | null>(null)
@@ -83,6 +97,18 @@ export function useNotifications(): NotificationsContextValue {
     )
   }
   return ctx
+}
+
+/**
+ * Internal "soft" variant of `useNotifications()` — returns null when
+ * no provider is mounted. Used by `<NotificationBell />` so the
+ * PortalShell can render the bell unconditionally without forcing
+ * every test fixture (which renders pages outside the global root
+ * layout) to mount its own NotificationProvider. Production never
+ * hits the `null` branch — the bell is a no-op stub in that case.
+ */
+function useOptionalNotifications(): NotificationsContextValue | null {
+  return useContext(NotificationsContext)
 }
 
 interface NotificationProviderProps {
@@ -98,12 +124,20 @@ export function NotificationProvider({ children }: NotificationProviderProps) {
     setItems((prev) => prev.filter((n) => n.id !== id))
   }, [])
 
+  const dismissAll = useCallback(() => {
+    setItems([])
+  }, [])
+
   const notify = useCallback<NotificationsContextValue['notify']>((n) => {
     const id = n.id ?? `auto-${++nextAutoId}`
-    const next: Notification = { ...n, id }
     setItems((prev) => {
       const idx = prev.findIndex((p) => p.id === id)
-      if (idx === -1) return [...prev, next]
+      if (idx === -1) {
+        const created: Notification = { ...n, id, createdAt: Date.now() }
+        return [...prev, created]
+      }
+      const existing = prev[idx]!
+      const next: Notification = { ...n, id, createdAt: existing.createdAt }
       const copy = [...prev]
       copy[idx] = next
       return copy
@@ -112,40 +146,184 @@ export function NotificationProvider({ children }: NotificationProviderProps) {
   }, [])
 
   const value = useMemo<NotificationsContextValue>(
-    () => ({ items, notify, dismiss }),
-    [items, notify, dismiss],
+    () => ({ items, notify, dismiss, dismissAll }),
+    [items, notify, dismiss, dismissAll],
   )
 
+  // The provider intentionally does NOT render any visible surface.
+  // The bell + dropdown lives in the PortalShell header and the
+  // standalone page at /notifications consumes the same context. Per
+  // founder mandate #531 the bottom-right toast tray is removed.
   return (
     <NotificationsContext.Provider value={value}>
       {children}
-      <NotificationTray items={items} dismiss={dismiss} />
     </NotificationsContext.Provider>
   )
 }
 
-interface NotificationTrayProps {
-  items: readonly Notification[]
-  dismiss: (id: string) => void
+/* ── Bell icon with dropdown panel ─────────────────────────────────── */
+
+export interface NotificationBellProps {
+  /** Optional class override for the trigger button — defaults match the
+   *  ThemeToggle chrome so the two sit side-by-side cleanly. */
+  className?: string
+  /** Icon size in px — defaults to 14, matching the ThemeToggle. */
+  size?: number
 }
 
 /**
- * Bottom-right stacked toast tray. Fixed positioning so the surface is
- * visible regardless of which page or tab is rendered. Tray is
- * unmounted entirely when there are no items, keeping the DOM clean
- * (and keeping the `role="alert"` / `role="status"` count at zero on
- * the page chrome).
+ * Bell icon button that lives at the right side of the PortalShell
+ * header. Renders an unread-count badge when there are active
+ * notifications and opens a panel listing them on click. The panel is
+ * the same `<NotificationListPanel />` rendered on the dedicated
+ * /notifications page so the surface is consistent across both
+ * affordances.
  */
-function NotificationTray({ items, dismiss }: NotificationTrayProps) {
-  if (items.length === 0) return null
+export function NotificationBell({ className, size = 14 }: NotificationBellProps) {
+  // `useOptionalNotifications` returns null when the bell is rendered
+  // outside a provider (e.g. unit-test fixtures that mount a single
+  // page without the RootLayout chrome). In that case the bell is
+  // visually present but inert — production always has the provider
+  // mounted via RootLayout.
+  const ctx = useOptionalNotifications()
+  const items = ctx?.items ?? []
+  const dismiss = ctx?.dismiss ?? (() => undefined)
+  const dismissAll = ctx?.dismissAll ?? (() => undefined)
+  const [open, setOpen] = useState(false)
+  const wrapRef = useRef<HTMLDivElement | null>(null)
+
+  // Close on click-outside / Esc — same pattern as the cloud chip
+  // popover and the row-actions menu.
+  useEffect(() => {
+    if (!open) return
+    function onDoc(ev: MouseEvent) {
+      if (!wrapRef.current?.contains(ev.target as Node)) setOpen(false)
+    }
+    function onKey(ev: KeyboardEvent) {
+      if (ev.key === 'Escape') setOpen(false)
+    }
+    document.addEventListener('mousedown', onDoc)
+    document.addEventListener('keydown', onKey)
+    return () => {
+      document.removeEventListener('mousedown', onDoc)
+      document.removeEventListener('keydown', onKey)
+    }
+  }, [open])
+
+  const count = items.length
+  const triggerClass =
+    className ??
+    'inline-flex items-center justify-center rounded-md border border-[var(--color-border)] bg-transparent text-[var(--color-text-dim)] hover:text-[var(--color-text-strong)] hover:border-[var(--color-accent)]/50 hover:bg-[var(--color-surface-hover)] transition-colors relative'
+
+  return (
+    <div ref={wrapRef} className="relative" data-testid="notification-bell-wrap">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-label={
+          count > 0
+            ? `${count} notification${count === 1 ? '' : 's'} — open list`
+            : 'No notifications'
+        }
+        aria-haspopup="menu"
+        aria-expanded={open}
+        title={
+          count > 0
+            ? `${count} notification${count === 1 ? '' : 's'}`
+            : 'No notifications'
+        }
+        data-testid="notification-bell"
+        data-count={count}
+        className={triggerClass}
+        style={{ width: 30, height: 30, padding: 0 }}
+      >
+        <Bell size={size} aria-hidden />
+        {count > 0 ? (
+          <span
+            data-testid="notification-bell-badge"
+            className="absolute -top-1 -right-1 inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-[var(--color-danger)] px-1 text-[10px] font-semibold leading-none text-white"
+            aria-hidden
+          >
+            {count > 9 ? '9+' : count}
+          </span>
+        ) : null}
+      </button>
+      {open && (
+        <div
+          data-testid="notification-bell-panel"
+          role="menu"
+          aria-label="Notifications"
+          className="absolute right-0 top-[calc(100%+6px)] z-[2000] w-[26rem] max-w-[calc(100vw-1rem)] overflow-hidden rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-2)] shadow-2xl"
+        >
+          <div className="flex items-center justify-between border-b border-[var(--color-border)] px-3 py-2">
+            <span className="text-sm font-semibold text-[var(--color-text-strong)]">
+              Notifications
+            </span>
+            {count > 0 ? (
+              <button
+                type="button"
+                data-testid="notification-bell-clear-all"
+                onClick={() => dismissAll()}
+                className="rounded-md border border-[var(--color-border)] bg-transparent px-2 py-0.5 text-[11px] text-[var(--color-text-dim)] hover:border-[var(--color-accent)] hover:text-[var(--color-accent)]"
+              >
+                Clear all
+              </button>
+            ) : null}
+          </div>
+          <div className="max-h-[60vh] overflow-y-auto p-2">
+            <NotificationListPanel
+              items={items}
+              dismiss={dismiss}
+              variant="dropdown"
+            />
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+/* ── List panel — used by both the bell dropdown and the page ──────── */
+
+interface NotificationListPanelProps {
+  items: readonly Notification[]
+  dismiss: (id: string) => void
+  /** `dropdown` keeps cards compact for the bell; `page` adds the
+   *  relative timestamp row and per-card padding. */
+  variant?: 'dropdown' | 'page'
+}
+
+export function NotificationListPanel({
+  items,
+  dismiss,
+  variant = 'page',
+}: NotificationListPanelProps) {
+  if (items.length === 0) {
+    return (
+      <div
+        data-testid="notification-list-empty"
+        className="flex flex-col items-center justify-center gap-1 rounded-md border border-dashed border-[var(--color-border)] bg-[var(--color-bg)] p-6 text-center text-sm text-[var(--color-text-dim)]"
+      >
+        <p className="font-medium text-[var(--color-text)]">No notifications</p>
+        <p className="text-xs">
+          Provisioning failures and other status updates will land here.
+        </p>
+      </div>
+    )
+  }
   return (
     <div
-      data-testid="notification-tray"
-      className="fixed bottom-4 right-4 z-[100] flex max-w-[26rem] flex-col gap-2"
+      data-testid="notification-list"
+      className="flex flex-col gap-2"
       aria-live="polite"
     >
       {items.map((n) => (
-        <NotificationCard key={n.id} item={n} dismiss={dismiss} />
+        <NotificationCard
+          key={n.id}
+          item={n}
+          dismiss={dismiss}
+          variant={variant}
+        />
       ))}
     </div>
   )
@@ -154,21 +332,29 @@ function NotificationTray({ items, dismiss }: NotificationTrayProps) {
 interface NotificationCardProps {
   item: Notification
   dismiss: (id: string) => void
+  variant: 'dropdown' | 'page'
 }
 
-function NotificationCard({ item, dismiss }: NotificationCardProps) {
+function NotificationCard({ item, dismiss, variant }: NotificationCardProps) {
   const tone = TONE_BY_LEVEL[item.level]
   return (
     <div
       role={item.level === 'error' ? 'alert' : 'status'}
       data-testid={`notification-${item.id}`}
       data-level={item.level}
-      className={`rounded-xl border ${tone.border} ${tone.surface} p-3 text-sm text-[var(--color-text)] shadow-lg`}
+      className={`rounded-xl border ${tone.border} ${tone.surface} ${
+        variant === 'page' ? 'p-4' : 'p-3'
+      } text-sm text-[var(--color-text)]`}
     >
       <div className="flex items-start gap-2">
         <h3 className={`m-0 flex-1 text-sm font-semibold ${tone.title}`}>
           {item.title}
         </h3>
+        {variant === 'page' ? (
+          <span className="text-[11px] text-[var(--color-text-dim)]">
+            {formatRelativeTime(item.createdAt)}
+          </span>
+        ) : null}
         <button
           type="button"
           aria-label="Dismiss notification"
@@ -248,4 +434,21 @@ const ACTION_CLASS: Record<NonNullable<NotificationAction['variant']>, string> =
     'rounded-md border border-[var(--color-danger)] bg-[var(--color-danger)] px-3 py-1 text-xs font-semibold text-white hover:opacity-90',
   ghost:
     'rounded-md border border-[var(--color-border)] bg-transparent px-3 py-1 text-xs text-[var(--color-text-dim)] hover:text-[var(--color-text)]',
+}
+
+/**
+ * Tiny relative-time formatter — avoids pulling in date-fns just to
+ * say "2 minutes ago" in the notifications page. Cap at "just now"
+ * for sub-minute durations and fall back to a locale string after a
+ * day.
+ */
+function formatRelativeTime(ts: number): string {
+  const delta = Math.max(0, Date.now() - ts)
+  const sec = Math.floor(delta / 1000)
+  if (sec < 60) return 'just now'
+  const min = Math.floor(sec / 60)
+  if (min < 60) return `${min} minute${min === 1 ? '' : 's'} ago`
+  const hr = Math.floor(min / 60)
+  if (hr < 24) return `${hr} hour${hr === 1 ? '' : 's'} ago`
+  return new Date(ts).toLocaleString()
 }


### PR DESCRIPTION
## Summary

Six founder-mandated UX cosmetics fixes for the Sovereign portal, shipped together as one polish pass.

| # | Item | Change |
|---|------|--------|
| 1 | Notification bell at top-right | Provider holds state only; `<NotificationBell />` renders next to the ThemeToggle. Bottom-right toast tray retired. New `/notifications` page surfaces the same list. |
| 2 | Page titles left-aligned | PortalShell header dropped the 3-slot centred-title grid in favour of title-left, controls-right. |
| 3 | Search ↔ filter alignment | Jobs + cloud-list toolbars now `align-items: flex-end` and shrink the search input to dropdown height so every control sits on the same baseline regardless of caption stacking. |
| 4 | Dashboard 'All' line | Breadcrumb hidden at root depth; reappears once the operator drills in. |
| 5 | +More cloud chip popover | Wrap now establishes a stacking context (`z-index: 50`); popover uses `z-index: 2000` so it paints above downstream page-body header / list table. |
| 6 | Settings left pane | Reduced from `col-span-3` (~25%) to a fixed 180px aside. |

## Test plan

- [x] `notifications.test.tsx` rewritten for the new bell + list-panel API (14 tests, green)
- [x] `Dashboard.test.tsx` breadcrumb-at-root assertion flipped to expect HIDDEN
- [x] All other Settings / Apps / JobsTable tests green (68 tests across the touched files)
- [x] `tsc --noEmit` clean
- [x] Live verification post-deploy: 6 screenshots at 1440×900 attached to issue #531 after image roll

Closes #531

🤖 Generated with [Claude Code](https://claude.com/claude-code)