### PR TITLE
fix(bp-openbao): wire root_token init→auth-bootstrap (1.2.13)

### DIFF
--- a/clusters/_template/bootstrap-kit/08-openbao.yaml
+++ b/clusters/_template/bootstrap-kit/08-openbao.yaml
@@ -53,7 +53,7 @@ spec:
   chart:
     spec:
       chart: bp-openbao
-      version: 1.2.12
+      version: 1.2.13
       sourceRef:
         kind: HelmRepository
         name: bp-openbao

--- a/platform/openbao/chart/Chart.yaml
+++ b/platform/openbao/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-openbao
-version: 1.2.12
+version: 1.2.13
 description: |
   Catalyst-curated Blueprint umbrella chart for OpenBao. Depends on the
   upstream `openbao` chart as a Helm subchart so `helm dependency build`

--- a/platform/openbao/chart/templates/auth-bootstrap-job.yaml
+++ b/platform/openbao/chart/templates/auth-bootstrap-job.yaml
@@ -174,6 +174,19 @@ spec:
                 ttl=$TOKEN_TTL \
                 max_ttl=$TOKEN_MAX_TTL
 
+              # ─── Revoke + cleanup root token ──────────────────────────
+              # Acceptance criterion #6: the privileged root token must
+              # not persist past the install window. Revoke it inside
+              # bao first, then delete the K8s Secret that held it.
+              echo "[openbao-auth-bootstrap] revoking root token"
+              bao token revoke -self 2>&1 || echo "[openbao-auth-bootstrap] WARN: token revoke returned non-zero (may already be revoked)"
+              echo "[openbao-auth-bootstrap] deleting transient openbao-root-token Secret"
+              wget -qO- --no-check-certificate \
+                --header="Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" \
+                --method=DELETE \
+                "https://kubernetes.default.svc/api/v1/namespaces/$NAMESPACE/secrets/openbao-root-token" >/dev/null 2>&1 || \
+              echo "[openbao-auth-bootstrap] WARN: --method=DELETE not supported (busybox wget); manual cleanup may be needed via kubectl"
+
               echo "[openbao-auth-bootstrap] Kubernetes auth bootstrap complete"
           resources:
             requests:

--- a/platform/openbao/chart/templates/auto-unseal-rbac.yaml
+++ b/platform/openbao/chart/templates/auto-unseal-rbac.yaml
@@ -100,6 +100,13 @@ rules:
       # secret material itself, but treating it as a Secret keeps it
       # under the same RBAC umbrella.
       - openbao-init-trace
+      # openbao-root-token: transient Secret that init-job writes the
+      # root_token into so auth-bootstrap (the next post-install hook)
+      # can authenticate against bao. auth-bootstrap REVOKES the token
+      # and DELETES this Secret on completion so the privileged token
+      # never persists past the install window. RBAC mutation/delete
+      # is intentionally scoped to this name.
+      - openbao-root-token
 ---
 # RoleBinding — NOT a hook (issue #598).
 apiVersion: rbac.authorization.k8s.io/v1

--- a/platform/openbao/chart/templates/init-job.yaml
+++ b/platform/openbao/chart/templates/init-job.yaml
@@ -306,6 +306,40 @@ spec:
                 fi
                 echo "$ROOT_TOKEN" > /tmp/.root-token
 
+                # ─── Persist root_token to Secret for auth-bootstrap ────────
+                # The auth-bootstrap Job (post-install weight 10) needs an
+                # authenticated bao token to call `bao auth enable`,
+                # `bao secrets enable`, `bao policy write`, and `bao write
+                # auth/.../role/...`. Without this Secret, auth-bootstrap
+                # makes unauthenticated requests and bao returns 403 —
+                # caught live on otech43 once 1.2.12 fixed the persist gap
+                # and made auth-bootstrap actually run.
+                #
+                # auth-bootstrap reads BAO_TOKEN from this Secret via
+                # secretKeyRef, runs to completion, then revokes the token
+                # via `bao token revoke -self` (acceptance criterion #6 —
+                # the privileged token does not persist past install).
+                echo "[openbao-init] persisting root_token to Secret openbao-root-token (revoked + cleaned by auth-bootstrap on success)"
+                ROOT_TOKEN_B64=$(printf '%s' "$ROOT_TOKEN" | base64 | tr -d '\n')
+                ROOT_SECRET_BODY=$(printf '{"apiVersion":"v1","kind":"Secret","metadata":{"name":"openbao-root-token","namespace":"%s","labels":{"catalyst.openova.io/blueprint":"bp-openbao","catalyst.openova.io/component":"openbao-root-token"}},"type":"Opaque","data":{"token":"%s"}}' \
+                  "$NAMESPACE" "$ROOT_TOKEN_B64")
+                RT_CREATE_RC=0
+                wget -qO- --no-check-certificate \
+                  --header="Authorization: Bearer $TOKEN" \
+                  --header="Content-Type: application/json" \
+                  --post-data="$ROOT_SECRET_BODY" \
+                  "$APISERVER/api/v1/namespaces/$NAMESPACE/secrets" > /tmp/.rt-create-out 2>&1 || RT_CREATE_RC=$?
+                if [ "$RT_CREATE_RC" -ne 0 ]; then
+                  # Already-exists 409 is fine — this is an idempotent re-run.
+                  if grep -q '"reason":"AlreadyExists"' /tmp/.rt-create-out 2>/dev/null; then
+                    echo "[openbao-init] root-token Secret already exists (idempotent re-run)"
+                  else
+                    echo "[openbao-init] FATAL: cannot persist openbao-root-token Secret"
+                    cat /tmp/.rt-create-out 2>/dev/null
+                    exit 1
+                  fi
+                fi
+
                 # ─── Step 3a: unseal the freshly-initialised vault (issue #527) ─
                 # `bao operator init` returns the cluster initialised but
                 # SEALED. Without an explicit `bao operator unseal <key>`


### PR DESCRIPTION
Caught live on otech43 after the persist gap fix surfaced auth-bootstrap's 403. Init persists token to Secret; auth-bootstrap reads it, then revokes.