### PR TITLE
fix(admin,billing): BillingPage spinner never resolves (#1000)

### DIFF
--- a/core/admin/src/components/BillingPage.svelte
+++ b/core/admin/src/components/BillingPage.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import AdminShell from './AdminShell.svelte';
   import {
+    getMe,
     getBillingSettings,
     updateBillingSettings,
     listPromoCodes,
@@ -15,6 +16,11 @@
   // settings. The Stripe-settings section is rendered conditionally on
   // `userRole === 'superadmin'` and the GET /billing/admin/settings call
   // is skipped for sovereign-admin (it would 403 anyway).
+  // #1000 — userRole is driven by BillingPage's own getMe() in the
+  // initial $effect, NOT by writing it from inside the AdminShell snippet's
+  // {@const}. Svelte 5 treats state writes during render as
+  // state_unsafe_mutation and the parent's $effect does not reliably
+  // re-fire — that's what stranded the spinner before.
   let userRole = $state<string>('');
   let settings = $state<BillingSettings | null>(null);
   let promos = $state<PromoCode[]>([]);
@@ -57,11 +63,21 @@
     }
   }
 
-  // Load happens once we know the user's role — AdminShell hands us
-  // `user` via the children snippet, so we re-trigger when userRole flips
-  // from '' to 'superadmin' / 'sovereign-admin'.
   $effect(() => {
-    if (userRole) load(userRole);
+    let cancelled = false;
+    (async () => {
+      try {
+        const me = await getMe();
+        if (cancelled) return;
+        userRole = me.role;
+        await load(me.role);
+      } catch (e: any) {
+        if (cancelled) return;
+        error = e.message;
+        loading = false;
+      }
+    })();
+    return () => { cancelled = true; };
   });
 
   async function saveSettings(e: Event) {
@@ -126,7 +142,6 @@
 
 <AdminShell activePage="billing">
   {#snippet children(user: User)}
-    {@const _ = (userRole = user.role)}
     <div>
       <div>
         <h1 class="text-2xl font-bold text-[var(--color-text-strong)]">Billing</h1>


### PR DESCRIPTION
## Summary
- BillingPage's data fetch was gated on `userRole`, a `$state` seeded by `{@const _ = (userRole = user.role)}` inside the AdminShell snippet — Svelte 5 treats writes-during-render as `state_unsafe_mutation` and the parent's `$effect` never re-fires.
- Replace with BillingPage's own `getMe()` in its initial `$effect` (mirrors RevenuePage). Drop the `@const` line in the snippet.
- Result: spinner clears, `/billing/admin/promos` (+ `/billing/admin/settings` for superadmin) actually get called, page renders.

Closes #1000.

## Test plan
- [ ] CI build green
- [ ] Once merged + image rolled, navigate to https://admin.openova.io/nova/billing as a superadmin → Stripe Configuration + Vouchers sections render (no infinite spinner)
- [ ] Navigate as a sovereign-admin → only Vouchers section renders
- [ ] Tail `kubectl logs -n sme deploy/gateway` and confirm `/billing/admin/promos` + `/billing/admin/settings` are now hit on page load

🤖 Generated with [Claude Code](https://claude.com/claude-code)