### PR TITLE
fix(catalyst): durable Phase-0 jobs + chroot post-cutover live data

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/deployments.go
+++ b/products/catalyst/bootstrap/api/internal/handler/deployments.go
@@ -1343,6 +1343,33 @@ func (h *Handler) GetDeploymentEvents(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) runProvisioning(dep *Deployment) {
+	// Pre-seed the 5 Phase-0 lifecycle Job rows ("provisioner" group)
+	// BEFORE prov.Provision starts. This guarantees:
+	//
+	//   1. Deep-links to /jobs/tofu-init|tofu-plan|tofu-apply|
+	//      tofu-output|cluster-bootstrap resolve from the very first
+	//      wizard render, not just after the corresponding emit.
+	//   2. The JobsTable can never "drop" the Phase-0 rows when
+	//      bootstrap-kit children land later (they're durable in
+	//      jobs.Store, not derived from the live event stream).
+	//
+	// The bridge initialiser is the same path emitWatchEvent uses;
+	// pre-allocating it here means SeedProvisionerJobs fires once per
+	// deployment regardless of whether the first emit beats this
+	// goroutine.
+	if h.jobs != nil {
+		dep.mu.Lock()
+		if dep.jobsBridge == nil {
+			dep.jobsBridge = jobs.NewBridge(h.jobs, dep.ID)
+		}
+		bridge := dep.jobsBridge
+		dep.mu.Unlock()
+		if seedErr := bridge.SeedProvisionerJobs(); seedErr != nil {
+			h.log.Warn("jobs bridge: seed Phase-0 lifecycle jobs failed",
+				"id", dep.ID, "err", seedErr)
+		}
+	}
+
 	// Tee — provisioner.Provision writes events into producer; this
 	// goroutine records every event in the durable buffer AND forwards
 	// it to the live SSE channel. recordEvent is the single emit path,
@@ -1366,6 +1393,26 @@ func (h *Handler) runProvisioning(dep *Deployment) {
 	result, err := prov.Provision(ctx, dep.Request, producer)
 	close(producer)
 	<-teeDone
+
+	// Stamp the Phase-0 lifecycle Jobs into terminal state so the
+	// JobsTable's Started/Finished/Duration columns populate without
+	// waiting for Phase-1 events. Failure stamps the in-flight phase
+	// as Failed (with the error captured as a final LogLine);
+	// success rolls every phase to Succeeded.
+	now := time.Now().UTC()
+	if h.jobs != nil && dep.jobsBridge != nil {
+		if err != nil {
+			if mErr := dep.jobsBridge.MarkProvisionerFailed(err.Error(), now); mErr != nil {
+				h.log.Warn("jobs bridge: mark Phase-0 failed",
+					"id", dep.ID, "err", mErr)
+			}
+		} else {
+			if mErr := dep.jobsBridge.MarkProvisionerComplete(now); mErr != nil {
+				h.log.Warn("jobs bridge: mark Phase-0 complete",
+					"id", dep.ID, "err", mErr)
+			}
+		}
+	}
 
 	// Capture Phase-0 outcome under the lock.
 	dep.mu.Lock()

--- a/products/catalyst/bootstrap/api/internal/handler/jobs.go
+++ b/products/catalyst/bootstrap/api/internal/handler/jobs.go
@@ -32,7 +32,43 @@ import (
 
 	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/helmwatch"
 	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/jobs"
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/provisioner"
 )
+
+// chrootEnsureDeployment — when the catalyst-api is running inside a
+// Sovereign chroot (SOVEREIGN_FQDN env set) and the requested
+// deployment id is not in the in-memory map, synthesise a minimal
+// Deployment record so chrootSeedJobsStoreIfEmpty can fire and
+// HandleK8sStream/list/sync's URL ID resolves to the chroot's single
+// self-registered cluster. Cutover steps don't import the mother's
+// deployment record onto the chroot — but the chroot has all the
+// authority it needs (SOVEREIGN_FQDN + in-cluster RBAC) to serve the
+// per-deployment views by ID alone.
+//
+// Returns the synthesised Deployment, or nil when not in chroot mode
+// or when the synthesis isn't safe (auth failure on the future
+// owner-check path is already covered by the caller's checkOwnership
+// gate; we only pre-load the record here).
+func (h *Handler) chrootEnsureDeployment(depID string) *Deployment {
+	selfFQDN := strings.TrimSpace(os.Getenv("SOVEREIGN_FQDN"))
+	if selfFQDN == "" {
+		return nil
+	}
+	if val, ok := h.deployments.Load(depID); ok {
+		return val.(*Deployment)
+	}
+	dep := &Deployment{
+		ID: depID,
+		Request: provisioner.Request{
+			SovereignFQDN: selfFQDN,
+		},
+		Status: "ready",
+	}
+	h.deployments.Store(depID, dep)
+	h.log.Info("chroot: synthesised in-memory deployment record",
+		"depId", depID, "sovereignFQDN", selfFQDN)
+	return dep
+}
 
 // chrootSeedJobsStoreIfEmpty — when the chroot Sovereign-side
 // catalyst-api gets a /jobs read for an imported deployment whose
@@ -132,8 +168,13 @@ func (h *Handler) ListJobs(w http.ResponseWriter, r *http.Request) {
 	// Issue #689 — ownership check. If the deployment is unknown the
 	// in-memory map returns no entry; treat that as 404. If the entry
 	// exists, the helper writes 404 on cross-tenant access.
-	if val, ok := h.deployments.Load(depID); ok {
-		dep := val.(*Deployment)
+	dep := h.chrootEnsureDeployment(depID)
+	if dep == nil {
+		if val, ok := h.deployments.Load(depID); ok {
+			dep = val.(*Deployment)
+		}
+	}
+	if dep != nil {
 		if !h.checkOwnership(w, r, dep) {
 			return
 		}
@@ -185,8 +226,13 @@ func (h *Handler) GetJob(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// Issue #689 — ownership check (404 on cross-tenant).
-	if val, ok := h.deployments.Load(depID); ok {
-		dep := val.(*Deployment)
+	dep := h.chrootEnsureDeployment(depID)
+	if dep == nil {
+		if val, ok := h.deployments.Load(depID); ok {
+			dep = val.(*Deployment)
+		}
+	}
+	if dep != nil {
 		if !h.checkOwnership(w, r, dep) {
 			return
 		}

--- a/products/catalyst/bootstrap/api/internal/handler/jobs_helmwatch_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/jobs_helmwatch_test.go
@@ -35,7 +35,10 @@ func TestEmitWatchEvent_PopulatesJobsStore(t *testing.T) {
 		done:      make(chan struct{}),
 	}
 
-	// Phase-0 event must NOT create a Job (filtered by bridge).
+	// Phase-0 event materialises the 5 lifecycle Jobs under the
+	// "provisioner" group (no-disappear contract). The current phase
+	// transitions to running; earlier phases are stamped Succeeded;
+	// later phases stay Pending.
 	h.emitWatchEvent(dep, provisioner.Event{
 		Time:    time.Now().UTC().Format(time.RFC3339),
 		Phase:   "tofu-apply",
@@ -47,8 +50,9 @@ func TestEmitWatchEvent_PopulatesJobsStore(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(got) != 0 {
-		t.Errorf("Phase-0 event must not create jobs, got %+v", got)
+	// 5 leaf lifecycle phases + 1 group ("provisioner") = 6.
+	if len(got) != 6 {
+		t.Errorf("Phase-0 event must materialise 5 lifecycle Jobs + provisioner group (=6), got %d (%+v)", len(got), got)
 	}
 
 	// Phase-1 component event → Job + Execution + LogLine.
@@ -74,9 +78,10 @@ func TestEmitWatchEvent_PopulatesJobsStore(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	// 1 leaf install + 1 synthesised bootstrap-kit parent group.
-	if len(got) != 2 {
-		t.Fatalf("expected 2 jobs (1 leaf + 1 group), got %d (%+v)", len(got), got)
+	// 5 lifecycle leaves + 1 install-cilium leaf + 2 groups
+	// (provisioner + bootstrap-kit) = 8.
+	if len(got) != 8 {
+		t.Fatalf("expected 8 jobs (5 lifecycle + 1 install + 2 groups), got %d (%+v)", len(got), got)
 	}
 	var job *jobs.Job
 	for i := range got {
@@ -95,6 +100,22 @@ func TestEmitWatchEvent_PopulatesJobsStore(t *testing.T) {
 	}
 	if job.Status != jobs.StatusSucceeded {
 		t.Errorf("status: want succeeded, got %q", job.Status)
+	}
+
+	// Lifecycle Phase-0 leaves must STILL be present after Phase-1
+	// children land — the no-disappear contract.
+	hasLifecycle := func(name string) bool {
+		for _, j := range got {
+			if j.JobName == name {
+				return true
+			}
+		}
+		return false
+	}
+	for _, name := range []string{"tofu-init", "tofu-plan", "tofu-apply", "tofu-output", "cluster-bootstrap"} {
+		if !hasLifecycle(name) {
+			t.Errorf("lifecycle leaf %q vanished after Phase-1 child landed", name)
+		}
 	}
 
 	// Bridge must NOT break the SSE stream — eventsBuf still records

--- a/products/catalyst/bootstrap/api/internal/handler/k8s.go
+++ b/products/catalyst/bootstrap/api/internal/handler/k8s.go
@@ -40,6 +40,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"os"
 	"sort"
 	"strconv"
 	"strings"
@@ -82,6 +83,7 @@ func (h *Handler) HandleK8sList(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "missing path parameters", http.StatusBadRequest)
 		return
 	}
+	clusterID = h.resolveChrootClusterID(clusterID)
 	if _, ok := h.k8sCache.Registry().Get(kindName); !ok {
 		// Helpful 404 lists every registered kind. Shaped this
 		// way so `curl /...invalid` self-documents the registry.
@@ -225,6 +227,7 @@ func (h *Handler) HandleK8sStream(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "missing sovereign id", http.StatusBadRequest)
 		return
 	}
+	clusterID = h.resolveChrootClusterID(clusterID)
 	if !h.k8sCacheHasCluster(clusterID) {
 		http.Error(w, fmt.Sprintf("sovereign %q not registered", clusterID), http.StatusNotFound)
 		return
@@ -386,6 +389,7 @@ func (h *Handler) HandleK8sSync(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	clusterID := chi.URLParam(r, "id")
+	clusterID = h.resolveChrootClusterID(clusterID)
 	all := h.k8sCache.Synced()
 	resp, ok := all[clusterID]
 	if !ok {
@@ -405,6 +409,33 @@ func (h *Handler) k8sCacheHasCluster(id string) bool {
 		}
 	}
 	return false
+}
+
+// resolveChrootClusterID rewrites an incoming URL cluster ID onto the
+// chroot's single self-registered cluster when running inside a
+// Sovereign (SOVEREIGN_FQDN env set) and the URL ID isn't directly
+// registered. The mother stamps the FE with the deployment ID it
+// generated; post-cutover the chroot has no deployment record for
+// that ID, but its k8scache.Factory.FromEnv self-registers exactly
+// one cluster (the local cluster) under a SOVEREIGN_FQDN-derived
+// alias. Aliasing here makes /sovereigns/<any>/k8s/{stream,list,sync}
+// resolve to the chroot's local cluster regardless of which id the
+// FE asserts — no per-Sovereign import step required.
+func (h *Handler) resolveChrootClusterID(clusterID string) string {
+	if h.k8sCache == nil {
+		return clusterID
+	}
+	if h.k8sCacheHasCluster(clusterID) {
+		return clusterID
+	}
+	if strings.TrimSpace(os.Getenv("SOVEREIGN_FQDN")) == "" {
+		return clusterID
+	}
+	clusters := h.k8sCache.Clusters()
+	if len(clusters) != 1 {
+		return clusterID
+	}
+	return clusters[0]
 }
 
 // k8sUser extracts the authenticated user identifier from the request.

--- a/products/catalyst/bootstrap/api/internal/jobs/helmwatch_bridge.go
+++ b/products/catalyst/bootstrap/api/internal/jobs/helmwatch_bridge.go
@@ -62,7 +62,69 @@ const (
 const (
 	phaseComponent    = "component"
 	phaseComponentLog = "component-log"
+	// Phase-0 stdout/stderr stream tag. provisioner.go's runTofu uses
+	// Phase="tofu" for every line of tofu's stdout/stderr; the bridge
+	// appends them to the currently-active lifecycle phase's Execution
+	// so /jobs/tofu-<step> exec logs render the full transcript.
+	phaseTofuStream = "tofu"
+	// Legacy alias the provisioner emits at the end of Phase-0; treated
+	// as cluster-bootstrap (it's the human-readable tail of the phase).
+	phaseFluxBootstrap = "flux-bootstrap"
 )
+
+// provisionerLifecyclePhases — ordered Phase-0 jobs the bridge
+// pre-seeds + transitions through. The order is the canonical
+// dependency chain (init → plan → apply → output → cluster-bootstrap)
+// and feeds DependsOn for graph rendering.
+var provisionerLifecyclePhases = []string{
+	PhaseTofuInit,
+	PhaseTofuPlan,
+	PhaseTofuApply,
+	PhaseTofuOutput,
+	PhaseClusterBootstrap,
+}
+
+// provisionerLifecycleDisplay — user-visible display names per phase.
+var provisionerLifecycleDisplay = map[string]string{
+	PhaseTofuInit:         "Terraform Init",
+	PhaseTofuPlan:         "Terraform Plan",
+	PhaseTofuApply:        "Terraform Apply",
+	PhaseTofuOutput:       "Terraform Output",
+	PhaseClusterBootstrap: "Bootstrap Cluster",
+}
+
+// lifecyclePhaseIndex returns the position of phase in
+// provisionerLifecyclePhases, or -1 if unknown. The legacy
+// "flux-bootstrap" emit alias maps onto the cluster-bootstrap slot.
+func lifecyclePhaseIndex(phase string) int {
+	if phase == phaseFluxBootstrap {
+		phase = PhaseClusterBootstrap
+	}
+	for i, p := range provisionerLifecyclePhases {
+		if p == phase {
+			return i
+		}
+	}
+	return -1
+}
+
+// dependsOnForLifecyclePhase returns the previous-phase Job ID list
+// (length 0 for the first phase, length 1 thereafter) so the graph
+// view's edges render the linear chain.
+func dependsOnForLifecyclePhase(deploymentID, phase string) []string {
+	idx := lifecyclePhaseIndex(phase)
+	if idx <= 0 {
+		return []string{}
+	}
+	return []string{JobID(deploymentID, provisionerLifecyclePhases[idx-1])}
+}
+
+// lifecycleCursorKey — namespaces the in-memory activeExecID map so
+// lifecycle cursors don't collide with helmwatch component cursors
+// (which key off the bare component id like "cilium").
+func lifecycleCursorKey(phase string) string {
+	return "lifecycle:" + phase
+}
 
 // Bridge holds the per-deployment cursor the helmwatch consumer needs:
 // which Execution is currently active for which Job. The cursor is
@@ -494,35 +556,291 @@ func (b *Bridge) OnHelmReleaseEvent(componentID, state, level, message string, t
 }
 
 // OnProvisionerEvent is the adapter the handler's emit path calls with
-// every provisioner.Event the helmwatch.Watcher emits. Two phase
-// classes have a Job/Execution analogue:
+// every provisioner.Event. Three phase classes have a Job/Execution
+// analogue:
 //
-//   - Phase=="component"     — HelmRelease state transition. Routes to
-//     OnHelmReleaseEvent which upserts the Job, allocates an Execution
-//     on the first non-pending edge, and closes the Execution on
-//     terminal transitions.
-//   - Phase=="component-log" — raw helm-controller log line tagged
-//     with the bp-* HR it relates to. Routes to OnRawComponentLog
-//     which appends the line verbatim to the active Execution so the
-//     GitLab-CI-style viewer renders the full helm-controller stdout
-//     for the install attempt.
-//
-// Phase-0 OpenTofu events ("phase-0", "tofu-init", etc.) have no
-// component-Job analogue and fall through silently.
+//   - Phase=="component"           — HelmRelease state transition.
+//     Routes to OnHelmReleaseEvent which upserts the Job, allocates an
+//     Execution on the first non-pending edge, and closes the Execution
+//     on terminal transitions.
+//   - Phase=="component-log"       — raw helm-controller log line
+//     tagged with the bp-* HR it relates to. Routes to
+//     OnRawComponentLog which appends the line verbatim to the active
+//     Execution.
+//   - Phase=="tofu-init|tofu-plan|tofu-apply|tofu-output|
+//     cluster-bootstrap|flux-bootstrap" — Phase-0 lifecycle markers
+//     emitted by the OpenTofu provisioner. Routes to
+//     OnProvisionerLifecycleEvent which transitions the corresponding
+//     pre-seeded Job into Running, marks earlier phases Succeeded, and
+//     allocates an Execution so the per-phase Exec Log surface
+//     resolves.
+//   - Phase=="tofu"                — raw stdout/stderr line from the
+//     in-flight tofu command. Routes to OnProvisionerStreamLog which
+//     appends to the currently-active lifecycle phase's Execution.
 func (b *Bridge) OnProvisionerEvent(ev provisioner.Event) error {
-	if ev.Component == "" {
-		return nil
-	}
 	t := parseEventTime(ev.Time)
 	switch ev.Phase {
 	case phaseComponent:
-		if ev.State == "" {
+		if ev.Component == "" || ev.State == "" {
 			return nil
 		}
 		return b.OnHelmReleaseEvent(ev.Component, ev.State, ev.Level, ev.Message, t)
 	case phaseComponentLog:
+		if ev.Component == "" {
+			return nil
+		}
 		return b.OnRawComponentLog(ev.Component, ev.Level, ev.Message, t)
+	case PhaseTofuInit, PhaseTofuPlan, PhaseTofuApply, PhaseTofuOutput,
+		PhaseClusterBootstrap, phaseFluxBootstrap:
+		return b.OnProvisionerLifecycleEvent(ev.Phase, ev.Level, ev.Message, t)
+	case phaseTofuStream:
+		return b.OnProvisionerStreamLog(ev.Level, ev.Message, t)
 	}
+	return nil
+}
+
+// SeedProvisionerJobs registers the 5 Phase-0 lifecycle Jobs (under the
+// "provisioner" parent group) in a pending state so deep links to
+// /jobs/tofu-<step> resolve from the very first wizard render, and
+// the JobsTable never drops the rows when bootstrap-kit children
+// arrive later. Idempotent — UpsertJob's mergeJob preserves
+// monotonic timestamps and any prior status.
+func (b *Bridge) SeedProvisionerJobs() error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if err := b.ensureGroupJob(GroupProvisioner, GroupProvisionerDisplay); err != nil {
+		return err
+	}
+	parent := JobID(b.deploymentID, GroupProvisioner)
+	for _, phase := range provisionerLifecyclePhases {
+		if err := b.store.UpsertJob(Job{
+			DeploymentID: b.deploymentID,
+			JobName:      phase,
+			DisplayName:  provisionerLifecycleDisplay[phase],
+			Type:         JobTypeInstall,
+			ParentID:     parent,
+			DependsOn:    dependsOnForLifecyclePhase(b.deploymentID, phase),
+			Status:       StatusPending,
+		}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// OnProvisionerLifecycleEvent transitions the named Phase-0 phase
+// into Running (allocating an Execution + StartedAt on the first
+// edge), marks every earlier phase Succeeded if not already terminal,
+// and appends an INFO LogLine for the human-readable phase header
+// the provisioner emits. Idempotent — re-emitting the same phase is
+// a no-op once it's in Running.
+func (b *Bridge) OnProvisionerLifecycleEvent(phase, level, message string, t time.Time) error {
+	idx := lifecyclePhaseIndex(phase)
+	if idx < 0 {
+		return nil
+	}
+	canonical := provisionerLifecyclePhases[idx]
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if err := b.ensureGroupJob(GroupProvisioner, GroupProvisionerDisplay); err != nil {
+		return err
+	}
+
+	// Lazy-seed every lifecycle Job (idempotent — UpsertJob's
+	// mergeJob preserves any prior status). This is the "no job
+	// should disappear" guard: once a single Phase-0 emit lands, the
+	// JobsTable shows all 5 lifecycle rows regardless of which phase
+	// fired first or whether SeedProvisionerJobs ran.
+	for _, phase := range provisionerLifecyclePhases {
+		if err := b.ensureLifecycleJobLocked(phase); err != nil {
+			return err
+		}
+	}
+
+	// Promote earlier phases to Succeeded — once a later phase has
+	// emitted, every prior step has provably finished. The sentinel
+	// "flux-bootstrap" emit lands at the END of Phase-0 so the four
+	// tofu phases all roll up cleanly.
+	for i := 0; i < idx; i++ {
+		if err := b.markLifecyclePhaseTerminalLocked(provisionerLifecyclePhases[i], StatusSucceeded, t, ""); err != nil {
+			return err
+		}
+	}
+
+	// Allocate a fresh Execution if the cursor is empty for this
+	// phase. StartExecution stamps the Job's StartedAt + Status=running
+	// + LatestExecutionID inside the same persistIndex.
+	cursor := lifecycleCursorKey(canonical)
+	execID := b.activeExecID[cursor]
+	if execID == "" {
+		exec, err := b.store.StartExecution(b.deploymentID, canonical, t)
+		if err != nil {
+			return err
+		}
+		execID = exec.ID
+		b.activeExecID[cursor] = execID
+	}
+
+	msg := strings.TrimSpace(message)
+	if msg == "" {
+		msg = "[" + canonical + "] starting"
+	}
+	return b.store.AppendLogLines(b.deploymentID, execID, []LogLine{{
+		Timestamp: t.UTC(),
+		Level:     mapLevel(level),
+		Message:   msg,
+	}})
+}
+
+// OnProvisionerStreamLog appends a raw "tofu" stdout/stderr line to
+// the currently-active lifecycle phase's Execution. The stream tag
+// ("tofu") covers every line of init/plan/apply/output stdout +
+// stderr — we route to whichever phase is currently in flight by
+// scanning the cursor map newest-first.
+func (b *Bridge) OnProvisionerStreamLog(level, message string, t time.Time) error {
+	if strings.TrimSpace(message) == "" {
+		return nil
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	for i := len(provisionerLifecyclePhases) - 1; i >= 0; i-- {
+		execID := b.activeExecID[lifecycleCursorKey(provisionerLifecyclePhases[i])]
+		if execID != "" {
+			return b.store.AppendLogLines(b.deploymentID, execID, []LogLine{{
+				Timestamp: t.UTC(),
+				Level:     mapLevel(level),
+				Message:   message,
+			}})
+		}
+	}
+	// No active lifecycle execution — drop the line. The provisioner
+	// only emits "tofu" streams between an init/plan/apply marker and
+	// the next phase marker, so this branch is unexpected; logging it
+	// would risk amplifying noise.
+	return nil
+}
+
+// MarkProvisionerComplete is called from runProvisioning after
+// prov.Provision returns successfully. Every lifecycle phase that
+// hasn't reached terminal yet is stamped Succeeded — the cluster
+// bootstrap is the last emit before Provision returns, and Phase-1
+// HR events take over the Job feed thereafter.
+func (b *Bridge) MarkProvisionerComplete(t time.Time) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	for _, phase := range provisionerLifecyclePhases {
+		if err := b.markLifecyclePhaseTerminalLocked(phase, StatusSucceeded, t, ""); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// MarkProvisionerFailed is called from runProvisioning after
+// prov.Provision returns an error. The most-recent non-terminal phase
+// is stamped Failed (with the error message captured as a final
+// LogLine); earlier phases are stamped Succeeded since their
+// emission is the proof of completion.
+func (b *Bridge) MarkProvisionerFailed(message string, t time.Time) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	failedSet := false
+	for i := len(provisionerLifecyclePhases) - 1; i >= 0; i-- {
+		phase := provisionerLifecyclePhases[i]
+		jobID := JobID(b.deploymentID, phase)
+		job, _, err := b.store.GetJob(b.deploymentID, jobID)
+		if err != nil {
+			continue
+		}
+		if IsTerminal(job.Status) {
+			continue
+		}
+		if !failedSet {
+			if err := b.markLifecyclePhaseTerminalLocked(phase, StatusFailed, t, message); err != nil {
+				return err
+			}
+			failedSet = true
+			continue
+		}
+		// Earlier non-terminal phases — their emission is implied by
+		// the failed phase being downstream of them, but the failed
+		// phase MAY have started without prior phases ever entering
+		// running (e.g. validation failure pre tofu-init). Leave them
+		// Pending in that case so the FE renders accurately.
+	}
+	return nil
+}
+
+// ensureLifecycleJobLocked idempotently materialises the durable Job
+// row for a single Phase-0 lifecycle phase. Used by paths that may
+// run before SeedProvisionerJobs (e.g. a fast emit, a test that
+// constructs the Bridge without calling Seed). Caller MUST hold b.mu.
+func (b *Bridge) ensureLifecycleJobLocked(phase string) error {
+	if lifecyclePhaseIndex(phase) < 0 {
+		return nil
+	}
+	return b.store.UpsertJob(Job{
+		DeploymentID: b.deploymentID,
+		JobName:      phase,
+		DisplayName:  provisionerLifecycleDisplay[phase],
+		Type:         JobTypeInstall,
+		ParentID:     JobID(b.deploymentID, GroupProvisioner),
+		DependsOn:    dependsOnForLifecyclePhase(b.deploymentID, phase),
+		Status:       StatusPending,
+	})
+}
+
+// markLifecyclePhaseTerminalLocked stamps a single lifecycle phase as
+// terminal (Succeeded or Failed). If the phase has an active
+// Execution it is finished with the same status; an optional final
+// LogLine is appended (used by MarkProvisionerFailed to capture the
+// error). If the phase had no Execution yet (was still Pending), one
+// is allocated retroactively so the Exec Log surface has at least
+// one line — the JobsTable never renders an `—` duration cell.
+//
+// Caller MUST hold b.mu.
+func (b *Bridge) markLifecyclePhaseTerminalLocked(phase, status string, t time.Time, finalMessage string) error {
+	jobID := JobID(b.deploymentID, phase)
+	job, _, err := b.store.GetJob(b.deploymentID, jobID)
+	if err != nil {
+		return nil // unknown phase — bridge is stateless about phases it didn't seed
+	}
+	if IsTerminal(job.Status) {
+		return nil
+	}
+
+	cursor := lifecycleCursorKey(phase)
+	execID := b.activeExecID[cursor]
+	if execID == "" && job.LatestExecutionID != "" {
+		execID = job.LatestExecutionID
+	}
+	if execID == "" {
+		exec, startErr := b.store.StartExecution(b.deploymentID, phase, t)
+		if startErr != nil {
+			return startErr
+		}
+		execID = exec.ID
+	}
+
+	if msg := strings.TrimSpace(finalMessage); msg != "" {
+		level := LevelInfo
+		if status == StatusFailed {
+			level = LevelError
+		}
+		_ = b.store.AppendLogLines(b.deploymentID, execID, []LogLine{{
+			Timestamp: t.UTC(),
+			Level:     level,
+			Message:   msg,
+		}})
+	}
+
+	if err := b.store.FinishExecution(b.deploymentID, execID, status, t); err != nil {
+		return err
+	}
+	b.activeExecID[cursor] = ""
 	return nil
 }
 

--- a/products/catalyst/bootstrap/api/internal/jobs/helmwatch_bridge_test.go
+++ b/products/catalyst/bootstrap/api/internal/jobs/helmwatch_bridge_test.go
@@ -221,24 +221,43 @@ func TestBridge_DuplicateStateSuppressed(t *testing.T) {
 	}
 }
 
-func TestBridge_OnProvisionerEvent_FiltersPhase0(t *testing.T) {
+func TestBridge_OnProvisionerEvent_Phase0Lifecycle(t *testing.T) {
 	st, br, depID := newBridgeFixture(t)
-	// Phase-0 OpenTofu event has no Component/State — bridge must drop.
+	// Phase-0 lifecycle event creates a durable Job under the
+	// "provisioner" group so deep-links to /jobs/tofu-apply resolve
+	// AND the JobsTable doesn't drop the row when bootstrap-kit
+	// children land later.
 	if err := br.OnProvisionerEvent(provisioner.Event{
 		Time:    time.Now().UTC().Format(time.RFC3339),
 		Phase:   "tofu-apply",
 		Level:   "info",
-		Message: "Apply complete",
+		Message: "Applying — this provisions real Hetzner resources, please wait",
 	}); err != nil {
 		t.Fatal(err)
 	}
-	got, _ := st.ListJobs(depID)
-	if len(got) != 0 {
-		t.Errorf("Phase-0 event must not create jobs, got %+v", got)
+	all, _ := st.ListJobs(depID)
+	leaves := leafJobs(all)
+	// 5 lifecycle phases: tofu-init, tofu-plan, tofu-apply, tofu-output,
+	// cluster-bootstrap. tofu-apply is running; init+plan promoted to
+	// succeeded; output+cluster-bootstrap remain pending.
+	if len(leaves) != 5 {
+		t.Fatalf("expected 5 lifecycle leaves, got %d: %+v", len(leaves), leaves)
+	}
+	apply := leafByName(t, leaves, "tofu-apply")
+	if apply.Status != StatusRunning {
+		t.Errorf("tofu-apply: status=%q want %q", apply.Status, StatusRunning)
+	}
+	plan := leafByName(t, leaves, "tofu-plan")
+	if plan.Status != StatusSucceeded {
+		t.Errorf("tofu-plan: status=%q want %q (promoted on later phase emit)", plan.Status, StatusSucceeded)
+	}
+	output := leafByName(t, leaves, "tofu-output")
+	if output.Status != StatusPending {
+		t.Errorf("tofu-output: status=%q want %q (not yet emitted)", output.Status, StatusPending)
 	}
 
-	// Phase-1 component event creates a leaf Job (and lazily the
-	// bootstrap-kit parent group).
+	// Phase-1 component event creates a leaf Job under the
+	// bootstrap-kit parent — the lifecycle leaves are unchanged.
 	if err := br.OnProvisionerEvent(provisioner.Event{
 		Time:      time.Now().UTC().Format(time.RFC3339),
 		Phase:     "component",
@@ -249,11 +268,12 @@ func TestBridge_OnProvisionerEvent_FiltersPhase0(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
-	leaves := leafJobs(mustList(t, st, depID))
-	if len(leaves) != 1 {
-		t.Fatalf("expected exactly 1 leaf, got %+v", leaves)
+	leaves = leafJobs(mustList(t, st, depID))
+	if len(leaves) != 6 {
+		t.Fatalf("expected 5 lifecycle + 1 install = 6 leaves, got %d: %+v", len(leaves), leaves)
 	}
 	leafByName(t, leaves, "install-cilium")
+	leafByName(t, leaves, "tofu-apply") // still present — must not vanish
 }
 
 func TestMapLevel(t *testing.T) {
@@ -680,12 +700,13 @@ func TestOnRawComponentLog_dropsAfterTerminal(t *testing.T) {
 }
 
 // TestOnProvisionerEvent_dropsUnknownPhases keeps the bridge inert for
-// Phase-0 OpenTofu events (Phase="phase-0", Phase="tofu-init") that
-// have no Job analogue — a regression guard against accidentally
-// materialising Jobs for opentofu output.
+// truly unknown phases ("phase-0", empty). Named Phase-0 lifecycle
+// phases (tofu-init / tofu-plan / tofu-apply / tofu-output /
+// cluster-bootstrap) are now durable Jobs and have their own coverage
+// in TestBridge_OnProvisionerEvent_Phase0Lifecycle.
 func TestOnProvisionerEvent_dropsUnknownPhases(t *testing.T) {
 	st, br, depID := newBridgeFixture(t)
-	for _, ph := range []string{"phase-0", "tofu-init", "tofu-apply", ""} {
+	for _, ph := range []string{"phase-0", "", "ham-sandwich"} {
 		if err := br.OnProvisionerEvent(provisioner.Event{
 			Time:      time.Now().UTC().Format(time.RFC3339),
 			Phase:     ph,
@@ -697,7 +718,7 @@ func TestOnProvisionerEvent_dropsUnknownPhases(t *testing.T) {
 	}
 	got, _ := st.ListJobs(depID)
 	if len(got) != 0 {
-		t.Errorf("non-component phases must not allocate Jobs, got %d", len(got))
+		t.Errorf("unknown phases must not allocate Jobs, got %d", len(got))
 	}
 }
 

--- a/products/catalyst/bootstrap/api/internal/jobs/types.go
+++ b/products/catalyst/bootstrap/api/internal/jobs/types.go
@@ -87,6 +87,7 @@ const (
 const (
 	GroupBootstrapKit   = "bootstrap-kit"
 	GroupDay2Mutations  = "day-2-mutations"
+	GroupProvisioner    = "provisioner"
 )
 
 // Group display names — user-visible labels for the synthesised
@@ -95,6 +96,19 @@ const (
 const (
 	GroupBootstrapKitDisplay   = "Bootstrap"
 	GroupDay2MutationsDisplay  = "Day-2 Mutations"
+	GroupProvisionerDisplay    = "Provision Hetzner"
+)
+
+// Phase-0 lifecycle phase slugs — durable Job rows the bridge writes
+// when the provisioner.Provision goroutine emits the corresponding
+// named-phase events. The slugs match provisioner.go's emit() phase
+// strings 1:1 so OnProvisionerLifecycleEvent's lookup is direct.
+const (
+	PhaseTofuInit         = "tofu-init"
+	PhaseTofuPlan         = "tofu-plan"
+	PhaseTofuApply        = "tofu-apply"
+	PhaseTofuOutput       = "tofu-output"
+	PhaseClusterBootstrap = "cluster-bootstrap"
 )
 
 // JobNamePrefix — every Phase-1 leaf install Job is named

--- a/products/catalyst/bootstrap/api/internal/k8scache/factory.go
+++ b/products/catalyst/bootstrap/api/internal/k8scache/factory.go
@@ -864,9 +864,24 @@ func buildChrootClusterRef(log *slog.Logger, sovereignFQDN string) (ClusterRef, 
 		depID = scanStoreForDeploymentID(sovereignFQDN)
 	}
 	if depID == "" {
-		log.Info("k8scache: chroot self-register deferred — no deployment id resolved yet",
-			"sovereignFQDN", sovereignFQDN)
-		return ClusterRef{}, false
+		// Post-cutover the chroot's catalyst-api typically has neither
+		// CATALYST_SELF_DEPLOYMENT_ID stamped (cutover step-07 patches
+		// CATALYST_GITOPS_REPO_URL only) nor a per-deployment record
+		// imported into the local store (no cutover step POSTs the
+		// mother's record to /api/v1/internal/deployments/import).
+		// Earlier builds deferred chroot self-register here and left
+		// /k8s/stream returning 404 forever — every Cloud list-view
+		// chip showed "Stream temporarily unreachable".
+		//
+		// Fall back to a deterministic ID derived from SOVEREIGN_FQDN
+		// (which IS guaranteed to be set on every chroot via the
+		// Helm chart). The handler layer already aliases unknown URL
+		// cluster IDs onto the single chroot cluster when SOVEREIGN_FQDN
+		// is set, so the FE's existing behaviour (URL still carries
+		// the mother's deployment id) keeps working.
+		depID = "sovereign-" + sovereignFQDN
+		log.Info("k8scache: chroot self-register using SOVEREIGN_FQDN-derived id",
+			"sovereignFQDN", sovereignFQDN, "deploymentID", depID)
 	}
 	cfg, err := rest.InClusterConfig()
 	if err != nil {


### PR DESCRIPTION
## Summary

Three coupled fixes for issues observed post-cutover on `console.omantel.biz`:

1. **JobsTable lifecycle rows disappeared** when bootstrap-kit children landed. 5 Phase-0 phases (tofu-init/plan/apply/output, cluster-bootstrap) are now durable Job records under a new `provisioner` group. /jobs/tofu-apply deep-link 404 ALSO fixed by this.

2. **/sovereigns/{id}/k8s/stream returned 404 on every chroot post-cutover** — Cloud list-view services chip showed \"Stream temporarily unreachable\". Chroot now self-registers via SOVEREIGN_FQDN; handlers alias unknown URL ids onto the single chroot cluster.

3. **/jobs returned every job as Pending** with no exec logs. chrootEnsureDeployment synthesises a minimal Deployment record from SOVEREIGN_FQDN so the existing chrootSeedJobsStoreIfEmpty path fires and the lazy HelmRelease snapshot converts to rich Job records.

Together these mean **post-cutover Sovereign Consoles serve real-time data for ALL future Sovereigns** with no per-deployment cutover import step required.

## Test plan

- [x] `go test ./internal/jobs/...` passes (incl. updated TestBridge_OnProvisionerEvent_Phase0Lifecycle)
- [x] `go test ./internal/k8scache/...` passes
- [x] `go vet ./...` clean
- [x] `npm run build` (UI) clean
- [ ] Wait for CI to roll the SHA via the chart auto-bump pipeline
- [ ] Verify on console.omantel.biz: /cloud?view=list&kind=services renders live items, /jobs shows non-Pending statuses with exec logs, /jobs/tofu-apply deep-link resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)