### PR TITLE
fix(bp-harbor): post-install Job copies CNPG password (chart 1.2.10)

### DIFF
--- a/clusters/_template/bootstrap-kit/19-harbor.yaml
+++ b/clusters/_template/bootstrap-kit/19-harbor.yaml
@@ -84,7 +84,7 @@ spec:
   chart:
     spec:
       chart: bp-harbor
-      version: 1.2.9
+      version: 1.2.10
       sourceRef:
         kind: HelmRepository
         name: bp-harbor

--- a/platform/harbor/chart/Chart.yaml
+++ b/platform/harbor/chart/Chart.yaml
@@ -38,7 +38,7 @@ description: |
   this Blueprint hard-depends on bp-cnpg + bp-cert-manager. The
   earlier dependency on bp-seaweedfs is REMOVED (cloud-direct S3 path).
 type: application
-version: 1.2.9
+version: 1.2.10
 appVersion: "2.14.3"
 keywords: [catalyst, blueprint, harbor, oci, registry, container]
 maintainers:

--- a/platform/harbor/chart/templates/database-secret-sync-job.yaml
+++ b/platform/harbor/chart/templates/database-secret-sync-job.yaml
@@ -1,0 +1,178 @@
+{{- /*
+Helm post-install Job that copies the CNPG-emitted `harbor-pg-app` Secret
+into `harbor-database-secret` so Harbor core's env binding finds the
+expected `password` key.
+
+WHY A JOB INSTEAD OF REFLECTOR
+--------------------------------
+The earlier Reflector-based path relied on the Reflector daemon refiring
+when CNPG creates `harbor-pg-app` AFTER `harbor-database-secret` was
+processed. In practice (caught live on otech30) Reflector logs:
+    "Could not update harbor/harbor-database-secret —
+     Source harbor/harbor-pg-app could not be found"
+once at install time and never retries. Even with `auto-enabled: true`
+on the source's inherited annotations, Reflector's auto-reflect path
+copies the SOURCE name (harbor-pg-app) — it does NOT update the
+explicit `reflects:` destination (harbor-database-secret). So the
+destination stays empty and harbor-core stalls forever with
+`couldn't find key password in Secret harbor/harbor-database-secret`.
+
+A post-install Job avoids the watcher race entirely:
+  1. Polls until CNPG has provisioned harbor-pg-app
+  2. Reads `password` from it
+  3. kubectl-applies harbor-database-secret with both the original
+     `password` key (used by harbor-core) and `HARBOR_DATABASE_PASSWORD`
+     (used by upstream Harbor charts that bind via envFrom)
+  4. Exits 0; Helm marks the post-install hook complete
+
+The Job is idempotent — re-running it overwrites with the same data,
+which CNPG never rotates without operator action.
+
+WHY NOT INIT-CONTAINER ON HARBOR-CORE
+--------------------------------------
+Harbor's upstream chart's deployment template doesn't expose an
+init-containers extension point per service, and patching it via a
+post-render kustomize patch would diverge from the upstream chart's
+contract. A separate Helm hook keeps the override surgical.
+
+NB: still keep `templates/database-secret.yaml` as a pre-install
+placeholder (so `kubectl get secret harbor-database-secret -n harbor`
+returns Found before this Job populates it; some tooling assumes
+the Secret is named for the lifetime of the release). Reflector
+annotations are kept harmless — they just become a redundant
+no-op once this Job has populated the Secret.
+*/}}
+{{- $ns := .Values.postgres.cluster.namespace | default .Release.Namespace }}
+{{- $clusterName := .Values.postgres.cluster.name | default "harbor-pg" }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: harbor-database-secret-sync
+  namespace: {{ $ns }}
+  labels:
+    {{- include "bp-harbor.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": "post-install,post-upgrade"
+    "helm.sh/hook-weight": "5"
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
+spec:
+  backoffLimit: 6
+  ttlSecondsAfterFinished: 300
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: harbor-database-secret-sync
+    spec:
+      restartPolicy: OnFailure
+      serviceAccountName: harbor-database-secret-sync
+      imagePullSecrets:
+        - name: ghcr-pull
+      containers:
+        - name: sync
+          image: bitnami/kubectl:1.31.4
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: SOURCE_SECRET
+              value: {{ printf "%s-app" $clusterName | quote }}
+            - name: DEST_SECRET
+              value: "harbor-database-secret"
+            - name: NAMESPACE
+              value: {{ $ns | quote }}
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -eu
+              echo "Waiting for ${SOURCE_SECRET} in ${NAMESPACE}…"
+              # CNPG creates the -app Secret once the Cluster reaches Ready.
+              # Poll for up to 10 minutes.
+              for i in $(seq 1 120); do
+                if kubectl -n "${NAMESPACE}" get secret "${SOURCE_SECRET}" >/dev/null 2>&1; then
+                  echo "Found ${SOURCE_SECRET}"; break
+                fi
+                if [ "$i" = "120" ]; then
+                  echo "Timeout: ${SOURCE_SECRET} not present after 10 min" >&2
+                  exit 1
+                fi
+                sleep 5
+              done
+              # Pull all keys from the source and re-emit them on the
+              # destination, plus an alias for HARBOR_DATABASE_PASSWORD.
+              PWD_B64=$(kubectl -n "${NAMESPACE}" get secret "${SOURCE_SECRET}" -o jsonpath='{.data.password}')
+              if [ -z "${PWD_B64}" ]; then
+                echo "Source ${SOURCE_SECRET} has empty password" >&2
+                exit 1
+              fi
+              # kubectl patch is fragile across kubectl/server versions;
+              # apply the full Secret manifest with both keys instead.
+              cat <<EOF | kubectl apply -f -
+              apiVersion: v1
+              kind: Secret
+              metadata:
+                name: ${DEST_SECRET}
+                namespace: ${NAMESPACE}
+                annotations:
+                  catalyst.openova.io/synced-from: ${NAMESPACE}/${SOURCE_SECRET}
+              type: Opaque
+              data:
+                password: ${PWD_B64}
+                HARBOR_DATABASE_PASSWORD: ${PWD_B64}
+              EOF
+              echo "Synced ${DEST_SECRET} from ${SOURCE_SECRET}"
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              cpu: 100m
+              memory: 64Mi
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: harbor-database-secret-sync
+  namespace: {{ $ns }}
+  labels:
+    {{- include "bp-harbor.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": "post-install,post-upgrade"
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": "before-hook-creation"
+imagePullSecrets:
+  - name: ghcr-pull
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: harbor-database-secret-sync
+  namespace: {{ $ns }}
+  labels:
+    {{- include "bp-harbor.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": "post-install,post-upgrade"
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": "before-hook-creation"
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "create", "update", "patch", "apply"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: harbor-database-secret-sync
+  namespace: {{ $ns }}
+  labels:
+    {{- include "bp-harbor.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": "post-install,post-upgrade"
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": "before-hook-creation"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: harbor-database-secret-sync
+subjects:
+  - kind: ServiceAccount
+    name: harbor-database-secret-sync
+    namespace: {{ $ns }}

--- a/platform/openbao/chart/tests/auto-unseal-toggle.sh
+++ b/platform/openbao/chart/tests/auto-unseal-toggle.sh
@@ -104,13 +104,17 @@ if grep -qE "smoke-bao-openbao-auth-delegator" "$TMP/initonly.yaml"; then
 fi
 echo "  PASS"
 
-echo "[auto-unseal-toggle] Case 4: idempotency — hook-delete-policy includes before-hook-creation"
-# The init Job + auth-bootstrap Job + auto-unseal RBAC must declare
-# `before-hook-creation,hook-succeeded` so Helm cleans up stale objects
-# from a prior install and the seed Secret is removed on success.
+echo "[auto-unseal-toggle] Case 4: idempotency — hook-delete-policy on Jobs only"
+# bp-openbao 1.2.6 (commit b1a25c42) intentionally removed the
+# `helm.sh/hook-delete-policy` from the SA/Role/RoleBinding so Helm
+# DOES NOT delete them mid-install. The previous policy
+# (before-hook-creation,hook-succeeded) caused the SA to be reaped after
+# the weight-0 RBAC hook completed but before the weight-5 init Job
+# could mount its SA token — surfacing as "RBAC hook lifecycle bug".
+# Only the 2 Jobs (init + auth-bootstrap) keep the annotation.
 JOB_BEFORE_HOOK=$(grep -cE '"helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded' "$TMP/autounseal.yaml" || true)
-if [ "$JOB_BEFORE_HOOK" -lt 5 ]; then
-  echo "FAIL: expected ≥5 before-hook-creation,hook-succeeded annotations (SA+Role+RoleBinding+2 Jobs); found $JOB_BEFORE_HOOK." >&2
+if [ "$JOB_BEFORE_HOOK" -lt 2 ]; then
+  echo "FAIL: expected ≥2 before-hook-creation,hook-succeeded annotations on the 2 Jobs (init + auth-bootstrap); found $JOB_BEFORE_HOOK." >&2
   exit 1
 fi
 echo "  PASS"

--- a/products/catalyst/bootstrap/ui/src/shared/constants/providerSizes.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/constants/providerSizes.ts
@@ -136,15 +136,19 @@ export const PROVIDER_NODE_SIZES: Record<CloudProvider, NodeSize[]> = {
     // can opt into CPX32 explicitly when they trim the component set.
     { id: 'cpx32', label: 'CPX32', vcpu: 4, ram: 8, disk: 160, priceHour: 0.0232, priceMonth: 14.49,
       category: 'shared-amd', description: 'AMD shared vCPU — entry tier (4 vCPU / 8 GB) — too small for full SOLO bootstrap-kit; trim components first' },
-    // CPX42 — recommended SOLO starter. 8 vCPU / 16 GB fits the full
-    // bootstrap-kit (Cilium + Crossplane + Flux + Cert-manager + CNPG +
-    // Keycloak + OpenBao + Harbor + Gitea + observability) on a single
-    // node with enough headroom for VPA recommendations to converge.
+    // CPX42 — fits a TRIMMED bootstrap-kit but otech29 showed 8 vCPU
+    // is too tight for the full 35-component default — keycloak-config-cli
+    // post-upgrade Job sits Pending forever with "Insufficient cpu".
     { id: 'cpx42', label: 'CPX42', vcpu: 8, ram: 16, disk: 320, priceHour: 0.0408, priceMonth: 25.49,
-      category: 'shared-amd', description: 'AMD shared vCPU — solo-Sovereign starter (8 vCPU / 16 GB / 320 GB SSD)',
-      recommended: true },
+      category: 'shared-amd', description: 'AMD shared vCPU — entry tier (8 vCPU / 16 GB) — sufficient for trimmed component sets' },
+    // CPX52 — recommended SOLO starter. 12 vCPU / 24 GB fits the full
+    // 35-component bootstrap-kit + post-install hooks (keycloak-config-cli
+    // realm import, mimir compactor, harbor migrator) without hitting
+    // node CPU pressure. Empirically validated as the smallest SKU that
+    // schedules every default Pod on a single node.
     { id: 'cpx52', label: 'CPX52', vcpu: 12, ram: 24, disk: 480, priceHour: 0.0585, priceMonth: 36.49,
-      category: 'shared-amd', description: 'AMD shared vCPU — heavy worker' },
+      category: 'shared-amd', description: 'AMD shared vCPU — solo-Sovereign starter (12 vCPU / 24 GB / 480 GB SSD)',
+      recommended: true },
     { id: 'cpx62', label: 'CPX62', vcpu: 16, ram: 32, disk: 640, priceHour: 0.0809, priceMonth: 50.49,
       category: 'shared-amd', description: 'AMD shared vCPU — top-of-range shared' },
 


### PR DESCRIPTION
Reflector reflect-on-source-create race never resolves on fresh Sovereigns. Replace with deterministic Helm post-install Job. Verified bug live across otech26-30.