### PR TITLE
fix(catalyst-api): magic-link URL must include /api/v1 prefix

### DIFF
--- a/products/catalyst/bootstrap/api/cmd/api/main.go
+++ b/products/catalyst/bootstrap/api/cmd/api/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/handler"
 	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/handoverjwt"
 	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/k8scache"
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/keycloak"
 	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/openbao"
 )
 
@@ -113,6 +114,20 @@ func main() {
 		)
 	}
 
+	// Option-B magic-link openova-realm Keycloak client (issue #614).
+	// Wired only when CATALYST_OPENOVA_KC_SA_CLIENT_SECRET is set.
+	// Catalyst-Zero always sets this; Sovereign clusters leave it unset.
+	if secret := os.Getenv("CATALYST_OPENOVA_KC_SA_CLIENT_SECRET"); secret != "" {
+		addr := env("CATALYST_OPENOVA_KC_ADDR", env("CATALYST_KC_ADDR", "http://keycloak-zero.keycloak-zero.svc.cluster.local"))
+		realm := env("CATALYST_OPENOVA_KC_REALM", "openova")
+		clientID := env("CATALYST_OPENOVA_KC_SA_CLIENT_ID", "catalyst-zero-server")
+		h.SetOpenovaKC(keycloak.New(addr, realm, clientID, secret))
+		log.Info("magic-link: openova KC client ready",
+			"addr", addr,
+			"realm", realm,
+		)
+	}
+
 	// K8s data-plane (issue #321) — informer cache + SSE + disk
 	// snapshot. Wired only when at least one kubeconfig is mountable;
 	// in test/CI without a real cluster the catalyst-api still
@@ -151,13 +166,24 @@ func main() {
 	r.Get("/readyz", h.Ready)
 	r.Handle("/metrics", promhttp.Handler())
 
-	// Unauthenticated auth endpoints — magic-link dispatch, PKCE callback,
-	// logout. These MUST remain outside the session gate (the user is not
-	// yet authenticated when they hit /magic-link and /callback).
-	// The session gate (RequireSession) guards ALL wizard data endpoints
-	// below in the r.Group block.
+	// Unauthenticated auth endpoints — magic-link dispatch, magic-link
+	// consumption (Option B server-side token-exchange), and logout.
+	// These MUST remain outside the session gate (the user is not yet
+	// authenticated when they hit /magic-link and /auth/magic).
+	//
+	// Option B replaces the Keycloak execute-actions-email PKCE flow:
+	//   POST /api/v1/auth/magic-link  — mint JWT + email link
+	//   GET  /api/v1/auth/magic       — validate JWT + KC token-exchange + cookies + redirect
+	//
+	// The legacy /auth/callback endpoint is kept as a 302 redirect to /login
+	// so any cached Keycloak redirect_uri bookmarks degrade gracefully.
 	r.Post("/api/v1/auth/magic-link", h.HandleMagicLink)
-	r.Get("/api/v1/auth/callback", h.HandleAuthCallback)
+	r.Get("/api/v1/auth/magic", h.HandleMagicValidate)
+	r.Get("/api/v1/auth/callback", func(w http.ResponseWriter, r *http.Request) {
+		// Legacy PKCE callback — Option B does not use this path.
+		// Redirect to login so cached bookmarks don't 404.
+		http.Redirect(w, r, "/login?error=flow_changed", http.StatusFound)
+	})
 	r.Delete("/api/v1/auth/session", h.HandleAuthLogout)
 
 	// Auth-gated wizard endpoints — RequireSession validates the

--- a/products/catalyst/bootstrap/api/internal/auth/session.go
+++ b/products/catalyst/bootstrap/api/internal/auth/session.go
@@ -222,14 +222,44 @@ func (c *Config) ClearSessionCookie(w http.ResponseWriter) {
 	})
 }
 
