### PR TITLE
fix(hetzner-tofu): add powerdns_api_key to templatefile() vars

### DIFF
--- a/infra/hetzner/main.tf
+++ b/infra/hetzner/main.tf
@@ -239,6 +239,12 @@ locals {
     # authenticates against harbor.openova.io proxy-cache projects.
     harbor_robot_token      = var.harbor_robot_token
 
+    # Contabo PowerDNS API key (PR #686, F3 followup). Interpolated into
+    # the Sovereign's cert-manager/powerdns-api-credentials Secret so
+    # bp-cert-manager-powerdns-webhook can write DNS-01 challenge TXT
+    # records to contabo's authoritative omani.works zone.
+    powerdns_api_key        = var.powerdns_api_key
+
     deployment_id           = var.deployment_id
     kubeconfig_bearer_token = var.kubeconfig_bearer_token
     catalyst_api_url        = var.catalyst_api_url


### PR DESCRIPTION
PR #686 follow-up — wire `var.powerdns_api_key` into the templatefile() vars dict in main.tf. PR #686 added the variable + template reference but missed the templatefile() vars wiring; otech48 plan failed with `vars map does not contain key "powerdns_api_key"`. One-line fix.