### PR TITLE
feat(bp-newapi): auto-seed channel #1 = Qwen3.6 @ BankDhofar (#915)

### DIFF
--- a/clusters/_template/bootstrap-kit/80-newapi.yaml
+++ b/clusters/_template/bootstrap-kit/80-newapi.yaml
@@ -63,11 +63,14 @@ spec:
   chart:
     spec:
       chart: bp-newapi
-      # 1.2.0: Traefik Middleware gated behind ingress.middleware.enabled
-      # (default false) — was hard-rendering on Cilium Sovereigns and
-      # failing install with "no matches for kind Middleware". See live
-      # otech103 failure 2026-05-04 21:30 Berlin.
-      version: 1.2.0
+      # 1.3.0: defaultChannels.qwenBankDhofar (channel #1 = Qwen3.6 @
+      # https://llm-api.omtd.bankdhofar.com) + post-install/post-upgrade
+      # `channel-seed` Helm hook Job that idempotently POSTs default
+      # channels into NewAPI's admin API. Issue #915 (epic SME tenant
+      # integration DoD: alice → OpenClaw → NewAPI → Qwen3.6@BankDhofar
+      # end-to-end).
+      # 1.2.0: Traefik Middleware gated behind ingress.middleware.enabled.
+      version: 1.3.0
       sourceRef:
         kind: HelmRepository
         name: bp-newapi
@@ -135,15 +138,55 @@ spec:
           # path is `secret/sovereign/<fqdn>/newapi/admin-token`.
           key: sovereign/${SOVEREIGN_FQDN}/newapi/admin-token
           property: ADMIN_API_TOKEN
-    # Default vLLM channel — disabled in the template so a fresh
-    # Sovereign does not silently wire customers to a third-party
-    # endpoint. Per-Sovereign overlays (e.g.
-    # `clusters/<sovereign>/bootstrap-kit/80-newapi.yaml`) enable this
-    # block and supply a concrete `endpoint`, `models`, and
-    # `attestation.owner`. The first-otech canonical reference is
-    # `https://llm-api.omtd.bankdhofar.com` with `qwen3-coder` (the same
-    # relay Axon uses on the OpenOva marketing deployment).
+    # Default channels — chart-side composition (channel #1 first).
+    #
+    # `qwenBankDhofar` (issue #915) is the canonical first channel:
+    # Qwen3.6 hosted at BankDhofar (https://llm-api.omtd.bankdhofar.com,
+    # model `qwen3-coder` / alias `qwen3.6`) — the SAME relay the
+    # OpenOva marketing site's Axon helmrelease consumes
+    # (openova-private/clusters/contabo-mkt/apps/axon/helmrelease.yaml).
+    # Disabled in the template so a fresh Sovereign does not silently
+    # wire customers to a third-party endpoint; per-Sovereign overlays
+    # (clusters/<sovereign>/bootstrap-kit/80-newapi.yaml) enable this
+    # block and supply:
+    #   - defaultChannels.qwenBankDhofar.enabled = true
+    #   - defaultChannels.qwenBankDhofar.endpoint = https://llm-api.omtd.bankdhofar.com
+    #   - defaultChannels.qwenBankDhofar.attestation.accountId   (legal-team-owned)
+    #   - defaultChannels.qwenBankDhofar.attestation.contractRef (legal-team-owned)
+    #   - the Secret `newapi-channel-qwen-bankdhofar` containing the
+    #     upstream API key under key `API_KEY` (or an ExternalSecret
+    #     pulling from OpenBao at
+    #     `sovereign/<sovereign-fqdn>/newapi/channel-qwen-bankdhofar`)
+    #   - auth.adminUI.masterKeySecret = name of a Secret carrying
+    #     `MASTER_KEY` (NewAPI bootstrap admin auth) — required for
+    #     the channel-seed Helm hook Job to POST against the admin API
+    #     ONCE at install time. Operator may rotate the master key out
+    #     post-bootstrap; channels persist in Postgres.
+    #
+    # When the operator flips `qwenBankDhofar.enabled: true`, the
+    # chart's post-install/post-upgrade `channel-seed` Job probes
+    # NewAPI's admin API (`/api/channel/?keyword=<name>`) and POSTs
+    # the channel definition idempotently. Re-runs after upgrades
+    # are no-ops once the channel exists.
+    #
+    # The legacy `vllm` slot (in-cluster vLLM fallback) remains for
+    # operators that run their own bp-vllm + open-weight model in-
+    # cluster; it composes after `qwenBankDhofar` and any operator
+    # `.Values.channels`.
     defaultChannels:
