### PR TITLE
fix(wizard): include credentials on subdomain availability check

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -231,7 +231,7 @@ spec:
       # fallback (data renders the moment cutover-import lands without
       # waiting for the orchestrator's chart-values overlay write).
       # 2026-05-05.
-      version: 1.4.33
+      version: 1.4.34
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/bootstrap/ui/src/shared/lib/useSubdomainAvailability.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/lib/useSubdomainAvailability.ts
@@ -98,6 +98,7 @@ export function useSubdomainAvailability(
       try {
         const res = await fetch(`${API_BASE}/v1/subdomains/check`, {
           method: 'POST',
+          credentials: 'include',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ subdomain: sub, poolDomain: pool }),
           signal: ctrl.signal,

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -124,8 +124,8 @@ name: bp-catalyst-platform
 # otech113 2026-05-05 — chart 0.1.18 fixed the readiness-probe loop
 # but every trigger immediately got 502 in <10ms (synchronous
 # apiserver permission rejection). 2026-05-05.
-version: 1.4.33
-appVersion: 1.4.33
+version: 1.4.34
+appVersion: 1.4.34
 description: |
   Catalyst Platform — the unified Catalyst control plane umbrella chart for Catalyst-Zero.
   Composes the catalyst-{ui,api}, console, admin, marketplace UI modules and the marketplace-api backend.

--- a/products/catalyst/chart/templates/api-deployment.yaml
+++ b/products/catalyst/chart/templates/api-deployment.yaml
@@ -152,7 +152,7 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       containers:
         - name: catalyst-api
-          image: "ghcr.io/openova-io/openova/catalyst-api:11dd19e"
+          image: "ghcr.io/openova-io/openova/catalyst-api:b45a49f"
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080

--- a/products/catalyst/chart/templates/ui-deployment.yaml
+++ b/products/catalyst/chart/templates/ui-deployment.yaml
@@ -19,7 +19,7 @@ spec:
         - name: ghcr-pull
       containers:
         - name: catalyst-ui
-          image: "ghcr.io/openova-io/openova/catalyst-ui:11dd19e"
+          image: "ghcr.io/openova-io/openova/catalyst-ui:b45a49f"
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080


### PR DESCRIPTION
POST /api/v1/subdomains/check from useSubdomainAvailability was missing credentials:include — session cookie not sent → catalyst-api 401 → wizard surfaces as "Availability check failed". Caught live mid-otech119 wizard.