### PR TITLE
fix(bp-catalyst-platform): add cutover-driver RBAC for catalyst-api (#830)

### DIFF
--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: bp-catalyst-platform
-version: 1.3.1
-appVersion: 1.3.1
+version: 1.3.2
+appVersion: 1.3.2
 description: |
   Catalyst Platform — the unified Catalyst control plane umbrella chart for Catalyst-Zero.
   Composes the catalyst-{ui,api}, console, admin, marketplace UI modules and the marketplace-api backend.
@@ -236,6 +236,32 @@ description: |
   OAuth client_credentials calls switch to the Service URL.
   Catalyst-Zero (contabo) uses keycloak-zero (separate chart) and
   is unaffected. 2026-05-04.
+
+  Bumped to 1.3.2 — Day-2 cutover RBAC P0 fix (otech102 incident,
+  2026-05-04, issue #830 Bug 1). The /api/v1/sovereign/cutover/start
+  endpoint returned 502 status-read-failed: "User
+  \"system:serviceaccount:catalyst-system:default\" cannot get resource
+  \"configmaps\" in API group \"\" in the namespace \"catalyst\"". The
+  catalyst-api Pod was running under the catalyst-system/default
+  ServiceAccount with no Role/ClusterRole binding to read or patch the
+  cutover ConfigMaps + create/watch Jobs in the `catalyst` namespace
+  where bp-self-sovereign-cutover ships its step ConfigMaps.
+  Fix: add a dedicated ServiceAccount + ClusterRole + ClusterRoleBinding
+  shipped by THIS chart:
+    - serviceaccount-cutover-driver.yaml — ServiceAccount
+      catalyst-api-cutover-driver in catalyst-system
+    - clusterrole-cutover-driver.yaml — ClusterRole granting
+      get/list/watch + patch on configmaps; create/get/list/watch/
+      delete/patch on batch/jobs; get/list/watch on pods + apps/
+      deployments + apps/daemonsets; create on events. Per
+      feedback_rbac_create_no_resourcenames.md the `create` verbs are
+      split into their own Rule WITHOUT resourceNames (combining
+      create + resourceNames produces 403 every POST).
+    - clusterrolebinding-cutover-driver.yaml — bind the SA to the
+      ClusterRole at cluster scope (cutover namespace is runtime-
+      configurable via CATALYST_CUTOVER_NAMESPACE).
+  Plus api-deployment.yaml: spec.serviceAccountName set to
+  catalyst-api-cutover-driver. Issue #830, 2026-05-04.
 type: application
 
 # Opt-out from the blueprint-release hollow-chart guard (issue #181 / #510).

--- a/products/catalyst/chart/templates/api-deployment.yaml
+++ b/products/catalyst/chart/templates/api-deployment.yaml
@@ -119,6 +119,20 @@ spec:
       labels:
         app.kubernetes.io/name: catalyst-api
     spec:
+      # serviceAccountName — bind the Pod to the dedicated cutover-driver
+      # ServiceAccount so the /api/v1/sovereign/cutover/start handler can
+      # read/patch the cutover ConfigMaps + create/watch Jobs in the
+      # `catalyst` namespace. See serviceaccount-cutover-driver.yaml +
+      # clusterrole-cutover-driver.yaml + clusterrolebinding-cutover-
+      # driver.yaml for the full RBAC graph (issue #830 P0 Bug 1).
+      #
+      # The SA is created by THIS chart in the same namespace catalyst-api
+      # runs in (catalyst-system) and bound at cluster scope (the cutover
+      # endpoint is namespace-configurable via CATALYST_CUTOVER_NAMESPACE).
+      # Without this, the Pod runs as system:serviceaccount:catalyst-
+      # system:default and every cutover-status read returns 502
+      # "configmaps is forbidden" (caught live on otech102, 2026-05-04).
+      serviceAccountName: catalyst-api-cutover-driver
       imagePullSecrets:
         - name: ghcr-pull
       # fsGroup applies to the volumes mounted into the Pod so the

--- a/products/catalyst/chart/templates/clusterrole-cutover-driver.yaml
+++ b/products/catalyst/chart/templates/clusterrole-cutover-driver.yaml
@@ -1,0 +1,80 @@
+{{- /*
+ClusterRole granting catalyst-api the verbs needed to drive the
+self-sovereignty cutover endpoint (issue #792, #830 P0 Bug 1).
+
+CRITICAL — feedback_rbac_create_no_resourcenames.md (auto-memory anchor):
+Kubernetes RBAC forbids combining `create` verbs with `resourceNames`.
+A POST request has no resource name yet; the apiserver MUST evaluate
+the rule against the request without a name match, and a `resourceNames`
+set with `create` produces a 403 every time. This caused the bp-openbao
+6+ provisioning loop. We split `create` into its own Rule with NO
+`resourceNames` and keep `update/patch/get/delete` in a separate Rule.
+
+What catalyst-api needs to do across namespaces (cutover sequence):
+  - read configmaps in the cutover namespace (default `catalyst`):
+    cutover-step PodSpec ConfigMaps + the self-sovereign-cutover-status
+    ConfigMap
+  - patch the status ConfigMap on every step transition
+  - create batchv1.Job from each PodSpec ConfigMap
+  - watch jobs to completion / Failed
+  - delete completed jobs after status capture (housekeeping)
+  - read daemonsets/deployments status for daemonset-wait + deployment-
+    targeted steps (step 04 registry-pivot DaemonSet readiness, step 07
+    catalyst-api Deployment env patch)
+  - emit Events as steps complete (operator-visible kube events)
+
+ClusterRole (not Role) because the cutover handler today is namespace-
+configurable via env CATALYST_CUTOVER_NAMESPACE — defaulting to
+`catalyst` but operators may relocate. A namespaced Role would couple
+the chart to a single namespace forever.
+*/ -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: catalyst-api-cutover-driver
+  labels:
+    app.kubernetes.io/name: catalyst-api
+    app.kubernetes.io/component: cutover-driver-rbac
+rules:
+  # ───────────────────────────────────────────────────────────────
+  # CREATE verbs — MUST be in their own Rule WITHOUT resourceNames.
+  # Per feedback_rbac_create_no_resourcenames.md this split is
+  # load-bearing: combining `create` with resourceNames produces a 403
+  # at every POST because the apiserver has no resource name to match
+  # the rule against on the create path.
+  # ───────────────────────────────────────────────────────────────
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["create"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create"]
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["create"]
+
+  # ───────────────────────────────────────────────────────────────
+  # READ verbs — get/list/watch on the resources the handler reads.
+  # ───────────────────────────────────────────────────────────────
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["pods", "pods/log"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apps"]
+    resources: ["deployments", "daemonsets"]
+    verbs: ["get", "list", "watch"]
+
+  # ───────────────────────────────────────────────────────────────
+  # UPDATE / PATCH / DELETE — separate from create per RBAC rule.
+  # ───────────────────────────────────────────────────────────────
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["update", "patch"]
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["delete", "patch", "update"]

--- a/products/catalyst/chart/templates/clusterrolebinding-cutover-driver.yaml
+++ b/products/catalyst/chart/templates/clusterrolebinding-cutover-driver.yaml
@@ -1,0 +1,23 @@
+{{- /*
+ClusterRoleBinding tying the catalyst-api-cutover-driver ServiceAccount
+to the same-named ClusterRole (issue #830, P0 Bug 1).
+
+This binding is what makes catalyst-api able to read/patch the cutover
+ConfigMaps + create/watch the cutover Jobs in the `catalyst` namespace
+when the operator hits POST /api/v1/sovereign/cutover/start.
+*/ -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: catalyst-api-cutover-driver
+  labels:
+    app.kubernetes.io/name: catalyst-api
+    app.kubernetes.io/component: cutover-driver-rbac
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: catalyst-api-cutover-driver
+subjects:
+  - kind: ServiceAccount
+    name: catalyst-api-cutover-driver
+    namespace: {{ .Release.Namespace }}

--- a/products/catalyst/chart/templates/serviceaccount-cutover-driver.yaml
+++ b/products/catalyst/chart/templates/serviceaccount-cutover-driver.yaml
@@ -1,0 +1,38 @@
+{{- /*
+ServiceAccount used by the catalyst-api Pod to drive the
+self-sovereignty cutover endpoint (issue #792).
+
+After handover, catalyst-api on the Sovereign cluster handles
+POST /api/v1/sovereign/cutover/start. The handler:
+  - reads the cutover-step PodSpec ConfigMaps in the `catalyst` namespace
+    (selected by app.kubernetes.io/part-of=self-sovereign-cutover)
+  - stamps batchv1.Job objects from those PodSpecs in the same namespace
+  - patches the self-sovereign-cutover-status ConfigMap as each step
+    transitions, recording state machine progress
+  - watches Job status to completion / Failed
+  - inspects DaemonSet readiness for daemonset-wait steps
+
+catalyst-api itself runs in the `catalyst-system` namespace (per the
+chart's targetNamespace) under THIS ServiceAccount. The ClusterRoleBinding
+in clusterrolebinding-cutover-driver.yaml binds it to the ClusterRole that
+grants the verbs above across the catalyst namespace.
+
+Why a dedicated SA (not `default`):
+  - The proof loop on otech102 surfaced a 502 status-read-failed:
+    "User \"system:serviceaccount:catalyst-system:default\" cannot get
+    resource \"configmaps\" in API group \"\" in the namespace \"catalyst\""
+    because no Role/ClusterRole was bound to the default SA. Granting
+    cluster-scope cutover-driver verbs to the default SA would leak
+    those permissions to every other Pod in catalyst-system.
+  - Per docs/INVIOLABLE-PRINCIPLES.md #10 (least privilege), bespoke
+    workload SAs are the canonical pattern. This SA is referenced
+    explicitly in api-deployment.yaml's spec.serviceAccountName.
+*/ -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: catalyst-api-cutover-driver
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: catalyst-api
+    app.kubernetes.io/component: cutover-driver-sa


### PR DESCRIPTION
## Summary
- Add ServiceAccount + ClusterRole + ClusterRoleBinding so catalyst-api can drive the self-sovereignty cutover state machine in the `catalyst` namespace
- Bind the catalyst-api Pod to the new SA via `spec.serviceAccountName`
- Bump `bp-catalyst-platform` 1.3.1 → 1.3.2

## Why
Proof loop on otech102 surfaced \`POST /api/v1/sovereign/cutover/start\` returning 502 status-read-failed:
\`\`\`
User "system:serviceaccount:catalyst-system:default" cannot get
resource "configmaps" in API group "" in the namespace "catalyst"
\`\`\`
catalyst-api runs in catalyst-system under default SA and the chart never shipped a cutover-driver RBAC binding. Without this, the cutover endpoint is unusable on every fresh Sovereign.

## RBAC shape
- Per [feedback_rbac_create_no_resourcenames.md](https://github.com/openova-io/openova/blob/main/docs/INVIOLABLE-PRINCIPLES.md) the \`create\` verbs are split into their own Rule WITHOUT \`resourceNames\` — combining them produces 403 every POST
- Verbs: get/list/watch + patch on configmaps; create/get/list/watch/delete/patch on batch/jobs; get/list/watch on pods + apps/deployments + apps/daemonsets; create on events
- ClusterRole (not Role) because the cutover namespace is runtime-configurable via \`CATALYST_CUTOVER_NAMESPACE\`

## Test plan
- [x] \`helm template\` renders cleanly with all 3 new resources + the SA reference on the Deployment
- [ ] Re-run proof loop on otech103: cutover-driver SA observed in \`catalyst-system\`, ClusterRole + Binding present, \`POST /sovereign/cutover/start\` returns 200 with the 8-step plan

Closes part of openova-io/openova#830 (Bug 1).