### PR TITLE
fix(catalyst): /jobs/timeline page renders without crash

### DIFF
--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/JobsTimeline.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/JobsTimeline.tsx
@@ -23,7 +23,8 @@
  */
 
 import { useMemo } from 'react'
-import { useParams, Link } from '@tanstack/react-router'
+import { Link } from '@tanstack/react-router'
+import { useResolvedDeploymentId } from '@/shared/lib/useResolvedDeploymentId'
 import { useWizardStore } from '@/entities/deployment/store'
 import { PortalShell } from './PortalShell'
 import { resolveApplications } from './applicationCatalog'
@@ -77,10 +78,17 @@ export function JobsTimeline({
   nowOverride,
   jobsOverride,
 }: JobsTimelineProps = {}) {
-  const params = useParams({
-    from: '/provision/$deploymentId/jobs/timeline' as never,
-  }) as { deploymentId: string }
-  const { deploymentId } = params
+  // Resolve deploymentId from either:
+  //   • URL :deploymentId param (mothership tenant route /provision/$id/jobs/timeline)
+  //   • /api/v1/sovereign/self (Sovereign chroot route /jobs/timeline, no URL param)
+  // Mirrors the pattern used by JobsPage / NotificationsPage / Dashboard.
+  // Caught on console.omantel.biz QA pass 2026-05-07 (TC-050): the previous
+  // strict useParams({ from: '/provision/$deploymentId/jobs/timeline' })
+  // threw "Invariant failed" when the route tree-match was the chroot
+  // consoleJobsTimelineRoute (path '/jobs/timeline'), tripping the React
+  // Error Boundary and replacing the surface with the error overlay.
+  const { deploymentId: resolvedId } = useResolvedDeploymentId()
+  const deploymentId = resolvedId ?? ''
   const store = useWizardStore()
 
   const applications = useMemo(

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/JobsTimeline.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/JobsTimeline.tsx
@@ -1,6 +1,8 @@
 /**
  * JobsTimeline — fullscreen Gantt-style retrospective view of all jobs.
- * (Stretch deliverable for #206; route at /provision/$deploymentId/jobs/timeline.)
+ * (Stretch deliverable for #206; routes:
+ *   • mothership tenant: /provision/$deploymentId/jobs/timeline
+ *   • Sovereign chroot:  /jobs/timeline (added by PR #1073, fixed in #1076).)
  *
  * Each row is one job; a horizontal bar spans `startedAt` → `finishedAt`
  * (or "now" if the job is still running). Bars are colour-coded by


### PR DESCRIPTION
## Summary
- Root cause: `JobsTimeline.tsx` used strict `useParams({ from: '/provision/$deploymentId/jobs/timeline' })`, which threw `Invariant failed` inside `useSyncExternalStoreWithSelector` when the actual route tree-match was the chroot `consoleJobsTimelineRoute` (path `/jobs/timeline`, added by PR #1073). The throw bubbled to the React Error Boundary and replaced the surface with the "Something went wrong! Show Error" overlay (TC-050 P1, Iteration 2 verdict).
- Fix: replace strict `useParams` with the canonical `useResolvedDeploymentId()` hook used by JobsPage / NotificationsPage / Dashboard. It reads the `:deploymentId` URL param when present (mothership tenant route) and falls back to `/api/v1/sovereign/self` when absent (chroot Sovereign route). Same module now serves both topologies.
- Scope: TOUCH ONLY `JobsTimeline.tsx`. No SSE / EventSource changes (Fix #5). No tenantDiscover / handover (Fix #6). No router.tsx edits (route registration from #1073 was already correct — only the component was broken).

## Test plan
- [x] tsc clean (`npm run typecheck`)
- [x] eslint clean
- [x] Reproduced crash on https://console.omantel.biz/jobs/timeline pre-fix: console error `Invariant failed` at `useSyncExternalStoreWithSelector`, body shows "Something went wrong! Show Error"
- [ ] Post-deploy: navigate /jobs/timeline on chroot → renders timeline shell (empty state OK if no jobs with timestamps)
- [ ] Post-deploy: mothership /provision/<id>/jobs/timeline still works (regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)