### PR TITLE
fix(bp-falco): rename rules_file → rules_files (Falco 0.36+ canonical key, Closes #570)

### DIFF
--- a/clusters/_template/bootstrap-kit/31-falco.yaml
+++ b/clusters/_template/bootstrap-kit/31-falco.yaml
@@ -49,7 +49,7 @@ spec:
   chart:
     spec:
       chart: bp-falco
-      version: 1.0.0
+      version: 1.0.1
       sourceRef:
         kind: HelmRepository
         name: bp-falco

--- a/platform/falco/chart/Chart.yaml
+++ b/platform/falco/chart/Chart.yaml
@@ -12,7 +12,7 @@ description: |
   (static scanning) and feeds the SIEM pipeline via Falcosidekick into
   bp-opensearch.
 type: application
-version: 1.0.0
+version: 1.0.1
 appVersion: "0.43.1"
 keywords: [catalyst, blueprint, falco, security, runtime, ebpf, threat-detection]
 maintainers:

--- a/platform/falco/chart/values.yaml
+++ b/platform/falco/chart/values.yaml
@@ -32,8 +32,12 @@ falco:
 
   # Falco rules — solo-Sovereign default uses the upstream stable rules.
   # Per-Sovereign overlays MAY append custom rules via `falco.rulesfile.customRules`.
+  # NOTE: `rules_files` (plural) is the canonical key since Falco 0.36+.
+  # Using the deprecated `rules_file` (singular) alongside the subchart's
+  # `rules_files` default causes Falco to abort with a config conflict.
+  # Fixes CrashLoopBackOff on otech22 (issue #570).
   falco:
-    rules_file:
+    rules_files:
       - /etc/falco/falco_rules.yaml
       - /etc/falco/falco_rules.local.yaml
       - /etc/falco/k8s_audit_rules.yaml


### PR DESCRIPTION
## Summary
- Renames `falco.falco.rules_file` (deprecated singular) to `falco.falco.rules_files` (plural, canonical since Falco 0.36)
- When both keys appear in the merged config, Falco detects a conflict and aborts — causing the DaemonSet CrashLoopBackOff on otech22
- Catalyst chart pins Falco 0.43.1 (well past 0.36 threshold), so `rules_files` is correct
- Bump bp-falco 1.0.0 → 1.0.1; bootstrap-kit slot 31 updated

## Test plan
- [ ] CI builds bp-falco:1.0.1 OCI artifact successfully
- [ ] On next otech provisioning: falco DaemonSet pods reach Running on all nodes
- [ ] No "conflicting config keys" error in falco pod logs

Closes #570