### PR TITLE
fix(jobs): coerce Sovereign live response into full Job shape

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -231,7 +231,7 @@ spec:
       # fallback (data renders the moment cutover-import lands without
       # waiting for the orchestrator's chart-values overlay write).
       # 2026-05-05.
-      version: 1.4.48
+      version: 1.4.49
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/useLiveJobsBackfill.ts
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/useLiveJobsBackfill.ts
@@ -85,7 +85,28 @@ async function defaultFetchJobs(deploymentId: string): Promise<Job[]> {
     throw new Error(`Failed to fetch jobs: ${res.status}`)
   }
   const body = (await res.json()) as JobsResponse
-  return Array.isArray(body.jobs) ? body.jobs : []
+  // Sovereign endpoint returns a minimal shape (no appId/parentId/
+  // dependsOn/childIds). JobsTable iterates `for (const d of
+  // job.dependsOn)` and reads `job.appId.toLowerCase()` etc., which
+  // crashes on undefined. Coerce missing fields to safe defaults so
+  // the table renders. Caught on omantel.biz 2026-05-06 — table
+  // rendered 0 rows because TypeError 'cannot read length of
+  // undefined' on dependsOn.
+  const raw = Array.isArray(body.jobs) ? body.jobs : []
+  return raw.map((j) => ({
+    id: j.id ?? '',
+    jobName: (j as { jobName?: string }).jobName ?? (j as { name?: string }).name ?? j.id ?? '',
+    displayName: (j as { displayName?: string }).displayName,
+    type: (j as { type?: 'install' | 'group' }).type ?? 'install',
+    appId: (j as { appId?: string }).appId ?? '',
+    parentId: (j as { parentId?: string }).parentId ?? '',
+    dependsOn: (j as { dependsOn?: string[] }).dependsOn ?? [],
+    childIds: (j as { childIds?: string[] }).childIds ?? [],
+    status: ((j as { status?: string }).status ?? 'pending') as Job['status'],
+    startedAt: (j as { startedAt?: string }).startedAt ?? null,
+    finishedAt: (j as { finishedAt?: string }).finishedAt ?? null,
+    durationMs: (j as { durationMs?: number }).durationMs ?? 0,
+  })) as Job[]
 }
 
 export interface UseLiveJobsBackfillOptions {

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -124,8 +124,8 @@ name: bp-catalyst-platform
 # otech113 2026-05-05 — chart 0.1.18 fixed the readiness-probe loop
 # but every trigger immediately got 502 in <10ms (synchronous
 # apiserver permission rejection). 2026-05-05.
-version: 1.4.48
-appVersion: 1.4.48
+version: 1.4.49
+appVersion: 1.4.49
 description: |
   Catalyst Platform — the unified Catalyst control plane umbrella chart for Catalyst-Zero.
   Composes the catalyst-{ui,api}, console, admin, marketplace UI modules and the marketplace-api backend.


### PR DESCRIPTION
Live /api/v1/sovereign/jobs returns minimal shape; JobsTable crashes on undefined .appId/.parentId/.dependsOn. Coerce in fetcher. Chart 1.4.49.