### PR TITLE
fix(catalyst-api): update CORS_ORIGIN to console.openova.io (#621)

### DIFF
--- a/products/catalyst/chart/templates/api-deployment.yaml
+++ b/products/catalyst/chart/templates/api-deployment.yaml
@@ -136,8 +136,13 @@ spec:
           env:
             - name: PORT
               value: "8080"
+            # CORS_ORIGIN — browser origin allowed to call the API.
+            # Catalyst-Zero (contabo-mkt Kustomize path): console.openova.io
+            # Sovereign clusters (Helm path): console.<sov-fqdn> (set via values.yaml)
+            # The catalyst-ui browser is always served from the same hostname as
+            # the API ingress, so this value equals the console hostname.
             - name: CORS_ORIGIN
-              value: "https://catalyst.openova.io"
+              value: "https://console.openova.io"
             - name: DYNADOT_API_KEY
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
## Problem

`CORS_ORIGIN=https://catalyst.openova.io` is a legacy hostname not used by the catalyst-ui. Browser requests from `https://console.openova.io/sovereign/` triggered CORS preflight (OPTIONS), which returned 405. This caused `wizardAuthGuard`'s `fetch` to `/sovereign/api/v1/whoami` to raise a network error (not a 401 response). The catch block swallows network errors by design (backend transient tolerance), so unauthenticated users could access `/sovereign/wizard`.

## Fix

Set `CORS_ORIGIN=https://console.openova.io` — the correct browser origin for Catalyst-Zero on contabo-mkt.

## Test plan
- [ ] CI green
- [ ] Direct navigation to `console.openova.io/sovereign/wizard` → redirects to `/sovereign/login`

🤖 Generated with [Claude Code](https://claude.com/claude-code)