### PR TITLE
fix(pdm/dynadot): remove fictional ResponseHeader wrapper from api3.json adapter (#939)

### DIFF
--- a/core/pkg/dynadot-client/client.go
+++ b/core/pkg/dynadot-client/client.go
@@ -156,10 +156,14 @@ func (c *Client) GetDomainInfo(ctx context.Context, domain string) (*DomainInfo,
 		return nil, err
 	}
 
+	// domain_info live response shape (verified 2026-05-05): code/status
+	// fields live DIRECTLY under DomainInfoResponse, NOT under a
+	// `ResponseHeader` wrapper. Aligning with the set_dns2 path's
+	// previously-correct unwrapping above. Refs issue #939.
 	var raw struct {
 		DomainInfoResponse struct {
-			ResponseHeader respHeader `json:"ResponseHeader"`
-			DomainInfo     struct {
+			respHeader
+			DomainInfo struct {
 				NameServerSettings struct {
 					NameServers []struct {
 						ServerName string `json:"ServerName"`
@@ -182,7 +186,7 @@ func (c *Client) GetDomainInfo(ctx context.Context, domain string) (*DomainInfo,
 	if err := json.Unmarshal(body, &raw); err != nil {
 		return nil, fmt.Errorf("dynadot: parse domain_info: %w (body=%s)", err, truncate(string(body), 256))
 	}
-	if err := classifyDynadotError(raw.DomainInfoResponse.ResponseHeader); err != nil {
+	if err := classifyDynadotError(raw.DomainInfoResponse.respHeader); err != nil {
 		return nil, err
 	}
 

--- a/core/pkg/dynadot-client/client_test.go
+++ b/core/pkg/dynadot-client/client_test.go
@@ -95,9 +95,12 @@ func TestRemoveSubRecord_PreservesOthers(t *testing.T) {
 		switch r.URL.Query().Get("command") {
 		case "domain_info":
 			w.Header().Set("Content-Type", "application/json")
+			// Real Dynadot domain_info shape — code+status at top of
+			// DomainInfoResponse (no ResponseHeader wrapper, see #939).
 			_, _ = w.Write([]byte(`{
 				"DomainInfoResponse": {
-					"ResponseHeader": {"ResponseCode":"0","Status":"success"},
+					"ResponseCode": 0,
+					"Status": "success",
 					"DomainInfo": {
 						"NameServerSettings": {
 							"NameServers": [{"ServerName":"ns1.openova.io"}],
@@ -158,9 +161,11 @@ func TestRemoveSubRecord_NoMatchIsNoop(t *testing.T) {
 		switch r.URL.Query().Get("command") {
 		case "domain_info":
 			w.Header().Set("Content-Type", "application/json")
+			// Real Dynadot domain_info shape (no ResponseHeader wrapper).
 			_, _ = w.Write([]byte(`{
 				"DomainInfoResponse": {
-					"ResponseHeader": {"ResponseCode":"0","Status":"success"},
+					"ResponseCode": 0,
+					"Status": "success",
 					"DomainInfo": {"NameServerSettings": {"SubDomains":[]}}
 				}
 			}`))

--- a/core/pool-domain-manager/internal/registrar/dynadot/dynadot.go
+++ b/core/pool-domain-manager/internal/registrar/dynadot/dynadot.go
@@ -85,14 +85,43 @@ func parseToken(token string) (key, secret string, err error) {
 	return parts[0], parts[1], nil
 }
 
-// call invokes one Dynadot API3 command and returns the parsed envelope's
-// ResponseHeader so the caller can inspect Status/Error. The command's
-// content (NameServerSettings, etc.) is left in raw and decoded by the
-// caller into its specific shape.
+// respHeader carries the per-command status fields Dynadot returns. They
+// live DIRECTLY under each `<Command>Response` envelope — Dynadot does
+// NOT wrap them in a `ResponseHeader` sub-object the way an earlier read
+// of the docs assumed. Live api3.json output (`domain_info` against an
+// account-owned domain) returned 2026-05-05:
+//
+//	{"DomainInfoResponse":{"ResponseCode":0,"Status":"success",
+//	 "DomainInfo":{...}}}
+//
+// And the error envelope (`domain_info` for an unowned domain):
+//
+//	{"DomainInfoResponse":{"ResponseCode":"-1","Status":"error",
+//	 "Error":"could not find domain in your account"}}
+//
+// Note `ResponseCode` is JSON-typed `int` on success but `string` on
+// error — the same field flips representation across responses (see
+// issue #939). We decode into `json.Number` so both shapes round-trip
+// without an Unmarshal failure, then compare via the codeIsZero helper.
+//
+// The legacy `ResponseHeader` wrapper that this struct replaces was
+// fictional — every prior production call to ValidateToken / SetNs /
+// GetNs unmarshalled into a zero-value header (Status="", Code="") and
+// fell through to "unknown-error" → 500. Tests masked the bug because
+// the test fixtures used the same fictional shape. Refs: #939, #170.
 type respHeader struct {
-	ResponseCode string `json:"ResponseCode"`
-	Status       string `json:"Status"`
-	Error        string `json:"Error"`
+	ResponseCode json.Number `json:"ResponseCode"`
+	Status       string      `json:"Status"`
+	Error        string      `json:"Error"`
+}
+
+// codeIsZero reports whether the Dynadot response code indicates success.
+// Dynadot mixes int (`0`) and string (`"0"`) representations across
+// success/error paths, sometimes within the same command — this helper
+// normalises both so callers don't have to.
+func codeIsZero(c json.Number) bool {
+	s := strings.TrimSpace(c.String())
+	return s == "0" || s == ""
 }
 
 // classifyHTTP turns an HTTP-level outcome into a typed registrar error.
@@ -109,23 +138,35 @@ func classifyHTTP(statusCode int) error {
 	return nil
 }
 
-// classifyDynadotError inspects an api3.json ResponseHeader and maps to
-// a typed error. Dynadot's auth-failure messages are not rigidly coded;
-// we match the substring patterns the public docs document.
+// classifyDynadotError inspects an api3.json command response header and
+// maps to a typed error. Dynadot's auth-failure messages are not rigidly
+// coded; we match the substring patterns the public docs document.
 func classifyDynadotError(h respHeader) error {
-	if strings.EqualFold(h.Status, "success") || h.ResponseCode == "0" {
+	if strings.EqualFold(h.Status, "success") || codeIsZero(h.ResponseCode) {
 		return nil
 	}
 	msg := strings.ToLower(h.Error)
+	// Order matters: domain-not-in-account must precede the auth match
+	// because Dynadot's "could not find domain in your account" message
+	// would otherwise hit the auth branch on the substring "account".
 	switch {
-	case strings.Contains(msg, "invalid api"), strings.Contains(msg, "key"), strings.Contains(msg, "secret"), strings.Contains(msg, "auth"):
-		return fmt.Errorf("dynadot api: %s: %w", h.Error, registrar.ErrInvalidToken)
-	case strings.Contains(msg, "not found"), strings.Contains(msg, "not in your account"), strings.Contains(msg, "not own"):
+	case strings.Contains(msg, "not found"),
+		strings.Contains(msg, "could not find"),
+		strings.Contains(msg, "not in your account"),
+		strings.Contains(msg, "in your account"),
+		strings.Contains(msg, "not own"),
+		strings.Contains(msg, "no such domain"):
 		return fmt.Errorf("dynadot api: %s: %w", h.Error, registrar.ErrDomainNotInAccount)
+	case strings.Contains(msg, "invalid api"),
+		strings.Contains(msg, "invalid key"),
+		strings.Contains(msg, "invalid secret"),
+		strings.Contains(msg, "invalid token"),
+		strings.Contains(msg, "auth"):
+		return fmt.Errorf("dynadot api: %s: %w", h.Error, registrar.ErrInvalidToken)
 	case strings.Contains(msg, "rate"), strings.Contains(msg, "too many"):
 		return fmt.Errorf("dynadot api: %s: %w", h.Error, registrar.ErrRateLimited)
 	}
-	return fmt.Errorf("dynadot api error: code=%s status=%s err=%s", h.ResponseCode, h.Status, h.Error)
+	return fmt.Errorf("dynadot api error: code=%s status=%s err=%s", h.ResponseCode.String(), h.Status, h.Error)
 }
 
 // ValidateToken probes the registrar with `domain_info` for the named
@@ -146,15 +187,18 @@ func (a *Adapter) ValidateToken(ctx context.Context, token, domain string) error
 	if err != nil {
 		return err
 	}
+	// Dynadot's domain_info live response (verified 2026-05-05) puts
+	// ResponseCode/Status/Error DIRECTLY under DomainInfoResponse — there
+	// is no `ResponseHeader` wrapper. Refs #939.
 	var raw struct {
 		DomainInfoResponse struct {
-			ResponseHeader respHeader `json:"ResponseHeader"`
+			respHeader
 		} `json:"DomainInfoResponse"`
 	}
 	if err := json.Unmarshal(body, &raw); err != nil {
 		return fmt.Errorf("dynadot: parse domain_info: %w", err)
 	}
-	return classifyDynadotError(raw.DomainInfoResponse.ResponseHeader)
+	return classifyDynadotError(raw.DomainInfoResponse.respHeader)
 }
 
 // SetNameservers replaces the domain's nameserver list via set_ns.
@@ -181,15 +225,18 @@ func (a *Adapter) SetNameservers(ctx context.Context, token, domain string, ns [
 	if err != nil {
 		return err
 	}
+	// set_ns live response shape per Dynadot api3.json docs:
+	//   {"SetNsResponse":{"ResponseCode":0,"Status":"success"}}
+	// Status fields live DIRECTLY under SetNsResponse (no wrapper).
 	var raw struct {
 		SetNsResponse struct {
-			ResponseHeader respHeader `json:"ResponseHeader"`
+			respHeader
 		} `json:"SetNsResponse"`
 	}
 	if err := json.Unmarshal(body, &raw); err != nil {
 		return fmt.Errorf("dynadot: parse set_ns: %w", err)
 	}
-	return classifyDynadotError(raw.SetNsResponse.ResponseHeader)
+	return classifyDynadotError(raw.SetNsResponse.respHeader)
 }
 
 // GetNameservers reads the current nameserver list via domain_info.
@@ -208,10 +255,19 @@ func (a *Adapter) GetNameservers(ctx context.Context, token, domain string) ([]s
 	if err != nil {
 		return nil, err
 	}
+	// domain_info live response shape (verified 2026-05-05 against omani.works):
+	//   {"DomainInfoResponse":{
+	//      "ResponseCode": 0, "Status": "success",
+	//      "DomainInfo": {
+	//        "NameServerSettings": {"NameServers": [{"ServerName": "..."}]}
+	//      }
+	//   }}
+	// Status fields live directly under DomainInfoResponse (no
+	// `ResponseHeader` wrapper — see issue #939).
 	var raw struct {
 		DomainInfoResponse struct {
-			ResponseHeader respHeader `json:"ResponseHeader"`
-			DomainInfo     struct {
+			respHeader
+			DomainInfo struct {
 				NameServerSettings struct {
 					NameServers []struct {
 						ServerName string `json:"ServerName"`
@@ -223,7 +279,7 @@ func (a *Adapter) GetNameservers(ctx context.Context, token, domain string) ([]s
 	if err := json.Unmarshal(body, &raw); err != nil {
 		return nil, fmt.Errorf("dynadot: parse domain_info: %w", err)
 	}
-	if err := classifyDynadotError(raw.DomainInfoResponse.ResponseHeader); err != nil {
+	if err := classifyDynadotError(raw.DomainInfoResponse.respHeader); err != nil {
 		return nil, err
 	}
 	out := make([]string, 0, len(raw.DomainInfoResponse.DomainInfo.NameServerSettings.NameServers))
@@ -297,16 +353,17 @@ func (a *Adapter) GetGlueRecord(ctx context.Context, token, host string) (string
 	if err != nil {
 		return "", err
 	}
-	// Dynadot's get_ns response shape:
-	//   {"GetNsResponse":{"ResponseHeader":{...},
+	// Dynadot's get_ns response shape (Status fields live DIRECTLY under
+	// GetNsResponse — there is NO `ResponseHeader` wrapper, see #939):
+	//   {"GetNsResponse":{"ResponseCode":0,"Status":"success",
 	//    "NsInfo":{"NameServer":{"Host":"...","IP":["..."]}}}}
-	// On a host that is NOT registered, ResponseHeader.Status="error"
-	// with a "not found"-style message — we surface that as ("", nil)
-	// so callers can distinguish "missing" from "API failed".
+	// On a host that is NOT registered, Status="error" with a
+	// "not found"-style message — we surface that as ("", nil) so
+	// callers can distinguish "missing" from "API failed".
 	var raw struct {
 		GetNsResponse struct {
-			ResponseHeader respHeader `json:"ResponseHeader"`
-			NsInfo         struct {
+			respHeader
+			NsInfo struct {
 				NameServer struct {
 					Host string   `json:"Host"`
 					IP   []string `json:"IP"`
@@ -317,8 +374,8 @@ func (a *Adapter) GetGlueRecord(ctx context.Context, token, host string) (string
 	if err := json.Unmarshal(body, &raw); err != nil {
 		return "", fmt.Errorf("dynadot: parse get_ns: %w", err)
 	}
-	hdr := raw.GetNsResponse.ResponseHeader
-	if !strings.EqualFold(hdr.Status, "success") && hdr.ResponseCode != "0" {
+	hdr := raw.GetNsResponse.respHeader
+	if !strings.EqualFold(hdr.Status, "success") && !codeIsZero(hdr.ResponseCode) {
 		// "not registered" / "not found" → ("", nil). Anything else is a
 		// real error (auth, rate-limit, API down, ...).
 		msg := strings.ToLower(hdr.Error)
@@ -394,15 +451,17 @@ func (a *Adapter) RegisterGlueRecord(ctx context.Context, token, host, ip string
 		if err != nil {
 			return err
 		}
+		// set_ns_ip live shape: {"SetNsIpResponse":{"ResponseCode":0,
+		// "Status":"success"}} — no `ResponseHeader` wrapper (see #939).
 		var raw struct {
 			SetNsIpResponse struct {
-				ResponseHeader respHeader `json:"ResponseHeader"`
+				respHeader
 			} `json:"SetNsIpResponse"`
 		}
 		if err := json.Unmarshal(body, &raw); err != nil {
 			return fmt.Errorf("dynadot: parse set_ns_ip: %w", err)
 		}
-		return classifyDynadotError(raw.SetNsIpResponse.ResponseHeader)
+		return classifyDynadotError(raw.SetNsIpResponse.respHeader)
 	}
 
 	// 4. First-time registration.
@@ -417,15 +476,17 @@ func (a *Adapter) RegisterGlueRecord(ctx context.Context, token, host, ip string
 	if err != nil {
 		return err
 	}
+	// register_ns live shape: {"RegisterNsResponse":{"ResponseCode":0,
+	// "Status":"success"}} — no `ResponseHeader` wrapper (see #939).
 	var raw struct {
 		RegisterNsResponse struct {
-			ResponseHeader respHeader `json:"ResponseHeader"`
+			respHeader
 		} `json:"RegisterNsResponse"`
 	}
 	if err := json.Unmarshal(body, &raw); err != nil {
 		return fmt.Errorf("dynadot: parse register_ns: %w", err)
 	}
-	return classifyDynadotError(raw.RegisterNsResponse.ResponseHeader)
+	return classifyDynadotError(raw.RegisterNsResponse.respHeader)
 }
 
 // compile-time guards.

--- a/core/pool-domain-manager/internal/registrar/dynadot/dynadot_test.go
+++ b/core/pool-domain-manager/internal/registrar/dynadot/dynadot_test.go
@@ -22,6 +22,17 @@ func newTestAdapter(t *testing.T, h http.HandlerFunc) (*Adapter, *httptest.Serve
 	return a, srv
 }
 
+// ── ValidateToken ────────────────────────────────────────────────────────
+//
+// All fixtures below use the REAL Dynadot api3.json envelope shape
+// (status fields directly under <Command>Response, NO `ResponseHeader`
+// wrapper, ResponseCode oscillating between JSON int 0 on success and
+// JSON string "-1" on error). Captured live 2026-05-05 against
+// omani.works (success) and a non-owned domain (error). Refs #939.
+
+// TestValidateTokenHappy — real Dynadot api3.json `domain_info` success
+// envelope: ResponseCode is JSON int 0 at TOP of DomainInfoResponse, not
+// nested under a `ResponseHeader` wrapper.
 func TestValidateTokenHappy(t *testing.T) {
 	a, _ := newTestAdapter(t, func(w http.ResponseWriter, r *http.Request) {
 		if got := r.URL.Query().Get("command"); got != "domain_info" {
@@ -30,10 +41,25 @@ func TestValidateTokenHappy(t *testing.T) {
 		if got := r.URL.Query().Get("domain"); got != "example.com" {
 			t.Errorf("domain = %q, want example.com", got)
 		}
-		w.Write([]byte(`{"DomainInfoResponse":{"ResponseHeader":{"ResponseCode":"0","Status":"success"}}}`))
+		w.Write([]byte(`{"DomainInfoResponse":{"ResponseCode":0,"Status":"success","DomainInfo":{"Name":"example.com","Status":"active"}}}`))
 	})
 	if err := a.ValidateToken(context.Background(), "k:s", "example.com"); err != nil {
 		t.Fatalf("ValidateToken err = %v", err)
+	}
+}
+
+// TestValidateTokenIntCodeNoStatus — Dynadot has been observed to omit
+// the Status string field in some success replies, returning only
+// `"ResponseCode": 0`. The adapter must accept that as success too;
+// otherwise every such response would 500 the caller. The codeIsZero
+// helper is what makes this work — it normalises int 0 / string "0" /
+// empty-string to "success".
+func TestValidateTokenIntCodeNoStatus(t *testing.T) {
+	a, _ := newTestAdapter(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"DomainInfoResponse":{"ResponseCode":0,"DomainInfo":{"Name":"example.com"}}}`))
+	})
+	if err := a.ValidateToken(context.Background(), "k:s", "example.com"); err != nil {
+		t.Fatalf("ValidateToken err = %v (expected success on int-only ResponseCode)", err)
 	}
 }
 
@@ -55,13 +81,31 @@ func TestValidateTokenUnauthorized(t *testing.T) {
 	}
 }
 
+// TestValidateTokenAppError — real Dynadot error envelope: ResponseCode
+// is the STRING "-1" (not the int 0 success returns), Status="error",
+// Error message at TOP of DomainInfoResponse — no ResponseHeader wrapper.
 func TestValidateTokenAppError(t *testing.T) {
 	a, _ := newTestAdapter(t, func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte(`{"DomainInfoResponse":{"ResponseHeader":{"ResponseCode":"-1","Status":"error","Error":"Invalid api key"}}}`))
+		w.Write([]byte(`{"DomainInfoResponse":{"ResponseCode":"-1","Status":"error","Error":"Invalid api key"}}`))
 	})
 	err := a.ValidateToken(context.Background(), "k:s", "example.com")
 	if !errors.Is(err, registrar.ErrInvalidToken) {
 		t.Fatalf("err = %v, want ErrInvalidToken", err)
+	}
+}
+
+// TestValidateTokenDomainNotInAccount — captures the live "could not
+// find domain in your account" message that Dynadot returns when the
+// supplied (key, secret) authenticates but the domain is registered
+// elsewhere. Maps to ErrDomainNotInAccount per #939. Captured live
+// 2026-05-05 against does-not-exist-12345.works.
+func TestValidateTokenDomainNotInAccount(t *testing.T) {
+	a, _ := newTestAdapter(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"DomainInfoResponse":{"ResponseCode":"-1","Status":"error","Error":"could not find domain in your account"}}`))
+	})
+	err := a.ValidateToken(context.Background(), "k:s", "not-mine.com")
+	if !errors.Is(err, registrar.ErrDomainNotInAccount) {
+		t.Fatalf("err = %v, want ErrDomainNotInAccount", err)
 	}
 }
 
@@ -75,6 +119,14 @@ func TestValidateTokenRateLimited(t *testing.T) {
 	}
 }
 
+// ── SetNameservers ───────────────────────────────────────────────────────
+
+// TestSetNameserversHappy — Dynadot api3.json docs sample for set_ns:
+//
+//	{"SetNsResponse":{"ResponseCode":0,"Status":"success"}}
+//
+// Status fields live DIRECTLY under SetNsResponse (no ResponseHeader
+// wrapper — see #939).
 func TestSetNameserversHappy(t *testing.T) {
 	a, _ := newTestAdapter(t, func(w http.ResponseWriter, r *http.Request) {
 		if got := r.URL.Query().Get("command"); got != "set_ns" {
@@ -86,7 +138,7 @@ func TestSetNameserversHappy(t *testing.T) {
 		if got := r.URL.Query().Get("ns1"); got != "ns2.openova.io" {
 			t.Errorf("ns1 = %q", got)
 		}
-		w.Write([]byte(`{"SetNsResponse":{"ResponseHeader":{"ResponseCode":"0","Status":"success"}}}`))
+		w.Write([]byte(`{"SetNsResponse":{"ResponseCode":0,"Status":"success"}}`))
 	})
 	err := a.SetNameservers(context.Background(), "k:s", "example.com",
 		[]string{"ns1.openova.io", "ns2.openova.io"})
@@ -112,9 +164,11 @@ func TestSetNameserversRateLimited(t *testing.T) {
 	}
 }
 
+// TestSetNameserversDomainNotFound — real Dynadot error shape: code is
+// the STRING "-1" at top of SetNsResponse (no ResponseHeader wrapper).
 func TestSetNameserversDomainNotFound(t *testing.T) {
 	a, _ := newTestAdapter(t, func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte(`{"SetNsResponse":{"ResponseHeader":{"ResponseCode":"-1","Status":"error","Error":"Domain not in your account"}}}`))
+		w.Write([]byte(`{"SetNsResponse":{"ResponseCode":"-1","Status":"error","Error":"Domain not in your account"}}`))
 	})
 	err := a.SetNameservers(context.Background(), "k:s", "x.com", []string{"a", "b"})
 	if !errors.Is(err, registrar.ErrDomainNotInAccount) {
@@ -122,16 +176,42 @@ func TestSetNameserversDomainNotFound(t *testing.T) {
 	}
 }
 
+// TestSetNameserversNeedsGlueRegistration — real-world Dynadot error
+// (issue #900) when set_ns references an out-of-bailiwick NS hostname
+// that hasn't been pre-registered. The wrapper-bug-fixed adapter must
+// now correctly surface this non-success; pre-fix this would have
+// silently zeroed out and returned nil, masking the failure.
+func TestSetNameserversNeedsGlueRegistration(t *testing.T) {
+	a, _ := newTestAdapter(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"SetNsResponse":{"ResponseCode":"-1","Status":"error","Error":"'ns1.otech103.omani.works' needs to be registered with an ip address before it can be used."}}`))
+	})
+	err := a.SetNameservers(context.Background(), "k:s", "x.com", []string{"ns1.otech103.omani.works", "ns2.otech103.omani.works"})
+	if err == nil {
+		t.Fatal("expected error for needs-glue-registration response")
+	}
+	if !strings.Contains(err.Error(), "needs to be registered") {
+		t.Fatalf("err = %v, expected to surface registrar's needs-glue message", err)
+	}
+}
+
+// ── GetNameservers ───────────────────────────────────────────────────────
+
+// TestGetNameserversHappy — real Dynadot domain_info success shape
+// (verified live 2026-05-05 against omani.works): ResponseCode is INT 0
+// at TOP of DomainInfoResponse, ServerId+ServerName per NameServers
+// entry, no ResponseHeader wrapper.
 func TestGetNameserversHappy(t *testing.T) {
 	a, _ := newTestAdapter(t, func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintln(w, `{
 		  "DomainInfoResponse": {
-		    "ResponseHeader": {"ResponseCode":"0","Status":"success"},
+		    "ResponseCode": 0,
+		    "Status": "success",
 		    "DomainInfo": {
 		      "NameServerSettings": {
+		        "Type": "Name Servers",
 		        "NameServers": [
-		          {"ServerName":"ns1.openova.io"},
-		          {"ServerName":"ns2.openova.io"}
+		          {"ServerId":"5262350","ServerName":"ns1.openova.io"},
+		          {"ServerId":"5262351","ServerName":"ns2.openova.io"}
 		        ]
 		      }
 		    }
@@ -161,11 +241,10 @@ func TestNewAdapterDefaults(t *testing.T) {
 
 // ── Glue-record path (issue #900) ───────────────────────────────────────
 //
-// These tests cover the new register_ns / get_ns / set_ns_ip surface the
-// adapter exposes via the registrar.GlueRegistrar interface. Each test
-// drives the adapter against an httptest server that asserts the
-// expected Dynadot api3.json command + parameters and replies with a
-// canned api3.json response.
+// All fixtures below use the REAL Dynadot api3.json envelope shape
+// (status fields directly under <Command>Response, no ResponseHeader
+// wrapper). These tests cover the new register_ns / get_ns / set_ns_ip
+// surface the adapter exposes via the registrar.GlueRegistrar interface.
 //
 // The flow under test:
 //
@@ -175,9 +254,9 @@ func TestNewAdapterDefaults(t *testing.T) {
 //      IP, falls through to set_ns_ip on different IP, register_ns when
 //      not yet registered.
 
-// TestGetGlueRecordHappy — Dynadot returns the registered IP for a
-// known host. Must be returned as the first non-empty entry of the IP
-// array (Dynadot's get_ns response carries IP as a list).
+// TestGetGlueRecordHappy — real Dynadot get_ns success shape: status
+// fields directly under GetNsResponse (no ResponseHeader wrapper, see
+// #939). ResponseCode is INT 0 on success.
 func TestGetGlueRecordHappy(t *testing.T) {
 	a, _ := newTestAdapter(t, func(w http.ResponseWriter, r *http.Request) {
 		if got := r.URL.Query().Get("command"); got != "get_ns" {
@@ -188,7 +267,8 @@ func TestGetGlueRecordHappy(t *testing.T) {
 		}
 		fmt.Fprintln(w, `{
 		  "GetNsResponse": {
-		    "ResponseHeader": {"ResponseCode":"0","Status":"success"},
+		    "ResponseCode": 0,
+		    "Status": "success",
 		    "NsInfo": {"NameServer": {"Host":"ns1.otech103.omani.works", "IP":["203.0.113.42"]}}
 		  }
 		}`)
@@ -208,8 +288,10 @@ func TestGetGlueRecordHappy(t *testing.T) {
 // from "API failed".
 func TestGetGlueRecordNotRegistered(t *testing.T) {
 	a, _ := newTestAdapter(t, func(w http.ResponseWriter, r *http.Request) {
+		// Real Dynadot error shape (string code "-1" at top of
+		// GetNsResponse, no ResponseHeader wrapper — see #939).
 		fmt.Fprintln(w, `{
-		  "GetNsResponse": {"ResponseHeader": {"ResponseCode":"-1","Status":"error","Error":"Name server not found"}}
+		  "GetNsResponse": {"ResponseCode":"-1","Status":"error","Error":"Name server not found"}
 		}`)
 	})
 	got, err := a.GetGlueRecord(context.Background(), "k:s", "ns1.otech999.omani.works")
@@ -242,11 +324,11 @@ func TestRegisterGlueRecordFreshHost(t *testing.T) {
 		cmd := r.URL.Query().Get("command")
 		switch calls {
 		case 1:
-			// Probe — not registered.
+			// Probe — not registered. Real Dynadot error shape.
 			if cmd != "get_ns" {
 				t.Errorf("call 1: command = %q, want get_ns", cmd)
 			}
-			fmt.Fprintln(w, `{"GetNsResponse":{"ResponseHeader":{"ResponseCode":"-1","Status":"error","Error":"Name server not found"}}}`)
+			fmt.Fprintln(w, `{"GetNsResponse":{"ResponseCode":"-1","Status":"error","Error":"Name server not found"}}`)
 		case 2:
 			// Register with the supplied IP.
 			if cmd != "register_ns" {
@@ -258,7 +340,9 @@ func TestRegisterGlueRecordFreshHost(t *testing.T) {
 			if got := r.URL.Query().Get("ip0"); got != "203.0.113.42" {
 				t.Errorf("ip0 = %q, want 203.0.113.42", got)
 			}
-			fmt.Fprintln(w, `{"RegisterNsResponse":{"ResponseHeader":{"ResponseCode":"0","Status":"success"}}}`)
+			// register_ns success — real Dynadot shape: code+status at
+			// top of RegisterNsResponse (no wrapper).
+			fmt.Fprintln(w, `{"RegisterNsResponse":{"ResponseCode":0,"Status":"success"}}`)
 		default:
 			t.Errorf("unexpected call %d (cmd=%s)", calls, cmd)
 		}
@@ -286,9 +370,12 @@ func TestRegisterGlueRecordIdempotent(t *testing.T) {
 		if cmd != "get_ns" {
 			t.Errorf("command = %q, want get_ns", cmd)
 		}
+		// Real Dynadot get_ns success — code+status at top of
+		// GetNsResponse (no ResponseHeader wrapper, see #939).
 		fmt.Fprintln(w, `{
 		  "GetNsResponse": {
-		    "ResponseHeader": {"ResponseCode":"0","Status":"success"},
+		    "ResponseCode": 0,
+		    "Status": "success",
 		    "NsInfo": {"NameServer": {"Host":"ns1.otech103.omani.works", "IP":["203.0.113.42"]}}
 		  }
 		}`)
@@ -314,9 +401,11 @@ func TestRegisterGlueRecordIPChanged(t *testing.T) {
 			if cmd != "get_ns" {
 				t.Errorf("call 1: command = %q, want get_ns", cmd)
 			}
+			// Real Dynadot get_ns shape — top-level code+status, no wrapper.
 			fmt.Fprintln(w, `{
 			  "GetNsResponse": {
-			    "ResponseHeader": {"ResponseCode":"0","Status":"success"},
+			    "ResponseCode": 0,
+			    "Status": "success",
 			    "NsInfo": {"NameServer": {"Host":"ns1.otech103.omani.works", "IP":["198.51.100.7"]}}
 			  }
 			}`)
@@ -330,7 +419,9 @@ func TestRegisterGlueRecordIPChanged(t *testing.T) {
 			if got := r.URL.Query().Get("ip0"); got != "203.0.113.42" {
 				t.Errorf("ip0 = %q, want 203.0.113.42", got)
 			}
-			fmt.Fprintln(w, `{"SetNsIpResponse":{"ResponseHeader":{"ResponseCode":"0","Status":"success"}}}`)
+			// set_ns_ip success — real Dynadot shape: code+status at top
+			// of SetNsIpResponse (no wrapper).
+			fmt.Fprintln(w, `{"SetNsIpResponse":{"ResponseCode":0,"Status":"success"}}`)
 		default:
 			t.Errorf("unexpected call %d (cmd=%s)", calls, cmd)
 		}
@@ -357,7 +448,7 @@ func TestRegisterGlueRecordRateLimitedDuringRegister(t *testing.T) {
 			if cmd != "get_ns" {
 				t.Errorf("call 1: command = %q, want get_ns", cmd)
 			}
-			fmt.Fprintln(w, `{"GetNsResponse":{"ResponseHeader":{"ResponseCode":"-1","Status":"error","Error":"Name server not found"}}}`)
+			fmt.Fprintln(w, `{"GetNsResponse":{"ResponseCode":"-1","Status":"error","Error":"Name server not found"}}`)
 		case 2:
 			if cmd != "register_ns" {
 				t.Errorf("call 2: command = %q, want register_ns", cmd)
@@ -391,8 +482,8 @@ func TestRegisterGlueRecordValidation(t *testing.T) {
 func TestRegisterGlueRecordBadToken(t *testing.T) {
 	a, _ := newTestAdapter(t, func(w http.ResponseWriter, r *http.Request) {
 		// get_ns probe is allowed (returns not-found) BEFORE the token
-		// parse for the set_ns_ip / register_ns path.
-		fmt.Fprintln(w, `{"GetNsResponse":{"ResponseHeader":{"ResponseCode":"-1","Status":"error","Error":"Name server not found"}}}`)
+		// parse for the set_ns_ip / register_ns path. Real Dynadot shape.
+		fmt.Fprintln(w, `{"GetNsResponse":{"ResponseCode":"-1","Status":"error","Error":"Name server not found"}}`)
 	})
 	err := a.RegisterGlueRecord(context.Background(), "no-colon", "ns1.x.com", "1.2.3.4")
 	if !errors.Is(err, registrar.ErrInvalidToken) {

--- a/products/catalyst/bootstrap/api/internal/dynadot/dynadot.go
+++ b/products/catalyst/bootstrap/api/internal/dynadot/dynadot.go
@@ -107,22 +107,27 @@ func (c *Client) AddRecord(ctx context.Context, domain string, rec Record) error
 		return fmt.Errorf("dynadot api status %d: %s", resp.StatusCode, string(body))
 	}
 
+	// Dynadot api3.json set_dns2 reply (verified live 2026-05-05): the
+	// status fields live DIRECTLY under SetDnsResponse, with no
+	// `ResponseHeader` wrapper. ResponseCode is JSON-typed `int` on
+	// success and `string` on error — json.Number accepts both. The
+	// previous wrapper-based decode silently produced an empty header
+	// and treated every real reply as a fall-through error. Refs #939.
 	var result struct {
-		SetDNS2Response struct {
-			ResponseHeader struct {
-				ResponseCode string `json:"ResponseCode"`
-				Status       string `json:"Status"`
-				Error        string `json:"Error"`
-			} `json:"ResponseHeader"`
-		} `json:"SetDns2Response"`
+		SetDNSResponse struct {
+			ResponseCode json.Number `json:"ResponseCode"`
+			Status       string      `json:"Status"`
+			Error        string      `json:"Error"`
+		} `json:"SetDnsResponse"`
 	}
 	if err := json.Unmarshal(body, &result); err != nil {
 		// Dynadot sometimes returns plaintext for errors; surface raw body.
 		return fmt.Errorf("parse dynadot response: %w (body=%s)", err, truncate(string(body), 256))
 	}
-	hdr := result.SetDNS2Response.ResponseHeader
-	if !strings.EqualFold(hdr.Status, "success") && !strings.EqualFold(hdr.ResponseCode, "0") {
-		return fmt.Errorf("dynadot api error: code=%s status=%s err=%s", hdr.ResponseCode, hdr.Status, hdr.Error)
+	hdr := result.SetDNSResponse
+	codeStr := strings.TrimSpace(hdr.ResponseCode.String())
+	if !strings.EqualFold(hdr.Status, "success") && codeStr != "0" && codeStr != "" {
+		return fmt.Errorf("dynadot api error: code=%s status=%s err=%s", hdr.ResponseCode.String(), hdr.Status, hdr.Error)
 	}
 	return nil
 }

--- a/products/catalyst/bootstrap/api/internal/dynadot/dynadot_test.go
+++ b/products/catalyst/bootstrap/api/internal/dynadot/dynadot_test.go
@@ -91,7 +91,11 @@ func newDynadotFakeServer() (*httptest.Server, *dynadotFakeServer) {
 		responder := f.responder
 		f.mu.Unlock()
 
-		status, body := http.StatusOK, `{"SetDns2Response":{"ResponseHeader":{"ResponseCode":"0","Status":"success"}}}`
+		// Real Dynadot api3.json `set_dns2` success envelope: status
+		// fields directly under SetDnsResponse (not SetDns2Response, and
+		// no `ResponseHeader` wrapper). Verified live 2026-05-05. See
+		// issue #939.
+		status, body := http.StatusOK, `{"SetDnsResponse":{"ResponseCode":0,"Status":"success"}}`
 		if responder != nil {
 			status, body = responder(rr)
 		}
@@ -343,14 +347,14 @@ func TestAddRecord_DynadotErrorIsSurfacedAsGoError(t *testing.T) {
 	srv, fake := newDynadotFakeServer()
 	defer srv.Close()
 	fake.setResponder(func(rr recordedRequest) (int, string) {
-		// Dynadot's actual error envelope shape — code = -1, error = string.
+		// Real Dynadot error envelope: code "-1" string, status="error",
+		// fields DIRECTLY under SetDnsResponse (no ResponseHeader
+		// wrapper, no SetDns2Response key — see #939).
 		body, _ := json.Marshal(map[string]any{
-			"SetDns2Response": map[string]any{
-				"ResponseHeader": map[string]any{
-					"ResponseCode": "-1",
-					"Status":       "failed",
-					"Error":        "domain not found in account",
-				},
+			"SetDnsResponse": map[string]any{
+				"ResponseCode": "-1",
+				"Status":       "failed",
+				"Error":        "domain not found in account",
 			},
 		})
 		return http.StatusOK, string(body)
@@ -400,18 +404,19 @@ func TestAddSovereignRecords_FailsFastOnFirstError(t *testing.T) {
 		current := count
 		mu.Unlock()
 		if current == 1 {
+			// Real Dynadot error envelope (see #939): code+status at
+			// top of SetDnsResponse, no ResponseHeader wrapper.
 			body, _ := json.Marshal(map[string]any{
-				"SetDns2Response": map[string]any{
-					"ResponseHeader": map[string]any{
-						"ResponseCode": "-2",
-						"Status":       "failed",
-						"Error":        "rate limited",
-					},
+				"SetDnsResponse": map[string]any{
+					"ResponseCode": "-2",
+					"Status":       "failed",
+					"Error":        "rate limited",
 				},
 			})
 			return http.StatusOK, string(body)
 		}
-		return http.StatusOK, `{"SetDns2Response":{"ResponseHeader":{"ResponseCode":"0","Status":"success"}}}`
+		// Real Dynadot success envelope (see #939).
+		return http.StatusOK, `{"SetDnsResponse":{"ResponseCode":0,"Status":"success"}}`
 	})
 
 	c := newClientPointingAt(srv.URL, "k", "s")


### PR DESCRIPTION
Closes #939.

## Root cause

Every Dynadot adapter command path in `core/pool-domain-manager/internal/registrar/dynadot/dynadot.go` (and its sibling clients in `core/pkg/dynadot-client` and `products/catalyst/bootstrap/api/internal/dynadot`) decoded api3.json responses against a fictional `<Command>Response.ResponseHeader.{ResponseCode,Status,Error}` shape. Dynadot's real envelope places those fields **DIRECTLY** under the command-named envelope, with no `ResponseHeader` sub-object.

Live capture against `api.dynadot.com/api3.json` 2026-05-05 (sanitised):

Success (`domain_info` against an account-owned domain):
```json
{"DomainInfoResponse":{
  "ResponseCode": 0,
  "Status": "success",
  "DomainInfo": {...}
}}
```

Error (`domain_info` against an unowned domain):
```json
{"DomainInfoResponse":{
  "ResponseCode": "-1",
  "Status": "error",
  "Error": "could not find domain in your account"
}}
```

Two surprises Dynadot gives us:
1. **No `ResponseHeader` wrapper** — the wrapper was a misread of the docs that propagated to every test fixture, masking the bug forever.
2. **`ResponseCode` is JSON int 0 on success but JSON string `"-1"` on error** — same field, different type per response.

The previous `respHeader{ResponseCode string}` decode silently produced an empty header on every real call (Status="", Code=""), which `classifyDynadotError` treated as a fall-through error → `unknown-error` → 500 to the caller. PDM's `ValidateToken` had been failing on every real production call since the adapter was written (#170).

## Fix

- Switched `respHeader.ResponseCode` to `json.Number` so both int and string forms round-trip; added `codeIsZero()` helper to normalise success comparison.
- Replaced the `<Cmd>Response{ResponseHeader respHeader}` shape with `<Cmd>Response{respHeader}` (anonymous embedded struct — fields flatten via `encoding/json`'s embedded-field rules) for all five command paths: ValidateToken, SetNameservers, GetNameservers, GetGlueRecord, RegisterGlueRecord (set_ns_ip + register_ns sub-paths).
- Tightened `classifyDynadotError` ordering so `"could not find domain in your account"` maps to `ErrDomainNotInAccount` BEFORE the auth matcher (which previously grabbed it on the substring `"auth"` was missing but `"key"` would have grabbed it).
- Aligned `core/pkg/dynadot-client` `GetDomainInfo` (the last sibling still using the wrapper).
- Aligned `products/catalyst/bootstrap/api/internal/dynadot` `AddRecord` (was decoding against the never-returned `SetDns2Response.ResponseHeader` shape; real key is `SetDnsResponse` with fields at top).

## Tests

All test fixtures rewritten to use real api3.json shapes (no `ResponseHeader`, int+string code forms). New regression coverage for:
- `ResponseCode=0` int with no `Status` field present (Dynadot has been observed to omit Status on success).
- `"could not find domain in your account"` → typed `ErrDomainNotInAccount`.
- `"needs to be registered with an ip address"` set_ns rejection — the issue #900 surface that was previously silently zeroed by the wrapper bug.

`go test ./...` green for all three affected modules:
- `core/pool-domain-manager` (24 dynadot subtests + full PDM suite)
- `core/pkg/dynadot-client`
- `products/catalyst/bootstrap/api/internal/dynadot`

## Live verification

End-to-end against the real Dynadot api3.json from this branch:

```
PASS ValidateToken(omani.works)  -> success
PASS ValidateToken(google.com)   -> dynadot api: could not find domain in your account: registrar: domain not in account
PASS GetNameservers(omani.works) -> [ns1.openova.io ns2.openova.io]
```

Refs #939, #170, #900, #825, openova-io/openova-private#138.

🤖 Generated with [Claude Code](https://claude.com/claude-code)