+      qwenBankDhofar:
+        enabled: false
+        name: qwen3.6-bankdhofar
+        endpoint: ""
+        models:
+          - qwen3.6
+          - qwen3-coder
+        existingSecret: newapi-channel-qwen-bankdhofar
+        existingSecretKey: API_KEY
+        attestation:
+          kind: commercial-contract
+          accountId: ""
+          contractRef: ""
       vllm:
         enabled: false
         name: qwen

--- a/platform/newapi/chart/Chart.yaml
+++ b/platform/newapi/chart/Chart.yaml
@@ -1,6 +1,15 @@
 apiVersion: v2
 name: bp-newapi
-version: 1.2.0
+# 1.3.0: defaultChannels.qwenBankDhofar (channel #1 = Qwen3.6 @
+# https://llm-api.omtd.bankdhofar.com) + post-install/post-upgrade
+# `channel-seed` Helm hook Job that idempotently POSTs default
+# channels into NewAPI's admin API at /api/channel/. Bridges the
+# previous documentation-only channels.yaml ConfigMap → the actual
+# Postgres-backed channel rows the upstream binary reads at runtime.
+# Issue #915 (epic SME tenant integration DoD: alice → OpenClaw →
+# NewAPI → Qwen3.6@BankDhofar end-to-end).
+# 1.2.0: Traefik Middleware gated behind ingress.middleware.enabled.
+version: 1.3.0
 appVersion: "0.4.5"
 description: |
   Catalyst Blueprint scratch chart for NewAPI — multi-tenant LLM

--- a/platform/newapi/chart/templates/_helpers.tpl
+++ b/platform/newapi/chart/templates/_helpers.tpl
@@ -63,13 +63,45 @@ ConfigMap name (channel + policy config).
 {{- end }}
 
 {{/*
-Effective channel list — `.Values.channels` plus the composed
-`defaultChannels.vllm` channel when enabled. Centralised so configmap.yaml
-and assertChannelAttestation operate on the same materialised list.
+Effective channel list — composed default channels plus
+`.Values.channels`. Composition order matters because NewAPI's
+channel-router resolves `model` lookups in row-insertion order:
+  1. defaultChannels.qwenBankDhofar     (issue #915 — channel #1)
+  2. .Values.channels                    (operator-supplied)
+  3. defaultChannels.vllm                (in-cluster vLLM fallback)
+A fresh customer landing on a fresh Sovereign with no
+`.Values.channels` set hits qwenBankDhofar first; this is the
+documented "channel #1 = Qwen3.6@BankDhofar" contract from epic #915
+(per-tenant SME alice → NewAPI → Qwen3.6@BankDhofar end-to-end DoD).
+Centralised so configmap.yaml + assertChannelAttestation +
+channel-seed-job.yaml operate on the same materialised list.
 */}}
 {{- define "bp-newapi.effectiveChannels" -}}
-{{- $channels := default (list) .Values.channels -}}
+{{- $channels := list -}}
 {{- $dc := .Values.defaultChannels | default dict -}}
+{{/* ── Channel #1: Qwen3.6 @ BankDhofar (#915) ───────────────── */}}
+{{- $qbd := $dc.qwenBankDhofar | default dict -}}
+{{- if $qbd.enabled -}}
+  {{- if not $qbd.endpoint -}}
+    {{- fail "defaultChannels.qwenBankDhofar.enabled=true but defaultChannels.qwenBankDhofar.endpoint is empty — supply the upstream relay URL in the per-Sovereign bootstrap-kit overlay (canonical: https://llm-api.omtd.bankdhofar.com)" -}}
+  {{- end -}}
+  {{- $att := $qbd.attestation | default (dict "kind" "commercial-contract") -}}
+  {{- $composed := dict
+        "name"      (default "qwen3.6-bankdhofar" $qbd.name)
+        "type"      "openai-compatible"
+        "endpoint"  $qbd.endpoint
+        "models"    (default (list "qwen3.6" "qwen3-coder") $qbd.models)
+        "attestation" $att -}}
+  {{- if $qbd.existingSecret -}}
+    {{- $_ := set $composed "existingSecret" $qbd.existingSecret -}}
+  {{- end -}}
+  {{- $channels = append $channels $composed -}}
+{{- end -}}
+{{/* ── Operator-supplied channels (in-order) ──────────────────── */}}
+{{- range (default (list) .Values.channels) -}}
+  {{- $channels = append $channels . -}}
+{{- end -}}
+{{/* ── Default vLLM (in-cluster fallback) ─────────────────────── */}}
 {{- $vllm := $dc.vllm | default dict -}}
 {{- if $vllm.enabled -}}
   {{- if not $vllm.endpoint -}}
