### PR TITLE
diag(bp-openbao): set -x trace every command (chart 1.2.8)

### DIFF
--- a/clusters/_template/bootstrap-kit/08-openbao.yaml
+++ b/clusters/_template/bootstrap-kit/08-openbao.yaml
@@ -53,7 +53,7 @@ spec:
   chart:
     spec:
       chart: bp-openbao
-      version: 1.2.7
+      version: 1.2.8
       sourceRef:
         kind: HelmRepository
         name: bp-openbao

--- a/platform/openbao/chart/Chart.yaml
+++ b/platform/openbao/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-openbao
-version: 1.2.7
+version: 1.2.8
 description: |
   Catalyst-curated Blueprint umbrella chart for OpenBao. Depends on the
   upstream `openbao` chart as a Helm subchart so `helm dependency build`

--- a/platform/openbao/chart/templates/init-job.yaml
+++ b/platform/openbao/chart/templates/init-job.yaml
@@ -102,6 +102,15 @@ spec:
           args:
             - |
               set -eu
+              # set -x makes every shell command echo to stderr so that
+              # if the script crashes mid-run (e.g. during `bao operator
+              # init` extraction), the LAST command before exit is
+              # captured in pod logs. Diagnostic guardrail added after
+              # otech37/38 surfaced first-attempt logs disappearing
+              # between init and persist (server became Initialized=true
+              # but unseal-keys Secret never got written, with no log
+              # evidence of where the crash happened).
+              set -x
               # ─── Step 1: wait for openbao-0 to answer status checks ────
               # Upstream chart name pattern: <release>-openbao-0. Skip if
               # already responsive.


### PR DESCRIPTION
Capture which command crashes between init and persist.