### PR TITLE
feat(self-sovereign-cutover): bp-self-sovereign-cutover chart + bootstrap-kit slot 06a (#791)

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -1,0 +1,98 @@
+# bp-self-sovereign-cutover — Catalyst bootstrap-kit Blueprint, slot 06a.
+#
+# Post-handover Self-Sovereignty Cutover. Installs DORMANT — see chart
+# README + ADR-0002. Eight step PodSpec ConfigMaps + the registry-pivot
+# DaemonSet land on the new Sovereign at HelmRelease apply time; the
+# catalyst-api cutover endpoint (issue #792) reads them by label
+# selector and stamps Jobs only on operator action.
+#
+# Slot 06a sits between the existing post-handover slots in the
+# bootstrap-kit ordering. It depends on bp-gitea + bp-harbor so the
+# step ConfigMaps reference real, healthy local Gitea + Harbor
+# Services at trigger time.
+#
+# Wrapper chart: platform/self-sovereign-cutover/chart/
+# Reconciled by: Flux on the new Sovereign's k3s control plane.
+#
+# Why disableWait: true
+#   The chart is dormant — no Job is created at install time. The only
+#   workload that actually runs is the registry-pivot DaemonSet, which
+#   never converges on its own (it waits for the cutover-status
+#   ConfigMap to flip registriesYamlActive=v2). disableWait: true makes
+#   Helm exit when the manifests apply rather than waiting on a Ready
+#   condition that never fires.
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: catalyst
+  labels:
+    catalyst.openova.io/sovereign: ${SOVEREIGN_FQDN}
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: bp-self-sovereign-cutover
+  namespace: flux-system
+spec:
+  type: oci
+  interval: 15m
+  # Pre-cutover (Phase-1) — sources from openova-io GHCR, identical to
+  # every other bootstrap-kit slot. The cutover itself (step 06,
+  # helmrepository-patches) is what flips this URL to the local Harbor
+  # post-handover; until then this Sovereign is soft-tethered like the
+  # rest of the kit.
+  url: oci://ghcr.io/openova-io
+  secretRef:
+    name: ghcr-pull
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: bp-self-sovereign-cutover
+  namespace: flux-system
+spec:
+  interval: 15m
+  releaseName: self-sovereign-cutover
+  # targetNamespace = catalyst because the catalyst-api cutover endpoint
+  # defaults its discovery namespace to "catalyst"
+  # (CATALYST_CUTOVER_NAMESPACE in
+  # products/catalyst/bootstrap/api/internal/handler/cutover.go). Keeping
+  # the chart resources colocated with catalyst-api avoids a cross-
+  # namespace selector + a CATALYST_CUTOVER_NAMESPACE env override on
+  # every Sovereign.
+  targetNamespace: catalyst
+  dependsOn:
+    # Both bp-gitea and bp-harbor must be Ready before the chart's
+    # PodSpec ConfigMaps reference real Services. The chart itself is
+    # dormant so an early apply is benign — but operator workflow
+    # ordering puts cutover after these two come up.
+    - name: bp-gitea
+    - name: bp-harbor
+  chart:
+    spec:
+      chart: bp-self-sovereign-cutover
+      version: 0.1.0
+      sourceRef:
+        kind: HelmRepository
+        name: bp-self-sovereign-cutover
+        namespace: flux-system
+  install:
+    disableWait: true
+    remediation:
+      retries: 3
+  upgrade:
+    disableWait: true
+    remediation:
+      retries: 3
+  # Per-Sovereign overrides — the chart's values.yaml carries
+  # placeholders so smoke renders pass; the real coordinates land
+  # here via Flux postBuild ${SOVEREIGN_FQDN} substitution.
+  values:
+    sovereign:
+      fqdn: ${SOVEREIGN_FQDN}
+      harborInternalURL: http://harbor-harbor-core.harbor.svc.cluster.local
+      harborPublicURL: https://harbor.${SOVEREIGN_FQDN}
+      giteaInternalURL: http://gitea-http.gitea.svc.cluster.local:3000
+      giteaPublicURL: https://gitea.${SOVEREIGN_FQDN}

--- a/clusters/_template/bootstrap-kit/kustomization.yaml
+++ b/clusters/_template/bootstrap-kit/kustomization.yaml
@@ -26,6 +26,12 @@ resources:
   - 17-valkey.yaml
   - 18-seaweedfs.yaml
   - 19-harbor.yaml
+  # 06a — Post-handover Self-Sovereignty Cutover (issue #791). Filename
+  # carries the 06a prefix to colocate cohorts visually, but the slot's
+  # dependsOn pins actual install order to AFTER bp-gitea (slot 10) and
+  # bp-harbor (slot 19). Chart installs DORMANT — catalyst-api stamps
+  # Jobs only on operator-driven cutover trigger.
+  - 06a-bp-self-sovereign-cutover.yaml
   - 20-opentelemetry.yaml
   - 21-alloy.yaml
   - 22-loki.yaml

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -1,0 +1,27 @@
+apiVersion: catalyst.openova.io/v1alpha1
+kind: Blueprint
+metadata:
+  name: bp-self-sovereign-cutover
+  labels:
+    catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
+spec:
+  version: 0.1.0
+  card:
+    title: self-sovereignty-cutover
+    summary: |
+      Post-handover Self-Sovereignty Cutover. After bp-gitea + bp-harbor
+      reach Ready, this Blueprint installs DORMANT on the new Sovereign.
+      The catalyst-api cutover endpoint (#792) stamps Jobs from the
+      eight PodSpec ConfigMaps shipped here and pivots EVERY upstream
+      reference (GitOps source, OCI HelmRepositories, container-registry
+      mirrors, catalyst-api repo env) to the local Sovereign — eliminating
+      runtime dependencies on github.com / ghcr.io / harbor.openova.io.
+      Trigger is operator-driven (admin-console button) or auto-fired
+      after the first successful operator login on the new Sovereign.
+      See ADR-0002 + issue #790 for the full tether map.
+  visibility: unlisted              # mandatory infra, auto-installed by bootstrap kit
+  manifests:
+    chart: ./chart
+  depends:
+    - bp-gitea
+    - bp-harbor

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -1,0 +1,70 @@
+apiVersion: v2
+name: bp-self-sovereign-cutover
+version: 0.1.0
+description: |
+  Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
+  chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),
+  the registry-pivot DaemonSet, the mutable cutover-status ConfigMap,
+  plus ServiceAccount/RBAC scoped to the cutover work. NO Helm
+  post-install hooks fire any of the steps; the catalyst-api cutover
+  endpoint (issue #792) reads each step ConfigMap by label selector,
+  stamps a real batch/v1 Job from the embedded PodSpec, and updates
+  the status ConfigMap as each step completes.
+
+  Trigger semantics (post-handover, per #790 scope-correction comment):
+  the operator clicks "Achieve True Sovereignty" in admin console (or
+  catalyst-api auto-fires after first successful operator login on the
+  new Sovereign). The handed-over Sovereign starts soft-tethered to
+  harbor.openova.io for image-pull rate-limit safety, then becomes
+  hard-independent only after this cutover sequence completes.
+
+  Step inventory (label app.kubernetes.io/component=cutover-step):
+    01  cutover-step-01-gitea-mirror               mode=job
+        git push --mirror github.com/openova-io/openova into local Gitea.
+    02  cutover-step-02-harbor-projects            mode=job
+        Create 7 proxy-cache projects in local Harbor.
+    03  cutover-step-03-harbor-prewarm             mode=job
+        HEAD-pull every image referenced by the bootstrap-kit through
+        the proxy-cache.
+    04  cutover-step-04-registry-pivot             mode=daemonset-wait
+        DaemonSet runs on every node + writes /etc/rancher/k3s/registries.yaml
+        v2 once the status ConfigMap key registriesYamlActive flips to v2.
+    05  cutover-step-05-flux-gitrepository-patch   mode=job
+        Patch flux-system/openova GitRepository.url → local Gitea.
+    06  cutover-step-06-helmrepository-patches     mode=job
+        Patch every OCI HelmRepository → oci://harbor.<sov-fqdn>/openova-io.
+    07  cutover-step-07-catalyst-api-env-patch     mode=job
+        kubectl set env deploy/catalyst-api CATALYST_GITOPS_REPO_URL=...
+    08  cutover-step-08-egress-block-test          mode=job
+        Apply CiliumNetworkPolicy denying egress to github.com / ghcr.io
+        / harbor.openova.io for 10 min, assert all reconciles stay Ready.
+
+  Plus:
+    self-sovereign-cutover-status                  ConfigMap
+        Initial state machine state (cutoverComplete: "false" + per-step
+        empty fields). catalyst-api updates this ConfigMap as each step
+        advances.
+    registry-pivot                                 DaemonSet
+        Always-on per-node reconcile loop; idempotent.
+    bp-self-sovereign-cutover-runner               ServiceAccount + ClusterRole +
+                                                   ClusterRoleBinding for the
+                                                   stamped Jobs and the DaemonSet.
+
+  This Blueprint legitimately ships NO upstream subchart — the entire
+  payload is Catalyst-authored ConfigMaps, ServiceAccount, RBAC, and one
+  DaemonSet. The blueprint-release CI hollow-chart guard reads the
+  annotation below and skips the dependencies-required rule.
+type: application
+keywords:
+  - catalyst
+  - blueprint
+  - self-sovereignty
+  - cutover
+  - gitea
+  - harbor
+maintainers:
+  - name: OpenOva Catalyst
+    email: catalyst@openova.io
+
+annotations:
+  catalyst.openova.io/no-upstream: "true"

--- a/platform/self-sovereign-cutover/chart/README.md
+++ b/platform/self-sovereign-cutover/chart/README.md
@@ -1,0 +1,101 @@
+# bp-self-sovereign-cutover
+
+Catalyst Self-Sovereignty Cutover Blueprint. Pivots a freshly handed-over
+Sovereign from soft-tether (mothership Harbor + GitHub upstream Git source)
+to hard-independent (local Sovereign Harbor + Sovereign Gitea).
+
+## Trigger semantics — DORMANT install
+
+This chart installs **dormant**. There are NO Helm post-install hooks. Every
+step is shipped as a `ConfigMap cutover-step-NN-<name>` carrying a PodSpec
+under key `podspec.yaml`. The `catalyst-api` cutover endpoint (filed
+separately under epic [#790](https://github.com/openova-io/openova/issues/790))
+reads each step ConfigMap, stamps a real `batch/v1.Job` from the embedded
+PodSpec, and updates the `self-sovereign-cutover-status` ConfigMap as each
+step completes.
+
+Per the parent-epic scope-correction comment, the cutover trigger is
+**post-handover**, not Phase-1.5:
+
+- The operator clicks **"Achieve True Sovereignty"** in the admin console, OR
+- `catalyst-api` auto-fires after the first successful operator login on
+  the new Sovereign (configurable via `.Values.trigger.auto`, default
+  `false`).
+
+A handed-over Sovereign therefore starts soft-tethered (still pulling
+through `harbor.openova.io`) and becomes hard-independent only after the
+operator chooses or after the auto-fire grace period.
+
+## Step inventory
+
+| # | Resource | Phase | Description |
+|---|---|---|---|
+| 01 | `cutover-step-01-gitea-mirror` ConfigMap | pre-pivot | `git clone --mirror` upstream → `git push --mirror` to local Gitea |
+| 02 | `cutover-step-02-harbor-projects` ConfigMap | pre-pivot | Create 7 proxy_cache projects in local Harbor |
+| 03 | `cutover-step-03-harbor-prewarm` ConfigMap | pre-pivot | HEAD-pull every image referenced by bootstrap-kit through proxy-cache |
+| 04 | `registry-pivot` DaemonSet | pre-pivot | Always-on per-node reconcile loop for `/etc/rancher/k3s/registries.yaml` (v1 ↔ v2) |
+| 05 | `cutover-step-05-flux-gitrepository-patch` ConfigMap | post-pivot | Patch `flux-system/openova` GitRepository.url → local Gitea |
+| 06 | `cutover-step-06-helmrepository-patches` ConfigMap | post-pivot | Patch every OCI HelmRepository → `oci://harbor.<sov-fqdn>/openova-io` |
+| 07 | `cutover-step-07-catalyst-api-env-patch` ConfigMap | post-pivot | `kubectl set env deploy/catalyst-api CATALYST_GITOPS_REPO_URL=...` |
+| 08 | `cutover-step-08-egress-block-test` ConfigMap | post-pivot | CiliumNetworkPolicy denies egress to upstream for 10 min, asserts cluster stays Ready |
+| 09 | `self-sovereign-cutover-status` ConfigMap | mutable state | Per-step state machine read+written by every step + the UI |
+
+The phase column controls image routing: `pre`-phase steps must use
+upstream-public images because they run BEFORE registries.yaml v2 takes
+effect on the node containerd. `post`-phase steps may pull through local
+Harbor when `.Values.global.imageRegistry` is set in the overlay.
+
+## Values
+
+See [`values.yaml`](./values.yaml). The required overlay-supplied keys are:
+
+| Key | Purpose |
+|---|---|
+| `sovereign.fqdn` | The Sovereign's base FQDN (e.g. `otech.omani.works`). Drives every public URL in this chart. |
+| `sovereign.harborPublicURL` | `https://harbor.<sovereign.fqdn>`. Routed to by registries.yaml v2 + step 06. |
+| `sovereign.giteaPublicURL` | `https://gitea.<sovereign.fqdn>`. Informational; jobs reach Gitea via the in-cluster Service URL. |
+
+Per `docs/INVIOLABLE-PRINCIPLES.md` #4 (never hardcode), the chart ships
+no real defaults for the Sovereign coordinates — `helm template` smoke
+renders against `example.local` placeholders, and runtime use without an
+overlay is non-functional by design.
+
+## Bootstrap-kit slot
+
+The HelmRelease that installs this chart is at
+`clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml`.
+It depends on `bp-gitea` and `bp-harbor` (so the local Gitea + Harbor
+exist before the chart's step ConfigMaps reference them at trigger time)
+and uses `disableWait: true` because the chart is dormant (no Pods to
+wait on except the registry-pivot DaemonSet, which is event-driven on
+the status ConfigMap).
+
+## RBAC discipline
+
+The runner ServiceAccount + ClusterRole + ClusterRoleBinding live at
+`templates/serviceaccount.yaml` + `templates/rbac.yaml`. Per
+`feedback_rbac_create_no_resourcenames.md` (auto-memory anchor), `create`
+verbs are split into a separate Rule **without** `resourceNames` —
+combining them produces a 403 every POST. Update verbs (`patch`,
+`update`, `delete`) live in their own Rule alongside `resourceNames`
+where appropriate.
+
+## Smoke test
+
+```bash
+helm dependency build platform/self-sovereign-cutover/chart   # no-op (no upstream subchart)
+helm template smoke platform/self-sovereign-cutover/chart \
+  --set sovereign.fqdn=otechN.omani.works \
+  --set sovereign.harborPublicURL=https://harbor.otechN.omani.works \
+  --set sovereign.giteaPublicURL=https://gitea.otechN.omani.works
+```
+
+CI (`blueprint-release.yaml`) runs the same smoke render with default
+values and uploads the rendered output as a workflow artifact.
+
+## References
+
+- Issue: [#791](https://github.com/openova-io/openova/issues/791) — chart implementation
+- Parent epic: [#790](https://github.com/openova-io/openova/issues/790) — Sovereign sovereignty cutover
+- Inviolable Principles: `docs/INVIOLABLE-PRINCIPLES.md` (#3 IaC-first, #4 never hardcode, §10 credential hygiene)
+- RBAC anchor: auto-memory `feedback_rbac_create_no_resourcenames.md`

--- a/platform/self-sovereign-cutover/chart/templates/01-gitea-mirror-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/01-gitea-mirror-job.yaml
@@ -1,0 +1,114 @@
+{{- /*
+Step 01 — gitea-mirror.
+
+Mirrors the upstream openova-io public repo into the local Sovereign
+Gitea so subsequent Flux GitRepository pivots resolve against in-cluster
+DNS. This step is the canonical seam: catalyst-api stamps a Job from
+this PodSpec exactly once per cutover.
+
+Consumer contract (catalyst-api cutover endpoint, issue #792):
+  - Discovered by labels app.kubernetes.io/part-of=self-sovereign-cutover
+    + app.kubernetes.io/component=cutover-step.
+  - Order = bp.openova.io/cutover-order label (integer, ascending).
+  - Mode = bp.openova.io/cutover-mode label ("job" here).
+  - Required data keys:
+      stepName  short slug used in status ConfigMap + Job naming
+      podSpec   YAML of corev1.PodSpec; catalyst-api wraps it in
+                PodTemplateSpec + batchv1.Job.
+
+Image phase: pre — runs BEFORE registries.yaml v2 is active.
+*/ -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cutover-step-01-gitea-mirror
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "bp-self-sovereign-cutover.labels" . | nindent 4 }}
+    app.kubernetes.io/component: cutover-step
+    bp.openova.io/cutover-order: "1"
+    bp.openova.io/cutover-mode: "job"
+data:
+  stepName: gitea-mirror
+  podSpec: |
+    serviceAccountName: {{ include "bp-self-sovereign-cutover.serviceAccountName" . }}
+    restartPolicy: Never
+    activeDeadlineSeconds: {{ .Values.stepTimeouts.giteaMirrorSeconds }}
+    containers:
+      - name: gitea-mirror
+        image: {{ include "bp-self-sovereign-cutover.image" (dict "repository" .Values.images.git.repository "tag" .Values.images.git.tag "cutoverPhase" "pre" "Values" .Values) }}
+        imagePullPolicy: IfNotPresent
+        env:
+          - name: UPSTREAM_REPO_URL
+            value: {{ .Values.upstream.repoURL | quote }}
+          - name: UPSTREAM_BRANCH
+            value: {{ .Values.upstream.branch | quote }}
+          - name: GITEA_INTERNAL_URL
+            value: {{ .Values.sovereign.giteaInternalURL | quote }}
+          - name: GITEA_ORG
+            value: {{ .Values.gitea.org | quote }}
+          - name: GITEA_REPO
+            value: {{ .Values.gitea.repo | quote }}
+          - name: GITEA_USERNAME
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.gitea.adminSecretRef.name }}
+                key: {{ .Values.gitea.adminSecretRef.usernameKey }}
+          - name: GITEA_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.gitea.adminSecretRef.name }}
+                key: {{ .Values.gitea.adminSecretRef.passwordKey }}
+        command: ["/bin/sh", "-c"]
+        args:
+          - |
+            set -eu
+            # Credential hygiene: never echo $GITEA_PASSWORD. We feed it
+            # to git via URL embedding only inside the redirected http
+            # call below; stdout shows just the redacted form.
+            redacted_url="${GITEA_INTERNAL_URL}/${GITEA_ORG}/${GITEA_REPO}.git"
+            echo "[gitea-mirror] upstream=${UPSTREAM_REPO_URL} branch=${UPSTREAM_BRANCH}"
+            echo "[gitea-mirror] target=${redacted_url}"
+
+            # 1. Ensure the repo exists in the local Gitea (idempotent).
+            #    Gitea returns 201 on create / 409 on exists — both OK.
+            api_url="${GITEA_INTERNAL_URL}/api/v1"
+            repo_check=$(wget -q -O - --header="Content-Type: application/json" \
+              --user="${GITEA_USERNAME}" --password="${GITEA_PASSWORD}" \
+              "${api_url}/repos/${GITEA_ORG}/${GITEA_REPO}" 2>/dev/null || echo "missing")
+            if [ "${repo_check}" = "missing" ]; then
+              echo "[gitea-mirror] creating ${GITEA_ORG}/${GITEA_REPO}"
+              wget -q -O /dev/null --post-data="{\"name\":\"${GITEA_REPO}\",\"private\":false,\"auto_init\":false}" \
+                --header="Content-Type: application/json" \
+                --user="${GITEA_USERNAME}" --password="${GITEA_PASSWORD}" \
+                "${api_url}/orgs/${GITEA_ORG}/repos" || \
+                wget -q -O /dev/null --post-data="{\"name\":\"${GITEA_REPO}\",\"private\":false,\"auto_init\":false}" \
+                  --header="Content-Type: application/json" \
+                  --user="${GITEA_USERNAME}" --password="${GITEA_PASSWORD}" \
+                  "${api_url}/user/repos"
+            else
+              echo "[gitea-mirror] repo already present"
+            fi
+
+            # 2. Mirror clone from upstream and push --mirror to local Gitea.
+            #    --mirror preserves all refs, branches, tags, notes; matches
+            #    the desired "lift the upstream wholesale into local" shape.
+            workdir=$(mktemp -d)
+            cd "${workdir}"
+            git clone --mirror "${UPSTREAM_REPO_URL}" upstream.git
+            cd upstream.git
+            # Embed credentials in the push URL only (never in stdout).
+            push_url=$(printf '%s' "${GITEA_INTERNAL_URL}" | sed -e "s,://,://${GITEA_USERNAME}:${GITEA_PASSWORD}@,")
+            git remote set-url --push origin "${push_url}/${GITEA_ORG}/${GITEA_REPO}.git"
+            git push --mirror
+            echo "[gitea-mirror] mirror complete"
+        resources:
+          requests: { cpu: 100m, memory: 256Mi }
+          limits:   { memory: 1Gi }
+        securityContext:
+          runAsNonRoot: true
+          runAsUser: 1000
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: false
+          capabilities:
+            drop: ["ALL"]

--- a/platform/self-sovereign-cutover/chart/templates/02-harbor-projects-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/02-harbor-projects-job.yaml
@@ -1,0 +1,136 @@
+{{- /*
+Step 02 — harbor-projects.
+
+Creates seven proxy_cache projects in the local Sovereign Harbor.
+Names are stable: registry-pivot DaemonSet (step 04) and step 06
+(helmrepository-patches) rewrite paths against these literal project
+names.
+
+Image phase: pre.
+*/ -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cutover-step-02-harbor-projects
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "bp-self-sovereign-cutover.labels" . | nindent 4 }}
+    app.kubernetes.io/component: cutover-step
+    bp.openova.io/cutover-order: "2"
+    bp.openova.io/cutover-mode: "job"
+data:
+  stepName: harbor-projects
+  proxyProjects.json: |
+    {{ .Values.harbor.proxyProjects | toJson }}
+  podSpec: |
+    serviceAccountName: {{ include "bp-self-sovereign-cutover.serviceAccountName" . }}
+    restartPolicy: Never
+    activeDeadlineSeconds: {{ .Values.stepTimeouts.harborProjectsSeconds }}
+    containers:
+      - name: harbor-projects
+        image: {{ include "bp-self-sovereign-cutover.image" (dict "repository" .Values.images.curl.repository "tag" .Values.images.curl.tag "cutoverPhase" "pre" "Values" .Values) }}
+        imagePullPolicy: IfNotPresent
+        env:
+          - name: HARBOR_INTERNAL_URL
+            value: {{ .Values.sovereign.harborInternalURL | quote }}
+          - name: HARBOR_USERNAME
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.harbor.adminSecretRef.name }}
+                key: {{ .Values.harbor.adminSecretRef.usernameKey }}
+                optional: true
+          - name: HARBOR_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.harbor.adminSecretRef.name }}
+                key: {{ .Values.harbor.adminSecretRef.passwordKey }}
+          - name: GHCR_DOCKERCONFIG
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.harbor.ghcrSecretRef.name }}
+                key: {{ .Values.harbor.ghcrSecretRef.dockerConfigKey }}
+        volumeMounts:
+          - name: proxy-projects
+            mountPath: /work
+            readOnly: true
+        command: ["/bin/sh", "-c"]
+        args:
+          - |
+            set -eu
+            : "${HARBOR_USERNAME:=admin}"
+            base="${HARBOR_INTERNAL_URL}/api/v2.0"
+
+            # 1. Decode GHCR creds (used by proxy-ghcr registry, authMode=credential).
+            if [ -n "${GHCR_DOCKERCONFIG:-}" ]; then
+              dc_decoded=$(printf '%s' "${GHCR_DOCKERCONFIG}" | base64 -d 2>/dev/null || printf '%s' "${GHCR_DOCKERCONFIG}")
+              auth_b64=$(printf '%s' "${dc_decoded}" | tr -d ' \n\r\t' | awk -F'"auth":"' '{print $2}' | awk -F'"' '{print $1}')
+              ghcr_user=$(printf '%s' "${auth_b64}" | base64 -d | awk -F: '{print $1}')
+              ghcr_pass=$(printf '%s' "${auth_b64}" | base64 -d | awk -F: '{print $2}')
+            else
+              ghcr_user=""
+              ghcr_pass=""
+            fi
+
+            # 2. Iterate the proxy-projects spec from the mounted ConfigMap.
+            proj_file=/work/proxyProjects.json
+            entries=$(awk 'BEGIN{RS="{"; FS="\""} /name/{name=""; up=""; rt=""; am="";
+              for(i=1;i<=NF;i++){
+                if($i=="name"){ name=$(i+2) }
+                if($i=="upstreamURL"){ up=$(i+2) }
+                if($i=="registryType"){ rt=$(i+2) }
+                if($i=="authMode"){ am=$(i+2) }
+              }
+              if(name!=""){print name"|"up"|"rt"|"am}
+            }' "${proj_file}")
+
+            echo "${entries}" | while IFS='|' read -r name upstream rtype amode; do
+              [ -z "${name}" ] && continue
+              echo "[harbor-projects] ensuring proxy-cache project ${name} → ${upstream} (${rtype}, ${amode})"
+
+              reg_payload="{\"name\":\"${name}-upstream\",\"type\":\"${rtype}\",\"url\":\"${upstream}\""
+              if [ "${amode}" = "credential" ] && [ -n "${ghcr_user}" ]; then
+                reg_payload="${reg_payload},\"credential\":{\"type\":\"basic\",\"access_key\":\"${ghcr_user}\",\"access_secret\":\"${ghcr_pass}\"}"
+              fi
+              reg_payload="${reg_payload}}"
+              code=$(curl -s -o /tmp/reg.out -w "%{http_code}" -u "${HARBOR_USERNAME}:${HARBOR_PASSWORD}" -X POST \
+                -H "Content-Type: application/json" \
+                "${base}/registries" --data "${reg_payload}")
+              case "${code}" in
+                201|409) echo "[harbor-projects]   registry ${name}-upstream OK (${code})" ;;
+                *)       echo "[harbor-projects]   registry ${name}-upstream FAILED (${code})"; cat /tmp/reg.out; exit 1 ;;
+              esac
+
+              reg_id=$(curl -s -u "${HARBOR_USERNAME}:${HARBOR_PASSWORD}" "${base}/registries?name=${name}-upstream" | tr ',' '\n' | grep -o '"id":[0-9]*' | head -1 | awk -F: '{print $2}')
+              if [ -z "${reg_id}" ]; then
+                echo "[harbor-projects]   could not resolve registry id for ${name}-upstream"
+                exit 1
+              fi
+
+              proj_payload="{\"project_name\":\"${name}\",\"public\":true,\"registry_id\":${reg_id},\"metadata\":{\"public\":\"true\"}}"
+              code=$(curl -s -o /tmp/proj.out -w "%{http_code}" -u "${HARBOR_USERNAME}:${HARBOR_PASSWORD}" -X POST \
+                -H "Content-Type: application/json" \
+                "${base}/projects" --data "${proj_payload}")
+              case "${code}" in
+                201|409) echo "[harbor-projects]   project ${name} OK (${code})" ;;
+                *)       echo "[harbor-projects]   project ${name} FAILED (${code})"; cat /tmp/proj.out; exit 1 ;;
+              esac
+            done
+
+            echo "[harbor-projects] all proxy-cache projects ensured"
+        resources:
+          requests: { cpu: 100m, memory: 128Mi }
+          limits:   { memory: 512Mi }
+        securityContext:
+          runAsNonRoot: true
+          runAsUser: 1000
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: false
+          capabilities:
+            drop: ["ALL"]
+    volumes:
+      - name: proxy-projects
+        configMap:
+          name: cutover-step-02-harbor-projects
+          items:
+            - key: proxyProjects.json
+              path: proxyProjects.json