@@ -88,6 +120,14 @@ and assertChannelAttestation operate on the same materialised list.
 {{- end -}}
 {{- toYaml $channels -}}
 {{- end -}}
+
+{{/*
+Channel-seed Job name. Reused by the Job + RBAC + ConfigMap manifests
+emitted by templates/channel-seed-job.yaml.
+*/}}
+{{- define "bp-newapi.channelSeedJobName" -}}
+{{- printf "%s-channel-seed" (include "bp-newapi.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}
 
 {{/*
 Channel attestation gate — refuses to render if any enabled channel

--- a/platform/newapi/chart/templates/channel-seed-job.yaml
+++ b/platform/newapi/chart/templates/channel-seed-job.yaml
@@ -1,0 +1,397 @@
+{{- /*
+Channel-seed Job (issue #915, parent epic #915).
+
+Per-Sovereign NewAPI MUST come up with channel #1 = Qwen3.6 hosted at
+BankDhofar already wired, so the FIRST customer request from an SME's
+OpenClaw → NewAPI hits a real upstream LLM rather than a 404 / "no
+channel found" error. The chart's existing ConfigMap (channels.yaml
+mounted at /etc/newapi/channels.yaml) is a documentation surface only —
+the upstream NewAPI binary persists channel state to its Postgres
+`channels` table via its admin API. This Job bridges that gap.
+
+Trigger:
+  - hook: post-install,post-upgrade — runs after Helm has applied
+    every other manifest in this chart, so the Service + Pod already
+    exist by the time the Job's first probe lands.
+  - hook-weight: "10" — runs after any "5"-weighted hooks (RBAC).
+  - hook-delete-policy: before-hook-creation — keep the most recent
+    Job around for operator forensics ('kubectl logs job/...') but
+    delete the previous one before each new install/upgrade so we do
+    not accumulate immutable Job objects across releases.
+
+Idempotency:
+  - For each channel the Job knows about, GET
+    `/api/channel/?keyword=<name>` first; if any returned row's
+    `name` field exactly matches, the channel is already seeded and
+    the loop SKIPs the POST. Re-runs after a chart upgrade are pure
+    no-ops once the channels exist.
+  - The Job is therefore safe to leave enabled across upgrades; it
+    will simply discover that channels already exist and exit clean.
+
+Authorization:
+  - NewAPI's admin API requires either an authenticated session
+    cookie OR the bootstrap MASTER_KEY in
+    `Authorization: Bearer <master-key>`. The Job mounts the operator-
+    supplied master-key Secret (`auth.adminUI.masterKeySecret`) and
+    uses it ONCE at install time. Operators that have rotated the
+    master key OUT post-bootstrap (the secure path) can re-supply it
+    transiently for the upgrade window or disable this Job
+    (`channelSeed.enabled: false`).
+
+Skip-render:
+  - When `channelSeed.enabled: false` the Job + RBAC bundle is
+    suppressed entirely.
+  - When NO default channel is enabled (`qwenBankDhofar.enabled:
+    false` AND no other future defaultChannels.* slot is on), the
+    Job has nothing to seed and is also suppressed (no-op render).
+  - When the operator has not supplied `auth.adminUI.masterKeySecret`,
+    the Job has no auth and is suppressed; the operator's own
+    out-of-band channel-creation flow takes over.
+
+Per docs/INVIOLABLE-PRINCIPLES.md #4 (never hardcode) every
+operationally-meaningful value flows from values.yaml — image,
+resources, backoff, deadline, channel list itself.
+
+Issue #915, 2026-05-05.
+*/}}
+{{- $cs := .Values.channelSeed | default dict -}}
+{{- $qbd := (.Values.defaultChannels | default dict).qwenBankDhofar | default dict -}}
+{{- $hasDefaults := $qbd.enabled -}}
+{{- $masterKeySecret := .Values.auth.adminUI.masterKeySecret | default "" -}}
+{{- if and $cs.enabled $hasDefaults $masterKeySecret -}}
+{{- $jobName := include "bp-newapi.channelSeedJobName" . -}}
+---
+{{- /*
+ServiceAccount + Role + RoleBinding for the Job.
+
+The Job needs read access to the master-key Secret AND any per-channel
+upstream-API-key Secrets (one Secret per default channel that has
+`existingSecret` set). We give it a dedicated SA + Role pair (NOT the
+NewAPI Deployment's SA) so the bootstrap posture is bounded — the SA
+can read the named Secrets and nothing else.
+*/}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ $jobName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "bp-newapi.labels" . | nindent 4 }}
+    catalyst.openova.io/component: channel-seed
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "5"
+    "helm.sh/hook-delete-policy": {{ $cs.hookDeletePolicy | default "before-hook-creation" | quote }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ $jobName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "bp-newapi.labels" . | nindent 4 }}
+    catalyst.openova.io/component: channel-seed
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "5"
+    "helm.sh/hook-delete-policy": {{ $cs.hookDeletePolicy | default "before-hook-creation" | quote }}
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames:
+      - {{ $masterKeySecret | quote }}
+{{- if and $qbd.enabled $qbd.existingSecret }}
+      - {{ $qbd.existingSecret | quote }}
+{{- end }}
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ $jobName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "bp-newapi.labels" . | nindent 4 }}
+    catalyst.openova.io/component: channel-seed
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "5"
+    "helm.sh/hook-delete-policy": {{ $cs.hookDeletePolicy | default "before-hook-creation" | quote }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ $jobName }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: {{ $jobName }}
+  apiGroup: rbac.authorization.k8s.io
+---
+{{- /*
+ConfigMap of channel definitions (audit pointer).
+
+The list rendered into data.channels.json is the operator-visible
+audit trail of "what default channels did the Sovereign think it
+should seed on this install/upgrade?". Side-channel only — the Job
+reads the same list directly out of its template-rendered shell
+script. The admin console / docs surface may consume this ConfigMap
+to show a "channels seeded by chart" badge without re-querying NewAPI.
+*/}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ $jobName }}-spec
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "bp-newapi.labels" . | nindent 4 }}
+    catalyst.openova.io/component: channel-seed
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "5"
+    "helm.sh/hook-delete-policy": {{ $cs.hookDeletePolicy | default "before-hook-creation" | quote }}
+    catalyst.openova.io/comment: |
+      Audit pointer for the default channels seeded on this install/
+      upgrade. Consumed by the admin console / docs UI to render the
+      list without re-querying NewAPI's admin API.
+data:
+  channels.json: |
+    {{- $list := list }}
+    {{- if $qbd.enabled }}
+      {{- $list = append $list (dict
+            "name"     (default "qwen3.6-bankdhofar" $qbd.name)
+            "type"     "openai-compatible"
+            "endpoint" $qbd.endpoint
+            "models"   (default (list "qwen3.6" "qwen3-coder") $qbd.models)) }}
+    {{- end }}
+    {{ $list | toJson }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ $jobName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "bp-newapi.labels" . | nindent 4 }}
+    catalyst.openova.io/component: channel-seed
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "10"
+    "helm.sh/hook-delete-policy": {{ $cs.hookDeletePolicy | default "before-hook-creation" | quote }}
+spec:
+  backoffLimit: {{ $cs.backoffLimit | default 6 }}
+  activeDeadlineSeconds: {{ $cs.activeDeadlineSeconds | default 300 }}
+  template:
+    metadata:
+      labels:
+        {{- include "bp-newapi.selectorLabels" . | nindent 8 }}
+        catalyst.openova.io/component: channel-seed
+    spec:
+      restartPolicy: OnFailure
+      serviceAccountName: {{ $jobName }}
+      volumes:
+        - name: tmp
+          emptyDir:
+            medium: Memory
+            sizeLimit: 8Mi
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        fsGroup: 65532
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: channel-seed
+          image: "{{ $cs.image.repository }}:{{ $cs.image.tag }}"
+          imagePullPolicy: {{ $cs.image.pullPolicy | default "IfNotPresent" }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 65532
+            runAsGroup: 65532
+            capabilities:
+              drop: ["ALL"]
+          # curl writes response bodies to /tmp; with readOnlyRootFilesystem
+          # the container's / is RO so /tmp must be backed by an emptyDir
+          # (in-memory, auto-cleaned post-Job).
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+          resources:
+            {{- toYaml $cs.resources | nindent 12 }}
+          env:
+            # In-cluster NewAPI Service. The chart's own service.yaml
+            # exposes port 3000 on the bare Service name {{ include "bp-newapi.fullname" . }}.
+            # The Job runs in the same namespace so the bare name resolves.
+            # Note: when the metering sidecar is enabled the Service still
+            # routes 3000 → sidecar → NewAPI on loopback; the seed Job's
+            # admin-API calls land on the SAME path the customer hits, which
+            # is what we want (it exercises the entire chain end-to-end).
+            - name: NEWAPI_BASE
+              value: "http://{{ include "bp-newapi.fullname" . }}:{{ .Values.service.port }}"
+            - name: NEWAPI_MASTER_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $masterKeySecret | quote }}
+                  key: MASTER_KEY
+{{- if and $qbd.enabled $qbd.existingSecret }}
+            - name: QWEN_BANKDHOFAR_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $qbd.existingSecret | quote }}
+                  key: {{ $qbd.existingSecretKey | default "API_KEY" | quote }}
+{{- end }}
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -eu
+
+              # ─── Idempotent channel-seed loop (issue #915) ──────────
+              #
+              # For each default channel the chart knows about, probe
+              # NewAPI's admin API for an existing row by name; POST a
+              # new row only if the name is not already present.
+              # NewAPI returns:
+              #   200 GET /api/channel/?keyword=<name> with `data:[]`
+              #     → channel does not exist; POST it
+              #   200 GET /api/channel/?keyword=<name> with `data:[...]`
+              #     and an entry whose `name` exactly matches
+              #     → channel already exists; SKIP
+              #   201 POST /api/channel/ → channel created
+              #   any other 4xx/5xx → fail the iteration so the Job
+              #                       backs off and retries (via
+              #                       restartPolicy=OnFailure +
+              #                       backoffLimit on the Job spec).
+              #
+              # NewAPI exposes its admin endpoints under /api/channel/
+              # (upstream Calcium-Ion/new-api: controller/channel.go).
+              # Auth header is `Authorization: Bearer <master-key>`.
+              #
+              # Wait-for-NewAPI: the Service exists from t=0 (Helm
+              # applies it before the post-install hook fires) but the
+              # Pod's readiness probe may not pass for ~30s after
+              # rollout. We poll /api/status until it returns 200,
+              # then proceed with the channel loop.
+
+              base="${NEWAPI_BASE}"
+              master_key="${NEWAPI_MASTER_KEY}"
+
+              echo "Channel-seed: target=${base}"
+              echo "Channel-seed: waiting for /api/status to return 200..."
+              # 60 attempts × 5s = 5min upper bound; outer activeDeadlineSeconds
+              # also caps the total Job runtime.
+              attempt=0
+              until [ "${attempt}" -ge 60 ]; do
+                code=$(curl --silent --output /dev/null --max-time 5 \
+                  --write-out '%{http_code}' \
+                  "${base}/api/status" || echo "000")
+                if [ "${code}" = "200" ]; then
+                  echo "  [OK] /api/status reachable (HTTP 200)"
+                  break
+                fi
+                attempt=$((attempt + 1))
+                echo "  [wait] /api/status HTTP ${code} (attempt ${attempt}/60)"
+                sleep 5
+              done
+
+              # seed_channel: probe by name → POST if missing.
+              # Args: 1=name 2=type 3=base_url 4=models_csv 5=key
+              seed_channel() {
+                local name="$1"
+                local type="$2"
+                local base_url="$3"
+                local models="$4"
+                local key="$5"
+
+                # Probe — the admin API supports keyword= for name search.
+                local probe_code probe_body
+                probe_body=$(curl --silent --max-time 10 \
+                  --output /tmp/probe-resp \
+                  --write-out '%{http_code}' \
+                  -H "Authorization: Bearer ${master_key}" \
+                  -H "Accept: application/json" \
+                  "${base}/api/channel/?keyword=$(echo "${name}" | sed 's/ /%20/g')&p=0")
+                probe_code="${probe_body}"
+
+                if [ "${probe_code}" = "200" ]; then
+                  # Look for an exact name match in the response.
+                  # The upstream returns
+                  # `{"success":true,"data":[{"id":...,"name":"...",...}]}`.
+                  # We grep for the literal `"name":"<name>"` substring
+                  # using `-F` (fixed-string) so channel names with `.` /
+                  # other regex metacharacters (e.g. `qwen3.6-bankdhofar`)
+                  # do not become wildcards.
+                  if grep -qF "\"name\":\"${name}\"" /tmp/probe-resp; then
+                    echo "  [SKIP] channel ${name} already exists"
+                    return 0
+                  fi
+                else
+                  echo "  [warn] probe ${name} HTTP ${probe_code}; will attempt POST anyway"
+                fi
+
+                # Build the JSON body. NewAPI's POST /api/channel/ shape
+                # (upstream controller/channel.go AddChannel):
+                #   {
+                #     "name":     "...",
+                #     "type":     <int-or-string>,        # type registry
+                #     "base_url": "...",                  # upstream endpoint
+                #     "key":      "<api-key>",            # upstream auth
+                #     "models":   "<comma-separated>",    # routed model list
+                #     "groups":   "default",              # default group
+                #     "status":   1                       # 1 = enabled
+                #   }
+                # `type` for OpenAI-compatible upstreams is "openai" in the
+                # upstream registry (constants/channel_type.go).
+                local body
+                body=$(printf '{"name":"%s","type":"%s","base_url":"%s","key":"%s","models":"%s","groups":"default","status":1}' \
+                  "${name}" "${type}" "${base_url}" "${key}" "${models}")
+
+                local post_code
+                post_code=$(curl --silent --max-time 10 \
+                  --output /tmp/post-resp \
+                  --write-out '%{http_code}' \
+                  --retry 3 --retry-delay 2 --retry-connrefused \
+                  -X POST \
+                  -H "Authorization: Bearer ${master_key}" \
+                  -H "Content-Type: application/json" \
+                  --data "${body}" \
+                  "${base}/api/channel/")
+
+                case "${post_code}" in
+                  200|201)
+                    echo "  [OK] channel ${name} created (HTTP ${post_code})"
+                    ;;
+                  409)
+                    # Race: someone else seeded the same name between our
+                    # probe and POST. Idempotent OK.
+                    echo "  [OK] channel ${name} already exists (HTTP 409)"
+                    ;;
+                  *)
+                    echo "  [FAIL] channel ${name} HTTP ${post_code}:"
+                    cat /tmp/post-resp || true
+                    echo
+                    return 1
+                    ;;
+                esac
+              }
+
+              echo "Channel-seed: seeding default channels"
+{{- if $qbd.enabled }}
+              # ── Channel #1: Qwen3.6 @ BankDhofar (#915) ────────────
+              # NewAPI's `type` field for OpenAI-compatible upstreams is
+              # "openai" (constants/channel_type.go ChannelTypeOpenAI).
+              # The chart's effectiveChannels helper marks the type as
+              # "openai-compatible" in the rendered channels.yaml audit
+              # pointer; the seed Job translates that to NewAPI's
+              # registry value here.
+              seed_channel \
+                {{ (default "qwen3.6-bankdhofar" $qbd.name) | quote }} \
+                "openai" \
+                {{ $qbd.endpoint | quote }} \
+                {{ join "," (default (list "qwen3.6" "qwen3-coder") $qbd.models) | quote }} \
+                "${QWEN_BANKDHOFAR_KEY}"
+{{- end }}
+
+              echo "Channel-seed: complete."
+{{- end }}

