### PR TITLE
feat(provisioner): cluster-autoscaler-hcloud + wizard footprint estimate (closes #767)

### DIFF
--- a/clusters/_template/bootstrap-kit/40-cluster-autoscaler.yaml
+++ b/clusters/_template/bootstrap-kit/40-cluster-autoscaler.yaml
@@ -1,0 +1,117 @@
+# bp-cluster-autoscaler-hcloud — Catalyst bootstrap-kit Blueprint #40
+# (W2.K3, Tier 5 — Scaling/Resilience).
+#
+# Adds and removes Hetzner Cloud worker nodes on demand in response to
+# `FailedScheduling` events on the Sovereign's k3s cluster. Bounded by
+# the `min`/`max` node-group config the operator picked at launch.
+#
+# Live evidence motivating this blueprint (issue #767):
+#   otech92 — 2× cpx32 workers couldn't fit external-secrets-webhook
+#   because the bootstrap-kit's RAM aggregate (~14 GB across 35
+#   HelmReleases) exceeded the 2× 8 GB pool the operator chose. With
+#   cluster-autoscaler the Sovereign would have grown the pool to a
+#   third worker automatically.
+#
+# Wrapper chart: platform/cluster-autoscaler-hcloud/chart/ — umbrella
+# over upstream kubernetes/autoscaler cluster-autoscaler chart 9.46.6
+# (appVersion 1.32.0). Catalyst-curated values flow under the
+# `cluster-autoscaler:` key + a vendor-agnostic
+# `clusterAutoscalerHcloud.*` block that ships the namespace-local
+# Hetzner-API-token Secret (`hcloud-token`).
+#
+# Reconciled by: Flux on the new Sovereign's k3s control plane.
+#
+# Hetzner-token wiring (mirrors the velero/harbor object-storage pattern
+# in 19-harbor.yaml + 34-velero.yaml):
+#   - cloud-init writes `flux-system/cloud-credentials` Secret with the
+#     `hcloud-token` key (see infra/hetzner/cloudinit-control-plane.tftpl
+#     §"cloud-credentials-secret"). That Secret is the canonical Hetzner-
+#     API-token holder for every Day-2 mutation seam (Crossplane provider-
+#     hcloud, this autoscaler, future hcloud Floating-IP claims).
+#   - This HelmRelease lifts the `hcloud-token` value into the umbrella
+#     chart's `clusterAutoscalerHcloud.hcloudToken` value via Flux
+#     `valuesFrom`. The umbrella chart then synthesises a namespace-local
+#     `cluster-autoscaler/hcloud-token` Secret (templates/hetzner-token-
+#     secret.yaml) the upstream chart's `extraEnvSecrets.HCLOUD_TOKEN`
+#     wiring binds as the deployment's HCLOUD_TOKEN env var.
+#
+# dependsOn: (none) — cluster-autoscaler is independent of every other
+# bootstrap-kit blueprint at install time. The cloud-credentials Secret
+# is provisioned by cloud-init BEFORE Flux installs anything.
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cluster-autoscaler
+  labels:
+    catalyst.openova.io/sovereign: ${SOVEREIGN_FQDN}
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: bp-cluster-autoscaler-hcloud
+  namespace: flux-system
+spec:
+  type: oci
+  interval: 15m
+  url: oci://ghcr.io/openova-io
+  secretRef:
+    name: ghcr-pull
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: bp-cluster-autoscaler-hcloud
+  namespace: flux-system
+spec:
+  interval: 15m
+  releaseName: cluster-autoscaler
+  targetNamespace: cluster-autoscaler
+  chart:
+    spec:
+      chart: bp-cluster-autoscaler-hcloud
+      version: 1.0.0
+      sourceRef:
+        kind: HelmRepository
+        name: bp-cluster-autoscaler-hcloud
+        namespace: flux-system
+  # Event-driven install: cluster-autoscaler is a single Deployment +
+  # ServiceAccount + RBAC. Helm install completes when manifests apply;
+  # the binary's Hetzner-API connectivity check is a runtime concern,
+  # not a Helm-wait concern. disableWait keeps Flux's Ready signal
+  # aligned with manifest apply.
+  install:
+    disableWait: true
+    remediation:
+      retries: 3
+  upgrade:
+    disableWait: true
+    remediation:
+      retries: 3
+  # ── Hetzner-token wiring ────────────────────────────────────────────
+  # Pulls the `hcloud-token` key from the canonical
+  # `flux-system/cloud-credentials` Secret cloud-init writes at Phase 0
+  # (infra/hetzner/cloudinit-control-plane.tftpl §"cloud-credentials-
+  # secret"). Flux dereferences `valuesFrom` at HelmRelease apply time,
+  # so the plaintext token never appears in this committed manifest.
+  valuesFrom:
+    - kind: Secret
+      name: cloud-credentials
+      valuesKey: hcloud-token
+      targetPath: clusterAutoscalerHcloud.hcloudToken
+  # Per-Sovereign baseline values. clusters/<sovereign>/bootstrap-kit/
+  # 40-cluster-autoscaler.yaml MAY override `autoscalingGroups` to set
+  # the actual instanceType + region + min/max + name the Tofu module
+  # provisioned at Phase 0. The defaults below match the canonical
+  # otechN topology (cpx32 in fsn1, min 2 / max 10) so a vanilla
+  # Sovereign that forgets to patch this still gets a sensible
+  # autoscaler.
+  values:
+    cluster-autoscaler:
+      autoscalingGroups:
+        - name: workers
+          instanceType: cpx32
+          region: fsn1
+          minSize: 2
+          maxSize: 10

--- a/clusters/_template/bootstrap-kit/50-cluster-autoscaler.yaml
+++ b/clusters/_template/bootstrap-kit/50-cluster-autoscaler.yaml
@@ -1,5 +1,9 @@
-# bp-cluster-autoscaler-hcloud — Catalyst bootstrap-kit Blueprint #40
-# (W2.K3, Tier 5 — Scaling/Resilience).
+# bp-cluster-autoscaler-hcloud — Catalyst bootstrap-kit Blueprint #50
+# (Tier 5 — Scaling/Resilience). Slot 40 was already forward-declared
+# for bp-llm-gateway in scripts/expected-bootstrap-deps.yaml; this
+# blueprint lands at slot 50 — after the W2.K4 cohort + slot 49
+# (bp-cert-manager-powerdns-webhook) — to preserve the existing
+# numbering plan.
 #
 # Adds and removes Hetzner Cloud worker nodes on demand in response to
 # `FailedScheduling` events on the Sovereign's k3s cluster. Bounded by

--- a/clusters/_template/bootstrap-kit/kustomization.yaml
+++ b/clusters/_template/bootstrap-kit/kustomization.yaml
@@ -41,5 +41,5 @@ resources:
   - 33-syft-grype.yaml
   - 34-velero.yaml
   - 35-coraza.yaml
-  - 40-cluster-autoscaler.yaml
   - 49-bp-cert-manager-powerdns-webhook.yaml
+  - 50-cluster-autoscaler.yaml

--- a/clusters/_template/bootstrap-kit/kustomization.yaml
+++ b/clusters/_template/bootstrap-kit/kustomization.yaml
@@ -41,4 +41,5 @@ resources:
   - 33-syft-grype.yaml
   - 34-velero.yaml
   - 35-coraza.yaml
+  - 40-cluster-autoscaler.yaml
   - 49-bp-cert-manager-powerdns-webhook.yaml

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -499,7 +499,63 @@ We are not a strict OAM implementation. We borrow the layered composition idea b
 
 ---
 
-## 14. Read further
+## 14. Autoscaling
+
+Catalyst layers four orthogonal autoscalers, each addressing a different
+dimension of "make this Sovereign fit its workload." None of them
+substitute for any of the others; they compose.
+
+| Dimension | Component | Blueprint | Where it lives | Decides |
+|---|---|---|---|---|
+| **Workload (vertical)** — right-size pod requests/limits | VPA | `bp-vpa` | bootstrap-kit slot 29 | "Pod X actually uses N MB / M mC, change its requests" |
+| **Workload (horizontal, metric-driven)** — replicas of a Deployment from CPU/memory | Kubernetes built-in | (HPA is a kube primitive — no blueprint needed) | every Sovereign | "Service Y is hot, run 5 replicas instead of 2" |
+| **Workload (horizontal, event-driven)** — replicas from queue depth, NATS lag, cron | KEDA | `bp-keda` | bootstrap-kit slot 28a | "JetStream subject Z has 50k pending msgs, scale consumer to 8" |
+| **Node (cluster-wide)** — add/remove cloud machines | cluster-autoscaler | `bp-cluster-autoscaler-hcloud` | bootstrap-kit slot 40 | "5 pods are FailedScheduling on the current pool, add a worker" |
+
+The wizard's pre-launch StepReview surfaces an *estimated* footprint
+(sum of `resources.requests` across the bootstrap-kit baseline +
+operator-selected components) so the operator picks an initial worker
+count that fits without immediately triggering cluster-autoscaler. The
+runtime cluster-autoscaler then handles drift and steady-state
+fluctuation within the operator's `min`/`max` bounds.
+
+**Why not a single autoscaler?**
+
+- HPA without VPA scales replicas of pods that may themselves be
+  starved or oversized — wasted capacity OR throttled latency.
+- VPA without HPA right-sizes pods but cannot redistribute load.
+- Neither moves the node-pool boundary; both will jam the scheduler
+  when the project quota is reached. cluster-autoscaler is the only
+  layer that touches the cloud API to change node count.
+- KEDA covers async-workload-driven scale (event log pressure, cron
+  windows, job queues) that HPA's CPU/memory model cannot express.
+
+**Bounds and safety:**
+
+- cluster-autoscaler is bounded by per-Sovereign `min`/`max` set in the
+  HelmRelease overlay (and surfaced on the wizard's Provider step).
+  `min` ≤ Tofu Phase 0's worker_count ≤ `max`.
+- Scale-down idle: 10 minutes default — workers must remain
+  underutilised for the full 10m before being removed (cost-saving
+  default; per-Sovereign overlays MAY raise this for spiky workloads).
+- The autoscaler runs on the control-plane node only — it is never
+  scheduled onto a worker it could itself terminate.
+- Hetzner project quota is the ultimate cap: when `max` is reached or
+  the project quota is exhausted, FailedScheduling persists until an
+  operator raises one or the other.
+
+**Why we did not pick KEDA for cluster scaling:**
+
+KEDA scales workloads (replicas), not nodes — different problem space
+even though both speak "autoscaler." When KEDA's scaler pushes a
+Deployment to N replicas the kube-scheduler still has to find Nodes for
+those replicas to land on; cluster-autoscaler is the only component
+that can grow the node pool to make room. They compose: KEDA decides
+*how many replicas*, cluster-autoscaler decides *how many nodes*.
+
+---
+
+## 15. Read further
 
 - [`GLOSSARY.md`](GLOSSARY.md) — every term defined.
 - [`NAMING-CONVENTION.md`](NAMING-CONVENTION.md) — every name's pattern.

--- a/platform/cluster-autoscaler-hcloud/README.md
+++ b/platform/cluster-autoscaler-hcloud/README.md
@@ -1,0 +1,62 @@
+# bp-cluster-autoscaler-hcloud
+
+Catalyst Blueprint umbrella chart for the Kubernetes
+[cluster-autoscaler](https://github.com/kubernetes/autoscaler) configured
+with the Hetzner Cloud cloud-provider. Adds and removes Hetzner workers
+in response to `FailedScheduling` events on a Sovereign's k3s cluster.
+
+## Why
+
+Per issue #767, a freshly-provisioned Sovereign reaches `FailedScheduling`
+the moment the bootstrap-kit's RAM aggregate exceeds the static worker
+pool the operator picked in the wizard. Live evidence (otech92): two
+`cpx32` workers couldn't fit the `external-secrets-webhook` Pod because
+the bootstrap-kit consumed the full 16 GB. The fix is two-pronged:
+
+1. **Pre-launch**: the wizard's StepReview surfaces an *estimated*
+   footprint so the operator picks a worker pool that fits.
+2. **Runtime**: this blueprint adds `cluster-autoscaler` so the
+   Sovereign scales workers up/down on demand, bounded by the
+   `min`/`max` operator chose at launch.
+
+## How it wires
+
+- **Helm subchart**: upstream
+  [`kubernetes/autoscaler/cluster-autoscaler`](https://github.com/kubernetes/autoscaler/tree/master/charts/cluster-autoscaler)
+  vendor-neutral, multi-cloud cluster-autoscaler. The Hetzner cloud
+  provider ships in the same upstream container image.
+- **Hetzner token**: read at HelmRelease apply time from
+  `flux-system/cloud-credentials.hcloud-token` (the canonical Secret
+  cloud-init writes per ADR-0001 §11.3 — same Secret consumed by
+  Crossplane provider-hcloud + provider-config-hcloud).
+- **Node group**: a single canonical pool keyed off the Sovereign's
+  worker SKU + region + cloud-init template. The pool's `min` is the
+  operator's chosen worker count; `max` defaults to 10 (overridable
+  per-Sovereign).
+- **Scale-down**: 10 minutes idle (cost-saving default).
+
+## What this blueprint does NOT do
+
+- **It does not pre-create extra nodes.** Phase 0 (`tofu apply`) only
+  provisions the `min` worker count; cluster-autoscaler creates
+  additional workers on-demand against the same Hetzner project.
+- **It does not provision the OpenTofu node-pool template.** That
+  restructuring is tracked separately (see follow-up issue) — the
+  MVP shipped in this PR pins the node-group config in chart values
+  and assumes the existing single-pool topology.
+- **It does not autoscale workloads.** `KEDA` (event-driven workload
+  autoscaling) and the kubernetes-builtin `HPA` (horizontal pod
+  autoscaler) are layered on top; cluster-autoscaler handles the
+  *node* dimension only.
+
+## Upstream pinning
+
+| Knob | Value | Notes |
+|------|-------|-------|
+| Chart | `cluster-autoscaler` (kubernetes/autoscaler) | `9.46.6` — current stable on 2026-05-04 |
+| App | `cluster-autoscaler` | `1.32.0` (matches k3s 1.31.x — within +/-1 minor of the Sovereign apiserver) |
+| Cloud provider | `hetzner` | Built into upstream image |
+
+Per `docs/INVIOLABLE-PRINCIPLES.md` #4 (never hardcode), every value is
+runtime-configurable; cluster overlays in `clusters/<sovereign>/` MAY
+override any of them without rebuilding the OCI artifact.

--- a/platform/cluster-autoscaler-hcloud/blueprint.yaml
+++ b/platform/cluster-autoscaler-hcloud/blueprint.yaml
@@ -1,0 +1,43 @@
+apiVersion: catalyst.openova.io/v1
+kind: Blueprint
+metadata:
+  name: cluster-autoscaler-hcloud
+  labels:
+    catalyst.openova.io/section: pts-3-2-scaling-and-resilience
+spec:
+  version: 1.0.0
+  card:
+    title: Cluster Autoscaler (Hetzner)
+    family: surge
+    description: Adds and removes Hetzner Cloud workers in response to FailedScheduling events. Bounded by the per-Sovereign min/max node-group config the operator picked at launch. Pairs with VPA (vertical) and HPA/KEDA (horizontal pod) on the workload axis.
+    docs: https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler/cloudprovider/hetzner
+  visibility: unlisted              # mandatory infra, auto-installed by bootstrap kit
+  configSchema:
+    type: object
+    properties:
+      minWorkers:
+        type: integer
+        default: 2
+        minimum: 0
+        maximum: 100
+        description: Minimum number of worker nodes the autoscaler will keep online. Tofu Phase 0 provisions exactly this many — the autoscaler never scales BELOW this count.
+      maxWorkers:
+        type: integer
+        default: 10
+        minimum: 1
+        maximum: 100
+        description: Maximum number of worker nodes the autoscaler may add to the project. Caps blast radius for runaway scale-ups.
+      scaleDownIdleMinutes:
+        type: integer
+        default: 10
+        minimum: 1
+        maximum: 60
+        description: Minutes a worker must remain underutilised before the autoscaler removes it. Cost-saving default.
+  placementSchema:
+    modes: [single-region, active-active]
+    default: active-active           # one autoscaler per host cluster
+  manifests:
+    chart: ./chart
+  depends: []                        # cloud-credentials Secret is provisioned by cloud-init before Flux installs anything
+  upgrades:
+    from: ["0.x"]

--- a/platform/cluster-autoscaler-hcloud/chart/Chart.yaml
+++ b/platform/cluster-autoscaler-hcloud/chart/Chart.yaml
@@ -1,0 +1,35 @@
+apiVersion: v2
+name: bp-cluster-autoscaler-hcloud
+description: |
+  Catalyst Blueprint umbrella chart for Kubernetes cluster-autoscaler with
+  the Hetzner Cloud cloud-provider. Depends on the upstream
+  `cluster-autoscaler` chart (kubernetes/autoscaler) as a Helm subchart so
+  `helm dependency build` pulls the upstream payload into this artifact.
+  Catalyst-curated values flow into the upstream subchart under the
+  `cluster-autoscaler:` key in values.yaml.
+
+  This blueprint adds and removes Hetzner Cloud workers in response to
+  `FailedScheduling` events on a Sovereign's k3s cluster, bounded by the
+  per-Sovereign `min`/`max` node-group config the operator picked at
+  launch. Pairs with VPA (right-sizing pods) and HPA / KEDA (right-sizing
+  workload replicas) on the workload axis. See
+  `platform/cluster-autoscaler-hcloud/README.md` for the rationale and
+  ADR-0001 §13 for the cloud-direct architecture rule.
+type: application
+version: 1.0.0
+appVersion: "1.32.0"
+keywords: [catalyst, blueprint, cluster-autoscaler, hetzner, autoscaling]
+maintainers:
+  - name: OpenOva Catalyst
+    email: catalyst@openova.io
+
+# Pinned to kubernetes/autoscaler cluster-autoscaler 9.46.6 (appVersion
+# 1.32.0). cluster-autoscaler 1.32.x is upstream-tested against k8s 1.31
+# (k3s 1.31.x apiserver on every Sovereign) per the autoscaler
+# compatibility matrix. Per docs/INVIOLABLE-PRINCIPLES.md #4 (never
+# hardcode) the version is operator-bumpable via PR + Blueprint release;
+# mirrors bp-vpa / bp-trivy / bp-external-dns wrapper shape.
+dependencies:
+  - name: cluster-autoscaler
+    version: "9.46.6"
+    repository: "https://kubernetes.github.io/autoscaler"

--- a/platform/cluster-autoscaler-hcloud/chart/templates/_helpers.tpl
+++ b/platform/cluster-autoscaler-hcloud/chart/templates/_helpers.tpl
@@ -1,0 +1,21 @@
+{{/*
+Catalyst-curated helpers for bp-cluster-autoscaler-hcloud. Mirrors the
+conventions used by bp-vpa / bp-velero / bp-external-dns.
+*/}}
+
+{{- define "bp-cluster-autoscaler-hcloud.fullname" -}}
+{{- default "cluster-autoscaler-hcloud" .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "bp-cluster-autoscaler-hcloud.labels" -}}
+app.kubernetes.io/name: {{ include "bp-cluster-autoscaler-hcloud.fullname" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+catalyst.openova.io/blueprint: bp-cluster-autoscaler-hcloud
+catalyst.openova.io/component: cluster-autoscaler-hcloud
+{{- end -}}
+
+{{- define "bp-cluster-autoscaler-hcloud.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "bp-cluster-autoscaler-hcloud.fullname" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}

--- a/platform/cluster-autoscaler-hcloud/chart/templates/hetzner-token-secret.yaml
+++ b/platform/cluster-autoscaler-hcloud/chart/templates/hetzner-token-secret.yaml
@@ -1,0 +1,31 @@
+{{/*
+Hetzner API token Secret consumed by cluster-autoscaler.
+
+Rendered into the chart's targetNamespace from a value sourced via Flux
+`valuesFrom` against the canonical `flux-system/cloud-credentials` Secret
+(key `hcloud-token`). Mirrors the pattern used by bp-velero +
+bp-cnpg-objectstorage when wiring object-storage credentials from the
+single per-Sovereign Secret cloud-init writes (ADR-0001 §11.3).
+
+The upstream cluster-autoscaler chart's deployment template injects
+this Secret's `token` key as the `HCLOUD_TOKEN` env var via the
+`extraEnvSecrets.HCLOUD_TOKEN` value in this chart's values.yaml.
+
+The Secret is only rendered when `clusterAutoscalerHcloud.hcloudToken`
+is non-empty — Helm will skip this template during `helm template` on
+an empty string so a per-Sovereign overlay that switches to ExternalSecret
+materialisation (Phase 2+ target state) does not collide with this Secret.
+*/}}
+{{- if .Values.clusterAutoscalerHcloud.hcloudToken }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: hcloud-token
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "bp-cluster-autoscaler-hcloud.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  token: {{ .Values.clusterAutoscalerHcloud.hcloudToken | quote }}
+{{- end }}

--- a/platform/cluster-autoscaler-hcloud/chart/templates/networkpolicy.yaml
+++ b/platform/cluster-autoscaler-hcloud/chart/templates/networkpolicy.yaml
@@ -1,0 +1,40 @@
+{{/*
+NetworkPolicy — egress allowlist for cluster-autoscaler.
+
+DEFAULT DISABLED: the apiserver Service CIDR + Hetzner-API CIDR are
+cluster-specific and the umbrella chart cannot know them in advance.
+Per-Sovereign overlays MAY flip
+`clusterAutoscalerHcloud.networkPolicy.enabled: true` and supply the
+matching CIDR allowlist for their region.
+*/}}
+{{- if .Values.clusterAutoscalerHcloud.networkPolicy.enabled }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: bp-cluster-autoscaler-hcloud
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "bp-cluster-autoscaler-hcloud.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "bp-cluster-autoscaler-hcloud.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Egress
+  egress:
+    # DNS — every egress flow needs DNS.
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    # Hetzner Cloud API — api.hetzner.cloud over HTTPS.
+    - ports:
+        - protocol: TCP
+          port: 443
+{{- end }}

--- a/platform/cluster-autoscaler-hcloud/chart/values.yaml
+++ b/platform/cluster-autoscaler-hcloud/chart/values.yaml
@@ -1,0 +1,170 @@
+# Catalyst Blueprint umbrella metadata — the upstream chart is resolved as
+# a Helm subchart via Chart.yaml `dependencies:`. This values.yaml carries:
+#   1. The catalystBlueprint metadata block (provenance + version) so
+#      observability/audit pipelines can inspect the artifact and report
+#      which upstream chart + version is bundled.
+#   2. The upstream subchart values overlay under the `cluster-autoscaler:`
+#      key (umbrella-chart convention — the dependency name from Chart.yaml
+#      is the values namespace).
+#   3. Catalyst overlay values (templates/secret.yaml, NetworkPolicy)
+#      consumed by templates/ in this chart.
+#
+# Per docs/INVIOLABLE-PRINCIPLES.md #4 (never hardcode), every operationally-
+# meaningful value is configurable; cluster overlays in clusters/<sovereign>/
+# may override any of these without rebuilding the Blueprint OCI artifact.
+
+catalystBlueprint:
+  upstream:
+    chart: cluster-autoscaler
+    version: "9.46.6"
+    repo: "https://kubernetes.github.io/autoscaler"
+    # Catalyst rationale for this upstream:
+    # - kubernetes/autoscaler is the canonical publisher (kubernetes-sigs).
+    # - Chart 9.46.x ships appVersion 1.32.0 — upstream-tested against
+    #   k8s 1.31 (the k3s 1.31.x apiserver shipping on every Sovereign).
+    # - Hetzner cloud-provider is built into the upstream container image.
+    # - Apache-2.0 licence.
+
+# ─── Upstream chart values (subchart key: cluster-autoscaler) ────────────
+# `helm dependency build` resolves the upstream as a subchart; values here
+# under the `cluster-autoscaler:` key flow into that subchart unchanged.
+cluster-autoscaler:
+  # Hetzner Cloud cloud-provider — built into the upstream image. Selecting
+  # `hetzner` here switches the deployment template's --nodes argument to
+  # the Hetzner-specific shape (minSize:maxSize:instanceType:region:name)
+  # per the upstream chart's deployment.yaml.
+  cloudProvider: hetzner
+
+  # autoDiscovery is irrelevant for the Hetzner provider — Hetzner has no
+  # native ASG/MIG concept; the autoscaler manages servers directly via
+  # the Cloud API. Disable to silence the lint warning the upstream chart
+  # emits when autoDiscovery is partially set.
+  autoDiscovery:
+    clusterName: ""
+
+  # autoscalingGroups — the Hetzner provider's "node groups". Each entry
+  # becomes a `--nodes=min:max:instanceType:region:name` flag rendered by
+  # the upstream deployment template (see chart templates/deployment.yaml
+  # eq cloudProvider "hetzner" branch). The default below MUST be
+  # overridden per-Sovereign via clusters/<sovereign>/.../bootstrap-kit/
+  # so the autoscaler creates servers of the SAME SKU + region the Tofu
+  # module provisioned at Phase 0. Per-Sovereign overlays write the
+  # actual instanceType / region / counts at HelmRelease apply time.
+  #
+  # Defaults below match the canonical otechN topology (cpx32 worker SKU
+  # in fsn1, min 2 / max 10) so a vanilla Sovereign that forgets to
+  # patch this still gets a sensible autoscaler.
+  autoscalingGroups:
+    - name: workers
+      instanceType: cpx32
+      region: fsn1
+      minSize: 2
+      maxSize: 10
+
+  # extraArgs — operational tuning. These flags are independent of the
+  # cloud-provider and match the upstream defaults except where called
+  # out below.
+  extraArgs:
+    # Scale-down idle interval — workers must remain underutilised for
+    # N minutes before being removed. 10m is the cost-saving Catalyst
+    # default; per-Sovereign overlays MAY raise this for spiky workloads.
+    scale-down-unneeded-time: 10m
+    scale-down-delay-after-add: 10m
+    scale-down-delay-after-failure: 3m
+    # Run on the control plane only — the autoscaler must NEVER schedule
+    # onto a node it could itself terminate (race during scale-down).
+    # The k3s control-plane node carries the
+    # `node-role.kubernetes.io/control-plane=` taint; the toleration +
+    # nodeSelector below pin the pod there.
+    expander: least-waste
+    skip-nodes-with-local-storage: false
+    skip-nodes-with-system-pods: false
+    balance-similar-node-groups: true
+
+  # ─── Pin to the k3s control plane ────────────────────────────────────
+  # The autoscaler must never run on a worker (it could terminate itself).
+  # k3s control-plane nodes carry both labels — the selector + toleration
+  # below match either. Per-Sovereign overlays MAY override this when the
+  # Sovereign is multi-CP and the operator wants the pod elsewhere.
+  nodeSelector:
+    node-role.kubernetes.io/control-plane: "true"
+  tolerations:
+    - key: node-role.kubernetes.io/control-plane
+      operator: Exists
+      effect: NoSchedule
+    - key: node-role.kubernetes.io/master
+      operator: Exists
+      effect: NoSchedule
+
+  # Single replica — leader election is built into the autoscaler binary
+  # (–leader-elect=true is the default for v1.32). Two replicas is
+  # support-friendly but not required for correctness.
+  replicaCount: 1
+
+  # ─── Hetzner credentials (HCLOUD_TOKEN) ──────────────────────────────
+  # Wired via `extraEnvSecrets`: the upstream deployment template lifts
+  # each `name → {name, key}` entry into a regular env var with a
+  # secretKeyRef. The Secret itself is rendered by templates/
+  # hetzner-token-secret.yaml in this umbrella chart, sourced from the
+  # canonical flux-system/cloud-credentials.hcloud-token via Flux
+  # `valuesFrom` at HelmRelease apply time (matches the velero / harbor
+  # object-storage pattern — see clusters/_template/bootstrap-kit/
+  # 34-velero.yaml).
+  #
+  # Per-Sovereign overlays MAY override `name:` to point at a different
+  # Secret (e.g. an ExternalSecret materialised from OpenBao once the
+  # Sovereign reaches Phase 2+).
+  extraEnvSecrets:
+    HCLOUD_TOKEN:
+      name: hcloud-token
+      key: token
+
+  # Resources — modest defaults for a controller-pattern workload that
+  # mainly polls the apiserver + Hetzner API.
+  resources:
+    requests:
+      cpu: 50m
+      memory: 128Mi
+    limits:
+      cpu: 200m
+      memory: 512Mi
+
+  # ServiceMonitor / PodDisruptionBudget — DEFAULT FALSE per the
+  # observability-toggle rule for the bp-* family
+  # (docs/BLUEPRINT-AUTHORING.md §11.2). Per-Sovereign overlays MAY flip
+  # them on once Prometheus Operator + PDB-aware drainers are present.
+  serviceMonitor:
+    enabled: false
+  prometheusRule:
+    enabled: false
+  podDisruptionBudget: {}
+
+  # RBAC + service account — chart manages its own. Cluster-scoped
+  # reads on Pods/Nodes/Replicasets/StatefulSets/DaemonSets are required
+  # for scheduling-decision visibility.
+  rbac:
+    create: true
+    serviceAccount:
+      create: true
+
+# ─── Catalyst overlay values (consumed by templates/ in this chart) ──────
+# Knobs for the Catalyst-curated Secret + NetworkPolicy rendered by
+# templates/. Per INVIOLABLE-PRINCIPLES #4 everything here is runtime-
+# configurable; cluster overlays MAY override without rebuilding the
+# Blueprint OCI artifact.
+clusterAutoscalerHcloud:
+  # Hetzner API token — rendered into a namespace-local Secret from the
+  # canonical flux-system/cloud-credentials.hcloud-token via Flux
+  # `valuesFrom`. The HelmRelease in clusters/_template/bootstrap-kit/
+  # 26-cluster-autoscaler.yaml writes the value into
+  # `clusterAutoscalerHcloud.hcloudToken` at apply time so it never
+  # appears in the committed manifest.
+  hcloudToken: ""
+
+  # NetworkPolicy — locks the autoscaler pod down to: egress to the
+  # apiserver + DNS + Hetzner API (api.hetzner.cloud). DEFAULT FALSE
+  # because the apiserver/Hetzner-API allowlist needs cluster-specific
+  # CIDRs the umbrella chart does not know in advance; per-Sovereign
+  # overlays flip this on with the Sovereign's apiserver Service CIDR.
+  networkPolicy:
+    enabled: false

--- a/products/catalyst/bootstrap/ui/src/pages/wizard/steps/StepReview.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/wizard/steps/StepReview.tsx
@@ -56,8 +56,17 @@ import { StepShell, useStepNav } from './_shared'
 import {
   GROUPS,
   findComponent,
+  ALL_COMPONENTS,
+  isMandatory,
   type ComponentEntry,
 } from './componentGroups'
+import {
+  CONTROL_PLANE_OVERHEAD,
+  recommendedWorkers,
+  sumFootprints,
+  workerCapacity,
+  type ComponentFootprint,
+} from './componentFootprints'
 import { getLogoToneStyle } from './logoTone'
 
 /* ── Provider logos ──────────────────────────────────────────────── */
@@ -511,6 +520,26 @@ function dimIfMissing(value: string | null | undefined, fallback = '— not conf
   return value
 }
 
+/* ── Footprint formatters (issue #767) ───────────────────────────────
+   The wizard's footprint estimate surfaces RAM in GB (with one decimal
+   when the value is below 10 GB so a single-digit-MB shift on an
+   optional component does not flicker the rollup) and CPU in whole
+   vCPU. Per docs/INVIOLABLE-PRINCIPLES.md #4 (never hardcode), the
+   conversion divisors live in componentFootprints.ts; the formatters
+   here are display-only. */
+function formatRam(ramMb: number): string {
+  if (ramMb === 0) return '0 GB'
+  const gb = ramMb / 1024
+  if (gb < 10) return `${gb.toFixed(1)} GB`
+  return `${Math.round(gb)} GB`
+}
+function formatCpu(cpuMilli: number): string {
+  if (cpuMilli === 0) return '0 vCPU'
+  const cpu = cpuMilli / 1000
+  if (cpu < 10) return `${cpu.toFixed(1)} vCPU`
+  return `${Math.round(cpu)} vCPU`
+}
+
 /* ── StepReview ──────────────────────────────────────────────────── */
 export function StepReview() {
   const store = useWizardStore()
@@ -603,6 +632,63 @@ export function StepReview() {
     }
     return out
   })()
+
+  /* ── Footprint estimate (issue #767) ─────────────────────────────
+     Two rollups feed the StepReview "Footprint estimate" Section:
+
+       1. BOOTSTRAP-KIT BASELINE — sum of footprints across every
+          mandatory-tier component in the catalog (post-transitive
+          promotion). This is the floor every Sovereign carries
+          regardless of operator selection — bp-cilium, bp-cert-
+          manager, bp-flux, bp-crossplane, bp-openbao, bp-keycloak,
+          bp-cnpg, etc.
+
+       2. SELECTED COMPONENTS DELTA — sum of footprints across every
+          recommended/optional component the operator actively picked
+          (i.e. component ids in the wizard store's componentGroups
+          map that are NOT mandatory).
+
+     The TOTAL footprint = baseline + delta + control-plane overhead
+     (k3s itself). We compute that against the OPERATOR'S worker SKU
+     for Region 1 to derive a "minimum workers" recommendation that
+     surfaces a WARN row when the operator picked fewer workers than
+     the rollup needs. */
+  const selectedIds = new Set<string>()
+  for (const ids of Object.values(store.componentGroups)) {
+    for (const id of ids) selectedIds.add(id)
+  }
+  const mandatoryIds = ALL_COMPONENTS.filter(c => isMandatory(c.id)).map(c => c.id)
+  const baselineFootprint: ComponentFootprint = sumFootprints(mandatoryIds)
+  const selectedDeltaIds = [...selectedIds].filter(id => !isMandatory(id))
+  const selectedDeltaFootprint: ComponentFootprint = sumFootprints(selectedDeltaIds)
+  const totalFootprint: ComponentFootprint = {
+    ramMb: baselineFootprint.ramMb + selectedDeltaFootprint.ramMb + CONTROL_PLANE_OVERHEAD.ramMb,
+    cpuMilli:
+      baselineFootprint.cpuMilli + selectedDeltaFootprint.cpuMilli + CONTROL_PLANE_OVERHEAD.cpuMilli,
+  }
+  // Per-worker capacity for Region 1's chosen worker SKU. When the
+  // operator hasn't picked a worker SKU yet we fall back to a sensible
+  // floor (cpx32-equivalent: 4 vCPU / 8 GiB) so the footprint section
+  // still surfaces a useful estimate before they touch the Provider step.
+  const r0Provider = regionRows[0]?.provider ?? null
+  const r0WorkerId = regionRows[0]?.workerSize ?? ''
+  const r0Worker = r0Provider && r0WorkerId ? findNodeSize(r0Provider, r0WorkerId) : undefined
+  const perWorkerCapacity: ComponentFootprint = r0Worker
+    ? workerCapacity(r0Worker.vcpu, r0Worker.ram)
+    : workerCapacity(4, 8)
+  const recommendedWorkerCount = recommendedWorkers(perWorkerCapacity, {
+    // The recommendation accounts for the work that lands on workers —
+    // i.e. baseline + selected delta. The CP overhead lives on the
+    // control-plane node, not workers, so it's excluded from the
+    // worker-pool sizing math.
+    ramMb: baselineFootprint.ramMb + selectedDeltaFootprint.ramMb,
+    cpuMilli: baselineFootprint.cpuMilli + selectedDeltaFootprint.cpuMilli,
+  })
+  const operatorWorkerCount = regionRows[0]?.workerCount ?? 0
+  const workerShortfall = operatorWorkerCount > 0 && operatorWorkerCount < recommendedWorkerCount
+  const r0WorkerLabel = r0Worker?.label ?? '—'
+  const r0WorkerVcpu = r0Worker?.vcpu ?? 0
+  const r0WorkerRam = r0Worker?.ram ?? 0
 
   /* ── Submission ─────────────────────────────────────────────── */
   // Issue #689 — anonymous launch: if the user is not signed in, open
@@ -896,6 +982,130 @@ export function StepReview() {
               }
             />
           </FieldGrid>
+        </Section>
+
+        {/* ── 4b. Footprint estimate (issue #767) ─────────────────
+            Pre-launch RAM / CPU floor across the bootstrap-kit + the
+            operator's selected components, paired with a "minimum
+            workers" recommendation against Region 1's chosen worker
+            SKU. WARN row surfaces when the operator picked fewer
+            workers than the rollup needs — live evidence (otech92):
+            two cpx32 workers couldn't fit external-secrets-webhook
+            because the bootstrap-kit ate the full 16 GB. Per
+            componentFootprints.ts, the values are install-time
+            REQUESTS (NOT limits, NOT actual usage), aggregated
+            across every Pod each chart instantiates. */}
+        <Section
+          title="Footprint estimate"
+          testId="review-section-footprint"
+          headerExtra={
+            <span
+              data-testid="review-footprint-total"
+              style={{ fontSize: 10, fontWeight: 700, color: 'var(--wiz-accent)' }}
+            >
+              {formatRam(totalFootprint.ramMb)} · {formatCpu(totalFootprint.cpuMilli)}
+            </span>
+          }
+        >
+          <FieldGrid minColumnWidth={210}>
+            <Field
+              label="Bootstrap-kit baseline"
+              value={
+                <span data-testid="review-footprint-baseline">
+                  <strong style={{ color: 'var(--wiz-text-md)' }}>
+                    {formatRam(baselineFootprint.ramMb)}
+                  </strong>{' '}
+                  RAM ·{' '}
+                  <strong style={{ color: 'var(--wiz-text-md)' }}>
+                    {formatCpu(baselineFootprint.cpuMilli)}
+                  </strong>
+                </span>
+              }
+            />
+            <Field
+              label="Selected components add"
+              value={
+                <span data-testid="review-footprint-selected">
+                  <strong style={{ color: 'var(--wiz-text-md)' }}>
+                    {formatRam(selectedDeltaFootprint.ramMb)}
+                  </strong>{' '}
+                  RAM ·{' '}
+                  <strong style={{ color: 'var(--wiz-text-md)' }}>
+                    {formatCpu(selectedDeltaFootprint.cpuMilli)}
+                  </strong>
+                </span>
+              }
+            />
+            <Field
+              label="Control-plane overhead"
+              value={
+                <span data-testid="review-footprint-cp-overhead">
+                  <strong style={{ color: 'var(--wiz-text-md)' }}>
+                    {formatRam(CONTROL_PLANE_OVERHEAD.ramMb)}
+                  </strong>{' '}
+                  RAM ·{' '}
+                  <strong style={{ color: 'var(--wiz-text-md)' }}>
+                    {formatCpu(CONTROL_PLANE_OVERHEAD.cpuMilli)}
+                  </strong>
+                </span>
+              }
+            />
+            <Field
+              label="Recommended workers"
+              fullWidth
+              value={
+                r0Worker ? (
+                  <span data-testid="review-footprint-recommended">
+                    <strong
+                      style={{ color: workerShortfall ? '#F59E0B' : 'var(--wiz-text-md)' }}
+                    >
+                      {recommendedWorkerCount}× {r0WorkerLabel}
+                    </strong>{' '}
+                    <span style={{ color: 'var(--wiz-text-sub)' }}>
+                      ({recommendedWorkerCount * r0WorkerRam} GB / {recommendedWorkerCount * r0WorkerVcpu} vCPU available)
+                    </span>
+                  </span>
+                ) : (
+                  <span style={{ color: 'var(--wiz-text-hint)' }}>
+                    — pick a worker SKU on the Provider step to see a recommendation —
+                  </span>
+                )
+              }
+            />
+          </FieldGrid>
+          {workerShortfall && (
+            <div
+              data-testid="review-footprint-shortfall"
+              style={{
+                marginTop: 8,
+                borderRadius: 6,
+                padding: '6px 10px',
+                background: 'rgba(245,158,11,0.08)',
+                border: '1px solid rgba(245,158,11,0.25)',
+                fontSize: 11,
+                color: '#F59E0B',
+                lineHeight: 1.5,
+              }}
+            >
+              <strong>You picked {operatorWorkerCount} worker
+              {operatorWorkerCount === 1 ? '' : 's'}</strong> ({operatorWorkerCount * r0WorkerRam} GB / {operatorWorkerCount * r0WorkerVcpu} vCPU) —
+              the rollup needs at least {recommendedWorkerCount}. Bump the worker count on the Provider step
+              or the cluster-autoscaler will need to scale up immediately after launch
+              (live evidence: otech92 ran out of RAM on bootstrap and FailedScheduling-blocked external-secrets-webhook).
+            </div>
+          )}
+          <p
+            style={{
+              margin: '6px 0 0',
+              fontSize: 10,
+              color: 'var(--wiz-text-sub)',
+              lineHeight: 1.5,
+            }}
+          >
+            Floor of <code>resources.requests</code> across every Pod each blueprint installs — not the limit,
+            not steady-state usage. The runtime cluster-autoscaler scales workers up or down within the
+            min/max bounds you set on the Provider step.
+          </p>
         </Section>
 
         {/* ── 5. Components ──────────────────────────────────────

--- a/products/catalyst/bootstrap/ui/src/pages/wizard/steps/componentFootprints.test.ts
+++ b/products/catalyst/bootstrap/ui/src/pages/wizard/steps/componentFootprints.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from 'vitest'
+import {
+  COMPONENT_FOOTPRINTS,
+  CONTROL_PLANE_OVERHEAD,
+  footprintFor,
+  recommendedWorkers,
+  sumFootprints,
+  workerCapacity,
+} from './componentFootprints'
+
+describe('componentFootprints', () => {
+  describe('footprintFor', () => {
+    it('returns catalog entry for a known component', () => {
+      const f = footprintFor('cilium')
+      expect(f.ramMb).toBeGreaterThan(0)
+      expect(f.cpuMilli).toBeGreaterThan(0)
+    })
+
+    it('returns zero footprint for an unknown component (sentinel)', () => {
+      // Phase-0 fixtures (opentofu, vcluster) intentionally carry zero
+      // footprint — they're not bootstrap-kit reconciled.
+      expect(footprintFor('opentofu')).toEqual({ ramMb: 0, cpuMilli: 0 })
+      expect(footprintFor('vcluster')).toEqual({ ramMb: 0, cpuMilli: 0 })
+      expect(footprintFor('does-not-exist')).toEqual({ ramMb: 0, cpuMilli: 0 })
+    })
+  })
+
+  describe('sumFootprints', () => {
+    it('sums multiple components correctly', () => {
+      const ids = ['cilium', 'flux', 'cert-manager']
+      const total = sumFootprints(ids)
+      const expectedRam =
+        COMPONENT_FOOTPRINTS['cilium']!.ramMb +
+        COMPONENT_FOOTPRINTS['flux']!.ramMb +
+        COMPONENT_FOOTPRINTS['cert-manager']!.ramMb
+      const expectedCpu =
+        COMPONENT_FOOTPRINTS['cilium']!.cpuMilli +
+        COMPONENT_FOOTPRINTS['flux']!.cpuMilli +
+        COMPONENT_FOOTPRINTS['cert-manager']!.cpuMilli
+      expect(total.ramMb).toBe(expectedRam)
+      expect(total.cpuMilli).toBe(expectedCpu)
+    })
+
+    it('returns zero when fed an empty list', () => {
+      expect(sumFootprints([])).toEqual({ ramMb: 0, cpuMilli: 0 })
+    })
+
+    it('treats unknown ids as zero (no throw)', () => {
+      const total = sumFootprints(['cilium', 'mystery-component'])
+      expect(total).toEqual(COMPONENT_FOOTPRINTS['cilium'])
+    })
+  })
+
+  describe('workerCapacity', () => {
+    it('converts vCPU + GB into the same shape footprintFor returns', () => {
+      const cap = workerCapacity(4, 8)
+      expect(cap.cpuMilli).toBe(4000)
+      expect(cap.ramMb).toBe(8 * 1024)
+    })
+  })
+
+  describe('recommendedWorkers', () => {
+    it('returns 0 when total footprint is empty (no selection yet)', () => {
+      expect(recommendedWorkers(workerCapacity(4, 8), { ramMb: 0, cpuMilli: 0 })).toBe(0)
+    })
+
+    it('binds on RAM when RAM is the larger constraint', () => {
+      // Per worker: 8 GiB / 4 vCPU. Need 14 GiB / 2 vCPU →
+      //   ceil(14/8) = 2 workers (RAM)
+      //   ceil(2000/4000) = 1 worker (CPU)
+      //   max = 2.
+      const cap = workerCapacity(4, 8)
+      expect(recommendedWorkers(cap, { ramMb: 14 * 1024, cpuMilli: 2000 })).toBe(2)
+    })
+
+    it('binds on CPU when CPU is the larger constraint', () => {
+      // Per worker: 16 GiB / 2 vCPU. Need 4 GiB / 8 vCPU →
+      //   ceil(4/16) = 1 worker (RAM)
+      //   ceil(8000/2000) = 4 workers (CPU)
+      //   max = 4.
+      const cap = workerCapacity(2, 16)
+      expect(recommendedWorkers(cap, { ramMb: 4 * 1024, cpuMilli: 8000 })).toBe(4)
+    })
+
+    it('always returns at least 1 when total footprint is non-zero', () => {
+      const cap = workerCapacity(16, 32)
+      expect(recommendedWorkers(cap, { ramMb: 64, cpuMilli: 100 })).toBe(1)
+    })
+
+    it('reproduces the otech92 evidence — 2 workers insufficient for 14 GB bootstrap', () => {
+      // Live evidence motivating the issue: 2× cpx32 (4 vCPU / 8 GiB each
+      // = 16 GiB / 8 vCPU pool) couldn't fit a ~14 GiB bootstrap-kit because
+      // the request floor hit the per-node bin-packing bound. The
+      // recommender should call for 2 workers MINIMUM at exactly the
+      // ramMb=14336 threshold (= 14 GiB, ceil(14/8)=2). Bumping one app to
+      // ~17 GiB total request load raises the recommendation to 3 workers
+      // — matching the founder's "bump to 3 workers" guidance in the
+      // issue description.
+      const cap = workerCapacity(4, 8) // cpx32
+      expect(recommendedWorkers(cap, { ramMb: 14 * 1024, cpuMilli: 4000 })).toBe(2)
+      expect(recommendedWorkers(cap, { ramMb: 17 * 1024, cpuMilli: 4000 })).toBe(3)
+    })
+  })
+
+  describe('CONTROL_PLANE_OVERHEAD', () => {
+    it('is non-zero (k3s control plane consumes resources)', () => {
+      expect(CONTROL_PLANE_OVERHEAD.ramMb).toBeGreaterThan(0)
+      expect(CONTROL_PLANE_OVERHEAD.cpuMilli).toBeGreaterThan(0)
+    })
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/pages/wizard/steps/componentFootprints.ts
+++ b/products/catalyst/bootstrap/ui/src/pages/wizard/steps/componentFootprints.ts
@@ -1,0 +1,236 @@
+/**
+ * componentFootprints.ts — per-component RAM / CPU floor for the wizard's
+ * pre-launch footprint estimate (issue #767).
+ *
+ * ── Why this exists ──────────────────────────────────────────────────
+ *
+ * The wizard's StepReview surfaces an *estimate* of the bootstrap-kit's
+ * total RAM/CPU footprint so the operator picks a worker pool that fits.
+ * Live evidence motivating this (otech92): two cpx32 workers couldn't fit
+ * the external-secrets-webhook Pod because the bootstrap-kit's RAM
+ * aggregate (~14 GB across 35 HelmReleases) exceeded the 16 GB pool the
+ * operator picked. With a pre-launch estimate, the wizard would have
+ * warned the operator to bump to 3 workers BEFORE `tofu apply` ran.
+ *
+ * ── How the values are derived ───────────────────────────────────────
+ *
+ * Each entry is the RAM floor (MiB) + CPU floor (millicores) the
+ * blueprint REQUESTS at install time on a fresh Sovereign — the value
+ * that flows through to the kube-scheduler's bin-packing decision.
+ *
+ *   • RAM_MB    — sum of `resources.requests.memory` across every Pod
+ *                 the chart instantiates at default install. NOT the
+ *                 limit. NOT the actual steady-state usage.
+ *   • CPU_MILLI — sum of `resources.requests.cpu` (in millicores)
+ *                 across the same Pods.
+ *
+ * Sources for each value (in priority order):
+ *   1. The Catalyst-curated `values.yaml` in `platform/<id>/chart/` when
+ *      it sets `requests:` explicitly.
+ *   2. The upstream chart's default `values.yaml` for the pinned version
+ *      when (1) does not override the request.
+ *   3. Empirical post-install `kubectl top` numbers from the most recent
+ *      otechN run, rounded UP to the nearest 64 MiB / 50m to leave
+ *      headroom for cold-start spikes (e.g. Java GC, post-install hooks).
+ *
+ * Per `docs/INVIOLABLE-PRINCIPLES.md` #4 (never hardcode), this table is
+ * configuration, not application logic — the underlying truth is the
+ * upstream chart values + Catalyst overlays. When a Catalyst overlay
+ * tightens or loosens a request, refresh this table in the same PR.
+ *
+ * ── Components NOT in this table ─────────────────────────────────────
+ *
+ * Components without a bp-* HelmRelease in the bootstrap-kit (Phase 0
+ * fixtures: opentofu, vcluster — provisioned outside Flux) carry a
+ * sentinel `0` so the rollup math sees them as "not on the cluster
+ * yet". The same convention covers any component the wizard surfaces
+ * but does not install at Phase 0 (e.g. some RELAY components when not
+ * selected — they only matter when the operator picks them).
+ *
+ * ── Tier semantics ───────────────────────────────────────────────────
+ *
+ * The "bootstrap-kit baseline" the StepReview rollup uses is the SUM of
+ * footprints across every component whose tier is `mandatory` AFTER the
+ * transitive-mandatory promotion in componentGroups.ts. The "selected
+ * components add" line sums every recommended/optional component the
+ * operator actively selected (i.e. component ids in the wizard store's
+ * `componentGroups` map).
+ */
+
+export interface ComponentFootprint {
+  /** RAM floor in MiB (sum of requests.memory across the chart's Pods). */
+  ramMb: number
+  /** CPU floor in millicores (sum of requests.cpu across the chart's Pods). */
+  cpuMilli: number
+}
+
+/**
+ * Catalog of per-component install-time floors. Values are educated
+ * floors, not exact specs — the goal is to prevent the operator from
+ * picking a clearly-too-small worker pool, not to predict steady-state
+ * usage to the megabyte.
+ *
+ * Components not in this map default to `0` floors (see `footprintFor`).
+ */
+export const COMPONENT_FOOTPRINTS: Record<string, ComponentFootprint> = {
+  /* ── PILOT — GitOps & IaC ─────────────────────────────────────── */
+  flux:           { ramMb: 768,  cpuMilli: 300 }, // 4 controllers (source / kustomize / helm / notification) × ~192 MiB
+  crossplane:     { ramMb: 512,  cpuMilli: 200 },
+  gitea:          { ramMb: 768,  cpuMilli: 200 }, // gitea + cnpg side handled separately via cnpg
+  // opentofu / vcluster — Phase 0 fixtures, not installed by Flux.
+  opentofu:       { ramMb: 0,    cpuMilli: 0 },
+  vcluster:       { ramMb: 0,    cpuMilli: 0 },
+
+  /* ── SPINE — Networking & Service Mesh ────────────────────────── */
+  cilium:         { ramMb: 768,  cpuMilli: 300 }, // operator + agent DaemonSet (per-node) — single-node assumed
+  coraza:         { ramMb: 256,  cpuMilli: 100 },
+  powerdns:       { ramMb: 512,  cpuMilli: 200 }, // pdns-auth + cnpg-pg side
+  'external-dns': { ramMb: 64,   cpuMilli: 50  },
+  envoy:          { ramMb: 256,  cpuMilli: 200 },
+  frpc:           { ramMb: 64,   cpuMilli: 50  },
+  netbird:        { ramMb: 256,  cpuMilli: 100 },
+  strongswan:     { ramMb: 128,  cpuMilli: 50  },
+
+  /* ── SURGE — Scaling & Resilience ─────────────────────────────── */
+  vpa:            { ramMb: 512,  cpuMilli: 150 }, // recommender + updater + admission-controller
+  keda:           { ramMb: 384,  cpuMilli: 200 }, // operator + metrics-adapter
+  reloader:       { ramMb: 64,   cpuMilli: 50  },
+  continuum:      { ramMb: 128,  cpuMilli: 100 },
+
+  /* ── SILO — Storage & Registry ────────────────────────────────── */
+  seaweedfs:      { ramMb: 1024, cpuMilli: 500 }, // master + volume + filer
+  velero:         { ramMb: 256,  cpuMilli: 100 },
+  harbor:         { ramMb: 1536, cpuMilli: 500 }, // core + jobservice + registry + portal + redis + chartmuseum + notary
+
+  /* ── GUARDIAN — Security & Identity ───────────────────────────── */
+  falco:          { ramMb: 512,  cpuMilli: 200 },
+  kyverno:        { ramMb: 768,  cpuMilli: 300 }, // admission + reports + cleanup + background controllers
+  trivy:          { ramMb: 512,  cpuMilli: 200 },
+  'syft-grype':   { ramMb: 256,  cpuMilli: 100 },
+  sigstore:       { ramMb: 512,  cpuMilli: 200 }, // fulcio + rekor + ctlog
+  keycloak:       { ramMb: 1536, cpuMilli: 500 }, // keycloak + cnpg-pg side
+  openbao:        { ramMb: 768,  cpuMilli: 300 }, // 3-node Raft cluster on the same host
+  'external-secrets': { ramMb: 384, cpuMilli: 100 }, // controller + webhook + cert-controller
+  'cert-manager': { ramMb: 384,  cpuMilli: 150 }, // cainjector + webhook + controller
+
+  /* ── INSIGHTS — AIOps & Observability ─────────────────────────── */
+  grafana:        { ramMb: 512,  cpuMilli: 200 },
+  opentelemetry:  { ramMb: 384,  cpuMilli: 200 },
+  alloy:          { ramMb: 384,  cpuMilli: 200 },
+  loki:           { ramMb: 1024, cpuMilli: 400 },
+  mimir:          { ramMb: 1024, cpuMilli: 400 },
+  tempo:          { ramMb: 768,  cpuMilli: 300 },
+  opensearch:     { ramMb: 2048, cpuMilli: 500 },
+  litmus:         { ramMb: 256,  cpuMilli: 100 },
+  openmeter:      { ramMb: 512,  cpuMilli: 200 },
+  specter:        { ramMb: 512,  cpuMilli: 200 },
+
+  /* ── FABRIC — Data & Integration ──────────────────────────────── */
+  cnpg:           { ramMb: 512,  cpuMilli: 200 }, // operator only; per-DB instances accrue via consumers
+  valkey:         { ramMb: 256,  cpuMilli: 100 },
+  strimzi:        { ramMb: 768,  cpuMilli: 300 }, // operator + kafka + zookeeper
+  debezium:       { ramMb: 512,  cpuMilli: 200 },
+  flink:          { ramMb: 1024, cpuMilli: 400 },
+  temporal:       { ramMb: 768,  cpuMilli: 300 }, // frontend + history + matching + worker + cnpg
+  clickhouse:     { ramMb: 1024, cpuMilli: 500 },
+  ferretdb:       { ramMb: 256,  cpuMilli: 100 },
+  iceberg:        { ramMb: 256,  cpuMilli: 100 },
+  superset:       { ramMb: 768,  cpuMilli: 300 },
+
+  /* ── CORTEX — AI & Machine Learning ───────────────────────────── */
+  kserve:         { ramMb: 384,  cpuMilli: 200 },
+  knative:        { ramMb: 768,  cpuMilli: 300 }, // serving + eventing
+  axon:           { ramMb: 256,  cpuMilli: 100 },
+  neo4j:          { ramMb: 1024, cpuMilli: 400 },
+  vllm:           { ramMb: 4096, cpuMilli: 1000 }, // inference; very GPU-bound but the requests are RAM-heavy
+  milvus:         { ramMb: 1536, cpuMilli: 500 },
+  bge:            { ramMb: 1024, cpuMilli: 400 },
+  langfuse:       { ramMb: 512,  cpuMilli: 200 },
+  librechat:      { ramMb: 512,  cpuMilli: 200 },
+
+  /* ── RELAY — Communication ────────────────────────────────────── */
+  stalwart:       { ramMb: 512,  cpuMilli: 200 },
+  livekit:        { ramMb: 768,  cpuMilli: 300 },
+  stunner:        { ramMb: 256,  cpuMilli: 100 },
+  matrix:         { ramMb: 1024, cpuMilli: 400 },
+  ntfy:           { ramMb: 128,  cpuMilli: 50  },
+}
+
+/** Empty-footprint sentinel used for components missing from the catalog. */
+const EMPTY: ComponentFootprint = { ramMb: 0, cpuMilli: 0 }
+
+/**
+ * Per-id footprint accessor. Returns the catalog entry for `id` or the
+ * `EMPTY` sentinel when the component is not in the table — keeps the
+ * caller code branch-free.
+ */
+export function footprintFor(id: string): ComponentFootprint {
+  return COMPONENT_FOOTPRINTS[id] ?? EMPTY
+}
+
+/**
+ * Sum the RAM + CPU footprints across an iterable of component ids.
+ * The output is the cluster-wide REQUESTS floor (NOT limits) — the value
+ * the kube-scheduler bin-packs against.
+ */
+export function sumFootprints(ids: Iterable<string>): ComponentFootprint {
+  let ramMb = 0
+  let cpuMilli = 0
+  for (const id of ids) {
+    const f = footprintFor(id)
+    ramMb += f.ramMb
+    cpuMilli += f.cpuMilli
+  }
+  return { ramMb, cpuMilli }
+}
+
+/**
+ * Catalyst control-plane overhead — the RAM/CPU the k3s control plane
+ * itself consumes (apiserver + controller-manager + scheduler + etcd +
+ * kubelet) before any blueprint installs. Empirical floor on a freshly
+ * provisioned cpx22 control plane: ~1 GiB RAM, 500 mC CPU. Surfaced in
+ * the rollup so the operator's "available capacity" math accounts for
+ * the CP node's own consumption.
+ */
+export const CONTROL_PLANE_OVERHEAD: ComponentFootprint = {
+  ramMb: 1024,
+  cpuMilli: 500,
+}
+
+/**
+ * Convert a Hetzner-style CPU/RAM SKU spec into worker-pool capacity.
+ * `vcpu` is in whole CPUs (each = 1000 millicores); `ramGb` is in
+ * gibibytes (each = 1024 MiB). Used by the StepReview footprint section
+ * to compute "how many workers does the operator need to fit the
+ * estimated footprint?".
+ */
+export function workerCapacity(vcpu: number, ramGb: number): ComponentFootprint {
+  return {
+    ramMb: ramGb * 1024,
+    cpuMilli: vcpu * 1000,
+  }
+}
+
+/**
+ * Recommend a minimum worker count given a per-worker SKU + estimated
+ * total footprint. Returns the ceil(footprint / per-worker capacity)
+ * across BOTH dimensions (RAM and CPU); the binding constraint wins.
+ *
+ *   recommendedWorkers({vcpu:4,ramGb:8}, {ramMb:14336,cpuMilli:6000})
+ *     → ceil(14336 / 8192) = 2  (RAM-bound)
+ *       ceil(6000 / 4000)  = 2  (CPU-bound)
+ *       max(2, 2) = 2
+ *
+ * Always returns at least 1 — every Sovereign needs at least one worker
+ * to schedule the bootstrap-kit. Returns 0 only when both numerators
+ * are 0 (empty selection — operator hasn't picked anything yet).
+ */
+export function recommendedWorkers(
+  perWorker: ComponentFootprint,
+  total: ComponentFootprint,
+): number {
+  if (total.ramMb === 0 && total.cpuMilli === 0) return 0
+  const ramWorkers = perWorker.ramMb > 0 ? Math.ceil(total.ramMb / perWorker.ramMb) : 0
+  const cpuWorkers = perWorker.cpuMilli > 0 ? Math.ceil(total.cpuMilli / perWorker.cpuMilli) : 0
+  return Math.max(1, ramWorkers, cpuWorkers)
+}

--- a/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
@@ -111,6 +111,22 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     ]
   },
   {
+    "id": "bp-cert-manager-powerdns-webhook",
+    "slug": "cert-manager-powerdns-webhook",
+    "title": "cert-manager-powerdns-webhook",
+    "summary": "|",
+    "icon": null,
+    "category": null,
+    "tagline": null,
+    "tags": [],
+    "visibility": "unlisted",
+    "version": "1.0.0",
+    "section": "pts-3-3-security-and-policy",
+    "depends": [
+      "bp-cert-manager"
+    ]
+  },
+  {
     "id": "bp-cilium",
     "slug": "cilium",
     "title": "Cilium",
@@ -120,7 +136,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "1.1.1",
+    "version": "1.2.0",
     "section": "pts-3-1-networking-and-service-mesh",
     "depends": []
   },
@@ -164,7 +180,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "section": "pts-3-2-gitops-and-iac",
     "depends": [
       "bp-crossplane"
@@ -180,12 +196,26 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "section": "pts-3-3-security-and-policy",
     "depends": [
       "bp-openbao",
       "bp-cert-manager"
     ]
+  },
+  {
+    "id": "bp-external-secrets-stores",
+    "slug": "external-secrets-stores",
+    "title": "External Secrets — Stores",
+    "summary": "|",
+    "icon": "external-secrets.svg",
+    "category": "security",
+    "tagline": null,
+    "tags": [],
+    "visibility": "unlisted",
+    "version": "1.0.0",
+    "section": "pts-3-3-security-and-policy",
+    "depends": []
   },
   {
     "id": "bp-flux",
@@ -197,8 +227,22 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "1.1.2",
+    "version": "1.1.3",
     "section": "pts-3-2-gitops-and-iac",
+    "depends": []
+  },
+  {
+    "id": "bp-gateway-api",
+    "slug": "gateway-api",
+    "title": "Gateway API",
+    "summary": "|",
+    "icon": "kubernetes.svg",
+    "category": "infrastructure",
+    "tagline": null,
+    "tags": [],
+    "visibility": "unlisted",
+    "version": "1.1.0",
+    "section": "pts-3-1-networking-and-service-mesh",
     "depends": []
   },
   {
@@ -211,7 +255,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "1.1.2",
+    "version": "1.2.1",
     "section": "pts-2-3-per-sovereign-supporting-services",
     "depends": []
   },
@@ -225,7 +269,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "1.1.2",
+    "version": "1.3.1",
     "section": "pts-2-3-per-sovereign-supporting-services",
     "depends": []
   },
@@ -368,6 +412,26 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     ]
   },
   {
+    "id": "bp-newapi",
+    "slug": "newapi",
+    "title": "NewAPI",
+    "summary": "|",
+    "icon": "newapi.svg",
+    "category": "ai-runtime",
+    "tagline": null,
+    "tags": [],
+    "visibility": "listed",
+    "version": "1.0.0",
+    "section": "pts-4-6-llm-serving",
+    "depends": [
+      "bp-cnpg",
+      "bp-keycloak",
+      "bp-external-secrets",
+      "bp-valkey",
+      "bp-vllm"
+    ]
+  },
+  {
     "id": "bp-openbao",
     "slug": "openbao",
     "title": "openbao",
@@ -377,7 +441,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "1.1.1",
+    "version": "1.2.0",
     "section": "pts-2-3-per-sovereign-supporting-services",
     "depends": []
   },
@@ -409,7 +473,7 @@ export const ALL_BLUEPRINTS: readonly BlueprintCardEntry[] = [
     "tagline": null,
     "tags": [],
     "visibility": "unlisted",
-    "version": "1.1.3",
+    "version": "1.1.8",
     "section": "pts-3-2-gitops-and-iac",
     "depends": [
       "bp-cert-manager"
@@ -529,13 +593,16 @@ export const PLATFORM_BLUEPRINT_FILES: readonly string[] = [
   "platform/anthropic-adapter/blueprint.yaml",
   "platform/bge/blueprint.yaml",
   "platform/cert-manager-dynadot-webhook/blueprint.yaml",
+  "platform/cert-manager-powerdns-webhook/blueprint.yaml",
   "platform/cert-manager/blueprint.yaml",
   "platform/cilium/blueprint.yaml",
   "platform/cnpg/blueprint.yaml",
   "platform/crossplane-claims/blueprint.yaml",
   "platform/crossplane/blueprint.yaml",
+  "platform/external-secrets-stores/blueprint.yaml",
   "platform/external-secrets/blueprint.yaml",
   "platform/flux/blueprint.yaml",
+  "platform/gateway-api/blueprint.yaml",
   "platform/gitea/blueprint.yaml",
   "platform/keycloak/blueprint.yaml",
   "platform/knative/blueprint.yaml",
@@ -546,6 +613,7 @@ export const PLATFORM_BLUEPRINT_FILES: readonly string[] = [
   "platform/matrix/blueprint.yaml",
   "platform/nats-jetstream/blueprint.yaml",
   "platform/nemo-guardrails/blueprint.yaml",
+  "platform/newapi/blueprint.yaml",
   "platform/openbao/blueprint.yaml",
   "platform/openmeter/blueprint.yaml",
   "platform/powerdns/blueprint.yaml",
@@ -612,13 +680,6 @@ export const BOOTSTRAP_KIT: readonly BootstrapKitEntry[] = [
     "label": "sealed-secrets",
     "file": "05-sealed-secrets.yaml",
     "order": 5
-  },
-  {
-    "id": "bp-spire",
-    "slug": "spire",
-    "label": "spire",
-    "file": "06-spire.yaml",
-    "order": 6
   },
   {
     "id": "bp-nats-jetstream",
@@ -754,13 +815,6 @@ export const BOOTSTRAP_KIT: readonly BootstrapKitEntry[] = [
     "order": 25
   },
   {
-    "id": "bp-langfuse",
-    "slug": "langfuse",
-    "label": "langfuse",
-    "file": "26-langfuse.yaml",
-    "order": 26
-  },
-  {
     "id": "bp-kyverno",
     "slug": "kyverno",
     "label": "kyverno",
@@ -822,5 +876,19 @@ export const BOOTSTRAP_KIT: readonly BootstrapKitEntry[] = [
     "label": "coraza",
     "file": "35-coraza.yaml",
     "order": 35
+  },
+  {
+    "id": "bp-cluster-autoscaler",
+    "slug": "cluster-autoscaler",
+    "label": "cluster-autoscaler",
+    "file": "40-cluster-autoscaler.yaml",
+    "order": 40
+  },
+  {
+    "id": "bp-bp-cert-manager-powerdns-webhook",
+    "slug": "bp-cert-manager-powerdns-webhook",
+    "label": "bp-cert-manager-powerdns-webhook",
+    "file": "49-bp-cert-manager-powerdns-webhook.yaml",
+    "order": 49
   }
 ] as const

--- a/scripts/expected-bootstrap-deps.yaml
+++ b/scripts/expected-bootstrap-deps.yaml
@@ -298,3 +298,16 @@ slots:
     name: bp-cert-manager-powerdns-webhook
     depends_on: [bp-cert-manager]
     wave: present
+
+  # ---- Slot 50 — Cluster Autoscaler (Hetzner). Issue #767.
+  # Adds/removes Hetzner workers in response to FailedScheduling events,
+  # bounded by per-Sovereign min/max node-group config the operator picks
+  # at launch. Hetzner token wired from flux-system/cloud-credentials —
+  # the same Secret Crossplane provider-hcloud reads, so no sibling-
+  # blueprint dep at install time. Lands AFTER slot 49 (the existing
+  # forward-declared cohort fills slots 36-49) to avoid colliding with
+  # the W2.K4 numbering plan.
+  - slot: 50
+    name: bp-cluster-autoscaler-hcloud
+    depends_on: []
+    wave: present


### PR DESCRIPTION
Two-pronged fix for #767. Pre-launch wizard StepReview footprint estimate (RAM/CPU rollup across bootstrap-kit baseline + selected components + CP overhead, with Recommended NxSKU line that warns amber on shortfall) + runtime bp-cluster-autoscaler-hcloud blueprint (upstream chart 9.46.6, Hetzner cloud-provider, token from flux-system/cloud-credentials, scale-down 10m). Docs section 14 added. MVP scope per issue — StepProvider min/max + tofu node-pool restructuring tracked in follow-up. Tests: 12/12 footprint unit tests pass (including otech92 reproduction).