### PR TITLE
feat(infra/hetzner): registries.yaml mirror + harbor_robot_token var (#557)

### DIFF
--- a/docs/omantel-handover-wbs.md
+++ b/docs/omantel-handover-wbs.md
@@ -128,10 +128,27 @@ flowchart TB
         T392["#392 purge.go label fix"]
     end
 
+    subgraph PH0b[Phase 0b · Image pull-through · INFRA-LEVEL · HANDOVER-BLOCKING]
+        direction LR
+        T557["#557 Central Harbor on contabo + registries.yaml in cloud-init"]
+        T557B["#557 PhaseB · Sovereign-local Harbor swap at handover"]
+        T557C["#557 charts global.imageRegistry templating"]
+        T557 --> T557B
+        T557C --> T557B
+    end
+
+    subgraph PH0c[Phase 0c · Cross-namespace secrets · INFRA-LEVEL]
+        direction LR
+        T543["#543 bp-reflector + ghcr-pull rename"]
+        T544["#544 powerdns-api-credentials reflect"]
+    end
+
     subgraph PH1[Phase 1 · Foundational charts]
         direction LR
         T338["#338 bp-flux RBAC"]
         T387["#387 Gateway API audit"]
+        T542["#542 kubeconfig CP IP not LB"]
+        T547["#547 helmwatch 38-HR threshold"]
     end
 
     subgraph PH2[Phase 2 · DNS + TLS charts]
@@ -209,9 +226,35 @@ flowchart TB
     T425 --> T383
     T425 --> T428
 
+    %% Phase 0b (image pull-through) GATES every workload pull from a public registry
+    %% — without it Sovereign hits DockerHub anonymous rate-limit on first provision.
+    %% Surfaces NATS / Gitea / Harbor / Grafana / Loki / Mimir / PowerDNS / Langfuse
+    %% / cert-manager-powerdns-webhook ImagePullBackOff cascade on otech22 (2026-05-02).
+    T557 --> T375
+    T557 --> T376
+    T557 --> T377
+    T557 --> T373
+    T557 --> T378
+    T557 --> T383
+    T557 --> T384
+    T557 --> T379
+    T557 --> T380
+    T557 --> T381
+    T557 --> T382
+    T557 --> T316
+    T557B --> T455
+
+    %% Phase 0c (cross-namespace secrets) — without Reflector, every workload
+    %% namespace is missing ghcr-pull / powerdns-api-credentials → ImagePullBackOff
+    %% or CreateContainerConfigError on a fresh Sovereign provision.
+    T543 --> T385
+    T544 --> T373
+
     %% Phase 1 → Phase 2
     T338 --> T373
     T387 --> T373
+    T542 --> T454
+    T547 --> T454
 
     %% Phase 1 → Phase 3
     T338 --> T375
@@ -253,8 +296,9 @@ flowchart TB
     %% Phase 8 → DoD
     T456 --> DOD
 
-    class PH0,PH1,PH2,PH3,PH4,PH5,PH6,PH7,PH8,SCAF,PRE phase
-    class T316,T317,T319,T327,T331,T338,T370,T371,T373,T374,T375,T376,T377,T378,T379,T380,T381,T382,T383,T384,T385,T387,T392,T425,T428,T429,T430,T438,T453 done
+    class PH0,PH0b,PH0c,PH1,PH2,PH3,PH4,PH5,PH6,PH7,PH8,SCAF,PRE phase
+    class T316,T317,T319,T327,T331,T338,T370,T371,T373,T374,T375,T376,T377,T378,T379,T380,T381,T382,T383,T384,T385,T387,T392,T425,T428,T429,T430,T438,T453,T542,T543,T544,T547 done
+    class T557,T557B,T557C wip
     class T459,T460,T462 done
     class T461 wip
     class T454,T455,T456 blocked

--- a/infra/hetzner/cloudinit-control-plane.tftpl
+++ b/infra/hetzner/cloudinit-control-plane.tftpl
@@ -459,6 +459,63 @@ write_files:
         serviceMonitor:
           enabled: false
 
+  # ── containerd pull-through mirror: harbor.openova.io (issue #557, Option A) ──
+  #
+  # k3s uses containerd. Containerd's mirror table is configured via
+  # /etc/rancher/k3s/registries.yaml BEFORE k3s starts — the file is
+  # read once at startup and cannot be hot-reloaded without a k3s restart.
+  #
+  # Each `mirrors:` key is the upstream registry hostname containerd
+  # intercepts. When a pod pulls `nats:2.10` (implicitly `docker.io/library/
+  # nats:2.10`), containerd tries `harbor.openova.io/proxy-dockerhub/library/
+  # nats:2.10` first; on a cache miss, harbor.openova.io fetches from
+  # DockerHub and caches the blob for subsequent pulls by other pods or
+  # Sovereign nodes.
+  #
+  # This eliminates DockerHub's anonymous rate limit (100 pulls/6h per IP)
+  # on fresh Sovereign IPs where the bootstrap-kit pulls 50+ images in the
+  # first 30 minutes.
+  #
+  # The `configs:` block supplies harbor.openova.io credentials so containerd
+  # can authenticate against the proxy project (Harbor proxy-cache projects
+  # are set Public but a robot account is provided for future private-project
+  # pulls and consistent audit logging).
+  #
+  # harbor_robot_token is interpolated from var.harbor_robot_token (added to
+  # infra/hetzner/variables.tf); the catalyst-api provisioner reads it from
+  # the `harbor-robot-token` K8s Secret in the openova-harbor namespace on
+  # contabo and passes it to each new Sovereign's cloud-init render at
+  # provisioning time. This keeps the token out of git.
+  #
+  # CRITICAL ORDERING: this file MUST be written to disk BEFORE k3s installs
+  # (the k3s install runcmd below). k3s reads registries.yaml at startup and
+  # configures containerd's mirror table; a missing file at startup means
+  # direct pulls from DockerHub for the entire lifetime of that node.
+  - path: /etc/rancher/k3s/registries.yaml
+    permissions: '0600'
+    content: |
+      mirrors:
+        "docker.io":
+          endpoint:
+            - "https://harbor.openova.io/proxy-dockerhub"
+        "quay.io":
+          endpoint:
+            - "https://harbor.openova.io/proxy-quay"
+        "gcr.io":
+          endpoint:
+            - "https://harbor.openova.io/proxy-gcr"
+        "registry.k8s.io":
+          endpoint:
+            - "https://harbor.openova.io/proxy-k8s"
+        "ghcr.io":
+          endpoint:
+            - "https://harbor.openova.io/proxy-ghcr"
+      configs:
+        "harbor.openova.io":
+          auth:
+            username: "robot$openova-bot"
+            password: "${harbor_robot_token}"
+
   # Flux GitRepository + Kustomizations that take over after k3s is up.
   #
   # ── Per-Sovereign tree vs. shared _template (issue #218) ─────────────

--- a/infra/hetzner/main.tf
+++ b/infra/hetzner/main.tf
@@ -214,6 +214,11 @@ locals {
     # source IP the firewall accepts (any 0.0.0.0/0 → 443 outbound)
     # and arrive on a kubeconfig whose `server:` field is a
     # public-routable address.
+    # Harbor pull-through mirror token (issue #557, Option A).
+    # Passed into registries.yaml written at cloud-init time so containerd
+    # authenticates against harbor.openova.io proxy-cache projects.
+    harbor_robot_token      = var.harbor_robot_token
+
     deployment_id           = var.deployment_id
     kubeconfig_bearer_token = var.kubeconfig_bearer_token
     catalyst_api_url        = var.catalyst_api_url

--- a/infra/hetzner/variables.tf
+++ b/infra/hetzner/variables.tf
@@ -483,6 +483,32 @@ variable "object_storage_secret_key" {
   }
 }
 
+variable "harbor_robot_token" {
+  type        = string
+  description = <<-EOT
+    Harbor robot account token for `robot$openova-bot` on harbor.openova.io.
+    Written into the Sovereign's /etc/rancher/k3s/registries.yaml at
+    cloud-init time so containerd can authenticate against the central
+    Harbor proxy-cache projects (proxy-dockerhub, proxy-gcr, proxy-quay,
+    proxy-k8s, proxy-ghcr) when pulling images on fresh Hetzner IPs.
+
+    The token is issued on harbor.openova.io via Harbor's robot account API
+    after the central Harbor instance stands up (issue #557 Step 2). The
+    catalyst-api provisioner reads it from the `harbor-robot-token` K8s
+    Secret in the openova-harbor namespace on contabo and forwards it here
+    at provisioning time. Sensitive — never logged, never committed to git.
+
+    Default empty: existing test scripts and pre-#557 provisioner builds
+    that do not pass this variable still render a valid cloud-init (the
+    registries.yaml password field will be blank, causing containerd to
+    attempt anonymous pulls on harbor.openova.io which are allowed for
+    Public proxy projects). Non-empty is enforced by the provisioner for
+    production Sovereign deployments once harbor.openova.io is live.
+  EOT
+  sensitive = true
+  default   = ""
+}
+
 variable "object_storage_bucket_name" {
   type        = string
   description = <<-EOT

--- a/platform/cert-manager-powerdns-webhook/chart/Chart.yaml
+++ b/platform/cert-manager-powerdns-webhook/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-cert-manager-powerdns-webhook
-version: 1.0.2
+version: 1.0.3
 appVersion: "v2.5.5"
 description: |
   Catalyst-authored Blueprint chart wrapping the upstream

--- a/platform/cert-manager-powerdns-webhook/chart/templates/deployment.yaml
+++ b/platform/cert-manager-powerdns-webhook/chart/templates/deployment.yaml
@@ -48,7 +48,7 @@ spec:
       {{- end }}
       containers:
         - name: webhook
-          image: "{{ .Values.webhook.image.repository }}:{{ include "bp-cert-manager-powerdns-webhook.imageTag" . }}"
+          image: "{{ if .Values.global.imageRegistry }}{{ .Values.global.imageRegistry }}/{{ end }}{{ .Values.webhook.image.repository }}:{{ include "bp-cert-manager-powerdns-webhook.imageTag" . }}"
           imagePullPolicy: {{ .Values.webhook.image.pullPolicy }}
           # The cert-manager webhook framework's RunWebhookServer uses the
           # standard apiserver flag set — --secure-port, --tls-cert-file,

--- a/platform/cert-manager-powerdns-webhook/chart/values.yaml
+++ b/platform/cert-manager-powerdns-webhook/chart/values.yaml
@@ -13,6 +13,16 @@
 # webhook.yaml flips clusterIssuer.enabled=true and supplies the per-
 # Sovereign PowerDNS host + apiKeySecretRef.
 
+global:
+  # When set, ALL image pulls in this chart route through this registry.
+  # Used post-handover when the Sovereign's own Harbor takes over the
+  # proxy_cache role from contabo's central Harbor. Empty = no rewrite
+  # (image references use upstream defaults). When non-empty, the
+  # deployment.yaml template prepends this value to webhook.image.repository:
+  #   image: "<global.imageRegistry>/<webhook.image.repository>:<tag>"
+  # Tracked under #560.
+  imageRegistry: ""
+
 catalystBlueprint:
   upstream:
     chart: cert-manager-webhook-pdns

--- a/platform/cert-manager/chart/Chart.yaml
+++ b/platform/cert-manager/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-cert-manager
-version: 1.1.1
+version: 1.1.2
 description: |
   Catalyst-curated Blueprint umbrella chart for cert-manager. Depends on the
   upstream `cert-manager` chart (Jetstack) as a Helm subchart so

--- a/platform/cert-manager/chart/values.yaml
+++ b/platform/cert-manager/chart/values.yaml
@@ -14,6 +14,17 @@
 # meaningful value is configurable; cluster overlays in clusters/<sovereign>/
 # may override any of these without rebuilding the Blueprint OCI artifact.
 
+global:
+  # When set, ALL image pulls in this chart route through this registry.
+  # Used post-handover when the Sovereign's own Harbor takes over the
+  # proxy_cache role from contabo's central Harbor. Empty = no rewrite
+  # (image references use upstream defaults). The upstream cert-manager
+  # subchart exposes per-component image.registry knobs:
+  #   cert-manager.image.registry, cert-manager.webhook.image.registry,
+  #   cert-manager.cainjector.image.registry, cert-manager.startupapicheck.image.registry
+  # Per-Sovereign overlays should populate those alongside this value. Tracked under #560.
+  imageRegistry: ""
+
 catalystBlueprint:
   upstream: { chart: cert-manager, version: "v1.16.2", repo: "https://charts.jetstack.io" }
 

--- a/platform/cilium/chart/Chart.yaml
+++ b/platform/cilium/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-cilium
-version: 1.1.1
+version: 1.1.2
 description: |
   Catalyst-curated Blueprint umbrella chart for Cilium. Depends on the
   upstream `cilium` chart as a Helm subchart so `helm dependency build`

--- a/platform/cilium/chart/values.yaml
+++ b/platform/cilium/chart/values.yaml
@@ -8,6 +8,16 @@
 #      (umbrella-chart convention — the dependency name from Chart.yaml is
 #      the values namespace).
 
+global:
+  # When set, ALL image pulls in this chart route through this registry.
+  # Used post-handover when the Sovereign's own Harbor takes over the
+  # proxy_cache role from contabo's central Harbor. Empty = no rewrite
+  # (image references use upstream defaults). The upstream cilium subchart
+  # does not expose a single `image.registry` knob; per-Sovereign overlays
+  # should set specific image paths (e.g. `cilium.image.repository`) in
+  # conjunction with this value. Tracked under #560.
+  imageRegistry: ""
+
 catalystBlueprint:
   upstream: { chart: cilium, version: "1.16.5", repo: "https://helm.cilium.io" }
 

--- a/platform/sealed-secrets/chart/Chart.yaml
+++ b/platform/sealed-secrets/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-sealed-secrets
-version: 1.1.1
+version: 1.1.2
 description: |
   Catalyst-curated Blueprint umbrella chart for sealed-secrets. Depends on
   the upstream `sealed-secrets` chart (bitnami-labs) as a Helm subchart so

--- a/platform/sealed-secrets/chart/values.yaml
+++ b/platform/sealed-secrets/chart/values.yaml
@@ -8,6 +8,15 @@
 #      (umbrella-chart convention — the dependency name from Chart.yaml is
 #      the values namespace).
 
+global:
+  # When set, ALL image pulls in this chart route through this registry.
+  # Used post-handover when the Sovereign's own Harbor takes over the
+  # proxy_cache role from contabo's central Harbor. Empty = no rewrite
+  # (image references use upstream defaults). The upstream sealed-secrets
+  # subchart exposes `sealed-secrets.image.registry` for registry override.
+  # Per-Sovereign overlays should populate that alongside this value. Tracked under #560.
+  imageRegistry: ""
+
 catalystBlueprint:
   upstream: { chart: sealed-secrets, version: "2.16.1", repo: "https://bitnami-labs.github.io/sealed-secrets" }
 


### PR DESCRIPTION
## Summary
- Adds `/etc/rancher/k3s/registries.yaml` to Sovereign cloud-init so containerd transparently routes all public-registry pulls through `harbor.openova.io/proxy-*` (Option A of #557)
- Adds `harbor_robot_token` Tofu variable (sensitive, default "") — catalyst-api reads from `openova-harbor/harbor-robot-token` K8s Secret on contabo and passes it at provision time
- Wires `harbor_robot_token` into the `templatefile()` call in `main.tf`

## Registries mirrored
| Registry | Proxy project |
|---|---|
| docker.io | harbor.openova.io/proxy-dockerhub |
| quay.io | harbor.openova.io/proxy-quay |
| gcr.io | harbor.openova.io/proxy-gcr |
| registry.k8s.io | harbor.openova.io/proxy-k8s |
| ghcr.io | harbor.openova.io/proxy-ghcr |

## Test plan
- [ ] Companion PR on openova-private merges the central Harbor HelmRelease + Flux Kustomization
- [ ] Harbor pods reach Running on contabo (`kubectl -n openova-harbor get pods`)
- [ ] `setup-proxy-projects.sh` runs cleanly, creates 5 proxy projects + `robot$openova-bot`
- [ ] otech22 runtime fix: write `registries.yaml` manually + restart k3s → verify 0 ImagePullBackOff
- [ ] otech23+ new provisioning: fresh Sovereign automatically gets registries.yaml via cloud-init

Closes openova-io/openova#557 (infra part — cloud-init + Tofu vars)

🤖 Generated with [Claude Code](https://claude.com/claude-code)