### PR TITLE
feat(sovereign-console): populate Jobs/Apps/Cloud views from local cluster (#933)

### DIFF
--- a/products/catalyst/bootstrap/api/cmd/api/main.go
+++ b/products/catalyst/bootstrap/api/cmd/api/main.go
@@ -605,6 +605,27 @@ func main() {
 		rg.Post("/api/v1/sme/tenants/{id}/reconcile", h.HandleReconcileSMETenant)
 		rg.Delete("/api/v1/sme/tenants/{id}", h.HandleDeleteSMETenant)
 
+		// Sovereign Console populated views (issue #933). Read-only
+		// endpoints the Console pages on console.<sov-fqdn>/console/*
+		// hit to render LIVE local-cluster data (HelmReleases, Jobs,
+		// catalog, nodes/namespaces/ingresses). Without these the
+		// freshly-handed-over Sovereign Console renders only
+		// placeholders — useless on day one.
+		//
+		// All four endpoints use rest.InClusterConfig + the
+		// catalyst-api ServiceAccount on the Sovereign cluster, so
+		// they continue to function after the Self-Sovereignty
+		// Cutover (issue #792) severs every mothership-side tether.
+		// On the mothership these endpoints also work (catalyst-api
+		// runs in-cluster on contabo too), but the mothership
+		// Console serves the per-deployment endpoints instead — the
+		// /api/v1/sovereign/* surface is the customer-side Console's
+		// data plane.
+		rg.Get("/api/v1/sovereign/status", h.HandleSovereignStatus)
+		rg.Get("/api/v1/sovereign/jobs", h.HandleSovereignJobs)
+		rg.Get("/api/v1/sovereign/apps", h.HandleSovereignApps)
+		rg.Get("/api/v1/sovereign/cloud", h.HandleSovereignCloud)
+
 		// Self-Sovereignty Cutover (issue #792 — parent epic #790). The
 		// post-handover step that severs a Sovereign's remaining
 		// tethers to the openova-io mothership: gitea-mirror,

--- a/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
+++ b/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
@@ -1,0 +1,882 @@
+{
+  "generatedAt": "2026-05-05T10:29:38.525Z",
+  "blueprints": [
+    {
+      "id": "bp-anthropic-adapter",
+      "slug": "anthropic-adapter",
+      "title": "Anthropic Adapter",
+      "summary": "|",
+      "icon": "anthropic-adapter.svg",
+      "category": "ai-runtime",
+      "tagline": null,
+      "tags": [],
+      "visibility": "listed",
+      "version": "1.0.0",
+      "section": "pts-4-6-llm-serving",
+      "depends": [
+        "bp-external-secrets"
+      ]
+    },
+    {
+      "id": "bp-bge",
+      "slug": "bge",
+      "title": "BGE Embeddings + Reranker",
+      "summary": "BAAI General Embedding (sentence-transformers + bge-reranker). CPU-friendly multilingual embeddings + cross-encoder reranking. Default model bge-small-en-v1.5; bp-llm-gateway discovers via Service annotation.",
+      "icon": "bge.svg",
+      "category": "ai-runtime",
+      "tagline": null,
+      "tags": [],
+      "visibility": "listed",
+      "version": "1.0.0",
+      "section": "pts-4-6-llm-serving",
+      "depends": [
+        "bp-cnpg"
+      ]
+    },
+    {
+      "id": "bp-cert-manager",
+      "slug": "cert-manager",
+      "title": "cert-manager",
+      "summary": "TLS certificate automation. Lets Encrypt issuer with Dynadot DNS-01 for omani.works pool, HTTP-01 for BYO domains.",
+      "icon": null,
+      "category": null,
+      "tagline": null,
+      "tags": [],
+      "visibility": "unlisted",
+      "version": "1.1.2",
+      "section": "pts-3-3-security-and-policy",
+      "depends": []
+    },
+    {
+      "id": "bp-cert-manager-dynadot-webhook",
+      "slug": "cert-manager-dynadot-webhook",
+      "title": "cert-manager-dynadot-webhook",
+      "summary": "|",
+      "icon": null,
+      "category": null,
+      "tagline": null,
+      "tags": [],
+      "visibility": "unlisted",
+      "version": "1.0.0",
+      "section": "pts-3-3-security-and-policy",
+      "depends": [
+        "bp-cert-manager"
+      ]
+    },
+    {
+      "id": "bp-cert-manager-powerdns-webhook",
+      "slug": "cert-manager-powerdns-webhook",
+      "title": "cert-manager-powerdns-webhook",
+      "summary": "|",
+      "icon": null,
+      "category": null,
+      "tagline": null,
+      "tags": [],
+      "visibility": "unlisted",
+      "version": "1.0.0",
+      "section": "pts-3-3-security-and-policy",
+      "depends": [
+        "bp-cert-manager"
+      ]
+    },
+    {
+      "id": "bp-cilium",
+      "slug": "cilium",
+      "title": "Cilium",
+      "summary": "Unified CNI + Service Mesh (eBPF). mTLS via WireGuard, Hubble observability, Gateway API.",
+      "icon": "cilium.svg",
+      "category": "infrastructure",
+      "tagline": null,
+      "tags": [],
+      "visibility": "unlisted",
+      "version": "1.2.0",
+      "section": "pts-3-1-networking-and-service-mesh",
+      "depends": []
+    },
+    {
+      "id": "bp-cnpg",
+      "slug": "cnpg",
+      "title": "CloudNativePG",
+      "summary": "|",
+      "icon": "cnpg.svg",
+      "category": "data",
+      "tagline": null,
+      "tags": [],
+      "visibility": "unlisted",
+      "version": "1.0.0",
+      "section": "pts-4-1-data-services",
+      "depends": [
+        "bp-flux"
+      ]
+    },
+    {
+      "id": "bp-crossplane",
+      "slug": "crossplane",
+      "title": "crossplane",
+      "summary": "|",
+      "icon": null,
+      "category": null,
+      "tagline": null,
+      "tags": [],
+      "visibility": "unlisted",
+      "version": "1.1.4",
+      "section": "pts-3-2-gitops-and-iac",
+      "depends": []
+    },
+    {
+      "id": "bp-crossplane-claims",
+      "slug": "crossplane-claims",
+      "title": "crossplane-claims",
+      "summary": "|",
+      "icon": null,
+      "category": null,
+      "tagline": null,
+      "tags": [],
+      "visibility": "unlisted",
+      "version": "1.1.0",
+      "section": "pts-3-2-gitops-and-iac",
+      "depends": [
+        "bp-crossplane"
+      ]
+    },
+    {
+      "id": "bp-external-secrets",
+      "slug": "external-secrets",
+      "title": "External Secrets Operator",
+      "summary": "|",
+      "icon": "external-secrets.svg",
+      "category": "security",
+      "tagline": null,
+      "tags": [],
+      "visibility": "unlisted",
+      "version": "1.1.0",
+      "section": "pts-3-3-security-and-policy",
+      "depends": [
+        "bp-openbao",
+        "bp-cert-manager"
+      ]
+    },
+    {
+      "id": "bp-external-secrets-stores",
+      "slug": "external-secrets-stores",
+      "title": "External Secrets — Stores",
+      "summary": "|",
+      "icon": "external-secrets.svg",
+      "category": "security",
+      "tagline": null,
+      "tags": [],
+      "visibility": "unlisted",
+      "version": "1.0.0",
+      "section": "pts-3-3-security-and-policy",
+      "depends": []
+    },
+    {
+      "id": "bp-flux",
+      "slug": "flux",
+      "title": "flux",
+      "summary": "GitOps reconciler. One per vcluster (source + kustomize + helm controllers); host-level Flux per host cluster watches its bp-* OCI sources.",
+      "icon": null,
+      "category": null,
+      "tagline": null,
+      "tags": [],
+      "visibility": "unlisted",
+      "version": "1.1.4",
+      "section": "pts-3-2-gitops-and-iac",
+      "depends": []
+    },
+    {
+      "id": "bp-gateway-api",
+      "slug": "gateway-api",
+      "title": "Gateway API",
+      "summary": "|",
+      "icon": "kubernetes.svg",
+      "category": "infrastructure",
+      "tagline": null,
+      "tags": [],
+      "visibility": "unlisted",
+      "version": "1.1.0",
+      "section": "pts-3-1-networking-and-service-mesh",
+      "depends": []
+    },
+    {
+      "id": "bp-gitea",
+      "slug": "gitea",
+      "title": "gitea",
+      "summary": "Gitea — per-Sovereign Git server. Catalyst control plane. Hosts catalog (public Blueprint mirror), catalog-sovereign (Sovereign-curated private Blueprints), one Gitea Org per Catalyst Organization, and system (sovereign-admin scope).",
+      "icon": null,
+      "category": null,
+      "tagline": null,
+      "tags": [],
+      "visibility": "unlisted",
+      "version": "1.2.4",
+      "section": "pts-2-3-per-sovereign-supporting-services",
+      "depends": []
+    },
+    {
+      "id": "bp-keycloak",
+      "slug": "keycloak",
+      "title": "keycloak",
+      "summary": "Keycloak — user identity. Topology decided by Sovereign CRD spec.keycloakTopology (per-organization for SME, shared-sovereign for corporate).",
+      "icon": null,
+      "category": null,
+      "tagline": null,
+      "tags": [],
+      "visibility": "unlisted",
+      "version": "1.4.0",
+      "section": "pts-2-3-per-sovereign-supporting-services",
+      "depends": []
+    },
+    {
+      "id": "bp-knative",
+      "slug": "knative",
+      "title": "Knative",
+      "summary": "|",
+      "icon": "knative.svg",
+      "category": "ai-ml",
+      "tagline": null,
+      "tags": [],
+      "visibility": "unlisted",
+      "version": "1.0.0",
+      "section": "pts-4-6-ai-ml",
+      "depends": [
+        "bp-cilium",
+        "bp-cert-manager"
+      ]
+    },
+    {
+      "id": "bp-kserve",
+      "slug": "kserve",
+      "title": "KServe",
+      "summary": "|",
+      "icon": "kserve.svg",
+      "category": "ai-ml",
+      "tagline": null,
+      "tags": [],
+      "visibility": "unlisted",
+      "version": "1.0.0",
+      "section": "pts-4-6-ai-ml",
+      "depends": [
+        "bp-cilium",
+        "bp-cert-manager",
+        "bp-knative"
+      ]
+    },
+    {
+      "id": "bp-librechat",
+      "slug": "librechat",
+      "title": "LibreChat",
+      "summary": "|",
+      "icon": "librechat.svg",
+      "category": "application",
+      "tagline": null,
+      "tags": [],
+      "visibility": "listed",
+      "version": "1.0.0",
+      "section": "pts-4-7-application-tier-chat-ui",
+      "depends": [
+        "bp-llm-gateway",
+        "bp-vllm",
+        "bp-bge",
+        "bp-keycloak"
+      ]
+    },
+    {
+      "id": "bp-livekit",
+      "slug": "livekit",
+      "title": "LiveKit",
+      "summary": "|",
+      "icon": "livekit.svg",
+      "category": "application",
+      "tagline": null,
+      "tags": [],
+      "visibility": "listed",
+      "version": "1.0.0",
+      "section": "pts-4-5-communication",
+      "depends": [
+        "bp-stunner",
+        "bp-cert-manager",
+        "bp-valkey"
+      ]
+    },
+    {
+      "id": "bp-llm-gateway",
+      "slug": "llm-gateway",
+      "title": "LLM Gateway",
+      "summary": "|",
+      "icon": "llm-gateway.svg",
+      "category": "ai-runtime",
+      "tagline": null,
+      "tags": [],
+      "visibility": "listed",
+      "version": "1.0.0",
+      "section": "pts-4-6-llm-serving",
+      "depends": [
+        "bp-cnpg",
+        "bp-keycloak",
+        "bp-external-secrets"
+      ]
+    },
+    {
+      "id": "bp-matrix",
+      "slug": "matrix",
+      "title": "Matrix (Synapse)",
+      "summary": "|",
+      "icon": "matrix.svg",
+      "category": "application",
+      "tagline": null,
+      "tags": [],
+      "visibility": "listed",
+      "version": "1.0.0",
+      "section": "pts-4-5-communication",
+      "depends": [
+        "bp-cnpg",
+        "bp-keycloak",
+        "bp-cert-manager"
+      ]
+    },
+    {
+      "id": "bp-nats-jetstream",
+      "slug": "nats-jetstream",
+      "title": "nats-jetstream",
+      "summary": "Event spine for the Catalyst control plane. JetStream Streams + KV. Per-Organization Accounts. Replaces what was previously specified as Redpanda + Valkey for the control plane.",
+      "icon": null,
+      "category": null,
+      "tagline": null,
+      "tags": [],
+      "visibility": "unlisted",
+      "version": "1.1.2",
+      "section": "pts-2-3-per-sovereign-supporting-services",
+      "depends": []
+    },
+    {
+      "id": "bp-nemo-guardrails",
+      "slug": "nemo-guardrails",
+      "title": "NeMo Guardrails",
+      "summary": "Programmable AI safety firewall — blocks prompt injection, PII leaks, off-topic content, and hallucinated citations between user input and the LLM. Wraps NVIDIA's `nemoguardrails server` (FastAPI on port 8000) as a Deployment + Service. Inline filter for bp-llm-gateway and bp-vllm.",
+      "icon": "nemo-guardrails.svg",
+      "category": "ai-safety",
+      "tagline": null,
+      "tags": [],
+      "visibility": "listed",
+      "version": "1.0.0",
+      "section": "pts-4-7-ai-safety",
+      "depends": [
+        "bp-vllm"
+      ]
+    },
+    {
+      "id": "bp-newapi",
+      "slug": "newapi",
+      "title": "NewAPI",
+      "summary": "|",
+      "icon": "newapi.svg",
+      "category": "ai-runtime",
+      "tagline": null,
+      "tags": [],
+      "visibility": "listed",
+      "version": "1.1.0",
+      "section": "pts-4-6-llm-serving",
+      "depends": [
+        "bp-cnpg",
+        "bp-keycloak",
+        "bp-external-secrets",
+        "bp-valkey",
+        "bp-vllm"
+      ]
+    },
+    {
+      "id": "bp-openbao",
+      "slug": "openbao",
+      "title": "openbao",
+      "summary": "OpenBao secret backend. 3-node Raft per region (independent quorum, async perf-replication across regions). MPL 2.0 — drop-in Vault replacement.",
+      "icon": null,
+      "category": null,
+      "tagline": null,
+      "tags": [],
+      "visibility": "unlisted",
+      "version": "1.2.14",
+      "section": "pts-2-3-per-sovereign-supporting-services",
+      "depends": []
+    },
+    {
+      "id": "bp-openclaw",
+      "slug": "openclaw",
+      "title": "OpenClaw",
+      "summary": "|",
+      "icon": "openclaw.svg",
+      "category": "ai-runtime",
+      "tagline": null,
+      "tags": [],
+      "visibility": "listed",
+      "version": "0.1.0",
+      "section": "pts-4-7-agentic-workspace",
+      "depends": [
+        "bp-newapi",
+        "bp-keycloak",
+        "bp-cert-manager"
+      ]
+    },
+    {
+      "id": "bp-openmeter",
+      "slug": "openmeter",
+      "title": "OpenMeter",
+      "summary": "|",
+      "icon": "openmeter.svg",
+      "category": "application",
+      "tagline": null,
+      "tags": [],
+      "visibility": "listed",
+      "version": "1.0.0",
+      "section": "pts-4-8-identity-and-metering",
+      "depends": [
+        "bp-cnpg",
+        "bp-nats-jetstream",
+        "bp-cert-manager"
+      ]
+    },
+    {
+      "id": "bp-powerdns",
+      "slug": "powerdns",
+      "title": "PowerDNS",
+      "summary": "|",
+      "icon": "powerdns.svg",
+      "category": "infrastructure",
+      "tagline": null,
+      "tags": [],
+      "visibility": "unlisted",
+      "version": "1.1.8",
+      "section": "pts-3-2-gitops-and-iac",
+      "depends": [
+        "bp-cert-manager"
+      ]
+    },
+    {
+      "id": "bp-sealed-secrets",
+      "slug": "sealed-secrets",
+      "title": "sealed-secrets",
+      "summary": "Sealed Secrets — used during Phase 0 bootstrap to transport bootstrap-only secrets, then archived after OpenBao + ESO replace it.",
+      "icon": null,
+      "category": null,
+      "tagline": null,
+      "tags": [],
+      "visibility": "unlisted",
+      "version": "1.1.2",
+      "section": "pts-3-3-security-and-policy",
+      "depends": []
+    },
+    {
+      "id": "bp-self-sovereign-cutover",
+      "slug": "self-sovereign-cutover",
+      "title": "self-sovereignty-cutover",
+      "summary": "|",
+      "icon": null,
+      "category": null,
+      "tagline": null,
+      "tags": [],
+      "visibility": "unlisted",
+      "version": "0.1.14",
+      "section": "pts-2-3-per-sovereign-supporting-services",
+      "depends": [
+        "bp-gitea",
+        "bp-harbor"
+      ]
+    },
+    {
+      "id": "bp-spire",
+      "slug": "spire",
+      "title": "spire",
+      "summary": "SPIFFE/SPIRE workload identity. 5-min rotating SVIDs. Server on mgt cluster + agent per host cluster.",
+      "icon": null,
+      "category": null,
+      "tagline": null,
+      "tags": [],
+      "visibility": "unlisted",
+      "version": "1.1.7",
+      "section": "pts-2-3-per-sovereign-supporting-services",
+      "depends": []
+    },
+    {
+      "id": "bp-stalwart-sovereign",
+      "slug": "stalwart-sovereign",
+      "title": "Stalwart (Sovereign Console mail)",
+      "summary": "|",
+      "icon": "stalwart.svg",
+      "category": "communication",
+      "tagline": null,
+      "tags": [],
+      "visibility": "listed",
+      "version": "0.1.0",
+      "section": "pts-4-5-communication",
+      "depends": [
+        "bp-cert-manager",
+        "bp-cert-manager-powerdns-webhook",
+        "bp-powerdns"
+      ]
+    },
+    {
+      "id": "bp-stalwart-tenant",
+      "slug": "stalwart-tenant",
+      "title": "Stalwart (per-tenant)",
+      "summary": "|",
+      "icon": "stalwart.svg",
+      "category": "communication",
+      "tagline": null,
+      "tags": [],
+      "visibility": "listed",
+      "version": "0.1.2",
+      "section": "pts-4-5-communication",
+      "depends": [
+        "bp-keycloak",
+        "bp-external-secrets",
+        "bp-cert-manager",
+        "bp-powerdns"
+      ]
+    },
+    {
+      "id": "bp-stunner",
+      "slug": "stunner",
+      "title": "STUNner",
+      "summary": "|",
+      "icon": "stunner.svg",
+      "category": "communication",
+      "tagline": null,
+      "tags": [],
+      "visibility": "unlisted",
+      "version": "1.0.0",
+      "section": "pts-4-5-communication",
+      "depends": [
+        "bp-cilium",
+        "bp-cert-manager"
+      ]
+    },
+    {
+      "id": "bp-temporal",
+      "slug": "temporal",
+      "title": "Temporal",
+      "summary": "Durable workflow orchestration with saga + compensation. Postgres-backed (CNPG); Postgres visibility store; Web UI; Keycloak OIDC integration via `--auth-claim-mapper`.",
+      "icon": "temporal.svg",
+      "category": "workflow",
+      "tagline": null,
+      "tags": [],
+      "visibility": "listed",
+      "version": "1.0.0",
+      "section": "pts-4-3-workflow-and-processing",
+      "depends": [
+        "bp-cnpg",
+        "bp-cert-manager"
+      ]
+    },
+    {
+      "id": "bp-valkey",
+      "slug": "valkey",
+      "title": "Valkey",
+      "summary": "|",
+      "icon": "valkey.svg",
+      "category": "data",
+      "tagline": null,
+      "tags": [],
+      "visibility": "unlisted",
+      "version": "1.0.0",
+      "section": "pts-4-1-data-services",
+      "depends": [
+        "bp-flux"
+      ]
+    },
+    {
+      "id": "bp-vllm",
+      "slug": "vllm",
+      "title": "vLLM",
+      "summary": "High-throughput LLM inference engine with PagedAttention. OpenAI-compatible API. GPU-accelerated when nvidia.com/gpu is available; CPU fallback for non-GPU dev Sovereigns.",
+      "icon": "vllm.svg",
+      "category": "ai-runtime",
+      "tagline": null,
+      "tags": [],
+      "visibility": "listed",
+      "version": "1.0.0",
+      "section": "pts-4-6-llm-serving",
+      "depends": [
+        "bp-kserve"
+      ]
+    },
+    {
+      "id": "bp-wordpress-tenant",
+      "slug": "wordpress-tenant",
+      "title": "WordPress Tenant",
+      "summary": "|",
+      "icon": "wordpress.svg",
+      "category": "tenant-app",
+      "tagline": null,
+      "tags": [],
+      "visibility": "listed",
+      "version": "0.2.0",
+      "section": "pts-7-sme-tenant",
+      "depends": [
+        "bp-cnpg",
+        "bp-keycloak",
+        "bp-reflector",
+        "bp-cert-manager"
+      ]
+    }
+  ],
+  "bootstrapKit": [
+    {
+      "id": "bp-cilium",
+      "slug": "cilium",
+      "label": "cilium",
+      "file": "01-cilium.yaml",
+      "order": 1
+    },
+    {
+      "id": "bp-cert-manager",
+      "slug": "cert-manager",
+      "label": "cert-manager",
+      "file": "02-cert-manager.yaml",
+      "order": 2
+    },
+    {
+      "id": "bp-flux",
+      "slug": "flux",
+      "label": "flux",
+      "file": "03-flux.yaml",
+      "order": 3
+    },
+    {
+      "id": "bp-crossplane",
+      "slug": "crossplane",
+      "label": "crossplane",
+      "file": "04-crossplane.yaml",
+      "order": 4
+    },
+    {
+      "id": "bp-sealed-secrets",
+      "slug": "sealed-secrets",
+      "label": "sealed-secrets",
+      "file": "05-sealed-secrets.yaml",
+      "order": 5
+    },
+    {
+      "id": "bp-nats-jetstream",
+      "slug": "nats-jetstream",
+      "label": "nats-jetstream",
+      "file": "07-nats-jetstream.yaml",
+      "order": 7
+    },
+    {
+      "id": "bp-openbao",
+      "slug": "openbao",
+      "label": "openbao",
+      "file": "08-openbao.yaml",
+      "order": 8
+    },
+    {
+      "id": "bp-keycloak",
+      "slug": "keycloak",
+      "label": "keycloak",
+      "file": "09-keycloak.yaml",
+      "order": 9
+    },
+    {
+      "id": "bp-gitea",
+      "slug": "gitea",
+      "label": "gitea",
+      "file": "10-gitea.yaml",
+      "order": 10
+    },
+    {
+      "id": "bp-powerdns",
+      "slug": "powerdns",
+      "label": "powerdns",
+      "file": "11-powerdns.yaml",
+      "order": 11
+    },
+    {
+      "id": "bp-external-dns",
+      "slug": "external-dns",
+      "label": "external-dns",
+      "file": "12-external-dns.yaml",
+      "order": 12
+    },
+    {
+      "id": "bp-bp-catalyst-platform",
+      "slug": "bp-catalyst-platform",
+      "label": "bp-catalyst-platform",
+      "file": "13-bp-catalyst-platform.yaml",
+      "order": 13
+    },
+    {
+      "id": "bp-crossplane-claims",
+      "slug": "crossplane-claims",
+      "label": "crossplane-claims",
+      "file": "14-crossplane-claims.yaml",
+      "order": 14
+    },
+    {
+      "id": "bp-external-secrets",
+      "slug": "external-secrets",
+      "label": "external-secrets",
+      "file": "15-external-secrets.yaml",
+      "order": 15
+    },
+    {
+      "id": "bp-cnpg",
+      "slug": "cnpg",
+      "label": "cnpg",
+      "file": "16-cnpg.yaml",
+      "order": 16
+    },
+    {
+      "id": "bp-valkey",
+      "slug": "valkey",
+      "label": "valkey",
+      "file": "17-valkey.yaml",
+      "order": 17
+    },
+    {
+      "id": "bp-seaweedfs",
+      "slug": "seaweedfs",
+      "label": "seaweedfs",
+      "file": "18-seaweedfs.yaml",
+      "order": 18
+    },
+    {
+      "id": "bp-harbor",
+      "slug": "harbor",
+      "label": "harbor",
+      "file": "19-harbor.yaml",
+      "order": 19
+    },
+    {
+      "id": "bp-opentelemetry",
+      "slug": "opentelemetry",
+      "label": "opentelemetry",
+      "file": "20-opentelemetry.yaml",
+      "order": 20
+    },
+    {
+      "id": "bp-alloy",
+      "slug": "alloy",
+      "label": "alloy",
+      "file": "21-alloy.yaml",
+      "order": 21
+    },
+    {
+      "id": "bp-loki",
+      "slug": "loki",
+      "label": "loki",
+      "file": "22-loki.yaml",
+      "order": 22
+    },
+    {
+      "id": "bp-mimir",
+      "slug": "mimir",
+      "label": "mimir",
+      "file": "23-mimir.yaml",
+      "order": 23
+    },
+    {
+      "id": "bp-tempo",
+      "slug": "tempo",
+      "label": "tempo",
+      "file": "24-tempo.yaml",
+      "order": 24
+    },
+    {
+      "id": "bp-grafana",
+      "slug": "grafana",
+      "label": "grafana",
+      "file": "25-grafana.yaml",
+      "order": 25
+    },
+    {
+      "id": "bp-kyverno",
+      "slug": "kyverno",
+      "label": "kyverno",
+      "file": "27-kyverno.yaml",
+      "order": 27
+    },
+    {
+      "id": "bp-reloader",
+      "slug": "reloader",
+      "label": "reloader",
+      "file": "28-reloader.yaml",
+      "order": 28
+    },
+    {
+      "id": "bp-vpa",
+      "slug": "vpa",
+      "label": "vpa",
+      "file": "29-vpa.yaml",
+      "order": 29
+    },
+    {
+      "id": "bp-trivy",
+      "slug": "trivy",
+      "label": "trivy",
+      "file": "30-trivy.yaml",
+      "order": 30
+    },
+    {
+      "id": "bp-falco",
+      "slug": "falco",
+      "label": "falco",
+      "file": "31-falco.yaml",
+      "order": 31
+    },
+    {
+      "id": "bp-sigstore",
+      "slug": "sigstore",
+      "label": "sigstore",
+      "file": "32-sigstore.yaml",
+      "order": 32
+    },
+    {
+      "id": "bp-syft-grype",
+      "slug": "syft-grype",
+      "label": "syft-grype",
+      "file": "33-syft-grype.yaml",
+      "order": 33
+    },
+    {
+      "id": "bp-velero",
+      "slug": "velero",
+      "label": "velero",
+      "file": "34-velero.yaml",
+      "order": 34
+    },
+    {
+      "id": "bp-coraza",
+      "slug": "coraza",
+      "label": "coraza",
+      "file": "35-coraza.yaml",
+      "order": 35
+    },
+    {
+      "id": "bp-bp-cert-manager-powerdns-webhook",
+      "slug": "bp-cert-manager-powerdns-webhook",
+      "label": "bp-cert-manager-powerdns-webhook",
+      "file": "49-bp-cert-manager-powerdns-webhook.yaml",
+      "order": 49
+    },
+    {
+      "id": "bp-cluster-autoscaler",
+      "slug": "cluster-autoscaler",
+      "label": "cluster-autoscaler",
+      "file": "50-cluster-autoscaler.yaml",
+      "order": 50
+    },
+    {
+      "id": "bp-newapi",
+      "slug": "newapi",
+      "label": "newapi",
+      "file": "80-newapi.yaml",
+      "order": 80
+    },
+    {
+      "id": "bp-bp-stalwart-sovereign",
+      "slug": "bp-stalwart-sovereign",
+      "label": "bp-stalwart-sovereign",
+      "file": "95-bp-stalwart-sovereign.yaml",
+      "order": 95
+    }
+  ]
+}

--- a/products/catalyst/bootstrap/api/internal/catalog/catalog.go
+++ b/products/catalyst/bootstrap/api/internal/catalog/catalog.go
@@ -1,0 +1,181 @@
+// Package catalog exposes the Blueprint marketplace catalog the Sovereign
+// Console reads at /api/v1/sovereign/apps. The catalog is the SAME
+// data the Catalyst-Zero wizard's StepComponents renders — per
+// docs/INVIOLABLE-PRINCIPLES.md #4, the Blueprint catalog has exactly
+// ONE source of truth (every platform/<name>/blueprint.yaml +
+// products/<name>/blueprint.yaml in the monorepo).
+//
+// The build pipeline is:
+//
+//  1. products/catalyst/bootstrap/ui/scripts/build-catalog.mjs walks
+//     the blueprint.yaml tree at build time and emits TWO files:
+//     a) catalog.generated.ts (TS) — for the wizard UI
+//     b) blueprints.json (JSON) — embedded here for the API
+//  2. The Containerfile build stage `COPY products/catalyst/bootstrap/api/`
+//     pulls the JSON into the image alongside the Go source.
+//  3. This file uses go:embed to ship the JSON inside the catalyst-api
+//     binary so a Sovereign-side Pod renders the catalog without
+//     network calls back to the mothership.
+//
+// On a freshly-handed-over Sovereign the local Console can therefore
+// render the FULL marketplace card grid the operator expects without
+// waiting for the gitea-mirror cutover step to land. After cutover,
+// the same catalog continues to serve from the same in-binary copy —
+// the Sovereign catalog and the mothership catalog stay byte-identical
+// because they are SHA-pinned to the same Catalyst-API image build.
+package catalog
+
+import (
+	_ "embed"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"sync"
+)
+
+// blueprintsJSON is the embedded JSON catalog produced by the UI
+// build-catalog.mjs script. The file is always present in the source
+// tree (committed alongside catalog.generated.ts); a missing or
+// truncated file is a build-time error that fails go:embed before
+// the binary ever ships.
+//
+//go:embed blueprints.json
+var blueprintsJSON []byte
+
+// Visibility mirrors the TS BlueprintVisibility union — listed
+// blueprints appear in the marketplace card grid; unlisted are
+// mandatory infra (bootstrap-kit) that the Sovereign Console renders
+// as "always installed" pills rather than installable cards; private
+// is org-only and is filtered out of every public response.
+type Visibility string
+
+const (
+	VisibilityListed   Visibility = "listed"
+	VisibilityUnlisted Visibility = "unlisted"
+	VisibilityPrivate  Visibility = "private"
+)
+
+// Blueprint is the catalogue entry shape — JSON tags match the
+// blueprints.json file emitted by build-catalog.mjs verbatim so a
+// future schema bump only needs to edit one side.
+type Blueprint struct {
+	ID         string     `json:"id"`
+	Slug       string     `json:"slug"`
+	Title      string     `json:"title"`
+	Summary    string     `json:"summary"`
+	Icon       *string    `json:"icon"`
+	Category   *string    `json:"category"`
+	Tagline    *string    `json:"tagline"`
+	Tags       []string   `json:"tags"`
+	Visibility Visibility `json:"visibility"`
+	Version    *string    `json:"version"`
+	Section    *string    `json:"section"`
+	Depends    []string   `json:"depends"`
+}
+
+// BootstrapKitEntry mirrors the wizard's BOOTSTRAP_KIT shape. These
+// are the always-installed platform components the Sovereign
+// already has — the Console marks them "Installed (bootstrap)" so
+// the operator sees them as part of the catalog, not gaps in it.
+type BootstrapKitEntry struct {
+	ID    string `json:"id"`
+	Slug  string `json:"slug"`
+	Label string `json:"label"`
+	File  string `json:"file"`
+	Order int    `json:"order"`
+}
+
+// catalogFile mirrors the JSON wrapper emitted by build-catalog.mjs.
+type catalogFile struct {
+	GeneratedAt   string              `json:"generatedAt"`
+	Blueprints    []Blueprint         `json:"blueprints"`
+	BootstrapKit  []BootstrapKitEntry `json:"bootstrapKit"`
+}
+
+var (
+	loadOnce sync.Once
+	loaded   *catalogFile
+	loadErr  error
+)
+
+// load decodes the embedded JSON exactly once on first call.
+// Subsequent calls reuse the parsed slices. Returns an error iff
+// the embedded JSON is corrupt — which would have been caught at
+// build time before this binary ever shipped, so callers can treat
+// non-nil err as a 500.
+func load() (*catalogFile, error) {
+	loadOnce.Do(func() {
+		var c catalogFile
+		if err := json.Unmarshal(blueprintsJSON, &c); err != nil {
+			loadErr = fmt.Errorf("catalog: unmarshal blueprints.json: %w", err)
+			return
+		}
+		// Stable sort by ID so callers don't depend on JSON
+		// emission order. The TS side already sorts; we sort
+		// again here defensively so the two ends agree even
+		// if the build script's sort key ever changes.
+		sort.Slice(c.Blueprints, func(i, j int) bool {
+			return c.Blueprints[i].ID < c.Blueprints[j].ID
+		})
+		sort.Slice(c.BootstrapKit, func(i, j int) bool {
+			return c.BootstrapKit[i].Order < c.BootstrapKit[j].Order
+		})
+		loaded = &c
+	})
+	return loaded, loadErr
+}
+
+// AllBlueprints returns every Blueprint in the catalog regardless of
+// visibility. Callers that want the marketplace-visible subset use
+// ListedBlueprints below.
+func AllBlueprints() ([]Blueprint, error) {
+	c, err := load()
+	if err != nil {
+		return nil, err
+	}
+	out := make([]Blueprint, len(c.Blueprints))
+	copy(out, c.Blueprints)
+	return out, nil
+}
+
+// ListedBlueprints returns the Blueprints with visibility=listed —
+// the same set the wizard's StepComponents card grid renders. This
+// is the canonical "marketplace" view a Sovereign Console operator
+// browses on /console/apps.
+func ListedBlueprints() ([]Blueprint, error) {
+	c, err := load()
+	if err != nil {
+		return nil, err
+	}
+	out := make([]Blueprint, 0, len(c.Blueprints))
+	for _, b := range c.Blueprints {
+		if b.Visibility == VisibilityListed {
+			out = append(out, b)
+		}
+	}
+	return out, nil
+}
+
+// BootstrapKit returns the always-installed platform components in
+// numerical install order.
+func BootstrapKit() ([]BootstrapKitEntry, error) {
+	c, err := load()
+	if err != nil {
+		return nil, err
+	}
+	out := make([]BootstrapKitEntry, len(c.BootstrapKit))
+	copy(out, c.BootstrapKit)
+	return out, nil
+}
+
+// GeneratedAt returns the timestamp the embedded JSON was generated at.
+// Callers can surface this in a /api/v1/sovereign/apps?meta=true response
+// so an operator (or automated drift-check) can see when the catalog
+// was last rebuilt.
+func GeneratedAt() (string, error) {
+	c, err := load()
+	if err != nil {
+		return "", err
+	}
+	return c.GeneratedAt, nil
+}

--- a/products/catalyst/bootstrap/api/internal/handler/handler.go
+++ b/products/catalyst/bootstrap/api/internal/handler/handler.go
@@ -288,6 +288,15 @@ type Handler struct {
 	// handler returns 503 "powerdns client not wired" so callers can
 	// distinguish "config gap" from "powerdns down".
 	powerdnsZoneClient powerdnsZoneClient
+
+	// ── Sovereign Console populated views (issue #933) ─────────────────
+	// sovereignDepsFactory — test-only override that builds the
+	// in-cluster (kubernetes.Interface, dynamic.Interface) pair the
+	// /api/v1/sovereign/{status,jobs,apps,cloud} endpoints read.
+	// Production leaves this nil and sovereignDepsFromEnv runs against
+	// rest.InClusterConfig() — catalyst-api always runs in the cluster
+	// it serves (mothership AND post-handover Sovereign).
+	sovereignDepsFactory SovereignDepsFactory
 }
 
 // powerdnsZoneClient is the narrow interface the parent-zone handler

--- a/products/catalyst/bootstrap/api/internal/handler/sovereign.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sovereign.go
@@ -1,0 +1,888 @@
+// Package handler — sovereign.go: REST surface the Sovereign Console
+// at console.<sov-fqdn>/console/* reads to populate its Jobs / Apps /
+// Cloud / Dashboard pages with LIVE local-cluster data.
+//
+// Until this file landed, every page in the freshly-handed-over
+// Sovereign Console rendered a "integration pending" placeholder
+// because the only data path was via the mothership at
+// console.openova.io/sovereign/* — useless at handover, since the
+// operator just severed every visual tether to the mothership.
+//
+// Routes:
+//
+//	GET /api/v1/sovereign/status   — counts for the Dashboard cards
+//	GET /api/v1/sovereign/jobs     — HelmRelease history + recent K8s Jobs
+//	GET /api/v1/sovereign/apps     — installable marketplace catalog +
+//	                                 currently-installed status
+//	GET /api/v1/sovereign/cloud    — nodes / namespaces / ingresses /
+//	                                 services (LBs) / storage classes / PVCs
+//
+// Architecture, per ADR-0001 §5 + INVIOLABLE-PRINCIPLES.md #3:
+//
+//   - The catalyst-api Pod runs on the SAME cluster the Console serves
+//     after handover. It uses rest.InClusterConfig() to read its own
+//     apiserver — there is NO mothership round-trip on any of these
+//     endpoints, so the Console stays fully populated even after the
+//     Self-Sovereignty Cutover (issue #792) severs every external link.
+//
+//   - The catalog endpoint embeds the same blueprints.json the wizard's
+//     StepComponents reads (internal/catalog), so the Sovereign side
+//     always has a Phase-1 catalog identical to the mothership — no
+//     gitea-mirror dependency for first paint. The local Gitea mirror
+//     established by cutover step `gitea-mirror` keeps the same
+//     catalog reconciled going forward.
+//
+// On Catalyst-Zero (mothership) the in-cluster client still resolves
+// (the catalyst-api on contabo also runs in-cluster) — the responses
+// are still correct (mothership cluster's view) but the mothership
+// Console serves /sovereign/jobs|apps|cloud via the existing
+// per-deployment endpoints, NOT these. The new /api/v1/sovereign/*
+// surface is intended for the Sovereign-side console only.
+package handler
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"sort"
+	"strings"
+	"time"
+
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/catalog"
+)
+
+// sovereignDeps bundles the Kubernetes clients the local-cluster
+// endpoints read from. Production builds these once from
+// rest.InClusterConfig (catalyst-api always runs IN the cluster it
+// serves — both on the mothership and after handover on the
+// Sovereign). Tests inject fakes via SetSovereignDepsFactory.
+type sovereignDeps struct {
+	core kubernetes.Interface
+	dyn  dynamic.Interface
+}
+
+// SovereignDepsFactory returns a fresh sovereignDeps. nil in
+// production means "build from in-cluster config"; tests inject a
+// closure returning a fake clientset + dynamic client.
+type SovereignDepsFactory func() (*sovereignDeps, error)
+
+// SetSovereignDepsFactory wires a test-only deps factory.
+func (h *Handler) SetSovereignDepsFactory(f SovereignDepsFactory) {
+	h.sovereignDepsFactory = f
+}
+
+func (h *Handler) sovereignDepsFor() (*sovereignDeps, error) {
+	if h.sovereignDepsFactory != nil {
+		return h.sovereignDepsFactory()
+	}
+	return sovereignDepsFromEnv()
+}
+
+func sovereignDepsFromEnv() (*sovereignDeps, error) {
+	cfg, err := rest.InClusterConfig()
+	if err != nil {
+		return nil, fmt.Errorf("sovereign: in-cluster config unavailable: %w", err)
+	}
+	core, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("sovereign: build core client: %w", err)
+	}
+	dyn, err := dynamic.NewForConfig(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("sovereign: build dynamic client: %w", err)
+	}
+	return &sovereignDeps{core: core, dyn: dyn}, nil
+}
+
+// ── GVRs the local-cluster endpoints read ─────────────────────────────────
+
+// helmReleaseGVR — flux v2.4 stable HelmRelease API. Mirrors the
+// canonical GVR in internal/helmwatch.HelmReleaseGVR; redeclared here
+// to avoid the import cycle (helmwatch already imports the handler
+// package transitively via the Job bridge wiring).
+var helmReleaseGVR = schema.GroupVersionResource{
+	Group:    "helm.toolkit.fluxcd.io",
+	Version:  "v2",
+	Resource: "helmreleases",
+}
+
+// httpRouteGVR — Gateway API HTTPRoute. The canonical Sovereign
+// install uses Cilium Gateway as the only ingress; Console / SME /
+// per-blueprint front-doors all surface as HTTPRoutes. We list both
+// HTTPRoutes and Ingresses so a Sovereign that hasn't fully
+// migrated to Gateway API still surfaces its operator-visible
+// front-doors on the Cloud page.
+var httpRouteGVR = schema.GroupVersionResource{
+	Group:    "gateway.networking.k8s.io",
+	Version:  "v1",
+	Resource: "httproutes",
+}
+
+// ── /api/v1/sovereign/status — Dashboard summary ──────────────────────────
+
+type sovereignStatus struct {
+	HelmReleasesReady   int `json:"helmReleasesReady"`
+	HelmReleasesTotal   int `json:"helmReleasesTotal"`
+	PodsRunning         int `json:"podsRunning"`
+	PodsTotal           int `json:"podsTotal"`
+	CertExpirySoonCount int `json:"certExpirySoonCount"`
+}
+
+// HandleSovereignStatus — GET /api/v1/sovereign/status.
+// Aggregate counts for the three Dashboard cards.
+func (h *Handler) HandleSovereignStatus(w http.ResponseWriter, r *http.Request) {
+	deps, err := h.sovereignDepsFor()
+	if err != nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]string{
+			"error":  "in-cluster-client-unavailable",
+			"detail": err.Error(),
+		})
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
+	defer cancel()
+
+	status := sovereignStatus{}
+
+	// HelmReleases — count Ready=True. The list is unbounded by
+	// namespace because bp-catalyst-platform's chart reconciles into
+	// {auth, catalyst, openbao, ...} and a flat "all bp-* HRs" view
+	// is the operator's mental model.
+	hrList, err := deps.dyn.Resource(helmReleaseGVR).Namespace("").List(ctx, metav1.ListOptions{})
+	if err == nil {
+		status.HelmReleasesTotal = len(hrList.Items)
+		for _, hr := range hrList.Items {
+			if helmReleaseReady(&hr) {
+				status.HelmReleasesReady++
+			}
+		}
+	}
+
+	// Pods — running vs total across the cluster.
+	pods, err := deps.core.CoreV1().Pods("").List(ctx, metav1.ListOptions{})
+	if err == nil {
+		status.PodsTotal = len(pods.Items)
+		for _, p := range pods.Items {
+			if p.Status.Phase == corev1.PodRunning {
+				status.PodsRunning++
+			}
+		}
+	}
+
+	// Certs expiring within 30 days. We treat any cert-manager
+	// Certificate whose Ready condition is False AND whose status
+	// reason mentions Expir* OR whose status.notAfter is within 30d
+	// as "expiring soon". Today we use the simpler signal: count
+	// Certificate resources whose Ready=False — works on every
+	// Sovereign that has cert-manager (every Sovereign does).
+	certGVR := schema.GroupVersionResource{Group: "cert-manager.io", Version: "v1", Resource: "certificates"}
+	certs, err := deps.dyn.Resource(certGVR).Namespace("").List(ctx, metav1.ListOptions{})
+	if err == nil {
+		now := time.Now()
+		for _, c := range certs.Items {
+			if certExpirySoon(&c, now) {
+				status.CertExpirySoonCount++
+			}
+		}
+	}
+
+	writeJSON(w, http.StatusOK, status)
+}
+
+// helmReleaseReady inspects a HelmRelease's status.conditions slice
+// for type=Ready, status=True. Defensive against unset-status cases
+// (a reconcile that hasn't fired yet) — those count as not-ready.
+func helmReleaseReady(u *unstructured.Unstructured) bool {
+	conds, ok, err := unstructured.NestedSlice(u.Object, "status", "conditions")
+	if !ok || err != nil {
+		return false
+	}
+	for _, c := range conds {
+		m, ok := c.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if m["type"] == "Ready" && m["status"] == "True" {
+			return true
+		}
+	}
+	return false
+}
+
+// certExpirySoon classifies a cert-manager Certificate as
+// expiring-soon. Returns true when:
+//   - Ready=False (re-issuance failed / pending); or
+//   - status.notAfter is within 30 days of now.
+func certExpirySoon(u *unstructured.Unstructured, now time.Time) bool {
+	conds, _, _ := unstructured.NestedSlice(u.Object, "status", "conditions")
+	for _, c := range conds {
+		m, ok := c.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if m["type"] == "Ready" && m["status"] != "True" {
+			return true
+		}
+	}
+	notAfterStr, ok, _ := unstructured.NestedString(u.Object, "status", "notAfter")
+	if ok && notAfterStr != "" {
+		if t, err := time.Parse(time.RFC3339, notAfterStr); err == nil {
+			if t.Sub(now) <= 30*24*time.Hour {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// ── /api/v1/sovereign/jobs — Job history populated from local cluster ─────
+
+// sovereignJobItem is the row shape rendered by the Console Jobs page.
+// Compatible with the existing JobsTable component shape but
+// stripped of the deployment-id-scoped fields the per-deployment
+// endpoint serves on the mothership.
+type sovereignJobItem struct {
+	ID         string    `json:"id"`
+	Name       string    `json:"name"`
+	Namespace  string    `json:"namespace"`
+	Kind       string    `json:"kind"`
+	Status     string    `json:"status"`
+	Message    string    `json:"message,omitempty"`
+	StartedAt  time.Time `json:"startedAt"`
+	FinishedAt time.Time `json:"finishedAt,omitempty"`
+}
+
+type sovereignJobsResponse struct {
+	Jobs []sovereignJobItem `json:"jobs"`
+}
+
+// HandleSovereignJobs — GET /api/v1/sovereign/jobs.
+//
+// Three signal sources, sorted started-DESC:
+//
+//  1. Flux HelmReleases — every reconcile result (Ready / NotReady)
+//     surfaced as a "reconcile" job row. Captures the bootstrap-kit
+//     install events the operator just lived through.
+//  2. K8s Jobs across all namespaces — captures Helm post-install
+//     hooks (e.g. bp-keycloak-zero-bootstrap) and any operator-
+//     authored CronJob / Job runs.
+//  3. K8s Events — operator-visible warnings (recent Failed/Unhealthy
+//     reasons). Bounded to last 100 to keep the response small.
+//
+// The endpoint is read-only and idempotent.
+func (h *Handler) HandleSovereignJobs(w http.ResponseWriter, r *http.Request) {
+	deps, err := h.sovereignDepsFor()
+	if err != nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]string{
+			"error":  "in-cluster-client-unavailable",
+			"detail": err.Error(),
+		})
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), 15*time.Second)
+	defer cancel()
+
+	out := []sovereignJobItem{}
+
+	// 1. HelmReleases.
+	if hrList, err := deps.dyn.Resource(helmReleaseGVR).Namespace("").List(ctx, metav1.ListOptions{}); err == nil {
+		for _, hr := range hrList.Items {
+			item := helmReleaseToJob(&hr)
+			out = append(out, item)
+		}
+	}
+
+	// 2. K8s Jobs.
+	if jobs, err := deps.core.BatchV1().Jobs("").List(ctx, metav1.ListOptions{}); err == nil {
+		for _, j := range jobs.Items {
+			out = append(out, k8sJobToJob(&j))
+		}
+	}
+
+	// 3. K8s Events (warnings only).
+	if events, err := deps.core.CoreV1().Events("").List(ctx, metav1.ListOptions{
+		FieldSelector: "type=Warning",
+		Limit:         100,
+	}); err == nil {
+		for _, e := range events.Items {
+			out = append(out, eventToJob(&e))
+		}
+	}
+
+	// Sort by StartedAt DESC, with zero-time items bucketed last.
+	sort.Slice(out, func(i, j int) bool {
+		ai, bi := out[i].StartedAt, out[j].StartedAt
+		if ai.IsZero() && !bi.IsZero() {
+			return false
+		}
+		if !ai.IsZero() && bi.IsZero() {
+			return true
+		}
+		return ai.After(bi)
+	})
+
+	writeJSON(w, http.StatusOK, sovereignJobsResponse{Jobs: out})
+}
+
+// helmReleaseToJob maps a Flux HelmRelease unstructured into the
+// Sovereign Console's Job row shape. Status derives from
+// status.conditions[type=Ready].
+func helmReleaseToJob(u *unstructured.Unstructured) sovereignJobItem {
+	name := u.GetName()
+	ns := u.GetNamespace()
+	id := fmt.Sprintf("hr/%s/%s", ns, name)
+	status := "running"
+	message := ""
+	conds, _, _ := unstructured.NestedSlice(u.Object, "status", "conditions")
+	for _, c := range conds {
+		m, ok := c.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if m["type"] != "Ready" {
+			continue
+		}
+		switch m["status"] {
+		case "True":
+			status = "succeeded"
+		case "False":
+			status = "failed"
+		default:
+			status = "running"
+		}
+		if msg, ok := m["message"].(string); ok {
+			message = msg
+		}
+	}
+	started := u.GetCreationTimestamp().Time
+	finished := time.Time{}
+	if status == "succeeded" || status == "failed" {
+		// Use lastTransitionTime as a proxy for finish.
+		for _, c := range conds {
+			m, ok := c.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			if m["type"] == "Ready" {
+				if t, ok := m["lastTransitionTime"].(string); ok {
+					if parsed, err := time.Parse(time.RFC3339, t); err == nil {
+						finished = parsed
+					}
+				}
+			}
+		}
+	}
+	return sovereignJobItem{
+		ID:         id,
+		Name:       name,
+		Namespace:  ns,
+		Kind:       "HelmRelease",
+		Status:     status,
+		Message:    message,
+		StartedAt:  started,
+		FinishedAt: finished,
+	}
+}
+
+// k8sJobToJob maps a batch/v1 Job into the Console Job row shape.
+func k8sJobToJob(j *batchv1.Job) sovereignJobItem {
+	status := "running"
+	for _, c := range j.Status.Conditions {
+		switch c.Type {
+		case "Complete":
+			if c.Status == corev1.ConditionTrue {
+				status = "succeeded"
+			}
+		case "Failed":
+			if c.Status == corev1.ConditionTrue {
+				status = "failed"
+			}
+		}
+	}
+	if status == "running" && j.Status.Active == 0 && j.Status.Succeeded == 0 && j.Status.Failed == 0 {
+		status = "pending"
+	}
+	started := time.Time{}
+	if j.Status.StartTime != nil {
+		started = j.Status.StartTime.Time
+	} else {
+		started = j.CreationTimestamp.Time
+	}
+	finished := time.Time{}
+	if j.Status.CompletionTime != nil {
+		finished = j.Status.CompletionTime.Time
+	}
+	return sovereignJobItem{
+		ID:         fmt.Sprintf("job/%s/%s", j.Namespace, j.Name),
+		Name:       j.Name,
+		Namespace:  j.Namespace,
+		Kind:       "Job",
+		Status:     status,
+		StartedAt:  started,
+		FinishedAt: finished,
+	}
+}
+
+// eventToJob maps a K8s Event (warning only) into a Job row so
+// operator-visible cluster anomalies surface alongside HelmReleases.
+func eventToJob(e *corev1.Event) sovereignJobItem {
+	involved := e.InvolvedObject.Kind + "/" + e.InvolvedObject.Name
+	if e.InvolvedObject.Namespace != "" && e.InvolvedObject.Namespace != e.Namespace {
+		involved = e.InvolvedObject.Namespace + "/" + involved
+	}
+	started := e.FirstTimestamp.Time
+	if started.IsZero() && !e.EventTime.Time.IsZero() {
+		started = e.EventTime.Time
+	}
+	if started.IsZero() {
+		started = e.CreationTimestamp.Time
+	}
+	return sovereignJobItem{
+		ID:        fmt.Sprintf("event/%s/%s", e.Namespace, e.Name),
+		Name:      e.Reason + ": " + involved,
+		Namespace: e.Namespace,
+		Kind:      "Event",
+		Status:    "warning",
+		Message:   e.Message,
+		StartedAt: started,
+	}
+}
+
+// ── /api/v1/sovereign/apps — installable catalog + installed status ───────
+
+type sovereignAppItem struct {
+	ID           string   `json:"id"`
+	Slug         string   `json:"slug"`
+	Title        string   `json:"title"`
+	Summary      string   `json:"summary"`
+	Category     string   `json:"category,omitempty"`
+	Tagline      string   `json:"tagline,omitempty"`
+	Tags         []string `json:"tags"`
+	Version      string   `json:"version,omitempty"`
+	Section      string   `json:"section,omitempty"`
+	Depends      []string `json:"depends"`
+	Status       string   `json:"status"` // installed | available | bootstrap
+	BootstrapKit bool     `json:"bootstrapKit"`
+}
+
+type sovereignAppsResponse struct {
+	Apps         []sovereignAppItem `json:"apps"`
+	GeneratedAt  string             `json:"generatedAt,omitempty"`
+	BootstrapKit []string           `json:"bootstrapKit"`
+}
+
+// HandleSovereignApps — GET /api/v1/sovereign/apps.
+//
+// Marketplace card grid for the Sovereign Console. Sources:
+//
+//   - Catalog: internal/catalog (embedded blueprints.json) — the
+//     SAME data the wizard's StepComponents renders.
+//   - Installed: HelmReleases on the local cluster, matched to
+//     blueprints by name (HR name "bp-<slug>" maps directly to
+//     catalog id "bp-<slug>").
+//
+// Each row carries a status field:
+//   - "installed"  — HR present & Ready=True
+//   - "installing" — HR present, Ready=False (or absent condition)
+//   - "bootstrap"  — visibility=unlisted AND part of bootstrap kit
+//                     (these always render as installed; the operator
+//                      cannot uninstall the spine)
+//   - "available"  — listed catalog entry, no matching HR yet
+func (h *Handler) HandleSovereignApps(w http.ResponseWriter, r *http.Request) {
+	listed, err := catalog.ListedBlueprints()
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{
+			"error":  "catalog-load-failed",
+			"detail": err.Error(),
+		})
+		return
+	}
+	bootstrap, err := catalog.BootstrapKit()
+	if err != nil {
+		// non-fatal: a missing bootstrap-kit entry just means
+		// nothing renders as bootstrap. The catalog blueprints
+		// still ship.
+		bootstrap = nil
+	}
+
+	// Map HR name → ready/notReady. Best-effort: a Sovereign with
+	// no in-cluster client (CI) gets "available" for every entry,
+	// which is the safe, non-misleading fallback.
+	installed := map[string]string{} // hr name → "installed" | "installing"
+	deps, depsErr := h.sovereignDepsFor()
+	if depsErr == nil {
+		ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
+		defer cancel()
+		if hrList, err := deps.dyn.Resource(helmReleaseGVR).Namespace("").List(ctx, metav1.ListOptions{}); err == nil {
+			for _, hr := range hrList.Items {
+				name := hr.GetName()
+				if helmReleaseReady(&hr) {
+					installed[name] = "installed"
+				} else {
+					installed[name] = "installing"
+				}
+			}
+		}
+	}
+
+	bootstrapIDs := map[string]bool{}
+	bootstrapList := make([]string, 0, len(bootstrap))
+	for _, b := range bootstrap {
+		bootstrapIDs[b.ID] = true
+		bootstrapList = append(bootstrapList, b.ID)
+	}
+
+	apps := make([]sovereignAppItem, 0, len(listed)+len(bootstrap))
+
+	// Bootstrap-kit always rendered first as "installed" (unlisted
+	// blueprints don't appear in `listed`). The operator sees them
+	// as part of the catalog, marked "bootstrap" so they can't be
+	// uninstalled via UI.
+	for _, b := range bootstrap {
+		apps = append(apps, sovereignAppItem{
+			ID:           b.ID,
+			Slug:         b.Slug,
+			Title:        humanizeSlug(b.Slug),
+			Summary:      "",
+			Status:       "bootstrap",
+			BootstrapKit: true,
+		})
+	}
+
+	for _, b := range listed {
+		// Skip duplicates that already appeared as bootstrap.
+		if bootstrapIDs[b.ID] {
+			continue
+		}
+		status := "available"
+		if s, ok := installed[b.ID]; ok {
+			status = s
+		}
+		apps = append(apps, sovereignAppItem{
+			ID:           b.ID,
+			Slug:         b.Slug,
+			Title:        b.Title,
+			Summary:      b.Summary,
+			Category:     deref(b.Category),
+			Tagline:      deref(b.Tagline),
+			Tags:         b.Tags,
+			Version:      deref(b.Version),
+			Section:      deref(b.Section),
+			Depends:      b.Depends,
+			Status:       status,
+			BootstrapKit: false,
+		})
+	}
+
+	gen, _ := catalog.GeneratedAt()
+	writeJSON(w, http.StatusOK, sovereignAppsResponse{
+		Apps:         apps,
+		GeneratedAt:  gen,
+		BootstrapKit: bootstrapList,
+	})
+}
+
+// ── /api/v1/sovereign/cloud — local-cluster topology surface ──────────────
+
+type sovereignCloudResponse struct {
+	Nodes          []sovereignNode      `json:"nodes"`
+	Namespaces     []sovereignNamespace `json:"namespaces"`
+	Ingresses      []sovereignIngress   `json:"ingresses"`
+	HTTPRoutes     []sovereignIngress   `json:"httpRoutes"`
+	LoadBalancers  []sovereignLB        `json:"loadBalancers"`
+	StorageClasses []sovereignSC        `json:"storageClasses"`
+	PVCs           []sovereignPVC       `json:"pvcs"`
+}
+
+type sovereignNode struct {
+	Name           string            `json:"name"`
+	Status         string            `json:"status"`
+	Roles          []string          `json:"roles"`
+	KubeletVersion string            `json:"kubeletVersion"`
+	OS             string            `json:"os"`
+	Arch           string            `json:"arch"`
+	InternalIP     string            `json:"internalIP"`
+	ExternalIP     string            `json:"externalIP,omitempty"`
+	CapacityCPU    string            `json:"capacityCPU"`
+	CapacityMemory string            `json:"capacityMemory"`
+	Labels         map[string]string `json:"labels,omitempty"`
+}
+
+type sovereignNamespace struct {
+	Name      string    `json:"name"`
+	Status    string    `json:"status"`
+	CreatedAt time.Time `json:"createdAt"`
+}
+
+type sovereignIngress struct {
+	Name      string   `json:"name"`
+	Namespace string   `json:"namespace"`
+	Hosts     []string `json:"hosts"`
+	URL       string   `json:"url,omitempty"`
+}
+
+type sovereignLB struct {
+	Name       string   `json:"name"`
+	Namespace  string   `json:"namespace"`
+	Type       string   `json:"type"`
+	ClusterIP  string   `json:"clusterIP,omitempty"`
+	ExternalIP string   `json:"externalIP,omitempty"`
+	Ports      []string `json:"ports"`
+}
+
+type sovereignSC struct {
+	Name           string `json:"name"`
+	Provisioner    string `json:"provisioner"`
+	IsDefault      bool   `json:"isDefault"`
+	ReclaimPolicy  string `json:"reclaimPolicy"`
+}
+
+type sovereignPVC struct {
+	Name         string `json:"name"`
+	Namespace    string `json:"namespace"`
+	StorageClass string `json:"storageClass"`
+	Capacity     string `json:"capacity"`
+	Status       string `json:"status"`
+}
+
+// HandleSovereignCloud — GET /api/v1/sovereign/cloud.
+//
+// Read-only topology snapshot for the Console Cloud page. Six lists,
+// every list paged in one call. The Console renders sections from
+// the same response so a freshly handed-over operator sees their
+// cluster's full surface at a glance.
+func (h *Handler) HandleSovereignCloud(w http.ResponseWriter, r *http.Request) {
+	deps, err := h.sovereignDepsFor()
+	if err != nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]string{
+			"error":  "in-cluster-client-unavailable",
+			"detail": err.Error(),
+		})
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), 15*time.Second)
+	defer cancel()
+
+	resp := sovereignCloudResponse{
+		Nodes:          []sovereignNode{},
+		Namespaces:     []sovereignNamespace{},
+		Ingresses:      []sovereignIngress{},
+		HTTPRoutes:     []sovereignIngress{},
+		LoadBalancers:  []sovereignLB{},
+		StorageClasses: []sovereignSC{},
+		PVCs:           []sovereignPVC{},
+	}
+
+	if nodes, err := deps.core.CoreV1().Nodes().List(ctx, metav1.ListOptions{}); err == nil {
+		for _, n := range nodes.Items {
+			resp.Nodes = append(resp.Nodes, mapNode(&n))
+		}
+	}
+
+	if nss, err := deps.core.CoreV1().Namespaces().List(ctx, metav1.ListOptions{}); err == nil {
+		for _, ns := range nss.Items {
+			resp.Namespaces = append(resp.Namespaces, sovereignNamespace{
+				Name:      ns.Name,
+				Status:    string(ns.Status.Phase),
+				CreatedAt: ns.CreationTimestamp.Time,
+			})
+		}
+	}
+
+	if ings, err := deps.core.NetworkingV1().Ingresses("").List(ctx, metav1.ListOptions{}); err == nil {
+		for _, ing := range ings.Items {
+			hosts := []string{}
+			for _, rule := range ing.Spec.Rules {
+				if rule.Host != "" {
+					hosts = append(hosts, rule.Host)
+				}
+			}
+			url := ""
+			if len(hosts) > 0 {
+				url = "https://" + hosts[0]
+			}
+			resp.Ingresses = append(resp.Ingresses, sovereignIngress{
+				Name:      ing.Name,
+				Namespace: ing.Namespace,
+				Hosts:     hosts,
+				URL:       url,
+			})
+		}
+	}
+
+	// HTTPRoutes via dynamic client — Gateway API may not be installed
+	// on every cluster, so the not-found error is non-fatal.
+	if rl, err := deps.dyn.Resource(httpRouteGVR).Namespace("").List(ctx, metav1.ListOptions{}); err == nil {
+		for _, h := range rl.Items {
+			hosts, _, _ := unstructured.NestedStringSlice(h.Object, "spec", "hostnames")
+			url := ""
+			if len(hosts) > 0 {
+				url = "https://" + hosts[0]
+			}
+			resp.HTTPRoutes = append(resp.HTTPRoutes, sovereignIngress{
+				Name:      h.GetName(),
+				Namespace: h.GetNamespace(),
+				Hosts:     hosts,
+				URL:       url,
+			})
+		}
+	}
+
+	if svcs, err := deps.core.CoreV1().Services("").List(ctx, metav1.ListOptions{}); err == nil {
+		for _, svc := range svcs.Items {
+			if svc.Spec.Type != corev1.ServiceTypeLoadBalancer {
+				continue
+			}
+			ports := []string{}
+			for _, p := range svc.Spec.Ports {
+				ports = append(ports, fmt.Sprintf("%d/%s", p.Port, p.Protocol))
+			}
+			extIP := ""
+			for _, ing := range svc.Status.LoadBalancer.Ingress {
+				if ing.IP != "" {
+					extIP = ing.IP
+					break
+				}
+				if ing.Hostname != "" {
+					extIP = ing.Hostname
+					break
+				}
+			}
+			resp.LoadBalancers = append(resp.LoadBalancers, sovereignLB{
+				Name:       svc.Name,
+				Namespace:  svc.Namespace,
+				Type:       string(svc.Spec.Type),
+				ClusterIP:  svc.Spec.ClusterIP,
+				ExternalIP: extIP,
+				Ports:      ports,
+			})
+		}
+	}
+
+	if scs, err := deps.core.StorageV1().StorageClasses().List(ctx, metav1.ListOptions{}); err == nil {
+		for _, sc := range scs.Items {
+			isDefault := sc.Annotations["storageclass.kubernetes.io/is-default-class"] == "true"
+			rp := ""
+			if sc.ReclaimPolicy != nil {
+				rp = string(*sc.ReclaimPolicy)
+			}
+			resp.StorageClasses = append(resp.StorageClasses, sovereignSC{
+				Name:          sc.Name,
+				Provisioner:   sc.Provisioner,
+				IsDefault:     isDefault,
+				ReclaimPolicy: rp,
+			})
+		}
+	}
+
+	if pvcs, err := deps.core.CoreV1().PersistentVolumeClaims("").List(ctx, metav1.ListOptions{}); err == nil {
+		for _, p := range pvcs.Items {
+			cap := ""
+			if v, ok := p.Spec.Resources.Requests[corev1.ResourceStorage]; ok {
+				cap = v.String()
+			}
+			sc := ""
+			if p.Spec.StorageClassName != nil {
+				sc = *p.Spec.StorageClassName
+			}
+			resp.PVCs = append(resp.PVCs, sovereignPVC{
+				Name:         p.Name,
+				Namespace:    p.Namespace,
+				StorageClass: sc,
+				Capacity:     cap,
+				Status:       string(p.Status.Phase),
+			})
+		}
+	}
+
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// mapNode converts a core/v1.Node to the Sovereign Console row shape.
+func mapNode(n *corev1.Node) sovereignNode {
+	status := "Unknown"
+	for _, c := range n.Status.Conditions {
+		if c.Type == corev1.NodeReady {
+			if c.Status == corev1.ConditionTrue {
+				status = "Ready"
+			} else {
+				status = "NotReady"
+			}
+			break
+		}
+	}
+	roles := []string{}
+	for k := range n.Labels {
+		const p = "node-role.kubernetes.io/"
+		if strings.HasPrefix(k, p) {
+			roles = append(roles, strings.TrimPrefix(k, p))
+		}
+	}
+	if len(roles) == 0 {
+		roles = []string{"worker"}
+	}
+	internalIP := ""
+	externalIP := ""
+	for _, addr := range n.Status.Addresses {
+		switch addr.Type {
+		case corev1.NodeInternalIP:
+			internalIP = addr.Address
+		case corev1.NodeExternalIP:
+			externalIP = addr.Address
+		}
+	}
+	cpuCap := ""
+	memCap := ""
+	if v, ok := n.Status.Capacity[corev1.ResourceCPU]; ok {
+		cpuCap = v.String()
+	}
+	if v, ok := n.Status.Capacity[corev1.ResourceMemory]; ok {
+		memCap = v.String()
+	}
+	return sovereignNode{
+		Name:           n.Name,
+		Status:         status,
+		Roles:          roles,
+		KubeletVersion: n.Status.NodeInfo.KubeletVersion,
+		OS:             n.Status.NodeInfo.OperatingSystem,
+		Arch:           n.Status.NodeInfo.Architecture,
+		InternalIP:     internalIP,
+		ExternalIP:     externalIP,
+		CapacityCPU:    cpuCap,
+		CapacityMemory: memCap,
+	}
+}
+
+// ── helpers ────────────────────────────────────────────────────────────────
+
+func deref(p *string) string {
+	if p == nil {
+		return ""
+	}
+	return *p
+}
+
+// humanizeSlug turns "cert-manager" into "Cert Manager".
+func humanizeSlug(s string) string {
+	parts := strings.Split(s, "-")
+	for i, p := range parts {
+		if p == "" {
+			continue
+		}
+		parts[i] = strings.ToUpper(p[:1]) + p[1:]
+	}
+	return strings.Join(parts, " ")
+}
+

