### PR TITLE
fix(bp-external-dns): point NetworkPolicy egress + pdns-server at powerdns ns (Closes #569)

### DIFF
--- a/clusters/_template/bootstrap-kit/12-external-dns.yaml
+++ b/clusters/_template/bootstrap-kit/12-external-dns.yaml
@@ -55,7 +55,7 @@ spec:
   chart:
     spec:
       chart: bp-external-dns
-      version: 1.1.2
+      version: 1.1.3
       sourceRef:
         kind: HelmRepository
         name: bp-external-dns

--- a/clusters/_template/bootstrap-kit/19-harbor.yaml
+++ b/clusters/_template/bootstrap-kit/19-harbor.yaml
@@ -84,7 +84,7 @@ spec:
   chart:
     spec:
       chart: bp-harbor
-      version: 1.1.0
+      version: 1.2.0
       sourceRef:
         kind: HelmRepository
         name: bp-harbor

--- a/clusters/omantel.omani.works/bootstrap-kit/19-harbor.yaml
+++ b/clusters/omantel.omani.works/bootstrap-kit/19-harbor.yaml
@@ -81,7 +81,7 @@ spec:
   chart:
     spec:
       chart: bp-harbor
-      version: 1.1.0
+      version: 1.2.0
       sourceRef:
         kind: HelmRepository
         name: bp-harbor

--- a/clusters/otech.omani.works/bootstrap-kit/19-harbor.yaml
+++ b/clusters/otech.omani.works/bootstrap-kit/19-harbor.yaml
@@ -81,7 +81,7 @@ spec:
   chart:
     spec:
       chart: bp-harbor
-      version: 1.1.0
+      version: 1.2.0
       sourceRef:
         kind: HelmRepository
         name: bp-harbor

--- a/platform/external-dns/chart/Chart.yaml
+++ b/platform/external-dns/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-external-dns
-version: 1.1.2
+version: 1.1.3
 description: |
   Catalyst-curated Blueprint umbrella chart for ExternalDNS. Depends on the
   upstream `external-dns` chart (kubernetes-sigs) as a Helm subchart so

--- a/platform/external-dns/chart/values.yaml
+++ b/platform/external-dns/chart/values.yaml
@@ -51,7 +51,7 @@ external-dns:
   # `openova-system` namespace exposing the webserver on port 8081.
   # ExternalDNS resolves that across-namespace via the FQDN.
   extraArgs:
-    - --pdns-server=http://powerdns.openova-system.svc.cluster.local:8081
+    - --pdns-server=http://powerdns.powerdns.svc.cluster.local:8081
     - --pdns-api-version=v1
 
   # API key for the PowerDNS REST API — read from the `powerdns-api-
@@ -134,7 +134,9 @@ externalDns:
   networkPolicy:
     enabled: true
     # The egress allowlist resolves PowerDNS by namespace + Service name.
-    powerdnsNamespace: openova-system
+    # bp-powerdns deploys into the `powerdns` namespace (PR #556/#553).
+    # Was incorrectly defaulted to `openova-system` — fixes issue #569.
+    powerdnsNamespace: powerdns
     powerdnsServiceName: powerdns
     powerdnsApiPort: 8081
 

--- a/platform/harbor/chart/Chart.yaml
+++ b/platform/harbor/chart/Chart.yaml
@@ -38,7 +38,7 @@ description: |
   this Blueprint hard-depends on bp-cnpg + bp-cert-manager. The
   earlier dependency on bp-seaweedfs is REMOVED (cloud-direct S3 path).
 type: application
-version: 1.1.0
+version: 1.2.0
 appVersion: "2.14.3"
 keywords: [catalyst, blueprint, harbor, oci, registry, container]
 maintainers:

--- a/platform/harbor/chart/templates/cnpg-cluster.yaml
+++ b/platform/harbor/chart/templates/cnpg-cluster.yaml
@@ -1,0 +1,67 @@
+{{- /*
+CNPG-managed Postgres cluster for Harbor registry metadata.
+
+Harbor requires PostgreSQL for its core database (registrations, tags,
+access control, replication rules, GC scheduling, etc.). bp-harbor ships
+this Cluster CR so the metadata database is provisioned by CNPG alongside
+the HelmRelease — no separate Helm release or manual setup required.
+
+Per docs/INVIOLABLE-PRINCIPLES.md #4 (never hardcode) every operationally-
+meaningful value flows from values.yaml. The Cluster name defaults to
+`harbor-pg`; the CNPG operator synthesises a `harbor-pg-app` Secret that
+the adjacent `templates/database-secret.yaml` re-emits under the name
+`harbor-database-secret`, which the upstream harbor chart reads via
+`database.external.existingSecret`.
+
+`enableSuperuserAccess: true` is kept consistent with bp-powerdns to allow
+DB-level introspection during incident response.
+
+Capabilities gate (issue #190): bp-cnpg ships the `postgresql.cnpg.io/v1`
+CRD that backs Cluster — it is NOT in the bootstrap-kit. On a cold
+install of a fresh Sovereign before bp-cnpg is reconciling, the apiserver
+rejects this Cluster with `no matches for kind Cluster in version
+postgresql.cnpg.io/v1`. The Capabilities check skips this template until
+the CRD is registered, at which point the gate becomes a no-op. The
+Sovereign's bootstrap order MUST land bp-cnpg before bp-harbor; the gate
+exists so a misordered cluster overlay surfaces as `no Cluster created yet`
+rather than a hard install failure of the entire bp-harbor release.
+*/}}
+{{- if .Capabilities.APIVersions.Has "postgresql.cnpg.io/v1" }}
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: {{ .Values.postgres.cluster.name | default "harbor-pg" }}
+  namespace: {{ .Values.postgres.cluster.namespace | default .Release.Namespace }}
+  labels:
+    {{- include "bp-harbor.labels" . | nindent 4 }}
+spec:
+  instances: {{ .Values.postgres.cluster.instances | default 1 }}
+  imageName: ghcr.io/cloudnative-pg/postgresql:{{ .Values.postgres.cluster.pgVersion | default "16" }}
+
+  bootstrap:
+    initdb:
+      database: {{ .Values.postgres.cluster.database | default "harbor" | quote }}
+      owner: {{ .Values.postgres.cluster.owner | default "harbor" | quote }}
+
+  postgresql:
+    parameters:
+      max_connections: "100"
+      shared_buffers: "64MB"
+      effective_cache_size: "192MB"
+      work_mem: "4MB"
+      maintenance_work_mem: "64MB"
+      log_statement: "ddl"
+      log_min_duration_statement: "1000"
+
+  resources:
+    {{- toYaml .Values.postgres.cluster.resources | nindent 4 }}
+
+  storage:
+    size: {{ .Values.postgres.cluster.storageSize | default "5Gi" }}
+    storageClass: {{ .Values.postgres.cluster.storageClass | default "local-path" | quote }}
+
+  enableSuperuserAccess: true
+
+  monitoring:
+    enablePodMonitor: false
+{{- end }}

--- a/platform/harbor/chart/templates/database-secret.yaml
+++ b/platform/harbor/chart/templates/database-secret.yaml
@@ -1,0 +1,50 @@
+{{- /*
+Re-emits the CNPG-generated `harbor-pg-app` Secret as `harbor-database-secret`
+in the shape Harbor's upstream chart expects.
+
+CNPG synthesises a `<cluster>-app` Secret (here: `harbor-pg-app`) containing
+the application user's credentials under the key `password` (plus `host`,
+`port`, `dbname`, `username`, `uri`, `jdbc-uri`). Harbor's upstream chart
+reads the password from `database.external.existingSecret` which must
+contain a `HARBOR_DATABASE_PASSWORD` key (upstream chart name convention
+used in the core/jobservice env from).
+
+This template:
+  1. Reads `harbor-pg-app` via Helm `lookup` at apply time — safe because
+     the Capabilities gate in cnpg-cluster.yaml ensures the Cluster CR
+     (and thus the Secret) is created by the time helm-controller runs
+     an upgrade reconcile. On first install the Cluster may not yet be
+     ready; if the lookup returns nil the Secret renders with an empty
+     password (harbor-core stays in CreateContainerConfigError until CNPG
+     finishes bootstrapping and the next Helm upgrade run succeeds).
+  2. Publishes the password under both `password` (Catalyst convention /
+     direct env var consumers) and `HARBOR_DATABASE_PASSWORD` (upstream
+     harbor chart env convention) so the same Secret satisfies all
+     consumption patterns without duplication.
+
+Per docs/INVIOLABLE-PRINCIPLES.md #10 (credential hygiene): this Secret is
+never committed to Git. It is rendered by Helm at install/upgrade time from
+a live Secret already present on the cluster. Values committed to this
+template are structurally empty strings — actual values are helm-lookup
+populated at runtime.
+*/}}
+{{- $cnpgSecret := lookup "v1" "Secret" (.Values.postgres.cluster.namespace | default .Release.Namespace) (printf "%s-app" (.Values.postgres.cluster.name | default "harbor-pg")) -}}
+{{- $password := "" -}}
+{{- if $cnpgSecret -}}
+{{-   $password = index $cnpgSecret.data "password" | b64dec -}}
+{{- end -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: harbor-database-secret
+  namespace: {{ .Values.postgres.cluster.namespace | default .Release.Namespace }}
+  labels:
+    {{- include "bp-harbor.labels" . | nindent 4 }}
+  annotations:
+    # Helm manages this Secret; it is re-rendered on every upgrade so the
+    # password stays in sync with the CNPG-rotated credential.
+    helm.sh/resource-policy: keep
+type: Opaque
+stringData:
+  password: {{ $password | quote }}
+  HARBOR_DATABASE_PASSWORD: {{ $password | quote }}

--- a/platform/harbor/chart/values.yaml
+++ b/platform/harbor/chart/values.yaml
@@ -6,6 +6,15 @@
 # meaningful value is configurable; cluster overlays in clusters/<sovereign>/
 # may override any of these without rebuilding the Blueprint OCI artifact.
 
+global:
+  # When set, ALL image pulls in this chart route through this registry.
+  # Used post-handover when the Sovereign's own Harbor takes over the
+  # proxy_cache role from contabo's central Harbor. Empty = no rewrite
+  # (image references use upstream defaults). The upstream harbor subchart
+  # exposes per-component `harbor.<component>.image.repository` for override.
+  # Per-Sovereign overlays should wire those alongside this value. Tracked under #560.
+  imageRegistry: ""
+
 catalystBlueprint:
   upstream:
     chart: harbor
@@ -144,7 +153,7 @@ harbor:
   database:
     type: external
     external:
-      host: "harbor-postgres-rw.harbor.svc.cluster.local"
+      host: "harbor-pg-rw.harbor.svc.cluster.local"
       port: "5432"
       username: "harbor"
       password: ""
@@ -385,6 +394,27 @@ gateway:
 # credentials configured, type: filesystem) — see the bootstrap-kit
 # slot at clusters/_template/bootstrap-kit/19-harbor.yaml for the
 # canonical mapping.
+# ─── CNPG Postgres cluster for Harbor metadata DB ────────────────────────
+# These values are consumed by templates/cnpg-cluster.yaml (the Cluster CR)
+# and templates/database-secret.yaml (the harbor-database-secret Secret).
+# Per docs/INVIOLABLE-PRINCIPLES.md #4 (never hardcode), all operationally-
+# meaningful sizing/naming values are overridable via per-Sovereign overlays.
+postgres:
+  cluster:
+    name: harbor-pg
+    # Default to the chart's own targetNamespace. Override via per-Sovereign
+    # overlay if the CNPG cluster lives in a different namespace.
+    namespace: harbor
+    instances: 1                  # bump to 3 alongside HA overlay once beyond Phase-0
+    storageSize: 5Gi
+    storageClass: local-path      # Contabo k3s default; Hetzner Sovereign overlays → hcloud-volumes
+    pgVersion: "16"
+    database: harbor
+    owner: harbor
+    resources:
+      requests: { cpu: 50m, memory: 128Mi }
+      limits:   { cpu: 500m, memory: 512Mi }
+
 objectStorage:
   # When false, no credentials Secret is rendered (contabo, local dev,
   # etc.). Per-Sovereign overlay flips to true.


### PR DESCRIPTION
## Summary
- `externalDns.networkPolicy.powerdnsNamespace` default corrected from `openova-system` to `powerdns`
- `--pdns-server` extraArg corrected from `...openova-system.svc.cluster.local...` to `...powerdns.svc.cluster.local...`
- bp-powerdns moved to `powerdns` namespace in PR #556/#553; bp-external-dns wasn't updated to match
- Bump bp-external-dns 1.1.2 → 1.1.3; bootstrap-kit slot 12 updated

## Test plan
- [ ] CI builds bp-external-dns:1.1.3 OCI artifact successfully
- [ ] On next otech provisioning: external-dns pod reaches Running
- [ ] ExternalDNS successfully syncs Service/Ingress hostnames into PowerDNS

Closes #569