### PR TITLE
fix(bp-trivy): node-collector tolerates control-plane taint (closes #769)

### DIFF
--- a/clusters/_template/bootstrap-kit/21-alloy.yaml
+++ b/clusters/_template/bootstrap-kit/21-alloy.yaml
@@ -56,7 +56,7 @@ spec:
   chart:
     spec:
       chart: bp-alloy
-      version: 1.0.0
+      version: 1.0.1
       sourceRef:
         kind: HelmRepository
         name: bp-alloy

--- a/clusters/_template/bootstrap-kit/30-trivy.yaml
+++ b/clusters/_template/bootstrap-kit/30-trivy.yaml
@@ -51,7 +51,7 @@ spec:
   chart:
     spec:
       chart: bp-trivy
-      version: 1.0.2
+      version: 1.0.3
       sourceRef:
         kind: HelmRepository
         name: bp-trivy

--- a/clusters/omantel.omani.works/bootstrap-kit/21-alloy.yaml
+++ b/clusters/omantel.omani.works/bootstrap-kit/21-alloy.yaml
@@ -56,7 +56,7 @@ spec:
   chart:
     spec:
       chart: bp-alloy
-      version: 1.0.0
+      version: 1.0.1
       sourceRef:
         kind: HelmRepository
         name: bp-alloy

--- a/clusters/omantel.omani.works/bootstrap-kit/30-trivy.yaml
+++ b/clusters/omantel.omani.works/bootstrap-kit/30-trivy.yaml
@@ -51,7 +51,7 @@ spec:
   chart:
     spec:
       chart: bp-trivy
-      version: 1.0.2
+      version: 1.0.3
       sourceRef:
         kind: HelmRepository
         name: bp-trivy

--- a/clusters/otech.omani.works/bootstrap-kit/21-alloy.yaml
+++ b/clusters/otech.omani.works/bootstrap-kit/21-alloy.yaml
@@ -56,7 +56,7 @@ spec:
   chart:
     spec:
       chart: bp-alloy
-      version: 1.0.0
+      version: 1.0.1
       sourceRef:
         kind: HelmRepository
         name: bp-alloy

--- a/clusters/otech.omani.works/bootstrap-kit/30-trivy.yaml
+++ b/clusters/otech.omani.works/bootstrap-kit/30-trivy.yaml
@@ -51,7 +51,7 @@ spec:
   chart:
     spec:
       chart: bp-trivy
-      version: 1.0.2
+      version: 1.0.3
       sourceRef:
         kind: HelmRepository
         name: bp-trivy

--- a/platform/alloy/chart/Chart.yaml
+++ b/platform/alloy/chart/Chart.yaml
@@ -12,7 +12,7 @@ description: |
   bp-mimir (metrics), bp-tempo (traces). Default controller is DaemonSet
   (one pod per node) so node + pod metrics + container logs are collected.
 type: application
-version: 1.0.0
+version: 1.0.1
 appVersion: "v1.16.0"
 keywords: [catalyst, blueprint, alloy, observability, otlp, telemetry, collector]
 maintainers:

--- a/platform/alloy/chart/values.yaml
+++ b/platform/alloy/chart/values.yaml
@@ -55,6 +55,17 @@ alloy:
   controller:
     type: daemonset
     replicas: 1
+    # Tolerations — Alloy is a DaemonSet; one pod MUST land on every node
+    # including the control plane so CP-local kubelet logs + node metrics
+    # are collected. PR #755 added a NoSchedule taint on the CP in multi-
+    # node Sovereigns; without this toleration Alloy sits at desired=N-1
+    # ready=N-1 and CP telemetry is silently lost (issue #769 audit). On
+    # solo Sovereigns (worker_count=0) the CP is untainted, so this
+    # toleration is a no-op.
+    tolerations:
+      - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+        effect: NoSchedule
 
   # ServiceMonitor — DEFAULT FALSE per docs/BLUEPRINT-AUTHORING.md §11.2.
   serviceMonitor:

--- a/platform/trivy/chart/Chart.yaml
+++ b/platform/trivy/chart/Chart.yaml
@@ -12,7 +12,7 @@ description: |
   secrets, infra assessments. Target namespaces follow the `bp-*` prefix
   convention so scan results align with Blueprint installation units.
 type: application
-version: 1.0.2
+version: 1.0.3
 appVersion: "0.30.1"
 keywords: [catalyst, blueprint, trivy, security, scanner, vulnerability]
 maintainers:

--- a/platform/trivy/chart/values.yaml
+++ b/platform/trivy/chart/values.yaml
@@ -76,6 +76,35 @@ trivy-operator:
     # Built-in policies — the upstream chart ships baseline policy bundle.
     builtInTrivyServer: false
 
+  # trivyOperator runtime config — values that the operator pod consumes
+  # at runtime via the trivy-operator-config ConfigMap (NOT the operator
+  # Deployment's own pod spec; that's the `operator:` block above).
+  trivyOperator:
+    # scanJobTolerations — applied by the operator to every scan-job pod
+    # it spawns dynamically (per-workload vuln + config-audit + RBAC scan
+    # jobs). Some target workloads (k8s-system DaemonSets, control-plane-
+    # pinned operators) live ONLY on the CP; without this toleration the
+    # scan jobs sit Pending and the matching reports are never produced.
+    # Pairs with the CP NoSchedule taint introduced in PR #755.
+    scanJobTolerations:
+      - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+        effect: NoSchedule
+
+  # node-collector — the operator spawns ONE node-collector pod per node
+  # (pinned via nodeSelector to each node's hostname) to read kubelet /
+  # etcd / kube-scheduler / kube-controller-manager config from hostPath.
+  # The CP node carries those control-plane config files, so the
+  # collector MUST land there. PR #755 added a NoSchedule taint on the CP
+  # in multi-node Sovereigns; without this toleration the CP-bound
+  # collector sits Pending forever (issue #769). On solo Sovereigns
+  # (worker_count=0) the CP is untainted, so this toleration is a no-op.
+  nodeCollector:
+    tolerations:
+      - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+        effect: NoSchedule
+
   # Resources for the operator pod itself.
   # 256Mi was too tight — operator manages scan jobs across 80+ pods and
   # each watch cache grows with cluster size. OOMKilled (exit 137) on otech22.


### PR DESCRIPTION
## Summary

Closes #769.

PR #755 added `node-role.kubernetes.io/control-plane=true:NoSchedule` to the CP node on multi-node Sovereigns. Two bootstrap-kit charts have pods that MUST land on the CP and lacked the matching toleration — adding it here.

### bp-trivy 1.0.2 → 1.0.3
- `nodeCollector.tolerations` — node-collector is pinned per-node via nodeSelector and the CP-bound pod reads `/var/lib/etcd`, `/var/lib/kubelet`, `/var/lib/kube-scheduler`, `/var/lib/kube-controller-manager` via hostPath (CP-only paths). On otech93 the CP-bound pod sat `Pending — FailedScheduling` forever. Live evidence in #769.
- `trivyOperator.scanJobTolerations` — per-workload scan jobs the operator spawns may target pods on CP-only system workloads. Adding the toleration so those reports are produced.

### bp-alloy 1.0.0 → 1.0.1
- `controller.tolerations` — Alloy is a DaemonSet; one pod MUST land on every node including the CP so CP kubelet logs + node metrics flow into the LGTM stack. On otech93 Alloy ran 3/4 nodes (CP telemetry silently lost).

Both tolerations are no-ops on solo Sovereigns (`worker_count=0`): the CP is untainted in solo mode per PR #755's conditional.

## Out of scope (audited, no change needed)

| Chart | DaemonSet/CP target? | Status |
|---|---|---|
| bp-cilium | DaemonSet | Upstream defaults tolerate everything — verified `cilium` DaemonSet at 4/4 nodes on otech93 |
| bp-falco | DaemonSet | values.yaml already declares `NoSchedule + NoExecute Exists` tolerations — 4/4 on otech93 |
| bp-cnpg / bp-harbor | (no kubelet-cert-renew Jobs in current charts) | n/a |

## Test plan

- [x] `helm template` on both charts renders the expected toleration
  - alloy: pod spec carries `node-role.kubernetes.io/control-plane:NoSchedule:Exists`
  - trivy: `trivy-operator-config` ConfigMap carries `nodeCollector.tolerations` + `scanJob.tolerations` JSON (consumed by the operator at scan-job spawn time)
- [x] `bash scripts/check-bootstrap-deps.sh` PASSED (no DAG drift)
- [ ] After merge: `Blueprint Release` workflow publishes `ghcr.io/openova-io/bp-trivy:1.0.3` and `bp-alloy:1.0.1`
- [ ] Next fresh multi-node Sovereign: trivy `node-collector-*` lands on CP and runs scans; alloy DaemonSet at 4/4 nodes.
- [ ] Solo Sovereign (`worker_count=0`): no regression — CP untainted, all pods schedule as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)