### PR TITLE
fix(cloud-init): Gateway API v1.1.0 CRDs before Cilium — fixes GatewayClass/cilium race (#503)

### DIFF
--- a/clusters/_template/bootstrap-kit/01-cilium.yaml
+++ b/clusters/_template/bootstrap-kit/01-cilium.yaml
@@ -36,7 +36,7 @@ spec:
   chart:
     spec:
       chart: bp-cilium
-      version: 1.1.1
+      version: 1.1.3
       sourceRef:
         kind: HelmRepository
         name: bp-cilium

--- a/clusters/_template/bootstrap-kit/01a-gateway-api.yaml
+++ b/clusters/_template/bootstrap-kit/01a-gateway-api.yaml
@@ -60,7 +60,7 @@ spec:
   chart:
     spec:
       chart: bp-gateway-api
-      version: 1.0.0
+      version: 1.1.0
       sourceRef:
         kind: HelmRepository
         name: bp-gateway-api

--- a/infra/hetzner/cloudinit-control-plane.tftpl
+++ b/infra/hetzner/cloudinit-control-plane.tftpl
@@ -421,6 +421,16 @@ write_files:
         type: wireguard
       gatewayAPI:
         enabled: true
+        gatewayClass:
+          # Force GatewayClass creation regardless of CRD presence at Helm
+          # render time. Default is "auto" which skips creation when the
+          # gateway.networking.k8s.io CRDs are not yet present — exactly
+          # what happens during bootstrap: the upstream Helm chart's
+          # Capabilities check fires BEFORE bp-gateway-api has run, so
+          # GatewayClass/cilium is never rendered into the release.
+          # Forcing "true" ensures the GatewayClass is always created.
+          # Fix for cilium-gateway-race (issue #503).
+          create: "true"
       envoy:
         enabled: true
       # envoyConfig.enabled is the load-bearing flag from issue #491.
@@ -847,6 +857,39 @@ runcmd:
   # inline as a --version flag because OpenTofu's `var.k3s_version`
   # parameterisation wires through to it (per INVIOLABLE-PRINCIPLES
   # #4 — never hardcode).
+  # ── Gateway API CRDs BEFORE Cilium ──────────────────────────────────────
+  #
+  # Cilium 1.16.x operator checks for gateway.networking.k8s.io CRDs at
+  # startup. If the CRDs are absent the operator disables its gateway
+  # controller entirely and never re-checks — a static decision made once
+  # at boot. This creates a race when Gateway API CRDs are installed AFTER
+  # k3s/Cilium, which is the normal Flux GitOps order (bp-gateway-api
+  # reconciles minutes after bp-cilium). Result: every fresh Sovereign has
+  # no GatewayClass/cilium, all HTTPRoutes are orphaned, no routing.
+  #
+  # Fix: pre-install the Gateway API experimental CRDs here, before the
+  # Cilium helm install below. The experimental channel is required because
+  # Cilium 1.16.x references tlsroutes.gateway.networking.k8s.io (v1alpha2)
+  # at startup; the standard channel does not ship TLSRoute.
+  #
+  # Version choice — v1.1.0 NOT v1.2.0:
+  #   Gateway API v1.2.0 changed status.supportedFeatures from an array of
+  #   strings to an array of objects ({name: string}). Cilium 1.16.5 still
+  #   writes the old string format; the v1.2.0 CRD rejects its status patch
+  #   with "must be of type object: string", leaving GatewayClass/cilium
+  #   permanently in status=Unknown/Pending. v1.1.0 retains the string
+  #   format and is fully compatible with Cilium 1.16.x.
+  #
+  # bp-gateway-api Flux blueprint becomes a no-op on first reconcile
+  # (CRDs already present, kubectl apply is idempotent); it is kept as the
+  # GitOps record and handles CRD upgrades when Cilium is bumped.
+  #
+  # Incident reference: otech22 2026-05-02 — all 8 HTTPRoutes orphaned,
+  # cilium-operator log: "Required GatewayAPI resources are not found …
+  # tlsroutes.gateway.networking.k8s.io not found". Fix: issue #503.
+  - 'kubectl --kubeconfig=/etc/rancher/k3s/k3s.yaml apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.1.0/experimental-install.yaml'
+  - 'kubectl --kubeconfig=/etc/rancher/k3s/k3s.yaml wait --for=condition=Established crd/tlsroutes.gateway.networking.k8s.io --timeout=60s'
+
   - 'curl -sSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash'
   - 'helm repo add cilium https://helm.cilium.io/'
   - 'helm repo update'

--- a/platform/cilium/blueprint.yaml
+++ b/platform/cilium/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/category: per-host-cluster-infrastructure
     catalyst.openova.io/section: pts-3-1-networking-and-service-mesh
 spec:
-  version: 1.1.1
+  version: 1.1.3
   card:
     title: Cilium
     summary: Unified CNI + Service Mesh (eBPF). mTLS via WireGuard, Hubble observability, Gateway API.

--- a/platform/cilium/chart/Chart.yaml
+++ b/platform/cilium/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-cilium
-version: 1.1.2
+version: 1.1.3
 description: |
   Catalyst-curated Blueprint umbrella chart for Cilium. Depends on the
   upstream `cilium` chart as a Helm subchart so `helm dependency build`

--- a/platform/cilium/chart/values.yaml
+++ b/platform/cilium/chart/values.yaml
@@ -86,6 +86,16 @@ cilium:
   # Gateway API — replaces traditional ingress controllers
   gatewayAPI:
     enabled: true
+    gatewayClass:
+      # Force GatewayClass creation regardless of CRD presence at Helm
+      # render time. Upstream default is "auto" which skips creation when
+      # the gateway.networking.k8s.io CRDs are absent (Capabilities check
+      # at helm install time). During bootstrap, bp-gateway-api runs AFTER
+      # bp-cilium, so "auto" silently skips the GatewayClass — leaving
+      # every HTTPRoute orphaned until the operator is manually restarted.
+      # Forcing "true" ensures GatewayClass/cilium is always created.
+      # Permanent fix for the cilium-gateway race (issue #503).
+      create: "true"
 
   # L7 proxy via Envoy — for HTTPRoute, gRPCRoute, L7 NetworkPolicy
   envoy:

--- a/platform/gateway-api/blueprint.yaml
+++ b/platform/gateway-api/blueprint.yaml
@@ -6,11 +6,11 @@ metadata:
     catalyst.openova.io/category: per-host-cluster-infrastructure
     catalyst.openova.io/section: pts-3-1-networking-and-service-mesh
 spec:
-  version: 1.0.0
+  version: 1.1.0
   card:
     title: Gateway API
     summary: |
-      Upstream Kubernetes Gateway API CRDs (Standard channel) — the
+      Upstream Kubernetes Gateway API CRDs (Experimental channel, v1.1.0) — the
       gateway.networking.k8s.io/v1 family that every HTTPRoute/Gateway/
       GatewayClass-using Blueprint depends on. Cilium 1.16's `gatewayAPI.
       enabled=true` flag wires up the cilium controller but does NOT

--- a/platform/gateway-api/chart/Chart.yaml
+++ b/platform/gateway-api/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-gateway-api
-version: 1.0.0
+version: 1.1.0
 description: |
   Catalyst Blueprint installing the upstream Kubernetes Gateway API
   CustomResourceDefinitions (Standard channel — gatewayclasses, gateways,
@@ -41,8 +41,21 @@ maintainers:
 # Upstream Gateway API release pinned here (operator-bumpable per
 # docs/INVIOLABLE-PRINCIPLES.md #4 — never hardcode in app/values, only in
 # the Blueprint version metadata + a single annotation that the templates
-# read via .Chart.Annotations). Cilium 1.16 supports Gateway API v1.2.x;
-# bumping requires a paired Cilium support-matrix check.
+# read via .Chart.Annotations).
+#
+# Version v1.1.0 (NOT v1.2.0): Gateway API v1.2.0 changed
+# status.supportedFeatures from string[] to object[]; Cilium 1.16.5
+# still writes the old string format. The v1.2.0 CRD rejects the
+# status patch with "must be of type object: string", leaving
+# GatewayClass/cilium permanently Unknown/Pending. v1.1.0 retains the
+# string schema. Bump in lock-step with Cilium when 1.17+ (which
+# writes the v1.2.0 object format) is adopted. See issue #503.
+#
+# experimental-install.yaml (NOT standard-install.yaml): Cilium 1.16.x
+# checks for tlsroutes.gateway.networking.k8s.io at operator startup.
+# The standard channel does not ship TLSRoute — the operator disables
+# its gateway controller if TLSRoute is absent. Experimental channel
+# includes TLSRoute, TCPRoute, UDPRoute, BackendLBPolicy, BackendTLSPolicy.
 annotations:
   catalyst.openova.io/no-upstream: "true"
-  catalyst.openova.io/upstream-gateway-api-version: "v1.2.0"
+  catalyst.openova.io/upstream-gateway-api-version: "v1.1.0"

--- a/platform/gateway-api/chart/templates/backendlbpolicies.yaml
+++ b/platform/gateway-api/chart/templates/backendlbpolicies.yaml
@@ -1,0 +1,569 @@
+{{/*
+  Vendored from kubernetes-sigs/gateway-api {{ index .Chart.Annotations "catalyst.openova.io/upstream-gateway-api-version" }}
+  experimental-install.yaml. Do NOT hand-edit annotations / spec — re-vendor
+  via the script in tests/regenerate.sh when bumping the upstream version
+  (also bump catalyst.openova.io/upstream-gateway-api-version in Chart.yaml).
+
+  helm.sh/resource-policy: keep is added under metadata.annotations so a
+  Helm uninstall does NOT delete the CRD. Gateway API CRDs are foundational
+  cluster-scoped infrastructure; deleting them on uninstall would break
+  every HTTPRoute on the cluster simultaneously.
+*/}}
+
+#
+# config/crd/experimental/gateway.networking.k8s.io_backendlbpolicies.yaml
+#
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    helm.sh/resource-policy: keep
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/2997
+    gateway.networking.k8s.io/bundle-version: v1.1.0
+    gateway.networking.k8s.io/channel: experimental
+  creationTimestamp: null
+  name: backendlbpolicies.gateway.networking.k8s.io
+spec:
+  group: gateway.networking.k8s.io
+  names:
+    categories:
+    - gateway-api
+    kind: BackendLBPolicy
+    listKind: BackendLBPolicyList
+    plural: backendlbpolicies
+    shortNames:
+    - blbpolicy
+    singular: backendlbpolicy
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: |-
+          BackendLBPolicy provides a way to define load balancing rules
+          for a backend.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of BackendLBPolicy.
+            properties:
+              sessionPersistence:
+                description: |-
+                  SessionPersistence defines and configures session persistence
+                  for the backend.
+
+
+                  Support: Extended
+                properties:
+                  absoluteTimeout:
+                    description: |-
+                      AbsoluteTimeout defines the absolute timeout of the persistent
+                      session. Once the AbsoluteTimeout duration has elapsed, the
+                      session becomes invalid.
+
+
+                      Support: Extended
+                    pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                    type: string
+                  cookieConfig:
+                    description: |-
+                      CookieConfig provides configuration settings that are specific
+                      to cookie-based session persistence.
+
+
+                      Support: Core
+                    properties:
+                      lifetimeType:
+                        default: Session
+                        description: |-
+                          LifetimeType specifies whether the cookie has a permanent or
+                          session-based lifetime. A permanent cookie persists until its
+                          specified expiry time, defined by the Expires or Max-Age cookie
+                          attributes, while a session cookie is deleted when the current
+                          session ends.
+
+
+                          When set to "Permanent", AbsoluteTimeout indicates the
+                          cookie's lifetime via the Expires or Max-Age cookie attributes
+                          and is required.
+
+
+                          When set to "Session", AbsoluteTimeout indicates the
+                          absolute lifetime of the cookie tracked by the gateway and
+                          is optional.
+
+
+                          Support: Core for "Session" type
+
+
+                          Support: Extended for "Permanent" type
+                        enum:
+                        - Permanent
+                        - Session
+                        type: string
+                    type: object
+                  idleTimeout:
+                    description: |-
+                      IdleTimeout defines the idle timeout of the persistent session.
+                      Once the session has been idle for more than the specified
+                      IdleTimeout duration, the session becomes invalid.
+
+
+                      Support: Extended
+                    pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                    type: string
+                  sessionName:
+                    description: |-
+                      SessionName defines the name of the persistent session token
+                      which may be reflected in the cookie or the header. Users
+                      should avoid reusing session names to prevent unintended
+                      consequences, such as rejection or unpredictable behavior.
+
+
+                      Support: Implementation-specific
+                    maxLength: 128
+                    type: string
+                  type:
+                    default: Cookie
+                    description: |-
+                      Type defines the type of session persistence such as through
+                      the use a header or cookie. Defaults to cookie based session
+                      persistence.
+
+
+                      Support: Core for "Cookie" type
+
+
+                      Support: Extended for "Header" type
+                    enum:
+                    - Cookie
+                    - Header
+                    type: string
+                type: object
+                x-kubernetes-validations:
+                - message: AbsoluteTimeout must be specified when cookie lifetimeType
+                    is Permanent
+                  rule: '!has(self.cookieConfig.lifetimeType) || self.cookieConfig.lifetimeType
+                    != ''Permanent'' || has(self.absoluteTimeout)'
+              targetRefs:
+                description: |-
+                  TargetRef identifies an API object to apply policy to.
+                  Currently, Backends (i.e. Service, ServiceImport, or any
+                  implementation-specific backendRef) are the only valid API
+                  target references.
+                items:
+                  description: |-
+                    LocalPolicyTargetReference identifies an API object to apply a direct or
+                    inherited policy to. This should be used as part of Policy resources
+                    that can target Gateway API resources. For more information on how this
+                    policy attachment model works, and a sample Policy resource, refer to
+                    the policy attachment documentation for Gateway API.
+                  properties:
+                    group:
+                      description: Group is the group of the target resource.
+                      maxLength: 253
+                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    kind:
+                      description: Kind is kind of the target resource.
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                      type: string
+                    name:
+                      description: Name is the name of the target resource.
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                  required:
+                  - group
+                  - kind
+                  - name
+                  type: object
+                maxItems: 16
+                minItems: 1
+                type: array
+                x-kubernetes-list-map-keys:
+                - group
+                - kind
+                - name
+                x-kubernetes-list-type: map
+            required:
+            - targetRefs
+            type: object
+          status:
+            description: Status defines the current state of BackendLBPolicy.
+            properties:
+              ancestors:
+                description: |-
+                  Ancestors is a list of ancestor resources (usually Gateways) that are
+                  associated with the policy, and the status of the policy with respect to
+                  each ancestor. When this policy attaches to a parent, the controller that
+                  manages the parent and the ancestors MUST add an entry to this list when
+                  the controller first sees the policy and SHOULD update the entry as
+                  appropriate when the relevant ancestor is modified.
+
+
+                  Note that choosing the relevant ancestor is left to the Policy designers;
+                  an important part of Policy design is designing the right object level at
+                  which to namespace this status.
+
+
+                  Note also that implementations MUST ONLY populate ancestor status for
+                  the Ancestor resources they are responsible for. Implementations MUST
+                  use the ControllerName field to uniquely identify the entries in this list
+                  that they are responsible for.
+
+
+                  Note that to achieve this, the list of PolicyAncestorStatus structs
+                  MUST be treated as a map with a composite key, made up of the AncestorRef
+                  and ControllerName fields combined.
+
+
+                  A maximum of 16 ancestors will be represented in this list. An empty list
+                  means the Policy is not relevant for any ancestors.
+
+
+                  If this slice is full, implementations MUST NOT add further entries.
+                  Instead they MUST consider the policy unimplementable and signal that
+                  on any related resources such as the ancestor that would be referenced
+                  here. For example, if this list was full on BackendTLSPolicy, no
+                  additional Gateways would be able to reference the Service targeted by
+                  the BackendTLSPolicy.
+                items:
+                  description: |-
+                    PolicyAncestorStatus describes the status of a route with respect to an
+                    associated Ancestor.
+
+
+                    Ancestors refer to objects that are either the Target of a policy or above it
+                    in terms of object hierarchy. For example, if a policy targets a Service, the
+                    Policy's Ancestors are, in order, the Service, the HTTPRoute, the Gateway, and
+                    the GatewayClass. Almost always, in this hierarchy, the Gateway will be the most
+                    useful object to place Policy status on, so we recommend that implementations
+                    SHOULD use Gateway as the PolicyAncestorStatus object unless the designers
+                    have a _very_ good reason otherwise.
+
+
+                    In the context of policy attachment, the Ancestor is used to distinguish which
+                    resource results in a distinct application of this policy. For example, if a policy
+                    targets a Service, it may have a distinct result per attached Gateway.
+
+
+                    Policies targeting the same resource may have different effects depending on the
+                    ancestors of those resources. For example, different Gateways targeting the same
+                    Service may have different capabilities, especially if they have different underlying
+                    implementations.
+
+
+                    For example, in BackendTLSPolicy, the Policy attaches to a Service that is
+                    used as a backend in a HTTPRoute that is itself attached to a Gateway.
+                    In this case, the relevant object for status is the Gateway, and that is the
+                    ancestor object referred to in this status.
+
+
+                    Note that a parent is also an ancestor, so for objects where the parent is the
+                    relevant object for status, this struct SHOULD still be used.
+
+
+                    This struct is intended to be used in a slice that's effectively a map,
+                    with a composite key made up of the AncestorRef and the ControllerName.
+                  properties:
+                    ancestorRef:
+                      description: |-
+                        AncestorRef corresponds with a ParentRef in the spec that this
+                        PolicyAncestorStatus struct describes the status of.
+                      properties:
+                        group:
+                          default: gateway.networking.k8s.io
+                          description: |-
+                            Group is the group of the referent.
+                            When unspecified, "gateway.networking.k8s.io" is inferred.
+                            To set the core API group (such as for a "Service" kind referent),
+                            Group must be explicitly set to "" (empty string).
+
+
+                            Support: Core
+                          maxLength: 253
+                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                        kind:
+                          default: Gateway
+                          description: |-
+                            Kind is kind of the referent.
+
+
+                            There are two kinds of parent resources with "Core" support:
+
+
+                            * Gateway (Gateway conformance profile)
+                            * Service (Mesh conformance profile, ClusterIP Services only)
+
+
+                            Support for other resources is Implementation-Specific.
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                          type: string
+                        name:
+                          description: |-
+                            Name is the name of the referent.
+
+
+                            Support: Core
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: |-
+                            Namespace is the namespace of the referent. When unspecified, this refers
+                            to the local namespace of the Route.
+
+
+                            Note that there are specific rules for ParentRefs which cross namespace
+                            boundaries. Cross-namespace references are only valid if they are explicitly
+                            allowed by something in the namespace they are referring to. For example:
+                            Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                            generic way to enable any other kind of cross-namespace reference.
+
+
+
+                            ParentRefs from a Route to a Service in the same namespace are "producer"
+                            routes, which apply default routing rules to inbound connections from
+                            any namespace to the Service.
+
+
+                            ParentRefs from a Route to a Service in a different namespace are
+                            "consumer" routes, and these routing rules are only applied to outbound
+                            connections originating from the same namespace as the Route, for which
+                            the intended destination of the connections are a Service targeted as a
+                            ParentRef of the Route.
+
+
+
+                            Support: Core
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                          type: string
+                        port:
+                          description: |-
+                            Port is the network port this Route targets. It can be interpreted
+                            differently based on the type of parent resource.
+
+
+                            When the parent resource is a Gateway, this targets all listeners
+                            listening on the specified port that also support this kind of Route(and
+                            select this Route). It's not recommended to set `Port` unless the
+                            networking behaviors specified in a Route must apply to a specific port
+                            as opposed to a listener(s) whose port(s) may be changed. When both Port
+                            and SectionName are specified, the name and port of the selected listener
+                            must match both specified values.
+
+
+
+                            When the parent resource is a Service, this targets a specific port in the
+                            Service spec. When both Port (experimental) and SectionName are specified,
+                            the name and port of the selected port must match both specified values.
+
+
+
+                            Implementations MAY choose to support other parent resources.
+                            Implementations supporting other types of parent resources MUST clearly
+                            document how/if Port is interpreted.
+
+
+                            For the purpose of status, an attachment is considered successful as
+                            long as the parent resource accepts it partially. For example, Gateway
+                            listeners can restrict which Routes can attach to them by Route kind,
+                            namespace, or hostname. If 1 of 2 Gateway listeners accept attachment
+                            from the referencing Route, the Route MUST be considered successfully
+                            attached. If no Gateway listeners accept attachment from this Route,
+                            the Route MUST be considered detached from the Gateway.
+
+
+                            Support: Extended
+                          format: int32
+                          maximum: 65535
+                          minimum: 1
+                          type: integer
+                        sectionName:
+                          description: |-
+                            SectionName is the name of a section within the target resource. In the
+                            following resources, SectionName is interpreted as the following:
+
+
+                            * Gateway: Listener name. When both Port (experimental) and SectionName
+                            are specified, the name and port of the selected listener must match
+                            both specified values.
+                            * Service: Port name. When both Port (experimental) and SectionName
+                            are specified, the name and port of the selected listener must match
+                            both specified values.
+
+
+                            Implementations MAY choose to support attaching Routes to other resources.
+                            If that is the case, they MUST clearly document how SectionName is
+                            interpreted.
+
+
+                            When unspecified (empty string), this will reference the entire resource.
+                            For the purpose of status, an attachment is considered successful if at
+                            least one section in the parent resource accepts it. For example, Gateway
+                            listeners can restrict which Routes can attach to them by Route kind,
+                            namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from
+                            the referencing Route, the Route MUST be considered successfully
+                            attached. If no Gateway listeners accept attachment from this Route, the
+                            Route MUST be considered detached from the Gateway.
+
+
+                            Support: Core
+                          maxLength: 253
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    conditions:
+                      description: Conditions describes the status of the Policy with
+                        respect to the given Ancestor.
+                      items:
+                        description: "Condition contains details for one aspect of
+                          the current state of this API Resource.\n---\nThis struct
+                          is intended for direct use as an array at the field path
+                          .status.conditions.  For example,\n\n\n\ttype FooStatus
+                          struct{\n\t    // Represents the observations of a foo's
+                          current state.\n\t    // Known .status.conditions.type are:
+                          \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                          +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    //
+                          +listType=map\n\t    // +listMapKey=type\n\t    Conditions
+                          []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\"
+                          patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                          \   // other fields\n\t}"
+                        properties:
+                          lastTransitionTime:
+                            description: |-
+                              lastTransitionTime is the last time the condition transitioned from one status to another.
+                              This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                            format: date-time
+                            type: string
+                          message:
+                            description: |-
+                              message is a human readable message indicating details about the transition.
+                              This may be an empty string.
+                            maxLength: 32768
+                            type: string
+                          observedGeneration:
+                            description: |-
+                              observedGeneration represents the .metadata.generation that the condition was set based upon.
+                              For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                              with respect to the current state of the instance.
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          reason:
+                            description: |-
+                              reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected values and meanings for this field,
+                              and whether the values are considered a guaranteed API.
+                              The value should be a CamelCase string.
+                              This field may not be empty.
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                            - "True"
+                            - "False"
+                            - Unknown
+                            type: string
+                          type:
+                            description: |-
+                              type of condition in CamelCase or in foo.example.com/CamelCase.
+                              ---
+                              Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                              useful (see .node.status.conditions), the ability to deconflict is important.
+                              The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                        - lastTransitionTime
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      maxItems: 8
+                      minItems: 1
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - type
+                      x-kubernetes-list-type: map
+                    controllerName:
+                      description: |-
+                        ControllerName is a domain/path string that indicates the name of the
+                        controller that wrote this status. This corresponds with the
+                        controllerName field on GatewayClass.
+
+
+                        Example: "example.net/gateway-controller".
+
+
+                        The format of this field is DOMAIN "/" PATH, where DOMAIN and PATH are
+                        valid Kubernetes names
+                        (https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names).
+
+
+                        Controllers MUST populate this field when writing status. Controllers should ensure that
+                        entries to status populated with their ControllerName are cleaned up when they are no
+                        longer necessary.
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
+                      type: string
+                  required:
+                  - ancestorRef
+                  - controllerName
+                  type: object
+                maxItems: 16
+                type: array
+            required:
+            - ancestors
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/platform/gateway-api/chart/templates/backendtlspolicies.yaml
+++ b/platform/gateway-api/chart/templates/backendtlspolicies.yaml
@@ -1,0 +1,616 @@
+{{/*
+  Vendored from kubernetes-sigs/gateway-api {{ index .Chart.Annotations "catalyst.openova.io/upstream-gateway-api-version" }}
+  experimental-install.yaml. Do NOT hand-edit annotations / spec — re-vendor
+  via the script in tests/regenerate.sh when bumping the upstream version
+  (also bump catalyst.openova.io/upstream-gateway-api-version in Chart.yaml).
+
+  helm.sh/resource-policy: keep is added under metadata.annotations so a
+  Helm uninstall does NOT delete the CRD. Gateway API CRDs are foundational
+  cluster-scoped infrastructure; deleting them on uninstall would break
+  every HTTPRoute on the cluster simultaneously.
+*/}}
+
+#
+# config/crd/experimental/gateway.networking.k8s.io_backendtlspolicies.yaml
+#
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    helm.sh/resource-policy: keep
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/2997
+    gateway.networking.k8s.io/bundle-version: v1.1.0
+    gateway.networking.k8s.io/channel: experimental
+  creationTimestamp: null
+  labels:
+    gateway.networking.k8s.io/policy: Direct
+  name: backendtlspolicies.gateway.networking.k8s.io
+spec:
+  group: gateway.networking.k8s.io
+  names:
+    categories:
+    - gateway-api
+    kind: BackendTLSPolicy
+    listKind: BackendTLSPolicyList
+    plural: backendtlspolicies
+    shortNames:
+    - btlspolicy
+    singular: backendtlspolicy
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: |-
+          BackendTLSPolicy provides a way to configure how a Gateway
+          connects to a Backend via TLS.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of BackendTLSPolicy.
+            properties:
+              targetRefs:
+                description: |-
+                  TargetRefs identifies an API object to apply the policy to.
+                  Only Services have Extended support. Implementations MAY support
+                  additional objects, with Implementation Specific support.
+                  Note that this config applies to the entire referenced resource
+                  by default, but this default may change in the future to provide
+                  a more granular application of the policy.
+
+
+                  Support: Extended for Kubernetes Service
+
+
+                  Support: Implementation-specific for any other resource
+                items:
+                  description: |-
+                    LocalPolicyTargetReferenceWithSectionName identifies an API object to apply a
+                    direct policy to. This should be used as part of Policy resources that can
+                    target single resources. For more information on how this policy attachment
+                    mode works, and a sample Policy resource, refer to the policy attachment
+                    documentation for Gateway API.
+
+
+                    Note: This should only be used for direct policy attachment when references
+                    to SectionName are actually needed. In all other cases,
+                    LocalPolicyTargetReference should be used.
+                  properties:
+                    group:
+                      description: Group is the group of the target resource.
+                      maxLength: 253
+                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    kind:
+                      description: Kind is kind of the target resource.
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                      type: string
+                    name:
+                      description: Name is the name of the target resource.
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                    sectionName:
+                      description: |-
+                        SectionName is the name of a section within the target resource. When
+                        unspecified, this targetRef targets the entire resource. In the following
+                        resources, SectionName is interpreted as the following:
+
+
+                        * Gateway: Listener name
+                        * HTTPRoute: HTTPRouteRule name
+                        * Service: Port name
+
+
+                        If a SectionName is specified, but does not exist on the targeted object,
+                        the Policy must fail to attach, and the policy implementation should record
+                        a `ResolvedRefs` or similar Condition in the Policy's status.
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                  required:
+                  - group
+                  - kind
+                  - name
+                  type: object
+                maxItems: 16
+                minItems: 1
+                type: array
+              validation:
+                description: Validation contains backend TLS validation configuration.
+                properties:
+                  caCertificateRefs:
+                    description: |-
+                      CACertificateRefs contains one or more references to Kubernetes objects that
+                      contain a PEM-encoded TLS CA certificate bundle, which is used to
+                      validate a TLS handshake between the Gateway and backend Pod.
+
+
+                      If CACertificateRefs is empty or unspecified, then WellKnownCACertificates must be
+                      specified. Only one of CACertificateRefs or WellKnownCACertificates may be specified,
+                      not both. If CACertifcateRefs is empty or unspecified, the configuration for
+                      WellKnownCACertificates MUST be honored instead if supported by the implementation.
+
+
+                      References to a resource in a different namespace are invalid for the
+                      moment, although we will revisit this in the future.
+
+
+                      A single CACertificateRef to a Kubernetes ConfigMap kind has "Core" support.
+                      Implementations MAY choose to support attaching multiple certificates to
+                      a backend, but this behavior is implementation-specific.
+
+
+                      Support: Core - An optional single reference to a Kubernetes ConfigMap,
+                      with the CA certificate in a key named `ca.crt`.
+
+
+                      Support: Implementation-specific (More than one reference, or other kinds
+                      of resources).
+                    items:
+                      description: |-
+                        LocalObjectReference identifies an API object within the namespace of the
+                        referrer.
+                        The API object must be valid in the cluster; the Group and Kind must
+                        be registered in the cluster for this reference to be valid.
+
+
+                        References to objects with invalid Group and Kind are not valid, and must
+                        be rejected by the implementation, with appropriate Conditions set
+                        on the containing object.
+                      properties:
+                        group:
+                          description: |-
+                            Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                            When unspecified or empty string, core API group is inferred.
+                          maxLength: 253
+                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                        kind:
+                          description: Kind is kind of the referent. For example "HTTPRoute"
+                            or "Service".
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                          type: string
+                        name:
+                          description: Name is the name of the referent.
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                      required:
+                      - group
+                      - kind
+                      - name
+                      type: object
+                    maxItems: 8
+                    type: array
+                  hostname:
+                    description: |-
+                      Hostname is used for two purposes in the connection between Gateways and
+                      backends:
+
+
+                      1. Hostname MUST be used as the SNI to connect to the backend (RFC 6066).
+                      2. Hostname MUST be used for authentication and MUST match the certificate
+                         served by the matching backend.
+
+
+                      Support: Core
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                  wellKnownCACertificates:
+                    description: |-
+                      WellKnownCACertificates specifies whether system CA certificates may be used in
+                      the TLS handshake between the gateway and backend pod.
+
+
+                      If WellKnownCACertificates is unspecified or empty (""), then CACertificateRefs
+                      must be specified with at least one entry for a valid configuration. Only one of
+                      CACertificateRefs or WellKnownCACertificates may be specified, not both. If an
+                      implementation does not support the WellKnownCACertificates field or the value
+                      supplied is not supported, the Status Conditions on the Policy MUST be
+                      updated to include an Accepted: False Condition with Reason: Invalid.
+
+
+                      Support: Implementation-specific
+                    enum:
+                    - System
+                    type: string
+                required:
+                - hostname
+                type: object
+                x-kubernetes-validations:
+                - message: must not contain both CACertificateRefs and WellKnownCACertificates
+                  rule: '!(has(self.caCertificateRefs) && size(self.caCertificateRefs)
+                    > 0 && has(self.wellKnownCACertificates) && self.wellKnownCACertificates
+                    != "")'
+                - message: must specify either CACertificateRefs or WellKnownCACertificates
+                  rule: (has(self.caCertificateRefs) && size(self.caCertificateRefs)
+                    > 0 || has(self.wellKnownCACertificates) && self.wellKnownCACertificates
+                    != "")
+            required:
+            - targetRefs
+            - validation
+            type: object
+          status:
+            description: Status defines the current state of BackendTLSPolicy.
+            properties:
+              ancestors:
+                description: |-
+                  Ancestors is a list of ancestor resources (usually Gateways) that are
+                  associated with the policy, and the status of the policy with respect to
+                  each ancestor. When this policy attaches to a parent, the controller that
+                  manages the parent and the ancestors MUST add an entry to this list when
+                  the controller first sees the policy and SHOULD update the entry as
+                  appropriate when the relevant ancestor is modified.
+
+
+                  Note that choosing the relevant ancestor is left to the Policy designers;
+                  an important part of Policy design is designing the right object level at
+                  which to namespace this status.
+
+
+                  Note also that implementations MUST ONLY populate ancestor status for
+                  the Ancestor resources they are responsible for. Implementations MUST
+                  use the ControllerName field to uniquely identify the entries in this list
+                  that they are responsible for.
+
+
+                  Note that to achieve this, the list of PolicyAncestorStatus structs
+                  MUST be treated as a map with a composite key, made up of the AncestorRef
+                  and ControllerName fields combined.
+
+
+                  A maximum of 16 ancestors will be represented in this list. An empty list
+                  means the Policy is not relevant for any ancestors.
+
+
+                  If this slice is full, implementations MUST NOT add further entries.
+                  Instead they MUST consider the policy unimplementable and signal that
+                  on any related resources such as the ancestor that would be referenced
+                  here. For example, if this list was full on BackendTLSPolicy, no
+                  additional Gateways would be able to reference the Service targeted by
+                  the BackendTLSPolicy.
+                items:
+                  description: |-
+                    PolicyAncestorStatus describes the status of a route with respect to an
+                    associated Ancestor.
+
+
+                    Ancestors refer to objects that are either the Target of a policy or above it
+                    in terms of object hierarchy. For example, if a policy targets a Service, the
+                    Policy's Ancestors are, in order, the Service, the HTTPRoute, the Gateway, and
+                    the GatewayClass. Almost always, in this hierarchy, the Gateway will be the most
+                    useful object to place Policy status on, so we recommend that implementations
+                    SHOULD use Gateway as the PolicyAncestorStatus object unless the designers
+                    have a _very_ good reason otherwise.
+
+
+                    In the context of policy attachment, the Ancestor is used to distinguish which
+                    resource results in a distinct application of this policy. For example, if a policy
+                    targets a Service, it may have a distinct result per attached Gateway.
+
+
+                    Policies targeting the same resource may have different effects depending on the
+                    ancestors of those resources. For example, different Gateways targeting the same
+                    Service may have different capabilities, especially if they have different underlying
+                    implementations.
+
+
+                    For example, in BackendTLSPolicy, the Policy attaches to a Service that is
+                    used as a backend in a HTTPRoute that is itself attached to a Gateway.
+                    In this case, the relevant object for status is the Gateway, and that is the
+                    ancestor object referred to in this status.
+
+
+                    Note that a parent is also an ancestor, so for objects where the parent is the
+                    relevant object for status, this struct SHOULD still be used.
+
+
+                    This struct is intended to be used in a slice that's effectively a map,
+                    with a composite key made up of the AncestorRef and the ControllerName.
+                  properties:
+                    ancestorRef:
+                      description: |-
+                        AncestorRef corresponds with a ParentRef in the spec that this
+                        PolicyAncestorStatus struct describes the status of.
+                      properties:
+                        group:
+                          default: gateway.networking.k8s.io
+                          description: |-
+                            Group is the group of the referent.
+                            When unspecified, "gateway.networking.k8s.io" is inferred.
+                            To set the core API group (such as for a "Service" kind referent),
+                            Group must be explicitly set to "" (empty string).
+
+
+                            Support: Core
+                          maxLength: 253
+                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                        kind:
+                          default: Gateway
+                          description: |-
+                            Kind is kind of the referent.
+
+
+                            There are two kinds of parent resources with "Core" support:
+
+
+                            * Gateway (Gateway conformance profile)
+                            * Service (Mesh conformance profile, ClusterIP Services only)
+
+
+                            Support for other resources is Implementation-Specific.
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                          type: string
+                        name:
+                          description: |-
+                            Name is the name of the referent.
+
+
+                            Support: Core
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: |-
+                            Namespace is the namespace of the referent. When unspecified, this refers
+                            to the local namespace of the Route.
+
+
+                            Note that there are specific rules for ParentRefs which cross namespace
+                            boundaries. Cross-namespace references are only valid if they are explicitly
+                            allowed by something in the namespace they are referring to. For example:
+                            Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                            generic way to enable any other kind of cross-namespace reference.
+
+
+
+                            ParentRefs from a Route to a Service in the same namespace are "producer"
+                            routes, which apply default routing rules to inbound connections from
+                            any namespace to the Service.
+
+
+                            ParentRefs from a Route to a Service in a different namespace are
+                            "consumer" routes, and these routing rules are only applied to outbound
+                            connections originating from the same namespace as the Route, for which
+                            the intended destination of the connections are a Service targeted as a
+                            ParentRef of the Route.
+
+
+
+                            Support: Core
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                          type: string
+                        port:
+                          description: |-
+                            Port is the network port this Route targets. It can be interpreted
+                            differently based on the type of parent resource.
+
+
+                            When the parent resource is a Gateway, this targets all listeners
+                            listening on the specified port that also support this kind of Route(and
+                            select this Route). It's not recommended to set `Port` unless the
+                            networking behaviors specified in a Route must apply to a specific port
+                            as opposed to a listener(s) whose port(s) may be changed. When both Port
+                            and SectionName are specified, the name and port of the selected listener
+                            must match both specified values.
+
+
+
+                            When the parent resource is a Service, this targets a specific port in the
+                            Service spec. When both Port (experimental) and SectionName are specified,
+                            the name and port of the selected port must match both specified values.
+
+
+
+                            Implementations MAY choose to support other parent resources.
+                            Implementations supporting other types of parent resources MUST clearly
+                            document how/if Port is interpreted.
+
+
+                            For the purpose of status, an attachment is considered successful as
+                            long as the parent resource accepts it partially. For example, Gateway
+                            listeners can restrict which Routes can attach to them by Route kind,
+                            namespace, or hostname. If 1 of 2 Gateway listeners accept attachment
+                            from the referencing Route, the Route MUST be considered successfully
+                            attached. If no Gateway listeners accept attachment from this Route,
+                            the Route MUST be considered detached from the Gateway.
+
+
+                            Support: Extended
+                          format: int32
+                          maximum: 65535
+                          minimum: 1
+                          type: integer
+                        sectionName:
+                          description: |-
+                            SectionName is the name of a section within the target resource. In the
+                            following resources, SectionName is interpreted as the following:
+
+
+                            * Gateway: Listener name. When both Port (experimental) and SectionName
+                            are specified, the name and port of the selected listener must match
+                            both specified values.
+                            * Service: Port name. When both Port (experimental) and SectionName
+                            are specified, the name and port of the selected listener must match
+                            both specified values.
+
+
+                            Implementations MAY choose to support attaching Routes to other resources.
+                            If that is the case, they MUST clearly document how SectionName is
+                            interpreted.
+
+
+                            When unspecified (empty string), this will reference the entire resource.
+                            For the purpose of status, an attachment is considered successful if at
+                            least one section in the parent resource accepts it. For example, Gateway
+                            listeners can restrict which Routes can attach to them by Route kind,
+                            namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from
+                            the referencing Route, the Route MUST be considered successfully
+                            attached. If no Gateway listeners accept attachment from this Route, the
+                            Route MUST be considered detached from the Gateway.
+
+
+                            Support: Core
+                          maxLength: 253
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    conditions:
+                      description: Conditions describes the status of the Policy with
+                        respect to the given Ancestor.
+                      items:
+                        description: "Condition contains details for one aspect of
+                          the current state of this API Resource.\n---\nThis struct
+                          is intended for direct use as an array at the field path
+                          .status.conditions.  For example,\n\n\n\ttype FooStatus
+                          struct{\n\t    // Represents the observations of a foo's
+                          current state.\n\t    // Known .status.conditions.type are:
+                          \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                          +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    //
+                          +listType=map\n\t    // +listMapKey=type\n\t    Conditions
+                          []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\"
+                          patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                          \   // other fields\n\t}"
+                        properties:
+                          lastTransitionTime:
+                            description: |-
+                              lastTransitionTime is the last time the condition transitioned from one status to another.
+                              This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                            format: date-time
+                            type: string
+                          message:
+                            description: |-
+                              message is a human readable message indicating details about the transition.
+                              This may be an empty string.
+                            maxLength: 32768
+                            type: string
+                          observedGeneration:
+                            description: |-
+                              observedGeneration represents the .metadata.generation that the condition was set based upon.
+                              For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                              with respect to the current state of the instance.
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          reason:
+                            description: |-
+                              reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected values and meanings for this field,
+                              and whether the values are considered a guaranteed API.
+                              The value should be a CamelCase string.
+                              This field may not be empty.
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                            - "True"
+                            - "False"
+                            - Unknown
+                            type: string
+                          type:
+                            description: |-
+                              type of condition in CamelCase or in foo.example.com/CamelCase.
+                              ---
+                              Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                              useful (see .node.status.conditions), the ability to deconflict is important.
+                              The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                        - lastTransitionTime
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      maxItems: 8
+                      minItems: 1
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - type
+                      x-kubernetes-list-type: map
+                    controllerName:
+                      description: |-
+                        ControllerName is a domain/path string that indicates the name of the
+                        controller that wrote this status. This corresponds with the
+                        controllerName field on GatewayClass.
+
+
+                        Example: "example.net/gateway-controller".
+
+
+                        The format of this field is DOMAIN "/" PATH, where DOMAIN and PATH are
+                        valid Kubernetes names
+                        (https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names).
+
+
+                        Controllers MUST populate this field when writing status. Controllers should ensure that
+                        entries to status populated with their ControllerName are cleaned up when they are no
+                        longer necessary.
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
+                      type: string
+                  required:
+                  - ancestorRef
+                  - controllerName
+                  type: object
+                maxItems: 16
+                type: array
+            required:
+            - ancestors
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/platform/gateway-api/chart/templates/gatewayclasses.yaml
+++ b/platform/gateway-api/chart/templates/gatewayclasses.yaml
@@ -1,6 +1,6 @@
 {{/*
   Vendored from kubernetes-sigs/gateway-api {{ index .Chart.Annotations "catalyst.openova.io/upstream-gateway-api-version" }}
-  standard-install.yaml. Do NOT hand-edit annotations / spec — re-vendor
+  experimental-install.yaml. Do NOT hand-edit annotations / spec — re-vendor
   via the script in tests/regenerate.sh when bumping the upstream version
   (also bump catalyst.openova.io/upstream-gateway-api-version in Chart.yaml).
 
@@ -9,17 +9,18 @@
   cluster-scoped infrastructure; deleting them on uninstall would break
   every HTTPRoute on the cluster simultaneously.
 */}}
+
 #
-# config/crd/standard/gateway.networking.k8s.io_gatewayclasses.yaml
+# config/crd/experimental/gateway.networking.k8s.io_gatewayclasses.yaml
 #
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/3328
-    gateway.networking.k8s.io/bundle-version: v1.2.0
-    gateway.networking.k8s.io/channel: standard
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/2997
+    gateway.networking.k8s.io/bundle-version: v1.1.0
+    gateway.networking.k8s.io/channel: experimental
   creationTimestamp: null
   name: gatewayclasses.gateway.networking.k8s.io
 spec:
@@ -56,6 +57,7 @@ spec:
           GatewayClass describes a class of Gateways available to the user for creating
           Gateway resources.
 
+
           It is recommended that this resource be used as a template for Gateways. This
           means that a Gateway is based on the state of the GatewayClass at the time it
           was created and changes to the GatewayClass or associated parameters are not
@@ -64,10 +66,12 @@ spec:
           If implementations choose to propagate GatewayClass changes to existing
           Gateways, that MUST be clearly documented by the implementation.
 
+
           Whenever one or more Gateways are using a GatewayClass, implementations SHOULD
           add the `gateway-exists-finalizer.gateway.networking.k8s.io` finalizer on the
           associated GatewayClass. This ensures that a GatewayClass associated with a
           Gateway is not deleted while in use.
+
 
           GatewayClass is a Cluster level resource.
         properties:
@@ -96,9 +100,12 @@ spec:
                   ControllerName is the name of the controller that is managing Gateways of
                   this class. The value of this field MUST be a domain prefixed path.
 
+
                   Example: "example.net/gateway-controller".
 
+
                   This field is not mutable and cannot be empty.
+
 
                   Support: Core
                 maxLength: 253
@@ -118,18 +125,20 @@ spec:
                   parameters corresponding to the GatewayClass. This is optional if the
                   controller does not require any additional configuration.
 
+
                   ParametersRef can reference a standard Kubernetes resource, i.e. ConfigMap,
                   or an implementation-specific custom resource. The resource can be
                   cluster-scoped or namespace-scoped.
 
-                  If the referent cannot be found, refers to an unsupported kind, or when
-                  the data within that resource is malformed, the GatewayClass SHOULD be
-                  rejected with the "Accepted" status condition set to "False" and an
-                  "InvalidParameters" reason.
+
+                  If the referent cannot be found, the GatewayClass's "InvalidParameters"
+                  status condition will be true.
+
 
                   A Gateway for this GatewayClass may provide its own `parametersRef`. When both are specified,
                   the merging behavior is implementation specific.
                   It is generally recommended that GatewayClass provides defaults that can be overridden by a Gateway.
+
 
                   Support: Implementation-specific
                 properties:
@@ -171,11 +180,12 @@ spec:
               conditions:
               - lastTransitionTime: "1970-01-01T00:00:00Z"
                 message: Waiting for controller
-                reason: Pending
+                reason: Waiting
                 status: Unknown
                 type: Accepted
             description: |-
               Status defines the current state of GatewayClass.
+
 
               Implementations MUST populate status on all GatewayClass resources which
               specify their controller name.
@@ -191,11 +201,20 @@ spec:
                   Conditions is the current status from the controller for
                   this GatewayClass.
 
+
                   Controllers should prefer to publish conditions using values
                   of GatewayClassConditionType for the type of each Condition.
                 items:
-                  description: Condition contains details for one aspect of the current
-                    state of this API Resource.
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
                   properties:
                     lastTransitionTime:
                       description: |-
@@ -236,7 +255,12 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
@@ -252,6 +276,18 @@ spec:
                 x-kubernetes-list-map-keys:
                 - type
                 x-kubernetes-list-type: map
+              supportedFeatures:
+                description: |
+                  SupportedFeatures is the set of features the GatewayClass support.
+                  It MUST be sorted in ascending alphabetical order.
+                items:
+                  description: |-
+                    SupportedFeature is used to describe distinct features that are covered by
+                    conformance tests.
+                  type: string
+                maxItems: 64
+                type: array
+                x-kubernetes-list-type: set
             type: object
         required:
         - spec
@@ -281,6 +317,7 @@ spec:
           GatewayClass describes a class of Gateways available to the user for creating
           Gateway resources.
 
+
           It is recommended that this resource be used as a template for Gateways. This
           means that a Gateway is based on the state of the GatewayClass at the time it
           was created and changes to the GatewayClass or associated parameters are not
@@ -289,10 +326,12 @@ spec:
           If implementations choose to propagate GatewayClass changes to existing
           Gateways, that MUST be clearly documented by the implementation.
 
+
           Whenever one or more Gateways are using a GatewayClass, implementations SHOULD
           add the `gateway-exists-finalizer.gateway.networking.k8s.io` finalizer on the
           associated GatewayClass. This ensures that a GatewayClass associated with a
           Gateway is not deleted while in use.
+
 
           GatewayClass is a Cluster level resource.
         properties:
@@ -321,9 +360,12 @@ spec:
                   ControllerName is the name of the controller that is managing Gateways of
                   this class. The value of this field MUST be a domain prefixed path.
 
+
                   Example: "example.net/gateway-controller".
 
+
                   This field is not mutable and cannot be empty.
+
 
                   Support: Core
                 maxLength: 253
@@ -343,18 +385,20 @@ spec:
                   parameters corresponding to the GatewayClass. This is optional if the
                   controller does not require any additional configuration.
 
+
                   ParametersRef can reference a standard Kubernetes resource, i.e. ConfigMap,
                   or an implementation-specific custom resource. The resource can be
                   cluster-scoped or namespace-scoped.
 
-                  If the referent cannot be found, refers to an unsupported kind, or when
-                  the data within that resource is malformed, the GatewayClass SHOULD be
-                  rejected with the "Accepted" status condition set to "False" and an
-                  "InvalidParameters" reason.
+
+                  If the referent cannot be found, the GatewayClass's "InvalidParameters"
+                  status condition will be true.
+
 
                   A Gateway for this GatewayClass may provide its own `parametersRef`. When both are specified,
                   the merging behavior is implementation specific.
                   It is generally recommended that GatewayClass provides defaults that can be overridden by a Gateway.
+
 
                   Support: Implementation-specific
                 properties:
@@ -396,11 +440,12 @@ spec:
               conditions:
               - lastTransitionTime: "1970-01-01T00:00:00Z"
                 message: Waiting for controller
-                reason: Pending
+                reason: Waiting
                 status: Unknown
                 type: Accepted
             description: |-
               Status defines the current state of GatewayClass.
+
 
               Implementations MUST populate status on all GatewayClass resources which
               specify their controller name.
@@ -416,11 +461,20 @@ spec:
                   Conditions is the current status from the controller for
                   this GatewayClass.
 
+
                   Controllers should prefer to publish conditions using values
                   of GatewayClassConditionType for the type of each Condition.
                 items:
-                  description: Condition contains details for one aspect of the current
-                    state of this API Resource.
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
                   properties:
                     lastTransitionTime:
                       description: |-
@@ -461,7 +515,12 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
@@ -477,6 +536,18 @@ spec:
                 x-kubernetes-list-map-keys:
                 - type
                 x-kubernetes-list-type: map
+              supportedFeatures:
+                description: |
+                  SupportedFeatures is the set of features the GatewayClass support.
+                  It MUST be sorted in ascending alphabetical order.
+                items:
+                  description: |-
+                    SupportedFeature is used to describe distinct features that are covered by
+                    conformance tests.
+                  type: string
+                maxItems: 64
+                type: array
+                x-kubernetes-list-type: set
             type: object
         required:
         - spec

--- a/platform/gateway-api/chart/templates/gateways.yaml
+++ b/platform/gateway-api/chart/templates/gateways.yaml
@@ -1,6 +1,6 @@
 {{/*
   Vendored from kubernetes-sigs/gateway-api {{ index .Chart.Annotations "catalyst.openova.io/upstream-gateway-api-version" }}
-  standard-install.yaml. Do NOT hand-edit annotations / spec — re-vendor
+  experimental-install.yaml. Do NOT hand-edit annotations / spec — re-vendor
   via the script in tests/regenerate.sh when bumping the upstream version
   (also bump catalyst.openova.io/upstream-gateway-api-version in Chart.yaml).
 
@@ -9,17 +9,18 @@
   cluster-scoped infrastructure; deleting them on uninstall would break
   every HTTPRoute on the cluster simultaneously.
 */}}
+
 #
-# config/crd/standard/gateway.networking.k8s.io_gateways.yaml
+# config/crd/experimental/gateway.networking.k8s.io_gateways.yaml
 #
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/3328
-    gateway.networking.k8s.io/bundle-version: v1.2.0
-    gateway.networking.k8s.io/channel: standard
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/2997
+    gateway.networking.k8s.io/bundle-version: v1.1.0
+    gateway.networking.k8s.io/channel: experimental
   creationTimestamp: null
   name: gateways.gateway.networking.k8s.io
 spec:
@@ -82,21 +83,26 @@ spec:
                   requested address is invalid or unavailable, the implementation MUST
                   indicate this in the associated entry in GatewayStatus.Addresses.
 
+
                   The Addresses field represents a request for the address(es) on the
                   "outside of the Gateway", that traffic bound for this Gateway will use.
                   This could be the IP address or hostname of an external load balancer or
                   other networking infrastructure, or some other address that traffic will
                   be sent to.
 
+
                   If no Addresses are specified, the implementation MAY schedule the
                   Gateway in an implementation-specific manner, assigning an appropriate
                   set of Addresses.
+
 
                   The implementation MUST bind all Listeners to every GatewayAddress that
                   it assigns to the Gateway and add a corresponding entry in
                   GatewayStatus.Addresses.
 
+
                   Support: Extended
+
 
                 items:
                   description: GatewayAddress describes an address that can be bound
@@ -128,6 +134,7 @@ spec:
                         Value of the address. The validity of the values will depend
                         on the type and support by the controller.
 
+
                         Examples: `1.2.3.4`, `128::1`, `my-ip-address`.
                       maxLength: 253
                       minLength: 1
@@ -157,10 +164,13 @@ spec:
                 minLength: 1
                 type: string
               infrastructure:
-                description: |-
+                description: |+
                   Infrastructure defines infrastructure level attributes about this Gateway instance.
 
-                  Support: Extended
+
+                  Support: Core
+
+
                 properties:
                   annotations:
                     additionalProperties:
@@ -175,73 +185,55 @@ spec:
                     description: |-
                       Annotations that SHOULD be applied to any resources created in response to this Gateway.
 
+
                       For implementations creating other Kubernetes objects, this should be the `metadata.annotations` field on resources.
                       For other implementations, this refers to any relevant (implementation specific) "annotations" concepts.
 
+
                       An implementation may chose to add additional implementation-specific annotations as they see fit.
+
 
                       Support: Extended
                     maxProperties: 8
                     type: object
-                    x-kubernetes-validations:
-                    - message: Annotation keys must be in the form of an optional
-                        DNS subdomain prefix followed by a required name segment of
-                        up to 63 characters.
-                      rule: self.all(key, key.matches(r"""^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?([A-Za-z0-9][-A-Za-z0-9_.]{0,61})?[A-Za-z0-9]$"""))
-                    - message: If specified, the annotation key's prefix must be a
-                        DNS subdomain not longer than 253 characters in total.
-                      rule: self.all(key, key.split("/")[0].size() < 253)
                   labels:
                     additionalProperties:
                       description: |-
-                        LabelValue is the value of a label in the Gateway API. This is used for validation
-                        of maps such as Gateway infrastructure labels. This matches the Kubernetes
-                        label validation rules:
-                        * must be 63 characters or less (can be empty),
-                        * unless empty, must begin and end with an alphanumeric character ([a-z0-9A-Z]),
-                        * could contain dashes (-), underscores (_), dots (.), and alphanumerics between.
-
-                        Valid values include:
-
-                        * MyValue
-                        * my.name
-                        * 123-my-value
-                      maxLength: 63
+                        AnnotationValue is the value of an annotation in Gateway API. This is used
+                        for validation of maps such as TLS options. This roughly matches Kubernetes
+                        annotation validation, although the length validation in that case is based
+                        on the entire size of the annotations struct.
+                      maxLength: 4096
                       minLength: 0
-                      pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
                       type: string
                     description: |-
                       Labels that SHOULD be applied to any resources created in response to this Gateway.
 
+
                       For implementations creating other Kubernetes objects, this should be the `metadata.labels` field on resources.
                       For other implementations, this refers to any relevant (implementation specific) "labels" concepts.
 
+
                       An implementation may chose to add additional implementation-specific labels as they see fit.
 
-                      If an implementation maps these labels to Pods, or any other resource that would need to be recreated when labels
-                      change, it SHOULD clearly warn about this behavior in documentation.
 
                       Support: Extended
                     maxProperties: 8
                     type: object
-                    x-kubernetes-validations:
-                    - message: Label keys must be in the form of an optional DNS subdomain
-                        prefix followed by a required name segment of up to 63 characters.
-                      rule: self.all(key, key.matches(r"""^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?([A-Za-z0-9][-A-Za-z0-9_.]{0,61})?[A-Za-z0-9]$"""))
-                    - message: If specified, the label key's prefix must be a DNS
-                        subdomain not longer than 253 characters in total.
-                      rule: self.all(key, key.split("/")[0].size() < 253)
                   parametersRef:
                     description: |-
                       ParametersRef is a reference to a resource that contains the configuration
                       parameters corresponding to the Gateway. This is optional if the
                       controller does not require any additional configuration.
 
+
                       This follows the same semantics as GatewayClass's `parametersRef`, but on a per-Gateway basis
+
 
                       The Gateway's GatewayClass may provide its own `parametersRef`. When both are specified,
                       the merging behavior is implementation specific.
                       It is generally recommended that GatewayClass provides defaults that can be overridden by a Gateway.
+
 
                       Support: Implementation-specific
                     properties:
@@ -273,6 +265,7 @@ spec:
                   logical endpoints that are bound on this Gateway's addresses.
                   At least one Listener MUST be specified.
 
+
                   Each Listener in a set of Listeners (for example, in a single Gateway)
                   MUST be _distinct_, in that a traffic flow MUST be able to be assigned to
                   exactly one listener. (This section uses "set of Listeners" rather than
@@ -280,23 +273,31 @@ spec:
                   from multiple Gateways onto a single data plane, and these rules _also_
                   apply in that case).
 
+
                   Practically, this means that each listener in a set MUST have a unique
                   combination of Port, Protocol, and, if supported by the protocol, Hostname.
+
 
                   Some combinations of port, protocol, and TLS settings are considered
                   Core support and MUST be supported by implementations based on their
                   targeted conformance profile:
 
+
                   HTTP Profile
+
 
                   1. HTTPRoute, Port: 80, Protocol: HTTP
                   2. HTTPRoute, Port: 443, Protocol: HTTPS, TLS Mode: Terminate, TLS keypair provided
 
+
                   TLS Profile
+
 
                   1. TLSRoute, Port: 443, Protocol: TLS, TLS Mode: Passthrough
 
+
                   "Distinct" Listeners have the following property:
+
 
                   The implementation can match inbound requests to a single distinct
                   Listener. When multiple Listeners share values for fields (for
@@ -304,7 +305,9 @@ spec:
                   can match requests to only one of the Listeners using other
                   Listener fields.
 
+
                   For example, the following Listener scenarios are distinct:
+
 
                   1. Multiple Listeners with the same Port that all use the "HTTP"
                      Protocol that all have unique Hostname values.
@@ -313,22 +316,27 @@ spec:
                   3. A mixture of "TCP" and "UDP" Protocol Listeners, where no Listener
                      with the same Protocol has the same Port value.
 
+
                   Some fields in the Listener struct have possible values that affect
                   whether the Listener is distinct. Hostname is particularly relevant
                   for HTTP or HTTPS protocols.
+
 
                   When using the Hostname value to select between same-Port, same-Protocol
                   Listeners, the Hostname value must be different on each Listener for the
                   Listener to be distinct.
 
+
                   When the Listeners are distinct based on Hostname, inbound request
                   hostnames MUST match from the most specific to least specific Hostname
                   values to choose the correct Listener and its associated set of Routes.
+
 
                   Exact matches must be processed before wildcard matches, and wildcard
                   matches must be processed before fallback (empty Hostname value)
                   matches. For example, `"foo.example.com"` takes precedence over
                   `"*.example.com"`, and `"*.example.com"` takes precedence over `""`.
+
 
                   Additionally, if there are multiple wildcard entries, more specific
                   wildcard entries must be processed before less specific wildcard entries.
@@ -336,13 +344,16 @@ spec:
                   The precise definition here is that the higher the number of dots in the
                   hostname to the right of the wildcard character, the higher the precedence.
 
+
                   The wildcard character will match any number of characters _and dots_ to
                   the left, however, so `"*.example.com"` will match both
                   `"foo.bar.example.com"` _and_ `"bar.example.com"`.
 
+
                   If a set of Listeners contains Listeners that are not distinct, then those
                   Listeners are Conflicted, and the implementation MUST set the "Conflicted"
                   condition in the Listener Status to "True".
+
 
                   Implementations MAY choose to accept a Gateway with some Conflicted
                   Listeners only if they only accept the partial Listener set that contains
@@ -353,6 +364,7 @@ spec:
                   Listener in this case, otherwise it violates the requirement that at
                   least one Listener must be present.
 
+
                   The implementation MUST set a "ListenersNotValid" condition on the
                   Gateway Status when the Gateway contains Conflicted Listeners whether or
                   not they accept the Gateway. That Condition SHOULD clearly
@@ -360,20 +372,25 @@ spec:
                   Accepted. Additionally, the Listener status for those listeners SHOULD
                   indicate which Listeners are conflicted and not Accepted.
 
+
                   A Gateway's Listeners are considered "compatible" if:
+
 
                   1. They are distinct.
                   2. The implementation can serve them in compliance with the Addresses
                      requirement that all Listeners are available on all assigned
                      addresses.
 
+
                   Compatible combinations in Extended support are expected to vary across
                   implementations. A combination that is compatible for one implementation
                   may not be compatible for another.
 
+
                   For example, an implementation that cannot serve both TCP and UDP listeners
                   on the same address, or cannot mix HTTPS and generic TLS listens on the same port
                   would not consider those cases compatible, even though they are distinct.
+
 
                   Note that requests SHOULD match at most one Listener. For example, if
                   Listeners are defined for "foo.example.com" and "*.example.com", a
@@ -382,8 +399,10 @@ spec:
                   This concept is known as "Listener Isolation". Implementations that do
                   not support Listener Isolation MUST clearly document this.
 
+
                   Implementations MAY merge separate Gateways onto a single set of
                   Addresses if all Listeners across all Gateways are compatible.
+
 
                   Support: Core
                 items:
@@ -400,9 +419,11 @@ spec:
                         Listener and the trusted namespaces where those Route resources MAY be
                         present.
 
+
                         Although a client request may match multiple route rules, only one rule
                         may ultimately receive the request. Matching precedence MUST be
                         determined in order of the following criteria:
+
 
                         * The most specific match as defined by the Route type.
                         * The oldest Route based on creation timestamp. For example, a Route with
@@ -412,12 +433,14 @@ spec:
                           alphabetical order (namespace/name) should be given precedence. For
                           example, foo/bar is given precedence over foo/baz.
 
+
                         All valid rules within a Route attached to this Listener should be
                         implemented. Invalid Route rules can be ignored (sometimes that will mean
                         the full Route). If a Route rule transitions from valid to invalid,
                         support for that Route rule should be dropped to ensure consistency. For
                         example, even if a filter specified by a Route rule is invalid, the rest
                         of the rules within that Route should still be supported.
+
 
                         Support: Core
                       properties:
@@ -427,11 +450,13 @@ spec:
                             to this Gateway Listener. When unspecified or empty, the kinds of Routes
                             selected are determined using the Listener protocol.
 
+
                             A RouteGroupKind MUST correspond to kinds of Routes that are compatible
                             with the application protocol specified in the Listener's Protocol field.
                             If an implementation does not support or recognize this resource type, it
                             MUST set the "ResolvedRefs" condition to False for this Listener with the
                             "InvalidRouteKinds" reason.
+
 
                             Support: Core
                           items:
@@ -462,6 +487,7 @@ spec:
                             Namespaces indicates namespaces from which Routes may be attached to this
                             Listener. This is restricted to the namespace of this Gateway by default.
 
+
                             Support: Core
                           properties:
                             from:
@@ -470,10 +496,12 @@ spec:
                                 From indicates where Routes will be selected for this Gateway. Possible
                                 values are:
 
+
                                 * All: Routes in all namespaces may be used by this Gateway.
                                 * Selector: Routes in namespaces selected by the selector may be used by
                                   this Gateway.
                                 * Same: Only Routes in the same namespace may be used by this Gateway.
+
 
                                 Support: Core
                               enum:
@@ -486,6 +514,7 @@ spec:
                                 Selector must be specified when From is set to "Selector". In that case,
                                 only Routes in Namespaces matching this Selector will be selected by this
                                 Gateway. This field is ignored for other values of "From".
+
 
                                 Support: Core
                               properties:
@@ -541,8 +570,10 @@ spec:
                         field is ignored for protocols that don't require hostname based
                         matching.
 
+
                         Implementations MUST apply Hostname matching appropriately for each of
                         the following protocols:
+
 
                         * TLS: The Listener Hostname MUST match the SNI.
                         * HTTP: The Listener Hostname MUST match the Host header of the request.
@@ -551,15 +582,18 @@ spec:
                           ensure that both the SNI and Host header match the Listener hostname,
                           it MUST clearly document that.
 
+
                         For HTTPRoute and TLSRoute resources, there is an interaction with the
                         `spec.hostnames` array. When both listener and route specify hostnames,
                         there MUST be an intersection between the values for a Route to be
                         accepted. For more information, refer to the Route specific Hostnames
                         documentation.
 
+
                         Hostnames that are prefixed with a wildcard label (`*.`) are interpreted
                         as a suffix match. That means that a match for `*.example.com` would match
                         both `test.example.com`, and `foo.test.example.com`, but not `example.com`.
+
 
                         Support: Core
                       maxLength: 253
@@ -571,6 +605,7 @@ spec:
                         Name is the name of the Listener. This name MUST be unique within a
                         Gateway.
 
+
                         Support: Core
                       maxLength: 253
                       minLength: 1
@@ -581,6 +616,7 @@ spec:
                         Port is the network port. Multiple listeners may use the
                         same port, subject to the Listener compatibility rules.
 
+
                         Support: Core
                       format: int32
                       maximum: 65535
@@ -590,10 +626,11 @@ spec:
                       description: |-
                         Protocol specifies the network protocol this listener expects to receive.
 
+
                         Support: Core
                       maxLength: 255
                       minLength: 1
-                      pattern: ^[a-zA-Z0-9]([-a-zA-Z0-9]*[a-zA-Z0-9])?$|[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9]+$
+                      pattern: ^[a-zA-Z0-9]([-a-zSA-Z0-9]*[a-zA-Z0-9])?$|[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9]+$
                       type: string
                     tls:
                       description: |-
@@ -601,11 +638,14 @@ spec:
                         the Protocol field is "HTTPS" or "TLS". It is invalid to set this field
                         if the Protocol field is "HTTP", "TCP", or "UDP".
 
+
                         The association of SNIs to Certificate defined in GatewayTLSConfig is
                         defined based on the Hostname field for this listener.
 
+
                         The GatewayClass MUST use the longest matching SNI out of all
                         available certificates for any TLS handshake.
+
 
                         Support: Core
                       properties:
@@ -616,9 +656,11 @@ spec:
                             establish a TLS handshake for requests that match the hostname of the
                             associated listener.
 
+
                             A single CertificateRef to a Kubernetes Secret has "Core" support.
                             Implementations MAY choose to support attaching multiple certificates to
                             a Listener, but this behavior is implementation-specific.
+
 
                             References to a resource in different namespace are invalid UNLESS there
                             is a ReferenceGrant in the target namespace that allows the certificate
@@ -626,13 +668,17 @@ spec:
                             "ResolvedRefs" condition MUST be set to False for this listener with the
                             "RefNotPermitted" reason.
 
+
                             This field is required to have at least one element when the mode is set
                             to "Terminate" (default) and is optional otherwise.
+
 
                             CertificateRefs can reference to standard Kubernetes resources, i.e.
                             Secret, or implementation-specific custom resources.
 
+
                             Support: Core - A single reference to a Kubernetes Secret of type kubernetes.io/tls
+
 
                             Support: Implementation-specific (More than one reference or other resource types)
                           items:
@@ -640,8 +686,10 @@ spec:
                               SecretObjectReference identifies an API object including its namespace,
                               defaulting to Secret.
 
+
                               The API object must be valid in the cluster; the Group and Kind must
                               be registered in the cluster for this reference to be valid.
+
 
                               References to objects with invalid Group and Kind are not valid, and must
                               be rejected by the implementation, with appropriate Conditions set
@@ -673,10 +721,12 @@ spec:
                                   Namespace is the namespace of the referenced object. When unspecified, the local
                                   namespace is inferred.
 
+
                                   Note that when a namespace different than the local namespace is specified,
                                   a ReferenceGrant object is required in the referent namespace to allow that
                                   namespace's owner to accept the reference. See the ReferenceGrant
                                   documentation for details.
+
 
                                   Support: Core
                                 maxLength: 63
@@ -688,11 +738,110 @@ spec:
                             type: object
                           maxItems: 64
                           type: array
+                        frontendValidation:
+                          description: |+
+                            FrontendValidation holds configuration information for validating the frontend (client).
+                            Setting this field will require clients to send a client certificate
+                            required for validation during the TLS handshake. In browsers this may result in a dialog appearing
+                            that requests a user to specify the client certificate.
+                            The maximum depth of a certificate chain accepted in verification is Implementation specific.
+
+
+                            Support: Extended
+
+
+                          properties:
+                            caCertificateRefs:
+                              description: |-
+                                CACertificateRefs contains one or more references to
+                                Kubernetes objects that contain TLS certificates of
+                                the Certificate Authorities that can be used
+                                as a trust anchor to validate the certificates presented by the client.
+
+
+                                A single CA certificate reference to a Kubernetes ConfigMap
+                                has "Core" support.
+                                Implementations MAY choose to support attaching multiple CA certificates to
+                                a Listener, but this behavior is implementation-specific.
+
+
+                                Support: Core - A single reference to a Kubernetes ConfigMap
+                                with the CA certificate in a key named `ca.crt`.
+
+
+                                Support: Implementation-specific (More than one reference, or other kinds
+                                of resources).
+
+
+                                References to a resource in a different namespace are invalid UNLESS there
+                                is a ReferenceGrant in the target namespace that allows the certificate
+                                to be attached. If a ReferenceGrant does not allow this reference, the
+                                "ResolvedRefs" condition MUST be set to False for this listener with the
+                                "RefNotPermitted" reason.
+                              items:
+                                description: |-
+                                  ObjectReference identifies an API object including its namespace.
+
+
+                                  The API object must be valid in the cluster; the Group and Kind must
+                                  be registered in the cluster for this reference to be valid.
+
+
+                                  References to objects with invalid Group and Kind are not valid, and must
+                                  be rejected by the implementation, with appropriate Conditions set
+                                  on the containing object.
+                                properties:
+                                  group:
+                                    description: |-
+                                      Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                                      When unspecified or empty string, core API group is inferred.
+                                    maxLength: 253
+                                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                    type: string
+                                  kind:
+                                    description: Kind is kind of the referent. For
+                                      example "ConfigMap" or "Service".
+                                    maxLength: 63
+                                    minLength: 1
+                                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                    type: string
+                                  name:
+                                    description: Name is the name of the referent.
+                                    maxLength: 253
+                                    minLength: 1
+                                    type: string
+                                  namespace:
+                                    description: |-
+                                      Namespace is the namespace of the referenced object. When unspecified, the local
+                                      namespace is inferred.
+
+
+                                      Note that when a namespace different than the local namespace is specified,
+                                      a ReferenceGrant object is required in the referent namespace to allow that
+                                      namespace's owner to accept the reference. See the ReferenceGrant
+                                      documentation for details.
+
+
+                                      Support: Core
+                                    maxLength: 63
+                                    minLength: 1
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                    type: string
+                                required:
+                                - group
+                                - kind
+                                - name
+                                type: object
+                              maxItems: 8
+                              minItems: 1
+                              type: array
+                          type: object
                         mode:
                           default: Terminate
                           description: |-
                             Mode defines the TLS behavior for the TLS session initiated by the client.
                             There are two possible modes:
+
 
                             - Terminate: The TLS session between the downstream client and the
                               Gateway is terminated at the Gateway. This mode requires certificates
@@ -702,6 +851,7 @@ spec:
                               implies that the Gateway can't decipher the TLS stream except for
                               the ClientHello message of the TLS protocol. The certificateRefs field
                               is ignored in this mode.
+
 
                             Support: Core
                           enum:
@@ -723,10 +873,12 @@ spec:
                             configuration for each implementation. For example, configuring the
                             minimum TLS version or supported cipher suites.
 
+
                             A set of common keys MAY be defined by the API in the future. To avoid
                             any ambiguity, implementation-specific definitions MUST use
                             domain-prefixed names, such as `example.com/my-custom-option`.
                             Un-prefixed names are reserved for key names defined by Gateway API.
+
 
                             Support: Implementation-specific
                           maxProperties: 16
@@ -790,12 +942,15 @@ spec:
                   Addresses lists the network addresses that have been bound to the
                   Gateway.
 
+
                   This list may differ from the addresses provided in the spec under some
                   conditions:
+
 
                     * no addresses are specified, all addresses are dynamically assigned
                     * a combination of specified and dynamic addresses are assigned
                     * a specified address was unusable (e.g. already in use)
+
 
                 items:
                   description: GatewayStatusAddress describes a network address that
@@ -827,6 +982,7 @@ spec:
                         Value of the address. The validity of the values will depend
                         on the type and support by the controller.
 
+
                         Examples: `1.2.3.4`, `128::1`, `my-ip-address`.
                       maxLength: 253
                       minLength: 1
@@ -856,19 +1012,30 @@ spec:
                 description: |-
                   Conditions describe the current conditions of the Gateway.
 
+
                   Implementations should prefer to express Gateway conditions
                   using the `GatewayConditionType` and `GatewayConditionReason`
                   constants so that operators and tools can converge on a common
                   vocabulary to describe Gateway state.
 
+
                   Known condition types are:
+
 
                   * "Accepted"
                   * "Programmed"
                   * "Ready"
                 items:
-                  description: Condition contains details for one aspect of the current
-                    state of this API Resource.
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
                   properties:
                     lastTransitionTime:
                       description: |-
@@ -909,7 +1076,12 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
@@ -936,6 +1108,7 @@ spec:
                         AttachedRoutes represents the total number of Routes that have been
                         successfully attached to this Listener.
 
+
                         Successful attachment of a Route to a Listener is based solely on the
                         combination of the AllowedRoutes field on the corresponding Listener
                         and the Route's ParentRefs field. A Route is successfully attached to
@@ -948,6 +1121,7 @@ spec:
                         for Listeners with condition Accepted: false and MUST count successfully
                         attached Routes that may themselves have Accepted: false conditions.
 
+
                         Uses for this field include troubleshooting Route attachment and
                         measuring blast radius/impact of changes to a Listener.
                       format: int32
@@ -956,8 +1130,18 @@ spec:
                       description: Conditions describe the current condition of this
                         listener.
                       items:
-                        description: Condition contains details for one aspect of
-                          the current state of this API Resource.
+                        description: "Condition contains details for one aspect of
+                          the current state of this API Resource.\n---\nThis struct
+                          is intended for direct use as an array at the field path
+                          .status.conditions.  For example,\n\n\n\ttype FooStatus
+                          struct{\n\t    // Represents the observations of a foo's
+                          current state.\n\t    // Known .status.conditions.type are:
+                          \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                          +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    //
+                          +listType=map\n\t    // +listMapKey=type\n\t    Conditions
+                          []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\"
+                          patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                          \   // other fields\n\t}"
                         properties:
                           lastTransitionTime:
                             description: |-
@@ -999,7 +1183,12 @@ spec:
                             - Unknown
                             type: string
                           type:
-                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                            description: |-
+                              type of condition in CamelCase or in foo.example.com/CamelCase.
+                              ---
+                              Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                              useful (see .node.status.conditions), the ability to deconflict is important.
+                              The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
                             maxLength: 316
                             pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                             type: string
@@ -1027,6 +1216,7 @@ spec:
                         SupportedKinds is the list indicating the Kinds supported by this
                         listener. This MUST represent the kinds an implementation supports for
                         that Listener configuration.
+
 
                         If kinds are specified in Spec that are not supported, they MUST NOT
                         appear in this list and an implementation MUST set the "ResolvedRefs"
@@ -1120,21 +1310,26 @@ spec:
                   requested address is invalid or unavailable, the implementation MUST
                   indicate this in the associated entry in GatewayStatus.Addresses.
 
+
                   The Addresses field represents a request for the address(es) on the
                   "outside of the Gateway", that traffic bound for this Gateway will use.
                   This could be the IP address or hostname of an external load balancer or
                   other networking infrastructure, or some other address that traffic will
                   be sent to.
 
+
                   If no Addresses are specified, the implementation MAY schedule the
                   Gateway in an implementation-specific manner, assigning an appropriate
                   set of Addresses.
+
 
                   The implementation MUST bind all Listeners to every GatewayAddress that
                   it assigns to the Gateway and add a corresponding entry in
                   GatewayStatus.Addresses.
 
+
                   Support: Extended
+
 
                 items:
                   description: GatewayAddress describes an address that can be bound
@@ -1166,6 +1361,7 @@ spec:
                         Value of the address. The validity of the values will depend
                         on the type and support by the controller.
 
+
                         Examples: `1.2.3.4`, `128::1`, `my-ip-address`.
                       maxLength: 253
                       minLength: 1
@@ -1195,10 +1391,13 @@ spec:
                 minLength: 1
                 type: string
               infrastructure:
-                description: |-
+                description: |+
                   Infrastructure defines infrastructure level attributes about this Gateway instance.
 
-                  Support: Extended
+
+                  Support: Core
+
+
                 properties:
                   annotations:
                     additionalProperties:
@@ -1213,73 +1412,55 @@ spec:
                     description: |-
                       Annotations that SHOULD be applied to any resources created in response to this Gateway.
 
+
                       For implementations creating other Kubernetes objects, this should be the `metadata.annotations` field on resources.
                       For other implementations, this refers to any relevant (implementation specific) "annotations" concepts.
 
+
                       An implementation may chose to add additional implementation-specific annotations as they see fit.
+
 
                       Support: Extended
                     maxProperties: 8
                     type: object
-                    x-kubernetes-validations:
-                    - message: Annotation keys must be in the form of an optional
-                        DNS subdomain prefix followed by a required name segment of
-                        up to 63 characters.
-                      rule: self.all(key, key.matches(r"""^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?([A-Za-z0-9][-A-Za-z0-9_.]{0,61})?[A-Za-z0-9]$"""))
-                    - message: If specified, the annotation key's prefix must be a
-                        DNS subdomain not longer than 253 characters in total.
-                      rule: self.all(key, key.split("/")[0].size() < 253)
                   labels:
                     additionalProperties:
                       description: |-
-                        LabelValue is the value of a label in the Gateway API. This is used for validation
-                        of maps such as Gateway infrastructure labels. This matches the Kubernetes
-                        label validation rules:
-                        * must be 63 characters or less (can be empty),
-                        * unless empty, must begin and end with an alphanumeric character ([a-z0-9A-Z]),
-                        * could contain dashes (-), underscores (_), dots (.), and alphanumerics between.
-
-                        Valid values include:
-
-                        * MyValue
-                        * my.name
-                        * 123-my-value
-                      maxLength: 63
+                        AnnotationValue is the value of an annotation in Gateway API. This is used
+                        for validation of maps such as TLS options. This roughly matches Kubernetes
+                        annotation validation, although the length validation in that case is based
+                        on the entire size of the annotations struct.
+                      maxLength: 4096
                       minLength: 0
-                      pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
                       type: string
                     description: |-
                       Labels that SHOULD be applied to any resources created in response to this Gateway.
 
+
                       For implementations creating other Kubernetes objects, this should be the `metadata.labels` field on resources.
                       For other implementations, this refers to any relevant (implementation specific) "labels" concepts.
 
+
                       An implementation may chose to add additional implementation-specific labels as they see fit.
 
-                      If an implementation maps these labels to Pods, or any other resource that would need to be recreated when labels
-                      change, it SHOULD clearly warn about this behavior in documentation.
 
                       Support: Extended
                     maxProperties: 8
                     type: object
-                    x-kubernetes-validations:
-                    - message: Label keys must be in the form of an optional DNS subdomain
-                        prefix followed by a required name segment of up to 63 characters.
-                      rule: self.all(key, key.matches(r"""^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?([A-Za-z0-9][-A-Za-z0-9_.]{0,61})?[A-Za-z0-9]$"""))
-                    - message: If specified, the label key's prefix must be a DNS
-                        subdomain not longer than 253 characters in total.
-                      rule: self.all(key, key.split("/")[0].size() < 253)
                   parametersRef:
                     description: |-
                       ParametersRef is a reference to a resource that contains the configuration
                       parameters corresponding to the Gateway. This is optional if the
                       controller does not require any additional configuration.
 
+
                       This follows the same semantics as GatewayClass's `parametersRef`, but on a per-Gateway basis
+
 
                       The Gateway's GatewayClass may provide its own `parametersRef`. When both are specified,
                       the merging behavior is implementation specific.
                       It is generally recommended that GatewayClass provides defaults that can be overridden by a Gateway.
+
 
                       Support: Implementation-specific
                     properties:
@@ -1311,6 +1492,7 @@ spec:
                   logical endpoints that are bound on this Gateway's addresses.
                   At least one Listener MUST be specified.
 
+
                   Each Listener in a set of Listeners (for example, in a single Gateway)
                   MUST be _distinct_, in that a traffic flow MUST be able to be assigned to
                   exactly one listener. (This section uses "set of Listeners" rather than
@@ -1318,23 +1500,31 @@ spec:
                   from multiple Gateways onto a single data plane, and these rules _also_
                   apply in that case).
 
+
                   Practically, this means that each listener in a set MUST have a unique
                   combination of Port, Protocol, and, if supported by the protocol, Hostname.
+
 
                   Some combinations of port, protocol, and TLS settings are considered
                   Core support and MUST be supported by implementations based on their
                   targeted conformance profile:
 
+
                   HTTP Profile
+
 
                   1. HTTPRoute, Port: 80, Protocol: HTTP
                   2. HTTPRoute, Port: 443, Protocol: HTTPS, TLS Mode: Terminate, TLS keypair provided
 
+
                   TLS Profile
+
 
                   1. TLSRoute, Port: 443, Protocol: TLS, TLS Mode: Passthrough
 
+
                   "Distinct" Listeners have the following property:
+
 
                   The implementation can match inbound requests to a single distinct
                   Listener. When multiple Listeners share values for fields (for
@@ -1342,7 +1532,9 @@ spec:
                   can match requests to only one of the Listeners using other
                   Listener fields.
 
+
                   For example, the following Listener scenarios are distinct:
+
 
                   1. Multiple Listeners with the same Port that all use the "HTTP"
                      Protocol that all have unique Hostname values.
@@ -1351,22 +1543,27 @@ spec:
                   3. A mixture of "TCP" and "UDP" Protocol Listeners, where no Listener
                      with the same Protocol has the same Port value.
 
+
                   Some fields in the Listener struct have possible values that affect
                   whether the Listener is distinct. Hostname is particularly relevant
                   for HTTP or HTTPS protocols.
+
 
                   When using the Hostname value to select between same-Port, same-Protocol
                   Listeners, the Hostname value must be different on each Listener for the
                   Listener to be distinct.
 
+
                   When the Listeners are distinct based on Hostname, inbound request
                   hostnames MUST match from the most specific to least specific Hostname
                   values to choose the correct Listener and its associated set of Routes.
+
 
                   Exact matches must be processed before wildcard matches, and wildcard
                   matches must be processed before fallback (empty Hostname value)
                   matches. For example, `"foo.example.com"` takes precedence over
                   `"*.example.com"`, and `"*.example.com"` takes precedence over `""`.
+
 
                   Additionally, if there are multiple wildcard entries, more specific
                   wildcard entries must be processed before less specific wildcard entries.
@@ -1374,13 +1571,16 @@ spec:
                   The precise definition here is that the higher the number of dots in the
                   hostname to the right of the wildcard character, the higher the precedence.
 
+
                   The wildcard character will match any number of characters _and dots_ to
                   the left, however, so `"*.example.com"` will match both
                   `"foo.bar.example.com"` _and_ `"bar.example.com"`.
 
+
                   If a set of Listeners contains Listeners that are not distinct, then those
                   Listeners are Conflicted, and the implementation MUST set the "Conflicted"
                   condition in the Listener Status to "True".
+
 
                   Implementations MAY choose to accept a Gateway with some Conflicted
                   Listeners only if they only accept the partial Listener set that contains
@@ -1391,6 +1591,7 @@ spec:
                   Listener in this case, otherwise it violates the requirement that at
                   least one Listener must be present.
 
+
                   The implementation MUST set a "ListenersNotValid" condition on the
                   Gateway Status when the Gateway contains Conflicted Listeners whether or
                   not they accept the Gateway. That Condition SHOULD clearly
@@ -1398,20 +1599,25 @@ spec:
                   Accepted. Additionally, the Listener status for those listeners SHOULD
                   indicate which Listeners are conflicted and not Accepted.
 
+
                   A Gateway's Listeners are considered "compatible" if:
+
 
                   1. They are distinct.
                   2. The implementation can serve them in compliance with the Addresses
                      requirement that all Listeners are available on all assigned
                      addresses.
 
+
                   Compatible combinations in Extended support are expected to vary across
                   implementations. A combination that is compatible for one implementation
                   may not be compatible for another.
 
+
                   For example, an implementation that cannot serve both TCP and UDP listeners
                   on the same address, or cannot mix HTTPS and generic TLS listens on the same port
                   would not consider those cases compatible, even though they are distinct.
+
 
                   Note that requests SHOULD match at most one Listener. For example, if
                   Listeners are defined for "foo.example.com" and "*.example.com", a
@@ -1420,8 +1626,10 @@ spec:
                   This concept is known as "Listener Isolation". Implementations that do
                   not support Listener Isolation MUST clearly document this.
 
+
                   Implementations MAY merge separate Gateways onto a single set of
                   Addresses if all Listeners across all Gateways are compatible.
+
 
                   Support: Core
                 items:
@@ -1438,9 +1646,11 @@ spec:
                         Listener and the trusted namespaces where those Route resources MAY be
                         present.
 
+
                         Although a client request may match multiple route rules, only one rule
                         may ultimately receive the request. Matching precedence MUST be
                         determined in order of the following criteria:
+
 
                         * The most specific match as defined by the Route type.
                         * The oldest Route based on creation timestamp. For example, a Route with
@@ -1450,12 +1660,14 @@ spec:
                           alphabetical order (namespace/name) should be given precedence. For
                           example, foo/bar is given precedence over foo/baz.
 
+
                         All valid rules within a Route attached to this Listener should be
                         implemented. Invalid Route rules can be ignored (sometimes that will mean
                         the full Route). If a Route rule transitions from valid to invalid,
                         support for that Route rule should be dropped to ensure consistency. For
                         example, even if a filter specified by a Route rule is invalid, the rest
                         of the rules within that Route should still be supported.
+
 
                         Support: Core
                       properties:
@@ -1465,11 +1677,13 @@ spec:
                             to this Gateway Listener. When unspecified or empty, the kinds of Routes
                             selected are determined using the Listener protocol.
 
+
                             A RouteGroupKind MUST correspond to kinds of Routes that are compatible
                             with the application protocol specified in the Listener's Protocol field.
                             If an implementation does not support or recognize this resource type, it
                             MUST set the "ResolvedRefs" condition to False for this Listener with the
                             "InvalidRouteKinds" reason.
+
 
                             Support: Core
                           items:
@@ -1500,6 +1714,7 @@ spec:
                             Namespaces indicates namespaces from which Routes may be attached to this
                             Listener. This is restricted to the namespace of this Gateway by default.
 
+
                             Support: Core
                           properties:
                             from:
@@ -1508,10 +1723,12 @@ spec:
                                 From indicates where Routes will be selected for this Gateway. Possible
                                 values are:
 
+
                                 * All: Routes in all namespaces may be used by this Gateway.
                                 * Selector: Routes in namespaces selected by the selector may be used by
                                   this Gateway.
                                 * Same: Only Routes in the same namespace may be used by this Gateway.
+
 
                                 Support: Core
                               enum:
@@ -1524,6 +1741,7 @@ spec:
                                 Selector must be specified when From is set to "Selector". In that case,
                                 only Routes in Namespaces matching this Selector will be selected by this
                                 Gateway. This field is ignored for other values of "From".
+
 
                                 Support: Core
                               properties:
@@ -1579,8 +1797,10 @@ spec:
                         field is ignored for protocols that don't require hostname based
                         matching.
 
+
                         Implementations MUST apply Hostname matching appropriately for each of
                         the following protocols:
+
 
                         * TLS: The Listener Hostname MUST match the SNI.
                         * HTTP: The Listener Hostname MUST match the Host header of the request.
@@ -1589,15 +1809,18 @@ spec:
                           ensure that both the SNI and Host header match the Listener hostname,
                           it MUST clearly document that.
 
+
                         For HTTPRoute and TLSRoute resources, there is an interaction with the
                         `spec.hostnames` array. When both listener and route specify hostnames,
                         there MUST be an intersection between the values for a Route to be
                         accepted. For more information, refer to the Route specific Hostnames
                         documentation.
 
+
                         Hostnames that are prefixed with a wildcard label (`*.`) are interpreted
                         as a suffix match. That means that a match for `*.example.com` would match
                         both `test.example.com`, and `foo.test.example.com`, but not `example.com`.
+
 
                         Support: Core
                       maxLength: 253
@@ -1609,6 +1832,7 @@ spec:
                         Name is the name of the Listener. This name MUST be unique within a
                         Gateway.
 
+
                         Support: Core
                       maxLength: 253
                       minLength: 1
@@ -1619,6 +1843,7 @@ spec:
                         Port is the network port. Multiple listeners may use the
                         same port, subject to the Listener compatibility rules.
 
+
                         Support: Core
                       format: int32
                       maximum: 65535
@@ -1628,10 +1853,11 @@ spec:
                       description: |-
                         Protocol specifies the network protocol this listener expects to receive.
 
+
                         Support: Core
                       maxLength: 255
                       minLength: 1
-                      pattern: ^[a-zA-Z0-9]([-a-zA-Z0-9]*[a-zA-Z0-9])?$|[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9]+$
+                      pattern: ^[a-zA-Z0-9]([-a-zSA-Z0-9]*[a-zA-Z0-9])?$|[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9]+$
                       type: string
                     tls:
                       description: |-
@@ -1639,11 +1865,14 @@ spec:
                         the Protocol field is "HTTPS" or "TLS". It is invalid to set this field
                         if the Protocol field is "HTTP", "TCP", or "UDP".
 
+
                         The association of SNIs to Certificate defined in GatewayTLSConfig is
                         defined based on the Hostname field for this listener.
 
+
                         The GatewayClass MUST use the longest matching SNI out of all
                         available certificates for any TLS handshake.
+
 
                         Support: Core
                       properties:
@@ -1654,9 +1883,11 @@ spec:
                             establish a TLS handshake for requests that match the hostname of the
                             associated listener.
 
+
                             A single CertificateRef to a Kubernetes Secret has "Core" support.
                             Implementations MAY choose to support attaching multiple certificates to
                             a Listener, but this behavior is implementation-specific.
+
 
                             References to a resource in different namespace are invalid UNLESS there
                             is a ReferenceGrant in the target namespace that allows the certificate
@@ -1664,13 +1895,17 @@ spec:
                             "ResolvedRefs" condition MUST be set to False for this listener with the
                             "RefNotPermitted" reason.
 
+
                             This field is required to have at least one element when the mode is set
                             to "Terminate" (default) and is optional otherwise.
+
 
                             CertificateRefs can reference to standard Kubernetes resources, i.e.
                             Secret, or implementation-specific custom resources.
 
+
                             Support: Core - A single reference to a Kubernetes Secret of type kubernetes.io/tls
+
 
                             Support: Implementation-specific (More than one reference or other resource types)
                           items:
@@ -1678,8 +1913,10 @@ spec:
                               SecretObjectReference identifies an API object including its namespace,
                               defaulting to Secret.
 
+
                               The API object must be valid in the cluster; the Group and Kind must
                               be registered in the cluster for this reference to be valid.
+
 
                               References to objects with invalid Group and Kind are not valid, and must
                               be rejected by the implementation, with appropriate Conditions set
@@ -1711,10 +1948,12 @@ spec:
                                   Namespace is the namespace of the referenced object. When unspecified, the local
                                   namespace is inferred.
 
+
                                   Note that when a namespace different than the local namespace is specified,
                                   a ReferenceGrant object is required in the referent namespace to allow that
                                   namespace's owner to accept the reference. See the ReferenceGrant
                                   documentation for details.
+
 
                                   Support: Core
                                 maxLength: 63
@@ -1726,11 +1965,110 @@ spec:
                             type: object
                           maxItems: 64
                           type: array
+                        frontendValidation:
+                          description: |+
+                            FrontendValidation holds configuration information for validating the frontend (client).
+                            Setting this field will require clients to send a client certificate
+                            required for validation during the TLS handshake. In browsers this may result in a dialog appearing
+                            that requests a user to specify the client certificate.
+                            The maximum depth of a certificate chain accepted in verification is Implementation specific.
+
+
+                            Support: Extended
+
+
+                          properties:
+                            caCertificateRefs:
+                              description: |-
+                                CACertificateRefs contains one or more references to
+                                Kubernetes objects that contain TLS certificates of
+                                the Certificate Authorities that can be used
+                                as a trust anchor to validate the certificates presented by the client.
+
+
+                                A single CA certificate reference to a Kubernetes ConfigMap
+                                has "Core" support.
+                                Implementations MAY choose to support attaching multiple CA certificates to
+                                a Listener, but this behavior is implementation-specific.
+
+
+                                Support: Core - A single reference to a Kubernetes ConfigMap
+                                with the CA certificate in a key named `ca.crt`.
+
+
+                                Support: Implementation-specific (More than one reference, or other kinds
+                                of resources).
+
+
+                                References to a resource in a different namespace are invalid UNLESS there
+                                is a ReferenceGrant in the target namespace that allows the certificate
+                                to be attached. If a ReferenceGrant does not allow this reference, the
+                                "ResolvedRefs" condition MUST be set to False for this listener with the
+                                "RefNotPermitted" reason.
+                              items:
+                                description: |-
+                                  ObjectReference identifies an API object including its namespace.
+
+
+                                  The API object must be valid in the cluster; the Group and Kind must
+                                  be registered in the cluster for this reference to be valid.
+
+
+                                  References to objects with invalid Group and Kind are not valid, and must
+                                  be rejected by the implementation, with appropriate Conditions set
+                                  on the containing object.
+                                properties:
+                                  group:
+                                    description: |-
+                                      Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                                      When unspecified or empty string, core API group is inferred.
+                                    maxLength: 253
+                                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                    type: string
+                                  kind:
+                                    description: Kind is kind of the referent. For
+                                      example "ConfigMap" or "Service".
+                                    maxLength: 63
+                                    minLength: 1
+                                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                    type: string
+                                  name:
+                                    description: Name is the name of the referent.
+                                    maxLength: 253
+                                    minLength: 1
+                                    type: string
+                                  namespace:
+                                    description: |-
+                                      Namespace is the namespace of the referenced object. When unspecified, the local
+                                      namespace is inferred.
+
+
+                                      Note that when a namespace different than the local namespace is specified,
+                                      a ReferenceGrant object is required in the referent namespace to allow that
+                                      namespace's owner to accept the reference. See the ReferenceGrant
+                                      documentation for details.
+
+
+                                      Support: Core
+                                    maxLength: 63
+                                    minLength: 1
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                    type: string
+                                required:
+                                - group
+                                - kind
+                                - name
+                                type: object
+                              maxItems: 8
+                              minItems: 1
+                              type: array
+                          type: object
                         mode:
                           default: Terminate
                           description: |-
                             Mode defines the TLS behavior for the TLS session initiated by the client.
                             There are two possible modes:
+
 
                             - Terminate: The TLS session between the downstream client and the
                               Gateway is terminated at the Gateway. This mode requires certificates
@@ -1740,6 +2078,7 @@ spec:
                               implies that the Gateway can't decipher the TLS stream except for
                               the ClientHello message of the TLS protocol. The certificateRefs field
                               is ignored in this mode.
+
 
                             Support: Core
                           enum:
@@ -1761,10 +2100,12 @@ spec:
                             configuration for each implementation. For example, configuring the
                             minimum TLS version or supported cipher suites.
 
+
                             A set of common keys MAY be defined by the API in the future. To avoid
                             any ambiguity, implementation-specific definitions MUST use
                             domain-prefixed names, such as `example.com/my-custom-option`.
                             Un-prefixed names are reserved for key names defined by Gateway API.
+
 
                             Support: Implementation-specific
                           maxProperties: 16
@@ -1828,12 +2169,15 @@ spec:
                   Addresses lists the network addresses that have been bound to the
                   Gateway.
 
+
                   This list may differ from the addresses provided in the spec under some
                   conditions:
+
 
                     * no addresses are specified, all addresses are dynamically assigned
                     * a combination of specified and dynamic addresses are assigned
                     * a specified address was unusable (e.g. already in use)
+
 
                 items:
                   description: GatewayStatusAddress describes a network address that
@@ -1865,6 +2209,7 @@ spec:
                         Value of the address. The validity of the values will depend
                         on the type and support by the controller.
 
+
                         Examples: `1.2.3.4`, `128::1`, `my-ip-address`.
                       maxLength: 253
                       minLength: 1
@@ -1894,19 +2239,30 @@ spec:
                 description: |-
                   Conditions describe the current conditions of the Gateway.
 
+
                   Implementations should prefer to express Gateway conditions
                   using the `GatewayConditionType` and `GatewayConditionReason`
                   constants so that operators and tools can converge on a common
                   vocabulary to describe Gateway state.
 
+
                   Known condition types are:
+
 
                   * "Accepted"
                   * "Programmed"
                   * "Ready"
                 items:
-                  description: Condition contains details for one aspect of the current
-                    state of this API Resource.
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
                   properties:
                     lastTransitionTime:
                       description: |-
@@ -1947,7 +2303,12 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
@@ -1974,6 +2335,7 @@ spec:
                         AttachedRoutes represents the total number of Routes that have been
                         successfully attached to this Listener.
 
+
                         Successful attachment of a Route to a Listener is based solely on the
                         combination of the AllowedRoutes field on the corresponding Listener
                         and the Route's ParentRefs field. A Route is successfully attached to
@@ -1986,6 +2348,7 @@ spec:
                         for Listeners with condition Accepted: false and MUST count successfully
                         attached Routes that may themselves have Accepted: false conditions.
 
+
                         Uses for this field include troubleshooting Route attachment and
                         measuring blast radius/impact of changes to a Listener.
                       format: int32
@@ -1994,8 +2357,18 @@ spec:
                       description: Conditions describe the current condition of this
                         listener.
                       items:
-                        description: Condition contains details for one aspect of
-                          the current state of this API Resource.
+                        description: "Condition contains details for one aspect of
+                          the current state of this API Resource.\n---\nThis struct
+                          is intended for direct use as an array at the field path
+                          .status.conditions.  For example,\n\n\n\ttype FooStatus
+                          struct{\n\t    // Represents the observations of a foo's
+                          current state.\n\t    // Known .status.conditions.type are:
+                          \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                          +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    //
+                          +listType=map\n\t    // +listMapKey=type\n\t    Conditions
+                          []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\"
+                          patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                          \   // other fields\n\t}"
                         properties:
                           lastTransitionTime:
                             description: |-
@@ -2037,7 +2410,12 @@ spec:
                             - Unknown
                             type: string
                           type:
-                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                            description: |-
+                              type of condition in CamelCase or in foo.example.com/CamelCase.
+                              ---
+                              Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                              useful (see .node.status.conditions), the ability to deconflict is important.
+                              The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
                             maxLength: 316
                             pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                             type: string
@@ -2065,6 +2443,7 @@ spec:
                         SupportedKinds is the list indicating the Kinds supported by this
                         listener. This MUST represent the kinds an implementation supports for
                         that Listener configuration.
+
 
                         If kinds are specified in Spec that are not supported, they MUST NOT
                         appear in this list and an implementation MUST set the "ResolvedRefs"

--- a/platform/gateway-api/chart/templates/grpcroutes.yaml
+++ b/platform/gateway-api/chart/templates/grpcroutes.yaml
@@ -1,6 +1,6 @@
 {{/*
   Vendored from kubernetes-sigs/gateway-api {{ index .Chart.Annotations "catalyst.openova.io/upstream-gateway-api-version" }}
-  standard-install.yaml. Do NOT hand-edit annotations / spec — re-vendor
+  experimental-install.yaml. Do NOT hand-edit annotations / spec — re-vendor
   via the script in tests/regenerate.sh when bumping the upstream version
   (also bump catalyst.openova.io/upstream-gateway-api-version in Chart.yaml).
 
@@ -9,17 +9,18 @@
   cluster-scoped infrastructure; deleting them on uninstall would break
   every HTTPRoute on the cluster simultaneously.
 */}}
+
 #
-# config/crd/standard/gateway.networking.k8s.io_grpcroutes.yaml
+# config/crd/experimental/gateway.networking.k8s.io_grpcroutes.yaml
 #
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/3328
-    gateway.networking.k8s.io/bundle-version: v1.2.0
-    gateway.networking.k8s.io/channel: standard
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/2997
+    gateway.networking.k8s.io/bundle-version: v1.1.0
+    gateway.networking.k8s.io/channel: experimental
   creationTimestamp: null
   name: grpcroutes.gateway.networking.k8s.io
 spec:
@@ -49,11 +50,13 @@ spec:
           Filters can be used to specify additional processing steps. Backends specify
           where matching requests will be routed.
 
+
           GRPCRoute falls under extended support within the Gateway API. Within the
           following specification, the word "MUST" indicates that an implementation
           supporting GRPCRoute must conform to the indicated requirement, but an
           implementation not supporting this route type need not follow the requirement
           unless explicitly indicated.
+
 
           Implementations supporting `GRPCRoute` with the `HTTPS` `ProtocolType` MUST
           accept HTTP/2 connections without an initial upgrade from HTTP/1.1, i.e. via
@@ -61,6 +64,7 @@ spec:
           "Accepted" condition to "False" for the affected listener with a reason of
           "UnsupportedProtocol".  Implementations MAY also accept HTTP/2 connections
           with an upgrade from HTTP/1.
+
 
           Implementations supporting `GRPCRoute` with the `HTTP` `ProtocolType` MUST
           support HTTP/2 over cleartext TCP (h2c,
@@ -98,13 +102,16 @@ spec:
                   Host header to select a GRPCRoute to process the request. This matches
                   the RFC 1123 definition of a hostname with 2 notable exceptions:
 
+
                   1. IPs are not allowed.
                   2. A hostname may be prefixed with a wildcard label (`*.`). The wildcard
                      label MUST appear by itself as the first label.
 
+
                   If a hostname is specified by both the Listener and GRPCRoute, there
                   MUST be at least one intersecting hostname for the GRPCRoute to be
                   attached to the Listener. For example:
+
 
                   * A Listener with `test.example.com` as the hostname matches GRPCRoutes
                     that have either not specified any hostnames, or have specified at
@@ -115,9 +122,11 @@ spec:
                     `test.example.com` and `*.example.com` would both match. On the other
                     hand, `example.com` and `test.example.net` would not match.
 
+
                   Hostnames that are prefixed with a wildcard label (`*.`) are interpreted
                   as a suffix match. That means that a match for `*.example.com` would match
                   both `test.example.com`, and `foo.test.example.com`, but not `example.com`.
+
 
                   If both the Listener and GRPCRoute have specified hostnames, any
                   GRPCRoute hostnames that do not match the Listener hostname MUST be
@@ -125,10 +134,12 @@ spec:
                   GRPCRoute specified `test.example.com` and `test.example.net`,
                   `test.example.net` MUST NOT be considered for a match.
 
+
                   If both the Listener and GRPCRoute have specified hostnames, and none
                   match with the criteria above, then the GRPCRoute MUST NOT be accepted by
                   the implementation. The implementation MUST raise an 'Accepted' Condition
                   with a status of `False` in the corresponding RouteParentStatus.
+
 
                   If a Route (A) of type HTTPRoute or GRPCRoute is attached to a
                   Listener and that listener already has another Route (B) of the other
@@ -136,12 +147,15 @@ spec:
                   non-empty, then the implementation MUST accept exactly one of these two
                   routes, determined by the following criteria, in order:
 
+
                   * The oldest Route based on creation timestamp.
                   * The Route appearing first in alphabetical order by
                     "{namespace}/{name}".
 
+
                   The rejected Route MUST raise an 'Accepted' condition with a status of
                   'False' in the corresponding RouteParentStatus.
+
 
                   Support: Core
                 items:
@@ -149,13 +163,16 @@ spec:
                     Hostname is the fully qualified domain name of a network host. This matches
                     the RFC 1123 definition of a hostname with 2 notable exceptions:
 
+
                      1. IPs are not allowed.
                      2. A hostname may be prefixed with a wildcard label (`*.`). The wildcard
                         label must appear by itself as the first label.
 
+
                     Hostname can be "precise" which is a domain name without the terminating
                     dot of a network host (e.g. "foo.example.com") or "wildcard", which is a
                     domain name prefixed with a single wildcard label (e.g. `*.example.com`).
+
 
                     Note that as per RFC1035 and RFC1123, a *label* must consist of lower case
                     alphanumeric characters or '-', and must start and end with an alphanumeric
@@ -179,15 +196,20 @@ spec:
                   create a "producer" route for a Service in a different namespace from the
                   Route.
 
+
                   There are two kinds of parent resources with "Core" support:
+
 
                   * Gateway (Gateway conformance profile)
                   * Service (Mesh conformance profile, ClusterIP Services only)
 
+
                   This API may be extended in the future to support additional kinds of parent
                   resources.
 
+
                   ParentRefs must be _distinct_. This means either that:
+
 
                   * They select different objects.  If this is the case, then parentRef
                     entries are distinct. In terms of fields, this means that the
@@ -198,7 +220,9 @@ spec:
                     optional fields to different values. If one ParentRef sets a
                     combination of optional fields, all must set the same combination.
 
+
                   Some examples:
+
 
                   * If one ParentRef sets `sectionName`, all ParentRefs referencing the
                     same object must also set `sectionName`.
@@ -207,17 +231,32 @@ spec:
                   * If one ParentRef sets `sectionName` and `port`, all ParentRefs
                     referencing the same object must also set `sectionName` and `port`.
 
+
                   It is possible to separately reference multiple distinct objects that may
                   be collapsed by an implementation. For example, some implementations may
                   choose to merge compatible Gateway Listeners together. If that is the
                   case, the list of routes attached to those resources should also be
                   merged.
 
+
                   Note that for ParentRefs that cross namespace boundaries, there are specific
                   rules. Cross-namespace references are only valid if they are explicitly
                   allowed by something in the namespace they are referring to. For example,
                   Gateway has the AllowedRoutes field, and ReferenceGrant provides a
                   generic way to enable other kinds of cross-namespace reference.
+
+
+
+                  ParentRefs from a Route to a Service in the same namespace are "producer"
+                  routes, which apply default routing rules to inbound connections from
+                  any namespace to the Service.
+
+
+                  ParentRefs from a Route to a Service in a different namespace are
+                  "consumer" routes, and these routing rules are only applied to outbound
+                  connections originating from the same namespace as the Route, for which
+                  the intended destination of the connections are a Service targeted as a
+                  ParentRef of the Route.
 
 
 
@@ -230,11 +269,14 @@ spec:
                     a parent of this resource (usually a route). There are two kinds of parent resources
                     with "Core" support:
 
+
                     * Gateway (Gateway conformance profile)
                     * Service (Mesh conformance profile, ClusterIP Services only)
 
+
                     This API may be extended in the future to support additional kinds of parent
                     resources.
+
 
                     The API object must be valid in the cluster; the Group and Kind must
                     be registered in the cluster for this reference to be valid.
@@ -247,6 +289,7 @@ spec:
                         To set the core API group (such as for a "Service" kind referent),
                         Group must be explicitly set to "" (empty string).
 
+
                         Support: Core
                       maxLength: 253
                       pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
@@ -256,10 +299,13 @@ spec:
                       description: |-
                         Kind is kind of the referent.
 
+
                         There are two kinds of parent resources with "Core" support:
+
 
                         * Gateway (Gateway conformance profile)
                         * Service (Mesh conformance profile, ClusterIP Services only)
+
 
                         Support for other resources is Implementation-Specific.
                       maxLength: 63
@@ -270,6 +316,7 @@ spec:
                       description: |-
                         Name is the name of the referent.
 
+
                         Support: Core
                       maxLength: 253
                       minLength: 1
@@ -279,11 +326,25 @@ spec:
                         Namespace is the namespace of the referent. When unspecified, this refers
                         to the local namespace of the Route.
 
+
                         Note that there are specific rules for ParentRefs which cross namespace
                         boundaries. Cross-namespace references are only valid if they are explicitly
                         allowed by something in the namespace they are referring to. For example:
                         Gateway has the AllowedRoutes field, and ReferenceGrant provides a
                         generic way to enable any other kind of cross-namespace reference.
+
+
+
+                        ParentRefs from a Route to a Service in the same namespace are "producer"
+                        routes, which apply default routing rules to inbound connections from
+                        any namespace to the Service.
+
+
+                        ParentRefs from a Route to a Service in a different namespace are
+                        "consumer" routes, and these routing rules are only applied to outbound
+                        connections originating from the same namespace as the Route, for which
+                        the intended destination of the connections are a Service targeted as a
+                        ParentRef of the Route.
 
 
 
@@ -297,6 +358,7 @@ spec:
                         Port is the network port this Route targets. It can be interpreted
                         differently based on the type of parent resource.
 
+
                         When the parent resource is a Gateway, this targets all listeners
                         listening on the specified port that also support this kind of Route(and
                         select this Route). It's not recommended to set `Port` unless the
@@ -307,9 +369,16 @@ spec:
 
 
 
+                        When the parent resource is a Service, this targets a specific port in the
+                        Service spec. When both Port (experimental) and SectionName are specified,
+                        the name and port of the selected port must match both specified values.
+
+
+
                         Implementations MAY choose to support other parent resources.
                         Implementations supporting other types of parent resources MUST clearly
                         document how/if Port is interpreted.
+
 
                         For the purpose of status, an attachment is considered successful as
                         long as the parent resource accepts it partially. For example, Gateway
@@ -318,6 +387,7 @@ spec:
                         from the referencing Route, the Route MUST be considered successfully
                         attached. If no Gateway listeners accept attachment from this Route,
                         the Route MUST be considered detached from the Gateway.
+
 
                         Support: Extended
                       format: int32
@@ -329,6 +399,7 @@ spec:
                         SectionName is the name of a section within the target resource. In the
                         following resources, SectionName is interpreted as the following:
 
+
                         * Gateway: Listener name. When both Port (experimental) and SectionName
                         are specified, the name and port of the selected listener must match
                         both specified values.
@@ -336,9 +407,11 @@ spec:
                         are specified, the name and port of the selected listener must match
                         both specified values.
 
+
                         Implementations MAY choose to support attaching Routes to other resources.
                         If that is the case, they MUST clearly document how SectionName is
                         interpreted.
+
 
                         When unspecified (empty string), this will reference the entire resource.
                         For the purpose of status, an attachment is considered successful if at
@@ -348,6 +421,7 @@ spec:
                         the referencing Route, the Route MUST be considered successfully
                         attached. If no Gateway listeners accept attachment from this Route, the
                         Route MUST be considered detached from the Gateway.
+
 
                         Support: Core
                       maxLength: 253
@@ -360,29 +434,30 @@ spec:
                 maxItems: 32
                 type: array
                 x-kubernetes-validations:
-                - message: sectionName must be specified when parentRefs includes
+                - message: sectionName or port must be specified when parentRefs includes
                     2 or more references to the same parent
                   rule: 'self.all(p1, self.all(p2, p1.group == p2.group && p1.kind
                     == p2.kind && p1.name == p2.name && (((!has(p1.__namespace__)
                     || p1.__namespace__ == '''') && (!has(p2.__namespace__) || p2.__namespace__
                     == '''')) || (has(p1.__namespace__) && has(p2.__namespace__) &&
-                    p1.__namespace__ == p2.__namespace__ )) ? ((!has(p1.sectionName)
+                    p1.__namespace__ == p2.__namespace__)) ? ((!has(p1.sectionName)
                     || p1.sectionName == '''') == (!has(p2.sectionName) || p2.sectionName
-                    == '''')) : true))'
-                - message: sectionName must be unique when parentRefs includes 2 or
-                    more references to the same parent
+                    == '''') && (!has(p1.port) || p1.port == 0) == (!has(p2.port)
+                    || p2.port == 0)): true))'
+                - message: sectionName or port must be unique when parentRefs includes
+                    2 or more references to the same parent
                   rule: self.all(p1, self.exists_one(p2, p1.group == p2.group && p1.kind
                     == p2.kind && p1.name == p2.name && (((!has(p1.__namespace__)
                     || p1.__namespace__ == '') && (!has(p2.__namespace__) || p2.__namespace__
                     == '')) || (has(p1.__namespace__) && has(p2.__namespace__) &&
                     p1.__namespace__ == p2.__namespace__ )) && (((!has(p1.sectionName)
                     || p1.sectionName == '') && (!has(p2.sectionName) || p2.sectionName
-                    == '')) || (has(p1.sectionName) && has(p2.sectionName) && p1.sectionName
-                    == p2.sectionName))))
+                    == '')) || ( has(p1.sectionName) && has(p2.sectionName) && p1.sectionName
+                    == p2.sectionName)) && (((!has(p1.port) || p1.port == 0) && (!has(p2.port)
+                    || p2.port == 0)) || (has(p1.port) && has(p2.port) && p1.port
+                    == p2.port))))
               rules:
-                description: |+
-                  Rules are a list of GRPC matchers, filters and actions.
-
+                description: Rules are a list of GRPC matchers, filters and actions.
                 items:
                   description: |-
                     GRPCRouteRule defines the semantics for matching a gRPC request based on
@@ -394,15 +469,19 @@ spec:
                         BackendRefs defines the backend(s) where matching requests should be
                         sent.
 
+
                         Failure behavior here depends on how many BackendRefs are specified and
                         how many are invalid.
+
 
                         If *all* entries in BackendRefs are invalid, and there are also no filters
                         specified in this route rule, *all* traffic which matches this rule MUST
                         receive an `UNAVAILABLE` status.
 
+
                         See the GRPCBackendRef definition for the rules about what makes a single
                         GRPCBackendRef invalid.
+
 
                         When a GRPCBackendRef is invalid, `UNAVAILABLE` statuses MUST be returned for
                         requests that would have otherwise been routed to an invalid backend. If
@@ -410,39 +489,50 @@ spec:
                         requests that would otherwise have been routed to an invalid backend
                         MUST receive an `UNAVAILABLE` status.
 
+
                         For example, if two backends are specified with equal weights, and one is
                         invalid, 50 percent of traffic MUST receive an `UNAVAILABLE` status.
                         Implementations may choose how that 50 percent is determined.
 
+
                         Support: Core for Kubernetes Service
 
+
                         Support: Implementation-specific for any other resource
+
 
                         Support for weight: Core
                       items:
                         description: |-
                           GRPCBackendRef defines how a GRPCRoute forwards a gRPC request.
 
+
                           Note that when a namespace different than the local namespace is specified, a
                           ReferenceGrant object is required in the referent namespace to allow that
                           namespace's owner to accept the reference. See the ReferenceGrant
                           documentation for details.
 
+
                           <gateway:experimental:description>
+
 
                           When the BackendRef points to a Kubernetes Service, implementations SHOULD
                           honor the appProtocol field if it is set for the target Service Port.
 
+
                           Implementations supporting appProtocol SHOULD recognize the Kubernetes
                           Standard Application Protocols defined in KEP-3726.
+
 
                           If a Service appProtocol isn't specified, an implementation MAY infer the
                           backend protocol through its own means. Implementations MAY infer the
                           protocol from the Route type referring to the backend Service.
 
+
                           If a Route is not able to send traffic to the backend using the specified
                           protocol then the backend is considered invalid. Implementations MUST set the
                           "ResolvedRefs" condition to "False" with the "UnsupportedProtocol" reason.
+
 
                           </gateway:experimental:description>
                         properties:
@@ -450,6 +540,7 @@ spec:
                             description: |-
                               Filters defined at this level MUST be executed if and only if the
                               request is being forwarded to the backend defined here.
+
 
                               Support: Implementation-specific (For broader support of filters, use the
                               Filters field in GRPCRouteRule.)
@@ -469,7 +560,9 @@ spec:
                                     "networking.example.net"). ExtensionRef MUST NOT be used for core and
                                     extended filters.
 
+
                                     Support: Implementation-specific
+
 
                                     This filter can be used multiple times within the same rule.
                                   properties:
@@ -502,6 +595,7 @@ spec:
                                     RequestHeaderModifier defines a schema for a filter that modifies request
                                     headers.
 
+
                                     Support: Core
                                   properties:
                                     add:
@@ -510,14 +604,17 @@ spec:
                                         before the action. It appends to any existing values associated
                                         with the header name.
 
+
                                         Input:
                                           GET /foo HTTP/1.1
                                           my-header: foo
+
 
                                         Config:
                                           add:
                                           - name: "my-header"
                                             value: "bar,baz"
+
 
                                         Output:
                                           GET /foo HTTP/1.1
@@ -531,6 +628,7 @@ spec:
                                             description: |-
                                               Name is the name of the HTTP Header to be matched. Name matching MUST be
                                               case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
 
                                               If multiple entries specify equivalent header names, the first entry with
                                               an equivalent name MUST be considered for a match. Subsequent entries
@@ -563,14 +661,17 @@ spec:
                                         names are case-insensitive (see
                                         https://datatracker.ietf.org/doc/html/rfc2616#section-4.2).
 
+
                                         Input:
                                           GET /foo HTTP/1.1
                                           my-header1: foo
                                           my-header2: bar
                                           my-header3: baz
 
+
                                         Config:
                                           remove: ["my-header1", "my-header3"]
+
 
                                         Output:
                                           GET /foo HTTP/1.1
@@ -585,14 +686,17 @@ spec:
                                         Set overwrites the request with the given header (name, value)
                                         before the action.
 
+
                                         Input:
                                           GET /foo HTTP/1.1
                                           my-header: foo
+
 
                                         Config:
                                           set:
                                           - name: "my-header"
                                             value: "bar"
+
 
                                         Output:
                                           GET /foo HTTP/1.1
@@ -606,6 +710,7 @@ spec:
                                             description: |-
                                               Name is the name of the HTTP Header to be matched. Name matching MUST be
                                               case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
 
                                               If multiple entries specify equivalent header names, the first entry with
                                               an equivalent name MUST be considered for a match. Subsequent entries
@@ -633,30 +738,34 @@ spec:
                                       x-kubernetes-list-type: map
                                   type: object
                                 requestMirror:
-                                  description: |+
+                                  description: |-
                                     RequestMirror defines a schema for a filter that mirrors requests.
                                     Requests are sent to the specified destination, but responses from
                                     that destination are ignored.
+
 
                                     This filter can be used multiple times within the same rule. Note that
                                     not all implementations will be able to support mirroring to multiple
                                     backends.
 
-                                    Support: Extended
 
+                                    Support: Extended
                                   properties:
                                     backendRef:
                                       description: |-
                                         BackendRef references a resource where mirrored requests are sent.
 
+
                                         Mirrored requests must be sent only to a single destination endpoint
                                         within this BackendRef, irrespective of how many endpoints are present
                                         within this BackendRef.
+
 
                                         If the referent cannot be found, this BackendRef is invalid and must be
                                         dropped from the Gateway. The controller must ensure the "ResolvedRefs"
                                         condition on the Route status is set to `status: False` and not configure
                                         this backend in the underlying implementation.
+
 
                                         If there is a cross-namespace reference to an *existing* object
                                         that is not allowed by a ReferenceGrant, the controller must ensure the
@@ -664,10 +773,13 @@ spec:
                                         with the "RefNotPermitted" reason and not configure this backend in the
                                         underlying implementation.
 
+
                                         In either error case, the Message of the `ResolvedRefs` Condition
                                         should be used to provide more detail about the problem.
 
+
                                         Support: Extended for Kubernetes Service
+
 
                                         Support: Implementation-specific for any other resource
                                       properties:
@@ -685,7 +797,9 @@ spec:
                                             Kind is the Kubernetes resource kind of the referent. For example
                                             "Service".
 
+
                                             Defaults to "Service" when not specified.
+
 
                                             ExternalName services can refer to CNAME DNS records that may live
                                             outside of the cluster and as such are difficult to reason about in
@@ -693,7 +807,9 @@ spec:
                                             CVE-2021-25740 for more information). Implementations SHOULD NOT
                                             support ExternalName Services.
 
+
                                             Support: Core (Services with a type other than ExternalName)
+
 
                                             Support: Implementation-specific (Services with type ExternalName)
                                           maxLength: 63
@@ -710,10 +826,12 @@ spec:
                                             Namespace is the namespace of the backend. When unspecified, the local
                                             namespace is inferred.
 
+
                                             Note that when a namespace different than the local namespace is specified,
                                             a ReferenceGrant object is required in the referent namespace to allow that
                                             namespace's owner to accept the reference. See the ReferenceGrant
                                             documentation for details.
+
 
                                             Support: Core
                                           maxLength: 63
@@ -746,6 +864,7 @@ spec:
                                     ResponseHeaderModifier defines a schema for a filter that modifies response
                                     headers.
 
+
                                     Support: Extended
                                   properties:
                                     add:
@@ -754,14 +873,17 @@ spec:
                                         before the action. It appends to any existing values associated
                                         with the header name.
 
+
                                         Input:
                                           GET /foo HTTP/1.1
                                           my-header: foo
+
 
                                         Config:
                                           add:
                                           - name: "my-header"
                                             value: "bar,baz"
+
 
                                         Output:
                                           GET /foo HTTP/1.1
@@ -775,6 +897,7 @@ spec:
                                             description: |-
                                               Name is the name of the HTTP Header to be matched. Name matching MUST be
                                               case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
 
                                               If multiple entries specify equivalent header names, the first entry with
                                               an equivalent name MUST be considered for a match. Subsequent entries
@@ -807,14 +930,17 @@ spec:
                                         names are case-insensitive (see
                                         https://datatracker.ietf.org/doc/html/rfc2616#section-4.2).
 
+
                                         Input:
                                           GET /foo HTTP/1.1
                                           my-header1: foo
                                           my-header2: bar
                                           my-header3: baz
 
+
                                         Config:
                                           remove: ["my-header1", "my-header3"]
+
 
                                         Output:
                                           GET /foo HTTP/1.1
@@ -829,14 +955,17 @@ spec:
                                         Set overwrites the request with the given header (name, value)
                                         before the action.
 
+
                                         Input:
                                           GET /foo HTTP/1.1
                                           my-header: foo
+
 
                                         Config:
                                           set:
                                           - name: "my-header"
                                             value: "bar"
+
 
                                         Output:
                                           GET /foo HTTP/1.1
@@ -850,6 +979,7 @@ spec:
                                             description: |-
                                               Name is the name of the HTTP Header to be matched. Name matching MUST be
                                               case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
 
                                               If multiple entries specify equivalent header names, the first entry with
                                               an equivalent name MUST be considered for a match. Subsequent entries
@@ -881,13 +1011,16 @@ spec:
                                     Type identifies the type of filter to apply. As with other API fields,
                                     types are classified into three conformance levels:
 
+
                                     - Core: Filter types and their corresponding configuration defined by
                                       "Support: Core" in this package, e.g. "RequestHeaderModifier". All
                                       implementations supporting GRPCRoute MUST support core filters.
 
+
                                     - Extended: Filter types and their corresponding configuration defined by
                                       "Support: Extended" in this package, e.g. "RequestMirror". Implementers
                                       are encouraged to support extended filters.
+
 
                                     - Implementation-specific: Filters that are defined and supported by specific vendors.
                                       In the future, filters showing convergence in behavior across multiple
@@ -896,12 +1029,15 @@ spec:
                                       is specified using the ExtensionRef field. `Type` MUST be set to
                                       "ExtensionRef" for custom filters.
 
+
                                     Implementers are encouraged to define custom implementation types to
                                     extend the core API with implementation-specific behavior.
+
 
                                     If a reference to a custom filter type cannot be resolved, the filter
                                     MUST NOT be skipped. Instead, requests that would have been processed by
                                     that filter MUST receive a HTTP error response.
+
 
                                   enum:
                                   - ResponseHeaderModifier
@@ -965,7 +1101,9 @@ spec:
                               Kind is the Kubernetes resource kind of the referent. For example
                               "Service".
 
+
                               Defaults to "Service" when not specified.
+
 
                               ExternalName services can refer to CNAME DNS records that may live
                               outside of the cluster and as such are difficult to reason about in
@@ -973,7 +1111,9 @@ spec:
                               CVE-2021-25740 for more information). Implementations SHOULD NOT
                               support ExternalName Services.
 
+
                               Support: Core (Services with a type other than ExternalName)
+
 
                               Support: Implementation-specific (Services with type ExternalName)
                             maxLength: 63
@@ -990,10 +1130,12 @@ spec:
                               Namespace is the namespace of the backend. When unspecified, the local
                               namespace is inferred.
 
+
                               Note that when a namespace different than the local namespace is specified,
                               a ReferenceGrant object is required in the referent namespace to allow that
                               namespace's owner to accept the reference. See the ReferenceGrant
                               documentation for details.
+
 
                               Support: Core
                             maxLength: 63
@@ -1021,10 +1163,12 @@ spec:
                               implementation supports. Weight is not a percentage and the sum of
                               weights does not need to equal 100.
 
+
                               If only one backend is specified and it has a weight greater than 0, 100%
                               of the traffic is forwarded to that backend. If weight is set to 0, no
                               traffic should be forwarded for this entry. If unspecified, weight
                               defaults to 1.
+
 
                               Support for this field varies based on the context where used.
                             format: int32
@@ -1045,10 +1189,13 @@ spec:
                         Filters define the filters that are applied to requests that match
                         this rule.
 
+
                         The effects of ordering of multiple behaviors are currently unspecified.
                         This can change in the future based on feedback during the alpha stage.
 
+
                         Conformance-levels at this level are defined based on the type of filter:
+
 
                         - ALL core filters MUST be supported by all implementations that support
                           GRPCRoute.
@@ -1056,14 +1203,17 @@ spec:
                         - Implementation-specific custom filters have no API guarantees across
                           implementations.
 
+
                         Specifying the same filter multiple times is not supported unless explicitly
                         indicated in the filter.
+
 
                         If an implementation can not support a combination of filters, it must clearly
                         document that limitation. In cases where incompatible or unsupported
                         filters are specified and cause the `Accepted` condition to be set to status
                         `False`, implementations may use the `IncompatibleFilters` reason to specify
                         this configuration error.
+
 
                         Support: Core
                       items:
@@ -1082,7 +1232,9 @@ spec:
                               "networking.example.net"). ExtensionRef MUST NOT be used for core and
                               extended filters.
 
+
                               Support: Implementation-specific
+
 
                               This filter can be used multiple times within the same rule.
                             properties:
@@ -1115,6 +1267,7 @@ spec:
                               RequestHeaderModifier defines a schema for a filter that modifies request
                               headers.
 
+
                               Support: Core
                             properties:
                               add:
@@ -1123,14 +1276,17 @@ spec:
                                   before the action. It appends to any existing values associated
                                   with the header name.
 
+
                                   Input:
                                     GET /foo HTTP/1.1
                                     my-header: foo
+
 
                                   Config:
                                     add:
                                     - name: "my-header"
                                       value: "bar,baz"
+
 
                                   Output:
                                     GET /foo HTTP/1.1
@@ -1143,6 +1299,7 @@ spec:
                                       description: |-
                                         Name is the name of the HTTP Header to be matched. Name matching MUST be
                                         case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
 
                                         If multiple entries specify equivalent header names, the first entry with
                                         an equivalent name MUST be considered for a match. Subsequent entries
@@ -1175,14 +1332,17 @@ spec:
                                   names are case-insensitive (see
                                   https://datatracker.ietf.org/doc/html/rfc2616#section-4.2).
 
+
                                   Input:
                                     GET /foo HTTP/1.1
                                     my-header1: foo
                                     my-header2: bar
                                     my-header3: baz
 
+
                                   Config:
                                     remove: ["my-header1", "my-header3"]
+
 
                                   Output:
                                     GET /foo HTTP/1.1
@@ -1197,14 +1357,17 @@ spec:
                                   Set overwrites the request with the given header (name, value)
                                   before the action.
 
+
                                   Input:
                                     GET /foo HTTP/1.1
                                     my-header: foo
+
 
                                   Config:
                                     set:
                                     - name: "my-header"
                                       value: "bar"
+
 
                                   Output:
                                     GET /foo HTTP/1.1
@@ -1217,6 +1380,7 @@ spec:
                                       description: |-
                                         Name is the name of the HTTP Header to be matched. Name matching MUST be
                                         case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
 
                                         If multiple entries specify equivalent header names, the first entry with
                                         an equivalent name MUST be considered for a match. Subsequent entries
@@ -1244,30 +1408,34 @@ spec:
                                 x-kubernetes-list-type: map
                             type: object
                           requestMirror:
-                            description: |+
+                            description: |-
                               RequestMirror defines a schema for a filter that mirrors requests.
                               Requests are sent to the specified destination, but responses from
                               that destination are ignored.
+
 
                               This filter can be used multiple times within the same rule. Note that
                               not all implementations will be able to support mirroring to multiple
                               backends.
 
-                              Support: Extended
 
+                              Support: Extended
                             properties:
                               backendRef:
                                 description: |-
                                   BackendRef references a resource where mirrored requests are sent.
 
+
                                   Mirrored requests must be sent only to a single destination endpoint
                                   within this BackendRef, irrespective of how many endpoints are present
                                   within this BackendRef.
+
 
                                   If the referent cannot be found, this BackendRef is invalid and must be
                                   dropped from the Gateway. The controller must ensure the "ResolvedRefs"
                                   condition on the Route status is set to `status: False` and not configure
                                   this backend in the underlying implementation.
+
 
                                   If there is a cross-namespace reference to an *existing* object
                                   that is not allowed by a ReferenceGrant, the controller must ensure the
@@ -1275,10 +1443,13 @@ spec:
                                   with the "RefNotPermitted" reason and not configure this backend in the
                                   underlying implementation.
 
+
                                   In either error case, the Message of the `ResolvedRefs` Condition
                                   should be used to provide more detail about the problem.
 
+
                                   Support: Extended for Kubernetes Service
+
 
                                   Support: Implementation-specific for any other resource
                                 properties:
@@ -1296,7 +1467,9 @@ spec:
                                       Kind is the Kubernetes resource kind of the referent. For example
                                       "Service".
 
+
                                       Defaults to "Service" when not specified.
+
 
                                       ExternalName services can refer to CNAME DNS records that may live
                                       outside of the cluster and as such are difficult to reason about in
@@ -1304,7 +1477,9 @@ spec:
                                       CVE-2021-25740 for more information). Implementations SHOULD NOT
                                       support ExternalName Services.
 
+
                                       Support: Core (Services with a type other than ExternalName)
+
 
                                       Support: Implementation-specific (Services with type ExternalName)
                                     maxLength: 63
@@ -1321,10 +1496,12 @@ spec:
                                       Namespace is the namespace of the backend. When unspecified, the local
                                       namespace is inferred.
 
+
                                       Note that when a namespace different than the local namespace is specified,
                                       a ReferenceGrant object is required in the referent namespace to allow that
                                       namespace's owner to accept the reference. See the ReferenceGrant
                                       documentation for details.
+
 
                                       Support: Core
                                     maxLength: 63
@@ -1357,6 +1534,7 @@ spec:
                               ResponseHeaderModifier defines a schema for a filter that modifies response
                               headers.
 
+
                               Support: Extended
                             properties:
                               add:
@@ -1365,14 +1543,17 @@ spec:
                                   before the action. It appends to any existing values associated
                                   with the header name.
 
+
                                   Input:
                                     GET /foo HTTP/1.1
                                     my-header: foo
+
 
                                   Config:
                                     add:
                                     - name: "my-header"
                                       value: "bar,baz"
+
 
                                   Output:
                                     GET /foo HTTP/1.1
@@ -1385,6 +1566,7 @@ spec:
                                       description: |-
                                         Name is the name of the HTTP Header to be matched. Name matching MUST be
                                         case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
 
                                         If multiple entries specify equivalent header names, the first entry with
                                         an equivalent name MUST be considered for a match. Subsequent entries
@@ -1417,14 +1599,17 @@ spec:
                                   names are case-insensitive (see
                                   https://datatracker.ietf.org/doc/html/rfc2616#section-4.2).
 
+
                                   Input:
                                     GET /foo HTTP/1.1
                                     my-header1: foo
                                     my-header2: bar
                                     my-header3: baz
 
+
                                   Config:
                                     remove: ["my-header1", "my-header3"]
+
 
                                   Output:
                                     GET /foo HTTP/1.1
@@ -1439,14 +1624,17 @@ spec:
                                   Set overwrites the request with the given header (name, value)
                                   before the action.
 
+
                                   Input:
                                     GET /foo HTTP/1.1
                                     my-header: foo
+
 
                                   Config:
                                     set:
                                     - name: "my-header"
                                       value: "bar"
+
 
                                   Output:
                                     GET /foo HTTP/1.1
@@ -1459,6 +1647,7 @@ spec:
                                       description: |-
                                         Name is the name of the HTTP Header to be matched. Name matching MUST be
                                         case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
 
                                         If multiple entries specify equivalent header names, the first entry with
                                         an equivalent name MUST be considered for a match. Subsequent entries
@@ -1490,13 +1679,16 @@ spec:
                               Type identifies the type of filter to apply. As with other API fields,
                               types are classified into three conformance levels:
 
+
                               - Core: Filter types and their corresponding configuration defined by
                                 "Support: Core" in this package, e.g. "RequestHeaderModifier". All
                                 implementations supporting GRPCRoute MUST support core filters.
 
+
                               - Extended: Filter types and their corresponding configuration defined by
                                 "Support: Extended" in this package, e.g. "RequestMirror". Implementers
                                 are encouraged to support extended filters.
+
 
                               - Implementation-specific: Filters that are defined and supported by specific vendors.
                                 In the future, filters showing convergence in behavior across multiple
@@ -1505,12 +1697,15 @@ spec:
                                 is specified using the ExtensionRef field. `Type` MUST be set to
                                 "ExtensionRef" for custom filters.
 
+
                               Implementers are encouraged to define custom implementation types to
                               extend the core API with implementation-specific behavior.
+
 
                               If a reference to a custom filter type cannot be resolved, the filter
                               MUST NOT be skipped. Instead, requests that would have been processed by
                               that filter MUST receive a HTTP error response.
+
 
                             enum:
                             - ResponseHeaderModifier
@@ -1565,7 +1760,9 @@ spec:
                         gRPC requests. Each match is independent, i.e. this rule will be matched
                         if **any** one of the matches is satisfied.
 
+
                         For example, take the following matches configuration:
+
 
                         ```
                         matches:
@@ -1578,21 +1775,27 @@ spec:
                             service: foo.bar.v2
                         ```
 
+
                         For a request to match against this rule, it MUST satisfy
                         EITHER of the two conditions:
+
 
                         - service of foo.bar AND contains the header `version: 2`
                         - service of foo.bar.v2
 
+
                         See the documentation for GRPCRouteMatch on how to specify multiple
                         match conditions to be ANDed together.
 
+
                         If no matches are specified, the implementation MUST match every gRPC request.
+
 
                         Proxy or Load Balancer routing configuration generated from GRPCRoutes
                         MUST prioritize rules based on the following criteria, continuing on
                         ties. Merging MUST not be done between GRPCRoutes and HTTPRoutes.
                         Precedence MUST be given to the rule with the largest number of:
+
 
                         * Characters in a matching non-wildcard hostname.
                         * Characters in a matching hostname.
@@ -1600,12 +1803,15 @@ spec:
                         * Characters in a matching method.
                         * Header matches.
 
+
                         If ties still exist across multiple Routes, matching precedence MUST be
                         determined in order of the following criteria, continuing on ties:
+
 
                         * The oldest Route based on creation timestamp.
                         * The Route appearing first in alphabetical order by
                           "{namespace}/{name}".
+
 
                         If ties still exist within the Route that has been given precedence,
                         matching precedence MUST be granted to the first matching rule meeting
@@ -1616,8 +1822,10 @@ spec:
                           action. Multiple match types are ANDed together, i.e. the match will
                           evaluate to true only if all conditions are satisfied.
 
+
                           For example, the match below will match a gRPC request only if its service
                           is `foo` AND it contains the `version: v1` header:
+
 
                           ```
                           matches:
@@ -1627,6 +1835,7 @@ spec:
                               headers:
                             - name: "version"
                               value "v1"
+
 
                           ```
                         properties:
@@ -1643,6 +1852,7 @@ spec:
                                 name:
                                   description: |-
                                     Name is the name of the gRPC Header to be matched.
+
 
                                     If multiple entries specify equivalent header names, only the first
                                     entry with an equivalent name MUST be considered for a match. Subsequent
@@ -1686,6 +1896,7 @@ spec:
                                   Value of the method to match against. If left empty or omitted, will
                                   match all services.
 
+
                                   At least one of Service and Method MUST be a non-empty string.
                                 maxLength: 1024
                                 type: string
@@ -1693,6 +1904,7 @@ spec:
                                 description: |-
                                   Value of the service to match against. If left empty or omitted, will
                                   match any service.
+
 
                                   At least one of Service and Method MUST be a non-empty string.
                                 maxLength: 1024
@@ -1703,7 +1915,9 @@ spec:
                                   Type specifies how to match against the service and/or method.
                                   Support: Core (Exact with service and method specified)
 
+
                                   Support: Implementation-specific (Exact with method specified but no service specified)
+
 
                                   Support: Implementation-specific (RegularExpression)
                                 enum:
@@ -1729,30 +1943,109 @@ spec:
                         type: object
                       maxItems: 8
                       type: array
+                    sessionPersistence:
+                      description: |+
+                        SessionPersistence defines and configures session persistence
+                        for the route rule.
+
+
+                        Support: Extended
+
+
+                      properties:
+                        absoluteTimeout:
+                          description: |-
+                            AbsoluteTimeout defines the absolute timeout of the persistent
+                            session. Once the AbsoluteTimeout duration has elapsed, the
+                            session becomes invalid.
+
+
+                            Support: Extended
+                          pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                          type: string
+                        cookieConfig:
+                          description: |-
+                            CookieConfig provides configuration settings that are specific
+                            to cookie-based session persistence.
+
+
+                            Support: Core
+                          properties:
+                            lifetimeType:
+                              default: Session
+                              description: |-
+                                LifetimeType specifies whether the cookie has a permanent or
+                                session-based lifetime. A permanent cookie persists until its
+                                specified expiry time, defined by the Expires or Max-Age cookie
+                                attributes, while a session cookie is deleted when the current
+                                session ends.
+
+
+                                When set to "Permanent", AbsoluteTimeout indicates the
+                                cookie's lifetime via the Expires or Max-Age cookie attributes
+                                and is required.
+
+
+                                When set to "Session", AbsoluteTimeout indicates the
+                                absolute lifetime of the cookie tracked by the gateway and
+                                is optional.
+
+
+                                Support: Core for "Session" type
+
+
+                                Support: Extended for "Permanent" type
+                              enum:
+                              - Permanent
+                              - Session
+                              type: string
+                          type: object
+                        idleTimeout:
+                          description: |-
+                            IdleTimeout defines the idle timeout of the persistent session.
+                            Once the session has been idle for more than the specified
+                            IdleTimeout duration, the session becomes invalid.
+
+
+                            Support: Extended
+                          pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                          type: string
+                        sessionName:
+                          description: |-
+                            SessionName defines the name of the persistent session token
+                            which may be reflected in the cookie or the header. Users
+                            should avoid reusing session names to prevent unintended
+                            consequences, such as rejection or unpredictable behavior.
+
+
+                            Support: Implementation-specific
+                          maxLength: 128
+                          type: string
+                        type:
+                          default: Cookie
+                          description: |-
+                            Type defines the type of session persistence such as through
+                            the use a header or cookie. Defaults to cookie based session
+                            persistence.
+
+
+                            Support: Core for "Cookie" type
+
+
+                            Support: Extended for "Header" type
+                          enum:
+                          - Cookie
+                          - Header
+                          type: string
+                      type: object
+                      x-kubernetes-validations:
+                      - message: AbsoluteTimeout must be specified when cookie lifetimeType
+                          is Permanent
+                        rule: '!has(self.cookieConfig.lifetimeType) || self.cookieConfig.lifetimeType
+                          != ''Permanent'' || has(self.absoluteTimeout)'
                   type: object
                 maxItems: 16
                 type: array
-                x-kubernetes-validations:
-                - message: While 16 rules and 64 matches per rule are allowed, the
-                    total number of matches across all rules in a route must be less
-                    than 128
-                  rule: '(self.size() > 0 ? (has(self[0].matches) ? self[0].matches.size()
-                    : 0) : 0) + (self.size() > 1 ? (has(self[1].matches) ? self[1].matches.size()
-                    : 0) : 0) + (self.size() > 2 ? (has(self[2].matches) ? self[2].matches.size()
-                    : 0) : 0) + (self.size() > 3 ? (has(self[3].matches) ? self[3].matches.size()
-                    : 0) : 0) + (self.size() > 4 ? (has(self[4].matches) ? self[4].matches.size()
-                    : 0) : 0) + (self.size() > 5 ? (has(self[5].matches) ? self[5].matches.size()
-                    : 0) : 0) + (self.size() > 6 ? (has(self[6].matches) ? self[6].matches.size()
-                    : 0) : 0) + (self.size() > 7 ? (has(self[7].matches) ? self[7].matches.size()
-                    : 0) : 0) + (self.size() > 8 ? (has(self[8].matches) ? self[8].matches.size()
-                    : 0) : 0) + (self.size() > 9 ? (has(self[9].matches) ? self[9].matches.size()
-                    : 0) : 0) + (self.size() > 10 ? (has(self[10].matches) ? self[10].matches.size()
-                    : 0) : 0) + (self.size() > 11 ? (has(self[11].matches) ? self[11].matches.size()
-                    : 0) : 0) + (self.size() > 12 ? (has(self[12].matches) ? self[12].matches.size()
-                    : 0) : 0) + (self.size() > 13 ? (has(self[13].matches) ? self[13].matches.size()
-                    : 0) : 0) + (self.size() > 14 ? (has(self[14].matches) ? self[14].matches.size()
-                    : 0) : 0) + (self.size() > 15 ? (has(self[15].matches) ? self[15].matches.size()
-                    : 0) : 0) <= 128'
             type: object
           status:
             description: Status defines the current state of GRPCRoute.
@@ -1766,10 +2059,12 @@ spec:
                   first sees the route and should update the entry as appropriate when the
                   route or gateway is modified.
 
+
                   Note that parent references that cannot be resolved by an implementation
                   of this API will not be added to this list. Implementations of this API
                   can only populate Route status for the Gateways/parent resources they are
                   responsible for.
+
 
                   A maximum of 32 Gateways will be represented in this list. An empty list
                   means the route has not been attached to any Gateway.
@@ -1784,24 +2079,38 @@ spec:
                         Note that the route's availability is also subject to the Gateway's own
                         status conditions and listener status.
 
+
                         If the Route's ParentRef specifies an existing Gateway that supports
                         Routes of this kind AND that Gateway's controller has sufficient access,
                         then that Gateway's controller MUST set the "Accepted" condition on the
                         Route, to indicate whether the route has been accepted or rejected by the
                         Gateway, and why.
 
+
                         A Route MUST be considered "Accepted" if at least one of the Route's
                         rules is implemented by the Gateway.
 
+
                         There are a number of cases where the "Accepted" condition may not be set
                         due to lack of controller visibility, that includes when:
+
 
                         * The Route refers to a non-existent parent.
                         * The Route is of a type that the controller does not support.
                         * The Route is in a namespace the controller does not have access to.
                       items:
-                        description: Condition contains details for one aspect of
-                          the current state of this API Resource.
+                        description: "Condition contains details for one aspect of
+                          the current state of this API Resource.\n---\nThis struct
+                          is intended for direct use as an array at the field path
+                          .status.conditions.  For example,\n\n\n\ttype FooStatus
+                          struct{\n\t    // Represents the observations of a foo's
+                          current state.\n\t    // Known .status.conditions.type are:
+                          \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                          +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    //
+                          +listType=map\n\t    // +listMapKey=type\n\t    Conditions
+                          []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\"
+                          patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                          \   // other fields\n\t}"
                         properties:
                           lastTransitionTime:
                             description: |-
@@ -1843,7 +2152,12 @@ spec:
                             - Unknown
                             type: string
                           type:
-                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                            description: |-
+                              type of condition in CamelCase or in foo.example.com/CamelCase.
+                              ---
+                              Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                              useful (see .node.status.conditions), the ability to deconflict is important.
+                              The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
                             maxLength: 316
                             pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                             type: string
@@ -1866,11 +2180,14 @@ spec:
                         controller that wrote this status. This corresponds with the
                         controllerName field on GatewayClass.
 
+
                         Example: "example.net/gateway-controller".
+
 
                         The format of this field is DOMAIN "/" PATH, where DOMAIN and PATH are
                         valid Kubernetes names
                         (https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names).
+
 
                         Controllers MUST populate this field when writing status. Controllers should ensure that
                         entries to status populated with their ControllerName are cleaned up when they are no
@@ -1892,6 +2209,7 @@ spec:
                             To set the core API group (such as for a "Service" kind referent),
                             Group must be explicitly set to "" (empty string).
 
+
                             Support: Core
                           maxLength: 253
                           pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
@@ -1901,10 +2219,13 @@ spec:
                           description: |-
                             Kind is kind of the referent.
 
+
                             There are two kinds of parent resources with "Core" support:
+
 
                             * Gateway (Gateway conformance profile)
                             * Service (Mesh conformance profile, ClusterIP Services only)
+
 
                             Support for other resources is Implementation-Specific.
                           maxLength: 63
@@ -1915,6 +2236,7 @@ spec:
                           description: |-
                             Name is the name of the referent.
 
+
                             Support: Core
                           maxLength: 253
                           minLength: 1
@@ -1924,11 +2246,25 @@ spec:
                             Namespace is the namespace of the referent. When unspecified, this refers
                             to the local namespace of the Route.
 
+
                             Note that there are specific rules for ParentRefs which cross namespace
                             boundaries. Cross-namespace references are only valid if they are explicitly
                             allowed by something in the namespace they are referring to. For example:
                             Gateway has the AllowedRoutes field, and ReferenceGrant provides a
                             generic way to enable any other kind of cross-namespace reference.
+
+
+
+                            ParentRefs from a Route to a Service in the same namespace are "producer"
+                            routes, which apply default routing rules to inbound connections from
+                            any namespace to the Service.
+
+
+                            ParentRefs from a Route to a Service in a different namespace are
+                            "consumer" routes, and these routing rules are only applied to outbound
+                            connections originating from the same namespace as the Route, for which
+                            the intended destination of the connections are a Service targeted as a
+                            ParentRef of the Route.
 
 
 
@@ -1942,6 +2278,7 @@ spec:
                             Port is the network port this Route targets. It can be interpreted
                             differently based on the type of parent resource.
 
+
                             When the parent resource is a Gateway, this targets all listeners
                             listening on the specified port that also support this kind of Route(and
                             select this Route). It's not recommended to set `Port` unless the
@@ -1952,9 +2289,16 @@ spec:
 
 
 
+                            When the parent resource is a Service, this targets a specific port in the
+                            Service spec. When both Port (experimental) and SectionName are specified,
+                            the name and port of the selected port must match both specified values.
+
+
+
                             Implementations MAY choose to support other parent resources.
                             Implementations supporting other types of parent resources MUST clearly
                             document how/if Port is interpreted.
+
 
                             For the purpose of status, an attachment is considered successful as
                             long as the parent resource accepts it partially. For example, Gateway
@@ -1963,6 +2307,7 @@ spec:
                             from the referencing Route, the Route MUST be considered successfully
                             attached. If no Gateway listeners accept attachment from this Route,
                             the Route MUST be considered detached from the Gateway.
+
 
                             Support: Extended
                           format: int32
@@ -1974,6 +2319,7 @@ spec:
                             SectionName is the name of a section within the target resource. In the
                             following resources, SectionName is interpreted as the following:
 
+
                             * Gateway: Listener name. When both Port (experimental) and SectionName
                             are specified, the name and port of the selected listener must match
                             both specified values.
@@ -1981,9 +2327,11 @@ spec:
                             are specified, the name and port of the selected listener must match
                             both specified values.
 
+
                             Implementations MAY choose to support attaching Routes to other resources.
                             If that is the case, they MUST clearly document how SectionName is
                             interpreted.
+
 
                             When unspecified (empty string), this will reference the entire resource.
                             For the purpose of status, an attachment is considered successful if at
@@ -1993,6 +2341,7 @@ spec:
                             the referencing Route, the Route MUST be considered successfully
                             attached. If no Gateway listeners accept attachment from this Route, the
                             Route MUST be considered detached from the Gateway.
+
 
                             Support: Core
                           maxLength: 253
@@ -2016,6 +2365,2331 @@ spec:
     storage: true
     subresources:
       status: {}
+  - deprecated: true
+    deprecationWarning: The v1alpha2 version of GRPCRoute has been deprecated and
+      will be removed in a future release of the API. Please upgrade to v1.
+    name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: |-
+          GRPCRoute provides a way to route gRPC requests. This includes the capability
+          to match requests by hostname, gRPC service, gRPC method, or HTTP/2 header.
+          Filters can be used to specify additional processing steps. Backends specify
+          where matching requests will be routed.
+
+
+          GRPCRoute falls under extended support within the Gateway API. Within the
+          following specification, the word "MUST" indicates that an implementation
+          supporting GRPCRoute must conform to the indicated requirement, but an
+          implementation not supporting this route type need not follow the requirement
+          unless explicitly indicated.
+
+
+          Implementations supporting `GRPCRoute` with the `HTTPS` `ProtocolType` MUST
+          accept HTTP/2 connections without an initial upgrade from HTTP/1.1, i.e. via
+          ALPN. If the implementation does not support this, then it MUST set the
+          "Accepted" condition to "False" for the affected listener with a reason of
+          "UnsupportedProtocol".  Implementations MAY also accept HTTP/2 connections
+          with an upgrade from HTTP/1.
+
+
+          Implementations supporting `GRPCRoute` with the `HTTP` `ProtocolType` MUST
+          support HTTP/2 over cleartext TCP (h2c,
+          https://www.rfc-editor.org/rfc/rfc7540#section-3.1) without an initial
+          upgrade from HTTP/1.1, i.e. with prior knowledge
+          (https://www.rfc-editor.org/rfc/rfc7540#section-3.4). If the implementation
+          does not support this, then it MUST set the "Accepted" condition to "False"
+          for the affected listener with a reason of "UnsupportedProtocol".
+          Implementations MAY also accept HTTP/2 connections with an upgrade from
+          HTTP/1, i.e. without prior knowledge.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of GRPCRoute.
+            properties:
+              hostnames:
+                description: |-
+                  Hostnames defines a set of hostnames to match against the GRPC
+                  Host header to select a GRPCRoute to process the request. This matches
+                  the RFC 1123 definition of a hostname with 2 notable exceptions:
+
+
+                  1. IPs are not allowed.
+                  2. A hostname may be prefixed with a wildcard label (`*.`). The wildcard
+                     label MUST appear by itself as the first label.
+
+
+                  If a hostname is specified by both the Listener and GRPCRoute, there
+                  MUST be at least one intersecting hostname for the GRPCRoute to be
+                  attached to the Listener. For example:
+
+
+                  * A Listener with `test.example.com` as the hostname matches GRPCRoutes
+                    that have either not specified any hostnames, or have specified at
+                    least one of `test.example.com` or `*.example.com`.
+                  * A Listener with `*.example.com` as the hostname matches GRPCRoutes
+                    that have either not specified any hostnames or have specified at least
+                    one hostname that matches the Listener hostname. For example,
+                    `test.example.com` and `*.example.com` would both match. On the other
+                    hand, `example.com` and `test.example.net` would not match.
+
+
+                  Hostnames that are prefixed with a wildcard label (`*.`) are interpreted
+                  as a suffix match. That means that a match for `*.example.com` would match
+                  both `test.example.com`, and `foo.test.example.com`, but not `example.com`.
+
+
+                  If both the Listener and GRPCRoute have specified hostnames, any
+                  GRPCRoute hostnames that do not match the Listener hostname MUST be
+                  ignored. For example, if a Listener specified `*.example.com`, and the
+                  GRPCRoute specified `test.example.com` and `test.example.net`,
+                  `test.example.net` MUST NOT be considered for a match.
+
+
+                  If both the Listener and GRPCRoute have specified hostnames, and none
+                  match with the criteria above, then the GRPCRoute MUST NOT be accepted by
+                  the implementation. The implementation MUST raise an 'Accepted' Condition
+                  with a status of `False` in the corresponding RouteParentStatus.
+
+
+                  If a Route (A) of type HTTPRoute or GRPCRoute is attached to a
+                  Listener and that listener already has another Route (B) of the other
+                  type attached and the intersection of the hostnames of A and B is
+                  non-empty, then the implementation MUST accept exactly one of these two
+                  routes, determined by the following criteria, in order:
+
+
+                  * The oldest Route based on creation timestamp.
+                  * The Route appearing first in alphabetical order by
+                    "{namespace}/{name}".
+
+
+                  The rejected Route MUST raise an 'Accepted' condition with a status of
+                  'False' in the corresponding RouteParentStatus.
+
+
+                  Support: Core
+                items:
+                  description: |-
+                    Hostname is the fully qualified domain name of a network host. This matches
+                    the RFC 1123 definition of a hostname with 2 notable exceptions:
+
+
+                     1. IPs are not allowed.
+                     2. A hostname may be prefixed with a wildcard label (`*.`). The wildcard
+                        label must appear by itself as the first label.
+
+
+                    Hostname can be "precise" which is a domain name without the terminating
+                    dot of a network host (e.g. "foo.example.com") or "wildcard", which is a
+                    domain name prefixed with a single wildcard label (e.g. `*.example.com`).
+
+
+                    Note that as per RFC1035 and RFC1123, a *label* must consist of lower case
+                    alphanumeric characters or '-', and must start and end with an alphanumeric
+                    character. No other punctuation is allowed.
+                  maxLength: 253
+                  minLength: 1
+                  pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                  type: string
+                maxItems: 16
+                type: array
+              parentRefs:
+                description: |+
+                  ParentRefs references the resources (usually Gateways) that a Route wants
+                  to be attached to. Note that the referenced parent resource needs to
+                  allow this for the attachment to be complete. For Gateways, that means
+                  the Gateway needs to allow attachment from Routes of this kind and
+                  namespace. For Services, that means the Service must either be in the same
+                  namespace for a "producer" route, or the mesh implementation must support
+                  and allow "consumer" routes for the referenced Service. ReferenceGrant is
+                  not applicable for governing ParentRefs to Services - it is not possible to
+                  create a "producer" route for a Service in a different namespace from the
+                  Route.
+
+
+                  There are two kinds of parent resources with "Core" support:
+
+
+                  * Gateway (Gateway conformance profile)
+                  * Service (Mesh conformance profile, ClusterIP Services only)
+
+
+                  This API may be extended in the future to support additional kinds of parent
+                  resources.
+
+
+                  ParentRefs must be _distinct_. This means either that:
+
+
+                  * They select different objects.  If this is the case, then parentRef
+                    entries are distinct. In terms of fields, this means that the
+                    multi-part key defined by `group`, `kind`, `namespace`, and `name` must
+                    be unique across all parentRef entries in the Route.
+                  * They do not select different objects, but for each optional field used,
+                    each ParentRef that selects the same object must set the same set of
+                    optional fields to different values. If one ParentRef sets a
+                    combination of optional fields, all must set the same combination.
+
+
+                  Some examples:
+
+
+                  * If one ParentRef sets `sectionName`, all ParentRefs referencing the
+                    same object must also set `sectionName`.
+                  * If one ParentRef sets `port`, all ParentRefs referencing the same
+                    object must also set `port`.
+                  * If one ParentRef sets `sectionName` and `port`, all ParentRefs
+                    referencing the same object must also set `sectionName` and `port`.
+
+
+                  It is possible to separately reference multiple distinct objects that may
+                  be collapsed by an implementation. For example, some implementations may
+                  choose to merge compatible Gateway Listeners together. If that is the
+                  case, the list of routes attached to those resources should also be
+                  merged.
+
+
+                  Note that for ParentRefs that cross namespace boundaries, there are specific
+                  rules. Cross-namespace references are only valid if they are explicitly
+                  allowed by something in the namespace they are referring to. For example,
+                  Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                  generic way to enable other kinds of cross-namespace reference.
+
+
+
+                  ParentRefs from a Route to a Service in the same namespace are "producer"
+                  routes, which apply default routing rules to inbound connections from
+                  any namespace to the Service.
+
+
+                  ParentRefs from a Route to a Service in a different namespace are
+                  "consumer" routes, and these routing rules are only applied to outbound
+                  connections originating from the same namespace as the Route, for which
+                  the intended destination of the connections are a Service targeted as a
+                  ParentRef of the Route.
+
+
+
+
+
+
+                items:
+                  description: |-
+                    ParentReference identifies an API object (usually a Gateway) that can be considered
+                    a parent of this resource (usually a route). There are two kinds of parent resources
+                    with "Core" support:
+
+
+                    * Gateway (Gateway conformance profile)
+                    * Service (Mesh conformance profile, ClusterIP Services only)
+
+
+                    This API may be extended in the future to support additional kinds of parent
+                    resources.
+
+
+                    The API object must be valid in the cluster; the Group and Kind must
+                    be registered in the cluster for this reference to be valid.
+                  properties:
+                    group:
+                      default: gateway.networking.k8s.io
+                      description: |-
+                        Group is the group of the referent.
+                        When unspecified, "gateway.networking.k8s.io" is inferred.
+                        To set the core API group (such as for a "Service" kind referent),
+                        Group must be explicitly set to "" (empty string).
+
+
+                        Support: Core
+                      maxLength: 253
+                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    kind:
+                      default: Gateway
+                      description: |-
+                        Kind is kind of the referent.
+
+
+                        There are two kinds of parent resources with "Core" support:
+
+
+                        * Gateway (Gateway conformance profile)
+                        * Service (Mesh conformance profile, ClusterIP Services only)
+
+
+                        Support for other resources is Implementation-Specific.
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                      type: string
+                    name:
+                      description: |-
+                        Name is the name of the referent.
+
+
+                        Support: Core
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                    namespace:
+                      description: |-
+                        Namespace is the namespace of the referent. When unspecified, this refers
+                        to the local namespace of the Route.
+
+
+                        Note that there are specific rules for ParentRefs which cross namespace
+                        boundaries. Cross-namespace references are only valid if they are explicitly
+                        allowed by something in the namespace they are referring to. For example:
+                        Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                        generic way to enable any other kind of cross-namespace reference.
+
+
+
+                        ParentRefs from a Route to a Service in the same namespace are "producer"
+                        routes, which apply default routing rules to inbound connections from
+                        any namespace to the Service.
+
+
+                        ParentRefs from a Route to a Service in a different namespace are
+                        "consumer" routes, and these routing rules are only applied to outbound
+                        connections originating from the same namespace as the Route, for which
+                        the intended destination of the connections are a Service targeted as a
+                        ParentRef of the Route.
+
+
+
+                        Support: Core
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                      type: string
+                    port:
+                      description: |-
+                        Port is the network port this Route targets. It can be interpreted
+                        differently based on the type of parent resource.
+
+
+                        When the parent resource is a Gateway, this targets all listeners
+                        listening on the specified port that also support this kind of Route(and
+                        select this Route). It's not recommended to set `Port` unless the
+                        networking behaviors specified in a Route must apply to a specific port
+                        as opposed to a listener(s) whose port(s) may be changed. When both Port
+                        and SectionName are specified, the name and port of the selected listener
+                        must match both specified values.
+
+
+
+                        When the parent resource is a Service, this targets a specific port in the
+                        Service spec. When both Port (experimental) and SectionName are specified,
+                        the name and port of the selected port must match both specified values.
+
+
+
+                        Implementations MAY choose to support other parent resources.
+                        Implementations supporting other types of parent resources MUST clearly
+                        document how/if Port is interpreted.
+
+
+                        For the purpose of status, an attachment is considered successful as
+                        long as the parent resource accepts it partially. For example, Gateway
+                        listeners can restrict which Routes can attach to them by Route kind,
+                        namespace, or hostname. If 1 of 2 Gateway listeners accept attachment
+                        from the referencing Route, the Route MUST be considered successfully
+                        attached. If no Gateway listeners accept attachment from this Route,
+                        the Route MUST be considered detached from the Gateway.
+
+
+                        Support: Extended
+                      format: int32
+                      maximum: 65535
+                      minimum: 1
+                      type: integer
+                    sectionName:
+                      description: |-
+                        SectionName is the name of a section within the target resource. In the
+                        following resources, SectionName is interpreted as the following:
+
+
+                        * Gateway: Listener name. When both Port (experimental) and SectionName
+                        are specified, the name and port of the selected listener must match
+                        both specified values.
+                        * Service: Port name. When both Port (experimental) and SectionName
+                        are specified, the name and port of the selected listener must match
+                        both specified values.
+
+
+                        Implementations MAY choose to support attaching Routes to other resources.
+                        If that is the case, they MUST clearly document how SectionName is
+                        interpreted.
+
+
+                        When unspecified (empty string), this will reference the entire resource.
+                        For the purpose of status, an attachment is considered successful if at
+                        least one section in the parent resource accepts it. For example, Gateway
+                        listeners can restrict which Routes can attach to them by Route kind,
+                        namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from
+                        the referencing Route, the Route MUST be considered successfully
+                        attached. If no Gateway listeners accept attachment from this Route, the
+                        Route MUST be considered detached from the Gateway.
+
+
+                        Support: Core
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                  required:
+                  - name
+                  type: object
+                maxItems: 32
+                type: array
+                x-kubernetes-validations:
+                - message: sectionName or port must be specified when parentRefs includes
+                    2 or more references to the same parent
+                  rule: 'self.all(p1, self.all(p2, p1.group == p2.group && p1.kind
+                    == p2.kind && p1.name == p2.name && (((!has(p1.__namespace__)
+                    || p1.__namespace__ == '''') && (!has(p2.__namespace__) || p2.__namespace__
+                    == '''')) || (has(p1.__namespace__) && has(p2.__namespace__) &&
+                    p1.__namespace__ == p2.__namespace__)) ? ((!has(p1.sectionName)
+                    || p1.sectionName == '''') == (!has(p2.sectionName) || p2.sectionName
+                    == '''') && (!has(p1.port) || p1.port == 0) == (!has(p2.port)
+                    || p2.port == 0)): true))'
+                - message: sectionName or port must be unique when parentRefs includes
+                    2 or more references to the same parent
+                  rule: self.all(p1, self.exists_one(p2, p1.group == p2.group && p1.kind
+                    == p2.kind && p1.name == p2.name && (((!has(p1.__namespace__)
+                    || p1.__namespace__ == '') && (!has(p2.__namespace__) || p2.__namespace__
+                    == '')) || (has(p1.__namespace__) && has(p2.__namespace__) &&
+                    p1.__namespace__ == p2.__namespace__ )) && (((!has(p1.sectionName)
+                    || p1.sectionName == '') && (!has(p2.sectionName) || p2.sectionName
+                    == '')) || ( has(p1.sectionName) && has(p2.sectionName) && p1.sectionName
+                    == p2.sectionName)) && (((!has(p1.port) || p1.port == 0) && (!has(p2.port)
+                    || p2.port == 0)) || (has(p1.port) && has(p2.port) && p1.port
+                    == p2.port))))
+              rules:
+                description: Rules are a list of GRPC matchers, filters and actions.
+                items:
+                  description: |-
+                    GRPCRouteRule defines the semantics for matching a gRPC request based on
+                    conditions (matches), processing it (filters), and forwarding the request to
+                    an API object (backendRefs).
+                  properties:
+                    backendRefs:
+                      description: |-
+                        BackendRefs defines the backend(s) where matching requests should be
+                        sent.
+
+
+                        Failure behavior here depends on how many BackendRefs are specified and
+                        how many are invalid.
+
+
+                        If *all* entries in BackendRefs are invalid, and there are also no filters
+                        specified in this route rule, *all* traffic which matches this rule MUST
+                        receive an `UNAVAILABLE` status.
+
+
+                        See the GRPCBackendRef definition for the rules about what makes a single
+                        GRPCBackendRef invalid.
+
+
+                        When a GRPCBackendRef is invalid, `UNAVAILABLE` statuses MUST be returned for
+                        requests that would have otherwise been routed to an invalid backend. If
+                        multiple backends are specified, and some are invalid, the proportion of
+                        requests that would otherwise have been routed to an invalid backend
+                        MUST receive an `UNAVAILABLE` status.
+
+
+                        For example, if two backends are specified with equal weights, and one is
+                        invalid, 50 percent of traffic MUST receive an `UNAVAILABLE` status.
+                        Implementations may choose how that 50 percent is determined.
+
+
+                        Support: Core for Kubernetes Service
+
+
+                        Support: Implementation-specific for any other resource
+
+
+                        Support for weight: Core
+                      items:
+                        description: |-
+                          GRPCBackendRef defines how a GRPCRoute forwards a gRPC request.
+
+
+                          Note that when a namespace different than the local namespace is specified, a
+                          ReferenceGrant object is required in the referent namespace to allow that
+                          namespace's owner to accept the reference. See the ReferenceGrant
+                          documentation for details.
+
+
+                          <gateway:experimental:description>
+
+
+                          When the BackendRef points to a Kubernetes Service, implementations SHOULD
+                          honor the appProtocol field if it is set for the target Service Port.
+
+
+                          Implementations supporting appProtocol SHOULD recognize the Kubernetes
+                          Standard Application Protocols defined in KEP-3726.
+
+
+                          If a Service appProtocol isn't specified, an implementation MAY infer the
+                          backend protocol through its own means. Implementations MAY infer the
+                          protocol from the Route type referring to the backend Service.
+
+
+                          If a Route is not able to send traffic to the backend using the specified
+                          protocol then the backend is considered invalid. Implementations MUST set the
+                          "ResolvedRefs" condition to "False" with the "UnsupportedProtocol" reason.
+
+
+                          </gateway:experimental:description>
+                        properties:
+                          filters:
+                            description: |-
+                              Filters defined at this level MUST be executed if and only if the
+                              request is being forwarded to the backend defined here.
+
+
+                              Support: Implementation-specific (For broader support of filters, use the
+                              Filters field in GRPCRouteRule.)
+                            items:
+                              description: |-
+                                GRPCRouteFilter defines processing steps that must be completed during the
+                                request or response lifecycle. GRPCRouteFilters are meant as an extension
+                                point to express processing that may be done in Gateway implementations. Some
+                                examples include request or response modification, implementing
+                                authentication strategies, rate-limiting, and traffic shaping. API
+                                guarantee/conformance is defined based on the type of the filter.
+                              properties:
+                                extensionRef:
+                                  description: |-
+                                    ExtensionRef is an optional, implementation-specific extension to the
+                                    "filter" behavior.  For example, resource "myroutefilter" in group
+                                    "networking.example.net"). ExtensionRef MUST NOT be used for core and
+                                    extended filters.
+
+
+                                    Support: Implementation-specific
+
+
+                                    This filter can be used multiple times within the same rule.
+                                  properties:
+                                    group:
+                                      description: |-
+                                        Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                                        When unspecified or empty string, core API group is inferred.
+                                      maxLength: 253
+                                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    kind:
+                                      description: Kind is kind of the referent. For
+                                        example "HTTPRoute" or "Service".
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                      type: string
+                                    name:
+                                      description: Name is the name of the referent.
+                                      maxLength: 253
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                  - group
+                                  - kind
+                                  - name
+                                  type: object
+                                requestHeaderModifier:
+                                  description: |-
+                                    RequestHeaderModifier defines a schema for a filter that modifies request
+                                    headers.
+
+
+                                    Support: Core
+                                  properties:
+                                    add:
+                                      description: |-
+                                        Add adds the given header(s) (name, value) to the request
+                                        before the action. It appends to any existing values associated
+                                        with the header name.
+
+
+                                        Input:
+                                          GET /foo HTTP/1.1
+                                          my-header: foo
+
+
+                                        Config:
+                                          add:
+                                          - name: "my-header"
+                                            value: "bar,baz"
+
+
+                                        Output:
+                                          GET /foo HTTP/1.1
+                                          my-header: foo,bar,baz
+                                      items:
+                                        description: HTTPHeader represents an HTTP
+                                          Header name and value as defined by RFC
+                                          7230.
+                                        properties:
+                                          name:
+                                            description: |-
+                                              Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                              case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+
+                                              If multiple entries specify equivalent header names, the first entry with
+                                              an equivalent name MUST be considered for a match. Subsequent entries
+                                              with an equivalent header name MUST be ignored. Due to the
+                                              case-insensitivity of header names, "foo" and "Foo" are considered
+                                              equivalent.
+                                            maxLength: 256
+                                            minLength: 1
+                                            pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                            type: string
+                                          value:
+                                            description: Value is the value of HTTP
+                                              Header to be matched.
+                                            maxLength: 4096
+                                            minLength: 1
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      maxItems: 16
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - name
+                                      x-kubernetes-list-type: map
+                                    remove:
+                                      description: |-
+                                        Remove the given header(s) from the HTTP request before the action. The
+                                        value of Remove is a list of HTTP header names. Note that the header
+                                        names are case-insensitive (see
+                                        https://datatracker.ietf.org/doc/html/rfc2616#section-4.2).
+
+
+                                        Input:
+                                          GET /foo HTTP/1.1
+                                          my-header1: foo
+                                          my-header2: bar
+                                          my-header3: baz
+
+
+                                        Config:
+                                          remove: ["my-header1", "my-header3"]
+
+
+                                        Output:
+                                          GET /foo HTTP/1.1
+                                          my-header2: bar
+                                      items:
+                                        type: string
+                                      maxItems: 16
+                                      type: array
+                                      x-kubernetes-list-type: set
+                                    set:
+                                      description: |-
+                                        Set overwrites the request with the given header (name, value)
+                                        before the action.
+
+
+                                        Input:
+                                          GET /foo HTTP/1.1
+                                          my-header: foo
+
+
+                                        Config:
+                                          set:
+                                          - name: "my-header"
+                                            value: "bar"
+
+
+                                        Output:
+                                          GET /foo HTTP/1.1
+                                          my-header: bar
+                                      items:
+                                        description: HTTPHeader represents an HTTP
+                                          Header name and value as defined by RFC
+                                          7230.
+                                        properties:
+                                          name:
+                                            description: |-
+                                              Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                              case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+
+                                              If multiple entries specify equivalent header names, the first entry with
+                                              an equivalent name MUST be considered for a match. Subsequent entries
+                                              with an equivalent header name MUST be ignored. Due to the
+                                              case-insensitivity of header names, "foo" and "Foo" are considered
+                                              equivalent.
+                                            maxLength: 256
+                                            minLength: 1
+                                            pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                            type: string
+                                          value:
+                                            description: Value is the value of HTTP
+                                              Header to be matched.
+                                            maxLength: 4096
+                                            minLength: 1
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      maxItems: 16
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - name
+                                      x-kubernetes-list-type: map
+                                  type: object
+                                requestMirror:
+                                  description: |-
+                                    RequestMirror defines a schema for a filter that mirrors requests.
+                                    Requests are sent to the specified destination, but responses from
+                                    that destination are ignored.
+
+
+                                    This filter can be used multiple times within the same rule. Note that
+                                    not all implementations will be able to support mirroring to multiple
+                                    backends.
+
+
+                                    Support: Extended
+                                  properties:
+                                    backendRef:
+                                      description: |-
+                                        BackendRef references a resource where mirrored requests are sent.
+
+
+                                        Mirrored requests must be sent only to a single destination endpoint
+                                        within this BackendRef, irrespective of how many endpoints are present
+                                        within this BackendRef.
+
+
+                                        If the referent cannot be found, this BackendRef is invalid and must be
+                                        dropped from the Gateway. The controller must ensure the "ResolvedRefs"
+                                        condition on the Route status is set to `status: False` and not configure
+                                        this backend in the underlying implementation.
+
+
+                                        If there is a cross-namespace reference to an *existing* object
+                                        that is not allowed by a ReferenceGrant, the controller must ensure the
+                                        "ResolvedRefs"  condition on the Route is set to `status: False`,
+                                        with the "RefNotPermitted" reason and not configure this backend in the
+                                        underlying implementation.
+
+
+                                        In either error case, the Message of the `ResolvedRefs` Condition
+                                        should be used to provide more detail about the problem.
+
+
+                                        Support: Extended for Kubernetes Service
+
+
+                                        Support: Implementation-specific for any other resource
+                                      properties:
+                                        group:
+                                          default: ""
+                                          description: |-
+                                            Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                                            When unspecified or empty string, core API group is inferred.
+                                          maxLength: 253
+                                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                          type: string
+                                        kind:
+                                          default: Service
+                                          description: |-
+                                            Kind is the Kubernetes resource kind of the referent. For example
+                                            "Service".
+
+
+                                            Defaults to "Service" when not specified.
+
+
+                                            ExternalName services can refer to CNAME DNS records that may live
+                                            outside of the cluster and as such are difficult to reason about in
+                                            terms of conformance. They also may not be safe to forward to (see
+                                            CVE-2021-25740 for more information). Implementations SHOULD NOT
+                                            support ExternalName Services.
+
+
+                                            Support: Core (Services with a type other than ExternalName)
+
+
+                                            Support: Implementation-specific (Services with type ExternalName)
+                                          maxLength: 63
+                                          minLength: 1
+                                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                          type: string
+                                        name:
+                                          description: Name is the name of the referent.
+                                          maxLength: 253
+                                          minLength: 1
+                                          type: string
+                                        namespace:
+                                          description: |-
+                                            Namespace is the namespace of the backend. When unspecified, the local
+                                            namespace is inferred.
+
+
+                                            Note that when a namespace different than the local namespace is specified,
+                                            a ReferenceGrant object is required in the referent namespace to allow that
+                                            namespace's owner to accept the reference. See the ReferenceGrant
+                                            documentation for details.
+
+
+                                            Support: Core
+                                          maxLength: 63
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                          type: string
+                                        port:
+                                          description: |-
+                                            Port specifies the destination port number to use for this resource.
+                                            Port is required when the referent is a Kubernetes Service. In this
+                                            case, the port number is the service port number, not the target port.
+                                            For other resources, destination port might be derived from the referent
+                                            resource or this field.
+                                          format: int32
+                                          maximum: 65535
+                                          minimum: 1
+                                          type: integer
+                                      required:
+                                      - name
+                                      type: object
+                                      x-kubernetes-validations:
+                                      - message: Must have port for Service reference
+                                        rule: '(size(self.group) == 0 && self.kind
+                                          == ''Service'') ? has(self.port) : true'
+                                  required:
+                                  - backendRef
+                                  type: object
+                                responseHeaderModifier:
+                                  description: |-
+                                    ResponseHeaderModifier defines a schema for a filter that modifies response
+                                    headers.
+
+
+                                    Support: Extended
+                                  properties:
+                                    add:
+                                      description: |-
+                                        Add adds the given header(s) (name, value) to the request
+                                        before the action. It appends to any existing values associated
+                                        with the header name.
+
+
+                                        Input:
+                                          GET /foo HTTP/1.1
+                                          my-header: foo
+
+
+                                        Config:
+                                          add:
+                                          - name: "my-header"
+                                            value: "bar,baz"
+
+
+                                        Output:
+                                          GET /foo HTTP/1.1
+                                          my-header: foo,bar,baz
+                                      items:
+                                        description: HTTPHeader represents an HTTP
+                                          Header name and value as defined by RFC
+                                          7230.
+                                        properties:
+                                          name:
+                                            description: |-
+                                              Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                              case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+
+                                              If multiple entries specify equivalent header names, the first entry with
+                                              an equivalent name MUST be considered for a match. Subsequent entries
+                                              with an equivalent header name MUST be ignored. Due to the
+                                              case-insensitivity of header names, "foo" and "Foo" are considered
+                                              equivalent.
+                                            maxLength: 256
+                                            minLength: 1
+                                            pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                            type: string
+                                          value:
+                                            description: Value is the value of HTTP
+                                              Header to be matched.
+                                            maxLength: 4096
+                                            minLength: 1
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      maxItems: 16
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - name
+                                      x-kubernetes-list-type: map
+                                    remove:
+                                      description: |-
+                                        Remove the given header(s) from the HTTP request before the action. The
+                                        value of Remove is a list of HTTP header names. Note that the header
+                                        names are case-insensitive (see
+                                        https://datatracker.ietf.org/doc/html/rfc2616#section-4.2).
+
+
+                                        Input:
+                                          GET /foo HTTP/1.1
+                                          my-header1: foo
+                                          my-header2: bar
+                                          my-header3: baz
+
+
+                                        Config:
+                                          remove: ["my-header1", "my-header3"]
+
+
+                                        Output:
+                                          GET /foo HTTP/1.1
+                                          my-header2: bar
+                                      items:
+                                        type: string
+                                      maxItems: 16
+                                      type: array
+                                      x-kubernetes-list-type: set
+                                    set:
+                                      description: |-
+                                        Set overwrites the request with the given header (name, value)
+                                        before the action.
+
+
+                                        Input:
+                                          GET /foo HTTP/1.1
+                                          my-header: foo
+
+
+                                        Config:
+                                          set:
+                                          - name: "my-header"
+                                            value: "bar"
+
+
+                                        Output:
+                                          GET /foo HTTP/1.1
+                                          my-header: bar
+                                      items:
+                                        description: HTTPHeader represents an HTTP
+                                          Header name and value as defined by RFC
+                                          7230.
+                                        properties:
+                                          name:
+                                            description: |-
+                                              Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                              case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+
+                                              If multiple entries specify equivalent header names, the first entry with
+                                              an equivalent name MUST be considered for a match. Subsequent entries
+                                              with an equivalent header name MUST be ignored. Due to the
+                                              case-insensitivity of header names, "foo" and "Foo" are considered
+                                              equivalent.
+                                            maxLength: 256
+                                            minLength: 1
+                                            pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                            type: string
+                                          value:
+                                            description: Value is the value of HTTP
+                                              Header to be matched.
+                                            maxLength: 4096
+                                            minLength: 1
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      maxItems: 16
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - name
+                                      x-kubernetes-list-type: map
+                                  type: object
+                                type:
+                                  description: |+
+                                    Type identifies the type of filter to apply. As with other API fields,
+                                    types are classified into three conformance levels:
+
+
+                                    - Core: Filter types and their corresponding configuration defined by
+                                      "Support: Core" in this package, e.g. "RequestHeaderModifier". All
+                                      implementations supporting GRPCRoute MUST support core filters.
+
+
+                                    - Extended: Filter types and their corresponding configuration defined by
+                                      "Support: Extended" in this package, e.g. "RequestMirror". Implementers
+                                      are encouraged to support extended filters.
+
+
+                                    - Implementation-specific: Filters that are defined and supported by specific vendors.
+                                      In the future, filters showing convergence in behavior across multiple
+                                      implementations will be considered for inclusion in extended or core
+                                      conformance levels. Filter-specific configuration for such filters
+                                      is specified using the ExtensionRef field. `Type` MUST be set to
+                                      "ExtensionRef" for custom filters.
+
+
+                                    Implementers are encouraged to define custom implementation types to
+                                    extend the core API with implementation-specific behavior.
+
+
+                                    If a reference to a custom filter type cannot be resolved, the filter
+                                    MUST NOT be skipped. Instead, requests that would have been processed by
+                                    that filter MUST receive a HTTP error response.
+
+
+                                  enum:
+                                  - ResponseHeaderModifier
+                                  - RequestHeaderModifier
+                                  - RequestMirror
+                                  - ExtensionRef
+                                  type: string
+                              required:
+                              - type
+                              type: object
+                              x-kubernetes-validations:
+                              - message: filter.requestHeaderModifier must be nil
+                                  if the filter.type is not RequestHeaderModifier
+                                rule: '!(has(self.requestHeaderModifier) && self.type
+                                  != ''RequestHeaderModifier'')'
+                              - message: filter.requestHeaderModifier must be specified
+                                  for RequestHeaderModifier filter.type
+                                rule: '!(!has(self.requestHeaderModifier) && self.type
+                                  == ''RequestHeaderModifier'')'
+                              - message: filter.responseHeaderModifier must be nil
+                                  if the filter.type is not ResponseHeaderModifier
+                                rule: '!(has(self.responseHeaderModifier) && self.type
+                                  != ''ResponseHeaderModifier'')'
+                              - message: filter.responseHeaderModifier must be specified
+                                  for ResponseHeaderModifier filter.type
+                                rule: '!(!has(self.responseHeaderModifier) && self.type
+                                  == ''ResponseHeaderModifier'')'
+                              - message: filter.requestMirror must be nil if the filter.type
+                                  is not RequestMirror
+                                rule: '!(has(self.requestMirror) && self.type != ''RequestMirror'')'
+                              - message: filter.requestMirror must be specified for
+                                  RequestMirror filter.type
+                                rule: '!(!has(self.requestMirror) && self.type ==
+                                  ''RequestMirror'')'
+                              - message: filter.extensionRef must be nil if the filter.type
+                                  is not ExtensionRef
+                                rule: '!(has(self.extensionRef) && self.type != ''ExtensionRef'')'
+                              - message: filter.extensionRef must be specified for
+                                  ExtensionRef filter.type
+                                rule: '!(!has(self.extensionRef) && self.type == ''ExtensionRef'')'
+                            maxItems: 16
+                            type: array
+                            x-kubernetes-validations:
+                            - message: RequestHeaderModifier filter cannot be repeated
+                              rule: self.filter(f, f.type == 'RequestHeaderModifier').size()
+                                <= 1
+                            - message: ResponseHeaderModifier filter cannot be repeated
+                              rule: self.filter(f, f.type == 'ResponseHeaderModifier').size()
+                                <= 1
+                          group:
+                            default: ""
+                            description: |-
+                              Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                              When unspecified or empty string, core API group is inferred.
+                            maxLength: 253
+                            pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                            type: string
+                          kind:
+                            default: Service
+                            description: |-
+                              Kind is the Kubernetes resource kind of the referent. For example
+                              "Service".
+
+
+                              Defaults to "Service" when not specified.
+
+
+                              ExternalName services can refer to CNAME DNS records that may live
+                              outside of the cluster and as such are difficult to reason about in
+                              terms of conformance. They also may not be safe to forward to (see
+                              CVE-2021-25740 for more information). Implementations SHOULD NOT
+                              support ExternalName Services.
+
+
+                              Support: Core (Services with a type other than ExternalName)
+
+
+                              Support: Implementation-specific (Services with type ExternalName)
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                            type: string
+                          name:
+                            description: Name is the name of the referent.
+                            maxLength: 253
+                            minLength: 1
+                            type: string
+                          namespace:
+                            description: |-
+                              Namespace is the namespace of the backend. When unspecified, the local
+                              namespace is inferred.
+
+
+                              Note that when a namespace different than the local namespace is specified,
+                              a ReferenceGrant object is required in the referent namespace to allow that
+                              namespace's owner to accept the reference. See the ReferenceGrant
+                              documentation for details.
+
+
+                              Support: Core
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                            type: string
+                          port:
+                            description: |-
+                              Port specifies the destination port number to use for this resource.
+                              Port is required when the referent is a Kubernetes Service. In this
+                              case, the port number is the service port number, not the target port.
+                              For other resources, destination port might be derived from the referent
+                              resource or this field.
+                            format: int32
+                            maximum: 65535
+                            minimum: 1
+                            type: integer
+                          weight:
+                            default: 1
+                            description: |-
+                              Weight specifies the proportion of requests forwarded to the referenced
+                              backend. This is computed as weight/(sum of all weights in this
+                              BackendRefs list). For non-zero values, there may be some epsilon from
+                              the exact proportion defined here depending on the precision an
+                              implementation supports. Weight is not a percentage and the sum of
+                              weights does not need to equal 100.
+
+
+                              If only one backend is specified and it has a weight greater than 0, 100%
+                              of the traffic is forwarded to that backend. If weight is set to 0, no
+                              traffic should be forwarded for this entry. If unspecified, weight
+                              defaults to 1.
+
+
+                              Support for this field varies based on the context where used.
+                            format: int32
+                            maximum: 1000000
+                            minimum: 0
+                            type: integer
+                        required:
+                        - name
+                        type: object
+                        x-kubernetes-validations:
+                        - message: Must have port for Service reference
+                          rule: '(size(self.group) == 0 && self.kind == ''Service'')
+                            ? has(self.port) : true'
+                      maxItems: 16
+                      type: array
+                    filters:
+                      description: |-
+                        Filters define the filters that are applied to requests that match
+                        this rule.
+
+
+                        The effects of ordering of multiple behaviors are currently unspecified.
+                        This can change in the future based on feedback during the alpha stage.
+
+
+                        Conformance-levels at this level are defined based on the type of filter:
+
+
+                        - ALL core filters MUST be supported by all implementations that support
+                          GRPCRoute.
+                        - Implementers are encouraged to support extended filters.
+                        - Implementation-specific custom filters have no API guarantees across
+                          implementations.
+
+
+                        Specifying the same filter multiple times is not supported unless explicitly
+                        indicated in the filter.
+
+
+                        If an implementation can not support a combination of filters, it must clearly
+                        document that limitation. In cases where incompatible or unsupported
+                        filters are specified and cause the `Accepted` condition to be set to status
+                        `False`, implementations may use the `IncompatibleFilters` reason to specify
+                        this configuration error.
+
+
+                        Support: Core
+                      items:
+                        description: |-
+                          GRPCRouteFilter defines processing steps that must be completed during the
+                          request or response lifecycle. GRPCRouteFilters are meant as an extension
+                          point to express processing that may be done in Gateway implementations. Some
+                          examples include request or response modification, implementing
+                          authentication strategies, rate-limiting, and traffic shaping. API
+                          guarantee/conformance is defined based on the type of the filter.
+                        properties:
+                          extensionRef:
+                            description: |-
+                              ExtensionRef is an optional, implementation-specific extension to the
+                              "filter" behavior.  For example, resource "myroutefilter" in group
+                              "networking.example.net"). ExtensionRef MUST NOT be used for core and
+                              extended filters.
+
+
+                              Support: Implementation-specific
+
+
+                              This filter can be used multiple times within the same rule.
+                            properties:
+                              group:
+                                description: |-
+                                  Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                                  When unspecified or empty string, core API group is inferred.
+                                maxLength: 253
+                                pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                type: string
+                              kind:
+                                description: Kind is kind of the referent. For example
+                                  "HTTPRoute" or "Service".
+                                maxLength: 63
+                                minLength: 1
+                                pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                type: string
+                              name:
+                                description: Name is the name of the referent.
+                                maxLength: 253
+                                minLength: 1
+                                type: string
+                            required:
+                            - group
+                            - kind
+                            - name
+                            type: object
+                          requestHeaderModifier:
+                            description: |-
+                              RequestHeaderModifier defines a schema for a filter that modifies request
+                              headers.
+
+
+                              Support: Core
+                            properties:
+                              add:
+                                description: |-
+                                  Add adds the given header(s) (name, value) to the request
+                                  before the action. It appends to any existing values associated
+                                  with the header name.
+
+
+                                  Input:
+                                    GET /foo HTTP/1.1
+                                    my-header: foo
+
+
+                                  Config:
+                                    add:
+                                    - name: "my-header"
+                                      value: "bar,baz"
+
+
+                                  Output:
+                                    GET /foo HTTP/1.1
+                                    my-header: foo,bar,baz
+                                items:
+                                  description: HTTPHeader represents an HTTP Header
+                                    name and value as defined by RFC 7230.
+                                  properties:
+                                    name:
+                                      description: |-
+                                        Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                        case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+
+                                        If multiple entries specify equivalent header names, the first entry with
+                                        an equivalent name MUST be considered for a match. Subsequent entries
+                                        with an equivalent header name MUST be ignored. Due to the
+                                        case-insensitivity of header names, "foo" and "Foo" are considered
+                                        equivalent.
+                                      maxLength: 256
+                                      minLength: 1
+                                      pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                      type: string
+                                    value:
+                                      description: Value is the value of HTTP Header
+                                        to be matched.
+                                      maxLength: 4096
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                maxItems: 16
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                              remove:
+                                description: |-
+                                  Remove the given header(s) from the HTTP request before the action. The
+                                  value of Remove is a list of HTTP header names. Note that the header
+                                  names are case-insensitive (see
+                                  https://datatracker.ietf.org/doc/html/rfc2616#section-4.2).
+
+
+                                  Input:
+                                    GET /foo HTTP/1.1
+                                    my-header1: foo
+                                    my-header2: bar
+                                    my-header3: baz
+
+
+                                  Config:
+                                    remove: ["my-header1", "my-header3"]
+
+
+                                  Output:
+                                    GET /foo HTTP/1.1
+                                    my-header2: bar
+                                items:
+                                  type: string
+                                maxItems: 16
+                                type: array
+                                x-kubernetes-list-type: set
+                              set:
+                                description: |-
+                                  Set overwrites the request with the given header (name, value)
+                                  before the action.
+
+
+                                  Input:
+                                    GET /foo HTTP/1.1
+                                    my-header: foo
+
+
+                                  Config:
+                                    set:
+                                    - name: "my-header"
+                                      value: "bar"
+
+
+                                  Output:
+                                    GET /foo HTTP/1.1
+                                    my-header: bar
+                                items:
+                                  description: HTTPHeader represents an HTTP Header
+                                    name and value as defined by RFC 7230.
+                                  properties:
+                                    name:
+                                      description: |-
+                                        Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                        case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+
+                                        If multiple entries specify equivalent header names, the first entry with
+                                        an equivalent name MUST be considered for a match. Subsequent entries
+                                        with an equivalent header name MUST be ignored. Due to the
+                                        case-insensitivity of header names, "foo" and "Foo" are considered
+                                        equivalent.
+                                      maxLength: 256
+                                      minLength: 1
+                                      pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                      type: string
+                                    value:
+                                      description: Value is the value of HTTP Header
+                                        to be matched.
+                                      maxLength: 4096
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                maxItems: 16
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                            type: object
+                          requestMirror:
+                            description: |-
+                              RequestMirror defines a schema for a filter that mirrors requests.
+                              Requests are sent to the specified destination, but responses from
+                              that destination are ignored.
+
+
+                              This filter can be used multiple times within the same rule. Note that
+                              not all implementations will be able to support mirroring to multiple
+                              backends.
+
+
+                              Support: Extended
+                            properties:
+                              backendRef:
+                                description: |-
+                                  BackendRef references a resource where mirrored requests are sent.
+
+
+                                  Mirrored requests must be sent only to a single destination endpoint
+                                  within this BackendRef, irrespective of how many endpoints are present
+                                  within this BackendRef.
+
+
+                                  If the referent cannot be found, this BackendRef is invalid and must be
+                                  dropped from the Gateway. The controller must ensure the "ResolvedRefs"
+                                  condition on the Route status is set to `status: False` and not configure
+                                  this backend in the underlying implementation.
+
+
+                                  If there is a cross-namespace reference to an *existing* object
+                                  that is not allowed by a ReferenceGrant, the controller must ensure the
+                                  "ResolvedRefs"  condition on the Route is set to `status: False`,
+                                  with the "RefNotPermitted" reason and not configure this backend in the
+                                  underlying implementation.
+
+
+                                  In either error case, the Message of the `ResolvedRefs` Condition
+                                  should be used to provide more detail about the problem.
+
+
+                                  Support: Extended for Kubernetes Service
+
+
+                                  Support: Implementation-specific for any other resource
+                                properties:
+                                  group:
+                                    default: ""
+                                    description: |-
+                                      Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                                      When unspecified or empty string, core API group is inferred.
+                                    maxLength: 253
+                                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                    type: string
+                                  kind:
+                                    default: Service
+                                    description: |-
+                                      Kind is the Kubernetes resource kind of the referent. For example
+                                      "Service".
+
+
+                                      Defaults to "Service" when not specified.
+
+
+                                      ExternalName services can refer to CNAME DNS records that may live
+                                      outside of the cluster and as such are difficult to reason about in
+                                      terms of conformance. They also may not be safe to forward to (see
+                                      CVE-2021-25740 for more information). Implementations SHOULD NOT
+                                      support ExternalName Services.
+
+
+                                      Support: Core (Services with a type other than ExternalName)
+
+
+                                      Support: Implementation-specific (Services with type ExternalName)
+                                    maxLength: 63
+                                    minLength: 1
+                                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                    type: string
+                                  name:
+                                    description: Name is the name of the referent.
+                                    maxLength: 253
+                                    minLength: 1
+                                    type: string
+                                  namespace:
+                                    description: |-
+                                      Namespace is the namespace of the backend. When unspecified, the local
+                                      namespace is inferred.
+
+
+                                      Note that when a namespace different than the local namespace is specified,
+                                      a ReferenceGrant object is required in the referent namespace to allow that
+                                      namespace's owner to accept the reference. See the ReferenceGrant
+                                      documentation for details.
+
+
+                                      Support: Core
+                                    maxLength: 63
+                                    minLength: 1
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                    type: string
+                                  port:
+                                    description: |-
+                                      Port specifies the destination port number to use for this resource.
+                                      Port is required when the referent is a Kubernetes Service. In this
+                                      case, the port number is the service port number, not the target port.
+                                      For other resources, destination port might be derived from the referent
+                                      resource or this field.
+                                    format: int32
+                                    maximum: 65535
+                                    minimum: 1
+                                    type: integer
+                                required:
+                                - name
+                                type: object
+                                x-kubernetes-validations:
+                                - message: Must have port for Service reference
+                                  rule: '(size(self.group) == 0 && self.kind == ''Service'')
+                                    ? has(self.port) : true'
+                            required:
+                            - backendRef
+                            type: object
+                          responseHeaderModifier:
+                            description: |-
+                              ResponseHeaderModifier defines a schema for a filter that modifies response
+                              headers.
+
+
+                              Support: Extended
+                            properties:
+                              add:
+                                description: |-
+                                  Add adds the given header(s) (name, value) to the request
+                                  before the action. It appends to any existing values associated
+                                  with the header name.
+
+
+                                  Input:
+                                    GET /foo HTTP/1.1
+                                    my-header: foo
+
+
+                                  Config:
+                                    add:
+                                    - name: "my-header"
+                                      value: "bar,baz"
+
+
+                                  Output:
+                                    GET /foo HTTP/1.1
+                                    my-header: foo,bar,baz
+                                items:
+                                  description: HTTPHeader represents an HTTP Header
+                                    name and value as defined by RFC 7230.
+                                  properties:
+                                    name:
+                                      description: |-
+                                        Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                        case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+
+                                        If multiple entries specify equivalent header names, the first entry with
+                                        an equivalent name MUST be considered for a match. Subsequent entries
+                                        with an equivalent header name MUST be ignored. Due to the
+                                        case-insensitivity of header names, "foo" and "Foo" are considered
+                                        equivalent.
+                                      maxLength: 256
+                                      minLength: 1
+                                      pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                      type: string
+                                    value:
+                                      description: Value is the value of HTTP Header
+                                        to be matched.
+                                      maxLength: 4096
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                maxItems: 16
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                              remove:
+                                description: |-
+                                  Remove the given header(s) from the HTTP request before the action. The
+                                  value of Remove is a list of HTTP header names. Note that the header
+                                  names are case-insensitive (see
+                                  https://datatracker.ietf.org/doc/html/rfc2616#section-4.2).
+
+
+                                  Input:
+                                    GET /foo HTTP/1.1
+                                    my-header1: foo
+                                    my-header2: bar
+                                    my-header3: baz
+
+
+                                  Config:
+                                    remove: ["my-header1", "my-header3"]
+
+
+                                  Output:
+                                    GET /foo HTTP/1.1
+                                    my-header2: bar
+                                items:
+                                  type: string
+                                maxItems: 16
+                                type: array
+                                x-kubernetes-list-type: set
+                              set:
+                                description: |-
+                                  Set overwrites the request with the given header (name, value)
+                                  before the action.
+
+
+                                  Input:
+                                    GET /foo HTTP/1.1
+                                    my-header: foo
+
+
+                                  Config:
+                                    set:
+                                    - name: "my-header"
+                                      value: "bar"
+
+
+                                  Output:
+                                    GET /foo HTTP/1.1
+                                    my-header: bar
+                                items:
+                                  description: HTTPHeader represents an HTTP Header
+                                    name and value as defined by RFC 7230.
+                                  properties:
+                                    name:
+                                      description: |-
+                                        Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                        case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+
+                                        If multiple entries specify equivalent header names, the first entry with
+                                        an equivalent name MUST be considered for a match. Subsequent entries
+                                        with an equivalent header name MUST be ignored. Due to the
+                                        case-insensitivity of header names, "foo" and "Foo" are considered
+                                        equivalent.
+                                      maxLength: 256
+                                      minLength: 1
+                                      pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                      type: string
+                                    value:
+                                      description: Value is the value of HTTP Header
+                                        to be matched.
+                                      maxLength: 4096
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                maxItems: 16
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                            type: object
+                          type:
+                            description: |+
+                              Type identifies the type of filter to apply. As with other API fields,
+                              types are classified into three conformance levels:
+
+
+                              - Core: Filter types and their corresponding configuration defined by
+                                "Support: Core" in this package, e.g. "RequestHeaderModifier". All
+                                implementations supporting GRPCRoute MUST support core filters.
+
+
+                              - Extended: Filter types and their corresponding configuration defined by
+                                "Support: Extended" in this package, e.g. "RequestMirror". Implementers
+                                are encouraged to support extended filters.
+
+
+                              - Implementation-specific: Filters that are defined and supported by specific vendors.
+                                In the future, filters showing convergence in behavior across multiple
+                                implementations will be considered for inclusion in extended or core
+                                conformance levels. Filter-specific configuration for such filters
+                                is specified using the ExtensionRef field. `Type` MUST be set to
+                                "ExtensionRef" for custom filters.
+
+
+                              Implementers are encouraged to define custom implementation types to
+                              extend the core API with implementation-specific behavior.
+
+
+                              If a reference to a custom filter type cannot be resolved, the filter
+                              MUST NOT be skipped. Instead, requests that would have been processed by
+                              that filter MUST receive a HTTP error response.
+
+
+                            enum:
+                            - ResponseHeaderModifier
+                            - RequestHeaderModifier
+                            - RequestMirror
+                            - ExtensionRef
+                            type: string
+                        required:
+                        - type
+                        type: object
+                        x-kubernetes-validations:
+                        - message: filter.requestHeaderModifier must be nil if the
+                            filter.type is not RequestHeaderModifier
+                          rule: '!(has(self.requestHeaderModifier) && self.type !=
+                            ''RequestHeaderModifier'')'
+                        - message: filter.requestHeaderModifier must be specified
+                            for RequestHeaderModifier filter.type
+                          rule: '!(!has(self.requestHeaderModifier) && self.type ==
+                            ''RequestHeaderModifier'')'
+                        - message: filter.responseHeaderModifier must be nil if the
+                            filter.type is not ResponseHeaderModifier
+                          rule: '!(has(self.responseHeaderModifier) && self.type !=
+                            ''ResponseHeaderModifier'')'
+                        - message: filter.responseHeaderModifier must be specified
+                            for ResponseHeaderModifier filter.type
+                          rule: '!(!has(self.responseHeaderModifier) && self.type
+                            == ''ResponseHeaderModifier'')'
+                        - message: filter.requestMirror must be nil if the filter.type
+                            is not RequestMirror
+                          rule: '!(has(self.requestMirror) && self.type != ''RequestMirror'')'
+                        - message: filter.requestMirror must be specified for RequestMirror
+                            filter.type
+                          rule: '!(!has(self.requestMirror) && self.type == ''RequestMirror'')'
+                        - message: filter.extensionRef must be nil if the filter.type
+                            is not ExtensionRef
+                          rule: '!(has(self.extensionRef) && self.type != ''ExtensionRef'')'
+                        - message: filter.extensionRef must be specified for ExtensionRef
+                            filter.type
+                          rule: '!(!has(self.extensionRef) && self.type == ''ExtensionRef'')'
+                      maxItems: 16
+                      type: array
+                      x-kubernetes-validations:
+                      - message: RequestHeaderModifier filter cannot be repeated
+                        rule: self.filter(f, f.type == 'RequestHeaderModifier').size()
+                          <= 1
+                      - message: ResponseHeaderModifier filter cannot be repeated
+                        rule: self.filter(f, f.type == 'ResponseHeaderModifier').size()
+                          <= 1
+                    matches:
+                      description: |-
+                        Matches define conditions used for matching the rule against incoming
+                        gRPC requests. Each match is independent, i.e. this rule will be matched
+                        if **any** one of the matches is satisfied.
+
+
+                        For example, take the following matches configuration:
+
+
+                        ```
+                        matches:
+                        - method:
+                            service: foo.bar
+                          headers:
+                            values:
+                              version: 2
+                        - method:
+                            service: foo.bar.v2
+                        ```
+
+
+                        For a request to match against this rule, it MUST satisfy
+                        EITHER of the two conditions:
+
+
+                        - service of foo.bar AND contains the header `version: 2`
+                        - service of foo.bar.v2
+
+
+                        See the documentation for GRPCRouteMatch on how to specify multiple
+                        match conditions to be ANDed together.
+
+
+                        If no matches are specified, the implementation MUST match every gRPC request.
+
+
+                        Proxy or Load Balancer routing configuration generated from GRPCRoutes
+                        MUST prioritize rules based on the following criteria, continuing on
+                        ties. Merging MUST not be done between GRPCRoutes and HTTPRoutes.
+                        Precedence MUST be given to the rule with the largest number of:
+
+
+                        * Characters in a matching non-wildcard hostname.
+                        * Characters in a matching hostname.
+                        * Characters in a matching service.
+                        * Characters in a matching method.
+                        * Header matches.
+
+
+                        If ties still exist across multiple Routes, matching precedence MUST be
+                        determined in order of the following criteria, continuing on ties:
+
+
+                        * The oldest Route based on creation timestamp.
+                        * The Route appearing first in alphabetical order by
+                          "{namespace}/{name}".
+
+
+                        If ties still exist within the Route that has been given precedence,
+                        matching precedence MUST be granted to the first matching rule meeting
+                        the above criteria.
+                      items:
+                        description: |-
+                          GRPCRouteMatch defines the predicate used to match requests to a given
+                          action. Multiple match types are ANDed together, i.e. the match will
+                          evaluate to true only if all conditions are satisfied.
+
+
+                          For example, the match below will match a gRPC request only if its service
+                          is `foo` AND it contains the `version: v1` header:
+
+
+                          ```
+                          matches:
+                            - method:
+                              type: Exact
+                              service: "foo"
+                              headers:
+                            - name: "version"
+                              value "v1"
+
+
+                          ```
+                        properties:
+                          headers:
+                            description: |-
+                              Headers specifies gRPC request header matchers. Multiple match values are
+                              ANDed together, meaning, a request MUST match all the specified headers
+                              to select the route.
+                            items:
+                              description: |-
+                                GRPCHeaderMatch describes how to select a gRPC route by matching gRPC request
+                                headers.
+                              properties:
+                                name:
+                                  description: |-
+                                    Name is the name of the gRPC Header to be matched.
+
+
+                                    If multiple entries specify equivalent header names, only the first
+                                    entry with an equivalent name MUST be considered for a match. Subsequent
+                                    entries with an equivalent header name MUST be ignored. Due to the
+                                    case-insensitivity of header names, "foo" and "Foo" are considered
+                                    equivalent.
+                                  maxLength: 256
+                                  minLength: 1
+                                  pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                  type: string
+                                type:
+                                  default: Exact
+                                  description: Type specifies how to match against
+                                    the value of the header.
+                                  enum:
+                                  - Exact
+                                  - RegularExpression
+                                  type: string
+                                value:
+                                  description: Value is the value of the gRPC Header
+                                    to be matched.
+                                  maxLength: 4096
+                                  minLength: 1
+                                  type: string
+                              required:
+                              - name
+                              - value
+                              type: object
+                            maxItems: 16
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                          method:
+                            description: |-
+                              Method specifies a gRPC request service/method matcher. If this field is
+                              not specified, all services and methods will match.
+                            properties:
+                              method:
+                                description: |-
+                                  Value of the method to match against. If left empty or omitted, will
+                                  match all services.
+
+
+                                  At least one of Service and Method MUST be a non-empty string.
+                                maxLength: 1024
+                                type: string
+                              service:
+                                description: |-
+                                  Value of the service to match against. If left empty or omitted, will
+                                  match any service.
+
+
+                                  At least one of Service and Method MUST be a non-empty string.
+                                maxLength: 1024
+                                type: string
+                              type:
+                                default: Exact
+                                description: |-
+                                  Type specifies how to match against the service and/or method.
+                                  Support: Core (Exact with service and method specified)
+
+
+                                  Support: Implementation-specific (Exact with method specified but no service specified)
+
+
+                                  Support: Implementation-specific (RegularExpression)
+                                enum:
+                                - Exact
+                                - RegularExpression
+                                type: string
+                            type: object
+                            x-kubernetes-validations:
+                            - message: One or both of 'service' or 'method' must be
+                                specified
+                              rule: 'has(self.type) ? has(self.service) || has(self.method)
+                                : true'
+                            - message: service must only contain valid characters
+                                (matching ^(?i)\.?[a-z_][a-z_0-9]*(\.[a-z_][a-z_0-9]*)*$)
+                              rule: '(!has(self.type) || self.type == ''Exact'') &&
+                                has(self.service) ? self.service.matches(r"""^(?i)\.?[a-z_][a-z_0-9]*(\.[a-z_][a-z_0-9]*)*$"""):
+                                true'
+                            - message: method must only contain valid characters (matching
+                                ^[A-Za-z_][A-Za-z_0-9]*$)
+                              rule: '(!has(self.type) || self.type == ''Exact'') &&
+                                has(self.method) ? self.method.matches(r"""^[A-Za-z_][A-Za-z_0-9]*$"""):
+                                true'
+                        type: object
+                      maxItems: 8
+                      type: array
+                    sessionPersistence:
+                      description: |+
+                        SessionPersistence defines and configures session persistence
+                        for the route rule.
+
+
+                        Support: Extended
+
+
+                      properties:
+                        absoluteTimeout:
+                          description: |-
+                            AbsoluteTimeout defines the absolute timeout of the persistent
+                            session. Once the AbsoluteTimeout duration has elapsed, the
+                            session becomes invalid.
+
+
+                            Support: Extended
+                          pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                          type: string
+                        cookieConfig:
+                          description: |-
+                            CookieConfig provides configuration settings that are specific
+                            to cookie-based session persistence.
+
+
+                            Support: Core
+                          properties:
+                            lifetimeType:
+                              default: Session
+                              description: |-
+                                LifetimeType specifies whether the cookie has a permanent or
+                                session-based lifetime. A permanent cookie persists until its
+                                specified expiry time, defined by the Expires or Max-Age cookie
+                                attributes, while a session cookie is deleted when the current
+                                session ends.
+
+
+                                When set to "Permanent", AbsoluteTimeout indicates the
+                                cookie's lifetime via the Expires or Max-Age cookie attributes
+                                and is required.
+
+
+                                When set to "Session", AbsoluteTimeout indicates the
+                                absolute lifetime of the cookie tracked by the gateway and
+                                is optional.
+
+
+                                Support: Core for "Session" type
+
+
+                                Support: Extended for "Permanent" type
+                              enum:
+                              - Permanent
+                              - Session
+                              type: string
+                          type: object
+                        idleTimeout:
+                          description: |-
+                            IdleTimeout defines the idle timeout of the persistent session.
+                            Once the session has been idle for more than the specified
+                            IdleTimeout duration, the session becomes invalid.
+
+
+                            Support: Extended
+                          pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                          type: string
+                        sessionName:
+                          description: |-
+                            SessionName defines the name of the persistent session token
+                            which may be reflected in the cookie or the header. Users
+                            should avoid reusing session names to prevent unintended
+                            consequences, such as rejection or unpredictable behavior.
+
+
+                            Support: Implementation-specific
+                          maxLength: 128
+                          type: string
+                        type:
+                          default: Cookie
+                          description: |-
+                            Type defines the type of session persistence such as through
+                            the use a header or cookie. Defaults to cookie based session
+                            persistence.
+
+
+                            Support: Core for "Cookie" type
+
+
+                            Support: Extended for "Header" type
+                          enum:
+                          - Cookie
+                          - Header
+                          type: string
+                      type: object
+                      x-kubernetes-validations:
+                      - message: AbsoluteTimeout must be specified when cookie lifetimeType
+                          is Permanent
+                        rule: '!has(self.cookieConfig.lifetimeType) || self.cookieConfig.lifetimeType
+                          != ''Permanent'' || has(self.absoluteTimeout)'
+                  type: object
+                maxItems: 16
+                type: array
+            type: object
+          status:
+            description: Status defines the current state of GRPCRoute.
+            properties:
+              parents:
+                description: |-
+                  Parents is a list of parent resources (usually Gateways) that are
+                  associated with the route, and the status of the route with respect to
+                  each parent. When this route attaches to a parent, the controller that
+                  manages the parent must add an entry to this list when the controller
+                  first sees the route and should update the entry as appropriate when the
+                  route or gateway is modified.
+
+
+                  Note that parent references that cannot be resolved by an implementation
+                  of this API will not be added to this list. Implementations of this API
+                  can only populate Route status for the Gateways/parent resources they are
+                  responsible for.
+
+
+                  A maximum of 32 Gateways will be represented in this list. An empty list
+                  means the route has not been attached to any Gateway.
+                items:
+                  description: |-
+                    RouteParentStatus describes the status of a route with respect to an
+                    associated Parent.
+                  properties:
+                    conditions:
+                      description: |-
+                        Conditions describes the status of the route with respect to the Gateway.
+                        Note that the route's availability is also subject to the Gateway's own
+                        status conditions and listener status.
+
+
+                        If the Route's ParentRef specifies an existing Gateway that supports
+                        Routes of this kind AND that Gateway's controller has sufficient access,
+                        then that Gateway's controller MUST set the "Accepted" condition on the
+                        Route, to indicate whether the route has been accepted or rejected by the
+                        Gateway, and why.
+
+
+                        A Route MUST be considered "Accepted" if at least one of the Route's
+                        rules is implemented by the Gateway.
+
+
+                        There are a number of cases where the "Accepted" condition may not be set
+                        due to lack of controller visibility, that includes when:
+
+
+                        * The Route refers to a non-existent parent.
+                        * The Route is of a type that the controller does not support.
+                        * The Route is in a namespace the controller does not have access to.
+                      items:
+                        description: "Condition contains details for one aspect of
+                          the current state of this API Resource.\n---\nThis struct
+                          is intended for direct use as an array at the field path
+                          .status.conditions.  For example,\n\n\n\ttype FooStatus
+                          struct{\n\t    // Represents the observations of a foo's
+                          current state.\n\t    // Known .status.conditions.type are:
+                          \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                          +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    //
+                          +listType=map\n\t    // +listMapKey=type\n\t    Conditions
+                          []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\"
+                          patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                          \   // other fields\n\t}"
+                        properties:
+                          lastTransitionTime:
+                            description: |-
+                              lastTransitionTime is the last time the condition transitioned from one status to another.
+                              This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                            format: date-time
+                            type: string
+                          message:
+                            description: |-
+                              message is a human readable message indicating details about the transition.
+                              This may be an empty string.
+                            maxLength: 32768
+                            type: string
+                          observedGeneration:
+                            description: |-
+                              observedGeneration represents the .metadata.generation that the condition was set based upon.
+                              For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                              with respect to the current state of the instance.
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          reason:
+                            description: |-
+                              reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected values and meanings for this field,
+                              and whether the values are considered a guaranteed API.
+                              The value should be a CamelCase string.
+                              This field may not be empty.
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                            - "True"
+                            - "False"
+                            - Unknown
+                            type: string
+                          type:
+                            description: |-
+                              type of condition in CamelCase or in foo.example.com/CamelCase.
+                              ---
+                              Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                              useful (see .node.status.conditions), the ability to deconflict is important.
+                              The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                        - lastTransitionTime
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      maxItems: 8
+                      minItems: 1
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - type
+                      x-kubernetes-list-type: map
+                    controllerName:
+                      description: |-
+                        ControllerName is a domain/path string that indicates the name of the
+                        controller that wrote this status. This corresponds with the
+                        controllerName field on GatewayClass.
+
+
+                        Example: "example.net/gateway-controller".
+
+
+                        The format of this field is DOMAIN "/" PATH, where DOMAIN and PATH are
+                        valid Kubernetes names
+                        (https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names).
+
+
+                        Controllers MUST populate this field when writing status. Controllers should ensure that
+                        entries to status populated with their ControllerName are cleaned up when they are no
+                        longer necessary.
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
+                      type: string
+                    parentRef:
+                      description: |-
+                        ParentRef corresponds with a ParentRef in the spec that this
+                        RouteParentStatus struct describes the status of.
+                      properties:
+                        group:
+                          default: gateway.networking.k8s.io
+                          description: |-
+                            Group is the group of the referent.
+                            When unspecified, "gateway.networking.k8s.io" is inferred.
+                            To set the core API group (such as for a "Service" kind referent),
+                            Group must be explicitly set to "" (empty string).
+
+
+                            Support: Core
+                          maxLength: 253
+                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                        kind:
+                          default: Gateway
+                          description: |-
+                            Kind is kind of the referent.
+
+
+                            There are two kinds of parent resources with "Core" support:
+
+
+                            * Gateway (Gateway conformance profile)
+                            * Service (Mesh conformance profile, ClusterIP Services only)
+
+
+                            Support for other resources is Implementation-Specific.
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                          type: string
+                        name:
+                          description: |-
+                            Name is the name of the referent.
+
+
+                            Support: Core
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: |-
+                            Namespace is the namespace of the referent. When unspecified, this refers
+                            to the local namespace of the Route.
+
+
+                            Note that there are specific rules for ParentRefs which cross namespace
+                            boundaries. Cross-namespace references are only valid if they are explicitly
+                            allowed by something in the namespace they are referring to. For example:
+                            Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                            generic way to enable any other kind of cross-namespace reference.
+
+
+
+                            ParentRefs from a Route to a Service in the same namespace are "producer"
+                            routes, which apply default routing rules to inbound connections from
+                            any namespace to the Service.
+
+
+                            ParentRefs from a Route to a Service in a different namespace are
+                            "consumer" routes, and these routing rules are only applied to outbound
+                            connections originating from the same namespace as the Route, for which
+                            the intended destination of the connections are a Service targeted as a
+                            ParentRef of the Route.
+
+
+
+                            Support: Core
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                          type: string
+                        port:
+                          description: |-
+                            Port is the network port this Route targets. It can be interpreted
+                            differently based on the type of parent resource.
+
+
+                            When the parent resource is a Gateway, this targets all listeners
+                            listening on the specified port that also support this kind of Route(and
+                            select this Route). It's not recommended to set `Port` unless the
+                            networking behaviors specified in a Route must apply to a specific port
+                            as opposed to a listener(s) whose port(s) may be changed. When both Port
+                            and SectionName are specified, the name and port of the selected listener
+                            must match both specified values.
+
+
+
+                            When the parent resource is a Service, this targets a specific port in the
+                            Service spec. When both Port (experimental) and SectionName are specified,
+                            the name and port of the selected port must match both specified values.
+
+
+
+                            Implementations MAY choose to support other parent resources.
+                            Implementations supporting other types of parent resources MUST clearly
+                            document how/if Port is interpreted.
+
+
+                            For the purpose of status, an attachment is considered successful as
+                            long as the parent resource accepts it partially. For example, Gateway
+                            listeners can restrict which Routes can attach to them by Route kind,
+                            namespace, or hostname. If 1 of 2 Gateway listeners accept attachment
+                            from the referencing Route, the Route MUST be considered successfully
+                            attached. If no Gateway listeners accept attachment from this Route,
+                            the Route MUST be considered detached from the Gateway.
+
+
+                            Support: Extended
+                          format: int32
+                          maximum: 65535
+                          minimum: 1
+                          type: integer
+                        sectionName:
+                          description: |-
+                            SectionName is the name of a section within the target resource. In the
+                            following resources, SectionName is interpreted as the following:
+
+
+                            * Gateway: Listener name. When both Port (experimental) and SectionName
+                            are specified, the name and port of the selected listener must match
+                            both specified values.
+                            * Service: Port name. When both Port (experimental) and SectionName
+                            are specified, the name and port of the selected listener must match
+                            both specified values.
+
+
+                            Implementations MAY choose to support attaching Routes to other resources.
+                            If that is the case, they MUST clearly document how SectionName is
+                            interpreted.
+
+
+                            When unspecified (empty string), this will reference the entire resource.
+                            For the purpose of status, an attachment is considered successful if at
+                            least one section in the parent resource accepts it. For example, Gateway
+                            listeners can restrict which Routes can attach to them by Route kind,
+                            namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from
+                            the referencing Route, the Route MUST be considered successfully
+                            attached. If no Gateway listeners accept attachment from this Route, the
+                            Route MUST be considered detached from the Gateway.
+
+
+                            Support: Core
+                          maxLength: 253
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                      required:
+                      - name
+                      type: object
+                  required:
+                  - controllerName
+                  - parentRef
+                  type: object
+                maxItems: 32
+                type: array
+            required:
+            - parents
+            type: object
+        type: object
+    served: true
+    storage: false
 status:
   acceptedNames:
     kind: ""

--- a/platform/gateway-api/chart/templates/httproutes.yaml
+++ b/platform/gateway-api/chart/templates/httproutes.yaml
@@ -1,6 +1,6 @@
 {{/*
   Vendored from kubernetes-sigs/gateway-api {{ index .Chart.Annotations "catalyst.openova.io/upstream-gateway-api-version" }}
-  standard-install.yaml. Do NOT hand-edit annotations / spec — re-vendor
+  experimental-install.yaml. Do NOT hand-edit annotations / spec — re-vendor
   via the script in tests/regenerate.sh when bumping the upstream version
   (also bump catalyst.openova.io/upstream-gateway-api-version in Chart.yaml).
 
@@ -9,17 +9,18 @@
   cluster-scoped infrastructure; deleting them on uninstall would break
   every HTTPRoute on the cluster simultaneously.
 */}}
+
 #
-# config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
+# config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
 #
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/3328
-    gateway.networking.k8s.io/bundle-version: v1.2.0
-    gateway.networking.k8s.io/channel: standard
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/2997
+    gateway.networking.k8s.io/bundle-version: v1.1.0
+    gateway.networking.k8s.io/channel: experimental
   creationTimestamp: null
   name: httproutes.gateway.networking.k8s.io
 spec:
@@ -77,16 +78,20 @@ spec:
                   performing a match and (absent of any applicable header modification
                   configuration) MUST forward this header unmodified to the backend.
 
+
                   Valid values for Hostnames are determined by RFC 1123 definition of a
                   hostname with 2 notable exceptions:
+
 
                   1. IPs are not allowed.
                   2. A hostname may be prefixed with a wildcard label (`*.`). The wildcard
                      label must appear by itself as the first label.
 
+
                   If a hostname is specified by both the Listener and HTTPRoute, there
                   must be at least one intersecting hostname for the HTTPRoute to be
                   attached to the Listener. For example:
+
 
                   * A Listener with `test.example.com` as the hostname matches HTTPRoutes
                     that have either not specified any hostnames, or have specified at
@@ -98,9 +103,11 @@ spec:
                     all match. On the other hand, `example.com` and `test.example.net` would
                     not match.
 
+
                   Hostnames that are prefixed with a wildcard label (`*.`) are interpreted
                   as a suffix match. That means that a match for `*.example.com` would match
                   both `test.example.com`, and `foo.test.example.com`, but not `example.com`.
+
 
                   If both the Listener and HTTPRoute have specified hostnames, any
                   HTTPRoute hostnames that do not match the Listener hostname MUST be
@@ -108,20 +115,25 @@ spec:
                   HTTPRoute specified `test.example.com` and `test.example.net`,
                   `test.example.net` must not be considered for a match.
 
+
                   If both the Listener and HTTPRoute have specified hostnames, and none
                   match with the criteria above, then the HTTPRoute is not accepted. The
                   implementation must raise an 'Accepted' Condition with a status of
                   `False` in the corresponding RouteParentStatus.
 
+
                   In the event that multiple HTTPRoutes specify intersecting hostnames (e.g.
                   overlapping wildcard matching and exact matching hostnames), precedence must
                   be given to rules from the HTTPRoute with the largest number of:
 
+
                   * Characters in a matching non-wildcard hostname.
                   * Characters in a matching hostname.
 
+
                   If ties exist across multiple Routes, the matching precedence rules for
                   HTTPRouteMatches takes over.
+
 
                   Support: Core
                 items:
@@ -129,13 +141,16 @@ spec:
                     Hostname is the fully qualified domain name of a network host. This matches
                     the RFC 1123 definition of a hostname with 2 notable exceptions:
 
+
                      1. IPs are not allowed.
                      2. A hostname may be prefixed with a wildcard label (`*.`). The wildcard
                         label must appear by itself as the first label.
 
+
                     Hostname can be "precise" which is a domain name without the terminating
                     dot of a network host (e.g. "foo.example.com") or "wildcard", which is a
                     domain name prefixed with a single wildcard label (e.g. `*.example.com`).
+
 
                     Note that as per RFC1035 and RFC1123, a *label* must consist of lower case
                     alphanumeric characters or '-', and must start and end with an alphanumeric
@@ -159,15 +174,20 @@ spec:
                   create a "producer" route for a Service in a different namespace from the
                   Route.
 
+
                   There are two kinds of parent resources with "Core" support:
+
 
                   * Gateway (Gateway conformance profile)
                   * Service (Mesh conformance profile, ClusterIP Services only)
 
+
                   This API may be extended in the future to support additional kinds of parent
                   resources.
 
+
                   ParentRefs must be _distinct_. This means either that:
+
 
                   * They select different objects.  If this is the case, then parentRef
                     entries are distinct. In terms of fields, this means that the
@@ -178,7 +198,9 @@ spec:
                     optional fields to different values. If one ParentRef sets a
                     combination of optional fields, all must set the same combination.
 
+
                   Some examples:
+
 
                   * If one ParentRef sets `sectionName`, all ParentRefs referencing the
                     same object must also set `sectionName`.
@@ -187,17 +209,32 @@ spec:
                   * If one ParentRef sets `sectionName` and `port`, all ParentRefs
                     referencing the same object must also set `sectionName` and `port`.
 
+
                   It is possible to separately reference multiple distinct objects that may
                   be collapsed by an implementation. For example, some implementations may
                   choose to merge compatible Gateway Listeners together. If that is the
                   case, the list of routes attached to those resources should also be
                   merged.
 
+
                   Note that for ParentRefs that cross namespace boundaries, there are specific
                   rules. Cross-namespace references are only valid if they are explicitly
                   allowed by something in the namespace they are referring to. For example,
                   Gateway has the AllowedRoutes field, and ReferenceGrant provides a
                   generic way to enable other kinds of cross-namespace reference.
+
+
+
+                  ParentRefs from a Route to a Service in the same namespace are "producer"
+                  routes, which apply default routing rules to inbound connections from
+                  any namespace to the Service.
+
+
+                  ParentRefs from a Route to a Service in a different namespace are
+                  "consumer" routes, and these routing rules are only applied to outbound
+                  connections originating from the same namespace as the Route, for which
+                  the intended destination of the connections are a Service targeted as a
+                  ParentRef of the Route.
 
 
 
@@ -210,11 +247,14 @@ spec:
                     a parent of this resource (usually a route). There are two kinds of parent resources
                     with "Core" support:
 
+
                     * Gateway (Gateway conformance profile)
                     * Service (Mesh conformance profile, ClusterIP Services only)
 
+
                     This API may be extended in the future to support additional kinds of parent
                     resources.
+
 
                     The API object must be valid in the cluster; the Group and Kind must
                     be registered in the cluster for this reference to be valid.
@@ -227,6 +267,7 @@ spec:
                         To set the core API group (such as for a "Service" kind referent),
                         Group must be explicitly set to "" (empty string).
 
+
                         Support: Core
                       maxLength: 253
                       pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
@@ -236,10 +277,13 @@ spec:
                       description: |-
                         Kind is kind of the referent.
 
+
                         There are two kinds of parent resources with "Core" support:
+
 
                         * Gateway (Gateway conformance profile)
                         * Service (Mesh conformance profile, ClusterIP Services only)
+
 
                         Support for other resources is Implementation-Specific.
                       maxLength: 63
@@ -250,6 +294,7 @@ spec:
                       description: |-
                         Name is the name of the referent.
 
+
                         Support: Core
                       maxLength: 253
                       minLength: 1
@@ -259,11 +304,25 @@ spec:
                         Namespace is the namespace of the referent. When unspecified, this refers
                         to the local namespace of the Route.
 
+
                         Note that there are specific rules for ParentRefs which cross namespace
                         boundaries. Cross-namespace references are only valid if they are explicitly
                         allowed by something in the namespace they are referring to. For example:
                         Gateway has the AllowedRoutes field, and ReferenceGrant provides a
                         generic way to enable any other kind of cross-namespace reference.
+
+
+
+                        ParentRefs from a Route to a Service in the same namespace are "producer"
+                        routes, which apply default routing rules to inbound connections from
+                        any namespace to the Service.
+
+
+                        ParentRefs from a Route to a Service in a different namespace are
+                        "consumer" routes, and these routing rules are only applied to outbound
+                        connections originating from the same namespace as the Route, for which
+                        the intended destination of the connections are a Service targeted as a
+                        ParentRef of the Route.
 
 
 
@@ -277,6 +336,7 @@ spec:
                         Port is the network port this Route targets. It can be interpreted
                         differently based on the type of parent resource.
 
+
                         When the parent resource is a Gateway, this targets all listeners
                         listening on the specified port that also support this kind of Route(and
                         select this Route). It's not recommended to set `Port` unless the
@@ -287,9 +347,16 @@ spec:
 
 
 
+                        When the parent resource is a Service, this targets a specific port in the
+                        Service spec. When both Port (experimental) and SectionName are specified,
+                        the name and port of the selected port must match both specified values.
+
+
+
                         Implementations MAY choose to support other parent resources.
                         Implementations supporting other types of parent resources MUST clearly
                         document how/if Port is interpreted.
+
 
                         For the purpose of status, an attachment is considered successful as
                         long as the parent resource accepts it partially. For example, Gateway
@@ -298,6 +365,7 @@ spec:
                         from the referencing Route, the Route MUST be considered successfully
                         attached. If no Gateway listeners accept attachment from this Route,
                         the Route MUST be considered detached from the Gateway.
+
 
                         Support: Extended
                       format: int32
@@ -309,6 +377,7 @@ spec:
                         SectionName is the name of a section within the target resource. In the
                         following resources, SectionName is interpreted as the following:
 
+
                         * Gateway: Listener name. When both Port (experimental) and SectionName
                         are specified, the name and port of the selected listener must match
                         both specified values.
@@ -316,9 +385,11 @@ spec:
                         are specified, the name and port of the selected listener must match
                         both specified values.
 
+
                         Implementations MAY choose to support attaching Routes to other resources.
                         If that is the case, they MUST clearly document how SectionName is
                         interpreted.
+
 
                         When unspecified (empty string), this will reference the entire resource.
                         For the purpose of status, an attachment is considered successful if at
@@ -328,6 +399,7 @@ spec:
                         the referencing Route, the Route MUST be considered successfully
                         attached. If no Gateway listeners accept attachment from this Route, the
                         Route MUST be considered detached from the Gateway.
+
 
                         Support: Core
                       maxLength: 253
@@ -340,34 +412,35 @@ spec:
                 maxItems: 32
                 type: array
                 x-kubernetes-validations:
-                - message: sectionName must be specified when parentRefs includes
+                - message: sectionName or port must be specified when parentRefs includes
                     2 or more references to the same parent
                   rule: 'self.all(p1, self.all(p2, p1.group == p2.group && p1.kind
                     == p2.kind && p1.name == p2.name && (((!has(p1.__namespace__)
                     || p1.__namespace__ == '''') && (!has(p2.__namespace__) || p2.__namespace__
                     == '''')) || (has(p1.__namespace__) && has(p2.__namespace__) &&
-                    p1.__namespace__ == p2.__namespace__ )) ? ((!has(p1.sectionName)
+                    p1.__namespace__ == p2.__namespace__)) ? ((!has(p1.sectionName)
                     || p1.sectionName == '''') == (!has(p2.sectionName) || p2.sectionName
-                    == '''')) : true))'
-                - message: sectionName must be unique when parentRefs includes 2 or
-                    more references to the same parent
+                    == '''') && (!has(p1.port) || p1.port == 0) == (!has(p2.port)
+                    || p2.port == 0)): true))'
+                - message: sectionName or port must be unique when parentRefs includes
+                    2 or more references to the same parent
                   rule: self.all(p1, self.exists_one(p2, p1.group == p2.group && p1.kind
                     == p2.kind && p1.name == p2.name && (((!has(p1.__namespace__)
                     || p1.__namespace__ == '') && (!has(p2.__namespace__) || p2.__namespace__
                     == '')) || (has(p1.__namespace__) && has(p2.__namespace__) &&
                     p1.__namespace__ == p2.__namespace__ )) && (((!has(p1.sectionName)
                     || p1.sectionName == '') && (!has(p2.sectionName) || p2.sectionName
-                    == '')) || (has(p1.sectionName) && has(p2.sectionName) && p1.sectionName
-                    == p2.sectionName))))
+                    == '')) || ( has(p1.sectionName) && has(p2.sectionName) && p1.sectionName
+                    == p2.sectionName)) && (((!has(p1.port) || p1.port == 0) && (!has(p2.port)
+                    || p2.port == 0)) || (has(p1.port) && has(p2.port) && p1.port
+                    == p2.port))))
               rules:
                 default:
                 - matches:
                   - path:
                       type: PathPrefix
                       value: /
-                description: |+
-                  Rules are a list of HTTP matchers, filters and actions.
-
+                description: Rules are a list of HTTP matchers, filters and actions.
                 items:
                   description: |-
                     HTTPRouteRule defines semantics for matching an HTTP request based on
@@ -379,15 +452,19 @@ spec:
                         BackendRefs defines the backend(s) where matching requests should be
                         sent.
 
+
                         Failure behavior here depends on how many BackendRefs are specified and
                         how many are invalid.
+
 
                         If *all* entries in BackendRefs are invalid, and there are also no filters
                         specified in this route rule, *all* traffic which matches this rule MUST
                         receive a 500 status code.
 
+
                         See the HTTPBackendRef definition for the rules about what makes a single
                         HTTPBackendRef invalid.
+
 
                         When a HTTPBackendRef is invalid, 500 status codes MUST be returned for
                         requests that would have otherwise been routed to an invalid backend. If
@@ -395,46 +472,53 @@ spec:
                         requests that would otherwise have been routed to an invalid backend
                         MUST receive a 500 status code.
 
+
                         For example, if two backends are specified with equal weights, and one is
                         invalid, 50 percent of traffic must receive a 500. Implementations may
                         choose how that 50 percent is determined.
 
-                        When a HTTPBackendRef refers to a Service that has no ready endpoints,
-                        implementations SHOULD return a 503 for requests to that backend instead.
-                        If an implementation chooses to do this, all of the above rules for 500 responses
-                        MUST also apply for responses that return a 503.
 
                         Support: Core for Kubernetes Service
 
+
                         Support: Extended for Kubernetes ServiceImport
 
+
                         Support: Implementation-specific for any other resource
+
 
                         Support for weight: Core
                       items:
                         description: |-
                           HTTPBackendRef defines how a HTTPRoute forwards a HTTP request.
 
+
                           Note that when a namespace different than the local namespace is specified, a
                           ReferenceGrant object is required in the referent namespace to allow that
                           namespace's owner to accept the reference. See the ReferenceGrant
                           documentation for details.
 
+
                           <gateway:experimental:description>
+
 
                           When the BackendRef points to a Kubernetes Service, implementations SHOULD
                           honor the appProtocol field if it is set for the target Service Port.
 
+
                           Implementations supporting appProtocol SHOULD recognize the Kubernetes
                           Standard Application Protocols defined in KEP-3726.
+
 
                           If a Service appProtocol isn't specified, an implementation MAY infer the
                           backend protocol through its own means. Implementations MAY infer the
                           protocol from the Route type referring to the backend Service.
 
+
                           If a Route is not able to send traffic to the backend using the specified
                           protocol then the backend is considered invalid. Implementations MUST set the
                           "ResolvedRefs" condition to "False" with the "UnsupportedProtocol" reason.
+
 
                           </gateway:experimental:description>
                         properties:
@@ -442,6 +526,7 @@ spec:
                             description: |-
                               Filters defined at this level should be executed if and only if the
                               request is being forwarded to the backend defined here.
+
 
                               Support: Implementation-specific (For broader support of filters, use the
                               Filters field in HTTPRouteRule.)
@@ -461,7 +546,9 @@ spec:
                                     "networking.example.net"). ExtensionRef MUST NOT be used for core and
                                     extended filters.
 
+
                                     This filter can be used multiple times within the same rule.
+
 
                                     Support: Implementation-specific
                                   properties:
@@ -494,6 +581,7 @@ spec:
                                     RequestHeaderModifier defines a schema for a filter that modifies request
                                     headers.
 
+
                                     Support: Core
                                   properties:
                                     add:
@@ -502,14 +590,17 @@ spec:
                                         before the action. It appends to any existing values associated
                                         with the header name.
 
+
                                         Input:
                                           GET /foo HTTP/1.1
                                           my-header: foo
+
 
                                         Config:
                                           add:
                                           - name: "my-header"
                                             value: "bar,baz"
+
 
                                         Output:
                                           GET /foo HTTP/1.1
@@ -523,6 +614,7 @@ spec:
                                             description: |-
                                               Name is the name of the HTTP Header to be matched. Name matching MUST be
                                               case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
 
                                               If multiple entries specify equivalent header names, the first entry with
                                               an equivalent name MUST be considered for a match. Subsequent entries
@@ -555,14 +647,17 @@ spec:
                                         names are case-insensitive (see
                                         https://datatracker.ietf.org/doc/html/rfc2616#section-4.2).
 
+
                                         Input:
                                           GET /foo HTTP/1.1
                                           my-header1: foo
                                           my-header2: bar
                                           my-header3: baz
 
+
                                         Config:
                                           remove: ["my-header1", "my-header3"]
+
 
                                         Output:
                                           GET /foo HTTP/1.1
@@ -577,14 +672,17 @@ spec:
                                         Set overwrites the request with the given header (name, value)
                                         before the action.
 
+
                                         Input:
                                           GET /foo HTTP/1.1
                                           my-header: foo
+
 
                                         Config:
                                           set:
                                           - name: "my-header"
                                             value: "bar"
+
 
                                         Output:
                                           GET /foo HTTP/1.1
@@ -598,6 +696,7 @@ spec:
                                             description: |-
                                               Name is the name of the HTTP Header to be matched. Name matching MUST be
                                               case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
 
                                               If multiple entries specify equivalent header names, the first entry with
                                               an equivalent name MUST be considered for a match. Subsequent entries
@@ -625,30 +724,34 @@ spec:
                                       x-kubernetes-list-type: map
                                   type: object
                                 requestMirror:
-                                  description: |+
+                                  description: |-
                                     RequestMirror defines a schema for a filter that mirrors requests.
                                     Requests are sent to the specified destination, but responses from
                                     that destination are ignored.
+
 
                                     This filter can be used multiple times within the same rule. Note that
                                     not all implementations will be able to support mirroring to multiple
                                     backends.
 
-                                    Support: Extended
 
+                                    Support: Extended
                                   properties:
                                     backendRef:
                                       description: |-
                                         BackendRef references a resource where mirrored requests are sent.
 
+
                                         Mirrored requests must be sent only to a single destination endpoint
                                         within this BackendRef, irrespective of how many endpoints are present
                                         within this BackendRef.
+
 
                                         If the referent cannot be found, this BackendRef is invalid and must be
                                         dropped from the Gateway. The controller must ensure the "ResolvedRefs"
                                         condition on the Route status is set to `status: False` and not configure
                                         this backend in the underlying implementation.
+
 
                                         If there is a cross-namespace reference to an *existing* object
                                         that is not allowed by a ReferenceGrant, the controller must ensure the
@@ -656,10 +759,13 @@ spec:
                                         with the "RefNotPermitted" reason and not configure this backend in the
                                         underlying implementation.
 
+
                                         In either error case, the Message of the `ResolvedRefs` Condition
                                         should be used to provide more detail about the problem.
 
+
                                         Support: Extended for Kubernetes Service
+
 
                                         Support: Implementation-specific for any other resource
                                       properties:
@@ -677,7 +783,9 @@ spec:
                                             Kind is the Kubernetes resource kind of the referent. For example
                                             "Service".
 
+
                                             Defaults to "Service" when not specified.
+
 
                                             ExternalName services can refer to CNAME DNS records that may live
                                             outside of the cluster and as such are difficult to reason about in
@@ -685,7 +793,9 @@ spec:
                                             CVE-2021-25740 for more information). Implementations SHOULD NOT
                                             support ExternalName Services.
 
+
                                             Support: Core (Services with a type other than ExternalName)
+
 
                                             Support: Implementation-specific (Services with type ExternalName)
                                           maxLength: 63
@@ -702,10 +812,12 @@ spec:
                                             Namespace is the namespace of the backend. When unspecified, the local
                                             namespace is inferred.
 
+
                                             Note that when a namespace different than the local namespace is specified,
                                             a ReferenceGrant object is required in the referent namespace to allow that
                                             namespace's owner to accept the reference. See the ReferenceGrant
                                             documentation for details.
+
 
                                             Support: Core
                                           maxLength: 63
@@ -738,6 +850,7 @@ spec:
                                     RequestRedirect defines a schema for a filter that responds to the
                                     request with an HTTP redirection.
 
+
                                     Support: Core
                                   properties:
                                     hostname:
@@ -745,6 +858,7 @@ spec:
                                         Hostname is the hostname to be used in the value of the `Location`
                                         header in the response.
                                         When empty, the hostname in the `Host` header of the request is used.
+
 
                                         Support: Core
                                       maxLength: 253
@@ -756,6 +870,7 @@ spec:
                                         Path defines parameters used to modify the path of the incoming request.
                                         The modified path is then used to construct the `Location` header. When
                                         empty, the request path is used as-is.
+
 
                                         Support: Extended
                                       properties:
@@ -772,17 +887,32 @@ spec:
                                             to "/foo/bar" with a prefix match of "/foo" and a ReplacePrefixMatch
                                             of "/xyz" would be modified to "/xyz/bar".
 
+
                                             Note that this matches the behavior of the PathPrefix match type. This
                                             matches full path elements. A path element refers to the list of labels
                                             in the path split by the `/` separator. When specified, a trailing `/` is
                                             ignored. For example, the paths `/abc`, `/abc/`, and `/abc/def` would all
                                             match the prefix `/abc`, but the path `/abcd` would not.
 
+
                                             ReplacePrefixMatch is only compatible with a `PathPrefix` HTTPRouteMatch.
                                             Using any other HTTPRouteMatch type on the same HTTPRouteRule will result in
                                             the implementation setting the Accepted Condition for the Route to `status: False`.
 
+
                                             Request Path | Prefix Match | Replace Prefix | Modified Path
+                                            -------------|--------------|----------------|----------
+                                            /foo/bar     | /foo         | /xyz           | /xyz/bar
+                                            /foo/bar     | /foo         | /xyz/          | /xyz/bar
+                                            /foo/bar     | /foo/        | /xyz           | /xyz/bar
+                                            /foo/bar     | /foo/        | /xyz/          | /xyz/bar
+                                            /foo         | /foo         | /xyz           | /xyz
+                                            /foo/        | /foo         | /xyz           | /xyz/
+                                            /foo/bar     | /foo         | <empty string> | /bar
+                                            /foo/        | /foo         | <empty string> | /
+                                            /foo         | /foo         | <empty string> | /
+                                            /foo/        | /foo         | /              | /
+                                            /foo         | /foo         | /              | /
                                           maxLength: 1024
                                           type: string
                                         type:
@@ -790,8 +920,10 @@ spec:
                                             Type defines the type of path modifier. Additional types may be
                                             added in a future release of the API.
 
+
                                             Note that values may be added to this enum, implementations
                                             must ensure that unknown values will not cause a crash.
+
 
                                             Unknown values here must result in the implementation setting the
                                             Accepted Condition for the Route to `status: False`, with a
@@ -825,8 +957,10 @@ spec:
                                         Port is the port to be used in the value of the `Location`
                                         header in the response.
 
+
                                         If no port is specified, the redirect port MUST be derived using the
                                         following rules:
+
 
                                         * If redirect scheme is not-empty, the redirect port MUST be the well-known
                                           port associated with the redirect scheme. Specifically "http" to port 80
@@ -835,13 +969,16 @@ spec:
                                         * If redirect scheme is empty, the redirect port MUST be the Gateway
                                           Listener port.
 
+
                                         Implementations SHOULD NOT add the port number in the 'Location'
                                         header in the following cases:
+
 
                                         * A Location header that will use HTTP (whether that is determined via
                                           the Listener protocol or the Scheme field) _and_ use port 80.
                                         * A Location header that will use HTTPS (whether that is determined via
                                           the Listener protocol or the Scheme field) _and_ use port 443.
+
 
                                         Support: Extended
                                       format: int32
@@ -853,15 +990,19 @@ spec:
                                         Scheme is the scheme to be used in the value of the `Location` header in
                                         the response. When empty, the scheme of the request is used.
 
+
                                         Scheme redirects can affect the port of the redirect, for more information,
                                         refer to the documentation for the port field of this filter.
+
 
                                         Note that values may be added to this enum, implementations
                                         must ensure that unknown values will not cause a crash.
 
+
                                         Unknown values here must result in the implementation setting the
                                         Accepted Condition for the Route to `status: False`, with a
                                         Reason of `UnsupportedValue`.
+
 
                                         Support: Extended
                                       enum:
@@ -873,12 +1014,15 @@ spec:
                                       description: |-
                                         StatusCode is the HTTP status code to be used in response.
 
+
                                         Note that values may be added to this enum, implementations
                                         must ensure that unknown values will not cause a crash.
+
 
                                         Unknown values here must result in the implementation setting the
                                         Accepted Condition for the Route to `status: False`, with a
                                         Reason of `UnsupportedValue`.
+
 
                                         Support: Core
                                       enum:
@@ -891,6 +1035,7 @@ spec:
                                     ResponseHeaderModifier defines a schema for a filter that modifies response
                                     headers.
 
+
                                     Support: Extended
                                   properties:
                                     add:
@@ -899,14 +1044,17 @@ spec:
                                         before the action. It appends to any existing values associated
                                         with the header name.
 
+
                                         Input:
                                           GET /foo HTTP/1.1
                                           my-header: foo
+
 
                                         Config:
                                           add:
                                           - name: "my-header"
                                             value: "bar,baz"
+
 
                                         Output:
                                           GET /foo HTTP/1.1
@@ -920,6 +1068,7 @@ spec:
                                             description: |-
                                               Name is the name of the HTTP Header to be matched. Name matching MUST be
                                               case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
 
                                               If multiple entries specify equivalent header names, the first entry with
                                               an equivalent name MUST be considered for a match. Subsequent entries
@@ -952,14 +1101,17 @@ spec:
                                         names are case-insensitive (see
                                         https://datatracker.ietf.org/doc/html/rfc2616#section-4.2).
 
+
                                         Input:
                                           GET /foo HTTP/1.1
                                           my-header1: foo
                                           my-header2: bar
                                           my-header3: baz
 
+
                                         Config:
                                           remove: ["my-header1", "my-header3"]
+
 
                                         Output:
                                           GET /foo HTTP/1.1
@@ -974,14 +1126,17 @@ spec:
                                         Set overwrites the request with the given header (name, value)
                                         before the action.
 
+
                                         Input:
                                           GET /foo HTTP/1.1
                                           my-header: foo
+
 
                                         Config:
                                           set:
                                           - name: "my-header"
                                             value: "bar"
+
 
                                         Output:
                                           GET /foo HTTP/1.1
@@ -995,6 +1150,7 @@ spec:
                                             description: |-
                                               Name is the name of the HTTP Header to be matched. Name matching MUST be
                                               case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
 
                                               If multiple entries specify equivalent header names, the first entry with
                                               an equivalent name MUST be considered for a match. Subsequent entries
@@ -1026,13 +1182,16 @@ spec:
                                     Type identifies the type of filter to apply. As with other API fields,
                                     types are classified into three conformance levels:
 
+
                                     - Core: Filter types and their corresponding configuration defined by
                                       "Support: Core" in this package, e.g. "RequestHeaderModifier". All
                                       implementations must support core filters.
 
+
                                     - Extended: Filter types and their corresponding configuration defined by
                                       "Support: Extended" in this package, e.g. "RequestMirror". Implementers
                                       are encouraged to support extended filters.
+
 
                                     - Implementation-specific: Filters that are defined and supported by
                                       specific vendors.
@@ -1042,15 +1201,19 @@ spec:
                                       is specified using the ExtensionRef field. `Type` should be set to
                                       "ExtensionRef" for custom filters.
 
+
                                     Implementers are encouraged to define custom implementation types to
                                     extend the core API with implementation-specific behavior.
+
 
                                     If a reference to a custom filter type cannot be resolved, the filter
                                     MUST NOT be skipped. Instead, requests that would have been processed by
                                     that filter MUST receive a HTTP error response.
 
+
                                     Note that values may be added to this enum, implementations
                                     must ensure that unknown values will not cause a crash.
+
 
                                     Unknown values here must result in the implementation setting the
                                     Accepted Condition for the Route to `status: False`, with a
@@ -1067,12 +1230,14 @@ spec:
                                   description: |-
                                     URLRewrite defines a schema for a filter that modifies a request during forwarding.
 
+
                                     Support: Extended
                                   properties:
                                     hostname:
                                       description: |-
                                         Hostname is the value to be used to replace the Host header value during
                                         forwarding.
+
 
                                         Support: Extended
                                       maxLength: 253
@@ -1082,6 +1247,7 @@ spec:
                                     path:
                                       description: |-
                                         Path defines a path rewrite.
+
 
                                         Support: Extended
                                       properties:
@@ -1098,17 +1264,32 @@ spec:
                                             to "/foo/bar" with a prefix match of "/foo" and a ReplacePrefixMatch
                                             of "/xyz" would be modified to "/xyz/bar".
 
+
                                             Note that this matches the behavior of the PathPrefix match type. This
                                             matches full path elements. A path element refers to the list of labels
                                             in the path split by the `/` separator. When specified, a trailing `/` is
                                             ignored. For example, the paths `/abc`, `/abc/`, and `/abc/def` would all
                                             match the prefix `/abc`, but the path `/abcd` would not.
 
+
                                             ReplacePrefixMatch is only compatible with a `PathPrefix` HTTPRouteMatch.
                                             Using any other HTTPRouteMatch type on the same HTTPRouteRule will result in
                                             the implementation setting the Accepted Condition for the Route to `status: False`.
 
+
                                             Request Path | Prefix Match | Replace Prefix | Modified Path
+                                            -------------|--------------|----------------|----------
+                                            /foo/bar     | /foo         | /xyz           | /xyz/bar
+                                            /foo/bar     | /foo         | /xyz/          | /xyz/bar
+                                            /foo/bar     | /foo/        | /xyz           | /xyz/bar
+                                            /foo/bar     | /foo/        | /xyz/          | /xyz/bar
+                                            /foo         | /foo         | /xyz           | /xyz
+                                            /foo/        | /foo         | /xyz           | /xyz/
+                                            /foo/bar     | /foo         | <empty string> | /bar
+                                            /foo/        | /foo         | <empty string> | /
+                                            /foo         | /foo         | <empty string> | /
+                                            /foo/        | /foo         | /              | /
+                                            /foo         | /foo         | /              | /
                                           maxLength: 1024
                                           type: string
                                         type:
@@ -1116,8 +1297,10 @@ spec:
                                             Type defines the type of path modifier. Additional types may be
                                             added in a future release of the API.
 
+
                                             Note that values may be added to this enum, implementations
                                             must ensure that unknown values will not cause a crash.
+
 
                                             Unknown values here must result in the implementation setting the
                                             Accepted Condition for the Route to `status: False`, with a
@@ -1231,7 +1414,9 @@ spec:
                               Kind is the Kubernetes resource kind of the referent. For example
                               "Service".
 
+
                               Defaults to "Service" when not specified.
+
 
                               ExternalName services can refer to CNAME DNS records that may live
                               outside of the cluster and as such are difficult to reason about in
@@ -1239,7 +1424,9 @@ spec:
                               CVE-2021-25740 for more information). Implementations SHOULD NOT
                               support ExternalName Services.
 
+
                               Support: Core (Services with a type other than ExternalName)
+
 
                               Support: Implementation-specific (Services with type ExternalName)
                             maxLength: 63
@@ -1256,10 +1443,12 @@ spec:
                               Namespace is the namespace of the backend. When unspecified, the local
                               namespace is inferred.
 
+
                               Note that when a namespace different than the local namespace is specified,
                               a ReferenceGrant object is required in the referent namespace to allow that
                               namespace's owner to accept the reference. See the ReferenceGrant
                               documentation for details.
+
 
                               Support: Core
                             maxLength: 63
@@ -1287,10 +1476,12 @@ spec:
                               implementation supports. Weight is not a percentage and the sum of
                               weights does not need to equal 100.
 
+
                               If only one backend is specified and it has a weight greater than 0, 100%
                               of the traffic is forwarded to that backend. If weight is set to 0, no
                               traffic should be forwarded for this entry. If unspecified, weight
                               defaults to 1.
+
 
                               Support for this field varies based on the context where used.
                             format: int32
@@ -1311,13 +1502,16 @@ spec:
                         Filters define the filters that are applied to requests that match
                         this rule.
 
+
                         Wherever possible, implementations SHOULD implement filters in the order
                         they are specified.
+
 
                         Implementations MAY choose to implement this ordering strictly, rejecting
                         any combination or order of filters that can not be supported. If implementations
                         choose a strict interpretation of filter ordering, they MUST clearly document
                         that behavior.
+
 
                         To reject an invalid combination or order of filters, implementations SHOULD
                         consider the Route Rules with this configuration invalid. If all Route Rules
@@ -1325,15 +1519,19 @@ spec:
                         a portion of Route Rules are invalid, implementations MUST set the
                         "PartiallyInvalid" condition for the Route.
 
+
                         Conformance-levels at this level are defined based on the type of filter:
+
 
                         - ALL core filters MUST be supported by all implementations.
                         - Implementers are encouraged to support extended filters.
                         - Implementation-specific custom filters have no API guarantees across
                           implementations.
 
+
                         Specifying the same filter multiple times is not supported unless explicitly
                         indicated in the filter.
+
 
                         All filters are expected to be compatible with each other except for the
                         URLRewrite and RequestRedirect filters, which may not be combined. If an
@@ -1342,6 +1540,7 @@ spec:
                         filters are specified and cause the `Accepted` condition to be set to status
                         `False`, implementations may use the `IncompatibleFilters` reason to specify
                         this configuration error.
+
 
                         Support: Core
                       items:
@@ -1360,7 +1559,9 @@ spec:
                               "networking.example.net"). ExtensionRef MUST NOT be used for core and
                               extended filters.
 
+
                               This filter can be used multiple times within the same rule.
+
 
                               Support: Implementation-specific
                             properties:
@@ -1393,6 +1594,7 @@ spec:
                               RequestHeaderModifier defines a schema for a filter that modifies request
                               headers.
 
+
                               Support: Core
                             properties:
                               add:
@@ -1401,14 +1603,17 @@ spec:
                                   before the action. It appends to any existing values associated
                                   with the header name.
 
+
                                   Input:
                                     GET /foo HTTP/1.1
                                     my-header: foo
+
 
                                   Config:
                                     add:
                                     - name: "my-header"
                                       value: "bar,baz"
+
 
                                   Output:
                                     GET /foo HTTP/1.1
@@ -1421,6 +1626,7 @@ spec:
                                       description: |-
                                         Name is the name of the HTTP Header to be matched. Name matching MUST be
                                         case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
 
                                         If multiple entries specify equivalent header names, the first entry with
                                         an equivalent name MUST be considered for a match. Subsequent entries
@@ -1453,14 +1659,17 @@ spec:
                                   names are case-insensitive (see
                                   https://datatracker.ietf.org/doc/html/rfc2616#section-4.2).
 
+
                                   Input:
                                     GET /foo HTTP/1.1
                                     my-header1: foo
                                     my-header2: bar
                                     my-header3: baz
 
+
                                   Config:
                                     remove: ["my-header1", "my-header3"]
+
 
                                   Output:
                                     GET /foo HTTP/1.1
@@ -1475,14 +1684,17 @@ spec:
                                   Set overwrites the request with the given header (name, value)
                                   before the action.
 
+
                                   Input:
                                     GET /foo HTTP/1.1
                                     my-header: foo
+
 
                                   Config:
                                     set:
                                     - name: "my-header"
                                       value: "bar"
+
 
                                   Output:
                                     GET /foo HTTP/1.1
@@ -1495,6 +1707,7 @@ spec:
                                       description: |-
                                         Name is the name of the HTTP Header to be matched. Name matching MUST be
                                         case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
 
                                         If multiple entries specify equivalent header names, the first entry with
                                         an equivalent name MUST be considered for a match. Subsequent entries
@@ -1522,30 +1735,34 @@ spec:
                                 x-kubernetes-list-type: map
                             type: object
                           requestMirror:
-                            description: |+
+                            description: |-
                               RequestMirror defines a schema for a filter that mirrors requests.
                               Requests are sent to the specified destination, but responses from
                               that destination are ignored.
+
 
                               This filter can be used multiple times within the same rule. Note that
                               not all implementations will be able to support mirroring to multiple
                               backends.
 
-                              Support: Extended
 
+                              Support: Extended
                             properties:
                               backendRef:
                                 description: |-
                                   BackendRef references a resource where mirrored requests are sent.
 
+
                                   Mirrored requests must be sent only to a single destination endpoint
                                   within this BackendRef, irrespective of how many endpoints are present
                                   within this BackendRef.
+
 
                                   If the referent cannot be found, this BackendRef is invalid and must be
                                   dropped from the Gateway. The controller must ensure the "ResolvedRefs"
                                   condition on the Route status is set to `status: False` and not configure
                                   this backend in the underlying implementation.
+
 
                                   If there is a cross-namespace reference to an *existing* object
                                   that is not allowed by a ReferenceGrant, the controller must ensure the
@@ -1553,10 +1770,13 @@ spec:
                                   with the "RefNotPermitted" reason and not configure this backend in the
                                   underlying implementation.
 
+
                                   In either error case, the Message of the `ResolvedRefs` Condition
                                   should be used to provide more detail about the problem.
 
+
                                   Support: Extended for Kubernetes Service
+
 
                                   Support: Implementation-specific for any other resource
                                 properties:
@@ -1574,7 +1794,9 @@ spec:
                                       Kind is the Kubernetes resource kind of the referent. For example
                                       "Service".
 
+
                                       Defaults to "Service" when not specified.
+
 
                                       ExternalName services can refer to CNAME DNS records that may live
                                       outside of the cluster and as such are difficult to reason about in
@@ -1582,7 +1804,9 @@ spec:
                                       CVE-2021-25740 for more information). Implementations SHOULD NOT
                                       support ExternalName Services.
 
+
                                       Support: Core (Services with a type other than ExternalName)
+
 
                                       Support: Implementation-specific (Services with type ExternalName)
                                     maxLength: 63
@@ -1599,10 +1823,12 @@ spec:
                                       Namespace is the namespace of the backend. When unspecified, the local
                                       namespace is inferred.
 
+
                                       Note that when a namespace different than the local namespace is specified,
                                       a ReferenceGrant object is required in the referent namespace to allow that
                                       namespace's owner to accept the reference. See the ReferenceGrant
                                       documentation for details.
+
 
                                       Support: Core
                                     maxLength: 63
@@ -1635,6 +1861,7 @@ spec:
                               RequestRedirect defines a schema for a filter that responds to the
                               request with an HTTP redirection.
 
+
                               Support: Core
                             properties:
                               hostname:
@@ -1642,6 +1869,7 @@ spec:
                                   Hostname is the hostname to be used in the value of the `Location`
                                   header in the response.
                                   When empty, the hostname in the `Host` header of the request is used.
+
 
                                   Support: Core
                                 maxLength: 253
@@ -1653,6 +1881,7 @@ spec:
                                   Path defines parameters used to modify the path of the incoming request.
                                   The modified path is then used to construct the `Location` header. When
                                   empty, the request path is used as-is.
+
 
                                   Support: Extended
                                 properties:
@@ -1669,17 +1898,32 @@ spec:
                                       to "/foo/bar" with a prefix match of "/foo" and a ReplacePrefixMatch
                                       of "/xyz" would be modified to "/xyz/bar".
 
+
                                       Note that this matches the behavior of the PathPrefix match type. This
                                       matches full path elements. A path element refers to the list of labels
                                       in the path split by the `/` separator. When specified, a trailing `/` is
                                       ignored. For example, the paths `/abc`, `/abc/`, and `/abc/def` would all
                                       match the prefix `/abc`, but the path `/abcd` would not.
 
+
                                       ReplacePrefixMatch is only compatible with a `PathPrefix` HTTPRouteMatch.
                                       Using any other HTTPRouteMatch type on the same HTTPRouteRule will result in
                                       the implementation setting the Accepted Condition for the Route to `status: False`.
 
+
                                       Request Path | Prefix Match | Replace Prefix | Modified Path
+                                      -------------|--------------|----------------|----------
+                                      /foo/bar     | /foo         | /xyz           | /xyz/bar
+                                      /foo/bar     | /foo         | /xyz/          | /xyz/bar
+                                      /foo/bar     | /foo/        | /xyz           | /xyz/bar
+                                      /foo/bar     | /foo/        | /xyz/          | /xyz/bar
+                                      /foo         | /foo         | /xyz           | /xyz
+                                      /foo/        | /foo         | /xyz           | /xyz/
+                                      /foo/bar     | /foo         | <empty string> | /bar
+                                      /foo/        | /foo         | <empty string> | /
+                                      /foo         | /foo         | <empty string> | /
+                                      /foo/        | /foo         | /              | /
+                                      /foo         | /foo         | /              | /
                                     maxLength: 1024
                                     type: string
                                   type:
@@ -1687,8 +1931,10 @@ spec:
                                       Type defines the type of path modifier. Additional types may be
                                       added in a future release of the API.
 
+
                                       Note that values may be added to this enum, implementations
                                       must ensure that unknown values will not cause a crash.
+
 
                                       Unknown values here must result in the implementation setting the
                                       Accepted Condition for the Route to `status: False`, with a
@@ -1722,8 +1968,10 @@ spec:
                                   Port is the port to be used in the value of the `Location`
                                   header in the response.
 
+
                                   If no port is specified, the redirect port MUST be derived using the
                                   following rules:
+
 
                                   * If redirect scheme is not-empty, the redirect port MUST be the well-known
                                     port associated with the redirect scheme. Specifically "http" to port 80
@@ -1732,13 +1980,16 @@ spec:
                                   * If redirect scheme is empty, the redirect port MUST be the Gateway
                                     Listener port.
 
+
                                   Implementations SHOULD NOT add the port number in the 'Location'
                                   header in the following cases:
+
 
                                   * A Location header that will use HTTP (whether that is determined via
                                     the Listener protocol or the Scheme field) _and_ use port 80.
                                   * A Location header that will use HTTPS (whether that is determined via
                                     the Listener protocol or the Scheme field) _and_ use port 443.
+
 
                                   Support: Extended
                                 format: int32
@@ -1750,15 +2001,19 @@ spec:
                                   Scheme is the scheme to be used in the value of the `Location` header in
                                   the response. When empty, the scheme of the request is used.
 
+
                                   Scheme redirects can affect the port of the redirect, for more information,
                                   refer to the documentation for the port field of this filter.
+
 
                                   Note that values may be added to this enum, implementations
                                   must ensure that unknown values will not cause a crash.
 
+
                                   Unknown values here must result in the implementation setting the
                                   Accepted Condition for the Route to `status: False`, with a
                                   Reason of `UnsupportedValue`.
+
 
                                   Support: Extended
                                 enum:
@@ -1770,12 +2025,15 @@ spec:
                                 description: |-
                                   StatusCode is the HTTP status code to be used in response.
 
+
                                   Note that values may be added to this enum, implementations
                                   must ensure that unknown values will not cause a crash.
+
 
                                   Unknown values here must result in the implementation setting the
                                   Accepted Condition for the Route to `status: False`, with a
                                   Reason of `UnsupportedValue`.
+
 
                                   Support: Core
                                 enum:
@@ -1788,6 +2046,7 @@ spec:
                               ResponseHeaderModifier defines a schema for a filter that modifies response
                               headers.
 
+
                               Support: Extended
                             properties:
                               add:
@@ -1796,14 +2055,17 @@ spec:
                                   before the action. It appends to any existing values associated
                                   with the header name.
 
+
                                   Input:
                                     GET /foo HTTP/1.1
                                     my-header: foo
+
 
                                   Config:
                                     add:
                                     - name: "my-header"
                                       value: "bar,baz"
+
 
                                   Output:
                                     GET /foo HTTP/1.1
@@ -1816,6 +2078,7 @@ spec:
                                       description: |-
                                         Name is the name of the HTTP Header to be matched. Name matching MUST be
                                         case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
 
                                         If multiple entries specify equivalent header names, the first entry with
                                         an equivalent name MUST be considered for a match. Subsequent entries
@@ -1848,14 +2111,17 @@ spec:
                                   names are case-insensitive (see
                                   https://datatracker.ietf.org/doc/html/rfc2616#section-4.2).
 
+
                                   Input:
                                     GET /foo HTTP/1.1
                                     my-header1: foo
                                     my-header2: bar
                                     my-header3: baz
 
+
                                   Config:
                                     remove: ["my-header1", "my-header3"]
+
 
                                   Output:
                                     GET /foo HTTP/1.1
@@ -1870,14 +2136,17 @@ spec:
                                   Set overwrites the request with the given header (name, value)
                                   before the action.
 
+
                                   Input:
                                     GET /foo HTTP/1.1
                                     my-header: foo
+
 
                                   Config:
                                     set:
                                     - name: "my-header"
                                       value: "bar"
+
 
                                   Output:
                                     GET /foo HTTP/1.1
@@ -1890,6 +2159,7 @@ spec:
                                       description: |-
                                         Name is the name of the HTTP Header to be matched. Name matching MUST be
                                         case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
 
                                         If multiple entries specify equivalent header names, the first entry with
                                         an equivalent name MUST be considered for a match. Subsequent entries
@@ -1921,13 +2191,16 @@ spec:
                               Type identifies the type of filter to apply. As with other API fields,
                               types are classified into three conformance levels:
 
+
                               - Core: Filter types and their corresponding configuration defined by
                                 "Support: Core" in this package, e.g. "RequestHeaderModifier". All
                                 implementations must support core filters.
 
+
                               - Extended: Filter types and their corresponding configuration defined by
                                 "Support: Extended" in this package, e.g. "RequestMirror". Implementers
                                 are encouraged to support extended filters.
+
 
                               - Implementation-specific: Filters that are defined and supported by
                                 specific vendors.
@@ -1937,15 +2210,19 @@ spec:
                                 is specified using the ExtensionRef field. `Type` should be set to
                                 "ExtensionRef" for custom filters.
 
+
                               Implementers are encouraged to define custom implementation types to
                               extend the core API with implementation-specific behavior.
+
 
                               If a reference to a custom filter type cannot be resolved, the filter
                               MUST NOT be skipped. Instead, requests that would have been processed by
                               that filter MUST receive a HTTP error response.
 
+
                               Note that values may be added to this enum, implementations
                               must ensure that unknown values will not cause a crash.
+
 
                               Unknown values here must result in the implementation setting the
                               Accepted Condition for the Route to `status: False`, with a
@@ -1962,12 +2239,14 @@ spec:
                             description: |-
                               URLRewrite defines a schema for a filter that modifies a request during forwarding.
 
+
                               Support: Extended
                             properties:
                               hostname:
                                 description: |-
                                   Hostname is the value to be used to replace the Host header value during
                                   forwarding.
+
 
                                   Support: Extended
                                 maxLength: 253
@@ -1977,6 +2256,7 @@ spec:
                               path:
                                 description: |-
                                   Path defines a path rewrite.
+
 
                                   Support: Extended
                                 properties:
@@ -1993,17 +2273,32 @@ spec:
                                       to "/foo/bar" with a prefix match of "/foo" and a ReplacePrefixMatch
                                       of "/xyz" would be modified to "/xyz/bar".
 
+
                                       Note that this matches the behavior of the PathPrefix match type. This
                                       matches full path elements. A path element refers to the list of labels
                                       in the path split by the `/` separator. When specified, a trailing `/` is
                                       ignored. For example, the paths `/abc`, `/abc/`, and `/abc/def` would all
                                       match the prefix `/abc`, but the path `/abcd` would not.
 
+
                                       ReplacePrefixMatch is only compatible with a `PathPrefix` HTTPRouteMatch.
                                       Using any other HTTPRouteMatch type on the same HTTPRouteRule will result in
                                       the implementation setting the Accepted Condition for the Route to `status: False`.
 
+
                                       Request Path | Prefix Match | Replace Prefix | Modified Path
+                                      -------------|--------------|----------------|----------
+                                      /foo/bar     | /foo         | /xyz           | /xyz/bar
+                                      /foo/bar     | /foo         | /xyz/          | /xyz/bar
+                                      /foo/bar     | /foo/        | /xyz           | /xyz/bar
+                                      /foo/bar     | /foo/        | /xyz/          | /xyz/bar
+                                      /foo         | /foo         | /xyz           | /xyz
+                                      /foo/        | /foo         | /xyz           | /xyz/
+                                      /foo/bar     | /foo         | <empty string> | /bar
+                                      /foo/        | /foo         | <empty string> | /
+                                      /foo         | /foo         | <empty string> | /
+                                      /foo/        | /foo         | /              | /
+                                      /foo         | /foo         | /              | /
                                     maxLength: 1024
                                     type: string
                                   type:
@@ -2011,8 +2306,10 @@ spec:
                                       Type defines the type of path modifier. Additional types may be
                                       added in a future release of the API.
 
+
                                       Note that values may be added to this enum, implementations
                                       must ensure that unknown values will not cause a crash.
+
 
                                       Unknown values here must result in the implementation setting the
                                       Accepted Condition for the Route to `status: False`, with a
@@ -2114,7 +2411,9 @@ spec:
                         HTTP requests. Each match is independent, i.e. this rule will be matched
                         if **any** one of the matches is satisfied.
 
+
                         For example, take the following matches configuration:
+
 
                         ```
                         matches:
@@ -2127,23 +2426,29 @@ spec:
                             value: "/v2/foo"
                         ```
 
+
                         For a request to match against this rule, a request must satisfy
                         EITHER of the two conditions:
+
 
                         - path prefixed with `/foo` AND contains the header `version: v2`
                         - path prefix of `/v2/foo`
 
+
                         See the documentation for HTTPRouteMatch on how to specify multiple
                         match conditions that should be ANDed together.
+
 
                         If no matches are specified, the default is a prefix
                         path match on "/", which has the effect of matching every
                         HTTP request.
 
+
                         Proxy or Load Balancer routing configuration generated from HTTPRoutes
                         MUST prioritize matches based on the following criteria, continuing on
                         ties. Across all rules specified on applicable Routes, precedence must be
                         given to the match having:
+
 
                         * "Exact" path match.
                         * "Prefix" path match with largest number of characters.
@@ -2151,18 +2456,23 @@ spec:
                         * Largest number of header matches.
                         * Largest number of query param matches.
 
+
                         Note: The precedence of RegularExpression path matches are implementation-specific.
+
 
                         If ties still exist across multiple Routes, matching precedence MUST be
                         determined in order of the following criteria, continuing on ties:
+
 
                         * The oldest Route based on creation timestamp.
                         * The Route appearing first in alphabetical order by
                           "{namespace}/{name}".
 
+
                         If ties still exist within an HTTPRoute, matching precedence MUST be granted
                         to the FIRST matching rule (in list order) with a match meeting the above
                         criteria.
+
 
                         When no rules matching a request have been successfully attached to the
                         parent a request is coming from, a HTTP 404 status code MUST be returned.
@@ -2170,11 +2480,11 @@ spec:
                         description: "HTTPRouteMatch defines the predicate used to
                           match requests to a given\naction. Multiple match types
                           are ANDed together, i.e. the match will\nevaluate to true
-                          only if all conditions are satisfied.\n\nFor example, the
-                          match below will match a HTTP request only if its path\nstarts
-                          with `/foo` AND it contains the `version: v1` header:\n\n```\nmatch:\n\n\tpath:\n\t
+                          only if all conditions are satisfied.\n\n\nFor example,
+                          the match below will match a HTTP request only if its path\nstarts
+                          with `/foo` AND it contains the `version: v1` header:\n\n\n```\nmatch:\n\n\n\tpath:\n\t
                           \ value: \"/foo\"\n\theaders:\n\t- name: \"version\"\n\t
-                          \ value \"v1\"\n\n```"
+                          \ value \"v1\"\n\n\n```"
                         properties:
                           headers:
                             description: |-
@@ -2191,11 +2501,13 @@ spec:
                                     Name is the name of the HTTP Header to be matched. Name matching MUST be
                                     case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
+
                                     If multiple entries specify equivalent header names, only the first
                                     entry with an equivalent name MUST be considered for a match. Subsequent
                                     entries with an equivalent header name MUST be ignored. Due to the
                                     case-insensitivity of header names, "foo" and "Foo" are considered
                                     equivalent.
+
 
                                     When a header is repeated in an HTTP request, it is
                                     implementation-specific behavior as to how this is represented.
@@ -2211,9 +2523,12 @@ spec:
                                   description: |-
                                     Type specifies how to match against the value of the header.
 
+
                                     Support: Core (Exact)
 
+
                                     Support: Implementation-specific (RegularExpression)
+
 
                                     Since RegularExpression HeaderMatchType has implementation-specific
                                     conformance, implementations can support POSIX, PCRE or any other dialects
@@ -2244,6 +2559,7 @@ spec:
                               When specified, this route will be matched only if the request has the
                               specified method.
 
+
                               Support: Extended
                             enum:
                             - GET
@@ -2269,7 +2585,9 @@ spec:
                                 description: |-
                                   Type specifies how to match against the path Value.
 
+
                                   Support: Core (Exact, PathPrefix)
+
 
                                   Support: Implementation-specific (RegularExpression)
                                 enum:
@@ -2335,6 +2653,7 @@ spec:
                               values are ANDed together, meaning, a request must match all the
                               specified query parameters to select the route.
 
+
                               Support: Extended
                             items:
                               description: |-
@@ -2347,9 +2666,11 @@ spec:
                                     exact string match. (See
                                     https://tools.ietf.org/html/rfc7230#section-2.7.3).
 
+
                                     If multiple entries specify equivalent query param names, only the first
                                     entry with an equivalent name MUST be considered for a match. Subsequent
                                     entries with an equivalent query param name MUST be ignored.
+
 
                                     If a query param is repeated in an HTTP request, the behavior is
                                     purposely left undefined, since different data planes have different
@@ -2357,6 +2678,7 @@ spec:
                                     match against the first value of the param if the data plane supports it,
                                     as this behavior is expected in other load balancing contexts outside of
                                     the Gateway API.
+
 
                                     Users SHOULD NOT route traffic based on repeated query params to guard
                                     themselves against potential differences in the implementations.
@@ -2369,9 +2691,12 @@ spec:
                                   description: |-
                                     Type specifies how to match against the value of the query parameter.
 
+
                                     Support: Extended (Exact)
 
+
                                     Support: Implementation-specific (RegularExpression)
+
 
                                     Since RegularExpression QueryParamMatchType has Implementation-specific
                                     conformance, implementations can support POSIX, PCRE or any other
@@ -2397,13 +2722,116 @@ spec:
                             - name
                             x-kubernetes-list-type: map
                         type: object
-                      maxItems: 64
+                      maxItems: 8
                       type: array
-                    timeouts:
-                      description: |-
-                        Timeouts defines the timeouts that can be configured for an HTTP request.
+                    sessionPersistence:
+                      description: |+
+                        SessionPersistence defines and configures session persistence
+                        for the route rule.
+
 
                         Support: Extended
+
+
+                      properties:
+                        absoluteTimeout:
+                          description: |-
+                            AbsoluteTimeout defines the absolute timeout of the persistent
+                            session. Once the AbsoluteTimeout duration has elapsed, the
+                            session becomes invalid.
+
+
+                            Support: Extended
+                          pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                          type: string
+                        cookieConfig:
+                          description: |-
+                            CookieConfig provides configuration settings that are specific
+                            to cookie-based session persistence.
+
+
+                            Support: Core
+                          properties:
+                            lifetimeType:
+                              default: Session
+                              description: |-
+                                LifetimeType specifies whether the cookie has a permanent or
+                                session-based lifetime. A permanent cookie persists until its
+                                specified expiry time, defined by the Expires or Max-Age cookie
+                                attributes, while a session cookie is deleted when the current
+                                session ends.
+
+
+                                When set to "Permanent", AbsoluteTimeout indicates the
+                                cookie's lifetime via the Expires or Max-Age cookie attributes
+                                and is required.
+
+
+                                When set to "Session", AbsoluteTimeout indicates the
+                                absolute lifetime of the cookie tracked by the gateway and
+                                is optional.
+
+
+                                Support: Core for "Session" type
+
+
+                                Support: Extended for "Permanent" type
+                              enum:
+                              - Permanent
+                              - Session
+                              type: string
+                          type: object
+                        idleTimeout:
+                          description: |-
+                            IdleTimeout defines the idle timeout of the persistent session.
+                            Once the session has been idle for more than the specified
+                            IdleTimeout duration, the session becomes invalid.
+
+
+                            Support: Extended
+                          pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                          type: string
+                        sessionName:
+                          description: |-
+                            SessionName defines the name of the persistent session token
+                            which may be reflected in the cookie or the header. Users
+                            should avoid reusing session names to prevent unintended
+                            consequences, such as rejection or unpredictable behavior.
+
+
+                            Support: Implementation-specific
+                          maxLength: 128
+                          type: string
+                        type:
+                          default: Cookie
+                          description: |-
+                            Type defines the type of session persistence such as through
+                            the use a header or cookie. Defaults to cookie based session
+                            persistence.
+
+
+                            Support: Core for "Cookie" type
+
+
+                            Support: Extended for "Header" type
+                          enum:
+                          - Cookie
+                          - Header
+                          type: string
+                      type: object
+                      x-kubernetes-validations:
+                      - message: AbsoluteTimeout must be specified when cookie lifetimeType
+                          is Permanent
+                        rule: '!has(self.cookieConfig.lifetimeType) || self.cookieConfig.lifetimeType
+                          != ''Permanent'' || has(self.absoluteTimeout)'
+                    timeouts:
+                      description: |+
+                        Timeouts defines the timeouts that can be configured for an HTTP request.
+
+
+                        Support: Extended
+
+
                       properties:
                         backendRequest:
                           description: |-
@@ -2411,19 +2839,21 @@ spec:
                             to a backend. This covers the time from when the request first starts being
                             sent from the gateway to when the full response has been received from the backend.
 
+
                             Setting a timeout to the zero duration (e.g. "0s") SHOULD disable the timeout
                             completely. Implementations that cannot completely disable the timeout MUST
                             instead interpret the zero duration as the longest possible value to which
                             the timeout can be set.
 
+
                             An entire client HTTP transaction with a gateway, covered by the Request timeout,
                             may result in more than one call from the gateway to the destination backend,
                             for example, if automatic retries are supported.
 
-                            The value of BackendRequest must be a Gateway API Duration string as defined by
-                            GEP-2257.  When this field is unspecified, its behavior is implementation-specific;
-                            when specified, the value of BackendRequest must be no more than the value of the
-                            Request timeout (since the Request timeout encompasses the BackendRequest timeout).
+
+                            Because the Request timeout encompasses the BackendRequest timeout, the value of
+                            BackendRequest must be <= the value of Request timeout.
+
 
                             Support: Extended
                           pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
@@ -2434,22 +2864,26 @@ spec:
                             If the gateway has not been able to respond before this deadline is met, the gateway
                             MUST return a timeout error.
 
+
                             For example, setting the `rules.timeouts.request` field to the value `10s` in an
                             `HTTPRoute` will cause a timeout if a client request is taking longer than 10 seconds
                             to complete.
+
 
                             Setting a timeout to the zero duration (e.g. "0s") SHOULD disable the timeout
                             completely. Implementations that cannot completely disable the timeout MUST
                             instead interpret the zero duration as the longest possible value to which
                             the timeout can be set.
 
+
                             This timeout is intended to cover as close to the whole request-response transaction
                             as possible although an implementation MAY choose to start the timeout after the entire
                             request stream has been received instead of immediately after the transaction is
                             initiated by the client.
 
-                            The value of Request is a Gateway API Duration string as defined by GEP-2257. When this
-                            field is unspecified, request timeout behavior is implementation-specific.
+
+                            When this field is unspecified, request timeout behavior is implementation-specific.
+
 
                             Support: Extended
                           pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
@@ -2504,21 +2938,6 @@ spec:
                       != ''PathPrefix'') ? false : true) : true'
                 maxItems: 16
                 type: array
-                x-kubernetes-validations:
-                - message: While 16 rules and 64 matches per rule are allowed, the
-                    total number of matches across all rules in a route must be less
-                    than 128
-                  rule: '(self.size() > 0 ? self[0].matches.size() : 0) + (self.size()
-                    > 1 ? self[1].matches.size() : 0) + (self.size() > 2 ? self[2].matches.size()
-                    : 0) + (self.size() > 3 ? self[3].matches.size() : 0) + (self.size()
-                    > 4 ? self[4].matches.size() : 0) + (self.size() > 5 ? self[5].matches.size()
-                    : 0) + (self.size() > 6 ? self[6].matches.size() : 0) + (self.size()
-                    > 7 ? self[7].matches.size() : 0) + (self.size() > 8 ? self[8].matches.size()
-                    : 0) + (self.size() > 9 ? self[9].matches.size() : 0) + (self.size()
-                    > 10 ? self[10].matches.size() : 0) + (self.size() > 11 ? self[11].matches.size()
-                    : 0) + (self.size() > 12 ? self[12].matches.size() : 0) + (self.size()
-                    > 13 ? self[13].matches.size() : 0) + (self.size() > 14 ? self[14].matches.size()
-                    : 0) + (self.size() > 15 ? self[15].matches.size() : 0) <= 128'
             type: object
           status:
             description: Status defines the current state of HTTPRoute.
@@ -2532,10 +2951,12 @@ spec:
                   first sees the route and should update the entry as appropriate when the
                   route or gateway is modified.
 
+
                   Note that parent references that cannot be resolved by an implementation
                   of this API will not be added to this list. Implementations of this API
                   can only populate Route status for the Gateways/parent resources they are
                   responsible for.
+
 
                   A maximum of 32 Gateways will be represented in this list. An empty list
                   means the route has not been attached to any Gateway.
@@ -2550,24 +2971,38 @@ spec:
                         Note that the route's availability is also subject to the Gateway's own
                         status conditions and listener status.
 
+
                         If the Route's ParentRef specifies an existing Gateway that supports
                         Routes of this kind AND that Gateway's controller has sufficient access,
                         then that Gateway's controller MUST set the "Accepted" condition on the
                         Route, to indicate whether the route has been accepted or rejected by the
                         Gateway, and why.
 
+
                         A Route MUST be considered "Accepted" if at least one of the Route's
                         rules is implemented by the Gateway.
 
+
                         There are a number of cases where the "Accepted" condition may not be set
                         due to lack of controller visibility, that includes when:
+
 
                         * The Route refers to a non-existent parent.
                         * The Route is of a type that the controller does not support.
                         * The Route is in a namespace the controller does not have access to.
                       items:
-                        description: Condition contains details for one aspect of
-                          the current state of this API Resource.
+                        description: "Condition contains details for one aspect of
+                          the current state of this API Resource.\n---\nThis struct
+                          is intended for direct use as an array at the field path
+                          .status.conditions.  For example,\n\n\n\ttype FooStatus
+                          struct{\n\t    // Represents the observations of a foo's
+                          current state.\n\t    // Known .status.conditions.type are:
+                          \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                          +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    //
+                          +listType=map\n\t    // +listMapKey=type\n\t    Conditions
+                          []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\"
+                          patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                          \   // other fields\n\t}"
                         properties:
                           lastTransitionTime:
                             description: |-
@@ -2609,7 +3044,12 @@ spec:
                             - Unknown
                             type: string
                           type:
-                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                            description: |-
+                              type of condition in CamelCase or in foo.example.com/CamelCase.
+                              ---
+                              Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                              useful (see .node.status.conditions), the ability to deconflict is important.
+                              The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
                             maxLength: 316
                             pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                             type: string
@@ -2632,11 +3072,14 @@ spec:
                         controller that wrote this status. This corresponds with the
                         controllerName field on GatewayClass.
 
+
                         Example: "example.net/gateway-controller".
+
 
                         The format of this field is DOMAIN "/" PATH, where DOMAIN and PATH are
                         valid Kubernetes names
                         (https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names).
+
 
                         Controllers MUST populate this field when writing status. Controllers should ensure that
                         entries to status populated with their ControllerName are cleaned up when they are no
@@ -2658,6 +3101,7 @@ spec:
                             To set the core API group (such as for a "Service" kind referent),
                             Group must be explicitly set to "" (empty string).
 
+
                             Support: Core
                           maxLength: 253
                           pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
@@ -2667,10 +3111,13 @@ spec:
                           description: |-
                             Kind is kind of the referent.
 
+
                             There are two kinds of parent resources with "Core" support:
+
 
                             * Gateway (Gateway conformance profile)
                             * Service (Mesh conformance profile, ClusterIP Services only)
+
 
                             Support for other resources is Implementation-Specific.
                           maxLength: 63
@@ -2681,6 +3128,7 @@ spec:
                           description: |-
                             Name is the name of the referent.
 
+
                             Support: Core
                           maxLength: 253
                           minLength: 1
@@ -2690,11 +3138,25 @@ spec:
                             Namespace is the namespace of the referent. When unspecified, this refers
                             to the local namespace of the Route.
 
+
                             Note that there are specific rules for ParentRefs which cross namespace
                             boundaries. Cross-namespace references are only valid if they are explicitly
                             allowed by something in the namespace they are referring to. For example:
                             Gateway has the AllowedRoutes field, and ReferenceGrant provides a
                             generic way to enable any other kind of cross-namespace reference.
+
+
+
+                            ParentRefs from a Route to a Service in the same namespace are "producer"
+                            routes, which apply default routing rules to inbound connections from
+                            any namespace to the Service.
+
+
+                            ParentRefs from a Route to a Service in a different namespace are
+                            "consumer" routes, and these routing rules are only applied to outbound
+                            connections originating from the same namespace as the Route, for which
+                            the intended destination of the connections are a Service targeted as a
+                            ParentRef of the Route.
 
 
 
@@ -2708,6 +3170,7 @@ spec:
                             Port is the network port this Route targets. It can be interpreted
                             differently based on the type of parent resource.
 
+
                             When the parent resource is a Gateway, this targets all listeners
                             listening on the specified port that also support this kind of Route(and
                             select this Route). It's not recommended to set `Port` unless the
@@ -2718,9 +3181,16 @@ spec:
 
 
 
+                            When the parent resource is a Service, this targets a specific port in the
+                            Service spec. When both Port (experimental) and SectionName are specified,
+                            the name and port of the selected port must match both specified values.
+
+
+
                             Implementations MAY choose to support other parent resources.
                             Implementations supporting other types of parent resources MUST clearly
                             document how/if Port is interpreted.
+
 
                             For the purpose of status, an attachment is considered successful as
                             long as the parent resource accepts it partially. For example, Gateway
@@ -2729,6 +3199,7 @@ spec:
                             from the referencing Route, the Route MUST be considered successfully
                             attached. If no Gateway listeners accept attachment from this Route,
                             the Route MUST be considered detached from the Gateway.
+
 
                             Support: Extended
                           format: int32
@@ -2740,6 +3211,7 @@ spec:
                             SectionName is the name of a section within the target resource. In the
                             following resources, SectionName is interpreted as the following:
 
+
                             * Gateway: Listener name. When both Port (experimental) and SectionName
                             are specified, the name and port of the selected listener must match
                             both specified values.
@@ -2747,9 +3219,11 @@ spec:
                             are specified, the name and port of the selected listener must match
                             both specified values.
 
+
                             Implementations MAY choose to support attaching Routes to other resources.
                             If that is the case, they MUST clearly document how SectionName is
                             interpreted.
+
 
                             When unspecified (empty string), this will reference the entire resource.
                             For the purpose of status, an attachment is considered successful if at
@@ -2759,6 +3233,7 @@ spec:
                             the referencing Route, the Route MUST be considered successfully
                             attached. If no Gateway listeners accept attachment from this Route, the
                             Route MUST be considered detached from the Gateway.
+
 
                             Support: Core
                           maxLength: 253
@@ -2828,16 +3303,20 @@ spec:
                   performing a match and (absent of any applicable header modification
                   configuration) MUST forward this header unmodified to the backend.
 
+
                   Valid values for Hostnames are determined by RFC 1123 definition of a
                   hostname with 2 notable exceptions:
+
 
                   1. IPs are not allowed.
                   2. A hostname may be prefixed with a wildcard label (`*.`). The wildcard
                      label must appear by itself as the first label.
 
+
                   If a hostname is specified by both the Listener and HTTPRoute, there
                   must be at least one intersecting hostname for the HTTPRoute to be
                   attached to the Listener. For example:
+
 
                   * A Listener with `test.example.com` as the hostname matches HTTPRoutes
                     that have either not specified any hostnames, or have specified at
@@ -2849,9 +3328,11 @@ spec:
                     all match. On the other hand, `example.com` and `test.example.net` would
                     not match.
 
+
                   Hostnames that are prefixed with a wildcard label (`*.`) are interpreted
                   as a suffix match. That means that a match for `*.example.com` would match
                   both `test.example.com`, and `foo.test.example.com`, but not `example.com`.
+
 
                   If both the Listener and HTTPRoute have specified hostnames, any
                   HTTPRoute hostnames that do not match the Listener hostname MUST be
@@ -2859,20 +3340,25 @@ spec:
                   HTTPRoute specified `test.example.com` and `test.example.net`,
                   `test.example.net` must not be considered for a match.
 
+
                   If both the Listener and HTTPRoute have specified hostnames, and none
                   match with the criteria above, then the HTTPRoute is not accepted. The
                   implementation must raise an 'Accepted' Condition with a status of
                   `False` in the corresponding RouteParentStatus.
 
+
                   In the event that multiple HTTPRoutes specify intersecting hostnames (e.g.
                   overlapping wildcard matching and exact matching hostnames), precedence must
                   be given to rules from the HTTPRoute with the largest number of:
 
+
                   * Characters in a matching non-wildcard hostname.
                   * Characters in a matching hostname.
 
+
                   If ties exist across multiple Routes, the matching precedence rules for
                   HTTPRouteMatches takes over.
+
 
                   Support: Core
                 items:
@@ -2880,13 +3366,16 @@ spec:
                     Hostname is the fully qualified domain name of a network host. This matches
                     the RFC 1123 definition of a hostname with 2 notable exceptions:
 
+
                      1. IPs are not allowed.
                      2. A hostname may be prefixed with a wildcard label (`*.`). The wildcard
                         label must appear by itself as the first label.
 
+
                     Hostname can be "precise" which is a domain name without the terminating
                     dot of a network host (e.g. "foo.example.com") or "wildcard", which is a
                     domain name prefixed with a single wildcard label (e.g. `*.example.com`).
+
 
                     Note that as per RFC1035 and RFC1123, a *label* must consist of lower case
                     alphanumeric characters or '-', and must start and end with an alphanumeric
@@ -2910,15 +3399,20 @@ spec:
                   create a "producer" route for a Service in a different namespace from the
                   Route.
 
+
                   There are two kinds of parent resources with "Core" support:
+
 
                   * Gateway (Gateway conformance profile)
                   * Service (Mesh conformance profile, ClusterIP Services only)
 
+
                   This API may be extended in the future to support additional kinds of parent
                   resources.
 
+
                   ParentRefs must be _distinct_. This means either that:
+
 
                   * They select different objects.  If this is the case, then parentRef
                     entries are distinct. In terms of fields, this means that the
@@ -2929,7 +3423,9 @@ spec:
                     optional fields to different values. If one ParentRef sets a
                     combination of optional fields, all must set the same combination.
 
+
                   Some examples:
+
 
                   * If one ParentRef sets `sectionName`, all ParentRefs referencing the
                     same object must also set `sectionName`.
@@ -2938,17 +3434,32 @@ spec:
                   * If one ParentRef sets `sectionName` and `port`, all ParentRefs
                     referencing the same object must also set `sectionName` and `port`.
 
+
                   It is possible to separately reference multiple distinct objects that may
                   be collapsed by an implementation. For example, some implementations may
                   choose to merge compatible Gateway Listeners together. If that is the
                   case, the list of routes attached to those resources should also be
                   merged.
 
+
                   Note that for ParentRefs that cross namespace boundaries, there are specific
                   rules. Cross-namespace references are only valid if they are explicitly
                   allowed by something in the namespace they are referring to. For example,
                   Gateway has the AllowedRoutes field, and ReferenceGrant provides a
                   generic way to enable other kinds of cross-namespace reference.
+
+
+
+                  ParentRefs from a Route to a Service in the same namespace are "producer"
+                  routes, which apply default routing rules to inbound connections from
+                  any namespace to the Service.
+
+
+                  ParentRefs from a Route to a Service in a different namespace are
+                  "consumer" routes, and these routing rules are only applied to outbound
+                  connections originating from the same namespace as the Route, for which
+                  the intended destination of the connections are a Service targeted as a
+                  ParentRef of the Route.
 
 
 
@@ -2961,11 +3472,14 @@ spec:
                     a parent of this resource (usually a route). There are two kinds of parent resources
                     with "Core" support:
 
+
                     * Gateway (Gateway conformance profile)
                     * Service (Mesh conformance profile, ClusterIP Services only)
 
+
                     This API may be extended in the future to support additional kinds of parent
                     resources.
+
 
                     The API object must be valid in the cluster; the Group and Kind must
                     be registered in the cluster for this reference to be valid.
@@ -2978,6 +3492,7 @@ spec:
                         To set the core API group (such as for a "Service" kind referent),
                         Group must be explicitly set to "" (empty string).
 
+
                         Support: Core
                       maxLength: 253
                       pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
@@ -2987,10 +3502,13 @@ spec:
                       description: |-
                         Kind is kind of the referent.
 
+
                         There are two kinds of parent resources with "Core" support:
+
 
                         * Gateway (Gateway conformance profile)
                         * Service (Mesh conformance profile, ClusterIP Services only)
+
 
                         Support for other resources is Implementation-Specific.
                       maxLength: 63
@@ -3001,6 +3519,7 @@ spec:
                       description: |-
                         Name is the name of the referent.
 
+
                         Support: Core
                       maxLength: 253
                       minLength: 1
@@ -3010,11 +3529,25 @@ spec:
                         Namespace is the namespace of the referent. When unspecified, this refers
                         to the local namespace of the Route.
 
+
                         Note that there are specific rules for ParentRefs which cross namespace
                         boundaries. Cross-namespace references are only valid if they are explicitly
                         allowed by something in the namespace they are referring to. For example:
                         Gateway has the AllowedRoutes field, and ReferenceGrant provides a
                         generic way to enable any other kind of cross-namespace reference.
+
+
+
+                        ParentRefs from a Route to a Service in the same namespace are "producer"
+                        routes, which apply default routing rules to inbound connections from
+                        any namespace to the Service.
+
+
+                        ParentRefs from a Route to a Service in a different namespace are
+                        "consumer" routes, and these routing rules are only applied to outbound
+                        connections originating from the same namespace as the Route, for which
+                        the intended destination of the connections are a Service targeted as a
+                        ParentRef of the Route.
 
 
 
@@ -3028,6 +3561,7 @@ spec:
                         Port is the network port this Route targets. It can be interpreted
                         differently based on the type of parent resource.
 
+
                         When the parent resource is a Gateway, this targets all listeners
                         listening on the specified port that also support this kind of Route(and
                         select this Route). It's not recommended to set `Port` unless the
@@ -3038,9 +3572,16 @@ spec:
 
 
 
+                        When the parent resource is a Service, this targets a specific port in the
+                        Service spec. When both Port (experimental) and SectionName are specified,
+                        the name and port of the selected port must match both specified values.
+
+
+
                         Implementations MAY choose to support other parent resources.
                         Implementations supporting other types of parent resources MUST clearly
                         document how/if Port is interpreted.
+
 
                         For the purpose of status, an attachment is considered successful as
                         long as the parent resource accepts it partially. For example, Gateway
@@ -3049,6 +3590,7 @@ spec:
                         from the referencing Route, the Route MUST be considered successfully
                         attached. If no Gateway listeners accept attachment from this Route,
                         the Route MUST be considered detached from the Gateway.
+
 
                         Support: Extended
                       format: int32
@@ -3060,6 +3602,7 @@ spec:
                         SectionName is the name of a section within the target resource. In the
                         following resources, SectionName is interpreted as the following:
 
+
                         * Gateway: Listener name. When both Port (experimental) and SectionName
                         are specified, the name and port of the selected listener must match
                         both specified values.
@@ -3067,9 +3610,11 @@ spec:
                         are specified, the name and port of the selected listener must match
                         both specified values.
 
+
                         Implementations MAY choose to support attaching Routes to other resources.
                         If that is the case, they MUST clearly document how SectionName is
                         interpreted.
+
 
                         When unspecified (empty string), this will reference the entire resource.
                         For the purpose of status, an attachment is considered successful if at
@@ -3079,6 +3624,7 @@ spec:
                         the referencing Route, the Route MUST be considered successfully
                         attached. If no Gateway listeners accept attachment from this Route, the
                         Route MUST be considered detached from the Gateway.
+
 
                         Support: Core
                       maxLength: 253
@@ -3091,34 +3637,35 @@ spec:
                 maxItems: 32
                 type: array
                 x-kubernetes-validations:
-                - message: sectionName must be specified when parentRefs includes
+                - message: sectionName or port must be specified when parentRefs includes
                     2 or more references to the same parent
                   rule: 'self.all(p1, self.all(p2, p1.group == p2.group && p1.kind
                     == p2.kind && p1.name == p2.name && (((!has(p1.__namespace__)
                     || p1.__namespace__ == '''') && (!has(p2.__namespace__) || p2.__namespace__
                     == '''')) || (has(p1.__namespace__) && has(p2.__namespace__) &&
-                    p1.__namespace__ == p2.__namespace__ )) ? ((!has(p1.sectionName)
+                    p1.__namespace__ == p2.__namespace__)) ? ((!has(p1.sectionName)
                     || p1.sectionName == '''') == (!has(p2.sectionName) || p2.sectionName
-                    == '''')) : true))'
-                - message: sectionName must be unique when parentRefs includes 2 or
-                    more references to the same parent
+                    == '''') && (!has(p1.port) || p1.port == 0) == (!has(p2.port)
+                    || p2.port == 0)): true))'
+                - message: sectionName or port must be unique when parentRefs includes
+                    2 or more references to the same parent
                   rule: self.all(p1, self.exists_one(p2, p1.group == p2.group && p1.kind
                     == p2.kind && p1.name == p2.name && (((!has(p1.__namespace__)
                     || p1.__namespace__ == '') && (!has(p2.__namespace__) || p2.__namespace__
                     == '')) || (has(p1.__namespace__) && has(p2.__namespace__) &&
                     p1.__namespace__ == p2.__namespace__ )) && (((!has(p1.sectionName)
                     || p1.sectionName == '') && (!has(p2.sectionName) || p2.sectionName
-                    == '')) || (has(p1.sectionName) && has(p2.sectionName) && p1.sectionName
-                    == p2.sectionName))))
+                    == '')) || ( has(p1.sectionName) && has(p2.sectionName) && p1.sectionName
+                    == p2.sectionName)) && (((!has(p1.port) || p1.port == 0) && (!has(p2.port)
+                    || p2.port == 0)) || (has(p1.port) && has(p2.port) && p1.port
+                    == p2.port))))
               rules:
                 default:
                 - matches:
                   - path:
                       type: PathPrefix
                       value: /
-                description: |+
-                  Rules are a list of HTTP matchers, filters and actions.
-
+                description: Rules are a list of HTTP matchers, filters and actions.
                 items:
                   description: |-
                     HTTPRouteRule defines semantics for matching an HTTP request based on
@@ -3130,15 +3677,19 @@ spec:
                         BackendRefs defines the backend(s) where matching requests should be
                         sent.
 
+
                         Failure behavior here depends on how many BackendRefs are specified and
                         how many are invalid.
+
 
                         If *all* entries in BackendRefs are invalid, and there are also no filters
                         specified in this route rule, *all* traffic which matches this rule MUST
                         receive a 500 status code.
 
+
                         See the HTTPBackendRef definition for the rules about what makes a single
                         HTTPBackendRef invalid.
+
 
                         When a HTTPBackendRef is invalid, 500 status codes MUST be returned for
                         requests that would have otherwise been routed to an invalid backend. If
@@ -3146,46 +3697,53 @@ spec:
                         requests that would otherwise have been routed to an invalid backend
                         MUST receive a 500 status code.
 
+
                         For example, if two backends are specified with equal weights, and one is
                         invalid, 50 percent of traffic must receive a 500. Implementations may
                         choose how that 50 percent is determined.
 
-                        When a HTTPBackendRef refers to a Service that has no ready endpoints,
-                        implementations SHOULD return a 503 for requests to that backend instead.
-                        If an implementation chooses to do this, all of the above rules for 500 responses
-                        MUST also apply for responses that return a 503.
 
                         Support: Core for Kubernetes Service
 
+
                         Support: Extended for Kubernetes ServiceImport
 
+
                         Support: Implementation-specific for any other resource
+
 
                         Support for weight: Core
                       items:
                         description: |-
                           HTTPBackendRef defines how a HTTPRoute forwards a HTTP request.
 
+
                           Note that when a namespace different than the local namespace is specified, a
                           ReferenceGrant object is required in the referent namespace to allow that
                           namespace's owner to accept the reference. See the ReferenceGrant
                           documentation for details.
 
+
                           <gateway:experimental:description>
+
 
                           When the BackendRef points to a Kubernetes Service, implementations SHOULD
                           honor the appProtocol field if it is set for the target Service Port.
 
+
                           Implementations supporting appProtocol SHOULD recognize the Kubernetes
                           Standard Application Protocols defined in KEP-3726.
+
 
                           If a Service appProtocol isn't specified, an implementation MAY infer the
                           backend protocol through its own means. Implementations MAY infer the
                           protocol from the Route type referring to the backend Service.
 
+
                           If a Route is not able to send traffic to the backend using the specified
                           protocol then the backend is considered invalid. Implementations MUST set the
                           "ResolvedRefs" condition to "False" with the "UnsupportedProtocol" reason.
+
 
                           </gateway:experimental:description>
                         properties:
@@ -3193,6 +3751,7 @@ spec:
                             description: |-
                               Filters defined at this level should be executed if and only if the
                               request is being forwarded to the backend defined here.
+
 
                               Support: Implementation-specific (For broader support of filters, use the
                               Filters field in HTTPRouteRule.)
@@ -3212,7 +3771,9 @@ spec:
                                     "networking.example.net"). ExtensionRef MUST NOT be used for core and
                                     extended filters.
 
+
                                     This filter can be used multiple times within the same rule.
+
 
                                     Support: Implementation-specific
                                   properties:
@@ -3245,6 +3806,7 @@ spec:
                                     RequestHeaderModifier defines a schema for a filter that modifies request
                                     headers.
 
+
                                     Support: Core
                                   properties:
                                     add:
@@ -3253,14 +3815,17 @@ spec:
                                         before the action. It appends to any existing values associated
                                         with the header name.
 
+
                                         Input:
                                           GET /foo HTTP/1.1
                                           my-header: foo
+
 
                                         Config:
                                           add:
                                           - name: "my-header"
                                             value: "bar,baz"
+
 
                                         Output:
                                           GET /foo HTTP/1.1
@@ -3274,6 +3839,7 @@ spec:
                                             description: |-
                                               Name is the name of the HTTP Header to be matched. Name matching MUST be
                                               case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
 
                                               If multiple entries specify equivalent header names, the first entry with
                                               an equivalent name MUST be considered for a match. Subsequent entries
@@ -3306,14 +3872,17 @@ spec:
                                         names are case-insensitive (see
                                         https://datatracker.ietf.org/doc/html/rfc2616#section-4.2).
 
+
                                         Input:
                                           GET /foo HTTP/1.1
                                           my-header1: foo
                                           my-header2: bar
                                           my-header3: baz
 
+
                                         Config:
                                           remove: ["my-header1", "my-header3"]
+
 
                                         Output:
                                           GET /foo HTTP/1.1
@@ -3328,14 +3897,17 @@ spec:
                                         Set overwrites the request with the given header (name, value)
                                         before the action.
 
+
                                         Input:
                                           GET /foo HTTP/1.1
                                           my-header: foo
+
 
                                         Config:
                                           set:
                                           - name: "my-header"
                                             value: "bar"
+
 
                                         Output:
                                           GET /foo HTTP/1.1
@@ -3349,6 +3921,7 @@ spec:
                                             description: |-
                                               Name is the name of the HTTP Header to be matched. Name matching MUST be
                                               case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
 
                                               If multiple entries specify equivalent header names, the first entry with
                                               an equivalent name MUST be considered for a match. Subsequent entries
@@ -3376,30 +3949,34 @@ spec:
                                       x-kubernetes-list-type: map
                                   type: object
                                 requestMirror:
-                                  description: |+
+                                  description: |-
                                     RequestMirror defines a schema for a filter that mirrors requests.
                                     Requests are sent to the specified destination, but responses from
                                     that destination are ignored.
+
 
                                     This filter can be used multiple times within the same rule. Note that
                                     not all implementations will be able to support mirroring to multiple
                                     backends.
 
-                                    Support: Extended
 
+                                    Support: Extended
                                   properties:
                                     backendRef:
                                       description: |-
                                         BackendRef references a resource where mirrored requests are sent.
 
+
                                         Mirrored requests must be sent only to a single destination endpoint
                                         within this BackendRef, irrespective of how many endpoints are present
                                         within this BackendRef.
+
 
                                         If the referent cannot be found, this BackendRef is invalid and must be
                                         dropped from the Gateway. The controller must ensure the "ResolvedRefs"
                                         condition on the Route status is set to `status: False` and not configure
                                         this backend in the underlying implementation.
+
 
                                         If there is a cross-namespace reference to an *existing* object
                                         that is not allowed by a ReferenceGrant, the controller must ensure the
@@ -3407,10 +3984,13 @@ spec:
                                         with the "RefNotPermitted" reason and not configure this backend in the
                                         underlying implementation.
 
+
                                         In either error case, the Message of the `ResolvedRefs` Condition
                                         should be used to provide more detail about the problem.
 
+
                                         Support: Extended for Kubernetes Service
+
 
                                         Support: Implementation-specific for any other resource
                                       properties:
@@ -3428,7 +4008,9 @@ spec:
                                             Kind is the Kubernetes resource kind of the referent. For example
                                             "Service".
 
+
                                             Defaults to "Service" when not specified.
+
 
                                             ExternalName services can refer to CNAME DNS records that may live
                                             outside of the cluster and as such are difficult to reason about in
@@ -3436,7 +4018,9 @@ spec:
                                             CVE-2021-25740 for more information). Implementations SHOULD NOT
                                             support ExternalName Services.
 
+
                                             Support: Core (Services with a type other than ExternalName)
+
 
                                             Support: Implementation-specific (Services with type ExternalName)
                                           maxLength: 63
@@ -3453,10 +4037,12 @@ spec:
                                             Namespace is the namespace of the backend. When unspecified, the local
                                             namespace is inferred.
 
+
                                             Note that when a namespace different than the local namespace is specified,
                                             a ReferenceGrant object is required in the referent namespace to allow that
                                             namespace's owner to accept the reference. See the ReferenceGrant
                                             documentation for details.
+
 
                                             Support: Core
                                           maxLength: 63
@@ -3489,6 +4075,7 @@ spec:
                                     RequestRedirect defines a schema for a filter that responds to the
                                     request with an HTTP redirection.
 
+
                                     Support: Core
                                   properties:
                                     hostname:
@@ -3496,6 +4083,7 @@ spec:
                                         Hostname is the hostname to be used in the value of the `Location`
                                         header in the response.
                                         When empty, the hostname in the `Host` header of the request is used.
+
 
                                         Support: Core
                                       maxLength: 253
@@ -3507,6 +4095,7 @@ spec:
                                         Path defines parameters used to modify the path of the incoming request.
                                         The modified path is then used to construct the `Location` header. When
                                         empty, the request path is used as-is.
+
 
                                         Support: Extended
                                       properties:
@@ -3523,17 +4112,32 @@ spec:
                                             to "/foo/bar" with a prefix match of "/foo" and a ReplacePrefixMatch
                                             of "/xyz" would be modified to "/xyz/bar".
 
+
                                             Note that this matches the behavior of the PathPrefix match type. This
                                             matches full path elements. A path element refers to the list of labels
                                             in the path split by the `/` separator. When specified, a trailing `/` is
                                             ignored. For example, the paths `/abc`, `/abc/`, and `/abc/def` would all
                                             match the prefix `/abc`, but the path `/abcd` would not.
 
+
                                             ReplacePrefixMatch is only compatible with a `PathPrefix` HTTPRouteMatch.
                                             Using any other HTTPRouteMatch type on the same HTTPRouteRule will result in
                                             the implementation setting the Accepted Condition for the Route to `status: False`.
 
+
                                             Request Path | Prefix Match | Replace Prefix | Modified Path
+                                            -------------|--------------|----------------|----------
+                                            /foo/bar     | /foo         | /xyz           | /xyz/bar
+                                            /foo/bar     | /foo         | /xyz/          | /xyz/bar
+                                            /foo/bar     | /foo/        | /xyz           | /xyz/bar
+                                            /foo/bar     | /foo/        | /xyz/          | /xyz/bar
+                                            /foo         | /foo         | /xyz           | /xyz
+                                            /foo/        | /foo         | /xyz           | /xyz/
+                                            /foo/bar     | /foo         | <empty string> | /bar
+                                            /foo/        | /foo         | <empty string> | /
+                                            /foo         | /foo         | <empty string> | /
+                                            /foo/        | /foo         | /              | /
+                                            /foo         | /foo         | /              | /
                                           maxLength: 1024
                                           type: string
                                         type:
@@ -3541,8 +4145,10 @@ spec:
                                             Type defines the type of path modifier. Additional types may be
                                             added in a future release of the API.
 
+
                                             Note that values may be added to this enum, implementations
                                             must ensure that unknown values will not cause a crash.
+
 
                                             Unknown values here must result in the implementation setting the
                                             Accepted Condition for the Route to `status: False`, with a
@@ -3576,8 +4182,10 @@ spec:
                                         Port is the port to be used in the value of the `Location`
                                         header in the response.
 
+
                                         If no port is specified, the redirect port MUST be derived using the
                                         following rules:
+
 
                                         * If redirect scheme is not-empty, the redirect port MUST be the well-known
                                           port associated with the redirect scheme. Specifically "http" to port 80
@@ -3586,13 +4194,16 @@ spec:
                                         * If redirect scheme is empty, the redirect port MUST be the Gateway
                                           Listener port.
 
+
                                         Implementations SHOULD NOT add the port number in the 'Location'
                                         header in the following cases:
+
 
                                         * A Location header that will use HTTP (whether that is determined via
                                           the Listener protocol or the Scheme field) _and_ use port 80.
                                         * A Location header that will use HTTPS (whether that is determined via
                                           the Listener protocol or the Scheme field) _and_ use port 443.
+
 
                                         Support: Extended
                                       format: int32
@@ -3604,15 +4215,19 @@ spec:
                                         Scheme is the scheme to be used in the value of the `Location` header in
                                         the response. When empty, the scheme of the request is used.
 
+
                                         Scheme redirects can affect the port of the redirect, for more information,
                                         refer to the documentation for the port field of this filter.
+
 
                                         Note that values may be added to this enum, implementations
                                         must ensure that unknown values will not cause a crash.
 
+
                                         Unknown values here must result in the implementation setting the
                                         Accepted Condition for the Route to `status: False`, with a
                                         Reason of `UnsupportedValue`.
+
 
                                         Support: Extended
                                       enum:
@@ -3624,12 +4239,15 @@ spec:
                                       description: |-
                                         StatusCode is the HTTP status code to be used in response.
 
+
                                         Note that values may be added to this enum, implementations
                                         must ensure that unknown values will not cause a crash.
+
 
                                         Unknown values here must result in the implementation setting the
                                         Accepted Condition for the Route to `status: False`, with a
                                         Reason of `UnsupportedValue`.
+
 
                                         Support: Core
                                       enum:
@@ -3642,6 +4260,7 @@ spec:
                                     ResponseHeaderModifier defines a schema for a filter that modifies response
                                     headers.
 
+
                                     Support: Extended
                                   properties:
                                     add:
@@ -3650,14 +4269,17 @@ spec:
                                         before the action. It appends to any existing values associated
                                         with the header name.
 
+
                                         Input:
                                           GET /foo HTTP/1.1
                                           my-header: foo
+
 
                                         Config:
                                           add:
                                           - name: "my-header"
                                             value: "bar,baz"
+
 
                                         Output:
                                           GET /foo HTTP/1.1
@@ -3671,6 +4293,7 @@ spec:
                                             description: |-
                                               Name is the name of the HTTP Header to be matched. Name matching MUST be
                                               case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
 
                                               If multiple entries specify equivalent header names, the first entry with
                                               an equivalent name MUST be considered for a match. Subsequent entries
@@ -3703,14 +4326,17 @@ spec:
                                         names are case-insensitive (see
                                         https://datatracker.ietf.org/doc/html/rfc2616#section-4.2).
 
+
                                         Input:
                                           GET /foo HTTP/1.1
                                           my-header1: foo
                                           my-header2: bar
                                           my-header3: baz
 
+
                                         Config:
                                           remove: ["my-header1", "my-header3"]
+
 
                                         Output:
                                           GET /foo HTTP/1.1
@@ -3725,14 +4351,17 @@ spec:
                                         Set overwrites the request with the given header (name, value)
                                         before the action.
 
+
                                         Input:
                                           GET /foo HTTP/1.1
                                           my-header: foo
+
 
                                         Config:
                                           set:
                                           - name: "my-header"
                                             value: "bar"
+
 
                                         Output:
                                           GET /foo HTTP/1.1
@@ -3746,6 +4375,7 @@ spec:
                                             description: |-
                                               Name is the name of the HTTP Header to be matched. Name matching MUST be
                                               case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
 
                                               If multiple entries specify equivalent header names, the first entry with
                                               an equivalent name MUST be considered for a match. Subsequent entries
@@ -3777,13 +4407,16 @@ spec:
                                     Type identifies the type of filter to apply. As with other API fields,
                                     types are classified into three conformance levels:
 
+
                                     - Core: Filter types and their corresponding configuration defined by
                                       "Support: Core" in this package, e.g. "RequestHeaderModifier". All
                                       implementations must support core filters.
 
+
                                     - Extended: Filter types and their corresponding configuration defined by
                                       "Support: Extended" in this package, e.g. "RequestMirror". Implementers
                                       are encouraged to support extended filters.
+
 
                                     - Implementation-specific: Filters that are defined and supported by
                                       specific vendors.
@@ -3793,15 +4426,19 @@ spec:
                                       is specified using the ExtensionRef field. `Type` should be set to
                                       "ExtensionRef" for custom filters.
 
+
                                     Implementers are encouraged to define custom implementation types to
                                     extend the core API with implementation-specific behavior.
+
 
                                     If a reference to a custom filter type cannot be resolved, the filter
                                     MUST NOT be skipped. Instead, requests that would have been processed by
                                     that filter MUST receive a HTTP error response.
 
+
                                     Note that values may be added to this enum, implementations
                                     must ensure that unknown values will not cause a crash.
+
 
                                     Unknown values here must result in the implementation setting the
                                     Accepted Condition for the Route to `status: False`, with a
@@ -3818,12 +4455,14 @@ spec:
                                   description: |-
                                     URLRewrite defines a schema for a filter that modifies a request during forwarding.
 
+
                                     Support: Extended
                                   properties:
                                     hostname:
                                       description: |-
                                         Hostname is the value to be used to replace the Host header value during
                                         forwarding.
+
 
                                         Support: Extended
                                       maxLength: 253
@@ -3833,6 +4472,7 @@ spec:
                                     path:
                                       description: |-
                                         Path defines a path rewrite.
+
 
                                         Support: Extended
                                       properties:
@@ -3849,17 +4489,32 @@ spec:
                                             to "/foo/bar" with a prefix match of "/foo" and a ReplacePrefixMatch
                                             of "/xyz" would be modified to "/xyz/bar".
 
+
                                             Note that this matches the behavior of the PathPrefix match type. This
                                             matches full path elements. A path element refers to the list of labels
                                             in the path split by the `/` separator. When specified, a trailing `/` is
                                             ignored. For example, the paths `/abc`, `/abc/`, and `/abc/def` would all
                                             match the prefix `/abc`, but the path `/abcd` would not.
 
+
                                             ReplacePrefixMatch is only compatible with a `PathPrefix` HTTPRouteMatch.
                                             Using any other HTTPRouteMatch type on the same HTTPRouteRule will result in
                                             the implementation setting the Accepted Condition for the Route to `status: False`.
 
+
                                             Request Path | Prefix Match | Replace Prefix | Modified Path
+                                            -------------|--------------|----------------|----------
+                                            /foo/bar     | /foo         | /xyz           | /xyz/bar
+                                            /foo/bar     | /foo         | /xyz/          | /xyz/bar
+                                            /foo/bar     | /foo/        | /xyz           | /xyz/bar
+                                            /foo/bar     | /foo/        | /xyz/          | /xyz/bar
+                                            /foo         | /foo         | /xyz           | /xyz
+                                            /foo/        | /foo         | /xyz           | /xyz/
+                                            /foo/bar     | /foo         | <empty string> | /bar
+                                            /foo/        | /foo         | <empty string> | /
+                                            /foo         | /foo         | <empty string> | /
+                                            /foo/        | /foo         | /              | /
+                                            /foo         | /foo         | /              | /
                                           maxLength: 1024
                                           type: string
                                         type:
@@ -3867,8 +4522,10 @@ spec:
                                             Type defines the type of path modifier. Additional types may be
                                             added in a future release of the API.
 
+
                                             Note that values may be added to this enum, implementations
                                             must ensure that unknown values will not cause a crash.
+
 
                                             Unknown values here must result in the implementation setting the
                                             Accepted Condition for the Route to `status: False`, with a
@@ -3982,7 +4639,9 @@ spec:
                               Kind is the Kubernetes resource kind of the referent. For example
                               "Service".
 
+
                               Defaults to "Service" when not specified.
+
 
                               ExternalName services can refer to CNAME DNS records that may live
                               outside of the cluster and as such are difficult to reason about in
@@ -3990,7 +4649,9 @@ spec:
                               CVE-2021-25740 for more information). Implementations SHOULD NOT
                               support ExternalName Services.
 
+
                               Support: Core (Services with a type other than ExternalName)
+
 
                               Support: Implementation-specific (Services with type ExternalName)
                             maxLength: 63
@@ -4007,10 +4668,12 @@ spec:
                               Namespace is the namespace of the backend. When unspecified, the local
                               namespace is inferred.
 
+
                               Note that when a namespace different than the local namespace is specified,
                               a ReferenceGrant object is required in the referent namespace to allow that
                               namespace's owner to accept the reference. See the ReferenceGrant
                               documentation for details.
+
 
                               Support: Core
                             maxLength: 63
@@ -4038,10 +4701,12 @@ spec:
                               implementation supports. Weight is not a percentage and the sum of
                               weights does not need to equal 100.
 
+
                               If only one backend is specified and it has a weight greater than 0, 100%
                               of the traffic is forwarded to that backend. If weight is set to 0, no
                               traffic should be forwarded for this entry. If unspecified, weight
                               defaults to 1.
+
 
                               Support for this field varies based on the context where used.
                             format: int32
@@ -4062,13 +4727,16 @@ spec:
                         Filters define the filters that are applied to requests that match
                         this rule.
 
+
                         Wherever possible, implementations SHOULD implement filters in the order
                         they are specified.
+
 
                         Implementations MAY choose to implement this ordering strictly, rejecting
                         any combination or order of filters that can not be supported. If implementations
                         choose a strict interpretation of filter ordering, they MUST clearly document
                         that behavior.
+
 
                         To reject an invalid combination or order of filters, implementations SHOULD
                         consider the Route Rules with this configuration invalid. If all Route Rules
@@ -4076,15 +4744,19 @@ spec:
                         a portion of Route Rules are invalid, implementations MUST set the
                         "PartiallyInvalid" condition for the Route.
 
+
                         Conformance-levels at this level are defined based on the type of filter:
+
 
                         - ALL core filters MUST be supported by all implementations.
                         - Implementers are encouraged to support extended filters.
                         - Implementation-specific custom filters have no API guarantees across
                           implementations.
 
+
                         Specifying the same filter multiple times is not supported unless explicitly
                         indicated in the filter.
+
 
                         All filters are expected to be compatible with each other except for the
                         URLRewrite and RequestRedirect filters, which may not be combined. If an
@@ -4093,6 +4765,7 @@ spec:
                         filters are specified and cause the `Accepted` condition to be set to status
                         `False`, implementations may use the `IncompatibleFilters` reason to specify
                         this configuration error.
+
 
                         Support: Core
                       items:
@@ -4111,7 +4784,9 @@ spec:
                               "networking.example.net"). ExtensionRef MUST NOT be used for core and
                               extended filters.
 
+
                               This filter can be used multiple times within the same rule.
+
 
                               Support: Implementation-specific
                             properties:
@@ -4144,6 +4819,7 @@ spec:
                               RequestHeaderModifier defines a schema for a filter that modifies request
                               headers.
 
+
                               Support: Core
                             properties:
                               add:
@@ -4152,14 +4828,17 @@ spec:
                                   before the action. It appends to any existing values associated
                                   with the header name.
 
+
                                   Input:
                                     GET /foo HTTP/1.1
                                     my-header: foo
+
 
                                   Config:
                                     add:
                                     - name: "my-header"
                                       value: "bar,baz"
+
 
                                   Output:
                                     GET /foo HTTP/1.1
@@ -4172,6 +4851,7 @@ spec:
                                       description: |-
                                         Name is the name of the HTTP Header to be matched. Name matching MUST be
                                         case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
 
                                         If multiple entries specify equivalent header names, the first entry with
                                         an equivalent name MUST be considered for a match. Subsequent entries
@@ -4204,14 +4884,17 @@ spec:
                                   names are case-insensitive (see
                                   https://datatracker.ietf.org/doc/html/rfc2616#section-4.2).
 
+
                                   Input:
                                     GET /foo HTTP/1.1
                                     my-header1: foo
                                     my-header2: bar
                                     my-header3: baz
 
+
                                   Config:
                                     remove: ["my-header1", "my-header3"]
+
 
                                   Output:
                                     GET /foo HTTP/1.1
@@ -4226,14 +4909,17 @@ spec:
                                   Set overwrites the request with the given header (name, value)
                                   before the action.
 
+
                                   Input:
                                     GET /foo HTTP/1.1
                                     my-header: foo
+
 
                                   Config:
                                     set:
                                     - name: "my-header"
                                       value: "bar"
+
 
                                   Output:
                                     GET /foo HTTP/1.1
@@ -4246,6 +4932,7 @@ spec:
                                       description: |-
                                         Name is the name of the HTTP Header to be matched. Name matching MUST be
                                         case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
 
                                         If multiple entries specify equivalent header names, the first entry with
                                         an equivalent name MUST be considered for a match. Subsequent entries
@@ -4273,30 +4960,34 @@ spec:
                                 x-kubernetes-list-type: map
                             type: object
                           requestMirror:
-                            description: |+
+                            description: |-
                               RequestMirror defines a schema for a filter that mirrors requests.
                               Requests are sent to the specified destination, but responses from
                               that destination are ignored.
+
 
                               This filter can be used multiple times within the same rule. Note that
                               not all implementations will be able to support mirroring to multiple
                               backends.
 
-                              Support: Extended
 
+                              Support: Extended
                             properties:
                               backendRef:
                                 description: |-
                                   BackendRef references a resource where mirrored requests are sent.
 
+
                                   Mirrored requests must be sent only to a single destination endpoint
                                   within this BackendRef, irrespective of how many endpoints are present
                                   within this BackendRef.
+
 
                                   If the referent cannot be found, this BackendRef is invalid and must be
                                   dropped from the Gateway. The controller must ensure the "ResolvedRefs"
                                   condition on the Route status is set to `status: False` and not configure
                                   this backend in the underlying implementation.
+
 
                                   If there is a cross-namespace reference to an *existing* object
                                   that is not allowed by a ReferenceGrant, the controller must ensure the
@@ -4304,10 +4995,13 @@ spec:
                                   with the "RefNotPermitted" reason and not configure this backend in the
                                   underlying implementation.
 
+
                                   In either error case, the Message of the `ResolvedRefs` Condition
                                   should be used to provide more detail about the problem.
 
+
                                   Support: Extended for Kubernetes Service
+
 
                                   Support: Implementation-specific for any other resource
                                 properties:
@@ -4325,7 +5019,9 @@ spec:
                                       Kind is the Kubernetes resource kind of the referent. For example
                                       "Service".
 
+
                                       Defaults to "Service" when not specified.
+
 
                                       ExternalName services can refer to CNAME DNS records that may live
                                       outside of the cluster and as such are difficult to reason about in
@@ -4333,7 +5029,9 @@ spec:
                                       CVE-2021-25740 for more information). Implementations SHOULD NOT
                                       support ExternalName Services.
 
+
                                       Support: Core (Services with a type other than ExternalName)
+
 
                                       Support: Implementation-specific (Services with type ExternalName)
                                     maxLength: 63
@@ -4350,10 +5048,12 @@ spec:
                                       Namespace is the namespace of the backend. When unspecified, the local
                                       namespace is inferred.
 
+
                                       Note that when a namespace different than the local namespace is specified,
                                       a ReferenceGrant object is required in the referent namespace to allow that
                                       namespace's owner to accept the reference. See the ReferenceGrant
                                       documentation for details.
+
 
                                       Support: Core
                                     maxLength: 63
@@ -4386,6 +5086,7 @@ spec:
                               RequestRedirect defines a schema for a filter that responds to the
                               request with an HTTP redirection.
 
+
                               Support: Core
                             properties:
                               hostname:
@@ -4393,6 +5094,7 @@ spec:
                                   Hostname is the hostname to be used in the value of the `Location`
                                   header in the response.
                                   When empty, the hostname in the `Host` header of the request is used.
+
 
                                   Support: Core
                                 maxLength: 253
@@ -4404,6 +5106,7 @@ spec:
                                   Path defines parameters used to modify the path of the incoming request.
                                   The modified path is then used to construct the `Location` header. When
                                   empty, the request path is used as-is.
+
 
                                   Support: Extended
                                 properties:
@@ -4420,17 +5123,32 @@ spec:
                                       to "/foo/bar" with a prefix match of "/foo" and a ReplacePrefixMatch
                                       of "/xyz" would be modified to "/xyz/bar".
 
+
                                       Note that this matches the behavior of the PathPrefix match type. This
                                       matches full path elements. A path element refers to the list of labels
                                       in the path split by the `/` separator. When specified, a trailing `/` is
                                       ignored. For example, the paths `/abc`, `/abc/`, and `/abc/def` would all
                                       match the prefix `/abc`, but the path `/abcd` would not.
 
+
                                       ReplacePrefixMatch is only compatible with a `PathPrefix` HTTPRouteMatch.
                                       Using any other HTTPRouteMatch type on the same HTTPRouteRule will result in
                                       the implementation setting the Accepted Condition for the Route to `status: False`.
 
+
                                       Request Path | Prefix Match | Replace Prefix | Modified Path
+                                      -------------|--------------|----------------|----------
+                                      /foo/bar     | /foo         | /xyz           | /xyz/bar
+                                      /foo/bar     | /foo         | /xyz/          | /xyz/bar
+                                      /foo/bar     | /foo/        | /xyz           | /xyz/bar
+                                      /foo/bar     | /foo/        | /xyz/          | /xyz/bar
+                                      /foo         | /foo         | /xyz           | /xyz
+                                      /foo/        | /foo         | /xyz           | /xyz/
+                                      /foo/bar     | /foo         | <empty string> | /bar
+                                      /foo/        | /foo         | <empty string> | /
+                                      /foo         | /foo         | <empty string> | /
+                                      /foo/        | /foo         | /              | /
+                                      /foo         | /foo         | /              | /
                                     maxLength: 1024
                                     type: string
                                   type:
@@ -4438,8 +5156,10 @@ spec:
                                       Type defines the type of path modifier. Additional types may be
                                       added in a future release of the API.
 
+
                                       Note that values may be added to this enum, implementations
                                       must ensure that unknown values will not cause a crash.
+
 
                                       Unknown values here must result in the implementation setting the
                                       Accepted Condition for the Route to `status: False`, with a
@@ -4473,8 +5193,10 @@ spec:
                                   Port is the port to be used in the value of the `Location`
                                   header in the response.
 
+
                                   If no port is specified, the redirect port MUST be derived using the
                                   following rules:
+
 
                                   * If redirect scheme is not-empty, the redirect port MUST be the well-known
                                     port associated with the redirect scheme. Specifically "http" to port 80
@@ -4483,13 +5205,16 @@ spec:
                                   * If redirect scheme is empty, the redirect port MUST be the Gateway
                                     Listener port.
 
+
                                   Implementations SHOULD NOT add the port number in the 'Location'
                                   header in the following cases:
+
 
                                   * A Location header that will use HTTP (whether that is determined via
                                     the Listener protocol or the Scheme field) _and_ use port 80.
                                   * A Location header that will use HTTPS (whether that is determined via
                                     the Listener protocol or the Scheme field) _and_ use port 443.
+
 
                                   Support: Extended
                                 format: int32
@@ -4501,15 +5226,19 @@ spec:
                                   Scheme is the scheme to be used in the value of the `Location` header in
                                   the response. When empty, the scheme of the request is used.
 
+
                                   Scheme redirects can affect the port of the redirect, for more information,
                                   refer to the documentation for the port field of this filter.
+
 
                                   Note that values may be added to this enum, implementations
                                   must ensure that unknown values will not cause a crash.
 
+
                                   Unknown values here must result in the implementation setting the
                                   Accepted Condition for the Route to `status: False`, with a
                                   Reason of `UnsupportedValue`.
+
 
                                   Support: Extended
                                 enum:
@@ -4521,12 +5250,15 @@ spec:
                                 description: |-
                                   StatusCode is the HTTP status code to be used in response.
 
+
                                   Note that values may be added to this enum, implementations
                                   must ensure that unknown values will not cause a crash.
+
 
                                   Unknown values here must result in the implementation setting the
                                   Accepted Condition for the Route to `status: False`, with a
                                   Reason of `UnsupportedValue`.
+
 
                                   Support: Core
                                 enum:
@@ -4539,6 +5271,7 @@ spec:
                               ResponseHeaderModifier defines a schema for a filter that modifies response
                               headers.
 
+
                               Support: Extended
                             properties:
                               add:
@@ -4547,14 +5280,17 @@ spec:
                                   before the action. It appends to any existing values associated
                                   with the header name.
 
+
                                   Input:
                                     GET /foo HTTP/1.1
                                     my-header: foo
+
 
                                   Config:
                                     add:
                                     - name: "my-header"
                                       value: "bar,baz"
+
 
                                   Output:
                                     GET /foo HTTP/1.1
@@ -4567,6 +5303,7 @@ spec:
                                       description: |-
                                         Name is the name of the HTTP Header to be matched. Name matching MUST be
                                         case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
 
                                         If multiple entries specify equivalent header names, the first entry with
                                         an equivalent name MUST be considered for a match. Subsequent entries
@@ -4599,14 +5336,17 @@ spec:
                                   names are case-insensitive (see
                                   https://datatracker.ietf.org/doc/html/rfc2616#section-4.2).
 
+
                                   Input:
                                     GET /foo HTTP/1.1
                                     my-header1: foo
                                     my-header2: bar
                                     my-header3: baz
 
+
                                   Config:
                                     remove: ["my-header1", "my-header3"]
+
 
                                   Output:
                                     GET /foo HTTP/1.1
@@ -4621,14 +5361,17 @@ spec:
                                   Set overwrites the request with the given header (name, value)
                                   before the action.
 
+
                                   Input:
                                     GET /foo HTTP/1.1
                                     my-header: foo
+
 
                                   Config:
                                     set:
                                     - name: "my-header"
                                       value: "bar"
+
 
                                   Output:
                                     GET /foo HTTP/1.1
@@ -4641,6 +5384,7 @@ spec:
                                       description: |-
                                         Name is the name of the HTTP Header to be matched. Name matching MUST be
                                         case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
 
                                         If multiple entries specify equivalent header names, the first entry with
                                         an equivalent name MUST be considered for a match. Subsequent entries
@@ -4672,13 +5416,16 @@ spec:
                               Type identifies the type of filter to apply. As with other API fields,
                               types are classified into three conformance levels:
 
+
                               - Core: Filter types and their corresponding configuration defined by
                                 "Support: Core" in this package, e.g. "RequestHeaderModifier". All
                                 implementations must support core filters.
 
+
                               - Extended: Filter types and their corresponding configuration defined by
                                 "Support: Extended" in this package, e.g. "RequestMirror". Implementers
                                 are encouraged to support extended filters.
+
 
                               - Implementation-specific: Filters that are defined and supported by
                                 specific vendors.
@@ -4688,15 +5435,19 @@ spec:
                                 is specified using the ExtensionRef field. `Type` should be set to
                                 "ExtensionRef" for custom filters.
 
+
                               Implementers are encouraged to define custom implementation types to
                               extend the core API with implementation-specific behavior.
+
 
                               If a reference to a custom filter type cannot be resolved, the filter
                               MUST NOT be skipped. Instead, requests that would have been processed by
                               that filter MUST receive a HTTP error response.
 
+
                               Note that values may be added to this enum, implementations
                               must ensure that unknown values will not cause a crash.
+
 
                               Unknown values here must result in the implementation setting the
                               Accepted Condition for the Route to `status: False`, with a
@@ -4713,12 +5464,14 @@ spec:
                             description: |-
                               URLRewrite defines a schema for a filter that modifies a request during forwarding.
 
+
                               Support: Extended
                             properties:
                               hostname:
                                 description: |-
                                   Hostname is the value to be used to replace the Host header value during
                                   forwarding.
+
 
                                   Support: Extended
                                 maxLength: 253
@@ -4728,6 +5481,7 @@ spec:
                               path:
                                 description: |-
                                   Path defines a path rewrite.
+
 
                                   Support: Extended
                                 properties:
@@ -4744,17 +5498,32 @@ spec:
                                       to "/foo/bar" with a prefix match of "/foo" and a ReplacePrefixMatch
                                       of "/xyz" would be modified to "/xyz/bar".
 
+
                                       Note that this matches the behavior of the PathPrefix match type. This
                                       matches full path elements. A path element refers to the list of labels
                                       in the path split by the `/` separator. When specified, a trailing `/` is
                                       ignored. For example, the paths `/abc`, `/abc/`, and `/abc/def` would all
                                       match the prefix `/abc`, but the path `/abcd` would not.
 
+
                                       ReplacePrefixMatch is only compatible with a `PathPrefix` HTTPRouteMatch.
                                       Using any other HTTPRouteMatch type on the same HTTPRouteRule will result in
                                       the implementation setting the Accepted Condition for the Route to `status: False`.
 
+
                                       Request Path | Prefix Match | Replace Prefix | Modified Path
+                                      -------------|--------------|----------------|----------
+                                      /foo/bar     | /foo         | /xyz           | /xyz/bar
+                                      /foo/bar     | /foo         | /xyz/          | /xyz/bar
+                                      /foo/bar     | /foo/        | /xyz           | /xyz/bar
+                                      /foo/bar     | /foo/        | /xyz/          | /xyz/bar
+                                      /foo         | /foo         | /xyz           | /xyz
+                                      /foo/        | /foo         | /xyz           | /xyz/
+                                      /foo/bar     | /foo         | <empty string> | /bar
+                                      /foo/        | /foo         | <empty string> | /
+                                      /foo         | /foo         | <empty string> | /
+                                      /foo/        | /foo         | /              | /
+                                      /foo         | /foo         | /              | /
                                     maxLength: 1024
                                     type: string
                                   type:
@@ -4762,8 +5531,10 @@ spec:
                                       Type defines the type of path modifier. Additional types may be
                                       added in a future release of the API.
 
+
                                       Note that values may be added to this enum, implementations
                                       must ensure that unknown values will not cause a crash.
+
 
                                       Unknown values here must result in the implementation setting the
                                       Accepted Condition for the Route to `status: False`, with a
@@ -4865,7 +5636,9 @@ spec:
                         HTTP requests. Each match is independent, i.e. this rule will be matched
                         if **any** one of the matches is satisfied.
 
+
                         For example, take the following matches configuration:
+
 
                         ```
                         matches:
@@ -4878,23 +5651,29 @@ spec:
                             value: "/v2/foo"
                         ```
 
+
                         For a request to match against this rule, a request must satisfy
                         EITHER of the two conditions:
+
 
                         - path prefixed with `/foo` AND contains the header `version: v2`
                         - path prefix of `/v2/foo`
 
+
                         See the documentation for HTTPRouteMatch on how to specify multiple
                         match conditions that should be ANDed together.
+
 
                         If no matches are specified, the default is a prefix
                         path match on "/", which has the effect of matching every
                         HTTP request.
 
+
                         Proxy or Load Balancer routing configuration generated from HTTPRoutes
                         MUST prioritize matches based on the following criteria, continuing on
                         ties. Across all rules specified on applicable Routes, precedence must be
                         given to the match having:
+
 
                         * "Exact" path match.
                         * "Prefix" path match with largest number of characters.
@@ -4902,18 +5681,23 @@ spec:
                         * Largest number of header matches.
                         * Largest number of query param matches.
 
+
                         Note: The precedence of RegularExpression path matches are implementation-specific.
+
 
                         If ties still exist across multiple Routes, matching precedence MUST be
                         determined in order of the following criteria, continuing on ties:
+
 
                         * The oldest Route based on creation timestamp.
                         * The Route appearing first in alphabetical order by
                           "{namespace}/{name}".
 
+
                         If ties still exist within an HTTPRoute, matching precedence MUST be granted
                         to the FIRST matching rule (in list order) with a match meeting the above
                         criteria.
+
 
                         When no rules matching a request have been successfully attached to the
                         parent a request is coming from, a HTTP 404 status code MUST be returned.
@@ -4921,11 +5705,11 @@ spec:
                         description: "HTTPRouteMatch defines the predicate used to
                           match requests to a given\naction. Multiple match types
                           are ANDed together, i.e. the match will\nevaluate to true
-                          only if all conditions are satisfied.\n\nFor example, the
-                          match below will match a HTTP request only if its path\nstarts
-                          with `/foo` AND it contains the `version: v1` header:\n\n```\nmatch:\n\n\tpath:\n\t
+                          only if all conditions are satisfied.\n\n\nFor example,
+                          the match below will match a HTTP request only if its path\nstarts
+                          with `/foo` AND it contains the `version: v1` header:\n\n\n```\nmatch:\n\n\n\tpath:\n\t
                           \ value: \"/foo\"\n\theaders:\n\t- name: \"version\"\n\t
-                          \ value \"v1\"\n\n```"
+                          \ value \"v1\"\n\n\n```"
                         properties:
                           headers:
                             description: |-
@@ -4942,11 +5726,13 @@ spec:
                                     Name is the name of the HTTP Header to be matched. Name matching MUST be
                                     case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
 
+
                                     If multiple entries specify equivalent header names, only the first
                                     entry with an equivalent name MUST be considered for a match. Subsequent
                                     entries with an equivalent header name MUST be ignored. Due to the
                                     case-insensitivity of header names, "foo" and "Foo" are considered
                                     equivalent.
+
 
                                     When a header is repeated in an HTTP request, it is
                                     implementation-specific behavior as to how this is represented.
@@ -4962,9 +5748,12 @@ spec:
                                   description: |-
                                     Type specifies how to match against the value of the header.
 
+
                                     Support: Core (Exact)
 
+
                                     Support: Implementation-specific (RegularExpression)
+
 
                                     Since RegularExpression HeaderMatchType has implementation-specific
                                     conformance, implementations can support POSIX, PCRE or any other dialects
@@ -4995,6 +5784,7 @@ spec:
                               When specified, this route will be matched only if the request has the
                               specified method.
 
+
                               Support: Extended
                             enum:
                             - GET
@@ -5020,7 +5810,9 @@ spec:
                                 description: |-
                                   Type specifies how to match against the path Value.
 
+
                                   Support: Core (Exact, PathPrefix)
+
 
                                   Support: Implementation-specific (RegularExpression)
                                 enum:
@@ -5086,6 +5878,7 @@ spec:
                               values are ANDed together, meaning, a request must match all the
                               specified query parameters to select the route.
 
+
                               Support: Extended
                             items:
                               description: |-
@@ -5098,9 +5891,11 @@ spec:
                                     exact string match. (See
                                     https://tools.ietf.org/html/rfc7230#section-2.7.3).
 
+
                                     If multiple entries specify equivalent query param names, only the first
                                     entry with an equivalent name MUST be considered for a match. Subsequent
                                     entries with an equivalent query param name MUST be ignored.
+
 
                                     If a query param is repeated in an HTTP request, the behavior is
                                     purposely left undefined, since different data planes have different
@@ -5108,6 +5903,7 @@ spec:
                                     match against the first value of the param if the data plane supports it,
                                     as this behavior is expected in other load balancing contexts outside of
                                     the Gateway API.
+
 
                                     Users SHOULD NOT route traffic based on repeated query params to guard
                                     themselves against potential differences in the implementations.
@@ -5120,9 +5916,12 @@ spec:
                                   description: |-
                                     Type specifies how to match against the value of the query parameter.
 
+
                                     Support: Extended (Exact)
 
+
                                     Support: Implementation-specific (RegularExpression)
+
 
                                     Since RegularExpression QueryParamMatchType has Implementation-specific
                                     conformance, implementations can support POSIX, PCRE or any other
@@ -5148,13 +5947,116 @@ spec:
                             - name
                             x-kubernetes-list-type: map
                         type: object
-                      maxItems: 64
+                      maxItems: 8
                       type: array
-                    timeouts:
-                      description: |-
-                        Timeouts defines the timeouts that can be configured for an HTTP request.
+                    sessionPersistence:
+                      description: |+
+                        SessionPersistence defines and configures session persistence
+                        for the route rule.
+
 
                         Support: Extended
+
+
+                      properties:
+                        absoluteTimeout:
+                          description: |-
+                            AbsoluteTimeout defines the absolute timeout of the persistent
+                            session. Once the AbsoluteTimeout duration has elapsed, the
+                            session becomes invalid.
+
+
+                            Support: Extended
+                          pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                          type: string
+                        cookieConfig:
+                          description: |-
+                            CookieConfig provides configuration settings that are specific
+                            to cookie-based session persistence.
+
+
+                            Support: Core
+                          properties:
+                            lifetimeType:
+                              default: Session
+                              description: |-
+                                LifetimeType specifies whether the cookie has a permanent or
+                                session-based lifetime. A permanent cookie persists until its
+                                specified expiry time, defined by the Expires or Max-Age cookie
+                                attributes, while a session cookie is deleted when the current
+                                session ends.
+
+
+                                When set to "Permanent", AbsoluteTimeout indicates the
+                                cookie's lifetime via the Expires or Max-Age cookie attributes
+                                and is required.
+
+
+                                When set to "Session", AbsoluteTimeout indicates the
+                                absolute lifetime of the cookie tracked by the gateway and
+                                is optional.
+
+
+                                Support: Core for "Session" type
+
+
+                                Support: Extended for "Permanent" type
+                              enum:
+                              - Permanent
+                              - Session
+                              type: string
+                          type: object
+                        idleTimeout:
+                          description: |-
+                            IdleTimeout defines the idle timeout of the persistent session.
+                            Once the session has been idle for more than the specified
+                            IdleTimeout duration, the session becomes invalid.
+
+
+                            Support: Extended
+                          pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                          type: string
+                        sessionName:
+                          description: |-
+                            SessionName defines the name of the persistent session token
+                            which may be reflected in the cookie or the header. Users
+                            should avoid reusing session names to prevent unintended
+                            consequences, such as rejection or unpredictable behavior.
+
+
+                            Support: Implementation-specific
+                          maxLength: 128
+                          type: string
+                        type:
+                          default: Cookie
+                          description: |-
+                            Type defines the type of session persistence such as through
+                            the use a header or cookie. Defaults to cookie based session
+                            persistence.
+
+
+                            Support: Core for "Cookie" type
+
+
+                            Support: Extended for "Header" type
+                          enum:
+                          - Cookie
+                          - Header
+                          type: string
+                      type: object
+                      x-kubernetes-validations:
+                      - message: AbsoluteTimeout must be specified when cookie lifetimeType
+                          is Permanent
+                        rule: '!has(self.cookieConfig.lifetimeType) || self.cookieConfig.lifetimeType
+                          != ''Permanent'' || has(self.absoluteTimeout)'
+                    timeouts:
+                      description: |+
+                        Timeouts defines the timeouts that can be configured for an HTTP request.
+
+
+                        Support: Extended
+
+
                       properties:
                         backendRequest:
                           description: |-
@@ -5162,19 +6064,21 @@ spec:
                             to a backend. This covers the time from when the request first starts being
                             sent from the gateway to when the full response has been received from the backend.
 
+
                             Setting a timeout to the zero duration (e.g. "0s") SHOULD disable the timeout
                             completely. Implementations that cannot completely disable the timeout MUST
                             instead interpret the zero duration as the longest possible value to which
                             the timeout can be set.
 
+
                             An entire client HTTP transaction with a gateway, covered by the Request timeout,
                             may result in more than one call from the gateway to the destination backend,
                             for example, if automatic retries are supported.
 
-                            The value of BackendRequest must be a Gateway API Duration string as defined by
-                            GEP-2257.  When this field is unspecified, its behavior is implementation-specific;
-                            when specified, the value of BackendRequest must be no more than the value of the
-                            Request timeout (since the Request timeout encompasses the BackendRequest timeout).
+
+                            Because the Request timeout encompasses the BackendRequest timeout, the value of
+                            BackendRequest must be <= the value of Request timeout.
+
 
                             Support: Extended
                           pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
@@ -5185,22 +6089,26 @@ spec:
                             If the gateway has not been able to respond before this deadline is met, the gateway
                             MUST return a timeout error.
 
+
                             For example, setting the `rules.timeouts.request` field to the value `10s` in an
                             `HTTPRoute` will cause a timeout if a client request is taking longer than 10 seconds
                             to complete.
+
 
                             Setting a timeout to the zero duration (e.g. "0s") SHOULD disable the timeout
                             completely. Implementations that cannot completely disable the timeout MUST
                             instead interpret the zero duration as the longest possible value to which
                             the timeout can be set.
 
+
                             This timeout is intended to cover as close to the whole request-response transaction
                             as possible although an implementation MAY choose to start the timeout after the entire
                             request stream has been received instead of immediately after the transaction is
                             initiated by the client.
 
-                            The value of Request is a Gateway API Duration string as defined by GEP-2257. When this
-                            field is unspecified, request timeout behavior is implementation-specific.
+
+                            When this field is unspecified, request timeout behavior is implementation-specific.
+
 
                             Support: Extended
                           pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
@@ -5255,21 +6163,6 @@ spec:
                       != ''PathPrefix'') ? false : true) : true'
                 maxItems: 16
                 type: array
-                x-kubernetes-validations:
-                - message: While 16 rules and 64 matches per rule are allowed, the
-                    total number of matches across all rules in a route must be less
-                    than 128
-                  rule: '(self.size() > 0 ? self[0].matches.size() : 0) + (self.size()
-                    > 1 ? self[1].matches.size() : 0) + (self.size() > 2 ? self[2].matches.size()
-                    : 0) + (self.size() > 3 ? self[3].matches.size() : 0) + (self.size()
-                    > 4 ? self[4].matches.size() : 0) + (self.size() > 5 ? self[5].matches.size()
-                    : 0) + (self.size() > 6 ? self[6].matches.size() : 0) + (self.size()
-                    > 7 ? self[7].matches.size() : 0) + (self.size() > 8 ? self[8].matches.size()
-                    : 0) + (self.size() > 9 ? self[9].matches.size() : 0) + (self.size()
-                    > 10 ? self[10].matches.size() : 0) + (self.size() > 11 ? self[11].matches.size()
-                    : 0) + (self.size() > 12 ? self[12].matches.size() : 0) + (self.size()
-                    > 13 ? self[13].matches.size() : 0) + (self.size() > 14 ? self[14].matches.size()
-                    : 0) + (self.size() > 15 ? self[15].matches.size() : 0) <= 128'
             type: object
           status:
             description: Status defines the current state of HTTPRoute.
@@ -5283,10 +6176,12 @@ spec:
                   first sees the route and should update the entry as appropriate when the
                   route or gateway is modified.
 
+
                   Note that parent references that cannot be resolved by an implementation
                   of this API will not be added to this list. Implementations of this API
                   can only populate Route status for the Gateways/parent resources they are
                   responsible for.
+
 
                   A maximum of 32 Gateways will be represented in this list. An empty list
                   means the route has not been attached to any Gateway.
@@ -5301,24 +6196,38 @@ spec:
                         Note that the route's availability is also subject to the Gateway's own
                         status conditions and listener status.
 
+
                         If the Route's ParentRef specifies an existing Gateway that supports
                         Routes of this kind AND that Gateway's controller has sufficient access,
                         then that Gateway's controller MUST set the "Accepted" condition on the
                         Route, to indicate whether the route has been accepted or rejected by the
                         Gateway, and why.
 
+
                         A Route MUST be considered "Accepted" if at least one of the Route's
                         rules is implemented by the Gateway.
 
+
                         There are a number of cases where the "Accepted" condition may not be set
                         due to lack of controller visibility, that includes when:
+
 
                         * The Route refers to a non-existent parent.
                         * The Route is of a type that the controller does not support.
                         * The Route is in a namespace the controller does not have access to.
                       items:
-                        description: Condition contains details for one aspect of
-                          the current state of this API Resource.
+                        description: "Condition contains details for one aspect of
+                          the current state of this API Resource.\n---\nThis struct
+                          is intended for direct use as an array at the field path
+                          .status.conditions.  For example,\n\n\n\ttype FooStatus
+                          struct{\n\t    // Represents the observations of a foo's
+                          current state.\n\t    // Known .status.conditions.type are:
+                          \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                          +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    //
+                          +listType=map\n\t    // +listMapKey=type\n\t    Conditions
+                          []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\"
+                          patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                          \   // other fields\n\t}"
                         properties:
                           lastTransitionTime:
                             description: |-
@@ -5360,7 +6269,12 @@ spec:
                             - Unknown
                             type: string
                           type:
-                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                            description: |-
+                              type of condition in CamelCase or in foo.example.com/CamelCase.
+                              ---
+                              Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                              useful (see .node.status.conditions), the ability to deconflict is important.
+                              The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
                             maxLength: 316
                             pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                             type: string
@@ -5383,11 +6297,14 @@ spec:
                         controller that wrote this status. This corresponds with the
                         controllerName field on GatewayClass.
 
+
                         Example: "example.net/gateway-controller".
+
 
                         The format of this field is DOMAIN "/" PATH, where DOMAIN and PATH are
                         valid Kubernetes names
                         (https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names).
+
 
                         Controllers MUST populate this field when writing status. Controllers should ensure that
                         entries to status populated with their ControllerName are cleaned up when they are no
@@ -5409,6 +6326,7 @@ spec:
                             To set the core API group (such as for a "Service" kind referent),
                             Group must be explicitly set to "" (empty string).
 
+
                             Support: Core
                           maxLength: 253
                           pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
@@ -5418,10 +6336,13 @@ spec:
                           description: |-
                             Kind is kind of the referent.
 
+
                             There are two kinds of parent resources with "Core" support:
+
 
                             * Gateway (Gateway conformance profile)
                             * Service (Mesh conformance profile, ClusterIP Services only)
+
 
                             Support for other resources is Implementation-Specific.
                           maxLength: 63
@@ -5432,6 +6353,7 @@ spec:
                           description: |-
                             Name is the name of the referent.
 
+
                             Support: Core
                           maxLength: 253
                           minLength: 1
@@ -5441,11 +6363,25 @@ spec:
                             Namespace is the namespace of the referent. When unspecified, this refers
                             to the local namespace of the Route.
 
+
                             Note that there are specific rules for ParentRefs which cross namespace
                             boundaries. Cross-namespace references are only valid if they are explicitly
                             allowed by something in the namespace they are referring to. For example:
                             Gateway has the AllowedRoutes field, and ReferenceGrant provides a
                             generic way to enable any other kind of cross-namespace reference.
+
+
+
+                            ParentRefs from a Route to a Service in the same namespace are "producer"
+                            routes, which apply default routing rules to inbound connections from
+                            any namespace to the Service.
+
+
+                            ParentRefs from a Route to a Service in a different namespace are
+                            "consumer" routes, and these routing rules are only applied to outbound
+                            connections originating from the same namespace as the Route, for which
+                            the intended destination of the connections are a Service targeted as a
+                            ParentRef of the Route.
 
 
 
@@ -5459,6 +6395,7 @@ spec:
                             Port is the network port this Route targets. It can be interpreted
                             differently based on the type of parent resource.
 
+
                             When the parent resource is a Gateway, this targets all listeners
                             listening on the specified port that also support this kind of Route(and
                             select this Route). It's not recommended to set `Port` unless the
@@ -5469,9 +6406,16 @@ spec:
 
 
 
+                            When the parent resource is a Service, this targets a specific port in the
+                            Service spec. When both Port (experimental) and SectionName are specified,
+                            the name and port of the selected port must match both specified values.
+
+
+
                             Implementations MAY choose to support other parent resources.
                             Implementations supporting other types of parent resources MUST clearly
                             document how/if Port is interpreted.
+
 
                             For the purpose of status, an attachment is considered successful as
                             long as the parent resource accepts it partially. For example, Gateway
@@ -5480,6 +6424,7 @@ spec:
                             from the referencing Route, the Route MUST be considered successfully
                             attached. If no Gateway listeners accept attachment from this Route,
                             the Route MUST be considered detached from the Gateway.
+
 
                             Support: Extended
                           format: int32
@@ -5491,6 +6436,7 @@ spec:
                             SectionName is the name of a section within the target resource. In the
                             following resources, SectionName is interpreted as the following:
 
+
                             * Gateway: Listener name. When both Port (experimental) and SectionName
                             are specified, the name and port of the selected listener must match
                             both specified values.
@@ -5498,9 +6444,11 @@ spec:
                             are specified, the name and port of the selected listener must match
                             both specified values.
 
+
                             Implementations MAY choose to support attaching Routes to other resources.
                             If that is the case, they MUST clearly document how SectionName is
                             interpreted.
+
 
                             When unspecified (empty string), this will reference the entire resource.
                             For the purpose of status, an attachment is considered successful if at
@@ -5510,6 +6458,7 @@ spec:
                             the referencing Route, the Route MUST be considered successfully
                             attached. If no Gateway listeners accept attachment from this Route, the
                             Route MUST be considered detached from the Gateway.
+
 
                             Support: Core
                           maxLength: 253

--- a/platform/gateway-api/chart/templates/referencegrants.yaml
+++ b/platform/gateway-api/chart/templates/referencegrants.yaml
@@ -1,6 +1,6 @@
 {{/*
   Vendored from kubernetes-sigs/gateway-api {{ index .Chart.Annotations "catalyst.openova.io/upstream-gateway-api-version" }}
-  standard-install.yaml. Do NOT hand-edit annotations / spec — re-vendor
+  experimental-install.yaml. Do NOT hand-edit annotations / spec — re-vendor
   via the script in tests/regenerate.sh when bumping the upstream version
   (also bump catalyst.openova.io/upstream-gateway-api-version in Chart.yaml).
 
@@ -9,17 +9,18 @@
   cluster-scoped infrastructure; deleting them on uninstall would break
   every HTTPRoute on the cluster simultaneously.
 */}}
+
 #
-# config/crd/standard/gateway.networking.k8s.io_referencegrants.yaml
+# config/crd/experimental/gateway.networking.k8s.io_referencegrants.yaml
 #
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
     helm.sh/resource-policy: keep
-    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/3328
-    gateway.networking.k8s.io/bundle-version: v1.2.0
-    gateway.networking.k8s.io/channel: standard
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/2997
+    gateway.networking.k8s.io/bundle-version: v1.1.0
+    gateway.networking.k8s.io/channel: experimental
   creationTimestamp: null
   name: referencegrants.gateway.networking.k8s.io
 spec:
@@ -39,7 +40,10 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
-    name: v1beta1
+    deprecated: true
+    deprecationWarning: The v1alpha2 version of ReferenceGrant has been deprecated
+      and will be removed in a future release of the API. Please upgrade to v1beta1.
+    name: v1alpha2
     schema:
       openAPIV3Schema:
         description: |-
@@ -47,12 +51,19 @@ spec:
           trusted to reference the specified kinds of resources in the same namespace
           as the policy.
 
+
           Each ReferenceGrant can be used to represent a unique trust relationship.
           Additional Reference Grants can be used to add to the set of trusted
           sources of inbound references for the namespace they are defined within.
 
-          All cross-namespace references in Gateway API (with the exception of cross-namespace
-          Gateway-route attachment) require a ReferenceGrant.
+
+          A ReferenceGrant is required for all cross-namespace references in Gateway API
+          (with the exception of cross-namespace Route-Gateway attachment, which is
+          governed by the AllowedRoutes configuration on the Gateway, and cross-namespace
+          Service ParentRefs on a "consumer" mesh Route, which defines routing rules
+          applicable only to workloads in the Route namespace). ReferenceGrants allowing
+          a reference from a Route to a Service are only applicable to BackendRefs.
+
 
           ReferenceGrant is a form of runtime verification allowing users to assert
           which cross-namespace object references are permitted. Implementations that
@@ -87,6 +98,7 @@ spec:
                   to be an additional place that references can be valid from, or to put
                   this another way, entries MUST be combined using OR.
 
+
                   Support: Core
                 items:
                   description: ReferenceGrantFrom describes trusted namespaces and
@@ -96,6 +108,7 @@ spec:
                       description: |-
                         Group is the group of the referent.
                         When empty, the Kubernetes core API group is inferred.
+
 
                         Support: Core
                       maxLength: 253
@@ -107,11 +120,15 @@ spec:
                         additional resources, the following types are part of the "Core"
                         support level for this field.
 
+
                         When used to permit a SecretObjectReference:
+
 
                         * Gateway
 
+
                         When used to permit a BackendObjectReference:
+
 
                         * GRPCRoute
                         * HTTPRoute
@@ -125,6 +142,7 @@ spec:
                     namespace:
                       description: |-
                         Namespace is the namespace of the referent.
+
 
                         Support: Core
                       maxLength: 63
@@ -146,6 +164,7 @@ spec:
                   additional place that references can be valid to, or to put this another
                   way, entries MUST be combined using OR.
 
+
                   Support: Core
                 items:
                   description: |-
@@ -157,6 +176,7 @@ spec:
                         Group is the group of the referent.
                         When empty, the Kubernetes core API group is inferred.
 
+
                         Support: Core
                       maxLength: 253
                       pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
@@ -166,6 +186,181 @@ spec:
                         Kind is the kind of the referent. Although implementations may support
                         additional resources, the following types are part of the "Core"
                         support level for this field:
+
+
+                        * Secret when used to permit a SecretObjectReference
+                        * Service when used to permit a BackendObjectReference
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                      type: string
+                    name:
+                      description: |-
+                        Name is the name of the referent. When unspecified, this policy
+                        refers to all resources of the specified Group and Kind in the local
+                        namespace.
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                  required:
+                  - group
+                  - kind
+                  type: object
+                maxItems: 16
+                minItems: 1
+                type: array
+            required:
+            - from
+            - to
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources: {}
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          ReferenceGrant identifies kinds of resources in other namespaces that are
+          trusted to reference the specified kinds of resources in the same namespace
+          as the policy.
+
+
+          Each ReferenceGrant can be used to represent a unique trust relationship.
+          Additional Reference Grants can be used to add to the set of trusted
+          sources of inbound references for the namespace they are defined within.
+
+
+          All cross-namespace references in Gateway API (with the exception of cross-namespace
+          Gateway-route attachment) require a ReferenceGrant.
+
+
+          ReferenceGrant is a form of runtime verification allowing users to assert
+          which cross-namespace object references are permitted. Implementations that
+          support ReferenceGrant MUST NOT permit cross-namespace references which have
+          no grant, and MUST respond to the removal of a grant by revoking the access
+          that the grant allowed.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of ReferenceGrant.
+            properties:
+              from:
+                description: |-
+                  From describes the trusted namespaces and kinds that can reference the
+                  resources described in "To". Each entry in this list MUST be considered
+                  to be an additional place that references can be valid from, or to put
+                  this another way, entries MUST be combined using OR.
+
+
+                  Support: Core
+                items:
+                  description: ReferenceGrantFrom describes trusted namespaces and
+                    kinds.
+                  properties:
+                    group:
+                      description: |-
+                        Group is the group of the referent.
+                        When empty, the Kubernetes core API group is inferred.
+
+
+                        Support: Core
+                      maxLength: 253
+                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    kind:
+                      description: |-
+                        Kind is the kind of the referent. Although implementations may support
+                        additional resources, the following types are part of the "Core"
+                        support level for this field.
+
+
+                        When used to permit a SecretObjectReference:
+
+
+                        * Gateway
+
+
+                        When used to permit a BackendObjectReference:
+
+
+                        * GRPCRoute
+                        * HTTPRoute
+                        * TCPRoute
+                        * TLSRoute
+                        * UDPRoute
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                      type: string
+                    namespace:
+                      description: |-
+                        Namespace is the namespace of the referent.
+
+
+                        Support: Core
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                      type: string
+                  required:
+                  - group
+                  - kind
+                  - namespace
+                  type: object
+                maxItems: 16
+                minItems: 1
+                type: array
+              to:
+                description: |-
+                  To describes the resources that may be referenced by the resources
+                  described in "From". Each entry in this list MUST be considered to be an
+                  additional place that references can be valid to, or to put this another
+                  way, entries MUST be combined using OR.
+
+
+                  Support: Core
+                items:
+                  description: |-
+                    ReferenceGrantTo describes what Kinds are allowed as targets of the
+                    references.
+                  properties:
+                    group:
+                      description: |-
+                        Group is the group of the referent.
+                        When empty, the Kubernetes core API group is inferred.
+
+
+                        Support: Core
+                      maxLength: 253
+                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    kind:
+                      description: |-
+                        Kind is the kind of the referent. Although implementations may support
+                        additional resources, the following types are part of the "Core"
+                        support level for this field:
+
 
                         * Secret when used to permit a SecretObjectReference
                         * Service when used to permit a BackendObjectReference

--- a/platform/gateway-api/chart/templates/tcproutes.yaml
+++ b/platform/gateway-api/chart/templates/tcproutes.yaml
@@ -1,0 +1,837 @@
+{{/*
+  Vendored from kubernetes-sigs/gateway-api {{ index .Chart.Annotations "catalyst.openova.io/upstream-gateway-api-version" }}
+  experimental-install.yaml. Do NOT hand-edit annotations / spec — re-vendor
+  via the script in tests/regenerate.sh when bumping the upstream version
+  (also bump catalyst.openova.io/upstream-gateway-api-version in Chart.yaml).
+
+  helm.sh/resource-policy: keep is added under metadata.annotations so a
+  Helm uninstall does NOT delete the CRD. Gateway API CRDs are foundational
+  cluster-scoped infrastructure; deleting them on uninstall would break
+  every HTTPRoute on the cluster simultaneously.
+*/}}
+
+#
+# config/crd/experimental/gateway.networking.k8s.io_tcproutes.yaml
+#
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    helm.sh/resource-policy: keep
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/2997
+    gateway.networking.k8s.io/bundle-version: v1.1.0
+    gateway.networking.k8s.io/channel: experimental
+  creationTimestamp: null
+  name: tcproutes.gateway.networking.k8s.io
+spec:
+  group: gateway.networking.k8s.io
+  names:
+    categories:
+    - gateway-api
+    kind: TCPRoute
+    listKind: TCPRouteList
+    plural: tcproutes
+    singular: tcproute
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: |-
+          TCPRoute provides a way to route TCP requests. When combined with a Gateway
+          listener, it can be used to forward connections on the port specified by the
+          listener to a set of backends specified by the TCPRoute.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of TCPRoute.
+            properties:
+              parentRefs:
+                description: |+
+                  ParentRefs references the resources (usually Gateways) that a Route wants
+                  to be attached to. Note that the referenced parent resource needs to
+                  allow this for the attachment to be complete. For Gateways, that means
+                  the Gateway needs to allow attachment from Routes of this kind and
+                  namespace. For Services, that means the Service must either be in the same
+                  namespace for a "producer" route, or the mesh implementation must support
+                  and allow "consumer" routes for the referenced Service. ReferenceGrant is
+                  not applicable for governing ParentRefs to Services - it is not possible to
+                  create a "producer" route for a Service in a different namespace from the
+                  Route.
+
+
+                  There are two kinds of parent resources with "Core" support:
+
+
+                  * Gateway (Gateway conformance profile)
+                  * Service (Mesh conformance profile, ClusterIP Services only)
+
+
+                  This API may be extended in the future to support additional kinds of parent
+                  resources.
+
+
+                  ParentRefs must be _distinct_. This means either that:
+
+
+                  * They select different objects.  If this is the case, then parentRef
+                    entries are distinct. In terms of fields, this means that the
+                    multi-part key defined by `group`, `kind`, `namespace`, and `name` must
+                    be unique across all parentRef entries in the Route.
+                  * They do not select different objects, but for each optional field used,
+                    each ParentRef that selects the same object must set the same set of
+                    optional fields to different values. If one ParentRef sets a
+                    combination of optional fields, all must set the same combination.
+
+
+                  Some examples:
+
+
+                  * If one ParentRef sets `sectionName`, all ParentRefs referencing the
+                    same object must also set `sectionName`.
+                  * If one ParentRef sets `port`, all ParentRefs referencing the same
+                    object must also set `port`.
+                  * If one ParentRef sets `sectionName` and `port`, all ParentRefs
+                    referencing the same object must also set `sectionName` and `port`.
+
+
+                  It is possible to separately reference multiple distinct objects that may
+                  be collapsed by an implementation. For example, some implementations may
+                  choose to merge compatible Gateway Listeners together. If that is the
+                  case, the list of routes attached to those resources should also be
+                  merged.
+
+
+                  Note that for ParentRefs that cross namespace boundaries, there are specific
+                  rules. Cross-namespace references are only valid if they are explicitly
+                  allowed by something in the namespace they are referring to. For example,
+                  Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                  generic way to enable other kinds of cross-namespace reference.
+
+
+
+                  ParentRefs from a Route to a Service in the same namespace are "producer"
+                  routes, which apply default routing rules to inbound connections from
+                  any namespace to the Service.
+
+
+                  ParentRefs from a Route to a Service in a different namespace are
+                  "consumer" routes, and these routing rules are only applied to outbound
+                  connections originating from the same namespace as the Route, for which
+                  the intended destination of the connections are a Service targeted as a
+                  ParentRef of the Route.
+
+
+
+
+
+
+                items:
+                  description: |-
+                    ParentReference identifies an API object (usually a Gateway) that can be considered
+                    a parent of this resource (usually a route). There are two kinds of parent resources
+                    with "Core" support:
+
+
+                    * Gateway (Gateway conformance profile)
+                    * Service (Mesh conformance profile, ClusterIP Services only)
+
+
+                    This API may be extended in the future to support additional kinds of parent
+                    resources.
+
+
+                    The API object must be valid in the cluster; the Group and Kind must
+                    be registered in the cluster for this reference to be valid.
+                  properties:
+                    group:
+                      default: gateway.networking.k8s.io
+                      description: |-
+                        Group is the group of the referent.
+                        When unspecified, "gateway.networking.k8s.io" is inferred.
+                        To set the core API group (such as for a "Service" kind referent),
+                        Group must be explicitly set to "" (empty string).
+
+
+                        Support: Core
+                      maxLength: 253
+                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    kind:
+                      default: Gateway
+                      description: |-
+                        Kind is kind of the referent.
+
+
+                        There are two kinds of parent resources with "Core" support:
+
+
+                        * Gateway (Gateway conformance profile)
+                        * Service (Mesh conformance profile, ClusterIP Services only)
+
+
+                        Support for other resources is Implementation-Specific.
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                      type: string
+                    name:
+                      description: |-
+                        Name is the name of the referent.
+
+
+                        Support: Core
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                    namespace:
+                      description: |-
+                        Namespace is the namespace of the referent. When unspecified, this refers
+                        to the local namespace of the Route.
+
+
+                        Note that there are specific rules for ParentRefs which cross namespace
+                        boundaries. Cross-namespace references are only valid if they are explicitly
+                        allowed by something in the namespace they are referring to. For example:
+                        Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                        generic way to enable any other kind of cross-namespace reference.
+
+
+
+                        ParentRefs from a Route to a Service in the same namespace are "producer"
+                        routes, which apply default routing rules to inbound connections from
+                        any namespace to the Service.
+
+
+                        ParentRefs from a Route to a Service in a different namespace are
+                        "consumer" routes, and these routing rules are only applied to outbound
+                        connections originating from the same namespace as the Route, for which
+                        the intended destination of the connections are a Service targeted as a
+                        ParentRef of the Route.
+
+
+
+                        Support: Core
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                      type: string
+                    port:
+                      description: |-
+                        Port is the network port this Route targets. It can be interpreted
+                        differently based on the type of parent resource.
+
+
+                        When the parent resource is a Gateway, this targets all listeners
+                        listening on the specified port that also support this kind of Route(and
+                        select this Route). It's not recommended to set `Port` unless the
+                        networking behaviors specified in a Route must apply to a specific port
+                        as opposed to a listener(s) whose port(s) may be changed. When both Port
+                        and SectionName are specified, the name and port of the selected listener
+                        must match both specified values.
+
+
+
+                        When the parent resource is a Service, this targets a specific port in the
+                        Service spec. When both Port (experimental) and SectionName are specified,
+                        the name and port of the selected port must match both specified values.
+
+
+
+                        Implementations MAY choose to support other parent resources.
+                        Implementations supporting other types of parent resources MUST clearly
+                        document how/if Port is interpreted.
+
+
+                        For the purpose of status, an attachment is considered successful as
+                        long as the parent resource accepts it partially. For example, Gateway
+                        listeners can restrict which Routes can attach to them by Route kind,
+                        namespace, or hostname. If 1 of 2 Gateway listeners accept attachment
+                        from the referencing Route, the Route MUST be considered successfully
+                        attached. If no Gateway listeners accept attachment from this Route,
+                        the Route MUST be considered detached from the Gateway.
+
+
+                        Support: Extended
+                      format: int32
+                      maximum: 65535
+                      minimum: 1
+                      type: integer
+                    sectionName:
+                      description: |-
+                        SectionName is the name of a section within the target resource. In the
+                        following resources, SectionName is interpreted as the following:
+
+
+                        * Gateway: Listener name. When both Port (experimental) and SectionName
+                        are specified, the name and port of the selected listener must match
+                        both specified values.
+                        * Service: Port name. When both Port (experimental) and SectionName
+                        are specified, the name and port of the selected listener must match
+                        both specified values.
+
+
+                        Implementations MAY choose to support attaching Routes to other resources.
+                        If that is the case, they MUST clearly document how SectionName is
+                        interpreted.
+
+
+                        When unspecified (empty string), this will reference the entire resource.
+                        For the purpose of status, an attachment is considered successful if at
+                        least one section in the parent resource accepts it. For example, Gateway
+                        listeners can restrict which Routes can attach to them by Route kind,
+                        namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from
+                        the referencing Route, the Route MUST be considered successfully
+                        attached. If no Gateway listeners accept attachment from this Route, the
+                        Route MUST be considered detached from the Gateway.
+
+
+                        Support: Core
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                  required:
+                  - name
+                  type: object
+                maxItems: 32
+                type: array
+                x-kubernetes-validations:
+                - message: sectionName or port must be specified when parentRefs includes
+                    2 or more references to the same parent
+                  rule: 'self.all(p1, self.all(p2, p1.group == p2.group && p1.kind
+                    == p2.kind && p1.name == p2.name && (((!has(p1.__namespace__)
+                    || p1.__namespace__ == '''') && (!has(p2.__namespace__) || p2.__namespace__
+                    == '''')) || (has(p1.__namespace__) && has(p2.__namespace__) &&
+                    p1.__namespace__ == p2.__namespace__)) ? ((!has(p1.sectionName)
+                    || p1.sectionName == '''') == (!has(p2.sectionName) || p2.sectionName
+                    == '''') && (!has(p1.port) || p1.port == 0) == (!has(p2.port)
+                    || p2.port == 0)): true))'
+                - message: sectionName or port must be unique when parentRefs includes
+                    2 or more references to the same parent
+                  rule: self.all(p1, self.exists_one(p2, p1.group == p2.group && p1.kind
+                    == p2.kind && p1.name == p2.name && (((!has(p1.__namespace__)
+                    || p1.__namespace__ == '') && (!has(p2.__namespace__) || p2.__namespace__
+                    == '')) || (has(p1.__namespace__) && has(p2.__namespace__) &&
+                    p1.__namespace__ == p2.__namespace__ )) && (((!has(p1.sectionName)
+                    || p1.sectionName == '') && (!has(p2.sectionName) || p2.sectionName
+                    == '')) || ( has(p1.sectionName) && has(p2.sectionName) && p1.sectionName
+                    == p2.sectionName)) && (((!has(p1.port) || p1.port == 0) && (!has(p2.port)
+                    || p2.port == 0)) || (has(p1.port) && has(p2.port) && p1.port
+                    == p2.port))))
+              rules:
+                description: Rules are a list of TCP matchers and actions.
+                items:
+                  description: TCPRouteRule is the configuration for a given rule.
+                  properties:
+                    backendRefs:
+                      description: |-
+                        BackendRefs defines the backend(s) where matching requests should be
+                        sent. If unspecified or invalid (refers to a non-existent resource or a
+                        Service with no endpoints), the underlying implementation MUST actively
+                        reject connection attempts to this backend. Connection rejections must
+                        respect weight; if an invalid backend is requested to have 80% of
+                        connections, then 80% of connections must be rejected instead.
+
+
+                        Support: Core for Kubernetes Service
+
+
+                        Support: Extended for Kubernetes ServiceImport
+
+
+                        Support: Implementation-specific for any other resource
+
+
+                        Support for weight: Extended
+                      items:
+                        description: |-
+                          BackendRef defines how a Route should forward a request to a Kubernetes
+                          resource.
+
+
+                          Note that when a namespace different than the local namespace is specified, a
+                          ReferenceGrant object is required in the referent namespace to allow that
+                          namespace's owner to accept the reference. See the ReferenceGrant
+                          documentation for details.
+
+
+                          <gateway:experimental:description>
+
+
+                          When the BackendRef points to a Kubernetes Service, implementations SHOULD
+                          honor the appProtocol field if it is set for the target Service Port.
+
+
+                          Implementations supporting appProtocol SHOULD recognize the Kubernetes
+                          Standard Application Protocols defined in KEP-3726.
+
+
+                          If a Service appProtocol isn't specified, an implementation MAY infer the
+                          backend protocol through its own means. Implementations MAY infer the
+                          protocol from the Route type referring to the backend Service.
+
+
+                          If a Route is not able to send traffic to the backend using the specified
+                          protocol then the backend is considered invalid. Implementations MUST set the
+                          "ResolvedRefs" condition to "False" with the "UnsupportedProtocol" reason.
+
+
+                          </gateway:experimental:description>
+
+
+                          Note that when the BackendTLSPolicy object is enabled by the implementation,
+                          there are some extra rules about validity to consider here. See the fields
+                          where this struct is used for more information about the exact behavior.
+                        properties:
+                          group:
+                            default: ""
+                            description: |-
+                              Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                              When unspecified or empty string, core API group is inferred.
+                            maxLength: 253
+                            pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                            type: string
+                          kind:
+                            default: Service
+                            description: |-
+                              Kind is the Kubernetes resource kind of the referent. For example
+                              "Service".
+
+
+                              Defaults to "Service" when not specified.
+
+
+                              ExternalName services can refer to CNAME DNS records that may live
+                              outside of the cluster and as such are difficult to reason about in
+                              terms of conformance. They also may not be safe to forward to (see
+                              CVE-2021-25740 for more information). Implementations SHOULD NOT
+                              support ExternalName Services.
+
+
+                              Support: Core (Services with a type other than ExternalName)
+
+
+                              Support: Implementation-specific (Services with type ExternalName)
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                            type: string
+                          name:
+                            description: Name is the name of the referent.
+                            maxLength: 253
+                            minLength: 1
+                            type: string
+                          namespace:
+                            description: |-
+                              Namespace is the namespace of the backend. When unspecified, the local
+                              namespace is inferred.
+
+
+                              Note that when a namespace different than the local namespace is specified,
+                              a ReferenceGrant object is required in the referent namespace to allow that
+                              namespace's owner to accept the reference. See the ReferenceGrant
+                              documentation for details.
+
+
+                              Support: Core
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                            type: string
+                          port:
+                            description: |-
+                              Port specifies the destination port number to use for this resource.
+                              Port is required when the referent is a Kubernetes Service. In this
+                              case, the port number is the service port number, not the target port.
+                              For other resources, destination port might be derived from the referent
+                              resource or this field.
+                            format: int32
+                            maximum: 65535
+                            minimum: 1
+                            type: integer
+                          weight:
+                            default: 1
+                            description: |-
+                              Weight specifies the proportion of requests forwarded to the referenced
+                              backend. This is computed as weight/(sum of all weights in this
+                              BackendRefs list). For non-zero values, there may be some epsilon from
+                              the exact proportion defined here depending on the precision an
+                              implementation supports. Weight is not a percentage and the sum of
+                              weights does not need to equal 100.
+
+
+                              If only one backend is specified and it has a weight greater than 0, 100%
+                              of the traffic is forwarded to that backend. If weight is set to 0, no
+                              traffic should be forwarded for this entry. If unspecified, weight
+                              defaults to 1.
+
+
+                              Support for this field varies based on the context where used.
+                            format: int32
+                            maximum: 1000000
+                            minimum: 0
+                            type: integer
+                        required:
+                        - name
+                        type: object
+                        x-kubernetes-validations:
+                        - message: Must have port for Service reference
+                          rule: '(size(self.group) == 0 && self.kind == ''Service'')
+                            ? has(self.port) : true'
+                      maxItems: 16
+                      minItems: 1
+                      type: array
+                  type: object
+                maxItems: 16
+                minItems: 1
+                type: array
+            required:
+            - rules
+            type: object
+          status:
+            description: Status defines the current state of TCPRoute.
+            properties:
+              parents:
+                description: |-
+                  Parents is a list of parent resources (usually Gateways) that are
+                  associated with the route, and the status of the route with respect to
+                  each parent. When this route attaches to a parent, the controller that
+                  manages the parent must add an entry to this list when the controller
+                  first sees the route and should update the entry as appropriate when the
+                  route or gateway is modified.
+
+
+                  Note that parent references that cannot be resolved by an implementation
+                  of this API will not be added to this list. Implementations of this API
+                  can only populate Route status for the Gateways/parent resources they are
+                  responsible for.
+
+
+                  A maximum of 32 Gateways will be represented in this list. An empty list
+                  means the route has not been attached to any Gateway.
+                items:
+                  description: |-
+                    RouteParentStatus describes the status of a route with respect to an
+                    associated Parent.
+                  properties:
+                    conditions:
+                      description: |-
+                        Conditions describes the status of the route with respect to the Gateway.
+                        Note that the route's availability is also subject to the Gateway's own
+                        status conditions and listener status.
+
+
+                        If the Route's ParentRef specifies an existing Gateway that supports
+                        Routes of this kind AND that Gateway's controller has sufficient access,
+                        then that Gateway's controller MUST set the "Accepted" condition on the
+                        Route, to indicate whether the route has been accepted or rejected by the
+                        Gateway, and why.
+
+
+                        A Route MUST be considered "Accepted" if at least one of the Route's
+                        rules is implemented by the Gateway.
+
+
+                        There are a number of cases where the "Accepted" condition may not be set
+                        due to lack of controller visibility, that includes when:
+
+
+                        * The Route refers to a non-existent parent.
+                        * The Route is of a type that the controller does not support.
+                        * The Route is in a namespace the controller does not have access to.
+                      items:
+                        description: "Condition contains details for one aspect of
+                          the current state of this API Resource.\n---\nThis struct
+                          is intended for direct use as an array at the field path
+                          .status.conditions.  For example,\n\n\n\ttype FooStatus
+                          struct{\n\t    // Represents the observations of a foo's
+                          current state.\n\t    // Known .status.conditions.type are:
+                          \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                          +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    //
+                          +listType=map\n\t    // +listMapKey=type\n\t    Conditions
+                          []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\"
+                          patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                          \   // other fields\n\t}"
+                        properties:
+                          lastTransitionTime:
+                            description: |-
+                              lastTransitionTime is the last time the condition transitioned from one status to another.
+                              This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                            format: date-time
+                            type: string
+                          message:
+                            description: |-
+                              message is a human readable message indicating details about the transition.
+                              This may be an empty string.
+                            maxLength: 32768
+                            type: string
+                          observedGeneration:
+                            description: |-
+                              observedGeneration represents the .metadata.generation that the condition was set based upon.
+                              For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                              with respect to the current state of the instance.
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          reason:
+                            description: |-
+                              reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected values and meanings for this field,
+                              and whether the values are considered a guaranteed API.
+                              The value should be a CamelCase string.
+                              This field may not be empty.
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                            - "True"
+                            - "False"
+                            - Unknown
+                            type: string
+                          type:
+                            description: |-
+                              type of condition in CamelCase or in foo.example.com/CamelCase.
+                              ---
+                              Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                              useful (see .node.status.conditions), the ability to deconflict is important.
+                              The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                        - lastTransitionTime
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      maxItems: 8
+                      minItems: 1
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - type
+                      x-kubernetes-list-type: map
+                    controllerName:
+                      description: |-
+                        ControllerName is a domain/path string that indicates the name of the
+                        controller that wrote this status. This corresponds with the
+                        controllerName field on GatewayClass.
+
+
+                        Example: "example.net/gateway-controller".
+
+
+                        The format of this field is DOMAIN "/" PATH, where DOMAIN and PATH are
+                        valid Kubernetes names
+                        (https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names).
+
+
+                        Controllers MUST populate this field when writing status. Controllers should ensure that
+                        entries to status populated with their ControllerName are cleaned up when they are no
+                        longer necessary.
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
+                      type: string
+                    parentRef:
+                      description: |-
+                        ParentRef corresponds with a ParentRef in the spec that this
+                        RouteParentStatus struct describes the status of.
+                      properties:
+                        group:
+                          default: gateway.networking.k8s.io
+                          description: |-
+                            Group is the group of the referent.
+                            When unspecified, "gateway.networking.k8s.io" is inferred.
+                            To set the core API group (such as for a "Service" kind referent),
+                            Group must be explicitly set to "" (empty string).
+
+
+                            Support: Core
+                          maxLength: 253
+                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                        kind:
+                          default: Gateway
+                          description: |-
+                            Kind is kind of the referent.
+
+
+                            There are two kinds of parent resources with "Core" support:
+
+
+                            * Gateway (Gateway conformance profile)
+                            * Service (Mesh conformance profile, ClusterIP Services only)
+
+
+                            Support for other resources is Implementation-Specific.
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                          type: string
+                        name:
+                          description: |-
+                            Name is the name of the referent.
+
+
+                            Support: Core
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: |-
+                            Namespace is the namespace of the referent. When unspecified, this refers
+                            to the local namespace of the Route.
+
+
+                            Note that there are specific rules for ParentRefs which cross namespace
+                            boundaries. Cross-namespace references are only valid if they are explicitly
+                            allowed by something in the namespace they are referring to. For example:
+                            Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                            generic way to enable any other kind of cross-namespace reference.
+
+
+
+                            ParentRefs from a Route to a Service in the same namespace are "producer"
+                            routes, which apply default routing rules to inbound connections from
+                            any namespace to the Service.
+
+
+                            ParentRefs from a Route to a Service in a different namespace are
+                            "consumer" routes, and these routing rules are only applied to outbound
+                            connections originating from the same namespace as the Route, for which
+                            the intended destination of the connections are a Service targeted as a
+                            ParentRef of the Route.
+
+
+
+                            Support: Core
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                          type: string
+                        port:
+                          description: |-
+                            Port is the network port this Route targets. It can be interpreted
+                            differently based on the type of parent resource.
+
+
+                            When the parent resource is a Gateway, this targets all listeners
+                            listening on the specified port that also support this kind of Route(and
+                            select this Route). It's not recommended to set `Port` unless the
+                            networking behaviors specified in a Route must apply to a specific port
+                            as opposed to a listener(s) whose port(s) may be changed. When both Port
+                            and SectionName are specified, the name and port of the selected listener
+                            must match both specified values.
+
+
+
+                            When the parent resource is a Service, this targets a specific port in the
+                            Service spec. When both Port (experimental) and SectionName are specified,
+                            the name and port of the selected port must match both specified values.
+
+
+
+                            Implementations MAY choose to support other parent resources.
+                            Implementations supporting other types of parent resources MUST clearly
+                            document how/if Port is interpreted.
+
+
+                            For the purpose of status, an attachment is considered successful as
+                            long as the parent resource accepts it partially. For example, Gateway
+                            listeners can restrict which Routes can attach to them by Route kind,
+                            namespace, or hostname. If 1 of 2 Gateway listeners accept attachment
+                            from the referencing Route, the Route MUST be considered successfully
+                            attached. If no Gateway listeners accept attachment from this Route,
+                            the Route MUST be considered detached from the Gateway.
+
+
+                            Support: Extended
+                          format: int32
+                          maximum: 65535
+                          minimum: 1
+                          type: integer
+                        sectionName:
+                          description: |-
+                            SectionName is the name of a section within the target resource. In the
+                            following resources, SectionName is interpreted as the following:
+
+
+                            * Gateway: Listener name. When both Port (experimental) and SectionName
+                            are specified, the name and port of the selected listener must match
+                            both specified values.
+                            * Service: Port name. When both Port (experimental) and SectionName
+                            are specified, the name and port of the selected listener must match
+                            both specified values.
+
+
+                            Implementations MAY choose to support attaching Routes to other resources.
+                            If that is the case, they MUST clearly document how SectionName is
+                            interpreted.
+
+
+                            When unspecified (empty string), this will reference the entire resource.
+                            For the purpose of status, an attachment is considered successful if at
+                            least one section in the parent resource accepts it. For example, Gateway
+                            listeners can restrict which Routes can attach to them by Route kind,
+                            namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from
+                            the referencing Route, the Route MUST be considered successfully
+                            attached. If no Gateway listeners accept attachment from this Route, the
+                            Route MUST be considered detached from the Gateway.
+
+
+                            Support: Core
+                          maxLength: 253
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                      required:
+                      - name
+                      type: object
+                  required:
+                  - controllerName
+                  - parentRef
+                  type: object
+                maxItems: 32
+                type: array
+            required:
+            - parents
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/platform/gateway-api/chart/templates/tlsroutes.yaml
+++ b/platform/gateway-api/chart/templates/tlsroutes.yaml
@@ -1,0 +1,910 @@
+{{/*
+  Vendored from kubernetes-sigs/gateway-api {{ index .Chart.Annotations "catalyst.openova.io/upstream-gateway-api-version" }}
+  experimental-install.yaml. Do NOT hand-edit annotations / spec — re-vendor
+  via the script in tests/regenerate.sh when bumping the upstream version
+  (also bump catalyst.openova.io/upstream-gateway-api-version in Chart.yaml).
+
+  helm.sh/resource-policy: keep is added under metadata.annotations so a
+  Helm uninstall does NOT delete the CRD. Gateway API CRDs are foundational
+  cluster-scoped infrastructure; deleting them on uninstall would break
+  every HTTPRoute on the cluster simultaneously.
+*/}}
+
+#
+# config/crd/experimental/gateway.networking.k8s.io_tlsroutes.yaml
+#
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    helm.sh/resource-policy: keep
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/2997
+    gateway.networking.k8s.io/bundle-version: v1.1.0
+    gateway.networking.k8s.io/channel: experimental
+  creationTimestamp: null
+  name: tlsroutes.gateway.networking.k8s.io
+spec:
+  group: gateway.networking.k8s.io
+  names:
+    categories:
+    - gateway-api
+    kind: TLSRoute
+    listKind: TLSRouteList
+    plural: tlsroutes
+    singular: tlsroute
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: |-
+          The TLSRoute resource is similar to TCPRoute, but can be configured
+          to match against TLS-specific metadata. This allows more flexibility
+          in matching streams for a given TLS listener.
+
+
+          If you need to forward traffic to a single target for a TLS listener, you
+          could choose to use a TCPRoute with a TLS listener.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of TLSRoute.
+            properties:
+              hostnames:
+                description: |-
+                  Hostnames defines a set of SNI names that should match against the
+                  SNI attribute of TLS ClientHello message in TLS handshake. This matches
+                  the RFC 1123 definition of a hostname with 2 notable exceptions:
+
+
+                  1. IPs are not allowed in SNI names per RFC 6066.
+                  2. A hostname may be prefixed with a wildcard label (`*.`). The wildcard
+                     label must appear by itself as the first label.
+
+
+                  If a hostname is specified by both the Listener and TLSRoute, there
+                  must be at least one intersecting hostname for the TLSRoute to be
+                  attached to the Listener. For example:
+
+
+                  * A Listener with `test.example.com` as the hostname matches TLSRoutes
+                    that have either not specified any hostnames, or have specified at
+                    least one of `test.example.com` or `*.example.com`.
+                  * A Listener with `*.example.com` as the hostname matches TLSRoutes
+                    that have either not specified any hostnames or have specified at least
+                    one hostname that matches the Listener hostname. For example,
+                    `test.example.com` and `*.example.com` would both match. On the other
+                    hand, `example.com` and `test.example.net` would not match.
+
+
+                  If both the Listener and TLSRoute have specified hostnames, any
+                  TLSRoute hostnames that do not match the Listener hostname MUST be
+                  ignored. For example, if a Listener specified `*.example.com`, and the
+                  TLSRoute specified `test.example.com` and `test.example.net`,
+                  `test.example.net` must not be considered for a match.
+
+
+                  If both the Listener and TLSRoute have specified hostnames, and none
+                  match with the criteria above, then the TLSRoute is not accepted. The
+                  implementation must raise an 'Accepted' Condition with a status of
+                  `False` in the corresponding RouteParentStatus.
+
+
+                  Support: Core
+                items:
+                  description: |-
+                    Hostname is the fully qualified domain name of a network host. This matches
+                    the RFC 1123 definition of a hostname with 2 notable exceptions:
+
+
+                     1. IPs are not allowed.
+                     2. A hostname may be prefixed with a wildcard label (`*.`). The wildcard
+                        label must appear by itself as the first label.
+
+
+                    Hostname can be "precise" which is a domain name without the terminating
+                    dot of a network host (e.g. "foo.example.com") or "wildcard", which is a
+                    domain name prefixed with a single wildcard label (e.g. `*.example.com`).
+
+
+                    Note that as per RFC1035 and RFC1123, a *label* must consist of lower case
+                    alphanumeric characters or '-', and must start and end with an alphanumeric
+                    character. No other punctuation is allowed.
+                  maxLength: 253
+                  minLength: 1
+                  pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                  type: string
+                maxItems: 16
+                type: array
+              parentRefs:
+                description: |+
+                  ParentRefs references the resources (usually Gateways) that a Route wants
+                  to be attached to. Note that the referenced parent resource needs to
+                  allow this for the attachment to be complete. For Gateways, that means
+                  the Gateway needs to allow attachment from Routes of this kind and
+                  namespace. For Services, that means the Service must either be in the same
+                  namespace for a "producer" route, or the mesh implementation must support
+                  and allow "consumer" routes for the referenced Service. ReferenceGrant is
+                  not applicable for governing ParentRefs to Services - it is not possible to
+                  create a "producer" route for a Service in a different namespace from the
+                  Route.
+
+
+                  There are two kinds of parent resources with "Core" support:
+
+
+                  * Gateway (Gateway conformance profile)
+                  * Service (Mesh conformance profile, ClusterIP Services only)
+
+
+                  This API may be extended in the future to support additional kinds of parent
+                  resources.
+
+
+                  ParentRefs must be _distinct_. This means either that:
+
+
+                  * They select different objects.  If this is the case, then parentRef
+                    entries are distinct. In terms of fields, this means that the
+                    multi-part key defined by `group`, `kind`, `namespace`, and `name` must
+                    be unique across all parentRef entries in the Route.
+                  * They do not select different objects, but for each optional field used,
+                    each ParentRef that selects the same object must set the same set of
+                    optional fields to different values. If one ParentRef sets a
+                    combination of optional fields, all must set the same combination.
+
+
+                  Some examples:
+
+
+                  * If one ParentRef sets `sectionName`, all ParentRefs referencing the
+                    same object must also set `sectionName`.
+                  * If one ParentRef sets `port`, all ParentRefs referencing the same
+                    object must also set `port`.
+                  * If one ParentRef sets `sectionName` and `port`, all ParentRefs
+                    referencing the same object must also set `sectionName` and `port`.
+
+
+                  It is possible to separately reference multiple distinct objects that may
+                  be collapsed by an implementation. For example, some implementations may
+                  choose to merge compatible Gateway Listeners together. If that is the
+                  case, the list of routes attached to those resources should also be
+                  merged.
+
+
+                  Note that for ParentRefs that cross namespace boundaries, there are specific
+                  rules. Cross-namespace references are only valid if they are explicitly
+                  allowed by something in the namespace they are referring to. For example,
+                  Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                  generic way to enable other kinds of cross-namespace reference.
+
+
+
+                  ParentRefs from a Route to a Service in the same namespace are "producer"
+                  routes, which apply default routing rules to inbound connections from
+                  any namespace to the Service.
+
+
+                  ParentRefs from a Route to a Service in a different namespace are
+                  "consumer" routes, and these routing rules are only applied to outbound
+                  connections originating from the same namespace as the Route, for which
+                  the intended destination of the connections are a Service targeted as a
+                  ParentRef of the Route.
+
+
+
+
+
+
+                items:
+                  description: |-
+                    ParentReference identifies an API object (usually a Gateway) that can be considered
+                    a parent of this resource (usually a route). There are two kinds of parent resources
+                    with "Core" support:
+
+
+                    * Gateway (Gateway conformance profile)
+                    * Service (Mesh conformance profile, ClusterIP Services only)
+
+
+                    This API may be extended in the future to support additional kinds of parent
+                    resources.
+
+
+                    The API object must be valid in the cluster; the Group and Kind must
+                    be registered in the cluster for this reference to be valid.
+                  properties:
+                    group:
+                      default: gateway.networking.k8s.io
+                      description: |-
+                        Group is the group of the referent.
+                        When unspecified, "gateway.networking.k8s.io" is inferred.
+                        To set the core API group (such as for a "Service" kind referent),
+                        Group must be explicitly set to "" (empty string).
+
+
+                        Support: Core
+                      maxLength: 253
+                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    kind:
+                      default: Gateway
+                      description: |-
+                        Kind is kind of the referent.
+
+
+                        There are two kinds of parent resources with "Core" support:
+
+
+                        * Gateway (Gateway conformance profile)
+                        * Service (Mesh conformance profile, ClusterIP Services only)
+
+
+                        Support for other resources is Implementation-Specific.
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                      type: string
+                    name:
+                      description: |-
+                        Name is the name of the referent.
+
+
+                        Support: Core
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                    namespace:
+                      description: |-
+                        Namespace is the namespace of the referent. When unspecified, this refers
+                        to the local namespace of the Route.
+
+
+                        Note that there are specific rules for ParentRefs which cross namespace
+                        boundaries. Cross-namespace references are only valid if they are explicitly
+                        allowed by something in the namespace they are referring to. For example:
+                        Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                        generic way to enable any other kind of cross-namespace reference.
+
+
+
+                        ParentRefs from a Route to a Service in the same namespace are "producer"
+                        routes, which apply default routing rules to inbound connections from
+                        any namespace to the Service.
+
+
+                        ParentRefs from a Route to a Service in a different namespace are
+                        "consumer" routes, and these routing rules are only applied to outbound
+                        connections originating from the same namespace as the Route, for which
+                        the intended destination of the connections are a Service targeted as a
+                        ParentRef of the Route.
+
+
+
+                        Support: Core
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                      type: string
+                    port:
+                      description: |-
+                        Port is the network port this Route targets. It can be interpreted
+                        differently based on the type of parent resource.
+
+
+                        When the parent resource is a Gateway, this targets all listeners
+                        listening on the specified port that also support this kind of Route(and
+                        select this Route). It's not recommended to set `Port` unless the
+                        networking behaviors specified in a Route must apply to a specific port
+                        as opposed to a listener(s) whose port(s) may be changed. When both Port
+                        and SectionName are specified, the name and port of the selected listener
+                        must match both specified values.
+
+
+
+                        When the parent resource is a Service, this targets a specific port in the
+                        Service spec. When both Port (experimental) and SectionName are specified,
+                        the name and port of the selected port must match both specified values.
+
+
+
+                        Implementations MAY choose to support other parent resources.
+                        Implementations supporting other types of parent resources MUST clearly
+                        document how/if Port is interpreted.
+
+
+                        For the purpose of status, an attachment is considered successful as
+                        long as the parent resource accepts it partially. For example, Gateway
+                        listeners can restrict which Routes can attach to them by Route kind,
+                        namespace, or hostname. If 1 of 2 Gateway listeners accept attachment
+                        from the referencing Route, the Route MUST be considered successfully
+                        attached. If no Gateway listeners accept attachment from this Route,
+                        the Route MUST be considered detached from the Gateway.
+
+
+                        Support: Extended
+                      format: int32
+                      maximum: 65535
+                      minimum: 1
+                      type: integer
+                    sectionName:
+                      description: |-
+                        SectionName is the name of a section within the target resource. In the
+                        following resources, SectionName is interpreted as the following:
+
+
+                        * Gateway: Listener name. When both Port (experimental) and SectionName
+                        are specified, the name and port of the selected listener must match
+                        both specified values.
+                        * Service: Port name. When both Port (experimental) and SectionName
+                        are specified, the name and port of the selected listener must match
+                        both specified values.
+
+
+                        Implementations MAY choose to support attaching Routes to other resources.
+                        If that is the case, they MUST clearly document how SectionName is
+                        interpreted.
+
+
+                        When unspecified (empty string), this will reference the entire resource.
+                        For the purpose of status, an attachment is considered successful if at
+                        least one section in the parent resource accepts it. For example, Gateway
+                        listeners can restrict which Routes can attach to them by Route kind,
+                        namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from
+                        the referencing Route, the Route MUST be considered successfully
+                        attached. If no Gateway listeners accept attachment from this Route, the
+                        Route MUST be considered detached from the Gateway.
+
+
+                        Support: Core
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                  required:
+                  - name
+                  type: object
+                maxItems: 32
+                type: array
+                x-kubernetes-validations:
+                - message: sectionName or port must be specified when parentRefs includes
+                    2 or more references to the same parent
+                  rule: 'self.all(p1, self.all(p2, p1.group == p2.group && p1.kind
+                    == p2.kind && p1.name == p2.name && (((!has(p1.__namespace__)
+                    || p1.__namespace__ == '''') && (!has(p2.__namespace__) || p2.__namespace__
+                    == '''')) || (has(p1.__namespace__) && has(p2.__namespace__) &&
+                    p1.__namespace__ == p2.__namespace__)) ? ((!has(p1.sectionName)
+                    || p1.sectionName == '''') == (!has(p2.sectionName) || p2.sectionName
+                    == '''') && (!has(p1.port) || p1.port == 0) == (!has(p2.port)
+                    || p2.port == 0)): true))'
+                - message: sectionName or port must be unique when parentRefs includes
+                    2 or more references to the same parent
+                  rule: self.all(p1, self.exists_one(p2, p1.group == p2.group && p1.kind
+                    == p2.kind && p1.name == p2.name && (((!has(p1.__namespace__)
+                    || p1.__namespace__ == '') && (!has(p2.__namespace__) || p2.__namespace__
+                    == '')) || (has(p1.__namespace__) && has(p2.__namespace__) &&
+                    p1.__namespace__ == p2.__namespace__ )) && (((!has(p1.sectionName)
+                    || p1.sectionName == '') && (!has(p2.sectionName) || p2.sectionName
+                    == '')) || ( has(p1.sectionName) && has(p2.sectionName) && p1.sectionName
+                    == p2.sectionName)) && (((!has(p1.port) || p1.port == 0) && (!has(p2.port)
+                    || p2.port == 0)) || (has(p1.port) && has(p2.port) && p1.port
+                    == p2.port))))
+              rules:
+                description: Rules are a list of TLS matchers and actions.
+                items:
+                  description: TLSRouteRule is the configuration for a given rule.
+                  properties:
+                    backendRefs:
+                      description: |-
+                        BackendRefs defines the backend(s) where matching requests should be
+                        sent. If unspecified or invalid (refers to a non-existent resource or
+                        a Service with no endpoints), the rule performs no forwarding; if no
+                        filters are specified that would result in a response being sent, the
+                        underlying implementation must actively reject request attempts to this
+                        backend, by rejecting the connection or returning a 500 status code.
+                        Request rejections must respect weight; if an invalid backend is
+                        requested to have 80% of requests, then 80% of requests must be rejected
+                        instead.
+
+
+                        Support: Core for Kubernetes Service
+
+
+                        Support: Extended for Kubernetes ServiceImport
+
+
+                        Support: Implementation-specific for any other resource
+
+
+                        Support for weight: Extended
+                      items:
+                        description: |-
+                          BackendRef defines how a Route should forward a request to a Kubernetes
+                          resource.
+
+
+                          Note that when a namespace different than the local namespace is specified, a
+                          ReferenceGrant object is required in the referent namespace to allow that
+                          namespace's owner to accept the reference. See the ReferenceGrant
+                          documentation for details.
+
+
+                          <gateway:experimental:description>
+
+
+                          When the BackendRef points to a Kubernetes Service, implementations SHOULD
+                          honor the appProtocol field if it is set for the target Service Port.
+
+
+                          Implementations supporting appProtocol SHOULD recognize the Kubernetes
+                          Standard Application Protocols defined in KEP-3726.
+
+
+                          If a Service appProtocol isn't specified, an implementation MAY infer the
+                          backend protocol through its own means. Implementations MAY infer the
+                          protocol from the Route type referring to the backend Service.
+
+
+                          If a Route is not able to send traffic to the backend using the specified
+                          protocol then the backend is considered invalid. Implementations MUST set the
+                          "ResolvedRefs" condition to "False" with the "UnsupportedProtocol" reason.
+
+
+                          </gateway:experimental:description>
+
+
+                          Note that when the BackendTLSPolicy object is enabled by the implementation,
+                          there are some extra rules about validity to consider here. See the fields
+                          where this struct is used for more information about the exact behavior.
+                        properties:
+                          group:
+                            default: ""
+                            description: |-
+                              Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                              When unspecified or empty string, core API group is inferred.
+                            maxLength: 253
+                            pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                            type: string
+                          kind:
+                            default: Service
+                            description: |-
+                              Kind is the Kubernetes resource kind of the referent. For example
+                              "Service".
+
+
+                              Defaults to "Service" when not specified.
+
+
+                              ExternalName services can refer to CNAME DNS records that may live
+                              outside of the cluster and as such are difficult to reason about in
+                              terms of conformance. They also may not be safe to forward to (see
+                              CVE-2021-25740 for more information). Implementations SHOULD NOT
+                              support ExternalName Services.
+
+
+                              Support: Core (Services with a type other than ExternalName)
+
+
+                              Support: Implementation-specific (Services with type ExternalName)
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                            type: string
+                          name:
+                            description: Name is the name of the referent.
+                            maxLength: 253
+                            minLength: 1
+                            type: string
+                          namespace:
+                            description: |-
+                              Namespace is the namespace of the backend. When unspecified, the local
+                              namespace is inferred.
+
+
+                              Note that when a namespace different than the local namespace is specified,
+                              a ReferenceGrant object is required in the referent namespace to allow that
+                              namespace's owner to accept the reference. See the ReferenceGrant
+                              documentation for details.
+
+
+                              Support: Core
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                            type: string
+                          port:
+                            description: |-
+                              Port specifies the destination port number to use for this resource.
+                              Port is required when the referent is a Kubernetes Service. In this
+                              case, the port number is the service port number, not the target port.
+                              For other resources, destination port might be derived from the referent
+                              resource or this field.
+                            format: int32
+                            maximum: 65535
+                            minimum: 1
+                            type: integer
+                          weight:
+                            default: 1
+                            description: |-
+                              Weight specifies the proportion of requests forwarded to the referenced
+                              backend. This is computed as weight/(sum of all weights in this
+                              BackendRefs list). For non-zero values, there may be some epsilon from
+                              the exact proportion defined here depending on the precision an
+                              implementation supports. Weight is not a percentage and the sum of
+                              weights does not need to equal 100.
+
+
+                              If only one backend is specified and it has a weight greater than 0, 100%
+                              of the traffic is forwarded to that backend. If weight is set to 0, no
+                              traffic should be forwarded for this entry. If unspecified, weight
+                              defaults to 1.
+
+
+                              Support for this field varies based on the context where used.
+                            format: int32
+                            maximum: 1000000
+                            minimum: 0
+                            type: integer
+                        required:
+                        - name
+                        type: object
+                        x-kubernetes-validations:
+                        - message: Must have port for Service reference
+                          rule: '(size(self.group) == 0 && self.kind == ''Service'')
+                            ? has(self.port) : true'
+                      maxItems: 16
+                      minItems: 1
+                      type: array
+                  type: object
+                maxItems: 16
+                minItems: 1
+                type: array
+            required:
+            - rules
+            type: object
+          status:
+            description: Status defines the current state of TLSRoute.
+            properties:
+              parents:
+                description: |-
+                  Parents is a list of parent resources (usually Gateways) that are
+                  associated with the route, and the status of the route with respect to
+                  each parent. When this route attaches to a parent, the controller that
+                  manages the parent must add an entry to this list when the controller
+                  first sees the route and should update the entry as appropriate when the
+                  route or gateway is modified.
+
+
+                  Note that parent references that cannot be resolved by an implementation
+                  of this API will not be added to this list. Implementations of this API
+                  can only populate Route status for the Gateways/parent resources they are
+                  responsible for.
+
+
+                  A maximum of 32 Gateways will be represented in this list. An empty list
+                  means the route has not been attached to any Gateway.
+                items:
+                  description: |-
+                    RouteParentStatus describes the status of a route with respect to an
+                    associated Parent.
+                  properties:
+                    conditions:
+                      description: |-
+                        Conditions describes the status of the route with respect to the Gateway.
+                        Note that the route's availability is also subject to the Gateway's own
+                        status conditions and listener status.
+
+
+                        If the Route's ParentRef specifies an existing Gateway that supports
+                        Routes of this kind AND that Gateway's controller has sufficient access,
+                        then that Gateway's controller MUST set the "Accepted" condition on the
+                        Route, to indicate whether the route has been accepted or rejected by the
+                        Gateway, and why.
+
+
+                        A Route MUST be considered "Accepted" if at least one of the Route's
+                        rules is implemented by the Gateway.
+
+
+                        There are a number of cases where the "Accepted" condition may not be set
+                        due to lack of controller visibility, that includes when:
+
+
+                        * The Route refers to a non-existent parent.
+                        * The Route is of a type that the controller does not support.
+                        * The Route is in a namespace the controller does not have access to.
+                      items:
+                        description: "Condition contains details for one aspect of
+                          the current state of this API Resource.\n---\nThis struct
+                          is intended for direct use as an array at the field path
+                          .status.conditions.  For example,\n\n\n\ttype FooStatus
+                          struct{\n\t    // Represents the observations of a foo's
+                          current state.\n\t    // Known .status.conditions.type are:
+                          \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                          +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    //
+                          +listType=map\n\t    // +listMapKey=type\n\t    Conditions
+                          []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\"
+                          patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                          \   // other fields\n\t}"
+                        properties:
+                          lastTransitionTime:
+                            description: |-
+                              lastTransitionTime is the last time the condition transitioned from one status to another.
+                              This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                            format: date-time
+                            type: string
+                          message:
+                            description: |-
+                              message is a human readable message indicating details about the transition.
+                              This may be an empty string.
+                            maxLength: 32768
+                            type: string
+                          observedGeneration:
+                            description: |-
+                              observedGeneration represents the .metadata.generation that the condition was set based upon.
+                              For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                              with respect to the current state of the instance.
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          reason:
+                            description: |-
+                              reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected values and meanings for this field,
+                              and whether the values are considered a guaranteed API.
+                              The value should be a CamelCase string.
+                              This field may not be empty.
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                            - "True"
+                            - "False"
+                            - Unknown
+                            type: string
+                          type:
+                            description: |-
+                              type of condition in CamelCase or in foo.example.com/CamelCase.
+                              ---
+                              Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                              useful (see .node.status.conditions), the ability to deconflict is important.
+                              The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                        - lastTransitionTime
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      maxItems: 8
+                      minItems: 1
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - type
+                      x-kubernetes-list-type: map
+                    controllerName:
+                      description: |-
+                        ControllerName is a domain/path string that indicates the name of the
+                        controller that wrote this status. This corresponds with the
+                        controllerName field on GatewayClass.
+
+
+                        Example: "example.net/gateway-controller".
+
+
+                        The format of this field is DOMAIN "/" PATH, where DOMAIN and PATH are
+                        valid Kubernetes names
+                        (https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names).
+
+
+                        Controllers MUST populate this field when writing status. Controllers should ensure that
+                        entries to status populated with their ControllerName are cleaned up when they are no
+                        longer necessary.
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
+                      type: string
+                    parentRef:
+                      description: |-
+                        ParentRef corresponds with a ParentRef in the spec that this
+                        RouteParentStatus struct describes the status of.
+                      properties:
+                        group:
+                          default: gateway.networking.k8s.io
+                          description: |-
+                            Group is the group of the referent.
+                            When unspecified, "gateway.networking.k8s.io" is inferred.
+                            To set the core API group (such as for a "Service" kind referent),
+                            Group must be explicitly set to "" (empty string).
+
+
+                            Support: Core
+                          maxLength: 253
+                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                        kind:
+                          default: Gateway
+                          description: |-
+                            Kind is kind of the referent.
+
+
+                            There are two kinds of parent resources with "Core" support:
+
+
+                            * Gateway (Gateway conformance profile)
+                            * Service (Mesh conformance profile, ClusterIP Services only)
+
+
+                            Support for other resources is Implementation-Specific.
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                          type: string
+                        name:
+                          description: |-
+                            Name is the name of the referent.
+
+
+                            Support: Core
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: |-
+                            Namespace is the namespace of the referent. When unspecified, this refers
+                            to the local namespace of the Route.
+
+
+                            Note that there are specific rules for ParentRefs which cross namespace
+                            boundaries. Cross-namespace references are only valid if they are explicitly
+                            allowed by something in the namespace they are referring to. For example:
+                            Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                            generic way to enable any other kind of cross-namespace reference.
+
+
+
+                            ParentRefs from a Route to a Service in the same namespace are "producer"
+                            routes, which apply default routing rules to inbound connections from
+                            any namespace to the Service.
+
+
+                            ParentRefs from a Route to a Service in a different namespace are
+                            "consumer" routes, and these routing rules are only applied to outbound
+                            connections originating from the same namespace as the Route, for which
+                            the intended destination of the connections are a Service targeted as a
+                            ParentRef of the Route.
+
+
+
+                            Support: Core
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                          type: string
+                        port:
+                          description: |-
+                            Port is the network port this Route targets. It can be interpreted
+                            differently based on the type of parent resource.
+
+
+                            When the parent resource is a Gateway, this targets all listeners
+                            listening on the specified port that also support this kind of Route(and
+                            select this Route). It's not recommended to set `Port` unless the
+                            networking behaviors specified in a Route must apply to a specific port
+                            as opposed to a listener(s) whose port(s) may be changed. When both Port
+                            and SectionName are specified, the name and port of the selected listener
+                            must match both specified values.
+
+
+
+                            When the parent resource is a Service, this targets a specific port in the
+                            Service spec. When both Port (experimental) and SectionName are specified,
+                            the name and port of the selected port must match both specified values.
+
+
+
+                            Implementations MAY choose to support other parent resources.
+                            Implementations supporting other types of parent resources MUST clearly
+                            document how/if Port is interpreted.
+
+
+                            For the purpose of status, an attachment is considered successful as
+                            long as the parent resource accepts it partially. For example, Gateway
+                            listeners can restrict which Routes can attach to them by Route kind,
+                            namespace, or hostname. If 1 of 2 Gateway listeners accept attachment
+                            from the referencing Route, the Route MUST be considered successfully
+                            attached. If no Gateway listeners accept attachment from this Route,
+                            the Route MUST be considered detached from the Gateway.
+
+
+                            Support: Extended
+                          format: int32
+                          maximum: 65535
+                          minimum: 1
+                          type: integer
+                        sectionName:
+                          description: |-
+                            SectionName is the name of a section within the target resource. In the
+                            following resources, SectionName is interpreted as the following:
+
+
+                            * Gateway: Listener name. When both Port (experimental) and SectionName
+                            are specified, the name and port of the selected listener must match
+                            both specified values.
+                            * Service: Port name. When both Port (experimental) and SectionName
+                            are specified, the name and port of the selected listener must match
+                            both specified values.
+
+
+                            Implementations MAY choose to support attaching Routes to other resources.
+                            If that is the case, they MUST clearly document how SectionName is
+                            interpreted.
+
+
+                            When unspecified (empty string), this will reference the entire resource.
+                            For the purpose of status, an attachment is considered successful if at
+                            least one section in the parent resource accepts it. For example, Gateway
+                            listeners can restrict which Routes can attach to them by Route kind,
+                            namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from
+                            the referencing Route, the Route MUST be considered successfully
+                            attached. If no Gateway listeners accept attachment from this Route, the
+                            Route MUST be considered detached from the Gateway.
+
+
+                            Support: Core
+                          maxLength: 253
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                      required:
+                      - name
+                      type: object
+                  required:
+                  - controllerName
+                  - parentRef
+                  type: object
+                maxItems: 32
+                type: array
+            required:
+            - parents
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/platform/gateway-api/chart/templates/udproutes.yaml
+++ b/platform/gateway-api/chart/templates/udproutes.yaml
@@ -1,0 +1,837 @@
+{{/*
+  Vendored from kubernetes-sigs/gateway-api {{ index .Chart.Annotations "catalyst.openova.io/upstream-gateway-api-version" }}
+  experimental-install.yaml. Do NOT hand-edit annotations / spec — re-vendor
+  via the script in tests/regenerate.sh when bumping the upstream version
+  (also bump catalyst.openova.io/upstream-gateway-api-version in Chart.yaml).
+
+  helm.sh/resource-policy: keep is added under metadata.annotations so a
+  Helm uninstall does NOT delete the CRD. Gateway API CRDs are foundational
+  cluster-scoped infrastructure; deleting them on uninstall would break
+  every HTTPRoute on the cluster simultaneously.
+*/}}
+
+#
+# config/crd/experimental/gateway.networking.k8s.io_udproutes.yaml
+#
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    helm.sh/resource-policy: keep
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/2997
+    gateway.networking.k8s.io/bundle-version: v1.1.0
+    gateway.networking.k8s.io/channel: experimental
+  creationTimestamp: null
+  name: udproutes.gateway.networking.k8s.io
+spec:
+  group: gateway.networking.k8s.io
+  names:
+    categories:
+    - gateway-api
+    kind: UDPRoute
+    listKind: UDPRouteList
+    plural: udproutes
+    singular: udproute
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: |-
+          UDPRoute provides a way to route UDP traffic. When combined with a Gateway
+          listener, it can be used to forward traffic on the port specified by the
+          listener to a set of backends specified by the UDPRoute.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of UDPRoute.
+            properties:
+              parentRefs:
+                description: |+
+                  ParentRefs references the resources (usually Gateways) that a Route wants
+                  to be attached to. Note that the referenced parent resource needs to
+                  allow this for the attachment to be complete. For Gateways, that means
+                  the Gateway needs to allow attachment from Routes of this kind and
+                  namespace. For Services, that means the Service must either be in the same
+                  namespace for a "producer" route, or the mesh implementation must support
+                  and allow "consumer" routes for the referenced Service. ReferenceGrant is
+                  not applicable for governing ParentRefs to Services - it is not possible to
+                  create a "producer" route for a Service in a different namespace from the
+                  Route.
+
+
+                  There are two kinds of parent resources with "Core" support:
+
+
+                  * Gateway (Gateway conformance profile)
+                  * Service (Mesh conformance profile, ClusterIP Services only)
+
+
+                  This API may be extended in the future to support additional kinds of parent
+                  resources.
+
+
+                  ParentRefs must be _distinct_. This means either that:
+
+
+                  * They select different objects.  If this is the case, then parentRef
+                    entries are distinct. In terms of fields, this means that the
+                    multi-part key defined by `group`, `kind`, `namespace`, and `name` must
+                    be unique across all parentRef entries in the Route.
+                  * They do not select different objects, but for each optional field used,
+                    each ParentRef that selects the same object must set the same set of
+                    optional fields to different values. If one ParentRef sets a
+                    combination of optional fields, all must set the same combination.
+
+
+                  Some examples:
+
+
+                  * If one ParentRef sets `sectionName`, all ParentRefs referencing the
+                    same object must also set `sectionName`.
+                  * If one ParentRef sets `port`, all ParentRefs referencing the same
+                    object must also set `port`.
+                  * If one ParentRef sets `sectionName` and `port`, all ParentRefs
+                    referencing the same object must also set `sectionName` and `port`.
+
+
+                  It is possible to separately reference multiple distinct objects that may
+                  be collapsed by an implementation. For example, some implementations may
+                  choose to merge compatible Gateway Listeners together. If that is the
+                  case, the list of routes attached to those resources should also be
+                  merged.
+
+
+                  Note that for ParentRefs that cross namespace boundaries, there are specific
+                  rules. Cross-namespace references are only valid if they are explicitly
+                  allowed by something in the namespace they are referring to. For example,
+                  Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                  generic way to enable other kinds of cross-namespace reference.
+
+
+
+                  ParentRefs from a Route to a Service in the same namespace are "producer"
+                  routes, which apply default routing rules to inbound connections from
+                  any namespace to the Service.
+
+
+                  ParentRefs from a Route to a Service in a different namespace are
+                  "consumer" routes, and these routing rules are only applied to outbound
+                  connections originating from the same namespace as the Route, for which
+                  the intended destination of the connections are a Service targeted as a
+                  ParentRef of the Route.
+
+
+
+
+
+
+                items:
+                  description: |-
+                    ParentReference identifies an API object (usually a Gateway) that can be considered
+                    a parent of this resource (usually a route). There are two kinds of parent resources
+                    with "Core" support:
+
+
+                    * Gateway (Gateway conformance profile)
+                    * Service (Mesh conformance profile, ClusterIP Services only)
+
+
+                    This API may be extended in the future to support additional kinds of parent
+                    resources.
+
+
+                    The API object must be valid in the cluster; the Group and Kind must
+                    be registered in the cluster for this reference to be valid.
+                  properties:
+                    group:
+                      default: gateway.networking.k8s.io
+                      description: |-
+                        Group is the group of the referent.
+                        When unspecified, "gateway.networking.k8s.io" is inferred.
+                        To set the core API group (such as for a "Service" kind referent),
+                        Group must be explicitly set to "" (empty string).
+
+
+                        Support: Core
+                      maxLength: 253
+                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    kind:
+                      default: Gateway
+                      description: |-
+                        Kind is kind of the referent.
+
+
+                        There are two kinds of parent resources with "Core" support:
+
+
+                        * Gateway (Gateway conformance profile)
+                        * Service (Mesh conformance profile, ClusterIP Services only)
+
+
+                        Support for other resources is Implementation-Specific.
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                      type: string
+                    name:
+                      description: |-
+                        Name is the name of the referent.
+
+
+                        Support: Core
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                    namespace:
+                      description: |-
+                        Namespace is the namespace of the referent. When unspecified, this refers
+                        to the local namespace of the Route.
+
+
+                        Note that there are specific rules for ParentRefs which cross namespace
+                        boundaries. Cross-namespace references are only valid if they are explicitly
+                        allowed by something in the namespace they are referring to. For example:
+                        Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                        generic way to enable any other kind of cross-namespace reference.
+
+
+
+                        ParentRefs from a Route to a Service in the same namespace are "producer"
+                        routes, which apply default routing rules to inbound connections from
+                        any namespace to the Service.
+
+
+                        ParentRefs from a Route to a Service in a different namespace are
+                        "consumer" routes, and these routing rules are only applied to outbound
+                        connections originating from the same namespace as the Route, for which
+                        the intended destination of the connections are a Service targeted as a
+                        ParentRef of the Route.
+
+
+
+                        Support: Core
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                      type: string
+                    port:
+                      description: |-
+                        Port is the network port this Route targets. It can be interpreted
+                        differently based on the type of parent resource.
+
+
+                        When the parent resource is a Gateway, this targets all listeners
+                        listening on the specified port that also support this kind of Route(and
+                        select this Route). It's not recommended to set `Port` unless the
+                        networking behaviors specified in a Route must apply to a specific port
+                        as opposed to a listener(s) whose port(s) may be changed. When both Port
+                        and SectionName are specified, the name and port of the selected listener
+                        must match both specified values.
+
+
+
+                        When the parent resource is a Service, this targets a specific port in the
+                        Service spec. When both Port (experimental) and SectionName are specified,
+                        the name and port of the selected port must match both specified values.
+
+
+
+                        Implementations MAY choose to support other parent resources.
+                        Implementations supporting other types of parent resources MUST clearly
+                        document how/if Port is interpreted.
+
+
+                        For the purpose of status, an attachment is considered successful as
+                        long as the parent resource accepts it partially. For example, Gateway
+                        listeners can restrict which Routes can attach to them by Route kind,
+                        namespace, or hostname. If 1 of 2 Gateway listeners accept attachment
+                        from the referencing Route, the Route MUST be considered successfully
+                        attached. If no Gateway listeners accept attachment from this Route,
+                        the Route MUST be considered detached from the Gateway.
+
+
+                        Support: Extended
+                      format: int32
+                      maximum: 65535
+                      minimum: 1
+                      type: integer
+                    sectionName:
+                      description: |-
+                        SectionName is the name of a section within the target resource. In the
+                        following resources, SectionName is interpreted as the following:
+
+
+                        * Gateway: Listener name. When both Port (experimental) and SectionName
+                        are specified, the name and port of the selected listener must match
+                        both specified values.
+                        * Service: Port name. When both Port (experimental) and SectionName
+                        are specified, the name and port of the selected listener must match
+                        both specified values.
+
+
+                        Implementations MAY choose to support attaching Routes to other resources.
+                        If that is the case, they MUST clearly document how SectionName is
+                        interpreted.
+
+
+                        When unspecified (empty string), this will reference the entire resource.
+                        For the purpose of status, an attachment is considered successful if at
+                        least one section in the parent resource accepts it. For example, Gateway
+                        listeners can restrict which Routes can attach to them by Route kind,
+                        namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from
+                        the referencing Route, the Route MUST be considered successfully
+                        attached. If no Gateway listeners accept attachment from this Route, the
+                        Route MUST be considered detached from the Gateway.
+
+
+                        Support: Core
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                  required:
+                  - name
+                  type: object
+                maxItems: 32
+                type: array
+                x-kubernetes-validations:
+                - message: sectionName or port must be specified when parentRefs includes
+                    2 or more references to the same parent
+                  rule: 'self.all(p1, self.all(p2, p1.group == p2.group && p1.kind
+                    == p2.kind && p1.name == p2.name && (((!has(p1.__namespace__)
+                    || p1.__namespace__ == '''') && (!has(p2.__namespace__) || p2.__namespace__
+                    == '''')) || (has(p1.__namespace__) && has(p2.__namespace__) &&
+                    p1.__namespace__ == p2.__namespace__)) ? ((!has(p1.sectionName)
+                    || p1.sectionName == '''') == (!has(p2.sectionName) || p2.sectionName
+                    == '''') && (!has(p1.port) || p1.port == 0) == (!has(p2.port)
+                    || p2.port == 0)): true))'
+                - message: sectionName or port must be unique when parentRefs includes
+                    2 or more references to the same parent
+                  rule: self.all(p1, self.exists_one(p2, p1.group == p2.group && p1.kind
+                    == p2.kind && p1.name == p2.name && (((!has(p1.__namespace__)
+                    || p1.__namespace__ == '') && (!has(p2.__namespace__) || p2.__namespace__
+                    == '')) || (has(p1.__namespace__) && has(p2.__namespace__) &&
+                    p1.__namespace__ == p2.__namespace__ )) && (((!has(p1.sectionName)
+                    || p1.sectionName == '') && (!has(p2.sectionName) || p2.sectionName
+                    == '')) || ( has(p1.sectionName) && has(p2.sectionName) && p1.sectionName
+                    == p2.sectionName)) && (((!has(p1.port) || p1.port == 0) && (!has(p2.port)
+                    || p2.port == 0)) || (has(p1.port) && has(p2.port) && p1.port
+                    == p2.port))))
+              rules:
+                description: Rules are a list of UDP matchers and actions.
+                items:
+                  description: UDPRouteRule is the configuration for a given rule.
+                  properties:
+                    backendRefs:
+                      description: |-
+                        BackendRefs defines the backend(s) where matching requests should be
+                        sent. If unspecified or invalid (refers to a non-existent resource or a
+                        Service with no endpoints), the underlying implementation MUST actively
+                        reject connection attempts to this backend. Packet drops must
+                        respect weight; if an invalid backend is requested to have 80% of
+                        the packets, then 80% of packets must be dropped instead.
+
+
+                        Support: Core for Kubernetes Service
+
+
+                        Support: Extended for Kubernetes ServiceImport
+
+
+                        Support: Implementation-specific for any other resource
+
+
+                        Support for weight: Extended
+                      items:
+                        description: |-
+                          BackendRef defines how a Route should forward a request to a Kubernetes
+                          resource.
+
+
+                          Note that when a namespace different than the local namespace is specified, a
+                          ReferenceGrant object is required in the referent namespace to allow that
+                          namespace's owner to accept the reference. See the ReferenceGrant
+                          documentation for details.
+
+
+                          <gateway:experimental:description>
+
+
+                          When the BackendRef points to a Kubernetes Service, implementations SHOULD
+                          honor the appProtocol field if it is set for the target Service Port.
+
+
+                          Implementations supporting appProtocol SHOULD recognize the Kubernetes
+                          Standard Application Protocols defined in KEP-3726.
+
+
+                          If a Service appProtocol isn't specified, an implementation MAY infer the
+                          backend protocol through its own means. Implementations MAY infer the
+                          protocol from the Route type referring to the backend Service.
+
+
+                          If a Route is not able to send traffic to the backend using the specified
+                          protocol then the backend is considered invalid. Implementations MUST set the
+                          "ResolvedRefs" condition to "False" with the "UnsupportedProtocol" reason.
+
+
+                          </gateway:experimental:description>
+
+
+                          Note that when the BackendTLSPolicy object is enabled by the implementation,
+                          there are some extra rules about validity to consider here. See the fields
+                          where this struct is used for more information about the exact behavior.
+                        properties:
+                          group:
+                            default: ""
+                            description: |-
+                              Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                              When unspecified or empty string, core API group is inferred.
+                            maxLength: 253
+                            pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                            type: string
+                          kind:
+                            default: Service
+                            description: |-
+                              Kind is the Kubernetes resource kind of the referent. For example
+                              "Service".
+
+
+                              Defaults to "Service" when not specified.
+
+
+                              ExternalName services can refer to CNAME DNS records that may live
+                              outside of the cluster and as such are difficult to reason about in
+                              terms of conformance. They also may not be safe to forward to (see
+                              CVE-2021-25740 for more information). Implementations SHOULD NOT
+                              support ExternalName Services.
+
+
+                              Support: Core (Services with a type other than ExternalName)
+
+
+                              Support: Implementation-specific (Services with type ExternalName)
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                            type: string
+                          name:
+                            description: Name is the name of the referent.
+                            maxLength: 253
+                            minLength: 1
+                            type: string
+                          namespace:
+                            description: |-
+                              Namespace is the namespace of the backend. When unspecified, the local
+                              namespace is inferred.
+
+
+                              Note that when a namespace different than the local namespace is specified,
+                              a ReferenceGrant object is required in the referent namespace to allow that
+                              namespace's owner to accept the reference. See the ReferenceGrant
+                              documentation for details.
+
+
+                              Support: Core
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                            type: string
+                          port:
+                            description: |-
+                              Port specifies the destination port number to use for this resource.
+                              Port is required when the referent is a Kubernetes Service. In this
+                              case, the port number is the service port number, not the target port.
+                              For other resources, destination port might be derived from the referent
+                              resource or this field.
+                            format: int32
+                            maximum: 65535
+                            minimum: 1
+                            type: integer
+                          weight:
+                            default: 1
+                            description: |-
+                              Weight specifies the proportion of requests forwarded to the referenced
+                              backend. This is computed as weight/(sum of all weights in this
+                              BackendRefs list). For non-zero values, there may be some epsilon from
+                              the exact proportion defined here depending on the precision an
+                              implementation supports. Weight is not a percentage and the sum of
+                              weights does not need to equal 100.
+
+
+                              If only one backend is specified and it has a weight greater than 0, 100%
+                              of the traffic is forwarded to that backend. If weight is set to 0, no
+                              traffic should be forwarded for this entry. If unspecified, weight
+                              defaults to 1.
+
+
+                              Support for this field varies based on the context where used.
+                            format: int32
+                            maximum: 1000000
+                            minimum: 0
+                            type: integer
+                        required:
+                        - name
+                        type: object
+                        x-kubernetes-validations:
+                        - message: Must have port for Service reference
+                          rule: '(size(self.group) == 0 && self.kind == ''Service'')
+                            ? has(self.port) : true'
+                      maxItems: 16
+                      minItems: 1
+                      type: array
+                  type: object
+                maxItems: 16
+                minItems: 1
+                type: array
+            required:
+            - rules
+            type: object
+          status:
+            description: Status defines the current state of UDPRoute.
+            properties:
+              parents:
+                description: |-
+                  Parents is a list of parent resources (usually Gateways) that are
+                  associated with the route, and the status of the route with respect to
+                  each parent. When this route attaches to a parent, the controller that
+                  manages the parent must add an entry to this list when the controller
+                  first sees the route and should update the entry as appropriate when the
+                  route or gateway is modified.
+
+
+                  Note that parent references that cannot be resolved by an implementation
+                  of this API will not be added to this list. Implementations of this API
+                  can only populate Route status for the Gateways/parent resources they are
+                  responsible for.
+
+
+                  A maximum of 32 Gateways will be represented in this list. An empty list
+                  means the route has not been attached to any Gateway.
+                items:
+                  description: |-
+                    RouteParentStatus describes the status of a route with respect to an
+                    associated Parent.
+                  properties:
+                    conditions:
+                      description: |-
+                        Conditions describes the status of the route with respect to the Gateway.
+                        Note that the route's availability is also subject to the Gateway's own
+                        status conditions and listener status.
+
+
+                        If the Route's ParentRef specifies an existing Gateway that supports
+                        Routes of this kind AND that Gateway's controller has sufficient access,
+                        then that Gateway's controller MUST set the "Accepted" condition on the
+                        Route, to indicate whether the route has been accepted or rejected by the
+                        Gateway, and why.
+
+
+                        A Route MUST be considered "Accepted" if at least one of the Route's
+                        rules is implemented by the Gateway.
+
+
+                        There are a number of cases where the "Accepted" condition may not be set
+                        due to lack of controller visibility, that includes when:
+
+
+                        * The Route refers to a non-existent parent.
+                        * The Route is of a type that the controller does not support.
+                        * The Route is in a namespace the controller does not have access to.
+                      items:
+                        description: "Condition contains details for one aspect of
+                          the current state of this API Resource.\n---\nThis struct
+                          is intended for direct use as an array at the field path
+                          .status.conditions.  For example,\n\n\n\ttype FooStatus
+                          struct{\n\t    // Represents the observations of a foo's
+                          current state.\n\t    // Known .status.conditions.type are:
+                          \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                          +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    //
+                          +listType=map\n\t    // +listMapKey=type\n\t    Conditions
+                          []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\"
+                          patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                          \   // other fields\n\t}"
+                        properties:
+                          lastTransitionTime:
+                            description: |-
+                              lastTransitionTime is the last time the condition transitioned from one status to another.
+                              This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                            format: date-time
+                            type: string
+                          message:
+                            description: |-
+                              message is a human readable message indicating details about the transition.
+                              This may be an empty string.
+                            maxLength: 32768
+                            type: string
+                          observedGeneration:
+                            description: |-
+                              observedGeneration represents the .metadata.generation that the condition was set based upon.
+                              For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                              with respect to the current state of the instance.
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          reason:
+                            description: |-
+                              reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected values and meanings for this field,
+                              and whether the values are considered a guaranteed API.
+                              The value should be a CamelCase string.
+                              This field may not be empty.
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                            - "True"
+                            - "False"
+                            - Unknown
+                            type: string
+                          type:
+                            description: |-
+                              type of condition in CamelCase or in foo.example.com/CamelCase.
+                              ---
+                              Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                              useful (see .node.status.conditions), the ability to deconflict is important.
+                              The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                        - lastTransitionTime
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      maxItems: 8
+                      minItems: 1
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - type
+                      x-kubernetes-list-type: map
+                    controllerName:
+                      description: |-
+                        ControllerName is a domain/path string that indicates the name of the
+                        controller that wrote this status. This corresponds with the
+                        controllerName field on GatewayClass.
+
+
+                        Example: "example.net/gateway-controller".
+
+
+                        The format of this field is DOMAIN "/" PATH, where DOMAIN and PATH are
+                        valid Kubernetes names
+                        (https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names).
+
+
+                        Controllers MUST populate this field when writing status. Controllers should ensure that
+                        entries to status populated with their ControllerName are cleaned up when they are no
+                        longer necessary.
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
+                      type: string
+                    parentRef:
+                      description: |-
+                        ParentRef corresponds with a ParentRef in the spec that this
+                        RouteParentStatus struct describes the status of.
+                      properties:
+                        group:
+                          default: gateway.networking.k8s.io
+                          description: |-
+                            Group is the group of the referent.
+                            When unspecified, "gateway.networking.k8s.io" is inferred.
+                            To set the core API group (such as for a "Service" kind referent),
+                            Group must be explicitly set to "" (empty string).
+
+
+                            Support: Core
+                          maxLength: 253
+                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                        kind:
+                          default: Gateway
+                          description: |-
+                            Kind is kind of the referent.
+
+
+                            There are two kinds of parent resources with "Core" support:
+
+
+                            * Gateway (Gateway conformance profile)
+                            * Service (Mesh conformance profile, ClusterIP Services only)
+
+
+                            Support for other resources is Implementation-Specific.
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                          type: string
+                        name:
+                          description: |-
+                            Name is the name of the referent.
+
+
+                            Support: Core
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: |-
+                            Namespace is the namespace of the referent. When unspecified, this refers
+                            to the local namespace of the Route.
+
+
+                            Note that there are specific rules for ParentRefs which cross namespace
+                            boundaries. Cross-namespace references are only valid if they are explicitly
+                            allowed by something in the namespace they are referring to. For example:
+                            Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                            generic way to enable any other kind of cross-namespace reference.
+
+
+
+                            ParentRefs from a Route to a Service in the same namespace are "producer"
+                            routes, which apply default routing rules to inbound connections from
+                            any namespace to the Service.
+
+
+                            ParentRefs from a Route to a Service in a different namespace are
+                            "consumer" routes, and these routing rules are only applied to outbound
+                            connections originating from the same namespace as the Route, for which
+                            the intended destination of the connections are a Service targeted as a
+                            ParentRef of the Route.
+
+
+
+                            Support: Core
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                          type: string
+                        port:
+                          description: |-
+                            Port is the network port this Route targets. It can be interpreted
+                            differently based on the type of parent resource.
+
+
+                            When the parent resource is a Gateway, this targets all listeners
+                            listening on the specified port that also support this kind of Route(and
+                            select this Route). It's not recommended to set `Port` unless the
+                            networking behaviors specified in a Route must apply to a specific port
+                            as opposed to a listener(s) whose port(s) may be changed. When both Port
+                            and SectionName are specified, the name and port of the selected listener
+                            must match both specified values.
+
+
+
+                            When the parent resource is a Service, this targets a specific port in the
+                            Service spec. When both Port (experimental) and SectionName are specified,
+                            the name and port of the selected port must match both specified values.
+
+
+
+                            Implementations MAY choose to support other parent resources.
+                            Implementations supporting other types of parent resources MUST clearly
+                            document how/if Port is interpreted.
+
+
+                            For the purpose of status, an attachment is considered successful as
+                            long as the parent resource accepts it partially. For example, Gateway
+                            listeners can restrict which Routes can attach to them by Route kind,
+                            namespace, or hostname. If 1 of 2 Gateway listeners accept attachment
+                            from the referencing Route, the Route MUST be considered successfully
+                            attached. If no Gateway listeners accept attachment from this Route,
+                            the Route MUST be considered detached from the Gateway.
+
+
+                            Support: Extended
+                          format: int32
+                          maximum: 65535
+                          minimum: 1
+                          type: integer
+                        sectionName:
+                          description: |-
+                            SectionName is the name of a section within the target resource. In the
+                            following resources, SectionName is interpreted as the following:
+
+
+                            * Gateway: Listener name. When both Port (experimental) and SectionName
+                            are specified, the name and port of the selected listener must match
+                            both specified values.
+                            * Service: Port name. When both Port (experimental) and SectionName
+                            are specified, the name and port of the selected listener must match
+                            both specified values.
+
+
+                            Implementations MAY choose to support attaching Routes to other resources.
+                            If that is the case, they MUST clearly document how SectionName is
+                            interpreted.
+
+
+                            When unspecified (empty string), this will reference the entire resource.
+                            For the purpose of status, an attachment is considered successful if at
+                            least one section in the parent resource accepts it. For example, Gateway
+                            listeners can restrict which Routes can attach to them by Route kind,
+                            namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from
+                            the referencing Route, the Route MUST be considered successfully
+                            attached. If no Gateway listeners accept attachment from this Route, the
+                            Route MUST be considered detached from the Gateway.
+
+
+                            Support: Core
+                          maxLength: 253
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                      required:
+                      - name
+                      type: object
+                  required:
+                  - controllerName
+                  - parentRef
+                  type: object
+                maxItems: 32
+                type: array
+            required:
+            - parents
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null


### PR DESCRIPTION
## Summary

- **Root cause**: Cilium 1.16.x operator checks for Gateway API CRDs at startup and permanently disables its gateway controller if absent. Cloud-init installs Cilium before Flux can reconcile bp-gateway-api, causing every fresh Sovereign to boot with no `GatewayClass/cilium` and all HTTPRoutes orphaned.
- **Second blocker**: Gateway API v1.2.0 changed `status.supportedFeatures` from `string[]` to `object[]`. Cilium 1.16.5 writes the old string format; the v1.2.0 CRD rejects the status update permanently.

## Three-part fix

1. **cloud-init**: Apply Gateway API v1.1.0 experimental CRDs (including TLSRoute) BEFORE the Cilium helm install. Cilium 1.16.x explicitly checks for `tlsroutes.gateway.networking.k8s.io` at boot.

2. **bp-cilium 1.1.2 → 1.1.3**: Add `gatewayAPI.gatewayClass.create: "true"` to force GatewayClass creation regardless of CRD presence at Helm render time. Upstream default `"auto"` silently skips when CRDs are absent.

3. **bp-gateway-api 1.0.0 → 1.1.0**: Downgrade from v1.2.0 to v1.1.0 CRDs and ship experimental channel (TLSRoute, TCPRoute, UDPRoute, BackendLBPolicy, BackendTLSPolicy). v1.1.0 retains the string schema for `supportedFeatures` compatible with Cilium 1.16.5.

## Runtime recovery (otech22 already fixed)

Applied on otech22 2026-05-02 manually:
- Applied v1.1.0 experimental CRDs
- Patched RBAC to add `create` verb on gatewayclasses  
- Created GatewayClass/cilium manually
- Restarted cilium-operator

Result: `GatewayClass/cilium Accepted=True`, `Gateway/cilium-gateway Programmed=True`, all 8 HTTPRoutes `Accepted=True`.

## Test plan

- [ ] CI passes on this PR
- [ ] Fresh Sovereign provision post-merge: `kubectl get gatewayclass cilium` shows `Accepted=True` within 120s of Cilium install
- [ ] All HTTPRoutes show `Accepted=True` without manual operator restart

Closes #503

🤖 Generated with [Claude Code](https://claude.com/claude-code)