### PR TITLE
fix(bp-catalyst-platform): bump 1.4.15 -> 1.4.16 to republish with #893/#889 catalyst-api image (727fb2f)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -128,7 +128,14 @@ spec:
       # CreateContainerConfigError. Fix mirrors sme-secrets/
       # valkey-cross-ns-secret/provisioning-github-token Helm-lookup
       # persistence pattern. helm.sh/resource-policy: keep.
-      version: 1.4.15
+      # 1.4.16 (#893/#889 follow-up): chart-version-only republish to
+      # bake catalyst-api image SHA 727fb2f (containing the parent-
+      # kustomization.yaml index + helmrepositories.yaml emit + correct
+      # per-blueprint sourceRef.name in tenant overlay templates) into
+      # values.yaml. Without this bump the OCI artifact still references
+      # the old image and the Sovereign's tenant orchestrator emits
+      # tenant overlays with stale openova-blueprints sourceRef.
+      version: 1.4.16
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: bp-catalyst-platform
-version: 1.4.15
-appVersion: 1.4.15
+version: 1.4.16
+appVersion: 1.4.16
 description: |
   Catalyst Platform — the unified Catalyst control plane umbrella chart for Catalyst-Zero.
   Composes the catalyst-{ui,api}, console, admin, marketplace UI modules and the marketplace-api backend.


### PR DESCRIPTION
Republish chart with new catalyst-api image SHA. Closes deploy-step race for #893/#889.