### PR TITLE
fix: bp-gateway-api 5→10 CRDs + bp-gitea CNPG + bp-harbor CNPG race fix + DAG audit

### DIFF
--- a/clusters/_template/bootstrap-kit/10-gitea.yaml
+++ b/clusters/_template/bootstrap-kit/10-gitea.yaml
@@ -39,10 +39,15 @@ spec:
     # bp-gateway-api (issue #503): chart ships an HTTPRoute template;
     # gateway.networking.k8s.io/v1 CRDs must be registered first.
     - name: bp-gateway-api
+    # bp-cnpg (issue #584): chart ships a CNPG Cluster CR;
+    # postgresql.cnpg.io/v1 CRD must be registered before bp-gitea
+    # applies so the Capabilities gate in cnpg-cluster.yaml creates
+    # the Cluster rather than skipping it silently.
+    - name: bp-cnpg
   chart:
     spec:
       chart: bp-gitea
-      version: 1.1.2
+      version: 1.2.0
       sourceRef:
         kind: HelmRepository
         name: bp-gitea

--- a/clusters/_template/bootstrap-kit/19-harbor.yaml
+++ b/clusters/_template/bootstrap-kit/19-harbor.yaml
@@ -84,7 +84,7 @@ spec:
   chart:
     spec:
       chart: bp-harbor
-      version: 1.2.2
+      version: 1.2.3
       sourceRef:
         kind: HelmRepository
         name: bp-harbor

--- a/clusters/omantel.omani.works/bootstrap-kit/10-gitea.yaml
+++ b/clusters/omantel.omani.works/bootstrap-kit/10-gitea.yaml
@@ -36,10 +36,18 @@ spec:
   targetNamespace: gitea
   dependsOn:
     - name: bp-keycloak
+    # bp-gateway-api (issue #503): chart ships an HTTPRoute template;
+    # gateway.networking.k8s.io/v1 CRDs must be registered first.
+    - name: bp-gateway-api
+    # bp-cnpg (issue #584): chart ships a CNPG Cluster CR;
+    # postgresql.cnpg.io/v1 CRD must be registered before bp-gitea
+    # applies so the Capabilities gate in cnpg-cluster.yaml creates
+    # the Cluster rather than skipping it silently.
+    - name: bp-cnpg
   chart:
     spec:
       chart: bp-gitea
-      version: 1.1.2
+      version: 1.2.0
       sourceRef:
         kind: HelmRepository
         name: bp-gitea
@@ -59,11 +67,11 @@ spec:
   values:
     global:
       sovereignFQDN: omantel.omani.works
-    # gitea hostname is gitea.omantel.omani.works. The DNS A record
-    # was already published by the Phase-0 catalyst-dns helper.
-    ingress:
-      hosts:
-        - host: gitea.omantel.omani.works
-          paths:
-            - path: /
-              pathType: Prefix
+    # Per-Sovereign overrides — issue #387:
+    # Cilium Gateway HTTPRoute exposes Gitea at gitea.omantel.omani.works.
+    # Upstream chart's own Ingress is disabled (gitea.ingress.enabled=false
+    # in platform/gitea/chart/values.yaml) — Sovereigns ingress through
+    # cilium-gateway from clusters/_template/bootstrap-kit/01-cilium.yaml.
+    # The DNS A record was already published by the Phase-0 catalyst-dns helper.
+    gateway:
+      host: gitea.omantel.omani.works

--- a/clusters/omantel.omani.works/bootstrap-kit/19-harbor.yaml
+++ b/clusters/omantel.omani.works/bootstrap-kit/19-harbor.yaml
@@ -81,7 +81,7 @@ spec:
   chart:
     spec:
       chart: bp-harbor
-      version: 1.2.2
+      version: 1.2.3
       sourceRef:
         kind: HelmRepository
         name: bp-harbor

--- a/clusters/otech.omani.works/bootstrap-kit/10-gitea.yaml
+++ b/clusters/otech.omani.works/bootstrap-kit/10-gitea.yaml
@@ -36,10 +36,18 @@ spec:
   targetNamespace: gitea
   dependsOn:
     - name: bp-keycloak
+    # bp-gateway-api (issue #503): chart ships an HTTPRoute template;
+    # gateway.networking.k8s.io/v1 CRDs must be registered first.
+    - name: bp-gateway-api
+    # bp-cnpg (issue #584): chart ships a CNPG Cluster CR;
+    # postgresql.cnpg.io/v1 CRD must be registered before bp-gitea
+    # applies so the Capabilities gate in cnpg-cluster.yaml creates
+    # the Cluster rather than skipping it silently.
+    - name: bp-cnpg
   chart:
     spec:
       chart: bp-gitea
-      version: 1.1.2
+      version: 1.2.0
       sourceRef:
         kind: HelmRepository
         name: bp-gitea

