### PR TITLE
fix(catalyst): unblock Sovereign Console login on fresh provision (#901)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -135,7 +135,27 @@ spec:
       # values.yaml. Without this bump the OCI artifact still references
       # the old image and the Sovereign's tenant orchestrator emits
       # tenant overlays with stale openova-blueprints sourceRef.
-      version: 1.4.16
+      # 1.4.17 (issue #901): unblock Sovereign Console login on every
+      # fresh provision. 3-bug chain:
+      #   1. NEW templates/catalyst-openova-kc-credentials-secret.yaml
+      #      auto-mirrors the canonical KC SA Secret (`keycloak/
+      #      catalyst-kc-sa-credentials`) into catalyst-system as
+      #      `catalyst-openova-kc-credentials` with the keys
+      #      api-deployment.yaml's PIN-auth env block expects. Gated on
+      #      `lookup "v1" "Secret" "keycloak" "catalyst-kc-sa-credentials"`
+      #      returning non-nil — renders only on Sovereign, skips on
+      #      contabo (which has its own hand-rolled Secret). Same Helm-
+      #      `lookup` persistence + `helm.sh/resource-policy: keep`
+      #      pattern as templates/marketplace-api/secret.yaml (#887).
+      #   2. SMTP host/port/from defaults flow through .Values.sovereign.
+      #      smtp.* (mail.openova.io:587 / noreply@openova.io). SMTP
+      #      user/pass mirrored from `catalyst-system/sovereign-smtp-
+      #      credentials` (#883) when present.
+      #   3. CATALYST_POST_AUTH_REDIRECT default flips from
+      #      /sovereign/wizard (mothership-only) to /sovereign/components
+      #      (post-handover Sovereign homepage). Per-Sovereign overlays
+      #      override via catalystApi.env additional-env patch.
+      version: 1.4.17
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: bp-catalyst-platform
-version: 1.4.16
-appVersion: 1.4.16
+version: 1.4.17
+appVersion: 1.4.17
 description: |
   Catalyst Platform — the unified Catalyst control plane umbrella chart for Catalyst-Zero.
   Composes the catalyst-{ui,api}, console, admin, marketplace UI modules and the marketplace-api backend.
@@ -776,6 +776,65 @@ description: |
   invalidate every active marketplace JWT. helm.sh/resource-policy: keep
   so the Secret survives helm uninstall. Lockstep slot 13 pin bumps to
   1.4.15. 2026-05-05.
+
+  1.4.17 (issue #901): unblock Sovereign Console login on every fresh
+  provision. https://console.<sov>/login PIN-issue endpoint returned 503
+  with "CATALYST_OPENOVA_KC_SA_CLIENT_SECRET not set" — a 3-bug chain:
+
+  Bug 1: api-deployment.yaml lines 676-739 reference a Secret
+    `catalyst-openova-kc-credentials` for the full PIN-auth env block
+    (CATALYST_OPENOVA_KC_* + CATALYST_SMTP_*). On contabo-mkt this Secret
+    is hand-rolled out-of-band (clusters/contabo-mkt/apps/keycloak-zero/
+    helmrelease.yaml mounts it via extraEnvVars). On a freshly franchised
+    Sovereign nothing equivalent existed — every secretKeyRef has
+    optional=true so the Pod started, but POST /api/v1/auth/pin/issue
+    503'd on the missing client-secret env. Fix: NEW
+    templates/catalyst-openova-kc-credentials-secret.yaml mirrors the
+    canonical KC SA Secret (`keycloak/catalyst-kc-sa-credentials`,
+    created by bp-keycloak's openbao-bridge post-install hook) into
+    catalyst-system as `catalyst-openova-kc-credentials` with the key
+    shape api-deployment.yaml expects. Same Helm-`lookup` persistence
+    pattern as templates/marketplace-api/secret.yaml (#887),
+    sme-secrets.yaml (#859), valkey-cross-ns-secret.yaml (#863),
+    provisioning-github-token.yaml (#866) and gitea-admin-secret.yaml
+    (#830). helm.sh/resource-policy: keep — Secret survives helm
+    uninstall.
+
+    Sovereign-vs-contabo gate (load-bearing): the new template is
+    rendered ONLY when `lookup "v1" "Secret" "keycloak"
+    "catalyst-kc-sa-credentials"` returns non-nil. On Catalyst-Zero
+    (contabo) Keycloak runs as `keycloak-zero` in its own namespace
+    and there is NO Secret by that name in the `keycloak` namespace
+    — lookup returns nil → the template renders empty bytes → the
+    existing hand-rolled Secret in clusters/contabo-mkt/apps/...
+    remains untouched (no helm-vs-kustomize ownership flap). The
+    new file is intentionally NOT added to templates/kustomization.yaml
+    `resources:` so Kustomize-mode contabo build skips it entirely
+    (same dual-mode pattern as templates/marketplace-api/secret.yaml).
+
+  Bug 2: SMTP host default `stalwart-web.stalwart.svc.cluster.local`
+    (an in-code constant) doesn't exist on Sovereign — even after Bug 1
+    the PIN-email delivery would fail at the next step. Fix: chart now
+    populates smtp-host/smtp-port/smtp-from from .Values.sovereign.smtp.*
+    defaulting to mail.openova.io:587 / noreply@openova.io. SMTP
+    user/pass come from a SECONDARY lookup against
+    `catalyst-system/sovereign-smtp-credentials` (Secret seeded by
+    cloud-init at provision time — issue #883 follow-up). If the source
+    Secret is missing, the Secret renders with empty smtp-user/smtp-pass
+    so the login surface still works and PIN delivery surfaces as a
+    clear "email delivery failed" log line, not as a 503.
+
+  Bug 3: CATALYST_POST_AUTH_REDIRECT default `/sovereign/wizard` is
+    mothership-only — the wizard page is the Provisioning Wizard the
+    operator drives at signup, not a post-handover Sovereign page. Fix:
+    chart-level default flips to `/sovereign/components` (the post-
+    handover Sovereign Console homepage). Per-Sovereign overlays
+    override via the catalystApi.env additional-env patch — the chart
+    value is a literal (per the dual-mode contract documented in the
+    CATALYST_POWERDNS_API_URL block of api-deployment.yaml).
+
+  Lockstep slot 13 pin in clusters/_template/bootstrap-kit/
+  13-bp-catalyst-platform.yaml bumps from 1.4.16 → 1.4.17. 2026-05-05.
 type: application
 
 # Opt-out from the blueprint-release hollow-chart guard (issue #181 / #510).

--- a/products/catalyst/chart/templates/api-deployment.yaml
+++ b/products/catalyst/chart/templates/api-deployment.yaml
@@ -661,13 +661,27 @@ spec:
                   key: session-cookie-secret
                   optional: true
             # CATALYST_POST_AUTH_REDIRECT — URL the browser is sent to after a
-            # successful magic-link callback. Defaults to /wizard in code; set
-            # to /sovereign/wizard here because Catalyst-Zero routes the UI
-            # under the /sovereign prefix and the Traefik strip-prefix middleware
-            # is transparent to the server-side Location header.
-            # Per INVIOLABLE-PRINCIPLES #4: runtime configuration, not hardcoded.
+            # successful magic-link / PIN callback. Defaults to /wizard in code.
+            # Catalyst-Zero (contabo) routes the UI under the /sovereign prefix
+            # (Traefik strip-prefix is transparent to the server-side Location
+            # header), so contabo overrides this to /sovereign/wizard via the
+            # per-environment overlay. On a freshly franchised Sovereign the
+            # wizard is mothership-only — empty page on /sovereign/wizard.
+            # The post-handover Sovereign Console homepage is /sovereign/components,
+            # so that's the default we now ship (issue #901, 2026-05-05).
+            #
+            # DUAL-MODE CONTRACT — see CATALYST_POWERDNS_API_URL block above:
+            # this file is consumed by both Helm (Sovereign) and Kustomize
+            # (contabo-mkt). Helm template directives (curly-brace syntax) in
+            # `value:` break the Kustomize render with "yaml: invalid map key".
+            # So this default is a literal. Per-Sovereign overrides go through
+            # the HelmRelease overlay's `catalystApi.env` additional-env patch,
+            # NOT through this file.
+            #
+            # Per INVIOLABLE-PRINCIPLES #4: the override seam exists (overlay
+            # env patch); only the chart-shipped default is a literal.
             - name: CATALYST_POST_AUTH_REDIRECT
-              value: /sovereign/wizard
+              value: "/sovereign/components"
             # ── Option-B magic-link: openova realm service account ───────────
             # CATALYST_OPENOVA_KC_ADDR — Keycloak base URL for the openova realm.
             # Defaults in code to keycloak-zero.keycloak-zero.svc (in-cluster

--- a/products/catalyst/chart/templates/catalyst-openova-kc-credentials-secret.yaml
+++ b/products/catalyst/chart/templates/catalyst-openova-kc-credentials-secret.yaml
@@ -1,0 +1,170 @@
+{{- /*
+Auto-provision catalyst-openova-kc-credentials Secret on Sovereign install
+(issue #901, login PIN-issue 503 chain).
+
+Why this template exists
+========================
+templates/api-deployment.yaml lines 676-739 reference a secretKeyRef on
+`catalyst-openova-kc-credentials` for the full PIN-auth env block:
+  - kc-addr, kc-realm, kc-sa-client-id, kc-sa-client-secret, kc-audience
+  - smtp-host, smtp-port, smtp-from, smtp-user, smtp-pass
+
+On Catalyst-Zero (contabo-mkt) this Secret is hand-rolled by the operator
+under clusters/contabo-mkt/apps/.../catalyst-openova-kc-credentials.yaml
+and points at the openova-realm running in keycloak-zero (separate ns).
+
+On a freshly franchised Sovereign nothing equivalent existed — every
+secretKeyRef has optional=true, so the catalyst-api Pod started, but
+POST /api/v1/auth/pin/issue then 503'd with
+  "CATALYST_OPENOVA_KC_SA_CLIENT_SECRET not set".
+Caught live on otech103, 2026-05-05.
+
+Sovereign-vs-Mothership gate (load-bearing)
+===========================================
+The canonical KC SA source on a Sovereign is the `catalyst-kc-sa-credentials`
+Secret in the `keycloak` namespace (created by bp-keycloak's openbao-bridge
+post-install hook — see platform/keycloak/chart/templates/, issue #781).
+On contabo-mkt Catalyst-Zero uses `keycloak-zero` (separate Helm release
+in its own namespace) — there is NO `catalyst-kc-sa-credentials` Secret in
+the `keycloak` namespace there.
+
+We gate render on `lookup "v1" "Secret" "keycloak" "catalyst-kc-sa-credentials"`
+returning non-nil. This means:
+  - On a Sovereign: lookup returns the secret → template renders → the
+    chart auto-provisions catalyst-openova-kc-credentials in
+    catalyst-system from the keycloak SA Secret + sovereign.smtp values.
+  - On contabo-mkt: lookup returns nil → template renders empty bytes →
+    the existing hand-rolled Secret in clusters/contabo-mkt/apps/...
+    is untouched (no helm-vs-kustomize ownership flap).
+
+Persistence across reconciles
+=============================
+Per the marketplace-api/secret.yaml + sme-secrets.yaml + valkey-cross-ns-
+secret.yaml pattern (issues #859/#863/#866/#887), this Secret MUST survive
+helm upgrade / Flux reconciliation. It carries the SMTP password (rotated
+out-of-band by the operator) and the keycloak client-secret (auto-rotated
+by openbao). We use Helm `lookup` against the TARGET Secret
+(catalyst-system/catalyst-openova-kc-credentials):
+  - Steady state: lookup finds the existing Secret, decodes existing values,
+    and re-encodes them verbatim → pass-through.
+  - First install: lookup returns nil → values come from the SOURCE Secrets
+    (catalyst-kc-sa-credentials + sovereign-smtp-credentials) and from
+    .Values.sovereign.smtp.{host,port,from}.
+  - Operator-driven rotation: edit the source Secrets; the next chart
+    reconcile sees this template's lookup hit the still-existing target
+    and rePersists those rotated bytes (because the target lookup wins
+    over the source lookup on subsequent renders). Net effect: rotation
+    requires either deleting the target Secret OR pushing the new value
+    directly into the target. Acceptable trade-off — the Secret
+    is auto-generated content, and the operator-friendly path
+    (`kubectl delete secret -n catalyst-system catalyst-openova-kc-credentials`)
+    forces the chart to re-mirror from sources on the next reconcile.
+
+helm.sh/resource-policy: keep — survives helm uninstall so a re-install
+picks up the same bytes via lookup.
+
+Per docs/INVIOLABLE-PRINCIPLES.md #10: NO plaintext credentials in this
+template. All values flow through Helm `lookup` of existing K8s Secrets
+or through .Values.sovereign.smtp.{host,port,from} which are non-secret
+infrastructure addresses (mail.openova.io / 587 / noreply@openova.io
+defaults).
+*/}}
+{{- $kcSrc := lookup "v1" "Secret" "keycloak" "catalyst-kc-sa-credentials" -}}
+{{- if and $kcSrc $kcSrc.data -}}
+{{- $secretName := "catalyst-openova-kc-credentials" -}}
+{{- $namespace := .Release.Namespace -}}
+{{- /* ---- Persistent target lookup ---- */ -}}
+{{- $existing := lookup "v1" "Secret" $namespace $secretName -}}
+{{- /* ---- KC fields: prefer existing target → fall back to source Secret ---- */ -}}
+{{- $kcAddr := "" -}}
+{{- $kcRealm := "" -}}
+{{- $kcClientID := "" -}}
+{{- $kcClientSecret := "" -}}
+{{- $kcAudience := "" -}}
+{{- if and $existing $existing.data (index $existing.data "kc-addr") -}}
+  {{- $kcAddr = index $existing.data "kc-addr" | b64dec -}}
+{{- else if (index $kcSrc.data "addr") -}}
+  {{- $kcAddr = index $kcSrc.data "addr" | b64dec -}}
+{{- end -}}
+{{- if and $existing $existing.data (index $existing.data "kc-realm") -}}
+  {{- $kcRealm = index $existing.data "kc-realm" | b64dec -}}
+{{- else if (index $kcSrc.data "realm") -}}
+  {{- $kcRealm = index $kcSrc.data "realm" | b64dec -}}
+{{- end -}}
+{{- if and $existing $existing.data (index $existing.data "kc-sa-client-id") -}}
+  {{- $kcClientID = index $existing.data "kc-sa-client-id" | b64dec -}}
+{{- else if (index $kcSrc.data "client-id") -}}
+  {{- $kcClientID = index $kcSrc.data "client-id" | b64dec -}}
+{{- end -}}
+{{- if and $existing $existing.data (index $existing.data "kc-sa-client-secret") -}}
+  {{- $kcClientSecret = index $existing.data "kc-sa-client-secret" | b64dec -}}
+{{- else if (index $kcSrc.data "client-secret") -}}
+  {{- $kcClientSecret = index $kcSrc.data "client-secret" | b64dec -}}
+{{- end -}}
+{{- /* kc-audience: source has no `audience` key — default to client-id (the
+       Keycloak client itself is the audience for token-exchange in the
+       PIN-auth flow). Existing target wins if set. */ -}}
+{{- if and $existing $existing.data (index $existing.data "kc-audience") -}}
+  {{- $kcAudience = index $existing.data "kc-audience" | b64dec -}}
+{{- else -}}
+  {{- $kcAudience = $kcClientID -}}
+{{- end -}}
+{{- /* ---- SMTP creds: secondary lookup against sovereign-smtp-credentials ---- */ -}}
+{{- /* Provisioner (issue #883, agent A5) seeds catalyst-system/sovereign-smtp-credentials
+       at handover time. Keys: user, password. Until that lands, missing creds surface
+       as "PIN email delivery failed" (a real, debuggable error) instead of as the
+       earlier "CATALYST_OPENOVA_KC_SA_CLIENT_SECRET not set" 503 — login surface still
+       renders, the user can see what's wrong. */ -}}
+{{- $smtpSrc := lookup "v1" "Secret" $namespace "sovereign-smtp-credentials" -}}
+{{- $smtpUser := "" -}}
+{{- $smtpPass := "" -}}
+{{- if and $existing $existing.data (index $existing.data "smtp-user") -}}
+  {{- $smtpUser = index $existing.data "smtp-user" | b64dec -}}
+{{- else if and $smtpSrc $smtpSrc.data (index $smtpSrc.data "user") -}}
+  {{- $smtpUser = index $smtpSrc.data "user" | b64dec -}}
+{{- end -}}
+{{- if and $existing $existing.data (index $existing.data "smtp-pass") -}}
+  {{- $smtpPass = index $existing.data "smtp-pass" | b64dec -}}
+{{- else if and $smtpSrc $smtpSrc.data (index $smtpSrc.data "password") -}}
+  {{- $smtpPass = index $smtpSrc.data "password" | b64dec -}}
+{{- end -}}
+{{- /* ---- SMTP non-secret fields: target → values defaults ---- */ -}}
+{{- $smtpHost := .Values.sovereign.smtp.host -}}
+{{- $smtpPort := .Values.sovereign.smtp.port -}}
+{{- $smtpFrom := .Values.sovereign.smtp.from -}}
+{{- if and $existing $existing.data (index $existing.data "smtp-host") -}}
+  {{- $smtpHost = index $existing.data "smtp-host" | b64dec -}}
+{{- end -}}
+{{- if and $existing $existing.data (index $existing.data "smtp-port") -}}
+  {{- $smtpPort = index $existing.data "smtp-port" | b64dec -}}
+{{- end -}}
+{{- if and $existing $existing.data (index $existing.data "smtp-from") -}}
+  {{- $smtpFrom = index $existing.data "smtp-from" | b64dec -}}
+{{- end -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $secretName }}
+  namespace: {{ $namespace }}
+  labels:
+    catalyst.openova.io/blueprint: bp-catalyst-platform
+    catalyst.openova.io/component: catalyst-api
+    app.kubernetes.io/part-of: catalyst
+  annotations:
+    # Survive helm uninstall — the Secret outlives the release. A
+    # subsequent helm install picks up the bytes via lookup against the
+    # source Secrets (and the persisted target if still present).
+    helm.sh/resource-policy: keep
+type: Opaque
+data:
+  kc-addr: {{ $kcAddr | b64enc | quote }}
+  kc-realm: {{ $kcRealm | b64enc | quote }}
+  kc-sa-client-id: {{ $kcClientID | b64enc | quote }}
+  kc-sa-client-secret: {{ $kcClientSecret | b64enc | quote }}
+  kc-audience: {{ $kcAudience | b64enc | quote }}
+  smtp-host: {{ $smtpHost | b64enc | quote }}
+  smtp-port: {{ $smtpPort | b64enc | quote }}
+  smtp-from: {{ $smtpFrom | b64enc | quote }}
+  smtp-user: {{ $smtpUser | b64enc | quote }}
+  smtp-pass: {{ $smtpPass | b64enc | quote }}
+{{- end }}

--- a/products/catalyst/chart/values.yaml
+++ b/products/catalyst/chart/values.yaml
@@ -14,6 +14,35 @@ global:
   # issue #827) when parentZones is empty (single-zone fallback).
   sovereignFQDN: ""
 
+# ─── Sovereign-side defaults (issue #901) ──────────────────────────────
+# Knobs that exclusively affect the franchised-Sovereign install path
+# and have no equivalent on Catalyst-Zero (contabo-mkt). Per-Sovereign
+# overlays may override every value here without forking the chart.
+sovereign:
+  # CATALYST_POST_AUTH_REDIRECT default. Browser is sent here after a
+  # successful PIN / magic-link callback. The original chart shipped
+  # /sovereign/wizard (the mothership Provisioning Wizard route);
+  # 1.4.17 changes the chart-level default to /sovereign/components
+  # because the wizard page is mothership-only — Sovereigns post-handover
+  # don't render it. The value at the top of the api-deployment.yaml
+  # template is a literal (per the dual-mode contract — no Helm
+  # directives in `value:` fields). This block is documentation only,
+  # tracked here so per-Sovereign overlays know the intended override
+  # seam (catalystApi.env additional-env patch).
+  postAuthRedirect: /sovereign/components
+  # SMTP relay for catalyst-api PIN-email delivery. Consumed by the
+  # auto-provisioned `catalyst-openova-kc-credentials` Secret (template
+  # at templates/catalyst-openova-kc-credentials-secret.yaml — issue
+  # #901). Defaults match the openova.io platform mail relay; per-
+  # Sovereign overlays MAY repoint at a Sovereign-local Stalwart
+  # instance once SMTP creds are reflected from cloud-init via the
+  # `catalyst-system/sovereign-smtp-credentials` Secret seam (issue
+  # #883, agent A5).
+  smtp:
+    host: mail.openova.io
+    port: "587"
+    from: noreply@openova.io
+
 # ─── Multi-zone parent domains (issue #827, parent epic #825) ──────────
 # A franchised Sovereign supports N parent zones, NOT one. The operator
 # brings 1+ parent domains at signup (`omani.works` for own use,


### PR DESCRIPTION
## Summary

Three-bug chain blocked `https://console.<sov-fqdn>/login` PIN-issue on every fresh Sovereign with HTTP 503 `"CATALYST_OPENOVA_KC_SA_CLIENT_SECRET not set"`. This PR fixes all three in one chart bump (1.4.16 → 1.4.17).

- **NEW** `templates/catalyst-openova-kc-credentials-secret.yaml` — auto-mirror `keycloak/catalyst-kc-sa-credentials` into `catalyst-system/catalyst-openova-kc-credentials` with the keys `api-deployment.yaml`'s PIN-auth env block expects. Sovereign-vs-contabo gate via `lookup` skip on contabo. Same persistence + `helm.sh/resource-policy: keep` pattern as `templates/marketplace-api/secret.yaml` (#887).
- SMTP host/port/from defaults now flow through `.Values.sovereign.smtp.*` (`mail.openova.io:587` / `noreply@openova.io`). user/pass mirrored from `catalyst-system/sovereign-smtp-credentials` (#883 seam) via secondary lookup.
- `CATALYST_POST_AUTH_REDIRECT` default flips from mothership-only `/sovereign/wizard` to `/sovereign/components` (post-handover Sovereign homepage). Literal value per dual-mode contract.

Lockstep slot pin `13-bp-catalyst-platform.yaml`: `1.4.16` → `1.4.17`.

Closes #901.

## Test plan

- [x] `helm lint products/catalyst/chart` clean
- [x] `helm template products/catalyst/chart` renders without error (lookup nil → new Secret template skips, contabo path unchanged)
- [ ] Post-merge: blueprint-release publishes 1.4.17 OCI artifact
- [ ] Force-push upstream main → otech103 local Gitea
- [ ] Reconcile cascade lands chart 1.4.17 on otech103
- [ ] Delete hot-fixed Secret on otech103 → chart recreates with correct addr (`http://keycloak.keycloak.svc.cluster.local`)
- [ ] `curl -X POST -H 'Content-Type: application/json' -d '{"email":"sales@openova.io"}' https://console.otech103.omani.works/api/v1/auth/pin/issue` returns `{"ok":true,...}` (200, not 503)

🤖 Generated with [Claude Code](https://claude.com/claude-code)