### PR TITLE
fix(self-sovereign-cutover): Step-1 push --all+--tags (skip GitHub PR refs)

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -80,7 +80,11 @@ spec:
       # POST /orgs/<org>/repos returns 404 if the org is missing, the
       # /user/repos fallback would create under gitea_admin (wrong path
       # for the subsequent push). Caught live on otech103 2026-05-04.
-      version: 0.1.2
+      # 0.1.3: replace `git push --mirror` with `git push --all + --tags`
+      # so Gitea's hooks don't decline GitHub-specific refs/pull/<n>
+      # refs (which --mirror would try to push). Branches+tags are what
+      # Flux GitRepository needs; PR refs are upstream-only metadata.
+      version: 0.1.3
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-self-sovereign-cutover
-version: 0.1.2
+version: 0.1.3
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/templates/01-gitea-mirror-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/01-gitea-mirror-job.yaml
@@ -113,9 +113,12 @@ data:
               echo "[gitea-mirror] repo already present"
             fi
 
-            # 2. Mirror clone from upstream and push --mirror to local Gitea.
-            #    --mirror preserves all refs, branches, tags, notes; matches
-            #    the desired "lift the upstream wholesale into local" shape.
+            # 3. Clone from upstream and push branches + tags to local Gitea.
+            #    We use --all + --tags rather than --mirror because Gitea
+            #    declines GitHub PR refs (refs/pull/<n>/head, /merge) via
+            #    its update hook — caught live on otech103 2026-05-04.
+            #    Branches and tags are sufficient for Flux GitRepository
+            #    reconciliation; PR refs are GitHub-specific metadata.
             workdir=$(mktemp -d)
             cd "${workdir}"
             git clone --mirror "${UPSTREAM_REPO_URL}" upstream.git
@@ -123,7 +126,10 @@ data:
             # Embed credentials in the push URL only (never in stdout).
             push_url=$(printf '%s' "${GITEA_INTERNAL_URL}" | sed -e "s,://,://${GITEA_USERNAME}:${GITEA_PASSWORD}@,")
             git remote set-url --push origin "${push_url}/${GITEA_ORG}/${GITEA_REPO}.git"
-            git push --mirror
+            # Push branches first (--all = all local branches), then
+            # tags. Filter out refs/pull/* by NOT using --mirror.
+            git push origin --all
+            git push origin --tags
             echo "[gitea-mirror] mirror complete"
         resources:
           requests: { cpu: 100m, memory: 256Mi }


### PR DESCRIPTION
0.1.2 → 0.1.3 — caught live on otech103 by Gitea hook decline on refs/pull/*.