### PR TITLE
deploy(contabo): release pin to :b4fb6cf — k8scache discovery probe removed (#975)

### DIFF
--- a/products/catalyst/chart/templates/api-deployment.yaml
+++ b/products/catalyst/chart/templates/api-deployment.yaml
@@ -152,7 +152,7 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       containers:
         - name: catalyst-api
-          image: "ghcr.io/openova-io/openova/catalyst-api:ed8872a"
+          image: "ghcr.io/openova-io/openova/catalyst-api:b4fb6cf"
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080

--- a/products/catalyst/chart/templates/ui-deployment.yaml
+++ b/products/catalyst/chart/templates/ui-deployment.yaml
@@ -19,7 +19,7 @@ spec:
         - name: ghcr-pull
       containers:
         - name: catalyst-ui
-          image: "ghcr.io/openova-io/openova/catalyst-ui:ed8872a"
+          image: "ghcr.io/openova-io/openova/catalyst-ui:b4fb6cf"
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080


### PR DESCRIPTION
Manual forward-roll of the contabo Kustomize-path image refs after the hotfix chain:

- #981 hotfix(catalyst-api): drop k8scache discovery probe — unblocks contabo startup
- #979 fix(catalyst-ui): drop stale params={{ deploymentId }} from clean-root Links

Per #980, the chart templates that contabo's Flux Kustomization renders are NOT auto-bumped by catalyst-build. This commit performs the manual bump from \`:ed8872a\` to \`:b4fb6cf\`.

Verification before merge:
- catalyst-build for b4fb6cf completed success
- Images \`ghcr.io/openova-io/openova/catalyst-{api,ui}:b4fb6cf\` are pushed and available
- The hotfix removes the synchronous Discovery probe that wedged AddCluster on dead kubeconfigs

🤖 Generated with [Claude Code](https://claude.com/claude-code)