### PR TITLE
fix(sovereign-console): flow physics, log tail, global log, header, theme (#669)

### DIFF
--- a/products/catalyst/bootstrap/ui/src/app/globals.css
+++ b/products/catalyst/bootstrap/ui/src/app/globals.css
@@ -65,6 +65,54 @@
   --color-accent-hover: #2563eb;
   --color-warn: #f59e0b;
   --color-danger: #ef4444;
+
+  /* ─── Flow-canvas + log-viewer tokens (issue #669) ──────────────────
+     Status palette for FlowCanvasOrganic bubbles (fill / ring / glyph
+     / glow / edge / arrow). Keyed by JobStatus. Light-mode peers in
+     the [data-theme="light"] block below. */
+  --bubble-fill-pending:   #0D1726;
+  --bubble-ring-pending:   rgba(148,163,184,0.45);
+  --bubble-glyph-pending:  rgba(148,163,184,0.75);
+  --bubble-glow-pending:   transparent;
+  --bubble-edge-pending:   rgba(148,163,184,0.32);
+  --bubble-arrow-pending:  rgba(148,163,184,0.60);
+
+  --bubble-fill-running:   #0E1A33;
+  --bubble-ring-running:   rgba(56,189,248,0.85);
+  --bubble-glyph-running:  #BAE6FD;
+  --bubble-glow-running:   rgba(56,189,248,0.30);
+  --bubble-edge-running:   rgba(56,189,248,0.65);
+  --bubble-arrow-running:  #38BDF8;
+
+  /* Issue #669 — succeeded bubbles MUST read as "done" at a glance.
+     Solid green fill, white tick. Was: dark fill #0F1F18 with green
+     glyph, which read identically to pending at a glance. */
+  --bubble-fill-succeeded: #16A34A;
+  --bubble-ring-succeeded: rgba(22,163,74,0.95);
+  --bubble-glyph-succeeded: #FFFFFF;
+  --bubble-glow-succeeded: rgba(74,222,128,0.20);
+  --bubble-edge-succeeded: rgba(74,222,128,0.55);
+  --bubble-arrow-succeeded: #4ADE80;
+
+  --bubble-fill-failed:    #23070A;
+  --bubble-ring-failed:    rgba(248,113,113,0.85);
+  --bubble-glyph-failed:   #FCA5A5;
+  --bubble-glow-failed:    rgba(248,113,113,0.30);
+  --bubble-edge-failed:    rgba(248,113,113,0.65);
+  --bubble-arrow-failed:   #F87171;
+
+  /* Bubble label (text below the bubble). Dark default = white-ish;
+     light peer flips to slate-900 for AA on white background. */
+  --bubble-label:          rgba(255,255,255,0.85);
+  --bubble-sublabel:       rgba(255,255,255,0.45);
+
+  /* Log viewer surface — was hardcoded #0D1117 in ExecutionLogs.tsx. */
+  --log-viewer-bg:         #0D1117;
+  --log-viewer-text:       #c9d1d9;
+  --log-viewer-text-dim:   rgba(139,148,158,0.85);
+  --log-viewer-text-num:   rgba(139,148,158,0.7);
+  --log-viewer-empty:      rgba(201,209,217,0.55);
+  --log-line-focused-bg:   rgba(56,139,253,0.18);
 }
 
 /* Console-token override for `--color-success` — the wizard surface
@@ -170,6 +218,49 @@
      dark-mode green semantic while clearing 4.5:1 against
      #ffffff bg (the dark default #10b981 is 1.6:1, AA-failing). */
   --color-success: #047857;
+
+  /* ─── Flow-canvas light peers (issue #669) ─────────────────────────
+     Bubble fills go pale tint instead of dark surface so glyph + ring
+     stay readable on a white page. Ring + glyph use AA-clearing
+     foregrounds. Edges + glows soften to keep the canvas light. */
+  --bubble-fill-pending:    #F1F5F9;
+  --bubble-ring-pending:    #94A3B8;
+  --bubble-glyph-pending:   #475569;
+  --bubble-glow-pending:    transparent;
+  --bubble-edge-pending:    rgba(100,116,139,0.45);
+  --bubble-arrow-pending:   #64748B;
+
+  --bubble-fill-running:    #DBEAFE;
+  --bubble-ring-running:    #2563EB;
+  --bubble-glyph-running:   #1E3A8A;
+  --bubble-glow-running:    rgba(37,99,235,0.20);
+  --bubble-edge-running:    rgba(37,99,235,0.65);
+  --bubble-arrow-running:   #2563EB;
+
+  --bubble-fill-succeeded:  #16A34A;
+  --bubble-ring-succeeded:  rgba(22,163,74,0.95);
+  --bubble-glyph-succeeded: #FFFFFF;
+  --bubble-glow-succeeded:  rgba(22,163,74,0.20);
+  --bubble-edge-succeeded:  rgba(22,163,74,0.65);
+  --bubble-arrow-succeeded: #16A34A;
+
+  --bubble-fill-failed:     #FEE2E2;
+  --bubble-ring-failed:     #B91C1C;
+  --bubble-glyph-failed:    #7F1D1D;
+  --bubble-glow-failed:     rgba(185,28,28,0.20);
+  --bubble-edge-failed:     rgba(185,28,28,0.65);
+  --bubble-arrow-failed:    #B91C1C;
+
+  --bubble-label:           #0F172A;
+  --bubble-sublabel:        #64748B;
+
+  /* Log viewer light peer — bright surface, AA-clearing text. */
+  --log-viewer-bg:          #F8FAFC;
+  --log-viewer-text:        #0F172A;
+  --log-viewer-text-dim:    #475569;
+  --log-viewer-text-num:    #94A3B8;
+  --log-viewer-empty:       #64748B;
+  --log-line-focused-bg:    rgba(37,99,235,0.12);
 
   /* Wizard theme channels — light overrides */
   --wiz-ch:         0, 0, 0;

--- a/products/catalyst/bootstrap/ui/src/components/ExecutionLogs.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/components/ExecutionLogs.test.tsx
@@ -199,12 +199,14 @@ describe('ExecutionLogs — rendering', () => {
       expect(screen.getByTestId('execution-logs-line-1')).toBeTruthy()
     })
     const root = screen.getByTestId('execution-logs-root')
-    // jsdom canonicalises hex → rgb. We accept either form so the test
-    // is portable across environments that preserve the literal vs.
-    // those that round-trip via CSSOM. Both representations encode the
-    // founder-specified `#0D1117`.
+    // Issue #669 — the viewer surface routes through `--log-viewer-bg`
+    // so the colour flips on `[data-theme="light"]`. Globals.css sets
+    // the dark default to #0D1117 (founder-specified, verbatim) and the
+    // light peer to #F8FAFC. We assert the CSS-variable wiring rather
+    // than the resolved colour because jsdom never loads the stylesheet
+    // that supplies the variable's value.
     const bg = (root as HTMLElement).style.background.toLowerCase()
-    expect(bg === '#0d1117' || bg.includes('rgb(13, 17, 23)')).toBe(true)
+    expect(bg).toContain('var(--log-viewer-bg)')
   })
 })
 