--- a/platform/self-sovereign-cutover/chart/templates/03-harbor-prewarm-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/03-harbor-prewarm-job.yaml
@@ -1,0 +1,96 @@
+{{- /*
+Step 03 — harbor-prewarm.
+
+For each image in .Values.prewarm.images, issues a HEAD against the
+local Harbor proxy-cache so the upstream image lands in the cache
+BEFORE the cluster's first reconcile reaches for it.
+
+Image phase: pre.
+*/ -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cutover-step-03-harbor-prewarm
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "bp-self-sovereign-cutover.labels" . | nindent 4 }}
+    app.kubernetes.io/component: cutover-step
+    bp.openova.io/cutover-order: "3"
+    bp.openova.io/cutover-mode: "job"
+data:
+  stepName: harbor-prewarm
+  prewarm.list: |
+    {{- range .Values.prewarm.images }}
+    {{ . }}
+    {{- end }}
+  podSpec: |
+    serviceAccountName: {{ include "bp-self-sovereign-cutover.serviceAccountName" . }}
+    restartPolicy: Never
+    activeDeadlineSeconds: {{ .Values.stepTimeouts.harborPrewarmSeconds }}
+    containers:
+      - name: harbor-prewarm
+        image: {{ include "bp-self-sovereign-cutover.image" (dict "repository" .Values.images.curl.repository "tag" .Values.images.curl.tag "cutoverPhase" "pre" "Values" .Values) }}
+        imagePullPolicy: IfNotPresent
+        env:
+          - name: HARBOR_INTERNAL_URL
+            value: {{ .Values.sovereign.harborInternalURL | quote }}
+          - name: HARBOR_USERNAME
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.harbor.adminSecretRef.name }}
+                key: {{ .Values.harbor.adminSecretRef.usernameKey }}
+                optional: true
+          - name: HARBOR_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.harbor.adminSecretRef.name }}
+                key: {{ .Values.harbor.adminSecretRef.passwordKey }}
+        volumeMounts:
+          - name: prewarm
+            mountPath: /work
+            readOnly: true
+        command: ["/bin/sh", "-c"]
+        args:
+          - |
+            set -eu
+            : "${HARBOR_USERNAME:=admin}"
+            base="${HARBOR_INTERNAL_URL}/v2"
+            ok=0
+            fail=0
+            while IFS= read -r line; do
+              ref=$(printf '%s' "${line}" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+              [ -z "${ref}" ] && continue
+              path=${ref%:*}
+              tag=${ref##*:}
+              code=$(curl -s -o /dev/null -w "%{http_code}" \
+                -u "${HARBOR_USERNAME}:${HARBOR_PASSWORD}" \
+                -H "Accept: application/vnd.oci.image.manifest.v1+json,application/vnd.docker.distribution.manifest.v2+json,application/vnd.docker.distribution.manifest.list.v2+json" \
+                -I "${base}/${path}/manifests/${tag}")
+              case "${code}" in
+                200|301|302) ok=$((ok+1)); echo "[harbor-prewarm] OK ${ref}" ;;
+                *)           fail=$((fail+1)); echo "[harbor-prewarm] MISS ${ref} (${code})" ;;
+              esac
+            done < /work/prewarm.list
+            echo "[harbor-prewarm] primed=${ok} failed=${fail}"
+            total=$((ok+fail))
+            if [ "${total}" -gt 0 ] && [ "${fail}" -gt $((total/4)) ]; then
+              echo "[harbor-prewarm] failure rate exceeds 25% — failing step"
+              exit 1
+            fi
+        resources:
+          requests: { cpu: 100m, memory: 128Mi }
+          limits:   { memory: 512Mi }
+        securityContext:
+          runAsNonRoot: true
+          runAsUser: 1000
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: false
+          capabilities:
+            drop: ["ALL"]
+    volumes:
+      - name: prewarm
+        configMap:
+          name: cutover-step-03-harbor-prewarm
+          items:
+            - key: prewarm.list
+              path: prewarm.list

