### PR TITLE
fix(k8scache): register podmetrics so utilization gradient works (#1084 third-piece)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/k8scache/k8scache_test.go
+++ b/products/catalyst/bootstrap/api/internal/k8scache/k8scache_test.go
@@ -114,17 +114,13 @@ func TestDefaultKinds_GraphAndDashboardSurface(t *testing.T) {
 		"ingress",
 		// graph + dashboard depend on these
 		"persistentvolume", "replicaset", "endpointslice",
+		// dashboard color_by=utilization depends on this (#1084)
+		"podmetrics",
 	}
 	for _, name := range mandatory {
 		if _, ok := r.Get(name); !ok {
 			t.Errorf("DefaultKinds missing %q — required by architecture-graph or dashboard", name)
 		}
-	}
-	// PodMetrics is intentionally NOT in DefaultKinds — see kinds.go
-	// for the rationale (the synchronous discovery probe that gated
-	// it caused contabo startup to block on dead kubeconfigs).
-	if _, ok := r.Get("podmetrics"); ok {
-		t.Errorf("podmetrics must not be in DefaultKinds; the discovery-gate path was reverted")
 	}
 }
 

--- a/products/catalyst/bootstrap/api/internal/k8scache/kinds.go
+++ b/products/catalyst/bootstrap/api/internal/k8scache/kinds.go
@@ -110,14 +110,16 @@ var DefaultKinds = []Kind{
 	// vCluster.io tenants.
 	{Name: "vcluster", GVR: schema.GroupVersionResource{Group: "vcluster.com", Version: "v1alpha1", Resource: "vclusters"}, Namespaced: true},
 
-	// NOTE: metrics.k8s.io/PodMetrics is NOT in DefaultKinds. The
-	// optional metrics-server APIService isn't installed on every
-	// Sovereign, and the original AddCluster discovery probe that
-	// gated this kind made startup block on dead kubeconfigs. Until
-	// a non-blocking activation path lands the dashboard's
-	// color_by=utilization stays null when no PodMetrics indexer is
-	// available; healthy + age + size paths still render off Pod /
-	// PVC indexers.
+	// metrics.k8s.io/PodMetrics — drives the dashboard's
+	// `color_by=utilization` overlay (#1084). Earlier versions excluded
+	// this kind because the synchronous AddCluster discovery probe
+	// blocked startup on dead kubeconfigs. With that probe removed,
+	// dynamicinformer can attempt LIST+WATCH directly — when the API
+	// isn't served the informer logs a soft error and retries with
+	// exponential backoff (no hot loop, no startup block). Every
+	// real Sovereign ships bp-metrics-server in the platform bundle,
+	// so the utilization gradient renders out of the box.
+	{Name: "podmetrics", GVR: schema.GroupVersionResource{Group: "metrics.k8s.io", Version: "v1beta1", Resource: "pods"}, Namespaced: true},
 }
 
 // Registry is a runtime-mutable lookup keyed by the short Name. It


### PR DESCRIPTION
Third + final piece of #1084. PR #1085 wired the UI/handler; PR #1087 added the ClusterRole rule. This PR registers podmetrics in k8scache.DefaultKinds so the informer actually starts and h.k8sCache.List(...,'podmetrics',...) returns real data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)