### PR TITLE
fix(bootstrap-kit): slot 06a harborInternalURL override (was hiding chart 0.1.5 fix)

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -109,7 +109,7 @@ spec:
   values:
     sovereign:
       fqdn: ${SOVEREIGN_FQDN}
-      harborInternalURL: http://harbor-harbor-core.harbor.svc.cluster.local
+      harborInternalURL: http://harbor-core.harbor.svc.cluster.local
       harborPublicURL: https://harbor.${SOVEREIGN_FQDN}
       giteaInternalURL: http://gitea-http.gitea.svc.cluster.local:3000
       giteaPublicURL: https://gitea.${SOVEREIGN_FQDN}


### PR DESCRIPTION
Slot override was hiding chart fix. Live otech103 still rendered old URL. Self-merge.