--- a/platform/self-sovereign-cutover/chart/templates/04-registry-pivot-daemonset.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/04-registry-pivot-daemonset.yaml
@@ -1,0 +1,255 @@
+{{- /*
+Step 04 — registry-pivot.
+
+This step is a DaemonSet, not a Job. The consumer (catalyst-api,
+issue #792) handles this via mode=daemonset-wait: when the cutover
+hits this step, it waits for the DaemonSet's
+`status.numberReady == status.desiredNumberScheduled` and treats that
+as step success. The DaemonSet is shipped HERE by the chart so it is
+already running by the time catalyst-api stamps the wait.
+
+What the DaemonSet actually does
+────────────────────────────────
+A reconcile loop on every node. Reads the `registriesYamlActive` key
+on the cutover-status ConfigMap via the in-cluster K8s API; when it
+sees "v2", atomically replaces /etc/rancher/k3s/registries.yaml with
+the v2 form (rewrites every upstream registry through harbor.<sov-fqdn>).
+"v1" or "rollback" restores the cold-start file (mothership Harbor).
+Idempotent across restarts.
+
+The daemonset-wait completion condition is "all node Pods Ready" — by
+the time every Pod is Running and reporting Ready, the reconcile loop
+has done its first sync. Because the chart ships registriesYamlActive=v1
+in the initial status ConfigMap, the FIRST sync writes v1 (no-op rollover).
+catalyst-api's runCutover sets registriesYamlActive=v2 BEFORE stamping
+step 05 — the next reconcile sweep then converges every node to v2
+within the 15s poll interval (well under the daemonset-wait timeout).
+
+Image phase: pre.
+*/ -}}
+{{- if .Values.registryPivot.enabled }}
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: registry-pivot
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "bp-self-sovereign-cutover.labels" . | nindent 4 }}
+    app.kubernetes.io/component: cutover-daemonset
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/component: cutover-daemonset
+      catalyst.openova.io/blueprint: bp-self-sovereign-cutover
+  template:
+    metadata:
+      labels:
+        {{- include "bp-self-sovereign-cutover.labels" . | nindent 8 }}
+        app.kubernetes.io/component: cutover-daemonset
+    spec:
+      serviceAccountName: {{ include "bp-self-sovereign-cutover.serviceAccountName" . }}
+      hostPID: true
+      tolerations:
+        - operator: Exists
+      containers:
+        - name: pivot
+          image: {{ include "bp-self-sovereign-cutover.image" (dict "repository" .Values.images.hostExec.repository "tag" .Values.images.hostExec.tag "cutoverPhase" "pre" "Values" .Values) }}
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            privileged: true
+            runAsUser: 0
+          env:
+            - name: HARBOR_PUBLIC_URL
+              value: {{ .Values.sovereign.harborPublicURL | quote }}
+            - name: STATUS_CONFIGMAP_NAME
+              value: {{ .Values.status.configMapName | quote }}
+            - name: STATUS_CONFIGMAP_NAMESPACE
+              value: {{ .Release.Namespace | quote }}
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          # readinessProbe: the script touches /tmp/ready after its first
+          # successful reconcile pass. catalyst-api's daemonset-wait
+          # then sees numberReady=desired and proceeds.
+          readinessProbe:
+            exec:
+              command: ["/bin/sh", "-c", "test -f /tmp/ready"]
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          volumeMounts:
+            - name: registries-d
+              mountPath: /host/etc/rancher/k3s
+            - name: pivot-script
+              mountPath: /usr/local/bin/pivot.sh
+              subPath: pivot.sh
+              readOnly: true
+            - name: registries-yaml-tpl
+              mountPath: /etc/registry-pivot/registries.yaml.v2
+              subPath: registries.yaml.v2
+              readOnly: true
+            - name: registries-yaml-tpl
+              mountPath: /etc/registry-pivot/registries.yaml.v1
+              subPath: registries.yaml.v1
+              readOnly: true
+          command: ["/bin/sh", "/usr/local/bin/pivot.sh"]
+          resources:
+            requests: { cpu: 25m, memory: 32Mi }
+            limits:   { memory: 128Mi }
+      volumes:
+        - name: registries-d
+          hostPath:
+            path: /etc/rancher/k3s
+            type: DirectoryOrCreate
+        - name: pivot-script
+          configMap:
+            name: registry-pivot-script
+            defaultMode: 0755
+        - name: registries-yaml-tpl
+          configMap:
+            name: registry-pivot-registries-yaml
+---
+# Step ConfigMap for catalyst-api consumer (mode=daemonset-wait).
+# The handler resolves the DaemonSet name from the `bp.openova.io/cutover-daemonset`
+# label; we set it explicitly so the lookup is stable even if the cm
+# name convention changes.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cutover-step-04-registry-pivot
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "bp-self-sovereign-cutover.labels" . | nindent 4 }}
+    app.kubernetes.io/component: cutover-step
+    bp.openova.io/cutover-order: "4"
+    bp.openova.io/cutover-mode: "daemonset-wait"
+    bp.openova.io/cutover-daemonset: "registry-pivot"
+data:
+  stepName: registry-pivot
+  # podSpec is intentionally absent — mode=daemonset-wait does NOT use it.
+  # Catalyst-api's parser tolerates absent podSpec when mode!=job.
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: registry-pivot-script
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "bp-self-sovereign-cutover.labels" . | nindent 4 }}
+    app.kubernetes.io/component: cutover-daemonset
+data:
+  pivot.sh: |
+    #!/bin/sh
+    # registry-pivot reconcile loop. Reads registriesYamlActive from the
+    # cutover-status ConfigMap; when the value changes, atomically
+    # replaces the host registries.yaml with v1 or v2.
+    set -eu
+
+    apk add --no-cache curl jq >/dev/null 2>&1 || true
+
+    api="https://kubernetes.default.svc"
+    token=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
+    cacert=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+    cm_url="${api}/api/v1/namespaces/${STATUS_CONFIGMAP_NAMESPACE}/configmaps/${STATUS_CONFIGMAP_NAME}"
+
+    target=/host/etc/rancher/k3s/registries.yaml
+    src_v1=/etc/registry-pivot/registries.yaml.v1
+    src_v2=/etc/registry-pivot/registries.yaml.v2
+    last_state=""
+
+    apply_state() {
+      desired="$1"
+      case "${desired}" in
+        v2)
+          harbor_host=$(printf '%s' "${HARBOR_PUBLIC_URL}" | sed -E 's,^https?://,,; s,/$,,')
+          sed -e "s,__HARBOR_PUBLIC_URL__,${harbor_host},g" "${src_v2}" > "${target}.new"
+          mv "${target}.new" "${target}"
+          chmod 600 "${target}"
+          echo "[registry-pivot]   wrote v2 to ${target} on ${NODE_NAME}"
+          ;;
+        v1|rollback|*)
+          cp "${src_v1}" "${target}.new"
+          mv "${target}.new" "${target}"
+          chmod 600 "${target}"
+          echo "[registry-pivot]   wrote v1 to ${target} on ${NODE_NAME}"
+          ;;
+      esac
+    }
+
+    while true; do
+      desired=$(curl -fsS --cacert "${cacert}" -H "Authorization: Bearer ${token}" "${cm_url}" 2>/dev/null \
+        | jq -r '.data.registriesYamlActive // "v1"' 2>/dev/null \
+        || echo "v1")
+      desired=${desired:-v1}
+
+      if [ "${desired}" != "${last_state}" ]; then
+        echo "[registry-pivot] state change ${last_state:-<none>} -> ${desired} on ${NODE_NAME}"
+        apply_state "${desired}"
+        last_state="${desired}"
+        # Mark Pod ready after the first successful sync.
+        touch /tmp/ready
+      fi
+
+      sleep 15
+    done
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: registry-pivot-registries-yaml
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "bp-self-sovereign-cutover.labels" . | nindent 4 }}
+    app.kubernetes.io/component: cutover-daemonset
+data:
+  # Cold-start registries.yaml v1 — soft-tethered to mothership Harbor.
+  registries.yaml.v1: |
+    mirrors:
+      ghcr.io:
+        endpoint:
+          - "{{ .Values.upstream.mothershipHarborURL }}/v2/proxy-ghcr"
+      docker.io:
+        endpoint:
+          - "{{ .Values.upstream.mothershipHarborURL }}/v2/proxy-docker"
+      registry.k8s.io:
+        endpoint:
+          - "{{ .Values.upstream.mothershipHarborURL }}/v2/proxy-k8s"
+      gcr.io:
+        endpoint:
+          - "{{ .Values.upstream.mothershipHarborURL }}/v2/proxy-gcr"
+      quay.io:
+        endpoint:
+          - "{{ .Values.upstream.mothershipHarborURL }}/v2/proxy-quay"
+      xpkg.upbound.io:
+        endpoint:
+          - "{{ .Values.upstream.mothershipHarborURL }}/v2/proxy-xpkg"
+      public.ecr.aws:
+        endpoint:
+          - "{{ .Values.upstream.mothershipHarborURL }}/v2/proxy-ecr"
+  # Hot-state registries.yaml v2 — independent. __HARBOR_PUBLIC_URL__
+  # placeholder is replaced in-pod by the pivot script.
+  registries.yaml.v2: |
+    mirrors:
+      ghcr.io:
+        endpoint:
+          - "https://__HARBOR_PUBLIC_URL__/v2/proxy-ghcr"
+      docker.io:
+        endpoint:
+          - "https://__HARBOR_PUBLIC_URL__/v2/proxy-docker"
+      registry.k8s.io:
+        endpoint:
+          - "https://__HARBOR_PUBLIC_URL__/v2/proxy-k8s"
+      gcr.io:
+        endpoint:
+          - "https://__HARBOR_PUBLIC_URL__/v2/proxy-gcr"
+      quay.io:
+        endpoint:
+          - "https://__HARBOR_PUBLIC_URL__/v2/proxy-quay"
+      xpkg.upbound.io:
+        endpoint:
+          - "https://__HARBOR_PUBLIC_URL__/v2/proxy-xpkg"
+      public.ecr.aws:
+        endpoint:
+          - "https://__HARBOR_PUBLIC_URL__/v2/proxy-ecr"
+{{- end }}

