### PR TITLE
fix(bp-catalyst-platform): bump 1.4.5 -> 1.4.6 to bundle rebuilt SME images (#863)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -86,7 +86,12 @@ spec:
       # via Helm lookup, and wire VALKEY_PASSWORD into auth + gateway
       # Deployments. Clears the NOAUTH HELLO crashloop that started
       # appearing after 1.4.4 made cross-ns Valkey reachable.
-      version: 1.4.5
+      # 1.4.6 (issue #863 follow-up): rebuild chart artifact to bundle
+      # the rebuilt services-auth + services-gateway image (SHA fa4395f)
+      # that contains the ConnectValkeyWithAuth Go change. 1.4.5 shipped
+      # with the OLD image SHA baked in due to a race between the
+      # blueprint-release pipeline and the services-build deploy step.
+      version: 1.4.6
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: bp-catalyst-platform
-version: 1.4.5
-appVersion: 1.4.5
+version: 1.4.6
+appVersion: 1.4.6
 description: |
   Catalyst Platform — the unified Catalyst control plane umbrella chart for Catalyst-Zero.
   Composes the catalyst-{ui,api}, console, admin, marketplace UI modules and the marketplace-api backend.
@@ -511,6 +511,26 @@ description: |
 
   Lockstep slot 13 pin in clusters/_template/bootstrap-kit/
   13-bp-catalyst-platform.yaml bumps from 1.4.4 → 1.4.5. 2026-05-04.
+
+  Bumped to 1.4.6 — bundle the rebuilt services-auth + services-gateway
+  image SHA fa4395f from PR #864 into the chart artifact (issue #863
+  follow-up, 2026-05-05). 1.4.5 was published at commit fa4395fa BEFORE
+  the deploy job updated auth.yaml's hardcoded `image:` to fa4395f, so
+  Sovereigns pulling 1.4.5 got the OLD image (5cdb738) without the
+  ConnectValkeyWithAuth Go change — VALKEY_PASSWORD env was wired but
+  the binary ignored it and still hit "NOAUTH HELLO" on connect.
+
+  Same race documented in the 1.1.16 changelog above (catalyst-ui
+  base:/ fix). 1.4.6 republishes the chart with the deploy-committed
+  image SHAs already in tree (auth.yaml + gateway.yaml `image:` lines
+  point at fa4395f as of commit 9731701c).
+
+  No template/code changes — pure version bump to roll a fresh OCI
+  artifact whose `helm template` output references the
+  ConnectValkeyWithAuth-enabled image.
+
+  Lockstep slot 13 pin in clusters/_template/bootstrap-kit/
+  13-bp-catalyst-platform.yaml bumps from 1.4.5 → 1.4.6. 2026-05-05.
 type: application
 
 # Opt-out from the blueprint-release hollow-chart guard (issue #181 / #510).


### PR DESCRIPTION
## Summary

Chart 1.4.5 (PR #864) was published at commit fa4395fa BEFORE the services-build deploy step committed 9731701c updating `auth.yaml` + `gateway.yaml` hardcoded `image:` lines from `5cdb738` -> `fa4395f`. Result: Sovereigns pulling 1.4.5 get the OLD image without the `ConnectValkeyWithAuth` Go change — VALKEY_PASSWORD env is wired but the binary ignores it and still fails with NOAUTH HELLO.

Same race already documented in the 1.1.16 changelog (catalyst-ui base:/ fix).

## Verification on otech103

After 1.4.5 rolled out:
- `sme-valkey-auth` Secret created (cross-ns mirror works)
- gateway Pod Running 1/1 (probably tolerated empty rate-limit Valkey, no AUTH attempted)
- auth Pod still CrashLoopBackOff; `kubectl get pod ... -o jsonpath='{.spec.containers[0].image}'` returns `services-auth:5cdb738` — the old image

## Changes

- `Chart.yaml`: 1.4.5 -> 1.4.6 + changelog entry
- `clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml`: slot 13 pin 1.4.5 -> 1.4.6

No template or code changes — pure version bump to roll a fresh OCI artifact whose chart sources include the deploy-committed image SHAs.

## Test plan

- [x] CI passes (manifest-validation gitea version mismatch is pre-existing on main)
- [ ] Post-merge: blueprint-release.yaml publishes bp-catalyst-platform 1.4.6 with auth.yaml `image: ...:fa4395f` baked in
- [ ] Post-merge: Flux on otech103 picks up 1.4.6, rolls auth Pod with new image
- [ ] auth Pod reaches Running 1/1

Closes #863.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

Generated with [Claude Code](https://claude.com/claude-code)