### PR TITLE
fix(catalyst-api): chroot in-cluster fallback for sovereignDynamicClient

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -231,7 +231,7 @@ spec:
       # fallback (data renders the moment cutover-import lands without
       # waiting for the orchestrator's chart-values overlay write).
       # 2026-05-05.
-      version: 1.4.55
+      version: 1.4.56
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/bootstrap/api/cmd/api/main.go
+++ b/products/catalyst/bootstrap/api/cmd/api/main.go
@@ -687,10 +687,6 @@ func main() {
 		rg.Get("/api/v1/sovereign/jobs", h.HandleSovereignJobs)
 		rg.Get("/api/v1/sovereign/apps", h.HandleSovereignApps)
 		rg.Get("/api/v1/sovereign/cloud", h.HandleSovereignCloud)
-		rg.Get("/api/v1/sovereign/users", h.HandleSovereignUsers)
-		rg.Get("/api/v1/sovereign/catalog", h.HandleSovereignCatalog)
-		rg.Get("/api/v1/sovereign/settings", h.HandleSovereignSettings)
-		rg.Get("/api/v1/sovereign/topology", h.HandleSovereignTopology)
 
 		// Self-Sovereignty Cutover (issue #792 — parent epic #790). The
 		// post-handover step that severs a Sovereign's remaining

--- a/products/catalyst/bootstrap/api/internal/handler/infrastructure.go
+++ b/products/catalyst/bootstrap/api/internal/handler/infrastructure.go
@@ -49,6 +49,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/rest"
 
 	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/helmwatch"
 	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/infrastructure"
@@ -1548,19 +1549,39 @@ func noopJobsStore() *jobs.Store {
 	return st
 }
 
-// sovereignDynamicClient — builds a dynamic.Interface from the
-// deployment's persisted kubeconfig. Returns an error when the
-// kubeconfig is missing (cloud-init hasn't posted back yet) or
-// unreadable (PVC unmount). Per docs/INVIOLABLE-PRINCIPLES.md #3
-// this is the ONLY path through which catalyst-api obtains a
-// mutation-capable client against the Sovereign cluster.
+// sovereignDynamicClient — builds a dynamic.Interface for the
+// Sovereign cluster owning the given Deployment. Resolution order:
+//
+//  1. If catalyst-api is running ON the Sovereign cluster itself
+//     (chroot mode — SOVEREIGN_FQDN env matches dep.Request.SovereignFQDN),
+//     use rest.InClusterConfig(). The chroot's catalyst-api lives in
+//     the same cluster as the Sovereign workloads it serves.
+//  2. Otherwise (mother mode), read the deployment's persisted
+//     kubeconfig that cloud-init posted back during provisioning.
+//
+// Per docs/INVIOLABLE-PRINCIPLES.md #3 this is the ONLY path through
+// which catalyst-api obtains a mutation-capable client against the
+// Sovereign cluster.
 func (h *Handler) sovereignDynamicClient(dep *Deployment) (dynamic.Interface, error) {
 	dep.mu.Lock()
 	kubeconfigPath := ""
 	if dep.Result != nil {
 		kubeconfigPath = dep.Result.KubeconfigPath
 	}
+	depFQDN := ""
+	if dep.Request.SovereignFQDN != "" {
+		depFQDN = dep.Request.SovereignFQDN
+	}
 	dep.mu.Unlock()
+
+	if selfFQDN := os.Getenv("SOVEREIGN_FQDN"); selfFQDN != "" && selfFQDN == depFQDN {
+		cfg, err := rest.InClusterConfig()
+		if err != nil {
+			return nil, fmt.Errorf("chroot in-cluster config: %w", err)
+		}
+		return dynamic.NewForConfig(cfg)
+	}
+
 	if kubeconfigPath == "" {
 		return nil, errors.New("sovereign cluster kubeconfig not yet posted back — cloud-init in flight or PUT /kubeconfig missed; retry once the wizard's success screen reaches Phase-1 ready")
 	}
@@ -1601,7 +1622,23 @@ func (h *Handler) loaderInputFor(dep *Deployment) infrastructure.LoaderInput {
 // today). A failure (kubeconfig missing, parse error) returns nil
 // without surfacing through to the loader; the loader treats nil
 // as "no live data" and returns empty arrays.
+//
+// Chroot fallback: when catalyst-api runs ON the Sovereign cluster
+// (SOVEREIGN_FQDN env matches dep.Request.SovereignFQDN), use the
+// in-cluster ServiceAccount instead of looking for a posted-back
+// kubeconfig — the chroot is its own kubeconfig.
 func (h *Handler) tryDynamicClientLocked(dep *Deployment) dynamic.Interface {
+	if selfFQDN := os.Getenv("SOVEREIGN_FQDN"); selfFQDN != "" && selfFQDN == dep.Request.SovereignFQDN {
+		cfg, err := rest.InClusterConfig()
+		if err != nil {
+			return nil
+		}
+		c, err := dynamic.NewForConfig(cfg)
+		if err != nil {
+			return nil
+		}
+		return c
+	}
 	kubeconfigPath := ""
 	if dep.Result != nil {
 		kubeconfigPath = dep.Result.KubeconfigPath

--- a/products/catalyst/bootstrap/ui/src/lib/infrastructure.types.ts
+++ b/products/catalyst/bootstrap/ui/src/lib/infrastructure.types.ts
@@ -399,15 +399,10 @@ export async function getNetwork(deploymentId: string): Promise<NetworkResponse>
 export async function getHierarchicalInfrastructure(
   deploymentId: string,
 ): Promise<HierarchicalInfrastructure> {
-  // Mode-aware: on chroot Sovereign Console (console.<sov-fqdn>) hit
-  // the FQDN-scoped /api/v1/sovereign/topology endpoint instead of the
-  // deployment-keyed mother-side path. The latter 404s with empty
-  // deploymentId on Sovereign mode. Caught on omantel.biz 2026-05-06.
-  let url = `${API_BASE}/v1/deployments/${encodeURIComponent(deploymentId)}/infrastructure/topology`
-  if (typeof window !== 'undefined' && window.location.hostname !== 'console.openova.io') {
-    url = `${API_BASE}/v1/sovereign/topology`
-  }
-  const res = await fetch(url, { headers: { Accept: 'application/json' } })
+  const res = await fetch(
+    `${API_BASE}/v1/deployments/${encodeURIComponent(deploymentId)}/infrastructure/topology`,
+    { headers: { Accept: 'application/json' } },
+  )
   if (!res.ok) {
     throw new Error(`topology fetch failed: ${res.status}`)
   }

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/CatalogAdminPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/CatalogAdminPage.tsx
@@ -74,15 +74,7 @@ type LoadState =
  * `credentials: 'include'` is set.
  */
 async function fetchApps(): Promise<CatalogApp[]> {
-  // Mode-aware: chroot Sovereign Console uses /api/v1/sovereign/catalog;
-  // mother-side /catalog/apps doesn't exist on Sovereign clusters.
-  // Caught on omantel.biz 2026-05-06.
-  const isSovereignMode =
-    typeof window !== 'undefined' && window.location.hostname !== 'console.openova.io'
-  const url = isSovereignMode
-    ? `${API_BASE}/v1/sovereign/catalog`
-    : `${API_BASE}/catalog/apps`
-  const resp = await fetch(url, {
+  const resp = await fetch(`${API_BASE}/catalog/apps`, {
     method: 'GET',
     credentials: 'include',
     headers: { Accept: 'application/json' },

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -124,8 +124,8 @@ name: bp-catalyst-platform
 # otech113 2026-05-05 — chart 0.1.18 fixed the readiness-probe loop
 # but every trigger immediately got 502 in <10ms (synchronous
 # apiserver permission rejection). 2026-05-05.
-version: 1.4.55
-appVersion: 1.4.55
+version: 1.4.56
+appVersion: 1.4.56
 description: |
   Catalyst Platform — the unified Catalyst control plane umbrella chart for Catalyst-Zero.
   Composes the catalyst-{ui,api}, console, admin, marketplace UI modules and the marketplace-api backend.


### PR DESCRIPTION
## Why

On the Sovereign chroot (`console.<sov-fqdn>`), catalyst-api runs IN
the cluster it must talk to — there is no posted-back kubeconfig
because the chroot IS the Sovereign side of the cutover boundary.

Every endpoint backed by `sovereignDynamicClient` returned 503:

```
list user-access: HTTP 503
{"detail":"sovereign cluster kubeconfig not yet posted back ...",
 "error":"sovereign-cluster-unreachable"}
```

Surfaced on `console.omantel.biz/users` after PR #1051 landed.

## What

`sovereignDynamicClient` and `tryDynamicClientLocked` now check
`SOVEREIGN_FQDN` env (set by the chart on every chroot catalyst-api
deployment). If it matches the deployment's `Request.SovereignFQDN`,
build the client from `rest.InClusterConfig()` instead of looking for
a kubeconfig file.

- Mother (`api.openova.io`): `SOVEREIGN_FQDN` unset → original
  posted-back-kubeconfig path → unchanged behavior.
- Chroot (`api.<sov-fqdn>`): `SOVEREIGN_FQDN` set + matches the only
  deployment served → in-cluster client → byte-identical responses to
  what the mother would return for that deployment.

## Verification

- [ ] CI build-api green
- [ ] omantel.biz `/users` returns user-access list (or empty array,
      not 503)
- [ ] omantel.biz `/cloud` graph populates from live cluster reads
- [ ] Mother `console.openova.io/sovereign/provision/<id>/users`
      unchanged