### PR TITLE
feat(provisioner): parentDomains[] data model + per-domain abstraction (#826)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/provisioner/parent_domains_test.go
+++ b/products/catalyst/bootstrap/api/internal/provisioner/parent_domains_test.go
@@ -1,0 +1,556 @@
+// Tests for the multi-domain Sovereign data model + provisioning
+// abstraction introduced by issue #826 (sub-1 of epic #825).
+//
+// The DoD covered here:
+//
+//  1. Validate() synthesises a single primary ParentDomain when the
+//     legacy single-FQDN payload arrives without a parentDomains
+//     slice — the migration step on every read.
+//  2. Validate() rejects malformed pools: empty, two primaries, no
+//     primary, unrecognised role, duplicate names, bad FQDN.
+//  3. ProvisionParentDomain runs every step against the supplied
+//     domain in order, stops on first error, emits SSE events the
+//     wizard surface (and #829's add-domain panel) can render
+//     per-domain.
+//  4. writeTfvars emits parent_domains as a JSON array (never null)
+//     so the OpenTofu module's `for pd in var.parent_domains`
+//     validator accepts the input on every payload — same nil-trap
+//     fix the regions slice already carries.
+//
+// The wizard UI is NOT exercised here — per the issue's SCOPE
+// CORRECTION, the wizard stays single-FQDN, and the multi-domain
+// pool is purely a backend representation that #829 (admin add-
+// domain) appends to post-handover.
+package provisioner
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+// validBaseWithSecrets seeds every required field so the parent-
+// domains code paths exercise their behaviour without tripping the
+// downstream Harbor / GHCR / object-storage validators. Mirrors
+// validBase in provisioner_test.go but with the credentials that
+// Validate() also requires.
+func validBaseWithSecrets() Request {
+	return Request{
+		OrgName:                "ACME",
+		OrgEmail:               "ops@acme.io",
+		SovereignFQDN:          "acme.openova.io",
+		HetznerToken:           "TEST-TOKEN-NOT-REAL",
+		HetznerProjectID:       "test-project",
+		Region:                 "fsn1",
+		SSHPublicKey:           "ssh-ed25519 AAAA test-not-a-real-key",
+		HarborRobotToken:       "harbor-test-token",
+		ObjectStorageRegion:    "fsn1",
+		ObjectStorageAccessKey: "TESTACCESSKEY1234567",
+		ObjectStorageSecretKey: "TESTSECRETKEY1234567890123456789012345678",
+		ObjectStorageBucket:    "catalyst-acme-openova-io",
+	}
+}
+
+// TestValidate_SynthesisesPrimaryFromSovereignFQDN proves the
+// migration step: a legacy payload with NO parentDomains slice gets
+// a single primary entry synthesised from SovereignFQDN (BYO mode)
+// or SovereignPoolDomain (pool mode). This is the core back-compat
+// guarantee on issue #826's DoD: existing single-FQDN records read
+// cleanly + persist back as the array shape on next Save().
+func TestValidate_SynthesisesPrimaryFromSovereignFQDN(t *testing.T) {
+	r := validBaseWithSecrets()
+	r.SovereignFQDN = "acme.openova.io"
+	// SovereignPoolDomain intentionally empty — BYO-or-legacy fallback.
+	if err := r.Validate(); err != nil {
+		t.Fatalf("Validate should pass on legacy single-FQDN payload: %v", err)
+	}
+	if len(r.ParentDomains) != 1 {
+		t.Fatalf("ParentDomains should be synthesised with 1 entry, got %d", len(r.ParentDomains))
+	}
+	pd := r.ParentDomains[0]
+	if pd.Name != "acme.openova.io" {
+		t.Errorf("synthesised Name = %q, want acme.openova.io (lowercased SovereignFQDN)", pd.Name)
+	}
+	if pd.Role != ParentDomainRolePrimary {
+		t.Errorf("synthesised Role = %q, want %q", pd.Role, ParentDomainRolePrimary)
+	}
+	if pd.RegistrarKind != defaultRegistrarKind {
+		t.Errorf("synthesised RegistrarKind = %q, want %q (defaultRegistrarKind)", pd.RegistrarKind, defaultRegistrarKind)
+	}
+	// AddedAt must be zero on synthesis — the on-disk record's zero
+	// timestamp lets the admin console distinguish migration-derived
+	// entries from explicit add-domain entries (which carry the
+	// admin's add-time per issue #829).
+	if !pd.AddedAt.IsZero() {
+		t.Errorf("synthesised AddedAt should be zero (migration source), got %s", pd.AddedAt)
+	}
+}
+
+// TestValidate_SynthesisesPrimaryFromSovereignPoolDomain proves the
+// pool-mode synthesis: when SovereignPoolDomain is set, the primary
+// entry's Name is the pool domain (the registered parent zone),
+// NOT the per-Sovereign sub-FQDN.
+func TestValidate_SynthesisesPrimaryFromSovereignPoolDomain(t *testing.T) {
+	r := validBaseWithSecrets()
+	r.SovereignFQDN = "omantel.omani.works"
+	r.SovereignPoolDomain = "omani.works"
+	r.SovereignDomainMode = "pool"
+	r.GHCRPullToken = "ghcr-test-token" // pool mode requires it
+	if err := r.Validate(); err != nil {
+		t.Fatalf("Validate should pass on pool-mode legacy payload: %v", err)
+	}
+	if len(r.ParentDomains) != 1 {
+		t.Fatalf("ParentDomains should be synthesised with 1 entry, got %d", len(r.ParentDomains))
+	}
+	pd := r.ParentDomains[0]
+	if pd.Name != "omani.works" {
+		t.Errorf("pool-mode synthesised Name = %q, want omani.works (the registered parent zone, not the sub-FQDN)", pd.Name)
+	}
+	if pd.Role != ParentDomainRolePrimary {
+		t.Errorf("Role = %q, want %q", pd.Role, ParentDomainRolePrimary)
+	}
+}
+
+// TestValidate_PreservesSuppliedParentDomains proves a payload that
+// already carries a parentDomains slice (e.g. #829's add-domain flow
+// appending an entry, then running Validate() on the round-trip)
+// keeps the slice verbatim — no double-synthesis.
+func TestValidate_PreservesSuppliedParentDomains(t *testing.T) {
+	r := validBaseWithSecrets()
+	r.SovereignFQDN = "omantel.omani.works"
+	addedAt := time.Date(2026, 5, 4, 12, 0, 0, 0, time.UTC)
+	r.ParentDomains = []ParentDomain{
+		{Name: "omani.works", Role: ParentDomainRolePrimary, RegistrarKind: "dynadot", AddedAt: addedAt},
+		{Name: "omani.trade", Role: ParentDomainRoleSMEPool, RegistrarKind: "dynadot", AddedAt: addedAt.Add(time.Hour)},
+	}
+
+	if err := r.Validate(); err != nil {
+		t.Fatalf("Validate should accept a well-formed multi-domain pool: %v", err)
+	}
+	if len(r.ParentDomains) != 2 {
+		t.Fatalf("ParentDomains should round-trip 2 entries, got %d", len(r.ParentDomains))
+	}
+	if r.ParentDomains[0].Name != "omani.works" {
+		t.Errorf("primary Name was clobbered: %q", r.ParentDomains[0].Name)
+	}
+	if r.ParentDomains[1].Role != ParentDomainRoleSMEPool {
+		t.Errorf("sme-pool Role was clobbered: %q", r.ParentDomains[1].Role)
+	}
+	if !r.ParentDomains[0].AddedAt.Equal(addedAt) {
+		t.Errorf("primary AddedAt was clobbered: %s", r.ParentDomains[0].AddedAt)
+	}
+}
+
+// TestValidate_RejectsTwoPrimaries proves the "exactly one primary"
+// invariant: a pool with two primary entries fails Validate() with
+// a clear message naming the count. Day-2 add-domain (#829) MUST
+// reject a payload that would create a second primary.
+func TestValidate_RejectsTwoPrimaries(t *testing.T) {
+	r := validBaseWithSecrets()
+	r.ParentDomains = []ParentDomain{
+		{Name: "omani.works", Role: ParentDomainRolePrimary},
+		{Name: "omani.trade", Role: ParentDomainRolePrimary},
+	}
+	err := r.Validate()
+	if err == nil {
+		t.Fatalf("two-primary pool should be rejected")
+	}
+	if !strings.Contains(err.Error(), "exactly one entry") {
+		t.Errorf("error should name the invariant, got %q", err.Error())
+	}
+}
+
+// TestValidate_RejectsZeroPrimaries proves the "exactly one primary"
+// invariant in the other direction: a pool of all sme-pool entries
+// is rejected.
+func TestValidate_RejectsZeroPrimaries(t *testing.T) {
+	r := validBaseWithSecrets()
+	r.ParentDomains = []ParentDomain{
+		{Name: "omani.trade", Role: ParentDomainRoleSMEPool},
+	}
+	err := r.Validate()
+	if err == nil {
+		t.Fatalf("zero-primary pool should be rejected")
+	}
+	if !strings.Contains(err.Error(), "exactly one entry") {
+		t.Errorf("error should name the invariant, got %q", err.Error())
+	}
+}
+
+// TestValidate_RejectsUnknownRole guards the role enum.
+func TestValidate_RejectsUnknownRole(t *testing.T) {
+	r := validBaseWithSecrets()
+	r.ParentDomains = []ParentDomain{
+		{Name: "omani.works", Role: "marketplace-only"},
+	}
+	err := r.Validate()
+	if err == nil {
+		t.Fatalf("unknown role should be rejected")
+	}
+	if !strings.Contains(err.Error(), "marketplace-only") {
+		t.Errorf("error should name the offending role, got %q", err.Error())
+	}
+}
+
+// TestValidate_RejectsEmptyRole proves an entry with no role at all
+// is rejected with a message naming the valid roles.
+func TestValidate_RejectsEmptyRole(t *testing.T) {
+	r := validBaseWithSecrets()
+	r.ParentDomains = []ParentDomain{
+		{Name: "omani.works"},
+	}
+	err := r.Validate()
+	if err == nil {
+		t.Fatalf("empty role should be rejected")
+	}
+	if !strings.Contains(err.Error(), "role is required") {
+		t.Errorf("error should name the required-field violation, got %q", err.Error())
+	}
+}
+
+// TestValidate_RejectsBadFQDN guards against malformed names.
+// Inviolable Principle #1 (target-state shape) — we don't accept a
+// "looks like" domain that the registrar would later reject. Note
+// uppercase names are NOT rejected — the validator normalises to
+// lowercase in place; that contract is exercised by
+// TestValidate_NormalisesUppercaseFQDNToLower below.
+func TestValidate_RejectsBadFQDN(t *testing.T) {
+	cases := []string{
+		"omani",         // single label
+		"-bad.works",    // leading dash
+		"omani..works",  // double dot
+		"omani.works.",  // trailing dot
+		"omani works",   // whitespace
+		"omani.works/x", // slash
+	}
+	for _, name := range cases {
+		t.Run(name, func(t *testing.T) {
+			r := validBaseWithSecrets()
+			r.ParentDomains = []ParentDomain{
+				{Name: name, Role: ParentDomainRolePrimary},
+			}
+			err := r.Validate()
+			if err == nil {
+				t.Fatalf("malformed FQDN %q should be rejected", name)
+			}
+		})
+	}
+}
+
+// TestValidate_NormalisesUppercaseFQDNToLower proves the validator
+// lower-cases the Name in place — uppercase user input is accepted
+// but stored canonical so downstream consumers (registrar adapter,
+// CRD projection, SME signup dropdown) see the same string.
+func TestValidate_NormalisesUppercaseFQDNToLower(t *testing.T) {
+	r := validBaseWithSecrets()
+	r.ParentDomains = []ParentDomain{
+		{Name: "OMANI.WORKS", Role: ParentDomainRolePrimary},
+	}
+	if err := r.Validate(); err != nil {
+		t.Fatalf("Validate should accept uppercase + normalise: %v", err)
+	}
+	if r.ParentDomains[0].Name != "omani.works" {
+		t.Errorf("Name was not normalised: got %q, want omani.works", r.ParentDomains[0].Name)
+	}
+}
+
+// TestValidate_RejectsDuplicateNames proves the dedupe check: an
+// admin trying to add the same domain twice via #829 surfaces a
+// clear 400 instead of a half-applied NS-flip.
+func TestValidate_RejectsDuplicateNames(t *testing.T) {
+	r := validBaseWithSecrets()
+	r.ParentDomains = []ParentDomain{
+		{Name: "omani.works", Role: ParentDomainRolePrimary},
+		{Name: "omani.works", Role: ParentDomainRoleSMEPool},
+	}
+	err := r.Validate()
+	if err == nil {
+		t.Fatalf("duplicate Name should be rejected")
+	}
+	if !strings.Contains(err.Error(), "duplicate") {
+		t.Errorf("error should name the duplicate violation, got %q", err.Error())
+	}
+}
+
+// TestPrimaryParentDomain_LookupHelper proves the lookup helper
+// returns the unique primary entry. Used by the catalyst-api's
+// runProvisioning to read the primary's Name without re-iterating
+// the slice at every call site.
+func TestPrimaryParentDomain_LookupHelper(t *testing.T) {
+	r := Request{
+		ParentDomains: []ParentDomain{
+			{Name: "omani.trade", Role: ParentDomainRoleSMEPool},
+			{Name: "omani.works", Role: ParentDomainRolePrimary},
+			{Name: "omani.shop", Role: ParentDomainRoleSMEPool},
+		},
+	}
+	pd := r.PrimaryParentDomain()
+	if pd == nil {
+		t.Fatalf("PrimaryParentDomain returned nil with a primary present")
+	}
+	if pd.Name != "omani.works" {
+		t.Errorf("primary Name = %q, want omani.works", pd.Name)
+	}
+}
+
+// TestPrimaryParentDomain_NoneReturnsNil — defensive case for
+// callers that haven't yet validated.
+func TestPrimaryParentDomain_NoneReturnsNil(t *testing.T) {
+	r := Request{
+		ParentDomains: []ParentDomain{
+			{Name: "omani.trade", Role: ParentDomainRoleSMEPool},
+		},
+	}
+	if pd := r.PrimaryParentDomain(); pd != nil {
+		t.Errorf("PrimaryParentDomain should return nil with no primary, got %+v", pd)
+	}
+}
+
+// TestSMEPoolParentDomains_FiltersToRole proves the slice filter
+// returns only the sme-pool entries, in their original order. The
+// SME signup wizard's parent-pool dropdown reads this for the
+// per-Sovereign list of free-subdomain options.
+func TestSMEPoolParentDomains_FiltersToRole(t *testing.T) {
+	r := Request{
+		ParentDomains: []ParentDomain{
+			{Name: "omani.works", Role: ParentDomainRolePrimary},
+			{Name: "omani.trade", Role: ParentDomainRoleSMEPool},
+			{Name: "omani.shop", Role: ParentDomainRoleSMEPool},
+		},
+	}
+	pool := r.SMEPoolParentDomains()
+	if len(pool) != 2 {
+		t.Fatalf("SMEPoolParentDomains returned %d entries, want 2", len(pool))
+	}
+	if pool[0].Name != "omani.trade" {
+		t.Errorf("pool[0].Name = %q, want omani.trade (original order preserved)", pool[0].Name)
+	}
+	if pool[1].Name != "omani.shop" {
+		t.Errorf("pool[1].Name = %q, want omani.shop", pool[1].Name)
+	}
+}
+
+// stepStub is a test-only ParentDomainStep that records every
+// invocation. Used to prove ProvisionParentDomain runs the steps in
+// order + threads the right (pd, lbIP) into Apply.
+type stepStub struct {
+	name    string
+	calls   []ParentDomain
+	failOn  string
+	failErr error
+}
+
+func (s *stepStub) Name() string { return s.name }
+
+func (s *stepStub) Apply(_ context.Context, pd ParentDomain, _ string) error {
+	s.calls = append(s.calls, pd)
+	if s.failOn == pd.Name {
+		return s.failErr
+	}
+	return nil
+}
+
+// TestProvisionParentDomain_RunsStepsInOrder proves the per-domain
+// abstraction iterates the steps as supplied. This is the core
+// re-usability contract the issue's DoD calls out: #829 (admin add-
+// domain) MUST be able to call ProvisionParentDomain with the same
+// step list the catalyst-api wires for Day-1.
+func TestProvisionParentDomain_RunsStepsInOrder(t *testing.T) {
+	flip := &stepStub{name: "registrar-flip"}
+	zone := &stepStub{name: "powerdns-zone-create"}
+	cert := &stepStub{name: "cert-manager-cert"}
+
+	pd := ParentDomain{Name: "omani.works", Role: ParentDomainRolePrimary, RegistrarKind: "dynadot"}
+	var emitted []string
+	emit := func(phase, _, msg string) {
+		emitted = append(emitted, phase+":"+msg)
+	}
+	if err := ProvisionParentDomain(context.Background(), pd, "10.0.0.1", []ParentDomainStep{flip, zone, cert}, emit); err != nil {
+		t.Fatalf("ProvisionParentDomain: %v", err)
+	}
+	for _, s := range []*stepStub{flip, zone, cert} {
+		if len(s.calls) != 1 {
+			t.Errorf("step %q should have run once, got %d", s.name, len(s.calls))
+		} else if s.calls[0].Name != "omani.works" {
+			t.Errorf("step %q got pd.Name = %q, want omani.works", s.name, s.calls[0].Name)
+		}
+	}
+	// Per-step events must include the step name + the domain name so
+	// the SSE stream surfaces the per-domain progress unambiguously.
+	joined := strings.Join(emitted, "\n")
+	for _, want := range []string{"registrar-flip", "powerdns-zone-create", "cert-manager-cert", "omani.works"} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("emitted events should mention %q, got:\n%s", want, joined)
+		}
+	}
+}
+
+// TestProvisionParentDomain_StopsOnFirstError proves a step that
+// fails halts the per-domain pipeline before subsequent steps run.
+// The wipe + restart loop relies on this: a partial state is the
+// operator's signal to wipe; we MUST NOT mask a failure by
+// continuing.
+func TestProvisionParentDomain_StopsOnFirstError(t *testing.T) {
+	flip := &stepStub{name: "registrar-flip", failOn: "omani.works", failErr: errors.New("dynadot 500")}
+	zone := &stepStub{name: "powerdns-zone-create"}
+	cert := &stepStub{name: "cert-manager-cert"}
+
+	pd := ParentDomain{Name: "omani.works", Role: ParentDomainRolePrimary}
+	err := ProvisionParentDomain(context.Background(), pd, "10.0.0.1", []ParentDomainStep{flip, zone, cert}, nil)
+	if err == nil {
+		t.Fatalf("ProvisionParentDomain should propagate the step error")
+	}
+	if !strings.Contains(err.Error(), "registrar-flip") || !strings.Contains(err.Error(), "omani.works") {
+		t.Errorf("wrapped error should name the step + domain, got %q", err.Error())
+	}
+	if len(flip.calls) != 1 {
+		t.Errorf("registrar-flip should have run once, got %d", len(flip.calls))
+	}
+	if len(zone.calls) != 0 || len(cert.calls) != 0 {
+		t.Errorf("subsequent steps should be skipped on failure: zone=%d cert=%d", len(zone.calls), len(cert.calls))
+	}
+}
+
+// TestProvisionParentDomains_IteratesEveryDomain proves the slice
+// flavour applies every step against every domain. Day-2 (#829)
+// uses this when an admin adds N domains in one batch.
+func TestProvisionParentDomains_IteratesEveryDomain(t *testing.T) {
+	flip := &stepStub{name: "registrar-flip"}
+	pds := []ParentDomain{
+		{Name: "omani.works", Role: ParentDomainRolePrimary},
+		{Name: "omani.trade", Role: ParentDomainRoleSMEPool},
+		{Name: "omani.shop", Role: ParentDomainRoleSMEPool},
+	}
+	if err := ProvisionParentDomains(context.Background(), pds, "10.0.0.1", []ParentDomainStep{flip}, nil); err != nil {
+		t.Fatalf("ProvisionParentDomains: %v", err)
+	}
+	if len(flip.calls) != 3 {
+		t.Fatalf("step should run once per domain (3), got %d", len(flip.calls))
+	}
+	for i, pd := range pds {
+		if flip.calls[i].Name != pd.Name {
+			t.Errorf("flip.calls[%d].Name = %q, want %q", i, flip.calls[i].Name, pd.Name)
+		}
+	}
+}
+
+// TestWriteTfvars_EmitsParentDomainsAsArrayNotNull is the parent-
+// domain analogue of TestWriteTfvars_EmitsRegionsAsEmptyArrayNotNull.
+// Same nil-trap fix: a future OpenTofu module's `for pd in
+// var.parent_domains` validator would fail on JSON null.
+func TestWriteTfvars_EmitsParentDomainsAsArrayNotNull(t *testing.T) {
+	dir, err := os.MkdirTemp("", "writeTfvars-pd-*")
+	if err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	defer os.RemoveAll(dir)
+
+	req := Request{
+		SovereignFQDN:    "otech87.omani.works",
+		OrgName:          "Acme",
+		OrgEmail:         "ops@acme.io",
+		HetznerToken:     "tok",
+		HetznerProjectID: "p1",
+		Region:           "fsn1",
+		WorkerCount:      2,
+		// ParentDomains intentionally nil — the typical Day-1 path
+		// before Validate() has run synthesis.
+	}
+	if err := writeTfvars(dir, req); err != nil {
+		t.Fatalf("writeTfvars: %v", err)
+	}
+	raw, err := os.ReadFile(dir + "/tofu.auto.tfvars.json")
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if strings.Contains(string(raw), `"parent_domains": null`) {
+		t.Fatalf("parent_domains must serialise as [] (not null). Got:\n%s", string(raw))
+	}
+	var parsed map[string]any
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	pds, ok := parsed["parent_domains"].([]any)
+	if !ok {
+		t.Fatalf("parent_domains must be a JSON array, got %T", parsed["parent_domains"])
+	}
+	if len(pds) != 0 {
+		t.Fatalf("parent_domains should be empty when request has none, got %d entries", len(pds))
+	}
+}
+
+// TestWriteTfvars_EmitsParentDomainsRoundTripsEntries proves the
+// supplied slice round-trips through the JSON shape — Name + Role +
+// RegistrarKind reach the OpenTofu module verbatim. The
+// RegistrarCredsRef field is preserved when set; AddedAt is dropped
+// when zero (omitempty).
+func TestWriteTfvars_EmitsParentDomainsRoundTripsEntries(t *testing.T) {
+	dir, err := os.MkdirTemp("", "writeTfvars-pd-*")
+	if err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	defer os.RemoveAll(dir)
+
+	req := Request{
+		SovereignFQDN:    "otech88.omani.works",
+		OrgName:          "Acme",
+		OrgEmail:         "ops@acme.io",
+		HetznerToken:     "tok",
+		HetznerProjectID: "p1",
+		Region:           "fsn1",
+		WorkerCount:      2,
+		ParentDomains: []ParentDomain{
+			{Name: "omani.works", Role: ParentDomainRolePrimary, RegistrarKind: "dynadot"},
+			{Name: "omani.trade", Role: ParentDomainRoleSMEPool, RegistrarKind: "dynadot", RegistrarCredsRef: "dynadot-omani-trade"},
+		},
+	}
+	if err := writeTfvars(dir, req); err != nil {
+		t.Fatalf("writeTfvars: %v", err)
+	}
+	raw, err := os.ReadFile(dir + "/tofu.auto.tfvars.json")
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	var parsed map[string]any
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	pdsRaw, ok := parsed["parent_domains"].([]any)
+	if !ok {
+		t.Fatalf("parent_domains must be a JSON array, got %T", parsed["parent_domains"])
+	}
+	if len(pdsRaw) != 2 {
+		t.Fatalf("parent_domains should round-trip 2 entries, got %d", len(pdsRaw))
+	}
+	first, _ := pdsRaw[0].(map[string]any)
+	if first["name"] != "omani.works" {
+		t.Errorf("first.name = %v, want omani.works", first["name"])
+	}
+	if first["role"] != ParentDomainRolePrimary {
+		t.Errorf("first.role = %v, want %q", first["role"], ParentDomainRolePrimary)
+	}
+	second, _ := pdsRaw[1].(map[string]any)
+	if second["registrarCredsRef"] != "dynadot-omani-trade" {
+		t.Errorf("second.registrarCredsRef = %v, want dynadot-omani-trade", second["registrarCredsRef"])
+	}
+}
+
+// TestDefaultRegistrarKindFromEnv proves Inviolable Principle #4 ──
+// the default registrar adapter id is overridable via env at runtime.
+// An operator running on a non-Dynadot registrar sets
+// CATALYST_DEFAULT_REGISTRAR_KIND on the catalyst-api Pod and the
+// Day-1 synthesis path picks it up.
+func TestDefaultRegistrarKindFromEnv(t *testing.T) {
+	t.Setenv("CATALYST_DEFAULT_REGISTRAR_KIND", "namecheap")
+	if got := defaultRegistrarKindFromEnv(); got != "namecheap" {
+		t.Errorf("env override not honoured: got %q, want namecheap", got)
+	}
+	t.Setenv("CATALYST_DEFAULT_REGISTRAR_KIND", "")
+	if got := defaultRegistrarKindFromEnv(); got != defaultRegistrarKind {
+		t.Errorf("empty env should fall back to default: got %q, want %q", got, defaultRegistrarKind)
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/provisioner/provisioner.go
+++ b/products/catalyst/bootstrap/api/internal/provisioner/provisioner.go
@@ -43,6 +43,95 @@ import (
 	"time"
 )
 
+// ParentDomain is one entry in Request.ParentDomains — a registered
+// parent zone the Sovereign-side PowerDNS becomes authoritative for
+// after NS-flip lands at the registrar.
+//
+// Issue #826 (sub-1 of epic #825 — Multi-domain Sovereign) introduces
+// this shape so a single Sovereign can own N parent domains rather
+// than the legacy one-FQDN model. Day-1 (wizard provision) populates
+// the slice with exactly ONE entry carrying Role="primary"; Day-2
+// add-domain calls (issue #829) append additional entries with
+// Role="sme-pool". The provisioning pipeline iterates over the slice
+// applying the same per-domain steps to each (NS-flip via registrar,
+// PowerDNS zone create, cert-manager Certificate create) — see
+// ProvisionParentDomain below.
+//
+// The wizard UI stays single-FQDN (per the SCOPE CORRECTION on issue
+// #826: multi-domain capability is a Day-2 admin-console action). The
+// catalyst-api translates the wizard's single FQDN into a 1-element
+// ParentDomains array internally — operators never see this struct in
+// the wizard.
+//
+// Field semantics:
+//
+//   - Name is the registered domain at the registrar
+//     (e.g. "omani.works"). Must match parentDomainNamePattern.
+//   - Role is one of ParentDomainRolePrimary | ParentDomainRoleSMEPool.
+//     Exactly one entry in the slice carries the primary role; zero or
+//     more carry sme-pool. Validation enforces this at Validate() time.
+//   - RegistrarKind is the adapter id used to flip the NS records at
+//     the registrar (today: "dynadot"; future: "namecheap" / "godaddy"
+//     / etc). Inviolable Principle #4 ("never hardcode") requires this
+//     to be a runtime value, not a compile-time switch.
+//   - RegistrarCredsRef is the name of a SealedSecret in
+//     catalyst-system holding the registrar credentials. The
+//     catalyst-api resolves this at provision time via the K8s API
+//     (issue #829 wires the resolver). Empty means "fall back to the
+//     same operator-supplied env-mounted credentials the catalyst-api
+//     uses for the primary domain" — the typical case where one
+//     Dynadot account holds every domain in the operator's portfolio.
+//   - AddedAt is the UTC timestamp the domain was added to the pool.
+//     Day-1 entries carry the deployment's StartedAt; Day-2 entries
+//     carry the moment the admin console add-domain handler was
+//     called. Stored on the persisted Record so the admin console can
+//     render "added 3 days ago" on the parent-domains panel.
+type ParentDomain struct {
+	Name              string    `json:"name"`
+	Role              string    `json:"role"`
+	RegistrarKind     string    `json:"registrarKind,omitempty"`
+	RegistrarCredsRef string    `json:"registrarCredsRef,omitempty"`
+	AddedAt           time.Time `json:"addedAt,omitempty"`
+}
+
+// ParentDomain role constants. Exactly one ParentDomain in
+// Request.ParentDomains carries ParentDomainRolePrimary; zero or more
+// carry ParentDomainRoleSMEPool. The wizard's Day-1 path always
+// produces a single primary entry — sme-pool entries are appended
+// post-handover via the admin console (issue #829).
+const (
+	// ParentDomainRolePrimary marks the unique parent domain that
+	// hosts the Sovereign's own URLs (console.<primary>,
+	// api.<primary>, marketplace.<primary>, ...). Its zone is the
+	// authoritative source for the Sovereign's bootstrap-kit
+	// HTTPRoutes.
+	ParentDomainRolePrimary = "primary"
+
+	// ParentDomainRoleSMEPool marks a parent domain offered to SME
+	// tenants for free-subdomain allocation. When an SME signs up
+	// under a Sovereign, they pick from the sme-pool entries to
+	// receive a free console.<sme>.<sme-pool> subdomain.
+	ParentDomainRoleSMEPool = "sme-pool"
+)
+
+// parentDomainNamePattern is the FQDN regex applied to ParentDomain.Name.
+// Matches the wizard's isValidDomain helper (RFC 1035 labels, ≥ 2
+// labels). Lower-cased before the test runs.
+var parentDomainNamePattern = regexp.MustCompile(`^[a-z]([a-z0-9-]*[a-z0-9])?(\.[a-z]([a-z0-9-]*[a-z0-9])?)+$`)
+
+// defaultRegistrarKind is the registrar adapter used when a Day-1
+// ParentDomain entry is synthesised from the legacy SovereignFQDN
+// payload (the wizard captures a single FQDN + relies on the
+// catalyst-api's env-mounted Dynadot credentials). Centralised here
+// rather than scattered as a magic string — Inviolable Principle #4.
+//
+// Future operators on registrars other than Dynadot override this via
+// CATALYST_DEFAULT_REGISTRAR_KIND on the catalyst-api Pod. The
+// wizard's StepDomain stays unchanged: the operator ships their
+// registrar credentials as env vars + sets this env to the matching
+// adapter id.
+const defaultRegistrarKind = "dynadot"
+
 // s3BucketNamePattern enforces RFC-compliant S3 bucket naming on
 // Request.ObjectStorageBucket per the rules at
 // https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html
@@ -82,6 +171,28 @@ type Request struct {
 	SovereignDomainMode string `json:"sovereignDomainMode"` // pool | byo
 	SovereignPoolDomain string `json:"sovereignPoolDomain"`
 	SovereignSubdomain  string `json:"sovereignSubdomain"`
+
+	// ParentDomains — the canonical multi-domain payload introduced by
+	// issue #826 (sub-1 of epic #825 — Multi-domain Sovereign). The
+	// Sovereign-side PowerDNS becomes authoritative for every entry
+	// here; exactly one entry carries Role="primary" (hosts
+	// console/api/marketplace), zero-or-more carry Role="sme-pool"
+	// (offered to SME tenants for free subdomains).
+	//
+	// Backward compatibility: when the wizard ships a payload without
+	// this field (every wizard payload as of issue #826 — the wizard
+	// stays single-FQDN per the scope correction), Validate()
+	// synthesises a single primary entry from SovereignPoolDomain (or
+	// SovereignFQDN when domain_mode is byo). Existing on-disk
+	// deployment records persisted under the legacy single-FQDN shape
+	// thus deserialize cleanly + on next Save() round-trip the
+	// synthesised array, achieving the migration the issue's DoD calls
+	// for without a one-shot migration step.
+	//
+	// Day-2 add-domain (issue #829) appends to this slice via the same
+	// per-domain abstraction the Day-1 path uses — see
+	// ProvisionParentDomain.
+	ParentDomains []ParentDomain `json:"parentDomains,omitempty"`
 
 	HetznerToken     string `json:"hetznerToken"`
 	HetznerProjectID string `json:"hetznerProjectID"`
@@ -308,6 +419,50 @@ func (r *Request) Validate() error {
 	if strings.TrimSpace(r.SovereignFQDN) == "" {
 		return errors.New("sovereign FQDN is required")
 	}
+
+	// ParentDomains migration (issue #826 — backward compat with the
+	// legacy single-FQDN payload). When the slice is empty, synthesise
+	// a single primary entry from SovereignPoolDomain (managed-pool
+	// mode) or SovereignFQDN (BYO mode) so the downstream provisioner
+	// always operates on the array shape regardless of how the request
+	// arrived. This is the migration step for in-flight wizard
+	// deployments and for on-disk records persisted under the old
+	// shape — the next Save() round-trip emits the array form. New
+	// wizard payloads (none today; #826 scope correction holds the
+	// wizard at single-FQDN) would populate the slice directly.
+	//
+	// When the slice IS supplied, validate every entry: name, role,
+	// and "exactly one primary" invariant. The catalyst-api's
+	// add-domain handler (#829) calls Validate() on the same request
+	// shape after appending — re-running the check here is idempotent.
+	if len(r.ParentDomains) == 0 {
+		// Pick the synthesis source: pool-domain mode uses
+		// SovereignPoolDomain (the operator-owned registered domain;
+		// SovereignFQDN is the per-Sovereign sub-zone like
+		// "omantel.omani.works"), BYO-or-empty falls back to
+		// SovereignFQDN. The role is always "primary" — Day-1 has
+		// exactly one entry.
+		name := strings.TrimSpace(r.SovereignPoolDomain)
+		if name == "" {
+			name = strings.TrimSpace(r.SovereignFQDN)
+		}
+		name = strings.ToLower(name)
+		// AddedAt is left zero on the synthesis path so the migration
+		// is observable from the on-disk record (a non-zero
+		// AddedAt indicates the entry was created via the explicit
+		// admin add-domain flow). Callers stamp a real timestamp
+		// when they construct a ParentDomain themselves — see
+		// internal/handler's add-domain handler in #829.
+		r.ParentDomains = []ParentDomain{{
+			Name:          name,
+			Role:          ParentDomainRolePrimary,
+			RegistrarKind: defaultRegistrarKindFromEnv(),
+		}}
+	}
+	if err := validateParentDomains(&r.ParentDomains); err != nil {
+		return err
+	}
+
 	if strings.TrimSpace(r.OrgName) == "" {
 		return errors.New("organisation name is required")
 	}
@@ -918,6 +1073,23 @@ func writeTfvars(deployDir string, req Request) error {
 		"dynadot_key":    req.DynadotAPIKey, // empty when domain_mode != "pool"
 		"dynadot_secret": req.DynadotAPISecret,
 
+		// Multi-domain payload (issue #826) — emitted as a list of
+		// objects so the OpenTofu module can iterate per-domain.
+		// At Day-1 the slice has length 1 (the primary entry). The
+		// OpenTofu module's `variable "parent_domains"` declaration
+		// (when added in a follow-up) consumes this shape directly;
+		// today the field is structural-correct + harmless if the
+		// module's variables.tf has not yet declared it (OpenTofu
+		// ignores unknown variables in tofu.auto.tfvars.json with a
+		// warning, not an error). Emitting it now lets the Day-2
+		// add-domain flow (#829) ship the same shape for every
+		// re-render.
+		//
+		// IMPORTANT: emit empty slice [] (not nil) to mirror the
+		// regions field's failure mode — `for r in var.parent_domains`
+		// in a future module would fail on null.
+		"parent_domains": coalesceParentDomains(req.ParentDomains),
+
 		// Contabo PowerDNS API key — interpolated by
 		// cloudinit-control-plane.tftpl into the Sovereign's
 		// `cert-manager/powerdns-api-credentials` Secret so
@@ -1064,6 +1236,228 @@ func env(key, def string) string {
 	return def
 }
 
+// ParentDomainStep is one named operation in the per-domain
+// provisioning pipeline. Day-1 (wizard signup) runs every registered
+// step against the single primary domain; Day-2 (admin add-domain
+// from issue #829) runs the same steps against each newly-added
+// sme-pool domain.
+//
+// Today the steps are:
+//
+//  1. registrar-flip — point the registered parent zone at the
+//     Sovereign's PowerDNS by writing ns1/ns2/ns3 NS records (and a
+//     glue A record for ns1) at the registrar's API.
+//  2. powerdns-zone-create — POST /api/v1/servers/localhost/zones to
+//     the Sovereign's PowerDNS so it serves the zone authoritatively.
+//  3. cert-manager-cert — apply a Certificate CR for *.<domain>
+//     against the Sovereign so cert-manager issues a wildcard.
+//
+// At Day-1 these are wired structurally inside the OpenTofu cloud-
+// init template (the catalyst-api's role is to write tofu.auto.tfvars.
+// json with the parent-domains list; the cloud-init renders the
+// per-domain Job manifests). At Day-2 (#829) the catalyst-api
+// implements them in-process — running each step against a freshly-
+// added domain post-handover. Same interface, same semantics; only
+// the executor differs.
+//
+// The interface lives here so #829's add-domain handler imports
+// THIS package's contract — not a parallel one. Issue #826's DoD
+// calls out "reusable per-domain function/interface ready for #829";
+// this is that contract.
+type ParentDomainStep interface {
+	// Name is a stable identifier emitted in SSE events
+	// (event.phase = "parent-domain:" + Name). Examples:
+	// "registrar-flip", "powerdns-zone-create", "cert-manager-cert".
+	Name() string
+
+	// Apply executes the step against pd. Implementations MUST be
+	// idempotent: re-running with the same (pd, lbIP) is a no-op
+	// when the desired state is already in place. Idempotency is the
+	// load-bearing property — the wipe + restart loop documented in
+	// the Catalyst-Zero memory ("FAILURE = WIPE + RESTART FROM
+	// ZERO") relies on every per-domain step being safe to re-run.
+	//
+	// The lbIP is the Sovereign's load-balancer IPv4, returned by
+	// the Phase-0 OpenTofu apply. Day-1 has it on the Result struct;
+	// Day-2 reads it from the persisted Record. Threading it through
+	// the interface keeps the steps independent of how the IP got
+	// computed.
+	Apply(ctx context.Context, pd ParentDomain, lbIP string) error
+}
+
+// ProvisionParentDomain runs the full per-domain pipeline (every
+// supplied ParentDomainStep, in order) against pd. Used by:
+//
+//   - Day-1 (wizard signup): the catalyst-api's runProvisioning
+//     iterates Request.ParentDomains and calls this once per entry
+//     (the slice is length 1 today). The OpenTofu module handles the
+//     same fan-out structurally inside cloud-init; this Go-side path
+//     exists for any domain step the catalyst-api owns directly
+//     (e.g. a future "verify NS propagation" probe that runs
+//     post-handover).
+//   - Day-2 (#829 admin add-domain): the catalyst-api's
+//     /api/v1/sovereign/parent-domains POST handler iterates the
+//     freshly-appended entries and calls this for each. Same steps
+//     as Day-1 — the abstraction is the entire point of #826.
+//
+// Per-step events are emitted via the supplied emit function so the
+// SSE stream surfaces "parent-domain:registrar-flip start
+// omani.works" → "parent-domain:registrar-flip ok omani.works" etc.
+// The event shape supports per-domain emission so #829's add-domain
+// flow surfaces progress per added domain.
+//
+// Stops on the first step error; subsequent steps are skipped
+// (failing partway through is the operator's signal to wipe and
+// restart per the wipe-and-rerun rule in the Catalyst-Zero memory).
+// The error wraps the step name + domain name so the operator's log
+// readout names the failure unambiguously.
+func ProvisionParentDomain(ctx context.Context, pd ParentDomain, lbIP string, steps []ParentDomainStep, emit func(phase, level, msg string)) error {
+	if emit == nil {
+		emit = func(string, string, string) {}
+	}
+	for _, step := range steps {
+		phase := "parent-domain:" + step.Name()
+		emit(phase, "info", fmt.Sprintf("%s start %s", step.Name(), pd.Name))
+		if err := step.Apply(ctx, pd, lbIP); err != nil {
+			emit(phase, "error", fmt.Sprintf("%s failed for %s: %s", step.Name(), pd.Name, err.Error()))
+			return fmt.Errorf("parent-domain step %q for %q: %w", step.Name(), pd.Name, err)
+		}
+		emit(phase, "info", fmt.Sprintf("%s ok %s", step.Name(), pd.Name))
+	}
+	return nil
+}
+
+// ProvisionParentDomains is the slice-flavoured ProvisionParentDomain.
+// Iterates pds applying every step against each entry, in order.
+// Day-1 (length 1) and Day-2 (length 1+) take the same path — the
+// Day-1 caller passes Request.ParentDomains, the Day-2 caller passes
+// a single-element slice with the freshly-added entry.
+//
+// Stops on first per-domain failure (the per-domain ProvisionParentDomain
+// call). The caller (catalyst-api handler) decides whether the whole
+// deployment should fail or whether to mark the failed entry and
+// continue — neither policy lives here.
+func ProvisionParentDomains(ctx context.Context, pds []ParentDomain, lbIP string, steps []ParentDomainStep, emit func(phase, level, msg string)) error {
+	for i := range pds {
+		if err := ProvisionParentDomain(ctx, pds[i], lbIP, steps, emit); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// validateParentDomains enforces the parent-domain pool invariants
+// expressed by the multi-domain epic (#825):
+//
+//   - every entry's Name is a syntactically valid FQDN ≥ 2 labels
+//     (parentDomainNamePattern, mirroring the wizard's isValidDomain
+//     helper)
+//   - every entry's Role is one of the two known roles
+//     (ParentDomainRolePrimary | ParentDomainRoleSMEPool)
+//   - exactly ONE entry carries the primary role — neither zero nor
+//     two-or-more is acceptable
+//   - duplicate Names within the slice are rejected (an operator
+//     adding the same domain twice via the admin console is a wizard
+//     bug; surfacing the error from Validate() lets #829's handler
+//     reject with a clear 400 instead of a half-applied NS-flip)
+//
+// Pure function — no side effects, called by Request.Validate after
+// the migration synthesis path runs so it sees the canonical array
+// shape on every request.
+// validateParentDomains uses a *[]ParentDomain so it can normalise
+// each entry's Name in place (lowercase + trim) — the on-disk record
+// then carries the canonical form, and downstream consumers (the
+// registrar adapter, the CRD projection, the SME-signup pool
+// dropdown) all see the same string. Mutating callers' slice
+// through a pointer mirrors how Validate() already mutates the
+// per-region singular fields on the same Request.
+func validateParentDomains(pds *[]ParentDomain) error {
+	if pds == nil || len(*pds) == 0 {
+		return errors.New("parent domains list is empty (migration path failed to synthesise an entry — check SovereignFQDN / SovereignPoolDomain)")
+	}
+	primaryCount := 0
+	seen := make(map[string]struct{}, len(*pds))
+	for i := range *pds {
+		pd := &(*pds)[i]
+		name := strings.ToLower(strings.TrimSpace(pd.Name))
+		if name == "" {
+			return fmt.Errorf("parent domain[%d] name is required", i)
+		}
+		if !parentDomainNamePattern.MatchString(name) {
+			return fmt.Errorf("parent domain[%d] name %q is not a valid FQDN (must be lowercase, ≥ 2 labels, RFC 1035)", i, pd.Name)
+		}
+		if _, dup := seen[name]; dup {
+			return fmt.Errorf("parent domain[%d] name %q is a duplicate of an earlier entry", i, pd.Name)
+		}
+		seen[name] = struct{}{}
+		// Normalise in-place so downstream consumers see the
+		// canonical lowercase form.
+		pd.Name = name
+
+		switch pd.Role {
+		case ParentDomainRolePrimary:
+			primaryCount++
+		case ParentDomainRoleSMEPool:
+			// OK — zero-or-more allowed.
+		case "":
+			return fmt.Errorf("parent domain[%d] role is required (one of %q | %q)", i, ParentDomainRolePrimary, ParentDomainRoleSMEPool)
+		default:
+			return fmt.Errorf("parent domain[%d] role %q is not recognised (one of %q | %q)", i, pd.Role, ParentDomainRolePrimary, ParentDomainRoleSMEPool)
+		}
+	}
+	if primaryCount != 1 {
+		return fmt.Errorf("parent domains must contain exactly one entry with role=%q (found %d)", ParentDomainRolePrimary, primaryCount)
+	}
+	return nil
+}
+
+// PrimaryParentDomain returns the single entry in r.ParentDomains
+// carrying ParentDomainRolePrimary, or nil if the slice has not yet
+// been validated/synthesised. Callers use this to read the primary
+// domain name when threading it through the OpenTofu module without
+// duplicating the "find the primary" loop at every call site. After
+// Validate() has run successfully, this is guaranteed non-nil.
+func (r Request) PrimaryParentDomain() *ParentDomain {
+	for i := range r.ParentDomains {
+		if r.ParentDomains[i].Role == ParentDomainRolePrimary {
+			return &r.ParentDomains[i]
+		}
+	}
+	return nil
+}
+
+// SMEPoolParentDomains returns every entry in r.ParentDomains carrying
+// ParentDomainRoleSMEPool. Day-1 always returns an empty slice; Day-2
+// add-domain (issue #829) populates the result.
+//
+// The order matches r.ParentDomains so callers iterating with the
+// catalyst-api's "add-order" semantics (oldest first) get a stable
+// list — useful for the admin console's "added 3 days ago" rendering
+// + for the SME wizard's parent-domain dropdown choosing the most
+// recently added pool domain when nothing is selected.
+func (r Request) SMEPoolParentDomains() []ParentDomain {
+	out := make([]ParentDomain, 0, len(r.ParentDomains))
+	for _, pd := range r.ParentDomains {
+		if pd.Role == ParentDomainRoleSMEPool {
+			out = append(out, pd)
+		}
+	}
+	return out
+}
+
+// defaultRegistrarKindFromEnv returns the registrar adapter id used
+// when synthesising a Day-1 ParentDomain entry from the legacy
+// single-FQDN payload. Reads CATALYST_DEFAULT_REGISTRAR_KIND with
+// fallback to defaultRegistrarKind ("dynadot"). Inviolable Principle
+// #4: never hardcode the registrar kind in a code path; let
+// operators on registrars other than Dynadot override via env.
+func defaultRegistrarKindFromEnv() string {
+	if v := strings.TrimSpace(os.Getenv("CATALYST_DEFAULT_REGISTRAR_KIND")); v != "" {
+		return strings.ToLower(v)
+	}
+	return defaultRegistrarKind
+}
+
 // coalesceRegions normalises a nil RegionSpec slice to an empty slice so
 // JSON marshalling emits `[]` instead of `null`. The OpenTofu module's
 // `variable "regions"` validator runs `for r in var.regions` which fails
@@ -1076,4 +1470,15 @@ func coalesceRegions(rs []RegionSpec) []RegionSpec {
 		return []RegionSpec{}
 	}
 	return rs
+}
+
+// coalesceParentDomains is the parent-domain analogue of coalesceRegions.
+// Mirrors the same nil → empty slice contract so future OpenTofu
+// modules iterating `var.parent_domains` get `[]` (validator-friendly)
+// instead of `null` (validator-fatal). Issue #826.
+func coalesceParentDomains(pds []ParentDomain) []ParentDomain {
+	if pds == nil {
+		return []ParentDomain{}
+	}
+	return pds
 }

--- a/products/catalyst/bootstrap/api/internal/store/crd_store.go
+++ b/products/catalyst/bootstrap/api/internal/store/crd_store.go
@@ -68,6 +68,8 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/provisioner"
 )
 
 // CRDGroup / CRDVersion / CRDResource pin the GroupVersionResource for
@@ -490,6 +492,33 @@ func recordToUnstructured(rec Record, namespace string) *unstructured.Unstructur
 		spec["regions"] = regions
 	}
 
+	// Multi-domain pool (issue #826). Persisted on the CRD so the
+	// admin add-domain flow (#829) + the SME signup parent-pool
+	// dropdown can read the live pool from the K8s API without
+	// rehydrating the full deployment record. RegistrarCredsRef
+	// points at a SealedSecret name; the plaintext registrar
+	// credentials are NEVER on the CRD.
+	if len(rec.Request.ParentDomains) > 0 {
+		pds := make([]any, 0, len(rec.Request.ParentDomains))
+		for _, pd := range rec.Request.ParentDomains {
+			entry := map[string]any{
+				"name": pd.Name,
+				"role": pd.Role,
+			}
+			if pd.RegistrarKind != "" {
+				entry["registrarKind"] = pd.RegistrarKind
+			}
+			if pd.RegistrarCredsRef != "" {
+				entry["registrarCredsRef"] = pd.RegistrarCredsRef
+			}
+			if !pd.AddedAt.IsZero() {
+				entry["addedAt"] = pd.AddedAt.UTC().Format(time.RFC3339)
+			}
+			pds = append(pds, entry)
+		}
+		spec["parentDomains"] = pds
+	}
+
 	phase := toCRDPhase(rec.Status)
 	status := map[string]any{
 		"phase":            phase,
@@ -655,6 +684,31 @@ func unstructuredToRecord(obj *unstructured.Unstructured) Record {
 			WorkerCount:         intField(spec, "workerCount"),
 			HAEnabled:           boolField(spec, "haEnabled"),
 			HetznerProjectID:    stringField(spec, "hetznerProjectID"),
+		}
+		// Multi-domain pool rehydrate (issue #826). A CRD persisted
+		// before the field was added returns an empty slice — the
+		// flat-file store + provisioner.Validate() migration path
+		// re-synthesises the primary entry on the next Save, keeping
+		// the CRD in sync over time without an explicit migration.
+		if raw, ok := spec["parentDomains"].([]any); ok && len(raw) > 0 {
+			pds := make([]provisioner.ParentDomain, 0, len(raw))
+			for _, e := range raw {
+				m, ok := e.(map[string]any)
+				if !ok {
+					continue
+				}
+				pd := provisioner.ParentDomain{
+					Name:              stringField(m, "name"),
+					Role:              stringField(m, "role"),
+					RegistrarKind:     stringField(m, "registrarKind"),
+					RegistrarCredsRef: stringField(m, "registrarCredsRef"),
+				}
+				if t, err := time.Parse(time.RFC3339, stringField(m, "addedAt")); err == nil {
+					pd.AddedAt = t
+				}
+				pds = append(pds, pd)
+			}
+			rec.Request.ParentDomains = pds
 		}
 	}
 	if status, ok := obj.Object["status"].(map[string]any); ok {

--- a/products/catalyst/bootstrap/api/internal/store/parent_domains_test.go
+++ b/products/catalyst/bootstrap/api/internal/store/parent_domains_test.go
@@ -1,0 +1,266 @@
+// Tests for the parent-domain pool persistence introduced by issue
+// #826 (sub-1 of epic #825).
+//
+// Two surfaces:
+//
+//  1. Redact() round-trips ParentDomains verbatim. The fields are
+//     non-secret (Name + Role + RegistrarKind + RegistrarCredsRef +
+//     AddedAt); RegistrarCredsRef points at a SealedSecret name in
+//     catalyst-system, the plaintext credentials never live on the
+//     deployment record.
+//  2. A record persisted under the LEGACY single-FQDN shape (no
+//     parentDomains key in JSON) deserializes cleanly + the
+//     provisioner.Validate() migration path re-synthesises the
+//     primary entry on the next read. This is the backward-compat
+//     guarantee on the issue's DoD: "existing records with
+//     sovereign_fqdn = X get translated to [{Name: X, Role: 'primary',
+//     ...}] on read; persist back on next save".
+package store
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/provisioner"
+)
+
+// TestRedact_RoundTripsParentDomains proves the non-secret pool
+// metadata reaches disk verbatim — the admin add-domain panel (#829)
+// reads this from the persisted record after a Pod restart and the
+// values must match what the operator configured at signup.
+func TestRedact_RoundTripsParentDomains(t *testing.T) {
+	addedAt := time.Date(2026, 5, 4, 12, 0, 0, 0, time.UTC)
+	req := provisioner.Request{
+		OrgName:       "Omantel",
+		SovereignFQDN: "omantel.omani.works",
+		HetznerToken:  "leaked-if-broken",
+		ParentDomains: []provisioner.ParentDomain{
+			{Name: "omani.works", Role: provisioner.ParentDomainRolePrimary, RegistrarKind: "dynadot", AddedAt: addedAt},
+			{Name: "omani.trade", Role: provisioner.ParentDomainRoleSMEPool, RegistrarKind: "dynadot", RegistrarCredsRef: "dynadot-omani-trade", AddedAt: addedAt.Add(time.Hour)},
+		},
+	}
+	out := Redact(req)
+
+	if len(out.ParentDomains) != 2 {
+		t.Fatalf("RedactedRequest.ParentDomains should round-trip 2 entries, got %d", len(out.ParentDomains))
+	}
+	if out.ParentDomains[0].Name != "omani.works" {
+		t.Errorf("first.Name = %q, want omani.works", out.ParentDomains[0].Name)
+	}
+	if out.ParentDomains[0].Role != provisioner.ParentDomainRolePrimary {
+		t.Errorf("first.Role = %q, want %q", out.ParentDomains[0].Role, provisioner.ParentDomainRolePrimary)
+	}
+	if out.ParentDomains[1].RegistrarCredsRef != "dynadot-omani-trade" {
+		t.Errorf("second.RegistrarCredsRef = %q, want dynadot-omani-trade", out.ParentDomains[1].RegistrarCredsRef)
+	}
+	if !out.ParentDomains[0].AddedAt.Equal(addedAt) {
+		t.Errorf("first.AddedAt = %v, want %v", out.ParentDomains[0].AddedAt, addedAt)
+	}
+
+	// Serialised form must NOT contain any pretend-secret value.
+	raw, err := json.Marshal(out)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(raw), "leaked-if-broken") {
+		t.Errorf("serialised form leaked credential: %s", raw)
+	}
+	// The serialised parentDomains array MUST appear under the canonical
+	// JSON key — admin tooling consumes this verbatim.
+	if !strings.Contains(string(raw), `"parentDomains"`) {
+		t.Errorf("serialised RedactedRequest missing parentDomains key: %s", raw)
+	}
+}
+
+// TestRedact_EmptyParentDomainsStaysEmpty proves a request without a
+// pool slice doesn't get an empty slice rewritten into the redacted
+// form. omitempty would otherwise drop nothing — but we want the
+// serialised form to skip the field entirely, not emit `[]`.
+func TestRedact_EmptyParentDomainsStaysEmpty(t *testing.T) {
+	req := provisioner.Request{
+		OrgName:       "Acme",
+		SovereignFQDN: "acme.openova.io",
+		HetznerToken:  "tok",
+		// ParentDomains intentionally nil.
+	}
+	out := Redact(req)
+	if out.ParentDomains != nil {
+		t.Errorf("nil ParentDomains should round-trip nil, got %v", out.ParentDomains)
+	}
+	raw, _ := json.Marshal(out)
+	if strings.Contains(string(raw), `"parentDomains"`) {
+		t.Errorf("nil ParentDomains should be omitted from JSON, got: %s", raw)
+	}
+}
+
+// TestSaveLoad_RoundTripsParentDomains proves a record with the
+// pool slice populated round-trips the slice through the store —
+// Save → on-disk file → LoadAll → in-memory record. The admin
+// add-domain panel (#829) relies on this surviving Pod restarts.
+func TestSaveLoad_RoundTripsParentDomains(t *testing.T) {
+	dir := t.TempDir()
+	s, err := New(dir)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	addedAt := time.Date(2026, 5, 4, 12, 0, 0, 0, time.UTC)
+	rec := Record{
+		ID:     "deadbeefcafef00d",
+		Status: "ready",
+		Request: Redact(provisioner.Request{
+			OrgName:       "Omantel",
+			SovereignFQDN: "omantel.omani.works",
+			HetznerToken:  "tok",
+			ParentDomains: []provisioner.ParentDomain{
+				{Name: "omani.works", Role: provisioner.ParentDomainRolePrimary, RegistrarKind: "dynadot", AddedAt: addedAt},
+				{Name: "omani.trade", Role: provisioner.ParentDomainRoleSMEPool, RegistrarKind: "dynadot", AddedAt: addedAt.Add(time.Hour)},
+			},
+		}),
+		StartedAt: time.Now().UTC().Truncate(time.Second),
+	}
+	if err := s.Save(rec); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	got, err := s.LoadAll(nil)
+	if err != nil {
+		t.Fatalf("LoadAll: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("LoadAll returned %d records, want 1", len(got))
+	}
+	pds := got[0].Request.ParentDomains
+	if len(pds) != 2 {
+		t.Fatalf("ParentDomains round-trip: len=%d, want 2", len(pds))
+	}
+	if pds[0].Name != "omani.works" || pds[0].Role != provisioner.ParentDomainRolePrimary {
+		t.Errorf("primary entry round-trip failed: %+v", pds[0])
+	}
+	if pds[1].Name != "omani.trade" || pds[1].Role != provisioner.ParentDomainRoleSMEPool {
+		t.Errorf("sme-pool entry round-trip failed: %+v", pds[1])
+	}
+}
+
+// TestLegacyRecord_NoParentDomainsKey_LoadsCleanly is the load-bearing
+// backward-compat test. Drops a legacy on-disk record (single-FQDN
+// shape, no parentDomains key) into the store directory and proves:
+//
+//   - LoadAll returns the record without error
+//   - the rehydrated provisioner.Request has empty ParentDomains
+//   - calling Validate() on the rehydrated Request synthesises the
+//     primary entry from SovereignPoolDomain (or SovereignFQDN)
+//   - persisting back via Save() emits the array form on the next
+//     read — the migration is transparent across a single Pod boot
+func TestLegacyRecord_NoParentDomainsKey_LoadsCleanly(t *testing.T) {
+	dir := t.TempDir()
+	s, err := New(dir)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	// Hand-craft a JSON file that mirrors the pre-#826 on-disk shape:
+	// no parentDomains key. We write it directly with os.WriteFile so
+	// we exercise the deserialiser the way a real legacy record would.
+	legacyJSON := `{
+  "id": "legacy0001legacy",
+  "status": "ready",
+  "request": {
+    "orgName": "Omantel",
+    "orgEmail": "ops@omantel.om",
+    "sovereignFQDN": "omantel.omani.works",
+    "sovereignDomainMode": "pool",
+    "sovereignPoolDomain": "omani.works",
+    "sovereignSubdomain": "omantel",
+    "region": "fsn1",
+    "controlPlaneSize": "cpx21",
+    "workerSize": "cpx31",
+    "workerCount": 2,
+    "haEnabled": false,
+    "sshPublicKey": "ssh-ed25519 AAAA legacy",
+    "hetznerToken": "<redacted>",
+    "dynadotKey": "<redacted>",
+    "dynadotSecret": "<redacted>"
+  },
+  "startedAt": "2026-04-30T12:00:00Z",
+  "events": []
+}
+`
+	path := filepath.Join(dir, "legacy0001legacy.json")
+	if err := os.WriteFile(path, []byte(legacyJSON), 0o600); err != nil {
+		t.Fatalf("write legacy file: %v", err)
+	}
+
+	// Load it back through the store.
+	got, err := s.LoadAll(nil)
+	if err != nil {
+		t.Fatalf("LoadAll: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("LoadAll returned %d records, want 1", len(got))
+	}
+	rec := got[0]
+	if rec.Request.SovereignFQDN != "omantel.omani.works" {
+		t.Errorf("non-secret context lost on legacy load: %+v", rec.Request)
+	}
+	// Pre-migration: the rehydrated slice is empty.
+	if len(rec.Request.ParentDomains) != 0 {
+		t.Fatalf("legacy record should rehydrate with empty ParentDomains, got %d entries", len(rec.Request.ParentDomains))
+	}
+
+	// Now simulate the on-restart re-validation path: rehydrate +
+	// run Validate(). The migration synthesises the primary entry.
+	// Validate() requires every secret field to be present — for a
+	// legacy record the credentials are <redacted>; we only exercise
+	// the parent-domains synthesis, so we patch the placeholders in
+	// to make the validator pass.
+	preq := rec.Request.ToProvisionerRequest()
+	preq.HetznerToken = "harness-token"
+	preq.HetznerProjectID = "harness-project"
+	preq.HarborRobotToken = "harness-harbor"
+	preq.GHCRPullToken = "harness-ghcr"
+	preq.ObjectStorageRegion = "fsn1"
+	preq.ObjectStorageAccessKey = "TESTACCESSKEY"
+	preq.ObjectStorageSecretKey = "TESTSECRETKEY1234567890123456789012345"
+	preq.ObjectStorageBucket = "catalyst-omantel-omani-works"
+	if err := preq.Validate(); err != nil {
+		t.Fatalf("Validate on rehydrated legacy request: %v", err)
+	}
+	if len(preq.ParentDomains) != 1 {
+		t.Fatalf("migration should synthesise 1 primary entry, got %d", len(preq.ParentDomains))
+	}
+	pd := preq.ParentDomains[0]
+	if pd.Name != "omani.works" {
+		t.Errorf("synthesised Name = %q, want omani.works (the SovereignPoolDomain — the registered parent zone)", pd.Name)
+	}
+	if pd.Role != provisioner.ParentDomainRolePrimary {
+		t.Errorf("synthesised Role = %q, want %q", pd.Role, provisioner.ParentDomainRolePrimary)
+	}
+
+	// Persist back — the next on-disk file MUST emit the array form.
+	rec.Request = Redact(preq)
+	if err := s.Save(rec); err != nil {
+		t.Fatalf("Save migrated record: %v", err)
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if !strings.Contains(string(raw), `"parentDomains"`) {
+		t.Errorf("migrated on-disk record should contain parentDomains key:\n%s", raw)
+	}
+	if !strings.Contains(string(raw), `"omani.works"`) {
+		t.Errorf("migrated on-disk record should contain primary domain:\n%s", raw)
+	}
+	// Re-load again and confirm the slice is now populated on the
+	// next round-trip.
+	got2, err := s.LoadAll(nil)
+	if err != nil {
+		t.Fatalf("LoadAll after migration: %v", err)
+	}
+	if len(got2[0].Request.ParentDomains) != 1 {
+		t.Errorf("after migration save, LoadAll should rehydrate 1 entry, got %d", len(got2[0].Request.ParentDomains))
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/store/store.go
+++ b/products/catalyst/bootstrap/api/internal/store/store.go
@@ -135,6 +135,24 @@ type RedactedRequest struct {
 	SovereignPoolDomain string `json:"sovereignPoolDomain,omitempty"`
 	SovereignSubdomain  string `json:"sovereignSubdomain,omitempty"`
 
+	// ParentDomains — multi-domain pool persisted across the
+	// catalyst-api Pod restart boundary (issue #826, sub-1 of epic
+	// #825). The slice carries per-domain metadata only; per-domain
+	// registrar credentials are NEVER persisted on the deployment
+	// record — RegistrarCredsRef points at a SealedSecret in
+	// catalyst-system whose plaintext lives only in K8s, never on
+	// the catalyst-api PVC. See provisioner.ParentDomain for field
+	// semantics.
+	//
+	// Backward compatibility: a record persisted under the legacy
+	// single-FQDN shape (no `parentDomains` key in JSON) deserializes
+	// with the slice empty; ToProvisionerRequest re-runs the
+	// provisioner.Validate() migration path on the next read so the
+	// rehydrated request carries the synthesised primary entry. The
+	// next Save() that writes this record back to disk emits the
+	// array form — the migration is transparent to operators.
+	ParentDomains []provisioner.ParentDomain `json:"parentDomains,omitempty"`
+
 	HetznerToken     string `json:"hetznerToken,omitempty"`
 	HetznerProjectID string `json:"hetznerProjectID,omitempty"`
 
@@ -196,6 +214,12 @@ func Redact(req provisioner.Request) RedactedRequest {
 		HAEnabled:           req.HAEnabled,
 		Regions:             req.Regions,
 		SSHPublicKey:        req.SSHPublicKey,
+		// Multi-domain pool (issue #826). Persisted verbatim — the
+		// fields on ParentDomain are non-secret (Name + Role +
+		// RegistrarKind + RegistrarCredsRef + AddedAt). The
+		// RegistrarCredsRef points at a SealedSecret name; the
+		// plaintext registrar credentials are NEVER on this record.
+		ParentDomains: req.ParentDomains,
 		// Object Storage non-secret context — region + bucket are public
 		// in the sense that they appear in tofu outputs and the cluster's
 		// Secret stringData on every reconciliation. Persisted verbatim.
@@ -240,17 +264,22 @@ func (r RedactedRequest) ToProvisionerRequest() provisioner.Request {
 		SovereignDomainMode: r.SovereignDomainMode,
 		SovereignPoolDomain: r.SovereignPoolDomain,
 		SovereignSubdomain:  r.SovereignSubdomain,
-		HetznerToken:        r.HetznerToken, // <redacted> or ""
-		HetznerProjectID:    r.HetznerProjectID,
-		Region:              r.Region,
-		ControlPlaneSize:    r.ControlPlaneSize,
-		WorkerSize:          r.WorkerSize,
-		WorkerCount:         r.WorkerCount,
-		HAEnabled:           r.HAEnabled,
-		Regions:             r.Regions,
-		SSHPublicKey:        r.SSHPublicKey,
-		DynadotAPIKey:       r.DynadotAPIKey,    // <redacted> or ""
-		DynadotAPISecret:    r.DynadotAPISecret, // <redacted> or ""
+		// Multi-domain pool rehydrate (issue #826). Records persisted
+		// before the field was added deserialize with this empty;
+		// provisioner.Request.Validate() then synthesises the primary
+		// entry on the next call — the migration is transparent.
+		ParentDomains:    r.ParentDomains,
+		HetznerToken:     r.HetznerToken, // <redacted> or ""
+		HetznerProjectID: r.HetznerProjectID,
+		Region:           r.Region,
+		ControlPlaneSize: r.ControlPlaneSize,
+		WorkerSize:       r.WorkerSize,
+		WorkerCount:      r.WorkerCount,
+		HAEnabled:        r.HAEnabled,
+		Regions:          r.Regions,
+		SSHPublicKey:     r.SSHPublicKey,
+		DynadotAPIKey:    r.DynadotAPIKey,    // <redacted> or ""
+		DynadotAPISecret: r.DynadotAPISecret, // <redacted> or ""
 		// Object Storage rehydrate (issue #371) — region + bucket are
 		// the verbatim values; access + secret come back as the redacted
 		// marker so a Pod restart can render the wizard's failure card


### PR DESCRIPTION
## Summary

Sub-1 of epic #825 (Multi-domain Sovereign). **Backend-only** per the SCOPE CORRECTION on issue #826: the wizard stays single-FQDN, multi-domain capability is a Day-2 admin-console action (#829, already merged with an in-memory stub waiting on this PR's persistence layer).

## What this PR adds

- **`provisioner.ParentDomain`** struct (Name, Role, RegistrarKind, RegistrarCredsRef, AddedAt) + role constants (`ParentDomainRolePrimary` | `ParentDomainRoleSMEPool`). Wire shape matches the handler-layer `ParentDomain` in `handler/parent_domains.go` (#829), so the handler's swap from in-memory store → `Deployment.parentDomains[]` is a one-line change in a follow-up PR.
- **`Request.ParentDomains []ParentDomain`** field. Backward-compatible: when the slice is empty, `Validate()` synthesises a single primary entry from `SovereignPoolDomain` (or `SovereignFQDN`) so legacy single-FQDN payloads + on-disk records read cleanly. The next `Save()` round-trips the array form — transparent migration with no one-shot script.
- **`validateParentDomains`** enforces "exactly one primary", role enum, FQDN regex (RFC 1035, mirrors wizard `isValidDomain`), duplicate-name dedupe, lowercase normalisation in place.
- **`ProvisionParentDomain` / `ProvisionParentDomains`** — the per-domain abstraction the issue's DoD calls out as "reusable function ready for #829". Day-2 add-domain calls this with the same step list (`registrar-flip → powerdns-zone-create → cert-manager-cert`) the Day-1 path uses; idempotent, stops on first error, emits per-step SSE events.
- **`Request.PrimaryParentDomain()` / `SMEPoolParentDomains()`** lookup helpers.
- **`writeTfvars`** emits `parent_domains` as a JSON array (never null) so a future OpenTofu module's `for pd in var.parent_domains` validator accepts the input — same nil-trap fix the regions slice already carries.
- **`store.RedactedRequest` + `ToProvisionerRequest`** round-trip the slice verbatim. Non-secret fields only.
- **`store.crdStore`** mirrors the slice into the ProvisioningState CRD spec so admin tooling reading via K8s API sees the live pool.

## What this PR does NOT touch (explicit scope)

- `products/catalyst/bootstrap/ui/src/pages/wizard/**` — wizard UI stays single-FQDN per the issue's SCOPE CORRECTION.
- `products/catalyst/bootstrap/api/internal/handler/parent_domains.go` — the #829-merged Day-2 admin handler keeps its in-memory store; a follow-up PR swaps to `Deployment.parentDomains[]`.

## Inviolable Principles

- **#1 (target-state shape)**: the persisted JSON shape is the final shape — `parentDomains[]` with role + registrarKind + registrarCredsRef + addedAt. No "for now" placeholder fields.
- **#4 (never hardcode)**: `defaultRegistrarKindFromEnv` reads `CATALYST_DEFAULT_REGISTRAR_KIND` so operators on registrars other than Dynadot override the synthesis path without code changes. No TLD or count is hardcoded.
- **#10 (credential hygiene)**: `RegistrarCredsRef` points at a SealedSecret name in `catalyst-system` — the plaintext registrar credentials NEVER live on the deployment record, the JSON store, or the CRD.

## Test plan

- [x] `go build ./products/catalyst/bootstrap/api/...` — compile clean
- [x] `go test ./internal/provisioner/...` — 14 new unit tests pass; pre-existing Harbor-token failures unchanged from `origin/main`
- [x] `go test ./internal/store/...` — all green (new + existing)
- [x] `go test ./internal/handler/...` — #829's `parent_domains_test.go` still green
- [x] `git diff origin/main..HEAD products/catalyst/bootstrap/ui/src/pages/wizard/` — empty (wizard UI untouched)

Closes #826.

🤖 Generated with [Claude Code](https://claude.com/claude-code)