### PR TITLE
fix(catalyst-ui): use isRedirect() to re-throw auth guard redirect (#620)

### DIFF
--- a/products/catalyst/bootstrap/ui/src/app/router.tsx
+++ b/products/catalyst/bootstrap/ui/src/app/router.tsx
@@ -1,4 +1,4 @@
-import { createRouter, createRoute, createRootRoute, redirect } from '@tanstack/react-router'
+import { createRouter, createRoute, createRootRoute, redirect, isRedirect } from '@tanstack/react-router'
 import { IS_SAAS } from '@/shared/constants/env'
 import { API_BASE } from '@/shared/config/urls'
 
@@ -114,9 +114,12 @@ async function wizardAuthGuard() {
     }
     // Any other status (200, 5xx) — allow through.
   } catch (err) {
-    // Re-throw TanStack redirect errors; swallow network/5xx so the
+    // Re-throw TanStack redirect Responses; swallow network/5xx so the
     // wizard remains usable during backend transients.
-    if (err && typeof err === 'object' && 'isRedirect' in err) throw err
+    // TanStack Router redirect() returns a Response with opts attached —
+    // use the isRedirect() helper rather than an 'isRedirect' property check
+    // (the property does not exist on the Response object).
+    if (isRedirect(err)) throw err
   }
 }
 


### PR DESCRIPTION
## Root Cause

`wizardAuthGuard` catch block used:
```javascript
if (err && typeof err === 'object' && 'isRedirect' in err) throw err
```

TanStack Router v1.x `redirect()` returns a `Response` object with an `options` property attached. It does NOT have an `'isRedirect'` own property. So `'isRedirect' in err` was always `false`, and the catch block silently swallowed the redirect throw.

Result: guard called `whoami`, got 401, threw `redirect({ to: '/login' })`, catch block swallowed it, wizard rendered for unauthenticated users.

## Fix

Import and use the `isRedirect()` helper from `@tanstack/react-router` which correctly checks `obj instanceof Response && !!obj.options`.

## Test plan
- [ ] CI green
- [ ] Direct navigation to `console.openova.io/sovereign/wizard` without session → browser redirects to `/sovereign/login`
- [ ] Login page renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)