### PR TITLE
fix(graphcanvas): defensive label render + adapter never-undefined labels

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -231,7 +231,7 @@ spec:
       # fallback (data renders the moment cutover-import lands without
       # waiting for the orchestrator's chart-values overlay write).
       # 2026-05-05.
-      version: 1.4.54
+      version: 1.4.55
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/bootstrap/ui/src/widgets/architecture-graph/GraphCanvas.tsx
+++ b/products/catalyst/bootstrap/ui/src/widgets/architecture-graph/GraphCanvas.tsx
@@ -972,7 +972,10 @@ export const GraphCanvas = forwardRef<GraphCanvasHandle, GraphCanvasProps>(funct
                   fill="var(--color-text)"
                   style={{ pointerEvents: 'none' }}
                 >
-                  {n.label.length > 24 ? n.label.slice(0, 23) + '…' : n.label}
+                  {(() => {
+                    const lbl = n.label ?? ''
+                    return lbl.length > 24 ? lbl.slice(0, 23) + '…' : lbl
+                  })()}
                 </text>
               </g>
             )

--- a/products/catalyst/bootstrap/ui/src/widgets/architecture-graph/adapter.ts
+++ b/products/catalyst/bootstrap/ui/src/widgets/architecture-graph/adapter.ts
@@ -127,8 +127,8 @@ function addRegion(
   nodes.push({
     id: regionId,
     type: 'Region',
-    label: region.name || region.providerRegion,
-    sublabel: `${region.provider} · ${region.providerRegion}`,
+    label: region.name || region.providerRegion || region.id || 'region',
+    sublabel: `${region.provider ?? ''} · ${region.providerRegion ?? ''}`,
     status: region.status,
     metadata: {
       provider: region.provider,
@@ -188,13 +188,13 @@ function addCluster(
   nodes.push({
     id: clusterId,
     type: 'Cluster',
-    label: cluster.name,
-    sublabel: cluster.version,
+    label: cluster.name || cluster.id || 'cluster',
+    sublabel: cluster.version ?? '',
     status: cluster.status,
     metadata: {
-      version: cluster.version,
-      nodes: String(cluster.nodeCount),
-      vclusters: String(cluster.vclusters.length),
+      version: cluster.version ?? '',
+      nodes: String(cluster.nodeCount ?? 0),
+      vclusters: String((cluster.vclusters ?? []).length),
     },
   })
   edges.push({

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -124,8 +124,8 @@ name: bp-catalyst-platform
 # otech113 2026-05-05 — chart 0.1.18 fixed the readiness-probe loop
 # but every trigger immediately got 502 in <10ms (synchronous
 # apiserver permission rejection). 2026-05-05.
-version: 1.4.54
-appVersion: 1.4.54
+version: 1.4.55
+appVersion: 1.4.55
 description: |
   Catalyst Platform — the unified Catalyst control plane umbrella chart for Catalyst-Zero.
   Composes the catalyst-{ui,api}, console, admin, marketplace UI modules and the marketplace-api backend.


### PR DESCRIPTION
Last-row red on /cloud DoD: GraphCanvas crashed on undefined label. Defensive coerce + adapter fallback. Chart 1.4.55.