### PR TITLE
fix(bp-catalyst-platform): provision harbor-robot-token automatically on Sovereign install (RCA + permanent fix)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -58,7 +58,7 @@ spec:
   chart:
     spec:
       chart: bp-catalyst-platform
-      version: 1.2.2
+      version: 1.2.3
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/infra/hetzner/cloudinit-control-plane.tftpl
+++ b/infra/hetzner/cloudinit-control-plane.tftpl
@@ -190,6 +190,58 @@ write_files:
           }
         }))}
 
+  # ── flux-system/harbor-robot-token Secret (issue #557 follow-up) ─────
+  #
+  # The catalyst-api Pod template (products/catalyst/chart/templates/
+  # api-deployment.yaml) references a Secret named `harbor-robot-token`
+  # via a REQUIRED (non-optional) secretKeyRef on every Sovereign. The
+  # token authenticates pulls from the central harbor.openova.io
+  # proxy-cache (proxy-dockerhub, proxy-gcr, proxy-quay, proxy-k8s,
+  # proxy-ghcr) — the same value already interpolated into
+  # /etc/rancher/k3s/registries.yaml below.
+  #
+  # Without this Secret the catalyst-api Pod stays in
+  # CreateContainerConfigError indefinitely. Caught live on otech43,
+  # otech45, otech46 — the operator workaround was hand-creating a
+  # placeholder Secret on each iteration, which is a workaround, not
+  # a fix.
+  #
+  # Why this Secret lives in flux-system + uses Reflector auto-mirror:
+  # the same canonical pattern as `ghcr-pull` above — bp-reflector
+  # (slot 05a) propagates the Secret to every namespace via
+  # `reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"`,
+  # so catalyst-system (and any other namespace that needs the token)
+  # picks it up event-driven on first reconcile.
+  #
+  # The Secret carries one key (`token`) which catalyst-api reads as
+  # CATALYST_HARBOR_ROBOT_TOKEN and re-stamps onto every grandchild
+  # Sovereign provision request — the Sovereign's own Sovereigns
+  # (post-handover) inherit the same central proxy-cache auth.
+  #
+  # Token rotation: yearly, see docs/SECRET-ROTATION.md. Rotation flows
+  # through `var.harbor_robot_token` → re-render cloud-init → re-apply
+  # this Secret. The plaintext NEVER lives in git.
+  - path: /var/lib/catalyst/harbor-robot-token-secret.yaml
+    permissions: '0600'
+    content: |
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: harbor-robot-token
+        namespace: flux-system
+        annotations:
+          # bp-reflector (slot 05a) mirrors this Secret to every
+          # namespace so catalyst-api in catalyst-system (and any
+          # workload added later that needs the central Harbor robot
+          # auth) picks it up without per-namespace manual creation.
+          reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
+          reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: ""
+          reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
+          reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: ""
+      type: Opaque
+      data:
+        token: ${base64encode(harbor_robot_token)}
+
   # ── cert-manager/dynadot-api-credentials Secret (issue #550) ─────────────
   #
   # The bp-cert-manager-dynadot-webhook Pod reads DYNADOT_API_KEY /
@@ -1018,6 +1070,16 @@ runcmd:
   # rewrites this with the same content; a token rotation propagates
   # through here on the next cloud-init render.
   - 'kubectl --kubeconfig=/etc/rancher/k3s/k3s.yaml apply -f /var/lib/catalyst/ghcr-pull-secret.yaml'
+
+  # ── flux-system/harbor-robot-token Secret (issue #557 follow-up) ─────
+  #
+  # Apply the central-Harbor robot-account Secret BEFORE Flux reconciles
+  # the bootstrap-kit. bp-catalyst-platform's catalyst-api Pod has a
+  # REQUIRED (non-optional) secretKeyRef to `harbor-robot-token` in its
+  # own namespace; bp-reflector (slot 05a) mirrors this Secret from
+  # flux-system into catalyst-system on first reconcile so the Pod can
+  # start cleanly. Same idempotency property as ghcr-pull above.
+  - 'kubectl --kubeconfig=/etc/rancher/k3s/k3s.yaml apply -f /var/lib/catalyst/harbor-robot-token-secret.yaml'
 
   # ── cert-manager/dynadot-api-credentials Secret (issue #550) ─────────
   #

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-catalyst-platform
-version: 1.2.2
+version: 1.2.3
 appVersion: 1.2.1
 description: |
   Catalyst Platform — the unified Catalyst control plane umbrella chart for Catalyst-Zero.
