### PR TITLE
fix(blueprints): align 9 blueprint.yaml spec.version with Chart.yaml (#817)

### DIFF
--- a/platform/cert-manager/blueprint.yaml
+++ b/platform/cert-manager/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-3-3-security-and-policy
 spec:
-  version: 1.1.1
+  version: 1.1.2
   card:
     title: cert-manager
     summary: TLS certificate automation. Lets Encrypt issuer with Dynadot DNS-01 for omani.works pool, HTTP-01 for BYO domains.

--- a/platform/crossplane/blueprint.yaml
+++ b/platform/crossplane/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-3-2-gitops-and-iac
 spec:
-  version: 1.1.3
+  version: 1.1.4
   card:
     title: crossplane
     summary: |

--- a/platform/flux/blueprint.yaml
+++ b/platform/flux/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-3-2-gitops-and-iac
 spec:
-  version: 1.1.3
+  version: 1.1.4
   card:
     title: flux
     summary: GitOps reconciler. One per vcluster (source + kustomize + helm controllers); host-level Flux per host cluster watches its bp-* OCI sources.

--- a/platform/gitea/blueprint.yaml
+++ b/platform/gitea/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
 spec:
-  version: 1.2.1
+  version: 1.2.3
   card:
     title: gitea
     summary: Gitea — per-Sovereign Git server. Catalyst control plane. Hosts catalog (public Blueprint mirror), catalog-sovereign (Sovereign-curated private Blueprints), one Gitea Org per Catalyst Organization, and system (sovereign-admin scope).

--- a/platform/keycloak/blueprint.yaml
+++ b/platform/keycloak/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
 spec:
-  version: 1.3.1
+  version: 1.3.2
   card:
     title: keycloak
     summary: Keycloak — user identity. Topology decided by Sovereign CRD spec.keycloakTopology (per-organization for SME, shared-sovereign for corporate).

--- a/platform/nats-jetstream/blueprint.yaml
+++ b/platform/nats-jetstream/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
 spec:
-  version: 1.1.1
+  version: 1.1.2
   card:
     title: nats-jetstream
     summary: Event spine for the Catalyst control plane. JetStream Streams + KV. Per-Organization Accounts. Replaces what was previously specified as Redpanda + Valkey for the control plane.

--- a/platform/openbao/blueprint.yaml
+++ b/platform/openbao/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
 spec:
-  version: 1.2.0
+  version: 1.2.14
   card:
     title: openbao
     summary: OpenBao secret backend. 3-node Raft per region (independent quorum, async perf-replication across regions). MPL 2.0 — drop-in Vault replacement.

--- a/platform/sealed-secrets/blueprint.yaml
+++ b/platform/sealed-secrets/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-3-3-security-and-policy
 spec:
-  version: 1.1.1
+  version: 1.1.2
   card:
     title: sealed-secrets
     summary: Sealed Secrets — used during Phase 0 bootstrap to transport bootstrap-only secrets, then archived after OpenBao + ESO replace it.

--- a/platform/spire/blueprint.yaml
+++ b/platform/spire/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
 spec:
-  version: 1.1.4
+  version: 1.1.7
   card:
     title: spire
     summary: SPIFFE/SPIRE workload identity. 5-min rotating SVIDs. Server on mgt cluster + agent per host cluster.


### PR DESCRIPTION
## Summary

Closes #817. `TestBootstrapKit_BlueprintCardsHaveRequiredFields` was failing on main for 9 blueprints because their `platform/<name>/chart/Chart.yaml` `version` had been bumped without a matching update to `platform/<name>/blueprint.yaml` `spec.version`. The persistent CI failure has been forcing 7 recent PRs (#806, #808, #809, #811, #813, #814, #815) to self-merge with `--admin`, which masks real failures.

This PR realigns the 9 drifted versions so the test goes green on main and `--admin` is no longer needed for SME-track PRs.

| Blueprint | Chart.yaml | blueprint.yaml (was -> now) |
|---|---|---|
| cert-manager | 1.1.2 | 1.1.1 -> **1.1.2** |
| flux | 1.1.4 | 1.1.3 -> **1.1.4** |
| crossplane | 1.1.4 | 1.1.3 -> **1.1.4** |
| sealed-secrets | 1.1.2 | 1.1.1 -> **1.1.2** |
| spire | 1.1.7 | 1.1.4 -> **1.1.7** |
| nats-jetstream | 1.1.2 | 1.1.1 -> **1.1.2** |
| openbao | 1.2.14 | 1.2.0 -> **1.2.14** |
| keycloak | 1.3.2 | 1.3.1 -> **1.3.2** |
| gitea | 1.2.3 | 1.2.1 -> **1.2.3** |

## Guardrail

The existing `TestBootstrapKit_BlueprintCardsHaveRequiredFields` (`tests/e2e/bootstrap-kit/main_test.go:145`) already enforces `Chart.yaml.version == blueprint.yaml.spec.version`. The cause of the drift is purely human-process — chart bumps that didn't carry a matching blueprint bump. The test is itself the catch-future-drift gate; no additional script needed. Skipped the bonus per scope discipline.

## Out of scope

`products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts` is auto-generated from these blueprints and now needs regeneration as a side-effect, BUT the regen also pulls in unrelated drift (5 new blueprint entries: openclaw, self-sovereign-cutover, stalwart-tenant, wordpress-tenant + an unrelated kserve version bump). Reverting that file from this PR keeps the diff small and on-topic; the catalog will regenerate naturally when the next consumer of those blueprints lands.

## Test plan

- [x] All 9 blueprint.yaml versions match their Chart.yaml versions (verified via grep)
- [x] Local `go test ./... -run TestBootstrapKit_BlueprintCardsHaveRequiredFields -count=1` passes (10/10 sub-tests)
- [ ] CI `manifest-validation` job passes on this PR
- [ ] PR merged, `manifest-validation` green on main