### PR TITLE
fix(bp-openbao): add BAO_TOKEN env to auth-bootstrap (1.2.14) — PR #663 missed half

### DIFF
--- a/clusters/_template/bootstrap-kit/08-openbao.yaml
+++ b/clusters/_template/bootstrap-kit/08-openbao.yaml
@@ -52,7 +52,7 @@ spec:
   chart:
     spec:
       chart: bp-openbao
-      version: 1.2.13
+      version: 1.2.14
       sourceRef:
         kind: HelmRepository
         name: bp-openbao

--- a/platform/openbao/chart/Chart.yaml
+++ b/platform/openbao/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-openbao
-version: 1.2.13
+version: 1.2.14
 description: |
   Catalyst-curated Blueprint umbrella chart for OpenBao. Depends on the
   upstream `openbao` chart as a Helm subchart so `helm dependency build`

--- a/platform/openbao/chart/templates/auth-bootstrap-job.yaml
+++ b/platform/openbao/chart/templates/auth-bootstrap-job.yaml
@@ -99,6 +99,23 @@ spec:
               value: {{ $tokenTTL | quote }}
             - name: TOKEN_MAX_TTL
               value: {{ $tokenMaxTTL | quote }}
+            # BAO_TOKEN sourced from openbao-root-token Secret that init-job
+            # (post-install weight 5) writes from the bao operator init
+            # output. Required so this Job's `bao auth enable`,
+            # `bao secrets enable`, `bao policy write`, and `bao write
+            # role/...` calls are authenticated. Without it bao returns
+            # 403 Forbidden — caught live on otech43+otech44 because the
+            # PR #663 commit only added the revoke logic, not the env
+            # declaration that gates it.
+            - name: BAO_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: openbao-root-token
+                  key: token
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
           command: ["/bin/sh", "-c"]
           args:
             - |


### PR DESCRIPTION
Companion to #663. The env block was missing from main.