### PR TITLE
feat(cutover): auto-trigger on install + always-defined State (#933 E1)

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -133,7 +133,16 @@ spec:
       # interval. Closes the "Sovereign drifts from upstream main
       # forever after Day-2 cutover" bug — hit twice on otech103
       # 2026-05-04 requiring manual `git fetch` per chart rollout. (#870)
-      version: 0.1.15
+      # 0.1.16: Auto-trigger via Helm post-install Job (#933). Handover
+      # is not "done" until cutover has run; the operator must NOT have
+      # to click a CTA. New `trigger.auto: true` (default) fires a
+      # post-install Job that POSTs /api/v1/sovereign/cutover/start
+      # on catalyst-api after the step ConfigMaps land. catalyst-api
+      # handles idempotency via the durable status ConfigMap, so the
+      # hook is safe on every install + every upgrade. Coupled with the
+      # cutoverStatusResponse.State field fix on the API side which
+      # closes the otech113 `invalid CutoverState: <undefined>` bug.
+      version: 0.1.16
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-self-sovereign-cutover
-version: 0.1.15
+version: 0.1.16
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/templates/10-auto-trigger-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/10-auto-trigger-job.yaml
@@ -1,0 +1,198 @@
+{{- if .Values.trigger.auto }}
+{{- /*
+Step 10 — auto-trigger Job (issue #933).
+
+Helm post-install / post-upgrade hook that fires the cutover automatically
+after the chart's ConfigMaps + RBAC land. Founder rule: handover is not
+"done" until cutover has run; the operator must NOT have to click a CTA
+on console.<sov-fqdn>/console/dashboard.
+
+Idempotency comes from catalyst-api's own /start endpoint:
+  - cutoverComplete=true → 200, no Jobs created (already done)
+  - cutoverComplete=false + steps in flight → 409 (in-progress)
+  - cutoverComplete=false + no run → 200, kicks off the engine
+
+So this Job can run on every chart install AND every upgrade without
+side effects: it asks catalyst-api to start, and catalyst-api decides
+whether anything actually needs to happen.
+
+Hook ordering (helm.sh/hook-weight=20):
+  - The chart's ConfigMaps + RBAC + DaemonSet land at default weight 0
+    via normal install (no helm.sh/hook on those — they're regular
+    resources, not hooks).
+  - Helm orders hooks AFTER regular resources at install time, then
+    by hook-weight ascending. Weight 20 leaves room for other charts
+    to insert pre-cutover hooks at lower weights if needed.
+
+Why a Job (not an init container on catalyst-api):
+  - catalyst-api is provisioned at Phase-1 (long before the cutover
+    chart). We can't tell catalyst-api "auto-trigger when you install
+    the cutover chart" because catalyst-api has no awareness of which
+    sub-charts have landed when.
+  - A chart-side Helm hook is the canonical seam: "this chart has
+    finished installing, fire its trigger." That's exactly what
+    helm.sh/hook=post-install was designed for.
+
+Why it doesn't crash a still-tethered Sovereign:
+  - The catalyst-api /start endpoint returns 200 if cutoverComplete=true,
+    409 if a cutover is already running, and 424 (FailedDependency) if
+    the step ConfigMaps haven't landed yet (impossible here — we run
+    AFTER them by hook ordering).
+  - Network failure or catalyst-api unreachable at hook time? We poll
+    with a generous timeout (5 minutes) and exit 0 even on timeout
+    so a slow Sovereign cold-start doesn't fail the chart install. The
+    operator can re-trigger via the CTA if auto-trigger never lands.
+
+Re-trigger semantics:
+  - On chart upgrade, this hook fires again. catalyst-api treats the
+    re-trigger idempotently (skips already-success steps via the
+    durable status ConfigMap). Safe to fire repeatedly.
+
+Operator override:
+  - Set trigger.auto=false in the per-Sovereign overlay to disable the
+    auto-trigger and require the manual CTA. Default: true (founder rule).
+*/ -}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "bp-self-sovereign-cutover.name" . }}-auto-trigger
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "bp-self-sovereign-cutover.labels" . | nindent 4 }}
+    app.kubernetes.io/component: cutover-auto-trigger
+  annotations:
+    "helm.sh/hook": "post-install,post-upgrade"
+    "helm.sh/hook-weight": "20"
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
+spec:
+  backoffLimit: 3
+  ttlSecondsAfterFinished: {{ .Values.trigger.autoJobTTLSeconds | default 86400 }}
+  activeDeadlineSeconds: {{ .Values.trigger.autoTimeoutSeconds | default 600 }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "bp-self-sovereign-cutover.name" . }}
+        app.kubernetes.io/component: cutover-auto-trigger
+        catalyst.openova.io/blueprint: bp-self-sovereign-cutover
+    spec:
+      serviceAccountName: {{ include "bp-self-sovereign-cutover.serviceAccountName" . }}
+      restartPolicy: Never
+      containers:
+        - name: trigger
+          image: {{ include "bp-self-sovereign-cutover.image" (dict "repository" .Values.images.curl.repository "tag" .Values.images.curl.tag "cutoverPhase" "pre" "Values" .Values) }}
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: CATALYST_API_URL
+              value: {{ .Values.trigger.catalystAPIURL | quote }}
+            - name: AUTO_DELAY_SECONDS
+              value: {{ .Values.trigger.autoDelaySeconds | default 0 | quote }}
+            - name: WAIT_TIMEOUT_SECONDS
+              value: {{ .Values.trigger.autoWaitForAPISeconds | default 300 | quote }}
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              set -eu
+
+              # Optional pre-flight delay to let just-handed-over operators
+              # confirm the dashboard renders before the cutover hides the
+              # CTA. autoDelaySeconds=0 means "fire immediately".
+              if [ "${AUTO_DELAY_SECONDS}" -gt 0 ]; then
+                echo "[auto-trigger] sleeping ${AUTO_DELAY_SECONDS}s before firing cutover"
+                sleep "${AUTO_DELAY_SECONDS}"
+              fi
+
+              api="${CATALYST_API_URL%/}"
+              status_url="${api}/api/v1/sovereign/cutover/status"
+              start_url="${api}/api/v1/sovereign/cutover/start"
+
+              # 1. Wait for catalyst-api to be reachable. In a fresh
+              #    Sovereign, the cutover chart and catalyst-platform
+              #    chart land on slightly different timelines via Flux.
+              #    We poll /status (a read-only endpoint, idempotent) up
+              #    to WAIT_TIMEOUT_SECONDS so a transient unreachability
+              #    doesn't fail the hook.
+              echo "[auto-trigger] waiting for catalyst-api at ${api}"
+              deadline=$(( $(date +%s) + WAIT_TIMEOUT_SECONDS ))
+              api_ready="false"
+              while [ "$(date +%s)" -lt "${deadline}" ]; do
+                code=$(curl -s -o /tmp/status.json -w "%{http_code}" \
+                  --connect-timeout 5 --max-time 15 \
+                  "${status_url}" 2>/dev/null || echo "000")
+                if [ "${code}" = "200" ]; then
+                  api_ready="true"
+                  break
+                fi
+                echo "[auto-trigger] catalyst-api not ready (HTTP ${code}); retrying in 10s"
+                sleep 10
+              done
+              if [ "${api_ready}" != "true" ]; then
+                echo "[auto-trigger] catalyst-api never became reachable within ${WAIT_TIMEOUT_SECONDS}s — exiting 0; operator can fire manually via CTA"
+                exit 0
+              fi
+
+              # 2. Read current state. If cutoverComplete=true, log and exit.
+              #    The /status endpoint is the durable record; we trust it
+              #    over any in-process state because catalyst-api Pods can
+              #    restart between cutover runs.
+              if grep -q '"cutoverComplete":true' /tmp/status.json 2>/dev/null; then
+                echo "[auto-trigger] cutover already complete on this Sovereign — no-op"
+                exit 0
+              fi
+
+              # 3. Fire POST /start. catalyst-api handles idempotency:
+              #    - cutoverComplete=true → 200 with the existing snapshot
+              #    - cutover already running on this Pod → 409 (benign)
+              #    - no steps found → 424 (chart not installed; impossible here)
+              #    - success → 200 with the freshly-seeded snapshot
+              echo "[auto-trigger] POSTing ${start_url}"
+              code=$(curl -s -o /tmp/start.json -w "%{http_code}" \
+                -X POST --connect-timeout 10 --max-time 60 \
+                -H "Content-Type: application/json" \
+                -d '{}' \
+                "${start_url}" 2>/dev/null || echo "000")
+
+              case "${code}" in
+                200)
+                  echo "[auto-trigger] cutover started successfully"
+                  cat /tmp/start.json 2>/dev/null || true
+                  ;;
+                409)
+                  echo "[auto-trigger] cutover already in progress on the catalyst-api Pod — no-op"
+                  ;;
+                424)
+                  echo "[auto-trigger] catalyst-api reports no step ConfigMaps — chart install ordering bug"
+                  cat /tmp/start.json 2>/dev/null || true
+                  exit 1
+                  ;;
+                *)
+                  echo "[auto-trigger] unexpected status ${code}"
+                  cat /tmp/start.json 2>/dev/null || true
+                  # Do NOT fail the hook — the operator can still fire
+                  # the cutover manually via the CTA. Exit 0 so the
+                  # chart install completes and Flux marks the
+                  # HelmRelease Ready.
+                  exit 0
+                  ;;
+              esac
+
+              echo "[auto-trigger] complete"
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              memory: 256Mi
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}
+{{- end }}

