### PR TITLE
fix(portalshell): skip inner Sidebar on Sovereign mode (duplicate with broken /provision//X URLs)

### DIFF
--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/PortalShell.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/PortalShell.tsx
@@ -47,6 +47,7 @@ import { Sidebar } from './Sidebar'
 import { ThemeToggle } from '@/components/ThemeToggle'
 import { NotificationBell } from '@/shared/ui/notifications'
 import { ProfileMenu } from '@/widgets/auth/ProfileMenu'
+import { DETECTED_MODE } from '@/shared/lib/detectMode'
 
 interface PortalShellProps {
   /** Stable deploymentId from the URL parameter. */
@@ -73,13 +74,27 @@ export function PortalShell({
   headerSlotRight,
   children,
 }: PortalShellProps) {
+  // On Sovereign mode (chroot Sovereign Console at console.<sov-fqdn>),
+  // SovereignConsoleLayout already mounts SovereignSidebar with the
+  // chroot-correct clean-root URLs (/jobs, /apps, etc.). PortalShell is
+  // shared with the wizard's mother-mode pages (/provision/$id/X) which
+  // use the deploymentId-templated Sidebar below. Rendering both at once
+  // produces TWO overlapping sidebars whose links resolve differently —
+  // the inner Sidebar renders /provision//jobs (empty $deploymentId)
+  // because the chroot route doesn't carry that param. Skip the inner
+  // Sidebar in Sovereign mode; the outer SovereignSidebar covers it.
+  // Caught on otech127 2026-05-05.
+  const renderSidebar = DETECTED_MODE.mode !== 'sovereign'
+  const mainOffset = renderSidebar ? 'ml-56' : ''
   return (
     <div
       className="flex min-h-screen bg-[var(--color-bg)] text-[var(--color-text)]"
       data-testid="sov-portal-shell"
     >
-      <Sidebar deploymentId={deploymentId} sovereignFQDN={sovereignFQDN} />
-      <div className="ml-56 flex flex-1 flex-col">
+      {renderSidebar ? (
+        <Sidebar deploymentId={deploymentId} sovereignFQDN={sovereignFQDN} />
+      ) : null}
+      <div className={`${mainOffset} flex flex-1 flex-col`}>
         {/* Sovereign portal top header band — title-left, controls-right. */}
         <header
           data-testid="portal-header"

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -124,8 +124,8 @@ name: bp-catalyst-platform
 # otech113 2026-05-05 — chart 0.1.18 fixed the readiness-probe loop
 # but every trigger immediately got 502 in <10ms (synchronous
 # apiserver permission rejection). 2026-05-05.
-version: 1.4.42
-appVersion: 1.4.42
+version: 1.4.43
+appVersion: 1.4.43
 description: |
   Catalyst Platform — the unified Catalyst control plane umbrella chart for Catalyst-Zero.
   Composes the catalyst-{ui,api}, console, admin, marketplace UI modules and the marketplace-api backend.


### PR DESCRIPTION
## Symptom

On otech127 2026-05-05 the Sovereign Console at \`console.<sov-fqdn>/dashboard\` rendered TWO sidebars stacked. The inner one had broken URLs \`/provision//jobs\`, \`/provision//apps\`, etc. (empty \`\$deploymentId\` after the slash) and intercepted pointer events, breaking sidebar navigation.

## Root cause

\`SovereignConsoleLayout\` (the chroot-route layout) mounts \`SovereignSidebar\` with clean-root URLs (\`/jobs\`, \`/apps\`, …). The page component (\`JobsPage\` etc.) wraps its content in \`PortalShell\`, which ALSO mounts the older \`Sidebar\` component with deploymentId-templated URLs (\`/provision/\$deploymentId/jobs\`). On the chroot route there's no \`deploymentId\` path param, so tan-stack renders \`/provision//jobs\`.

Both sidebars render side-by-side; the inner one captures clicks.

## Fix

\`PortalShell\` skips the inner \`<Sidebar>\` when \`DETECTED_MODE.mode === 'sovereign'\`. The outer \`SovereignSidebar\` (mounted by \`SovereignConsoleLayout\`) is the correct chroot sidebar in that mode. On mother-mode (\`/provision/\$id/X\`) the inner Sidebar renders normally.

Bumps bp-catalyst-platform 1.4.42 → 1.4.43.

## Test plan

- [ ] Provision otech128, drive handover, click Apps / Jobs / Cloud / Users / Catalog / Settings on the chroot Sovereign Console — confirm only ONE sidebar renders, all clicks land at the clean-root URL.
- [ ] On contabo (mother), navigate to \`/sovereign/provision/<id>/jobs\` — confirm the inner Sidebar still renders with \`/provision/<id>/X\` links.