### PR TITLE
fix(bp-harbor): nil-safe value extraction in cnpg-app-annotator Job — fixes 1.2.3 smoke render

### DIFF
--- a/platform/harbor/chart/templates/cnpg-app-annotator-job.yaml
+++ b/platform/harbor/chart/templates/cnpg-app-annotator-job.yaml
@@ -66,6 +66,11 @@ never reads or copies the actual password bytes.
 {{- $pgAppSecret := printf "%s-app" $clusterName -}}
 {{- $deadline := 600 -}}
 {{- $backoff := 5 -}}
+{{- $annotatorCfg := .Values.cnpgAnnotator | default dict -}}
+{{- $imgCfg := $annotatorCfg.image | default dict -}}
+{{- $imgRepo := $imgCfg.repository | default "busybox" -}}
+{{- $imgTag := $imgCfg.tag | default "1.36.1" -}}
+{{- $imgPullPolicy := $imgCfg.pullPolicy | default "IfNotPresent" -}}
 ---
 apiVersion: batch/v1
 kind: Job
@@ -105,8 +110,8 @@ spec:
           # busybox ships wget + base64 + sh — zero extra deps.
           # Upstream pinned tag per INVIOLABLE-PRINCIPLES #4; operator-
           # bumpable via .Values.cnpgAnnotator.image.{repository,tag}.
-          image: "{{ .Values.cnpgAnnotator.image.repository | default "busybox" }}:{{ .Values.cnpgAnnotator.image.tag | default "1.36.1" }}"
-          imagePullPolicy: {{ .Values.cnpgAnnotator.image.pullPolicy | default "IfNotPresent" | quote }}
+          image: {{ printf "%s:%s" $imgRepo $imgTag | quote }}
+          imagePullPolicy: {{ $imgPullPolicy | quote }}
           env:
             - name: NAMESPACE
               valueFrom:


### PR DESCRIPTION
## Summary

- `bp-harbor:1.2.3` blueprint-release smoke render fails with nil pointer on `.Values.cnpgAnnotator.image.repository`. This is because Helm's nil pointer dereference behaviour: when values are merged in the render pipeline, `cnpgAnnotator` exists in `values.yaml` but nested access `.cnpgAnnotator.image.repository` trips nil pointer when Helm's template evaluator traverses it without `| default dict` guard.
- Fix: extract values with chained `| default dict` pattern so nested access is nil-safe regardless of values merge order.

## Test plan

- [ ] CI `blueprint-release` for `platform/harbor` passes `Helm template smoke render` step on 1.2.3

Closes #585 (build fix for chart shipped in #592)

🤖 Generated with [Claude Code](https://claude.com/claude-code)