### PR TITLE
fix(catalyst): chroot Sovereign Console OIDC bearer auth + self synth id

### DIFF
--- a/products/catalyst/bootstrap/api/internal/auth/session.go
+++ b/products/catalyst/bootstrap/api/internal/auth/session.go
@@ -254,21 +254,43 @@ func (c *Config) ClearSessionCookie(w http.ResponseWriter) {
 	})
 }
 
-// ReadSessionToken extracts the access token from the session cookie.
+// ReadSessionToken extracts the access token from the session cookie
+// OR the Authorization header.
 //
-// Two cookie shapes are accepted:
+// Token sources (first match wins):
 //
-//  1. HMAC-wrapped (Option A legacy): "<token>.<hmac>" — produced by
-//     IssueSessionCookie. The HMAC suffix is verified and stripped.
+//  1. Authorization: Bearer <jwt> header — used by the chroot Sovereign
+//     Console SPA, which holds the Keycloak access_token in sessionStorage
+//     after its own OIDC callback. The BE has no chance to mint a cookie
+//     during that flow (token exchange happens entirely client-side via
+//     PKCE), so the SPA must attach the token to every API fetch as
+//     Authorization: Bearer. ValidateToken handles signature verification
+//     against the same JWKS regardless of whether the JWT arrived via
+//     cookie or header.
 //
-//  2. Raw self-signed JWT (PIN auth, issue #688): the cookie value is a
-//     compact JWT ("<header>.<payload>.<sig>"). Recognised by the absence
-//     of an additional "." after the third segment. When CookieSecret is
-//     empty, only this path is used so existing single-component deployments
-//     (Sovereign clusters) continue to work unchanged.
+//  2. catalyst_session cookie — two shapes accepted:
+//     a. HMAC-wrapped (Option A legacy): "<token>.<hmac>" — produced by
+//        IssueSessionCookie. The HMAC suffix is verified and stripped.
+//     b. Raw self-signed JWT (PIN auth, issue #688): the cookie value is
+//        a compact JWT ("<header>.<payload>.<sig>"). Recognised by exactly
+//        3 base64url segments. When CookieSecret is empty, only this path
+//        is used so existing single-component deployments (Sovereign
+//        clusters) continue to work unchanged.
 //
