### PR TITLE
fix(cloud-page): defensive slice guard + chart 1.4.47 with literal :2122fb8

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -231,7 +231,7 @@ spec:
       # fallback (data renders the moment cutover-import lands without
       # waiting for the orchestrator's chart-values overlay write).
       # 2026-05-05.
-      version: 1.4.46
+      version: 1.4.47
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/CloudPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/CloudPage.tsx
@@ -509,8 +509,8 @@ export function CloudPage({
           className="rounded-md border border-[var(--color-border)] bg-[var(--color-bg-2)] px-2 py-1 text-xs text-[var(--color-text)]"
         >
           {switcherOptions.map((d) => (
-            <option key={d.id} value={d.id}>
-              {d.sovereignFQDN || d.id.slice(0, 8)}
+            <option key={d.id ?? ''} value={d.id ?? ''}>
+              {d.sovereignFQDN || (d.id ?? '').slice(0, 8) || '(unknown)'}
             </option>
           ))}
         </select>

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -124,8 +124,8 @@ name: bp-catalyst-platform
 # otech113 2026-05-05 — chart 0.1.18 fixed the readiness-probe loop
 # but every trigger immediately got 502 in <10ms (synchronous
 # apiserver permission rejection). 2026-05-05.
-version: 1.4.46
-appVersion: 1.4.46
+version: 1.4.47
+appVersion: 1.4.47
 description: |
   Catalyst Platform — the unified Catalyst control plane umbrella chart for Catalyst-Zero.
   Composes the catalyst-{ui,api}, console, admin, marketplace UI modules and the marketplace-api backend.

--- a/products/catalyst/chart/templates/api-deployment.yaml
+++ b/products/catalyst/chart/templates/api-deployment.yaml
@@ -152,7 +152,7 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       containers:
         - name: catalyst-api
-          image: "ghcr.io/openova-io/openova/catalyst-api:91eeeed"
+          image: "ghcr.io/openova-io/openova/catalyst-api:2122fb8"
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080

--- a/products/catalyst/chart/templates/ui-deployment.yaml
+++ b/products/catalyst/chart/templates/ui-deployment.yaml
@@ -19,7 +19,7 @@ spec:
         - name: ghcr-pull
       containers:
         - name: catalyst-ui
-          image: "ghcr.io/openova-io/openova/catalyst-ui:91eeeed"
+          image: "ghcr.io/openova-io/openova/catalyst-ui:2122fb8"
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080


### PR DESCRIPTION
Cloud page crashed with 'Cannot read properties of undefined (reading slice)' on switcher render. Adds nullish guard. Bumps chart 1.4.47 with literal image :2122fb8 so freshly provisioned Sovereigns get the JobsPage+AppsPage live-status fix from PR #1039.