--- a/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
+++ b/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
@@ -129,4 +129,30 @@ else
   exit 1
 fi
 
+echo "[cutover-contract] Case 8: auto-trigger Job renders by default (#933)"
+# Founder rule: handover is not done until cutover has run. The chart MUST
+# auto-fire by default. trigger.auto=false is the operator override, NOT
+# the default.
+if ! grep -q 'cutover-auto-trigger' "$TMP/render.yaml"; then
+  echo "FAIL: auto-trigger Job missing from default render — handover gate broken" >&2
+  exit 1
+fi
+# It MUST be a post-install + post-upgrade Helm hook so chart upgrades
+# also re-fire (catalyst-api handles idempotency).
+if ! grep -q '"helm.sh/hook": "post-install,post-upgrade"' "$TMP/render.yaml" ; then
+  echo "FAIL: auto-trigger Job missing post-install + post-upgrade hook annotations" >&2
+  exit 1
+fi
+echo "  PASS (auto-trigger Job present + hook-annotated)"
+
+echo "[cutover-contract] Case 9: auto-trigger absent when trigger.auto=false"
+# Operator override path — the chart MUST install dormant when an overlay
+# disables auto-trigger.
+helm template smoke-noauto . --set trigger.auto=false > "$TMP/render-noauto.yaml"
+if grep -q 'cutover-auto-trigger' "$TMP/render-noauto.yaml"; then
+  echo "FAIL: auto-trigger Job rendered despite trigger.auto=false" >&2
+  exit 1
+fi
+echo "  PASS (auto-trigger gated on trigger.auto)"
+
 echo "[cutover-contract] All gates green."