-// ReadSessionToken extracts and verifies the HMAC of the session cookie,
-// returning the raw access token. Returns "" if no valid cookie is present.
+// ReadSessionToken extracts the access token from the session cookie.
+//
+// Two cookie shapes are accepted:
+//
+//  1. HMAC-wrapped (Option A legacy): "<token>.<hmac>" — produced by
+//     IssueSessionCookie. The HMAC suffix is verified and stripped.
+//
+//  2. Raw Keycloak JWT (Option B magic-link): the cookie value is a
+//     compact JWT ("<header>.<payload>.<sig>"). Recognised by the absence
+//     of an additional "." after the third segment. When CookieSecret is
+//     empty, only this path is used so existing single-component deployments
+//     (Sovereign clusters) continue to work unchanged.
+//
+// Returns "" when no valid cookie is present.
 func (c *Config) ReadSessionToken(r *http.Request) string {
 	cookie, err := r.Cookie(SessionCookieName)
-	if err != nil {
+	if err != nil || cookie.Value == "" {
 		return ""
 	}
-	return c.verifyAndStrip(cookie.Value)
+
+	// Option A: HMAC-wrapped. Only attempt HMAC verification when a
+	// CookieSecret is configured — avoids mis-treating a raw JWT as a
+	// corrupt HMAC-wrapped value.
+	if c.CookieSecret != "" {
+		if stripped := c.verifyAndStrip(cookie.Value); stripped != "" {
+			return stripped
+		}
+	}
+
+	// Option B: raw Keycloak JWT. A compact JWT has exactly 3 base64url
+	// segments separated by '.'. Check that the value looks like a JWT
+	// (two dots minimum) and return it directly.
+	parts := strings.Split(cookie.Value, ".")
+	if len(parts) == 3 {
+		return cookie.Value
+	}
+
+	return ""
 }
 
 // signValue returns "<token>.<hmac>" where hmac is the HMAC-SHA256

--- a/products/catalyst/bootstrap/api/internal/handler/auth.go
+++ b/products/catalyst/bootstrap/api/internal/handler/auth.go
@@ -47,7 +47,7 @@ const magicLinkTTL = 15 * time.Minute
 const magicLinkIssuer = "https://console.openova.io"
 
 // magicLinkAudience — the consume endpoint URL.
-const magicLinkAudience = "https://console.openova.io/sovereign/auth/magic"
+const magicLinkAudience = "https://console.openova.io/sovereign/api/v1/auth/magic"
 
 // magicLinkRole — role claim stamped into every magic-link JWT.
 const magicLinkRole = "openova-user"
@@ -259,7 +259,7 @@ func (h *Handler) HandleMagicLink(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// ── 3. Email the link ────────────────────────────────────────────────────
-	magicURL := consoleBase() + "/auth/magic?token=" + url.QueryEscape(tokenStr)
+	magicURL := consoleBase() + "/api/v1/auth/magic?token=" + url.QueryEscape(tokenStr)
 	if err := sendMagicLinkEmail(email, magicURL); err != nil {
 		h.log.Error("magic-link: SMTP send failed", "email", email, "err", err)
 		writeJSON(w, http.StatusBadGateway, map[string]string{"error": "email dispatch failed"})

--- a/products/catalyst/bootstrap/api/internal/handler/auth.go
+++ b/products/catalyst/bootstrap/api/internal/handler/auth.go
@@ -1,18 +1,63 @@
+// auth.go — magic-link dispatch + consumption (Option B, issue #614 Phase-8b).
+//
+// Option B replaces the Keycloak execute-actions-email flow (Agent A) with a
+// fully self-contained passwordless path:
+//
+//  1. POST /api/v1/auth/magic-link — catalyst-api mints its own one-time
+//     RS256 JWT (same signer as the handover JWT, different claims set),
+//     calls keycloak.EnsureUser against the openova realm, and delivers the
+//     link via Stalwart SMTP. Zero Keycloak UI, zero PKCE round-trip.
+//
+//  2. GET /api/v1/auth/magic — the user clicks the link in their inbox.
+//     catalyst-api validates the JWT (exp, iss, aud, role, email_verified),
+//     marks the jti single-use, calls keycloak.ImpersonateToken to exchange
+//     for a user session in the openova realm, sets HttpOnly cookies, and
+//     302-redirects to /sovereign/wizard.
+//
+// Per docs/INVIOLABLE-PRINCIPLES.md:
+//   - #4: all hostnames and secrets are runtime-configurable via env.
+//   - #10: no credentials logged or emitted in error responses.
 package handler
 
 import (
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
+	"net/smtp"
 	"net/url"
 	"os"
 	"strings"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/google/uuid"
 
 	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/auth"
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/jtistore"
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/keycloak"
 )
 
-const pkceVerifierCookieName = "catalyst_pkce_verifier"
+// ── Constants ────────────────────────────────────────────────────────────────
+
+// magicLinkTTL — 15 minutes. Short enough to limit replay window; long enough
+// for users on slow mail delivery paths.
+const magicLinkTTL = 15 * time.Minute
+
+// magicLinkIssuer — constant issuer claim in the magic-link JWT.
+const magicLinkIssuer = "https://console.openova.io"
+
+// magicLinkAudience — the consume endpoint URL.
+const magicLinkAudience = "https://console.openova.io/sovereign/auth/magic"
+
+// magicLinkRole — role claim stamped into every magic-link JWT.
+const magicLinkRole = "openova-user"
+
+// magicJTIStorePath — dedicated flat-file log for consumed magic-link JTIs.
+// Separate from /var/lib/catalyst/jti.log (handover JTIs) to avoid replay
+// cross-contamination.
+const magicJTIStorePath = "/var/lib/catalyst/magic-jti.log"
+
+// ── helpers ──────────────────────────────────────────────────────────────────
 
 // postAuthRedirect returns the URL the browser is sent to after a successful
 // magic-link callback. Defaults to "/wizard"; can be overridden via
@@ -40,138 +85,388 @@ func loginRedirect(reason string) string {
 	return prefix + "/login?error=" + url.QueryEscape(reason)
 }
 
-// HandleMagicLink handles POST /api/v1/auth/magic-link.
+// smtpAddr returns "host:port" for the outbound SMTP relay.
+// Env: CATALYST_SMTP_HOST (default: stalwart-web.stalwart.svc.cluster.local)
 //
-// It accepts {"email":"<addr>"}, ensures the user exists in the Keycloak
-// openova realm, and triggers Keycloak's built-in VERIFY_EMAIL execute-actions
-// email (which renders as a passwordless "sign in" link). No password is ever
-// set or required — the link itself is the credential.
+//	CATALYST_SMTP_PORT (default: 587)
+func smtpAddr() string {
+	host := os.Getenv("CATALYST_SMTP_HOST")
+	if host == "" {
+		host = "stalwart-web.stalwart.svc.cluster.local"
+	}
+	port := os.Getenv("CATALYST_SMTP_PORT")
+	if port == "" {
+		port = "587"
+	}
+	return host + ":" + port
+}
+
+// smtpFrom returns the envelope-from / From header.
+// Env: CATALYST_SMTP_FROM (default: noreply@openova.io)
+func smtpFrom() string {
+	if v := os.Getenv("CATALYST_SMTP_FROM"); v != "" {
+		return v
+	}
+	return "noreply@openova.io"
+}
+
+// consoleBase returns the public base URL for the catalyst-api.
+// Env: CATALYST_API_PUBLIC_URL (default: https://console.openova.io/sovereign)
+func consoleBase() string {
+	if v := os.Getenv("CATALYST_API_PUBLIC_URL"); v != "" {
+		return strings.TrimRight(v, "/")
+	}
+	return "https://console.openova.io/sovereign"
+}
+
+// openovaKCClient returns the openova-realm Keycloak client.
 //
-// On success: 200 {"ok":true}
-// On bad request: 400 {"error":"<msg>"}
-// On backend failure: 502 {"error":"<msg>"}
+// Resolution order:
+//  1. h.openovaKC (injected by main.go or tests)
+//  2. Built lazily from CATALYST_OPENOVA_KC_* env vars
+//  3. nil when CATALYST_OPENOVA_KC_SA_CLIENT_SECRET is unset (Sovereign, CI)
+func (h *Handler) openovaKCClient() keycloakClient {
+	if h.openovaKC != nil {
+		return h.openovaKC
+	}
+	addr := os.Getenv("CATALYST_OPENOVA_KC_ADDR")
+	if addr == "" {
+		// Fall back to the shared KC addr env (Catalyst-Zero uses the same KC
+		// instance but a different realm + service-account client).
+		addr = os.Getenv("CATALYST_KC_ADDR")
+	}
+	if addr == "" {
+		addr = "http://keycloak-zero.keycloak-zero.svc.cluster.local"
+	}
+	realm := os.Getenv("CATALYST_OPENOVA_KC_REALM")
+	if realm == "" {
+		realm = "openova"
+	}
+	clientID := os.Getenv("CATALYST_OPENOVA_KC_SA_CLIENT_ID")
+	if clientID == "" {
+		clientID = "catalyst-zero-server"
+	}
+	secret := os.Getenv("CATALYST_OPENOVA_KC_SA_CLIENT_SECRET")
+	if secret == "" {
+		return nil // unconfigured — magic endpoint returns 503
+	}
+	return keycloak.New(addr, realm, clientID, secret)
+}
+
+// magicLinkJTIStore returns the jtiStorer for magic-link JWT replay protection.
+// Reuses the Handler field (jtiStore) if it happens to be wired (tests); in
+// production creates a fresh file-backed store at magicJTIStorePath.
+func (h *Handler) magicLinkJTIStore() jtiStorer {
+	if h.jtiStore != nil {
+		return h.jtiStore
+	}
+	return jtistore.New(magicJTIStorePath)
+}
+
+// ── magicLinkClaims ───────────────────────────────────────────────────────────
+
+// magicLinkClaims extends jwt.RegisteredClaims with the fields the /auth/magic
+// consumer validates.
+type magicLinkClaims struct {
+	jwt.RegisteredClaims
+	Email         string `json:"email"`
+	EmailVerified bool   `json:"email_verified"`
+	Role          string `json:"role"`
+}
+
+// ── Step 1: POST /api/v1/auth/magic-link ─────────────────────────────────────
+
+// HandleMagicLink handles POST /api/v1/auth/magic-link (Option B).
+//
+// 1. Reads {"email": "<addr>"} from the request body.
+// 2. Calls keycloak.EnsureUser in the openova realm via the catalyst-zero-server
+//    service-account (CATALYST_OPENOVA_KC_* env).
+// 3. Mints a 15-minute RS256 JWT using the same handoverSigner keypair as Agent B.
+// 4. Sends the magic link via Stalwart SMTP.
+// 5. Returns {"ok": true}.
+//
+// The user never sees Keycloak's hosted UI — the link goes directly to our
+// GET /api/v1/auth/magic endpoint which handles the token-exchange server-side.
 func (h *Handler) HandleMagicLink(w http.ResponseWriter, r *http.Request) {
-	cfg := h.authConfig
-	if cfg == nil {
-		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "auth not configured"})
+	if h.handoverSigner == nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]string{
+			"error": "auth not configured: handover signer unavailable (CATALYST_HANDOVER_KEY_PATH not set)",
+		})
 		return
 	}
 
 	var body struct {
 		Email string `json:"email"`
 	}
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil || body.Email == "" {
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil || strings.TrimSpace(body.Email) == "" {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "email required"})
 		return
 	}
+	email := strings.TrimSpace(body.Email)
 
-	// Generate PKCE verifier and store in HttpOnly cookie.
-	verifier, err := auth.GeneratePKCEVerifier()
-	if err != nil {
-		h.log.Error("magic-link: PKCE generation failed", "err", err)
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "pkce generation failed"})
+	// ── 1. EnsureUser in openova realm ──────────────────────────────────────
+	kc := h.openovaKCClient()
+	if kc == nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]string{
+			"error": "auth not configured: CATALYST_OPENOVA_KC_SA_CLIENT_SECRET not set",
+		})
 		return
 	}
-	challenge := auth.PKCEChallenge(verifier)
-
-	// Store verifier in HttpOnly cookie so HandleAuthCallback can use it.
-	http.SetCookie(w, &http.Cookie{
-		Name:     pkceVerifierCookieName,
-		Value:    verifier,
-		Path:     "/",
-		MaxAge:   3600,
-		HttpOnly: true,
-		Secure:   true,
-		SameSite: http.SameSiteLaxMode, // Lax so the Keycloak redirect back carries it
-	})
-
-	// Obtain an admin token against the master realm.
-	adminToken, err := authAdminToken(cfg)
+	userID, err := kc.EnsureUser(r.Context(), email, "openova-users")
 	if err != nil {
-		h.log.Error("magic-link: admin token failed", "err", err)
-		writeJSON(w, http.StatusBadGateway, map[string]string{"error": "keycloak admin unavailable"})
-		return
-	}
-
-	// Ensure the user exists in the realm.
-	userID, err := ensureUser(cfg, adminToken, body.Email)
-	if err != nil {
-		h.log.Error("magic-link: ensureUser failed", "email", body.Email, "err", err)
+		h.log.Error("magic-link: EnsureUser failed", "email", email, "err", err)
 		writeJSON(w, http.StatusBadGateway, map[string]string{"error": "user provisioning failed"})
 		return
 	}
 
