### PR TITLE
fix(bp-keycloak,bp-openbao): HTTPRoute backend wrong name + RBAC SA lifecycle bug (#598)

### DIFF
--- a/clusters/_template/bootstrap-kit/08-openbao.yaml
+++ b/clusters/_template/bootstrap-kit/08-openbao.yaml
@@ -53,7 +53,7 @@ spec:
   chart:
     spec:
       chart: bp-openbao
-      version: 1.2.4
+      version: 1.2.6
       sourceRef:
         kind: HelmRepository
         name: bp-openbao

--- a/clusters/_template/bootstrap-kit/09-keycloak.yaml
+++ b/clusters/_template/bootstrap-kit/09-keycloak.yaml
@@ -41,7 +41,7 @@ spec:
   chart:
     spec:
       chart: bp-keycloak
-      version: 1.2.0
+      version: 1.2.2
       sourceRef:
         kind: HelmRepository
         name: bp-keycloak

--- a/platform/keycloak/chart/Chart.yaml
+++ b/platform/keycloak/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-keycloak
-version: 1.2.1
+version: 1.2.2
 description: |
   Catalyst-curated Blueprint umbrella chart for Keycloak. Depends on the
   upstream `keycloak` chart (bitnami) as a Helm subchart so

--- a/platform/keycloak/chart/templates/httproute.yaml
+++ b/platform/keycloak/chart/templates/httproute.yaml
@@ -10,11 +10,13 @@ Pattern from docs/INVIOLABLE-PRINCIPLES.md #4 (never hardcode):
                           (the per-Sovereign Gateway from bootstrap-kit
                           01-cilium.yaml)
 
-Backend reference: the upstream bitnami/keycloak chart's Service is
-named `<release>-keycloak`. With `releaseName: keycloak` set in the
-bootstrap-kit slot the Service is `keycloak-keycloak`. Operators can
-override via `gateway.backendService` if a non-default release name is
-used.
+Backend reference: the upstream bitnami/keycloak chart uses Helm's
+`fullname` template which TRIMS the chart-name suffix when the Release.Name
+already contains it. With releaseName=keycloak (bootstrap-kit default), the
+bitnami fullname returns "keycloak" (not "keycloak-keycloak"). The default
+backendService MUST use `.Release.Name` directly (issue #598).
+Operators can override via `gateway.backendService` for non-default
+release names.
 */}}
 {{- if and .Values.gateway .Values.gateway.enabled -}}
 {{- if .Values.gateway.host }}
@@ -41,7 +43,7 @@ spec:
             type: PathPrefix
             value: {{ .Values.gateway.path | default "/" | quote }}
       backendRefs:
-        - name: {{ .Values.gateway.backendService | default (printf "%s-keycloak" .Release.Name) | quote }}
+        - name: {{ .Values.gateway.backendService | default .Release.Name | quote }}
           port: {{ .Values.gateway.backendPort | default 80 }}
 {{- end }}
 {{- end }}

--- a/platform/openbao/chart/Chart.yaml
+++ b/platform/openbao/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-openbao
-version: 1.2.5
+version: 1.2.6
 description: |
   Catalyst-curated Blueprint umbrella chart for OpenBao. Depends on the
   upstream `openbao` chart as a Helm subchart so `helm dependency build`

