### PR TITLE
fix(self-sovereign-cutover): Step-1 bare clone + explicit refspec push

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -84,7 +84,10 @@ spec:
       # so Gitea's hooks don't decline GitHub-specific refs/pull/<n>
       # refs (which --mirror would try to push). Branches+tags are what
       # Flux GitRepository needs; PR refs are upstream-only metadata.
-      version: 0.1.3
+      # 0.1.4: Step-1 uses `git clone --bare` (not --mirror) + explicit
+      # refspec push of refs/heads/* and refs/tags/* only. --all in a
+      # mirror clone still pushed refs/pull/* — caught live otech103.
+      version: 0.1.4
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-self-sovereign-cutover
-version: 0.1.3
+version: 0.1.4
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/templates/01-gitea-mirror-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/01-gitea-mirror-job.yaml
@@ -113,23 +113,28 @@ data:
               echo "[gitea-mirror] repo already present"
             fi
 
-            # 3. Clone from upstream and push branches + tags to local Gitea.
-            #    We use --all + --tags rather than --mirror because Gitea
-            #    declines GitHub PR refs (refs/pull/<n>/head, /merge) via
-            #    its update hook — caught live on otech103 2026-05-04.
-            #    Branches and tags are sufficient for Flux GitRepository
-            #    reconciliation; PR refs are GitHub-specific metadata.
+            # 3. Clone from upstream then push branches + tags only to
+            #    local Gitea, explicitly skipping GitHub-specific
+            #    refs/pull/<n>/(head|merge) refs that Gitea's update
+            #    hook declines. We DO NOT use --mirror or --all here:
+            #    a mirror clone stores GitHub PR refs at the same
+            #    namespace as branches and `git push --all` in that
+            #    context tries to push them too — caught live on
+            #    otech103 2026-05-04. An explicit refspec is the
+            #    correct shape: refs/heads/* and refs/tags/* only.
             workdir=$(mktemp -d)
             cd "${workdir}"
-            git clone --mirror "${UPSTREAM_REPO_URL}" upstream.git
+            # Plain (non-mirror) clone keeps refs/pull/* out of the
+            # local refs entirely. We then fetch tags separately.
+            git clone --bare "${UPSTREAM_REPO_URL}" upstream.git
             cd upstream.git
+            git fetch --tags origin
             # Embed credentials in the push URL only (never in stdout).
             push_url=$(printf '%s' "${GITEA_INTERNAL_URL}" | sed -e "s,://,://${GITEA_USERNAME}:${GITEA_PASSWORD}@,")
             git remote set-url --push origin "${push_url}/${GITEA_ORG}/${GITEA_REPO}.git"
-            # Push branches first (--all = all local branches), then
-            # tags. Filter out refs/pull/* by NOT using --mirror.
-            git push origin --all
-            git push origin --tags
+            # Explicit refspecs — branches and tags only, no PR refs.
+            git push origin 'refs/heads/*:refs/heads/*'
+            git push origin 'refs/tags/*:refs/tags/*'
             echo "[gitea-mirror] mirror complete"
         resources:
           requests: { cpu: 100m, memory: 256Mi }


### PR DESCRIPTION
0.1.3 → 0.1.4 — fix Gitea hook decline on refs/pull/* refs that mirror+--all still pushes.