### PR TITLE
fix(marketplace,checkout): drop Google sign-in, port Sovereign-style PinInput6 (#1010)

### DIFF
--- a/core/marketplace/src/components/CheckoutStep.svelte
+++ b/core/marketplace/src/components/CheckoutStep.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
-  import { sendMagicLink, verifyMagicLink, getMe, getGoogleAuthUrl, googleCallback, createTenant, getMyOrgs, createCheckout, startProvisioning, getProvisionByTenant, checkSlug, getPlans, getAddons, getCreditBalance, setAuthTokens, setActiveOrg, type User, type Provision, type Plan, type AddOn } from '../lib/api';
+  import { sendMagicLink, verifyMagicLink, getMe, createTenant, getMyOrgs, createCheckout, startProvisioning, getProvisionByTenant, checkSlug, getPlans, getAddons, getCreditBalance, setAuthTokens, setActiveOrg, type User, type Provision, type Plan, type AddOn } from '../lib/api';
   import { readCart, clearCart } from '../lib/cart';
   import { formatOMR } from '../lib/currency';
   import { consoleHref } from '../lib/config';
+  import PinInput6 from './PinInput6.svelte';
 
   let cart = $state(readCart());
   let plans = $state<Plan[]>([]);
@@ -52,100 +53,17 @@
     payMethod = payMethod === m ? null : m;
   }
 
-  // ── 6-box PIN UX (issue #721) ─────────────────────────────────────────
-  // Each digit is a separate <input maxlength=1>. Auto-advance, paste-fan-
-  // out, backspace-back. Mirrors the React PinInput6 component on the
-  // catalyst-zero side so the operator gets the same experience whether
-  // they sign into the Sovereign console or the marketplace storefront.
-  let codeDigits = $state<string[]>(['', '', '', '', '', '']);
-  let codeRefs: (HTMLInputElement | null)[] = $state([null, null, null, null, null, null]);
-  // Mirror digits → existing `code` field so the rest of the form (verify
-  // submit) keeps working unchanged.
-  $effect(() => {
-    code = codeDigits.join('');
-  });
-  function focusBox(i: number) {
-    const el = codeRefs[i];
-    if (el) {
-      el.focus();
-      el.setSelectionRange(el.value.length, el.value.length);
-    }
-  }
-  function setDigitAt(i: number, v: string) {
-    if (codeDigits[i] === v) return;
-    const next = codeDigits.slice();
-    next[i] = v;
-    codeDigits = next;
-  }
-  function onDigitInput(i: number, ev: Event) {
-    const el = ev.target as HTMLInputElement;
-    const cleaned = (el.value.match(/\d/g) ?? []).join('');
-    if (cleaned.length === 0) {
-      setDigitAt(i, '');
-      return;
-    }
-    if (cleaned.length === 1) {
-      setDigitAt(i, cleaned);
-      el.value = cleaned;
-      if (i < 5) focusBox(i + 1);
-      return;
-    }
-    // Multiple digits typed/autofilled — fan out across remaining boxes.
-    const next = codeDigits.slice();
-    let idx = i;
-    for (const d of cleaned.split('')) {
-      if (idx >= 6) break;
-      next[idx] = d;
-      idx += 1;
-    }
-    codeDigits = next;
-    queueMicrotask(() => focusBox(Math.min(idx, 5)));
-  }
-  function onDigitKeyDown(i: number, ev: KeyboardEvent) {
-    const k = ev.key;
-    if (k === 'Backspace') {
-      if (codeDigits[i] === '' && i > 0) {
-        ev.preventDefault();
-        setDigitAt(i - 1, '');
-        focusBox(i - 1);
-      }
-      return;
-    }
-    if (k === 'ArrowLeft' && i > 0) {
-      ev.preventDefault();
-      focusBox(i - 1);
-      return;
-    }
-    if (k === 'ArrowRight' && i < 5) {
-      ev.preventDefault();
-      focusBox(i + 1);
-      return;
-    }
-    if (k === 'Enter') {
-      if (codeDigits.every((d) => d !== '')) {
-        handleVerify();
-      }
-      return;
-    }
-    if (k.length === 1 && (k < '0' || k > '9')) {
-      ev.preventDefault();
-    }
-  }
-  function onDigitPaste(ev: ClipboardEvent) {
-    ev.preventDefault();
-    const text = ev.clipboardData?.getData('text') ?? '';
-    const cleaned = (text.match(/\d/g) ?? []).join('').slice(0, 6);
-    if (!cleaned) return;
-    const next = ['', '', '', '', '', ''];
-    for (let i = 0; i < cleaned.length; i += 1) {
-      next[i] = cleaned.charAt(i);
-    }
-    codeDigits = next;
-    const last = Math.min(cleaned.length, 5);
-    queueMicrotask(() => focusBox(last));
-    if (cleaned.length === 6) {
-      queueMicrotask(() => handleVerify());
-    }
+  // ── PIN UX ────────────────────────────────────────────────────────────
+  // Single PinInput6 component (Svelte 5 port of the canonical React
+  // component on the Sovereign wizard side, products/catalyst/bootstrap/
+  // ui/src/components/PinInput6.tsx). One hidden <input maxlength=6>
+  // overlaid on 6 decorative boxes — auto-focused on mount + tab-back,
+  // so paste anywhere just works. #1010.
+  let pinResetCounter = $state(0);
+  function onPinChange(v: string) { code = v; }
+  function onPinComplete(v: string) {
+    code = v;
+    if (!authLoading) handleVerify();
   }
 
   // Email pill — copy-on-click for one-shot copy of the address the code
@@ -282,9 +200,16 @@
     try {
       const res = await verifyMagicLink(email, code);
       setAuthTokens(res.token, res.refresh_token);
+      // Clear the PIN from local state immediately on success — credential
+      // hygiene #10 (never linger longer than necessary).
+      code = '';
+      pinResetCounter += 1;
       user = res.user;
     } catch (e: any) {
       authError = e.message || 'Invalid code';
+      // Clear the boxes so the user can retype without backspace-chasing.
+      code = '';
+      pinResetCounter += 1;
     }
     authLoading = false;
   }
