### PR TITLE
fix(cutover-step-06): surface git push stderr (was swallowed) + chart 0.1.21

### DIFF
--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-self-sovereign-cutover
-version: 0.1.20
+version: 0.1.21
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),


### PR DESCRIPTION
cutover-helmrepository-patches kept FATAL-ing without showing the real git push error. Surface stderr.