### PR TITLE
fix(tenant): JWT-bypass /tenant/internal/* — paid checkouts never provisioned (#1018)

### DIFF
--- a/core/services/tenant/main.go
+++ b/core/services/tenant/main.go
@@ -121,7 +121,17 @@ func main() {
 
 	mux.Handle("/tenant/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Slug check is public — no JWT required.
-		if strings.HasPrefix(r.URL.Path, "/tenant/check-slug/") {
+		// /tenant/internal/* is service-to-service (#105 / #1018): the
+		// route was registered with that intent in routes.go but the
+		// JWT bypass here was never wired, so billing's
+		// dispatchOrderPlaced lookupTenantSubdomain got a 401 and
+		// shipped an empty subdomain into order.placed, which
+		// provisioning then rejected as "invalid subdomain". Both
+		// gateways already 401 /tenant/internal/* externally, so the
+		// bypass only opens the path to in-cluster callers (the
+		// documented threat model — subdomain values are public DNS).
+		if strings.HasPrefix(r.URL.Path, "/tenant/check-slug/") ||
+			strings.HasPrefix(r.URL.Path, "/tenant/internal/") {
 			tenantRoutes.ServeHTTP(w, r)
 			return
 		}


### PR DESCRIPTION
## Summary
- Tenant service was wrapping `/tenant/internal/*` in JWTAuth despite the route being declared "service-to-service unauthenticated" in `routes.go` (#105). Billing's `dispatchOrderPlaced` got 401 → empty subdomain → provisioning rejected `order.placed` with `invalid subdomain` → no paid checkout has provisioned a tenant.
- One-line fix: extend the public-paths bypass in `tenant/main.go` to include `/tenant/internal/` alongside `/tenant/check-slug/`.

External attack surface: both gateways (`marketplace`, `console`) already 401 `/tenant/internal/*` at the front door — billing reaches tenant on the in-cluster ClusterIP, not via the gateway. The bypass exposes only the subdomain (a public DNS name) to in-cluster callers — documented threat model.

Closes #1018.

## Test plan
- [ ] CI green
- [ ] After merge + image roll: probe `http://tenant.sme.svc.cluster.local:8083/tenant/internal/tenants/<known-id>/subdomain` from inside the cluster — expect 200
- [ ] Trigger a fresh paid checkout on https://marketplace.openova.io and watch `kubectl logs -n sme deploy/provisioning` for `committed manifests to GitHub` instead of `invalid subdomain`
- [ ] /jobs page in Console shows the new provisioning job

🤖 Generated with [Claude Code](https://claude.com/claude-code)