### PR TITLE
fix(catalyst-api): mint own session JWT — KC 24.7 dropped legacy token-exchange

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/auth.go
+++ b/products/catalyst/bootstrap/api/internal/handler/auth.go
@@ -405,28 +405,31 @@ func (h *Handler) HandleMagicValidate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// ── 4. Token-exchange with Keycloak ──────────────────────────────────────
-	kc := h.openovaKCClient()
-	if kc == nil {
-		writeMagicError(w, "server misconfiguration: keycloak not configured")
-		return
+	// ── 4. Mint session JWT (catalyst-api owns sessions; Keycloak only stores
+	// the user record, no token-exchange needed). RFC 8693 in Keycloak 24.7+
+	// removed legacy `requested_subject`, so server-side impersonation through
+	// KC is unavailable without a real user token. We sign our own session JWT
+	// with the same handover key.
+	sessionTTL := 8 * time.Hour
+	sessionClaims := jwt.MapClaims{
+		"iss":            magicLinkIssuer,
+		"sub":            claims.Subject,
+		"email":          claims.Email,
+		"email_verified": true,
+		"role":           magicLinkRole,
+		"iat":            time.Now().Unix(),
+		"exp":            time.Now().Add(sessionTTL).Unix(),
+		"jti":            uuid.NewString(),
+		"typ":            "session",
 	}
-
-	kcAudience := os.Getenv("CATALYST_OPENOVA_KC_AUDIENCE")
-	if kcAudience == "" {
-		kcAudience = "catalyst-zero-ui"
-	}
-
-	accessToken, refreshToken, expiresIn, err := kc.ImpersonateToken(r.Context(), claims.Subject, kcAudience)
+	accessToken, err := h.handoverSigner.SignCustomClaims(sessionClaims)
 	if err != nil {
-		h.log.Error("magic-validate: ImpersonateToken failed",
-			"userID", claims.Subject,
-			"email", claims.Email,
-			"err", err,
-		)
-		writeMagicError(w, "keycloak error: token exchange")
+		h.log.Error("magic-validate: SignCustomClaims failed", "err", err)
+		writeMagicError(w, "session signing failed")
 		return
 	}
+	refreshToken := ""
+	expiresIn := int(sessionTTL.Seconds())
 
 	// ── 5. Issue session cookies ─────────────────────────────────────────────
 	cookieMaxAge := expiresIn

--- a/products/catalyst/bootstrap/api/internal/handler/auth.go
+++ b/products/catalyst/bootstrap/api/internal/handler/auth.go
@@ -47,7 +47,7 @@ const magicLinkTTL = 15 * time.Minute
 const magicLinkIssuer = "https://console.openova.io"
 
 // magicLinkAudience — the consume endpoint URL.
-const magicLinkAudience = "https://console.openova.io/sovereign/auth/magic"
+const magicLinkAudience = "https://console.openova.io/sovereign/api/v1/auth/magic"
 
 // magicLinkRole — role claim stamped into every magic-link JWT.
 const magicLinkRole = "openova-user"
@@ -259,7 +259,7 @@ func (h *Handler) HandleMagicLink(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// ── 3. Email the link ────────────────────────────────────────────────────
-	magicURL := consoleBase() + "/auth/magic?token=" + url.QueryEscape(tokenStr)
+	magicURL := consoleBase() + "/api/v1/auth/magic?token=" + url.QueryEscape(tokenStr)
 	if err := sendMagicLinkEmail(email, magicURL); err != nil {
 		h.log.Error("magic-link: SMTP send failed", "email", email, "err", err)
 		writeJSON(w, http.StatusBadGateway, map[string]string{"error": "email dispatch failed"})

--- a/products/catalyst/chart/templates/api-deployment.yaml
+++ b/products/catalyst/chart/templates/api-deployment.yaml
@@ -322,6 +322,12 @@ spec:
             # time. optional=true: Catalyst-Zero side leaves this unset.
             - name: CATALYST_HANDOVER_JWT_PUBLIC_KEY_PATH
               value: /var/lib/catalyst/handover-jwt-public.jwk
+            # CATALYST_HANDOVER_KEY_PATH — path to the RS256 PRIVATE key
+            # catalyst-api uses to mint magic-link + handover JWTs. The
+            # signer auto-generates the keypair on first start if absent.
+            # MUST be on a writable PVC mount. Catalyst-Zero only.
+            - name: CATALYST_HANDOVER_KEY_PATH
+              value: /var/lib/catalyst/handover-jwt-private.pem
             # ── Magic-link auth (issue #608, Phase-8b Agent A) ──────────────
             # CATALYST_KC_CLIENT_ID — OIDC client ID for the Catalyst-Zero
             # UI (catalyst-zero-ui PKCE client). Defaults to "catalyst-zero-ui"


### PR DESCRIPTION
Self-signed session JWTs replace KC token-exchange.