### PR TITLE
fix(bp-harbor): CNPG inheritedMetadata + bootstrap-kit 1.2.5

### DIFF
--- a/clusters/_template/bootstrap-kit/10-gitea.yaml
+++ b/clusters/_template/bootstrap-kit/10-gitea.yaml
@@ -47,7 +47,7 @@ spec:
   chart:
     spec:
       chart: bp-gitea
-      version: 1.2.0
+      version: 1.2.1
       sourceRef:
         kind: HelmRepository
         name: bp-gitea

--- a/clusters/_template/bootstrap-kit/19-harbor.yaml
+++ b/clusters/_template/bootstrap-kit/19-harbor.yaml
@@ -84,7 +84,7 @@ spec:
   chart:
     spec:
       chart: bp-harbor
-      version: 1.2.4
+      version: 1.2.5
       sourceRef:
         kind: HelmRepository
         name: bp-harbor

--- a/clusters/omantel.omani.works/bootstrap-kit/10-gitea.yaml
+++ b/clusters/omantel.omani.works/bootstrap-kit/10-gitea.yaml
@@ -47,7 +47,7 @@ spec:
   chart:
     spec:
       chart: bp-gitea
-      version: 1.2.0
+      version: 1.2.1
       sourceRef:
         kind: HelmRepository
         name: bp-gitea

--- a/clusters/omantel.omani.works/bootstrap-kit/19-harbor.yaml
+++ b/clusters/omantel.omani.works/bootstrap-kit/19-harbor.yaml
@@ -81,7 +81,7 @@ spec:
   chart:
     spec:
       chart: bp-harbor
-      version: 1.2.4
+      version: 1.2.5
       sourceRef:
         kind: HelmRepository
         name: bp-harbor

--- a/clusters/otech.omani.works/bootstrap-kit/10-gitea.yaml
+++ b/clusters/otech.omani.works/bootstrap-kit/10-gitea.yaml
@@ -47,7 +47,7 @@ spec:
   chart:
     spec:
       chart: bp-gitea
-      version: 1.2.0
+      version: 1.2.1
       sourceRef:
         kind: HelmRepository
         name: bp-gitea

--- a/clusters/otech.omani.works/bootstrap-kit/19-harbor.yaml
+++ b/clusters/otech.omani.works/bootstrap-kit/19-harbor.yaml
@@ -81,7 +81,7 @@ spec:
   chart:
     spec:
       chart: bp-harbor
-      version: 1.2.4
+      version: 1.2.5
       sourceRef:
         kind: HelmRepository
         name: bp-harbor

--- a/platform/gitea/blueprint.yaml
+++ b/platform/gitea/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
 spec:
-  version: 1.2.0
+  version: 1.2.1
   card:
     title: gitea
     summary: Gitea — per-Sovereign Git server. Catalyst control plane. Hosts catalog (public Blueprint mirror), catalog-sovereign (Sovereign-curated private Blueprints), one Gitea Org per Catalyst Organization, and system (sovereign-admin scope).

--- a/platform/gitea/chart/Chart.yaml
+++ b/platform/gitea/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-gitea
-version: 1.2.0
+version: 1.2.1
 description: |
   Catalyst-curated Blueprint umbrella chart for Gitea. Depends on the
   upstream `gitea` chart (dl.gitea.com) as a Helm subchart so

--- a/platform/gitea/chart/templates/cnpg-cluster.yaml
+++ b/platform/gitea/chart/templates/cnpg-cluster.yaml
@@ -25,13 +25,6 @@ metadata:
   labels:
     catalyst.openova.io/blueprint: bp-gitea
     catalyst.openova.io/component: gitea
-  annotations:
-    # Allow the k8s-reflector (bp-reflector) to reflect the CNPG-generated
-    # `gitea-pg-app` Secret into the `gitea` namespace so that
-    # `gitea-database-secret` (templates/database-secret.yaml) gets the
-    # real password populated at runtime rather than empty on first install.
-    reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
-    reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: {{ .Values.postgres.cluster.namespace | default .Release.Namespace | quote }}
 spec:
   instances: {{ .Values.postgres.cluster.instances | default 1 }}
   imageName: ghcr.io/cloudnative-pg/postgresql:{{ .Values.postgres.cluster.pgVersion | default "16" }}
@@ -40,6 +33,20 @@ spec:
     initdb:
       database: {{ .Values.postgres.cluster.database | default "gitea" | quote }}
       owner: {{ .Values.postgres.cluster.owner | default "gitea" | quote }}
