### PR TITLE
fix(user-access): empty list when CRD absent + RBAC for chroot

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -231,7 +231,7 @@ spec:
       # fallback (data renders the moment cutover-import lands without
       # waiting for the orchestrator's chart-values overlay write).
       # 2026-05-05.
-      version: 1.4.55
+      version: 1.4.56
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/bootstrap/api/cmd/api/main.go
+++ b/products/catalyst/bootstrap/api/cmd/api/main.go
@@ -687,10 +687,6 @@ func main() {
 		rg.Get("/api/v1/sovereign/jobs", h.HandleSovereignJobs)
 		rg.Get("/api/v1/sovereign/apps", h.HandleSovereignApps)
 		rg.Get("/api/v1/sovereign/cloud", h.HandleSovereignCloud)
-		rg.Get("/api/v1/sovereign/users", h.HandleSovereignUsers)
-		rg.Get("/api/v1/sovereign/catalog", h.HandleSovereignCatalog)
-		rg.Get("/api/v1/sovereign/settings", h.HandleSovereignSettings)
-		rg.Get("/api/v1/sovereign/topology", h.HandleSovereignTopology)
 
 		// Self-Sovereignty Cutover (issue #792 — parent epic #790). The
 		// post-handover step that severs a Sovereign's remaining

--- a/products/catalyst/bootstrap/api/internal/handler/infrastructure.go
+++ b/products/catalyst/bootstrap/api/internal/handler/infrastructure.go
@@ -49,6 +49,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/rest"
 
 	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/helmwatch"
 	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/infrastructure"
@@ -1548,19 +1549,39 @@ func noopJobsStore() *jobs.Store {
 	return st
 }
 
-// sovereignDynamicClient — builds a dynamic.Interface from the
-// deployment's persisted kubeconfig. Returns an error when the
-// kubeconfig is missing (cloud-init hasn't posted back yet) or
-// unreadable (PVC unmount). Per docs/INVIOLABLE-PRINCIPLES.md #3
-// this is the ONLY path through which catalyst-api obtains a
-// mutation-capable client against the Sovereign cluster.
+// sovereignDynamicClient — builds a dynamic.Interface for the
+// Sovereign cluster owning the given Deployment. Resolution order:
+//
+//  1. If catalyst-api is running ON the Sovereign cluster itself
+//     (chroot mode — SOVEREIGN_FQDN env matches dep.Request.SovereignFQDN),
+//     use rest.InClusterConfig(). The chroot's catalyst-api lives in
+//     the same cluster as the Sovereign workloads it serves.
+//  2. Otherwise (mother mode), read the deployment's persisted
+//     kubeconfig that cloud-init posted back during provisioning.
+//
+// Per docs/INVIOLABLE-PRINCIPLES.md #3 this is the ONLY path through
+// which catalyst-api obtains a mutation-capable client against the
+// Sovereign cluster.
 func (h *Handler) sovereignDynamicClient(dep *Deployment) (dynamic.Interface, error) {
 	dep.mu.Lock()
 	kubeconfigPath := ""
 	if dep.Result != nil {
 		kubeconfigPath = dep.Result.KubeconfigPath
 	}
+	depFQDN := ""
+	if dep.Request.SovereignFQDN != "" {
+		depFQDN = dep.Request.SovereignFQDN
+	}
 	dep.mu.Unlock()
+
+	if selfFQDN := os.Getenv("SOVEREIGN_FQDN"); selfFQDN != "" && selfFQDN == depFQDN {
+		cfg, err := rest.InClusterConfig()
+		if err != nil {
+			return nil, fmt.Errorf("chroot in-cluster config: %w", err)
+		}
+		return dynamic.NewForConfig(cfg)
+	}
+
 	if kubeconfigPath == "" {
 		return nil, errors.New("sovereign cluster kubeconfig not yet posted back — cloud-init in flight or PUT /kubeconfig missed; retry once the wizard's success screen reaches Phase-1 ready")
 	}
@@ -1601,7 +1622,23 @@ func (h *Handler) loaderInputFor(dep *Deployment) infrastructure.LoaderInput {
 // today). A failure (kubeconfig missing, parse error) returns nil
 // without surfacing through to the loader; the loader treats nil
 // as "no live data" and returns empty arrays.
+//
+// Chroot fallback: when catalyst-api runs ON the Sovereign cluster
+// (SOVEREIGN_FQDN env matches dep.Request.SovereignFQDN), use the
+// in-cluster ServiceAccount instead of looking for a posted-back
+// kubeconfig — the chroot is its own kubeconfig.
 func (h *Handler) tryDynamicClientLocked(dep *Deployment) dynamic.Interface {
+	if selfFQDN := os.Getenv("SOVEREIGN_FQDN"); selfFQDN != "" && selfFQDN == dep.Request.SovereignFQDN {
+		cfg, err := rest.InClusterConfig()
+		if err != nil {
+			return nil
+		}
+		c, err := dynamic.NewForConfig(cfg)
+		if err != nil {
+			return nil
+		}
+		return c
+	}
 	kubeconfigPath := ""
 	if dep.Result != nil {
 		kubeconfigPath = dep.Result.KubeconfigPath

--- a/products/catalyst/bootstrap/api/internal/handler/user_access.go
+++ b/products/catalyst/bootstrap/api/internal/handler/user_access.go
@@ -153,6 +153,15 @@ func (h *Handler) ListUserAccess(w http.ResponseWriter, r *http.Request) {
 	// is preserved in the metadata for any caller that wants it.
 	listIface, err := client.Resource(UserAccessGVR()).Namespace("").List(r.Context(), metav1.ListOptions{})
 	if err != nil {
+		// CRD not installed → return empty list, not 500. The
+		// access.openova.io UserAccess CRD ships via a separate
+		// blueprint that may not yet be installed on a fresh
+		// Sovereign. The page should render its empty state, not
+		// an error toast.
+		if apierrors.IsNotFound(err) {
+			writeJSON(w, http.StatusOK, userAccessListResponse{Items: []userAccessItem{}})
+			return
+		}
 		h.log.Warn("user-access: list failed", "depId", depID, "err", err)
 		writeJSON(w, http.StatusInternalServerError, map[string]string{
 			"error":  "list-failed",

--- a/products/catalyst/bootstrap/ui/src/lib/infrastructure.types.ts
+++ b/products/catalyst/bootstrap/ui/src/lib/infrastructure.types.ts
@@ -399,15 +399,10 @@ export async function getNetwork(deploymentId: string): Promise<NetworkResponse>
 export async function getHierarchicalInfrastructure(
   deploymentId: string,
 ): Promise<HierarchicalInfrastructure> {
-  // Mode-aware: on chroot Sovereign Console (console.<sov-fqdn>) hit
-  // the FQDN-scoped /api/v1/sovereign/topology endpoint instead of the
-  // deployment-keyed mother-side path. The latter 404s with empty
-  // deploymentId on Sovereign mode. Caught on omantel.biz 2026-05-06.
-  let url = `${API_BASE}/v1/deployments/${encodeURIComponent(deploymentId)}/infrastructure/topology`
-  if (typeof window !== 'undefined' && window.location.hostname !== 'console.openova.io') {
-    url = `${API_BASE}/v1/sovereign/topology`
-  }
-  const res = await fetch(url, { headers: { Accept: 'application/json' } })
+  const res = await fetch(
+    `${API_BASE}/v1/deployments/${encodeURIComponent(deploymentId)}/infrastructure/topology`,
+    { headers: { Accept: 'application/json' } },
+  )
   if (!res.ok) {
     throw new Error(`topology fetch failed: ${res.status}`)
   }

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/CatalogAdminPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/CatalogAdminPage.tsx
@@ -74,15 +74,7 @@ type LoadState =
  * `credentials: 'include'` is set.
  */
 async function fetchApps(): Promise<CatalogApp[]> {
-  // Mode-aware: chroot Sovereign Console uses /api/v1/sovereign/catalog;
-  // mother-side /catalog/apps doesn't exist on Sovereign clusters.
-  // Caught on omantel.biz 2026-05-06.
-  const isSovereignMode =
-    typeof window !== 'undefined' && window.location.hostname !== 'console.openova.io'
-  const url = isSovereignMode
-    ? `${API_BASE}/v1/sovereign/catalog`
-    : `${API_BASE}/catalog/apps`
-  const resp = await fetch(url, {
+  const resp = await fetch(`${API_BASE}/catalog/apps`, {
     method: 'GET',
     credentials: 'include',
     headers: { Accept: 'application/json' },

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -124,8 +124,8 @@ name: bp-catalyst-platform
 # otech113 2026-05-05 — chart 0.1.18 fixed the readiness-probe loop
 # but every trigger immediately got 502 in <10ms (synchronous
 # apiserver permission rejection). 2026-05-05.
-version: 1.4.55
-appVersion: 1.4.55
+version: 1.4.56
+appVersion: 1.4.56
 description: |
   Catalyst Platform — the unified Catalyst control plane umbrella chart for Catalyst-Zero.
   Composes the catalyst-{ui,api}, console, admin, marketplace UI modules and the marketplace-api backend.

--- a/products/catalyst/chart/templates/clusterrole-cutover-driver.yaml
+++ b/products/catalyst/chart/templates/clusterrole-cutover-driver.yaml
@@ -136,3 +136,25 @@ rules:
   - apiGroups: ["helm.toolkit.fluxcd.io"]
     resources: ["helmreleases"]
     verbs: ["get", "list", "watch"]
+
+  # ───────────────────────────────────────────────────────────────
+  # USER ACCESS CRD — backs /users on the chroot Sovereign Console.
+  # The mother-side handlers (ListUserAccess, CreateUserAccess,
+  # UpdateUserAccess, DeleteUserAccess) read/write the
+  # access.openova.io/v1alpha1 UserAccess CR via the in-cluster
+  # dynamic client (issue #322). On the Sovereign chroot the
+  # catalyst-api SA needs full CRUD on this CRD to render and edit
+  # the User Access list. Caught live on omantel.biz 2026-05-06:
+  # GET /api/v1/deployments/{depId}/admin/user-access returned 500
+  # "useraccesses.access.openova.io is forbidden" because the SA
+  # had no rule covering this GVR.
+  #
+  # `create` MUST be in its own rule WITHOUT resourceNames per
+  # feedback_rbac_create_no_resourcenames.md.
+  # ───────────────────────────────────────────────────────────────
+  - apiGroups: ["access.openova.io"]
+    resources: ["useraccesses"]
+    verbs: ["create"]
+  - apiGroups: ["access.openova.io"]
+    resources: ["useraccesses"]
+    verbs: ["get", "list", "watch", "update", "patch", "delete"]


### PR DESCRIPTION
Two coupled fixes for /users on chroot Sovereign Console.

1. ClusterRole catalyst-api-cutover-driver: add read/write on `useraccesses.access.openova.io`. After PR #1052 the chroot catalyst-api uses the in-cluster ServiceAccount, but the SA had no rule covering this CRD → 403.

2. ListUserAccess: return 200 + empty items when the CRD itself is not installed (apierrors.IsNotFound). The CRD ships via a separate blueprint that may not yet be installed on a fresh Sovereign — page should render its empty state, not a 500 toast.

Caught live on omantel.biz after PR #1052: 403 → 500 (CRD missing) → with this PR, 200 + [].