### PR TITLE
fix(sovereign-console): URL contract on Sovereign — clean roots, real data, working sidebar

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/auth_handover.go
+++ b/products/catalyst/bootstrap/api/internal/handler/auth_handover.go
@@ -19,7 +19,7 @@
 //     refresh token pair (audience: catalyst-ui OIDC client).
 //  6. Sets HttpOnly Secure SameSite=Lax cookies (catalyst_session +
 //     catalyst_refresh).
-//  7. 302 redirects to /console/dashboard.
+//  7. 302 redirects to /dashboard (clean Sovereign root URL).
 //
 // All errors return 401 with terse JSON {"error": "..."}.
 // No secrets are emitted in error responses (per INVIOLABLE-PRINCIPLES #10).
@@ -250,7 +250,7 @@ func (h *Handler) AuthHandover(w http.ResponseWriter, r *http.Request) {
 
 	redirectTarget := h.authHandoverRedirect
 	if redirectTarget == "" {
-		redirectTarget = "/console/dashboard"
+		redirectTarget = "/dashboard"
 	}
 	http.Redirect(w, r, redirectTarget, http.StatusFound)
 }

--- a/products/catalyst/bootstrap/api/internal/handler/auth_handover_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/auth_handover_test.go
@@ -53,7 +53,7 @@ func testHandoverSetup(t *testing.T) (h *Handler, privKey *rsa.PrivateKey, keyPa
 		log:                       slog.New(slog.NewTextHandler(io.Discard, nil)),
 		handoverJWTPublicKeyPath:  keyPath,
 		authHandoverSovereignFQDN: "sov.test",
-		authHandoverRedirect:      "/console/dashboard",
+		authHandoverRedirect:      "/dashboard",
 		jtiStore:                  jtiSt,
 		kc:                        &stubKeycloakClient{},
 	}
