### PR TITLE
fix(infra): kubeconfig points at CP public IP not LB IP (Closes #542)

### DIFF
--- a/infra/hetzner/cloudinit-control-plane.tftpl
+++ b/infra/hetzner/cloudinit-control-plane.tftpl
@@ -693,9 +693,14 @@ runcmd:
   # local single-node install. catalyst-api lives off-cluster (Catalyst-Zero
   # franchise console on contabo-mkt) and cannot reach 127.0.0.1 on this
   # node, so we MUST rewrite that field before sending the kubeconfig
-  # back. The Hetzner load balancer at $${load_balancer_ipv4} forwards
-  # 6443 to the control plane's 6443 (firewall rule above), so a kubeconfig
-  # pointing at the LB's public IPv4 is reachable from anywhere.
+  # back.
+  #
+  # Issue #542: kubeconfig server: must be the control-plane's PUBLIC IPv4,
+  # NOT the load balancer's. The Hetzner LB only forwards 80/443 (Cilium
+  # Gateway ingress); 6443 is exposed directly on the CP via firewall rule
+  # main.tf:51-56 (0.0.0.0/0 → CP:6443). Earlier code rewrote to the LB IP
+  # which silently fails with "connect: connection refused" — wizard jobs
+  # page stuck PENDING for 50+ minutes after install completes.
   #
   # Plaintext: we read from /etc/rancher/k3s/k3s.yaml (mode 0644 written
   # by k3s), apply the rewrite via sed, write the result to
@@ -710,7 +715,7 @@ runcmd:
   # reconciliation) — the cloud-init runcmd budget is bounded by the
   # systemd cloud-final timeout (~30 minutes).
   - install -m 0600 /dev/null /etc/rancher/k3s/k3s.yaml.public
-  - sed 's|https://127.0.0.1:6443|https://${load_balancer_ipv4}:6443|g' /etc/rancher/k3s/k3s.yaml > /etc/rancher/k3s/k3s.yaml.public
+  - sed 's|https://127.0.0.1:6443|https://${control_plane_ipv4}:6443|g' /etc/rancher/k3s/k3s.yaml > /etc/rancher/k3s/k3s.yaml.public
   - chmod 0600 /etc/rancher/k3s/k3s.yaml.public
   - |
     curl -fsSL --retry 60 --retry-delay 10 --retry-all-errors \

--- a/infra/hetzner/main.tf
+++ b/infra/hetzner/main.tf
@@ -209,6 +209,7 @@ locals {
     kubeconfig_bearer_token = var.kubeconfig_bearer_token
     catalyst_api_url        = var.catalyst_api_url
     load_balancer_ipv4      = hcloud_load_balancer.main.ipv4
+    control_plane_ipv4      = hcloud_server.control_plane[0].ipv4_address
   }), "/(?m)^[ ]{0,2}# .*\n/", "")
 
   worker_cloud_init = replace(templatefile("${path.module}/cloudinit-worker.tftpl", {


### PR DESCRIPTION
## Root cause
Hetzner LB only forwards 80/443 (Cilium Gateway ingress). Port 6443 is exposed directly on the CP node via firewall rule (`main.tf:51-56`, `0.0.0.0/0 → CP:6443`).

Cloud-init was rewriting the kubeconfig `server:` to the LB's IP, which has nothing listening on 6443. Result: `connect: connection refused` on every catalyst-api helmwatch attempt → wizard jobs page stuck PENDING for 50+ minutes after cluster was healthy.

## Fix
Pass `control_plane_ipv4 = hcloud_server.control_plane[0].ipv4_address` into the cloud-init template, rewrite `server: https://127.0.0.1:6443` to `server: https://CP_IP:6443` instead of the LB.

## Verified
- Founder confirmed `https://178.104.211.206:6443` (otech22 CP IP) is reachable from contabo right now.
- Firewall already permits this — no infra change needed beyond the template var.

Closes #542.