### PR TITLE
chore(contabo): bump catalyst-{ui,api}:4e2192e → :ff864e9 (#1029 cutover demirror fix)

### DIFF
--- a/products/catalyst/chart/templates/api-deployment.yaml
+++ b/products/catalyst/chart/templates/api-deployment.yaml
@@ -152,7 +152,7 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       containers:
         - name: catalyst-api
-          image: "ghcr.io/openova-io/openova/catalyst-api:4e2192e"
+          image: "ghcr.io/openova-io/openova/catalyst-api:ff864e9"
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080

--- a/products/catalyst/chart/templates/ui-deployment.yaml
+++ b/products/catalyst/chart/templates/ui-deployment.yaml
@@ -19,7 +19,7 @@ spec:
         - name: ghcr-pull
       containers:
         - name: catalyst-ui
-          image: "ghcr.io/openova-io/openova/catalyst-ui:4e2192e"
+          image: "ghcr.io/openova-io/openova/catalyst-ui:ff864e9"
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080


### PR DESCRIPTION
Bumps contabo's Kustomize-path catalyst-api/-ui to image :ff864e9, which builds from main with PR #1029's cutover step-06 demirror fix included. Per docs/RUNBOOK-CONTABO-IMAGE-BUMP.md the contabo image is bumped manually.