### PR TITLE
fix(catalyst-api,bp-keycloak): handover 401 — FQDN race + realm SA roles (closes #713)

### DIFF
--- a/platform/keycloak/chart/templates/configmap-sovereign-realm.yaml
+++ b/platform/keycloak/chart/templates/configmap-sovereign-realm.yaml
@@ -334,7 +334,22 @@ data:
             ]
           }
         ]
-      }
+      },
+      "users": [
+        {
+          "username": "service-account-catalyst-api-server",
+          "enabled": true,
+          "serviceAccountClientId": "catalyst-api-server",
+          "clientRoles": {
+            "realm-management": [
+              "impersonation",
+              "manage-users",
+              "view-users",
+              "query-users"
+            ]
+          }
+        }
+      ]
     }
 ---
 {{- /* ── catalyst-kc-sa-credentials Secret ─────────────────────────────────

--- a/products/catalyst/chart/templates/api-deployment.yaml
+++ b/products/catalyst/chart/templates/api-deployment.yaml
@@ -77,6 +77,16 @@ metadata:
     # itself is NOT recreated by this annotation — only the
     # Deployment resource is.
     kustomize.toolkit.fluxcd.io/force: enabled
+    # Reloader watches the sovereign-fqdn + handover-jwt-public ConfigMaps/Secrets
+    # this Pod reads via valueFrom. On Sovereigns, those resources are applied
+    # by the sovereign-tls Kustomization concurrently with the bp-catalyst-platform
+    # HelmRelease. If the Pod started first, optional valueFrom resolves to ""
+    # and SOVEREIGN_FQDN stays empty for the lifetime of the Pod — every handover
+    # then fails the audience check with 401 "invalid audience" (caught live on
+    # otech62, 2026-05-03). Reloader rolls the Deployment when those resources
+    # land, fixing the race without requiring strict Flux dependsOn ordering.
+    configmap.reloader.stakater.com/reload: "sovereign-fqdn"
+    secret.reloader.stakater.com/reload: "handover-jwt-public"
 spec:
   replicas: 1
   # Recreate strategy is required because the deployments PVC is RWO


### PR DESCRIPTION
## Summary
- **Bug 1 — SOVEREIGN_FQDN race**: Pod starts before `sovereign-fqdn` ConfigMap, `valueFrom` resolves to "", audience check fails. Add Reloader annotation to roll Pod when the CM appears.
- **Bug 2 — SA missing role mappings**: `clientScopeMappings` ≠ user-level role mappings. Add explicit `users` array with `service-account-catalyst-api-server` bound to `realm-management.{impersonation,manage-users,view-users,query-users}`.

Both caught live on otech62 (2026-05-03). Closes #713.

## Test plan
- [x] Manual repro on otech62
- [ ] Republish bp-catalyst-platform + bp-keycloak via blueprint-release after merge
- [ ] otech64 zero-touch: handover returns 302 without manual restart
- [ ] 5-cycle E2E test all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)