### PR TITLE
fix(bp-catalyst-platform): /auth/* and /api/* routed to catalyst-api on console host (1.2.2)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -58,7 +58,7 @@ spec:
   chart:
     spec:
       chart: bp-catalyst-platform
-      version: 1.2.0
+      version: 1.2.2
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-catalyst-platform
-version: 1.2.1
+version: 1.2.2
 appVersion: 1.2.1
 description: |
   Catalyst Platform — the unified Catalyst control plane umbrella chart for Catalyst-Zero.

--- a/products/catalyst/chart/templates/httproute.yaml
+++ b/products/catalyst/chart/templates/httproute.yaml
@@ -43,6 +43,28 @@ spec:
   hostnames:
     - {{ $consoleHost | quote }}
   rules:
+    # /auth/* and /api/* on the console hostname route to catalyst-api
+    # (the Go backend), not catalyst-ui (the React shell). The handover
+    # JWT lands at GET /auth/handover?token=… which is implemented in
+    # catalyst-api. Without this rule the React app sees /auth/handover,
+    # has no client-side route for it, and falls through to Keycloak's
+    # bare login screen — defeating the Phase-8b seamless auth promise.
+    # Caught live on otech46.
+    - matches:
+        - path:
+            type: PathPrefix
+            value: "/auth/"
+      backendRefs:
+        - name: catalyst-api
+          port: 8080
+    - matches:
+        - path:
+            type: PathPrefix
+            value: "/api/"
+      backendRefs:
+        - name: catalyst-api
+          port: 8080
+    # Default — catalyst-ui (the React shell)
     - matches:
         - path:
             type: PathPrefix


### PR DESCRIPTION
Without this, handover JWT can't reach the Go handler. Caught on otech46.