### PR TITLE
fix(jobs/jobdetail): URL-encode live job ids + strict:false params

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -231,7 +231,7 @@ spec:
       # fallback (data renders the moment cutover-import lands without
       # waiting for the orchestrator's chart-values overlay write).
       # 2026-05-05.
-      version: 1.4.51
+      version: 1.4.52
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/JobDetail.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/JobDetail.tsx
@@ -45,6 +45,7 @@ import { useWizardStore } from '@/entities/deployment/store'
 import { PortalShell } from './PortalShell'
 import { resolveApplications } from './applicationCatalog'
 import { useDeploymentEvents } from './useDeploymentEvents'
+import { useResolvedDeploymentId } from '@/shared/lib/useResolvedDeploymentId'
 import { deriveJobs, fmtTime, statusBadge } from './jobs'
 import type { Job as DerivedJob, JobUiStatus, JobStep } from './jobs'
 import { adaptDerivedJobsToFlat } from './jobsAdapter'
@@ -66,10 +67,19 @@ export function JobDetail({
   disableStream = false,
   disableJobsBackfill = false,
 }: JobDetailProps = {}) {
-  const params = useParams({
-    from: '/provision/$deploymentId/jobs/$jobId' as never,
-  }) as { deploymentId: string; jobId: string }
-  const { deploymentId, jobId } = params
+  // strict:false params + useResolvedDeploymentId so this page works
+  // on BOTH /provision/$deploymentId/jobs/$jobId AND the chroot
+  // Sovereign route /jobs/$jobId. Strict-mode useParams throws
+  // Invariant on chroot. Caught on omantel.biz 2026-05-06.
+  const params = useParams({ strict: false }) as { deploymentId?: string; jobId?: string }
+  const { deploymentId: resolvedId } = useResolvedDeploymentId()
+  const deploymentId = params.deploymentId ?? resolvedId ?? ''
+  // Decode in case the link source URL-encoded the id (live K8s job
+  // ids contain `/`).
+  const rawJobId = params.jobId ?? ''
+  const jobId = (() => {
+    try { return decodeURIComponent(rawJobId) } catch { return rawJobId }
+  })()
   const store = useWizardStore()
 
   const applications = useMemo(

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/JobsTable.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/JobsTable.tsx
@@ -365,10 +365,17 @@ function useJobLinkBuilder(): (jobId: string) => string {
   const params = useParams({ strict: false }) as { deploymentId?: string }
   const isSovereign = DETECTED_MODE.mode === 'sovereign'
   const depId = params.deploymentId ?? ''
-  return (jobId: string) =>
-    isSovereign || !depId
-      ? `/jobs/${jobId}`
-      : `/provision/${depId}/jobs/${jobId}`
+  // URL-encode the jobId so live K8s job ids that contain `/`
+  // (e.g. "job/syft-grype/syft-grype-bp-syft-grype-29633910" from
+  // /api/v1/sovereign/jobs) don't fragment the route. tan-stack's
+  // `/jobs/$jobId` matches a single path segment and would 404 on
+  // multi-segment ids. Caught on omantel.biz 2026-05-06.
+  return (jobId: string) => {
+    const encoded = encodeURIComponent(jobId)
+    return isSovereign || !depId
+      ? `/jobs/${encoded}`
+      : `/provision/${depId}/jobs/${encoded}`
+  }
 }
 
 function JobRow({ job, parentLabel }: JobRowProps) {

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -124,8 +124,8 @@ name: bp-catalyst-platform
 # otech113 2026-05-05 — chart 0.1.18 fixed the readiness-probe loop
 # but every trigger immediately got 502 in <10ms (synchronous
 # apiserver permission rejection). 2026-05-05.
-version: 1.4.51
-appVersion: 1.4.51
+version: 1.4.52
+appVersion: 1.4.52
 description: |
   Catalyst Platform — the unified Catalyst control plane umbrella chart for Catalyst-Zero.
   Composes the catalyst-{ui,api}, console, admin, marketplace UI modules and the marketplace-api backend.


### PR DESCRIPTION
Live job ids contain '/' which broke the /jobs/$jobId route. Encode in link builder + decode in JobDetail. Also fix JobDetail strict useParams. Chart 1.4.52.