### PR TITLE
fix(ci): disable buildx provenance attestation in dynadot-webhook build

### DIFF
--- a/.github/workflows/build-cert-manager-dynadot-webhook.yaml
+++ b/.github/workflows/build-cert-manager-dynadot-webhook.yaml
@@ -110,8 +110,16 @@ jobs:
             org.opencontainers.image.revision=${{ github.sha }}
             org.opencontainers.image.title=cert-manager-dynadot-webhook
             org.opencontainers.image.description=cert-manager DNS-01 external webhook for Dynadot (closes openova#159)
-          provenance: true
-          sbom: true
+          # provenance=false: containerd 1.7.x on k3s cannot pull multi-arch
+          # images that include an attestation manifest (the unknown/unknown
+          # platform entry in the OCI index). When provenance=true the pushed
+          # index contains a provenance attestation manifest that containerd
+          # mis-resolves, returning the HTML error page SHA from GHCR instead
+          # of the actual linux/amd64 layer. SBOM attestation is handled by
+          # the cosign attest step below — no need for buildx to embed it in
+          # the index. See: https://github.com/containerd/containerd/issues/7972
+          provenance: false
+          sbom: false
 
       - name: Install cosign
         if: github.event_name != 'pull_request'


### PR DESCRIPTION
## Summary

- Disable `provenance: true` and `sbom: true` in `docker/build-push-action` step for `build-cert-manager-dynadot-webhook.yaml`
- containerd 1.7.x on k3s fails to pull any image whose OCI manifest index contains an attestation manifest (the `unknown/unknown` platform entry injected by buildx when provenance is enabled)
- Root cause: when containerd fetches the manifest index, it encounters the attestation entry descriptor, fetches that descriptor from GHCR which returns an HTML error page, and caches the HTML page as a blob — every subsequent pull of any tag returns that HTML blob SHA (`sha256:5b4f1e85...`) instead of the actual image layers
- SBOM attestation is preserved via the separate `cosign attest` step which uses Sigstore transparency log, not OCI index embedding

## Impact

- Fixes `cert-manager-dynadot-webhook` failing to pull on all k3s Sovereign nodes (otech22 confirmed affected)
- Unblocks `sovereign-wildcard-tls` certificate issuance via Dynadot DNS-01 webhook

## Test plan
- [ ] CI build passes with `provenance: false`
- [ ] New image tag pulls cleanly on otech22 (`crictl pull ghcr.io/.../cert-manager-dynadot-webhook:<new-sha>`)
- [ ] `sovereign-wildcard-tls` certificate reaches `Ready=True` in `kube-system`

🤖 Generated with [Claude Code](https://claude.com/claude-code)