### PR TITLE
feat(bp-catalyst-platform): deploy FerretDB in sme ns + cross-ns valkey wire (#861)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -74,7 +74,14 @@ spec:
       # clusters/contabo-mkt/apps/sme/data/* manifests — those are
       # outside templates/kustomization.yaml's resource list so the
       # contabo Kustomize-mode build is unaffected.
-      version: 1.4.3
+      # 1.4.4 (issue #861): deploy FerretDB in `sme` ns + cross-ns
+      # CiliumNetworkPolicy from sme → valkey. Unblocks the 4 SME
+      # services (catalog, tenant, domain, provisioning) that pin to
+      # ferretdb.sme.svc.cluster.local for the MongoDB wire and the 2
+      # services (auth, gateway) that pin to valkey for session/state.
+      # cnpg-cluster.yaml extended to bootstrap sme_documents (FerretDB
+      # backing DB) alongside sme_billing.
+      version: 1.4.4
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: bp-catalyst-platform
-version: 1.4.3
-appVersion: 1.4.3
+version: 1.4.4
+appVersion: 1.4.4
 description: |
   Catalyst Platform — the unified Catalyst control plane umbrella chart for Catalyst-Zero.
   Composes the catalyst-{ui,api}, console, admin, marketplace UI modules and the marketplace-api backend.
@@ -387,6 +387,73 @@ description: |
 
   Lockstep slot 13 pin in clusters/_template/bootstrap-kit/
   13-bp-catalyst-platform.yaml bumps from 1.4.2 → 1.4.3. 2026-05-04.
+
+  Bumped to 1.4.4 — deploy FerretDB in sme ns + cross-ns Valkey wire
+  to unblock catalog/tenant/domain SME services on franchised
+  Sovereigns (issue #861, 2026-05-04). After 1.4.3 landed sme-pg +
+  sme-secrets, 7/12 SME pods reached Running on otech103 but 3 stayed
+  in CrashLoopBackOff with the same DNS error:
+
+      catalog: failed to ping MongoDB
+      error=...lookup ferretdb.sme.svc.cluster.local on 10.43.0.10:53:
+      no such host
+
+  Root cause: SME service ConfigMap (sme-services-config) hardcoded
+  two URLs that have no Sovereign-side workload behind them:
+    - MONGODB_URI: mongodb://ferretdb.sme.svc.cluster.local:27017
+      (FerretDB has no Deployment on Sovereigns — only on contabo-mkt
+      via clusters/contabo-mkt/apps/sme/data/ferretdb.yaml)
+    - VALKEY_ADDR: valkey.sme.svc.cluster.local:6379
+      (bp-valkey 1.0.0 deploys to namespace `valkey`, not `sme`,
+      and exposes Services `valkey-primary` / `valkey-replicas` /
+      `valkey-headless` — no plain `valkey` service)
+
+  Fix:
+  - NEW templates/sme-services/ferretdb.yaml — gated on the same
+    .Values.ingress.marketplace.enabled flag. Deployment + Service
+    `ferretdb` in `sme` ns, image pinned ghcr.io/ferretdb/ferretdb:1.24
+    (matches contabo's data/ferretdb.yaml — v2.x requires PostgreSQL
+    with the DocumentDB extension which the sme-pg CNPG cluster from
+    PR #860 does not ship; v1.24 works against vanilla CNPG postgres:
+    16 and is the proven path). Backed by sme-pg via FERRETDB_POSTGRESQL_
+    URL env interpolating PG_USER + PG_PASSWORD from the sme-pg-app
+    Secret (auto-created by CNPG in 1.4.3) and pointing at
+    sme-pg-rw.sme.svc.cluster.local:5432/sme_documents. Image is
+    operator-overridable via .Values.smeServices.ferretdb.{image,tag}
+    (Inviolable Principle #4).
+  - cnpg-cluster.yaml — extend postInitApplicationSQL to also
+    CREATE DATABASE sme_documents OWNER sme so FerretDB has a DB to
+    write into on first install. The DB list is data-driven from
+    .Values.smePostgres.cluster.additionalDatabases (defaulting to
+    [sme_billing, sme_documents]) so adding a new SME service is a
+    values-only change.
+  - configmap.yaml — VALKEY_ADDR now reads from .Values.smeServices.
+    valkey.host (default valkey-primary.valkey.svc.cluster.local:6379
+    — the actual Service name bitnami/valkey 5.5.1 with replication
+    architecture renders, NOT the issue's `valkey.valkey.svc.cluster.
+    local` which doesn't exist on Sovereigns). MONGODB_URI also uses
+    .Values.smeServices.ferretdb.{host,port} for symmetry.
+  - NEW templates/sme-services/valkey-cross-ns-policy.yaml —
+    CiliumNetworkPolicy in `valkey` namespace allowing ingress on
+    6379/TCP from any Pod in the `sme` namespace. Defense-in-depth on
+    top of bp-valkey 1.0.0's upstream NetworkPolicy (which already
+    permits port 6379 from any source). Gated on the same
+    marketplace.enabled flag.
+  - values.yaml — add `smeServices.ferretdb.{image,tag,replicas,
+    resources}` and `smeServices.valkey.host` blocks. Every URL,
+    image ref, and resource value is operator-overridable per
+    Inviolable Principle #4.
+
+  Known follow-up: bp-valkey ships with `auth.enabled: true` (bitnami
+  default). SME services pass only VALKEY_ADDR (no password env). Two
+  remediation paths exist: (a) per-Sovereign overlay disables
+  bp-valkey auth, or (b) plumb VALKEY_PASSWORD through SME service
+  Deployments + service code. Filed separately. This PR ships the
+  infrastructure (FQDN + CiliumNetworkPolicy) so the wire is in place
+  when one of those auth fixes lands.
+
+  Lockstep slot 13 pin in clusters/_template/bootstrap-kit/
+  13-bp-catalyst-platform.yaml bumps from 1.4.3 → 1.4.4. 2026-05-04.
 type: application
 
 # Opt-out from the blueprint-release hollow-chart guard (issue #181 / #510).

--- a/products/catalyst/chart/templates/sme-services/cnpg-cluster.yaml
+++ b/products/catalyst/chart/templates/sme-services/cnpg-cluster.yaml
@@ -25,13 +25,19 @@ Capabilities gate:
   rendered" rather than a hard install failure of the umbrella chart.
   See feedback_inviolable_principles.md #4.
 
-Why two databases (sme_auth + sme_billing):
-  The SME auth service uses sme_auth as its primary store; the billing
-  service uses sme_billing. On contabo a separate Job
-  (data/init-databases.yaml) creates sme_billing post-cluster-bootstrap.
-  Here we fold both into `bootstrap.initdb.postInitApplicationSQL` so a
-  single CNPG Cluster bootstraps both DBs atomically — one fewer Job to
-  watch, one fewer race against pod readiness.
+Why N databases (sme_auth primary, sme_billing + sme_documents secondary):
+  The SME auth service uses sme_auth as its primary store; billing uses
+  sme_billing; FerretDB (the MongoDB-wire-compatible front-end shipped
+  by templates/sme-services/ferretdb.yaml in 1.4.4) uses sme_documents.
+  On contabo a separate Job (data/init-databases.yaml) creates the
+  secondary DBs post-cluster-bootstrap. Here we fold them all into
+  `bootstrap.initdb.postInitApplicationSQL` so a single CNPG Cluster
+  bootstraps every DB atomically — one fewer Job to watch, one fewer
+  race against pod readiness.
+
+  The secondary-DB list is data-driven via
+  .Values.smePostgres.cluster.additionalDatabases so adding a new SME
+  service is a values-only change (Inviolable Principle #4).
 
 Credential persistence:
   CNPG owns the `sme-pg-app` Secret and emits stable bytes across
@@ -81,13 +87,18 @@ spec:
     initdb:
       database: {{ .Values.smePostgres.cluster.database | default "sme_auth" | quote }}
       owner: {{ .Values.smePostgres.cluster.owner | default "sme" | quote }}
-      # Create the secondary DBs the SME mesh needs (sme_billing).
+      # Create the secondary DBs the SME mesh needs.
       # postInitApplicationSQL runs as the postgres superuser AFTER
       # initdb has created the primary DB + owner role, so CREATE
       # DATABASE here is the canonical CNPG-blessed extension point
-      # for multi-DB clusters.
+      # for multi-DB clusters. Data-driven from
+      # .Values.smePostgres.cluster.additionalDatabases — defaults to
+      # [sme_billing, sme_documents] (1.4.4 — sme_documents is
+      # FerretDB's backing DB, see ferretdb.yaml).
       postInitApplicationSQL:
-        - CREATE DATABASE sme_billing OWNER {{ .Values.smePostgres.cluster.owner | default "sme" }};
+        {{- range $db := .Values.smePostgres.cluster.additionalDatabases | default (list "sme_billing" "sme_documents") }}
+        - CREATE DATABASE {{ $db }} OWNER {{ $.Values.smePostgres.cluster.owner | default "sme" }};
+        {{- end }}
 
   postgresql:
     parameters:

--- a/products/catalyst/chart/templates/sme-services/configmap.yaml
+++ b/products/catalyst/chart/templates/sme-services/configmap.yaml
@@ -26,10 +26,22 @@ data:
   NOTIFICATION_URL: "http://notification.sme.svc.cluster.local:8087"
 
   # ---- shared backing-store endpoints ---------------------------------------
-  MONGODB_URI: "mongodb://ferretdb.sme.svc.cluster.local:27017"
-  VALKEY_ADDR: "valkey.sme.svc.cluster.local:6379"
-  POSTGRES_HOST: "sme-pg-rw.sme.svc.cluster.local"
-  POSTGRES_PORT: "5432"
+  # FerretDB (MongoDB-wire) — Catalyst-curated Deployment in `sme` ns
+  # (see ferretdb.yaml, issue #861). Operator-overridable via
+  # .Values.smeServices.ferretdb.{host,port} so a per-Sovereign overlay
+  # MAY swap to an external MongoDB endpoint without forking the chart.
+  MONGODB_URI: "mongodb://{{ .Values.smeServices.ferretdb.host | default "ferretdb.sme.svc.cluster.local" }}:{{ .Values.smeServices.ferretdb.port | default 27017 }}"
+  # Valkey — bp-valkey 1.0.0 deploys to `valkey` namespace (slot 17,
+  # see 17-valkey.yaml). Bitnami valkey 5.5.1 with architecture:replication
+  # renders Services `valkey-primary` (read/write), `valkey-replicas`,
+  # `valkey-headless` — NO plain `valkey` Service exists. Default points
+  # at the primary; per-Sovereign overlays MAY override via
+  # .Values.smeServices.valkey.host (e.g. for HA replicas read-only or
+  # to swap to an external Redis-compatible cache). Cross-ns reachability
+  # is granted by templates/sme-services/valkey-cross-ns-policy.yaml.
+  VALKEY_ADDR: "{{ .Values.smeServices.valkey.host | default "valkey-primary.valkey.svc.cluster.local" }}:{{ .Values.smeServices.valkey.port | default 6379 }}"
+  POSTGRES_HOST: "{{ .Values.smePostgres.cluster.name | default "sme-pg" }}-rw.{{ .Values.smePostgres.cluster.namespace | default "sme" }}.svc.cluster.local"
+  POSTGRES_PORT: "{{ .Values.smeServices.ferretdb.postgresPort | default 5432 }}"
 
   # ---- cross-namespace event bus --------------------------------------------
   # Redpanda currently lives in the talentmesh namespace (migration tracked

--- a/products/catalyst/chart/templates/sme-services/ferretdb.yaml
+++ b/products/catalyst/chart/templates/sme-services/ferretdb.yaml
@@ -1,0 +1,140 @@
+{{- /*
+FerretDB — MongoDB-wire-compatible front-end backed by Postgres for the
+SME microservice mesh (issue #861).
+
+Why this template exists:
+  Three SME services (catalog, tenant, domain) and provisioning use a
+  MongoDB-wire driver to talk to a `ferretdb.sme.svc.cluster.local:27017`
+  service. On contabo-mkt this Deployment is shipped via
+  clusters/contabo-mkt/apps/sme/data/ferretdb.yaml. On a freshly
+  franchised Sovereign nothing equivalent exists, so 4 of the 11 SME
+  pods crashloop with `failed to ping MongoDB error=...lookup
+  ferretdb.sme.svc.cluster.local on 10.43.0.10:53: no such host`.
+  Caught live on otech103 (2026-05-04) after #859 landed sme-pg —
+  every SME pod that uses MONGODB_URI was still down.
+
+Image pinning:
+  ghcr.io/ferretdb/ferretdb:1.24 mirrors contabo's data/ferretdb.yaml.
+
+  WHY v1.24 NOT v2.x: FerretDB v2.x requires PostgreSQL with the
+  DocumentDB extension (microsoft/documentdb fork). The sme-pg CNPG
+  Cluster from #859/PR #860 uses ghcr.io/cloudnative-pg/postgresql:16
+  which ships vanilla Postgres without that extension — so a v2 image
+  would error out on first connect. v1.24 works against vanilla
+  Postgres and is the proven path on contabo. Bumping to v2 is a
+  separate change that needs a custom CNPG image AND a values toggle
+  to switch the imageName on sme-pg.
+
+Backing-store wiring:
+  FERRETDB_POSTGRESQL_URL points at the sme-pg-rw read/write Service
+  in this namespace. Credentials come from the sme-pg-app Secret CNPG
+  auto-creates in 1.4.3 (key names `username` + `password`). The DSN
+  interpolates them via Pod env-var-in-env-var substitution
+  ($(PG_USER)/$(PG_PASSWORD)) so the plaintext password never appears
+  in the Deployment manifest (Inviolable Principle #10 — no plaintext
+  credentials in source).
+
+  The connection target DB `sme_documents` is created by the
+  cnpg-cluster.yaml's postInitApplicationSQL block (1.4.4 extension)
+  alongside sme_billing.
+
+  sslmode=disable matches contabo's Deployment — sme-pg-rw is a
+  ClusterIP Service, traffic stays inside Cilium overlay encryption,
+  and CNPG's default issuer chain isn't trusted by FerretDB's bundled
+  PG client without extra config. Per-Sovereign overlays may flip
+  to require/verify-full via .Values.smeServices.ferretdb.sslmode if
+  the operator wires the CNPG CA into the FerretDB pod (separate
+  follow-up).
+
+Per Inviolable Principle #4 (never hardcode), every operationally-
+meaningful value flows through .Values.smeServices.ferretdb.* and
+.Values.smePostgres.* — image, tag, resources, sslmode, target DB
+name. Defaults match contabo's known-working shape so a fresh
+Sovereign install renders cleanly without operator input.
+*/}}
+{{- if and .Values.ingress .Values.ingress.marketplace .Values.ingress.marketplace.enabled -}}
+{{- $ferret := .Values.smeServices.ferretdb -}}
+{{- $ns := $ferret.namespace | default "sme" -}}
+{{- $pgService := printf "%s-rw.%s.svc.cluster.local" (.Values.smePostgres.cluster.name | default "sme-pg") $ns -}}
+{{- $pgPort := $ferret.postgresPort | default 5432 -}}
+{{- $pgDB := $ferret.postgresDatabase | default "sme_documents" -}}
+{{- $sslmode := $ferret.sslmode | default "disable" -}}
+{{- $appSecret := printf "%s-app" (.Values.smePostgres.cluster.name | default "sme-pg") -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ferretdb
+  namespace: {{ $ns }}
+  labels:
+    catalyst.openova.io/blueprint: bp-catalyst-platform
+    catalyst.openova.io/component: sme-ferretdb
+    app.kubernetes.io/part-of: sme
+spec:
+  replicas: {{ $ferret.replicas | default 1 }}
+  selector:
+    matchLabels:
+      app: sme-ferretdb
+  template:
+    metadata:
+      labels:
+        app: sme-ferretdb
+        catalyst.openova.io/component: sme-ferretdb
+        app.kubernetes.io/part-of: sme
+    spec:
+      containers:
+        - name: ferretdb
+          image: {{ printf "%s:%s" ($ferret.image | default "ghcr.io/ferretdb/ferretdb") ($ferret.tag | default "1.24") | quote }}
+          imagePullPolicy: {{ $ferret.imagePullPolicy | default "IfNotPresent" }}
+          ports:
+            - containerPort: 27017
+              name: mongo
+          env:
+            # Pull username/password from CNPG-managed sme-pg-app Secret
+            # (auto-created in 1.4.3 — see cnpg-cluster.yaml). Names
+            # `username` / `password` are CNPG defaults; do not override.
+            - name: PG_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $appSecret }}
+                  key: username
+            - name: PG_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $appSecret }}
+                  key: password
+            # FerretDB v1.x reads FERRETDB_POSTGRESQL_URL as its
+            # connection string. Pod env-var substitution
+            # ($(PG_USER)/$(PG_PASSWORD)) keeps the plaintext password
+            # out of the Deployment manifest (Inviolable Principle #10).
+            - name: FERRETDB_POSTGRESQL_URL
+              value: "postgres://$(PG_USER):$(PG_PASSWORD)@{{ $pgService }}:{{ $pgPort }}/{{ $pgDB }}?sslmode={{ $sslmode }}"
+          resources:
+            {{- toYaml ($ferret.resources | default (dict "requests" (dict "cpu" "25m" "memory" "64Mi") "limits" (dict "cpu" "500m" "memory" "256Mi"))) | nindent 12 }}
+          livenessProbe:
+            tcpSocket:
+              port: 27017
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          readinessProbe:
+            tcpSocket:
+              port: 27017
+            initialDelaySeconds: 10
+            periodSeconds: 5
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ferretdb
+  namespace: {{ $ns }}
+  labels:
+    catalyst.openova.io/blueprint: bp-catalyst-platform
+    catalyst.openova.io/component: sme-ferretdb
+    app.kubernetes.io/part-of: sme
+spec:
+  selector:
+    app: sme-ferretdb
+  ports:
+    - name: mongo
+      port: 27017
+      targetPort: 27017
+{{- end }}

--- a/products/catalyst/chart/templates/sme-services/valkey-cross-ns-policy.yaml
+++ b/products/catalyst/chart/templates/sme-services/valkey-cross-ns-policy.yaml
@@ -1,0 +1,95 @@
+{{- /*
+CiliumNetworkPolicy — explicit allow for sme-namespace Pods to reach the
+bp-valkey workload in the `valkey` namespace (issue #861).
+
+Why this template exists:
+  bp-valkey 1.0.0 deploys to namespace `valkey` (releaseName=valkey,
+  targetNamespace=valkey — see clusters/_template/bootstrap-kit/
+  17-valkey.yaml). The bitnami valkey 5.5.1 subchart with
+  `architecture: replication` renders three Services:
+    - valkey-headless.valkey.svc.cluster.local:6379
+    - valkey-primary.valkey.svc.cluster.local:6379  (read/write)
+    - valkey-replicas.valkey.svc.cluster.local:6379
+  None named just `valkey.valkey.svc.cluster.local` exists; the SME
+  configmap is updated to point at `valkey-primary` accordingly (see
+  configmap.yaml + .Values.smeServices.valkey.host).
+
+  bp-valkey's UPSTREAM NetworkPolicy (rendered into the `valkey`
+  namespace) already allows ingress on TCP/6379 from any source — the
+  upstream chart's default leaves `from` empty which is "all sources".
+  So strictly speaking, no NetworkPolicy change is required for the
+  cross-ns wire to function on a vanilla Cilium install.
+
+  This CiliumNetworkPolicy is shipped as DEFENSE-IN-DEPTH: an explicit
+  Cilium-native rule scoping the cross-ns allow to ONLY pods in the
+  `sme` namespace (no other workload should ever reach valkey
+  cross-ns). If a future bp-valkey bump tightens the upstream
+  NetworkPolicy to require namespaced sources, this CNP keeps the SME
+  wire working without coordinated chart changes. If a future bp-valkey
+  bump REMOVES the upstream NetworkPolicy entirely (and a Cilium
+  cluster-wide default-deny were applied), this CNP keeps the SME
+  ingress allowed.
+
+  Cilium uses union semantics across multiple policies — adding this
+  CNP only grants additional allow scope; it never narrows the
+  upstream NetworkPolicy.
+
+Where this lands:
+  metadata.namespace = `valkey` (NOT this chart's release namespace).
+  Cross-namespace render is fine: a CiliumNetworkPolicy targeting
+  workloads in namespace X must live IN namespace X (where the
+  endpointSelector resolves). Helm renders cross-ns resources without
+  trouble; Flux applies them as a single Kustomization. The
+  `valkey` namespace is created by clusters/_template/bootstrap-kit/
+  17-valkey.yaml AHEAD of bp-catalyst-platform (slot 13), so the
+  namespace is guaranteed present at reconcile time.
+
+Per Inviolable Principle #4 (never hardcode), the source/destination
+namespaces and Valkey port are operator-overridable via
+.Values.smeServices.valkey.{namespace,port,sourceNamespace}.
+
+Authoritative reference:
+  https://docs.cilium.io/en/stable/security/policy/language/#namespace-based
+*/}}
+{{- if and .Values.ingress .Values.ingress.marketplace .Values.ingress.marketplace.enabled -}}
+{{- if .Values.smeServices.valkey.crossNsPolicy.enabled }}
+{{- if .Capabilities.APIVersions.Has "cilium.io/v2" }}
+{{- $valkey := .Values.smeServices.valkey -}}
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: bp-catalyst-platform-sme-valkey-ingress
+  # Lives in the `valkey` namespace where the bp-valkey workload runs —
+  # endpointSelector below targets pods in this namespace. Per-Sovereign
+  # overlays MAY override the namespace if bp-valkey is repackaged into
+  # a different home (rare).
+  namespace: {{ $valkey.namespace | default "valkey" }}
+  labels:
+    catalyst.openova.io/blueprint: bp-catalyst-platform
+    catalyst.openova.io/component: sme-valkey-cross-ns-allow
+    app.kubernetes.io/part-of: sme
+  annotations:
+    description: |
+      Allow ingress on TCP/{{ $valkey.port | default 6379 }} from pods in
+      the `{{ $valkey.crossNsPolicy.sourceNamespace | default "sme" }}`
+      namespace to bp-valkey workloads. Defense-in-depth — bp-valkey's
+      upstream NetworkPolicy already permits port 6379 from any source.
+spec:
+  endpointSelector:
+    matchLabels:
+      # bitnami valkey 5.5.1 labels every Pod (primary + replicas +
+      # headless) with these. We grant ingress to all of them so SME
+      # services that route to any topology (read primary, replicas
+      # via -replicas Service) all work.
+      app.kubernetes.io/name: valkey
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: {{ $valkey.crossNsPolicy.sourceNamespace | default "sme" }}
+      toPorts:
+        - ports:
+            - port: {{ $valkey.port | default 6379 | quote }}
+              protocol: TCP
+{{- end }}
+{{- end }}
+{{- end }}

--- a/products/catalyst/chart/values.yaml
+++ b/products/catalyst/chart/values.yaml
@@ -222,8 +222,14 @@ smePostgres:
     namespace: sme                  # the SME services live here too
     instances: 1                    # single-node by default; HA is a per-overlay decision
     pgVersion: "16"                 # tracks contabo data/postgresql.yaml + ADR-0003
-    database: sme_auth              # primary DB owned by the `sme` user; sme_billing is created via postInitApplicationSQL
+    database: sme_auth              # primary DB owned by the `sme` user; secondary DBs below
     owner: sme                      # role name + secret username
+    # Secondary DBs created via postInitApplicationSQL (1.4.4 — added
+    # sme_documents for FerretDB, see ferretdb.yaml + cnpg-cluster.yaml).
+    # Adding a new SME service is a values-only change.
+    additionalDatabases:
+      - sme_billing                 # billing service primary DB
+      - sme_documents               # FerretDB (MongoDB-wire) backing DB — issue #861
     storageSize: 10Gi
     storageClass: local-path        # k3s default; per-Sovereign overlays may override
     resources:
@@ -282,3 +288,68 @@ smeSecrets:
     # randAlphaNum (32 chars) on first install — never settable from
     # values per Inviolable Principle #10.
     email: "admin@openova.io"
+
+# ─── SME service backing-store endpoints (issue #861) ─────────────────────
+# When ingress.marketplace.enabled=true the chart renders:
+#   - templates/sme-services/ferretdb.yaml — FerretDB Deployment + Service
+#     in `sme` ns, MongoDB-wire-compatible front end backed by sme-pg.
+#   - templates/sme-services/valkey-cross-ns-policy.yaml —
+#     CiliumNetworkPolicy in `valkey` ns allowing ingress from `sme` ns.
+#   - templates/sme-services/configmap.yaml — MONGODB_URI + VALKEY_ADDR
+#     populated from the values below.
+#
+# Per docs/INVIOLABLE-PRINCIPLES.md #4 (never hardcode), every URL,
+# image ref, and resource value is operator-overridable. Defaults match
+# the known-working contabo-mkt shape (FerretDB v1.24 against vanilla
+# CNPG postgres:16; valkey-primary as the bp-valkey 1.0.0 read/write
+# Service name).
+smeServices:
+  ferretdb:
+    namespace: sme
+    # FerretDB v1.24 — works against vanilla CNPG postgres:16. v2.x
+    # requires PostgreSQL with the DocumentDB extension which the
+    # sme-pg cluster does not ship; bumping is a separate change that
+    # also needs a custom CNPG image. See Chart.yaml 1.4.4 changelog.
+    image: ghcr.io/ferretdb/ferretdb
+    tag: "1.24"
+    imagePullPolicy: IfNotPresent
+    replicas: 1
+    # Postgres connection target — sme-pg-rw read/write Service in
+    # `sme` ns, sme_documents DB created by sme-pg's
+    # postInitApplicationSQL block (see smePostgres.cluster.
+    # additionalDatabases above).
+    postgresPort: 5432
+    postgresDatabase: sme_documents
+    sslmode: disable                          # ClusterIP traffic is overlay-encrypted; CNPG default issuer chain not bundled
+    # Service FQDN exposed to other SME services via configmap MONGODB_URI.
+    # Per-Sovereign overlays MAY swap to an external MongoDB endpoint.
+    host: ferretdb.sme.svc.cluster.local
+    port: 27017
+    resources:
+      requests:
+        cpu: 25m
+        memory: 64Mi
+      limits:
+        cpu: 500m
+        memory: 256Mi
+  valkey:
+    # bp-valkey 1.0.0 (slot 17) deploys to namespace `valkey` with
+    # bitnami valkey 5.5.1 + architecture: replication. Service names:
+    #   - valkey-primary.valkey.svc.cluster.local (read/write)
+    #   - valkey-replicas.valkey.svc.cluster.local (read-only)
+    #   - valkey-headless.valkey.svc.cluster.local (StatefulSet headless)
+    # SME services pin to the primary by default so writes succeed; per-
+    # Sovereign overlays MAY split read traffic to -replicas via a
+    # second VALKEY_READ_ADDR (separate ticket).
+    host: valkey-primary.valkey.svc.cluster.local
+    port: 6379
+    namespace: valkey
+    crossNsPolicy:
+      # Render templates/sme-services/valkey-cross-ns-policy.yaml — a
+      # CiliumNetworkPolicy in the `valkey` namespace allowing ingress
+      # from the `sme` namespace on Valkey's port. Default true since
+      # the cross-ns wire is the canonical Sovereign topology. Disable
+      # via per-Sovereign overlay only when bp-valkey is repackaged
+      # into the `sme` namespace (rare).
+      enabled: true
+      sourceNamespace: sme


### PR DESCRIPTION
## Summary
- Chart 1.4.3 → 1.4.4. Unblocks the 4 SME services (catalog, tenant, domain, provisioning) crashlooping on `lookup ferretdb.sme.svc.cluster.local on 10.43.0.10:53: no such host` and wires the valkey-using services (auth, gateway) to the cross-namespace bp-valkey workload.
- **NEW** `templates/sme-services/ferretdb.yaml` — Deployment + Service in `sme` ns, gated on `ingress.marketplace.enabled`. Pinned `ghcr.io/ferretdb/ferretdb:1.24` (matches contabo). Backed by `sme-pg` via env interpolation (`PG_USER`/`PG_PASSWORD` from `sme-pg-app` Secret auto-created in #860).
- **NEW** `templates/sme-services/valkey-cross-ns-policy.yaml` — `CiliumNetworkPolicy` in `valkey` ns allowing ingress on TCP/6379 from `sme` ns. Capabilities-gated on `cilium.io/v2`.
- `cnpg-cluster.yaml` — extend `postInitApplicationSQL` to also create `sme_documents` (FerretDB backing DB). Data-driven via `.Values.smePostgres.cluster.additionalDatabases`.
- `configmap.yaml` — `MONGODB_URI` / `VALKEY_ADDR` / `POSTGRES_HOST` now read chart values with defaults targeting the actual Sovereign topology (`valkey-primary.valkey.svc.cluster.local:6379` — bp-valkey 1.0.0 with `architecture: replication` does NOT create a plain `valkey` Service).
- Slot 13 pin in `clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml` bumps `1.4.3` → `1.4.4`.

## Why FerretDB v1.24 not v2.x
FerretDB v2.x requires PostgreSQL with the DocumentDB extension. The `sme-pg` CNPG cluster from PR #860 uses `ghcr.io/cloudnative-pg/postgresql:16` (vanilla Postgres). v1.24 works against vanilla CNPG postgres and is the proven contabo path. v2 is a separate change requiring custom CNPG image + values toggle.

## Why `valkey-primary` not `valkey`
`helm template` of `bp-valkey:1.0.0` (bitnami valkey 5.5.1, `architecture: replication`) renders three Services: `valkey-headless`, `valkey-primary` (read/write), `valkey-replicas`. There is **no plain `valkey` Service**. The chart value defaults to `valkey-primary` (matches `platform/matrix/chart/values.yaml` precedent); operator-overridable.

## Inviolable principle compliance
- **#4 (never hardcode)**: every URL, image ref, port, sslmode, resources value flows through `.Values.smeServices.*` / `.Values.smePostgres.cluster.additionalDatabases`. Operator-overridable per-Sovereign without forking the chart.
- **#10 (credential hygiene)**: FerretDB DSN uses `$(PG_USER)/$(PG_PASSWORD)` Pod env-var-in-env-var substitution so the plaintext password never appears in the Deployment manifest.

## Test plan
- [x] `helm lint products/catalyst/chart` — clean
- [x] `helm template --set ingress.marketplace.enabled=true --api-versions postgresql.cnpg.io/v1 --api-versions cilium.io/v2` — renders `Deployment+Service ferretdb` in `sme`, `CiliumNetworkPolicy bp-catalyst-platform-sme-valkey-ingress` in `valkey`, `Cluster sme-pg` with `sme_billing` + `sme_documents` post-init SQL, `ConfigMap sme-services-config` with `VALKEY_ADDR=valkey-primary.valkey.svc.cluster.local:6379`
- [x] `helm template` (defaults — `ingress.marketplace.enabled=false`) — none of the marketplace-gated resources render
- [x] `helm template --set ingress.marketplace.enabled=true --set smeServices.valkey.crossNsPolicy.enabled=false` — CNP skipped, FerretDB still renders
- [x] `helm template` without `cilium.io/v2` API version — CNP gracefully skipped (Capabilities check), other resources render
- [x] Full rendered output (58 docs) parses as valid YAML
- [ ] Live on otech103: chart 1.4.4 reconciles, `ferretdb` Deployment Running 1/1, `sme_documents` DB exists, catalog/tenant/domain reach Running 1/1 (no MongoDB DNS errors), CiliumNetworkPolicy applied in valkey ns

## Known follow-up (non-blocking)
bp-valkey ships with `auth.enabled=true` (bitnami default). SME services pass only `VALKEY_ADDR` (no password env). Two remediation paths: (a) per-Sovereign overlay disables bp-valkey auth, or (b) plumb `VALKEY_PASSWORD` through SME service Deployments + service code. Filed separately.

Refs #861.

🤖 Generated with [Claude Code](https://claude.com/claude-code)