### PR TITLE
feat(bp-openclaw): workspace controller + per-user pod chart (#803)

### DIFF
--- a/.github/workflows/openclaw-runtime.yaml
+++ b/.github/workflows/openclaw-runtime.yaml
@@ -1,0 +1,121 @@
+# Build openclaw-runtime — per-user pod image consumed by bp-openclaw.
+#
+# Per Inviolable Principle 1 (event-driven, never schedule:cron) and per
+# Inviolable Principle 4 (never floating tags in production), this
+# workflow:
+#   - Triggers on push to platform/openclaw/runtime/** on main.
+#   - Tags the image with the short SHA of the triggering commit.
+#   - Provides workflow_dispatch ONLY for re-running an existing commit
+#     without a code change (per the 2026-05-01 lesson in CLAUDE.md).
+#
+# Output: ghcr.io/openova-io/openova/openclaw-runtime:<sha>
+#
+# Tracking: openova-io/openova#803 (SME-4 bp-openclaw)
+
+name: Build openclaw-runtime
+
+on:
+  push:
+    paths:
+      - 'platform/openclaw/runtime/**'
+      - '.github/workflows/openclaw-runtime.yaml'
+    branches: [main]
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE: ghcr.io/openova-io/openova/openclaw-runtime
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set short SHA
+        id: vars
+        run: echo "sha_short=$(echo $GITHUB_SHA | head -c 7)" >> "$GITHUB_OUTPUT"
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build image (load for smoke test)
+        uses: docker/build-push-action@v6
+        with:
+          context: platform/openclaw/runtime
+          file: platform/openclaw/runtime/Dockerfile
+          push: false
+          load: true
+          tags: ${{ env.IMAGE }}:test
+
+      - name: Smoke test (FATAL when env vars missing)
+        run: |
+          # The runtime is contractually required to refuse to start
+          # without NEWAPI_BASE_URL + NEWAPI_KEY. Verify the FATAL
+          # message fires.
+          if docker run --rm ${{ env.IMAGE }}:test 2>&1 | grep -q "FATAL: NEWAPI_BASE_URL and NEWAPI_KEY"; then
+            echo "Runtime correctly refuses to start without env vars."
+          else
+            echo "FAIL: runtime did NOT print FATAL when env vars missing"
+            docker run --rm ${{ env.IMAGE }}:test || true
+            exit 1
+          fi
+
+      - name: Smoke test (runs with env vars)
+        run: |
+          # Verify the runtime starts cleanly and serves /healthz when
+          # env vars are present.
+          docker run -d --name openclaw-smoke \
+            -p 18080:8080 \
+            -e NEWAPI_BASE_URL=http://localhost:9999 \
+            -e NEWAPI_KEY=sk-smoke-test \
+            ${{ env.IMAGE }}:test
+          # Wait for listener.
+          for i in $(seq 1 10); do
+            if curl -sf http://127.0.0.1:18080/healthz > /dev/null; then
+              echo "healthz OK"
+              break
+            fi
+            sleep 1
+          done
+          if ! curl -sf http://127.0.0.1:18080/healthz > /dev/null; then
+            echo "FAIL: /healthz did not respond"
+            docker logs openclaw-smoke
+            docker stop openclaw-smoke
+            exit 1
+          fi
+          # Exercise the index page.
+          curl -sf http://127.0.0.1:18080/ | grep -q "OpenClaw runtime" || {
+            echo "FAIL: index page missing expected marker"
+            docker stop openclaw-smoke
+            exit 1
+          }
+          docker stop openclaw-smoke
+          echo "Smoke OK: container starts, /healthz responds, / serves landing."
+
+      - name: Push image (SHA-pinned tag only)
+        uses: docker/build-push-action@v6
+        with:
+          context: platform/openclaw/runtime
+          file: platform/openclaw/runtime/Dockerfile
+          push: true
+          # SHA-pinned tag ONLY. Per Inviolable Principle 4, do NOT
+          # publish a `:latest` for production-consumed images — every
+          # consumer pins to a specific SHA.
+          tags: |
+            ${{ env.IMAGE }}:${{ steps.vars.outputs.sha_short }}
+
+      - name: Summary
+        run: |
+          echo "openclaw-runtime built and pushed" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Image: \`${{ env.IMAGE }}:${{ steps.vars.outputs.sha_short }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Commit: \`${{ github.sha }}\`" >> "$GITHUB_STEP_SUMMARY"

--- a/platform/openclaw/README.md
+++ b/platform/openclaw/README.md
@@ -1,0 +1,182 @@
+# bp-openclaw — workspace controller + per-user pod
+
+Catalyst Blueprint for OpenClaw: a multi-tenant **workspace controller**
+deployment plus per-user **runtime pods** spawned on demand. Implements
+locked decision **[A]** of epic [#795](https://github.com/openova-io/openova/issues/795)
+and consumes the per-user `newapi-key-{user-uuid}` Secrets rendered by the
+unified-rbac user-create hook ([ADR-0003](../../docs/adr/0003-rbac-newapi-user-create-hook.md)).
+
+---
+
+## Architecture
+
+```
+                       openclaw.<sme-domain>            (Traefik ingress + cert-manager TLS)
+                              │
+                              ▼
+              ┌──────────────────────────────────┐
+              │  Controller Deployment (HA-able) │
+              │  - validates SME Keycloak JWT    │
+              │  - spawns / proxies / reaps      │
+              │    per-user pods                 │
+              └─────┬───────────────────┬────────┘
+                    │  K8s API           │  WebSocket / SSE proxy
+                    ▼                    ▼
+        ┌─────────────────────┐    ┌──────────────────────┐
+        │  newapi-key-{uuid}  │    │  Per-user runtime    │
+        │  Secret (per ADR-3) │    │  Pod (one per active │
+        │  - api-key          │◀───│  session). Reads     │
+        │  - base-url         │    │  NEWAPI_BASE_URL +   │
+        └─────────────────────┘    │  NEWAPI_KEY env. NO  │
+                                   │  Keycloak code, NO   │
+                                   │  key-mgmt code.      │
+                                   └──────────────────────┘
+```
+
+**Why this shape (and not the rejected alternative).** A "shared OpenClaw
+service forwarding the SME-vcluster JWT to NewAPI" was explicitly rejected
+in #795: it would force NewAPI to trust a Keycloak realm it has no
+ownership of (cross-realm OIDC trust = identity sprawl). The workspace-
+controller pattern keeps NewAPI talking only to its own keys (one per SME
+end-user), and the controller is the *only* component that ever sees a
+JWT from the SME's Keycloak realm.
+
+This pattern generalises to bp-opencode / bp-aider / bp-cursor-server
+later — the chart's structure (controller + per-user pod + identity-
+blind runtime image) is intentionally reusable.
+
+---
+
+## What this chart contains
+
+| File | Purpose |
+|---|---|
+| `Chart.yaml` | Metadata; `catalyst.openova.io/no-upstream: "true"` (no upstream Helm chart) |
+| `values.yaml` | All operator-tunable values; assertions in `_helpers.tpl` fail render with helpful messages when required values are missing |
+| `templates/_helpers.tpl` | Naming / labels / required-value assertions |
+| `templates/serviceaccount.yaml` | Controller ServiceAccount (release ns) |
+| `templates/controller-rbac.yaml` | Namespaced `Role` + `RoleBinding` in **tenant** ns. `create` verbs split into separate rules WITHOUT `resourceNames` per `feedback_rbac_create_no_resourcenames.md` |
+| `templates/controller-deployment.yaml` | Multi-tenant controller pod |
+| `templates/controller-service.yaml` | ClusterIP Service for the controller |
+| `templates/controller-ingress.yaml` | Public hostname `openclaw.<sme-domain>` with cert-manager auto-issue |
+| `templates/per-user-pod-template.yaml` | ConfigMap holding the pod-spec the controller renders per session |
+| `templates/networkpolicy.yaml` | Controller NetworkPolicy. The per-user pod's NetworkPolicy is rendered by the controller at session-start (see "Per-user pod NetworkPolicy" below) |
+| `runtime/` | Source for the per-user runtime container image (separate OCI artifact, built by `.github/workflows/openclaw-runtime.yaml`) |
+| `tests/render-toggles.sh` | Helm-template integration test exercised by the blueprint-release CI workflow |
+
+---
+
+## Required overlay values
+
+The chart fails to render if any of these are unset (see
+`_helpers.tpl :: assertRequired`):
+
+| Value | Example |
+|---|---|
+| `keycloak.realmURL` | `https://keycloak.acme.<otech-fqdn>/realms/acme` |
+| `keycloak.clientSecretName` | `openclaw-oidc` (ExternalSecret with key `OIDC_CLIENT_SECRET`) |
+| `tenant.namespace` | `sme-acme` |
+| `newapi.baseURL` | `https://newapi.<otech-fqdn>` |
+| `controller.image.tag` | SHA-pinned tag (Inviolable Principle 4) |
+| `perUserPod.image.tag` | SHA-pinned tag (Inviolable Principle 4) |
+| `ingress.host` | `openclaw.acme.<otech-fqdn>` |
+
+---
+
+## Runtime image contract
+
+Per locked decision [A] of #795, the per-user runtime image reads **only
+two env vars**:
+
+| Env | Source |
+|---|---|
+| `NEWAPI_BASE_URL` | `secretKeyRef: name=newapi-key-{uuid}, key=base-url` |
+| `NEWAPI_KEY` | `secretKeyRef: name=newapi-key-{uuid}, key=api-key` |
+
+It carries **no Keycloak code, no key-management code, no knowledge of
+the SME tenant model**. Identity-blind by construction.
+
+The `runtime/` directory in this Blueprint ships a minimal reference
+implementation that satisfies the contract: a Go binary exposing an
+HTTP `/healthz` and a `/v1/chat/completions` proxy that forwards to
+NewAPI with the injected key. Operators may override
+`perUserPod.image.repository` to point at any other image satisfying the
+same env-vars contract — e.g. a fork of upstream OpenClaw, an
+OpenAI-compatible coding-CLI image, etc.
+
+### Why a stub instead of the upstream OpenClaw
+
+Upstream `OpenClaw` (https://openclaw.ai) targets messaging-platform
+integration (WhatsApp / Telegram / Slack) — a different shape from the
+"per-user agentic workspace" that #795 calls for. There's no upstream
+Helm chart, and the upstream container expects a wholly different
+configuration surface (no `NEWAPI_BASE_URL` env). Rather than fork the
+upstream and graft a NewAPI driver onto it (significant work, owned by
+a different ticket), this Blueprint ships a contract-minimal runtime:
+identity-blind, two env vars, OpenAI-compatible proxy. Future work can
+swap the runtime image without changing this chart.
+
+---
+
+## RBAC posture
+
+The controller's `Role` lives in the **tenant** namespace (where the
+per-user pods and Secrets live), not the release namespace. The
+`RoleBinding` subject is the controller's ServiceAccount in the release
+namespace.
+
+`create` verbs are **split into their own rules** with no
+`resourceNames`. This is mandatory: the K8s authorizer rejects `create`
+combined with `resourceNames` (you can't constrain a not-yet-existing
+resource by name). Label-based ownership (`catalyst.openova.io/openclaw-user`)
+is enforced at the controller, not in RBAC. See
+`feedback_rbac_create_no_resourcenames.md` for the full incident report.
+
+---
+
+## Per-user pod NetworkPolicy
+
+This chart's `networkpolicy.yaml` covers the **controller** pod only.
+Each per-user pod gets its own NetworkPolicy applied by the controller
+at session-start, restricting egress to:
+
+- NewAPI (operator's customer-facing hostname or in-cluster Service)
+- DNS (kube-system :53)
+
+The per-user pod NetworkPolicy is rendered by the controller from a
+template baked into its container image; it cannot be a static chart
+template because the egress target (specifically the NewAPI hostname)
+is read from the per-user `newapi-key-{uuid}` Secret, which doesn't
+exist at chart-render time.
+
+---
+
+## Build + publish
+
+The chart is built and published by the existing event-driven CI
+workflow `.github/workflows/blueprint-release.yaml` whenever
+`platform/openclaw/chart/**` changes on `main`. Output:
+
+```
+oci://ghcr.io/openova-io/bp-openclaw:0.1.0
+```
+
+The runtime image is built by a sister workflow,
+`.github/workflows/openclaw-runtime.yaml`, on push to
+`platform/openclaw/runtime/**`. Output:
+
+```
+ghcr.io/openova-io/openova/openclaw-runtime:<sha>
+```
+
+Per Inviolable Principle 1, both workflows are event-driven; neither
+uses `schedule:` cron. `workflow_dispatch` is provided for re-runs only.
+
+---
+
+## Related
+
+- Epic [#795](https://github.com/openova-io/openova/issues/795) — SME-tenant turnkey experience
+- ADR-0003 — RBAC ↔ NewAPI user-create hook
+- bp-newapi (`platform/newapi/`) — Sovereign-level metered LLM gateway
+- bp-keycloak (`platform/keycloak/`) — SME-vcluster realm

--- a/platform/openclaw/blueprint.yaml
+++ b/platform/openclaw/blueprint.yaml
@@ -1,0 +1,124 @@
+apiVersion: catalyst.openova.io/v1alpha1
+kind: Blueprint
+metadata:
+  name: bp-openclaw
+  labels:
+    catalyst.openova.io/category: ai-runtime
+    catalyst.openova.io/section: pts-4-7-agentic-workspace
+spec:
+  version: 0.1.0
+  card:
+    title: OpenClaw
+    summary: |
+      Per-user agentic workspace for SME tenants. A multi-tenant
+      controller deployment in the SME tenant namespace authenticates
+      end users via the SME-vcluster Keycloak realm and spawns one
+      runtime pod per active session. Each runtime pod reads ONLY two
+      env vars (NEWAPI_BASE_URL + NEWAPI_KEY) mounted from the per-user
+      `newapi-key-{uuid}` Secret rendered by the unified-rbac user-create
+      hook (ADR-0003). Identity-blind by construction.
+    icon: openclaw.svg
+    category: ai-runtime
+    tags: [openclaw, agentic, workspace, sme, keycloak, newapi, multi-tenant, per-user-pod]
+    documentation: https://github.com/openova-io/openova/blob/main/platform/openclaw/README.md
+    license: Apache-2.0
+  visibility: listed
+  owner:
+    team: ai-platform
+    contact: ai-platform@openova.io
+  configSchema:
+    type: object
+    required: [keycloak, tenant, newapi, ingress]
+    properties:
+      controller:
+        type: object
+        properties:
+          replicas:
+            type: integer
+            default: 1
+            minimum: 1
+            maximum: 5
+          image:
+            type: object
+            required: [tag]
+            properties:
+              tag:
+                type: string
+                description: SHA-pinned tag for the controller image (operator-supplied).
+      keycloak:
+        type: object
+        required: [realmURL, clientSecretName]
+        properties:
+          realmURL:
+            type: string
+            description: Full SME-vcluster Keycloak realm issuer URL (e.g. https://keycloak.acme.example/realms/acme).
+          clientID:
+            type: string
+            default: openclaw
+          clientSecretName:
+            type: string
+            description: ExternalSecret name carrying OIDC_CLIENT_SECRET.
+      newapi:
+        type: object
+        required: [baseURL]
+        properties:
+          baseURL:
+            type: string
+            description: NewAPI customer-facing hostname (e.g. https://newapi.<otech-fqdn>).
+      tenant:
+        type: object
+        required: [namespace]
+        properties:
+          namespace:
+            type: string
+            description: SME tenant namespace where per-user pods are spawned and newapi-key-{uuid} Secrets are read.
+      perUserPod:
+        type: object
+        properties:
+          image:
+            type: object
+            required: [tag]
+            properties:
+              tag:
+                type: string
+                description: SHA-pinned tag for the runtime image (operator-supplied).
+          idleTimeoutMinutes:
+            type: integer
+            default: 30
+            minimum: 1
+            maximum: 480
+            description: Reaper deletes per-user pods idle for longer than this.
+      ingress:
+        type: object
+        required: [host]
+        properties:
+          host:
+            type: string
+            description: Controller public hostname (e.g. openclaw.<sme-domain>).
+          tls:
+            type: object
+            properties:
+              issuer:
+                type: string
+                default: letsencrypt-prod
+                description: cert-manager ClusterIssuer.
+  placementSchema:
+    modes: [single-region]
+    default: single-region
+  manifests:
+    chart: ./chart
+  depends:
+    - blueprint: bp-newapi
+      version: ^1.0
+      alias: gateway
+    - blueprint: bp-keycloak
+      version: ^1.0
+      alias: idp
+    - blueprint: bp-cert-manager
+      version: ^1.0
+      alias: tls
+  upgrades:
+    from: []
+  observability:
+    metrics: prometheus
+    logs: stdout

--- a/platform/openclaw/chart/Chart.yaml
+++ b/platform/openclaw/chart/Chart.yaml
@@ -1,0 +1,48 @@
+apiVersion: v2
+name: bp-openclaw
+version: 0.1.0
+appVersion: "0.1.0"
+description: |
+  Catalyst Blueprint chart for the OpenClaw workspace controller pattern
+  — a multi-tenant controller deployment in an SME tenant namespace plus
+  per-user runtime pods spawned on demand. Implements decision [A] of
+  epic #795 (locked) and the user-side of ADR-0003 (consumes the
+  `newapi-key-{user-uuid}` Secrets rendered by the unified-rbac hook).
+
+  Deployment shape:
+    - One controller Deployment per SME tenant namespace. Authenticates
+      end users via the SME-vcluster Keycloak realm (OIDC) and validates
+      the JWT signature + sub claim before spawning a per-user pod.
+    - Per-user pods carry only two env vars (NEWAPI_BASE_URL, NEWAPI_KEY)
+      mounted from the per-user Secret labelled
+      `catalyst.openova.io/sme-user-uuid=<uuid>`. The runtime image is
+      identity-blind: no Keycloak code, no key-management code.
+
+  This chart ships ZERO upstream Helm subchart bytes — there is no
+  upstream OpenClaw Helm chart. The runtime image
+  (ghcr.io/openova-io/openova/openclaw-runtime) is built by the existing
+  event-driven CI workflow off platform/openclaw/runtime/ and pinned by
+  SHA in the consuming overlay (per Inviolable Principle 4 — never use
+  floating tags in production manifests).
+
+  Pairs with bp-newapi (Sovereign-level metered LLM gateway), bp-keycloak
+  (SME-vcluster realm), bp-cert-manager (per-host TLS).
+
+type: application
+keywords: [catalyst, blueprint, openclaw, sme, workspace-controller, per-user-pod, llm, agent]
+maintainers:
+  - name: OpenOva Catalyst
+    email: catalyst@openova.io
+
+# No upstream Helm chart — every byte of this Blueprint is Catalyst-
+# authored. The blueprint-release workflow's hollow-chart guard
+# (issue #181) requires either a `dependencies:` block OR this
+# annotation; we use the annotation. The runtime container image is a
+# separate OCI artifact built via .github/workflows/openclaw-runtime.yaml
+# (event-driven on push to platform/openclaw/runtime/**), not a Helm
+# subchart.
+annotations:
+  catalyst.openova.io/no-upstream: "true"
+  catalyst.openova.io/depends-on: "bp-newapi,bp-keycloak,bp-cert-manager"
+  catalyst.openova.io/owner-epic: "795"
+  catalyst.openova.io/adr: "0003"

--- a/platform/openclaw/chart/templates/_helpers.tpl
+++ b/platform/openclaw/chart/templates/_helpers.tpl
@@ -1,0 +1,107 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "bp-openclaw.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "bp-openclaw.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Common labels — required by docs/BLUEPRINT-AUTHORING.md §14 and by the
+Catalyst projector to track resources back to the Blueprint.
+*/}}
+{{- define "bp-openclaw.labels" -}}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+app.kubernetes.io/name: {{ include "bp-openclaw.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+catalyst.openova.io/blueprint: bp-openclaw
+{{- end }}
+
+{{/*
+Selector labels.
+*/}}
+{{- define "bp-openclaw.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "bp-openclaw.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+ServiceAccount name.
+*/}}
+{{- define "bp-openclaw.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "bp-openclaw.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+ConfigMap name (per-user pod template).
+*/}}
+{{- define "bp-openclaw.podTemplateConfigMapName" -}}
+{{- printf "%s-pod-template" (include "bp-openclaw.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Tenant namespace — falls back to .Release.Namespace if tenant.namespace
+is unset, but we prefer an explicit value so the controller's RBAC scope
+matches the operator's intent.
+*/}}
+{{- define "bp-openclaw.tenantNamespace" -}}
+{{- default .Release.Namespace .Values.tenant.namespace }}
+{{- end }}
+
+{{/*
+Render-time assertions for required values. Fail loudly when the
+controller or per-user pod template is enabled but missing a value the
+operator MUST supply (Inviolable Principle 4 — never hardcode, but ALSO
+never silently default to a placeholder that would make the runtime
+malfunction).
+*/}}
+{{- define "bp-openclaw.assertRequired" -}}
+{{- if .Values.controller.enabled }}
+{{- if not .Values.keycloak.realmURL }}
+{{- fail "keycloak.realmURL is required when controller.enabled=true (full SME-vcluster Keycloak realm issuer URL, e.g. https://keycloak.<sme-domain>/realms/<realm>)" }}
+{{- end }}
+{{- if not .Values.keycloak.clientSecretName }}
+{{- fail "keycloak.clientSecretName is required when controller.enabled=true (ExternalSecret name carrying OIDC_CLIENT_SECRET)" }}
+{{- end }}
+{{- if not .Values.tenant.namespace }}
+{{- fail "tenant.namespace is required when controller.enabled=true (SME tenant namespace where per-user pods are spawned and newapi-key-{uuid} Secrets are read)" }}
+{{- end }}
+{{- if not .Values.newapi.baseURL }}
+{{- fail "newapi.baseURL is required when controller.enabled=true (NewAPI customer-facing hostname, e.g. https://newapi.<otech-fqdn>)" }}
+{{- end }}
+{{- if not .Values.controller.image.tag }}
+{{- fail "controller.image.tag is required when controller.enabled=true (SHA-pinned tag — never use floating tags per Inviolable Principle 4)" }}
+{{- end }}
+{{- if not .Values.perUserPod.image.tag }}
+{{- fail "perUserPod.image.tag is required when controller.enabled=true (SHA-pinned tag — never use floating tags per Inviolable Principle 4)" }}
+{{- end }}
+{{- if .Values.ingress.enabled }}
+{{- if not .Values.ingress.host }}
+{{- fail "ingress.host is required when ingress.enabled=true (controller public hostname, e.g. openclaw.<sme-domain>)" }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/platform/openclaw/chart/templates/controller-deployment.yaml
+++ b/platform/openclaw/chart/templates/controller-deployment.yaml
@@ -1,0 +1,107 @@
+{{- if .Values.controller.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "bp-openclaw.fullname" . }}-controller
+  labels:
+    {{- include "bp-openclaw.labels" . | nindent 4 }}
+    catalyst.openova.io/component: controller
+spec:
+  replicas: {{ .Values.controller.replicas }}
+  selector:
+    matchLabels:
+      {{- include "bp-openclaw.selectorLabels" . | nindent 6 }}
+      catalyst.openova.io/component: controller
+  template:
+    metadata:
+      labels:
+        {{- include "bp-openclaw.selectorLabels" . | nindent 8 }}
+        catalyst.openova.io/component: controller
+      annotations:
+        # Roll the pod when the per-user pod-spec template changes so
+        # newly-spawned per-user pods always reflect overlay edits.
+        checksum/pod-template: {{ include (print $.Template.BasePath "/per-user-pod-template.yaml") . | sha256sum }}
+    spec:
+      serviceAccountName: {{ include "bp-openclaw.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.controller.securityContext | nindent 8 }}
+      containers:
+        - name: controller
+          image: "{{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag }}"
+          imagePullPolicy: {{ .Values.controller.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.controller.port }}
+              protocol: TCP
+          env:
+            # ── Identity: SME-vcluster Keycloak realm ─────────────────
+            - name: KEYCLOAK_REALM_URL
+              value: {{ required "keycloak.realmURL is required" .Values.keycloak.realmURL | quote }}
+            - name: KEYCLOAK_CLIENT_ID
+              value: {{ .Values.keycloak.clientID | quote }}
+            - name: KEYCLOAK_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ required "keycloak.clientSecretName is required" .Values.keycloak.clientSecretName }}
+                  key: OIDC_CLIENT_SECRET
+
+            # ── Tenant placement for per-user pods ────────────────────
+            - name: TENANT_NAMESPACE
+              value: {{ include "bp-openclaw.tenantNamespace" . | quote }}
+
+            # ── NewAPI customer-facing base URL (fallback default) ───
+            # Authoritative value per ADR-0003 §3.3 lives on each
+            # `newapi-key-{uuid}` Secret as `base-url`. The controller
+            # reads that field; this env is the chart-render-time
+            # fallback for overlays that haven't yet been migrated.
+            - name: NEWAPI_BASE_URL_DEFAULT
+              value: {{ required "newapi.baseURL is required" .Values.newapi.baseURL | quote }}
+
+            # ── Per-user pod template ConfigMap reference ─────────────
+            - name: POD_TEMPLATE_CONFIGMAP
+              value: {{ include "bp-openclaw.podTemplateConfigMapName" . | quote }}
+            - name: POD_TEMPLATE_NAMESPACE
+              value: {{ .Release.Namespace | quote }}
+
+            # ── Idle-session reaper interval ──────────────────────────
+            - name: IDLE_TIMEOUT_MINUTES
+              value: {{ .Values.perUserPod.idleTimeoutMinutes | quote }}
+
+            # ── Listen port ───────────────────────────────────────────
+            - name: PORT
+              value: {{ .Values.controller.port | quote }}
+
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.controller.probes.liveness.path }}
+              port: {{ .Values.controller.probes.liveness.port }}
+            initialDelaySeconds: {{ .Values.controller.probes.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.controller.probes.liveness.periodSeconds }}
+            timeoutSeconds: {{ .Values.controller.probes.liveness.timeoutSeconds }}
+            failureThreshold: {{ .Values.controller.probes.liveness.failureThreshold }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.controller.probes.readiness.path }}
+              port: {{ .Values.controller.probes.readiness.port }}
+            initialDelaySeconds: {{ .Values.controller.probes.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.controller.probes.readiness.periodSeconds }}
+            timeoutSeconds: {{ .Values.controller.probes.readiness.timeoutSeconds }}
+            failureThreshold: {{ .Values.controller.probes.readiness.failureThreshold }}
+
+          resources:
+            {{- toYaml .Values.controller.resources | nindent 12 }}
+
+          volumeMounts:
+            - name: pod-template
+              mountPath: /etc/openclaw
+              readOnly: true
+            - name: tmp
+              mountPath: /tmp
+
+      volumes:
+        - name: pod-template
+          configMap:
+            name: {{ include "bp-openclaw.podTemplateConfigMapName" . }}
+        - name: tmp
+          emptyDir: {}
+{{- end }}

--- a/platform/openclaw/chart/templates/controller-ingress.yaml
+++ b/platform/openclaw/chart/templates/controller-ingress.yaml
@@ -1,0 +1,40 @@
+{{- if and .Values.controller.enabled .Values.ingress.enabled }}
+{{- $fullName := include "bp-openclaw.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- $host := required "ingress.host is required (controller public hostname, e.g. openclaw.<sme-domain>)" .Values.ingress.host -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}-controller
+  labels:
+    {{- include "bp-openclaw.labels" . | nindent 4 }}
+    catalyst.openova.io/component: controller
+  annotations:
+    traefik.ingress.kubernetes.io/router.entrypoints: websecure
+    traefik.ingress.kubernetes.io/router.tls: "true"
+    {{- if .Values.ingress.tls.enabled }}
+    cert-manager.io/cluster-issuer: {{ .Values.ingress.tls.issuer | quote }}
+    {{- end }}
+    {{- with .Values.ingress.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- if .Values.ingress.tls.enabled }}
+  tls:
+    - hosts:
+        - {{ $host }}
+      secretName: {{ .Values.ingress.tls.secretName }}
+  {{- end }}
+  rules:
+    - host: {{ $host }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ $fullName }}-controller
+                port:
+                  number: {{ $svcPort }}
+{{- end }}

--- a/platform/openclaw/chart/templates/controller-rbac.yaml
+++ b/platform/openclaw/chart/templates/controller-rbac.yaml
@@ -1,0 +1,89 @@
+{{- if .Values.controller.enabled }}
+{{- $fullName := include "bp-openclaw.fullname" . -}}
+{{- $tenantNs := include "bp-openclaw.tenantNamespace" . -}}
+---
+# ─── Controller Role (namespaced — tenant ns only) ───────────────────────
+# Minimum-RBAC scoping per ADR-0003 §3.3 + Inviolable Principle 7
+# (tenancy is K8s-native; no cluster-scoped roles for tenant work).
+#
+# Per feedback_rbac_create_no_resourcenames.md (2026-05-03 root cause of
+# bp-openbao 6+ provisioning loops): the K8s authorizer REJECTS Roles
+# that combine the `create` verb with a `resourceNames` selector — POSTs
+# return 403 because resourceNames cannot apply to a not-yet-existing
+# resource. We therefore split the rules:
+#
+#   Rule 1 — read user-key Secrets (get/list/watch ONLY, with a label
+#            selector enforced at controller side, NOT in RBAC).
+#   Rule 2 — get/list/watch/delete pods labelled
+#            catalyst.openova.io/openclaw-user (no create here).
+#   Rule 3 — CREATE pods (NO resourceNames).
+#   Rule 4 — CREATE secrets (NO resourceNames) — needed if the
+#            controller ever materialises a runtime-side Secret; kept
+#            narrow.
+#
+# resourceNames CANNOT be used to constrain `create` regardless; the
+# controller enforces label-based ownership at the application layer
+# when reading Secrets and when deleting Pods.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ $fullName }}-controller
+  namespace: {{ $tenantNs }}
+  labels:
+    {{- include "bp-openclaw.labels" . | nindent 4 }}
+rules:
+  # Rule 1 — read per-user NewAPI key Secrets.
+  # The controller selects by label
+  # `catalyst.openova.io/sme-user-uuid=<uuid>` at the API call boundary
+  # (via List with a labelSelector); RBAC permits get/list/watch on all
+  # secrets in the namespace, but the controller code path NEVER reads
+  # an unlabelled Secret.
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "watch"]
+
+  # Rule 2 — manage existing per-user pods (no create).
+  # The controller deletes a pod when its owning session ends or the
+  # idle-timeout fires.
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch", "delete"]
+
+  # Rule 3 — CREATE pods. SPLIT INTO ITS OWN RULE WITHOUT resourceNames.
+  # Per feedback_rbac_create_no_resourcenames.md (2026-05-03):
+  # combining `create` with resourceNames produces a 403 every time —
+  # resourceNames cannot constrain a not-yet-existing resource. Label-
+  # based ownership is enforced at the controller, not in RBAC.
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["create"]
+
+  # Rule 4 — CREATE pods/exec subresource (used to proxy the user's
+  # interactive shell into the runtime container). Split per the same
+  # rule as Rule 3.
+  - apiGroups: [""]
+    resources: ["pods/exec"]
+    verbs: ["create"]
+
+  # Rule 5 — read pod logs (for the controller's log-streaming endpoint
+  # when the per-user runtime is non-interactive).
+  - apiGroups: [""]
+    resources: ["pods/log"]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ $fullName }}-controller
+  namespace: {{ $tenantNs }}
+  labels:
+    {{- include "bp-openclaw.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ $fullName }}-controller
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "bp-openclaw.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/platform/openclaw/chart/templates/controller-service.yaml
+++ b/platform/openclaw/chart/templates/controller-service.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.controller.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "bp-openclaw.fullname" . }}-controller
+  labels:
+    {{- include "bp-openclaw.labels" . | nindent 4 }}
+    catalyst.openova.io/component: controller
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.targetPort }}
+      protocol: TCP
+  selector:
+    {{- include "bp-openclaw.selectorLabels" . | nindent 4 }}
+    catalyst.openova.io/component: controller
+{{- end }}

