### PR TITLE
fix(cloud-init): quote MARKETPLACE_ENABLED — postBuild.substitute requires string

### DIFF
--- a/infra/hetzner/cloudinit-control-plane.tftpl
+++ b/infra/hetzner/cloudinit-control-plane.tftpl
@@ -802,7 +802,7 @@ write_files:
             # checkbox) flips this to "true" via per-Sovereign overlay
             # patch — bp-catalyst-platform 1.3.0 then renders the
             # marketplace + tenant-wildcard HTTPRoutes.
-            MARKETPLACE_ENABLED: ${marketplace_enabled}
+            MARKETPLACE_ENABLED: "${marketplace_enabled}"
       ---
       apiVersion: kustomize.toolkit.fluxcd.io/v1
       kind: Kustomization
@@ -839,7 +839,7 @@ write_files:
             # checkbox) flips this to "true" via per-Sovereign overlay
             # patch — bp-catalyst-platform 1.3.0 then renders the
             # marketplace + tenant-wildcard HTTPRoutes.
-            MARKETPLACE_ENABLED: ${marketplace_enabled}
+            MARKETPLACE_ENABLED: "${marketplace_enabled}"
       ---
       apiVersion: kustomize.toolkit.fluxcd.io/v1
       kind: Kustomization
@@ -871,7 +871,7 @@ write_files:
             # checkbox) flips this to "true" via per-Sovereign overlay
             # patch — bp-catalyst-platform 1.3.0 then renders the
             # marketplace + tenant-wildcard HTTPRoutes.
-            MARKETPLACE_ENABLED: ${marketplace_enabled}
+            MARKETPLACE_ENABLED: "${marketplace_enabled}"
 
 runcmd:
   - swapoff -a


### PR DESCRIPTION
## Root cause for the zero-touch handover stall

Cloud-init template was emitting unquoted bool:

```yaml
postBuild:
  substitute:
    SOVEREIGN_FQDN: otech89.omani.works
    MARKETPLACE_ENABLED: false      ← unquoted YAML bool
```

Flux's `postBuild.substitute` CRD schema is `map[string]string` — bools are silently rejected. GitRepository (no postBuild) lands fine, but all 3 Kustomizations are rejected by the CRD validator. Kustomize-controller has no Kustomizations to reconcile → 0 HRs ever Ready → bootstrap-kit never lands.

This blocked otech85–89 (and several before). Quote the value: `MARKETPLACE_ENABLED: "${marketplace_enabled}"` → renders as `"false"` string → passes validator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)