### PR TITLE
fix: catalyst-build actions:write + AuthLayout overflow scroll

### DIFF
--- a/.github/workflows/catalyst-build.yaml
+++ b/.github/workflows/catalyst-build.yaml
@@ -291,7 +291,19 @@ jobs:
     needs: [build-ui, build-api]
     runs-on: ubuntu-latest
     permissions:
+      # contents: write — push the values.yaml SHA bump back to main
       contents: write
+      # actions: write — required for `gh workflow run` to dispatch
+      # blueprint-release.yaml after the deploy commit lands. Without
+      # this, the dispatch step (added in PR #720 to close the
+      # bot-deploy-doesn't-trigger-workflows gap from #712) returns
+      # HTTP 403 "Resource not accessible by integration", the
+      # blueprint-release fires NEVER, and the bp-catalyst-platform
+      # OCI artifact stays stuck on the PREVIOUS deploy's image SHA.
+      # Caught live 2026-05-04 — PR #722–727 all built green but
+      # blueprint-release was never dispatched, leaving Sovereigns
+      # provisioned afterwards on the pre-fix chart.
+      actions: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/products/catalyst/bootstrap/ui/src/app/layouts/AuthLayout.tsx
+++ b/products/catalyst/bootstrap/ui/src/app/layouts/AuthLayout.tsx
@@ -7,8 +7,19 @@ export function AuthLayout() {
 }
 
 export function AuthShell({ children }: { children: React.ReactNode }) {
+  // min-h-dvh + items-stretch on the outer flex makes the LEFT panel
+  // fill viewport height. The RIGHT panel uses overflow-y-auto so the
+  // form card NEVER truncates at small viewport heights (laptops at
+  // 1366×650, browsers with dev tools open, mobile landscape) — the
+  // card stays visible by scrolling its own column instead of the
+  // whole document. min-h-full + items-center on the right panel
+  // anchors the card vertically; if content fits, it's centered, if
+  // it doesn't, the user can scroll within the column. Caught live
+  // 2026-05-04: at certain heights the card sat at the top of the
+  // right panel because the parent was min-h-dvh but the inner
+  // wrapper had no flex-grow.
   return (
-    <div className="min-h-dvh flex">
+    <div className="min-h-dvh flex items-stretch">
       {/* Left panel — branding */}
       <div className="hidden lg:flex lg:w-[420px] xl:w-[480px] shrink-0 flex-col justify-between bg-[--color-surface-1] border-r border-[--color-surface-border] p-10">
         <div className="flex items-center gap-2.5">
@@ -53,8 +64,11 @@ export function AuthShell({ children }: { children: React.ReactNode }) {
       </div>
 
       {/* Right panel — form */}
-      <div className="flex flex-1 items-center justify-center p-6 bg-[--color-surface-0]">
-        <div className="w-full max-w-sm">{children}</div>
+      <div className="flex flex-1 items-center justify-center overflow-y-auto p-6 sm:p-8 bg-[--color-surface-0]">
+        {/* py-8 inside the card column gives the card breathing room
+            top + bottom even when overflow-y-auto kicks in, so the
+            "scroll inside the column" path stays comfortable. */}
+        <div className="w-full max-w-sm py-8">{children}</div>
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary
- **CI**: deploy job's `gh workflow run` dispatch was failing with HTTP 403 because GITHUB_TOKEN lacked `actions: write`. blueprint-release never fired after PR #722–727 merged. Add the permission.
- **Auth UX**: sign-in / verify cards were mathematically centered at 1440×900 but truncated at smaller heights because the right panel had no overflow fallback. Added `items-stretch` + `overflow-y-auto` + `py-8` so the card stays centered when it fits and scrolls within its column when it doesn't.

🤖 Generated with [Claude Code](https://claude.com/claude-code)