### PR TITLE
feat(bp-wordpress-tenant): wp-cli OIDC bootstrap + oidc.* canonical block (0.2.0, #915)

### DIFF
--- a/platform/wordpress-tenant/blueprint.yaml
+++ b/platform/wordpress-tenant/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/category: tenant-app
     catalyst.openova.io/section: pts-7-sme-tenant
 spec:
-  version: 0.1.0
+  version: 0.2.0
   card:
     title: WordPress Tenant
     summary: |
@@ -29,7 +29,7 @@ spec:
     contact: catalyst@openova.io
   configSchema:
     type: object
-    required: [smeDomain, keycloak, adminUser]
+    required: [smeDomain, oidc, adminUser]
     properties:
       smeDomain:
         type: string
@@ -44,27 +44,58 @@ spec:
         default: 1
         minimum: 1
         maximum: 8
+      oidc:
+        type: object
+        required: [issuerURL, clientSecretName]
+        properties:
+          enabled:
+            type: boolean
+            default: true
+            description: Master toggle — when false the post-install Job is rendered but short-circuits.
+          issuerURL:
+            type: string
+            description: |
+              Discovery URL of the per-tenant Keycloak realm. Example:
+              `https://keycloak.<sme-domain>/realms/sme-<subdomain>`.
+              The openid-connect-generic plugin uses this to derive the
+              token / userinfo / authorization / end-session endpoints.
+          clientId:
+            type: string
+            default: wordpress
+            description: OIDC client ID registered in the per-tenant realm.
+          clientSecretName:
+            type: string
+            default: wordpress-oidc-client-secret
+            description: |
+              K8s Secret carrying the OIDC client secret (key
+              `client-secret`). Provisioned by the bp-keycloak chart
+              (PR #918) at the same time as the realm import.
+          defaultRole:
+            type: string
+            default: subscriber
+            description: |
+              WordPress role assigned to a brand-new SSO user when
+              `create_if_does_not_exist=1`. Set to empty string to
+              create SSO users with no role.
+          identityKey:
+            type: string
+            default: preferred_username
+            description: Keycloak claim used to match id_token back to a WP user.
       keycloak:
         type: object
-        required: [realmURL, clientSecretName]
+        description: |
+          DEPRECATED — preserved as a backward-compat alias for chart
+          0.1.x clusters whose orchestrator overlays still emit
+          `keycloak.{realmURL,clientID,clientSecretName}`. New overlays
+          MUST emit `oidc.*`. Folded into oidc.* by _helpers.tpl when
+          oidc.* is at its values.yaml defaults.
         properties:
           realmURL:
             type: string
-            description: |
-              Discovery URL of the SME-vcluster Keycloak realm. Example:
-              `https://auth.acme.<otech-fqdn>/realms/sme`. The
-              openid-connect-generic plugin uses this to derive the
-              token / userinfo / authorization / end-session endpoints.
           clientID:
             type: string
-            default: wordpress
-            description: OIDC client ID registered in the SME realm.
           clientSecretName:
             type: string
-            description: |
-              ExternalSecret carrying the OIDC client secret (key
-              `client-secret`). Provisioned by the tenant-provisioning
-              pipeline before this chart installs.
       database:
         type: object
         properties:

--- a/platform/wordpress-tenant/chart/Chart.yaml
+++ b/platform/wordpress-tenant/chart/Chart.yaml
@@ -1,22 +1,47 @@
 apiVersion: v2
 name: bp-wordpress-tenant
-version: 0.1.0
+# 0.2.0 (2026-05-05) — umbrella issue #915 (D1):
+#   - Replaced direct PHP/SQL writes in templates/oidc-config-job.yaml
+#     with wp-cli commands run from the canonical `wordpress:cli`
+#     image. `wp plugin install openid-connect-generic --activate`
+#     replaces the previous `INSERT INTO wp_options ('active_plugins',
+#     ...)`; `wp option update openid_connect_generic_settings` replaces
+#     the previous serialised-PHP UPSERT. Idempotency via `wp plugin
+#     is-installed` + `wp core is-installed`.
+#   - New `oidc.*` block in values.yaml (canonical input contract):
+#     `oidc.{enabled,issuerURL,clientId,clientSecretName,defaultRole,
+#     identityKey,roleMapping,cliImage}`. The legacy `keycloak.*` block
+#     remains as a back-compat alias (chart 0.1.x clusters whose
+#     orchestrator hasn't been re-rendered keep working) — folding
+#     happens via _helpers.tpl `oidcIssuerURL/oidcClientId/
+#     oidcClientSecretName` definitions.
+#   - Default OIDC client secret name moved from `wordpress-oidc` to
+#     `wordpress-oidc-client-secret` to align with the Secret name
+#     emitted by PR #918 (bp-keycloak tenant-realm ConfigMap).
+#   - `oidc.defaultRole=subscriber` — newly auto-created SSO users land
+#     with subscriber capability (operator can override via overlay).
+#   - Orchestrator emit (products/catalyst/bootstrap/api/internal/handler/
+#     sme_tenant_gitops.go `smeTenantBPWordPress`) bumped to emit both
+#     `oidc.*` and `keycloak.*` so chart 0.1.x and 0.2.0 reconciles work.
+# 0.1.0 — initial release (#800).
+version: 0.2.0
 appVersion: "6"
 description: |
   Catalyst Blueprint scratch chart for in-vcluster WordPress, one
   instance per SME tenant. Pre-wires:
 
-    - SSO via the SME-vcluster Keycloak realm using the
+    - SSO via the per-tenant Keycloak realm using the
       `openid-connect-generic` plugin (auto-create-on-first-login,
-      Keycloak-group → WP-role mapping).
+      configurable default role, Keycloak-group → WP-role mapping).
     - Postgres provisioned by bp-cnpg (Cluster CR) in the SME tenant
       namespace; password mirrored via reflector + post-install Job.
     - PVC-backed `/var/www/html/wp-content/` for theme/plugin/upload
       persistence.
     - Ingress at `wordpress.<sme-domain>` routed via the SME's ingress
       with cert-manager TLS.
-    - Idempotent post-install Jobs that (a) install + activate the
-      `openid-connect-generic` plugin and write its option row pointing
+    - Idempotent post-install Jobs run via `wp-cli` that (a) `wp core
+      install` + `wp plugin install openid-connect-generic --activate`
+      + `wp option update openid_connect_generic_settings` pointing
       at the operator-supplied Keycloak realm + client, (b) pre-seed
       the SME admin WP user with the SSO email mapping.
 

--- a/platform/wordpress-tenant/chart/README.md
+++ b/platform/wordpress-tenant/chart/README.md
@@ -22,7 +22,7 @@ pattern.
 | `Cluster.postgresql.cnpg.io` (1 instance, 10Gi) | Tenant-isolated Postgres provisioned by bp-cnpg. The CNPG-emitted `<cluster>-app` Secret carries the password. |
 | `Secret wordpress-database-secret` (placeholder) | Reflector-managed bridge that the WordPress Pod reads via `secretKeyRef`. Populated by the post-install `db-secret-sync` Job. |
 | `Job <release>-db-secret-sync` (post-install/upgrade) | Mirrors `<cluster>-app.password` into `wordpress-database-secret.password`. Eliminates the otech30-class Reflector race documented in `bp-gitea`. |
-| `Job <release>-oidc-config` (post-install/upgrade) | Connects to Postgres, ensures `wp_options` exists, then UPSERTs the `openid_connect_generic_settings` row (Keycloak URLs + client secret), `active_plugins` (activates the OIDC plugin), `template`/`stylesheet` (default theme), `siteurl`/`home`. Idempotent — re-running on `helm upgrade` is safe. |
+| `Job <release>-oidc-config` (post-install/upgrade) | Runs the canonical `wordpress:cli` image: `wp core install` (idempotent), `wp plugin install openid-connect-generic --activate` (idempotent), `wp option update openid_connect_generic_settings <json>` with the per-tenant Keycloak realm + client + secret, `wp option update default_role`, `wp theme activate`, `wp option update siteurl/home`. Idempotent — re-running on `helm upgrade` is safe. |
 | `Job <release>-admin-user` (post-install/upgrade, hook weight 15) | Pre-seeds the SME admin into `wp_users` + `wp_usermeta` with the `administrator` role + the SSO email mapping. The user can log in via Keycloak only. |
 | `NetworkPolicy` | Restricts egress to: bp-cnpg :5432, Keycloak :8443/:8080, kube-dns, and HTTPS to public IPs (for plugin/theme fetches at first install). Ingress allowed only from the configured ingress namespace (default `traefik`). |
 | `ServiceAccount` | Default SA for the WordPress Pod. The post-install Jobs use a dedicated SA + Role + RoleBinding scoped to the tenant namespace. |
@@ -36,8 +36,10 @@ helm install
   │               Cluster.postgresql.cnpg.io, wordpress-database-secret (empty)
   ├─ post-install hook weight 5:  db-secret-sync Job
   │     └─ waits for CNPG <cluster>-app, PATCHes wordpress-database-secret
-  ├─ post-install hook weight 10: oidc-config Job
-  │     └─ trips WP install via Service GET, UPSERTs OIDC + theme + siteurl
+  ├─ post-install hook weight 10: oidc-config Job (wp-cli)
+  │     └─ wp core install, wp plugin install openid-connect-generic
+  │        --activate, wp option update openid_connect_generic_settings,
+  │        wp theme activate, wp option update siteurl/home
   └─ post-install hook weight 15: admin-user Job
         └─ INSERT/UPDATE wp_users row for the SME admin's email
 ```
@@ -52,9 +54,11 @@ WP install wizard, no manual config.
 | Value | Description |
 |---|---|
 | `smeDomain` | The SME tenant's domain (e.g. `acme.<otech-fqdn>` or BYO `acme.com`). Used to derive the default ingress host as `wordpress.<smeDomain>`. |
-| `keycloak.realmURL` | Discovery URL of the SME-vcluster Keycloak realm. Example: `https://auth.acme.<otech-fqdn>/realms/sme`. |
-| `keycloak.clientSecretName` | ExternalSecret carrying the Keycloak OIDC client secret (key `client-secret`). Provisioned by the tenant-provisioning pipeline before this chart installs. |
+| `oidc.issuerURL` | Discovery URL of the per-tenant Keycloak realm. Example: `https://keycloak.acme.<otech-fqdn>/realms/sme-acme`. The wp-cli Job derives the OIDC `endpoint_*` URLs from this. |
+| `oidc.clientSecretName` | K8s Secret carrying the OIDC client secret (key `client-secret`). Provisioned by `bp-keycloak`'s tenant-realm ConfigMap (PR #918) at the same time as the realm import. |
 | `adminUser.email` | Email of the SME admin (must match the `email` claim Keycloak issues for that user). The admin-user Job pre-seeds a wp_user with this email and the administrator role. |
+
+> **Back-compat (chart 0.1.x):** `keycloak.{realmURL,clientID,clientSecretName}` is still accepted as an alias when the modern `oidc.*` block is at its values.yaml defaults. New overlays MUST emit `oidc.*` — the legacy block is removed in chart `0.3.0`.
 
 ## Override surface
 

--- a/platform/wordpress-tenant/chart/templates/_helpers.tpl
+++ b/platform/wordpress-tenant/chart/templates/_helpers.tpl
@@ -111,3 +111,66 @@ from the Cluster CR; suffix is `-rw` per the CNPG operator convention.
 {{- define "bp-wordpress-tenant.cnpgRwHost" -}}
 {{- printf "%s-rw.%s.svc.cluster.local" .Values.database.cnpgClusterName (include "bp-wordpress-tenant.cnpgNamespace" .) -}}
 {{- end -}}
+
+{{/*
+wp-cli image reference, with optional `global.imageRegistry` rewrite for
+Sovereign Harbor proxy-cache. Mirrors `wordpressImage` so both runtime
+and CLI images route through the same proxy. Returns
+`{registry/}repository:tag@digest`.
+*/}}
+{{- define "bp-wordpress-tenant.wpCliImage" -}}
+{{- $reg := .Values.global.imageRegistry | default "" -}}
+{{- $repo := .Values.oidc.cliImage.repository -}}
+{{- $tag := .Values.oidc.cliImage.tag -}}
+{{- $digest := .Values.oidc.cliImage.digest -}}
+{{- if $reg -}}
+{{- printf "%s/%s:%s@%s" $reg $repo $tag $digest -}}
+{{- else -}}
+{{- printf "%s:%s@%s" $repo $tag $digest -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Resolved OIDC issuer URL. Folds the legacy `keycloak.realmURL` into
+`oidc.issuerURL` for clusters whose orchestrator overlays haven't been
+re-rendered with the canonical `oidc.*` block. Operator-supplied
+`oidc.issuerURL` always wins; only when it equals the values.yaml
+placeholder ("https://keycloak.sme.local/realms/sme") AND a non-empty
+`keycloak.realmURL` is present does the fallback take effect.
+*/}}
+{{- define "bp-wordpress-tenant.oidcIssuerURL" -}}
+{{- $modern := .Values.oidc.issuerURL -}}
+{{- $legacy := .Values.keycloak.realmURL -}}
+{{- $placeholder := "https://keycloak.sme.local/realms/sme" -}}
+{{- if and (eq $modern $placeholder) $legacy -}}
+{{- $legacy -}}
+{{- else -}}
+{{- $modern -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Resolved OIDC clientId. Same fold pattern as oidcIssuerURL.
+*/}}
+{{- define "bp-wordpress-tenant.oidcClientId" -}}
+{{- $modern := .Values.oidc.clientId -}}
+{{- $legacy := .Values.keycloak.clientID -}}
+{{- if and (eq $modern "wordpress") $legacy -}}
+{{- $legacy -}}
+{{- else -}}
+{{- $modern -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Resolved OIDC clientSecretName. Same fold pattern as oidcIssuerURL.
+*/}}
+{{- define "bp-wordpress-tenant.oidcClientSecretName" -}}
+{{- $modern := .Values.oidc.clientSecretName -}}
+{{- $legacy := .Values.keycloak.clientSecretName -}}
+{{- if and (eq $modern "wordpress-oidc-client-secret") $legacy -}}
+{{- $legacy -}}
+{{- else -}}
+{{- $modern -}}
+{{- end -}}
+{{- end -}}

--- a/platform/wordpress-tenant/chart/templates/deployment.yaml
+++ b/platform/wordpress-tenant/chart/templates/deployment.yaml
@@ -23,9 +23,10 @@ Boot sequence (per docs/INVIOLABLE-PRINCIPLES.md #2 — ship target-state shape,
 
 The OIDC plugin's option row, the admin user, and the default theme
 activation are populated by the post-install Jobs in
-templates/oidc-config-job.yaml + templates/admin-user-job.yaml — those
-talk to the WordPress install once the Service is reachable, which
-keeps this Deployment template free of WP CLI.
+templates/oidc-config-job.yaml + templates/admin-user-job.yaml. Both
+run via wp-cli (the canonical wordpress:cli-* image) against the same
+DB the runtime container uses, so any plugin/theme/option change goes
+through WordPress core's public API rather than direct schema writes.
 */}}
 apiVersion: apps/v1
 kind: Deployment

