### PR TITLE
fix(bp-external-dns): --request-timeout=120s for cold-cluster initial sync (1.1.5)

### DIFF
--- a/clusters/_template/bootstrap-kit/12-external-dns.yaml
+++ b/clusters/_template/bootstrap-kit/12-external-dns.yaml
@@ -55,7 +55,7 @@ spec:
   chart:
     spec:
       chart: bp-external-dns
-      version: 1.1.4
+      version: 1.1.5
       sourceRef:
         kind: HelmRepository
         name: bp-external-dns

--- a/platform/external-dns/chart/Chart.yaml
+++ b/platform/external-dns/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-external-dns
-version: 1.1.4
+version: 1.1.5
 description: |
   Catalyst-curated Blueprint umbrella chart for ExternalDNS. Depends on the
   upstream `external-dns` chart (kubernetes-sigs) as a Helm subchart so

--- a/platform/external-dns/chart/values.yaml
+++ b/platform/external-dns/chart/values.yaml
@@ -53,8 +53,18 @@ external-dns:
   # NOTE: --pdns-api-version is NOT a valid flag for external-dns v0.15.1
   # native pdns provider — it causes `unknown long flag '--pdns-api-version'`
   # fatal on start. The provider auto-negotiates the API version. Removed.
+  #
+  # --request-timeout=120s — bumps the apiserver client RequestTimeout from
+  # the upstream default of 30s. On every fresh Sovereign provision the
+  # k3s apiserver is CPU-saturated for the first ~5 minutes (catalyst-api
+  # kubeconfig PUT, Flux bootstrap, all 38 HelmReleases reconciling
+  # concurrently). With the 30s default external-dns crashloops 10+ times
+  # with `level=fatal msg="failed to sync *v1.Pod: context deadline exceeded"`
+  # before the initial cluster cache sync completes. 120s lets the first
+  # sync finish cleanly. Caught live on otech43–46.
   extraArgs:
     - --pdns-server=http://powerdns.powerdns.svc.cluster.local:8081
+    - --request-timeout=120s
 
   # API key for the PowerDNS REST API — read from the `powerdns-api-
   # credentials` Secret rendered by bp-powerdns (templates/api-credentials-


### PR DESCRIPTION
Caught live on otech43–46: external-dns crashloops 10+ times on fresh Sovereign before initial *v1.Pod sync completes. Default 30s timeout insufficient when k3s apiserver is CPU-saturated.

## Root cause

On every fresh Sovereign provision, the k3s apiserver is CPU-saturated for the first ~5 minutes (catalyst-api kubeconfig PUT, Flux bootstrap, all 38 HelmReleases reconciling concurrently). external-dns's default \`--request-timeout=30s\` is insufficient for the initial cluster cache sync under that load. Logs show:

\`\`\`
level=fatal msg=\"failed to sync *v1.Pod: context deadline exceeded\"
\`\`\`

The pod CrashLoopBackOff cycles 10+ times before the initial cache sync finally completes.

## Fix

Adds \`--request-timeout=120s\` to the upstream \`external-dns\` subchart's \`extraArgs\` list (the canonical seam — same path the existing \`--pdns-server\` flag uses). Bumps \`bp-external-dns\` from 1.1.4 → 1.1.5 and updates the bootstrap-kit \`_template/12-external-dns.yaml\` HelmRelease pin.

## Files changed

- \`platform/external-dns/chart/values.yaml\` — add \`--request-timeout=120s\` to \`external-dns.extraArgs\`
- \`platform/external-dns/chart/Chart.yaml\` — version 1.1.4 → 1.1.5
- \`clusters/_template/bootstrap-kit/12-external-dns.yaml\` — HelmRelease chart version 1.1.4 → 1.1.5

## Verification

- Next fresh Sovereign provision should show external-dns reaching Ready=True on first pod start (no crashloop chain).
- Watch \`kubectl -n external-dns logs -f deploy/external-dns\` on otech47+ during phase-1 — initial cache sync should complete cleanly without \`context deadline exceeded\`.

Generated with [Claude Code](https://claude.com/claude-code)