-	// Build the authorisation URL with PKCE so the email link lands on our callback.
-	authURL := cfg.KeycloakAddr + "/realms/" + cfg.Realm + "/protocol/openid-connect/auth" +
-		"?response_type=code" +
-		"&client_id=" + url.QueryEscape(cfg.ClientID) +
-		"&redirect_uri=" + url.QueryEscape(cfg.RedirectURI) +
-		"&scope=openid+email+profile" +
-		"&code_challenge=" + url.QueryEscape(challenge) +
-		"&code_challenge_method=S256"
+	// ── 2. Mint one-time JWT ─────────────────────────────────────────────────
+	jti, err := uuid.NewRandom()
+	if err != nil {
+		h.log.Error("magic-link: uuid generation failed", "err", err)
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "jti generation failed"})
+		return
+	}
+	now := time.Now().UTC()
+	claims := magicLinkClaims{
+		RegisteredClaims: jwt.RegisteredClaims{
+			Issuer:    magicLinkIssuer,
+			Audience:  jwt.ClaimStrings{magicLinkAudience},
+			Subject:   userID,
+			IssuedAt:  jwt.NewNumericDate(now),
+			ExpiresAt: jwt.NewNumericDate(now.Add(magicLinkTTL)),
+			ID:        jti.String(),
+		},
+		Email:         email,
+		EmailVerified: true,
+		Role:          magicLinkRole,
+	}
 
-	// Trigger VERIFY_EMAIL execute-actions-email — Keycloak sends the user
-	// a link that completes the PKCE auth flow and lands on our callback.
-	if err := executeActionsEmail(cfg, adminToken, userID, authURL); err != nil {
-		h.log.Error("magic-link: executeActionsEmail failed", "user_id", userID, "err", err)
+	// Sign using the same RSA private key as the handover JWT signer.
+	// We access it via a shim because the signer's private key is unexported.
+	// We re-use MintToken as a passthrough and then sign our own claims
+	// directly by calling the JWT library with the signer's exposed method.
+	//
+	// Actually: handoverjwt.Signer.MintToken is purpose-built for the handover
+	// shape (sovereign_fqdn, deployment_id, role=sovereign-admin). For
+	// magic-link we need a different claims shape, so we use a dedicated helper
+	// that calls jwt.NewWithClaims + SignedString directly on the RSA key.
+	// We expose this via a new SignMagicLink shim on handoverSigner (below).
+	tokenStr, err := h.handoverSigner.SignCustomClaims(claims)
+	if err != nil {
+		h.log.Error("magic-link: sign claims failed", "err", err)
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "token signing failed"})
+		return
+	}
+
+	// ── 3. Email the link ────────────────────────────────────────────────────
+	magicURL := consoleBase() + "/auth/magic?token=" + url.QueryEscape(tokenStr)
+	if err := sendMagicLinkEmail(email, magicURL); err != nil {
+		h.log.Error("magic-link: SMTP send failed", "email", email, "err", err)
 		writeJSON(w, http.StatusBadGateway, map[string]string{"error": "email dispatch failed"})
 		return
 	}
 
+	h.log.Info("magic-link: dispatched", "email", email, "userID", userID)
 	writeJSON(w, http.StatusOK, map[string]bool{"ok": true})
 }
 
-// HandleAuthCallback handles GET /api/v1/auth/callback.
+// sendMagicLinkEmail sends the magic-link to the given address via Stalwart SMTP.
+// Credentials: CATALYST_SMTP_USER / CATALYST_SMTP_PASS (optional; Stalwart
+// on contabo accepts SMTP from pods in-cluster without auth, but we support
+// it for environments where the relay requires credentials).
+func sendMagicLinkEmail(to, magicURL string) error {
+	from := smtpFrom()
+	addr := smtpAddr()
+
+	subject := "Your OpenOva sign-in link"
+	body := fmt.Sprintf("Click the link below to sign in to OpenOva.\r\n\r\n%s\r\n\r\nThis link expires in 15 minutes.\r\nIf you did not request this, you can safely ignore this email.", magicURL)
+
+	msg := fmt.Sprintf(
+		"From: OpenOva Platform <%s>\r\nTo: %s\r\nSubject: %s\r\nContent-Type: text/plain; charset=utf-8\r\n\r\n%s",
+		from, to, subject, body,
+	)
+
+	smtpUser := os.Getenv("CATALYST_SMTP_USER")
+	smtpPass := os.Getenv("CATALYST_SMTP_PASS")
+
+	var authMethod smtp.Auth
+	if smtpUser != "" && smtpPass != "" {
+		host := strings.Split(addr, ":")[0]
+		authMethod = smtp.PlainAuth("", smtpUser, smtpPass, host)
+	}
+
+	return smtp.SendMail(addr, authMethod, from, []string{to}, []byte(msg))
+}
+
+// ── Step 2: GET /api/v1/auth/magic ───────────────────────────────────────────
+
+// HandleMagicValidate handles GET /api/v1/auth/magic?token=<jwt> (Option B).
 //
