### PR TITLE
fix(catalyst-api+sovereign-tls): SOVEREIGN_FQDN via ConfigMap, not Helm template (PR #692 followup)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -58,7 +58,7 @@ spec:
   chart:
     spec:
       chart: bp-catalyst-platform
-      version: 1.2.5
+      version: 1.2.7
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/clusters/_template/sovereign-tls/kustomization.yaml
+++ b/clusters/_template/sovereign-tls/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 resources:
   - cilium-gateway-cert.yaml
   - cilium-gateway.yaml
+  - sovereign-fqdn-configmap.yaml

--- a/clusters/_template/sovereign-tls/sovereign-fqdn-configmap.yaml
+++ b/clusters/_template/sovereign-tls/sovereign-fqdn-configmap.yaml
@@ -1,0 +1,36 @@
+# SOVEREIGN_FQDN ConfigMap — supplies the per-Sovereign FQDN to catalyst-api
+# Pods running on the Sovereign cluster.
+#
+# auth_handover.go reads SOVEREIGN_FQDN env to compute the expected JWT
+# audience claim during /auth/handover validation. Without this ConfigMap,
+# the audience check collapses to "https://console." and every valid handover
+# JWT is rejected — caught live on otech48 (2026-05-03).
+#
+# Why a ConfigMap (not a Helm template value):
+#   products/catalyst/chart/templates/api-deployment.yaml is consumed BOTH by
+#   Helm (per-Sovereign bp-catalyst-platform install) and by Kustomize
+#   (contabo-mkt's catalyst-platform Kustomization at path ./products/
+#   catalyst/chart/templates). Helm template syntax `{{ ... }}` in raw env
+#   `value:` breaks Kustomize parsing — see the Kustomization chain that
+#   landed in commit adf8dc7d failing with "yaml: invalid map key:
+#   {.Values.global.sovereignFQDN | default \"\" | quote}".
+#
+#   This ConfigMap-driven approach uses `valueFrom.configMapKeyRef.optional:
+#   true` in api-deployment.yaml so the same template renders cleanly under
+#   BOTH Kustomize (where the ConfigMap doesn't exist on contabo, env stays
+#   empty — fine, contabo never validates handover JWTs) AND under Helm on
+#   Sovereigns (where this ConfigMap is applied by the sovereign-tls
+#   Kustomization with envsubst rendering ${SOVEREIGN_FQDN}).
+#
+# The sovereign-tls Kustomization already runs envsubst (see PostBuild
+# substituteFrom on the parent flux Kustomization for ${SOVEREIGN_FQDN}).
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: sovereign-fqdn
+  namespace: catalyst-system
+  labels:
+    catalyst.openova.io/sovereign: ${SOVEREIGN_FQDN}
+    catalyst.openova.io/component: sovereign-fqdn-config
+data:
+  fqdn: ${SOVEREIGN_FQDN}

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-catalyst-platform
-version: 1.2.6
+version: 1.2.7
 appVersion: 1.2.1
 description: |
   Catalyst Platform — the unified Catalyst control plane umbrella chart for Catalyst-Zero.

--- a/products/catalyst/chart/templates/api-deployment.yaml
+++ b/products/catalyst/chart/templates/api-deployment.yaml
@@ -408,20 +408,31 @@ spec:
             # SOVEREIGN_FQDN — Sovereign's public FQDN. The /auth/handover
             # validator (auth_handover.go) reads this to compute the expected
             # JWT audience claim ("https://console." + SOVEREIGN_FQDN). When
-            # unset on a Sovereign, the audience check collapses to the literal
-            # "https://console." prefix and every valid token is rejected with
-            # "invalid audience" 401 — caught live on otech48, 2026-05-03.
+            # unset on a Sovereign, the audience check collapses to "https://
+            # console." and every valid token is rejected with "invalid
+            # audience" 401 — caught live on otech48, 2026-05-03.
             #
-            # Default empty string is fine for Catalyst-Zero (contabo-mkt):
-            # catalyst-api there is the SIGNER, never the validator, and the
-            # /auth/handover handler is never hit on contabo. The bp-catalyst-
-            # platform HelmRelease overlay in clusters/_template/bootstrap-kit/
-            # 13-bp-catalyst-platform.yaml stamps `global.sovereignFQDN:
-            # ${SOVEREIGN_FQDN}` onto every per-Sovereign install via Flux's
-            # postBuild substitution; this template line plumbs that value
-            # through to the Pod env.
+            # NOTE: this file is consumed BOTH by Helm (per-Sovereign install
+            # via bp-catalyst-platform OCI chart) AND by Kustomize (contabo-
+            # mkt's clusters/contabo-mkt/apps/catalyst-platform Kustomization
+            # at path: ./products/catalyst/chart/templates). Kustomize parses
+            # raw YAML — Helm template syntax `{{ ... }}` here breaks the
+            # Kustomize build (caught live on contabo 2026-05-03 from
+            # commit adf8dc7d: "yaml: invalid map key: {.Values.global...}").
+            #
+            # Solution: read the value from a ConfigMap that exists ONLY on
+            # Sovereigns (not contabo). On contabo the optional reference
+            # resolves to empty (correct — catalyst-api on contabo is the
+            # SIGNER never the validator, /auth/handover never hits there).
+            # On Sovereigns, clusters/_template/sovereign-tls/sovereign-fqdn-
+            # configmap.yaml renders the ConfigMap from envsubst-ed
+            # ${SOVEREIGN_FQDN} when Flux applies the kustomization.
             - name: SOVEREIGN_FQDN
-              value: {{ .Values.global.sovereignFQDN | default "" | quote }}
+              valueFrom:
+                configMapKeyRef:
+                  name: sovereign-fqdn
+                  key: fqdn
+                  optional: true
             # CATALYST_HANDOVER_KEY_PATH — path to the RS256 PRIVATE key
             # catalyst-api uses to mint magic-link + handover JWTs. The
             # signer auto-generates the keypair on first start if absent.


### PR DESCRIPTION
## Why

PR #692 added inline Helm-template syntax `value: {{ .Values.global.sovereignFQDN | default "" | quote }}` in api-deployment.yaml. This breaks contabo-mkt's `catalyst-platform` Kustomization (path: `./products/catalyst/chart/templates`) because Kustomize parses raw YAML and `{{ ... }}` is not valid YAML.

Live error on contabo at adf8dc7d (caught now blocking all catalyst-api updates from PRs #691/#692/#694/#696/#697 from rolling):

```
kustomize build failed: yaml: invalid map key:
map[string]interface {}{".Values.global.sovereignFQDN | default \"\" | quote":""}
```

## Fix

Replace inline Helm value with `valueFrom.configMapKeyRef.optional: true`. ConfigMap `sovereign-fqdn` is rendered on Sovereigns by the sovereign-tls Kustomization (which already runs envsubst on `${SOVEREIGN_FQDN}`). On contabo the ConfigMap doesn't exist → optional ref → env stays empty → catalyst-api on contabo never validates handover JWTs anyway. Correct.

## DoD

- [ ] contabo `catalyst-platform` Kustomization Ready=True after merge
- [ ] catalyst-api Pod rolls to latest SHA (1946e0a or newer)
- [ ] On otech49 fresh provision: SOVEREIGN_FQDN env var populated from sovereign-fqdn ConfigMap
