### PR TITLE
rollback(contabo): pin :0daaac5 → :8a1fe04 — last user-confirmed stable

### DIFF
--- a/products/catalyst/chart/templates/api-deployment.yaml
+++ b/products/catalyst/chart/templates/api-deployment.yaml
@@ -152,7 +152,7 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       containers:
         - name: catalyst-api
-          image: "ghcr.io/openova-io/openova/catalyst-api:0daaac5"
+          image: "ghcr.io/openova-io/openova/catalyst-api:8a1fe04"
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080

--- a/products/catalyst/chart/templates/ui-deployment.yaml
+++ b/products/catalyst/chart/templates/ui-deployment.yaml
@@ -19,7 +19,7 @@ spec:
         - name: ghcr-pull
       containers:
         - name: catalyst-ui
-          image: "ghcr.io/openova-io/openova/catalyst-ui:0daaac5"
+          image: "ghcr.io/openova-io/openova/catalyst-ui:8a1fe04"
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080


### PR DESCRIPTION
## What
Reverts contabo's chart template literal to \`:8a1fe04\` — the last image SHA the founder confirmed as stable before today's auth-loop fix chain (#984 → #987 → #989).

## Why
Live verification on contabo right now:
\`\`\`
$ curl -ksI https://console.openova.io/
HTTP/2 307
location: https://console.openova.io/nova/
\`\`\`
Operators landing on the mothership get bounced to the marketplace instead of the provisioning wizard. The three-PR fix chain (#984/#987/#989) hasn't restored the working state.

This pin restores the wizard. Sovereigns unaffected (otech117 is on \`:8a83416\` via Helm and not auto-rolling due to the source-controller OCI-version cache behavior).

## Next steps (separate PR)
1. Reproduce the \`/\` → \`/nova/\` redirect locally in catalyst-ui (likely an index-route or beforeLoad in router.tsx that fires in Catalyst-Zero mode).
2. Fix at root.
3. Ship a new image SHA + manually re-pin contabo when verified.