### PR TITLE
fix(bp-gitea): reflector mirror gitea-admin-secret to catalyst ns for cutover Step-1

### DIFF
--- a/clusters/_template/bootstrap-kit/10-gitea.yaml
+++ b/clusters/_template/bootstrap-kit/10-gitea.yaml
@@ -47,7 +47,12 @@ spec:
   chart:
     spec:
       chart: bp-gitea
-      version: 1.2.4
+      # 1.2.5: gitea-admin-secret carries reflector.v1.k8s.emberstack.com
+      # annotations so bp-reflector mirrors it into the catalyst ns where
+      # bp-self-sovereign-cutover Step 1 gitea-mirror Job mounts it. K8s
+      # forbids cross-namespace secretKeyRef; reflector is the canonical
+      # platform-level mirror. Caught live on otech103 2026-05-04.
+      version: 1.2.5
       sourceRef:
         kind: HelmRepository
         name: bp-gitea

--- a/platform/gitea/chart/Chart.yaml
+++ b/platform/gitea/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-gitea
-version: 1.2.4
+version: 1.2.5
 description: |
   Catalyst-curated Blueprint umbrella chart for Gitea. Depends on the
   upstream `gitea` chart (dl.gitea.com) as a Helm subchart so

--- a/platform/gitea/chart/templates/admin-secret.yaml
+++ b/platform/gitea/chart/templates/admin-secret.yaml
@@ -88,6 +88,16 @@ metadata:
     # Survive helm uninstall — the Secret outlives the release. A
     # subsequent helm install picks up the bytes via lookup.
     helm.sh/resource-policy: keep
+    # bp-reflector mirrors this Secret into the namespaces listed below
+    # so cross-namespace consumers (bp-self-sovereign-cutover Step 1
+    # gitea-mirror Job in the catalyst namespace) can mount the same
+    # credentials without a cross-namespace secretKeyRef (which K8s
+    # forbids). reflector keeps the mirror in lockstep on every change.
+    # See https://github.com/emberstack/kubernetes-reflector.
+    reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
+    reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "catalyst"
+    reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
+    reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: "catalyst"
 type: Opaque
 data:
   username: {{ $username | b64enc | quote }}


### PR DESCRIPTION
Live otech103 verification — cutover Step-1 needed gitea-admin-secret in catalyst ns. Adds reflector annotations. Bump 1.2.4 → 1.2.5.