### PR TITLE
fix(sovereign-console): jobs + apps pages show LIVE status (not imported snapshot Pending)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -231,7 +231,7 @@ spec:
       # fallback (data renders the moment cutover-import lands without
       # waiting for the orchestrator's chart-values overlay write).
       # 2026-05-05.
-      version: 1.4.45
+      version: 1.4.46
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/AppsPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/AppsPage.tsx
@@ -32,8 +32,10 @@
 
 import { useEffect, useMemo, useState } from 'react'
 import { useRouter, Link, useParams } from '@tanstack/react-router'
+import { useQuery } from '@tanstack/react-query'
 import { useResolvedDeploymentId } from '@/shared/lib/useResolvedDeploymentId'
 import { DETECTED_MODE } from '@/shared/lib/detectMode'
+import { API_BASE } from '@/shared/config/urls'
 import { useWizardStore } from '@/entities/deployment/store'
 import { PortalShell } from './PortalShell'
 import { resolveApplications, type ApplicationDescriptor } from './applicationCatalog'
@@ -77,6 +79,49 @@ export function AppsPage({ disableStream = false }: AppsPageProps = {}) {
     applicationIds,
     disableStream,
   })
+
+  // On Sovereign mode the imported reducer state is FROZEN at mother's
+  // last snapshot (every app reads "pending"). Layer in live status
+  // from /api/v1/sovereign/apps so the AppCards reflect ground truth.
+  // Server status enum: "installed" | "installing" | "bootstrap" |
+  // "available" — map to the UI's ApplicationStatus vocabulary.
+  // Caught on omantel.biz 2026-05-06.
+  const isSovereignMode = DETECTED_MODE.mode === 'sovereign'
+  const liveAppsQuery = useQuery<Record<string, ApplicationStatus>>({
+    queryKey: ['sovereign-apps-live'],
+    enabled: isSovereignMode,
+    refetchInterval: 5_000,
+    queryFn: async () => {
+      const r = await fetch(`${API_BASE}/v1/sovereign/apps`, {
+        credentials: 'include',
+        headers: { Accept: 'application/json' },
+      })
+      if (!r.ok) throw new Error(`live apps fetch ${r.status}`)
+      const body = (await r.json()) as { apps?: Array<{ id: string; status?: string }> }
+      const out: Record<string, ApplicationStatus> = {}
+      for (const a of body.apps ?? []) {
+        if (!a.id) continue
+        switch (a.status) {
+          case 'installed':
+          case 'bootstrap':
+            out[a.id] = 'installed'
+            break
+          case 'installing':
+            out[a.id] = 'installing'
+            break
+          case 'available':
+            out[a.id] = 'pending'
+            break
+          default:
+            out[a.id] = 'pending'
+        }
+      }
+      return out
+    },
+    retry: false,
+    placeholderData: (prev) => prev,
+  })
+  const liveAppStatus = liveAppsQuery.data ?? {}
 
   const isFailed = streamStatus === 'failed' || streamStatus === 'unreachable'
   const failureMessage = streamError ?? snapshot?.error ?? null
@@ -484,7 +529,7 @@ export function AppsPage({ disableStream = false }: AppsPageProps = {}) {
             <AppCard
               key={app.id}
               app={app}
-              status={state.apps[app.id]?.status ?? 'pending'}
+              status={liveAppStatus[app.id] ?? state.apps[app.id]?.status ?? 'pending'}
               isService={app.familyId === 'platform' && !app.bootstrapKit ? false : !app.bootstrapKit && app.tier === 'optional' ? false : false}
             />
           ))}

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/JobsPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/JobsPage.tsx
@@ -27,6 +27,7 @@ import { useDeploymentEvents } from './useDeploymentEvents'
 import { deriveJobs } from './jobs'
 import { adaptDerivedJobsToFlat } from './jobsAdapter'
 import { useLiveJobsBackfill, mergeJobs } from './useLiveJobsBackfill'
+import { DETECTED_MODE } from '@/shared/lib/detectMode'
 
 interface JobsPageProps {
   /** Test seam — disables the live SSE EventSource attach. */
@@ -65,11 +66,20 @@ export function JobsPage({
   // the backend's Jobs API gives us the current ground-truth list and
   // the merge below ensures live data wins on conflict. Polling stops
   // automatically when the deployment reaches a terminal state.
+  // On Sovereign mode the imported snapshot from mother is FROZEN at
+  // mother's last reducer state (always streamStatus="completed" by the
+  // time handover fires), so the inFlight gate would never poll the
+  // live /api/v1/sovereign/jobs endpoint. The Sovereign Console MUST
+  // always show ground-truth from the local cluster, so override the
+  // gate when we're running on chroot Sovereign mode. Caught on
+  // omantel.biz 2026-05-06 — every job rendered "Pending" because
+  // mergeJobs fell through to the imported snapshot.
+  const isSovereignMode = DETECTED_MODE.mode === 'sovereign'
   const inFlight = streamStatus !== 'completed' && streamStatus !== 'failed'
   const { liveJobs } = useLiveJobsBackfill({
     deploymentId,
     enabled: !disableJobsBackfill,
-    disablePolling: disableJobsBackfill || !inFlight,
+    disablePolling: disableJobsBackfill || (!inFlight && !isSovereignMode),
   })
 
   const flatJobs = useMemo(

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -124,8 +124,8 @@ name: bp-catalyst-platform
 # otech113 2026-05-05 — chart 0.1.18 fixed the readiness-probe loop
 # but every trigger immediately got 502 in <10ms (synchronous
 # apiserver permission rejection). 2026-05-05.
-version: 1.4.45
-appVersion: 1.4.45
+version: 1.4.46
+appVersion: 1.4.46
 description: |
   Catalyst Platform — the unified Catalyst control plane umbrella chart for Catalyst-Zero.
   Composes the catalyst-{ui,api}, console, admin, marketplace UI modules and the marketplace-api backend.


### PR DESCRIPTION
On Sovereign mode, JobsPage skipped live polling because the imported snapshot's streamStatus is always 'completed'. AppsPage never overlay'd /api/v1/sovereign/apps either. Fixes both. Caught on omantel.biz. Bumps chart 1.4.46.