### PR TITLE
fix(bp-spire): re-enable oidc-discovery-provider ClusterSPIFFEID (Closes #571)

### DIFF
--- a/clusters/_template/bootstrap-kit/06-spire.yaml
+++ b/clusters/_template/bootstrap-kit/06-spire.yaml
@@ -38,7 +38,7 @@ spec:
   chart:
     spec:
       chart: bp-spire
-      version: 1.1.4
+      version: 1.1.6
       sourceRef:
         kind: HelmRepository
         name: bp-spire

--- a/platform/spire/chart/Chart.yaml
+++ b/platform/spire/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-spire
-version: 1.1.4
+version: 1.1.6
 description: |
   Catalyst-curated Blueprint umbrella chart for SPIRE. Depends on the
   upstream `spire-crds` and `spire` charts (spiffe.github.io/helm-charts-hardened)

--- a/platform/spire/chart/values.yaml
+++ b/platform/spire/chart/values.yaml
@@ -10,6 +10,16 @@
 #      sub-subcharts spire-server/spire-agent/etc, which appear as
 #      second-level keys nested under `spire:`).
 
+global:
+  # When set, ALL image pulls in this chart route through this registry.
+  # Used post-handover when the Sovereign's own Harbor takes over the
+  # proxy_cache role from contabo's central Harbor. Empty = no rewrite
+  # (image references use upstream defaults). The upstream spire chart
+  # (spiffe hardened) exposes `spire.global.spire.image.registry` for
+  # global override. Per-Sovereign overlays wire that alongside this value.
+  # Tracked under #560.
+  imageRegistry: ""
+
 catalystBlueprint:
   upstream: { chart: spire, version: "0.21.0", repo: "https://spiffe.github.io/helm-charts-hardened" }
 
@@ -58,7 +68,14 @@ spire:
           default:
             enabled: false
           oidc-discovery-provider:
-            enabled: false
+            # Re-enabled in bp-spire 1.1.6: the CRD-ordering problem that
+            # originally forced all ClusterSPIFFEIDs to disabled was fixed
+            # in 1.1.4 (spire-crds listed first as a Helm dependency).
+            # Without this identity the oidc-discovery-provider init
+            # container blocks with "PermissionDenied: no identity issued"
+            # because the spire-controller-manager never creates the
+            # registration entry. Fixes otech22 OIDC init stuck (issue #571).
+            enabled: true
           test-keys:
             enabled: false
           # child-servers already defaults false upstream


### PR DESCRIPTION
## Summary
- Re-enables `oidc-discovery-provider` ClusterSPIFFEID in bp-spire values.yaml
- The CRD-ordering race that originally forced all ClusterSPIFFEIDs disabled was fixed in bp-spire 1.1.4 (spire-crds listed first as Helm dependency)
- Without this identity registered, the oidc-discovery-provider init container blocks with `PermissionDenied: no identity issued` — no SVID issued, pod never starts
- Carries `global.imageRegistry` field from issue #560 (was at 1.1.5 in working tree)
- Bump bp-spire 1.1.5 → 1.1.6; bootstrap-kit slot 06 updated from 1.1.4 → 1.1.6

## Test plan
- [ ] CI builds bp-spire:1.1.6 OCI artifact successfully
- [ ] On next otech provisioning: spire-oidc init container completes (no "PermissionDenied" in logs)
- [ ] spire-oidc-discovery-provider pod reaches Running
- [ ] OIDC discovery endpoint responds at `https://oidc.<sovereign>/openid-configuration`

Closes #571