### PR TITLE
fix(catalyst): restore literal image refs in Kustomize-path deployment YAMLs (#608)

### DIFF
--- a/.github/workflows/catalyst-build.yaml
+++ b/.github/workflows/catalyst-build.yaml
@@ -296,14 +296,23 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Update SHA tags in values.yaml
-        # The catalyst-ui and catalyst-api images are referenced via Helm
-        # template expressions (e.g. `{{ .Values.images.catalystUi.tag }}`).
-        # sed targeting the template YAML files silently no-ops because the
-        # pattern `image: ghcr.io/.../catalyst-ui:.*` never matches. The
-        # canonical update point is images.catalystUi.tag / images.catalystApi.tag
-        # in products/catalyst/chart/values.yaml. We use awk to replace the
-        # `tag:` line that immediately follows the catalystUi/catalystApi key.
+      - name: Update SHA tags in values.yaml and deployment manifests
+        # The catalyst-ui and catalyst-api images are referenced in two places:
+        #
+        # 1. products/catalyst/chart/values.yaml — used by the Helm chart path
+        #    (bp-catalyst-platform OCI chart on Sovereign clusters). Helm template
+        #    expressions ({{ .Values.images.catalystUi.tag }}) are rendered at
+        #    `helm install` time by Flux's helm-controller. We use awk to replace
+        #    the `tag:` line that immediately follows the catalystUi/catalystApi key.
+        #
+        # 2. products/catalyst/chart/templates/{api,ui}-deployment.yaml — used by
+        #    the Kustomize path (catalyst-platform Kustomization on contabo-mkt).
+        #    These files are applied as raw manifests by Flux kustomize-controller;
+        #    Helm template syntax is NOT rendered. A literal image ref is required.
+        #    Bug history: feat/global-imageRegistry (#580) converted the literal
+        #    image ref to a Helm template without updating this deploy step, causing
+        #    InvalidImageName on the contabo-mkt Kustomize path. Fixed here by also
+        #    sed-patching the literal image refs in those two deployment files.
         env:
           SHA_SHORT: ${{ needs.build-ui.outputs.sha_short }}
         run: |
@@ -318,13 +327,26 @@ jobs:
           echo "values.yaml after update:"
           grep -A2 "catalystUi\|catalystApi" "${VALUES}" | head -10
 
+          # Also patch the literal image refs in the Kustomize-path deployment
+          # manifests so Flux kustomize-controller uses a valid image reference.
+          API_DEP="products/catalyst/chart/templates/api-deployment.yaml"
+          UI_DEP="products/catalyst/chart/templates/ui-deployment.yaml"
+          sed -i "s|ghcr\.io/openova-io/openova/catalyst-api:[a-z0-9]*\"|ghcr.io/openova-io/openova/catalyst-api:${SHA_SHORT}\"|" "${API_DEP}"
+          sed -i "s|ghcr\.io/openova-io/openova/catalyst-ui:[a-z0-9]*\"|ghcr.io/openova-io/openova/catalyst-ui:${SHA_SHORT}\"|" "${UI_DEP}"
+          echo "api-deployment.yaml image after update:"
+          grep "image:" "${API_DEP}"
+          echo "ui-deployment.yaml image after update:"
+          grep "image:" "${UI_DEP}"
+
       - name: Commit and push manifest updates
         env:
           SHA_SHORT: ${{ needs.build-ui.outputs.sha_short }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add products/catalyst/chart/values.yaml
+          git add products/catalyst/chart/values.yaml \
+                  products/catalyst/chart/templates/api-deployment.yaml \
+                  products/catalyst/chart/templates/ui-deployment.yaml
           git diff --staged --quiet && echo "No changes to commit" && exit 0
           git commit -m "deploy: update catalyst images to ${SHA_SHORT}"
           git push

--- a/products/catalyst/chart/templates/api-deployment.yaml
+++ b/products/catalyst/chart/templates/api-deployment.yaml
@@ -128,7 +128,7 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       containers:
         - name: catalyst-api
-          image: "{{ if .Values.global.imageRegistry }}{{ .Values.global.imageRegistry }}{{ else }}{{ .Values.images.registry }}{{ end }}/{{ .Values.images.organization }}/catalyst-api:{{ .Values.images.catalystApi.tag }}"
+          image: "ghcr.io/openova-io/openova/catalyst-api:b50a600"
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080

--- a/products/catalyst/chart/templates/ui-deployment.yaml
+++ b/products/catalyst/chart/templates/ui-deployment.yaml
@@ -19,7 +19,7 @@ spec:
         - name: ghcr-pull
       containers:
         - name: catalyst-ui
-          image: "{{ if .Values.global.imageRegistry }}{{ .Values.global.imageRegistry }}{{ else }}{{ .Values.images.registry }}{{ end }}/{{ .Values.images.organization }}/catalyst-ui:{{ .Values.images.catalystUi.tag }}"
+          image: "ghcr.io/openova-io/openova/catalyst-ui:b50a600"
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080


### PR DESCRIPTION
## Summary

- **Root cause**: `feat/global-imageRegistry` (#580) converted literal image refs in `api-deployment.yaml` and `ui-deployment.yaml` to Helm template expressions (`{{ .Values.global.imageRegistry }}...`). The Flux `catalyst-platform` Kustomization reads these as raw manifests — Helm templates are **never rendered** here — so the Pod image became a literal `{{ if .Values... }}` string, causing `InvalidImageName` on every Pod start.
- **Fix**: Restore literal `ghcr.io/openova-io/openova/catalyst-{api,ui}:b50a600` in both deployment YAMLs (immediate unblock), and update the CI deploy step to `sed`-patch those literal refs on every deploy commit (durable, prevents recurrence).
- **Impact**: Unblocks issue #608 (Phase-8b Agent A magic-link auth). The `catalyst-api` Deployment has been `InvalidImageName` since commit `83ec889f`, so the Keycloak auth gate (`CATALYST_KC_ADDR` / session-cookie) has never loaded on contabo-mkt.

## Changed files

| File | Change |
|------|--------|
| `products/catalyst/chart/templates/api-deployment.yaml` | Literal image ref `ghcr.io/.../catalyst-api:b50a600` |
| `products/catalyst/chart/templates/ui-deployment.yaml` | Literal image ref `ghcr.io/.../catalyst-ui:b50a600` |
| `.github/workflows/catalyst-build.yaml` | Deploy step now also `sed`-patches the literal image refs + stages those files in the deploy commit |

## Test plan

- [ ] PR merges to main → CI workflow triggers → deploy commit updates both `values.yaml` AND `api-deployment.yaml`/`ui-deployment.yaml` with a new SHA
- [ ] Flux reconciles `catalyst-platform` Kustomization → `catalyst-api` Deployment reaches `Running` state
- [ ] `curl https://console.openova.io/sovereign/api/v1/whoami` → 401 (auth gate active, not 503 / panic)
- [ ] Cold-load `https://console.openova.io/sovereign` → redirects to `/sovereign/login` (wizardAuthGuard works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)