### PR TITLE
fix(catalyst): chroot /events + /logs IsNotFound -> empty 200 fallback (TC-229)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/deployments.go
+++ b/products/catalyst/bootstrap/api/internal/handler/deployments.go
@@ -1199,12 +1199,27 @@ func (h *Handler) GetDeployment(w http.ResponseWriter, r *http.Request) {
 
 func (h *Handler) StreamLogs(w http.ResponseWriter, r *http.Request) {
 	id := chi.URLParam(r, "id")
+	// chroot fallback: empty until deployment record settles.
+	// On the chroot (SOVEREIGN_FQDN env set), the cutover does NOT
+	// import the mother's deployment record into the chroot's
+	// in-memory map. The first dashboard load after handover races
+	// the synthesis path so without this fallback the wizard's SSE
+	// reconnect loop sees a transient 404 (TC-229).
+	// chrootEnsureDeployment synthesises a record with pre-closed
+	// channels, so the "completed deployment, replay buffer + emit
+	// done" branch fires below — empty buffer + done frame is the
+	// right shape for a freshly-handed-over Sovereign. Once the
+	// chroot lazy-seed populates jobs/events the next reconnect
+	// returns the real history. On the mother (no SOVEREIGN_FQDN)
+	// chrootEnsureDeployment returns nil and the legacy 404 stands.
 	val, ok := h.deployments.Load(id)
-	if !ok {
+	var dep *Deployment
+	if ok {
+		dep = val.(*Deployment)
+	} else if dep = h.chrootEnsureDeployment(id); dep == nil {
 		http.Error(w, "deployment not found", http.StatusNotFound)
 		return
 	}
-	dep := val.(*Deployment)
 	// Issue #689 — ownership check BEFORE any SSE bytes are written. Once
 	// the response is hijacked into text/event-stream mode the helper's
 	// JSON 404 path can't fire, so this MUST happen before the SSE headers.
@@ -1325,12 +1340,26 @@ func writeSSEEvent(w http.ResponseWriter, ev provisioner.Event) {
 // agree by construction.
 func (h *Handler) GetDeploymentEvents(w http.ResponseWriter, r *http.Request) {
 	id := chi.URLParam(r, "id")
+	// chroot fallback: empty until deployment record settles.
+	// On the chroot (SOVEREIGN_FQDN env set), the cutover does NOT
+	// import the mother's deployment record. The first dashboard
+	// load races the in-memory synthesis path so without this
+	// fallback the wizard sees a transient 404 (TC-229) on
+	// /api/v1/deployments/<id>/events. Synthesise a minimal record
+	// — snapshotEvents() returns an empty slice on the synthetic
+	// record so the wizard renders its empty state and reconnects;
+	// once Phase-1 watch starts emitting (chroot lazy-seed path),
+	// subsequent reads return the populated buffer. On the mother
+	// (no SOVEREIGN_FQDN) chrootEnsureDeployment returns nil and
+	// the legacy 404 path is preserved.
 	val, ok := h.deployments.Load(id)
-	if !ok {
+	var dep *Deployment
+	if ok {
+		dep = val.(*Deployment)
+	} else if dep = h.chrootEnsureDeployment(id); dep == nil {
 		http.Error(w, "deployment not found", http.StatusNotFound)
 		return
 	}
-	dep := val.(*Deployment)
 	// Issue #689 — ownership check (404 on mismatch — never leak existence).
 	if !h.checkOwnership(w, r, dep) {
 		return

--- a/products/catalyst/bootstrap/api/internal/handler/deployments_events_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/deployments_events_test.go
@@ -358,6 +358,80 @@ func TestStreamLogs_NotFound(t *testing.T) {
 	}
 }
 
+// TestGetDeploymentEvents_ChrootFallback — TC-229 regression.
+//
+// On the Sovereign chroot, the cutover does NOT import the mother's
+// deployment record into the chroot's in-memory map. The first
+// dashboard load after handover races the synthesis path so without
+// chrootEnsureDeployment the wizard sees a transient 404.
+//
+// With SOVEREIGN_FQDN set, /events on an unknown id MUST return 200
+// with an empty events slice (and done=true so the wizard renders
+// the empty state, doesn't poll forever, and reconnects when Phase-1
+// watch starts emitting via the chroot lazy-seed path).
+func TestGetDeploymentEvents_ChrootFallback(t *testing.T) {
+	t.Setenv("SOVEREIGN_FQDN", "sovereign-omantel.biz")
+	h := New(slog.Default())
+	r := chi.NewRouter()
+	r.Get("/api/v1/deployments/{id}/events", h.GetDeploymentEvents)
+	srv := httptest.NewServer(r)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/api/v1/deployments/sovereign-omantel.biz/events")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (chroot fallback)", resp.StatusCode)
+	}
+	var body struct {
+		Events []provisioner.Event `json:"events"`
+		State  map[string]any      `json:"state"`
+		Done   bool                `json:"done"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.Events == nil || len(body.Events) != 0 {
+		t.Errorf("events = %v, want empty slice", body.Events)
+	}
+	if !body.Done {
+		t.Errorf("done = false, want true (synthetic record is closed)")
+	}
+}
+
+// TestStreamLogs_ChrootFallback — TC-229 regression on the SSE side.
+// Same race as the /events test — chroot must replay an empty buffer
+// + emit `done` instead of returning 404.
+func TestStreamLogs_ChrootFallback(t *testing.T) {
+	t.Setenv("SOVEREIGN_FQDN", "sovereign-omantel.biz")
+	h := New(slog.Default())
+	r := chi.NewRouter()
+	r.Get("/api/v1/deployments/{id}/logs", h.StreamLogs)
+	srv := httptest.NewServer(r)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/api/v1/deployments/sovereign-omantel.biz/logs")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (chroot fallback SSE)", resp.StatusCode)
+	}
+	if got := resp.Header.Get("Content-Type"); !strings.HasPrefix(got, "text/event-stream") {
+		t.Errorf("Content-Type = %q, want text/event-stream", got)
+	}
+	frames := readSSEFrames(t, resp.Body)
+	if len(frames.dataFrames) != 0 {
+		t.Errorf("dataFrames = %d, want 0 (synthetic record has empty buffer)", len(frames.dataFrames))
+	}
+	if frames.doneFrame == nil {
+		t.Errorf("doneFrame = nil, want a `done` event with state JSON")
+	}
+}
+
 /* ── SSE frame parsing helpers ───────────────────────────────────────── */
 
 type parsedFrames struct {

--- a/products/catalyst/bootstrap/api/internal/handler/jobs.go
+++ b/products/catalyst/bootstrap/api/internal/handler/jobs.go
@@ -58,12 +58,26 @@ func (h *Handler) chrootEnsureDeployment(depID string) *Deployment {
 	if val, ok := h.deployments.Load(depID); ok {
 		return val.(*Deployment)
 	}
+	// chroot fallback: empty until deployment record settles.
+	// Channels are pre-closed so consumers that select on them
+	// (StreamLogs, isDone) treat the synthetic record as a
+	// completed deployment with an empty event buffer instead of
+	// blocking on a nil channel forever. This matches fromRecord's
+	// "post-Pod-restart, runProvisioning is gone" branch — on the
+	// chroot, runProvisioning never runs at all (cutover already
+	// happened on the mother), so the same shape is correct.
+	closedCh := make(chan provisioner.Event)
+	closedDone := make(chan struct{})
+	close(closedCh)
+	close(closedDone)
 	dep := &Deployment{
 		ID: depID,
 		Request: provisioner.Request{
 			SovereignFQDN: selfFQDN,
 		},
-		Status: "ready",
+		Status:   "ready",
+		eventsCh: closedCh,
+		done:     closedDone,
 	}
 	h.deployments.Store(depID, dep)
 	h.log.Info("chroot: synthesised in-memory deployment record",


### PR DESCRIPTION
## Summary

- TC-229 (omantel.biz QA loop iter-3) caught a transient 404 on the first
  dashboard load to `/api/v1/deployments/<sov-fqdn>/{events,logs}`.
- Same race class PR #1052/#1053 fixed for `sovereignDynamicClient` + access CRD
  reads — the events + logs handlers had not been migrated to the chroot
  fallback pattern yet.
- StreamLogs and GetDeploymentEvents now fall back to `chrootEnsureDeployment`
  when the in-memory `h.deployments` map misses. The synthesised record
  carries pre-closed `eventsCh` + `done` channels (same shape as
  `fromRecord`'s post-Pod-restart branch) so:
  - `/events` returns `{events: [], state: {...}, done: true}` with HTTP 200
  - `/logs` replays the empty buffer + emits `event: done` + closes the SSE stream
- Mother behaviour preserved: `SOVEREIGN_FQDN` unset -> `chrootEnsureDeployment`
  returns `nil` -> legacy 404 path stands. Existing
  `TestGetDeploymentEvents_NotFound` + `TestStreamLogs_NotFound` still pass.
- Once Phase-1 watch starts emitting on the chroot (existing
  `chrootSeedJobsStoreIfEmpty` path on `/jobs` reads), subsequent /events +
  /logs reads return the populated buffer naturally.

## Files changed

- `products/catalyst/bootstrap/api/internal/handler/jobs.go` —
  `chrootEnsureDeployment` initialises pre-closed channels so consumers
  that select on them (`StreamLogs`, `isDone`) treat the synthetic record
  as "completed deployment, empty buffer" instead of blocking on a nil chan.
- `products/catalyst/bootstrap/api/internal/handler/deployments.go` —
  `StreamLogs` + `GetDeploymentEvents` call `chrootEnsureDeployment` on map miss.
- `products/catalyst/bootstrap/api/internal/handler/deployments_events_test.go` —
  added `TestGetDeploymentEvents_ChrootFallback` + `TestStreamLogs_ChrootFallback`
  using `t.Setenv("SOVEREIGN_FQDN", ...)` to exercise the new path.

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./internal/handler/` — clean
- [x] `go test ./internal/handler/ -run 'TestGetDeploymentEvents|TestStreamLogs'` — 10/10 PASS (incl. 2 new + 4 pre-existing on these handlers)
- [x] `go test ./internal/handler/ -run 'TestGetJob|TestListJobs|TestPhase1Watch|TestPhase1Handover|TestDeploymentsPersist|TestDeploymentsOwner|TestDeploymentsAdopted|TestDeploymentsList'` — PASS
- [ ] omantel.biz Test Executor reruns TC-229 walk on the new SHA, network walk records 0 transient 404s

## Cluster role / RBAC

Unchanged — no new GVRs read in this fix; the race is in our own in-memory map.

## Root cause sentence

The chroot's catalyst-api owns a sync.Map keyed by deployment-id, but
cutover never posts the mother's record into it; the first
`/events`/`/logs` request races the synthesis path and returns 404
until something else (e.g. a `/jobs` read triggering
`chrootEnsureDeployment`) populates the map.