### PR TITLE
fix(catalyst-api): /api/v1/whoami enrichment with sovereign context

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/auth.go
+++ b/products/catalyst/bootstrap/api/internal/handler/auth.go
@@ -715,12 +715,58 @@ func resolvePostLogoutPath() string {
 	return "/sovereign/login"
 }
 
+// whoamiResponse is the wire shape of GET /api/v1/whoami.
+//
+// On Catalyst-Zero (mother) the sovereign fields are empty and the
+// `omitempty` JSON tags drop them, preserving the original
+// {email, sub, verified} shape that pre-#608 callers depend on.
+//
+// On a chroot Sovereign the fields are populated so the SPA can
+// discover its sovereign context from a single round-trip without a
+// follow-up /api/v1/sovereign/self call. This is the contract
+// SovereignConsoleLayout + chroot SPA features assert in TC-232.
+type whoamiResponse struct {
+	Email         string `json:"email"`
+	Sub           string `json:"sub"`
+	Verified      bool   `json:"verified"`
+	DeploymentID  string `json:"deploymentId,omitempty"`
+	SovereignFQDN string `json:"sovereignFQDN,omitempty"`
+	Mode          string `json:"mode,omitempty"`
+}
+
 // HandleWhoami handles GET /api/v1/whoami.
 //
 // Returns the authenticated operator's claims from context. The
 // RequireSession middleware has already validated the session cookie
 // before this handler is reached, so a nil claims is a logic error.
-// Returns {"email":"...","sub":"...","verified":true/false}.
+//
+// Mother (Catalyst-Zero) returns:
+//
+//	{"email":"...","sub":"...","verified":true}
+//
+// Chroot (Sovereign) additionally returns:
+//
+//	{..., "deploymentId":"sovereign-<fqdn>",
+//	      "sovereignFQDN":"<fqdn>",
+//	      "mode":"sovereign"}
+//
+// The chroot enrichment uses the same resolution precedence as
+// HandleSovereignSelf (sovereign_self.go) so both endpoints converge on
+// the same identifiers post-handover:
+//
+//  1. Session-JWT claims SovereignFQDN + DeploymentID (set by
+//     /auth/handover when the operator arrived from the wizard).
+//  2. Env CATALYST_SELF_DEPLOYMENT_ID / CATALYST_OTECH_FQDN /
+//     SOVEREIGN_FQDN (stamped on every chroot catalyst-api by the
+//     bp-catalyst-platform sovereign-fqdn ConfigMap).
+//  3. If the chroot is identifiable by FQDN but lacks a stamped
+//     deployment id (typical post-cutover before orchestrator overlay
+//     write lands), synthesize the canonical
+//     `sovereign-<fqdn>` id — the same convention as
+//     sovereign_self.go's step-3 fallback so URL routing stays stable.
+//
+// Mothership (no FQDN env, no claim-fqdn) → fields stay empty and
+// `omitempty` drops them: pre-#608 wire compatibility preserved.
 func (h *Handler) HandleWhoami(w http.ResponseWriter, r *http.Request) {
 	claims := auth.ClaimsFromContext(r.Context())
 	if claims == nil {
@@ -728,9 +774,37 @@ func (h *Handler) HandleWhoami(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "unauthenticated"})
 		return
 	}
-	writeJSON(w, http.StatusOK, map[string]interface{}{
-		"email":    claims.Email,
-		"sub":      claims.Sub,
-		"verified": claims.EmailVerified,
-	})
+
+	resp := whoamiResponse{
+		Email:    claims.Email,
+		Sub:      claims.Sub,
+		Verified: claims.EmailVerified,
+	}
+
+	// Sovereign-context enrichment — same precedence as HandleSovereignSelf
+	// so the two endpoints never disagree about which sovereign this is.
+	deploymentID := strings.TrimSpace(claims.DeploymentID)
+	fqdn := strings.TrimSpace(claims.SovereignFQDN)
+	if fqdn == "" {
+		fqdn = strings.TrimSpace(os.Getenv("CATALYST_OTECH_FQDN"))
+	}
+	if fqdn == "" {
+		fqdn = strings.TrimSpace(os.Getenv("SOVEREIGN_FQDN"))
+	}
+	if deploymentID == "" {
+		deploymentID = strings.TrimSpace(os.Getenv("CATALYST_SELF_DEPLOYMENT_ID"))
+	}
+	// Synthesize the canonical chroot id when FQDN is known but no id
+	// has been stamped yet — matches sovereign_self.go step-3.
+	if deploymentID == "" && fqdn != "" {
+		deploymentID = "sovereign-" + fqdn
+	}
+
+	if fqdn != "" {
+		resp.SovereignFQDN = fqdn
+		resp.DeploymentID = deploymentID
+		resp.Mode = "sovereign"
+	}
+
+	writeJSON(w, http.StatusOK, resp)
 }