--- a/platform/wordpress-tenant/chart/templates/oidc-config-job.yaml
+++ b/platform/wordpress-tenant/chart/templates/oidc-config-job.yaml
@@ -1,41 +1,54 @@
-{{- if .Values.wordpress.enabled }}
+{{- if and .Values.wordpress.enabled .Values.oidc.enabled }}
 {{- /*
-Helm post-install Job that wires the openid-connect-generic plugin's
-WordPress option row to the SME-vcluster Keycloak realm + client at
-first install. Also activates the plugin, the default theme, and the
-pg4wp drop-in so the SME admin never sees the WordPress install
-wizard.
+Helm post-install / post-upgrade Job that:
 
-Strategy
-────────
-The WordPress `wp_options` table is the single source of truth for
-plugin configuration: a row keyed `openid_connect_generic_settings`
-holds a serialised PHP array with login_type / endpoint URLs / client
-id / client secret. The active theme + the active plugin list also
-live in `wp_options` (`template`, `stylesheet`, `active_plugins`).
+  1. Waits for the WordPress Pod to be reachable (its initContainers
+     have seeded /var/www/html/wp-content with pg4wp + the
+     openid-connect-generic plugin from the wordpress.org plugin
+     registry — see deployment.yaml).
+  2. Runs `wp core install` (idempotent — `wp core is-installed` first).
+     This populates the wp_* tables via WordPress's own install code,
+     which goes through pg4wp and is therefore Postgres-safe.
+  3. Runs `wp plugin install openid-connect-generic --activate` —
+     idempotent: skips when the plugin is already present.
+  4. Runs `wp option update openid_connect_generic_settings <json>`
+     with the per-tenant Keycloak realm + client + secret from the
+     chart values. Idempotent — overwrites with the same values on
+     `helm upgrade`.
+  5. Runs `wp theme activate <defaultTheme>` if the theme is
+     installed; otherwise installs + activates it.
 
-This Job installs WordPress's database schema if not already present
-(invokes the official `wordpress` image's `wp-cli`-equivalent install
-flow via PHP directly), then UPSERTs the OIDC settings row, the
-`active_plugins` row, and the `template`/`stylesheet` rows. Idempotent:
-re-running on `helm upgrade` overwrites with the same values.
-
-Why direct DB writes instead of WP-CLI
+Why wp-cli (not direct PHP/SQL writes)
 ──────────────────────────────────────
-WP-CLI is not bundled with the official `wordpress:*` Docker image
-and adding a layer just for this install would diverge from the
-upstream image (and force a Catalyst-built WordPress image, which
-violates the issue's "pull through Sovereign Harbor proxy-cache, no
-local rebuild" constraint). The Job uses PHP from the WordPress
-image to talk to Postgres via PDO; same image, no extra dependency.
+- WordPress's table schema, option-row serialisation format, and the
+  `active_plugins` / `template` / `stylesheet` semantics evolve
+  between minor releases. wp-cli sits ON TOP of WordPress core's
+  public PHP API and is the only stable contract.
+- pg4wp's drop-in handles MySQL→Postgres translation transparently
+  for any code that goes through `wpdb` — wp-cli uses `wpdb`, so it
+  Just Works against bp-cnpg.
+- The official `wordpress:cli-*` image bundles the same WordPress
+  core layout as the runtime image, so the wp-content PVC mount is
+  byte-for-byte interchangeable.
 
-Why post-install (not pre-install)
-──────────────────────────────────
-WORDPRESS_DB_PASSWORD is only populated by the
-database-secret-sync-job at post-install hook-weight 5. This OIDC
-Job runs at hook-weight 10 (after the DB Secret is reconciled).
+Why post-install / weight 10
+────────────────────────────
+- weight 5: database-secret-sync-job populates `wordpress-database-
+  secret` from the CNPG-emitted `<cluster>-app` Secret.
+- weight 10: this Job — DB Secret is now real, WordPress Pod is up,
+  PVC initContainers seeded wp-content + db.php drop-in.
+- weight 15: admin-user-job pre-seeds the SME admin's wp_users row.
+
+Canonical seam — see umbrella issue #915 (D1 sub-task) and the
+matching tenant-realm Keycloak client registration in
+platform/keycloak/chart/templates/configmap-tenant-realm.yaml
+(PR #918) which emits `wordpress-oidc-client-secret` carrying the
+same client_secret bytes the realm JSON registers.
 */}}
 {{- $ns := .Release.Namespace }}
