### PR TITLE
fix(deployments-list): row click goes to that row's dashboard, not the current one

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -231,7 +231,7 @@ spec:
       # fallback (data renders the moment cutover-import lands without
       # waiting for the orchestrator's chart-values overlay write).
       # 2026-05-05.
-      version: 1.4.40
+      version: 1.4.41
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/DeploymentsList.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/DeploymentsList.tsx
@@ -22,6 +22,7 @@ import { Link } from '@tanstack/react-router'
 import { useSession } from '@/shared/lib/useSession'
 import { useInflightDeployment, INFLIGHT_STATUSES } from '@/shared/lib/useInflightDeployment'
 import type { DeploymentListEntry } from '@/shared/lib/useInflightDeployment'
+import { DETECTED_MODE } from '@/shared/lib/detectMode'
 
 function formatDate(iso?: string): string {
   if (!iso) return '—'
@@ -131,7 +132,11 @@ export function DeploymentsList() {
                 >
                   <td style={{ padding: '10px 12px', borderBottom: '1px solid var(--wiz-border)' }}>
                     <Link
-                      to={`/dashboard` as never}
+                      to={
+                        (DETECTED_MODE.mode === 'sovereign'
+                          ? `/dashboard`
+                          : `/provision/${d.id}/dashboard`) as never
+                      }
                       style={{ color: 'var(--wiz-text-hi)', textDecoration: 'none', fontWeight: 600 }}
                     >
                       {d.sovereignFQDN || d.id}

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -124,8 +124,8 @@ name: bp-catalyst-platform
 # otech113 2026-05-05 — chart 0.1.18 fixed the readiness-probe loop
 # but every trigger immediately got 502 in <10ms (synchronous
 # apiserver permission rejection). 2026-05-05.
-version: 1.4.40
-appVersion: 1.4.40
+version: 1.4.41
+appVersion: 1.4.41
 description: |
   Catalyst Platform — the unified Catalyst control plane umbrella chart for Catalyst-Zero.
   Composes the catalyst-{ui,api}, console, admin, marketplace UI modules and the marketplace-api backend.


### PR DESCRIPTION
## Bug

User reported (2026-05-05): clicking ANY row on \`console.openova.io/sovereign/deployments\` navigates to \`console.openova.io/sovereign/dashboard\` regardless of which row was clicked.

## Root cause

\`DeploymentsList.tsx:134\` rendered every FQDN as \`<Link to=\`/dashboard\`>\` — a path that resolves to the operator's *current* Sovereign dashboard via SovereignConsoleRedirect / clean-root chroot, NOT the dashboard of the deployment in that row.

## Fix

Route each row to \`/provision/<row-id>/dashboard\` on the mother view (Catalyst-Zero), and to \`/dashboard\` on the chroot Sovereign view (where the only deployment is the current Sovereign, so \`/dashboard\` is already the right target).

Mode resolved via the existing \`DETECTED_MODE\` singleton.

Bumps bp-catalyst-platform chart 1.4.40 → 1.4.41.

## Test plan

- [x] Built locally (vite + tsc) — diff is one-line plus a static import.
- [ ] Post-merge: navigate to \`console.openova.io/sovereign/deployments\` on contabo, click each row, confirm URL changes to \`/sovereign/provision/<id>/dashboard\` (NOT \`/sovereign/dashboard\`).