### PR TITLE
fix(catalyst-api): PDM commit retry + propagate failure to deployment.Error

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/deployments.go
+++ b/products/catalyst/bootstrap/api/internal/handler/deployments.go
@@ -1023,6 +1023,31 @@ func (h *Handler) runProvisioning(dep *Deployment) {
 	// resumed/diagnosed correctly.
 	h.persistDeployment(dep)
 
+	// PDM /commit fires HERE — between Phase 0 and Phase 1 — for two
+	// architectural reasons:
+	//
+	//   1. The Phase-0 LB IP is the ONLY data PDM needs to write the
+	//      child-zone records (NS delegation + console/api/wildcard
+	//      A records). Phase-1 outcome does NOT change DNS routing,
+	//      so deferring the commit to AFTER Phase 1 just delays the
+	//      moment console.<sub>.<pool> resolves (and previously did
+	//      so with the SSE channel already closed — failures were
+	//      invisible to the wizard).
+	//   2. The PDM reservation TTL is 10 minutes by default; Phase-0
+	//      routinely takes 8-12 min on a fresh Hetzner cluster, so
+	//      the commit can race the sweeper. CommitWithRetry handles
+	//      that by re-Reserving on 404/410/403 — and it does so while
+	//      the wizard SSE stream is still open, surfacing each
+	//      attempt as an event. See pdm/client.go:CommitWithRetry.
+	//
+	// On Phase-0 failure (no LB IP), Release is called instead so the
+	// reservation TTL doesn't have to expire to free the name.
+	if err == nil && result != nil {
+		h.commitPDMWithRetry(dep, result)
+	} else {
+		h.releasePDMReservation(dep)
+	}
+
 	// Phase 1 — HelmRelease watch. Only runs on Phase-0 success and
 	// only when a kubeconfig is available. The watch emits per-
 	// component events into the same SSE buffer + live channel; when
@@ -1044,50 +1069,137 @@ func (h *Handler) runProvisioning(dep *Deployment) {
 	// ran, or is a no-op for the Phase 0 failure path (already
 	// persisted above).
 	h.persistDeployment(dep)
+}
 
-	// PDM lifecycle: on success, /commit with the LB IP; on failure,
-	// /release so the reservation TTL doesn't have to expire to free
-	// the name. PDM is the single owner of the Dynadot side-effect
-	// (it is also responsible for AddSovereignRecords on commit;
-	// catalyst-api never writes DNS itself). The commit happens
-	// post-Phase-0 because the LB IP is the only data PDM needs;
-	// the Phase-1 watch outcome does NOT change DNS routing.
-	if dep.pdmReservationToken != "" && h.pdm != nil {
-		pdmCtx, pdmCancel := context.WithTimeout(context.Background(), 30*time.Second)
-		defer pdmCancel()
-		if err == nil && result != nil {
-			commitErr := h.pdm.Commit(pdmCtx, dep.pdmPoolDomain, pdm.CommitInput{
-				Subdomain:        dep.pdmSubdomain,
-				ReservationToken: dep.pdmReservationToken,
-				SovereignFQDN:    result.SovereignFQDN,
-				LoadBalancerIP:   result.LoadBalancerIP,
-			})
-			if commitErr != nil {
-				h.log.Error("pdm commit failed; sovereign is live but DNS records may be stale",
-					"id", dep.ID,
-					"poolDomain", dep.pdmPoolDomain,
-					"subdomain", dep.pdmSubdomain,
-					"err", commitErr,
-				)
-			} else {
-				h.log.Info("pdm commit complete",
-					"id", dep.ID,
-					"poolDomain", dep.pdmPoolDomain,
-					"subdomain", dep.pdmSubdomain,
-					"loadBalancerIP", result.LoadBalancerIP,
-				)
-			}
+// commitPDMWithRetry promotes the deployment's PDM reservation to
+// ACTIVE and triggers the per-Sovereign zone write inside PDM. It runs
+// while the wizard SSE stream is still open so each attempt + failure
+// surfaces as an event; on final exhaustion the human-readable error
+// is appended to dep.Error so the wizard FailureCard renders it.
+//
+// The retry loop is delegated to pdm.Client.CommitWithRetry (5
+// attempts, 1s → 16s backoff). Re-Reserve on 404/410/403 is done
+// inline so a TTL-expiry — the actual symptom that broke otech41+ —
+// recovers automatically and the persisted deployment row is updated
+// to the fresh token (so a Pod restart between re-Reserve and
+// re-Commit picks up the new token instead of the stale one).
+//
+// No-op when the deployment isn't using PDM (BYO domain mode, or
+// h.pdm == nil in tests).
+func (h *Handler) commitPDMWithRetry(dep *Deployment, result *provisioner.Result) {
+	if dep.pdmReservationToken == "" || h.pdm == nil {
+		return
+	}
+
+	// Up to 5 minutes for the full retry window — 5 attempts at
+	// 1s/2s/4s/8s/16s backoff plus per-attempt HTTP timeouts (15s
+	// each from Client.HTTP) plus a re-Reserve every other attempt
+	// in the worst case = ~3 min ceiling, with a safety margin.
+	pdmCtx, pdmCancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer pdmCancel()
+
+	emitInfo := func(msg string) {
+		h.emitWatchEvent(dep, provisioner.Event{
+			Time:    time.Now().UTC().Format(time.RFC3339),
+			Phase:   "pdm-commit",
+			Level:   "info",
+			Message: msg,
+		})
+	}
+	emitErr := func(msg string) {
+		h.emitWatchEvent(dep, provisioner.Event{
+			Time:    time.Now().UTC().Format(time.RFC3339),
+			Phase:   "pdm-commit",
+			Level:   "error",
+			Message: msg,
+		})
+	}
+
+	emitInfo(fmt.Sprintf("Publishing DNS records for %s via pool-domain-manager (LB %s)…",
+		result.SovereignFQDN, result.LoadBalancerIP))
+
+	commitErr := h.pdm.CommitWithRetry(
+		pdmCtx,
+		dep.pdmPoolDomain,
+		pdm.CommitInput{
+			Subdomain:        dep.pdmSubdomain,
+			ReservationToken: dep.pdmReservationToken,
+			SovereignFQDN:    result.SovereignFQDN,
+			LoadBalancerIP:   result.LoadBalancerIP,
+		},
+		func(ctx context.Context) (*pdm.Reservation, error) {
+			emitInfo(fmt.Sprintf("PDM reservation expired during Phase 0 — re-Reserving %s.%s",
+				dep.pdmSubdomain, dep.pdmPoolDomain))
+			return h.pdm.Reserve(ctx, dep.pdmPoolDomain, dep.pdmSubdomain, "catalyst-api/deployment-"+dep.ID)
+		},
+		func(newToken string) {
+			// Token rotated — persist the new token onto the row so a
+			// Pod restart between this re-Reserve and the next
+			// Commit attempt doesn't lose it.
+			dep.mu.Lock()
+			dep.pdmReservationToken = newToken
+			dep.mu.Unlock()
+			h.persistDeployment(dep)
+		},
+		pdm.CommitRetryConfig{}, // production defaults
+	)
+	if commitErr != nil {
+		// Final exhaustion — surface to the wizard. The Sovereign is
+		// live (cluster, LB, kubeconfig all good) but DNS is stale,
+		// so we annotate dep.Error rather than flipping Status to
+		// failed (which would imply the cluster itself is broken).
+		// The wizard's FailureCard checks dep.Error before rendering
+		// "ready" so the operator sees this regardless.
+		h.log.Error("pdm commit failed after retry; sovereign is live but DNS records are stale — operator action required",
+			"id", dep.ID,
+			"poolDomain", dep.pdmPoolDomain,
+			"subdomain", dep.pdmSubdomain,
+			"err", commitErr,
+		)
+		emitErr(fmt.Sprintf("DNS publish FAILED after retry: %v. The Sovereign cluster is live (LB %s) but %s will not resolve until an operator runs PDM /commit manually or re-runs the deployment.",
+			commitErr, result.LoadBalancerIP, result.SovereignFQDN))
+		dep.mu.Lock()
+		errMsg := fmt.Sprintf("DNS commit failed: %v — sovereign cluster is live but %s does not resolve. Re-run `curl -X POST $POOL_DOMAIN_MANAGER_URL/api/v1/pool/%s/commit` with a fresh reservation, or re-trigger the deployment.",
+			commitErr, result.SovereignFQDN, dep.pdmPoolDomain)
+		if dep.Error == "" {
+			dep.Error = errMsg
 		} else {
-			releaseErr := h.pdm.Release(pdmCtx, dep.pdmPoolDomain, dep.pdmSubdomain)
-			if releaseErr != nil && !errors.Is(releaseErr, pdm.ErrNotFound) {
-				h.log.Error("pdm release failed; reservation will expire on TTL",
-					"id", dep.ID,
-					"poolDomain", dep.pdmPoolDomain,
-					"subdomain", dep.pdmSubdomain,
-					"err", releaseErr,
-				)
-			}
+			dep.Error = dep.Error + " | " + errMsg
 		}
+		dep.mu.Unlock()
+		h.persistDeployment(dep)
+		return
+	}
+
+	h.log.Info("pdm commit complete",
+		"id", dep.ID,
+		"poolDomain", dep.pdmPoolDomain,
+		"subdomain", dep.pdmSubdomain,
+		"loadBalancerIP", result.LoadBalancerIP,
+	)
+	emitInfo(fmt.Sprintf("DNS published — %s now resolves to %s.",
+		result.SovereignFQDN, result.LoadBalancerIP))
+}
+
+// releasePDMReservation releases the PDM reservation on Phase-0
+// failure so the reservation TTL doesn't have to expire to free the
+// name. Best-effort: a release failure logs a warning but does not
+// block the failure-cleanup path. ErrNotFound is silently ignored
+// because the row may have been swept already.
+func (h *Handler) releasePDMReservation(dep *Deployment) {
+	if dep.pdmReservationToken == "" || h.pdm == nil {
+		return
+	}
+	pdmCtx, pdmCancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer pdmCancel()
+	releaseErr := h.pdm.Release(pdmCtx, dep.pdmPoolDomain, dep.pdmSubdomain)
+	if releaseErr != nil && !errors.Is(releaseErr, pdm.ErrNotFound) {
+		h.log.Error("pdm release failed; reservation will expire on TTL",
+			"id", dep.ID,
+			"poolDomain", dep.pdmPoolDomain,
+			"subdomain", dep.pdmSubdomain,
+			"err", releaseErr,
+		)
 	}
 }
 

--- a/products/catalyst/bootstrap/api/internal/handler/subdomains.go
+++ b/products/catalyst/bootstrap/api/internal/handler/subdomains.go
@@ -243,9 +243,21 @@ func isNXDomain(err error) bool {
 
 // pdmClient is implemented by *pdm.Client. The interface lets us pass a
 // fake in tests without wiring a real HTTP server.
+//
+// CommitWithRetry is the production path for /commit (handles TTL-expiry
+// re-Reserve + 5xx exponential backoff); plain Commit is retained for
+// tests that exercise the underlying single-shot semantics.
 type pdmClient interface {
 	Check(ctx context.Context, poolDomain, subdomain string) (*pdm.CheckResult, error)
 	Reserve(ctx context.Context, poolDomain, subdomain, createdBy string) (*pdm.Reservation, error)
 	Commit(ctx context.Context, poolDomain string, in pdm.CommitInput) error
+	CommitWithRetry(
+		ctx context.Context,
+		poolDomain string,
+		in pdm.CommitInput,
+		reserve func(ctx context.Context) (*pdm.Reservation, error),
+		onRereserve func(newToken string),
+		cfg pdm.CommitRetryConfig,
+	) error
 	Release(ctx context.Context, poolDomain, subdomain string) error
 }

--- a/products/catalyst/bootstrap/api/internal/handler/subdomains_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/subdomains_test.go
@@ -100,6 +100,57 @@ func (f *fakePDM) Commit(ctx context.Context, pool string, in pdm.CommitInput) e
 	return nil
 }
 
+// CommitWithRetry on the fake delegates to the same commit hook used by
+// Commit (so existing tests that stub `commit` keep working unchanged)
+// but threads the re-Reserve loop manually so the retry behaviour can
+// be exercised against in-memory fakes too. The 5xx-backoff branch
+// is a no-op on the fake (it returns whatever the hook returns and
+// the caller's MaxAttempts gate stops the loop) — callers that want
+// to verify backoff timing should use the httptest-based test in
+// pdm/client_test.go instead.
+func (f *fakePDM) CommitWithRetry(
+	ctx context.Context,
+	pool string,
+	in pdm.CommitInput,
+	reserve func(ctx context.Context) (*pdm.Reservation, error),
+	onRereserve func(newToken string),
+	cfg pdm.CommitRetryConfig,
+) error {
+	if cfg.MaxAttempts <= 0 {
+		cfg.MaxAttempts = 5
+	}
+	current := in
+	var lastErr error
+	for attempt := 1; attempt <= cfg.MaxAttempts; attempt++ {
+		err := f.Commit(ctx, pool, current)
+		if err == nil {
+			return nil
+		}
+		lastErr = err
+		if errors.Is(err, pdm.ErrNotFound) || errors.Is(err, pdm.ErrExpired) || errors.Is(err, pdm.ErrTokenMismatch) {
+			if reserve == nil || attempt == cfg.MaxAttempts {
+				break
+			}
+			fresh, rerr := reserve(ctx)
+			if rerr != nil {
+				return rerr
+			}
+			current.ReservationToken = fresh.ReservationToken
+			if onRereserve != nil {
+				onRereserve(fresh.ReservationToken)
+			}
+			continue
+		}
+		// Non-sentinel error — fakes don't sleep; just keep iterating
+		// up to MaxAttempts so a stub returning an error N times then
+		// success behaves the same as the real client.
+		if attempt == cfg.MaxAttempts {
+			break
+		}
+	}
+	return lastErr
+}
+
 func (f *fakePDM) Release(ctx context.Context, pool, sub string) error {
 	f.mu.Lock()
 	f.releases = append(f.releases, releaseCall{pool, sub})

--- a/products/catalyst/bootstrap/api/internal/pdm/client.go
+++ b/products/catalyst/bootstrap/api/internal/pdm/client.go
@@ -88,8 +88,26 @@ type Reservation struct {
 // ErrConflict — PDM returned 409 Conflict (subdomain already taken).
 var ErrConflict = errors.New("pool allocation conflict")
 
-// ErrNotFound — PDM returned 404 (no row to commit/release).
+// ErrNotFound — PDM returned 404 (no row to commit/release). Most often
+// raised on /commit when the reservation TTL elapsed and PDM's sweeper
+// goroutine has already deleted the row. CommitWithRetry treats this as
+// recoverable by re-Reserving with the same (poolDomain, subdomain,
+// createdBy) tuple and re-Committing with the fresh token.
 var ErrNotFound = errors.New("pool allocation not found")
+
+// ErrExpired — PDM returned 410 Gone on /commit. The reservation row
+// is still in the database but its expires_at has elapsed; the caller
+// must Reserve again before committing. CommitWithRetry treats this as
+// recoverable identically to ErrNotFound.
+var ErrExpired = errors.New("pool allocation expired before commit")
+
+// ErrTokenMismatch — PDM returned 403 Forbidden on /commit. The supplied
+// reservationToken does not match the token PDM holds for this row.
+// In practice this happens when a sweeper-then-rereserve race produced
+// a fresh row under the same name with a different token between the
+// initial Reserve and the Commit. Recoverable by re-Reserving (via
+// CommitWithRetry).
+var ErrTokenMismatch = errors.New("pool allocation token mismatch")
 
 // Reserve calls POST /api/v1/pool/{domain}/reserve. Returns ErrConflict on
 // 409 so callers can distinguish "name taken" from "PDM down".
@@ -137,6 +155,23 @@ type CommitInput struct {
 }
 
 // Commit calls POST /api/v1/pool/{domain}/commit.
+//
+// Status mapping (mirrors core/pool-domain-manager/internal/handler/handler.go
+// /commit semantics):
+//
+//	200/202    — success (202 means row committed but PowerDNS write
+//	             pending; the caller can re-Commit idempotently to
+//	             republish DNS — CommitWithRetry handles that)
+//	404        — ErrNotFound: the reservation row was swept (TTL
+//	             elapsed) and no row exists; caller must Reserve again
+//	410        — ErrExpired: the row is still present but expires_at
+//	             has elapsed before the sweeper ran; same recovery
+//	             (Reserve again) as 404
+//	403        — ErrTokenMismatch: a parallel /reserve replaced the row
+//	             with a different token after the original Reserve;
+//	             same recovery (Reserve again) as 404
+//	5xx / network errors → wrapped in fmt.Errorf so CommitWithRetry's
+//	             backoff loop can detect-and-retry.
 func (c *Client) Commit(ctx context.Context, poolDomain string, in CommitInput) error {
 	body := map[string]string{
 		"subdomain":        in.Subdomain,
@@ -165,9 +200,130 @@ func (c *Client) Commit(ctx context.Context, poolDomain string, in CommitInput) 
 		return nil
 	case http.StatusNotFound:
 		return ErrNotFound
+	case http.StatusGone:
+		return ErrExpired
+	case http.StatusForbidden:
+		return ErrTokenMismatch
 	default:
 		return fmt.Errorf("pdm commit status %d: %s", resp.StatusCode, truncate(string(respBody), 256))
 	}
+}
+
+// CommitRetryConfig parameterises CommitWithRetry. Zero values fall
+// back to production defaults (5 attempts, 1s → 16s exponential
+// backoff). Tests inject tighter bounds so a 404→200 re-Reserve path
+// completes in milliseconds rather than seconds.
+type CommitRetryConfig struct {
+	// MaxAttempts — total attempts including the first. <=0 → 5.
+	MaxAttempts int
+	// InitialBackoff — delay before the second attempt (doubles each
+	// retry, capped at MaxBackoff). <=0 → 1s.
+	InitialBackoff time.Duration
+	// MaxBackoff — upper bound on the per-step delay. <=0 → 16s.
+	MaxBackoff time.Duration
+}
+
+// CommitWithRetry runs Commit with two layered recovery primitives:
+//
+//  1. Re-Reserve on TTL expiry — when Commit returns ErrNotFound /
+//     ErrExpired / ErrTokenMismatch, the reservation row is gone or
+//     unusable. PDM's design says "Reserve again." This loop calls
+//     reserve(ctx) (a caller-supplied closure that wraps Client.Reserve
+//     with the deployment's poolDomain/subdomain/createdBy) to obtain
+//     a fresh reservation token, then retries Commit with the new
+//     token. The caller's onRereserve callback receives the fresh
+//     token so it can update the persisted Deployment row (otherwise
+//     a Pod restart between re-Reserve and re-Commit would lose the
+//     new token).
+//
+//  2. Exponential backoff on 5xx / network — when Commit returns a
+//     non-sentinel error (network failure, PDM 500, etc.) the loop
+//     sleeps InitialBackoff * 2^attempt (capped at MaxBackoff) then
+//     retries the SAME token. Up to MaxAttempts total attempts.
+//
+// On final exhaustion the loop returns the last error wrapped with
+// "pdm commit retry exhausted (N attempts)" — the caller surfaces
+// that string into Deployment.Error so the wizard FailureCard
+// renders it.
+//
+// The 404/410/403 branch counts against MaxAttempts (a malicious /
+// flapping PDM cannot loop forever) but does NOT sleep between the
+// re-Reserve and the next Commit — the row is gone, not flapping;
+// a fresh write is the right next step.
+func (c *Client) CommitWithRetry(
+	ctx context.Context,
+	poolDomain string,
+	in CommitInput,
+	reserve func(ctx context.Context) (*Reservation, error),
+	onRereserve func(newToken string),
+	cfg CommitRetryConfig,
+) error {
+	if cfg.MaxAttempts <= 0 {
+		cfg.MaxAttempts = 5
+	}
+	if cfg.InitialBackoff <= 0 {
+		cfg.InitialBackoff = 1 * time.Second
+	}
+	if cfg.MaxBackoff <= 0 {
+		cfg.MaxBackoff = 16 * time.Second
+	}
+
+	current := in
+	var lastErr error
+	backoff := cfg.InitialBackoff
+
+	for attempt := 1; attempt <= cfg.MaxAttempts; attempt++ {
+		err := c.Commit(ctx, poolDomain, current)
+		if err == nil {
+			return nil
+		}
+		lastErr = err
+
+		// 404/410/403 — reservation gone or unusable. Re-Reserve and
+		// retry with the fresh token. Don't sleep — the row is gone,
+		// not flapping; a fresh write is the right next step.
+		if errors.Is(err, ErrNotFound) || errors.Is(err, ErrExpired) || errors.Is(err, ErrTokenMismatch) {
+			if reserve == nil {
+				return fmt.Errorf("pdm commit needs re-Reserve but no reserve closure provided: %w", err)
+			}
+			if attempt == cfg.MaxAttempts {
+				break
+			}
+			fresh, rerr := reserve(ctx)
+			if rerr != nil {
+				// Re-reserve itself failed — most likely ErrConflict
+				// (someone else grabbed the name in the gap, which
+				// for catalyst-api is a hard fail because the
+				// deployment is already running on Hetzner) or a
+				// network/5xx (transient). Either way, propagate so
+				// the caller can mark dep.Error.
+				return fmt.Errorf("pdm re-reserve after commit %v: %w", err, rerr)
+			}
+			current.ReservationToken = fresh.ReservationToken
+			if onRereserve != nil {
+				onRereserve(fresh.ReservationToken)
+			}
+			continue
+		}
+
+		// 5xx / network — back off before retrying with the SAME
+		// token. The reservation row is still good (no sentinel), the
+		// PDM service is just unhappy.
+		if attempt == cfg.MaxAttempts {
+			break
+		}
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("pdm commit retry cancelled after %d attempts: %w", attempt, ctx.Err())
+		case <-time.After(backoff):
+		}
+		backoff *= 2
+		if backoff > cfg.MaxBackoff {
+			backoff = cfg.MaxBackoff
+		}
+	}
+
+	return fmt.Errorf("pdm commit retry exhausted (%d attempts): %w", cfg.MaxAttempts, lastErr)
 }
 
 // Release calls DELETE /api/v1/pool/{domain}/release.

--- a/products/catalyst/bootstrap/api/internal/pdm/client_test.go
+++ b/products/catalyst/bootstrap/api/internal/pdm/client_test.go
@@ -1,0 +1,317 @@
+// Tests for the PDM client retry primitives. These cover the
+// regressions caught live on otech41+ where Phase-0 ran longer than
+// PDM's 10-minute reservation TTL and Commit returned 404 ("pool
+// allocation not found"), causing console.<sub>.<pool> to never
+// resolve until an operator hand-seeded zone records.
+//
+// CommitWithRetry must:
+//
+//   - Treat 404 / 410 / 403 as "Reserve again, then retry Commit"
+//     (TTL elapsed or token rotated).
+//   - Treat 5xx / network errors as transient — exponential backoff,
+//     up to MaxAttempts.
+//   - Surface the final error verbatim on exhaustion so the caller
+//     can populate Deployment.Error with a human-actionable message.
+//   - Honour ctx cancellation between backoff sleeps.
+package pdm
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestCommitWithRetry_404_ThenSuccess models the canonical otech41+
+// failure mode: first /commit returns 404 because the reservation
+// row was swept (TTL elapsed during Phase-0 tofu apply); the retry
+// loop must re-Reserve, get a fresh token, and Commit successfully
+// on the second attempt — without operator intervention.
+func TestCommitWithRetry_404_ThenSuccess(t *testing.T) {
+	var commits int32
+	var reserves int32
+	var lastCommitToken string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/commit"):
+			n := atomic.AddInt32(&commits, 1)
+			var body map[string]string
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			lastCommitToken = body["reservationToken"]
+			if n == 1 {
+				// First attempt — TTL has expired, sweeper deleted
+				// the row. PDM returns 404.
+				w.WriteHeader(http.StatusNotFound)
+				_, _ = w.Write([]byte(`{"error":"not-found"}`))
+				return
+			}
+			// Subsequent attempts succeed.
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"state":"active"}`))
+		case strings.HasSuffix(r.URL.Path, "/reserve"):
+			atomic.AddInt32(&reserves, 1)
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(Reservation{
+				PoolDomain:       "omani.works",
+				Subdomain:        "otech-test",
+				State:            "reserved",
+				ReservationToken: "fresh-token-after-rereserve",
+			})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	c := New(srv.URL)
+	var newTokenSeen string
+
+	err := c.CommitWithRetry(
+		context.Background(),
+		"omani.works",
+		CommitInput{
+			Subdomain:        "otech-test",
+			ReservationToken: "stale-token-from-original-reserve",
+			SovereignFQDN:    "otech-test.omani.works",
+			LoadBalancerIP:   "1.2.3.4",
+		},
+		func(ctx context.Context) (*Reservation, error) {
+			return c.Reserve(ctx, "omani.works", "otech-test", "test")
+		},
+		func(token string) {
+			newTokenSeen = token
+		},
+		CommitRetryConfig{MaxAttempts: 5, InitialBackoff: time.Millisecond, MaxBackoff: time.Millisecond},
+	)
+	if err != nil {
+		t.Fatalf("CommitWithRetry: %v", err)
+	}
+	if got := atomic.LoadInt32(&commits); got != 2 {
+		t.Errorf("commits=%d, want 2 (1 fail + 1 success)", got)
+	}
+	if got := atomic.LoadInt32(&reserves); got != 1 {
+		t.Errorf("reserves=%d, want 1 (single re-Reserve after 404)", got)
+	}
+	if newTokenSeen != "fresh-token-after-rereserve" {
+		t.Errorf("onRereserve callback received token=%q, want fresh-token-after-rereserve", newTokenSeen)
+	}
+	if lastCommitToken != "fresh-token-after-rereserve" {
+		t.Errorf("second Commit sent token=%q, want fresh-token-after-rereserve (the retry must use the NEW token)", lastCommitToken)
+	}
+}
+
+// TestCommitWithRetry_410Gone_TriggersRereserve covers the alternate
+// PDM failure mode where the row is still present but expires_at has
+// elapsed before the sweeper ran — PDM returns 410 Gone instead of
+// 404. CommitWithRetry must treat it identically to 404.
+func TestCommitWithRetry_410Gone_TriggersRereserve(t *testing.T) {
+	var commits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/commit"):
+			if atomic.AddInt32(&commits, 1) == 1 {
+				w.WriteHeader(http.StatusGone)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+		case strings.HasSuffix(r.URL.Path, "/reserve"):
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(Reservation{ReservationToken: "fresh"})
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	c := New(srv.URL)
+	called := false
+	err := c.CommitWithRetry(
+		context.Background(),
+		"omani.works",
+		CommitInput{Subdomain: "otech", ReservationToken: "stale", LoadBalancerIP: "1.1.1.1"},
+		func(ctx context.Context) (*Reservation, error) { called = true; return c.Reserve(ctx, "omani.works", "otech", "x") },
+		nil,
+		CommitRetryConfig{MaxAttempts: 3, InitialBackoff: time.Millisecond, MaxBackoff: time.Millisecond},
+	)
+	if err != nil {
+		t.Fatalf("CommitWithRetry: %v", err)
+	}
+	if !called {
+		t.Errorf("410 Gone should trigger re-Reserve")
+	}
+}
+
+// TestCommitWithRetry_5xx_BackoffThenExhaustion covers the transient
+// PDM-down case: every attempt returns 500 and the retry loop must
+// exhaust MaxAttempts before returning a wrapped error containing
+// "retry exhausted" so the caller's dep.Error message is actionable.
+func TestCommitWithRetry_5xx_BackoffThenExhaustion(t *testing.T) {
+	var commits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&commits, 1)
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":"db down"}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	c := New(srv.URL)
+	err := c.CommitWithRetry(
+		context.Background(),
+		"omani.works",
+		CommitInput{Subdomain: "otech", ReservationToken: "ok", LoadBalancerIP: "1.2.3.4"},
+		nil, // no reserve closure — 5xx never triggers re-Reserve
+		nil,
+		CommitRetryConfig{MaxAttempts: 4, InitialBackoff: time.Millisecond, MaxBackoff: 2 * time.Millisecond},
+	)
+	if err == nil {
+		t.Fatal("CommitWithRetry should fail on persistent 5xx")
+	}
+	if !strings.Contains(err.Error(), "retry exhausted") {
+		t.Errorf("err=%q should contain 'retry exhausted'", err.Error())
+	}
+	if !strings.Contains(err.Error(), "4 attempts") {
+		t.Errorf("err=%q should mention attempt count (4)", err.Error())
+	}
+	if got := atomic.LoadInt32(&commits); got != 4 {
+		t.Errorf("commits=%d, want 4 (MaxAttempts)", got)
+	}
+}
+
+// TestCommitWithRetry_5xx_RecoversBeforeExhaustion verifies that the
+// loop returns success the moment PDM recovers — it does not over-
+// retry once it sees a 200.
+func TestCommitWithRetry_5xx_RecoversBeforeExhaustion(t *testing.T) {
+	var commits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if atomic.AddInt32(&commits, 1) < 3 {
+			w.WriteHeader(http.StatusBadGateway)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	c := New(srv.URL)
+	err := c.CommitWithRetry(
+		context.Background(),
+		"omani.works",
+		CommitInput{Subdomain: "otech", ReservationToken: "ok", LoadBalancerIP: "1.2.3.4"},
+		nil,
+		nil,
+		CommitRetryConfig{MaxAttempts: 5, InitialBackoff: time.Millisecond, MaxBackoff: time.Millisecond},
+	)
+	if err != nil {
+		t.Fatalf("CommitWithRetry: %v", err)
+	}
+	if got := atomic.LoadInt32(&commits); got != 3 {
+		t.Errorf("commits=%d, want 3 (2 5xx + 1 success, no over-retry)", got)
+	}
+}
+
+// TestCommitWithRetry_403_TokenMismatch_TriggersRereserve covers the
+// case where a parallel /reserve replaced the row with a different
+// token between the original Reserve and the Commit. Same recovery
+// (Reserve again) as 404/410.
+func TestCommitWithRetry_403_TokenMismatch_TriggersRereserve(t *testing.T) {
+	var commits int32
+	var reserves int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/commit"):
+			if atomic.AddInt32(&commits, 1) == 1 {
+				w.WriteHeader(http.StatusForbidden)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+		case strings.HasSuffix(r.URL.Path, "/reserve"):
+			atomic.AddInt32(&reserves, 1)
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(Reservation{ReservationToken: "fresh"})
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	c := New(srv.URL)
+	err := c.CommitWithRetry(
+		context.Background(),
+		"omani.works",
+		CommitInput{Subdomain: "otech", ReservationToken: "stale", LoadBalancerIP: "1.1.1.1"},
+		func(ctx context.Context) (*Reservation, error) {
+			return c.Reserve(ctx, "omani.works", "otech", "x")
+		},
+		nil,
+		CommitRetryConfig{MaxAttempts: 3, InitialBackoff: time.Millisecond, MaxBackoff: time.Millisecond},
+	)
+	if err != nil {
+		t.Fatalf("CommitWithRetry: %v", err)
+	}
+	if got := atomic.LoadInt32(&reserves); got != 1 {
+		t.Errorf("reserves=%d, want 1 (re-Reserve after 403)", got)
+	}
+}
+
+// TestCommitWithRetry_ContextCancellation_StopsBackoff verifies that
+// a cancelled context unblocks the backoff sleep and returns
+// immediately, instead of waiting MaxBackoff before noticing.
+func TestCommitWithRetry_ContextCancellation_StopsBackoff(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(srv.Close)
+
+	c := New(srv.URL)
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		cancel()
+	}()
+
+	start := time.Now()
+	err := c.CommitWithRetry(
+		ctx,
+		"omani.works",
+		CommitInput{Subdomain: "otech", ReservationToken: "ok"},
+		nil,
+		nil,
+		// 1s/2s/4s backoff would normally take >= 7s — the cancel
+		// must unblock far sooner.
+		CommitRetryConfig{MaxAttempts: 5, InitialBackoff: time.Second, MaxBackoff: 4 * time.Second},
+	)
+	elapsed := time.Since(start)
+	if err == nil {
+		t.Fatal("expected cancel error")
+	}
+	if elapsed > 500*time.Millisecond {
+		t.Errorf("CommitWithRetry honoured backoff after cancel: elapsed=%v (want < 500ms)", elapsed)
+	}
+}
+
+// TestCommitWithRetry_NoReserveClosure_404Fails ensures that a caller
+// passing nil reserve closure does not silently retry forever — a
+// 404 with no recovery primitive is a programming error and surfaces
+// as a clear error message.
+func TestCommitWithRetry_NoReserveClosure_404Fails(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Cleanup(srv.Close)
+
+	c := New(srv.URL)
+	err := c.CommitWithRetry(
+		context.Background(),
+		"omani.works",
+		CommitInput{Subdomain: "otech", ReservationToken: "ok"},
+		nil, // <- the bug: caller forgot to pass a reserve closure
+		nil,
+		CommitRetryConfig{MaxAttempts: 3},
+	)
+	if err == nil {
+		t.Fatal("expected error when reserve closure is nil and PDM returns 404")
+	}
+	if !strings.Contains(err.Error(), "no reserve closure provided") {
+		t.Errorf("err=%q should mention missing reserve closure", err.Error())
+	}
+}


### PR DESCRIPTION
Closes #678.

Caught on otech41+; manual zone-seeding workaround was needed each iteration.

## Summary

- PDM's 10-minute reservation TTL is shorter than Phase-0's actual run time on a fresh Hetzner cluster (8-12 min), so by the time catalyst-api calls /commit the sweeper has deleted the reservation row → 404 → the Sovereign cluster comes up live but `console.<sub>.omani.works` never resolves.
- Adds `CommitWithRetry` with 5-attempt exponential backoff (1s → 16s) plus automatic re-Reserve on 404/410/403; new sentinels `ErrExpired` (410) and `ErrTokenMismatch` (403).
- Moves the commit call to BEFORE Phase-1 watch (LB IP is the only data PDM needs; Phase-1 doesn't change DNS routing) so retry events flow through the still-open wizard SSE stream.
- On final exhaustion, appends human-actionable text to `dep.Error` so the wizard FailureCard surfaces it instead of silently logging.

## Retry parameters

| Knob | Value | Rationale |
|------|-------|-----------|
| MaxAttempts | 5 | 1+2+4+8+16 = 31s of cumulative backoff plus per-attempt HTTP — fits inside a 5-min outer timeout with margin |
| InitialBackoff | 1s | Tight enough that a flake recovers in seconds, loose enough to not hammer PDM |
| MaxBackoff | 16s | Caps the worst-case last sleep; combined with the outer ctx, total ceiling is ~3 min |
| 4xx (TTL expired) | 0s before re-Reserve | The row is gone, not flapping — a fresh write is the right next step |

## Files changed

- `products/catalyst/bootstrap/api/internal/pdm/client.go` — sentinels + `CommitWithRetry`
- `products/catalyst/bootstrap/api/internal/pdm/client_test.go` — 7 unit tests (404→200, 410, 403, 5xx exhaust, 5xx-then-recover, ctx-cancel, missing-closure)
- `products/catalyst/bootstrap/api/internal/handler/deployments.go` — `commitPDMWithRetry` + `releasePDMReservation` helpers; commit moved to before Phase-1 watch; failure path enriches `dep.Error`
- `products/catalyst/bootstrap/api/internal/handler/subdomains.go` — pdmClient interface gains `CommitWithRetry`
- `products/catalyst/bootstrap/api/internal/handler/subdomains_test.go` — fakePDM shim

## Test plan

- [x] `go build ./products/catalyst/bootstrap/api/...` passes
- [x] `go test ./products/catalyst/bootstrap/api/internal/pdm/...` — 7/7 new tests pass
- [x] `go vet ./products/catalyst/bootstrap/api/...` clean
- [x] No new failures in `go test ./products/catalyst/bootstrap/api/internal/handler/...` — the 3 preexisting failures (Harbor robot token + magic auth, tracked separately) match origin/main
- [ ] Live verification on next otech provision: `console.otechN.omani.works` resolves without manual `pdnsutil` intervention. The "Build & Deploy Catalyst" workflow auto-rebuilds on merge to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)