--- a/platform/self-sovereign-cutover/chart/values.yaml
+++ b/platform/self-sovereign-cutover/chart/values.yaml
@@ -292,13 +292,40 @@ stepTimeouts:
   egressBlockTestSeconds: 900   # 600 deny + buffer for assert sweep
 
 # Trigger configuration — surface here so operators see it in
-# `helm get values`. The chart itself does NOT auto-fire; catalyst-api
-# reads .Values.trigger.auto and either waits for operator click or
-# auto-fires after first successful operator login.
+# `helm get values`. When trigger.auto=true, the chart's Helm
+# post-install hook (templates/10-auto-trigger-job.yaml) POSTs
+# /api/v1/sovereign/cutover/start on catalyst-api after the chart's
+# ConfigMaps + RBAC land. catalyst-api handles idempotency via the
+# durable status ConfigMap, so the hook is safe to fire on every
+# install AND every upgrade.
 trigger:
-  # default false: operator must explicitly click "Achieve True
-  # Sovereignty" in admin console.
-  auto: false
-  # When auto=true, fire N seconds after the first successful operator
-  # login on the new Sovereign. Ignored when auto=false.
+  # Default true (founder rule per #933): handover is not "done" until
+  # cutover has run; the operator must NOT have to click a CTA on
+  # console.<sov-fqdn>/console/dashboard. Set to false in per-Sovereign
+  # overlay if a sandboxed test Sovereign should stay tethered.
+  auto: true
+  # Optional pre-flight delay before the hook POSTs /start. 0 = fire
+  # immediately. Useful for soak Sovereigns where the operator wants a
+  # short window to inspect the freshly-handed-over dashboard before
+  # the cutover starts.
   autoDelaySeconds: 0
