### PR TITLE
fix(bp-keycloak): templatize existingConfigmap for per-tenant installs (#899)

### DIFF
--- a/clusters/_template/bootstrap-kit/09-keycloak.yaml
+++ b/clusters/_template/bootstrap-kit/09-keycloak.yaml
@@ -41,7 +41,7 @@ spec:
   chart:
     spec:
       chart: bp-keycloak
-      version: 1.3.2
+      version: 1.3.3
       sourceRef:
         kind: HelmRepository
         name: bp-keycloak

--- a/platform/keycloak/blueprint.yaml
+++ b/platform/keycloak/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
 spec:
-  version: 1.3.2
+  version: 1.3.3
   card:
     title: keycloak
     summary: Keycloak — user identity. Topology decided by Sovereign CRD spec.keycloakTopology (per-organization for SME, shared-sovereign for corporate).

--- a/platform/keycloak/chart/Chart.yaml
+++ b/platform/keycloak/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-keycloak
-version: 1.3.2
+version: 1.3.3
 description: |
   Catalyst-curated Blueprint umbrella chart for Keycloak. Depends on the
   upstream `keycloak` chart (bitnami) as a Helm subchart so

--- a/platform/keycloak/chart/values.yaml
+++ b/platform/keycloak/chart/values.yaml
@@ -170,7 +170,7 @@ keycloak:
       registry: docker.io
       repository: bitnamilegacy/keycloak-config-cli
       tag: 6.4.0-debian-12-r11
-    # ─── Phase-8b realm ConfigMap (issue #604) ───────────────────────────────
+    # ─── Phase-8b realm ConfigMap (issue #604, #899) ─────────────────────────
     # The realm import JSON is now owned by the parent bp-keycloak chart's
     # templates/configmap-sovereign-realm.yaml template. That template has
     # access to .Values.sovereignFQDN and .Values.smtp.* for per-Sovereign
@@ -179,10 +179,23 @@ keycloak:
     #
     # The upstream bitnami/keycloak chart honours `keycloakConfigCli.existingConfigmap`:
     # when set it skips creating its own ConfigMap and uses the named one instead.
-    # Name convention: "<releaseName>-sovereign-realm-config".
-    # With the bootstrap-kit default releaseName=keycloak → "keycloak-sovereign-realm-config".
-    # Operators using a non-default releaseName must override this key to match.
-    existingConfigmap: keycloak-sovereign-realm-config
+    # The bitnami helper "keycloak.keycloakConfigCli.configmapName" applies
+    # `tpl` to the value (see charts/keycloak/templates/_helpers.tpl), so we
+    # can embed a Helm template expression here that resolves at render time.
+    #
+    # Name convention: "<releaseName>-sovereign-realm-config" — emitted by
+    # templates/configmap-sovereign-realm.yaml at the parent scope. Using
+    # `{{ .Release.Name }}` (subchart scope; identical Release object)
+    # keeps the reference correct on EVERY install topology:
+    #   - Sovereign-mothership bootstrap-kit: releaseName=keycloak →
+    #     "keycloak-sovereign-realm-config"
+    #   - Per-tenant SME (issue #899): releaseName=bp-keycloak →
+    #     "bp-keycloak-sovereign-realm-config"
+    # Issue #899 root cause: this was a literal "keycloak-sovereign-realm-config"
+    # which broke whenever the operator-supplied releaseName != "keycloak".
+    # Per Inviolable Principle #4 (never hardcode): the release-name
+    # derivation here is the seam.
+    existingConfigmap: '{{ .Release.Name }}-sovereign-realm-config'
   # Metrics + ServiceMonitor + PrometheusRule — DEFAULT OFF.
   #
   # Per docs/INVIOLABLE-PRINCIPLES.md #4 and docs/BLUEPRINT-AUTHORING.md


### PR DESCRIPTION
## Summary

Closes #899. bp-keycloak 1.3.2 hardcoded `keycloak.keycloakConfigCli.existingConfigmap` to literal `keycloak-sovereign-realm-config`, breaking every per-tenant install where the release name is not `keycloak`.

## Root cause

The chart's `templates/configmap-sovereign-realm.yaml` already emits a release-name-templated ConfigMap (`{{ .Release.Name }}-sovereign-realm-config`). The upstream bitnami/keycloak subchart's `existingConfigmap` value, however, is referenced literally in the post-install `keycloak-config-cli` Job's volume mount.

Per-tenant install (releaseName=`bp-keycloak`):
- Emitted ConfigMap: `bp-keycloak-sovereign-realm-config`
- existingConfigmap reference: `keycloak-sovereign-realm-config` (literal)
- Result: post-install Job stuck `ContainerCreating`, HR InstallFailed at 15m, cascade-blocks bp-openclaw + bp-wordpress-tenant

Live evidence on otech103 sme-789ae512-...:
```
MountVolume.SetUp failed for volume "config-volume" : configmap "keycloak-sovereign-realm-config" not found
```

## Fix

The bitnami subchart's `keycloak.keycloakConfigCli.configmapName` helper (charts/keycloak/templates/_helpers.tpl) applies `tpl` to the `existingConfigmap` string value. Embedding `{{ .Release.Name }}` resolves at chart render time. One-line value change:

```yaml
existingConfigmap: '{{ .Release.Name }}-sovereign-realm-config'
```

Verified via `helm template` both topologies:
- Sovereign-mothership (releaseName=`keycloak`) → `keycloak-sovereign-realm-config` (unchanged behaviour)
- Per-tenant (releaseName=`bp-keycloak`) → `bp-keycloak-sovereign-realm-config` (matches actual emitted ConfigMap)

Chart bumped 1.3.2 → 1.3.3, bootstrap-kit slot 09 + blueprint.yaml pin updated.

## Test plan
- [x] `helm template` Sovereign mode renders without error and config-volume.configMap.name matches emitted ConfigMap
- [x] `helm template` per-tenant mode (releaseName=bp-keycloak) renders without error and config-volume.configMap.name matches
- [ ] On otech103 after merge + chart publish: bp-keycloak HR Ready=True in alice tenant ns
- [ ] bp-openclaw + bp-wordpress-tenant cascade unblocks (or surfaces other bugs — out of scope, will note)

🤖 Generated with [Claude Code](https://claude.com/claude-code)