### PR TITLE
fix(bp-newapi+services-build): imagePullSecrets + values.yaml smeTag bump (#952 #953)

### DIFF
--- a/.github/workflows/services-build.yaml
+++ b/.github/workflows/services-build.yaml
@@ -93,14 +93,62 @@ jobs:
           SHA=$(echo $GITHUB_SHA | head -c 7)
           DEPLOY_DIR="products/catalyst/chart/templates/sme-services"
           CHART_YAML="products/catalyst/chart/Chart.yaml"
+          VALUES_YAML="products/catalyst/chart/values.yaml"
 
+          # ──────────────────────────────────────────────────────────
+          # Issue #953: 7 of 8 sme-services templates render their
+          # image as `{{ .Values.images.smeTag }}` — the chart's
+          # values.yaml `images.smeTag` field is the SINGLE source of
+          # truth for those Pods. Only `auth.yaml` keeps a hardcoded
+          # `image: ghcr.io/...:<sha>` line (held at the older shape
+          # because of a historical InvalidImageName quirk).
+          #
+          # Pre-#953 this loop only ran a sed against the hardcoded
+          # form. The 7 templated services silently no-op'd and the
+          # deploy commit reported "update sme service images to
+          # ${SHA}" while only auth.yaml actually rolled. Result:
+          # every fix to catalog/tenant/etc. shipped the merge but
+          # the live Pod kept running pre-fix bytes (caught live on
+          # otech113 — services-catalog Pod still on 95a06f5 after
+          # PR #951's commit `68927688` claimed it deployed).
+          #
+          # Fix: bump `images.smeTag` in values.yaml AS WELL AS the
+          # hardcoded auth.yaml line. The values.yaml bump rolls
+          # all 7 templated services on the next chart release; the
+          # auth.yaml sed keeps the special-cased Pod on the same
+          # SHA. This stays event-driven (the push to main triggers
+          # this workflow); cron is intentionally absent per
+          # CLAUDE.md (every workflow MUST be event-driven, never
+          # scheduled).
+          # ──────────────────────────────────────────────────────────
+
+          # Hardcoded form — auth.yaml only. Kept until auth.yaml is
+          # re-templated (issue #953 fix scope was values.yaml; the
+          # back-compat hardcoded loop is preserved so a future
+          # auth-template flip is a no-op for this workflow).
           for svc in auth catalog gateway tenant domain billing provisioning notification; do
             FILE="${DEPLOY_DIR}/${svc}.yaml"
             if [ -f "$FILE" ]; then
               sed -i "s|image: ${IMAGE_BASE}-${svc}:.*|image: ${IMAGE_BASE}-${svc}:${SHA}|" "$FILE"
-              echo "Updated ${svc} to SHA ${SHA}"
+              echo "Updated ${svc} hardcoded image refs (no-op for templated forms) to SHA ${SHA}"
             fi
           done
+
+          # Templated form — bump `images.smeTag` in values.yaml so
+          # the 7 templated services (catalog, gateway, tenant,
+          # domain, billing, provisioning, notification) all roll on
+          # the next chart release. Match the canonical 2-space
+          # indented form `  smeTag: "<sha>"` (with quotes) emitted
+          # by the chart's existing values.yaml shape; refuse to
+          # auto-bump if the line is missing or shaped differently
+          # so a contributor renaming the field does not silently
+          # break this workflow's promise.
+          if ! grep -Eq '^  smeTag: "[A-Za-z0-9_.-]*"$' "${VALUES_YAML}"; then
+            echo "::error title=smeTag field missing or unparseable::Expected '  smeTag: \"<sha>\"' line in ${VALUES_YAML}; refusing to auto-bump."
+            exit 1
+          fi
+          sed -i "s|^  smeTag: \"[A-Za-z0-9_.-]*\"$|  smeTag: \"${SHA}\"|" "${VALUES_YAML}"
+          echo "Bumped ${VALUES_YAML} images.smeTag to ${SHA}"
 
           # Patch-bump Chart.yaml `version:` and `appVersion:` (kept in
           # lockstep — the chart reflects the bundled appVersion via
@@ -128,6 +176,7 @@ jobs:
           SHA=$(echo $GITHUB_SHA | head -c 7)
           DEPLOY_DIR="products/catalyst/chart/templates/sme-services"
           CHART_YAML="products/catalyst/chart/Chart.yaml"
+          VALUES_YAML="products/catalyst/chart/values.yaml"
 
           # Idempotent reset-and-rewrite. Parallel/back-to-back CI runs
           # both try to update the same `image:` lines AND the same
@@ -137,6 +186,12 @@ jobs:
           # version origin/main currently holds and bump from THAT, so
           # two concurrent runs produce strictly increasing patch
           # versions instead of clobbering each other.
+          #
+          # Issue #953: rewrite() must mirror the values.yaml smeTag
+          # bump that the rewrite step does — otherwise a retry that
+          # reset-to-origin/main would leave values.yaml on the OLD
+          # SHA and only auth.yaml would carry the new SHA, recreating
+          # the original bug under any push-conflict scenario.
           rewrite() {
             for svc in auth catalog gateway tenant domain billing provisioning notification; do
               FILE="${DEPLOY_DIR}/${svc}.yaml"
@@ -144,6 +199,11 @@ jobs:
                 sed -i "s|image: ${IMAGE_BASE}-${svc}:.*|image: ${IMAGE_BASE}-${svc}:${SHA}|" "$FILE"
               fi
             done
+            if ! grep -Eq '^  smeTag: "[A-Za-z0-9_.-]*"$' "${VALUES_YAML}"; then
+              echo "::error title=smeTag field missing on retry::Expected '  smeTag: \"<sha>\"' line in ${VALUES_YAML}."
+              exit 1
+            fi
+            sed -i "s|^  smeTag: \"[A-Za-z0-9_.-]*\"$|  smeTag: \"${SHA}\"|" "${VALUES_YAML}"
             current=$(awk '/^version:/{print $2; exit}' "${CHART_YAML}" | tr -d '"')
             if ! echo "$current" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
               echo "::error title=Unparseable chart version on retry::Chart.yaml version='${current}' is not semver."

--- a/clusters/_template/bootstrap-kit/80-newapi.yaml
+++ b/clusters/_template/bootstrap-kit/80-newapi.yaml
@@ -79,7 +79,12 @@ spec:
       # integration DoD: alice → OpenClaw → NewAPI → Qwen3.6@BankDhofar
       # end-to-end).
       # 1.2.0: Traefik Middleware gated behind ingress.middleware.enabled.
-      version: 1.4.0
+      # 1.4.1 (issue #952, 2026-05-05): Pod imagePullSecrets templated +
+      # default to `[{name: ghcr-pull}]` so kubelet authenticates pulls
+      # of the PRIVATE newapi-mirror + metering-sidecar images. Paired
+      # with cloud-init adding `newapi` to flux-system/ghcr-pull's
+      # reflector auto-namespaces list.
+      version: 1.4.1
       sourceRef:
         kind: HelmRepository
         name: bp-newapi

--- a/infra/hetzner/cloudinit-control-plane.tftpl
+++ b/infra/hetzner/cloudinit-control-plane.tftpl
@@ -190,10 +190,17 @@ write_files:
           # otech103 verified live. Future namespaces added to the
           # bootstrap-kit (a new bp-* slot) only need an addition here
           # plus a Pod restart to pick up the new mirror.
+          #
+          # Issue #952 (2026-05-05): added `newapi` — the bp-newapi
+          # bootstrap-kit slot 80 lands its Deployment in this namespace
+          # and pulls PRIVATE `newapi-mirror` + `services-metering-sidecar`
+          # images. Without `newapi` on this list the Pod stalls in
+          # ImagePullBackOff with 403 Forbidden, blocking alice signup
+          # gate 5 (LLM). Caught live on otech113.
           reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
-          reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "sme,catalyst,catalyst-system,gitea,harbor"
+          reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "sme,catalyst,catalyst-system,gitea,harbor,newapi"
           reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
-          reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: "sme,catalyst,catalyst-system,gitea,harbor"
+          reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: "sme,catalyst,catalyst-system,gitea,harbor,newapi"
       type: kubernetes.io/dockerconfigjson
       data:
         .dockerconfigjson: ${base64encode(jsonencode({

--- a/platform/newapi/chart/Chart.yaml
+++ b/platform/newapi/chart/Chart.yaml
@@ -1,5 +1,17 @@
 apiVersion: v2
 name: bp-newapi
+# 1.4.1 (issue #952, 2026-05-05): templatize spec.imagePullSecrets on the
+# Deployment + channel-seed Job and default `imagePullSecrets:
+# [{name: ghcr-pull}]` in values.yaml. Pre-1.4.1 the Pod template emitted
+# no imagePullSecrets, so kubelet pulled the PRIVATE
+# `ghcr.io/openova-io/openova/newapi-mirror` and
+# `ghcr.io/openova-io/openova/services-metering-sidecar` images
+# anonymously and got 403 Forbidden on every fresh Sovereign — blocking
+# alice signup gate 5 (LLM). The cloud-init `flux-system/ghcr-pull`
+# Secret is reflected into the `newapi` namespace via bp-reflector
+# annotations (paired with #952 cloud-init update adding `newapi` to the
+# `reflection-auto-namespaces` list).
+#
 # 1.4.0 (issue #943, 2026-05-05): auto-provision CNPG-backed Postgres +
 # in-chart credentials Secret so a Sovereign install at bootstrap-kit
 # slot 80 lands a real Pod without operator intervention.
@@ -46,7 +58,7 @@ name: bp-newapi
 # Issue #915 (epic SME tenant integration DoD: alice → OpenClaw →
 # NewAPI → Qwen3.6@BankDhofar end-to-end).
 # 1.2.0: Traefik Middleware gated behind ingress.middleware.enabled.
-version: 1.4.0
+version: 1.4.1
 appVersion: "0.4.5"
 description: |
   Catalyst Blueprint scratch chart for NewAPI — multi-tenant LLM

--- a/platform/newapi/chart/templates/channel-seed-job.yaml
+++ b/platform/newapi/chart/templates/channel-seed-job.yaml
@@ -187,6 +187,16 @@ spec:
     spec:
       restartPolicy: OnFailure
       serviceAccountName: {{ $jobName }}
+      {{- with .Values.imagePullSecrets }}
+      # Issue #952: ensure the Job inherits the same `ghcr-pull` Secret
+      # as the NewAPI Deployment. The default `curlimages/curl` image
+      # lives on Docker Hub (public) so the Secret is harmless when
+      # unused, but operator overlays may swap in a private mirror at
+      # `ghcr.io/openova-io/openova/*` — in which case the imagePullSecret
+      # is REQUIRED for kubelet to authenticate the pull.
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       volumes:
         - name: tmp
           emptyDir:

--- a/platform/newapi/chart/templates/deployment.yaml
+++ b/platform/newapi/chart/templates/deployment.yaml
@@ -69,6 +69,19 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
     spec:
       serviceAccountName: {{ include "bp-newapi.serviceAccountName" . }}
+      {{- with .Values.imagePullSecrets }}
+      # Issue #952: NewAPI image (`newapi-mirror`) and the metering
+      # sidecar both live in PRIVATE ghcr.io/openova-io/openova/*
+      # repositories — kubelet must authenticate to pull. The canonical
+      # `ghcr-pull` Secret is reflected into every namespace listed in
+      # bp-reflector's annotations on flux-system/ghcr-pull (cloud-init
+      # writes the source Secret with `reflection-auto-namespaces`
+      # explicitly enumerating `newapi`). Without these references the
+      # Pod stalls in ImagePullBackOff with a 403 Forbidden, blocking
+      # alice signup gate 5 (LLM) on every fresh Sovereign.
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       securityContext:
         {{- toYaml .Values.newapi.securityContext | nindent 8 }}
       containers:

--- a/platform/newapi/chart/tests/imagepullsecrets-render.sh
+++ b/platform/newapi/chart/tests/imagepullsecrets-render.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+# bp-newapi — imagePullSecrets render audit (issue #952).
+#
+# Verifies the chart renders Pod-level imagePullSecrets so kubelet can
+# authenticate against the PRIVATE ghcr.io/openova-io/openova/* images
+# (newapi-mirror + services-metering-sidecar). Pre-1.4.1 the Pod
+# template emitted no imagePullSecrets and the live Pod stalled in
+# ImagePullBackOff with 403 Forbidden on every fresh Sovereign.
+#
+# Cases:
+#   1. Default values render — Deployment carries
+#      `imagePullSecrets: [{name: ghcr-pull}]`.
+#   2. Channel-seed Job (when default channel + master key are wired)
+#      also carries the imagePullSecrets reference.
+#   3. Operator override `imagePullSecrets: []` suppresses the block —
+#      relevant on clusters that pull strictly from public registries.
+#   4. Operator override with a custom secret name renders that name
+#      (per Inviolable Principle #4 — never hardcode).
+
+set -euo pipefail
+
+chart_dir="$(cd "$(dirname "$0")/.." && pwd)"
+helm="${HELM_BIN:-helm}"
+
+# Build chart deps once so `helm template` does not error on the
+# `common` library subchart reference.
+"$helm" dependency build "$chart_dir" >/dev/null 2>&1 || true
+
+# Common values that flip the Pod-render gate to TRUE — the gate
+# requires a database Secret AND credentials to be wireable AND
+# keycloak NOT in misconfigured mode. Use masterKey to skip the
+# keycloak issuer requirement so smoke render works without a
+# realistic per-Sovereign overlay.
+common_values=$(mktemp)
+trap 'rm -f "$common_values"' EXIT
+cat > "$common_values" <<'EOF'
+auth:
+  adminUI:
+    mode: masterKey
+database:
+  existingSecret: test-dsn
+EOF
+
+# ── Case 1: default render carries `ghcr-pull` ────────────────────────
+echo "[bp-newapi] Case 1: default render — imagePullSecrets present"
+out=$("$helm" template smoke "$chart_dir" -f "$common_values" 2>&1)
+
+# Pull the Deployment block out of the multi-doc render so we can
+# assert against the Pod template specifically (not any other manifest
+# that may also touch imagePullSecrets in the future).
+deployment_block=$(echo "$out" | awk '/^---$/{f=0} /^kind: Deployment$/{f=1} f')
+if [ -z "$deployment_block" ]; then
+  echo "FAIL: Deployment did not render"
+  exit 1
+fi
+
+if ! echo "$deployment_block" | grep -q "imagePullSecrets:"; then
+  echo "FAIL: Deployment has no imagePullSecrets block"
+  exit 1
+fi
+if ! echo "$deployment_block" | grep -q "name: ghcr-pull"; then
+  echo "FAIL: Deployment imagePullSecrets does not reference ghcr-pull"
+  exit 1
+fi
+echo "[bp-newapi] Case 1: PASS"
+
+# ── Case 2: channel-seed Job inherits the same secret ─────────────────
+echo "[bp-newapi] Case 2: channel-seed Job — imagePullSecrets present"
+seed_values=$(mktemp)
+cat > "$seed_values" <<'EOF'
+auth:
+  adminUI:
+    mode: masterKey
+    masterKeySecret: newapi-bootstrap-master-key
+database:
+  existingSecret: test-dsn
+defaultChannels:
+  qwenBankDhofar:
+    enabled: true
+    endpoint: https://llm-api.example.test
+    attestation:
+      kind: commercial-contract
+      accountId: TEST-ACCT
+      contractRef: TEST-CONTRACT
+EOF
+out2=$("$helm" template smoke "$chart_dir" -f "$seed_values" 2>&1)
+rm -f "$seed_values"
+
+job_block=$(echo "$out2" | awk '/^---$/{f=0} /^kind: Job$/{f=1} f')
+if [ -z "$job_block" ]; then
+  echo "FAIL: channel-seed Job did not render with default channel enabled"
+  exit 1
+fi
+if ! echo "$job_block" | grep -q "imagePullSecrets:"; then
+  echo "FAIL: channel-seed Job has no imagePullSecrets block"
+  exit 1
+fi
+if ! echo "$job_block" | grep -q "name: ghcr-pull"; then
+  echo "FAIL: channel-seed Job imagePullSecrets does not reference ghcr-pull"
+  exit 1
+fi
+echo "[bp-newapi] Case 2: PASS"
+
+# ── Case 3: operator override `imagePullSecrets: []` suppresses ───────
+echo "[bp-newapi] Case 3: empty override — imagePullSecrets omitted"
+empty_values=$(mktemp)
+cat > "$empty_values" <<'EOF'
+imagePullSecrets: []
+auth:
+  adminUI:
+    mode: masterKey
+database:
+  existingSecret: test-dsn
+EOF
+out3=$("$helm" template smoke "$chart_dir" -f "$empty_values" 2>&1)
+rm -f "$empty_values"
+
+deployment_block3=$(echo "$out3" | awk '/^---$/{f=0} /^kind: Deployment$/{f=1} f')
+if [ -z "$deployment_block3" ]; then
+  echo "FAIL: Deployment did not render with empty imagePullSecrets"
+  exit 1
+fi
+if echo "$deployment_block3" | grep -q "imagePullSecrets:"; then
+  echo "FAIL: empty override should suppress imagePullSecrets block (Inviolable Principle #4)"
+  exit 1
+fi
+echo "[bp-newapi] Case 3: PASS"
+
+# ── Case 4: custom secret name flows through ──────────────────────────
+echo "[bp-newapi] Case 4: custom secret name — operator override"
+custom_values=$(mktemp)
+cat > "$custom_values" <<'EOF'
+imagePullSecrets:
+  - name: my-private-registry-creds
+auth:
+  adminUI:
+    mode: masterKey
+database:
+  existingSecret: test-dsn
+EOF
+out4=$("$helm" template smoke "$chart_dir" -f "$custom_values" 2>&1)
+rm -f "$custom_values"
+
+deployment_block4=$(echo "$out4" | awk '/^---$/{f=0} /^kind: Deployment$/{f=1} f')
+if ! echo "$deployment_block4" | grep -q "name: my-private-registry-creds"; then
+  echo "FAIL: custom imagePullSecret name not propagated to Deployment"
+  exit 1
+fi
+if echo "$deployment_block4" | grep -q "name: ghcr-pull"; then
+  echo "FAIL: custom override leaked default ghcr-pull reference"
+  exit 1
+fi
+echo "[bp-newapi] Case 4: PASS"
+
+echo "[bp-newapi] All imagePullSecrets render cases PASS"

--- a/platform/newapi/chart/values.yaml
+++ b/platform/newapi/chart/values.yaml
@@ -15,6 +15,24 @@ catalystBlueprint:
     images:
       newapi: "ghcr.io/openova-io/openova/newapi-mirror"
 
+# ─── Image pull secrets (issue #952) ─────────────────────────────────────
+# Both the NewAPI mirror image and the metering sidecar live in PRIVATE
+# ghcr.io/openova-io/openova/* repositories. Without an imagePullSecret
+# on the Pod, kubelet cannot authenticate to pull them and the Pod stalls
+# in ImagePullBackOff with a 403 Forbidden — blocking alice signup gate
+# 5 (LLM) on every fresh Sovereign.
+#
+# `ghcr-pull` is the canonical name created in flux-system at cloud-init
+# (infra/hetzner/cloudinit-control-plane.tftpl) and reflected into every
+# bootstrap-kit namespace listed in the source Secret's
+# `reflector.v1.k8s.emberstack.com/reflection-{allowed,auto}-namespaces`
+# annotation. The newapi namespace is included in that list so this
+# default works on every Sovereign without operator intervention. Per
+# Inviolable Principle #4 the list is overrideable from per-Sovereign
+# overlays (set to `[]` for clusters that pull from public repos only).
+imagePullSecrets:
+  - name: ghcr-pull
+
 # ─── NewAPI application ──────────────────────────────────────────────────
 newapi:
   enabled: true

--- a/tests/integration/services-build-rewrite.sh
+++ b/tests/integration/services-build-rewrite.sh
@@ -1,0 +1,209 @@
+#!/usr/bin/env bash
+# tests/integration/services-build-rewrite.sh
+#
+# Issue #953 regression test for `.github/workflows/services-build.yaml`.
+#
+# Why this test exists
+# --------------------
+# 2026-05-05: the deploy step's image-rewrite loop only matched
+# hardcoded `image: ghcr.io/openova-io/openova/services-<svc>:<sha>`
+# lines. 7 of 8 sme-services templates are written in the templated
+# form `image: "{{ ... }}/services-<svc>:{{ .Values.images.smeTag }}"`
+# — the sed regex never matched those, so each services-build run
+# bumped only `auth.yaml` while reporting a successful deploy of all
+# eight services. Caught live on otech113: services-catalog Pod still
+# pulled `:95a06f5` after PR #951's commit `68927688` claimed it had
+# rolled out, so #941's catalog migration fix never reached the live
+# Pod despite the merge + chart bump + commit chain looking healthy.
+#
+# This test reproduces the exact rewrite logic the workflow runs
+# locally (no GitHub Actions runner needed) on a snapshot of
+# products/catalyst/chart/{templates/sme-services/*.yaml,values.yaml}
+# at HEAD, then asserts:
+#
+#   1. The hardcoded `auth.yaml` image gets bumped (back-compat is
+#      preserved).
+#   2. The 7 templated services' VALUES surface (`images.smeTag` in
+#      values.yaml) gets bumped to the new SHA — i.e. the chart will
+#      render every templated `image:` line at the new SHA on the
+#      next release.
+#   3. The other unrelated tag fields in values.yaml
+#      (`catalystApi.tag`, `console.tag`, etc.) are left untouched.
+#   4. A second invocation with a DIFFERENT SHA correctly re-bumps
+#      everything to the second SHA (idempotency / no-locking on the
+#      first SHA).
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/../.." && pwd)"
+deploy_dir="${repo_root}/products/catalyst/chart/templates/sme-services"
+values_yaml="${repo_root}/products/catalyst/chart/values.yaml"
+image_base="ghcr.io/openova-io/openova/services"
+
+# Sandbox copies — never mutate the live tree.
+sandbox=$(mktemp -d)
+trap 'rm -rf "$sandbox"' EXIT
+mkdir -p "${sandbox}/templates/sme-services"
+cp -r "${deploy_dir}"/*.yaml "${sandbox}/templates/sme-services/"
+cp "${values_yaml}" "${sandbox}/values.yaml"
+
+sandbox_deploy_dir="${sandbox}/templates/sme-services"
+sandbox_values="${sandbox}/values.yaml"
+
+# Apply the workflow's rewrite logic (verbatim copy of the bash
+# block that lives in services-build.yaml's `Update deployment
+# manifests` step, parameterised on the sandbox paths). If the
+# workflow body changes shape, this test must change in lockstep.
+rewrite() {
+  local SHA="$1"
+  for svc in auth catalog gateway tenant domain billing provisioning notification; do
+    local FILE="${sandbox_deploy_dir}/${svc}.yaml"
+    if [ -f "$FILE" ]; then
+      sed -i "s|image: ${image_base}-${svc}:.*|image: ${image_base}-${svc}:${SHA}|" "$FILE"
+    fi
+  done
+  if ! grep -Eq '^  smeTag: "[A-Za-z0-9_.-]*"$' "${sandbox_values}"; then
+    echo "FAIL: smeTag line not found in values.yaml"
+    return 1
+  fi
+  sed -i "s|^  smeTag: \"[A-Za-z0-9_.-]*\"$|  smeTag: \"${SHA}\"|" "${sandbox_values}"
+}
+
+# Capture pre-state so we can assert which fields changed.
+pre_catalystApi_tag=$(awk '/^  catalystApi:/{f=1; next} f && /tag:/{print; exit}' "${sandbox_values}")
+pre_console_tag=$(awk '/^  console:/{f=1; next} f && /tag:/{print; exit}' "${sandbox_values}")
+pre_marketplace_tag=$(awk '/^  marketplaceApi:/{f=1; next} f && /tag:/{print; exit}' "${sandbox_values}")
+
+# ── Case 1: bump to NEW_SHA_1 ─────────────────────────────────────────
+NEW_SHA_1="abc1234"
+echo "[services-build-rewrite] Case 1: bump to ${NEW_SHA_1}"
+rewrite "${NEW_SHA_1}"
+
+# auth.yaml hardcoded line bumped
+if ! grep -q "image: ${image_base}-auth:${NEW_SHA_1}" "${sandbox_deploy_dir}/auth.yaml"; then
+  echo "FAIL: auth.yaml hardcoded image not bumped to ${NEW_SHA_1}"
+  exit 1
+fi
+
+# values.yaml smeTag bumped
+if ! grep -q "^  smeTag: \"${NEW_SHA_1}\"$" "${sandbox_values}"; then
+  echo "FAIL: values.yaml smeTag not bumped to ${NEW_SHA_1}"
+  echo "Live smeTag line:"
+  grep "^  smeTag:" "${sandbox_values}"
+  exit 1
+fi
+
+# 7 templated services — verify their helm-rendered image tag now
+# resolves to the new SHA. Templated form is:
+#   image: "{{ ... }}/services-<svc>:{{ .Values.images.smeTag }}"
+# We do not rewrite those .yaml files directly; we rewrote the
+# values.yaml smeTag and that's what the chart consumes at render
+# time. Assert the templated-form lines are STILL templated (we did
+# not accidentally rewrite them to a hardcoded string) AND assert
+# the values.yaml change would feed them.
+for svc in catalog gateway tenant domain billing provisioning notification; do
+  if ! grep -q '{{ .Values.images.smeTag }}' "${sandbox_deploy_dir}/${svc}.yaml"; then
+    echo "FAIL: ${svc}.yaml lost its templated smeTag reference"
+    exit 1
+  fi
+done
+
+# Untouched tag fields preserved
+post_catalystApi_tag=$(awk '/^  catalystApi:/{f=1; next} f && /tag:/{print; exit}' "${sandbox_values}")
+post_console_tag=$(awk '/^  console:/{f=1; next} f && /tag:/{print; exit}' "${sandbox_values}")
+post_marketplace_tag=$(awk '/^  marketplaceApi:/{f=1; next} f && /tag:/{print; exit}' "${sandbox_values}")
+if [ "${pre_catalystApi_tag}" != "${post_catalystApi_tag}" ]; then
+  echo "FAIL: catalystApi.tag mutated unexpectedly"
+  echo "  pre:  ${pre_catalystApi_tag}"
+  echo "  post: ${post_catalystApi_tag}"
+  exit 1
+fi
+if [ "${pre_console_tag}" != "${post_console_tag}" ]; then
+  echo "FAIL: console.tag mutated unexpectedly"
+  exit 1
+fi
+if [ "${pre_marketplace_tag}" != "${post_marketplace_tag}" ]; then
+  echo "FAIL: marketplaceApi.tag mutated unexpectedly"
+  exit 1
+fi
+echo "[services-build-rewrite] Case 1: PASS"
+
+# ── Case 2: re-bump to NEW_SHA_2 (idempotency / second invocation) ────
+NEW_SHA_2="def5678"
+echo "[services-build-rewrite] Case 2: re-bump to ${NEW_SHA_2}"
+rewrite "${NEW_SHA_2}"
+
+if ! grep -q "image: ${image_base}-auth:${NEW_SHA_2}" "${sandbox_deploy_dir}/auth.yaml"; then
+  echo "FAIL: auth.yaml hardcoded image not re-bumped to ${NEW_SHA_2}"
+  exit 1
+fi
+if grep -q "image: ${image_base}-auth:${NEW_SHA_1}" "${sandbox_deploy_dir}/auth.yaml"; then
+  echo "FAIL: auth.yaml still references first SHA"
+  exit 1
+fi
+if ! grep -q "^  smeTag: \"${NEW_SHA_2}\"$" "${sandbox_values}"; then
+  echo "FAIL: values.yaml smeTag not re-bumped to ${NEW_SHA_2}"
+  exit 1
+fi
+if grep -q "^  smeTag: \"${NEW_SHA_1}\"$" "${sandbox_values}"; then
+  echo "FAIL: values.yaml smeTag still references first SHA"
+  exit 1
+fi
+echo "[services-build-rewrite] Case 2: PASS"
+
+# ── Case 3: helm-render assertion — actual SME-services Pods carry the
+# new SHA after the bump. Renders the catalyst chart with the sandbox
+# values.yaml + an enableSme override (the chart's existing dispatch
+# knob) and greps the resulting Deployment manifests for the SHA.
+# ──────────────────────────────────────────────────────────────────────
+echo "[services-build-rewrite] Case 3: helm-render — Pods carry new smeTag"
+helm="${HELM_BIN:-helm}"
+chart_root="${repo_root}/products/catalyst/chart"
+
+# Build chart deps once into a sandbox so we don't pollute the live
+# tree's charts/ directory.
+sandbox_chart="${sandbox}/catalyst-chart"
+cp -r "${chart_root}" "${sandbox_chart}"
+cp "${sandbox_values}" "${sandbox_chart}/values.yaml"
+# Carry over the rewritten sme-services templates (auth.yaml's
+# hardcoded image line is the one our sed loop touched in Cases 1/2;
+# the rest are unchanged but copying the directory wholesale is
+# cheaper than per-file conditional logic).
+cp -r "${sandbox_deploy_dir}"/*.yaml "${sandbox_chart}/templates/sme-services/"
+"$helm" dependency build "${sandbox_chart}" >/dev/null 2>&1 || true
+
+render_values=$(mktemp)
+cat > "${render_values}" <<'EOF'
+global:
+  sovereignFQDN: test.example.test
+ingress:
+  marketplace:
+    enabled: true
+EOF
+out=$("$helm" template smoke "${sandbox_chart}" -f "${render_values}" 2>&1 || true)
+rm -f "${render_values}"
+
+# Drop into a per-svc check: every templated SME service's image must
+# now reference NEW_SHA_2.
+fail=0
+for svc in catalog gateway tenant domain billing provisioning notification; do
+  if ! echo "$out" | grep -q "/services-${svc}:${NEW_SHA_2}"; then
+    echo "FAIL: helm-rendered ${svc} image does not carry SHA ${NEW_SHA_2}"
+    echo "  matched:"
+    echo "$out" | grep -E "image:.*/services-${svc}:" | head -3 || true
+    fail=1
+  fi
+done
+
+# auth.yaml is hardcoded — its rendered image must also carry the new SHA.
+if ! echo "$out" | grep -q "/services-auth:${NEW_SHA_2}"; then
+  echo "FAIL: helm-rendered auth image does not carry SHA ${NEW_SHA_2}"
+  fail=1
+fi
+
+if [ "$fail" -eq 1 ]; then
+  exit 1
+fi
+echo "[services-build-rewrite] Case 3: PASS"
+
+echo "[services-build-rewrite] All cases PASS"


### PR DESCRIPTION
## Summary

Two SME-blocker bugs caught live on otech113 (alice signup gate 5 fails on every fresh Sovereign).

### #952 — bp-newapi Pod has no imagePullSecrets

After PR #951 / chart 1.4.0, the NewAPI Deployment renders correctly with CNPG + credentials Secret, but `kubectl get pod -o jsonpath='{.spec.imagePullSecrets[*].name}'` returns empty. Both `ghcr.io/openova-io/openova/newapi-mirror:v0.4.5` and `ghcr.io/openova-io/openova/services-metering-sidecar:latest` are PRIVATE GHCR repos — kubelet returns 403 Forbidden on anonymous pull and the Pod stalls in `ImagePullBackOff` indefinitely.

Fix:
- Templatize `spec.imagePullSecrets` on `platform/newapi/chart/templates/deployment.yaml` AND `templates/channel-seed-job.yaml`.
- Default `values.yaml` `imagePullSecrets: [{name: ghcr-pull}]` so the canonical Secret is referenced out of the box.
- Add `newapi` to `flux-system/ghcr-pull`'s reflector `reflection-{allowed,auto}-namespaces` annotation in `infra/hetzner/cloudinit-control-plane.tftpl` so bp-reflector mirrors the source Secret into the namespace automatically on every fresh Sovereign (matches the canonical pattern caught in #879 Bonus Bug 6).
- Bump `bp-newapi` 1.4.0 -> 1.4.1, update `clusters/_template/bootstrap-kit/80-newapi.yaml` to reference the new chart version.

### #953 — services-build sed pattern misses 7 of 8 sme-services

`.github/workflows/services-build.yaml` only ran a sed against `image: ${IMAGE_BASE}-${svc}:.*`. 7 of 8 templates use the templated form `image: "{{ ... }}/services-<svc>:{{ .Values.images.smeTag }}"`. Each services-build run silently no-op'd 7 services while reporting "update sme service images to ${SHA}". PR #951's #941 fix to `migrateAppDeployable` never reached the live `services-catalog` Pod despite a successful chart bump + commit chain.

Fix:
- After the existing hardcoded loop (kept for back-compat with `auth.yaml`), also bump `images.smeTag` in `products/catalyst/chart/values.yaml` with a strict regex (`^  smeTag: "<sha>"$`). Refuse to auto-bump if the line shape changes — defends against silent drift if a contributor renames the field.
- Mirror the change into the retry-path `rewrite()` function so a reset-to-origin/main retry does not recreate the original bug under push-conflict scenarios.

## Tests

- `platform/newapi/chart/tests/imagepullsecrets-render.sh` — 4 cases:
  1. Default render — Deployment carries `imagePullSecrets: [{name: ghcr-pull}]`.
  2. channel-seed Job (when default channel + master key are wired) carries the same reference.
  3. Operator override `imagePullSecrets: []` suppresses the block (Inviolable Principle #4).
  4. Custom secret name flows through to the rendered Deployment.
- `tests/integration/services-build-rewrite.sh` — 3 cases:
  1. Bump to a synthetic `NEW_SHA_1` — auth.yaml hardcoded line bumped, values.yaml `smeTag` bumped, sibling tag fields (`catalystApi.tag`, `console.tag`, `marketplaceApi.tag`) preserved, all 7 templated services keep their templated form.
  2. Re-bump to `NEW_SHA_2` — both surfaces idempotently re-roll without locking on the first SHA.
  3. Helm-render assertion — render the catalyst chart with the bumped values.yaml + `ingress.marketplace.enabled: true` and grep that all 8 SME-service Deployments carry the new SHA in their `image:` line.

Both test suites run green locally.

## Test plan

- [x] `helm template smoke platform/newapi/chart -f <realistic-overlay>` — Deployment + Job carry `imagePullSecrets: [{name: ghcr-pull}]`
- [x] `platform/newapi/chart/tests/imagepullsecrets-render.sh` — 4/4 PASS
- [x] `tests/integration/services-build-rewrite.sh` — 3/3 PASS (incl. helm-render)
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/services-build.yaml'))"` — workflow YAML still valid
- [ ] Post-merge: live verify on next fresh Sovereign — newapi Pod transitions to Running (no more ImagePullBackOff), services-build commit shows values.yaml smeTag bumped alongside auth.yaml
- [ ] Post-merge: confirm bp-reflector mirrors `flux-system/ghcr-pull` into `newapi` namespace on otech-next

Refs #952 #953 (umbrella #915 — alice signup gate 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)