### PR TITLE
fix(pdm/dynadot): pre-register glue records before set_ns (#900)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -161,6 +161,17 @@ spec:
   values:
     global:
       sovereignFQDN: ${SOVEREIGN_FQDN}
+      # sovereignLBIP — Sovereign's load-balancer public IPv4. Issue #900:
+      # the Day-2 multi-domain add-domain flow uses this to pre-register
+      # glue records at the customer's registrar before flipping NS.
+      # Resolved via envsubst from `SOVEREIGN_LB_IP` set in the Sovereign
+      # cloud-init env (rendered into bootstrap-kit by infra/hetzner from
+      # hcloud_load_balancer.main.ipv4 — see infra/hetzner/main.tf:274).
+      # When the Sovereign cloud-init pre-dates #900 the env stays empty
+      # and the chart renders an empty `lbIP` ConfigMap key — catalyst-api
+      # then short-circuits the glue registration and falls back to plain
+      # set_ns (legacy behaviour).
+      sovereignLBIP: ${SOVEREIGN_LB_IP}
     ingress:
       hosts:
         console:

--- a/core/pool-domain-manager/internal/handler/registrar.go
+++ b/core/pool-domain-manager/internal/handler/registrar.go
@@ -146,10 +146,21 @@ func (h *Handler) Validate(w http.ResponseWriter, r *http.Request) {
 //
 // IMPORTANT: do NOT add struct tags that mark Token as loggable. The
 // handler intentionally avoids logging this struct directly.
+//
+// GlueIP is OPTIONAL. When supplied, and the chosen adapter implements
+// registrar.GlueRegistrar (today: Dynadot, per issue #900), the handler
+// pre-registers each NS hostname against the customer's account with
+// the supplied IPv4 BEFORE flipping the nameservers. This is what
+// unblocks the multi-domain Day-2 add-domain flow when the customer's
+// own domain is at Dynadot — Dynadot otherwise rejects set_ns with
+// "'ns1.<sov>.omani.works' needs to be registered with an ip address
+// before it can be used". Adapters that don't need glue ignore the
+// field; the call falls through to the existing SetNameservers path.
 type SetNSRequest struct {
 	Domain      string   `json:"domain"`
 	Token       string   `json:"token"`
 	Nameservers []string `json:"nameservers"`
+	GlueIP      string   `json:"glueIP,omitempty"`
 }
 
 // SetNSResponse is the JSON reply on success.
@@ -197,6 +208,7 @@ func (h *Handler) SetNS(w http.ResponseWriter, r *http.Request) {
 	domain := strings.ToLower(strings.TrimSpace(req.Domain))
 	token := req.Token // intentionally not normalised; some providers care
 	ns := normaliseNS(req.Nameservers)
+	glueIP := strings.TrimSpace(req.GlueIP)
 
 	if domain == "" {
 		writeJSON(w, http.StatusUnprocessableEntity, map[string]string{
@@ -234,7 +246,44 @@ func (h *Handler) SetNS(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// 2) Flip the nameservers.
+	// 2) Pre-register glue records for out-of-bailiwick NS hostnames
+	//    BEFORE the set_ns flip — issue #900. Only adapters that
+	//    implement registrar.GlueRegistrar participate (today: Dynadot);
+	//    others fall through. Skipped when glueIP is empty: BYO Flow A
+	//    customers (the Sovereign's primary domain) flip to NS hostnames
+	//    that already have glue baked in by Day-1 cloud-init via
+	//    AddNSDelegation, so re-registration is unnecessary.
+	if glueIP != "" {
+		if glueRegistrar, ok := adapter.(registrar.GlueRegistrar); ok {
+			for _, host := range ns {
+				// Only register hosts that look like child-of-
+				// customer-domain ↔ pool-domain NS records — i.e. NOT a
+				// child of the customer's domain (those are
+				// in-bailiwick and Dynadot resolves them via
+				// child-zone DNS, no registered-host required).
+				if isInBailiwick(host, domain) {
+					continue
+				}
+				if err := glueRegistrar.RegisterGlueRecord(ctx, token, host, glueIP); err != nil {
+					h.Log.Info("registrar set-ns: glue register failed",
+						"registrar", registrarName,
+						"domain", domain,
+						"host", host,
+						"outcome", classifyOutcome(err),
+					)
+					writeRegistrarErr(w, err, registrarName, domain)
+					return
+				}
+			}
+			h.Log.Info("registrar set-ns: glue registered",
+				"registrar", registrarName,
+				"domain", domain,
+				"hosts", len(ns),
+			)
+		}
+	}
+
+	// 3) Flip the nameservers.
 	if err := adapter.SetNameservers(ctx, token, domain, ns); err != nil {
 		h.Log.Info("registrar set-ns: write failed",
 			"registrar", registrarName,
@@ -245,7 +294,7 @@ func (h *Handler) SetNS(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// 3) Read back the nameservers as a confirmation. Failure here is
+	// 4) Read back the nameservers as a confirmation. Failure here is
 	//    NOT fatal — the write succeeded, the read might race against
 	//    propagation. We log and return whatever we have.
 	confirmed, readErr := adapter.GetNameservers(ctx, token, domain)
@@ -336,6 +385,26 @@ func writeRegistrarErr(w http.ResponseWriter, err error, registrarName, domain s
 			"domain":    domain,
 		})
 	}
+}
+
+// isInBailiwick reports whether nsHost is a child of zone (the customer-
+// owned domain whose NS we are flipping). Used to skip glue registration
+// for in-bailiwick NS hostnames (RFC 1034 §4.2.1) — those are resolved
+// by the customer's own DNS via the zone's child A records and do not
+// need an account-level "registered host" entry.
+//
+// Both arguments are case-insensitive; the function tolerates either
+// being supplied with or without a trailing dot.
+func isInBailiwick(nsHost, zone string) bool {
+	nsHost = strings.ToLower(strings.TrimSuffix(strings.TrimSpace(nsHost), "."))
+	zone = strings.ToLower(strings.TrimSuffix(strings.TrimSpace(zone), "."))
+	if nsHost == "" || zone == "" {
+		return false
+	}
+	if nsHost == zone {
+		return true
+	}
+	return strings.HasSuffix(nsHost, "."+zone)
 }
 
 // normaliseNS lowercases + trims each entry; drops empty strings and

--- a/core/pool-domain-manager/internal/handler/registrar_test.go
+++ b/core/pool-domain-manager/internal/handler/registrar_test.go
@@ -365,3 +365,198 @@ func TestSetNSResponseDoesNotEchoToken(t *testing.T) {
 		t.Fatalf("response body leaks token: %s", string(body))
 	}
 }
+
+// ── Glue-record path (issue #900) ───────────────────────────────────────
+//
+// fakeGlueAdapter extends fakeAdapter with the registrar.GlueRegistrar
+// surface. The HTTP handler's type-assertion on adapter.(GlueRegistrar)
+// MUST succeed for instances of this struct, exercising the SetNS code
+// path that pre-registers glue before the set_ns flip.
+type fakeGlueAdapter struct {
+	fakeAdapter
+	registerErr error
+	registered  []glueCall
+}
+
+type glueCall struct {
+	host string
+	ip   string
+}
+
+func (f *fakeGlueAdapter) RegisterGlueRecord(_ context.Context, _, host, ip string) error {
+	if f.registerErr != nil {
+		return f.registerErr
+	}
+	f.registered = append(f.registered, glueCall{host: host, ip: ip})
+	return nil
+}
+func (f *fakeGlueAdapter) GetGlueRecord(_ context.Context, _, host string) (string, error) {
+	for _, g := range f.registered {
+		if g.host == host {
+			return g.ip, nil
+		}
+	}
+	return "", nil
+}
+
+func newGlueTestHandler(t *testing.T, adapter *fakeGlueAdapter) *Handler {
+	t.Helper()
+	log, _ := captureLogger()
+	h := &Handler{Log: log}
+	h.SetRegistry(registrar.Registry{adapter.name: adapter})
+	return h
+}
+
+// TestSetNSGluePreRegistersBeforeFlip — when the request body carries a
+// non-empty glueIP and the adapter implements GlueRegistrar, the
+// handler MUST call RegisterGlueRecord for each NS hostname BEFORE
+// invoking SetNameservers. Verifies the canonical issue #900 unblock
+// path: register first, flip second.
+func TestSetNSGluePreRegistersBeforeFlip(t *testing.T) {
+	a := &fakeGlueAdapter{fakeAdapter: fakeAdapter{name: "dynadot"}}
+	h := newGlueTestHandler(t, a)
+	body := `{
+	  "domain":"customer-acme.tld",
+	  "token":"` + supersecretToken + `",
+	  "nameservers":["ns1.otech103.omani.works","ns2.otech103.omani.works"],
+	  "glueIP":"203.0.113.42"
+	}`
+	rec := doSetNS(t, h, "dynadot", body)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	if len(a.registered) != 2 {
+		t.Fatalf("expected 2 glue registrations (one per NS), got %d (%+v)", len(a.registered), a.registered)
+	}
+	for i, exp := range []glueCall{
+		{"ns1.otech103.omani.works", "203.0.113.42"},
+		{"ns2.otech103.omani.works", "203.0.113.42"},
+	} {
+		if a.registered[i] != exp {
+			t.Errorf("registration[%d] = %+v, want %+v", i, a.registered[i], exp)
+		}
+	}
+}
+
+// TestSetNSGlueRegisterFails — when RegisterGlueRecord returns a typed
+// registrar error, the handler MUST surface the same status code as a
+// SetNameservers failure (e.g. 401 for ErrInvalidToken) and MUST NOT
+// proceed to set_ns. Verifies the fail-fast contract — a failed glue
+// pre-step never leaves the customer's NS in an intermediate state.
+func TestSetNSGlueRegisterFails(t *testing.T) {
+	a := &fakeGlueAdapter{
+		fakeAdapter: fakeAdapter{name: "dynadot"},
+		registerErr: registrar.ErrInvalidToken,
+	}
+	h := newGlueTestHandler(t, a)
+	body := `{
+	  "domain":"customer-acme.tld",
+	  "token":"t",
+	  "nameservers":["ns1.otech103.omani.works"],
+	  "glueIP":"203.0.113.42"
+	}`
+	rec := doSetNS(t, h, "dynadot", body)
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d body=%s, want 401 (ErrInvalidToken passthrough)", rec.Code, rec.Body.String())
+	}
+	// SetNameservers MUST NOT have been called — gotNS is still the
+	// fakeAdapter zero-value (nil), proving the flip was skipped.
+	if a.gotNS != nil {
+		t.Errorf("SetNameservers was called despite glue register failure; gotNS=%+v", a.gotNS)
+	}
+}
+
+// TestSetNSGlueSkipsInBailiwick — when an NS hostname IS a child of the
+// customer's own domain, glue pre-registration is a no-op (the customer
+// resolves it via their zone's own A records). The handler MUST skip
+// RegisterGlueRecord for that host, and call it only for out-of-bailiwick
+// hosts.
+func TestSetNSGlueSkipsInBailiwick(t *testing.T) {
+	a := &fakeGlueAdapter{fakeAdapter: fakeAdapter{name: "dynadot"}}
+	h := newGlueTestHandler(t, a)
+	// First NS is in-bailiwick (child of customer-acme.tld);
+	// second NS is out-of-bailiwick (omani.works subzone).
+	body := `{
+	  "domain":"customer-acme.tld",
+	  "token":"t",
+	  "nameservers":["ns.customer-acme.tld","ns1.otech103.omani.works"],
+	  "glueIP":"203.0.113.42"
+	}`
+	rec := doSetNS(t, h, "dynadot", body)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	if len(a.registered) != 1 {
+		t.Fatalf("expected 1 glue registration (out-of-bailiwick only), got %d (%+v)", len(a.registered), a.registered)
+	}
+	if a.registered[0].host != "ns1.otech103.omani.works" {
+		t.Errorf("registered host = %q, want ns1.otech103.omani.works (in-bailiwick should be skipped)", a.registered[0].host)
+	}
+}
+
+// TestSetNSGlueOmittedSkipsRegister — when the request body has NO
+// glueIP field, the handler MUST NOT touch RegisterGlueRecord even
+// when the adapter implements GlueRegistrar. Backward-compat: existing
+// pdmFlipNS callers that pre-date #900 keep working unchanged.
+func TestSetNSGlueOmittedSkipsRegister(t *testing.T) {
+	a := &fakeGlueAdapter{fakeAdapter: fakeAdapter{name: "dynadot"}}
+	h := newGlueTestHandler(t, a)
+	body := `{
+	  "domain":"customer-acme.tld",
+	  "token":"t",
+	  "nameservers":["ns1.otech103.omani.works","ns2.otech103.omani.works"]
+	}`
+	rec := doSetNS(t, h, "dynadot", body)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	if len(a.registered) != 0 {
+		t.Errorf("expected no glue registrations when glueIP omitted, got %d", len(a.registered))
+	}
+}
+
+// TestSetNSGlueIgnoredForNonGlueAdapter — when the adapter does NOT
+// implement GlueRegistrar (cloudflare/godaddy/etc), the handler MUST
+// skip the glue path entirely even if glueIP is supplied. The set_ns
+// flow proceeds as normal.
+func TestSetNSGlueIgnoredForNonGlueAdapter(t *testing.T) {
+	// Plain fakeAdapter does NOT embed glue methods.
+	a := &fakeAdapter{name: "cloudflare"}
+	h, _ := newTestHandler(t, a)
+	body := `{
+	  "domain":"customer-acme.tld",
+	  "token":"t",
+	  "nameservers":["ns1.otech103.omani.works"],
+	  "glueIP":"203.0.113.42"
+	}`
+	rec := doSetNS(t, h, "cloudflare", body)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+// TestIsInBailiwick — pure unit coverage for the in-/out-of-bailiwick
+// classifier the SetNS handler uses to skip glue registration for NS
+// hostnames that the customer's own DNS resolves.
+func TestIsInBailiwick(t *testing.T) {
+	cases := []struct {
+		nsHost, zone string
+		want         bool
+	}{
+		{"ns.customer-acme.tld", "customer-acme.tld", true},
+		{"ns1.sub.customer-acme.tld", "customer-acme.tld", true},
+		{"customer-acme.tld", "customer-acme.tld", true},
+		{"ns1.otech103.omani.works", "customer-acme.tld", false},
+		{"NS1.OTECH103.omani.works", "customer-acme.tld", false},
+		{"ns.customer-acme.tld.", "customer-acme.tld.", true},
+		{"", "customer-acme.tld", false},
+		{"ns.x.com", "", false},
+		{"customer-acme.tld.evil.com", "customer-acme.tld", false},
+	}
+	for _, tc := range cases {
+		got := isInBailiwick(tc.nsHost, tc.zone)
+		if got != tc.want {
+			t.Errorf("isInBailiwick(%q, %q) = %v, want %v", tc.nsHost, tc.zone, got, tc.want)
+		}
+	}
+}

--- a/core/pool-domain-manager/internal/registrar/dynadot/dynadot.go
+++ b/core/pool-domain-manager/internal/registrar/dynadot/dynadot.go
@@ -16,6 +16,31 @@
 // supplied (apiKey, apiSecret) pair. Token format: "<apiKey>:<apiSecret>".
 //
 // Reference: https://www.dynadot.com/domain/api3.html#set_ns
+//
+// ── Glue records (issue #900) ──────────────────────────────────────────
+//
+// Dynadot rejects set_ns calls when the supplied NS hostnames are NOT
+// registered as "host records" against the customer's Dynadot account:
+//
+//	{"SetNsResponse":{"ResponseCode":"-1","Status":"error",
+//	 "Error":"'ns1.otech103.omani.works' needs to be registered with an
+//	  ip address before it can be used."}}
+//
+// This is Dynadot's "registered nameserver" feature — the customer's
+// account must know the IPv4 of every external NS host before it can
+// reference them in set_ns. The fix: BEFORE set_ns, register every
+// out-of-bailiwick NS (one whose suffix is NOT the customer-owned
+// domain) via the `register_ns` command using the customer's token. The
+// flow is idempotent: get_ns first → register_ns only when missing or
+// the IP differs (set_ns_ip when it differs).
+//
+// The glue-record path is invoked when SetNameservers receives a
+// non-empty `glueIP` argument — the upstream caller (catalyst-api's
+// pdmFlipNS, PDM's HTTP /set-ns handler) supplies the Sovereign's
+// load-balancer IPv4 from `SOVEREIGN_LB_IP`/the deployment record so
+// the registration uses ground-truth state, never a hardcoded value.
+// Adapters whose providers do not require pre-registration can keep
+// SetNameservers (no-glueIP) — see the GlueRegistrar interface below.
 package dynadot
 
 import (
@@ -238,5 +263,171 @@ func (a *Adapter) do(ctx context.Context, params url.Values) ([]byte, error) {
 	return body, nil
 }
 
-// compile-time guard.
+// GetGlueRecord reads the currently-registered IPv4 for the given host
+// via Dynadot's `get_ns` command. Returns ("", nil) when Dynadot reports
+// the host is not registered (the canonical "needs to be registered"
+// signal); a non-nil error for any other API/HTTP failure.
+//
+// The customer's (key, secret) pair authenticates the call — Dynadot's
+// `register_ns`/`get_ns`/`set_ns_ip` commands are account-scoped, so the
+// host appears registered on the customer's account once we've called
+// register_ns with their token. This is what unblocks the subsequent
+// set_ns: the customer's account knows the NS hostname's IP.
+//
+// Per docs/INVIOLABLE-PRINCIPLES.md #10 the host string is intentionally
+// not embedded in any error message that propagates outside this package
+// without first going through classifyDynadotError so token-bearing
+// Dynadot error strings can't echo into logs.
+func (a *Adapter) GetGlueRecord(ctx context.Context, token, host string) (string, error) {
+	host = strings.ToLower(strings.TrimSpace(host))
+	if host == "" {
+		return "", fmt.Errorf("dynadot: host is required")
+	}
+	key, secret, err := parseToken(token)
+	if err != nil {
+		return "", err
+	}
+	params := url.Values{}
+	params.Set("key", key)
+	params.Set("secret", secret)
+	params.Set("command", "get_ns")
+	params.Set("ns", host)
+
+	body, err := a.do(ctx, params)
+	if err != nil {
+		return "", err
+	}
+	// Dynadot's get_ns response shape:
+	//   {"GetNsResponse":{"ResponseHeader":{...},
+	//    "NsInfo":{"NameServer":{"Host":"...","IP":["..."]}}}}
+	// On a host that is NOT registered, ResponseHeader.Status="error"
+	// with a "not found"-style message — we surface that as ("", nil)
+	// so callers can distinguish "missing" from "API failed".
+	var raw struct {
+		GetNsResponse struct {
+			ResponseHeader respHeader `json:"ResponseHeader"`
+			NsInfo         struct {
+				NameServer struct {
+					Host string   `json:"Host"`
+					IP   []string `json:"IP"`
+				} `json:"NameServer"`
+			} `json:"NsInfo"`
+		} `json:"GetNsResponse"`
+	}
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return "", fmt.Errorf("dynadot: parse get_ns: %w", err)
+	}
+	hdr := raw.GetNsResponse.ResponseHeader
+	if !strings.EqualFold(hdr.Status, "success") && hdr.ResponseCode != "0" {
+		// "not registered" / "not found" → ("", nil). Anything else is a
+		// real error (auth, rate-limit, API down, ...).
+		msg := strings.ToLower(hdr.Error)
+		if strings.Contains(msg, "not found") ||
+			strings.Contains(msg, "not register") ||
+			strings.Contains(msg, "no such") ||
+			strings.Contains(msg, "does not exist") {
+			return "", nil
+		}
+		return "", classifyDynadotError(hdr)
+	}
+	for _, ip := range raw.GetNsResponse.NsInfo.NameServer.IP {
+		if ip = strings.TrimSpace(ip); ip != "" {
+			return ip, nil
+		}
+	}
+	return "", nil
+}
+
+// RegisterGlueRecord registers `host` with the supplied `ip` against the
+// customer's Dynadot account so subsequent set_ns calls referencing
+// `host` succeed. Idempotent — a host already registered with the same
+// IP is a no-op; one registered with a different IP is updated in place
+// via `set_ns_ip`. The customer's token authenticates every call.
+//
+// Implementation:
+//
+//  1. GetGlueRecord(host) — short-circuit on identical IP.
+//  2. If host exists with a DIFFERENT IP → set_ns_ip(host, ip).
+//  3. If host does not exist → register_ns(host, ip).
+//
+// Per docs/INVIOLABLE-PRINCIPLES.md #2 the function returns typed
+// registrar errors (ErrInvalidToken, ErrRateLimited, ...) so the HTTP
+// handler can map them to the same status codes as SetNameservers.
+func (a *Adapter) RegisterGlueRecord(ctx context.Context, token, host, ip string) error {
+	host = strings.ToLower(strings.TrimSpace(host))
+	ip = strings.TrimSpace(ip)
+	if host == "" {
+		return fmt.Errorf("dynadot: host is required")
+	}
+	if ip == "" {
+		return fmt.Errorf("dynadot: ip is required")
+	}
+
+	// 1. Idempotency probe.
+	currentIP, err := a.GetGlueRecord(ctx, token, host)
+	if err != nil {
+		return fmt.Errorf("dynadot: probe glue record: %w", err)
+	}
+
+	// 2. Short-circuit when the host is already registered with the
+	//    same IP — a re-run of SetNameservers must not cost an extra
+	//    write at the registrar's billed-API tier.
+	if currentIP == ip {
+		return nil
+	}
+
+	key, secret, err := parseToken(token)
+	if err != nil {
+		return err
+	}
+
+	// 3. Update-in-place when host is registered but with a stale IP.
+	if currentIP != "" {
+		params := url.Values{}
+		params.Set("key", key)
+		params.Set("secret", secret)
+		params.Set("command", "set_ns_ip")
+		params.Set("ns", host)
+		params.Set("ip0", ip)
+
+		body, err := a.do(ctx, params)
+		if err != nil {
+			return err
+		}
+		var raw struct {
+			SetNsIpResponse struct {
+				ResponseHeader respHeader `json:"ResponseHeader"`
+			} `json:"SetNsIpResponse"`
+		}
+		if err := json.Unmarshal(body, &raw); err != nil {
+			return fmt.Errorf("dynadot: parse set_ns_ip: %w", err)
+		}
+		return classifyDynadotError(raw.SetNsIpResponse.ResponseHeader)
+	}
+
+	// 4. First-time registration.
+	params := url.Values{}
+	params.Set("key", key)
+	params.Set("secret", secret)
+	params.Set("command", "register_ns")
+	params.Set("ns", host)
+	params.Set("ip0", ip)
+
+	body, err := a.do(ctx, params)
+	if err != nil {
+		return err
+	}
+	var raw struct {
+		RegisterNsResponse struct {
+			ResponseHeader respHeader `json:"ResponseHeader"`
+		} `json:"RegisterNsResponse"`
+	}
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return fmt.Errorf("dynadot: parse register_ns: %w", err)
+	}
+	return classifyDynadotError(raw.RegisterNsResponse.ResponseHeader)
+}
+
+// compile-time guards.
 var _ registrar.Registrar = (*Adapter)(nil)
+var _ registrar.GlueRegistrar = (*Adapter)(nil)

--- a/core/pool-domain-manager/internal/registrar/dynadot/dynadot_test.go
+++ b/core/pool-domain-manager/internal/registrar/dynadot/dynadot_test.go
@@ -158,3 +158,256 @@ func TestNewAdapterDefaults(t *testing.T) {
 		t.Fatalf("expected defaults")
 	}
 }
+
+// ── Glue-record path (issue #900) ───────────────────────────────────────
+//
+// These tests cover the new register_ns / get_ns / set_ns_ip surface the
+// adapter exposes via the registrar.GlueRegistrar interface. Each test
+// drives the adapter against an httptest server that asserts the
+// expected Dynadot api3.json command + parameters and replies with a
+// canned api3.json response.
+//
+// The flow under test:
+//
+//   1. GetGlueRecord — probes the host via `command=get_ns` and returns
+//      the registered IPv4 (or "" + nil for "not registered").
+//   2. RegisterGlueRecord — idempotency-aware: short-circuits on same
+//      IP, falls through to set_ns_ip on different IP, register_ns when
+//      not yet registered.
+
+// TestGetGlueRecordHappy — Dynadot returns the registered IP for a
+// known host. Must be returned as the first non-empty entry of the IP
+// array (Dynadot's get_ns response carries IP as a list).
+func TestGetGlueRecordHappy(t *testing.T) {
+	a, _ := newTestAdapter(t, func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Query().Get("command"); got != "get_ns" {
+			t.Errorf("command = %q, want get_ns", got)
+		}
+		if got := r.URL.Query().Get("ns"); got != "ns1.otech103.omani.works" {
+			t.Errorf("ns = %q, want ns1.otech103.omani.works", got)
+		}
+		fmt.Fprintln(w, `{
+		  "GetNsResponse": {
+		    "ResponseHeader": {"ResponseCode":"0","Status":"success"},
+		    "NsInfo": {"NameServer": {"Host":"ns1.otech103.omani.works", "IP":["203.0.113.42"]}}
+		  }
+		}`)
+	})
+	got, err := a.GetGlueRecord(context.Background(), "k:s", "ns1.otech103.omani.works")
+	if err != nil {
+		t.Fatalf("GetGlueRecord err = %v", err)
+	}
+	if got != "203.0.113.42" {
+		t.Fatalf("ip = %q, want 203.0.113.42", got)
+	}
+}
+
+// TestGetGlueRecordNotRegistered — Dynadot returns an error envelope
+// with a "not found"/"not registered" error string. Adapter must
+// translate that into ("", nil) so callers can distinguish "missing"
+// from "API failed".
+func TestGetGlueRecordNotRegistered(t *testing.T) {
+	a, _ := newTestAdapter(t, func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, `{
+		  "GetNsResponse": {"ResponseHeader": {"ResponseCode":"-1","Status":"error","Error":"Name server not found"}}
+		}`)
+	})
+	got, err := a.GetGlueRecord(context.Background(), "k:s", "ns1.otech999.omani.works")
+	if err != nil {
+		t.Fatalf("expected nil err for not-registered, got %v", err)
+	}
+	if got != "" {
+		t.Fatalf("expected empty ip for not-registered, got %q", got)
+	}
+}
+
+// TestGetGlueRecordRateLimited — typed registrar.ErrRateLimited
+// passes through GetGlueRecord so the HTTP handler can map to 429.
+func TestGetGlueRecordRateLimited(t *testing.T) {
+	a, _ := newTestAdapter(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+	})
+	_, err := a.GetGlueRecord(context.Background(), "k:s", "ns1.otech103.omani.works")
+	if !errors.Is(err, registrar.ErrRateLimited) {
+		t.Fatalf("err = %v, want ErrRateLimited", err)
+	}
+}
+
+// TestRegisterGlueRecordFreshHost — the host is not registered; adapter
+// runs get_ns (returns not-found), then register_ns with the supplied IP.
+func TestRegisterGlueRecordFreshHost(t *testing.T) {
+	calls := 0
+	a, _ := newTestAdapter(t, func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		cmd := r.URL.Query().Get("command")
+		switch calls {
+		case 1:
+			// Probe — not registered.
+			if cmd != "get_ns" {
+				t.Errorf("call 1: command = %q, want get_ns", cmd)
+			}
+			fmt.Fprintln(w, `{"GetNsResponse":{"ResponseHeader":{"ResponseCode":"-1","Status":"error","Error":"Name server not found"}}}`)
+		case 2:
+			// Register with the supplied IP.
+			if cmd != "register_ns" {
+				t.Errorf("call 2: command = %q, want register_ns", cmd)
+			}
+			if got := r.URL.Query().Get("ns"); got != "ns1.otech103.omani.works" {
+				t.Errorf("ns = %q", got)
+			}
+			if got := r.URL.Query().Get("ip0"); got != "203.0.113.42" {
+				t.Errorf("ip0 = %q, want 203.0.113.42", got)
+			}
+			fmt.Fprintln(w, `{"RegisterNsResponse":{"ResponseHeader":{"ResponseCode":"0","Status":"success"}}}`)
+		default:
+			t.Errorf("unexpected call %d (cmd=%s)", calls, cmd)
+		}
+	})
+	if err := a.RegisterGlueRecord(context.Background(), "k:s", "ns1.otech103.omani.works", "203.0.113.42"); err != nil {
+		t.Fatalf("RegisterGlueRecord err = %v", err)
+	}
+	if calls != 2 {
+		t.Fatalf("expected 2 api calls (get_ns + register_ns), got %d", calls)
+	}
+}
+
+// TestRegisterGlueRecordIdempotent — the host is already registered
+// with the same IP. Adapter MUST short-circuit after the get_ns probe
+// (no register_ns / set_ns_ip call). This is the property that makes
+// SetNameservers retries safe at billed-API tiers.
+func TestRegisterGlueRecordIdempotent(t *testing.T) {
+	calls := 0
+	a, _ := newTestAdapter(t, func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		cmd := r.URL.Query().Get("command")
+		if calls > 1 {
+			t.Errorf("expected exactly 1 api call (get_ns), got call %d (cmd=%s)", calls, cmd)
+		}
+		if cmd != "get_ns" {
+			t.Errorf("command = %q, want get_ns", cmd)
+		}
+		fmt.Fprintln(w, `{
+		  "GetNsResponse": {
+		    "ResponseHeader": {"ResponseCode":"0","Status":"success"},
+		    "NsInfo": {"NameServer": {"Host":"ns1.otech103.omani.works", "IP":["203.0.113.42"]}}
+		  }
+		}`)
+	})
+	if err := a.RegisterGlueRecord(context.Background(), "k:s", "ns1.otech103.omani.works", "203.0.113.42"); err != nil {
+		t.Fatalf("RegisterGlueRecord err = %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("expected 1 api call (idempotent short-circuit), got %d", calls)
+	}
+}
+
+// TestRegisterGlueRecordIPChanged — the host is already registered but
+// with a stale IP. Adapter MUST take the set_ns_ip update-in-place path
+// (NOT register_ns, which Dynadot rejects when the host already exists).
+func TestRegisterGlueRecordIPChanged(t *testing.T) {
+	calls := 0
+	a, _ := newTestAdapter(t, func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		cmd := r.URL.Query().Get("command")
+		switch calls {
+		case 1:
+			if cmd != "get_ns" {
+				t.Errorf("call 1: command = %q, want get_ns", cmd)
+			}
+			fmt.Fprintln(w, `{
+			  "GetNsResponse": {
+			    "ResponseHeader": {"ResponseCode":"0","Status":"success"},
+			    "NsInfo": {"NameServer": {"Host":"ns1.otech103.omani.works", "IP":["198.51.100.7"]}}
+			  }
+			}`)
+		case 2:
+			if cmd != "set_ns_ip" {
+				t.Errorf("call 2: command = %q, want set_ns_ip", cmd)
+			}
+			if got := r.URL.Query().Get("ns"); got != "ns1.otech103.omani.works" {
+				t.Errorf("ns = %q", got)
+			}
+			if got := r.URL.Query().Get("ip0"); got != "203.0.113.42" {
+				t.Errorf("ip0 = %q, want 203.0.113.42", got)
+			}
+			fmt.Fprintln(w, `{"SetNsIpResponse":{"ResponseHeader":{"ResponseCode":"0","Status":"success"}}}`)
+		default:
+			t.Errorf("unexpected call %d (cmd=%s)", calls, cmd)
+		}
+	})
+	if err := a.RegisterGlueRecord(context.Background(), "k:s", "ns1.otech103.omani.works", "203.0.113.42"); err != nil {
+		t.Fatalf("RegisterGlueRecord err = %v", err)
+	}
+	if calls != 2 {
+		t.Fatalf("expected 2 api calls (get_ns + set_ns_ip), got %d", calls)
+	}
+}
+
+// TestRegisterGlueRecordRateLimitedDuringRegister — the get_ns probe
+// succeeds (host not registered), but the subsequent register_ns
+// returns a 429. The typed error must surface so the HTTP handler can
+// map to a 429 response — same behaviour as set_ns rate-limit handling.
+func TestRegisterGlueRecordRateLimitedDuringRegister(t *testing.T) {
+	calls := 0
+	a, _ := newTestAdapter(t, func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		cmd := r.URL.Query().Get("command")
+		switch calls {
+		case 1:
+			if cmd != "get_ns" {
+				t.Errorf("call 1: command = %q, want get_ns", cmd)
+			}
+			fmt.Fprintln(w, `{"GetNsResponse":{"ResponseHeader":{"ResponseCode":"-1","Status":"error","Error":"Name server not found"}}}`)
+		case 2:
+			if cmd != "register_ns" {
+				t.Errorf("call 2: command = %q, want register_ns", cmd)
+			}
+			w.WriteHeader(http.StatusTooManyRequests)
+		default:
+			t.Errorf("unexpected call %d (cmd=%s)", calls, cmd)
+		}
+	})
+	err := a.RegisterGlueRecord(context.Background(), "k:s", "ns1.otech103.omani.works", "203.0.113.42")
+	if !errors.Is(err, registrar.ErrRateLimited) {
+		t.Fatalf("err = %v, want ErrRateLimited", err)
+	}
+}
+
+// TestRegisterGlueRecordValidation — empty host or empty IP both fail
+// fast without a network call. Hardens against silently-bad input from
+// the HTTP handler / wizard layer.
+func TestRegisterGlueRecordValidation(t *testing.T) {
+	a := New()
+	if err := a.RegisterGlueRecord(context.Background(), "k:s", "", "1.2.3.4"); err == nil {
+		t.Fatal("expected error for empty host")
+	}
+	if err := a.RegisterGlueRecord(context.Background(), "k:s", "ns1.x", ""); err == nil {
+		t.Fatal("expected error for empty ip")
+	}
+}
+
+// TestRegisterGlueRecordBadToken — token-shape parse must fail before
+// any network call. Mirrors the existing TestValidateTokenBadFormat.
+func TestRegisterGlueRecordBadToken(t *testing.T) {
+	a, _ := newTestAdapter(t, func(w http.ResponseWriter, r *http.Request) {
+		// get_ns probe is allowed (returns not-found) BEFORE the token
+		// parse for the set_ns_ip / register_ns path.
+		fmt.Fprintln(w, `{"GetNsResponse":{"ResponseHeader":{"ResponseCode":"-1","Status":"error","Error":"Name server not found"}}}`)
+	})
+	err := a.RegisterGlueRecord(context.Background(), "no-colon", "ns1.x.com", "1.2.3.4")
+	if !errors.Is(err, registrar.ErrInvalidToken) {
+		t.Fatalf("err = %v, want ErrInvalidToken", err)
+	}
+}
+
+// TestAdapterImplementsGlueRegistrar — compile-time guard that the
+// adapter satisfies the optional registrar.GlueRegistrar interface.
+// The HTTP handler relies on this via type-assertion (see
+// handler/registrar.go SetNS), so a future refactor that drops a
+// method must fail here, not silently bypass the glue path live.
+func TestAdapterImplementsGlueRegistrar(t *testing.T) {
+	var _ registrar.GlueRegistrar = (*Adapter)(nil)
+	if _, ok := any(New()).(registrar.GlueRegistrar); !ok {
+		t.Fatal("New() does not implement registrar.GlueRegistrar")
+	}
+}

