### PR TITLE
fix(catalyst-api): minimum-life guard refuses mid-provision wipe (#914)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/handler.go
+++ b/products/catalyst/bootstrap/api/internal/handler/handler.go
@@ -162,6 +162,23 @@ type Handler struct {
 	// deterministically against a stuck fake informer.
 	refreshWatchSeedTimeout time.Duration
 
+	// wipeMinLifeProtection — issue #914. Minimum age below which a
+	// POST /api/v1/deployments/{id}/wipe call is REJECTED with 409 when
+	// the deployment is still in `phase1-watching` (i.e. mid-converge).
+	// The operator can override with `?force=true` query param. Zero
+	// falls back to env var (CATALYST_WIPE_MIN_LIFE_PROTECTION) →
+	// DefaultWipeMinLifeProtection (30m). Tests inject a tiny value
+	// (e.g. 100ms) to exercise the protection path in milliseconds.
+	//
+	// The threshold is sized vs the Phase-1 watcher's overall budget
+	// (DefaultWatchTimeout = 60m) so a deployment that's still
+	// converging gets at least half the watch budget before any
+	// external wipe can destroy it. otech106 incident, 2026-05-05:
+	// an external POST /wipe at T+24m killed a still-converging
+	// 28/40-installed Sovereign because no minimum-life guard
+	// existed.
+	wipeMinLifeProtection time.Duration
+
 	// k8sCache — catalyst-wide informer cache (issue #321). Owns one
 	// SharedInformerFactory per managed Sovereign cluster. The k8s
 	// REST + SSE handlers in k8s.go read its Indexer + Subscribe.

--- a/products/catalyst/bootstrap/api/internal/handler/wipe.go
+++ b/products/catalyst/bootstrap/api/internal/handler/wipe.go
@@ -55,6 +55,91 @@ import (
 // importing the pdm package at every call site.
 func pdmErrNotFound() error { return pdm.ErrNotFound }
 
+// wipeMinLifeProtectionEnv — issue #914. Env var override for the
+// minimum-age threshold below which an externally-triggered wipe is
+// REFUSED when the deployment is still in `phase1-watching`. Operator
+// override is the `?force=true` query param on the wipe URL.
+//
+// Per docs/INVIOLABLE-PRINCIPLES.md #4, every threshold is a runtime
+// knob. The default (DefaultWipeMinLifeProtection, 30m) is sized
+// against the Phase-1 watcher's DefaultWatchTimeout (60m) so a
+// converging Sovereign gets at least half the watch budget before any
+// external wipe can destroy it. otech106 incident, 2026-05-05.
+const wipeMinLifeProtectionEnv = "CATALYST_WIPE_MIN_LIFE_PROTECTION"
+
+// DefaultWipeMinLifeProtection — production default for the
+// minimum-life guard. Issue #914.
+//
+// 30 minutes covers the worst-observed bp-catalyst-platform install
+// window (15m install timer × multiple retries) plus headroom for the
+// 4-component install cascade (keycloak/openbao/powerdns/crossplane all
+// in their 15m windows simultaneously, which is exactly the otech106
+// snapshot). Below this age a still-converging deployment must be
+// protected from accidental external wipes — operator can override via
+// `?force=true` when they really mean it.
+const DefaultWipeMinLifeProtection = 30 * time.Minute
+
+// compileWipeMinLifeProtection — small parse helper. Returns
+// DefaultWipeMinLifeProtection for empty / unparseable / non-positive
+// input.
+func compileWipeMinLifeProtection(raw string) time.Duration {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return DefaultWipeMinLifeProtection
+	}
+	d, err := time.ParseDuration(raw)
+	if err != nil || d <= 0 {
+		return DefaultWipeMinLifeProtection
+	}
+	return d
+}
+
+// wipeMinLifeProtectionFor returns the effective protection threshold
+// for this Handler. Test override (h.wipeMinLifeProtection) wins;
+// production reads env → default.
+func (h *Handler) wipeMinLifeProtectionFor() time.Duration {
+	if h.wipeMinLifeProtection > 0 {
+		return h.wipeMinLifeProtection
+	}
+	return compileWipeMinLifeProtection(envOrEmpty(wipeMinLifeProtectionEnv))
+}
+
+// shouldRefuseWipe — pure decision function for issue #914's
+// minimum-life guard. Returns true when the wipe MUST be refused with
+// 409 because the deployment is still mid-converge.
+//
+// The four-input contract is intentional so tests can exercise each
+// branch deterministically without standing up a Handler:
+//
+//   - status            — current dep.Status snapshot
+//   - startedAt         — dep.StartedAt snapshot (zero = unknown)
+//   - now               — wall-clock at decision time
+//   - threshold         — minimum-life protection threshold
+//   - force             — operator override flag (?force=true)
+//
+// Refuse iff status is `phase1-watching` AND startedAt is non-zero AND
+// (now - startedAt) < threshold AND force is false. Every other shape
+// falls through to allow the wipe — including a finished deployment, a
+// failed deployment, a missing startedAt (legacy record from before the
+// field was stamped — can't enforce a threshold we have no anchor for),
+// or an explicit force override.
+func shouldRefuseWipe(status string, startedAt, now time.Time, threshold time.Duration, force bool) bool {
+	if force {
+		return false
+	}
+	if status != "phase1-watching" {
+		return false
+	}
+	if startedAt.IsZero() {
+		// Legacy record — without an anchor we can't compute age.
+		// Allow the wipe; the operator's intent is clearer than the
+		// guard's heuristic.
+		return false
+	}
+	age := now.Sub(startedAt)
+	return age < threshold
+}
+
 // wipeRequest is the body of POST /api/v1/deployments/{id}/wipe.
 //
 // HetznerToken is required ONLY when the on-disk Deployment record's
@@ -87,7 +172,12 @@ type wipeResponse struct {
 //   - 200 OK on full or partial success (errors in the body)
 //   - 400 Bad Request when the body cannot be parsed
 //   - 404 Not Found when the deployment id is unknown
-//   - 409 Conflict if a wipe is already in progress for this deployment
+//   - 409 Conflict if a wipe is already in progress for this deployment,
+//     OR (issue #914) if the deployment is still in `phase1-watching`
+//     AND younger than wipeMinLifeProtection (default 30m). The 409
+//     body carries `retryAfterSec` + `minLifeSec` so the wizard can
+//     render a "wait N minutes" countdown. Operator override:
+//     `?force=true` query param.
 //   - 500 on a fatal local-state error (workdir non-removable, etc.)
 //
 // The endpoint is idempotent: re-running on a partially-wiped deployment
@@ -120,6 +210,70 @@ func (h *Handler) WipeDeployment(w http.ResponseWriter, r *http.Request) {
 	}
 	if strings.TrimSpace(body.HetznerToken) == "" {
 		http.Error(w, "hetznerToken is required (re-prompt the operator before calling this endpoint)", http.StatusBadRequest)
+		return
+	}
+
+	// Issue #914 — minimum-life guard against externally-triggered
+	// wipes that destroy still-converging Sovereigns.
+	//
+	// otech106.omani.works (2026-05-05) was 28/40 components installed,
+	// 4 actively installing in their 15m install windows, when an
+	// external POST /wipe at T+24m destroyed it. Same shape as B2 #910
+	// (orchestrator marking deployment FAILED prematurely) but on the
+	// WIPE path. Whatever path triggered it (stale browser tab,
+	// decommission button on adjacent deployment, watchdog goroutine),
+	// the result is data destruction without warning.
+	//
+	// Guard logic: when status is `phase1-watching` AND the deployment
+	// is younger than wipeMinLifeProtection (default 30m, runtime-
+	// configurable per docs/INVIOLABLE-PRINCIPLES.md #4), refuse the
+	// wipe with 409 + a clear retry_after_sec hint. Operator can
+	// override with `?force=true` query param when they really mean
+	// it (after reading the wizard banner that says "this Sovereign is
+	// still converging — wait N minutes or click Force Wipe").
+	//
+	// Audit log emitted unconditionally so future incidents have a
+	// single grep target — see [WIPE-AUDIT] tag.
+	force := r.URL.Query().Get("force") == "true"
+	dep.mu.Lock()
+	depStatus := dep.Status
+	depStartedAt := dep.StartedAt
+	depFQDN := dep.Request.SovereignFQDN
+	dep.mu.Unlock()
+
+	now := time.Now()
+	age := now.Sub(depStartedAt)
+	threshold := h.wipeMinLifeProtectionFor()
+	refuse := shouldRefuseWipe(depStatus, depStartedAt, now, threshold, force)
+
+	h.log.Info("[WIPE-AUDIT] wipe request received",
+		"id", id,
+		"sovereignFQDN", depFQDN,
+		"status", depStatus,
+		"startedAt", depStartedAt.UTC().Format(time.RFC3339),
+		"ageSec", int(age.Seconds()),
+		"thresholdSec", int(threshold.Seconds()),
+		"refuse", refuse,
+		"force", force,
+		"remoteAddr", r.RemoteAddr,
+	)
+
+	if refuse {
+		retryAfter := int((threshold - age).Seconds())
+		if retryAfter < 1 {
+			retryAfter = 1
+		}
+		writeJSON(w, http.StatusConflict, map[string]any{
+			"error":         "deployment is still converging — wipe refused to protect a mid-provision Sovereign",
+			"deploymentId":  id,
+			"sovereignFQDN": depFQDN,
+			"status":        depStatus,
+			"startedAt":     depStartedAt.UTC().Format(time.RFC3339),
+			"ageSec":        int(age.Seconds()),
+			"minLifeSec":    int(threshold.Seconds()),
+			"retryAfterSec": retryAfter,
+			"hint":          "wait for status to leave 'phase1-watching', or re-issue with ?force=true to override (only use force if you truly intend to destroy a still-converging Sovereign — see issue #914)",
+		})
 		return
 	}
 

--- a/products/catalyst/bootstrap/api/internal/handler/wipe_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/wipe_test.go
@@ -1,0 +1,370 @@
+// Tests for the issue #914 minimum-life wipe guard.
+//
+// Mid-provision wipe at T+25m destroyed a still-converging Sovereign
+// (otech106.omani.works, 2026-05-05). The fix is a server-side
+// minimum-life guard: when status is `phase1-watching` AND the
+// deployment is younger than wipeMinLifeProtection (default 30m), POST
+// /wipe returns 409 with retryAfterSec instead of running the
+// destructive purge sequence.
+//
+// Operator override: `?force=true` query param. The pure decision
+// function shouldRefuseWipe is the test seam — the four-input contract
+// (status, startedAt, now, threshold, force) lets every branch be
+// exercised without standing up a Handler.
+//
+// The HTTP-level 409-on-still-converging test is the integration
+// proof: the guard short-circuits BEFORE any tofu / hetzner / pdm
+// call, so the test runs without hitting external APIs and verifies
+// the wire shape the wizard's banner reads (retryAfterSec,
+// minLifeSec, hint).
+package handler
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/provisioner"
+)
+
+// callWipeDeployment wires a chi router so chi.URLParam("id") resolves
+// to the supplied id and returns the recorded response.
+func callWipeDeployment(h *Handler, id, query, bodyJSON string) *httptest.ResponseRecorder {
+	r := chi.NewRouter()
+	r.Post("/api/v1/deployments/{id}/wipe", h.WipeDeployment)
+	w := httptest.NewRecorder()
+	url := "/api/v1/deployments/" + id + "/wipe"
+	if query != "" {
+		url += "?" + query
+	}
+	req := httptest.NewRequest(http.MethodPost, url, bytes.NewBufferString(bodyJSON))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+	return w
+}
+
+// ── shouldRefuseWipe pure-function tests ────────────────────────────
+
+// TestShouldRefuseWipe_StillConvergingTooYoung — the headline case.
+// status=phase1-watching, age below threshold, no force → REFUSE.
+func TestShouldRefuseWipe_StillConvergingTooYoung(t *testing.T) {
+	now := time.Now()
+	startedAt := now.Add(-25 * time.Minute) // age = 25m
+	threshold := 30 * time.Minute
+
+	if !shouldRefuseWipe("phase1-watching", startedAt, now, threshold, false) {
+		t.Errorf("status=phase1-watching age=25m threshold=30m force=false → expected REFUSE, got allow")
+	}
+}
+
+// TestShouldRefuseWipe_StillConvergingOldEnoughAccept — the watcher
+// has had time to converge or fail; refusing further wipes is no
+// longer the right behaviour. Age ≥ threshold → ALLOW.
+func TestShouldRefuseWipe_StillConvergingOldEnoughAccept(t *testing.T) {
+	now := time.Now()
+	startedAt := now.Add(-31 * time.Minute) // age = 31m
+	threshold := 30 * time.Minute
+
+	if shouldRefuseWipe("phase1-watching", startedAt, now, threshold, false) {
+		t.Errorf("status=phase1-watching age=31m threshold=30m → expected ALLOW (past min-life), got refuse")
+	}
+}
+
+// TestShouldRefuseWipe_FinishedAccept — status=ready (terminal). The
+// guard MUST allow wipe of a finished deployment regardless of age.
+func TestShouldRefuseWipe_FinishedAccept(t *testing.T) {
+	now := time.Now()
+	startedAt := now.Add(-1 * time.Minute) // very young
+	threshold := 30 * time.Minute
+
+	if shouldRefuseWipe("ready", startedAt, now, threshold, false) {
+		t.Errorf("status=ready → expected ALLOW (terminal), got refuse")
+	}
+}
+
+// TestShouldRefuseWipe_FailedAccept — status=failed. Wipe is the
+// canonical recovery path for a failed deployment; refusing it would
+// strand the operator.
+func TestShouldRefuseWipe_FailedAccept(t *testing.T) {
+	now := time.Now()
+	startedAt := now.Add(-2 * time.Minute) // very young
+	threshold := 30 * time.Minute
+
+	if shouldRefuseWipe("failed", startedAt, now, threshold, false) {
+		t.Errorf("status=failed → expected ALLOW (terminal), got refuse")
+	}
+}
+
+// TestShouldRefuseWipe_ForceFlagAlwaysAccepts — the explicit operator
+// override. Even when the deployment is still converging and young,
+// ?force=true must let the wipe proceed.
+func TestShouldRefuseWipe_ForceFlagAlwaysAccepts(t *testing.T) {
+	now := time.Now()
+	startedAt := now.Add(-5 * time.Minute) // young
+	threshold := 30 * time.Minute
+
+	if shouldRefuseWipe("phase1-watching", startedAt, now, threshold, true) {
+		t.Errorf("status=phase1-watching age=5m force=true → expected ALLOW (force override), got refuse")
+	}
+}
+
+// TestShouldRefuseWipe_NonConvergingStatusAccept — table-driven check
+// that every non-`phase1-watching` status falls through to allow,
+// even while age < threshold. The guard ONLY protects mid-converge
+// deployments; everything else (pending, provisioning, tofu-applying,
+// flux-bootstrapping, wiping, wiped) is a state where the operator's
+// wipe intent is not in question.
+func TestShouldRefuseWipe_NonConvergingStatusAccept(t *testing.T) {
+	now := time.Now()
+	startedAt := now.Add(-5 * time.Minute) // young
+	threshold := 30 * time.Minute
+
+	statuses := []string{
+		"pending",
+		"provisioning",
+		"tofu-applying",
+		"flux-bootstrapping",
+		"ready",
+		"failed",
+		"wiping",
+		"wiped",
+		"adopted",
+	}
+	for _, s := range statuses {
+		if shouldRefuseWipe(s, startedAt, now, threshold, false) {
+			t.Errorf("status=%q young → expected ALLOW (only phase1-watching is protected), got refuse", s)
+		}
+	}
+}
+
+// TestShouldRefuseWipe_ZeroStartedAtAccept — legacy records persisted
+// before StartedAt was stamped lack the anchor needed to compute age.
+// In that shape the guard CANNOT enforce a threshold and falls
+// through to allow — the operator's intent is clearer than the
+// guard's heuristic.
+func TestShouldRefuseWipe_ZeroStartedAtAccept(t *testing.T) {
+	now := time.Now()
+	threshold := 30 * time.Minute
+
+	if shouldRefuseWipe("phase1-watching", time.Time{}, now, threshold, false) {
+		t.Errorf("status=phase1-watching startedAt=zero → expected ALLOW (no anchor), got refuse")
+	}
+}
+
+// TestShouldRefuseWipe_ExactlyAtThresholdAccept — boundary. Age ==
+// threshold means "the protected window has just ended"; the wipe
+// must proceed.
+func TestShouldRefuseWipe_ExactlyAtThresholdAccept(t *testing.T) {
+	now := time.Now()
+	threshold := 30 * time.Minute
+	startedAt := now.Add(-threshold) // age = threshold exactly
+
+	if shouldRefuseWipe("phase1-watching", startedAt, now, threshold, false) {
+		t.Errorf("status=phase1-watching age==threshold → expected ALLOW (boundary), got refuse")
+	}
+}
+
+// ── compileWipeMinLifeProtection helper tests ───────────────────────
+
+func TestCompileWipeMinLifeProtection_DefaultOnEmpty(t *testing.T) {
+	if got := compileWipeMinLifeProtection(""); got != DefaultWipeMinLifeProtection {
+		t.Errorf("empty input → expected %v, got %v", DefaultWipeMinLifeProtection, got)
+	}
+}
+
+func TestCompileWipeMinLifeProtection_DefaultOnGarbage(t *testing.T) {
+	if got := compileWipeMinLifeProtection("not-a-duration"); got != DefaultWipeMinLifeProtection {
+		t.Errorf("garbage input → expected default %v, got %v", DefaultWipeMinLifeProtection, got)
+	}
+}
+
+func TestCompileWipeMinLifeProtection_DefaultOnNonPositive(t *testing.T) {
+	for _, raw := range []string{"0s", "-5m", "0"} {
+		if got := compileWipeMinLifeProtection(raw); got != DefaultWipeMinLifeProtection {
+			t.Errorf("input %q → expected default %v, got %v", raw, DefaultWipeMinLifeProtection, got)
+		}
+	}
+}
+
+func TestCompileWipeMinLifeProtection_ParsesValidDuration(t *testing.T) {
+	if got := compileWipeMinLifeProtection("45m"); got != 45*time.Minute {
+		t.Errorf("45m → expected %v, got %v", 45*time.Minute, got)
+	}
+	if got := compileWipeMinLifeProtection("1h"); got != 1*time.Hour {
+		t.Errorf("1h → expected %v, got %v", 1*time.Hour, got)
+	}
+}
+
+// ── HTTP-level integration tests ────────────────────────────────────
+
+// TestWipeDeployment_StillConvergingReturns409 — headline integration
+// test. A deployment in phase1-watching, 5 minutes old (well under the
+// 30m default threshold), receives a wipe request and the handler
+// returns 409 with the structured body the wizard banner reads. The
+// Hetzner / tofu / PDM call paths are NOT invoked — the guard
+// short-circuits BEFORE any of them.
+//
+// This is exactly the otech106 incident shape: external POST /wipe at
+// T+24m on a Sovereign with status=phase1-watching, 28/40 components
+// installed. With this guard, that wipe is refused.
+func TestWipeDeployment_StillConvergingReturns409(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+
+	dep := &Deployment{
+		ID:        "dep-otech106",
+		Status:    "phase1-watching",
+		StartedAt: time.Now().Add(-5 * time.Minute), // 5m old, well under 30m
+		Request: provisioner.Request{
+			SovereignFQDN:       "otech106.omani.works",
+			SovereignDomainMode: "pool",
+		},
+	}
+	h.deployments.Store(dep.ID, dep)
+
+	w := callWipeDeployment(h, dep.ID, "", `{"hetznerToken":"fake-hetzner-token"}`)
+
+	if w.Code != http.StatusConflict {
+		t.Fatalf("status=%d, want 409 — body=%s", w.Code, w.Body.String())
+	}
+
+	var body map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode response: %v — raw=%s", err, w.Body.String())
+	}
+
+	if body["deploymentId"] != "dep-otech106" {
+		t.Errorf("deploymentId=%v, want dep-otech106", body["deploymentId"])
+	}
+	if body["sovereignFQDN"] != "otech106.omani.works" {
+		t.Errorf("sovereignFQDN=%v, want otech106.omani.works", body["sovereignFQDN"])
+	}
+	if body["status"] != "phase1-watching" {
+		t.Errorf("status=%v, want phase1-watching", body["status"])
+	}
+	// retryAfterSec must be present and positive — the wizard banner
+	// reads this for the countdown.
+	retry, ok := body["retryAfterSec"].(float64)
+	if !ok {
+		t.Errorf("retryAfterSec missing or wrong type: %v", body["retryAfterSec"])
+	} else if retry < 1 {
+		t.Errorf("retryAfterSec=%v, want positive", retry)
+	}
+	if _, ok := body["minLifeSec"]; !ok {
+		t.Errorf("minLifeSec missing from response — wizard banner needs it")
+	}
+	if _, ok := body["hint"]; !ok {
+		t.Errorf("hint missing from response — operator-guidance text required")
+	}
+
+	// Critical invariant: the deployment status MUST NOT have flipped
+	// to "wiping". The guard short-circuits BEFORE the single-flight
+	// status flip, so the still-converging deployment continues to be
+	// observed by the Phase-1 watcher.
+	dep.mu.Lock()
+	defer dep.mu.Unlock()
+	if dep.Status != "phase1-watching" {
+		t.Errorf("dep.Status=%q after refused wipe, want phase1-watching (guard must not mutate state)", dep.Status)
+	}
+}
+
+// TestWipeDeployment_ForceFlagBypassesGuard — operator override path.
+// `?force=true` skips the minimum-life guard and proceeds to the
+// destructive path. We can't run the full destroy in unit-tests
+// without a Hetzner mock, but we CAN verify the guard doesn't return
+// 409: a non-409 response (any status) proves the guard was bypassed.
+//
+// In practice the destructive path will fail later (no real Hetzner
+// token, no real workdir) and surface in the response body's Errors,
+// but that's noise for this assertion — we're proving the guard
+// allowed the flow to proceed.
+//
+// The test injects a near-zero wipeMinLifeProtection so even without
+// force the deployment WOULD be allowed; we then verify the same
+// outcome holds with force=true on a young deployment to prove the
+// flag works.
+func TestWipeDeployment_ForceFlagBypassesGuard(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	// Set protection to 30m default; deployment is 5m old so guard
+	// would normally fire.
+	h.wipeMinLifeProtection = 30 * time.Minute
+
+	dep := &Deployment{
+		ID:        "dep-force-young",
+		Status:    "phase1-watching",
+		StartedAt: time.Now().Add(-5 * time.Minute),
+		Request: provisioner.Request{
+			SovereignFQDN:       "otech-force.omani.works",
+			SovereignDomainMode: "pool",
+		},
+	}
+	h.deployments.Store(dep.ID, dep)
+
+	w := callWipeDeployment(h, dep.ID, "force=true", `{"hetznerToken":"fake-hetzner-token"}`)
+
+	// The guard must NOT have returned 409 with the still-converging
+	// body. The downstream destructive path may set its own status
+	// codes (likely 200 with errors after tofu/hetzner stubs noop) —
+	// the only thing we're proving here is "guard didn't refuse".
+	if w.Code == http.StatusConflict {
+		// Decode and check it isn't OUR 409 — there's also the
+		// "wipe already in progress" 409 from the single-flight
+		// guard, but that fires AFTER ours and only when status is
+		// already "wiping" (which it isn't here).
+		body := w.Body.String()
+		if bytes.Contains([]byte(body), []byte("still converging")) {
+			t.Errorf("force=true did NOT bypass minimum-life guard: status=409 body=%s", body)
+		}
+	}
+
+	// Critical invariant: with force=true on a young still-converging
+	// deployment, the handler must have moved past the guard (i.e.
+	// status flipped to "wiping" by the single-flight guard, even if
+	// downstream errors followed).
+	dep.mu.Lock()
+	defer dep.mu.Unlock()
+	if dep.Status == "phase1-watching" {
+		t.Errorf("dep.Status=%q after force=true wipe, expected status to have moved past the guard", dep.Status)
+	}
+}
+
+// TestWipeDeployment_MissingTokenIs400 — defensive cross-check that
+// the guard does NOT fire before token validation. A wipe call
+// without a hetznerToken must still return 400, not 409, even on a
+// still-converging deployment.
+func TestWipeDeployment_MissingTokenIs400(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+
+	dep := &Deployment{
+		ID:        "dep-no-token",
+		Status:    "phase1-watching",
+		StartedAt: time.Now().Add(-2 * time.Minute),
+		Request: provisioner.Request{
+			SovereignFQDN:       "otech-no-tok.omani.works",
+			SovereignDomainMode: "pool",
+		},
+	}
+	h.deployments.Store(dep.ID, dep)
+
+	w := callWipeDeployment(h, dep.ID, "", `{}`) // empty body, no token
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status=%d, want 400 (missing token must surface BEFORE the min-life guard) — body=%s", w.Code, w.Body.String())
+	}
+}
+
+// TestWipeDeployment_UnknownDeploymentIs404 — defensive cross-check.
+// Unknown id must return 404 regardless of any guard configuration.
+func TestWipeDeployment_UnknownDeploymentIs404(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+
+	w := callWipeDeployment(h, "no-such-deployment", "", `{"hetznerToken":"x"}`)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("status=%d, want 404 — body=%s", w.Code, w.Body.String())
+	}
+}