--- a/platform/self-sovereign-cutover/chart/templates/05-flux-gitrepository-patch-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/05-flux-gitrepository-patch-job.yaml
@@ -1,0 +1,61 @@
+{{- /*
+Step 05 — flux-gitrepository-patch.
+
+Patches `flux-system/<gitopsRepository.name>` GitRepository.spec.url
+to the local Sovereign Gitea URL. After this patch source-controller
+reconciles against the in-cluster Gitea Service.
+
+Image phase: post.
+*/ -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cutover-step-05-flux-gitrepository-patch
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "bp-self-sovereign-cutover.labels" . | nindent 4 }}
+    app.kubernetes.io/component: cutover-step
+    bp.openova.io/cutover-order: "5"
+    bp.openova.io/cutover-mode: "job"
+data:
+  stepName: flux-gitrepository-patch
+  podSpec: |
+    serviceAccountName: {{ include "bp-self-sovereign-cutover.serviceAccountName" . }}
+    restartPolicy: Never
+    activeDeadlineSeconds: {{ .Values.stepTimeouts.fluxGitRepositoryPatchSeconds }}
+    containers:
+      - name: flux-gitrepository-patch
+        image: {{ include "bp-self-sovereign-cutover.image" (dict "repository" .Values.images.kubectl.repository "tag" .Values.images.kubectl.tag "cutoverPhase" "post" "Values" .Values) }}
+        imagePullPolicy: IfNotPresent
+        env:
+          - name: GITREPO_NAME
+            value: {{ .Values.gitopsRepository.name | quote }}
+          - name: GITREPO_NAMESPACE
+            value: {{ .Values.gitopsRepository.namespace | quote }}
+          - name: LOCAL_GITEA_URL
+            value: {{ printf "%s/%s/%s" .Values.sovereign.giteaInternalURL .Values.gitea.org .Values.gitea.repo | quote }}
+          - name: BRANCH
+            value: {{ .Values.upstream.branch | quote }}
+        command: ["/bin/sh", "-c"]
+        args:
+          - |
+            set -eu
+            echo "[flux-gitrepository-patch] target=${GITREPO_NAMESPACE}/${GITREPO_NAME} -> ${LOCAL_GITEA_URL} (branch=${BRANCH})"
+            patch=$(printf '{"spec":{"url":"%s","ref":{"branch":"%s"}}}' "${LOCAL_GITEA_URL}" "${BRANCH}")
+            kubectl patch gitrepository "${GITREPO_NAME}" \
+              -n "${GITREPO_NAMESPACE}" \
+              --type=merge --patch "${patch}"
+            kubectl annotate --overwrite gitrepository "${GITREPO_NAME}" \
+              -n "${GITREPO_NAMESPACE}" \
+              "reconcile.fluxcd.io/requestedAt=$(date +%s)"
+            echo "[flux-gitrepository-patch] done"
+        resources:
+          requests: { cpu: 50m, memory: 64Mi }
+          limits:   { memory: 256Mi }
+        securityContext:
+          runAsNonRoot: true
+          runAsUser: 1001
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop: ["ALL"]