--- a/platform/openclaw/chart/templates/networkpolicy.yaml
+++ b/platform/openclaw/chart/templates/networkpolicy.yaml
@@ -1,0 +1,68 @@
+{{- if and .Values.controller.enabled .Values.networkPolicy.enabled }}
+{{- $fullName := include "bp-openclaw.fullname" . -}}
+---
+# ─── Controller NetworkPolicy ────────────────────────────────────────────
+# Ingress: traefik (public-facing) → controller :8080
+# Egress:  controller → kube-system (api-server + DNS), keycloak (OIDC),
+#          per-user pods in tenant namespace (proxy traffic)
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ $fullName }}-controller
+  labels:
+    {{- include "bp-openclaw.labels" . | nindent 4 }}
+    catalyst.openova.io/component: controller
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "bp-openclaw.selectorLabels" . | nindent 6 }}
+      catalyst.openova.io/component: controller
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              {{- toYaml .Values.networkPolicy.controller.ingress.fromNamespaceLabels | nindent 14 }}
+      ports:
+        - port: {{ .Values.controller.port }}
+          protocol: TCP
+  egress:
+    # K8s api-server (pod create/delete + Secret list/get).
+    # The kubernetes.default Service ClusterIP route is not always
+    # selectable by namespaceSelector — operators may add a more
+    # specific egress rule via overlay if their CNI needs it. We keep
+    # the kube-system DNS rule below; the api-server rule itself is
+    # commonly handled by the CNI's default-allow for kubernetes-api.
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+      ports:
+        - port: 443
+          protocol: TCP
+        # DNS resolution.
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+    # SME-vcluster Keycloak (OIDC discovery + JWKS).
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.networkPolicy.controller.egress.keycloakNamespaceLabel }}
+      ports:
+        - port: {{ .Values.networkPolicy.controller.egress.keycloakPort }}
+          protocol: TCP
+    # Per-user pod range — the controller proxies WebSocket/SSE traffic
+    # to the runtime container in the tenant namespace.
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ include "bp-openclaw.tenantNamespace" . }}
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/component: per-user-pod
+              catalyst.openova.io/blueprint: bp-openclaw
+{{- end }}

