### PR TITLE
fix(catalyst): chroot dashboard tenant pill click surfaces FQDN

### DIFF
--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/SovereignSidebar.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/SovereignSidebar.tsx
@@ -19,8 +19,10 @@
  * Related: GitHub issue #607
  */
 
+import { useState } from 'react'
 import { Link, useRouterState } from '@tanstack/react-router'
 import { loadTokens, parseJWTClaims } from '@/shared/lib/oidc'
+import { DETECTED_MODE } from '@/shared/lib/detectMode'
 
 interface SovereignSidebarProps {
   /** Sovereign FQDN derived from window.location.hostname. */
@@ -140,6 +142,25 @@ export function SovereignSidebar({ sovereignFQDN }: SovereignSidebarProps) {
   const activeSettingsSub = deriveActiveSettingsSubItem(pathname)
   const settingsExpanded = activeSection === 'settings'
 
+  // Tenant-label expanded state — clicking the pill opens a small inline
+  // panel listing the full Sovereign FQDN. The pill itself only has room
+  // for a truncated label; the expanded panel guarantees the FQDN is
+  // surfaced into the viewport DOM regardless of width. Closes on a
+  // second click. (Issue #607 — TC-133 contract: clicking the sidebar
+  // tenant label surfaces the FQDN.)
+  const [tenantOpen, setTenantOpen] = useState(false)
+
+  // Resolve the FQDN to display. The prop is the canonical source when
+  // present; on the chroot Sovereign Console the deploymentId-bound
+  // snapshot may not yet be loaded for newly-mounted pages, in which
+  // case we fall back to the hostname-derived FQDN exposed by
+  // `DETECTED_MODE`. This avoids ever rendering an empty tenant label
+  // on `console.<sov-fqdn>` regardless of network timing.
+  const resolvedFQDN =
+    sovereignFQDN && sovereignFQDN.length > 0
+      ? sovereignFQDN
+      : DETECTED_MODE.sovereignFQDN ?? ''
+
   // Read user info from the OIDC session for the footer card.
   const tokens = loadTokens()
   const claims = tokens ? parseJWTClaims(tokens.idToken) : {}
@@ -182,14 +203,49 @@ export function SovereignSidebar({ sovereignFQDN }: SovereignSidebarProps) {
           </span>
         </div>
         <div className="px-3 pb-3">
-          <div
-            className="flex w-full items-center justify-between gap-2 rounded-lg border border-[var(--color-border)] bg-[var(--color-bg)] px-3 py-2 text-left text-xs"
+          <button
+            type="button"
+            onClick={() => setTenantOpen((v) => !v)}
+            aria-expanded={tenantOpen}
+            aria-controls="sov-console-tenant-details"
+            className="flex w-full items-center justify-between gap-2 rounded-lg border border-[var(--color-border)] bg-[var(--color-bg)] px-3 py-2 text-left text-xs transition-colors hover:border-[var(--color-accent)] hover:bg-[var(--color-surface-hover)]"
             data-testid="sov-console-tenant-label"
+            title={resolvedFQDN}
           >
-            <span className="min-w-0 flex-1 truncate text-[var(--color-text-strong)]">
-              {sovereignFQDN}
+            <span
+              className="min-w-0 flex-1 truncate text-[var(--color-text-strong)]"
+              data-testid="sov-console-tenant-fqdn"
+            >
+              {resolvedFQDN}
             </span>
-          </div>
+            <svg
+              className={`h-3 w-3 shrink-0 text-[var(--color-text-dim)] transition-transform ${
+                tenantOpen ? 'rotate-180' : ''
+              }`}
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              strokeWidth={2}
+              aria-hidden
+            >
+              <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
+            </svg>
+          </button>
+          {tenantOpen ? (
+            <div
+              id="sov-console-tenant-details"
+              data-testid="sov-console-tenant-details"
+              className="mt-2 rounded-lg border border-[var(--color-border)] bg-[var(--color-bg)] px-3 py-2 text-[11px]"
+            >
+              <p className="text-[var(--color-text-dimmer)]">Sovereign FQDN</p>
+              <p
+                className="mt-0.5 break-all font-mono text-[var(--color-text-strong)]"
+                data-testid="sov-console-tenant-fqdn-full"
+              >
+                {resolvedFQDN}
+              </p>
+            </div>
+          ) : null}
         </div>
       </div>
 
@@ -271,7 +327,7 @@ export function SovereignSidebar({ sovereignFQDN }: SovereignSidebarProps) {
           </div>
           <div className="min-w-0 flex-1">
             <p className="truncate text-xs font-medium text-[var(--color-text)]">{userName}</p>
-            <p className="truncate text-[10px] text-[var(--color-text-dimmer)]">{sovereignFQDN}</p>
+            <p className="truncate text-[10px] text-[var(--color-text-dimmer)]">{resolvedFQDN}</p>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary

TC-133 (iter-3 QA loop) reported: clicking the sidebar tenant pill on `/dashboard` did not surface the Sovereign FQDN (`omantel.biz`) into the dashboard body — the FQDN rendered fine in settings + header, but the sidebar tenant label was empty AND was a passive `<div>` with no click handler.

Root cause: two stacked bugs in `SovereignSidebar.tsx`:

1. The label bound directly to `sovereignFQDN` from the deployment snapshot. On chroot pages where the snapshot is still in flight (or where the route doesn't subscribe), the value fell through `?? ''` and the label rendered empty — even though `DETECTED_MODE.sovereignFQDN` (parsed from `console.<sov-fqdn>` hostname) was available the whole time.
2. The label was a `<div>`. The matrix asserts that **clicking** the pill surfaces the FQDN. No handler = no surface.

## Fix

- New `resolvedFQDN` fallback chain: `prop ?? DETECTED_MODE.sovereignFQDN ?? ''`. The hostname-derived value is the canonical chroot identity — a snapshot race can never starve it.
- Tenant label is now a `<button aria-expanded aria-controls>` that toggles an inline details panel (`sov-console-tenant-details`). The expanded panel renders the full FQDN in a dedicated `font-mono` block (`sov-console-tenant-fqdn-full`), guaranteeing it's in the body innerText regardless of sidebar width / truncation.
- Bottom user card also reads `resolvedFQDN` so the FQDN under the user-name never renders empty either.

## Test contract

Matrix TC-133:
- `action`: click sidebar tenant label; verify it shows omantel.biz FQDN
- `expected`: Sidebar tenant label renders 'omantel.biz' or similar derived from sovereignFQDN
- `must_contain`: ["omantel"]
- `testid`: `sov-console-tenant-label` (preserved); new `sov-console-tenant-details`, `sov-console-tenant-fqdn`, `sov-console-tenant-fqdn-full`

After this PR, on `console.omantel.biz/dashboard`:
- Sidebar tenant pill text content = `omantel.biz` (from `DETECTED_MODE` even when snapshot late)
- Click pill → panel expands with `Sovereign FQDN` label + `omantel.biz` in mono
- Body innerText contains `omantel` (sidebar is part of the body)

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run SovereignConsoleLayout` (3/3 pass — sidebar is mocked)
- [x] `npx vitest run Dashboard` (6/6 pass)
- [ ] Playwright TC-133: click `sov-console-tenant-label` on chroot dashboard, assert body innerText contains `omantel`, screenshot

## Hard rules respected
- Pill design unchanged (same border, padding, accent hover); just turned the wrapper into a button + added a chevron + toggle panel
- No sidebar tenant-selector logic touched (other Fix Author scope if any)
- No hardcoded FQDN — `DETECTED_MODE.sovereignFQDN` is hostname-derived per existing canonical seam