--- a/products/catalyst/bootstrap/api/internal/handler/sovereign_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sovereign_test.go
@@ -1,0 +1,400 @@
+// Tests for the Sovereign Console populated-views endpoints (issue #933).
+//
+// What this file proves:
+//
+//  1. /api/v1/sovereign/status — counts HelmReleases (Ready vs total)
+//     and pods (Running vs total) from the in-cluster client.
+//  2. /api/v1/sovereign/jobs — surfaces HelmReleases, K8s Jobs, and
+//     Warning-level Events as Job rows, sorted started-DESC.
+//  3. /api/v1/sovereign/apps — joins the embedded blueprint catalog
+//     with HelmRelease state on the cluster:
+//       - HR present + Ready=True       → "installed"
+//       - HR present + Ready=False/none → "installing"
+//       - listed catalog, no HR         → "available"
+//       - bootstrap-kit                 → "bootstrap"
+//  4. /api/v1/sovereign/cloud — emits nodes / namespaces / ingresses /
+//     LoadBalancer-services / storage classes / PVCs from the in-cluster
+//     client, with HTTPRoutes coming via dynamic client.
+//
+// Tests inject (kubernetes.Interface, dynamic.Interface) via
+// SetSovereignDepsFactory so no real cluster is needed.
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	fakek8s "k8s.io/client-go/kubernetes/fake"
+)
+
+// ── Fixtures + helpers ─────────────────────────────────────────────────────
+
+func newSovereignHandler(t *testing.T, coreObjs []runtime.Object, dynObjs []runtime.Object) *Handler {
+	t.Helper()
+	core := fakek8s.NewSimpleClientset(coreObjs...)
+
+	scheme := runtime.NewScheme()
+	gvrToList := map[schema.GroupVersionResource]string{
+		helmReleaseGVR: "HelmReleaseList",
+		httpRouteGVR:   "HTTPRouteList",
+		{Group: "cert-manager.io", Version: "v1", Resource: "certificates"}: "CertificateList",
+	}
+	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrToList, dynObjs...)
+
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	h.SetSovereignDepsFactory(func() (*sovereignDeps, error) {
+		return &sovereignDeps{core: core, dyn: dyn}, nil
+	})
+	return h
+}
+
+func makeHR(name, ns, ready string) *unstructured.Unstructured {
+	u := &unstructured.Unstructured{}
+	u.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "helm.toolkit.fluxcd.io",
+		Version: "v2",
+		Kind:    "HelmRelease",
+	})
+	u.SetName(name)
+	u.SetNamespace(ns)
+	u.SetCreationTimestamp(metav1.NewTime(time.Now().Add(-1 * time.Hour)))
+	conds := []interface{}{
+		map[string]interface{}{
+			"type":               "Ready",
+			"status":             ready,
+			"message":            "test condition",
+			"lastTransitionTime": time.Now().Add(-30 * time.Minute).Format(time.RFC3339),
+		},
+	}
+	_ = unstructured.SetNestedSlice(u.Object, conds, "status", "conditions")
+	return u
+}
+
+func makeHTTPRoute(name, ns string, hosts []string) *unstructured.Unstructured {
+	u := &unstructured.Unstructured{}
+	u.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "gateway.networking.k8s.io",
+		Version: "v1",
+		Kind:    "HTTPRoute",
+	})
+	u.SetName(name)
+	u.SetNamespace(ns)
+	hostsAny := make([]interface{}, len(hosts))
+	for i, h := range hosts {
+		hostsAny[i] = h
+	}
+	_ = unstructured.SetNestedSlice(u.Object, hostsAny, "spec", "hostnames")
+	return u
+}
+
+func mustGet[T any](t *testing.T, h http.Handler, path string) T {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("GET %s: status = %d, body=%s", path, w.Code, w.Body.String())
+	}
+	var out T
+	if err := json.NewDecoder(w.Body).Decode(&out); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	return out
+}
+
+// ── /status ────────────────────────────────────────────────────────────────
+
+func TestSovereignStatus_CountsHelmReleasesAndPods(t *testing.T) {
+	dynObjs := []runtime.Object{
+		makeHR("bp-cilium", "flux-system", "True"),
+		makeHR("bp-cert-manager", "flux-system", "True"),
+		makeHR("bp-flux", "flux-system", "False"),
+	}
+	coreObjs := []runtime.Object{
+		&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "a", Namespace: "default"},
+			Status:     corev1.PodStatus{Phase: corev1.PodRunning},
+		},
+		&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "b", Namespace: "default"},
+			Status:     corev1.PodStatus{Phase: corev1.PodRunning},
+		},
+		&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "c", Namespace: "default"},
+			Status:     corev1.PodStatus{Phase: corev1.PodPending},
+		},
+	}
+	h := newSovereignHandler(t, coreObjs, dynObjs)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/sovereign/status", nil)
+	w := httptest.NewRecorder()
+	h.HandleSovereignStatus(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status code = %d; body=%s", w.Code, w.Body.String())
+	}
+	var got sovereignStatus
+	if err := json.NewDecoder(w.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.HelmReleasesTotal != 3 {
+		t.Errorf("HelmReleasesTotal = %d, want 3", got.HelmReleasesTotal)
+	}
+	if got.HelmReleasesReady != 2 {
+		t.Errorf("HelmReleasesReady = %d, want 2", got.HelmReleasesReady)
+	}
+	if got.PodsTotal != 3 {
+		t.Errorf("PodsTotal = %d, want 3", got.PodsTotal)
+	}
+	if got.PodsRunning != 2 {
+		t.Errorf("PodsRunning = %d, want 2", got.PodsRunning)
+	}
+}
+
+// ── /jobs ──────────────────────────────────────────────────────────────────
+
+func TestSovereignJobs_HelmReleasesAndK8sJobs(t *testing.T) {
+	dynObjs := []runtime.Object{
+		makeHR("bp-cilium", "flux-system", "True"),
+		makeHR("bp-cert-manager", "flux-system", "False"),
+	}
+	coreObjs := []runtime.Object{
+		&batchv1.Job{
+			ObjectMeta: metav1.ObjectMeta{Name: "bp-keycloak-bootstrap", Namespace: "auth"},
+			Status: batchv1.JobStatus{
+				Conditions: []batchv1.JobCondition{
+					{Type: "Complete", Status: corev1.ConditionTrue},
+				},
+				StartTime:      &metav1.Time{Time: time.Now().Add(-2 * time.Hour)},
+				CompletionTime: &metav1.Time{Time: time.Now().Add(-1 * time.Hour)},
+			},
+		},
+		&corev1.Event{
+			ObjectMeta:     metav1.ObjectMeta{Name: "warn-1", Namespace: "default"},
+			Type:           "Warning",
+			Reason:         "FailedMount",
+			Message:        "could not mount volume",
+			InvolvedObject: corev1.ObjectReference{Kind: "Pod", Name: "x"},
+			FirstTimestamp: metav1.NewTime(time.Now().Add(-15 * time.Minute)),
+		},
+	}
+	h := newSovereignHandler(t, coreObjs, dynObjs)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/sovereign/jobs", nil)
+	w := httptest.NewRecorder()
+	h.HandleSovereignJobs(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status code = %d; body=%s", w.Code, w.Body.String())
+	}
+	var got sovereignJobsResponse
+	if err := json.NewDecoder(w.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	// 2 HRs + 1 K8s Job + 1 Event = 4 rows.
+	if len(got.Jobs) < 3 {
+		t.Errorf("expected at least 3 jobs, got %d", len(got.Jobs))
+	}
+	kinds := map[string]int{}
+	for _, j := range got.Jobs {
+		kinds[j.Kind]++
+	}
+	if kinds["HelmRelease"] != 2 {
+		t.Errorf("HelmRelease rows = %d, want 2", kinds["HelmRelease"])
+	}
+	if kinds["Job"] != 1 {
+		t.Errorf("Job rows = %d, want 1", kinds["Job"])
+	}
+}
+
+// ── /apps ──────────────────────────────────────────────────────────────────
+
+func TestSovereignApps_StatusJoinHelmReleases(t *testing.T) {
+	// Catalog will return embedded JSON blueprints. We don't seed
+	// blueprints (they're embedded). We DO seed HelmReleases that
+	// claim to install bp-cilium so the apps list reflects that.
+	dynObjs := []runtime.Object{
+		makeHR("bp-cilium", "flux-system", "True"),
+		makeHR("bp-keycloak", "flux-system", "False"),
+	}
+	h := newSovereignHandler(t, nil, dynObjs)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/sovereign/apps", nil)
+	w := httptest.NewRecorder()
+	h.HandleSovereignApps(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status code = %d; body=%s", w.Code, w.Body.String())
+	}
+	var got sovereignAppsResponse
+	if err := json.NewDecoder(w.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(got.Apps) == 0 {
+		t.Fatal("expected at least one app from embedded catalog, got 0")
+	}
+	// Find bp-cilium and check status.
+	byID := map[string]sovereignAppItem{}
+	for _, a := range got.Apps {
+		byID[a.ID] = a
+	}
+	if cilium, ok := byID["bp-cilium"]; ok {
+		if cilium.Status != "installed" && cilium.Status != "bootstrap" {
+			t.Errorf("bp-cilium status = %q; want installed or bootstrap", cilium.Status)
+		}
+	}
+	if kc, ok := byID["bp-keycloak"]; ok {
+		// keycloak HR is not Ready, so status must be either
+		// "installing" (if listed and HR present) or "bootstrap"
+		// (if it's part of the bootstrap-kit which always renders).
+		if kc.Status != "installing" && kc.Status != "bootstrap" {
+			t.Errorf("bp-keycloak status = %q; want installing or bootstrap", kc.Status)
+		}
+	}
+	if got.GeneratedAt == "" {
+		t.Error("expected GeneratedAt to be populated from embedded catalog")
+	}
+}
+
+// ── /cloud ─────────────────────────────────────────────────────────────────
+
+func TestSovereignCloud_NodesAndNamespaces(t *testing.T) {
+	coreObjs := []runtime.Object{
+		&corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   "cp-1",
+				Labels: map[string]string{"node-role.kubernetes.io/control-plane": ""},
+			},
+			Status: corev1.NodeStatus{
+				Conditions: []corev1.NodeCondition{
+					{Type: corev1.NodeReady, Status: corev1.ConditionTrue},
+				},
+				NodeInfo: corev1.NodeSystemInfo{
+					KubeletVersion:  "v1.31.4",
+					OperatingSystem: "linux",
+					Architecture:    "amd64",
+				},
+				Addresses: []corev1.NodeAddress{
+					{Type: corev1.NodeInternalIP, Address: "10.0.0.1"},
+				},
+				Capacity: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("4"),
+					corev1.ResourceMemory: resource.MustParse("8Gi"),
+				},
+			},
+		},
+		&corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{Name: "auth"},
+			Status:     corev1.NamespaceStatus{Phase: corev1.NamespaceActive},
+		},
+		&networkingv1.Ingress{
+			ObjectMeta: metav1.ObjectMeta{Name: "console", Namespace: "catalyst"},
+			Spec: networkingv1.IngressSpec{
+				Rules: []networkingv1.IngressRule{{Host: "console.example.com"}},
+			},
+		},
+		&corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{Name: "cilium-gateway", Namespace: "kube-system"},
+			Spec: corev1.ServiceSpec{
+				Type:      corev1.ServiceTypeLoadBalancer,
+				ClusterIP: "10.43.0.1",
+				Ports:     []corev1.ServicePort{{Port: 443, Protocol: corev1.ProtocolTCP}},
+			},
+			Status: corev1.ServiceStatus{
+				LoadBalancer: corev1.LoadBalancerStatus{
+					Ingress: []corev1.LoadBalancerIngress{{IP: "1.2.3.4"}},
+				},
+			},
+		},
+		&storagev1.StorageClass{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "local-path",
+				Annotations: map[string]string{"storageclass.kubernetes.io/is-default-class": "true"},
+			},
+			Provisioner: "rancher.io/local-path",
+		},
+		&corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{Name: "data-keycloak", Namespace: "auth"},
+			Spec: corev1.PersistentVolumeClaimSpec{
+				StorageClassName: ptr("local-path"),
+				Resources: corev1.VolumeResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceStorage: resource.MustParse("5Gi"),
+					},
+				},
+			},
+			Status: corev1.PersistentVolumeClaimStatus{Phase: corev1.ClaimBound},
+		},
+	}
+	dynObjs := []runtime.Object{
+		makeHTTPRoute("console", "catalyst", []string{"console.sov.example.com"}),
+	}
+	h := newSovereignHandler(t, coreObjs, dynObjs)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/sovereign/cloud", nil)
+	w := httptest.NewRecorder()
+	h.HandleSovereignCloud(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status code = %d; body=%s", w.Code, w.Body.String())
+	}
+	var got sovereignCloudResponse
+	if err := json.NewDecoder(w.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(got.Nodes) != 1 {
+		t.Errorf("nodes = %d, want 1", len(got.Nodes))
+	}
+	if len(got.Nodes) > 0 {
+		n := got.Nodes[0]
+		if n.Status != "Ready" {
+			t.Errorf("node status = %q, want Ready", n.Status)
+		}
+		if n.InternalIP != "10.0.0.1" {
+			t.Errorf("node internalIP = %q, want 10.0.0.1", n.InternalIP)
+		}
+	}
+	if len(got.Namespaces) != 1 || got.Namespaces[0].Name != "auth" {
+		t.Errorf("namespaces = %+v, want [auth]", got.Namespaces)
+	}
+	if len(got.Ingresses) != 1 || got.Ingresses[0].Hosts[0] != "console.example.com" {
+		t.Errorf("ingresses = %+v", got.Ingresses)
+	}
+	if len(got.HTTPRoutes) != 1 || got.HTTPRoutes[0].Hosts[0] != "console.sov.example.com" {
+		t.Errorf("httproutes = %+v", got.HTTPRoutes)
+	}
+	if len(got.LoadBalancers) != 1 || got.LoadBalancers[0].ExternalIP != "1.2.3.4" {
+		t.Errorf("loadbalancers = %+v", got.LoadBalancers)
+	}
+	if len(got.StorageClasses) != 1 || !got.StorageClasses[0].IsDefault {
+		t.Errorf("storageClasses = %+v; want one default class", got.StorageClasses)
+	}
+	if len(got.PVCs) != 1 {
+		t.Errorf("pvcs = %d, want 1", len(got.PVCs))
+	}
+}
+
+// ── client unavailable path ─────────────────────────────────────────────────
+
+func TestSovereignStatus_503WhenInClusterUnavailable(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	// SetSovereignDepsFactory not called → falls back to
+	// rest.InClusterConfig() which fails outside K8s.
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/sovereign/status", nil)
+	w := httptest.NewRecorder()
+	h.HandleSovereignStatus(w, req)
+	if w.Code != http.StatusServiceUnavailable {
+		t.Errorf("status code = %d, want 503 (in-cluster client missing)", w.Code)
+	}
+}
+
+func ptr[T any](v T) *T { return &v }

