### PR TITLE
fix(infra): restore handover-jwt-public.jwk cloud-init write + variables.tf

### DIFF
--- a/infra/hetzner/cloudinit-control-plane.tftpl
+++ b/infra/hetzner/cloudinit-control-plane.tftpl
@@ -354,6 +354,22 @@ write_files:
             name: cloud-credentials
             key: hcloud-token
 
+  # ── Handover JWT public key (issue #605, Phase-8b) ───────────────────
+  #
+  # RFC 7517 JWK JSON of the Catalyst-Zero RS256 public key. Written to
+  # /var/lib/catalyst/handover-jwt-public.jwk (mode 0600) on the new
+  # Sovereign control-plane. Agent-C (auth/handover) reads this file to
+  # verify the one-time handover JWT without a cross-cluster RPC.
+  #
+  # Per INVIOLABLE-PRINCIPLES.md #10 (credential hygiene): mode 0600 so
+  # the file is readable only by root. Even though RSA public keys are
+  # technically non-secret, tightening the permission costs nothing and
+  # avoids any future confusion about sensitivity.
+  - path: /var/lib/catalyst/handover-jwt-public.jwk
+    permissions: '0600'
+    content: |
+      ${handover_jwt_public_key}
+
   # ── Cilium bootstrap values (issue #491) ─────────────────────────────
   #
   # The bootstrap helm install below MUST land the same effective values

--- a/infra/hetzner/variables.tf
+++ b/infra/hetzner/variables.tf
@@ -535,3 +535,33 @@ variable "object_storage_bucket_name" {
     error_message = "Object Storage bucket name must be 3-63 chars, lowercase alphanumeric + hyphens, starting and ending with alphanumeric (RFC-compliant S3 bucket naming)."
   }
 }
+
+# ── Handover JWT public key (issue #605, Phase-8b) ────────────────────────
+#
+# RFC 7517 JWK JSON bytes of the Catalyst-Zero RS256 public key. Written to
+# /var/lib/catalyst/handover-jwt-public.jwk (mode 0600) on the new Sovereign
+# control-plane by cloud-init. The Sovereign-side Agent-C (auth_handover.go)
+# reads this file to verify the one-time handover JWT without a cross-cluster
+# RPC to Catalyst-Zero.
+#
+# Source: the catalyst-api provisioner reads the live Signer's PublicJWK()
+# and stamps it onto provisioner.Request.HandoverJWTPublicKey before writing
+# tofu.auto.tfvars.json. The field carries json:"-" so the wizard POST body
+# can never inject it — it always comes from the live Signer.
+#
+# Default empty: pre-#605 provisioner builds that do not pass this variable
+# write an empty file; auth/handover returns 503 (key unavailable) on any
+# Sovereign provisioned without it until a subsequent reprovisioning run.
+variable "handover_jwt_public_key" {
+  type        = string
+  description = <<-EOT
+    RFC 7517 JWK JSON of the Catalyst-Zero RS256 handover-JWT public key.
+    Written to /var/lib/catalyst/handover-jwt-public.jwk (mode 0600) on
+    the new Sovereign control-plane by cloud-init so Agent-C can verify
+    the one-time JWT without a cross-cluster network call to Catalyst-Zero.
+    Supplied by the catalyst-api provisioner from h.handoverSigner.PublicJWK().
+    Empty when the provisioner has no signer (CATALYST_HANDOVER_KEY_PATH unset).
+  EOT
+  sensitive = true
+  default   = ""
+}


### PR DESCRIPTION
## Summary

PR #611's squash commit accidentally reverted the Phase-8b infra additions from PR #615 (92fdda42):

- `infra/hetzner/cloudinit-control-plane.tftpl`: restores the `write_files` entry that writes `/var/lib/catalyst/handover-jwt-public.jwk` (mode 0600) to new Sovereign control-planes at provision time
- `infra/hetzner/variables.tf`: restores the `handover_jwt_public_key` variable (sensitive, default empty)

Without these, new Sovereign provisioning runs will not write the public key to disk and `auth/handover` on the Sovereign will return 503 (key unavailable).

## Root cause

When PR #611 was squash-merged, the squash commit was built from `diff(origin/main after #615, feat/607 branch)`. The feat/607 branch did not include the infra changes from PR #615 (Agent B's work was separate from Agent D's UI work). The diff therefore showed -16 lines for cloudinit and reverted the JWT infrastructure.

## Test plan

- [ ] Infra diff is clean: `git show HEAD -- infra/hetzner/` shows only additions
- [ ] No other regressions introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)