### PR TITLE
chore(contabo): bump catalyst-{ui,api}:074d65c → :4e2192e (PR #1026 DeploymentsList fix)

### DIFF
--- a/products/catalyst/chart/templates/api-deployment.yaml
+++ b/products/catalyst/chart/templates/api-deployment.yaml
@@ -152,7 +152,7 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       containers:
         - name: catalyst-api
-          image: "ghcr.io/openova-io/openova/catalyst-api:074d65c"
+          image: "ghcr.io/openova-io/openova/catalyst-api:4e2192e"
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080

--- a/products/catalyst/chart/templates/ui-deployment.yaml
+++ b/products/catalyst/chart/templates/ui-deployment.yaml
@@ -19,7 +19,7 @@ spec:
         - name: ghcr-pull
       containers:
         - name: catalyst-ui
-          image: "ghcr.io/openova-io/openova/catalyst-ui:074d65c"
+          image: "ghcr.io/openova-io/openova/catalyst-ui:4e2192e"
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080


### PR DESCRIPTION
## Why

PR #1026 fixed \`/sovereign/deployments\` row click navigating to \`/sovereign/dashboard\` instead of \`/sovereign/provision/<id>/dashboard\`. That fix shipped to \`values.yaml\` automatically (image \`:4e2192e\` published) but contabo's catalyst-api/-ui run from the Kustomize-path manifests at \`products/catalyst/chart/templates/{api,ui}-deployment.yaml\` whose literal image refs are NOT auto-bumped (per docs/RUNBOOK-CONTABO-IMAGE-BUMP.md — auto-bumping caused a contabo crashloop on 2026-05-05).

This is the manual bump to make contabo pick up :4e2192e so users hitting \`console.openova.io/sovereign/deployments\` see the row-click fix live.

## Scope

- \`api-deployment.yaml\`: \`:074d65c\` → \`:4e2192e\`
- \`ui-deployment.yaml\`: \`:074d65c\` → \`:4e2192e\`

No chart-version bump (contabo doesn't use the chart). No values.yaml change (already at :4e2192e from the deploy job that ran for #1026).