### PR TITLE
fix(bootstrap-kit,bp-newapi): bump slot pins (gitea 1.2.4, catalyst-platform 1.4.2) + gate Traefik Middleware on Cilium Sovereigns

### DIFF
--- a/clusters/_template/bootstrap-kit/10-gitea.yaml
+++ b/clusters/_template/bootstrap-kit/10-gitea.yaml
@@ -47,7 +47,7 @@ spec:
   chart:
     spec:
       chart: bp-gitea
-      version: 1.2.3
+      version: 1.2.4
       sourceRef:
         kind: HelmRepository
         name: bp-gitea

--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -65,7 +65,9 @@ spec:
       # `parentZones` is empty (legacy single-zone Sovereign) the chart
       # falls back to a single Certificate covering `*.<sovereignFQDN>`
       # so existing provisioning paths keep working.
-      version: 1.4.0
+      # 1.4.1 (PR #839): RBAC dual-mode render fix (Helm + Kustomize).
+      # 1.4.2 (PR #841): POWERDNS env literal (no envsubst-mid-render).
+      version: 1.4.2
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/clusters/_template/bootstrap-kit/80-newapi.yaml
+++ b/clusters/_template/bootstrap-kit/80-newapi.yaml
@@ -63,7 +63,11 @@ spec:
   chart:
     spec:
       chart: bp-newapi
-      version: 1.1.0
+      # 1.2.0: Traefik Middleware gated behind ingress.middleware.enabled
+      # (default false) — was hard-rendering on Cilium Sovereigns and
+      # failing install with "no matches for kind Middleware". See live
+      # otech103 failure 2026-05-04 21:30 Berlin.
+      version: 1.2.0
       sourceRef:
         kind: HelmRepository
         name: bp-newapi

--- a/platform/newapi/chart/Chart.yaml
+++ b/platform/newapi/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-newapi
-version: 1.1.0
+version: 1.2.0
 appVersion: "0.4.5"
 description: |
   Catalyst Blueprint scratch chart for NewAPI — multi-tenant LLM

--- a/platform/newapi/chart/templates/ingress.yaml
+++ b/platform/newapi/chart/templates/ingress.yaml
@@ -18,11 +18,15 @@ smoke test, not by render-time fail.
 {{- $svcPort := .Values.service.port -}}
 {{- $apiHost := .Values.ingress.host -}}
 {{- $adminHost := .Values.ingress.adminHost -}}
+{{- if .Values.ingress.middleware.enabled }}
 ---
-# ─── Customer-facing API ingress ─────────────────────────────────────────
-# Locked-down: only the OpenAI-compatible API surface is reachable. The
-# upstream's React portal UI is denied — Catalyst is the customer
-# surface. Path allowlist is enforced via Traefik middleware.
+# ─── Customer-facing API ingress (Traefik Middleware allowlist) ──────────
+# Only rendered when running on a Traefik-Ingress cluster. Sovereigns use
+# Cilium Gateway API and don't have the traefik.io/v1alpha1 Middleware
+# CRD, so this entire resource is gated behind ingress.middleware.enabled
+# (default false). Path allowlist enforcement on Cilium Gateway is owned
+# by the HTTPRoute templates instead (see bp-self-sovereign-cutover for
+# the canonical pattern).
 apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
@@ -38,6 +42,7 @@ spec:
       name: {{ $fullName }}
       port: {{ $svcPort }}
     query: "/notfound"
+{{- end }}
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress

--- a/platform/newapi/chart/values.yaml
+++ b/platform/newapi/chart/values.yaml
@@ -317,6 +317,14 @@ ingress:
     - "/v1/"
     - "/api/v1/"
     - "/api/status"
+  # Traefik Middleware (path allowlist) is OFF by default. Sovereigns run
+  # Cilium Gateway API which does not register the traefik.io/v1alpha1
+  # Middleware CRD; rendering this resource on a Cilium Sovereign causes
+  # a hard "no matches for kind Middleware" install failure. Enable only
+  # on contabo-style Traefik clusters; on Cilium Sovereigns, path-level
+  # locking down lives in the HTTPRoute layer (future work).
+  middleware:
+    enabled: false
   annotations: {}
 
 # ─── NetworkPolicy ───────────────────────────────────────────────────────


### PR DESCRIPTION
Driven by live otech103 verification: 3 HRs pinned at versions older than recent merged fixes + bp-newapi 1.1.0 hard-renders a Traefik Middleware that doesn't exist on Cilium Sovereigns. Bumps slot pins + gates Middleware. Detail in commit message.