### PR TITLE
fix(sovereign-topology): return CloudSpec[] not object

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -231,7 +231,7 @@ spec:
       # fallback (data renders the moment cutover-import lands without
       # waiting for the orchestrator's chart-values overlay write).
       # 2026-05-05.
-      version: 1.4.50
+      version: 1.4.51
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/bootstrap/api/internal/handler/sovereign_more.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sovereign_more.go
@@ -190,22 +190,60 @@ func (h *Handler) HandleSovereignSettings(w http.ResponseWriter, r *http.Request
 // On any error returns the well-shaped empty topology so the canvas
 // renders its "Provisioning…" overlay rather than crashing the page.
 
+type hierCloudSpec struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Provider    string `json:"provider"`
+	RegionCount int    `json:"regionCount"`
+	QuotaUsed   int    `json:"quotaUsed"`
+	QuotaLimit  int    `json:"quotaLimit"`
+}
+
+type hierStorageBlock struct {
+	StorageClasses []interface{} `json:"storageClasses"`
+	Pools          []interface{} `json:"pools"`
+	Volumes        []interface{} `json:"volumes"`
+	Buckets        []interface{} `json:"buckets"`
+}
+
+// hierTopologyResponse matches HierarchicalInfrastructure in the UI:
+//   cloud: CloudSpec[]   — array, NOT an object (CloudPage iterates).
+//   topology: { pattern, regions: [...] }
+//   storage: { storageClasses, pools, volumes, buckets }
 type hierTopologyResponse struct {
-	Cloud    map[string]interface{}   `json:"cloud"`
-	Topology map[string]interface{}   `json:"topology"`
+	Cloud    []hierCloudSpec        `json:"cloud"`
+	Topology map[string]interface{} `json:"topology"`
+	Storage  hierStorageBlock       `json:"storage"`
 }
 
 // HandleSovereignTopology — GET /api/v1/sovereign/topology.
 func (h *Handler) HandleSovereignTopology(w http.ResponseWriter, r *http.Request) {
+	provider := strings.TrimSpace(os.Getenv("CATALYST_PROVIDER"))
+	if provider == "" {
+		provider = "hetzner"
+	}
+	region := strings.TrimSpace(os.Getenv("CATALYST_REGION"))
+	cloudSpec := hierCloudSpec{
+		ID:          provider + ":" + region,
+		Name:        provider + " " + region,
+		Provider:    provider,
+		RegionCount: 1,
+		QuotaUsed:   0,
+		QuotaLimit:  0,
+	}
+	emptyStorage := hierStorageBlock{
+		StorageClasses: []interface{}{},
+		Pools:          []interface{}{},
+		Volumes:        []interface{}{},
+		Buckets:        []interface{}{},
+	}
 	emptyResp := hierTopologyResponse{
-		Cloud: map[string]interface{}{
-			"provider":       strings.TrimSpace(os.Getenv("CATALYST_PROVIDER")),
-			"providerRegion": strings.TrimSpace(os.Getenv("CATALYST_REGION")),
-		},
+		Cloud: []hierCloudSpec{cloudSpec},
 		Topology: map[string]interface{}{
 			"pattern": "solo",
 			"regions": []interface{}{},
 		},
+		Storage: emptyStorage,
 	}
 
 	deps, err := h.sovereignDepsFor()
@@ -278,7 +316,7 @@ func (h *Handler) HandleSovereignTopology(w http.ResponseWriter, r *http.Request
 		"status":        "healthy",
 	}
 
-	region := map[string]interface{}{
+	regionMap := map[string]interface{}{
 		"id":          strings.TrimSpace(os.Getenv("CATALYST_REGION")),
 		"name":        strings.TrimSpace(os.Getenv("CATALYST_REGION")),
 		"provider":    strings.TrimSpace(os.Getenv("CATALYST_PROVIDER")),
@@ -291,8 +329,9 @@ func (h *Handler) HandleSovereignTopology(w http.ResponseWriter, r *http.Request
 		Cloud: emptyResp.Cloud,
 		Topology: map[string]interface{}{
 			"pattern": "solo",
-			"regions": []interface{}{region},
+			"regions": []interface{}{regionMap},
 		},
+		Storage: emptyStorage,
 	}
 	writeJSON(w, http.StatusOK, resp)
 }

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -124,8 +124,8 @@ name: bp-catalyst-platform
 # otech113 2026-05-05 — chart 0.1.18 fixed the readiness-probe loop
 # but every trigger immediately got 502 in <10ms (synchronous
 # apiserver permission rejection). 2026-05-05.
-version: 1.4.50
-appVersion: 1.4.50
+version: 1.4.51
+appVersion: 1.4.51
 description: |
   Catalyst Platform — the unified Catalyst control plane umbrella chart for Catalyst-Zero.
   Composes the catalyst-{ui,api}, console, admin, marketplace UI modules and the marketplace-api backend.


### PR DESCRIPTION
CloudPage threw TypeError on iterating cloud. Server now returns the proper HierarchicalInfrastructure shape. Chart 1.4.51.