### PR TITLE
fix(sovereign-console): per-depth Y centering, adaptive R, globe toggle, sticky header (#669 round 2)

### DIFF
--- a/products/catalyst/bootstrap/ui/src/app/globals.css
+++ b/products/catalyst/bootstrap/ui/src/app/globals.css
@@ -113,6 +113,30 @@
   --log-viewer-text-num:   rgba(139,148,158,0.7);
   --log-viewer-empty:      rgba(201,209,217,0.55);
   --log-line-focused-bg:   rgba(56,139,253,0.18);
+
+  /* Log search bar (issue #669 round 2). */
+  --log-search-bg:               rgba(13,17,23,0.5);
+  --log-search-input-bg:         rgba(13,17,23,0.85);
+  --log-search-input-text:       #c9d1d9;
+  --log-search-input-placeholder:rgba(148,163,184,0.55);
+  --log-search-icon:             rgba(148,163,184,0.6);
+  --log-search-nav-hover:        rgba(148,163,184,0.10);
+  --log-search-pill-text:        rgba(148,163,184,0.7);
+  --log-search-pill-regex-bg:    rgba(192,132,252,0.15);
+  --log-search-pill-regex-fg:    #C084FC;
+  --log-search-pill-regex-border:rgba(192,132,252,0.45);
+  --log-search-level-info-bg:     rgba(56,139,253,0.18);
+  --log-search-level-info-fg:     #79b8ff;
+  --log-search-level-info-border: rgba(56,139,253,0.45);
+  --log-search-level-warn-bg:     rgba(245,158,11,0.18);
+  --log-search-level-warn-fg:     #f59e0b;
+  --log-search-level-warn-border: rgba(245,158,11,0.45);
+  --log-search-level-error-bg:    rgba(248,81,73,0.18);
+  --log-search-level-error-fg:    #f85149;
+  --log-search-level-error-border:rgba(248,81,73,0.45);
+  --log-search-level-debug-bg:    rgba(148,163,184,0.18);
+  --log-search-level-debug-fg:    #94a3b8;
+  --log-search-level-debug-border:rgba(148,163,184,0.45);
 }
 
 /* Console-token override for `--color-success` — the wizard surface
@@ -261,6 +285,31 @@
   --log-viewer-text-num:    #94A3B8;
   --log-viewer-empty:       #64748B;
   --log-line-focused-bg:    rgba(37,99,235,0.12);
+
+  /* Log search bar light peers (issue #669 round 2). All FG values
+   * AA-clearing on the white search bar bg. */
+  --log-search-bg:               #F1F5F9;
+  --log-search-input-bg:         #FFFFFF;
+  --log-search-input-text:       #0F172A;
+  --log-search-input-placeholder:#94A3B8;
+  --log-search-icon:             #64748B;
+  --log-search-nav-hover:        rgba(15,23,42,0.06);
+  --log-search-pill-text:        #475569;
+  --log-search-pill-regex-bg:    rgba(124,58,237,0.10);
+  --log-search-pill-regex-fg:    #7C3AED;
+  --log-search-pill-regex-border:rgba(124,58,237,0.45);
+  --log-search-level-info-bg:     rgba(37,99,235,0.10);
+  --log-search-level-info-fg:     #1D4ED8;
+  --log-search-level-info-border: rgba(37,99,235,0.45);
+  --log-search-level-warn-bg:     rgba(180,83,9,0.10);
+  --log-search-level-warn-fg:     #B45309;
+  --log-search-level-warn-border: rgba(180,83,9,0.45);
+  --log-search-level-error-bg:    rgba(185,28,28,0.10);
+  --log-search-level-error-fg:    #B91C1C;
+  --log-search-level-error-border:rgba(185,28,28,0.45);
+  --log-search-level-debug-bg:    rgba(71,85,105,0.10);
+  --log-search-level-debug-fg:    #475569;
+  --log-search-level-debug-border:rgba(71,85,105,0.45);
 
   /* Wizard theme channels — light overrides */
   --wiz-ch:         0, 0, 0;

