### PR TITLE
fix(bp-harbor): drop data block — Helm overwrite regression (1.2.7)

### DIFF
--- a/clusters/_template/bootstrap-kit/19-harbor.yaml
+++ b/clusters/_template/bootstrap-kit/19-harbor.yaml
@@ -84,7 +84,7 @@ spec:
   chart:
     spec:
       chart: bp-harbor
-      version: 1.2.6
+      version: 1.2.7
       sourceRef:
         kind: HelmRepository
         name: bp-harbor

--- a/clusters/omantel.omani.works/bootstrap-kit/19-harbor.yaml
+++ b/clusters/omantel.omani.works/bootstrap-kit/19-harbor.yaml
@@ -81,7 +81,7 @@ spec:
   chart:
     spec:
       chart: bp-harbor
-      version: 1.2.6
+      version: 1.2.7
       sourceRef:
         kind: HelmRepository
         name: bp-harbor

--- a/clusters/otech.omani.works/bootstrap-kit/19-harbor.yaml
+++ b/clusters/otech.omani.works/bootstrap-kit/19-harbor.yaml
@@ -81,7 +81,7 @@ spec:
   chart:
     spec:
       chart: bp-harbor
-      version: 1.2.6
+      version: 1.2.7
       sourceRef:
         kind: HelmRepository
         name: bp-harbor

--- a/platform/harbor/chart/Chart.yaml
+++ b/platform/harbor/chart/Chart.yaml
@@ -38,7 +38,7 @@ description: |
   this Blueprint hard-depends on bp-cnpg + bp-cert-manager. The
   earlier dependency on bp-seaweedfs is REMOVED (cloud-direct S3 path).
 type: application
-version: 1.2.6
+version: 1.2.7
 appVersion: "2.14.3"
 keywords: [catalyst, blueprint, harbor, oci, registry, container]
 maintainers:

--- a/platform/harbor/chart/templates/database-secret.yaml
+++ b/platform/harbor/chart/templates/database-secret.yaml
@@ -24,6 +24,15 @@ on every reconciliation pass. Once the source carries
 from the secret on the next CrashLoop retry — typically within seconds
 of Reflector firing.
 
+CRITICAL — no `data:` block: Helm three-way merge will overwrite ANY
+key declared in this template on every `helm upgrade`. If we declare
+`data: { password: "", HARBOR_DATABASE_PASSWORD: "" }` here, every Flux
+chart upgrade will reset those two keys to empty AFTER Reflector has
+populated them — harbor-core then crashes again on the next pod restart.
+By omitting `data:` entirely, the Secret is created with no keys owned
+by Helm; Reflector adds (and owns) all keys; Helm's three-way merge has
+nothing to overwrite on subsequent upgrades.
+
 Why not Helm `lookup`?
   Helm `lookup` is evaluated only during `helm install` / `helm upgrade`
   template rendering. On a fresh Sovereign, CNPG bootstraps the Cluster AFTER
@@ -57,13 +66,5 @@ metadata:
     # Secret is independently managed by reflector after initial creation).
     helm.sh/resource-policy: keep
 type: Opaque
-# Bootstrap empty data — reflector overwrites these within seconds of
-# harbor-pg-app being created by CNPG. The empty values prevent harbor-core
-# from getting into CreateContainerConfigError (secret missing) on the
-# initial render. It will still fail auth on the empty password but will
-# crash-loop until reflector propagates, which happens ~seconds after CNPG
-# reaches Ready — typically within the first bp-harbor upgrade remediation
-# cycle (retries: 3 per HelmRelease spec).
-data:
-  password: ""
-  HARBOR_DATABASE_PASSWORD: ""
+# NO `data:` block by design — see header comment. Reflector populates
+# all keys from harbor-pg-app on the first SecretWatcher event.


### PR DESCRIPTION
## Summary

- Drops `data:` block from `templates/database-secret.yaml` so Helm three-way merge doesn't overwrite Reflector-populated keys on every chart upgrade
- Bumps bp-harbor 1.2.6 → 1.2.7
- Bumps bootstrap-kit refs for `_template`, `otech.omani.works`, `omantel.omani.works`

## Regression observed

On otech22 after Flux upgraded bp-harbor from 1.2.5 to 1.2.6:
- `harbor-database-secret.password` was reset from 64 bytes back to 0 bytes
- `harbor-core` entered CrashLoopBackOff with "password authentication failed for user harbor"

Root cause: chart template declared `data: { password: "", HARBOR_DATABASE_PASSWORD: "" }`. Helm's three-way merge on every upgrade resets those keys to empty AFTER Reflector populated them from `harbor-pg-app`.

## Architectural fix

Omit the `data:` block entirely. Helm creates the Secret with no data keys; Reflector populates all keys from `harbor-pg-app` (password, HARBOR_DATABASE_PASSWORD, username, host, dbname, etc.) on the first SecretWatcher event. Helm's subsequent three-way merges have nothing to overwrite in `data:` because the chart owns no keys there.

## Test plan

- [ ] Blueprint-release CI publishes bp-harbor:1.2.7 to GHCR
- [ ] Flux reconciles bp-harbor on otech22 to 1.2.7
- [ ] After upgrade, `harbor-database-secret` retains all keys populated by Reflector (no reset to empty)
- [ ] `harbor-core` and `harbor-jobservice` show `1/1 Running`
- [ ] Subsequent helm upgrade does not regress the secret

Closes #585 (regression of)

🤖 Generated with [Claude Code](https://claude.com/claude-code)