@@ -128,8 +128,8 @@ func TestAuthHandover_HappyPath(t *testing.T) {
 	if resp.StatusCode != http.StatusFound {
 		t.Errorf("status: got %d want 302", resp.StatusCode)
 	}
-	if loc := resp.Header.Get("Location"); loc != "/console/dashboard" {
-		t.Errorf("Location: got %q want /console/dashboard", loc)
+	if loc := resp.Header.Get("Location"); loc != "/dashboard" {
+		t.Errorf("Location: got %q want /dashboard", loc)
 	}
 
 	cookies := resp.Cookies()

--- a/products/catalyst/bootstrap/api/internal/handler/handler.go
+++ b/products/catalyst/bootstrap/api/internal/handler/handler.go
@@ -241,7 +241,7 @@ type Handler struct {
 	authHandoverSovereignFQDN string
 	// kcAudience — OIDC client id for token-exchange. Defaults to "catalyst-ui".
 	kcAudience string
-	// authHandoverRedirect — post-handover redirect target. Defaults to "/console/dashboard".
+	// authHandoverRedirect — post-handover redirect target. Defaults to "/dashboard".
 	authHandoverRedirect string
 
 	// ── /auth/pin fields (issue #688, replaces magic-link flow) ─────────────

--- a/products/catalyst/bootstrap/api/internal/handler/sovereign_self.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sovereign_self.go
@@ -3,28 +3,34 @@
 // Sovereign self-discovery: returns the deployment id and FQDN of the
 // Sovereign cluster the catalyst-api Pod is running on. Used by the
 // Sovereign-mode catalyst-ui to resolve the deployment id for clean URLs
-// (`/console/dashboard` → `/provision/<self-id>/dashboard`) and to wire
-// the deployment-scoped data fetches the canonical UI components expect.
+// (`/dashboard`, `/jobs`, `/cloud`, …) and to wire the deployment-scoped
+// data fetches the canonical UI components expect.
 //
-// Resolution order:
+// Resolution order (first non-empty wins):
 //
-//  1. CATALYST_SELF_DEPLOYMENT_ID env (populated at handover from the
-//     contabo orchestrator via the bp-catalyst-platform chart's
-//     sovereign-fqdn ConfigMap). This is the canonical source of truth
-//     post-handover.
-//  2. CATALYST_OTECH_FQDN env (already wired via the same ConfigMap, see
-//     B1 PR #912). Used to populate the FQDN field. If
-//     CATALYST_SELF_DEPLOYMENT_ID is empty AND CATALYST_OTECH_FQDN is
-//     populated, returns 503 deployment-id-not-yet-stamped to make the
-//     UI fall back gracefully (instead of looping on empty).
-//  3. Both empty → 404 not-a-sovereign — the mothership (contabo) hits
-//     this and the UI silently treats it as "not on a Sovereign", which
-//     is the correct default for `console.openova.io`.
+//  1. CATALYST_SELF_DEPLOYMENT_ID env (populated by the contabo
+//     orchestrator through the bp-catalyst-platform chart's
+//     sovereign-fqdn ConfigMap when it stamps the per-Sovereign overlay).
+//  2. Local store scan — find the single deployment record whose
+//     SovereignFQDN matches CATALYST_OTECH_FQDN. The
+//     POST /api/v1/internal/deployments/import endpoint persists exactly
+//     one such record at handover time after rejecting any FQDN that
+//     doesn't match this cluster's env, so a single-record lookup is
+//     unambiguous. This branch is what makes clean URLs render data on
+//     the very first handover-arrival, before the orchestrator has had
+//     a chance to update the values overlay + Flux to stamp the env.
+//  3. CATALYST_OTECH_FQDN populated but no record yet — return 503
+//     so the UI surfaces a "waiting for handover" state instead of
+//     looping on an empty id. This is the genuine
+//     `mother-not-yet-fired` window.
+//  4. Both env empty AND no record — return 404 (mothership). The UI
+//     hook treats this as "not on a Sovereign" and falls back to URL
+//     params for `/provision/$id/...`.
 //
 // No authentication required: the response carries no secrets, only
 // public identifiers (deployment id + FQDN are both visible in URLs).
-// Bypassing the session gate keeps the SovereignConsoleRedirect helper
-// usable on the very first browser hit before login.
+// Bypassing the session gate keeps the cookie-vs-OIDC pre-flight in
+// SovereignConsoleLayout usable on the very first browser hit.
 package handler
 
 import (
@@ -44,11 +50,10 @@ type SovereignSelfResponse struct {
 }
 
 // HandleSovereignSelf returns the active Sovereign's deployment id + FQDN.
-// Returns 404 on the mothership, 503 on Sovereigns that haven't received
-// the post-handover deployment-id stamp yet.
 func (h *Handler) HandleSovereignSelf(w http.ResponseWriter, _ *http.Request) {
 	deploymentID := strings.TrimSpace(os.Getenv("CATALYST_SELF_DEPLOYMENT_ID"))
 	fqdn := strings.TrimSpace(os.Getenv("CATALYST_OTECH_FQDN"))
+
 	// Mothership: neither env is set — surface 404 so the UI hook treats
 	// this as "not on a Sovereign" and uses URL params instead.
 	if deploymentID == "" && fqdn == "" {
@@ -58,9 +63,26 @@ func (h *Handler) HandleSovereignSelf(w http.ResponseWriter, _ *http.Request) {
 		})
 		return
 	}
-	// Sovereign without stamped deployment id — the handover step is
-	// behind. UI sees 503 and shows a "waiting for handover" pill rather
-	// than looping.
+
+	// Step 2: store fallback — scan the local store for a record whose
+	// SovereignFQDN matches CATALYST_OTECH_FQDN. The cutover-import
+	// endpoint enforces the FQDN match before persisting, so the only
+	// record on disk should already be ours — but we still filter
+	// defensively in case a tenant migration ever lands a stale record.
+	if deploymentID == "" && h.store != nil {
+		recs, err := h.store.LoadAll(nil)
+		if err == nil {
+			for _, r := range recs {
+				if strings.EqualFold(r.Request.SovereignFQDN, fqdn) {
+					deploymentID = r.ID
+					break
+				}
+			}
+		}
+	}
+
+	// Step 3: still no id — handover hasn't fired yet. Return 503 so the
+	// UI shows a "waiting for handover" state.
 	if deploymentID == "" {
 		writeJSON(w, http.StatusServiceUnavailable, map[string]string{
 			"error":  "deployment-id-not-yet-stamped",
@@ -69,9 +91,9 @@ func (h *Handler) HandleSovereignSelf(w http.ResponseWriter, _ *http.Request) {
 		})
 		return
 	}
+
 	writeJSON(w, http.StatusOK, SovereignSelfResponse{
 		DeploymentID:  deploymentID,
 		SovereignFQDN: fqdn,
 	})
 }
-

--- a/products/catalyst/bootstrap/ui/src/app/layouts/SovereignConsoleLayout.tsx
+++ b/products/catalyst/bootstrap/ui/src/app/layouts/SovereignConsoleLayout.tsx
@@ -8,7 +8,7 @@
  *      `catalyst_session` cookie minted by the server-side /auth/handover
  *      handler. If 200, the operator is authenticated via the cookie —
  *      render the console without ever touching Keycloak.
- *   2. If 401, fall back to the legacy OIDC flow:
+ *   2. If 401, fall back to the OIDC flow:
  *      - read tokens from sessionStorage,
  *      - if missing/expired, attempt silentRefresh,
  *      - if that fails, initiateLogin (PKCE redirect to Keycloak).
@@ -28,7 +28,7 @@
  * otech49 + otech52 today, operator landed on a username/password
  * screen instead of the dashboard).
  *
- * The SovereignSidebar uses `/console/*` routes (no deploymentId param) —
+ * The SovereignSidebar uses clean root routes (/dashboard, /apps, …) —
  * in Sovereign mode the sovereign context is implicit from the hostname.
  *
  * Layout contract:
@@ -325,7 +325,7 @@ export function SovereignConsoleLayout({
                   {sovereignFQDN}
                 </DropdownMenuLabel>
                 <DropdownMenuItem
-                  onClick={() => router.navigate({ to: '/console/settings' as never })}
+                  onClick={() => router.navigate({ to: '/settings' as never })}
                 >
                   <Settings className="h-3.5 w-3.5" />
                   Settings

--- a/products/catalyst/bootstrap/ui/src/app/router.tsx
+++ b/products/catalyst/bootstrap/ui/src/app/router.tsx
@@ -91,7 +91,7 @@ const rootRoute = createRootRoute({ component: RootLayout })
  * Index redirect — mode-aware.
  *
  * catalyst-zero (console.openova.io): redirect to /wizard (Provisioning Wizard)
- * sovereign (console.<sov-fqdn>):     redirect to /console/dashboard (Sovereign Console)
+ * sovereign (console.<sov-fqdn>):     redirect to /dashboard (Sovereign Console clean root)
  *
  * IS_SAAS is preserved as a higher-priority override for the Catalyst-Zero
  * SaaS variant of the platform where local auth is used.
@@ -106,7 +106,7 @@ const indexRoute = createRoute({
   path: '/',
   beforeLoad: () => {
     if (IS_SAAS) throw redirect({ to: '/login' })
-    if (DETECTED_MODE.mode === 'sovereign') throw redirect({ to: '/console/dashboard' as never })
+    if (DETECTED_MODE.mode === 'sovereign') throw redirect({ to: '/dashboard' as never })
     throw redirect({ to: '/wizard' })
   },
 })
@@ -132,8 +132,8 @@ const forgotRoute = createRoute({ getParentRoute: () => rootRoute, path: '/forgo
  *   GET /auth/callback?code=<code>&state=<state>
  *
  * AuthCallbackPage exchanges the code for tokens, then navigates to
- * /console/dashboard. The route is intentionally outside the
- * SovereignConsoleLayout so it runs before auth state is resolved.
+ * /dashboard (clean Sovereign root). The route is intentionally outside
+ * the SovereignConsoleLayout so it runs before auth state is resolved.
  */
 const authCallbackRoute = createRoute({
   getParentRoute: () => rootRoute,
@@ -146,11 +146,11 @@ const authCallbackRoute = createRoute({
  *
  * The server-side (Agent C / catalyst-api on the Sovereign) handles
  * POST /auth/handover — it validates the JWT, creates a Keycloak session,
- * and returns 302 with session cookies to /console/dashboard.
+ * and returns 302 with session cookies to /dashboard.
  *
  * The client does NOT intercept this URL at the fetch level. If the
  * browser lands here (unlikely — the server redirect should carry the
- * browser directly to /console/dashboard), redirect immediately.
+ * browser directly to /dashboard), redirect immediately.
  *
  * This route exists purely as a safety net to prevent a TanStack Router
  * 404 in case the server 302 for some reason resolves to a client-side
@@ -160,7 +160,7 @@ const authHandoverRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: '/auth/handover',
   beforeLoad: () => {
-    throw redirect({ to: '/console/dashboard' as never, replace: true })
+    throw redirect({ to: '/dashboard' as never, replace: true })
   },
   component: () => null,
 })

--- a/products/catalyst/bootstrap/ui/src/pages/auth/AuthCallbackPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/auth/AuthCallbackPage.tsx
@@ -14,7 +14,7 @@ import { useSearch, useRouter } from '@tanstack/react-router'
  *   Keycloak redirects to /auth/callback?code=...&state=... after the
  *   operator authenticates. The page calls handleCallback() to exchange
  *   the code for tokens via the PKCE token endpoint (client-side), then
- *   navigates to /console/dashboard.
+ *   navigates to /dashboard.
  *
  * Catalyst-Zero (console.openova.io):
  *   The PIN flow set the catalyst_session cookie on /auth/pin/verify;
@@ -77,7 +77,7 @@ function SovereignCallbackPage() {
         await handleCallback(sovereignFQDN, params)
         // Navigate to the console dashboard — replace so the callback
         // URL doesn't appear in browser history.
-        router.navigate({ to: '/console/dashboard' as never, replace: true })
+        router.navigate({ to: '/dashboard' as never, replace: true })
       } catch (err) {
         setState({
           status: 'error',

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/SovereignSidebar.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/SovereignSidebar.tsx
@@ -4,8 +4,10 @@
  * Analogous to Sidebar.tsx (which is tied to the Catalyst-Zero
  * /provision/$deploymentId/* route tree), but in Sovereign mode:
  *
- *   - Routes use the /console/* prefix (no deploymentId param) — the
- *     Sovereign is implicit from the hostname.
+ *   - Routes are at clean root paths (/dashboard, /apps, /jobs, /cloud,
+ *     /users, /settings, /catalog, /parent-domains) — the Sovereign
+ *     is implicit from the hostname; no deploymentId param appears in
+ *     any URL the operator sees.
  *   - The tenant label shows the Sovereign FQDN.
  *   - The footer card shows the authenticated user's name (from
  *     OIDC tokens), not the generic "Operator" placeholder.
@@ -42,31 +44,31 @@ const FLAT_NAV: FlatNavItem[] = [
   {
     id: 'apps',
     label: 'Apps',
-    to: '/console/apps',
+    to: '/apps',
     icon: 'M4 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2V6zm10 0a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2V6zM4 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2v-2zm10 0a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2v-2z',
   },
   {
     id: 'jobs',
     label: 'Jobs',
-    to: '/console/jobs',
+    to: '/jobs',
     icon: 'M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-6 9l2 2 4-4',
   },
   {
     id: 'dashboard',
     label: 'Dashboard',
-    to: '/console/dashboard',
+    to: '/dashboard',
     icon: 'M3 3h7v9H3V3zm11 0h7v5h-7V3zM14 10h7v11h-7V10zM3 14h7v7H3v-7z',
   },
   {
     id: 'cloud',
     label: 'Cloud',
-    to: '/console/cloud',
+    to: '/cloud',
     icon: CLOUD_ICON,
   },
   {
     id: 'users',
     label: 'Users',
-    to: '/console/users',
+    to: '/users',
     icon: 'M9 7a4 4 0 100 8 4 4 0 000-8zM3 21v-2a4 4 0 014-4h4a4 4 0 014 4v2M16 3.13a4 4 0 010 7.75M21 21v-2a4 4 0 00-3-3.87',
   },
   {
@@ -74,7 +76,7 @@ const FLAT_NAV: FlatNavItem[] = [
     // publishing toggles (issue #710 wave 2.5).
     id: 'catalog',
     label: 'Catalog',
-    to: '/console/catalog',
+    to: '/catalog',
     icon: 'M3 7v13h18V7M3 7l9-4 9 4M3 7h18M9 11v6M15 11v6',
   },
 ]
@@ -82,7 +84,7 @@ const FLAT_NAV: FlatNavItem[] = [
 const SETTINGS_ITEM: FlatNavItem = {
   id: 'settings',
   label: 'Settings',
-  to: '/console/settings',
+  to: '/settings',
   icon: 'M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.066 2.573c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.573 1.066c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.066-2.573c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z M15 12a3 3 0 11-6 0 3 3 0 016 0z',
 }
 
@@ -101,32 +103,32 @@ interface SubNavItem {
 }
 
 const SETTINGS_SUB_NAV: SubNavItem[] = [
-  { id: 'marketplace', label: 'Marketplace', to: '/console/settings/marketplace' },
+  { id: 'marketplace', label: 'Marketplace', to: '/settings/marketplace' },
   // Parent Domains — admin "Add another parent domain" + DNS propagation
   // status panel (issue #829). Lives under Settings so the sidebar
   // surface stays compact for the typical SME tenant who never sees
-  // this surface; operator-admins reach it via /console/parent-domains
-  // directly from the welcome email or by clicking through Settings.
-  { id: 'parent-domains', label: 'Parent Domains', to: '/console/parent-domains' },
+  // this surface; operator-admins reach it via /parent-domains directly
+  // from the welcome email or by clicking through Settings.
+  { id: 'parent-domains', label: 'Parent Domains', to: '/parent-domains' },
 ]
 
 // ── Active-state derivation ───────────────────────────────────────────────────
 
 type ActiveSection = 'apps' | 'jobs' | 'dashboard' | 'cloud' | 'users' | 'catalog' | 'settings'
 
-const CLOUD_PATH_RE = /\/console\/(cloud|infrastructure)(\/|$)/
+const CLOUD_PATH_RE = /^\/(cloud|infrastructure)(\/|$)/
 
 function deriveActiveSection(pathname: string): ActiveSection {
   if (CLOUD_PATH_RE.test(pathname)) return 'cloud'
-  if (/\/console\/dashboard(\/|$)/.test(pathname)) return 'dashboard'
-  if (/\/console\/jobs(\/|$)/.test(pathname)) return 'jobs'
-  if (/\/console\/users(\/|$)/.test(pathname)) return 'users'
-  if (/\/console\/catalog(\/|$)/.test(pathname)) return 'catalog'
-  // /console/settings/* OR /console/parent-domains → 'settings' so the
-  // Settings nav item highlights and the sub-nav (Marketplace + Parent
-  // Domains) expands. Per inviolable principle #4, the path list is
-  // pulled from SETTINGS_SUB_NAV rather than re-typed here.
-  if (/\/console\/settings(\/|$)/.test(pathname)) return 'settings'
+  if (/^\/dashboard(\/|$)/.test(pathname)) return 'dashboard'
+  if (/^\/jobs(\/|$)/.test(pathname)) return 'jobs'
+  if (/^\/users(\/|$)/.test(pathname)) return 'users'
+  if (/^\/catalog(\/|$)/.test(pathname)) return 'catalog'
+  // /settings/* OR /parent-domains → 'settings' so the Settings nav
+  // item highlights and the sub-nav (Marketplace + Parent Domains)
+  // expands. Per inviolable principle #4, the path list is pulled
+  // from SETTINGS_SUB_NAV rather than re-typed here.
+  if (/^\/settings(\/|$)/.test(pathname)) return 'settings'
   if (SETTINGS_SUB_NAV.some((s) => pathname.startsWith(s.to))) return 'settings'
   return 'apps'
 }

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-list/cloudListShared.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-list/cloudListShared.tsx
@@ -18,6 +18,7 @@ import { useEffect, useRef, useState, type ReactNode } from 'react'
 import { Link } from '@tanstack/react-router'
 import type { TopologyStatus } from '@/lib/infrastructure.types'
 import type { SortState } from './sortState'
+import { sovereignPath } from '@/shared/lib/sovereignPaths'
 
 /* ── Header ──────────────────────────────────────────────────────── */
 
@@ -80,8 +81,7 @@ export function CloudListHeader({
           </button>
         )}
         <Link
-          to={'/provision/$deploymentId/cloud' as never}
-          params={{ deploymentId } as never}
+          to={sovereignPath('cloud', { deploymentId }) as never}
           className="text-xs text-[var(--color-text-dim)] hover:text-[var(--color-text)] no-underline"
           data-testid={`${testId}-back`}
         >

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-network/CloudNetworkPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-network/CloudNetworkPage.tsx
@@ -11,6 +11,7 @@ import { useMemo } from 'react'
 import { Link } from '@tanstack/react-router'
 import { useCloud } from '../CloudPage'
 import { CLOUD_LIST_CSS } from '../cloud-list/cloudListCss'
+import { DETECTED_MODE } from '@/shared/lib/detectMode'
 
 interface NetworkTile {
   id: 'services' | 'ingresses' | 'load-balancers' | 'dns-zones'
@@ -97,8 +98,11 @@ export function CloudNetworkPage() {
             return (
               <Link
                 key={tile.id}
-                to={`/provision/$deploymentId/cloud/network/${tile.id}` as never}
-                params={{ deploymentId } as never}
+                to={
+                  (DETECTED_MODE.mode === 'sovereign'
+                    ? `/cloud/network/${tile.id}`
+                    : `/provision/${deploymentId}/cloud/network/${tile.id}`) as never
+                }
                 className="cloud-list-tile"
                 data-testid={`cloud-network-page-tile-${tile.id}`}
               >

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-storage/CloudStoragePage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-storage/CloudStoragePage.tsx
@@ -10,6 +10,7 @@ import { useMemo } from 'react'
 import { Link } from '@tanstack/react-router'
 import { useCloud } from '../CloudPage'
 import { CLOUD_LIST_CSS } from '../cloud-list/cloudListCss'
+import { DETECTED_MODE } from '@/shared/lib/detectMode'
 
 interface StorageTile {
   id: 'pvcs' | 'storage-classes' | 'buckets' | 'volumes'
@@ -91,8 +92,11 @@ export function CloudStoragePage() {
             return (
               <Link
                 key={tile.id}
-                to={`/provision/$deploymentId/cloud/storage/${tile.id}` as never}
-                params={{ deploymentId } as never}
+                to={
+                  (DETECTED_MODE.mode === 'sovereign'
+                    ? `/cloud/storage/${tile.id}`
+                    : `/provision/${deploymentId}/cloud/storage/${tile.id}`) as never
+                }
                 className="cloud-list-tile"
                 data-testid={`cloud-storage-page-tile-${tile.id}`}
               >


### PR DESCRIPTION
## What the operator sees on otech117 (BUG)

After PR #976/#977 landed:
1. Login redirects to \`https://console.otech117.omani.works/provision/<id>\` instead of \`/dashboard\`.
2. Clean root URLs (\`/dashboard\`, \`/jobs\`, \`/cloud\`, …) show no data; data only at \`/provision/<id>/…\`.
3. Clicking \"Cloud\" from \`/dashboard\` lands on \`/provision//cloud\` (empty id) — sidebar broken.

## Root causes

| File | Bug |
|---|---|
| auth_handover.go:253 | Default redirect target still \`/console/dashboard\` (deleted route). |
| handler.go:244 + auth_handover_test.go | Same legacy default + test fixture. |
| router.tsx:109,163 | Index + /auth/handover safety-net redirect to \`/console/dashboard\`. |
| AuthCallbackPage.tsx:80 | Post-PKCE navigate to \`/console/dashboard\`. |
| SovereignSidebar.tsx:45-110 | FLAT_NAV / SETTINGS / SETTINGS_SUB_NAV \`to:\` literals all \`/console/X\`; \`deriveActiveSection\` regex matches \`/console/X\`. |
| SovereignConsoleLayout.tsx:328 | Settings menu navigates \`/console/settings\`. |
| cloudListShared.tsx:83 | \`to={'/provision/\$deploymentId/cloud'}\` literal — empty id on Sovereign → \`/provision//cloud\`. |
| CloudNetworkPage.tsx + CloudStoragePage.tsx | Same \`/provision/\$deploymentId/cloud/X/Y\` literal in tile Links. |
| sovereign_self.go | 503 \`deployment-id-not-yet-stamped\` because env empty. \`useResolvedDeploymentId\` returns null → every page has no id to fetch with. |

## Fix

- All redirects + nav targets land on clean roots (\`/dashboard\`, \`/cloud\`, \`/jobs\`, \`/users\`, \`/settings\`, \`/catalog\`, \`/parent-domains\`).
- All sidebar regexes match clean roots.
- Cloud sub-page Links are mode-aware (\`sovereignPath\` helper for back-link; inline \`DETECTED_MODE.mode === 'sovereign'\` branch for tile sub-routes).
- \`sovereign_self.go\`: when CATALYST_SELF_DEPLOYMENT_ID env is empty but the local store contains a deployment record whose SovereignFQDN matches CATALYST_OTECH_FQDN, return that record's id. The cutover import endpoint enforces FQDN match before persisting, so a single matching record is unambiguously this Sovereign's. Means data flows on clean URLs the moment \`fireHandover\` POSTs the record to /api/v1/internal/deployments/import — no values-overlay roundtrip + Flux reconcile required.

## Test plan
- [ ] Build catalyst-api + catalyst-ui.
- [ ] After CI bumps the chart's values.yaml, fresh otech117 provision: handover button → land at \`/dashboard\` (not \`/provision/<id>\`).
- [ ] Click each sidebar item — URL is clean root, Cloud doesn't go to \`/provision//cloud\`.
- [ ] /dashboard, /jobs, /apps, /cloud render the imported deployment record's data (events, jobs, components).