### PR TITLE
fix(useLiveJobsBackfill): enable query on Sovereign mode even when deploymentId empty

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -231,7 +231,7 @@ spec:
       # fallback (data renders the moment cutover-import lands without
       # waiting for the orchestrator's chart-values overlay write).
       # 2026-05-05.
-      version: 1.4.47
+      version: 1.4.48
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/useLiveJobsBackfill.ts
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/useLiveJobsBackfill.ts
@@ -112,10 +112,17 @@ export function useLiveJobsBackfill(
 ): UseLiveJobsBackfillResult {
   const { deploymentId, disablePolling = false, fetcher = defaultFetchJobs, enabled = true } = opts
 
+  // On Sovereign mode the URL doesn't need a deploymentId path segment
+  // (/api/v1/sovereign/jobs is FQDN-scoped from the cookie), so an
+  // empty deploymentId must NOT disable the query — otherwise jobs
+  // never poll on chroot Sovereign Console where /sovereign/self may
+  // return 503 (deployment-id-not-yet-stamped) and the URL params
+  // route doesn't carry the id.
+  const isSovereignMode = DETECTED_MODE.mode === 'sovereign'
   const query = useQuery<Job[]>({
-    queryKey: ['live-jobs-backfill', deploymentId],
+    queryKey: ['live-jobs-backfill', isSovereignMode ? 'sovereign' : deploymentId],
     queryFn: () => fetcher(deploymentId),
-    enabled: enabled && !!deploymentId,
+    enabled: enabled && (isSovereignMode || !!deploymentId),
     refetchInterval: () => {
       if (disablePolling) return false
       return POLL_INTERVAL_MS

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -124,8 +124,8 @@ name: bp-catalyst-platform
 # otech113 2026-05-05 — chart 0.1.18 fixed the readiness-probe loop
 # but every trigger immediately got 502 in <10ms (synchronous
 # apiserver permission rejection). 2026-05-05.
-version: 1.4.47
-appVersion: 1.4.47
+version: 1.4.48
+appVersion: 1.4.48
 description: |
   Catalyst Platform — the unified Catalyst control plane umbrella chart for Catalyst-Zero.
   Composes the catalyst-{ui,api}, console, admin, marketplace UI modules and the marketplace-api backend.


### PR DESCRIPTION
Caught on omantel.biz: jobs page rendered all-Pending because useLiveJobsBackfill required non-empty deploymentId, but Sovereign Console has empty deploymentId. Enable query on Sovereign mode regardless. Chart 1.4.48.