### PR TITLE
fix(auth-ux): HTML PIN email + email pill + 6-box marketplace PIN + drop UI debris (#721 Wave 1)

### DIFF
--- a/core/marketplace/src/components/CheckoutStep.svelte
+++ b/core/marketplace/src/components/CheckoutStep.svelte
@@ -51,6 +51,126 @@
   function togglePayMethod(m: PayMethod) {
     payMethod = payMethod === m ? null : m;
   }
+
+  // ── 6-box PIN UX (issue #721) ─────────────────────────────────────────
+  // Each digit is a separate <input maxlength=1>. Auto-advance, paste-fan-
+  // out, backspace-back. Mirrors the React PinInput6 component on the
+  // catalyst-zero side so the operator gets the same experience whether
+  // they sign into the Sovereign console or the marketplace storefront.
+  let codeDigits = $state<string[]>(['', '', '', '', '', '']);
+  let codeRefs: (HTMLInputElement | null)[] = $state([null, null, null, null, null, null]);
+  // Mirror digits → existing `code` field so the rest of the form (verify
+  // submit) keeps working unchanged.
+  $effect(() => {
+    code = codeDigits.join('');
+  });
+  function focusBox(i: number) {
+    const el = codeRefs[i];
+    if (el) {
+      el.focus();
+      el.setSelectionRange(el.value.length, el.value.length);
+    }
+  }
+  function setDigitAt(i: number, v: string) {
+    if (codeDigits[i] === v) return;
+    const next = codeDigits.slice();
+    next[i] = v;
+    codeDigits = next;
+  }
+  function onDigitInput(i: number, ev: Event) {
+    const el = ev.target as HTMLInputElement;
+    const cleaned = (el.value.match(/\d/g) ?? []).join('');
+    if (cleaned.length === 0) {
+      setDigitAt(i, '');
+      return;
+    }
+    if (cleaned.length === 1) {
+      setDigitAt(i, cleaned);
+      el.value = cleaned;
+      if (i < 5) focusBox(i + 1);
+      return;
+    }
+    // Multiple digits typed/autofilled — fan out across remaining boxes.
+    const next = codeDigits.slice();
+    let idx = i;
+    for (const d of cleaned.split('')) {
+      if (idx >= 6) break;
+      next[idx] = d;
+      idx += 1;
+    }
+    codeDigits = next;
+    queueMicrotask(() => focusBox(Math.min(idx, 5)));
+  }
+  function onDigitKeyDown(i: number, ev: KeyboardEvent) {
+    const k = ev.key;
+    if (k === 'Backspace') {
+      if (codeDigits[i] === '' && i > 0) {
+        ev.preventDefault();
+        setDigitAt(i - 1, '');
+        focusBox(i - 1);
+      }
+      return;
+    }
+    if (k === 'ArrowLeft' && i > 0) {
+      ev.preventDefault();
+      focusBox(i - 1);
+      return;
+    }
+    if (k === 'ArrowRight' && i < 5) {
+      ev.preventDefault();
+      focusBox(i + 1);
+      return;
+    }
+    if (k === 'Enter') {
+      if (codeDigits.every((d) => d !== '')) {
+        handleVerify();
+      }
+      return;
+    }
+    if (k.length === 1 && (k < '0' || k > '9')) {
+      ev.preventDefault();
+    }
+  }
+  function onDigitPaste(ev: ClipboardEvent) {
+    ev.preventDefault();
+    const text = ev.clipboardData?.getData('text') ?? '';
+    const cleaned = (text.match(/\d/g) ?? []).join('').slice(0, 6);
+    if (!cleaned) return;
+    const next = ['', '', '', '', '', ''];
+    for (let i = 0; i < cleaned.length; i += 1) {
+      next[i] = cleaned.charAt(i);
+    }
+    codeDigits = next;
+    const last = Math.min(cleaned.length, 5);
+    queueMicrotask(() => focusBox(last));
+    if (cleaned.length === 6) {
+      queueMicrotask(() => handleVerify());
+    }
+  }
+
+  // Email pill — copy-on-click for one-shot copy of the address the code
+  // was sent to, so the operator can pivot to their email client and
+  // paste it into the search bar.
+  let emailCopied = $state(false);
+  let emailCopyTimer: ReturnType<typeof setTimeout> | null = null;
+  async function copyEmail() {
+    try {
+      await navigator.clipboard.writeText(email);
+      emailCopied = true;
+      if (emailCopyTimer) clearTimeout(emailCopyTimer);
+      emailCopyTimer = setTimeout(() => { emailCopied = false; }, 1500);
+    } catch {
+      // Fallback: select the pill text so the user can Cmd-C.
+      const sel = window.getSelection();
+      const range = document.createRange();
+      const tgt = document.getElementById('checkout-email-pill-text');
+      if (tgt && sel) {
+        range.selectNodeContents(tgt);
+        sel.removeAllRanges();
+        sel.addRange(range);
+      }
+    }
+  }
   let slugStatus = $state<'idle' | 'checking' | 'available' | 'taken' | 'invalid'>('idle');
   let slugChecked = $state('');
   let slugTimer: ReturnType<typeof setTimeout> | null = null;
@@ -347,6 +467,14 @@
 </script>
 
 <div class="py-4">
+  <!-- Wayfinding: back link sits top-left where users instinctively look,
+       not bottom-left of the form (issue #721). -->
+  <div class="mb-4">
+    <a href="/review" class="inline-flex items-center gap-1 text-sm text-[var(--color-text-dim)] hover:text-[var(--color-text)] no-underline">
+      <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="15 18 9 12 15 6"/></svg>
+      Back to Review
+    </a>
+  </div>
   <div class="mb-8 text-center">
     <h1 class="text-3xl font-bold text-[var(--color-text-strong)]">Checkout</h1>
     <p class="mt-2 text-[var(--color-text-dim)]">
@@ -462,31 +590,66 @@
           </form>
         {:else}
           <form onsubmit={(e) => { e.preventDefault(); handleVerify(); }}>
-            <p class="mb-3 text-sm text-[var(--color-text-dim)]">
-              We sent a 6-digit code to <span class="font-medium text-[var(--color-text)]">{email}</span>
+            <p class="mb-2 text-center text-sm text-[var(--color-text-dim)]">
+              A 6-digit code was sent to
             </p>
-            <input
-              type="text"
-              bind:value={code}
-              placeholder="Enter 6-digit code"
-              maxlength={6}
-              required
-              class="mb-3 w-full rounded-xl border border-[var(--color-border)] bg-[var(--color-bg)] px-4 py-3 text-center font-mono text-lg tracking-[0.5em] text-[var(--color-text)] placeholder-[var(--color-text-dimmer)] focus:border-[var(--color-accent)] focus:outline-none"
-            />
+            <div class="mb-5 flex justify-center">
+              <button
+                type="button"
+                onclick={copyEmail}
+                title={emailCopied ? 'Copied' : 'Copy email'}
+                class="group inline-flex items-center gap-2 rounded-full border border-[var(--color-border)] bg-[var(--color-bg)] px-3.5 py-1.5 text-sm font-medium text-[var(--color-text)] hover:border-[var(--color-accent)]/60 hover:bg-[var(--color-surface)] transition-colors"
+              >
+                <span id="checkout-email-pill-text" class="select-all">{email}</span>
+                {#if emailCopied}
+                  <svg class="h-3.5 w-3.5 text-green-500" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-label="Copied"><polyline points="20 6 9 17 4 12"/></svg>
+                {:else}
+                  <svg class="h-3.5 w-3.5 text-[var(--color-text-dim)] group-hover:text-[var(--color-accent)] transition-colors" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-label="Copy email"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
+                {/if}
+              </button>
+            </div>
+
+            <div class="mb-5 flex items-center justify-center gap-2 sm:gap-2.5" role="group" aria-label="Sign-in code" data-testid="checkout-pin-row">
+              {#each codeDigits as digit, i}
+                <input
+                  type="text"
+                  inputmode="numeric"
+                  pattern="[0-9]*"
+                  autocomplete={i === 0 ? 'one-time-code' : 'off'}
+                  maxlength={1}
+                  bind:this={codeRefs[i]}
+                  value={digit}
+                  disabled={authLoading}
+                  oninput={(e) => onDigitInput(i, e)}
+                  onkeydown={(e) => onDigitKeyDown(i, e)}
+                  onpaste={onDigitPaste}
+                  data-testid={`checkout-pin-${i}`}
+                  aria-label={`Digit ${i + 1}`}
+                  class={[
+                    'w-12 h-14 sm:w-14 sm:h-16',
+                    'text-center text-2xl sm:text-3xl font-semibold tabular-nums tracking-tight',
+                    'rounded-xl border-[1.5px] bg-[var(--color-bg)] text-[var(--color-text)]',
+                    'shadow-[0_1px_0_rgba(255,255,255,0.04),_inset_0_-1px_0_rgba(255,255,255,0.02)]',
+                    digit !== '' ? 'border-[var(--color-accent)]/70' : 'border-[var(--color-border)]',
+                    'focus:border-[var(--color-accent)] focus:outline-none focus:ring-[3px] focus:ring-[var(--color-accent)]/30 focus:scale-[1.04]',
+                    'transition-[border-color,transform] duration-150 ease-out',
+                    'disabled:opacity-50 disabled:cursor-not-allowed',
+                    'caret-transparent',
+                  ].join(' ')}
+                />
+              {/each}
+            </div>
+
             <button
               type="submit"
-              disabled={authLoading}
+              disabled={authLoading || code.length !== 6}
               class="flex w-full items-center justify-center rounded-xl bg-[var(--color-accent)] px-4 py-3 text-sm font-semibold text-white transition-colors hover:bg-[var(--color-accent-hover)] disabled:opacity-50"
             >
               {authLoading ? 'Verifying...' : 'Verify & Continue'}
             </button>
-            <button
-              type="button"
-              onclick={() => { authMode = 'login'; code = ''; authError = ''; }}
-              class="mt-2 w-full text-center text-xs text-[var(--color-text-dim)] hover:text-[var(--color-text)]"
-            >
-              Use a different email
-            </button>
+            <p class="mt-3 text-center text-xs text-[var(--color-text-dimmer)]">
+              Codes expire after 10 minutes — check your spam folder.
+            </p>
           </form>
         {/if}
 
@@ -708,9 +871,6 @@
     {/if}
   </div>
 
-  <div class="mt-8">
-    <a href="/review" class="text-sm text-[var(--color-text-dim)] hover:text-[var(--color-text)] no-underline">
-      &larr; Back to Review
-    </a>
-  </div>
+  <!-- Bottom-left "Back to Review" removed (issue #721) — moved to top-left
+       above the Checkout heading where wayfinding belongs. -->
 </div>

--- a/core/marketplace/src/components/Header.svelte
+++ b/core/marketplace/src/components/Header.svelte
@@ -10,6 +10,21 @@
   let user = $state<User | null>(null);
   let menuOpen = $state(false);
   let theme = $state<'light' | 'dark'>('dark');
+  // Hide the redundant top-right "Sign in" button when the user is already
+  // on a page where signing in IS the primary action (checkout, login).
+  // Showing two sign-in CTAs on the same screen is the UX debris caught
+  // live 2026-05-04.
+  let onSignInPage = $state(false);
+  $effect(() => {
+    if (typeof window === 'undefined') return;
+    const update = () => {
+      const p = window.location.pathname;
+      onSignInPage = p.startsWith('/checkout') || p.startsWith('/login');
+    };
+    update();
+    window.addEventListener('popstate', update);
+    return () => window.removeEventListener('popstate', update);
+  });
 
   $effect(() => {
     if (typeof document === 'undefined') return;
@@ -223,7 +238,7 @@
             </div>
           {/if}
         </div>
-      {:else}
+      {:else if !onSignInPage}
         <a href="/checkout" class="flex items-center gap-1.5 rounded-lg border border-[var(--color-border)] px-3 py-1.5 text-xs font-medium text-[var(--color-text)] transition-colors hover:bg-[var(--color-surface-hover)] no-underline">
           <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
             <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 6a3.75 3.75 0 11-7.5 0 3.75 3.75 0 017.5 0zM4.501 20.118a7.5 7.5 0 0114.998 0A17.933 17.933 0 0112 21.75c-2.676 0-5.216-.584-7.499-1.632z"/>

--- a/products/catalyst/bootstrap/api/internal/handler/auth.go
+++ b/products/catalyst/bootstrap/api/internal/handler/auth.go
@@ -287,23 +287,14 @@ func (h *Handler) HandlePinIssue(w http.ResponseWriter, r *http.Request) {
 // via Stalwart per smtpAddr().
 var sendPinEmail = sendPinEmailDefault
 
-// sendPinEmailDefault sends a plaintext email containing the 6-digit
-// code and no clickable URL.
+// sendPinEmailDefault sends a multipart MIME email (text + HTML) with
+// the 6-digit code rendered as a polished one-time-code card. iCloud /
+// Stripe parity — large monospaced digit groups, brand mark, expiration
+// notice. The plaintext alternative covers email clients that block HTML.
 //
-// Format (per founder spec on #688):
-//
-//	Your OpenOva sign-in code:
-//
-//	    3 7 2 4 5 8
-//
-//	Enter this code at https://console.openova.io/sovereign/login.
-//	The code expires in 10 minutes.
-//
-//	If you didn't request this, you can ignore this email.
-//
-// The bare URL on line 4 is informational only — operators must type
-// the code, not click anything. Per founder rule on #688 there must be
-// NO magic-link URL (no token, no auto-login query string).
+// Per founder rule on #688: NO magic-link URL (no token, no auto-login
+// query string). The login URL is shown only as informational text so
+// the operator pastes the code into the on-screen 6-box input.
 func sendPinEmailDefault(to, pin string) error {
 	from := smtpFrom()
 	addr := smtpAddr()
@@ -311,22 +302,38 @@ func sendPinEmailDefault(to, pin string) error {
 	if len(pin) != 6 {
 		return errors.New("sendPinEmail: pin must be 6 digits")
 	}
-	// "3 7 2 4 5 8" — single ASCII space between digits keeps the layout
-	// stable across every plaintext client.
-	spaced := strings.Join(strings.Split(pin, ""), " ")
-	subject := fmt.Sprintf("Your OpenOva sign-in code: %s", pin)
-	body := fmt.Sprintf(
-		"Your OpenOva sign-in code:\r\n\r\n    %s\r\n\r\n"+
-			"Enter this code at https://console.openova.io/sovereign/login.\r\n"+
-			"The code expires in 10 minutes.\r\n\r\n"+
-			"If you didn't request this, you can ignore this email.",
-		spaced,
-	)
 
-	msg := fmt.Sprintf(
-		"From: OpenOva Platform <%s>\r\nTo: %s\r\nSubject: %s\r\nContent-Type: text/plain; charset=utf-8\r\n\r\n%s",
-		from, to, subject, body,
-	)
+	subject := fmt.Sprintf("Your OpenOva sign-in code: %s", pin)
+	plain := pinEmailPlainText(pin)
+	html := pinEmailHTML(pin)
+
+	// RFC 2046 multipart/alternative — clients render HTML when they
+	// support it, fall back to plain otherwise. Boundary is a UUID so it
+	// can never collide with body content.
+	boundary := strings.ReplaceAll(uuid.NewString(), "-", "")
+	headers := strings.Join([]string{
+		"From: OpenOva Platform <" + from + ">",
+		"To: " + to,
+		"Subject: " + subject,
+		"MIME-Version: 1.0",
+		"Content-Type: multipart/alternative; boundary=\"" + boundary + "\"",
+	}, "\r\n")
+	body := strings.Join([]string{
+		"",
+		"--" + boundary,
+		"Content-Type: text/plain; charset=utf-8",
+		"Content-Transfer-Encoding: 7bit",
+		"",
+		plain,
+		"--" + boundary,
+		"Content-Type: text/html; charset=utf-8",
+		"Content-Transfer-Encoding: 7bit",
+		"",
+		html,
+		"--" + boundary + "--",
+		"",
+	}, "\r\n")
+	msg := headers + "\r\n" + body
 
 	smtpUser := os.Getenv("CATALYST_SMTP_USER")
 	smtpPass := os.Getenv("CATALYST_SMTP_PASS")
@@ -338,6 +345,64 @@ func sendPinEmailDefault(to, pin string) error {
 	}
 
 	return smtp.SendMail(addr, authMethod, from, []string{to}, []byte(msg))
+}
+
+// pinEmailPlainText is the text/plain alternative — terse, copy-friendly,
+// single-shot copy of the 6-digit code.
+func pinEmailPlainText(pin string) string {
+	return "Your OpenOva sign-in code is:\r\n\r\n" +
+		"  " + pin + "\r\n\r\n" +
+		"Enter it at https://console.openova.io/sovereign/login\r\n" +
+		"This code expires in 10 minutes.\r\n\r\n" +
+		"If you didn't request this, you can ignore this email."
+}
+
+// pinEmailHTML renders the polished verification-code email. Inline
+// styles only — no <style> blocks, no external assets — Gmail and
+// Outlook web both strip <head>/<style>. Width pinned at 480px so the
+// card looks correct in narrow webmail panes and on phones.
+//
+// Visual pattern (Apple iCloud / Stripe):
+//   - White card on neutral background
+//   - Brand mark + "OpenOva" wordmark at the top
+//   - Headline "Your sign-in code"
+//   - Big monospaced 6-digit code in a tinted box (one-tap copy on iOS)
+//   - Expiration line + ignore-if-not-you safety line below
+//   - Footer credit line
+func pinEmailHTML(pin string) string {
+	const (
+		bg      = "#f5f6f8"
+		card    = "#ffffff"
+		border  = "#e3e6eb"
+		textPri = "#0b0d12"
+		textSec = "#5f6470"
+		brand   = "#3357ff"
+		codeBg  = "#f0f3ff"
+		codeFg  = "#0b0d12"
+	)
+	return `<!doctype html>
+<html lang="en">
+<head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>Your OpenOva sign-in code</title></head>
+<body style="margin:0;padding:32px 16px;background:` + bg + `;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;color:` + textPri + `;">
+  <table role="presentation" align="center" cellspacing="0" cellpadding="0" border="0" width="480" style="max-width:480px;margin:0 auto;">
+    <tr><td style="padding:0 0 20px 0;text-align:center;">
+      <span style="display:inline-flex;align-items:center;gap:8px;font-size:14px;font-weight:600;color:` + textPri + `;letter-spacing:-0.01em;">
+        <span style="display:inline-block;width:22px;height:22px;border-radius:6px;background:` + brand + `;line-height:22px;color:#fff;font-weight:700;">∞</span>
+        OpenOva
+      </span>
+    </td></tr>
+    <tr><td style="background:` + card + `;border:1px solid ` + border + `;border-radius:14px;padding:32px 32px 28px 32px;">
+      <h1 style="margin:0 0 6px 0;font-size:20px;font-weight:600;letter-spacing:-0.01em;color:` + textPri + `;">Your sign-in code</h1>
+      <p style="margin:0 0 24px 0;font-size:14px;line-height:1.55;color:` + textSec + `;">Enter this 6-digit code at <a href="https://console.openova.io/sovereign/login" style="color:` + brand + `;text-decoration:none;font-weight:500;">console.openova.io</a> to finish signing in.</p>
+      <div style="background:` + codeBg + `;border:1px solid ` + border + `;border-radius:12px;padding:18px 0;text-align:center;font-family:'SF Mono',Menlo,Consolas,monospace;font-size:34px;font-weight:600;letter-spacing:10px;color:` + codeFg + `;">` + pin + `</div>
+      <p style="margin:18px 0 0 0;font-size:13px;line-height:1.5;color:` + textSec + `;">This code expires in 10 minutes. If you didn't request this, you can safely ignore this email — your account stays secure.</p>
+    </td></tr>
+    <tr><td style="padding:18px 0 0 0;text-align:center;font-size:12px;color:#8e94a3;">
+      Sent by OpenOva Platform · <a href="https://openova.io" style="color:#8e94a3;text-decoration:underline;">openova.io</a>
+    </td></tr>
+  </table>
+</body>
+</html>`
 }
 
 // ── Step 2: POST /api/v1/auth/pin/verify ─────────────────────────────────────

--- a/products/catalyst/bootstrap/ui/src/pages/auth/VerifyPinPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/auth/VerifyPinPage.tsx
@@ -11,9 +11,9 @@
  * (/sovereign/api/...) and Sovereign clusters (/api/...).
  */
 
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { motion } from 'framer-motion'
-import { ArrowRight } from 'lucide-react'
+import { ArrowRight, Check, Copy } from 'lucide-react'
 import { useNavigate, useSearch } from '@tanstack/react-router'
 import { AuthShell } from '@/app/layouts/AuthLayout'
 import { Button } from '@/shared/ui/button'
@@ -33,6 +33,28 @@ export function VerifyPinPage() {
   const [state, setState] = useState<State>('idle')
   const [errorMsg, setErrorMsg] = useState('')
   const [resetCounter, setResetCounter] = useState(0) // bumps to clear PinInput6
+  const [copied, setCopied] = useState(false)
+  const copyTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  async function copyEmail() {
+    try {
+      await navigator.clipboard.writeText(email)
+      setCopied(true)
+      if (copyTimer.current) clearTimeout(copyTimer.current)
+      copyTimer.current = setTimeout(() => setCopied(false), 1500)
+    } catch {
+      // Fallback for browsers without clipboard API: select the text so
+      // the user can Cmd-C / Ctrl-C themselves.
+      const sel = window.getSelection()
+      const range = document.createRange()
+      const target = document.getElementById('verify-email-pill-text')
+      if (target && sel) {
+        range.selectNodeContents(target)
+        sel.removeAllRanges()
+        sel.addRange(range)
+      }
+    }
+  }
 
   // If the user landed here without going through /login (refresh after
   // bookmarking, etc.), kick them back so they can request a new code.
@@ -107,15 +129,32 @@ export function VerifyPinPage() {
         transition={{ duration: 0.4, ease: [0.4, 0, 0.2, 1] }}
         className="flex flex-col gap-9"
       >
-        <div className="flex flex-col gap-2 text-center">
+        <div className="flex flex-col items-center gap-3 text-center">
           <h1 className="text-2xl font-semibold tracking-tight text-[oklch(94%_0.01_250)]">
             Enter the verification code
           </h1>
           <p className="text-[15px] text-[oklch(58%_0.01_250)] leading-snug">
             A 6-digit code was sent to
-            <br />
-            <span className="font-medium text-[oklch(80%_0.01_250)]">{email}</span>.
           </p>
+          <button
+            type="button"
+            onClick={copyEmail}
+            data-testid="verify-email-pill"
+            title="Copy email"
+            className="group inline-flex items-center gap-2 rounded-full border border-[--color-surface-border] bg-[--color-surface-1] px-3.5 py-1.5 text-sm font-medium text-[oklch(85%_0.01_250)] hover:border-[--color-brand-500]/60 hover:bg-[--color-surface-2] transition-colors"
+          >
+            <span id="verify-email-pill-text" className="select-all">
+              {email}
+            </span>
+            {copied ? (
+              <Check className="h-3.5 w-3.5 text-[--color-success]" aria-label="Copied" />
+            ) : (
+              <Copy
+                className="h-3.5 w-3.5 text-[oklch(50%_0.01_250)] group-hover:text-[--color-brand-400] transition-colors"
+                aria-label="Copy email"
+              />
+            )}
+          </button>
         </div>
 
         <form
@@ -156,7 +195,7 @@ export function VerifyPinPage() {
           </Button>
         </form>
 
-        <div className="flex flex-col items-center gap-2 text-center">
+        <div className="flex flex-col items-center gap-1.5 text-center">
           <button
             type="button"
             onClick={() =>
@@ -171,7 +210,7 @@ export function VerifyPinPage() {
             Didn't get a code? Send a new one
           </button>
           <p className="text-xs text-[oklch(40%_0.01_250)]">
-            Check your spam folder — codes expire after 10 minutes.
+            Codes expire after 10 minutes — check your spam folder.
           </p>
         </div>
       </motion.div>


### PR DESCRIPTION
## Summary
- **PIN email** plaintext-only → multipart MIME with iCloud/Stripe-style HTML card (480px white card on neutral bg, branded mark, big tinted code block, expiration line)
- **Catalyst-Zero verify page** email shown as a copyable pill (click → clipboard + check-mark feedback)
- **Marketplace checkout** swapped 1-input for 6 boxes with auto-advance + paste-fan-out, copyable email pill, dropped "Use a different email" link
- **Header.svelte** hides redundant top-right Sign in when on /checkout or /login
- **Bottom-left "Back to Review"** moved to top-left chevron-back above Checkout heading

Closes #721 Wave 1. Wave 2 (catalog Published flag + console publish toggle) and Wave 3 (marketplace settings + wizard step, GitOps) follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)