### PR TITLE
fix(bp-seaweedfs): remove double slash in image ref (Closes #568)

### DIFF
--- a/clusters/_template/bootstrap-kit/18-seaweedfs.yaml
+++ b/clusters/_template/bootstrap-kit/18-seaweedfs.yaml
@@ -55,7 +55,7 @@ spec:
   chart:
     spec:
       chart: bp-seaweedfs
-      version: 1.1.0
+      version: 1.1.1
       sourceRef:
         kind: HelmRepository
         name: bp-seaweedfs

--- a/clusters/omantel.omani.works/bootstrap-kit/18-seaweedfs.yaml
+++ b/clusters/omantel.omani.works/bootstrap-kit/18-seaweedfs.yaml
@@ -55,7 +55,7 @@ spec:
   chart:
     spec:
       chart: bp-seaweedfs
-      version: 1.0.1
+      version: 1.1.1
       sourceRef:
         kind: HelmRepository
         name: bp-seaweedfs

--- a/clusters/otech.omani.works/bootstrap-kit/18-seaweedfs.yaml
+++ b/clusters/otech.omani.works/bootstrap-kit/18-seaweedfs.yaml
@@ -55,7 +55,7 @@ spec:
   chart:
     spec:
       chart: bp-seaweedfs
-      version: 1.0.1
+      version: 1.1.1
       sourceRef:
         kind: HelmRepository
         name: bp-seaweedfs

--- a/platform/seaweedfs/chart/Chart.yaml
+++ b/platform/seaweedfs/chart/Chart.yaml
@@ -31,7 +31,7 @@ description: |
     IAM credentials sourced from External Secrets, not via the upstream
     chart's TLS/JWT machinery).
 type: application
-version: 1.1.0
+version: 1.1.1
 appVersion: "4.22"
 keywords: [catalyst, blueprint, seaweedfs, s3, object-storage, storage]
 maintainers:

--- a/platform/seaweedfs/chart/values.yaml
+++ b/platform/seaweedfs/chart/values.yaml
@@ -32,7 +32,11 @@ seaweedfs:
     enableSecurity: false
     # Pin upstream image tag — DO NOT use floating tags per
     # docs/INVIOLABLE-PRINCIPLES.md #4.
-    registry: "chrislusf/"
+    # NOTE: registry must NOT have a trailing slash — the vendored chart's
+    # _helpers.tpl seaweedfs.image renders `printf "%s/%s:%s" registry name tag`.
+    # A trailing slash in registry produces a double slash: "chrislusf//seaweedfs:4.22"
+    # which is an invalid image reference (issue #568).
+    registry: "chrislusf"
     repository: ""
     imageName: seaweedfs
     imageTag: "4.22"


### PR DESCRIPTION
## Summary

- `registry: "chrislusf/"` in `platform/seaweedfs/chart/values.yaml` had a trailing slash
- The vendored chart's `_helpers.tpl` renders `printf "%s/%s:%s" $registryName $name $tag` — trailing slash + separator slash = `chrislusf//seaweedfs:4.22` (invalid image reference)
- Fix: remove trailing slash → `registry: "chrislusf"`
- Bump bp-seaweedfs 1.1.0 → 1.1.1
- Update bootstrap-kit version refs in `clusters/_template`, `clusters/otech.omani.works`, `clusters/omantel.omani.works` (1.0.1 → 1.1.1)

## Test plan

- [ ] OCI blueprint release CI builds bp-seaweedfs 1.1.1
- [ ] Flux picks up version 1.1.1 on otech22
- [ ] `seaweedfs-volume-*` pods reach Running (no more InvalidImageName)
- [ ] `seaweedfs-master-*` and `seaweedfs-filer-*` also Running

🤖 Generated with [Claude Code](https://claude.com/claude-code)