### PR TITLE
fix(sme-services): de-templatize auth.yaml image (unblocks magic-link)

### DIFF
--- a/products/catalyst/chart/templates/sme-services/auth.yaml
+++ b/products/catalyst/chart/templates/sme-services/auth.yaml
@@ -19,7 +19,11 @@ spec:
         - name: ghcr-pull
       containers:
         - name: auth
-          image: "{{ if .Values.global.imageRegistry }}{{ .Values.global.imageRegistry }}{{ else }}{{ .Values.images.registry }}{{ end }}/{{ .Values.images.organization }}/services-auth:{{ .Values.images.smeTag }}"
+          # See marketplace.yaml: this directory is Kustomize-applied by the
+          # contabo-mkt Flux Kustomization (Sovereigns skip via .helmignore),
+          # so the image must be a concrete string. PR #580 templated it and
+          # pinned the new ReplicaSet at InvalidImageName since 2026-05-02.
+          image: ghcr.io/openova-io/openova/services-auth:046e5eb
           imagePullPolicy: Always
           ports:
             - containerPort: 8081


### PR DESCRIPTION
## Summary
- Hotfix on top of #633: auth.yaml had the same Helm-template-in-Kustomize bug PR #580 introduced. New ReplicaSet has been stuck on \`InvalidImageName\` since 2026-05-02, so the SMTP_PASS rotation (private \`aaf0229\`) couldn't reach the pod and magic-link sign-in returns 500 "failed to send email".
- De-templatizes the auth image to \`services-auth:046e5eb\` so Flux applies it cleanly and the new pod picks up the rotated env.

## Root cause chain
1. PR #580 templated 11 sme-services image refs with \`{{ .Values… }}\`.
2. The directory is Kustomize-applied (Sovereigns skip via \`.helmignore\`), so the templates aren't rendered — they land on the API as literal strings → \`InvalidImageName\` on every new ReplicaSet.
3. Old 046e5eb pods kept serving, but the env couldn't be refreshed.
4. Stalwart's \`noreply@openova.io\` cleartext secret had drifted from \`sme-secrets/SMTP_PASS\`. Rotating both sides + restart was the canonical fix — but step 4 needs the deployment template to render correctly first.

## Test plan
- [ ] Flux reconciles \`sme-services\` after merge.
- [ ] New auth pod rolls (concrete image, not InvalidImageName).
- [ ] AUTH PLAIN against stalwart-mail:587 returns 235 from inside the pod.
- [ ] POST omantel.openova.io/api/auth/magic-link returns 200 + email lands in inbox.

## Out of scope (follow-up)
The same fix applies to admin, billing, catalog, console, domain, gateway, notification, provisioning, tenant. None block the demo (their old ReplicaSets are still serving). Will batch them in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)