### PR TITLE
fix(bp-gitea): use explicit labels in sync-job (1.2.3 retry)

### DIFF
--- a/platform/gitea/chart/templates/database-secret-sync-job.yaml
+++ b/platform/gitea/chart/templates/database-secret-sync-job.yaml
@@ -50,7 +50,8 @@ metadata:
   name: gitea-database-secret-sync
   namespace: {{ $ns }}
   labels:
-    {{- include "bp-gitea.labels" . | nindent 4 }}
+    catalyst.openova.io/blueprint: bp-gitea
+    catalyst.openova.io/component: gitea-database-secret-sync
   annotations:
     "helm.sh/hook": "post-install,post-upgrade"
     "helm.sh/hook-weight": "5"
@@ -143,7 +144,8 @@ metadata:
   name: gitea-database-secret-sync
   namespace: {{ $ns }}
   labels:
-    {{- include "bp-gitea.labels" . | nindent 4 }}
+    catalyst.openova.io/blueprint: bp-gitea
+    catalyst.openova.io/component: gitea-database-secret-sync
   annotations:
     "helm.sh/hook": "post-install,post-upgrade"
     "helm.sh/hook-weight": "0"
@@ -157,7 +159,8 @@ metadata:
   name: gitea-database-secret-sync
   namespace: {{ $ns }}
   labels:
-    {{- include "bp-gitea.labels" . | nindent 4 }}
+    catalyst.openova.io/blueprint: bp-gitea
+    catalyst.openova.io/component: gitea-database-secret-sync
   annotations:
     "helm.sh/hook": "post-install,post-upgrade"
     "helm.sh/hook-weight": "0"
@@ -173,7 +176,8 @@ metadata:
   name: gitea-database-secret-sync
   namespace: {{ $ns }}
   labels:
-    {{- include "bp-gitea.labels" . | nindent 4 }}
+    catalyst.openova.io/blueprint: bp-gitea
+    catalyst.openova.io/component: gitea-database-secret-sync
   annotations:
     "helm.sh/hook": "post-install,post-upgrade"
     "helm.sh/hook-weight": "0"


### PR DESCRIPTION
Re-publish 1.2.3 — previous attempt failed helm-template gate due to missing helper.