### PR TITLE
fix(catalyst-ui): add /assets + /component-logos ingress rules (fixes blank page on /sovereign)

### DIFF
--- a/products/catalyst/chart/templates/ingress.yaml
+++ b/products/catalyst/chart/templates/ingress.yaml
@@ -43,3 +43,51 @@ spec:
                 name: catalyst-ui
                 port:
                   number: 80
+---
+# Static asset routing for the Catalyst-Zero UI.
+#
+# With Vite base: '/' (issue #596/#599), the HTML at /sovereign/ references
+# assets as /assets/*.js — the browser requests console.openova.io/assets/*
+# directly (no /sovereign/ prefix). The strip-sovereign middleware on
+# console-sovereign only applies to /sovereign/* paths, so /assets/* would
+# fall through to the SME console's catch-all and return 404.
+#
+# This ingress routes /assets/* and /favicon.svg to catalyst-ui WITHOUT
+# stripping any prefix (no middleware), so nginx receives /assets/* directly.
+# Priority 90 (below console-sovereign at 100) ensures /sovereign/* is
+# handled first; /assets/* only reaches this rule when there is no /sovereign
+# prefix on the request — which is exactly the Vite static-asset case.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: console-sovereign-assets
+  namespace: catalyst
+  annotations:
+    traefik.ingress.kubernetes.io/router.priority: "90"
+spec:
+  ingressClassName: traefik
+  rules:
+    - host: console.openova.io
+      http:
+        paths:
+          - path: /assets
+            pathType: Prefix
+            backend:
+              service:
+                name: catalyst-ui
+                port:
+                  number: 80
+          - path: /favicon.svg
+            pathType: Exact
+            backend:
+              service:
+                name: catalyst-ui
+                port:
+                  number: 80
+          - path: /component-logos
+            pathType: Prefix
+            backend:
+              service:
+                name: catalyst-ui
+                port:
+                  number: 80


### PR DESCRIPTION
## Summary

- **Root cause**: With `Vite base: '/'` (issue #596/#599), the HTML at `/sovereign/` references static assets as `/assets/*.js`. The browser requests `console.openova.io/assets/*` without the `/sovereign/` prefix. The existing `console-sovereign` Ingress only matches `/sovereign/*` so `/assets/*` fell through to the SME console catch-all → 404 → blank page.
- **Fix**: Add a second Ingress `console-sovereign-assets` (priority 90) that routes `/assets/*`, `/component-logos/*`, and `/favicon.svg` directly to `catalyst-ui` without a strip-prefix middleware. nginx receives the exact path the browser sent.
- **Impact**: Fixes blank page at `https://console.openova.io/sovereign/` and unblocks UAT for issue #608 (magic-link auth login page).

## Test plan

- [ ] Flux reconciles `catalyst-platform` Kustomization → new `console-sovereign-assets` Ingress appears
- [ ] `curl https://console.openova.io/assets/index-*.js` → 200 with correct MIME type
- [ ] Cold-load `https://console.openova.io/sovereign` → page renders (no blank, no 404 console errors)
- [ ] Login page visible at `/sovereign/login`

🤖 Generated with [Claude Code](https://claude.com/claude-code)