### PR TITLE
feat(bp-newapi): chart maturation + first-otech deploy + Qwen vLLM channel (#799)

### DIFF
--- a/clusters/_template/bootstrap-kit/80-newapi.yaml
+++ b/clusters/_template/bootstrap-kit/80-newapi.yaml
@@ -1,0 +1,151 @@
+# bp-newapi — Catalyst Application Blueprint, bootstrap-kit slot 80.
+# Multi-tenant LLM marketplace gateway. Ships in backend-only mode: the
+# OpenAI-compatible API at api.<sovereign-fqdn>/v1/* is customer-facing;
+# the upstream's portal UI is disabled at ingress; Catalyst replaces it
+# as the customer surface; NewAPI's admin UI at admin.<sovereign-fqdn>
+# is exposed only to ops staff (Keycloak-gated).
+#
+# This slot enables the SME-tenant turnkey experience (epic #795). The
+# Catalyst signup hook (delivered by unified-rbac in #802 against the
+# contract recorded in ADR-0003) reads the `catalyst-newapi-admin-token`
+# Secret rendered by this chart's ExternalSecret to issue per-user API
+# keys against NewAPI's admin API at `http://newapi.newapi.svc`.
+#
+# Wrapper chart: platform/newapi/chart/
+# Catalyst-curated values: platform/newapi/chart/values.yaml
+# Reconciled by: Flux on the new Sovereign's k3s control plane.
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: newapi
+  labels:
+    catalyst.openova.io/sovereign: ${SOVEREIGN_FQDN}
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: bp-newapi
+  namespace: flux-system
+spec:
+  type: oci
+  interval: 15m
+  url: oci://ghcr.io/openova-io
+  secretRef:
+    name: ghcr-pull
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: bp-newapi
+  namespace: flux-system
+spec:
+  interval: 15m
+  releaseName: newapi
+  targetNamespace: newapi
+  # bp-newapi depends on:
+  #   - bp-openbao(08): the secret backend the chart's ExternalSecret
+  #     pulls `ADMIN_API_TOKEN` from. Without OpenBao Ready, the
+  #     ExternalSecret never resolves and the Catalyst signup hook can't
+  #     reach the NewAPI admin API.
+  #   - bp-keycloak(09): the OIDC issuer for the ops-staff admin UI at
+  #     admin.<sovereign-fqdn>. Without Keycloak Ready, the OIDC
+  #     middleware can't redirect ops-staff requests.
+  #   - bp-cnpg(16): operator provisions the Postgres cluster for users,
+  #     credits, channels, and audit log via a Crossplane
+  #     PostgresqlInstance claim once cnpg is Ready. The DSN is mounted
+  #     into NewAPI via `database.existingSecret` (operator-set).
+  dependsOn:
+    - name: bp-openbao
+    - name: bp-keycloak
+    - name: bp-cnpg
+  chart:
+    spec:
+      chart: bp-newapi
+      version: 1.1.0
+      sourceRef:
+        kind: HelmRepository
+        name: bp-newapi
+        namespace: flux-system
+  # Event-driven install per docs/INVIOLABLE-PRINCIPLES.md #3 (Flux
+  # dependsOn is the gate, not Helm timeout). NewAPI itself starts in
+  # ~10 s once the Postgres DSN Secret is present; the long pole is
+  # waiting for the operator's Crossplane claim to materialise the DB.
+  install:
+    disableWait: true
+    remediation:
+      retries: 3
+  upgrade:
+    disableWait: true
+    remediation:
+      retries: 3
+  # Per-Sovereign overrides — the operator MUST supply at install time:
+  #   - ingress.host           = api.${SOVEREIGN_FQDN}
+  #   - ingress.adminHost      = admin.${SOVEREIGN_FQDN}
+  #   - auth.adminUI.keycloak.issuer = https://auth.${SOVEREIGN_FQDN}/realms/ops
+  #   - database.existingSecret      = Postgres DSN Secret (from the
+  #                                    Crossplane PostgresqlInstance claim)
+  #   - credentials.existingSecret   = SESSION_SECRET + CRYPTO_SECRET
+  #                                    (rotated via OpenBao)
+  #   - catalystIntegration.externalSecret.remoteRef.key
+  #                                  = sovereign/${SOVEREIGN_FQDN}/newapi/admin-token
+  #   - defaultChannels.vllm.enabled = true (first-otech)
+  #   - defaultChannels.vllm.endpoint
+  #     + defaultChannels.vllm.attestation.owner
+  #
+  # Defaults below wire the first-otech provider channel to the same
+  # upstream the OpenOva marketing site uses (Qwen via Axon →
+  # `llm-api.omtd.bankdhofar.com`, model `qwen3-coder`); the operator
+  # overlay overrides any of these by setting them in this HelmRelease's
+  # spec.values.
+  values:
+    sovereignFQDN: ${SOVEREIGN_FQDN}
+    ingress:
+      host: api.${SOVEREIGN_FQDN}
+      adminHost: admin.${SOVEREIGN_FQDN}
+      tls:
+        enabled: true
+        issuer: letsencrypt-prod
+    auth:
+      adminUI:
+        mode: keycloak
+        keycloak:
+          issuer: https://auth.${SOVEREIGN_FQDN}/realms/ops
+          clientId: newapi-admin
+          existingSecret: newapi-oidc
+      customerAPI:
+        keyIssuer: catalyst
+    catalystIntegration:
+      enabled: true
+      existingSecret: catalyst-newapi-admin-token
+      externalSecret:
+        enabled: true
+        refreshInterval: "1h"
+        secretStoreRef:
+          kind: ClusterSecretStore
+          name: vault-region1
+        remoteRef:
+          # Canonical OpenBao path per docs/INVIOLABLE-PRINCIPLES.md #4.
+          # Under the `vault-region1` store's `secret/` mount the full
+          # path is `secret/sovereign/<fqdn>/newapi/admin-token`.
+          key: sovereign/${SOVEREIGN_FQDN}/newapi/admin-token
+          property: ADMIN_API_TOKEN
+    # Default vLLM channel — disabled in the template so a fresh
+    # Sovereign does not silently wire customers to a third-party
+    # endpoint. Per-Sovereign overlays (e.g.
+    # `clusters/<sovereign>/bootstrap-kit/80-newapi.yaml`) enable this
+    # block and supply a concrete `endpoint`, `models`, and
+    # `attestation.owner`. The first-otech canonical reference is
+    # `https://llm-api.omtd.bankdhofar.com` with `qwen3-coder` (the same
+    # relay Axon uses on the OpenOva marketing deployment).
+    defaultChannels:
+      vllm:
+        enabled: false
+        name: qwen
+        endpoint: ""
+        models:
+          - qwen3-coder
+        attestation:
+          kind: in-cluster
+          owner: ${SOVEREIGN_FQDN}

--- a/clusters/_template/bootstrap-kit/kustomization.yaml
+++ b/clusters/_template/bootstrap-kit/kustomization.yaml
@@ -49,3 +49,9 @@ resources:
   - 35-coraza.yaml
   - 49-bp-cert-manager-powerdns-webhook.yaml
   - 50-cluster-autoscaler.yaml
+  # bp-newapi (slot 80) — multi-tenant LLM marketplace gateway. Sequenced
+  # after the W2.K1 dependency wave (cnpg/keycloak/openbao Ready) so
+  # NewAPI's ExternalSecret + DSN dependencies resolve on first reconcile.
+  # See clusters/_template/bootstrap-kit/80-newapi.yaml for full
+  # dependsOn rationale and per-Sovereign override surface.
+  - 80-newapi.yaml

--- a/platform/newapi/blueprint.yaml
+++ b/platform/newapi/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/category: ai-runtime
     catalyst.openova.io/section: pts-4-6-llm-serving
 spec:
-  version: 1.0.0
+  version: 1.1.0
   card:
     title: NewAPI
     summary: |

--- a/platform/newapi/chart/Chart.yaml
+++ b/platform/newapi/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-newapi
-version: 1.0.0
+version: 1.1.0
 appVersion: "0.4.5"
 description: |
   Catalyst Blueprint scratch chart for NewAPI — multi-tenant LLM

--- a/platform/newapi/chart/templates/_helpers.tpl
+++ b/platform/newapi/chart/templates/_helpers.tpl
@@ -63,12 +63,41 @@ ConfigMap name (channel + policy config).
 {{- end }}
 
 {{/*
+Effective channel list — `.Values.channels` plus the composed
+`defaultChannels.vllm` channel when enabled. Centralised so configmap.yaml
+and assertChannelAttestation operate on the same materialised list.
+*/}}
+{{- define "bp-newapi.effectiveChannels" -}}
+{{- $channels := default (list) .Values.channels -}}
+{{- $dc := .Values.defaultChannels | default dict -}}
+{{- $vllm := $dc.vllm | default dict -}}
+{{- if $vllm.enabled -}}
+  {{- if not $vllm.endpoint -}}
+    {{- fail "defaultChannels.vllm.enabled=true but defaultChannels.vllm.endpoint is empty — supply the upstream vLLM relay URL in the per-Sovereign bootstrap-kit overlay (e.g. https://llm-api.omtd.bankdhofar.com)" -}}
+  {{- end -}}
+  {{- $composed := dict
+        "name"      (default "qwen" $vllm.name)
+        "type"      "vllm"
+        "endpoint"  $vllm.endpoint
+        "models"    (default (list "qwen3-coder") $vllm.models)
+        "attestation" (default (dict "kind" "in-cluster") $vllm.attestation) -}}
+  {{- if $vllm.existingSecret -}}
+    {{- $_ := set $composed "existingSecret" $vllm.existingSecret -}}
+  {{- end -}}
+  {{- $channels = append $channels $composed -}}
+{{- end -}}
+{{- toYaml $channels -}}
+{{- end -}}
+
+{{/*
 Channel attestation gate — refuses to render if any enabled channel
 lacks attestation. Compliance posture defined in
-platform/newapi/README.md and blueprint.yaml configSchema.
+platform/newapi/README.md and blueprint.yaml configSchema. Operates on
+the EFFECTIVE channel list (`.Values.channels` + composed defaults).
 */}}
 {{- define "bp-newapi.assertChannelAttestation" -}}
-{{- range $idx, $ch := .Values.channels }}
+{{- $effective := include "bp-newapi.effectiveChannels" . | fromYamlArray -}}
+{{- range $idx, $ch := $effective }}
 {{- if not $ch.attestation }}
 {{- fail (printf "channel[%d] (%s): missing required attestation block — see platform/newapi/README.md compliance posture" $idx (default "<unnamed>" $ch.name)) }}
 {{- end }}

--- a/platform/newapi/chart/templates/configmap.yaml
+++ b/platform/newapi/chart/templates/configmap.yaml
@@ -13,10 +13,13 @@ data:
   # customer-facing portal UI when set to "catalyst".
   CUSTOMER_KEY_ISSUER: {{ .Values.auth.customerAPI.keyIssuer | quote }}
 
-  # OIDC for ops-staff admin UI.
-  {{- if eq .Values.auth.adminUI.mode "keycloak" }}
+  # OIDC for ops-staff admin UI. Skip-render gate: when
+  # `auth.adminUI.mode=keycloak` but the issuer is not yet wired (e.g.
+  # CI smoke render with default values), emit `OIDC_ENABLED=false` and
+  # let the per-Sovereign overlay set the real issuer at install time.
+  {{- if and (eq .Values.auth.adminUI.mode "keycloak") .Values.auth.adminUI.keycloak.issuer }}
   OIDC_ENABLED: "true"
-  OIDC_ISSUER: {{ required "auth.adminUI.keycloak.issuer is required when auth.adminUI.mode=keycloak" .Values.auth.adminUI.keycloak.issuer | quote }}
+  OIDC_ISSUER: {{ .Values.auth.adminUI.keycloak.issuer | quote }}
   OIDC_CLIENT_ID: {{ .Values.auth.adminUI.keycloak.clientId | quote }}
   OIDC_CALLBACK_PATH: {{ .Values.auth.adminUI.keycloak.callbackPath | quote }}
   {{- else }}
@@ -41,11 +44,12 @@ data:
   # Reseller disclosure assertion.
   RESELLER_DISCLOSURE_REQUIRED: {{ .Values.reseller.disclosureRequired | quote }}
 
-  # Channel definitions (operator-supplied; full attestation enforced by
-  # the assertChannelAttestation helper). Loaded by NewAPI at boot via
+  # Channel definitions (operator-supplied + first-otech `defaultChannels`
+  # composition; full attestation enforced by the
+  # assertChannelAttestation helper). Loaded by NewAPI at boot via
   # /etc/newapi/channels.yaml.
   channels.yaml: |
-{{- range .Values.channels }}
+{{- range (include "bp-newapi.effectiveChannels" . | fromYamlArray) }}
     - name: {{ .name | quote }}
       type: {{ .type | quote }}
       {{- if .endpoint }}

--- a/platform/newapi/chart/templates/deployment.yaml
+++ b/platform/newapi/chart/templates/deployment.yaml
@@ -1,4 +1,24 @@
-{{- if .Values.newapi.enabled }}
+{{- /*
+Deployment skip-render gate. The Deployment binds three operator-supplied
+Secrets (database DSN, app credentials, optional OIDC client secret); if
+any are missing on a default-values render (CI smoke test), the
+Deployment is silently skipped. The Service / ServiceAccount / ConfigMap
+/ NetworkPolicy still render so `helm template` produces a non-empty
+output that proves the chart is structurally sound, while the actual
+Pod-rendering deferred until the per-Sovereign overlay sets
+`database.existingSecret` and `credentials.existingSecret`.
+
+Keycloak OIDC client secret is required only when
+`auth.adminUI.mode=keycloak` AND `auth.adminUI.keycloak.issuer` is set;
+the configmap mirrors this gate.
+*/ -}}
+{{- $kcMode := eq .Values.auth.adminUI.mode "keycloak" -}}
+{{- $kcConfigured := and $kcMode .Values.auth.adminUI.keycloak.issuer .Values.auth.adminUI.keycloak.existingSecret -}}
+{{- $deployReady := and .Values.newapi.enabled .Values.database.existingSecret .Values.credentials.existingSecret -}}
+{{- if and $kcMode (not $kcConfigured) -}}
+{{- $deployReady = false -}}
+{{- end -}}
+{{- if $deployReady }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -34,7 +54,7 @@ spec:
             - name: SQL_DSN
               valueFrom:
                 secretKeyRef:
-                  name: {{ required "database.existingSecret is required" .Values.database.existingSecret }}
+                  name: {{ .Values.database.existingSecret }}
                   key: {{ .Values.database.existingSecretKey }}
 
             # ── Valkey cache ──────────────────────────────────────────
@@ -55,7 +75,7 @@ spec:
             - name: SESSION_SECRET
               valueFrom:
                 secretKeyRef:
-                  name: {{ required "credentials.existingSecret is required" .Values.credentials.existingSecret }}
+                  name: {{ .Values.credentials.existingSecret }}
                   key: SESSION_SECRET
             - name: CRYPTO_SECRET
               valueFrom:
@@ -64,11 +84,11 @@ spec:
                   key: CRYPTO_SECRET
 
             # ── OIDC (admin UI) ───────────────────────────────────────
-            {{- if eq .Values.auth.adminUI.mode "keycloak" }}
+            {{- if $kcConfigured }}
             - name: OIDC_CLIENT_SECRET
               valueFrom:
                 secretKeyRef:
-                  name: {{ required "auth.adminUI.keycloak.existingSecret is required when auth.adminUI.mode=keycloak" .Values.auth.adminUI.keycloak.existingSecret }}
+                  name: {{ .Values.auth.adminUI.keycloak.existingSecret }}
                   key: OIDC_CLIENT_SECRET
             {{- end }}
 

--- a/platform/newapi/chart/templates/external-secret.yaml
+++ b/platform/newapi/chart/templates/external-secret.yaml
@@ -1,0 +1,58 @@
+{{- /*
+ExternalSecret — `catalyst-newapi-admin-token`.
+
+Bound to ADR-0003 §3.2 + §6: the unified-rbac service in the OTECH
+control plane reads this Secret's `ADMIN_API_TOKEN` key and uses it as
+`Authorization: Bearer <token>` against
+`http://newapi.newapi.svc/api/v1/admin/users` to issue per-user keys
+during the SME user-create flow. The Secret therefore MUST exist on the
+OTECH control plane before unified-rbac begins reconciliation.
+
+Sourced from the operator's OpenBao via a ClusterSecretStore (Catalyst
+default = `vault-region1`, shipped by bp-external-secrets-stores). The
+remote OpenBao path is operator-supplied at install time per the
+canonical convention `sovereign/<sovereign-fqdn>/newapi/admin-token`
+(under the store's `secret/` mount) with property `ADMIN_API_TOKEN`.
+
+Per docs/INVIOLABLE-PRINCIPLES.md #4 (never hardcode), every knob
+(refreshInterval, secretStoreRef.kind/name, remoteRef.key,
+remoteRef.property, target.name) is operator-tunable; the cluster
+overlay at `clusters/<sovereign>/bootstrap-kit/80-newapi.yaml` sets
+the per-Sovereign values without rebuilding the OCI artifact.
+
+Capabilities gate: the chart MUST NOT render an ExternalSecret on a
+Sovereign where bp-external-secrets has not yet registered the
+`external-secrets.io/v1beta1` CRD. Without the gate, a cold install
+fails with "no matches for kind ExternalSecret" — the same architectural
+pattern the bp-external-dns chart uses (issue #190).
+*/ -}}
+{{- $ci := .Values.catalystIntegration | default dict -}}
+{{- $es := $ci.externalSecret | default dict -}}
+{{- if and $ci.enabled $es.enabled (.Capabilities.APIVersions.Has "external-secrets.io/v1beta1") -}}
+{{- $store := $es.secretStoreRef | default dict -}}
+{{- $remote := $es.remoteRef | default dict -}}
+{{- $secretName := $ci.existingSecret | default "catalyst-newapi-admin-token" -}}
+{{- $remoteKey := $remote.key | default "" -}}
+{{- if not $remoteKey -}}
+{{- fail "catalystIntegration.externalSecret.enabled=true but catalystIntegration.externalSecret.remoteRef.key is empty — supply the per-Sovereign OpenBao path in the bootstrap-kit overlay (canonical: sovereign/<sovereign-fqdn>/newapi/admin-token)" -}}
+{{- end -}}
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: {{ $secretName | quote }}
+  labels:
+    {{- include "bp-newapi.labels" . | nindent 4 }}
+spec:
+  refreshInterval: {{ $es.refreshInterval | default "1h" | quote }}
+  secretStoreRef:
+    kind: {{ $store.kind | default "ClusterSecretStore" | quote }}
+    name: {{ $store.name | default "vault-region1" | quote }}
+  target:
+    name: {{ $secretName | quote }}
+    creationPolicy: Owner
+  data:
+    - secretKey: ADMIN_API_TOKEN
+      remoteRef:
+        key: {{ $remoteKey | quote }}
+        property: {{ $remote.property | default "ADMIN_API_TOKEN" | quote }}
+{{- end }}

--- a/platform/newapi/chart/templates/ingress.yaml
+++ b/platform/newapi/chart/templates/ingress.yaml
@@ -1,8 +1,23 @@
-{{- if and .Values.newapi.enabled .Values.ingress.enabled }}
+{{- /*
+Ingress + admin Ingress + Traefik allowlist Middleware. Both virtual
+hosts (`api.<sovereign-fqdn>` + `admin.<sovereign-fqdn>`) are
+operator-supplied via `ingress.host` + `ingress.adminHost` in the
+per-Sovereign bootstrap-kit overlay (slot 80-newapi.yaml).
+
+Skip-render gate: when EITHER host is empty, the chart's ingress block
+is silently skipped. This matches the pattern used by other bootstrap-
+kit HTTPRoute templates (bp-keycloak / bp-openbao / bp-external-dns)
+and lets the CI smoke render (`helm template` with default values)
+succeed end-to-end without smuggling a host placeholder. A real
+Sovereign install whose overlay forgets to set the hosts surfaces the
+gap as "no Ingress object materialised" — caught by the bootstrap-kit
+smoke test, not by render-time fail.
+*/ -}}
+{{- if and .Values.newapi.enabled .Values.ingress.enabled .Values.ingress.host .Values.ingress.adminHost }}
 {{- $fullName := include "bp-newapi.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-{{- $apiHost := required "ingress.host is required (customer-facing API hostname, e.g. api.<sovereign-fqdn>)" .Values.ingress.host -}}
-{{- $adminHost := required "ingress.adminHost is required (ops-staff admin UI hostname, e.g. admin.<sovereign-fqdn>)" .Values.ingress.adminHost -}}
+{{- $apiHost := .Values.ingress.host -}}
+{{- $adminHost := .Values.ingress.adminHost -}}
 ---
 # ─── Customer-facing API ingress ─────────────────────────────────────────
 # Locked-down: only the OpenAI-compatible API surface is reachable. The

--- a/platform/newapi/chart/values.yaml
+++ b/platform/newapi/chart/values.yaml
@@ -158,6 +158,45 @@ auth:
 #       kind: byok
 channels: []
 
+# First-otech default vLLM channel. Disabled by default — opt-in per
+# Sovereign via the bootstrap-kit overlay (slot 80-newapi.yaml). When
+# `enabled: true` AND `endpoint != ""`, the chart composes a `vllm`-typed
+# channel into the rendered channels list.
+#
+# Per docs/INVIOLABLE-PRINCIPLES.md #4 (never hardcode), the endpoint and
+# model identifiers are operator-supplied at install time. The Catalyst
+# repo references the OpenOva marketing site's wired upstream
+# (`https://llm-api.omtd.bankdhofar.com`, model `qwen3-coder`, used by
+# Axon at `openova-private/clusters/contabo-mkt/apps/axon/helmrelease.yaml`)
+# as the canonical first-otech default ONLY for documentation; the
+# chart's defaults here are empty so an unconfigured deploy does not
+# silently wire customers to a third-party endpoint.
+defaultChannels:
+  vllm:
+    # Set true in the per-Sovereign bootstrap-kit overlay. When false,
+    # this block is ignored and the channel is NOT composed.
+    enabled: false
+    # Customer-visible model prefix.
+    name: "qwen"
+    # Upstream vLLM endpoint URL. Operator-supplied. The chart never
+    # bakes a default endpoint — `helm template` with
+    # `defaultChannels.vllm.enabled: true` and an empty `endpoint` is a
+    # configuration error caught at render time.
+    endpoint: ""
+    # Models exposed via this channel.
+    models:
+      - "qwen3-coder"
+    # ExternalSecret name holding the upstream API key (omit for truly
+    # in-cluster vLLM where no key is required).
+    existingSecret: ""
+    # Attestation block. Default kind = `in-cluster` (operator owns the
+    # weights and inference hardware behind the relay). Overlay the kind
+    # to `commercial-contract` if the relay terminates at a third-party
+    # provider; in that case `accountId` + `contractRef` become required.
+    attestation:
+      kind: "in-cluster"
+      owner: ""
+
 # ─── Geographic AUP enforcement ──────────────────────────────────────────
 # Blocks requests from sanctioned regions on commercial-provider
 # channels. US/EU export-control baseline by default. Operator extends
@@ -198,13 +237,50 @@ reseller:
 # When enabled, the chart provisions a Kubernetes secret
 # `catalyst-newapi-admin-token` consumed by Catalyst's signup hook to
 # issue per-user API keys against NewAPI's admin API.
+#
+# ADR-0003 §3.2 + §6 binds this Secret. The unified-rbac service in the
+# OTECH control plane reads it and `Authorization: Bearer <ADMIN_API_TOKEN>`
+# against `http://newapi.newapi.svc/api/v1/admin/users` to issue per-user
+# keys. Idempotency on `external_id` (return-existing api_key on 409) is
+# the responsibility of the NewAPI admin API itself, not this chart.
 catalystIntegration:
   enabled: true
   # ExternalSecret name carrying the admin API token NewAPI generates at
   # bootstrap. Required key: ADMIN_API_TOKEN. The token is rotated by
   # the operator on a schedule documented in
   # docs/CATALYST-CLI-AGENT.md.
-  existingSecret: ""              # e.g. "catalyst-newapi-admin-token"
+  existingSecret: "catalyst-newapi-admin-token"
+
+  # ExternalSecret render — gated, default true. Sources the admin token
+  # from the operator's OpenBao via a ClusterSecretStore (default
+  # `vault-region1`, the bp-external-secrets-stores default). The remote
+  # path is operator-supplied; the canonical convention per
+  # docs/INVIOLABLE-PRINCIPLES.md #4 is
+  # `sovereign/<sovereign-fqdn>/newapi/admin-token` (under the store's
+  # `secret/` mount) with property `ADMIN_API_TOKEN`. The cluster overlay
+  # at `clusters/<sovereign>/bootstrap-kit/80-newapi.yaml` sets
+  # `externalSecret.remoteRef.key` per Sovereign.
+  externalSecret:
+    enabled: true
+    refreshInterval: "1h"
+    secretStoreRef:
+      # ClusterSecretStore (Catalyst default = `vault-region1`, shipped
+      # by bp-external-secrets-stores). Overlays may swap to a
+      # SecretStore by switching kind.
+      kind: "ClusterSecretStore"
+      name: "vault-region1"
+    # Remote OpenBao path. Per ADR-0001 the secret-store backend is
+    # OpenBao via the vault provider; the path uses the operator's
+    # convention. Operator overlay supplies the per-Sovereign value.
+    remoteRef:
+      # `key` is the OpenBao path under the ClusterSecretStore's base
+      # path (`secret/` in the Catalyst default). Operator overlay
+      # supplies the per-Sovereign value, e.g.:
+      #   sovereign/omantel.omani.works/newapi/admin-token
+      key: ""
+      # `property` is the JSON field inside the OpenBao secret holding
+      # the bearer token used by the Catalyst signup hook (ADR-0003 §3.2).
+      property: "ADMIN_API_TOKEN"
 
 # ─── Service ─────────────────────────────────────────────────────────────
 service:

--- a/scripts/expected-bootstrap-deps.yaml
+++ b/scripts/expected-bootstrap-deps.yaml
@@ -320,3 +320,17 @@ slots:
     name: bp-cluster-autoscaler-hcloud
     depends_on: []
     wave: present
+
+  # ---- Slot 80 — bp-newapi multi-tenant LLM marketplace gateway. Issue #799.
+  # Sequenced past the W2.K4 numbering plan (slots 36-48) so it never
+  # collides with the AI-runtime / observability / livekit cohort. The
+  # HelmRelease's dependsOn pins install order to AFTER bp-openbao(08),
+  # bp-keycloak(09), and bp-cnpg(16) Ready=True regardless of slot order:
+  #   - bp-openbao: backs the catalyst-newapi-admin-token ExternalSecret
+  #     consumed by unified-rbac (ADR-0003 §3.2 + §6).
+  #   - bp-keycloak: OIDC issuer for the ops-staff admin UI.
+  #   - bp-cnpg: Postgres for users/credits/channels/audit (claim-driven).
+  - slot: 80
+    name: bp-newapi
+    depends_on: [bp-openbao, bp-keycloak, bp-cnpg]
+    wave: present


### PR DESCRIPTION
## Summary

Closes #799. Matures the bp-newapi scratch chart so it can publish to
GHCR, slots it into the bootstrap-kit for every fresh Sovereign, and
binds it to the ADR-0003 admin-token contract that #802 (unified-rbac
SME-tier) consumes.

The blueprint-release CI for bp-newapi:1.0.0 has been failing at the
helm-template smoke gate since PR #396 merged (run 25213444992). This
PR fixes the root cause (four `required` calls + ingress host
`required` blocked the default-values render) by introducing
skip-render gates that match the pattern used by bp-keycloak,
bp-openbao, and bp-external-dns.

## Notable changes

- **`templates/external-secret.yaml` (NEW)** — renders the
  `catalyst-newapi-admin-token` ExternalSecret per ADR-0003 §3.2 + §6.
  Sourced from OpenBao via `vault-region1`. Capabilities-gated so cold
  installs without ESO don't fail-render.
- **`defaultChannels.vllm` block** — first-otech shorthand. When the
  per-Sovereign overlay enables it and supplies `endpoint`, the chart
  composes a vLLM-typed channel into the rendered list. The canonical
  reference is `https://llm-api.omtd.bankdhofar.com` model
  `qwen3-coder` (same relay Axon uses on the OpenOva marketing
  deployment); the chart's default endpoint is **empty** per Inviolable
  Principle #4.
- **Skip-render gates on Deployment + Ingress + ConfigMap-OIDC-block**
  so default-values render produces a non-empty output, satisfying the
  CI 5-line minimum without smuggling placeholder values.
- **Bootstrap-kit slot 80-newapi.yaml** — `dependsOn:
  [bp-openbao, bp-keycloak, bp-cnpg]`, every per-Sovereign override
  surfaced in `spec.values`.
- **Chart.yaml version bump 1.0.0 → 1.1.0** — additive features only;
  defensible per semver. The DoD on #799 named `0.1.0` but the chart
  was already published as `1.0.0` (see PR #396); regressing the
  version would violate semver. **Filing this minor bump as the most
  defensible default per the issue's "If undecidable, comment + pick
  most defensible default" clause.**

## Verification

```text
helm template smoke-newapi . --namespace smoke-newapi
  → 168 lines, 4 resources (NetworkPolicy / ServiceAccount /
    ConfigMap / Service)

helm template smoke-newapi . --namespace smoke-newapi -f overlay.yaml \\
    --api-versions external-secrets.io/v1beta1 \\
    --api-versions traefik.io/v1alpha1
  → 8 resources including Deployment, both Ingresses,
    Traefik allowlist Middleware, ExternalSecret. Composed
    qwen channel emitted with endpoint + models + attestation.

helm template smoke-newapi . --set defaultChannels.vllm.enabled=true
  → fail-fast: "defaultChannels.vllm.enabled=true but
    defaultChannels.vllm.endpoint is empty — supply the upstream
    vLLM relay URL in the per-Sovereign bootstrap-kit overlay
    (e.g. https://llm-api.omtd.bankdhofar.com)"
```

## Test plan

- [ ] Blueprint-release CI green on bp-newapi:1.1.0 path matrix
- [ ] `oci://ghcr.io/openova-io/bp-newapi:1.1.0` published + cosigned + SBOM-attested
- [ ] First otech that picks up the new bootstrap-kit reconciles bp-newapi to Ready=True
- [ ] `catalyst-newapi-admin-token` Secret materialises in `newapi` ns from OpenBao
- [ ] vLLM channel responds to a curl test once a Sovereign overlay enables `defaultChannels.vllm`

## Refs

- ADR-0003 — RBAC ↔ NewAPI user-create hook contract
- #795 (epic) — SME-tenant turnkey experience
- #796 (sequential blocker, merged) — hook contract spec
- #802 — unified-rbac SME-tier (consumes the ExternalSecret rendered here)

## Inviolable principles satisfied

- #1 event-driven (Flux dependsOn, no cron)
- #3 Crossplane / Flux / Blueprint pipeline (no bespoke API calls)
- #4 never hardcode (every URL/endpoint/model is operator-supplied)
- #11 GitHub-Actions-only build path (CI publishes the OCI artifact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)