+  # In-cluster URL the auto-trigger Job hits. Default points at the
+  # catalyst-api Service in `catalyst-system` (the post-handover
+  # Sovereign-side namespace per .Values.catalystAPI.namespace), which
+  # is reachable by the Job's catalyst-runner SA without any cross-
+  # namespace egress concerns. Override per-Sovereign if catalyst-api
+  # is exposed under a different Service name.
+  catalystAPIURL: "http://catalyst-api.catalyst-system.svc.cluster.local:8080"
+  # How long the auto-trigger Job will wait for catalyst-api to be
+  # reachable before giving up (and exiting 0 so the operator can fire
+  # manually). 5 minutes is enough for a Sovereign mid-cold-start.
+  autoWaitForAPISeconds: 300
+  # Overall cap on the auto-trigger Job runtime. activeDeadlineSeconds
+  # on the Job spec — anything longer means catalyst-api is sick and
+  # the operator should investigate. The Job exiting at this deadline
+  # is non-fatal for the chart install (the cutover engine already
+  # runs detached inside catalyst-api once /start returns 200).
+  autoTimeoutSeconds: 600
+  # TTL on the completed Job — kept for audit so operators can read
+  # the trigger Pod logs if something looks wrong.
+  autoJobTTLSeconds: 86400

--- a/products/catalyst/bootstrap/api/internal/handler/cutover.go
+++ b/products/catalyst/bootstrap/api/internal/handler/cutover.go
@@ -900,7 +900,15 @@ func (h *Handler) publishCutoverEvent(bus *cutoverBroadcaster, ev cutoverEvent) 
 // per-step keys are also surfaced under `raw` so a UI can render
 // arbitrary additional metadata the chart adds in the future without
 // a client-side change.
