### PR TITLE
fix(tls): Sovereign wildcard TLS — add dynadot-webhook slot 49b + fix DNS-01 JSON parsing

### DIFF
--- a/clusters/_template/bootstrap-kit/49b-bp-cert-manager-dynadot-webhook.yaml
+++ b/clusters/_template/bootstrap-kit/49b-bp-cert-manager-dynadot-webhook.yaml
@@ -1,0 +1,125 @@
+# bp-cert-manager-dynadot-webhook — Catalyst bootstrap-kit Blueprint #49b.
+#
+# Slot 49b sits adjacent to 49 (bp-cert-manager-powerdns-webhook). The
+# naming split reflects the two lifecycle phases:
+#   - 49b (this file) = PRE-handover DNS-01 solver. Dynadot IS
+#     authoritative for omani.works, so Let's Encrypt can validate
+#     challenges at public DNS resolution. Active from Day 0.
+#   - 49  (powerdns)  = POST-handover DNS-01 solver. Activates once the
+#     Sovereign owns its delegated subdomain and PowerDNS is the authority.
+#     Closes openova#373; gates #319.
+#
+# ──────────────────────────────────────────────────────────────────────────
+# Why this slot exists — Root cause of openova#550
+# ──────────────────────────────────────────────────────────────────────────
+# The bp-cert-manager chart ships a `letsencrypt-dns01-prod` ClusterIssuer
+# (in clusterissuer-letsencrypt-dns01.yaml) that points its DNS-01 solver
+# at the `acme.dynadot.openova.io` API group / solver `dynadot`. That
+# ClusterIssuer is ACTIVE on every new Sovereign (it is the pre-handover
+# issuer). The Certificate `kube-system/sovereign-wildcard-tls` references
+# it for the wildcard *.${SOVEREIGN_FQDN}.
+#
+# However, bootstrap-kit slot 49 installs bp-cert-manager-POWERDNS-webhook,
+# not the Dynadot webhook. Without the Dynadot webhook:
+#   1. No APIService for acme.dynadot.openova.io exists on the cluster.
+#   2. cert-manager's challenge controller gets:
+#      "dynadot.acme.dynadot.openova.io is forbidden: User
+#       system:serviceaccount:cert-manager:cert-manager cannot create
+#       resource dynadot in API group acme.dynadot.openova.io"
+#   3. The Certificate stays in state DoesNotExist/Issuing indefinitely.
+#   4. The Sovereign's HTTPS gateway has no TLS cert → SSL_ERROR_SYSCALL.
+#
+# Installing THIS blueprint (49b) before sovereign-tls is applied resolves
+# all four items above. The powerdns-webhook (slot 49) is still installed
+# so it is ready for post-handover without an additional bootstrap-kit edit.
+#
+# ──────────────────────────────────────────────────────────────────────────
+# Secret pre-requisite: cert-manager/dynadot-api-credentials
+# ──────────────────────────────────────────────────────────────────────────
+# The webhook Pod reads DYNADOT_API_KEY / DYNADOT_API_SECRET from a K8s
+# Secret named `dynadot-api-credentials` in the cert-manager namespace.
+# This Secret MUST exist before the Pod starts. cloud-init materializes it
+# at Sovereign boot time (infra/hetzner/cloudinit-control-plane.tftpl) from
+# the dynadot_key / dynadot_secret tfvars injected by the provisioner API.
+# If that Secret is absent, the Pod enters CrashLoopBackOff (secretKeyRef
+# required, not optional).
+#
+# ──────────────────────────────────────────────────────────────────────────
+# Wiring
+# ──────────────────────────────────────────────────────────────────────────
+# Wrapper chart: platform/cert-manager-dynadot-webhook/chart/
+# Catalyst-curated values: platform/cert-manager-dynadot-webhook/chart/values.yaml
+# Reconciled by: Flux on the new Sovereign's k3s control plane.
+#
+# dependsOn:
+#   - bp-cert-manager — provides the cert-manager.io CRDs + controllers.
+#                       Without this the ClusterIssuer (rendered by this
+#                       chart's clusterissuer.yaml) can't apply, and the
+#                       serving Certificate cert-manager generates for the
+#                       webhook itself can't be issued.
+
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: bp-cert-manager-dynadot-webhook
+  namespace: flux-system
+spec:
+  type: oci
+  interval: 15m
+  url: oci://ghcr.io/openova-io
+  secretRef:
+    name: ghcr-pull
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: bp-cert-manager-dynadot-webhook
+  namespace: flux-system
+spec:
+  interval: 15m
+  releaseName: cert-manager-dynadot-webhook
+  # Co-located with cert-manager so the webhook's serving Certificate
+  # (issued by the chart's selfSigned + CA Issuers) and APIService
+  # caBundle injection live in the same namespace cert-manager itself
+  # watches. Mirrors upstream chart convention.
+  targetNamespace: cert-manager
+  dependsOn:
+    - name: bp-cert-manager
+  chart:
+    spec:
+      chart: bp-cert-manager-dynadot-webhook
+      version: 1.1.0
+      sourceRef:
+        kind: HelmRepository
+        name: bp-cert-manager-dynadot-webhook
+        namespace: flux-system
+  # Event-driven install: the chart's ClusterIssuer template uses a
+  # Helm post-install hook that runs AFTER cert-manager's CRDs land,
+  # so blocking on Helm `--wait` for the leaf Certificate to reach
+  # Ready is unnecessary. Replaces blanket spec.timeout band-aids.
+  install:
+    disableWait: true
+    remediation:
+      retries: 3
+  upgrade:
+    disableWait: true
+    remediation:
+      retries: 3
+  values:
+    # ─── Paired ClusterIssuer ───────────────────────────────────────────
+    # Enables `letsencrypt-dns01-prod` wired to the Dynadot webhook.
+    # This is the PRE-handover issuer; the wildcard Certificate in
+    # clusters/_template/sovereign-tls/cilium-gateway-cert.yaml
+    # references it via issuerRef.name: letsencrypt-dns01-prod.
+    clusterIssuer:
+      enabled: true
+      email: "ops@${SOVEREIGN_FQDN}"
+      acmeServer: "https://acme-v02.api.letsencrypt.org/directory"
+    webhook:
+      # ghcr-pull is reflected into cert-manager namespace by the bootstrap
+      # kit (bp-reflector or the Flux source-controller's pull-secret
+      # propagation). Without this the Pod enters ImagePullBackOff on fresh
+      # Sovereigns because ghcr.io/openova-io/openova/* is a private registry.
+      imagePullSecrets:
+        - name: ghcr-pull

