### PR TITLE
fix(catalyst-api): durable Phase-1 watcher across Pod restart (#830)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/deployments.go
+++ b/products/catalyst/bootstrap/api/internal/handler/deployments.go
@@ -369,12 +369,32 @@ func fromRecord(rec store.Record) *Deployment {
 		}
 	}
 
-	// In-flight at restart time → failed. The wizard's FailureCard is
-	// the right surface for this state — operator must purge the
-	// orphaned cloud resources by hand because catalyst-api can't
-	// resume an OpenTofu run mid-apply (state-lock + the workdir on
-	// /tmp emptyDir died with the previous Pod).
-	if isInFlightStatus(rec.Status) {
+	// Phase-0 in-flight at restart time → failed. The wizard's
+	// FailureCard is the right surface for this state — operator must
+	// purge the orphaned cloud resources by hand because catalyst-api
+	// can't resume an OpenTofu run mid-apply (state-lock + the workdir
+	// on /tmp emptyDir died with the previous Pod).
+	//
+	// "phase1-watching" is deliberately EXCLUDED from this rewrite (issue
+	// #830 Bug 3). Phase 1 is purely observational — Phase 0 has already
+	// committed its tofu state, the Hetzner resources exist and are
+	// reachable, the kubeconfig is on the PVC, and the bootstrap-kit
+	// HelmReleases keep reconciling on the Sovereign cluster regardless
+	// of whether catalyst-api's in-memory watcher is alive. The new Pod
+	// can re-attach the helmwatch informer and continue streaming
+	// per-component state. The on-disk record retains Status=
+	// "phase1-watching" so /deployments/{id} keeps reporting the truth
+	// (the watch is in-flight, not failed) until the resumed watcher
+	// terminates and markPhase1Done flips Status to ready/failed.
+	//
+	// Without this carve-out, a transient catalyst-api roll mid-Phase-1
+	// (image bump, OOM, node maintenance) latches the deployment record
+	// to status=failed even though the Sovereign cluster reaches Ready=
+	// True for every HelmRelease seconds later — the auto-fire handover
+	// then never triggers and the operator is stranded on the wizard
+	// page. otech102 incident, 2026-05-04. The downstream resume happens
+	// in restoreFromStore via shouldResumePhase1 + resumePhase1Watch.
+	if isPhase0InFlightStatus(rec.Status) {
 		dep.Status = "failed"
 		dep.Error = "catalyst-api restarted during provisioning — this deployment was abandoned mid-apply. Hetzner resources tagged with `catalyst-deployment-id=" + rec.ID + "` are orphans and must be purged manually (hcloud server, lb, network, firewall, ssh-key) before retrying. The wizard cannot resume — start a new deployment."
 		dep.FinishedAt = time.Now()
@@ -382,9 +402,28 @@ func fromRecord(rec store.Record) *Deployment {
 	return dep
 }
 
+// isInFlightStatus reports whether a deployment is operationally
+// still running. Used by the orphan-PDM-release decision logic to
+// avoid releasing a slot that's still active.
 func isInFlightStatus(s string) bool {
 	switch s {
 	case "pending", "provisioning", "tofu-applying", "flux-bootstrapping", "phase1-watching":
+		return true
+	}
+	return false
+}
+
+// isPhase0InFlightStatus reports whether a deployment was abandoned
+// mid-Phase-0 (a state catalyst-api cannot resume — tofu workdir lives
+// on /tmp emptyDir which dies with the Pod). These statuses get
+// rewritten to "failed" on restart so the wizard renders FailureCard.
+//
+// "phase1-watching" is deliberately EXCLUDED — Phase 1 is observational
+// and resumable across Pod restarts. See fromRecord's comment for the
+// full rationale (issue #830 Bug 3).
+func isPhase0InFlightStatus(s string) bool {
+	switch s {
+	case "pending", "provisioning", "tofu-applying", "flux-bootstrapping":
 		return true
 	}
 	return false
@@ -580,11 +619,18 @@ func (h *Handler) releaseOrphanedReservation(deploymentID, poolDomain, subdomain
 // criteria are:
 //   - Result.KubeconfigPath is non-empty AND points at a readable file
 //   - Phase 1 has NOT already terminated (Phase1FinishedAt == nil)
-//   - Status was not rewritten by fromRecord — i.e. the original
-//     status was NOT phase1-watching (which fromRecord rewrote to
-//     failed). A genuinely-finished "ready" or "failed" deployment
-//     is not resumed; only one that survived a restart with the
-//     watch still owing work.
+//   - Original on-disk status was NOT a Phase-0 in-flight state (those
+//     are unrecoverable — fromRecord rewrites them to "failed")
+//
+// Resume IS triggered for the following original statuses:
+//   - "phase1-watching" — the canonical durable-watcher case (issue
+//     #830 Bug 3). Phase 0 already committed its tofu state, the
+//     Sovereign cluster is healthy, and the new Pod re-attaches the
+//     helmwatch informer to continue streaming per-component events.
+//   - Terminal states ("ready", "failed", "adopted") with
+//     Phase1FinishedAt == nil — contract-violation residual; resume is
+//     the safer-default action because the helmwatch is idempotent
+//     (it just observes HelmRelease.status — no patches/applies).
 //
 // Why we resume even when rec.Status is "ready" but Phase1FinishedAt
 // is nil: that combination is a contract violation — markPhase1Done
@@ -599,9 +645,13 @@ func (h *Handler) shouldResumePhase1(dep *Deployment, rec store.Record) bool {
 	if dep.Result.Phase1FinishedAt != nil {
 		return false
 	}
-	// fromRecord rewrites in-flight statuses (including
-	// "phase1-watching") to "failed" — those are not resumable.
-	if isInFlightStatus(rec.Status) {
+	// Phase-0 in-flight statuses are rewritten to "failed" by
+	// fromRecord — those are not resumable (tofu workdir died with
+	// the previous Pod, Hetzner resources are orphaned).
+	// "phase1-watching" is NOT in this set per issue #830 Bug 3 — the
+	// watcher IS resumable, and resuming is the whole point of the
+	// durable-watcher fix.
+	if isPhase0InFlightStatus(rec.Status) {
 		return false
 	}
 	if _, err := os.Stat(dep.Result.KubeconfigPath); err != nil {

--- a/products/catalyst/bootstrap/api/internal/handler/kubeconfig_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/kubeconfig_test.go
@@ -724,9 +724,21 @@ func TestShouldResumePhase1_GatesProperly(t *testing.T) {
 			want: false,
 		},
 		{
-			name: "in-flight-rewritten-to-failed",
+			// Issue #830 Bug 3 — phase1-watching is now RESUMABLE.
+			// Phase 0 already committed its tofu state; the watcher
+			// is the only thing that needs re-attaching across a Pod
+			// restart, and it's idempotent.
+			name: "phase1-watching-resumes",
 			dep:  &Deployment{Result: &provisioner.Result{KubeconfigPath: existingFile}},
 			rec:  store.Record{Status: "phase1-watching"},
+			want: true,
+		},
+		{
+			// Phase-0 in-flight statuses remain non-resumable (tofu
+			// workdir on /tmp emptyDir died with the previous Pod).
+			name: "phase0-tofu-applying-not-resumable",
+			dep:  &Deployment{Result: &provisioner.Result{KubeconfigPath: existingFile}},
+			rec:  store.Record{Status: "tofu-applying"},
 			want: false,
 		},
 		{

--- a/products/catalyst/bootstrap/api/internal/handler/phase1_watch_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/phase1_watch_test.go
@@ -16,9 +16,13 @@
 //     warn event and still calls markPhase1Done so Status doesn't
 //     stay "phase1-watching" forever.
 //  5. Pod-restart resume — a deployment loaded from disk with
-//     Status="phase1-watching" gets rewritten to "failed" by
-//     fromRecord (existing contract) so a Pod kill mid-watch
-//     surfaces as the wizard's FailureCard, not a stuck pill.
+//     Status="phase1-watching" KEEPS that status (issue #830 Bug 3:
+//     Phase 1 is observational and resumable across Pod restarts —
+//     the helmwatch informer is re-attached on the new Pod and the
+//     deployment record reflects the truth: the watch is in-flight,
+//     not abandoned). Phase-0 in-flight statuses still rewrite to
+//     "failed" because tofu workdir lives on /tmp emptyDir and dies
+//     with the Pod.
 //  6. CATALYST_PHASE1_WATCH_TIMEOUT env var parses through
 //     phase1WatchConfigForDeployment.
 //  7. The on-disk store record JSON includes ComponentStates +
@@ -609,12 +613,25 @@ func TestPodRestart_ResumeRehydratesComponentStates(t *testing.T) {
 	}
 }
 
-// TestPodRestart_StuckPhase1WatchingRewrittenToFailed proves the
-// existing in-flight-status rewrite covers the "phase1-watching"
-// case the Phase-1 watch introduced. A Pod kill mid-watch must NOT
-// leave a deployment stuck at phase1-watching; the wizard's
-// FailureCard renders instead.
-func TestPodRestart_StuckPhase1WatchingRewrittenToFailed(t *testing.T) {
+// TestPodRestart_Phase1WatchingPreservedNotRewrittenToFailed proves
+// the issue #830 Bug 3 fix: a deployment loaded from disk with
+// Status="phase1-watching" but no kubeconfig file (so no resume
+// happens) PRESERVES the phase1-watching status — it does NOT get
+// rewritten to "failed" the way Phase-0 in-flight states do.
+//
+// Why this matters: a transient catalyst-api roll mid-Phase-1
+// (image bump, OOM, node maintenance) used to latch the deployment
+// record to status=failed even though the Sovereign cluster was
+// reaching Ready=True for every HelmRelease seconds later. The
+// auto-fire handover then never triggered and the operator was
+// stranded on the wizard page. Phase 1 is purely observational —
+// the on-disk record stays phase1-watching until the resumed
+// watcher's markPhase1Done flips it to ready/failed.
+//
+// This test exercises the no-kubeconfig branch (status preserved,
+// resume skipped). The companion test below exercises the
+// with-kubeconfig branch where resume IS triggered.
+func TestPodRestart_Phase1WatchingPreservedNotRewrittenToFailed(t *testing.T) {
 	tmp := t.TempDir()
 	st1, err := store.New(tmp)
 	if err != nil {
@@ -622,8 +639,8 @@ func TestPodRestart_StuckPhase1WatchingRewrittenToFailed(t *testing.T) {
 	}
 
 	rec := store.Record{
-		ID:        "rehydrate-stuck-phase1",
-		Status:    "phase1-watching", // in-flight at restart
+		ID:        "rehydrate-phase1-watching",
+		Status:    "phase1-watching",
 		StartedAt: time.Now().Add(-5 * time.Minute).UTC(),
 		Request: store.RedactedRequest{
 			SovereignFQDN: "test.example",
@@ -631,6 +648,7 @@ func TestPodRestart_StuckPhase1WatchingRewrittenToFailed(t *testing.T) {
 		},
 		Result: &provisioner.Result{
 			SovereignFQDN: "test.example",
+			// KubeconfigPath empty so resumePhase1Watch is skipped.
 		},
 	}
 	if err := st1.Save(rec); err != nil {
@@ -645,11 +663,123 @@ func TestPodRestart_StuckPhase1WatchingRewrittenToFailed(t *testing.T) {
 
 	val, _ := h.deployments.Load(rec.ID)
 	dep := val.(*Deployment)
-	if dep.Status != "failed" {
-		t.Errorf("Status = %q, want %q (in-flight phase1-watching must rewrite to failed)", dep.Status, "failed")
+	if dep.Status != "phase1-watching" {
+		t.Errorf("Status = %q, want %q (Phase-1 watching is resumable, must NOT be rewritten to failed)", dep.Status, "phase1-watching")
 	}
-	if dep.Error == "" {
-		t.Errorf("Error empty — operator wouldn't know why this deployment failed")
+}
+
+// TestPodRestart_Phase1WatchingResumesWithKubeconfig proves the
+// happy-path of issue #830 Bug 3: a deployment loaded from disk
+// with Status="phase1-watching" + Result.KubeconfigPath pointing at
+// a real file triggers shouldResumePhase1=true and the new Pod
+// re-attaches the helmwatch goroutine.
+//
+// We don't drive the watcher to completion here — that's covered
+// by the runPhase1Watch happy-path tests above. The test asserts
+// the gating decision: the rehydrated deployment is a resume
+// candidate (shouldResumePhase1 returns true on the rec the store
+// loads back).
+func TestPodRestart_Phase1WatchingResumesWithKubeconfig(t *testing.T) {
+	tmp := t.TempDir()
+	st, err := store.New(tmp)
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+
+	kcPath := filepath.Join(tmp, "kubeconfigs", "resume-phase1.yaml")
+	if err := os.MkdirAll(filepath.Dir(kcPath), 0o700); err != nil {
+		t.Fatalf("mkdir kubeconfigs: %v", err)
+	}
+	if err := os.WriteFile(kcPath, []byte("fake-kubeconfig: yaml"), 0o600); err != nil {
+		t.Fatalf("write kubeconfig: %v", err)
+	}
+
+	rec := store.Record{
+		ID:        "resume-phase1",
+		Status:    "phase1-watching",
+		StartedAt: time.Now().Add(-5 * time.Minute).UTC(),
+		Request: store.RedactedRequest{
+			SovereignFQDN: "test.example",
+			Region:        "fsn1",
+		},
+		Result: &provisioner.Result{
+			SovereignFQDN:  "test.example",
+			KubeconfigPath: kcPath,
+			// Phase1FinishedAt nil → watcher had not yet terminated
+			// when the previous Pod died.
+		},
+	}
+	if err := st.Save(rec); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	// Build a handler against the on-disk store. We do NOT exercise
+	// runPhase1Watch end-to-end here (that's covered above); we only
+	// assert the gating decision (shouldResumePhase1=true) and the
+	// preserved Status value, both of which are the load-bearing
+	// pieces of the issue #830 Bug 3 fix.
+	h := NewWithStore(silentLogger(), &fakePDM{}, st)
+
+	// Confirm the gating decision matches expectation.
+	dep := fromRecord(rec)
+	if !h.shouldResumePhase1(dep, rec) {
+		t.Errorf("shouldResumePhase1 = false, want true (Status=phase1-watching + KubeconfigPath set + Phase1FinishedAt nil)")
+	}
+
+	// Confirm the loaded deployment preserves the phase1-watching
+	// status (issue #830 Bug 3 — fromRecord must NOT rewrite it to
+	// failed).
+	if dep.Status != "phase1-watching" {
+		t.Errorf("dep.Status = %q, want %q after fromRecord", dep.Status, "phase1-watching")
+	}
+}
+
+// TestPodRestart_Phase0InFlightStillRewrittenToFailed proves the
+// Phase-0 in-flight statuses (pending/provisioning/tofu-applying/
+// flux-bootstrapping) are still rewritten to "failed" on Pod
+// restart — these are unrecoverable because the OpenTofu workdir
+// lives on /tmp emptyDir and dies with the Pod.
+//
+// Carved out from the earlier "everything in-flight → failed" rule
+// which was overly broad and was breaking the durable Phase-1
+// watcher (issue #830 Bug 3).
+func TestPodRestart_Phase0InFlightStillRewrittenToFailed(t *testing.T) {
+	for _, status := range []string{"pending", "provisioning", "tofu-applying", "flux-bootstrapping"} {
+		t.Run(status, func(t *testing.T) {
+			tmp := t.TempDir()
+			st1, err := store.New(tmp)
+			if err != nil {
+				t.Fatalf("store.New: %v", err)
+			}
+
+			rec := store.Record{
+				ID:        "rehydrate-phase0-" + status,
+				Status:    status,
+				StartedAt: time.Now().Add(-5 * time.Minute).UTC(),
+				Request: store.RedactedRequest{
+					SovereignFQDN: "test.example",
+					Region:        "fsn1",
+				},
+			}
+			if err := st1.Save(rec); err != nil {
+				t.Fatalf("Save: %v", err)
+			}
+
+			st2, err := store.New(tmp)
+			if err != nil {
+				t.Fatalf("store.New (restart): %v", err)
+			}
+			h := NewWithStore(silentLogger(), &fakePDM{}, st2)
+
+			val, _ := h.deployments.Load(rec.ID)
+			dep := val.(*Deployment)
+			if dep.Status != "failed" {
+				t.Errorf("Status = %q, want %q (Phase-0 in-flight must rewrite to failed — tofu workdir died with Pod)", dep.Status, "failed")
+			}
+			if dep.Error == "" {
+				t.Errorf("Error empty — operator wouldn't know why this deployment failed")
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary
- Stop rewriting \`phase1-watching\` to \`failed\` on Pod restart (it's resumable!)
- Carve out a new \`isPhase0InFlightStatus\` helper for the four Phase-0 statuses that legitimately must fail on restart
- Update \`shouldResumePhase1\` to allow resume from \`phase1-watching\` (the new canonical case)
- Updated tests to reflect the new correct behavior + added positive test for the resume path

## Why
Caught live on otech102 (2026-05-04): a transient catalyst-api roll mid-Phase-1 latched the deployment to \`status=failed\`, the auto-fire handover never triggered, and the operator was stranded on the wizard page. Manual workaround was patching the record back + minting handover token by hand.

Phase 1 is purely observational — Phase 0 has already committed its tofu state, the Sovereign cluster is healthy, the kubeconfig is on the PVC, and the bootstrap-kit HelmReleases keep reconciling regardless of whether catalyst-api's in-memory watcher is alive. The new Pod can re-attach the helmwatch informer and continue streaming per-component events.

## Architecture
\`\`\`
                BEFORE (phase1-watching rewritten to failed)        AFTER (phase1-watching preserved + resumed)
                ──────────────────────────────────────────         ──────────────────────────────────────────
Pod restart →   isInFlightStatus("phase1-watching") = true         isPhase0InFlightStatus("phase1-watching") = false
fromRecord →    Status: phase1-watching → failed                   Status: phase1-watching (preserved)
restoreFromStore → orphan-PDM-release fires                        shouldResumePhase1 = true → resumePhase1Watch
                                                                   ↓
                                                                   helmwatch informer re-attached
                                                                   per-component events resume
                                                                   markPhase1Done flips to ready/failed
                                                                   auto-fire handover → operator console
\`\`\`

## Test plan
- [x] \`go build ./...\` passes
- [x] \`go test ./internal/handler/ -run "TestPodRestart|TestShouldResumePhase1|TestRunPhase1Watch|TestMarkPhase1|TestPhase1Started"\` all pass
- [x] New test \`TestPodRestart_Phase1WatchingPreservedNotRewrittenToFailed\` proves status preserved when no kubeconfig
- [x] New test \`TestPodRestart_Phase1WatchingResumesWithKubeconfig\` proves \`shouldResumePhase1=true\` when kubeconfig is on disk
- [x] Parameterized test \`TestPodRestart_Phase0InFlightStillRewrittenToFailed\` proves all four Phase-0 statuses still fail on restart
- [ ] otech103 re-run: catalyst-api Pod roll mid-Phase-1 keeps deployment progressing, watcher resumes, handover auto-fires

Closes part of openova-io/openova#830 (Bug 3).