### PR TITLE
fix: remove empty dependsOn from bp-nats-jetstream (PR #665 follow-up)

### DIFF
--- a/clusters/_template/bootstrap-kit/07-nats-jetstream.yaml
+++ b/clusters/_template/bootstrap-kit/07-nats-jetstream.yaml
@@ -33,7 +33,10 @@ spec:
   interval: 15m
   releaseName: nats-jetstream
   targetNamespace: nats-system
-  dependsOn:
+  # No dependsOn: bp-spire was dropped (PR #665, founder direction
+  # 2026-05-03 — Cilium WireGuard mesh handles east-west mTLS).
+  # NATS no longer needs SVID-based auth; the kernel-level WireGuard
+  # encryption between every pod covers the in-flight traffic.
   chart:
     spec:
       chart: bp-nats-jetstream


### PR DESCRIPTION
Empty dependsOn: in YAML = null, fails CRD validation. Block whole bootstrap-kit.