### PR TITLE
fix(catalyst-api): emit per-tenant bp-newapi HelmRelease in SME tenant overlay (#945)

### DIFF
--- a/products/catalyst/bootstrap/api/cmd/api/main.go
+++ b/products/catalyst/bootstrap/api/cmd/api/main.go
@@ -330,6 +330,7 @@ func main() {
 					WordPress: os.Getenv("CATALYST_SME_BP_WORDPRESS_VER"),
 					OpenClaw:  os.Getenv("CATALYST_SME_BP_OPENCLAW_VER"),
 					Stalwart:  os.Getenv("CATALYST_SME_BP_STALWART_VER"),
+					NewAPI:    os.Getenv("CATALYST_SME_BP_NEWAPI_VER"),
 				},
 			}
 			// DNS provisioner — wraps PowerDNS for free-subdomain

--- a/products/catalyst/bootstrap/api/internal/handler/sme_tenant_gitops.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sme_tenant_gitops.go
@@ -67,15 +67,17 @@ type DefaultSMETenantGitOpsWriter struct {
 // generator emits for each bp-* HelmRelease. The orchestrator's
 // wiring (main.go) reads each from env (CATALYST_SME_BP_KEYCLOAK_VER,
 // CATALYST_SME_BP_CNPG_VER, CATALYST_SME_BP_WORDPRESS_VER,
-// CATALYST_SME_BP_OPENCLAW_VER, CATALYST_SME_BP_STALWART_VER); when
-// any is empty the generator falls back to "*" so Flux pulls the
-// latest matching chart in the repository.
+// CATALYST_SME_BP_OPENCLAW_VER, CATALYST_SME_BP_STALWART_VER,
+// CATALYST_SME_BP_NEWAPI_VER); when any is empty the generator falls
+// back to "*" so Flux pulls the latest matching chart in the
+// repository.
 type SMETenantChartVersions struct {
 	Keycloak  string
 	CNPG      string
 	WordPress string
 	OpenClaw  string
 	Stalwart  string
+	NewAPI    string
 }
 
 // WriteTenantOverlay implements SMETenantGitOpsWriter. Returns the
@@ -294,6 +296,18 @@ apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: HelmRepository
 metadata:
   name: bp-cnpg
+  namespace: flux-system
+spec:
+  type: oci
+  interval: 15m
+  url: oci://ghcr.io/openova-io
+  secretRef:
+    name: ghcr-pull
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: bp-newapi
   namespace: flux-system
 spec:
   type: oci
@@ -532,6 +546,7 @@ func withVersionDefaults(v SMETenantChartVersions) SMETenantChartVersions {
 		WordPress: star(v.WordPress),
 		OpenClaw:  star(v.OpenClaw),
 		Stalwart:  star(v.Stalwart),
+		NewAPI:    star(v.NewAPI),
 	}
 }
 
