### PR TITLE
fix(catalyst-ui): re-import isRedirect — auth guard silently swallows redirects (#624)

### DIFF
--- a/products/catalyst/bootstrap/ui/src/app/router.tsx
+++ b/products/catalyst/bootstrap/ui/src/app/router.tsx
@@ -1,4 +1,4 @@
-import { createRouter, createRoute, createRootRoute, redirect } from '@tanstack/react-router'
+import { createRouter, createRoute, createRootRoute, redirect, isRedirect } from '@tanstack/react-router'
 import { IS_SAAS } from '@/shared/constants/env'
 import { API_BASE } from '@/shared/config/urls'
 import { DETECTED_MODE } from '@/shared/lib/detectMode'
@@ -177,7 +177,7 @@ async function wizardAuthGuard() {
   } catch (err) {
     // Re-throw TanStack redirect errors; swallow network/5xx so the
     // wizard remains usable during backend transients.
-    if (err && typeof err === 'object' && 'isRedirect' in err) throw err
+    if (isRedirect(err)) throw err
   }
 }
 


### PR DESCRIPTION
## Root Cause

PR #611 squash-merged `router.tsx` without the `isRedirect` import that was added in #620. The result: `wizardAuthGuard` catches the redirect thrown on 401 and silently swallows it — unauthenticated users reach `/wizard`.

TanStack Router's `redirect()` returns a `Response` with `.options` set. The check:
```ts
if (err && typeof err === 'object' && 'isRedirect' in err) throw err
```
is always `false` because `Response` has no `isRedirect` property. The correct check uses the exported `isRedirect()` helper which tests `err instanceof Response && !!err.options`.

## Fix

```ts
// Before (broken):
import { createRouter, createRoute, createRootRoute, redirect } from '@tanstack/react-router'
// ...
if (err && typeof err === 'object' && 'isRedirect' in err) throw err

// After (correct):
import { createRouter, createRoute, createRootRoute, redirect, isRedirect } from '@tanstack/react-router'
// ...
if (isRedirect(err)) throw err
```

## Evidence

Playwright E2E confirms: before this fix, navigating to `/sovereign/wizard` without a session cookie renders the wizard (401 on whoami but guard doesn't redirect). After this fix, the 401 triggers `throw redirect({to:'/login'})` which is correctly re-thrown and handled by TanStack Router, redirecting to `/sovereign/login`.

Closes #624