### PR TITLE
fix(bp-external-dns): apiserver Endpoints sync timeout — Cilium kube-apiserver entity required (closes #770)

### DIFF
--- a/clusters/_template/bootstrap-kit/12-external-dns.yaml
+++ b/clusters/_template/bootstrap-kit/12-external-dns.yaml
@@ -55,7 +55,12 @@ spec:
   chart:
     spec:
       chart: bp-external-dns
-      version: 1.1.6
+      # 1.1.7: companion CiliumNetworkPolicy with toEntities[kube-apiserver]
+      # so external-dns can reach the kube-apiserver on Cilium clusters
+      # (default policy-cidr-match-mode=""). Fixes #770 — the vanilla
+      # NetworkPolicy 0.0.0.0/0 ipBlock does NOT match apiserver traffic
+      # under Cilium's identity model.
+      version: 1.1.7
       sourceRef:
         kind: HelmRepository
         name: bp-external-dns

--- a/platform/external-dns/chart/Chart.yaml
+++ b/platform/external-dns/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-external-dns
-version: 1.1.6
+version: 1.1.7
 description: |
   Catalyst-curated Blueprint umbrella chart for ExternalDNS. Depends on the
   upstream `external-dns` chart (kubernetes-sigs) as a Helm subchart so

--- a/platform/external-dns/chart/templates/ciliumnetworkpolicy.yaml
+++ b/platform/external-dns/chart/templates/ciliumnetworkpolicy.yaml
@@ -1,0 +1,89 @@
+{{- /*
+CiliumNetworkPolicy — grants egress to the Kubernetes API server.
+
+WHY THIS EXISTS (issue #770)
+─────────────────────────────────────────────────────────────────────
+ExternalDNS's first action on startup is the cluster-wide
+`*v1.Endpoints` / `*v1.Service` / `*v1.Node` informer cache sync against
+the kube-apiserver (https://10.43.0.1:443 → DNAT'd to the CP node's host
+network at <cp-ip>:6443). When that sync misses its 60s hardcoded
+WaitForCacheSync window the binary exits with:
+
+  fatal: failed to sync *v1.Endpoints: context deadline exceeded
+
+The companion templates/networkpolicy.yaml allows egress on TCP/443 +
+TCP/6443 to ipBlock 0.0.0.0/0, which on every other CNI is sufficient
+to reach the apiserver. On Cilium it is NOT — Cilium models traffic to
+node IPs as a special `kube-apiserver` (or `host`/`remote-node`)
+reserved identity, NOT as a CIDR range. With the cluster-wide setting
+`policy-cidr-match-mode: ""` (the default, per bp-cilium values) the
+0.0.0.0/0 rule does NOT match traffic destined for the apiserver, so
+the apiserver call is dropped at the egress hook of the external-dns
+endpoint. Result: the symptom above on every fresh otech9X provision.
+
+Authoritative reference:
+  https://docs.cilium.io/en/stable/security/policy/language/#entities-based
+  https://docs.cilium.io/en/stable/security/policy/language/#policies-cidr-match-mode
+
+Two correct fixes exist:
+
+  (1) Set `policy-cidr-match-mode: nodes` cluster-wide on bp-cilium —
+      makes vanilla NetworkPolicy ipBlock rules match node IPs. This
+      is a global change with cluster-wide blast radius (silently
+      relaxes EVERY other NetworkPolicy that uses 0.0.0.0/0 in the
+      cluster); rejected because per INVIOLABLE-PRINCIPLES the fix
+      MUST be scoped to the workload that needs it.
+
+  (2) Pair the vanilla NetworkPolicy with a CiliumNetworkPolicy that
+      grants egress to the `kube-apiserver` reserved entity for ONLY
+      this Pod selector. This is the canonical Cilium pattern for
+      controllers that watch the apiserver. CHOSEN — fixes the
+      symptom without altering policy semantics for any other
+      workload.
+
+The companion vanilla NetworkPolicy is preserved verbatim so that a
+hypothetical non-Cilium CNI (none on Catalyst today, but the Blueprint
+must remain CNI-agnostic per BLUEPRINT-AUTHORING.md) still has
+apiserver egress via the 0.0.0.0/0 ipBlock.
+
+This file renders ONLY when both flags are true:
+  - externalDns.networkPolicy.enabled
+  - externalDns.networkPolicy.ciliumApiserverEntity.enabled
+The second defaults to TRUE because Cilium is the only CNI shipped by
+Catalyst (see ADR-0001 §"CNI is Cilium"). Cluster overlays running on
+non-Cilium CNIs MAY set it to false to avoid creating an unrecognised
+CRD; the vanilla NetworkPolicy alone covers them.
+
+Per INVIOLABLE-PRINCIPLES.md #4 every selector / port is operator-
+tunable via values.yaml.
+
+LIVE PROOF (otech93, 2026-05-04)
+─────────────────────────────────────────────────────────────────────
+Before: external-dns-5f596c748b-htr4z CrashLoopBackOff (8 restarts in
+20m), `failed to sync *v1.Endpoints: context deadline exceeded`.
+After applying this CNP: pod transitioned to Running 1/1 within ~30s,
+informer cache sync completed cleanly.
+*/}}
+{{- if and .Values.externalDns.networkPolicy.enabled .Values.externalDns.networkPolicy.ciliumApiserverEntity.enabled }}
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: bp-external-dns-apiserver
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "bp-external-dns.labels" . | nindent 4 }}
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: external-dns
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  egress:
+    # Cilium reserved identity that resolves to ALL endpoints backing
+    # the kube-apiserver (control-plane host IPs on host network +
+    # ClusterIP 10.43.0.1:443 on the kubernetes Service in default ns).
+    # This is the ONLY rule needed — Cilium short-circuits the lookup
+    # at the eBPF level so the egress hook returns ALLOW immediately
+    # rather than falling through to the vanilla NetworkPolicy.
+    - toEntities:
+        - kube-apiserver
+{{- end }}

