### PR TITLE
fix(catalyst-ui): mothership /sovereign/* anon hang + deep-link drop (#1090 cluster B)

### DIFF
--- a/products/catalyst/bootstrap/ui/src/app/layouts/SovereignConsoleLayout.catalyst-zero.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/app/layouts/SovereignConsoleLayout.catalyst-zero.test.tsx
@@ -1,0 +1,190 @@
+/**
+ * SovereignConsoleLayout.catalyst-zero.test.tsx — issue #1090 cluster B
+ *
+ * Regression coverage for the mothership-anon-hung bug:
+ *
+ *   The same SovereignConsoleLayout mounts at console.openova.io/sovereign/*
+ *   on Catalyst-Zero (mothership) under the basepath strip. In that mode
+ *   `DETECTED_MODE.mode === 'catalyst-zero'` and `sovereignFQDN` is null.
+ *
+ *   The PREVIOUS layout's `if (!sovereignFQDN)` early-return set
+ *   `unauthenticated` state and rendered the loading spinner forever —
+ *   never navigated. Visitors to `/sovereign/dashboard`, `/jobs/timeline`,
+ *   `/cloud`, `/users`, `/settings`, `/notifications`, `/apps` saw an
+ *   indefinite "Authenticating…" spinner.
+ *
+ *   The fix: in the no-sovereignFQDN branch, probe /whoami first (cookie
+ *   auth works on the mothership too — same backend, same cookie). On
+ *   200, render the console; on 401, hard-redirect to /sovereign/login
+ *   with `?next=<post-basepath-path>` so VerifyPinPage routes back to
+ *   the deep link after PIN verify.
+ *
+ * The two contracts under test:
+ *   1. catalyst-zero + /whoami 200 → console shell renders, NO navigate.
+ *   2. catalyst-zero + /whoami 401 → window.location.replace fires with
+ *      target = /sovereign/login?next=<post-basepath-path>. The OIDC
+ *      `initiateLogin` MUST NOT fire (catalyst-zero has no Keycloak).
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, screen, cleanup, waitFor } from '@testing-library/react'
+
+// Mock detectMode for catalyst-zero mode (sovereignFQDN: null).
+vi.mock('@/shared/lib/detectMode', () => ({
+  DETECTED_MODE: { mode: 'catalyst-zero' as const, sovereignFQDN: null },
+  detectMode: () => ({ mode: 'catalyst-zero' as const, sovereignFQDN: null }),
+}))
+
+// Mock urls so BASE matches the contabo-mkt /sovereign/ basepath.
+vi.mock('@/shared/config/urls', () => ({
+  BASE: '/sovereign/',
+  API_BASE: '/sovereign/api',
+  apiUrl: (p: string) => `/sovereign/api${p.startsWith('/') ? p : '/' + p}`,
+  path: (p: string) => `/sovereign/${p.replace(/^\//, '')}`,
+}))
+
+const initiateLoginSpy = vi.fn<(fqdn: string) => Promise<void>>()
+const silentRefreshSpy = vi.fn<(fqdn: string) => Promise<unknown>>()
+const loadTokensSpy = vi.fn<() => unknown>()
+initiateLoginSpy.mockResolvedValue(undefined)
+silentRefreshSpy.mockResolvedValue(null)
+loadTokensSpy.mockReturnValue(null)
+vi.mock('@/shared/lib/oidc', () => ({
+  loadTokens: () => loadTokensSpy(),
+  isTokenExpired: () => true,
+  silentRefresh: (fqdn: string) => silentRefreshSpy(fqdn),
+  initiateLogin: (fqdn: string) => initiateLoginSpy(fqdn),
+  initiateLogout: () => undefined,
+  parseJWTClaims: () => ({}),
+  getRequiredActions: () => [],
+}))
+
+vi.mock('@/pages/sovereign/SovereignSidebar', () => ({
+  SovereignSidebar: () => <div data-testid="sov-sidebar-stub" />,
+}))
+vi.mock('@/components/RequiredActionsModal', () => ({
+  RequiredActionsModal: () => <div data-testid="sov-required-actions-stub" />,
+}))
+vi.mock('@/shared/ui/notifications', () => ({
+  NotificationBell: () => <div data-testid="sov-bell-stub" />,
+}))
+vi.mock('@/components/ThemeToggle', () => ({
+  ThemeToggle: () => <div data-testid="sov-theme-stub" />,
+}))
+vi.mock('@tanstack/react-router', async (importOriginal) => {
+  const actual = (await importOriginal()) as object
+  return {
+    ...actual,
+    useRouter: () => ({ navigate: vi.fn() }),
+    Outlet: () => <div data-testid="sov-outlet-stub" />,
+  }
+})
+
+import { SovereignConsoleLayout } from './SovereignConsoleLayout'
+
+let originalLocation: Location
+
+beforeEach(() => {
+  initiateLoginSpy.mockClear()
+  silentRefreshSpy.mockClear()
+  loadTokensSpy.mockClear()
+  loadTokensSpy.mockReturnValue(null)
+
+  originalLocation = window.location
+  // jsdom's window.location is non-configurable; replace with a stub
+  // that exposes a `replace` spy plus the URL surface we read.
+  delete (window as unknown as { location?: Location }).location
+  ;(window as unknown as { location: Partial<Location> }).location = {
+    pathname: '/sovereign/dashboard',
+    search: '',
+    hostname: 'console.openova.io',
+    href: 'https://console.openova.io/sovereign/dashboard',
+    origin: 'https://console.openova.io',
+    replace: vi.fn(),
+    assign: vi.fn(),
+  } as unknown as Location
+})
+
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+  ;(window as unknown as { location: Location }).location = originalLocation
+})
+
+describe('SovereignConsoleLayout — catalyst-zero (mothership) auth path', () => {
+  it('renders the console shell when /whoami returns 200 (mothership cookie-authenticated)', async () => {
+    vi.spyOn(global, 'fetch').mockImplementation(async (input) => {
+      const url = typeof input === 'string' ? input : (input as URL).toString()
+      if (url.endsWith('/v1/whoami')) {
+        return new Response(
+          JSON.stringify({ email: 'op@openova.io', sub: 'kc-uid', verified: true }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        )
+      }
+      return new Response(null, { status: 404 })
+    })
+
+    render(<SovereignConsoleLayout />)
+
+    // Cookie probe succeeded → outlet renders, NO redirect.
+    await screen.findByTestId('sov-outlet-stub')
+    expect(window.location.replace).not.toHaveBeenCalled()
+    expect(initiateLoginSpy).not.toHaveBeenCalled()
+  })
+
+  it('redirects to /sovereign/login with next= when /whoami returns 401 (no Keycloak fallback)', async () => {
+    // Anonymous mothership visit — must hard-navigate to the PIN flow,
+    // NEVER to Keycloak (catalyst-zero has no KC issuer wired).
+    vi.spyOn(global, 'fetch').mockImplementation(async (input) => {
+      const url = typeof input === 'string' ? input : (input as URL).toString()
+      if (url.endsWith('/v1/whoami')) {
+        return new Response(JSON.stringify({ error: 'unauthenticated' }), { status: 401 })
+      }
+      return new Response(null, { status: 404 })
+    })
+
+    render(<SovereignConsoleLayout />)
+
+    await waitFor(() => {
+      expect(window.location.replace).toHaveBeenCalledTimes(1)
+    })
+
+    const target = (window.location.replace as ReturnType<typeof vi.fn>).mock.calls[0][0] as string
+    // Goes to mothership PIN page under the /sovereign basepath.
+    expect(target).toMatch(/^\/sovereign\/login\?next=/)
+    // next= holds the POST-basepath path (so VerifyPinPage's
+    // navigate({ to: next }) round-trips cleanly through the router).
+    const url = new URL(target, 'https://console.openova.io')
+    expect(url.searchParams.get('next')).toBe('/dashboard')
+
+    // Decisive: NO Keycloak redirect on the mothership.
+    expect(initiateLoginSpy).not.toHaveBeenCalled()
+  })
+
+  it('preserves the full deep-link path including search params when redirecting', async () => {
+    // A deep link like /sovereign/cloud?view=graph must round-trip the
+    // ?view=graph query through the next= param so the operator lands
+    // back on the same view after PIN verify.
+    ;(window.location as unknown as { pathname: string }).pathname = '/sovereign/cloud'
+    ;(window.location as unknown as { search: string }).search = '?view=graph'
+
+    vi.spyOn(global, 'fetch').mockImplementation(async (input) => {
+      const url = typeof input === 'string' ? input : (input as URL).toString()
+      if (url.endsWith('/v1/whoami')) {
+        return new Response(JSON.stringify({ error: 'unauthenticated' }), { status: 401 })
+      }
+      return new Response(null, { status: 404 })
+    })
+
+    render(<SovereignConsoleLayout />)
+
+    await waitFor(() => {
+      expect(window.location.replace).toHaveBeenCalledTimes(1)
+    })
+
+    const target = (window.location.replace as ReturnType<typeof vi.fn>).mock.calls[0][0] as string
+    const url = new URL(target, 'https://console.openova.io')
+    expect(url.searchParams.get('next')).toBe('/cloud?view=graph')
+    expect(initiateLoginSpy).not.toHaveBeenCalled()
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/app/layouts/SovereignConsoleLayout.tsx
+++ b/products/catalyst/bootstrap/ui/src/app/layouts/SovereignConsoleLayout.tsx
@@ -48,7 +48,8 @@
 import { useEffect, useState } from 'react'
 import { Outlet } from '@tanstack/react-router'
 import { DETECTED_MODE } from '@/shared/lib/detectMode'
-import { API_BASE } from '@/shared/config/urls'
+import { API_BASE, BASE } from '@/shared/config/urls'
+import { currentPathRelativeToBasepath } from '@/shared/lib/basepathRelative'
 import {
   loadTokens,
   isTokenExpired,
@@ -112,8 +113,37 @@ export function SovereignConsoleLayout() {
 
   useEffect(() => {
     async function initAuth() {
+      // Catalyst-Zero (mothership) mode: the same SovereignConsoleLayout
+      // mounts at console.openova.io/sovereign/* under the basepath strip.
+      // There's no Sovereign FQDN and no Keycloak — auth is the mothership
+      // PIN-cookie flow (/login → /login/verify → catalyst_session).
+      //
+      // On a 200 from /whoami, render the console. On 401, hard-redirect
+      // to /sovereign/login?next=<currentPath> so VerifyPinPage routes
+      // back to the deep-link after the 6-digit code lands. The OIDC
+      // fallback below is sovereign-cluster-only and must NOT fire here
+      // (no Keycloak issuer is configured for the mothership host).
+      //
+      // Issue #1090 (cluster B): /sovereign/{dashboard,jobs/timeline,
+      // cloud,users,settings,notifications,apps} previously hung on the
+      // "Authenticating…" spinner forever because the early-return on
+      // !sovereignFQDN never navigated.
       if (!sovereignFQDN) {
-        // Should not happen in sovereign mode, but guard defensively.
+        const cookieClaims = await probeSessionCookie()
+        if (cookieClaims) {
+          setAuthState({ status: 'cookie-authenticated', claims: cookieClaims })
+          return
+        }
+        if (typeof window !== 'undefined') {
+          // `next` is the POST-basepath route path so VerifyPinPage's
+          // navigate({ to: next }) resolves cleanly through the router
+          // (basepath is added back automatically). The hard-redirect
+          // target itself uses BASE so the browser lands at the
+          // /sovereign/login URL — only the `next` value is stripped.
+          const here = currentPathRelativeToBasepath()
+          const target = `${BASE}login?next=${encodeURIComponent(here)}`
+          window.location.replace(target)
+        }
         setAuthState({ status: 'unauthenticated' })
         return
       }

--- a/products/catalyst/bootstrap/ui/src/app/router.tsx
+++ b/products/catalyst/bootstrap/ui/src/app/router.tsx
@@ -3,6 +3,7 @@ import { IS_SAAS } from '@/shared/constants/env'
 import { API_BASE } from '@/shared/config/urls'
 import { DETECTED_MODE } from '@/shared/lib/detectMode'
 import { setProvisionFlashBanner } from '@/shared/lib/flashBanner'
+import { currentPathRelativeToBasepath } from '@/shared/lib/basepathRelative'
 
 /**
  * Runtime basepath detection (issue #618).
@@ -111,7 +112,23 @@ const indexRoute = createRoute({
 })
 
 // Auth routes
-const loginRoute = createRoute({ getParentRoute: () => rootRoute, path: '/login', component: LoginPage })
+// /login — search params: `next` (deep-link target preserved across the
+// PIN flow, issue #1090 cluster B), `error` (post-redirect error code
+// from VerifyPinPage's expired/attempts-exceeded branch). validateSearch
+// is required so TanStack Router preserves both keys on
+// `redirect({ to: '/login', search: { next, error } })` calls — without
+// it the search type defaults to `{}` and the params are stripped.
+const loginRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/login',
+  component: LoginPage,
+  validateSearch: (raw: Record<string, unknown>): { next?: string; error?: string } => {
+    const out: { next?: string; error?: string } = {}
+    if (typeof raw.next === 'string' && raw.next.length > 0) out.next = raw.next
+    if (typeof raw.error === 'string' && raw.error.length > 0) out.error = raw.error
+    return out
+  },
+})
 // /login/verify — PIN-entry step of the 6-digit auth flow (issue #688).
 // Mounted at sibling depth (not nested under /login) so a refresh on the
 // verify URL doesn't lose its email/requestId search params to a parent
@@ -120,6 +137,24 @@ const loginVerifyRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: '/login/verify',
   component: VerifyPinPage,
+  // Search params: `email` + `requestId` (issued by /login PIN POST),
+  // and `next` (deep-link target, issue #1090 cluster B) preserved
+  // across the PIN flow so VerifyPinPage can navigate back to the
+  // requested deployment surface after a successful 6-digit verify
+  // instead of dropping the operator on /wizard.
+  validateSearch: (raw: Record<string, unknown>): {
+    email?: string
+    requestId?: string
+    next?: string
+  } => {
+    const out: { email?: string; requestId?: string; next?: string } = {}
+    if (typeof raw.email === 'string' && raw.email.length > 0) out.email = raw.email
+    if (typeof raw.requestId === 'string' && raw.requestId.length > 0) {
+      out.requestId = raw.requestId
+    }
+    if (typeof raw.next === 'string' && raw.next.length > 0) out.next = raw.next
+    return out
+  },
 })
 const signupRoute = createRoute({ getParentRoute: () => rootRoute, path: '/signup', component: SignupPage })
 const forgotRoute = createRoute({ getParentRoute: () => rootRoute, path: '/forgot', component: ForgotPage })
@@ -256,9 +291,30 @@ async function provisionAuthGuard() {
       headers: { Accept: 'application/json' },
     })
     if (res.status === 401) {
-      // Anonymous — flash a banner the wizard can render, then redirect.
+      // Anonymous — flash the banner AND preserve the deep-link target as
+      // ?next= so the PIN flow lands the operator BACK on the requested
+      // page after verify. The flash banner is kept for the case where
+      // the operator dismisses /login and clicks "Wizard" — they still
+      // see a contextual hint.
+      //
+      // Issue #1090 (cluster B): /sovereign/provision/<id>/{jobs/timeline,
+      // cloud,users,settings} previously bounced to /wizard step-1 with
+      // a banner but lost the deep link entirely — no sessionStorage of
+      // the path, no next= param, so post-PIN the operator landed on
+      // /wizard, never on the requested deployment surface.
+      //
+      // The `next` value is the post-basepath route path so
+      // VerifyPinPage's `navigate({ to: next })` resolves cleanly through
+      // the router (basepath is added back automatically). On contabo
+      // the browser URL is `/sovereign/provision/...`; we strip
+      // `/sovereign` here so the round-trip doesn't double up.
       setProvisionFlashBanner('Sign in to view your deployments')
-      throw redirect({ to: '/wizard', replace: true })
+      const here = currentPathRelativeToBasepath()
+      throw redirect({
+        to: '/login',
+        search: { next: here } as never,
+        replace: true,
+      })
     }
     // Any other status (200, 5xx) — allow through. A 5xx that locks the
     // user out of `/provision` would erase their post-launch progress

--- a/products/catalyst/bootstrap/ui/src/shared/lib/basepathRelative.test.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/lib/basepathRelative.test.ts
@@ -1,0 +1,73 @@
+/**
+ * basepathRelative tests — issue #1090 cluster B.
+ *
+ * The deep-link round-trip across the PIN flow depends on the `next=`
+ * value being the POST-basepath route path, not the raw browser path.
+ * If we get this wrong, VerifyPinPage's `navigate({ to: next })` either
+ * 404s (basepath stripped twice) or double-prefixes (basepath added
+ * back to a path that already had it). Both manifest as "deep link
+ * lost" — the symptom we are fixing.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { pathRelativeToBasepath } from './basepathRelative'
+
+describe('pathRelativeToBasepath', () => {
+  it('strips the /sovereign basepath from contabo paths', () => {
+    expect(pathRelativeToBasepath('/sovereign/dashboard')).toBe('/dashboard')
+    expect(pathRelativeToBasepath('/sovereign/users')).toBe('/users')
+    expect(pathRelativeToBasepath('/sovereign/jobs/timeline')).toBe('/jobs/timeline')
+  })
+
+  it('preserves search params when stripping the basepath', () => {
+    expect(pathRelativeToBasepath('/sovereign/cloud', '?view=graph')).toBe('/cloud?view=graph')
+    expect(pathRelativeToBasepath('/sovereign/users', '?filter=admin')).toBe('/users?filter=admin')
+  })
+
+  it('preserves provision deep-links with deploymentId (TC-R-081..084)', () => {
+    expect(
+      pathRelativeToBasepath('/sovereign/provision/sovereign-omantel.biz/jobs/timeline'),
+    ).toBe('/provision/sovereign-omantel.biz/jobs/timeline')
+    expect(pathRelativeToBasepath('/sovereign/provision/sov-acme/cloud')).toBe(
+      '/provision/sov-acme/cloud',
+    )
+    expect(pathRelativeToBasepath('/sovereign/provision/sov-acme/users')).toBe(
+      '/provision/sov-acme/users',
+    )
+    expect(pathRelativeToBasepath('/sovereign/provision/sov-acme/settings')).toBe(
+      '/provision/sov-acme/settings',
+    )
+  })
+
+  it('returns the path unchanged when no /sovereign prefix is present (Sovereign cluster)', () => {
+    // On a chroot Sovereign the browser URL has no /sovereign prefix —
+    // the same helper must be a no-op there so the same code path works
+    // in both topologies.
+    expect(pathRelativeToBasepath('/dashboard')).toBe('/dashboard')
+    expect(pathRelativeToBasepath('/cloud', '?view=list')).toBe('/cloud?view=list')
+    expect(pathRelativeToBasepath('/jobs/abc-123')).toBe('/jobs/abc-123')
+  })
+
+  it('handles the bare /sovereign path (edge case)', () => {
+    // No trailing slash, no descendant route — a visit to literally
+    // `/sovereign` resolves to the root. Returning '/' keeps the next=
+    // round-trip semantically equivalent to "back to the index".
+    expect(pathRelativeToBasepath('/sovereign')).toBe('/')
+  })
+
+  it('does NOT strip a /sovereignty prefix (similar but distinct)', () => {
+    // The basepath check uses '/sovereign/' (with trailing slash) so
+    // unrelated routes that happen to share the prefix string are not
+    // mangled. /sovereignty/preview is a real route — see router.tsx.
+    expect(pathRelativeToBasepath('/sovereignty/preview')).toBe('/sovereignty/preview')
+  })
+
+  it('always returns a leading slash', () => {
+    // Defensive — the function MUST return a path that begins with '/'
+    // because navigate({ to }) treats slashless paths as relative. The
+    // input is always a window.location.pathname which itself begins
+    // with '/', but the contract is enforced explicitly.
+    expect(pathRelativeToBasepath('/')).toBe('/')
+    expect(pathRelativeToBasepath('/sovereign/')).toBe('/')
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/shared/lib/basepathRelative.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/lib/basepathRelative.ts
@@ -1,0 +1,41 @@
+/**
+ * Compute the current page path relative to the router basepath.
+ *
+ * Issue #1090 (cluster B): the mothership auth guards need to preserve
+ * the operator's deep-link target across the PIN flow so the POST-verify
+ * navigate({ to: next }) lands them BACK on the requested page. The
+ * `next` value MUST be the POST-basepath route path because TanStack
+ * Router's `navigate` resolves relative to the configured basepath:
+ *
+ *   On contabo (Catalyst-Zero) basepath = '/sovereign'.
+ *   On Sovereign clusters basepath = '/'.
+ *
+ *   raw browser path     →  pathRelativeToBasepath()
+ *   /sovereign/dashboard →  /dashboard
+ *   /sovereign/cloud?v=g →  /cloud?v=g
+ *   /dashboard           →  /dashboard
+ *   /cloud?v=g           →  /cloud?v=g
+ *
+ * Always returns a path that begins with `/`, including search params.
+ */
+export function pathRelativeToBasepath(
+  pathname: string,
+  search: string = '',
+): string {
+  let p = pathname + search
+  if (p.startsWith('/sovereign/')) p = p.slice('/sovereign'.length)
+  else if (p === '/sovereign') p = '/'
+  if (!p.startsWith('/')) p = '/' + p
+  return p
+}
+
+/**
+ * Browser-aware variant — reads `window.location` and falls back to '/'
+ * outside a browser (SSR / unit tests without jsdom). Pure callers
+ * (e.g. unit tests of the function itself) should use the parameterised
+ * `pathRelativeToBasepath` directly.
+ */
+export function currentPathRelativeToBasepath(): string {
+  if (typeof window === 'undefined') return '/'
+  return pathRelativeToBasepath(window.location.pathname, window.location.search)
+}