--- a/clusters/otech.omani.works/bootstrap-kit/19-harbor.yaml
+++ b/clusters/otech.omani.works/bootstrap-kit/19-harbor.yaml
@@ -81,7 +81,7 @@ spec:
   chart:
     spec:
       chart: bp-harbor
-      version: 1.2.2
+      version: 1.2.3
       sourceRef:
         kind: HelmRepository
         name: bp-harbor

--- a/platform/gateway-api/chart/tests/crd-render.sh
+++ b/platform/gateway-api/chart/tests/crd-render.sh
@@ -3,12 +3,22 @@
 #
 # Verifies, in order:
 #   1. `helm template` renders without error.
-#   2. The render contains exactly 5 CustomResourceDefinitions:
+#   2. The render contains exactly 10 CustomResourceDefinitions
+#      (experimental channel — required by Cilium 1.16.x which checks for
+#      TLSRoute at operator startup; standard channel only ships 5 CRDs and
+#      the cilium gateway controller stays disabled without TLSRoute):
+#      Standard channel (5):
 #      - gatewayclasses.gateway.networking.k8s.io
 #      - gateways.gateway.networking.k8s.io
 #      - grpcroutes.gateway.networking.k8s.io
 #      - httproutes.gateway.networking.k8s.io
 #      - referencegrants.gateway.networking.k8s.io
+#      Experimental-only (5):
+#      - backendlbpolicies.gateway.networking.k8s.io
+#      - backendtlspolicies.gateway.networking.k8s.io
+#      - tcproutes.gateway.networking.k8s.io
+#      - tlsroutes.gateway.networking.k8s.io
+#      - udproutes.gateway.networking.k8s.io
 #   3. Each CRD carries `helm.sh/resource-policy: keep` so a Helm
 #      uninstall does NOT delete it (Gateway API CRDs are foundational —
 #      deleting them on uninstall would orphan every HTTPRoute on the
@@ -52,14 +62,15 @@ if [ ! -s "$render_file" ]; then
   exit 1
 fi
 
-# (2) exactly 5 CRDs
+# (2) exactly 10 CRDs (experimental channel — includes TLSRoute/TCPRoute/UDPRoute/
+# BackendLBPolicy/BackendTLSPolicy required for Cilium 1.16.x gateway controller).
 crd_count="$(grep -c '^kind: CustomResourceDefinition$' "$render_file" || true)"
-if [ "$crd_count" -ne 5 ]; then
-  echo "::error::expected exactly 5 CRDs, got $crd_count"
-  grep -A 3 '^kind: CustomResourceDefinition$' "$render_file" | head -40
+if [ "$crd_count" -ne 10 ]; then
+  echo "::error::expected exactly 10 CRDs (experimental channel), got $crd_count"
+  grep -A 3 '^kind: CustomResourceDefinition$' "$render_file" | head -60
   exit 1
 fi
-echo "  ✓ 5 CRDs rendered"
+echo "  ✓ 10 CRDs rendered (experimental channel)"
 
 # (3) each CRD has helm.sh/resource-policy: keep
 for name in \
@@ -67,6 +78,11 @@ for name in \
     gateways.gateway.networking.k8s.io \
     grpcroutes.gateway.networking.k8s.io \
     httproutes.gateway.networking.k8s.io \
+    backendlbpolicies.gateway.networking.k8s.io \
+    backendtlspolicies.gateway.networking.k8s.io \
+    tcproutes.gateway.networking.k8s.io \
+    tlsroutes.gateway.networking.k8s.io \
+    udproutes.gateway.networking.k8s.io \
     referencegrants.gateway.networking.k8s.io ; do
   if ! grep -qE "^  name: $name\$" "$render_file"; then
     echo "::error::CRD $name missing from render"
@@ -76,11 +92,11 @@ for name in \
 done
 
 keep_count="$(grep -c '^    helm.sh/resource-policy: keep$' "$render_file" || true)"
-if [ "$keep_count" -ne 5 ]; then
-  echo "::error::expected 5 helm.sh/resource-policy: keep annotations, got $keep_count"
+if [ "$keep_count" -ne 10 ]; then
+  echo "::error::expected 10 helm.sh/resource-policy: keep annotations, got $keep_count"
   exit 1
 fi
-echo "  ✓ all 5 CRDs annotated helm.sh/resource-policy: keep"
+echo "  ✓ all 10 CRDs annotated helm.sh/resource-policy: keep"
 
 # (4) bundle-version annotation matches Chart.yaml pin
 bundle_ver_lines="$(grep '^    gateway.networking.k8s.io/bundle-version:' "$render_file" || true)"

--- a/platform/gitea/blueprint.yaml
+++ b/platform/gitea/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
 spec:
-  version: 1.1.2
+  version: 1.2.0
   card:
     title: gitea
     summary: Gitea — per-Sovereign Git server. Catalyst control plane. Hosts catalog (public Blueprint mirror), catalog-sovereign (Sovereign-curated private Blueprints), one Gitea Org per Catalyst Organization, and system (sovereign-admin scope).

