### PR TITLE
fix(wizard): SOLO default CPX32 → CPX42 (4→8 vCPU)

### DIFF
--- a/clusters/_template/bootstrap-kit/29-vpa.yaml
+++ b/clusters/_template/bootstrap-kit/29-vpa.yaml
@@ -48,7 +48,7 @@ spec:
   chart:
     spec:
       chart: bp-vpa
-      version: 1.0.0
+      version: 1.0.1
       sourceRef:
         kind: HelmRepository
         name: bp-vpa

--- a/infra/hetzner/cloudinit-control-plane.tftpl
+++ b/infra/hetzner/cloudinit-control-plane.tftpl
@@ -833,8 +833,13 @@ runcmd:
   # where catalyst-api is briefly unreachable (image roll, ingress
   # reconciliation) — the cloud-init runcmd budget is bounded by the
   # systemd cloud-final timeout (~30 minutes).
+  # control_plane_ipv4 resolved at runtime via Hetzner metadata service
+  # (rather than templated by Tofu — that would create a dependency cycle:
+  # cloud-init → control_plane.ipv4_address → control_plane.user_data → cloud-init).
+  # 169.254.169.254 is the standard cloud metadata endpoint; Hetzner exposes
+  # public-ipv4 at /hetzner/v1/metadata/public-ipv4 — single line, no auth.
   - install -m 0600 /dev/null /etc/rancher/k3s/k3s.yaml.public
-  - sed 's|https://127.0.0.1:6443|https://${control_plane_ipv4}:6443|g' /etc/rancher/k3s/k3s.yaml > /etc/rancher/k3s/k3s.yaml.public
+  - 'CP_PUBLIC_IPV4=$(curl -fsSL --retry 30 --retry-delay 2 http://169.254.169.254/hetzner/v1/metadata/public-ipv4) && sed "s|https://127.0.0.1:6443|https://$${CP_PUBLIC_IPV4}:6443|g" /etc/rancher/k3s/k3s.yaml > /etc/rancher/k3s/k3s.yaml.public'
   - chmod 0600 /etc/rancher/k3s/k3s.yaml.public
   - |
     curl -fsSL --retry 60 --retry-delay 10 --retry-all-errors \

--- a/infra/hetzner/cloudinit-control-plane.tftpl
+++ b/infra/hetzner/cloudinit-control-plane.tftpl
@@ -520,22 +520,48 @@ write_files:
   - path: /etc/rancher/k3s/registries.yaml
     permissions: '0600'
     content: |
+      # Harbor proxy-cache projects use the URL form
+      #   https://harbor.openova.io/v2/<project>/<image>/manifests/<tag>
+      # NOT
+      #   https://harbor.openova.io/<project>/v2/<image>/manifests/<tag>
+      # which is what containerd would naively build from
+      # `endpoint: ["https://harbor.openova.io/<project>"]`.
+      # Harbor returns its UI HTML (status 200, content-type text/html)
+      # for the wrong-shape URL — containerd then surfaces:
+      #   "unexpected media type text/html for sha256:..."
+      # and cilium / coredns / pause-image pulls all fail forever.
+      #
+      # k3s registries.yaml supports a per-mirror `rewrite` map:
+      # containerd builds `<endpoint>/v2/<repo>/...` (host-only endpoint),
+      # then rewrite() transforms the repo path before the request goes out.
+      # Mapping `(.*)` → `proxy-<flavor>/$1` produces the correct
+      # Harbor-project-prefixed path. Diagnosed live during otech25.
       mirrors:
         "docker.io":
           endpoint:
-            - "https://harbor.openova.io/proxy-dockerhub"
+            - "https://harbor.openova.io"
+          rewrite:
+            "(.*)": "proxy-dockerhub/$1"
         "quay.io":
           endpoint:
-            - "https://harbor.openova.io/proxy-quay"
+            - "https://harbor.openova.io"
+          rewrite:
+            "(.*)": "proxy-quay/$1"
         "gcr.io":
           endpoint:
-            - "https://harbor.openova.io/proxy-gcr"
+            - "https://harbor.openova.io"
+          rewrite:
+            "(.*)": "proxy-gcr/$1"
         "registry.k8s.io":
           endpoint:
-            - "https://harbor.openova.io/proxy-k8s"
+            - "https://harbor.openova.io"
+          rewrite:
+            "(.*)": "proxy-k8s/$1"
         "ghcr.io":
           endpoint:
