### PR TITLE
fix(decommission): live exec-log view (unified) — was 'stuck' banner (closes #766)

### DIFF
--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/DecommissionPage.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/DecommissionPage.test.tsx
@@ -33,21 +33,72 @@ import {
 import { DecommissionPage } from './DecommissionPage'
 
 // useDeploymentEvents — stub the hook so the page doesn't try to attach
-// an EventSource to a fake catalyst-api. The page only needs the
-// snapshot.sovereignFQDN to render the typed-confirmation hint.
+// an EventSource to a fake catalyst-api. The page needs:
+//   • snapshot.sovereignFQDN — the typed-confirmation hint.
+//   • state.eventsByTarget   — the unified LogPane log lines (issue
+//                              #766). The synthetic events below
+//                              mirror the real wipe-handler emissions
+//                              (phase="wipe") so the streaming-view
+//                              tests assert the LogPane renders them.
+//
+// `useDeploymentEventsLastOpts` records the most-recent invocation so
+// the streaming-view tests can assert that `disableStream: false` was
+// passed once the wipe POST landed (i.e. the SSE stream was actually
+// attached during decommission, not just left disabled like during the
+// pre-submit form view).
+const useDeploymentEventsLastOpts: { current: { disableStream?: boolean } } = {
+  current: {},
+}
 vi.mock('./useDeploymentEvents', () => ({
-  useDeploymentEvents: () => ({
-    state: {},
-    snapshot: {
-      sovereignFQDN: 'omantel.omani.works',
-      result: { sovereignFQDN: 'omantel.omani.works' },
-    },
-    streamStatus: 'completed',
-    streamError: null,
-    startedAt: null,
-    finishedAt: null,
-    retry: () => {},
-  }),
+  useDeploymentEvents: (opts: { disableStream?: boolean }) => {
+    useDeploymentEventsLastOpts.current = opts
+    return {
+      state: {
+        apps: {},
+        hetznerInfra: { status: 'pending', message: null, lastEventTime: null, seenResources: new Set() },
+        clusterBootstrap: { status: 'pending', message: null, lastEventTime: null },
+        phase1WatchSkipped: false,
+        phase1WatchSkippedReason: null,
+        eventsByTarget: {
+          // Synthetic wipe events — the catalyst-api emits these with
+          // phase="wipe" today; the reducer's fall-through routes them
+          // to the cluster-bootstrap bucket. The DecommissionPage
+          // flatten collects every bucket so the precise key here
+          // doesn't matter for the contract.
+          __cluster_bootstrap__: [
+            {
+              time: '2026-05-04T17:00:00Z',
+              phase: 'wipe',
+              level: 'info',
+              message: 'Wipe initiated for omantel.omani.works (was: failed)',
+            },
+            {
+              time: '2026-05-04T17:00:01Z',
+              phase: 'wipe',
+              level: 'info',
+              message: 'hetzner: Deleting LB lb-omantel-cp… Deleted (200)',
+            },
+            {
+              time: '2026-05-04T17:00:02Z',
+              phase: 'wipe',
+              level: 'info',
+              message:
+                'hetzner: Hetzner orphan purge removed 4 resource(s) (servers: 1, lbs: 1, networks: 1, firewalls: 1, ssh-keys: 0, s3-buckets: 0)',
+            },
+          ],
+        },
+      },
+      snapshot: {
+        sovereignFQDN: 'omantel.omani.works',
+        result: { sovereignFQDN: 'omantel.omani.works' },
+      },
+      streamStatus: 'completed',
+      streamError: null,
+      startedAt: null,
+      finishedAt: null,
+      retry: () => {},
+    }
+  },
 }))
 
 function renderPage(deploymentId: string) {
@@ -211,5 +262,137 @@ describe('DecommissionPage', () => {
     const errPre = await screen.findByTestId('decommission-error')
     expect(errPre.textContent).toContain('HTTP 400')
     expect(screen.queryByTestId('decommission-success')).toBeNull()
+  })
+})
+
+/* ── #766 — verbose live exec-log view during the wipe ──────────────
+ *
+ * Lock-in for the streaming view that replaces the static
+ * "Decommissioning…" banner. The wipe handler in api/internal/handler/
+ * wipe.go ALREADY emits a per-resource SSE stream — the page now
+ * subscribes to it via useDeploymentEvents and pipes the events
+ * through the unified LogPane (the same component /provision/<id>
+ * uses for per-job logs). Assertions:
+ *
+ *   1. While the wipe POST is in flight, the streaming layout (LogPane
+ *      + STREAMING chip + per-event log lines) is rendered, NOT the
+ *      pre-submit form.
+ *   2. The SSE stream is actually attached: the page passes
+ *      `disableStream: false` to useDeploymentEvents during streaming.
+ *   3. Once the wipe POST resolves, the layout flips to the COMPLETE
+ *      chip + green checkmark + Hetzner-sweep summary + countdown row.
+ *      The historical log is preserved (operator can scroll back).
+ *   4. The summary surfaces every Hetzner resource kind with the
+ *      removed count — the founder-verbatim "0 of every kind" DoD.
+ */
+describe('DecommissionPage — #766 streaming exec-log view', () => {
+  beforeEach(() => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async () => {
+      throw new Error('fetch should not be called by default')
+    })
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.restoreAllMocks()
+  })
+
+  it('renders the unified LogPane streaming layout while the wipe POST is in flight', async () => {
+    // Pending fetch — the wipe POST hangs forever for this test so we
+    // can observe the in-flight UI state without a race against the
+    // success handler.
+    vi.spyOn(globalThis, 'fetch').mockImplementation(
+      () => new Promise(() => {}) as Promise<Response>,
+    )
+    renderPage('dep-1')
+    fireEvent.change(await screen.findByTestId('decommission-confirm-text'), {
+      target: { value: 'omantel.omani.works' },
+    })
+    fireEvent.change(screen.getByTestId('decommission-hetzner-token'), {
+      target: { value: longHetznerToken },
+    })
+    fireEvent.click(screen.getByTestId('decommission-acknowledge'))
+    fireEvent.click(screen.getByTestId('decommission-submit'))
+
+    // Streaming layout appears, the form is gone.
+    await waitFor(() => screen.getByTestId('decommission-page-streaming'))
+    expect(screen.queryByTestId('decommission-page')).toBeNull()
+    expect(screen.getByTestId('decommission-streaming-spinner')).toBeTruthy()
+    expect(screen.getByTestId('decommission-log-host')).toBeTruthy()
+    expect(screen.getByTestId('log-pane')).toBeTruthy()
+
+    // Synthetic wipe events from the useDeploymentEvents mock are
+    // surfaced as LogPane fallback lines.
+    expect(screen.getByTestId('fallback-log-line-1')).toBeTruthy()
+    expect(screen.getByTestId('fallback-log-line-2')).toBeTruthy()
+    expect(screen.getByTestId('fallback-log-line-3')).toBeTruthy()
+    // Founder-verbatim phrasing — every resource deletion is visible.
+    expect(screen.getByText(/Deleting LB lb-omantel-cp/)).toBeTruthy()
+
+    // SSE stream is attached during streaming (NOT disabled).
+    expect(useDeploymentEventsLastOpts.current.disableStream).toBe(false)
+  })
+
+  it('flips to the COMPLETE chip + Hetzner-sweep summary + countdown when the wipe report arrives', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async () => {
+      return new Response(
+        JSON.stringify({
+          deploymentId: 'dep-1',
+          sovereignFQDN: 'omantel.omani.works',
+          tofuDestroyed: true,
+          hetznerPurge: {
+            servers: [],
+            load_balancers: [],
+            networks: [],
+            firewalls: [],
+            ssh_keys: [],
+            s3_buckets: [],
+            errors: [],
+          },
+          pdmReleased: true,
+          localCleaned: true,
+          errors: [],
+          wipedAt: '2026-05-04T17:05:00Z',
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      )
+    })
+
+    renderPage('dep-1')
+    fireEvent.change(await screen.findByTestId('decommission-confirm-text'), {
+      target: { value: 'omantel.omani.works' },
+    })
+    fireEvent.change(screen.getByTestId('decommission-hetzner-token'), {
+      target: { value: longHetznerToken },
+    })
+    fireEvent.click(screen.getByTestId('decommission-acknowledge'))
+    fireEvent.click(screen.getByTestId('decommission-submit'))
+
+    // Final state: COMPLETE chip + full sweep summary visible.
+    await waitFor(() => screen.getByTestId('decommission-streaming-checkmark'))
+    expect(screen.getByTestId('decommission-streaming-title').textContent).toContain(
+      'decommissioned',
+    )
+    const summary = screen.getByTestId('decommission-streaming-summary').textContent ?? ''
+    // Founder DoD — "0 of every kind" is visible in the summary block.
+    expect(summary).toContain('servers:        0 removed')
+    expect(summary).toContain('load_balancers: 0 removed')
+    expect(summary).toContain('networks:       0 removed')
+    expect(summary).toContain('firewalls:      0 removed')
+    expect(summary).toContain('ssh_keys:       0 removed')
+    expect(summary).toContain('s3_buckets:     0 removed')
+
+    // Countdown row surfaces an explicit "Returning to wizard" hint so
+    // operators know the auto-redirect is coming.
+    expect(screen.getByTestId('decommission-countdown').textContent).toMatch(
+      /Returning to wizard in \d+s/,
+    )
+
+    // Historical scrollback preserved — every wipe event is still in
+    // the LogPane after the report lands.
+    expect(screen.getByTestId('fallback-log-line-1')).toBeTruthy()
+
+    // The hidden marker for backwards compatibility.
+    expect(screen.getByTestId('decommission-success')).toBeTruthy()
   })
 })

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/DecommissionPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/DecommissionPage.tsx
@@ -1,5 +1,5 @@
 /**
- * DecommissionPage — Sovereign self-decommission surface (issue #319).
+ * DecommissionPage — Sovereign self-decommission surface (issue #319, #766).
  *
  * Reached from:
  *   • Catalyst-Zero ops shell:  /sovereign/decommission/$deploymentId
@@ -19,16 +19,43 @@
  * SSE-progress-rendering) is reused. The post-handover-specific delta
  * is the optional backup-destination selector and the copy.
  *
+ * Issue #766 — verbose live exec-log view during the wipe.
+ *
+ * Until #766 the page rendered a static "Decommissioning…" button label
+ * with no progress signal — operators thought the page was stuck while
+ * tofu destroy + the Hetzner orphan purge were running for 30+ minutes.
+ *
+ * The wipe handler in api/internal/handler/wipe.go ALREADY emits a per-
+ * resource SSE event stream on the same `dep.eventsCh` channel that
+ * provisioning uses, surfaced at GET /api/v1/deployments/{id}/logs.
+ * Every "tofu destroy" tick, every Hetzner DELETE response, every S3
+ * bucket purge step, every PDM release call, every local-state cleanup
+ * is already a discrete event with phase="wipe".
+ *
+ * The fix is purely UI — subscribe to the same SSE the wipe emits via
+ * useDeploymentEvents (no new endpoint, no protocol change), flatten
+ * every recorded event into a LogLine, and feed the unified LogPane
+ * (the same component /provision/<id> JobDetail uses for per-job logs).
+ *
+ * Per docs/INVIOLABLE-PRINCIPLES.md #1 (waterfall — target shape on
+ * first commit): full streaming view ships in this PR, with the
+ * scrollback, search, full-screen toggle, and final-state summary all
+ * threaded through the existing LogPane primitives. No "for now we'll
+ * just show a spinner" intermediate.
+ *
  * Scope contract with #317 (do NOT touch handover.go): #317 owns the
  * write side of `adoptedAt` (set by the handover handler). #319 owns
  * the read side (the redirect in router.tsx + this page) plus the
  * decommission flow that drains the minimum-retention surface.
  */
 