--- a/platform/openclaw/chart/templates/per-user-pod-template.yaml
+++ b/platform/openclaw/chart/templates/per-user-pod-template.yaml
@@ -1,0 +1,77 @@
+{{- if .Values.controller.enabled }}
+{{- $tenantNs := include "bp-openclaw.tenantNamespace" . -}}
+# ─── Per-user pod template (consumed by the controller) ──────────────────
+# This ConfigMap holds the pod-spec template the controller renders per
+# session. The controller reads it from /etc/openclaw/pod-template.yaml,
+# substitutes ${USER_UUID} and ${SECRET_NAME}, and submits the resulting
+# Pod to the K8s api-server.
+#
+# Substitution variables (filled by the controller at session-start):
+#   ${USER_UUID}    — the SME user UUID (= JWT `sub` claim)
+#   ${SECRET_NAME}  — `newapi-key-${USER_UUID}` (per ADR-0003 §3.3)
+#
+# Per [A] of #795: the runtime image reads ONLY two env vars
+# (NEWAPI_BASE_URL + NEWAPI_KEY). It carries NO Keycloak code, NO key-
+# management code, NO knowledge of the SME tenant model. Identity-blind
+# by construction.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "bp-openclaw.podTemplateConfigMapName" . }}
+  labels:
+    {{- include "bp-openclaw.labels" . | nindent 4 }}
+data:
+  pod-template.yaml: |
+    apiVersion: v1
+    kind: Pod
+    metadata:
+      # The controller post-processes this name to be unique-per-session
+      # (e.g. openclaw-user-${USER_UUID}-${SESSION_ID}).
+      name: openclaw-user-${USER_UUID}
+      namespace: {{ $tenantNs }}
+      labels:
+        app.kubernetes.io/name: {{ include "bp-openclaw.name" . }}
+        app.kubernetes.io/component: per-user-pod
+        catalyst.openova.io/blueprint: bp-openclaw
+        catalyst.openova.io/openclaw-user: ${USER_UUID}
+        # Ownership label — the controller's RBAC scope (Role rules 2/3
+        # in controller-rbac.yaml) is enforced at the application layer
+        # by selecting only pods that carry this label.
+    spec:
+      restartPolicy: Never
+      automountServiceAccountToken: false
+      securityContext:
+        {{- toYaml .Values.perUserPod.securityContext | nindent 8 }}
+      containers:
+        - name: runtime
+          image: "{{ .Values.perUserPod.image.repository }}:{{ .Values.perUserPod.image.tag }}"
+          imagePullPolicy: {{ .Values.perUserPod.image.pullPolicy }}
+          env:
+            - name: NEWAPI_BASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: ${SECRET_NAME}
+                  key: base-url
+            - name: NEWAPI_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: ${SECRET_NAME}
+                  key: api-key
+            {{- range .Values.perUserPod.extraEnv }}
+            - {{- toYaml . | nindent 14 }}
+            {{- end }}
+          resources:
+            {{- toYaml .Values.perUserPod.resources | nindent 12 }}
+          volumeMounts:
+            - name: workspace
+              mountPath: /workspace
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: workspace
+          emptyDir:
+            sizeLimit: 1Gi
+        - name: tmp
+          emptyDir:
+            sizeLimit: 256Mi
+{{- end }}