--- a/core/pool-domain-manager/internal/registrar/registrar.go
+++ b/core/pool-domain-manager/internal/registrar/registrar.go
@@ -69,6 +69,48 @@ type Registrar interface {
 	GetNameservers(ctx context.Context, token, domain string) ([]string, error)
 }
 
+// GlueRegistrar is implemented by adapters whose registrar requires
+// out-of-bailiwick NS hostnames to be PRE-registered as account-level
+// "host records" before they can be referenced in a SetNameservers
+// call. Dynadot is the canonical example (issue #900): a set_ns call
+// pointing customer.tld at ns1.<sovereign>.omani.works fails with
+//
+//	"'ns1.<sovereign>.omani.works' needs to be registered with an ip
+//	 address before it can be used"
+//
+// unless the customer's account first runs the equivalent of:
+//
+//	register_ns(host="ns1.<sovereign>.omani.works", ip=<lbIP>)
+//
+// Adapters whose providers do NOT require this (Cloudflare, GoDaddy,
+// Namecheap, OVH all accept arbitrary NS hostnames in their set-ns
+// commands without an account-level "registered host" step) deliberately
+// do not implement this interface; the HTTP handler falls back to plain
+// SetNameservers for them. This keeps the common Registrar surface
+// minimal — only Dynadot pays the extra round-trip per NS hostname.
+//
+// Method semantics:
+//
+//   - RegisterGlueRecord(ctx, token, host, ip): register a glue record
+//     mapping `host` (an FQDN, e.g. "ns1.otech103.omani.works") to
+//     `ip` (an IPv4 string). MUST be idempotent — implementations
+//     short-circuit when the host is already registered with the same
+//     IP, and update the IP in place (e.g. via Dynadot's `set_ns_ip`
+//     command) when the host exists but the IP differs. This means a
+//     SetNameservers retry after a transient failure does not produce
+//     duplicate registrations or cost extra registrar API quota.
+//
+//   - GetGlueRecord(ctx, token, host): read the currently registered
+//     IPv4 for `host`, or ("", nil) when the host is not registered.
+//     Used by callers (and the adapter itself) for the idempotency
+//     check above. Errors are returned untouched so the caller can
+//     distinguish "not registered" (empty string, no error) from
+//     "API failed" (any non-nil error).
+type GlueRegistrar interface {
+	RegisterGlueRecord(ctx context.Context, token, host, ip string) error
+	GetGlueRecord(ctx context.Context, token, host string) (string, error)
+}
+
 // Typed errors that adapters return so HTTP handlers can map to status
 // codes without string matching.
 //

