### PR TITLE
fix(redirects): /console/dashboard → /dashboard in 3 remaining sites (#983 follow-up)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/auth_handover.go
+++ b/products/catalyst/bootstrap/api/internal/handler/auth_handover.go
@@ -19,7 +19,7 @@
 //     refresh token pair (audience: catalyst-ui OIDC client).
 //  6. Sets HttpOnly Secure SameSite=Lax cookies (catalyst_session +
 //     catalyst_refresh).
-//  7. 302 redirects to /console/dashboard.
+//  7. 302 redirects to /dashboard (clean Sovereign root).
 //
 // All errors return 401 with terse JSON {"error": "..."}.
 // No secrets are emitted in error responses (per INVIOLABLE-PRINCIPLES #10).
@@ -250,7 +250,7 @@ func (h *Handler) AuthHandover(w http.ResponseWriter, r *http.Request) {
 
 	redirectTarget := h.authHandoverRedirect
 	if redirectTarget == "" {
-		redirectTarget = "/console/dashboard"
+		redirectTarget = "/dashboard"
 	}
 	http.Redirect(w, r, redirectTarget, http.StatusFound)
 }

--- a/products/catalyst/bootstrap/api/internal/handler/auth_handover_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/auth_handover_test.go
@@ -53,7 +53,7 @@ func testHandoverSetup(t *testing.T) (h *Handler, privKey *rsa.PrivateKey, keyPa
 		log:                       slog.New(slog.NewTextHandler(io.Discard, nil)),
 		handoverJWTPublicKeyPath:  keyPath,
 		authHandoverSovereignFQDN: "sov.test",
-		authHandoverRedirect:      "/console/dashboard",
+		authHandoverRedirect:      "/dashboard",
 		jtiStore:                  jtiSt,
 		kc:                        &stubKeycloakClient{},
 	}
@@ -128,8 +128,8 @@ func TestAuthHandover_HappyPath(t *testing.T) {
 	if resp.StatusCode != http.StatusFound {
 		t.Errorf("status: got %d want 302", resp.StatusCode)
 	}
-	if loc := resp.Header.Get("Location"); loc != "/console/dashboard" {
-		t.Errorf("Location: got %q want /console/dashboard", loc)
+	if loc := resp.Header.Get("Location"); loc != "/dashboard" {
+		t.Errorf("Location: got %q want /dashboard", loc)
 	}
 
 	cookies := resp.Cookies()

--- a/products/catalyst/bootstrap/ui/src/app/router.tsx
+++ b/products/catalyst/bootstrap/ui/src/app/router.tsx
@@ -106,7 +106,7 @@ const indexRoute = createRoute({
   path: '/',
   beforeLoad: () => {
     if (IS_SAAS) throw redirect({ to: '/login' })
-    if (DETECTED_MODE.mode === 'sovereign') throw redirect({ to: '/console/dashboard' as never })
+    if (DETECTED_MODE.mode === 'sovereign') throw redirect({ to: '/dashboard' as never })
     throw redirect({ to: '/wizard' })
   },
 })
@@ -160,7 +160,7 @@ const authHandoverRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: '/auth/handover',
   beforeLoad: () => {
-    throw redirect({ to: '/console/dashboard' as never, replace: true })
+    throw redirect({ to: '/dashboard' as never, replace: true })
   },
   component: () => null,
 })


### PR DESCRIPTION
Reverts of #984/#987/#989 brought back legacy `/console/dashboard` redirects in 3 places PR #983 had originally cleaned up. None of those targets resolve to a real route on Sovereign anymore (clean root is /dashboard) — they would 404/catchall on a fresh Sovereign after handover JWT consumption.

- `auth_handover.go:253` default
- `router.tsx:109` index sovereign redirect
- `router.tsx:163` /auth/handover safety-net
- test fixture sync