### PR TITLE
feat(platform): add global.imageRegistry to bp-keycloak/crossplane/crossplane-claims/velero/kyverno/trivy/grafana/flux + bp-catalyst-platform (PR 3/3, #560)

### DIFF
--- a/platform/crossplane-claims/chart/Chart.yaml
+++ b/platform/crossplane-claims/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-crossplane-claims
-version: 1.1.0
+version: 1.1.1
 description: |
   Catalyst Crossplane XRDs + Compositions Blueprint. Carries ONLY the
   apiextensions.crossplane.io/v1 CompositeResourceDefinition and

--- a/platform/crossplane-claims/chart/templates/compositions/nodeactionclaim.yaml
+++ b/platform/crossplane-claims/chart/templates/compositions/nodeactionclaim.yaml
@@ -81,7 +81,7 @@ spec:
                     serviceAccountName: catalyst-node-action
                     containers:
                       - name: kubectl
-                        image: bitnami/kubectl:1.31
+                        image: {{ if .Values.global.imageRegistry }}{{ .Values.global.imageRegistry }}/{{ end }}{{ .Values.global.kubectlImage.repository }}:{{ .Values.global.kubectlImage.tag }}
                         command: ["/bin/bash", "-c"]
                         args:
                           - "echo node-action placeholder; exit 1"

--- a/platform/crossplane-claims/chart/values.yaml
+++ b/platform/crossplane-claims/chart/values.yaml
@@ -5,6 +5,23 @@
 # defaults document; future per-Sovereign overrides (e.g.
 # defaultCompositionRef swaps for a non-Hetzner cloud) would land here.
 
+global:
+  # When set, ALL Docker image pulls in this chart route through this registry.
+  # Used post-handover when the Sovereign's own Harbor takes over the proxy_cache
+  # role from contabo's central Harbor. Empty = no rewrite. Tracked under #560.
+  #
+  # NOTE: Hetzner cloud server images (e.g. ubuntu-24.04 in Crossplane Server
+  # resources) are NOT Docker images and MUST NOT be registry-prefixed.
+  # Only the kubectl Job container image is affected by this knob.
+  imageRegistry: ""
+
+  # kubectl container image used in XNodeActionClaim Jobs.
+  # Repository and tag are separately configurable so post-handover per-Sovereign
+  # overlays can point at a Harbor-cached copy without rebuilding this Blueprint.
+  kubectlImage:
+    repository: bitnami/kubectl
+    tag: "1.31"
+
 catalystBlueprint:
   upstream: null
 

--- a/platform/crossplane/chart/Chart.yaml
+++ b/platform/crossplane/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-crossplane
-version: 1.1.3
+version: 1.1.4
 description: |
   Catalyst-curated Blueprint umbrella chart for Crossplane (controller-
   only payload). Depends on the upstream `crossplane` chart as a Helm

--- a/platform/crossplane/chart/values.yaml
+++ b/platform/crossplane/chart/values.yaml
@@ -8,6 +8,15 @@
 #      (umbrella-chart convention — the dependency name from Chart.yaml is
 #      the values namespace).
 
+global:
+  # When set, ALL image pulls in this chart route through this registry.
+  # Used post-handover when the Sovereign's own Harbor takes over the
+  # proxy_cache role from contabo's central Harbor. Empty = no rewrite
+  # (image references use upstream defaults). The upstream crossplane chart
+  # exposes `crossplane.image.registry` for override. Per-Sovereign overlays
+  # wire that alongside this value. Tracked under #560.
+  imageRegistry: ""
+
 catalystBlueprint:
   upstream: { chart: crossplane, version: "1.18.0", repo: "https://charts.crossplane.io/stable" }
 

--- a/platform/flux/chart/Chart.yaml
+++ b/platform/flux/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-flux
-version: 1.1.3
+version: 1.1.4
 description: |
   Catalyst-curated Blueprint umbrella chart for Flux. Depends on the
   upstream `flux2` chart (fluxcd-community) as a Helm subchart so

--- a/platform/flux/chart/values.yaml
+++ b/platform/flux/chart/values.yaml
@@ -8,6 +8,15 @@
 #      (umbrella-chart convention — the dependency name from Chart.yaml is
 #      the values namespace).
 
+global:
+  # When set, ALL image pulls in this chart route through this registry.
+  # Used post-handover when the Sovereign's own Harbor takes over the
+  # proxy_cache role from contabo's central Harbor. Empty = no rewrite
+  # (image references use upstream defaults). The upstream flux2 chart
+  # exposes per-controller `flux2.<controller>.image.repository` knobs.
+  # Per-Sovereign overlays wire those alongside this value. Tracked under #560.
+  imageRegistry: ""
+
 catalystBlueprint:
   # Pinned to flux2 2.14.1 (= upstream Flux appVersion 2.4.0). MUST match
   # `infra/hetzner/cloudinit-control-plane.tftpl`'s install.yaml URL

--- a/platform/grafana/chart/Chart.yaml
+++ b/platform/grafana/chart/Chart.yaml
@@ -11,7 +11,7 @@ description: |
   (logs), bp-tempo (traces), bp-mimir (metrics), and bp-alloy or
   bp-opentelemetry (collection).
 type: application
-version: 1.0.0
+version: 1.0.1
 appVersion: "12.3.1"
 keywords: [catalyst, blueprint, grafana, observability, dashboards]
 maintainers:

--- a/platform/grafana/chart/values.yaml
+++ b/platform/grafana/chart/values.yaml
@@ -6,6 +6,15 @@
 # meaningful value is configurable; cluster overlays in clusters/<sovereign>/
 # may override any of these without rebuilding the Blueprint OCI artifact.
 
+global:
+  # When set, ALL image pulls in this chart route through this registry.
+  # Used post-handover when the Sovereign's own Harbor takes over the
+  # proxy_cache role from contabo's central Harbor. Empty = no rewrite
+  # (image references use upstream defaults). The upstream grafana chart
+  # exposes `grafana.image.repository` for override. Per-Sovereign overlays
+  # wire that alongside this value. Tracked under #560.
+  imageRegistry: ""
+
 catalystBlueprint:
   upstream:
     chart: grafana

--- a/platform/keycloak/chart/Chart.yaml
+++ b/platform/keycloak/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-keycloak
-version: 1.2.0
+version: 1.2.1
 description: |
   Catalyst-curated Blueprint umbrella chart for Keycloak. Depends on the
   upstream `keycloak` chart (bitnami) as a Helm subchart so

--- a/platform/keycloak/chart/values.yaml
+++ b/platform/keycloak/chart/values.yaml
@@ -8,6 +8,16 @@
 #      (umbrella-chart convention — the dependency name from Chart.yaml is
 #      the values namespace).
 
+global:
+  # When set, ALL image pulls in this chart route through this registry.
+  # Used post-handover when the Sovereign's own Harbor takes over the
+  # proxy_cache role from contabo's central Harbor. Empty = no rewrite
+  # (image references use upstream defaults). The upstream Bitnami keycloak
+  # chart exposes per-component `keycloak.image.registry`,
+  # `keycloak.postgresql.image.registry`, etc. for fine-grained override.
+  # Per-Sovereign overlays wire those alongside this value. Tracked under #560.
+  imageRegistry: ""
+
 catalystBlueprint:
   upstream: { chart: keycloak, version: "25.2.0", repo: "https://charts.bitnami.com/bitnami" }
 

--- a/platform/kyverno/chart/Chart.yaml
+++ b/platform/kyverno/chart/Chart.yaml
@@ -12,7 +12,7 @@ description: |
   HA mode runs four controllers (admission, background, cleanup, reports);
   solo-Sovereign default is replicas=1 each.
 type: application
-version: 1.0.0
+version: 1.0.1
 appVersion: "v1.18.0"
 keywords: [catalyst, blueprint, kyverno, policy, admission, security]
 maintainers:

--- a/platform/kyverno/chart/values.yaml
+++ b/platform/kyverno/chart/values.yaml
@@ -6,6 +6,15 @@
 # meaningful value is configurable; cluster overlays in clusters/<sovereign>/
 # may override any of these without rebuilding the Blueprint OCI artifact.
 
+global:
+  # When set, ALL image pulls in this chart route through this registry.
+  # Used post-handover when the Sovereign's own Harbor takes over the
+  # proxy_cache role from contabo's central Harbor. Empty = no rewrite
+  # (image references use upstream defaults). The upstream Kyverno chart
+  # exposes per-controller `kyverno.<controller>.image.registry` knobs.
+  # Per-Sovereign overlays wire those alongside this value. Tracked under #560.
+  imageRegistry: ""
+
 catalystBlueprint:
   upstream:
     chart: kyverno

--- a/platform/trivy/chart/Chart.yaml
+++ b/platform/trivy/chart/Chart.yaml
@@ -12,7 +12,7 @@ description: |
   secrets, infra assessments. Target namespaces follow the `bp-*` prefix
   convention so scan results align with Blueprint installation units.
 type: application
-version: 1.0.0
+version: 1.0.1
 appVersion: "0.30.1"
 keywords: [catalyst, blueprint, trivy, security, scanner, vulnerability]
 maintainers:

--- a/platform/trivy/chart/values.yaml
+++ b/platform/trivy/chart/values.yaml
@@ -6,6 +6,16 @@
 # meaningful value is configurable; cluster overlays in clusters/<sovereign>/
 # may override any of these without rebuilding the Blueprint OCI artifact.
 
+global:
+  # When set, ALL image pulls in this chart route through this registry.
+  # Used post-handover when the Sovereign's own Harbor takes over the
+  # proxy_cache role from contabo's central Harbor. Empty = no rewrite
+  # (image references use upstream defaults). The upstream trivy-operator chart
+  # exposes `trivy-operator.image.registry` and `trivy-operator.trivy.image.registry`
+  # for override. Per-Sovereign overlays wire those alongside this value.
+  # Tracked under #560.
+  imageRegistry: ""
+
 catalystBlueprint:
   upstream:
     chart: trivy-operator

--- a/platform/velero/chart/Chart.yaml
+++ b/platform/velero/chart/Chart.yaml
@@ -24,7 +24,7 @@ description: |
   Sovereign requires only a sibling `infra/<provider>/` Tofu module —
   this chart Just Works.
 type: application
-version: 1.2.0
+version: 1.2.1
 appVersion: "1.18.0"
 keywords: [catalyst, blueprint, velero, backup, disaster-recovery]
 maintainers:

--- a/platform/velero/chart/values.yaml
+++ b/platform/velero/chart/values.yaml
@@ -6,6 +6,15 @@
 # meaningful value is configurable; cluster overlays in clusters/<sovereign>/
 # may override any of these without rebuilding the Blueprint OCI artifact.
 
+global:
+  # When set, ALL image pulls in this chart route through this registry.
+  # Used post-handover when the Sovereign's own Harbor takes over the
+  # proxy_cache role from contabo's central Harbor. Empty = no rewrite
+  # (image references use upstream defaults). The upstream velero chart
+  # exposes `velero.image.repository` for override. Per-Sovereign overlays
+  # wire those alongside this value. Tracked under #560.
+  imageRegistry: ""
+
 catalystBlueprint:
   upstream:
     chart: velero

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-catalyst-platform
-version: 1.1.13
+version: 1.1.14
 appVersion: 1.1.6
 description: |
   Catalyst Platform — the unified Catalyst control plane umbrella chart for Catalyst-Zero.
@@ -95,6 +95,10 @@ description: |
   11 SME service deployments. Paired with new bp-reflector (slot 05a)
   that auto-mirrors flux-system/ghcr-pull to every namespace via
   reflector.v1.k8s.emberstack.com annotations. Issue #543, 2026-05-02.
+  Bumped to 1.1.14 to add global.imageRegistry value and template all
+  Catalyst-authored image refs (catalyst-api, catalyst-ui, marketplace-api,
+  console, and all 10 SME service deployments). Post-handover per-Sovereign
+  overlays set global.imageRegistry to the local Harbor mirror. Issue #560.
 type: application
 
 # Opt-out from the blueprint-release hollow-chart guard (issue #181 / #510).

--- a/products/catalyst/chart/templates/api-deployment.yaml
+++ b/products/catalyst/chart/templates/api-deployment.yaml
@@ -128,7 +128,7 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       containers:
         - name: catalyst-api
-          image: ghcr.io/openova-io/openova/catalyst-api:ccc3898
+          image: "{{ if .Values.global.imageRegistry }}{{ .Values.global.imageRegistry }}{{ else }}{{ .Values.images.registry }}{{ end }}/{{ .Values.images.organization }}/catalyst-api:{{ .Values.images.catalystApi.tag }}"
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080

--- a/products/catalyst/chart/templates/marketplace-api/deployment.yaml
+++ b/products/catalyst/chart/templates/marketplace-api/deployment.yaml
@@ -19,7 +19,7 @@ spec:
         - name: ghcr-pull
       containers:
         - name: marketplace-api
-          image: ghcr.io/openova-io/openova/marketplace-api:3c2f7e4
+          image: "{{ if .Values.global.imageRegistry }}{{ .Values.global.imageRegistry }}{{ else }}{{ .Values.images.registry }}{{ end }}/{{ .Values.images.organization }}/marketplace-api:{{ .Values.images.marketplaceApi.tag }}"
           ports:
             - containerPort: 8080
               protocol: TCP

--- a/products/catalyst/chart/templates/sme-services/admin.yaml
+++ b/products/catalyst/chart/templates/sme-services/admin.yaml
@@ -19,7 +19,7 @@ spec:
         - name: ghcr-pull
       containers:
         - name: admin
-          image: ghcr.io/openova-io/openova/admin:046e5eb
+          image: "{{ if .Values.global.imageRegistry }}{{ .Values.global.imageRegistry }}{{ else }}{{ .Values.images.registry }}{{ end }}/{{ .Values.images.organization }}/admin:{{ .Values.images.smeTag }}"
           imagePullPolicy: Always
           ports:
             - containerPort: 8080

--- a/products/catalyst/chart/templates/sme-services/auth.yaml
+++ b/products/catalyst/chart/templates/sme-services/auth.yaml
@@ -19,7 +19,7 @@ spec:
         - name: ghcr-pull
       containers:
         - name: auth
-          image: ghcr.io/openova-io/openova/services-auth:046e5eb
+          image: "{{ if .Values.global.imageRegistry }}{{ .Values.global.imageRegistry }}{{ else }}{{ .Values.images.registry }}{{ end }}/{{ .Values.images.organization }}/services-auth:{{ .Values.images.smeTag }}"
           imagePullPolicy: Always
           ports:
             - containerPort: 8081

--- a/products/catalyst/chart/templates/sme-services/billing.yaml
+++ b/products/catalyst/chart/templates/sme-services/billing.yaml
@@ -19,7 +19,7 @@ spec:
         - name: ghcr-pull
       containers:
         - name: billing
-          image: ghcr.io/openova-io/openova/services-billing:046e5eb
+          image: "{{ if .Values.global.imageRegistry }}{{ .Values.global.imageRegistry }}{{ else }}{{ .Values.images.registry }}{{ end }}/{{ .Values.images.organization }}/services-billing:{{ .Values.images.smeTag }}"
           imagePullPolicy: Always
           ports:
             - containerPort: 8085

--- a/products/catalyst/chart/templates/sme-services/catalog.yaml
+++ b/products/catalyst/chart/templates/sme-services/catalog.yaml
@@ -19,7 +19,7 @@ spec:
         - name: ghcr-pull
       containers:
         - name: catalog
-          image: ghcr.io/openova-io/openova/services-catalog:046e5eb
+          image: "{{ if .Values.global.imageRegistry }}{{ .Values.global.imageRegistry }}{{ else }}{{ .Values.images.registry }}{{ end }}/{{ .Values.images.organization }}/services-catalog:{{ .Values.images.smeTag }}"
           imagePullPolicy: Always
           ports:
             - containerPort: 8082

--- a/products/catalyst/chart/templates/sme-services/console.yaml
+++ b/products/catalyst/chart/templates/sme-services/console.yaml
@@ -19,7 +19,7 @@ spec:
         - name: ghcr-pull
       containers:
         - name: console
-          image: ghcr.io/openova-io/openova/console:3c2f7e4
+          image: "{{ if .Values.global.imageRegistry }}{{ .Values.global.imageRegistry }}{{ else }}{{ .Values.images.registry }}{{ end }}/{{ .Values.images.organization }}/console:{{ .Values.images.console.tag }}"
           imagePullPolicy: Always
           ports:
             - containerPort: 8080

--- a/products/catalyst/chart/templates/sme-services/domain.yaml
+++ b/products/catalyst/chart/templates/sme-services/domain.yaml
@@ -19,7 +19,7 @@ spec:
         - name: ghcr-pull
       containers:
         - name: domain
-          image: ghcr.io/openova-io/openova/services-domain:046e5eb
+          image: "{{ if .Values.global.imageRegistry }}{{ .Values.global.imageRegistry }}{{ else }}{{ .Values.images.registry }}{{ end }}/{{ .Values.images.organization }}/services-domain:{{ .Values.images.smeTag }}"
           imagePullPolicy: Always
           ports:
             - containerPort: 8086

--- a/products/catalyst/chart/templates/sme-services/gateway.yaml
+++ b/products/catalyst/chart/templates/sme-services/gateway.yaml
@@ -19,7 +19,7 @@ spec:
         - name: ghcr-pull
       containers:
         - name: gateway
-          image: ghcr.io/openova-io/openova/services-gateway:046e5eb
+          image: "{{ if .Values.global.imageRegistry }}{{ .Values.global.imageRegistry }}{{ else }}{{ .Values.images.registry }}{{ end }}/{{ .Values.images.organization }}/services-gateway:{{ .Values.images.smeTag }}"
           imagePullPolicy: Always
           ports:
             - containerPort: 8080

--- a/products/catalyst/chart/templates/sme-services/marketplace.yaml
+++ b/products/catalyst/chart/templates/sme-services/marketplace.yaml
@@ -19,7 +19,7 @@ spec:
         - name: ghcr-pull
       containers:
         - name: marketplace
-          image: ghcr.io/openova-io/openova/marketplace:046e5eb
+          image: "{{ if .Values.global.imageRegistry }}{{ .Values.global.imageRegistry }}{{ else }}{{ .Values.images.registry }}{{ end }}/{{ .Values.images.organization }}/marketplace:{{ .Values.images.smeTag }}"
           imagePullPolicy: Always
           ports:
             - containerPort: 8080

--- a/products/catalyst/chart/templates/sme-services/notification.yaml
+++ b/products/catalyst/chart/templates/sme-services/notification.yaml
@@ -17,7 +17,7 @@ spec:
         - name: ghcr-pull
       containers:
         - name: notification
-          image: ghcr.io/openova-io/openova/services-notification:046e5eb
+          image: "{{ if .Values.global.imageRegistry }}{{ .Values.global.imageRegistry }}{{ else }}{{ .Values.images.registry }}{{ end }}/{{ .Values.images.organization }}/services-notification:{{ .Values.images.smeTag }}"
           imagePullPolicy: Always
           ports:
             - containerPort: 8087

--- a/products/catalyst/chart/templates/sme-services/provisioning.yaml
+++ b/products/catalyst/chart/templates/sme-services/provisioning.yaml
@@ -140,7 +140,7 @@ spec:
         - name: ghcr-pull
       containers:
         - name: provisioning
-          image: ghcr.io/openova-io/openova/services-provisioning:046e5eb
+          image: "{{ if .Values.global.imageRegistry }}{{ .Values.global.imageRegistry }}{{ else }}{{ .Values.images.registry }}{{ end }}/{{ .Values.images.organization }}/services-provisioning:{{ .Values.images.smeTag }}"
           imagePullPolicy: Always
           ports:
             - containerPort: 8084

--- a/products/catalyst/chart/templates/sme-services/tenant.yaml
+++ b/products/catalyst/chart/templates/sme-services/tenant.yaml
@@ -19,7 +19,7 @@ spec:
         - name: ghcr-pull
       containers:
         - name: tenant
-          image: ghcr.io/openova-io/openova/services-tenant:046e5eb
+          image: "{{ if .Values.global.imageRegistry }}{{ .Values.global.imageRegistry }}{{ else }}{{ .Values.images.registry }}{{ end }}/{{ .Values.images.organization }}/services-tenant:{{ .Values.images.smeTag }}"
           imagePullPolicy: Always
           ports:
             - containerPort: 8083

--- a/products/catalyst/chart/templates/ui-deployment.yaml
+++ b/products/catalyst/chart/templates/ui-deployment.yaml
@@ -19,7 +19,7 @@ spec:
         - name: ghcr-pull
       containers:
         - name: catalyst-ui
-          image: ghcr.io/openova-io/openova/catalyst-ui:ccc3898
+          image: "{{ if .Values.global.imageRegistry }}{{ .Values.global.imageRegistry }}{{ else }}{{ .Values.images.registry }}{{ end }}/{{ .Values.images.organization }}/catalyst-ui:{{ .Values.images.catalystUi.tag }}"
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080

--- a/products/catalyst/chart/values.yaml
+++ b/products/catalyst/chart/values.yaml
@@ -1,3 +1,31 @@
+global:
+  # When set, ALL Catalyst-authored container image pulls route through this
+  # registry. Post-handover: per-Sovereign overlays set this to
+  # harbor.<sovereign-fqdn> so every image pull hits the Sovereign's own Harbor
+  # proxy_cache rather than ghcr.io directly. Empty = no rewrite (image refs
+  # use `images.registry` / `images.organization` defaults below). Tracked
+  # under #560.
+  imageRegistry: ""
+
+# ─── Catalyst image coordinates ───────────────────────────────────────────────
+# Default registry + org point at ghcr.io/openova-io/openova. Per-Sovereign
+# overlays leave these untouched and set global.imageRegistry to the local
+# Harbor mirror instead.
+images:
+  registry: "ghcr.io"
+  organization: "openova-io/openova"
+  # SHA tags — bump these via CI when building new images.
+  catalystApi:
+    tag: "ccc3898"
+  catalystUi:
+    tag: "ccc3898"
+  marketplaceApi:
+    tag: "3c2f7e4"
+  console:
+    tag: "3c2f7e4"
+  # All 10 SME microservices share one SHA tag (built from the same mono-repo commit).
+  smeTag: "046e5eb"
+
 # bp-catalyst-platform umbrella values
 #
 # As of 1.1.9 this umbrella ships ONLY the Catalyst-Zero control-plane


### PR DESCRIPTION
## Summary

Third and final PR of the global.imageRegistry series (closes #560).

**Charts updated in this PR:**
- bp-keycloak 1.2.0 → 1.2.1 — subchart stub; documents Bitnami per-component `image.registry` knobs
- bp-crossplane 1.1.3 → 1.1.4 — subchart stub
- bp-crossplane-claims 1.1.0 → 1.1.1 — adds `global.kubectlImage.{repository,tag}`; templates `bitnami/kubectl:1.31` Job image; Hetzner `ubuntu-24.04` server images intentionally untouched (not Docker images)
- bp-velero 1.2.0 → 1.2.1 — subchart stub
- bp-kyverno 1.0.0 → 1.0.1 — subchart stub; documents per-controller `image.registry` knobs
- bp-trivy 1.0.0 → 1.0.1 — subchart stub; documents both operator + scanner `image.registry` knobs
- bp-grafana 1.0.0 → 1.0.1 — subchart stub
- bp-flux 1.1.3 → 1.1.4 — subchart stub; documents per-controller `image.repository` knobs
- bp-catalyst-platform 1.1.13 → 1.1.14 — full templating: adds `global.imageRegistry` + `images.{catalystApi,catalystUi,marketplaceApi,console,smeTag}` block; templates all 14 Catalyst-authored image refs

**PRs 1/3 and 2/3 already merged:**
- PR 1/3 (#562) — bp-cilium, bp-cert-manager, bp-cert-manager-pdns-webhook, bp-sealed-secrets
- PR 2/3 (#565) — bp-openbao, bp-external-secrets, bp-cnpg, bp-valkey, bp-nats-jetstream, bp-powerdns, bp-gitea

**Already carried in prior fix PRs:** bp-spire (#575), bp-harbor (#576 + current)

## Validation

```
helm template products/catalyst/chart \
  --set global.imageRegistry=harbor.example.com \
  --set ingress.hosts.console.host=console.example.com \
  --set ingress.hosts.api.host=api.example.com | grep "image:"
# => harbor.example.com/openova-io/openova/catalyst-api:ccc3898
# => harbor.example.com/openova-io/openova/catalyst-ui:ccc3898
```

Default render (no registry set) still uses `ghcr.io/openova-io/openova/...`.

## Test plan
- [ ] `helm template` with `--set global.imageRegistry=harbor.example.com` emits `harbor.example.com/...` for all Catalyst-authored images
- [ ] `helm template` without flag emits `ghcr.io/openova-io/openova/...` (no regression)
- [ ] CI blueprint-release smoke render passes for all bumped charts
- [ ] crossplane-claims: `bitnami/kubectl:1.31` is templated; `ubuntu-24.04` Hetzner server images are NOT prefixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)