--- a/clusters/_template/bootstrap-kit/kustomization.yaml
+++ b/clusters/_template/bootstrap-kit/kustomization.yaml
@@ -44,3 +44,4 @@ resources:
   - 34-velero.yaml
   - 35-coraza.yaml
   - 49-bp-cert-manager-powerdns-webhook.yaml
+  - 49b-bp-cert-manager-dynadot-webhook.yaml

--- a/core/pkg/dynadot-client/client.go
+++ b/core/pkg/dynadot-client/client.go
@@ -119,14 +119,14 @@ func (c *Client) AddRecord(ctx context.Context, domain string, rec Record) error
 	}
 
 	var raw struct {
-		SetDNS2Response struct {
+		SetDNSResponse struct {
 			ResponseHeader respHeader `json:"ResponseHeader"`
-		} `json:"SetDns2Response"`
+		} `json:"SetDnsResponse"`
 	}
 	if err := json.Unmarshal(body, &raw); err != nil {
 		return fmt.Errorf("dynadot: parse set_dns2: %w (body=%s)", err, truncate(string(body), 256))
 	}
-	return classifyDynadotError(raw.SetDNS2Response.ResponseHeader)
+	return classifyDynadotError(raw.SetDNSResponse.ResponseHeader)
 }
 
 // DomainInfo is the parsed result of a `domain_info` call. Only the