--- a/platform/external-dns/chart/values.yaml
+++ b/platform/external-dns/chart/values.yaml
@@ -191,6 +191,29 @@ externalDns:
     powerdnsServiceName: powerdns
     powerdnsApiPort: 8081
 
+    # Companion CiliumNetworkPolicy that grants egress to the
+    # `kube-apiserver` reserved Cilium entity. REQUIRED on Cilium —
+    # see templates/ciliumnetworkpolicy.yaml header for the full
+    # diagnosis (issue #770).
+    #
+    # Short version: the vanilla NetworkPolicy egress rule
+    # `to: ipBlock: 0.0.0.0/0 ports: 443,6443` does NOT match traffic
+    # to the kube-apiserver under Cilium with the default
+    # `policy-cidr-match-mode: ""`. Cilium models the apiserver as a
+    # reserved identity, not a CIDR range, so the ipBlock rule is
+    # bypassed and the apiserver call is dropped. Without this CNP,
+    # ExternalDNS fails its initial `*v1.Endpoints` informer cache
+    # sync on every fresh Sovereign provision with:
+    #   fatal: failed to sync *v1.Endpoints: context deadline exceeded
+    # …and crashloops indefinitely.
+    #
+    # Default TRUE because Cilium is the canonical CNI per ADR-0001.
+    # Cluster overlays running on a non-Cilium CNI (none today) MAY
+    # set this to false; the vanilla NetworkPolicy 0.0.0.0/0 rule
+    # covers them.
+    ciliumApiserverEntity:
+      enabled: true
+
   # ServiceMonitor (Catalyst overlay variant) — ALSO default FALSE per the
   # observability-toggle rule. The upstream subchart's ServiceMonitor block
   # above governs scraping of external-dns itself; this Catalyst-side


### PR DESCRIPTION
## Summary

- **Root cause**: vanilla NetworkPolicy egress rule `to: ipBlock: 0.0.0.0/0 ports: 443,6443` does NOT match traffic to the kube-apiserver under Cilium (default `policy-cidr-match-mode: ""`). Cilium models the apiserver as a reserved identity, not a CIDR — so the ipBlock rule is bypassed and the apiserver call is dropped at the egress hook of the external-dns endpoint. ExternalDNS crashloops on every fresh otech9X with `fatal: failed to sync *v1.Endpoints: context deadline exceeded`.
- **Fix**: render a companion `CiliumNetworkPolicy` with `toEntities: [kube-apiserver]` scoped to the external-dns Pod selector. Canonical Cilium pattern for controllers that watch the apiserver. Existing vanilla NetworkPolicy preserved verbatim so Blueprint stays CNI-agnostic.
- **Bumps** bp-external-dns `1.1.6` → `1.1.7`.

## Live evidence (otech93, 2026-05-04)

```
# Before — pod logs:
fatal: failed to sync *v1.Node: context deadline exceeded
external-dns-5f596c748b-htr4z   0/1   CrashLoopBackOff   8 restarts in 20m

# Manual application of the rendered CNP to otech93:
$ kubectl --context=otech93 apply -f bp-external-dns-apiserver.yaml
ciliumnetworkpolicy.cilium.io/bp-external-dns-apiserver created

# 30s later:
external-dns-5f596c748b-htr4z   1/1   Running   8 restarts (6m ago)   25m
```

## Why not `policy-cidr-match-mode: nodes` cluster-wide on bp-cilium?

It silently relaxes EVERY other NetworkPolicy that uses `0.0.0.0/0` in the cluster — too broad a blast radius. Per INVIOLABLE-PRINCIPLES the fix MUST be scoped to the workload that needs it.

## Test plan

- [x] `helm lint` passes
- [x] `helm template` renders the CNP with correct selector + entity
- [x] Manual apply on otech93 → external-dns transitions to `1/1 Running` within 30s
- [ ] Blueprint Release CI builds and pushes `bp-external-dns:1.1.7` to GHCR
- [ ] Per-Sovereign overlays in `clusters/<sovereign>/bootstrap-kit/12-external-dns.yaml` pin to `1.1.7`
- [ ] Fresh otech provision: external-dns reaches `Ready` within ~3 min, PowerDNS records get created for ingresses

## DoD

- [ ] external-dns Pod stays Ready on a fresh otech provision
- [ ] PowerDNS records get created for ingresses on the Sovereign

🤖 Generated with [Claude Code](https://claude.com/claude-code)