--- a/infra/hetzner/cloudinit-control-plane.tftpl
+++ b/infra/hetzner/cloudinit-control-plane.tftpl
@@ -866,6 +866,13 @@ write_files:
         postBuild:
           substitute:
             SOVEREIGN_FQDN: ${sovereign_fqdn}
+            # SOVEREIGN_LB_IP — Hetzner load balancer's public IPv4 (issue
+            # #900). Threaded into bp-catalyst-platform's
+            # `global.sovereignLBIP` so catalyst-api can pre-register glue
+            # records at the customer's Dynadot account before flipping NS
+            # for Day-2 multi-domain adds. Sourced from
+            # hcloud_load_balancer.main.ipv4 in main.tf.
+            SOVEREIGN_LB_IP: ${load_balancer_ipv4}
             # Marketplace mode toggle (issue #710). Default "false" so a
             # zero-touch provision lands a non-marketplace Sovereign. The
             # operator (or the wizard's "Enable Marketplace" component
@@ -913,6 +920,13 @@ write_files:
         postBuild:
           substitute:
             SOVEREIGN_FQDN: ${sovereign_fqdn}
+            # SOVEREIGN_LB_IP — Hetzner load balancer's public IPv4 (issue
+            # #900). Threaded into bp-catalyst-platform's
+            # `global.sovereignLBIP` so catalyst-api can pre-register glue
+            # records at the customer's Dynadot account before flipping NS
+            # for Day-2 multi-domain adds. Sourced from
+            # hcloud_load_balancer.main.ipv4 in main.tf.
+            SOVEREIGN_LB_IP: ${load_balancer_ipv4}
             # Marketplace mode toggle (issue #710). Default "false" so a
             # zero-touch provision lands a non-marketplace Sovereign. The
             # operator (or the wizard's "Enable Marketplace" component