@@ -255,14 +255,14 @@ func (c *Client) SetFullDNS(ctx context.Context, domain string, mains, subs []Re
 	}
 
 	var raw struct {
-		SetDNS2Response struct {
+		SetDNSResponse struct {
 			ResponseHeader respHeader `json:"ResponseHeader"`
-		} `json:"SetDns2Response"`
+		} `json:"SetDnsResponse"`
 	}
 	if err := json.Unmarshal(body, &raw); err != nil {
 		return fmt.Errorf("dynadot: parse set_dns2: %w (body=%s)", err, truncate(string(body), 256))
 	}
-	return classifyDynadotError(raw.SetDNS2Response.ResponseHeader)
+	return classifyDynadotError(raw.SetDNSResponse.ResponseHeader)
 }
 
 // RemoveSubRecord performs a safe read-modify-write that removes any
@@ -306,10 +306,15 @@ func (c *Client) RemoveSubRecord(ctx context.Context, domain string, match Recor
 // respHeader matches the Dynadot envelope's ResponseHeader on every
 // command. `ResponseCode` is 0 on success, non-zero on failure;
 // `Error` is human-readable.
+//
+// ResponseCode is typed as json.Number because the Dynadot api3.json
+// endpoint returns it as a JSON integer (e.g. `"ResponseCode":0`) rather
+// than a quoted string — using json.Number accepts both forms so the
+// client does not break if Dynadot ever changes its encoding.
 type respHeader struct {
-	ResponseCode string `json:"ResponseCode"`
-	Status       string `json:"Status"`
-	Error        string `json:"Error"`
+	ResponseCode json.Number `json:"ResponseCode"`
+	Status       string      `json:"Status"`
+	Error        string      `json:"Error"`
 }
 
 // classifyHTTP turns a transport-level outcome into a typed sentinel

--- a/core/pkg/dynadot-client/client_test.go
+++ b/core/pkg/dynadot-client/client_test.go
@@ -37,7 +37,7 @@ func TestAddRecord_AppendPath(t *testing.T) {
 	c, _ := stubServer(t, func(w http.ResponseWriter, r *http.Request) {
 		captured = r.URL.Query()
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"SetDns2Response":{"ResponseHeader":{"ResponseCode":"0","Status":"success"}}}`))
+		_, _ = w.Write([]byte(`{"SetDnsResponse":{"ResponseHeader":{"ResponseCode":0,"Status":"success"}}}`))
 	})
 
 	err := c.AddRecord(context.Background(), "omani.works", Record{
@@ -68,7 +68,7 @@ func TestAddRecord_ApexPath(t *testing.T) {
 	c, _ := stubServer(t, func(w http.ResponseWriter, r *http.Request) {
 		captured = r.URL.Query()
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"SetDns2Response":{"ResponseHeader":{"ResponseCode":"0","Status":"success"}}}`))
+		_, _ = w.Write([]byte(`{"SetDnsResponse":{"ResponseHeader":{"ResponseCode":0,"Status":"success"}}}`))
 	})
 
 	err := c.AddRecord(context.Background(), "omani.works", Record{
@@ -113,7 +113,7 @@ func TestRemoveSubRecord_PreservesOthers(t *testing.T) {
 		case "set_dns2":
 			setQuery = r.URL.Query()
 			w.Header().Set("Content-Type", "application/json")
-			_, _ = w.Write([]byte(`{"SetDns2Response":{"ResponseHeader":{"ResponseCode":"0","Status":"success"}}}`))
+			_, _ = w.Write([]byte(`{"SetDnsResponse":{"ResponseHeader":{"ResponseCode":0,"Status":"success"}}}`))
 		default:
 			t.Fatalf("unexpected command %q", r.URL.Query().Get("command"))
 		}

--- a/infra/hetzner/cloudinit-control-plane.tftpl
+++ b/infra/hetzner/cloudinit-control-plane.tftpl
@@ -170,6 +170,33 @@ write_files:
           }
         }))}
 
