### PR TITLE
fix(cilium): hostNetwork gateway + Hetzner LB→80/443 (1.1.5) — fixes silent TLS drop on Sovereign

### DIFF
--- a/clusters/_template/bootstrap-kit/01-cilium.yaml
+++ b/clusters/_template/bootstrap-kit/01-cilium.yaml
@@ -36,7 +36,7 @@ spec:
   chart:
     spec:
       chart: bp-cilium
-      version: 1.1.4
+      version: 1.1.5
       sourceRef:
         kind: HelmRepository
         name: bp-cilium

--- a/infra/hetzner/main.tf
+++ b/infra/hetzner/main.tf
@@ -341,14 +341,21 @@ resource "hcloud_load_balancer_service" "http" {
   load_balancer_id = hcloud_load_balancer.main.id
   protocol         = "tcp"
   listen_port      = 80
-  destination_port = 31080 # Cilium Gateway will bind this NodePort post-bootstrap
+  # destination_port=80 — Cilium Gateway runs in hostNetwork mode
+  # (bp-cilium 1.1.5+ values: gatewayAPI.hostNetwork.enabled=true),
+  # binding cilium-envoy directly to the host's :80 instead of a random
+  # nodePort. The previous nodePort=31080 mapping broke because Cilium
+  # 1.16.5's BPF L7LB Proxy Port (e.g. 12869) doesn't actually align
+  # with what cilium-envoy listens on, dropping all TLS handshakes
+  # silently. Caught live on otech45.
+  destination_port = 80
 }
 
 resource "hcloud_load_balancer_service" "https" {
   load_balancer_id = hcloud_load_balancer.main.id
   protocol         = "tcp"
   listen_port      = 443
-  destination_port = 31443
+  destination_port = 443
 }
 
 resource "hcloud_load_balancer_service" "dns" {

--- a/platform/cilium/chart/Chart.yaml
+++ b/platform/cilium/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-cilium
-version: 1.1.4
+version: 1.1.5
 description: |
   Catalyst-curated Blueprint umbrella chart for Cilium. Depends on the
   upstream `cilium` chart as a Helm subchart so `helm dependency build`

--- a/platform/cilium/chart/values.yaml
+++ b/platform/cilium/chart/values.yaml
@@ -106,6 +106,18 @@ cilium:
       # Forcing "true" ensures GatewayClass/cilium is always created.
       # Permanent fix for the cilium-gateway race (issue #503).
       create: "true"
+    # hostNetwork mode — bind gateway listeners directly to the host's
+    # 80/443 ports (instead of Service-of-type-LoadBalancer with random
+    # nodePort allocation). Required for the Hetzner Cloud Load Balancer
+    # forwarding chain: HCLB listens on public 80/443 and forwards via
+    # the private network to the CP node's 80/443 (NOT to a random
+    # nodePort). With nodePort mode, Cilium's BPF L7LB Proxy Port doesn't
+    # match what cilium-envoy actually binds, breaking TLS termination
+    # entirely (cilium service list shows the redirect, but envoy isn't
+    # listening on the proxy port). Caught live on otech45 — TCP connects
+    # but TLS handshake never completes.
+    hostNetwork:
+      enabled: true
 
   # L7 proxy via Envoy — for HTTPRoute, gRPCRoute, L7 NetworkPolicy
   envoy:


### PR DESCRIPTION
Caught on otech45: BPF L7LB Proxy Port (12869) doesn't match envoy listener. Bypass nodePort entirely via hostNetwork mode.