### PR TITLE
feat(handover): auto-fire on Phase1 Ready + UI redirect (closes #764, #768)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/deployments.go
+++ b/products/catalyst/bootstrap/api/internal/handler/deployments.go
@@ -710,6 +710,19 @@ func (d *Deployment) State() map[string]any {
 		if d.Result.Phase1Outcome != "" {
 			out["phase1Outcome"] = d.Result.Phase1Outcome
 		}
+		// Issues #764 + #768 — lift the handover-fire surface to the
+		// top level so the wizard's provision-page reducer can drive
+		// the "Open your Sovereign console →" button + auto-redirect
+		// without unwrapping result. handoverURL is the canonical
+		// post-mint redirect; handoverFiredAt is the proof-of-fire
+		// timestamp the UI uses to render the toast exactly once
+		// even on a poll-after-SSE-reconnect.
+		if d.Result.HandoverURL != "" {
+			out["handoverURL"] = d.Result.HandoverURL
+		}
+		if d.Result.HandoverFiredAt != nil {
+			out["handoverFiredAt"] = d.Result.HandoverFiredAt.UTC().Format(time.RFC3339)
+		}
 	}
 	// adoptedAt — handover-finalisation flag (issue #317) lifted to the
 	// top level so the UI's beforeLoad redirect (issue #319) reads it
@@ -1158,7 +1171,7 @@ func (h *Handler) StreamLogs(w http.ResponseWriter, r *http.Request) {
 	// of an empty shell — a browser that connects after `event: done`
 	// arrived at an already-closed channel previously got nothing.
 	for _, ev := range dep.snapshotEvents() {
-		fmt.Fprintf(w, "data: %s\n\n", mustJSON(ev))
+		writeSSEEvent(w, ev)
 	}
 	flusher.Flush()
 
@@ -1186,10 +1199,63 @@ func (h *Handler) StreamLogs(w http.ResponseWriter, r *http.Request) {
 				flusher.Flush()
 				return
 			}
-			fmt.Fprintf(w, "data: %s\n\n", mustJSON(ev))
+			writeSSEEvent(w, ev)
 			flusher.Flush()
 		}
 	}
+}
+
+// PhaseHandoverReady — Phase value set on a synthesized provisioner.Event
+// when catalyst-api auto-fires the handover JWT mint after the Phase-1
+// watch terminates with OutcomeReady (issues #764 + #768). The event's
+// Message carries a JSON object `{"handoverURL": "...", "expiresAt":
+// "..."}` (RFC 3339 expiry, RS256 token contract — see
+// internal/handoverjwt/signer.go).
+//
+// StreamLogs renders this Event as a typed SSE event:
+//
+//	event: handover-ready
+//	data: {"handoverURL": "...", "expiresAt": "..."}
+//
+// The wizard's useDeploymentEvents hook listens via
+// EventSource.addEventListener('handover-ready', ...) so the typed
+// channel is independent of the default `message` event reducer.
+//
+// Per docs/INVIOLABLE-PRINCIPLES.md #4 the URL is built from the
+// Sovereign FQDN persisted on the deployment record + the JWT minted
+// by handoverjwt.Signer.MintToken — no hardcoded host.
+const PhaseHandoverReady = "handover-ready"
+
+// writeSSEEvent renders a single provisioner.Event onto an SSE stream.
+//
+// Default rendering is the legacy shape:
+//
+//	data: <json-of-event>
+//
+// (no `event:` prefix → the browser dispatches it as the default
+// `message` event, which the existing reducer consumes).
+//
+// The single typed-event branch is `Phase == PhaseHandoverReady`,
+// which renders:
+//
+//	event: handover-ready
+//	data: <Event.Message verbatim>
+//
+// Event.Message for the handover-ready event is already a JSON object
+// — see Handler.fireHandover in phase1_watch.go. The wizard's
+// addEventListener('handover-ready', ...) parses it directly without
+// the Event wrapper.
+func writeSSEEvent(w http.ResponseWriter, ev provisioner.Event) {
+	if ev.Phase == PhaseHandoverReady {
+		// The Message field is the canonical JSON payload —
+		// emit it verbatim under the typed event channel. No
+		// double-wrapping in the Event struct, so the Sovereign UI's
+		// addEventListener handler receives the exact shape #768
+		// specifies: {"handoverURL": "...", "expiresAt": "..."}.
+		fmt.Fprintf(w, "event: %s\ndata: %s\n\n", PhaseHandoverReady, ev.Message)
+		return
+	}
+	fmt.Fprintf(w, "data: %s\n\n", mustJSON(ev))
 }
 
 // GetDeploymentEvents returns the buffered event history + state JSON for

--- a/products/catalyst/bootstrap/api/internal/handler/phase1_watch.go
+++ b/products/catalyst/bootstrap/api/internal/handler/phase1_watch.go
@@ -29,10 +29,14 @@ package handler
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"net/url"
 	"os"
+	"strings"
 	"time"
 
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/handoverjwt"
 	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/helmwatch"
 	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/provisioner"
 )
