### PR TITLE
fix(dashboard): treemap recharts→squarified dead-code cleanup (TS6133 hotfix to #1085)

### DIFF
--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/Dashboard.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/Dashboard.tsx
@@ -104,14 +104,12 @@ interface CellHoverInfo {
 
 let _onCellHover: ((info: CellHoverInfo | null) => void) | null = null
 let _onCellClick: ((item: TreemapItem) => void) | null = null
-let _activeColorFn: (pct: number) => string = colorFunctionFor('utilization')
-const _parentBoundsByName: Map<string, { x: number; y: number; width: number; height: number }> =
-  new Map()
-/** Lookup table keyed by cell `name` so the cell renderer can recover
- *  the original TreemapItem (with its `children[]` and full
- *  `percentage`) from whatever shape Recharts hands the renderer.
- *  The page repopulates this at every render. */
-const _itemsByName: Map<string, TreemapItem> = new Map()
+
+/** Neutral fill used when a cell's percentage is null (e.g. utilization
+ *  requested but metrics-server is not installed on the Sovereign).
+ *  Desaturated grey, visibly different from any point on the
+ *  utilization/health/age gradients. */
+const NULL_PERCENTAGE_FILL = 'rgba(125, 125, 125, 0.45)'
 
 /* ── Page ────────────────────────────────────────────────────────── */
 
@@ -202,12 +200,13 @@ export function Dashboard({
     return walkDrillPath(treemapData.items, drillPath)
   }, [treemapData, drillPath])
 
-  /* Wire module-level callbacks. The cell renderer reads from these
-   * synchronously, no React closure capture. */
+  /* SquarifiedSurface receives colorFn directly via prop. The
+   * _onCellHover / _onCellClick mailboxes survive only because they
+   * decouple the surface from the page's tooltip + drill state — the
+   * page registers handlers that read its own React state, and the
+   * surface invokes them without needing a closure-bound prop callback
+   * that would re-render on every mouse move. */
   const colorFn = useMemo(() => colorFunctionFor(colorBy), [colorBy])
-  useEffect(() => {
-    _activeColorFn = colorFn
-  }, [colorFn])
   useEffect(() => {
     _onCellHover = (info) => {
       if (hoverTimerRef.current !== null) {
@@ -244,21 +243,6 @@ export function Dashboard({
       }
     }
   }, [])
-
-  /* Reset parent bounds map every render. The cell renderer fills it
-   * during the same paint, so children seeing an outdated map is
-   * acceptable on the first paint and self-corrects on the next. */
-  _parentBoundsByName.clear()
-  // Repopulate the name→item lookup so the cell renderer can
-  // recover the original TreemapItem (with children and a full
-  // percentage) regardless of how recharts mangles the props.
-  _itemsByName.clear()
-  for (const it of visibleItems) {
-    _itemsByName.set(it.name, it)
-    if (it.children) {
-      for (const c of it.children) _itemsByName.set(c.name, c)
-    }
-  }
 
   const isEmpty = !query.isLoading && (!treemapData || treemapData.items.length === 0)
   const isNested = layers.length > 1 && drillPath.length === 0
@@ -584,324 +568,6 @@ function Legend({ colorBy }: { colorBy: TreemapColorBy }) {
       <span className="font-medium text-[var(--color-text-dim)]">{rightLabel}</span>
     </div>
   )
-}
-
-/* ── Cell renderers (cloned by Recharts — NO HOOKS) ─────────────── */
-
-interface RechartsCellProps {
-  x?: number
-  y?: number
-  width?: number
-  height?: number
-  index?: number
-  depth?: number
-  name?: string
-  size_value?: number
-  percentage?: number | null
-  count?: number
-  id?: string | null
-  children?: TreemapItem[]
-  root?: { children?: TreemapItem[] }
-  payload?: TreemapItem
-}
-
-/** Neutral fill used when a cell's percentage is null (e.g. utilization
- *  requested but metrics-server is not installed on the Sovereign).
- *  The colour is a desaturated grey that visibly differs from any
- *  point on the utilization/health/age gradients. */
-const NULL_PERCENTAGE_FILL = 'rgba(125, 125, 125, 0.45)'
-
-/**
- * Resolve the underlying TreemapItem from whatever shape Recharts
- * passes through. Recharts may flatten the node onto props directly OR
- * pass it as `payload`; we accept either so the renderer is robust to
- * a recharts version bump.
- */
-function resolveItem(props: RechartsCellProps): TreemapItem | null {
-  // Prefer the name→item lookup so we recover the full TreemapItem
-  // (with its children[]) regardless of what Recharts hands the
-  // cloned renderer.
-  if (props.name) {
-    const fromLookup = _itemsByName.get(props.name)
-    if (fromLookup) return fromLookup
-  }
-  if (props.payload && typeof props.payload === 'object' && 'name' in props.payload) {
-    return props.payload as TreemapItem
-  }
-  if (props.name) {
-    return {
-      id: (props.id as string | null | undefined) ?? null,
-      name: props.name,
-      count: props.count ?? 0,
-      percentage: props.percentage ?? null,
-      size_value: props.size_value,
-    }
-  }
-  return null
-}
-
-/**
- * Flat cell renderer used when the tree has only one layer (or when
- * the operator has drilled into a leaf parent so the visible items
- * are flat). NO React hooks — Recharts clones this and the cloned
- * tree's render path doesn't preserve hook order.
- */
-function TreemapContent(props: RechartsCellProps) {
-  const {
-    x = 0,
-    y = 0,
-    width = 0,
-    height = 0,
-    name = '',
-  } = props
-
-  if (width <= 0 || height <= 0) return null
-
-  const item = resolveItem(props)
-  const rawPct = item?.percentage ?? props.percentage ?? null
-  const fill = rawPct === null ? NULL_PERCENTAGE_FILL : _activeColorFn(rawPct)
-  const showLabel = width >= LABEL_MIN_WIDTH_PX && height >= LABEL_MIN_HEIGHT_PX
-
-  function handleEnter(e: React.MouseEvent) {
-    if (!_onCellHover || !item) return
-    _onCellHover({ item, x: e.clientX, y: e.clientY })
-  }
-  function handleLeave() {
-    if (!_onCellHover) return
-    _onCellHover(null)
-  }
-  function handleClick() {
-    if (!_onCellClick || !item) return
-    _onCellClick(item)
-  }
-
-  return (
-    <g onMouseEnter={handleEnter} onMouseMove={handleEnter} onMouseLeave={handleLeave} onClick={handleClick} style={{ cursor: item?.children?.length ? 'pointer' : 'default' }}>
-      <rect
-        x={x}
-        y={y}
-        width={width}
-        height={height}
-        style={{
-          fill,
-          stroke: 'rgba(255, 255, 255, 0.18)',
-          strokeWidth: 1,
-        }}
-      />
-      {showLabel && (
-        <>
-          <text
-            x={x + 8}
-            y={y + 16}
-            fill="rgba(255, 255, 255, 0.95)"
-            fontSize={11}
-            fontWeight={600}
-            style={{ pointerEvents: 'none' }}
-          >
-            {truncateLabel(name, width)}
-          </text>
-          <text
-            x={x + 8}
-            y={y + 30}
-            fill="rgba(255, 255, 255, 0.7)"
-            fontSize={10}
-            style={{ pointerEvents: 'none' }}
-          >
-            {rawPct === null ? '— %' : `${Math.round(rawPct)}%`}
-          </text>
-        </>
-      )}
-    </g>
-  )
-}
-
-/**
- * Two-level nested cell renderer. Recharts emits cells at depth=1
- * (parent rectangle) and depth=2 (children); the renderer gates the
- * label band + parent-bounds bookkeeping on `depth`.
- *
- * Children's labels are clipped vertically against the parent's
- * stored bounds via `_parentBoundsByName` so a label can't escape
- * under the parent's header.
- */
-function NestedTreemapContent(props: RechartsCellProps) {
-  const {
-    x = 0,
-    y = 0,
-    width = 0,
-    height = 0,
-    depth = 1,
-    name = '',
-  } = props
-
-  if (width <= 0 || height <= 0) return null
-
-  const item = resolveItem(props)
-  const rawPct = item?.percentage ?? props.percentage ?? null
-
-  // Recharts depths: 0 = root, 1 = first-level cells (the parents),
-  // 2 = second-level cells (the children). Treat depth >= 2 as leaf.
-  const isParent = depth === 1
-  const isLeaf = depth >= 2
-
-  if (isParent) {
-    // Record bounds so leaves know where the header band ends.
-    _parentBoundsByName.set(name, { x, y, width, height })
-
-    function handleParentEnter(e: React.MouseEvent) {
-      if (!_onCellHover || !item) return
-      _onCellHover({ item, x: e.clientX, y: e.clientY })
-    }
-    function handleParentLeave() {
-      if (!_onCellHover) return
-      _onCellHover(null)
-    }
-    function handleParentClick() {
-      if (!_onCellClick || !item) return
-      _onCellClick(item)
-    }
-
-    return (
-      <g
-        onMouseEnter={handleParentEnter}
-        onMouseMove={handleParentEnter}
-        onMouseLeave={handleParentLeave}
-        onClick={handleParentClick}
-        style={{ cursor: item?.children?.length ? 'pointer' : 'default' }}
-      >
-        {/* Outer parent frame — no fill, just a subtle outline. */}
-        <rect
-          x={x}
-          y={y}
-          width={width}
-          height={height}
-          style={{
-            fill: 'rgba(255, 255, 255, 0.02)',
-            stroke: 'rgba(255, 255, 255, 0.20)',
-            strokeWidth: 1,
-          }}
-        />
-        {/* Parent header strip with the parent's own name + count. */}
-        <rect
-          x={x}
-          y={y}
-          width={width}
-          height={NESTED_HEADER_HEIGHT_PX}
-          style={{ fill: 'rgba(0, 0, 0, 0.35)' }}
-        />
-        {width >= LABEL_MIN_WIDTH_PX && (
-          <text
-            x={x + 8}
-            y={y + 16}
-            fill="rgba(255, 255, 255, 0.92)"
-            fontSize={11}
-            fontWeight={700}
-            style={{ pointerEvents: 'none' }}
-          >
-            {truncateLabel(name, width)} · {item?.count ?? 0}
-          </text>
-        )}
-      </g>
-    )
-  }
-
-  if (isLeaf) {
-    const fill = rawPct === null ? NULL_PERCENTAGE_FILL : _activeColorFn(rawPct)
-
-    // Clip leaf y against parent header — leaf cells whose top edge is
-    // inside the header strip get pushed down so labels don't render
-    // under the header.
-    let renderY = y
-    let renderHeight = height
-    // Find the parent containing this leaf by spatial test (leaf is
-    // contained when its centre is inside the parent rect).
-    const cx = x + width / 2
-    const cy = y + height / 2
-    let parent: { x: number; y: number; width: number; height: number } | null = null
-    for (const [, bounds] of _parentBoundsByName) {
-      if (
-        cx >= bounds.x &&
-        cx <= bounds.x + bounds.width &&
-        cy >= bounds.y &&
-        cy <= bounds.y + bounds.height
-      ) {
-        parent = bounds
-        break
-      }
-    }
-    if (parent) {
-      const minY = parent.y + NESTED_HEADER_HEIGHT_PX + NESTED_PADDING_PX
-      if (renderY < minY) {
-        const delta = minY - renderY
-        renderY = minY
-        renderHeight = Math.max(0, renderHeight - delta)
-      }
-    }
-    if (renderHeight <= 0) return null
-
-    const showLabel =
-      width >= LABEL_MIN_WIDTH_PX && renderHeight >= LABEL_MIN_HEIGHT_PX
-
-    function handleEnter(e: React.MouseEvent) {
-      if (!_onCellHover || !item) return
-      _onCellHover({ item, x: e.clientX, y: e.clientY })
-    }
-    function handleLeave() {
-      if (!_onCellHover) return
-      _onCellHover(null)
-    }
-    function handleClick() {
-      if (!_onCellClick || !item) return
-      _onCellClick(item)
-    }
-
-    return (
-      <g
-        onMouseEnter={handleEnter}
-        onMouseMove={handleEnter}
-        onMouseLeave={handleLeave}
-        onClick={handleClick}
-        style={{ cursor: item?.children?.length ? 'pointer' : 'default' }}
-      >
-        <rect
-          x={x}
-          y={renderY}
-          width={width}
-          height={renderHeight}
-          style={{
-            fill,
-            stroke: 'rgba(255, 255, 255, 0.15)',
-            strokeWidth: 1,
-          }}
-        />
-        {showLabel && (
-          <>
-            <text
-              x={x + 6}
-              y={renderY + 14}
-              fill="rgba(255, 255, 255, 0.95)"
-              fontSize={10}
-              fontWeight={600}
-              style={{ pointerEvents: 'none' }}
-            >
-              {truncateLabel(name, width)}
-            </text>
-            <text
-              x={x + 6}
-              y={renderY + 26}
-              fill="rgba(255, 255, 255, 0.65)"
-              fontSize={9}
-              style={{ pointerEvents: 'none' }}
-            >
-              {rawPct === null ? '— %' : `${Math.round(rawPct)}%`}
-            </text>
-          </>
-        )}
-      </g>
-    )
-  }
-
-  return null
 }
 
 /**


### PR DESCRIPTION
Hotfix to #1085 (#1084). The merge stranded TreemapContent + NestedTreemapContent + 4 helpers as dead code; strict tsc with noUnusedLocals failed the prod build. This PR removes 346 lines of unreferenced recharts cell-renderer code.

46 treemap-relevant tests still pass; build succeeds locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)