--- a/platform/openclaw/chart/templates/serviceaccount.yaml
+++ b/platform/openclaw/chart/templates/serviceaccount.yaml
@@ -1,0 +1,9 @@
+{{- include "bp-openclaw.assertRequired" . -}}
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "bp-openclaw.serviceAccountName" . }}
+  labels:
+    {{- include "bp-openclaw.labels" . | nindent 4 }}
+{{- end }}

--- a/platform/openclaw/chart/tests/render-toggles.sh
+++ b/platform/openclaw/chart/tests/render-toggles.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# bp-openclaw render-toggle integration test.
+#
+# Drives the helm-template gate run by .github/workflows/blueprint-release.yaml.
+# Verifies:
+#   1. Default values render FAILS — required values must be enforced.
+#   2. Minimum-required values render SUCCEEDS and produces expected resources.
+#   3. RBAC: `create` verbs are NOT combined with `resourceNames`
+#      (per feedback_rbac_create_no_resourcenames.md).
+#   4. ServiceMonitor toggle defaults to off (per BLUEPRINT-AUTHORING §11.2).
+#   5. networkPolicy toggle suppresses NetworkPolicy when off.
+#   6. Per-user pod template ConfigMap is rendered.
+#
+# Usage: bash tests/render-toggles.sh [CHART_DIR]
+
+set -euo pipefail
+
+CHART_DIR="${1:-$(cd "$(dirname "$0")/.." && pwd)}"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+cd "$CHART_DIR"
+
+# Common args every successful render needs (the operator-supplied
+# values that the chart's assertRequired helper guards on).
+COMMON_ARGS=(
+  --set "keycloak.realmURL=https://kc.acme.example/realms/acme"
+  --set "keycloak.clientSecretName=openclaw-oidc"
+  --set "tenant.namespace=sme-acme"
+  --set "newapi.baseURL=https://newapi.example"
+  --set "controller.image.tag=sha-deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+  --set "perUserPod.image.tag=sha-cafef00dcafef00dcafef00dcafef00dcafef00d"
+  --set "ingress.host=openclaw.acme.example"
+)
+
+echo "[render-toggles] Case 1: default render FAILS without required values"
+if helm template smoke-openclaw . > "$TMP/default.yaml" 2> "$TMP/default.err"; then
+  echo "FAIL: default render succeeded — assertRequired in _helpers.tpl is broken." >&2
+  echo "      Expected the chart to fail with a helpful error when keycloak.realmURL et al are unset." >&2
+  exit 1
+fi
+if ! grep -q "is required" "$TMP/default.err"; then
+  echo "FAIL: default render failure did not include the expected 'is required' helper-message." >&2
+  cat "$TMP/default.err" >&2
+  exit 1
+fi
+echo "  PASS"
+
+echo "[render-toggles] Case 2: minimum-required values render succeeds"
+if ! helm template smoke-openclaw . "${COMMON_ARGS[@]}" > "$TMP/ok.yaml" 2> "$TMP/ok.err"; then
+  echo "FAIL: minimum-required render failed:" >&2
+  cat "$TMP/ok.err" >&2
+  exit 1
+fi
+for kind in Deployment Service Ingress Role RoleBinding ConfigMap NetworkPolicy ServiceAccount; do
+  if ! grep -qE "^kind: ${kind}$" "$TMP/ok.yaml"; then
+    echo "FAIL: minimum-required render is missing kind=${kind}" >&2
+    exit 1
+  fi
+done
+echo "  PASS"
+
+echo "[render-toggles] Case 3: RBAC — 'create' verb is NOT combined with resourceNames"
+# Extract all rules blocks from any Role/ClusterRole rendered by the
+# chart and assert no rule contains both `verbs: [..., create, ...]`
+# AND a `resourceNames:` selector. This is the canonical defense
+# against the bp-openbao 6+ provisioning loop incident
+# (feedback_rbac_create_no_resourcenames.md, 2026-05-03).
+RENDER_OUT="$TMP/ok.yaml" python3 - <<'PY'
+import os, sys, yaml
+path = os.environ["RENDER_OUT"]
+with open(path) as f:
+    docs = list(yaml.safe_load_all(f))
+violations = []
+for d in docs:
+    if not d:
+        continue
+    if d.get("kind") not in {"Role", "ClusterRole"}:
+        continue
+    name = d.get("metadata", {}).get("name", "<unnamed>")
+    for i, rule in enumerate(d.get("rules", []) or []):
+        verbs = rule.get("verbs", []) or []
+        rns = rule.get("resourceNames", []) or []
+        if "create" in verbs and rns:
+            violations.append(f"{name} rule[{i}]: verbs={verbs} resourceNames={rns}")
+if violations:
+    print("FAIL: RBAC rule combines create with resourceNames (forbidden per feedback_rbac_create_no_resourcenames.md):", file=sys.stderr)
+    for v in violations:
+        print(f"  - {v}", file=sys.stderr)
+    sys.exit(1)
+PY
+echo "  PASS"
+
+echo "[render-toggles] Case 4: ServiceMonitor defaults off"
+if grep -qE "kind: (ServiceMonitor|PodMonitor|PrometheusRule)" "$TMP/ok.yaml"; then
+  echo "FAIL: default render contains a Prometheus operator resource — observability toggles must default off (BLUEPRINT-AUTHORING.md §11.2)." >&2
+  exit 1
+fi
+echo "  PASS"
+
+echo "[render-toggles] Case 5: networkPolicy.enabled=false suppresses NetworkPolicy"
+if ! helm template smoke-openclaw . "${COMMON_ARGS[@]}" \
+    --set "networkPolicy.enabled=false" \
+    > "$TMP/np-off.yaml" 2> "$TMP/np-off.err"; then
+  echo "FAIL: networkPolicy.enabled=false render failed:" >&2
+  cat "$TMP/np-off.err" >&2
+  exit 1
+fi
+if grep -qE "^kind: NetworkPolicy$" "$TMP/np-off.yaml"; then
+  echo "FAIL: networkPolicy.enabled=false still renders a NetworkPolicy — toggle is broken." >&2
+  exit 1
+fi
+echo "  PASS"
+
+echo "[render-toggles] Case 6: per-user pod template ConfigMap is rendered"
+if ! grep -q "pod-template.yaml: |" "$TMP/ok.yaml"; then
+  echo "FAIL: per-user pod-template ConfigMap was not rendered (controller would have no pod-spec template at runtime)." >&2
+  exit 1
+fi
+# Assert the substitution placeholders the controller will fill at
+# session-start are present in the rendered template.
+for placeholder in '${USER_UUID}' '${SECRET_NAME}'; do
+  if ! grep -qF "$placeholder" "$TMP/ok.yaml"; then
+    echo "FAIL: per-user pod-template missing controller substitution placeholder ${placeholder}" >&2
+    exit 1
+  fi
+done
+echo "  PASS"
+
+echo "[render-toggles] Case 7: ingress carries cert-manager cluster-issuer annotation"
+if ! grep -q 'cert-manager.io/cluster-issuer: "letsencrypt-prod"' "$TMP/ok.yaml"; then
+  echo "FAIL: ingress is missing cert-manager.io/cluster-issuer annotation — ACME auto-issue won't fire." >&2
+  exit 1
+fi
+echo "  PASS"
+
+echo "[render-toggles] All bp-openclaw render-toggle gates green."

