### PR TITLE
fix(infra): break tofu cycle — resolve CP public IP at boot via metadata service

### DIFF
--- a/infra/hetzner/cloudinit-control-plane.tftpl
+++ b/infra/hetzner/cloudinit-control-plane.tftpl
@@ -833,8 +833,13 @@ runcmd:
   # where catalyst-api is briefly unreachable (image roll, ingress
   # reconciliation) — the cloud-init runcmd budget is bounded by the
   # systemd cloud-final timeout (~30 minutes).
+  # control_plane_ipv4 resolved at runtime via Hetzner metadata service
+  # (rather than templated by Tofu — that would create a dependency cycle:
+  # cloud-init → control_plane.ipv4_address → control_plane.user_data → cloud-init).
+  # 169.254.169.254 is the standard cloud metadata endpoint; Hetzner exposes
+  # public-ipv4 at /hetzner/v1/metadata/public-ipv4 — single line, no auth.
   - install -m 0600 /dev/null /etc/rancher/k3s/k3s.yaml.public
-  - sed 's|https://127.0.0.1:6443|https://${control_plane_ipv4}:6443|g' /etc/rancher/k3s/k3s.yaml > /etc/rancher/k3s/k3s.yaml.public
+  - 'CP_PUBLIC_IPV4=$(curl -fsSL --retry 30 --retry-delay 2 http://169.254.169.254/hetzner/v1/metadata/public-ipv4) && sed "s|https://127.0.0.1:6443|https://$${CP_PUBLIC_IPV4}:6443|g" /etc/rancher/k3s/k3s.yaml > /etc/rancher/k3s/k3s.yaml.public'
   - chmod 0600 /etc/rancher/k3s/k3s.yaml.public
   - |
     curl -fsSL --retry 60 --retry-delay 10 --retry-all-errors \

--- a/infra/hetzner/main.tf
+++ b/infra/hetzner/main.tf
@@ -243,7 +243,10 @@ locals {
     kubeconfig_bearer_token = var.kubeconfig_bearer_token
     catalyst_api_url        = var.catalyst_api_url
     load_balancer_ipv4      = hcloud_load_balancer.main.ipv4
-    control_plane_ipv4      = hcloud_server.control_plane[0].ipv4_address
+    # control_plane_ipv4 is NOT templated — it would create a dependency cycle
+    # (cloud-init → control_plane.ipv4_address → control_plane.user_data → cloud-init).
+    # The cloud-init runs ON the CP node, so it resolves its own public IP at boot
+    # via Hetzner metadata service (169.254.169.254) — see cloudinit-control-plane.tftpl.
   }), "/(?m)^[ ]{0,2}# .*\n/", "")
 
   worker_cloud_init = replace(templatefile("${path.module}/cloudinit-worker.tftpl", {


### PR DESCRIPTION
## Summary
- PR #546 introduced a dependency cycle in the OpenTofu module:
  `hcloud_server.control_plane.user_data` → `local.control_plane_cloud_init` → `hcloud_server.control_plane[0].ipv4_address` → cycle.
- `tofu plan` failed live during the **otech23 first-end-to-end provisioning attempt** with `Error: Cycle: local.control_plane_cloud_init (expand), hcloud_server.control_plane`.
- Fix: stop templating `control_plane_ipv4` at plan time. cloud-init resolves its own public IPv4 at boot via Hetzner metadata: `curl http://169.254.169.254/hetzner/v1/metadata/public-ipv4`. Preserves the #546 fix (kubeconfig points at CP public IP, not LB IP) without the graph cycle.

## Test plan
- [x] Live E2E: otech23 wizard launch reproduced the cycle
- [ ] After merge + image roll: re-launch otech23, watch `tofu plan` succeed and `tofu apply` provision the Hetzner CPX32 + LB
- [ ] Verify CP boots, k3s self-installs, kubeconfig PUTs back to catalyst-api with `server: https://<CP-public-IP>:6443`
- [ ] Wizard jobs page transitions out of PENDING when bootstrap completes