### PR TITLE
fix(provision-page): re-fetch deployment state on SSE close before showing failure (closes #782)

### DIFF
--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/useDeploymentEvents.refetch.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/useDeploymentEvents.refetch.test.tsx
@@ -1,0 +1,333 @@
+/**
+ * useDeploymentEvents.refetch.test.tsx — issue #782 lock-in.
+ *
+ * Ground truth:
+ *   • An SSE stream closing without a terminal `event: done` is a
+ *     transport drop, NOT a deployment failure.
+ *   • Before flipping the UI to "Provisioning failed", the hook MUST
+ *     re-fetch /deployments/{id} once and switch on the canonical
+ *     status.
+ *   • status="ready"           → streamStatus='completed', handoverReady set
+ *   • status="failed"          → streamStatus='failed' with REAL error
+ *   • status in IN_FLIGHT_*    → streamStatus='streaming' (spinner +
+ *                                reconnect SSE), NEVER 'failed' with
+ *                                "Deployment ended with status=phase1-watching"
+ *
+ * jsdom doesn't implement EventSource — we install a minimal fake that
+ * captures every constructed instance + supports addEventListener for
+ * the typed `done` + `handover-ready` channels.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { act, cleanup, renderHook, waitFor } from '@testing-library/react'
+import { useDeploymentEvents } from './useDeploymentEvents'
+
+interface ListenerMap {
+  done: Array<(e: MessageEvent) => void>
+  'handover-ready': Array<(e: MessageEvent) => void>
+}
+
+class FakeEventSource {
+  static CLOSED = 2 as const
+  static CONNECTING = 0 as const
+  static OPEN = 1 as const
+  static instances: FakeEventSource[] = []
+
+  url: string
+  onopen: ((e: Event) => void) | null = null
+  onmessage: ((e: MessageEvent) => void) | null = null
+  onerror: ((e: Event) => void) | null = null
+  readyState: number = FakeEventSource.CONNECTING
+  listeners: ListenerMap = { done: [], 'handover-ready': [] }
+
+  constructor(url: string) {
+    this.url = url
+    FakeEventSource.instances.push(this)
+  }
+  addEventListener(event: string, handler: (e: MessageEvent) => void) {
+    if (event === 'done' || event === 'handover-ready') {
+      this.listeners[event].push(handler)
+    }
+  }
+  removeEventListener(event: string, handler: (e: MessageEvent) => void) {
+    if (event === 'done' || event === 'handover-ready') {
+      this.listeners[event] = this.listeners[event].filter((h) => h !== handler)
+    }
+  }
+  close() {
+    this.readyState = FakeEventSource.CLOSED
+  }
+  /** Test helper — fire the connection-closed signal from the network. */
+  simulateClose() {
+    this.readyState = FakeEventSource.CLOSED
+    this.onerror?.(new Event('error'))
+  }
+}
+
+function lastES(): FakeEventSource {
+  const inst = FakeEventSource.instances.at(-1)
+  if (!inst) throw new Error('no EventSource constructed')
+  return inst
+}
+
+function makeFetchResponses(...responses: Array<{ ok: boolean; status?: number; body: unknown }>) {
+  let i = 0
+  return ((..._args: unknown[]) => {
+    const r = responses[Math.min(i, responses.length - 1)]!
+    i += 1
+    return Promise.resolve({
+      ok: r.ok,
+      status: r.status ?? (r.ok ? 200 : 500),
+      json: () => Promise.resolve(r.body),
+    } as unknown as Response)
+  }) as typeof fetch
+}
+
+const APPS = ['cilium', 'cert-manager'] as const
+
+beforeEach(() => {
+  FakeEventSource.instances = []
+  // @ts-expect-error — install on global
+  globalThis.EventSource = FakeEventSource
+})
+
+afterEach(() => {
+  cleanup()
+  vi.useRealTimers()
+  // @ts-expect-error — clean up
+  delete globalThis.EventSource
+})
+
+/** Drain pending microtasks (fetch.then chains) under real timers. */
+async function flush() {
+  for (let i = 0; i < 5; i++) {
+    await Promise.resolve()
+  }
+}
+
+describe('useDeploymentEvents — SSE drop re-fetches /deployments/{id} (issue #782)', () => {
+  it('renders SUCCESS when SSE drops mid-flight AND poll returns status=ready', async () => {
+    // First fetch: history-replay (no events, not done — in-flight start).
+    // Second fetch: triggered by the SSE drop, returns ready+handover.
+    globalThis.fetch = makeFetchResponses(
+      { ok: true, body: { events: [], state: undefined, done: false } },
+      {
+        ok: true,
+        body: {
+          id: 'd-ready',
+          status: 'ready',
+          sovereignFQDN: 'otech.example.com',
+          handoverURL: 'https://console.otech.example.com/auth/handover?token=AAA',
+          handoverFiredAt: '2026-05-04T16:17:09Z',
+          phase1Outcome: 'ready',
+          componentStates: { cilium: 'installed', 'cert-manager': 'installed' },
+        },
+      },
+    )
+
+    const { result } = renderHook(() =>
+      useDeploymentEvents({ deploymentId: 'd-ready', applicationIds: APPS }),
+    )
+
+    // Open + drop the SSE — emulates a reverse-proxy idle timeout
+    // dropping the stream after the catalyst-api has already auto-fired
+    // the handover JWT mint. The hook MUST poll /deployments/{id}
+    // BEFORE rendering "Provisioning failed".
+    await act(async () => {
+      await flush()
+      lastES().onopen?.(new Event('open'))
+      lastES().simulateClose()
+      await flush()
+    })
+
+    await waitFor(() => {
+      expect(result.current.streamStatus).toBe('completed')
+    })
+    expect(result.current.streamError).toBeNull()
+    expect(result.current.handoverReady?.handoverURL).toBe(
+      'https://console.otech.example.com/auth/handover?token=AAA',
+    )
+    expect(result.current.snapshot?.status).toBe('ready')
+  })
+
+  it('renders SPINNER (status=streaming) when SSE drops mid-flight AND poll returns status=phase1-watching', async () => {
+    globalThis.fetch = makeFetchResponses(
+      { ok: true, body: { events: [], state: undefined, done: false } },
+      {
+        ok: true,
+        body: {
+          id: 'd-watching',
+          status: 'phase1-watching',
+          sovereignFQDN: 'otech.example.com',
+          phase1Outcome: '',
+        },
+      },
+    )
+
+    const { result } = renderHook(() =>
+      useDeploymentEvents({ deploymentId: 'd-watching', applicationIds: APPS }),
+    )
+
+    await act(async () => {
+      await flush()
+      lastES().onopen?.(new Event('open'))
+      lastES().simulateClose()
+      await flush()
+    })
+
+    // CRITICAL: must NEVER be 'failed' with the stale phase id message.
+    expect(result.current.streamStatus).not.toBe('failed')
+    expect(String(result.current.streamError ?? '')).not.toContain('phase1-watching')
+    expect(String(result.current.streamError ?? '')).not.toContain(
+      'Deployment ended with status=',
+    )
+    // The UI stays in the spinner state — either 'streaming' (after
+    // reconnect kicks off) or 'connecting'. Both render the spinner.
+    expect(['streaming', 'connecting']).toContain(result.current.streamStatus)
+  })
+
+  it('reconnects the SSE stream when the canonical state is still in-flight', async () => {
+    globalThis.fetch = makeFetchResponses(
+      { ok: true, body: { events: [], state: undefined, done: false } },
+      // Same poll response for any number of subsequent polls.
+      {
+        ok: true,
+        body: { id: 'd-reconnect', status: 'phase1-watching' },
+      },
+    )
+
+    renderHook(() =>
+      useDeploymentEvents({ deploymentId: 'd-reconnect', applicationIds: APPS }),
+    )
+
+    await act(async () => {
+      await flush()
+      lastES().onopen?.(new Event('open'))
+      lastES().simulateClose()
+      await flush()
+    })
+    // First-attempt reconnect backoff is 1000ms — wait it out under
+    // real timers. We don't use fake timers here because the fetch
+    // promise chain mixes poorly with vi.advanceTimersByTimeAsync().
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 1500))
+    })
+
+    // A second EventSource MUST have been constructed against the same
+    // /logs URL — the proof the hook reconnects rather than terminating.
+    expect(FakeEventSource.instances.length).toBeGreaterThanOrEqual(2)
+    expect(FakeEventSource.instances[1]!.url).toBe(FakeEventSource.instances[0]!.url)
+  })
+
+  it('renders FAILURE with the REAL error message when SSE drops AND poll returns status=failed', async () => {
+    const realError = 'tofu apply: Server returned 502'
+    globalThis.fetch = makeFetchResponses(
+      { ok: true, body: { events: [], state: undefined, done: false } },
+      {
+        ok: true,
+        body: {
+          id: 'd-failed',
+          status: 'failed',
+          sovereignFQDN: 'otech.example.com',
+          error: realError,
+          phase1Outcome: '',
+        },
+      },
+    )
+
+    const { result } = renderHook(() =>
+      useDeploymentEvents({ deploymentId: 'd-failed', applicationIds: APPS }),
+    )
+
+    await act(async () => {
+      await flush()
+      lastES().onopen?.(new Event('open'))
+      lastES().simulateClose()
+      await flush()
+    })
+
+    await waitFor(() => {
+      expect(result.current.streamStatus).toBe('failed')
+    })
+    // The REAL error is surfaced — not the stale "Deployment ended with
+    // status=phase1-watching" copy.
+    expect(result.current.streamError).toBe(realError)
+    expect(String(result.current.streamError ?? '')).not.toContain('phase1-watching')
+    expect(String(result.current.streamError ?? '')).not.toContain(
+      'Deployment ended with status=',
+    )
+  })
+
+  it('never hard-codes "Deployment ended with status=phase1-watching" in the failure message', async () => {
+    // The legacy code's stale-banner copy was:
+    //   `Deployment ended with status=${snap.status}` → "Deployment
+    //   ended with status=phase1-watching" — fired purely off the SSE
+    //   close. This test pins the regression: the SSE drop alone MUST
+    //   NEVER produce that copy, even if the canonical poll never
+    //   resolves.
+    globalThis.fetch = makeFetchResponses(
+      { ok: true, body: { events: [], state: undefined, done: false } },
+      // Network failure on the canonical poll → unreachable, but with
+      // a clean message, never "ended with status=phase1-watching".
+      { ok: false, status: 500, body: {} },
+    )
+
+    const { result } = renderHook(() =>
+      useDeploymentEvents({ deploymentId: 'd-no-poll', applicationIds: APPS }),
+    )
+
+    await act(async () => {
+      await flush()
+      lastES().onopen?.(new Event('open'))
+      lastES().simulateClose()
+      await flush()
+    })
+
+    expect(String(result.current.streamError ?? '')).not.toContain('phase1-watching')
+    expect(String(result.current.streamError ?? '')).not.toContain(
+      'Deployment ended with status=',
+    )
+  })
+
+  it('promotes to completed if the canonical poll surfaces a non-empty handoverURL even before status flips to ready', async () => {
+    // catalyst-api stamps handoverURL on the deployment record AT the
+    // same moment Phase-1 reaches OutcomeReady. There can be a tiny
+    // window where the top-level status is still "phase1-watching" but
+    // handoverURL is already populated — the founder's incident report
+    // for #782 explicitly described this state. The hook must render
+    // success in that case, not failure.
+    globalThis.fetch = makeFetchResponses(
+      { ok: true, body: { events: [], state: undefined, done: false } },
+      {
+        ok: true,
+        body: {
+          id: 'd-handover-early',
+          status: 'phase1-watching',
+          sovereignFQDN: 'otech.example.com',
+          handoverURL: 'https://console.otech.example.com/auth/handover?token=BBB',
+          handoverFiredAt: '2026-05-04T16:17:09Z',
+          componentStates: { cilium: 'installed', 'cert-manager': 'installed' },
+        },
+      },
+    )
+
+    const { result } = renderHook(() =>
+      useDeploymentEvents({ deploymentId: 'd-handover-early', applicationIds: APPS }),
+    )
+
+    await act(async () => {
+      await flush()
+      lastES().onopen?.(new Event('open'))
+      lastES().simulateClose()
+      await flush()
+    })
+
+    await waitFor(() => {
+      expect(result.current.streamStatus).toBe('completed')
+    })
+    expect(result.current.handoverReady?.handoverURL).toBe(
+      'https://console.otech.example.com/auth/handover?token=BBB',
+    )
+    expect(result.current.streamError).toBeNull()
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/useDeploymentEvents.ts
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/useDeploymentEvents.ts
@@ -50,6 +50,24 @@ import {
 
 export type StreamStatus = 'connecting' | 'streaming' | 'completed' | 'failed' | 'unreachable'
 
+/**
+ * In-flight backend statuses (issue #782). The deployment record carries
+ * one of these values while provisioning is still progressing. The SSE
+ * stream closing while the canonical record is in any of these states
+ * means the transport dropped, NOT that the deployment failed: the
+ * wizard MUST keep showing a "still running" UI and reconnect rather
+ * than render a "Provisioning failed" banner with the stale phase id.
+ *
+ * Mirrors api/internal/handler/deployments.go isInFlightStatus().
+ */
+const IN_FLIGHT_STATUSES: ReadonlySet<string> = new Set([
+  'pending',
+  'provisioning',
+  'tofu-applying',
+  'flux-bootstrapping',
+  'phase1-watching',
+])
+
 export interface DeploymentSnapshot {
   id?: string
   status?: 'pending' | 'provisioning' | 'ready' | 'failed' | string
@@ -321,57 +339,67 @@ export function useDeploymentEvents(
     setFinishedAt(null)
     setHandoverReady(null)
     const url = `${API_BASE}/v1/deployments/${encodeURIComponent(deploymentId)}/logs`
-    const es = new EventSource(url)
+    let cancelled = false
     let seen = 0
+    let es: EventSource | null = null
+    // Issue #782 — guards reconnection backoff. When the SSE drops while
+    // the canonical deployment status is still in-flight (e.g. the
+    // reverse proxy idle-timed out the long-lived stream), we re-open
+    // the EventSource against the same URL. The backend's
+    // replay-on-connect serves the buffered history again; the `seen`
+    // counter resets so the reducer skips already-applied events via
+    // the same `seen <= historyCountRef.current` rule. We hard-cap
+    // reconnect attempts so a permanently-broken transport eventually
+    // surfaces as `failed` rather than spinning forever.
+    let reconnectAttempts = 0
+    const MAX_RECONNECT_ATTEMPTS = 5
+    let reconnectTimer: ReturnType<typeof setTimeout> | null = null
 
-    es.onopen = () => {
-      setStreamStatus('streaming')
-      setStartedAt((prev) => prev ?? Date.now())
-    }
-    es.onmessage = (msg) => {
-      try {
-        const ev = JSON.parse(msg.data) as DeploymentEvent
-        seen += 1
-        if (seen <= historyCountRef.current) return
-        setState((prev) => reduceEvents(prev, [ev]))
-      } catch {
-        /* malformed event — drop, the next event will recover */
+    const applySnapshotAndComplete = (snap: DeploymentSnapshot) => {
+      setSnapshot(snap)
+      setFinishedAt(Date.now())
+      const handoverURL = snap.handoverURL ?? snap.result?.handoverURL ?? ''
+      if (handoverURL) {
+        setHandoverReady((prev) => prev ?? { handoverURL, expiresAt: '' })
+      }
+      if (snap.status === 'ready') {
+        const componentStates =
+          snap.componentStates ?? snap.result?.componentStates ?? null
+        setState((prev) => markAllReady(prev, componentStates))
+        setStreamStatus('completed')
+      } else if (snap.status === 'failed') {
+        const componentStates =
+          snap.componentStates ?? snap.result?.componentStates ?? null
+        const phase1Outcome =
+          snap.phase1Outcome ?? snap.result?.phase1Outcome ?? ''
+        setState((prev) => markFailedTerminal(prev, phase1Outcome, componentStates))
+        setStreamStatus('failed')
+        // Issue #782 — surface the REAL error from the canonical record.
+        // Never synthesise "Deployment ended with status=<phase>" because
+        // a phase id (e.g. "phase1-watching") is a transient state, not a
+        // final outcome. If the backend somehow reports a non-terminal
+        // status here we leave streamError null rather than fabricate a
+        // misleading copy.
+        setStreamError(snap.error ?? null)
+      } else {
+        // Backend reported a non-terminal status on what should be a
+        // terminal `done` event. This shouldn't happen, but defensive:
+        // treat it as still in-flight rather than failure. The
+        // reconnect/poll loop above will re-evaluate.
+        setStreamStatus('streaming')
       }
     }
+
     const onDone = (msg: MessageEvent) => {
       try {
         const snap = JSON.parse(msg.data) as DeploymentSnapshot
-        setSnapshot(snap)
-        setFinishedAt(Date.now())
-        if (snap?.status === 'ready') {
-          // Same grounding rule as the GET-replay path above.
-          const componentStates =
-            snap.componentStates ?? snap.result?.componentStates ?? null
-          setState((prev) => markAllReady(prev, componentStates))
-          setStreamStatus('completed')
-        } else {
-          // Issue #519 — same Phase-0 banner convergence as the GET-
-          // replay path above. The SSE `done` event is the live-stream
-          // mirror; failing to converge here would cause the same
-          // "Phase-0 stuck Running" UX on a tab that stayed open from
-          // the start.
-          if (snap?.status === 'failed') {
-            const componentStates =
-              snap.componentStates ?? snap.result?.componentStates ?? null
-            const phase1Outcome =
-              snap.phase1Outcome ?? snap.result?.phase1Outcome ?? ''
-            setState((prev) => markFailedTerminal(prev, phase1Outcome, componentStates))
-          }
-          setStreamStatus('failed')
-          setStreamError(snap?.error ?? `Deployment ended with status=${snap?.status ?? 'unknown'}`)
-        }
+        applySnapshotAndComplete(snap)
       } catch (err) {
         setStreamStatus('failed')
         setStreamError(`Failed to parse final snapshot: ${String(err)}`)
       }
-      es.close()
+      es?.close()
     }
-    es.addEventListener('done', onDone as EventListener)
 
     // Issues #764 + #768 — typed `handover-ready` SSE event. Carries
     // {handoverURL, expiresAt}; the provision page renders the
@@ -394,21 +422,148 @@ export function useDeploymentEvents(
         /* malformed payload — drop, the GET-replay fallback recovers */
       }
     }
-    es.addEventListener('handover-ready', onHandoverReady as EventListener)
 
-    es.onerror = () => {
-      if (es.readyState === EventSource.CLOSED) {
-        setStreamStatus((prev) => {
-          if (prev === 'completed') return prev
-          return prev === 'connecting' ? 'unreachable' : 'failed'
-        })
-        setStreamError((prev) => prev ?? 'SSE connection closed before completion')
+    /**
+     * Issue #782 — re-fetch /deployments/{id} once and switch on the
+     * canonical status. Called when the SSE stream closes WITHOUT a
+     * terminal `event: done`. The transport drop alone is NOT a failure
+     * signal; only `status === 'failed'` from this canonical poll is.
+     *
+     * Returns true if a terminal state was reached (ready/failed/
+     * unreachable), false if the deployment is still in flight (caller
+     * will reconnect SSE with backoff).
+     */
+    const pollCanonicalState = async (): Promise<boolean> => {
+      const pollUrl = `${API_BASE}/v1/deployments/${encodeURIComponent(deploymentId)}`
+      try {
+        const resp = await fetch(pollUrl, { headers: { Accept: 'application/json' } })
+        if (cancelled) return true
+        if (!resp.ok) {
+          // 404/5xx — treat as unreachable so the operator can retry.
+          setStreamStatus('unreachable')
+          setStreamError(
+            (prev) => prev ?? `Deployment status poll returned HTTP ${resp.status}`,
+          )
+          return true
+        }
+        const snap = (await resp.json()) as DeploymentSnapshot
+        if (cancelled) return true
+        const status = snap?.status ?? ''
+        if (status === 'ready' || status === 'failed') {
+          applySnapshotAndComplete(snap)
+          return true
+        }
+        if (IN_FLIGHT_STATUSES.has(status)) {
+          // Still in flight — surface the snapshot so handover-URL
+          // (which catalyst-api may have stamped before the stream
+          // dropped) is recovered immediately, and keep the UI in
+          // `streaming` so the wizard's spinner stays up. The caller
+          // re-opens the EventSource via the reconnect branch.
+          setSnapshot(snap)
+          const handoverURL = snap.handoverURL ?? snap.result?.handoverURL ?? ''
+          if (handoverURL) {
+            // The handover URL is itself a terminal signal: catalyst-api
+            // only stamps it after the Phase-1 watch reaches
+            // OutcomeReady. Promote to completed so the AppsPage banner
+            // renders even if the top-level status hasn't flipped yet.
+            setHandoverReady((prev) => prev ?? { handoverURL, expiresAt: '' })
+            const componentStates =
+              snap.componentStates ?? snap.result?.componentStates ?? null
+            setState((prev) => markAllReady(prev, componentStates))
+            setStreamStatus('completed')
+            setFinishedAt(Date.now())
+            return true
+          }
+          // Spinner UI — the reducer state already reflects whatever
+          // events the GET-replay seeded; nothing more to do here.
+          setStreamStatus('streaming')
+          return false
+        }
+        // Unknown status — defensive: don't synthesize a failure copy.
+        return false
+      } catch {
+        if (cancelled) return true
+        setStreamStatus('unreachable')
+        setStreamError(
+          (prev) => prev ?? 'Could not reach the catalyst-api to confirm deployment status',
+        )
+        return true
       }
     }
+
+    const handleStreamClose = () => {
+      if (cancelled) return
+      // Issue #782 — SSE close is a TRANSPORT signal, not a deployment
+      // outcome. Re-fetch the canonical /deployments/{id} record and
+      // switch on the real status: `ready` → success banner, `failed`
+      // → real-error banner, in-flight → spinner + reconnect SSE.
+      void pollCanonicalState().then((terminal) => {
+        if (cancelled) return
+        if (terminal) return
+        // Still in flight — reconnect the SSE stream after a small
+        // exponential backoff. The reducer is idempotent over replayed
+        // events thanks to the `seen <= historyCountRef.current` guard,
+        // so the buffered history can be safely served again.
+        if (reconnectAttempts >= MAX_RECONNECT_ATTEMPTS) {
+          setStreamStatus('failed')
+          setStreamError(
+            (prev) =>
+              prev ??
+              'SSE connection dropped repeatedly — could not maintain a stream to the catalyst-api',
+          )
+          return
+        }
+        reconnectAttempts += 1
+        const backoffMs = Math.min(1000 * 2 ** (reconnectAttempts - 1), 8000)
+        if (reconnectTimer !== null) clearTimeout(reconnectTimer)
+        reconnectTimer = setTimeout(() => {
+          if (cancelled) return
+          es = openStream()
+        }, backoffMs)
+      })
+    }
+
+    const openStream = (): EventSource => {
+      const next = new EventSource(url)
+      seen = 0
+      next.onopen = () => {
+        setStreamStatus('streaming')
+        setStartedAt((prev) => prev ?? Date.now())
+      }
+      next.onmessage = (msg) => {
+        try {
+          const ev = JSON.parse(msg.data) as DeploymentEvent
+          seen += 1
+          if (seen <= historyCountRef.current) return
+          setState((prev) => reduceEvents(prev, [ev]))
+        } catch {
+          /* malformed event — drop, the next event will recover */
+        }
+      }
+      next.addEventListener('done', onDone as EventListener)
+      next.addEventListener('handover-ready', onHandoverReady as EventListener)
+      next.onerror = () => {
+        if (next.readyState === EventSource.CLOSED) {
+          // Issue #782 — SSE close is a TRANSPORT signal, not a
+          // deployment outcome. Re-fetch the canonical /deployments/{id}
+          // record and switch on the real status. We NEVER flip to
+          // `failed` purely on a stream close.
+          handleStreamClose()
+        }
+      }
+      return next
+    }
+
+    es = openStream()
+
     return () => {
-      es.removeEventListener('done', onDone as EventListener)
-      es.removeEventListener('handover-ready', onHandoverReady as EventListener)
-      es.close()
+      cancelled = true
+      if (reconnectTimer !== null) clearTimeout(reconnectTimer)
+      if (es) {
+        es.removeEventListener('done', onDone as EventListener)
+        es.removeEventListener('handover-ready', onHandoverReady as EventListener)
+        es.close()
+      }
     }
   }, [deploymentId, retryNonce, disableStream])
 


### PR DESCRIPTION
## Summary
- Replaces the SSE-close failure path in `useDeploymentEvents` with a single re-fetch of `/sovereign/api/v1/deployments/{id}` that switches on the canonical `status`. `ready` → success banner with handoverURL, `failed` → real `snapshot.error` (never the stale `Deployment ended with status=<phase>` copy), in-flight statuses → spinner + auto-reconnect with exponential backoff (max 5 attempts).
- Recovers `handoverURL` from the canonical poll so a tab that lost the SSE during the handover-mint window still renders the "Open your Sovereign console →" affordance.
- Adds 6 unit tests covering all three branches plus the hard regression that "Deployment ended with status=phase1-watching" can never appear in streamError under any SSE-close path.

Closes #782.

## Why
Founder evidence (otech93 + otech94, 2026-05-04): the provision page banner showed:

> Provisioning failed
> Deployment ended with status=phase1-watching

while the canonical record was already `status=ready, handoverFiredAt=...`. `phase1-watching` is a transient phase, not a terminal outcome — the SSE close was a transport drop (reverse-proxy idle timeout), not a failure signal. The fix moves the failure decision from "SSE closed" to "the canonical record says failed", per the issue's required behavior.

## Test plan
- [x] `npx vitest run src/pages/sovereign/useDeploymentEvents.refetch.test.tsx` — 6 / 6 pass
- [x] `npx vitest run src/pages/sovereign/AppsPage.handover.test.tsx` — 4 / 4 pass (existing #764 lock-ins still green)
- [x] `npx vitest run src/pages/sovereign/eventReducer.test.ts` — 41 / 41 pass
- [x] `npm run typecheck` — only the pre-existing unrelated `@tabler/icons-react` error
- [ ] After merge: verify on next provision run that an SSE drop mid-Phase-1 keeps the spinner up and either re-syncs to success or shows the real error

🤖 Generated with [Claude Code](https://claude.com/claude-code)