### PR TITLE
fix(catalyst-platform): escape literal Helm-curly in api-deployment.yaml comment

### DIFF
--- a/products/catalyst/chart/templates/api-deployment.yaml
+++ b/products/catalyst/chart/templates/api-deployment.yaml
@@ -416,9 +416,9 @@ spec:
             # via bp-catalyst-platform OCI chart) AND by Kustomize (contabo-
             # mkt's clusters/contabo-mkt/apps/catalyst-platform Kustomization
             # at path: ./products/catalyst/chart/templates). Kustomize parses
-            # raw YAML — Helm template syntax `{{ ... }}` here breaks the
-            # Kustomize build (caught live on contabo 2026-05-03 from
-            # commit adf8dc7d: "yaml: invalid map key: {.Values.global...}").
+            # raw YAML — Helm template syntax (double-curly directives) here
+            # breaks the Kustomize build (caught live on contabo 2026-05-03
+            # from commit adf8dc7d: "yaml: invalid map key").
             #
             # Solution: read the value from a ConfigMap that exists ONLY on
             # Sovereigns (not contabo). On contabo the optional reference


### PR DESCRIPTION
PR #698 followup. Helm parsed literal '{{ ... }}' inside a YAML comment as a template directive, failing the Blueprint Release with 'unexpected <.> in operand' at line 419. Reword the comment to avoid the literal curlies.