@@ -950,6 +964,13 @@ write_files:
         postBuild:
           substitute:
             SOVEREIGN_FQDN: ${sovereign_fqdn}
+            # SOVEREIGN_LB_IP — Hetzner load balancer's public IPv4 (issue
+            # #900). Threaded into bp-catalyst-platform's
+            # `global.sovereignLBIP` so catalyst-api can pre-register glue
+            # records at the customer's Dynadot account before flipping NS
+            # for Day-2 multi-domain adds. Sourced from
+            # hcloud_load_balancer.main.ipv4 in main.tf.
+            SOVEREIGN_LB_IP: ${load_balancer_ipv4}
             # Marketplace mode toggle (issue #710). Default "false" so a
             # zero-touch provision lands a non-marketplace Sovereign. The
             # operator (or the wizard's "Enable Marketplace" component

--- a/products/catalyst/bootstrap/api/internal/handler/parent_domains.go
+++ b/products/catalyst/bootstrap/api/internal/handler/parent_domains.go
@@ -933,11 +933,31 @@ func (h *Handler) pdmFlipNS(ctx context.Context, registrarKind, domain, token st
 	if len(nameservers) == 0 {
 		return fmt.Errorf("expected-ns-unavailable: cannot compute nameservers (primary domain unknown)")
 	}
-	body, _ := json.Marshal(map[string]any{
+	// glueIP — Sovereign's load-balancer public IPv4 (issue #900). When
+	// non-empty PDM pre-registers each NS hostname against the customer's
+	// account before the set_ns flip, unblocking Dynadot's "needs to be
+	// registered with an ip address" rejection. Source order:
+	//
+	//   1. SOVEREIGN_LB_IP env var (api-deployment.yaml mounts this from
+	//      the sovereign-fqdn ConfigMap key `lbIP`, which the chart
+	//      renders from `global.sovereignLBIP`).
+	//   2. The adopted Deployment's Result.LoadBalancerIP (when running
+	//      on Catalyst-Zero / contabo where SOVEREIGN_LB_IP is empty
+	//      but a deployment record exists with the result captured).
+	//   3. Empty — non-Dynadot adapters ignore the field; Dynadot
+	//      adapter falls through and set_ns runs as-is. This preserves
+	//      backward compat with pre-#900 deployments while making the
+	//      glue path the default on Sovereigns.
+	glueIP := h.lookupSovereignLBIP()
+	payload := map[string]any{
 		"domain":      domain,
 		"token":       token,
 		"nameservers": nameservers,
-	})
+	}
+	if glueIP != "" {
+		payload["glueIP"] = glueIP
+	}
+	body, _ := json.Marshal(payload)
 	target := fmt.Sprintf("%s/api/v1/registrar/%s/set-ns",
 		strings.TrimRight(pdmBase, "/"),
 		strings.ToLower(registrarKind),
@@ -965,6 +985,49 @@ func (h *Handler) pdmFlipNS(ctx context.Context, registrarKind, domain, token st
 		return fmt.Errorf("pdm-status-%d: %s", resp.StatusCode, strings.TrimSpace(string(respBody)))
 	}
 	return nil
+}
+
+// lookupSovereignLBIP resolves the Sovereign's load-balancer public
+// IPv4 for the multi-domain Day-2 add-domain flow's glue-record
+// pre-registration step (issue #900). Source order:
+//
+//  1. SOVEREIGN_LB_IP env var — wired on Sovereign Pods from the
+//     `sovereign-fqdn` ConfigMap key `lbIP` (chart renders from
+//     `global.sovereignLBIP`). This is the post-handover canonical
+//     source.
+//  2. Any adopted deployment's Result.LoadBalancerIP — covers the
+//     Catalyst-Zero (contabo) path where SOVEREIGN_LB_IP is unset
+//     but a finalised deployment record exists with the LB captured.
+//  3. "" — no Sovereign LB IP available. Day-2 add-domain still
+//     proceeds (legacy plain set_ns); Dynadot will reject only if
+//     the host hasn't been registered manually first.
+//
+// Per docs/INVIOLABLE-PRINCIPLES.md #4 the env var name is the only
+// runtime-configurable knob; nothing about the IP itself is hardcoded.
+func (h *Handler) lookupSovereignLBIP() string {
+	if v := strings.TrimSpace(os.Getenv("SOVEREIGN_LB_IP")); v != "" {
+		return v
+	}
+	var picked string
+	h.deployments.Range(func(_, v any) bool {
+		dep, ok := v.(*Deployment)
+		if !ok {
+			return true
+		}
+		dep.mu.Lock()
+		adopted := dep.AdoptedAt != nil
+		var lb string
+		if dep.Result != nil {
+			lb = strings.TrimSpace(dep.Result.LoadBalancerIP)
+		}
+		dep.mu.Unlock()
+		if adopted && lb != "" {
+			picked = lb
+			return false
+		}
+		return true
+	})
+	return picked
 }
 
 // pdmBasicAuth reads the basic-auth credentials for the PDM public

--- a/products/catalyst/bootstrap/api/internal/handler/parent_domains_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/parent_domains_test.go
@@ -555,3 +555,145 @@ func TestGetPropagation_ResponseShape(t *testing.T) {
 		t.Fatalf("expected 0%% propagated when all errored, got %d", resp.Percentage)
 	}
 }
