### PR TITLE
fix(bp-catalyst-platform 1.4.26): grant TokenReview RBAC for cutover trigger (#957)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -218,7 +218,15 @@ spec:
       # so SME auth Pod's PIN delivery (gate 2) works on Sovereigns
       # whose A5-seeded sovereign-smtp-credentials Secret only carries
       # smtp-user + smtp-pass without host/port/from. 2026-05-05.
-      version: 1.4.24
+      # 1.4.25: deploy-bot auto-bump (sme-services 94ffe01 image roll).
+      # 1.4.26 (#957 follow-up): catalyst-api-cutover-driver
+      # ClusterRole gains `create tokenreviews.authentication.k8s.io`
+      # so /api/v1/internal/cutover/trigger can validate the
+      # auto-trigger Job's SA token via TokenReview. Without this rule
+      # every trigger call returned 502 "token-review-failed" on
+      # otech113 (chart 0.1.18 fixed the readiness loop but exposed
+      # this missing-RBAC bug as the next failure). 2026-05-05.
+      version: 1.4.26
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -115,8 +115,17 @@ name: bp-catalyst-platform
 # proven catalyst-api PIN delivery path. When A5 ships the missing
 # host/port/from coverage these defaults become unused (source wins).
 # 2026-05-05.
-version: 1.4.25
-appVersion: 1.4.25
+# 1.4.26 (#957 follow-up): catalyst-api-cutover-driver ClusterRole
+# gains a `create tokenreviews.authentication.k8s.io` rule so that
+# HandleCutoverInternalTrigger can validate the auto-trigger Job's
+# projected SA token via the apiserver's TokenReview API. Without
+# this rule the endpoint returns 502 "token-review-failed" on every
+# call; PR #947 wired the endpoint but not its RBAC. Caught live on
+# otech113 2026-05-05 — chart 0.1.18 fixed the readiness-probe loop
+# but every trigger immediately got 502 in <10ms (synchronous
+# apiserver permission rejection). 2026-05-05.
+version: 1.4.26
+appVersion: 1.4.26
 description: |
   Catalyst Platform — the unified Catalyst control plane umbrella chart for Catalyst-Zero.
   Composes the catalyst-{ui,api}, console, admin, marketplace UI modules and the marketplace-api backend.

--- a/products/catalyst/chart/templates/clusterrole-cutover-driver.yaml
+++ b/products/catalyst/chart/templates/clusterrole-cutover-driver.yaml
@@ -80,3 +80,27 @@ rules:
   - apiGroups: ["batch"]
     resources: ["jobs"]
     verbs: ["delete", "patch", "update"]
+
+  # ───────────────────────────────────────────────────────────────
+  # TokenReview — required by HandleCutoverInternalTrigger to
+  # validate the in-cluster auto-trigger Job's projected SA token
+  # against the apiserver's authentication chain (issue #957
+  # follow-up; PR #947 wired the endpoint but not its RBAC).
+  #
+  # Without this rule POST /api/v1/internal/cutover/trigger fails
+  # at TokenReviews().Create with HTTP 403 "tokenreviews is
+  # forbidden", which the handler maps to a generic 502
+  # "token-review-failed". Caught live on otech113 2026-05-05
+  # immediately after chart 0.1.18 fixed the readiness-probe loop:
+  # the trigger reached catalyst-api but every call returned 502
+  # in 8.87ms (well under any I/O latency, indicating a synchronous
+  # apiserver permission rejection).
+  #
+  # Per feedback_rbac_create_no_resourcenames.md (auto-memory
+  # anchor) `create` MUST be in its own Rule WITHOUT
+  # `resourceNames`. TokenReview is a virtual sub-resource of
+  # authentication.k8s.io — there is no name to scope to.
+  # ───────────────────────────────────────────────────────────────
+  - apiGroups: ["authentication.k8s.io"]
+    resources: ["tokenreviews"]
+    verbs: ["create"]


### PR DESCRIPTION
## Summary

Follow-up to PR #959 (chart bp-self-sovereign-cutover 0.1.18). The readiness-probe loop is fixed — the trigger now reaches catalyst-api — but every call returns **502 token-review-failed** in <10ms because the catalyst-api SA does not have permission to create TokenReviews against the apiserver.

## Live evidence on otech113 (2026-05-05 12:02:55)

```
GET  /healthz                              → 200  (0.1.18 probe SUCCESS)
POST /api/v1/internal/cutover/trigger      → 502 in 8.879ms
```

```
$ kubectl auth can-i create tokenreviews \
    --as=system:serviceaccount:catalyst-system:catalyst-api-cutover-driver
no
```

The ClusterRole `catalyst-api-cutover-driver` had every verb the cutover engine needs (configmaps, jobs, events, deployments, daemonsets) — but NOT `authentication.k8s.io/tokenreviews`. PR #947 wired `HandleCutoverInternalTrigger` (validates SA bearer via TokenReview) but didn't ship the matching RBAC rule.

## Fix

Add a separate Rule in `clusterrole-cutover-driver.yaml`:

```yaml
- apiGroups: ["authentication.k8s.io"]
  resources: ["tokenreviews"]
  verbs: ["create"]
```

Per `feedback_rbac_create_no_resourcenames.md` (auto-memory anchor) the `create` verb stays in its own Rule.

## Changes

| File | Change |
|---|---|
| `products/catalyst/chart/templates/clusterrole-cutover-driver.yaml` | NEW Rule: `tokenreviews` create |
| `products/catalyst/chart/Chart.yaml` | `1.4.25` → `1.4.26` |
| `clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml` | pin `1.4.26` |

## Test plan

- [x] `helm template` clean
- [ ] After merge + Blueprint Release CI publishes 1.4.26, force-reconcile bp-catalyst-platform on otech113
- [ ] Watch `kubectl --context=otech113 get jobs -n catalyst -w` until 8 cutover-step-* Jobs reach Complete
- [ ] `cutover-status` ConfigMap reaches `cutoverComplete=true`
- [ ] Comment proof on the cutover-track issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)