### PR DESCRIPTION
## Summary

- Fixes mothership-anon-hung: `/sovereign/{dashboard,jobs/timeline,cloud,users,settings,notifications,apps}` previously hung on "Authenticating…" forever because `SovereignConsoleLayout`'s catalyst-zero branch never navigated. Now probes `/whoami`, redirects 401s to `/sovereign/login?next=<deep-path>`.
- Fixes mothership-chroot-deep-link-drop: `/sovereign/provision/<id>/{jobs/timeline,cloud,users,settings}` previously bounced to `/wizard` with the deep-link target dropped. Now redirects to `/login?next=<deep-path>` so post-PIN navigates back to the requested surface.
- Both fixes consolidate to one root cause: anon mothership visitors weren't routed through the PIN-login flow with deep-link preservation. LoginPage + VerifyPinPage already honor `next=` end-to-end — this PR feeds the deep link into that already-wired contract.

## Closes 12 FAILs (iter1 of #1090)

- mothership-anon-hung: TC-R-022, TC-R-067, TC-R-068, TC-R-077, TC-R-078, TC-R-079, TC-R-080, TC-R-092
- mothership-chroot-deep-link-drop: TC-R-081, TC-R-082, TC-R-083, TC-R-084

## Files changed

- `products/catalyst/bootstrap/ui/src/app/layouts/SovereignConsoleLayout.tsx` — catalyst-zero auth path: probe /whoami, redirect 401s to /sovereign/login?next=
- `products/catalyst/bootstrap/ui/src/app/router.tsx` — provisionAuthGuard redirects to /login?next= instead of /wizard; add validateSearch to loginRoute + loginVerifyRoute so next= survives redirect()
- `products/catalyst/bootstrap/ui/src/shared/lib/basepathRelative.ts` — new helper extracted so the next= round-trip works in both contabo (basepath /sovereign) and Sovereign cluster (basepath /) topologies
- `products/catalyst/bootstrap/ui/src/shared/lib/basepathRelative.test.ts` — 7 unit tests for the helper
- `products/catalyst/bootstrap/ui/src/app/layouts/SovereignConsoleLayout.catalyst-zero.test.tsx` — 3 regression tests for the new catalyst-zero auth path

## Test plan

- [x] `npx vitest run src/shared/lib/basepathRelative.test.ts` — 7 passed
- [x] `npx vitest run src/app/layouts/SovereignConsoleLayout.catalyst-zero.test.tsx` — 3 passed
- [x] `npx vitest run src/app/layouts/SovereignConsoleLayout.test.tsx` — 3 passed (existing chroot tests still green)
- [x] `npx tsc -b --noEmit` — clean
- [ ] Live verification: deploy SHA captured by chart auto-bump, executor re-runs the 12 TC-R rows in iter2

## Coordination with Fix #A

Fix #A owns the chroot-Sovereign auth gate (SovereignConsoleLayout lines 138-149, the OIDC fallback). This PR touches the catalyst-zero branch (the no-sovereignFQDN early-return) and router.tsx — disjoint from Fix #A's territory.

Generated with [Claude Code](https://claude.com/claude-code)