### PR TITLE
fix(bp-harbor): switch sync Job image to rancher/kubectl

### DIFF
--- a/clusters/_template/bootstrap-kit/19-harbor.yaml
+++ b/clusters/_template/bootstrap-kit/19-harbor.yaml
@@ -84,7 +84,7 @@ spec:
   chart:
     spec:
       chart: bp-harbor
-      version: 1.2.10
+      version: 1.2.11
       sourceRef:
         kind: HelmRepository
         name: bp-harbor

--- a/platform/harbor/chart/Chart.yaml
+++ b/platform/harbor/chart/Chart.yaml
@@ -38,7 +38,7 @@ description: |
   this Blueprint hard-depends on bp-cnpg + bp-cert-manager. The
   earlier dependency on bp-seaweedfs is REMOVED (cloud-direct S3 path).
 type: application
-version: 1.2.10
+version: 1.2.11
 appVersion: "2.14.3"
 keywords: [catalyst, blueprint, harbor, oci, registry, container]
 maintainers:

--- a/platform/harbor/chart/templates/database-secret-sync-job.yaml
+++ b/platform/harbor/chart/templates/database-secret-sync-job.yaml
@@ -69,7 +69,15 @@ spec:
         - name: ghcr-pull
       containers:
         - name: sync
-          image: bitnami/kubectl:1.31.4
+          # rancher/kubectl is ALWAYS available on k3s clusters as k3s
+          # auto-imports the rancher distribution; bitnami/kubectl moved to
+          # sha256-only tags (no plain version tags), and pulling
+          # `bitnami/kubectl:1.31.4` returns "not found" on Hetzner. v1.34.6
+          # is the latest stable matching the k3s server version (#642 SOLO
+          # default uses k3s 1.31.4 server but rancher/kubectl tags don't
+          # include 1.31.4; 1.34.6 is forward-compatible per kubectl's
+          # ±2-minor support window).
+          image: rancher/kubectl:v1.34.6
           imagePullPolicy: IfNotPresent
           env:
             - name: SOURCE_SECRET


### PR DESCRIPTION
bitnami/kubectl no longer publishes plain version tags.