--- a/platform/openclaw/chart/values.yaml
+++ b/platform/openclaw/chart/values.yaml
@@ -1,0 +1,191 @@
+# bp-openclaw values.
+#
+# Per docs/INVIOLABLE-PRINCIPLES.md #4 (never hardcode), every
+# operationally-meaningful value is configurable; cluster overlays in
+# clusters/<sovereign>/bootstrap-kit/ may override any of these without
+# rebuilding the Blueprint OCI artifact.
+#
+# Required at install time (overlay MUST set):
+#   - keycloak.realmURL          (SME-vcluster Keycloak realm OIDC issuer)
+#   - keycloak.clientSecretName  (ExternalSecret with OIDC client_secret)
+#   - tenant.namespace           (SME tenant namespace where per-user pods run)
+#   - ingress.host               (controller public hostname)
+#   - newapi.baseURL             (NewAPI customer-facing hostname)
+#
+# The chart will fail to render with a helpful error if any of these are
+# missing — see _helpers.tpl :: bp-openclaw.assertRequired.
+
+catalystBlueprint:
+  upstream:
+    chart: ""              # scratch chart — no upstream Helm chart
+    version: ""
+    repo: ""
+    images:
+      controller: "ghcr.io/openova-io/openova/openclaw-controller"
+      runtime: "ghcr.io/openova-io/openova/openclaw-runtime"
+
+# ─── Controller (multi-tenant) ───────────────────────────────────────────
+controller:
+  enabled: true
+  replicas: 1
+  image:
+    # Operator-supplied SHA tag; the chart's default placeholder is
+    # rejected by an assertion in _helpers.tpl when controller.enabled=true.
+    repository: ghcr.io/openova-io/openova/openclaw-controller
+    tag: ""                       # operator-supplied — SHA-pinned per Inviolable Principle 4
+    pullPolicy: IfNotPresent
+  port: 8080
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 1001
+    readOnlyRootFilesystem: true
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop: ["ALL"]
+  probes:
+    liveness:
+      path: /healthz
+      port: 8080
+      initialDelaySeconds: 10
+      periodSeconds: 10
+      timeoutSeconds: 5
+      failureThreshold: 3
+    readiness:
+      path: /readyz
+      port: 8080
+      initialDelaySeconds: 5
+      periodSeconds: 10
+      timeoutSeconds: 5
+      failureThreshold: 3
+
+# ─── Auth: SME-vcluster Keycloak (OIDC) ──────────────────────────────────
+# The controller validates inbound end-user JWTs against the SME's own
+# Keycloak realm. It NEVER uses the OTECH-ops realm, NEVER trusts a JWT
+# from outside the SME vcluster.
+keycloak:
+  # Required: full realm issuer URL.
+  # e.g. "https://keycloak.<sme-domain>/realms/<sme-realm>"
+  realmURL: ""
+  # OIDC client registered in the SME's Keycloak realm for OpenClaw.
+  clientID: "openclaw"
+  # ExternalSecret name carrying the OIDC client_secret. Required key:
+  # OIDC_CLIENT_SECRET. Provisioned by the SME-tenant onboarding pipeline
+  # (epic #795 ticket #804).
+  clientSecretName: ""
+
+# ─── NewAPI integration ──────────────────────────────────────────────────
+# Per-user pods talk to NewAPI via its CUSTOMER-FACING hostname (egress
+# through the OTECH ingress with TLS), NEVER the in-cluster admin URL.
+# Per ADR-0003 §3.3 the per-user Secret carries `base-url` matching this
+# value; we read the value from the Secret at pod-spawn time so this
+# field acts as a fallback default for overlays that don't yet set
+# `base-url` on the Secret.
+newapi:
+  baseURL: ""                     # operator-supplied (e.g. https://newapi.<otech-fqdn>)
+
+# ─── Tenant namespace ────────────────────────────────────────────────────
+# SME tenant namespace where:
+#   - per-user pods are created and deleted
+#   - newapi-key-{uuid} Secrets are read by the controller's ServiceAccount
+tenant:
+  namespace: ""                   # operator-supplied (e.g. sme-acme)
+
+# ─── Per-user pod template ───────────────────────────────────────────────
+# These values are baked into a ConfigMap; the controller renders the
+# pod-spec at session-start time, substituting NEWAPI_KEY (Secret ref)
+# and NEWAPI_BASE_URL (env value).
+perUserPod:
+  image:
+    repository: ghcr.io/openova-io/openova/openclaw-runtime
+    tag: ""                       # operator-supplied — SHA-pinned per Inviolable Principle 4
+    pullPolicy: IfNotPresent
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: 1
+      memory: 1Gi
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 1001
+    readOnlyRootFilesystem: true
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop: ["ALL"]
+  # Idle-session reaper — controller deletes the per-user pod after
+  # this many minutes without inbound traffic. Default 30 minutes.
+  idleTimeoutMinutes: 30
+  # Optional extra env vars baked into every per-user pod (operator
+  # overlay may extend, e.g. for HTTP proxy, telemetry endpoint, etc.).
+  extraEnv: []
+
+# ─── Service ─────────────────────────────────────────────────────────────
+service:
+  type: ClusterIP
+  port: 8080
+  targetPort: 8080
+
+# ─── ServiceAccount ──────────────────────────────────────────────────────
+serviceAccount:
+  create: true
+  name: ""
+
+# ─── Ingress + cert-manager TLS ──────────────────────────────────────────
+# Public hostname for the controller. Per Q-mine-1 of #795:
+# `openclaw.<sme-domain-or-subdomain>`. cert-manager auto-issues a
+# per-host certificate via the operator's ACME issuer.
+ingress:
+  enabled: true
+  className: "traefik"
+  host: ""                        # operator-supplied (e.g. openclaw.<sme-domain>)
+  tls:
+    enabled: true
+    issuer: "letsencrypt-prod"    # cert-manager ClusterIssuer
+    secretName: "openclaw-tls"
+  annotations: {}
+
+# ─── NetworkPolicy ───────────────────────────────────────────────────────
+# Default-allow ingress from the platform's gateway namespace (traefik).
+# Egress from CONTROLLER:
+#   - SME-vcluster Keycloak (OIDC discovery + JWKS)
+#   - K8s api-server (pod create/delete; goes to kube-system endpoint)
+#   - per-user pod range in tenant namespace (proxy WebSocket/SSE)
+#   - DNS
+# Egress from PER-USER pod (separate NetworkPolicy applied at pod-spawn
+# time by the controller, NOT by this chart's render — see
+# README.md §"per-user-pod NetworkPolicy"):
+#   - NewAPI Service (cluster-internal hostname or external ingress)
+#   - DNS
+# This chart's NetworkPolicy template covers the controller pod only;
+# per-user pods receive their NetworkPolicy from a controller-rendered
+# template at session-start.
+networkPolicy:
+  enabled: true
+  controller:
+    ingress:
+      fromNamespaceLabels:
+        kubernetes.io/metadata.name: traefik
+    # Egress targets — operator may extend if SME-vcluster Keycloak
+    # reaches the controller via a different namespace label.
+    egress:
+      keycloakNamespaceLabel: "keycloak"
+      keycloakPort: 8443
+
+# ─── ServiceMonitor ──────────────────────────────────────────────────────
+# Default false per docs/BLUEPRINT-AUTHORING.md §11.2 (Observability
+# toggles must default false). Operator opts in via per-cluster overlay
+# once kube-prometheus-stack reconciles.
+serviceMonitor:
+  enabled: false
+  interval: "30s"
+  scrapeTimeout: "10s"
+  path: "/metrics"
+  labels: {}

