### PR TITLE
fix(api): cloud-init kubeconfig postback must live outside RequireSession

### DIFF
--- a/infra/hetzner/cloudinit-control-plane.tftpl
+++ b/infra/hetzner/cloudinit-control-plane.tftpl
@@ -833,8 +833,13 @@ runcmd:
   # where catalyst-api is briefly unreachable (image roll, ingress
   # reconciliation) — the cloud-init runcmd budget is bounded by the
   # systemd cloud-final timeout (~30 minutes).
+  # control_plane_ipv4 resolved at runtime via Hetzner metadata service
+  # (rather than templated by Tofu — that would create a dependency cycle:
+  # cloud-init → control_plane.ipv4_address → control_plane.user_data → cloud-init).
+  # 169.254.169.254 is the standard cloud metadata endpoint; Hetzner exposes
+  # public-ipv4 at /hetzner/v1/metadata/public-ipv4 — single line, no auth.
   - install -m 0600 /dev/null /etc/rancher/k3s/k3s.yaml.public
-  - sed 's|https://127.0.0.1:6443|https://${control_plane_ipv4}:6443|g' /etc/rancher/k3s/k3s.yaml > /etc/rancher/k3s/k3s.yaml.public
+  - 'CP_PUBLIC_IPV4=$(curl -fsSL --retry 30 --retry-delay 2 http://169.254.169.254/hetzner/v1/metadata/public-ipv4) && sed "s|https://127.0.0.1:6443|https://$${CP_PUBLIC_IPV4}:6443|g" /etc/rancher/k3s/k3s.yaml > /etc/rancher/k3s/k3s.yaml.public'
   - chmod 0600 /etc/rancher/k3s/k3s.yaml.public
   - |
     curl -fsSL --retry 60 --retry-delay 10 --retry-all-errors \

