### PR TITLE
fix(provision): drop bespoke 'Operator' widget, use ProfileMenu top-right (closes #750)

### DIFF
--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/PortalShell.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/PortalShell.tsx
@@ -5,8 +5,8 @@
  *   • flex min-h-screen wrapper
  *   • left rail: <Sidebar /> w-56 fixed
  *   • main: ml-56 flex-1 with a 56px sticky header band hosting the
- *     NotificationBell + ThemeToggle (top-right) and the page title
- *     left-aligned at the start of the band.
+ *     NotificationBell + ThemeToggle + ProfileMenu (top-right) and the
+ *     page title left-aligned at the start of the band.
  *
  * Per founder mandate #531 (2026-05-02), the page title is left-aligned
  * (sat in the LEFT slot), and a NotificationBell is rendered to the
@@ -22,6 +22,14 @@
  *   • optional right slot         — `headerSlotRight` (FQDN switcher etc.)
  *   • <NotificationBell />        — global notifications affordance
  *   • <ThemeToggle />             — theme switcher
+ *   • <ProfileMenu />             — signed-in user identity (#750)
+ *
+ * Issue #750 — identity placement: the provisioning surface previously
+ * embedded a bespoke "Operator / Provisioning session" card in the
+ * bottom-left of the Sidebar. That widget is gone; the canonical
+ * <ProfileMenu /> (the same widget the wizard header uses) now lives
+ * in the top-right of this shell so identity placement is consistent
+ * across wizard + provisioning + Sovereign-console.
  *
  * The canonical shell handles auth + tenant resolution; in the
  * Sovereign-provision wizard context that's not relevant — the wizard
@@ -38,6 +46,7 @@ import type { ReactNode } from 'react'
 import { Sidebar } from './Sidebar'
 import { ThemeToggle } from '@/components/ThemeToggle'
 import { NotificationBell } from '@/shared/ui/notifications'
+import { ProfileMenu } from '@/widgets/auth/ProfileMenu'
 
 interface PortalShellProps {
   /** Stable deploymentId from the URL parameter. */
@@ -97,6 +106,10 @@ export function PortalShell({
             {headerSlotRight}
             <NotificationBell />
             <ThemeToggle />
+            {/* Issue #750 — signed-in user identity in the top-right
+                slot (anonymous renders [Sign in], signed-in renders the
+                email-initial avatar with a Sign-out dropdown). */}
+            <ProfileMenu />
           </div>
         </header>
         <main className="flex-1 p-8">{children}</main>

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/Sidebar.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/Sidebar.test.tsx
@@ -13,7 +13,8 @@
  *   • Cloud highlight applies whenever the operator is on any
  *     /cloud/* path (including the legacy P3 sub-routes that now
  *     redirect to /cloud?view=… queries)
- *   • Operator card at the bottom (analog of canonical "User" card)
+ *   • No bespoke operator/identity card — issue #750 moved identity
+ *     to the canonical <ProfileMenu /> in PortalShell's top-right.
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
@@ -239,11 +240,14 @@ describe('Sidebar — Cloud entry (issue #350: accordion dropped)', () => {
   })
 })
 
-describe('Sidebar — operator card', () => {
-  it('renders Operator + "Provisioning session" footer text', async () => {
+describe('Sidebar — identity placement (issue #750)', () => {
+  it('does NOT render the bespoke "Operator / Provisioning session" card', async () => {
     renderSidebarAt('/provision/d-test-1234')
     const sidebar = await screen.findByTestId('admin-sidebar')
-    expect(within(sidebar).getByText('Operator')).toBeTruthy()
-    expect(within(sidebar).getByText('Provisioning session')).toBeTruthy()
+    // The bespoke widget was removed — identity now lives in the
+    // top-right of PortalShell via <ProfileMenu />, mirroring the
+    // wizard + Sovereign-console surfaces.
+    expect(within(sidebar).queryByText('Operator')).toBeNull()
+    expect(within(sidebar).queryByText('Provisioning session')).toBeNull()
   })
 })

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/Sidebar.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/Sidebar.tsx
@@ -25,9 +25,11 @@
  *     /cloud/* route OR any legacy /infrastructure/* route (covered
  *     by the redirect-only routes in app/router.tsx).
  *
- *   • Operator card at the bottom — analog of the canonical "User"
- *     card; the wizard runs unauthenticated so we show "Operator ·
- *     Provisioning session".
+ * Issue #750: the bespoke bottom-left "Operator / Provisioning session"
+ * card was removed. Identity placement is now consistent with the rest
+ * of the application — the signed-in user's email-initial avatar +
+ * sign-out menu live in the top-right of the PortalShell header via
+ * <ProfileMenu />, mirroring the wizard + Sovereign-console surfaces.
  *
  * Per docs/INVIOLABLE-PRINCIPLES.md #4 (never hardcode), every label,
  * href and color comes from runtime data + canonical token names —
@@ -229,18 +231,17 @@ export function Sidebar({ deploymentId, sovereignFQDN }: SidebarProps) {
         })()}
       </nav>
 
-      {/* Operator card at the bottom — analog of canonical "User" card */}
-      <div className="border-t border-[var(--color-border)] p-3">
-        <div className="flex items-center gap-2">
-          <div className="flex h-8 w-8 items-center justify-center rounded-full bg-[var(--color-accent)]/20 text-xs font-bold text-[var(--color-accent)]">
-            O
-          </div>
-          <div className="min-w-0 flex-1">
-            <p className="truncate text-xs font-medium text-[var(--color-text)]">Operator</p>
-            <p className="truncate text-[10px] text-[var(--color-text-dimmer)]">Provisioning session</p>
-          </div>
-        </div>
-      </div>
+      {/*
+        Issue #750: the bespoke "Operator / Provisioning session" card
+        used to live here. It was removed because:
+          1. Identity belongs top-right (matches WizardLayout +
+             SovereignConsoleLayout + marketplace header — this surface
+             was the lone outlier).
+          2. The label "Operator" was hard-coded and never reflected the
+             actual signed-in user's email; the canonical <ProfileMenu />
+             reads useSession() and renders the email-initial avatar.
+        The replacement now lives in PortalShell.tsx's top-right slot.
+      */}
     </aside>
   )
 }


### PR DESCRIPTION
## Summary

- Drop the bespoke "Operator / Provisioning session" card from `Sidebar.tsx` — it was hard-coded, never reflected the signed-in user's email, and lived in the wrong corner.
- Render the canonical `<ProfileMenu />` in `PortalShell.tsx`'s top-right slot. ProfileMenu reads `useSession()` and renders an email-initial avatar with a "Signed in as <email>" + "Sign out" dropdown — the same widget the wizard header uses.
- Identity placement is now consistent across wizard / provisioning / Sovereign-console / marketplace.

Because `PortalShell` wraps every `/sovereign/provision/*` route (apps, jobs, dashboard, cloud, users, settings), this fix lands in all of them in one place.

## Closes
Closes #750

## Test plan
- [x] `npx vitest run src/pages/sovereign/Sidebar.test.tsx` — 16/16 pass; new regression guard asserts the bespoke widget is GONE.
- [ ] Live: navigate to `/sovereign/provision/<any-id>` while signed in. Top-right shows the email-initial avatar; click → "Signed in as <session.email>" + "Sign out".
- [ ] Live: anonymous visitor sees `[Sign in]` button top-right.
- [ ] Bottom-left of the sidebar no longer shows "O / Operator / Provisioning session".

🤖 Generated with [Claude Code](https://claude.com/claude-code)