### PR TITLE
fix(provisioning): re-read parent kustomization on retry — prevent slug-resurrection race

### DIFF
--- a/core/services/provisioning/github/client.go
+++ b/core/services/provisioning/github/client.go
@@ -66,14 +66,58 @@ func (c *Client) CommitFiles(ctx context.Context, branch, message string, files 
 // prunePrefixes must not be empty strings; each must end with "/" (e.g.,
 // "clusters/contabo-mkt/tenants/haty/apps/"). Paths outside the prefixes are
 // preserved via base_tree as before.
+//
+// On ref-race retry, the SAME files map is committed against the new HEAD —
+// safe when the file content is independent of HEAD (e.g. tenant manifests
+// scoped to a fresh tenant subdirectory). NOT safe when the content is a
+// read-modify-write of an existing file (e.g. parent kustomization.yaml that
+// needs to merge in a slug). For that case use CommitFilesWithPruneAndRebuild.
 func (c *Client) CommitFilesWithPrune(ctx context.Context, branch, message string, files map[string]string, prunePrefixes []string) error {
-	if len(files) == 0 && len(prunePrefixes) == 0 {
+	return c.CommitFilesWithPruneAndRebuild(ctx, branch, message, files, prunePrefixes, nil)
+}
+
+// CommitFilesWithPruneAndRebuild is like CommitFilesWithPrune but lets the
+// caller participate in the ref-race retry. If non-nil, `rebuild` is called
+// at the START of each attempt (including the first) to (re)compute the file
+// map. This gives the caller a chance to read the latest HEAD content of any
+// merge-target file (e.g. parent kustomization.yaml) and re-apply the merge
+// against the post-race state, preventing stale read-modify-write resurrection.
+//
+// Issue #1031 — observed live 2026-05-06: tenant teardown of "bookcheck"
+// committed at T, then a multitest provision committed at T+5s. Multitest's
+// first commit attempt got the ref-race rejection because teardown landed
+// first; the retry re-used the SAME files map (containing a stale parent
+// kustomization that still listed "bookcheck"), wedging Flux's `tenants`
+// Kustomization in a build-failure loop because the bookcheck/ directory
+// was already gone but the slug was back in resources:.
+func (c *Client) CommitFilesWithPruneAndRebuild(
+	ctx context.Context,
+	branch, message string,
+	files map[string]string,
+	prunePrefixes []string,
+	rebuild func(ctx context.Context) (map[string]string, error),
+) error {
+	if rebuild == nil && len(files) == 0 && len(prunePrefixes) == 0 {
 		return fmt.Errorf("no files to commit")
 	}
 
 	var lastErr error
 	for attempt := 1; attempt <= commitAttemptsMax; attempt++ {
-		err := c.commitOnce(ctx, branch, message, files, prunePrefixes)
+		// Each attempt starts from a fresh files map when the caller has
+		// supplied a rebuilder. Without one, the static files map flows
+		// through unchanged — preserving the old behaviour.
+		attemptFiles := files
+		if rebuild != nil {
+			fresh, rebuildErr := rebuild(ctx)
+			if rebuildErr != nil {
+				return fmt.Errorf("rebuild files for commit: %w", rebuildErr)
+			}
+			attemptFiles = fresh
+			if len(attemptFiles) == 0 && len(prunePrefixes) == 0 {
+				return fmt.Errorf("rebuild returned no files to commit")
+			}
+		}
+		err := c.commitOnce(ctx, branch, message, attemptFiles, prunePrefixes)
 		if err == nil {
 			return nil
 		}

--- a/core/services/provisioning/handlers/consumer.go
+++ b/core/services/provisioning/handlers/consumer.go
@@ -568,14 +568,23 @@ func (h *Handler) handleTenantDeleted(ctx context.Context, event *events.Event) 
 		branch = "main"
 	}
 
-	currentParent, readErr := h.GitHubClient.ReadFile(ctx, branch, parentPath)
-	files := map[string]string{}
-	if readErr == nil {
-		files[parentPath] = gitops.RemoveTenantFromParentKustomization(currentParent, data.Slug)
+	// Re-read the parent kustomization on EACH attempt so a concurrent
+	// provision/teardown that beat us doesn't get its slug entry resurrected
+	// when our retry replays a stale files map. Issue: live race observed
+	// 2026-05-06 between bookcheck teardown and a concurrent multitest
+	// provision — multitest's retry resurrected bookcheck because
+	// CommitFilesWithPrune didn't re-read the parent on rebuild.
+	rebuild := func(ctx context.Context) (map[string]string, error) {
+		currentParent, readErr := h.GitHubClient.ReadFile(ctx, branch, parentPath)
+		files := map[string]string{}
+		if readErr == nil {
+			files[parentPath] = gitops.RemoveTenantFromParentKustomization(currentParent, data.Slug)
+		}
+		return files, nil
 	}
 
 	commitMsg := fmt.Sprintf("teardown: delete tenant %s", data.Slug)
-	if err := h.GitHubClient.CommitFilesWithPrune(ctx, branch, commitMsg, files, []string{tenantDir}); err != nil {
+	if err := h.GitHubClient.CommitFilesWithPruneAndRebuild(ctx, branch, commitMsg, nil, []string{tenantDir}, rebuild); err != nil {
 		slog.Error("teardown: commit/prune failed", "slug", data.Slug, "error", err)
 		return err
 	}
@@ -929,15 +938,27 @@ func (h *Handler) runProvisioningWorkflow(provisionID, tenantID, subdomain, plan
 		branch = "main"
 	}
 
-	currentParentKustom, readErr := h.GitHubClient.ReadFile(ctx, branch, parentKustomPath)
-	if readErr != nil {
-		slog.Warn("could not read parent kustomization, using empty", "error", readErr)
-		currentParentKustom = "apiVersion: kustomize.config.k8s.io/v1beta1\nkind: Kustomization\nresources: []\n"
+	// Re-read the parent kustomization on EACH commit attempt so a concurrent
+	// teardown's removal of another slug doesn't get reverted by our retry
+	// replaying a stale files map. Issue: live race observed 2026-05-06 where
+	// multitest provision's retry resurrected the just-deleted bookcheck slug.
+	rebuild := func(ctx context.Context) (map[string]string, error) {
+		currentParentKustom, readErr := h.GitHubClient.ReadFile(ctx, branch, parentKustomPath)
+		if readErr != nil {
+			slog.Warn("could not read parent kustomization, using empty", "error", readErr)
+			currentParentKustom = "apiVersion: kustomize.config.k8s.io/v1beta1\nkind: Kustomization\nresources: []\n"
+		}
+		// Copy the static tenant manifests + the freshly-merged parent.
+		fresh := make(map[string]string, len(manifests)+1)
+		for k, v := range manifests {
+			fresh[k] = v
+		}
+		fresh[parentKustomPath] = gitops.UpdateParentKustomization(currentParentKustom, subdomain)
+		return fresh, nil
 	}
-	manifests[parentKustomPath] = gitops.UpdateParentKustomization(currentParentKustom, subdomain)
 
 	commitMsg := fmt.Sprintf("provision: deploy tenant %s (plan: %s, apps: %d)", subdomain, planSlug, len(appSlugs))
-	if err := h.GitHubClient.CommitFiles(ctx, branch, commitMsg, manifests); err != nil {
+	if err := h.GitHubClient.CommitFilesWithPruneAndRebuild(ctx, branch, commitMsg, nil, nil, rebuild); err != nil {
 		slog.Error("failed to commit manifests", "provision_id", provisionID, "error", err)
 		h.failProvision(ctx, provisionID, tenantID, stepIdx, fmt.Sprintf("git commit failed: %s", err))
 		return


### PR DESCRIPTION
## Summary
Live race observed 2026-05-06: bookcheck teardown committed at T (removed slug + pruned dir). Multitest provision's first commit got ref-rejected, the github client retry replayed the SAME files map, and the retry overwrote the teardown's parent-kustomization removal. Flux's \`tenants\` Kustomization then wedged because the slug listed a directory that didn't exist.

## Fix
- New \`CommitFilesWithPruneAndRebuild\` API on the github client. Takes a \`rebuild(ctx) → (files, error)\` callback that runs at the start of EACH attempt. The retry path now reads the latest HEAD content of the merge-target file and re-applies the merge, instead of replaying stale bytes.
- Wire both provisioning entry points (provision, teardown) through it. Tenant-scoped static manifests still flow as before; only the parent-kustomization merge is rebuilt.

## Test plan
- [x] \`go test ./core/services/provisioning/...\` green
- [ ] After merge + image roll: re-run a concurrent provision/teardown pair (e.g. provision tenant A, immediately teardown tenant B) and confirm both commits land cleanly with the parent kustomization correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)