### PR TITLE
fix(catalyst-ui): drop unused imports — unblocks #972 build

### DIFF
--- a/products/catalyst/bootstrap/ui/src/app/router.tsx
+++ b/products/catalyst/bootstrap/ui/src/app/router.tsx
@@ -83,7 +83,6 @@ import { UsersPage as SMEUsersPage } from '@/pages/sme/UsersPage'
 import { RolesPage as SMERolesPage } from '@/pages/sme/RolesPage'
 import { CreateTenantPage as SMECreateTenantPage } from '@/pages/sme/CreateTenantPage'
 import { SovereigntyPreviewPage } from '@/pages/sovereignty/SovereigntyPreviewPage'
-import { SovereignConsoleRedirect } from '@/pages/sovereign/SovereignConsoleRedirect'
 
 // Root
 const rootRoute = createRootRoute({ component: RootLayout })

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/Dashboard.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/Dashboard.tsx
@@ -130,7 +130,7 @@ export function Dashboard({
   initialColorBy,
   initialSizeBy,
 }: DashboardProps = {}) {
-  const { deploymentId: resolved, isLoading: idLoading } = useResolvedDeploymentId()
+  const { deploymentId: resolved } = useResolvedDeploymentId()
   const deploymentId = resolved ?? ''
   const router = useRouter()
 


### PR DESCRIPTION
Two TS6133 unused-symbol errors blocked the catalyst-ui image build on the merge SHA `6ec7851` of PR #972. Drops the now-unused `SovereignConsoleRedirect` import and `idLoading` binding. Both removed cleanly because /console/* now wires directly to the canonical components — the redirect helper is no longer needed.