### PR TITLE
fix(catalyst): runtime basepath + auth guard for Catalyst-Zero sovereign prefix (#618)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/auth.go
+++ b/products/catalyst/bootstrap/api/internal/handler/auth.go
@@ -14,6 +14,32 @@ import (
 
 const pkceVerifierCookieName = "catalyst_pkce_verifier"
 
+// postAuthRedirect returns the URL the browser is sent to after a successful
+// magic-link callback. Defaults to "/wizard"; can be overridden via
+// CATALYST_POST_AUTH_REDIRECT for deployments where the UI lives under a
+// path prefix (e.g. /sovereign/wizard on Catalyst-Zero / contabo-mkt).
+func postAuthRedirect() string {
+	if v := os.Getenv("CATALYST_POST_AUTH_REDIRECT"); v != "" {
+		return v
+	}
+	return "/wizard"
+}
+
+// loginRedirect returns the URL the browser is sent to on auth failure.
+// Derived from postAuthRedirect: replaces the last path component with "login"
+// so the prefix stays consistent.
+func loginRedirect(reason string) string {
+	base := postAuthRedirect()
+	// Strip the trailing component (e.g. /sovereign/wizard → /sovereign)
+	// and append /login?error=<reason>.
+	idx := strings.LastIndex(base, "/")
+	if idx < 0 {
+		return "/login?error=" + url.QueryEscape(reason)
+	}
+	prefix := base[:idx] // e.g. "" or "/sovereign"
+	return prefix + "/login?error=" + url.QueryEscape(reason)
+}
+
 // HandleMagicLink handles POST /api/v1/auth/magic-link.
 //
 // It accepts {"email":"<addr>"}, ensures the user exists in the Keycloak
@@ -138,14 +164,14 @@ func (h *Handler) HandleAuthCallback(w http.ResponseWriter, r *http.Request) {
 	accessToken, _, claims, err := cfg.ExchangeCode(r.Context(), code, verifier)
 	if err != nil {
 		h.log.Debug("auth callback: code exchange failed", "err", err)
-		http.Redirect(w, r, "/login?error=callback_failed", http.StatusSeeOther)
+		http.Redirect(w, r, loginRedirect("callback_failed"), http.StatusSeeOther)
 		return
 	}
 
 	cfg.IssueSessionCookie(w, accessToken)
 
 	_ = claims
-	http.Redirect(w, r, "/wizard", http.StatusSeeOther)
+	http.Redirect(w, r, postAuthRedirect(), http.StatusSeeOther)
 }
 
 // HandleAuthLogout handles DELETE /api/v1/auth/session.

--- a/products/catalyst/bootstrap/ui/src/app/router.tsx
+++ b/products/catalyst/bootstrap/ui/src/app/router.tsx
@@ -2,6 +2,39 @@ import { createRouter, createRoute, createRootRoute, redirect } from '@tanstack/
 import { IS_SAAS } from '@/shared/constants/env'
 import { API_BASE } from '@/shared/config/urls'
 
+/**
+ * Runtime basepath detection (issue #618).
+ *
+ * The same catalyst-ui image is deployed in two topologies:
+ *   1. Sovereign clusters — served at console.<sov-fqdn>/ (basepath '/')
+ *   2. Catalyst-Zero on contabo — served at console.openova.io/sovereign/*
+ *      with a Traefik strip-prefix middleware (browser URL keeps /sovereign/).
+ *
+ * Vite base is '/' so the nginx bundle is always rooted at '/'. But
+ * TanStack Router reads window.location.pathname, which still has the
+ * '/sovereign' prefix on contabo. We detect this at module-init time:
+ * if the current path starts with '/sovereign', tell the router the
+ * base is '/sovereign' so it strips the prefix before matching routes.
+ */
+const basepath =
+  typeof window !== 'undefined' && window.location.pathname.startsWith('/sovereign')
+    ? '/sovereign'
+    : '/'
+
+/**
+ * isCatalystZero — true when the UI is running on Catalyst-Zero
+ * (console.openova.io/sovereign/*). Used by wizardAuthGuard to decide
+ * whether to enforce session-cookie auth.
+ *
+ * We detect by hostname rather than IS_SAAS / IS_SELFHOSTED because the
+ * same selfhosted build image runs on both Catalyst-Zero (contabo-mkt)
+ * and tenant Sovereign consoles (console.<sov-fqdn>). Only Catalyst-Zero
+ * has Keycloak + the session middleware wired up; Sovereign clusters
+ * manage their own auth separately.
+ */
+const isCatalystZero =
+  typeof window !== 'undefined' && window.location.hostname === 'console.openova.io'
+
 // Lazy page imports
 import { RootLayout } from './layouts/RootLayout'
 import { AppLayout } from './layouts/AppLayout'
@@ -64,17 +97,12 @@ const dashboardRoute = createRoute({ getParentRoute: () => appRoute, path: '/das
  * backend restart doesn't lock the operator out of the wizard UI
  * during a deployment run.
  *
- * The guard is a no-op when CATALYST_KC_ADDR is not configured
- * (RequireSession is a transparent passthrough on the server side),
- * because /whoami will return 401 from the session check but the
- * session check itself is skipped — wait, in that case the middleware
- * passes through so /whoami returns the claims from context which are
- * nil, so HandleWhoami returns 401 anyway. To handle this: the guard
- * checks IS_SAAS — in SaaS (catalyst-zero) mode it enforces the guard;
- * in selfhosted (Sovereign) mode it is a no-op.
+ * The guard only fires on Catalyst-Zero (console.openova.io). Sovereign
+ * clusters do not have the session middleware wired and handle auth
+ * through their own Keycloak realm — the guard is a no-op there.
  */
 async function wizardAuthGuard() {
-  if (!IS_SAAS) return // Sovereign clusters handle auth themselves
+  if (!isCatalystZero) return // Sovereign clusters manage their own auth
   try {
     const res = await fetch(`${API_BASE}/v1/whoami`, {
       method: 'GET',
@@ -458,10 +486,10 @@ const routeTree = rootRoute.addChildren([
   marketplaceProductRoute,
 ])
 
-// basepath: '/' — Vite base is now '/' (issue #596). Both Sovereigns
-// (console.<sov>/) and contabo (console.openova.io/sovereign/* with
-// Traefik strip-prefix) resolve to root, so router and Vite must agree.
-export const router = createRouter({ routeTree, basepath: '/' })
+// basepath is resolved at runtime (see top of file).
+// Catalyst-Zero (contabo): '/sovereign' — browser URL has /sovereign prefix.
+// Sovereign clusters: '/' — served at the domain root.
+export const router = createRouter({ routeTree, basepath })
 
 declare module '@tanstack/react-router' {
   interface Register {

--- a/products/catalyst/bootstrap/ui/src/pages/auth/AuthCallbackPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/auth/AuthCallbackPage.tsx
@@ -3,6 +3,22 @@ import { useSearch } from '@tanstack/react-router'
 import { API_BASE } from '@/shared/config/urls'
 
 /**
+ * Derive the path-only UI base prefix for hard-navigation fallback.
+ *
+ * On contabo-mkt the browser URL has a '/sovereign' prefix (Traefik
+ * routes /sovereign/* → catalyst-ui but does NOT rewrite the Location
+ * header on client-side navigations). Error redirects must therefore go
+ * to '/sovereign/login' not '/login'.
+ *
+ * On Sovereign clusters the UI is served at the domain root (basepath '/')
+ * so the prefix is empty.
+ */
+function uiBase(): string {
+  if (typeof window === 'undefined') return ''
+  return window.location.pathname.startsWith('/sovereign') ? '/sovereign' : ''
+}
+
+/**
  * AuthCallbackPage — handles the Keycloak PKCE callback for Catalyst-Zero.
  *
  * Keycloak redirects to console.openova.io/sovereign/auth/callback?code=...
@@ -13,7 +29,7 @@ import { API_BASE } from '@/shared/config/urls'
  *   1. Read the PKCE verifier cookie (same-origin, carried automatically)
  *   2. Exchange the code for tokens
  *   3. Issue the HMAC-signed session cookie
- *   4. Redirect the browser to /wizard
+ *   4. Redirect the browser to /sovereign/wizard (or /wizard on Sovereign clusters)
  *
  * A hard navigation (window.location.replace) is required so the
  * browser's cookie jar picks up the Set-Cookie header from the server's
@@ -32,13 +48,13 @@ export function AuthCallbackPage() {
     if (error) {
       // Keycloak denied or the magic-link expired — redirect to login with
       // an error indicator so the UI can surface the right copy.
-      window.location.replace('/login?error=' + encodeURIComponent(error))
+      window.location.replace(uiBase() + '/login?error=' + encodeURIComponent(error))
       return
     }
 
     if (!code) {
       // No code and no error — unexpected. Redirect to login.
-      window.location.replace('/login?error=no_code')
+      window.location.replace(uiBase() + '/login?error=no_code')
       return
     }
 

--- a/products/catalyst/chart/templates/api-deployment.yaml
+++ b/products/catalyst/chart/templates/api-deployment.yaml
@@ -352,6 +352,14 @@ spec:
                   name: catalyst-magic-link-credentials
                   key: session-cookie-secret
                   optional: true
+            # CATALYST_POST_AUTH_REDIRECT — URL the browser is sent to after a
+            # successful magic-link callback. Defaults to /wizard in code; set
+            # to /sovereign/wizard here because Catalyst-Zero routes the UI
+            # under the /sovereign prefix and the Traefik strip-prefix middleware
+            # is transparent to the server-side Location header.
+            # Per INVIOLABLE-PRINCIPLES #4: runtime configuration, not hardcoded.
+            - name: CATALYST_POST_AUTH_REDIRECT
+              value: /sovereign/wizard
             # CATALYST_KC_ADMIN_USER / CATALYST_KC_ADMIN_PASS — Keycloak master
             # realm admin credentials used by HandleMagicLink to call the Admin
             # REST API (create user, execute-actions-email). On Catalyst-Zero the


### PR DESCRIPTION
## Problem

Three related bugs blocking `console.openova.io/sovereign/` from working:

1. **TanStack Router "Not Found"** — `basepath: '/'` hardcoded, but browser URL has `/sovereign/` prefix on contabo-mkt. Router sees `/sovereign/login` with no matching route.

2. **wizardAuthGuard no-op** — guard checked `IS_SAAS` to decide whether to enforce session auth. The selfhosted build sets `IS_SAAS=false` for *both* Catalyst-Zero and Sovereign clusters, so the guard was always skipped on contabo-mkt.

3. **Post-auth redirect 404** — Go handler `HandleAuthCallback` redirected to `/wizard` after issuing session cookie. Traefik's strip-prefix middleware is transparent to server `Location` headers, so browser was sent to `console.openova.io/wizard` (404) instead of `console.openova.io/sovereign/wizard`.

## Fix

- **`router.tsx`**: derive `basepath` at module-init from `window.location.pathname`. `/sovereign` prefix → `basepath='/sovereign'`; otherwise `basepath='/'`.
- **`router.tsx`**: replace `IS_SAAS` gate in `wizardAuthGuard` with hostname check (`window.location.hostname === 'console.openova.io'`). Fires on Catalyst-Zero, no-op on Sovereign clusters.
- **`AuthCallbackPage.tsx`**: error fallback redirects prepend `uiBase()` (`/sovereign` on contabo-mkt, `''` on Sovereign clusters).
- **`auth.go`**: `CATALYST_POST_AUTH_REDIRECT` env var (default `/wizard`) for the browser redirect target after callback. `loginRedirect()` derives the error URL from the same base.
- **`api-deployment.yaml`**: set `CATALYST_POST_AUTH_REDIRECT=/sovereign/wizard` for the Kustomize/contabo path.

## Test plan
- [ ] CI build green
- [ ] `console.openova.io/sovereign/` loads login page (not "Not Found")
- [ ] `console.openova.io/sovereign/wizard` → redirects to `/sovereign/login` (auth guard active)
- [ ] Submit email on `/sovereign/login` → 200 `{"ok":true}` from magic-link endpoint
- [ ] Magic-link click → lands on `/sovereign/wizard` authenticated

🤖 Generated with [Claude Code](https://claude.com/claude-code)