### PR TITLE
fix(catalyst-api): include username in Keycloak user creation (#622)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/auth.go
+++ b/products/catalyst/bootstrap/api/internal/handler/auth.go
@@ -276,9 +276,10 @@ func ensureUser(cfg *auth.Config, adminToken, email string) (string, error) {
 		return users[0].ID, nil
 	}
 
-	// Create the user.
+	// Create the user. Keycloak 24+ requires "username" — use the email
+	// address as the username (standard for email-first/passwordless flows).
 	createURL := cfg.KeycloakAddr + "/admin/realms/" + cfg.Realm + "/users"
-	payload := fmt.Sprintf(`{"email":%q,"enabled":true,"emailVerified":false}`, email)
+	payload := fmt.Sprintf(`{"email":%q,"username":%q,"enabled":true,"emailVerified":false}`, email, email)
 	req2, _ := http.NewRequest(http.MethodPost, createURL, strings.NewReader(payload))
 	req2.Header.Set("Authorization", "Bearer "+adminToken)
 	req2.Header.Set("Content-Type", "application/json")


### PR DESCRIPTION
## Problem

`ensureUser` created new users with `{"email":"...","enabled":true,"emailVerified":false}` but Keycloak 24+ requires the `username` field. This caused:

```
magic-link: ensureUser failed","err":"ensureUser create: status 400 body {\"errorMessage\":\"User name is missing\"}"
```

## Fix

Use the email address as the `username` value — standard pattern for passwordless/email-first flows where there is no separate username concept.

## Test plan
- [ ] CI green
- [ ] POST `/sovereign/api/v1/auth/magic-link` with email → 200 `{"ok":true}`
- [ ] Email received with sign-in link

🤖 Generated with [Claude Code](https://claude.com/claude-code)