### PR TITLE
feat(catalyst-api): sovereignty cutover endpoints (#792)

### DIFF
--- a/products/catalyst/bootstrap/api/cmd/api/main.go
+++ b/products/catalyst/bootstrap/api/cmd/api/main.go
@@ -409,6 +409,20 @@ func main() {
 		rg.Post("/api/v1/deployments/{depId}/admin/user-access", h.CreateUserAccess)
 		rg.Put("/api/v1/deployments/{depId}/admin/user-access/{name}", h.UpdateUserAccess)
 		rg.Delete("/api/v1/deployments/{depId}/admin/user-access/{name}", h.DeleteUserAccess)
+
+		// Self-Sovereignty Cutover (issue #792 — parent epic #790). The
+		// post-handover step that severs a Sovereign's remaining
+		// tethers to the openova-io mothership: gitea-mirror,
+		// harbor-projects, harbor-prewarm, registry-pivot DaemonSet,
+		// flux-gitrepository-patch, helmrepository-patches,
+		// catalyst-api-env-patch, and an egress-block self-test.
+		// PodSpec ConfigMaps are shipped by bp-self-sovereign-cutover
+		// (issue #791); catalyst-api creates the actual Jobs.
+		// Operator-admin gating is provided by RequireSession above —
+		// only authenticated console operators can fire this.
+		rg.Post("/api/v1/sovereign/cutover/start", h.HandleCutoverStart)
+		rg.Get("/api/v1/sovereign/cutover/status", h.HandleCutoverStatus)
+		rg.Get("/api/v1/sovereign/cutover/events", h.HandleCutoverEvents)
 	})
 
 	log.Info("catalyst api listening", "port", port)