--- a/platform/newapi/chart/values.yaml
+++ b/platform/newapi/chart/values.yaml
@@ -197,6 +197,124 @@ defaultChannels:
       kind: "in-cluster"
       owner: ""
 
+  # ─── Qwen3.6 @ BankDhofar (canonical first channel — issue #915) ─────
+  # First-class default channel: Qwen3.6 hosted at BankDhofar
+  # (`https://llm-api.omtd.bankdhofar.com`, model `qwen3-coder` / alias
+  # `qwen3.6`). When `qwenBankDhofar.enabled: true`, the chart:
+  #   1. Composes this entry into the EFFECTIVE channels list as
+  #      channel #1 (BEFORE any operator-supplied `.Values.channels`
+  #      and BEFORE the generic `defaultChannels.vllm` block) — so a
+  #      fresh customer landing on a fresh Sovereign gets routed here
+  #      by default.
+  #   2. Triggers the `channel-seed` post-install/post-upgrade Helm
+  #      hook Job that probes NewAPI's admin API for the channel by
+  #      name and POSTs it if missing (idempotent — re-runs after an
+  #      upgrade are no-ops).
+  #
+  # Per docs/INVIOLABLE-PRINCIPLES.md #4 (never hardcode), every knob
+  # below is configurable via the per-Sovereign bootstrap-kit overlay.
+  # The endpoint default is empty so a `helm template` with default
+  # values does not silently wire customers to a third-party host;
+  # operators set `endpoint: https://llm-api.omtd.bankdhofar.com` in
+  # their per-Sovereign overlay (matches the canonical wiring in
+  # openova-private/clusters/contabo-mkt/apps/axon/helmrelease.yaml,
+  # the SAME relay the OpenOva marketing site uses).
+  qwenBankDhofar:
+    # Toggle the channel composition + seed-Job render. Default false
+    # so a CI smoke render produces no Job; per-Sovereign overlay flips
+    # this true with the canonical endpoint + a wired ExternalSecret.
+    enabled: false
+    # Customer-visible channel name. Channel name is the human-readable
+    # row label in NewAPI's admin UI AND is the idempotency key for
+    # the seed Job's existence-probe (GET /api/channel/?keyword=<name>).
+    name: "qwen3.6-bankdhofar"
+    # Upstream OpenAI-compatible endpoint URL. The chart leaves this
+    # empty so an unconfigured deploy never silently dials a third-
+    # party host. Per-Sovereign overlay sets it to
+    # `https://llm-api.omtd.bankdhofar.com` (canonical first-otech
+    # default; matches the existing Axon helmrelease).
+    endpoint: ""
+    # Customer-facing model identifiers exposed via this channel. NewAPI
+    # routes incoming requests whose `model` field matches any string
+    # here to this channel. The default list contains both the
+    # human-friendly `qwen3.6` alias (used in product docs) and the
+    # upstream-canonical `qwen3-coder` (matches the Axon helmrelease at
+    # https://llm-api.omtd.bankdhofar.com — DO NOT delete this alias
+    # or existing OpenClaw/Axon deployments stop routing).
+    models:
+      - "qwen3.6"
+      - "qwen3-coder"
+    # ExternalSecret name carrying the upstream API key under the
+    # canonical key `API_KEY`. Operator overlay creates this Secret
+    # (or wires an ExternalSecret pulling from OpenBao) before
+    # enabling the channel; the seed Job mounts it and POSTs the
+    # value as the channel's `key` field to NewAPI's admin API. The
+    # canonical OpenBao path is
+    # `sovereign/<sovereign-fqdn>/newapi/channel-qwen-bankdhofar` with
+    # property `API_KEY` (operator overlay supplies the ExternalSecret).
+    existingSecret: "newapi-channel-qwen-bankdhofar"
+    # Secret key name holding the upstream API key.
+    existingSecretKey: "API_KEY"
+    # Channel attestation. The Qwen3.6@BankDhofar relay is operated by
+    # Bank Dhofar (a commercial counterparty); the attestation kind is
+    # `commercial-contract` per platform/newapi/README.md compliance
+    # posture. Operator overlay supplies `accountId` + `contractRef`
+    # (legal-team-owned doc link) before flipping `enabled: true`.
+    attestation:
+      kind: "commercial-contract"
+      accountId: ""
+      contractRef: ""
+
+# ─── Channel-seed Job (issue #915) ───────────────────────────────────────
+# Post-install / post-upgrade Helm hook Job that POSTs default channels
+# (currently `defaultChannels.qwenBankDhofar`) into NewAPI's admin API
+# so the FIRST customer request lands on a fully-wired channel, not a
+# 404 / 400. The Job is idempotent: it probes existence via
+# GET `/api/channel/?keyword=<name>` and skips channels that already
+# exist; only newly-added entries POST against NewAPI.
+#
+# Authorization: NewAPI's admin API requires either a logged-in admin
+# session cookie OR the bootstrap MASTER_KEY in the
+# `Authorization: Bearer <master-key>` header. The seed Job mounts the
+# operator-supplied master-key Secret (`auth.adminUI.masterKeySecret`)
+# and uses it ONCE at install time. After bootstrap completes, the
+# operator may rotate the master key out — channels persist in
+# Postgres independent of the master key.
+#
+# Defaults to enabled=true so a Sovereign with `qwenBankDhofar.enabled`
+# also seeds the channel. Operators that load channels via an
+# out-of-band controller flip this off to suppress the Job entirely.
+channelSeed:
+  enabled: true
+  # Image for the curl-based seed loop. Pinned at the upstream-mutable
+  # default tag; production overlays SHA-pin per
+  # docs/INVIOLABLE-PRINCIPLES.md #4a.
+  image:
+    repository: docker.io/curlimages/curl
+    tag: "8.10.1"
+    pullPolicy: IfNotPresent
+  # Resource budget — small. Each channel is one GET (probe) + zero
+  # or one POST against the in-cluster NewAPI Service.
+  resources:
+    requests:
+      cpu: 10m
+      memory: 32Mi
+    limits:
+      cpu: 100m
+      memory: 64Mi
+  # Hook delete policy — keep the most recent Job around for operator
+  # forensics (`kubectl logs job/<release>-channel-seed`) but delete
+  # the previous one before each install/upgrade so we don't pile up
+  # immutable Jobs across upgrades.
+  hookDeletePolicy: "before-hook-creation"
+  # backoffLimit — retries on transient errors (NewAPI Pod still
+  # warming up post-rollout) before the Job marks itself Failed.
+  backoffLimit: 6
+  # activeDeadlineSeconds — upper bound on Job runtime. 5 minutes
+  # is generous for a single-channel seed loop that retries through
+  # NewAPI's startup window.
+  activeDeadlineSeconds: 300
+
 # ─── Geographic AUP enforcement ──────────────────────────────────────────
 # Blocks requests from sanctioned regions on commercial-provider
 # channels. US/EU export-control baseline by default. Operator extends