--- a/products/catalyst/bootstrap/ui/scripts/build-catalog.mjs
+++ b/products/catalyst/bootstrap/ui/scripts/build-catalog.mjs
@@ -42,6 +42,13 @@ const PLATFORM_DIR = resolve(REPO_ROOT, 'platform')
 const PRODUCTS_DIR = resolve(REPO_ROOT, 'products')
 const BOOTSTRAP_KIT_DIR = resolve(REPO_ROOT, 'clusters/_template/bootstrap-kit')
 const OUT_FILE = resolve(__dirname, '../src/shared/constants/catalog.generated.ts')
+// Sister output for the Go catalyst-api side. The Sovereign Console's
+// /api/v1/sovereign/apps endpoint embeds this JSON via go:embed so the
+// in-cluster apps catalog mirrors the wizard's marketplace 1:1. Per
+// docs/INVIOLABLE-PRINCIPLES.md #4, the Blueprint catalog has exactly
+// ONE source of truth (blueprint.yaml files). This file is generated
+// alongside catalog.generated.ts and committed; CI catches drift.
+const OUT_FILE_JSON = resolve(REPO_ROOT, 'products/catalyst/bootstrap/api/internal/catalog/blueprints.json')
 
 // Fail loudly if the source dirs are missing — silently producing an empty
 // BOOTSTRAP_KIT[] is what shipped a broken provision page where only the
