### PR TITLE
fix(bp-catalyst-platform): bump 1.4.8 -> 1.4.9 to republish with current services-auth image (#871)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -104,7 +104,7 @@ spec:
       # /auth/send-pin → SendMagicLink (and /auth/verify-pin →
       # VerifyMagicLink) so the UI's PIN-naming reaches the existing
       # backend handler.
-      version: 1.4.8
+      version: 1.4.9
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: bp-catalyst-platform
-version: 1.4.8
-appVersion: 1.4.8
+version: 1.4.9
+appVersion: 1.4.9
 description: |
   Catalyst Platform — the unified Catalyst control plane umbrella chart for Catalyst-Zero.
   Composes the catalyst-{ui,api}, console, admin, marketplace UI modules and the marketplace-api backend.
@@ -590,6 +590,18 @@ description: |
       authorised by Gateway API.
   Lockstep slot 13 pin in clusters/_template/bootstrap-kit/
   13-bp-catalyst-platform.yaml bumps from 1.4.7 → 1.4.8. 2026-05-04.
+
+  1.4.9 (issue #871): no template change — chart-version-only bump to
+  republish the OCI artifact with the current services-auth image SHA
+  baked into templates/sme-services/auth.yaml. 1.4.8 was published from
+  commit 95a06f56 BEFORE the deploy-bot updated auth.yaml's image pin
+  from `services-auth:fa4395f` (old) → `services-auth:95a06f5` (new,
+  with the /auth/send-pin alias), so 1.4.8 OCI bytes still reference
+  the OLD SHA and otech103 reconciled the broken image. Bumping the
+  chart version forces blueprint-release to publish a fresh artifact
+  with the current pin. Same race documented in
+  feedback_idempotent_iac_purge.md and overnight DoD doc as
+  "deploy-step race". Lockstep slot 13 pin bumps to 1.4.9. 2026-05-05.
 type: application
 
 # Opt-out from the blueprint-release hollow-chart guard (issue #181 / #510).


### PR DESCRIPTION
## Summary

Chart 1.4.8 was published from commit `95a06f56` BEFORE the deploy-bot updated `templates/sme-services/auth.yaml`'s image pin from `services-auth:fa4395f` (old) → `services-auth:95a06f5` (new, with the `/auth/send-pin` alias from PR #869). The `blueprint-release` workflow fired on `95a06f56` only, so the OCI artifact for `1.4.8` was published with the OLD image SHA baked into chart bytes.

otech103 reconciled `1.4.8` and rendered the auth Deployment with the OLD image, so `/auth/send-pin` returns 404 — SME marketplace signup blocked.

Same deploy-step race documented in `feedback_idempotent_iac_purge.md` and the overnight DoD bookmark.

## Changes
- `products/catalyst/chart/Chart.yaml`: 1.4.8 → 1.4.9 + changelog
- `clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml`: slot pin 1.4.8 → 1.4.9

No template change. The chart-version bump alone forces `blueprint-release` to republish the artifact with the current image pin in `auth.yaml`.

## Test plan
- [ ] `blueprint-release` workflow rebuilds bp-catalyst-platform 1.4.9 (event-driven on chart change)
- [ ] otech103 reconciles 1.4.9 → auth Deployment image == `services-auth:95a06f5`
- [ ] `curl -X POST -d '{"email":"sales@openova.io"}' https://marketplace.otech103.omani.works/api/auth/send-pin` returns 200 (NOT 404)
- [ ] Marketplace UI signup walks end-to-end

Closes #871. Unblocks #795 / #805.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>