### PR TITLE
fix(rbac): grant catalyst-api cluster reads for /sovereign/cloud + /apps

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -231,7 +231,7 @@ spec:
       # fallback (data renders the moment cutover-import lands without
       # waiting for the orchestrator's chart-values overlay write).
       # 2026-05-05.
-      version: 1.4.44
+      version: 1.4.45
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -124,8 +124,8 @@ name: bp-catalyst-platform
 # otech113 2026-05-05 — chart 0.1.18 fixed the readiness-probe loop
 # but every trigger immediately got 502 in <10ms (synchronous
 # apiserver permission rejection). 2026-05-05.
-version: 1.4.44
-appVersion: 1.4.44
+version: 1.4.45
+appVersion: 1.4.45
 description: |
   Catalyst Platform — the unified Catalyst control plane umbrella chart for Catalyst-Zero.
   Composes the catalyst-{ui,api}, console, admin, marketplace UI modules and the marketplace-api backend.

--- a/products/catalyst/chart/templates/clusterrole-cutover-driver.yaml
+++ b/products/catalyst/chart/templates/clusterrole-cutover-driver.yaml
@@ -104,3 +104,35 @@ rules:
   - apiGroups: ["authentication.k8s.io"]
     resources: ["tokenreviews"]
     verbs: ["create"]
+
+  # ───────────────────────────────────────────────────────────────
+  # SOVEREIGN ENDPOINT READS — backing the chroot Sovereign Console
+  # at console.<sov-fqdn>. Handlers (`HandleSovereignCloud`,
+  # `HandleSovereignApps`) live in catalyst-api and use the
+  # in-cluster client to enumerate cluster-wide resources for the
+  # /cloud and /apps panes. Caught live on otech130 2026-05-06:
+  # /api/v1/sovereign/cloud returned `{nodes:[], namespaces:[], …}`
+  # because the SA was silently rejected by the apiserver on the
+  # Nodes().List call (handler's err branch falls through to an
+  # empty response).
+  # ───────────────────────────────────────────────────────────────
+  - apiGroups: [""]
+    resources:
+      - nodes
+      - namespaces
+      - services
+      - persistentvolumes
+      - persistentvolumeclaims
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["networking.k8s.io"]
+    resources: ["ingresses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["gateway.networking.k8s.io"]
+    resources: ["httproutes", "gateways"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["helm.toolkit.fluxcd.io"]
+    resources: ["helmreleases"]
+    verbs: ["get", "list", "watch"]


### PR DESCRIPTION
/api/v1/sovereign/cloud returned empty on otech130 because the SA lacks list permissions for nodes/namespaces/services/PVCs/ingresses. Adds the missing rules. Bumps chart 1.4.44 → 1.4.45.