### PR TITLE
fix(bp-catalyst-platform): Flux Kustomization watching SME tenant overlays (#882)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -104,6 +104,16 @@ spec:
       # /auth/send-pin → SendMagicLink (and /auth/verify-pin →
       # VerifyMagicLink) so the UI's PIN-naming reaches the existing
       # backend handler.
+      # 1.4.13 (issue #882): NEW templates/sme-services/sme-tenants-
+      # kustomization.yaml renders a Flux Kustomization in flux-system
+      # that watches ./clusters/<sov-fqdn>/sme-tenants — the path the
+      # catalyst-api SME-tenant orchestrator (sme_tenant_gitops.go)
+      # commits per-tenant overlays to. Without this, POST
+      # /api/v1/sme/tenants reached state=done optimistically but no
+      # K8s resources materialised because nothing reconciled the
+      # orchestrator's write target. Gated on
+      # ingress.marketplace.enabled — non-marketplace Sovereigns don't
+      # run the SME tenant pipeline.
       version: 1.4.13
       sourceRef:
         kind: HelmRepository

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -694,6 +694,58 @@ description: |
       wired by api-deployment.yaml from the sovereign-fqdn ConfigMap.
 
   Lockstep slot 13 pin in clusters/_template/bootstrap-kit/
+  13-bp-catalyst-platform.yaml bumps from 1.4.11 → 1.4.12. 2026-05-05.
+
+  Bumped to 1.4.13 — Flux Kustomization watching SME tenant overlays
+  (issue #882, 2026-05-05). The catalyst-api SME-tenant pipeline's
+  GitOps writer (sme_tenant_gitops.go::WriteTenantOverlay) commits
+  per-tenant Kustomize overlays to clusters/<sov-fqdn>/sme-tenants/
+  <tenant-id>/ on every successful POST /api/v1/sme/tenants — but no
+  Flux Kustomization on the Sovereign cluster watched that path. The
+  state machine (sme_tenant.go) advanced optimistically through every
+  step (vcluster → bp_charts → dns → certs → keycloak_clients →
+  registry) and reported state=done, while no actual K8s resources
+  materialised because nothing was reconciling the orchestrator's
+  write target.
+
+  Verified live on otech103 (2026-05-04 23:18 Berlin): the orchestrator
+  successfully committed the 9-file overlay for tenant 15f1e45e-...
+  to the local Gitea openova/openova repo @main, but `kubectl get hr
+  -n sme-15f1e45e-...` returned No resources found indefinitely.
+
+  Fix: NEW templates/sme-services/sme-tenants-kustomization.yaml,
+  gated on .Values.ingress.marketplace.enabled (same flag the rest of
+  the SME bundle uses) — non-marketplace Sovereigns don't run the SME
+  tenant pipeline so they don't render this Kustomization. Renders one
+  Flux Kustomization in flux-system that sweeps the entire
+  ./clusters/<sovereignFQDN>/sme-tenants directory tree:
+    - sourceRef:  flux-system/openova GitRepository (the same one the
+                  cluster bootstraps from; cutover Step 5 flips its
+                  .spec.url to the local in-cluster Gitea, which is
+                  precisely where sme_tenant_gitops.go pushes via
+                  CATALYST_GITOPS_REPO_URL=http://gitea-http.gitea.svc
+                  .cluster.local:3000/openova/openova)
+    - path:       ./clusters/{{ .Values.global.sovereignFQDN }}/sme-tenants
+    - interval:   1m (matches the orchestrator's "Flux reconciles
+                  within ~1 min" SLA documented at the top of
+                  sme_tenant_gitops.go)
+    - prune:      true (DELETE /api/v1/sme/tenants/<id> removes the
+                  overlay directory; Flux GCs the tenant resources)
+    - wait:       false (per-tenant overlays each install ~5 bp-* HRs
+                  asynchronously and have their own readiness watcher
+                  in the orchestrator; blocking this top-level
+                  Kustomization on every tenant's full readiness would
+                  let one stuck tenant gate every other tenant)
+
+  Per Inviolable Principle #4 (never hardcode), every knob is
+  operator-overridable via .Values.smeTenants.kustomization.* —
+  the GitRepository sourceRef name/namespace, the resource name,
+  the cadence (interval/retryInterval/timeout), and the toggles
+  (prune/wait). Defaults match the canonical bootstrap-kit
+  conventions documented in clusters/_template/bootstrap-kit/03-flux
+  .yaml + the cloud-init flux-bootstrap.yaml block.
+
+  Lockstep slot 13 pin in clusters/_template/bootstrap-kit/
   13-bp-catalyst-platform.yaml bumps from 1.4.12 → 1.4.13. 2026-05-05.
 type: application
 

--- a/products/catalyst/chart/templates/sme-services/sme-tenants-kustomization.yaml
+++ b/products/catalyst/chart/templates/sme-services/sme-tenants-kustomization.yaml
@@ -1,0 +1,117 @@
+{{- /*
+Flux Kustomization watching the SME-tenant overlay tree (issue #882).
+
+WHY THIS FILE EXISTS
+--------------------
+The catalyst-api SME-tenant pipeline's GitOps writer
+(products/catalyst/bootstrap/api/internal/handler/sme_tenant_gitops.go,
+function `WriteTenantOverlay`) commits a 9-file Kustomize overlay per
+tenant to:
+
+  clusters/<sovereign-fqdn>/sme-tenants/<sme_tenant_id>/
+
+…on every successful POST /api/v1/sme/tenants. The overlay carries:
+
+  - namespace.yaml          → `sme-<tenant-id>` Namespace
+  - vcluster.yaml           → vCluster CR for the tenant control plane
+  - bp-keycloak.yaml        → fresh realm + clients
+  - bp-cnpg.yaml            → tenant Postgres
+  - bp-wordpress-tenant.yaml
+  - bp-openclaw.yaml
+  - bp-stalwart-tenant.yaml
+  - certificate.yaml        → BYO-mode TLS (skipped for free-subdomain)
+  - kustomization.yaml      → the kustomize index
+
+WITHOUT a Flux Kustomization watching this path, the orchestrator's
+state machine optimistically advances through every step (vcluster →
+bp_charts → dns → certs → keycloak_clients → registry) and reports
+state=done — but no K8s resources materialise because nothing on the
+Sovereign cluster is reconciling the path the orchestrator wrote into.
+Documented live failure: otech103, 2026-05-04 (issue #882).
+
+CONTRACT
+--------
+This template renders ONE Flux Kustomization per Sovereign that sweeps
+the whole `sme-tenants` directory tree. Every per-tenant overlay
+beneath it is reconciled as a sub-Kustomization via the kustomize
+index file the orchestrator writes alongside the manifests, so adding
+a new tenant is a pure git-commit operation — no chart upgrade needed.
+
+  sourceRef: flux-system/openova   (the same GitRepository the cluster
+                                    bootstraps from; cutover Step 5
+                                    flips its `.spec.url` to the local
+                                    in-cluster Gitea at
+                                    http://gitea-http.gitea.svc.cluster.local:3000/openova/openova,
+                                    which is precisely where
+                                    sme_tenant_gitops.go pushes via
+                                    CATALYST_GITOPS_REPO_URL)
+  path:      ./clusters/<sov-fqdn>/sme-tenants
+  interval:  1m  (matches the orchestrator's "Flux on the OTECH
+                  cluster reconciles within ~1 min" SLA documented at
+                  the top of sme_tenant_gitops.go)
+  prune:     true  (a DELETE /api/v1/sme/tenants/<id> removes the
+                    overlay directory; we want Flux to GC the tenant
+                    resources accordingly)
+  wait:      false (tenant overlays each install ~5 bp-* HelmReleases
+                    independently; per-tenant readiness is owned by the
+                    SME-tenant orchestrator's own watcher loop, not by
+                    this top-level Kustomization. Avoids a stuck tenant
+                    blocking every other tenant's reconcile)
+
+GATING
+------
+Rendered ONLY when `.Values.ingress.marketplace.enabled=true` — same
+flag the rest of the SME bundle (configmap.yaml, marketplace.yaml,
+ferretdb.yaml, sme-secrets.yaml, …) is gated on. Non-marketplace
+Sovereigns don't run the SME tenant pipeline so they don't need this
+Kustomization.
+
+Per Inviolable Principle #4 (never hardcode):
+  - Sovereign FQDN comes from .Values.global.sovereignFQDN
+    (populated from $${SOVEREIGN_FQDN} envsubst by the bootstrap-kit
+    slot 13 overlay)
+  - GitRepository name + namespace are operator-overridable via
+    .Values.smeTenants.kustomization.sourceRef.{name,namespace}
+  - All cadence/timeout knobs (interval, retryInterval, timeout) are
+    operator-overridable via .Values.smeTenants.kustomization.*
+
+Per Inviolable Principle #3, the chart templates the resource and
+Flux owns the apply — we do NOT shell out to `kubectl apply`.
+
+References:
+  - Issue #882
+  - sme_tenant_gitops.go (WriteTenantOverlay write target)
+  - clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml (slot pin)
+  - clusters/_template/bootstrap-kit/03-flux.yaml (Kustomization shape)
+*/}}
+{{- if and .Values.ingress .Values.ingress.marketplace .Values.ingress.marketplace.enabled -}}
+{{- $sovFQDN := .Values.global.sovereignFQDN -}}
+{{- if $sovFQDN -}}
+{{- $kt := (.Values.smeTenants).kustomization | default dict -}}
+{{- $sourceRef := ($kt.sourceRef | default dict) -}}
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: {{ $kt.name | default "sme-tenants" | quote }}
+  namespace: {{ $kt.namespace | default "flux-system" | quote }}
+  labels:
+    catalyst.openova.io/blueprint: bp-catalyst-platform
+    catalyst.openova.io/component: sme-tenants-reconciler
+    app.kubernetes.io/part-of: sme
+spec:
+  interval: {{ $kt.interval | default "1m" | quote }}
+  retryInterval: {{ $kt.retryInterval | default "1m" | quote }}
+  timeout: {{ $kt.timeout | default "5m" | quote }}
+  path: ./clusters/{{ $sovFQDN }}/sme-tenants
+  prune: {{ $kt.prune | default true }}
+  # wait: false — each tenant overlay's bp-* HelmReleases install
+  # asynchronously and have their own readiness watcher in the SME
+  # tenant orchestrator. Blocking this Kustomization on every tenant's
+  # full readiness would let one stuck tenant gate every other tenant.
+  wait: {{ $kt.wait | default false }}
+  sourceRef:
+    kind: GitRepository
+    name: {{ $sourceRef.name | default "openova" | quote }}
+    namespace: {{ $sourceRef.namespace | default "flux-system" | quote }}
+{{- end }}
+{{- end }}

--- a/products/catalyst/chart/values.yaml
+++ b/products/catalyst/chart/values.yaml
@@ -176,6 +176,73 @@ ingress:
   marketplace:
     enabled: false
 
+# ─── SME tenant overlay reconciler (issue #882) ───────────────────────────
+# Flux Kustomization shipped by templates/sme-services/sme-tenants-
+# kustomization.yaml. Watches the path the catalyst-api SME-tenant
+# orchestrator (sme_tenant_gitops.go::WriteTenantOverlay) commits
+# per-tenant overlays to:
+#
+#   ./clusters/<global.sovereignFQDN>/sme-tenants
+#
+# Without it, every POST /api/v1/sme/tenants reaches state=done
+# optimistically but the per-tenant K8s resources (Namespace, vCluster,
+# bp-keycloak / bp-cnpg / bp-wordpress-tenant / bp-openclaw /
+# bp-stalwart-tenant HRs) never materialise. Caught live on otech103,
+# 2026-05-04.
+#
+# Gated on ingress.marketplace.enabled (non-marketplace Sovereigns
+# don't run the SME tenant pipeline).
+#
+# Per Inviolable Principle #4 (never hardcode), every operationally-
+# meaningful value is operator-overridable. Defaults match the
+# canonical bootstrap-kit conventions documented in
+# clusters/_template/bootstrap-kit/03-flux.yaml + the cloud-init
+# flux-bootstrap.yaml block (which seeds flux-system/openova
+# GitRepository).
+smeTenants:
+  kustomization:
+    # Resource name. Default `sme-tenants` — short, ops-readable,
+    # appears in `kubectl get kustomization -n flux-system`.
+    name: sme-tenants
+    # Lives in flux-system alongside the cluster's other Kustomizations
+    # (bootstrap-kit, sovereign-tls, infrastructure-config) so operator
+    # tooling can discover it via the standard `-n flux-system` flag.
+    namespace: flux-system
+    # The same GitRepository the cluster bootstraps from. Cutover
+    # Step 5 patches its .spec.url from github.com to the local
+    # in-cluster Gitea (http://gitea-http.gitea.svc.cluster.local:3000/
+    # openova/openova) — exactly the URL sme_tenant_gitops.go pushes
+    # via CATALYST_GITOPS_REPO_URL. Operator overlays MAY repoint at
+    # a different GitRepository name (e.g. an SME-tenants-only repo
+    # split out of the monorepo) without forking the chart.
+    sourceRef:
+      name: openova
+      namespace: flux-system
+    # Reconcile cadence. 1m matches the orchestrator's documented
+    # "Flux on the OTECH cluster reconciles within ~1 min" SLA at the
+    # top of sme_tenant_gitops.go.
+    interval: 1m
+    # Same as interval — failed reconciles release the revision lock
+    # quickly so a per-tenant fix lands on the next poll.
+    retryInterval: 1m
+    # Per-tenant overlays each install ~5 bp-* HelmReleases that take
+    # multiple minutes to roll. 5m bounds the apply attempt without
+    # falsely declaring readiness or holding the lock too long. Each
+    # tenant's full readiness is owned by the orchestrator's watcher
+    # loop, not this Kustomization (wait: false below).
+    timeout: 5m
+    # DELETE /api/v1/sme/tenants/<id> removes the per-tenant overlay
+    # directory. Flux GCs the corresponding K8s resources via the
+    # Kustomization's prune contract.
+    prune: true
+    # Each tenant overlay's HelmReleases install asynchronously and
+    # have their own readiness watcher in the SME-tenant orchestrator.
+    # Blocking this top-level Kustomization on every tenant's full
+    # readiness would let one stuck tenant gate every other tenant's
+    # reconcile — a single CrashLooping bp-keycloak in tenant A would
+    # prevent tenant B from being created.
+    wait: false
+
 # Marketplace operator branding + payment + signup config (issue #710).
 # Operator-supplied at provision time; rendered into ConfigMaps consumed
 # by templates/sme-services/marketplace.yaml + admin.yaml. Defaults are


### PR DESCRIPTION
## Summary
- NEW `templates/sme-services/sme-tenants-kustomization.yaml` renders one Flux Kustomization in `flux-system` that watches `./clusters/<sovereignFQDN>/sme-tenants` — the exact path the catalyst-api SME-tenant orchestrator (`sme_tenant_gitops.go::WriteTenantOverlay`) commits per-tenant overlays to.
- Without this template, every `POST /api/v1/sme/tenants` reaches `state=done` optimistically but no K8s resources materialise because nothing on the Sovereign cluster reconciles the orchestrator's write target. Caught live on otech103, 2026-05-04 (issue #882).
- Bumps `bp-catalyst-platform` 1.4.12 -> 1.4.13 + lockstep `clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml` slot pin.

## Design
- **sourceRef**: `flux-system/openova` GitRepository — the same one the cluster bootstraps from. Cutover Step 5 flips its `.spec.url` to the local in-cluster Gitea (`http://gitea-http.gitea.svc.cluster.local:3000/openova/openova`), which is precisely where the orchestrator pushes via `CATALYST_GITOPS_REPO_URL`.
- **path**: `./clusters/{{ .Values.global.sovereignFQDN }}/sme-tenants` (sweeps the whole tenant tree — adding a new tenant is a pure git-commit operation).
- **interval**: `1m` (matches the orchestrator's "Flux reconciles within ~1 min" SLA documented at the top of `sme_tenant_gitops.go`).
- **prune**: `true` (`DELETE /api/v1/sme/tenants/<id>` removes the overlay directory; Flux GCs the tenant resources).
- **wait**: `false` (per-tenant overlays each install ~5 bp-* HelmReleases asynchronously and have their own readiness watcher in the SME-tenant orchestrator; blocking this top-level Kustomization on every tenant's full readiness would let one stuck tenant gate every other tenant's reconcile).

## Constraints honored
- Inviolable Principle #4 (never hardcode): Sovereign FQDN comes from `.Values.global.sovereignFQDN` (envsubst from slot 13). All other knobs (sourceRef name/namespace, interval, retryInterval, timeout, prune, wait) are operator-overridable via `.Values.smeTenants.kustomization.*`.
- Inviolable Principle #3 (Flux is the canonical reconciler): chart templates the resource; Flux owns the apply. No `kubectl apply`, no shell-out.
- Gated on `.Values.ingress.marketplace.enabled` — same flag the rest of the SME bundle uses. Non-marketplace Sovereigns don't render this Kustomization.

## Verified locally
- `helm template` with `marketplace.enabled=true` -> renders the Kustomization with all expected fields.
- `helm template` with default values (`marketplace.enabled=false`) -> Kustomization is correctly omitted.
- `helm template` with default values -> exits 0; full chart still renders.
- `kubectl kustomize products/catalyst/chart/templates/` -> exits 0; SME-tenants Kustomization correctly NOT in contabo Kustomize-mode output (kustomization.yaml index gates it like every other marketplace.enabled-only file).
- `helm lint` -> 0 failures.

## Test plan
- [x] `helm template` renders cleanly with marketplace enabled
- [x] `helm template` correctly omits Kustomization when marketplace disabled
- [x] `kubectl kustomize` (contabo Kustomize-mode) still renders cleanly
- [x] `helm lint` clean
- [ ] Live on otech103 after release: `kubectl get kustomization -n flux-system sme-tenants` exists
- [ ] The previously committed `15f1e45e-...` tenant overlay reconciles into K8s resources (vCluster + 5 bp-* HRs in `sme-15f1e45e-...` ns)

## Related
- Closes #882
- Predecessor fixes: #871, #876, #878, #859, #860, #861, #862, #863, #864, #866, #867, #868
- Epic: #795 / #805 (SME tenant pipeline E2E)

🤖 Generated with [Claude Code](https://claude.com/claude-code)