### PR TITLE
fix(bp-catalyst-platform): populate smeSecrets.smtp defaults — gate 2 unblock (#934 followup)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -212,7 +212,13 @@ spec:
       # contabo-mkt; chart values now template per-Sovereign with
       # provisioning-binary Go-side validation guard refusing commits
       # to foreign cluster trees). 2026-05-05.
-      version: 1.4.22
+      # 1.4.23: deploy-bot auto-bump (services-auth image SHA roll).
+      # 1.4.24 (#934 follow-up): smeSecrets.smtp.{host,port,from,user}
+      # defaults populated with mothership relay (mail.openova.io:587)
+      # so SME auth Pod's PIN delivery (gate 2) works on Sovereigns
+      # whose A5-seeded sovereign-smtp-credentials Secret only carries
+      # smtp-user + smtp-pass without host/port/from. 2026-05-05.
+      version: 1.4.24
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -103,8 +103,20 @@ name: bp-catalyst-platform
 # carried only credentials and the chart fell back to
 # .Values.sovereign.smtp.* defaults — that fallback path remains as
 # the Sovereign-without-bp-stalwart-sovereign back-compat seam.
-version: 1.4.23
-appVersion: 1.4.23
+# 1.4.24 (#934 follow-up): smeSecrets.smtp.{host,port,from,user}
+# defaults flipped from "" to the mothership relay
+# (mail.openova.io:587, noreply@openova.io). On otech113 the
+# `catalyst-system/sovereign-smtp-credentials` Secret seeded by A5's
+# provisioner only carried smtp-user + smtp-pass (host/port/from
+# missing in the seed) — sme-secrets source-wins lookup correctly
+# kept SMTP_HOST="" because the source field was unset, but the
+# auth Pod then failed `failed to send email` for gate 2 (PIN
+# delivery). Defaults match `.Values.sovereign.smtp.*` which is the
+# proven catalyst-api PIN delivery path. When A5 ships the missing
+# host/port/from coverage these defaults become unused (source wins).
+# 2026-05-05.
+version: 1.4.24
+appVersion: 1.4.24
 description: |
   Catalyst Platform — the unified Catalyst control plane umbrella chart for Catalyst-Zero.
   Composes the catalyst-{ui,api}, console, admin, marketplace UI modules and the marketplace-api backend.

--- a/products/catalyst/chart/values.yaml
+++ b/products/catalyst/chart/values.yaml
@@ -386,15 +386,21 @@ smeSecrets:
     # installs keep working unchanged.
     sovereignNamespace: catalyst-system
     sovereignSecretName: sovereign-smtp-credentials
-    # In-cluster Stalwart Service URL, or per-Sovereign override pointing
-    # at the operator's preferred relay. Empty default means non-
-    # marketplace Sovereigns stay clean (the Secret renders with empty
-    # SMTP_HOST and the SMTP-using services degrade gracefully — no
-    # outbound mail attempted).
-    host: ""                                  # e.g. "stalwart-mail.stalwart.svc.cluster.local"
-    port: ""                                  # e.g. "587"
-    from: ""                                  # e.g. "noreply@<sov-fqdn>"
-    user: ""                                  # SMTP submission username (often == from)
+    # Defaults match `.Values.sovereign.smtp.*` (the catalyst-api PIN
+    # delivery path) so the SME auth service uses the same mothership
+    # relay coordinates as the catalyst Console PIN flow until the
+    # Sovereign-local Stalwart relay (slot 95 bp-stalwart-sovereign)
+    # lands. The SMTP source-Secret (catalyst-system/sovereign-smtp-
+    # credentials) is layered on top via source-wins precedence in
+    # sme-secrets.yaml — when A5's provisioner (#883/#905) seeds the
+    # canonical key shape (smtp-host/port/from), those bytes win over
+    # these fallbacks. Until A5 ships full host/port/from coverage
+    # the chart-level fallback keeps gate 2 (PIN delivery) working.
+    # Issue #934 follow-up.
+    host: "mail.openova.io"
+    port: "587"
+    from: "noreply@openova.io"
+    user: "noreply@openova.io"                # SMTP submission username (often == from)
     # SMTP_PASS is sensitive — never inline it. Reference an existing
     # Secret in the `sme` namespace (the per-Sovereign overlay typically
     # creates this from cloud-init or via OpenBao + ExternalSecret).


### PR DESCRIPTION
## Summary

Live verification on otech113 (2026-05-05) after PR #951 (chart 1.4.22) landed showed the SME auth Pod still failing PIN delivery for alice signup gate 2:

- `catalyst-system/sovereign-smtp-credentials` Secret (seeded by A5's provisioner #883/#905) only carries `smtp-user` + `smtp-pass`. Host/port/from coverage is missing in the seed.
- The #934 source-wins lookup correctly preserved the empty chart-level fallbacks for those fields → auth Pod sent `SMTP_HOST=""` and gate 2 (PIN delivery) failed with `failed to send email`.

Fix: flip `.Values.smeSecrets.smtp.{host,port,from,user}` defaults from `""` to the mothership relay (`mail.openova.io:587` / `noreply@openova.io`) — the SAME values `.Values.sovereign.smtp.*` uses for the catalyst-api PIN delivery path that is already proven on otech113. When A5 ships full host/port/from coverage in `sovereign-smtp-credentials`, the source-wins precedence in sme-secrets.yaml makes these defaults unused.

## Bumps

- `bp-catalyst-platform`: 1.4.23 → **1.4.24**
- `clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml` slot pin

## Test plan

- [x] `helm template` smoke shows SMTP_HOST=`mail.openova.io`, SMTP_PORT=`587`, SMTP_FROM=`noreply@openova.io`, SMTP_USER=`noreply@openova.io` on Sovereign render
- [x] Source-wins precedence preserved — when source Secret has `smtp-host`, source still wins
- [ ] Live verification on otech113 after Blueprint Release CI publishes 1.4.24 + Flux reconciles: auth Pod's POST `/auth/send-pin` returns 200, alice signup gate 2 GREEN

Refs #934 (closed by parent PR #951; this follow-up unblocks the live gate-2 verification on otech113).

🤖 Generated with [Claude Code](https://claude.com/claude-code)