### PR TITLE
fix(sovereign-console): close DoD gaps — Invariant + missing endpoints + chroot fetchers

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -231,7 +231,7 @@ spec:
       # fallback (data renders the moment cutover-import lands without
       # waiting for the orchestrator's chart-values overlay write).
       # 2026-05-05.
-      version: 1.4.49
+      version: 1.4.50
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/bootstrap/api/cmd/api/main.go
+++ b/products/catalyst/bootstrap/api/cmd/api/main.go
@@ -687,6 +687,10 @@ func main() {
 		rg.Get("/api/v1/sovereign/jobs", h.HandleSovereignJobs)
 		rg.Get("/api/v1/sovereign/apps", h.HandleSovereignApps)
 		rg.Get("/api/v1/sovereign/cloud", h.HandleSovereignCloud)
+		rg.Get("/api/v1/sovereign/users", h.HandleSovereignUsers)
+		rg.Get("/api/v1/sovereign/catalog", h.HandleSovereignCatalog)
+		rg.Get("/api/v1/sovereign/settings", h.HandleSovereignSettings)
+		rg.Get("/api/v1/sovereign/topology", h.HandleSovereignTopology)
 
 		// Self-Sovereignty Cutover (issue #792 — parent epic #790). The
 		// post-handover step that severs a Sovereign's remaining

--- a/products/catalyst/bootstrap/api/internal/auth/session.go
+++ b/products/catalyst/bootstrap/api/internal/auth/session.go
@@ -32,6 +32,18 @@ type Claims struct {
 	Email         string `json:"email"`
 	EmailVerified bool   `json:"email_verified"`
 	PreferredName string `json:"preferred_username"`
+
+	// SovereignFQDN — populated by the Sovereign session minted at
+	// /auth/handover (auth_handover.go). Empty on Catalyst-Zero
+	// sessions. Used by HandleSovereignSelf to resolve the Sovereign
+	// identity post-handover when env CATALYST_OTECH_FQDN /
+	// CATALYST_SELF_DEPLOYMENT_ID may still be unset. 2026-05-06.
+	SovereignFQDN string `json:"sovereign_fqdn"`
+
+	// DeploymentID — populated alongside SovereignFQDN. The chroot
+	// Sovereign Console reads this via /api/v1/sovereign/self so
+	// useResolvedDeploymentId never returns empty post-handover.
+	DeploymentID string `json:"deployment_id"`
 }
 
 // Config holds the runtime configuration for the auth package.

--- a/products/catalyst/bootstrap/api/internal/handler/auth_handover.go
+++ b/products/catalyst/bootstrap/api/internal/handler/auth_handover.go
@@ -66,6 +66,17 @@ type authHandoverClaims struct {
 
 	// Role must equal "sovereign-admin".
 	Role string `json:"role"`
+
+	// SovereignFQDN is the new Sovereign's FQDN (mother stamps this).
+	// Used to enrich the Sovereign session cookie so /sovereign/self
+	// and other chroot endpoints can resolve the Sovereign identity
+	// without falling back to env or store-fallback.
+	SovereignFQDN string `json:"sovereign_fqdn"`
+
+	// DeploymentID is the Catalyst-Zero deployment record ID (16-char
+	// hex). Used by chroot pages to scope deployment-keyed API paths
+	// once /sovereign/self resolution is JWT-driven.
+	DeploymentID string `json:"deployment_id"`
 }
 
 // AuthHandover handles GET /auth/handover?token=<jwt>.
@@ -210,6 +221,14 @@ func (h *Handler) AuthHandover(w http.ResponseWriter, r *http.Request) {
 		"jti":            uuid.NewString(),
 		"typ":            "session",
 		"keycloak_uid":   userID,
+		// Carry Sovereign identity into the session token so downstream
+		// handlers (HandleSovereignSelf, /users, /catalog, /settings)
+		// can resolve the deployment id WITHOUT depending on the
+		// orchestrator overlay write or store-fallback. Caught on
+		// omantel.biz 2026-05-06: every chroot page broke because
+		// /sovereign/self returned 503 (no env populated post-handover).
+		"sovereign_fqdn": claims.SovereignFQDN,
+		"deployment_id":  claims.DeploymentID,
 	}
 	accessToken, err := h.handoverSigner.SignCustomClaims(sessionClaims)
 	if err != nil {

--- a/products/catalyst/bootstrap/api/internal/handler/sovereign_more.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sovereign_more.go
@@ -1,0 +1,322 @@
+// sovereign_more.go — additional Sovereign Console endpoints (#L6-DoD).
+//
+// The Sovereign Console at console.<sov-fqdn> renders the chroot
+// /users, /catalog, /settings, /cloud (graph + topology) pages, all
+// of which need data shaped to match the existing wizard surfaces
+// they're ported from. This file groups the small data-shim handlers
+// that didn't fit naturally into sovereign.go (which already hosts
+// the larger /jobs / /apps / /cloud handlers).
+//
+// All handlers in this file:
+//   - mount on the Sovereign-side catalyst-api (FQDN console.<sov>)
+//   - read live cluster state via the in-cluster client (sovereignDepsFor)
+//   - return a STABLE empty shape on any error (the Sovereign Console
+//     pages render the empty state gracefully — never crash on null).
+//
+// Caught on omantel.biz 2026-05-06: every chroot page hit a 404 because
+// these endpoints didn't exist; the React error boundary caught the
+// resulting fetch failure and rendered "Something went wrong".
+package handler
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/catalog"
+)
+
+// base64Decode is the URL-safe base64 decoder used to read JWT payloads.
+func base64Decode(s string) ([]byte, error) {
+	return base64.RawURLEncoding.DecodeString(s)
+}
+
+// ── /api/v1/sovereign/users — Keycloak realm users ──────────────────────────
+//
+// Returns the operator users registered in the Sovereign's local
+// Keycloak realm (typically just the org-admin who completed handover,
+// plus any users invited via the Sovereign Console's Users page).
+// Sourced from the kc-sa client credentials secret + Keycloak admin API.
+//
+// Empty-shape contract: returns {"users":[]} on any error so the UI
+// renders an "(no users)" empty state rather than a fetch failure.
+
+type sovereignUsersResponse struct {
+	Users []sovereignUser `json:"users"`
+}
+
+type sovereignUser struct {
+	ID            string `json:"id"`
+	Email         string `json:"email"`
+	Name          string `json:"name"`
+	Role          string `json:"role"`
+	Status        string `json:"status"`
+	LastSignInISO string `json:"lastSignInISO,omitempty"`
+}
+
+// HandleSovereignUsers — GET /api/v1/sovereign/users.
+func (h *Handler) HandleSovereignUsers(w http.ResponseWriter, r *http.Request) {
+	resp := sovereignUsersResponse{Users: []sovereignUser{}}
+
+	// Surface the operator who's currently authenticated (always at
+	// least one user — the operator hitting the page). Read from
+	// session cookie claims (email + sub).
+	if email, ok := readEmailFromSessionCookie(r); ok && email != "" {
+		resp.Users = append(resp.Users, sovereignUser{
+			ID:     email,
+			Email:  email,
+			Name:   email,
+			Role:   "sovereign-admin",
+			Status: "active",
+		})
+	}
+
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// ── /api/v1/sovereign/catalog — Sovereign-side catalog adapter ──────────────
+//
+// The CatalogAdminPage was originally ported from core/services/catalog
+// (a separate service that doesn't exist on Sovereign clusters). To
+// avoid a 404 + sidebar-link error, expose a minimal Sovereign catalog
+// view sourced from the embedded blueprints catalog (same data the
+// /apps endpoint already uses, just shaped for the publish-toggle UI).
+//
+// Wire shape — bare array (the CatalogAdminPage's fetcher does
+// `respond.OK(w, apps)` and expects an array, not a wrapper object).
+
+type sovereignCatalogApp struct {
+	ID         string `json:"id"`
+	Slug       string `json:"slug"`
+	Name       string `json:"name"`
+	Title      string `json:"title"`
+	Family     string `json:"family"`
+	Tier       string `json:"tier"`
+	Published  bool   `json:"published"`
+	Visibility string `json:"visibility"`
+	Icon       string `json:"icon,omitempty"`
+}
+
+// HandleSovereignCatalog — GET /api/v1/sovereign/catalog.
+func (h *Handler) HandleSovereignCatalog(w http.ResponseWriter, _ *http.Request) {
+	listed, err := catalog.ListedBlueprints()
+	if err != nil {
+		writeJSON(w, http.StatusOK, []sovereignCatalogApp{})
+		return
+	}
+	apps := make([]sovereignCatalogApp, 0, len(listed))
+	for _, bp := range listed {
+		family := ""
+		if bp.Category != nil {
+			family = *bp.Category
+		}
+		section := ""
+		if bp.Section != nil {
+			section = *bp.Section
+		}
+		visStr := string(bp.Visibility)
+		apps = append(apps, sovereignCatalogApp{
+			ID:         bp.ID,
+			Slug:       bp.Slug,
+			Name:       bp.Title,
+			Title:      bp.Title,
+			Family:     family,
+			Tier:       section,
+			Published:  visStr == "listed",
+			Visibility: visStr,
+		})
+	}
+	writeJSON(w, http.StatusOK, apps)
+}
+
+// ── /api/v1/sovereign/settings — Sovereign tenant settings overview ─────────
+//
+// Powers the chroot /settings page. Returns the Sovereign's identity,
+// handover record, and runtime config flags so the page can render
+// "About this Sovereign" + tenant-admin affordances without any other
+// API round-trip.
+
+type sovereignSettingsResponse struct {
+	SovereignFQDN string                 `json:"sovereignFQDN"`
+	DeploymentID  string                 `json:"deploymentId"`
+	Region        string                 `json:"region"`
+	Provider      string                 `json:"provider"`
+	HandoverISO   string                 `json:"handoverISO,omitempty"`
+	Marketplace   bool                   `json:"marketplaceEnabled"`
+	Features      map[string]interface{} `json:"features"`
+}
+
+// HandleSovereignSettings — GET /api/v1/sovereign/settings.
+func (h *Handler) HandleSovereignSettings(w http.ResponseWriter, r *http.Request) {
+	fqdn := strings.TrimSpace(os.Getenv("CATALYST_OTECH_FQDN"))
+	deploymentID := strings.TrimSpace(os.Getenv("CATALYST_SELF_DEPLOYMENT_ID"))
+	if jwtFQDN, jwtDepID, ok := readSessionClaimsFromCookie(r); ok {
+		if fqdn == "" {
+			fqdn = jwtFQDN
+		}
+		if deploymentID == "" {
+			deploymentID = jwtDepID
+		}
+	}
+
+	resp := sovereignSettingsResponse{
+		SovereignFQDN: fqdn,
+		DeploymentID:  deploymentID,
+		Region:        strings.TrimSpace(os.Getenv("CATALYST_REGION")),
+		Provider:      strings.TrimSpace(os.Getenv("CATALYST_PROVIDER")),
+		Marketplace:   os.Getenv("CATALYST_MARKETPLACE_ENABLED") == "true",
+		Features: map[string]interface{}{
+			"handoverFiredAt": strings.TrimSpace(os.Getenv("CATALYST_HANDOVER_FIRED_AT")),
+		},
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// ── /api/v1/sovereign/topology — hierarchical infrastructure for /cloud ─────
+//
+// CloudPage's getHierarchicalInfrastructure() in the UI hits this
+// endpoint when DETECTED_MODE.mode === 'sovereign'. Builds the
+// HierarchicalInfrastructure shape the UI expects (cloud → region →
+// cluster → vcluster|node|lb|network) from the same in-cluster client
+// queries that /sovereign/cloud uses, but reshaped into the single
+// hierarchical tree the canvas + tabs render off.
+//
+// On any error returns the well-shaped empty topology so the canvas
+// renders its "Provisioning…" overlay rather than crashing the page.
+
+type hierTopologyResponse struct {
+	Cloud    map[string]interface{}   `json:"cloud"`
+	Topology map[string]interface{}   `json:"topology"`
+}
+
+// HandleSovereignTopology — GET /api/v1/sovereign/topology.
+func (h *Handler) HandleSovereignTopology(w http.ResponseWriter, r *http.Request) {
+	emptyResp := hierTopologyResponse{
+		Cloud: map[string]interface{}{
+			"provider":       strings.TrimSpace(os.Getenv("CATALYST_PROVIDER")),
+			"providerRegion": strings.TrimSpace(os.Getenv("CATALYST_REGION")),
+		},
+		Topology: map[string]interface{}{
+			"pattern": "solo",
+			"regions": []interface{}{},
+		},
+	}
+
+	deps, err := h.sovereignDepsFor()
+	if err != nil {
+		writeJSON(w, http.StatusOK, emptyResp)
+		return
+	}
+	ctx, cancel := context.WithTimeout(r.Context(), 15*time.Second)
+	defer cancel()
+
+	// Build a single region from the live Nodes list. Cluster name
+	// derived from the Sovereign's FQDN env. NodePool synthesised
+	// from k3s role labels (control-plane vs worker).
+	type nodeOut struct {
+		ID     string `json:"id"`
+		Name   string `json:"name"`
+		SKU    string `json:"sku"`
+		Role   string `json:"role"`
+		IP     string `json:"ip"`
+		Status string `json:"status"`
+	}
+	var nodes []nodeOut
+	if list, err := deps.core.CoreV1().Nodes().List(ctx, metav1.ListOptions{}); err == nil {
+		for _, n := range list.Items {
+			role := "worker"
+			for k := range n.Labels {
+				if strings.HasSuffix(k, "node-role.kubernetes.io/control-plane") ||
+					strings.HasSuffix(k, "node-role.kubernetes.io/master") {
+					role = "control-plane"
+				}
+			}
+			ip := ""
+			for _, a := range n.Status.Addresses {
+				if a.Type == "ExternalIP" || a.Type == "InternalIP" {
+					ip = a.Address
+					if a.Type == "ExternalIP" {
+						break
+					}
+				}
+			}
+			status := "unknown"
+			for _, c := range n.Status.Conditions {
+				if c.Type == "Ready" {
+					if c.Status == "True" {
+						status = "healthy"
+					} else {
+						status = "degraded"
+					}
+				}
+			}
+			nodes = append(nodes, nodeOut{
+				ID:     string(n.UID),
+				Name:   n.Name,
+				SKU:    n.Labels["instance.hetzner.cloud/server-type"],
+				Role:   role,
+				IP:     ip,
+				Status: status,
+			})
+		}
+	}
+
+	cluster := map[string]interface{}{
+		"id":            strings.TrimSpace(os.Getenv("CATALYST_OTECH_FQDN")),
+		"name":          strings.TrimSpace(os.Getenv("CATALYST_OTECH_FQDN")),
+		"version":       "k3s",
+		"vclusters":     []interface{}{},
+		"loadBalancers": []interface{}{},
+		"nodePools":     []interface{}{},
+		"nodes":         nodes,
+		"status":        "healthy",
+	}
+
+	region := map[string]interface{}{
+		"id":          strings.TrimSpace(os.Getenv("CATALYST_REGION")),
+		"name":        strings.TrimSpace(os.Getenv("CATALYST_REGION")),
+		"provider":    strings.TrimSpace(os.Getenv("CATALYST_PROVIDER")),
+		"workerCount": len(nodes),
+		"clusters":    []interface{}{cluster},
+		"networks":    []interface{}{},
+	}
+
+	resp := hierTopologyResponse{
+		Cloud: emptyResp.Cloud,
+		Topology: map[string]interface{}{
+			"pattern": "solo",
+			"regions": []interface{}{region},
+		},
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// ── helper — read email from session cookie (no signature verify) ──────────
+
+func readEmailFromSessionCookie(r *http.Request) (string, bool) {
+	c, err := r.Cookie("catalyst_session")
+	if err != nil || c == nil || c.Value == "" {
+		return "", false
+	}
+	parts := strings.Split(c.Value, ".")
+	if len(parts) != 3 {
+		return "", false
+	}
+	payload, err := base64Decode(parts[1])
+	if err != nil {
+		return "", false
+	}
+	var claims struct {
+		Email string `json:"email"`
+	}
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return "", false
+	}
+	return claims.Email, claims.Email != ""
+}

--- a/products/catalyst/bootstrap/api/internal/handler/sovereign_self.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sovereign_self.go
@@ -28,6 +28,9 @@
 package handler
 
 import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
 	"net/http"
 	"os"
 	"strings"
@@ -56,9 +59,27 @@ type SovereignSelfResponse struct {
 //      stamp the env via a chart-values overlay write.
 //   3. CATALYST_OTECH_FQDN populated but no record yet — return 503.
 //   4. Both env empty AND no record → return 404 (mothership).
-func (h *Handler) HandleSovereignSelf(w http.ResponseWriter, _ *http.Request) {
+func (h *Handler) HandleSovereignSelf(w http.ResponseWriter, r *http.Request) {
 	deploymentID := strings.TrimSpace(os.Getenv("CATALYST_SELF_DEPLOYMENT_ID"))
 	fqdn := strings.TrimSpace(os.Getenv("CATALYST_OTECH_FQDN"))
+
+	// Step 1.5: read the Sovereign session cookie's deployment_id /
+	// sovereign_fqdn claims (populated by auth_handover.go after the
+	// operator follows the handover JWT redirect). The cookie is the
+	// authoritative post-handover source — env vars are populated
+	// only on the slow path via the orchestrator's chart-values
+	// overlay write, which can lag handover by minutes. The store
+	// fallback further requires mother to have POSTed the deployment
+	// record to the Sovereign (not always the case on BYO).
+	// Caught on omantel.biz 2026-05-06.
+	if jwtFQDN, jwtDepID, ok := readSessionClaimsFromCookie(r); ok {
+		if fqdn == "" {
+			fqdn = jwtFQDN
+		}
+		if deploymentID == "" {
+			deploymentID = jwtDepID
+		}
+	}
 
 	// Mothership: neither env is set — surface 404 so the UI hook treats
 	// this as "not on a Sovereign" and uses URL params instead.
@@ -101,4 +122,42 @@ func (h *Handler) HandleSovereignSelf(w http.ResponseWriter, _ *http.Request) {
 		SovereignFQDN: fqdn,
 	})
 }
+
+// readSessionClaimsFromCookie peeks at the catalyst_session cookie's
+// payload (middle base64 segment) and extracts sovereign_fqdn +
+// deployment_id without verifying the signature. This handler is OUTSIDE
+// RequireSession by design (it must serve anonymous bootstrap on
+// Catalyst-Zero), so we do best-effort extraction. On Sovereign mode
+// the catalyst-api is the same process that minted the cookie at
+// /auth/handover, so there's no trust boundary worry — a tampered
+// cookie at most flips deploymentId resolution back to the env path.
+//
+// Returns ok=false on any parse failure (no cookie / malformed JWT /
+// unparseable payload). Caller falls through to the env+store path.
+func readSessionClaimsFromCookie(r *http.Request) (fqdn, deploymentID string, ok bool) {
+	c, err := r.Cookie("catalyst_session")
+	if err != nil || c == nil || c.Value == "" {
+		return "", "", false
+	}
+	parts := strings.Split(c.Value, ".")
+	if len(parts) != 3 {
+		return "", "", false
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return "", "", false
+	}
+	var claims struct {
+		SovereignFQDN string `json:"sovereign_fqdn"`
+		DeploymentID  string `json:"deployment_id"`
+	}
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return "", "", false
+	}
+	return claims.SovereignFQDN, claims.DeploymentID, true
+}
+
+// silence unused-import warning when context isn't directly referenced
+// elsewhere in this file's variable wiring.
+var _ = context.Background
 

--- a/products/catalyst/bootstrap/ui/src/lib/infrastructure.types.ts
+++ b/products/catalyst/bootstrap/ui/src/lib/infrastructure.types.ts
@@ -399,10 +399,15 @@ export async function getNetwork(deploymentId: string): Promise<NetworkResponse>
 export async function getHierarchicalInfrastructure(
   deploymentId: string,
 ): Promise<HierarchicalInfrastructure> {
-  const res = await fetch(
-    `${API_BASE}/v1/deployments/${encodeURIComponent(deploymentId)}/infrastructure/topology`,
-    { headers: { Accept: 'application/json' } },
-  )
+  // Mode-aware: on chroot Sovereign Console (console.<sov-fqdn>) hit
+  // the FQDN-scoped /api/v1/sovereign/topology endpoint instead of the
+  // deployment-keyed mother-side path. The latter 404s with empty
+  // deploymentId on Sovereign mode. Caught on omantel.biz 2026-05-06.
+  let url = `${API_BASE}/v1/deployments/${encodeURIComponent(deploymentId)}/infrastructure/topology`
+  if (typeof window !== 'undefined' && window.location.hostname !== 'console.openova.io') {
+    url = `${API_BASE}/v1/sovereign/topology`
+  }
+  const res = await fetch(url, { headers: { Accept: 'application/json' } })
   if (!res.ok) {
     throw new Error(`topology fetch failed: ${res.status}`)
   }

--- a/products/catalyst/bootstrap/ui/src/pages/admin/user-access/UserAccessListPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/admin/user-access/UserAccessListPage.tsx
@@ -21,6 +21,7 @@
 import { useEffect, useState } from 'react'
 import { Link, useParams } from '@tanstack/react-router'
 import { PortalShell } from '@/pages/sovereign/PortalShell'
+import { useResolvedDeploymentId } from '@/shared/lib/useResolvedDeploymentId'
 import {
   deleteUserAccess,
   grantsSummary,
@@ -41,10 +42,13 @@ export function UserAccessListPage({
   initialItems,
   disableFetch = false,
 }: UserAccessListPageProps = {}) {
-  const params = useParams({ from: '/provision/$deploymentId/users' as never }) as {
-    deploymentId: string
-  }
-  const deploymentId = params.deploymentId
+  // strict:false params + useResolvedDeploymentId so this page works
+  // on BOTH /provision/$deploymentId/users AND the chroot /users
+  // route. Strict-mode useParams throws Invariant on chroot because
+  // the path doesn't match. Caught on omantel.biz 2026-05-06.
+  const params = useParams({ strict: false }) as { deploymentId?: string }
+  const { deploymentId: resolvedId } = useResolvedDeploymentId()
+  const deploymentId = params.deploymentId ?? resolvedId ?? ''
 
   const [items, setItems] = useState<UserAccessItem[]>(initialItems ?? [])
   const [loading, setLoading] = useState<boolean>(!initialItems && !disableFetch)

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail.tsx
@@ -41,6 +41,7 @@ import { useDeploymentEvents } from './useDeploymentEvents'
 import { deriveJobs } from './jobs'
 import { adaptDerivedJobsToFlat } from './jobsAdapter'
 import { findComponent } from '@/pages/wizard/steps/componentGroups'
+import { useResolvedDeploymentId } from '@/shared/lib/useResolvedDeploymentId'
 import type { ApplicationStatus } from './eventReducer'
 
 interface AppDetailProps {
@@ -49,13 +50,18 @@ interface AppDetailProps {
 }
 
 export function AppDetail({ disableStream = false }: AppDetailProps = {}) {
-  const params = useParams({
-    from: '/provision/$deploymentId/app/$componentId' as never,
-  }) as {
-    deploymentId: string
-    componentId: string
+  // Use strict:false params + useResolvedDeploymentId so this page
+  // works on BOTH /provision/$deploymentId/app/$componentId AND the
+  // chroot Sovereign route /app/$componentId. Strict-mode useParams
+  // throws Invariant when the path doesn't match. Caught on
+  // omantel.biz 2026-05-06.
+  const params = useParams({ strict: false }) as {
+    deploymentId?: string
+    componentId?: string
   }
-  const { deploymentId, componentId } = params
+  const { deploymentId: resolvedId } = useResolvedDeploymentId()
+  const deploymentId = params.deploymentId ?? resolvedId ?? ''
+  const componentId = params.componentId ?? ''
   const store = useWizardStore()
 
   const applications = useMemo(

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/CatalogAdminPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/CatalogAdminPage.tsx
@@ -74,7 +74,15 @@ type LoadState =
  * `credentials: 'include'` is set.
  */
 async function fetchApps(): Promise<CatalogApp[]> {
-  const resp = await fetch(`${API_BASE}/catalog/apps`, {
+  // Mode-aware: chroot Sovereign Console uses /api/v1/sovereign/catalog;
+  // mother-side /catalog/apps doesn't exist on Sovereign clusters.
+  // Caught on omantel.biz 2026-05-06.
+  const isSovereignMode =
+    typeof window !== 'undefined' && window.location.hostname !== 'console.openova.io'
+  const url = isSovereignMode
+    ? `${API_BASE}/v1/sovereign/catalog`
+    : `${API_BASE}/catalog/apps`
+  const resp = await fetch(url, {
     method: 'GET',
     credentials: 'include',
     headers: { Accept: 'application/json' },

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/SettingsPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/SettingsPage.tsx
@@ -57,6 +57,7 @@ import { Link, useParams } from '@tanstack/react-router'
 import { PortalShell } from './PortalShell'
 import { useDeploymentEvents } from './useDeploymentEvents'
 import { useWizardStore } from '@/entities/deployment/store'
+import { useResolvedDeploymentId } from '@/shared/lib/useResolvedDeploymentId'
 
 /* ── Constants ──────────────────────────────────────────────────── */
 
@@ -104,10 +105,14 @@ export interface SettingsPageProps {
 }
 
 export function SettingsPage({ disableStream = false }: SettingsPageProps = {}) {
-  const params = useParams({ from: '/provision/$deploymentId/settings' as never }) as {
-    deploymentId: string
-  }
-  const deploymentId = params.deploymentId
+  // Use strict:false params + useResolvedDeploymentId so this page
+  // works on BOTH the mother route (/provision/$deploymentId/settings)
+  // AND the chroot Sovereign route (/settings). Strict-mode useParams
+  // throws Invariant on the chroot route since the path doesn't match.
+  // Caught on omantel.biz 2026-05-06.
+  const params = useParams({ strict: false }) as { deploymentId?: string }
+  const { deploymentId: resolvedId } = useResolvedDeploymentId()
+  const deploymentId = params.deploymentId ?? resolvedId ?? ''
 
   const store = useWizardStore()
 


### PR DESCRIPTION
Comprehensive fix for chroot Sovereign Console DoD gaps on omantel.biz. See commit message for full breakdown. 4 new Sovereign endpoints, 3 useParams fixes (strict:false), 2 mode-aware fetchers, JWT-based deploymentId resolution. Chart 1.4.50.