### PR TITLE
fix(catalyst-api): rip out dangling sovereign_* refs + chart 1.4.56

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -231,7 +231,7 @@ spec:
       # fallback (data renders the moment cutover-import lands without
       # waiting for the orchestrator's chart-values overlay write).
       # 2026-05-05.
-      version: 1.4.55
+      version: 1.4.56
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/bootstrap/api/cmd/api/main.go
+++ b/products/catalyst/bootstrap/api/cmd/api/main.go
@@ -687,10 +687,6 @@ func main() {
 		rg.Get("/api/v1/sovereign/jobs", h.HandleSovereignJobs)
 		rg.Get("/api/v1/sovereign/apps", h.HandleSovereignApps)
 		rg.Get("/api/v1/sovereign/cloud", h.HandleSovereignCloud)
-		rg.Get("/api/v1/sovereign/users", h.HandleSovereignUsers)
-		rg.Get("/api/v1/sovereign/catalog", h.HandleSovereignCatalog)
-		rg.Get("/api/v1/sovereign/settings", h.HandleSovereignSettings)
-		rg.Get("/api/v1/sovereign/topology", h.HandleSovereignTopology)
 
 		// Self-Sovereignty Cutover (issue #792 — parent epic #790). The
 		// post-handover step that severs a Sovereign's remaining

--- a/products/catalyst/bootstrap/ui/src/lib/infrastructure.types.ts
+++ b/products/catalyst/bootstrap/ui/src/lib/infrastructure.types.ts
@@ -399,15 +399,10 @@ export async function getNetwork(deploymentId: string): Promise<NetworkResponse>
 export async function getHierarchicalInfrastructure(
   deploymentId: string,
 ): Promise<HierarchicalInfrastructure> {
-  // Mode-aware: on chroot Sovereign Console (console.<sov-fqdn>) hit
-  // the FQDN-scoped /api/v1/sovereign/topology endpoint instead of the
-  // deployment-keyed mother-side path. The latter 404s with empty
-  // deploymentId on Sovereign mode. Caught on omantel.biz 2026-05-06.
-  let url = `${API_BASE}/v1/deployments/${encodeURIComponent(deploymentId)}/infrastructure/topology`
-  if (typeof window !== 'undefined' && window.location.hostname !== 'console.openova.io') {
-    url = `${API_BASE}/v1/sovereign/topology`
-  }
-  const res = await fetch(url, { headers: { Accept: 'application/json' } })
+  const res = await fetch(
+    `${API_BASE}/v1/deployments/${encodeURIComponent(deploymentId)}/infrastructure/topology`,
+    { headers: { Accept: 'application/json' } },
+  )
   if (!res.ok) {
     throw new Error(`topology fetch failed: ${res.status}`)
   }

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/CatalogAdminPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/CatalogAdminPage.tsx
@@ -74,15 +74,7 @@ type LoadState =
  * `credentials: 'include'` is set.
  */
 async function fetchApps(): Promise<CatalogApp[]> {
-  // Mode-aware: chroot Sovereign Console uses /api/v1/sovereign/catalog;
-  // mother-side /catalog/apps doesn't exist on Sovereign clusters.
-  // Caught on omantel.biz 2026-05-06.
-  const isSovereignMode =
-    typeof window !== 'undefined' && window.location.hostname !== 'console.openova.io'
-  const url = isSovereignMode
-    ? `${API_BASE}/v1/sovereign/catalog`
-    : `${API_BASE}/catalog/apps`
-  const resp = await fetch(url, {
+  const resp = await fetch(`${API_BASE}/catalog/apps`, {
     method: 'GET',
     credentials: 'include',
     headers: { Accept: 'application/json' },

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -124,8 +124,8 @@ name: bp-catalyst-platform
 # otech113 2026-05-05 — chart 0.1.18 fixed the readiness-probe loop
 # but every trigger immediately got 502 in <10ms (synchronous
 # apiserver permission rejection). 2026-05-05.
-version: 1.4.55
-appVersion: 1.4.55
+version: 1.4.56
+appVersion: 1.4.56
 description: |
   Catalyst Platform — the unified Catalyst control plane umbrella chart for Catalyst-Zero.
   Composes the catalyst-{ui,api}, console, admin, marketplace UI modules and the marketplace-api backend.


### PR DESCRIPTION
## Why

PR #1050 deleted `sovereign_more.go` but left four route registrations in `cmd/api/main.go` that still referenced the deleted handler methods (`HandleSovereignUsers/Catalog/Settings/Topology`). The catalyst-api build for the merged revert (run 25439549879) failed:

```
cmd/api/main.go:690:39: h.HandleSovereignUsers undefined
cmd/api/main.go:691:41: h.HandleSovereignCatalog undefined
cmd/api/main.go:692:42: h.HandleSovereignSettings undefined
cmd/api/main.go:693:42: h.HandleSovereignTopology undefined
```

`ghcr.io/openova-io/openova/catalyst-api:fdd3354` never published. omantel.biz catalyst-api pod is stuck in `ImagePullBackOff`.

## What

- Drop the four dangling route registrations.
- Revert two more parallel-baby fragments still on main:
  - `getHierarchicalInfrastructure` mode-aware fetcher → single mother URL.
  - `CatalogAdminPage.fetchApps` mode-aware → `/catalog/apps` everywhere.
- Bump bp-catalyst-platform chart 1.4.55 → 1.4.56 and the cluster Kustomization pin.

Same baby, new address — chroot Sovereign uses the existing `/api/v1/deployments/{depId}/*` handlers via the JWT-resolved deploymentId.

## Verification

- [ ] CI build-api succeeds
- [ ] CI build-ui succeeds
- [ ] CI deploy job commits new SHAs
- [ ] omantel pods roll past `ImagePullBackOff`
- [ ] Validator: 9-route Playwright sweep on `console.omantel.biz` returns all-green twice in a row