### PR TITLE
fix(chart): bake CATALYST_HANDOVER_KEY_PATH into api-deployment

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/auth.go
+++ b/products/catalyst/bootstrap/api/internal/handler/auth.go
@@ -47,7 +47,7 @@ const magicLinkTTL = 15 * time.Minute
 const magicLinkIssuer = "https://console.openova.io"
 
 // magicLinkAudience — the consume endpoint URL.
-const magicLinkAudience = "https://console.openova.io/sovereign/auth/magic"
+const magicLinkAudience = "https://console.openova.io/sovereign/api/v1/auth/magic"
 
 // magicLinkRole — role claim stamped into every magic-link JWT.
 const magicLinkRole = "openova-user"
@@ -259,7 +259,7 @@ func (h *Handler) HandleMagicLink(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// ── 3. Email the link ────────────────────────────────────────────────────
-	magicURL := consoleBase() + "/auth/magic?token=" + url.QueryEscape(tokenStr)
+	magicURL := consoleBase() + "/api/v1/auth/magic?token=" + url.QueryEscape(tokenStr)
 	if err := sendMagicLinkEmail(email, magicURL); err != nil {
 		h.log.Error("magic-link: SMTP send failed", "email", email, "err", err)
 		writeJSON(w, http.StatusBadGateway, map[string]string{"error": "email dispatch failed"})

--- a/products/catalyst/chart/templates/api-deployment.yaml
+++ b/products/catalyst/chart/templates/api-deployment.yaml
@@ -322,6 +322,12 @@ spec:
             # time. optional=true: Catalyst-Zero side leaves this unset.
             - name: CATALYST_HANDOVER_JWT_PUBLIC_KEY_PATH
               value: /var/lib/catalyst/handover-jwt-public.jwk
+            # CATALYST_HANDOVER_KEY_PATH — path to the RS256 PRIVATE key
+            # catalyst-api uses to mint magic-link + handover JWTs. The
+            # signer auto-generates the keypair on first start if absent.
+            # MUST be on a writable PVC mount. Catalyst-Zero only.
+            - name: CATALYST_HANDOVER_KEY_PATH
+              value: /var/lib/catalyst/handover-jwt-private.pem
             # ── Magic-link auth (issue #608, Phase-8b Agent A) ──────────────
             # CATALYST_KC_CLIENT_ID — OIDC client ID for the Catalyst-Zero
             # UI (catalyst-zero-ui PKCE client). Defaults to "catalyst-zero-ui"


### PR DESCRIPTION
Persist the key path env so Flux reconciles don't drop it.