### PR TITLE
fix(bp-catalyst-platform): remove Helm directives from CATALYST_POWERDNS_* env (#830)

### DIFF
--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: bp-catalyst-platform
-version: 1.4.1
-appVersion: 1.4.1
+version: 1.4.2
+appVersion: 1.4.2
 description: |
   Catalyst Platform — the unified Catalyst control plane umbrella chart for Catalyst-Zero.
   Composes the catalyst-{ui,api}, console, admin, marketplace UI modules and the marketplace-api backend.
@@ -323,6 +323,22 @@ description: |
   deployment.yaml comments. Verified with `helm template` (subjects[0].
   namespace=catalyst-system) AND `kubectl kustomize` (subjects[0].
   namespace=catalyst). 2026-05-04.
+
+  Bumped to 1.4.2 — dual-mode contract violation in 1.4.0
+  CATALYST_POWERDNS_API_URL block (issue #830 follow-up, 2026-05-04).
+  PR #838 introduced two `value: {{ default "..." .Values... | quote }}`
+  Helm directives in api-deployment.yaml's CATALYST_POWERDNS_API_URL +
+  CATALYST_POWERDNS_SERVER_ID env entries. Both broke the Kustomize-
+  mode contabo-mkt build with "yaml: invalid map key: map[string]
+  interface {}{...}", stalling every contabo reconciliation including
+  THIS chart's own RBAC fix from 1.4.1.
+  Same pattern as the SOVEREIGN_FQDN block right below in the same
+  file (extensively documented as a dual-mode hazard): replace the
+  Helm directive with a literal default. The in-cluster Service URL
+  is a non-secret constant on every Sovereign that ships bp-powerdns
+  at its canonical release name; per-Sovereign overrides are still
+  possible via the HelmRelease overlay's `catalystApi.env` additional-
+  env patch (which takes precedence). 2026-05-04.
 type: application
 
 # Opt-out from the blueprint-release hollow-chart guard (issue #181 / #510).

--- a/products/catalyst/chart/templates/api-deployment.yaml
+++ b/products/catalyst/chart/templates/api-deployment.yaml
@@ -402,14 +402,37 @@ spec:
             # non-standard layouts override via the Helm values overlay
             # at clusters/<sovereign>/bootstrap-kit/13-bp-catalyst-
             # platform.yaml.
+            #
+            # NOTE — DUAL-MODE CONTRACT (see SOVEREIGN_FQDN block below
+            # for the canonical explanation): this file is consumed BOTH
+            # by Helm (per-Sovereign install) AND by Kustomize (contabo-
+            # mkt's flux Kustomization at path: ./products/catalyst/chart/
+            # templates). Helm template syntax (double-curly directives)
+            # in this file BREAKS the Kustomize build with
+            # "yaml: invalid map key" and stalls every contabo
+            # reconciliation. The 1.4.0 version of this block used
+            # {{ default "..." .Values.catalystApi.powerdnsURL }} — that
+            # broke contabo's catalyst-platform Kustomization until this
+            # follow-up landed. Issue #830 follow-up.
+            #
+            # Solution: the in-cluster Service URL is a non-secret
+            # constant on every Sovereign that ships bp-powerdns at its
+            # canonical release name (powerdns/powerdns). Hardcode the
+            # literal here so the Kustomize build stays clean. Per-
+            # Sovereign overrides are still possible via the per-
+            # Sovereign HelmRelease overlay's `catalystApi.env`
+            # additional-env patch that takes precedence over the
+            # default below.
             - name: CATALYST_POWERDNS_API_URL
-              value: {{ default "http://powerdns.powerdns.svc.cluster.local:8081" .Values.catalystApi.powerdnsURL | quote }}
+              value: "http://powerdns.powerdns.svc.cluster.local:8081"
             # CATALYST_POWERDNS_SERVER_ID — virtually always "localhost"
             # per the PowerDNS REST API contract. Operator-overridable
             # for multi-tenant PowerDNS deployments where a single
-            # PowerDNS instance hosts multiple servers.
+            # PowerDNS instance hosts multiple servers (override via the
+            # HelmRelease overlay env patch — same pattern as
+            # CATALYST_POWERDNS_API_URL above).
             - name: CATALYST_POWERDNS_SERVER_ID
-              value: {{ default "localhost" .Values.catalystApi.powerdnsServerID | quote }}
+              value: "localhost"
             # ── /auth/handover Keycloak service-account (issue #606) ──────────
             # CATALYST_KC_ADDR — Keycloak base URL. Defaults to in-cluster
             # service FQDN in code; override here for non-standard Sovereign


### PR DESCRIPTION
## Summary
- Replace `value: {{ default "..." .Values.catalystApi.powerdnsURL | quote }}` with literal value
- Same fix for `CATALYST_POWERDNS_SERVER_ID`
- Bump bp-catalyst-platform 1.4.1 → 1.4.2

## Why
PR #838 (1.4.0) introduced two Helm `{{ }}` directives in api-deployment.yaml's CATALYST_POWERDNS_API_URL + CATALYST_POWERDNS_SERVER_ID env entries. Both broke the Kustomize-mode contabo-mkt build with `yaml: invalid map key: map[string]interface {}`, stalling every contabo reconciliation including the catalyst-platform-cutover RBAC fix from 1.4.1.

This is the exact dual-mode hazard the SOVEREIGN_FQDN block right below in the same file extensively documents.

## Test plan
- [x] `helm template` renders both env vars cleanly
- [x] `kubectl kustomize` renders both env vars cleanly (no more invalid-map-key error)

Unblocks openova-io/openova#830 cutover-driver RBAC reconciliation on contabo-mkt.