--- a/platform/openclaw/runtime/Dockerfile
+++ b/platform/openclaw/runtime/Dockerfile
@@ -1,0 +1,32 @@
+# OpenClaw runtime — per-user pod image.
+#
+# Per locked decision [A] of #795, this image reads ONLY two env vars
+# (NEWAPI_BASE_URL + NEWAPI_KEY). It is identity-blind: no Keycloak
+# code, no key-management code, no SME-tenant model knowledge.
+#
+# Contract:
+#   - HTTP server on $PORT (default 8080)
+#   - GET /healthz   → 200 if NEWAPI_BASE_URL+NEWAPI_KEY are present
+#   - GET /readyz    → 200 once the upstream NewAPI base URL responds
+#   - POST /v1/chat/completions  → forwards to ${NEWAPI_BASE_URL}/v1/chat/completions
+#                                   with `Authorization: Bearer ${NEWAPI_KEY}`
+#   - GET /          → minimal HTML landing for browser confirm-loop
+#
+# This is a contract-minimal stub. Operators may override
+# perUserPod.image.repository in the chart values to any image that
+# satisfies the same two-env-var contract — e.g. a coding-CLI fork,
+# the upstream OpenClaw, etc.
+
+FROM golang:1.22-alpine AS build
+WORKDIR /src
+COPY go.mod main.go ./
+RUN CGO_ENABLED=0 go build -ldflags="-s -w" -o /openclaw-runtime .
+
+FROM scratch
+LABEL org.opencontainers.image.source="https://github.com/openova-io/openova"
+LABEL org.opencontainers.image.description="OpenClaw per-user runtime — identity-blind NewAPI proxy"
+LABEL org.opencontainers.image.licenses="Apache-2.0"
+COPY --from=build /openclaw-runtime /openclaw-runtime
+USER 1001:1001
+EXPOSE 8080
+ENTRYPOINT ["/openclaw-runtime"]