@@ -364,6 +368,155 @@ func (h *Handler) markPhase1Done(dep *Deployment, finalStates map[string]string,
 		"failedCount", failed,
 		"finalStatus", finalStatus,
 		"phase1Outcome", outcome,
+	)
+
+	// Issues #764 + #768 — auto-fire the handover JWT mint immediately
+	// after Phase-1 reaches OutcomeReady. Until this landed, the
+	// operator was stranded on the wizard's provision page after a
+	// successful provision: the page rendered the apps grid in
+	// terminal-completed state but the "Open your Sovereign console →"
+	// button + the auto-redirect never appeared because the JWT mint
+	// was a manual operator step (POST /deployments/{id}/mint-handover-
+	// token, called by a button the wizard never showed unless the SSE
+	// banner specifically prompted it).
+	//
+	// Auto-fire happens here, AFTER the lock is released and AFTER the
+	// terminal Status flip is persisted, so the SSE event the
+	// fireHandover helper emits is guaranteed to land on the durable
+	// buffer ordered AFTER the Phase-1 terminal events. Tests assert
+	// the buffer ordering invariant; the wizard's reducer relies on
+	// it.
+	if outcome == helmwatch.OutcomeReady && finalStatus == "ready" {
+		h.fireHandover(dep)
+	}
+}
+
+// fireHandover mints a handover JWT, persists handoverFiredAt +
+// handoverURL onto the deployment record, and emits a typed SSE event
+// `event: handover-ready, data: { handoverURL, expiresAt }` so the
+// wizard's provision page can render the "Open your Sovereign console
+// →" button + auto-redirect immediately (issues #764 + #768).
+//
+// The mint goes through h.handoverSigner — the same Signer that backs
+// the manual POST /deployments/{id}/mint-handover-token endpoint
+// (handover_jwt.go). Token claims contract is documented on
+// internal/handoverjwt/signer.go (RS256, 5-minute TTL,
+// aud=https://console.<sovereignFqdn>). The same private key the
+// manual endpoint uses signs the auto-fire token, so Sovereign-side
+// /auth/handover (already live on every otech9X provision) accepts it
+// without any new key distribution.
+//
+// Idempotency: the function checks dep.Result.HandoverFiredAt ==
+// nil under dep.mu before minting, so a double-fire from a helmwatch
+// flake (informer disconnect + reattach + re-emit terminal event)
+// does NOT mint a second JWT. The first mint wins; the second call
+// returns silently without emitting a duplicate SSE event.
+//
+// Failure modes:
+//   - h.handoverSigner is nil — log + skip. Production catalyst-api
+//     always has a wired Signer (cmd/api/main.go LoadOrGenerate's the
+//     keypair on first boot); a nil Signer is the test-only or
+//     misconfigured-CI path. The wizard falls back to the manual
+//     mint-handover-token endpoint that the operator can hit via the
+//     existing "Open Sovereign console" button on the AdminPage.
+//   - dep.Request.SovereignFQDN empty — log + skip. Same fallback.
+//   - h.handoverSigner.MintToken returns an error — log + skip. The
+//     UI's status=ready + handoverURL=="" branch renders a manual-
+//     mint button so the operator is never silently stranded.
+//
+// Per docs/INVIOLABLE-PRINCIPLES.md #10 the JWT itself is NEVER logged
+// — only the deployment id + the post-mint expiry timestamp lands in
+// structured logs.
+func (h *Handler) fireHandover(dep *Deployment) {
+	if h.handoverSigner == nil {
+		h.log.Warn("handover auto-fire: signer not configured; skipping mint",
+			"id", dep.ID,
+		)
+		return
+	}
+
+	dep.mu.Lock()
+	if dep.Result == nil || dep.Result.HandoverFiredAt != nil {
+		// Already fired (a duplicate markPhase1Done from an informer
+		// reattach raced this path) — leave it alone. The original
+		// handoverURL + handoverFiredAt remain on the record.
+		dep.mu.Unlock()
+		return
+	}
+	fqdn := dep.Request.SovereignFQDN
+	depID := dep.ID
+	owner := dep.OwnerEmail
+	if owner == "" {
+		// Fall back to OrgEmail — pre-#689 deployments may have an
+		// empty OwnerEmail but still carry a valid OrgEmail (e.g.
+		// the wizard's PIN-auth flow stamps both with the same
+		// session.email value at CreateDeployment time).
+		owner = dep.Request.OrgEmail
+	}
+	dep.mu.Unlock()
+
+	if strings.TrimSpace(fqdn) == "" {
+		h.log.Warn("handover auto-fire: deployment has no SovereignFQDN; skipping",
+			"id", depID,
+		)
+		return
+	}
+	if strings.TrimSpace(owner) == "" {
+		// Sub claim must be non-empty for the Sovereign-side handover
+		// handler to bind a session. Surface the misconfiguration
+		// loudly — a manual mint via the existing endpoint can recover
+		// once the operator re-authenticates.
+		h.log.Warn("handover auto-fire: deployment has no owner email; skipping (operator can manual-mint via /mint-handover-token)",
+			"id", depID,
+		)
+		return
+	}
+
+	tokenStr, err := h.handoverSigner.MintToken(fqdn, depID, owner, owner)
+	if err != nil {
+		h.log.Error("handover auto-fire: MintToken failed",
+			"id", depID,
+			"fqdn", fqdn,
+			"err", err,
+		)
+		return
+	}
+	now := time.Now().UTC()
+	expiresAt := now.Add(handoverjwt.DefaultTTL)
+	handoverURL := "https://console." + fqdn + "/auth/handover?token=" + url.QueryEscape(tokenStr)
+
+	// Persist the URL + timestamp on the deployment record under the
+	// lock. Doing this BEFORE the SSE emit guarantees a /deployments/
+	// {id} GET that races the SSE event sees the same value the
+	// emit carries — no flap window where the typed event arrived
+	// but the durable record disagreed.
+	dep.mu.Lock()
+	if dep.Result != nil {
+		dep.Result.HandoverFiredAt = &now
+		dep.Result.HandoverURL = handoverURL
+	}
+	dep.mu.Unlock()
+	h.persistDeployment(dep)
+
+	// Emit the typed SSE event. The Message field IS the data payload
+	// (see writeSSEEvent in deployments.go) — a JSON object the
+	// wizard parses verbatim. Per #768's contract the payload is
+	// `{handoverURL, expiresAt}`.
+	payload, _ := json.Marshal(map[string]string{
+		"handoverURL": handoverURL,
+		"expiresAt":   expiresAt.Format(time.RFC3339),
+	})
+	h.emitWatchEvent(dep, provisioner.Event{
+		Time:    now.Format(time.RFC3339),
+		Phase:   PhaseHandoverReady,
+		Level:   "info",
+		Message: string(payload),
+	})
+
+	h.log.Info("handover auto-fire: minted + staged",
+		"id", depID,
+		"fqdn", fqdn,
+		"expiresAt", expiresAt.Format(time.RFC3339),
 	)
 }
 

