### PR TITLE
fix(sme-marketplace): unblock PIN signin — gateway backendRef + send-pin alias (#868)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -96,7 +96,15 @@ spec:
       # (provisioning) reaches Running 1/1 on a fresh Sovereign,
       # completing the SME stack 12/13 → 13/13. Same lookup-and-mirror
       # pattern as valkey-cross-ns-secret.yaml (#863).
-      version: 1.4.7
+      # 1.4.8 (issue #868): fix marketplace UI PIN-signin — /api/*
+      # HTTPRoute now backendRefs sme/gateway:8080 (cross-namespace,
+      # authorised by ReferenceGrant). The previous catalyst-system/
+      # marketplace-api Service had zero backing Pods, so every signin
+      # POST 503'd at the gateway. Pairs with services-auth route alias
+      # /auth/send-pin → SendMagicLink (and /auth/verify-pin →
+      # VerifyMagicLink) so the UI's PIN-naming reaches the existing
+      # backend handler.
+      version: 1.4.8
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/core/services/auth/handlers/routes.go
+++ b/core/services/auth/handlers/routes.go
@@ -7,7 +7,16 @@ func (h *Handler) Routes() http.Handler {
 	mux := http.NewServeMux()
 	mux.HandleFunc("POST /auth/login", h.Login)
 	mux.HandleFunc("POST /auth/magic-link", h.SendMagicLink)
+	// /auth/send-pin is the canonical UX-facing alias for the same flow:
+	// the marketplace UI surfaces a 6-digit PIN ("Send PIN" button), so the
+	// route name "send-pin" is more honest than "magic-link". Both paths
+	// share the SendMagicLink handler — see issue #868. Likewise the
+	// verifier is exposed under both /auth/verify (legacy) and
+	// /auth/verify-pin (alias) so the UI can converge on the PIN naming
+	// without forcing a backend rename.
+	mux.HandleFunc("POST /auth/send-pin", h.SendMagicLink)
 	mux.HandleFunc("POST /auth/verify", h.VerifyMagicLink)
+	mux.HandleFunc("POST /auth/verify-pin", h.VerifyMagicLink)
 	mux.HandleFunc("POST /auth/refresh", h.RefreshToken)
 	mux.HandleFunc("GET /auth/google", h.GoogleLogin)
 	mux.HandleFunc("POST /auth/google/callback", h.GoogleCallback)

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: bp-catalyst-platform
-version: 1.4.7
-appVersion: 1.4.7
+version: 1.4.8
+appVersion: 1.4.8
 description: |
   Catalyst Platform — the unified Catalyst control plane umbrella chart for Catalyst-Zero.
   Composes the catalyst-{ui,api}, console, admin, marketplace UI modules and the marketplace-api backend.
@@ -576,6 +576,20 @@ description: |
 
   Lockstep slot 13 pin in clusters/_template/bootstrap-kit/
   13-bp-catalyst-platform.yaml bumps from 1.4.6 → 1.4.7. 2026-05-04.
+
+  1.4.8 (issue #868): fix the marketplace UI PIN-signin flow that 503'd
+  on otech103 because the public /api/* HTTPRoute backend-ref'd a dead
+  Service (catalyst-system/marketplace-api with zero matching Pods).
+  Two template fixes:
+    - templates/sme-services/marketplace-routes.yaml: /api/* rule now
+      cross-namespace backendRef sme/gateway:8080 (the SME BSS gateway
+      Pod that already fronts services-auth, catalog, tenant, billing,
+      provisioning).
+    - templates/sme-services/marketplace-reference-grant.yaml: extend
+      `to:` list with the gateway Service so the cross-ns hop is
+      authorised by Gateway API.
+  Lockstep slot 13 pin in clusters/_template/bootstrap-kit/
+  13-bp-catalyst-platform.yaml bumps from 1.4.7 → 1.4.8. 2026-05-04.
 type: application
 
 # Opt-out from the blueprint-release hollow-chart guard (issue #181 / #510).

--- a/products/catalyst/chart/templates/sme-services/marketplace-reference-grant.yaml
+++ b/products/catalyst/chart/templates/sme-services/marketplace-reference-grant.yaml
@@ -36,4 +36,12 @@ spec:
     - group: ""
       kind: Service
       name: console
+    # Issue #868: marketplace HTTPRoute /api/* now cross-namespace
+    # backendRefs to sme/gateway:8080 (replacing the dead
+    # catalyst-system/marketplace-api Service). The gateway Pod fronts
+    # services-auth (PIN signin), services-catalog, services-tenant,
+    # services-billing, services-provisioning — the entire SME BSS API.
+    - group: ""
+      kind: Service
+      name: gateway
 {{- end }}

--- a/products/catalyst/chart/templates/sme-services/marketplace-routes.yaml
+++ b/products/catalyst/chart/templates/sme-services/marketplace-routes.yaml
@@ -57,9 +57,19 @@ spec:
         - path:
             type: PathPrefix
             value: "/api/"
+      # /api/* is the SME BSS REST surface (auth, catalog, tenant, billing,
+      # provisioning) served by the gateway Pod in the sme namespace, NOT
+      # the catalyst-system marketplace-api Service. Live debugging on
+      # otech103 (issue #868) showed catalyst-system/marketplace-api had
+      # zero backing Pods (selector matched nothing), so PIN-signin POSTs
+      # 503'd at the gateway before ever reaching the auth service. The
+      # gateway in sme already proxies /auth/* to services-auth, so we
+      # cross-namespace backendRef directly. ReferenceGrant
+      # marketplace-routes-to-sme (in sme ns) authorises this hop.
       backendRefs:
-        - name: marketplace-api
-          port: 80
+        - name: gateway
+          namespace: sme
+          port: 8080
     - matches:
         - path:
             type: PathPrefix


### PR DESCRIPTION
## Summary
Two-part fix for the marketplace UI PIN signin flow that 503'd then 404'd on otech103.

- **Chart** (`bp-catalyst-platform` 1.4.7 → 1.4.8 + lockstep slot 13 pin):
  - `marketplace-routes.yaml`: `/api/*` rule now cross-namespace backendRefs `sme/gateway:8080` (replaces dead `catalyst-system/marketplace-api` Service with zero matching Pods)
  - `marketplace-reference-grant.yaml`: extend `to:` list with the `gateway` Service to authorise the cross-ns hop
- **services-auth** (`core/services/auth/handlers/routes.go`):
  - Add `POST /auth/send-pin` → `SendMagicLink` and `POST /auth/verify-pin` → `VerifyMagicLink` aliases. The UI surfaces "Send PIN" — PIN naming is the canonical UX. `/auth/magic-link` + `/auth/verify` remain registered for backward compat.

## Test plan
- [ ] services-build workflow auto-rebuilds services-auth image on `core/services/**` push (event-driven)
- [ ] blueprint-release workflow auto-rebuilds bp-catalyst-platform 1.4.8 on `products/*/chart/**` push
- [ ] Live verification on otech103: `curl -X POST -d '{"email":"sales@openova.io"}' https://marketplace.otech103.omani.works/api/auth/send-pin` returns 200
- [ ] Marketplace UI signup flow walked end-to-end in browser

Closes #868

🤖 Generated with [Claude Code](https://claude.com/claude-code)