### PR TITLE
fix(bp-harbor): convert harbor-database-secret to Helm pre-install hook (1.2.8)

### DIFF
--- a/clusters/_template/bootstrap-kit/19-harbor.yaml
+++ b/clusters/_template/bootstrap-kit/19-harbor.yaml
@@ -84,7 +84,7 @@ spec:
   chart:
     spec:
       chart: bp-harbor
-      version: 1.2.7
+      version: 1.2.8
       sourceRef:
         kind: HelmRepository
         name: bp-harbor

--- a/clusters/omantel.omani.works/bootstrap-kit/19-harbor.yaml
+++ b/clusters/omantel.omani.works/bootstrap-kit/19-harbor.yaml
@@ -81,7 +81,7 @@ spec:
   chart:
     spec:
       chart: bp-harbor
-      version: 1.2.7
+      version: 1.2.8
       sourceRef:
         kind: HelmRepository
         name: bp-harbor

--- a/clusters/otech.omani.works/bootstrap-kit/19-harbor.yaml
+++ b/clusters/otech.omani.works/bootstrap-kit/19-harbor.yaml
@@ -81,7 +81,7 @@ spec:
   chart:
     spec:
       chart: bp-harbor
-      version: 1.2.7
+      version: 1.2.8
       sourceRef:
         kind: HelmRepository
         name: bp-harbor

--- a/platform/harbor/chart/Chart.yaml
+++ b/platform/harbor/chart/Chart.yaml
@@ -38,7 +38,7 @@ description: |
   this Blueprint hard-depends on bp-cnpg + bp-cert-manager. The
   earlier dependency on bp-seaweedfs is REMOVED (cloud-direct S3 path).
 type: application
-version: 1.2.7
+version: 1.2.8
 appVersion: "2.14.3"
 keywords: [catalyst, blueprint, harbor, oci, registry, container]
 maintainers:

--- a/platform/harbor/chart/templates/database-secret.yaml
+++ b/platform/harbor/chart/templates/database-secret.yaml
@@ -24,14 +24,23 @@ on every reconciliation pass. Once the source carries
 from the secret on the next CrashLoop retry — typically within seconds
 of Reflector firing.
 
-CRITICAL — no `data:` block: Helm three-way merge will overwrite ANY
-key declared in this template on every `helm upgrade`. If we declare
-`data: { password: "", HARBOR_DATABASE_PASSWORD: "" }` here, every Flux
-chart upgrade will reset those two keys to empty AFTER Reflector has
-populated them — harbor-core then crashes again on the next pod restart.
-By omitting `data:` entirely, the Secret is created with no keys owned
-by Helm; Reflector adds (and owns) all keys; Helm's three-way merge has
-nothing to overwrite on subsequent upgrades.
+CRITICAL — Helm pre-install hook (NOT a normal release resource):
+  - `helm.sh/hook: pre-install` — Helm creates this Secret ONLY at
+    install time. On `helm upgrade`, Helm does NOT touch the Secret at
+    all (no three-way merge), so the keys Reflector populates persist
+    across every chart version bump.
+  - `helm.sh/hook-delete-policy: before-hook-creation` — On a re-install
+    (e.g. after `helm uninstall` followed by `helm install`), Helm
+    deletes the previous Secret first so the hook recreates a clean one.
+    With `resource-policy: keep` below, `helm uninstall` does NOT delete
+    the Secret, so the standard upgrade path never sees a delete.
+  - Hook resources are NOT recorded in the Helm release manifest, so
+    they're invisible to `helm upgrade`'s three-way merge.
+
+Earlier attempts (1.2.5–1.2.7) tried `data: { password: "", ... }` and
+then dropped the `data:` block entirely, but Helm still owns the Secret
+under upgrade and resets its `data:` to nil on every chart bump.
+The hook approach removes Helm's ownership entirely after install.
 
 Why not Helm `lookup`?
   Helm `lookup` is evaluated only during `helm install` / `helm upgrade`
@@ -56,6 +65,12 @@ metadata:
   labels:
     {{- include "bp-harbor.labels" . | nindent 4 }}
   annotations:
+    # Helm pre-install hook — Secret is created at install time only.
+    # On `helm upgrade`, Helm does not touch this Secret at all, so
+    # keys populated by Reflector persist across chart upgrades.
+    "helm.sh/hook": "pre-install"
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": "before-hook-creation"
     # Reflector (bp-reflector) copies all keys from harbor-pg-app into this
     # Secret. Harbor upstream reads HARBOR_DATABASE_PASSWORD; CNPG ships
     # `password`. Both land in the Secret via the copy, and Harbor's env
@@ -66,5 +81,7 @@ metadata:
     # Secret is independently managed by reflector after initial creation).
     helm.sh/resource-policy: keep
 type: Opaque
-# NO `data:` block by design — see header comment. Reflector populates
-# all keys from harbor-pg-app on the first SecretWatcher event.
+# NO `data:` block by design — Reflector populates all keys from
+# harbor-pg-app on the first SecretWatcher event after CNPG bootstraps
+# the source. Helm doesn't track this Secret on upgrade (pre-install
+# hook), so subsequent chart upgrades cannot overwrite the data.


### PR DESCRIPTION
## Summary

- Converts `harbor-database-secret` from a release resource to a Helm `pre-install` hook
- Hook resources are not tracked by Helm's three-way merge on upgrade — Reflector-populated keys persist across all subsequent chart bumps
- Bumps bp-harbor 1.2.7 → 1.2.8

## Why 1.2.7 wasn't enough

Even with the `data:` block dropped from the chart template, Helm's three-way merge still owns the Secret as a release resource and resets `data: {}` (or removes the field entirely) on every `helm upgrade`. Verified on otech22: the 1.2.6→1.2.7 reconcile wiped Reflector-populated keys back to nil, harbor-core entered CrashLoopBackOff again.

## How the hook approach fixes it

| Helm Phase | Behavior with hook |
|---|---|
| `helm install` | Secret created (empty) by hook → Reflector populates keys → harbor-core boots |
| `helm upgrade` | Hook NOT re-triggered (no `pre-upgrade`) → Helm three-way merge does NOT see the Secret → Reflector data preserved |
| `helm uninstall` | `resource-policy: keep` → Secret survives |
| Re-`helm install` | `before-hook-creation` deletes leftover Secret first → fresh creation → Reflector re-populates |

## Test plan

- [ ] Blueprint-release CI publishes bp-harbor:1.2.8 to GHCR
- [ ] Flux reconciles bp-harbor on otech22 to 1.2.8
- [ ] After upgrade, `harbor-database-secret.password` retains 64 bytes (not wiped)
- [ ] `harbor-core` and `harbor-jobservice` show `1/1 Running`
- [ ] Manual subsequent flux reconcile does NOT reset the secret data

Closes #585

🤖 Generated with [Claude Code](https://claude.com/claude-code)