### PR TITLE
fix(catalyst-api): Phase-1 watch waits for cloud-init kubeconfig (Closes #538)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/handler.go
+++ b/products/catalyst/bootstrap/api/internal/handler/handler.go
@@ -98,6 +98,16 @@ type Handler struct {
 	phase1MinBootstrapKitHRs int
 	phase1FirstSeenTimeout   time.Duration
 
+	// kubeconfigArrivalTimeout / kubeconfigArrivalPollInterval —
+	// runtime knobs for the polling loop that waits for cloud-init
+	// to PUT the new Sovereign's kubeconfig. Zero falls back to the
+	// env var → DefaultKubeconfigArrivalTimeout /
+	// DefaultKubeconfigArrivalPollInterval. Tests inject tiny
+	// values (e.g. 200ms / 50ms) so the kubeconfig-arrival path
+	// can be exercised in milliseconds. Issue #538.
+	kubeconfigArrivalTimeout      time.Duration
+	kubeconfigArrivalPollInterval time.Duration
+
 	// refreshWatchSeedTimeout — bound on how long
 	// POST /api/v1/deployments/{id}/refresh-watch blocks waiting for
 	// the bridge seed hook to fire. Zero falls back to

--- a/products/catalyst/bootstrap/api/internal/handler/kubeconfig.go
+++ b/products/catalyst/bootstrap/api/internal/handler/kubeconfig.go
@@ -77,9 +77,11 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/helmwatch"
 	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/provisioner"
 )
 
@@ -271,6 +273,16 @@ func (h *Handler) PutKubeconfig(w http.ResponseWriter, r *http.Request) {
 	// SovereignFQDN; the runProvisioning goroutine merges in
 	// ControlPlaneIP / LoadBalancerIP / ConsoleURL / GitOpsRepoURL
 	// when Phase 0 finishes.
+	//
+	// Issue #538 belt-and-braces: if a previous Phase-1 watch
+	// already terminated with OutcomeKubeconfigMissing (the
+	// pre-#538 short-circuit, or a #538 wait-loop that timed out
+	// before this PUT arrived), reset the terminal markers and
+	// the phase1Started guard so the goroutine kicked off below
+	// can actually run a fresh watch. Without this, the running
+	// catalyst-api would have a kubeconfig on disk + a terminal
+	// "failed" deployment record forever — exactly the live bug
+	// PutKubeconfig is supposed to defend against.
 	dep.mu.Lock()
 	if dep.Result == nil {
 		dep.Result = &provisioner.Result{
@@ -278,6 +290,30 @@ func (h *Handler) PutKubeconfig(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	dep.Result.KubeconfigPath = target
+	relaunchAfterTerminalKubeconfigMissing := false
+	if dep.Result.Phase1Outcome == helmwatch.OutcomeKubeconfigMissing {
+		// Clear the terminal markers so markPhase1Done writes the
+		// new outcome cleanly when the relaunched watch finishes,
+		// and clear phase1Started so the goroutine below isn't
+		// short-circuited by the at-most-once guard.
+		dep.Result.Phase1Outcome = ""
+		dep.Result.Phase1FinishedAt = nil
+		dep.Result.ComponentStates = nil
+		dep.Status = "phase1-watching"
+		dep.Error = ""
+		dep.FinishedAt = time.Time{}
+		dep.phase1Started = false
+		// The done/eventsCh channels were closed by runProvisioning
+		// when it called close(dep.eventsCh) / close(dep.done) at
+		// the end of the original run — see deployments.go after
+		// the runPhase1Watch invocation. Allocate fresh ones so the
+		// new watch's emits + SSE consumers + the close(...) in our
+		// goroutine below all see a live channel pair (mirrors
+		// resumePhase1Watch).
+		dep.eventsCh = make(chan provisioner.Event, 256)
+		dep.done = make(chan struct{})
+		relaunchAfterTerminalKubeconfigMissing = true
+	}
 	dep.mu.Unlock()
 	h.persistDeployment(dep)
 
@@ -286,14 +322,36 @@ func (h *Handler) PutKubeconfig(w http.ResponseWriter, r *http.Request) {
 		"sovereignFQDN", dep.Request.SovereignFQDN,
 		"path", target,
 		"bytes", len(body),
+		"relaunchAfterKubeconfigMissing", relaunchAfterTerminalKubeconfigMissing,
 	)
 
 	// Launch the helmwatch goroutine in the background. The PUT
 	// returns immediately; per-component events flow via the SSE
 	// stream the wizard already has open. The phase1Started guard
 	// ensures runProvisioning's later (synchronous) call is a
-	// no-op so we don't run two informers.
-	go h.runPhase1Watch(dep)
+	// no-op so we don't run two informers — except in the
+	// relaunch-after-kubeconfig-missing case, where we cleared the
+	// guard above so this fresh watch can run and supersede the
+	// terminal-failed state. Issue #538.
+	go func() {
+		h.runPhase1Watch(dep)
+		// On the relaunch path we own the channels we just
+		// allocated under the lock above (the original
+		// runProvisioning's close()s ran long ago). Mirror
+		// resumePhase1Watch's close-on-terminate logic so any SSE
+		// consumer waiting on `event: done` is released.
+		if relaunchAfterTerminalKubeconfigMissing {
+			dep.mu.Lock()
+			select {
+			case <-dep.done:
+				// Already closed (defensive).
+			default:
+				close(dep.eventsCh)
+				close(dep.done)
+			}
+			dep.mu.Unlock()
+		}
+	}()
 
 	w.WriteHeader(http.StatusNoContent)
 }

--- a/products/catalyst/bootstrap/api/internal/handler/phase1_watch.go
+++ b/products/catalyst/bootstrap/api/internal/handler/phase1_watch.go
@@ -58,6 +58,37 @@ const phase1MinBootstrapKitHRsEnv = "CATALYST_PHASE1_MIN_BOOTSTRAP_KIT_HRS"
 // watch's overall budget is phase1WatchTimeoutEnv.
 const phase1FirstSeenTimeoutEnv = "CATALYST_PHASE1_FIRST_SEEN_TIMEOUT"
 
+// kubeconfigArrivalTimeoutEnv — how long runPhase1Watch waits for the
+// cloud-init PUT to land /var/lib/catalyst/kubeconfigs/<id>.yaml on
+// disk before giving up with OutcomeKubeconfigMissing. Cloud-init
+// typically completes within 3-6 minutes after `tofu apply` returns;
+// 15 minutes is generous headroom for slow Hetzner regions or LB
+// reconcile delays. Tests inject a much shorter value via
+// Handler.kubeconfigArrivalTimeout.
+//
+// While waiting, dep.Status stays "phase1-watching" (NOT "failed")
+// — markPhase1Done is only called once the timeout elapses. Issue
+// #538: previously the watch terminated on the first miss, so when
+// runProvisioning launched it moments before cloud-init's PUT
+// landed, the deployment latched terminal-failed and the wizard
+// showed Install X jobs PENDING forever even when the new Sovereign
+// was actually healthy.
+const kubeconfigArrivalTimeoutEnv = "CATALYST_PHASE1_KUBECONFIG_ARRIVAL_TIMEOUT"
+
+// kubeconfigArrivalPollIntervalEnv — how often runPhase1Watch
+// re-checks for the kubeconfig file on disk while waiting for the
+// cloud-init PUT. 15 seconds keeps the wizard log pane responsive
+// without thrashing the PVC.
+const kubeconfigArrivalPollIntervalEnv = "CATALYST_PHASE1_KUBECONFIG_POLL_INTERVAL"
+
+// DefaultKubeconfigArrivalTimeout — production default for the
+// kubeconfig-arrival wait window. Issue #538.
+const DefaultKubeconfigArrivalTimeout = 15 * time.Minute
+
+// DefaultKubeconfigArrivalPollInterval — production default for the
+// kubeconfig-arrival poll cadence. Issue #538.
+const DefaultKubeconfigArrivalPollInterval = 15 * time.Second
+
 // runPhase1Watch builds a helmwatch.Watcher and runs it to completion.
 // All emit goes through h.emitWatchEvent so the durable buffer + SSE
 // channel get every per-component event.
@@ -73,6 +104,13 @@ func (h *Handler) runPhase1Watch(dep *Deployment) {
 	// goroutine; the second is a no-op. Without this, a duplicate
 	// run would spin up a second informer + emit a duplicate set of
 	// per-component events into the SSE buffer.
+	//
+	// Issue #538 nuance: PutKubeconfig clears phase1Started AND
+	// resets the terminal kubeconfig-missing markers BEFORE
+	// re-launching, so the belt-and-braces kick-the-watch path
+	// can run a fresh watch even after a previous attempt
+	// terminated kubeconfig-missing. See PutKubeconfig in
+	// kubeconfig.go for the reset logic.
 	dep.mu.Lock()
 	if dep.phase1Started {
 		dep.mu.Unlock()
@@ -82,43 +120,22 @@ func (h *Handler) runPhase1Watch(dep *Deployment) {
 		return
 	}
 	dep.phase1Started = true
-	kubeconfigPath := ""
-	if dep.Result != nil {
-		kubeconfigPath = dep.Result.KubeconfigPath
-	}
 	dep.mu.Unlock()
 
-	// Read the kubeconfig from disk. Plaintext lives only on the
-	// PVC at /var/lib/catalyst/kubeconfigs/<id>.yaml (chmod 0600),
-	// never in the on-disk JSON record. An empty path OR a missing
-	// file are both short-circuit cases — the wizard's FailureCard
-	// reads the emitted warn event so the operator can investigate
-	// the cloud-init postback.
-	kubeconfig := ""
-	if kubeconfigPath != "" {
-		raw, err := os.ReadFile(kubeconfigPath)
-		if err == nil {
-			kubeconfig = string(raw)
-		} else {
-			h.log.Warn("phase 1 watch: kubeconfig file not readable",
-				"id", dep.ID,
-				"path", kubeconfigPath,
-				"err", err,
-			)
-		}
-	}
-
-	if kubeconfig == "" {
-		h.emitWatchEvent(dep, provisioner.Event{
-			Time:    time.Now().UTC().Format(time.RFC3339),
-			Phase:   helmwatch.PhaseComponent,
-			Level:   "warn",
-			Message: "Phase-1 watch skipped: no kubeconfig is available on the catalyst-api side. The new Sovereign's cloud-init has not yet PUT its kubeconfig to /api/v1/deployments/{id}/kubeconfig — either Phase 0 is still in flight, or cloud-init failed to reach this endpoint. Operator can fetch the kubeconfig via SSH (see docs/RUNBOOK-PROVISIONING.md §Fetch kubeconfig via SSH) and re-run the deployment to observe per-component install state.",
-		})
-		// Short-circuit path — no watch ever ran. Outcome MUST be
-		// OutcomeKubeconfigMissing (not empty) so markPhase1Done sets
-		// Status to a truthful failed state instead of falling through
-		// to the default "ready" branch — issue #488.
+	// Wait for the kubeconfig file to appear on disk. The path
+	// pointer (dep.Result.KubeconfigPath) is set by PutKubeconfig
+	// when cloud-init's postback succeeds. While waiting, dep.Status
+	// stays "phase1-watching" — markPhase1Done is only called on
+	// timeout. Issue #538: previously the watch terminated on the
+	// first miss, so when runProvisioning launched it moments before
+	// cloud-init's PUT landed, the deployment latched terminal-failed
+	// and the wizard showed Install X jobs PENDING forever even when
+	// the new Sovereign was actually healthy.
+	kubeconfig, ok := h.waitForKubeconfig(dep)
+	if !ok {
+		// Timeout elapsed — surface kubeconfig-missing as before.
+		// The warn event was emitted by waitForKubeconfig at the
+		// final tick.
 		h.markPhase1Done(dep, nil, helmwatch.OutcomeKubeconfigMissing)
 		return
 	}
@@ -323,4 +340,96 @@ func (h *Handler) markPhase1Done(dep *Deployment, finalStates map[string]string,
 // env var the package reads. Returns "" if unset.
 func envOrEmpty(key string) string {
 	return os.Getenv(key)
+}
+
+// waitForKubeconfig polls for the cloud-init kubeconfig postback to
+// land on disk. Returns (kubeconfig-bytes, true) when the file
+// appears within the timeout, or ("", false) when the timeout
+// elapses. While waiting, an info-level component event is emitted
+// every poll-interval so the wizard log pane shows progress
+// instead of going silent. Issue #538.
+//
+// Timeout / poll cadence are runtime-configurable per
+// docs/INVIOLABLE-PRINCIPLES.md #4 — see kubeconfigArrivalTimeoutEnv
+// and kubeconfigArrivalPollIntervalEnv. Tests override via the
+// Handler.kubeconfigArrivalTimeout / kubeconfigArrivalPollInterval
+// fields so the path is exercised in milliseconds.
+func (h *Handler) waitForKubeconfig(dep *Deployment) (string, bool) {
+	timeout := h.kubeconfigArrivalTimeout
+	if timeout == 0 {
+		if v, _ := time.ParseDuration(envOrEmpty(kubeconfigArrivalTimeoutEnv)); v > 0 {
+			timeout = v
+		} else {
+			timeout = DefaultKubeconfigArrivalTimeout
+		}
+	}
+	pollEvery := h.kubeconfigArrivalPollInterval
+	if pollEvery == 0 {
+		if v, _ := time.ParseDuration(envOrEmpty(kubeconfigArrivalPollIntervalEnv)); v > 0 {
+			pollEvery = v
+		} else {
+			pollEvery = DefaultKubeconfigArrivalPollInterval
+		}
+	}
+
+	deadline := time.Now().Add(timeout)
+	first := true
+	for {
+		// Snapshot the current kubeconfig path under the lock.
+		// PutKubeconfig writes Result.KubeconfigPath under the same
+		// lock, so a concurrent PUT is observed atomically.
+		dep.mu.Lock()
+		path := ""
+		if dep.Result != nil {
+			path = dep.Result.KubeconfigPath
+		}
+		dep.mu.Unlock()
+
+		// If the path pointer is set, try to read it. The pointer
+		// can be set BEFORE the file is fully fsynced on slow disks
+		// — read errors fall through to the next poll tick.
+		if path != "" {
+			if raw, err := os.ReadFile(path); err == nil && len(raw) > 0 {
+				if !first {
+					h.emitWatchEvent(dep, provisioner.Event{
+						Time:    time.Now().UTC().Format(time.RFC3339),
+						Phase:   helmwatch.PhaseComponent,
+						Level:   "info",
+						Message: fmt.Sprintf("Phase-1 watch: kubeconfig received from cloud-init (%d bytes); starting per-component HelmRelease watch.", len(raw)),
+					})
+				}
+				return string(raw), true
+			}
+		}
+
+		// First tick is a single "waiting for cloud-init" message
+		// so the wizard log pane shows the watch is alive.
+		// Subsequent ticks are silent on the event bus (every 15s
+		// of "still waiting" log noise would drown the operator's
+		// view); we still poll the file system every tick so a
+		// PUT lands as soon as it arrives.
+		if first {
+			h.emitWatchEvent(dep, provisioner.Event{
+				Time:    time.Now().UTC().Format(time.RFC3339),
+				Phase:   helmwatch.PhaseComponent,
+				Level:   "info",
+				Message: fmt.Sprintf("Phase-1 watch: waiting for cloud-init to PUT the new Sovereign's kubeconfig (timeout %s, polling every %s).", timeout, pollEvery),
+			})
+			first = false
+		}
+
+		// Check the deadline AFTER an emit so the operator-visible
+		// log includes the final timeout reason.
+		if time.Now().After(deadline) {
+			h.emitWatchEvent(dep, provisioner.Event{
+				Time:    time.Now().UTC().Format(time.RFC3339),
+				Phase:   helmwatch.PhaseComponent,
+				Level:   "warn",
+				Message: fmt.Sprintf("Phase-1 watch: timed out after %s waiting for cloud-init kubeconfig postback. The new Sovereign's cloud-init never PUT its kubeconfig to /api/v1/deployments/{id}/kubeconfig — either Phase 0 failed, the LB never routed to the cloud-init endpoint, or cloud-init crashed. Operator can fetch the kubeconfig via SSH (see docs/RUNBOOK-PROVISIONING.md §Fetch kubeconfig via SSH) and re-run the deployment.", timeout),
+			})
+			return "", false
+		}
+
+		time.Sleep(pollEvery)
+	}
 }

--- a/products/catalyst/bootstrap/api/internal/handler/phase1_watch_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/phase1_watch_test.go
@@ -268,8 +268,17 @@ func TestRunPhase1Watch_FailedComponentFlipsStatusToFailed(t *testing.T) {
 // that a Sovereign was Ready when catalyst-api had never observed
 // it. The truthful state is "failed" with a kubeconfig-missing
 // outcome and an operator-actionable error message.
+//
+// Issue #538: the watch now POLLS for the cloud-init kubeconfig
+// rather than terminating on the first miss. To exercise the
+// terminal-on-timeout path deterministically the test injects a
+// tiny kubeconfigArrivalTimeout / kubeconfigArrivalPollInterval —
+// the polling loop runs for ~50 ms and then surfaces
+// OutcomeKubeconfigMissing as the original test expected.
 func TestRunPhase1Watch_EmptyKubeconfigShortCircuits(t *testing.T) {
 	h := NewWithPDM(silentLogger(), &fakePDM{})
+	h.kubeconfigArrivalTimeout = 50 * time.Millisecond
+	h.kubeconfigArrivalPollInterval = 10 * time.Millisecond
 	dep := makeDeploymentWithKubeconfig(t, h, "phase1-no-kubeconfig", "")
 	h.runPhase1Watch(dep)
 
@@ -688,6 +697,187 @@ func TestEvent_ComponentAndStateFieldsPresentForPhase1(t *testing.T) {
 	}
 	if !strings.Contains(got, `"state":"installed"`) {
 		t.Errorf("Phase-1 event missing state: %s", got)
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Issue #538 — Phase-1 watch waits for cloud-init's kubeconfig PUT
+// instead of terminating on the first miss.
+// ─────────────────────────────────────────────────────────────────────
+
+// TestRunPhase1Watch_WaitsForKubeconfigArrival proves that
+// runPhase1Watch polls for the kubeconfig file and proceeds when it
+// shows up partway through the wait window — instead of terminating
+// kubeconfig-missing on the first poll. This is the live bug from
+// otech21 (1a7328cc3a94210b): runProvisioning launched the watch
+// moments before cloud-init's PUT arrived, so the deployment latched
+// terminal-failed and the wizard showed Install X jobs PENDING
+// forever even though the cluster was healthy.
+//
+// The test races a goroutine that writes the kubeconfig file 50 ms
+// into the watch against a ~5 s deadline; the watch must observe
+// the kubeconfig and run the helmwatch successfully against the
+// fake dynamic client.
+func TestRunPhase1Watch_WaitsForKubeconfigArrival(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	h.dynamicFactory = fakeDynamicFactoryFromObjects(
+		makeReadyHR("bp-cilium"),
+	)
+	h.phase1WatchTimeout = 5 * time.Second
+	// 5 s of polling time, every 25 ms — tiny enough to keep the
+	// test fast but big enough that the writer goroutine has time
+	// to hand the file to the watch.
+	h.kubeconfigArrivalTimeout = 5 * time.Second
+	h.kubeconfigArrivalPollInterval = 25 * time.Millisecond
+
+	// Build a deployment whose KubeconfigPath is set BEFORE the
+	// watch starts (so the polling loop knows where to look) but
+	// whose file does NOT yet exist on disk — a faithful re-creation
+	// of the live race: dep.Result.KubeconfigPath was never going
+	// to be empty in production because PutKubeconfig sets it.
+	id := "phase1-arrival-race"
+	kcDir := t.TempDir()
+	kcPath := filepath.Join(kcDir, id+".yaml")
+	dep := &Deployment{
+		ID:        id,
+		Status:    "phase1-watching",
+		StartedAt: time.Now(),
+		eventsCh:  make(chan provisioner.Event, 256),
+		done:      make(chan struct{}),
+		Request: provisioner.Request{
+			SovereignFQDN: "test." + id + ".example",
+			Region:        "fsn1",
+		},
+		Result: &provisioner.Result{
+			SovereignFQDN:  "test." + id + ".example",
+			KubeconfigPath: kcPath,
+		},
+	}
+	h.deployments.Store(id, dep)
+
+	// Writer goroutine: after a short delay, drop the kubeconfig
+	// onto disk. The polling loop should pick it up on the next
+	// tick (≤25 ms later) and proceed with helmwatch.
+	go func() {
+		time.Sleep(60 * time.Millisecond)
+		_ = os.WriteFile(kcPath, []byte("fake-kubeconfig: yaml"), 0o600)
+	}()
+
+	h.runPhase1Watch(dep)
+
+	dep.mu.Lock()
+	defer dep.mu.Unlock()
+
+	if dep.Status != "ready" {
+		t.Fatalf("Status = %q, want %q (kubeconfig arrived mid-wait — watch must NOT terminate kubeconfig-missing on first miss; issue #538): error=%q outcome=%q",
+			dep.Status, "ready", dep.Error, func() string {
+				if dep.Result == nil {
+					return "<nil>"
+				}
+				return dep.Result.Phase1Outcome
+			}())
+	}
+	// Issue #538 contract: the watch ran (it didn't short-circuit
+	// kubeconfig-missing). Phase1Outcome is OutcomeKubeconfigMissing
+	// ONLY when the wait window times out without a PUT — anything
+	// else proves the wait succeeded and the watch took over.
+	if dep.Result == nil || dep.Result.Phase1Outcome == helmwatch.OutcomeKubeconfigMissing {
+		got := "<nil result>"
+		if dep.Result != nil {
+			got = dep.Result.Phase1Outcome
+		}
+		t.Errorf("Phase1Outcome = %q, want anything other than %q — kubeconfig arrived mid-wait (issue #538)", got, helmwatch.OutcomeKubeconfigMissing)
+	}
+	if dep.Result.ComponentStates["cilium"] != helmwatch.StateInstalled {
+		t.Errorf("ComponentStates[cilium] = %q, want %q",
+			dep.Result.ComponentStates["cilium"], helmwatch.StateInstalled)
+	}
+}
+
+// TestPutKubeconfig_RestartsWatchAfterTerminalKubeconfigMissing
+// proves the belt-and-braces second half of the issue #538 fix:
+// when a previous Phase-1 watch already terminated with
+// OutcomeKubeconfigMissing (the deployment is terminal-failed,
+// phase1Started=true, Phase1FinishedAt set), a successful
+// PutKubeconfig clears those terminal markers and launches a fresh
+// watch. The freshly-started watch picks the kubeconfig up off disk
+// and observes the bp-cilium HelmRelease, ending in Status=ready
+// with Phase1Outcome=ready.
+func TestPutKubeconfig_RestartsWatchAfterTerminalKubeconfigMissing(t *testing.T) {
+	h, _, id, bearer := makePutFixture(t, "phase1-watching")
+	h.dynamicFactory = fakeDynamicFactoryFromObjects(
+		makeReadyHR("bp-cilium"),
+	)
+	h.phase1WatchTimeout = 3 * time.Second
+	h.kubeconfigArrivalTimeout = 1 * time.Second
+	h.kubeconfigArrivalPollInterval = 10 * time.Millisecond
+
+	val, _ := h.deployments.Load(id)
+	dep := val.(*Deployment)
+
+	// Simulate the live state from otech21: a previous watch ran,
+	// timed out kubeconfig-missing, and latched the deployment in
+	// terminal-failed. phase1Started=true, Phase1Outcome=
+	// OutcomeKubeconfigMissing, Phase1FinishedAt set, Status=failed.
+	finishedAt := time.Now().UTC()
+	dep.mu.Lock()
+	dep.Status = "failed"
+	dep.Error = "Phase 1 watch never ran: kubeconfig missing"
+	dep.FinishedAt = finishedAt
+	dep.phase1Started = true
+	dep.Result.Phase1Outcome = helmwatch.OutcomeKubeconfigMissing
+	dep.Result.Phase1FinishedAt = &finishedAt
+	dep.Result.ComponentStates = map[string]string{}
+	// runProvisioning's close()s would have run when the original
+	// watch terminated; close them here too so the relaunch path's
+	// channel-allocation branch is genuinely exercised.
+	close(dep.eventsCh)
+	close(dep.done)
+	dep.mu.Unlock()
+
+	// Drive the cloud-init PUT.
+	w := httptest.NewRecorder()
+	r := putReq(t, id, bearer, []byte("fake-kubeconfig: yaml"))
+	h.PutKubeconfig(w, r)
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("PUT status = %d, want 204; body=%s", w.Code, w.Body.String())
+	}
+
+	// Wait for the relaunched watch to terminate. With a fake
+	// dynamic client + ~3 s phase1WatchTimeout it should land
+	// within ~1 s.
+	deadline := time.Now().Add(6 * time.Second)
+	for time.Now().Before(deadline) {
+		dep.mu.Lock()
+		done := dep.Result != nil &&
+			dep.Result.Phase1Outcome != helmwatch.OutcomeKubeconfigMissing &&
+			dep.Result.Phase1Outcome != ""
+		dep.mu.Unlock()
+		if done {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	dep.mu.Lock()
+	defer dep.mu.Unlock()
+
+	if dep.Status != "ready" {
+		t.Fatalf("Status = %q, want %q after PUT-relaunch; outcome=%q error=%q (issue #538)",
+			dep.Status, "ready", dep.Result.Phase1Outcome, dep.Error)
+	}
+	// Issue #538 contract: the relaunched watch ran. The exact
+	// terminal outcome is OutcomeReady when the all-done gate fires
+	// (≥ MinBootstrapKitHRs observed) or OutcomeTimeout otherwise;
+	// what matters is that we are NOT still latched in
+	// OutcomeKubeconfigMissing.
+	if dep.Result.Phase1Outcome == helmwatch.OutcomeKubeconfigMissing || dep.Result.Phase1Outcome == "" {
+		t.Errorf("Phase1Outcome = %q, want anything other than %q/empty — PUT must have relaunched the watch (issue #538)",
+			dep.Result.Phase1Outcome, helmwatch.OutcomeKubeconfigMissing)
+	}
+	if dep.Result.ComponentStates["cilium"] != helmwatch.StateInstalled {
+		t.Errorf("ComponentStates[cilium] = %q, want %q (relaunched watch must observe HRs)",
+			dep.Result.ComponentStates["cilium"], helmwatch.StateInstalled)
 	}
 }
 


### PR DESCRIPTION
## Live bug

After PR #536 (the #530 healthz fix), catalyst-api stays alive long enough that cloud-init's kubeconfig PUT actually lands on disk — `/var/lib/catalyst/kubeconfigs/{id}.yaml` exists. BUT:

- catalyst-api's Phase-1 watch was already triggered moments before the kubeconfig arrived
- It hit the kubeconfig-missing short-circuit (#488 path), called `markPhase1Done(_, _, OutcomeKubeconfigMissing)`, set Status="failed"
- The deployment was now TERMINAL — nothing restarted the watch when kubeconfig arrived
- Wizard showed all Install X jobs PENDING forever even though the Sovereign cluster had 26+/38 HRs Ready=True

Live evidence: deployment `1a7328cc3a94210b` on contabo-mkt — `phase1Outcome: kubeconfig-missing` at 06:31:10, kubeconfig file existed on PVC at the same instant.

## Fix (Option C)

### 1. `phase1_watch.go` — runPhase1Watch polls instead of terminating on first miss

Replaces the immediate kubeconfig-missing short-circuit with a polling loop. New `waitForKubeconfig(dep)` helper:
- Polls every 15 s (default; runtime-configurable via `CATALYST_PHASE1_KUBECONFIG_POLL_INTERVAL`)
- Times out at 15 min (default; runtime-configurable via `CATALYST_PHASE1_KUBECONFIG_ARRIVAL_TIMEOUT`)
- While waiting, `dep.Status` stays `phase1-watching` — `markPhase1Done` is only called on timeout
- Emits one info event at start so the wizard log pane shows progress; on success emits a confirmation event

### 2. `kubeconfig.go` — PutKubeconfig resets terminal markers + relaunches watch

Belt-and-braces: if `dep.Result.Phase1Outcome == OutcomeKubeconfigMissing` when a successful PUT arrives:
- Clears `Phase1Outcome` / `Phase1FinishedAt` / `ComponentStates` / `Error`
- Sets `dep.Status = "phase1-watching"`, clears `dep.FinishedAt`
- Clears `phase1Started` so the at-most-once guard doesn't short-circuit the relaunch
- Re-allocates `eventsCh` + `done` (the originals were `close()`d at the end of runProvisioning)
- Goroutine launches `runPhase1Watch` and closes the new channels on terminate (mirrors `resumePhase1Watch`)

## Tests

- `TestRunPhase1Watch_EmptyKubeconfigShortCircuits` — updated. Injects 50 ms `kubeconfigArrivalTimeout` so the terminal-on-timeout path stays exercised deterministically.
- `TestRunPhase1Watch_WaitsForKubeconfigArrival` — NEW. Writes the kubeconfig file 60 ms into the watch, asserts the watch picks it up and proceeds (Status=ready, ComponentStates populated).
- `TestPutKubeconfig_RestartsWatchAfterTerminalKubeconfigMissing` — NEW. Simulates a deployment latched in `OutcomeKubeconfigMissing` (phase1Started=true, channels closed), drives the PUT, asserts the relaunched watch transitions to Status=ready.

All existing handler tests stay green (32.9 s suite); helmwatch + jobs + k8scache + store + dynadot + objectstorage all green.

## Test plan

- [x] `go test ./products/catalyst/bootstrap/api/...` all green
- [ ] catalyst-build image rolls
- [ ] Live: fresh otech provision, watch real-time logs show watch waiting for kubeconfig, then transitioning to per-component HR events when cloud-init PUTs
- [ ] Live: wizard `/jobs` page shows REAL HR Ready transitions on Install X rows

Closes #538

🤖 Generated with [Claude Code](https://claude.com/claude-code)