### PR TITLE
fix(catalyst-api): include username in magic-link Keycloak user creation

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/auth.go
+++ b/products/catalyst/bootstrap/api/internal/handler/auth.go
@@ -276,9 +276,10 @@ func ensureUser(cfg *auth.Config, adminToken, email string) (string, error) {
 		return users[0].ID, nil
 	}
 
-	// Create the user.
+	// Create the user. Keycloak 24.7+ requires "username" — use the email
+	// as the username for email-only magic-link login UX.
 	createURL := cfg.KeycloakAddr + "/admin/realms/" + cfg.Realm + "/users"
-	payload := fmt.Sprintf(`{"email":%q,"enabled":true,"emailVerified":false}`, email)
+	payload := fmt.Sprintf(`{"username":%q,"email":%q,"enabled":true,"emailVerified":false}`, email, email)
 	req2, _ := http.NewRequest(http.MethodPost, createURL, strings.NewReader(payload))
 	req2.Header.Set("Authorization", "Bearer "+adminToken)
 	req2.Header.Set("Content-Type", "application/json")

--- a/products/catalyst/chart/templates/api-deployment.yaml
+++ b/products/catalyst/chart/templates/api-deployment.yaml
@@ -137,7 +137,7 @@ spec:
             - name: PORT
               value: "8080"
             - name: CORS_ORIGIN
-              value: "https://catalyst.openova.io"
+              value: "https://console.openova.io"
             - name: DYNADOT_API_KEY
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
Mirrors PR #622 for the openova-side magic-link flow. Resolves 'user provisioning failed' on console.openova.io/sovereign/login.