### PR TITLE
diag(bp-openbao): restartPolicy: Never to preserve fresh-init logs (1.2.11)

### DIFF
--- a/clusters/_template/bootstrap-kit/08-openbao.yaml
+++ b/clusters/_template/bootstrap-kit/08-openbao.yaml
@@ -53,7 +53,7 @@ spec:
   chart:
     spec:
       chart: bp-openbao
-      version: 1.2.10
+      version: 1.2.11
       sourceRef:
         kind: HelmRepository
         name: bp-openbao

--- a/platform/openbao/chart/Chart.yaml
+++ b/platform/openbao/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-openbao
-version: 1.2.10
+version: 1.2.11
 description: |
   Catalyst-curated Blueprint umbrella chart for OpenBao. Depends on the
   upstream `openbao` chart as a Helm subchart so `helm dependency build`

--- a/platform/openbao/chart/templates/init-job.yaml
+++ b/platform/openbao/chart/templates/init-job.yaml
@@ -77,7 +77,15 @@ spec:
         catalyst.openova.io/component: openbao-init
     spec:
       serviceAccountName: openbao-auto-unseal
-      restartPolicy: OnFailure
+      # restartPolicy: Never — with OnFailure, the kubelet restarts the
+      # SAME container in the SAME pod on every failure, and only the
+      # MOST RECENT failed container's logs are retrievable (older
+      # restarts get reaped). Switching to Never means each retry is a
+      # NEW pod via the Job's backoffLimit replay; every failed pod is
+      # individually inspectable with `kubectl logs <pod>` until
+      # ttlSecondsAfterFinished tears it down. Required to diagnose
+      # the fresh-init persist gap.
+      restartPolicy: Never
       securityContext:
         runAsNonRoot: true
         runAsUser: 100


### PR DESCRIPTION
Per-pod log retention so fresh-init failure point is observable.