@@ -430,40 +355,9 @@
     }, 120000);
   }
 
-  async function handleGoogleAuth() {
-    try {
-      const callbackUrl = window.location.origin + '/auth/callback';
-      const data = await getGoogleAuthUrl(callbackUrl);
-      window.location.href = data.url;
-    } catch (e: any) {
-      authError = e.message || 'Failed to start Google login';
-    }
-  }
-
-  // Check for Google OAuth callback params on mount
-  $effect(() => {
-    const params = new URLSearchParams(window.location.search);
-    const code = params.get('code');
-    const googleAuth = params.get('google_auth');
-    if (code && googleAuth === '1') {
-      handleGoogleCallback(code);
-      window.history.replaceState({}, '', window.location.pathname);
-    }
-  });
-
-  async function handleGoogleCallback(code: string) {
-    authLoading = true;
-    authError = '';
-    try {
-      const callbackUrl = window.location.origin + '/auth/callback';
-      const res = await googleCallback(code, callbackUrl);
-      setAuthTokens(res.token, res.refresh_token);
-      user = res.user;
-    } catch (e: any) {
-      authError = e.message || 'Google login failed';
-    }
-    authLoading = false;
-  }
+  // #1010 — Google sign-in removed. Email + PIN only. The `/auth/callback`
+  // route is preserved as a passive redirect to /checkout in case any
+  // stale Google-issued redirect URI fires.
 </script>
 
 <div class="py-4">
@@ -550,27 +444,8 @@
       <div class="rounded-2xl border border-[var(--color-border)] bg-[var(--color-surface)] p-8">
         <h2 class="mb-6 text-center text-lg font-semibold text-[var(--color-text-strong)]">Sign in to continue</h2>
 