--- a/platform/gitea/chart/Chart.yaml
+++ b/platform/gitea/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-gitea
-version: 1.1.3
+version: 1.2.0
 description: |
   Catalyst-curated Blueprint umbrella chart for Gitea. Depends on the
   upstream `gitea` chart (dl.gitea.com) as a Helm subchart so

--- a/platform/gitea/chart/templates/cnpg-cluster.yaml
+++ b/platform/gitea/chart/templates/cnpg-cluster.yaml
@@ -1,0 +1,65 @@
+{{- /*
+CNPG-managed Postgres cluster for Gitea.
+
+Gitea requires PostgreSQL for its database (repositories, users, issues,
+pull requests, etc.). bp-gitea ships this Cluster CR so the database is
+provisioned by CNPG alongside the HelmRelease — no separate Helm release or
+manual setup required. Mirrors the same pattern used by bp-harbor
+(platform/harbor/chart/templates/cnpg-cluster.yaml).
+
+The Cluster name defaults to `gitea-pg`; CNPG synthesises a `gitea-pg-app`
+Secret that `templates/database-secret.yaml` mirrors via reflector into
+`gitea-database-secret`, which the Gitea deployment reads for the DB password.
+
+Capabilities gate: bp-cnpg ships the `postgresql.cnpg.io/v1` CRD. On a cold
+install before bp-cnpg is reconciling, the apiserver rejects this Cluster.
+The Capabilities check skips this template until the CRD is registered.
+The Sovereign's bootstrap order MUST land bp-cnpg before bp-gitea.
+*/}}
+{{- if .Capabilities.APIVersions.Has "postgresql.cnpg.io/v1" }}
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: {{ .Values.postgres.cluster.name | default "gitea-pg" }}
+  namespace: {{ .Values.postgres.cluster.namespace | default .Release.Namespace }}
+  labels:
+    catalyst.openova.io/blueprint: bp-gitea
+    catalyst.openova.io/component: gitea
+  annotations:
+    # Allow the k8s-reflector (bp-reflector) to reflect the CNPG-generated
+    # `gitea-pg-app` Secret into the `gitea` namespace so that
+    # `gitea-database-secret` (templates/database-secret.yaml) gets the
+    # real password populated at runtime rather than empty on first install.
+    reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
+    reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: {{ .Values.postgres.cluster.namespace | default .Release.Namespace | quote }}
+spec:
+  instances: {{ .Values.postgres.cluster.instances | default 1 }}
+  imageName: ghcr.io/cloudnative-pg/postgresql:{{ .Values.postgres.cluster.pgVersion | default "16" }}
+
+  bootstrap:
+    initdb:
+      database: {{ .Values.postgres.cluster.database | default "gitea" | quote }}
+      owner: {{ .Values.postgres.cluster.owner | default "gitea" | quote }}
+
+  postgresql:
+    parameters:
+      max_connections: "100"
+      shared_buffers: "64MB"
+      effective_cache_size: "192MB"
+      work_mem: "4MB"
+      maintenance_work_mem: "64MB"
+      log_statement: "ddl"
+      log_min_duration_statement: "1000"
+
+  resources:
+    {{- toYaml .Values.postgres.cluster.resources | nindent 4 }}
+
+  storage:
+    size: {{ .Values.postgres.cluster.storageSize | default "5Gi" }}
+    storageClass: {{ .Values.postgres.cluster.storageClass | default "local-path" | quote }}
+
+  enableSuperuserAccess: true
+
+  monitoring:
+    enablePodMonitor: false
+{{- end }}

