### PR TITLE
chore(bootstrap-kit): pin bp-catalyst-platform 1.4.43 (PR #1032 follow-up)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -231,7 +231,7 @@ spec:
       # fallback (data renders the moment cutover-import lands without
       # waiting for the orchestrator's chart-values overlay write).
       # 2026-05-05.
-      version: 1.4.41
+      version: 1.4.43
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform


### PR DESCRIPTION
PR #1032's sed missed the 1.4.41→1.4.43 bump in clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml. Without this, freshly provisioned Sovereigns still install chart 1.4.41 (no PortalShell sidebar fix). otech128 hit this — provisioned with 1.4.41.