### PR TITLE
fix(chart): metrics.k8s.io ClusterRole rule for dashboard utilization (#1084 chart-side)

### DIFF
--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -124,7 +124,7 @@ name: bp-catalyst-platform
 # otech113 2026-05-05 — chart 0.1.18 fixed the readiness-probe loop
 # but every trigger immediately got 502 in <10ms (synchronous
 # apiserver permission rejection). 2026-05-05.
-version: 1.4.84
+version: 1.4.85
 appVersion: 1.4.84
 description: |
   Catalyst Platform — the unified Catalyst control plane umbrella chart for Catalyst-Zero.

--- a/products/catalyst/chart/templates/clusterrole-cutover-driver.yaml
+++ b/products/catalyst/chart/templates/clusterrole-cutover-driver.yaml
@@ -205,3 +205,14 @@ rules:
   - apiGroups: ["authorization.k8s.io"]
     resources: ["subjectaccessreviews"]
     verbs: ["create"]
+  # PodMetrics + NodeMetrics — required for the Sovereign Dashboard's
+  # `color_by=utilization` overlay. Without this rule the dynamic
+  # client returns 403 on every metrics.k8s.io list and the dashboard
+  # falls back to null-percentage grey cells. metrics-server is
+  # always installed by bp-metrics-server in the platform bundle, so
+  # the only thing standing between the dashboard and a working
+  # gradient was this RBAC rule. (#1084 follow-up — the chart-side
+  # half of the treemap utilization fix.)
+  - apiGroups: ["metrics.k8s.io"]
+    resources: ["pods", "nodes"]
+    verbs: ["get", "list", "watch"]


### PR DESCRIPTION
Follow-up to #1085 (#1084). The treemap utilization gradient stays grey on every chroot Sovereign because the catalyst-api-cutover-driver ClusterRole was missing the metrics.k8s.io rule.

Verified missing on omantel:
```
$ kubectl --context=omantel auth can-i list pods.metrics.k8s.io \
    --as=system:serviceaccount:catalyst-system:catalyst-api-cutover-driver -A
no
```

Adds the rule + bumps chart 1.4.84 → 1.4.85.

🤖 Generated with [Claude Code](https://claude.com/claude-code)