### PR TITLE
fix(self-sovereign-cutover): bitnami/kubectl → alpine/k8s (Bitnami deprecated)

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -103,7 +103,11 @@ spec:
       # at minor-version, only patch). Caught live otech103 — Step-5
       # Pod hit DeadlineExceeded after 10m of ImagePullBackOff for
       # docker.io/bitnami/kubectl:1.31 (404 not found).
-      version: 0.1.8
+      # 0.1.9: bitnami/kubectl :1.31.4 ALSO 404 (Bitnami deprecated
+      # public Docker Hub in 2025). Switched to alpine/k8s:1.31.4 —
+      # canonical alpine-based image with kubectl + helm + k8s CLI
+      # surface, actively maintained.
+      version: 0.1.9
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-self-sovereign-cutover
-version: 0.1.8
+version: 0.1.9
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/values.yaml
+++ b/platform/self-sovereign-cutover/chart/values.yaml
@@ -222,11 +222,12 @@ catalystAPI:
 # global.imageRegistry — defaulted off so smoke render is clean.
 images:
   kubectl:
-    repository: "bitnami/kubectl"
-    # bitnami doesn't tag with :1.31 (only :1.31.X — patch-level). Caught
-    # live on otech103 — DockerHub returned 404 'not found' for :1.31
-    # and Pod hit DeadlineExceeded after 10m of pull retries. Pinning to
-    # the latest .X release for the 1.31 minor.
+    # Switched from bitnami/kubectl (Bitnami deprecated public Docker Hub
+    # in 2025; both :1.31 and :1.31.4 returned 404). alpine/k8s is the
+    # canonical alternative — alpine-based image with kubectl + helm +
+    # the standard k8s CLI surface, actively maintained on Docker Hub.
+    # Caught live on otech103 2026-05-04.
+    repository: "alpine/k8s"
     tag: "1.31.4"
   git:
     repository: "alpine/git"


### PR DESCRIPTION
0.1.8 → 0.1.9. Caught live otech103.