+  # ── cert-manager/dynadot-api-credentials Secret (issue #550) ─────────────
+  #
+  # The bp-cert-manager-dynadot-webhook Pod reads DYNADOT_API_KEY /
+  # DYNADOT_API_SECRET / DYNADOT_MANAGED_DOMAINS from this Secret at startup.
+  # The Secret MUST exist BEFORE the webhook Pod first starts — a missing
+  # secretKeyRef (required, not optional) causes CrashLoopBackOff.
+  #
+  # Namespace: cert-manager — the same namespace the HelmRelease targets
+  # (spec.targetNamespace: cert-manager in 49b-bp-cert-manager-dynadot-webhook.yaml).
+  #
+  # Why cloud-init and not a SealedSecret in git: the Dynadot credentials are
+  # operator-issued, forwarded from the provisioner API wizard payload, and must
+  # never land in a public git repository. Same rationale as ghcr-pull.
+  - path: /var/lib/catalyst/dynadot-api-credentials.yaml
+    permissions: '0600'
+    content: |
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: dynadot-api-credentials
+        namespace: cert-manager
+      type: Opaque
+      data:
+        api-key: ${base64encode(dynadot_key)}
+        api-secret: ${base64encode(dynadot_secret)}
+        domains: ${base64encode(dynadot_managed_domains)}
+
   # ── flux-system/object-storage Secret (issue #371, vendor-agnostic since #425) ─
   #
   # The Sovereign's per-cluster S3 credentials, materialised as a stock
@@ -819,6 +846,18 @@ runcmd:
   # rewrites this with the same content; a token rotation propagates
   # through here on the next cloud-init render.
   - 'kubectl --kubeconfig=/etc/rancher/k3s/k3s.yaml apply -f /var/lib/catalyst/ghcr-pull-secret.yaml'
+
+  # ── cert-manager/dynadot-api-credentials Secret (issue #550) ─────────
+  #
+  # Apply the Dynadot credentials BEFORE Flux reconciles the bootstrap-kit:
+  # bp-cert-manager-dynadot-webhook (slot 49b) references this Secret via
+  # secretKeyRef (required). A missing Secret causes CrashLoopBackOff and
+  # stalls TLS issuance from Day 0.
+  #
+  # cert-manager namespace is created by bp-cert-manager via Flux — we
+  # pre-create it idempotently here so the Secret apply does not fail.
+  - 'kubectl --kubeconfig=/etc/rancher/k3s/k3s.yaml create namespace cert-manager --dry-run=client -o yaml | kubectl --kubeconfig=/etc/rancher/k3s/k3s.yaml apply -f -'
+  - 'kubectl --kubeconfig=/etc/rancher/k3s/k3s.yaml apply -f /var/lib/catalyst/dynadot-api-credentials.yaml'
 
   # ── OpenBao auto-unseal seed Secret (issue #316) ─────────────────────
   #

