### PR TITLE
deploy(contabo): bump pin to :e221b48 — fix mothership redirect

### DIFF
--- a/products/catalyst/chart/templates/api-deployment.yaml
+++ b/products/catalyst/chart/templates/api-deployment.yaml
@@ -152,7 +152,7 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       containers:
         - name: catalyst-api
-          image: "ghcr.io/openova-io/openova/catalyst-api:8a83416"
+          image: "ghcr.io/openova-io/openova/catalyst-api:e221b48"
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080

--- a/products/catalyst/chart/templates/ui-deployment.yaml
+++ b/products/catalyst/chart/templates/ui-deployment.yaml
@@ -19,7 +19,7 @@ spec:
         - name: ghcr-pull
       containers:
         - name: catalyst-ui
-          image: "ghcr.io/openova-io/openova/catalyst-ui:8a83416"
+          image: "ghcr.io/openova-io/openova/catalyst-ui:e221b48"
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080


### PR DESCRIPTION
Lands #987 on contabo: SovereignConsoleLayout's mothership-fall-through now redirects to /sovereign/ (wizard) instead of / (which 302s to /nova marketplace).