### PR TITLE
fix(catalyst): DYNADOT_* env vars optional for Sovereign installs

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -58,7 +58,7 @@ spec:
   chart:
     spec:
       chart: bp-catalyst-platform
-      version: 1.1.9
+      version: 1.1.12
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-catalyst-platform
-version: 1.1.9
+version: 1.1.12
 appVersion: 1.1.6
 description: |
   Catalyst Platform — the unified Catalyst control plane umbrella chart for Catalyst-Zero.
@@ -80,6 +80,14 @@ description: |
   the umbrella ships ONLY Catalyst-Zero control-plane workloads; the
   foundation layer is owned end-to-end by the bootstrap-kit. Issue
   #510, 2026-05-02.
+  Bumped to 1.1.12 to add optional=true to the DYNADOT_API_KEY and
+  DYNADOT_API_SECRET secretKeyRef entries in the catalyst-api Deployment.
+  Sovereign clusters don't hold Dynadot credentials (their tenant DNS
+  is served by the Sovereign's own PowerDNS instance); without
+  optional=true Kubernetes refuses to start the pod when the
+  dynadot-api-credentials Secret is absent, crashlooping catalyst-api
+  on every new Sovereign. The fix mirrors the existing optional=true on
+  DYNADOT_MANAGED_DOMAINS and DYNADOT_DOMAIN. Issue #547, 2026-05-02.
 type: application
 
 # Opt-out from the blueprint-release hollow-chart guard (issue #181 / #510).

--- a/products/catalyst/chart/templates/api-deployment.yaml
+++ b/products/catalyst/chart/templates/api-deployment.yaml
@@ -143,11 +143,20 @@ spec:
                 secretKeyRef:
                   name: dynadot-api-credentials
                   key: api-key
+                  # optional=true: Sovereign clusters don't hold Dynadot
+                  # credentials — their tenant DNS is served by the
+                  # Sovereign's own PowerDNS instance, not the parent
+                  # account. Catalyst-Zero (contabo-mkt) supplies the
+                  # real secret; Sovereigns use an empty stub or omit it
+                  # entirely. Without optional=true the pod refuses to
+                  # start when the secret is absent (issue #547).
+                  optional: true
             - name: DYNADOT_API_SECRET
               valueFrom:
                 secretKeyRef:
                   name: dynadot-api-credentials
                   key: api-secret
+                  optional: true
             # DYNADOT_MANAGED_DOMAINS — comma-separated list of pool domains
             # the same Dynadot account manages. Per docs/INVIOLABLE-PRINCIPLES.md
             # #4, this is runtime configuration so adding a third pool domain


### PR DESCRIPTION
## Problem

`catalyst-api` crashloops on every new Sovereign with:
```
Error: secret "dynadot-api-credentials" not found
```

`api-deployment.yaml` lines 141-150 declared `DYNADOT_API_KEY` and `DYNADOT_API_SECRET` without `optional: true`. Sovereign clusters don't need Dynadot — their tenant DNS is served by the Sovereign's own PowerDNS instance.

## Fix

Add `optional: true` to both `secretKeyRef` entries, matching the existing pattern already on `DYNADOT_MANAGED_DOMAINS` and `DYNADOT_DOMAIN` (lines 160-175).

## Go code verified safe

`handler.go` uses `os.Getenv("DYNADOT_API_KEY")` which returns `""` when absent — the empty string is passed to OpenTofu tfvars only when `domain_mode == "pool"`. No hard-fail path when creds are empty.

## Runtime hotfix (otech22)

Stub secret already applied:
```bash
kubectl -n catalyst-system create secret generic dynadot-api-credentials \
  --from-literal=api-key= --from-literal=api-secret= --dry-run=client -o yaml | kubectl apply -f -
kubectl -n catalyst-system rollout restart deployment catalyst-api
```

## Chart bump

1.1.9 → 1.1.12 (1.1.10 + 1.1.11 consumed by parallel agents #543/#544).

Closes #547

🤖 Generated with [Claude Code](https://claude.com/claude-code)