--- a/infra/hetzner/main.tf
+++ b/infra/hetzner/main.tf
@@ -190,6 +190,15 @@ locals {
     # favour of XRC writes per ADR-0001 §11.3 + INVIOLABLE-PRINCIPLES #3.
     hcloud_token               = var.hcloud_token
 
+    # Dynadot credentials — injected into cert-manager/dynadot-api-credentials
+    # K8s Secret at cloud-init time so the bp-cert-manager-dynadot-webhook Pod
+    # can start without a manual secret-creation step (issue #550 root-cause fix).
+    # dynadot_managed_domains defaults to the parent zone of sovereign_fqdn when
+    # the caller leaves it blank — e.g. "omani.works" for "console.otech22.omani.works".
+    dynadot_key             = var.dynadot_key
+    dynadot_secret          = var.dynadot_secret
+    dynadot_managed_domains = coalesce(var.dynadot_managed_domains, join(".", slice(split(".", var.sovereign_fqdn), 1, length(split(".", var.sovereign_fqdn)))))
+
     # Cloud-init kubeconfig postback (issue #183, Option D). When
     # all three are non-empty, the template renders a runcmd that
     # rewrites k3s.yaml's 127.0.0.1:6443 to the LB's public IPv4

--- a/infra/hetzner/variables.tf
+++ b/infra/hetzner/variables.tf
@@ -244,6 +244,12 @@ variable "dynadot_secret" {
   sensitive   = true
 }
 
+variable "dynadot_managed_domains" {
+  type        = string
+  description = "Comma-separated list of pool domains the Dynadot webhook is permitted to mutate. Defaults to the parent zone of sovereign_fqdn when blank (e.g. 'omani.works' for 'console.otech22.omani.works')."
+  default     = ""
+}
+
 # ── GHCR pull token ───────────────────────────────────────────────────────
 #
 # Long-lived GHCR token (GitHub PAT or fine-grained token, scope

--- a/platform/cert-manager-dynadot-webhook/chart/Chart.yaml
+++ b/platform/cert-manager-dynadot-webhook/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: bp-cert-manager-dynadot-webhook
-version: 1.0.0
-appVersion: "1.0.0"
+version: 1.1.0
+appVersion: "1.1.0"
 description: |
   Catalyst-authored Blueprint chart for the cert-manager-dynadot-webhook
   binary. Deploys a TLS-fronted aggregated apiserver that cert-manager's

--- a/platform/cert-manager-dynadot-webhook/chart/templates/certificate.yaml
+++ b/platform/cert-manager-dynadot-webhook/chart/templates/certificate.yaml
@@ -33,7 +33,7 @@ spec:
   duration: {{ .Values.servingCert.duration }}
   renewBefore: {{ .Values.servingCert.renewBefore }}
   isCA: true
-  commonName: "ca.{{ include "bp-cert-manager-dynadot-webhook.fullname" . }}.cert-manager"
+  commonName: {{ printf "ca.%s" (include "bp-cert-manager-dynadot-webhook.fullname" .) | trunc 64 | trimSuffix "-" | quote }}
   privateKey:
     rotationPolicy: Always
     algorithm: ECDSA

--- a/platform/cert-manager-dynadot-webhook/chart/templates/clusterissuer.yaml
+++ b/platform/cert-manager-dynadot-webhook/chart/templates/clusterissuer.yaml
@@ -1,0 +1,84 @@
+{{/*
+ClusterIssuer paired with the Dynadot webhook above.
+
+Skip-render pattern (mirrors bp-cert-manager-powerdns-webhook/chart/templates/
+clusterissuer.yaml, lesson from #387 follow-up #402): when the operator has
+not opted in (default-values render, e.g. CI smoke test), this template emits
+NOTHING rather than failing the chart. The blueprint-release.yaml smoke-render
+gate (helm template with default values) therefore passes cleanly. Cluster
+overlays that want the ClusterIssuer flip `clusterIssuer.enabled=true` in the
+per-Sovereign values.
+
+Two gates:
+  1. clusterIssuer.enabled — operator opt-in (default false)
+  2. dynadot.credentialsSecret.name — required config; empty = skip render
+
+Rationale for this issuer vs the one already inside bp-cert-manager:
+  bp-cert-manager/chart/templates/clusterissuer-letsencrypt-dns01.yaml
+  renders `letsencrypt-dns01-prod` ONLY when certManager.issuers.dns01.enabled=true
+  (default false). On active Sovereigns that were bootstrapped before that
+  flag was set, OR on Sovereigns where the operator explicitly wants the
+  ClusterIssuer managed here (lifecycle tied to the webhook chart), this
+  paired ClusterIssuer is the more operationally coherent choice — it is
+  created and deleted with the webhook HelmRelease rather than with the
+  bp-cert-manager HelmRelease.
+
+  If both `letsencrypt-dns01-prod` ClusterIssuers coexist (one from
+  bp-cert-manager and one from this chart), they are idempotent — they carry
+  the same spec and the same ACME account-key Secret name. cert-manager last-
+  write-wins reconciliation means they converge on the same state.
+*/}}
+{{- if and .Values.clusterIssuer.enabled .Values.dynadot.credentialsSecret.name }}
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: {{ .Values.clusterIssuer.name }}
+  {{- if .Values.clusterIssuer.helmHookEnabled }}
+  annotations:
+    # Helm post-install/post-upgrade hook: ClusterIssuer is a
+    # cert-manager.io/v1 CRD that only exists AFTER the cert-manager
+    # controllers + CRDs (installed by bp-cert-manager) are running.
+    # Without the hook, Helm renders this template in the same install
+    # pass as the cert-manager controllers and the apply fails with
+    # `no matches for kind "ClusterIssuer"`. Same pattern as
+    # bp-cert-manager's own letsencrypt-dns01-prod / -http01-prod.
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "5"
+    "helm.sh/hook-delete-policy": before-hook-creation
+  {{- end }}
+  labels:
+    {{- include "bp-cert-manager-dynadot-webhook.labels" . | nindent 4 }}
+    catalyst.openova.io/issuer-class: dns01
+    catalyst.openova.io/issuer-backend: dynadot
+spec:
+  acme:
+    server: {{ .Values.clusterIssuer.acmeServer | quote }}
+    email: {{ .Values.clusterIssuer.email | quote }}
+    privateKeySecretRef:
+      name: {{ .Values.clusterIssuer.privateKeySecretRefName }}
+    solvers:
+      - dns01:
+          webhook:
+            groupName: {{ .Values.webhook.groupName | quote }}
+            solverName: {{ .Values.webhook.solverName | quote }}
+            config:
+              # The webhook reads these credentials at ChallengeRequest time
+              # from the Secret in the cert-manager release namespace (the
+              # secretKeyRef env vars in deployment.yaml supply them). The
+              # config block here is the cert-manager wire format — it is
+              # decoded by the webhook's ChallengeRequest handler, NOT by
+              # Kubernetes itself. All three refs below must resolve to a
+              # Secret in the WEBHOOK'S namespace (cert-manager) at runtime.
+              apiKeySecretRef:
+                name: {{ .Values.dynadot.credentialsSecret.name | quote }}
+                namespace: {{ .Values.dynadot.credentialsSecret.namespace | default .Release.Namespace | quote }}
+                key: {{ .Values.dynadot.credentialsSecret.keys.apiKey | quote }}
+              apiSecretSecretRef:
+                name: {{ .Values.dynadot.credentialsSecret.name | quote }}
+                namespace: {{ .Values.dynadot.credentialsSecret.namespace | default .Release.Namespace | quote }}
+                key: {{ .Values.dynadot.credentialsSecret.keys.apiSecret | quote }}
+              managedDomainsSecretRef:
+                name: {{ .Values.dynadot.credentialsSecret.name | quote }}
+                namespace: {{ .Values.dynadot.credentialsSecret.namespace | default .Release.Namespace | quote }}
+                key: {{ .Values.dynadot.credentialsSecret.keys.managedDomains | quote }}
+{{- end }}

--- a/platform/cert-manager-dynadot-webhook/chart/templates/deployment.yaml
+++ b/platform/cert-manager-dynadot-webhook/chart/templates/deployment.yaml
@@ -19,6 +19,10 @@ spec:
       serviceAccountName: {{ include "bp-cert-manager-dynadot-webhook.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.webhook.podSecurityContext | nindent 8 }}
+      {{- with .Values.webhook.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: webhook
           image: "{{ .Values.webhook.image.repository }}:{{ .Values.webhook.image.tag }}"

--- a/platform/cert-manager-dynadot-webhook/chart/templates/rbac.yaml
+++ b/platform/cert-manager-dynadot-webhook/chart/templates/rbac.yaml
@@ -74,4 +74,46 @@ subjects:
   - kind: ServiceAccount
     name: {{ include "bp-cert-manager-dynadot-webhook.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
+---
+# ─── Domain-solver RBAC ──────────────────────────────────────────────────────
+# cert-manager's challenge controller needs to CREATE resources on the webhook's
+# API group so it can dispatch DNS-01 challenges. Without this ClusterRole +
+# ClusterRoleBinding the challenge controller gets:
+#
+#   dynadot.acme.dynadot.openova.io is forbidden: User
+#   system:serviceaccount:cert-manager:cert-manager cannot create resource
+#   dynadot in API group acme.dynadot.openova.io
+#
+# This is the pattern prescribed at
+# https://cert-manager.io/docs/configuration/acme/dns01/webhook/#preparing-rbac
+# — the ClusterRole grants create on `*` under the webhook's groupName, and
+# is bound to cert-manager's ServiceAccount in cert-manager's namespace.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "bp-cert-manager-dynadot-webhook.fullname" . }}:domain-solver
+  labels:
+    {{- include "bp-cert-manager-dynadot-webhook.labels" . | nindent 4 }}
+rules:
+  - apiGroups:
+      - {{ .Values.webhook.groupName }}
+    resources:
+      - "*"
+    verbs:
+      - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "bp-cert-manager-dynadot-webhook.fullname" . }}:domain-solver
+  labels:
+    {{- include "bp-cert-manager-dynadot-webhook.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "bp-cert-manager-dynadot-webhook.fullname" . }}:domain-solver
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.certManager.serviceAccountName }}
+    namespace: {{ .Values.certManager.namespace }}
 {{- end }}

--- a/platform/cert-manager-dynadot-webhook/chart/values.yaml
+++ b/platform/cert-manager-dynadot-webhook/chart/values.yaml
@@ -156,7 +156,37 @@ rbac:
   #     (it's an aggregated apiserver, so the standard kube-apiserver
   #     proxying RBAC applies)
   #   - get on the Dynadot credentials Secret in openova-system
+  #   - domain-solver ClusterRole so cert-manager's SA can create
+  #     resources on the webhook's API group (resolves #550 "forbidden")
   create: true
+
+# ─── cert-manager identity (for domain-solver binding) ───────────────────
+# The domain-solver ClusterRoleBinding grants cert-manager's ServiceAccount
+# the right to CREATE on acme.dynadot.openova.io. Override only when the
+# cert-manager release uses a non-default SA name or namespace.
+certManager:
+  namespace: cert-manager
+  serviceAccountName: cert-manager
+
+# ─── Paired ClusterIssuer ────────────────────────────────────────────────
+# When enabled, the chart renders a `letsencrypt-dns01-prod` ClusterIssuer
+# wired to this webhook's solver. This is the PRE-handover issuer — active
+# while Dynadot is still authoritative for the Sovereign's parent zone
+# (omani.works). Set clusterIssuer.enabled=true in the bootstrap-kit
+# cluster overlay (see clusters/_template/bootstrap-kit/49b-bp-cert-manager-dynadot-webhook.yaml).
+clusterIssuer:
+  # Default false per BLUEPRINT-AUTHORING.md §skip-render pattern. The
+  # bootstrap-kit overlay flips this to true.
+  enabled: false
+  name: letsencrypt-dns01-prod
+  email: ""
+  acmeServer: "https://acme-v02.api.letsencrypt.org/directory"
+  # Name of the K8s Secret that cert-manager writes the ACME account
+  # private key into. Defaults to the well-known name cert-manager uses.
+  privateKeySecretRefName: letsencrypt-dns01-prod
+  # Post-install hook wiring — renders the ClusterIssuer via a Helm hook
+  # AFTER cert-manager CRDs land so kube-apiserver can admit it.
+  helmHookEnabled: true
 
 # ─── ServiceMonitor ──────────────────────────────────────────────────────
 # DEFAULT FALSE per docs/BLUEPRINT-AUTHORING.md §11.2. The


### PR DESCRIPTION
## Summary

- **Root cause (#550):** `bootstrap-kit` installs `bp-cert-manager-powerdns-webhook` (slot 49) but the `letsencrypt-dns01-prod` ClusterIssuer targets the dynadot webhook (`groupName: acme.dynadot.openova.io`). Without the dynadot webhook the APIService for `acme.dynadot.openova.io` does not exist → cert-manager SA gets `forbidden` on every ChallengeRequest → `sovereign-wildcard-tls` stays in `Issuing` indefinitely → HTTPS gateway has no TLS cert → `SSL_ERROR_SYSCALL` on the Sovereign's handover URL.
- **JSON bug:** Go dynadot client parsed `SetDns2Response` from JSON but the Dynadot API returns `SetDnsResponse`. Also `ResponseCode` is a JSON integer `0` not a string `"0"` — changed to `json.Number`. DNS writes WERE succeeding but the client erroneously returned an error on every call.
- **Chart gap:** `certificate.yaml` commonName was 76 bytes; cert-manager rejects commonName > 64 bytes. Fixed with `| trunc 64`.

## Changes

### Core (dynadot client binary)
- `core/pkg/dynadot-client/client.go`: fix `SetDns2Response` → `SetDnsResponse` JSON key in `AddRecord` + `SetFullDNS`; change `ResponseCode string` → `json.Number` to accept integer `0` from the API
- `core/pkg/dynadot-client/client_test.go`: update fixtures to match real API response format (integer ResponseCode, correct JSON key)

### Chart (bp-cert-manager-dynadot-webhook 1.0.0 → 1.1.0)
- `rbac.yaml`: **add domain-solver ClusterRole + ClusterRoleBinding** — this is the fix for the "forbidden" error; cert-manager's SA needs CREATE on `acme.dynadot.openova.io`
- `values.yaml`: add `certManager.{namespace,serviceAccountName}`, `clusterIssuer.*`, `privateKeySecretRefName`; add `imagePullSecrets` to `webhook`
- `certificate.yaml`: fix commonName truncation to ≤64 bytes
- `clusterissuer.yaml`: new template (skip-render default; enabled via bootstrap-kit overlay)
- `deployment.yaml`: add `imagePullSecrets` support for private GHCR images

### Bootstrap kit
- `49b-bp-cert-manager-dynadot-webhook.yaml`: new slot — PRE-handover dynadot DNS-01 solver, active from Day 0 while Dynadot is authoritative for `omani.works`
- `kustomization.yaml`: add `49b` entry

### Infra
- `variables.tf`: add `dynadot_managed_domains` variable
- `main.tf`: pass `dynadot_{key,secret,managed_domains}` to the cloud-init templatefile call
- `cloudinit-control-plane.tftpl`: write `cert-manager/dynadot-api-credentials` Secret + apply it before Flux reconciles the bootstrap-kit

## Test plan

- [ ] CI: `build-cert-manager-dynadot-webhook` workflow builds new image (triggers on `core/pkg/dynadot-client/**` path change)
- [ ] CI: `blueprint-release` workflow publishes `bp-cert-manager-dynadot-webhook:1.1.0` OCI artifact (triggers on `platform/*/chart/**` path change)
- [ ] On otech22 (runtime hotfix): patch webhook image to new SHA, verify `sovereign-wildcard-tls` Certificate reaches `Ready=True`
- [ ] `curl -s -o /dev/null -w "%{http_code}\n" https://console.otech22.omani.works/` returns `200`
- [ ] New Sovereigns: provision with the updated bootstrap-kit and verify TLS is Ready within 5 minutes of Flux bootstrap

🤖 Generated with [Claude Code](https://claude.com/claude-code)