-        <!-- Google SSO -->
-        <button
-          onclick={handleGoogleAuth}
-          class="flex w-full items-center justify-center gap-3 rounded-xl border border-[var(--color-border)] bg-white px-4 py-3 text-sm font-medium text-gray-800 transition-colors hover:bg-gray-50"
-        >
-          <svg class="h-5 w-5" viewBox="0 0 24 24">
-            <path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 01-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z" fill="#4285F4"/>
-            <path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" fill="#34A853"/>
-            <path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" fill="#FBBC05"/>
-            <path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" fill="#EA4335"/>
-          </svg>
-          Continue with Google
-        </button>
-
-        <div class="my-6 flex items-center gap-3">
-          <div class="flex-1 border-t border-[var(--color-border)]"></div>
-          <span class="text-xs text-[var(--color-text-dimmer)]">or use email</span>
-          <div class="flex-1 border-t border-[var(--color-border)]"></div>
-        </div>
-
-        <!-- Magic Link -->
+        <!-- Email + 6-digit PIN — same flow as the Sovereign wizard sign-in
+             modal at console.openova.io/sovereign/wizard. (#1010) -->
         {#if authMode === 'login'}
           <form onsubmit={(e) => { e.preventDefault(); handleSendCode(); }}>
             <input
@@ -609,35 +484,14 @@
               </button>
             </div>
 
-            <div class="mb-5 flex items-center justify-center gap-2 sm:gap-2.5" role="group" aria-label="Sign-in code" data-testid="checkout-pin-row">
-              {#each codeDigits as digit, i}
-                <input
-                  type="text"
-                  inputmode="numeric"
-                  pattern="[0-9]*"
-                  autocomplete={i === 0 ? 'one-time-code' : 'off'}
-                  maxlength={1}
-                  bind:this={codeRefs[i]}
-                  value={digit}
-                  disabled={authLoading}
-                  oninput={(e) => onDigitInput(i, e)}
-                  onkeydown={(e) => onDigitKeyDown(i, e)}
-                  onpaste={onDigitPaste}
-                  data-testid={`checkout-pin-${i}`}
-                  aria-label={`Digit ${i + 1}`}
-                  class={[
-                    'w-12 h-14 sm:w-14 sm:h-16',
-                    'text-center text-2xl sm:text-3xl font-semibold tabular-nums tracking-tight',
-                    'rounded-xl border-[1.5px] bg-[var(--color-bg)] text-[var(--color-text)]',
-                    'shadow-[0_1px_0_rgba(255,255,255,0.04),_inset_0_-1px_0_rgba(255,255,255,0.02)]',
-                    digit !== '' ? 'border-[var(--color-accent)]/70' : 'border-[var(--color-border)]',
-                    'focus:border-[var(--color-accent)] focus:outline-none focus:ring-[3px] focus:ring-[var(--color-accent)]/30 focus:scale-[1.04]',
-                    'transition-[border-color,transform] duration-150 ease-out',
-                    'disabled:opacity-50 disabled:cursor-not-allowed',
-                    'caret-transparent',
-                  ].join(' ')}
-                />
-              {/each}
+            <div class="mb-5">
+              <PinInput6
+                resetKey={pinResetCounter}
+                disabled={authLoading}
+                onChange={onPinChange}
+                onComplete={onPinComplete}
+                testId="checkout-pin"
+              />
             </div>
 
             <button

--- a/core/marketplace/src/components/PinInput6.svelte
+++ b/core/marketplace/src/components/PinInput6.svelte
@@ -1,0 +1,154 @@
+<script lang="ts">
+  // PinInput6 — Stripe-style 6-digit PIN input, Svelte 5 port of the
+  // canonical React component at
+  // products/catalyst/bootstrap/ui/src/components/PinInput6.tsx (#1010).
+  //
+  // Architecture (founder rule "paste must just work" 2026-05-04):
+  //   - ONE real <input maxlength={6}> captures all keystrokes + paste.
+  //   - 6 visible boxes mirror the digits the input is holding. Boxes
+  //     are decorative; clicking any focuses the hidden input.
+  //   - Input is positioned over the box row with transparent text, so
+  //     paste / autofill / one-time-code suggestion all flow into a
+  //     single canonical element. No per-box paste fan-out, no race.
+  //
+  // Per docs/INVIOLABLE-PRINCIPLES.md #10: presentational only — parent
+  // owns the fetch and clears the value after submit.
+
+  interface Props {
+    disabled?: boolean;
+    autoFocus?: boolean;
+    value?: string;
+    testId?: string;
+    onChange?: (pin: string) => void;
+    onComplete?: (pin: string) => void;
+    /** Re-mount key from parent flips → reset internal state. */
+    resetKey?: number;
+  }
+
+  let {
+    disabled = false,
+    autoFocus = true,
+    value = '',
+    testId = 'pin-box',
+    onChange,
+    onComplete,
+    resetKey = 0,
+  }: Props = $props();
+
+  const N = 6;
+  let inputEl: HTMLInputElement | null = $state(null);
+
+  function extractDigits(s: string): string {
+    return (s.match(/\d/g) ?? []).join('');
+  }
+
+  let pin = $state<string>(extractDigits(value).slice(0, N));
+
+  // Reset when parent flips resetKey (mirrors React's `key` re-mount idiom).
+  let lastResetKey = resetKey;
+  $effect(() => {
+    if (resetKey !== lastResetKey) {
+      lastResetKey = resetKey;
+      pin = '';
+    }
+  });
+
+  // Notify parent on change + completion.
+  $effect(() => {
+    onChange?.(pin);
+    if (pin.length === N) onComplete?.(pin);
+  });
+
+  // Auto-focus on mount AND when the user tab-backs to the page (so they
+  // can paste IMMEDIATELY after returning from their email client without
+  // having to click). Founder rule 2026-05-04.
+  $effect(() => {
+    if (!autoFocus || disabled) return;
+    const el = inputEl;
+    if (!el) return;
+    el.focus();
+    const onVisible = () => {
+      if (document.visibilityState === 'visible' && !disabled && !el.disabled) {
+        el.focus();
+      }
+    };
+    const onWindowFocus = () => {
+      if (!disabled && !el.disabled) el.focus();
+    };
+    document.addEventListener('visibilitychange', onVisible);
+    window.addEventListener('focus', onWindowFocus);
+    return () => {
+      document.removeEventListener('visibilitychange', onVisible);
+      window.removeEventListener('focus', onWindowFocus);
+    };
+  });
+
+  function handleInput(e: Event) {
+    const el = e.target as HTMLInputElement;
+    pin = extractDigits(el.value).slice(0, N);
+  }
+
+  function focusInput() {
+    const el = inputEl;
+    if (!el) return;
+    el.focus();
+    const len = el.value.length;
+    el.setSelectionRange(len, len);
+  }
+</script>
+
+<div
+  role="group"
+  aria-label="Sign-in code"
+  class="relative flex items-center justify-center gap-2 sm:gap-2.5"
+  onclick={focusInput}
+  data-testid={testId}
+>
+  {#each Array.from({ length: N }) as _, i}
+    {@const digit = pin[i] ?? ''}
+    {@const filled = digit !== ''}
+    {@const isActive = !disabled && pin.length === i}
+    <div
+      data-testid={`${testId}-${i}`}
+      aria-label={`Digit ${i + 1}: ${digit || 'empty'}`}
+      class={[
+        'flex items-center justify-center select-none',
+        'w-12 h-14 sm:w-14 sm:h-16',
+        'text-center text-2xl sm:text-3xl font-semibold tabular-nums tracking-tight',
+        'rounded-xl border-[1.5px] bg-[var(--color-bg)] text-[var(--color-text)]',
+        'shadow-[0_1px_0_rgba(255,255,255,0.04),_inset_0_-1px_0_rgba(255,255,255,0.02)]',
+        filled
+          ? 'border-[var(--color-accent)]/70'
+          : isActive
+            ? 'border-[var(--color-accent)] ring-[3px] ring-[var(--color-accent)]/30'
+            : 'border-[var(--color-border)]',
+        'transition-[border-color,box-shadow,transform] duration-150 ease-out',
+        disabled ? 'opacity-50' : '',
+      ].join(' ')}
+    >
+      {digit}
+    </div>
+  {/each}
+
+  <!--
+    Single real input. Captures every keystroke + paste. Visually hidden
+    via opacity:0 + transparent caret. Positioned absolute over the row
+    so clicks on boxes hit it via pointer-events. autoComplete="one-time-code"
+    targets iOS SMS autofill into the focused input.
+  -->
+  <input
+    bind:this={inputEl}
+    type="text"
+    inputmode="numeric"
+    pattern="[0-9]*"
+    autocomplete="one-time-code"
+    maxlength={N}
+    value={pin}
+    {disabled}
+    oninput={handleInput}
+    aria-label="Sign-in code (6 digits)"
+    data-testid={`${testId}-input`}
+    class="absolute inset-0 w-full h-full opacity-0 cursor-text"
+    style="caret-color: transparent; color: transparent; background: transparent; border: 0; outline: 0; padding: 0; font-size: inherit; letter-spacing: inherit;"
+  />
+</div>

--- a/core/marketplace/src/pages/auth/callback.astro
+++ b/core/marketplace/src/pages/auth/callback.astro
@@ -1,23 +1,18 @@
 ---
 import Layout from '../../layouts/Layout.astro';
 ---
-<Layout title="Signing in..." step={5}>
+<Layout title="Redirecting…" step={5}>
   <div class="flex justify-center items-center py-20">
     <div class="text-center">
       <div class="mx-auto mb-4 h-8 w-8 animate-spin rounded-full border-2 border-[var(--color-accent)] border-t-transparent"></div>
-      <p class="text-[var(--color-text-dim)]">Completing sign-in...</p>
+      <p class="text-[var(--color-text-dim)]">Redirecting…</p>
     </div>
   </div>
   <script>
-    // Extract the authorization code from Google's redirect
-    const params = new URLSearchParams(window.location.search);
-    const code = params.get('code');
-    if (code) {
-      // Redirect to checkout with the code
-      window.location.href = `/checkout?code=${encodeURIComponent(code)}&google_auth=1`;
-    } else {
-      // No code — redirect to checkout page
-      window.location.href = '/checkout';
-    }
+    // #1010 — Google sign-in removed from the marketplace login surface.
+    // This route is preserved as a passive redirect to /checkout in case
+    // any stale Google-issued redirect URI fires (so old links from the
+    // brief Google-enabled window don't 404).
+    window.location.replace('/checkout');
   </script>
 </Layout>


### PR DESCRIPTION
## Summary
- Marketplace `/checkout` login surface now matches the Sovereign wizard sign-in (console.openova.io/sovereign/wizard): email + 6-digit PIN only. Google removed.
- New `PinInput6.svelte` is a Svelte 5 port of the canonical React `PinInput6.tsx` — one hidden `<input maxlength=6>` overlaid on 6 decorative boxes, auto-focused on mount + tab-back. Paste-anywhere fills all 6, auto-submits on the 6th digit. The previous "click inside before paste" bug is gone.
- Inline ~80 LOC of per-box PIN helpers replaced by a single `<PinInput6 />` invocation. Net `-191 +194` LOC across 3 files (3 of those LOC are the new component file header).
- `auth/callback.astro` simplified to a passive redirect to `/checkout` — keeps the route alive so any stale Google-issued redirect URI doesn't 404.

API unchanged: `/api/auth/magic-link` + `/api/auth/verify` already work as a PIN flow.

Closes #1010.

## Test plan
- [ ] CI build green
- [ ] After merge + image roll, navigate to https://marketplace.openova.io/checkout
  - [ ] Only email field + "Send sign-in code" button visible — no Google button, no "or use email" divider
  - [ ] After requesting code, PIN row appears with focus already on the input — paste 6 digits without clicking, auto-submits
  - [ ] Wrong PIN clears boxes (no backspace-chasing)
  - [ ] Mobile / iOS SMS autofill still routes one-time-code into the boxes
- [ ] Visual parity check vs https://console.openova.io/sovereign/wizard sign-in modal

🤖 Generated with [Claude Code](https://claude.com/claude-code)