+//
+// `State` is ALWAYS populated: "tethered" when the cutover hasn't
+// completed (cold-start, mid-flight, or failed) and "sovereign" when
+// cutoverComplete=true. The UI's branded `CutoverState` parser refuses
+// any other value (or undefined), so the wire MUST never emit an empty
+// state — that's what was rendering `invalid CutoverState: <undefined>`
+// on otech113 (issue #933).
 type cutoverStatusResponse struct {
+	State             string              `json:"state"`
 	CutoverComplete   bool                `json:"cutoverComplete"`
 	CutoverStartedAt  string              `json:"cutoverStartedAt,omitempty"`
 	CutoverFinishedAt string              `json:"cutoverFinishedAt,omitempty"`
@@ -912,6 +920,20 @@ type cutoverStatusResponse struct {
 	LastError         string              `json:"lastError,omitempty"`
 	Steps             []cutoverStepStatus `json:"steps"`
 	Raw               map[string]string   `json:"raw,omitempty"`
+}
+
+// cutoverStateValue returns the canonical wire string for the overall
+// state, derived from the `cutoverComplete` flag. The UI's
+// `parseCutoverState` accepts only "tethered" or "sovereign"; any
+// other value (including the empty string or undefined) throws the
+// `invalid CutoverState: <…>` error that surfaced on otech113. We
+// canonicalise here so /status always answers a UI-parseable state
+// regardless of the underlying ConfigMap state.
+func cutoverStateValue(complete bool) string {
+	if complete {
+		return "sovereign"
+	}
+	return "tethered"
 }
 
 type cutoverStepStatus struct {
@@ -1143,6 +1165,7 @@ func buildCutoverStatusResponseFromMap(status map[string]string, stepNames []str
 		Raw: status,
 	}
 	resp.CutoverComplete = status["cutoverComplete"] == "true"
+	resp.State = cutoverStateValue(resp.CutoverComplete)
 	resp.CutoverStartedAt = status["cutoverStartedAt"]
 	resp.CutoverFinishedAt = status["cutoverFinishedAt"]
 	resp.CurrentStep = status["currentStep"]

--- a/products/catalyst/bootstrap/api/internal/handler/cutover_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/cutover_test.go
@@ -586,6 +586,9 @@ func TestBuildCutoverStatusResponse_PromotesKeys(t *testing.T) {
 		"progressPercent":   "100",
 	}
 	resp := buildCutoverStatusResponseFromMap(status, []string{"x"})
+	if resp.State != "sovereign" {
+		t.Errorf("State = %q, want sovereign", resp.State)
+	}
 	if !resp.CutoverComplete {
 		t.Errorf("CutoverComplete = false, want true")
 	}
@@ -600,6 +603,103 @@ func TestBuildCutoverStatusResponse_PromotesKeys(t *testing.T) {
 	}
 	if len(resp.Steps) != 1 || resp.Steps[0].Name != "x" {
 		t.Errorf("Steps = %+v, want one step named x", resp.Steps)
+	}
+}
+
+// TestBuildCutoverStatusResponse_StateAlwaysDefined proves the
+// `state` field is ALWAYS one of the two UI-parseable values
+// (`tethered` | `sovereign`), regardless of how sparse or empty the
+// underlying ConfigMap is. This is the wire-side fix for the
+// `invalid CutoverState: <undefined>` regression seen on otech113
+// (issue #933) where the UI's branded `parseCutoverState` threw
+// because the API never emitted a state field.
+func TestBuildCutoverStatusResponse_StateAlwaysDefined(t *testing.T) {
+	cases := []struct {
+		name   string
+		status map[string]string
+		want   string
+	}{
+		{
+			name:   "empty status map → tethered",
+			status: map[string]string{},
+			want:   "tethered",
+		},
+		{
+			name: "cutoverComplete=false → tethered",
+			status: map[string]string{
+				"cutoverComplete": "false",
+			},
+			want: "tethered",
+		},
+		{
+			name: "cutoverComplete=true → sovereign",
+			status: map[string]string{
+				"cutoverComplete": "true",
+			},
+			want: "sovereign",
+		},
+		{
+			name: "cutoverComplete missing entirely → tethered (default)",
+			status: map[string]string{
+				"currentStep": "harbor-projects",
+			},
+			want: "tethered",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			resp := buildCutoverStatusResponseFromMap(tc.status, nil)
+			if resp.State != tc.want {
+				t.Errorf("State = %q, want %q", resp.State, tc.want)
+			}
+			if resp.State == "" {
+				t.Error("State is empty — UI parseCutoverState would throw `invalid CutoverState: <undefined>`")
+			}
+		})
+	}
+}
+
+// TestHandleCutoverStatus_StateFieldEmittedOnFreshSovereign proves the
+// HTTP /status endpoint always includes a defined `state` field when
+// no cutover has run yet (the otech113 regression scenario). The chart
+// pre-creates the status ConfigMap with cutoverComplete="false"; the
+// API must emit state="tethered" so the UI's branded parser accepts it.
+func TestHandleCutoverStatus_StateFieldEmittedOnFreshSovereign(t *testing.T) {
+	freshStatus := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cutoverStatusConfigMapName(),
+			Namespace: cutoverTestNS,
+		},
+		Data: map[string]string{
+			"cutoverComplete": "false",
+			"totalSteps":      "8",
+			"progressPercent": "0",
+		},
+	}
+	h, _ := fakeHandlerWithCutover(t, freshStatus)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/sovereign/cutover/status", nil)
+	h.HandleCutoverStatus(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	// Decode into a generic map so we can assert the presence of `state`
+	// at the JSON level — not the typed struct (which would default to "").
+	var rawResp map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &rawResp); err != nil {
+		t.Fatalf("unmarshal: %v; body=%s", err, rec.Body.String())
+	}
+	state, ok := rawResp["state"]
+	if !ok {
+		t.Fatalf("response missing `state` field; body=%s", rec.Body.String())
+	}
+	stateStr, ok := state.(string)
+	if !ok {
+		t.Fatalf("state is not a string: %#v", state)
+	}
+	if stateStr != "tethered" {
+		t.Errorf("state = %q, want tethered", stateStr)
 	}
 }
 

