### PR TITLE
fix(bp-cilium): upgrade upstream cilium 1.16.5 → 1.19.3 (1.2.0)

### DIFF
--- a/clusters/_template/bootstrap-kit/01-cilium.yaml
+++ b/clusters/_template/bootstrap-kit/01-cilium.yaml
@@ -36,7 +36,7 @@ spec:
   chart:
     spec:
       chart: bp-cilium
-      version: 1.1.5
+      version: 1.2.0
       sourceRef:
         kind: HelmRepository
         name: bp-cilium

--- a/platform/cilium/blueprint.yaml
+++ b/platform/cilium/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/category: per-host-cluster-infrastructure
     catalyst.openova.io/section: pts-3-1-networking-and-service-mesh
 spec:
-  version: 1.1.3
+  version: 1.2.0
   card:
     title: Cilium
     summary: Unified CNI + Service Mesh (eBPF). mTLS via WireGuard, Hubble observability, Gateway API.

--- a/platform/cilium/chart/Chart.yaml
+++ b/platform/cilium/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-cilium
-version: 1.1.5
+version: 1.2.0
 description: |
   Catalyst-curated Blueprint umbrella chart for Cilium. Depends on the
   upstream `cilium` chart as a Helm subchart so `helm dependency build`
@@ -16,11 +16,21 @@ maintainers:
     email: catalyst@openova.io
 
 # Upstream chart pulled in as a Helm subchart so `helm dependency build`
-# bundles it into the OCI artifact. Pinned to cilium/cilium 1.16.5 (matches
+# bundles it into the OCI artifact. Pinned to cilium/cilium 1.19.3 (matches
 # platform/cilium/blueprint.yaml + values.yaml `catalystBlueprint.upstream
 # .version`). Per docs/INVIOLABLE-PRINCIPLES.md #4 (never hardcode) the
 # version is operator-bumpable via PR + Blueprint release.
+#
+# 1.16.5 → 1.19.3 jump (2026-05-03): 1.16.x had buggy gateway-api hostNetwork
+# mode where cilium-envoy NACK'd listeners with "cannot bind '0.0.0.0:80':
+# Permission denied" and the loaded RDS for the Sovereign vhost only
+# carried the default `/` route — `/auth/*` and `/api/*` HTTPRoute matches
+# never reached envoy's live config. 1.18+ ships the mature Gateway API
+# implementation (graduated from beta), 1.19 is the current stable line.
+# Values shape verified compatible: gatewayAPI.hostNetwork.enabled,
+# envoy.enabled, envoyConfig.enabled, encryption.type=wireguard,
+# nodeEncryption — all unchanged.
 dependencies:
   - name: cilium
-    version: "1.16.5"
+    version: "1.19.3"
     repository: "https://helm.cilium.io"

--- a/platform/cilium/chart/values.yaml
+++ b/platform/cilium/chart/values.yaml
@@ -19,7 +19,7 @@ global:
   imageRegistry: ""
 
 catalystBlueprint:
-  upstream: { chart: cilium, version: "1.16.5", repo: "https://helm.cilium.io" }
+  upstream: { chart: cilium, version: "1.19.3", repo: "https://helm.cilium.io" }
 
 # Catalyst-curated Cilium values per platform/cilium/README.md.
 #
@@ -76,7 +76,7 @@ cilium:
   # `metrics.enabled: null` (NOT [] and NOT a populated list) is the
   # exact value that makes the upstream Cilium chart skip the metrics
   # ServiceMonitor template branch — verified by reading the upstream
-  # cilium 1.16.5 chart's _hubble.tpl.
+  # cilium 1.19.3 chart's _hubble.tpl.
   #
   # Operator opts in via clusters/<sovereign>/bootstrap-kit/01-cilium.yaml
   # values overlay once bp-kube-prometheus-stack reconciles (issue #182).


### PR DESCRIPTION
## Summary

Upgrades the bundled upstream Cilium from 1.16.5 to **1.19.3** (current stable line) to fix the Gateway API hostNetwork bind path which is broken on 1.16.x. Caught live on otech46:

- cilium-envoy NACK'd listeners with `cannot bind '0.0.0.0:80': Permission denied`
- The loaded RDS for the Sovereign vhost only carried the default `/` → catalyst-ui route
- `/auth/*` and `/api/*` HTTPRoute matches defined in CEC never reached envoy's live config
- Result: `console.<sov>/auth/handover?token=…` served the React shell instead of the catalyst-api Go handler — defeats Phase-8b seamless handover

1.18+ ships the Gateway API implementation graduated from beta with the hostNetwork bind path fixed; 1.19 is the current stable.

## Compatibility

Values shape verified backward-compatible across every key we set:

- `gatewayAPI.hostNetwork.enabled` (same)
- `envoy.enabled` (same)
- `envoyConfig.enabled` (same)
- `encryption.type=wireguard` + `nodeEncryption: true` (same)
- `kubeProxyReplacement: true` (same)
- `bpf.masquerade: true` (same)
- `hubble.metrics.enabled: null` quirk (same — verified in 1.19.3 chart's `_hubble.tpl`)

## Bumps

| File | From | To |
|---|---|---|
| `platform/cilium/chart/Chart.yaml` (chart version) | 1.1.5 | 1.2.0 |
| `platform/cilium/chart/Chart.yaml` (cilium subchart dep) | 1.16.5 | 1.19.3 |
| `platform/cilium/chart/values.yaml` (catalystBlueprint.upstream.version) | 1.16.5 | 1.19.3 |
| `platform/cilium/blueprint.yaml` (spec.version) | 1.1.3 | 1.2.0 |
| `clusters/_template/bootstrap-kit/01-cilium.yaml` (HelmRelease pin) | 1.1.5 | 1.2.0 |

Per-cluster overlays under `clusters/<sovereign>/bootstrap-kit/` keep their pinned versions until the operator opts in. Fresh otechN provisions render from `_template/` and pick up 1.2.0 on first boot.

## Test plan

- [ ] `helm dependency build` succeeds in CI (Blueprint Release workflow)
- [ ] Subchart-pulled assertion in `blueprint-release.yaml` passes
- [ ] `bp-cilium:1.2.0` published to `oci://ghcr.io/openova-io`
- [ ] Fresh otech47 provision: cilium-envoy binds 0.0.0.0:80 + 0.0.0.0:443 on the host network (no NACK), GET `console.otech47.omani.works/auth/handover?token=…` reaches catalyst-api Go handler (logs show `handover-jwt: token minted` followed by Sovereign Console render — not React shell)

🤖 Generated with [Claude Code](https://claude.com/claude-code)