### PR TITLE
fix(cutover step-06): convert pull-mirror to standalone before pushing patches

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -204,7 +204,7 @@ spec:
       #   commits, and pushes. Subsequent reconciles see local Harbor
       #   as steady-state. Image bumped to alpine/k8s:1.31.4 (kubectl
       #   + git in one image; verified live on otech116).
-      version: 0.1.20
+      version: 0.1.22
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-self-sovereign-cutover
-version: 0.1.21
+version: 0.1.22
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/templates/06-helmrepository-patches-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/06-helmrepository-patches-job.yaml
@@ -146,6 +146,33 @@ data:
             push_url=$(printf '%s' "${GITEA_INTERNAL_URL}" | sed -E "s,^(https?://),\1${GITEA_USERNAME}:${GITEA_PASSWORD}@,")"/${GITEA_ORG}/${GITEA_REPO}.git"
             redacted=$(printf '%s' "${GITEA_INTERNAL_URL}/${GITEA_ORG}/${GITEA_REPO}.git")
 
+            # ---- Phase 1.5: convert pull-mirror to standalone (#1028) ----
+            #
+            # Step-01 created openova/openova as a Gitea pull-mirror so the
+            # Sovereign's local Gitea tracks upstream during early
+            # bootstrap. After cutover the Sovereign is self-hosted and
+            # MUST diverge from upstream — but Gitea blocks pushes to a
+            # mirror with HTTP 403 "remote: mirror repository is read-only".
+            # PATCH the repo to flip mirror=false BEFORE git push so
+            # subsequent push commands write to the now-standalone repo.
+            #
+            # Without this conversion, Step-06's git push (added in #970)
+            # always failed on 403, blocking handover. Caught on otech125
+            # 2026-05-05.
+            api="${GITEA_INTERNAL_URL%/}/api/v1/repos/${GITEA_ORG}/${GITEA_REPO}"
+            demirror_code=$(curl -sS -o /tmp/.demirror.json -w '%{http_code}' \
+              -u "${GITEA_USERNAME}:${GITEA_PASSWORD}" \
+              -X PATCH \
+              -H 'Content-Type: application/json' \
+              -d '{"mirror": false, "mirror_interval": "0"}' \
+              "${api}")
+            if [ "${demirror_code}" != "200" ]; then
+              echo "[helmrepository-patches] FATAL: demirror PATCH returned HTTP ${demirror_code}" >&2
+              cat /tmp/.demirror.json >&2 || true
+              exit 1
+            fi
+            echo "[helmrepository-patches] demirror PATCH OK — repo is now standalone"
+
             echo "[helmrepository-patches] cloning ${redacted}"
             cd /tmp
             rm -rf repo


### PR DESCRIPTION
## Bug

Cutover step-06 (\`cutover-helmrepository-patches\`) FAILED on otech125 2026-05-05 with:

\`\`\`
[helmrepository-patches] FATAL: git push failed
\`\`\`

## Root cause (reproduced)

Step-01 (\`cutover-gitea-mirror\`) creates \`openova/openova\` on the Sovereign's local Gitea as a *pull mirror* of upstream openova-public — that's the design so the Sovereign tracks upstream during bootstrap. Step-06 then tries to push HelmRepository URL patches to that same repo, and Gitea returns:

\`\`\`
remote: mirror repository is read-only
fatal: unable to access ... HTTP 403
\`\`\`

Confirmed by cloning + attempting a manual push from a probe Pod:

\`\`\`
$ git push origin main
remote: mirror repository is read-only
fatal: unable to access 'http://gitea-http.gitea.svc.cluster.local:3000/openova/openova.git/': The requested URL returned error: 403
push exit 128
\`\`\`

This blocks Sovereign handover for every freshly provisioned cluster.

## Fix

Add Phase-1.5 to step-06: PATCH \`/api/v1/repos/{owner}/{repo}\` with \`{"mirror": false, "mirror_interval": "0"}\` BEFORE cloning+pushing. Converts the pull-mirror to a standalone writable repo — exactly the post-cutover architecture (the Sovereign is self-hosted; upstream tracking ends at handover).

## Bumps

- \`bp-self-sovereign-cutover\` chart 0.1.21 → 0.1.22
- bootstrap-kit pin 0.1.20 → 0.1.22

## Test plan

- [ ] Wipe otech125 + provision otech126; confirm step-06 logs \`[helmrepository-patches] demirror PATCH OK\` then \`pushed to ...\`.
- [ ] Confirm cutover-state ConfigMap reaches \`status: complete\`.
- [ ] Confirm phase1-watcher transitions Sovereign to \`status: ready\` and handover JWT redirects to console.otech126.omani.works.