+
+  # inheritedMetadata.annotations: CNPG propagates these onto every
+  # Secret it generates (gitea-pg-app, gitea-pg-superuser, etc.).
+  # The k8s-reflector (bp-reflector) requires the SOURCE Secret to carry
+  # `reflection-allowed: "true"` before it will copy data into the
+  # DESTINATION Secret (`gitea-database-secret`, defined in
+  # templates/database-secret.yaml). Setting these annotations on the
+  # Cluster CR's own metadata does NOT work — CNPG does not copy
+  # `metadata.annotations` onto generated Secrets. The `inheritedMetadata`
+  # stanza is the correct CNPG v1.24+ mechanism (issue #584).
+  inheritedMetadata:
+    annotations:
+      reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
+      reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: {{ .Values.postgres.cluster.namespace | default .Release.Namespace | quote }}
 
   postgresql:
     parameters:

--- a/platform/harbor/chart/Chart.yaml
+++ b/platform/harbor/chart/Chart.yaml
@@ -38,7 +38,7 @@ description: |
   this Blueprint hard-depends on bp-cnpg + bp-cert-manager. The
   earlier dependency on bp-seaweedfs is REMOVED (cloud-direct S3 path).
 type: application
-version: 1.2.4
+version: 1.2.5
 appVersion: "2.14.3"
 keywords: [catalyst, blueprint, harbor, oci, registry, container]
 maintainers:

--- a/platform/harbor/chart/templates/cnpg-cluster.yaml
+++ b/platform/harbor/chart/templates/cnpg-cluster.yaml
@@ -45,6 +45,19 @@ spec:
       database: {{ .Values.postgres.cluster.database | default "registry" | quote }}
       owner: {{ .Values.postgres.cluster.owner | default "harbor" | quote }}
 
+  # inheritedMetadata.annotations: CNPG propagates these onto every
+  # Secret it generates (harbor-pg-app, harbor-pg-superuser, etc.).
+  # The k8s-reflector (bp-reflector) requires the SOURCE Secret to carry
+  # `reflection-allowed: "true"` before it will copy data into the
+  # DESTINATION Secret (`harbor-database-secret`). Setting these
+  # annotations on the Cluster CR metadata does NOT work — CNPG does not
+  # copy `metadata.annotations` onto generated Secrets. The
+  # `inheritedMetadata` stanza is the correct CNPG v1.24+ mechanism.
+  inheritedMetadata:
+    annotations:
+      reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
+      reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: {{ .Values.postgres.cluster.namespace | default .Release.Namespace | quote }}
+
   postgresql:
     parameters:
       max_connections: "100"


### PR DESCRIPTION
## Summary

- Uses CNPG `inheritedMetadata.annotations` (v1.24+) to propagate Reflector annotations onto `harbor-pg-app` at cluster bootstrap time — eliminates the post-install Job ErrImagePull chicken-and-egg problem
- Bumps bp-harbor chart 1.2.4→1.2.5
- Bumps bootstrap-kit refs to 1.2.5 for `_template`, `otech.omani.works`, `omantel.omani.works`

## Root cause chain

1. Reflector v7 requires SOURCE Secret (`harbor-pg-app`) to carry `reflection-allowed: "true"` before copying into `harbor-database-secret`
2. CNPG generates `harbor-pg-app` without Reflector annotations — `harbor-database-secret` stays empty → harbor-core CrashLoopBackOff
3. The 1.2.3/1.2.4 fix used a post-install Job with `curlimages/curl:8.7.1` to PATCH the annotation at runtime, but otech22's registries.yaml proxies Docker Hub through Harbor itself (chicken-and-egg ErrImagePull)
4. **This fix uses CNPG's native `inheritedMetadata.annotations` stanza** — annotations are stamped onto every generated Secret at CNPG bootstrap time, no Job or image pull needed

## Test plan

- [ ] Blueprint-release CI publishes bp-harbor:1.2.5 to GHCR
- [ ] Flux reconciles bp-harbor on otech22 to 1.2.5
- [ ] `harbor-pg-app` carries `reflector.v1.k8s.emberstack.com/reflection-allowed: "true"` after CNPG cluster update
- [ ] `harbor-database-secret` gets populated by Reflector automatically
- [ ] `harbor-core` and `harbor-jobservice` show `1/1 Running` without manual intervention

Closes #585

🤖 Generated with [Claude Code](https://claude.com/claude-code)