-            - "https://harbor.openova.io/proxy-ghcr"
+            - "https://harbor.openova.io"
+          rewrite:
+            "(.*)": "proxy-ghcr/$1"
       configs:
         "harbor.openova.io":
           auth:

--- a/infra/hetzner/main.tf
+++ b/infra/hetzner/main.tf
@@ -243,7 +243,10 @@ locals {
     kubeconfig_bearer_token = var.kubeconfig_bearer_token
     catalyst_api_url        = var.catalyst_api_url
     load_balancer_ipv4      = hcloud_load_balancer.main.ipv4
-    control_plane_ipv4      = hcloud_server.control_plane[0].ipv4_address
+    # control_plane_ipv4 is NOT templated — it would create a dependency cycle
+    # (cloud-init → control_plane.ipv4_address → control_plane.user_data → cloud-init).
+    # The cloud-init runs ON the CP node, so it resolves its own public IP at boot
+    # via Hetzner metadata service (169.254.169.254) — see cloudinit-control-plane.tftpl.
   }), "/(?m)^[ ]{0,2}# .*\n/", "")
 
   worker_cloud_init = replace(templatefile("${path.module}/cloudinit-worker.tftpl", {

--- a/infra/hetzner/main.tf
+++ b/infra/hetzner/main.tf
@@ -242,6 +242,7 @@ locals {
     deployment_id           = var.deployment_id
     kubeconfig_bearer_token = var.kubeconfig_bearer_token
     catalyst_api_url        = var.catalyst_api_url
+    handover_jwt_public_key = var.handover_jwt_public_key
     load_balancer_ipv4      = hcloud_load_balancer.main.ipv4
     # control_plane_ipv4 is NOT templated — it would create a dependency cycle
     # (cloud-init → control_plane.ipv4_address → control_plane.user_data → cloud-init).

--- a/platform/vpa/chart/Chart.yaml
+++ b/platform/vpa/chart/Chart.yaml
@@ -17,7 +17,7 @@ description: |
   (recommend only) — SREs opt individual workloads into `Auto` via
   VerticalPodAutoscaler CRs.
 type: application
-version: 1.0.0
+version: 1.0.1
 appVersion: "1.5.0"
 keywords: [catalyst, blueprint, vpa, autoscaling, vertical-pod-autoscaler, right-sizing]
 maintainers:

--- a/platform/vpa/chart/values.yaml
+++ b/platform/vpa/chart/values.yaml
@@ -24,7 +24,13 @@ vertical-pod-autoscaler:
     enabled: true
     replicaCount: 1
     image:
-      repository: registry.k8s.io/autoscaling/vpa-recommender
+      # Upstream cowboysysop chart prepends `.image.registry` (default
+      # registry.k8s.io) to `.image.repository`, so we MUST NOT include
+      # the registry hostname in repository — the rendered image would
+      # be `registry.k8s.io/registry.k8s.io/autoscaling/...` (doubled
+      # prefix) and pulls fail with "image not found" (caught live on
+      # otech26).
+      repository: autoscaling/vpa-recommender
       tag: "1.5.0"
       pullPolicy: IfNotPresent
     resources:
@@ -53,7 +59,7 @@ vertical-pod-autoscaler:
     enabled: true
     replicaCount: 1
     image:
-      repository: registry.k8s.io/autoscaling/vpa-updater
+      repository: autoscaling/vpa-updater
       tag: "1.5.0"
       pullPolicy: IfNotPresent
     resources:
@@ -75,7 +81,7 @@ vertical-pod-autoscaler:
     enabled: true
     replicaCount: 1
     image:
-      repository: registry.k8s.io/autoscaling/vpa-admission-controller
+      repository: autoscaling/vpa-admission-controller
       tag: "1.5.0"
       pullPolicy: IfNotPresent
     resources:

--- a/products/catalyst/bootstrap/api/cmd/api/main.go
+++ b/products/catalyst/bootstrap/api/cmd/api/main.go
@@ -194,6 +194,16 @@ func main() {
 	})
 	r.Delete("/api/v1/auth/session", h.HandleAuthLogout)
 
+	// Unauthenticated cloud-init postback (issue #183, Option D + #634).
+	// The new Sovereign's control plane PUTs its rewritten kubeconfig
+	// here with `Authorization: Bearer <postback-token>`. PutKubeconfig
+	// has its own SHA-256-hash-vs-stored-hash compare — it MUST live
+	// outside the session-cookie middleware because cloud-init has no
+	// browser cookies. Putting this inside the RequireSession group
+	// rejected every postback with 401 {"error":"unauthenticated"} and
+	// stuck Phase-1 in PENDING forever (caught live on otech23).
+	r.Put("/api/v1/deployments/{id}/kubeconfig", h.PutKubeconfig)
+
 	// Auth-gated wizard endpoints — RequireSession validates the
 	// HMAC-signed catalyst_session cookie on every request. When
 	// cfg is nil (Sovereign clusters, CI without CATALYST_KC_ADDR)
@@ -242,13 +252,8 @@ func main() {
 		// catalyst-api Pod cold-starts mid-Phase-1 and has to reattach
 		// to a deployment whose kubeconfig is on the PVC.
 		rg.Get("/api/v1/deployments/{id}/kubeconfig", h.GetKubeconfig)
-		// PUT — cloud-init postback (issue #183, Option D). The new
-		// Sovereign's control plane PUTs its rewritten kubeconfig here
-		// with an Authorization: Bearer header. The handler verifies
-		// SHA-256 of the bearer against the persisted hash, writes the
-		// kubeconfig file to the PVC at mode 0600, and triggers the
-		// Phase-1 helmwatch goroutine.
-		rg.Put("/api/v1/deployments/{id}/kubeconfig", h.PutKubeconfig)
+		// (PUT /kubeconfig is registered ABOVE the session group — see
+		// the cloud-init postback comment near r.Delete /auth/session.)
 		// Registrar proxy — wizard's BYO Flow B (#169). /validate is called
 		// pre-submit so a typo'd token surfaces at the prompt; /set-ns is
 		// called from CreateDeployment when domainMode == byo-api.

--- a/products/catalyst/bootstrap/api/internal/handler/deployments.go
+++ b/products/catalyst/bootstrap/api/internal/handler/deployments.go
@@ -733,6 +733,16 @@ func (h *Handler) CreateDeployment(w http.ResponseWriter, r *http.Request) {
 	if tok := os.Getenv("CATALYST_GHCR_PULL_TOKEN"); tok != "" {
 		req.GHCRPullToken = tok
 	}
+	// Same fail-fast pattern for the Harbor proxy-cache robot token
+	// (issue #557). Empty token here = Validate() rejects the deployment
+	// at /api/v1/deployments POST, which is the right time to surface
+	// the missing CATALYST_HARBOR_ROBOT_TOKEN env var on the catalyst-
+	// api Pod. Falling through to docker.io is forbidden architecturally;
+	// the alternative is 5+ min of `tofu apply` followed by a stuck CP
+	// at Init:0/6 (caught live during otech24).
+	if tok := os.Getenv("CATALYST_HARBOR_ROBOT_TOKEN"); tok != "" {
+		req.HarborRobotToken = tok
+	}
 
 	// Derive the per-Sovereign Object Storage bucket name (issue #371).
 	// Hetzner Object Storage bucket names share a global namespace across

--- a/products/catalyst/bootstrap/api/internal/handler/deployments.go
+++ b/products/catalyst/bootstrap/api/internal/handler/deployments.go
@@ -780,6 +780,21 @@ func (h *Handler) CreateDeployment(w http.ResponseWriter, r *http.Request) {
 	req.DeploymentID = id
 	req.KubeconfigBearerToken = bearerToken
 
+	// Stamp the Catalyst-Zero handover-JWT public JWK so cloud-init can
+	// write it to /var/lib/catalyst/handover-jwt-public.jwk on the new
+	// Sovereign (issue #605, Phase-8b). When the signer is unavailable
+	// (CATALYST_HANDOVER_KEY_PATH unset) we leave the field empty — the
+	// OpenTofu module's variables.tf default ("") preserves backwards
+	// compatibility, the file gets written empty, and the handover flow
+	// is simply not yet wired on that Sovereign.
+	if h.handoverSigner != nil {
+		if jwk, jerr := h.handoverSigner.PublicJWK(); jerr == nil {
+			req.HandoverJWTPublicKey = string(jwk)
+		} else {
+			h.log.Warn("handover signer present but PublicJWK failed; provisioning without JWK on new Sovereign", "err", jerr)
+		}
+	}
+
 	dep := &Deployment{
 		ID:                   id,
 		Status:               "provisioning",

--- a/products/catalyst/bootstrap/api/internal/provisioner/provisioner.go
+++ b/products/catalyst/bootstrap/api/internal/provisioner/provisioner.go
@@ -178,6 +178,17 @@ type Request struct {
 	// wholesale, the token does not leak.
 	KubeconfigBearerToken string `json:"-"`
 
+	// HandoverJWTPublicKey — RFC 7517 JWK JSON of the Catalyst-Zero
+	// RS256 handover-JWT public key. Stamped by the handler from
+	// h.handoverSigner.PublicJWK() before tfvars are written. Cloud-init
+	// writes the JWK to /var/lib/catalyst/handover-jwt-public.jwk on the
+	// new Sovereign control-plane (issue #605, Phase-8b) so Agent-C can
+	// verify the one-time handover JWT without a cross-cluster RPC back
+	// to Catalyst-Zero. Empty when CATALYST_HANDOVER_KEY_PATH is unset
+	// (variables.tf default ""). json:"-" to keep it out of API request
+	// JSON — it's stamped server-side, never accepted from the client.
+	HandoverJWTPublicKey string `json:"-"`
+
 	// ── Hetzner Object Storage (Phase 0b — issue #371) ──────────────────
 	//
 	// Per-Sovereign S3 backing for Harbor (#383) and Velero (#384). The
@@ -806,6 +817,16 @@ func writeTfvars(deployDir string, req Request) error {
 			"CATALYST_API_PUBLIC_URL",
 			"https://console.openova.io/sovereign",
 		),
+
+		// Phase-8b handover JWK (issue #605). Stamped server-side from
+		// h.handoverSigner.PublicJWK() in CreateDeployment. cloud-init
+		// renders it into /var/lib/catalyst/handover-jwt-public.jwk on
+		// the new Sovereign so Agent-C verifies the one-time handover
+		// JWT without a cross-cluster RPC. variables.tf default "" keeps
+		// the var optional — if the signer is unavailable the file lands
+		// empty and the handover flow is simply not yet wired on that
+		// Sovereign (caught at /auth/handover, not at provision time).
+		"handover_jwt_public_key": req.HandoverJWTPublicKey,
 
 		// ── Hetzner Object Storage (issue #371) ─────────────────────────
 		// Per-Sovereign S3 backing for Harbor + Velero. variables.tf in

--- a/products/catalyst/bootstrap/api/internal/provisioner/provisioner.go
+++ b/products/catalyst/bootstrap/api/internal/provisioner/provisioner.go
@@ -147,6 +147,18 @@ type Request struct {
 	// 0o600.
 	GHCRPullToken string `json:"-"`
 
+	// HarborRobotToken — central Harbor proxy-cache robot account secret
+	// (issue #557). Stamped server-side from Provisioner.HarborRobotToken
+	// (env CATALYST_HARBOR_ROBOT_TOKEN). Interpolated by
+	// cloudinit-control-plane.tftpl into /etc/rancher/k3s/registries.yaml
+	// so containerd authenticates against harbor.openova.io's proxy
+	// projects (proxy-dockerhub, proxy-gcr, proxy-quay, proxy-k8s,
+	// proxy-ghcr) on every image pull. Without this, containerd falls
+	// through to the upstream registry on a fresh Hetzner IP — Docker Hub
+	// returns rate-limit HTML and pods stick at Init:0/6 (caught live
+	// during otech24). json:"-" — never accepted from the wizard payload.
+	HarborRobotToken string `json:"-"`
+
 	// DeploymentID — catalyst-api's per-deployment identifier (16-char
 	// hex). Stamped onto the Request by the handler before tfvars are
 	// emitted so the OpenTofu cloud-init template can render the URL
@@ -312,6 +324,20 @@ func (r *Request) Validate() error {
 	// of `tofu apply`.
 	if r.SovereignDomainMode == "pool" && strings.TrimSpace(r.GHCRPullToken) == "" {
 		return errors.New("GHCR pull token is required for managed-pool deployments (CATALYST_GHCR_PULL_TOKEN missing on catalyst-api — see docs/SECRET-ROTATION.md)")
+	}
+	// Harbor robot token (issue #557) — REQUIRED, no exceptions. The
+	// architecture mandate is that every Sovereign image pull goes
+	// through harbor.openova.io's proxy projects (proxy-dockerhub,
+	// proxy-gcr, proxy-quay, proxy-k8s, proxy-ghcr). An empty token
+	// means containerd will fail authentication against Harbor and
+	// fall through to upstream registries — Docker Hub then
+	// rate-limits a fresh Hetzner IP and pods stick at Init:0/6
+	// forever (caught live during otech24). Fail fast at /api/v1/
+	// deployments POST so a misconfigured catalyst-api Pod surfaces
+	// the missing CATALYST_HARBOR_ROBOT_TOKEN env immediately
+	// instead of after 5 min of tofu apply.
+	if strings.TrimSpace(r.HarborRobotToken) == "" {
+		return errors.New("Harbor robot token is required (CATALYST_HARBOR_ROBOT_TOKEN missing on catalyst-api — every Sovereign image pull MUST go through harbor.openova.io; falling through to docker.io is not allowed)")
 	}
 
 	// Hetzner Object Storage (issue #371) — Phase 0b. All four fields are
@@ -490,6 +516,20 @@ type Provisioner struct {
 	// error so the operator notices the misconfiguration before
 	// `tofu apply` runs.
 	GHCRPullToken string
+
+	// HarborRobotToken is the central Harbor proxy-cache robot account
+	// secret (`robot$openova-bot` on harbor.openova.io). Mounted from
+	// the Reflector-mirrored `harbor-robot-token` K8s Secret in the
+	// catalyst namespace as env CATALYST_HARBOR_ROBOT_TOKEN.
+	// cloudinit-control-plane.tftpl interpolates it into the new
+	// Sovereign's /etc/rancher/k3s/registries.yaml so containerd
+	// authenticates against harbor.openova.io's docker.io / gcr / quay /
+	// k8s / ghcr proxy projects on every image pull (issue #557).
+	// Empty falls through to anonymous Harbor pulls; if the proxy is
+	// configured for public access this still works, but rate-limited
+	// upstream (Docker Hub) pulls will fail when the proxy can't
+	// authenticate either. Stamped onto every Request before tfvars.
+	HarborRobotToken string
 }
 
 // New returns a Provisioner with paths read from environment.
@@ -503,9 +543,10 @@ type Provisioner struct {
 // with a clear pointer to docs/SECRET-ROTATION.md.
 func New() *Provisioner {
 	return &Provisioner{
-		ModulePath:    env("CATALYST_TOFU_MODULE_PATH", "/infra/hetzner"),
-		WorkDir:       env("CATALYST_TOFU_WORKDIR", "/var/lib/catalyst/tofu"),
-		GHCRPullToken: os.Getenv("CATALYST_GHCR_PULL_TOKEN"),
+		ModulePath:       env("CATALYST_TOFU_MODULE_PATH", "/infra/hetzner"),
+		WorkDir:          env("CATALYST_TOFU_WORKDIR", "/var/lib/catalyst/tofu"),
+		GHCRPullToken:    os.Getenv("CATALYST_GHCR_PULL_TOKEN"),
+		HarborRobotToken: os.Getenv("CATALYST_HARBOR_ROBOT_TOKEN"),
 	}
 }
 
@@ -520,6 +561,9 @@ func (p *Provisioner) Provision(ctx context.Context, req Request, events chan<- 
 	// the deployment with a clear error when the env var is missing.
 	if strings.TrimSpace(req.GHCRPullToken) == "" {
 		req.GHCRPullToken = p.GHCRPullToken
+	}
+	if strings.TrimSpace(req.HarborRobotToken) == "" {
+		req.HarborRobotToken = p.HarborRobotToken
 	}
 
 	if err := req.Validate(); err != nil {
@@ -597,6 +641,9 @@ func (p *Provisioner) Provision(ctx context.Context, req Request, events chan<- 
 func (p *Provisioner) Destroy(ctx context.Context, req Request, events chan<- Event) error {
 	if strings.TrimSpace(req.GHCRPullToken) == "" {
 		req.GHCRPullToken = p.GHCRPullToken
+	}
+	if strings.TrimSpace(req.HarborRobotToken) == "" {
+		req.HarborRobotToken = p.HarborRobotToken
 	}
 
 	emit := func(phase, level, msg string) {
@@ -796,6 +843,13 @@ func writeTfvars(deployDir string, req Request) error {
 		// directory is purged. Per docs/SECRET-ROTATION.md the token
 		// rotates yearly and is stored in 1Password — never in git.
 		"ghcr_pull_token": req.GHCRPullToken,
+
+		// Harbor proxy-cache robot token (issue #557). Stamped server-
+		// side. cloudinit-control-plane.tftpl writes it into
+		// /etc/rancher/k3s/registries.yaml so containerd authenticates
+		// against harbor.openova.io's proxy projects. Empty falls
+		// through to anonymous Harbor pulls.
+		"harbor_robot_token": req.HarborRobotToken,
 
 		// Cloud-init kubeconfig postback (issue #183, Option D). The
 		// catalyst-api stamps deployment_id + kubeconfig_bearer_token

--- a/products/catalyst/bootstrap/ui/src/shared/constants/providerSizes.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/constants/providerSizes.ts
@@ -129,12 +129,20 @@ export const PROVIDER_NODE_SIZES: Record<CloudProvider, NodeSize[]> = {
     // CPX — AMD shared (Regular Performance lineup)
     { id: 'cpx22', label: 'CPX22', vcpu: 2, ram: 4, disk: 80, priceHour: 0.0128, priceMonth: 7.99,
       category: 'shared-amd', description: 'AMD shared vCPU — entry compute' },
-    // CPX32 — founder-stated Helsinki tier price; recommended starter SKU.
+    // CPX32 — entry-level shared SKU. NOT default for SOLO Sovereigns
+    // because the bootstrap-kit's 35 components + CNPG / Harbor /
+    // Keycloak / Cilium / Flux / etc together exceed 4 vCPU at peak —
+    // pods queue Pending forever (caught live on otech26). Operators
+    // can opt into CPX32 explicitly when they trim the component set.
     { id: 'cpx32', label: 'CPX32', vcpu: 4, ram: 8, disk: 160, priceHour: 0.0232, priceMonth: 14.49,
-      category: 'shared-amd', description: 'AMD shared vCPU — solo-Sovereign starter (4 vCPU / 8 GB / 160 GB SSD)',
-      recommended: true },
+      category: 'shared-amd', description: 'AMD shared vCPU — entry tier (4 vCPU / 8 GB) — too small for full SOLO bootstrap-kit; trim components first' },
+    // CPX42 — recommended SOLO starter. 8 vCPU / 16 GB fits the full
+    // bootstrap-kit (Cilium + Crossplane + Flux + Cert-manager + CNPG +
+    // Keycloak + OpenBao + Harbor + Gitea + observability) on a single
+    // node with enough headroom for VPA recommendations to converge.
     { id: 'cpx42', label: 'CPX42', vcpu: 8, ram: 16, disk: 320, priceHour: 0.0408, priceMonth: 25.49,
-      category: 'shared-amd', description: 'AMD shared vCPU — production worker' },
+      category: 'shared-amd', description: 'AMD shared vCPU — solo-Sovereign starter (8 vCPU / 16 GB / 320 GB SSD)',
+      recommended: true },
     { id: 'cpx52', label: 'CPX52', vcpu: 12, ram: 24, disk: 480, priceHour: 0.0585, priceMonth: 36.49,
       category: 'shared-amd', description: 'AMD shared vCPU — heavy worker' },
     { id: 'cpx62', label: 'CPX62', vcpu: 16, ram: 32, disk: 640, priceHour: 0.0809, priceMonth: 50.49,

--- a/products/catalyst/chart/templates/api-deployment.yaml
+++ b/products/catalyst/chart/templates/api-deployment.yaml
@@ -287,6 +287,24 @@ spec:
                   name: catalyst-ghcr-pull-token
                   key: token
                   optional: true
+            # CATALYST_HARBOR_ROBOT_TOKEN — central Harbor proxy-cache
+            # robot account secret (issue #557). Reflector mirrors the
+            # `harbor-robot-token` Secret from openova-harbor namespace
+            # into catalyst namespace; the value is interpolated into
+            # the new Sovereign's /etc/rancher/k3s/registries.yaml at
+            # cloud-init time so containerd authenticates against
+            # harbor.openova.io's proxy projects (proxy-dockerhub etc).
+            #
+            # NOT optional — provisioner.Validate() rejects deployments
+            # with an empty token. The architecture mandate is that every
+            # Sovereign image pull goes through harbor.openova.io; falling
+            # through to docker.io is forbidden (rate-limit makes a fresh
+            # Hetzner IP unbootable within minutes).
+            - name: CATALYST_HARBOR_ROBOT_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: harbor-robot-token
+                  key: token
             # ── /auth/handover Keycloak service-account (issue #606) ──────────
             # CATALYST_KC_ADDR — Keycloak base URL. Defaults to in-cluster
             # service FQDN in code; override here for non-standard Sovereign


### PR DESCRIPTION
CPX32 too small for 35-component bootstrap-kit; pods stuck Pending with insufficient CPU on otech26. Bump default to CPX42 (8 vCPU / 16 GB).