### PR TITLE
chore(bp-catalyst-platform): bump 1.4.28 → 1.4.29 — pulls in #983 URL contract

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -226,7 +226,12 @@ spec:
       # every trigger call returned 502 "token-review-failed" on
       # otech113 (chart 0.1.18 fixed the readiness loop but exposed
       # this missing-RBAC bug as the next failure). 2026-05-05.
-      version: 1.4.28
+      # 1.4.29 (#983 follow-up): Sovereign Console URL contract — clean
+      # root URLs (/dashboard /jobs /cloud …), sovereign_self.go store
+      # fallback (data renders the moment cutover-import lands without
+      # waiting for the orchestrator's chart-values overlay write).
+      # 2026-05-05.
+      version: 1.4.29
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -124,8 +124,8 @@ name: bp-catalyst-platform
 # otech113 2026-05-05 — chart 0.1.18 fixed the readiness-probe loop
 # but every trigger immediately got 502 in <10ms (synchronous
 # apiserver permission rejection). 2026-05-05.
-version: 1.4.28
-appVersion: 1.4.28
+version: 1.4.29
+appVersion: 1.4.29
 description: |
   Catalyst Platform — the unified Catalyst control plane umbrella chart for Catalyst-Zero.
   Composes the catalyst-{ui,api}, console, admin, marketplace UI modules and the marketplace-api backend.


### PR DESCRIPTION
## What

- \`products/catalyst/chart/Chart.yaml\` 1.4.28 → 1.4.29
- \`clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml\` HelmRelease pin 1.4.28 → 1.4.29

## Why

PR #983 landed the Sovereign Console URL contract (clean root URLs, store fallback for sovereign_self, sidebar paths, redirect targets). The image SHA carrying that fix gets auto-bumped into chart \`values.yaml\` by the catalyst-build workflow — but every Sovereign HelmRelease pins \`version: 1.4.28\`, so Flux on otech117 won't roll up to the new image without a chart version bump. This bumps both files in lockstep so the next blueprint-release publishes 1.4.29 + every Sovereign upgrades.

## Test plan
- [ ] Merge → catalyst-build → blueprint-release publishes bp-catalyst-platform:1.4.29 OCI artifact.
- [ ] otech117 Flux reconciles bootstrap-kit Kustomization → HelmRelease bp-catalyst-platform upgrades to 1.4.29 → catalyst-api/ui Pods restart with the URL-contract code.
- [ ] Hard-refresh \`https://console.otech117.omani.works/\`: lands at \`/dashboard\` (not \`/provision/<id>\`); sidebar Cloud link goes to \`/cloud\`; \`/dashboard\` /apps /jobs render data.