### PR TITLE
fix(bp-openbao): wc -l returns 0 for single-key extraction (1.2.12) — TRUE root cause of provisioning loop

### DIFF
--- a/clusters/_template/bootstrap-kit/08-openbao.yaml
+++ b/clusters/_template/bootstrap-kit/08-openbao.yaml
@@ -53,7 +53,7 @@ spec:
   chart:
     spec:
       chart: bp-openbao
-      version: 1.2.11
+      version: 1.2.12
       sourceRef:
         kind: HelmRepository
         name: bp-openbao

--- a/platform/openbao/chart/Chart.yaml
+++ b/platform/openbao/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-openbao
-version: 1.2.11
+version: 1.2.12
 description: |
   Catalyst-curated Blueprint umbrella chart for OpenBao. Depends on the
   upstream `openbao` chart as a Helm subchart so `helm dependency build`

--- a/platform/openbao/chart/templates/init-job.yaml
+++ b/platform/openbao/chart/templates/init-job.yaml
@@ -339,13 +339,26 @@ spec:
                 fi
                 echo "[openbao-init] unseal threshold = $UNSEAL_THRESHOLD; extracting keys"
                 # Pull the unseal_keys_b64 array, split into one key per line.
+                # The trailing `awk 1` ensures the LAST line has a trailing
+                # newline. Without it, with key-shares=1 the pipeline
+                # produces `<key>` with NO terminal `\n` (because tr+sed
+                # only added newlines BETWEEN comma-separated entries),
+                # and `wc -l` counts 0. Caught live on otech42 with chart
+                # 1.2.11's per-pod logs: "extracted 0 unseal key(s) but
+                # threshold=1" — root cause for every prior provisioning
+                # loop attributed to RBAC/wget/etc. (See PR history of
+                # 1.2.5..1.2.11.)
                 tr -d '\n' < /tmp/init-output.json \
                   | sed -E 's/.*"unseal_keys_b64"[[:space:]]*:[[:space:]]*\[([^]]*)\].*/\1/' \
                   | tr ',' '\n' \
                   | sed -E 's/.*"([^"]+)".*/\1/' \
                   | sed '/^[[:space:]]*$/d' \
+                  | awk 1 \
                   > /tmp/.unseal-keys
-                KEY_COUNT=$(wc -l < /tmp/.unseal-keys | tr -d ' ')
+                # Count via grep -c . to count NON-EMPTY lines without
+                # depending on trailing-newline semantics. Belt-and-braces
+                # alongside the awk 1 above.
+                KEY_COUNT=$(grep -c . /tmp/.unseal-keys 2>/dev/null || echo 0)
                 if [ "$KEY_COUNT" -lt "$UNSEAL_THRESHOLD" ]; then
                   echo "[openbao-init] FATAL: extracted $KEY_COUNT unseal key(s) but threshold=$UNSEAL_THRESHOLD — see /tmp/init-output.json"
                   exit 1


### PR DESCRIPTION
Caught live on otech42 with chart 1.2.11's per-pod logs. key-shares=1 produces no comma → final sed line lacks trailing newline → wc -l counts 0. Every prior fix (RBAC, wget --method, restartPolicy) was a downstream symptom.