### PR TITLE
fix(bp-catalyst-platform): wire VALKEY_PASSWORD into SME auth + gateway (#863)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -81,7 +81,12 @@ spec:
       # services (auth, gateway) that pin to valkey for session/state.
       # cnpg-cluster.yaml extended to bootstrap sme_documents (FerretDB
       # backing DB) alongside sme_billing.
-      version: 1.4.4
+      # 1.4.5 (issue #863): mirror bp-valkey's auto-generated auth
+      # password from `valkey/valkey` Secret into `sme/sme-valkey-auth`
+      # via Helm lookup, and wire VALKEY_PASSWORD into auth + gateway
+      # Deployments. Clears the NOAUTH HELLO crashloop that started
+      # appearing after 1.4.4 made cross-ns Valkey reachable.
+      version: 1.4.5
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/core/services/auth/main.go
+++ b/core/services/auth/main.go
@@ -13,12 +13,18 @@ import (
 	"github.com/openova-io/openova/core/services/shared/events"
 	"github.com/openova-io/openova/core/services/shared/health"
 	"github.com/openova-io/openova/core/services/shared/middleware"
+	"github.com/valkey-io/valkey-go"
 )
 
 func main() {
 	// Configuration from environment.
 	databaseURL := getEnv("DATABASE_URL", "postgres://postgres:postgres@localhost:5432/auth?sslmode=disable")
 	valkeyAddr := getEnv("VALKEY_ADDR", "localhost:6379")
+	// Cross-ns bp-valkey deployments require auth (bitnami default).
+	// Issue #863: empty username + password keep contabo-mkt's auth-less
+	// in-namespace Valkey working unchanged.
+	valkeyUsername := getEnv("VALKEY_USERNAME", "")
+	valkeyPassword := getEnv("VALKEY_PASSWORD", "")
 	redpandaBrokers := strings.Split(getEnv("REDPANDA_BROKERS", "localhost:9092"), ",")
 	jwtSecret := []byte(getEnv("JWT_SECRET", ""))
 	jwtRefreshSecret := []byte(getEnv("JWT_REFRESH_SECRET", ""))
@@ -38,8 +44,16 @@ func main() {
 	defer pgDB.Close()
 	slog.Info("connected to PostgreSQL")
 
-	// Connect to Valkey.
-	valkeyClient, err := db.ConnectValkey(valkeyAddr)
+	// Connect to Valkey. Use the auth-aware constructor when a password
+	// is configured; otherwise fall through to the no-auth path so
+	// existing deployments without `requirepass` keep working.
+	var valkeyClient valkey.Client
+	var err error
+	if valkeyPassword != "" {
+		valkeyClient, err = db.ConnectValkeyWithAuth(valkeyAddr, valkeyUsername, valkeyPassword)
+	} else {
+		valkeyClient, err = db.ConnectValkey(valkeyAddr)
+	}
 	if err != nil {
 		slog.Error("failed to connect to Valkey", "error", err)
 		os.Exit(1)

--- a/core/services/gateway/main.go
+++ b/core/services/gateway/main.go
@@ -9,6 +9,7 @@ import (
 	"github.com/openova-io/openova/core/services/shared/db"
 	"github.com/openova-io/openova/core/services/shared/health"
 	"github.com/openova-io/openova/core/services/shared/middleware"
+	"github.com/valkey-io/valkey-go"
 )
 
 func main() {
@@ -16,6 +17,11 @@ func main() {
 	jwtSecret := getEnv("JWT_SECRET", "dev-secret")
 	corsOrigin := getEnv("CORS_ORIGIN", "*")
 	valkeyAddr := getEnv("VALKEY_ADDR", "valkey:6379")
+	// Cross-ns bp-valkey deployments require auth (bitnami default).
+	// Issue #863: empty username + password keep contabo-mkt's auth-less
+	// in-namespace Valkey working unchanged.
+	valkeyUsername := getEnv("VALKEY_USERNAME", "")
+	valkeyPassword := getEnv("VALKEY_PASSWORD", "")
 	rateLimit := getEnvInt("RATE_LIMIT_RPM", 120)
 	// Trusted proxy CIDRs are consulted when deciding whether to honour
 	// X-Forwarded-For / X-Real-IP headers. Defaults to the k3s pod CIDR so
@@ -65,8 +71,16 @@ func main() {
 		{PathPrefix: "/api/notification/", Upstream: notificationURL, StripPrefix: "/api", Public: false},
 	}
 
-	// Connect to Valkey for rate limiting.
-	valkeyClient, err := db.ConnectValkey(valkeyAddr)
+	// Connect to Valkey for rate limiting. Use the auth-aware constructor
+	// when a password is configured; otherwise fall through to the no-auth
+	// path so existing deployments without `requirepass` keep working.
+	var valkeyClient valkey.Client
+	var err error
+	if valkeyPassword != "" {
+		valkeyClient, err = db.ConnectValkeyWithAuth(valkeyAddr, valkeyUsername, valkeyPassword)
+	} else {
+		valkeyClient, err = db.ConnectValkey(valkeyAddr)
+	}
 	if err != nil {
 		log.Printf("warning: valkey unavailable (%v), rate limiting disabled", err)
 	}

--- a/core/services/shared/db/valkey.go
+++ b/core/services/shared/db/valkey.go
@@ -3,8 +3,41 @@ package db
 import "github.com/valkey-io/valkey-go"
 
 // ConnectValkey creates a Valkey client connected to the given address.
+//
+// Backwards-compatible single-arg form. Callers that need to authenticate
+// against a Valkey deployment with `requirepass` set (e.g. bp-valkey 1.0.0
+// which ships `auth.enabled=true` and auto-generates a random password)
+// should use ConnectValkeyWithAuth.
 func ConnectValkey(addr string) (valkey.Client, error) {
 	return valkey.NewClient(valkey.ClientOption{
 		InitAddress: []string{addr},
+	})
+}
+
+// ConnectValkeyWithAuth creates a Valkey client and authenticates with the
+// given username + password.
+//
+// Why this overload exists (issue #863):
+//
+//	bp-valkey (Catalyst Blueprint slot 17, bitnami valkey 5.5.1) defaults
+//	to `auth.enabled=true` and exposes the auto-generated password via the
+//	`valkey-password` key in the `valkey` Secret. Sovereign-side SME
+//	services consume Valkey cross-namespace from `sme` ns; the catalyst
+//	chart mirrors the password into `sme-valkey-auth` Secret in `sme` ns
+//	(see products/catalyst/chart/templates/sme-services/
+//	valkey-cross-ns-secret.yaml) and the auth + gateway Deployments wire
+//	it into VALKEY_USERNAME / VALKEY_PASSWORD env. Without these, NEWHELLO
+//	is rejected with "NOAUTH HELLO must be called with the client already
+//	authenticated".
+//
+// Username may be empty — bitnami's auth scheme uses the implicit
+// `default` ACL user with the password set via `requirepass`, so passing
+// username="" + password=<from-secret> is the canonical contabo / Sovereign
+// shape today.
+func ConnectValkeyWithAuth(addr, username, password string) (valkey.Client, error) {
+	return valkey.NewClient(valkey.ClientOption{
+		InitAddress: []string{addr},
+		Username:    username,
+		Password:    password,
 	})
 }

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: bp-catalyst-platform
-version: 1.4.4
-appVersion: 1.4.4
+version: 1.4.5
+appVersion: 1.4.5
 description: |
   Catalyst Platform — the unified Catalyst control plane umbrella chart for Catalyst-Zero.
   Composes the catalyst-{ui,api}, console, admin, marketplace UI modules and the marketplace-api backend.
@@ -454,6 +454,63 @@ description: |
 
   Lockstep slot 13 pin in clusters/_template/bootstrap-kit/
   13-bp-catalyst-platform.yaml bumps from 1.4.3 → 1.4.4. 2026-05-04.
+
+  Bumped to 1.4.5 — wire VALKEY_PASSWORD into SME auth + gateway services
+  to clear cross-ns Valkey auth crashloop on franchised Sovereigns
+  (issue #863, 2026-05-04). After 1.4.4 landed FerretDB + the cross-ns
+  CiliumNetworkPolicy, 11/13 SME pods reached Running 1/1 on otech103
+  but `auth` stayed in CrashLoopBackOff and `gateway`'s rate limiter
+  was disabled, both with the same error:
+
+      ERROR failed to connect to Valkey error="NOAUTH HELLO must be
+      called with the client already authenticated, otherwise the
+      HELLO <proto> AUTH <user> <pass> option can be used..."
+
+  Root cause: bp-valkey 1.0.0 (slot 17) ships with `auth.enabled=true`
+  (bitnami valkey 5.5.1 default convention). The bitnami subchart
+  auto-generates a random password and exposes it via the
+  `valkey-password` key in the `valkey` Secret in the `valkey`
+  namespace. SME service code (`core/services/shared/db/valkey.go`)
+  only accepted an addr — no password — and the auth.yaml + gateway.yaml
+  Deployments only set VALKEY_ADDR. Cross-ns AUTH was never plumbed
+  through. Pre-1.4.4 this was masked because VALKEY_ADDR pointed at a
+  non-existent `valkey.sme.svc.cluster.local` and the connect failed
+  at DNS not at AUTH.
+
+  Fix:
+  - core/services/shared/db/valkey.go — add ConnectValkeyWithAuth
+    overload that takes username + password. ConnectValkey kept
+    backwards-compatible for callers that don't pass auth (contabo-mkt
+    auth-less in-namespace Valkey under data/valkey.yaml).
+  - core/services/auth/main.go + core/services/gateway/main.go —
+    read VALKEY_USERNAME + VALKEY_PASSWORD env, call
+    ConnectValkeyWithAuth when password is non-empty, else fall through
+    to the no-auth path. Empty password = current contabo behaviour.
+  - NEW templates/sme-services/valkey-cross-ns-secret.yaml — use Helm
+    `lookup` to read the bp-valkey auto-generated password from
+    `valkey/valkey` Secret and re-emit it as `sme-valkey-auth` in
+    `sme` namespace. Same lookup-and-mirror pattern as
+    sme-secrets.yaml (issue #859) and gitea-admin-secret (issue #830
+    Bug 2). On first install the lookup may return nil — Flux's 15m
+    reconcile picks up the mirror once bp-valkey is Ready.
+  - auth.yaml + gateway.yaml — add VALKEY_PASSWORD env reading from
+    `sme-valkey-auth` Secret with `optional: true` so contabo-mkt's
+    auth-less Valkey path keeps working when the mirror Secret is
+    absent. valkey-go's `default` ACL user uses `requirepass`, so
+    VALKEY_USERNAME stays unset by convention.
+  - values.yaml — add `smeServices.valkey.{sourceSecretName,
+    sourcePasswordKey, destNamespace, destSecretName}` knobs so a
+    forked bp-valkey with non-default Secret naming can override
+    without forking the chart (Inviolable Principle #4).
+
+  No SME smeTag bump needed at chart-source time — the
+  services-build.yaml workflow rebuilds the auth + gateway images
+  from this commit's SHA and updates the `image:` line in auth.yaml +
+  gateway.yaml directly. The chart's blueprint-release pipeline picks
+  up those updated SHAs in its values.yaml on the next chart push.
+
+  Lockstep slot 13 pin in clusters/_template/bootstrap-kit/
+  13-bp-catalyst-platform.yaml bumps from 1.4.4 → 1.4.5. 2026-05-04.
 type: application
 
 # Opt-out from the blueprint-release hollow-chart guard (issue #181 / #510).

--- a/products/catalyst/chart/templates/sme-services/auth.yaml
+++ b/products/catalyst/chart/templates/sme-services/auth.yaml
@@ -56,6 +56,20 @@ spec:
                 configMapKeyRef:
                   name: sme-services-config
                   key: VALKEY_ADDR
+            # bp-valkey ships auth.enabled=true (bitnami default); the
+            # `default` ACL user uses requirepass, so VALKEY_USERNAME stays
+            # empty and VALKEY_PASSWORD reads from the cross-ns mirror
+            # Secret rendered by templates/sme-services/valkey-cross-ns-
+            # secret.yaml. Issue #863. optional=true so contabo-mkt's
+            # auth-less in-namespace Valkey (data/valkey.yaml) works
+            # unchanged — empty VALKEY_PASSWORD triggers the no-auth
+            # connect path in core/services/shared/db/valkey.go.
+            - name: VALKEY_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: sme-valkey-auth
+                  key: valkey-password
+                  optional: true
             - name: REDPANDA_BROKERS
               valueFrom:
                 configMapKeyRef:

--- a/products/catalyst/chart/templates/sme-services/gateway.yaml
+++ b/products/catalyst/chart/templates/sme-services/gateway.yaml
@@ -35,6 +35,20 @@ spec:
                 configMapKeyRef:
                   name: sme-services-config
                   key: VALKEY_ADDR
+            # bp-valkey ships auth.enabled=true (bitnami default); the
+            # `default` ACL user uses requirepass, so VALKEY_USERNAME stays
+            # empty and VALKEY_PASSWORD reads from the cross-ns mirror
+            # Secret rendered by templates/sme-services/valkey-cross-ns-
+            # secret.yaml. Issue #863. optional=true so contabo-mkt's
+            # auth-less in-namespace Valkey (data/valkey.yaml) works
+            # unchanged — empty VALKEY_PASSWORD triggers the no-auth
+            # connect path in core/services/shared/db/valkey.go.
+            - name: VALKEY_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: sme-valkey-auth
+                  key: valkey-password
+                  optional: true
             - name: CORS_ORIGIN
               valueFrom:
                 configMapKeyRef:

--- a/products/catalyst/chart/templates/sme-services/valkey-cross-ns-secret.yaml
+++ b/products/catalyst/chart/templates/sme-services/valkey-cross-ns-secret.yaml
@@ -1,0 +1,84 @@
+{{- /*
+Cross-namespace mirror of bp-valkey's auto-generated auth Secret (issue
+#863).
+
+Why this template exists:
+  bp-valkey 1.0.0 (Catalyst Blueprint slot 17) ships with
+  `auth.enabled=true` (bitnami valkey 5.5.1 default). The bitnami subchart
+  auto-generates a random password on first install and exposes it via
+  the `valkey-password` key in the `valkey` Secret in the `valkey`
+  namespace. SME services (auth + gateway) consume this Valkey
+  cross-namespace from the `sme` namespace; without the password they
+  hit "NOAUTH HELLO must be called with the client already authenticated"
+  on every connect attempt.
+
+  This template uses Helm `lookup` to read the bp-valkey password at
+  reconcile time and re-emit it as a Secret named `sme-valkey-auth` in
+  the `sme` namespace. The auth + gateway Deployments (auth.yaml /
+  gateway.yaml) wire VALKEY_PASSWORD via secretKeyRef.
+
+Why not Reflector annotations on the bp-valkey Secret?
+  Reflector requires the SOURCE Secret to carry mirror annotations.
+  bp-valkey 1.0.0 doesn't expose a values-knob to add annotations to
+  the auto-generated `valkey` Secret (bitnami chart 5.5.1 doesn't
+  support annotation injection on internal-credentials Secrets).
+  Forking the upstream chart to inject annotations would couple this
+  fix to a bp-valkey rebuild + slot 17 lockstep — substantially more
+  blast radius for a one-line problem. The lookup-and-mirror pattern
+  used here is identical to the one already used by sme-secrets.yaml
+  (issue #859) and gitea-admin-secret (issue #830 Bug 2).
+
+First-install ordering:
+  bp-valkey (slot 17) and bp-catalyst-platform (slot 13) install in
+  parallel under Flux. There is NO explicit dependsOn from slot 13 →
+  slot 17 today (Catalyst-platform's umbrella Helm install does not
+  require Valkey to be Ready). On first install the lookup MAY return
+  nil — in that case this template renders no Secret, and a subsequent
+  reconcile (Flux's 15m default) finds the bp-valkey Secret and emits
+  the mirrored copy.
+
+  The two SME services that consume Valkey (auth + gateway) will
+  CrashLoopBackOff until the mirror appears, but Kubernetes' restart
+  backoff handles that gracefully (steady state is ~2-5 minutes after
+  bp-valkey reaches Ready).
+
+Per docs/INVIOLABLE-PRINCIPLES.md #10: NO plaintext credentials in this
+template. The password lives only in the bp-valkey Secret and is read
+back via lookup; the bytes never appear in chart source or rendered
+manifests on disk.
+
+Per #4 (never hardcode): source/destination namespace + Secret names
+flow through .Values.smeServices.valkey.* with sensible defaults.
+*/}}
+{{- if and .Values.ingress .Values.ingress.marketplace .Values.ingress.marketplace.enabled -}}
+{{- $sourceNamespace := .Values.smeServices.valkey.namespace | default "valkey" -}}
+{{- $sourceSecretName := .Values.smeServices.valkey.sourceSecretName | default "valkey" -}}
+{{- $sourcePasswordKey := .Values.smeServices.valkey.sourcePasswordKey | default "valkey-password" -}}
+{{- $destNamespace := .Values.smeServices.valkey.destNamespace | default "sme" -}}
+{{- $destSecretName := .Values.smeServices.valkey.destSecretName | default "sme-valkey-auth" -}}
+{{- $sourceSecret := lookup "v1" "Secret" $sourceNamespace $sourceSecretName -}}
+{{- if and $sourceSecret $sourceSecret.data (index $sourceSecret.data $sourcePasswordKey) -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $destSecretName }}
+  namespace: {{ $destNamespace }}
+  labels:
+    catalyst.openova.io/blueprint: bp-catalyst-platform
+    catalyst.openova.io/component: valkey-cross-ns-mirror
+    app.kubernetes.io/part-of: sme
+  annotations:
+    # Identifies the upstream source for ops visibility — `kubectl describe
+    # secret sme-valkey-auth -n sme` makes the provenance obvious without
+    # tribal knowledge.
+    catalyst.openova.io/mirrored-from: {{ printf "%s/%s" $sourceNamespace $sourceSecretName | quote }}
+    helm.sh/resource-policy: keep
+type: Opaque
+data:
+  # Re-emit the password verbatim. valkey-go's ClientOption.Password
+  # field is the canonical wire — bitnami valkey's `requirepass` uses
+  # the implicit `default` ACL user, so VALKEY_USERNAME is empty by
+  # convention (auth.yaml + gateway.yaml don't set it explicitly).
+  valkey-password: {{ index $sourceSecret.data $sourcePasswordKey | quote }}
+{{- end }}
+{{- end }}

--- a/products/catalyst/chart/values.yaml
+++ b/products/catalyst/chart/values.yaml
@@ -344,6 +344,20 @@ smeServices:
     host: valkey-primary.valkey.svc.cluster.local
     port: 6379
     namespace: valkey
+    # ─── Cross-ns auth Secret mirror (issue #863) ──────────────────────
+    # bp-valkey 1.0.0 ships auth.enabled=true; bitnami auto-generates a
+    # random password and exposes it via the `valkey` Secret in the
+    # `valkey` namespace. The catalyst chart renders templates/
+    # sme-services/valkey-cross-ns-secret.yaml which uses Helm `lookup`
+    # to read that password and re-emit it as `sme-valkey-auth` in
+    # `sme` ns — auth.yaml + gateway.yaml then wire VALKEY_PASSWORD via
+    # secretKeyRef. Each knob below is operator-overridable in case a
+    # Sovereign uses a forked bp-valkey with a different Secret name
+    # or key.
+    sourceSecretName: valkey
+    sourcePasswordKey: valkey-password
+    destNamespace: sme
+    destSecretName: sme-valkey-auth
     crossNsPolicy:
       # Render templates/sme-services/valkey-cross-ns-policy.yaml — a
       # CiliumNetworkPolicy in the `valkey` namespace allowing ingress


### PR DESCRIPTION
## Summary

After #862 (1.4.4) made cross-ns Valkey reachable from `sme` ns, the auth Pod started CrashLoopBackOff with `NOAUTH HELLO must be called with the client already authenticated`. Root cause: bp-valkey 1.0.0 ships `auth.enabled=true` (bitnami default) but SME service code + Deployment templates never plumbed a password through. This PR wires VALKEY_PASSWORD into auth + gateway.

Bumps chart 1.4.4 -> 1.4.5 and slot 13 pin lockstep.

## Changes

- `core/services/shared/db/valkey.go` — add `ConnectValkeyWithAuth(addr, username, password)` overload. `ConnectValkey(addr)` kept backwards-compatible for contabo-mkt's auth-less in-namespace Valkey.
- `core/services/auth/main.go` + `gateway/main.go` — read `VALKEY_USERNAME` + `VALKEY_PASSWORD` env, call the auth-aware constructor when password is non-empty, else fall through to the no-auth path.
- **NEW** `templates/sme-services/valkey-cross-ns-secret.yaml` — Helm `lookup` reads bp-valkey's auto-generated `valkey-password` key from `valkey/valkey` Secret and re-emits it as `sme-valkey-auth` Secret in `sme` ns. Same lookup-and-mirror pattern as `sme-secrets.yaml` (#859) and `gitea-admin-secret` (#830 Bug 2).
- `auth.yaml` + `gateway.yaml` — add `VALKEY_PASSWORD` env from `sme-valkey-auth` Secret with `optional: true` so contabo's auth-less path keeps working when the mirror Secret is absent.
- `values.yaml` — add `smeServices.valkey.{sourceSecretName, sourcePasswordKey, destNamespace, destSecretName}` knobs (Inviolable Principle #4).

## First-install ordering note

bp-valkey (slot 17) and bp-catalyst-platform (slot 13) install in parallel under Flux. There is no explicit dependsOn from slot 13 -> slot 17 today. On first install the `lookup` may return nil — in that case the mirror Secret renders empty and Flux's 15m reconcile picks up the password once bp-valkey is Ready. Auth + gateway CrashLoopBackOff during the gap; Kubernetes' restart backoff handles it (steady state ~2-5 minutes after bp-valkey Ready).

## Test plan

- [x] Live failure reproduced on otech103: 11/13 SME pods Running 1/1, auth in CrashLoopBackOff with NOAUTH HELLO. (provisioning Pod's CreateContainerConfigError is unrelated ghcr-pull, separate ticket.)
- [x] `helm template` renders VALKEY_PASSWORD env on auth + gateway Deployments
- [x] `helm lint` passes
- [x] `go build` clean for shared/db, auth, gateway
- [x] `go vet` clean
- [ ] Post-merge: services-build.yaml workflow rebuilds auth + gateway with new SHA
- [ ] Post-merge: blueprint-release.yaml publishes bp-catalyst-platform 1.4.5
- [ ] Post-merge: Flux reconciles otech103, auth Pod reaches Running 1/1

Closes #863.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

Generated with [Claude Code](https://claude.com/claude-code)