--- a/platform/openclaw/runtime/go.mod
+++ b/platform/openclaw/runtime/go.mod
@@ -1,0 +1,3 @@
+module github.com/openova-io/openova/platform/openclaw/runtime
+
+go 1.22

--- a/platform/openclaw/runtime/main.go
+++ b/platform/openclaw/runtime/main.go
@@ -1,0 +1,171 @@
+// OpenClaw per-user runtime — identity-blind NewAPI proxy.
+//
+// Per locked decision [A] of openova-io/openova#795, this binary reads
+// ONLY two env vars (NEWAPI_BASE_URL + NEWAPI_KEY). It carries NO
+// Keycloak code, NO key-management code, NO SME-tenant model knowledge.
+// Identity flows in through the Secret-mounted env vars; the runtime
+// trusts what the controller injected at pod-spawn time.
+//
+// HTTP surface:
+//   - GET  /                       minimal HTML landing
+//   - GET  /healthz                200 if env vars are present
+//   - GET  /readyz                 200 if NEWAPI_BASE_URL responds
+//   - POST /v1/chat/completions    forwards to ${NEWAPI_BASE_URL}/v1/chat/completions
+//   - POST /v1/completions         forwards to ${NEWAPI_BASE_URL}/v1/completions
+//   - POST /v1/embeddings          forwards to ${NEWAPI_BASE_URL}/v1/embeddings
+//   - GET  /v1/models              forwards to ${NEWAPI_BASE_URL}/v1/models
+//
+// Per Inviolable Principle 4 (never hardcode), the listen port is
+// $PORT (default 8080) and the upstream is $NEWAPI_BASE_URL — both
+// configurable.
+
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+)
+
+const (
+	defaultPort       = "8080"
+	upstreamTimeout   = 60 * time.Second
+	readyzProbeTimeout = 5 * time.Second
+)
+
+func main() {
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = defaultPort
+	}
+
+	baseURL := strings.TrimRight(os.Getenv("NEWAPI_BASE_URL"), "/")
+	apiKey := os.Getenv("NEWAPI_KEY")
+	if baseURL == "" || apiKey == "" {
+		log.Fatalf("FATAL: NEWAPI_BASE_URL and NEWAPI_KEY env vars are required (per locked decision [A] of openova-io/openova#795)")
+	}
+
+	upstream, err := url.Parse(baseURL)
+	if err != nil {
+		log.Fatalf("FATAL: invalid NEWAPI_BASE_URL=%q: %v", baseURL, err)
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", indexHandler)
+	mux.HandleFunc("/healthz", healthzHandler(baseURL, apiKey))
+	mux.HandleFunc("/readyz", readyzHandler(baseURL))
+	mux.Handle("/v1/", proxyHandler(upstream, apiKey))
+
+	addr := net.JoinHostPort("", port)
+	srv := &http.Server{
+		Addr:              addr,
+		Handler:           mux,
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+
+	log.Printf("openclaw-runtime listening on %s; upstream=%s", addr, baseURL)
+	if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		log.Fatalf("FATAL: server error: %v", err)
+	}
+}
+
+func indexHandler(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path != "/" {
+		http.NotFound(w, r)
+		return
+	}
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	_, _ = io.WriteString(w, `<!doctype html>
+<html><head><title>OpenClaw runtime</title></head>
+<body style="font-family:system-ui,sans-serif;max-width:640px;margin:2rem auto;color:#222">
+<h1>OpenClaw runtime</h1>
+<p>Identity-blind NewAPI proxy. Two env vars (NEWAPI_BASE_URL, NEWAPI_KEY) configured.</p>
+<p>Endpoints:
+  <code>/v1/chat/completions</code>,
+  <code>/v1/completions</code>,
+  <code>/v1/embeddings</code>,
+  <code>/v1/models</code>,
+  <code>/healthz</code>,
+  <code>/readyz</code>
+</p>
+</body></html>
+`)
+}
+
+func healthzHandler(baseURL, apiKey string) http.HandlerFunc {
+	return func(w http.ResponseWriter, _ *http.Request) {
+		// Liveness — env vars present.
+		if baseURL == "" || apiKey == "" {
+			http.Error(w, "missing env", http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, "ok")
+	}
+}
+
+func readyzHandler(baseURL string) http.HandlerFunc {
+	client := &http.Client{Timeout: readyzProbeTimeout}
+	return func(w http.ResponseWriter, _ *http.Request) {
+		ctx, cancel := context.WithTimeout(context.Background(), readyzProbeTimeout)
+		defer cancel()
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+"/v1/models", nil)
+		if err != nil {
+			http.Error(w, fmt.Sprintf("readyz: build req: %v", err), http.StatusServiceUnavailable)
+			return
+		}
+		resp, err := client.Do(req)
+		if err != nil {
+			http.Error(w, fmt.Sprintf("readyz: upstream unreachable: %v", err), http.StatusServiceUnavailable)
+			return
+		}
+		_ = resp.Body.Close()
+		// Even 401/403 means the upstream is reachable — readyz only
+		// asserts network reachability, not auth (auth is exercised on
+		// real requests).
+		if resp.StatusCode >= 500 {
+			http.Error(w, fmt.Sprintf("readyz: upstream %d", resp.StatusCode), http.StatusServiceUnavailable)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, "ready")
+	}
+}
+
+func proxyHandler(upstream *url.URL, apiKey string) http.Handler {
+	rp := &httputil.ReverseProxy{
+		Rewrite: func(pr *httputil.ProxyRequest) {
+			pr.SetURL(upstream)
+			// Inject Authorization. The runtime is identity-blind —
+			// it forwards every /v1/* request with the per-user
+			// NEWAPI_KEY (mounted at startup from the per-user
+			// Secret), regardless of who the original caller is. The
+			// controller upstream of this pod is responsible for
+			// authenticating the SME end-user via Keycloak before
+			// proxying any traffic here.
+			pr.Out.Header.Set("Authorization", "Bearer "+apiKey)
+			pr.Out.Header.Del("Cookie")
+			// Preserve Accept-Encoding etc. as-is.
+		},
+		ErrorLog: log.New(os.Stderr, "proxy: ", log.LstdFlags),
+		ErrorHandler: func(w http.ResponseWriter, r *http.Request, err error) {
+			log.Printf("proxy: error forwarding %s %s: %v", r.Method, r.URL.Path, err)
+			http.Error(w, "upstream proxy error", http.StatusBadGateway)
+		},
+		Transport: &http.Transport{
+			Proxy:                 http.ProxyFromEnvironment,
+			ResponseHeaderTimeout: upstreamTimeout,
+			IdleConnTimeout:       90 * time.Second,
+		},
+	}
+	return rp
+}


