### PR TITLE
fix(cilium-gateway): listener ports 80/443 → 30080/30443 + LB retarget

### DIFF
--- a/clusters/_template/sovereign-tls/cilium-gateway.yaml
+++ b/clusters/_template/sovereign-tls/cilium-gateway.yaml
@@ -15,9 +15,26 @@ metadata:
     catalyst.openova.io/component: cilium-gateway
 spec:
   gatewayClassName: cilium
+  # NOTE: ports 30080/30443 (not 80/443) — even with hostNetwork=true,
+  # cilium-envoy refuses to bind privileged ports because cilium-agent
+  # gates that bind through its `envoy-keep-cap-netbindservice` flag and
+  # the resulting bind() syscall is intercepted by the agent's BPF
+  # socket-LB program. Setting privileged: true on the cilium-envoy
+  # DaemonSet + adding NET_BIND_SERVICE + flipping the configmap flag
+  # all failed to lift the bind() rejection (verified live on otech45,
+  # otech46, otech47).
+  #
+  # High-port (>1024) bind succeeds without NET_BIND_SERVICE. The
+  # Hetzner LB does the public-facing port translation: HCLB listens on
+  # 80→forwards to CP node:30080; HCLB listens on 443→forwards to CP
+  # node:30443. Browsers hit the canonical URL (`https://console.<fqdn>/`)
+  # so port 30443 is never visible externally.
+  #
+  # See infra/hetzner/main.tf hcloud_load_balancer_service.{http,https}
+  # destination_port settings — they MUST match these listener ports.
   listeners:
     - name: https
-      port: 443
+      port: 30443
       protocol: HTTPS
       hostname: "*.${SOVEREIGN_FQDN}"
       tls:
@@ -29,7 +46,7 @@ spec:
         namespaces:
           from: All
     - name: http
-      port: 80
+      port: 30080
       protocol: HTTP
       hostname: "*.${SOVEREIGN_FQDN}"
       allowedRoutes:

--- a/infra/hetzner/main.tf
+++ b/infra/hetzner/main.tf
@@ -341,21 +341,29 @@ resource "hcloud_load_balancer_service" "http" {
   load_balancer_id = hcloud_load_balancer.main.id
   protocol         = "tcp"
   listen_port      = 80
-  # destination_port=80 — Cilium Gateway runs in hostNetwork mode
-  # (bp-cilium 1.1.5+ values: gatewayAPI.hostNetwork.enabled=true),
-  # binding cilium-envoy directly to the host's :80 instead of a random
-  # nodePort. The previous nodePort=31080 mapping broke because Cilium
-  # 1.16.5's BPF L7LB Proxy Port (e.g. 12869) doesn't actually align
-  # with what cilium-envoy listens on, dropping all TLS handshakes
-  # silently. Caught live on otech45.
-  destination_port = 80
+  # destination_port=30080 — Cilium Gateway listens on a high port
+  # (clusters/_template/sovereign-tls/cilium-gateway.yaml) because even
+  # with hostNetwork=true + privileged=true + NET_BIND_SERVICE +
+  # envoy-keep-cap-netbindservice=true, cilium-envoy still gets
+  # "Permission denied" binding 0.0.0.0:80 on the host. The bind is
+  # intercepted by cilium-agent's BPF socket-LB program in a way that
+  # is not resolvable via container caps. High ports work without
+  # privileged binding (verified on otech47 after iterating through
+  # the privileged-bind chain). Hetzner LB translates the public 80→
+  # node:30080 so the operator-facing URL stays `http://console.<fqdn>/`.
+  destination_port = 30080
 }
 
 resource "hcloud_load_balancer_service" "https" {
   load_balancer_id = hcloud_load_balancer.main.id
   protocol         = "tcp"
   listen_port      = 443
-  destination_port = 443
+  # destination_port=30443 — see http service comment above. The
+  # cilium-gateway HTTPS listener binds 30443 (not 443) because
+  # privileged-port bind through cilium-agent's BPF intercept fails
+  # regardless of capability configuration. HCLB does the listener-side
+  # port translation so external users still hit `https://console.<fqdn>/`.
+  destination_port = 30443
 }
 
 resource "hcloud_load_balancer_service" "dns" {


### PR DESCRIPTION
## Summary

Sovereign cilium-gateway listeners are moved from privileged ports (80/443) to high ports (30080/30443). The Hetzner LB does the public-facing port translation so the operator-facing URL stays canonical.

## Why

cilium-envoy refuses to bind privileged ports on Sovereigns regardless of every capability/security configuration we tried:

- gatewayAPI.hostNetwork.enabled=true ✓
- securityContext.privileged=true ✓
- NET_BIND_SERVICE capability added ✓
- envoy-keep-cap-netbindservice=true in cilium-config ✓
- Gateway API CRDs at v1.3.0 ✓
- cilium 1.19.3 (PR #684) ✓

Error reproducible on otech45, otech46, otech47:
\`\`\`
listener 'kube-system/cilium-gateway-cilium-gateway/listener' failed
to bind or apply socket options: cannot bind '0.0.0.0:80':
Permission denied
\`\`\`

PID 1 with CapEff=0x000001ffffffffff (ALL caps) and uid=0 still gets EACCES — the bind() is intercepted by cilium-agent's BPF socket-LB program in a way that does not honour container capabilities. This is a known Cilium L7LB / hostNetwork interaction.

## Fix

Listener ports → 30080 (HTTP) / 30443 (HTTPS). HCLB:
- listen 80 → dest 30080
- listen 443 → dest 30443

High-port bind succeeds without NET_BIND_SERVICE (kernel only gates ports < \`net.ipv4.ip_unprivileged_port_start\` = 1024).

External users hit \`https://console.<sov>.omani.works/auth/handover\` on standard 443; the high port is never visible.

## Test plan

- [ ] Wipe + provision otech48
- [ ] All 38 HRs Ready=True zero-touch (regression of all prior wins)
- [ ] cilium-envoy listener: \`workers running\`, no \`Permission denied\` in logs
- [ ] HCLB targets healthy on 30080/30443
- [ ] \`curl https://console.otech48.omani.works/\` → 200 with catalyst-ui
- [ ] \`curl https://console.otech48.omani.works/auth/handover?token=...\` → catalyst-api Go handler (not React shell)
- [ ] Browser end-to-end: wizard mints handover JWT, lands operator on Sovereign Console authenticated

🤖 Generated with [Claude Code](https://claude.com/claude-code)