### PR TITLE
fix(self-sovereign-cutover): GHCR Harbor adapter 'github-ghcr' not 'github'

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -90,7 +90,11 @@ spec:
       # 0.1.5: harborInternalURL fix — bp-harbor service is `harbor-core`
       # not `harbor-harbor-core` (release name doesn't double-prefix).
       # Caught live otech103 — Step-2 curl exit 6 (couldn't resolve).
-      version: 0.1.5
+      # 0.1.6: proxy-ghcr registryType "github" → "github-ghcr" (the
+      # canonical Harbor adapter name for GHCR proxy-cache, per Harbor
+      # 2.x docs). Caught live otech103 — Harbor 500 "adapter factory
+      # for github not found".
+      version: 0.1.6
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-self-sovereign-cutover
-version: 0.1.5
+version: 0.1.6
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/values.yaml
+++ b/platform/self-sovereign-cutover/chart/values.yaml
@@ -96,7 +96,11 @@ harbor:
   proxyProjects:
     - name: "proxy-ghcr"
       upstreamURL: "https://ghcr.io"
-      registryType: "github"
+      # Harbor adapter "github-ghcr" (the canonical GHCR proxy-cache
+      # adapter), with `docker-registry` fallback for older Harbor
+      # versions. Caught live on otech103 2026-05-04 (was "github" →
+      # "adapter factory for github not found"). Per Harbor 2.x docs.
+      registryType: "github-ghcr"
       authMode: "credential"      # uses harbor.ghcrSecretRef
     - name: "proxy-docker"
       upstreamURL: "https://registry-1.docker.io"


### PR DESCRIPTION
0.1.5 → 0.1.6 — caught live on otech103.