### PR TITLE
fix(provisioning): BookStack — also emit DB_USERNAME/DB_PASSWORD (Laravel-native)

### DIFF
--- a/core/services/provisioning/gitops/gitops.go
+++ b/core/services/provisioning/gitops/gitops.go
@@ -669,16 +669,30 @@ func generateAppDeployment(ns, slug, appSlug string, spec AppSpec, dbPassword st
 	case "mysql":
 		switch spec.DBEnvStyle {
 		case "bookstack":
-			// linuxserver/bookstack reads DB_HOST/DB_USER/DB_PASS/DB_DATABASE
-			// (not WORDPRESS_DB_*) and refuses to start without APP_KEY +
-			// APP_URL. APP_KEY must be a Laravel-style base64:<32-byte> string.
+			// linuxserver/bookstack docs advertise DB_USER/DB_PASS, but the
+			// container's init script (init-bookstack-config) only copies
+			// .env.example into place — it does NOT substitute DB_USER ->
+			// DB_USERNAME or DB_PASS -> DB_PASSWORD. Laravel reads env vars
+			// natively, but using the Laravel-native names DB_USERNAME and
+			// DB_PASSWORD. Without those, Laravel falls back to the .env
+			// placeholder values (database_username / database_user_password)
+			// and the app fails with SQLSTATE[HY000] [1045] Access denied for
+			// user 'database_username'@... — caught live on tenant
+			// 'bookcheck' on 2026-05-06. We emit BOTH name pairs so the env
+			// works regardless of which the LSIO upstream eventually wires.
+			// APP_KEY must be a Laravel-style base64:<32-byte> string;
+			// without it, init halts with "The application key is missing".
 			envLines += fmt.Sprintf(`            - name: DB_HOST
               value: "mysql"
             - name: DB_PORT
               value: "3306"
             - name: DB_USER
               value: "app"
+            - name: DB_USERNAME
+              value: "app"
             - name: DB_PASS
+              value: "%s"
+            - name: DB_PASSWORD
               value: "%s"
             - name: DB_DATABASE
               value: "%s"
@@ -686,7 +700,7 @@ func generateAppDeployment(ns, slug, appSlug string, spec AppSpec, dbPassword st
               value: "https://%s.omani.rest"
             - name: APP_KEY
               value: "%s"
-`, dbPassword, appDB, slug, randomAppKey())
+`, dbPassword, dbPassword, appDB, slug, randomAppKey())
 		case "ghost":
 			envLines += fmt.Sprintf(`            - name: database__client
               value: "mysql"


### PR DESCRIPTION
## Summary
Follow-up to #1028. PR #1028 added \`DB_USER\`/\`DB_PASS\` per linuxserver/bookstack docs, but the LSIO init script doesn't substitute those into Laravel's expected \`DB_USERNAME\`/\`DB_PASSWORD\`. Live tenant \`bookcheck\` (2026-05-06) showed the bug:

\`\`\`
SQLSTATE[HY000] [1045] Access denied for user 'database_username'@10.42.0.177
\`\`\`

Laravel was falling back to the .env placeholder values. Emit BOTH name pairs.

Verified by inspecting the container's .env after pod start (still showed \`DB_USERNAME=database_username\`, the .env.example default) and the LSIO init script (\`/etc/s6-overlay/s6-rc.d/init-bookstack-config/run\`) which copies \`.env.example\` and then runs \`php artisan migrate\` — no env-var substitution.

## Test plan
- [ ] After merge + image roll: kill the failing bookcheck namespace, re-provision, confirm \`https://bookcheck.omani.rest\` returns the BookStack login page (not the Laravel error trace).

🤖 Generated with [Claude Code](https://claude.com/claude-code)