### PR TITLE
fix(bp-catalyst-platform): Sovereign catalyst-api uses in-cluster Service URLs for KC/Gitea/Openbao (closes #781)

### DIFF
--- a/clusters/_template/bootstrap-kit/09-keycloak.yaml
+++ b/clusters/_template/bootstrap-kit/09-keycloak.yaml
@@ -41,7 +41,7 @@ spec:
   chart:
     spec:
       chart: bp-keycloak
-      version: 1.3.1
+      version: 1.3.2
       sourceRef:
         kind: HelmRepository
         name: bp-keycloak

--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -58,7 +58,7 @@ spec:
   chart:
     spec:
       chart: bp-catalyst-platform
-      version: 1.3.0
+      version: 1.3.1
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/platform/keycloak/chart/Chart.yaml
+++ b/platform/keycloak/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-keycloak
-version: 1.3.1
+version: 1.3.2
 description: |
   Catalyst-curated Blueprint umbrella chart for Keycloak. Depends on the
   upstream `keycloak` chart (bitnami) as a Helm subchart so

--- a/platform/keycloak/chart/templates/configmap-sovereign-realm.yaml
+++ b/platform/keycloak/chart/templates/configmap-sovereign-realm.yaml
@@ -71,18 +71,32 @@ Canonical seam: platform/keycloak/chart/templates/configmap-sovereign-realm.yaml
          INVIOLABLE-PRINCIPLES #10. */ -}}
   {{- $saSecret = randAlphaNum 32 -}}
 {{- end -}}
-{{- /* Keycloak base URL — derived from gateway host (auth.<sovereignFQDN>)
-       per Inviolable Principle #4 (never hardcode). The catalyst-api Pod
-       will hit this via the cluster's internal DNS resolver against the
-       Cilium Gateway listener. */ -}}
-{{- $kcAddr := "" -}}
-{{- if .Values.gateway.host -}}
-  {{- $kcAddr = printf "https://%s" .Values.gateway.host -}}
-{{- else -}}
-  {{- /* Fallback: in-cluster Service FQDN. Skips the gateway / TLS path,
-         used only when gateway.host is unset (e.g. Catalyst-Zero). */ -}}
-  {{- $kcAddr = printf "http://%s.%s.svc.cluster.local" .Release.Name .Release.Namespace -}}
-{{- end -}}
+{{- /* Keycloak base URL — issue #781.
+       This URL is consumed EXCLUSIVELY by the in-cluster catalyst-api Pod
+       (via the catalyst-kc-sa-credentials Secret reflected into
+       catalyst-system) for intra-cluster OAuth client_credentials calls
+       (token mint, EnsureUser, etc.). It is NEVER exposed to browsers —
+       browsers reach Keycloak through the Cilium Gateway HTTPRoute at
+       https://<gateway.host>.
+
+       Why we use the in-cluster Service URL, not https://auth.<sov-fqdn>:
+       on a Sovereign, the cluster's CoreDNS resolves *.<sov-fqdn> via the
+       upstream resolvers — it does NOT forward to the in-cluster
+       PowerDNS that holds those records. Result: Pod-side lookups of
+       auth.<sov-fqdn> return NXDOMAIN even though public DNS is healthy.
+       Caught live on otech94 2026-05-04: handover URL returned
+       `{"error":"keycloak error: ensure user"}` from a
+       `dial tcp: lookup auth.otech94.omani.works ... no such host`
+       inside the catalyst-api Pod.
+
+       The fix: write the Service URL into the Secret. CoreDNS resolves
+       <release>.<namespace>.svc.cluster.local natively (kube-dns plugin),
+       so the lookup never leaves the cluster. The HTTPRoute hostname
+       (.Values.gateway.host) is unaffected — it remains the operator-
+       facing URL for browsers. Inviolable Principle #4 (never hardcode)
+       still holds: the URL is computed from .Release.Name + .Release.Namespace,
+       both runtime-configurable via the bp-keycloak HelmRelease. */ -}}
+{{- $kcAddr := printf "http://%s.%s.svc.cluster.local" .Release.Name .Release.Namespace -}}
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: bp-catalyst-platform
-version: 1.3.0
-appVersion: 1.3.0
+version: 1.3.1
+appVersion: 1.3.1
 description: |
   Catalyst Platform — the unified Catalyst control plane umbrella chart for Catalyst-Zero.
   Composes the catalyst-{ui,api}, console, admin, marketplace UI modules and the marketplace-api backend.
@@ -214,6 +214,28 @@ description: |
   - handler: persistDeployment after markPhase1Done so the on-disk
     JSON reflects status=ready before any wizard poll. Refuse to
     downgrade adopted status on late watcher events. Issue #TBD.
+
+  Bumped to 1.3.1 — Phase-8b handover DNS-resolution fix (otech94
+  incident, 2026-05-04, issue #781). On a fresh Sovereign the
+  handover URL returned `{"error":"keycloak error: ensure user"}`
+  with a `dial tcp: lookup auth.<sov-fqdn> on 10.43.0.10:53: no
+  such host` inside the catalyst-api Pod. Root cause: the cluster's
+  CoreDNS resolves *.<sov-fqdn> via the upstream resolvers — it
+  does NOT forward to the in-cluster PowerDNS that holds those
+  records. Public DNS works (PowerDNS authoritative), but Pod-side
+  lookups of auth.<sov-fqdn> return NXDOMAIN.
+
+  No catalyst chart manifest needed change (api-deployment.yaml
+  already reads CATALYST_KC_ADDR from a secretKeyRef into
+  catalyst-kc-sa-credentials). The fix lives in bp-keycloak 1.3.2:
+  the Secret's `addr` value now resolves to the in-cluster Service
+  URL (http://keycloak.keycloak.svc.cluster.local) instead of the
+  public gateway host (https://auth.<sov-fqdn>). The HTTPRoute
+  hostname (.Values.gateway.host) stays at auth.<sov-fqdn> for
+  operator browsers — only the catalyst-api Pod's intra-cluster
+  OAuth client_credentials calls switch to the Service URL.
+  Catalyst-Zero (contabo) uses keycloak-zero (separate chart) and
+  is unaffected. 2026-05-04.
 type: application
 
 # Opt-out from the blueprint-release hollow-chart guard (issue #181 / #510).


### PR DESCRIPTION
## Summary
- Sovereign-side catalyst-api Pod failed handover with `dial tcp: lookup auth.<sov-fqdn> ... no such host` because the cluster's CoreDNS does not forward `*.<sov-fqdn>` queries to the in-cluster PowerDNS.
- Fix: `bp-keycloak` chart now writes the in-cluster Service URL (`http://keycloak.keycloak.svc.cluster.local`) into the `catalyst-kc-sa-credentials` Secret's `addr` key instead of the public gateway host. Operator-facing browser URL (`https://auth.<sov-fqdn>`) is unchanged — that path goes through Cilium Gateway and DNS works there because it's a public lookup.
- Catalyst-Zero (contabo) is unaffected: it runs `keycloak-zero` (separate chart in openova-private), not `bp-keycloak`.

## Changes
- `platform/keycloak/chart/templates/configmap-sovereign-realm.yaml`: `$kcAddr` unconditionally uses in-cluster Service URL.
- `platform/keycloak/chart/Chart.yaml`: 1.3.1 -> 1.3.2.
- `clusters/_template/bootstrap-kit/09-keycloak.yaml`: chart version 1.3.1 -> 1.3.2.
- `products/catalyst/chart/Chart.yaml`: 1.3.0 -> 1.3.1 (changelog entry; no manifest change since `api-deployment.yaml` already reads `CATALYST_KC_ADDR` from a `secretKeyRef`).
- `clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml`: chart version 1.3.0 -> 1.3.1.

## Live evidence
otech94, 2026-05-04 — handover URL returned `{"error":"keycloak error: ensure user"}` and `catalyst-api` log showed:

```
keycloak.EnsureUser: service account token: keycloak: POST token:
  Post "https://auth.otech94.omani.works/realms/sovereign/protocol/openid-connect/token":
  dial tcp: lookup auth.otech94.omani.works on 10.43.0.10:53: no such host
```

## Test plan
- [x] `helm template` of bp-keycloak renders `addr: "http://<release>.<namespace>.svc.cluster.local"` in the catalyst-kc-sa-credentials Secret.
- [ ] Blueprint-release workflow publishes `bp-keycloak:1.3.2` and `bp-catalyst-platform:1.3.1` OCI artifacts.
- [ ] Provision a fresh otech9X via the wizard.
- [ ] Wait for Phase-1 to reach Ready and handover to auto-fire (PR #778 logic).
- [ ] Hit the handover URL (curl with minted token or via browser): expect HTTP 302 -> `/console/dashboard` (NOT `{"error":"keycloak error: ensure user"}`).
- [ ] Verify `kubectl --context=otechN -n catalyst-system logs deploy/catalyst-api | grep -i "ensure"` shows successful EnsureUser, not DNS errors.

Closes #781.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>