### PR TITLE
chore(bp-catalyst-platform): bump 1.4.29 → 1.4.30 + literal :8a1fe04 → :019309f

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -231,7 +231,7 @@ spec:
       # fallback (data renders the moment cutover-import lands without
       # waiting for the orchestrator's chart-values overlay write).
       # 2026-05-05.
-      version: 1.4.29
+      version: 1.4.30
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -124,8 +124,8 @@ name: bp-catalyst-platform
 # otech113 2026-05-05 — chart 0.1.18 fixed the readiness-probe loop
 # but every trigger immediately got 502 in <10ms (synchronous
 # apiserver permission rejection). 2026-05-05.
-version: 1.4.29
-appVersion: 1.4.29
+version: 1.4.30
+appVersion: 1.4.30
 description: |
   Catalyst Platform — the unified Catalyst control plane umbrella chart for Catalyst-Zero.
   Composes the catalyst-{ui,api}, console, admin, marketplace UI modules and the marketplace-api backend.

--- a/products/catalyst/chart/templates/api-deployment.yaml
+++ b/products/catalyst/chart/templates/api-deployment.yaml
@@ -152,7 +152,7 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       containers:
         - name: catalyst-api
-          image: "ghcr.io/openova-io/openova/catalyst-api:8a1fe04"
+          image: "ghcr.io/openova-io/openova/catalyst-api:019309f"
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080

--- a/products/catalyst/chart/templates/ui-deployment.yaml
+++ b/products/catalyst/chart/templates/ui-deployment.yaml
@@ -19,7 +19,7 @@ spec:
         - name: ghcr-pull
       containers:
         - name: catalyst-ui
-          image: "ghcr.io/openova-io/openova/catalyst-ui:8a1fe04"
+          image: "ghcr.io/openova-io/openova/catalyst-ui:019309f"
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080


### PR DESCRIPTION
## What
- Chart version 1.4.29 → 1.4.30 (forces Flux source-controller's OCI cache to invalidate — otherwise Sovereigns stay on the first 1.4.29 digest they pulled).
- Chart template literal \`:8a1fe04\` → \`:019309f\` (the catalyst-build output for commit \`019309f9\`, the revert merge of the broken redirect chain).
- bootstrap-kit HelmRelease pin 1.4.29 → 1.4.30.

## Why
\`:019309f\` carries PR #983's URL contract fix WITHOUT the broken \`/\` → \`/nova/\` redirect chain that was reverted in PR #992. Sovereigns (otech117 et al) finally pick up the clean code.

## Contabo unaffected
Contabo's Kustomize path reads \`clusters/contabo-mkt/...\` — not the chart templates. PR #991 already pinned contabo to \`:8a1fe04\`. This chart change only affects the Sovereign Helm-install path.

## Test plan
- [ ] Build for \`019309f9\` finishes → image \`:019309f\` lands in GHCR.
- [ ] Merge → blueprint-release publishes 1.4.30.
- [ ] otech117 Flux reconciles bootstrap-kit Kustomization → HelmRelease upgrades to 1.4.30 → catalyst-api/ui restart with \`:019309f\`.
- [ ] curl https://console.otech117.omani.works/dashboard — clean route, sidebar links to clean roots, /api/v1/sovereign/self returns deploymentId.