### PR TITLE
fix(ci): services-build auto-bumps chart patch + dispatches blueprint-release

### DIFF
--- a/.github/workflows/services-build.yaml
+++ b/.github/workflows/services-build.yaml
@@ -53,15 +53,46 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     permissions:
+      # contents: write — push the SHA + Chart.yaml patch bump back to main.
       contents: write
+      # actions: write — required for `gh workflow run` to dispatch
+      # blueprint-release.yaml after the deploy commit lands. Without
+      # this, the dispatch step returns HTTP 403 "Resource not
+      # accessible by integration" and blueprint-release never fires
+      # for deploy commits (issues #872, #712 — same root cause as the
+      # catalyst-build dispatch fix in PR #720).
+      actions: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Update deployment manifests with new SHA tags
+      # ──────────────────────────────────────────────────────────────
+      # Helper: bump the Chart.yaml patch version atomically with the
+      # SHA-tag rewrite so blueprint-release publishes a single coherent
+      # chart that bundles the freshly committed image refs.
+      #
+      # Why this exists (issue #872): without the bump, the merge commit
+      # for a chart-version-bumping PR triggers blueprint-release IN
+      # PARALLEL with services-build. blueprint-release packages the
+      # working tree at the merge SHA — which still has the OLD image
+      # SHA in templates/sme-services/*.yaml because services-build has
+      # not yet committed its deploy update. The chart at that version
+      # ships with stale images, and a manual no-op chart bump PR is
+      # the only way to republish (PR #865 chasing PR #864 was the live
+      # incident).
+      #
+      # By having the deploy step bump the patch version itself, the
+      # dispatched blueprint-release publishes a NEW chart version that
+      # — by construction — was packaged AFTER the SHA rewrite. No race.
+      # The manual chart-version field in the PR becomes the floor; the
+      # CI auto-bumps from there.
+      # ──────────────────────────────────────────────────────────────
+      - name: Update deployment manifests + bump chart patch version
+        id: rewrite
         run: |
           SHA=$(echo $GITHUB_SHA | head -c 7)
           DEPLOY_DIR="products/catalyst/chart/templates/sme-services"
+          CHART_YAML="products/catalyst/chart/Chart.yaml"
 
           for svc in auth catalog gateway tenant domain billing provisioning notification; do
             FILE="${DEPLOY_DIR}/${svc}.yaml"
@@ -71,44 +102,105 @@ jobs:
             fi
           done
 
+          # Patch-bump Chart.yaml `version:` and `appVersion:` (kept in
+          # lockstep — the chart reflects the bundled appVersion via
+          # convention). Pure-bash semver patch increment to avoid
+          # depending on yq in this job.
+          current=$(awk '/^version:/{print $2; exit}' "${CHART_YAML}" | tr -d '"')
+          if ! echo "$current" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error title=Unparseable chart version::Chart.yaml version='${current}' is not semver MAJOR.MINOR.PATCH; refusing to auto-bump."
+            exit 1
+          fi
+          major=$(echo "$current" | cut -d. -f1)
+          minor=$(echo "$current" | cut -d. -f2)
+          patch=$(echo "$current" | cut -d. -f3)
+          next="${major}.${minor}.$((patch + 1))"
+          sed -i "s|^version: .*$|version: ${next}|" "${CHART_YAML}"
+          sed -i "s|^appVersion: .*$|appVersion: ${next}|" "${CHART_YAML}"
+          echo "Bumped Chart.yaml ${current} -> ${next}"
+          echo "next_version=${next}" >> "$GITHUB_OUTPUT"
+
       - name: Commit and push manifest updates
+        id: deploy_commit
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           SHA=$(echo $GITHUB_SHA | head -c 7)
           DEPLOY_DIR="products/catalyst/chart/templates/sme-services"
+          CHART_YAML="products/catalyst/chart/Chart.yaml"
 
