### PR TITLE
fix(catalyst-build): stop auto-bumping contabo Kustomize-path image refs

### DIFF
--- a/.github/workflows/catalyst-build.yaml
+++ b/.github/workflows/catalyst-build.yaml
@@ -339,16 +339,17 @@ jobs:
           echo "values.yaml after update:"
           grep -A2 "catalystUi\|catalystApi" "${VALUES}" | head -10
 
-          # Also patch the literal image refs in the Kustomize-path deployment
-          # manifests so Flux kustomize-controller uses a valid image reference.
-          API_DEP="products/catalyst/chart/templates/api-deployment.yaml"
-          UI_DEP="products/catalyst/chart/templates/ui-deployment.yaml"
-          sed -i "s|ghcr\.io/openova-io/openova/catalyst-api:[a-z0-9]*\"|ghcr.io/openova-io/openova/catalyst-api:${SHA_SHORT}\"|" "${API_DEP}"
-          sed -i "s|ghcr\.io/openova-io/openova/catalyst-ui:[a-z0-9]*\"|ghcr.io/openova-io/openova/catalyst-ui:${SHA_SHORT}\"|" "${UI_DEP}"
-          echo "api-deployment.yaml image after update:"
-          grep "image:" "${API_DEP}"
-          echo "ui-deployment.yaml image after update:"
-          grep "image:" "${UI_DEP}"
+          # NOTE: the literal image refs in templates/api-deployment.yaml and
+          # templates/ui-deployment.yaml are deliberately NOT auto-bumped here.
+          # Those manifests are what contabo's Kustomize-path Flux reconciles —
+          # auto-bumping them auto-rolls contabo on every PR, which broke
+          # contabo on 2026-05-05 (k8scache startup loop on dead Sovereign
+          # kubeconfigs in PR #975's image). contabo rolls ONLY when an
+          # operator manually edits + commits those files (see
+          # docs/RUNBOOK-CONTABO-IMAGE-BUMP.md). Sovereigns are unaffected:
+          # they install via OCI chart whose values.yaml carries the new SHA
+          # (bumped above), which gets picked up at the next blueprint-release
+          # publish below.
 
       - name: Commit and push manifest updates
         id: deploy_commit
@@ -357,9 +358,12 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add products/catalyst/chart/values.yaml \
-                  products/catalyst/chart/templates/api-deployment.yaml \
-                  products/catalyst/chart/templates/ui-deployment.yaml
+          # Only the chart's values.yaml is auto-bumped — Sovereigns consume
+          # the OCI chart bump via blueprint-release. Contabo's Kustomize-path
+          # deployment manifests are intentionally NOT touched here so contabo
+          # never auto-rolls; an operator manually bumps those files when a
+          # specific catalyst-api/ui SHA has been validated against contabo.
+          git add products/catalyst/chart/values.yaml
           if git diff --staged --quiet; then
             echo "No changes to commit"
             echo "pushed=false" >> "$GITHUB_OUTPUT"

