### PR TITLE
fix(catalyst): /jobs/timeline router precedence + bp-spire/keycloak detail copy

### DIFF
--- a/products/catalyst/bootstrap/ui/src/app/router.tsx
+++ b/products/catalyst/bootstrap/ui/src/app/router.tsx
@@ -659,6 +659,18 @@ const consoleJobsRoute = createRoute({
   path: '/jobs',
   component: JobsPage,
 })
+// Jobs timeline (Gantt-style retrospective) — chroot Sovereign Console.
+// MUST be registered BEFORE the dynamic $jobId route below so TanStack
+// Router resolves `/jobs/timeline` to this surface, not to JobDetail with
+// jobId="timeline" (which would render the canonical "Job not found"
+// branch). Sibling parity with provisionJobsTimelineRoute on the
+// /provision/$deploymentId/* tree. Caught on console.omantel.biz QA pass
+// 2026-05-07 (TC-050).
+const consoleJobsTimelineRoute = createRoute({
+  getParentRoute: () => consoleLayoutRoute,
+  path: '/jobs/timeline',
+  component: JobsTimeline,
+})
 const consoleJobDetailRoute = createRoute({
   getParentRoute: () => consoleLayoutRoute,
   path: '/jobs/$jobId',
@@ -807,6 +819,7 @@ const routeTree = rootRoute.addChildren([
     consoleAppsRoute,
     consoleAppDetailRoute,
     consoleJobsRoute,
+    consoleJobsTimelineRoute,
     consoleJobDetailRoute,
     consoleCloudRoute,
     consoleUsersRoute,

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/applicationCatalog.ts
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/applicationCatalog.ts
@@ -3,10 +3,14 @@
  * Admin landing page renders.
  *
  * Inputs:
- *   • BOOTSTRAP_KIT (catalog.generated.ts) — 11 always-installed
- *     Blueprints (cilium, cert-manager, flux, crossplane, sealed-secrets,
- *     spire, nats-jetstream, openbao, keycloak, gitea,
- *     bp-catalyst-platform).
+ *   • BOOTSTRAP_KIT (catalog.generated.ts) — always-installed Blueprints
+ *     defined by the NN-prefixed files under
+ *     clusters/_template/bootstrap-kit/. The exact set is generated
+ *     from the filesystem at build time (see catalog.generated.ts);
+ *     bp-spire is NOT in this kit (deploying SPIRE is a tier-up choice,
+ *     not a bootstrap default), so /app/bp-spire on a deployed Sovereign
+ *     correctly renders the App-not-found surface unless the operator
+ *     selected it in the wizard.
  *   • The wizard store's `selectedComponents` (string[] of bare ids
  *     without the bp- prefix, e.g. "harbor", "kserve", "axon"). Each
  *     gets normalised to its Blueprint id for display alongside the


### PR DESCRIPTION
## Summary

QA pass on console.omantel.biz surfaced three suspect AppDetail / JobDetail surfaces. After investigation:

- **TC-050 (real bug, fixed)** — `/jobs/timeline` on the chroot Sovereign Console renders \"Job not found — timeline is not part of this deployment\". Root cause: the chroot route tree (`consoleLayoutRoute` children) registered only `/jobs` and `/jobs/\$jobId` — the static `/jobs/timeline` was missing entirely, so TanStack Router fell through to the dynamic param route with `jobId=\"timeline\"`. Mothership (`/provision/\$deploymentId/jobs`) already had timeline registered before `\$jobId` (lines 326-343 of `router.tsx`). This PR ports the same precedence pattern to the chroot tree.
- **TC-029 (matrix drift)** — `/app/bp-spire` correctly renders \"App not found\" on the omantel Sovereign because **bp-spire is not in BOOTSTRAP_KIT and not deployed** (verified via `kubectl get hr -A` against the live `omantel.biz` cluster — 40 HRs reconciled, no bp-spire among them). The generated `BOOTSTRAP_KIT` constant in `catalog.generated.ts` does NOT include bp-spire. SPIRE is a tier-up selection; on a Sovereign where the operator did not select spire in the wizard, AppDetail's not-found branch is canonical behavior. Test matrix should be updated by Fix Author #4. This PR corrects a stale comment in `applicationCatalog.ts` that misleadingly listed spire among the bootstrap kit.
- **TC-023 (matrix drift)** — `/app/bp-keycloak` is missing a \"Configuration\" section. Investigation: `AppDetail.tsx` lines 285-292 deliberately short-circuit the Configuration section when the descriptor doesn't expose a `configSchema` — exact parity with the canonical `core/console/AppDetail.svelte`. None of today's catalog descriptors expose a config schema, so Configuration is omitted everywhere. The matrix expectation that bp-keycloak's detail page contain \"Configuration\" text is wrong. No FE bug.

## Changes

- `products/catalyst/bootstrap/ui/src/app/router.tsx` — register `consoleJobsTimelineRoute` for `/jobs/timeline` BEFORE `consoleJobDetailRoute` in the chroot Sovereign Console tree.
- `products/catalyst/bootstrap/ui/src/pages/sovereign/applicationCatalog.ts` — correct stale comment listing spire among the bootstrap kit.

## Per-TC verdict

| TC | URL | Verdict |
|---|---|---|
| TC-050 | `/jobs/timeline` | real-bug-fixed — sibling parity with mothership tree |
| TC-029 | `/app/bp-spire` | matrix-drift-confirmed — bp-spire not deployed on omantel; AppDetail behavior is canonical |
| TC-023 | `/app/bp-keycloak` (Configuration) | matrix-drift-confirmed — Configuration section short-circuits when descriptor exposes no schema (canonical) |

## Test plan

- [x] `npm run typecheck` passes (no TS errors)
- [ ] Post-deploy: visit `https://console.omantel.biz/jobs/timeline` — expect Gantt-style timeline view, NOT \"Job not found\"
- [ ] Post-deploy: visit `https://console.omantel.biz/jobs/\$realJobId` — expect JobDetail page (regression check that the new sibling route doesn't shadow the dynamic param)
- [ ] Risk: low. Pure additive route registration + comment edit. No FE state changes, no API contract changes, no SSE changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)