-          # Re-applies the sed substitution against whatever state main is
-          # currently in. Needed because parallel/back-to-back CI runs both
-          # try to update the same image: lines — a plain `git pull --rebase`
-          # hits content conflicts since every SHA bump touches exactly the
-          # same lines a previous run just wrote. Idempotent reset-and-resed
-          # is conflict-free by construction.
-          apply_sed() {
+          # Idempotent reset-and-rewrite. Parallel/back-to-back CI runs
+          # both try to update the same `image:` lines AND the same
+          # version line — `git pull --rebase` would hit content
+          # conflicts. Idempotent reset-to-origin + re-apply is
+          # conflict-free by construction. On retry we re-read whatever
+          # version origin/main currently holds and bump from THAT, so
+          # two concurrent runs produce strictly increasing patch
+          # versions instead of clobbering each other.
+          rewrite() {
             for svc in auth catalog gateway tenant domain billing provisioning notification; do
               FILE="${DEPLOY_DIR}/${svc}.yaml"
               if [ -f "$FILE" ]; then
                 sed -i "s|image: ${IMAGE_BASE}-${svc}:.*|image: ${IMAGE_BASE}-${svc}:${SHA}|" "$FILE"
               fi
             done
+            current=$(awk '/^version:/{print $2; exit}' "${CHART_YAML}" | tr -d '"')
+            if ! echo "$current" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+              echo "::error title=Unparseable chart version on retry::Chart.yaml version='${current}' is not semver."
+              exit 1
+            fi
+            major=$(echo "$current" | cut -d. -f1)
+            minor=$(echo "$current" | cut -d. -f2)
+            patch=$(echo "$current" | cut -d. -f3)
+            next="${major}.${minor}.$((patch + 1))"
+            sed -i "s|^version: .*$|version: ${next}|" "${CHART_YAML}"
+            sed -i "s|^appVersion: .*$|appVersion: ${next}|" "${CHART_YAML}"
+            echo "${next}"
           }
 
           git add products/
-          git diff --staged --quiet && echo "No changes to commit" && exit 0
-          git commit -m "deploy: update sme service images to ${SHA}"
+          if git diff --staged --quiet; then
+            echo "No changes to commit"
+            echo "pushed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          NEXT="${{ steps.rewrite.outputs.next_version }}"
+          git commit -m "deploy: update sme service images to ${SHA} + bump chart to ${NEXT}"
 
           for i in 1 2 3; do
-            if git push; then exit 0; fi
-            echo "push attempt $i failed — resetting to origin/main and re-applying sed"
+            if git push; then
+              echo "pushed=true" >> "$GITHUB_OUTPUT"
+              echo "next_version=${NEXT}" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            echo "push attempt $i failed — resetting to origin/main and re-applying rewrite"
             git fetch origin main
             git reset --hard origin/main
-            apply_sed
+            NEXT=$(rewrite)
             git add products/
             if git diff --staged --quiet; then
               echo "no changes after re-fetch — another run already shipped this SHA"
+              echo "pushed=false" >> "$GITHUB_OUTPUT"
               exit 0
             fi
-            git commit -m "deploy: update sme service images to ${SHA}"
+            git commit -m "deploy: update sme service images to ${SHA} + bump chart to ${NEXT}"
           done
           echo "push failed after 3 attempts"
           exit 1
+
+      # GITHUB_TOKEN-authored pushes do NOT re-trigger workflows by
+      # design, so a `push` path-trigger on blueprint-release.yaml is
+      # not enough on its own — we must explicitly dispatch. Same
+      # mechanism catalyst-build.yaml uses (PR #720) to publish the
+      # bp-catalyst-platform OCI artifact for the bumped chart.
+      - name: Trigger blueprint-release for the chart bump
+        if: steps.deploy_commit.outputs.pushed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh workflow run blueprint-release.yaml \
+            --repo "${{ github.repository }}" \
+            --ref main \
+            -f blueprint=catalyst \
+            -f tree=products
+          echo "blueprint-release dispatched for products/catalyst @ main (chart ${{ steps.deploy_commit.outputs.next_version }})"

--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -104,7 +104,7 @@ spec:
       # /auth/send-pin → SendMagicLink (and /auth/verify-pin →
       # VerifyMagicLink) so the UI's PIN-naming reaches the existing
       # backend handler.
-      version: 1.4.8
+      version: 1.4.9
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: bp-catalyst-platform
-version: 1.4.8
-appVersion: 1.4.8
+version: 1.4.9
+appVersion: 1.4.9
 description: |
   Catalyst Platform — the unified Catalyst control plane umbrella chart for Catalyst-Zero.
   Composes the catalyst-{ui,api}, console, admin, marketplace UI modules and the marketplace-api backend.
@@ -590,6 +590,18 @@ description: |
       authorised by Gateway API.
   Lockstep slot 13 pin in clusters/_template/bootstrap-kit/
   13-bp-catalyst-platform.yaml bumps from 1.4.7 → 1.4.8. 2026-05-04.
+
+  1.4.9 (issue #871): no template change — chart-version-only bump to
+  republish the OCI artifact with the current services-auth image SHA
+  baked into templates/sme-services/auth.yaml. 1.4.8 was published from
+  commit 95a06f56 BEFORE the deploy-bot updated auth.yaml's image pin
+  from `services-auth:fa4395f` (old) → `services-auth:95a06f5` (new,
+  with the /auth/send-pin alias), so 1.4.8 OCI bytes still reference
+  the OLD SHA and otech103 reconciled the broken image. Bumping the
+  chart version forces blueprint-release to publish a fresh artifact
+  with the current pin. Same race documented in
+  feedback_idempotent_iac_purge.md and overnight DoD doc as
+  "deploy-step race". Lockstep slot 13 pin bumps to 1.4.9. 2026-05-05.
 type: application
 
 # Opt-out from the blueprint-release hollow-chart guard (issue #181 / #510).


### PR DESCRIPTION
## Summary
- Eliminate the recurring race between services-build's deploy commit and blueprint-release's path-trigger on chart-version-bumping PRs
- services-build's deploy step now patch-bumps `products/catalyst/chart/Chart.yaml` `version`/`appVersion` atomically with the `image:` SHA rewrite, then explicitly dispatches blueprint-release via `gh workflow run` (matching catalyst-build's PR #720 pattern)
- No more manual no-op chart bump PRs to republish with corrected image refs

## Why
Hit twice in days: PR #864 (chart 1.4.5) merged → services-build rebuilt SME auth with `VALKEY_PASSWORD` env, blueprint-release published 1.4.5 with the OLD auth image because it packaged the merge commit BEFORE services-build's deploy commit landed. Required manual PR #865 (chart 1.4.6) to bundle the rebuilt image. Same chain repeated tonight on PRs #864 / #865.

Root cause: blueprint-release fires on the merge commit's chart-version bump in parallel with services-build. Per GitHub Actions design, services-build's `GITHUB_TOKEN`-authored deploy commit does NOT re-trigger workflows, so blueprint-release never fires a second time on the corrected chart.

Fix: services-build's deploy step bumps the chart patch version atomically with the image SHA rewrite. The dispatched blueprint-release publishes a NEW chart version that — by construction — was packaged AFTER the rewrite. No race.

## Author guidance
PR authors no longer need to bump the chart patch when their PR also touches `core/services/**` — CI does it. Major/minor bumps remain the author's call (those bumps express semantic intent, not just "rebuild SME images"). The manual chart-version field becomes a floor; CI auto-bumps from there.

## Test plan
- [ ] PR merges, services-build deploy job runs on next `core/services/**` commit
- [ ] Verify deploy commit message reads "deploy: update sme service images to <sha> + bump chart to <next>"
- [ ] Verify blueprint-release fires after the deploy commit (workflow_dispatch event, not push)
- [ ] Verify ghcr.io/openova-io/bp-catalyst-platform:<bumped-version> published with the freshly committed image SHAs in templates/sme-services/*.yaml
- [ ] Confirm the next chart-touching code change produces a single coherent release with NO follow-up no-op bump needed

## Related
- Fixes #872
- Live incident: PR #864 (chart 1.4.5) → manual PR #865 (chart 1.4.6) chase
- Precedent: PR #720 / catalyst-build.yaml — same dispatch pattern for catalyst UI/API images

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>