+
+// ── Issue #900 — glue IP forwarding through pdmFlipNS ───────────────────
+
+// TestAddParentDomain_ForwardsGlueIP — when SOVEREIGN_LB_IP is set on
+// the Pod env, AddParentDomain's pdmFlipNS step MUST include `glueIP`
+// in the JSON body it POSTs to PDM /set-ns. This is the carrier wire
+// that unblocks the Dynadot register_ns pre-step on the PDM side.
+func TestAddParentDomain_ForwardsGlueIP(t *testing.T) {
+	t.Setenv("CATALYST_PRIMARY_DOMAIN", "")
+	t.Setenv("SOVEREIGN_LB_IP", "203.0.113.42")
+
+	// Capture the raw body PDM receives so we can assert wire shape.
+	var observedBody []byte
+	stub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/set-ns") {
+			observedBody, _ = io.ReadAll(r.Body)
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"valid":true}`))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer stub.Close()
+	t.Setenv("POOL_DOMAIN_MANAGER_URL", stub.URL)
+
+	h := &Handler{log: slog.Default()}
+	seedActiveDeployment(t, h, "omani.works")
+
+	body := `{"name":"customer-acme.tld","role":"sme-pool","registrarKind":"dynadot","registrarToken":"abc"}`
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sovereign/parent-domains", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	newParentDomainsRouter(h).ServeHTTP(rec, req)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("want 201, got %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal(observedBody, &got); err != nil {
+		t.Fatalf("PDM body not JSON: %v (raw=%s)", err, observedBody)
+	}
+	if got["domain"] != "customer-acme.tld" {
+		t.Errorf("PDM body domain=%v, want customer-acme.tld", got["domain"])
+	}
+	if got["glueIP"] != "203.0.113.42" {
+		t.Errorf("PDM body glueIP=%v, want 203.0.113.42 (from SOVEREIGN_LB_IP env)", got["glueIP"])
+	}
+	// nameservers must still be present — glue IP doesn't replace it.
+	if _, ok := got["nameservers"].([]any); !ok {
+		t.Errorf("PDM body missing nameservers array; raw=%s", observedBody)
+	}
+}
+
+// TestAddParentDomain_OmitsGlueIPWhenNoLBIP — when SOVEREIGN_LB_IP is
+// empty (Catalyst-Zero / contabo / pre-#900 Sovereigns) AND no adopted
+// deployment carries a Result.LoadBalancerIP, pdmFlipNS MUST omit the
+// glueIP field entirely (so PDM falls through to plain set_ns and
+// non-Dynadot adapters never see a stray field). Backward-compat
+// guarantee for the existing pool of franchised Sovereigns.
+func TestAddParentDomain_OmitsGlueIPWhenNoLBIP(t *testing.T) {
+	t.Setenv("CATALYST_PRIMARY_DOMAIN", "")
+	t.Setenv("SOVEREIGN_LB_IP", "")
+
+	var observedBody []byte
+	stub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/set-ns") {
+			observedBody, _ = io.ReadAll(r.Body)
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"valid":true}`))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer stub.Close()
+	t.Setenv("POOL_DOMAIN_MANAGER_URL", stub.URL)
+
+	h := &Handler{log: slog.Default()}
+	// Adopted deployment WITHOUT Result.LoadBalancerIP — fallback chain
+	// resolves to "" so glueIP is omitted from the wire payload.
+	seedActiveDeployment(t, h, "omani.works")
+
+	body := `{"name":"customer-acme.tld","role":"sme-pool","registrarKind":"dynadot","registrarToken":"abc"}`
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sovereign/parent-domains", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	newParentDomainsRouter(h).ServeHTTP(rec, req)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("want 201, got %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal(observedBody, &got); err != nil {
+		t.Fatalf("PDM body not JSON: %v", err)
+	}
+	if _, present := got["glueIP"]; present {
+		t.Errorf("expected no glueIP in PDM body when SOVEREIGN_LB_IP is unset; got %v", got["glueIP"])
+	}
+}
+
+// TestAddParentDomain_GlueIPFromDeploymentResult — when SOVEREIGN_LB_IP
+// is empty but the adopted deployment's Result.LoadBalancerIP is set,
+// pdmFlipNS MUST fall through to the deployment-record source and
+// still forward the IP to PDM. Covers the Catalyst-Zero (contabo) path
+// during single-Sovereign sandbox runs of the Day-2 add-domain flow.
+func TestAddParentDomain_GlueIPFromDeploymentResult(t *testing.T) {
+	t.Setenv("CATALYST_PRIMARY_DOMAIN", "")
+	t.Setenv("SOVEREIGN_LB_IP", "")
+
+	var observedBody []byte
+	stub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/set-ns") {
+			observedBody, _ = io.ReadAll(r.Body)
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"valid":true}`))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer stub.Close()
+	t.Setenv("POOL_DOMAIN_MANAGER_URL", stub.URL)
+
+	h := &Handler{log: slog.Default()}
+	dep := seedActiveDeployment(t, h, "omani.works")
+	dep.Result = &provisioner.Result{LoadBalancerIP: "198.51.100.7"}
+
+	body := `{"name":"customer-acme.tld","role":"sme-pool","registrarKind":"dynadot","registrarToken":"abc"}`
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sovereign/parent-domains", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	newParentDomainsRouter(h).ServeHTTP(rec, req)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("want 201, got %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal(observedBody, &got); err != nil {
+		t.Fatalf("PDM body not JSON: %v", err)
+	}
+	if got["glueIP"] != "198.51.100.7" {
+		t.Errorf("PDM body glueIP=%v, want 198.51.100.7 (from Deployment.Result.LoadBalancerIP)", got["glueIP"])
+	}
+}

--- a/products/catalyst/chart/templates/api-deployment.yaml
+++ b/products/catalyst/chart/templates/api-deployment.yaml
@@ -524,6 +524,25 @@ spec:
                   name: sovereign-fqdn
                   key: fqdn
                   optional: true
+            # SOVEREIGN_LB_IP — Sovereign's load-balancer public IPv4. Used by
+            # the Day-2 multi-domain add-domain flow (issue #900) to
+            # pre-register glue records at the customer's registrar before
+            # the set_ns flip. Without it Dynadot rejects with
+            # "'ns1.<sov>.omani.works' needs to be registered with an ip
+            # address before it can be used" — caught live during otech103
+            # multi-domain verification.
+            #
+            # Sourced from the chart's `global.sovereignLBIP` value (rendered
+            # into the same `sovereign-fqdn` ConfigMap that holds `fqdn`).
+            # optional=true: Catalyst-Zero (contabo) doesn't run the Sovereign-
+            # side multi-domain pipeline; the env stays empty and the glue
+            # path becomes a no-op (plain set_ns flows through unchanged).
+            - name: SOVEREIGN_LB_IP
+              valueFrom:
+                configMapKeyRef:
+                  name: sovereign-fqdn
+                  key: lbIP
+                  optional: true
             # CATALYST_GITOPS_USER + CATALYST_GITOPS_TOKEN — basic-auth
             # credentials embedded in the GitOps clone URL (issue #878).
             # Pre-cutover (Catalyst-Zero): User=x-access-token, Token=GitHub

--- a/products/catalyst/chart/templates/sovereign-fqdn-configmap.yaml
+++ b/products/catalyst/chart/templates/sovereign-fqdn-configmap.yaml
@@ -46,4 +46,13 @@ metadata:
     catalyst.openova.io/sovereign: {{ .Values.global.sovereignFQDN | quote }}
 data:
   fqdn: {{ .Values.global.sovereignFQDN | quote }}
+  # lbIP — Sovereign's load-balancer public IPv4. Consumed by
+  # catalyst-api's SOVEREIGN_LB_IP env (api-deployment.yaml) so the
+  # multi-domain Day-2 add-domain flow can pre-register glue records
+  # at the customer's registrar before flipping NS (issue #900).
+  # When .Values.global.sovereignLBIP is empty the key is rendered as
+  # empty string — catalyst-api treats that as "no glue registration"
+  # and falls back to plain set_ns. Operators on legacy Sovereigns
+  # without this value wired set the env via per-cluster overlay.
+  lbIP: {{ .Values.global.sovereignLBIP | default "" | quote }}
 {{- end }}

--- a/products/catalyst/chart/values.yaml
+++ b/products/catalyst/chart/values.yaml
@@ -13,6 +13,20 @@ global:
   # wildcard Certificate template (templates/sovereign-wildcard-certs.yaml,
   # issue #827) when parentZones is empty (single-zone fallback).
   sovereignFQDN: ""
+  # Sovereign load-balancer IPv4 — populated by the bootstrap-kit slot
+  # from the ${SOVEREIGN_LB_IP} envsubst (cloud-init writes this from
+  # hcloud_load_balancer.main.ipv4 / equivalent). Consumed by
+  # api-deployment.yaml's SOVEREIGN_LB_IP env var so the Day-2
+  # add-domain flow can pre-register glue records at the customer's
+  # registrar (issue #900 — Dynadot's set_ns rejects with "needs to be
+  # registered with an ip address" until the NS host is bound to an
+  # IP in the customer's account).
+  #
+  # Empty = not on a Sovereign cluster (Catalyst-Zero / contabo). The
+  # Day-2 flow short-circuits cleanly when unset; legacy non-Dynadot
+  # registrars never need it. Per docs/INVIOLABLE-PRINCIPLES.md #4 the
+  # value is fully runtime-configurable.
+  sovereignLBIP: ""
 
 # ─── Multi-zone parent domains (issue #827, parent epic #825) ──────────
 # A franchised Sovereign supports N parent zones, NOT one. The operator


### PR DESCRIPTION
## Summary

Closes #900. Multi-domain Day-2 add-domain on a Sovereign was failing with Dynadot's

```
'ns1.otech103.omani.works' needs to be registered with an ip address before it can be used.
```

Dynadot rejects `set_ns` whenever the NS hostnames are not registered as account-level "host records" against the customer's account first. This PR wires the glue pre-registration end-to-end:

- **PDM dynadot adapter** (`core/pool-domain-manager/internal/registrar/dynadot/`): adds `RegisterGlueRecord` + `GetGlueRecord` via the new optional `registrar.GlueRegistrar` interface. Idempotent `get_ns` probe → `register_ns` (fresh) / `set_ns_ip` (IP changed) / no-op (same IP).
- **PDM HTTP handler** (`core/pool-domain-manager/internal/handler/registrar.go`): `SetNSRequest` gains an optional `glueIP`. When present and the adapter implements `GlueRegistrar`, the handler calls `RegisterGlueRecord` for each out-of-bailiwick NS BEFORE `SetNameservers`. Skips in-bailiwick NS (resolved via the customer's own zone) via the new `isInBailiwick` classifier.
- **catalyst-api** (`products/catalyst/bootstrap/api/internal/handler/parent_domains.go`): `pdmFlipNS` resolves the Sovereign's LB IP via `lookupSovereignLBIP` (env `SOVEREIGN_LB_IP` → adopted Deployment's `Result.LoadBalancerIP` → `""`) and threads it as `glueIP` into the PDM POST body. Field is omitted when unresolved so non-Dynadot adapters and pre-#900 deployments are unaffected.
- **Chart wiring**:
  - `global.sovereignLBIP` value in `products/catalyst/chart/values.yaml`.
  - Rendered into the `sovereign-fqdn` ConfigMap (`templates/sovereign-fqdn-configmap.yaml`) under key `lbIP`.
  - Mounted into the api Pod as `SOVEREIGN_LB_IP` env in `templates/api-deployment.yaml`.
- **Bootstrap-kit + cloud-init**:
  - `clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml` passes `${SOVEREIGN_LB_IP}` into `global.sovereignLBIP`.
  - `infra/hetzner/cloudinit-control-plane.tftpl` adds `SOVEREIGN_LB_IP: ${load_balancer_ipv4}` to the `bootstrap-kit` Kustomization's `postBuild.substitute` (already-templated `load_balancer_ipv4` from `hcloud_load_balancer.main.ipv4`).

## Test plan

- [x] `cd core/pool-domain-manager && go test ./...` — all green
- [x] `cd products/catalyst/bootstrap/api && go build ./... && go test -run "ParentDomain|GlueIP" ./internal/handler/...` — all green (pre-existing `TestAuthHandover_HappyPath` panic is unrelated, present on `main`).
- [x] New unit tests cover:
  - Dynadot adapter: fresh-host registration, idempotent same-IP short-circuit, IP-changed `set_ns_ip` update, rate-limit passthrough, validation, GlueRegistrar interface compliance.
  - PDM SetNS handler: glue pre-registers before flip, glue failure short-circuits flip, in-bailiwick NS skipped, omitted `glueIP` skips registration, non-Glue adapter unaffected.
  - catalyst-api: `glueIP` forwarded when `SOVEREIGN_LB_IP` set, omitted when unset, fallback to `Deployment.Result.LoadBalancerIP`.
- [ ] Post-merge: services-build CI green, image SHA-pinned, catalyst-api Pod restart on otech103, multi-domain add via live Sovereign Console no longer hits "needs to be registered with an ip address".

🤖 Generated with [Claude Code](https://claude.com/claude-code)