### PR TITLE
fix(bootstrap-kit): bump bp-keycloak to 1.4.0 for tenant-mode realm (#915)

### DIFF
--- a/clusters/_template/bootstrap-kit/09-keycloak.yaml
+++ b/clusters/_template/bootstrap-kit/09-keycloak.yaml
@@ -41,7 +41,7 @@ spec:
   chart:
     spec:
       chart: bp-keycloak
-      version: 1.3.3
+      version: 1.4.0
       sourceRef:
         kind: HelmRepository
         name: bp-keycloak


### PR DESCRIPTION
## Summary
- PR #918 published `bp-keycloak` chart **1.4.0** with the tenant-mode realm template that registers WordPress / Stalwart / OpenClaw OIDC clients (alice E2E DoD prerequisite), but did NOT update the version pin in `clusters/_template/bootstrap-kit/09-keycloak.yaml`. Fresh Sovereigns therefore still install 1.3.3 → no tenant-mode realm → gates 3/4/5 of the alice DoD fail.
- F3 chart-staleness guard detected this drift on otech113 (deployed bp-keycloak: 1.3.3 vs required 1.4.0).
- This PR bumps the bootstrap-kit HR pin to 1.4.0. Verified published in GHCR (`oci://ghcr.io/openova-io/bp-keycloak:1.4.0`).

## Test plan
- CI green
- otech113 flux-system bp-keycloak HR upgrades from 1.3.3 -> 1.4.0 after merge + reconcile
- tenant-mode realm template renders WordPress / Stalwart / OpenClaw OIDC clients on alice signup
- alice DoD gates 3/4/5 (#915) pass on otech113

Refs #915 #918