--- a/products/catalyst/bootstrap/api/internal/handler/phase1_watch_handover_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/phase1_watch_handover_test.go
@@ -1,0 +1,412 @@
+// Tests for the catalyst-api auto-fire of the handover JWT mint after the
+// Phase-1 watch terminates with OutcomeReady (issues #764 + #768).
+//
+// What this file proves:
+//
+//  1. markPhase1Done's terminal Ready transition triggers fireHandover
+//     when h.handoverSigner is wired — Result.HandoverFiredAt and
+//     Result.HandoverURL are populated, and the typed
+//     `handover-ready` SSE event lands in the durable buffer.
+//  2. A non-Ready terminal outcome (failed, kubeconfig-missing, …)
+//     does NOT fire the handover — the URL + timestamp stay nil.
+//  3. The auto-fire is idempotent: a second markPhase1Done call (e.g.
+//     informer reattach + re-emit) does NOT mint a second JWT or emit
+//     a duplicate SSE event.
+//  4. fireHandover is a no-op when h.handoverSigner is nil — the
+//     existing tests that build Handler{} without a Signer continue
+//     to flip Status to "ready" without crashing.
+//  5. StreamLogs renders a buffered handover-ready event as the typed
+//     SSE shape `event: handover-ready, data: {handoverURL, expiresAt}`
+//     — the wizard's addEventListener('handover-ready', …) consumes
+//     this contract.
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/handoverjwt"
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/helmwatch"
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/provisioner"
+)
+
+// loadTestSigner returns a real handoverjwt.Signer wired with a freshly
+// generated RSA-2048 keypair. Each test gets its own pair — the
+// generation cost (~50 ms on a developer laptop, sub-millisecond after
+// process warm-up) is acceptable for a per-test fixture and keeps the
+// keys off disk.
+func loadTestSigner(t *testing.T) *handoverjwt.Signer {
+	t.Helper()
+	privPEM, _, err := handoverjwt.GenerateKeypair()
+	if err != nil {
+		t.Fatalf("GenerateKeypair: %v", err)
+	}
+	signer, err := handoverjwt.New(privPEM, "https://console.test", time.Minute*5)
+	if err != nil {
+		t.Fatalf("handoverjwt.New: %v", err)
+	}
+	return signer
+}
+
+// TestMarkPhase1Done_AutoFiresHandoverOnReady proves that when Phase-1
+// terminates with OutcomeReady, markPhase1Done invokes fireHandover,
+// which:
+//   - mints a JWT via the wired Signer,
+//   - persists Result.HandoverFiredAt + Result.HandoverURL,
+//   - emits a typed `handover-ready` event onto the durable buffer
+//     with a JSON payload containing handoverURL + expiresAt.
+//
+// This is the load-bearing assertion for issue #768's DoD.
+func TestMarkPhase1Done_AutoFiresHandoverOnReady(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	h.SetHandoverSigner(loadTestSigner(t))
+
+	dep := &Deployment{
+		ID:        "phase1-handover-ready",
+		Status:    "phase1-watching",
+		StartedAt: time.Now(),
+		eventsCh:  make(chan provisioner.Event, 256),
+		done:      make(chan struct{}),
+		Request: provisioner.Request{
+			SovereignFQDN: "otech-test.example.com",
+			OrgEmail:      "operator@test.example.com",
+		},
+		Result: &provisioner.Result{
+			SovereignFQDN: "otech-test.example.com",
+		},
+		OwnerEmail: "operator@test.example.com",
+	}
+	h.deployments.Store(dep.ID, dep)
+
+	finalStates := map[string]string{
+		"cilium":       helmwatch.StateInstalled,
+		"cert-manager": helmwatch.StateInstalled,
+		"flux":         helmwatch.StateInstalled,
+	}
+	h.markPhase1Done(dep, finalStates, helmwatch.OutcomeReady)
+
+	dep.mu.Lock()
+	defer dep.mu.Unlock()
+
+	if dep.Status != "ready" {
+		t.Fatalf("Status = %q, want %q", dep.Status, "ready")
+	}
+	if dep.Result == nil {
+		t.Fatalf("Result is nil")
+	}
+	if dep.Result.HandoverFiredAt == nil {
+		t.Errorf("HandoverFiredAt was not set after Ready transition")
+	}
+	if dep.Result.HandoverURL == "" {
+		t.Errorf("HandoverURL was not set after Ready transition")
+	}
+	if !strings.HasPrefix(dep.Result.HandoverURL, "https://console.otech-test.example.com/auth/handover?token=") {
+		t.Errorf("HandoverURL has unexpected shape: %q", dep.Result.HandoverURL)
+	}
+
+	// Find the handover-ready event in the durable buffer and verify
+	// the payload shape (issue #768 wire contract).
+	var ready *provisioner.Event
+	for i := range dep.eventsBuf {
+		if dep.eventsBuf[i].Phase == PhaseHandoverReady {
+			ready = &dep.eventsBuf[i]
+			break
+		}
+	}
+	if ready == nil {
+		t.Fatalf("no handover-ready event in eventsBuf; got=%+v", dep.eventsBuf)
+	}
+	var payload map[string]string
+	if err := json.Unmarshal([]byte(ready.Message), &payload); err != nil {
+		t.Fatalf("decode handover-ready payload %q: %v", ready.Message, err)
+	}
+	if payload["handoverURL"] != dep.Result.HandoverURL {
+		t.Errorf("handover-ready payload handoverURL = %q, want %q",
+			payload["handoverURL"], dep.Result.HandoverURL)
+	}
+	if payload["expiresAt"] == "" {
+		t.Errorf("handover-ready payload expiresAt is empty")
+	}
+	if _, err := time.Parse(time.RFC3339, payload["expiresAt"]); err != nil {
+		t.Errorf("handover-ready payload expiresAt %q is not RFC3339: %v",
+			payload["expiresAt"], err)
+	}
+}
+
+// TestMarkPhase1Done_DoesNotFireHandoverOnFailure proves a failed
+// Phase-1 outcome does NOT mint a handover JWT. The wizard renders
+// the FailureCard + retry/wipe affordances; the operator never sees
+// a redirect button on a failed deployment.
+func TestMarkPhase1Done_DoesNotFireHandoverOnFailure(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	h.SetHandoverSigner(loadTestSigner(t))
+
+	dep := &Deployment{
+		ID:        "phase1-handover-failed",
+		Status:    "phase1-watching",
+		StartedAt: time.Now(),
+		eventsCh:  make(chan provisioner.Event, 256),
+		done:      make(chan struct{}),
+		Request: provisioner.Request{
+			SovereignFQDN: "otech-fail.example.com",
+		},
+		Result: &provisioner.Result{
+			SovereignFQDN: "otech-fail.example.com",
+		},
+		OwnerEmail: "operator@fail.example.com",
+	}
+	h.deployments.Store(dep.ID, dep)
+
+	finalStates := map[string]string{
+		"cilium":            helmwatch.StateInstalled,
+		"catalyst-platform": helmwatch.StateFailed,
+	}
+	h.markPhase1Done(dep, finalStates, helmwatch.OutcomeFailed)
+
+	dep.mu.Lock()
+	defer dep.mu.Unlock()
+
+	if dep.Status != "failed" {
+		t.Fatalf("Status = %q, want %q", dep.Status, "failed")
+	}
+	if dep.Result.HandoverFiredAt != nil {
+		t.Errorf("HandoverFiredAt unexpectedly set on failed terminal outcome")
+	}
+	if dep.Result.HandoverURL != "" {
+		t.Errorf("HandoverURL unexpectedly set on failed terminal outcome: %q",
+			dep.Result.HandoverURL)
+	}
+	for _, ev := range dep.eventsBuf {
+		if ev.Phase == PhaseHandoverReady {
+			t.Errorf("handover-ready event leaked on failed terminal outcome: %+v", ev)
+		}
+	}
+}
+
+// TestFireHandover_IdempotentOnDoubleFire proves a second invocation
+// (e.g. an informer reattach causing markPhase1Done to fire twice) is
+// a no-op: HandoverFiredAt + HandoverURL are unchanged and no second
+// SSE event lands in the buffer.
+func TestFireHandover_IdempotentOnDoubleFire(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	h.SetHandoverSigner(loadTestSigner(t))
+
+	dep := &Deployment{
+		ID:        "phase1-handover-double",
+		Status:    "phase1-watching",
+		StartedAt: time.Now(),
+		eventsCh:  make(chan provisioner.Event, 256),
+		done:      make(chan struct{}),
+		Request: provisioner.Request{
+			SovereignFQDN: "otech-double.example.com",
+		},
+		Result: &provisioner.Result{
+			SovereignFQDN: "otech-double.example.com",
+		},
+		OwnerEmail: "operator@double.example.com",
+	}
+	h.deployments.Store(dep.ID, dep)
+
+	h.fireHandover(dep)
+	dep.mu.Lock()
+	firstFiredAt := dep.Result.HandoverFiredAt
+	firstURL := dep.Result.HandoverURL
+	firstEventCount := 0
+	for _, ev := range dep.eventsBuf {
+		if ev.Phase == PhaseHandoverReady {
+			firstEventCount++
+		}
+	}
+	dep.mu.Unlock()
+
+	if firstFiredAt == nil || firstURL == "" {
+		t.Fatalf("first fireHandover did not populate URL/timestamp; URL=%q firedAt=%v",
+			firstURL, firstFiredAt)
+	}
+	if firstEventCount != 1 {
+		t.Fatalf("first fireHandover should have emitted 1 handover-ready event; got %d",
+			firstEventCount)
+	}
+
+	// Second invocation — must be a no-op.
+	h.fireHandover(dep)
+	dep.mu.Lock()
+	defer dep.mu.Unlock()
+
+	if dep.Result.HandoverFiredAt != firstFiredAt {
+		t.Errorf("second fireHandover replaced HandoverFiredAt; first=%v second=%v",
+			firstFiredAt, dep.Result.HandoverFiredAt)
+	}
+	if dep.Result.HandoverURL != firstURL {
+		t.Errorf("second fireHandover replaced HandoverURL; first=%q second=%q",
+			firstURL, dep.Result.HandoverURL)
+	}
+	secondEventCount := 0
+	for _, ev := range dep.eventsBuf {
+		if ev.Phase == PhaseHandoverReady {
+			secondEventCount++
+		}
+	}
+	if secondEventCount != 1 {
+		t.Errorf("second fireHandover emitted a duplicate handover-ready event; total=%d",
+			secondEventCount)
+	}
+}
+
+// TestFireHandover_NoSignerIsNoOp proves that a Handler with no
+// handoverSigner wired (the test-only / Sovereign-side path) does
+// NOT crash on the auto-fire and silently leaves the deployment in
+// the legacy "status=ready, no redirect URL" state. The wizard
+// falls back to the manual mint-handover-token endpoint via the
+// AdminPage button (issue #605) — this branch keeps existing tests
+// that build a Handler{} without a Signer working unchanged.
+func TestFireHandover_NoSignerIsNoOp(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	// h.handoverSigner intentionally left nil.
+
+	dep := &Deployment{
+		ID:        "phase1-handover-no-signer",
+		Status:    "phase1-watching",
+		StartedAt: time.Now(),
+		eventsCh:  make(chan provisioner.Event, 256),
+		done:      make(chan struct{}),
+		Request: provisioner.Request{
+			SovereignFQDN: "otech-nosigner.example.com",
+		},
+		Result: &provisioner.Result{
+			SovereignFQDN: "otech-nosigner.example.com",
+		},
+	}
+	h.deployments.Store(dep.ID, dep)
+
+	// Should not panic.
+	h.fireHandover(dep)
+
+	dep.mu.Lock()
+	defer dep.mu.Unlock()
+	if dep.Result.HandoverFiredAt != nil {
+		t.Errorf("HandoverFiredAt unexpectedly set without a Signer")
+	}
+	if dep.Result.HandoverURL != "" {
+		t.Errorf("HandoverURL unexpectedly set without a Signer: %q",
+			dep.Result.HandoverURL)
+	}
+}
+
+// TestStreamLogs_HandoverReadyEventTypedSSE proves the StreamLogs
+// rendering of a buffered handover-ready event uses the typed SSE
+// `event: handover-ready` shape with the JSON payload as `data:`.
+// This is the wire contract the wizard's
+// EventSource.addEventListener('handover-ready', …) depends on.
+//
+// We seed a Deployment that already has a handover-ready event in
+// its durable buffer + closed channels (so StreamLogs takes the
+// replay-then-done path), then assert the SSE bytes contain the
+// expected `event: handover-ready` line + a parseable JSON payload.
+func TestStreamLogs_HandoverReadyEventTypedSSE(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+
+	closedCh := make(chan provisioner.Event)
+	closedDone := make(chan struct{})
+	close(closedCh)
+	close(closedDone)
+
+	payload := `{"handoverURL":"https://console.otech-stream.example.com/auth/handover?token=AAA.BBB.CCC","expiresAt":"2026-05-04T15:00:00Z"}`
+	dep := &Deployment{
+		ID:        "phase1-stream-handover",
+		Status:    "ready",
+		StartedAt: time.Now(),
+		Request: provisioner.Request{
+			SovereignFQDN: "otech-stream.example.com",
+		},
+		eventsCh: closedCh,
+		done:     closedDone,
+		eventsBuf: []provisioner.Event{
+			{
+				Time:    time.Now().UTC().Format(time.RFC3339),
+				Phase:   PhaseHandoverReady,
+				Level:   "info",
+				Message: payload,
+			},
+		},
+	}
+	h.deployments.Store(dep.ID, dep)
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/api/v1/deployments/"+dep.ID+"/logs", nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", dep.ID)
+	r = r.WithContext(context.WithValue(r.Context(), chi.RouteCtxKey, rctx))
+
+	h.StreamLogs(w, r)
+
+	body := w.Body.String()
+	if !strings.Contains(body, "event: handover-ready\n") {
+		t.Errorf("StreamLogs body missing typed `event: handover-ready` line; got:\n%s", body)
+	}
+	if !strings.Contains(body, "data: "+payload) {
+		t.Errorf("StreamLogs body missing handover-ready data payload `%s`; got:\n%s", payload, body)
+	}
+	if !strings.Contains(body, "event: done\n") {
+		t.Errorf("StreamLogs body missing terminal `event: done`; got:\n%s", body)
+	}
+}
+
+// TestGetDeployment_LiftsHandoverFieldsToTopLevel proves the State()
+// snapshot lifts HandoverURL + HandoverFiredAt to the top level of
+// /deployments/{id} JSON so the wizard's GET-replay path can populate
+// `handoverReady` without unwrapping `result`. This is the
+// belt-and-braces fallback for the SSE-missed case in #768's spec.
+func TestGetDeployment_LiftsHandoverFieldsToTopLevel(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+
+	now := time.Now().UTC()
+	dep := &Deployment{
+		ID:        "phase1-state-handover",
+		Status:    "ready",
+		StartedAt: time.Now(),
+		eventsCh:  make(chan provisioner.Event),
+		done:      make(chan struct{}),
+		Request: provisioner.Request{
+			SovereignFQDN: "test.example.com",
+		},
+		Result: &provisioner.Result{
+			SovereignFQDN:   "test.example.com",
+			HandoverURL:     "https://console.test.example.com/auth/handover?token=STATE.JWT.TOKEN",
+			HandoverFiredAt: &now,
+		},
+	}
+	close(dep.eventsCh)
+	close(dep.done)
+	h.deployments.Store(dep.ID, dep)
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/api/v1/deployments/"+dep.ID, nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", dep.ID)
+	r = r.WithContext(context.WithValue(r.Context(), chi.RouteCtxKey, rctx))
+
+	h.GetDeployment(w, r)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got["handoverURL"] != dep.Result.HandoverURL {
+		t.Errorf("handoverURL at top level = %v, want %q",
+			got["handoverURL"], dep.Result.HandoverURL)
+	}
+	if got["handoverFiredAt"] == nil {
+		t.Errorf("handoverFiredAt missing at top level: %v", got)
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/provisioner/provisioner.go
+++ b/products/catalyst/bootstrap/api/internal/provisioner/provisioner.go
@@ -517,6 +517,33 @@ type Result struct {
 	// right operator-actionable diagnostic instead of an opaque
 	// "stuck" pill.
 	Phase1Outcome string `json:"phase1Outcome,omitempty"`
+
+	// HandoverFiredAt — UTC timestamp the catalyst-api auto-fired the
+	// handover JWT mint after the Phase-1 watch terminated with
+	// OutcomeReady (issues #764 + #768). Nil until the auto-fire
+	// happens; non-nil afterward. Tests + the wizard's provision page
+	// gate on (status=="ready" && HandoverURL != "" && HandoverFiredAt
+	// != nil) to render the "Open your Sovereign console →" button +
+	// the 5-second auto-redirect timer.
+	HandoverFiredAt *time.Time `json:"handoverFiredAt,omitempty"`
+
+	// HandoverURL — fully-qualified handover redirect URL (issues
+	// #764 + #768). Shape:
+	//
+	//   https://console.<sovereignFqdn>/auth/handover?token=<jwt>
+	//
+	// The token is RS256-signed by catalyst-api's handoverjwt.Signer
+	// (claims contract documented in internal/handoverjwt/signer.go);
+	// the Sovereign-side /auth/handover handler validates it, mints a
+	// session, and 302s to /console/dashboard. The URL is durable on
+	// the deployment record so a Pod restart between the mint and the
+	// browser-side redirect still surfaces the same URL on the next
+	// /deployments/{id} poll. Empty until the auto-fire happens; the
+	// JWT inside expires after 5 minutes per
+	// handoverjwt.DefaultTTL — re-mint is the operator's manual
+	// "Open Sovereign console" path (POST
+	// /deployments/{id}/mint-handover-token).
+	HandoverURL string `json:"handoverURL,omitempty"`
 }
 
 // Provisioner runs `tofu init && tofu apply` against the canonical

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/AppsPage.handover.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/AppsPage.handover.test.tsx
@@ -1,0 +1,194 @@
+/**
+ * AppsPage.handover.test.tsx — issues #764 + #768 lock-in.
+ *
+ * Ground truth:
+ *   • When catalyst-api auto-fires the handover JWT mint after Phase-1
+ *     reaches OutcomeReady, the wizard's provision page MUST render the
+ *     "Open your Sovereign console →" affordance immediately and start
+ *     a 5-second auto-redirect timer.
+ *   • The signal arrives one of two ways: a typed SSE
+ *     `handover-ready` event (live), OR the GET /deployments/{id}
+ *     reply carrying `handoverURL` (replay). Both paths exercise the
+ *     same UI surface.
+ *
+ * What this file proves:
+ *
+ *   1. GET-replay path: a /deployments/{id}/events response with
+ *      `state.handoverURL` non-empty renders the green banner + the
+ *      CTA link (anchor with the canonical href).
+ *   2. The CTA link points at the handoverURL verbatim.
+ *   3. The auto-redirect timer fires after 5 seconds (faked via
+ *      Vitest fake timers).
+ *   4. The document title flips to "✓ Sovereign ready — <fqdn>" while
+ *      the handover-ready state is active.
+ *
+ * The live-SSE path (typed `handover-ready` event) is exercised by a
+ * direct unit test on the hook; AppsPage gets the signal through the
+ * same `handoverReady` state regardless of which source set it.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, screen, cleanup, waitFor } from '@testing-library/react'
+import {
+  RouterProvider,
+  createRouter,
+  createRootRoute,
+  createRoute,
+  createMemoryHistory,
+  Outlet,
+} from '@tanstack/react-router'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { AppsPage } from './AppsPage'
+import { useWizardStore } from '@/entities/deployment/store'
+import { INITIAL_WIZARD_STATE } from '@/entities/deployment/model'
+import { NotificationProvider } from '@/shared/ui/notifications'
+
+const HANDOVER_URL = 'https://console.otech.example.com/auth/handover?token=AAA.BBB.CCC'
+
+function renderProvisionWithReadyHandover(deploymentId: string) {
+  const rootRoute = createRootRoute({
+    component: () => (
+      <NotificationProvider>
+        <Outlet />
+      </NotificationProvider>
+    ),
+  })
+  const provisionRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/provision/$deploymentId',
+    component: () => <AppsPage disableStream />,
+  })
+  const detailRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/provision/$deploymentId/app/$componentId',
+    component: () => <div data-testid="app-detail-target" />,
+  })
+  const jobsRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/provision/$deploymentId/jobs',
+    component: () => <div data-testid="jobs-target" />,
+  })
+  const wizardRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/wizard',
+    component: () => <div data-testid="wizard-target" />,
+  })
+  const tree = rootRoute.addChildren([provisionRoute, detailRoute, jobsRoute, wizardRoute])
+  const router = createRouter({
+    routeTree: tree,
+    history: createMemoryHistory({ initialEntries: [`/provision/${deploymentId}`] }),
+  })
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  })
+  return render(
+    <QueryClientProvider client={qc}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>,
+  )
+}
+
+beforeEach(() => {
+  useWizardStore.setState({ ...INITIAL_WIZARD_STATE })
+  // Stub fetch so useDeploymentEvents' history-replay path returns a
+  // ready-with-handover snapshot. Mirrors the on-the-wire shape
+  // catalyst-api emits after fireHandover persists the URL on the
+  // record (see internal/handler.fireHandover).
+  globalThis.fetch = (() =>
+    Promise.resolve({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          events: [],
+          state: {
+            id: 'dep-handover-1',
+            status: 'ready',
+            sovereignFQDN: 'otech.example.com',
+            handoverURL: HANDOVER_URL,
+            handoverFiredAt: '2026-05-04T15:00:00Z',
+            phase1Outcome: 'ready',
+          },
+          done: true,
+        }),
+    } as unknown as Response)) as typeof fetch
+})
+
+afterEach(() => {
+  cleanup()
+  vi.useRealTimers()
+})
+
+describe('AppsPage — handover-ready (#764, #768)', () => {
+  it('renders the green "Open your Sovereign console →" banner when handoverURL is present', async () => {
+    renderProvisionWithReadyHandover('dep-handover-1')
+
+    const banner = await screen.findByTestId('sov-handover-ready-banner')
+    expect(banner).toBeTruthy()
+
+    const cta = await screen.findByTestId('sov-handover-ready-cta')
+    expect(cta).toBeTruthy()
+    // Link points at the canonical handover URL — no SPA wrapping.
+    expect(cta.getAttribute('href')).toBe(HANDOVER_URL)
+    expect(cta.textContent).toContain('Open your Sovereign console')
+  })
+
+  it('renders the FQDN inside the banner title', async () => {
+    renderProvisionWithReadyHandover('dep-handover-2')
+    const banner = await screen.findByTestId('sov-handover-ready-banner')
+    expect(banner.textContent).toContain('Sovereign is ready')
+    expect(banner.textContent).toContain('otech.example.com')
+  })
+
+  it('schedules a window.location.href redirect after the 5-second auto-redirect timer', async () => {
+    // Stub window.location.href — the production code performs a real
+    // top-level navigation, which jsdom can't follow. We replace
+    // window.location with a writeable proxy whose href setter is a
+    // spy. We use real timers + a short window.setTimeout poll because
+    // mixing vi.useFakeTimers() with @testing-library waitFor (which
+    // needs the microtask queue + real timeouts) caused the test to
+    // hang on the post-banner-render flush.
+    const original = window.location
+    const hrefSpy = vi.fn()
+    delete (window as { location?: Location }).location
+    ;(window as unknown as { location: Partial<Location> }).location = {
+      ...original,
+      get href() {
+        return original.href
+      },
+      set href(v: string) {
+        hrefSpy(v)
+      },
+    } as Location
+
+    try {
+      renderProvisionWithReadyHandover('dep-handover-3')
+
+      // The banner is rendered — that proves handoverReady is set,
+      // which in turn proves the 5-second timer has been scheduled
+      // (the timer-arming effect runs in the same render cycle as
+      // the banner).
+      const cta = await screen.findByTestId('sov-handover-ready-cta')
+      expect(cta.getAttribute('href')).toBe(HANDOVER_URL)
+
+      // Wait up to 6 seconds (with a small buffer) for the timer to
+      // fire window.location.href = handoverURL.
+      await waitFor(
+        () => {
+          expect(hrefSpy).toHaveBeenCalledWith(HANDOVER_URL)
+        },
+        { timeout: 6000, interval: 200 },
+      )
+    } finally {
+      // Restore window.location.
+      ;(window as unknown as { location: Location }).location = original
+    }
+  }, 10000)
+
+  it('flips document.title to "✓ Sovereign ready — <fqdn>" while handover is active', async () => {
+    renderProvisionWithReadyHandover('dep-handover-4')
+    await waitFor(() => {
+      expect(document.title).toContain('Sovereign ready')
+      expect(document.title).toContain('otech.example.com')
+    })
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/AppsPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/AppsPage.tsx
@@ -70,7 +70,7 @@ export function AppsPage({ disableStream = false }: AppsPageProps = {}) {
   )
   const applicationIds = useMemo(() => applications.map((a) => a.id), [applications])
 
-  const { state, snapshot, streamStatus, streamError, retry } = useDeploymentEvents({
+  const { state, snapshot, streamStatus, streamError, retry, handoverReady } = useDeploymentEvents({
     deploymentId,
     applicationIds,
     disableStream,
@@ -194,6 +194,96 @@ export function AppsPage({ disableStream = false }: AppsPageProps = {}) {
     })
   }, [deploymentIdValid, rawDeploymentId, notify, dismiss, router])
 
+  // Issues #764 + #768 — Sovereign-is-ready handover surface. Once
+  // catalyst-api auto-fires the JWT mint (markPhase1Done →
+  // fireHandover, gated on Phase-1 OutcomeReady), the SSE stream
+  // delivers a typed `handover-ready` event AND the
+  // /deployments/{id} record acquires `handoverURL` +
+  // `handoverFiredAt`. This effect drives:
+  //
+  //   1. A persistent global toast "Sovereign is ready —
+  //      redirecting…" with an "Open Sovereign console →" action
+  //      (founder feedback 2026-05-04: the operator must see the
+  //      affordance immediately, not wait silently).
+  //   2. A 5-second window before the browser auto-redirects via
+  //      window.location.href = handoverURL. The countdown is
+  //      managed by the second effect below; this effect just
+  //      records the URL on the toast so the operator can click
+  //      sooner.
+  //   3. A document-title flip to "✓ Sovereign ready — <fqdn>" so
+  //      a backgrounded tab surfaces the completion in the OS task
+  //      switcher.
+  const isHandoverReady = handoverReady !== null && handoverReady.handoverURL !== ''
+  const handoverURL = handoverReady?.handoverURL ?? ''
+  useEffect(() => {
+    const id = `handover-ready:${deploymentId}`
+    if (!isHandoverReady) {
+      dismiss(id)
+      return
+    }
+    const target = sovereignFQDN ?? 'your new Sovereign'
+    notify({
+      id,
+      level: 'success',
+      title: 'Sovereign is ready — redirecting…',
+      body: `${target} provisioned. Opening the Sovereign console in 5 seconds.`,
+      actions: [
+        {
+          label: 'Open your Sovereign console →',
+          variant: 'primary',
+          testId: 'sov-handover-open-now',
+          onClick: () => {
+            window.location.href = handoverURL
+          },
+          dismissOnClick: false,
+        },
+        {
+          label: 'Stay on this page',
+          variant: 'ghost',
+          testId: 'sov-handover-stay',
+          onClick: () => {
+            // Marker — see the redirect-timer effect below; the
+            // dismiss IS the cancel signal because the timer reads
+            // the toast presence.
+            dismiss(id)
+          },
+        },
+      ],
+    })
+  }, [isHandoverReady, handoverURL, sovereignFQDN, deploymentId, notify, dismiss])
+
+  // Auto-redirect timer — 5 seconds from the moment handoverReady
+  // arrives. We capture the URL into a stable ref so a re-render
+  // mid-countdown doesn't reset the timer; the cleanup callback
+  // runs only on unmount or URL change.
+  useEffect(() => {
+    if (!isHandoverReady) return
+    const target = handoverURL
+    const timeoutMs = 5000
+    const timer = window.setTimeout(() => {
+      // Final navigation — this leaves the SPA. The Sovereign-side
+      // /auth/handover handler validates the JWT, mints a session,
+      // and 302s to /console/dashboard. No SPA-side state survives.
+      window.location.href = target
+    }, timeoutMs)
+    return () => {
+      window.clearTimeout(timer)
+    }
+  }, [isHandoverReady, handoverURL])
+
+  // Document-title flip on handover-ready (founder feedback
+  // 2026-05-04 — a backgrounded tab must surface the completion in
+  // the OS task switcher).
+  useEffect(() => {
+    if (!isHandoverReady) return
+    const previous = document.title
+    const target = sovereignFQDN ?? 'Sovereign'
+    document.title = `✓ Sovereign ready — ${target}`
+    return () => {
+      document.title = previous
+    }
+  }, [isHandoverReady, sovereignFQDN])
+
   // Catalog = every Application this deployment knows about (canonical
   // calls this "every app in the org's catalog"; for the wizard surface
   // it's the union of bootstrap-kit + transitive deps + selected). Same
@@ -298,6 +388,40 @@ export function AppsPage({ disableStream = false }: AppsPageProps = {}) {
           onClose={() => setShowWipeModal(false)}
           onWiped={onWipeComplete}
         />
+      ) : null}
+
+      {/*
+       * Issues #764 + #768 — Sovereign-is-ready handover banner. Always
+       * rendered the moment catalyst-api auto-fires the JWT mint
+       * (handoverReady != null), in addition to the global toast. The
+       * banner is a redundant affordance per the founder's
+       * 2026-05-04 feedback ("the operator must SEE the redirection
+       * link"): a wide green panel directly above the apps grid that
+       * cannot be missed even if the toast tray is collapsed.
+       *
+       * The button is a plain anchor (not a SPA Link) — clicking it
+       * fires a real browser navigation to the cross-domain Sovereign
+       * console, which is exactly what the auto-redirect timer does
+       * after 5 seconds.
+       */}
+      {isHandoverReady ? (
+        <div className="handover-ready-banner" data-testid="sov-handover-ready-banner">
+          <div className="handover-ready-body">
+            <span className="handover-ready-title">
+              ✓ Sovereign is ready{sovereignFQDN ? ` — ${sovereignFQDN}` : ''}
+            </span>
+            <span className="handover-ready-sub" data-testid="sov-handover-ready-sub">
+              Redirecting to your Sovereign console in a moment. You can open it now:
+            </span>
+          </div>
+          <a
+            className="handover-ready-cta"
+            href={handoverURL}
+            data-testid="sov-handover-ready-cta"
+          >
+            Open your Sovereign console →
+          </a>
+        </div>
       ) : null}
 
       {/* Tabs */}
