### PR TITLE
fix(bp-self-sovereign-cutover): auto-sync local Gitea mirror from upstream GitHub (#870)

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -127,7 +127,13 @@ spec:
       # verdict — sovereignty asks "did cutover break anything", not
       # "is the cluster perfect". Caught live otech103 — infrastructure
       # -config Kustomization had been NotReady for 4h pre-cutover.
-      version: 0.1.13
+      # 0.1.14: Step-1 gitea-mirror replaces one-shot create+push with
+      # Gitea native /repos/migrate `mirror=true` + mirror_interval=10m
+      # so the local Gitea polls upstream GitHub on a recurring 10-min
+      # interval. Closes the "Sovereign drifts from upstream main
+      # forever after Day-2 cutover" bug — hit twice on otech103
+      # 2026-05-04 requiring manual `git fetch` per chart rollout. (#870)
+      version: 0.1.14
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
 spec:
-  version: 0.1.0
+  version: 0.1.14
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-self-sovereign-cutover
-version: 0.1.13
+version: 0.1.14
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/templates/01-gitea-mirror-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/01-gitea-mirror-job.yaml
@@ -49,6 +49,8 @@ data:
             value: {{ .Values.gitea.org | quote }}
           - name: GITEA_REPO
             value: {{ .Values.gitea.repo | quote }}
+          - name: MIRROR_INTERVAL
+            value: {{ .Values.upstream.mirrorInterval | quote }}
           - name: GITEA_USERNAME
             valueFrom:
               secretKeyRef:
@@ -72,6 +74,7 @@ data:
             redacted_url="${GITEA_INTERNAL_URL}/${GITEA_ORG}/${GITEA_REPO}.git"
             echo "[gitea-mirror] upstream=${UPSTREAM_REPO_URL} branch=${UPSTREAM_BRANCH}"
             echo "[gitea-mirror] target=${redacted_url}"
+            echo "[gitea-mirror] mirror_interval=${MIRROR_INTERVAL}"
 
             # Build BusyBox-wget-compatible Basic auth header. printf -n
             # avoids the trailing newline that would otherwise corrupt
@@ -97,45 +100,112 @@ data:
               echo "[gitea-mirror] org already present"
             fi
 
-            # 2. Ensure the repo exists under the org (idempotent).
-            #    Gitea returns 201 on create / 409 on exists — both OK.
+            # 2. Check whether the local repo already exists. Two cases:
+            #    - exists  → ensure mirror_interval is set + trigger sync
+            #    - missing → create via /repos/migrate with mirror=true
+            #                so Gitea owns the recurring upstream sync
+            #                going forward (10m default; tunable via
+            #                .Values.upstream.mirrorInterval).
+            #
+            #    Why migrate (mirror=true) over the legacy create+push:
+            #    Gitea's native pull-mirror polls upstream on the
+            #    configured interval and replicates branches+tags. The
+            #    previous one-shot push left local Gitea drifting from
+            #    upstream main indefinitely after Day-2 cutover, requiring
+            #    operator-driven `git fetch` for every chart rollout
+            #    (hit twice on otech103 2026-05-04). Mirror mode makes
+            #    drift impossible. Per Gitea migrate API, we explicitly
+            #    opt out of issues/pull-requests/wiki — the Sovereign
+            #    only needs branches+tags for Flux GitRepository.
             repo_check=$(wget -q -O - \
               --header="Authorization: Basic ${basic_auth}" \
               --header="Content-Type: application/json" \
               "${api_url}/repos/${GITEA_ORG}/${GITEA_REPO}" 2>/dev/null || echo "missing")
+
             if [ "${repo_check}" = "missing" ]; then
-              echo "[gitea-mirror] creating ${GITEA_ORG}/${GITEA_REPO}"
-              wget -q -O /dev/null --post-data="{\"name\":\"${GITEA_REPO}\",\"private\":false,\"auto_init\":false}" \
+              echo "[gitea-mirror] creating mirror ${GITEA_ORG}/${GITEA_REPO} via /repos/migrate"
+              # POST /api/v1/repos/migrate — single-shot create-as-mirror.
+              # service=git is the generic git source (works for github
+              # without forcing the github-specific importer, which would
+              # require a GitHub PAT we don't have).
+              #
+              # Build payload via printf rather than a heredoc — the YAML
+              # block-scalar wrapper indents every shell line, and POSIX
+              # `<<MARKER` heredocs require the closing MARKER token to
+              # appear unindented in column 0 (only `<<-MARKER` strips
+              # leading tabs, not spaces). Using printf side-steps that
+              # whole class of shell-quoting bugs and keeps the JSON on a
+              # single line, which is also easier on stdout when set -x
+              # debugging is on.
+              migrate_payload=$(printf '{"clone_addr":"%s","repo_name":"%s","repo_owner":"%s","service":"git","mirror":true,"mirror_interval":"%s","private":false,"wiki":false,"issues":false,"pull_requests":false,"labels":false,"milestones":false,"releases":false,"description":"Pull-mirror of %s (auto-sync every %s)"}' \
+                "${UPSTREAM_REPO_URL}" "${GITEA_REPO}" "${GITEA_ORG}" "${MIRROR_INTERVAL}" "${UPSTREAM_REPO_URL}" "${MIRROR_INTERVAL}")
+              # Capture status code so we can fail loud if migrate refuses.
+              # wget -S writes status to stderr; grep for "HTTP/1.1 2".
+              migrate_log=$(mktemp)
+              wget -q -O "${migrate_log}" -S \
+                --post-data="${migrate_payload}" \
                 --header="Authorization: Basic ${basic_auth}" \
                 --header="Content-Type: application/json" \
-                "${api_url}/orgs/${GITEA_ORG}/repos" 2>/dev/null || true
+                "${api_url}/repos/migrate" 2>&1 || true
+              if ! wget -q -O - \
+                --header="Authorization: Basic ${basic_auth}" \
+                --header="Content-Type: application/json" \
+                "${api_url}/repos/${GITEA_ORG}/${GITEA_REPO}" >/dev/null 2>&1; then
+                echo "[gitea-mirror] FATAL: migrate failed — repo not visible after POST" >&2
+                cat "${migrate_log}" >&2 || true
+                exit 1
+              fi
+              echo "[gitea-mirror] migrate complete — repo now mirroring from upstream"
             else
-              echo "[gitea-mirror] repo already present"
+              # Repo already present (re-run / prior cutover attempt).
+              # PATCH the mirror_interval to the desired value. Note:
+              # PATCH only succeeds in setting interval if the repo was
+              # already created with mirror=true. Older Sovereigns seeded
+              # by chart < 0.1.14 (legacy create+push) lack the mirror
+              # bit and PATCH alone won't convert them — operator action
+              # to delete+re-migrate would be required. New provisions
+              # always go through the migrate path above and are fine.
+              echo "[gitea-mirror] repo already present — patching mirror_interval=${MIRROR_INTERVAL}"
+              patch_payload="{\"mirror_interval\":\"${MIRROR_INTERVAL}\"}"
+              # BusyBox wget supports --method via newer alpine builds,
+              # but to stay portable across alpine/git image variants we
+              # fall back to a raw-style PATCH using the X-HTTP-Method-
+              # Override header which Gitea's middleware honours.
+              wget -q -O /dev/null \
+                --post-data="${patch_payload}" \
+                --header="Authorization: Basic ${basic_auth}" \
+                --header="Content-Type: application/json" \
+                --header="X-HTTP-Method-Override: PATCH" \
+                "${api_url}/repos/${GITEA_ORG}/${GITEA_REPO}" 2>/dev/null || \
+                echo "[gitea-mirror] note: mirror_interval PATCH failed — repo may be a legacy non-mirror; continuing"
+
+              # Trigger an immediate sync so the local repo catches up
+              # with whatever has accumulated upstream since last interval.
+              # POST /repos/{owner}/{repo}/mirror-sync — fire-and-forget.
+              wget -q -O /dev/null \
+                --post-data='' \
+                --header="Authorization: Basic ${basic_auth}" \
+                "${api_url}/repos/${GITEA_ORG}/${GITEA_REPO}/mirror-sync" 2>/dev/null || true
             fi
 
-            # 3. Clone from upstream then push branches + tags only to
-            #    local Gitea, explicitly skipping GitHub-specific
-            #    refs/pull/<n>/(head|merge) refs that Gitea's update
-            #    hook declines. We DO NOT use --mirror or --all here:
-            #    a mirror clone stores GitHub PR refs at the same
-            #    namespace as branches and `git push --all` in that
-            #    context tries to push them too — caught live on
-            #    otech103 2026-05-04. An explicit refspec is the
-            #    correct shape: refs/heads/* and refs/tags/* only.
-            workdir=$(mktemp -d)
-            cd "${workdir}"
-            # Plain (non-mirror) clone keeps refs/pull/* out of the
-            # local refs entirely. We then fetch tags separately.
-            git clone --bare "${UPSTREAM_REPO_URL}" upstream.git
-            cd upstream.git
-            git fetch --tags origin
-            # Embed credentials in the push URL only (never in stdout).
-            push_url=$(printf '%s' "${GITEA_INTERNAL_URL}" | sed -e "s,://,://${GITEA_USERNAME}:${GITEA_PASSWORD}@,")
-            git remote set-url --push origin "${push_url}/${GITEA_ORG}/${GITEA_REPO}.git"
-            # Explicit refspecs — branches and tags only, no PR refs.
-            git push origin 'refs/heads/*:refs/heads/*'
-            git push origin 'refs/tags/*:refs/tags/*'
-            echo "[gitea-mirror] mirror complete"
+            # 3. Verify the mirror config landed. Read back the repo
+            #    metadata and confirm mirror=true + mirror_interval set.
+            #    This is the "no manual git fetch ever again" assertion.
+            repo_meta=$(wget -q -O - \
+              --header="Authorization: Basic ${basic_auth}" \
+              "${api_url}/repos/${GITEA_ORG}/${GITEA_REPO}" 2>/dev/null || echo "{}")
+            # Lightweight JSON probe — no jq in alpine/git. We only need
+            # to confirm `"mirror":true` and the interval string land.
+            if printf '%s' "${repo_meta}" | grep -q '"mirror":true'; then
+              echo "[gitea-mirror] verified: mirror=true on ${GITEA_ORG}/${GITEA_REPO}"
+            else
+              echo "[gitea-mirror] WARN: mirror flag not visible in repo metadata"
+              echo "[gitea-mirror] (legacy chart < 0.1.14 seed; auto-sync will not engage)"
+            fi
+            if printf '%s' "${repo_meta}" | grep -q "\"mirror_interval\":\"${MIRROR_INTERVAL}\""; then
+              echo "[gitea-mirror] verified: mirror_interval=${MIRROR_INTERVAL}"
+            fi
+            echo "[gitea-mirror] step complete"
         resources:
           requests: { cpu: 100m, memory: 256Mi }
           limits:   { memory: 1Gi }

--- a/platform/self-sovereign-cutover/chart/values.yaml
+++ b/platform/self-sovereign-cutover/chart/values.yaml
@@ -46,12 +46,22 @@ sovereign:
   # ↓ overlay supplies https://gitea.${SOVEREIGN_FQDN} (informational; jobs use internal URL).
   giteaPublicURL: "https://gitea.example.local"
 
-# Upstream openova-io read-only public clone — the source for the
-# cutover step 01 git push --mirror into local Gitea. Overrideable so a
-# Sovereign that ships from a fork can rebase the seed.
+# Upstream openova-io read-only public clone — the source for cutover
+# step 01. Step-1 calls Gitea's /repos/migrate API with mirror=true so
+# Gitea itself owns the recurring upstream sync going forward; the local
+# repo polls upstream on .Values.upstream.mirrorInterval. Overrideable
+# so a Sovereign that ships from a fork can rebase the seed.
 upstream:
   repoURL: "https://github.com/openova-io/openova"
   branch: "main"
+  # Gitea pull-mirror poll interval. Format = Go duration string parsed
+  # by Gitea (e.g. "10m0s", "1h0m0s"). Set to 10m by default — short
+  # enough that a chart bump → upstream merge → Sovereign reconcile
+  # cycle stays under 15 minutes end-to-end, long enough that GitHub
+  # anonymous-clone rate limits aren't a concern even with hundreds of
+  # Sovereigns. Caught the "drifts forever after cutover" bug live on
+  # otech103 2026-05-04 — chart 0.1.14 closes that loop. (#870)
+  mirrorInterval: "10m0s"
   # Mothership Harbor — the soft-tethered cold-start registry. Step 08
   # egress-block test asserts the cluster can survive without this URL.
   mothershipHarborURL: "https://harbor.openova.io"


### PR DESCRIPTION
## Summary

- Replace one-shot Gitea repo seed with `POST /repos/migrate` `mirror=true, mirror_interval=10m0s` so the local Sovereign Gitea auto-syncs from upstream `openova-io/openova` every 10 min.
- Closes the "Sovereign drifts from upstream main forever after Day-2 cutover" bug — hit twice on otech103 during the 2026-05-04 overnight DoD session.
- Chart bump `0.1.13 → 0.1.14`, blueprint.yaml `spec.version` aligned, slot `06a-bp-self-sovereign-cutover.yaml` pinned in lockstep.

## Why /repos/migrate

- Gitea cannot convert a regular repo to a pull-mirror after creation; the `mirror` flag must be set at create time.
- Toggles `wiki`, `issues`, `pull_requests`, `labels`, `milestones`, `releases` to false — Sovereign only needs branches + tags for Flux GitRepository.
- Native Gitea capability — no CronJob (would violate "event-driven not cron"), no long-poll sidecar.

## Idempotency

If the repo already exists from a prior cutover attempt: PATCH `mirror_interval` then POST `/mirror-sync` for an immediate refresh. PATCH alone cannot retrofit auto-sync onto a legacy chart-<0.1.14 repo (the mirror flag was never set) — log a WARN in that case but don't fail.

## Verification

- `helm template smoke .` — renders 16 docs cleanly
- `bash tests/cutover-contract.sh` — all 7 gates green
- `sh -n <rendered-script>` — POSIX shell syntax OK
- Heredoc avoidance: payload built via `printf` since `<<MARKER` requires unindented closing token (only `<<-MARKER` strips tabs, not spaces)

## Test plan

- [ ] Next fresh otechN provision: confirm Step-1 `gitea-mirror` Job logs `migrate complete — repo now mirroring from upstream`
- [ ] On the same Sovereign, exec into Gitea pod and confirm via API: `curl http://gitea-http:3000/api/v1/repos/openova/openova | jq '.mirror, .mirror_interval'` returns `true, "10m0s"`
- [ ] Make a trivial commit to upstream `main`; wait <15min; confirm Sovereign's Flux GitRepository reconciles to the new SHA without operator intervention

Refs #790.

Closes #870.

🤖 Generated with [Claude Code](https://claude.com/claude-code)