### PR TITLE
fix(architecture-graph): try/catch adapter calls

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -231,7 +231,7 @@ spec:
       # fallback (data renders the moment cutover-import lands without
       # waiting for the orchestrator's chart-values overlay write).
       # 2026-05-05.
-      version: 1.4.53
+      version: 1.4.54
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/bootstrap/ui/src/widgets/architecture-graph/ArchitectureGraphPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/widgets/architecture-graph/ArchitectureGraphPage.tsx
@@ -203,8 +203,25 @@ export function ArchitectureGraphPage({
 
   /* ── 1. Adapter — tree → nodes/edges, merged with K8s side ─── */
   const { nodes: allNodes, edges: allEdges } = useMemo(() => {
-    const cloud = hierarchyToGraph(data)
-    const k8s = k8sToGraph(k8sSnapshot)
+    // hierarchyToGraph reads many nested fields that the Sovereign
+    // chroot /api/v1/sovereign/topology shape may not carry (legacy
+    // assumes mother-side shape). Wrap in try/catch so a missing
+    // field never crashes the entire /cloud page via the React
+    // error boundary. Caught on omantel.biz 2026-05-06.
+    let cloud: { nodes: GraphNode[]; edges: GraphEdge[] }
+    try {
+      cloud = hierarchyToGraph(data)
+    } catch (err) {
+      console.warn('[ArchitectureGraph] hierarchyToGraph threw, using empty:', err)
+      cloud = { nodes: [], edges: [] }
+    }
+    let k8s: { nodes: GraphNode[]; edges: GraphEdge[] }
+    try {
+      k8s = k8sToGraph(k8sSnapshot)
+    } catch (err) {
+      console.warn('[ArchitectureGraph] k8sToGraph threw, using empty:', err)
+      k8s = { nodes: [], edges: [] }
+    }
     return mergeGraphs(cloud, k8s)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [data, k8sRevision])

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -124,8 +124,8 @@ name: bp-catalyst-platform
 # otech113 2026-05-05 — chart 0.1.18 fixed the readiness-probe loop
 # but every trigger immediately got 502 in <10ms (synchronous
 # apiserver permission rejection). 2026-05-05.
-version: 1.4.53
-appVersion: 1.4.53
+version: 1.4.54
+appVersion: 1.4.54
 description: |
   Catalyst Platform — the unified Catalyst control plane umbrella chart for Catalyst-Zero.
   Composes the catalyst-{ui,api}, console, admin, marketplace UI modules and the marketplace-api backend.


### PR DESCRIPTION
Wrap hierarchyToGraph + k8sToGraph in try/catch in ArchitectureGraphPage so a Sovereign-mode shape mismatch falls through to empty graph rather than crashing /cloud. Chart 1.4.54.