### PR TITLE
fix(catalyst): chroot /jobs Phase-0 + /cloud topology synth + AVAILABLE pill

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/infrastructure.go
+++ b/products/catalyst/bootstrap/api/internal/handler/infrastructure.go
@@ -1735,14 +1735,20 @@ func writeBadRequest(w http.ResponseWriter, code, detail string) {
 // on miss so the caller can write a 404 with a contextual error body.
 func (h *Handler) lookupDeploymentForInfra(id string) (*Deployment, bool) {
 	val, ok := h.deployments.Load(id)
-	if !ok {
-		return nil, false
+	if ok {
+		dep, ok := val.(*Deployment)
+		if ok {
+			return dep, true
+		}
 	}
-	dep, ok := val.(*Deployment)
-	if !ok {
-		return nil, false
+	// Chroot post-cutover: synthesise an in-memory Deployment from
+	// SOVEREIGN_FQDN so the topology loader gets a non-nil dep with
+	// SovereignFQDN set; the loader's chroot fallback then probes the
+	// live cluster for Nodes via the in-cluster dynamic client.
+	if dep := h.chrootEnsureDeployment(id); dep != nil {
+		return dep, true
 	}
-	return dep, true
+	return nil, false
 }
 
 // statusForDeployment maps the Deployment.Status string to the canonical

--- a/products/catalyst/bootstrap/api/internal/handler/jobs.go
+++ b/products/catalyst/bootstrap/api/internal/handler/jobs.go
@@ -27,6 +27,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 
@@ -124,6 +125,20 @@ func (h *Handler) chrootSeedJobsStoreIfEmpty(ctx context.Context, dep *Deploymen
 	if err != nil {
 		h.log.Warn("chroot seed: bridge seed failed", "depId", dep.ID, "err", err)
 		return
+	}
+	// Phase-0 lifecycle history — by the time we've reached the chroot
+	// post-cutover, every Phase-0 step (tofu-init/plan/apply/output,
+	// cluster-bootstrap) has provably completed (the cluster exists,
+	// kubeconfig was posted back, Phase-1 ran, cutover triggered, the
+	// chroot's own catalyst-api is now serving). Seed all 5 lifecycle
+	// Jobs as Succeeded under the "provisioner" group so /jobs on the
+	// chroot shows the full history alongside bootstrap-kit children.
+	// Idempotent (UpsertJob's monotonic merge).
+	if err := bridge.SeedProvisionerJobs(); err != nil {
+		h.log.Warn("chroot seed: provisioner lifecycle seed failed", "depId", dep.ID, "err", err)
+	}
+	if err := bridge.MarkProvisionerComplete(time.Now().UTC()); err != nil {
+		h.log.Warn("chroot seed: mark Phase-0 complete failed", "depId", dep.ID, "err", err)
 	}
 	h.log.Info("chroot seed: per-deployment jobs.Store populated from live cluster",
 		"depId", dep.ID,

--- a/products/catalyst/bootstrap/api/internal/infrastructure/topology_loader.go
+++ b/products/catalyst/bootstrap/api/internal/infrastructure/topology_loader.go
@@ -113,11 +113,216 @@ func buildTopology(ctx context.Context, in LoaderInput) TopologyData {
 			WorkerCount:      in.WorkerCount,
 		}
 		regions = append(regions, buildRegion(ctx, in, legacy))
+	} else if in.DynamicClient != nil && in.SovereignFQDN != "" {
+		// Chroot post-cutover path: the synthesised Deployment record
+		// has empty Regions + empty Region (the wizard data lives on
+		// the mother). Probe the live cluster's Nodes via the dynamic
+		// client, group by `node.kubernetes.io/instance-type`, and
+		// emit one Region with one Cluster carrying all real Nodes +
+		// derived NodePools. Result: /cloud kind=clusters /node-pools
+		// /worker-nodes render real data on the chroot.
+		if rs, ok := buildRegionFromLiveNodes(ctx, in); ok {
+			regions = append(regions, rs)
+		}
+	}
+	if len(regions) > 0 && pattern == "unknown" {
+		pattern = "solo"
 	}
 	return TopologyData{
 		Pattern: pattern,
 		Regions: regions,
 	}
+}
+
+// nodeGVR — schema reference for core/v1 Node listing via dynamic client.
+var nodeGVR = schema.GroupVersionResource{Group: "", Version: "v1", Resource: "nodes"}
+
+// buildRegionFromLiveNodes synthesises a Region from the live cluster's
+// Node list when the deployment record has no declared Regions (the
+// chroot post-cutover case). Groups Nodes by SKU label to derive
+// NodePools; emits one Cluster carrying all real Nodes. Returns
+// (zero, false) when the Node list is empty or unreachable.
+func buildRegionFromLiveNodes(ctx context.Context, in LoaderInput) (Region, bool) {
+	listCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	list, err := in.DynamicClient.Resource(nodeGVR).List(listCtx, metav1.ListOptions{})
+	if err != nil || list == nil || len(list.Items) == 0 {
+		return Region{}, false
+	}
+
+	// Pick a region from a Node label if any node carries one; else
+	// fall back to the SovereignFQDN as the region label.
+	regionName := ""
+	for _, n := range list.Items {
+		for _, k := range []string{"topology.kubernetes.io/region", "failure-domain.beta.kubernetes.io/region"} {
+			if v, ok := n.GetLabels()[k]; ok && v != "" {
+				regionName = v
+				break
+			}
+		}
+		if regionName != "" {
+			break
+		}
+	}
+	if regionName == "" {
+		regionName = in.SovereignFQDN
+	}
+
+	type poolKey struct {
+		role string // control-plane or worker
+		sku  string
+	}
+	poolNodes := map[poolKey][]Node{}
+	cpSKU := ""
+	workerSKU := ""
+	cpCount, workerCount := 0, 0
+	for _, n := range list.Items {
+		labels := n.GetLabels()
+		role := "worker"
+		if _, ok := labels["node-role.kubernetes.io/control-plane"]; ok {
+			role = "control-plane"
+		} else if _, ok := labels["node-role.kubernetes.io/master"]; ok {
+			role = "control-plane"
+		}
+		sku := labels["node.kubernetes.io/instance-type"]
+		if sku == "" {
+			sku = labels["beta.kubernetes.io/instance-type"]
+		}
+		// Read the first InternalIP for display.
+		ip := ""
+		if addrs, found, _ := unstructuredAddresses(n.Object); found {
+			for _, a := range addrs {
+				m, ok := a.(map[string]any)
+				if !ok {
+					continue
+				}
+				if t, _ := m["type"].(string); t == "InternalIP" {
+					ip, _ = m["address"].(string)
+					break
+				}
+			}
+		}
+		key := poolKey{role: role, sku: sku}
+		nodeID := "node-" + n.GetName()
+		statusReady := nodeReadyStatus(n.Object)
+		nodeStatus := in.Status
+		if statusReady == "True" {
+			nodeStatus = "healthy"
+		} else if statusReady == "False" {
+			nodeStatus = "degraded"
+		}
+		poolNodes[key] = append(poolNodes[key], Node{
+			ID:         nodeID,
+			Name:       n.GetName(),
+			SKU:        sku,
+			Region:     regionName,
+			Role:       role,
+			IP:         ip,
+			Status:     nodeStatus,
+			NodePoolID: "pool-" + role + "-" + regionName,
+		})
+		if role == "control-plane" {
+			cpCount++
+			if cpSKU == "" {
+				cpSKU = sku
+			}
+		} else {
+			workerCount++
+			if workerSKU == "" {
+				workerSKU = sku
+			}
+		}
+	}
+
+	allNodes := make([]Node, 0, len(list.Items))
+	pools := make([]NodePool, 0, len(poolNodes))
+	for k, ns := range poolNodes {
+		allNodes = append(allNodes, ns...)
+		pools = append(pools, NodePool{
+			ID:          "pool-" + k.role + "-" + regionName,
+			Name:        k.role + "-" + regionName,
+			Role:        k.role,
+			SKU:         k.sku,
+			Region:      regionName,
+			DesiredSize: len(ns),
+			CurrentSize: len(ns),
+			Status:      in.Status,
+		})
+	}
+
+	clusterName := in.SovereignFQDN
+	if clusterName == "" {
+		clusterName = "cluster-" + in.DeploymentID
+	}
+	clusterID := "cluster-" + in.DeploymentID
+	cluster := Cluster{
+		ID:            clusterID,
+		Name:          clusterName,
+		Version:       "v1.31",
+		Status:        in.Status,
+		NodeCount:     len(allNodes),
+		VClusters:     loadVClusters(ctx, in),
+		LoadBalancers: []LoadBalancer{},
+		NodePools:     pools,
+		Nodes:         allNodes,
+	}
+	provider := in.Provider
+	if provider == "" {
+		provider = "hetzner"
+	}
+	region := Region{
+		ID:             "region-" + regionName,
+		Name:           regionName,
+		Provider:       provider,
+		ProviderRegion: regionName,
+		SkuCP:          cpSKU,
+		SkuWorker:      workerSKU,
+		WorkerCount:    workerCount,
+		Status:         in.Status,
+		Clusters:       []Cluster{cluster},
+		Networks:       []Network{},
+	}
+	_ = cpCount
+	return region, true
+}
+
+// unstructuredAddresses returns status.addresses[] from a Node's
+// unstructured object payload.
+func unstructuredAddresses(obj map[string]any) ([]any, bool, error) {
+	st, ok := obj["status"].(map[string]any)
+	if !ok {
+		return nil, false, nil
+	}
+	addrs, ok := st["addresses"].([]any)
+	if !ok {
+		return nil, false, nil
+	}
+	return addrs, true, nil
+}
+
+// nodeReadyStatus returns the Ready condition status string ("True" /
+// "False" / "Unknown") from the Node's status.conditions[]. Returns
+// empty string when not found.
+func nodeReadyStatus(obj map[string]any) string {
+	st, ok := obj["status"].(map[string]any)
+	if !ok {
+		return ""
+	}
+	conds, ok := st["conditions"].([]any)
+	if !ok {
+		return ""
+	}
+	for _, c := range conds {
+		m, ok := c.(map[string]any)
+		if !ok {
+			continue
+		}
+		if t, _ := m["type"].(string); t == "Ready" {
+			s, _ := m["status"].(string)
+			return s
+		}
+	}
+	return ""
 }
 
 func derivePattern(in LoaderInput) string {

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/AppsPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/AppsPage.tsx
@@ -122,7 +122,11 @@ export function AppsPage({ disableStream = false }: AppsPageProps = {}) {
             statusById[a.id] = 'installing'
             break
           case 'available':
-            statusById[a.id] = 'pending'
+            // Catalog item not yet installed → render as "AVAILABLE"
+            // with an "Install" affordance, NOT a misleading "PENDING"
+            // pill. Caught on omantel.biz 2026-05-07 — KEDA showed
+            // PENDING with no install action.
+            statusById[a.id] = 'available'
             break
           default:
             statusById[a.id] = 'pending'
@@ -700,6 +704,10 @@ function AppCard({ app, status, isService, marketplacePublished, slug, onPublish
           <span className="status-chip s-failed">
             <span className="dot" /> DEGRADED
           </span>
+        ) : status === 'available' ? (
+          <span className="status-chip s-available">
+            <span className="dot" /> AVAILABLE
+          </span>
         ) : (
           <span className="status-chip s-pending">
             <span className="dot" /> PENDING
@@ -966,6 +974,7 @@ const APPS_PAGE_CSS = `
 .s-installed { background: color-mix(in srgb, var(--color-success) 16%, transparent); color: var(--color-success); }
 .s-installing { background: color-mix(in srgb, var(--color-accent) 16%, transparent); color: var(--color-accent); }
 .s-pending { background: color-mix(in srgb, var(--color-text-dim) 16%, transparent); color: var(--color-text-dim); }
+.s-available { background: color-mix(in srgb, var(--color-accent) 12%, transparent); color: var(--color-accent); border: 1px solid color-mix(in srgb, var(--color-accent) 40%, transparent); }
 .s-failed { background: color-mix(in srgb, var(--color-danger) 16%, transparent); color: var(--color-danger); }
 
 @keyframes sov-pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.35; } }

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/StatusPill.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/StatusPill.tsx
@@ -28,6 +28,7 @@ export const STATUS_TONE: Record<PillStatus, ToneSpec> = {
   installed:  { bg: 'rgba(74,222,128,0.10)',  border: 'rgba(74,222,128,0.35)',  fg: '#4ADE80',            label: 'Installed',  pulsing: false },
   failed:     { bg: 'rgba(248,113,113,0.10)', border: 'rgba(248,113,113,0.35)', fg: '#F87171',            label: 'Failed',     pulsing: false },
   degraded:   { bg: 'rgba(245,158,11,0.10)',  border: 'rgba(245,158,11,0.35)',  fg: '#F59E0B',            label: 'Degraded',   pulsing: false },
+  available:  { bg: 'rgba(56,189,248,0.08)',  border: 'rgba(56,189,248,0.40)',  fg: '#38BDF8',            label: 'Available',  pulsing: false },
   unknown:    { bg: 'rgba(148,163,184,0.10)', border: 'rgba(148,163,184,0.30)', fg: 'var(--wiz-text-sub)', label: 'Unknown',    pulsing: false },
   connecting: { bg: 'rgba(56,189,248,0.10)',  border: 'rgba(56,189,248,0.35)',  fg: '#38BDF8',            label: 'Connecting', pulsing: true  },
   streaming:  { bg: 'rgba(56,189,248,0.10)',  border: 'rgba(56,189,248,0.35)',  fg: '#38BDF8',            label: 'Provisioning', pulsing: true },

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/eventReducer.ts
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/eventReducer.ts
@@ -68,6 +68,7 @@ export type ApplicationStatus =
   | 'installed'
   | 'failed'
   | 'degraded'
+  | 'available'
   | 'unknown'
 
 export type PhaseStatus = 'pending' | 'running' | 'done' | 'failed'


### PR DESCRIPTION
Three follow-ups to PR #1071 — each visually verified in Playwright BEFORE this fix.

1. /jobs Phase-0 lifecycle missing on chroot — chrootSeedJobsStoreIfEmpty now seeds the 5 lifecycle Jobs as Succeeded under the provisioner group.
2. /cloud kind=clusters/node-pools/vclusters/load-balancers empty — topology_loader synthesizes Region/Cluster/NodePools from live K8s Nodes when the deployment record has empty Regions.
3. KEDA-style catalog items showing PENDING — added ApplicationStatus='available' distinct from 'pending' with an AVAILABLE pill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)