### PR TITLE
feat(provision): one-click kubeconfig download + merge for k9s parity (closes #765)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/kubeconfig.go
+++ b/products/catalyst/bootstrap/api/internal/handler/kubeconfig.go
@@ -51,7 +51,19 @@
 // GET semantics (unchanged contract for operator break-glass /
 // wizard "Download kubeconfig"):
 //
-//   - 200 application/yaml when KubeconfigPath is set and readable
+//   - 200 application/yaml when KubeconfigPath is set and readable.
+//     The bytes returned are the ON-DISK file with the cluster /
+//     context / user names rewritten from k3s's hardcoded `default`
+//     to the Sovereign's subdomain (e.g. `otech94`) so the operator
+//     can run `KUBECONFIG=$HOME/.kube/config:<file> kubectl config
+//     view --flatten > $HOME/.kube/config` and then
+//     `k9s --context=otech94` immediately, with no manual sed
+//     pipeline. Issue #765. The rename is idempotent (re-applying
+//     to an already-renamed file is a no-op) and preserves the
+//     certificate-authority-data + token bytes verbatim. If the
+//     YAML is not parseable as a kubeconfig we serve the bytes
+//     unmodified so an operator's hand-edited file is never
+//     corrupted by the rewriter.
 //   - 409 {"error":"not-implemented"} when the postback hasn't
 //     happened yet — preserves the StepSuccess.test.tsx fallback.
 //   - 409 {"error":"kubeconfig-file-missing"} when the path pointer
@@ -70,7 +82,9 @@
 package handler
 
 import (
+	"bytes"
 	"crypto/subtle"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -80,6 +94,7 @@ import (
 	"time"
 
 	"github.com/go-chi/chi/v5"
+	"gopkg.in/yaml.v3"
 
 	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/helmwatch"
 	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/provisioner"
@@ -139,17 +154,238 @@ func (h *Handler) GetKubeconfig(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Issue #765 — rewrite cluster / context / user names from
+	// k3s's hardcoded `default` to the Sovereign's subdomain so the
+	// operator can `k9s --context=otech94` after a single
+	// `kubectl config view --flatten` merge without manually
+	// sed-ing the YAML. The on-disk file is left as the cloud-init
+	// produced it; the rewrite happens on the response only so the
+	// PUT idempotency invariant holds. If the rewrite fails we serve
+	// the raw bytes unchanged — better to give the operator the
+	// k3s-default-context kubeconfig than fail the download.
+	contextName := preferredContextName(&dep.Request)
+	served := raw
+	if rewritten, rewriteErr := rewriteKubeconfigContext(raw, contextName); rewriteErr == nil {
+		served = rewritten
+	} else {
+		h.log.Warn("kubeconfig context rewrite failed; serving raw file",
+			"id", id,
+			"sovereignFQDN", dep.Request.SovereignFQDN,
+			"contextName", contextName,
+			"err", rewriteErr,
+		)
+	}
+
+	// Filename uses the subdomain when available so a freshly-
+	// downloaded file lands in ~/Downloads as `otech94.yaml` rather
+	// than `otech94.omantel.omani.works-kubeconfig.yaml` which is
+	// awkward to type in a `KUBECONFIG=...` invocation.
 	w.Header().Set("Content-Type", "application/yaml")
 	w.Header().Set("Content-Disposition",
-		`attachment; filename="`+dep.Request.SovereignFQDN+`-kubeconfig.yaml"`)
+		`attachment; filename="`+kubeconfigDownloadFilename(&dep.Request)+`"`)
 	w.WriteHeader(http.StatusOK)
-	_, _ = w.Write(raw)
+	_, _ = w.Write(served)
 
 	h.log.Info("kubeconfig served",
 		"id", id,
 		"sovereignFQDN", dep.Request.SovereignFQDN,
-		"bytes", len(raw),
+		"contextName", contextName,
+		"bytesRaw", len(raw),
+		"bytesServed", len(served),
 	)
+}
+
+// preferredContextName returns the kubeconfig context name to use
+// when serving GET /kubeconfig. Issue #765 spec: "context name =
+// otechN (not default)". Order of preference:
+//
+//  1. Request.SovereignSubdomain — set by the wizard for every
+//     pool-mode deployment (e.g. "otech94"). Sanitised to a safe
+//     k8s context name (RFC 1123-ish: lowercase alnum + dash).
+//  2. First label of SovereignFQDN — for BYO-domain deployments
+//     where SovereignSubdomain is empty (e.g. "k8s.foo.example"
+//     → "k8s").
+//  3. The literal string "sovereign" — last-resort fallback so the
+//     YAML never contains an empty context name (which kubectl
+//     refuses to parse).
+//
+// The returned value is always non-empty.
+func preferredContextName(req *provisioner.Request) string {
+	if req == nil {
+		return "sovereign"
+	}
+	if name := sanitiseContextName(req.SovereignSubdomain); name != "" {
+		return name
+	}
+	if fqdn := strings.TrimSpace(req.SovereignFQDN); fqdn != "" {
+		first := fqdn
+		if dot := strings.IndexByte(first, '.'); dot > 0 {
+			first = first[:dot]
+		}
+		if name := sanitiseContextName(first); name != "" {
+			return name
+		}
+	}
+	return "sovereign"
+}
+
+// sanitiseContextName strips characters kubectl rejects in a
+// context name. kubeconfig technically accepts any string, but
+// $HOME/.kube/config consumers (k9s, kubectl config use-context,
+// kubeconform) treat it as a CLI argument so we restrict to the
+// RFC-1123 lowercase label charset (alphanumeric + dash) and trim
+// leading / trailing dashes.
+func sanitiseContextName(in string) string {
+	in = strings.ToLower(strings.TrimSpace(in))
+	if in == "" {
+		return ""
+	}
+	var b strings.Builder
+	for _, r := range in {
+		switch {
+		case r >= 'a' && r <= 'z':
+			b.WriteRune(r)
+		case r >= '0' && r <= '9':
+			b.WriteRune(r)
+		case r == '-':
+			b.WriteRune(r)
+		}
+	}
+	out := strings.Trim(b.String(), "-")
+	return out
+}
+
+// kubeconfigDownloadFilename builds the Content-Disposition
+// filename. Prefers the subdomain (operator's mental model — they
+// know "otech94" not "otech94.omantel.omani.works"); falls back to
+// the FQDN when subdomain is empty.
+func kubeconfigDownloadFilename(req *provisioner.Request) string {
+	if req == nil {
+		return "sovereign-kubeconfig.yaml"
+	}
+	if sub := sanitiseContextName(req.SovereignSubdomain); sub != "" {
+		return sub + ".yaml"
+	}
+	if fqdn := strings.TrimSpace(req.SovereignFQDN); fqdn != "" {
+		return fqdn + "-kubeconfig.yaml"
+	}
+	return "sovereign-kubeconfig.yaml"
+}
+
+// rewriteKubeconfigContext rewrites every reference to the k3s
+// default cluster / context / user name to `target` so a downloaded
+// kubeconfig merges into $HOME/.kube/config under a stable, human-
+// readable context name. Specifically rewrites:
+//
+//   - clusters[].name
+//   - contexts[].name
+//   - contexts[].context.cluster
+//   - contexts[].context.user
+//   - users[].name
+//   - current-context
+//
+// Only renames the entry whose existing name == "default" (the
+// k3s seed). Other named entries are left alone so an operator's
+// hand-merged file isn't clobbered. A round-trip through yaml.v3
+// preserves field ordering + comments so the file diffs cleanly.
+//
+// A nil/empty target is rejected (the caller computes a non-empty
+// fallback). A YAML parse failure or a structurally unexpected
+// document (no `kind: Config` root, no `clusters` key) returns the
+// input unchanged with no error so a hand-edited or future-format
+// kubeconfig is never silently corrupted — the GET handler logs
+// the warning and serves raw on rewrite-error path.
+func rewriteKubeconfigContext(in []byte, target string) ([]byte, error) {
+	target = strings.TrimSpace(target)
+	if target == "" {
+		return nil, errors.New("rewriteKubeconfigContext: target context name is empty")
+	}
+	if len(in) == 0 {
+		return nil, errors.New("rewriteKubeconfigContext: input is empty")
+	}
+
+	var root yaml.Node
+	if err := yaml.Unmarshal(in, &root); err != nil {
+		return nil, fmt.Errorf("yaml parse: %w", err)
+	}
+	if root.Kind != yaml.DocumentNode || len(root.Content) == 0 {
+		return nil, errors.New("rewriteKubeconfigContext: not a YAML document")
+	}
+	doc := root.Content[0]
+	if doc.Kind != yaml.MappingNode {
+		return nil, errors.New("rewriteKubeconfigContext: root is not a mapping")
+	}
+
+	// Validate kind: Config (the kubeconfig sentinel). If absent
+	// or wrong, refuse to rewrite — caller will serve raw.
+	if kind := mapStringValue(doc, "kind"); kind != "" && kind != "Config" {
+		return nil, fmt.Errorf("rewriteKubeconfigContext: unexpected kind %q", kind)
+	}
+
+	// rename rewrites a string scalar field on a mapping node from
+	// "default" to target. No-op if the field is missing or the
+	// value is not the k3s default (idempotent re-apply).
+	rename := func(n *yaml.Node, key string) {
+		if n == nil || n.Kind != yaml.MappingNode {
+			return
+		}
+		v := mapChild(n, key)
+		if v == nil || v.Kind != yaml.ScalarNode {
+			return
+		}
+		if v.Value == "default" {
+			v.Value = target
+			v.Tag = "!!str"
+			v.Style = 0
+		}
+	}
+
+	// Iterate clusters[], contexts[], users[] sequences.
+	renameSeq := func(seqKey string, perItem func(*yaml.Node)) {
+		seq := mapChild(doc, seqKey)
+		if seq == nil || seq.Kind != yaml.SequenceNode {
+			return
+		}
+		for _, item := range seq.Content {
+			if item.Kind == yaml.MappingNode {
+				perItem(item)
+			}
+		}
+	}
+
+	renameSeq("clusters", func(item *yaml.Node) {
+		rename(item, "name")
+	})
+	renameSeq("contexts", func(item *yaml.Node) {
+		rename(item, "name")
+		ctx := mapChild(item, "context")
+		if ctx != nil && ctx.Kind == yaml.MappingNode {
+			rename(ctx, "cluster")
+			rename(ctx, "user")
+		}
+	})
+	renameSeq("users", func(item *yaml.Node) {
+		rename(item, "name")
+	})
+
+	// Top-level current-context.
+	if cc := mapChild(doc, "current-context"); cc != nil && cc.Kind == yaml.ScalarNode && cc.Value == "default" {
+		cc.Value = target
+		cc.Tag = "!!str"
+		cc.Style = 0
+	}
+
+	var out bytes.Buffer
+	enc := yaml.NewEncoder(&out)
+	enc.SetIndent(2)
+	if err := enc.Encode(&root); err != nil {
+		_ = enc.Close()
+		return nil, fmt.Errorf("yaml encode: %w", err)
+	}
+	if err := enc.Close(); err != nil {
+		return nil, fmt.Errorf("yaml encoder close: %w", err)
+	}
+	return out.Bytes(), nil
 }
 
 // PutKubeconfig — PUT /api/v1/deployments/{id}/kubeconfig.

--- a/products/catalyst/bootstrap/api/internal/handler/kubeconfig_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/kubeconfig_test.go
@@ -462,8 +462,28 @@ func TestGetKubeconfig_ReadsFromPathPointer(t *testing.T) {
 	if wGet.Code != http.StatusOK {
 		t.Fatalf("GET status = %d, want 200; body=%s", wGet.Code, wGet.Body.String())
 	}
-	if got := wGet.Body.String(); got != validKubeconfigYAML {
-		t.Errorf("GET body drift: got %q want %q", got, validKubeconfigYAML)
+	// Issue #765 — GET response is the on-disk YAML with the
+	// context names rewritten from `default` to the Sovereign's
+	// subdomain (or first label of FQDN when subdomain is empty).
+	// The fixture's FQDN is "test.<id>.example" and Subdomain is
+	// empty, so the expected context name is "test". Sensitive
+	// payload (CA, token) MUST be preserved verbatim — that's the
+	// load-bearing invariant of the rewriter.
+	got := wGet.Body.String()
+	if strings.Contains(got, "name: default") {
+		t.Errorf("rewritten kubeconfig still contains `name: default`:\n%s", got)
+	}
+	if !strings.Contains(got, "name: test") {
+		t.Errorf("rewritten kubeconfig missing rewritten context `name: test`:\n%s", got)
+	}
+	if !strings.Contains(got, "current-context: test") {
+		t.Errorf("rewritten kubeconfig missing `current-context: test`:\n%s", got)
+	}
+	if !strings.Contains(got, "TEST-CA-MARKER") {
+		t.Errorf("rewriter dropped certificate-authority-data sentinel:\n%s", got)
+	}
+	if !strings.Contains(got, "TEST-USER-TOKEN-MARKER") {
+		t.Errorf("rewriter dropped user-token sentinel:\n%s", got)
 	}
 	if ct := wGet.Header().Get("Content-Type"); ct != "application/yaml" {
 		t.Errorf("Content-Type = %q, want application/yaml", ct)
@@ -806,5 +826,249 @@ func TestExtractBearer_RFC6750(t *testing.T) {
 				t.Errorf("extractBearer(%q) = %q, want %q", c.header, got, c.want)
 			}
 		})
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────
+// Issue #765 — context-rewrite helpers + GET behaviour
+// ─────────────────────────────────────────────────────────────────
+
+func TestPreferredContextName(t *testing.T) {
+	cases := []struct {
+		name string
+		req  provisioner.Request
+		want string
+	}{
+		{
+			name: "subdomain-wins",
+			req:  provisioner.Request{SovereignSubdomain: "otech94", SovereignFQDN: "otech94.omantel.omani.works"},
+			want: "otech94",
+		},
+		{
+			name: "subdomain-uppercase-normalised",
+			req:  provisioner.Request{SovereignSubdomain: "OTECH-Beta", SovereignFQDN: "otech-beta.foo.example"},
+			want: "otech-beta",
+		},
+		{
+			name: "fqdn-fallback-when-subdomain-empty",
+			req:  provisioner.Request{SovereignFQDN: "k8s.byo.example.com"},
+			want: "k8s",
+		},
+		{
+			name: "all-empty-fallback",
+			req:  provisioner.Request{},
+			want: "sovereign",
+		},
+		{
+			name: "subdomain-with-junk-stripped",
+			req:  provisioner.Request{SovereignSubdomain: "  otech_99!  "},
+			want: "otech99",
+		},
+		{
+			name: "subdomain-all-junk-falls-through-to-fqdn",
+			req:  provisioner.Request{SovereignSubdomain: "@@@", SovereignFQDN: "abc.example"},
+			want: "abc",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := preferredContextName(&c.req)
+			if got != c.want {
+				t.Errorf("preferredContextName(%+v) = %q, want %q", c.req, got, c.want)
+			}
+		})
+	}
+	// Nil-request safety net so callers can pass &dep.Request unchecked.
+	if got := preferredContextName(nil); got != "sovereign" {
+		t.Errorf("preferredContextName(nil) = %q, want sovereign", got)
+	}
+}
+
+func TestKubeconfigDownloadFilename(t *testing.T) {
+	cases := []struct {
+		name string
+		req  provisioner.Request
+		want string
+	}{
+		{"subdomain", provisioner.Request{SovereignSubdomain: "otech94"}, "otech94.yaml"},
+		{"fqdn-fallback", provisioner.Request{SovereignFQDN: "test.example"}, "test.example-kubeconfig.yaml"},
+		{"empty", provisioner.Request{}, "sovereign-kubeconfig.yaml"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := kubeconfigDownloadFilename(&c.req)
+			if got != c.want {
+				t.Errorf("kubeconfigDownloadFilename(%+v) = %q, want %q", c.req, got, c.want)
+			}
+		})
+	}
+}
+
+// TestRewriteKubeconfigContext_K3sDefault is the load-bearing
+// rewriter test. Given a k3s-style kubeconfig with `name: default`
+// in cluster, context, user, and current-context, the rewriter
+// MUST replace every occurrence with the target context name and
+// preserve the certificate-authority-data + token bytes verbatim.
+func TestRewriteKubeconfigContext_K3sDefault(t *testing.T) {
+	out, err := rewriteKubeconfigContext([]byte(validKubeconfigYAML), "otech94")
+	if err != nil {
+		t.Fatalf("rewrite: %v", err)
+	}
+	got := string(out)
+	if strings.Contains(got, "name: default") {
+		t.Errorf("rewriter left `name: default` in output:\n%s", got)
+	}
+	if !strings.Contains(got, "name: otech94") {
+		t.Errorf("rewriter missing `name: otech94`:\n%s", got)
+	}
+	if !strings.Contains(got, "cluster: otech94") {
+		t.Errorf("rewriter missing `cluster: otech94` in context block:\n%s", got)
+	}
+	if !strings.Contains(got, "user: otech94") {
+		t.Errorf("rewriter missing `user: otech94` in context block:\n%s", got)
+	}
+	if !strings.Contains(got, "current-context: otech94") {
+		t.Errorf("rewriter missing `current-context: otech94`:\n%s", got)
+	}
+	if !strings.Contains(got, "TEST-CA-MARKER") {
+		t.Errorf("rewriter dropped certificate-authority-data sentinel:\n%s", got)
+	}
+	if !strings.Contains(got, "TEST-USER-TOKEN-MARKER") {
+		t.Errorf("rewriter dropped user-token sentinel:\n%s", got)
+	}
+
+	// Idempotency — re-running the rewriter on the already-renamed
+	// output must be a no-op (no further `default` matches; output
+	// is byte-stable enough that downstream consumers see no diff).
+	out2, err := rewriteKubeconfigContext(out, "otech94")
+	if err != nil {
+		t.Fatalf("idempotent rewrite: %v", err)
+	}
+	if string(out2) != string(out) {
+		t.Errorf("rewriter is not idempotent:\nfirst:\n%s\nsecond:\n%s", out, out2)
+	}
+}
+
+func TestRewriteKubeconfigContext_LeavesNonDefaultEntriesAlone(t *testing.T) {
+	const yamlWithMixedNames = `apiVersion: v1
+kind: Config
+clusters:
+- cluster: { server: https://1.2.3.4:6443 }
+  name: default
+- cluster: { server: https://5.6.7.8:6443 }
+  name: other-cluster
+contexts:
+- context: { cluster: default, user: default }
+  name: default
+- context: { cluster: other-cluster, user: other-user }
+  name: other
+current-context: default
+users:
+- name: default
+  user: { token: abc }
+- name: other-user
+  user: { token: xyz }
+`
+	out, err := rewriteKubeconfigContext([]byte(yamlWithMixedNames), "otech94")
+	if err != nil {
+		t.Fatalf("rewrite: %v", err)
+	}
+	got := string(out)
+	// "default" entries renamed.
+	if !strings.Contains(got, "name: otech94") {
+		t.Errorf("missing renamed `name: otech94`:\n%s", got)
+	}
+	// "other" entries untouched.
+	if !strings.Contains(got, "name: other-cluster") {
+		t.Errorf("rewriter clobbered `name: other-cluster`:\n%s", got)
+	}
+	if !strings.Contains(got, "name: other-user") {
+		t.Errorf("rewriter clobbered `name: other-user`:\n%s", got)
+	}
+	if !strings.Contains(got, "name: other") {
+		t.Errorf("rewriter clobbered context `name: other`:\n%s", got)
+	}
+}
+
+func TestRewriteKubeconfigContext_RejectsEmptyTarget(t *testing.T) {
+	_, err := rewriteKubeconfigContext([]byte(validKubeconfigYAML), "")
+	if err == nil {
+		t.Error("expected error for empty target, got nil")
+	}
+}
+
+func TestRewriteKubeconfigContext_RejectsBadYAML(t *testing.T) {
+	_, err := rewriteKubeconfigContext([]byte("not: : a valid: ::: yaml"), "otech94")
+	if err == nil {
+		t.Error("expected parse error for malformed YAML")
+	}
+}
+
+func TestRewriteKubeconfigContext_NotAKubeconfig(t *testing.T) {
+	// A valid YAML doc that is NOT a kubeconfig (kind: Pod) — must
+	// be rejected so the GET handler serves the raw bytes rather
+	// than mutating an unrelated file.
+	const podYAML = `apiVersion: v1
+kind: Pod
+metadata:
+  name: example
+`
+	_, err := rewriteKubeconfigContext([]byte(podYAML), "otech94")
+	if err == nil {
+		t.Error("expected error for non-kubeconfig document")
+	}
+}
+
+// TestGetKubeconfig_UsesSubdomainAsContextName drives the GET
+// handler with a deployment whose SovereignSubdomain is set, and
+// asserts the served body has the context names rewritten to that
+// subdomain — the canonical "operator can `k9s --context=otech94`
+// after merge" flow from issue #765.
+func TestGetKubeconfig_UsesSubdomainAsContextName(t *testing.T) {
+	deploymentsDir := t.TempDir()
+	kubeconfigsDir := t.TempDir()
+	st, _ := store.New(deploymentsDir)
+	h := NewWithStoreAndKubeconfigsDir(silentLogger(), &fakePDM{}, st, kubeconfigsDir)
+
+	id := "kc-subdomain-rewrite"
+	kcPath := filepath.Join(kubeconfigsDir, id+".yaml")
+	if err := os.WriteFile(kcPath, []byte(validKubeconfigYAML), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	dep := &Deployment{
+		ID:        id,
+		Status:    "ready",
+		StartedAt: time.Now(),
+		eventsCh:  make(chan provisioner.Event, 256),
+		done:      make(chan struct{}),
+		Request: provisioner.Request{
+			SovereignSubdomain: "otech94",
+			SovereignFQDN:      "otech94.omantel.omani.works",
+		},
+		Result: &provisioner.Result{
+			SovereignFQDN:  "otech94.omantel.omani.works",
+			KubeconfigPath: kcPath,
+		},
+	}
+	h.deployments.Store(id, dep)
+
+	w := httptest.NewRecorder()
+	r := getReq(t, id)
+	h.GetKubeconfig(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+	got := w.Body.String()
+	if !strings.Contains(got, "name: otech94") {
+		t.Errorf("served kubeconfig missing `name: otech94`:\n%s", got)
+	}
+	if strings.Contains(got, "name: default") {
+		t.Errorf("served kubeconfig still has `name: default`:\n%s", got)
+	}
+	// Filename in Content-Disposition should be the subdomain.
+	cd := w.Header().Get("Content-Disposition")
+	if !strings.Contains(cd, `filename="otech94.yaml"`) {
+		t.Errorf("Content-Disposition = %q, want filename=otech94.yaml", cd)
 	}
 }

--- a/products/catalyst/bootstrap/ui/src/pages/wizard/steps/StepSuccess.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/wizard/steps/StepSuccess.test.tsx
@@ -18,6 +18,8 @@ import {
   sovereignSubURL,
   adminLoginAPIPath,
   kubeconfigAPIPath,
+  sovereignContextName,
+  buildKubeconfigMergeCommand,
   DEFAULT_FIRST_LOGIN_DOCS_URL,
   DEFAULT_KUBECONFIG_DOCS_URL,
 } from './StepSuccess'
@@ -95,6 +97,38 @@ describe('URL helpers', () => {
     expect(kubeconfigAPIPath('abc')).toMatch(
       /\/api\/v1\/deployments\/abc\/kubeconfig$/,
     )
+  })
+
+  /* Issue #765 — context-name + merge-command helpers. The backend
+   * picks the same name with a Go-side mirror of this logic; the two
+   * implementations agreeing is the load-bearing invariant. */
+  it('sovereignContextName prefers the subdomain', () => {
+    expect(sovereignContextName('otech94', 'otech94.omantel.omani.works')).toBe('otech94')
+  })
+
+  it('sovereignContextName falls back to the first FQDN label', () => {
+    expect(sovereignContextName('', 'k8s.byo.example')).toBe('k8s')
+  })
+
+  it('sovereignContextName lowercases + strips invalid chars', () => {
+    expect(sovereignContextName('OTECH-Beta!', '')).toBe('otech-beta')
+  })
+
+  it('sovereignContextName returns "sovereign" when both inputs are empty', () => {
+    expect(sovereignContextName('', '')).toBe('sovereign')
+  })
+
+  it('buildKubeconfigMergeCommand emits a one-liner with KUBECONFIG + flatten + k9s', () => {
+    const cmd = buildKubeconfigMergeCommand('otech94.yaml', 'otech94')
+    expect(cmd).toMatch(/^KUBECONFIG=\$HOME\/\.kube\/config:\$HOME\/Downloads\/otech94\.yaml /)
+    expect(cmd).toContain('kubectl config view --flatten')
+    expect(cmd).toContain('chmod 600 $HOME/.kube/config')
+    expect(cmd).toContain('k9s --context=otech94')
+    // Atomic move pattern — we never write directly to ~/.kube/config
+    // mid-pipe (a Ctrl-C would otherwise corrupt the operator's
+    // existing config).
+    expect(cmd).toContain('$HOME/.kube/config.tmp')
+    expect(cmd).toContain('mv $HOME/.kube/config.tmp $HOME/.kube/config')
   })
 })
 
@@ -192,6 +226,50 @@ describe('kubeconfig fallback when endpoint is not implemented', () => {
     expect(fallback.textContent).toMatch(/Coming soon — fetch via SSH/)
     const docsLink = screen.getByTestId('kubeconfig-docs') as HTMLAnchorElement
     expect(docsLink.href).toBe(DEFAULT_KUBECONFIG_DOCS_URL)
+  })
+})
+
+/* ── kubeconfig merge command (issue #765) ─────────────────────── */
+
+describe('kubeconfig merge command surface', () => {
+  it('renders the merge one-liner with the right context name + filename', () => {
+    render(<StepSuccess />)
+    const cmd = screen.getByTestId('kubeconfig-merge-command')
+    // Subdomain in fixture is "omantel" → context name omantel, filename omantel.yaml.
+    expect(cmd.textContent).toContain('$HOME/Downloads/omantel.yaml')
+    expect(cmd.textContent).toContain('k9s --context=omantel')
+    expect(cmd.textContent).toContain('kubectl config view --flatten')
+  })
+
+  it('"Copy" button copies the command to clipboard and flips to Copied', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    Object.assign(navigator, { clipboard: { writeText } })
+    render(<StepSuccess />)
+    const btn = screen.getByTestId('copy-merge-command')
+    expect(btn.textContent).toMatch(/Copy/)
+    fireEvent.click(btn)
+    // writeText invoked with a string containing the full pipeline.
+    expect(writeText).toHaveBeenCalledTimes(1)
+    const written = String(writeText.mock.calls[0][0])
+    expect(written).toContain('KUBECONFIG=$HOME/.kube/config:$HOME/Downloads/omantel.yaml')
+    expect(written).toContain('k9s --context=omantel')
+    // Wait for state flip to "Copied".
+    await screen.findByText(/Copied/)
+  })
+
+  it('uses a different filename + context when subdomain changes', () => {
+    useWizardStore.setState({
+      sovereignSubdomain: 'otech94',
+      sovereignPoolDomain: 'omani-works',
+      lastProvisionResult: {
+        ...FIXTURE_RESULT,
+        sovereignFQDN: 'otech94.omani.works',
+      },
+    })
+    render(<StepSuccess />)
+    const cmd = screen.getByTestId('kubeconfig-merge-command')
+    expect(cmd.textContent).toContain('$HOME/Downloads/otech94.yaml')
+    expect(cmd.textContent).toContain('k9s --context=otech94')
   })
 })
 

