### PR TITLE
fix(catalyst-ui): Vite base / — fixes blank page on Sovereign clusters (#596)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -58,7 +58,7 @@ spec:
   chart:
     spec:
       chart: bp-catalyst-platform
-      version: 1.1.13
+      version: 1.1.15
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/bootstrap/ui/nginx.conf
+++ b/products/catalyst/bootstrap/ui/nginx.conf
@@ -45,12 +45,13 @@ server {
     }
 
     # SPA fallback — all routes serve index.html.
-    # Note: when deployed behind the console.openova.io/sovereign ingress,
-    # Traefik strips /sovereign before requests reach here, so nginx sees
-    # /dashboard, /wizard, etc. These are React routes handled client-side,
-    # so fall straight to /index.html without the directory-check middle
-    # step (which would 301 to add a trailing slash and lose the /sovereign
-    # prefix on the client side).
+    # Vite is built with base: '/' so assets live at /assets/*.
+    # On contabo (console.openova.io/sovereign/*), Traefik's strip-sovereign
+    # Middleware rewrites /sovereign/assets/foo → /assets/foo before the
+    # request reaches nginx. On Sovereigns (console.<sov>/), the HTTPRoute
+    # passes through to / directly. Both paths resolve to /assets/* here.
+    # React routes (/dashboard, /wizard, etc.) fall through to /index.html
+    # and are handled client-side (issue #596).
     location / {
         try_files $uri /index.html;
     }

--- a/products/catalyst/bootstrap/ui/src/app/router.tsx
+++ b/products/catalyst/bootstrap/ui/src/app/router.tsx
@@ -413,9 +413,10 @@ const routeTree = rootRoute.addChildren([
   marketplaceProductRoute,
 ])
 
-// basepath mirrors Vite's `base: '/sovereign/'` so internal <Link> and
-// router.navigate calls emit URLs prefixed with /sovereign/.
-export const router = createRouter({ routeTree, basepath: '/sovereign' })
+// basepath: '/' — Vite base is now '/' (issue #596). Both Sovereigns
+// (console.<sov>/) and contabo (console.openova.io/sovereign/* with
+// Traefik strip-prefix) resolve to root, so router and Vite must agree.
+export const router = createRouter({ routeTree, basepath: '/' })
 
 declare module '@tanstack/react-router' {
   interface Register {

--- a/products/catalyst/bootstrap/ui/vite.config.ts
+++ b/products/catalyst/bootstrap/ui/vite.config.ts
@@ -52,7 +52,19 @@ function rebuildCatalogOnYamlChange(): Plugin {
 }
 
 export default defineConfig({
-  base: '/sovereign/',
+  // base: '/' — path-agnostic for all deployment contexts.
+  //
+  // On Sovereigns (console.<sov>.omani.works/) the HTTPRoute passes
+  // through to nginx root; assets must be at /assets/*, not
+  // /sovereign/assets/*. On contabo (console.openova.io/sovereign/*),
+  // the Traefik strip-sovereign Middleware strips the /sovereign prefix
+  // BEFORE forwarding to nginx, so nginx still sees /assets/* — both
+  // cases resolve correctly with base: '/'.
+  //
+  // Issue #596: the previous base: '/sovereign/' caused blank pages on
+  // every Sovereign cluster because the browser requested
+  // /sovereign/assets/index-*.js but nginx (serving dist at /) returned 404.
+  base: '/',
   plugins: [tailwindcss(), react(), rebuildCatalogOnYamlChange()],
   resolve: {
     alias: {
@@ -62,19 +74,11 @@ export default defineConfig({
   server: {
     port: 5173,
     proxy: {
+      // With base: '/', API_BASE = '/api' in dev too. Direct proxy to
+      // catalyst-api on localhost:8080 — no prefix rewrite needed.
       '/api': {
         target: 'http://localhost:8080',
         changeOrigin: true,
-      },
-      // The UI is served under `base: '/sovereign/'`, so fetch calls
-      // emitted by `${API_BASE}/v1/...` (where API_BASE = `/sovereign/api`)
-      // arrive here as `/sovereign/api/...`. Rewrite to `/api/...` so
-      // catalyst-api receives the canonical path. Production traefik
-      // performs the same prefix strip, so dev mirrors prod.
-      '/sovereign/api': {
-        target: 'http://localhost:8080',
-        changeOrigin: true,
-        rewrite: (p: string) => p.replace(/^\/sovereign/, ''),
       },
     },
   },

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-catalyst-platform
-version: 1.1.14
+version: 1.1.15
 appVersion: 1.1.6
 description: |
   Catalyst Platform — the unified Catalyst control plane umbrella chart for Catalyst-Zero.
@@ -99,6 +99,15 @@ description: |
   Catalyst-authored image refs (catalyst-api, catalyst-ui, marketplace-api,
   console, and all 10 SME service deployments). Post-handover per-Sovereign
   overlays set global.imageRegistry to the local Harbor mirror. Issue #560.
+  Bumped to 1.1.15 to rebuild catalyst-ui with Vite base: '/' (was
+  /sovereign/). The previous base caused blank pages on Sovereign clusters:
+  the browser requested /sovereign/assets/index-*.js but nginx served the
+  dist at / so every asset returned 404. On contabo
+  (console.openova.io/sovereign/*) Traefik's strip-sovereign Middleware strips
+  the prefix before reaching nginx — both environments now serve assets at
+  /assets/* as expected. Also fixes router.tsx basepath from '/sovereign' to
+  '/' so TanStack Router Link/navigate calls emit correct paths. Issue #596,
+  2026-05-02.
 type: application
 
 # Opt-out from the blueprint-release hollow-chart guard (issue #181 / #510).


### PR DESCRIPTION
## Summary

- **Root cause**: `vite.config.ts` had `base: '/sovereign/'` causing HTML to reference `/sovereign/assets/*.js`. On Sovereign clusters (`console.otech22.omani.works/`), nginx serves dist at `/` root — the browser got 404 on every JS/CSS asset → blank page.
- **Fix**: Change `base: '/'`. Traefik's `strip-sovereign` Middleware on contabo still strips `/sovereign` before nginx, so `/sovereign/assets/foo → /assets/foo → 200`. Sovereigns need no rewrite. Both environments now serve assets at `/assets/*`.
- **Also fixed**: `router.tsx` `basepath` changed from `'/sovereign'` to `'/'` so TanStack Router `<Link>` and `navigate()` calls emit correct root-relative paths on Sovereigns.
- **Chart**: Bumped `bp-catalyst-platform` to 1.1.15. Bootstrap-kit ref updated.

## Files changed

| File | Change |
|---|---|
| `products/catalyst/bootstrap/ui/vite.config.ts` | `base: '/sovereign/'` → `base: '/'`, remove stale `/sovereign/api` proxy entry |
| `products/catalyst/bootstrap/ui/src/app/router.tsx` | `basepath: '/sovereign'` → `basepath: '/'` |
| `products/catalyst/bootstrap/ui/nginx.conf` | Update comment to reflect Traefik strips at ingress layer |
| `products/catalyst/chart/Chart.yaml` | Bump to 1.1.15 with changelog |
| `clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml` | Pin to 1.1.15 |

## No change needed
- `products/catalyst/chart/templates/ingress.yaml` — existing `strip-sovereign` Middleware already rewrites `/sovereign/assets/foo` → `/assets/foo`. With `base: '/'` this is exactly correct.
- `products/catalyst/chart/templates/httproute.yaml` — Sovereign HTTPRoute passes through to `/`. Correct.
- `products/catalyst/bootstrap/ui/src/shared/config/urls.ts` — `BASE` and `API_BASE` derive from `import.meta.env.BASE_URL` at build time. With `base: '/'`, `BASE=/` and `API_BASE=/api`. All fetch calls correctly go to `/api/v1/...` which nginx proxy_pass handles.

## Test plan
- [ ] CI builds catalyst-ui image, smoke test passes (`curl / → 200`)
- [ ] `curl -sk https://console.otech22.omani.works/ | grep 'src='` — assets at `/assets/` not `/sovereign/assets/`
- [ ] Playwright screenshot of `console.otech22.omani.works` — UI renders (not blank)
- [ ] `console.openova.io/sovereign/*` — still works (Traefik strip-sovereign Middleware unchanged)

Closes #596.