### PR TITLE
fix(self-sovereign-cutover): proxy-quay adapter type docker-registry

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -94,7 +94,12 @@ spec:
       # canonical Harbor adapter name for GHCR proxy-cache, per Harbor
       # 2.x docs). Caught live otech103 — Harbor 500 "adapter factory
       # for github not found".
-      version: 0.1.6
+      # 0.1.7: proxy-quay registryType "quay" → "docker-registry" —
+      # Harbor's "quay" adapter rejects project metadata.proxy_cache
+      # with HTTP 400. Quay speaks plain v2 so generic docker-registry
+      # is correct. Caught live otech103 — 4/7 proxy-cache projects
+      # were created OK, blocked at proxy-quay.
+      version: 0.1.7
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-self-sovereign-cutover
-version: 0.1.6
+version: 0.1.7
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/values.yaml
+++ b/platform/self-sovereign-cutover/chart/values.yaml
@@ -116,7 +116,12 @@ harbor:
       authMode: "anonymous"
     - name: "proxy-quay"
       upstreamURL: "https://quay.io"
-      registryType: "quay"
+      # docker-registry adapter — Harbor's "quay" type is internal/legacy
+      # and rejects project metadata.proxy_cache=true with HTTP 400
+      # "unsupported registry type quay". Quay speaks plain v2 so the
+      # generic docker-registry adapter is the right shape. Caught live
+      # on otech103 2026-05-04.
+      registryType: "docker-registry"
       authMode: "anonymous"
     - name: "proxy-xpkg"
       upstreamURL: "https://xpkg.upbound.io"


### PR DESCRIPTION
0.1.6 → 0.1.7.