### PR DESCRIPTION
## Summary

- Adds server-side minimum-life guard on `POST /api/v1/deployments/{id}/wipe` — returns 409 with `retryAfterSec` when status=`phase1-watching` AND age < `CATALYST_WIPE_MIN_LIFE_PROTECTION` (default 30m).
- Operator override: `?force=true` query param.
- Unconditional `[WIPE-AUDIT]` structured log line on every call so future incidents have a single grep target.
- Phase-1 watcher already uses `context.Background()` (line 217) so an HTTP-level refusal does NOT cancel the watch — the still-converging Sovereign continues to be observed independently.

## Background

otech106.omani.works (2026-05-05) was 28/40 components installed and 4 actively converging in their 15m install windows when an external POST /wipe at T+24m destroyed it. Same shape as B2 #910 (premature FAILED) but on the WIPE path. Whatever path triggered it (stale browser tab, decommission button on adjacent deployment, watchdog goroutine), the result was data destruction without warning.

## Decision matrix

The pure `shouldRefuseWipe(status, startedAt, now, threshold, force)` function is the test seam:

| Case | Result |
|------|--------|
| status=phase1-watching, age < threshold, force=false | REFUSE |
| status=phase1-watching, age >= threshold | ALLOW |
| status=ready / failed / wiping / wiped / adopted / pending / provisioning | ALLOW |
| force=true | ALLOW (always) |
| StartedAt zero (legacy record) | ALLOW (no anchor) |
| age == threshold (boundary) | ALLOW |

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./internal/handler/` — clean
- [x] `go test -race ./internal/handler/ -run 'TestWipeDeployment|TestShouldRefuseWipe|TestCompileWipeMinLifeProtection'` — 16/16 PASS
- [x] Pure-function decision tests cover every branch
- [x] HTTP-level integration test verifies 409 wire shape (`retryAfterSec`, `minLifeSec`, `hint`, `sovereignFQDN`)
- [x] HTTP-level integration test verifies `?force=true` bypasses the guard (status moves past `phase1-watching`)
- [x] Cross-checks: missing token still returns 400 (guard runs after token validation), unknown id still returns 404

Closes #914

🤖 Generated with [Claude Code](https://claude.com/claude-code)