-// Returns "" when no valid cookie is present.
+// Returns "" when no valid token source is present.
 func (c *Config) ReadSessionToken(r *http.Request) string {
+	// Bearer header — used by the chroot SPA after its own OIDC callback.
+	if hdr := r.Header.Get("Authorization"); hdr != "" {
+		const prefix = "Bearer "
+		if len(hdr) > len(prefix) && strings.EqualFold(hdr[:len(prefix)], prefix) {
+			tok := strings.TrimSpace(hdr[len(prefix):])
+			parts := strings.Split(tok, ".")
+			if len(parts) == 3 {
+				return tok
+			}
+		}
+	}
+
 	cookie, err := r.Cookie(SessionCookieName)
 	if err != nil || cookie.Value == "" {
 		return ""

--- a/products/catalyst/bootstrap/api/internal/handler/sovereign_self.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sovereign_self.go
@@ -62,6 +62,13 @@ type SovereignSelfResponse struct {
 func (h *Handler) HandleSovereignSelf(w http.ResponseWriter, r *http.Request) {
 	deploymentID := strings.TrimSpace(os.Getenv("CATALYST_SELF_DEPLOYMENT_ID"))
 	fqdn := strings.TrimSpace(os.Getenv("CATALYST_OTECH_FQDN"))
+	// SOVEREIGN_FQDN is the standard env every chroot already has from
+	// the bp-catalyst-platform chart's sovereign-fqdn ConfigMap; treat
+	// it as a synonym for CATALYST_OTECH_FQDN so a chroot pod where
+	// either name is set resolves correctly.
+	if fqdn == "" {
+		fqdn = strings.TrimSpace(os.Getenv("SOVEREIGN_FQDN"))
+	}
 
 	// Step 1.5: read the Sovereign session cookie's deployment_id /
 	// sovereign_fqdn claims (populated by auth_handover.go after the
@@ -107,14 +114,18 @@ func (h *Handler) HandleSovereignSelf(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// Step 3: still no id — handover hasn't fired yet.
+	// Step 3: still no id — synthesize one from SOVEREIGN_FQDN. The
+	// chroot post-cutover often has neither CATALYST_SELF_DEPLOYMENT_ID
+	// stamped (cutover step-07 only patches GITOPS_REPO_URL) nor the
+	// mother's deployment record imported. Returning 503 here breaks
+	// every downstream view (apps/jobs/cloud) for users who logged in
+	// directly via Keycloak (no handover JWT). Fall back to a stable
+	// id derived from SOVEREIGN_FQDN — k8scache.factory.go and the
+	// chroot k8s handler aliases agree on this convention so the FE's
+	// subsequent /api/v1/sovereigns/{id}/* calls resolve to the chroot's
+	// single self-registered cluster.
 	if deploymentID == "" {
-		writeJSON(w, http.StatusServiceUnavailable, map[string]string{
-			"error":  "deployment-id-not-yet-stamped",
-			"detail": "Sovereign FQDN is known but the contabo orchestrator has not yet POSTed the deployment id to this cluster. The handover step is behind — retry shortly.",
-			"fqdn":   fqdn,
-		})
-		return
+		deploymentID = "sovereign-" + fqdn
 	}
 
 	writeJSON(w, http.StatusOK, SovereignSelfResponse{

--- a/products/catalyst/bootstrap/ui/src/main.tsx
+++ b/products/catalyst/bootstrap/ui/src/main.tsx
@@ -4,7 +4,18 @@ import { RouterProvider } from '@tanstack/react-router'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { router } from './app/router'
 import { bootstrapTenant } from './shared/lib/tenantDiscover'
+import { installFetchAuthInterceptor } from './shared/lib/authedFetch'
 import './app/globals.css'
+
+// Install the OIDC bearer-token fetch interceptor BEFORE any module
+// touches fetch(). Sovereign Console (chroot) holds the access_token
+// in sessionStorage after its own PKCE OIDC flow; without this
+// interceptor every /api/v1/ fetch would 401 because the SPA can't
+// set the catalyst_session cookie that the BE's session middleware
+// expects on mother. Mother itself keeps using cookies — the
+// interceptor is a transparent no-op when sessionStorage has no OIDC
+// tokens.
+installFetchAuthInterceptor()
 
 const queryClient = new QueryClient({
   defaultOptions: {

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/AppsPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/AppsPage.tsx
@@ -36,6 +36,7 @@ import { useQuery } from '@tanstack/react-query'
 import { useResolvedDeploymentId } from '@/shared/lib/useResolvedDeploymentId'
 import { DETECTED_MODE } from '@/shared/lib/detectMode'
 import { API_BASE } from '@/shared/config/urls'
+import { authedFetch } from '@/shared/lib/authedFetch'
 import { useWizardStore } from '@/entities/deployment/store'
 import { PortalShell } from './PortalShell'
 import { resolveApplications, type ApplicationDescriptor } from './applicationCatalog'
@@ -96,8 +97,7 @@ export function AppsPage({ disableStream = false }: AppsPageProps = {}) {
     enabled: isSovereignMode,
     refetchInterval: 5_000,
     queryFn: async () => {
-      const r = await fetch(`${API_BASE}/v1/sovereign/apps`, {
-        credentials: 'include',
+      const r = await authedFetch(`${API_BASE}/v1/sovereign/apps`, {
         headers: { Accept: 'application/json' },
       })
       if (!r.ok) throw new Error(`live apps fetch ${r.status}`)
@@ -565,11 +565,10 @@ export function AppsPage({ disableStream = false }: AppsPageProps = {}) {
                 marketplacePublished={published}
                 slug={slug}
                 onPublishedChange={async (next) => {
-                  const r = await fetch(
+                  const r = await authedFetch(
                     `${API_BASE}/v1/sovereign/apps/${encodeURIComponent(slug)}/publish`,
                     {
                       method: 'PATCH',
-                      credentials: 'include',
                       headers: {
                         Accept: 'application/json',
                         'Content-Type': 'application/json',

--- a/products/catalyst/bootstrap/ui/src/shared/lib/authedFetch.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/lib/authedFetch.ts
@@ -1,0 +1,93 @@
+/**
+ * authedFetch — fetch wrapper that injects the OIDC access token as
+ * Authorization: Bearer for catalyst-api calls on Sovereign mode.
+ *
+ * The chroot Sovereign Console SPA performs its own OIDC flow with
+ * Keycloak and stores the access_token in sessionStorage (oidc:access_token).
+ * The catalyst-api session middleware ALSO accepts Authorization: Bearer
+ * (in addition to the catalyst_session cookie used by mother), so the
+ * SPA can authenticate API calls by attaching the token from
+ * sessionStorage.
+ *
+ * Mother (Catalyst-Zero) flow uses the catalyst_session cookie minted
+ * by the PIN-verify endpoint; cookie carries through credentials:'include'
+ * and no Authorization header is needed. authedFetch adds the header
+ * when (and only when) sessionStorage has an OIDC access_token — so the
+ * same code path works on both sides without an explicit mode check.
+ */
+
+import { loadTokens } from './oidc'
+
+export type AuthedRequestInit = RequestInit & { skipAuth?: boolean }
+
+/**
+ * Fetch with credentials:'include' AND an Authorization: Bearer header
+ * sourced from sessionStorage when available. Pass `skipAuth: true` to
+ * suppress the Authorization header (e.g. for the OIDC token-exchange
+ * call itself).
+ */
+export async function authedFetch(
+  input: RequestInfo | URL,
+  init: AuthedRequestInit = {},
+): Promise<Response> {
+  const { skipAuth, ...rest } = init
+  const headers = new Headers(rest.headers || {})
+  if (!skipAuth) {
+    const tokens = loadTokens()
+    if (tokens && tokens.accessToken && !headers.has('Authorization')) {
+      headers.set('Authorization', `Bearer ${tokens.accessToken}`)
+    }
+  }
+  const credentials: RequestCredentials = rest.credentials ?? 'include'
+  return fetch(input, { ...rest, credentials, headers })
+}
+
+/**
+ * installFetchAuthInterceptor — monkey-patches window.fetch so every
+ * call to a same-origin /api/v1/ path automatically picks up the
+ * Authorization: Bearer header from the OIDC sessionStorage token,
+ * when one is present.
+ *
+ * This unblocks the chroot Sovereign Console where the SPA performs
+ * its own PKCE OIDC flow (no server-minted catalyst_session cookie)
+ * and dozens of fetch() callsites would otherwise need individual
+ * authedFetch swaps. With the interceptor installed, existing code
+ * paths Just Work — and on mother (where no OIDC token is ever in
+ * sessionStorage) the interceptor is a transparent passthrough.
+ *
+ * Idempotent — running twice is a no-op (the marker symbol guards
+ * against double-installation under hot-reload).
+ */
+const INSTALLED = Symbol.for('catalyst.fetchAuthInterceptor.installed')
+type WithMarker = typeof globalThis & { [INSTALLED]?: true }
+
+export function installFetchAuthInterceptor(): void {
+  if (typeof window === 'undefined') return
+  const g = globalThis as WithMarker
+  if (g[INSTALLED]) return
+  const origFetch = window.fetch.bind(window)
+  window.fetch = async (input, init = {}): Promise<Response> => {
+    let url = ''
+    if (typeof input === 'string') url = input
+    else if (input instanceof URL) url = input.toString()
+    else if (input instanceof Request) url = input.url
+    // Only attach to API calls; static assets, cross-origin URLs and
+    // anything outside /api/v1 retain their original semantics.
+    const isApiCall =
+      url.includes('/api/v1/') &&
+      (url.startsWith('/') ||
+        url.startsWith(window.location.origin) ||
+        url.startsWith('http') === false)
+    if (!isApiCall) return origFetch(input, init)
+    const headers = new Headers(init.headers || {})
+    if (!headers.has('Authorization')) {
+      const tokens = loadTokens()
+      if (tokens && tokens.accessToken) {
+        headers.set('Authorization', `Bearer ${tokens.accessToken}`)
+      }
+    }
+    const credentials: RequestCredentials = init.credentials ?? 'include'
+    return origFetch(input, { ...init, credentials, headers })
+  }
+  g[INSTALLED] = true
+}


### PR DESCRIPTION
## Summary

Fixes the chroot Sovereign Console UX where the user observed all 36 apps showing as PENDING, /jobs limited, /cloud empty, /dashboard empty.

**Root cause**: The chroot SPA performs its own PKCE OIDC flow client-side and stores access_token in sessionStorage — but the BE session middleware only read the catalyst_session cookie. Every /api/v1/* fetch 401'd from the chroot Sovereign Console.

## Three coupled fixes

1. **BE accepts Authorization: Bearer** — `ReadSessionToken` now reads the header before the cookie. Same JWKS validation path.
2. **FE installs global fetch interceptor** at boot — every /api/v1/ fetch automatically attaches `Authorization: Bearer ${oidcToken}` from sessionStorage. Transparent no-op on mother (no OIDC token in sessionStorage there).
3. **HandleSovereignSelf** reads `SOVEREIGN_FQDN` env in addition to `CATALYST_OTECH_FQDN`, and synthesises a `sovereign-<fqdn>` deployment id when nothing else resolves. Matches the k8scache.factory.go convention so chroot-aliasing in the k8s handlers resolves consistently.

## Test plan

- [x] `go build ./...` clean
- [x] `npm run build` clean
- [ ] After CI rolls new SHA: verify console.omantel.biz/apps shows real "installed"/"available" statuses (not all pending), /sovereign/self returns 200, /sovereign/apps returns 200 from FE

🤖 Generated with [Claude Code](https://claude.com/claude-code)