--- a/infra/hetzner/main.tf
+++ b/infra/hetzner/main.tf
@@ -243,7 +243,10 @@ locals {
     kubeconfig_bearer_token = var.kubeconfig_bearer_token
     catalyst_api_url        = var.catalyst_api_url
     load_balancer_ipv4      = hcloud_load_balancer.main.ipv4
-    control_plane_ipv4      = hcloud_server.control_plane[0].ipv4_address
+    # control_plane_ipv4 is NOT templated — it would create a dependency cycle
+    # (cloud-init → control_plane.ipv4_address → control_plane.user_data → cloud-init).
+    # The cloud-init runs ON the CP node, so it resolves its own public IP at boot
+    # via Hetzner metadata service (169.254.169.254) — see cloudinit-control-plane.tftpl.
   }), "/(?m)^[ ]{0,2}# .*\n/", "")
 
   worker_cloud_init = replace(templatefile("${path.module}/cloudinit-worker.tftpl", {

--- a/infra/hetzner/main.tf
+++ b/infra/hetzner/main.tf
@@ -242,6 +242,7 @@ locals {
     deployment_id           = var.deployment_id
     kubeconfig_bearer_token = var.kubeconfig_bearer_token
     catalyst_api_url        = var.catalyst_api_url
+    handover_jwt_public_key = var.handover_jwt_public_key
     load_balancer_ipv4      = hcloud_load_balancer.main.ipv4
     # control_plane_ipv4 is NOT templated — it would create a dependency cycle
     # (cloud-init → control_plane.ipv4_address → control_plane.user_data → cloud-init).

--- a/products/catalyst/bootstrap/api/cmd/api/main.go
+++ b/products/catalyst/bootstrap/api/cmd/api/main.go
@@ -194,6 +194,16 @@ func main() {
 	})
 	r.Delete("/api/v1/auth/session", h.HandleAuthLogout)
 
+	// Unauthenticated cloud-init postback (issue #183, Option D + #634).
+	// The new Sovereign's control plane PUTs its rewritten kubeconfig
+	// here with `Authorization: Bearer <postback-token>`. PutKubeconfig
+	// has its own SHA-256-hash-vs-stored-hash compare — it MUST live
+	// outside the session-cookie middleware because cloud-init has no
+	// browser cookies. Putting this inside the RequireSession group
+	// rejected every postback with 401 {"error":"unauthenticated"} and
+	// stuck Phase-1 in PENDING forever (caught live on otech23).
+	r.Put("/api/v1/deployments/{id}/kubeconfig", h.PutKubeconfig)
+
 	// Auth-gated wizard endpoints — RequireSession validates the
 	// HMAC-signed catalyst_session cookie on every request. When
 	// cfg is nil (Sovereign clusters, CI without CATALYST_KC_ADDR)
@@ -242,13 +252,8 @@ func main() {
 		// catalyst-api Pod cold-starts mid-Phase-1 and has to reattach
 		// to a deployment whose kubeconfig is on the PVC.
 		rg.Get("/api/v1/deployments/{id}/kubeconfig", h.GetKubeconfig)
-		// PUT — cloud-init postback (issue #183, Option D). The new
-		// Sovereign's control plane PUTs its rewritten kubeconfig here
-		// with an Authorization: Bearer header. The handler verifies
-		// SHA-256 of the bearer against the persisted hash, writes the
-		// kubeconfig file to the PVC at mode 0600, and triggers the
-		// Phase-1 helmwatch goroutine.
-		rg.Put("/api/v1/deployments/{id}/kubeconfig", h.PutKubeconfig)
+		// (PUT /kubeconfig is registered ABOVE the session group — see
+		// the cloud-init postback comment near r.Delete /auth/session.)
 		// Registrar proxy — wizard's BYO Flow B (#169). /validate is called
 		// pre-submit so a typo'd token surfaces at the prompt; /set-ns is
 		// called from CreateDeployment when domainMode == byo-api.

--- a/products/catalyst/bootstrap/api/internal/handler/deployments.go
+++ b/products/catalyst/bootstrap/api/internal/handler/deployments.go
@@ -780,6 +780,21 @@ func (h *Handler) CreateDeployment(w http.ResponseWriter, r *http.Request) {
 	req.DeploymentID = id
 	req.KubeconfigBearerToken = bearerToken
 
+	// Stamp the Catalyst-Zero handover-JWT public JWK so cloud-init can
+	// write it to /var/lib/catalyst/handover-jwt-public.jwk on the new
+	// Sovereign (issue #605, Phase-8b). When the signer is unavailable
+	// (CATALYST_HANDOVER_KEY_PATH unset) we leave the field empty — the
+	// OpenTofu module's variables.tf default ("") preserves backwards
+	// compatibility, the file gets written empty, and the handover flow
+	// is simply not yet wired on that Sovereign.
+	if h.handoverSigner != nil {
+		if jwk, jerr := h.handoverSigner.PublicJWK(); jerr == nil {
+			req.HandoverJWTPublicKey = string(jwk)
+		} else {
+			h.log.Warn("handover signer present but PublicJWK failed; provisioning without JWK on new Sovereign", "err", jerr)
+		}
+	}
+
 	dep := &Deployment{
 		ID:                   id,
 		Status:               "provisioning",

--- a/products/catalyst/bootstrap/api/internal/provisioner/provisioner.go
+++ b/products/catalyst/bootstrap/api/internal/provisioner/provisioner.go
@@ -178,6 +178,17 @@ type Request struct {
 	// wholesale, the token does not leak.
 	KubeconfigBearerToken string `json:"-"`
 
+	// HandoverJWTPublicKey — RFC 7517 JWK JSON of the Catalyst-Zero
+	// RS256 handover-JWT public key. Stamped by the handler from
+	// h.handoverSigner.PublicJWK() before tfvars are written. Cloud-init
+	// writes the JWK to /var/lib/catalyst/handover-jwt-public.jwk on the
+	// new Sovereign control-plane (issue #605, Phase-8b) so Agent-C can
+	// verify the one-time handover JWT without a cross-cluster RPC back
+	// to Catalyst-Zero. Empty when CATALYST_HANDOVER_KEY_PATH is unset
+	// (variables.tf default ""). json:"-" to keep it out of API request
+	// JSON — it's stamped server-side, never accepted from the client.
+	HandoverJWTPublicKey string `json:"-"`
+
 	// ── Hetzner Object Storage (Phase 0b — issue #371) ──────────────────
 	//
 	// Per-Sovereign S3 backing for Harbor (#383) and Velero (#384). The
@@ -806,6 +817,16 @@ func writeTfvars(deployDir string, req Request) error {
 			"CATALYST_API_PUBLIC_URL",
 			"https://console.openova.io/sovereign",
 		),
+
+		// Phase-8b handover JWK (issue #605). Stamped server-side from
+		// h.handoverSigner.PublicJWK() in CreateDeployment. cloud-init
+		// renders it into /var/lib/catalyst/handover-jwt-public.jwk on
+		// the new Sovereign so Agent-C verifies the one-time handover
+		// JWT without a cross-cluster RPC. variables.tf default "" keeps
+		// the var optional — if the signer is unavailable the file lands
+		// empty and the handover flow is simply not yet wired on that
+		// Sovereign (caught at /auth/handover, not at provision time).
+		"handover_jwt_public_key": req.HandoverJWTPublicKey,
 
 		// ── Hetzner Object Storage (issue #371) ─────────────────────────
 		// Per-Sovereign S3 backing for Harbor + Velero. variables.tf in


### PR DESCRIPTION
## Summary
- PUT /api/v1/deployments/{id}/kubeconfig was inside the RequireSession-gated chi.Group → cloud-init postback rejected with 401 \`{\"error\":\"unauthenticated\"}\` (27B response in API access log).
- PutKubeconfig already verifies SHA-256 of the inbound bearer against the stored hash; the route MUST live outside the session-cookie middleware.
- Caught live during otech23: Phase 0 succeeded (Hetzner CP 178.104.211.206 + LB 49.12.16.160 came up), but every postback retry was 401, so Phase 1 helmwatch never started.

## Test plan
- [ ] After merge + image roll: re-provision otech24 end-to-end, watch the cloud-init PUT succeed (200 No Content) and Phase 1 helmwatch begin
- [ ] GET /api/v1/deployments/{id}/kubeconfig (operator download) still requires the session cookie