### PR TITLE
hotfix(catalyst-api): drop k8scache discovery probe — unblocks contabo startup (#975)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/dashboard_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/dashboard_test.go
@@ -211,7 +211,6 @@ func newDashHandlerWithCache(t *testing.T, clusterID string, withMetrics bool, o
 		Name:       "podmetrics",
 		GVR:        schema.GroupVersionResource{Group: "metrics.k8s.io", Version: "v1beta1", Resource: "pods"},
 		Namespaced: true,
-		Optional:   true,
 	})
 	cfg := k8scache.Config{
 		Logger:   quietHandlerLogger(),

--- a/products/catalyst/bootstrap/api/internal/k8scache/factory.go
+++ b/products/catalyst/bootstrap/api/internal/k8scache/factory.go
@@ -440,41 +440,23 @@ func (f *Factory) AddCluster(c ClusterRef) error {
 		lastEventAt: map[string]time.Time{},
 	}
 
-	// Build the per-cluster availability set for Optional kinds. The
-	// probe is one ServerResourcesForGroupVersion call per distinct
-	// (group,version), cached by string key. When discovery fails we
-	// log + skip the optional kind entirely (treat as absent) — better
-	// to render a degraded UI than crash-loop the informer.
-	optionalAvail := map[string]bool{}
-	if core != nil {
-		seenGV := map[string]bool{}
-		for _, k := range f.registry.All() {
-			if !k.Optional {
-				continue
-			}
-			gv := k.GVR.GroupVersion().String()
-			if seenGV[gv] {
-				continue
-			}
-			seenGV[gv] = true
-			list, derr := core.Discovery().ServerResourcesForGroupVersion(gv)
-			if derr != nil || list == nil {
-				f.log.Info("k8scache: optional GroupVersion absent on cluster",
-					"cluster", c.ID, "gv", gv, "err", derr)
-				continue
-			}
-			for _, r := range list.APIResources {
-				optionalAvail[k.GVR.GroupVersion().WithResource(r.Name).String()] = true
-			}
-		}
-	}
-
+	// Spawn one informer per registered kind. AddCluster MUST stay
+	// synchronous-network-free so a dead Sovereign kubeconfig — e.g. a
+	// decommissioned otech whose kubeconfig file was never removed
+	// from /var/lib/catalyst/kubeconfigs — cannot block catalyst-api
+	// startup.
+	//
+	// Earlier this site held a discovery probe that gated Optional
+	// kinds (metrics.k8s.io/PodMetrics) by calling
+	//   core.Discovery().ServerResourcesForGroupVersion(gv)
+	// to skip the informer when the GVR wasn't served. That call
+	// issues a synchronous REST GET against the cluster's apiserver
+	// with NO context timeout. On a kubeconfig pointing at a dead
+	// machine the call hangs until the underlying TCP connect times
+	// out (often minutes), and AddCluster is on the main startup
+	// path — so the contabo mothership boot blocked while iterating
+	// dead clusters. Removed.
 	for _, k := range f.registry.All() {
-		if k.Optional && !optionalAvail[k.GVR.String()] {
-			f.log.Info("k8scache: skipping optional kind on cluster (GVR not discoverable)",
-				"cluster", c.ID, "kind", k.Name, "gvr", k.GVR.String())
-			continue
-		}
 		inf := cs.factory.ForResource(k.GVR).Informer()
 		k := k // capture per-iteration
 		_, err := inf.AddEventHandler(cache.ResourceEventHandlerFuncs{

--- a/products/catalyst/bootstrap/api/internal/k8scache/k8scache_test.go
+++ b/products/catalyst/bootstrap/api/internal/k8scache/k8scache_test.go
@@ -31,7 +31,6 @@ import (
 	dynamicfake "k8s.io/client-go/dynamic/fake"
 	clientgokubernetes "k8s.io/client-go/kubernetes"
 	kfake "k8s.io/client-go/kubernetes/fake"
-	fakediscovery "k8s.io/client-go/discovery/fake"
 )
 
 // quietLogger discards log output so test runs aren't noisy.
@@ -113,30 +112,19 @@ func TestDefaultKinds_GraphAndDashboardSurface(t *testing.T) {
 		"namespace", "node", "pod", "service", "configmap", "secret",
 		"persistentvolumeclaim", "deployment", "statefulset", "daemonset",
 		"ingress",
-		// new — graph + dashboard depend on these
+		// graph + dashboard depend on these
 		"persistentvolume", "replicaset", "endpointslice",
-		// optional but registered
-		"podmetrics",
 	}
 	for _, name := range mandatory {
 		if _, ok := r.Get(name); !ok {
 			t.Errorf("DefaultKinds missing %q — required by architecture-graph or dashboard", name)
 		}
 	}
-
-	// PodMetrics MUST be flagged Optional so the discovery probe in
-	// AddCluster skips it on Sovereigns without metrics-server.
-	if pm, ok := r.Get("podmetrics"); !ok {
-		t.Fatalf("podmetrics not in registry")
-	} else if !pm.Optional {
-		t.Errorf("podmetrics must be Optional=true; got false")
-	}
-	// All other kinds must be mandatory — Optional is reserved for
-	// add-ons we know are not part of in-spec K8s.
-	for _, k := range DefaultKinds {
-		if k.Name != "podmetrics" && k.Optional {
-			t.Errorf("kind %q should be mandatory; got Optional=true", k.Name)
-		}
+	// PodMetrics is intentionally NOT in DefaultKinds — see kinds.go
+	// for the rationale (the synchronous discovery probe that gated
+	// it caused contabo startup to block on dead kubeconfigs).
+	if _, ok := r.Get("podmetrics"); ok {
+		t.Errorf("podmetrics must not be in DefaultKinds; the discovery-gate path was reverted")
 	}
 }
 
@@ -238,94 +226,6 @@ func TestFactory_ListUnknownClusterErrors(t *testing.T) {
 	_, _, err = f.List("missing", "pod", labels.Everything())
 	if err == nil {
 		t.Fatalf("expected error for unknown cluster")
-	}
-}
-
-// TestFactory_OptionalKindSkippedWhenAbsent — adding a Kind flagged
-// Optional whose GVR is not in the cluster's discovery surface MUST
-// not crash-loop the informer. The factory probes discovery, sees
-// the GroupVersion is unregistered, and silently skips the informer.
-// Listing that kind on the cluster then errors out cleanly.
-func TestFactory_OptionalKindSkippedWhenAbsent(t *testing.T) {
-	dyn, core := fakeClients()
-	r := minimalRegistry()
-	// metrics.k8s.io is NOT registered on the fake clientset's discovery,
-	// so this Optional kind must be skipped at AddCluster time.
-	_ = r.Add(Kind{
-		Name:       "podmetrics",
-		GVR:        schema.GroupVersionResource{Group: "metrics.k8s.io", Version: "v1beta1", Resource: "pods"},
-		Namespaced: true,
-		Optional:   true,
-	})
-	cfg := Config{
-		Logger:   quietLogger(),
-		Registry: r,
-		Clusters: []ClusterRef{
-			{ID: "alpha", DynamicClient: dyn, CoreClient: core},
-		},
-	}
-	f, err := NewFactory(cfg)
-	if err != nil {
-		t.Fatalf("NewFactory: %v", err)
-	}
-	defer f.Stop()
-	if err := f.Start(context.Background()); err != nil {
-		t.Fatalf("Start: %v", err)
-	}
-	_, _, err = f.List("alpha", "podmetrics", labels.Everything())
-	if err == nil {
-		t.Fatalf("expected error listing optional+absent kind, got nil")
-	}
-}
-
-// TestFactory_OptionalKindRegisteredWhenPresent — when discovery does
-// surface the Optional kind's GroupVersion, the informer spawns
-// normally and List works. We seed metrics.k8s.io into the typed
-// fake's Discovery via the kfake.Resources field.
-func TestFactory_OptionalKindRegisteredWhenPresent(t *testing.T) {
-	dyn, _ := fakeClients()
-	core := kfake.NewSimpleClientset()
-	// kfake exposes a fake discovery client; populate it with the
-	// metrics.k8s.io/v1beta1 resource list so AddCluster's probe
-	// returns success.
-	if fd, ok := core.Discovery().(*fakediscovery.FakeDiscovery); ok {
-		fd.Resources = append(fd.Resources, &metav1.APIResourceList{
-			GroupVersion: "metrics.k8s.io/v1beta1",
-			APIResources: []metav1.APIResource{
-				{Name: "pods", Namespaced: true, Kind: "PodMetrics"},
-			},
-		})
-	} else {
-		t.Skipf("fake discovery not assertable; skipping")
-	}
-
-	r := minimalRegistry()
-	_ = r.Add(Kind{
-		Name:       "podmetrics",
-		GVR:        schema.GroupVersionResource{Group: "metrics.k8s.io", Version: "v1beta1", Resource: "pods"},
-		Namespaced: true,
-		Optional:   true,
-	})
-	cfg := Config{
-		Logger:   quietLogger(),
-		Registry: r,
-		Clusters: []ClusterRef{
-			{ID: "alpha", DynamicClient: dyn, CoreClient: core},
-		},
-	}
-	f, err := NewFactory(cfg)
-	if err != nil {
-		t.Fatalf("NewFactory: %v", err)
-	}
-	defer f.Stop()
-	if err := f.Start(context.Background()); err != nil {
-		t.Fatalf("Start: %v", err)
-	}
-	// List of zero items is fine; the contract under test is that
-	// the informer was spawned (no "kind not registered" error).
-	_, _, err = f.List("alpha", "podmetrics", labels.Everything())
-	if err != nil {
-		t.Fatalf("expected optional+present kind to list cleanly, got %v", err)
 	}
 }
 

--- a/products/catalyst/bootstrap/api/internal/k8scache/kinds.go
+++ b/products/catalyst/bootstrap/api/internal/k8scache/kinds.go
@@ -60,16 +60,6 @@ type Kind struct {
 	// Secret. ConfigMap data is treated as PII-adjacent and also
 	// stripped (see redactObject).
 	Sensitive bool
-
-	// Optional — true when the GVR is provided by an add-on that may
-	// be absent from a given Sovereign (today: metrics.k8s.io served
-	// by the optional metrics-server). The factory probes discovery
-	// at AddCluster time and only spawns an informer for the cluster
-	// when the GVR is registered. Mandatory kinds (Optional=false)
-	// always get an informer; if the watch fails the informer retries
-	// — that path is reserved for kinds we know are part of any
-	// in-spec K8s distro (core/v1, apps/v1, networking.k8s.io/v1).
-	Optional bool
 }
 
 // DefaultKinds is the built-in registry — every Sovereign starts with
@@ -120,12 +110,14 @@ var DefaultKinds = []Kind{
 	// vCluster.io tenants.
 	{Name: "vcluster", GVR: schema.GroupVersionResource{Group: "vcluster.com", Version: "v1alpha1", Resource: "vclusters"}, Namespaced: true},
 
-	// metrics-server projection. Optional — only registered on
-	// Sovereigns where metrics-server has installed the
-	// metrics.k8s.io APIService. The dashboard handler reads this
-	// indexer for color_by=utilization; when absent the handler
-	// returns percentage=null and the UI greys those cells.
-	{Name: "podmetrics", GVR: schema.GroupVersionResource{Group: "metrics.k8s.io", Version: "v1beta1", Resource: "pods"}, Namespaced: true, Optional: true},
+	// NOTE: metrics.k8s.io/PodMetrics is NOT in DefaultKinds. The
+	// optional metrics-server APIService isn't installed on every
+	// Sovereign, and the original AddCluster discovery probe that
+	// gated this kind made startup block on dead kubeconfigs. Until
+	// a non-blocking activation path lands the dashboard's
+	// color_by=utilization stays null when no PodMetrics indexer is
+	// available; healthy + age + size paths still render off Pod /
+	// PVC indexers.
 }
 
 // Registry is a runtime-mutable lookup keyed by the short Name. It


### PR DESCRIPTION
## Summary
- Removes the synchronous `core.Discovery().ServerResourcesForGroupVersion(gv)` call I added in #976/#978's k8scache prep. That call has NO context timeout, so on a kubeconfig pointing at a dead Sovereign apiserver (decommissioned otech whose `<id>.yaml` was never removed from `/var/lib/catalyst/kubeconfigs/`) it hangs until TCP connect times out. With many dead kubeconfigs the contabo mothership boot serially blocks for minutes — observed live as catalyst-api stuck "iterating dead clusters" on startup.
- Drops `Kind.Optional`, removes `PodMetrics` from `DefaultKinds`, and deletes the two probe-specific tests + the `fakediscovery` import. Until a non-blocking activation path lands, the dashboard's `color_by=utilization` returns null when no PodMetrics indexer exists; health/age/size paths still ride the Pod + PVC indexers untouched.

## Root cause
In `factory.go:AddCluster()` I added a probe loop that called `core.Discovery().ServerResourcesForGroupVersion(gv)` to gate Optional kinds. Per `client-go/discovery/discovery_client.go`, that helper issues `RESTClient().Get().AbsPath(...).Do(context.TODO())` — no caller context, so the request is bound only by the underlying transport's TCP connect timeout. On a kubeconfig with a dead `server:` URL the call hangs minutes per cluster; AddCluster runs serially over every kubeconfig at startup.

## Test plan
- [x] go build ./... clean
- [x] go test ./internal/k8scache/... ./internal/handler/... -run "TestDefaultKinds|TestRegistry|TestFactory|TestDashboard" green
- [ ] On contabo: catalyst-api starts within seconds even with stale kubeconfigs in /var/lib/catalyst/kubeconfigs/

## Companion
Coordinate with the other session's local rollback that pinned contabo to :8a1fe04. Once this hotfix builds and deploys, the pin can be released forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)