### PR TITLE
fix(cloud-init): tolerate Crossplane Provider apply failure + background retry

### DIFF
--- a/infra/hetzner/cloudinit-control-plane.tftpl
+++ b/infra/hetzner/cloudinit-control-plane.tftpl
@@ -1274,13 +1274,25 @@ runcmd:
   # → Crossplane handover seam. Tofu provisions Phase 0 exactly once;
   # everything else flows through XRC writes against this Provider.
   - 'kubectl --kubeconfig=/etc/rancher/k3s/k3s.yaml apply -f /var/lib/catalyst/cloud-credentials-secret.yaml'
-  - 'kubectl --kubeconfig=/etc/rancher/k3s/k3s.yaml apply -f /var/lib/catalyst/crossplane-provider-hcloud.yaml'
+  # IMPORTANT: the Provider CRD (`pkg.crossplane.io/v1`) is registered by
+  # bp-crossplane via Flux AFTER flux-bootstrap.yaml is applied below.
+  # Apply with `|| true` so the failure here doesn't propagate into
+  # cloud-init's exit status. The Provider CR is re-applied below in a
+  # background retry once Crossplane core CRDs land.
+  - 'kubectl --kubeconfig=/etc/rancher/k3s/k3s.yaml apply -f /var/lib/catalyst/crossplane-provider-hcloud.yaml || true'
 
   # Apply the Flux bootstrap GitRepository + Kustomization. From here, Flux
   # owns the cluster: pulls clusters/_template/ (with $${SOVEREIGN_FQDN}
   # substituted to ${sovereign_fqdn} via postBuild), installs Cilium
   # via bp-cilium, cert-manager via bp-cert-manager, etc., then bp-catalyst-platform.
   - 'kubectl --kubeconfig=/etc/rancher/k3s/k3s.yaml apply -f /var/lib/catalyst/flux-bootstrap.yaml'
+
+  # Background retry of the Crossplane Provider CR apply. Polls every
+  # 30s up to 30m for the Crossplane Provider CRD to be registered
+  # (i.e. bp-crossplane reconciled by Flux), then `kubectl apply`
+  # succeeds and the loop exits. Detached via `&` so cloud-init runcmd
+  # completes without waiting for Crossplane to be Ready.
+  - 'nohup bash -c "deadline=\$((SECONDS+1800)); while [ \$SECONDS -lt \$deadline ]; do kubectl --kubeconfig=/etc/rancher/k3s/k3s.yaml apply -f /var/lib/catalyst/crossplane-provider-hcloud.yaml >/dev/null 2>&1 && break; sleep 30; done" >/dev/null 2>&1 &'
 
   # Marker for the catalyst-api provisioner to detect cloud-init is done.
   - mkdir -p /var/lib/catalyst


### PR DESCRIPTION
## Problem

Live on otech88 (DID b2c528023b50ec45, 2026-05-04 11:40:42Z): new Sovereign's flux-system reaches Ready (GitRepository artifact stored, all 6 Flux deployments Available) but no Kustomization CRs appear — kustomize-controller has 0 to reconcile, `hr=True=0/0` forever.

## Fix

Belt-and-braces hardening of cloud-init's Crossplane Provider apply:

1. `|| true` so the apply's failure (Crossplane Provider CRD not yet registered — bp-crossplane is installed by Flux later) doesn't propagate non-zero exit through cloud-init.

2. Background retry that polls every 30s up to 30m for the Provider CRD, applying once it lands. Detached via `&` so cloud-init runcmd completes immediately.

## Test plan

- [x] Build clean
- [ ] catalyst-build CI green
- [ ] Live verification: 2 consecutive zero-touch end-to-end provisioning cycles via autopilot

🤖 Generated with [Claude Code](https://claude.com/claude-code)