--- a/products/catalyst/bootstrap/api/internal/handler/whoami_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/whoami_test.go
@@ -1,0 +1,162 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/auth"
+)
+
+// TestHandleWhoami_Mothership pins the original wire shape on
+// Catalyst-Zero (mother): when neither the session JWT carries
+// sovereign claims nor any sovereign-fqdn env is set, the response is
+// the pre-#608 {email, sub, verified} shape with no sovereign fields.
+//
+// `omitempty` on DeploymentID/SovereignFQDN/Mode is what guarantees
+// existing mother callers never see new keys.
+func TestHandleWhoami_Mothership(t *testing.T) {
+	// Make sure no leaked env from another test contaminates the result.
+	t.Setenv("SOVEREIGN_FQDN", "")
+	t.Setenv("CATALYST_OTECH_FQDN", "")
+	t.Setenv("CATALYST_SELF_DEPLOYMENT_ID", "")
+
+	h := New(slog.New(slog.NewTextHandler(os.Stderr, nil)))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/whoami", nil)
+	ctx := context.WithValue(req.Context(), auth.ClaimsKey, &auth.Claims{
+		Sub:           "kc-sub-mother",
+		Email:         "ops@openova.io",
+		EmailVerified: true,
+	})
+	req = req.WithContext(ctx)
+	rr := httptest.NewRecorder()
+
+	h.HandleWhoami(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status: want 200, got %d (body=%s)", rr.Code, rr.Body.String())
+	}
+	// Decode into a generic map so we can assert *absence* of the
+	// sovereign keys (a typed struct with omitempty would silently zero
+	// them and lose the regression signal).
+	var got map[string]any
+	if err := json.Unmarshal(rr.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v (body=%s)", err, rr.Body.String())
+	}
+	if got["email"] != "ops@openova.io" {
+		t.Errorf("email: want ops@openova.io, got %v", got["email"])
+	}
+	if got["sub"] != "kc-sub-mother" {
+		t.Errorf("sub: want kc-sub-mother, got %v", got["sub"])
+	}
+	if got["verified"] != true {
+		t.Errorf("verified: want true, got %v", got["verified"])
+	}
+	for _, k := range []string{"deploymentId", "sovereignFQDN", "mode"} {
+		if _, ok := got[k]; ok {
+			t.Errorf("mothership response must not include %q (got %v)", k, got[k])
+		}
+	}
+}
+
+// TestHandleWhoami_ChrootFromClaims — post-handover path. The
+// session JWT minted by /auth/handover carries SovereignFQDN +
+// DeploymentID and whoami surfaces them so SovereignConsoleLayout +
+// chroot SPA features (TC-232) can discover the sovereign context in
+// a single round trip.
+func TestHandleWhoami_ChrootFromClaims(t *testing.T) {
+	t.Setenv("SOVEREIGN_FQDN", "")
+	t.Setenv("CATALYST_OTECH_FQDN", "")
+	t.Setenv("CATALYST_SELF_DEPLOYMENT_ID", "")
+
+	h := New(slog.New(slog.NewTextHandler(os.Stderr, nil)))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/whoami", nil)
+	ctx := context.WithValue(req.Context(), auth.ClaimsKey, &auth.Claims{
+		Sub:           "kc-sub-sov",
+		Email:         "operator@example.com",
+		EmailVerified: true,
+		SovereignFQDN: "omantel.biz",
+		DeploymentID:  "sovereign-omantel.biz",
+	})
+	req = req.WithContext(ctx)
+	rr := httptest.NewRecorder()
+
+	h.HandleWhoami(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status: want 200, got %d (body=%s)", rr.Code, rr.Body.String())
+	}
+	var got whoamiResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.Email != "operator@example.com" || got.Sub != "kc-sub-sov" || !got.Verified {
+		t.Errorf("base claims wrong: %+v", got)
+	}
+	if got.SovereignFQDN != "omantel.biz" {
+		t.Errorf("sovereignFQDN: want omantel.biz, got %q", got.SovereignFQDN)
+	}
+	if got.DeploymentID != "sovereign-omantel.biz" {
+		t.Errorf("deploymentId: want sovereign-omantel.biz, got %q", got.DeploymentID)
+	}
+	if got.Mode != "sovereign" {
+		t.Errorf("mode: want sovereign, got %q", got.Mode)
+	}
+}
+
+// TestHandleWhoami_ChrootFromEnv — direct-OIDC chroot login (no
+// /auth/handover detour) leaves the session JWT without sovereign
+// claims, but the chroot pod's env (SOVEREIGN_FQDN) identifies it.
+// Verifies env-fallback + synthesized "sovereign-<fqdn>" deployment id.
+func TestHandleWhoami_ChrootFromEnv(t *testing.T) {
+	t.Setenv("SOVEREIGN_FQDN", "omantel.biz")
+	t.Setenv("CATALYST_OTECH_FQDN", "")
+	t.Setenv("CATALYST_SELF_DEPLOYMENT_ID", "")
+
+	h := New(slog.New(slog.NewTextHandler(os.Stderr, nil)))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/whoami", nil)
+	ctx := context.WithValue(req.Context(), auth.ClaimsKey, &auth.Claims{
+		Sub:           "kc-sub-direct",
+		Email:         "operator@example.com",
+		EmailVerified: true,
+	})
+	req = req.WithContext(ctx)
+	rr := httptest.NewRecorder()
+
+	h.HandleWhoami(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status: want 200, got %d", rr.Code)
+	}
+	var got whoamiResponse
+	_ = json.Unmarshal(rr.Body.Bytes(), &got)
+	if got.SovereignFQDN != "omantel.biz" {
+		t.Errorf("sovereignFQDN: want omantel.biz, got %q", got.SovereignFQDN)
+	}
+	if got.DeploymentID != "sovereign-omantel.biz" {
+		t.Errorf("deploymentId: want synthesized sovereign-omantel.biz, got %q", got.DeploymentID)
+	}
+	if got.Mode != "sovereign" {
+		t.Errorf("mode: want sovereign, got %q", got.Mode)
+	}
+}
+
+// TestHandleWhoami_NilClaims — defensive: RequireSession should always
+// inject claims, but a logic bug stripping the middleware must surface
+// as 401, not a panic / empty 200.
+func TestHandleWhoami_NilClaims(t *testing.T) {
+	h := New(slog.New(slog.NewTextHandler(os.Stderr, nil)))
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/whoami", nil)
+	rr := httptest.NewRecorder()
+	h.HandleWhoami(rr, req)
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("nil-claims path: want 401, got %d (body=%s)", rr.Code, rr.Body.String())
+	}
+}


