### PR TITLE
fix(catalyst): cloud list views consume SSE cache for 7 missing kinds

### DIFF
--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/Architecture.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/Architecture.tsx
@@ -19,11 +19,19 @@
  *      or the type/edge palette in widgets/architecture-graph/types.ts.
  */
 
-import { ArchitectureGraphPage } from '@/widgets/architecture-graph'
+import { ArchitectureGraphPage, type K8sSnapshot } from '@/widgets/architecture-graph'
 import { useCloud } from './CloudPage'
 
 export function Architecture() {
-  const { deploymentId, data, isLoading, isError, refetch } = useCloud()
+  const {
+    deploymentId,
+    data,
+    isLoading,
+    isError,
+    refetch,
+    k8sSnapshot,
+    k8sRevision,
+  } = useCloud()
   return (
     <ArchitectureGraphPage
       deploymentId={deploymentId}
@@ -31,6 +39,15 @@ export function Architecture() {
       isLoading={isLoading}
       isError={isError}
       onRefetch={refetch}
+      // Forward the shared SSE snapshot so the graph widget consumes
+      // the SAME live snapshot the chip counts and every K8s list view
+      // read from. Without this the widget would open a duplicate
+      // EventSource and the per-page snapshot read by CloudListView /
+      // K8sListPage would starve under the HTTP/1.1 connection budget,
+      // leaving services / ingresses / deployments / statefulsets /
+      // daemonsets / namespaces / nodes rendering "No X objects".
+      k8sSnapshot={(k8sSnapshot as unknown as K8sSnapshot | null) ?? null}
+      k8sRevision={k8sRevision}
     />
   )
 }

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-list/K8sListPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/cloud-list/K8sListPage.tsx
@@ -103,8 +103,17 @@ export function K8sListPage({
   // alternative (per-page subscriptions) starved under the HTTP/1.1
   // 6-connections-per-origin limit because each open SSE stream
   // holds a connection slot for its lifetime.
+  //
+  // The snapshot Map is mutated in-place by useK8sCacheStream so its
+  // reference is STABLE across deltas — listing `k8sSnapshot` alone in
+  // the useMemo deps would never recompute past the first render. The
+  // `k8sRevision` counter bumps on every applied event, so adding it to
+  // the deps is what actually makes the list re-derive when new objects
+  // arrive over SSE. Without this, services / ingresses / deployments /
+  // statefulsets / daemonsets / namespaces / nodes all rendered "No X
+  // objects" while the graph view (which keeps its own revision-keyed
+  // memo) showed full counts.
   const { k8sSnapshot, k8sStatus, k8sRevision } = useCloud()
-  void k8sRevision // dependency hint for future memo passes
 
   const rows = useMemo(() => {
     const out: K8sObject[] = []
@@ -124,7 +133,8 @@ export function K8sListPage({
       })
     }
     return out
-  }, [k8sSnapshot, kind, sortByName])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [k8sSnapshot, k8sRevision, kind, sortByName])
 
   return (
     <div data-testid={`cloud-${kind}-list`}>

--- a/products/catalyst/bootstrap/ui/src/widgets/architecture-graph/ArchitectureGraphPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/widgets/architecture-graph/ArchitectureGraphPage.tsx
@@ -66,7 +66,7 @@ import type {
 import { GraphCanvas, type GraphCanvasHandle } from './GraphCanvas'
 import { hierarchyToGraph } from './adapter'
 import { k8sToGraph, mergeGraphs } from './k8sAdapter'
-import { useK8sCacheStream } from './useK8sCacheStream'
+import { useK8sCacheStream, type K8sSnapshot } from './useK8sCacheStream'
 import {
   ALL_EDGE_TYPES,
   ALL_NODE_TYPES,
@@ -126,6 +126,22 @@ export interface ArchitectureGraphPageProps {
   isLoading: boolean
   isError: boolean
   onRefetch: () => void
+  /**
+   * Live K8s cache snapshot fed by the page-level useK8sCacheStream
+   * subscription on CloudPage. When provided, this widget reads from
+   * the shared snapshot instead of opening its own EventSource —
+   * ONE SSE connection per page is the canonical pattern (see
+   * useK8sCacheStream's design notes about HTTP/1.1 connection-budget
+   * starvation when the same origin opens duplicate streams).
+   *
+   * When omitted (e.g. in standalone storybook usage or tests), the
+   * widget falls back to opening its own subscription.
+   */
+  k8sSnapshot?: K8sSnapshot | null
+  /** Companion revision counter from useK8sCacheStream — bumps on every
+   *  applied delta so memoised adapters re-derive when the in-place
+   *  Map mutates. */
+  k8sRevision?: number
 }
 
 /* ── Component ───────────────────────────────────────────────────── */
@@ -191,15 +207,30 @@ export function ArchitectureGraphPage({
   isLoading,
   isError,
   onRefetch,
+  k8sSnapshot: k8sSnapshotProp,
+  k8sRevision: k8sRevisionProp,
 }: ArchitectureGraphPageProps) {
   const handleRef = useRef<GraphCanvasHandle | null>(null)
 
   /* ── 0. Live K8s cache stream — feeds the K8s-side adapter
-   *     alongside the cloud-side hierarchy fetch. The hook opens an
-   *     EventSource against /api/v1/sovereigns/{deploymentId}/k8s/
-   *     stream?initialState=1 and accumulates a snapshot map as
-   *     ADDED/MODIFIED/DELETED events arrive. */
-  const { snapshot: k8sSnapshot, revision: k8sRevision } = useK8sCacheStream(deploymentId)
+   *     alongside the cloud-side hierarchy fetch.
+   *
+   *     PRIMARY: read from the page-level shared snapshot passed in
+   *     via props. CloudPage holds ONE EventSource subscribing to all
+   *     kinds; the snapshot is broadcast to (a) the chip counts in
+   *     the toolbar, (b) every K8sListPage in list view, and (c) this
+   *     graph view. Sharing one subscription avoids the HTTP/1.1
+   *     6-connections-per-origin starvation that otherwise leaves
+   *     consumers stuck on the "connecting" placeholder forever.
+   *
+   *     FALLBACK: when no snapshot is supplied (storybook / tests /
+   *     direct embed), open an internal stream so the widget remains
+   *     self-sufficient. */
+  const fallback = useK8sCacheStream(deploymentId, {
+    enabled: k8sSnapshotProp == null,
+  })
+  const k8sSnapshot = k8sSnapshotProp ?? fallback.snapshot
+  const k8sRevision = k8sRevisionProp ?? fallback.revision
 
   /* ── 1. Adapter — tree → nodes/edges, merged with K8s side ─── */
   const { nodes: allNodes, edges: allEdges } = useMemo(() => {


### PR DESCRIPTION
## Summary

Closes 7 FAIL rows in the iter-3 Sovereign Console QA matrix — services / ingresses / deployments / statefulsets / daemonsets / namespaces / nodes (TC-066/067/072/073/074/078/079) all rendered \"No X objects\" even though the architecture graph view showed full counts for the same kinds.

Two stacked bugs in the SSE-cache consumer path:

1. **Duplicate EventSource subscription.** `ArchitectureGraphPage` opened its own `useK8sCacheStream(deploymentId)` subscription instead of consuming the page-level snapshot exposed on `CloudPage`'s `useCloud()` context. That meant TWO concurrent EventSource connections per page — under the chroot's HTTP/1.1 6-connections-per-origin budget, `CloudPage`'s subscription got starved, leaving the chip counts and every `K8sListPage` reading an empty snapshot.

2. **Stale-Map useMemo deps.** `K8sListPage`'s `rows` memo listed `[k8sSnapshot, kind, sortByName]` only. The snapshot `Map` is mutated **in-place** by `useK8sCacheStream` (intentional, to coalesce high-frequency event bursts) so its reference is stable across deltas — the memo never recomputed past the initial empty snapshot. `k8sRevision` is the companion counter that bumps on every applied event; the previous code marked it as a `void k8sRevision // dependency hint for future memo passes` no-op. The future is now.

## Fix

- `ArchitectureGraphPage` accepts optional `k8sSnapshot` + `k8sRevision` props. When provided (the production path via `Architecture.tsx` → `useCloud()`), the widget reads from the shared snapshot. When omitted (storybook / tests), it opens its own subscription as a fallback so the widget remains self-sufficient.
- `Architecture.tsx` forwards `k8sSnapshot` + `k8sRevision` from `useCloud()` into the widget — collapsing the two SSE connections into one shared page-level subscription.
- `K8sListPage` adds `k8sRevision` to the rows `useMemo` deps so the list re-derives on every applied delta. Extended comment explains why the revision is what makes the in-place-mutated `Map` observable.

## Test plan

- [x] `tsc -b --noEmit` clean
- [x] `vitest run src/pages/sovereign/CloudPage.test.tsx src/pages/sovereign/Architecture.test.tsx` — 21/21 passing
- [x] `vitest run src/widgets/architecture-graph/k8sAdapter.test.ts` — 13/13 passing
- [ ] Live Playwright on `console.sovereign-omantel.biz/cloud?view=list&kind={services|ingresses|deployments|statefulsets|daemonsets|namespaces|nodes}` after deploy — expect each list to render rows from the live SSE snapshot (was: \"No X objects\")
- [ ] Graph view continues to show same counts (regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)