### PR TITLE
fix(cilium): k8sServiceHost 127.0.0.1 → 10.0.1.2 so workers' Cilium reaches apiserver

### DIFF
--- a/infra/hetzner/cloudinit-control-plane.tftpl
+++ b/infra/hetzner/cloudinit-control-plane.tftpl
@@ -545,7 +545,17 @@ write_files:
       # comment block immediately above this write_files entry, and
       # cilium_values_parity_test.go for the regression guard.
       kubeProxyReplacement: true
-      k8sServiceHost: 127.0.0.1
+      # k8sServiceHost: the CP's stable private IP on the 10.0.1.0/24
+      # subnet (cp1=10.0.1.2 per main.tf network block). Was previously
+      # 127.0.0.1 which works on the CP (k3s server listens on
+      # localhost:6443) but FAILS on workers (k3s agent does NOT expose
+      # apiserver on localhost — only the supervisor port on :6444).
+      # When worker_count>0 (issue #733 multi-node default), the Cilium
+      # DaemonSet on workers used to crashloop with "127.0.0.1:6443:
+      # connect: connection refused" forever. Routing every Cilium agent
+      # to the CP private IP fixes the worker path and is a no-op on
+      # the CP itself (10.0.1.2 IS its own private IP).
+      k8sServiceHost: 10.0.1.2
       k8sServicePort: 6443
       tunnelProtocol: vxlan
       bpf:

--- a/platform/cilium/chart/values.yaml
+++ b/platform/cilium/chart/values.yaml
@@ -31,7 +31,19 @@ catalystBlueprint:
 cilium:
   # kube-proxy replacement (faster + simpler than iptables)
   kubeProxyReplacement: true
-  k8sServiceHost: 127.0.0.1
+  # k8sServiceHost: CP's stable private IP on the Sovereign's 10.0.1.0/24
+  # subnet (cp1=10.0.1.2 per infra/hetzner/main.tf). Multi-node-aware:
+  # works on the CP itself (10.0.1.2 IS its own private IP) AND on
+  # workers (which need the CP's IP because k3s agents do NOT expose the
+  # apiserver on localhost — only the supervisor on :6444). Previously
+  # `127.0.0.1` here, which crashloop'd Cilium on every worker for
+  # multi-node Sovereigns (issue #733). For air-gap / multi-CP / non-
+  # Hetzner Sovereigns the canonical fix is to point this at the in-
+  # cluster apiserver Service (kubernetes.default.svc.cluster.local) —
+  # but that requires DNS up before Cilium, which is the chicken-egg
+  # this whole config exists to solve. The Sovereign template subnet
+  # is fixed at 10.0.1.0/24 so 10.0.1.2 is a stable load-bearing value.
+  k8sServiceHost: 10.0.1.2
   k8sServicePort: 6443
 
   # eBPF-host-routing — bypasses iptables stack


### PR DESCRIPTION
Issue #733 follow-up.

## Problem

The default `cpx32` multi-node Sovereign (1 CP + 2 workers) from #736 provisioned successfully, but worker nodes stuck `NotReady` because `cilium-agent` on workers crashloop'd:

```
Get "https://127.0.0.1:6443/api/v1/namespaces/kube-system":
  dial tcp 127.0.0.1:6443: connect: connection refused
```

Root cause: `k8sServiceHost: 127.0.0.1` works on the k3s SERVER node (supervisor binds `localhost:6443`) but FAILS on every k3s AGENT node — k3s agent does NOT expose the apiserver on localhost; it exposes only the supervisor on `:6444`. Pre-#733 every Sovereign was solo (`worker_count=0`), so this never fired.

## Fix

Point Cilium at `10.0.1.2` — the CP's stable private IP on the Sovereign's `10.0.1.0/24` subnet (`cp1=10.0.1.2` per `infra/hetzner/main.tf` network block). No-op on the CP (10.0.1.2 IS its own private IP) and works on workers (they already join the cluster via the same address per `cloudinit-worker.tftpl`'s `K3S_URL=https://${cp_private_ip}:6443`).

## Files

- `infra/hetzner/cloudinit-control-plane.tftpl` — bootstrap helm install values written to `/var/lib/catalyst/cilium-values.yaml`
- `platform/cilium/chart/values.yaml` — Flux bp-cilium HelmRelease values

`cilium_values_parity_test.go` already enforces both stay aligned, and only checks for the presence of `k8sServiceHost:` (not the literal value) so it stays green.

## Live evidence (otech50, post-#736 deploy)

```
$ curl -sH "Authorization: Bearer $TOKEN" "https://api.hetzner.cloud/v1/servers" | python3 -c "..."
catalyst-otech50-omani-works-cp1 cpx32 running
catalyst-otech50-omani-works-w1 cpx32 running
catalyst-otech50-omani-works-w2 cpx32 running

$ kubectl --context=otech50 get nodes
NAME                               STATUS     ROLES                       AGE     VERSION
catalyst-otech50-omani-works-cp1   Ready      control-plane,etcd,master   3m13s   v1.31.4+k3s1
catalyst-otech50-omani-works-w1    NotReady   <none>                      94s     v1.31.4+k3s1
catalyst-otech50-omani-works-w2    NotReady   <none>                      2m22s   v1.31.4+k3s1

$ kubectl --context=otech50 logs -n kube-system cilium-jr9cb -c config --previous | tail -3
Error: Build config failed: failed to start: Get "https://127.0.0.1:6443/api/v1/namespaces/kube-system":
  dial tcp 127.0.0.1:6443: connect: connection refused
```

After this PR rolls + a fresh provision, workers should reach `Ready` and the Phase-1 watcher sees all components `Ready=True` across the multi-node cluster. Verification cycle is queued.

## Test plan

- [x] cilium_values_parity_test.go still passes (presence-only check)
- [ ] CI green
- [ ] After merge + image roll: provision a fresh Sovereign with default settings (CPX32 × 3) → all 3 nodes Ready

🤖 Generated with [Claude Code](https://claude.com/claude-code)