### PR TITLE
fix(bp-powerdns): default cluster.namespace=powerdns not openova-system (Closes #553)

### DIFF
--- a/clusters/_template/bootstrap-kit/11-powerdns.yaml
+++ b/clusters/_template/bootstrap-kit/11-powerdns.yaml
@@ -83,7 +83,7 @@ spec:
   chart:
     spec:
       chart: bp-powerdns
-      version: 1.1.4
+      version: 1.1.5
       sourceRef:
         kind: HelmRepository
         name: bp-powerdns

--- a/clusters/omantel.omani.works/bootstrap-kit/11-powerdns.yaml
+++ b/clusters/omantel.omani.works/bootstrap-kit/11-powerdns.yaml
@@ -80,7 +80,7 @@ spec:
   chart:
     spec:
       chart: bp-powerdns
-      version: 1.1.4
+      version: 1.1.5
       sourceRef:
         kind: HelmRepository
         name: bp-powerdns

--- a/clusters/otech.omani.works/bootstrap-kit/11-powerdns.yaml
+++ b/clusters/otech.omani.works/bootstrap-kit/11-powerdns.yaml
@@ -80,7 +80,7 @@ spec:
   chart:
     spec:
       chart: bp-powerdns
-      version: 1.1.4
+      version: 1.1.5
       sourceRef:
         kind: HelmRepository
         name: bp-powerdns

--- a/platform/powerdns/chart/Chart.yaml
+++ b/platform/powerdns/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-powerdns
-version: 1.1.4
+version: 1.1.5
 description: |
   Catalyst-curated Blueprint wrapper for PowerDNS Authoritative.
   Carries Catalyst-specific values.yaml + templates (CNPG cluster, dnsdist

--- a/platform/powerdns/chart/values.yaml
+++ b/platform/powerdns/chart/values.yaml
@@ -264,7 +264,15 @@ postgres:
   # ─── Cluster ────────────────────────────────────────────────────────
   cluster:
     name: pdns-pg
-    namespace: openova-system
+    # On Sovereign clusters the chart's targetNamespace is `powerdns` and
+    # `openova-system` does not exist — Helm upgrade fails with
+    # `namespaces "openova-system" not found` and the CNPG Cluster CR is
+    # never applied, so the powerdns Deployment crashloops on the missing
+    # `pdns-pg-app` Secret. Default to the chart's own targetNamespace so
+    # the Secret materialises in the same place the consumer reads it
+    # from. Contabo legacy can override via per-Sovereign values overlay
+    # if it still uses openova-system. Issue #553.
+    namespace: powerdns
     instances: 1                 # bump to 3 alongside replicaCount=3 once we move beyond Phase-0 single-region
     storageSize: 5Gi
     storageClass: local-path     # Contabo k3s default; Sovereign Hetzner clusters override to hcloud-volumes


### PR DESCRIPTION
On Sovereign clusters `openova-system` ns doesn't exist. Helm aborts upgrade before applying the CNPG Cluster CR, so `pdns-pg-app` Secret never created → powerdns Deployment CreateContainerConfigError forever. Default to chart's targetNamespace. Closes #553.