### PR TITLE
fix(bp-catalyst-platform): wire CATALYST_OTECH_FQDN env on catalyst-api (#876)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -104,7 +104,7 @@ spec:
       # /auth/send-pin → SendMagicLink (and /auth/verify-pin →
       # VerifyMagicLink) so the UI's PIN-naming reaches the existing
       # backend handler.
-      version: 1.4.9
+      version: 1.4.10
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: bp-catalyst-platform
-version: 1.4.9
-appVersion: 1.4.9
+version: 1.4.10
+appVersion: 1.4.10
 description: |
   Catalyst Platform — the unified Catalyst control plane umbrella chart for Catalyst-Zero.
   Composes the catalyst-{ui,api}, console, admin, marketplace UI modules and the marketplace-api backend.
@@ -602,6 +602,18 @@ description: |
   with the current pin. Same race documented in
   feedback_idempotent_iac_purge.md and overnight DoD doc as
   "deploy-step race". Lockstep slot 13 pin bumps to 1.4.9. 2026-05-05.
+
+  1.4.10 (issue #876): wire CATALYST_OTECH_FQDN env on the catalyst-api
+  Deployment from the same `sovereign-fqdn` ConfigMap (key `fqdn`) that
+  feeds SOVEREIGN_FQDN. The SME tenant create handler (sme_tenant.go)
+  and the sovereign-parent-domains seed (sovereign_parent_domains.go)
+  both read CATALYST_OTECH_FQDN — without it, POST /api/v1/sme/tenants
+  returns 503 {"error":"otech-fqdn-unconfigured"} on every Sovereign,
+  and the SME-pool fallback returns an empty list. The two env names
+  exist for historical reasons (Phase-8b handover vs SME-tier tenant
+  pipeline) but ultimately point at the Sovereign's public FQDN.
+  optional=true since Catalyst-Zero (contabo) doesn't run the SME
+  tenant pipeline. Lockstep slot 13 pin bumps to 1.4.10. 2026-05-05.
 type: application
 
 # Opt-out from the blueprint-release hollow-chart guard (issue #181 / #510).

--- a/products/catalyst/chart/templates/api-deployment.yaml
+++ b/products/catalyst/chart/templates/api-deployment.yaml
@@ -507,6 +507,23 @@ spec:
                   name: sovereign-fqdn
                   key: fqdn
                   optional: true
+            # CATALYST_OTECH_FQDN — same value as SOVEREIGN_FQDN, but read by
+            # the SME tenant create handler (sme_tenant.go) and the
+            # sovereign-parent-domains seed (sovereign_parent_domains.go).
+            # The two envs exist for historical reasons: SOVEREIGN_FQDN is the
+            # Phase-8b handover-flow JWT-audience env; CATALYST_OTECH_FQDN is
+            # the SME-tier tenant-pipeline env (epic #795 / #804). Both
+            # ultimately point at the Sovereign's public FQDN. Wired from the
+            # same `sovereign-fqdn` ConfigMap (key `fqdn`). optional=true since
+            # Catalyst-Zero (contabo) doesn't run the SME tenant pipeline.
+            # Issue #876 — without this, POST /api/v1/sme/tenants returns
+            # 503 {"error":"otech-fqdn-unconfigured"} on every Sovereign.
+            - name: CATALYST_OTECH_FQDN
+              valueFrom:
+                configMapKeyRef:
+                  name: sovereign-fqdn
+                  key: fqdn
+                  optional: true
             # CATALYST_HANDOVER_KEY_PATH — path to the RS256 PRIVATE key
             # catalyst-api uses to mint magic-link + handover JWTs. The
             # signer auto-generates the keypair on first start if absent.


### PR DESCRIPTION
## Summary

Without `CATALYST_OTECH_FQDN` env, `POST /api/v1/sme/tenants` returns 503 `otech-fqdn-unconfigured` on every Sovereign — verified live on otech103 with chart 1.4.9. The SME tenant create handler and the parent-domain pool seed both read this env; the chart only wired `SOVEREIGN_FQDN` (same value, different env name).

## Changes
- `products/catalyst/chart/templates/api-deployment.yaml`: add `CATALYST_OTECH_FQDN` env entry sourced from the same `sovereign-fqdn` ConfigMap that feeds `SOVEREIGN_FQDN`. `optional=true` (Catalyst-Zero doesn't need it).
- `products/catalyst/chart/Chart.yaml`: 1.4.9 → 1.4.10 + changelog
- `clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml`: slot pin 1.4.9 → 1.4.10

## Test plan
- [ ] `blueprint-release` rebuilds bp-catalyst-platform 1.4.10
- [ ] otech103 reconciles 1.4.10 + catalyst-api Pod gets `CATALYST_OTECH_FQDN=otech103.omani.works`
- [ ] `POST /api/v1/sme/tenants` no longer returns 503 (404/202/etc., NOT 503)

Closes #876. Unblocks #795 / #805.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>