### PR TITLE
fix(k3s): add 10.0.1.2 to --tls-san so Cilium can verify CP cert from workers

### DIFF
--- a/infra/hetzner/cloudinit-control-plane.tftpl
+++ b/infra/hetzner/cloudinit-control-plane.tftpl
@@ -950,7 +950,7 @@ runcmd:
   # provisioned hcloud-csi. Result on a fresh Sovereign: every PVC stuck
   # Pending forever, bootstrap-kit deadlocked. Keeping local-path solves
   # the circularity by giving the cluster a default StorageClass at boot.
-  - 'curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION=${k3s_version} K3S_TOKEN=${k3s_token} INSTALL_K3S_EXEC="server --cluster-init --flannel-backend=none --disable-network-policy --disable=traefik --disable=servicelb --tls-san=${sovereign_fqdn} --kube-apiserver-arg=oidc-issuer-url=https://auth.${sovereign_fqdn}/realms/sovereign --kube-apiserver-arg=oidc-client-id=kubectl --kube-apiserver-arg=oidc-username-claim=preferred_username --kube-apiserver-arg=oidc-username-prefix=oidc: --kube-apiserver-arg=oidc-groups-claim=groups --kube-apiserver-arg=oidc-groups-prefix=oidc: --node-label catalyst.openova.io/role=control-plane --write-kubeconfig-mode=0644" sh -'
+  - 'curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION=${k3s_version} K3S_TOKEN=${k3s_token} INSTALL_K3S_EXEC="server --cluster-init --flannel-backend=none --disable-network-policy --disable=traefik --disable=servicelb --tls-san=${sovereign_fqdn} --tls-san=10.0.1.2 --kube-apiserver-arg=oidc-issuer-url=https://auth.${sovereign_fqdn}/realms/sovereign --kube-apiserver-arg=oidc-client-id=kubectl --kube-apiserver-arg=oidc-username-claim=preferred_username --kube-apiserver-arg=oidc-username-prefix=oidc: --kube-apiserver-arg=oidc-groups-claim=groups --kube-apiserver-arg=oidc-groups-prefix=oidc: --node-label catalyst.openova.io/role=control-plane --write-kubeconfig-mode=0644" sh -'
 
   # Wait for the API server to be reachable. Cilium needs to come up before
   # nodes Ready, so we wait specifically for the API endpoint.


### PR DESCRIPTION
Issue #733 follow-up #2 (after #738).

## Problem

After #738 pointed Cilium's `k8sServiceHost` at the CP private IP `10.0.1.2`, Cilium's TLS verification fails:

```
Get "https://10.0.1.2:6443/api/v1/namespaces/kube-system":
  tls: failed to verify certificate: x509: certificate is valid for
  10.43.0.1, 127.0.0.1, 178.104.211.206, 2a01:..., ::1, not 10.0.1.2
```

k3s auto-generates the apiserver TLS cert with SANs covering the public IP, the cluster service IP (`10.43.0.1`), and localhost — but NOT the private subnet IP `10.0.1.2`.

## Fix

Add `--tls-san=10.0.1.2` to the k3s server install command so the cert is valid for the address Cilium (and any other in-cluster client) reaches the apiserver via.

The sovereign FQDN (`${sovereign_fqdn}`) was already in `--tls-san`; this just adds the private subnet anchor that the multi-node Cilium config from #738 introduced.

## Live evidence (otech51, deploy SHA `69de64b`)

```
$ kubectl --context=otech51 logs -n kube-system cilium-zxbt5 -c config --previous | tail -3
ERROR Start hook failed function="client.(*compositeClientset).onStart (k8s-client)"
  error="Get \"https://10.0.1.2:6443/api/v1/namespaces/kube-system\":
  tls: failed to verify certificate: x509: certificate is valid for
  10.43.0.1, 127.0.0.1, 178.104.211.206, 2a01:..., ::1, not 10.0.1.2"
```

Note Cilium IS using `https://10.0.1.2:6443` correctly per #738 — the bug now is purely cert SAN. After this PR the SAN list will include `10.0.1.2` and verification succeeds.

## Test plan

- [ ] CI green
- [ ] After merge + image roll: provision a fresh Sovereign with default settings (CPX32 × 3) → all 3 nodes reach Ready
- [ ] Wipe to clean up

🤖 Generated with [Claude Code](https://claude.com/claude-code)