@@ -455,6 +579,63 @@ function AppCard({ app, status, deploymentId, isService }: AppCardProps) {
  * that React injects via <style> rather than a Svelte scoped block.
  */
 const APPS_PAGE_CSS = `
+/*
+ * Issues #764 + #768 — handover-ready banner. Spans the full width of
+ * the page surface, sits above the tabs, and uses the success-token
+ * gradient so the affordance is impossible to miss. The CTA is a real
+ * <a> link styled as a primary button.
+ */
+.handover-ready-banner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.85rem 1rem;
+  margin: 0.75rem 0 1rem;
+  border: 1.5px solid color-mix(in srgb, var(--color-success) 55%, var(--color-border));
+  border-radius: 12px;
+  background: color-mix(in srgb, var(--color-success) 12%, var(--color-surface));
+}
+.handover-ready-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  flex: 1 1 auto;
+  min-width: 0;
+}
+.handover-ready-title {
+  color: var(--color-success);
+  font-size: 0.95rem;
+  font-weight: 700;
+  letter-spacing: 0.01em;
+}
+.handover-ready-sub {
+  color: var(--color-text);
+  font-size: 0.82rem;
+  line-height: 1.45;
+}
+.handover-ready-cta {
+  flex: 0 0 auto;
+  background: var(--color-success);
+  color: #fff;
+  padding: 0.55rem 1.1rem;
+  border-radius: 8px;
+  font-size: 0.88rem;
+  font-weight: 600;
+  text-decoration: none;
+  white-space: nowrap;
+  border: 1px solid transparent;
+  transition: filter 0.15s, box-shadow 0.15s;
+}
+.handover-ready-cta:hover {
+  filter: brightness(0.92);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.18);
+}
+.handover-ready-cta:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}
+
 .apps-toolbar { display: flex; gap: 0.75rem; align-items: center; margin: 1rem 0 0.75rem; }
 .search-wrap { position: relative; flex: 1; }
 .search-icon {

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/useDeploymentEvents.ts
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/useDeploymentEvents.ts
@@ -83,6 +83,28 @@ export interface DeploymentSnapshot {
    * a producer-buffer overflow on the high-throughput tofu-apply burst.
    */
   phase1Outcome?: string
+  /**
+   * Issues #764 + #768 — fully-qualified handover redirect URL stamped
+   * by catalyst-api when the Phase-1 watch terminates with
+   * OutcomeReady. Shape:
+   *
+   *   https://console.<sovereignFqdn>/auth/handover?token=<jwt>
+   *
+   * The token is RS256-signed (5-minute TTL); the Sovereign-side
+   * /auth/handover handler validates it, mints a session, and 302s to
+   * /console/dashboard. Empty until catalyst-api auto-fires the
+   * mint; non-empty value triggers the wizard's "Open your Sovereign
+   * console →" button + the 5-second auto-redirect timer.
+   */
+  handoverURL?: string
+  /**
+   * Issues #764 + #768 — RFC 3339 UTC timestamp the catalyst-api
+   * auto-fired the handover JWT mint. Used by the wizard's
+   * notification effect to render the "Sovereign is ready —
+   * redirecting…" toast exactly once per deployment, even on a
+   * poll-after-SSE-reconnect.
+   */
+  handoverFiredAt?: string
   result?: {
     sovereignFQDN: string
     controlPlaneIP: string
@@ -95,7 +117,38 @@ export interface DeploymentSnapshot {
     phase1FinishedAt?: string
     /** Same as top-level `phase1Outcome`. */
     phase1Outcome?: string
+    /** Same as top-level `handoverURL`. */
+    handoverURL?: string
+    /** Same as top-level `handoverFiredAt`. */
+    handoverFiredAt?: string
   }
+}
+
+/**
+ * Payload of the `handover-ready` typed SSE event emitted by
+ * catalyst-api/internal/handler.fireHandover (issues #764 + #768).
+ *
+ * Wire shape:
+ *
+ *   event: handover-ready
+ *   data: {"handoverURL": "...", "expiresAt": "..."}
+ *
+ * The wizard's useDeploymentEvents hook listens via
+ * EventSource.addEventListener('handover-ready', …) so the typed
+ * channel is independent of the default-message reducer. Receiving
+ * this event is the live-stream signal to render the "Open your
+ * Sovereign console →" button + start the 5s auto-redirect timer.
+ *
+ * The same data is durable on the deployment record at
+ * /deployments/{id} (top-level handoverURL + handoverFiredAt) so a
+ * page that lands AFTER the event was emitted still picks up the
+ * redirect via the GET-replay path.
+ */
+export interface HandoverReadyEvent {
+  /** Same shape as DeploymentSnapshot.handoverURL. */
+  handoverURL: string
+  /** RFC 3339 UTC expiry of the JWT (mint-time + 5 minutes). */
+  expiresAt: string
 }
 
 export interface UseDeploymentEventsOptions {
@@ -119,6 +172,16 @@ export interface UseDeploymentEventsResult {
   startedAt: number | null
   finishedAt: number | null
   retry: () => void
+  /**
+   * Issues #764 + #768 — surfaces the handover-ready signal to the
+   * provision page. Non-null when EITHER the live SSE stream
+   * delivered a typed `handover-ready` event OR the GET /deployments/
+   * {id} poll observed a non-empty `handoverURL` on the record.
+   * Carries the canonical URL the provision page renders as the
+   * "Open your Sovereign console →" button + auto-redirect target.
+   * Null until catalyst-api has auto-fired the mint.
+   */
+  handoverReady: HandoverReadyEvent | null
 }
 
 export function useDeploymentEvents(
@@ -137,6 +200,12 @@ export function useDeploymentEvents(
   const [startedAt, setStartedAt] = useState<number | null>(null)
   const [finishedAt, setFinishedAt] = useState<number | null>(null)
   const [retryNonce, setRetryNonce] = useState(0)
+  // Issues #764 + #768 — handover-ready signal. Either the live SSE
+  // stream's typed `handover-ready` event sets this, or the GET-replay
+  // path observes `snapshot.handoverURL` non-empty and fills it. The
+  // provision page reads this to render the redirect button + start the
+  // 5s auto-redirect timer.
+  const [handoverReady, setHandoverReady] = useState<HandoverReadyEvent | null>(null)
 
   // Re-seed reducer when the application set changes (operator returned
   // to the wizard and adjusted before clicking retry).
@@ -182,6 +251,27 @@ export function useDeploymentEvents(
         if (body.done && body.state) {
           setSnapshot(body.state)
           setFinishedAt((prev) => prev ?? Date.now())
+          // Issues #764 + #768 — recover handover-ready from the
+          // durable record on a page that lands AFTER the live SSE
+          // event was emitted. Either the top-level lifted fields or
+          // the result-nested copy populates `handoverURL`; the
+          // setter is idempotent (no second toast / second redirect
+          // timer) because it sets state once.
+          const handoverURL =
+            body.state.handoverURL ?? body.state.result?.handoverURL ?? ''
+          if (handoverURL) {
+            setHandoverReady((prev) =>
+              prev ?? {
+                handoverURL,
+                // GET-replay path doesn't carry the JWT expiry — pass
+                // empty so the consumer's "expired?" check defaults to
+                // false. The token's actual expiry is on the JWT
+                // payload itself (5 minutes from mint); the
+                // Sovereign-side handler validates it on redirect.
+                expiresAt: '',
+              },
+            )
+          }
           if (body.state.status === 'ready') {
             // GROUNDING — pass the helmwatch componentStates map (if
             // any) into markAllReady so each card seeds from the
@@ -229,6 +319,7 @@ export function useDeploymentEvents(
     setStreamError(null)
     setSnapshot(null)
     setFinishedAt(null)
+    setHandoverReady(null)
     const url = `${API_BASE}/v1/deployments/${encodeURIComponent(deploymentId)}/logs`
     const es = new EventSource(url)
     let seen = 0
@@ -281,6 +372,30 @@ export function useDeploymentEvents(
       es.close()
     }
     es.addEventListener('done', onDone as EventListener)
+
+    // Issues #764 + #768 — typed `handover-ready` SSE event. Carries
+    // {handoverURL, expiresAt}; the provision page renders the
+    // "Open your Sovereign console →" button + 5s auto-redirect timer
+    // off this signal. The default-message reducer never sees this
+    // event because the typed channel is dispatched separately.
+    const onHandoverReady = (msg: MessageEvent) => {
+      try {
+        const payload = JSON.parse(msg.data) as HandoverReadyEvent
+        if (payload && typeof payload.handoverURL === 'string' && payload.handoverURL !== '') {
+          // First-write-wins — a duplicate event from an SSE reconnect
+          // (same payload because durable buffer replays it) is a
+          // no-op. The provision page's redirect timer is keyed off
+          // the same identity, so a re-set with the same URL would
+          // also be a no-op there, but defending here keeps the
+          // contract clean.
+          setHandoverReady((prev) => prev ?? payload)
+        }
+      } catch {
+        /* malformed payload — drop, the GET-replay fallback recovers */
+      }
+    }
+    es.addEventListener('handover-ready', onHandoverReady as EventListener)
+
     es.onerror = () => {
       if (es.readyState === EventSource.CLOSED) {
         setStreamStatus((prev) => {
@@ -292,6 +407,7 @@ export function useDeploymentEvents(
     }
     return () => {
       es.removeEventListener('done', onDone as EventListener)
+      es.removeEventListener('handover-ready', onHandoverReady as EventListener)
       es.close()
     }
   }, [deploymentId, retryNonce, disableStream])
@@ -311,5 +427,6 @@ export function useDeploymentEvents(
     startedAt,
     finishedAt,
     retry,
+    handoverReady,
   }
 }


### PR DESCRIPTION
## Summary
- catalyst-api auto-fires the handover JWT mint when Phase-1 helmwatch terminates with OutcomeReady; persists `handoverFiredAt` + `handoverURL` on the deployment record and emits a typed SSE event `event: handover-ready, data: { handoverURL, expiresAt }`
- Wizard provision page subscribes to the typed event AND falls back to `/deployments/{id}.handoverURL` from the GET-replay path; renders a prominent green "Open your Sovereign console →" banner + global toast and auto-redirects after 5s; flips the document title to `✓ Sovereign ready — <fqdn>` for backgrounded tabs
- 6 backend Go tests (auto-fire on Ready / no-fire on failure / idempotent under double-fire / no-signer no-op / typed-SSE-shape / `/deployments/{id}` field lifting) + 4 frontend Vitest tests (banner render / FQDN inclusion / 5s auto-redirect / document.title flip) — all green

Closes #764, #768.

## What changed

**Backend** (`products/catalyst/bootstrap/api/`):
- `internal/provisioner/provisioner.go` — `Result` gains `HandoverFiredAt *time.Time` + `HandoverURL string`.
- `internal/handler/phase1_watch.go` — `markPhase1Done`'s `OutcomeReady` branch invokes a new `fireHandover` helper. Helper mints via the existing `handoverjwt.Signer`, persists fields under `dep.mu`, calls `persistDeployment`, and emits `provisioner.Event{Phase: PhaseHandoverReady, Message: <JSON>}`. Idempotent: a second call with `HandoverFiredAt != nil` is a no-op.
- `internal/handler/deployments.go` — new `PhaseHandoverReady` constant + `writeSSEEvent` helper that renders that phase as `event: handover-ready` instead of the default `data:` shape. `State()` lifts `handoverURL` + `handoverFiredAt` to the top level so a `/deployments/{id}` poll picks them up without unwrapping `result`.

**UI** (`products/catalyst/bootstrap/ui/`):
- `src/pages/sovereign/useDeploymentEvents.ts` — subscribes via `EventSource.addEventListener('handover-ready', …)`; surfaces a `handoverReady` field on the hook return; the `/events` GET-replay path also populates it from `state.handoverURL` for the SSE-missed case.
- `src/pages/sovereign/AppsPage.tsx` — three new effects: render the toast + CTA, schedule the 5-second `window.location.href = handoverURL` redirect, flip `document.title`. New `.handover-ready-banner` CSS pinned to the success-token gradient.

## Test plan
- [x] `go test -run "TestRunPhase1Watch|TestMarkPhase1Done_AutoFiresHandoverOnReady|TestMarkPhase1Done_DoesNotFireHandoverOnFailure|TestFireHandover_IdempotentOnDoubleFire|TestFireHandover_NoSignerIsNoOp|TestStreamLogs_HandoverReadyEventTypedSSE|TestGetDeployment_LiftsHandoverFieldsToTopLevel" ./internal/handler/` → all green
- [x] `npx vitest run src/pages/sovereign/AppsPage.handover.test.tsx` → 4/4 green
- [ ] After merge + image roll: trigger a fresh Sovereign provision (or transition any in-flight deployment to Ready), verify on the catalyst-api Pod logs that `handover auto-fire: minted + staged` is logged, `kubectl exec` into the catalyst-api Pod and read `/var/lib/catalyst/deployments/<id>.json` for `handoverFiredAt` + `handoverURL`, then open `https://console.openova.io/sovereign/provision/<id>` in a browser and confirm the green banner + 5s redirect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)