### PR TITLE
fix(provisioner): map wizard's 3-mode domain selector to tofu's binary pool/byo enum

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -231,7 +231,7 @@ spec:
       # fallback (data renders the moment cutover-import lands without
       # waiting for the orchestrator's chart-values overlay write).
       # 2026-05-05.
-      version: 1.4.83
+      version: 1.4.84
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/bootstrap/api/internal/provisioner/provisioner.go
+++ b/products/catalyst/bootstrap/api/internal/provisioner/provisioner.go
@@ -1174,7 +1174,16 @@ func writeTfvars(deployDir string, req Request) error {
 		"ssh_public_key": req.SSHPublicKey,
 
 		// Domain
-		"domain_mode":    req.SovereignDomainMode, // pool | byo
+		// The wizard exposes three modes (pool / byo-manual / byo-api) so
+		// the StepDomain UX can branch the operator into the right
+		// flow. The OpenTofu module only cares about the binary
+		// pool/byo distinction (pool means "we own the parent zone via
+		// Dynadot"; byo means "operator is bringing their own
+		// domain"). Collapse byo-manual + byo-api → "byo" before
+		// writing the tfvars. Caught live on omantel.biz 2026-05-07
+		// — provisioning failed at `tofu plan` with
+		// `Invalid value for variable: var.domain_mode is "byo-manual" — Domain mode must be 'pool' or 'byo'`.
+		"domain_mode":    mapDomainModeForTofu(req.SovereignDomainMode),
 		"pool_domain":    req.SovereignPoolDomain,
 		"dynadot_key":    req.DynadotAPIKey, // empty when domain_mode != "pool"
 		"dynadot_secret": req.DynadotAPISecret,
@@ -1598,4 +1607,27 @@ func coalesceParentDomains(pds []ParentDomain) []ParentDomain {
 		return []ParentDomain{}
 	}
 	return pds
+}
+
+// mapDomainModeForTofu collapses the wizard's three-mode domain
+// selector (`pool` / `byo-manual` / `byo-api`) into the binary
+// pool/byo enum the OpenTofu module's `variable "domain_mode"`
+// validation accepts.
+//
+// The wizard's tri-state exists for UX branching — pool flows through
+// the OpenOva PDM + Dynadot path; byo-manual asks the operator to
+// paste the NS records into their registrar manually; byo-api drives
+// the registrar API automatically. From the cloud-infrastructure
+// layer (Hetzner servers, network, LB) NONE of those distinctions
+// matter — the only thing tofu needs to know is "do I need to call
+// Dynadot at apply time?" which is `pool` only.
+//
+// An empty string maps to "byo" so the test path that leaves
+// SovereignDomainMode unset doesn't accidentally trigger the pool
+// branch.
+func mapDomainModeForTofu(wizardMode string) string {
+	if wizardMode == "pool" {
+		return "pool"
+	}
+	return "byo"
 }

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -124,8 +124,8 @@ name: bp-catalyst-platform
 # otech113 2026-05-05 — chart 0.1.18 fixed the readiness-probe loop
 # but every trigger immediately got 502 in <10ms (synchronous
 # apiserver permission rejection). 2026-05-05.
-version: 1.4.83
-appVersion: 1.4.83
+version: 1.4.84
+appVersion: 1.4.84
 description: |
   Catalyst Platform — the unified Catalyst control plane umbrella chart for Catalyst-Zero.
   Composes the catalyst-{ui,api}, console, admin, marketplace UI modules and the marketplace-api backend.


### PR DESCRIPTION
Caught live on omantel.biz re-provision. `tofu plan` failed:

```
Error: Invalid value for variable
  on variables.tf line 296:
 296: variable "domain_mode" {
   ├────────────────
   │ var.domain_mode is "byo-manual"
  Domain mode must be 'pool' or 'byo'.
```

**Cause**: wizard's StepDomain has 3 options (`pool` / `byo-manual` / `byo-api`) for UX branching. OpenTofu module's `variable.domain_mode` validation only accepts the binary `pool`/`byo`. The provisioner wrote the raw wizard value verbatim.

**Fix**: `mapDomainModeForTofu(wizardMode)` collapses byo-manual + byo-api → 'byo'. Tofu only needs to know whether to call Dynadot at apply time.

Chart 1.4.83 → 1.4.84.