--- a/products/catalyst/bootstrap/ui/src/components/LogPane.tsx
+++ b/products/catalyst/bootstrap/ui/src/components/LogPane.tsx
@@ -92,14 +92,17 @@ export function LogPane({
   const [matchCount, setMatchCount] = useState<number>(0)
   const [matchIndex, setMatchIndex] = useState<number>(0)
   const [fullScreen, setFullScreen] = useState<boolean>(false)
-  /* Issue #669 — split-view state. When `splitView` is true and there
-   * are non-empty `globalLines`, the pane body lays out as a 2-column
-   * grid: per-component on the left, global merged stream on the
-   * right. Default to OFF so the pane keeps its slim 30vw footprint
-   * for the common single-component flow; operators flip it on when
-   * they want a provision-wide tail. */
-  const [splitView, setSplitView] = useState<boolean>(false)
+  /* Issue #669 round 2 — global view is a TOGGLE, not a split. Operators
+   * flip a globe icon to swap the single-column body between the host
+   * job's logs and the provision-wide merged stream. The pane width
+   * stays the same in both modes. Founder-verbatim 2026-05-03: "we do
+   * not split the page in to 2 pieces instead we toggle between global
+   * and the individual log views". */
+  const [viewMode, setViewMode] = useState<'component' | 'global'>('component')
   const hasGlobal = (globalLines?.length ?? 0) > 0
+  useEffect(() => {
+    if (!hasGlobal && viewMode === 'global') setViewMode('component')
+  }, [hasGlobal, viewMode])
 
   // Reset matchIndex whenever the count drops below it (e.g. operator
   // tightens the query). Bumping it from 0 → 1 the moment results
@@ -156,10 +159,8 @@ export function LogPane({
       aria-label={`Logs for ${jobTitle}`}
       data-testid="log-pane"
       data-fullscreen={fullScreen ? 'true' : 'false'}
-      data-split={splitView && hasGlobal ? 'true' : 'false'}
-      className={`log-pane${fullScreen ? ' is-fullscreen' : ''}${
-        splitView && hasGlobal ? ' is-split' : ''
-      }`}
+      data-view-mode={viewMode}
+      className={`log-pane${fullScreen ? ' is-fullscreen' : ''}`}
     >
       <style>{LOG_PANE_CSS}</style>
       <header className="log-pane-header" data-testid="log-pane-header">
@@ -173,29 +174,33 @@ export function LogPane({
         <span className="log-pane-title" data-testid="log-pane-title" title={jobTitle}>
           {jobTitle}
         </span>
-        {/* Issue #669 — split-view toggle. Only enabled when the
-            consumer passes `globalLines` so legacy mounts (no global
-            stream) hide the affordance entirely instead of showing a
-            disabled button. */}
+        {/* Issue #669 round 2 — globe icon toggles single-column view
+            between this component's log and the provision-wide merged
+            stream. Pressed = global, unpressed = component. */}
         {hasGlobal ? (
           <button
             type="button"
             className="log-pane-icon-btn"
-            aria-label={splitView ? 'Hide global log column' : 'Show global log column'}
-            aria-pressed={splitView}
-            data-testid="log-pane-split"
-            onClick={() => setSplitView((v) => !v)}
-            title={splitView ? 'Hide global log column' : 'Show global log column'}
+            aria-label={
+              viewMode === 'global'
+                ? 'Show this component log'
+                : 'Show global (all-components) log'
+            }
+            aria-pressed={viewMode === 'global'}
+            data-testid="log-pane-view-toggle"
+            onClick={() =>
+              setViewMode((m) => (m === 'global' ? 'component' : 'global'))
+            }
+            title={
+              viewMode === 'global'
+                ? 'Showing global · click to view this component'
+                : 'Showing this component · click to view global'
+            }
           >
             <svg width="14" height="14" viewBox="0 0 14 14" aria-hidden>
-              <path
-                d="M2 2 L6 2 L6 12 L2 12 Z M8 2 L12 2 L12 12 L8 12 Z"
-                stroke="currentColor"
-                strokeWidth="1.4"
-                fill="none"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              />
+              <circle cx="7" cy="7" r="5.5" stroke="currentColor" strokeWidth="1.3" fill="none" />
+              <ellipse cx="7" cy="7" rx="2.4" ry="5.5" stroke="currentColor" strokeWidth="1.3" fill="none" />
+              <path d="M1.5 7 L12.5 7" stroke="currentColor" strokeWidth="1.3" fill="none" />
             </svg>
           </button>
         ) : null}
@@ -246,7 +251,27 @@ export function LogPane({
         </button>
       </header>
 
-      {executionId ? (
+      {/*
+        Issue #669 round 2 — single-column body. `viewMode` selects the
+        content: 'component' renders the host job's logs (executionId
+        if present, else fallbackLines, else empty state); 'global'
+        renders the provision-wide merged stream. The LogSearch above
+        applies to whichever view is active.
+       */}
+      {viewMode === 'global' && hasGlobal ? (
+        <>
+          <LogSearch
+            matchCount={matchCount}
+            matchIndex={matchIndex}
+            onPrev={goPrev}
+            onNext={goNext}
+            onFilterChange={setFilter}
+          />
+          <div className="log-pane-body" data-testid="log-pane-body">
+            <GlobalLogColumn lines={globalLines!} filter={filter} />
+          </div>
+        </>
+      ) : executionId ? (
         <>
           <LogSearch
             matchCount={matchCount}
@@ -257,9 +282,6 @@ export function LogPane({
           />
           <div className="log-pane-body" data-testid="log-pane-body">
             <div className="log-pane-col" data-testid="log-pane-col-primary">
-              <div className="log-pane-col-header" data-testid="log-pane-col-primary-header">
-                <span>{jobTitle}</span>
-              </div>
               <div className="log-pane-col-body">
                 <ExecutionLogs
                   executionId={executionId}
@@ -270,9 +292,6 @@ export function LogPane({
                 />
               </div>
             </div>
-            {splitView && hasGlobal ? (
-              <GlobalLogColumn lines={globalLines!} filter={filter} />
-            ) : null}
           </div>
         </>
       ) : fallbackLines && fallbackLines.length > 0 ? (
@@ -286,9 +305,6 @@ export function LogPane({
           />
           <div className="log-pane-body" data-testid="log-pane-body">
             <div className="log-pane-col" data-testid="log-pane-col-primary">
-              <div className="log-pane-col-header" data-testid="log-pane-col-primary-header">
-                <span>{jobTitle}</span>
-              </div>
               <div className="log-pane-col-body">
                 <FallbackLogList
                   lines={fallbackLines}
@@ -298,19 +314,8 @@ export function LogPane({
                 />
               </div>
             </div>
-            {splitView && hasGlobal ? (
-              <GlobalLogColumn lines={globalLines!} filter={filter} />
-            ) : null}
           </div>
         </>
-      ) : splitView && hasGlobal ? (
-        // Issue #669 — operator opened split-view on a host job that has
-        // no recorded execution + no fallback lines yet. Render the
-        // global column on its own so the split affordance still
-        // delivers value.
-        <div className="log-pane-body" data-testid="log-pane-body">
-          <GlobalLogColumn lines={globalLines!} filter={filter} />
-        </div>
       ) : (
         <div className="log-pane-empty" data-testid="log-pane-empty">
           No execution recorded yet.
@@ -692,28 +697,21 @@ const LOG_PANE_CSS = `
   border-color: var(--color-accent, #38BDF8);
   background: rgba(56, 189, 248, 0.10);
 }
-/* Issue #669 — log-pane body lays out as a row of columns. With one
- * column (default) the column fills the body. With split-view on
- * (.is-split on the root aside element) the body holds two columns
- * side-by-side, each at 50% with a divider between them. */
+/* Issue #669 round 2 — single-column body. Globe icon swaps content
+ * in place; pane width stays the same in both modes. */
 .log-pane-body {
   flex: 1 1 auto;
   overflow: hidden;
   display: flex;
-  flex-direction: row;
-  gap: 0;
+  flex-direction: column;
   min-height: 0;
 }
 .log-pane-col {
-  flex: 1 1 50%;
+  flex: 1 1 auto;
   display: flex;
   flex-direction: column;
   min-height: 0;
   min-width: 0;
-  border-left: 1px solid var(--color-border);
-}
-.log-pane-col:first-child {
-  border-left: 0;
 }
 .log-pane-col-header {
   flex-shrink: 0;
@@ -740,11 +738,6 @@ const LOG_PANE_CSS = `
 .log-pane-col-body > * {
   flex: 1 1 auto;
   min-height: 0;
-}
-/* Wider footprint when split-view is on so each column has breathing
- * room. Falls back to the single-column 30vw when split is off. */
-.log-pane.is-split:not(.is-fullscreen) {
-  width: max(var(--log-pane-width, 30vw), 56vw);
 }
 .log-pane-empty {
   display: flex;

--- a/products/catalyst/bootstrap/ui/src/components/LogSearch.tsx
+++ b/products/catalyst/bootstrap/ui/src/components/LogSearch.tsx
@@ -201,6 +201,15 @@ export function lineMatches(text: string, filter: LogFilter): boolean {
   return text.toLowerCase().includes(q.toLowerCase())
 }
 
+/* Issue #669 round 2 — LogSearch theme tokens.
+ *
+ * All hardcoded rgba/hex values routed through CSS variables so the
+ * search bar reskins under [data-theme="light"] without losing AA
+ * contrast. New tokens: --log-search-bg, --log-search-input-bg,
+ * --log-search-input-text, --log-search-icon, --log-search-pill-text,
+ * --log-search-pill-regex-{bg,fg,border}, plus per-level
+ * --log-search-level-{info,warn,error,debug}-{bg,fg,border}. Light
+ * peers are defined in globals.css. */
 const LOG_SEARCH_CSS = `
 .log-search {
   display: flex;
@@ -208,7 +217,7 @@ const LOG_SEARCH_CSS = `
   gap: 0.4rem;
   padding: 0.5rem 0.6rem;
   border-bottom: 1px solid var(--color-border);
-  background: rgba(13, 17, 23, 0.5);
+  background: var(--log-search-bg, rgba(13,17,23,0.5));
   flex-shrink: 0;
 }
 .log-search-input-wrap {
@@ -222,27 +231,30 @@ const LOG_SEARCH_CSS = `
   left: 0.55rem;
   width: 13px;
   height: 13px;
-  color: rgba(148, 163, 184, 0.6);
+  color: var(--log-search-icon, rgba(148,163,184,0.6));
   pointer-events: none;
 }
 .log-search-input {
   flex: 1 1 auto;
   padding: 0.34rem 0.55rem 0.34rem 1.7rem;
-  background: rgba(13, 17, 23, 0.85);
+  background: var(--log-search-input-bg, rgba(13,17,23,0.85));
   border: 1px solid var(--color-border);
   border-radius: 6px;
-  color: rgba(201, 209, 217, 0.95);
+  color: var(--log-search-input-text, var(--color-text));
   font-size: 0.78rem;
   font-family: ui-monospace, SFMono-Regular, monospace;
   outline: none;
   transition: border-color 0.15s ease;
+}
+.log-search-input::placeholder {
+  color: var(--log-search-input-placeholder, var(--color-text-dim));
 }
 .log-search-input:focus {
   border-color: var(--color-accent, #38BDF8);
 }
 .log-search-count {
   font-size: 0.7rem;
-  color: rgba(148, 163, 184, 0.7);
+  color: var(--color-text-dim);
   font-variant-numeric: tabular-nums;
   white-space: nowrap;
   padding: 0 0.35rem;
@@ -251,17 +263,18 @@ const LOG_SEARCH_CSS = `
   appearance: none;
   border: 1px solid var(--color-border);
   background: transparent;
-  color: rgba(201, 209, 217, 0.85);
+  color: var(--color-text-dim);
   border-radius: 6px;
   width: 24px;
   height: 24px;
   font-size: 0.85rem;
   cursor: pointer;
-  transition: background-color 0.12s ease, border-color 0.12s ease;
+  transition: background-color 0.12s ease, border-color 0.12s ease, color 0.12s ease;
   flex-shrink: 0;
 }
 .log-search-nav:hover:not(:disabled) {
-  background: rgba(148, 163, 184, 0.1);
+  background: var(--log-search-nav-hover, rgba(148,163,184,0.1));
+  color: var(--color-text-strong);
   border-color: var(--color-text-dim);
 }
 .log-search-nav:disabled {
@@ -284,7 +297,7 @@ const LOG_SEARCH_CSS = `
   letter-spacing: 0.04em;
   text-transform: uppercase;
   cursor: pointer;
-  color: rgba(148, 163, 184, 0.7);
+  color: var(--log-search-pill-text, var(--color-text-dim));
   transition: background-color 0.12s ease, color 0.12s ease, border-color 0.12s ease;
 }
 .log-search-pill:hover { color: var(--color-text-strong); }
@@ -294,12 +307,28 @@ const LOG_SEARCH_CSS = `
   letter-spacing: 0;
 }
 .log-search-pill.regex.active {
-  background: rgba(192, 132, 252, 0.15);
-  color: #C084FC;
-  border-color: rgba(192, 132, 252, 0.45);
+  background: var(--log-search-pill-regex-bg, rgba(192,132,252,0.15));
+  color: var(--log-search-pill-regex-fg, #C084FC);
+  border-color: var(--log-search-pill-regex-border, rgba(192,132,252,0.45));
 }
-.log-search-pill.level-info.active   { background: rgba(56, 139, 253, 0.18);  color: #79b8ff; border-color: rgba(56, 139, 253, 0.45); }
-.log-search-pill.level-warn.active   { background: rgba(245, 158, 11, 0.18);  color: #f59e0b; border-color: rgba(245, 158, 11, 0.45); }
-.log-search-pill.level-error.active  { background: rgba(248, 81, 73, 0.18);   color: #f85149; border-color: rgba(248, 81, 73, 0.45); }
-.log-search-pill.level-debug.active  { background: rgba(148, 163, 184, 0.18); color: #94a3b8; border-color: rgba(148, 163, 184, 0.45); }
+.log-search-pill.level-info.active   {
+  background: var(--log-search-level-info-bg, rgba(56,139,253,0.18));
+  color: var(--log-search-level-info-fg, #79b8ff);
+  border-color: var(--log-search-level-info-border, rgba(56,139,253,0.45));
+}
+.log-search-pill.level-warn.active   {
+  background: var(--log-search-level-warn-bg, rgba(245,158,11,0.18));
+  color: var(--log-search-level-warn-fg, #f59e0b);
+  border-color: var(--log-search-level-warn-border, rgba(245,158,11,0.45));
+}
+.log-search-pill.level-error.active  {
+  background: var(--log-search-level-error-bg, rgba(248,81,73,0.18));
+  color: var(--log-search-level-error-fg, #f85149);
+  border-color: var(--log-search-level-error-border, rgba(248,81,73,0.45));
+}
+.log-search-pill.level-debug.active  {
+  background: var(--log-search-level-debug-bg, rgba(148,163,184,0.18));
+  color: var(--log-search-level-debug-fg, #94a3b8);
+  border-color: var(--log-search-level-debug-border, rgba(148,163,184,0.45));
+}
 `

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/FlowCanvasOrganic.bounded.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/FlowCanvasOrganic.bounded.test.tsx
@@ -195,9 +195,9 @@ describe('FlowCanvasOrganic — Bug #481 bounded layout', () => {
           const r = Number(c.getAttribute('r') ?? '0')
           if (r > maxR) maxR = r
         }
-        // The status-fill circle is at r=NODE_RADIUS (40); ensure the
-        // bubble has at least that much radius (≥40 → diameter ≥80).
-        expect(maxR).toBeGreaterThanOrEqual(40)
+        // Issue #669 round 2 — radius adaptive within
+        // [MIN_NODE_RADIUS=16, MAX_NODE_RADIUS=40]; assert floor only.
+        expect(maxR).toBeGreaterThanOrEqual(16)
       }
       void baseCircles
       void allCircles
@@ -540,7 +540,12 @@ describe('FlowCanvasOrganic — Bug #481 bounded layout', () => {
     ).toBeNull()
   })
 
-  it('keeps every bubble visible (radius ≥40) and viewBox bounded for a 60-node graph', () => {
+  it('keeps every bubble visible (radius ≥ MIN_NODE_RADIUS) and viewBox bounded for a 60-node graph (#669 round 2)', () => {
+    /* Issue #669 round 2 — bubble radius is now ADAPTIVE: clamped to
+     * [MIN_NODE_RADIUS=16, MAX_NODE_RADIUS=40]. A 60-node graph in a
+     * default-host (1200×700) shrinks toward MIN; we just assert R is
+     * never below the floor and the viewBox stays bounded. */
+    const MIN_NODE_RADIUS = 16
     const layout = makeLayout(60)
     const { container } = render(
       <FlowCanvasOrganic
@@ -569,7 +574,7 @@ describe('FlowCanvasOrganic — Bug #481 bounded layout', () => {
         const r = Number(c.getAttribute('r') ?? '0')
         if (r > maxR) maxR = r
       }
-      expect(maxR).toBeGreaterThanOrEqual(40)
+      expect(maxR).toBeGreaterThanOrEqual(MIN_NODE_RADIUS)
     }
   })
 
@@ -644,7 +649,7 @@ describe('FlowCanvasOrganic — Bug #481 bounded layout', () => {
     }
   })
 
-  it('orders Y by depRank — root sits higher than leaves (#532)', async () => {
+  it('linear chain reads horizontally on the X-axis centerline (#669 round 2)', async () => {
     const { flowLayoutOrganic } = await import('@/lib/flowLayoutOrganic')
     const baseJob = {
       appId: 'x',
@@ -687,8 +692,8 @@ describe('FlowCanvasOrganic — Bug #481 bounded layout', () => {
         onCanvasBackgroundClick={() => {}}
       />,
     )
-    // Read each node's rendered Y coordinate.
-    const yById = new Map<string, number>()
+    // Read each node's rendered position.
+    const posById = new Map<string, { x: number; y: number }>()
     for (const id of ['a', 'b', 'c', 'd', 'e']) {
       const g = container.querySelector<SVGGElement>(
         `[data-flow-draggable][data-job-id="${id}"]`,
@@ -697,18 +702,29 @@ describe('FlowCanvasOrganic — Bug #481 bounded layout', () => {
       const t = g!.getAttribute('transform') ?? ''
       const m = t.match(/translate\(([-\d.]+),\s*([-\d.]+)\)/)
       expect(m).not.toBeNull()
-      yById.set(id, Number(m![2]))
+      posById.set(id, { x: Number(m![1]), y: Number(m![2]) })
     }
-    // Higher depRank → higher Y (lower on canvas — Y grows downward).
-    // Because forceY is gentle and the initial seed already orders by
-    // depRank, the rendered Y must be non-decreasing along the chain.
-    expect(yById.get('a')!).toBeLessThan(yById.get('b')!)
-    expect(yById.get('b')!).toBeLessThan(yById.get('c')!)
-    expect(yById.get('c')!).toBeLessThan(yById.get('d')!)
-    expect(yById.get('d')!).toBeLessThan(yById.get('e')!)
+    /* Issue #669 round 2 — linear chain reads LEFT-TO-RIGHT (X grows
+     * with depth) and clusters around the X-axis centerline (each
+     * depth's bucket has size 1 so the median sibling lands at y=h/2).
+     * X must be strictly increasing along the dep chain; Y stays
+     * within ±halfBand of the host centerline. */
+    const svg = container.querySelector<SVGSVGElement>('[data-testid="flow-canvas-svg"]')!
+    const vbParts = (svg.getAttribute('viewBox') ?? '').split(/\s+/).map(Number)
+    const hostH = vbParts[3]
+    const yCenter = hostH / 2
+    expect(posById.get('a')!.x).toBeLessThan(posById.get('b')!.x)
+    expect(posById.get('b')!.x).toBeLessThan(posById.get('c')!.x)
+    expect(posById.get('c')!.x).toBeLessThan(posById.get('d')!.x)
+    expect(posById.get('d')!.x).toBeLessThan(posById.get('e')!.x)
+    // Y stays clustered near the centerline (±100px tolerance for
+    // jitter + force settling).
+    for (const id of ['a', 'b', 'c', 'd', 'e']) {
+      expect(Math.abs(posById.get(id)!.y - yCenter)).toBeLessThanOrEqual(100)
+    }
   })
 
-  it('forceCollide guarantees min spacing of NODE_RADIUS*2 + COLLIDE_PADDING (#532 no-overlap)', async () => {
+  it('forceCollide guarantees min spacing of 2R + COLLIDE_PADDING — adaptive R (#669 round 2 no-overlap)', async () => {
     // 8 sibling nodes — same depth, same region, all pending. Without
     // forceCollide they'd want to overlap at the same depth-anchor.
     const { flowLayoutOrganic } = await import('@/lib/flowLayoutOrganic')
@@ -761,11 +777,15 @@ describe('FlowCanvasOrganic — Bug #481 bounded layout', () => {
       positions.push({ id, x: Number(m[1]), y: Number(m[2]) })
     }
     expect(positions.length).toBe(8)
-    // Acceptance: every pair of node centroids is ≥
-    // NODE_RADIUS*2 + COLLIDE_PADDING apart (= 92px). Allow a small
-    // numerical tolerance (2px) for sub-pixel float drift before the
-    // sim fully converges.
-    const MIN_SPACING = 40 * 2 + 12 // NODE_RADIUS*2 + COLLIDE_PADDING
+    /* Issue #669 round 2 — bubble radius is adaptive. Read the actual
+     * rendered radius from the SVG (last <circle> on each <g> is the
+     * status fill) and require pairwise distance ≥ 2R + COLLIDE_PADDING.
+     * R is constant across all bubbles in a single layout. */
+    const COLLIDE_PADDING = 12
+    const someG = groups[0]!
+    const lastCircle = someG.querySelectorAll('circle')[someG.querySelectorAll('circle').length - 1]
+    const renderedR = Number(lastCircle?.getAttribute('r') ?? '40')
+    const MIN_SPACING = renderedR * 2 + COLLIDE_PADDING
     const TOL = 2
     for (let i = 0; i < positions.length; i++) {
       for (let j = i + 1; j < positions.length; j++) {

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/FlowCanvasOrganic.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/FlowCanvasOrganic.tsx
@@ -144,25 +144,28 @@ const ARROW_FALLBACK: Record<JobStatus, string> = {
  *  edge by the per-tick clamp; forceCollide then resolves any
  *  edge-induced overlaps within the visible window.
  */
-const NODE_RADIUS = 40
-const GROUP_RADIUS = 48
-const COLLIDE_PADDING = 12
-/** Initial host dimensions used until ResizeObserver fires.
+/** Issue #669 round 2 — adaptive bubble + edge sizing.
  *
- *  ResizeObserver emits asynchronously after mount, so on first paint
- *  we lay out against a sensible default rather than 0×0 (which would
- *  collapse every node onto the origin and break forceCollide's
- *  pairwise spacing). 1200×700 mirrors the previous MAX_VBOX seed —
- *  the first frame renders against that, then the observer's first
- *  callback corrects to the real host pixel rect within ~16ms. */
+ *  Bubbles render at a per-layout effective radius `R` clamped to
+ *  [MIN_NODE_RADIUS, MAX_NODE_RADIUS]. The chosen R is the largest
+ *  size that keeps the densest depth bucket fitting vertically inside
+ *  the host. With one bubble on a wide canvas R=MAX (the bubble doesn't
+ *  inflate to fill the screen); with 30+ siblings in a tight column
+ *  R shrinks to MIN before any flow shape compromises kick in.
+ *  Founder-verbatim 2026-05-03: "if there is only one buble on
+ *  the page... we prefer making them sammller instead of compromising
+ *  from their flow view". */
+const MIN_NODE_RADIUS = 16
+const MAX_NODE_RADIUS = 40
+const GROUP_RADIUS_DELTA = 8
+const COLLIDE_PADDING = 12
+/** Initial host dimensions used until ResizeObserver fires. */
 const MIN_HOST_W = 1200
 const MIN_HOST_H = 700
-/** Per-depth column width — wider than NODE_RADIUS*4 so adjacent-depth
- *  bubbles never visually touch. */
-const PER_DEPTH_X = NODE_RADIUS * 4
-/** Link distance — connected siblings settle ~100px apart, total
- *  on-canvas edge length stays <140px even with arrowhead trim. */
-const LINK_DISTANCE = NODE_RADIUS * 2.5
+/** Per-depth horizontal step floor / ceiling — `layoutMetrics` picks
+ *  inside this range based on layout density and host width. */
+const MIN_PER_DEPTH_X = 110
+const MAX_PER_DEPTH_X = 200
 /** Force strengths re-tuned post-#483. Gentle X-anchor lets the link
  *  force pull connected nodes together without the X-force fighting
  *  back and producing the oscillation that read as "infinite stretch". */
@@ -272,15 +275,57 @@ export function FlowCanvasOrganic(props: FlowCanvasOrganicProps) {
   // Regions still drive family/region badges in FlowNode but no longer
   // partition the canvas vertically — the dependency order does.
 
-  /* Issue #669 — anchor depth 0 at a left margin instead of x=0 so the
-   * grid-target sub-columns (centred on baseX with span ±SUB_COL_SPAN)
-   * don't extend into negative X. With viewBox = host px starting at
-   * 0,0 (preserveAspectRatio "xMinYMin meet"), negative coordinates
-   * render off-canvas to the left. */
-  const X_LEFT_MARGIN = NODE_RADIUS + PER_DEPTH_X / 2
+  /* Issue #669 round 2 — adaptive layout metrics.
+   *
+   * For each layout we compute the effective bubble radius `R`, group
+   * radius `GR`, per-depth horizontal step `perDepthX`, and link
+   * distance `linkDistance`. The chosen R is the largest that lets
+   * the densest depth bucket fit vertically inside the host AND the
+   * depth-chain fit horizontally; if neither constraint binds, R
+   * snaps to MAX_NODE_RADIUS. A single bubble does NOT inflate; many
+   * bubbles in a tight host shrink toward MIN before any flow-shape
+   * compromise is made.
+   *
+   * The metrics depend on layout.nodes + hostSize.{w,h} so they
+   * re-run when LogPane opens/closes or window resizes, which —
+   * together with the sim-restart effect below that re-seeds free
+   * nodes to their fresh targets — gives bubbles a visible re-flow
+   * pass on every host change. */
+  const layoutMetrics = useMemo(() => {
+    let maxBucket = 0
+    let maxDepth = 0
+    const buckets = new Map<number, number>()
+    for (const n of layout.nodes) {
+      const c = (buckets.get(n.depth) ?? 0) + 1
+      buckets.set(n.depth, c)
+      if (c > maxBucket) maxBucket = c
+      if (n.depth > maxDepth) maxDepth = n.depth
+    }
+    const depthCount = maxDepth + 1
+    let r = MAX_NODE_RADIUS
+    if (maxBucket > 1) {
+      const usableH = Math.max(60, hostSize.h - 2 * (MAX_NODE_RADIUS + COLLIDE_PADDING))
+      const pitchAvail = usableH / maxBucket
+      const rFit = (pitchAvail - COLLIDE_PADDING) / 2
+      r = Math.min(MAX_NODE_RADIUS, Math.max(MIN_NODE_RADIUS, Math.floor(rFit)))
+    }
+    let perDepthX = Math.max(MIN_PER_DEPTH_X, Math.min(MAX_PER_DEPTH_X, r * 4))
+    if (depthCount > 1) {
+      const usableW = Math.max(120, hostSize.w - 2 * (r + COLLIDE_PADDING))
+      const fitW = usableW / Math.max(1, depthCount - 1)
+      perDepthX = Math.min(perDepthX, Math.max(MIN_PER_DEPTH_X, fitW))
+    }
+    const linkDistance = perDepthX * 0.625
+    const gr = r + GROUP_RADIUS_DELTA
+    const xLeftMargin = r + perDepthX / 2
+    return { r, gr, perDepthX, linkDistance, xLeftMargin, maxBucket, depthCount }
+  }, [layout.nodes, hostSize.w, hostSize.h])
+
+  const { r: R, gr: GR, perDepthX: PER_DEPTH_X, linkDistance: LINK_DISTANCE, xLeftMargin: X_LEFT_MARGIN } = layoutMetrics
+
   const depthToX = useCallback(
     (depth: number) => X_LEFT_MARGIN + depth * PER_DEPTH_X,
-    [X_LEFT_MARGIN],
+    [X_LEFT_MARGIN, PER_DEPTH_X],
   )
 
   /* Issue #532 — resolve a per-node depRank.
@@ -322,19 +367,47 @@ export function FlowCanvasOrganic(props: FlowCanvasOrganicProps) {
    * of fully-spread nodes at MAX_VBOX_H / 92 ≈ 7; beyond that, the
    * forceCollide guarantees pairwise spacing while siblings pack into
    * the available vertical band naturally. */
-  const Y_MARGIN = NODE_RADIUS + COLLIDE_PADDING
-  /* Issue #669 — Y-range driven by hostSize.h, not a hardcoded MAX_VBOX
-   * ceiling. ResizeObserver on the canvas-host re-runs this whenever
-   * the host pixel height changes (e.g. fullscreen, log-pane closed). */
-  const Y_RANGE = Math.max(NODE_RADIUS * 2, hostSize.h - Y_MARGIN * 2)
-  const totalNodes = layout.nodes.length
-  const yForDepRank = useCallback(
-    (depRank: number) => {
-      if (totalNodes <= 1) return Y_MARGIN + Y_RANGE / 2
-      const t = depRank / (totalNodes - 1)
-      return Y_MARGIN + t * Y_RANGE
+  /* Issue #669 round 2 — per-depth-bucket Y rank.
+   *
+   * Founder-verbatim 2026-05-03: "y axis should be equally splitted
+   * into y and -y... items distributed in +y and -y axis accepting
+   * the x axis as their separator". The diagonal layout came from a
+   * global topo-rank for Y — depth-0 nodes piled at the top while
+   * deeper ranks slid down, producing a left-top → right-bottom
+   * diagonal. Replace with per-depth ranks so each depth column
+   * distributes its siblings symmetrically around y=h/2. */
+  const Y_CENTER = hostSize.h / 2
+  const PITCH = R * 2 + COLLIDE_PADDING
+
+  const bucketRank = useMemo(() => {
+    const rank = new Map<string, { idx: number; size: number }>()
+    const seen = new Map<number, OrganicNode[]>()
+    for (const n of layout.nodes) {
+      let arr = seen.get(n.depth)
+      if (!arr) { arr = []; seen.set(n.depth, arr) }
+      arr.push(n)
+    }
+    for (const arr of seen.values()) {
+      arr.sort((a, b) => {
+        const ra = resolvedDepRank.get(a.id) ?? 0
+        const rb = resolvedDepRank.get(b.id) ?? 0
+        return ra - rb
+      })
+      arr.forEach((n, i) => rank.set(n.id, { idx: i, size: arr.length }))
+    }
+    return rank
+  }, [layout.nodes, resolvedDepRank])
+
+  /* Per-bucket centred Y target — sibling at index `i` of `n` lands
+   * at h/2 + (i - (n-1)/2) * pitch. Median sibling on the X-axis
+   * centerline; rest spread symmetrically above and below. */
+  const yForBucket = useCallback(
+    (id: string) => {
+      const b = bucketRank.get(id)
+      if (!b) return Y_CENTER
+      return Y_CENTER + (b.idx - (b.size - 1) / 2) * PITCH
     },
-    [totalNodes, Y_RANGE, Y_MARGIN],
+    [bucketRank, Y_CENTER, PITCH],
   )
 
   const familyById = useMemo(() => {
@@ -370,9 +443,10 @@ export function FlowCanvasOrganic(props: FlowCanvasOrganicProps) {
       totalCols: number
       totalRows: number
     }
-    const ROW_PITCH = NODE_RADIUS * 2 + COLLIDE_PADDING
-    const Y_MARGIN_LOCAL = NODE_RADIUS + COLLIDE_PADDING
-    const Y_RANGE_LOCAL = Math.max(NODE_RADIUS * 2, hostSize.h - Y_MARGIN_LOCAL * 2)
+    const ROW_PITCH = R * 2 + COLLIDE_PADDING
+    const Y_MARGIN_LOCAL = R + COLLIDE_PADDING
+    const Y_RANGE_LOCAL = Math.max(R * 2, hostSize.h - Y_MARGIN_LOCAL * 2)
+    const Y_CENTER_LOCAL = hostSize.h / 2
     // How many bubbles fit vertically with the no-overlap collision
     // pitch (NODE_RADIUS*2 + COLLIDE_PADDING = 92px on 700px viewBox →
     // 7 rows). Beyond that, we MUST add sub-columns or bubbles overlap.
@@ -413,21 +487,20 @@ export function FlowCanvasOrganic(props: FlowCanvasOrganicProps) {
       // Issue #532 founder verbatim: "homogenously spread". Distribute
       // rows evenly across the full Y range (not packed at the top).
       const rowStep = totalRows > 1
-        ? Y_RANGE_LOCAL / (totalRows - 1)
+        ? Math.min(ROW_PITCH * 1.2, Y_RANGE_LOCAL / (totalRows - 1))
         : 0
       bucket.forEach((n, idx) => {
-        // Column-major fill: idx 0..(totalRows-1) fill column 0 top→
-        // bottom, then idx totalRows..(2*totalRows-1) fill column 1,
-        // etc. This keeps consecutive siblings (often related in the
-        // upstream order) clustered together rather than scattered.
         const subCol = Math.floor(idx / totalRows)
         const subRow = idx % totalRows
         const colOffset = totalCols > 1
           ? (subCol - (totalCols - 1) / 2) * colStep
           : 0
+        // Issue #669 round 2 — centred row spread around y=h/2 instead
+        // of starting from the top margin. Median row lands on the
+        // X-axis centerline; rest spread above and below.
         const ty = totalRows > 1
-          ? Y_MARGIN_LOCAL + subRow * rowStep
-          : Y_MARGIN_LOCAL + Y_RANGE_LOCAL / 2
+          ? Y_CENTER_LOCAL + (subRow - (totalRows - 1) / 2) * rowStep
+          : Y_CENTER_LOCAL
         cells.set(n.id, {
           tx: baseX + colOffset,
           ty,
@@ -437,7 +510,7 @@ export function FlowCanvasOrganic(props: FlowCanvasOrganicProps) {
       })
     }
     return cells
-  }, [layout.nodes, hostSize.h, X_LEFT_MARGIN])
+  }, [layout.nodes, hostSize.h, X_LEFT_MARGIN, R, PER_DEPTH_X])
 
   const simNodes = useMemo<SimNode[]>(() => {
     const next: SimNode[] = []
@@ -456,19 +529,13 @@ export function FlowCanvasOrganic(props: FlowCanvasOrganicProps) {
         next.push(existing)
       } else {
         const baseX = depthToX(n.depth)
-        // Issue #532 — initial Y comes from either the high-fan-out
-        // grid pre-pass (cell.ty is now absolute, homogeneous-spread
-        // Y target for the depth bucket) or the depRank ladder for
-        // sparse depths.
         const seed = hashSeed(n.id)
         const cell = gridTargets.get(n.id)
-        const initX = cell ? cell.tx : baseX + (seed.fx - 0.5) * NODE_RADIUS * 1.5
-        // For sparse-depth nodes, small Y jitter so two nodes with
-        // identical depRank don't start at literally the same pixel —
-        // the collision force then separates them deterministically.
+        const initX = cell ? cell.tx : baseX + (seed.fx - 0.5) * R * 1.5
+        // Issue #669 round 2 — initial Y from per-bucket centred target.
         const initY = cell
           ? cell.ty
-          : yForDepRank(rank) + (seed.fy - 0.5) * NODE_RADIUS * 0.6
+          : yForBucket(n.id) + (seed.fy - 0.5) * R * 0.6
         const fresh: SimNode = {
           id: n.id,
           depth: n.depth,
@@ -488,7 +555,7 @@ export function FlowCanvasOrganic(props: FlowCanvasOrganicProps) {
       if (!seen.has(id)) nodesRef.current.delete(id)
     }
     return next
-  }, [layout.nodes, depthToX, yForDepRank, gridTargets, resolvedDepRank])
+  }, [layout.nodes, depthToX, yForBucket, gridTargets, resolvedDepRank, R])
 
   useEffect(() => {
     if (simNodes.length === 0) {
@@ -516,6 +583,19 @@ export function FlowCanvasOrganic(props: FlowCanvasOrganicProps) {
     // freezing again.
     const MAX_TICKS = 120
     tickCountRef.current = 0
+    /* Issue #669 round 2 — visible re-flow on every layout/host change.
+     * Snap each free (un-pinned) node to its fresh target so the
+     * operator sees the reflow rather than the sim drifting back to
+     * old positions over 2s. Pinned (dragged) nodes keep fx/fy. */
+    for (const n of simNodes) {
+      if (typeof n.fx === 'number' && typeof n.fy === 'number') continue
+      const cell = gridTargets.get(n.id)
+      const seed = hashSeed(n.id)
+      n.x = cell ? cell.tx : depthToX(n.depth) + (seed.fx - 0.5) * R * 1.5
+      n.y = cell ? cell.ty : yForBucket(n.id) + (seed.fy - 0.5) * R * 0.6
+      n.vx = 0
+      n.vy = 0
+    }
     const sim = forceSimulation<SimNode>(simNodes)
       .alpha(0.9)
       .alphaDecay(0.06)
@@ -524,7 +604,7 @@ export function FlowCanvasOrganic(props: FlowCanvasOrganicProps) {
       .force(
         'collide',
         forceCollide<SimNode>()
-          .radius((d) => (d.isGroup ? GROUP_RADIUS : NODE_RADIUS) + COLLIDE_PADDING)
+          .radius((d) => (d.isGroup ? GR : R) + COLLIDE_PADDING)
           .strength(0.95)
           .iterations(2),
       )
@@ -532,8 +612,6 @@ export function FlowCanvasOrganic(props: FlowCanvasOrganicProps) {
         'x',
         forceX<SimNode>()
           .x((d) => {
-            // Issue #493 — high-fan-out depth buckets have a sub-column
-            // X target. Sparse depths fall through to the depth anchor.
             const cell = gridTargets.get(d.id)
             return cell ? cell.tx : depthToX(d.depth)
           })
@@ -543,14 +621,11 @@ export function FlowCanvasOrganic(props: FlowCanvasOrganicProps) {
         'y',
         forceY<SimNode>()
           .y((d) => {
-            // Issue #532 — Y target. High-fan-out depth buckets get
-            // a homogeneous-spread Y from the gridTargets pre-pass
-            // (cell.ty is absolute). Sparse depths fall through to
-            // the depRank ladder so depth-of-dep order reads as
-            // top → bottom.
+            // Issue #669 round 2 — Y target now per-bucket centred
+            // (yForBucket) instead of global topo ladder.
             const cell = gridTargets.get(d.id)
             if (cell) return cell.ty
-            return yForDepRank(d.depRank)
+            return yForBucket(d.id)
           })
           .strength(FORCE_Y_STRENGTH),
       )
@@ -593,8 +668,8 @@ export function FlowCanvasOrganic(props: FlowCanvasOrganicProps) {
             const colSlot = cell.totalCols > 1
               ? SUB_COL_SPAN / (cell.totalCols - 1)
               : PER_DEPTH_X
-            const Y_MARGIN_LOCAL = NODE_RADIUS + COLLIDE_PADDING
-            const Y_RANGE_LOCAL = Math.max(NODE_RADIUS * 2, hostSize.h - Y_MARGIN_LOCAL * 2)
+            const Y_MARGIN_LOCAL = R + COLLIDE_PADDING
+            const Y_RANGE_LOCAL = Math.max(R * 2, hostSize.h - Y_MARGIN_LOCAL * 2)
             const rowSlot = cell.totalRows > 1
               ? Y_RANGE_LOCAL / (cell.totalRows - 1)
               : Y_RANGE_LOCAL
@@ -625,16 +700,16 @@ export function FlowCanvasOrganic(props: FlowCanvasOrganicProps) {
            * outside the viewBox, post-render clamping cannot recover
            * pairwise spacing. Keep the sim inside the visible window
            * end-to-end. */
-          const xMin = Math.max(NODE_RADIUS, baseX - PER_DEPTH_X)
-          const xMax = Math.min(hostSize.w - NODE_RADIUS, baseX + PER_DEPTH_X)
+          const xMin = Math.max(R, baseX - PER_DEPTH_X)
+          const xMax = Math.min(hostSize.w - R, baseX + PER_DEPTH_X)
           if (typeof n.x === 'number') {
             if (n.x < xMin) n.x = xMin
             else if (n.x > xMax) n.x = xMax
           }
-          const targetY = yForDepRank(n.depRank)
-          const Y_HALF_BAND = (NODE_RADIUS * 2 + COLLIDE_PADDING)
-          const yMin = Math.max(NODE_RADIUS, targetY - Y_HALF_BAND)
-          const yMax = Math.min(hostSize.h - NODE_RADIUS, targetY + Y_HALF_BAND)
+          const targetY = yForBucket(n.id)
+          const Y_HALF_BAND = (R * 2 + COLLIDE_PADDING)
+          const yMin = Math.max(R, targetY - Y_HALF_BAND)
+          const yMax = Math.min(hostSize.h - R, targetY + Y_HALF_BAND)
           if (typeof n.y === 'number') {
             if (n.y < yMin) n.y = yMin
             else if (n.y > yMax) n.y = yMax
@@ -657,7 +732,7 @@ export function FlowCanvasOrganic(props: FlowCanvasOrganicProps) {
     return () => {
       sim.stop()
     }
-  }, [simNodes, layout.edges, depthToX, yForDepRank, gridTargets, hostSize.h, hostSize.w])
+  }, [simNodes, layout.edges, depthToX, yForBucket, gridTargets, hostSize.h, hostSize.w, R, GR, PER_DEPTH_X, LINK_DISTANCE])
 
   const nodeIdsKey = simNodes.map((n) => n.id).join(',')
   useEffect(() => {
@@ -771,7 +846,7 @@ export function FlowCanvasOrganic(props: FlowCanvasOrganicProps) {
    * ≥ NODE_RADIUS*2 + COLLIDE_PADDING (= 92 px), and clamping to a
    * single edge cannot reduce two clamped nodes' distance below that
    * threshold (the collide pass owns it pre-render). */
-  const CLAMP_INSET = NODE_RADIUS + 8
+  const CLAMP_INSET = R + 8
   const project = (p: { x: number; y: number }) => {
     const x = Math.min(vbW - CLAMP_INSET, Math.max(CLAMP_INSET, p.x))
     const y = Math.min(vbH - CLAMP_INSET, Math.max(CLAMP_INSET, p.y))
@@ -868,6 +943,7 @@ export function FlowCanvasOrganic(props: FlowCanvasOrganicProps) {
             status={e.fromStatus}
             kind={e.kind}
             highlighted={onSelectionPath ? 'selection' : onHostPath ? 'host' : 'none'}
+            r={R}
           />
         )
       })}
@@ -894,6 +970,8 @@ export function FlowCanvasOrganic(props: FlowCanvasOrganicProps) {
             isDimmed={openJobId !== null && !isNeighbor && !isOpen && !isHost}
             onClick={(e) => onJobClick(node.id, e)}
             onDoubleClick={() => onJobDoubleClick(node.id)}
+            r={R}
+            gr={GR}
           />
         )
       })}
@@ -910,16 +988,17 @@ interface FlowEdgeProps {
   status: JobStatus
   kind: 'depends-on' | 'parent-child'
   highlighted: 'none' | 'selection' | 'host'
+  r: number
 }
 
-function FlowEdge({ from, to, status, kind, highlighted }: FlowEdgeProps) {
+function FlowEdge({ from, to, status, kind, highlighted, r }: FlowEdgeProps) {
   const tone = STATUS_TONE[status]
   const dx = to.x - from.x
   const dy = to.y - from.y
   const len = Math.hypot(dx, dy) || 1
-  const trim = NODE_RADIUS + 6
-  const fx = from.x + (dx / len) * NODE_RADIUS
-  const fy = from.y + (dy / len) * NODE_RADIUS
+  const trim = r + 6
+  const fx = from.x + (dx / len) * r
+  const fy = from.y + (dy / len) * r
   const tx = to.x - (dx / len) * trim
   const ty = to.y - (dy / len) * trim
 
@@ -963,6 +1042,8 @@ interface FlowNodeProps {
   isDimmed: boolean
   onClick: (e: ReactMouseEvent<SVGGElement>) => void
   onDoubleClick: () => void
+  r: number
+  gr: number
 }
 
 function FlowNode({
@@ -976,6 +1057,8 @@ function FlowNode({
   isDimmed,
   onClick,
   onDoubleClick,
+  r,
+  gr,
 }: FlowNodeProps) {
   const tone = STATUS_TONE[node.status]
   // Inner ring priority — drawn on the bubble itself:
@@ -992,7 +1075,7 @@ function FlowNode({
         ? HOST_RING
         : tone.ring
   const familyColor = family?.color ?? 'rgba(148,163,184,0.55)'
-  const radius = node.isGroup ? GROUP_RADIUS : NODE_RADIUS
+  const radius = node.isGroup ? gr : r
   const grpStyle: CSSProperties = { cursor: 'grab' }
   const groupOpacity = isDimmed ? 0.35 : 1
   const innerWidth = isOpen ? 4 : isNeighbor ? 3 : isHost ? 3.5 : 2

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/JobDetail.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/JobDetail.tsx
@@ -427,11 +427,22 @@ const JOB_DETAIL_CSS = `
   padding-right: 1rem;
 }
 
+/* Issue #669 round 2 — sticky header. The Back link, last-update
+ * timestamp and status chip stay frozen at the top of the canvas
+ * scroll area while the flow-canvas / LogPane content scrolls.
+ * position:sticky + top:0 pin against the .job-detail-page
+ * container; a solid surface background prevents the header text
+ * from blending into the canvas backdrop while content slides
+ * underneath. */
 .job-detail-header {
+  position: sticky;
+  top: 0;
+  z-index: 5;
+  background: var(--color-bg);
   display: flex;
   align-items: center;
   gap: 1rem;
-  padding-bottom: 0.45rem;
+  padding: 0.45rem 0;
   border-bottom: 1px solid var(--color-border);
   flex-shrink: 0;
   min-width: 0;


### PR DESCRIPTION
## Summary

Round 2 of #669 — addressing the founder's UAT feedback after #671/#672/#673/#675:

1. **Per-depth Y centering** — replaced the global topo-rank Y ladder (which made the layout read as a top-left → bottom-right diagonal) with per-depth-bucket centered spread. Each depth column distributes its siblings symmetrically above and below y=h/2; the X-axis acts as the separator.
2. **Adaptive R + edge sizing** — bubble radius is now clamped to `[MIN_NODE_RADIUS=16, MAX_NODE_RADIUS=40]`. The chosen R is the largest that lets the densest depth bucket fit the host vertically AND the depth chain fit horizontally. Single bubble doesn't inflate; tight clusters shrink toward MIN before any flow-shape compromise.
3. **Re-flow on resize / pane close** — the simulation now snaps every free (un-pinned) node to its fresh layout target before alpha kicks in, so closing the LogPane / resizing the window produces a visible re-flow rather than the sim drifting back over 2s.
4. **Global log = TOGGLE not split** — globe icon in `LogPane` header swaps the single-column body between this component's log and the provision-wide merged stream. Pane width stays the same in both modes; split-view CSS removed.
5. **Sticky JobDetail header strip** — `← Back / last update / status` line is now `position: sticky` against the page container.
6. **Light-theme audit on LogSearch** — search bar bg, input, icons, level pills, regex pill all routed through new CSS variables with `[data-theme="light"]` peers.

## Test plan

- [x] `tsc -b` clean
- [x] `vitest run` — FlowCanvasOrganic.bounded (17 tests, including updated adaptive-R + per-depth-Y assertions), JobDetail, ExecutionLogs, LogPane.fallback all green
- [ ] Live verification on console.openova.io after deploy: layout no longer diagonal, bubbles reflow on pane-close, globe-toggle swaps content, header sticks while scrolling, light-theme on log search

🤖 Generated with [Claude Code](https://claude.com/claude-code)