--- a/products/catalyst/bootstrap/ui/src/shared/types/cutover.test.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/types/cutover.test.ts
@@ -186,12 +186,44 @@ describe('parseCutoverStatus — happy paths', () => {
     const out = parseCutoverStatus({ state: 'sovereign', steps: [] })
     expect(out.cutoverComplete).toBe(true)
   })
+
+  it('defaults state to `tethered` when the wire field is missing (otech113 #933)', () => {
+    // The dashboard rendered `invalid CutoverState: <undefined>` because
+    // the catalyst-api response did not include a `state` field on
+    // freshly-handed-over Sovereigns. Defensive parser must derive the
+    // state from `cutoverComplete` rather than throwing.
+    const out = parseCutoverStatus({ cutoverComplete: false, steps: [] })
+    expect(out.state).toBe('tethered')
+    expect(out.cutoverComplete).toBe(false)
+  })
+
+  it('defaults state to `sovereign` when wire field is missing but cutoverComplete=true', () => {
+    const out = parseCutoverStatus({ cutoverComplete: true, steps: [] })
+    expect(out.state).toBe('sovereign')
+    expect(out.cutoverComplete).toBe(true)
+  })
+
+  it('defaults to `tethered` for an empty wire object (older catalyst-api Pod)', () => {
+    const out = parseCutoverStatus({})
+    expect(out.state).toBe('tethered')
+    expect(out.cutoverComplete).toBe(false)
+  })
+
+  it('defaults to `tethered` when state is explicitly null', () => {
+    const out = parseCutoverStatus({ state: null, cutoverComplete: false })
+    expect(out.state).toBe('tethered')
+  })
 })
 
 describe('parseCutoverStatus — defensive boundaries', () => {
-  it('throws when state is missing or unknown', () => {
-    expect(() => parseCutoverStatus({})).toThrow(/invalid CutoverState/)
+  it('throws when state is an unknown string (typo / hostile input)', () => {
     expect(() => parseCutoverStatus({ state: 'pending', steps: [] })).toThrow(
+      /invalid CutoverState/,
+    )
+    expect(() => parseCutoverStatus({ state: 'TETHERED', steps: [] })).toThrow(
+      /invalid CutoverState/,
+    )
+    expect(() => parseCutoverStatus({ state: '', steps: [] })).toThrow(
       /invalid CutoverState/,
     )
   })

--- a/products/catalyst/bootstrap/ui/src/shared/types/cutover.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/types/cutover.ts
@@ -255,8 +255,17 @@ export interface CutoverStatus {
  * MUST NOT crash the page or render an undefined badge.
  *
  * Strategy:
- *   • `state` MUST round-trip through `parseCutoverState`. A wire frame
- *     with an unknown overall state is rejected outright.
+ *   • `state` MUST resolve to a valid `CutoverState`. The wire SHOULD
+ *     emit `tethered` or `sovereign`; if the field is missing/undefined
+ *     (older catalyst-api Pod, sparse status ConfigMap mid-rollout)
+ *     we DERIVE it from `cutoverComplete` rather than throwing.
+ *     Throwing was the otech113 regression — `parseCutoverState`
+ *     surfaced `invalid CutoverState: <undefined>` as user-visible
+ *     text on the dashboard. Default = `tethered` (safe / accurate
+ *     for newly-handed-over Sovereigns where no cutover has run yet).
+ *   • A wire frame with an EXPLICITLY-WRONG state value (a typo, a
+ *     hostile string) still rejects via `parseCutoverState` — we
+ *     only soften the missing-field case.
  *   • Step records are filtered: any record whose `step` id is unknown
  *     is dropped (forward-compat — a future api version that adds a
  *     9th step won't break a stale UI).
@@ -269,7 +278,24 @@ export function parseCutoverStatus(input: unknown): CutoverStatus {
     throw new Error('invalid CutoverStatus: not an object')
   }
   const raw = input as Record<string, unknown>
-  const state = parseCutoverState(raw.state)
+  // Resolve state and cutoverComplete jointly. Either field can be the
+  // primary source; if neither is present we default to `tethered`
+  // (a freshly-handed-over Sovereign that hasn't run cutover yet).
+  // The API contract guarantees an explicit state field on every
+  // post-#933 catalyst-api build, but a stale Pod or partial-rollout
+  // wire snapshot must not crash the UI.
+  let state: CutoverState
+  if (raw.state === undefined || raw.state === null) {
+    // Wire field missing — derive from cutoverComplete. Default tethered.
+    const fromComplete =
+      typeof raw.cutoverComplete === 'boolean' && raw.cutoverComplete
+    state = (fromComplete ? 'sovereign' : 'tethered') as CutoverState
+  } else {
+    // Wire field present — branded parse (rejects typos / hostile input).
+    state = parseCutoverState(raw.state)
+  }
+  // cutoverComplete prefers the explicit boolean wire value when present,
+  // otherwise mirrors the resolved state.
   const cutoverComplete =
     typeof raw.cutoverComplete === 'boolean'
       ? raw.cutoverComplete


### PR DESCRIPTION
## Summary

Closes the otech113 dashboard regression and the founder's complaint that handover delivers an empty/broken Sovereign Console.

- **Bug 1 fixed (`invalid CutoverState: <undefined>` rendered as text):** catalyst-api now ALWAYS emits a `state` field (\"tethered\" / \"sovereign\") derived from `cutoverComplete`. The UI's branded `parseCutoverState` was throwing on the missing field; defensive parser now derives from `cutoverComplete` instead of throwing.
- **Bug 2 fixed (Day-2 cutover NOT auto-triggered):** new Helm post-install/post-upgrade hook in bp-self-sovereign-cutover 0.1.16 POSTs `/api/v1/sovereign/cutover/start` on catalyst-api after the step ConfigMaps + RBAC land. catalyst-api handles idempotency via the durable status ConfigMap, so the hook is safe on every install + every upgrade. Gated on `.Values.trigger.auto` (default `true`; overlay can disable for soak Sovereigns).

## Architecture

- **Canonical seam preserved:** auto-trigger uses catalyst-api's existing `/start` endpoint — no bespoke cluster mutation outside the chart, no parallel control flow.
- **Idempotency:** the `/start` endpoint returns 200 if cutoverComplete=true (no-op), 409 if running, 200 to start. The auto-trigger Job uses `helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded` so the artefact stays around for audit but doesn't accumulate.
- **Fail-open:** a transient catalyst-api unreachability at hook time exits 0 so the chart install doesn't block. Operator can re-fire via the manual CTA, which still works.
- **No contabo Pods touched.** Per-Sovereign change only — existing tethered Sovereigns running 0.1.15 stay tethered (the auto-trigger lands when they upgrade to 0.1.16).

## Test plan
- [x] Go API tests pass — `TestBuildCutoverStatusResponse_StateAlwaysDefined`, `TestHandleCutoverStatus_StateFieldEmittedOnFreshSovereign` cover the wire contract
- [x] TS tests pass — `cutover.test.ts` 35/35 (5 new cases for state-fallback), sovereignty widget 20/20
- [x] Chart contract tests pass — `cutover-contract.sh` cases 8 (auto-trigger renders by default) + 9 (absent under `trigger.auto=false`)
- [x] `helm template` smoke render clean
- [ ] E2E verification on next fresh Sovereign provision (auto-trigger should fire post-install; dashboard renders \"Cutover in progress\" → \"Sovereign\")

🤖 Generated with [Claude Code](https://claude.com/claude-code)