@@ -545,6 +560,7 @@ var smeTenantTemplates = map[string]string{
 	"vcluster.yaml":            smeTenantVCluster,
 	"bp-keycloak.yaml":         smeTenantBPKeycloak,
 	"bp-cnpg.yaml":             smeTenantBPCNPG,
+	"bp-newapi.yaml":           smeTenantBPNewAPI,
 	"bp-wordpress-tenant.yaml": smeTenantBPWordPress,
 	"bp-openclaw.yaml":         smeTenantBPOpenClaw,
 	"bp-stalwart-tenant.yaml":  smeTenantBPStalwart,
@@ -560,6 +576,7 @@ resources:
   - vcluster.yaml
   - bp-keycloak.yaml
   - bp-cnpg.yaml
+  - bp-newapi.yaml
   - bp-wordpress-tenant.yaml
   - bp-openclaw.yaml
   - bp-stalwart-tenant.yaml
@@ -799,6 +816,174 @@ spec:
       monitoring:
         # Default OFF per docs/BLUEPRINT-AUTHORING.md §11.2.
         podMonitorEnabled: false
+`
+
+// smeTenantBPNewAPI emits the per-tenant bp-newapi HelmRelease (#945).
+//
+// Architecture: every SME runs ITS OWN NewAPI gateway. alice's OpenClaw
+// boots and points at https://api.alice.<parent>/v1 (set by
+// smeTenantBPOpenClaw). That hostname MUST resolve to a per-tenant
+// NewAPI Pod with its own Postgres-backed channels list, its own admin
+// UI gated by the tenant Keycloak realm, and its own customer-API key
+// minted by Catalyst on signup. A shared otech-wide newapi.<otech-fqdn>
+// would defeat per-tenant channel routing (alice and bob would share
+// the same channel set + audit log + commercial-contract attestation).
+//
+// Values contract (chart >= 1.3.0, see platform/newapi/chart/values.yaml):
+//   - sovereignFQDN          → drives the OpenBao path convention for
+//                              ExternalSecrets (sovereign/<fqdn>/...).
+//   - ingress.host           → customer-facing OpenAI-compatible API at
+//                              api.<sub>.<parent>/v1
+//   - ingress.adminHost      → ops-staff admin UI at
+//                              admin.<sub>.<parent>
+//   - auth.adminUI           → mode=keycloak, issuer = per-tenant realm
+//                              (alice's tenant Keycloak), clientId
+//                              "newapi-admin" registered by the tenant
+//                              realm-config (see #910/#915 C1).
+//   - auth.customerAPI       → keyIssuer=catalyst (Catalyst mints
+//                              per-user bearer keys on signup; the
+//                              upstream's self-serve portal is OFF).
+//   - database.existingSecret → newapi-pg-app — the Secret bp-cnpg's
+//                              CNPG Cluster auto-renders for the
+//                              "newapi" Database (cnpg.enabled=true so
+//                              per-tenant Postgres auto-provisions per
+//                              #943).
+//   - credentials.existingSecret → newapi-credentials — pulled from
+//                              OpenBao via ExternalSecret carrying the
+//                              SESSION_SECRET + CRYPTO_SECRET keys.
+//   - defaultChannels.qwenBankDhofar → channel #1 = Qwen3.6@BankDhofar
+//                              auto-seeded at install time (canonical
+//                              first-otech default per #915 C4 PR #919).
+//
+// dependsOn: bp-keycloak (OIDC for admin UI) + bp-cnpg (Postgres
+// backend). Ordering matters — without it the chart's channel-seed
+// post-install Job races the readiness of the dependencies and Flux
+// retries cost minutes.
+const smeTenantBPNewAPI = `# bp-newapi per-tenant (#915, #945) — alice's own NewAPI gateway.
+#
+# Per umbrella epic #915 + bug #945 (G3 surfaced 2026-05-05): every SME
+# tenant runs its own NewAPI Pod with its own channels list + admin UI.
+# OpenClaw's llm.baseURL points here (api.<sub>.<parent>/v1) so each
+# tenant's chats route through their own NewAPI which proxies to the
+# configured channel — Qwen3.6@BankDhofar wired by C4 (PR #919).
+#
+# A shared otech-wide newapi.<otech-fqdn> would defeat per-tenant
+# channel routing, audit isolation, and commercial-contract attestation
+# (alice and bob would share the same upstream account). Hence per-
+# tenant deployment.
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: bp-newapi
+  namespace: {{.Namespace}}
+spec:
+  interval: 10m
+  chart:
+    spec:
+      chart: bp-newapi
+      version: "{{.ChartVersions.NewAPI}}"
+      sourceRef:
+        kind: HelmRepository
+        name: bp-newapi
+        namespace: flux-system
+  install:
+    timeout: 15m
+  upgrade:
+    timeout: 15m
+    cleanupOnFail: true
+  dependsOn:
+    - name: bp-keycloak
+      namespace: {{.Namespace}}
+    - name: bp-cnpg
+      namespace: {{.Namespace}}
+  values:
+    # Per-tenant identity zone — drives the OpenBao path convention for
+    # ExternalSecrets (sovereign/<fqdn>/newapi/...). The sub.parent form
+    # makes the path tenant-unique on a multi-tenant Sovereign.
+    sovereignFQDN: {{.Subdomain}}.{{.ParentDomain}}
+    # ── Postgres backend (bp-cnpg in tenant ns auto-provisions) ────────
+    # bp-cnpg renders a per-database app Secret named "<db>-app" (#943).
+    # The NewAPI chart consumes the canonical SQL_DSN key.
+    database:
+      existingSecret: newapi-pg-app
+      existingSecretKey: SQL_DSN
+    # ── App credentials (SESSION_SECRET + CRYPTO_SECRET) ──────────────
+    # Materialised by an ExternalSecret pulling from the per-tenant
+    # OpenBao path. The chart's manifest fails render if the Secret is
+    # missing both keys; the operator overlay seeds them out-of-band on
+    # tenant creation (bootstrap-kit reflector setup).
+    credentials:
+      existingSecret: newapi-credentials
+    # ── Auth: ops-staff admin UI gated by per-tenant Keycloak ─────────
+    # Customer-facing API uses Catalyst-minted keys (NewAPI's self-serve
+    # portal stays OFF on Catalyst Sovereigns per platform/newapi).
+    auth:
+      adminUI:
+        mode: keycloak
+        keycloak:
+          issuer: https://keycloak.{{.Subdomain}}.{{.ParentDomain}}/realms/sme-{{.Subdomain}}
+          clientId: newapi-admin
+          callbackPath: /oauth/callback
+          existingSecret: newapi-oidc-client-secret
+      customerAPI:
+        keyIssuer: catalyst
+    # ── Ingress + cert-manager TLS ────────────────────────────────────
+    # Two virtual hosts:
+    #   api.<sub>.<parent>    → customer-facing OpenAI-compatible /v1/*
+    #                          endpoint OpenClaw's llm.baseURL points to.
+    #   admin.<sub>.<parent>  → ops-staff admin UI (OIDC against tenant
+    #                          Keycloak realm).
+    # The wildcard *.<parent> Cert covers the free-subdomain mode hosts;
+    # BYO mode adds explicit dnsNames in certificate.yaml above.
+    ingress:
+      enabled: true
+      className: traefik
+      host: api.{{.Subdomain}}.{{.ParentDomain}}
+      adminHost: admin.{{.Subdomain}}.{{.ParentDomain}}
+      tls:
+        enabled: true
+        issuer: letsencrypt-prod
+        apiSecretName: newapi-api-tls
+        adminSecretName: newapi-admin-tls
+    # ── Default channels: Qwen3.6 @ BankDhofar (canonical #915 C4) ────
+    # Channel #1 — auto-seeded at install time by the chart's
+    # post-install/post-upgrade channel-seed Helm hook Job. The seed
+    # Job probes NewAPI's admin API via GET /api/channel/?keyword=NAME
+    # (idempotent) and POSTs the channel if missing. The accountId +
+    # contractRef carry the commercial-contract attestation per
+    # platform/newapi/README.md compliance posture (operator overlay
+    # supplies the legal-team-owned contract reference).
+    defaultChannels:
+      qwenBankDhofar:
+        enabled: true
+        name: qwen3.6-bankdhofar
+        endpoint: https://llm-api.omtd.bankdhofar.com
+        models:
+          - qwen3.6
+          - qwen3-coder
+        existingSecret: newapi-channel-qwen-bankdhofar
+        existingSecretKey: API_KEY
+        attestation:
+          kind: commercial-contract
+          accountId: bankdhofar-omtd
+          contractRef: sovereign/{{.OTECHFQDN}}/newapi/qwen-bankdhofar/contract
+    # ── Catalyst integration — admin token for per-user key minting ──
+    # ADR-0003 §3.2: Catalyst's signup hook reads this Secret and POSTs
+    # against NewAPI's admin API with Authorization: Bearer header to
+    # issue per-user customer-API keys. The token is rotated per the
+    # convention in docs/CATALYST-CLI-AGENT.md.
+    catalystIntegration:
+      enabled: true
+      existingSecret: catalyst-newapi-admin-token
+      externalSecret:
+        enabled: true
+        refreshInterval: 1h
+        secretStoreRef:
+          kind: ClusterSecretStore
+          name: vault-region1
+        remoteRef:
+          key: sovereign/{{.OTECHFQDN}}/newapi/{{.TenantID}}/admin-token
+          property: ADMIN_API_TOKEN
 `
 
 const smeTenantBPWordPress = `# bp-wordpress-tenant (#800, #915) — SSO-pre-wired WordPress per SME.

--- a/products/catalyst/bootstrap/api/internal/handler/sme_tenant_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sme_tenant_test.go
@@ -440,6 +440,7 @@ func TestRenderSMETenantOverlay_FreeSubdomain_AllChartsPresent(t *testing.T) {
 		"vcluster.yaml",
 		"bp-keycloak.yaml",
 		"bp-cnpg.yaml",
+		"bp-newapi.yaml",
 		"bp-wordpress-tenant.yaml",
 		"bp-openclaw.yaml",
 		"bp-stalwart-tenant.yaml",
@@ -590,6 +591,175 @@ func TestRenderSMETenantOverlay_OpenClawOIDCAndLLMBlocks(t *testing.T) {
 	// channel routing).
 	if strings.Contains(body, "https://newapi.otech107.omani.works") {
 		t.Errorf("bp-openclaw llm.baseURL must be per-tenant api.<sub>.<parent>, not otech-wide newapi: %s", body)
+	}
+}
+
+// TestRenderSMETenantOverlay_NewAPIEmitted asserts the SME tenant
+// overlay emits a per-tenant bp-newapi HelmRelease (#945). Without it
+// the bp-openclaw HR points at https://api.<sub>.<parent>/v1 with no
+// chart materialising that ingress — alice's OpenClaw boots and gets
+// NXDOMAIN on every chat request.
+//
+// The chart values must:
+//   - dependsOn bp-keycloak (admin-UI OIDC) AND bp-cnpg (Postgres backend).
+//   - Emit ingress.host = api.<sub>.<parent> + ingress.adminHost =
+//     admin.<sub>.<parent> so OpenClaw's llm.baseURL resolves.
+//   - Wire auth.adminUI to the per-tenant Keycloak realm
+//     (alice's tenant Keycloak), NOT a shared otech-level IdP.
+//   - Enable defaultChannels.qwenBankDhofar so the chart's channel-seed
+//     post-install Job auto-seeds Qwen3.6@BankDhofar at install time
+//     (canonical first-otech default per #915 C4 PR #919).
+//   - Reference newapi-pg-app for the database (bp-cnpg renders the
+//     app secret in tenant ns) + newapi-credentials for app secrets.
+func TestRenderSMETenantOverlay_NewAPIEmitted(t *testing.T) {
+	rec := store.SMETenantProvisionRecord{
+		SMETenantID:     "t-alice",
+		Subdomain:       "alice",
+		ParentDomain:    "omantel.omani.works",
+		DomainMode:      store.SMEDomainFreeSubdomain,
+		AdminEmail:      "admin@alice.test",
+		CompanyName:     "Alice Corp",
+		OTECHFQDN:       "otech113.omani.works",
+		VClusterName:    "vc-alice",
+		TenantNamespace: "sme-t-alice",
+	}
+	files, err := renderSMETenantOverlay(rec, SMETenantChartVersions{})
+	if err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	body, ok := files["bp-newapi.yaml"]
+	if !ok {
+		t.Fatalf("bp-newapi.yaml missing from rendered overlay")
+	}
+
+	// HelmRelease metadata.
+	for _, want := range []string{
+		"kind: HelmRelease",
+		"name: bp-newapi",
+		"namespace: sme-t-alice",
+		"chart: bp-newapi",
+		`version: "*"`, // unconfigured chart version falls back to "*"
+		"name: bp-newapi", // sourceRef.name
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("bp-newapi.yaml missing %q\n--- rendered ---\n%s", want, body)
+		}
+	}
+
+	// dependsOn: bp-keycloak + bp-cnpg (BOTH required).
+	wantDependsOn := []string{
+		"  dependsOn:",
+		"    - name: bp-keycloak",
+		"      namespace: sme-t-alice",
+		"    - name: bp-cnpg",
+		"      namespace: sme-t-alice",
+	}
+	for _, line := range wantDependsOn {
+		if !strings.Contains(body, line) {
+			t.Errorf("bp-newapi.yaml dependsOn missing line %q\n--- rendered ---\n%s", line, body)
+		}
+	}
+
+	// Ingress hosts — customer-API + admin UI.
+	wantIngress := []string{
+		"      host: api.alice.omantel.omani.works",
+		"      adminHost: admin.alice.omantel.omani.works",
+		"        issuer: letsencrypt-prod",
+	}
+	for _, line := range wantIngress {
+		if !strings.Contains(body, line) {
+			t.Errorf("bp-newapi.yaml ingress missing line %q\n--- rendered ---\n%s", line, body)
+		}
+	}
+
+	// Admin UI gated by the PER-TENANT Keycloak realm (NOT otech-wide).
+	wantAdminAuth := []string{
+		"        mode: keycloak",
+		"          issuer: https://keycloak.alice.omantel.omani.works/realms/sme-alice",
+		"          clientId: newapi-admin",
+		"          existingSecret: newapi-oidc-client-secret",
+	}
+	for _, line := range wantAdminAuth {
+		if !strings.Contains(body, line) {
+			t.Errorf("bp-newapi.yaml auth.adminUI missing line %q\n--- rendered ---\n%s", line, body)
+		}
+	}
+
+	// Customer-API issuer = catalyst (Catalyst mints per-user keys; the
+	// upstream's self-serve portal stays OFF on Catalyst Sovereigns).
+	if !strings.Contains(body, "        keyIssuer: catalyst") {
+		t.Errorf("bp-newapi.yaml customerAPI.keyIssuer must be 'catalyst' to disable the self-serve portal")
+	}
+
+	// Per-tenant database + credentials Secrets.
+	wantSecrets := []string{
+		"      existingSecret: newapi-pg-app",
+		"      existingSecretKey: SQL_DSN",
+		"      existingSecret: newapi-credentials",
+	}
+	for _, line := range wantSecrets {
+		if !strings.Contains(body, line) {
+			t.Errorf("bp-newapi.yaml DB/credentials missing line %q", line)
+		}
+	}
+
+	// defaultChannels.qwenBankDhofar — channel #1 auto-seeded by the
+	// chart's post-install Helm hook Job (per #915 C4 PR #919).
+	wantChannel := []string{
+		"      qwenBankDhofar:",
+		"        enabled: true",
+		"        name: qwen3.6-bankdhofar",
+		"        endpoint: https://llm-api.omtd.bankdhofar.com",
+		"          - qwen3.6",
+		"          - qwen3-coder",
+		"        existingSecret: newapi-channel-qwen-bankdhofar",
+		"        existingSecretKey: API_KEY",
+		"          kind: commercial-contract",
+	}
+	for _, line := range wantChannel {
+		if !strings.Contains(body, line) {
+			t.Errorf("bp-newapi.yaml defaultChannels.qwenBankDhofar missing line %q\n--- rendered ---\n%s", line, body)
+		}
+	}
+
+	// MUST NOT point at the otech-wide newapi.<otech-fqdn> — that would
+	// defeat per-tenant channel routing (alice + bob would share a
+	// single channel set, audit log, and commercial-contract).
+	if strings.Contains(body, "newapi.otech113.omani.works") {
+		t.Errorf("bp-newapi.yaml must be per-tenant api.<sub>.<parent>, not otech-wide newapi: %s", body)
+	}
+
+	// kustomization.yaml MUST list bp-newapi.yaml so Flux materialises it.
+	kust, ok := files["kustomization.yaml"]
+	if !ok {
+		t.Fatalf("kustomization.yaml missing")
+	}
+	if !strings.Contains(kust, "  - bp-newapi.yaml") {
+		t.Errorf("kustomization.yaml resources list must include bp-newapi.yaml — got:\n%s", kust)
+	}
+}
+
+// TestRenderSMETenantOverlay_NewAPIChartVersion asserts the NewAPI
+// chart version is overridable via SMETenantChartVersions.NewAPI (per
+// Inviolable Principle 4 — never hardcode versions in source).
+func TestRenderSMETenantOverlay_NewAPIChartVersion(t *testing.T) {
+	rec := store.SMETenantProvisionRecord{
+		SMETenantID:     "t-alice",
+		Subdomain:       "alice",
+		ParentDomain:    "omantel.omani.works",
+		DomainMode:      store.SMEDomainFreeSubdomain,
+		AdminEmail:      "admin@alice.test",
+		OTECHFQDN:       "otech113.omani.works",
+		VClusterName:    "vc-alice",
+		TenantNamespace: "sme-t-alice",
+	}
+	versions := SMETenantChartVersions{NewAPI: "1.3.0"}
+	files, err := renderSMETenantOverlay(rec, versions)
+	if err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	if !strings.Contains(files["bp-newapi.yaml"], `version: "1.3.0"`) {
+		t.Errorf("bp-newapi version override missing — got:\n%s", files["bp-newapi.yaml"])
 	}
 }
 


### PR DESCRIPTION
Fixes #945. Refs umbrella #915.

## Summary

The SME tenant orchestrator's `smeTenantTemplates` map (in `products/catalyst/bootstrap/api/internal/handler/sme_tenant_gitops.go`) did NOT include `bp-newapi.yaml`. Result: alice's tenant signup created HRs for bp-cnpg / bp-keycloak / bp-stalwart-tenant / bp-wordpress-tenant / bp-openclaw — but no per-tenant NewAPI HR. Alice's bp-openclaw HR set `llm.baseURL: https://api.alice.<parent>/v1` (per #917) which then NXDOMAIN'd because no chart materialised that ingress.

This PR closes the seam.

## Changes

- New `smeTenantBPNewAPI` template + `bp-newapi.yaml` map entry, modelled on the existing per-tenant blueprint patterns:
  - `dependsOn: bp-keycloak + bp-cnpg`
  - `ingress.host = api.<sub>.<parent>` + `ingress.adminHost = admin.<sub>.<parent>`
  - `auth.adminUI` → per-tenant Keycloak realm (`sme-<sub>`), client `newapi-admin`
  - `auth.customerAPI.keyIssuer = catalyst` (the upstream self-serve portal stays OFF)
  - `defaultChannels.qwenBankDhofar.enabled = true` so channel #1 auto-seeds per PR #919 / #915 C4
  - `existingSecret` refs match the bp-newapi 1.3.0 chart contract (`newapi-pg-app`, `newapi-credentials`, `newapi-channel-qwen-bankdhofar`, `newapi-oidc-client-secret`)
- `SMETenantChartVersions.NewAPI` field + `main.go` env wire (`CATALYST_SME_BP_NEWAPI_VER`)
- `bp-newapi` HelmRepository added to `smeTenantSharedHelmRepositories` so the per-tenant HR has a valid sourceRef
- `kustomization.yaml` resources list updated

## Tests

- `TestRenderSMETenantOverlay_NewAPIEmitted` — asserts ingress hosts, `dependsOn`, per-tenant Keycloak issuer (`sme-alice`), qwenBankDhofar channel, `keyIssuer=catalyst`, and that the otech-wide `newapi.<otech-fqdn>` is NOT referenced (per-tenant routing guardrail).
- `TestRenderSMETenantOverlay_NewAPIChartVersion` — chart version overridable per Inviolable Principle 4.
- Updated `TestRenderSMETenantOverlay_FreeSubdomain_AllChartsPresent` to include `bp-newapi.yaml`.

```
$ go test ./internal/handler/ -run "TestRenderSMETenantOverlay" -v
=== RUN   TestRenderSMETenantOverlay_FreeSubdomain_AllChartsPresent
--- PASS
=== RUN   TestRenderSMETenantOverlay_BYO_EmitsCertificate
--- PASS
=== RUN   TestRenderSMETenantOverlay_VersionsApplied
--- PASS
=== RUN   TestRenderSMETenantOverlay_NoVersionsDefaultsToStar
--- PASS
=== RUN   TestRenderSMETenantOverlay_OpenClawOIDCAndLLMBlocks
--- PASS
=== RUN   TestRenderSMETenantOverlay_NewAPIEmitted
--- PASS
=== RUN   TestRenderSMETenantOverlay_NewAPIChartVersion
--- PASS
=== RUN   TestRenderSMETenantOverlay_WordPressEmitsOIDC
--- PASS
=== RUN   TestRenderSMETenantOverlay_WordPressOIDC_BYOMode
--- PASS
=== RUN   TestRenderSMETenantOverlay_StalwartEmitsKeycloakOIDC
--- PASS
PASS
ok      github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/handler  0.145s
```

## Notes / Cascade dependencies

The orchestrator-side fix is independent and ships now. Per #945 the chart-side cascade is being handled separately:

- #943 — Sovereign-level bp-newapi has no per-tenant DB Cluster (H1 in flight).
- #941 — catalog `migrateAppDeployable` missing openclaw + stalwart-mail (H1 in flight).

The per-tenant NewAPI HR will reach `Ready=True` once the cascade lands; until then it surfaces a clean Helm install error instead of a silent NXDOMAIN, which is the strictly better failure mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)