### PR TITLE
fix: cloud chroot escapes + wizard-inflight banner instead of auto-redirect

### DIFF
--- a/products/catalyst/bootstrap/ui/src/pages/admin/user-access/UserAccessEditPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/admin/user-access/UserAccessEditPage.tsx
@@ -26,6 +26,7 @@
 
 import { useEffect, useMemo, useState } from 'react'
 import { useNavigate, useParams } from '@tanstack/react-router'
+import { DETECTED_MODE } from '@/shared/lib/detectMode'
 import { PortalShell } from '@/pages/sovereign/PortalShell'
 import {
   createUserAccess,
@@ -130,7 +131,9 @@ export function UserAccessEditPage({
         await createUserAccess(deploymentId, req)
       }
       navigate({
-        to: '/users' as never,
+        to: (DETECTED_MODE.mode === 'sovereign' || !deploymentId
+          ? '/users'
+          : `/provision/${deploymentId}/users`) as never,
         params: { deploymentId } as never,
       })
     } catch (err) {
@@ -252,7 +255,9 @@ export function UserAccessEditPage({
               data-testid="ua-button-cancel"
               onClick={() =>
                 navigate({
-                  to: '/users' as never,
+                  to: (DETECTED_MODE.mode === 'sovereign' || !deploymentId
+                    ? '/users'
+                    : `/provision/${deploymentId}/users`) as never,
                   params: { deploymentId } as never,
                 })
               }

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/CloudPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/CloudPage.tsx
@@ -51,6 +51,7 @@ import {
 } from '@tanstack/react-router'
 import { useQuery } from '@tanstack/react-query'
 import { PortalShell } from './PortalShell'
+import { DETECTED_MODE } from '@/shared/lib/detectMode'
 import { useDeploymentEvents } from './useDeploymentEvents'
 import { Architecture } from './Architecture'
 import { CloudListView } from './cloud-list/CloudListView'
@@ -186,6 +187,14 @@ export function CloudPage({
   // rename window.
   const params = useParams({ strict: false }) as { deploymentId: string }
   const deploymentId = params.deploymentId
+  // Chroot-aware nav target: when the operator is monitoring an in-flight
+  // Sovereign from the mothership wizard, every link MUST stay scoped under
+  // /provision/<id>/cloud. On the Sovereign's adult hostname (DETECTED_MODE
+  // === 'sovereign') the deploymentId is implicit so we use clean /cloud.
+  const cloudPath = (id: string) =>
+    DETECTED_MODE.mode === 'sovereign' || !id
+      ? '/cloud'
+      : `/provision/${id}/cloud`
   const navigate = useNavigate()
 
   const pathname = useRouterState({ select: (s) => s.location.pathname })
@@ -310,7 +319,7 @@ export function CloudPage({
       next.kind = search.kind
     }
     navigate({
-      to: '/cloud' as never,
+      to: cloudPath(deploymentId) as never,
       params: { deploymentId } as never,
       search: next as never,
       replace: true,
@@ -325,7 +334,7 @@ export function CloudPage({
       target.kind = search.kind
     }
     navigate({
-      to: '/cloud' as never,
+      to: cloudPath(deploymentId) as never,
       params: { deploymentId } as never,
       search: target as never,
       replace: false,
@@ -341,7 +350,7 @@ export function CloudPage({
       target.kind = search.kind
     }
     navigate({
-      to: '/cloud' as never,
+      to: cloudPath(nextId) as never,
       params: { deploymentId: nextId } as never,
       search: target as never,
     })
@@ -398,7 +407,7 @@ export function CloudPage({
   const setKind = useCallback(
     (next: CloudListKind) => {
       navigate({
-        to: '/cloud' as never,
+        to: cloudPath(deploymentId) as never,
         params: { deploymentId } as never,
         search: { view: 'list', kind: next } as never,
         replace: false,

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-list/CloudListView.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-list/CloudListView.tsx
@@ -15,6 +15,7 @@
 
 import { useCallback, useEffect, useMemo } from 'react'
 import { useNavigate, useRouterState, useSearch } from '@tanstack/react-router'
+import { DETECTED_MODE } from '@/shared/lib/detectMode'
 import { useCloud } from '../CloudPage'
 import { CLOUD_LIST_CSS } from './cloudListCss'
 import {
@@ -66,7 +67,9 @@ export function CloudListView({ kindOverride }: CloudListViewProps = {}) {
     if (search.kind === activeKind) return
     if (!pathname.endsWith('/cloud')) return
     navigate({
-      to: '/cloud' as never,
+      to: (DETECTED_MODE.mode === 'sovereign' || !deploymentId
+        ? '/cloud'
+        : `/provision/${deploymentId}/cloud`) as never,
       params: { deploymentId } as never,
       search: { view: 'list', kind: activeKind } as never,
       replace: true,

--- a/products/catalyst/bootstrap/ui/src/pages/wizard/WizardPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/wizard/WizardPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from 'react'
 import { AnimatePresence, motion } from 'framer-motion'
-import { Link, useNavigate } from '@tanstack/react-router'
+import { Link } from '@tanstack/react-router'
 import { useWizardStore } from '@/entities/deployment/store'
 import { useSession } from '@/shared/lib/useSession'
 import { useInflightDeployment } from '@/shared/lib/useInflightDeployment'
@@ -71,14 +71,13 @@ export function WizardPage() {
   const idx = Math.max(0, Math.min(currentStep - 1, STEPS.length - 1))
   const StepComponent = STEPS[idx]!
 
-  // Issue #747 — auto-redirect a signed-in operator who already owns
-  // an in-flight deployment back to /provision/<id>. This is the bug
-  // surfaced when the founder refreshed the wizard tab during otech90
-  // provisioning and lost the progress page. We deliberately wait
-  // until the session is resolved before deciding — running the
-  // redirect during session.loading would race the cookie check and
-  // bounce an anonymous visitor erroneously.
-  const navigate = useNavigate()
+  // The operator may legitimately want to start a SECOND provision
+  // even when one is already in flight (founder framing 2026-05-05:
+  // 'maybe I'll provision one more'). So we DON'T auto-redirect; we
+  // surface a banner pointing at the inflight deployment's monitor
+  // and let the operator continue stepping through the wizard.
+  // Replaces the previous useEffect-redirect that bounced /sovereign/wizard
+  // → /provision/<id>/dashboard unconditionally on signed-in load.
   const session = useSession()
   const { inflight, completed } = useInflightDeployment({
     ownerEmail: session.email,
@@ -86,29 +85,8 @@ export function WizardPage() {
   })
 
   useEffect(() => {
-    if (session.loading) return
-    if (!session.signedIn) return
-    if (!inflight) return
-    // replace:true so the wizard URL doesn't sit in history — a
-    // back-button press from /provision/<id> should land on the
-    // referrer, not on a doomed wizard step.
-    navigate({
-      to: '/provision/$deploymentId/dashboard',
-      params: { deploymentId: inflight.id },
-      replace: true,
-    })
-  }, [session.loading, session.signedIn, inflight, navigate])
-
-  useEffect(() => {
     document.getElementById('wizard-body')?.scrollTo({ top: 0, behavior: 'instant' as ScrollBehavior })
   }, [currentStep])
-
-  // While the redirect is pending render nothing — surfacing a
-  // half-rendered Step 1 for one frame before TanStack Router replaces
-  // the route is jarring.
-  if (!session.loading && session.signedIn && inflight) {
-    return null
-  }
 
   // History banner — operator has at least one completed/wiped/failed
   // deployment but no live one. Render a single-line strip pointing at
@@ -116,8 +94,53 @@ export function WizardPage() {
   const hasHistory =
     !session.loading && session.signedIn && !inflight && completed.length > 0
 
+  // Inflight banner — operator has a deployment currently provisioning.
+  // The wizard stays interactive (so they can start a SECOND), but a
+  // strip at the top points at the inflight monitor for one-click resume.
+  const hasInflight =
+    !session.loading && session.signedIn && inflight
+
   return (
     <>
+      {hasInflight && inflight && (
+        <div
+          role="status"
+          data-testid="wizard-inflight-banner"
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 12,
+            padding: '8px 16px',
+            margin: '0 0 16px 0',
+            background: 'rgba(168,85,247,0.10)',
+            border: '1px solid rgba(168,85,247,0.30)',
+            borderRadius: 8,
+            fontSize: 13,
+            color: 'var(--wiz-text-md)',
+          }}
+        >
+          <span style={{ flex: 1 }}>
+            You have a deployment in flight: <strong>{inflight.sovereignFQDN ?? inflight.id}</strong>.
+          </span>
+          <Link
+            to={'/provision/$deploymentId/dashboard' as never}
+            params={{ deploymentId: inflight.id } as never}
+            data-testid="wizard-inflight-banner-link"
+            style={{
+              padding: '4px 10px',
+              borderRadius: 6,
+              background: 'rgba(168,85,247,0.20)',
+              color: '#a855f7',
+              fontSize: 12,
+              fontWeight: 600,
+              textDecoration: 'none',
+              border: '1px solid rgba(168,85,247,0.45)',
+            }}
+          >
+            Open monitor →
+          </Link>
+        </div>
+      )}
       {hasHistory && (
         <div
           role="status"


### PR DESCRIPTION
Two operator-reported bugs on otech118 monitoring view + wizard.

**1. Cloud chroot escapes** — PR #998 covered Sidebar/JobsTable/FlowPage but missed CloudPage / CloudListView / UserAccessEditPage. Same DETECTED_MODE-aware fix.

**2. Wizard inaccessible when an inflight exists** — operator wants to provision a second Sovereign in parallel. Replace the auto-redirect with an inline banner pointing at the inflight monitor. The wizard stays interactive; operator chooses.