### PR TITLE
rollback: chart literal :8ec8c01 → :b45a49f (image not built yet)

### DIFF
--- a/products/catalyst/chart/templates/api-deployment.yaml
+++ b/products/catalyst/chart/templates/api-deployment.yaml
@@ -152,7 +152,7 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       containers:
         - name: catalyst-api
-          image: "ghcr.io/openova-io/openova/catalyst-api:8ec8c01"
+          image: "ghcr.io/openova-io/openova/catalyst-api:b45a49f"
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080

--- a/products/catalyst/chart/templates/ui-deployment.yaml
+++ b/products/catalyst/chart/templates/ui-deployment.yaml
@@ -19,7 +19,7 @@ spec:
         - name: ghcr-pull
       containers:
         - name: catalyst-ui
-          image: "ghcr.io/openova-io/openova/catalyst-ui:8ec8c01"
+          image: "ghcr.io/openova-io/openova/catalyst-ui:b45a49f"
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080


### PR DESCRIPTION
catalyst-api pod ImagePullBackOff because :8ec8c01 build in flight when chart bump landed. Rollback to :b45a49f restores the working pod.