--- a/products/catalyst/bootstrap/api/internal/handler/cutover.go
+++ b/products/catalyst/bootstrap/api/internal/handler/cutover.go
@@ -1,0 +1,1172 @@
+// cutover.go — Self-Sovereignty Cutover endpoints (issue #792).
+//
+// The "cutover" is the post-handover step that severs a Sovereign's
+// remaining tethers to the openova-io mothership: it mirrors the
+// GitOps repo into local Gitea, configures Harbor proxy-cache projects,
+// pre-warms the bootstrap-kit images through the local Harbor, pivots
+// containerd's registries.yaml on every Node so all upstream traffic
+// flows through harbor.<sovereign-fqdn>, patches the flux-system
+// GitRepository to point at the local Gitea, patches every
+// HelmRepository's OCI URL to point at local Harbor, patches the
+// catalyst-api Deployment env to forget the upstream GitOps URL, and
+// finally proves the result with an egress-block self-test.
+//
+// The chart that ships these steps is bp-self-sovereign-cutover
+// (issue #791). It installs DORMANT — no Helm post-install hook fires
+// the Jobs. Instead, it publishes one "PodSpec ConfigMap" per step
+// and a status ConfigMap. The Jobs are created HERE, by catalyst-api,
+// when the operator hits POST /api/v1/sovereign/cutover/start.
+//
+// ── Contract with bp-self-sovereign-cutover ─────────────────────────────────
+//
+// Namespace:
+//   - Default `catalyst` (the namespace catalyst-api itself runs in
+//     after handover). Override via env CATALYST_CUTOVER_NAMESPACE.
+//
+// PodSpec ConfigMaps (one per step):
+//   - Selected by labels:
+//     app.kubernetes.io/part-of=self-sovereign-cutover
+//     app.kubernetes.io/component=cutover-step
+//   - Order encoded as the integer label `bp.openova.io/cutover-order`
+//     (e.g. "1", "2", ..., "8"). Steps are sorted ascending.
+//   - Mode encoded as the label `bp.openova.io/cutover-mode`:
+//     "job" (default) — data.podSpec is YAML of corev1.PodSpec; the
+//     handler creates a fresh batchv1.Job per run, watches to
+//     completion, and treats Failed as a terminal cutover failure.
+//     "daemonset-wait" — the chart already deployed a DaemonSet
+//     with name = label `bp.openova.io/cutover-daemonset` (default
+//     the ConfigMap name without the "cutover-step-NN-" prefix).
+//     The handler waits for `.status.numberReady == .status.desiredNumberScheduled`
+//     on every Node before declaring the step done.
+//   - Step ConfigMap data keys:
+//     data.stepName  — short slug used in the status ConfigMap and
+//     Job naming (e.g. "gitea-mirror"). Required.
+//     data.podSpec   — corev1.PodSpec YAML. Required for mode=job.
+//
+// Status ConfigMap:
+//   - Name: `self-sovereign-cutover-status` (override via
+//     CATALYST_CUTOVER_STATUS_CONFIGMAP).
+//   - Created by the chart with `data.cutoverComplete = "false"`.
+//   - Patched after every step transition by this handler. Keys:
+//     cutoverComplete          "true" | "false"
+//     cutoverStartedAt         RFC3339, set by /start on first run
+//     cutoverFinishedAt        RFC3339, set when last step succeeds
+//     currentStep              <stepName> | "" when idle
+//     currentStepIndex         "0".."N"
+//     totalSteps               "N"
+//     progressPercent          "0".."100"
+//     failedStep               <stepName> | "" when no failure
+//     lastError                operator-actionable string | ""
+//     step.<stepName>.startedAt
+//     step.<stepName>.finishedAt
+//     step.<stepName>.result   "success" | "failed" | "skipped"
+//     step.<stepName>.jobName  Job/DaemonSet name (audit pointer)
+//   - Idempotency anchor: when `cutoverComplete == "true"` POST /start
+//     returns 200 with the existing state and does NOT re-run.
+//
+// ── Endpoints ───────────────────────────────────────────────────────────────
+//
+// POST /api/v1/sovereign/cutover/start
+//   - Operator-admin only (RequireSession middleware in main.go).
+//   - Returns 200 with the status snapshot. The cutover runs in a
+//     background goroutine; the operator polls /status or subscribes
+//     to /events for live progress.
+//   - Idempotent: if cutoverComplete=true, returns the existing state.
+//   - 409 if a cutover is already in progress on this Pod (in-process
+//     mutex). A fresh Pod after a restart will see the partially-
+//     written status ConfigMap and resume from the next pending step.
+//
+// GET /api/v1/sovereign/cutover/status
+//   - Returns the status ConfigMap as JSON (keys promoted to top-level,
+//     plus a typed `steps` array with each step's startedAt/finishedAt/
+//     result/jobName).
+//
+// GET /api/v1/sovereign/cutover/events
+//   - SSE stream of state-change events. Uses an in-memory broadcaster
+//     per process (the cutover goroutine emits, the handler subscribes).
+//   - Replay-on-connect from a small ring buffer so a wizard tab opened
+//     after the cutover started sees the prior steps.
+//
+// ── Constraints honoured ────────────────────────────────────────────────────
+//
+//   - IaC-first: every cluster mutation goes via the in-cluster
+//     kubernetes.Interface (Create Job / Patch ConfigMap / Get DaemonSet
+//     / List ConfigMaps). NEVER bespoke cloud-API calls.
+//   - Credential hygiene: this handler does NOT read any secrets. The
+//     ConfigMaps it consumes carry only PodSpecs; secrets referenced by
+//     those PodSpecs are mounted via secretRef envFrom — that's the
+//     chart's concern.
+//   - Event-driven: SSE not polling. The Watch on each Job uses the
+//     informer-style Watch verb, not periodic GETs.
+//   - Runtime-configurable: namespace, status ConfigMap name, per-step
+//     timeouts all read from env per docs/INVIOLABLE-PRINCIPLES.md #4.
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/yaml"
+)
+
+// ── Config knobs (every value runtime-overridable per principle #4) ─────────
+
+const (
+	// Default namespace the chart installs into and where the Jobs run.
+	defaultCutoverNamespace = "catalyst"
+
+	// Default name of the status ConfigMap. The chart pre-creates it
+	// with `cutoverComplete: "false"`.
+	defaultCutoverStatusConfigMap = "self-sovereign-cutover-status"
+
+	// Per-step Job watch timeout. The cutover Jobs are short-running
+	// (gitea-mirror is the longest at a few minutes for a clone of the
+	// public openova repo). 15 minutes is a generous worst case.
+	defaultCutoverStepTimeout = 15 * time.Minute
+
+	// DaemonSet ready-wait timeout. registry-pivot rolls in seconds on
+	// a small Sovereign and a few minutes on a large one.
+	defaultDaemonSetReadyTimeout = 10 * time.Minute
+
+	// Selector labels for cutover step ConfigMaps.
+	cutoverStepPartOfLabel    = "app.kubernetes.io/part-of"
+	cutoverStepPartOfValue    = "self-sovereign-cutover"
+	cutoverStepComponentLabel = "app.kubernetes.io/component"
+	cutoverStepComponentValue = "cutover-step"
+	cutoverStepOrderLabel     = "bp.openova.io/cutover-order"
+	cutoverStepModeLabel      = "bp.openova.io/cutover-mode"
+	cutoverStepDaemonSetLabel = "bp.openova.io/cutover-daemonset"
+
+	// Cutover modes.
+	cutoverModeJob           = "job"
+	cutoverModeDaemonSetWait = "daemonset-wait"
+
+	// SSE phase names.
+	cutoverPhaseStepStarted  = "cutover-step-started"
+	cutoverPhaseStepFinished = "cutover-step-finished"
+	cutoverPhaseStepFailed   = "cutover-step-failed"
+	cutoverPhaseCompleted    = "cutover-completed"
+	cutoverPhaseAlreadyDone  = "cutover-already-complete"
+	cutoverPhaseStarted      = "cutover-started"
+	cutoverPhaseSnapshot     = "cutover-status"
+
+	// Env override names.
+	envCutoverNamespace     = "CATALYST_CUTOVER_NAMESPACE"
+	envCutoverStatusCM      = "CATALYST_CUTOVER_STATUS_CONFIGMAP"
+	envCutoverStepTimeout   = "CATALYST_CUTOVER_STEP_TIMEOUT"
+	envCutoverDaemonSetWait = "CATALYST_CUTOVER_DAEMONSET_TIMEOUT"
+)
+
+// ── In-process state ────────────────────────────────────────────────────────
+
+// cutoverEvent is the SSE payload shape (a superset of provisioner.Event
+// for visual parity with phase-1 events but without the Component/State
+// fields the helmwatch bridge uses).
+type cutoverEvent struct {
+	Time    string `json:"time"`
+	Phase   string `json:"phase"`
+	Level   string `json:"level"` // info | warn | error
+	Message string `json:"message"`
+	Step    string `json:"step,omitempty"`
+	JobName string `json:"jobName,omitempty"`
+}
+
+// cutoverBroadcaster is the in-process pub/sub for cutover events.
+// One instance is wired into the Handler the first time a cutover-
+// related endpoint is hit. The cutover goroutine emits via Publish;
+// every active SSE subscriber receives a copy via Subscribe; a small
+// ring buffer drives replay-on-connect for wizard tabs that open
+// after the cutover started.
+type cutoverBroadcaster struct {
+	mu      sync.Mutex
+	buf     []cutoverEvent
+	subs    map[chan cutoverEvent]struct{}
+	bufCap  int
+	running bool // set true while a cutover goroutine is executing
+}
+
+func newCutoverBroadcaster() *cutoverBroadcaster {
+	return &cutoverBroadcaster{
+		subs:   make(map[chan cutoverEvent]struct{}),
+		bufCap: 256,
+	}
+}
+
+func (b *cutoverBroadcaster) Publish(ev cutoverEvent) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if len(b.buf) >= b.bufCap {
+		// Drop oldest — the cutover is short-lived and a wizard
+		// reconnecting late just sees the most recent events.
+		b.buf = append(b.buf[1:], ev)
+	} else {
+		b.buf = append(b.buf, ev)
+	}
+	for ch := range b.subs {
+		// Non-blocking; subscribers must drain quickly. A slow
+		// consumer drops messages rather than stalling the cutover.
+		select {
+		case ch <- ev:
+		default:
+		}
+	}
+}
+
+func (b *cutoverBroadcaster) Subscribe() (chan cutoverEvent, []cutoverEvent, func()) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	ch := make(chan cutoverEvent, 64)
+	b.subs[ch] = struct{}{}
+	replay := append([]cutoverEvent(nil), b.buf...)
+	cancel := func() {
+		b.mu.Lock()
+		defer b.mu.Unlock()
+		if _, ok := b.subs[ch]; ok {
+			delete(b.subs, ch)
+			close(ch)
+		}
+	}
+	return ch, replay, cancel
+}
+
+// tryStartRun atomically claims the in-process "cutover running" flag.
+// Returns true if the caller acquired it; false if a previous goroutine
+// still holds it. The caller MUST defer endRun on success.
+func (b *cutoverBroadcaster) tryStartRun() bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.running {
+		return false
+	}
+	b.running = true
+	return true
+}
+
+func (b *cutoverBroadcaster) endRun() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.running = false
+}
+
+// ── Handler wiring ──────────────────────────────────────────────────────────
+
+// cutoverDeps bundles every external dependency the cutover engine
+// needs. Production wires this from rest.InClusterConfig + a real
+// kubernetes.Clientset; tests inject a fake.NewSimpleClientset.
+type cutoverDeps struct {
+	core kubernetes.Interface
+	ns   string
+}
+
+// CutoverDepsFactory returns a fresh cutoverDeps. nil in production
+// means "build from in-cluster config"; tests inject a closure that
+// returns a fake clientset bound to a t.TempDir() namespace.
+type CutoverDepsFactory func() (*cutoverDeps, error)
+
+// SetCutoverDepsFactory wires a test-only factory. Production code
+// leaves this nil and cutoverDepsFromEnv runs.
+func (h *Handler) SetCutoverDepsFactory(f CutoverDepsFactory) {
+	h.cutoverDepsFactory = f
+}
+
+// SetCutoverBroadcaster wires a test-only broadcaster. Useful when a
+// test wants to seed a buffer or assert post-condition invariants.
+// Production leaves this nil and the lazy lookup in cutoverBus()
+// builds one on first use.
+func (h *Handler) SetCutoverBroadcaster(b *cutoverBroadcaster) {
+	h.cutoverBus = b
+}
+
+func (h *Handler) cutoverBusFor() *cutoverBroadcaster {
+	h.cutoverBusOnce.Do(func() {
+		if h.cutoverBus == nil {
+			h.cutoverBus = newCutoverBroadcaster()
+		}
+	})
+	return h.cutoverBus
+}
+
+func (h *Handler) cutoverDepsFor() (*cutoverDeps, error) {
+	if h.cutoverDepsFactory != nil {
+		return h.cutoverDepsFactory()
+	}
+	return cutoverDepsFromEnv()
+}
+
+func cutoverDepsFromEnv() (*cutoverDeps, error) {
+	cfg, err := rest.InClusterConfig()
+	if err != nil {
+		return nil, fmt.Errorf("cutover: in-cluster config unavailable: %w", err)
+	}
+	core, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("cutover: build core client: %w", err)
+	}
+	ns := os.Getenv(envCutoverNamespace)
+	if ns == "" {
+		ns = defaultCutoverNamespace
+	}
+	return &cutoverDeps{core: core, ns: ns}, nil
+}
+
+func cutoverStatusConfigMapName() string {
+	if v := os.Getenv(envCutoverStatusCM); v != "" {
+		return v
+	}
+	return defaultCutoverStatusConfigMap
+}
+
+func cutoverStepTimeout() time.Duration {
+	if v, _ := time.ParseDuration(os.Getenv(envCutoverStepTimeout)); v > 0 {
+		return v
+	}
+	return defaultCutoverStepTimeout
+}
+
+func cutoverDaemonSetTimeout() time.Duration {
+	if v, _ := time.ParseDuration(os.Getenv(envCutoverDaemonSetWait)); v > 0 {
+		return v
+	}
+	return defaultDaemonSetReadyTimeout
+}
+
+// ── Step discovery ──────────────────────────────────────────────────────────
+
+// cutoverStep is the resolved view of a step ConfigMap.
+type cutoverStep struct {
+	order        int
+	cmName       string
+	stepName     string
+	mode         string
+	daemonsetRef string
+	podSpec      *corev1.PodSpec
+}
+
+// listCutoverSteps reads every ConfigMap with the cutover labels in
+// the cutover namespace and parses them into ordered cutoverStep
+// structs. An invalid ConfigMap (missing required keys, malformed
+// PodSpec YAML) is surfaced as an error so the operator can fix the
+// chart values rather than silently skipping the step.
+func listCutoverSteps(ctx context.Context, deps *cutoverDeps) ([]cutoverStep, error) {
+	selector := fmt.Sprintf("%s=%s,%s=%s",
+		cutoverStepPartOfLabel, cutoverStepPartOfValue,
+		cutoverStepComponentLabel, cutoverStepComponentValue,
+	)
+	cms, err := deps.core.CoreV1().ConfigMaps(deps.ns).List(ctx, metav1.ListOptions{
+		LabelSelector: selector,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list cutover step ConfigMaps in %q: %w", deps.ns, err)
+	}
+	var out []cutoverStep
+	for _, cm := range cms.Items {
+		step, err := parseCutoverStep(cm)
+		if err != nil {
+			return nil, fmt.Errorf("ConfigMap %s/%s: %w", cm.Namespace, cm.Name, err)
+		}
+		out = append(out, step)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].order != out[j].order {
+			return out[i].order < out[j].order
+		}
+		// Stable secondary sort on name so two steps with the same
+		// order (chart bug) still produce a deterministic sequence
+		// rather than a flake.
+		return out[i].cmName < out[j].cmName
+	})
+	return out, nil
+}
+
+func parseCutoverStep(cm corev1.ConfigMap) (cutoverStep, error) {
+	step := cutoverStep{cmName: cm.Name}
+	if v := cm.Labels[cutoverStepOrderLabel]; v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil {
+			return step, fmt.Errorf("label %s=%q is not an integer", cutoverStepOrderLabel, v)
+		}
+		step.order = n
+	} else {
+		return step, fmt.Errorf("missing required label %s", cutoverStepOrderLabel)
+	}
+	step.mode = cm.Labels[cutoverStepModeLabel]
+	if step.mode == "" {
+		step.mode = cutoverModeJob
+	}
+	step.stepName = strings.TrimSpace(cm.Data["stepName"])
+	if step.stepName == "" {
+		return step, fmt.Errorf("missing required data key %q", "stepName")
+	}
+	switch step.mode {
+	case cutoverModeJob:
+		raw := cm.Data["podSpec"]
+		if strings.TrimSpace(raw) == "" {
+			return step, fmt.Errorf("missing required data key %q for mode=%s", "podSpec", step.mode)
+		}
+		var ps corev1.PodSpec
+		if err := yaml.Unmarshal([]byte(raw), &ps); err != nil {
+			return step, fmt.Errorf("parse podSpec YAML: %w", err)
+		}
+		// Defensive: a zero-value PodSpec with no containers is a
+		// chart bug.
+		if len(ps.Containers) == 0 {
+			return step, fmt.Errorf("podSpec has no containers")
+		}
+		// Cutover Jobs MUST NOT auto-restart on failure — a failed
+		// step must surface as a terminal cutover failure, not silently
+		// retry forever. Force restartPolicy=Never if the chart left
+		// it empty (corev1 default for PodSpec is "Always" which is
+		// invalid for batch Jobs anyway).
+		if ps.RestartPolicy == "" {
+			ps.RestartPolicy = corev1.RestartPolicyNever
+		}
+		step.podSpec = &ps
+	case cutoverModeDaemonSetWait:
+		ref := cm.Labels[cutoverStepDaemonSetLabel]
+		if ref == "" {
+			// Fallback: derive from cm name by stripping the
+			// "cutover-step-NN-" prefix the chart uses by convention.
+			ref = stripCutoverStepPrefix(cm.Name)
+		}
+		if ref == "" {
+			return step, fmt.Errorf("mode=%s requires label %s or a derivable cm name", step.mode, cutoverStepDaemonSetLabel)
+		}
+		step.daemonsetRef = ref
+	default:
+		return step, fmt.Errorf("unknown cutover mode %q (want %q or %q)", step.mode, cutoverModeJob, cutoverModeDaemonSetWait)
+	}
+	return step, nil
+}
+
+// stripCutoverStepPrefix turns "cutover-step-04-registry-pivot" into
+// "registry-pivot" so a daemonset-wait step can default its target by
+// convention.
+func stripCutoverStepPrefix(name string) string {
+	const pfx = "cutover-step-"
+	if !strings.HasPrefix(name, pfx) {
+		return name
+	}
+	rest := name[len(pfx):]
+	// Strip leading "NN-" if present.
+	if i := strings.IndexByte(rest, '-'); i > 0 {
+		// Confirm the first segment is numeric.
+		head := rest[:i]
+		if _, err := strconv.Atoi(head); err == nil {
+			return rest[i+1:]
+		}
+	}
+	return rest
+}
+
+// ── Status ConfigMap ────────────────────────────────────────────────────────
+
+// readCutoverStatus returns the status ConfigMap or a zero map if it
+// does not exist yet. NotFound is benign: the chart pre-creates it,
+// but a misordered Helm install + first-time POST /start race would
+// otherwise 503.
+func readCutoverStatus(ctx context.Context, deps *cutoverDeps) (map[string]string, error) {
+	name := cutoverStatusConfigMapName()
+	cm, err := deps.core.CoreV1().ConfigMaps(deps.ns).Get(ctx, name, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		return map[string]string{}, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get status ConfigMap %s/%s: %w", deps.ns, name, err)
+	}
+	if cm.Data == nil {
+		return map[string]string{}, nil
+	}
+	out := make(map[string]string, len(cm.Data))
+	for k, v := range cm.Data {
+		out[k] = v
+	}
+	return out, nil
+}
+
+// patchCutoverStatus issues a strategic-merge patch to the status
+// ConfigMap, creating it with `cutoverComplete: "false"` if absent.
+func patchCutoverStatus(ctx context.Context, deps *cutoverDeps, updates map[string]string) error {
+	name := cutoverStatusConfigMapName()
+	if updates == nil {
+		updates = map[string]string{}
+	}
+	// Use a strategic-merge patch on .data — Server-Side Apply or
+	// Update would race against a chart re-reconciliation; a merge
+	// patch keys-by-key is the smallest possible blast radius.
+	body := map[string]any{
+		"data": updates,
+	}
+	raw, err := json.Marshal(body)
+	if err != nil {
+		return fmt.Errorf("marshal patch: %w", err)
+	}
+	_, err = deps.core.CoreV1().ConfigMaps(deps.ns).Patch(
+		ctx, name, types.StrategicMergePatchType, raw, metav1.PatchOptions{},
+	)
+	if apierrors.IsNotFound(err) {
+		// Create on the fly if the chart has not landed yet (the
+		// chart will subsequently adopt the existing object via
+		// metadata.ownerReferences when it next reconciles, since
+		// our merge patch carries no ownerRef of its own).
+		cm := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: deps.ns,
+				Labels: map[string]string{
+					cutoverStepPartOfLabel: cutoverStepPartOfValue,
+				},
+			},
+			Data: updates,
+		}
+		// Always anchor cutoverComplete to a defined value on first
+		// create so the idempotency check can read it without nil
+		// checks.
+		if _, ok := cm.Data["cutoverComplete"]; !ok {
+			cm.Data["cutoverComplete"] = "false"
+		}
+		_, err = deps.core.CoreV1().ConfigMaps(deps.ns).Create(ctx, cm, metav1.CreateOptions{})
+		if err != nil && !apierrors.IsAlreadyExists(err) {
+			return fmt.Errorf("create status ConfigMap %s/%s: %w", deps.ns, name, err)
+		}
+		// AlreadyExists: a parallel writer beat us to it. Re-issue
+		// the patch.
+		if apierrors.IsAlreadyExists(err) {
+			_, err = deps.core.CoreV1().ConfigMaps(deps.ns).Patch(
+				ctx, name, types.StrategicMergePatchType, raw, metav1.PatchOptions{},
+			)
+			if err != nil {
+				return fmt.Errorf("re-patch status ConfigMap %s/%s: %w", deps.ns, name, err)
+			}
+		}
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("patch status ConfigMap %s/%s: %w", deps.ns, name, err)
+	}
+	return nil
+}
+
+// ── Job creation + watch ────────────────────────────────────────────────────
+
+// cutoverJobName returns the deterministic Job name for a step. Each
+// /start invocation appends an epoch suffix so a re-run after a
+// failure does NOT collide with the leftover Job from the previous
+// attempt — we rely on the Job's own GC for cleanup.
+func cutoverJobName(stepName string, runEpoch int64) string {
+	return fmt.Sprintf("cutover-%s-%d", stepName, runEpoch)
+}
+
+// createCutoverJob creates a fresh Job from the step's PodSpec.
+//
+// Per docs/INVIOLABLE-PRINCIPLES.md #3 (Crossplane is the ONLY day-2
+// IaC seam) cutover Jobs are one-shot bootstrap helpers, not declared
+// state — they execute and exit. This is consistent with the existing
+// hook-style Helm Jobs the bootstrap-kit uses elsewhere.
+func createCutoverJob(ctx context.Context, deps *cutoverDeps, step cutoverStep, runEpoch int64) (*batchv1.Job, error) {
+	name := cutoverJobName(step.stepName, runEpoch)
+	backoffLimit := int32(0)   // No retries — fail fast, surface to the operator.
+	ttl := int32(24 * 60 * 60) // 24h GC so the Job evidence stays around for audit.
+	activeDeadline := int64(cutoverStepTimeout().Seconds())
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: deps.ns,
+			Labels: map[string]string{
+				cutoverStepPartOfLabel:    cutoverStepPartOfValue,
+				cutoverStepComponentLabel: "cutover-job",
+				"cutover.openova.io/step": step.stepName,
+			},
+		},
+		Spec: batchv1.JobSpec{
+			BackoffLimit:            &backoffLimit,
+			TTLSecondsAfterFinished: &ttl,
+			ActiveDeadlineSeconds:   &activeDeadline,
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						cutoverStepPartOfLabel:    cutoverStepPartOfValue,
+						cutoverStepComponentLabel: "cutover-job",
+						"cutover.openova.io/step": step.stepName,
+					},
+				},
+				Spec: *step.podSpec,
+			},
+		},
+	}
+	created, err := deps.core.BatchV1().Jobs(deps.ns).Create(ctx, job, metav1.CreateOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("create Job %s/%s: %w", deps.ns, name, err)
+	}
+	return created, nil
+}
+
+// watchJobToCompletion blocks until the Job reports a terminal
+// condition (Complete or Failed). Returns the terminal condition type
+// or an error on watch / context failure. Uses a single Watch call
+// against the Job by name so we get an event-driven completion signal
+// rather than polling.
+func watchJobToCompletion(ctx context.Context, deps *cutoverDeps, jobName string) (batchv1.JobConditionType, error) {
+	timeout := cutoverStepTimeout()
+	wctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	// Sanity-check the current state up front so a Job that completed
+	// between Create and Watch (rare but possible on a small cluster)
+	// is recognised without waiting for the next event.
+	if existing, err := deps.core.BatchV1().Jobs(deps.ns).Get(wctx, jobName, metav1.GetOptions{}); err == nil {
+		if t, ok := terminalJobCondition(existing); ok {
+			return t, nil
+		}
+	}
+
+	w, err := deps.core.BatchV1().Jobs(deps.ns).Watch(wctx, metav1.ListOptions{
+		FieldSelector: "metadata.name=" + jobName,
+	})
+	if err != nil {
+		return "", fmt.Errorf("watch Job %s/%s: %w", deps.ns, jobName, err)
+	}
+	defer w.Stop()
+
+	for {
+		select {
+		case <-wctx.Done():
+			return "", fmt.Errorf("watch Job %s/%s: %w", deps.ns, jobName, wctx.Err())
+		case ev, ok := <-w.ResultChan():
+			if !ok {
+				// Watch closed (resource version expired, server
+				// flake). Fall back to a one-shot Get + retry the
+				// watch up to the deadline.
+				if existing, err := deps.core.BatchV1().Jobs(deps.ns).Get(wctx, jobName, metav1.GetOptions{}); err == nil {
+					if t, ok := terminalJobCondition(existing); ok {
+						return t, nil
+					}
+				}
+				return "", fmt.Errorf("watch Job %s/%s: channel closed before terminal condition", deps.ns, jobName)
+			}
+			if ev.Type == watch.Error {
+				return "", fmt.Errorf("watch Job %s/%s: error event: %#v", deps.ns, jobName, ev.Object)
+			}
+			job, ok := ev.Object.(*batchv1.Job)
+			if !ok {
+				continue
+			}
+			if t, ok := terminalJobCondition(job); ok {
+				return t, nil
+			}
+		}
+	}
+}
+
+// terminalJobCondition returns (Complete|Failed, true) if the Job has
+// a terminal condition with status=True; otherwise (_, false).
+func terminalJobCondition(job *batchv1.Job) (batchv1.JobConditionType, bool) {
+	for _, c := range job.Status.Conditions {
+		if c.Status != corev1.ConditionTrue {
+			continue
+		}
+		if c.Type == batchv1.JobComplete || c.Type == batchv1.JobFailed {
+			return c.Type, true
+		}
+	}
+	return "", false
+}
+
+// ── DaemonSet ready wait ────────────────────────────────────────────────────
+
+// waitForDaemonSetReady polls (with exponential backoff) until
+// `numberReady == desiredNumberScheduled` and `desiredNumberScheduled > 0`,
+// or returns an error on context cancel / timeout. The chart already
+// deployed the DaemonSet — this is a wait, not a create.
+func waitForDaemonSetReady(ctx context.Context, deps *cutoverDeps, dsName string) error {
+	timeout := cutoverDaemonSetTimeout()
+	wctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	return wait.PollUntilContextCancel(wctx, 3*time.Second, true, func(c context.Context) (bool, error) {
+		ds, err := deps.core.AppsV1().DaemonSets(deps.ns).Get(c, dsName, metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			// The chart has not landed yet — keep polling, the
+			// outer timeout bounds this.
+			return false, nil
+		}
+		if err != nil {
+			return false, fmt.Errorf("get DaemonSet %s/%s: %w", deps.ns, dsName, err)
+		}
+		desired := ds.Status.DesiredNumberScheduled
+		ready := ds.Status.NumberReady
+		if desired > 0 && desired == ready {
+			return true, nil
+		}
+		return false, nil
+	})
+}
+
+// ── Cutover engine ──────────────────────────────────────────────────────────
+
+// runCutover executes the discovered steps in order. It is run in a
+// background goroutine spawned by HandleCutoverStart. Every state
+// transition (started, finished, failed) is published to the
+// broadcaster AND patched onto the status ConfigMap.
+func (h *Handler) runCutover(ctx context.Context, deps *cutoverDeps, steps []cutoverStep) {
+	bus := h.cutoverBusFor()
+	defer bus.endRun()
+
+	runEpoch := time.Now().Unix()
+	totalSteps := len(steps)
+
+	startedAt := time.Now().UTC()
+	if err := patchCutoverStatus(ctx, deps, map[string]string{
+		"cutoverStartedAt": startedAt.Format(time.RFC3339),
+		"totalSteps":       strconv.Itoa(totalSteps),
+		"cutoverComplete":  "false",
+		"failedStep":       "",
+		"lastError":        "",
+	}); err != nil {
+		h.publishCutoverEvent(bus, cutoverEvent{
+			Time:    time.Now().UTC().Format(time.RFC3339),
+			Phase:   cutoverPhaseStepFailed,
+			Level:   "error",
+			Message: fmt.Sprintf("cutover: failed to seed status ConfigMap: %v", err),
+		})
+		return
+	}
+
+	h.publishCutoverEvent(bus, cutoverEvent{
+		Time:    startedAt.Format(time.RFC3339),
+		Phase:   cutoverPhaseStarted,
+		Level:   "info",
+		Message: fmt.Sprintf("Self-Sovereignty Cutover started: %d steps", totalSteps),
+	})
+
+	// Skip steps already marked success (resume-after-restart). The
+	// status ConfigMap is the durable record; if a previous run
+	// completed step 1 and 2 then crashed before step 3, a fresh
+	// /start picks up at step 3.
+	priorStatus, _ := readCutoverStatus(ctx, deps)
+
+	for i, step := range steps {
+		percent := int(100 * (float64(i) / float64(totalSteps)))
+		_ = patchCutoverStatus(ctx, deps, map[string]string{
+			"currentStep":      step.stepName,
+			"currentStepIndex": strconv.Itoa(i),
+			"progressPercent":  strconv.Itoa(percent),
+		})
+
+		if priorStatus["step."+step.stepName+".result"] == "success" {
+			h.publishCutoverEvent(bus, cutoverEvent{
+				Time:    time.Now().UTC().Format(time.RFC3339),
+				Phase:   cutoverPhaseStepFinished,
+				Level:   "info",
+				Step:    step.stepName,
+				Message: fmt.Sprintf("step %s already succeeded on a prior run; skipping", step.stepName),
+			})
+			continue
+		}
+
+		if err := h.runCutoverStep(ctx, deps, step, runEpoch); err != nil {
+			finishedAt := time.Now().UTC()
+			_ = patchCutoverStatus(ctx, deps, map[string]string{
+				"currentStep":                           "",
+				"failedStep":                            step.stepName,
+				"lastError":                             err.Error(),
+				"step." + step.stepName + ".finishedAt": finishedAt.Format(time.RFC3339),
+				"step." + step.stepName + ".result":     "failed",
+			})
+			h.publishCutoverEvent(bus, cutoverEvent{
+				Time:    finishedAt.Format(time.RFC3339),
+				Phase:   cutoverPhaseStepFailed,
+				Level:   "error",
+				Step:    step.stepName,
+				Message: fmt.Sprintf("step %s failed: %v", step.stepName, err),
+			})
+			h.log.Error("cutover: step failed", "step", step.stepName, "err", err)
+			return
+		}
+	}
+
+	finishedAt := time.Now().UTC()
+	_ = patchCutoverStatus(ctx, deps, map[string]string{
+		"cutoverComplete":   "true",
+		"cutoverFinishedAt": finishedAt.Format(time.RFC3339),
+		"currentStep":       "",
+		"currentStepIndex":  strconv.Itoa(totalSteps),
+		"progressPercent":   "100",
+	})
+	h.publishCutoverEvent(bus, cutoverEvent{
+		Time:    finishedAt.Format(time.RFC3339),
+		Phase:   cutoverPhaseCompleted,
+		Level:   "info",
+		Message: "Self-Sovereignty Cutover completed successfully",
+	})
+}
+
+func (h *Handler) runCutoverStep(ctx context.Context, deps *cutoverDeps, step cutoverStep, runEpoch int64) error {
+	bus := h.cutoverBusFor()
+	startedAt := time.Now().UTC()
+	jobOrDS := ""
+
+	switch step.mode {
+	case cutoverModeJob:
+		jobOrDS = cutoverJobName(step.stepName, runEpoch)
+	case cutoverModeDaemonSetWait:
+		jobOrDS = step.daemonsetRef
+	}
+
+	if err := patchCutoverStatus(ctx, deps, map[string]string{
+		"step." + step.stepName + ".startedAt": startedAt.Format(time.RFC3339),
+		"step." + step.stepName + ".result":    "running",
+		"step." + step.stepName + ".jobName":   jobOrDS,
+	}); err != nil {
+		return fmt.Errorf("status patch (start): %w", err)
+	}
+
+	h.publishCutoverEvent(bus, cutoverEvent{
+		Time:    startedAt.Format(time.RFC3339),
+		Phase:   cutoverPhaseStepStarted,
+		Level:   "info",
+		Step:    step.stepName,
+		JobName: jobOrDS,
+		Message: fmt.Sprintf("step %s started (%s)", step.stepName, step.mode),
+	})
+
+	switch step.mode {
+	case cutoverModeJob:
+		if _, err := createCutoverJob(ctx, deps, step, runEpoch); err != nil {
+			return err
+		}
+		cond, err := watchJobToCompletion(ctx, deps, jobOrDS)
+		if err != nil {
+			return err
+		}
+		if cond == batchv1.JobFailed {
+			return fmt.Errorf("Job %s/%s reported Failed condition", deps.ns, jobOrDS)
+		}
+	case cutoverModeDaemonSetWait:
+		if err := waitForDaemonSetReady(ctx, deps, jobOrDS); err != nil {
+			return fmt.Errorf("DaemonSet %s/%s did not reach ready in %s: %w",
+				deps.ns, jobOrDS, cutoverDaemonSetTimeout(), err)
+		}
+	default:
+		return fmt.Errorf("internal error: unknown step mode %q", step.mode)
+	}
+
+	finishedAt := time.Now().UTC()
+	if err := patchCutoverStatus(ctx, deps, map[string]string{
+		"step." + step.stepName + ".finishedAt": finishedAt.Format(time.RFC3339),
+		"step." + step.stepName + ".result":     "success",
+	}); err != nil {
+		return fmt.Errorf("status patch (success): %w", err)
+	}
+
+	h.publishCutoverEvent(bus, cutoverEvent{
+		Time:    finishedAt.Format(time.RFC3339),
+		Phase:   cutoverPhaseStepFinished,
+		Level:   "info",
+		Step:    step.stepName,
+		JobName: jobOrDS,
+		Message: fmt.Sprintf("step %s completed", step.stepName),
+	})
+	return nil
+}
+
+func (h *Handler) publishCutoverEvent(bus *cutoverBroadcaster, ev cutoverEvent) {
+	if ev.Time == "" {
+		ev.Time = time.Now().UTC().Format(time.RFC3339)
+	}
+	bus.Publish(ev)
+}
+
+// ── HTTP handlers ───────────────────────────────────────────────────────────
+
+// cutoverStatusResponse is the typed shape /status returns. Promotes
+// the well-known keys to top-level fields for ergonomics; the raw
+// per-step keys are also surfaced under `raw` so a UI can render
+// arbitrary additional metadata the chart adds in the future without
+// a client-side change.
+type cutoverStatusResponse struct {
+	CutoverComplete   bool                `json:"cutoverComplete"`
+	CutoverStartedAt  string              `json:"cutoverStartedAt,omitempty"`
+	CutoverFinishedAt string              `json:"cutoverFinishedAt,omitempty"`
+	CurrentStep       string              `json:"currentStep,omitempty"`
+	CurrentStepIndex  int                 `json:"currentStepIndex"`
+	TotalSteps        int                 `json:"totalSteps"`
+	ProgressPercent   int                 `json:"progressPercent"`
+	FailedStep        string              `json:"failedStep,omitempty"`
+	LastError         string              `json:"lastError,omitempty"`
+	Steps             []cutoverStepStatus `json:"steps"`
+	Raw               map[string]string   `json:"raw,omitempty"`
+}
+
+type cutoverStepStatus struct {
+	Name       string `json:"name"`
+	Result     string `json:"result"`
+	StartedAt  string `json:"startedAt,omitempty"`
+	FinishedAt string `json:"finishedAt,omitempty"`
+	JobName    string `json:"jobName,omitempty"`
+}
+
+// HandleCutoverStart handles POST /api/v1/sovereign/cutover/start.
+//
+// Idempotent: when the status ConfigMap reports cutoverComplete=true
+// the handler returns 200 with the existing snapshot and does NOT
+// re-run. When a cutover is already in flight on this Pod the
+// handler returns 409 (a fresh Pod after a restart will still be
+// able to resume from the on-disk state via /start because the
+// in-process running flag is per-Pod).
+func (h *Handler) HandleCutoverStart(w http.ResponseWriter, r *http.Request) {
+	deps, err := h.cutoverDepsFor()
+	if err != nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]string{
+			"error":  "cutover-unconfigured",
+			"detail": err.Error(),
+		})
+		return
+	}
+
+	status, err := readCutoverStatus(r.Context(), deps)
+	if err != nil {
+		writeJSON(w, http.StatusBadGateway, map[string]string{
+			"error":  "status-read-failed",
+			"detail": err.Error(),
+		})
+		return
+	}
+
+	if status["cutoverComplete"] == "true" {
+		bus := h.cutoverBusFor()
+		h.publishCutoverEvent(bus, cutoverEvent{
+			Phase:   cutoverPhaseAlreadyDone,
+			Level:   "info",
+			Message: "cutover already complete; /start is a no-op",
+		})
+		resp := buildCutoverStatusResponseFromMap(status, listStepNamesFromStatus(status))
+		writeJSON(w, http.StatusOK, resp)
+		return
+	}
+
+	steps, err := listCutoverSteps(r.Context(), deps)
+	if err != nil {
+		writeJSON(w, http.StatusBadGateway, map[string]string{
+			"error":  "step-discovery-failed",
+			"detail": err.Error(),
+		})
+		return
+	}
+	if len(steps) == 0 {
+		writeJSON(w, http.StatusFailedDependency, map[string]string{
+			"error":  "no-steps-found",
+			"detail": fmt.Sprintf("no cutover-step ConfigMaps found in namespace %q — bp-self-sovereign-cutover not installed?", deps.ns),
+		})
+		return
+	}
+
+	bus := h.cutoverBusFor()
+	if !bus.tryStartRun() {
+		writeJSON(w, http.StatusConflict, map[string]string{
+			"error":  "cutover-in-progress",
+			"detail": "a cutover is already running on this catalyst-api Pod",
+		})
+		return
+	}
+
+	// Run the engine with a context independent of the request so a
+	// client disconnect doesn't cancel a multi-step cutover. The
+	// cutoverStepTimeout on each step bounds the overall runtime.
+	go h.runCutover(context.Background(), deps, steps)
+
+	// Re-read status so the response reflects the freshly-patched
+	// `cutoverStartedAt` from the engine — the goroutine has likely
+	// already written it.
+	freshStatus, _ := readCutoverStatus(r.Context(), deps)
+	stepNames := make([]string, 0, len(steps))
+	for _, s := range steps {
+		stepNames = append(stepNames, s.stepName)
+	}
+	resp := buildCutoverStatusResponseFromMap(freshStatus, stepNames)
+	resp.TotalSteps = len(steps)
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// HandleCutoverStatus handles GET /api/v1/sovereign/cutover/status.
+func (h *Handler) HandleCutoverStatus(w http.ResponseWriter, r *http.Request) {
+	deps, err := h.cutoverDepsFor()
+	if err != nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]string{
+			"error":  "cutover-unconfigured",
+			"detail": err.Error(),
+		})
+		return
+	}
+	status, err := readCutoverStatus(r.Context(), deps)
+	if err != nil {
+		writeJSON(w, http.StatusBadGateway, map[string]string{
+			"error":  "status-read-failed",
+			"detail": err.Error(),
+		})
+		return
+	}
+	// Pull step names from the status ConfigMap keys; the chart's
+	// step ConfigMaps may be deleted post-cutover, so /status MUST
+	// reconstruct from the durable status keys.
+	stepNames := listStepNamesFromStatus(status)
+	// Fall back to live discovery if the status has no per-step keys
+	// yet (cutover never started).
+	if len(stepNames) == 0 {
+		if steps, err := listCutoverSteps(r.Context(), deps); err == nil {
+			for _, s := range steps {
+				stepNames = append(stepNames, s.stepName)
+			}
+		}
+	}
+	resp := buildCutoverStatusResponseFromMap(status, stepNames)
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// HandleCutoverEvents handles GET /api/v1/sovereign/cutover/events.
+//
+// Standard SSE protocol: text/event-stream, replay-on-connect from
+// the broadcaster's ring buffer, then live tail. Closes when the
+// client disconnects.
+func (h *Handler) HandleCutoverEvents(w http.ResponseWriter, r *http.Request) {
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "streaming not supported", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("X-Accel-Buffering", "no")
+
+	bus := h.cutoverBusFor()
+	ch, replay, cancel := bus.Subscribe()
+	defer cancel()
+
+	// Replay-on-connect.
+	for _, ev := range replay {
+		writeCutoverSSE(w, ev)
+	}
+	// Snapshot of current status as the first typed event so a wizard
+	// reconnecting after a Pod restart can render the durable state
+	// without an extra GET /status call.
+	if deps, err := h.cutoverDepsFor(); err == nil {
+		if status, err := readCutoverStatus(r.Context(), deps); err == nil {
+			snap, _ := json.Marshal(status)
+			writeCutoverSSE(w, cutoverEvent{
+				Time:    time.Now().UTC().Format(time.RFC3339),
+				Phase:   cutoverPhaseSnapshot,
+				Level:   "info",
+				Message: string(snap),
+			})
+		}
+	}
+	flusher.Flush()
+
+	for {
+		select {
+		case <-r.Context().Done():
+			return
+		case ev, open := <-ch:
+			if !open {
+				return
+			}
+			writeCutoverSSE(w, ev)
+			flusher.Flush()
+			// Close the stream after the terminal event so a wizard
+			// EventSource closes cleanly without requiring the
+			// browser to time out.
+			if ev.Phase == cutoverPhaseCompleted || ev.Phase == cutoverPhaseStepFailed {
+				return
+			}
+		}
+	}
+}
+
+func writeCutoverSSE(w http.ResponseWriter, ev cutoverEvent) {
+	raw, err := json.Marshal(ev)
+	if err != nil {
+		// Marshalling our own struct should never fail; drop the
+		// event with a comment line so the client sees something
+		// useful.
+		fmt.Fprintf(w, ": cutover: marshal failed: %v\n\n", err)
+		return
+	}
+	fmt.Fprintf(w, "event: %s\ndata: %s\n\n", ev.Phase, raw)
+}
+
+// ── Status response builders ────────────────────────────────────────────────
+
+func listStepNamesFromStatus(status map[string]string) []string {
+	seen := map[string]struct{}{}
+	for k := range status {
+		const pfx = "step."
+		if !strings.HasPrefix(k, pfx) {
+			continue
+		}
+		rest := k[len(pfx):]
+		// rest is "<stepName>.<field>"; find the last dot — step
+		// names should not contain dots, but defend against it.
+		idx := strings.LastIndex(rest, ".")
+		if idx <= 0 {
+			continue
+		}
+		name := rest[:idx]
+		seen[name] = struct{}{}
+	}
+	out := make([]string, 0, len(seen))
+	for n := range seen {
+		out = append(out, n)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func buildCutoverStatusResponseFromMap(status map[string]string, stepNames []string) cutoverStatusResponse {
+	resp := cutoverStatusResponse{
+		Raw: status,
+	}
+	resp.CutoverComplete = status["cutoverComplete"] == "true"
+	resp.CutoverStartedAt = status["cutoverStartedAt"]
+	resp.CutoverFinishedAt = status["cutoverFinishedAt"]
+	resp.CurrentStep = status["currentStep"]
+	if v, err := strconv.Atoi(status["currentStepIndex"]); err == nil {
+		resp.CurrentStepIndex = v
+	}
+	if v, err := strconv.Atoi(status["totalSteps"]); err == nil {
+		resp.TotalSteps = v
+	}
+	if v, err := strconv.Atoi(status["progressPercent"]); err == nil {
+		resp.ProgressPercent = v
+	}
+	resp.FailedStep = status["failedStep"]
+	resp.LastError = status["lastError"]
+
+	resp.Steps = make([]cutoverStepStatus, 0, len(stepNames))
+	for _, name := range stepNames {
+		resp.Steps = append(resp.Steps, cutoverStepStatus{
+			Name:       name,
+			Result:     status["step."+name+".result"],
+			StartedAt:  status["step."+name+".startedAt"],
+			FinishedAt: status["step."+name+".finishedAt"],
+			JobName:    status["step."+name+".jobName"],
+		})
+	}
+	return resp
+}

--- a/products/catalyst/bootstrap/api/internal/handler/cutover_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/cutover_test.go
@@ -1,0 +1,665 @@
+// Tests for the Self-Sovereignty Cutover endpoints (issue #792).
+//
+// What this file proves (matches the GATES checklist for #792):
+//
+//  1. parseCutoverStep — well-formed ConfigMap parses into a step
+//     with the expected order/mode/podSpec; malformed ConfigMap
+//     returns a typed error rather than silently skipping.
+//  2. listCutoverSteps — multiple step ConfigMaps come back ordered
+//     by `bp.openova.io/cutover-order`.
+//  3. HandleCutoverStart — runs all discovered steps, creates a real
+//     Job per `mode=job` step, waits for the DaemonSet ready signal
+//     for `mode=daemonset-wait`, and patches the status ConfigMap
+//     with `cutoverComplete=true` on success.
+//  4. HandleCutoverStart — idempotent: a second invocation against an
+//     already-complete status returns 200 + the durable snapshot
+//     and does NOT re-run.
+//  5. HandleCutoverStart — a Job that ends in JobFailed surfaces as
+//     `failedStep` + `lastError` on the status ConfigMap; the engine
+//     does NOT continue to subsequent steps.
+//  6. HandleCutoverStatus — surfaces every status ConfigMap key as a
+//     typed JSON response with promoted top-level fields.
+//  7. HandleCutoverEvents — SSE replay-on-connect fires every prior
+//     event, then live events stream in.
+//  8. parseCutoverStep handles the daemonset-wait mode (registry-
+//     pivot's special case) — the DaemonSet ref is derived from the
+//     label or from a sane name-strip fallback.
+package handler
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sruntime "k8s.io/apimachinery/pkg/runtime"
+	fakek8s "k8s.io/client-go/kubernetes/fake"
+	clienttesting "k8s.io/client-go/testing"
+)
+
+// ── Fixtures ────────────────────────────────────────────────────────────────
+
+const cutoverTestNS = "catalyst"
+
+// makeCutoverStepCM builds a properly-labelled ConfigMap that
+// listCutoverSteps will pick up.
+func makeCutoverStepCM(name, stepName string, order int, mode string, podSpec, daemonset string) *corev1.ConfigMap {
+	labels := map[string]string{
+		cutoverStepPartOfLabel:    cutoverStepPartOfValue,
+		cutoverStepComponentLabel: cutoverStepComponentValue,
+		cutoverStepOrderLabel:     fmt.Sprintf("%d", order),
+		cutoverStepModeLabel:      mode,
+	}
+	if daemonset != "" {
+		labels[cutoverStepDaemonSetLabel] = daemonset
+	}
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: cutoverTestNS,
+			Labels:    labels,
+		},
+		Data: map[string]string{
+			"stepName": stepName,
+		},
+	}
+	if podSpec != "" {
+		cm.Data["podSpec"] = podSpec
+	}
+	return cm
+}
+
+// minimalPodSpecYAML returns a syntactically valid corev1.PodSpec
+// YAML with a single busybox container — enough for parseCutoverStep
+// to succeed and for the fake clientset to round-trip the Job.
+const minimalPodSpecYAML = `containers:
+- name: cutover-step
+  image: busybox:1.36
+  command: ["/bin/sh", "-c", "echo step done"]
+restartPolicy: Never
+`
+
+// makeReadyDaemonSet builds a DaemonSet whose Status fields claim
+// every node is ready, so waitForDaemonSetReady terminates on the
+// first poll.
+func makeReadyDaemonSet(name string) *appsv1.DaemonSet {
+	return &appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: cutoverTestNS,
+		},
+		Status: appsv1.DaemonSetStatus{
+			DesiredNumberScheduled: 3,
+			NumberReady:            3,
+		},
+	}
+}
+
+// installJobReactor wires a reactor that auto-completes any Created
+// Job by stamping a JobComplete=True condition. Without this the
+// fake clientset would return the freshly-created Job indefinitely
+// and watchJobToCompletion would block.
+func installJobReactor(t *testing.T, client *fakek8s.Clientset, terminalCondition batchv1.JobConditionType) {
+	t.Helper()
+	client.PrependReactor("create", "jobs", func(action clienttesting.Action) (bool, k8sruntime.Object, error) {
+		ca, ok := action.(clienttesting.CreateAction)
+		if !ok {
+			return false, nil, nil
+		}
+		job, ok := ca.GetObject().(*batchv1.Job)
+		if !ok {
+			return false, nil, nil
+		}
+		// Capture identity so the goroutine below can update Status.
+		updated := job.DeepCopy()
+		updated.Status.Conditions = []batchv1.JobCondition{{
+			Type:   terminalCondition,
+			Status: corev1.ConditionTrue,
+			Reason: "Test",
+		}}
+		// We let the default tracker create the Job, then schedule an
+		// Update so a later Get / Watch observes the terminal status.
+		go func() {
+			// Tiny delay so the Watch starts before the Update lands.
+			time.Sleep(20 * time.Millisecond)
+			_, _ = client.BatchV1().Jobs(job.Namespace).UpdateStatus(
+				context.Background(), updated, metav1.UpdateOptions{},
+			)
+		}()
+		return false, nil, nil // let default tracker create the Job
+	})
+}
+
+// fakeHandlerWithCutover wires a Handler bound to a fake clientset
+// pre-seeded with the given objects.
+func fakeHandlerWithCutover(t *testing.T, objs ...k8sruntime.Object) (*Handler, *fakek8s.Clientset) {
+	t.Helper()
+	client := fakek8s.NewSimpleClientset(objs...)
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	h.SetCutoverDepsFactory(func() (*cutoverDeps, error) {
+		return &cutoverDeps{core: client, ns: cutoverTestNS}, nil
+	})
+	return h, client
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+func TestParseCutoverStep_ValidJob(t *testing.T) {
+	cm := makeCutoverStepCM("cutover-step-01-gitea-mirror", "gitea-mirror", 1, cutoverModeJob, minimalPodSpecYAML, "")
+	step, err := parseCutoverStep(*cm)
+	if err != nil {
+		t.Fatalf("parseCutoverStep: %v", err)
+	}
+	if step.order != 1 {
+		t.Errorf("order = %d, want 1", step.order)
+	}
+	if step.stepName != "gitea-mirror" {
+		t.Errorf("stepName = %q, want gitea-mirror", step.stepName)
+	}
+	if step.mode != cutoverModeJob {
+		t.Errorf("mode = %q, want %q", step.mode, cutoverModeJob)
+	}
+	if step.podSpec == nil || len(step.podSpec.Containers) != 1 {
+		t.Fatalf("podSpec must have one container; got %+v", step.podSpec)
+	}
+	if got := step.podSpec.Containers[0].Image; got != "busybox:1.36" {
+		t.Errorf("container image = %q, want busybox:1.36", got)
+	}
+}
+
+func TestParseCutoverStep_DaemonSetWaitDerivesNameFromCM(t *testing.T) {
+	cm := makeCutoverStepCM("cutover-step-04-registry-pivot", "registry-pivot", 4, cutoverModeDaemonSetWait, "", "")
+	step, err := parseCutoverStep(*cm)
+	if err != nil {
+		t.Fatalf("parseCutoverStep: %v", err)
+	}
+	if step.daemonsetRef != "registry-pivot" {
+		t.Errorf("daemonsetRef = %q, want %q (must derive from cm name when label is absent)", step.daemonsetRef, "registry-pivot")
+	}
+}
+
+func TestParseCutoverStep_MissingPodSpecForJobMode(t *testing.T) {
+	cm := makeCutoverStepCM("cutover-step-01-x", "x", 1, cutoverModeJob, "", "")
+	if _, err := parseCutoverStep(*cm); err == nil {
+		t.Fatalf("expected error for job mode without podSpec")
+	}
+}
+
+func TestParseCutoverStep_UnknownMode(t *testing.T) {
+	cm := makeCutoverStepCM("cutover-step-01-x", "x", 1, "bogus-mode", minimalPodSpecYAML, "")
+	if _, err := parseCutoverStep(*cm); err == nil {
+		t.Fatalf("expected error for unknown mode")
+	}
+}
+
+func TestParseCutoverStep_MissingOrderLabel(t *testing.T) {
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cutover-step-x",
+			Namespace: cutoverTestNS,
+			Labels: map[string]string{
+				cutoverStepPartOfLabel:    cutoverStepPartOfValue,
+				cutoverStepComponentLabel: cutoverStepComponentValue,
+			},
+		},
+		Data: map[string]string{"stepName": "x", "podSpec": minimalPodSpecYAML},
+	}
+	if _, err := parseCutoverStep(*cm); err == nil {
+		t.Fatalf("expected error when cutover-order label is missing")
+	}
+}
+
+func TestListCutoverSteps_OrdersByOrderLabel(t *testing.T) {
+	objs := []k8sruntime.Object{
+		makeCutoverStepCM("cutover-step-03-c", "c", 3, cutoverModeJob, minimalPodSpecYAML, ""),
+		makeCutoverStepCM("cutover-step-01-a", "a", 1, cutoverModeJob, minimalPodSpecYAML, ""),
+		makeCutoverStepCM("cutover-step-02-b", "b", 2, cutoverModeJob, minimalPodSpecYAML, ""),
+	}
+	_, client := fakeHandlerWithCutover(t, objs...)
+
+	steps, err := listCutoverSteps(context.Background(), &cutoverDeps{core: client, ns: cutoverTestNS})
+	if err != nil {
+		t.Fatalf("listCutoverSteps: %v", err)
+	}
+	if len(steps) != 3 {
+		t.Fatalf("got %d steps, want 3", len(steps))
+	}
+	want := []string{"a", "b", "c"}
+	for i, s := range steps {
+		if s.stepName != want[i] {
+			t.Errorf("steps[%d].stepName = %q, want %q", i, s.stepName, want[i])
+		}
+	}
+}
+
+// TestHandleCutoverStart_RunsAllStepsAndPersistsCompleted runs the
+// engine end-to-end against a fake clientset with two job-mode steps
+// and one daemonset-wait step, asserts the Job creates land, the
+// DaemonSet wait sees a ready DS, and the status ConfigMap finishes
+// in cutoverComplete=true with every per-step row marked success.
+func TestHandleCutoverStart_RunsAllStepsAndPersistsCompleted(t *testing.T) {
+	objs := []k8sruntime.Object{
+		makeCutoverStepCM("cutover-step-01-gitea-mirror", "gitea-mirror", 1, cutoverModeJob, minimalPodSpecYAML, ""),
+		makeCutoverStepCM("cutover-step-02-harbor-projects", "harbor-projects", 2, cutoverModeJob, minimalPodSpecYAML, ""),
+		makeCutoverStepCM("cutover-step-03-registry-pivot", "registry-pivot", 3, cutoverModeDaemonSetWait, "", "registry-pivot"),
+		makeReadyDaemonSet("registry-pivot"),
+	}
+	h, client := fakeHandlerWithCutover(t, objs...)
+	installJobReactor(t, client, batchv1.JobComplete)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sovereign/cutover/start", nil)
+	h.HandleCutoverStart(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("HandleCutoverStart: status %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+
+	// Wait for the engine goroutine to finish — the in-process running
+	// flag flips back to false on completion.
+	deadline := time.Now().Add(15 * time.Second)
+	for time.Now().Before(deadline) {
+		bus := h.cutoverBusFor()
+		bus.mu.Lock()
+		running := bus.running
+		bus.mu.Unlock()
+		if !running {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	// Re-read the status ConfigMap.
+	cm, err := client.CoreV1().ConfigMaps(cutoverTestNS).Get(context.Background(),
+		cutoverStatusConfigMapName(), metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get status ConfigMap: %v", err)
+	}
+	if cm.Data["cutoverComplete"] != "true" {
+		t.Errorf("cutoverComplete = %q, want true (data=%v)", cm.Data["cutoverComplete"], cm.Data)
+	}
+	for _, name := range []string{"gitea-mirror", "harbor-projects", "registry-pivot"} {
+		key := "step." + name + ".result"
+		if cm.Data[key] != "success" {
+			t.Errorf("%s = %q, want success", key, cm.Data[key])
+		}
+	}
+	if cm.Data["progressPercent"] != "100" {
+		t.Errorf("progressPercent = %q, want 100", cm.Data["progressPercent"])
+	}
+	if cm.Data["failedStep"] != "" {
+		t.Errorf("failedStep = %q, want empty", cm.Data["failedStep"])
+	}
+}
+
+// TestHandleCutoverStart_IdempotentWhenComplete proves a second
+// invocation against an already-complete status returns 200 with the
+// durable snapshot and does NOT re-create any Jobs.
+func TestHandleCutoverStart_IdempotentWhenComplete(t *testing.T) {
+	preComplete := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cutoverStatusConfigMapName(),
+			Namespace: cutoverTestNS,
+		},
+		Data: map[string]string{
+			"cutoverComplete":          "true",
+			"cutoverFinishedAt":        "2026-05-04T10:00:00Z",
+			"step.gitea-mirror.result": "success",
+		},
+	}
+	objs := []k8sruntime.Object{
+		makeCutoverStepCM("cutover-step-01-gitea-mirror", "gitea-mirror", 1, cutoverModeJob, minimalPodSpecYAML, ""),
+		preComplete,
+	}
+	h, client := fakeHandlerWithCutover(t, objs...)
+
+	// Track how many Jobs got created — should stay at zero.
+	jobCreates := 0
+	client.PrependReactor("create", "jobs", func(action clienttesting.Action) (bool, k8sruntime.Object, error) {
+		jobCreates++
+		return false, nil, nil
+	})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sovereign/cutover/start", nil)
+	h.HandleCutoverStart(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("HandleCutoverStart: status %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	if jobCreates != 0 {
+		t.Errorf("created %d Jobs on idempotent /start call, want 0", jobCreates)
+	}
+	// Response body should reflect cutoverComplete=true.
+	var resp cutoverStatusResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal response: %v; body=%s", err, rec.Body.String())
+	}
+	if !resp.CutoverComplete {
+		t.Errorf("response.cutoverComplete = false, want true")
+	}
+}
+
+// TestHandleCutoverStart_FailsHaltAtFailedStep proves a failed Job
+// stops the engine and persists the failure on the status ConfigMap.
+// A second step must NOT run.
+func TestHandleCutoverStart_FailsHaltAtFailedStep(t *testing.T) {
+	objs := []k8sruntime.Object{
+		makeCutoverStepCM("cutover-step-01-gitea-mirror", "gitea-mirror", 1, cutoverModeJob, minimalPodSpecYAML, ""),
+		makeCutoverStepCM("cutover-step-02-harbor-projects", "harbor-projects", 2, cutoverModeJob, minimalPodSpecYAML, ""),
+	}
+	h, client := fakeHandlerWithCutover(t, objs...)
+	installJobReactor(t, client, batchv1.JobFailed) // every Job fails
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sovereign/cutover/start", nil)
+	h.HandleCutoverStart(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("HandleCutoverStart: status %d, want 200 (engine started); body=%s", rec.Code, rec.Body.String())
+	}
+
+	// Wait for engine to terminate.
+	deadline := time.Now().Add(15 * time.Second)
+	for time.Now().Before(deadline) {
+		bus := h.cutoverBusFor()
+		bus.mu.Lock()
+		running := bus.running
+		bus.mu.Unlock()
+		if !running {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	cm, err := client.CoreV1().ConfigMaps(cutoverTestNS).Get(context.Background(),
+		cutoverStatusConfigMapName(), metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get status ConfigMap: %v", err)
+	}
+	if cm.Data["cutoverComplete"] == "true" {
+		t.Errorf("cutoverComplete = true, want false (run failed)")
+	}
+	if cm.Data["failedStep"] != "gitea-mirror" {
+		t.Errorf("failedStep = %q, want %q", cm.Data["failedStep"], "gitea-mirror")
+	}
+	if cm.Data["lastError"] == "" {
+		t.Errorf("lastError empty; want operator-actionable string")
+	}
+	if cm.Data["step.gitea-mirror.result"] != "failed" {
+		t.Errorf("step.gitea-mirror.result = %q, want failed", cm.Data["step.gitea-mirror.result"])
+	}
+	// Step 2 must NOT have started — its key should be absent or empty.
+	if cm.Data["step.harbor-projects.startedAt"] != "" {
+		t.Errorf("step.harbor-projects.startedAt = %q, must be empty (engine should have halted at step 1)", cm.Data["step.harbor-projects.startedAt"])
+	}
+}
+
+// TestHandleCutoverStart_NoStepsFound surfaces 424 (Failed Dependency)
+// when bp-self-sovereign-cutover has not been installed yet.
+func TestHandleCutoverStart_NoStepsFound(t *testing.T) {
+	h, _ := fakeHandlerWithCutover(t)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sovereign/cutover/start", nil)
+	h.HandleCutoverStart(rec, req)
+	if rec.Code != http.StatusFailedDependency {
+		t.Errorf("status = %d, want %d (FailedDependency); body=%s",
+			rec.Code, http.StatusFailedDependency, rec.Body.String())
+	}
+}
+
+// TestHandleCutoverStatus_ReturnsTypedSnapshot proves /status promotes
+// the well-known keys to typed top-level fields and reconstructs the
+// per-step rows from the durable status keys.
+func TestHandleCutoverStatus_ReturnsTypedSnapshot(t *testing.T) {
+	preStatus := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cutoverStatusConfigMapName(),
+			Namespace: cutoverTestNS,
+		},
+		Data: map[string]string{
+			"cutoverComplete":                "false",
+			"currentStep":                    "harbor-projects",
+			"currentStepIndex":               "1",
+			"totalSteps":                     "8",
+			"progressPercent":                "12",
+			"step.gitea-mirror.result":       "success",
+			"step.gitea-mirror.startedAt":    "2026-05-04T10:00:00Z",
+			"step.gitea-mirror.finishedAt":   "2026-05-04T10:01:30Z",
+			"step.harbor-projects.result":    "running",
+			"step.harbor-projects.startedAt": "2026-05-04T10:01:30Z",
+		},
+	}
+	h, _ := fakeHandlerWithCutover(t, preStatus)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/sovereign/cutover/status", nil)
+	h.HandleCutoverStatus(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	var resp cutoverStatusResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v; body=%s", err, rec.Body.String())
+	}
+	if resp.CutoverComplete {
+		t.Errorf("cutoverComplete = true, want false")
+	}
+	if resp.CurrentStep != "harbor-projects" {
+		t.Errorf("currentStep = %q, want harbor-projects", resp.CurrentStep)
+	}
+	if resp.TotalSteps != 8 {
+		t.Errorf("totalSteps = %d, want 8", resp.TotalSteps)
+	}
+	if resp.ProgressPercent != 12 {
+		t.Errorf("progressPercent = %d, want 12", resp.ProgressPercent)
+	}
+	if len(resp.Steps) != 2 {
+		t.Fatalf("steps length = %d, want 2", len(resp.Steps))
+	}
+	stepByName := map[string]cutoverStepStatus{}
+	for _, s := range resp.Steps {
+		stepByName[s.Name] = s
+	}
+	if g := stepByName["gitea-mirror"]; g.Result != "success" {
+		t.Errorf("gitea-mirror.result = %q, want success", g.Result)
+	}
+	if g := stepByName["harbor-projects"]; g.Result != "running" {
+		t.Errorf("harbor-projects.result = %q, want running", g.Result)
+	}
+}
+
+// TestHandleCutoverEvents_ReplayAndLive proves the SSE handler replays
+// buffered events to a late subscriber, surfaces a snapshot event,
+// and tails live events as they're published.
+func TestHandleCutoverEvents_ReplayAndLive(t *testing.T) {
+	h, _ := fakeHandlerWithCutover(t)
+	bus := h.cutoverBusFor()
+
+	// Pre-publish a couple of events so replay-on-connect has something
+	// to fire.
+	bus.Publish(cutoverEvent{
+		Time:    time.Now().UTC().Format(time.RFC3339),
+		Phase:   cutoverPhaseStepStarted,
+		Level:   "info",
+		Step:    "gitea-mirror",
+		Message: "step gitea-mirror started",
+	})
+	bus.Publish(cutoverEvent{
+		Time:    time.Now().UTC().Format(time.RFC3339),
+		Phase:   cutoverPhaseStepFinished,
+		Level:   "info",
+		Step:    "gitea-mirror",
+		Message: "step gitea-mirror completed",
+	})
+
+	// Start the SSE handler in a goroutine and drive the response
+	// through an httptest.ResponseRecorder + a custom flushable writer.
+	rec := newFlushableRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/sovereign/cutover/events", nil)
+	ctx, cancel := context.WithCancel(req.Context())
+	defer cancel()
+	req = req.WithContext(ctx)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		h.HandleCutoverEvents(rec, req)
+	}()
+
+	// Give the handler a beat to flush the replay buffer + snapshot.
+	time.Sleep(150 * time.Millisecond)
+
+	// Publish a live event after subscription.
+	bus.Publish(cutoverEvent{
+		Time:    time.Now().UTC().Format(time.RFC3339),
+		Phase:   cutoverPhaseCompleted,
+		Level:   "info",
+		Message: "Self-Sovereignty Cutover completed successfully",
+	})
+
+	// Wait for the handler to return on the terminal-cutoverPhaseCompleted
+	// auto-close.
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		cancel()
+		<-done
+	}
+
+	body := rec.Body()
+	// Replay must include both pre-published events.
+	if !bytes.Contains(body, []byte("step gitea-mirror started")) {
+		t.Errorf("replay missing first pre-published event; body=%s", body)
+	}
+	if !bytes.Contains(body, []byte("step gitea-mirror completed")) {
+		t.Errorf("replay missing second pre-published event; body=%s", body)
+	}
+	// Snapshot event must be present.
+	if !bytes.Contains(body, []byte("event: "+cutoverPhaseSnapshot)) {
+		t.Errorf("missing snapshot SSE event; body=%s", body)
+	}
+	// Live event must be present.
+	if !bytes.Contains(body, []byte("Self-Sovereignty Cutover completed successfully")) {
+		t.Errorf("live event missing; body=%s", body)
+	}
+	// Each SSE record ends with a blank line — sanity-check that the
+	// stream is well-formed by counting `data:` occurrences.
+	if c := bytes.Count(body, []byte("data: ")); c < 3 {
+		t.Errorf("expected at least 3 SSE data records (2 replay + snapshot + live), got %d", c)
+	}
+}
+
+// TestStripCutoverStepPrefix exercises the daemonset-name fallback
+// derivation used when the chart omits the explicit label.
+func TestStripCutoverStepPrefix(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"cutover-step-04-registry-pivot", "registry-pivot"},
+		{"cutover-step-12-foo-bar", "foo-bar"},
+		{"cutover-step-no-number", "no-number"},
+		{"unrelated-name", "unrelated-name"},
+	}
+	for _, tc := range cases {
+		if got := stripCutoverStepPrefix(tc.in); got != tc.want {
+			t.Errorf("stripCutoverStepPrefix(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+// TestBuildCutoverStatusResponse_PromotesKeys proves the typed
+// response builder recovers all the well-known keys.
+func TestBuildCutoverStatusResponse_PromotesKeys(t *testing.T) {
+	status := map[string]string{
+		"cutoverComplete":   "true",
+		"cutoverStartedAt":  "2026-05-04T10:00:00Z",
+		"cutoverFinishedAt": "2026-05-04T10:30:00Z",
+		"totalSteps":        "8",
+		"progressPercent":   "100",
+	}
+	resp := buildCutoverStatusResponseFromMap(status, []string{"x"})
+	if !resp.CutoverComplete {
+		t.Errorf("CutoverComplete = false, want true")
+	}
+	if resp.TotalSteps != 8 {
+		t.Errorf("TotalSteps = %d, want 8", resp.TotalSteps)
+	}
+	if resp.ProgressPercent != 100 {
+		t.Errorf("ProgressPercent = %d, want 100", resp.ProgressPercent)
+	}
+	if resp.CutoverStartedAt != "2026-05-04T10:00:00Z" {
+		t.Errorf("CutoverStartedAt = %q, want %q", resp.CutoverStartedAt, "2026-05-04T10:00:00Z")
+	}
+	if len(resp.Steps) != 1 || resp.Steps[0].Name != "x" {
+		t.Errorf("Steps = %+v, want one step named x", resp.Steps)
+	}
+}
+
+// ── test helpers ────────────────────────────────────────────────────────────
+
+// flushableRecorder wraps httptest.ResponseRecorder with an http.Flusher
+// implementation so the SSE handler's flusher.Flush() calls don't 500.
+type flushableRecorder struct {
+	*httptest.ResponseRecorder
+	mu  []byte
+	buf *bytes.Buffer
+}
+
+func newFlushableRecorder() *flushableRecorder {
+	rec := httptest.NewRecorder()
+	return &flushableRecorder{
+		ResponseRecorder: rec,
+		buf:              new(bytes.Buffer),
+	}
+}
+
+func (r *flushableRecorder) Write(p []byte) (int, error) {
+	n, err := r.ResponseRecorder.Write(p)
+	r.buf.Write(p)
+	return n, err
+}
+
+func (r *flushableRecorder) WriteString(s string) (int, error) {
+	return r.Write([]byte(s))
+}
+
+func (r *flushableRecorder) Flush() {
+	// httptest.ResponseRecorder doesn't implement Flusher pre-Go 1.21;
+	// nothing to do — Body() returns whatever has been written so far.
+}
+
+func (r *flushableRecorder) Body() []byte {
+	return r.buf.Bytes()
+}
+
+// scanForSSEEvent returns the data lines for a named SSE event.
+// Helper utility for tests that want to assert payload shape rather
+// than substring matches.
+func scanForSSEEvent(body []byte, eventName string) []string {
+	var out []string
+	scanner := bufio.NewScanner(bytes.NewReader(body))
+	inEvent := false
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.HasPrefix(line, "event: ") {
+			inEvent = strings.TrimPrefix(line, "event: ") == eventName
+			continue
+		}
+		if inEvent && strings.HasPrefix(line, "data: ") {
+			out = append(out, strings.TrimPrefix(line, "data: "))
+			inEvent = false
+		}
+	}
+	return out
+}
+
+// Suppress unused warnings on test-only helpers.
+var _ = scanForSSEEvent

--- a/products/catalyst/bootstrap/api/internal/handler/handler.go
+++ b/products/catalyst/bootstrap/api/internal/handler/handler.go
@@ -193,6 +193,17 @@ type Handler struct {
 	// PINs are credentials and per docs/INVIOLABLE-PRINCIPLES.md #10 are
 	// NEVER persisted to disk — a Pod restart invalidates every code.
 	pinStore *pinStore
+
+	// ── Self-Sovereignty Cutover (issue #792) ───────────────────────────────
+	// cutoverBus — in-process broadcaster that fans cutover state-change
+	// events to every active SSE subscriber. Lazy-wired in cutoverBusFor();
+	// tests inject a deterministic instance via SetCutoverBroadcaster.
+	cutoverBus     *cutoverBroadcaster
+	cutoverBusOnce sync.Once
+	// cutoverDepsFactory — test-only override that builds the in-cluster
+	// kubernetes.Interface + namespace pair the cutover engine reads
+	// from. Production leaves this nil and cutoverDepsFromEnv runs.
+	cutoverDepsFactory CutoverDepsFactory
 }
 
 // defaultDeploymentsDir is the on-PVC path the chart mounts. A separate


### PR DESCRIPTION
## Summary

Implements POST /sovereign/cutover/start + GET /status + GET /events (SSE) for the post-handover Self-Sovereignty Cutover.

- Operator-admin gated via existing RequireSession middleware
- Consumes PodSpec ConfigMaps installed by sister chart bp-self-sovereign-cutover (#791)
- Sequences 8 steps (gitea-mirror through egress-block-test) — creates a real batchv1.Job per step; special-cases registry-pivot DaemonSet wait
- Idempotent — `cutoverComplete=true` short-circuits POST /start
- Fail-halt — failed step latches engine; operator inspects /status and re-runs after chart fix; succeeded steps are skipped on resume
- Patches `self-sovereign-cutover-status` ConfigMap on every transition
- SSE event channel with replay-on-connect ring buffer

## Constraints honoured

- IaC-first: zero bespoke cloud-API calls; all mutations via in-cluster kubernetes.Interface
- Event-driven: Job completion uses Watch verb, not GET polling
- Credential hygiene: handler reads no secrets; chart PodSpecs reference secrets via envFrom secretRef
- Runtime-configurable: namespace, status CM name, per-step timeouts via env

## Files

- `products/catalyst/bootstrap/api/internal/handler/cutover.go` (new, ~870 lines)
- `products/catalyst/bootstrap/api/internal/handler/cutover_test.go` (new, 14 tests)
- `products/catalyst/bootstrap/api/internal/handler/handler.go` (cutover broadcaster + deps factory fields on Handler)
- `products/catalyst/bootstrap/api/cmd/api/main.go` (route wiring under RequireSession group)

## Test plan

- [x] go build ./... clean
- [x] go vet ./... clean
- [x] All 14 new cutover unit tests pass (gofmt clean):
  - parse step (valid, daemonset-wait derive, missing podSpec, unknown mode, missing order label)
  - listCutoverSteps orders by cutover-order label
  - HandleCutoverStart end-to-end success across job + daemonset-wait modes (final cutoverComplete=true)
  - HandleCutoverStart idempotent when complete (zero new Job creates)
  - HandleCutoverStart fail-halt at first failed Job (subsequent step never starts)
  - HandleCutoverStart returns 424 when no step ConfigMaps installed
  - HandleCutoverStatus typed JSON snapshot promotes well-known keys
  - HandleCutoverEvents SSE replay-on-connect + live tail + auto-close on terminal phase
- [x] Pre-existing handler test failures (TestAuthHandover_HappyPath nil-Signer panic, provisioner CATALYST_HARBOR_ROBOT_TOKEN tests) verified present on `main` — unrelated to this PR

Refs #790 (parent epic), #791 (sister chart)
Closes #792

🤖 Generated with [Claude Code](https://claude.com/claude-code)