### PR TITLE
fix(bp-catalyst-platform): create sme namespace on marketplace Sovereigns (1.4.18)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -155,7 +155,16 @@ spec:
       #      /sovereign/wizard (mothership-only) to /sovereign/components
       #      (post-handover Sovereign homepage). Per-Sovereign overlays
       #      override via catalystApi.env additional-env patch.
-      version: 1.4.17
+      # 1.4.18 (issue #910): NEW templates/sme-services/sme-namespace.yaml
+      # creates the `sme` namespace on Sovereigns where the marketplace
+      # is enabled. Without this, chart 1.4.17 install failed 23 times
+      # with `failed to create resource: namespaces "sme" not found` on
+      # every fresh franchised Sovereign with marketplace.enabled=true —
+      # caught live on otech105 (2026-05-05). Same dual-mode contract as
+      # the rest of templates/sme-services/* (gated on
+      # ingress.marketplace.enabled, excluded from kustomization.yaml's
+      # resources: list).
+      version: 1.4.18
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: bp-catalyst-platform
-version: 1.4.17
-appVersion: 1.4.17
+version: 1.4.18
+appVersion: 1.4.18
 description: |
   Catalyst Platform — the unified Catalyst control plane umbrella chart for Catalyst-Zero.
   Composes the catalyst-{ui,api}, console, admin, marketplace UI modules and the marketplace-api backend.
@@ -835,6 +835,26 @@ description: |
 
   Lockstep slot 13 pin in clusters/_template/bootstrap-kit/
   13-bp-catalyst-platform.yaml bumps from 1.4.16 → 1.4.17. 2026-05-05.
+
+  1.4.18 (issue #910 — TBD): create the `sme` namespace on Sovereigns
+  where the marketplace is enabled. Every template under
+  templates/sme-services/* (billing, auth, ferretdb, valkey-cross-ns-
+  secret, sme-secrets, provisioning-github-token, cnpg-cluster, ...)
+  emits resources with `namespace: sme`. On Catalyst-Zero (contabo)
+  the `sme` namespace is pre-provisioned by clusters/contabo-mkt/apps/
+  sme/* — so the chart never created it. On a fresh franchised
+  Sovereign nothing else creates the `sme` namespace, so chart 1.4.17
+  install failed 23 times with `failed to create resource: namespaces
+  "sme" not found` — caught live on otech105 (2026-05-05). Fix: NEW
+  templates/sme-services/sme-namespace.yaml gated on the same
+  ingress.marketplace.enabled flag as the rest of the SME bundle so
+  non-marketplace Sovereigns and the Kustomize-mode contabo build
+  (which does NOT include sme-namespace.yaml in templates/sme-services/
+  kustomization.yaml's `resources:` list) skip this entirely.
+  helm.sh/resource-policy: keep — never cascade-delete the namespace
+  on chart uninstall (would erase every SME workload + tenant).
+  Lockstep slot 13 pin in clusters/_template/bootstrap-kit/
+  13-bp-catalyst-platform.yaml bumps from 1.4.17 → 1.4.18. 2026-05-05.
 type: application
 
 # Opt-out from the blueprint-release hollow-chart guard (issue #181 / #510).

--- a/products/catalyst/chart/templates/sme-services/sme-namespace.yaml
+++ b/products/catalyst/chart/templates/sme-services/sme-namespace.yaml
@@ -1,0 +1,38 @@
+{{- /*
+Auto-create the `sme` namespace on Sovereigns where the marketplace is
+enabled.
+
+Why: every other template under templates/sme-services/* (billing.yaml,
+auth.yaml, ferretdb.yaml, valkey-cross-ns-secret.yaml, sme-secrets.yaml,
+provisioning-github-token.yaml, ...) emits resources with
+`namespace: sme`. On Catalyst-Zero (contabo) the `sme` namespace is
+pre-provisioned by clusters/contabo-mkt/apps/sme/* — so the chart never
+needed to create it. On a freshly franchised Sovereign nothing else
+provisions the `sme` namespace, so without this template Helm install
+fails 23 times with `failed to create resource: namespaces "sme" not
+found` (live blocker on otech105 — 2026-05-05).
+
+Same dual-mode contract as the rest of templates/sme-services/* — gated
+on `ingress.marketplace.enabled` so non-marketplace Sovereigns and the
+Kustomize-mode contabo build skip this entirely. Kustomize-mode build
+does NOT include `templates/sme-services/sme-namespace.yaml` in
+`templates/sme-services/kustomization.yaml`'s `resources:` list (the
+contabo build manages the `sme` namespace via
+clusters/contabo-mkt/apps/sme/namespace.yaml).
+
+helm.sh/resource-policy: keep — never delete the namespace on a
+chart uninstall (would cascade-delete every SME workload + tenant).
+*/ -}}
+{{- if and .Values.ingress .Values.ingress.marketplace .Values.ingress.marketplace.enabled -}}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: sme
+  labels:
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: catalyst-platform
+    catalyst.openova.io/sovereign: {{ .Values.global.sovereignFQDN | quote }}
+  annotations:
+    helm.sh/resource-policy: keep
+    catalyst.openova.io/created-by: bp-catalyst-platform
+{{- end -}}


### PR DESCRIPTION
## Root cause

Every template under `templates/sme-services/*` (billing, auth, ferretdb, valkey-cross-ns-secret, sme-secrets, provisioning-github-token, cnpg-cluster, ...) emits resources with `namespace: sme`.

- On Catalyst-Zero (contabo) the `sme` namespace is pre-provisioned by `clusters/contabo-mkt/apps/sme/*` — so the chart never needed to create it.
- On a fresh franchised Sovereign nothing else creates the `sme` namespace.

Result: chart 1.4.17 install failed 23 times with `failed to create resource: namespaces "sme" not found`. Caught live on otech105 (2026-05-05) — bp-catalyst-platform stuck Ready=False for 18 minutes blocking Sovereign Console login + the full marketplace UI.

## Fix

- **NEW** `templates/sme-services/sme-namespace.yaml` — gated on the same `.Values.ingress.marketplace.enabled` flag the rest of the SME bundle uses. Renders a `Namespace sme` with `helm.sh/resource-policy: keep` so a chart uninstall never cascade-deletes every SME workload + tenant.
- Same dual-mode contract as `templates/marketplace-api/secret.yaml` (#887) and `templates/catalyst-openova-kc-credentials-secret.yaml` (#901): the new file is intentionally NOT added to `templates/sme-services/kustomization.yaml`'s `resources:` list, so the Kustomize-mode contabo build skips it entirely (contabo's `sme` namespace is owned by `clusters/contabo-mkt/apps/sme/namespace.yaml`).

## Lockstep

- `products/catalyst/chart/Chart.yaml`: 1.4.17 -> 1.4.18 with full 1.4.18 changelog block.
- `clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml`: pinned chart version 1.4.17 -> 1.4.18 with inline rationale comment.

## Test plan

- [x] otech105 runtime hot-fix (`kubectl create ns sme`) made bp-catalyst-platform Ready=True ("Helm upgrade succeeded for release catalyst-system/catalyst-platform.v2 with chart bp-catalyst-platform@1.4.17") and all 40/40 bootstrap-kit HRs converged
- [ ] CI blueprint-release publishes 1.4.18 OCI artifact
- [ ] Next fresh Sovereign provisions cleanly without operator `kubectl create ns sme` intervention

🤖 Generated with [Claude Code](https://claude.com/claude-code)