### PR TITLE
feat(bp-keycloak): tenant-mode realm with wordpress/openclaw/stalwart OIDC clients (1.4.0, #915)

### DIFF
--- a/platform/keycloak/blueprint.yaml
+++ b/platform/keycloak/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
 spec:
-  version: 1.3.3
+  version: 1.4.0
   card:
     title: keycloak
     summary: Keycloak — user identity. Topology decided by Sovereign CRD spec.keycloakTopology (per-organization for SME, shared-sovereign for corporate).

--- a/platform/keycloak/chart/Chart.yaml
+++ b/platform/keycloak/chart/Chart.yaml
@@ -1,17 +1,25 @@
 apiVersion: v2
 name: bp-keycloak
-version: 1.3.3
+version: 1.4.0
 description: |
   Catalyst-curated Blueprint umbrella chart for Keycloak. Depends on the
   upstream `keycloak` chart (bitnami) as a Helm subchart so
   `helm dependency build` pulls the upstream payload into this artifact;
   the Catalyst overlay templates in templates/ (HTTPRoute, sovereign realm
-  ConfigMap) sit alongside the upstream subchart and Helm renders both at
-  install time. Catalyst-curated values flow into the upstream subchart under
-  the `keycloak:` key in values.yaml.
+  ConfigMap, tenant realm ConfigMap) sit alongside the upstream subchart and
+  Helm renders both at install time. Catalyst-curated values flow into the
+  upstream subchart under the `keycloak:` key in values.yaml.
   Phase-8b (issue #604): adds catalyst-ui PKCE client, catalyst-api-server
   service-account client with impersonate role, token-exchange enabled on
   sovereign realm, WebAuthn Required Actions, and SMTP configuration.
+  1.4.0 (issue #915 / C1): tenant-mode realm import. When
+  realmConfig.tenant.enabled=true the chart emits a per-tenant realm with
+  wordpress / openclaw / stalwart OIDC clients pre-registered, plus the
+  matching `wordpress-oidc-client-secret` / `openclaw-oidc-client-secret`
+  / `stalwart-oidc-client-secret` Secrets the downstream
+  bp-wordpress-tenant / bp-openclaw / bp-stalwart-tenant charts consume
+  via secretKeyRef. Sovereign-mode unchanged. Closes the chart-side gap
+  left by orchestrator PR #911 (which already emits realmConfig.tenant.*).
 type: application
 keywords: [catalyst, blueprint, keycloak]
 maintainers:

--- a/platform/keycloak/chart/templates/configmap-sovereign-realm.yaml
+++ b/platform/keycloak/chart/templates/configmap-sovereign-realm.yaml
@@ -50,8 +50,22 @@ mint an admin token, (c) PUT the client secret, (d) write the K8s Secret —
 that's four failure modes the lookup-or-generate pattern eliminates.
 
 Canonical seam: platform/keycloak/chart/templates/configmap-sovereign-realm.yaml
+
+Tenant-mode mutual exclusion (issue #915, C1)
+─────────────────────────────────────────────
+When `realmConfig.tenant.enabled=true` the chart is being installed for an
+SME tenant (per-tenant Keycloak with a tenant realm + per-app OIDC clients
+for wordpress / openclaw / stalwart). In that mode the tenant realm
+ConfigMap (templates/configmap-tenant-realm.yaml) emits a ConfigMap with
+the SAME name expected by `keycloakConfigCli.existingConfigmap`
+(`{{"{{ .Release.Name }}"}}-sovereign-realm-config`) so the upstream
+keycloak-config-cli Job imports the tenant realm instead. To avoid two
+ConfigMaps colliding on the same name, this Sovereign template skips when
+tenant mode is on. The orchestrator (A3 / PR #911) currently sets BOTH
+`sovereignRealm.enabled=true` and `realmConfig.tenant.enabled=true` in the
+tenant emit; tenant takes precedence here.
 */}}
-{{- if .Values.sovereignRealm.enabled }}
+{{- if and .Values.sovereignRealm.enabled (not (and .Values.realmConfig (and .Values.realmConfig.tenant .Values.realmConfig.tenant.enabled))) }}
 {{- /* ── Resolve catalyst-api-server client secret ─────────────────────── */}}
 {{- $saSecretName := "catalyst-kc-sa-credentials" -}}
 {{- $existing := lookup "v1" "Secret" .Release.Namespace $saSecretName -}}

--- a/platform/keycloak/chart/templates/configmap-tenant-realm.yaml
+++ b/platform/keycloak/chart/templates/configmap-tenant-realm.yaml
@@ -1,0 +1,488 @@
+{{- /*
+Catalyst bp-keycloak — Per-tenant SME realm import ConfigMap + per-app
+OIDC client Secrets (issue #915).
+
+When a tenant is provisioned on a Sovereign (per-tenant Namespace, single
+Keycloak Pod + Postgres backend), the Keycloak realm imported by the
+upstream bitnami/keycloak chart's keycloak-config-cli post-install Job
+MUST register OIDC clients for the SME's downstream apps so first-login
+SSO works end-to-end:
+
+  - wordpress  (confidential client; auth-code flow; redirect URI to the
+                 openid-connect-generic plugin's admin-ajax.php callback
+                 plus /wp-login.php fallback)
+  - openclaw   (confidential client; auth-code flow; redirect URI to
+                 https://openclaw.<host>/oauth/callback)
+  - stalwart   (confidential client; client_credentials AND auth-code
+                 enabled — Stalwart's `directory.keycloak` of type=oidc
+                 uses client_credentials to introspect IMAP/SMTP tokens,
+                 webmail uses auth-code)
+
+The orchestrator (products/catalyst/bootstrap/api/internal/handler/
+sme_tenant_gitops.go, smeTenantBPKeycloak) emits
+realmConfig.tenant.enabled=true alongside sovereignRealm.enabled=true on
+the per-tenant HelmRelease (PR #911). When tenant mode is on,
+configmap-sovereign-realm.yaml SKIPS (mutual exclusion) and this template
+emits the realm import ConfigMap with the SAME name expected by
+.Values.keycloak.keycloakConfigCli.existingConfigmap
+(`<release>-sovereign-realm-config`) so the upstream Job picks it up
+without further values plumbing. Mutual-exclusion guard lives in
+configmap-sovereign-realm.yaml.
+
+Per-app client secrets — persistence + zero-touch
+─────────────────────────────────────────────────
+Each of wordpress / openclaw / stalwart needs a confidential client
+secret that is:
+  1. registered in the realm JSON imported by keycloak-config-cli, AND
+  2. materialised as a K8s Secret in the tenant Namespace so the per-
+     app Helm chart can mount it (bp-wordpress-tenant references
+     `wordpress-oidc-client-secret`, bp-openclaw references
+     `openclaw-oidc-client-secret`, bp-stalwart-tenant references
+     `stalwart-oidc-client-secret`).
+
+Resolution order (first match wins) — same pattern as
+configmap-sovereign-realm.yaml's catalyst-api-server secret:
+  1. operator-supplied .Values.realmConfig.tenant.<app>.clientSecret
+     (rare; useful for replicating from sealed-secret store)
+  2. existing K8s Secret in .Release.Namespace (helm `lookup` →
+     idempotent on upgrade; secret stays stable across reconciles so
+     the downstream app never sees a rotation)
+  3. fresh randAlphaNum 32 (zero-touch on first install)
+
+This template emits all three Secrets PLUS the realm-config ConfigMap in
+ONE template scope so the same `$wpSecret`/`$ocSecret`/`$swSecret`
+variables flow into both the realm JSON and the K8s Secrets — the
+secrets cannot drift because one render produces both.
+
+Per docs/INVIOLABLE-PRINCIPLES.md #4 (never hardcode): every host-derived
+URI is templated off `realmConfig.tenant.parentDomain` +
+`realmConfig.tenant.subdomain` with operator override via per-app `host`.
+Per docs/INVIOLABLE-PRINCIPLES.md #10 (never print credentials): the
+generated client secrets land ONLY in K8s Secret bytes (and the realm
+JSON ConfigMap consumed by keycloak-config-cli, which itself runs as a
+Job and reads the ConfigMap via projected volume — no credential ever
+leaves the cluster).
+
+Canonical seam: platform/keycloak/chart/templates/configmap-tenant-realm.yaml
+*/}}
+{{- if and .Values.realmConfig .Values.realmConfig.tenant .Values.realmConfig.tenant.enabled }}
+{{- /* ── Validate required tenant fields ──────────────────────────────── */}}
+{{- $t := .Values.realmConfig.tenant -}}
+{{- if not $t.realmName -}}
+  {{- fail "realmConfig.tenant.enabled=true requires realmConfig.tenant.realmName (convention: sme-<subdomain>) — Inviolable Principle #4 (never hardcode)" -}}
+{{- end -}}
+{{- if not $t.parentDomain -}}
+  {{- fail "realmConfig.tenant.enabled=true requires realmConfig.tenant.parentDomain — Inviolable Principle #4 (never hardcode)" -}}
+{{- end -}}
+{{- if not $t.subdomain -}}
+  {{- fail "realmConfig.tenant.enabled=true requires realmConfig.tenant.subdomain — Inviolable Principle #4 (never hardcode)" -}}
+{{- end -}}
+{{- /* ── Resolve per-app hosts (operator override OR <app>.<sub>.<parent>) ─── */}}
+{{- $defaultZone := printf "%s.%s" $t.subdomain $t.parentDomain -}}
+{{- $wpHost := $t.wordpress.host | default (printf "wordpress.%s" $defaultZone) -}}
+{{- $ocHost := $t.openclaw.host  | default (printf "openclaw.%s"  $defaultZone) -}}
+{{- $swHost := $t.stalwart.host  | default (printf "mail.%s"      $defaultZone) -}}
+{{- /* ── Resolve per-app client secrets via lookup-or-generate ─────────── */}}
+{{- $wpSecretName := $t.wordpress.clientSecretName | default "wordpress-oidc-client-secret" -}}
+{{- $ocSecretName := $t.openclaw.clientSecretName  | default "openclaw-oidc-client-secret" -}}
+{{- $swSecretName := $t.stalwart.clientSecretName  | default "stalwart-oidc-client-secret" -}}
+{{- $wpSecret := $t.wordpress.clientSecret -}}
+{{- if not $wpSecret -}}
+  {{- $existing := lookup "v1" "Secret" .Release.Namespace $wpSecretName -}}
+  {{- if and $existing $existing.data (index $existing.data "client-secret") -}}
+    {{- $wpSecret = index $existing.data "client-secret" | b64dec -}}
+  {{- else -}}
+    {{- $wpSecret = randAlphaNum 32 -}}
+  {{- end -}}
+{{- end -}}
+{{- $ocSecret := $t.openclaw.clientSecret -}}
+{{- if not $ocSecret -}}
+  {{- $existing := lookup "v1" "Secret" .Release.Namespace $ocSecretName -}}
+  {{- if and $existing $existing.data (index $existing.data "client-secret") -}}
+    {{- $ocSecret = index $existing.data "client-secret" | b64dec -}}
+  {{- else -}}
+    {{- $ocSecret = randAlphaNum 32 -}}
+  {{- end -}}
+{{- end -}}
+{{- $swSecret := $t.stalwart.clientSecret -}}
+{{- if not $swSecret -}}
+  {{- $existing := lookup "v1" "Secret" .Release.Namespace $swSecretName -}}
+  {{- if and $existing $existing.data (index $existing.data "client-secret") -}}
+    {{- $swSecret = index $existing.data "client-secret" | b64dec -}}
+  {{- else -}}
+    {{- $swSecret = randAlphaNum 32 -}}
+  {{- end -}}
+{{- end -}}
+{{- /* ── Resolve default redirect URI lists ────────────────────────────── */}}
+{{- $wpRedirects := $t.wordpress.redirectURIs -}}
+{{- if not $wpRedirects -}}
+  {{- /* openid-connect-generic plugin: admin-ajax.php callback (default
+         when alternate_redirect_uri=0) + /wp-login.php fallback so both
+         paths work even if the plugin's setting is toggled. */ -}}
+  {{- $wpRedirects = list
+        (printf "https://%s/wp-admin/admin-ajax.php?action=openid-connect-authorize" $wpHost)
+        (printf "https://%s/wp-login.php" $wpHost)
+        (printf "https://%s/openid-connect-authorize" $wpHost)
+        (printf "https://%s/*" $wpHost) -}}
+{{- end -}}
+{{- $ocRedirects := $t.openclaw.redirectURIs -}}
+{{- if not $ocRedirects -}}
+  {{- /* OpenClaw OIDC redirect URI per #915 spec: /oauth/callback. */ -}}
+  {{- $ocRedirects = list
+        (printf "https://%s/oauth/callback" $ocHost)
+        (printf "https://%s/*" $ocHost) -}}
+{{- end -}}
+{{- $swRedirects := $t.stalwart.redirectURIs -}}
+{{- if not $swRedirects -}}
+  {{- /* Stalwart webmail OIDC callback (auth-code flow). The directory
+         backend uses client_credentials (no redirect needed) — the
+         webmail UI uses auth-code. */ -}}
+  {{- $swRedirects = list
+        (printf "https://%s/auth/oidc/callback" $swHost)
+        (printf "https://%s/*" $swHost) -}}
+{{- end -}}
+{{- /* Helper: render a JSON string array from a Helm list. */ -}}
+{{- $renderRedirects := "" -}}
+{{- /* ── Default-groups list defaulted to first entry of .groups ──────── */}}
+{{- $defaultGroup := "" -}}
+{{- if $t.groups -}}
+  {{- $defaultGroup = index $t.groups 0 -}}
+{{- end -}}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-sovereign-realm-config
+  namespace: {{ .Release.Namespace }}
+  labels:
+    catalyst.openova.io/blueprint: bp-keycloak
+    catalyst.openova.io/component: keycloak-config-cli
+    catalyst.openova.io/realm-mode: tenant
+    catalyst.openova.io/tenant-realm: {{ $t.realmName | quote }}
+    {{- with .Values.sovereignFQDN }}
+    catalyst.openova.io/sovereign-fqdn: {{ . | quote }}
+    {{- end }}
+  annotations:
+    catalyst.openova.io/comment: |
+      Tenant-mode realm import for SME `{{ $t.realmName }}`. Replaces
+      the Sovereign realm import (configmap-sovereign-realm.yaml is
+      gated off when realmConfig.tenant.enabled=true). Imported by the
+      upstream keycloak-config-cli post-install Job referenced via
+      `keycloakConfigCli.existingConfigmap` in values.yaml.
+data:
+  sovereign-realm.json: |
+    {
+      "realm": {{ $t.realmName | quote }},
+      "enabled": true,
+      "displayName": {{ ($t.displayName | default $t.realmName) | quote }},
+      "sslRequired": "external",
+      "registrationAllowed": false,
+      "loginWithEmailAllowed": true,
+      "duplicateEmailsAllowed": false,
+      "resetPasswordAllowed": true,
+      "editUsernameAllowed": false,
+      "bruteForceProtected": true,
+      "accessTokenLifespan": 900,
+      "ssoSessionIdleTimeout": 1800,
+      "ssoSessionMaxLifespan": 28800,
+      "attributes": {
+        "token-exchange": "true"
+      },
+      {{- if and .Values.smtp .Values.smtp.host }}
+      "smtpServer": {
+        "host": {{ .Values.smtp.host | quote }},
+        "port": {{ .Values.smtp.port | default "587" | quote }},
+        "from": {{ .Values.smtp.from | default (printf "noreply@%s" $defaultZone) | quote }},
+        "fromDisplayName": {{ ($t.displayName | default $t.realmName) | quote }},
+        "ssl": {{ .Values.smtp.ssl | default "false" | quote }},
+        "starttls": {{ .Values.smtp.starttls | default "true" | quote }},
+        "auth": {{ .Values.smtp.auth | default "true" | quote }}
+        {{- if .Values.smtp.user }},
+        "user": {{ .Values.smtp.user | quote }}
+        {{- end }}
+      },
+      {{- end }}
+      {{- if $defaultGroup }}
+      "defaultGroups": [
+        {{ printf "/%s" $defaultGroup | quote }}
+      ],
+      {{- end }}
+      "groups": [
+        {{- range $i, $g := $t.groups }}
+        {{- if $i }},{{ end }}
+        { "name": {{ $g | quote }} }
+        {{- end }}
+      ],
+      "requiredActions": [
+        {
+          "alias": "UPDATE_PASSWORD",
+          "name": "Update Password",
+          "providerId": "UPDATE_PASSWORD",
+          "enabled": true,
+          "defaultAction": false,
+          "priority": 30,
+          "config": {}
+        }
+      ],
+      "clientScopes": [
+        {
+          "name": "groups",
+          "protocol": "openid-connect",
+          "attributes": {
+            "include.in.token.scope": "true",
+            "display.on.consent.screen": "true"
+          },
+          "protocolMappers": [
+            {
+              "name": "groups",
+              "protocol": "openid-connect",
+              "protocolMapper": "oidc-group-membership-mapper",
+              "consentRequired": false,
+              "config": {
+                "full.path": "false",
+                "id.token.claim": "true",
+                "access.token.claim": "true",
+                "claim.name": "groups",
+                "userinfo.token.claim": "true"
+              }
+            }
+          ]
+        }
+      ],
+      "clients": [
+        {
+          "clientId": {{ ($t.wordpress.clientID | default "wordpress") | quote }},
+          "name": "WordPress (SME tenant — openid-connect-generic plugin)",
+          "description": "Confidential OIDC client for the SME tenant's WordPress instance. Auth-code flow with PKCE optional. Redirect URIs cover the openid-connect-generic plugin's admin-ajax.php callback (default when alternate_redirect_uri=0) plus /wp-login.php fallback.",
+          "enabled": true,
+          "publicClient": false,
+          "standardFlowEnabled": true,
+          "directAccessGrantsEnabled": false,
+          "implicitFlowEnabled": false,
+          "serviceAccountsEnabled": false,
+          "secret": {{ $wpSecret | quote }},
+          "redirectUris": [
+            {{- range $i, $u := $wpRedirects }}
+            {{- if $i }},{{ end }}
+            {{ $u | quote }}
+            {{- end }}
+          ],
+          "webOrigins": [
+            {{ printf "https://%s" $wpHost | quote }}
+          ],
+          "defaultClientScopes": [
+            "web-origins",
+            "acr",
+            "profile",
+            "roles",
+            "email",
+            "groups"
+          ],
+          "optionalClientScopes": [
+            "address",
+            "phone",
+            "offline_access",
+            "microprofile-jwt"
+          ],
+          "attributes": {
+            "access.token.lifespan": "900",
+            "post.logout.redirect.uris": {{ printf "https://%s/*" $wpHost | quote }}
+          }
+        },
+        {
+          "clientId": {{ ($t.openclaw.clientID | default "openclaw") | quote }},
+          "name": "OpenClaw (SME tenant — Claude UI)",
+          "description": "Confidential OIDC client for the SME tenant's OpenClaw deployment. Auth-code flow; redirect URI per #915 spec is /oauth/callback.",
+          "enabled": true,
+          "publicClient": false,
+          "standardFlowEnabled": true,
+          "directAccessGrantsEnabled": false,
+          "implicitFlowEnabled": false,
+          "serviceAccountsEnabled": false,
+          "secret": {{ $ocSecret | quote }},
+          "redirectUris": [
+            {{- range $i, $u := $ocRedirects }}
+            {{- if $i }},{{ end }}
+            {{ $u | quote }}
+            {{- end }}
+          ],
+          "webOrigins": [
+            {{ printf "https://%s" $ocHost | quote }}
+          ],
+          "defaultClientScopes": [
+            "web-origins",
+            "acr",
+            "profile",
+            "roles",
+            "email",
+            "groups"
+          ],
+          "optionalClientScopes": [
+            "address",
+            "phone",
+            "offline_access",
+            "microprofile-jwt"
+          ],
+          "attributes": {
+            "pkce.code.challenge.method": "S256",
+            "access.token.lifespan": "900",
+            "post.logout.redirect.uris": {{ printf "https://%s/*" $ocHost | quote }}
+          }
+        },
+        {
+          "clientId": {{ ($t.stalwart.clientID | default "stalwart") | quote }},
+          "name": "Stalwart (SME tenant — mail server OIDC)",
+          "description": "Confidential OIDC client for the SME tenant's Stalwart mail server. serviceAccountsEnabled=true so the directory.keycloak backend can use client_credentials to introspect IMAP/SMTP tokens; standardFlowEnabled=true so the webmail UI can do auth-code login. Single client covers both flows.",
+          "enabled": true,
+          "publicClient": false,
+          "standardFlowEnabled": true,
+          "directAccessGrantsEnabled": false,
+          "implicitFlowEnabled": false,
+          "serviceAccountsEnabled": true,
+          "authorizationServicesEnabled": false,
+          "secret": {{ $swSecret | quote }},
+          "redirectUris": [
+            {{- range $i, $u := $swRedirects }}
+            {{- if $i }},{{ end }}
+            {{ $u | quote }}
+            {{- end }}
+          ],
+          "webOrigins": [
+            {{ printf "https://%s" $swHost | quote }}
+          ],
+          "defaultClientScopes": [
+            "web-origins",
+            "acr",
+            "profile",
+            "roles",
+            "email",
+            "groups"
+          ],
+          "optionalClientScopes": [
+            "address",
+            "phone",
+            "offline_access",
+            "microprofile-jwt"
+          ],
+          "attributes": {
+            "access.token.lifespan": "900"
+          }
+        }
+      ],
+      "clientScopeMappings": {
+        "realm-management": [
+          {
+            "client": {{ ($t.stalwart.clientID | default "stalwart") | quote }},
+            "roles": [
+              "view-users",
+              "query-users"
+            ]
+          }
+        ]
+      },
+      "users": [
+        {
+          "username": {{ printf "service-account-%s" ($t.stalwart.clientID | default "stalwart") | quote }},
+          "enabled": true,
+          "serviceAccountClientId": {{ ($t.stalwart.clientID | default "stalwart") | quote }},
+          "clientRoles": {
+            "realm-management": [
+              "view-users",
+              "query-users"
+            ]
+          }
+        }
+        {{- if $t.adminEmail }},
+        {
+          "username": "admin",
+          "enabled": true,
+          "email": {{ $t.adminEmail | quote }},
+          "emailVerified": false,
+          "firstName": "Admin",
+          "lastName": {{ ($t.displayName | default $t.realmName) | quote }},
+          "groups": [
+            {{- if $defaultGroup }}
+            {{ $defaultGroup | quote }}
+            {{- end }}
+          ],
+          "requiredActions": [
+            "UPDATE_PASSWORD"
+          ]
+        }
+        {{- end }}
+      ]
+    }
+{{- /* ── wordpress-oidc-client-secret ────────────────────────────────── */}}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $wpSecretName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    catalyst.openova.io/blueprint: bp-keycloak
+    catalyst.openova.io/component: tenant-oidc-client-secret
+    catalyst.openova.io/oidc-client: wordpress
+    catalyst.openova.io/tenant-realm: {{ $t.realmName | quote }}
+  annotations:
+    catalyst.openova.io/comment: |
+      Per-tenant Keycloak OIDC client secret for the `wordpress` client
+      registered in realm `{{ $t.realmName }}`. The bp-wordpress-tenant
+      chart consumes this Secret via .Values.keycloak.clientSecretName
+      (default `wordpress-oidc-client-secret`). Bytes persist across
+      `helm upgrade` via lookup-or-generate (issue #915 / C1).
+    helm.sh/resource-policy: keep
+type: Opaque
+stringData:
+  client-secret: {{ $wpSecret | quote }}
+{{- /* ── openclaw-oidc-client-secret ─────────────────────────────────── */}}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $ocSecretName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    catalyst.openova.io/blueprint: bp-keycloak
+    catalyst.openova.io/component: tenant-oidc-client-secret
+    catalyst.openova.io/oidc-client: openclaw
+    catalyst.openova.io/tenant-realm: {{ $t.realmName | quote }}
+  annotations:
+    catalyst.openova.io/comment: |
+      Per-tenant Keycloak OIDC client secret for the `openclaw` client
+      registered in realm `{{ $t.realmName }}`. The bp-openclaw chart
+      consumes this Secret via .Values.keycloak.clientSecretName
+      (default `openclaw-oidc-client-secret`). Bytes persist across
+      `helm upgrade` via lookup-or-generate (issue #915 / C1).
+    helm.sh/resource-policy: keep
+type: Opaque
+stringData:
+  client-secret: {{ $ocSecret | quote }}
+{{- /* ── stalwart-oidc-client-secret ─────────────────────────────────── */}}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $swSecretName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    catalyst.openova.io/blueprint: bp-keycloak
+    catalyst.openova.io/component: tenant-oidc-client-secret
+    catalyst.openova.io/oidc-client: stalwart
+    catalyst.openova.io/tenant-realm: {{ $t.realmName | quote }}
+  annotations:
+    catalyst.openova.io/comment: |
+      Per-tenant Keycloak OIDC client secret for the `stalwart` client
+      registered in realm `{{ $t.realmName }}`. The bp-stalwart-tenant
+      chart consumes this Secret via .Values.keycloak.clientSecretName
+      (default `stalwart-oidc-client-secret`); the OIDC_CLIENT_SECRET
+      key shape is provided alongside `client-secret` so both consumers
+      (legacy ExternalSecret-driven `OIDC_CLIENT_SECRET` AND the
+      generic `client-secret` key) resolve. Bytes persist across `helm
+      upgrade` via lookup-or-generate (issue #915 / C1).
+    helm.sh/resource-policy: keep
+type: Opaque
+stringData:
+  client-secret: {{ $swSecret | quote }}
+  OIDC_CLIENT_SECRET: {{ $swSecret | quote }}
+{{- end }}

--- a/platform/keycloak/chart/tests/tenant-realm-oidc-clients.sh
+++ b/platform/keycloak/chart/tests/tenant-realm-oidc-clients.sh
@@ -1,0 +1,288 @@
+#!/usr/bin/env bash
+# bp-keycloak per-tenant realm + OIDC clients integration test (issue #915, C1).
+#
+# Verifies the chart renders correctly in BOTH installation modes:
+#
+#   1. Sovereign-mothership mode (default)
+#      - sovereignRealm.enabled=true (default)
+#      - configmap-sovereign-realm.yaml renders with `sovereign` realm
+#        and the canonical kubectl / catalyst-ui / catalyst-api-server
+#        clients
+#      - the per-app tenant Secrets are NOT emitted
+#
+#   2. Tenant mode (issue #915 / SME multi-tenant SSO)
+#      - realmConfig.tenant.enabled=true
+#      - configmap-sovereign-realm.yaml SKIPS (mutual exclusion)
+#      - configmap-tenant-realm.yaml renders the tenant realm with
+#        wordpress / openclaw / stalwart OIDC clients pre-registered
+#        and emits per-app `*-oidc-client-secret` Secrets the downstream
+#        bp-wordpress-tenant / bp-openclaw / bp-stalwart-tenant charts
+#        consume
+#      - The keycloak-config-cli post-install Job mounts the SAME
+#        ConfigMap name (`<release>-sovereign-realm-config`) so no
+#        further values plumbing is needed — the Job picks up whichever
+#        realm template rendered it.
+#
+# Companion to the orchestrator-side test
+# (products/catalyst/bootstrap/api/internal/handler/sme_tenant_keycloak_values_test.go)
+# from PR #911. Together they form the contract: orchestrator emits
+# realmConfig.tenant.* → chart honours it. Each side guards its half.
+#
+# Usage: bash tests/tenant-realm-oidc-clients.sh [CHART_DIR]
+
+set -euo pipefail
+
+CHART_DIR="${1:-$(cd "$(dirname "$0")/.." && pwd)}"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+cd "$CHART_DIR"
+if [ ! -d charts ] || [ -z "$(ls -A charts 2>/dev/null)" ]; then
+  helm dependency build >/dev/null
+fi
+
+PYTHON="${PYTHON:-python3}"
+if ! command -v "$PYTHON" >/dev/null; then
+  echo "FAIL: python3 is required for JSON-parse assertions in this test." >&2
+  exit 1
+fi
+
+echo "[tenant-realm] Case 1: Sovereign-mothership default render"
+helm template smoke-kc . > "$TMP/sov.yaml"
+
+if ! grep -q '"realm": "sovereign"' "$TMP/sov.yaml"; then
+  echo "FAIL: Sovereign-mode default render does not declare realm 'sovereign'." >&2
+  exit 1
+fi
+if ! grep -q '"clientId": "kubectl"' "$TMP/sov.yaml"; then
+  echo "FAIL: Sovereign-mode default render does not contain kubectl client." >&2
+  exit 1
+fi
+if ! grep -q '"clientId": "catalyst-ui"' "$TMP/sov.yaml"; then
+  echo "FAIL: Sovereign-mode default render does not contain catalyst-ui client." >&2
+  exit 1
+fi
+if ! grep -q '"clientId": "catalyst-api-server"' "$TMP/sov.yaml"; then
+  echo "FAIL: Sovereign-mode default render does not contain catalyst-api-server client." >&2
+  exit 1
+fi
+# Tenant-mode artefacts MUST NOT leak into Sovereign render.
+for forbidden in \
+  "wordpress-oidc-client-secret" \
+  "openclaw-oidc-client-secret" \
+  "stalwart-oidc-client-secret" \
+  "catalyst.openova.io/realm-mode: tenant"; do
+  if grep -q "$forbidden" "$TMP/sov.yaml"; then
+    echo "FAIL: Sovereign-mode render leaked tenant-mode artefact: $forbidden" >&2
+    exit 1
+  fi
+done
+echo "  PASS"
+
+echo "[tenant-realm] Case 2: Tenant-mode render with full operator values"
+helm template smoke-kc . \
+  --set realmConfig.tenant.enabled=true \
+  --set realmConfig.tenant.realmName=sme-acme \
+  --set realmConfig.tenant.displayName="Acme SME" \
+  --set realmConfig.tenant.parentDomain=omantel.omani.works \
+  --set realmConfig.tenant.subdomain=acme \
+  --set realmConfig.tenant.adminEmail=admin@acme.example \
+  --set sovereignFQDN=acme.omantel.omani.works \
+  --set gateway.host=keycloak.acme.omantel.omani.works \
+  > "$TMP/tenant.yaml"
+
+# The realm CM uses the SAME name as Sovereign mode so existingConfigmap
+# resolves identically in both modes. Sovereign-realm template must be
+# gated off — only ONE realm CM in the render.
+realm_cm_count=$(grep -c "^  name: smoke-kc-sovereign-realm-config$" "$TMP/tenant.yaml" || true)
+if [ "$realm_cm_count" -ne 1 ]; then
+  echo "FAIL: Tenant-mode render produced $realm_cm_count realm ConfigMaps (expected exactly 1)." >&2
+  exit 1
+fi
+# catalyst-kc-sa-credentials Secret is part of the sovereign-realm
+# template; tenant mode must NOT emit it (Sovereign-only artefact).
+if grep -q "catalyst-kc-sa-credentials" "$TMP/tenant.yaml"; then
+  echo "FAIL: Tenant-mode render leaked Sovereign-only catalyst-kc-sa-credentials Secret." >&2
+  exit 1
+fi
+# Sovereign-realm clients MUST NOT appear in tenant-mode realm.
+for forbidden in '"clientId": "kubectl"' '"clientId": "catalyst-ui"' '"clientId": "catalyst-api-server"'; do
+  if grep -q "$forbidden" "$TMP/tenant.yaml"; then
+    echo "FAIL: Tenant-mode render leaked Sovereign-mode client: $forbidden" >&2
+    exit 1
+  fi
+done
+echo "  PASS"
+
+echo "[tenant-realm] Case 3: Tenant realm JSON parses + 3 OIDC clients with correct shape"
+"$PYTHON" - <<'PY' "$TMP/tenant.yaml" "$TMP"
+import sys, yaml, json, pathlib
+
+src, tmp = sys.argv[1], pathlib.Path(sys.argv[2])
+with open(src) as f:
+    docs = list(yaml.safe_load_all(f))
+
+cms = [d for d in docs
+       if d and d.get('kind') == 'ConfigMap'
+       and 'sovereign-realm.json' in (d.get('data') or {})]
+assert len(cms) == 1, f"expected exactly 1 realm-config CM, got {len(cms)}"
+realm = json.loads(cms[0]['data']['sovereign-realm.json'])
+assert realm['realm'] == 'sme-acme', f"realm name mismatch: {realm['realm']!r}"
+assert realm['displayName'] == 'Acme SME', f"displayName mismatch: {realm['displayName']!r}"
+
+clients = {c['clientId']: c for c in realm['clients']}
+required = {'wordpress', 'openclaw', 'stalwart'}
+missing = required - clients.keys()
+assert not missing, f"missing OIDC clients: {missing}"
+assert len(clients) == 3, f"expected exactly 3 clients, got {sorted(clients)}"
+
+# Spec contract assertions per #915 task brief.
+wp = clients['wordpress']
+assert wp['publicClient'] is False, "wordpress must be confidential"
+assert wp['standardFlowEnabled'] is True, "wordpress needs auth-code flow"
+wp_uris = wp['redirectUris']
+assert any('wp-login.php' in u for u in wp_uris), \
+    f"wordpress redirect missing wp-login.php fallback: {wp_uris}"
+assert any('admin-ajax.php' in u and 'openid-connect-authorize' in u for u in wp_uris), \
+    f"wordpress redirect missing openid-connect-generic plugin callback: {wp_uris}"
+assert wp['secret'], "wordpress client secret must be present in realm JSON"
+
+oc = clients['openclaw']
+assert oc['publicClient'] is False, "openclaw must be confidential"
+assert oc['standardFlowEnabled'] is True, "openclaw needs auth-code flow"
+oc_uris = oc['redirectUris']
+assert any(u.endswith('/oauth/callback') for u in oc_uris), \
+    f"openclaw redirect missing /oauth/callback per #915 spec: {oc_uris}"
+assert oc['secret'], "openclaw client secret must be present in realm JSON"
+
+sw = clients['stalwart']
+assert sw['publicClient'] is False, "stalwart must be confidential"
+assert sw['serviceAccountsEnabled'] is True, \
+    "stalwart needs serviceAccountsEnabled=true for client-credentials grant " \
+    "(directory.keycloak type=oidc backend uses it for IMAP/SMTP token introspection)"
+assert sw['standardFlowEnabled'] is True, \
+    "stalwart needs standardFlowEnabled=true for webmail auth-code login"
+assert sw['secret'], "stalwart client secret must be present in realm JSON"
+
+# clientScopeMappings: stalwart's service-account user has the
+# realm-management view-users role so client_credentials introspection
+# can resolve user info for IMAP auth.
+sa_users = [u for u in realm['users']
+            if u.get('serviceAccountClientId') == 'stalwart']
+assert len(sa_users) == 1, "stalwart service-account user should be present"
+sa = sa_users[0]
+assert 'view-users' in sa.get('clientRoles', {}).get('realm-management', []), \
+    "stalwart service-account needs realm-management:view-users for token introspection"
+
+# Default groups + admin user wired up.
+assert realm['defaultGroups'], f"defaultGroups missing: {realm}"
+assert any(g['name'] == 'sme-admins' for g in realm['groups']), "sme-admins group missing"
+assert any(u.get('username') == 'admin' and u.get('email') == 'admin@acme.example'
+           for u in realm['users']), "admin bootstrap user missing"
+
+# Per-app K8s Secrets — bytes match what's in the realm JSON.
+secrets = {d['metadata']['name']: d for d in docs
+           if d and d.get('kind') == 'Secret'
+           and d['metadata']['name'].endswith('-oidc-client-secret')}
+assert set(secrets) == {
+    'wordpress-oidc-client-secret',
+    'openclaw-oidc-client-secret',
+    'stalwart-oidc-client-secret',
+}, f"per-app secrets missing: {sorted(secrets)}"
+
+# Stalwart Secret carries BOTH client-secret (generic) and OIDC_CLIENT_SECRET
+# (Stalwart's runtime env-var name) so both consumers resolve.
+sw_secret = secrets['stalwart-oidc-client-secret']
+sw_data = sw_secret.get('stringData') or sw_secret.get('data') or {}
+assert 'client-secret' in sw_data, "stalwart secret missing client-secret key"
+assert 'OIDC_CLIENT_SECRET' in sw_data, "stalwart secret missing OIDC_CLIENT_SECRET key"
+
+# Realm secrets must match Secret bytes (single-template-scope invariant).
+def _val(s, key):
+    sd = s.get('stringData') or {}
+    if key in sd:
+        return sd[key]
+    import base64
+    d = s.get('data') or {}
+    if key in d:
+        return base64.b64decode(d[key]).decode()
+    return None
+
+assert _val(secrets['wordpress-oidc-client-secret'], 'client-secret') == wp['secret'], \
+    "wordpress realm-JSON secret != K8s Secret bytes (template-scope drift)"
+assert _val(secrets['openclaw-oidc-client-secret'], 'client-secret') == oc['secret'], \
+    "openclaw realm-JSON secret != K8s Secret bytes (template-scope drift)"
+assert _val(secrets['stalwart-oidc-client-secret'], 'client-secret') == sw['secret'], \
+    "stalwart realm-JSON secret != K8s Secret bytes (template-scope drift)"
+
+# helm.sh/resource-policy: keep — Secrets must outlive the release so
+# re-install picks the bytes back up via lookup (mirrors marketplace-api/
+# secret.yaml pattern, issue #887).
+for name, s in secrets.items():
+    ann = (s['metadata'].get('annotations') or {})
+    assert ann.get('helm.sh/resource-policy') == 'keep', \
+        f"{name} missing helm.sh/resource-policy: keep — re-install will rotate the secret"
+
+print("[parse-asserts] all tenant-realm structural assertions pass")
+PY
+echo "  PASS"
+
+echo "[tenant-realm] Case 4: Fail-closed validation when required tenant fields absent"
+if helm template smoke-kc . \
+    --set realmConfig.tenant.enabled=true \
+    --set sovereignFQDN=acme.omantel.omani.works \
+    --set gateway.host=keycloak.acme.omantel.omani.works \
+    > "$TMP/fail.yaml" 2> "$TMP/fail.err"; then
+  echo "FAIL: Tenant-mode render with no realmName / parentDomain / subdomain unexpectedly succeeded." >&2
+  exit 1
+fi
+if ! grep -q "realmConfig.tenant.enabled=true requires" "$TMP/fail.err"; then
+  echo "FAIL: Tenant-mode missing-field error did not surface fail-closed message." >&2
+  cat "$TMP/fail.err" >&2
+  exit 1
+fi
+echo "  PASS"
+
+echo "[tenant-realm] Case 5: keycloak-config-cli Job picks up tenant ConfigMap by SAME name"
+# Both modes set existingConfigmap to '<release>-sovereign-realm-config'
+# via values.yaml; the same Job resolves both renderings — no separate
+# Job override is needed in the orchestrator emit.
+if ! grep -q '^            name: smoke-kc-sovereign-realm-config$' "$TMP/tenant.yaml"; then
+  echo "FAIL: tenant-mode render does not project the realm CM into a Pod by its expected name." >&2
+  exit 1
+fi
+if ! grep -q "helm.sh/hook: post-install,post-upgrade,post-rollback" "$TMP/tenant.yaml"; then
+  echo "FAIL: tenant-mode render missing keycloak-config-cli post-install Helm hook." >&2
+  exit 1
+fi
+echo "  PASS"
+
+echo "[tenant-realm] Case 6: Operator-supplied per-app clientSecret overrides lookup"
+helm template smoke-kc . \
+  --set realmConfig.tenant.enabled=true \
+  --set realmConfig.tenant.realmName=sme-acme \
+  --set realmConfig.tenant.parentDomain=omantel.omani.works \
+  --set realmConfig.tenant.subdomain=acme \
+  --set realmConfig.tenant.wordpress.clientSecret="OPERATOR_WP_SECRET_VAL" \
+  --set realmConfig.tenant.openclaw.clientSecret="OPERATOR_OC_SECRET_VAL" \
+  --set realmConfig.tenant.stalwart.clientSecret="OPERATOR_SW_SECRET_VAL" \
+  --set sovereignFQDN=acme.omantel.omani.works \
+  --set gateway.host=keycloak.acme.omantel.omani.works \
+  > "$TMP/operator-override.yaml"
+
+# Realm JSON should carry the operator-supplied values verbatim.
+if ! grep -q '"secret": "OPERATOR_WP_SECRET_VAL"' "$TMP/operator-override.yaml"; then
+  echo "FAIL: operator-supplied wordpress.clientSecret did not flow into realm JSON." >&2
+  exit 1
+fi
+if ! grep -q '"secret": "OPERATOR_OC_SECRET_VAL"' "$TMP/operator-override.yaml"; then
+  echo "FAIL: operator-supplied openclaw.clientSecret did not flow into realm JSON." >&2
+  exit 1
+fi
+if ! grep -q '"secret": "OPERATOR_SW_SECRET_VAL"' "$TMP/operator-override.yaml"; then
+  echo "FAIL: operator-supplied stalwart.clientSecret did not flow into realm JSON." >&2
+  exit 1
+fi
+echo "  PASS"
+
+echo "[tenant-realm] All bp-keycloak tenant-realm OIDC-clients gates green."

--- a/platform/keycloak/chart/values.yaml
+++ b/platform/keycloak/chart/values.yaml
@@ -78,6 +78,108 @@ smtp:
   starttls: "true"
   auth: "true"
 
+# ─── Per-tenant realm configuration (issue #915, SME multi-tenant SSO) ────
+#
+# When the bp-keycloak chart is installed for an SME tenant (one Keycloak
+# Pod per SME under a per-tenant Namespace), the Sovereign realm import
+# is NOT what we want — the tenant has its own realm with per-app OIDC
+# clients (wordpress / openclaw / stalwart) so each app federates against
+# THIS tenant's identity store, not the Sovereign-wide one.
+#
+# Set realmConfig.tenant.enabled=true to switch the chart into tenant
+# mode:
+#   - configmap-sovereign-realm.yaml SKIPS (gated mutual exclusion)
+#   - configmap-tenant-realm.yaml RENDERS with the tenant realm JSON
+#     and three per-app OIDC client Secrets (wordpress-oidc-client-secret,
+#     openclaw-oidc-client-secret, stalwart-oidc-client-secret) that the
+#     downstream bp-wordpress-tenant / bp-openclaw / bp-stalwart-tenant
+#     charts consume via secretKeyRef.
+#   - The keycloak-config-cli post-install Job picks up the tenant
+#     ConfigMap (same name `{{ .Release.Name }}-sovereign-realm-config`
+#     so the existing existingConfigmap reference still resolves) and
+#     imports the tenant realm idempotently.
+#
+# Per-app client secrets persist via Helm `lookup` (same pattern as
+# templates/configmap-sovereign-realm.yaml's catalystApiServerClientSecret
+# resolution and products/catalyst/chart/templates/marketplace-api/
+# secret.yaml's jwt-secret pattern) — first install generates a fresh
+# random; subsequent reconciles re-emit the existing bytes verbatim so
+# downstream apps don't see secret rotation.
+#
+# Per Inviolable Principle #4 (never hardcode), every host-derived field
+# is templated off `realmConfig.tenant.parentDomain` +
+# `realmConfig.tenant.subdomain` (or operator-supplied per-app hosts).
+# Per Inviolable Principle #10 (never print credentials), the per-app
+# client secrets only land in the generated K8s Secret bytes — never in
+# stdout / logs / git.
+realmConfig:
+  tenant:
+    # Master switch — when false (default), chart stays in Sovereign mode.
+    enabled: false
+    # Realm name in the tenant Keycloak (e.g. `sme-acme`). REQUIRED when
+    # enabled=true. Convention: `sme-<subdomain>` matching the tenant
+    # subdomain registered in the SME pool (multi-domain Sovereign #826).
+    realmName: ""
+    # Display name shown in the Keycloak login UI — typically the SME's
+    # company name. Falls back to realmName if blank.
+    displayName: ""
+    # Tenant admin's email — receives the welcome / password-reset mail
+    # when keycloak-config-cli imports the realm with bootstrap users.
+    adminEmail: ""
+    # Tenant zone fields used to template default redirect / origin URIs.
+    # parentDomain example: omantel.omani.works ; subdomain example: acme.
+    # The chart computes default per-app hosts as
+    # <app>.<subdomain>.<parentDomain> when the per-app `host` is unset.
+    parentDomain: ""
+    subdomain: ""
+    # Default groups bootstrapped in the tenant realm. Mirror the
+    # sovereign-admins/sovereign-ops/sovereign-viewers triad at the SME
+    # level so RBAC scaffolding is consistent.
+    groups:
+      - sme-admins
+      - sme-users
+    # Per-app OIDC client configuration. Each block honours an operator-
+    # supplied `clientSecret` (rare; useful for sealed-secret replication)
+    # — when blank the chart looks up an existing K8s Secret in the
+    # release namespace and persists; on a fresh install a 32-char
+    # randAlphaNum value is generated.
+    wordpress:
+      # Public host the WordPress site is reachable at. Defaults to
+      # wordpress.<subdomain>.<parentDomain> when unset.
+      host: ""
+      # OIDC client ID — the bp-wordpress-tenant chart consumes this
+      # via .Values.keycloak.clientID (default "wordpress").
+      clientID: "wordpress"
+      # Pre-generated client secret. Leave blank for self-bootstrap via
+      # lookup-or-generate.
+      clientSecret: ""
+      # Name of the K8s Secret materialised in the tenant Namespace.
+      # bp-wordpress-tenant references this by default
+      # (`wordpress-oidc-client-secret`).
+      clientSecretName: "wordpress-oidc-client-secret"
+      # Redirect URIs registered in Keycloak. Leave empty to use the
+      # default templated off the host (the openid-connect-generic
+      # WP plugin's admin-ajax.php callback + /wp-login.php).
+      redirectURIs: []
+    openclaw:
+      host: ""
+      clientID: "openclaw"
+      clientSecret: ""
+      clientSecretName: "openclaw-oidc-client-secret"
+      # Default redirect URI: https://<host>/oauth/callback (per #915 spec)
+      redirectURIs: []
+    stalwart:
+      host: ""
+      clientID: "stalwart"
+      clientSecret: ""
+      clientSecretName: "stalwart-oidc-client-secret"
+      # Stalwart's `directory.keycloak` of type=oidc uses the
+      # client_credentials grant (serviceAccountsEnabled=true) to
+      # introspect tokens for IMAP/SMTP auth. The webmail UI also uses
+      # the auth-code flow — both flows are enabled on the same client
+      # by default so a single registration covers both sides.
+      redirectURIs: []
+
 # ─── Upstream chart values (subchart key: keycloak) ───────────────────────
 # Generated by docs/PROVISIONING-PLAN.md tickets [F] chart Pass 105+.
 keycloak:


### PR DESCRIPTION
## Summary

C1 of issue #915. PR #911 wired the SME tenant orchestrator to emit
`realmConfig.tenant.enabled=true` on the per-tenant bp-keycloak HelmRelease — but the chart had no template that consumed those values, so the WordPress / OpenClaw / Stalwart OIDC integrations had no client registered in the tenant realm and SSO failed end-to-end.

This PR adds the chart-side template the orchestrator was already emitting for. Sovereign-mode is unchanged; tenant-mode is new.

## What ships

When `realmConfig.tenant.enabled=true`:

- `configmap-sovereign-realm.yaml` SKIPS (mutual-exclusion guard added on the existing template) so only one realm CM is rendered.
- NEW `templates/configmap-tenant-realm.yaml` renders a realm import ConfigMap (SAME name `<release>-sovereign-realm-config` so the upstream `keycloak-config-cli` `existingConfigmap` reference still resolves) carrying the tenant realm + 3 OIDC clients:
  - **wordpress** — confidential, auth-code; redirect URIs cover the `openid-connect-generic` plugin's `admin-ajax.php?action=openid-connect-authorize` callback + `/wp-login.php` fallback
  - **openclaw** — confidential, auth-code; redirect URI `/oauth/callback` (per #915 task brief)
  - **stalwart** — confidential, `serviceAccountsEnabled=true` so the `directory.keycloak` type=`oidc` backend can use client_credentials to introspect IMAP/SMTP tokens; `standardFlowEnabled=true` for webmail UI auth-code
- NEW per-app Secrets emitted in the same template scope as the realm ConfigMap so the realm JSON's `secret` field and the K8s Secret bytes never drift:
  - `wordpress-oidc-client-secret`
  - `openclaw-oidc-client-secret`
  - `stalwart-oidc-client-secret` (carries BOTH `client-secret` AND `OIDC_CLIENT_SECRET` keys for the two consumer paths)
- Each per-app secret persists across `helm upgrade` via lookup-or-generate (mirrors `marketplace-api/secret.yaml` pattern from #887 and the existing `catalyst-api-server` secret in `configmap-sovereign-realm.yaml`). `helm.sh/resource-policy: keep` so bytes outlive uninstall.
- Fail-closed validation when `realmConfig.tenant.enabled=true` and any of `realmName` / `parentDomain` / `subdomain` is unset (Inviolable Principle #4).

## Test plan

NEW `tests/tenant-realm-oidc-clients.sh` covers 6 cases — all green locally:

- [x] Case 1: Sovereign-mode default render unchanged (kubectl + catalyst-ui + catalyst-api-server clients present, no tenant artefacts leak)
- [x] Case 2: Tenant-mode render produces exactly ONE realm CM under the expected name + zero leaked Sovereign-only resources
- [x] Case 3: Tenant realm JSON parses + 3 OIDC clients present with the redirect-URI / publicClient / serviceAccountsEnabled shape per #915 spec; Secret bytes match realm JSON's `secret` fields
- [x] Case 4: Fail-closed validation when tenant fields missing
- [x] Case 5: `keycloak-config-cli` post-install Job projects the realm CM by SAME name in BOTH modes
- [x] Case 6: Operator-supplied per-app `clientSecret` overrides the lookup-or-generate path
- [x] Existing `tests/observability-toggle.sh` + `tests/oidc-kubectl-client.sh` still pass
- [x] `go test ./internal/handler/ -run "TestSMETenant|TestKeycloak|TestRenderSME"` green (orchestrator-side contract from PR #911 still honoured)
- [ ] Post-merge: blueprint-release pipeline publishes `bp-keycloak:1.4.0` OCI artifact; tenant signup on otech107 picks up the new chart and the per-tenant realm gets imported with all 3 clients

## Closes

- #915 (C1 sub-task)
- Chart-side gap left by #911 (orchestrator emit was correct; chart needed to consume)

## Hard rules honoured

- Sovereign-mode behaviour is byte-for-byte unchanged (existing tests pass)
- No credentials in template, commit message, or CI logs (Inviolable Principle #10)
- All host-derived URIs templated off `realmConfig.tenant.{parentDomain,subdomain}` (Inviolable Principle #4)
- Same lookup-or-generate persistence pattern as the existing canonical seam (anti-duplication)

🤖 Generated with [Claude Code](https://claude.com/claude-code)