@@ -135,6 +135,25 @@ description: |
   - ZERO Keycloak UI exposure, ZERO browser PKCE round-trip
   Adds CATALYST_OPENOVA_KC_* env refs from new catalyst-openova-kc-credentials
   Secret + CATALYST_SESSION_COOKIE_DOMAIN. 2026-05-02.
+
+  Bumped to 1.2.3 — RCA + permanent fix for catalyst-api Pods stuck in
+  CreateContainerConfigError on every fresh Sovereign because the
+  required (non-optional) `harbor-robot-token` secretKeyRef had no
+  source. Caught live on otech43, otech45, otech46 — operator was
+  hand-creating a placeholder Secret each iteration. Root cause: the
+  chart references `harbor-robot-token` as required but nothing
+  materialised it on the Sovereign cluster. The token VALUE was
+  already arriving (cloud-init interpolates var.harbor_robot_token
+  into /etc/rancher/k3s/registries.yaml), but no Kubernetes Secret
+  was created for catalyst-api to mount. Fix paired with
+  infra/hetzner/cloudinit-control-plane.tftpl: cloud-init now writes
+  /var/lib/catalyst/harbor-robot-token-secret.yaml into flux-system ns
+  with auto-mirror Reflector annotations, runcmd applies it BEFORE
+  flux-bootstrap, and bp-reflector (slot 05a) propagates it into
+  catalyst-system on first reconcile — exactly the canonical pattern
+  flux-system/ghcr-pull already uses (PR #543). Chart-side change is
+  a comment update on the secretKeyRef explaining the new seam.
+  Issue #557 follow-up, 2026-05-03.
 type: application
 
 # Opt-out from the blueprint-release hollow-chart guard (issue #181 / #510).

--- a/products/catalyst/chart/templates/api-deployment.yaml
+++ b/products/catalyst/chart/templates/api-deployment.yaml
@@ -288,18 +288,41 @@ spec:
                   key: token
                   optional: true
             # CATALYST_HARBOR_ROBOT_TOKEN — central Harbor proxy-cache
-            # robot account secret (issue #557). Reflector mirrors the
-            # `harbor-robot-token` Secret from openova-harbor namespace
-            # into catalyst namespace; the value is interpolated into
-            # the new Sovereign's /etc/rancher/k3s/registries.yaml at
-            # cloud-init time so containerd authenticates against
-            # harbor.openova.io's proxy projects (proxy-dockerhub etc).
+            # robot account secret (issue #557 + #557 follow-up). The
+            # value is interpolated into the new Sovereign's
+            # /etc/rancher/k3s/registries.yaml at cloud-init time so
+            # containerd authenticates against harbor.openova.io's proxy
+            # projects (proxy-dockerhub etc).
+            #
+            # Provisioning seam (catalyst-system Pod gets the Secret):
+            #   1. Tofu var.harbor_robot_token enters cloud-init
+            #      (infra/hetzner/cloudinit-control-plane.tftpl).
+            #   2. Cloud-init writes /var/lib/catalyst/harbor-robot-
+            #      token-secret.yaml into flux-system ns with the
+            #      auto-mirror Reflector annotations
+            #      (reflection-auto-enabled: "true").
+            #   3. runcmd applies it BEFORE flux-bootstrap, so the
+            #      Secret exists before any Helm release runs.
+            #   4. bp-reflector (slot 05a) propagates it into every
+            #      namespace (incl. catalyst-system) on first reconcile.
+            #   5. This Pod's secretKeyRef resolves once the mirror lands.
+            # Mirrors the canonical pattern that flux-system/ghcr-pull
+            # already uses (PR #543).
             #
             # NOT optional — provisioner.Validate() rejects deployments
             # with an empty token. The architecture mandate is that every
             # Sovereign image pull goes through harbor.openova.io; falling
             # through to docker.io is forbidden (rate-limit makes a fresh
-            # Hetzner IP unbootable within minutes).
+            # Hetzner IP unbootable within minutes). When `optional: true`
+            # was previously contemplated we chose against it: a missing
+            # token must surface immediately as a Pod start failure
+            # (CreateContainerConfigError), not silently mid-provision.
+            #
+            # Rotation: yearly. Re-render Tofu plan → re-apply cloud-init
+            # → kubectl apply runs against the existing Secret with
+            # rotated bytes; bp-reflector propagates the rotation to all
+            # mirrored copies on the next watch tick. Plaintext NEVER
+            # lives in git.
             - name: CATALYST_HARBOR_ROBOT_TOKEN
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
## Summary

- Catalyst-api Pods on every fresh Sovereign were stuck in
  `CreateContainerConfigError: secret "harbor-robot-token" not found`.
  Caught live on otech43, otech45, otech46 — manual placeholder Secret
  was being created each iteration as a workaround.
- Permanent fix mirrors the canonical `ghcr-pull` seam from PR #543:
  cloud-init writes the Secret into `flux-system` with auto-mirror
  Reflector annotations; bp-reflector propagates it into
  `catalyst-system` on first reconcile.
- Bumps `bp-catalyst-platform` 1.2.2 → 1.2.3 + bootstrap-kit reference.

## Root cause analysis

The catalyst-api Pod template at
`products/catalyst/chart/templates/api-deployment.yaml` references a
Secret named `harbor-robot-token` via a **required (non-optional)**
secretKeyRef. On Sovereign clusters that Secret was never materialised:

- The token **value** was already arriving on the Sovereign — Tofu
  `var.harbor_robot_token` is interpolated into
  `/etc/rancher/k3s/registries.yaml` at cloud-init time so containerd
  can authenticate against `harbor.openova.io`'s proxy-cache projects.
- But no Kubernetes Secret was created for catalyst-api to mount.
- The chart's old comment said "Reflector mirrors from openova-harbor
  namespace into catalyst" — but `openova-harbor` namespace lives only
  on contabo (the central Harbor) and doesn't exist on Sovereigns.
- Result: catalyst-api Pod stuck in `CreateContainerConfigError`
  indefinitely until the operator hand-created a placeholder Secret.

## Architecture decision

Mirror the canonical `ghcr-pull` cloud-init + Reflector pattern
established in PR #543. **Not** a placeholder Secret in the chart — the
architecture mandate is the token MUST be present (every Sovereign
image pull goes through harbor.openova.io; falling through to docker.io
is forbidden — anonymous rate-limit makes a fresh Hetzner IP
unbootable). **Not** a Sovereign-side bp-harbor post-install Job
either — the Sovereign's local Harbor at `harbor.<sovereign>` is a
DIFFERENT registry from `harbor.openova.io`; only the central token can
authenticate the central proxy-cache.

The cleanest answer: cloud-init writes the same value it already
interpolates into `registries.yaml` as a Kubernetes Secret too.

## Changes

1. `infra/hetzner/cloudinit-control-plane.tftpl`:
   - New `write_files` entry for
     `/var/lib/catalyst/harbor-robot-token-secret.yaml` — a Secret in
     `flux-system` ns with the `reflector.v1.k8s.emberstack.com/
     reflection-auto-enabled: "true"` annotation.
   - New `runcmd` line that `kubectl apply`s the Secret BEFORE
     `flux-bootstrap.yaml` lands.
2. `products/catalyst/chart/templates/api-deployment.yaml`:
   - Updated comment on the `CATALYST_HARBOR_ROBOT_TOKEN` secretKeyRef
     to document the new 5-step provisioning seam (Tofu var →
     cloud-init write_files → runcmd apply → bp-reflector mirror →
     catalyst-api Pod resolves).
   - **Pod spec unchanged** (still references `harbor-robot-token` /
     `token` as required).
3. `products/catalyst/chart/Chart.yaml`:
   - Bumped to `1.2.3` with a full changelog entry.
4. `clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml`:
   - Bumped `version: 1.2.2` → `1.2.3`.

No bootstrap-kit `dependsOn` changes — `bp-reflector` (slot 05a) was
already in place and was already required for the ghcr-pull mirror.
No `scripts/expected-bootstrap-deps.yaml` edits needed.

## Test plan

- [ ] `bp-catalyst-platform` chart releases at OCI tag `1.2.3` via the
      event-driven `blueprint-release.yaml` workflow on merge.
- [ ] Provision a fresh Sovereign (e.g. `otech47`) and verify:
  - `kubectl -n flux-system get secret harbor-robot-token` exists
    immediately after k3s comes up (cloud-init runcmd phase).
  - `kubectl -n catalyst-system get secret harbor-robot-token` is
    auto-created by bp-reflector within ~30s of bp-reflector reaching
    Ready.
  - `kubectl -n catalyst-system get pods -l app.kubernetes.io/name=
    catalyst-api` reaches `Running` without operator intervention; no
    `CreateContainerConfigError` events on the Pod.
  - `kubectl -n catalyst-system exec deploy/catalyst-api -- env |
    grep CATALYST_HARBOR_ROBOT_TOKEN` returns the same value as
    `var.harbor_robot_token` for that deployment.
- [ ] No regression in the existing ghcr-pull mirror flow (parallel
      pattern — must keep working unchanged).

## Issue links

- #557 (Image pull-through Harbor architecture) follow-up — this PR
  closes the per-Sovereign manual workaround for catalyst-api start.
- PR #543 (ghcr-pull Reflector pattern) — this PR copies its shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)