### PR TITLE
fix(self-sovereign-cutover): harbor service URL (harbor-core not harbor-harbor-core)

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -87,7 +87,10 @@ spec:
       # 0.1.4: Step-1 uses `git clone --bare` (not --mirror) + explicit
       # refspec push of refs/heads/* and refs/tags/* only. --all in a
       # mirror clone still pushed refs/pull/* — caught live otech103.
-      version: 0.1.4
+      # 0.1.5: harborInternalURL fix — bp-harbor service is `harbor-core`
+      # not `harbor-harbor-core` (release name doesn't double-prefix).
+      # Caught live otech103 — Step-2 curl exit 6 (couldn't resolve).
+      version: 0.1.5
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-self-sovereign-cutover
-version: 0.1.4
+version: 0.1.5
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/values.yaml
+++ b/platform/self-sovereign-cutover/chart/values.yaml
@@ -36,7 +36,10 @@ sovereign:
   # (helmrepository-patches) rewrite to (since containerd + Flux
   # source-controller resolve through public DNS, not in-cluster
   # CoreDNS).
-  harborInternalURL: "http://harbor-harbor-core.harbor.svc.cluster.local"
+  # Service name on bp-harbor is `harbor-core` (NOT `harbor-harbor-core`)
+  # — caught live on otech103 2026-05-04. Verified via
+  # `kubectl get svc -n harbor` returns harbor-core ClusterIP.
+  harborInternalURL: "http://harbor-core.harbor.svc.cluster.local"
   # ↓ overlay required for real cutover (uses ${SOVEREIGN_FQDN}).
   harborPublicURL: "https://harbor.example.local"
   giteaInternalURL: "http://gitea-http.gitea.svc.cluster.local:3000"


### PR DESCRIPTION
0.1.4 → 0.1.5 — caught live on otech103 Step-2.