### PR TITLE
fix(bp-catalyst-platform+bp-newapi): unblock alice signup gates 2-6 on Sovereigns (#915)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -199,7 +199,20 @@ spec:
       # and (b) canonical key shape `smtp-user`/`smtp-pass` in addition
       # to the legacy `user`/`password` source key shape — the new
       # chart writes both shapes, this chart reads either.
-      version: 1.4.21
+      # 1.4.22 (#915 SME blockers): six chart + orchestrator fixes
+      # unblocking alice signup gates 2-6 on franchised Sovereigns —
+      # issues #934 (auth SMTP empty), #940 (provisioning placeholder
+      # GITHUB_TOKEN + hardcoded upstream github.com), #941 (catalog
+      # migrateAppDeployable missing openclaw + stalwart-mail), #942
+      # (REDPANDA_BROKERS hardcoded to talentmesh — switched to NATS
+      # JetStream on Sovereigns per ADR-0001), #943 (bp-newapi
+      # silently skipped Deployment — paired bp-newapi 1.4.0 auto-
+      # provisions CNPG cluster + credentials Secret), #944 (CRITICAL
+      # cross-cluster pollution — GIT_BASE_PATH was hardcoded to
+      # contabo-mkt; chart values now template per-Sovereign with
+      # provisioning-binary Go-side validation guard refusing commits
+      # to foreign cluster trees). 2026-05-05.
+      version: 1.4.22
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/clusters/_template/bootstrap-kit/80-newapi.yaml
+++ b/clusters/_template/bootstrap-kit/80-newapi.yaml
@@ -63,6 +63,15 @@ spec:
   chart:
     spec:
       chart: bp-newapi
+      # 1.4.0 (issue #943, 2026-05-05): auto-provision CNPG-backed
+      # Postgres + chart-emitted SESSION_SECRET/CRYPTO_SECRET so a
+      # Sovereign install lands a real Pod without operator intervention.
+      # Pre-#943 the Deployment silently skipped render whenever
+      # database.existingSecret OR credentials.existingSecret was
+      # empty (the bootstrap-kit overlay supplies neither), so NewAPI
+      # never came up and alice signup gate 5 (LLM) timed out. Both
+      # auto-provisions are capability-gated on bp-cnpg's CRD and
+      # operator-overridable per Inviolable Principle #4.
       # 1.3.0: defaultChannels.qwenBankDhofar (channel #1 = Qwen3.6 @
       # https://llm-api.omtd.bankdhofar.com) + post-install/post-upgrade
       # `channel-seed` Helm hook Job that idempotently POSTs default
@@ -70,7 +79,7 @@ spec:
       # integration DoD: alice → OpenClaw → NewAPI → Qwen3.6@BankDhofar
       # end-to-end).
       # 1.2.0: Traefik Middleware gated behind ingress.middleware.enabled.
-      version: 1.3.0
+      version: 1.4.0
       sourceRef:
         kind: HelmRepository
         name: bp-newapi

--- a/core/services/catalog/handlers/seed.go
+++ b/core/services/catalog/handlers/seed.go
@@ -565,21 +565,50 @@ func (h *Handler) migrateAppDependencies(ctx context.Context) {
 // (chatwoot → needs Redis, issue #100; listmonk → config.toml bug,
 // issue #101; rocket-chat → needs MongoDB backing service) are marked
 // NOT deployable until their fixes ship.
-func (h *Handler) migrateAppDeployable(ctx context.Context) {
-	deployable := map[string]bool{
-		"wordpress":    true,
-		"ghost":        true,
-		"nextcloud":    true,
-		"bookstack":    true,
-		"uptime-kuma":  true,
-		"gitea":        true,
-		"vaultwarden":  true,
-		"umami":        true,
-		"nocodb":       true,
-		"cal-com":      true,
-		"invoiceshelf": true,
-		"formbricks":   true,
-		"listmonk":     true, // fixed in #101 — DBEnvStyle:"listmonk" + InitCommand
+//
+// Issue #941 (2026-05-05): openclaw + stalwart-mail were missing here even
+// though both blueprints (bp-openclaw, bp-stalwart-sovereign) ship with
+// visibility=listed in products/catalyst/bootstrap/api/internal/catalog/
+// blueprints.json. The result on a fresh Sovereign was the marketplace UI
+// drawing a "COMING SOON" overlay on every "AI" + "Communication" card —
+// alice signup gates 4 (LLM) and 5 (mail) blocked before alice could click
+// Install. Both are SME-tenant-pipeline-installable per the per-tenant
+// overlay templates emitted by sme_tenant_gitops.go (bp-openclaw +
+// bp-stalwart-tenant HelmRelease emit), so they MUST appear as Available
+// to install. The marketplace shows the customer-app slug (`stalwart-mail`,
+// matching seedApps line 48) — bp-stalwart-sovereign is the Sovereign-side
+// realisation; bp-stalwart-tenant is the per-tenant one driven by the
+// SME-tenant orchestrator.
+// DeployableAppSlugs returns the canonical map of catalog app slugs the
+// SME provisioning service / SME-tenant orchestrator can install end to
+// end. Apps NOT in this map are flagged with Deployable=false on the
+// catalog rows so the marketplace UI overlays them with "COMING SOON"
+// per issue #102. The map is exported as a function so unit tests can
+// assert membership without invoking a Mongo store.
+//
+// Issue #941 (2026-05-05): added `openclaw` + `stalwart-mail` after
+// C5-final hit "27 apps COMING SOON" on otech113 — both blueprints
+// (bp-openclaw, bp-stalwart-{sovereign,tenant}) ship with visibility=
+// listed in the embedded blueprints.json AND have working SME-tenant
+// overlay templates in sme_tenant_gitops.go, but the catalog handler
+// silently filtered them out because they were missing here.
+func DeployableAppSlugs() map[string]bool {
+	return map[string]bool{
+		"wordpress":     true,
+		"ghost":         true,
+		"nextcloud":     true,
+		"bookstack":     true,
+		"uptime-kuma":   true,
+		"gitea":         true,
+		"vaultwarden":   true,
+		"umami":         true,
+		"nocodb":        true,
+		"cal-com":       true,
+		"invoiceshelf":  true,
+		"formbricks":    true,
+		"listmonk":      true, // fixed in #101 — DBEnvStyle:"listmonk" + InitCommand
+		"openclaw":      true, // #941 — bp-openclaw + bp-newapi via SME-tenant overlay
+		"stalwart-mail": true, // #941 — bp-stalwart-tenant via SME-tenant overlay
 		// Backing services are always deployable — they come bundled with
 		// whichever business app needs them. Marking them true so the
 		// catalog UI doesn't draw a 'Coming soon' overlay on them. #112.
@@ -587,6 +616,10 @@ func (h *Handler) migrateAppDeployable(ctx context.Context) {
 		"mysql":    true,
 		"redis":    true,
 	}
+}
+
+func (h *Handler) migrateAppDeployable(ctx context.Context) {
+	deployable := DeployableAppSlugs()
 	apps, err := h.Store.ListApps(ctx)
 	if err != nil {
 		slog.Error("seed: list apps for deployable migration", "error", err)

--- a/core/services/catalog/handlers/seed_test.go
+++ b/core/services/catalog/handlers/seed_test.go
@@ -1,0 +1,46 @@
+package handlers
+
+import "testing"
+
+// TestDeployableAppSlugs_Issue941 asserts that openclaw + stalwart-mail
+// are present in the deployable map (issue #941). C5-final hit "27 apps
+// COMING SOON" on otech113 because both were missing — gates 4 (LLM)
+// and 5 (mail) blocked before alice could click Install.
+func TestDeployableAppSlugs_Issue941(t *testing.T) {
+	d := DeployableAppSlugs()
+	wantTrue := []string{
+		"openclaw",      // #941 — bp-openclaw via SME-tenant overlay
+		"stalwart-mail", // #941 — bp-stalwart-tenant via SME-tenant overlay
+		// Sanity — the canonical alice baseline apps.
+		"wordpress",
+		"ghost",
+		"nextcloud",
+	}
+	for _, slug := range wantTrue {
+		if !d[slug] {
+			t.Errorf("expected %q to be deployable, got false (or missing)", slug)
+		}
+	}
+}
+
+// TestDeployableAppSlugs_StableShape locks the map's exported keys so a
+// rename (or accidental delete) of a deployable slug fails the test
+// instead of silently flipping a marketplace card to COMING SOON.
+func TestDeployableAppSlugs_StableShape(t *testing.T) {
+	d := DeployableAppSlugs()
+	expected := []string{
+		"wordpress", "ghost", "nextcloud", "bookstack", "uptime-kuma",
+		"gitea", "vaultwarden", "umami", "nocodb", "cal-com",
+		"invoiceshelf", "formbricks", "listmonk",
+		"openclaw", "stalwart-mail",
+		"postgres", "mysql", "redis",
+	}
+	if got, want := len(d), len(expected); got != want {
+		t.Errorf("deployable map size = %d, want %d", got, want)
+	}
+	for _, slug := range expected {
+		if _, ok := d[slug]; !ok {
+			t.Errorf("expected %q in deployable map, missing", slug)
+		}
+	}
+}

--- a/core/services/provisioning/gitguard/gitguard.go
+++ b/core/services/provisioning/gitguard/gitguard.go
@@ -1,0 +1,124 @@
+// Package gitguard centralises the cross-cluster pollution guard that
+// keeps the SME provisioning service from committing per-tenant overlays
+// into a foreign cluster's clusters/<fqdn>/ tree (issue #944).
+//
+// Background:
+//
+//	The provisioning service runs on Catalyst-Zero (contabo) AND on
+//	every franchised Sovereign that flips MARKETPLACE_ENABLED=true.
+//	On contabo the canonical write target is
+//	`clusters/contabo-mkt/tenants/...`. On a Sovereign it is
+//	`clusters/<sovereign-fqdn>/sme-tenants/...`. Pre-#944 the
+//	GIT_BASE_PATH env defaulted to the contabo path EVERYWHERE — so a
+//	Sovereign-side provisioning Pod committed alice's tenant overlay
+//	to upstream openova/openova `clusters/contabo-mkt/tenants/<id>/`,
+//	which the contabo Flux Kustomization would then install on the
+//	contabo cluster. C5-final caught + reverted the alice2 incident
+//	at commit 5715db04 (2026-05-05) — without #944 it would have
+//	repeated on every alice retry.
+//
+// The validator runs in TWO places:
+//
+//  1. main.go startup, before the HTTP listener starts: a misconfigured
+//     env crashes the Pod into Pending so the operator notices via a
+//     normal kubectl status read.
+//
+//  2. handlers.Handler.VerifyCommitTargetSafe, which every code path
+//     that reaches GitHubClient.CommitFiles* MUST invoke before the
+//     commit. Defence in depth — runtime mutations (kubectl exec env
+//     change, ConfigMap update without Pod restart, an OTECHFQDN
+//     resolution that does not share the configured prefix) can not
+//     bypass the startup check.
+//
+// Per Inviolable Principle #4 the configured base path AND the live
+// SOVEREIGN_FQDN are env-driven; the validator never reads from os.Getenv
+// itself so unit tests stay deterministic.
+package gitguard
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// ValidateBasePath enforces the cross-cluster pollution guard from
+// issue #944. On Sovereigns the only legitimate write target is
+// `clusters/<SOVEREIGN_FQDN>/sme-tenants[...]/`. Anything else (e.g.
+// `clusters/contabo-mkt/tenants/`, `clusters/otechN.omani.works/...`
+// from a stale per-Sovereign overlay) would route the per-tenant
+// commit at a foreign cluster's tree.
+//
+// Catalyst-Zero (contabo) runs with sovereignFQDN unset and the legacy
+// path `clusters/contabo-mkt/tenants` is canonical there; the guard
+// recognises that case as the only allowed empty-FQDN path.
+//
+// Returns nil if the path is safe; a descriptive error otherwise.
+// Callers fail loud at startup AND before every git commit so a
+// runtime env mutation cannot bypass the check.
+func ValidateBasePath(gitBasePath, sovereignFQDN string) error {
+	if gitBasePath == "" {
+		return errors.New("GIT_BASE_PATH must be set")
+	}
+	clean := strings.TrimSuffix(gitBasePath, "/")
+	// Disallow obvious traversal — neither `..` nor absolute paths are
+	// ever valid for this env.
+	if strings.HasPrefix(clean, "/") || strings.Contains(clean, "..") {
+		return fmt.Errorf("GIT_BASE_PATH must be a repo-relative path under clusters/, got %q", gitBasePath)
+	}
+	if !strings.HasPrefix(clean, "clusters/") {
+		return fmt.Errorf("GIT_BASE_PATH must start with clusters/, got %q", gitBasePath)
+	}
+	if sovereignFQDN == "" {
+		// Catalyst-Zero (contabo). The only legitimate path is the
+		// canonical contabo-mkt prefix; anything else (especially a
+		// stale otechN per-Sovereign overlay leaking into a contabo
+		// install) is rejected.
+		const contaboPrefix = "clusters/contabo-mkt/"
+		if !strings.HasPrefix(clean, contaboPrefix) {
+			return fmt.Errorf(
+				"GIT_BASE_PATH on Catalyst-Zero (SOVEREIGN_FQDN unset) must start with %q, got %q — refusing to commit to a foreign cluster's tree",
+				contaboPrefix, gitBasePath,
+			)
+		}
+		return nil
+	}
+	wantPrefix := "clusters/" + sovereignFQDN + "/"
+	if !strings.HasPrefix(clean, wantPrefix) {
+		return fmt.Errorf(
+			"GIT_BASE_PATH must start with %q on this Sovereign, got %q — refusing to commit to a foreign cluster's tree (issue #944 cross-cluster pollution guard)",
+			wantPrefix, gitBasePath,
+		)
+	}
+	return nil
+}
+
+// PlaceholderTokenSubstrings are byte sequences a Helm-templated /
+// hand-rolled placeholder Secret might carry that we MUST refuse at
+// startup rather than silently accept (issue #940). Empty token already
+// trips an explicit warn-and-continue path in main.go; this list catches
+// the literal placeholder strings the chart historically shipped.
+var PlaceholderTokenSubstrings = []string{
+	"<placeholder>",
+	"<changeme>",
+	"<change-me>",
+	"PLACEHOLDER",
+	"REPLACE_ME",
+	"REPLACEME",
+}
+
+// ValidateGitHubToken rejects placeholder Secret bytes at startup
+// (issue #940). Returns nil for empty token (handled by an explicit
+// warn-and-continue path in main.go) so behaviour stays compatible
+// with existing contabo paths that may legitimately run without a
+// token (read-only deployments).
+func ValidateGitHubToken(token string) error {
+	if token == "" {
+		return nil
+	}
+	for _, marker := range PlaceholderTokenSubstrings {
+		if strings.Contains(token, marker) {
+			return fmt.Errorf("GITHUB_TOKEN looks like a placeholder (matches %q) — refusing to start. Provision the real token via the chart's provisioning-github-token Secret seam (issue #940)", marker)
+		}
+	}
+	return nil
+}

--- a/core/services/provisioning/gitguard/gitguard_test.go
+++ b/core/services/provisioning/gitguard/gitguard_test.go
@@ -1,0 +1,150 @@
+package gitguard
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateBasePath_Sovereign(t *testing.T) {
+	cases := []struct {
+		name     string
+		path     string
+		fqdn     string
+		wantErr  bool
+		errMatch string
+	}{
+		{
+			name: "ok — canonical sovereign path",
+			path: "clusters/otech113.omani.works/sme-tenants",
+			fqdn: "otech113.omani.works",
+		},
+		{
+			name: "ok — sovereign path with trailing slash",
+			path: "clusters/otech113.omani.works/sme-tenants/",
+			fqdn: "otech113.omani.works",
+		},
+		{
+			name: "ok — sovereign path with subdir",
+			path: "clusters/otech113.omani.works/sme-tenants/alice",
+			fqdn: "otech113.omani.works",
+		},
+		{
+			name:     "reject — contabo path on Sovereign (the alice2 incident)",
+			path:     "clusters/contabo-mkt/tenants",
+			fqdn:     "otech113.omani.works",
+			wantErr:  true,
+			errMatch: "refusing to commit to a foreign cluster",
+		},
+		{
+			name:     "reject — different sovereign FQDN",
+			path:     "clusters/otechZ.omani.works/sme-tenants",
+			fqdn:     "otech113.omani.works",
+			wantErr:  true,
+			errMatch: "refusing to commit to a foreign cluster",
+		},
+		{
+			name:     "reject — empty path",
+			path:     "",
+			fqdn:     "otech113.omani.works",
+			wantErr:  true,
+			errMatch: "must be set",
+		},
+		{
+			name:     "reject — absolute path",
+			path:     "/clusters/otech113.omani.works/sme-tenants",
+			fqdn:     "otech113.omani.works",
+			wantErr:  true,
+			errMatch: "repo-relative",
+		},
+		{
+			name:     "reject — path traversal",
+			path:     "clusters/otech113.omani.works/../contabo-mkt/tenants",
+			fqdn:     "otech113.omani.works",
+			wantErr:  true,
+			errMatch: "repo-relative",
+		},
+		{
+			name:     "reject — outside clusters/",
+			path:     "products/catalyst",
+			fqdn:     "otech113.omani.works",
+			wantErr:  true,
+			errMatch: "must start with clusters/",
+		},
+		{
+			name:     "reject — prefix-collision (e.g. otech113-evil.omani.works)",
+			path:     "clusters/otech113-evil.omani.works/sme-tenants",
+			fqdn:     "otech113.omani.works",
+			wantErr:  true,
+			errMatch: "refusing to commit to a foreign cluster",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateBasePath(tc.path, tc.fqdn)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil for path=%q fqdn=%q", tc.path, tc.fqdn)
+				}
+				if tc.errMatch != "" && !strings.Contains(err.Error(), tc.errMatch) {
+					t.Fatalf("error %q does not contain %q", err.Error(), tc.errMatch)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error for path=%q fqdn=%q: %v", tc.path, tc.fqdn, err)
+			}
+		})
+	}
+}
+
+func TestValidateBasePath_CatalystZero(t *testing.T) {
+	cases := []struct {
+		name    string
+		path    string
+		wantErr bool
+	}{
+		{name: "ok — canonical contabo path", path: "clusters/contabo-mkt/tenants"},
+		{name: "ok — contabo path with subdir", path: "clusters/contabo-mkt/tenants/alice"},
+		{name: "reject — Sovereign-shaped path on contabo", path: "clusters/otech113.omani.works/sme-tenants", wantErr: true},
+		{name: "reject — non-clusters/ path", path: "products/catalyst", wantErr: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateBasePath(tc.path, "")
+			if tc.wantErr && err == nil {
+				t.Fatalf("expected error, got nil for path=%q", tc.path)
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("unexpected error for path=%q: %v", tc.path, err)
+			}
+		})
+	}
+}
+
+func TestValidateGitHubToken(t *testing.T) {
+	cases := []struct {
+		name    string
+		token   string
+		wantErr bool
+	}{
+		{name: "ok — empty (warn-and-continue path)", token: ""},
+		{name: "ok — real-looking PAT", token: "ghp_aBcDeFgHiJkLmNoPqRsTuVwXyZ1234567890ab"},
+		{name: "ok — gitea token shape", token: "5e3f8b6e1234567890abcdef1234567890abcdef"},
+		{name: "reject — <placeholder>", token: "<placeholder>", wantErr: true},
+		{name: "reject — <changeme>", token: "<changeme>", wantErr: true},
+		{name: "reject — PLACEHOLDER substring", token: "secret-PLACEHOLDER-here", wantErr: true},
+		{name: "reject — REPLACE_ME substring", token: "REPLACE_ME_BEFORE_PROD", wantErr: true},
+		{name: "reject — REPLACEME substring", token: "tokenREPLACEME123", wantErr: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateGitHubToken(tc.token)
+			if tc.wantErr && err == nil {
+				t.Fatalf("expected error, got nil for token %q", tc.token)
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("unexpected error for token: %v", err)
+			}
+		})
+	}
+}

--- a/core/services/provisioning/github/client.go
+++ b/core/services/provisioning/github/client.go
@@ -12,16 +12,37 @@ import (
 	"time"
 )
 
-// Client provides methods to commit files to a GitHub repository via the Git Data API.
+// Client provides methods to commit files to a GitHub repository via the
+// Git Data API. The API base URL is configurable so the client can target
+// either upstream github.com (the contabo path) or a local Gitea REST API
+// running inside a Sovereign cluster (the issue #940 fix path).
+//
+// Gitea exposes a GitHub-compatible Git Data API at /api/v1 (the same
+// shape this client already uses). The only difference is the base URL —
+// `https://api.github.com` vs e.g.
+// `http://gitea-http.gitea.svc.cluster.local:3000/api/v1`. apiURL on the
+// client struct lets a caller override the prefix without re-implementing
+// the whole client.
 type Client struct {
-	Token string
-	Owner string
-	Repo  string
+	Token  string
+	Owner  string
+	Repo   string
+	APIURL string // optional — defaults to https://api.github.com when empty.
 }
 
-// NewClient creates a GitHub API client.
+// NewClient creates a GitHub API client targeting upstream github.com.
+// Use NewClientWithAPIURL when targeting a Gitea-compatible REST API on
+// a Sovereign cluster.
 func NewClient(token, owner, repo string) *Client {
 	return &Client{Token: token, Owner: owner, Repo: repo}
+}
+
+// NewClientWithAPIURL creates a Git Data API client with a custom base
+// URL — used to target an in-cluster Gitea on Sovereigns (issue #940).
+// Pass apiURL="" or apiURL="https://api.github.com" to fall back to the
+// canonical upstream endpoint.
+func NewClientWithAPIURL(token, owner, repo, apiURL string) *Client {
+	return &Client{Token: token, Owner: owner, Repo: repo, APIURL: strings.TrimRight(apiURL, "/")}
 }
 
 // commitAttemptsMax is how many times CommitFilesWithPrune retries a full
@@ -243,7 +264,11 @@ func (t treeEntry) MarshalJSON() ([]byte, error) {
 }
 
 func (c *Client) apiURL(path string) string {
-	return fmt.Sprintf("https://api.github.com/repos/%s/%s%s", c.Owner, c.Repo, path)
+	base := c.APIURL
+	if base == "" {
+		base = "https://api.github.com"
+	}
+	return fmt.Sprintf("%s/repos/%s/%s%s", base, c.Owner, c.Repo, path)
 }
 
 func (c *Client) doRequest(ctx context.Context, method, url string, body any) ([]byte, error) {

--- a/core/services/provisioning/handlers/consumer.go
+++ b/core/services/provisioning/handlers/consumer.go
@@ -395,9 +395,20 @@ func (h *Handler) applyTenantChange(ctx context.Context, data appChangeData, act
 	tenantDir := h.Generator.TenantDir(data.TenantSlug) + "/"
 	prunePrefixes := []string{tenantDir}
 
+	// Issue #944 cross-cluster pollution guard — defence in depth on top
+	// of main.go's startup validation. Refuses to commit into a foreign
+	// cluster's tree even if a runtime env mutation slipped past startup.
+	if err := h.VerifyCommitTargetSafe(tenantDir); err != nil {
+		return fmt.Errorf("commit guard: %w", err)
+	}
+
+	branch := h.GitBranch
+	if branch == "" {
+		branch = "main"
+	}
 	commitMsg := fmt.Sprintf("day-2: %s %s on tenant %s (apps: %d)",
 		action, data.AppSlug, data.TenantSlug, len(appSlugs))
-	if err := h.GitHubClient.CommitFilesWithPrune(ctx, "main", commitMsg, manifests, prunePrefixes); err != nil {
+	if err := h.GitHubClient.CommitFilesWithPrune(ctx, branch, commitMsg, manifests, prunePrefixes); err != nil {
 		return fmt.Errorf("commit: %w", err)
 	}
 	slog.Info("day-2: committed tenant manifests",
@@ -406,12 +417,17 @@ func (h *Handler) applyTenantChange(ctx context.Context, data appChangeData, act
 }
 
 // readExistingDBPassword tries db-postgres.yaml then db-mysql.yaml from the
-// tenant's apps/ dir on main. Returns "" if neither file exists (first-time DB
-// install) or the password couldn't be parsed.
+// tenant's apps/ dir on the configured branch (default "main"). Returns ""
+// if neither file exists (first-time DB install) or the password couldn't
+// be parsed.
 func (h *Handler) readExistingDBPassword(ctx context.Context, tenantSlug string) string {
 	dir := h.Generator.TenantDir(tenantSlug) + "/apps"
+	branch := h.GitBranch
+	if branch == "" {
+		branch = "main"
+	}
 	for _, name := range []string{"db-postgres.yaml", "db-mysql.yaml"} {
-		content, err := h.GitHubClient.ReadFile(ctx, "main", dir+"/"+name)
+		content, err := h.GitHubClient.ReadFile(ctx, branch, dir+"/"+name)
 		if err != nil {
 			continue
 		}
@@ -542,14 +558,24 @@ func (h *Handler) handleTenantDeleted(ctx context.Context, event *events.Event) 
 	tenantDir := h.Generator.TenantDir(data.Slug) + "/"
 	parentPath := h.Generator.BasePath + "/kustomization.yaml"
 
-	currentParent, readErr := h.GitHubClient.ReadFile(ctx, "main", parentPath)
+	// Issue #944 cross-cluster pollution guard.
+	if err := h.VerifyCommitTargetSafe(tenantDir); err != nil {
+		return fmt.Errorf("teardown: commit guard: %w", err)
+	}
+
+	branch := h.GitBranch
+	if branch == "" {
+		branch = "main"
+	}
+
+	currentParent, readErr := h.GitHubClient.ReadFile(ctx, branch, parentPath)
 	files := map[string]string{}
 	if readErr == nil {
 		files[parentPath] = gitops.RemoveTenantFromParentKustomization(currentParent, data.Slug)
 	}
 
 	commitMsg := fmt.Sprintf("teardown: delete tenant %s", data.Slug)
-	if err := h.GitHubClient.CommitFilesWithPrune(ctx, "main", commitMsg, files, []string{tenantDir}); err != nil {
+	if err := h.GitHubClient.CommitFilesWithPrune(ctx, branch, commitMsg, files, []string{tenantDir}); err != nil {
 		slog.Error("teardown: commit/prune failed", "slug", data.Slug, "error", err)
 		return err
 	}
@@ -883,7 +909,27 @@ func (h *Handler) runProvisioningWorkflow(provisionID, tenantID, subdomain, plan
 	}
 
 	parentKustomPath := h.Generator.BasePath + "/kustomization.yaml"
-	currentParentKustom, readErr := h.GitHubClient.ReadFile(ctx, "main", parentKustomPath)
+
+	// Issue #944 cross-cluster pollution guard. Validate the parent
+	// kustomization path AND the per-tenant subdir live under the
+	// configured GIT_BASE_PATH before any commit lands.
+	if err := h.VerifyCommitTargetSafe(parentKustomPath); err != nil {
+		slog.Error("commit guard rejected provision target", "provision_id", provisionID, "path", parentKustomPath, "error", err)
+		h.failProvision(ctx, provisionID, tenantID, stepIdx, fmt.Sprintf("commit guard: %s", err))
+		return
+	}
+	if err := h.VerifyCommitTargetSafe(h.Generator.TenantDir(subdomain) + "/"); err != nil {
+		slog.Error("commit guard rejected tenant target", "provision_id", provisionID, "tenant", subdomain, "error", err)
+		h.failProvision(ctx, provisionID, tenantID, stepIdx, fmt.Sprintf("commit guard: %s", err))
+		return
+	}
+
+	branch := h.GitBranch
+	if branch == "" {
+		branch = "main"
+	}
+
+	currentParentKustom, readErr := h.GitHubClient.ReadFile(ctx, branch, parentKustomPath)
 	if readErr != nil {
 		slog.Warn("could not read parent kustomization, using empty", "error", readErr)
 		currentParentKustom = "apiVersion: kustomize.config.k8s.io/v1beta1\nkind: Kustomization\nresources: []\n"
@@ -891,7 +937,7 @@ func (h *Handler) runProvisioningWorkflow(provisionID, tenantID, subdomain, plan
 	manifests[parentKustomPath] = gitops.UpdateParentKustomization(currentParentKustom, subdomain)
 
 	commitMsg := fmt.Sprintf("provision: deploy tenant %s (plan: %s, apps: %d)", subdomain, planSlug, len(appSlugs))
-	if err := h.GitHubClient.CommitFiles(ctx, "main", commitMsg, manifests); err != nil {
+	if err := h.GitHubClient.CommitFiles(ctx, branch, commitMsg, manifests); err != nil {
 		slog.Error("failed to commit manifests", "provision_id", provisionID, "error", err)
 		h.failProvision(ctx, provisionID, tenantID, stepIdx, fmt.Sprintf("git commit failed: %s", err))
 		return

--- a/core/services/provisioning/handlers/handlers.go
+++ b/core/services/provisioning/handlers/handlers.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	ghclient "github.com/openova-io/openova/core/services/provisioning/github"
+	"github.com/openova-io/openova/core/services/provisioning/gitguard"
 	"github.com/openova-io/openova/core/services/provisioning/gitops"
 	"github.com/openova-io/openova/core/services/provisioning/store"
 	"github.com/openova-io/openova/core/services/shared/events"
@@ -28,9 +29,52 @@ type Handler struct {
 	GitHubClient *ghclient.Client
 	CatalogURL   string // internal URL to catalog service
 
+	// GitBasePath + SovereignFQDN are read at startup from env and used
+	// to re-validate every commit before it lands (issue #944 cross-
+	// cluster pollution guard, defence in depth on top of the startup
+	// validation in main.go). Empty SovereignFQDN means Catalyst-Zero
+	// (contabo) — see ValidateGitBasePath in main.go.
+	GitBasePath   string
+	SovereignFQDN string
+
+	// GitBranch is the branch name commits target. Defaults to "main"
+	// (matching both upstream github.com defaults and bp-gitea's seeded
+	// repo on Sovereigns). Operator-overridable via GITHUB_BRANCH env.
+	GitBranch string
+
 	// day2Cancels tracks in-flight day-2 job wait contexts so tenant.deleted
 	// can preempt them (issue #99). Zero value is ready to use.
 	day2Cancels day2CancelRegistry
+}
+
+// VerifyCommitTargetSafe re-runs the issue #944 cross-cluster pollution
+// guard before every git commit. Callers MUST invoke it as the first
+// statement of any code path that reaches GitHubClient.CommitFiles* —
+// even though startup already validated, a runtime mutation (env-var
+// flip via kubectl exec, ConfigMap update without Pod restart, or a
+// mis-resolved manifest path computed from rec.OTECHFQDN that doesn't
+// share the prefix) could still slip a foreign-cluster path past the
+// startup check.
+//
+// The function is intentionally a thin wrapper around the package-level
+// validator (sub-package gitguard) so the policy lives in exactly one
+// place.
+func (h *Handler) VerifyCommitTargetSafe(targetPath string) error {
+	if err := gitguard.ValidateBasePath(h.GitBasePath, h.SovereignFQDN); err != nil {
+		return fmt.Errorf("base path: %w", err)
+	}
+	if targetPath == "" {
+		return nil
+	}
+	clean := strings.TrimSuffix(targetPath, "/")
+	if strings.HasPrefix(clean, "/") || strings.Contains(clean, "..") {
+		return fmt.Errorf("commit target path must be repo-relative without traversal, got %q", targetPath)
+	}
+	base := strings.TrimSuffix(h.GitBasePath, "/")
+	if base != "" && !strings.HasPrefix(clean, base+"/") && clean != base {
+		return fmt.Errorf("commit target path %q escapes configured GIT_BASE_PATH %q (issue #944 cross-cluster pollution guard)", targetPath, h.GitBasePath)
+	}
+	return nil
 }
 
 // startRequest is the JSON body for manually starting a provision.

--- a/core/services/provisioning/main.go
+++ b/core/services/provisioning/main.go
@@ -12,6 +12,7 @@ import (
 	"go.mongodb.org/mongo-driver/v2/mongo/options"
 
 	ghclient "github.com/openova-io/openova/core/services/provisioning/github"
+	"github.com/openova-io/openova/core/services/provisioning/gitguard"
 	"github.com/openova-io/openova/core/services/provisioning/gitops"
 	"github.com/openova-io/openova/core/services/provisioning/handlers"
 	"github.com/openova-io/openova/core/services/provisioning/store"
@@ -29,12 +30,39 @@ func main() {
 	corsOrigin := getEnv("CORS_ORIGIN", "*")
 	port := getEnv("PORT", "8084")
 	gitBasePath := getEnv("GIT_BASE_PATH", "clusters/contabo-mkt/tenants")
+	sovereignFQDN := getEnv("SOVEREIGN_FQDN", "")
 	catalogURL := getEnv("CATALOG_URL", "http://catalog.sme.svc.cluster.local:8082")
 
 	// GitHub API credentials for committing manifests.
 	githubToken := getEnv("GITHUB_TOKEN", "")
 	githubOwner := getEnv("GITHUB_OWNER", "openova-io")
 	githubRepo := getEnv("GITHUB_REPO", "openova-private")
+
+	// ── Cross-cluster pollution guard (issue #944, CRITICAL) ─────────
+	// Validate GIT_BASE_PATH against SOVEREIGN_FQDN at startup. Failure
+	// is fail-loud — the binary refuses to start so an operator notices
+	// the misconfiguration the moment the Pod fails readiness rather
+	// than after alice signups have leaked into a foreign cluster's
+	// tree.
+	if err := gitguard.ValidateBasePath(gitBasePath, sovereignFQDN); err != nil {
+		slog.Error("FATAL: GIT_BASE_PATH validation failed",
+			"git_base_path", gitBasePath,
+			"sovereign_fqdn", sovereignFQDN,
+			"error", err)
+		os.Exit(1)
+	}
+	slog.Info("git base path validated against sovereign fqdn",
+		"git_base_path", gitBasePath,
+		"sovereign_fqdn", sovereignFQDN)
+
+	// ── Placeholder token guard (issue #940) ─────────────────────────
+	// Reject leaked placeholder Secret bytes at startup so the operator
+	// sees the failure before alice signups start hitting "401 Bad
+	// credentials" buried in service logs.
+	if err := gitguard.ValidateGitHubToken(githubToken); err != nil {
+		slog.Error("FATAL: GITHUB_TOKEN validation failed", "error", err)
+		os.Exit(1)
+	}
 
 	// Connect to MongoDB (FerretDB).
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
@@ -81,20 +109,34 @@ func main() {
 	slog.Info("provisioning job indexes ensured")
 	generator := gitops.NewManifestGenerator(gitBasePath)
 
+	// ── Git host coordinates (issue #940) ────────────────────────────
+	// On Sovereigns the canonical Git target is the local Gitea (the
+	// cutover step flipped the Sovereign's GitRepository CR to point
+	// there). The provisioning binary's GitHub-Data-API client targets
+	// whatever GITHUB_API_URL specifies — Gitea exposes a GitHub-
+	// compatible Git Data API at /api/v1, so the wire format is
+	// unchanged. Empty value falls back to https://api.github.com (the
+	// contabo path).
+	githubAPIURL := getEnv("GITHUB_API_URL", "")
+	githubBranch := getEnv("GITHUB_BRANCH", "main")
+
 	var gc *ghclient.Client
 	if githubToken != "" {
-		gc = ghclient.NewClient(githubToken, githubOwner, githubRepo)
-		slog.Info("GitHub client configured", "owner", githubOwner, "repo", githubRepo)
+		gc = ghclient.NewClientWithAPIURL(githubToken, githubOwner, githubRepo, githubAPIURL)
+		slog.Info("GitHub client configured", "owner", githubOwner, "repo", githubRepo, "api_url_set", githubAPIURL != "", "branch", githubBranch)
 	} else {
 		slog.Warn("GITHUB_TOKEN not set — provisioning will fail to commit manifests")
 	}
 
 	h := &handlers.Handler{
-		Store:        provisionStore,
-		Producer:     producer,
-		Generator:    generator,
-		GitHubClient: gc,
-		CatalogURL:   catalogURL,
+		Store:         provisionStore,
+		Producer:      producer,
+		Generator:     generator,
+		GitHubClient:  gc,
+		CatalogURL:    catalogURL,
+		GitBasePath:   gitBasePath,
+		SovereignFQDN: sovereignFQDN,
+		GitBranch:     githubBranch,
 	}
 
 	// Start event consumer in a background goroutine.

--- a/platform/newapi/chart/Chart.yaml
+++ b/platform/newapi/chart/Chart.yaml
@@ -1,5 +1,42 @@
 apiVersion: v2
 name: bp-newapi
+# 1.4.0 (issue #943, 2026-05-05): auto-provision CNPG-backed Postgres +
+# in-chart credentials Secret so a Sovereign install at bootstrap-kit
+# slot 80 lands a real Pod without operator intervention.
+#
+# Pre-#943 the deployment.yaml gate REQUIRED operator-supplied
+# `database.existingSecret` AND `credentials.existingSecret` — the Pod
+# silently skipped render whenever either was empty. On a freshly
+# franchised Sovereign nothing populated those values, so NewAPI never
+# came up and alice signup gate 5 (LLM) timed out waiting for the
+# customer-facing /v1/* API to respond.
+#
+# Fix:
+#   - NEW templates/cnpg-cluster.yaml — when .Values.cnpg.enabled
+#     (DEFAULT true), renders postgresql.cnpg.io/v1.Cluster
+#     `<release>-newapi-pg` + a Helm-`lookup`-persistent DSN Secret
+#     `<release>-newapi-db-dsn` (key: SQL_DSN) read by the deployment.
+#     Capabilities-gated on postgresql.cnpg.io/v1 so a cold install
+#     before bp-cnpg is Ready surfaces as "no Cluster yet" rather
+#     than a hard install error (mirrors platform/powerdns/chart/
+#     templates/cnpg-cluster.yaml's pattern).
+#   - NEW templates/credentials-secret.yaml — when
+#     .Values.credentials.autoProvision (DEFAULT true) AND
+#     .Values.credentials.existingSecret is empty, renders
+#     `<release>-app-creds` carrying SESSION_SECRET + CRYPTO_SECRET
+#     (each 64-char randAlphaNum, persistent across reconciles via
+#     Helm `lookup`). helm.sh/resource-policy: keep so a re-install
+#     recovers the same bytes (otherwise an upgrade silently rotates
+#     the keys, invalidating every active session cookie + every
+#     encrypted token).
+#   - deployment.yaml — Secret name resolution now picks the chart-
+#     emitted defaults when the operator hasn't supplied an override.
+#     The Pod-render gate accepts EITHER an explicit existingSecret
+#     OR the auto-provisioned one.
+#   - values.yaml — adds .Values.cnpg.* and .Values.credentials.
+#     {autoProvision,autoSecretName} blocks; every knob is operator-
+#     overridable per Inviolable Principle #4.
+#
 # 1.3.0: defaultChannels.qwenBankDhofar (channel #1 = Qwen3.6 @
 # https://llm-api.omtd.bankdhofar.com) + post-install/post-upgrade
 # `channel-seed` Helm hook Job that idempotently POSTs default
@@ -9,7 +46,7 @@ name: bp-newapi
 # Issue #915 (epic SME tenant integration DoD: alice → OpenClaw →
 # NewAPI → Qwen3.6@BankDhofar end-to-end).
 # 1.2.0: Traefik Middleware gated behind ingress.middleware.enabled.
-version: 1.3.0
+version: 1.4.0
 appVersion: "0.4.5"
 description: |
   Catalyst Blueprint scratch chart for NewAPI — multi-tenant LLM

--- a/platform/newapi/chart/templates/cnpg-cluster.yaml
+++ b/platform/newapi/chart/templates/cnpg-cluster.yaml
@@ -1,0 +1,117 @@
+{{- /*
+CNPG Cluster + DSN Secret for bp-newapi (issue #943).
+
+NewAPI persists users, credits, channels, tokens, and an audit log to
+PostgreSQL. Pre-#943 the chart REQUIRED an operator-supplied
+`database.existingSecret` to render the Deployment — the deployment
+template silently skipped Pod render if it was empty. On a freshly
+franchised Sovereign installing bp-newapi via Flux from the bootstrap-kit
+slot 80 overlay nothing populated this Secret, so the Deployment never
+materialised, NewAPI never came up, and alice signup gate 5 (LLM)
+timed out waiting for `api.<sov-fqdn>` to respond.
+
+Fix (issue #943, 2026-05-05): auto-provision the backing Postgres via
+CNPG when `cnpg.enabled=true` (DEFAULT). The chart renders:
+
+  - postgresql.cnpg.io/v1.Cluster `<release>-newapi-pg` with the
+    operator-configured size + storage from .Values.cnpg.cluster.*.
+    CNPG auto-creates `<cluster>-app` Secret (basic-auth shape:
+    username + password keys) and `<cluster>-rw` Service.
+
+  - Secret `<release>-newapi-db-dsn` with the SQL_DSN key the chart's
+    deployment.yaml reads. The DSN is materialised via Helm `lookup`
+    against the CNPG-emitted Secret so the bytes are stable across
+    reinstalls. Persistent across reconciles per the same lookup-and-
+    persist pattern as platform/gitea/chart/templates/admin-secret.yaml
+    (issue #830 Bug 2 + feedback_passwords.md). On first install the
+    lookup returns nil — the Cluster is still warming — and the DSN
+    Secret renders with an empty password. The 1-minute Flux reconcile
+    picks it up on the next tick once CNPG has materialised the bytes.
+
+  - `database.existingSecret` and `database.existingSecretKey` default
+    to the chart-emitted Secret name and key when cnpg.enabled=true,
+    so the deployment.yaml gate passes WITHOUT operator intervention.
+    Per Inviolable Principle #4 the operator MAY still override
+    `.Values.database.existingSecret` to wire NewAPI at an external
+    Postgres without forking the chart.
+
+Capabilities gate: the chart MUST NOT render the Cluster on a Sovereign
+where bp-cnpg has not yet registered the `postgresql.cnpg.io/v1` CRD.
+Without the gate, a cold install fails with "no matches for kind
+Cluster". Same pattern the bp-external-dns chart uses (issue #190) and
+the platform/powerdns/chart/templates/cnpg-cluster.yaml mirror.
+
+Lockstep with bp-newapi 1.4.0 — paired with deployment.yaml change to
+read the chart-emitted DSN by default + the existingSecret value
+defaulting in values.yaml.
+*/}}
+{{- if .Values.cnpg.enabled -}}
+{{- $clusterName := printf "%s-newapi-pg" (include "bp-newapi.fullname" .) -}}
+{{- $cnpgSecretName := printf "%s-app" $clusterName -}}
+{{- $dsnSecretName := default (printf "%s-newapi-db-dsn" (include "bp-newapi.fullname" .)) .Values.cnpg.dsnSecretName -}}
+{{- $database := .Values.cnpg.database | default "newapi" -}}
+{{- if .Capabilities.APIVersions.Has "postgresql.cnpg.io/v1" -}}
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: {{ $clusterName }}
+  labels:
+    {{- include "bp-newapi.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/resource-policy: keep
+spec:
+  instances: {{ .Values.cnpg.cluster.instances | default 1 }}
+  imageName: {{ .Values.cnpg.cluster.imageName | default "ghcr.io/cloudnative-pg/postgresql:16.4" | quote }}
+  storage:
+    size: {{ .Values.cnpg.cluster.storage | default "5Gi" | quote }}
+    {{- with .Values.cnpg.cluster.storageClassName }}
+    storageClass: {{ . | quote }}
+    {{- end }}
+  bootstrap:
+    initdb:
+      database: {{ $database | quote }}
+      owner: {{ .Values.cnpg.cluster.owner | default "newapi" | quote }}
+      {{- with .Values.cnpg.cluster.postInitApplicationSQL }}
+      postInitApplicationSQL:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+  {{- with .Values.cnpg.cluster.resources }}
+  resources:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}
+---
+{{- /*
+DSN Secret — read CNPG's auto-emitted basic-auth Secret via Helm lookup
+and re-emit the canonical SQL_DSN string the deployment.yaml expects.
+On first install the lookup returns nil; the DSN renders with empty
+password and the Pod stays in CrashLoopBackOff until the next 1-minute
+Flux reconcile picks up the materialised bytes. Same first-install race
+as templates/sme-services/sme-secrets.yaml (issue #859) and
+templates/sme-services/valkey-cross-ns-secret.yaml (issue #863) — both
+proven to recover on the second reconcile in production.
+*/ -}}
+{{- $cnpgSecret := lookup "v1" "Secret" .Release.Namespace $cnpgSecretName -}}
+{{- $pgUser := .Values.cnpg.cluster.owner | default "newapi" -}}
+{{- $pgPass := "" -}}
+{{- $pgHost := printf "%s-rw.%s.svc.cluster.local" $clusterName .Release.Namespace -}}
+{{- if and $cnpgSecret $cnpgSecret.data $cnpgSecret.data.password -}}
+  {{- $pgPass = $cnpgSecret.data.password | b64dec -}}
+{{- end -}}
+{{- $sslMode := .Values.cnpg.sslMode | default "require" -}}
+{{- $dsn := printf "postgres://%s:%s@%s:5432/%s?sslmode=%s" $pgUser $pgPass $pgHost $database $sslMode -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $dsnSecretName }}
+  labels:
+    {{- include "bp-newapi.labels" . | nindent 4 }}
+  annotations:
+    # Keep the Secret across helm uninstall — re-install picks the
+    # bytes back up via lookup, so external consumers (debug Pods,
+    # backup scripts) keep a stable reference.
+    helm.sh/resource-policy: keep
+type: Opaque
+data:
+  SQL_DSN: {{ $dsn | b64enc | quote }}
+{{- end }}

--- a/platform/newapi/chart/templates/credentials-secret.yaml
+++ b/platform/newapi/chart/templates/credentials-secret.yaml
@@ -1,0 +1,55 @@
+{{- /*
+NewAPI internal credentials Secret (issue #943).
+
+NewAPI requires SESSION_SECRET + CRYPTO_SECRET (both 32+ bytes of random
+entropy) per upstream's controller/auth.go. Pre-#943 the chart REQUIRED
+operator-supplied bytes via .Values.credentials.existingSecret — the
+deployment template silently skipped Pod render if it was empty. On a
+freshly franchised Sovereign nothing populated this Secret, so the Pod
+never came up and alice signup gate 5 (LLM) failed.
+
+Fix: auto-generate via sprig randAlphaNum (64 / 64 chars) when
+credentials.autoProvision=true (DEFAULT). Persistent across reconciles
+via Helm `lookup` — same load-bearing pattern as platform/gitea/chart/
+templates/admin-secret.yaml (issue #830 Bug 2 + feedback_passwords.md).
+Without lookup every reconcile would invalidate every active session
+cookie and every encrypted token across NewAPI's user base.
+
+Per Inviolable Principle #4 (never hardcode), the operator may bring
+their own bytes by setting `.Values.credentials.existingSecret` in the
+per-Sovereign overlay; when non-empty THAT name takes precedence
+(deployment.yaml reads from it directly) and this template renders
+nothing extra. The chart-emitted Secret is only created when
+autoProvision=true AND existingSecret is empty.
+
+helm.sh/resource-policy: keep so a `helm uninstall` + reinstall recovers
+the same bytes (otherwise an upgrade would silently rotate the keys).
+*/}}
+{{- if and .Values.credentials.autoProvision (not .Values.credentials.existingSecret) -}}
+{{- $secretName := default (printf "%s-app-creds" (include "bp-newapi.fullname" .)) .Values.credentials.autoSecretName -}}
+{{- $existing := lookup "v1" "Secret" .Release.Namespace $secretName -}}
+{{- $sessionSecret := "" -}}
+{{- $cryptoSecret := "" -}}
+{{- if and $existing $existing.data $existing.data.SESSION_SECRET -}}
+  {{- $sessionSecret = $existing.data.SESSION_SECRET | b64dec -}}
+{{- else -}}
+  {{- $sessionSecret = randAlphaNum 64 -}}
+{{- end -}}
+{{- if and $existing $existing.data $existing.data.CRYPTO_SECRET -}}
+  {{- $cryptoSecret = $existing.data.CRYPTO_SECRET | b64dec -}}
+{{- else -}}
+  {{- $cryptoSecret = randAlphaNum 64 -}}
+{{- end -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $secretName }}
+  labels:
+    {{- include "bp-newapi.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/resource-policy: keep
+type: Opaque
+data:
+  SESSION_SECRET: {{ $sessionSecret | b64enc | quote }}
+  CRYPTO_SECRET: {{ $cryptoSecret | b64enc | quote }}
+{{- end }}

--- a/platform/newapi/chart/templates/deployment.yaml
+++ b/platform/newapi/chart/templates/deployment.yaml
@@ -1,12 +1,31 @@
 {{- /*
-Deployment skip-render gate. The Deployment binds three operator-supplied
-Secrets (database DSN, app credentials, optional OIDC client secret); if
-any are missing on a default-values render (CI smoke test), the
-Deployment is silently skipped. The Service / ServiceAccount / ConfigMap
-/ NetworkPolicy still render so `helm template` produces a non-empty
-output that proves the chart is structurally sound, while the actual
-Pod-rendering deferred until the per-Sovereign overlay sets
-`database.existingSecret` and `credentials.existingSecret`.
+Deployment skip-render gate.
+
+Pre-#943 the Deployment skipped silently unless the operator manually
+provided three Secrets (database DSN, app credentials, optional OIDC
+client secret) via per-Sovereign overlay. On a freshly franchised
+Sovereign nothing populated those values — the chart emitted Service +
+ConfigMap + NetworkPolicy but no Pod, so NewAPI never came up and
+alice signup gate 5 (LLM) failed.
+
+Issue #943 fix: chart auto-provisions BOTH the CNPG-backed Postgres
+DSN Secret (templates/cnpg-cluster.yaml, gated on .Values.cnpg.enabled)
+AND the SESSION_SECRET/CRYPTO_SECRET credentials Secret (templates/
+credentials-secret.yaml, gated on .Values.credentials.autoProvision).
+Defaults flip both to true so a Sovereign install with bp-newapi at
+slot 80 lands a real Pod without operator intervention.
+
+Effective DSN Secret name resolution:
+  1. .Values.database.existingSecret (operator override) — if set, use
+     it directly (the contabo path or a per-Sovereign external Postgres).
+  2. else when .Values.cnpg.enabled the chart auto-emits its own DSN
+     Secret named `<release>-newapi-db-dsn`.
+  3. else the Deployment skip-renders (legacy path — preserved for
+     environments where neither auto-provision nor a manual Secret is
+     wired).
+
+Same precedence for credentials: explicit existingSecret > auto-emitted
+`<release>-app-creds` > skip-render.
 
 Keycloak OIDC client secret is required only when
 `auth.adminUI.mode=keycloak` AND `auth.adminUI.keycloak.issuer` is set;
@@ -14,7 +33,18 @@ the configmap mirrors this gate.
 */ -}}
 {{- $kcMode := eq .Values.auth.adminUI.mode "keycloak" -}}
 {{- $kcConfigured := and $kcMode .Values.auth.adminUI.keycloak.issuer .Values.auth.adminUI.keycloak.existingSecret -}}
-{{- $deployReady := and .Values.newapi.enabled .Values.database.existingSecret .Values.credentials.existingSecret -}}
+{{- /* Resolve database secret: explicit override > chart-emitted CNPG DSN */ -}}
+{{- $effDbSecret := .Values.database.existingSecret -}}
+{{- $effDbKey := .Values.database.existingSecretKey | default "SQL_DSN" -}}
+{{- if and (not $effDbSecret) .Values.cnpg.enabled -}}
+{{- $effDbSecret = default (printf "%s-newapi-db-dsn" (include "bp-newapi.fullname" .)) .Values.cnpg.dsnSecretName -}}
+{{- end -}}
+{{- /* Resolve credentials secret: explicit override > chart auto-provision */ -}}
+{{- $effCredsSecret := .Values.credentials.existingSecret -}}
+{{- if and (not $effCredsSecret) .Values.credentials.autoProvision -}}
+{{- $effCredsSecret = default (printf "%s-app-creds" (include "bp-newapi.fullname" .)) .Values.credentials.autoSecretName -}}
+{{- end -}}
+{{- $deployReady := and .Values.newapi.enabled $effDbSecret $effCredsSecret -}}
 {{- if and $kcMode (not $kcConfigured) -}}
 {{- $deployReady = false -}}
 {{- end -}}
@@ -51,11 +81,15 @@ spec:
               protocol: TCP
           env:
             # ── Database (Postgres on bp-cnpg) ────────────────────────
+            # Secret name resolution (issue #943):
+            #   1. .Values.database.existingSecret if set (operator override)
+            #   2. else chart-emitted DSN Secret from cnpg-cluster.yaml
+            #      (`<release>-newapi-db-dsn`) when .Values.cnpg.enabled
             - name: SQL_DSN
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.database.existingSecret }}
-                  key: {{ .Values.database.existingSecretKey }}
+                  name: {{ $effDbSecret }}
+                  key: {{ $effDbKey }}
 
             # ── Valkey cache ──────────────────────────────────────────
             {{- if .Values.valkey.enabled }}
@@ -72,15 +106,19 @@ spec:
             {{- end }}
 
             # ── App credentials (NewAPI-internal) ─────────────────────
+            # Secret name resolution (issue #943):
+            #   1. .Values.credentials.existingSecret (operator override)
+            #   2. else chart-emitted credentials-secret.yaml output
+            #      when .Values.credentials.autoProvision (DEFAULT true)
             - name: SESSION_SECRET
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.credentials.existingSecret }}
+                  name: {{ $effCredsSecret }}
                   key: SESSION_SECRET
             - name: CRYPTO_SECRET
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.credentials.existingSecret }}
+                  name: {{ $effCredsSecret }}
                   key: CRYPTO_SECRET
 
             # ── OIDC (admin UI) ───────────────────────────────────────

--- a/platform/newapi/chart/values.yaml
+++ b/platform/newapi/chart/values.yaml
@@ -78,8 +78,55 @@ newapi:
 database:
   # ExternalSecret name carrying the full DSN. Required key: SQL_DSN
   # (e.g. "postgres://user:pass@host:5432/newapi?sslmode=require").
+  # Pre-#943 this was REQUIRED — the deployment.yaml gate skipped Pod
+  # render when empty, blocking alice signup gate 5 (LLM) on every
+  # fresh Sovereign. Issue #943 (2026-05-05): when empty, the chart
+  # auto-provisions via .Values.cnpg.* below and the Pod reads from
+  # the chart-emitted DSN Secret. Operator may still set this to
+  # bypass auto-provision and wire NewAPI at an external Postgres
+  # (the contabo path historically did this via Crossplane).
   existingSecret: ""              # operator-supplied (e.g. "newapi-db-dsn")
   existingSecretKey: "SQL_DSN"
+
+# ─── CNPG-backed auto-provisioned Postgres (issue #943) ──────────────────
+# When enabled (DEFAULT true), the chart renders templates/cnpg-cluster.yaml:
+#   - postgresql.cnpg.io/v1.Cluster `<release>-newapi-pg`
+#   - Secret `<release>-newapi-db-dsn` (key: SQL_DSN) read by the Pod
+# The Cluster's auto-emitted basic-auth Secret is read via Helm `lookup`
+# and the DSN string is composed at render time. Per Inviolable Principle
+# #4 the instance count, image, storage, and SSL mode are all operator-
+# tunable via per-Sovereign overlay.
+#
+# Capabilities-gated on postgresql.cnpg.io/v1 — when bp-cnpg is not yet
+# Ready the Cluster CR is skipped and chart install does not fail.
+cnpg:
+  enabled: true
+  # Override the auto-emitted DSN Secret name. Default empty ⇒ derived
+  # from release name (`<release>-newapi-db-dsn`).
+  dsnSecretName: ""
+  # Database name created by CNPG initdb.
+  database: newapi
+  # SSL mode component of the DSN string. CNPG enforces TLS by default
+  # so `require` matches the cluster's posture; operators may relax to
+  # `prefer` on dev clusters by overlaying this value.
+  sslMode: "require"
+  cluster:
+    instances: 1
+    imageName: "ghcr.io/cloudnative-pg/postgresql:16.4"
+    storage: "5Gi"
+    storageClassName: ""          # empty ⇒ default StorageClass
+    owner: "newapi"
+    # Optional bootstrap SQL — empty by default. Operators may add
+    # CREATE EXTENSION / additional databases here without forking
+    # the chart.
+    postInitApplicationSQL: []
+    resources:
+      requests:
+        cpu: 50m
+        memory: 128Mi
+      limits:
+        cpu: 500m
+        memory: 512Mi
 
 # ─── Valkey cache (bp-valkey) ────────────────────────────────────────────
 # Session store and rate-limit counters. Optional but recommended
@@ -94,12 +141,26 @@ valkey:
 
 # ─── App credentials (NewAPI-internal) ───────────────────────────────────
 # SESSION_SECRET (random 32+ bytes) and CRYPTO_SECRET (random 32+ bytes)
-# are NewAPI-internal cryptographic material. Generated out-of-band by
-# the operator (per docs/INVIOLABLE-PRINCIPLES.md #4 and the credential
-# hygiene rules in ~/.claude/CLAUDE.md), mounted via ExternalSecret.
-# Required keys: SESSION_SECRET, CRYPTO_SECRET.
+# are NewAPI-internal cryptographic material.
+#
+# Issue #943 (2026-05-05): the chart auto-provisions these via
+# templates/credentials-secret.yaml when autoProvision=true (DEFAULT)
+# AND existingSecret is empty. Persistence across reconciles via Helm
+# `lookup` — same load-bearing pattern as gitea-admin-secret (issue
+# #830 Bug 2). Without this, every reconcile would invalidate every
+# active session cookie and every encrypted token across NewAPI's user
+# base. helm.sh/resource-policy: keep so a `helm uninstall` + reinstall
+# recovers the same bytes.
+#
+# Operator may bring their own bytes via per-Sovereign overlay setting
+# `existingSecret` — when non-empty it takes precedence and the chart-
+# emitted Secret is NOT rendered.
 credentials:
   existingSecret: ""              # operator-supplied (e.g. "newapi-app-creds")
+  autoProvision: true
+  # Override the auto-emitted credentials Secret name. Default empty
+  # ⇒ derived from release name (`<release>-app-creds`).
+  autoSecretName: ""
 
 # ─── Auth: ops-staff admin UI ────────────────────────────────────────────
 # The admin UI at admin.<host> is gated by the operator's IdP. Default

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -1,5 +1,94 @@
 apiVersion: v2
 name: bp-catalyst-platform
+# 1.4.22 (#915 SME blockers — issues #934/#940/#941/#942/#943/#944): six
+# coupled chart + orchestrator fixes that unblock alice signup gates 2-6
+# on a freshly franchised Sovereign. C5-final got Gate 1 GREEN on
+# otech113 (2026-05-05) but every downstream gate failed because the SME
+# bundle hardcoded contabo-only assumptions:
+#
+#   - #934: auth + notification SME services pinned SMTP env to bytes
+#     the operator placed in `sme-secrets` via .Values.smeSecrets.smtp.*.
+#     On a Sovereign nothing populated those values — auth.yaml's POST
+#     /auth/send-pin returned `failed to send email` and gate 2 (PIN
+#     delivery) timed out. Fix: sme-secrets.yaml now reads SMTP_*
+#     from `catalyst-system/sovereign-smtp-credentials` (the same
+#     A5-seeded source #883/#905 the chart 1.4.20 catalyst-openova-kc-
+#     credentials Secret already uses) with source-wins precedence.
+#     Empty source falls back to legacy chart-level defaults so
+#     contabo paths stay clean. Both canonical (smtp-host/port/from/
+#     user/pass) AND legacy (host/port/from/user/password) source-Secret
+#     key shapes are accepted.
+#
+#   - #940: Sovereign provisioning service shipped with GITHUB_TOKEN
+#     placeholder bytes AND with GITHUB_OWNER + GITHUB_REPO hardcoded
+#     to upstream `openova-io/openova` so per-tenant commits attempted
+#     authenticated POST against api.github.com — failed every time
+#     with 401. Fix: chart values
+#     .Values.smeServices.provisioning.{githubToken,git.{apiURL,owner,
+#     repo,branch}} make every GitHub-API coordinate operator-overridable
+#     with topology-aware defaults (Sovereign ⇒ in-cluster Gitea REST
+#     API + `openova` org; contabo ⇒ api.github.com + `openova-io` org).
+#     Provisioning binary's startup gate validates the GITHUB_TOKEN
+#     does NOT contain placeholder substrings (`<placeholder>`,
+#     `PLACEHOLDER`, `REPLACE_ME`, ...) and crashes the Pod into
+#     Pending if it does — the operator sees the misconfig immediately
+#     instead of after alice signups have failed silently in Pod logs.
+#
+#   - #941: marketplace UI drew "COMING SOON" overlay on every AI +
+#     Communication card on a fresh Sovereign because catalog handler's
+#     migrateAppDeployable() map at core/services/catalog/handlers/
+#     seed.go omitted `openclaw` and `stalwart-mail` even though both
+#     blueprints (bp-openclaw, bp-stalwart-{sovereign,tenant}) are
+#     visibility=listed in the embedded blueprints.json. C5-final hit
+#     "27 apps COMING SOON" because of this — gates 4 (LLM) and 5
+#     (mail) blocked before alice could click Install. Fix: add both
+#     slugs to the deployable map.
+#
+#   - #942: configmap.yaml hardcoded REDPANDA_BROKERS to
+#     `redpanda.talentmesh.svc.cluster.local:9092`. talentmesh ns does
+#     not exist on a Sovereign and the OpenOva architecture uses NATS
+#     JetStream as the only local bus per ADR-0001 (slot 09 ships
+#     bp-nats-jetstream into namespace `nats-jetstream`). Every SME
+#     service crashlooped at startup with `lookup ...: no such host`,
+#     blocking gate 3 (tenant ready). Fix: data-driven via
+#     .Values.smeServices.eventBus.brokers with a topology-aware default
+#     — Sovereign ⇒ NATS JetStream Service, contabo ⇒ legacy Redpanda
+#     Service. The ConfigMap key name stays REDPANDA_BROKERS for
+#     back-compat with existing SME service Go env wiring.
+#
+#   - #943: bp-newapi chart silently skipped Deployment render on a
+#     fresh Sovereign because the Pod gate REQUIRED operator-supplied
+#     `database.existingSecret` AND `credentials.existingSecret`. The
+#     bootstrap-kit slot 80 overlay supplied neither, so NewAPI never
+#     came up and gate 5 (LLM) timed out. Fix: bp-newapi 1.4.0 auto-
+#     provisions a CNPG-backed Postgres Cluster + a chart-emitted DSN
+#     Secret + a Helm-lookup-persistent SESSION_SECRET/CRYPTO_SECRET
+#     Secret when the operator hasn't overridden either. The
+#     deployment.yaml gate now passes by default. Capabilities-gated
+#     on postgresql.cnpg.io/v1 so a cold install before bp-cnpg is
+#     Ready surfaces as "no Cluster yet" rather than an install error.
+#
+#   - #944 (CRITICAL — cross-cluster pollution): Sovereign provisioning
+#     service had GIT_BASE_PATH hardcoded to `clusters/contabo-mkt/
+#     tenants` so every alice tenant overlay landed in the upstream
+#     openova/openova repo's contabo overlay, which contabo Flux would
+#     then install on the contabo cluster. C5-final caught + reverted
+#     the alice2 incident at commit 5715db04 (2026-05-05). Fix:
+#     provisioning.yaml templates GIT_BASE_PATH from
+#     .Values.smeServices.provisioning.gitBasePath with a topology-
+#     aware default `clusters/<sovereignFQDN>/sme-tenants` on
+#     Sovereigns. Provisioning binary's startup AND every commit code
+#     path validate the path begins with `clusters/<self-FQDN>/` via
+#     a new shared `core/services/provisioning/gitguard` package —
+#     refusing to commit to any other cluster's tree. Defence in depth
+#     so a runtime env mutation (kubectl exec, ConfigMap update without
+#     Pod restart, hostile sidecar) cannot bypass the check.
+#
+# Lockstep slot 13 pin in clusters/_template/bootstrap-kit/
+# 13-bp-catalyst-platform.yaml bumps from 1.4.21 → 1.4.22.
+# Coupled bp-newapi bump 1.3.0 → 1.4.0 for the #943 CNPG auto-
+# provisioning. 2026-05-05.
+#
 # 1.4.20 (#924): Phase-2 SMTP source-wins extended to non-secret fields
 # (smtp-host, smtp-port, smtp-from) AND to canonical key shape `smtp-user`/
 # `smtp-pass` in addition to legacy `user`/`password`. Pairs with the
@@ -14,8 +103,8 @@ name: bp-catalyst-platform
 # carried only credentials and the chart fell back to
 # .Values.sovereign.smtp.* defaults — that fallback path remains as
 # the Sovereign-without-bp-stalwart-sovereign back-compat seam.
-version: 1.4.21
-appVersion: 1.4.21
+version: 1.4.22
+appVersion: 1.4.22
 description: |
   Catalyst Platform — the unified Catalyst control plane umbrella chart for Catalyst-Zero.
   Composes the catalyst-{ui,api}, console, admin, marketplace UI modules and the marketplace-api backend.

--- a/products/catalyst/chart/templates/sme-services/configmap.yaml
+++ b/products/catalyst/chart/templates/sme-services/configmap.yaml
@@ -1,4 +1,41 @@
 {{- if and .Values.ingress .Values.ingress.marketplace .Values.ingress.marketplace.enabled -}}
+{{- /*
+Event-bus default — issue #942 (2026-05-05).
+
+On Catalyst-Zero (contabo, global.sovereignFQDN empty) the SME services
+historically point at a cross-namespace Redpanda in `talentmesh` (migration
+tracked in #68). On franchised Sovereigns the talentmesh namespace does
+not exist and the OpenOva architecture uses NATS JetStream as the only
+local bus per ADR-0001 — slot 09 ships bp-nats-jetstream into namespace
+`nats-jetstream`. Pre-#942 the value was hardcoded to the talentmesh
+Service, which made every SME service crashloop on a fresh Sovereign at
+startup with `lookup redpanda.talentmesh.svc.cluster.local: no such host`,
+blocking alice signup gate 3 (tenant ready).
+
+Per Inviolable Principle #4 (never hardcode), the broker target is
+data-driven via .Values.smeServices.eventBus.brokers. Defaults differ per
+topology so the contabo + Sovereign render paths both work out of the box:
+
+  - Sovereign install (global.sovereignFQDN non-empty) defaults to the
+    in-cluster NATS JetStream Service.
+  - Catalyst-Zero install (global.sovereignFQDN empty) defaults to the
+    legacy Redpanda Service in talentmesh so contabo keeps working.
+
+Per-Sovereign overlays MAY override either default to wire SME services
+at any NATS-protocol or Kafka-protocol broker without forking the chart.
+
+The ConfigMap key name stays REDPANDA_BROKERS for backwards-compatibility
+with existing SME service Go env wiring (the env name is historical; the
+value is whatever broker is actually wired). A future ticket may rename
+the env to EVENT_BUS_BROKERS once every SME service binary reads the new
+name; that rename can ship without re-touching this template because the
+key name is the only thing this template promises to its consumers.
+*/ -}}
+{{- $defaultBrokers := "redpanda.talentmesh.svc.cluster.local:9092" -}}
+{{- if .Values.global.sovereignFQDN -}}
+  {{- $defaultBrokers = "nats-jetstream.nats-jetstream.svc.cluster.local:4222" -}}
+{{- end -}}
+{{- $brokers := default $defaultBrokers (index (default (dict) .Values.smeServices.eventBus) "brokers") -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -43,11 +80,14 @@ data:
   POSTGRES_HOST: "{{ .Values.smePostgres.cluster.name | default "sme-pg" }}-rw.{{ .Values.smePostgres.cluster.namespace | default "sme" }}.svc.cluster.local"
   POSTGRES_PORT: "{{ .Values.smeServices.ferretdb.postgresPort | default 5432 }}"
 
-  # ---- cross-namespace event bus --------------------------------------------
-  # Redpanda currently lives in the talentmesh namespace (migration tracked
-  # in issue #68). Centralised so the eventual move to a sme-owned broker
-  # is a single-key change.
-  REDPANDA_BROKERS: "redpanda.talentmesh.svc.cluster.local:9092"
+  # ---- event bus ------------------------------------------------------------
+  # See header comment for the topology-aware default selection (issue #942).
+  REDPANDA_BROKERS: {{ $brokers | quote }}
+  # Protocol hint for SME services that want to switch wire formats per
+  # broker without re-reading the URL — `kafka` for Redpanda (legacy
+  # contabo), `nats` for NATS JetStream (Sovereign default). Operator-
+  # overridable via .Values.smeServices.eventBus.protocol.
+  EVENT_BUS_PROTOCOL: {{ default (ternary "nats" "kafka" (ne (toString .Values.global.sovereignFQDN) "")) (index (default (dict) .Values.smeServices.eventBus) "protocol") | quote }}
 
   # ---- public / CORS endpoints ----------------------------------------------
   CORS_ORIGIN_PUBLIC: "https://sme.openova.io"

--- a/products/catalyst/chart/templates/sme-services/provisioning.yaml
+++ b/products/catalyst/chart/templates/sme-services/provisioning.yaml
@@ -158,6 +158,12 @@ spec:
                 configMapKeyRef:
                   name: sme-services-config
                   key: REDPANDA_BROKERS
+            - name: EVENT_BUS_PROTOCOL
+              valueFrom:
+                configMapKeyRef:
+                  name: sme-services-config
+                  key: EVENT_BUS_PROTOCOL
+                  optional: true
             - name: JWT_SECRET
               valueFrom:
                 secretKeyRef:
@@ -168,22 +174,114 @@ spec:
                 configMapKeyRef:
                   name: sme-services-config
                   key: CORS_ORIGIN_PUBLIC
+            # ── GitOps target path — issue #944 ───────────────────────────
+            # Pre-#944 GIT_BASE_PATH was hardcoded to
+            # `clusters/contabo-mkt/tenants` here. On a freshly franchised
+            # Sovereign (the SME marketplace runs on the Sovereign too) that
+            # path points at CONTABO's clusters/ tree — every alice tenant
+            # commit landed in upstream openova/openova's contabo overlay,
+            # which contabo Flux would then install on the contabo cluster.
+            # C5-final caught + reverted the alice2 incident at commit
+            # 20a0884a (revert visible on main as 5715db04, 2026-05-05).
+            #
+            # Fix: data-driven via .Values.smeServices.provisioning.gitBasePath
+            # with a topology-aware default. Sovereign installs default to
+            # clusters/<sovereignFQDN>/sme-tenants/ (matches the existing
+            # catalyst-api SME-tenant orchestrator path in
+            # sme_tenant_gitops.go and the Flux Kustomization spec.path the
+            # chart 1.4.13 sme-tenants-kustomization.yaml watches). Catalyst-
+            # Zero (contabo) keeps the legacy `clusters/contabo-mkt/tenants`
+            # path so existing contabo-mkt tenants continue to reconcile.
+            #
+            # Source-side cross-cluster pollution guard: the provisioning
+            # binary ALSO validates at startup + before every commit that
+            # the path begins with `clusters/<self-FQDN>/` so a malicious
+            # or misconfigured value pointing at a foreign cluster's tree
+            # is rejected at runtime even if a per-Sovereign overlay sets
+            # the value wrong. See main.go validateGitBasePath.
             - name: GIT_BASE_PATH
+            {{- if .Values.smeServices.provisioning.gitBasePath }}
+              value: {{ .Values.smeServices.provisioning.gitBasePath | quote }}
+            {{- else if .Values.global.sovereignFQDN }}
+              value: "clusters/{{ .Values.global.sovereignFQDN }}/sme-tenants"
+            {{- else }}
               value: "clusters/contabo-mkt/tenants"
+            {{- end }}
+            # ── Sovereign FQDN env (cross-cluster pollution guard) ────────
+            # Provisioning service uses this to validate that GIT_BASE_PATH
+            # starts with `clusters/<SOVEREIGN_FQDN>/` before any git
+            # commit. Empty on Catalyst-Zero (contabo) where the legacy
+            # `clusters/contabo-mkt/tenants` path is the canonical write
+            # target — the binary's guard recognises that special case.
+            - name: SOVEREIGN_FQDN
+              value: {{ .Values.global.sovereignFQDN | default "" | quote }}
             - name: CATALOG_URL
               valueFrom:
                 configMapKeyRef:
                   name: sme-services-config
                   key: CATALOG_URL
+            # ── GitOps token — issue #940 ─────────────────────────────────
+            # On contabo this Secret is hand-rolled (clusters/contabo-mkt/
+            # apps/sme/data/...). On franchised Sovereigns it is rendered by
+            # templates/sme-services/provisioning-github-token.yaml (issue
+            # #866) which mirrors the local Gitea admin password into
+            # `sme/provisioning-github-token`. The Secret name + key are
+            # operator-overridable via
+            # .Values.smeServices.provisioning.githubToken.* without
+            # forking the chart.
+            #
+            # Provisioning service rejects placeholder values at startup
+            # (`<placeholder>`, `<changeme>`, empty) — a leaked Secret with
+            # a placeholder string in its bytes is just as broken as no
+            # Secret, and silent acceptance previously failed every per-
+            # tenant commit on Sovereigns with "401 Bad credentials" buried
+            # in service logs.
             - name: GITHUB_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: provisioning-github-token
-                  key: GITHUB_TOKEN
+                  name: {{ .Values.smeServices.provisioning.githubToken.secretName | default "provisioning-github-token" }}
+                  key: {{ .Values.smeServices.provisioning.githubToken.secretKey | default "GITHUB_TOKEN" }}
+            # ── Git host coordinates — issue #940 ─────────────────────────
+            # Pre-#940 GITHUB_OWNER + GITHUB_REPO were chart-level literals
+            # ("openova-io" / "openova"). On a Sovereign the orchestrator
+            # MUST commit to the LOCAL Gitea (the cutover step flipped the
+            # GitRepository CR to point there), so writes to upstream
+            # github.com would (a) leak per-tenant overlays into the public
+            # repo's main branch and (b) fail authentication because the
+            # GITHUB_TOKEN Secret is the local Gitea admin password, not a
+            # GitHub PAT.
+            #
+            # Defaults match the catalyst-api gitops env contract:
+            #   - GITHUB_API_URL: in-cluster Gitea on Sovereign,
+            #     https://api.github.com on contabo.
+            #   - GITHUB_OWNER:   `openova` (the local Gitea org bp-gitea
+            #     ships) on Sovereign, `openova-io` on contabo.
+            #   - GITHUB_REPO:    `openova` on both — bp-gitea seeds a
+            #     bare-name `openova/openova` repo on Sovereign install to
+            #     match the upstream path so Kustomization paths stay
+            #     stable across the cutover boundary.
+            # Per Inviolable Principle #4, every value is operator-
+            # overridable via .Values.smeServices.provisioning.git.*.
+            - name: GITHUB_API_URL
+            {{- if .Values.smeServices.provisioning.git.apiURL }}
+              value: {{ .Values.smeServices.provisioning.git.apiURL | quote }}
+            {{- else if .Values.global.sovereignFQDN }}
+              value: "http://gitea-http.gitea.svc.cluster.local:3000/api/v1"
+            {{- else }}
+              value: "https://api.github.com"
+            {{- end }}
             - name: GITHUB_OWNER
-              value: "openova-io"
-            - name: GITHUB_REPO
+            {{- if .Values.smeServices.provisioning.git.owner }}
+              value: {{ .Values.smeServices.provisioning.git.owner | quote }}
+            {{- else if .Values.global.sovereignFQDN }}
               value: "openova"
+            {{- else }}
+              value: "openova-io"
+            {{- end }}
+            - name: GITHUB_REPO
+              value: {{ .Values.smeServices.provisioning.git.repo | default "openova" | quote }}
+            - name: GITHUB_BRANCH
+              value: {{ .Values.smeServices.provisioning.git.branch | default "main" | quote }}
           resources:
             requests:
               cpu: 25m

--- a/products/catalyst/chart/templates/sme-services/sme-secrets.yaml
+++ b/products/catalyst/chart/templates/sme-services/sme-secrets.yaml
@@ -105,6 +105,69 @@ per-Sovereign overlay or admin-console signup form).
     {{- end -}}
   {{- end -}}
 {{- end -}}
+{{- /*
+---- Sovereign SMTP source-wins lookup (issue #934) ------------------
+
+Pre-#934 the auth + notification SME services pinned SMTP_HOST/PORT/
+USER/PASS to the bytes the operator placed in this `sme-secrets`
+Secret via .Values.smeSecrets.smtp.*. On a freshly franchised
+Sovereign nothing populates those values (the per-Sovereign overlay
+can't carry plaintext SMTP creds), so auth.yaml's POST /auth/send-pin
+returned `failed to send email` and blocked alice signup gate 2 (PIN
+delivery).
+
+Fix: the SAME `catalyst-system/sovereign-smtp-credentials` Secret that
+catalyst-openova-kc-credentials reads (per A5's pattern in chart
+1.4.20) becomes the source-of-truth for the SME services' SMTP env.
+Cloud-init seeds that Secret at provision time (issue #883) with the
+mothership relay creds OR — once bp-stalwart-sovereign reaches Ready
+(slot 95) — with the Sovereign-local relay coordinates. Either way
+SME services consume real bytes on first reconcile.
+
+Source-wins precedence: when the source Secret carries non-empty
+bytes they override anything in .Values.smeSecrets.smtp.*. The
+chart-level defaults remain available as fallbacks for environments
+without the A5 seed (legacy contabo path) where the operator brings
+the values via overlay. Five fields are read with the canonical key
+shape (smtp-host / smtp-port / smtp-from / smtp-user / smtp-pass)
+AND the legacy shape (host / port / from / user / password) for
+back-compat with the chart 1.4.20 catalyst-openova-kc-credentials
+seam.
+
+Source-Secret namespace + name are operator-overridable via
+.Values.smeSecrets.smtp.sovereign{Namespace,SecretName} for unusual
+topologies (e.g. a per-Sovereign overlay that places the seeded
+Secret in a different namespace). Defaults match A5 PR #905.
+*/ -}}
+{{- $sovSMTPNs := .Values.smeSecrets.smtp.sovereignNamespace | default "catalyst-system" -}}
+{{- $sovSMTPName := .Values.smeSecrets.smtp.sovereignSecretName | default "sovereign-smtp-credentials" -}}
+{{- $sovSMTPSecret := lookup "v1" "Secret" $sovSMTPNs $sovSMTPName -}}
+{{- $sovSMTPHost := "" -}}
+{{- $sovSMTPPort := "" -}}
+{{- $sovSMTPFrom := "" -}}
+{{- $sovSMTPUser := "" -}}
+{{- $sovSMTPPass := "" -}}
+{{- if and $sovSMTPSecret $sovSMTPSecret.data -}}
+  {{- $d := $sovSMTPSecret.data -}}
+  {{- /* canonical key shape */ -}}
+  {{- if hasKey $d "smtp-host" -}}{{ $sovSMTPHost = index $d "smtp-host" | b64dec -}}{{- end -}}
+  {{- if hasKey $d "smtp-port" -}}{{ $sovSMTPPort = index $d "smtp-port" | b64dec -}}{{- end -}}
+  {{- if hasKey $d "smtp-from" -}}{{ $sovSMTPFrom = index $d "smtp-from" | b64dec -}}{{- end -}}
+  {{- if hasKey $d "smtp-user" -}}{{ $sovSMTPUser = index $d "smtp-user" | b64dec -}}{{- end -}}
+  {{- if hasKey $d "smtp-pass" -}}{{ $sovSMTPPass = index $d "smtp-pass" | b64dec -}}{{- end -}}
+  {{- /* legacy key shape (back-compat) */ -}}
+  {{- if and (eq $sovSMTPHost "") (hasKey $d "host") -}}{{ $sovSMTPHost = index $d "host" | b64dec -}}{{- end -}}
+  {{- if and (eq $sovSMTPPort "") (hasKey $d "port") -}}{{ $sovSMTPPort = index $d "port" | b64dec -}}{{- end -}}
+  {{- if and (eq $sovSMTPFrom "") (hasKey $d "from") -}}{{ $sovSMTPFrom = index $d "from" | b64dec -}}{{- end -}}
+  {{- if and (eq $sovSMTPUser "") (hasKey $d "user") -}}{{ $sovSMTPUser = index $d "user" | b64dec -}}{{- end -}}
+  {{- if and (eq $sovSMTPPass "") (hasKey $d "password") -}}{{ $sovSMTPPass = index $d "password" | b64dec -}}{{- end -}}
+{{- end -}}
+{{- /* Effective values: source-wins for every non-empty source byte */ -}}
+{{- $effSMTPHost := ternary $sovSMTPHost (default "" .Values.smeSecrets.smtp.host) (ne $sovSMTPHost "") -}}
+{{- $effSMTPPort := ternary $sovSMTPPort (.Values.smeSecrets.smtp.port | toString) (ne $sovSMTPPort "") -}}
+{{- $effSMTPFrom := ternary $sovSMTPFrom (default "" .Values.smeSecrets.smtp.from) (ne $sovSMTPFrom "") -}}
+{{- $effSMTPUser := ternary $sovSMTPUser (default "" .Values.smeSecrets.smtp.user) (ne $sovSMTPUser "") -}}
+{{- $effSMTPPass := ternary $sovSMTPPass $smtpPass (ne $sovSMTPPass "") -}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -128,12 +191,16 @@ data:
   # ---- Google OAuth (operator-supplied) ----
   GOOGLE_CLIENT_ID: {{ $googleClientID | b64enc | quote }}
   GOOGLE_CLIENT_SECRET: {{ $googleClientSecret | b64enc | quote }}
-  # ---- SMTP (operator-supplied; defaults safe for non-marketplace Sovereigns) ----
-  SMTP_HOST: {{ .Values.smeSecrets.smtp.host | default "" | b64enc | quote }}
-  SMTP_PORT: {{ .Values.smeSecrets.smtp.port | toString | default "" | b64enc | quote }}
-  SMTP_FROM: {{ .Values.smeSecrets.smtp.from | default "" | b64enc | quote }}
-  SMTP_USER: {{ .Values.smeSecrets.smtp.user | default "" | b64enc | quote }}
-  SMTP_PASS: {{ $smtpPass | b64enc | quote }}
+  # ---- SMTP (issue #934 source-wins from sovereign-smtp-credentials) ----
+  # Source-wins precedence: catalyst-system/sovereign-smtp-credentials
+  # (seeded by A5's provisioner #883/#905) overrides chart-level
+  # defaults whenever it carries non-empty bytes for each field.
+  # Empty source ⇒ falls back to .Values.smeSecrets.smtp.* defaults.
+  SMTP_HOST: {{ $effSMTPHost | b64enc | quote }}
+  SMTP_PORT: {{ $effSMTPPort | b64enc | quote }}
+  SMTP_FROM: {{ $effSMTPFrom | b64enc | quote }}
+  SMTP_USER: {{ $effSMTPUser | b64enc | quote }}
+  SMTP_PASS: {{ $effSMTPPass | b64enc | quote }}
   # ---- Admin bootstrap (email static, password persistent random) ----
   ADMIN_EMAIL: {{ .Values.smeSecrets.admin.email | default "admin@openova.io" | b64enc | quote }}
   ADMIN_PASSWORD: {{ $adminPassword | b64enc | quote }}

--- a/products/catalyst/chart/values.yaml
+++ b/products/catalyst/chart/values.yaml
@@ -376,6 +376,16 @@ smeSecrets:
   secretName: sme-secrets
   namespace: sme
   smtp:
+    # ─── Sovereign source-Secret (issue #934) ────────────────────────
+    # On a freshly franchised Sovereign the SMTP creds are seeded by
+    # cloud-init / A5's provisioner (#883/#905) into
+    # `catalyst-system/sovereign-smtp-credentials`. The sme-secrets
+    # template reads from there with source-wins precedence so any
+    # non-empty bytes override the chart-level defaults below. Empty
+    # source falls back to the defaults so non-Sovereign (contabo)
+    # installs keep working unchanged.
+    sovereignNamespace: catalyst-system
+    sovereignSecretName: sovereign-smtp-credentials
     # In-cluster Stalwart Service URL, or per-Sovereign override pointing
     # at the operator's preferred relay. Empty default means non-
     # marketplace Sovereigns stay clean (the Secret renders with empty
@@ -414,6 +424,22 @@ smeSecrets:
 # CNPG postgres:16; valkey-primary as the bp-valkey 1.0.0 read/write
 # Service name).
 smeServices:
+  # ─── Event bus (issue #942) ────────────────────────────────────────────
+  # Per ADR-0001 the OpenOva architecture uses NATS JetStream as the only
+  # local bus on Sovereigns. On Catalyst-Zero (contabo) the legacy SME
+  # services still target a Redpanda Service in the talentmesh namespace
+  # (migration #68). The configmap.yaml template selects the default at
+  # render time based on .Values.global.sovereignFQDN:
+  #   - non-empty (Sovereign)  → nats-jetstream.nats-jetstream.svc:4222
+  #   - empty (Catalyst-Zero) → redpanda.talentmesh.svc:9092
+  # `brokers` overrides the default outright — operator MAY wire any
+  # NATS-protocol or Kafka-protocol broker without forking the chart.
+  # `protocol` is an explicit hint for SME services that want to switch
+  # wire format independently (e.g. a Sovereign with a Kafka-compatible
+  # broker outside the cluster).
+  eventBus:
+    brokers: ""
+    protocol: ""
   ferretdb:
     namespace: sme
     # FerretDB v1.24 — works against vanilla CNPG postgres:16. v2.x
@@ -509,3 +535,38 @@ smeServices:
       destNamespace: sme
       destSecretName: provisioning-github-token
       destKey: GITHUB_TOKEN
+    # ─── Provisioning service GitOps env (issues #940 + #944) ──────────
+    # The SME provisioning service Deployment env block is rendered from
+    # these keys. Every value is operator-overridable per Inviolable
+    # Principle #4. Defaults are topology-aware:
+    #   - Sovereign install (global.sovereignFQDN non-empty) defaults
+    #     gitBasePath to clusters/<sovereignFQDN>/sme-tenants and points
+    #     git.{apiURL,owner} at the local Gitea bp-gitea installs.
+    #   - Catalyst-Zero install (global.sovereignFQDN empty) keeps the
+    #     legacy contabo-mkt write target.
+    #
+    # gitBasePath: filesystem prefix under the cloned repo root. When
+    # non-empty, takes precedence over the topology default. The
+    # provisioning binary's startup guard (validateGitBasePath in
+    # core/services/provisioning/main.go) rejects values that don't
+    # start with `clusters/<SOVEREIGN_FQDN>/` on Sovereigns — the
+    # cross-cluster pollution defence (#944 critical).
+    gitBasePath: ""
+    # githubToken: Secret name + key the Deployment reads GITHUB_TOKEN
+    # from. Defaults match the chart-emitted
+    # templates/sme-services/provisioning-github-token.yaml output
+    # (issue #866). Operator may swap to a per-Sovereign ExternalSecret
+    # by setting both fields here.
+    githubToken:
+      secretName: provisioning-github-token
+      secretKey: GITHUB_TOKEN
+    # git.{apiURL,owner,repo,branch}: Git host coordinates. The
+    # provisioning binary uses GITHUB_API_URL when non-empty (Sovereign
+    # path → in-cluster Gitea REST API) and otherwise falls back to the
+    # canonical https://api.github.com (contabo path). All four values
+    # are operator-overridable.
+    git:
+      apiURL: ""
+      owner: ""
+      repo: openova
+      branch: main


### PR DESCRIPTION
## Summary

Six coupled chart + orchestrator fixes that unblock alice marketplace signup → tenant ready → SaaS integrations → LLM → ledger on a freshly franchised Sovereign. C5-final got Gate 1 GREEN on otech113 (2026-05-05) but every downstream gate failed because the SME bundle hardcoded contabo-only assumptions.

Shipping as **one consolidated PR** — smaller PRs would race against alice signup retries.

## Bumps

- `bp-catalyst-platform`: 1.4.21 → **1.4.22**
- `bp-newapi`:           1.3.0 → **1.4.0**
- `clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml` slot pin updated
- `clusters/_template/bootstrap-kit/80-newapi.yaml` slot pin updated

## Issues addressed

| # | Symptom | Fix |
|---|---------|-----|
| #934 | auth `failed to send email` (gate 2 PIN delivery) | sme-secrets.yaml reads SMTP_* from `catalyst-system/sovereign-smtp-credentials` with source-wins precedence (canonical + legacy key shapes) |
| #940 | provisioning service hardcoded to upstream `github.com/openova-io/openova` + accepts placeholder GITHUB_TOKEN | chart values templates GitHub-API coords with topology-aware defaults; binary rejects placeholder tokens at startup; GitHub client supports custom API URL → in-cluster Gitea |
| #941 | marketplace UI "27 apps COMING SOON" (gates 4 LLM + 5 mail) | added `openclaw` + `stalwart-mail` to migrateAppDeployable map; extracted to DeployableAppSlugs() for unit testing |
| #942 | SME services crashloop `lookup redpanda.talentmesh.svc.cluster.local` (gate 3) | configmap.yaml selects broker default per topology — Sovereign ⇒ NATS JetStream (per ADR-0001), contabo ⇒ legacy Redpanda |
| #943 | bp-newapi Deployment never renders on Sovereigns (gate 5 LLM) | NEW cnpg-cluster.yaml auto-provisions CNPG Postgres + DSN Secret; NEW credentials-secret.yaml auto-generates SESSION_SECRET/CRYPTO_SECRET via Helm `lookup` persistence; deployment.yaml gate now passes by default |
| #944 | **CRITICAL cross-cluster pollution** — Sovereign provisioning service writes alice tenants into `clusters/contabo-mkt/tenants/` causing contabo Flux to install them on the wrong cluster (the 5715db04 alice2 incident) | provisioning.yaml templates GIT_BASE_PATH per-Sovereign; NEW `core/services/provisioning/gitguard` package validates at startup AND on every commit that the path begins with `clusters/<self-FQDN>/` — refuses commits to any foreign cluster's tree. Defence in depth so runtime env mutations cannot bypass the check |

## Test plan

- [x] `go test ./core/services/provisioning/...` — gitguard 22 cases pass (Sovereign happy paths, contabo happy paths, traversal/absolute-path rejection, prefix-collision rejection like `otech113-evil`, empty-path rejection, placeholder-token rejection)
- [x] `go test ./core/services/catalog/...` — DeployableAppSlugs includes openclaw + stalwart-mail; stable-shape lock prevents accidental delete
- [x] `helm template` smoke — bp-newapi renders Deployment + auto-provisioned Secrets without operator-supplied existingSecret values
- [x] `helm template` smoke — bp-catalyst-platform Sovereign render shows `GIT_BASE_PATH=clusters/otech113.omani.works/sme-tenants`, `REDPANDA_BROKERS=nats-jetstream.nats-jetstream.svc.cluster.local:4222`, `GITHUB_OWNER=openova`, `GITHUB_API_URL=http://gitea-http.gitea.svc.cluster.local:3000/api/v1`
- [x] `helm template` smoke — bp-catalyst-platform contabo render preserves legacy values (`clusters/contabo-mkt/tenants`, `redpanda.talentmesh.svc.cluster.local:9092`, `openova-io`, `https://api.github.com`)
- [x] `go vet`, `go build` clean across affected modules
- [ ] **Live verification on otech113** after Blueprint Release CI publishes 1.4.22 + force-push of this commit into otech113's local Gitea: alice signup reaches gate 6 (ledger)

## Notes

The catalyst-api SME-tenant orchestrator (`sme_tenant_gitops.go::WriteTenantOverlay`) was ALREADY computing the per-tenant overlay path correctly via `rec.OTECHFQDN` — no change needed there. The cross-cluster pollution risk lived entirely in the SME `provisioning` service (a separate Go binary at `core/services/provisioning`), which is what this PR fixes.

The pre-existing test failure in `products/catalyst/bootstrap/api/internal/provisioner` (about `CATALYST_HARBOR_ROBOT_TOKEN` env) is unrelated to this PR — confirmed present on `main` before any of these changes.

Closes #934 #940 #941 #942 #943 #944
Refs umbrella #915

🤖 Generated with [Claude Code](https://claude.com/claude-code)