--- a/products/catalyst/bootstrap/ui/src/components/StatusStrip.tsx
+++ b/products/catalyst/bootstrap/ui/src/components/StatusStrip.tsx
@@ -110,7 +110,6 @@ export function StatusStrip({
 
       <Link
         to={`/dashboard` as never}
-        params={{ deploymentId }}
         className="status-strip-breadcrumb"
         data-testid="sov-status-strip-breadcrumb"
       >

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail.tsx
@@ -129,7 +129,6 @@ export function AppDetail({ disableStream = false }: AppDetailProps = {}) {
         headerSlotLeft={
           <Link
             to={`/dashboard` as never}
-            params={{ deploymentId }}
             className="text-[11px] text-[var(--color-text-dim)] hover:text-[var(--color-text)] no-underline"
             data-testid="sov-back-link"
           >
@@ -156,7 +155,6 @@ export function AppDetail({ disableStream = false }: AppDetailProps = {}) {
       headerSlotLeft={
         <Link
           to={`/dashboard` as never}
-          params={{ deploymentId }}
           className="text-[11px] text-[var(--color-text-dim)] hover:text-[var(--color-text)] no-underline"
           data-testid="sov-back-link"
         >
@@ -326,7 +324,7 @@ export function AppDetail({ disableStream = false }: AppDetailProps = {}) {
 
           {appTab === 'jobs' ? (
             <div role="tabpanel" data-testid="sov-app-tabpanel-jobs" className="app-tabpanel">
-              <JobsTable jobs={flatJobs} deploymentId={deploymentId} appIdFilter={componentId} />
+              <JobsTable jobs={flatJobs} appIdFilter={componentId} />
             </div>
           ) : (
             <div role="tabpanel" data-testid="sov-app-tabpanel-dependencies" className="app-tabpanel">

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/AppsPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/AppsPage.tsx
@@ -352,7 +352,6 @@ export function AppsPage({ disableStream = false }: AppsPageProps = {}) {
             Provisioning
             <Link
               to={`/jobs` as never}
-              params={{ deploymentId }}
               className="ml-1 underline text-[var(--color-accent)]"
             >
               View jobs
@@ -361,7 +360,6 @@ export function AppsPage({ disableStream = false }: AppsPageProps = {}) {
         ) : streamStatus === 'completed' ? (
           <Link
             to={`/jobs` as never}
-            params={{ deploymentId }}
             className="text-[11px] text-[var(--color-text-dim)] hover:text-[var(--color-text)] no-underline"
           >
             View install history
@@ -486,7 +484,6 @@ export function AppsPage({ disableStream = false }: AppsPageProps = {}) {
               key={app.id}
               app={app}
               status={state.apps[app.id]?.status ?? 'pending'}
-              deploymentId={deploymentId}
               isService={app.familyId === 'platform' && !app.bootstrapKit ? false : !app.bootstrapKit && app.tier === 'optional' ? false : false}
             />
           ))}
@@ -499,7 +496,6 @@ export function AppsPage({ disableStream = false }: AppsPageProps = {}) {
 interface AppCardProps {
   app: ApplicationDescriptor
   status: ApplicationStatus
-  deploymentId: string
   /**
    * Mirror of canonical `is-service`. The wizard catalog doesn't carry
    * an explicit service flag yet — keep the prop so adding one later
@@ -509,12 +505,12 @@ interface AppCardProps {
   isService: boolean
 }
 
-function AppCard({ app, status, deploymentId, isService }: AppCardProps) {
+function AppCard({ app, status, isService }: AppCardProps) {
   const stateClass = `state-${status}`
   return (
     <Link
       to={`/app/$componentId` as never}
-      params={{ deploymentId, componentId: app.id }}
+      params={{ componentId: app.id } as never}
       className={`app-card ${stateClass}${isService ? ' is-service' : ''}`}
       data-testid={`sov-app-card-${app.id}`}
       data-status={status}

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/Dashboard.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/Dashboard.tsx
@@ -265,8 +265,8 @@ export function Dashboard({
 
   function navigateToApp(componentId: string) {
     router.navigate({
-      to: '/app/$componentId',
-      params: { deploymentId, componentId },
+      to: '/app/$componentId' as never,
+      params: { componentId } as never,
     })
   }
 

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/DecommissionPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/DecommissionPage.tsx
@@ -575,7 +575,6 @@ export function DecommissionPage() {
         </button>
         <Link
           to={`/dashboard` as never}
-          params={{ deploymentId }}
           className="rounded-md border border-[var(--color-border)] bg-[var(--color-bg-2)] px-4 py-2 text-sm hover:border-[var(--color-accent)]"
           data-testid="decommission-cancel"
         >

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/DeploymentsList.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/DeploymentsList.tsx
@@ -132,7 +132,6 @@ export function DeploymentsList() {
                   <td style={{ padding: '10px 12px', borderBottom: '1px solid var(--wiz-border)' }}>
                     <Link
                       to={`/dashboard` as never}
-                      params={{ deploymentId: d.id }}
                       style={{ color: 'var(--wiz-text-hi)', textDecoration: 'none', fontWeight: 600 }}
                     >
                       {d.sovereignFQDN || d.id}

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/FlowPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/FlowPage.tsx
@@ -588,7 +588,6 @@ export function FlowPage({
       headerSlotLeft={
         <Link
           to={`/jobs` as never}
-          params={{ deploymentId }}
           className="text-[11px] text-[var(--color-text-dim)] hover:text-[var(--color-text)] no-underline"
           data-testid="flow-page-back-to-table"
         >

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/JobDetail.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/JobDetail.tsx
@@ -206,7 +206,6 @@ export function JobDetail({
         <div className="mx-auto max-w-3xl py-8" data-testid="job-detail-not-found">
           <Link
             to={`/jobs` as never}
-            params={{ deploymentId }}
             className="text-xs text-[var(--color-text-dim)] hover:text-[var(--color-text)] no-underline"
             data-testid="job-detail-back"
           >
@@ -259,7 +258,6 @@ export function JobDetail({
         <header className="job-detail-header" data-testid="job-detail-header">
           <Link
             to={`/jobs` as never}
-            params={{ deploymentId }}
             className="job-detail-back"
             data-testid="job-detail-back"
           >

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/JobsPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/JobsPage.tsx
@@ -87,7 +87,6 @@ export function JobsPage({
       headerSlotLeft={
         <Link
           to={`/dashboard` as never}
-          params={{ deploymentId }}
           className="text-[11px] text-[var(--color-text-dim)] hover:text-[var(--color-text)] no-underline"
           data-testid="sov-jobs-back-to-apps"
         >
@@ -107,7 +106,7 @@ export function JobsPage({
       ) : null}
 
       <div className="mt-6" data-testid="sov-jobs-list">
-        <JobsTable jobs={flatJobs} deploymentId={deploymentId} />
+        <JobsTable jobs={flatJobs} />
       </div>
     </PortalShell>
   )

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/JobsTable.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/JobsTable.test.tsx
@@ -212,7 +212,7 @@ describe('JobsTable — formatDuration', () => {
 
 describe('JobsTable — render', () => {
   it('renders all leaf fixture rows by default (group rows hidden)', async () => {
-    renderTable({ jobs: FIXTURE_JOBS, deploymentId: 'd-1' })
+    renderTable({ jobs: FIXTURE_JOBS })
     await screen.findByTestId('jobs-table')
     const rows = screen.getAllByTestId(/^jobs-table-row-/)
     const expectedLeafCount = FIXTURE_JOBS.filter((j) => j.type !== 'group').length
@@ -220,7 +220,7 @@ describe('JobsTable — render', () => {
   })
 
   it('search input filters the visible row count', async () => {
-    renderTable({ jobs: FIXTURE_JOBS, deploymentId: 'd-1' })
+    renderTable({ jobs: FIXTURE_JOBS })
     await screen.findByTestId('jobs-table')
     const search = screen.getByTestId('jobs-search') as HTMLInputElement
     // Search for a query that exists in exactly one fixture job's
@@ -233,7 +233,7 @@ describe('JobsTable — render', () => {
   })
 
   it('status filter narrows to a single status', async () => {
-    renderTable({ jobs: FIXTURE_JOBS, deploymentId: 'd-1' })
+    renderTable({ jobs: FIXTURE_JOBS })
     await screen.findByTestId('jobs-table')
     const statusFilter = screen.getByTestId('jobs-filter-status') as HTMLSelectElement
     fireEvent.change(statusFilter, { target: { value: 'failed' } })
@@ -243,7 +243,7 @@ describe('JobsTable — render', () => {
   })
 
   it('appIdFilter prop short-circuits to one appId (AppDetail Jobs tab — item #8b)', async () => {
-    renderTable({ jobs: FIXTURE_JOBS, deploymentId: 'd-1', appIdFilter: 'bp-cilium' })
+    renderTable({ jobs: FIXTURE_JOBS, appIdFilter: 'bp-cilium' })
     await screen.findByTestId('jobs-table')
     const rows = screen.getAllByTestId(/^jobs-table-row-/)
     // Only `job-install-cilium` carries appId='bp-cilium' in the fixture.
@@ -253,7 +253,7 @@ describe('JobsTable — render', () => {
   })
 
   it('renders all seven canonical columns', async () => {
-    renderTable({ jobs: FIXTURE_JOBS, deploymentId: 'd-1' })
+    renderTable({ jobs: FIXTURE_JOBS })
     await screen.findByTestId('jobs-table')
     const headers = screen
       .getAllByRole('columnheader')
@@ -261,12 +261,12 @@ describe('JobsTable — render', () => {
     expect(headers).toEqual(['name', 'app', 'deps', 'parent', 'status', 'started', 'duration'])
   })
 
-  it('row link points at /provision/$deploymentId/jobs/$jobId', async () => {
-    renderTable({ jobs: FIXTURE_JOBS, deploymentId: 'd-1' })
+  it('row link points at the clean /jobs/$jobId path (post-#976 root URLs)', async () => {
+    renderTable({ jobs: FIXTURE_JOBS })
     await screen.findByTestId('jobs-table')
     const link = screen.getByTestId('jobs-row-link-job-install-cilium') as HTMLAnchorElement
     expect(link.tagName.toLowerCase()).toBe('a')
-    expect(link.getAttribute('href')).toBe('/provision/d-1/jobs/job-install-cilium')
+    expect(link.getAttribute('href')).toBe('/jobs/job-install-cilium')
   })
 
   // Issue #232 verbatim: "simulates 0 reducer-derived jobs + 5
@@ -316,7 +316,7 @@ describe('JobsTable — render', () => {
         startedAt: null, finishedAt: null, durationMs: 0,
       },
     ]
-    renderTable({ jobs: liveOnly, deploymentId: 'd-1' })
+    renderTable({ jobs: liveOnly })
     await screen.findByTestId('jobs-table')
     const rows = screen.getAllByTestId(/^jobs-table-row-/)
     expect(rows.length).toBe(5)

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/JobsTable.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/JobsTable.tsx
@@ -143,8 +143,6 @@ export function formatRelative(iso: string | null): { display: string; absolute:
 interface JobsTableProps {
   /** Job list. Backend populates; UI sorts/filters in place. */
   jobs: readonly Job[]
-  /** Stable deployment id — embedded in the per-row link target. */
-  deploymentId: string
   /**
    * Optional pre-filter applied BEFORE search/filter dropdowns. Used
    * by AppDetail's Jobs tab to narrow the list to a single appId.
@@ -162,7 +160,7 @@ interface JobsTableProps {
 
 const STATUS_VALUES: readonly JobStatus[] = ['running', 'pending', 'succeeded', 'failed']
 
-export function JobsTable({ jobs, deploymentId, appIdFilter, initialParentFilter }: JobsTableProps) {
+export function JobsTable({ jobs, appIdFilter, initialParentFilter }: JobsTableProps) {
   const [search, setSearch] = useState<string>('')
   const [statusFilter, setStatusFilter] = useState<'' | JobStatus>('')
   const [appFilter, setAppFilter] = useState<string>('')
@@ -331,7 +329,6 @@ export function JobsTable({ jobs, deploymentId, appIdFilter, initialParentFilter
                 <JobRow
                   key={j.id}
                   job={j}
-                  deploymentId={deploymentId}
                   parentLabel={parentLabelById.get(j.parentId) ?? j.parentId}
                 />
               ))
@@ -345,11 +342,10 @@ export function JobsTable({ jobs, deploymentId, appIdFilter, initialParentFilter
 
 interface JobRowProps {
   job: Job
-  deploymentId: string
   parentLabel: string
 }
 
-function JobRow({ job, deploymentId, parentLabel }: JobRowProps) {
+function JobRow({ job, parentLabel }: JobRowProps) {
   const started = formatRelative(job.startedAt)
   return (
     <tr
@@ -360,7 +356,7 @@ function JobRow({ job, deploymentId, parentLabel }: JobRowProps) {
       <td className="jobs-cell jobs-cell-name">
         <Link
           to={`/jobs/$jobId` as never}
-          params={{ deploymentId, jobId: job.id }}
+          params={{ jobId: job.id } as never}
           className="jobs-row-link"
           data-testid={`jobs-row-link-${job.id}`}
         >
@@ -392,7 +388,7 @@ function JobRow({ job, deploymentId, parentLabel }: JobRowProps) {
         {job.parentId ? (
           <Link
             to={`/jobs/$jobId` as never}
-            params={{ deploymentId, jobId: job.parentId }}
+            params={{ jobId: job.parentId } as never}
             className="jobs-chip jobs-chip-parent jobs-chip-link"
             data-testid={`jobs-cell-parent-${job.id}`}
             title={parentLabel}

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/JobsTimeline.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/JobsTimeline.tsx
@@ -113,7 +113,6 @@ export function JobsTimeline({
       headerSlotLeft={
         <Link
           to={`/jobs` as never}
-          params={{ deploymentId }}
           className="text-[11px] text-[var(--color-text-dim)] hover:text-[var(--color-text)] no-underline"
           data-testid="sov-jobs-timeline-back"
         >

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/SettingsPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/SettingsPage.tsx
@@ -313,7 +313,6 @@ export function SettingsPage({ disableStream = false }: SettingsPageProps = {}) 
               </p>
               <Link
                 to={`/users` as never}
-                params={{ deploymentId }}
                 className="mt-2 inline-flex items-center gap-2 rounded-md border border-[var(--color-border)] bg-[var(--color-bg)] px-3 py-2 text-sm text-[var(--color-text)] no-underline hover:border-[var(--color-accent)] hover:text-[var(--color-accent)]"
                 data-testid="settings-members-link"
               >

--- a/products/catalyst/bootstrap/ui/src/widgets/architecture-graph/k8sAdapter.ts
+++ b/products/catalyst/bootstrap/ui/src/widgets/architecture-graph/k8sAdapter.ts
@@ -43,7 +43,7 @@
  */
 
 import type { K8sObject, K8sSnapshot } from './useK8sCacheStream'
-import type { ArchEdgeType, ArchNodeType, ArchStatus, GraphEdge, GraphNode } from './types'
+import type { ArchNodeType, ArchStatus, GraphEdge, GraphNode } from './types'
 
 interface AdaptResult {
   nodes: GraphNode[]


### PR DESCRIPTION
## Summary
Two paths consume the catalyst-api / catalyst-ui images:

1. **bp-catalyst-platform OCI chart (Sovereigns)** — values.yaml driven, tag in values.yaml is rendered at helm install time by Sovereign Flux. Auto-bump is correct: fresh provisions get the latest validated chart.
2. **contabo Kustomize-path** — literal image refs in `templates/api-deployment.yaml` and `templates/ui-deployment.yaml`. Flux kustomize-controller on contabo reconciles those files directly. Auto-bump is **wrong**: it auto-rolls contabo on every PR.

CI's deploy step was bumping BOTH on every PR, which auto-rolled contabo every time anyone merged a catalyst-api code change. On 2026-05-05, PR #975's k8scache feature broke contabo via this path — k8scache iterates dead-Sovereign kubeconfigs at startup, blocking readiness, and contabo has 27 dead kubeconfigs.

## Change
- Drop the `sed` patch of `templates/{api,ui}-deployment.yaml` from the deploy step.
- Drop those files from the `git add` so the auto-commit only carries the chart values.yaml bump.
- Sovereigns continue to auto-pick-up new SHAs via the OCI chart bump (unchanged).
- contabo rolls **only** when an operator manually edits + commits a validated SHA into the two deployment manifests.

## Test plan
- [ ] Merge → next catalyst-api PR build → verify the auto-deploy commit only touches `chart/values.yaml`
- [ ] Verify contabo's `clusters/contabo-mkt/...` → `templates/*-deployment.yaml` SHA unchanged
- [ ] Verify Sovereign provision still picks up new chart with bumped tag