### PR TITLE
fix(flow-canvas): variable slots + fit-to-host + zigzag (#669 round 5)

### DIFF
--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/FlowCanvasOrganic.bounded.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/FlowCanvasOrganic.bounded.test.tsx
@@ -385,8 +385,12 @@ describe('FlowCanvasOrganic — Bug #481 bounded layout', () => {
     )!
     const vb = svg.getAttribute('viewBox') ?? ''
     const [vbX, vbY, vbW, vbH] = vb.split(/\s+/).map(Number)
-    expect(vbW).toBeLessThanOrEqual(1200)
+    /* Issue #669 round 5 — viewBox width can exceed host width when
+     * the dep chain doesn't fit horizontally even at MIN_NODE_RADIUS;
+     * the parent host scrolls. Assert vbH still bounded (Y always
+     * fits) and vbW positive. */
     expect(vbH).toBeLessThanOrEqual(700)
+    expect(vbW).toBeGreaterThan(0)
     const groups = container.querySelectorAll<SVGGElement>(
       '[data-flow-draggable]',
     )

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/FlowCanvasOrganic.distribution.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/FlowCanvasOrganic.distribution.test.tsx
@@ -1,0 +1,199 @@
+/**
+ * FlowCanvasOrganic — X-axis distribution regression (issue #669 round 3).
+ *
+ * Reproduces the exact shape from the founder's UAT screenshot:
+ *   • 1 bubble at depth 0 ("Provision Hetzner network")
+ *   • 1 bubble at depth 1 ("Provision Hetzner ...")
+ *   • 30 siblings at depth 2 (real provision graph has 30+ blueprint
+ *     installs at the deepest depth)
+ *
+ * Round-2 (constant perDepthX) failed: the dense bucket piled into a
+ * thin sub-grid against the right edge while 60% of the canvas sat
+ * empty on the left. Round-3 introduces variable-width depth slots —
+ * dense buckets claim more X-extent so the cluster spreads laterally.
+ *
+ * Asserts:
+ *   1. depth-0 X < depth-1 X < depth-2 (centerline) — left-to-right.
+ *   2. Dense bucket spans ≥ 30% of total layout width — not piled.
+ *   3. Sparse bubbles (depth 0/1) sit comfortably inside the canvas
+ *      (i.e. X ≥ R, X ≤ totalWidth - R).
+ */
+import { describe, it, expect, afterEach } from 'vitest'
+import { render, cleanup } from '@testing-library/react'
+import { FlowCanvasOrganic } from './FlowCanvasOrganic'
+
+afterEach(() => cleanup())
+
+const FAMILIES = [{ id: 'catalyst', label: 'Catalyst', color: '#fff' }]
+const REGIONS = [{ id: 'primary', label: 'Primary' }]
+
+function makeNode(opts: {
+  id: string
+  depth: number
+  depRank: number
+  parentId?: string
+  dependsOn?: string[]
+}) {
+  return {
+    id: opts.id,
+    depth: opts.depth,
+    depRank: opts.depRank,
+    regionId: 'primary',
+    familyId: 'catalyst',
+    label: opts.id,
+    subLabel: '',
+    status: 'pending' as const,
+    isGroup: false,
+    isFolded: false,
+    childCount: 0,
+    job: {
+      id: opts.id,
+      jobName: opts.id,
+      type: 'install' as const,
+      appId: 'x',
+      parentId: opts.parentId ?? '',
+      dependsOn: opts.dependsOn ?? [],
+      childIds: [],
+      status: 'pending' as const,
+      startedAt: null,
+      finishedAt: null,
+      durationMs: 0,
+    },
+  }
+}
+
+function buildScreenshotLayout() {
+  // Replicates the founder's screenshot:
+  //   d0: 1 (provision-hetzner-network)
+  //   d1: 1 (provision-hetzner-control-plane) depends-on d0
+  //   d2: 30 leaves all depending on d1
+  const root = makeNode({ id: 'd0', depth: 0, depRank: 0 })
+  const phase1 = makeNode({ id: 'd1', depth: 1, depRank: 1, dependsOn: ['d0'] })
+  const leaves = Array.from({ length: 30 }, (_, i) =>
+    makeNode({
+      id: `leaf-${i}`,
+      depth: 2,
+      depRank: 2 + i,
+      dependsOn: ['d1'],
+    }),
+  )
+  const nodes = [root, phase1, ...leaves]
+  const edges = [
+    { fromId: 'd0', toId: 'd1', fromStatus: 'pending' as const, crossRegion: false, kind: 'depends-on' as const },
+    ...leaves.map((n) => ({
+      fromId: 'd1',
+      toId: n.id,
+      fromStatus: 'pending' as const,
+      crossRegion: false,
+      kind: 'depends-on' as const,
+    })),
+  ]
+  return { nodes, edges, families: FAMILIES, regions: REGIONS, maxDepth: 2 }
+}
+
+function readPositions(container: HTMLElement) {
+  const groups = container.querySelectorAll<SVGGElement>('[data-flow-draggable]')
+  const out = new Map<string, { x: number; y: number }>()
+  for (const g of Array.from(groups)) {
+    const id = g.getAttribute('data-job-id') ?? ''
+    const t = g.getAttribute('transform') ?? ''
+    const m = t.match(/translate\(([-\d.]+),\s*([-\d.]+)\)/)
+    if (!m) continue
+    out.set(id, { x: Number(m[1]), y: Number(m[2]) })
+  }
+  return out
+}
+
+describe('FlowCanvasOrganic — X-axis distribution under dense-bucket shape (#669 round 3)', () => {
+  it('does NOT pile the dense bucket against the right edge', async () => {
+    const layout = buildScreenshotLayout()
+    const { container } = render(
+      <FlowCanvasOrganic
+        layout={layout}
+        openJobId={null}
+        hostJobId={null}
+        onJobClick={() => {}}
+        onJobDoubleClick={() => {}}
+        onCanvasBackgroundClick={() => {}}
+      />,
+    )
+    // Let the d3-force sim converge.
+    await new Promise((r) => setTimeout(r, 300))
+
+    const pos = readPositions(container)
+    expect(pos.size).toBe(32)
+
+    // 1. Depth ordering on X — left to right.
+    const x0 = pos.get('d0')!.x
+    const x1 = pos.get('d1')!.x
+    const leafXs = Array.from({ length: 30 }, (_, i) => pos.get(`leaf-${i}`)!.x)
+    expect(x0).toBeLessThan(x1)
+    for (const lx of leafXs) {
+      expect(x1).toBeLessThan(lx) // every leaf is right of the depth-1 anchor
+    }
+
+    // 2. Dense bucket spread — leaf cluster width ≥ 30% of total
+    // layout width. (Total layout width = max X across all bubbles.)
+    const allXs = [x0, x1, ...leafXs]
+    const totalWidth = Math.max(...allXs) - Math.min(...allXs)
+    const leafSpan = Math.max(...leafXs) - Math.min(...leafXs)
+    // Round-2 failure mode: leafSpan ≈ 0.13 × totalWidth (sub-grid
+    // crammed into 80% × perDepthX = ~128 px). Round-3 fix puts the
+    // dense bucket in its own slot whose width tracks sibling count,
+    // so leafSpan should occupy a meaningful fraction of the total.
+    expect(leafSpan / totalWidth).toBeGreaterThanOrEqual(0.3)
+
+    // 3. Sparse bubbles must NOT all share the same X as the leftmost
+    // leaf — i.e., depth 0/1 are visibly separated from the dense
+    // cluster, not crowding the same x-band.
+    const minLeafX = Math.min(...leafXs)
+    expect(x1).toBeLessThan(minLeafX)
+    // The gap between depth-1 anchor and the leftmost leaf is ≥ R
+    // (one bubble radius — visual breathing room).
+    const svg = container.querySelector<SVGSVGElement>('[data-testid="flow-canvas-svg"]')!
+    const someGroup = container.querySelector<SVGGElement>('[data-flow-draggable]')!
+    const lastCircle = someGroup.querySelectorAll('circle')[someGroup.querySelectorAll('circle').length - 1]
+    const r = Number(lastCircle?.getAttribute('r') ?? '40')
+    expect(minLeafX - x1).toBeGreaterThanOrEqual(r)
+
+    // 4. Sanity — every bubble is inside the SVG viewBox.
+    const vb = (svg.getAttribute('viewBox') ?? '').split(/\s+/).map(Number)
+    const [, , vbW, vbH] = vb
+    for (const [, p] of pos) {
+      expect(p.x).toBeGreaterThanOrEqual(0)
+      expect(p.x).toBeLessThanOrEqual(vbW)
+      expect(p.y).toBeGreaterThanOrEqual(0)
+      expect(p.y).toBeLessThanOrEqual(vbH)
+    }
+  })
+
+  it('keeps adjacent leaves at least 2R apart (forceCollide invariant under variable slots)', async () => {
+    const layout = buildScreenshotLayout()
+    const { container } = render(
+      <FlowCanvasOrganic
+        layout={layout}
+        openJobId={null}
+        hostJobId={null}
+        onJobClick={() => {}}
+        onJobDoubleClick={() => {}}
+        onCanvasBackgroundClick={() => {}}
+      />,
+    )
+    await new Promise((r) => setTimeout(r, 300))
+    const pos = readPositions(container)
+    const someGroup = container.querySelector<SVGGElement>('[data-flow-draggable]')!
+    const lastCircle = someGroup.querySelectorAll('circle')[someGroup.querySelectorAll('circle').length - 1]
+    const r = Number(lastCircle?.getAttribute('r') ?? '40')
+    const minDist = 2 * r // bubble rims must not overlap (some collide-pad slack tolerated)
+    const TOL = 4
+    const ids = Array.from(pos.keys())
+    for (let i = 0; i < ids.length; i++) {
+      for (let j = i + 1; j < ids.length; j++) {
+        const a = pos.get(ids[i])!
+        const b = pos.get(ids[j])!
+        const d = Math.hypot(a.x - b.x, a.y - b.y)
+        expect(d).toBeGreaterThanOrEqual(minDist - TOL)
+      }
+    }
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/FlowCanvasOrganic.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/FlowCanvasOrganic.tsx
@@ -339,6 +339,26 @@ export function FlowCanvasOrganic(props: FlowCanvasOrganicProps) {
    * animations don't perturb the metrics — without snapping, every
    * frame of a 220ms padding-right transition recomputes the
    * `Math.floor(rFit)` value and restarts the sim → never settles. */
+  /* Issue #669 round 4 — sqrt-aspect-ratio dense-bucket grids.
+   *
+   * Round-3 grew dense slot width with bucket size, but used the
+   * vertical-fit COL_CAPACITY (~14 rows on a 700px host) which still
+   * forced wide buckets into thin tall columns. Result: 30 leaves in
+   * 3 sub-cols × 10 rows = ~120 px wide slot, only ~28% of total
+   * X-extent.
+   *
+   * Round-4: target a square-ish-but-wider aspect for dense buckets.
+   *   targetRows = round(sqrt(count / 1.6))
+   * gives e.g. 30 → 4 rows, 8 cols → ~700 px slot. Densest bucket's
+   * targetRows then sets R via vertical-fit so all rows of the
+   * tightest column fit in hostSize.h. With R = 40 (max), sparse
+   * depths get 2R = 80 px slots and dense buckets sprawl horizontally
+   * exactly enough to read as a block, not a pile.
+   *
+   * Stabilization (carries from round-3): R snaps to nearest 4, slot
+   * widths snap to nearest 8, ResizeObserver debounces 180ms with
+   * 8px epsilon — sub-pixel flicker during pane-transition animations
+   * doesn't perturb the metrics. */
   const layoutMetrics = useMemo(() => {
     const buckets = new Map<number, number>()
     let maxBucket = 0
@@ -351,49 +371,50 @@ export function FlowCanvasOrganic(props: FlowCanvasOrganicProps) {
     }
     const depthCount = maxDepth + 1
 
-    // Step 1 — adaptive R. Densest bucket must fit vertically.
+    // Target rows for a bucket of given size — slightly wider than tall.
+    const targetRowsFor = (count: number) =>
+      Math.max(1, Math.round(Math.sqrt(Math.max(1, count) / 1.6)))
+
+    // R derived from the densest bucket's *target* rows (NOT the host's
+    // raw vertical capacity), so wide buckets actually claim X-room.
+    const denseRows = targetRowsFor(maxBucket)
     let r = MAX_NODE_RADIUS
     if (maxBucket > 1) {
       const usableH = Math.max(60, hostSize.h - 2 * (MAX_NODE_RADIUS + COLLIDE_PADDING))
-      const pitchAvail = usableH / maxBucket
+      const pitchAvail = usableH / denseRows
       const rFit = (pitchAvail - COLLIDE_PADDING) / 2
       r = Math.min(MAX_NODE_RADIUS, Math.max(MIN_NODE_RADIUS, Math.floor(rFit)))
     }
-    // Snap R to nearest 4 — kills sub-pixel flicker during animations.
     r = Math.max(MIN_NODE_RADIUS, Math.min(MAX_NODE_RADIUS, Math.round(r / 4) * 4))
 
     const ROW_PITCH = r * 2 + COLLIDE_PADDING
     const Y_RANGE = Math.max(r * 2, hostSize.h - 2 * (r + COLLIDE_PADDING))
-    const COL_CAPACITY = Math.max(1, Math.floor(Y_RANGE / ROW_PITCH))
+    const HARD_ROW_CAP = Math.max(1, Math.floor(Y_RANGE / ROW_PITCH))
 
-    // Step 2 — per-depth slot width.
-    //   sparse (count ≤ COL_CAPACITY): width = 2R + minimal padding
-    //   dense  (count >  COL_CAPACITY): width grows with sub-column count
-    const slotWidth = new Map<number, number>()
+    // Per-bucket sub-grid info (cols × rows + slot width).
+    const slotInfo = new Map<number, { cols: number; rows: number; width: number }>()
     for (const [d, count] of buckets) {
-      const totalCols = Math.max(1, Math.ceil(count / COL_CAPACITY))
-      const naturalCols = totalCols > 1
-        ? (totalCols - 1) * (r * 2 + COLLIDE_PADDING) + r * 2
+      // Cap target rows by what fits vertically — defensive when R
+      // got pushed to MIN_NODE_RADIUS by an unusually tight host.
+      const rows = Math.min(targetRowsFor(count), HARD_ROW_CAP)
+      const cols = Math.max(1, Math.ceil(count / rows))
+      const naturalW = cols > 1
+        ? (cols - 1) * (r * 2 + COLLIDE_PADDING) + r * 2
         : r * 2
-      // Snap to nearest 8 px.
-      const w = Math.round(Math.max(naturalCols, r * 2) / 8) * 8
-      slotWidth.set(d, w)
+      const width = Math.round(Math.max(naturalW, r * 2) / 8) * 8
+      slotInfo.set(d, { cols, rows, width })
     }
 
-    // Step 3 — gap between adjacent depth columns. The gap doubles as
-    // edge length when chains run depth-to-depth. Clamp to
-    // [MIN_PER_DEPTH_X, MAX_PER_DEPTH_X].
     const gap = Math.max(MIN_PER_DEPTH_X, Math.min(MAX_PER_DEPTH_X, r * 4))
 
-    // Step 4 — place each depth at its own X. Cumulative cursor.
     const xByDepth = new Map<number, number>()
-    let cursor = r + COLLIDE_PADDING // left margin
+    let cursor = r + COLLIDE_PADDING
     for (let d = 0; d <= maxDepth; d++) {
-      const w = slotWidth.get(d) ?? r * 2
-      xByDepth.set(d, cursor + w / 2) // centerline of slot
+      const w = slotInfo.get(d)?.width ?? r * 2
+      xByDepth.set(d, cursor + w / 2)
       cursor += w + gap
     }
-    const totalWidth = cursor - gap + r + COLLIDE_PADDING // total layout extent
+    const totalWidth = cursor - gap + r + COLLIDE_PADDING
 
     const linkDistance = gap * 0.625
     const gr = r + GROUP_RADIUS_DELTA
@@ -402,17 +423,17 @@ export function FlowCanvasOrganic(props: FlowCanvasOrganicProps) {
       r,
       gr,
       gap,
-      slotWidth,
+      slotInfo,
       xByDepth,
       totalWidth,
       linkDistance,
       maxBucket,
       depthCount,
-      colCapacity: COL_CAPACITY,
+      hardRowCap: HARD_ROW_CAP,
     }
   }, [layout.nodes, hostSize.w, hostSize.h])
 
-  const { r: R, gr: GR, gap: PER_DEPTH_X, linkDistance: LINK_DISTANCE, xByDepth, slotWidth } = layoutMetrics
+  const { r: R, gr: GR, gap: PER_DEPTH_X, linkDistance: LINK_DISTANCE, xByDepth, slotInfo } = layoutMetrics
 
   const depthToX = useCallback(
     (depth: number) => xByDepth.get(depth) ?? (R + COLLIDE_PADDING + depth * (R * 4)),
@@ -529,19 +550,14 @@ export function FlowCanvasOrganic(props: FlowCanvasOrganicProps) {
    */
   const gridTargets = useMemo(() => {
     type GridCell = {
-      tx: number // absolute target X in layout coordinates
-      ty: number // absolute target Y in layout coordinates
+      tx: number
+      ty: number
       totalCols: number
       totalRows: number
     }
     const ROW_PITCH = R * 2 + COLLIDE_PADDING
-    const Y_MARGIN_LOCAL = R + COLLIDE_PADDING
-    const Y_RANGE_LOCAL = Math.max(R * 2, hostSize.h - Y_MARGIN_LOCAL * 2)
+    const Y_RANGE_LOCAL = Math.max(R * 2, hostSize.h - 2 * (R + COLLIDE_PADDING))
     const Y_CENTER_LOCAL = hostSize.h / 2
-    // How many bubbles fit vertically with the no-overlap collision
-    // pitch (NODE_RADIUS*2 + COLLIDE_PADDING = 92px on 700px viewBox →
-    // 7 rows). Beyond that, we MUST add sub-columns or bubbles overlap.
-    const COL_CAPACITY = Math.max(1, Math.floor(Y_RANGE_LOCAL / ROW_PITCH))
     const buckets = new Map<number, OrganicNode[]>()
     for (const n of layout.nodes) {
       let bucket = buckets.get(n.depth)
@@ -553,21 +569,19 @@ export function FlowCanvasOrganic(props: FlowCanvasOrganicProps) {
     }
     const cells = new Map<string, GridCell>()
     for (const [depth, bucket] of buckets) {
-      if (bucket.length <= COL_CAPACITY) continue
-      // Issue #669 round 3 — anchor at the depth's CENTERLINE in the
-      // variable-width-slot layout, and use the bucket's own slot
-      // width for sub-column spread (NOT a fraction of perDepthX).
-      // This is what stops the dense cluster from piling at the
-      // right edge: dense buckets get a slot wide enough to spread,
-      // and the rest of the depth chain shifts further right to make
-      // room.
+      const info = slotInfo.get(depth)
+      // Sparse depths (cols=1, rows=1, slot=2R) skip the grid pre-pass —
+      // the force-anchor + per-bucket Y target handles them naturally.
+      if (!info || (info.cols <= 1 && info.rows <= 1)) continue
+      // Issue #669 round 4 — read sub-grid dims from layoutMetrics
+      // (sqrt-aspect target) instead of recomputing here. Guarantees
+      // gridTargets and slotWidth agree on cols/rows.
       const baseX = xByDepth.get(depth) ?? (R + COLLIDE_PADDING + depth * (R * 4))
-      const totalCols = Math.max(1, Math.ceil(bucket.length / COL_CAPACITY))
-      const totalRows = Math.ceil(bucket.length / totalCols)
-      const slot = slotWidth.get(depth) ?? (R * 2)
-      // Sub-column inner span — full slot minus one bubble at each
-      // edge (so a sub-col centerline stays inside the slot).
-      const SUB_COL_SPAN = Math.max(0, slot - R * 2)
+      const totalCols = info.cols
+      const totalRows = info.rows
+      // Sub-column inner span = slot width minus one bubble at each
+      // edge (centerlines stay inside the slot).
+      const SUB_COL_SPAN = Math.max(0, info.width - R * 2)
       const colStep = totalCols > 1 ? SUB_COL_SPAN / (totalCols - 1) : 0
       // Issue #532 founder verbatim: "homogenously spread". Distribute
       // rows evenly across the full Y range (not packed at the top).
@@ -595,7 +609,7 @@ export function FlowCanvasOrganic(props: FlowCanvasOrganicProps) {
       })
     }
     return cells
-  }, [layout.nodes, hostSize.h, xByDepth, slotWidth, R])
+  }, [layout.nodes, hostSize.h, xByDepth, slotInfo, R])
 
   const simNodes = useMemo<SimNode[]>(() => {
     const next: SimNode[] = []
@@ -741,27 +755,30 @@ export function FlowCanvasOrganic(props: FlowCanvasOrganicProps) {
           if (typeof n.fx === 'number' && typeof n.fy === 'number') continue
           const cell = gridTargets.get(n.id)
           if (cell) {
-            // Issue #532 — sub-grid clamping. Each sibling has an
-            // absolute (tx, ty) target inside the depth column's
-            // sub-grid. The clamp window is half the sub-column span
-            // wide and half the row step tall so adjacent siblings
-            // can settle without invading each other's slots, but
-            // the slot itself is large enough that forceCollide can
-            // resolve any tiny overlaps inside the slot without
-            // pushing the node outside.
-            const SUB_COL_SPAN = PER_DEPTH_X * 0.8
-            const colSlot = cell.totalCols > 1
-              ? SUB_COL_SPAN / (cell.totalCols - 1)
-              : PER_DEPTH_X
-            const Y_MARGIN_LOCAL = R + COLLIDE_PADDING
-            const Y_RANGE_LOCAL = Math.max(R * 2, hostSize.h - Y_MARGIN_LOCAL * 2)
-            const rowSlot = cell.totalRows > 1
-              ? Y_RANGE_LOCAL / (cell.totalRows - 1)
-              : Y_RANGE_LOCAL
-            const xMin = cell.tx - colSlot * 0.5
-            const xMax = cell.tx + colSlot * 0.5
-            const yMin = cell.ty - rowSlot * 0.5
-            const yMax = cell.ty + rowSlot * 0.5
+            // Issue #669 round 4 — narrow per-cell clamp.
+            //
+            // Each grid cell's clamp window is half the cell pitch in
+            // each axis, MINUS R, so the bubble's edge can never reach
+            // its neighbour's centre. Old code used colSlot = full
+            // pitch which let two adjacent cells' clamp windows
+            // overlap → forceCollide pushed bubbles into neighbour
+            // territory, the clamp ratcheted them in, and centres
+            // could collapse to <2R apart. The narrow window keeps
+            // forceCollide's pairwise floor intact at runtime. */
+            const xPitch = cell.totalCols > 1
+              ? layoutMetrics.slotInfo.get(n.depth)?.width
+                  ? Math.max(1, ((layoutMetrics.slotInfo.get(n.depth)!.width - R * 2) / (cell.totalCols - 1)))
+                  : R * 2 + COLLIDE_PADDING
+              : layoutMetrics.gap
+            const yPitch = cell.totalRows > 1
+              ? Math.max(R * 2 + COLLIDE_PADDING, (hostSize.h - 2 * (R + COLLIDE_PADDING)) / (cell.totalRows - 1))
+              : hostSize.h - 2 * (R + COLLIDE_PADDING)
+            const xHalf = Math.max(R, xPitch * 0.5 - R)
+            const yHalf = Math.max(R, yPitch * 0.5 - R)
+            const xMin = cell.tx - xHalf
+            const xMax = cell.tx + xHalf
+            const yMin = cell.ty - yHalf
+            const yMax = cell.ty + yHalf
             if (typeof n.x === 'number') {
               if (n.x < xMin) n.x = xMin
               else if (n.x > xMax) n.x = xMax

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/FlowCanvasOrganic.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/FlowCanvasOrganic.tsx
@@ -235,30 +235,51 @@ export function FlowCanvasOrganic(props: FlowCanvasOrganicProps) {
   useEffect(() => {
     const el = hostRef.current
     if (!el) return
-    // ResizeObserver may fire synchronously during layout — use rAF to
-    // batch state updates so we never trigger a re-render mid-tick.
-    let raf = 0
+    /* Issue #669 round 3 — debounced + epsilon-gated ResizeObserver.
+     *
+     * Background: closing/opening the LogPane animates `padding-right`
+     * over 220ms (cubic-bezier). During that animation the canvas
+     * host width changes by ~1-2 px every animation frame; round-2
+     * fired setHostSize on every rAF, which restarted the d3-force
+     * sim every frame — the operator saw the bubbles "trying never
+     * stabilizing".
+     *
+     * Fix: wait for the host size to be stable for 180ms before
+     * pushing it to React state, AND ignore changes smaller than 8 px
+     * in either dimension (the layoutMetrics snap-to-4 + slot
+     * snap-to-8 combination tolerates ±4 px without re-emitting any
+     * different metric, but explicit gating keeps the sim restart
+     * effect downstream from running unnecessarily). */
+    let timer: ReturnType<typeof setTimeout> | null = null
+    let pending: { w: number; h: number } | null = null
+    const RESIZE_DEBOUNCE_MS = 180
+    const RESIZE_EPSILON_PX = 8
     const ro = new ResizeObserver((entries) => {
       const e = entries[0]
       if (!e) return
       const rect = e.contentRect
-      // Use the actual measured rect — not a floor. The MIN_HOST_*
-      // constants only apply when the rect is degenerate (0×0 during
-      // first paint). Forcing the viewBox to MIN_HOST_W when the
-      // host is narrower (e.g. LogPane reserves 30vw) causes the
-      // SVG to render 1200 viewBox-units into 686 CSS px (0.57×
-      // downscale), shrinking bubbles AND collapsing pairwise
-      // distances below the no-overlap threshold.
       const w = Math.round(rect.width) || MIN_HOST_W
       const h = Math.round(rect.height) || MIN_HOST_H
-      cancelAnimationFrame(raf)
-      raf = requestAnimationFrame(() => {
-        setHostSize((prev) => (prev.w === w && prev.h === h ? prev : { w, h }))
-      })
+      pending = { w, h }
+      if (timer) clearTimeout(timer)
+      timer = setTimeout(() => {
+        if (!pending) return
+        const next = pending
+        pending = null
+        setHostSize((prev) => {
+          if (
+            Math.abs(prev.w - next.w) < RESIZE_EPSILON_PX &&
+            Math.abs(prev.h - next.h) < RESIZE_EPSILON_PX
+          ) {
+            return prev // ignore — sub-threshold flicker
+          }
+          return next
+        })
+      }, RESIZE_DEBOUNCE_MS)
     })
     ro.observe(el)
     return () => {
-      cancelAnimationFrame(raf)
+      if (timer) clearTimeout(timer)
       ro.disconnect()
     }
   }, [])
@@ -291,10 +312,37 @@ export function FlowCanvasOrganic(props: FlowCanvasOrganicProps) {
    * together with the sim-restart effect below that re-seeds free
    * nodes to their fresh targets — gives bubbles a visible re-flow
    * pass on every host change. */
+  /* Issue #669 round 3 — variable-width depth columns.
+   *
+   * Founder-verbatim 2026-05-03 (round-2 UAT): "while 2/3 of the
+   * screen is empty, it is trying to pile up everything in the right
+   * edge. And it keep trying never stabilizing. Despite y axis
+   * homogeneous distribution looks fine, x axis distribution is
+   * terrible".
+   *
+   * Root cause: round-2 used a CONSTANT `perDepthX` for every depth
+   * column. With one-bubble depths next to a 30+ sibling depth, the
+   * dense bucket got 80% × perDepthX (~128px) of horizontal room and
+   * had to pile into 8+ sub-columns; the sparse depths each got their
+   * own perDepthX (~160px) for one bubble. End result: 60% of canvas
+   * unused on the left, dense cluster jammed at right.
+   *
+   * Round-3 fix: each depth bucket gets a horizontal slot whose width
+   * equals the bucket's *natural* extent at radius R. Sparse buckets
+   * (1 sibling) need 2R + small gap; dense buckets need
+   * `(totalCols - 1) * (2R + COLLIDE_PADDING)` to fit their
+   * sub-columns side-by-side. Total layout width = sum(slots) + gaps
+   * between slots. depthToX returns the centerline of slot[depth].
+   *
+   * Stabilization: round R to nearest 4 and slot widths to nearest 8
+   * so sub-pixel ResizeObserver fires during pane-transition
+   * animations don't perturb the metrics — without snapping, every
+   * frame of a 220ms padding-right transition recomputes the
+   * `Math.floor(rFit)` value and restarts the sim → never settles. */
   const layoutMetrics = useMemo(() => {
+    const buckets = new Map<number, number>()
     let maxBucket = 0
     let maxDepth = 0
-    const buckets = new Map<number, number>()
     for (const n of layout.nodes) {
       const c = (buckets.get(n.depth) ?? 0) + 1
       buckets.set(n.depth, c)
@@ -302,6 +350,8 @@ export function FlowCanvasOrganic(props: FlowCanvasOrganicProps) {
       if (n.depth > maxDepth) maxDepth = n.depth
     }
     const depthCount = maxDepth + 1
+
+    // Step 1 — adaptive R. Densest bucket must fit vertically.
     let r = MAX_NODE_RADIUS
     if (maxBucket > 1) {
       const usableH = Math.max(60, hostSize.h - 2 * (MAX_NODE_RADIUS + COLLIDE_PADDING))
@@ -309,23 +359,64 @@ export function FlowCanvasOrganic(props: FlowCanvasOrganicProps) {
       const rFit = (pitchAvail - COLLIDE_PADDING) / 2
       r = Math.min(MAX_NODE_RADIUS, Math.max(MIN_NODE_RADIUS, Math.floor(rFit)))
     }
-    let perDepthX = Math.max(MIN_PER_DEPTH_X, Math.min(MAX_PER_DEPTH_X, r * 4))
-    if (depthCount > 1) {
-      const usableW = Math.max(120, hostSize.w - 2 * (r + COLLIDE_PADDING))
-      const fitW = usableW / Math.max(1, depthCount - 1)
-      perDepthX = Math.min(perDepthX, Math.max(MIN_PER_DEPTH_X, fitW))
+    // Snap R to nearest 4 — kills sub-pixel flicker during animations.
+    r = Math.max(MIN_NODE_RADIUS, Math.min(MAX_NODE_RADIUS, Math.round(r / 4) * 4))
+
+    const ROW_PITCH = r * 2 + COLLIDE_PADDING
+    const Y_RANGE = Math.max(r * 2, hostSize.h - 2 * (r + COLLIDE_PADDING))
+    const COL_CAPACITY = Math.max(1, Math.floor(Y_RANGE / ROW_PITCH))
+
+    // Step 2 — per-depth slot width.
+    //   sparse (count ≤ COL_CAPACITY): width = 2R + minimal padding
+    //   dense  (count >  COL_CAPACITY): width grows with sub-column count
+    const slotWidth = new Map<number, number>()
+    for (const [d, count] of buckets) {
+      const totalCols = Math.max(1, Math.ceil(count / COL_CAPACITY))
+      const naturalCols = totalCols > 1
+        ? (totalCols - 1) * (r * 2 + COLLIDE_PADDING) + r * 2
+        : r * 2
+      // Snap to nearest 8 px.
+      const w = Math.round(Math.max(naturalCols, r * 2) / 8) * 8
+      slotWidth.set(d, w)
     }
-    const linkDistance = perDepthX * 0.625
+
+    // Step 3 — gap between adjacent depth columns. The gap doubles as
+    // edge length when chains run depth-to-depth. Clamp to
+    // [MIN_PER_DEPTH_X, MAX_PER_DEPTH_X].
+    const gap = Math.max(MIN_PER_DEPTH_X, Math.min(MAX_PER_DEPTH_X, r * 4))
+
+    // Step 4 — place each depth at its own X. Cumulative cursor.
+    const xByDepth = new Map<number, number>()
+    let cursor = r + COLLIDE_PADDING // left margin
+    for (let d = 0; d <= maxDepth; d++) {
+      const w = slotWidth.get(d) ?? r * 2
+      xByDepth.set(d, cursor + w / 2) // centerline of slot
+      cursor += w + gap
+    }
+    const totalWidth = cursor - gap + r + COLLIDE_PADDING // total layout extent
+
+    const linkDistance = gap * 0.625
     const gr = r + GROUP_RADIUS_DELTA
-    const xLeftMargin = r + perDepthX / 2
-    return { r, gr, perDepthX, linkDistance, xLeftMargin, maxBucket, depthCount }
+
+    return {
+      r,
+      gr,
+      gap,
+      slotWidth,
+      xByDepth,
+      totalWidth,
+      linkDistance,
+      maxBucket,
+      depthCount,
+      colCapacity: COL_CAPACITY,
+    }
   }, [layout.nodes, hostSize.w, hostSize.h])
 
-  const { r: R, gr: GR, perDepthX: PER_DEPTH_X, linkDistance: LINK_DISTANCE, xLeftMargin: X_LEFT_MARGIN } = layoutMetrics
+  const { r: R, gr: GR, gap: PER_DEPTH_X, linkDistance: LINK_DISTANCE, xByDepth, slotWidth } = layoutMetrics
 
   const depthToX = useCallback(
-    (depth: number) => X_LEFT_MARGIN + depth * PER_DEPTH_X,
-    [X_LEFT_MARGIN, PER_DEPTH_X],
+    (depth: number) => xByDepth.get(depth) ?? (R + COLLIDE_PADDING + depth * (R * 4)),
+    [xByDepth, R],
   )
 
   /* Issue #532 — resolve a per-node depRank.
@@ -462,27 +553,21 @@ export function FlowCanvasOrganic(props: FlowCanvasOrganicProps) {
     }
     const cells = new Map<string, GridCell>()
     for (const [depth, bucket] of buckets) {
-      // Only apply grid layout when sibling count exceeds the single-
-      // column vertical capacity. Sparse depths keep the original
-      // force-anchor behaviour (depthX + depRank-based Y).
       if (bucket.length <= COL_CAPACITY) continue
-      // Issue #669 — anchor at depthToX (NODE_RADIUS + PER_DEPTH_X/2 +
-      // depth * PER_DEPTH_X) so sub-columns centred on baseX never
-      // extend into negative X (which would render off-canvas under
-      // the new viewBox = host-px convention).
-      const baseX = X_LEFT_MARGIN + depth * PER_DEPTH_X
-      // Issue #532: with N siblings in a depth bucket and Y-range
-      // budget that fits COL_CAPACITY rows at the no-overlap pitch,
-      // we need ceil(N / COL_CAPACITY) sub-columns. Each sub-column
-      // contains COL_CAPACITY rows distributed homogeneously across
-      // the full Y range. This guarantees no overlap by construction
-      // (forceCollide is then a safety net for boundary effects).
+      // Issue #669 round 3 — anchor at the depth's CENTERLINE in the
+      // variable-width-slot layout, and use the bucket's own slot
+      // width for sub-column spread (NOT a fraction of perDepthX).
+      // This is what stops the dense cluster from piling at the
+      // right edge: dense buckets get a slot wide enough to spread,
+      // and the rest of the depth chain shifts further right to make
+      // room.
+      const baseX = xByDepth.get(depth) ?? (R + COLLIDE_PADDING + depth * (R * 4))
       const totalCols = Math.max(1, Math.ceil(bucket.length / COL_CAPACITY))
       const totalRows = Math.ceil(bucket.length / totalCols)
-      // Sub-column span — each sub-column gets a slice of the depth
-      // column's natural width. Cap at PER_DEPTH_X so adjacent depth
-      // columns never visually merge.
-      const SUB_COL_SPAN = PER_DEPTH_X * 0.8
+      const slot = slotWidth.get(depth) ?? (R * 2)
+      // Sub-column inner span — full slot minus one bubble at each
+      // edge (so a sub-col centerline stays inside the slot).
+      const SUB_COL_SPAN = Math.max(0, slot - R * 2)
       const colStep = totalCols > 1 ? SUB_COL_SPAN / (totalCols - 1) : 0
       // Issue #532 founder verbatim: "homogenously spread". Distribute
       // rows evenly across the full Y range (not packed at the top).
@@ -510,7 +595,7 @@ export function FlowCanvasOrganic(props: FlowCanvasOrganicProps) {
       })
     }
     return cells
-  }, [layout.nodes, hostSize.h, X_LEFT_MARGIN, R, PER_DEPTH_X])
+  }, [layout.nodes, hostSize.h, xByDepth, slotWidth, R])
 
   const simNodes = useMemo<SimNode[]>(() => {
     const next: SimNode[] = []

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/FlowCanvasOrganic.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/FlowCanvasOrganic.tsx
@@ -169,8 +169,8 @@ const MAX_PER_DEPTH_X = 200
 /** Force strengths re-tuned post-#483. Gentle X-anchor lets the link
  *  force pull connected nodes together without the X-force fighting
  *  back and producing the oscillation that read as "infinite stretch". */
-const FORCE_X_STRENGTH = 0.12
-const FORCE_Y_STRENGTH = 0.10
+const FORCE_X_STRENGTH = 0.18
+const FORCE_Y_STRENGTH = 0.22
 const FORCE_LINK_STRENGTH = 0.18
 
 /** Selection palette — distinct from any status colour AND distinct
@@ -252,8 +252,8 @@ export function FlowCanvasOrganic(props: FlowCanvasOrganicProps) {
      * effect downstream from running unnecessarily). */
     let timer: ReturnType<typeof setTimeout> | null = null
     let pending: { w: number; h: number } | null = null
-    const RESIZE_DEBOUNCE_MS = 180
-    const RESIZE_EPSILON_PX = 8
+    const RESIZE_DEBOUNCE_MS = 60
+    const RESIZE_EPSILON_PX = 4
     const ro = new ResizeObserver((entries) => {
       const e = entries[0]
       if (!e) return
@@ -387,34 +387,155 @@ export function FlowCanvasOrganic(props: FlowCanvasOrganicProps) {
     }
     r = Math.max(MIN_NODE_RADIUS, Math.min(MAX_NODE_RADIUS, Math.round(r / 4) * 4))
 
-    const ROW_PITCH = r * 2 + COLLIDE_PADDING
-    const Y_RANGE = Math.max(r * 2, hostSize.h - 2 * (r + COLLIDE_PADDING))
-    const HARD_ROW_CAP = Math.max(1, Math.floor(Y_RANGE / ROW_PITCH))
-
-    // Per-bucket sub-grid info (cols × rows + slot width).
-    const slotInfo = new Map<number, { cols: number; rows: number; width: number }>()
-    for (const [d, count] of buckets) {
-      // Cap target rows by what fits vertically — defensive when R
-      // got pushed to MIN_NODE_RADIUS by an unusually tight host.
-      const rows = Math.min(targetRowsFor(count), HARD_ROW_CAP)
-      const cols = Math.max(1, Math.ceil(count / rows))
-      const naturalW = cols > 1
-        ? (cols - 1) * (r * 2 + COLLIDE_PADDING) + r * 2
-        : r * 2
-      const width = Math.round(Math.max(naturalW, r * 2) / 8) * 8
-      slotInfo.set(d, { cols, rows, width })
+    /* computeAt(radius, rowMultiplier) — recomputes slot widths at the
+     * given radius. rowMultiplier > 1 forces dense buckets to use MORE
+     * rows (and fewer columns) per bucket, compressing the slot
+     * horizontally at the cost of more vertical space. Used when the
+     * chain still overflows the host width even at R = MIN_NODE_RADIUS:
+     * we trade horizontal sprawl for vertical until totalWidth fits. */
+    const computeAt = (radius: number, rowMultiplier = 1) => {
+      const ROW_PITCH = radius * 2 + COLLIDE_PADDING
+      const Y_RANGE = Math.max(radius * 2, hostSize.h - 2 * (radius + COLLIDE_PADDING))
+      const hardRowCap = Math.max(1, Math.floor(Y_RANGE / ROW_PITCH))
+      const slotInfo = new Map<number, { cols: number; rows: number; width: number }>()
+      for (const [d, count] of buckets) {
+        const baseRows = targetRowsFor(count)
+        const rows = Math.min(Math.max(1, Math.ceil(baseRows * rowMultiplier)), hardRowCap, count)
+        const cols = Math.max(1, Math.ceil(count / rows))
+        const naturalW = cols > 1
+          ? (cols - 1) * (radius * 2 + COLLIDE_PADDING) + radius * 2
+          : radius * 2
+        const width = Math.round(Math.max(naturalW, radius * 2) / 8) * 8
+        slotInfo.set(d, { cols, rows, width })
+      }
+      const gap = Math.max(MIN_PER_DEPTH_X, Math.min(MAX_PER_DEPTH_X, radius * 4))
+      const xByDepth = new Map<number, number>()
+      let cursor = radius + COLLIDE_PADDING
+      for (let d = 0; d <= maxDepth; d++) {
+        const w = slotInfo.get(d)?.width ?? radius * 2
+        xByDepth.set(d, cursor + w / 2)
+        cursor += w + gap
+      }
+      const totalWidth = cursor - gap + radius + COLLIDE_PADDING
+      return { slotInfo, gap, xByDepth, totalWidth, hardRowCap }
     }
 
-    const gap = Math.max(MIN_PER_DEPTH_X, Math.min(MAX_PER_DEPTH_X, r * 4))
-
-    const xByDepth = new Map<number, number>()
-    let cursor = r + COLLIDE_PADDING
-    for (let d = 0; d <= maxDepth; d++) {
-      const w = slotInfo.get(d)?.width ?? r * 2
-      xByDepth.set(d, cursor + w / 2)
-      cursor += w + gap
+    /* Issue #669 round 5 — aggressive fit-to-host horizontally.
+     *
+     * Founder UAT: "the graph is not fitting into the full page,
+     * getting out of the full screen with huge extended x axis".
+     *
+     * Two-stage fit:
+     *   Stage 1 — shrink the inter-depth gap proportionally toward
+     *             a tight floor (R*2.2) before touching R. Wide
+     *             gaps are the first thing to give up.
+     *   Stage 2 — if even a tight gap doesn't fit, shrink R by 4
+     *             and recompute everything. R has its own MIN floor;
+     *             past that we accept horizontal scroll.
+     */
+    let attempt = computeAt(r)
+    // Stage 1: tighten gap if it would let us fit.
+    if (attempt.totalWidth > hostSize.w && depthCount > 1) {
+      const slotsTotal = Array.from(attempt.slotInfo.values()).reduce((acc, s) => acc + s.width, 0)
+      const margin = 2 * (r + COLLIDE_PADDING)
+      const fitGap = (hostSize.w - slotsTotal - margin) / (depthCount - 1)
+      // Floor on inter-depth gap = just enough to prevent adjacent
+      // depth bubbles from visually touching (R*2.2 → 9.6px clear gap
+      // at R=16). MIN_PER_DEPTH_X is the *aesthetic* preference for
+      // sparse layouts; when the chain doesn't fit, function over form.
+      const minGap = r * 2.2
+      if (fitGap >= minGap) {
+        // Recompute xByDepth + totalWidth with the tighter gap.
+        const newGap = Math.floor(fitGap)
+        const newX = new Map<number, number>()
+        let cursor = r + COLLIDE_PADDING
+        for (let d = 0; d <= maxDepth; d++) {
+          const w = attempt.slotInfo.get(d)?.width ?? r * 2
+          newX.set(d, cursor + w / 2)
+          cursor += w + newGap
+        }
+        attempt = {
+          ...attempt,
+          gap: newGap,
+          xByDepth: newX,
+          totalWidth: cursor - newGap + r + COLLIDE_PADDING,
+        }
+      }
     }
-    const totalWidth = cursor - gap + r + COLLIDE_PADDING
+    // Stage 2: shrink R if still overflows.
+    while (attempt.totalWidth > hostSize.w && r > MIN_NODE_RADIUS) {
+      r = Math.max(MIN_NODE_RADIUS, r - 4)
+      attempt = computeAt(r)
+      if (attempt.totalWidth > hostSize.w && depthCount > 1) {
+        const slotsTotal = Array.from(attempt.slotInfo.values()).reduce((acc, s) => acc + s.width, 0)
+        const margin = 2 * (r + COLLIDE_PADDING)
+        const fitGap = (hostSize.w - slotsTotal - margin) / (depthCount - 1)
+        // Floor on inter-depth gap = just enough to prevent adjacent
+      // depth bubbles from visually touching (R*2.2 → 9.6px clear gap
+      // at R=16). MIN_PER_DEPTH_X is the *aesthetic* preference for
+      // sparse layouts; when the chain doesn't fit, function over form.
+      const minGap = r * 2.2
+        if (fitGap >= minGap) {
+          const newGap = Math.floor(fitGap)
+          const newX = new Map<number, number>()
+          let cursor = r + COLLIDE_PADDING
+          for (let d = 0; d <= maxDepth; d++) {
+            const w = attempt.slotInfo.get(d)?.width ?? r * 2
+            newX.set(d, cursor + w / 2)
+            cursor += w + newGap
+          }
+          attempt = {
+            ...attempt,
+            gap: newGap,
+            xByDepth: newX,
+            totalWidth: cursor - newGap + r + COLLIDE_PADDING,
+          }
+        }
+      }
+    }
+    /* Stage 3 — at MIN_R with min gap and STILL overflowing? Trade
+     * horizontal extent for vertical: increase the row-multiplier on
+     * dense buckets so they pile MORE vertically and less
+     * horizontally. Each step multiplies targetRows by 1.4 (so a
+     * bucket that wanted 3 rows × 4 cols becomes 5 rows × 3 cols,
+     * shrinking slot from 356 → 264 px). Stops when fits or
+     * rowMultiplier exceeds the bucket's hard row cap. */
+    let rowMul = 1
+    while (attempt.totalWidth > hostSize.w && rowMul < 4) {
+      rowMul *= 1.4
+      const next = computeAt(r, rowMul)
+      // Re-apply gap tightening at the new radius/rowMul.
+      let stage1 = next
+      if (next.totalWidth > hostSize.w && depthCount > 1) {
+        const slotsTotal = Array.from(next.slotInfo.values()).reduce((acc, s) => acc + s.width, 0)
+        const margin = 2 * (r + COLLIDE_PADDING)
+        const fitGap = (hostSize.w - slotsTotal - margin) / (depthCount - 1)
+        const minGap = r * 2.2
+        if (fitGap >= minGap) {
+          const newGap = Math.floor(fitGap)
+          const newX = new Map<number, number>()
+          let cursor = r + COLLIDE_PADDING
+          for (let d = 0; d <= maxDepth; d++) {
+            const w = next.slotInfo.get(d)?.width ?? r * 2
+            newX.set(d, cursor + w / 2)
+            cursor += w + newGap
+          }
+          stage1 = {
+            ...next,
+            gap: newGap,
+            xByDepth: newX,
+            totalWidth: cursor - newGap + r + COLLIDE_PADDING,
+          }
+        }
+      }
+      // Only adopt if it actually improves fit (or fits exactly).
+      if (stage1.totalWidth <= attempt.totalWidth) {
+        attempt = stage1
+      } else {
+        break
+      }
+    }
+    const { slotInfo, gap, xByDepth, totalWidth, hardRowCap } = attempt
 
     const linkDistance = gap * 0.625
     const gr = r + GROUP_RADIUS_DELTA
@@ -429,7 +550,7 @@ export function FlowCanvasOrganic(props: FlowCanvasOrganicProps) {
       linkDistance,
       maxBucket,
       depthCount,
-      hardRowCap: HARD_ROW_CAP,
+      hardRowCap,
     }
   }, [layout.nodes, hostSize.w, hostSize.h])
 
@@ -512,14 +633,44 @@ export function FlowCanvasOrganic(props: FlowCanvasOrganicProps) {
 
   /* Per-bucket centred Y target — sibling at index `i` of `n` lands
    * at h/2 + (i - (n-1)/2) * pitch. Median sibling on the X-axis
-   * centerline; rest spread symmetrically above and below. */
+   * centerline; rest spread symmetrically above and below.
+   *
+   * Issue #669 round 5 — for SINGLETON depth buckets (size === 1) we
+   * zigzag Y by depth parity so a long sequential chain (e.g. Phase 0
+   * → cluster-bootstrap → cilium → cert-manager) reads as a gentle
+   * wave that uses the vertical canvas instead of a flat horizontal
+   * line. The amplitude (R*1.5) keeps adjacent depths visually
+   * connected while filling more of the host height. */
+  const depthByNodeId = useMemo(() => {
+    const m = new Map<string, number>()
+    for (const n of layout.nodes) m.set(n.id, n.depth)
+    return m
+  }, [layout.nodes])
+  /* Zigzag amplitude — sized to USE the host height, not R. With a
+   * 900-px host, amplitude is ~270 px → singletons sit at
+   * y = h/2 ± 270, filling the upper and lower fifths of the host.
+   * Bounded at host_h × 0.32 (so the bubble's full diameter never
+   * crosses the edge) and at host_h/2 - R - COLLIDE_PADDING (hard
+   * floor to keep bubble inside viewBox). */
+  /* Modest amplitude — just enough to lift singletons off the
+   * centerline so the chain reads as a gentle wave instead of a flat
+   * timeline, but short enough that adjacent depths stay visually
+   * connected without dragging the eye across the canvas. Founder
+   * UAT 2026-05-03: "even if it is kept short, it would give similar
+   * result and look nicer". */
+  const ZIGZAG_AMPLITUDE = Math.min(R * 3, hostSize.h * 0.12)
   const yForBucket = useCallback(
     (id: string) => {
       const b = bucketRank.get(id)
       if (!b) return Y_CENTER
+      if (b.size === 1) {
+        const d = depthByNodeId.get(id) ?? 0
+        const sign = d % 2 === 0 ? -1 : 1
+        return Y_CENTER + sign * ZIGZAG_AMPLITUDE
+      }
       return Y_CENTER + (b.idx - (b.size - 1) / 2) * PITCH
     },
-    [bucketRank, Y_CENTER, PITCH],
+    [bucketRank, Y_CENTER, PITCH, ZIGZAG_AMPLITUDE, depthByNodeId],
   )
 
   const familyById = useMemo(() => {
@@ -803,7 +954,7 @@ export function FlowCanvasOrganic(props: FlowCanvasOrganicProps) {
            * pairwise spacing. Keep the sim inside the visible window
            * end-to-end. */
           const xMin = Math.max(R, baseX - PER_DEPTH_X)
-          const xMax = Math.min(hostSize.w - R, baseX + PER_DEPTH_X)
+          const xMax = Math.min(layoutMetrics.totalWidth - R, baseX + PER_DEPTH_X)
           if (typeof n.x === 'number') {
             if (n.x < xMin) n.x = xMin
             else if (n.x > xMax) n.x = xMax
@@ -935,19 +1086,16 @@ export function FlowCanvasOrganic(props: FlowCanvasOrganicProps) {
    * within the visible area. We do NOT compress positions; we let the
    * sim clamp positions, which preserves the no-overlap guarantee.
    */
+  /* Issue #669 round 4 — viewBox tracks the LARGER of host width or
+   * total layout extent. When the dep chain doesn't fit horizontally
+   * even after R shrinks to MIN_NODE_RADIUS, the SVG renders at full
+   * layout width and the parent host scrolls horizontally instead of
+   * piling bubbles at the right edge. Y still tracks host height. */
   const vbX = 0
   const vbY = 0
-  const vbW = hostSize.w
+  const vbW = Math.max(hostSize.w, layoutMetrics.totalWidth)
   const vbH = hostSize.h
 
-  /* Hard-clamp positions to viewBox. The per-tick clamp inside the sim
-   * also clamps, but ResizeObserver may shrink hostSize between sim
-   * ticks (drag of the LogPane); applying the clamp here ensures
-   * rendering never paints a bubble outside the visible area, even
-   * one frame. forceCollide already guarantees pairwise spacing of
-   * ≥ NODE_RADIUS*2 + COLLIDE_PADDING (= 92 px), and clamping to a
-   * single edge cannot reduce two clamped nodes' distance below that
-   * threshold (the collide pass owns it pre-render). */
   const CLAMP_INSET = R + 8
   const project = (p: { x: number; y: number }) => {
     const x = Math.min(vbW - CLAMP_INSET, Math.max(CLAMP_INSET, p.x))
@@ -969,12 +1117,13 @@ export function FlowCanvasOrganic(props: FlowCanvasOrganicProps) {
         height: '100%',
         minHeight: 0,
         minWidth: 0,
-        overflow: 'hidden',
+        overflowX: layoutMetrics.totalWidth > hostSize.w ? 'auto' : 'hidden',
+        overflowY: 'hidden',
       }}
     >
     <svg
       ref={svgRef}
-      width="100%"
+      width={vbW}
       height="100%"
       viewBox={`${vbX} ${vbY} ${vbW} ${vbH}`}
       preserveAspectRatio="xMinYMin meet"
@@ -982,7 +1131,7 @@ export function FlowCanvasOrganic(props: FlowCanvasOrganicProps) {
       data-testid="flow-canvas-svg"
       role="img"
       aria-label="Provisioning dependency flow"
-      style={{ display: 'block', width: '100%', height: '100%' }}
+      style={{ display: 'block', minWidth: '100%', height: '100%' }}
       onClick={(e) => {
         if (e.target === e.currentTarget) onCanvasBackgroundClick()
       }}


### PR DESCRIPTION
## Summary

Round 5 — production rollout of the layout iterations validated in the standalone flow-demo at http://45.151.123.50:8888/flow-demo.html (real OpenOva blueprint graph, 45 nodes, 12 depths).

- **Variable-width depth slots** — sparse depths shrink, dense depths claim the room they need (no more piling at the right edge).
- **sqrt-aspect dense buckets** — wider grids fill the canvas instead of tall thin columns.
- **Fit-to-host** — Stage 1 tightens gap, Stage 2 shrinks R, Stage 3 escalates row-multiplier; only scrolls when the chain genuinely cannot fit at MIN_R.
- **Zigzag for singletons** — Phase 0 chain reads as a gentle wave instead of a flat horizontal timeline (amplitude `min(R*3, h*0.12)` — short by design per founder UAT).
- **Snappy resize** — debounce 60 ms / 4 px epsilon so real window resizes feel immediate.
- **Force tuning** — X strength 0.12 → 0.18, Y 0.10 → 0.22 so per-bucket Y targets actually settle.

## Test plan

- [x] `tsc -b` clean
- [x] `vitest run` — bounded layout (17), JobDetail (5) green; bounded test updated to allow vbW > host (intentional scroll for tight chains).
- [x] Standalone demo validated locally with real `blueprint-deps.generated.json` graph at multiple viewport sizes (1920, 1440, 800).
- [ ] Live verify on console.openova.io after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)