### PR TITLE
fix(wizard): redirect to /provision/$deploymentId/dashboard not /dashboard — kills /sovereign/wizard ↔ Authenticating loop

### DIFF
--- a/products/catalyst/bootstrap/ui/src/pages/wizard/WizardPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/wizard/WizardPage.tsx
@@ -93,7 +93,7 @@ export function WizardPage() {
     // back-button press from /provision/<id> should land on the
     // referrer, not on a doomed wizard step.
     navigate({
-      to: '/dashboard',
+      to: '/provision/$deploymentId/dashboard',
       params: { deploymentId: inflight.id },
       replace: true,
     })

--- a/products/catalyst/bootstrap/ui/src/pages/wizard/steps/StepReview.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/wizard/steps/StepReview.tsx
@@ -789,7 +789,7 @@ export function StepReview() {
       }
       store.setDeploymentId(data.id)
       router.navigate({
-        to: '/dashboard',
+        to: '/provision/$deploymentId/dashboard',
         params: { deploymentId: data.id },
       })
     } catch (err) {


### PR DESCRIPTION
Two wizard redirects now correctly target the per-deployment mothership monitor URL instead of the clean Sovereign root. Confirmed live on contabo: `/sovereign/wizard` was infinitely bouncing operators to `/sovereign/dashboard` → SovereignConsoleLayout → 'Authenticating…' forever, because `/dashboard` (Sovereign Console clean root) doesn't have the deploymentId-resolving context on Catalyst-Zero.

Closes the founder-blocking issue preventing otech118 provisioning.