### PR DESCRIPTION
## Why — TC-232 regression on omantel.biz iter-3

`GET /api/v1/whoami` on chroot `console.omantel.biz` returns only:

```json
{"email":"...","sub":"...","verified":true}
```

The matrix and PR #608 / #1052 contracts expect the chroot path to
also surface:

- `deploymentId` (e.g. `sovereign-omantel.biz`)
- `sovereignFQDN` (e.g. `omantel.biz`)
- `mode: "sovereign"`

Without these, the chroot SPA's `SovereignConsoleLayout` plus every
feature that reads sovereign context from whoami either falls back to
a follow-up `/api/v1/sovereign/self` call (extra round-trip) or — for
features that only consult whoami — silently degrades.

## Root cause

`HandleWhoami` was surfacing the bare auth claims (email/sub/verified)
and ignoring two already-available sources of sovereign context:

1. The session JWT carries `SovereignFQDN` + `DeploymentID` claims
   (added 2026-05-06 in the `sovereign_self.go` cookie-claims path)
   when the operator arrived via `/auth/handover`.
2. The chroot pod's env (`SOVEREIGN_FQDN`, `CATALYST_OTECH_FQDN`,
   `CATALYST_SELF_DEPLOYMENT_ID`) is stamped by the
   bp-catalyst-platform sovereign-fqdn ConfigMap.

Whoami needs to read the same precedence as `HandleSovereignSelf` so
the two endpoints never disagree about which sovereign this is.

## What

- New typed `whoamiResponse` struct with `omitempty` on
  `deploymentId` / `sovereignFQDN` / `mode` — mothership wire shape
  remains byte-identical to before.
- Resolution order mirrors `sovereign_self.go`:
  1. `claims.DeploymentID` / `claims.SovereignFQDN`.
  2. Env: `CATALYST_SELF_DEPLOYMENT_ID`, `CATALYST_OTECH_FQDN`,
     `SOVEREIGN_FQDN`.
  3. If FQDN is known but no id stamped → synthesize
     `sovereign-<fqdn>` (same convention as `sovereign_self.go`
     step-3, so SPA deployment-scoped fetches resolve to the
     chroot's self-registered cluster).
- `mode: "sovereign"` is set only when an FQDN is found — chroot SPA
  features can branch on this single field.

## Tests

`internal/handler/whoami_test.go` (4 cases):

- `TestHandleWhoami_Mothership` — pre-#608 wire shape preserved (no
  `deploymentId`, no `sovereignFQDN`, no `mode` keys).
- `TestHandleWhoami_ChrootFromClaims` — post-handover path.
- `TestHandleWhoami_ChrootFromEnv` — direct-OIDC chroot login.
- `TestHandleWhoami_NilClaims` — defensive 401 (logic-bug guard).

All four pass locally.

## Scope

- ONLY `internal/handler/auth.go::HandleWhoami` + the new test file.
- No change to `sovereign_self.go` (separate endpoint).
- No new auth flows; the existing RequireSession gate still owns the
  401 path.

## Verification (post-merge)

- [ ] CI build-api green
- [ ] After chart auto-bump rolls the new image on omantel.biz, curl
      `https://console.omantel.biz/api/v1/whoami` with a valid
      `catalyst_session` cookie → response includes `deploymentId`,
      `sovereignFQDN`, `mode: "sovereign"`.
- [ ] Mother `https://api.openova.io/api/v1/whoami` unchanged
      (no new keys; existing callers untouched).

Refs: TC-232, PR #608, PR #1052.

🤖 Generated with [Claude Code](https://claude.com/claude-code)