--- a/platform/self-sovereign-cutover/chart/templates/06-helmrepository-patches-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/06-helmrepository-patches-job.yaml
@@ -1,0 +1,111 @@
+{{- /*
+Step 06 — helmrepository-patches.
+
+For each HelmRepository in .Values.helmRepositories.names, patches
+spec.url from oci://ghcr.io/openova-io/<name> to
+oci://harbor.<sov-fqdn>/openova-io/<name>.
+
+Image phase: post.
+*/ -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cutover-step-06-helmrepository-patches
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "bp-self-sovereign-cutover.labels" . | nindent 4 }}
+    app.kubernetes.io/component: cutover-step
+    bp.openova.io/cutover-order: "6"
+    bp.openova.io/cutover-mode: "job"
+data:
+  stepName: helmrepository-patches
+  helmrepository-names.txt: |
+    {{- range .Values.helmRepositories.names }}
+    {{ . }}
+    {{- end }}
+  podSpec: |
+    serviceAccountName: {{ include "bp-self-sovereign-cutover.serviceAccountName" . }}
+    restartPolicy: Never
+    activeDeadlineSeconds: {{ .Values.stepTimeouts.helmRepositoryPatchesSeconds }}
+    containers:
+      - name: helmrepository-patches
+        image: {{ include "bp-self-sovereign-cutover.image" (dict "repository" .Values.images.kubectl.repository "tag" .Values.images.kubectl.tag "cutoverPhase" "post" "Values" .Values) }}
+        imagePullPolicy: IfNotPresent
+        env:
+          - name: HELMREPO_NAMESPACE
+            value: {{ .Values.helmRepositories.namespace | quote }}
+          - name: UPSTREAM_PREFIX
+            value: {{ .Values.helmRepositories.upstreamPrefix | quote }}
+          - name: HARBOR_PUBLIC_URL
+            value: {{ .Values.sovereign.harborPublicURL | quote }}
+        volumeMounts:
+          - name: helmrepository-list
+            mountPath: /work
+            readOnly: true
+        command: ["/bin/sh", "-c"]
+        args:
+          - |
+            set -eu
+            harbor_host=$(printf '%s' "${HARBOR_PUBLIC_URL}" | sed -E 's,^https?://,,; s,/$,,')
+            local_prefix="oci://${harbor_host}/openova-io"
+
+            echo "[helmrepository-patches] upstream=${UPSTREAM_PREFIX} -> local=${local_prefix}"
+
+            ok=0
+            skip=0
+            fail=0
+            while IFS= read -r line; do
+              name=$(printf '%s' "${line}" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+              [ -z "${name}" ] && continue
+
+              cur_url=$(kubectl get helmrepository "${name}" \
+                -n "${HELMREPO_NAMESPACE}" \
+                -o jsonpath='{.spec.url}' 2>/dev/null || echo "")
+
+              if [ -z "${cur_url}" ]; then
+                echo "[helmrepository-patches] SKIP ${name} (not found)"
+                skip=$((skip+1))
+                continue
+              fi
+
+              new_url=$(printf '%s' "${cur_url}" | sed -e "s,${UPSTREAM_PREFIX},${local_prefix},")
+              if [ "${new_url}" = "${cur_url}" ]; then
+                echo "[helmrepository-patches] SKIP ${name} (already pivoted or non-default URL)"
+                skip=$((skip+1))
+                continue
+              fi
+
+              patch=$(printf '{"spec":{"url":"%s"}}' "${new_url}")
+              if kubectl patch helmrepository "${name}" \
+                  -n "${HELMREPO_NAMESPACE}" \
+                  --type=merge --patch "${patch}" >/dev/null; then
+                kubectl annotate --overwrite helmrepository "${name}" \
+                  -n "${HELMREPO_NAMESPACE}" \
+                  "reconcile.fluxcd.io/requestedAt=$(date +%s)" >/dev/null
+                echo "[helmrepository-patches] OK ${name} -> ${new_url}"
+                ok=$((ok+1))
+              else
+                echo "[helmrepository-patches] FAIL ${name}"
+                fail=$((fail+1))
+              fi
+            done < /work/helmrepository-names.txt
+
+            echo "[helmrepository-patches] ok=${ok} skip=${skip} fail=${fail}"
+            [ "${fail}" -eq 0 ]
+        resources:
+          requests: { cpu: 50m, memory: 64Mi }
+          limits:   { memory: 256Mi }
+        securityContext:
+          runAsNonRoot: true
+          runAsUser: 1001
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop: ["ALL"]
+    volumes:
+      - name: helmrepository-list
+        configMap:
+          name: cutover-step-06-helmrepository-patches
+          items:
+            - key: helmrepository-names.txt
+              path: helmrepository-names.txt

--- a/platform/self-sovereign-cutover/chart/templates/07-catalyst-api-env-patch-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/07-catalyst-api-env-patch-job.yaml
@@ -1,0 +1,60 @@
+{{- /*
+Step 07 — catalyst-api-env-patch.
+
+Sets the env var on the catalyst-api Deployment that drives its
+GitOps source URL. Trips a rolling restart of the catalyst-api pod fleet.
+
+Image phase: post.
+*/ -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cutover-step-07-catalyst-api-env-patch
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "bp-self-sovereign-cutover.labels" . | nindent 4 }}
+    app.kubernetes.io/component: cutover-step
+    bp.openova.io/cutover-order: "7"
+    bp.openova.io/cutover-mode: "job"
+data:
+  stepName: catalyst-api-env-patch
+  podSpec: |
+    serviceAccountName: {{ include "bp-self-sovereign-cutover.serviceAccountName" . }}
+    restartPolicy: Never
+    activeDeadlineSeconds: {{ .Values.stepTimeouts.catalystAPIEnvPatchSeconds }}
+    containers:
+      - name: catalyst-api-env-patch
+        image: {{ include "bp-self-sovereign-cutover.image" (dict "repository" .Values.images.kubectl.repository "tag" .Values.images.kubectl.tag "cutoverPhase" "post" "Values" .Values) }}
+        imagePullPolicy: IfNotPresent
+        env:
+          - name: DEPLOYMENT_NAME
+            value: {{ .Values.catalystAPI.deploymentName | quote }}
+          - name: DEPLOYMENT_NAMESPACE
+            value: {{ .Values.catalystAPI.namespace | quote }}
+          - name: ENV_VAR_NAME
+            value: {{ .Values.catalystAPI.envVar | quote }}
+          - name: ENV_VAR_VALUE
+            value: {{ printf "%s/%s/%s" .Values.sovereign.giteaInternalURL .Values.gitea.org .Values.gitea.repo | quote }}
+        command: ["/bin/sh", "-c"]
+        args:
+          - |
+            set -eu
+            echo "[catalyst-api-env-patch] target=${DEPLOYMENT_NAMESPACE}/${DEPLOYMENT_NAME}"
+            echo "[catalyst-api-env-patch] ${ENV_VAR_NAME}=${ENV_VAR_VALUE}"
+            kubectl set env "deploy/${DEPLOYMENT_NAME}" \
+              -n "${DEPLOYMENT_NAMESPACE}" \
+              "${ENV_VAR_NAME}=${ENV_VAR_VALUE}"
+            kubectl rollout status "deploy/${DEPLOYMENT_NAME}" \
+              -n "${DEPLOYMENT_NAMESPACE}" \
+              --timeout=300s
+            echo "[catalyst-api-env-patch] done"
+        resources:
+          requests: { cpu: 50m, memory: 64Mi }
+          limits:   { memory: 256Mi }
+        securityContext:
+          runAsNonRoot: true
+          runAsUser: 1001
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop: ["ALL"]

--- a/platform/self-sovereign-cutover/chart/templates/08-egress-block-test-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/08-egress-block-test-job.yaml
@@ -1,0 +1,116 @@
+{{- /*
+Step 08 — egress-block-test.
+
+The proof-of-sovereignty step. Applies a CiliumNetworkPolicy denying
+egress to upstream domains for .Values.egressTest.durationSeconds, then
+asserts every HelmRelease + Kustomization stays Ready throughout. The
+policy is removed at end-of-test regardless of pass/fail.
+
+Image phase: post.
+*/ -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cutover-step-08-egress-block-test
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "bp-self-sovereign-cutover.labels" . | nindent 4 }}
+    app.kubernetes.io/component: cutover-step
+    bp.openova.io/cutover-order: "8"
+    bp.openova.io/cutover-mode: "job"
+data:
+  stepName: egress-block-test
+  cilium-policy.yaml: |
+    apiVersion: cilium.io/v2
+    kind: CiliumNetworkPolicy
+    metadata:
+      name: cutover-egress-block
+      namespace: {{ .Release.Namespace }}
+      labels:
+        {{- include "bp-self-sovereign-cutover.labels" . | nindent 8 }}
+        app.kubernetes.io/component: cutover-egress-policy
+    spec:
+      endpointSelector: {}
+      egressDeny:
+        - toFQDNs:
+        {{- range .Values.egressTest.blockedDomains }}
+            - matchPattern: {{ . | quote }}
+            - matchPattern: {{ printf "*.%s" . | quote }}
+        {{- end }}
+  podSpec: |
+    serviceAccountName: {{ include "bp-self-sovereign-cutover.serviceAccountName" . }}
+    restartPolicy: Never
+    activeDeadlineSeconds: {{ .Values.stepTimeouts.egressBlockTestSeconds }}
+    containers:
+      - name: egress-block-test
+        image: {{ include "bp-self-sovereign-cutover.image" (dict "repository" .Values.images.kubectl.repository "tag" .Values.images.kubectl.tag "cutoverPhase" "post" "Values" .Values) }}
+        imagePullPolicy: IfNotPresent
+        env:
+          - name: DURATION_SECONDS
+            value: {{ .Values.egressTest.durationSeconds | quote }}
+          - name: NAMESPACE
+            value: {{ .Release.Namespace | quote }}
+        volumeMounts:
+          - name: cilium-policy
+            mountPath: /work
+            readOnly: true
+        command: ["/bin/sh", "-c"]
+        args:
+          - |
+            set -eu
+
+            cleanup() {
+              echo "[egress-block-test] removing CiliumNetworkPolicy"
+              kubectl delete -f /work/cilium-policy.yaml --ignore-not-found
+            }
+            trap cleanup EXIT INT TERM
+
+            echo "[egress-block-test] applying CiliumNetworkPolicy for ${DURATION_SECONDS}s"
+            kubectl apply -f /work/cilium-policy.yaml
+
+            start=$(date +%s)
+            deadline=$((start + DURATION_SECONDS))
+            poll_interval=30
+            failures=0
+
+            while [ "$(date +%s)" -lt "${deadline}" ]; do
+              hr_not_ready=$(kubectl get helmreleases.helm.toolkit.fluxcd.io -A \
+                -o jsonpath='{range .items[*]}{.metadata.namespace}/{.metadata.name}={.status.conditions[?(@.type=="Ready")].status}{"\n"}{end}' \
+                | grep -E '=False$' || true)
+              ks_not_ready=$(kubectl get kustomizations.kustomize.toolkit.fluxcd.io -A \
+                -o jsonpath='{range .items[*]}{.metadata.namespace}/{.metadata.name}={.status.conditions[?(@.type=="Ready")].status}{"\n"}{end}' \
+                | grep -E '=False$' || true)
+
+              if [ -n "${hr_not_ready}${ks_not_ready}" ]; then
+                echo "[egress-block-test] NotReady detected at $(($(date +%s) - start))s:"
+                [ -n "${hr_not_ready}" ] && echo "${hr_not_ready}" | sed 's/^/  HR /'
+                [ -n "${ks_not_ready}" ] && echo "${ks_not_ready}" | sed 's/^/  KS /'
+                failures=$((failures+1))
+              fi
+
+              sleep "${poll_interval}"
+            done
+
+            echo "[egress-block-test] window complete; observed-failure-cycles=${failures}"
+            if [ "${failures}" -gt 0 ]; then
+              echo "[egress-block-test] cluster did NOT survive egress block — sovereignty proof FAILED"
+              exit 1
+            fi
+            echo "[egress-block-test] cluster survived ${DURATION_SECONDS}s egress block — sovereignty proof PASSED"
+        resources:
+          requests: { cpu: 50m, memory: 64Mi }
+          limits:   { memory: 256Mi }
+        securityContext:
+          runAsNonRoot: true
+          runAsUser: 1001
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop: ["ALL"]
+    volumes:
+      - name: cilium-policy
+        configMap:
+          name: cutover-step-08-egress-block-test
+          items:
+            - key: cilium-policy.yaml
+              path: cilium-policy.yaml

--- a/platform/self-sovereign-cutover/chart/templates/09-cutover-status-configmap.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/09-cutover-status-configmap.yaml
@@ -1,0 +1,85 @@
+{{- /*
+Status ConfigMap — initial state for the cutover state machine.
+
+Keys consumed by the catalyst-api cutover endpoint (issue #792,
+products/catalyst/bootstrap/api/internal/handler/cutover.go):
+
+  cutoverComplete          "true" | "false"
+  cutoverStartedAt         RFC3339, set by /start
+  cutoverFinishedAt        RFC3339, set when last step succeeds
+  currentStep              <stepName> | "" when idle
+  currentStepIndex         "0" .. "N"
+  totalSteps               "N"
+  progressPercent          "0" .. "100"
+  failedStep               <stepName> | "" when no failure
+  lastError                operator-actionable string | ""
+  step.<stepName>.startedAt
+  step.<stepName>.finishedAt
+  step.<stepName>.result   "success" | "failed" | "skipped"
+  step.<stepName>.jobName  Job/DaemonSet name (audit pointer)
+
+Plus this chart's own:
+  registriesYamlActive     "v1" | "v2" | "rollback"
+                           Read by the registry-pivot DaemonSet's
+                           reconcile loop; written by catalyst-api
+                           between step 03 success and step 05.
+
+helm.sh/resource-policy: keep ensures Helm leaves this ConfigMap in
+place on chart uninstall so a re-install doesn't lose state mid-cutover.
+*/ -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.status.configMapName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "bp-self-sovereign-cutover.labels" . | nindent 4 }}
+    app.kubernetes.io/component: cutover-status
+  annotations:
+    helm.sh/resource-policy: keep
+data:
+  cutoverComplete: "false"
+  cutoverStartedAt: ""
+  cutoverFinishedAt: ""
+  currentStep: ""
+  currentStepIndex: "0"
+  totalSteps: "8"
+  progressPercent: "0"
+  failedStep: ""
+  lastError: ""
+  registriesYamlActive: "v1"
+  # Per-step keys are populated lazily by catalyst-api as steps run.
+  # Initial empty placeholders included so a UI rendering this ConfigMap
+  # before /start has been called has something to bind to.
+  step.gitea-mirror.startedAt: ""
+  step.gitea-mirror.finishedAt: ""
+  step.gitea-mirror.result: ""
+  step.gitea-mirror.jobName: ""
+  step.harbor-projects.startedAt: ""
+  step.harbor-projects.finishedAt: ""
+  step.harbor-projects.result: ""
+  step.harbor-projects.jobName: ""
+  step.harbor-prewarm.startedAt: ""
+  step.harbor-prewarm.finishedAt: ""
+  step.harbor-prewarm.result: ""
+  step.harbor-prewarm.jobName: ""
+  step.registry-pivot.startedAt: ""
+  step.registry-pivot.finishedAt: ""
+  step.registry-pivot.result: ""
+  step.registry-pivot.jobName: ""
+  step.flux-gitrepository-patch.startedAt: ""
+  step.flux-gitrepository-patch.finishedAt: ""
+  step.flux-gitrepository-patch.result: ""
+  step.flux-gitrepository-patch.jobName: ""
+  step.helmrepository-patches.startedAt: ""
+  step.helmrepository-patches.finishedAt: ""
+  step.helmrepository-patches.result: ""
+  step.helmrepository-patches.jobName: ""
+  step.catalyst-api-env-patch.startedAt: ""
+  step.catalyst-api-env-patch.finishedAt: ""
+  step.catalyst-api-env-patch.result: ""
+  step.catalyst-api-env-patch.jobName: ""
+  step.egress-block-test.startedAt: ""
+  step.egress-block-test.finishedAt: ""
+  step.egress-block-test.result: ""
+  step.egress-block-test.jobName: ""

--- a/platform/self-sovereign-cutover/chart/templates/_helpers.tpl
+++ b/platform/self-sovereign-cutover/chart/templates/_helpers.tpl
@@ -1,0 +1,67 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "bp-self-sovereign-cutover.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels — applied to every resource emitted by this chart.
+
+Why these label keys are load-bearing
+─────────────────────────────────────
+The catalyst-api cutover endpoint (issue #792, products/catalyst/bootstrap/api/
+internal/handler/cutover.go) discovers step ConfigMaps via:
+
+    app.kubernetes.io/part-of=self-sovereign-cutover
+    app.kubernetes.io/component=cutover-step
+
+…and resolves order/mode/daemonsetRef via:
+
+    bp.openova.io/cutover-order        integer 1..N
+    bp.openova.io/cutover-mode         "job" | "daemonset-wait"
+    bp.openova.io/cutover-daemonset    DaemonSet name (mode=daemonset-wait only)
+
+Those labels are EMITTED PER-STEP-TEMPLATE because each step's order /
+mode / daemonsetRef differ. The helpers below provide ONLY the common
+ones; per-step templates inline their own.
+*/}}
+{{- define "bp-self-sovereign-cutover.labels" -}}
+app.kubernetes.io/name: {{ include "bp-self-sovereign-cutover.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: self-sovereign-cutover
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | quote }}
+catalyst.openova.io/blueprint: bp-self-sovereign-cutover
+catalyst.openova.io/sovereign-fqdn: {{ .Values.sovereign.fqdn | quote }}
+{{- end -}}
+
+{{/*
+Image reference helper. Routes through .Values.global.imageRegistry IF
+set AND the caller passes `cutoverPhase: post`. The first three steps
+(01/02/03) and the registry-pivot DaemonSet MUST use upstream-public
+images (cutoverPhase: pre) because they run BEFORE registries.yaml v2
+takes effect on the node containerd. Post-pivot steps (05/06/07/08)
+declare cutoverPhase: post so they pull from local Harbor when the
+operator overlay sets global.imageRegistry.
+
+Inputs (dict): .repository .tag .cutoverPhase (pre|post) .Values
+*/}}
+{{- define "bp-self-sovereign-cutover.image" -}}
+{{- $repo := .repository -}}
+{{- $tag := .tag -}}
+{{- $registry := "" -}}
+{{- if and (eq .cutoverPhase "post") .Values.global.imageRegistry -}}
+{{- $registry = printf "%s/" .Values.global.imageRegistry -}}
+{{- end -}}
+{{- printf "%s%s:%s" $registry $repo $tag -}}
+{{- end -}}
+
+{{/*
+ServiceAccount name — every step Job (stamped by catalyst-api from the
+PodSpec ConfigMaps in this chart) AND the registry-pivot DaemonSet use
+the same SA so RBAC is single-source.
+*/}}
+{{- define "bp-self-sovereign-cutover.serviceAccountName" -}}
+{{- printf "%s-runner" (include "bp-self-sovereign-cutover.name" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/platform/self-sovereign-cutover/chart/templates/namespace.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/namespace.yaml
@@ -1,0 +1,20 @@
+{{- /*
+Per-Sovereign cutover namespace. NO Helm hook annotations on this chart
+(the entire chart installs DORMANT — nothing fires until catalyst-api
+stamps Jobs from the step PodSpec ConfigMaps). The namespace is
+delivered as a normal install resource so it lands at HelmRelease apply
+time alongside the step ConfigMaps.
+
+The bootstrap-kit slot
+clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+also declares this Namespace at the slot level so Flux can apply the
+HelmRelease into it without a chicken-and-egg ordering. That declaration
+is the canonical owner; this template is a no-op safety net for `helm
+template` smoke renders + standalone `helm install` dev workflows.
+*/ -}}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .Release.Namespace }}
+  labels:
+    {{- include "bp-self-sovereign-cutover.labels" . | nindent 4 }}

--- a/platform/self-sovereign-cutover/chart/templates/rbac.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/rbac.yaml
@@ -1,0 +1,118 @@
+{{- /*
+RBAC for the cutover runner ServiceAccount.
+
+CRITICAL — feedback_rbac_create_no_resourcenames.md (auto-memory anchor):
+Kubernetes RBAC forbids combining `create` verbs with `resourceNames`.
+A POST request has no resource name yet; the apiserver MUST evaluate the
+rule against the request without a name match, and a `resourceNames` set
+with `create` produces a 403 every time. This caused the bp-openbao
+6+ provisioning loop. We split `create` into its own Rule with NO
+`resourceNames` and keep `update/patch/get/delete` in a separate Rule
+that may be name-scoped.
+
+The cutover runner needs cluster-scope reach because:
+  - Step 02 reads bp-harbor admin Secret in `harbor` namespace.
+  - Step 02 reads ghcr-pull Secret in `flux-system` namespace.
+  - Step 03 only writes to local Harbor over HTTP (no K8s API).
+  - Step 05 patches GitRepository in `flux-system` namespace.
+  - Step 06 patches HelmRepositories in `flux-system` namespace.
+  - Step 07 patches Deployment in `catalyst-platform` namespace.
+  - Step 08 creates+deletes a CiliumNetworkPolicy cluster-wide and
+    queries HelmRelease/Kustomization status across all namespaces.
+  - Registry-pivot DaemonSet writes to /etc/rancher/k3s/registries.yaml
+    on the host filesystem (hostPath, no K8s API needed beyond status
+    update on the cutover-status ConfigMap).
+
+We use ClusterRole + ClusterRoleBinding because the namespaces touched
+are heterogeneous and cluster-scoped resources (CiliumNetworkPolicy)
+must be addressable.
+*/ -}}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "bp-self-sovereign-cutover.serviceAccountName" . }}
+  labels:
+    {{- include "bp-self-sovereign-cutover.labels" . | nindent 4 }}
+rules:
+  # ───────────────────────────────────────────────────────────────
+  # CREATE verbs — MUST be in their own Rule WITHOUT resourceNames.
+  # ───────────────────────────────────────────────────────────────
+  - apiGroups: [""]
+    resources: ["configmaps"]   # cutover-status ConfigMap is created+updated by every step
+    verbs: ["create"]
+  - apiGroups: ["cilium.io"]
+    resources: ["ciliumnetworkpolicies"]   # step 08 creates the egress-block NP
+    verbs: ["create"]
+  - apiGroups: [""]
+    resources: ["events"]   # informational events posted as steps complete
+    verbs: ["create"]
+  - apiGroups: ["batch"]
+    resources: ["jobs"]   # catalyst-api stamps Jobs in this namespace from step ConfigMaps
+    verbs: ["create"]
+
+  # ───────────────────────────────────────────────────────────────
+  # READ verbs — namespace-spanning per the step inventory above.
+  # ───────────────────────────────────────────────────────────────
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["pods", "pods/log"]   # step 08 inspects pod status during the egress block window
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apps"]
+    resources: ["deployments", "daemonsets", "statefulsets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["source.toolkit.fluxcd.io"]
+    resources: ["gitrepositories", "helmrepositories", "ocirepositories"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["helm.toolkit.fluxcd.io"]
+    resources: ["helmreleases"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["kustomize.toolkit.fluxcd.io"]
+    resources: ["kustomizations"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["cilium.io"]
+    resources: ["ciliumnetworkpolicies"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["nodes"]   # registry-pivot DaemonSet reports node status into the status ConfigMap
+    verbs: ["get", "list", "watch"]
+
+  # ───────────────────────────────────────────────────────────────
+  # UPDATE / PATCH / DELETE — separate from create per RBAC rule.
+  # ───────────────────────────────────────────────────────────────
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["update", "patch"]
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["update", "patch"]   # step 07 sets env on catalyst-api deployment
+  - apiGroups: ["source.toolkit.fluxcd.io"]
+    resources: ["gitrepositories", "helmrepositories"]
+    verbs: ["update", "patch"]   # steps 05 + 06
+  - apiGroups: ["cilium.io"]
+    resources: ["ciliumnetworkpolicies"]
+    verbs: ["delete", "patch", "update"]   # step 08 removes the policy at end-of-test
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "bp-self-sovereign-cutover.serviceAccountName" . }}
+  labels:
+    {{- include "bp-self-sovereign-cutover.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "bp-self-sovereign-cutover.serviceAccountName" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "bp-self-sovereign-cutover.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}

--- a/platform/self-sovereign-cutover/chart/templates/serviceaccount.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/serviceaccount.yaml
@@ -1,0 +1,17 @@
+{{- /*
+ServiceAccount used by every step Job (stamped by catalyst-api from the
+PodSpec ConfigMaps in this chart) AND by the registry-pivot DaemonSet
+that ships in this chart. Single SA → single RBAC binding to audit.
+
+Per docs/INVIOLABLE-PRINCIPLES.md §10 (credential hygiene), tokens are
+auto-mounted at /var/run/secrets/kubernetes.io/serviceaccount and never
+echoed; step PodSpecs talk to the in-cluster API via these tokens, no
+plaintext kubeconfig ships in this chart.
+*/ -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "bp-self-sovereign-cutover.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "bp-self-sovereign-cutover.labels" . | nindent 4 }}

--- a/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
+++ b/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# bp-self-sovereign-cutover — consumer-contract gate.
+#
+# Verifies that the chart's rendered output complies with the contract
+# the catalyst-api cutover endpoint (issue #792, products/catalyst/
+# bootstrap/api/internal/handler/cutover.go) depends on:
+#
+#   1. Chart MUST render with default values (smoke).
+#   2. Each step ConfigMap MUST carry labels:
+#        app.kubernetes.io/part-of=self-sovereign-cutover
+#        app.kubernetes.io/component=cutover-step
+#        bp.openova.io/cutover-order=<integer>
+#        bp.openova.io/cutover-mode=<job|daemonset-wait>
+#   3. Each step ConfigMap MUST carry data keys:
+#        stepName  (always)
+#        podSpec   (mode=job only)
+#   4. EXACTLY 8 step ConfigMaps must render (steps 1..8).
+#   5. Step 04 must be mode=daemonset-wait.
+#   6. The status ConfigMap (default name self-sovereign-cutover-status)
+#      MUST render with helm.sh/resource-policy: keep so a chart
+#      uninstall doesn't lose mid-cutover state.
+#   7. RBAC: the runner ClusterRole MUST split create verbs into a Rule
+#      WITHOUT resourceNames (feedback_rbac_create_no_resourcenames.md
+#      auto-memory anchor — combining create + resourceNames produces
+#      403 every POST).
+#
+# Usage: bash tests/cutover-contract.sh [CHART_DIR]
+
+set -euo pipefail
+
+CHART_DIR="${1:-$(cd "$(dirname "$0")/.." && pwd)}"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+cd "$CHART_DIR"
+
+echo "[cutover-contract] Case 1: chart renders with default values"
+helm template smoke . > "$TMP/render.yaml"
+echo "  PASS ($(wc -l < "$TMP/render.yaml") lines)"
+
+echo "[cutover-contract] Case 2 + 4: exactly 8 step ConfigMaps render with required labels"
+# Use yq if present (the CI runner installs it for the blueprint-release
+# guards); fall back to grep counting on workstations without yq.
+if command -v yq >/dev/null 2>&1; then
+  # yq emits `---` separators between matched docs; filter those out
+  # before counting names. `grep -E '^cutover-step-'` matches only the
+  # actual ConfigMap names emitted by the projection.
+  step_count=$(yq 'select(.kind == "ConfigMap" and .metadata.labels."app.kubernetes.io/component" == "cutover-step") | .metadata.name' "$TMP/render.yaml" | grep -cE '^cutover-step-')
+else
+  # Each step has labels block including `bp.openova.io/cutover-order: "N"`
+  # — count distinct order values, which equals step count.
+  step_count=$(grep -c 'bp.openova.io/cutover-order:' "$TMP/render.yaml")
+fi
+if [ "${step_count}" -ne 8 ]; then
+  echo "FAIL: expected 8 step ConfigMaps, got ${step_count}" >&2
+  exit 1
+fi
+echo "  PASS (8 step ConfigMaps)"
+
+echo "[cutover-contract] Case 3: required data keys present"
+# stepName key must exist on every step ConfigMap (8 total).
+# podSpec key must exist on every job-mode step (7 of 8 — step 04 is daemonset-wait).
+mode_job_count=$(grep -c 'bp.openova.io/cutover-mode: "job"' "$TMP/render.yaml")
+if [ "${mode_job_count}" -ne 7 ]; then
+  echo "FAIL: expected 7 job-mode step ConfigMaps, got ${mode_job_count}" >&2
+  exit 1
+fi
+podspec_keys=$(grep -c '^  podSpec: |' "$TMP/render.yaml")
+if [ "${podspec_keys}" -lt 7 ]; then
+  echo "FAIL: expected at least 7 podSpec keys (one per job-mode step), got ${podspec_keys}" >&2
+  exit 1
+fi
+stepname_keys=$(grep -c '^  stepName:' "$TMP/render.yaml")
+if [ "${stepname_keys}" -lt 8 ]; then
+  echo "FAIL: expected at least 8 stepName keys, got ${stepname_keys}" >&2
+  exit 1
+fi
+echo "  PASS (data keys present on every step)"
+
+echo "[cutover-contract] Case 5: step 04 is mode=daemonset-wait"
+if ! grep -B5 'bp.openova.io/cutover-order: "4"' "$TMP/render.yaml" | grep -q 'cutover-mode: "daemonset-wait"'; then
+  # `grep -B5 cutover-order:"4"` finds the metadata block that has the order
+  # label; the mode label appears below order, not above. Switch to a forward
+  # search.
+  if ! grep -A3 'bp.openova.io/cutover-order: "4"' "$TMP/render.yaml" | grep -q 'cutover-mode: "daemonset-wait"'; then
+    echo "FAIL: step 04 must have bp.openova.io/cutover-mode=daemonset-wait" >&2
+    exit 1
+  fi
+fi
+echo "  PASS (step 04 daemonset-wait)"
+
+echo "[cutover-contract] Case 6: status ConfigMap has helm.sh/resource-policy: keep"
+if ! awk '/kind: ConfigMap/,/^---$/' "$TMP/render.yaml" | grep -B2 'name: self-sovereign-cutover-status' | grep -q 'self-sovereign-cutover-status' ; then
+  echo "FAIL: self-sovereign-cutover-status ConfigMap not found" >&2
+  exit 1
+fi
+if ! grep -B5 'name: self-sovereign-cutover-status' "$TMP/render.yaml" | grep -q 'helm.sh/resource-policy: keep'; then
+  # Resource-policy annotation may render after the metadata block; do a
+  # post-block sweep.
+  if ! awk '/name: self-sovereign-cutover-status/,/^---$/' "$TMP/render.yaml" | grep -q 'helm.sh/resource-policy: keep' ; then
+    echo "FAIL: status ConfigMap missing helm.sh/resource-policy: keep" >&2
+    exit 1
+  fi
+fi
+echo "  PASS (status ConfigMap retained on uninstall)"
+
+echo "[cutover-contract] Case 7: RBAC splits create verbs into a Rule WITHOUT resourceNames"
+# Extract the ClusterRole block and confirm no rule has both verbs:[create]
+# and resourceNames. The chart's templates/rbac.yaml structures the rules
+# so create lives in its own Rule; this gate guards against future edits
+# that accidentally combine them and reproduce the bp-openbao 403 loop.
+clusterrole_block=$(awk '/^kind: ClusterRole$/,/^---$/' "$TMP/render.yaml")
+# Crude but reliable: check that no rule has 'create' immediately followed
+# (within 5 lines) by 'resourceNames'.
+if printf '%s\n' "${clusterrole_block}" | awk '
+  /verbs:/ { in_verbs=1; verbs_line=NR; line=$0; verb_block=line; next }
+  in_verbs && (NR <= verbs_line + 1) { verb_block=verb_block"\n"$0 }
+  in_verbs && (NR > verbs_line + 1) { in_verbs=0 }
+  /resourceNames:/ && (NR <= verbs_line + 6) {
+    if (verb_block ~ /create/) {
+      print "FAIL: create + resourceNames in same rule (line " NR ")"
+      exit 1
+    }
+  }
+'; then
+  echo "  PASS (create verbs split out)"
+else
+  echo "FAIL: RBAC has create verbs combined with resourceNames" >&2
+  exit 1
+fi
+
+echo "[cutover-contract] All gates green."

--- a/platform/self-sovereign-cutover/chart/values.yaml
+++ b/platform/self-sovereign-cutover/chart/values.yaml
@@ -1,0 +1,273 @@
+# bp-self-sovereign-cutover — default values.
+#
+# Per docs/INVIOLABLE-PRINCIPLES.md #4 (never hardcode), every operationally
+# meaningful value flows in via per-Sovereign Flux HelmRelease values; the
+# placeholder defaults below let `helm template` smoke-render cleanly in CI
+# without --set. Per-Sovereign overlays
+# (clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml)
+# supply real values via envsubst on `${SOVEREIGN_FQDN}` exactly the way
+# 19-harbor.yaml + 10-gitea.yaml do.
+#
+# This chart installs DORMANT. Job PodSpecs are emitted as ConfigMaps;
+# catalyst-api reads them at cutover trigger time and stamps real batch/v1
+# Jobs. NO helm.sh/hook annotations on any Job manifests in this chart.
+
+global:
+  # When set, post-pivot step ConfigMaps render image references through
+  # this prefix (so catalyst-api stamps Jobs that pull from the local
+  # Harbor proxy-cache). Pre-pivot steps (gitea-mirror, harbor-projects,
+  # harbor-prewarm, registry-pivot) MUST use upstream-public images
+  # because they run BEFORE the local Harbor proxy-cache + containerd
+  # registries.yaml v2 are in place. Default empty = upstream-public for
+  # all steps (safe default for smoke render).
+  imageRegistry: ""
+
+# Sovereign coordinates. The HelmRelease in
+# clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+# substitutes ${SOVEREIGN_FQDN} from cluster overlays.
+sovereign:
+  # REQUIRED at install time — overlay supplies a real FQDN. The
+  # placeholder below lets `helm template` smoke-render in CI; runtime
+  # use with the placeholder is non-functional by design.
+  fqdn: "example.local"
+  # Local Harbor URL (in-cluster Service form). Used by step 02
+  # (harbor-projects) and step 03 (harbor-prewarm). The PUBLIC
+  # harbor.<sovereign.fqdn> URL is what registries.yaml v2 + step 06
+  # (helmrepository-patches) rewrite to (since containerd + Flux
+  # source-controller resolve through public DNS, not in-cluster
+  # CoreDNS).
+  harborInternalURL: "http://harbor-harbor-core.harbor.svc.cluster.local"
+  # ↓ overlay required for real cutover (uses ${SOVEREIGN_FQDN}).
+  harborPublicURL: "https://harbor.example.local"
+  giteaInternalURL: "http://gitea-http.gitea.svc.cluster.local:3000"
+  # ↓ overlay supplies https://gitea.${SOVEREIGN_FQDN} (informational; jobs use internal URL).
+  giteaPublicURL: "https://gitea.example.local"
+
+# Upstream openova-io read-only public clone — the source for the
+# cutover step 01 git push --mirror into local Gitea. Overrideable so a
+# Sovereign that ships from a fork can rebase the seed.
+upstream:
+  repoURL: "https://github.com/openova-io/openova"
+  branch: "main"
+  # Mothership Harbor — the soft-tethered cold-start registry. Step 08
+  # egress-block test asserts the cluster can survive without this URL.
+  mothershipHarborURL: "https://harbor.openova.io"
+
+# Local Gitea target — the org + repo created by step 01 (gitea-mirror).
+gitea:
+  org: "openova"
+  repo: "openova"
+  # Shape of the admin secret created by bp-gitea's templates.
+  # Keys: username, password, token (optional). Job uses BasicAuth
+  # username:password against /api/v1 + git push.
+  adminSecretRef:
+    name: "gitea-admin-secret"
+    namespace: "gitea"
+    usernameKey: "username"
+    passwordKey: "password"
+
+# Local Harbor target — admin credentials + proxy_cache projects to create.
+harbor:
+  # Shape of the admin secret created by bp-harbor's templates
+  # (HARBOR_ADMIN_PASSWORD per upstream chart). Keys:
+  # HARBOR_ADMIN_USERNAME (optional, falls back to "admin"),
+  # HARBOR_ADMIN_PASSWORD.
+  adminSecretRef:
+    name: "harbor-core"
+    namespace: "harbor"
+    usernameKey: "HARBOR_ADMIN_USERNAME"
+    passwordKey: "HARBOR_ADMIN_PASSWORD"
+  # GHCR upstream credential (operator-issued, written by cloud-init at
+  # /var/lib/catalyst/ghcr-pull-secret.yaml). Used as the credential the
+  # proxy-ghcr registry attaches when pulling from ghcr.io.
+  ghcrSecretRef:
+    name: "ghcr-pull"
+    namespace: "flux-system"
+    # Secrets of dockerconfigjson type carry their value under
+    # `.dockerconfigjson`; step 02 parses it for username/password.
+    dockerConfigKey: ".dockerconfigjson"
+  # Seven proxy-cache projects + their upstream registry endpoints.
+  # Names are stable because step 06 (helmrepository-patches) +
+  # registries.yaml v2 (registry-pivot) rewrite paths against these
+  # literal project names.
+  proxyProjects:
+    - name: "proxy-ghcr"
+      upstreamURL: "https://ghcr.io"
+      registryType: "github"
+      authMode: "credential"      # uses harbor.ghcrSecretRef
+    - name: "proxy-docker"
+      upstreamURL: "https://registry-1.docker.io"
+      registryType: "docker-hub"
+      authMode: "anonymous"
+    - name: "proxy-k8s"
+      upstreamURL: "https://registry.k8s.io"
+      registryType: "docker-registry"
+      authMode: "anonymous"
+    - name: "proxy-gcr"
+      upstreamURL: "https://gcr.io"
+      registryType: "docker-registry"
+      authMode: "anonymous"
+    - name: "proxy-quay"
+      upstreamURL: "https://quay.io"
+      registryType: "quay"
+      authMode: "anonymous"
+    - name: "proxy-xpkg"
+      upstreamURL: "https://xpkg.upbound.io"
+      registryType: "docker-registry"
+      authMode: "anonymous"
+    - name: "proxy-ecr"
+      upstreamURL: "https://public.ecr.aws"
+      registryType: "docker-registry"
+      authMode: "anonymous"
+
+# Pre-warm list — images to HEAD-pull through Harbor proxy-cache before
+# the cluster reconciles against local Harbor, so first-reconcile pulls
+# hit a warm cache. The list is intentionally narrow (the heaviest
+# charts). Operators can extend via overlay; an empty list is also valid.
+prewarm:
+  images:
+    - "proxy-docker/library/redis:7"
+    - "proxy-docker/library/postgres:16"
+    - "proxy-quay/cilium/cilium:v1.16.5"
+    - "proxy-quay/jetstack/cert-manager-controller:v1.16.1"
+    - "proxy-quay/kyverno/kyverno:v1.13.4"
+    - "proxy-docker/grafana/loki:3.3.2"
+    - "proxy-docker/grafana/grafana:11.4.0"
+    - "proxy-docker/grafana/alloy:v1.5.1"
+    - "proxy-docker/falcosecurity/falco:0.39.2"
+    - "proxy-ghcr/fluxcd/source-controller:v1.4.1"
+    - "proxy-ghcr/fluxcd/helm-controller:v1.1.0"
+
+# GitOps source — Flux GitRepository in flux-system namespace that step
+# 05 (flux-gitrepository-patch) patches to point at local Gitea.
+gitopsRepository:
+  name: "openova"
+  namespace: "flux-system"
+
+# HelmRepository patch list — step 06 (helmrepository-patches) iterates
+# this list and replaces oci://ghcr.io/openova-io →
+# oci://harbor.<sov-fqdn>/openova-io for every entry. Default is
+# materialised by listing the bp-* HelmRepositories the bootstrap-kit
+# ships; per-Sovereign overlays may extend the list with operator-added
+# Application Blueprints.
+helmRepositories:
+  namespace: "flux-system"
+  upstreamPrefix: "oci://ghcr.io/openova-io"
+  # Local prefix is computed at runtime from sovereign.harborPublicURL
+  # so we don't double-encode the FQDN here. Step 06 PodSpec carries
+  # the pivot script that does the substitution.
+  names:
+    - "bp-cilium"
+    - "bp-gateway-api"
+    - "bp-cert-manager"
+    - "bp-flux"
+    - "bp-crossplane"
+    - "bp-sealed-secrets"
+    - "bp-reflector"
+    - "bp-nats-jetstream"
+    - "bp-openbao"
+    - "bp-keycloak"
+    - "bp-gitea"
+    - "bp-powerdns"
+    - "bp-external-dns"
+    - "bp-catalyst-platform"
+    - "bp-crossplane-claims"
+    - "bp-external-secrets"
+    - "bp-external-secrets-stores"
+    - "bp-cnpg"
+    - "bp-valkey"
+    - "bp-seaweedfs"
+    - "bp-harbor"
+    - "bp-opentelemetry"
+    - "bp-alloy"
+    - "bp-loki"
+    - "bp-mimir"
+    - "bp-tempo"
+    - "bp-grafana"
+    - "bp-kyverno"
+    - "bp-reloader"
+    - "bp-vpa"
+    - "bp-trivy"
+    - "bp-falco"
+    - "bp-sigstore"
+    - "bp-syft-grype"
+    - "bp-velero"
+    - "bp-coraza"
+    - "bp-cert-manager-powerdns-webhook"
+    - "bp-cluster-autoscaler-hcloud"
+
+# catalyst-api Deployment to patch in step 07 (catalyst-api-env-patch).
+catalystAPI:
+  deploymentName: "catalyst-api"
+  namespace: "catalyst-platform"
+  # The env var that catalyst-api reads for its GitOps source URL.
+  envVar: "CATALYST_GITOPS_REPO_URL"
+
+# Step container images. The first three steps (01..03) + the
+# registry-pivot DaemonSet use upstream-public images because they run
+# BEFORE registries.yaml v2 takes effect on the node containerd.
+# Post-pivot steps (≥ 05) MAY use the local Harbor copy via
+# global.imageRegistry — defaulted off so smoke render is clean.
+images:
+  kubectl:
+    repository: "bitnami/kubectl"
+    tag: "1.31"
+  git:
+    repository: "alpine/git"
+    tag: "v2.45.2"
+  curl:
+    repository: "curlimages/curl"
+    tag: "8.10.1"
+  # registry-pivot writes to /etc/rancher/k3s/registries.yaml on every
+  # node. Uses bitnami/kubectl (already present in the platform fleet)
+  # plus a `chroot /host` invocation pattern.
+  hostExec:
+    repository: "alpine"
+    tag: "3.20"
+
+# registry-pivot DaemonSet — runs from chart install to converge
+# /etc/rancher/k3s/registries.yaml on every node. The DaemonSet starts
+# DORMANT (writes the v1 cold-start file) and only flips to v2 when
+# catalyst-api updates the cutover-status ConfigMap key
+# `registriesYamlActive` to "v2" — see template 04-registry-pivot-daemonset.yaml.
+# Operators can disable the always-on DaemonSet shape via overlay; in
+# that case catalyst-api stamps the DaemonSet on demand at trigger time.
+registryPivot:
+  enabled: true
+
+# CiliumNetworkPolicy for step 08 (egress-block-test). Operator
+# overrides duration via overlay if 10 min isn't enough.
+egressTest:
+  durationSeconds: 600
+  blockedDomains:
+    - "github.com"
+    - "ghcr.io"
+    - "harbor.openova.io"
+
+# Status sentinel ConfigMap — initial state machine state. catalyst-api
+# updates the per-step fields as each Job completes.
+status:
+  configMapName: "self-sovereign-cutover-status"
+
+# Per-step Job-stamp tuning. Each value lands inside the corresponding
+# PodSpec ConfigMap; catalyst-api copies it onto the stamped Job.
+stepTimeouts:
+  giteaMirrorSeconds: 1200
+  harborProjectsSeconds: 600
+  harborPrewarmSeconds: 1800
+  fluxGitRepositoryPatchSeconds: 600
+  helmRepositoryPatchesSeconds: 600
+  catalystAPIEnvPatchSeconds: 600
+  egressBlockTestSeconds: 900   # 600 deny + buffer for assert sweep
+
+# Trigger configuration — surface here so operators see it in
+# `helm get values`. The chart itself does NOT auto-fire; catalyst-api
+# reads .Values.trigger.auto and either waits for operator click or
+# auto-fires after first successful operator login.
+trigger:
+  # default false: operator must explicitly click "Achieve True
+  # Sovereignty" in admin console.
+  auto: false
+  # When auto=true, fire N seconds after the first successful operator
+  # login on the new Sovereign. Ignored when auto=false.
+  autoDelaySeconds: 0

--- a/scripts/expected-bootstrap-deps.yaml
+++ b/scripts/expected-bootstrap-deps.yaml
@@ -159,6 +159,15 @@ slots:
     # gateway.networking.k8s.io/v1 CRDs must be registered first.
     depends_on: [bp-cnpg, bp-cert-manager, bp-gateway-api]
     wave: W2.K1
+  - slot: 6a
+    name: bp-self-sovereign-cutover
+    # Post-handover self-sovereignty cutover (issue #791). Filename
+    # carries the 06a- prefix to colocate cohorts visually but the slot
+    # depends on bp-gitea + bp-harbor and therefore actually installs
+    # AFTER both. Chart ships dormant — catalyst-api stamps Jobs from
+    # the chart's PodSpec ConfigMaps only on operator-driven trigger.
+    depends_on: [bp-gitea, bp-harbor]
+    wave: W2.K1
 
   # ---- Tier 6: observability (W2.K2, slots 20-26) ---------------------------
   - slot: 20


### PR DESCRIPTION
## Summary

- New platform Blueprint at `platform/self-sovereign-cutover/chart/` (version 0.1.0) — installs DORMANT and ships eight step PodSpec ConfigMaps + the registry-pivot DaemonSet + the mutable `self-sovereign-cutover-status` ConfigMap + ServiceAccount/RBAC. The catalyst-api cutover endpoint (#792, merged at 03828641) reads each step ConfigMap by label selector and stamps real Jobs only on operator-driven trigger.
- Bootstrap-kit slot `clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml` installs the chart into the `catalyst` namespace (matches catalyst-api's default discovery namespace), depends on `bp-gitea` + `bp-harbor`, uses `disableWait: true`.
- `scripts/expected-bootstrap-deps.yaml` registers slot 6a with `depends_on: [bp-gitea, bp-harbor]`.
- RBAC splits `create` verbs into their own Rule WITHOUT `resourceNames` per `feedback_rbac_create_no_resourcenames.md` — the bp-openbao loop anchor.

## Step inventory (label `app.kubernetes.io/component=cutover-step`)

| # | Resource | Mode | Description |
|---|---|---|---|
| 01 | `cutover-step-01-gitea-mirror` | job | `git push --mirror` upstream → local Gitea |
| 02 | `cutover-step-02-harbor-projects` | job | Create 7 proxy-cache projects in local Harbor |
| 03 | `cutover-step-03-harbor-prewarm` | job | HEAD-pull bootstrap-kit images through proxy-cache |
| 04 | `cutover-step-04-registry-pivot` + DaemonSet | daemonset-wait | Per-node reconcile loop; writes `/etc/rancher/k3s/registries.yaml` v2 once status flips |
| 05 | `cutover-step-05-flux-gitrepository-patch` | job | Patch `flux-system/openova` GitRepository.url → local Gitea |
| 06 | `cutover-step-06-helmrepository-patches` | job | Patch all 38 OCI HelmRepositories → `oci://harbor.<sov-fqdn>/openova-io` |
| 07 | `cutover-step-07-catalyst-api-env-patch` | job | `kubectl set env deploy/catalyst-api CATALYST_GITOPS_REPO_URL=...` |
| 08 | `cutover-step-08-egress-block-test` | job | CiliumNetworkPolicy denies upstream egress for 10 min, asserts cluster stays Ready |

## Render proof

```
$ helm lint platform/self-sovereign-cutover/chart
==> Linting platform/self-sovereign-cutover/chart
[INFO] Chart.yaml: icon is recommended
1 chart(s) linted, 0 chart(s) failed

$ helm template smoke platform/self-sovereign-cutover/chart \
    --set sovereign.fqdn=otechN.omani.works \
    --set sovereign.harborPublicURL=https://harbor.otechN.omani.works \
    --set sovereign.giteaPublicURL=https://gitea.otechN.omani.works \
  | grep -E '^kind:' | sort | uniq -c
      1 kind: ClusterRole
      1 kind: ClusterRoleBinding
     11 kind: ConfigMap
      1 kind: DaemonSet
      1 kind: Namespace
      1 kind: ServiceAccount

$ bash platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
[cutover-contract] All gates green.

$ bash scripts/check-bootstrap-deps.sh | tail -5
  Drift:                 0
  Cycles:                0
OK: bootstrap-kit dependency graph audit PASSED
```

## Test plan

- [ ] `Blueprint Release` workflow publishes `oci://ghcr.io/openova-io/bp-self-sovereign-cutover:0.1.0` (cosigned, SBOM attested) — guards 1/2/3 + smoke render + chart-test gate must all pass
- [ ] `crane manifest oci://ghcr.io/openova-io/bp-self-sovereign-cutover:0.1.0` returns the published manifest after merge
- [ ] On a fresh Sovereign post-handover, `kubectl get cm -n catalyst -l app.kubernetes.io/part-of=self-sovereign-cutover,app.kubernetes.io/component=cutover-step` returns 8 step ConfigMaps in order 1..8
- [ ] `kubectl get ds -n catalyst registry-pivot` is Ready on every node before catalyst-api stamps step 04
- [ ] Operator click on "Achieve True Sovereignty" (post-#793 UI) runs the 8-step engine end-to-end, status ConfigMap shows `cutoverComplete: true`, egress-block-test PASSES with all reconciles staying Ready

## Constraints honoured

- Inviolable Principle #3 IaC-first — every cluster mutation goes via in-cluster K8s API
- Inviolable Principle #4 never hardcode — sovereign FQDN / Harbor URL / Gitea URL all flow via overlay
- Inviolable Principle #10 credential hygiene — secret values referenced via `secretKeyRef`, never echoed
- Anti-duplication — this chart is the canonical seam; consumer contract aligned to #792 (merged)
- RBAC anchor — `create` verbs split to a separate Rule without `resourceNames`

Closes #791.
Refs #790, #792, #794 (ADR-0002).

🤖 Generated with [Claude Code](https://claude.com/claude-code)