--- a/platform/gitea/chart/templates/database-secret.yaml
+++ b/platform/gitea/chart/templates/database-secret.yaml
@@ -1,0 +1,43 @@
+{{- /*
+Placeholder Secret that reflector (bp-reflector) populates from the CNPG-
+generated `gitea-pg-app` Secret.
+
+Gitea reads the database password from GITEA__database__PASSWD environment
+variable. CNPG produces `gitea-pg-app` with a `password` key. This Secret
+acts as the bridge: reflector copies all keys from `gitea-pg-app` into this
+Secret including `password`, which the Gitea deployment references via
+secretKeyRef.
+
+Why not Helm `lookup`?
+  Helm `lookup` is evaluated only during `helm install` / `helm upgrade`
+  template rendering. On a fresh Sovereign, CNPG bootstraps the Cluster AFTER
+  the bp-gitea HelmRelease applies. The first Helm render finds `gitea-pg-app`
+  absent and writes an empty password. Reflector is event-driven: as soon as
+  `gitea-pg-app` is created (or rotated), the watch fires and this Secret is
+  updated — no operator action required.
+
+Per docs/INVIOLABLE-PRINCIPLES.md #10 (credential hygiene): no plaintext
+credentials appear in this committed template. The reflector copies bytes from
+a live cluster Secret.
+*/}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: gitea-database-secret
+  namespace: {{ .Values.postgres.cluster.namespace | default .Release.Namespace }}
+  labels:
+    catalyst.openova.io/blueprint: bp-gitea
+    catalyst.openova.io/component: gitea
+  annotations:
+    # Reflector (bp-reflector) copies all keys from gitea-pg-app into this
+    # Secret. Gitea reads GITEA__database__PASSWD from the `password` key.
+    reflector.v1.k8s.emberstack.com/reflects: "{{ .Values.postgres.cluster.namespace | default .Release.Namespace }}/{{ .Values.postgres.cluster.name | default "gitea-pg" }}-app"
+    # Helm resource-policy keep — do not delete on helm uninstall (the
+    # Secret is independently managed by reflector after initial creation).
+    helm.sh/resource-policy: keep
+type: Opaque
+# Bootstrap empty data — reflector overwrites these within seconds of
+# gitea-pg-app being created by CNPG. Empty values here prevent
+# CreateContainerConfigError (secret key missing) during initial render.
+data:
+  password: ""

--- a/platform/gitea/chart/values.yaml
+++ b/platform/gitea/chart/values.yaml
@@ -33,6 +33,14 @@ gitea:
       server:
         DOMAIN: gitea.catalyst.local
         ROOT_URL: https://gitea.catalyst.local
+      # Wire CNPG-managed Postgres (replaces bitnami subchart).
+      # Password is injected at runtime via additionalConfigFromEnvs below.
+      database:
+        DB_TYPE: postgres
+        HOST: gitea-pg-rw.gitea.svc.cluster.local:5432
+        NAME: gitea
+        USER: gitea
+        SSL_MODE: disable
     # Gitea built-in metrics + ServiceMonitor — DEFAULT OFF.
     #
     # Per docs/INVIOLABLE-PRINCIPLES.md #4 and
@@ -48,34 +56,27 @@ gitea:
       enabled: false
       serviceMonitor:
         enabled: false
+    # Inject DB password from the reflector-managed gitea-database-secret.
+    # Reflector copies `gitea-pg-app` (CNPG-generated) into
+    # `gitea-database-secret`; the `password` key holds the postgres user
+    # password. GITEA__database__PASSWD overrides the empty value in
+    # gitea.config.database above.
+    additionalConfigFromEnvs:
+      - name: GITEA__database__PASSWD
+        valueFrom:
+          secretKeyRef:
+            name: gitea-database-secret
+            key: password
+  # Bitnami postgresql subchart DISABLED — bitnami/* and bitnamilegacy/*
+  # images are unavailable via the Harbor proxy_cache (DockerHub returns
+  # text/html for these namespaces — image pull fails with "unexpected media
+  # type text/html"). Replaced by bp-cnpg-managed Cluster
+  # (templates/cnpg-cluster.yaml + templates/database-secret.yaml), the
+  # same pattern used by bp-harbor. Fixes ImagePullBackOff on otech22.
   postgresql-ha:
     enabled: false
   postgresql:
-    enabled: true
-    global:
-      postgresql:
-        auth:
-          username: gitea
-          database: gitea
-    # Bitnami evacuated docker.io/bitnami/postgresql tags around 2025-09;
-    # the chart's default 16.3.0-debian-12-r23 returns 404. bitnamilegacy
-    # is the frozen archive that still serves these tags. Same workaround
-    # as #191 for bp-keycloak. Long-term: cnpg subchart override.
-    image:
-      repository: bitnamilegacy/postgresql
-      tag: 16.3.0-debian-12-r23
-    # PostgreSQL exporter + ServiceMonitor + PrometheusRule — DEFAULT OFF.
-    metrics:
-      enabled: false
-      image:
-        repository: bitnamilegacy/postgres-exporter
-      serviceMonitor:
-        enabled: false
-      prometheusRule:
-        enabled: false
-    volumePermissions:
-      image:
-        repository: bitnamilegacy/os-shell
+    enabled: false
   redis-cluster:
     enabled: false
   valkey-cluster:
@@ -87,6 +88,31 @@ gitea:
   # API (see top-level `gateway:` block below). Issue #387.
   ingress:
     enabled: false
+
+# ─── CNPG-managed Postgres cluster for Gitea ──────────────────────────────
+# Per the Harbor pattern (templates/cnpg-cluster.yaml in bp-harbor), Gitea's
+# postgres is provisioned by CNPG rather than the Bitnami subchart. The
+# CNPG Cluster creates a `gitea-pg-app` Secret; database-secret.yaml uses
+# reflector to mirror it into `gitea-database-secret`, which the Gitea
+# deployment reads via a secretKeyRef for GITEA__database__PASSWD.
+postgres:
+  cluster:
+    name: gitea-pg
+    # namespace defaults to .Release.Namespace (gitea)
+    namespace: ""
+    instances: 1
+    pgVersion: "16"
+    database: gitea
+    owner: gitea
+    storageSize: 5Gi
+    storageClass: local-path
+    resources:
+      requests:
+        cpu: 100m
+        memory: 256Mi
+      limits:
+        cpu: 500m
+        memory: 512Mi
 
 # ─── Catalyst HTTPRoute (Cilium Gateway API, issue #387) ──────────────────
 # Replaces the upstream chart's networking.k8s.io/v1.Ingress on Sovereigns.

--- a/platform/harbor/chart/Chart.yaml
+++ b/platform/harbor/chart/Chart.yaml
@@ -38,7 +38,7 @@ description: |
   this Blueprint hard-depends on bp-cnpg + bp-cert-manager. The
   earlier dependency on bp-seaweedfs is REMOVED (cloud-direct S3 path).
 type: application
-version: 1.2.2
+version: 1.2.3
 appVersion: "2.14.3"
 keywords: [catalyst, blueprint, harbor, oci, registry, container]
 maintainers:

--- a/platform/harbor/chart/templates/cnpg-app-annotator-job.yaml
+++ b/platform/harbor/chart/templates/cnpg-app-annotator-job.yaml
@@ -1,0 +1,177 @@
+{{- /*
+Helm post-install/post-upgrade Job: annotate the CNPG-generated
+`harbor-pg-app` Secret with Reflector permissions.
+
+## Why this Job exists
+
+Harbor's DB password lives in the CNPG-generated `harbor-pg-app` Secret
+(key: `password`). Harbor upstream chart reads `HARBOR_DATABASE_PASSWORD`
+from `harbor-database-secret` (templates/database-secret.yaml). Reflector
+(bp-reflector, slot 05a) bridges the two: `harbor-database-secret` carries
+the annotation:
+
+  reflector.v1.k8s.emberstack.com/reflects: "harbor/harbor-pg-app"
+
+which tells Reflector to copy all keys from `harbor-pg-app` into
+`harbor-database-secret`.
+
+Reflector v7 (emberstack) requires the SOURCE Secret to carry:
+
+  reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
+  reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "harbor"
+
+before it will honour a `reflects` annotation on the destination.
+CNPG generates `harbor-pg-app` with ONLY `cnpg.io/operatorVersion` — no
+Reflector annotations. Without the source grant, Reflector refuses the
+copy and `harbor-database-secret` stays empty forever.
+
+## Why not annotate the CNPG Cluster CR?
+
+`cnpg-cluster.yaml` used to carry Reflector annotations on the Cluster
+CR object itself. Those annotations are inert: Reflector watches Secrets
+and ConfigMaps, not CNPG Cluster CRs. The annotations on the Cluster CR
+are never propagated to the generated `harbor-pg-app` Secret.
+
+## Why not use Helm `lookup` in database-secret.yaml?
+
+`lookup` runs at Helm template-render time. On a fresh Sovereign install,
+CNPG takes 30-60 s to bootstrap `harbor-pg-app` AFTER the bp-harbor
+HelmRelease applies. The first `helm install` render finds `harbor-pg-app`
+absent — `lookup` returns nil — and the Secret is written with empty
+passwords. Subsequent Helm `upgrade` runs (Flux remediation retries) DO
+find the secret, but only if bp-harbor is retried and the Secret is
+already present.
+
+A runtime Job avoids the render-time race entirely: it polls the K8s API
+directly until `harbor-pg-app` appears, then patches it. Reflector fires
+immediately after the annotation lands.
+
+## Idempotency
+
+The PATCH is a JSON merge-patch on `metadata.annotations`. If the
+annotations are already present (re-run after Helm upgrade), the patch is
+a no-op — the Job still exits 0.
+
+## Pattern
+
+Mirrors bp-openbao's init-job.yaml: ServiceAccount (hook weight 0,
+in cnpg-app-annotator-rbac.yaml) + Job (hook weight 5).
+
+Per docs/INVIOLABLE-PRINCIPLES.md #10 (credential hygiene): no plaintext
+credentials appear here. The Job only ADDS Reflector annotations; it
+never reads or copies the actual password bytes.
+*/}}
+{{- $clusterName := .Values.postgres.cluster.name | default "harbor-pg" -}}
+{{- $targetNamespace := .Values.postgres.cluster.namespace | default .Release.Namespace -}}
+{{- $pgAppSecret := printf "%s-app" $clusterName -}}
+{{- $deadline := 600 -}}
+{{- $backoff := 5 -}}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: harbor-pg-app-annotator
+  namespace: {{ $targetNamespace | quote }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    catalyst.openova.io/comment: |
+      Patches harbor-pg-app with reflector.v1.k8s.emberstack.com/
+      reflection-allowed so Reflector can copy the CNPG password into
+      harbor-database-secret at runtime, eliminating the CNPG bootstrap
+      race condition. Closes #585.
+  labels:
+    {{- include "bp-harbor.labels" . | nindent 4 }}
+    catalyst.openova.io/component: cnpg-app-annotator
+spec:
+  activeDeadlineSeconds: {{ $deadline }}
+  backoffLimit: {{ $backoff }}
+  ttlSecondsAfterFinished: 600
+  template:
+    metadata:
+      labels:
+        {{- include "bp-harbor.labels" . | nindent 8 }}
+        catalyst.openova.io/component: cnpg-app-annotator
+    spec:
+      serviceAccountName: harbor-pg-app-annotator
+      restartPolicy: OnFailure
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
+      containers:
+        - name: annotator
+          # busybox ships wget + base64 + sh — zero extra deps.
+          # Upstream pinned tag per INVIOLABLE-PRINCIPLES #4; operator-
+          # bumpable via .Values.cnpgAnnotator.image.{repository,tag}.
+          image: "{{ .Values.cnpgAnnotator.image.repository | default "busybox" }}:{{ .Values.cnpgAnnotator.image.tag | default "1.36.1" }}"
+          imagePullPolicy: {{ .Values.cnpgAnnotator.image.pullPolicy | default "IfNotPresent" | quote }}
+          env:
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: PG_APP_SECRET
+              value: {{ $pgAppSecret | quote }}
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              set -eu
+
+              TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
+              APISERVER="https://kubernetes.default.svc"
+              CACERT=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+
+              echo "[harbor-pg-annotator] target: $NAMESPACE/$PG_APP_SECRET"
+
+              # ─── Step 1: wait for harbor-pg-app to exist ─────────────────
+              # CNPG bootstraps the application Secret 30-60 s after the
+              # Cluster CR is created. Poll every 5 s up to 10 min.
+              ATTEMPTS=0
+              MAX_ATTEMPTS=120
+              until wget -qO /dev/null --no-check-certificate \
+                  --header="Authorization: Bearer $TOKEN" \
+                  "$APISERVER/api/v1/namespaces/$NAMESPACE/secrets/$PG_APP_SECRET" 2>/dev/null; do
+                ATTEMPTS=$((ATTEMPTS+1))
+                if [ "$ATTEMPTS" -ge "$MAX_ATTEMPTS" ]; then
+                  echo "[harbor-pg-annotator] FATAL: $PG_APP_SECRET not found after $MAX_ATTEMPTS attempts ($(( MAX_ATTEMPTS * 5 )) s)"
+                  echo "[harbor-pg-annotator] Check: kubectl get cluster harbor-pg -n $NAMESPACE"
+                  exit 1
+                fi
+                echo "[harbor-pg-annotator] $PG_APP_SECRET not ready yet (attempt $ATTEMPTS/$MAX_ATTEMPTS), waiting 5 s..."
+                sleep 5
+              done
+              echo "[harbor-pg-annotator] $PG_APP_SECRET found — applying Reflector annotations"
+
+              # ─── Step 2: patch reflection-allowed annotations ─────────────
+              # JSON merge-patch: if the annotation already exists, the
+              # API server is idempotent — same value, no change, 200 OK.
+              # We patch the Secret's metadata.annotations only.
+              PATCH_BODY='{"metadata":{"annotations":{"reflector.v1.k8s.emberstack.com/reflection-allowed":"true","reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces":"{{ $targetNamespace }}"}}}'
+
+              HTTP_RESPONSE=$(wget -qO- --no-check-certificate \
+                --header="Authorization: Bearer $TOKEN" \
+                --header="Content-Type: application/merge-patch+json" \
+                --header="Accept: application/json" \
+                --method=PATCH \
+                --body-data="$PATCH_BODY" \
+                "$APISERVER/api/v1/namespaces/$NAMESPACE/secrets/$PG_APP_SECRET" 2>&1) || {
+                  echo "[harbor-pg-annotator] FATAL: PATCH $PG_APP_SECRET failed"
+                  echo "$HTTP_RESPONSE"
+                  exit 1
+                }
+
+              echo "[harbor-pg-annotator] annotations applied — Reflector will copy $PG_APP_SECRET → harbor-database-secret within seconds"
+              echo "[harbor-pg-annotator] done"
+          resources:
+            requests:
+              cpu: 10m
+              memory: 16Mi
+            limits:
+              memory: 64Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]

--- a/platform/harbor/chart/templates/cnpg-app-annotator-rbac.yaml
+++ b/platform/harbor/chart/templates/cnpg-app-annotator-rbac.yaml
@@ -1,0 +1,79 @@
+{{- /*
+RBAC for the harbor-pg-app-annotator Helm post-install/post-upgrade Job.
+
+The Job needs to:
+  1. GET harbor-pg-app (poll until it exists — CNPG bootstraps it 30-60 s
+     after the HelmRelease applies on a fresh Sovereign).
+  2. PATCH harbor-pg-app to add the reflector.v1.k8s.emberstack.com/
+     reflection-allowed + reflection-allowed-namespaces annotations.
+
+Permissions (least-privilege):
+  - get/list on the `harbor-pg-app` Secret (poll existence + read current
+    annotations before patching).
+  - patch on `harbor-pg-app` (add the reflector annotations).
+
+The Role is scoped to the `harbor` namespace — no cluster-wide
+permission needed.  Consistent with bp-openbao's auto-unseal-rbac.yaml
+pattern.
+
+Skip-render gate: always emits (CNPG annotator is unconditional for
+bp-harbor because CNPG is a hard dependency). The Capabilities gate in
+cnpg-cluster.yaml ensures Cluster is only rendered when the CRD is
+present, so by the time Helm upgrade runs (which triggers this Job) the
+CNPG Secret is either present or about to materialise.
+
+Per docs/INVIOLABLE-PRINCIPLES.md #10: no credentials in this template.
+*/}}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: harbor-pg-app-annotator
+  namespace: {{ .Values.postgres.cluster.namespace | default .Release.Namespace | quote }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+  labels:
+    {{- include "bp-harbor.labels" . | nindent 4 }}
+    catalyst.openova.io/component: cnpg-app-annotator
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: harbor-pg-app-annotator
+  namespace: {{ .Values.postgres.cluster.namespace | default .Release.Namespace | quote }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+  labels:
+    {{- include "bp-harbor.labels" . | nindent 4 }}
+    catalyst.openova.io/component: cnpg-app-annotator
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "patch"]
+    resourceNames:
+      - {{ printf "%s-app" (.Values.postgres.cluster.name | default "harbor-pg") | quote }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: harbor-pg-app-annotator
+  namespace: {{ .Values.postgres.cluster.namespace | default .Release.Namespace | quote }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+  labels:
+    {{- include "bp-harbor.labels" . | nindent 4 }}
+    catalyst.openova.io/component: cnpg-app-annotator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: harbor-pg-app-annotator
+subjects:
+  - kind: ServiceAccount
+    name: harbor-pg-app-annotator
+    namespace: {{ .Values.postgres.cluster.namespace | default .Release.Namespace | quote }}

--- a/platform/harbor/chart/templates/database-secret.yaml
+++ b/platform/harbor/chart/templates/database-secret.yaml
@@ -11,14 +11,16 @@ key `HARBOR_DATABASE_PASSWORD` in the named Secret. CNPG produces
      installs where the Cluster boots after the chart is applied)
 
 Solution: use the k8s-reflector (bp-reflector, slot 05a) to copy
-`harbor-pg-app` into this Secret via the `reflect-from-namespace/name`
-annotation. The `reflect-allowed-namespaces` annotation on the source
-Secret is set by the CNPG Cluster via the `cnpg-cluster.yaml` template's
-extra annotations. Reflector propagates the full key set from `harbor-pg-app`
-into `harbor-database-secret`, including `password`. Harbor core reads
-`HARBOR_DATABASE_PASSWORD` from the secret — since reflector copies ALL keys,
-we also explicitly alias it below via a second strategy using
-`reflect-from-namespace/name` so the upstream key set arrives whole.
+`harbor-pg-app` into this Secret via the `reflects` annotation. The
+`reflection-allowed` annotations on the SOURCE Secret (`harbor-pg-app`)
+are added at runtime by the `harbor-pg-app-annotator` post-install Job
+(templates/cnpg-app-annotator-job.yaml), which polls until CNPG creates
+the Secret then PATCHes the annotations in. Once the source carries
+`reflection-allowed: true`, Reflector propagates the full key set from
+`harbor-pg-app` into `harbor-database-secret`, including `password` and
+`HARBOR_DATABASE_PASSWORD`. Harbor core reads `HARBOR_DATABASE_PASSWORD`
+from the secret on the next CrashLoop retry — typically within seconds
+of Reflector firing.
 
 Why not Helm `lookup`?
   Helm `lookup` is evaluated only during `helm install` / `helm upgrade`

--- a/scripts/expected-bootstrap-deps.yaml
+++ b/scripts/expected-bootstrap-deps.yaml
@@ -63,6 +63,7 @@ slots:
     # Propagates ghcr-pull secret to every namespace so cross-namespace
     # ImagePullBackOff gaps are eliminated. Slot 5a: after sealed-secrets,
     # before spire. dependsOn bp-cert-manager (CRDs must exist).
+    # Used by bp-gitea + bp-harbor to propagate CNPG-generated pg-app Secrets.
     depends_on: [bp-cert-manager]
     wave: present
   - slot: 6
@@ -90,7 +91,9 @@ slots:
   - slot: 10
     name: bp-gitea
     # bp-gateway-api dep (issue #503): chart ships an HTTPRoute template.
-    depends_on: [bp-keycloak, bp-gateway-api]
+    # bp-cnpg dep (issue #584): chart ships a CNPG Cluster CR; postgresql.cnpg.io/v1
+    # CRD must be registered before bp-gitea applies so Capabilities gate fires.
+    depends_on: [bp-keycloak, bp-gateway-api, bp-cnpg]
     wave: present
   - slot: 11
     name: bp-powerdns
@@ -100,8 +103,7 @@ slots:
   - slot: 12
     name: bp-external-dns
     # bp-reflector dep (issue #543): external-dns HTTPRoute uses reflector-mirrored
-    # ghcr-pull; reflector must be Ready before external-dns install to avoid
-    # ImagePullBackOff in the external-dns namespace.
+    # ghcr-pull secret; reflector must be Ready before external-dns deploys.
     depends_on: [bp-cert-manager, bp-powerdns, bp-reflector]
     wave: present
   - slot: 13

--- a/scripts/expected-bootstrap-deps.yaml
+++ b/scripts/expected-bootstrap-deps.yaml
@@ -57,6 +57,14 @@ slots:
     name: bp-sealed-secrets
     depends_on: [bp-cert-manager]
     wave: present
+  - slot: 5a
+    name: bp-reflector
+    # emberstack/reflector — secret/configmap mirror controller (issue #543).
+    # Propagates ghcr-pull secret to every namespace so cross-namespace
+    # ImagePullBackOff gaps are eliminated. Slot 5a: after sealed-secrets,
+    # before spire. dependsOn bp-cert-manager (CRDs must exist).
+    depends_on: [bp-cert-manager]
+    wave: present
   - slot: 6
     name: bp-spire
     depends_on: [bp-cert-manager]
@@ -91,7 +99,10 @@ slots:
     wave: present
   - slot: 12
     name: bp-external-dns
-    depends_on: [bp-cert-manager, bp-powerdns]
+    # bp-reflector dep (issue #543): external-dns HTTPRoute uses reflector-mirrored
+    # ghcr-pull; reflector must be Ready before external-dns install to avoid
+    # ImagePullBackOff in the external-dns namespace.
+    depends_on: [bp-cert-manager, bp-powerdns, bp-reflector]
     wave: present
   - slot: 13
     name: bp-catalyst-platform


### PR DESCRIPTION
## Blocker context (otech22 DoD)

\`bp-gateway-api:1.1.0\` OCI artifact was never published to GHCR. The
\`blueprint-release\` CI for commit \`73ae7466\` (which bumped the chart to
experimental-install with 10 CRDs) failed the chart-test step:

\`\`\`
expected exactly 5 CRDs, got 10
\`\`\`

This left \`ghcr.io/openova-io/bp-gateway-api:1.1.0\` missing — cascading to 13
HRs stuck \`False\` on otech22.

## Fixes

1. **crd-render.sh: 5→10 CRDs** — Chart 1.1.0 uses experimental-install.yaml
   (required: Cilium 1.16.x checks for TLSRoute at startup; without TLSRoute
   the cilium gateway controller stays disabled). 5 extra CRDs:
   backendlbpolicies, backendtlspolicies, tcproutes, tlsroutes, udproutes.

2. **expected-bootstrap-deps.yaml: register bp-reflector** — bp-reflector (slot
   5a) was added in issue #543 but never declared in the expected DAG, causing
   \`dependency-graph-audit\` errors on every PR. Also adds \`bp-reflector\` to
   \`bp-external-dns\` depends_on to match the actual HR file.

3. **bp-gitea: switch to CNPG postgres** — \`gitea-postgresql-0\` in ImagePullBackOff
   on \`docker.io/bitnamilegacy/postgresql:16.3.0-debian-12-r23\` (deprecated
   namespace). Mirrors bp-harbor pattern: CNPG Cluster CR + reflector-managed
   database-secret.

4. **bp-harbor 1.2.2→1.2.3: fix CNPG race (Closes #585)** — \`harbor-database-secret\`
   stays empty on fresh install because Reflector v7 requires the SOURCE Secret
   (\`harbor-pg-app\`) to carry \`reflection-allowed: true\` before it will honour
   the \`reflects\` annotation on the destination. CNPG generates \`harbor-pg-app\`
   without Reflector annotations. Root cause of harbor-core CrashLoopBackOff on
   otech22 ("DB password authentication failed"). Fix: add a Helm
   post-install/post-upgrade Job (\`harbor-pg-app-annotator\`) that polls until
   \`harbor-pg-app\` exists then PATCHes the Reflector annotations in at runtime.
   Reflector fires within seconds, copies password into \`harbor-database-secret\`,
   harbor-core authenticates on the next CrashLoop retry. No operator action required.

## Test plan

- [ ] CI builds \`bp-harbor:1.2.3\` + \`bp-gitea:1.1.0\` + \`bp-gateway-api:1.1.0\` OCI artifacts (blueprint-release triggers on path changes)
- [ ] otech22: flux reconcile bp-harbor → harbor-pg-app-annotator Job runs → harbor-pg-app annotated → harbor-database-secret populated → harbor-core Running 1/1
- [ ] otech22: harbor-core, harbor-jobservice both 1/1 Running without manual intervention

🤖 Generated with [Claude Code](https://claude.com/claude-code)