### PR TITLE
fix(cutover 0.1.18): poll /healthz for readiness, NOT auth-gated /status (#957)

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -162,7 +162,19 @@ spec:
       #     via TokenReview. The Job now mounts its projected SA
       #     token at /var/run/secrets/kubernetes.io/serviceaccount/
       #     token and sends it as `Authorization: Bearer <token>`.
-      version: 0.1.17
+      # 0.1.18: Auto-trigger readiness probe loops on 401 (#957).
+      #   0.1.17 polled /api/v1/sovereign/cutover/status to check
+      #   "is catalyst-api up yet?" That endpoint lives INSIDE
+      #   RequireSession and returned 401 to every unauthenticated
+      #   probe from the in-cluster Job. The probe treated 401 as
+      #   "API not ready" → loop never broke → /internal/cutover/
+      #   trigger was never called → cutover never fired (caught
+      #   live on otech113 2026-05-05). Fix: poll /healthz
+      #   (unauthenticated, always 200 when the process is up).
+      #   Also drops the pre-flight cutoverComplete=true short-
+      #   circuit since /internal/cutover/trigger is itself
+      #   idempotent.
+      version: 0.1.18
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-self-sovereign-cutover
-version: 0.1.17
+version: 0.1.18
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/templates/10-auto-trigger-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/10-auto-trigger-job.yaml
@@ -28,6 +28,27 @@ The SA token mounts at the standard projected-volume path
 the bytes at request time so the token rotates correctly on long-
 running deadlines.
 
+Readiness probe (issue #957 — chart 0.1.18)
+───────────────────────────────────────────
+0.1.17's readiness loop polled /api/v1/sovereign/cutover/status to
+decide "is catalyst-api up yet?" That endpoint lives INSIDE the
+RequireSession group and returned 401 to every unauthenticated probe
+from this Pod. The probe treated 401 as "API not ready" → loop never
+broke → /internal/cutover/trigger was NEVER called → cutover never
+fired on otech113 2026-05-05. Live evidence: catalyst-api access log
+showed 30 consecutive 401 responses on /sovereign/cutover/status from
+the auto-trigger Pod and zero hits on /internal/cutover/trigger.
+
+0.1.18 polls /healthz instead — an unauthenticated, always-200
+endpoint while the process is up (products/catalyst/bootstrap/api/
+internal/handler/health.go:51). The endpoint exists for exactly this
+purpose (kubelet liveness, in-cluster reachability tests). Once
+/healthz returns 200 we proceed straight to /internal/cutover/trigger;
+the trigger endpoint is itself idempotent — it returns 200 with the
+existing snapshot when cutoverComplete=true, 409 when a run is
+already in progress, 200 otherwise — so we no longer need a separate
+"cutoverComplete already true" pre-flight read.
+
 Idempotency comes from catalyst-api's own engine logic:
   - cutoverComplete=true → 200, no Jobs created (already done)
   - cutoverComplete=false + steps in flight → 409 (in-progress)
@@ -123,7 +144,17 @@ spec:
               fi
 
               api="${CATALYST_API_URL%/}"
-              status_url="${api}/api/v1/sovereign/cutover/status"
+              # Issue #957 — chart 0.1.18: poll the unauthenticated
+              # /healthz endpoint to test reachability. /api/v1/sovereign/
+              # cutover/status (used in 0.1.17) lives behind RequireSession
+              # middleware and returned 401 to every probe from this Pod
+              # because the in-cluster Job has no operator session cookie.
+              # The probe treated 401 as "API not ready" → loop never
+              # broke → trigger was never called → cutover never fired.
+              # /healthz exists for exactly this purpose (kubelet liveness
+              # + in-cluster reachability) and returns 200 unconditionally
+              # while the process is up.
+              healthz_url="${api}/healthz"
               # Issue #935 Bug 2: hit the in-cluster /internal/cutover/trigger
               # endpoint (lives outside RequireSession) with this Pod's
               # ServiceAccount token. The previous /sovereign/cutover/start
@@ -134,16 +165,16 @@ spec:
               # 1. Wait for catalyst-api to be reachable. In a fresh
               #    Sovereign, the cutover chart and catalyst-platform
               #    chart land on slightly different timelines via Flux.
-              #    We poll /status (a read-only endpoint, idempotent) up
-              #    to WAIT_TIMEOUT_SECONDS so a transient unreachability
+              #    We poll /healthz (an unauthenticated liveness endpoint)
+              #    up to WAIT_TIMEOUT_SECONDS so a transient unreachability
               #    doesn't fail the hook.
               echo "[auto-trigger] waiting for catalyst-api at ${api}"
               deadline=$(( $(date +%s) + WAIT_TIMEOUT_SECONDS ))
               api_ready="false"
               while [ "$(date +%s)" -lt "${deadline}" ]; do
-                code=$(curl -s -o /tmp/status.json -w "%{http_code}" \
+                code=$(curl -s -o /dev/null -w "%{http_code}" \
                   --connect-timeout 5 --max-time 15 \
-                  "${status_url}" 2>/dev/null || echo "000")
+                  "${healthz_url}" 2>/dev/null || echo "000")
                 if [ "${code}" = "200" ]; then
                   api_ready="true"
                   break
@@ -156,14 +187,13 @@ spec:
                 exit 0
               fi
 
-              # 2. Read current state. If cutoverComplete=true, log and exit.
-              #    The /status endpoint is the durable record; we trust it
-              #    over any in-process state because catalyst-api Pods can
-              #    restart between cutover runs.
-              if grep -q '"cutoverComplete":true' /tmp/status.json 2>/dev/null; then
-                echo "[auto-trigger] cutover already complete on this Sovereign — no-op"
-                exit 0
-              fi
+              # 2. Skip the pre-flight cutoverComplete=true short-circuit
+              #    that 0.1.17 had: /internal/cutover/trigger is itself
+              #    idempotent — it returns 200 with the existing snapshot
+              #    when cutoverComplete=true (cutover_internal.go line
+              #    279). Removing the pre-read keeps us off the auth-gated
+              #    /sovereign/cutover/status endpoint entirely, which is
+              #    the whole point of the 0.1.18 change.
 
               # 3. Confirm the SA token is mountable. Should always be
               #    true when the Pod is running with our serviceAccount,

--- a/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
+++ b/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
@@ -197,4 +197,52 @@ if grep -A3 'name: HARBOR_PASSWORD' "$TMP/render.yaml" | grep -q 'name: harbor-c
 fi
 echo "  PASS (Step 02 references harbor-admin)"
 
+echo "[cutover-contract] Case 13: readiness probe targets /healthz, NOT /sovereign/cutover/status (#957)"
+# Chart 0.1.17 polled /api/v1/sovereign/cutover/status to test
+# "is catalyst-api up yet?" That endpoint sits inside RequireSession
+# and returns 401 to every unauthenticated probe from the in-cluster
+# Job — the probe treated 401 as "not ready" → loop never broke →
+# /internal/cutover/trigger was never called → cutover never fired
+# (caught live on otech113 2026-05-05).
+#
+# 0.1.18 polls /healthz instead (unauthenticated, always 200 when
+# the process is up). This gate guards against future regressions
+# that re-introduce an auth-gated readiness probe.
+if ! grep -q 'healthz_url=' "$TMP/render.yaml"; then
+  echo "FAIL: auto-trigger Job missing healthz_url= readiness probe target" >&2
+  exit 1
+fi
+if ! grep -q '/healthz' "$TMP/render.yaml"; then
+  echo "FAIL: auto-trigger Job does NOT include the /healthz probe path" >&2
+  exit 1
+fi
+# The readiness loop must NOT poll /sovereign/cutover/status. The
+# auto-trigger code intentionally uses the unauthenticated /healthz
+# probe; any future re-introduction of a session-cookie-gated probe
+# would silently re-break the same way 0.1.17 did. We assert no
+# poll-loop variable is set to a /sovereign/cutover/* URL by checking
+# that no shell-line of the form `<id>=...sovereign/cutover/status...`
+# appears in the rendered Job. The string itself is allowed in
+# documentation comments — that's why we anchor on `=` (assignment),
+# not just substring presence.
+if grep -E '^\s*[a-zA-Z_][a-zA-Z0-9_]*=.*/api/v1/sovereign/cutover/status' "$TMP/render.yaml" >/dev/null; then
+  echo "FAIL: auto-trigger Job polls /sovereign/cutover/status as a readiness probe (auth-gated, 401-loops)" >&2
+  exit 1
+fi
+echo "  PASS (readiness probe is /healthz)"
+
+echo "[cutover-contract] Case 14: no early cutoverComplete short-circuit on auth-gated /status (#957)"
+# 0.1.17 had a pre-flight 'if cutoverComplete=true exit 0' check that
+# parsed the response body of /sovereign/cutover/status. Even if a
+# future change moves that check elsewhere, it must NOT depend on a
+# response body fetched from an auth-gated endpoint. The /internal/
+# cutover/trigger endpoint is itself idempotent (returns 200 with the
+# existing snapshot when cutoverComplete=true; cutover_internal.go
+# line 279) so no separate pre-read is needed.
+if grep -E "grep.*cutoverComplete.*/tmp/status\.json" "$TMP/render.yaml" >/dev/null; then
+  echo "FAIL: auto-trigger Job retains the 0.1.17 cutoverComplete pre-read off /tmp/status.json — that file no longer exists" >&2
+  exit 1
+fi
+echo "  PASS (no stale cutoverComplete pre-read)"
+
 echo "[cutover-contract] All gates green."


### PR DESCRIPTION
## Summary

Fixes #957 — the chart 0.1.17 auto-trigger Job loops forever on 401 because its readiness probe targets an auth-gated endpoint.

PR #947's catalyst-api side is correct: `/api/v1/internal/cutover/trigger` exists, lives outside RequireSession, validates the SA bearer token via TokenReview, and is idempotent. The Job's auth path to that endpoint is correct too. But before reaching it, the Job runs a probe loop that hits `/api/v1/sovereign/cutover/status` (which lives INSIDE RequireSession). The probe gets 401 (no session cookie), treats it as "API not ready," loops 30 times for 300s, then exits 0. The trigger endpoint is NEVER called.

## Live evidence (otech113 2026-05-05)

```
$ kubectl --context=otech113 logs -n catalyst -l job-name=bp-self-sovereign-cutover-auto-trigger
[auto-trigger] catalyst-api not ready (HTTP 401); retrying in 10s
... (30 times) ...
[auto-trigger] catalyst-api never became reachable within 300s

$ kubectl --context=otech113 -n catalyst-system logs deploy/catalyst-api | grep cutover
"GET /api/v1/sovereign/cutover/status" from 10.42.4.216 - 401  (x30)
# zero hits on /api/v1/internal/cutover/trigger
```

## Fix (chart-side only)

| Change | Why |
|---|---|
| Poll `/healthz` for readiness | Unauthenticated; always 200 when process is up. Exists for exactly this purpose (kubelet liveness, in-cluster reachability tests). See `health.go:51`. |
| Drop the pre-flight `cutoverComplete=true` short-circuit | `/internal/cutover/trigger` already returns 200 with the existing snapshot when `cutoverComplete=true` (see `cutover_internal.go:279`). Removing the pre-read means we never need to touch the auth-gated `/status` endpoint. |
| Bump chart 0.1.17 → 0.1.18 | Standard SemVer for a behaviour-changing fix. |
| Pin slot 06a to 0.1.18 | Bootstrap-kit overlay alignment. |

No catalyst-api change needed — PR #947's wiring is correct.

## Test plan

- [x] `helm template` + `helm lint` clean
- [x] `bash tests/cutover-contract.sh` all 14 gates pass (12 existing + 2 new for #957)
  - Case 13: readiness probe targets `/healthz`, NOT `/sovereign/cutover/status`
  - Case 14: no stale `cutoverComplete` pre-read off `/tmp/status.json`
- [x] Go unit tests for `HandleCutoverInternalTrigger` (6/6) still pass
- [ ] Live verify on otech113 after Blueprint Release CI publishes 0.1.18

## After merge

1. Merge → Blueprint Release CI publishes `oci://ghcr.io/openova-io/bp-self-sovereign-cutover:0.1.18`
2. Force-reconcile flux-system on otech113
3. Watch `kubectl --context=otech113 get jobs -n catalyst -w` until 8 cutover-* Jobs reach Complete
4. Comment proof on the cutover-track issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)