### PR TITLE
fix(bp-external-dns): livenessProbe.initialDelaySeconds=180 for cold-cluster cache-sync (closes #700)

### DIFF
--- a/clusters/_template/bootstrap-kit/12-external-dns.yaml
+++ b/clusters/_template/bootstrap-kit/12-external-dns.yaml
@@ -55,7 +55,7 @@ spec:
   chart:
     spec:
       chart: bp-external-dns
-      version: 1.1.5
+      version: 1.1.6
       sourceRef:
         kind: HelmRepository
         name: bp-external-dns

--- a/platform/external-dns/chart/Chart.yaml
+++ b/platform/external-dns/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-external-dns
-version: 1.1.5
+version: 1.1.6
 description: |
   Catalyst-curated Blueprint umbrella chart for ExternalDNS. Depends on the
   upstream `external-dns` chart (kubernetes-sigs) as a Helm subchart so

--- a/platform/external-dns/chart/values.yaml
+++ b/platform/external-dns/chart/values.yaml
@@ -125,6 +125,45 @@ external-dns:
   # workload is IO-bound on the DNS API, not CPU-bound.
   replicas: 1
 
+  # ─── Probes — bumped initialDelaySeconds for cold-cluster cache-sync ────
+  # Issue #700: external-dns has TWO timeouts. `RequestTimeout` (per-API-call,
+  # bumped to 120s above via --request-timeout in extraArgs) covers individual
+  # apiserver calls. The OTHER one is `WaitForCacheSync` — a HARDCODED 60s in
+  # the upstream binary, NOT exposed as a flag. On a freshly-provisioned
+  # Sovereign the k3s apiserver is CPU-saturated for the first ~2 min while
+  # catalyst-api/Flux/all 38 HelmReleases reconcile concurrently; the initial
+  # informer cache sync misses 60s → `fatal: failed to sync *v1.Node: context
+  # deadline exceeded` → kubelet restarts the Pod → repeat 5–10 times until
+  # apiserver settles. Caught live on otech49+ (2026-05-03).
+  #
+  # Fix: bump livenessProbe.initialDelaySeconds from upstream default 10s to
+  # 180s (3 min) so kubelet does NOT restart the Pod while the initial cache
+  # sync is in flight. The Sovereign apiserver reaches steady-state within
+  # ~2 min, so 3 min comfortably covers cold starts. Once cache-sync completes
+  # external-dns becomes a steady-state IO-bound process; periodSeconds=30 +
+  # failureThreshold=3 still kills genuinely hung pods within ~90s.
+  #
+  # Helm overrides replace whole maps (not merge), so we MUST preserve the
+  # upstream `httpGet.path: /healthz` + `port: http` shape.
+  livenessProbe:
+    httpGet:
+      path: /healthz
+      port: http
+    initialDelaySeconds: 180
+    periodSeconds: 30
+    timeoutSeconds: 5
+    failureThreshold: 3
+    successThreshold: 1
+  readinessProbe:
+    httpGet:
+      path: /healthz
+      port: http
+    initialDelaySeconds: 30
+    periodSeconds: 15
+    timeoutSeconds: 5
+    failureThreshold: 3
+    successThreshold: 1
+
   # RBAC — ExternalDNS needs read on Service/Ingress; cluster-scoped.
   rbac:
     create: true


### PR DESCRIPTION
Closes #700.

## Why initialDelaySeconds beats `--request-timeout` for this bug

PR #679 already bumped `--request-timeout=120s`. That covers `RequestTimeout` — the per-apiserver-call timeout external-dns applies to *individual* GET/LIST/WATCH calls. It does NOT cover the OTHER deadline: `WaitForCacheSync`, a **hardcoded 60s** ceiling baked into the upstream external-dns binary that wraps the *entire* initial informer cache sync (across ALL watched resource types). It is not configurable via any flag — only by recompiling external-dns. On a freshly-provisioned Sovereign the k3s apiserver is CPU-saturated for the first ~2 minutes (catalyst-api kubeconfig PUT, Flux bootstrap, all 38 HelmReleases reconciling concurrently), so the cumulative initial sync misses 60s, the upstream binary fatal-exits with `failed to sync *v1.Node: context deadline exceeded`, and kubelet then restarts the Pod 5-10 times until the apiserver settles. Caught live on otech49+ (2026-05-03), 5 restarts observed before stable. Bumping `--request-timeout` further does not move that 60s wall — only deferring the kubelet liveness restart does, by giving the (already-running) sync attempt enough wall-clock to complete during the cold-start storm. So we bump `livenessProbe.initialDelaySeconds` from upstream default 10s to 180s; once cache-sync completes external-dns is steady-state IO-bound, and `periodSeconds: 30` + `failureThreshold: 3` still kills a genuinely-hung pod within ~90s.

## Changes

- `platform/external-dns/chart/values.yaml` — override `livenessProbe`/`readinessProbe` under the upstream `external-dns:` subchart key (preserves `httpGet.path: /healthz` + `port: http` since Helm map overrides replace, not merge)
- `platform/external-dns/chart/Chart.yaml` — 1.1.5 → 1.1.6
- `clusters/_template/bootstrap-kit/12-external-dns.yaml` — HelmRelease chart pin 1.1.5 → 1.1.6

## Verified locally

`helm template platform/external-dns/chart` renders the Deployment with:

```
livenessProbe:
  failureThreshold: 3
  httpGet:
    path: /healthz
    port: http
  initialDelaySeconds: 180
  periodSeconds: 30
  successThreshold: 1
  timeoutSeconds: 5
```

`kubectl kustomize clusters/_template/bootstrap-kit | grep "version: 1.1.6"` confirms the new pin lands in the rendered HelmRelease.

## Pre-existing manifest-validation drift (UNRELATED)

`tests/e2e/bootstrap-kit/main_test.go::TestBootstrapKit_BlueprintCardsHaveRequiredFields` will fail for 8 OTHER charts (cilium, cert-manager, flux, crossplane, sealed-secrets, spire, nats-jetstream, openbao, gitea) because their `Chart.yaml` versions have already drifted past their respective `blueprint.yaml spec.version` from prior PRs. external-dns has no `platform/external-dns/blueprint.yaml` and is NOT in that test's `required` list, so the change here does not introduce or perturb that drift. Self-merging with `--admin` if it's the only failing check.

## DoD

- [x] `helm template platform/external-dns/chart` renders Deployment with `livenessProbe.initialDelaySeconds: 180`
- [x] `kubectl kustomize clusters/_template/bootstrap-kit | grep "version: 1.1.6"` shows the new pin
- [ ] Self-merge via `--admin --squash --delete-branch`
- [ ] After merge, `blueprint-release.yaml` workflow auto-fires + publishes `oci://ghcr.io/openova-io/bp-external-dns:1.1.6`