@@ -387,7 +394,22 @@ export const BOOTSTRAP_KIT: readonly BootstrapKitEntry[] = ${JSON.stringify(boot
   mkdirSync(dirname(OUT_FILE), { recursive: true })
   writeFileSync(OUT_FILE, tsBody)
 
+  // Sister JSON output for the Go catalyst-api side. The Sovereign
+  // Console's /api/v1/sovereign/apps endpoint embeds this via go:embed.
+  const jsonBody = JSON.stringify(
+    {
+      generatedAt: new Date().toISOString(),
+      blueprints: entries,
+      bootstrapKit,
+    },
+    null,
+    2,
+  )
+  mkdirSync(dirname(OUT_FILE_JSON), { recursive: true })
+  writeFileSync(OUT_FILE_JSON, jsonBody + '\n')
+
   console.log(`[build-catalog] wrote ${entries.length} blueprints to ${OUT_FILE}`)
+  console.log(`[build-catalog] wrote ${entries.length} blueprints to ${OUT_FILE_JSON}`)
   console.log(`[build-catalog]   listed:   ${entries.filter(e => e.visibility === 'listed').length}`)
   console.log(`[build-catalog]   unlisted: ${entries.filter(e => e.visibility === 'unlisted').length}`)
   console.log(`[build-catalog]   private:  ${entries.filter(e => e.visibility === 'private').length}`)

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/console/ConsoleAppsPage.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/console/ConsoleAppsPage.test.tsx
@@ -1,0 +1,121 @@
+/**
+ * ConsoleAppsPage.test.tsx — issue #933.
+ *
+ * Locks in the Sovereign Console Apps surface against
+ * /api/v1/sovereign/apps:
+ *
+ *   • Loaded state renders one card per app with status badge
+ *   • Bootstrap-kit cards render with the "bootstrap" badge
+ *   • Available cards render an "Install" button affordance
+ *   • Search filter narrows the visible cards
+ *   • Status filter chips narrow the visible cards
+ *   • Error state surfaces the API error message
+ */
+
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react'
+import { ConsoleAppsPage } from './ConsoleAppsPage'
+
+const ORIGINAL_FETCH = globalThis.fetch
+
+afterEach(() => {
+  cleanup()
+  globalThis.fetch = ORIGINAL_FETCH
+})
+
+function mockFetchOnce(body: unknown, ok = true) {
+  globalThis.fetch = vi.fn().mockResolvedValue({
+    ok,
+    status: ok ? 200 : 500,
+    json: async () => body,
+  }) as unknown as typeof fetch
+}
+
+const SAMPLE_APPS = {
+  generatedAt: '2026-05-05T10:00:00Z',
+  bootstrapKit: ['bp-cilium'],
+  apps: [
+    {
+      id: 'bp-cilium',
+      slug: 'cilium',
+      title: 'Cilium',
+      summary: 'eBPF networking',
+      tags: [],
+      status: 'bootstrap',
+      bootstrapKit: true,
+    },
+    {
+      id: 'bp-keycloak',
+      slug: 'keycloak',
+      title: 'Keycloak',
+      summary: 'Identity provider',
+      category: 'identity',
+      tags: ['auth'],
+      status: 'installed',
+      bootstrapKit: false,
+    },
+    {
+      id: 'bp-harbor',
+      slug: 'harbor',
+      title: 'Harbor Registry',
+      summary: 'OCI registry',
+      category: 'platform',
+      tags: ['registry'],
+      status: 'available',
+      bootstrapKit: false,
+    },
+  ],
+}
+
+describe('ConsoleAppsPage', () => {
+  it('renders one card per app with status badge', async () => {
+    mockFetchOnce(SAMPLE_APPS)
+    render(<ConsoleAppsPage />)
+    await waitFor(() => {
+      expect(screen.getByTestId('apps-grid')).toBeTruthy()
+    })
+    expect(screen.getByTestId('app-card-bp-cilium')).toBeTruthy()
+    expect(screen.getByTestId('app-card-bp-keycloak')).toBeTruthy()
+    expect(screen.getByTestId('app-card-bp-harbor')).toBeTruthy()
+    // Available card carries an Install button.
+    expect(screen.getByTestId('app-install-bp-harbor')).toBeTruthy()
+  })
+
+  it('search narrows results by title / id / category', async () => {
+    mockFetchOnce(SAMPLE_APPS)
+    render(<ConsoleAppsPage />)
+    await waitFor(() => screen.getByTestId('apps-grid'))
+
+    const search = screen.getByTestId('apps-search') as HTMLInputElement
+    fireEvent.change(search, { target: { value: 'harbor' } })
+
+    expect(screen.getByTestId('app-card-bp-harbor')).toBeTruthy()
+    expect(screen.queryByTestId('app-card-bp-cilium')).toBeNull()
+    expect(screen.queryByTestId('app-card-bp-keycloak')).toBeNull()
+  })
+
+  it('filter chips narrow by status', async () => {
+    mockFetchOnce(SAMPLE_APPS)
+    render(<ConsoleAppsPage />)
+    await waitFor(() => screen.getByTestId('apps-grid'))
+
+    fireEvent.click(screen.getByTestId('apps-filter-available'))
+
+    expect(screen.getByTestId('app-card-bp-harbor')).toBeTruthy()
+    expect(screen.queryByTestId('app-card-bp-cilium')).toBeNull()
+    expect(screen.queryByTestId('app-card-bp-keycloak')).toBeNull()
+  })
+
+  it('renders the error state when the API fails', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 503,
+      json: async () => ({ error: 'oops' }),
+    }) as unknown as typeof fetch
+
+    render(<ConsoleAppsPage />)
+    await waitFor(() => {
+      expect(screen.getByTestId('apps-error')).toBeTruthy()
+    })
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/console/ConsoleAppsPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/console/ConsoleAppsPage.tsx
@@ -1,35 +1,54 @@
 /**
- * ConsoleAppsPage — Sovereign Console /console/apps
+ * ConsoleAppsPage — Sovereign Console /console/apps.
  *
- * Lists installed apps (HTTPRoutes → backing services) on the Sovereign.
- * Reuses the same visual shape as AppsPage.tsx but without a deploymentId
- * param — in Sovereign mode the cluster is implicit from the hostname.
+ * Reads /api/v1/sovereign/apps (issue #933). The endpoint joins the
+ * embedded Blueprint catalog (same data the wizard's StepComponents
+ * renders) with the local cluster's HelmRelease state, so:
  *
- * Phase 8b: renders a placeholder card grid until the
- * /api/v1/sovereign/apps endpoint (Agent C) is implemented.
+ *   - "installed"  → bp-* HR present + Ready=True
+ *   - "installing" → bp-* HR present, Ready=False or pending
+ *   - "bootstrap"  → bootstrap-kit member (always installed; cannot
+ *                    be uninstalled via UI)
+ *   - "available"  → listed in catalog, no matching HR yet
  *
- * Related: GitHub issue #607
+ * The page renders the FULL marketplace card grid an operator expects
+ * after handover — no need to reach the mothership, no waiting for
+ * the gitea-mirror cutover step. This is the "Apps" surface that
+ * makes a fresh Sovereign immediately useful.
  */
 
-import { useEffect, useState } from 'react'
-import { Package } from 'lucide-react'
+import { useEffect, useMemo, useState } from 'react'
+import { Package, Search, Filter, RefreshCw, AlertCircle, CheckCircle2 } from 'lucide-react'
 import { API_BASE } from '@/shared/config/urls'
 import { loadTokens } from '@/shared/lib/oidc'
 
 interface AppRow {
   id: string
-  name: string
-  version: string
-  status: 'ready' | 'degraded' | 'pending' | 'failed'
-  url?: string
+  slug: string
+  title: string
+  summary: string
+  category?: string
+  tagline?: string
+  tags?: string[]
+  version?: string
+  section?: string
+  depends?: string[]
+  status: 'installed' | 'installing' | 'available' | 'bootstrap'
+  bootstrapKit: boolean
+}
+
+interface ApiResponse {
+  apps: AppRow[]
+  generatedAt?: string
+  bootstrapKit?: string[]
 }
 
 type PageState =
   | { status: 'loading' }
-  | { status: 'loaded'; apps: AppRow[] }
+  | { status: 'loaded'; apps: AppRow[]; generatedAt?: string }
   | { status: 'error'; message: string }
 
-async function fetchApps(): Promise<AppRow[]> {
+async function fetchApps(): Promise<ApiResponse> {
   const tokens = loadTokens()
   const resp = await fetch(`${API_BASE}/v1/sovereign/apps`, {
     headers: {
@@ -38,65 +57,127 @@ async function fetchApps(): Promise<AppRow[]> {
     },
   })
   if (!resp.ok) throw new Error(`status ${resp.status}`)
-  return resp.json() as Promise<AppRow[]>
+  return (await resp.json()) as ApiResponse
 }
 
-const STATUS_COLORS: Record<AppRow['status'], string> = {
-  ready: 'text-green-400',
-  degraded: 'text-amber-400',
-  pending: 'text-blue-400',
-  failed: 'text-red-400',
+const STATUS_LABEL: Record<AppRow['status'], { color: string; text: string }> = {
+  installed: { color: 'text-green-400', text: 'Installed' },
+  installing: { color: 'text-blue-400', text: 'Installing' },
+  available: { color: 'text-[var(--color-text-dim)]', text: 'Available' },
+  bootstrap: { color: 'text-cyan-400', text: 'Bootstrap' },
 }
 
 export function ConsoleAppsPage() {
   const [state, setState] = useState<PageState>({ status: 'loading' })
+  const [search, setSearch] = useState('')
+  const [filter, setFilter] = useState<'all' | AppRow['status']>('all')
 
-  useEffect(() => {
+  const reload = () => {
+    setState({ status: 'loading' })
     fetchApps()
-      .then((apps) => setState({ status: 'loaded', apps }))
+      .then((body) => setState({ status: 'loaded', apps: body.apps ?? [], generatedAt: body.generatedAt }))
       .catch((err: unknown) => {
         const msg = err instanceof Error ? err.message : 'Unknown error'
         setState({ status: 'error', message: msg })
       })
+  }
+
+  useEffect(() => {
+    reload()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
+
+  const filteredApps = useMemo(() => {
+    if (state.status !== 'loaded') return []
+    const q = search.trim().toLowerCase()
+    return state.apps.filter((a) => {
+      if (filter !== 'all' && a.status !== filter) return false
+      if (!q) return true
+      return (
+        a.title.toLowerCase().includes(q) ||
+        a.id.toLowerCase().includes(q) ||
+        (a.category ?? '').toLowerCase().includes(q) ||
+        (a.tags ?? []).some((t) => t.toLowerCase().includes(q))
+      )
+    })
+  }, [state, search, filter])
 
   return (
     <div data-testid="console-apps-page">
-      <div className="mb-6">
-        <h1 className="text-2xl font-semibold text-[var(--color-text-strong)]">Applications</h1>
-        <p className="mt-1 text-sm text-[var(--color-text-dim)]">
-          Installed apps on this Sovereign cluster.
-        </p>
+      <div className="mb-6 flex items-start justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-semibold text-[var(--color-text-strong)]">Applications</h1>
+          <p className="mt-1 text-sm text-[var(--color-text-dim)]">
+            Installable Blueprints + currently-installed apps on this Sovereign cluster.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={reload}
+          className="flex h-9 items-center gap-2 rounded-lg border border-[var(--color-border)] bg-[var(--color-bg-2)] px-3 text-sm text-[var(--color-text)] hover:bg-[var(--color-bg-3)]"
+          data-testid="apps-refresh"
+        >
+          <RefreshCw className="h-4 w-4" />
+          Refresh
+        </button>
+      </div>
+
+      {/* toolbar */}
+      <div className="mb-4 flex flex-wrap items-center gap-3">
+        <div className="relative flex-1 min-w-[200px]">
+          <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-[var(--color-text-dim)]" />
+          <input
+            type="search"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Search apps…"
+            className="h-9 w-full rounded-lg border border-[var(--color-border)] bg-[var(--color-bg-2)] pl-9 pr-3 text-sm text-[var(--color-text)] placeholder-[var(--color-text-dim)]"
+            data-testid="apps-search"
+          />
+        </div>
+        <div className="flex items-center gap-2">
+          <Filter className="h-4 w-4 text-[var(--color-text-dim)]" />
+          {(['all', 'installed', 'installing', 'available', 'bootstrap'] as const).map((k) => (
+            <button
+              key={k}
+              type="button"
+              onClick={() => setFilter(k)}
+              className={`h-9 rounded-lg border px-3 text-xs uppercase transition-colors ${
+                filter === k
+                  ? 'border-[var(--color-accent)] bg-[var(--color-accent)]/10 text-[var(--color-accent)]'
+                  : 'border-[var(--color-border)] bg-[var(--color-bg-2)] text-[var(--color-text-dim)] hover:bg-[var(--color-bg-3)]'
+              }`}
+              data-testid={`apps-filter-${k}`}
+            >
+              {k}
+            </button>
+          ))}
+        </div>
       </div>
 
       {state.status === 'loading' ? (
         <div className="flex items-center gap-2 text-sm text-[var(--color-text-dim)]" data-testid="apps-loading">
-          <svg className="h-4 w-4 animate-spin" viewBox="0 0 24 24" fill="none" aria-hidden>
-            <circle cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="3" opacity="0.25" />
-            <path fill="currentColor" opacity="0.8" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
-          </svg>
+          <RefreshCw className="h-4 w-4 animate-spin" />
           Loading apps…
         </div>
       ) : state.status === 'error' ? (
         <div
           className="rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-2)] p-8 text-center"
-          data-testid="apps-api-placeholder"
+          data-testid="apps-error"
         >
-          <Package className="mx-auto mb-3 h-10 w-10 text-[var(--color-text-dim)]" />
-          <p className="text-sm font-medium text-[var(--color-text)]">Apps API not yet available</p>
-          <p className="mt-1 text-xs text-[var(--color-text-dim)]">
-            {state.message} — /api/v1/sovereign/apps integration pending.
-          </p>
+          <AlertCircle className="mx-auto mb-3 h-10 w-10 text-red-400" />
+          <p className="text-sm font-medium text-[var(--color-text)]">Couldn’t load apps</p>
+          <p className="mt-1 text-xs text-[var(--color-text-dim)]">{state.message}</p>
         </div>
-      ) : state.apps.length === 0 ? (
+      ) : filteredApps.length === 0 ? (
         <div
           className="rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-2)] p-8 text-center"
           data-testid="apps-empty"
         >
           <Package className="mx-auto mb-3 h-10 w-10 text-[var(--color-text-dim)]" />
-          <p className="text-sm font-medium text-[var(--color-text)]">No apps installed</p>
+          <p className="text-sm font-medium text-[var(--color-text)]">No matching apps</p>
           <p className="mt-1 text-xs text-[var(--color-text-dim)]">
-            Apps installed via the Wizard will appear here.
+            {search ? 'Try a different search term.' : 'No apps in this filter.'}
           </p>
         </div>
       ) : (
@@ -104,40 +185,66 @@ export function ConsoleAppsPage() {
           className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3"
           data-testid="apps-grid"
         >
-          {state.apps.map((app) => (
-            <div
-              key={app.id}
-              className="rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-2)] p-5"
-              data-testid={`app-card-${app.id}`}
-            >
-              <div className="flex items-start justify-between gap-3">
-                <div className="min-w-0">
-                  <p className="truncate text-sm font-semibold text-[var(--color-text-strong)]">
-                    {app.name}
-                  </p>
-                  <p className="mt-0.5 text-xs text-[var(--color-text-dim)]">{app.version}</p>
+          {filteredApps.map((app) => {
+            const badge = STATUS_LABEL[app.status]
+            return (
+              <div
+                key={app.id}
+                className="flex h-full flex-col rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-2)] p-5"
+                data-testid={`app-card-${app.id}`}
+              >
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0">
+                    <p className="truncate text-sm font-semibold text-[var(--color-text-strong)]">
+                      {app.title}
+                    </p>
+                    <p className="mt-0.5 text-xs text-[var(--color-text-dim)]">
+                      {app.id}
+                      {app.version ? ` · v${app.version}` : ''}
+                    </p>
+                  </div>
+                  <span
+                    className={`shrink-0 text-xs font-semibold uppercase ${badge.color}`}
+                    data-testid={`app-status-${app.id}`}
+                  >
+                    <span className="inline-flex items-center gap-1">
+                      {(app.status === 'installed' || app.status === 'bootstrap') && (
+                        <CheckCircle2 className="h-3.5 w-3.5" />
+                      )}
+                      {badge.text}
+                    </span>
+                  </span>
                 </div>
-                <span
-                  className={`shrink-0 text-xs font-semibold uppercase ${STATUS_COLORS[app.status]}`}
-                  data-testid={`app-status-${app.id}`}
-                >
-                  {app.status}
-                </span>
+                {app.summary ? (
+                  <p className="mt-2 line-clamp-3 text-xs text-[var(--color-text-dim)]">{app.summary}</p>
+                ) : null}
+                <div className="mt-auto pt-3 flex flex-wrap items-center gap-2">
+                  {app.category ? (
+                    <span className="rounded-full border border-[var(--color-border)] px-2 py-0.5 text-[10px] uppercase tracking-wide text-[var(--color-text-dim)]">
+                      {app.category}
+                    </span>
+                  ) : null}
+                  {app.status === 'available' ? (
+                    <button
+                      type="button"
+                      className="ml-auto h-7 rounded-md border border-[var(--color-accent)] bg-[var(--color-accent)]/10 px-3 text-xs font-medium text-[var(--color-accent)] hover:bg-[var(--color-accent)]/20"
+                      data-testid={`app-install-${app.id}`}
+                    >
+                      Install
+                    </button>
+                  ) : null}
+                </div>
               </div>
-              {app.url ? (
-                <a
-                  href={app.url}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="mt-3 block truncate text-xs text-[var(--color-accent)] hover:underline"
-                >
-                  {app.url}
-                </a>
-              ) : null}
-            </div>
-          ))}
+            )
+          })}
         </div>
       )}
+
+      {state.status === 'loaded' && state.generatedAt ? (
+        <p className="mt-6 text-xs text-[var(--color-text-dim)]" data-testid="apps-catalog-meta">
+          Catalog snapshot generated {new Date(state.generatedAt).toLocaleString()}.
+        </p>
+      ) : null}
     </div>
   )
 }

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/console/ConsoleCloudPage.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/console/ConsoleCloudPage.test.tsx
@@ -1,0 +1,150 @@
+/**
+ * ConsoleCloudPage.test.tsx — issue #933.
+ *
+ * Locks in the Sovereign Console Cloud surface against
+ * /api/v1/sovereign/cloud:
+ *
+ *   • Loaded state renders all 7 sections (Nodes, Namespaces,
+ *     Ingresses, HTTPRoutes, LBs, Storage Classes, PVCs)
+ *   • Each list item renders with name + namespace + URL when
+ *     applicable
+ *   • Empty cluster surface still renders all 7 sections (zero rows)
+ *     plus a "cluster appears empty" hint
+ *   • Error state surfaces the API error
+ */
+
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { render, screen, cleanup, waitFor } from '@testing-library/react'
+import { ConsoleCloudPage } from './ConsoleCloudPage'
+
+const ORIGINAL_FETCH = globalThis.fetch
+
+afterEach(() => {
+  cleanup()
+  globalThis.fetch = ORIGINAL_FETCH
+})
+
+function mockFetchOnce(body: unknown, ok = true) {
+  globalThis.fetch = vi.fn().mockResolvedValue({
+    ok,
+    status: ok ? 200 : 500,
+    json: async () => body,
+  }) as unknown as typeof fetch
+}
+
+const POPULATED = {
+  nodes: [
+    {
+      name: 'cp-1',
+      status: 'Ready',
+      roles: ['control-plane'],
+      kubeletVersion: 'v1.31.4',
+      os: 'linux',
+      arch: 'amd64',
+      internalIP: '10.0.0.1',
+      capacityCPU: '4',
+      capacityMemory: '8Gi',
+    },
+  ],
+  namespaces: [{ name: 'auth', status: 'Active', createdAt: '2026-04-30T10:00:00Z' }],
+  ingresses: [
+    {
+      name: 'console',
+      namespace: 'catalyst',
+      hosts: ['console.example.com'],
+      url: 'https://console.example.com',
+    },
+  ],
+  httpRoutes: [
+    {
+      name: 'console',
+      namespace: 'catalyst',
+      hosts: ['console.sov.example.com'],
+      url: 'https://console.sov.example.com',
+    },
+  ],
+  loadBalancers: [
+    {
+      name: 'cilium-gateway',
+      namespace: 'kube-system',
+      type: 'LoadBalancer',
+      clusterIP: '10.43.0.1',
+      externalIP: '1.2.3.4',
+      ports: ['443/TCP'],
+    },
+  ],
+  storageClasses: [
+    {
+      name: 'local-path',
+      provisioner: 'rancher.io/local-path',
+      isDefault: true,
+      reclaimPolicy: 'Delete',
+    },
+  ],
+  pvcs: [
+    {
+      name: 'data-keycloak',
+      namespace: 'auth',
+      storageClass: 'local-path',
+      capacity: '5Gi',
+      status: 'Bound',
+    },
+  ],
+}
+
+describe('ConsoleCloudPage', () => {
+  it('renders all 7 sections when populated', async () => {
+    mockFetchOnce(POPULATED)
+    render(<ConsoleCloudPage />)
+
+    await waitFor(() => screen.getByTestId('cloud-nodes'))
+
+    expect(screen.getByTestId('cloud-nodes')).toBeTruthy()
+    expect(screen.getByTestId('cloud-namespaces')).toBeTruthy()
+    expect(screen.getByTestId('cloud-ingresses')).toBeTruthy()
+    expect(screen.getByTestId('cloud-httproutes')).toBeTruthy()
+    expect(screen.getByTestId('cloud-loadbalancers')).toBeTruthy()
+    expect(screen.getByTestId('cloud-storage-classes')).toBeTruthy()
+    expect(screen.getByTestId('cloud-pvcs')).toBeTruthy()
+
+    expect(screen.getByTestId('cloud-node-cp-1')).toBeTruthy()
+    expect(screen.getByTestId('cloud-ns-auth')).toBeTruthy()
+  })
+
+  it('surfaces ingress URL with external link', async () => {
+    mockFetchOnce(POPULATED)
+    render(<ConsoleCloudPage />)
+    await waitFor(() => screen.getByTestId('cloud-ingresses'))
+    expect(screen.getByText('console.example.com')).toBeTruthy()
+  })
+
+  it('renders the error state when the API fails', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 503,
+      json: async () => ({}),
+    }) as unknown as typeof fetch
+
+    render(<ConsoleCloudPage />)
+    await waitFor(() => {
+      expect(screen.getByTestId('cloud-error')).toBeTruthy()
+    })
+  })
+
+  it('still renders all sections on an empty cluster', async () => {
+    mockFetchOnce({
+      nodes: [],
+      namespaces: [],
+      ingresses: [],
+      httpRoutes: [],
+      loadBalancers: [],
+      storageClasses: [],
+      pvcs: [],
+    })
+    render(<ConsoleCloudPage />)
+    await waitFor(() => screen.getByTestId('cloud-nodes'))
+    // 7 sections present even when empty.
+    expect(screen.getByTestId('cloud-nodes')).toBeTruthy()
+    expect(screen.getByTestId('cloud-pvcs')).toBeTruthy()
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/console/ConsoleCloudPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/console/ConsoleCloudPage.tsx
@@ -1,37 +1,408 @@
 /**
- * ConsoleCloudPage — Sovereign Console /console/cloud
+ * ConsoleCloudPage — Sovereign Console /console/cloud.
  *
- * Topology / architecture / infrastructure view for this Sovereign.
- * Reuses the CloudPage visual concept without the deploymentId param.
+ * Reads /api/v1/sovereign/cloud (issue #933). Six lists in one response:
  *
- * Phase 8b placeholder — full graph wiring is Phase 4 work.
+ *   - Nodes (kubectl get nodes)
+ *   - Namespaces
+ *   - Ingresses (networking.k8s.io/v1)
+ *   - HTTPRoutes (gateway.networking.k8s.io/v1)
+ *   - LoadBalancer-typed Services
+ *   - StorageClasses + PVCs
  *
- * Related: GitHub issue #607
+ * Renders each list as its own collapsible section so an operator's
+ * mental model maps 1:1 to the cluster's actual surface area. The
+ * Console Cloud page is the operator's "where do I click to reach X"
+ * surface — Ingresses + HTTPRoutes carry an https://hostname URL
+ * affordance that opens the in-cluster service in a new tab.
  */
 
-import { Cloud } from 'lucide-react'
+import { useEffect, useState } from 'react'
+import {
+  Cloud,
+  Server,
+  Box,
+  Globe,
+  Network,
+  HardDrive,
+  Database,
+  RefreshCw,
+  AlertCircle,
+  ExternalLink,
+} from 'lucide-react'
+import { API_BASE } from '@/shared/config/urls'
+import { loadTokens } from '@/shared/lib/oidc'
+
+interface NodeRow {
+  name: string
+  status: string
+  roles: string[]
+  kubeletVersion: string
+  os: string
+  arch: string
+  internalIP: string
+  externalIP?: string
+  capacityCPU: string
+  capacityMemory: string
+}
+interface NamespaceRow {
+  name: string
+  status: string
+  createdAt: string
+}
+interface IngressRow {
+  name: string
+  namespace: string
+  hosts: string[]
+  url?: string
+}
+interface LBRow {
+  name: string
+  namespace: string
+  type: string
+  clusterIP?: string
+  externalIP?: string
+  ports: string[]
+}
+interface SCRow {
+  name: string
+  provisioner: string
+  isDefault: boolean
+  reclaimPolicy: string
+}
+interface PVCRow {
+  name: string
+  namespace: string
+  storageClass: string
+  capacity: string
+  status: string
+}
+
+interface CloudResponse {
+  nodes: NodeRow[]
+  namespaces: NamespaceRow[]
+  ingresses: IngressRow[]
+  httpRoutes: IngressRow[]
+  loadBalancers: LBRow[]
+  storageClasses: SCRow[]
+  pvcs: PVCRow[]
+}
+
+type PageState =
+  | { status: 'loading' }
+  | { status: 'loaded'; data: CloudResponse }
+  | { status: 'error'; message: string }
+
+async function fetchCloud(): Promise<CloudResponse> {
+  const tokens = loadTokens()
+  const resp = await fetch(`${API_BASE}/v1/sovereign/cloud`, {
+    headers: {
+      Accept: 'application/json',
+      ...(tokens ? { Authorization: `Bearer ${tokens.accessToken}` } : {}),
+    },
+  })
+  if (!resp.ok) throw new Error(`status ${resp.status}`)
+  return (await resp.json()) as CloudResponse
+}
+
+function Section({
+  title,
+  icon,
+  count,
+  children,
+  testId,
+}: {
+  title: string
+  icon: React.ReactNode
+  count: number
+  children: React.ReactNode
+  testId: string
+}) {
+  return (
+    <section
+      className="rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-2)] p-5"
+      data-testid={testId}
+    >
+      <div className="mb-3 flex items-center gap-2">
+        <div className="flex h-7 w-7 items-center justify-center rounded-lg bg-[var(--color-bg)]">
+          {icon}
+        </div>
+        <h2 className="text-sm font-semibold text-[var(--color-text-strong)]">{title}</h2>
+        <span className="text-xs text-[var(--color-text-dim)]">({count})</span>
+      </div>
+      {children}
+    </section>
+  )
+}
+
+function EmptyRow({ label }: { label: string }) {
+  return <p className="text-xs text-[var(--color-text-dim)]">{label}</p>
+}
 
 export function ConsoleCloudPage() {
+  const [state, setState] = useState<PageState>({ status: 'loading' })
+
+  const reload = () => {
+    setState({ status: 'loading' })
+    fetchCloud()
+      .then((data) => setState({ status: 'loaded', data }))
+      .catch((err: unknown) => {
+        const msg = err instanceof Error ? err.message : 'Unknown error'
+        setState({ status: 'error', message: msg })
+      })
+  }
+
+  useEffect(() => {
+    reload()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
   return (
     <div data-testid="console-cloud-page">
-      <div className="mb-6">
-        <h1 className="text-2xl font-semibold text-[var(--color-text-strong)]">Cloud</h1>
-        <p className="mt-1 text-sm text-[var(--color-text-dim)]">
-          Infrastructure topology and resource explorer for this Sovereign.
-        </p>
+      <div className="mb-6 flex items-start justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-semibold text-[var(--color-text-strong)]">Cloud</h1>
+          <p className="mt-1 text-sm text-[var(--color-text-dim)]">
+            Live topology of this Sovereign cluster — nodes, namespaces, ingress, storage.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={reload}
+          className="flex h-9 items-center gap-2 rounded-lg border border-[var(--color-border)] bg-[var(--color-bg-2)] px-3 text-sm text-[var(--color-text)] hover:bg-[var(--color-bg-3)]"
+          data-testid="cloud-refresh"
+        >
+          <RefreshCw className="h-4 w-4" />
+          Refresh
+        </button>
       </div>
 
-      {/* Placeholder — Phase 4 wires the topology graph */}
-      <div
-        className="rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-2)] p-10 text-center"
-        data-testid="cloud-placeholder"
-      >
-        <Cloud className="mx-auto mb-3 h-10 w-10 text-[var(--color-text-dim)]" />
-        <p className="text-sm font-medium text-[var(--color-text)]">Cloud topology</p>
-        <p className="mt-1 text-xs text-[var(--color-text-dim)]">
-          Topology graph integration pending (Phase 4).
-        </p>
-      </div>
+      {state.status === 'loading' ? (
+        <div className="flex items-center gap-2 text-sm text-[var(--color-text-dim)]" data-testid="cloud-loading">
+          <RefreshCw className="h-4 w-4 animate-spin" />
+          Loading cluster topology…
+        </div>
+      ) : state.status === 'error' ? (
+        <div
+          className="rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-2)] p-8 text-center"
+          data-testid="cloud-error"
+        >
+          <AlertCircle className="mx-auto mb-3 h-10 w-10 text-red-400" />
+          <p className="text-sm font-medium text-[var(--color-text)]">Couldn’t load cluster topology</p>
+          <p className="mt-1 text-xs text-[var(--color-text-dim)]">{state.message}</p>
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+          {/* Nodes */}
+          <Section
+            title="Nodes"
+            icon={<Server className="h-4 w-4 text-blue-400" />}
+            count={state.data.nodes.length}
+            testId="cloud-nodes"
+          >
+            {state.data.nodes.length === 0 ? (
+              <EmptyRow label="No nodes visible." />
+            ) : (
+              <div className="space-y-2">
+                {state.data.nodes.map((n) => (
+                  <div
+                    key={n.name}
+                    className="rounded-lg border border-[var(--color-border)] bg-[var(--color-bg)] p-3 text-xs"
+                    data-testid={`cloud-node-${n.name}`}
+                  >
+                    <div className="flex items-center justify-between">
+                      <span className="font-semibold text-[var(--color-text-strong)]">{n.name}</span>
+                      <span
+                        className={`text-[10px] uppercase ${n.status === 'Ready' ? 'text-green-400' : 'text-red-400'}`}
+                      >
+                        {n.status}
+                      </span>
+                    </div>
+                    <div className="mt-1 grid grid-cols-2 gap-x-3 text-[var(--color-text-dim)]">
+                      <span>{n.roles.join(', ') || 'worker'}</span>
+                      <span>{n.kubeletVersion}</span>
+                      <span>{n.internalIP}</span>
+                      <span>
+                        {n.capacityCPU} cores · {n.capacityMemory}
+                      </span>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+          </Section>
+
+          {/* Namespaces */}
+          <Section
+            title="Namespaces"
+            icon={<Box className="h-4 w-4 text-purple-400" />}
+            count={state.data.namespaces.length}
+            testId="cloud-namespaces"
+          >
+            {state.data.namespaces.length === 0 ? (
+              <EmptyRow label="No namespaces visible." />
+            ) : (
+              <ul className="grid grid-cols-2 gap-1 text-xs">
+                {state.data.namespaces.map((n) => (
+                  <li
+                    key={n.name}
+                    className="truncate text-[var(--color-text)]"
+                    data-testid={`cloud-ns-${n.name}`}
+                  >
+                    {n.name}{' '}
+                    <span className="text-[10px] text-[var(--color-text-dim)]">{n.status}</span>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </Section>
+
+          {/* Ingresses */}
+          <Section
+            title="Ingresses"
+            icon={<Globe className="h-4 w-4 text-amber-400" />}
+            count={state.data.ingresses.length}
+            testId="cloud-ingresses"
+          >
+            {state.data.ingresses.length === 0 ? (
+              <EmptyRow label="No ingresses." />
+            ) : (
+              <ul className="space-y-1 text-xs">
+                {state.data.ingresses.map((i) => (
+                  <li key={`${i.namespace}/${i.name}`} className="flex items-center gap-2">
+                    <span className="font-medium text-[var(--color-text-strong)]">{i.name}</span>
+                    <span className="text-[var(--color-text-dim)]">{i.namespace}</span>
+                    {i.url ? (
+                      <a
+                        href={i.url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="ml-auto inline-flex items-center gap-1 text-[var(--color-accent)] hover:underline"
+                      >
+                        {i.hosts[0]}
+                        <ExternalLink className="h-3 w-3" />
+                      </a>
+                    ) : null}
+                  </li>
+                ))}
+              </ul>
+            )}
+          </Section>
+
+          {/* HTTPRoutes */}
+          <Section
+            title="HTTPRoutes"
+            icon={<Globe className="h-4 w-4 text-green-400" />}
+            count={state.data.httpRoutes.length}
+            testId="cloud-httproutes"
+          >
+            {state.data.httpRoutes.length === 0 ? (
+              <EmptyRow label="No HTTPRoutes (Gateway API not in use)." />
+            ) : (
+              <ul className="space-y-1 text-xs">
+                {state.data.httpRoutes.map((i) => (
+                  <li key={`${i.namespace}/${i.name}`} className="flex items-center gap-2">
+                    <span className="font-medium text-[var(--color-text-strong)]">{i.name}</span>
+                    <span className="text-[var(--color-text-dim)]">{i.namespace}</span>
+                    {i.url ? (
+                      <a
+                        href={i.url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="ml-auto inline-flex items-center gap-1 text-[var(--color-accent)] hover:underline"
+                      >
+                        {i.hosts[0]}
+                        <ExternalLink className="h-3 w-3" />
+                      </a>
+                    ) : null}
+                  </li>
+                ))}
+              </ul>
+            )}
+          </Section>
+
+          {/* Load balancers */}
+          <Section
+            title="Load Balancers"
+            icon={<Network className="h-4 w-4 text-sky-400" />}
+            count={state.data.loadBalancers.length}
+            testId="cloud-loadbalancers"
+          >
+            {state.data.loadBalancers.length === 0 ? (
+              <EmptyRow label="No LoadBalancer services." />
+            ) : (
+              <ul className="space-y-1 text-xs">
+                {state.data.loadBalancers.map((lb) => (
+                  <li key={`${lb.namespace}/${lb.name}`} className="text-[var(--color-text)]">
+                    <span className="font-medium text-[var(--color-text-strong)]">{lb.name}</span>{' '}
+                    <span className="text-[var(--color-text-dim)]">
+                      {lb.namespace} · {lb.externalIP || 'pending'} · {lb.ports.join(', ')}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </Section>
+
+          {/* Storage classes */}
+          <Section
+            title="Storage Classes"
+            icon={<HardDrive className="h-4 w-4 text-orange-400" />}
+            count={state.data.storageClasses.length}
+            testId="cloud-storage-classes"
+          >
+            {state.data.storageClasses.length === 0 ? (
+              <EmptyRow label="No storage classes." />
+            ) : (
+              <ul className="space-y-1 text-xs">
+                {state.data.storageClasses.map((sc) => (
+                  <li key={sc.name} className="text-[var(--color-text)]">
+                    <span className="font-medium text-[var(--color-text-strong)]">{sc.name}</span>{' '}
+                    <span className="text-[var(--color-text-dim)]">
+                      {sc.provisioner}
+                      {sc.isDefault ? ' · default' : ''}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </Section>
+
+          {/* PVCs */}
+          <Section
+            title="Persistent Volume Claims"
+            icon={<Database className="h-4 w-4 text-rose-400" />}
+            count={state.data.pvcs.length}
+            testId="cloud-pvcs"
+          >
+            {state.data.pvcs.length === 0 ? (
+              <EmptyRow label="No PVCs." />
+            ) : (
+              <ul className="space-y-1 text-xs">
+                {state.data.pvcs.map((p) => (
+                  <li key={`${p.namespace}/${p.name}`} className="text-[var(--color-text)]">
+                    <span className="font-medium text-[var(--color-text-strong)]">{p.name}</span>{' '}
+                    <span className="text-[var(--color-text-dim)]">
+                      {p.namespace} · {p.capacity} · {p.storageClass} · {p.status}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </Section>
+        </div>
+      )}
+
+      {state.status === 'loaded' &&
+      state.data.nodes.length === 0 &&
+      state.data.namespaces.length === 0 ? (
+        <div className="mt-4 rounded-lg border border-[var(--color-border)] bg-[var(--color-bg-2)] p-4 text-center">
+          <Cloud className="mx-auto mb-2 h-8 w-8 text-[var(--color-text-dim)]" />
+          <p className="text-xs text-[var(--color-text-dim)]">
+            The cluster appears empty. If you just provisioned, give Flux a minute to reconcile.
+          </p>
+        </div>
+      ) : null}
     </div>
   )
 }

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/console/ConsoleJobsPage.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/console/ConsoleJobsPage.test.tsx
@@ -1,0 +1,93 @@
+/**
+ * ConsoleJobsPage.test.tsx — issue #933.
+ *
+ * Locks in the Sovereign Console Jobs surface against
+ * /api/v1/sovereign/jobs:
+ *
+ *   • Loading state renders a spinner
+ *   • Loaded state renders one row per job, sorted started-DESC
+ *   • Error state surfaces the API error message
+ *   • Empty state surfaces a "no jobs" empty card
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, screen, cleanup, waitFor } from '@testing-library/react'
+import { ConsoleJobsPage } from './ConsoleJobsPage'
+
+const ORIGINAL_FETCH = globalThis.fetch
+
+afterEach(() => {
+  cleanup()
+  globalThis.fetch = ORIGINAL_FETCH
+})
+
+function mockFetchOnce(body: unknown, ok = true) {
+  globalThis.fetch = vi.fn().mockResolvedValue({
+    ok,
+    status: ok ? 200 : 500,
+    json: async () => body,
+  }) as unknown as typeof fetch
+}
+
+describe('ConsoleJobsPage', () => {
+  beforeEach(() => {
+    // jsdom's fetch is unset by default
+  })
+
+  it('renders rows for each returned job', async () => {
+    mockFetchOnce({
+      jobs: [
+        {
+          id: 'hr/flux-system/bp-cilium',
+          name: 'bp-cilium',
+          namespace: 'flux-system',
+          kind: 'HelmRelease',
+          status: 'succeeded',
+          startedAt: '2026-04-30T10:00:00Z',
+          finishedAt: '2026-04-30T10:05:00Z',
+        },
+        {
+          id: 'job/auth/keycloak-bootstrap',
+          name: 'keycloak-bootstrap',
+          namespace: 'auth',
+          kind: 'Job',
+          status: 'failed',
+          startedAt: '2026-04-30T09:00:00Z',
+        },
+      ],
+    })
+
+    render(<ConsoleJobsPage />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('jobs-table')).toBeTruthy()
+    })
+
+    expect(screen.getByTestId('job-row-hr/flux-system/bp-cilium')).toBeTruthy()
+    expect(screen.getByTestId('job-row-job/auth/keycloak-bootstrap')).toBeTruthy()
+  })
+
+  it('renders the empty state when no jobs', async () => {
+    mockFetchOnce({ jobs: [] })
+
+    render(<ConsoleJobsPage />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('jobs-empty')).toBeTruthy()
+    })
+  })
+
+  it('renders the error state when the API fails', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 503,
+      json: async () => ({ error: 'in-cluster-client-unavailable' }),
+    }) as unknown as typeof fetch
+
+    render(<ConsoleJobsPage />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('jobs-error')).toBeTruthy()
+    })
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/console/ConsoleJobsPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/console/ConsoleJobsPage.tsx
@@ -1,39 +1,190 @@
 /**
- * ConsoleJobsPage — Sovereign Console /console/jobs
+ * ConsoleJobsPage — Sovereign Console /console/jobs.
  *
- * Shows the history of provisioning jobs (HelmRelease install runs) on
- * this Sovereign cluster. Reuses the same table shape as JobsPage.tsx
- * but targets /api/v1/sovereign/jobs (no deploymentId param).
+ * Reads /api/v1/sovereign/jobs (issue #933) which surfaces THREE
+ * signal sources from the local cluster:
  *
- * Phase 8b: renders a placeholder table until the sovereign jobs endpoint
- * is wired by Agent C.
+ *   1. Flux HelmRelease Ready/NotReady transitions (the bootstrap-kit
+ *      install path the operator just lived through)
+ *   2. K8s Jobs across all namespaces (Helm post-install hooks, any
+ *      operator-authored Job/CronJob runs)
+ *   3. K8s Warning Events (operator-visible cluster anomalies)
  *
- * Related: GitHub issue #607
+ * Sorted started-DESC. Each row carries kind / status / message so the
+ * operator sees their cluster's full activity feed without round-tripping
+ * to the mothership.
+ *
+ * Phase 8b shipped this page as a placeholder; #933 wires the actual
+ * data source. The PortalShell + sidebar surrounding this view stays
+ * unchanged.
  */
 
-import { Clipboard } from 'lucide-react'
+import { useEffect, useState } from 'react'
+import { Clipboard, AlertCircle, CheckCircle2, RefreshCw } from 'lucide-react'
+import { API_BASE } from '@/shared/config/urls'
+import { loadTokens } from '@/shared/lib/oidc'
+
+interface SovereignJob {
+  id: string
+  name: string
+  namespace: string
+  kind: string
+  status: string
+  message?: string
+  startedAt: string
+  finishedAt?: string
+}
+
+type PageState =
+  | { status: 'loading' }
+  | { status: 'loaded'; jobs: SovereignJob[] }
+  | { status: 'error'; message: string }
+
+async function fetchJobs(): Promise<SovereignJob[]> {
+  const tokens = loadTokens()
+  const resp = await fetch(`${API_BASE}/v1/sovereign/jobs`, {
+    headers: {
+      Accept: 'application/json',
+      ...(tokens ? { Authorization: `Bearer ${tokens.accessToken}` } : {}),
+    },
+  })
+  if (!resp.ok) throw new Error(`status ${resp.status}`)
+  const body = (await resp.json()) as { jobs?: SovereignJob[] }
+  return body.jobs ?? []
+}
+
+const STATUS_BADGE: Record<string, { color: string; label: string }> = {
+  succeeded: { color: 'text-green-400', label: 'Succeeded' },
+  installed: { color: 'text-green-400', label: 'Installed' },
+  failed: { color: 'text-red-400', label: 'Failed' },
+  running: { color: 'text-blue-400', label: 'Running' },
+  pending: { color: 'text-amber-400', label: 'Pending' },
+  warning: { color: 'text-amber-400', label: 'Warning' },
+}
+
+function formatTimestamp(iso?: string): string {
+  if (!iso) return '—'
+  try {
+    const t = new Date(iso)
+    if (Number.isNaN(t.getTime())) return '—'
+    return t.toLocaleString()
+  } catch {
+    return iso
+  }
+}
 
 export function ConsoleJobsPage() {
+  const [state, setState] = useState<PageState>({ status: 'loading' })
+
+  const reload = () => {
+    setState({ status: 'loading' })
+    fetchJobs()
+      .then((jobs) => setState({ status: 'loaded', jobs }))
+      .catch((err: unknown) => {
+        const msg = err instanceof Error ? err.message : 'Unknown error'
+        setState({ status: 'error', message: msg })
+      })
+  }
+
+  useEffect(() => {
+    reload()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
   return (
     <div data-testid="console-jobs-page">
-      <div className="mb-6">
-        <h1 className="text-2xl font-semibold text-[var(--color-text-strong)]">Jobs</h1>
-        <p className="mt-1 text-sm text-[var(--color-text-dim)]">
-          Provisioning and maintenance job history for this Sovereign.
-        </p>
+      <div className="mb-6 flex items-start justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-semibold text-[var(--color-text-strong)]">Jobs</h1>
+          <p className="mt-1 text-sm text-[var(--color-text-dim)]">
+            Provisioning + maintenance + warning events from the local cluster.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={reload}
+          className="flex h-9 items-center gap-2 rounded-lg border border-[var(--color-border)] bg-[var(--color-bg-2)] px-3 text-sm text-[var(--color-text)] hover:bg-[var(--color-bg-3)]"
+          data-testid="jobs-refresh"
+        >
+          <RefreshCw className="h-4 w-4" />
+          Refresh
+        </button>
       </div>
 
-      {/* Placeholder — Phase 4 ticket wires the API */}
-      <div
-        className="rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-2)] p-10 text-center"
-        data-testid="jobs-placeholder"
-      >
-        <Clipboard className="mx-auto mb-3 h-10 w-10 text-[var(--color-text-dim)]" />
-        <p className="text-sm font-medium text-[var(--color-text)]">Jobs history</p>
-        <p className="mt-1 text-xs text-[var(--color-text-dim)]">
-          /api/v1/sovereign/jobs integration pending (Phase 4).
-        </p>
-      </div>
+      {state.status === 'loading' ? (
+        <div className="flex items-center gap-2 text-sm text-[var(--color-text-dim)]" data-testid="jobs-loading">
+          <RefreshCw className="h-4 w-4 animate-spin" />
+          Loading jobs…
+        </div>
+      ) : state.status === 'error' ? (
+        <div
+          className="rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-2)] p-8 text-center"
+          data-testid="jobs-error"
+        >
+          <AlertCircle className="mx-auto mb-3 h-10 w-10 text-red-400" />
+          <p className="text-sm font-medium text-[var(--color-text)]">Couldn’t load jobs</p>
+          <p className="mt-1 text-xs text-[var(--color-text-dim)]">{state.message}</p>
+        </div>
+      ) : state.jobs.length === 0 ? (
+        <div
+          className="rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-2)] p-8 text-center"
+          data-testid="jobs-empty"
+        >
+          <Clipboard className="mx-auto mb-3 h-10 w-10 text-[var(--color-text-dim)]" />
+          <p className="text-sm font-medium text-[var(--color-text)]">No jobs to display</p>
+          <p className="mt-1 text-xs text-[var(--color-text-dim)]">
+            Provisioning + maintenance activity from the local cluster will appear here.
+          </p>
+        </div>
+      ) : (
+        <div
+          className="overflow-hidden rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-2)]"
+          data-testid="jobs-table"
+        >
+          <table className="w-full text-sm">
+            <thead className="bg-[var(--color-bg)] text-left text-xs uppercase text-[var(--color-text-dim)]">
+              <tr>
+                <th className="px-4 py-2">Name</th>
+                <th className="px-4 py-2">Kind</th>
+                <th className="px-4 py-2">Namespace</th>
+                <th className="px-4 py-2">Status</th>
+                <th className="px-4 py-2">Started</th>
+                <th className="px-4 py-2">Message</th>
+              </tr>
+            </thead>
+            <tbody>
+              {state.jobs.map((j) => {
+                const badge = STATUS_BADGE[j.status] ?? { color: 'text-[var(--color-text)]', label: j.status }
+                return (
+                  <tr
+                    key={j.id}
+                    className="border-t border-[var(--color-border)]"
+                    data-testid={`job-row-${j.id}`}
+                  >
+                    <td className="px-4 py-2 font-medium text-[var(--color-text-strong)]">{j.name}</td>
+                    <td className="px-4 py-2 text-[var(--color-text-dim)]">{j.kind}</td>
+                    <td className="px-4 py-2 text-[var(--color-text-dim)]">{j.namespace || '—'}</td>
+                    <td className={`px-4 py-2 font-semibold uppercase ${badge.color}`}>
+                      <span className="inline-flex items-center gap-1">
+                        {j.status === 'succeeded' || j.status === 'installed' ? (
+                          <CheckCircle2 className="h-3.5 w-3.5" />
+                        ) : null}
+                        {badge.label}
+                      </span>
+                    </td>
+                    <td className="px-4 py-2 text-[var(--color-text-dim)]">{formatTimestamp(j.startedAt)}</td>
+                    <td className="px-4 py-2 text-xs text-[var(--color-text-dim)]">
+                      <div className="max-w-md truncate" title={j.message}>
+                        {j.message ?? ''}
+                      </div>
+                    </td>
+                  </tr>
+                )
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary

After handover the Sovereign Console at `console.<sov-fqdn>/console/*` rendered empty placeholders on Jobs, Apps, and Cloud. This makes the handover useless — operator gets a fully-functional cluster with a completely empty operational view.

This PR wires LIVE local-cluster data into all three pages so the Console stays fully populated even after the Self-Sovereignty Cutover (#792) severs every external link.

### Fix A — Job history populated from local cluster state

`GET /api/v1/sovereign/jobs` joins three signal sources from the in-cluster apiserver:

1. Flux HelmRelease Ready/NotReady transitions (the bootstrap-kit install path the operator just lived through)
2. K8s Jobs across all namespaces (Helm post-install hooks, any operator-authored Job/CronJob runs)
3. K8s Warning Events (operator-visible cluster anomalies)

Sorted started-DESC. Each row carries kind / status / message.

### Fix B — Apps catalog mirrors mothership marketplace

`GET /api/v1/sovereign/apps` joins the embedded Blueprint catalog (same source of truth `blueprint.yaml` the wizard's StepComponents reads, per INVIOLABLE-PRINCIPLES #4) with the local cluster's HelmRelease state:

- `installed` → bp-* HR present + Ready=True
- `installing` → bp-* HR present, Ready=False/none
- `available` → listed in catalog, no matching HR
- `bootstrap` → bootstrap-kit member (always installed)

The UI renders the FULL marketplace card grid with search + status filter chips + Install affordance — no waiting for the gitea-mirror cutover step to land for first paint.

### Fix C — Cloud view auto-populates from local cluster

`GET /api/v1/sovereign/cloud` returns 7 lists in one call:

- Nodes (with status / roles / kubelet version / IPs / capacity)
- Namespaces
- Ingresses (`networking.k8s.io/v1`)
- HTTPRoutes (`gateway.networking.k8s.io/v1`)
- LoadBalancer-typed Services
- Storage Classes
- PVCs

Each ingress + HTTPRoute carries an `https://hostname` affordance with an external-link icon so the operator can jump straight to console / marketplace / gitea / harbor / etc.

## Architecture

- All four endpoints use `rest.InClusterConfig()` — catalyst-api always runs in the cluster it serves (mothership AND post-handover Sovereign).
- Test seam: `SovereignDepsFactory` injects `(kubernetes.Interface, dynamic.Interface)` from `fakek8s.NewSimpleClientset` + `dynamicfake.NewSimpleDynamicClientWithCustomListKinds` so tests run without a real cluster.
- Catalog seam: `internal/catalog` embeds `blueprints.json` via `go:embed`. Build script `products/catalyst/bootstrap/ui/scripts/build-catalog.mjs` now writes that JSON alongside `catalog.generated.ts`. CI catches drift via the committed file.

## Test plan

- [x] Go: `go test ./internal/handler/ -run TestSovereign` — 5/5 pass
- [x] UI: `npx vitest run src/pages/sovereign/console/` — 11/11 pass
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `npx tsc --noEmit` clean
- [ ] Self-merge `--admin --delete-branch` and watch the catalyst-build workflow roll a new image
- [ ] Verify on otech113 after image roll: console.<sov-fqdn>/console/jobs shows HRs, /apps shows full catalog, /cloud shows nodes/namespaces/etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)