### PR TITLE
fix(flow-canvas): MIN_HOST is a fallback, not a floor (#669 live overlap)

### DIFF
--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/FlowCanvasOrganic.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/FlowCanvasOrganic.tsx
@@ -239,8 +239,15 @@ export function FlowCanvasOrganic(props: FlowCanvasOrganicProps) {
       const e = entries[0]
       if (!e) return
       const rect = e.contentRect
-      const w = Math.max(MIN_HOST_W, Math.round(rect.width))
-      const h = Math.max(MIN_HOST_H, Math.round(rect.height))
+      // Use the actual measured rect — not a floor. The MIN_HOST_*
+      // constants only apply when the rect is degenerate (0×0 during
+      // first paint). Forcing the viewBox to MIN_HOST_W when the
+      // host is narrower (e.g. LogPane reserves 30vw) causes the
+      // SVG to render 1200 viewBox-units into 686 CSS px (0.57×
+      // downscale), shrinking bubbles AND collapsing pairwise
+      // distances below the no-overlap threshold.
+      const w = Math.round(rect.width) || MIN_HOST_W
+      const h = Math.round(rect.height) || MIN_HOST_H
       cancelAnimationFrame(raf)
       raf = requestAnimationFrame(() => {
         setHostSize((prev) => (prev.w === w && prev.h === h ? prev : { w, h }))

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/JobDetail.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/JobDetail.tsx
@@ -158,7 +158,11 @@ export function JobDetail({
     const merged: Array<{ ts: number; line: LogLine }> = []
     let counter = 1
     for (const dj of derivedJobs) {
-      const label = dj.displayName ?? dj.jobName ?? dj.id
+      // DerivedJob (./jobs.ts) uses `title` for the human-readable
+      // label — not `displayName`/`jobName` which belong to the flat
+      // Job in @/lib/jobs.types. Fall back to the id when title is
+      // unset (it shouldn't be, but defensive).
+      const label = dj.title || dj.id
       for (const ll of stepsToLogLines(dj.steps)) {
         const ts = ll.timestamp ? Date.parse(ll.timestamp) : NaN
         merged.push({


### PR DESCRIPTION
Live test on console.openova.io after #671 showed bubbles overlapping by ~13 CSS px. Root cause: ResizeObserver clamped hostSize.w to max(1200, 686). SVG then rendered 1200 viewBox-units into 686 CSS px (0.57× downscale), collapsing pairwise distances below the 92px threshold.

Use actual contentRect; fall back to MIN_HOST only when rect is 0×0.

Refs #669, follow-up to #671/#672.

🤖 Generated with [Claude Code](https://claude.com/claude-code)