### PR DESCRIPTION
## Summary

Implements [#803](https://github.com/openova-io/openova/issues/803) — locked decision **[A]** of epic [#795](https://github.com/openova-io/openova/issues/795). Ships a Catalyst Blueprint chart (`bp-openclaw`) that deploys:

- a multi-tenant **workspace controller** in the SME tenant namespace (validates inbound JWTs against the SME-vcluster Keycloak realm; spawns / proxies / reaps per-user runtime pods)
- a **per-user runtime pod** template, mounted from the per-user `newapi-key-{uuid}` Secret rendered by ADR-0003 §3.3 — runtime is identity-blind, reads ONLY `NEWAPI_BASE_URL` + `NEWAPI_KEY` env vars
- a Go reference runtime image (OpenAI-compatible proxy to NewAPI) and its event-driven CI workflow

This pattern generalises to bp-opencode / bp-aider / bp-cursor-server later. Rejected alternative ("shared OpenClaw forwarding SME JWT to NewAPI") would have forced cross-realm OIDC trust onto NewAPI — explicitly out per #795.

## Files

- `platform/openclaw/Chart.yaml` — bp-openclaw 0.1.0 (`catalyst.openova.io/no-upstream: "true"`)
- `platform/openclaw/values.yaml` — operator-tunable values; required-value assertions in `_helpers.tpl`
- `platform/openclaw/templates/` — controller Deployment / Service / Ingress (cert-manager auto-issue) / RBAC / NetworkPolicy + per-user pod-template ConfigMap + ServiceAccount
- `platform/openclaw/runtime/` — Go reference runtime (Dockerfile + main.go) — minimal NewAPI proxy
- `platform/openclaw/blueprint.yaml` — Catalyst registration + configSchema
- `platform/openclaw/README.md` — architecture diagram, RBAC posture rationale, why-stub-not-upstream
- `.github/workflows/openclaw-runtime.yaml` — event-driven CI (paths-on-push + manual rerun, no `schedule:`)
- `platform/openclaw/chart/tests/render-toggles.sh` — 7 helm-template gates run by `blueprint-release.yaml`

## RBAC posture

Per `feedback_rbac_create_no_resourcenames.md`, the `create` verb is **split into separate rules with NO `resourceNames`** — the K8s authorizer rejects `create + resourceNames`. Label-based ownership (`catalyst.openova.io/openclaw-user`) is enforced at the controller, not in RBAC.

## Inviolable principles

- #1 event-driven: all triggers are paths-on-push or workflow_dispatch; no `schedule:` cron.
- #4 never hardcode: every operationally-meaningful value (FQDN, image, secret name, port) is in values.yaml; the chart fails render with helpful messages when required values are missing.
- #4a images-via-CI-only: runtime image is built and pushed by `.github/workflows/openclaw-runtime.yaml` from a committed git SHA; no local docker push.
- #7 K8s-native tenancy: controller's Role is namespaced (tenant ns), not cluster-scoped.

## Test plan

- [x] Default render fails with helpful "is required" errors for all 6 required values
- [x] Minimum-required render produces Deployment / Service / Ingress / Role / RoleBinding / ConfigMap / NetworkPolicy / ServiceAccount
- [x] No Role rule combines `create` with `resourceNames`
- [x] No ServiceMonitor / PodMonitor / PrometheusRule by default (BLUEPRINT-AUTHORING §11.2)
- [x] `networkPolicy.enabled=false` suppresses the NetworkPolicy
- [x] Per-user pod-template ConfigMap renders with `${USER_UUID}` / `${SECRET_NAME}` substitution placeholders
- [x] Ingress carries `cert-manager.io/cluster-issuer` annotation
- [x] Go runtime compiles, refuses to start without env vars, serves `/healthz` when env vars present
- [ ] (CI) Chart published to `oci://ghcr.io/openova-io/bp-openclaw:0.1.0` via blueprint-release workflow
- [ ] (CI) Runtime image published to `ghcr.io/openova-io/openova/openclaw-runtime:<sha>` via openclaw-runtime workflow

## DoD per #803

- [x] PR opened with bp-openclaw chart shape implementing [A]
- [ ] Chart published at `oci://ghcr.io/openova-io/bp-openclaw:0.1.0` (blueprint-release CI)
- [ ] Status moved to status/uat after merge
- (Live SME-tenant test on a fresh otech is part of epic #804/#805, not this ticket)

🤖 Generated with [Claude Code](https://claude.com/claude-code)