--- a/products/catalyst/bootstrap/api/internal/handler/sme_tenant_gitops.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sme_tenant_gitops.go
@@ -867,6 +867,13 @@ spec:
       # SME's chosen parent zone — there's exactly one NewAPI per
       # Sovereign and it's anchored to OTECHFQDN.
       baseURL: https://newapi.{{.OTECHFQDN}}
+      # Default model alias for OpenClaw → NewAPI requests. Channel #1
+      # in the per-Sovereign NewAPI is Qwen3.6 hosted at BankDhofar
+      # (issue #915 / bp-newapi 1.3.0 defaultChannels.qwenBankDhofar).
+      # Both qwen3.6 (canonical UI alias) and qwen3-coder (upstream
+      # model id) route to the same channel; OpenClaw's UI surfaces
+      # the friendlier name.
+      defaultModel: qwen3.6
     tenant:
       namespace: {{.Namespace}}
     ingress:


### PR DESCRIPTION
## Summary
- bp-newapi 1.3.0: defaultChannels.qwenBankDhofar (channel #1 = Qwen3.6 hosted at BankDhofar) + post-install/post-upgrade `channel-seed` Helm hook Job that idempotently POSTs default channels into NewAPI's admin API at /api/channel/.
- Bridges the chart's previous documentation-only channels.yaml ConfigMap → the actual Postgres-backed channel rows the upstream NewAPI binary reads at runtime.
- Orchestrator (sme_tenant_gitops.go) emits `newapi.defaultModel: qwen3.6` for bp-openclaw per-tenant overlays so alice's OpenClaw lands on the canonical channel by default.

## Discovery
- Canonical BankDhofar relay reference: https://llm-api.omtd.bankdhofar.com (model `qwen3-coder` / alias `qwen3.6`) — already wired in `openova-private/clusters/contabo-mkt/apps/axon/helmrelease.yaml` (axon.vllm.baseUrl, axon-vllm-secret).
- Live K8s secret confirmed present (axon/axon-vllm-secret with key AXON_VLLM_API_KEY).
- Architecture: bp-newapi is per-Sovereign (one NewAPI per OTECH); SME tenants share via OpenClaw's `newapi.baseURL`. Channel seeding therefore happens at the Sovereign-level chart install, NOT per-tenant.

## What ships
1. `platform/newapi/chart/values.yaml` — `defaultChannels.qwenBankDhofar` + `channelSeed` knobs.
2. `platform/newapi/chart/templates/_helpers.tpl` — `effectiveChannels` composes qwenBankDhofar as channel #1 in row-insertion order.
3. `platform/newapi/chart/templates/channel-seed-job.yaml` (NEW) — post-install/post-upgrade hook Job, idempotent (probes `/api/channel/?keyword=<name>` and skips if present, POSTs otherwise). Bounded RBAC, skip-render gates on `channelSeed.enabled` + default-channel enabled + master-key Secret supplied.
4. `clusters/_template/bootstrap-kit/80-newapi.yaml` — chart 1.2.0 → 1.3.0; new defaultChannels.qwenBankDhofar overlay shape.
5. `platform/newapi/chart/Chart.yaml` — version bump 1.2.0 → 1.3.0 with changelog.
6. `products/catalyst/bootstrap/api/internal/handler/sme_tenant_gitops.go` — bp-openclaw overlay emits `newapi.defaultModel: qwen3.6`.

## Verification
- `helm lint .` PASS
- `helm template` (defaults) — no Job rendered, render clean
- `helm template` (qwenBankDhofar enabled) — Job + RBAC + ConfigMap + channels.yaml render correctly with channel #1 first
- `helm template` (endpoint empty) — fails with the documented helpful error
- `go build ./...` PASS
- `go test ./internal/handler/...` SME-tenant overlay tests PASS (TestRenderSMETenantOverlay_*)

## Test plan
- [x] helm-template smoke clean (defaults + qwen-enabled + endpoint-empty failure)
- [x] go build clean
- [x] SME tenant overlay rendering tests pass
- [x] Job is idempotent (probe+skip via `/api/channel/?keyword=`)
- [x] Per-Sovereign overlay shape documented in 80-newapi.yaml
- [ ] Live verification on a Sovereign with `qwenBankDhofar.enabled: true` + master-key Secret + Bank Dhofar API key Secret → Job logs `[OK] channel qwen3.6-bankdhofar created` on first run, `[SKIP] channel qwen3.6-bankdhofar already exists` on re-run

🤖 Generated with [Claude Code](https://claude.com/claude-code)