### PR TITLE
deploy: re-bump chart literal :b45a49f → :8ec8c01 (revert rollback)

### DIFF
--- a/products/catalyst/chart/templates/api-deployment.yaml
+++ b/products/catalyst/chart/templates/api-deployment.yaml
@@ -152,7 +152,7 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       containers:
         - name: catalyst-api
-          image: "ghcr.io/openova-io/openova/catalyst-api:b45a49f"
+          image: "ghcr.io/openova-io/openova/catalyst-api:8ec8c01"
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080

--- a/products/catalyst/chart/templates/ui-deployment.yaml
+++ b/products/catalyst/chart/templates/ui-deployment.yaml
@@ -19,7 +19,7 @@ spec:
         - name: ghcr-pull
       containers:
         - name: catalyst-ui
-          image: "ghcr.io/openova-io/openova/catalyst-ui:b45a49f"
+          image: "ghcr.io/openova-io/openova/catalyst-ui:8ec8c01"
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080


### PR DESCRIPTION
PR #1006 rollback was unnecessary — :8ec8c01 image is in GHCR (verified via docker pull). Re-bump forward to land #1004 wizard credentials fix.