--- a/platform/openbao/chart/templates/auto-unseal-rbac.yaml
+++ b/platform/openbao/chart/templates/auto-unseal-rbac.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Catalyst auto-unseal RBAC — bp-openbao (issue #316).
+Catalyst auto-unseal RBAC — bp-openbao (issue #316, bug fix issue #598).
 
 ServiceAccount + RoleBindings used by the post-install Jobs that run
 `bao operator init` and bootstrap the Kubernetes auth method.
@@ -16,6 +16,17 @@ Permissions required (least-privilege):
     runtime, not a one-shot init step) so it lives outside the Helm
     hook lifecycle.
 
+RBAC resources are NOT Helm hooks (issue #598 root cause fix):
+  The SA/Role/RoleBinding must NOT have hook-delete-policy so they
+  persist for the Job container to use. Previously they had
+  `hook-delete-policy: before-hook-creation,hook-succeeded` — the
+  `hook-succeeded` clause caused Helm to delete the SA immediately
+  after the weight-0 hook "succeeded", before the weight-5 init Job
+  pod could start (Job pod needs the SA to exist for token mount).
+  Making them regular Helm-managed resources (no hook annotations)
+  ensures they exist for the full duration of the install/upgrade and
+  for idempotent re-runs.
+
 Skip-render pattern (per #402 lesson, never use `{{ fail }}`): when
 `autoUnseal.enabled=false` this entire file emits nothing — `helm
 template` with default values stays clean.
@@ -24,30 +35,24 @@ template` with default values stays clean.
 {{- if $au.enabled -}}
 ---
 # ServiceAccount used by the init + auth-bootstrap Jobs. Lives in the
-# openbao namespace alongside the StatefulSet.
+# openbao namespace alongside the StatefulSet. NOT a hook — must persist
+# for the Job container's SA token mount (issue #598).
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: openbao-auto-unseal
   namespace: {{ .Release.Namespace | quote }}
-  annotations:
-    "helm.sh/hook": post-install,post-upgrade
-    "helm.sh/hook-weight": "0"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   labels:
     catalyst.openova.io/blueprint: bp-openbao
     catalyst.openova.io/component: openbao-auto-unseal
 ---
 # Role: read+delete the seed Secret, get/list Pods to poll readiness.
+# NOT a hook — persists for life of the Helm release (issue #598).
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: openbao-auto-unseal
   namespace: {{ .Release.Namespace | quote }}
-  annotations:
-    "helm.sh/hook": post-install,post-upgrade
-    "helm.sh/hook-weight": "0"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   labels:
     catalyst.openova.io/blueprint: bp-openbao
 rules:
@@ -75,15 +80,12 @@ rules:
       # later retry when the vault is initialised but still sealed.
       - openbao-unseal-keys
 ---
+# RoleBinding — NOT a hook (issue #598).
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: openbao-auto-unseal
   namespace: {{ .Release.Namespace | quote }}
-  annotations:
-    "helm.sh/hook": post-install,post-upgrade
-    "helm.sh/hook-weight": "0"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   labels:
     catalyst.openova.io/blueprint: bp-openbao
 roleRef:


### PR DESCRIPTION
## Summary

- **Bug A — bp-keycloak@1.2.2**: HTTPRoute `backendService` default was `<release>-keycloak` which produced `keycloak-keycloak` with `releaseName: keycloak`. Bitnami's fullname helper trims the chart-name suffix when `Release.Name` already contains it, so the actual Service is `keycloak`. Changed default to `.Release.Name`. Root cause confirmed on otech22: Gateway showed `BackendNotFound` for `keycloak-keycloak`, all requests to `auth.otech22.omani.works` returned HTTP 500. The sovereign realm was already correctly imported by config-cli — only routing was broken.

- **Bug B — bp-openbao@1.2.6**: `auto-unseal-rbac.yaml` SA/Role/RoleBinding had `helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded`. The `hook-succeeded` clause caused Helm to delete the SA immediately after the weight-0 RBAC hook completed. The weight-5 init Job pod then could not mount its SA token and failed silently. Removed all hook annotations from RBAC resources — they are now regular Helm-managed resources created before hooks run and never deleted mid-install.

Bootstrap-kit refs bumped: bp-keycloak `1.2.0→1.2.2`, bp-openbao `1.2.4→1.2.6`.

## Test plan

- [ ] bp-keycloak chart CI builds and publishes 1.2.2 to GHCR
- [ ] bp-openbao chart CI builds and publishes 1.2.6 to GHCR
- [ ] Flux picks up new versions on next Sovereign provisioning
- [ ] `curl -sk https://auth.<sovereign-fqdn>/realms/sovereign/.well-known/openid-configuration` returns JSON with correct issuer
- [ ] `bao status` on openbao-0 reports `Initialized=true Sealed=false`

## Verified on otech22 (manual remediation applied in same session)

- `curl -sk https://auth.otech22.omani.works/realms/sovereign/.well-known/openid-configuration` → `issuer: https://auth.otech22.omani.works/realms/sovereign`
- `kubectl -n openbao exec openbao-0 -c openbao -- bao status` → `Initialized: true, Sealed: false`
- openbao-0: `1/1 Running`

Closes #598

🤖 Generated with [Claude Code](https://claude.com/claude-code)