### PR TITLE
fix(auth): accept self-signed session JWTs via LocalPublicKey fallback

### DIFF
--- a/products/catalyst/bootstrap/api/cmd/api/main.go
+++ b/products/catalyst/bootstrap/api/cmd/api/main.go
@@ -107,6 +107,14 @@ func main() {
 			CookieSecret: cookieSecret,
 			JWKSCache:    auth.NewJWKSCache(jwksURL, 10*time.Minute),
 		}
+		// Wire the handover signer's public key as a fallback for self-signed
+		// session JWTs (KC 24.7+ removed legacy token-exchange).
+		if signer := h.GetHandoverSigner(); signer != nil {
+			if pub, err := signer.PublicRSAKey(); err == nil {
+				authCfg.LocalPublicKey = pub
+				log.Info("auth: local public key wired into session validator")
+			}
+		}
 		h.SetAuthConfig(authCfg)
 		log.Info("auth: Keycloak session gate enabled",
 			"addr", kcAddr,

--- a/products/catalyst/bootstrap/api/internal/auth/session.go
+++ b/products/catalyst/bootstrap/api/internal/auth/session.go
@@ -51,6 +51,12 @@ type Config struct {
 	CookieSecret string
 	// JWKSCache caches the realm's public keys.
 	JWKSCache *JWKSCache
+	// LocalPublicKey is catalyst-api's own RS256 public key (handover signer).
+	// When ValidateToken can't find a matching kid in JWKS, it falls back to
+	// this key — this lets catalyst-api accept its own self-signed session
+	// JWTs (Keycloak 24.7+ removed legacy token-exchange so we can't get
+	// a Keycloak-signed user token without a real user session).
+	LocalPublicKey *rsa.PublicKey
 }
 
 // tokenURL returns the Keycloak token endpoint for the configured realm.
@@ -136,27 +142,41 @@ func (c *Config) ValidateToken(ctx context.Context, rawToken string) (*Claims, e
 		return nil, fmt.Errorf("auth: unsupported alg %s (expected RS256)", header.Alg)
 	}
 
-	// Fetch JWKS and find matching key
-	keys, err := c.JWKSCache.Keys(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("auth: fetch JWKS: %w", err)
-	}
-
-	var matchedKey *jwksEntry
-	for i := range keys {
-		if keys[i].Kid == header.Kid {
-			matchedKey = &keys[i]
-			break
+	// First try our own self-signed session JWTs (no kid header).
+	// These are minted by handler/auth.go HandleMagicValidate after a
+	// successful magic-link click. Always try local first for low latency
+	// and to avoid an unnecessary JWKS fetch on the hot path.
+	var pubKey *rsa.PublicKey
+	if c.LocalPublicKey != nil && header.Kid == "" {
+		pubKey = c.LocalPublicKey
+	} else {
+		// Fall back to Keycloak JWKS (Sovereign-side / legacy KC tokens).
+		keys, err := c.JWKSCache.Keys(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("auth: fetch JWKS: %w", err)
 		}
-	}
-	if matchedKey == nil {
-		return nil, fmt.Errorf("auth: no JWKS key for kid %q", header.Kid)
-	}
 
-	// Build RSA public key from JWK n+e
-	pubKey, err := jwkToRSAPublicKey(matchedKey)
-	if err != nil {
-		return nil, fmt.Errorf("auth: build RSA key from JWK: %w", err)
+		var matchedKey *jwksEntry
+		for i := range keys {
+			if keys[i].Kid == header.Kid {
+				matchedKey = &keys[i]
+				break
+			}
+		}
+		if matchedKey == nil {
+			// Last-resort fallback: try LocalPublicKey even if kid is set
+			// (some signers stamp a kid header).
+			if c.LocalPublicKey != nil {
+				pubKey = c.LocalPublicKey
+			} else {
+				return nil, fmt.Errorf("auth: no JWKS key for kid %q", header.Kid)
+			}
+		} else {
+			pubKey, err = jwkToRSAPublicKey(matchedKey)
+			if err != nil {
+				return nil, fmt.Errorf("auth: build RSA key from JWK: %w", err)
+			}
+		}
 	}
 
 	// Verify signature

--- a/products/catalyst/bootstrap/api/internal/handler/auth.go
+++ b/products/catalyst/bootstrap/api/internal/handler/auth.go
@@ -405,28 +405,31 @@ func (h *Handler) HandleMagicValidate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// ── 4. Token-exchange with Keycloak ──────────────────────────────────────
-	kc := h.openovaKCClient()
-	if kc == nil {
-		writeMagicError(w, "server misconfiguration: keycloak not configured")
-		return
+	// ── 4. Mint session JWT (catalyst-api owns sessions; Keycloak only stores
+	// the user record, no token-exchange needed). RFC 8693 in Keycloak 24.7+
+	// removed legacy `requested_subject`, so server-side impersonation through
+	// KC is unavailable without a real user token. We sign our own session JWT
+	// with the same handover key.
+	sessionTTL := 8 * time.Hour
+	sessionClaims := jwt.MapClaims{
+		"iss":            magicLinkIssuer,
+		"sub":            claims.Subject,
+		"email":          claims.Email,
+		"email_verified": true,
+		"role":           magicLinkRole,
+		"iat":            time.Now().Unix(),
+		"exp":            time.Now().Add(sessionTTL).Unix(),
+		"jti":            uuid.NewString(),
+		"typ":            "session",
 	}
-
-	kcAudience := os.Getenv("CATALYST_OPENOVA_KC_AUDIENCE")
-	if kcAudience == "" {
-		kcAudience = "catalyst-zero-ui"
-	}
-
-	accessToken, refreshToken, expiresIn, err := kc.ImpersonateToken(r.Context(), claims.Subject, kcAudience)
+	accessToken, err := h.handoverSigner.SignCustomClaims(sessionClaims)
 	if err != nil {
-		h.log.Error("magic-validate: ImpersonateToken failed",
-			"userID", claims.Subject,
-			"email", claims.Email,
-			"err", err,
-		)
-		writeMagicError(w, "keycloak error: token exchange")
+		h.log.Error("magic-validate: SignCustomClaims failed", "err", err)
+		writeMagicError(w, "session signing failed")
 		return
 	}
+	refreshToken := ""
+	expiresIn := int(sessionTTL.Seconds())
 
 	// ── 5. Issue session cookies ─────────────────────────────────────────────
 	cookieMaxAge := expiresIn

--- a/products/catalyst/bootstrap/api/internal/handler/auth.go
+++ b/products/catalyst/bootstrap/api/internal/handler/auth.go
@@ -47,7 +47,7 @@ const magicLinkTTL = 15 * time.Minute
 const magicLinkIssuer = "https://console.openova.io"
 
 // magicLinkAudience — the consume endpoint URL.
-const magicLinkAudience = "https://console.openova.io/sovereign/auth/magic"
+const magicLinkAudience = "https://console.openova.io/sovereign/api/v1/auth/magic"
 
 // magicLinkRole — role claim stamped into every magic-link JWT.
 const magicLinkRole = "openova-user"
@@ -259,7 +259,7 @@ func (h *Handler) HandleMagicLink(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// ── 3. Email the link ────────────────────────────────────────────────────
-	magicURL := consoleBase() + "/auth/magic?token=" + url.QueryEscape(tokenStr)
+	magicURL := consoleBase() + "/api/v1/auth/magic?token=" + url.QueryEscape(tokenStr)
 	if err := sendMagicLinkEmail(email, magicURL); err != nil {
 		h.log.Error("magic-link: SMTP send failed", "email", email, "err", err)
 		writeJSON(w, http.StatusBadGateway, map[string]string{"error": "email dispatch failed"})

--- a/products/catalyst/bootstrap/api/internal/handler/handler.go
+++ b/products/catalyst/bootstrap/api/internal/handler/handler.go
@@ -384,6 +384,11 @@ func (h *Handler) GetAuthConfig() *auth.Config { return h.authConfig }
 // SetAuthConfig wires an auth.Config into the Handler.
 func (h *Handler) SetAuthConfig(cfg *auth.Config) { h.authConfig = cfg }
 
+// GetHandoverSigner returns the wired handoverjwt.Signer (or nil if unset).
+// Used by main.go to wire the public key into auth.Config.LocalPublicKey
+// so the session middleware can validate self-signed session JWTs.
+func (h *Handler) GetHandoverSigner() *handoverjwt.Signer { return h.handoverSigner }
+
 // SetOpenovaKC wires the openova-realm Keycloak client (Option-B magic-link).
 // Called by main.go at startup when CATALYST_OPENOVA_KC_SA_CLIENT_SECRET is set.
 func (h *Handler) SetOpenovaKC(kc keycloakClient) { h.openovaKC = kc }

--- a/products/catalyst/chart/templates/api-deployment.yaml
+++ b/products/catalyst/chart/templates/api-deployment.yaml
@@ -322,6 +322,12 @@ spec:
             # time. optional=true: Catalyst-Zero side leaves this unset.
             - name: CATALYST_HANDOVER_JWT_PUBLIC_KEY_PATH
               value: /var/lib/catalyst/handover-jwt-public.jwk
+            # CATALYST_HANDOVER_KEY_PATH — path to the RS256 PRIVATE key
+            # catalyst-api uses to mint magic-link + handover JWTs. The
+            # signer auto-generates the keypair on first start if absent.
+            # MUST be on a writable PVC mount. Catalyst-Zero only.
+            - name: CATALYST_HANDOVER_KEY_PATH
+              value: /var/lib/catalyst/handover-jwt-private.pem
             # ── Magic-link auth (issue #608, Phase-8b Agent A) ──────────────
             # CATALYST_KC_CLIENT_ID — OIDC client ID for the Catalyst-Zero
             # UI (catalyst-zero-ui PKCE client). Defaults to "catalyst-zero-ui"


### PR DESCRIPTION
Unblocks magic-link end-to-end after KC 24.7 token-exchange removal.