+{{- $issuer := include "bp-wordpress-tenant.oidcIssuerURL" . }}
+{{- $clientId := include "bp-wordpress-tenant.oidcClientId" . }}
+{{- $secretName := include "bp-wordpress-tenant.oidcClientSecretName" . }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -62,18 +75,22 @@ spec:
         {{- toYaml .Values.wordpress.podSecurityContext | nindent 8 }}
       containers:
         - name: oidc-config
-          image: {{ include "bp-wordpress-tenant.wordpressImage" . | quote }}
-          imagePullPolicy: {{ .Values.wordpress.image.pullPolicy }}
+          image: {{ include "bp-wordpress-tenant.wpCliImage" . | quote }}
+          imagePullPolicy: {{ .Values.oidc.cliImage.pullPolicy }}
           securityContext:
             {{- toYaml .Values.wordpress.containerSecurityContext | nindent 12 }}
           env:
-            - name: WP_DB_HOST
+            # WordPress DB connection — wp-cli reads these via the
+            # wp-config.php we materialise inline below. Identical
+            # variable names to the runtime container so the same
+            # values.yaml block drives both.
+            - name: WORDPRESS_DB_HOST
               value: {{ include "bp-wordpress-tenant.cnpgRwHost" . | quote }}
-            - name: WP_DB_NAME
+            - name: WORDPRESS_DB_NAME
               value: {{ .Values.database.cluster.database | default "wordpress" | quote }}
-            - name: WP_DB_USER
+            - name: WORDPRESS_DB_USER
               value: {{ .Values.database.cluster.owner | default "wordpress" | quote }}
-            - name: WP_DB_PASSWORD
+            - name: WORDPRESS_DB_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ .Values.database.secretName }}
@@ -82,157 +99,174 @@ spec:
               value: "https://{{ include "bp-wordpress-tenant.ingressHost" . }}"
             - name: WP_DEFAULT_THEME
               value: {{ .Values.defaultTheme | quote }}
-            - name: KC_REALM_URL
-              value: {{ .Values.keycloak.realmURL | quote }}
+            # OIDC inputs — folded from oidc.*  /  keycloak.* (legacy).
+            - name: KC_ISSUER_URL
+              value: {{ $issuer | quote }}
             - name: KC_CLIENT_ID
-              value: {{ .Values.keycloak.clientID | quote }}
+              value: {{ $clientId | quote }}
             - name: KC_CLIENT_SECRET
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.keycloak.clientSecretName }}
+                  name: {{ $secretName }}
                   key: client-secret
+            - name: OIDC_DEFAULT_ROLE
+              value: {{ .Values.oidc.defaultRole | quote }}
+            - name: OIDC_IDENTITY_KEY
+              value: {{ .Values.oidc.identityKey | quote }}
           command:
-            - /bin/bash
+            - /bin/sh
             - -c
             - |
               set -eu
-              # Ensure php-pgsql + the postgres CLI are present. The
-              # official wordpress image ships php-mysqli but not
-              # php-pgsql; we install at boot (one-time) via apt.
-              if ! php -m | grep -qi pdo_pgsql; then
-                apt-get update
-                DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-                  php-pgsql postgresql-client
-              fi
-              cat > /tmp/oidc-config.php <<'PHP'
+              # The wordpress:cli image's default WORKDIR is /var/www/html;
+              # wp-cli expects to find wp-config.php and the WordPress
+              # core files there. We materialise wp-config.php inline so
+              # `wp` boots WordPress and chain-loads pg4wp from the
+              # mounted /var/www/html/wp-content PVC (db.php drop-in).
+              cd /var/www/html
+
+              # 1. Materialise wp-config.php — same contract as the
+              #    runtime container's WORDPRESS_CONFIG_EXTRA so the
+              #    site URL + reverse-proxy headers are consistent.
+              if [ ! -f wp-config.php ]; then
+                cat > wp-config.php <<'PHPCFG'
               <?php
