### PR TITLE
fix(bp-harbor): CNPG database name must be 'registry' — matches Harbor coreDatabase

### DIFF
--- a/clusters/_template/bootstrap-kit/19-harbor.yaml
+++ b/clusters/_template/bootstrap-kit/19-harbor.yaml
@@ -84,7 +84,7 @@ spec:
   chart:
     spec:
       chart: bp-harbor
-      version: 1.2.1
+      version: 1.2.2
       sourceRef:
         kind: HelmRepository
         name: bp-harbor

--- a/clusters/omantel.omani.works/bootstrap-kit/19-harbor.yaml
+++ b/clusters/omantel.omani.works/bootstrap-kit/19-harbor.yaml
@@ -81,7 +81,7 @@ spec:
   chart:
     spec:
       chart: bp-harbor
-      version: 1.2.1
+      version: 1.2.2
       sourceRef:
         kind: HelmRepository
         name: bp-harbor

--- a/clusters/otech.omani.works/bootstrap-kit/19-harbor.yaml
+++ b/clusters/otech.omani.works/bootstrap-kit/19-harbor.yaml
@@ -81,7 +81,7 @@ spec:
   chart:
     spec:
       chart: bp-harbor
-      version: 1.2.1
+      version: 1.2.2
       sourceRef:
         kind: HelmRepository
         name: bp-harbor

--- a/platform/harbor/chart/Chart.yaml
+++ b/platform/harbor/chart/Chart.yaml
@@ -38,7 +38,7 @@ description: |
   this Blueprint hard-depends on bp-cnpg + bp-cert-manager. The
   earlier dependency on bp-seaweedfs is REMOVED (cloud-direct S3 path).
 type: application
-version: 1.2.1
+version: 1.2.2
 appVersion: "2.14.3"
 keywords: [catalyst, blueprint, harbor, oci, registry, container]
 maintainers:

--- a/platform/harbor/chart/templates/cnpg-cluster.yaml
+++ b/platform/harbor/chart/templates/cnpg-cluster.yaml
@@ -40,7 +40,9 @@ spec:
 
   bootstrap:
     initdb:
-      database: {{ .Values.postgres.cluster.database | default "harbor" | quote }}
+      # Harbor connects to a DB named "registry" (upstream coreDatabase default).
+      # Keep in sync with harbor.database.external.coreDatabase in values.yaml.
+      database: {{ .Values.postgres.cluster.database | default "registry" | quote }}
       owner: {{ .Values.postgres.cluster.owner | default "harbor" | quote }}
 
   postgresql:

--- a/platform/harbor/chart/values.yaml
+++ b/platform/harbor/chart/values.yaml
@@ -409,7 +409,9 @@ postgres:
     storageSize: 5Gi
     storageClass: local-path      # Contabo k3s default; Hetzner Sovereign overlays → hcloud-volumes
     pgVersion: "16"
-    database: harbor
+    # MUST match harbor.database.external.coreDatabase. Harbor upstream
+    # defaults coreDatabase="registry" and connects to a DB named "registry".
+    database: registry
     owner: harbor
     resources:
       requests: { cpu: 50m, memory: 128Mi }


### PR DESCRIPTION
## Summary

- Follow-up to #578: the CNPG Cluster was initialising with `database: harbor` but Harbor upstream always connects to a database named `registry` (its `coreDatabase` default)
- harbor-core was crashing: `FATAL: database "registry" does not exist`
- Fix: change `postgres.cluster.database` default `harbor` → `registry` in both `values.yaml` and the `database:` default in `cnpg-cluster.yaml`
- Runtime hotfix on otech22: `CREATE DATABASE registry OWNER harbor` was run against `harbor-pg-1`; harbor-core is now **1/1 Running**
- Bump bp-harbor 1.2.1 → 1.2.2; bootstrap-kit refs updated in `_template`, `otech.omani.works`, `omantel.omani.works`

## Test plan

- [ ] OCI blueprint release CI builds bp-harbor 1.2.2
- [ ] Flux picks up 1.2.2 on otech22
- [ ] CNPG Cluster initialises with `registry` database
- [ ] harbor-core 1/1 Running (confirmed already on otech22 via runtime fix)
- [ ] harbor-jobservice reaches Running once Cilium intra-cluster policy is resolved (separate issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)