--- a/products/catalyst/bootstrap/ui/src/components/ExecutionLogs.tsx
+++ b/products/catalyst/bootstrap/ui/src/components/ExecutionLogs.tsx
@@ -61,8 +61,11 @@ export type FetchLogsFn = (args: {
 
 /* ── Constants ──────────────────────────────────────────────────── */
 
-/** Founder-specified background — verbatim. */
-export const LOG_VIEWER_BG = '#0D1117'
+/** Founder-specified background — kept as the legacy default for any
+ *  consumer that imports it directly. New code should use
+ *  `var(--log-viewer-bg)` (issue #669) so the viewer reskins under
+ *  `[data-theme="light"]` without a re-mount. */
+export const LOG_VIEWER_BG = 'var(--log-viewer-bg)'
 
 /** Founder-specified page size — verbatim ("chunks of 500 at a time"). */
 const LOG_PAGE_LIMIT = 500
@@ -231,12 +234,23 @@ export function ExecutionLogs({
   }, [query.data, fromLine])
 
   /* Auto-scroll on new lines if user is "near-bottom"; if they've
-   * scrolled up, leave the viewport where they put it. */
+   * scrolled up, leave the viewport where they put it.
+   *
+   * Issue #669 — real `tail -f` slide. Was: `el.scrollTop = scrollHeight`
+   * instant snap. Now uses native smooth scroll so the viewport glides
+   * to the new bottom over ~120-200ms. New lines also fade-up via the
+   * `log-line-row` keyframe animation (see <style> block at the bottom
+   * of this component) so the effect reads as content streaming in,
+   * not a teleport. */
   useEffect(() => {
     const el = viewportRef.current
     if (!el) return
     if (pausedAutoScroll) return
-    el.scrollTop = el.scrollHeight
+    if (typeof el.scrollTo === 'function') {
+      el.scrollTo({ top: el.scrollHeight, behavior: 'smooth' })
+    } else {
+      el.scrollTop = el.scrollHeight
+    }
     wasAtBottomRef.current = true
   }, [allLines.length, pausedAutoScroll])
 
@@ -336,14 +350,20 @@ export function ExecutionLogs({
   return (
     <div
       data-testid="execution-logs-root"
+      className="execution-logs-root"
       style={{
-        background: LOG_VIEWER_BG,
+        background: 'var(--log-viewer-bg)',
         borderRadius: 6,
         position: 'relative',
         overflow: 'hidden',
         fontFamily: 'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace',
       }}
     >
+      {/* Issue #669 — keyframes for the tail-slide effect. Applied to
+          new line rows via the `log-line-row` class so each incoming
+          line fades+rises into place; combined with smooth scrollTo,
+          the viewer reads as a real `tail -f` stream. */}
+      <style>{LOG_VIEWER_CSS}</style>
       <div
         ref={viewportRef}
         onScroll={handleScroll}
@@ -359,7 +379,7 @@ export function ExecutionLogs({
             data-testid="execution-logs-empty"
             style={{
               padding: '1rem',
-              color: 'rgba(201, 209, 217, 0.55)',
+              color: 'var(--log-viewer-empty)',
               fontSize: '0.78rem',
             }}
           >
@@ -466,6 +486,7 @@ function LogLineRow({ line, lineNumWidth, matchPosition, isFocusedMatch }: LogLi
   return (
     <div
       data-testid={`execution-logs-line-${line.lineNumber}`}
+      className="log-line-row"
       data-level={line.level}
       data-match-position={matchPosition || undefined}
       data-focused-match={isFocusedMatch ? 'true' : undefined}
@@ -476,10 +497,10 @@ function LogLineRow({ line, lineNumWidth, matchPosition, isFocusedMatch }: LogLi
         padding: '0.1rem 0.85rem',
         fontSize: '0.78rem',
         lineHeight: 1.55,
-        color: '#c9d1d9',
+        color: 'var(--log-viewer-text)',
         whiteSpace: 'pre-wrap',
         wordBreak: 'break-word',
-        background: isFocusedMatch ? 'rgba(56, 139, 253, 0.18)' : 'transparent',
+        background: isFocusedMatch ? 'var(--log-line-focused-bg)' : 'transparent',
       }}
     >
       <span
@@ -488,7 +509,7 @@ function LogLineRow({ line, lineNumWidth, matchPosition, isFocusedMatch }: LogLi
           width: lineNumWidth,
           flexShrink: 0,
           textAlign: 'right',
-          color: 'rgba(139, 148, 158, 0.7)',
+          color: 'var(--log-viewer-text-num)',
           fontVariantNumeric: 'tabular-nums',
           userSelect: 'none',
         }}
@@ -499,7 +520,7 @@ function LogLineRow({ line, lineNumWidth, matchPosition, isFocusedMatch }: LogLi
         data-testid={`execution-logs-ts-${line.lineNumber}`}
         style={{
           flexShrink: 0,
-          color: 'rgba(139, 148, 158, 0.85)',
+          color: 'var(--log-viewer-text-dim)',
           fontVariantNumeric: 'tabular-nums',
         }}
       >
@@ -534,3 +555,39 @@ function LogLineRow({ line, lineNumWidth, matchPosition, isFocusedMatch }: LogLi
     </div>
   )
 }
+
+/* ── Tail-slide keyframes (issue #669) ────────────────────────────
+ *
+ * Each row plays a one-shot fade+rise animation when it mounts. The
+ * `prefers-reduced-motion` query disables it for users who set that
+ * accessibility flag. Combined with `el.scrollTo({behavior: 'smooth'})`
+ * in the auto-scroll effect, the viewer reads as a `tail -f` stream
+ * rather than the previous instant-snap append.
+ *
+ * Note on duration: 180ms is short enough that on burst-write logs
+ * (10 lines/s during install-openbao) animations stay below the
+ * frame budget. Longer durations get visibly choppy under load.
+ */
+const LOG_VIEWER_CSS = `
+@keyframes log-line-tail-in {
+  from {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.execution-logs-root .log-line-row {
+  animation: log-line-tail-in 180ms cubic-bezier(0.4, 0, 0.2, 1) both;
+  will-change: transform, opacity;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .execution-logs-root .log-line-row {
+    animation: none;
+  }
+}
+`

--- a/products/catalyst/bootstrap/ui/src/components/LogPane.tsx
+++ b/products/catalyst/bootstrap/ui/src/components/LogPane.tsx
@@ -27,8 +27,8 @@
  *       tokens; only the slide-in keyframe owns motion-specific values.
  */
 
-import { useCallback, useEffect, useMemo, useState } from 'react'
-import { ExecutionLogs, type LogLine, LOG_VIEWER_BG, formatLogTimestamp } from './ExecutionLogs'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { ExecutionLogs, type LogLine, formatLogTimestamp } from './ExecutionLogs'
 import { LogSearch, lineMatches, type LogFilter } from './LogSearch'
 
 interface LogPaneProps {
@@ -50,6 +50,16 @@ interface LogPaneProps {
    * filter pipeline as the polling viewer.
    */
   fallbackLines?: readonly LogLine[]
+  /**
+   * Issue #669 — global log lines for the *entire deployment*, merged
+   * across every component by timestamp. When non-empty, the pane
+   * surfaces a "Split" toggle in the header that adds a second column
+   * showing these lines next to the per-component pane on the left.
+   * Each entry is prefixed with the source component name in
+   * `LogLine.message` by the consumer (JobDetail) so the column reads
+   * as a unified provision-wide tail.
+   */
+  globalLines?: readonly LogLine[]
   /** Display title — typically the host job's display name or jobName. */
   jobTitle: string
   /** Status text rendered as a small chip in the header strip. */
@@ -72,6 +82,7 @@ const EMPTY_FILTER: LogFilter = { query: '', regex: false, levels: new Set() }
 export function LogPane({
   executionId,
   fallbackLines,
+  globalLines,
   jobTitle,
   statusLabel,
   statusTone = 'pending',
@@ -81,6 +92,14 @@ export function LogPane({
   const [matchCount, setMatchCount] = useState<number>(0)
   const [matchIndex, setMatchIndex] = useState<number>(0)
   const [fullScreen, setFullScreen] = useState<boolean>(false)
+  /* Issue #669 — split-view state. When `splitView` is true and there
+   * are non-empty `globalLines`, the pane body lays out as a 2-column
+   * grid: per-component on the left, global merged stream on the
+   * right. Default to OFF so the pane keeps its slim 30vw footprint
+   * for the common single-component flow; operators flip it on when
+   * they want a provision-wide tail. */
+  const [splitView, setSplitView] = useState<boolean>(false)
+  const hasGlobal = (globalLines?.length ?? 0) > 0
 
   // Reset matchIndex whenever the count drops below it (e.g. operator
   // tightens the query). Bumping it from 0 → 1 the moment results
@@ -137,7 +156,10 @@ export function LogPane({
       aria-label={`Logs for ${jobTitle}`}
       data-testid="log-pane"
       data-fullscreen={fullScreen ? 'true' : 'false'}
-      className={`log-pane${fullScreen ? ' is-fullscreen' : ''}`}
+      data-split={splitView && hasGlobal ? 'true' : 'false'}
+      className={`log-pane${fullScreen ? ' is-fullscreen' : ''}${
+        splitView && hasGlobal ? ' is-split' : ''
+      }`}
     >
       <style>{LOG_PANE_CSS}</style>
       <header className="log-pane-header" data-testid="log-pane-header">
@@ -151,6 +173,32 @@ export function LogPane({
         <span className="log-pane-title" data-testid="log-pane-title" title={jobTitle}>
           {jobTitle}
         </span>
+        {/* Issue #669 — split-view toggle. Only enabled when the
+            consumer passes `globalLines` so legacy mounts (no global
+            stream) hide the affordance entirely instead of showing a
+            disabled button. */}
+        {hasGlobal ? (
+          <button
+            type="button"
+            className="log-pane-icon-btn"
+            aria-label={splitView ? 'Hide global log column' : 'Show global log column'}
+            aria-pressed={splitView}
+            data-testid="log-pane-split"
+            onClick={() => setSplitView((v) => !v)}
+            title={splitView ? 'Hide global log column' : 'Show global log column'}
+          >
+            <svg width="14" height="14" viewBox="0 0 14 14" aria-hidden>
+              <path
+                d="M2 2 L6 2 L6 12 L2 12 Z M8 2 L12 2 L12 12 L8 12 Z"
+                stroke="currentColor"
+                strokeWidth="1.4"
+                fill="none"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            </svg>
+          </button>
+        ) : null}
         <button
           type="button"
           className="log-pane-icon-btn"
@@ -208,13 +256,23 @@ export function LogPane({
             onFilterChange={setFilter}
           />
           <div className="log-pane-body" data-testid="log-pane-body">
-            <ExecutionLogs
-              executionId={executionId}
-              filter={filter}
-              matchIndex={matchIndex}
-              onMatchCountChange={setMatchCount}
-              height="100%"
-            />
+            <div className="log-pane-col" data-testid="log-pane-col-primary">
+              <div className="log-pane-col-header" data-testid="log-pane-col-primary-header">
+                <span>{jobTitle}</span>
+              </div>
+              <div className="log-pane-col-body">
+                <ExecutionLogs
+                  executionId={executionId}
+                  filter={filter}
+                  matchIndex={matchIndex}
+                  onMatchCountChange={setMatchCount}
+                  height="100%"
+                />
+              </div>
+            </div>
+            {splitView && hasGlobal ? (
+              <GlobalLogColumn lines={globalLines!} filter={filter} />
+            ) : null}
           </div>
         </>
       ) : fallbackLines && fallbackLines.length > 0 ? (
@@ -227,20 +285,178 @@ export function LogPane({
             onFilterChange={setFilter}
           />
           <div className="log-pane-body" data-testid="log-pane-body">
-            <FallbackLogList
-              lines={fallbackLines}
-              filter={filter}
-              matchIndex={matchIndex}
-              onMatchCountChange={setMatchCount}
-            />
+            <div className="log-pane-col" data-testid="log-pane-col-primary">
+              <div className="log-pane-col-header" data-testid="log-pane-col-primary-header">
+                <span>{jobTitle}</span>
+              </div>
+              <div className="log-pane-col-body">
+                <FallbackLogList
+                  lines={fallbackLines}
+                  filter={filter}
+                  matchIndex={matchIndex}
+                  onMatchCountChange={setMatchCount}
+                />
+              </div>
+            </div>
+            {splitView && hasGlobal ? (
+              <GlobalLogColumn lines={globalLines!} filter={filter} />
+            ) : null}
           </div>
         </>
+      ) : splitView && hasGlobal ? (
+        // Issue #669 — operator opened split-view on a host job that has
+        // no recorded execution + no fallback lines yet. Render the
+        // global column on its own so the split affordance still
+        // delivers value.
+        <div className="log-pane-body" data-testid="log-pane-body">
+          <GlobalLogColumn lines={globalLines!} filter={filter} />
+        </div>
       ) : (
         <div className="log-pane-empty" data-testid="log-pane-empty">
           No execution recorded yet.
         </div>
       )}
     </aside>
+  )
+}
+
+/* ── GlobalLogColumn ─────────────────────────────────────────────
+ *
+ * Issue #669 — provision-wide merged log column. Reads `globalLines`
+ * (already merged + sorted by timestamp by JobDetail) and renders
+ * them through the same dark/light themed surface as the per-
+ * component view, with auto-tail-on-bottom and the search filter
+ * piped through. Each line's `message` is expected to have a
+ * component-name prefix so operators can read the column as a
+ * unified provision tail without losing source context.
+ */
+interface GlobalLogColumnProps {
+  lines: readonly LogLine[]
+  filter: LogFilter
+}
+
+function GlobalLogColumn({ lines, filter }: GlobalLogColumnProps) {
+  const filterActive = filter.query.trim().length > 0 || filter.levels.size > 0
+  const displayed = useMemo(() => {
+    if (!filterActive) return lines
+    const out: LogLine[] = []
+    for (const ll of lines) {
+      if (filter.levels.size > 0 && !filter.levels.has(ll.level)) continue
+      if (!lineMatches(ll.message, filter)) continue
+      out.push(ll)
+    }
+    return out
+  }, [lines, filter, filterActive])
+
+  const viewportRef = useRef<HTMLDivElement | null>(null)
+  const [pausedAutoScroll, setPausedAutoScroll] = useState(false)
+
+  useEffect(() => {
+    const el = viewportRef.current
+    if (!el || pausedAutoScroll) return
+    if (typeof el.scrollTo === 'function') {
+      el.scrollTo({ top: el.scrollHeight, behavior: 'smooth' })
+    } else {
+      el.scrollTop = el.scrollHeight
+    }
+  }, [displayed.length, pausedAutoScroll])
+
+  function handleScroll(e: React.UIEvent<HTMLDivElement>) {
+    const el = e.currentTarget
+    const distFromBottom = el.scrollHeight - (el.scrollTop + el.clientHeight)
+    const atBottom = distFromBottom <= 40
+    if (!atBottom && !pausedAutoScroll) setPausedAutoScroll(true)
+    else if (atBottom && pausedAutoScroll) setPausedAutoScroll(false)
+  }
+
+  const lineNumWidth = useMemo(() => {
+    const last = displayed[displayed.length - 1]
+    const digits = Math.max(3, String(last?.lineNumber ?? 0).length)
+    return `${digits}ch`
+  }, [displayed])
+
+  return (
+    <div className="log-pane-col" data-testid="log-pane-col-global">
+      <div className="log-pane-col-header" data-testid="log-pane-col-global-header">
+        <span>Global · all components</span>
+      </div>
+      <div className="log-pane-col-body">
+        <div
+          ref={viewportRef}
+          onScroll={handleScroll}
+          data-testid="global-log-viewport"
+          className="execution-logs-root"
+          style={{
+            background: 'var(--log-viewer-bg)',
+            borderRadius: 6,
+            position: 'relative',
+            overflowY: 'auto',
+            height: '100%',
+            fontFamily:
+              'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace',
+            padding: '0.5rem 0',
+          }}
+        >
+          {displayed.length === 0 ? (
+            <div
+              data-testid="global-log-empty"
+              style={{
+                padding: '1rem',
+                color: 'var(--log-viewer-empty)',
+                fontSize: '0.78rem',
+              }}
+            >
+              {filterActive
+                ? 'No global log lines match the active search.'
+                : 'No global logs captured yet.'}
+            </div>
+          ) : (
+            displayed.map((line) => (
+              <div
+                key={`${line.timestamp}-${line.lineNumber}`}
+                className="log-line-row"
+                data-testid={`global-log-line-${line.lineNumber}`}
+                data-level={line.level}
+                style={{
+                  display: 'flex',
+                  alignItems: 'flex-start',
+                  gap: '0.6rem',
+                  padding: '0.1rem 0.85rem',
+                  fontSize: '0.78rem',
+                  lineHeight: 1.55,
+                  color: 'var(--log-viewer-text)',
+                  whiteSpace: 'pre-wrap',
+                  wordBreak: 'break-word',
+                }}
+              >
+                <span
+                  style={{
+                    width: lineNumWidth,
+                    flexShrink: 0,
+                    textAlign: 'right',
+                    color: 'var(--log-viewer-text-num)',
+                    fontVariantNumeric: 'tabular-nums',
+                    userSelect: 'none',
+                  }}
+                >
+                  {line.lineNumber}
+                </span>
+                <span
+                  style={{
+                    flexShrink: 0,
+                    color: 'var(--log-viewer-text-dim)',
+                    fontVariantNumeric: 'tabular-nums',
+                  }}
+                >
+                  {formatLogTimestamp(line.timestamp)}
+                </span>
+                <span style={{ flex: '1 1 auto', minWidth: 0 }}>{line.message}</span>
+              </div>
+            ))
+          )}
+        </div>
+      </div>
+    </div>
   )
 }
 
@@ -302,8 +518,9 @@ function FallbackLogList({
   return (
     <div
       data-testid="fallback-log-list"
+      className="execution-logs-root"
       style={{
-        background: LOG_VIEWER_BG,
+        background: 'var(--log-viewer-bg)',
         borderRadius: 6,
         position: 'relative',
         overflow: 'auto',
@@ -317,7 +534,7 @@ function FallbackLogList({
           data-testid="fallback-log-empty"
           style={{
             padding: '1rem',
-            color: 'rgba(201, 209, 217, 0.55)',
+            color: 'var(--log-viewer-empty)',
             fontSize: '0.78rem',
           }}
         >
@@ -333,6 +550,7 @@ function FallbackLogList({
             <div
               key={line.lineNumber}
               data-testid={`fallback-log-line-${line.lineNumber}`}
+              className="log-line-row"
               data-level={line.level}
               data-match-position={matchPosition || undefined}
               data-focused-match={isFocusedMatch ? 'true' : undefined}
@@ -343,10 +561,10 @@ function FallbackLogList({
                 padding: '0.1rem 0.85rem',
                 fontSize: '0.78rem',
                 lineHeight: 1.55,
-                color: '#c9d1d9',
+                color: 'var(--log-viewer-text)',
                 whiteSpace: 'pre-wrap',
                 wordBreak: 'break-word',
-                background: isFocusedMatch ? 'rgba(56, 139, 253, 0.18)' : 'transparent',
+                background: isFocusedMatch ? 'var(--log-line-focused-bg)' : 'transparent',
               }}
             >
               <span
@@ -354,7 +572,7 @@ function FallbackLogList({
                   width: lineNumWidth,
                   flexShrink: 0,
                   textAlign: 'right',
-                  color: 'rgba(139, 148, 158, 0.7)',
+                  color: 'var(--log-viewer-text-num)',
                   fontVariantNumeric: 'tabular-nums',
                   userSelect: 'none',
                 }}
@@ -364,7 +582,7 @@ function FallbackLogList({
               <span
                 style={{
                   flexShrink: 0,
-                  color: 'rgba(139, 148, 158, 0.85)',
+                  color: 'var(--log-viewer-text-dim)',
                   fontVariantNumeric: 'tabular-nums',
                 }}
               >
@@ -474,15 +692,59 @@ const LOG_PANE_CSS = `
   border-color: var(--color-accent, #38BDF8);
   background: rgba(56, 189, 248, 0.10);
 }
+/* Issue #669 — log-pane body lays out as a row of columns. With one
+ * column (default) the column fills the body. With split-view on
+ * (.is-split on the root aside element) the body holds two columns
+ * side-by-side, each at 50% with a divider between them. */
 .log-pane-body {
   flex: 1 1 auto;
   overflow: hidden;
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
+  gap: 0;
+  min-height: 0;
 }
-.log-pane-body > * {
+.log-pane-col {
+  flex: 1 1 50%;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  min-width: 0;
+  border-left: 1px solid var(--color-border);
+}
+.log-pane-col:first-child {
+  border-left: 0;
+}
+.log-pane-col-header {
+  flex-shrink: 0;
+  padding: 0.35rem 0.75rem;
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 0.68rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--color-text-dim);
+  background: var(--color-bg-2);
+  border-bottom: 1px solid var(--color-border);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.log-pane-col-body {
   flex: 1 1 auto;
   min-height: 0;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+.log-pane-col-body > * {
+  flex: 1 1 auto;
+  min-height: 0;
+}
+/* Wider footprint when split-view is on so each column has breathing
+ * room. Falls back to the single-column 30vw when split is off. */
+.log-pane.is-split:not(.is-fullscreen) {
+  width: max(var(--log-pane-width, 30vw), 56vw);
 }
 .log-pane-empty {
   display: flex;

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/FlowCanvasOrganic.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/FlowCanvasOrganic.tsx
@@ -51,7 +51,14 @@ import type {
   OrganicRegion,
 } from '@/lib/flowLayoutOrganic'
 
-/* ── Status palette ──────────────────────────────────────────── */
+/* ── Status palette ──────────────────────────────────────────────────
+ *
+ * Colours are read from CSS variables defined in globals.css so the
+ * whole flow canvas reskins on `[data-theme="light"]` without touching
+ * this file. Each status has a six-token surface (fill / ring / glyph
+ * / glow / edge / arrow). Tokens are looked up via `var(--bubble-*)`
+ * inline so hot-reload + theme flips work without re-mounting.
+ */
 
 interface StatusTone {
   fill: string
@@ -64,88 +71,92 @@ interface StatusTone {
 }
 const STATUS_TONE: Record<JobStatus, StatusTone> = {
   succeeded: {
-    fill: '#0F1F18',
-    ring: 'rgba(74,222,128,0.78)',
-    glyph: '#86EFAC',
-    glow: 'rgba(74,222,128,0.20)',
-    edge: 'rgba(74,222,128,0.55)',
-    arrow: '#4ADE80',
+    fill: 'var(--bubble-fill-succeeded)',
+    ring: 'var(--bubble-ring-succeeded)',
+    glyph: 'var(--bubble-glyph-succeeded)',
+    glow: 'var(--bubble-glow-succeeded)',
+    edge: 'var(--bubble-edge-succeeded)',
+    arrow: 'var(--bubble-arrow-succeeded)',
     label: 'Succeeded',
   },
   running: {
-    fill: '#0E1A33',
-    ring: 'rgba(56,189,248,0.85)',
-    glyph: '#BAE6FD',
-    glow: 'rgba(56,189,248,0.30)',
-    edge: 'rgba(56,189,248,0.65)',
-    arrow: '#38BDF8',
+    fill: 'var(--bubble-fill-running)',
+    ring: 'var(--bubble-ring-running)',
+    glyph: 'var(--bubble-glyph-running)',
+    glow: 'var(--bubble-glow-running)',
+    edge: 'var(--bubble-edge-running)',
+    arrow: 'var(--bubble-arrow-running)',
     label: 'Running',
   },
   failed: {
-    fill: '#23070A',
-    ring: 'rgba(248,113,113,0.85)',
-    glyph: '#FCA5A5',
-    glow: 'rgba(248,113,113,0.30)',
-    edge: 'rgba(248,113,113,0.65)',
-    arrow: '#F87171',
+    fill: 'var(--bubble-fill-failed)',
+    ring: 'var(--bubble-ring-failed)',
+    glyph: 'var(--bubble-glyph-failed)',
+    glow: 'var(--bubble-glow-failed)',
+    edge: 'var(--bubble-edge-failed)',
+    arrow: 'var(--bubble-arrow-failed)',
     label: 'Failed',
   },
   pending: {
-    fill: '#0D1726',
-    ring: 'rgba(148,163,184,0.45)',
-    glyph: 'rgba(148,163,184,0.65)',
-    glow: 'transparent',
-    edge: 'rgba(148,163,184,0.32)',
-    arrow: 'rgba(148,163,184,0.60)',
+    fill: 'var(--bubble-fill-pending)',
+    ring: 'var(--bubble-ring-pending)',
+    glyph: 'var(--bubble-glyph-pending)',
+    glow: 'var(--bubble-glow-pending)',
+    edge: 'var(--bubble-edge-pending)',
+    arrow: 'var(--bubble-arrow-pending)',
     label: 'Pending',
   },
 }
 
-/** Bug #481 follow-up — the previous fix (#483) over-corrected.
- *  Symptoms after #483: bubbles invisible at default zoom, edges
- *  appeared to stretch infinitely. Root causes:
- *    (1) NODE_RADIUS was still 22 → diameter 44 → at MAX_VBOX 1600
- *        scale 0.4-0.5 in a 600-800px canvas-host (LogPane covers half
- *        the screen), bubbles rendered ~16-22px wide. Effectively
- *        invisible to the operator.
- *    (2) MIN_VBOX_W/H floors at 1200×700 forced sparse graphs (4-6
- *        nodes spread across 200×100 of layout space) into a viewBox
- *        6× bigger than the cluster — bubbles shrank to specks.
- *    (3) FORCE_X_STRENGTH=0.55 + FORCE_LINK_STRENGTH=0.45 fought hard
- *        on graphs with depth-disparate dependencies (depth 0 root
- *        wired to depth-5 leaf), causing oscillation that read as
- *        "infinitely stretching" in mid-tick frames.
+/** SVG `<marker>` elements cannot read CSS variables directly inside
+ *  attributes that the browser resolves at definition time (Chrome's
+ *  marker resolution does not propagate `currentColor` through `<marker>`
+ *  consistently). Concrete fallback colours used only inside the
+ *  arrow-marker `<defs>` — bubble + edge strokes themselves use the
+ *  CSS-variable tokens above. The marker fill is a small visual
+ *  arrowhead and these fallbacks read acceptable on both themes. */
+const ARROW_FALLBACK: Record<JobStatus, string> = {
+  succeeded: '#16A34A',
+  running:   '#38BDF8',
+  failed:    '#B91C1C',
+  pending:   '#94A3B8',
+}
+
+/** Issue #669 — bubble sizing decoupled from canvas size.
  *
- *  The fix:
- *    • NODE_RADIUS 22 → 40 (diameter 80px — meets acceptance: bubble
- *      ≥80px wide on 1440×900 viewport).
- *    • MIN_VBOX dropped to a small floor (400×280) so sparse graphs
- *      render at native scale without the SVG zooming out to fit a
- *      pretend 1200×700 canvas.
- *    • MAX_VBOX 1600×900 → 1200×700 so even on full-screen canvas the
- *      effective render scale stays close to 1:1.
- *    • Force strengths balanced: X=0.12, Y=0.10, link=0.18 — gentle
- *      enough not to oscillate, strong enough to converge.
- *    • LINK_DISTANCE = NODE_RADIUS * 2.5 = 100px → connected siblings
- *      stay <140px apart at steady state, well under the 300px
- *      acceptance ceiling.
- *    • Per-tick X clamp tightened to ±PER_DEPTH_X (was ±1.5×) so depth
- *      anchoring stays disciplined.
+ *  The previous design coupled bubble radius to the SVG viewBox: viewBox
+ *  was capped at MAX_VBOX 1200×700 and `preserveAspectRatio="xMidYMid
+ *  meet"` upscaled the entire content to fit the host. On full-screen,
+ *  that upscale made bubbles bigger instead of giving the dependency
+ *  chain more horizontal room.
+ *
+ *  Fix: viewBox = host pixel dimensions (driven by ResizeObserver), so
+ *  NODE_RADIUS=40 means literally 40 CSS px on screen, regardless of
+ *  host size. Extra horizontal canvas space becomes layout space along
+ *  the dep chain.
+ *
+ *  No-overlap rule: the previous projection-scale fallback (`xScale`)
+ *  compressed positions but not radii — guaranteed overlap on wide
+ *  clusters. Removed entirely. forceCollide (radius NODE_RADIUS +
+ *  COLLIDE_PADDING, strength 0.95, iterations 2) is now the single
+ *  source of pairwise spacing, applied to the rendered positions
+ *  directly. Wide clusters that don't fit get clamped at the viewBox
+ *  edge by the per-tick clamp; forceCollide then resolves any
+ *  edge-induced overlaps within the visible window.
  */
 const NODE_RADIUS = 40
 const GROUP_RADIUS = 48
 const COLLIDE_PADDING = 12
-/** Floor for very-sparse graphs — enough room for 1-3 nodes without
- *  the SVG collapsing to a single point. Anything denser uses the
- *  measured cluster bbox + padding. */
-const MIN_VBOX_W = 400
-const MIN_VBOX_H = 280
-/** MAX_VBOX matters because preserveAspectRatio "meet" scales the
- *  viewBox to fit the canvas-host. With MAX 1200×700, on a 1200px-wide
- *  host scale=1.0 (bubble = 80px). On a 600px host scale=0.5 (bubble =
- *  40px — still readable, vs the previous 22px). */
-const MAX_VBOX_W = 1200
-const MAX_VBOX_H = 700
+/** Initial host dimensions used until ResizeObserver fires.
+ *
+ *  ResizeObserver emits asynchronously after mount, so on first paint
+ *  we lay out against a sensible default rather than 0×0 (which would
+ *  collapse every node onto the origin and break forceCollide's
+ *  pairwise spacing). 1200×700 mirrors the previous MAX_VBOX seed —
+ *  the first frame renders against that, then the observer's first
+ *  callback corrects to the real host pixel rect within ~16ms. */
+const MIN_HOST_W = 1200
+const MIN_HOST_H = 700
 /** Per-depth column width — wider than NODE_RADIUS*4 so adjacent-depth
  *  bubbles never visually touch. */
 const PER_DEPTH_X = NODE_RADIUS * 4
@@ -202,11 +213,45 @@ export function FlowCanvasOrganic(props: FlowCanvasOrganicProps) {
   } = props
 
   const svgRef = useRef<SVGSVGElement | null>(null)
+  const hostRef = useRef<HTMLDivElement | null>(null)
   const simRef = useRef<Simulation<SimNode, SimulationLinkDatum<SimNode>> | null>(
     null,
   )
   const nodesRef = useRef<Map<string, SimNode>>(new Map())
   const [tick, setTick] = useState(0)
+  /* Issue #669 — track the canvas-host pixel dimensions so the
+   * viewBox can equal them 1:1. Bubble radius (CSS px) then stays
+   * constant regardless of host size; full-screening the canvas
+   * gives the dep chain more horizontal room instead of magnifying
+   * each bubble. */
+  const [hostSize, setHostSize] = useState<{ w: number; h: number }>({
+    w: MIN_HOST_W,
+    h: MIN_HOST_H,
+  })
+
+  useEffect(() => {
+    const el = hostRef.current
+    if (!el) return
+    // ResizeObserver may fire synchronously during layout — use rAF to
+    // batch state updates so we never trigger a re-render mid-tick.
+    let raf = 0
+    const ro = new ResizeObserver((entries) => {
+      const e = entries[0]
+      if (!e) return
+      const rect = e.contentRect
+      const w = Math.max(MIN_HOST_W, Math.round(rect.width))
+      const h = Math.max(MIN_HOST_H, Math.round(rect.height))
+      cancelAnimationFrame(raf)
+      raf = requestAnimationFrame(() => {
+        setHostSize((prev) => (prev.w === w && prev.h === h ? prev : { w, h }))
+      })
+    })
+    ro.observe(el)
+    return () => {
+      cancelAnimationFrame(raf)
+      ro.disconnect()
+    }
+  }, [])
   // Issue #532 — mutable tick counter shared between the sim's tick
   // callback and the drag-handler effect. dragstart resets tickCount to
   // 0 so each drag gets a fresh MAX_TICKS budget; without this, after
@@ -220,9 +265,15 @@ export function FlowCanvasOrganic(props: FlowCanvasOrganicProps) {
   // Regions still drive family/region badges in FlowNode but no longer
   // partition the canvas vertically — the dependency order does.
 
+  /* Issue #669 — anchor depth 0 at a left margin instead of x=0 so the
+   * grid-target sub-columns (centred on baseX with span ±SUB_COL_SPAN)
+   * don't extend into negative X. With viewBox = host px starting at
+   * 0,0 (preserveAspectRatio "xMinYMin meet"), negative coordinates
+   * render off-canvas to the left. */
+  const X_LEFT_MARGIN = NODE_RADIUS + PER_DEPTH_X / 2
   const depthToX = useCallback(
-    (depth: number) => depth * PER_DEPTH_X,
-    [],
+    (depth: number) => X_LEFT_MARGIN + depth * PER_DEPTH_X,
+    [X_LEFT_MARGIN],
   )
 
   /* Issue #532 — resolve a per-node depRank.
@@ -265,7 +316,10 @@ export function FlowCanvasOrganic(props: FlowCanvasOrganicProps) {
    * forceCollide guarantees pairwise spacing while siblings pack into
    * the available vertical band naturally. */
   const Y_MARGIN = NODE_RADIUS + COLLIDE_PADDING
-  const Y_RANGE = Math.max(NODE_RADIUS * 2, MAX_VBOX_H - Y_MARGIN * 2)
+  /* Issue #669 — Y-range driven by hostSize.h, not a hardcoded MAX_VBOX
+   * ceiling. ResizeObserver on the canvas-host re-runs this whenever
+   * the host pixel height changes (e.g. fullscreen, log-pane closed). */
+  const Y_RANGE = Math.max(NODE_RADIUS * 2, hostSize.h - Y_MARGIN * 2)
   const totalNodes = layout.nodes.length
   const yForDepRank = useCallback(
     (depRank: number) => {
@@ -311,7 +365,7 @@ export function FlowCanvasOrganic(props: FlowCanvasOrganicProps) {
     }
     const ROW_PITCH = NODE_RADIUS * 2 + COLLIDE_PADDING
     const Y_MARGIN_LOCAL = NODE_RADIUS + COLLIDE_PADDING
-    const Y_RANGE_LOCAL = Math.max(NODE_RADIUS * 2, MAX_VBOX_H - Y_MARGIN_LOCAL * 2)
+    const Y_RANGE_LOCAL = Math.max(NODE_RADIUS * 2, hostSize.h - Y_MARGIN_LOCAL * 2)
     // How many bubbles fit vertically with the no-overlap collision
     // pitch (NODE_RADIUS*2 + COLLIDE_PADDING = 92px on 700px viewBox →
     // 7 rows). Beyond that, we MUST add sub-columns or bubbles overlap.
@@ -331,7 +385,11 @@ export function FlowCanvasOrganic(props: FlowCanvasOrganicProps) {
       // column vertical capacity. Sparse depths keep the original
       // force-anchor behaviour (depthX + depRank-based Y).
       if (bucket.length <= COL_CAPACITY) continue
-      const baseX = depth * PER_DEPTH_X
+      // Issue #669 — anchor at depthToX (NODE_RADIUS + PER_DEPTH_X/2 +
+      // depth * PER_DEPTH_X) so sub-columns centred on baseX never
+      // extend into negative X (which would render off-canvas under
+      // the new viewBox = host-px convention).
+      const baseX = X_LEFT_MARGIN + depth * PER_DEPTH_X
       // Issue #532: with N siblings in a depth bucket and Y-range
       // budget that fits COL_CAPACITY rows at the no-overlap pitch,
       // we need ceil(N / COL_CAPACITY) sub-columns. Each sub-column
@@ -372,7 +430,7 @@ export function FlowCanvasOrganic(props: FlowCanvasOrganicProps) {
       })
     }
     return cells
-  }, [layout.nodes])
+  }, [layout.nodes, hostSize.h, X_LEFT_MARGIN])
 
   const simNodes = useMemo<SimNode[]>(() => {
     const next: SimNode[] = []
@@ -529,7 +587,7 @@ export function FlowCanvasOrganic(props: FlowCanvasOrganicProps) {
               ? SUB_COL_SPAN / (cell.totalCols - 1)
               : PER_DEPTH_X
             const Y_MARGIN_LOCAL = NODE_RADIUS + COLLIDE_PADDING
-            const Y_RANGE_LOCAL = Math.max(NODE_RADIUS * 2, MAX_VBOX_H - Y_MARGIN_LOCAL * 2)
+            const Y_RANGE_LOCAL = Math.max(NODE_RADIUS * 2, hostSize.h - Y_MARGIN_LOCAL * 2)
             const rowSlot = cell.totalRows > 1
               ? Y_RANGE_LOCAL / (cell.totalRows - 1)
               : Y_RANGE_LOCAL
@@ -548,20 +606,28 @@ export function FlowCanvasOrganic(props: FlowCanvasOrganicProps) {
             continue
           }
           const baseX = depthToX(n.depth)
-          // Sparse-depth fallback — clamp X around the depth column,
-          // Y around the dep-rank slot ± half the collision pitch so
-          // siblings of identical depRank can still separate via the
-          // forceCollide pass without escaping the rank-ordered band.
-          const xMin = baseX - PER_DEPTH_X
-          const xMax = baseX + PER_DEPTH_X
+          /* Sparse-depth fallback — clamp X around the depth column,
+           * Y around the dep-rank slot ± half the collision pitch so
+           * siblings of identical depRank can still separate via the
+           * forceCollide pass without escaping the rank-ordered band.
+           *
+           * Issue #669 — also clamp X+Y inside hostSize so no node
+           * settles outside the viewBox. forceCollide is the no-
+           * overlap guarantee, but it only resolves overlaps inside
+           * the simulated coordinate space; if sim positions are
+           * outside the viewBox, post-render clamping cannot recover
+           * pairwise spacing. Keep the sim inside the visible window
+           * end-to-end. */
+          const xMin = Math.max(NODE_RADIUS, baseX - PER_DEPTH_X)
+          const xMax = Math.min(hostSize.w - NODE_RADIUS, baseX + PER_DEPTH_X)
           if (typeof n.x === 'number') {
             if (n.x < xMin) n.x = xMin
             else if (n.x > xMax) n.x = xMax
           }
           const targetY = yForDepRank(n.depRank)
           const Y_HALF_BAND = (NODE_RADIUS * 2 + COLLIDE_PADDING)
-          const yMin = targetY - Y_HALF_BAND
-          const yMax = targetY + Y_HALF_BAND
+          const yMin = Math.max(NODE_RADIUS, targetY - Y_HALF_BAND)
+          const yMax = Math.min(hostSize.h - NODE_RADIUS, targetY + Y_HALF_BAND)
           if (typeof n.y === 'number') {
             if (n.y < yMin) n.y = yMin
             else if (n.y > yMax) n.y = yMax
@@ -584,7 +650,7 @@ export function FlowCanvasOrganic(props: FlowCanvasOrganicProps) {
     return () => {
       sim.stop()
     }
-  }, [simNodes, layout.edges, depthToX, yForDepRank, gridTargets])
+  }, [simNodes, layout.edges, depthToX, yForDepRank, gridTargets, hostSize.h, hostSize.w])
 
   const nodeIdsKey = simNodes.map((n) => n.id).join(',')
   useEffect(() => {
@@ -640,6 +706,7 @@ export function FlowCanvasOrganic(props: FlowCanvasOrganicProps) {
   if (layout.nodes.length === 0) {
     return (
       <div
+        ref={hostRef}
         data-testid="flow-canvas-empty"
         className="rounded-xl border border-dashed border-[var(--color-border)] p-8 text-center text-sm text-[var(--color-text-dim)]"
       >
@@ -663,94 +730,44 @@ export function FlowCanvasOrganic(props: FlowCanvasOrganicProps) {
     }
   }
 
-  // Bug #481 (reopened 2026-05-01) — operator's exact words:
-  //   "they could have put a simple rule saying the max distance of a
-  //    line cannot be longer than a percentage of canvas, or they could
-  //    say no single bubble could be outside of the canvas etc."
-  //
-  // Live failure on otech17: a single dependency chain reached depth
-  // 190 (e.g. bp-catalyst-platform → bp-langfuse → ... long chain). At
-  // PER_DEPTH_X=160 that placed leaves at x=30,400+. Per-tick clamps
-  // bound nodes around their own depth-anchor (which itself was at
-  // 30,400) so they never came back into view — and the viewBox
-  // ceiling MAX_VBOX_W=1200 captured only a 1200px slice of a 30,000px
-  // cluster. The yellow horizontal lines on screen were the few edges
-  // that happened to cross the visible 1200px window; every bubble was
-  // off-canvas.
-  //
-  // The bounded tests passed because they asserted positions inside
-  // the viewBox for 5-80 sibling stars, but never modelled a deep
-  // chain (the actual production shape).
-  //
-  // Structural fix per operator's ask: "no single bubble could be
-  // outside of the canvas". After the natural bbox is computed, clamp
-  // it to MAX so the viewBox stays bounded, then HARD-CLAMP every
-  // rendered position into the viewBox. Edges are then drawn between
-  // already-clamped positions, so the second rule ("max line length")
-  // is also bounded as a side effect (any link is at most the
-  // viewBox's diagonal).
-  let bbMinX = Infinity, bbMinY = Infinity, bbMaxX = -Infinity, bbMaxY = -Infinity
-  for (const p of livePos.values()) {
-    if (p.x < bbMinX) bbMinX = p.x
-    if (p.y < bbMinY) bbMinY = p.y
-    if (p.x > bbMaxX) bbMaxX = p.x
-    if (p.y > bbMaxY) bbMaxY = p.y
-  }
-  const PAD_X = NODE_RADIUS + 30
-  const PAD_Y_TOP = NODE_RADIUS + 12
-  const PAD_Y_BOTTOM = NODE_RADIUS + 40
-  const naturalW = (bbMaxX - bbMinX) + PAD_X * 2
-  const naturalH = (bbMaxY - bbMinY) + PAD_Y_TOP + PAD_Y_BOTTOM
-  const vbW = Math.min(MAX_VBOX_W, Math.max(MIN_VBOX_W, naturalW))
-  const vbH = Math.min(MAX_VBOX_H, Math.max(MIN_VBOX_H, naturalH))
-  // Bug #481 — when the natural bbox is wider than MAX_VBOX, anchor
-  // the viewBox at the LEFT-MOST cluster point (depth 0) instead of
-  // centring on the cluster centroid. Centring put depth 0 at
-  // x=-15,000 off-canvas; left-anchor keeps the visible 1200px slice
-  // starting at the actual left edge of the data, where the operator
-  // expects depth-0 root nodes to live.
-  const naturalCx = Number.isFinite(bbMinX) ? (bbMinX + bbMaxX) / 2 : vbW / 2
-  const naturalCy = Number.isFinite(bbMinY) ? (bbMinY + bbMaxY) / 2 : vbH / 2
-  const vbX = naturalW > MAX_VBOX_W && Number.isFinite(bbMinX)
-    ? bbMinX - PAD_X
-    : naturalCx - vbW / 2
-  const vbY = naturalH > MAX_VBOX_H && Number.isFinite(bbMinY)
-    ? bbMinY - PAD_Y_TOP
-    : naturalCy - vbH / 2
+  /* Issue #669 — viewBox = host pixel dimensions (1:1).
+   *
+   * Bubble radius (NODE_RADIUS=40 in viewBox units) renders at exactly
+   * 40 CSS px on screen because the viewBox now equals the host's
+   * pixel rect — there is no preserveAspectRatio scale. Full-screening
+   * the canvas grows hostSize.w / hostSize.h, which gives the
+   * dependency chain more layout room along x without changing bubble
+   * size. The preserveAspectRatio default is "xMidYMid meet", which is
+   * a no-op when viewBox dims = SVG dims.
+   *
+   * The previous bbox-then-scale-then-clamp pipeline actively caused
+   * overlap on wide clusters because position scaling did not also
+   * scale the rendered radius. forceCollide's pairwise distance
+   * guarantee then no longer held in screen space. Removed.
+   *
+   * For wide clusters that don't fit in hostSize.w (deep dep chains),
+   * the per-tick clamp at line 540-606 already pulls nodes back inside
+   * the viewBox window, and forceCollide resolves resulting clusters
+   * within the visible area. We do NOT compress positions; we let the
+   * sim clamp positions, which preserves the no-overlap guarantee.
+   */
+  const vbX = 0
+  const vbY = 0
+  const vbW = hostSize.w
+  const vbH = hostSize.h
 
-  // Bug #481 — Constraint A: hard-clamp every render position into the
-  // viewBox so no bubble ever drifts off-canvas, regardless of what the
-  // simulation, depth-anchor, or grid-target produced. Operator's exact
-  // request: "no single bubble could be outside of the canvas".
-  //
-  // For pathological-width clusters (depth-190 chains with naturalW
-  // ≈ 30,000 vs MAX_VBOX_W=1200) plain clamping would pile every
-  // distant node on the right edge. Solve that by scaling the X axis
-  // proportionally to fit the viewBox, then clamping as a final
-  // safety net. Y gets the same treatment.
+  /* Hard-clamp positions to viewBox. The per-tick clamp inside the sim
+   * also clamps, but ResizeObserver may shrink hostSize between sim
+   * ticks (drag of the LogPane); applying the clamp here ensures
+   * rendering never paints a bubble outside the visible area, even
+   * one frame. forceCollide already guarantees pairwise spacing of
+   * ≥ NODE_RADIUS*2 + COLLIDE_PADDING (= 92 px), and clamping to a
+   * single edge cannot reduce two clamped nodes' distance below that
+   * threshold (the collide pass owns it pre-render). */
   const CLAMP_INSET = NODE_RADIUS + 8
-  const usableW = vbW - CLAMP_INSET * 2
-  const usableH = vbH - CLAMP_INSET * 2
-  const xScale = naturalW > vbW && (bbMaxX - bbMinX) > 0
-    ? usableW / (bbMaxX - bbMinX)
-    : 1
-  const yScale = naturalH > vbH && (bbMaxY - bbMinY) > 0
-    ? usableH / (bbMaxY - bbMinY)
-    : 1
   const project = (p: { x: number; y: number }) => {
-    let x = p.x
-    let y = p.y
-    if (xScale < 1 && Number.isFinite(bbMinX)) {
-      x = vbX + CLAMP_INSET + (p.x - bbMinX) * xScale
-    }
-    if (yScale < 1 && Number.isFinite(bbMinY)) {
-      y = vbY + CLAMP_INSET + (p.y - bbMinY) * yScale
-    }
-    // Final safety clamp — even when scaling, FP drift / partial-tick
-    // values can land a fraction outside; the inset clamp guarantees
-    // the bubble's full diameter stays visible.
-    x = Math.min(vbX + vbW - CLAMP_INSET, Math.max(vbX + CLAMP_INSET, x))
-    y = Math.min(vbY + vbH - CLAMP_INSET, Math.max(vbY + CLAMP_INSET, y))
+    const x = Math.min(vbW - CLAMP_INSET, Math.max(CLAMP_INSET, p.x))
+    const y = Math.min(vbH - CLAMP_INSET, Math.max(CLAMP_INSET, p.y))
     return { x, y }
   }
   const renderPos = new Map<string, { x: number; y: number }>()
@@ -759,12 +776,24 @@ export function FlowCanvasOrganic(props: FlowCanvasOrganicProps) {
   }
 
   return (
+    <div
+      ref={hostRef}
+      data-testid="flow-canvas-host"
+      style={{
+        position: 'relative',
+        width: '100%',
+        height: '100%',
+        minHeight: 0,
+        minWidth: 0,
+        overflow: 'hidden',
+      }}
+    >
     <svg
       ref={svgRef}
       width="100%"
       height="100%"
-      viewBox={`${vbX.toFixed(1)} ${vbY.toFixed(1)} ${vbW.toFixed(1)} ${vbH.toFixed(1)}`}
-      preserveAspectRatio="xMidYMid meet"
+      viewBox={`${vbX} ${vbY} ${vbW} ${vbH}`}
+      preserveAspectRatio="xMinYMin meet"
       className="flow-canvas-svg-organic"
       data-testid="flow-canvas-svg"
       role="img"
@@ -786,7 +815,7 @@ export function FlowCanvasOrganic(props: FlowCanvasOrganicProps) {
             markerHeight="6"
             orient="auto-start-reverse"
           >
-            <path d="M0,1 L9,5 L0,9 Z" fill={STATUS_TONE[s].arrow} opacity="0.92" />
+            <path d="M0,1 L9,5 L0,9 Z" fill={ARROW_FALLBACK[s]} opacity="0.92" />
           </marker>
         ))}
         <marker
@@ -862,6 +891,7 @@ export function FlowCanvasOrganic(props: FlowCanvasOrganicProps) {
         )
       })}
     </svg>
+    </div>
   )
 }
 
@@ -1060,13 +1090,14 @@ function FlowNode({
         </text>
       )}
 
-      {/* Label below bubble */}
+      {/* Label below bubble — routed through CSS var so it flips on
+          [data-theme="light"] (issue #669). */}
       <text
         x={0}
         y={radius + 14}
         textAnchor="middle"
         fontSize={10}
-        fill="rgba(255,255,255,0.85)"
+        fill="var(--bubble-label)"
         fontFamily="var(--font-mono, ui-monospace, monospace)"
         pointerEvents="none"
       >
@@ -1080,7 +1111,7 @@ function FlowNode({
           y={radius + 26}
           textAnchor="middle"
           fontSize={8}
-          fill="rgba(255,255,255,0.45)"
+          fill="var(--bubble-sublabel)"
           fontFamily="var(--font-mono, ui-monospace, monospace)"
           pointerEvents="none"
         >

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/JobDetail.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/JobDetail.test.tsx
@@ -149,13 +149,17 @@ function renderDetailWithLiveJobs(
 }
 
 describe('JobDetail — v3 surface (full-bleed canvas + LogPane, no tab strip)', () => {
-  it('renders the two-line header with the populated jobId', async () => {
+  it('renders the collapsed header (#669) with the back link, last-update + status chip', async () => {
+    // Issue #669 — the in-page job-detail-title was removed (PortalShell
+    // owns the page title now). The header strip keeps the back link,
+    // last-update timestamp and status chip; the page title lives in
+    // PortalShell's portal-header-title.
     renderDetail('d-1', 'bp-cilium')
     await waitFor(() => {
-      const header = screen.queryByTestId('job-detail-header')
-      const title = screen.queryByTestId('job-detail-title')
-      expect(header).toBeTruthy()
-      expect(title).toBeTruthy()
+      expect(screen.queryByTestId('job-detail-header')).toBeTruthy()
+      expect(screen.queryByTestId('job-detail-back')).toBeTruthy()
+      expect(screen.queryByTestId('job-detail-status')).toBeTruthy()
+      expect(screen.queryByTestId('portal-header-title')).toBeTruthy()
     })
   })
 
@@ -210,7 +214,8 @@ describe('JobDetail — backend-format jobId lookup (regression for #245 not-fou
       expect(screen.queryByTestId('job-detail-not-found')).toBeNull()
       expect(screen.queryByTestId(`job-detail-${jobId}`)).toBeTruthy()
     })
-    expect(screen.getByTestId('job-detail-title').textContent).toBe('Install Cilium')
+    // Issue #669 — title now lives in PortalShell's portal-header-title.
+    expect(screen.getByTestId('portal-header-title').textContent).toBe('Install Cilium')
   })
 
   it('still renders not-found when no live job AND no reducer-derived job matches', async () => {

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/JobDetail.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/JobDetail.tsx
@@ -147,6 +147,37 @@ export function JobDetail({
     return stepsToLogLines(dj.steps)
   }, [executionId, selectedJob, jobId, derivedJobsById])
 
+  // Issue #669 — provision-wide global log stream. Merge the SSE-event
+  // step log of every derived job (Phase 0, cluster-bootstrap, every
+  // bp-*) into a single timestamp-sorted list. Each line's message is
+  // prefixed with the source job's display name so the column reads as
+  // a unified provision tail without losing the per-component context.
+  // Re-runs on every reducer state change (every SSE event) so the
+  // global stream is live, no polling needed.
+  const globalLines = useMemo<LogLine[]>(() => {
+    const merged: Array<{ ts: number; line: LogLine }> = []
+    let counter = 1
+    for (const dj of derivedJobs) {
+      const label = dj.displayName ?? dj.jobName ?? dj.id
+      for (const ll of stepsToLogLines(dj.steps)) {
+        const ts = ll.timestamp ? Date.parse(ll.timestamp) : NaN
+        merged.push({
+          ts: Number.isFinite(ts) ? ts : 0,
+          line: {
+            lineNumber: counter++,
+            timestamp: ll.timestamp,
+            level: ll.level,
+            message: `[${label}] ${ll.message}`,
+          },
+        })
+      }
+    }
+    merged.sort((a, b) => a.ts - b.ts)
+    // Renumber after sort so lineNumber reads top-down in chronological
+    // order rather than the per-job order produced above.
+    return merged.map((m, i) => ({ ...m.line, lineNumber: i + 1 }))
+  }, [derivedJobs])
+
   const onCanvasJobSelect = useCallback(
     (id: string | null) => {
       // Empty / null — operator clicked the canvas background; restore
@@ -190,19 +221,8 @@ export function JobDetail({
 
   const badge = statusBadge(job.status as JobUiStatus)
   const lastUpdate = job.finishedAt ?? job.startedAt
-  const parent = job.parentId ? jobsById[job.parentId] ?? null : null
-  const parentLabel = parent ? parent.displayName ?? parent.jobName : null
   const titleLabel = job.displayName ?? job.jobName
-
-  // Subtitle pieces — composed into a single line so the chrome stays
-  // at 2 lines (header title + meta). Empty pieces drop out.
-  const subtitlePieces: string[] = [job.id]
-  if (job.appId && job.appId !== 'infrastructure' && job.appId !== 'cluster-bootstrap' && job.type !== 'group') {
-    subtitlePieces.push(job.appId)
-  }
-  if (parentLabel) subtitlePieces.push(parentLabel)
   const lastUpdateLabel = fmtTime(lastUpdate)
-  if (lastUpdateLabel) subtitlePieces.push(`last update ${lastUpdateLabel}`)
 
   // LogPane title + status — driven by the SELECTED job (operator
   // clicked something), defaulting to the host job.
@@ -221,31 +241,31 @@ export function JobDetail({
       >
         <style>{JOB_DETAIL_CSS}</style>
 
-        {/* Two-line compact header with status chip top-right. */}
+        {/* Issue #669 — collapsed header.
+         *
+         * The page title (titleLabel) is already rendered by PortalShell
+         * via `pageTitle={titleLabel}` above; we no longer duplicate it
+         * here. The previous subtitle row (`<jobId> · <appId> ·
+         * <parentDisplayName> · last update`) is gone — jobId / appId /
+         * parent are derivable from the title and the canvas selection,
+         * and the only piece operators routinely scan is the
+         * last-update timestamp, which now lives inline next to the
+         * back link. Title + status chip remain available; meta clutter
+         * does not. */}
         <header className="job-detail-header" data-testid="job-detail-header">
-          <div className="job-detail-header-titles">
-            <div className="job-detail-header-line1">
-              <Link
-                to="/provision/$deploymentId/jobs"
-                params={{ deploymentId }}
-                className="job-detail-back"
-                data-testid="job-detail-back"
-              >
-                ← Back to jobs
-              </Link>
-              <h1 className="job-detail-title" data-testid="job-detail-title" title={titleLabel}>
-                {titleLabel}
-              </h1>
-            </div>
-            <div className="job-detail-header-line2" data-testid="job-detail-meta">
-              {subtitlePieces.map((p, idx) => (
-                <span key={idx} className="job-detail-meta-piece">
-                  {idx > 0 ? <span className="job-detail-meta-sep" aria-hidden> · </span> : null}
-                  {p}
-                </span>
-              ))}
-            </div>
-          </div>
+          <Link
+            to="/provision/$deploymentId/jobs"
+            params={{ deploymentId }}
+            className="job-detail-back"
+            data-testid="job-detail-back"
+          >
+            ← Back to jobs
+          </Link>
+          {lastUpdateLabel ? (
+            <span className="job-detail-last-update" data-testid="job-detail-last-update">
+              last update {lastUpdateLabel}
+            </span>
+          ) : null}
           <span
             className={`job-detail-status-chip ${badge.classes}`}
             data-testid="job-detail-status"
@@ -274,25 +294,11 @@ export function JobDetail({
           />
         </div>
 
-        {/* When the pane is closed, surface a small re-open button so
-            the operator can recover the log surface without having to
-            click a bubble. Stays out of the way (top-right of the
-            canvas area). */}
-        {!paneOpen ? (
-          <button
-            type="button"
-            className="job-detail-reopen-pane"
-            data-testid="job-detail-reopen-pane"
-            aria-label="Show log pane"
-            title="Show log pane"
-            onClick={() => setPaneOpen(true)}
-          >
-            <svg width="14" height="14" viewBox="0 0 14 14" aria-hidden>
-              <path d="M2 3 L12 3 M2 7 L12 7 M2 11 L8 11" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
-            </svg>
-            Logs
-          </button>
-        ) : null}
+        {/* Issue #669 — the floating "Logs" reopen chip overlapped the
+         * status chip in the top-right corner. Removed: operators
+         * reopen the pane by clicking any bubble in the canvas (still
+         * wired in `onCanvasJobSelect`), or by toggling fullscreen
+         * with the existing keyboard shortcut. */}
       </div>
 
       {/* Floating log pane — open by default on the host's logs.
@@ -302,6 +308,7 @@ export function JobDetail({
         <CanvasLogBridge
           executionId={executionId}
           fallbackLines={fallbackLines}
+          globalLines={globalLines}
           jobTitle={logPaneJob.displayName ?? logPaneJob.jobName}
           jobStatus={logPaneStatus}
           onClose={() => {
@@ -326,6 +333,8 @@ interface CanvasLogBridgeProps {
   executionId: string | null | undefined
   /** Bug #481 — derived-job fallback lines (Phase-0, cluster-bootstrap). */
   fallbackLines: readonly LogLine[]
+  /** Issue #669 — provision-wide merged log stream. */
+  globalLines: readonly LogLine[]
   jobTitle: string
   jobStatus: string
   onClose: () => void
@@ -334,6 +343,7 @@ interface CanvasLogBridgeProps {
 function CanvasLogBridge({
   executionId,
   fallbackLines,
+  globalLines,
   jobTitle,
   jobStatus,
   onClose,
@@ -346,6 +356,7 @@ function CanvasLogBridge({
     <LogPane
       executionId={executionId ?? null}
       fallbackLines={fallbackLines}
+      globalLines={globalLines}
       jobTitle={jobTitle}
       statusLabel={jobStatus}
       statusTone={tone}
@@ -411,56 +422,18 @@ const JOB_DETAIL_CSS = `
 .job-detail-page.is-pane-closed {
   padding-right: 1rem;
 }
-.job-detail-reopen-pane {
-  position: absolute;
-  top: 12px;
-  right: 12px;
-  display: inline-flex;
-  align-items: center;
-  gap: 0.4rem;
-  padding: 0.32rem 0.7rem;
-  border-radius: 999px;
-  border: 1px solid var(--color-border);
-  background: var(--color-surface);
-  color: var(--color-text-dim);
-  font-size: 0.72rem;
-  font-weight: 600;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-  cursor: pointer;
-  z-index: 50;
-  transition: color 0.12s ease, background-color 0.12s ease, border-color 0.12s ease;
-}
-.job-detail-reopen-pane:hover {
-  color: var(--color-text-strong);
-  border-color: var(--color-text-dim);
-  background: rgba(148, 163, 184, 0.08);
-}
 
 .job-detail-header {
   display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
+  align-items: center;
   gap: 1rem;
   padding-bottom: 0.45rem;
   border-bottom: 1px solid var(--color-border);
   flex-shrink: 0;
-}
-.job-detail-header-titles {
-  display: flex;
-  flex-direction: column;
-  min-width: 0;
-  flex: 1 1 auto;
-  gap: 0.05rem;
-}
-.job-detail-header-line1 {
-  display: flex;
-  align-items: baseline;
-  gap: 0.7rem;
   min-width: 0;
 }
 .job-detail-back {
-  font-size: 0.72rem;
+  font-size: 0.78rem;
   color: var(--color-text-dim);
   text-decoration: none;
   white-space: nowrap;
@@ -468,28 +441,15 @@ const JOB_DETAIL_CSS = `
   transition: color 0.12s ease;
 }
 .job-detail-back:hover { color: var(--color-text-strong); }
-.job-detail-title {
-  margin: 0;
-  font-size: 1.4rem;
-  font-weight: 700;
-  color: var(--color-text-strong);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  flex: 1 1 auto;
-  min-width: 0;
-}
-.job-detail-header-line2 {
+.job-detail-last-update {
   font-family: var(--font-mono, ui-monospace, monospace);
   font-size: 0.72rem;
   color: var(--color-text-dim);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-}
-.job-detail-meta-sep {
-  margin: 0 0.4rem;
-  opacity: 0.6;
+  flex: 1 1 auto;
+  min-width: 0;
 }
 .job-detail-status-chip {
   flex-shrink: 0;

--- a/products/catalyst/bootstrap/ui/src/test/setup.ts
+++ b/products/catalyst/bootstrap/ui/src/test/setup.ts
@@ -1,0 +1,22 @@
+/**
+ * Vitest setup — polyfills + global stubs for jsdom.
+ *
+ * Issue #669 — FlowCanvasOrganic uses `ResizeObserver` to track its
+ * canvas-host pixel size so the SVG viewBox can render at 1:1. jsdom
+ * doesn't ship `ResizeObserver`; a minimal stub is enough for the
+ * existing tests, which never assert against the canvas dimensions
+ * directly (the FlowCanvas test suite asserts node positions / DOM
+ * structure, not measured rects).
+ */
+
+if (typeof globalThis.ResizeObserver === 'undefined') {
+  class StubResizeObserver {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    constructor(_cb: ResizeObserverCallback) {}
+    observe(): void {}
+    unobserve(): void {}
+    disconnect(): void {}
+  }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ;(globalThis as any).ResizeObserver = StubResizeObserver
+}

--- a/products/catalyst/bootstrap/ui/vite.config.ts
+++ b/products/catalyst/bootstrap/ui/vite.config.ts
@@ -89,5 +89,6 @@ export default defineConfig({
     globals: false,
     css: false,
     include: ['src/**/*.test.{ts,tsx}'],
+    setupFiles: ['src/test/setup.ts'],
   },
 })


### PR DESCRIPTION
## Summary

JobDetail page UX rewrite addressing five issues reported on the running otech-N console (issue #669).

- **Flow canvas**: viewBox tracks host pixel rect (ResizeObserver). Bubble radius is constant CSS px regardless of host size; full-screening grows horizontal layout room instead of magnifying bubbles. Removed projection scaling that caused overlap on wide clusters — `forceCollide` now owns pairwise distance end-to-end (no-overlap rule).
- **Completed bubbles**: solid green fill, white tick. Was: dark fill + green glyph that read identically to pending at a glance.
- **Light theme**: status palette + log viewer surface routed through CSS variables (`--bubble-*`, `--log-viewer-*`) with `[data-theme="light"]` peers in `globals.css`. Flow canvas + ExecutionLogs reskin properly under light mode.
- **Tail effect**: `scrollTo({behavior: smooth})` + per-row 180ms fade+rise animation. Reads as a real `tail -f`.
- **Header cleanup**: removed duplicated title/subtitle (PortalShell owns the page title) and the "Logs" reopen-pane button (overlapped status chip).
- **Global log column** (new): split-view toggle in `LogPane` adds a second column showing the provision-wide merged log stream — every derived job's SSE step events interleaved by timestamp.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run src/components/ExecutionLogs.test.tsx src/components/LogPane.fallback.test.tsx src/pages/sovereign/JobDetail.test.tsx src/pages/sovereign/FlowCanvasOrganic.bounded.test.tsx` — all green
- [x] Pre-existing test failures (cloud-* missing `@tabler/icons-react`, JobsPage 2 unrelated) confirmed unchanged
- [ ] Playwright E2E on console.openova.io after deploy:
  - bubble radius ≈ 40 CSS px at 1440×900 AND 1920×1080
  - no overlapping bubbles (DOM bbox pairwise check)
  - completed bubbles render solid green
  - tail animates smoothly on a running provision
  - light theme contrast on canvas + log viewer
  - global log column shows merged content
- [ ] Visual verification screenshots in `.playwright-mcp/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)