-              /**
-               * bp-wordpress-tenant OIDC config bootstrap.
-               *
-               * Connects to the bp-cnpg Postgres provisioned for this
-               * SME tenant, ensures the `wp_options` table exists with
-               * a minimal schema (WP creates it on first browser hit
-               * — we pre-create here to avoid the wizard race),
-               * and UPSERTs the rows that activate openid-connect-
-               * generic + select the default theme.
-               *
-               * Idempotent — re-running on `helm upgrade` overwrites
-               * with the same values.
-               */
-              $host    = getenv('WP_DB_HOST');
-              $db      = getenv('WP_DB_NAME');
-              $user    = getenv('WP_DB_USER');
-              $pass    = getenv('WP_DB_PASSWORD');
-              $siteurl = getenv('WP_SITE_URL');
-              $theme   = getenv('WP_DEFAULT_THEME');
-              $issuer  = getenv('KC_REALM_URL');
-              $cid     = getenv('KC_CLIENT_ID');
-              $csecret = getenv('KC_CLIENT_SECRET');
-
-              echo "[oidc-config] connecting to Postgres at {$host}\n";
-              $pdo = new PDO(
-                "pgsql:host={$host};port=5432;dbname={$db}",
-                $user, $pass,
-                [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]
-              );
-
-              // Wait for WordPress's wp_options table to exist —
-              // WP creates it lazily on the first browser request. We
-              // poll for up to 5 minutes; if it still doesn't exist,
-              // we trip a sentinel HTTP request to the WP Service to
-              // force the install routine. The WordPress Service in
-              // the same namespace is reachable as
-              // <release>-bp-wordpress-tenant.<ns>.svc.cluster.local.
-              $tableExists = function() use ($pdo) {
-                $r = $pdo->query("SELECT to_regclass('public.wp_options') AS t")->fetch();
-                return !empty($r['t']);
-              };
-              for ($i = 0; $i < 60; $i++) {
-                if ($tableExists()) break;
-                if ($i === 0) {
-                  // Trip the install by GETting the WP Service.
-                  $svcUrl = sprintf('http://%s.%s.svc.cluster.local/',
-                    getenv('WP_SVC_NAME') ?: 'wordpress',
-                    getenv('WP_NAMESPACE') ?: 'default');
-                  echo "[oidc-config] tripping WP install via {$svcUrl}\n";
-                  @file_get_contents($svcUrl);
-                }
-                sleep(5);
+              define('DB_NAME',     getenv('WORDPRESS_DB_NAME'));
+              define('DB_USER',     getenv('WORDPRESS_DB_USER'));
+              define('DB_PASSWORD', getenv('WORDPRESS_DB_PASSWORD'));
+              define('DB_HOST',     getenv('WORDPRESS_DB_HOST'));
+              define('DB_CHARSET',  'utf8');
+              define('DB_COLLATE',  '');
+              $table_prefix = 'wp_';
+              define('WP_DEBUG', false);
+              define('WP_HOME',    getenv('WP_SITE_URL'));
+              define('WP_SITEURL', getenv('WP_SITE_URL'));
+              if (!defined('ABSPATH')) {
+                define('ABSPATH', __DIR__ . '/');
               }
-              if (!$tableExists()) {
-                fprintf(STDERR, "[oidc-config] FATAL: wp_options not present after 5 min\n");
-                exit(1);
+              if (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] === 'https') {
+                $_SERVER['HTTPS'] = 'on';
               }
-              echo "[oidc-config] wp_options present.\n";
+              require_once ABSPATH . 'wp-settings.php';
+              PHPCFG
+                echo "[oidc-config] wrote wp-config.php";
+              else
+                echo "[oidc-config] wp-config.php already present";
+              fi
 
-              // Build the OIDC settings array. Field names match the
-              // openid-connect-generic plugin's option schema (see
-              // upstream openid-connect-generic-settings.php).
-              $oidcSettings = [
-                'login_type'                => 'auto',         // auto-redirect to Keycloak
-                'client_id'                 => $cid,
-                'client_secret'             => $csecret,
-                'scope'                     => 'openid email profile',
-                'endpoint_login'            => rtrim($issuer, '/') . '/protocol/openid-connect/auth',
-                'endpoint_userinfo'         => rtrim($issuer, '/') . '/protocol/openid-connect/userinfo',
-                'endpoint_token'            => rtrim($issuer, '/') . '/protocol/openid-connect/token',
-                'endpoint_end_session'      => rtrim($issuer, '/') . '/protocol/openid-connect/logout',
-                'identity_key'              => 'preferred_username',
-                'no_sslverify'              => 0,
-                'http_request_timeout'      => 5,
-                'enforce_privacy'           => 0,
-                'alternate_redirect_uri'    => 0,
-                'token_refresh_enable'      => 1,
-                'link_existing_users'       => 1,
-                'create_if_does_not_exist'  => 1,             // auto-create user on first SSO login
-                'redirect_user_back'        => 1,
-                'redirect_on_logout'        => 1,
-                'acl_enabled'               => 0,
-                'enable_logging'            => 0,
-                'log_limit'                 => 1000,
-              ];
-              $oidcSerialised = serialize($oidcSettings);
+              # 2. Wait for the database to be reachable. wp-cli
+              #    `wp db check` returns non-zero when the DB isn't up;
+              #    we poll for up to 5 minutes. pg4wp's drop-in will
+              #    automatically run from wp-content/db.php, having been
+              #    seeded by the wp-plugin-install initContainer.
+              for i in $(seq 1 60); do
+                if wp db check --allow-root >/dev/null 2>&1; then
+                  echo "[oidc-config] database reachable"
+                  break
+                fi
+                if [ "$i" = "60" ]; then
+                  echo "[oidc-config] FATAL: database not reachable after 5 min" >&2
+                  exit 1
+                fi
+                sleep 5
+              done
 
-              $upsert = function($key, $value) use ($pdo) {
-                // wp_options.option_id is autoincrement; ON CONFLICT
-                // on option_name handles the upsert. Postgres-flavoured
-                // INSERT ... ON CONFLICT works because pg4wp uses the
-                // native wp_options layout.
-                $stmt = $pdo->prepare(
-                  "INSERT INTO wp_options (option_name, option_value, autoload)
-                   VALUES (:k, :v, 'yes')
-                   ON CONFLICT (option_name) DO UPDATE SET option_value = EXCLUDED.option_value"
-                );
-                $stmt->execute([':k' => $key, ':v' => $value]);
-              };
+              # 3. Run `wp core install` if WordPress isn't installed
+              #    yet. Idempotent — `wp core is-installed` exits 0
+              #    when the install row in wp_options is present.
+              if ! wp core is-installed --allow-root >/dev/null 2>&1; then
+                echo "[oidc-config] wp_options/install row absent — running wp core install"
+                # Generate a strong throwaway admin password — the SME
+                # admin will only ever log in via Keycloak SSO; this
+                # password is never used. NEVER printed (Inviolable
+                # Principle #10).
+                ADMIN_PASS="$(head -c 48 /dev/urandom | base64 | tr -dc 'A-Za-z0-9' | head -c 32)"
+                wp core install \
+                  --allow-root \
+                  --url="${WP_SITE_URL}" \
+                  --title="WordPress" \
+                  --admin_user="wp-bootstrap" \
+                  --admin_password="${ADMIN_PASS}" \
+                  --admin_email="bootstrap@${WP_SITE_URL##https://}" \
+                  --skip-email
+                unset ADMIN_PASS
+                echo "[oidc-config] wp core install complete"
+              else
+                echo "[oidc-config] WordPress already installed — skipping core install"
+              fi
 
-              // 1. OIDC plugin settings.
-              $upsert('openid_connect_generic_settings', $oidcSerialised);
-              echo "[oidc-config] openid_connect_generic_settings upserted.\n";
+              # 4. Install + activate openid-connect-generic. wp-cli
+              #    deduplicates: --activate is a no-op when already
+              #    active; `wp plugin is-installed` returns 0 when the
+              #    plugin directory exists on the PVC (seeded by the
+              #    wp-plugin-install initContainer in deployment.yaml,
+              #    so wp-cli skips the wordpress.org download).
+              if wp plugin is-installed openid-connect-generic --allow-root >/dev/null 2>&1; then
+                echo "[oidc-config] openid-connect-generic already installed"
+                wp plugin activate openid-connect-generic --allow-root >/dev/null
+              else
+                echo "[oidc-config] installing openid-connect-generic from wordpress.org"
+                wp plugin install openid-connect-generic --activate --allow-root
+              fi
+              echo "[oidc-config] openid-connect-generic activated"
 
-              // 2. Activate openid-connect-generic in WP.
-              $activePlugins = serialize([
-                'openid-connect-generic/openid-connect-generic.php',
-              ]);
-              $upsert('active_plugins', $activePlugins);
-              echo "[oidc-config] active_plugins upserted.\n";
+              # 5. Compose the OIDC settings option row. Fields match
+              #    the openid-connect-generic plugin's option schema —
+              #    see openid-connect-generic-settings.php upstream.
+              #    `endpoint_*` URLs are derived from the issuer URL
+              #    (Keycloak's standard /protocol/openid-connect/* paths).
+              ISSUER="${KC_ISSUER_URL%/}"
+              wp option update openid_connect_generic_settings --format=json --allow-root <<EOF
+              {
+                "login_type":               "auto",
+                "client_id":                "${KC_CLIENT_ID}",
+                "client_secret":            "${KC_CLIENT_SECRET}",
+                "scope":                    "openid email profile",
+                "endpoint_login":           "${ISSUER}/protocol/openid-connect/auth",
+                "endpoint_userinfo":        "${ISSUER}/protocol/openid-connect/userinfo",
+                "endpoint_token":           "${ISSUER}/protocol/openid-connect/token",
+                "endpoint_end_session":     "${ISSUER}/protocol/openid-connect/logout",
+                "identity_key":             "${OIDC_IDENTITY_KEY}",
+                "no_sslverify":             0,
+                "http_request_timeout":     5,
+                "enforce_privacy":          0,
+                "alternate_redirect_uri":   0,
+                "token_refresh_enable":     1,
+                "link_existing_users":      1,
+                "create_if_does_not_exist": 1,
+                "redirect_user_back":       1,
+                "redirect_on_logout":       1,
+                "acl_enabled":              0,
+                "enable_logging":           0,
+                "log_limit":                1000
+              }
+              EOF
+              echo "[oidc-config] openid_connect_generic_settings written"
 
-              // 3. Default theme — both rows MUST be set (template is
-              // the parent theme, stylesheet is the active child/parent).
-              $upsert('template',   $theme);
-              $upsert('stylesheet', $theme);
-              echo "[oidc-config] default theme set to {$theme}.\n";
+              # 6. Default WordPress role for newly-created SSO users —
+              #    plugin reads this from the standard `default_role`
+              #    option.
+              wp option update default_role "${OIDC_DEFAULT_ROLE}" --allow-root >/dev/null
+              echo "[oidc-config] default_role set to ${OIDC_DEFAULT_ROLE}"
 
-              // 4. siteurl + home — overwrite the WP install defaults
-              // so links resolve through the ingress host.
-              $upsert('siteurl', $siteurl);
-              $upsert('home',    $siteurl);
-              echo "[oidc-config] siteurl/home set to {$siteurl}.\n";
+              # 7. Theme activation — install + activate idempotently.
+              if wp theme is-installed "${WP_DEFAULT_THEME}" --allow-root >/dev/null 2>&1; then
+                wp theme activate "${WP_DEFAULT_THEME}" --allow-root >/dev/null
+              else
+                wp theme install "${WP_DEFAULT_THEME}" --activate --allow-root
+              fi
+              echo "[oidc-config] theme ${WP_DEFAULT_THEME} active"
 
-              echo "[oidc-config] all upserts complete.\n";
-              PHP
-              php /tmp/oidc-config.php
-          envFrom: []
+              # 8. siteurl + home — overwrite the WP install defaults so
+              #    links resolve through the ingress host.
+              wp option update siteurl "${WP_SITE_URL}" --allow-root >/dev/null
+              wp option update home    "${WP_SITE_URL}" --allow-root >/dev/null
+              echo "[oidc-config] siteurl/home set to ${WP_SITE_URL}"
+
+              echo "[oidc-config] all OIDC bootstrap steps complete"
+          volumeMounts:
+            - name: wp-content
+              mountPath: /var/www/html/wp-content
           resources:
             requests:
               cpu: 50m
@@ -240,4 +274,12 @@ spec:
             limits:
               cpu: 500m
               memory: 256Mi
+      volumes:
+        - name: wp-content
+          {{- if .Values.persistence.wpContent.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ include "bp-wordpress-tenant.fullname" . }}-wp-content
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
 {{- end }}

--- a/platform/wordpress-tenant/chart/tests/oidc-config.sh
+++ b/platform/wordpress-tenant/chart/tests/oidc-config.sh
@@ -1,0 +1,207 @@
+#!/usr/bin/env bash
+# bp-wordpress-tenant OIDC config integration test (issue #915, D1).
+#
+# Verifies the post-install `oidc-config` Job:
+#   1. Renders by default with sane wp-cli command structure.
+#   2. Honours the canonical `oidc.*` block in values.yaml.
+#   3. Falls back to the legacy `keycloak.*` block when modern keys
+#      are at their values.yaml defaults (chart 0.1.x compat).
+#   4. Short-circuits when `oidc.enabled=false`.
+#   5. References the K8s Secret + key path that bp-keycloak's
+#      tenant-realm ConfigMap (PR #918) materialises.
+#   6. Uses the canonical `wordpress:cli` image (wp-cli, not direct
+#      PHP/SQL writes — requirement of umbrella issue #915).
+#
+# Usage: bash tests/oidc-config.sh [CHART_DIR]
+
+set -euo pipefail
+
+CHART_DIR="${1:-$(cd "$(dirname "$0")/.." && pwd)}"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+cd "$CHART_DIR"
+if [ ! -d charts ] || [ -z "$(ls -A charts 2>/dev/null)" ]; then
+  helm dependency build >/dev/null
+fi
+
+# Per-tenant inputs the orchestrator (#804) supplies. The canonical
+# values match what sme_tenant_gitops.go emits for an SME with
+# subdomain=acme on parentDomain=omantel.omani.works.
+COMMON_SET=(
+  --set "smeDomain=acme.omantel.omani.works"
+  --set "oidc.issuerURL=https://keycloak.acme.omantel.omani.works/realms/sme-acme"
+  --set "oidc.clientId=wordpress"
+  --set "oidc.clientSecretName=wordpress-oidc-client-secret"
+  --set "adminUser.email=admin@acme.test"
+)
+
+echo "[oidc-config] Case 1: canonical oidc.* render produces a working Job"
+helm template smoke-wp . "${COMMON_SET[@]}" > "$TMP/canonical.yaml"
+
+# Job present + post-install hook.
+if ! grep -q "name: smoke-wp-bp-wordpress-tenant-oidc-config" "$TMP/canonical.yaml"; then
+  echo "FAIL: oidc-config Job not rendered" >&2
+  exit 1
+fi
+if ! grep -q '"helm.sh/hook": "post-install,post-upgrade"' "$TMP/canonical.yaml"; then
+  echo "FAIL: hook annotation missing" >&2
+  exit 1
+fi
+if ! grep -q '"helm.sh/hook-weight": "10"' "$TMP/canonical.yaml"; then
+  echo "FAIL: hook-weight 10 missing" >&2
+  exit 1
+fi
+
+# wp-cli image (canonical) — NOT the runtime wordpress:6-* image.
+if ! grep -qE 'image: "wordpress:cli-2\.12\.0-php8\.3@sha256:[0-9a-f]{64}"' "$TMP/canonical.yaml"; then
+  echo "FAIL: oidc-config container must use wordpress:cli-* image (umbrella #915 requirement)" >&2
+  exit 1
+fi
+
+# wp-cli command flow — verifies the user-visible commands the Job runs.
+for needle in \
+  'wp core install' \
+  'wp plugin install openid-connect-generic --activate' \
+  'wp plugin is-installed openid-connect-generic' \
+  'wp option update openid_connect_generic_settings' \
+  'wp option update default_role' \
+  'wp theme activate' \
+; do
+  if ! grep -qF "${needle}" "$TMP/canonical.yaml"; then
+    echo "FAIL: wp-cli command missing: ${needle}" >&2
+    exit 1
+  fi
+done
+
+# Issuer URL + client ID flow into both env and the option JSON.
+if ! grep -q 'value: "https://keycloak.acme.omantel.omani.works/realms/sme-acme"' "$TMP/canonical.yaml"; then
+  echo "FAIL: KC_ISSUER_URL env not rendered from oidc.issuerURL" >&2
+  exit 1
+fi
+
+# Client secret references the K8s Secret PR #918 emits.
+if ! grep -A5 'name: KC_CLIENT_SECRET' "$TMP/canonical.yaml" | grep -q "name: wordpress-oidc-client-secret"; then
+  echo "FAIL: KC_CLIENT_SECRET must come from Secret 'wordpress-oidc-client-secret' (PR #918)" >&2
+  echo "--- KC_CLIENT_SECRET context ---" >&2
+  grep -A5 'name: KC_CLIENT_SECRET' "$TMP/canonical.yaml" >&2
+  exit 1
+fi
+if ! grep -A5 'name: KC_CLIENT_SECRET' "$TMP/canonical.yaml" | grep -q "key: client-secret"; then
+  echo "FAIL: KC_CLIENT_SECRET must read 'client-secret' key from the Secret" >&2
+  exit 1
+fi
+
+echo "  PASS"
+
+echo "[oidc-config] Case 2: legacy keycloak.* fold path (chart 0.1.x compat)"
+helm template smoke-wp . \
+  --set "smeDomain=acme.example.local" \
+  --set "keycloak.realmURL=https://auth.acme.example.local/realms/sme" \
+  --set "keycloak.clientID=wordpress" \
+  --set "keycloak.clientSecretName=wordpress-oidc" \
+  --set "adminUser.email=admin@acme.example.local" \
+  > "$TMP/legacy.yaml"
+
+# Legacy realmURL must propagate when oidc.* is at its values.yaml defaults.
+if ! grep -q 'value: "https://auth.acme.example.local/realms/sme"' "$TMP/legacy.yaml"; then
+  echo "FAIL: legacy keycloak.realmURL not folded into KC_ISSUER_URL" >&2
+  exit 1
+fi
+# Legacy clientSecretName must propagate.
+if ! grep -A5 'name: KC_CLIENT_SECRET' "$TMP/legacy.yaml" | grep -q "name: wordpress-oidc$"; then
+  echo "FAIL: legacy keycloak.clientSecretName not folded" >&2
+  echo "--- KC_CLIENT_SECRET context (legacy) ---" >&2
+  grep -A5 'name: KC_CLIENT_SECRET' "$TMP/legacy.yaml" >&2
+  exit 1
+fi
+echo "  PASS"
+
+echo "[oidc-config] Case 3: oidc.enabled=false short-circuits the Job"
+helm template smoke-wp . "${COMMON_SET[@]}" --set "oidc.enabled=false" > "$TMP/disabled.yaml"
+if grep -q "name: smoke-wp-bp-wordpress-tenant-oidc-config" "$TMP/disabled.yaml"; then
+  echo "FAIL: oidc-config Job rendered despite oidc.enabled=false" >&2
+  exit 1
+fi
+echo "  PASS"
+
+echo "[oidc-config] Case 4: redirect URIs match what bp-keycloak's PR #918 registers"
+# The Job writes openid_connect_generic_settings — the plugin builds
+# its callback URL as `<siteurl>/wp-admin/admin-ajax.php?action=
+# openid-connect-authorize` when alternate_redirect_uri=0 (our default).
+# bp-keycloak (PR #918) registers the SAME URL for the wordpress
+# client. We don't directly assert the URL string here (the plugin
+# composes it at runtime) but we DO assert alternate_redirect_uri=0
+# is written so the redirect URL matches what KC will accept.
+if ! grep -q '"alternate_redirect_uri":   0' "$TMP/canonical.yaml"; then
+  echo "FAIL: alternate_redirect_uri must be 0 so the plugin uses the path" >&2
+  echo "      bp-keycloak (PR #918) registered: " >&2
+  echo "        /wp-admin/admin-ajax.php?action=openid-connect-authorize" >&2
+  exit 1
+fi
+echo "  PASS"
+
+echo "[oidc-config] Case 5: defaultRole written to wp_options"
+if ! grep -A3 'name: OIDC_DEFAULT_ROLE' "$TMP/canonical.yaml" | grep -q 'value: "subscriber"'; then
+  echo "FAIL: OIDC_DEFAULT_ROLE env not rendered (default 'subscriber')" >&2
+  exit 1
+fi
+helm template smoke-wp . "${COMMON_SET[@]}" --set "oidc.defaultRole=editor" > "$TMP/role-editor.yaml"
+if ! grep -A3 'name: OIDC_DEFAULT_ROLE' "$TMP/role-editor.yaml" | grep -q 'value: "editor"'; then
+  echo "FAIL: oidc.defaultRole=editor not propagated" >&2
+  exit 1
+fi
+echo "  PASS"
+
+echo "[oidc-config] Case 6: smoke render unchanged when only modern oidc.* keys supplied"
+# Same as case 1 but lifted out so any future regression surfaces here:
+# the Job MUST render valid YAML with no errors.
+if ! python3 -c "
+import yaml, sys
+docs = list(yaml.safe_load_all(open('$TMP/canonical.yaml')))
+got = [d['kind'] for d in docs if d]
+required = ['Deployment', 'Service', 'Job', 'Ingress']
+for r in required:
+    if r not in got:
+        print(f'FAIL: {r} not in render', file=sys.stderr)
+        sys.exit(1)
+print(f'render kinds: {got}')
+" 2>&1 | tail -5; then
+  echo "FAIL: render YAML invalid" >&2
+  exit 1
+fi
+echo "  PASS"
+
+echo "[oidc-config] Case 7: wp-content PVC mounted in Job (so seeded plugin/db.php drop-in are visible)"
+# The Job MUST mount the same wp-content PVC the runtime container
+# uses, otherwise wp-cli won't find pg4wp's db.php drop-in and `wp db
+# check` will fall through to the default mysqli adapter (which fails
+# against bp-cnpg).
+#
+# Extract just the oidc-config Job document and assert PVC mount.
+python3 - "$TMP/canonical.yaml" <<'PYEOF'
+import sys, yaml
+docs = list(yaml.safe_load_all(open(sys.argv[1])))
+job = next(
+  (d for d in docs if d and d.get('kind') == 'Job'
+   and d['metadata']['name'].endswith('-oidc-config')),
+  None,
+)
+assert job, "oidc-config Job missing"
+spec = job['spec']['template']['spec']
+volumes = spec.get('volumes') or []
+pvc_vols = [v for v in volumes if v.get('persistentVolumeClaim')]
+assert pvc_vols, "oidc-config Job has no PVC volumes"
+claim = pvc_vols[0]['persistentVolumeClaim']['claimName']
+assert claim.endswith('-wp-content'), f"unexpected PVC claim: {claim}"
+mounts = spec['containers'][0].get('volumeMounts') or []
+mount_names = [m['name'] for m in mounts]
+assert pvc_vols[0]['name'] in mount_names, "PVC volume not mounted into container"
+mount = next(m for m in mounts if m['name'] == pvc_vols[0]['name'])
+assert mount['mountPath'] == '/var/www/html/wp-content', \
+  f"unexpected mountPath: {mount['mountPath']}"
+print(f"  PVC {claim} -> {mount['mountPath']}")
+PYEOF
+echo "  PASS"
+
+echo "[oidc-config] All bp-wordpress-tenant OIDC integration gates green."

--- a/platform/wordpress-tenant/chart/values.yaml
+++ b/platform/wordpress-tenant/chart/values.yaml
@@ -148,37 +148,88 @@ database:
   secretName: "wordpress-database-secret"
 
 # ─── SSO via SME-vcluster Keycloak (openid-connect-generic plugin) ──────
-# The plugin is pre-installed by the WordPress entrypoint (initContainer)
-# from the wordpress.org plugin registry, then registered + configured
-# at first install via templates/oidc-config-job.yaml so the SME admin
-# never sees the WP setup wizard.
-keycloak:
-  # Discovery endpoint of the SME's realm — operator-supplied. Example:
-  #   https://auth.acme.<otech-fqdn>/realms/sme
+# The plugin is installed + activated + configured by the post-install
+# `oidc-config` Job (templates/oidc-config-job.yaml) using `wp-cli` so
+# the SME admin never sees the WordPress setup wizard.
+#
+# Canonical block — `oidc.*`. The legacy `keycloak.*` block below is
+# kept as a backward-compat alias for clusters that haven't been
+# re-rendered through the orchestrator yet (#804 emits both via
+# sme_tenant_gitops.go to keep the upgrade path zero-downtime).
+oidc:
+  # Master toggle. When `false` the post-install Job is rendered but
+  # short-circuits at the top — useful for `helm template` smoke
+  # renders that don't have a real Keycloak. Defaults true so that
+  # production installs are SSO-on by default; per-Sovereign overlays
+  # (e.g. an air-gapped install) may flip false.
+  enabled: true
+  # Discovery URL of the SME-vcluster Keycloak realm. Example:
+  #   https://keycloak.<sme-domain>/realms/sme-<subdomain>
   #
   # The placeholder default below is set ONLY so the `helm template`
   # smoke render in the Blueprint Release workflow (which runs with
   # no overrides) produces valid YAML; per-Sovereign overlays MUST
-  # override. The post-install `oidc-config` Job WILL fail at runtime
-  # if this remains the placeholder — that's the correct guardrail
-  # per docs/INVIOLABLE-PRINCIPLES.md #4 (no hardcoded production
-  # values, but smoke-rendering must succeed).
-  realmURL: "https://auth.sme.local/realms/sme"
-  # OIDC client registered in the SME realm — provisioned by the
-  # tenant-provisioning pipeline (#804) before this chart installs.
-  clientID: "wordpress"
-  # ExternalSecret name carrying the OIDC client secret. Required
-  # key: client-secret. Provisioned by the tenant-provisioning
-  # pipeline at the same time as the Keycloak client registration.
-  clientSecretName: "wordpress-oidc"
+  # override. The post-install Job WILL fail at runtime if this
+  # remains the placeholder — that's the correct guardrail per
+  # docs/INVIOLABLE-PRINCIPLES.md #4 (no hardcoded production values,
+  # but smoke-rendering must succeed).
+  issuerURL: "https://keycloak.sme.local/realms/sme"
+  # OIDC client ID registered in the per-tenant Keycloak realm — see
+  # platform/keycloak/chart/templates/configmap-tenant-realm.yaml
+  # (PR #918) where the realm import ConfigMap registers the client.
+  clientId: "wordpress"
+  # K8s Secret carrying the OIDC client secret. Required key:
+  # `client-secret`. PR #918 emits this Secret as part of the
+  # bp-keycloak tenant-realm ConfigMap render so the realm JSON's
+  # `secret` field and these K8s Secret bytes never drift.
+  clientSecretName: "wordpress-oidc-client-secret"
+  # Default WordPress role assigned to a brand-new SSO user when the
+  # `create_if_does_not_exist` setting fires. Operators may tighten
+  # to `subscriber` or open up to `editor` via overlay. The plugin
+  # honours an empty string as "no role" (login allowed but no
+  # capabilities); we default to `subscriber` so SSO logins land with
+  # at least minimal access.
+  defaultRole: "subscriber"
+  # Identity claim used to match the Keycloak `id_token` payload back
+  # to a WP user. `preferred_username` is the canonical KC claim;
+  # `email` is also valid when KC's email-as-username is enforced.
+  identityKey: "preferred_username"
   # Keycloak group → WP role mapping. Default mirrors the SME unified-
-  # RBAC tier names. Operator may extend per their RBAC posture.
+  # RBAC tier names. Operator may extend per their RBAC posture. The
+  # plugin's `acl` setting consumes this when `acl_enabled=1`; default
+  # ACL is OFF (every authenticated SSO user lands with `defaultRole`).
   roleMapping:
     administrator: "administrator"
     editor: "editor"
     author: "author"
     contributor: "contributor"
     subscriber: "subscriber"
+  # `wp-cli` image (canonical wp-cli release). Used by the post-
+  # install Job to run `wp plugin install --activate` + `wp option
+  # update`. Pinned to a SemVer tag + manifest-list digest per
+  # docs/INVIOLABLE-PRINCIPLES.md #4. The image bundles wp-cli on
+  # top of the same WordPress core layout as the runtime image so
+  # pg4wp's db.php drop-in (mounted via the wp-content PVC) loads
+  # transparently — wp-cli boots core, core picks up the drop-in.
+  cliImage:
+    repository: "wordpress"
+    tag: "cli-2.12.0-php8.3"
+    # Manifest-list digest for `wordpress:cli-2.12.0-php8.3` (verified
+    # against registry-1.docker.io 2026-05-05).
+    digest: "sha256:cbdb19366ee143c5fb353181a0f0e2d4fea1562dd28b1c63cf4ec0d086f2fc2d"
+    pullPolicy: IfNotPresent
+
+# Legacy alias — preserves zero-downtime upgrade for clusters whose
+# orchestrator overlays still emit `keycloak.{realmURL,clientID,
+# clientSecretName}`. Fields below are deprecated and will be removed
+# in chart 0.3.0; new overlays MUST emit `oidc.*`. The post-install
+# Job in templates/oidc-config-job.yaml folds `keycloak.*` into
+# `oidc.*` when the modern keys are at their values.yaml default.
+keycloak:
+  realmURL: ""
+  clientID: ""
+  clientSecretName: ""
+  roleMapping: {}
 
 # ─── First-install admin user (created via SSO mapping) ─────────────────
 # The admin-user-job pre-seeds a wp_users row with `user_login = email`

--- a/products/catalyst/bootstrap/api/internal/handler/sme_tenant_gitops.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sme_tenant_gitops.go
@@ -801,7 +801,19 @@ spec:
         podMonitorEnabled: false
 `
 
-const smeTenantBPWordPress = `# bp-wordpress-tenant (#800) — SSO-pre-wired WordPress per SME.
+const smeTenantBPWordPress = `# bp-wordpress-tenant (#800, #915) — SSO-pre-wired WordPress per SME.
+#
+# Per umbrella epic #915 (D1 sub-task) the chart's post-install
+# oidc-config Job uses wp-cli to install + activate the openid-connect-
+# generic plugin and write its option row pointing at the per-tenant
+# Keycloak realm. The oidc.* block below is the canonical input contract
+# for chart >= 0.2.0; keycloak.* is emitted alongside for back-compat
+# with chart 0.1.x clusters that haven't picked up the new release yet.
+#
+# The wordpress-oidc-client-secret Secret carrying the client-secret key
+# is materialised by bp-keycloak's tenant-realm ConfigMap render
+# (PR #918, platform/keycloak/chart/templates/configmap-tenant-realm.yaml)
+# at the same time as the realm JSON so the two never drift.
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
@@ -824,6 +836,15 @@ spec:
       namespace: {{.Namespace}}
   values:
     smeDomain: {{if .IsBYO}}{{.BYODomain}}{{else}}{{.Subdomain}}.{{.ParentDomain}}{{end}}
+    # Canonical OIDC block (chart >= 0.2.0).
+    oidc:
+      enabled: true
+      issuerURL: https://keycloak.{{.Subdomain}}.{{.ParentDomain}}/realms/sme-{{.Subdomain}}
+      clientId: wordpress
+      clientSecretName: wordpress-oidc-client-secret
+      defaultRole: subscriber
+      identityKey: preferred_username
+    # Legacy alias (chart 0.1.x back-compat). Removed in chart 0.3.0.
     keycloak:
       realmURL: https://keycloak.{{.Subdomain}}.{{.ParentDomain}}/realms/sme-{{.Subdomain}}
       clientID: wordpress

--- a/products/catalyst/bootstrap/api/internal/handler/sme_tenant_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sme_tenant_test.go
@@ -593,6 +593,108 @@ func TestRenderSMETenantOverlay_OpenClawOIDCAndLLMBlocks(t *testing.T) {
 	}
 }
 
+// #915 (D1) — bp-wordpress-tenant.yaml MUST emit per-tenant OIDC values
+// so the chart's post-install wp-cli Job seeds openid-connect-generic
+// against the per-tenant Keycloak realm. PR #918 registers the matching
+// `wordpress` client + Secret on the bp-keycloak side; this test pins
+// the orchestrator-side contract that consumes them.
+func TestRenderSMETenantOverlay_WordPressEmitsOIDC(t *testing.T) {
+	rec := store.SMETenantProvisionRecord{
+		SMETenantID:     "t-alice",
+		Subdomain:       "alice",
+		ParentDomain:    "omantel.omani.works",
+		DomainMode:      store.SMEDomainFreeSubdomain,
+		AdminEmail:      "admin@alice.test",
+		CompanyName:     "Alice Corp",
+		OTECHFQDN:       "otech107.omani.works",
+		VClusterName:    "vc-alice",
+		TenantNamespace: "sme-t-alice",
+	}
+	files, err := renderSMETenantOverlay(rec, SMETenantChartVersions{})
+	if err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	body, ok := files["bp-wordpress-tenant.yaml"]
+	if !ok {
+		t.Fatalf("bp-wordpress-tenant.yaml missing from rendered overlay")
+	}
+	// Canonical oidc.* block — chart >= 0.2.0 contract.
+	wantOIDC := []string{
+		"    oidc:",
+		"      enabled: true",
+		"      issuerURL: https://keycloak.alice.omantel.omani.works/realms/sme-alice",
+		"      clientId: wordpress",
+		"      clientSecretName: wordpress-oidc-client-secret",
+		"      defaultRole: subscriber",
+		"      identityKey: preferred_username",
+	}
+	for _, line := range wantOIDC {
+		if !strings.Contains(body, line) {
+			t.Errorf("bp-wordpress-tenant oidc block missing line %q\n--- rendered ---\n%s", line, body)
+		}
+	}
+	// Legacy keycloak.* alias — chart 0.1.x back-compat. Removed in 0.3.0.
+	wantLegacy := []string{
+		"    keycloak:",
+		"      realmURL: https://keycloak.alice.omantel.omani.works/realms/sme-alice",
+		"      clientID: wordpress",
+		"      clientSecretName: wordpress-oidc-client-secret",
+	}
+	for _, line := range wantLegacy {
+		if !strings.Contains(body, line) {
+			t.Errorf("bp-wordpress-tenant legacy keycloak block missing line %q (back-compat)", line)
+		}
+	}
+	// Per-tenant realm URL MUST be the per-SME Keycloak, not a shared
+	// otech-level IdP. Same guardrail as the OpenClaw/Stalwart tests.
+	bad := "https://keycloak.otech107.omani.works"
+	if strings.Contains(body, bad) {
+		t.Errorf("bp-wordpress-tenant issuerURL must be per-tenant, not otech-wide: %s", body)
+	}
+	// Ingress + admin-user blocks are unchanged (kept here so a regression
+	// to those surfaces in the same test).
+	if !strings.Contains(body, "host: wordpress.alice.omantel.omani.works") {
+		t.Errorf("wordpress ingress host missing")
+	}
+	if !strings.Contains(body, "email: admin@alice.test") {
+		t.Errorf("admin email missing")
+	}
+	// dependsOn: bp-keycloak so the wp-cli Job runs AFTER the realm
+	// import + Secret materialisation.
+	if !strings.Contains(body, "name: bp-keycloak") {
+		t.Errorf("expected dependsOn bp-keycloak in bp-wordpress-tenant.yaml")
+	}
+}
+
+// #915 (D1) — BYO domain mode must emit OIDC against the BYO host, not
+// the otech default zone. Mirrors the BYO certificate-emission test for
+// wordpress.
+func TestRenderSMETenantOverlay_WordPressOIDC_BYOMode(t *testing.T) {
+	rec := store.SMETenantProvisionRecord{
+		SMETenantID:     "t-acme",
+		Subdomain:       "acme",
+		DomainMode:      store.SMEDomainBYO,
+		BYODomain:       "acme.com",
+		AdminEmail:      "admin@acme.com",
+		OTECHFQDN:       "otech.example",
+		VClusterName:    "vc-acme",
+		TenantNamespace: "sme-t-acme",
+	}
+	files, err := renderSMETenantOverlay(rec, SMETenantChartVersions{})
+	if err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	body := files["bp-wordpress-tenant.yaml"]
+	// BYO ingress host is wordpress.acme.com (derived from BYO domain).
+	if !strings.Contains(body, "host: wordpress.acme.com") {
+		t.Errorf("byo wordpress host missing — got:\n%s", body)
+	}
+	// smeDomain (BYO mode) is the bare BYO domain.
+	if !strings.Contains(body, "smeDomain: acme.com") {
+		t.Errorf("byo smeDomain missing")
+	}
+}
+
 // #915 (C2) — bp-stalwart-tenant.yaml MUST emit per-tenant Keycloak OIDC
 // values so the chart's setup Job seeds the OIDC directory entry against
 // the per-tenant Keycloak realm. Without these the chart falls back to


### PR DESCRIPTION
## Summary

D1 of umbrella issue #915. Aligns bp-wordpress-tenant with the canonical
wp-cli OIDC bootstrap flow and consumes the `wordpress-oidc-client-secret`
Secret + tenant-realm `wordpress` client that C1's PR #918 ships.

When this lands, a fresh `helm install bp-wordpress-tenant` against a
tenant namespace whose bp-keycloak chart has `realmConfig.tenant.enabled=true`
will:

1. Run `wp core install` (idempotent) to populate the WordPress schema.
2. Run `wp plugin install openid-connect-generic --activate` (idempotent).
3. Run `wp option update openid_connect_generic_settings <json>` with the
   per-tenant realm + client + `client-secret` from the K8s Secret PR
   #918 emits.
4. Set `default_role` (default `subscriber`) so newly-created SSO users
   land with sane permissions.
5. Activate the chosen theme.
6. Set `siteurl`/`home` to the tenant's WordPress ingress host.

Subsequent SSO logins via Keycloak hit the redirect URI
`/wp-admin/admin-ajax.php?action=openid-connect-authorize` (the plugin's
default when `alternate_redirect_uri=0`) — which PR #918 already added
to the `wordpress` client's allowed-redirect-URI list along with
`/wp-login.php`, `/openid-connect-authorize`, and a `/*` wildcard.

## What ships

### Chart 0.2.0 (`platform/wordpress-tenant/chart/`)

- `templates/oidc-config-job.yaml` rewritten end-to-end. Replaces the
  previous direct PHP/SQL `INSERT INTO wp_options ...` UPSERTs with
  wp-cli running on the canonical `wordpress:cli-2.12.0-php8.3` image
  (manifest-list digest pinned). The Job mounts the same wp-content PVC
  the runtime container does, so pg4wp's `db.php` drop-in loads
  transparently and `wp db check` succeeds against bp-cnpg.
- `values.yaml`: new canonical `oidc.*` block — `oidc.{enabled,
  issuerURL, clientId, clientSecretName, defaultRole, identityKey,
  roleMapping, cliImage}`. Default `oidc.clientSecretName =
  "wordpress-oidc-client-secret"` matches PR #918's emit.
- Legacy `keycloak.{realmURL, clientID, clientSecretName}` kept as a
  back-compat alias. `_helpers.tpl` folds it into `oidc.*` when the
  modern keys are at their values.yaml defaults so chart 0.1.x clusters
  keep reconciling. Removed in chart 0.3.0.
- `templates/_helpers.tpl`: 4 new defs — `wpCliImage`, `oidcIssuerURL`,
  `oidcClientId`, `oidcClientSecretName` — all driving the fold logic.
- `Chart.yaml`: bumped to `0.2.0` with full changelog.
- `blueprint.yaml`: schema updated to require `oidc` instead of
  legacy `keycloak`; legacy block kept as deprecated.
- `README.md`: refreshed to describe the wp-cli flow + the back-compat
  banner.

### Orchestrator (`products/catalyst/bootstrap/api/internal/handler/sme_tenant_gitops.go`)

- `smeTenantBPWordPress` template now emits the canonical `oidc.*`
  block AND the legacy `keycloak.*` alias (chart 0.1.x mid-upgrade
  compat).

### Tests

- `chart/tests/oidc-config.sh` — 7 helm-template assertions covering
  the canonical render, legacy fold, `oidc.enabled=false`
  short-circuit, redirect-URI alignment, defaultRole propagation,
  YAML parseability, and PVC mount.
- `internal/handler/sme_tenant_test.go`:
    * `TestRenderSMETenantOverlay_WordPressEmitsOIDC` — pins the
      canonical + legacy block emit for the `alice@omantel` fixture.
    * `TestRenderSMETenantOverlay_WordPressOIDC_BYOMode` — BYO mode
      renders `wordpress.<byo-domain>` correctly.

## Test plan

- [x] `helm lint` clean (canonical + legacy)
- [x] `helm template` clean for: canonical `oidc.*`, legacy `keycloak.*`
      fold, `oidc.enabled=false` short-circuit
- [x] `chart/tests/oidc-config.sh`: 7/7 PASS
- [x] `chart/tests/observability-toggle.sh`: 2/2 PASS (regression)
- [x] `go test ./internal/handler/ -run "SMETenant|TestRenderSME"`:
      all green (the `TestAuthHandover_HappyPath` failure visible in
      the broader suite is pre-existing on main, unrelated)
- [ ] Post-merge: blueprint-release pipeline publishes
      `bp-wordpress-tenant:0.2.0` OCI artifact
- [ ] Post-merge: tenant signup on otech107 picks up the new chart;
      alice's WordPress lands with openid-connect-generic active and
      one redirect to `keycloak.alice.omantel.omani.works/realms/sme-alice`
      logs the SME admin in as administrator (DoD §1 of #915)

## Hard rules honoured

- No credentials in template, commit message, or PR body
  (Inviolable Principle #10)
- Every host-derived URL templated off `oidc.issuerURL` /
  `smeDomain` / orchestrator-supplied subdomain+parentDomain
  (Inviolable Principle #4)
- `wordpress:cli-*` image SHA-pinned via manifest-list digest
- Canonical seam (chart `templates/oidc-config-job.yaml` + helpers)
  preserved; no parallel implementation introduced
  (anti-duplication rule)
- Sovereign-mode bp-keycloak behaviour byte-for-byte unchanged
  (this PR touches bp-wordpress-tenant only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)