--- a/products/catalyst/bootstrap/ui/src/pages/wizard/steps/StepSuccess.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/wizard/steps/StepSuccess.tsx
@@ -103,6 +103,78 @@ export function kubeconfigAPIPath(deploymentId: string | null): string | null {
   return `${API_BASE}/v1/deployments/${deploymentId}/kubeconfig`
 }
 
+/**
+ * Resolve the kubeconfig context name the same way the catalyst-api
+ * does on the GET /kubeconfig path (issue #765). Order:
+ *
+ *   1. SovereignSubdomain — when set by the wizard for pool-mode.
+ *   2. First label of FQDN — for BYO-domain deployments.
+ *   3. The literal "sovereign" — last-resort fallback.
+ *
+ * Used to label the download filename + the `k9s --context=...`
+ * snippet in the merge command so the operator's mental model
+ * matches what's actually in the file.
+ *
+ * The sanitiser is RFC-1123-ish (lowercase alnum + dash) to mirror
+ * the backend's `sanitiseContextName` so both sides agree.
+ */
+export function sovereignContextName(subdomain: string, fqdn: string): string {
+  const fromSubdomain = sanitiseLabel(subdomain)
+  if (fromSubdomain) return fromSubdomain
+  const trimmed = (fqdn ?? '').trim()
+  if (trimmed) {
+    const firstLabel = trimmed.split('.')[0]
+    const fromFqdn = sanitiseLabel(firstLabel)
+    if (fromFqdn) return fromFqdn
+  }
+  return 'sovereign'
+}
+
+function sanitiseLabel(input: string): string {
+  const lower = (input ?? '').trim().toLowerCase()
+  if (!lower) return ''
+  let out = ''
+  for (const ch of lower) {
+    if ((ch >= 'a' && ch <= 'z') || (ch >= '0' && ch <= '9') || ch === '-') {
+      out += ch
+    }
+  }
+  // Trim leading/trailing dashes per RFC-1123 label rules.
+  return out.replace(/^-+|-+$/g, '')
+}
+
+/**
+ * Build the one-liner the operator pastes into a shell to merge the
+ * downloaded kubeconfig into `$HOME/.kube/config` and immediately
+ * launch k9s on the new context (issue #765).
+ *
+ * The command:
+ *   - Uses `KUBECONFIG=$HOME/.kube/config:<path>` to compose the
+ *     existing config with the freshly-downloaded one.
+ *   - Pipes through `kubectl config view --flatten` so the CA / token
+ *     bytes inline (output is self-contained — no path references).
+ *   - Writes back to a temp file then atomically moves it onto
+ *     $HOME/.kube/config so a Ctrl-C mid-pipe never truncates the
+ *     operator's existing config.
+ *   - Sets mode 0600 (kubectl warns if perms are looser).
+ *   - Uses `k9s --context=<name>` so the operator lands in the new
+ *     cluster the same second they run the command.
+ *
+ * The operator drops their downloaded kubeconfig into
+ * `~/Downloads/<contextName>.yaml` (the default browser-download
+ * location matching the Content-Disposition filename the API sets).
+ */
+export function buildKubeconfigMergeCommand(downloadFilename: string, contextName: string): string {
+  const path = `$HOME/Downloads/${downloadFilename}`
+  return [
+    `KUBECONFIG=$HOME/.kube/config:${path}`,
+    `kubectl config view --flatten > $HOME/.kube/config.tmp`,
+    `&& mv $HOME/.kube/config.tmp $HOME/.kube/config`,
+    `&& chmod 600 $HOME/.kube/config`,
+    `&& k9s --context=${contextName}`,
+  ].join(' ')
+}
+
 /* ── Small UI helpers ─────────────────────────────────────────────── */
 
 function CopyChip({ text, label = 'Copy' }: { text: string; label?: string }) {
@@ -269,10 +341,28 @@ export function StepSuccess({
     }
   }
 
-  /* ── kubeconfig download — fetches the binary YAML from catalyst-api. ── */
+  /* ── kubeconfig download + merge command (issue #765) ──────────────
+   *
+   * The catalyst-api GET /kubeconfig endpoint rewrites the cluster /
+   * context / user names from k3s's hardcoded `default` to the
+   * Sovereign's subdomain (e.g. `otech94`), so the operator can run
+   *
+   *   KUBECONFIG=$HOME/.kube/config:~/Downloads/otech94.yaml \
+   *     kubectl config view --flatten > $HOME/.kube/config && \
+   *     chmod 600 $HOME/.kube/config && k9s --context=otech94
+   *
+   * after a single click. The "Copy merge command" button below
+   * copies that one-liner so the operator pastes it directly into a
+   * shell — no manual sed pipeline.
+   */
+
+  const contextName = sovereignContextName(store.sovereignSubdomain, fqdn)
+  const downloadFilename = contextName + '.yaml'
+  const mergeCommand = buildKubeconfigMergeCommand(downloadFilename, contextName)
 
   const [kubeconfigError, setKubeconfigError] = useState<string | null>(null)
   const [downloadingKubeconfig, setDownloadingKubeconfig] = useState(false)
+  const [mergeCopied, setMergeCopied] = useState(false)
 
   async function downloadKubeconfig() {
     const path = kubeconfigAPIPath(deploymentId)
@@ -297,13 +387,25 @@ export function StepSuccess({
       const url = URL.createObjectURL(blob)
       const a = document.createElement('a')
       a.href = url
-      a.download = `${fqdn || 'sovereign'}-kubeconfig.yaml`
+      a.download = downloadFilename
       a.click()
       URL.revokeObjectURL(url)
     } catch (err) {
       setKubeconfigError(`Network error: ${String(err)}`)
     } finally {
       setDownloadingKubeconfig(false)
+    }
+  }
+
+  async function copyMergeCommand() {
+    try {
+      await navigator.clipboard.writeText(mergeCommand)
+      setMergeCopied(true)
+      setTimeout(() => setMergeCopied(false), 2500)
+    } catch {
+      // Air-gap browser without clipboard permission — fall through
+      // silently. The command stays visible in the inline <code>
+      // block so the operator can select-copy.
     }
   }
 
@@ -471,34 +573,94 @@ export function StepSuccess({
           } />
         </Section>
 
-        {/* ── Cluster access — kubeconfig ── */}
+        {/* ── Cluster access — kubeconfig + merge command (issue #765) ── */}
         <Section title={
           <span style={{ display: 'inline-flex', alignItems: 'center', gap: 6 }}>
             <Terminal size={11} />Cluster access
           </span>
         }>
-          <div style={{ padding: '10px 14px', display: 'flex', flexDirection: 'column', gap: 8 }}>
-            <button
-              type="button"
-              onClick={downloadKubeconfig}
-              disabled={downloadingKubeconfig || !deploymentId}
-              data-testid="download-kubeconfig"
-              style={{
-                alignSelf: 'flex-start',
-                display: 'inline-flex', alignItems: 'center', gap: 6,
-                padding: '6px 12px', borderRadius: 6,
-                border: '1px solid var(--wiz-border)',
-                background: 'var(--wiz-bg-sub)',
-                color: 'var(--wiz-text-hi)',
-                fontSize: 11, fontWeight: 600,
-                cursor: deploymentId ? 'pointer' : 'not-allowed',
-                opacity: deploymentId ? 1 : 0.55,
-                fontFamily: 'Inter, sans-serif',
-              }}
-            >
-              <Download size={11} />
-              {downloadingKubeconfig ? 'Downloading…' : 'Download kubeconfig'}
-            </button>
+          <div style={{ padding: '10px 14px', display: 'flex', flexDirection: 'column', gap: 10 }}>
+            <span style={{
+              fontSize: 10.5, color: 'var(--wiz-text-sub)', lineHeight: 1.55,
+              fontFamily: 'Inter, sans-serif',
+            }}>
+              Step 1 — Download the kubeconfig (saves as
+              {' '}<code style={{ fontFamily: 'JetBrains Mono, monospace', color: 'var(--wiz-text-md)' }}>
+                {downloadFilename}
+              </code> with context name
+              {' '}<code style={{ fontFamily: 'JetBrains Mono, monospace', color: 'var(--wiz-text-md)' }}>
+                {contextName}
+              </code>).
+            </span>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
+              <button
+                type="button"
+                onClick={downloadKubeconfig}
+                disabled={downloadingKubeconfig || !deploymentId}
+                data-testid="download-kubeconfig"
+                style={{
+                  display: 'inline-flex', alignItems: 'center', gap: 6,
+                  padding: '6px 12px', borderRadius: 6,
+                  border: '1px solid var(--wiz-border)',
+                  background: 'var(--wiz-bg-sub)',
+                  color: 'var(--wiz-text-hi)',
+                  fontSize: 11, fontWeight: 600,
+                  cursor: deploymentId ? 'pointer' : 'not-allowed',
+                  opacity: deploymentId ? 1 : 0.55,
+                  fontFamily: 'Inter, sans-serif',
+                }}
+              >
+                <Download size={11} />
+                {downloadingKubeconfig ? 'Downloading…' : 'Download kubeconfig'}
+              </button>
+            </div>
+
+            <span style={{
+              fontSize: 10.5, color: 'var(--wiz-text-sub)', lineHeight: 1.55,
+              fontFamily: 'Inter, sans-serif', marginTop: 4,
+            }}>
+              Step 2 — Paste this one-liner into a shell to merge the new
+              context into <code style={{ fontFamily: 'JetBrains Mono, monospace' }}>$HOME/.kube/config</code>
+              {' '}and launch k9s on it:
+            </span>
+            <div style={{
+              display: 'flex', alignItems: 'flex-start', gap: 8,
+              padding: '8px 10px', borderRadius: 6,
+              border: '1px solid var(--wiz-border-sub)',
+              background: 'var(--wiz-bg-xs)',
+            }}>
+              <code
+                data-testid="kubeconfig-merge-command"
+                style={{
+                  flex: 1,
+                  fontFamily: 'JetBrains Mono, monospace',
+                  fontSize: 10.5, lineHeight: 1.55,
+                  color: 'var(--wiz-text-md)',
+                  whiteSpace: 'pre-wrap',
+                  wordBreak: 'break-all',
+                }}
+              >{mergeCommand}</code>
+              <button
+                type="button"
+                onClick={copyMergeCommand}
+                aria-label="Copy merge command"
+                data-testid="copy-merge-command"
+                style={{
+                  flexShrink: 0,
+                  display: 'inline-flex', alignItems: 'center', gap: 4,
+                  padding: '4px 9px', borderRadius: 5,
+                  border: '1px solid var(--wiz-border-sub)',
+                  background: 'transparent',
+                  color: 'var(--wiz-text-md)',
+                  fontSize: 10, fontWeight: 600,
+                  cursor: 'pointer',
+                  fontFamily: 'Inter, sans-serif',
+                }}
+              >
+                {mergeCopied ? <Check size={11} /> : <Copy size={11} />}
+                {mergeCopied ? 'Copied' : 'Copy'}
+              </button>
+            </div>
             {kubeconfigError === 'not-implemented' && (
               <div role="alert" data-testid="kubeconfig-fallback" style={{
                 fontSize: 10.5, color: 'var(--wiz-text-sub)',


### PR DESCRIPTION
## Summary
- catalyst-api now rewrites k3s's hardcoded `default` cluster/context/user names to the Sovereign's subdomain (e.g. `otech94`) on `GET /api/v1/deployments/{id}/kubeconfig`, so the downloaded file merges into `$HOME/.kube/config` under a stable, human-readable context name.
- StepSuccess wizard step exposes a "Copy merge command" button next to "Download kubeconfig" — the one-liner does `KUBECONFIG=…:… kubectl config view --flatten > tmp && mv tmp config && chmod 600 && k9s --context=…`. Operator pastes once and lands in the new cluster the same second.
- Mirror logic in TS (`sovereignContextName`, `buildKubeconfigMergeCommand`) so the UI's filename + context name match what the backend serves byte-for-byte.

## Decisions
- **Rewrite on response, not on PUT** — keeps the cloud-init postback idempotency invariant (single-use bearer, byte-identical file on disk per #183) and lets us evolve the context-naming policy without re-uploading from every Sovereign.
- **YAML round-trip via yaml.v3 Node** — preserves comments + ordering, mutates only `name == "default"` entries (idempotent on re-apply, leaves operator-merged kubeconfigs alone).
- **Atomic temp-file move in the merge command** — never write directly to `~/.kube/config` mid-pipe (Ctrl-C corruption).
- **Both sides agree on context name** — Go and TS implementations of `sanitiseLabel` follow RFC-1123 (lowercase alnum + dash). Tests pin the agreement.

## Test plan
- [x] `go test ./internal/handler/` — 6 new tests pass (idempotency, mixed-name file, malformed YAML rejection, non-kubeconfig rejection, GET integration with subdomain context name).
- [x] `vitest run StepSuccess.test.tsx` — 8 new tests pass.
- [ ] Live verification on a fresh Sovereign: provision otech9X → click "Download kubeconfig" → paste merge command → `k9s --context=otech9X`.

## DoD (issue #765)
- [x] After `phase1Outcome=ready`, operator can run `k9s --context=otech9X` immediately without manual `sed`/merge.
- [ ] Decommission removes the context from the merged kubeconfig — out of scope (the merged context lives on the operator's own machine and is cleaned via standard `kubectl config delete-context <name>`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)