-// The Keycloak magic-link redirects here with ?code=... after the user clicks
-// the email link. This handler:
-//  1. Reads the PKCE verifier from the catalyst_pkce_verifier cookie.
-//  2. Exchanges the code for tokens via cfg.ExchangeCode.
-//  3. Issues an HMAC-signed session cookie via cfg.IssueSessionCookie.
-//  4. Redirects the browser to /wizard (Catalyst-Zero operator entry-point).
-func (h *Handler) HandleAuthCallback(w http.ResponseWriter, r *http.Request) {
-	cfg := h.authConfig
-	if cfg == nil {
-		http.Error(w, "auth not configured", http.StatusServiceUnavailable)
+// 1. Parses and RS256-verifies the JWT using the handover signing keypair's
+//    public key (same key pair as handoverSigner).
+// 2. Validates claims: aud, iss, exp (enforced by jwt-go library), role,
+//    email_verified.
+// 3. Marks the jti single-use via jtistore.
+// 4. Calls keycloak.ImpersonateToken with the userID (sub) and audience
+//    "catalyst-zero-ui" to exchange for a user-scoped access + refresh token.
+// 5. Sets HttpOnly Secure SameSite=Lax cookies (catalyst_session + catalyst_refresh).
+// 6. 302 redirects to /sovereign/wizard (CATALYST_POST_AUTH_REDIRECT).
+// 7. On any error: 401 with terse JSON.
+func (h *Handler) HandleMagicValidate(w http.ResponseWriter, r *http.Request) {
+	if h.handoverSigner == nil {
+		writeMagicError(w, "server misconfiguration: signer unavailable")
 		return
 	}
 
-	code := r.URL.Query().Get("code")
-	if code == "" {
-		http.Error(w, "missing code parameter", http.StatusBadRequest)
+	rawToken := r.URL.Query().Get("token")
+	if rawToken == "" {
+		http.Redirect(w, r, loginRedirect("missing_token"), http.StatusSeeOther)
 		return
 	}
 
-	// Read the PKCE verifier stored in the cookie during magic-link dispatch.
-	verifierCookie, err := r.Cookie(pkceVerifierCookieName)
-	if err != nil || verifierCookie.Value == "" {
-		http.Error(w, "missing pkce verifier cookie", http.StatusBadRequest)
+	// ── 1. Parse + verify JWT ────────────────────────────────────────────────
+	pubKey, err := h.handoverSigner.PublicRSAKey()
+	if err != nil {
+		h.log.Error("magic-validate: PublicRSAKey failed", "err", err)
+		writeMagicError(w, "server misconfiguration: keypair unavailable")
 		return
 	}
-	verifier := verifierCookie.Value
 
-	// Clear the PKCE cookie — single use.
+	var claims magicLinkClaims
+	tok, err := jwt.ParseWithClaims(rawToken, &claims,
+		func(t *jwt.Token) (interface{}, error) {
+			if _, ok := t.Method.(*jwt.SigningMethodRSA); !ok {
+				return nil, fmt.Errorf("unexpected signing method: %v", t.Header["alg"])
+			}
+			return pubKey, nil
+		},
+		jwt.WithValidMethods([]string{"RS256"}),
+		jwt.WithExpirationRequired(),
+	)
+	if err != nil || !tok.Valid {
+		h.log.Warn("magic-validate: JWT parse failed", "err", err)
+		http.Redirect(w, r, loginRedirect("invalid_token"), http.StatusSeeOther)
+		return
+	}
+
+	// ── 2. Validate claims ───────────────────────────────────────────────────
+	iss, _ := claims.GetIssuer()
+	if iss != magicLinkIssuer {
+		h.log.Warn("magic-validate: invalid issuer", "iss", iss)
+		http.Redirect(w, r, loginRedirect("invalid_issuer"), http.StatusSeeOther)
+		return
+	}
+
+	auds, _ := claims.GetAudience()
+	foundAud := false
+	for _, a := range auds {
+		if a == magicLinkAudience {
+			foundAud = true
+			break
+		}
+	}
+	if !foundAud {
+		h.log.Warn("magic-validate: invalid audience", "aud", auds)
+		http.Redirect(w, r, loginRedirect("invalid_audience"), http.StatusSeeOther)
+		return
+	}
+
+	if claims.Role != magicLinkRole {
+		h.log.Warn("magic-validate: invalid role", "role", claims.Role)
+		http.Redirect(w, r, loginRedirect("insufficient_role"), http.StatusSeeOther)
+		return
+	}
+	if !claims.EmailVerified {
+		writeMagicError(w, "email not verified")
+		return
+	}
+	if claims.Email == "" || claims.Subject == "" {
+		writeMagicError(w, "missing email or sub claim")
+		return
+	}
+
+	jti := claims.ID
+	if jti == "" {
+		writeMagicError(w, "missing jti")
+		return
+	}
+
+	// ── 3. Replay check ──────────────────────────────────────────────────────
+	store := h.magicLinkJTIStore()
+	firstUse, err := store.Mark(jti)
+	if err != nil {
+		h.log.Error("magic-validate: jtistore.Mark failed", "err", err)
+		writeMagicError(w, "internal error")
+		return
+	}
+	if !firstUse {
+		h.log.Warn("magic-validate: replayed jti", "jti", jti)
+		http.Redirect(w, r, loginRedirect("token_replayed"), http.StatusSeeOther)
+		return
+	}
+
+	// ── 4. Token-exchange with Keycloak ──────────────────────────────────────
+	kc := h.openovaKCClient()
+	if kc == nil {
+		writeMagicError(w, "server misconfiguration: keycloak not configured")
+		return
+	}
+
+	kcAudience := os.Getenv("CATALYST_OPENOVA_KC_AUDIENCE")
+	if kcAudience == "" {
+		kcAudience = "catalyst-zero-ui"
+	}
+
+	accessToken, refreshToken, expiresIn, err := kc.ImpersonateToken(r.Context(), claims.Subject, kcAudience)
+	if err != nil {
+		h.log.Error("magic-validate: ImpersonateToken failed",
+			"userID", claims.Subject,
+			"email", claims.Email,
+			"err", err,
+		)
+		writeMagicError(w, "keycloak error: token exchange")
+		return
+	}
+
+	// ── 5. Issue session cookies ─────────────────────────────────────────────
+	cookieMaxAge := expiresIn
+	if cookieMaxAge <= 0 {
+		cookieMaxAge = 3600
+	}
+	secure := r.TLS != nil || r.Header.Get("X-Forwarded-Proto") == "https"
+	cookieDomain := os.Getenv("CATALYST_SESSION_COOKIE_DOMAIN") // e.g. "console.openova.io"
+
 	http.SetCookie(w, &http.Cookie{
-		Name:     pkceVerifierCookieName,
-		Value:    "",
+		Name:     auth.SessionCookieName,
+		Value:    accessToken,
 		Path:     "/",
-		MaxAge:   -1,
+		Domain:   cookieDomain,
+		MaxAge:   cookieMaxAge,
 		HttpOnly: true,
-		Secure:   true,
+		Secure:   secure,
 		SameSite: http.SameSiteLaxMode,
 	})
-
-	accessToken, _, claims, err := cfg.ExchangeCode(r.Context(), code, verifier)
-	if err != nil {
-		h.log.Debug("auth callback: code exchange failed", "err", err)
-		http.Redirect(w, r, loginRedirect("callback_failed"), http.StatusSeeOther)
-		return
+	if refreshToken != "" {
+		http.SetCookie(w, &http.Cookie{
+			Name:     "catalyst_refresh",
+			Value:    refreshToken,
+			Path:     "/",
+			Domain:   cookieDomain,
+			MaxAge:   cookieMaxAge * 8,
+			HttpOnly: true,
+			Secure:   secure,
+			SameSite: http.SameSiteLaxMode,
+		})
 	}
 
-	cfg.IssueSessionCookie(w, accessToken)
+	h.log.Info("magic-validate: session established",
+		"email", claims.Email,
+		"userID", claims.Subject,
+		"expires_in", expiresIn,
+	)
 
-	_ = claims
-	http.Redirect(w, r, postAuthRedirect(), http.StatusSeeOther)
+	// ── 6. Redirect to wizard ─────────────────────────────────────────────────
+	http.Redirect(w, r, postAuthRedirect(), http.StatusFound)
 }
 
 // HandleAuthLogout handles DELETE /api/v1/auth/session.
@@ -183,6 +478,25 @@ func (h *Handler) HandleAuthLogout(w http.ResponseWriter, r *http.Request) {
 	if cfg != nil {
 		cfg.ClearSessionCookie(w)
 	}
+	// Also clear the raw cookie set by Option-B path (no HMAC wrapping).
+	http.SetCookie(w, &http.Cookie{
+		Name:     auth.SessionCookieName,
+		Value:    "",
+		Path:     "/",
+		MaxAge:   -1,
+		HttpOnly: true,
+		Secure:   true,
+		SameSite: http.SameSiteLaxMode,
+	})
+	http.SetCookie(w, &http.Cookie{
+		Name:     "catalyst_refresh",
+		Value:    "",
+		Path:     "/",
+		MaxAge:   -1,
+		HttpOnly: true,
+		Secure:   true,
+		SameSite: http.SameSiteLaxMode,
+	})
 	w.WriteHeader(http.StatusNoContent)
 }
 
@@ -206,128 +520,10 @@ func (h *Handler) HandleWhoami(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-// ── Keycloak Admin REST helpers ───────────────────────────────────────────────
-
-// authAdminToken obtains a short-lived admin access token via the
-// Keycloak master realm password grant for the admin-cli client.
-// Credentials are read from CATALYST_KC_ADMIN_USER / CATALYST_KC_ADMIN_PASS.
-func authAdminToken(cfg *auth.Config) (string, error) {
-	adminUser := os.Getenv("CATALYST_KC_ADMIN_USER")
-	adminPass := os.Getenv("CATALYST_KC_ADMIN_PASS")
-	if adminUser == "" || adminPass == "" {
-		return "", fmt.Errorf("CATALYST_KC_ADMIN_USER or CATALYST_KC_ADMIN_PASS not set")
-	}
-
-	tokenURL := cfg.KeycloakAddr + "/realms/master/protocol/openid-connect/token"
-	resp, err := http.PostForm(tokenURL, url.Values{
-		"grant_type": {"password"},
-		"client_id":  {"admin-cli"},
-		"username":   {adminUser},
-		"password":   {adminPass},
-	})
-	if err != nil {
-		return "", fmt.Errorf("admin token request: %w", err)
-	}
-	defer resp.Body.Close()
-
-	body, _ := io.ReadAll(resp.Body)
-	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("admin token: status %d body %s", resp.StatusCode, string(body))
-	}
-
-	var tr struct {
-		AccessToken string `json:"access_token"`
-	}
-	if err := json.Unmarshal(body, &tr); err != nil {
-		return "", fmt.Errorf("admin token decode: %w", err)
-	}
-	if tr.AccessToken == "" {
-		return "", fmt.Errorf("admin token: empty access_token in response")
-	}
-	return tr.AccessToken, nil
-}
-
-// ensureUser looks up a Keycloak user by exact email address in the realm.
-// If the user doesn't exist it creates them. Returns the Keycloak user ID.
-func ensureUser(cfg *auth.Config, adminToken, email string) (string, error) {
-	// Check if user exists.
-	lookupURL := cfg.KeycloakAddr + "/admin/realms/" + cfg.Realm + "/users?email=" + url.QueryEscape(email) + "&exact=true"
-	req, _ := http.NewRequest(http.MethodGet, lookupURL, nil)
-	req.Header.Set("Authorization", "Bearer "+adminToken)
-
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return "", fmt.Errorf("ensureUser lookup: %w", err)
-	}
-	defer resp.Body.Close()
-
-	raw, _ := io.ReadAll(resp.Body)
-	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("ensureUser lookup: status %d", resp.StatusCode)
-	}
-
-	var users []struct {
-		ID string `json:"id"`
-	}
-	if err := json.Unmarshal(raw, &users); err != nil {
-		return "", fmt.Errorf("ensureUser decode: %w", err)
-	}
-	if len(users) > 0 {
-		return users[0].ID, nil
-	}
-
-	// Create the user. Keycloak 24.7+ requires "username" — use the email
-	// as the username for email-only magic-link login UX.
-	createURL := cfg.KeycloakAddr + "/admin/realms/" + cfg.Realm + "/users"
-	payload := fmt.Sprintf(`{"username":%q,"email":%q,"enabled":true,"emailVerified":false}`, email, email)
-	req2, _ := http.NewRequest(http.MethodPost, createURL, strings.NewReader(payload))
-	req2.Header.Set("Authorization", "Bearer "+adminToken)
-	req2.Header.Set("Content-Type", "application/json")
-
-	resp2, err := http.DefaultClient.Do(req2)
-	if err != nil {
-		return "", fmt.Errorf("ensureUser create: %w", err)
-	}
-	defer resp2.Body.Close()
-
-	if resp2.StatusCode != http.StatusCreated {
-		b, _ := io.ReadAll(resp2.Body)
-		return "", fmt.Errorf("ensureUser create: status %d body %s", resp2.StatusCode, string(b))
-	}
-
-	// The ID is in the Location header: .../users/<uuid>
-	location := resp2.Header.Get("Location")
-	parts := strings.Split(location, "/")
-	if len(parts) == 0 {
-		return "", fmt.Errorf("ensureUser create: empty Location header")
-	}
-	return parts[len(parts)-1], nil
-}
-
-// executeActionsEmail triggers Keycloak's VERIFY_EMAIL execute-actions email
-// for the given user. lifespan is 3600 seconds (1 hour). The redirectUri is
-// the PKCE-decorated authorisation URL so Keycloak renders the magic-link
-// as a one-click sign-in.
-func executeActionsEmail(cfg *auth.Config, adminToken, userID, redirectURI string) error {
-	u := cfg.KeycloakAddr + "/admin/realms/" + cfg.Realm + "/users/" + userID +
-		"/execute-actions-email" +
-		"?client_id=" + url.QueryEscape(cfg.ClientID) +
-		"&redirect_uri=" + url.QueryEscape(redirectURI) +
-		"&lifespan=3600"
-
-	req, _ := http.NewRequest(http.MethodPut, u, strings.NewReader(`["VERIFY_EMAIL"]`))
-	req.Header.Set("Authorization", "Bearer "+adminToken)
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return fmt.Errorf("executeActionsEmail: %w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusNoContent {
-		b, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("executeActionsEmail: status %d body %s", resp.StatusCode, string(b))
-	}
-	return nil
+// writeMagicError writes a 401 JSON error for the magic-validate flow.
+// Per INVIOLABLE-PRINCIPLES #10 — no credentials or internal state in the message.
+func writeMagicError(w http.ResponseWriter, msg string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusUnauthorized)
+	json.NewEncoder(w).Encode(map[string]string{"error": msg}) //nolint:errcheck
 }

--- a/products/catalyst/bootstrap/api/internal/handler/auth.go
+++ b/products/catalyst/bootstrap/api/internal/handler/auth.go
@@ -276,9 +276,10 @@ func ensureUser(cfg *auth.Config, adminToken, email string) (string, error) {
 		return users[0].ID, nil
 	}
 
-	// Create the user.
+	// Create the user. Keycloak 24.7+ requires "username" — use the email
+	// as the username for email-only magic-link login UX.
 	createURL := cfg.KeycloakAddr + "/admin/realms/" + cfg.Realm + "/users"
-	payload := fmt.Sprintf(`{"email":%q,"enabled":true,"emailVerified":false}`, email)
+	payload := fmt.Sprintf(`{"username":%q,"email":%q,"enabled":true,"emailVerified":false}`, email, email)
 	req2, _ := http.NewRequest(http.MethodPost, createURL, strings.NewReader(payload))
 	req2.Header.Set("Authorization", "Bearer "+adminToken)
 	req2.Header.Set("Content-Type", "application/json")

--- a/products/catalyst/bootstrap/api/internal/handler/auth_magic_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/auth_magic_test.go
@@ -1,0 +1,432 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/handoverjwt"
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/jtistore"
+)
+
+// ─── magic-link test helpers ──────────────────────────────────────────────────
+
+// testMagicSetup creates a Handler wired for magic-link Option-B tests.
+// Returns the handler. The handoverSigner is a real signer backed by a
+// freshly-generated RSA-2048 keypair so JWT round-trips work end-to-end.
+func testMagicSetup(t *testing.T) *Handler {
+	t.Helper()
+	dir := t.TempDir()
+
+	privPEM, pubJWK, err := handoverjwt.GenerateKeypair()
+	if err != nil {
+		t.Fatalf("GenerateKeypair: %v", err)
+	}
+
+	keyPath := filepath.Join(dir, "handover.pem")
+	pubPath := filepath.Join(dir, "public.jwk")
+	if err := writeFile(t, keyPath, privPEM, 0o600); err != nil {
+		t.Fatalf("write privPEM: %v", err)
+	}
+	if err := writeFile(t, pubPath, pubJWK, 0o644); err != nil { //nolint:gocritic
+		t.Fatalf("write pubJWK: %v", err)
+	}
+
+	signer, err := handoverjwt.LoadOrGenerate(keyPath, pubPath, "https://console.openova.io", 5*time.Minute)
+	if err != nil {
+		t.Fatalf("LoadOrGenerate: %v", err)
+	}
+
+	jtiSt := jtistore.New(filepath.Join(dir, "magic-jti.log"))
+
+	return &Handler{
+		log:            slog.New(slog.NewTextHandler(io.Discard, nil)),
+		handoverSigner: signer,
+		jtiStore:       jtiSt,
+		// openovaKC is the openova-realm KC client; kc is the sovereign-realm KC client.
+		// Tests for magic-link inject openovaKC; auth_handover tests inject kc.
+		openovaKC: &stubKeycloakClient{},
+	}
+}
+
+// mintMagicToken uses the handler's signer to mint a valid magic-link JWT.
+func mintMagicToken(t *testing.T, h *Handler, email string) string {
+	t.Helper()
+	jti := fmt.Sprintf("test-jti-%d", time.Now().UnixNano())
+	now := time.Now().UTC()
+	claims := magicLinkClaims{
+		RegisteredClaims: jwt.RegisteredClaims{
+			Issuer:    magicLinkIssuer,
+			Audience:  jwt.ClaimStrings{magicLinkAudience},
+			Subject:   "user-uuid-001",
+			IssuedAt:  jwt.NewNumericDate(now),
+			ExpiresAt: jwt.NewNumericDate(now.Add(magicLinkTTL)),
+			ID:        jti,
+		},
+		Email:         email,
+		EmailVerified: true,
+		Role:          magicLinkRole,
+	}
+	tok, err := h.handoverSigner.SignCustomClaims(claims)
+	if err != nil {
+		t.Fatalf("SignCustomClaims: %v", err)
+	}
+	return tok
+}
+
+// ─── POST /api/v1/auth/magic-link tests ──────────────────────────────────────
+
+// TestMagicLink_NoSignerReturns503 tests that the handler returns 503 when the
+// handover signer is not configured (CATALYST_HANDOVER_KEY_PATH not set).
+func TestMagicLink_NoSignerReturns503(t *testing.T) {
+	h := &Handler{
+		log:            slog.New(slog.NewTextHandler(io.Discard, nil)),
+		handoverSigner: nil, // signer absent
+	}
+	body := `{"email":"test@example.com"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/magic-link",
+		strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.HandleMagicLink(w, req)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Errorf("status: got %d want 503", w.Code)
+	}
+}
+
+// TestMagicLink_EmptyEmailReturns400 tests that a missing email in the body
+// returns 400.
+func TestMagicLink_EmptyEmailReturns400(t *testing.T) {
+	h := testMagicSetup(t)
+	// openovaKCClient will return nil without CATALYST_OPENOVA_KC_SA_CLIENT_SECRET
+	// set, but the email validation fires first.
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/magic-link",
+		strings.NewReader(`{}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.HandleMagicLink(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status: got %d want 400", w.Code)
+	}
+}
+
+// TestMagicLink_NoKCReturns503 tests that missing KC config returns 503.
+func TestMagicLink_NoKCReturns503(t *testing.T) {
+	h := testMagicSetup(t)
+	// No openovaKC injected and no env var set — openovaKCClient() returns nil.
+	h.openovaKC = nil
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/magic-link",
+		strings.NewReader(`{"email":"test@example.com"}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.HandleMagicLink(w, req)
+
+	// openovaKCClient checks CATALYST_OPENOVA_KC_SA_CLIENT_SECRET — not set.
+	if w.Code != http.StatusServiceUnavailable {
+		t.Errorf("status: got %d want 503", w.Code)
+	}
+}
+
+// ─── GET /api/v1/auth/magic tests ────────────────────────────────────────────
+
+// magicValidateHandler wires the handler and a stub KC client that returns
+// tokens so the full happy path can be tested.
+func magicValidateHandler(t *testing.T) *Handler {
+	t.Helper()
+	h := testMagicSetup(t)
+	h.openovaKC = &stubKeycloakClient{
+		impersonateAccess:  "kc-access-token",
+		impersonateRefresh: "kc-refresh-token",
+		impersonateExpiry:  3600,
+	}
+	return h
+}
+
+// TestMagicValidate_HappyPath tests the full validate flow:
+// valid JWT → KC token-exchange → cookies set → redirect to wizard.
+func TestMagicValidate_HappyPath(t *testing.T) {
+	h := magicValidateHandler(t)
+	tok := mintMagicToken(t, h, "operator@example.com")
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/auth/magic?token="+tok, nil)
+	w := httptest.NewRecorder()
+	h.HandleMagicValidate(w, req)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusFound {
+		t.Errorf("status: got %d want 302 (body: %s)", resp.StatusCode, w.Body.String())
+	}
+
+	// Cookies.
+	sessionCookie := findCookie(resp.Cookies(), "catalyst_session")
+	if sessionCookie == nil {
+		t.Fatal("catalyst_session cookie not set")
+	}
+	if sessionCookie.Value != "kc-access-token" {
+		t.Errorf("catalyst_session value: got %q want kc-access-token", sessionCookie.Value)
+	}
+	if !sessionCookie.HttpOnly {
+		t.Error("catalyst_session must be HttpOnly")
+	}
+	if sessionCookie.SameSite != http.SameSiteLaxMode {
+		t.Error("catalyst_session must be SameSite=Lax")
+	}
+
+	refreshCookie := findCookie(resp.Cookies(), "catalyst_refresh")
+	if refreshCookie == nil {
+		t.Fatal("catalyst_refresh cookie not set")
+	}
+	if refreshCookie.Value != "kc-refresh-token" {
+		t.Errorf("catalyst_refresh value: got %q", refreshCookie.Value)
+	}
+}
+
+// TestMagicValidate_MissingToken tests that a missing ?token param redirects to /login.
+func TestMagicValidate_MissingToken(t *testing.T) {
+	h := magicValidateHandler(t)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/auth/magic", nil)
+	w := httptest.NewRecorder()
+	h.HandleMagicValidate(w, req)
+
+	// Missing token → redirect to /login (not 401) so the user sees the login UI.
+	if w.Code != http.StatusSeeOther {
+		t.Errorf("status: got %d want 303", w.Code)
+	}
+}
+
+// TestMagicValidate_ExpiredToken tests that an expired JWT redirects to /login?error=.
+func TestMagicValidate_ExpiredToken(t *testing.T) {
+	h := magicValidateHandler(t)
+
+	now := time.Now().UTC()
+	claims := magicLinkClaims{
+		RegisteredClaims: jwt.RegisteredClaims{
+			Issuer:    magicLinkIssuer,
+			Audience:  jwt.ClaimStrings{magicLinkAudience},
+			Subject:   "user-uuid-001",
+			IssuedAt:  jwt.NewNumericDate(now.Add(-30 * time.Minute)),
+			ExpiresAt: jwt.NewNumericDate(now.Add(-15 * time.Minute)),
+			ID:        "expired-jti",
+		},
+		Email:         "op@example.com",
+		EmailVerified: true,
+		Role:          magicLinkRole,
+	}
+	tok, err := h.handoverSigner.SignCustomClaims(claims)
+	if err != nil {
+		t.Fatalf("SignCustomClaims: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/auth/magic?token="+tok, nil)
+	w := httptest.NewRecorder()
+	h.HandleMagicValidate(w, req)
+
+	if w.Code != http.StatusSeeOther {
+		t.Errorf("expired token: got %d want 303", w.Code)
+	}
+	loc := w.Header().Get("Location")
+	if !strings.Contains(loc, "error=") {
+		t.Errorf("Location should contain error param, got %q", loc)
+	}
+}
+
+// TestMagicValidate_ReplayedJTI tests that a second use of the same JTI is rejected.
+func TestMagicValidate_ReplayedJTI(t *testing.T) {
+	h := magicValidateHandler(t)
+	tok := mintMagicToken(t, h, "op@example.com")
+
+	// First use — should succeed.
+	req1 := httptest.NewRequest(http.MethodGet, "/api/v1/auth/magic?token="+tok, nil)
+	w1 := httptest.NewRecorder()
+	h.HandleMagicValidate(w1, req1)
+	if w1.Code != http.StatusFound {
+		t.Fatalf("first use: expected 302, got %d (body: %s)", w1.Code, w1.Body.String())
+	}
+
+	// Second use — should be rejected (redirect to /login?error=token_replayed).
+	req2 := httptest.NewRequest(http.MethodGet, "/api/v1/auth/magic?token="+tok, nil)
+	w2 := httptest.NewRecorder()
+	h.HandleMagicValidate(w2, req2)
+	if w2.Code != http.StatusSeeOther {
+		t.Errorf("replayed jti: got %d want 303", w2.Code)
+	}
+	loc := w2.Header().Get("Location")
+	if !strings.Contains(loc, "token_replayed") {
+		t.Errorf("Location should contain token_replayed, got %q", loc)
+	}
+}
+
+// TestMagicValidate_WrongAudience tests that a token with the wrong audience claim
+// redirects to /login?error=invalid_audience.
+func TestMagicValidate_WrongAudience(t *testing.T) {
+	h := magicValidateHandler(t)
+
+	now := time.Now().UTC()
+	claims := magicLinkClaims{
+		RegisteredClaims: jwt.RegisteredClaims{
+			Issuer:    magicLinkIssuer,
+			Audience:  jwt.ClaimStrings{"https://evil.example.com/auth/magic"},
+			Subject:   "user-uuid-001",
+			IssuedAt:  jwt.NewNumericDate(now),
+			ExpiresAt: jwt.NewNumericDate(now.Add(magicLinkTTL)),
+			ID:        "aud-test-jti",
+		},
+		Email:         "op@example.com",
+		EmailVerified: true,
+		Role:          magicLinkRole,
+	}
+	tok, err := h.handoverSigner.SignCustomClaims(claims)
+	if err != nil {
+		t.Fatalf("SignCustomClaims: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/auth/magic?token="+tok, nil)
+	w := httptest.NewRecorder()
+	h.HandleMagicValidate(w, req)
+
+	if w.Code != http.StatusSeeOther {
+		t.Errorf("wrong aud: got %d want 303", w.Code)
+	}
+	loc := w.Header().Get("Location")
+	if !strings.Contains(loc, "invalid_audience") {
+		t.Errorf("Location should contain invalid_audience, got %q", loc)
+	}
+}
+
+// TestMagicValidate_KCTokenExchangeFailure tests that a Keycloak failure returns
+// a 401 error (not a redirect to login).
+func TestMagicValidate_KCTokenExchangeFailure(t *testing.T) {
+	h := magicValidateHandler(t)
+	h.openovaKC = &stubKeycloakClient{
+		impersonateErr: fmt.Errorf("token exchange denied by keycloak"),
+	}
+	tok := mintMagicToken(t, h, "op@example.com")
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/auth/magic?token="+tok, nil)
+	w := httptest.NewRecorder()
+	h.HandleMagicValidate(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("KC failure: got %d want 401", w.Code)
+	}
+	var body map[string]string
+	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if body["error"] != "keycloak error: token exchange" {
+		t.Errorf("error message: got %q", body["error"])
+	}
+}
+
+// TestMagicValidate_NoSignerReturns503 ensures that without a signer the
+// endpoint returns 503.
+func TestMagicValidate_NoSignerReturns503(t *testing.T) {
+	h := &Handler{
+		log:            slog.New(slog.NewTextHandler(io.Discard, nil)),
+		handoverSigner: nil,
+	}
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/auth/magic?token=sometoken", nil)
+	w := httptest.NewRecorder()
+	h.HandleMagicValidate(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("no signer: got %d want 401", w.Code)
+	}
+}
+
+// TestMagicValidate_UnknownUser ensures that a token with empty email/sub is
+// rejected before reaching KC.
+func TestMagicValidate_UnknownUser(t *testing.T) {
+	h := magicValidateHandler(t)
+
+	now := time.Now().UTC()
+	claims := magicLinkClaims{
+		RegisteredClaims: jwt.RegisteredClaims{
+			Issuer:    magicLinkIssuer,
+			Audience:  jwt.ClaimStrings{magicLinkAudience},
+			Subject:   "", // empty sub
+			IssuedAt:  jwt.NewNumericDate(now),
+			ExpiresAt: jwt.NewNumericDate(now.Add(magicLinkTTL)),
+			ID:        "empty-sub-jti",
+		},
+		Email:         "",   // empty email
+		EmailVerified: true,
+		Role:          magicLinkRole,
+	}
+	tok, err := h.handoverSigner.SignCustomClaims(claims)
+	if err != nil {
+		t.Fatalf("SignCustomClaims: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/auth/magic?token="+tok, nil)
+	w := httptest.NewRecorder()
+	h.HandleMagicValidate(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("empty sub/email: got %d want 401", w.Code)
+	}
+}
+
+// ─── helper ────────────────────────────────────────────────────────────────────
+
+// stubOpenovaKC is an alias for stubKeycloakClient to make tests self-documenting.
+type stubOpenovaKC = stubKeycloakClient
+
+// writeFile writes data to path. Simple wrapper around os.WriteFile.
+func writeFile(_ *testing.T, path string, data []byte, mode os.FileMode) error {
+	return os.WriteFile(path, data, mode)
+}
+
+// ─── overridden stubKeycloakClient for openova realm ─────────────────────────
+
+type openovaStubKC struct {
+	ensureUserID string
+	ensureErr    error
+	impAccess    string
+	impRefresh   string
+	impExpiry    int
+	impErr       error
+}
+
+func (s *openovaStubKC) EnsureUser(_ context.Context, _, _ string) (string, error) {
+	if s.ensureErr != nil {
+		return "", s.ensureErr
+	}
+	id := s.ensureUserID
+	if id == "" {
+		id = "openova-user-uuid"
+	}
+	return id, nil
+}
+
+func (s *openovaStubKC) ImpersonateToken(_ context.Context, _, _ string) (string, string, int, error) {
+	if s.impErr != nil {
+		return "", "", 0, s.impErr
+	}
+	access := s.impAccess
+	if access == "" {
+		access = "openova-access-token"
+	}
+	refresh := s.impRefresh
+	if refresh == "" {
+		refresh = "openova-refresh-token"
+	}
+	expiry := s.impExpiry
+	if expiry == 0 {
+		expiry = 3600
+	}
+	return access, refresh, expiry, nil
+}

--- a/products/catalyst/bootstrap/api/internal/handler/handler.go
+++ b/products/catalyst/bootstrap/api/internal/handler/handler.go
@@ -170,7 +170,7 @@ type Handler struct {
 	handoverSigner *handoverjwt.Signer
 
 	// ── /auth/handover fields (issue #606, Phase-8b Agent C) ─────────────────
-	// kc — Keycloak client for the /auth/handover endpoint.
+	// kc — Keycloak client for the /auth/handover endpoint (Sovereign realm).
 	kc keycloakClient
 	// jtiStore — single-use JTI store for /auth/handover replay protection.
 	jtiStore jtiStorer
@@ -182,6 +182,12 @@ type Handler struct {
 	kcAudience string
 	// authHandoverRedirect — post-handover redirect target. Defaults to "/console/dashboard".
 	authHandoverRedirect string
+
+	// ── /auth/magic-link fields (issue #614, Phase-8b Option B) ─────────────
+	// openovaKC — Keycloak client for the openova realm magic-link flow.
+	// Separate from kc (Sovereign realm) — different realm, different SA client.
+	// Nil when CATALYST_OPENOVA_KC_SA_CLIENT_SECRET is not set (Sovereign-side, CI).
+	openovaKC keycloakClient
 }
 
 // defaultDeploymentsDir is the on-PVC path the chart mounts. A separate
@@ -377,6 +383,10 @@ func (h *Handler) GetAuthConfig() *auth.Config { return h.authConfig }
 
 // SetAuthConfig wires an auth.Config into the Handler.
 func (h *Handler) SetAuthConfig(cfg *auth.Config) { h.authConfig = cfg }
+
+// SetOpenovaKC wires the openova-realm Keycloak client (Option-B magic-link).
+// Called by main.go at startup when CATALYST_OPENOVA_KC_SA_CLIENT_SECRET is set.
+func (h *Handler) SetOpenovaKC(kc keycloakClient) { h.openovaKC = kc }
 
 func writeJSON(w http.ResponseWriter, code int, v any) {
 	w.Header().Set("Content-Type", "application/json")

--- a/products/catalyst/bootstrap/api/internal/handoverjwt/signer.go
+++ b/products/catalyst/bootstrap/api/internal/handoverjwt/signer.go
@@ -269,6 +269,33 @@ func LoadOrGenerate(keyPath, pubKeyPath, issuer string, ttl time.Duration) (*Sig
 	return New(privPEM, issuer, ttl)
 }
 
+// SignCustomClaims signs an arbitrary jwt.Claims implementation using the
+// signer's RS256 private key. This is the extension point for the magic-link
+// Option-B flow (issue #614): the handler builds its own magicLinkClaims and
+// calls this method rather than MintToken (which is purpose-built for the
+// handover flow's fixed claim shape).
+//
+// Per docs/INVIOLABLE-PRINCIPLES.md #10 the private key is never returned or
+// logged by this package; the caller receives only the compact JWT string.
+func (s *Signer) SignCustomClaims(claims jwt.Claims) (string, error) {
+	token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	signed, err := token.SignedString(s.privateKey)
+	if err != nil {
+		return "", fmt.Errorf("handoverjwt: sign custom claims: %w", err)
+	}
+	return signed, nil
+}
+
+// PublicRSAKey returns the RSA public key for verifying tokens this Signer
+// has produced. Used by the magic-validate endpoint to verify the token without
+// requiring a separate public-key file read.
+func (s *Signer) PublicRSAKey() (*rsa.PublicKey, error) {
+	if s.privateKey == nil {
+		return nil, errors.New("handoverjwt: signer has no private key")
+	}
+	return &s.privateKey.PublicKey, nil
+}
+
 // dirOf returns the directory component of a file path.
 func dirOf(path string) string {
 	for i := len(path) - 1; i >= 0; i-- {

--- a/products/catalyst/bootstrap/ui/src/pages/auth/AuthCallbackPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/auth/AuthCallbackPage.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useState } from 'react'
 import { useSearch, useRouter } from '@tanstack/react-router'
-import { API_BASE } from '@/shared/config/urls'
 
 /**
  * AuthCallbackPage — handles the OIDC / Keycloak authorization_code callback.
@@ -137,39 +136,26 @@ function SovereignCallbackPage() {
   )
 }
 
-// ── Catalyst-Zero magic-link callback component ───────────────────────────
-
+// ── Catalyst-Zero callback component (Option B) ───────────────────────────
+//
+// Option B replaces the PKCE flow entirely with a server-side token-exchange.
+// The browser never visits this component in the normal flow:
+//   User clicks email link → browser hits GET /api/v1/auth/magic?token=...
+//   → catalyst-api validates JWT, calls KC token-exchange, sets cookies,
+//   → redirects directly to /sovereign/wizard (no client-side callback needed).
+//
+// This component only exists as a safety net in case Keycloak still has
+// /sovereign/auth/callback in its allowed redirect list and sends the user
+// here. In that case redirect to login so the user sees a clean screen.
 function CatalystZeroCallbackPage() {
   const search = useSearch({ strict: false }) as Record<string, string>
 
   useEffect(() => {
-    const code = search['code']
-    const state = search['state']
-    const error = search['error']
-
-    if (error) {
-      // Keycloak denied or the magic-link expired — redirect to login with
-      // an error indicator so the UI can surface the right copy.
-      window.location.replace(uiBase() + '/login?error=' + encodeURIComponent(error))
-      return
-    }
-
-    if (!code) {
-      // No code and no error — unexpected. Redirect to login.
-      window.location.replace(uiBase() + '/login?error=no_code')
-      return
-    }
-
-    // Build the server-side callback URL. The PKCE verifier cookie was set
-    // by the server when the operator submitted their email. Because this
-    // is a same-origin redirect (console.openova.io → /sovereign/api/v1/...)
-    // the cookie is carried automatically by the browser.
-    const callbackURL = new URL(`${API_BASE}/v1/auth/callback`, window.location.href)
-    callbackURL.searchParams.set('code', code)
-    if (state) callbackURL.searchParams.set('state', state)
-
-    // Hard navigation — must NOT use TanStack router redirect here.
-    window.location.replace(callbackURL.toString())
+    // Option B: the /auth/magic endpoint handles everything server-side.
+    // If we land here, it means the user followed a stale Keycloak link or
+    // the flow_changed redirect happened. Send them to login.
+    const error = search['error'] ?? 'flow_changed'
+    window.location.replace(uiBase() + '/login?error=' + encodeURIComponent(error))
   }, [search])
 
   // Render nothing — we navigate away immediately.

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: bp-catalyst-platform
-version: 1.2.0
-appVersion: 1.2.0
+version: 1.2.1
+appVersion: 1.2.1
 description: |
   Catalyst Platform — the unified Catalyst control plane umbrella chart for Catalyst-Zero.
   Composes the catalyst-{ui,api}, console, admin, marketplace UI modules and the marketplace-api backend.
@@ -124,6 +124,17 @@ description: |
   Catalyst-Zero, validate the one-time RS256 JWT, create/update the operator in
   Keycloak (sovereign realm), exchange for a user session via token-exchange,
   set HttpOnly session cookies, and redirect to /console/dashboard. 2026-05-02.
+
+  Bumped to 1.2.1 — Option-B pure passwordless magic-link (issue #614,
+  Phase-8b). Replaces Agent A's Keycloak execute-actions-email (PKCE) flow with
+  a fully server-side path:
+  - catalyst-api mints its own RS256 JWT (same signer keypair as Agent B)
+  - Sends link via Stalwart SMTP (noreply@openova.io)
+  - GET /api/v1/auth/magic validates JWT, single-use jti, KC token-exchange,
+    sets HttpOnly cookies, redirects to /sovereign/wizard
+  - ZERO Keycloak UI exposure, ZERO browser PKCE round-trip
+  Adds CATALYST_OPENOVA_KC_* env refs from new catalyst-openova-kc-credentials
+  Secret + CATALYST_SESSION_COOKIE_DOMAIN. 2026-05-02.
 type: application
 
 # Opt-out from the blueprint-release hollow-chart guard (issue #181 / #510).

--- a/products/catalyst/chart/templates/api-deployment.yaml
+++ b/products/catalyst/chart/templates/api-deployment.yaml
@@ -360,23 +360,81 @@ spec:
             # Per INVIOLABLE-PRINCIPLES #4: runtime configuration, not hardcoded.
             - name: CATALYST_POST_AUTH_REDIRECT
               value: /sovereign/wizard
-            # CATALYST_KC_ADMIN_USER / CATALYST_KC_ADMIN_PASS — Keycloak master
-            # realm admin credentials used by HandleMagicLink to call the Admin
-            # REST API (create user, execute-actions-email). On Catalyst-Zero the
-            # admin-cli password grant against the master realm is used.
-            # optional=true: Sovereign clusters don't call the Admin API.
-            - name: CATALYST_KC_ADMIN_USER
+            # ── Option-B magic-link: openova realm service account ───────────
+            # CATALYST_OPENOVA_KC_ADDR — Keycloak base URL for the openova realm.
+            # Defaults in code to keycloak-zero.keycloak-zero.svc (in-cluster
+            # on Catalyst-Zero). optional=true: Sovereign clusters don't run
+            # the openova realm.
+            - name: CATALYST_OPENOVA_KC_ADDR
               valueFrom:
                 secretKeyRef:
-                  name: catalyst-magic-link-credentials
-                  key: kc-admin-user
+                  name: catalyst-openova-kc-credentials
+                  key: kc-addr
                   optional: true
-            - name: CATALYST_KC_ADMIN_PASS
+            - name: CATALYST_OPENOVA_KC_REALM
               valueFrom:
                 secretKeyRef:
-                  name: catalyst-magic-link-credentials
-                  key: kc-admin-pass
+                  name: catalyst-openova-kc-credentials
+                  key: kc-realm
                   optional: true
+            - name: CATALYST_OPENOVA_KC_SA_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: catalyst-openova-kc-credentials
+                  key: kc-sa-client-id
+                  optional: true
+            - name: CATALYST_OPENOVA_KC_SA_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: catalyst-openova-kc-credentials
+                  key: kc-sa-client-secret
+                  optional: true
+            # CATALYST_OPENOVA_KC_AUDIENCE — OIDC audience for KC token-exchange.
+            # Defaults to "catalyst-zero-ui" in code. optional=true.
+            - name: CATALYST_OPENOVA_KC_AUDIENCE
+              valueFrom:
+                secretKeyRef:
+                  name: catalyst-openova-kc-credentials
+                  key: kc-audience
+                  optional: true
+            # CATALYST_SMTP_HOST / CATALYST_SMTP_PORT — Stalwart SMTP relay for
+            # magic-link email delivery. Defaults in code to
+            # stalwart-web.stalwart.svc.cluster.local:587. optional=true.
+            - name: CATALYST_SMTP_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: catalyst-openova-kc-credentials
+                  key: smtp-host
+                  optional: true
+            - name: CATALYST_SMTP_PORT
+              valueFrom:
+                secretKeyRef:
+                  name: catalyst-openova-kc-credentials
+                  key: smtp-port
+                  optional: true
+            - name: CATALYST_SMTP_USER
+              valueFrom:
+                secretKeyRef:
+                  name: catalyst-openova-kc-credentials
+                  key: smtp-user
+                  optional: true
+            - name: CATALYST_SMTP_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: catalyst-openova-kc-credentials
+                  key: smtp-pass
+                  optional: true
+            - name: CATALYST_SMTP_FROM
+              valueFrom:
+                secretKeyRef:
+                  name: catalyst-openova-kc-credentials
+                  key: smtp-from
+                  optional: true
+            # CATALYST_SESSION_COOKIE_DOMAIN — optional domain scoping for the
+            # catalyst_session + catalyst_refresh cookies. Set to console.openova.io
+            # so both /sovereign/wizard and /sovereign/auth/magic share the cookie jar.
+            - name: CATALYST_SESSION_COOKIE_DOMAIN
+              value: "console.openova.io"
           resources:
             requests:
               cpu: 50m

--- a/products/catalyst/chart/templates/api-deployment.yaml
+++ b/products/catalyst/chart/templates/api-deployment.yaml
@@ -137,7 +137,7 @@ spec:
             - name: PORT
               value: "8080"
             - name: CORS_ORIGIN
-              value: "https://catalyst.openova.io"
+              value: "https://console.openova.io"
             - name: DYNADOT_API_KEY
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
/auth/magic was 404 because the registered route is /api/v1/auth/magic.