### PR TITLE
fix(provisioning): BookStack — DB_* envs, APP_KEY, APP_URL (502 → working)

### DIFF
--- a/core/services/provisioning/gitops/apps.go
+++ b/core/services/provisioning/gitops/apps.go
@@ -101,7 +101,14 @@ var KnownApps = map[string]AppSpec{
 		Image: "lscr.io/linuxserver/bookstack:latest", Port: 80,
 		NeedsDB: "mysql",
 		RAMMI: "256Mi", CPUMilli: "100m",
-		EnvVars: map[string]string{},
+		// linuxserver/bookstack reads DB_HOST/DB_USER/DB_PASS/DB_DATABASE
+		// (NOT WORDPRESS_DB_*) and refuses to start without APP_KEY. Without
+		// the bookstack DBEnvStyle the manifest emitted only WordPress-shape
+		// vars and the container halted in init with "The application key is
+		// missing, halting init!" — pod stayed 1/1 Running with no
+		// application listening, ingress returned 502.
+		DBEnvStyle: "bookstack",
+		EnvVars:    map[string]string{},
 	},
 	"nocodb": {
 		Image: "nocodb/nocodb:latest", Port: 8080,

--- a/core/services/provisioning/gitops/gitops.go
+++ b/core/services/provisioning/gitops/gitops.go
@@ -2,6 +2,7 @@ package gitops
 
 import (
 	"crypto/rand"
+	"encoding/base64"
 	"encoding/hex"
 	"fmt"
 	"strings"
@@ -667,6 +668,25 @@ func generateAppDeployment(ns, slug, appSlug string, spec AppSpec, dbPassword st
 		}
 	case "mysql":
 		switch spec.DBEnvStyle {
+		case "bookstack":
+			// linuxserver/bookstack reads DB_HOST/DB_USER/DB_PASS/DB_DATABASE
+			// (not WORDPRESS_DB_*) and refuses to start without APP_KEY +
+			// APP_URL. APP_KEY must be a Laravel-style base64:<32-byte> string.
+			envLines += fmt.Sprintf(`            - name: DB_HOST
+              value: "mysql"
+            - name: DB_PORT
+              value: "3306"
+            - name: DB_USER
+              value: "app"
+            - name: DB_PASS
+              value: "%s"
+            - name: DB_DATABASE
+              value: "%s"
+            - name: APP_URL
+              value: "https://%s.omani.rest"
+            - name: APP_KEY
+              value: "%s"
+`, dbPassword, appDB, slug, randomAppKey())
 		case "ghost":
 			envLines += fmt.Sprintf(`            - name: database__client
               value: "mysql"
@@ -998,6 +1018,16 @@ func randomHex(n int) string {
 	b := make([]byte, n)
 	rand.Read(b)
 	return hex.EncodeToString(b)
+}
+
+// randomAppKey generates a Laravel-style APP_KEY of the form
+// "base64:<32-byte-base64>". BookStack (lscr.io/linuxserver/bookstack) and
+// other Laravel apps refuse to start when APP_KEY is missing — the linuxserver
+// container halts in init with "The application key is missing, halting init!".
+func randomAppKey() string {
+	b := make([]byte, 32)
+	rand.Read(b)
+	return "base64:" + base64.StdEncoding.EncodeToString(b)
 }
 
 // ExtractDBPassword scans a tenant DB manifest (db-postgres.yaml or


### PR DESCRIPTION
## Summary
BookStack tenants couldn't load (\`502\` from ingress) despite all provisioning steps reporting done. \`linuxserver/bookstack\` reads \`DB_*\` envs (not \`WORDPRESS_DB_*\`) and halts in init when \`APP_KEY\` is missing — the pod stayed \`1/1 Running\` because readiness was satisfied before the halt, so nothing pages this except the user hitting the URL.

Add a \`bookstack\` \`DBEnvStyle\` case that emits \`DB_HOST/DB_PORT/DB_USER/DB_PASS/DB_DATABASE\`, plus \`APP_URL=https://<slug>.omani.rest\` and a Laravel-format \`APP_KEY\` (\`base64:<32-byte>\`). New \`randomAppKey()\` helper sits alongside \`randomHex()\`.

## Discovered live (2026-05-06 E2E)
- Tenant \`aaa\`, plan M, BookStack picked.
- Provisioning: all 7 steps progress=100, vcluster ready, mysql + bookstack pods Running.
- Ingress reachable, TLS issued.
- \`curl https://aaa.omani.rest\` → \`502\`.
- Pod logs: \`The application key is missing, halting init!\`
- Manifest had \`WORDPRESS_DB_*\` + \`MYSQL_*\` only, no \`DB_*\`, no \`APP_KEY\`.

Closes the gap. Other Laravel-image apps that wire a similar overlay can reuse the same pattern.

## Test plan
- [ ] Unit tests pass (\`go test ./core/services/provisioning/...\`)
- [ ] After merge + image roll: provision a new BookStack tenant, confirm pod logs show "Server starting" instead of "halting init", and \`https://<slug>.omani.rest\` returns \`200\` with the BookStack login page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)