### PR TITLE
fix(catalyst-api): CORS_ORIGIN revert after PR #611 squash-merge (#625)

### DIFF
--- a/products/catalyst/chart/templates/api-deployment.yaml
+++ b/products/catalyst/chart/templates/api-deployment.yaml
@@ -137,7 +137,7 @@ spec:
             - name: PORT
               value: "8080"
             - name: CORS_ORIGIN
-              value: "https://catalyst.openova.io"
+              value: "https://console.openova.io"
             - name: DYNADOT_API_KEY
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
## Problem

PR #611 squash-merged `api-deployment.yaml` without the CORS_ORIGIN fix from #621, reverting it from `https://console.openova.io` back to `https://catalyst.openova.io`.

With the wrong origin the browser OPTIONS preflight from `console.openova.io` gets a 405 from catalyst-api. All `fetch()` calls from the login page throw network errors that the catch block silently swallows — the effect is that the magic-link POST never reaches the server.

## Fix

Set `CORS_ORIGIN` back to `https://console.openova.io` in `api-deployment.yaml`.

Closes #625 (regression of #621)