### PR TITLE
fix(cloud-page): defensive normalize + try/catch fallback

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -231,7 +231,7 @@ spec:
       # fallback (data renders the moment cutover-import lands without
       # waiting for the orchestrator's chart-values overlay write).
       # 2026-05-05.
-      version: 1.4.52
+      version: 1.4.53
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/CloudPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/CloudPage.tsx
@@ -231,43 +231,75 @@ export function CloudPage({
       topologyQuery.data ??
       (topologyQuery.isError ? infrastructureTopologyFixture : null)
     if (!raw) return null
-    return {
-      cloud: raw.cloud ?? inferCloudFromTopology(raw.topology),
-      topology: {
-        pattern: raw.topology?.pattern ?? 'solo',
-        regions: (raw.topology?.regions ?? []).map((r) => ({
-          ...r,
-          clusters: (r.clusters ?? []).map((c) => ({
-            ...c,
-            vclusters: c.vclusters ?? [],
-            loadBalancers: (c.loadBalancers ?? []).map((lb) => ({
-              ...lb,
-              listeners:
-                lb.listeners ??
-                (typeof (lb as unknown as { ports?: string }).ports === 'string'
-                  ? ((lb as unknown as { ports: string }).ports || '')
-                      .split(',')
-                      .map((p) => p.trim())
-                      .filter(Boolean)
-                      .map((p) => ({ port: parseInt(p, 10), protocol: 'tcp' }))
-                  : []),
-              targets: lb.targets ?? [],
+    // Defensive guards — Sovereign-mode /api/v1/sovereign/topology may
+    // return slimmer node/cluster/region shapes than the wizard's
+    // mother-side endpoint. Coerce every nested array to the full
+    // shape so downstream count/lookup code never reads .length on
+    // undefined. Caught on omantel.biz 2026-05-06.
+    try {
+      return {
+        cloud: Array.isArray(raw.cloud) && raw.cloud.length > 0
+          ? raw.cloud
+          : inferCloudFromTopology(raw.topology),
+        topology: {
+          pattern: raw.topology?.pattern ?? 'solo',
+          regions: (raw.topology?.regions ?? []).map((r: any) => ({
+            id: r?.id ?? '',
+            name: r?.name ?? '',
+            provider: r?.provider ?? '',
+            workerCount: r?.workerCount ?? 0,
+            ...r,
+            clusters: (r?.clusters ?? []).map((c: any) => ({
+              id: c?.id ?? '',
+              name: c?.name ?? '',
+              version: c?.version ?? '',
+              status: c?.status ?? 'unknown',
+              ...c,
+              vclusters: c?.vclusters ?? [],
+              loadBalancers: (c?.loadBalancers ?? []).map((lb: any) => ({
+                ...lb,
+                listeners:
+                  lb?.listeners ??
+                  (typeof (lb as unknown as { ports?: string })?.ports === 'string'
+                    ? ((lb as unknown as { ports: string }).ports || '')
+                        .split(',')
+                        .map((p) => p.trim())
+                        .filter(Boolean)
+                        .map((p) => ({ port: parseInt(p, 10), protocol: 'tcp' }))
+                    : []),
+                targets: lb?.targets ?? [],
+              })),
+              nodePools: c?.nodePools ?? [],
+              nodes: (c?.nodes ?? []).map((n: any) => ({
+                region: n?.region ?? r?.id ?? '',
+                ...n,
+              })),
             })),
-            nodePools: c.nodePools ?? [],
-            nodes: c.nodes ?? [],
+            networks: (r?.networks ?? []).map((n: any) => ({
+              id: n?.id ?? '',
+              name: n?.name ?? '',
+              ...n,
+              peerings: n?.peerings ?? [],
+              firewalls: n?.firewalls ?? [],
+            })),
           })),
-          networks: (r.networks ?? []).map((n) => ({
-            ...n,
-            peerings: n.peerings ?? [],
-            firewalls: n.firewalls ?? [],
-          })),
-        })),
-      },
-      storage: {
-        pvcs: raw.storage?.pvcs ?? [],
-        buckets: raw.storage?.buckets ?? [],
-        volumes: raw.storage?.volumes ?? [],
-      },
+        },
+        storage: {
+          pvcs: raw.storage?.pvcs ?? [],
+          buckets: raw.storage?.buckets ?? [],
+          volumes: raw.storage?.volumes ?? [],
+        },
+      }
+    } catch (err) {
+      // Last-resort fallback — if any unexpected shape mismatch
+      // throws here, render an empty topology rather than crashing
+      // the entire /cloud page with the React error boundary.
+      console.warn('[CloudPage] data normalize threw, using empty fallback:', err)
+      return {
+        cloud: [],
+        topology: { pattern: 'solo', regions: [] },
+        storage: { pvcs: [], buckets: [], volumes: [] },
+      } as unknown as HierarchicalInfrastructure
     }
   }, [initialDataOverride, topologyQuery.data, topologyQuery.isError])
 

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -124,8 +124,8 @@ name: bp-catalyst-platform
 # otech113 2026-05-05 — chart 0.1.18 fixed the readiness-probe loop
 # but every trigger immediately got 502 in <10ms (synchronous
 # apiserver permission rejection). 2026-05-05.
-version: 1.4.52
-appVersion: 1.4.52
+version: 1.4.53
+appVersion: 1.4.53
 description: |
   Catalyst Platform — the unified Catalyst control plane umbrella chart for Catalyst-Zero.
   Composes the catalyst-{ui,api}, console, admin, marketplace UI modules and the marketplace-api backend.


### PR DESCRIPTION
/cloud crashed with 'reading length' on omantel.biz because Sovereign-mode topology shape lacks some optional fields the wizard normalize assumed. Defensive nullish + try/catch fallback. Chart 1.4.53.