-import { useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { useParams, useRouter, Link } from '@tanstack/react-router'
 import { API_BASE } from '@/shared/config/urls'
+import { LogPane } from '@/components/LogPane'
+import type { LogLevel, LogLine } from '@/components/ExecutionLogs'
 import { useDeploymentEvents } from './useDeploymentEvents'
+import type { DeploymentEvent } from './eventReducer'
 import type { WipeReport } from '@/components/CrudModals/WipeDeploymentModal'
 
 /**
@@ -57,16 +84,37 @@ export interface BackupDestination {
   }
 }
 
+/**
+ * Map a raw catalyst-api event level to the LogLine vocabulary the
+ * unified ExecutionLogs / LogPane components understand. The wipe
+ * handler emits "info" and "warn" today; "error" is reserved for
+ * future fatal cases.
+ */
+function levelOf(ev: DeploymentEvent): LogLevel {
+  switch (ev.level) {
+    case 'error':
+      return 'ERROR'
+    case 'warn':
+      return 'WARN'
+    case 'info':
+    default:
+      return 'INFO'
+  }
+}
+
+/**
+ * Auto-redirect countdown (seconds) after a successful decommission
+ * before the page navigates back to /wizard. Operators can click the
+ * "Provision a new Sovereign" button at any point to skip the wait.
+ *
+ * Per #4 (never hardcode), this is exported as a named constant the
+ * test suite can reference rather than inlining a magic number.
+ */
+export const DECOMMISSION_REDIRECT_SECONDS = 10
+
 export function DecommissionPage() {
   const { deploymentId } = useParams({ strict: false }) as { deploymentId: string }
   const router = useRouter()
-  const { snapshot } = useDeploymentEvents({
-    deploymentId,
-    applicationIds: [],
-    disableStream: true,
-  })
-  const sovereignFQDN =
-    snapshot?.sovereignFQDN ?? snapshot?.result?.sovereignFQDN ?? 'unknown'
 
   const [confirmText, setConfirmText] = useState('')
   const [hetznerToken, setHetznerToken] = useState('')
@@ -75,6 +123,63 @@ export function DecommissionPage() {
   const [busy, setBusy] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [report, setReport] = useState<WipeReport | null>(null)
+  const [redirectCountdown, setRedirectCountdown] = useState<number | null>(null)
+
+  // Subscribe to the live event stream:
+  //
+  //   • Pre-submit  — disable the EventSource so the form view is
+  //                   inert (matches existing test expectations and
+  //                   avoids holding an SSE connection open while the
+  //                   operator types their FQDN confirmation).
+  //   • Post-submit — open the stream so every wipe event the API
+  //                   emits (tofu destroy, Hetzner orphan purge per
+  //                   resource, S3 bucket purge, PDM release, local
+  //                   state cleanup) flows through the reducer and
+  //                   into the LogPane below.
+  //
+  // The `snapshot.sovereignFQDN` is also surfaced from this hook for
+  // the typed-confirmation hint, irrespective of whether the stream
+  // is attached.
+  const streaming = busy || report !== null
+  const { state: streamState, snapshot } = useDeploymentEvents({
+    deploymentId,
+    applicationIds: [],
+    disableStream: !streaming,
+  })
+  const sovereignFQDN =
+    snapshot?.sovereignFQDN ?? snapshot?.result?.sovereignFQDN ?? 'unknown'
+
+  // Flatten every event the reducer routed into ANY bucket
+  // (eventsByTarget keyed by HETZNER_INFRA / CLUSTER_BOOTSTRAP / per-
+  // app), de-duplicate by identity, and order by timestamp. The wipe
+  // handler emits all events under phase="wipe" today which the
+  // reducer fall-throughs route to CLUSTER_BOOTSTRAP_KEY — the
+  // pageful flatten below collects every bucket so we never silently
+  // drop an event because of a future reducer rule change.
+  const wipeLogLines: LogLine[] = useMemo(() => {
+    const collected: DeploymentEvent[] = []
+    const seen = new Set<DeploymentEvent>()
+    const buckets = streamState?.eventsByTarget ?? {}
+    for (const arr of Object.values(buckets)) {
+      if (!Array.isArray(arr)) continue
+      for (const ev of arr) {
+        if (seen.has(ev)) continue
+        seen.add(ev)
+        collected.push(ev)
+      }
+    }
+    collected.sort((a, b) => {
+      const at = a.time ? Date.parse(a.time) : 0
+      const bt = b.time ? Date.parse(b.time) : 0
+      return at - bt
+    })
+    return collected.map<LogLine>((ev, idx) => ({
+      lineNumber: idx + 1,
+      timestamp: ev.time ?? new Date().toISOString(),
+      level: levelOf(ev),
+      message: ev.message ?? '',
+    }))
+  }, [streamState])
 
   const fqdnConfirmed = confirmText.trim() === sovereignFQDN
   const hetznerOK = hetznerToken.trim().length > 20
@@ -88,6 +193,23 @@ export function DecommissionPage() {
       !!backup.s3?.secretKey)
 
   const ready = fqdnConfirmed && hetznerOK && acceptedDataLoss && backupOK && !busy
+
+  // Auto-redirect countdown — fires when the wipe POST resolves with
+  // a final report, ticks once per second, navigates to /wizard at 0.
+  useEffect(() => {
+    if (!report) return
+    setRedirectCountdown(DECOMMISSION_REDIRECT_SECONDS)
+    let remaining = DECOMMISSION_REDIRECT_SECONDS
+    const interval = setInterval(() => {
+      remaining -= 1
+      setRedirectCountdown(remaining)
+      if (remaining <= 0) {
+        clearInterval(interval)
+        router.navigate({ to: '/wizard' })
+      }
+    }, 1000)
+    return () => clearInterval(interval)
+  }, [report, router])
 
   async function performDecommission() {
     setBusy(true)
@@ -124,54 +246,151 @@ export function DecommissionPage() {
     }
   }
 
-  if (report) {
+  // Streaming exec-log view — rendered while the wipe is in flight or
+  // after it completed (so the operator can scroll back through every
+  // deletion). Built around the same LogPane component the unified
+  // /provision/<id> JobDetail surface uses; passes the live event log
+  // via fallbackLines (no per-execution row exists for the wipe).
+  if (streaming) {
+    const summary = renderHetznerSummary(report)
     return (
       <main
-        data-testid="decommission-success"
-        className="mx-auto max-w-2xl p-8 text-[var(--color-text)]"
+        data-testid="decommission-page-streaming"
+        className="mx-auto max-w-4xl p-8 text-[var(--color-text)]"
       >
-        <h1 className="text-2xl font-semibold">Sovereign decommissioned</h1>
-        <p className="mt-2 text-sm text-[var(--color-text-dim)]">
-          {report.sovereignFQDN} has been wiped. Hetzner resources removed:{' '}
-          {(report.hetznerPurge.servers?.length ?? 0)} servers,{' '}
-          {(report.hetznerPurge.load_balancers?.length ?? 0)} load balancers,{' '}
-          {(report.hetznerPurge.networks?.length ?? 0)} networks,{' '}
-          {(report.hetznerPurge.firewalls?.length ?? 0)} firewalls,{' '}
-          {(report.hetznerPurge.ssh_keys?.length ?? 0)} ssh-keys,{' '}
-          {(report.hetznerPurge.s3_buckets?.length ?? 0)} S3 buckets.
-          {(report.hetznerPurge.firewalls_retried ?? 0) > 0 ? (
-            <>
-              {' '}
-              <span>
-                ({report.hetznerPurge.firewalls_retried} firewall delete retr
-                {report.hetznerPurge.firewalls_retried === 1 ? 'y' : 'ies'} while
-                server detach completed)
-              </span>
-            </>
-          ) : null}
+        <header className="mb-4 flex flex-wrap items-center gap-3">
+          <h1 className="text-2xl font-semibold" data-testid="decommission-streaming-title">
+            {report ? 'Sovereign decommissioned' : 'Decommissioning Sovereign'}
+          </h1>
+          <span
+            data-testid="decommission-streaming-fqdn"
+            className="rounded bg-[var(--color-bg-2)] px-2 py-0.5 font-mono text-xs"
+          >
+            {sovereignFQDN}
+          </span>
+          {report ? (
+            <span
+              data-testid="decommission-streaming-checkmark"
+              aria-label="Decommission complete"
+              className="inline-flex h-7 items-center gap-1 rounded-full border border-emerald-400/50 bg-emerald-500/10 px-3 text-xs font-semibold text-emerald-300"
+            >
+              <svg width="14" height="14" viewBox="0 0 14 14" aria-hidden>
+                <path
+                  d="M3 7.5 L6 10.5 L11 4.5"
+                  stroke="currentColor"
+                  strokeWidth="1.8"
+                  fill="none"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+              Complete
+            </span>
+          ) : (
+            <span
+              data-testid="decommission-streaming-spinner"
+              className="inline-flex h-7 items-center gap-2 rounded-full border border-sky-400/50 bg-sky-500/10 px-3 text-xs font-semibold text-sky-300"
+            >
+              <span
+                aria-hidden
+                className="inline-block h-2 w-2 animate-pulse rounded-full bg-sky-300"
+              />
+              Streaming
+            </span>
+          )}
+        </header>
+
+        <p className="text-sm text-[var(--color-text-dim)]">
+          {report
+            ? 'Every Hetzner resource, the PDM allocation, and the local deployment record have been removed. The full event log below is preserved for audit — scroll back through every deletion.'
+            : 'Live progress streamed from catalyst-api. Every tofu destroy step, every Hetzner resource DELETE, every S3 bucket purge, every PDM release, and every local cleanup step appears below as it happens.'}
         </p>
-        <p className="mt-1 text-sm text-[var(--color-text-dim)]">
-          PDM allocation released: {report.pdmReleased ? 'yes' : 'n/a (BYO)'} ·
-          tofu destroy: {report.tofuDestroyed ? '✓' : '✗'} · local state cleaned: {report.localCleaned ? '✓' : '✗'}
-        </p>
-        {report.errors && report.errors.length > 0 ? (
+
+        {summary ? (
+          <pre
+            data-testid="decommission-streaming-summary"
+            className="mt-3 whitespace-pre-wrap rounded-md border border-[var(--color-border)] bg-[var(--color-bg-2)] p-3 text-xs text-[var(--color-text)]"
+          >
+            {summary}
+          </pre>
+        ) : null}
+
+        {error ? (
+          <pre
+            data-testid="decommission-error"
+            className="mt-3 whitespace-pre-wrap rounded-md bg-[var(--color-bg-2)] p-3 text-xs text-rose-300"
+          >
+            {error}
+          </pre>
+        ) : null}
+
+        {report ? (
+          <div
+            className="mt-4 flex flex-wrap items-center gap-3"
+            data-testid="decommission-redirect-row"
+          >
+            <button
+              type="button"
+              onClick={() => router.navigate({ to: '/wizard' })}
+              className="rounded-md border border-[var(--color-border)] bg-[var(--color-bg-2)] px-4 py-2 text-sm hover:border-[var(--color-accent)]"
+              data-testid="decommission-finish"
+            >
+              Provision a new Sovereign
+            </button>
+            <span
+              className="text-xs text-[var(--color-text-dim)]"
+              data-testid="decommission-countdown"
+            >
+              Returning to wizard in {Math.max(0, redirectCountdown ?? DECOMMISSION_REDIRECT_SECONDS)}s…
+            </span>
+          </div>
+        ) : null}
+
+        {/*
+          Unified LogPane — same component /provision/<id> uses for
+          per-job ExecutionLogs. We have no Bridge-allocated execution
+          row for the wipe, so we feed events through the
+          fallbackLines surface (Bug #481 path). The LogPane provides
+          search, full-screen toggle, scrollback, and the same dark/
+          light themed presentation as every other exec-log surface.
+        */}
+        <div data-testid="decommission-log-host" className="relative mt-6">
+          <LogPane
+            executionId={null}
+            fallbackLines={wipeLogLines}
+            jobTitle={`Decommission · ${sovereignFQDN}`}
+            statusLabel={report ? 'COMPLETE' : 'STREAMING'}
+            statusTone={report ? 'succeeded' : 'running'}
+            onClose={() => {
+              if (report) router.navigate({ to: '/wizard' })
+            }}
+          />
+        </div>
+
+        {report && report.errors && report.errors.length > 0 ? (
           <pre
             data-testid="decommission-errors"
-            className="mt-4 rounded-md bg-[var(--color-bg-2)] p-3 text-xs text-amber-300 whitespace-pre-wrap"
+            className="mt-4 whitespace-pre-wrap rounded-md bg-[var(--color-bg-2)] p-3 text-xs text-amber-300"
           >
             {report.errors.join('\n')}
           </pre>
         ) : null}
-        <div className="mt-6">
-          <button
-            type="button"
-            onClick={() => router.navigate({ to: '/wizard' })}
-            className="rounded-md border border-[var(--color-border)] bg-[var(--color-bg-2)] px-4 py-2 text-sm hover:border-[var(--color-accent)]"
-            data-testid="decommission-finish"
+
+        {report ? (
+          <div
+            data-testid="decommission-success"
+            aria-hidden
+            style={{ display: 'none' }}
           >
-            Provision a new Sovereign
-          </button>
-        </div>
+            {/*
+              Hidden marker preserved for the existing test that
+              awaits `decommission-success` after submit. The visible
+              UI is the streaming layout above; this marker keeps the
+              contract with DecommissionPage.test.tsx without forking
+              two render paths.
+            */}
+          </div>
+        ) : null}
       </main>
     )
   }
@@ -365,4 +584,42 @@ export function DecommissionPage() {
       </div>
     </main>
   )
+}
+
+/**
+ * Render a one-line-per-resource-kind summary of the final wipe report,
+ * mirroring the founder-verbatim shape from issue #766:
+ *
+ *     Hetzner sweep complete:
+ *       servers:        0
+ *       load_balancers: 0
+ *       networks:       0
+ *       firewalls:      0
+ *       ssh_keys:       0
+ *       s3_buckets:     0
+ *
+ * Returns null until the wipe report has actually arrived, so callers
+ * can `if (summary)` without a separate flag.
+ */
+function renderHetznerSummary(report: WipeReport | null): string | null {
+  if (!report) return null
+  const purge = report.hetznerPurge
+  const lines = [
+    `Hetzner sweep complete for ${report.sovereignFQDN}:`,
+    `  servers:        ${(purge.servers?.length ?? 0)} removed`,
+    `  load_balancers: ${(purge.load_balancers?.length ?? 0)} removed`,
+    `  networks:       ${(purge.networks?.length ?? 0)} removed`,
+    `  firewalls:      ${(purge.firewalls?.length ?? 0)} removed`,
+    `  ssh_keys:       ${(purge.ssh_keys?.length ?? 0)} removed`,
+    `  s3_buckets:     ${(purge.s3_buckets?.length ?? 0)} removed`,
+    `tofu destroy: ${report.tofuDestroyed ? '✓' : '✗'}` +
+      ` · PDM released: ${report.pdmReleased ? '✓' : 'n/a (BYO)'}` +
+      ` · local state cleaned: ${report.localCleaned ? '✓' : '✗'}`,
+  ]
+  if (purge.firewalls_retried && purge.firewalls_retried > 0) {
+    lines.push(
+      `  (firewall delete retr${purge.firewalls_retried === 1 ? 'y' : 'ies'}: ${purge.firewalls_retried} while server detach completed)`,
+    )
+  }
+  return lines.join('\n')
 }


### PR DESCRIPTION
## Summary

- `/sovereign/decommission/<id>` used to render a static "Decommissioning…" button with no progress signal — operators thought the page was stuck while `tofu destroy` + the Hetzner orphan purge ran for 30+ minutes.
- The wipe handler already emits a per-resource SSE stream on the same `dep.eventsCh` channel as provisioning (`GET /api/v1/deployments/{id}/logs`); this PR is purely a UI subscription, no backend change.
- The page now mounts the unified `LogPane` (same component `/provision/<id>` JobDetail uses for per-job logs) for the lifetime of the wipe — every event surfaces live with scrollback, search, full-screen toggle.
- On completion: COMPLETE chip + green checkmark + per-resource-kind Hetzner sweep summary + 10s countdown back to `/wizard`.

## Test plan

- [x] `npx vitest run src/pages/sovereign/DecommissionPage.test.tsx` — 7/7 pass (5 original + 2 new locking in the #766 streaming layout)
- [x] `npx tsc --noEmit` — clean
- [ ] After merge + image build: visit `console.openova.io/sovereign/decommission/<id>` for an in-flight wipe, confirm streaming + scrollback + final summary + countdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)