### PR TITLE
chore(bp-catalyst-platform): bump 1.4.44 + literal :91eeeed (#1032 PortalShell fix)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -231,7 +231,7 @@ spec:
       # fallback (data renders the moment cutover-import lands without
       # waiting for the orchestrator's chart-values overlay write).
       # 2026-05-05.
-      version: 1.4.43
+      version: 1.4.44
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/chart/templates/api-deployment.yaml
+++ b/products/catalyst/chart/templates/api-deployment.yaml
@@ -152,7 +152,7 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       containers:
         - name: catalyst-api
-          image: "ghcr.io/openova-io/openova/catalyst-api:ff864e9"
+          image: "ghcr.io/openova-io/openova/catalyst-api:91eeeed"
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080

--- a/products/catalyst/chart/templates/ui-deployment.yaml
+++ b/products/catalyst/chart/templates/ui-deployment.yaml
@@ -19,7 +19,7 @@ spec:
         - name: ghcr-pull
       containers:
         - name: catalyst-ui
-          image: "ghcr.io/openova-io/openova/catalyst-ui:ff864e9"
+          image: "ghcr.io/openova-io/openova/catalyst-ui:91eeeed"
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080


### PR DESCRIPTION
Sovereigns provisioned with chart 1.4.43 still have the duplicate-sidebar bug because the hardcoded `:ff864e9` in `api-deployment.yaml`/`ui-deployment.yaml` was never bumped to `:91eeeed` (PR #1032's commit). This commit fixes that. Verified missing on otech129 — both `sov-console-nav-*` and `sov-nav-*` sidebars rendered with the inner one having broken /provision//X URLs.