### PR TITLE
fix(bp-mimir): disable ingest_storage to fix Kafka CrashLoop (Closes #567)

### DIFF
--- a/clusters/_template/bootstrap-kit/23-mimir.yaml
+++ b/clusters/_template/bootstrap-kit/23-mimir.yaml
@@ -53,7 +53,7 @@ spec:
   chart:
     spec:
       chart: bp-mimir
-      version: 1.0.0
+      version: 1.0.1
       sourceRef:
         kind: HelmRepository
         name: bp-mimir

--- a/platform/mimir/chart/Chart.yaml
+++ b/platform/mimir/chart/Chart.yaml
@@ -13,7 +13,7 @@ description: |
   overlays scale per-component replicas + flip zone-aware-replication on
   for HA Sovereigns.
 type: application
-version: 1.0.0
+version: 1.0.1
 appVersion: "3.0.4"
 keywords: [catalyst, blueprint, mimir, observability, metrics, prometheus]
 maintainers:

--- a/platform/mimir/chart/values.yaml
+++ b/platform/mimir/chart/values.yaml
@@ -70,6 +70,17 @@ mimir-distributed:
   kafka:
     enabled: false
 
+  # Structured Mimir config — explicitly disable ingest_storage so the
+  # Mimir process does NOT require a Kafka address. The upstream
+  # mimir-distributed 6.0.6 chart may default ingest_storage.enabled to
+  # true in its bundled config; this override forces classic ingester mode
+  # (blocks-storage, no Kafka). Fixes CrashLoopBackOff on otech22 with
+  # "the Kafka address has not been configured" (issue #567).
+  mimir:
+    structuredConfig:
+      ingest_storage:
+        enabled: false
+
   # MetaMonitoring (ServiceMonitor + Grafana dashboards) — DEFAULT FALSE
   # per docs/BLUEPRINT-AUTHORING.md §11.2.
   metaMonitoring:


### PR DESCRIPTION
## Summary
- Adds `mimir.structuredConfig.ingest_storage.enabled: false` to bp-mimir values.yaml to force classic blocks-storage ingester mode
- Without this, Mimir boots in ingest-storage mode and CrashLoops with "the Kafka address has not been configured"
- `kafka.enabled: false` only disabled the bundled Kafka subchart — the Mimir process itself still defaulted to ingest-storage mode
- Bump bp-mimir 1.0.0 → 1.0.1; bootstrap-kit slot 23 updated

## Test plan
- [ ] CI builds bp-mimir:1.0.1 OCI artifact successfully
- [ ] On next otech provisioning: all 10 mimir pods reach Running (not CrashLoopBackOff)
- [ ] No "Kafka address" errors in mimir pod logs

Closes #567