### PR TITLE
fix(sovereign-console): JobDetail global-log uses DerivedJob.title not displayName (#669 follow-up)

### DIFF
--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/JobDetail.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/JobDetail.tsx
@@ -158,7 +158,11 @@ export function JobDetail({
     const merged: Array<{ ts: number; line: LogLine }> = []
     let counter = 1
     for (const dj of derivedJobs) {
-      const label = dj.displayName ?? dj.jobName ?? dj.id
+      // DerivedJob (./jobs.ts) uses `title` for the human-readable
+      // label — not `displayName`/`jobName` which belong to the flat
+      // Job in @/lib/jobs.types. Fall back to the id when title is
+      // unset (it shouldn't be, but defensive).
+      const label = dj.title || dj.id
       for (const ll of stepsToLogLines(dj.steps)) {
         const ts = ll.timestamp ? Date.parse(ll.timestamp) : NaN
         merged.push({


### PR DESCRIPTION
Build-ui failed on tsc -b after PR #671 because DerivedJob (src/pages/sovereign/jobs.ts) uses `title`, not the flat Job's `displayName`/`jobName`. `tsc --noEmit` locally didn't catch this; `tsc -b` (project-references mode used by CI) does. One-line fix: `dj.title || dj.id`.

Refs #669, follow-up to #671.

🤖 Generated with [Claude Code](https://claude.com/claude-code)