### PR TITLE
fix(bp-cert-manager-dynadot-webhook): dedupe template labels (Closes #561)

### DIFF
--- a/clusters/_template/bootstrap-kit/49b-bp-cert-manager-dynadot-webhook.yaml
+++ b/clusters/_template/bootstrap-kit/49b-bp-cert-manager-dynadot-webhook.yaml
@@ -89,7 +89,7 @@ spec:
   chart:
     spec:
       chart: bp-cert-manager-dynadot-webhook
-      version: 1.1.0
+      version: 1.1.1
       sourceRef:
         kind: HelmRepository
         name: bp-cert-manager-dynadot-webhook

--- a/platform/cert-manager-dynadot-webhook/chart/Chart.yaml
+++ b/platform/cert-manager-dynadot-webhook/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: bp-cert-manager-dynadot-webhook
-version: 1.1.0
-appVersion: "1.1.0"
+version: 1.1.1
+appVersion: "1.1.1"
 description: |
   Catalyst-authored Blueprint chart for the cert-manager-dynadot-webhook
   binary. Deploys a TLS-fronted aggregated apiserver that cert-manager's

--- a/platform/cert-manager-dynadot-webhook/chart/templates/deployment.yaml
+++ b/platform/cert-manager-dynadot-webhook/chart/templates/deployment.yaml
@@ -13,7 +13,6 @@ spec:
   template:
     metadata:
       labels:
-        {{- include "bp-cert-manager-dynadot-webhook.selectorLabels" . | nindent 8 }}
         {{- include "bp-cert-manager-dynadot-webhook.labels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ include "bp-cert-manager-dynadot-webhook.serviceAccountName" . }}


### PR DESCRIPTION
## Summary

- Removes the redundant `selectorLabels` include from the Deployment pod template metadata labels — `labels` already contains both `app.kubernetes.io/name` and `app.kubernetes.io/instance`, so including `selectorLabels` on top caused duplicate keys
- Bumps chart version `1.1.0 → 1.1.1` in `Chart.yaml` and `49b-bp-cert-manager-dynadot-webhook.yaml`
- `selector.matchLabels` still uses `selectorLabels` correctly; pod template labels now include `selectorLabels` keys via the `labels` template

## Root cause

`deployment.yaml` pod template metadata included both:
```yaml
{{- include "bp-cert-manager-dynadot-webhook.selectorLabels" . | nindent 8 }}
{{- include "bp-cert-manager-dynadot-webhook.labels" . | nindent 8 }}
```
`selectorLabels` emits `app.kubernetes.io/name` + `app.kubernetes.io/instance`; `labels` also emits those two plus additional keys — rendering each of those two keys twice in the same YAML map, triggering Flux HelmRelease validation error: `spec.values.metadata.labels has duplicate key`.

## Test plan

- [x] `helm template platform/cert-manager-dynadot-webhook/chart` renders cleanly (exit 0)
- [x] Pod template metadata labels contain each key exactly once
- [x] `selector.matchLabels` still resolves to `{app.kubernetes.io/name, app.kubernetes.io/instance}`
- [ ] HelmRelease `bp-cert-manager-dynadot-webhook` on otech22 reaches `Ready=True` after Flux picks up 1.1.1

Closes #561. Unblocks parallel agent #15 (cert TLS via dynadot-webhook for `https://console.otech22.omani.works/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)