### PR TITLE
fix: reflect powerdns-api-credentials to external-dns namespace (Closes #544)

### DIFF
--- a/clusters/_template/bootstrap-kit/11-powerdns.yaml
+++ b/clusters/_template/bootstrap-kit/11-powerdns.yaml
@@ -83,7 +83,7 @@ spec:
   chart:
     spec:
       chart: bp-powerdns
-      version: 1.1.3
+      version: 1.1.4
       sourceRef:
         kind: HelmRepository
         name: bp-powerdns

--- a/clusters/_template/bootstrap-kit/12-external-dns.yaml
+++ b/clusters/_template/bootstrap-kit/12-external-dns.yaml
@@ -14,6 +14,10 @@
 #     bp-powerdns Service and reads the `powerdns-api-credentials` Secret
 #     it renders. Without bp-powerdns the ExternalDNS pod CrashLoops
 #     trying to dial a non-existent DNS API.
+#   - bp-reflector — Reflector mirrors the `powerdns-api-credentials`
+#     Secret from the `powerdns` namespace to `external-dns` automatically
+#     (issue #544). bp-reflector must be running before bp-external-dns
+#     installs so the reflected Secret is present when the pod starts.
 
 ---
 apiVersion: v1
@@ -47,6 +51,7 @@ spec:
   dependsOn:
     - name: bp-cert-manager
     - name: bp-powerdns
+    - name: bp-reflector
   chart:
     spec:
       chart: bp-external-dns

--- a/clusters/omantel.omani.works/bootstrap-kit/11-powerdns.yaml
+++ b/clusters/omantel.omani.works/bootstrap-kit/11-powerdns.yaml
@@ -80,7 +80,7 @@ spec:
   chart:
     spec:
       chart: bp-powerdns
-      version: 1.1.3
+      version: 1.1.4
       sourceRef:
         kind: HelmRepository
         name: bp-powerdns

--- a/clusters/omantel.omani.works/bootstrap-kit/12-external-dns.yaml
+++ b/clusters/omantel.omani.works/bootstrap-kit/12-external-dns.yaml
@@ -14,6 +14,10 @@
 #     bp-powerdns Service and reads the `powerdns-api-credentials` Secret
 #     it renders. Without bp-powerdns the ExternalDNS pod CrashLoops
 #     trying to dial a non-existent DNS API.
+#   - bp-reflector — Reflector mirrors the `powerdns-api-credentials`
+#     Secret from the `powerdns` namespace to `external-dns` automatically
+#     (issue #544). bp-reflector must be running before bp-external-dns
+#     installs so the reflected Secret is present when the pod starts.
 
 ---
 apiVersion: v1
@@ -47,6 +51,7 @@ spec:
   dependsOn:
     - name: bp-cert-manager
     - name: bp-powerdns
+    - name: bp-reflector
   chart:
     spec:
       chart: bp-external-dns

--- a/clusters/otech.omani.works/bootstrap-kit/11-powerdns.yaml
+++ b/clusters/otech.omani.works/bootstrap-kit/11-powerdns.yaml
@@ -80,7 +80,7 @@ spec:
   chart:
     spec:
       chart: bp-powerdns
-      version: 1.1.3
+      version: 1.1.4
       sourceRef:
         kind: HelmRepository
         name: bp-powerdns

--- a/clusters/otech.omani.works/bootstrap-kit/12-external-dns.yaml
+++ b/clusters/otech.omani.works/bootstrap-kit/12-external-dns.yaml
@@ -14,6 +14,10 @@
 #     bp-powerdns Service and reads the `powerdns-api-credentials` Secret
 #     it renders. Without bp-powerdns the ExternalDNS pod CrashLoops
 #     trying to dial a non-existent DNS API.
+#   - bp-reflector — Reflector mirrors the `powerdns-api-credentials`
+#     Secret from the `powerdns` namespace to `external-dns` automatically
+#     (issue #544). bp-reflector must be running before bp-external-dns
+#     installs so the reflected Secret is present when the pod starts.
 
 ---
 apiVersion: v1
@@ -47,6 +51,7 @@ spec:
   dependsOn:
     - name: bp-cert-manager
     - name: bp-powerdns
+    - name: bp-reflector
   chart:
     spec:
       chart: bp-external-dns

--- a/platform/powerdns/chart/Chart.yaml
+++ b/platform/powerdns/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-powerdns
-version: 1.1.3
+version: 1.1.4
 description: |
   Catalyst-curated Blueprint wrapper for PowerDNS Authoritative.
   Carries Catalyst-specific values.yaml + templates (CNPG cluster, dnsdist

--- a/platform/powerdns/chart/templates/api-credentials-secret.yaml
+++ b/platform/powerdns/chart/templates/api-credentials-secret.yaml
@@ -71,6 +71,16 @@ metadata:
       Secret is stable across upgrades. Operator may override via
       .Values.powerdns.apiKey / .Values.powerdns.webserverPassword in the
       cluster overlay.
+    # Reflector cross-namespace mirror annotations (issue #544).
+    # bp-external-dns deploys to the `external-dns` namespace but reads
+    # this Secret by name — Reflector (bp-reflector, slot 05a) propagates
+    # the Secret automatically so no manual copy-paste is required.
+    # reflection-allowed-namespaces / reflection-auto-namespaces are
+    # comma-separated; add more if other blueprints need the API key.
+    reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
+    reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "external-dns"
+    reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
+    reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: "external-dns"
 type: Opaque
 stringData:
   api-key: {{ $apiKey | quote }}


### PR DESCRIPTION
## Summary

- **Root cause**: `bp-powerdns` creates `powerdns-api-credentials` Secret in the `powerdns` namespace, but `bp-external-dns` runs in `external-dns` and references the Secret by name. No cross-namespace propagation existed → pod crashed with `secret "powerdns-api-credentials" not found`.
- **Fix**: Add Reflector annotations to the `powerdns-api-credentials` Secret template in `bp-powerdns` so `bp-reflector` (slot 05a) auto-mirrors it to `external-dns`. Bump `bp-powerdns` chart version `1.1.3 → 1.1.4`.
- **DAG wiring**: Add `dependsOn: bp-reflector` to `bp-external-dns` HelmRelease in `_template` and per-Sovereign overlays (`otech` + `omantel`) so Flux waits for the mirror controller before installing ExternalDNS.
- **Runtime hotfix**: Already applied on otech22 via `kubectl get secret ... | jq ... | kubectl apply` + `rollout restart`. Pod is `1/1 Running` and processing DNS records.

## Files changed

| File | Change |
|------|--------|
| `platform/powerdns/chart/Chart.yaml` | Bump version 1.1.3 → 1.1.4 |
| `platform/powerdns/chart/templates/api-credentials-secret.yaml` | Add Reflector annotations |
| `clusters/_template/bootstrap-kit/11-powerdns.yaml` | Bump chart ref to 1.1.4 |
| `clusters/_template/bootstrap-kit/12-external-dns.yaml` | Add `dependsOn: bp-reflector` + comment |
| `clusters/otech.omani.works/bootstrap-kit/11-powerdns.yaml` | Bump chart ref to 1.1.4 |
| `clusters/otech.omani.works/bootstrap-kit/12-external-dns.yaml` | Add `dependsOn: bp-reflector` + comment |
| `clusters/omantel.omani.works/bootstrap-kit/11-powerdns.yaml` | Bump chart ref to 1.1.4 |
| `clusters/omantel.omani.works/bootstrap-kit/12-external-dns.yaml` | Add `dependsOn: bp-reflector` + comment |

## Test plan

- [x] Runtime hotfix verified: `kubectl get secret powerdns-api-credentials -n external-dns` exists on otech22
- [x] `kubectl -n external-dns get pods` shows `1/1 Running`
- [x] `kubectl -n external-dns logs` shows ExternalDNS reading `PDNSAPIKey:******` and connecting to `powerdns.powerdns.svc.cluster.local:8081`
- [ ] After `bp-powerdns 1.1.4` CI build lands: fresh Sovereign install verifies auto-mirror fires on Reflector startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)