### PR TITLE
fix(catalyst-api): logout cookie clearing + PIN rate-limit 429 + 2 endpoint regressions (#1090 cluster E)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/auth.go
+++ b/products/catalyst/bootstrap/api/internal/handler/auth.go
@@ -208,7 +208,30 @@ func (h *Handler) HandlePinIssue(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// ── 1. EnsureUser in openova realm ──────────────────────────────────────
+	// ── 1. Rate-limit (per-email, 60s) ──────────────────────────────────────
+	//
+	// The rate-limit check runs BEFORE EnsureUser so that concurrent
+	// /pin/issue calls for the same email (TC-R-089: 3-way --parallel
+	// curl) do not each attempt EnsureUser. Without this ordering,
+	// every concurrent caller races createUser at Keycloak; KC accepts
+	// the first POST /users and returns 409 Conflict to the others —
+	// surfaced here as a 502 response (TC-R-089's pre-fix symptom).
+	// Rate-limit-first means losers in the race get 429 immediately,
+	// the winner reaches Keycloak alone, and the rate limiter is
+	// honoured even under concurrency.
+	store := h.pinStoreFor()
+	if ok, retry := store.canIssue(email); !ok {
+		retryAfterSec := int(retry.Seconds()) + 1
+		w.Header().Set("Retry-After", fmt.Sprintf("%d", retryAfterSec))
+		writeJSON(w, http.StatusTooManyRequests, map[string]any{
+			"error":         "pin-rate-limited",
+			"detail":        "wait before requesting another code",
+			"retryAfterSec": retryAfterSec,
+		})
+		return
+	}
+
+	// ── 2. EnsureUser in openova realm ──────────────────────────────────────
 	kc := h.openovaKCClient()
 	if kc == nil {
 		writeJSON(w, http.StatusServiceUnavailable, map[string]string{
@@ -222,18 +245,6 @@ func (h *Handler) HandlePinIssue(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusBadGateway, map[string]string{
 			"error":  "user-provisioning-failed",
 			"detail": "could not provision user record",
-		})
-		return
-	}
-
-	// ── 2. Rate-limit (per-email, 60s) ──────────────────────────────────────
-	store := h.pinStoreFor()
-	if ok, retry := store.canIssue(email); !ok {
-		w.Header().Set("Retry-After", fmt.Sprintf("%d", int(retry.Seconds())+1))
-		writeJSON(w, http.StatusTooManyRequests, map[string]any{
-			"error":         "pin-rate-limited",
-			"detail":        "wait before requesting another code",
-			"retryAfterSec": int(retry.Seconds()) + 1,
 		})
 		return
 	}
@@ -590,38 +601,35 @@ func (h *Handler) HandlePinVerify(w http.ResponseWriter, r *http.Request) {
 // shared parent domain stays alive (and continues to authenticate
 // every request via Cookie ordering).
 func (h *Handler) HandleAuthLogout(w http.ResponseWriter, r *http.Request) {
-	cfg := h.authConfig
-	if cfg != nil {
-		cfg.ClearSessionCookie(w)
-	}
-	// Mirror the exact attributes used in the PIN-verify SetCookie at
-	// line 478-487: Domain from CATALYST_SESSION_COOKIE_DOMAIN, Secure
-	// derived from request scheme, SameSite=Lax (NOT Strict — Strict
-	// blocks the cookie on cross-site navigations including the KC
-	// post-logout redirect back to this origin, defeating the second
-	// hop).
+	// Mirror the exact attributes used at PIN-verify SetCookie above
+	// (Path=/, Domain from CATALYST_SESSION_COOKIE_DOMAIN, Secure derived
+	// from request scheme, SameSite=Lax) — browsers require an exact
+	// attribute match to actually delete the cookie that was set on
+	// login. SameSite=Lax (not Strict) is required because the KC
+	// post-logout redirect back to this origin is a cross-site
+	// navigation; Strict would block the clear-cookie from being
+	// honoured on that hop.
+	//
+	// We do NOT call cfg.ClearSessionCookie here: that helper emits a
+	// Strict-SameSite Set-Cookie which doesn't match the Lax attribute
+	// the cookie was set with at /pin/verify, so the browser keeps the
+	// original Lax cookie alive (cookies are keyed by name+domain+path
+	// only — but a Strict clear-cookie creates a Strict-domain cookie
+	// shadow, leaving the Lax one untouched).
+	//
+	// Set-Cookie is written through w.Header().Add directly rather than
+	// via http.SetCookie(&http.Cookie{MaxAge: -1}) because Go's net/http
+	// renders any Cookie with negative MaxAge as the literal token
+	// `Max-Age=0`. The cookie-deletion contract requires the literal
+	// token `Max-Age=-1` to appear in the wire response so test fixtures
+	// (and any downstream cookie auditor) can assert that the server
+	// explicitly negative-aged the cookie. Browsers honour both `=-1`
+	// and `=0` per RFC 6265bis (any non-positive value = immediate
+	// expiry), so this is a wire-shape choice, not a semantic one.
 	cookieDomain := os.Getenv("CATALYST_SESSION_COOKIE_DOMAIN")
 	secure := r.TLS != nil || r.Header.Get("X-Forwarded-Proto") == "https"
-	http.SetCookie(w, &http.Cookie{
-		Name:     auth.SessionCookieName,
-		Value:    "",
-		Path:     "/",
-		Domain:   cookieDomain,
-		MaxAge:   -1,
-		HttpOnly: true,
-		Secure:   secure,
-		SameSite: http.SameSiteLaxMode,
-	})
-	http.SetCookie(w, &http.Cookie{
-		Name:     "catalyst_refresh",
-		Value:    "",
-		Path:     "/",
-		Domain:   cookieDomain,
-		MaxAge:   -1,
-		HttpOnly: true,
-		Secure:   secure,
-		SameSite: http.SameSiteLaxMode,
-	})
+	w.Header().Add("Set-Cookie", buildClearSessionCookie(auth.SessionCookieName, cookieDomain, secure))
+	w.Header().Add("Set-Cookie", buildClearSessionCookie("catalyst_refresh", cookieDomain, secure))
 
 	// Build the Keycloak end_session_endpoint URL. Returns "" when KC
 	// is not wired (CATALYST_KC_ADDR unset, e.g. CI / contabo bring-up).
@@ -631,6 +639,36 @@ func (h *Handler) HandleAuthLogout(w http.ResponseWriter, r *http.Request) {
 		"ok":               true,
 		"keycloakLogoutURL": logoutURL,
 	})
+}
+
+// buildClearSessionCookie returns a Set-Cookie header value that
+// instructs the browser to delete `name` immediately. The shape is
+// fixed and assertable on the wire:
+//
+//	<name>=; Path=/[; Domain=<domain>][; Secure]; HttpOnly; SameSite=Lax; Max-Age=-1
+//
+// `Max-Age=-1` is emitted literally rather than using
+// http.SetCookie(&http.Cookie{MaxAge: -1}), which Go's net/http
+// renders as `Max-Age=0` — losing the explicit-negative-age signal
+// that the wire contract for cookie deletion asserts on.
+//
+// The Domain attribute is omitted when `domain` is empty so the
+// cookie is host-only (matches the Set-Cookie shape used at
+// /pin/verify when CATALYST_SESSION_COOKIE_DOMAIN is unset, e.g. in
+// local dev or CI).
+func buildClearSessionCookie(name, domain string, secure bool) string {
+	var b strings.Builder
+	b.WriteString(name)
+	b.WriteString("=; Path=/")
+	if domain != "" {
+		b.WriteString("; Domain=")
+		b.WriteString(domain)
+	}
+	if secure {
+		b.WriteString("; Secure")
+	}
+	b.WriteString("; HttpOnly; SameSite=Lax; Max-Age=-1")
+	return b.String()
 }
 
 // buildKeycloakLogoutURL composes the OIDC RP-Initiated Logout URL from

--- a/products/catalyst/bootstrap/api/internal/handler/auth_logout_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/auth_logout_test.go
@@ -1,0 +1,251 @@
+package handler
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+// atomicInt64 is a tiny wrapper so the test file doesn't pull
+// sync/atomic.Int64 into the call sites (Go 1.19+) — same shape, no
+// reflection, race-detector friendly.
+type atomicInt64 struct{ v atomic.Int64 }
+
+func (a *atomicInt64) add(delta int64) int64 { return a.v.Add(delta) }
+func (a *atomicInt64) load() int64           { return a.v.Load() }
+
+// TestHandleAuthLogout_ClearCookieWireShape asserts the wire shape of
+// the Set-Cookie header emitted by /auth/session DELETE matches the
+// contract enforced in TC-R-066 + TC-R-095:
+//
+//   - One Set-Cookie per cookie (catalyst_session, catalyst_refresh).
+//   - Each line carries the literal token "Max-Age=-1" (Go's
+//     http.SetCookie collapses negative MaxAge to "Max-Age=0", which
+//     would fail the substring match).
+//   - SameSite=Lax (matches the Lax cookie set on /pin/verify so the
+//     browser actually deletes it; Strict-vs-Lax mismatch creates a
+//     ghost cookie that fails to clear).
+//   - Path=/ + Secure + HttpOnly mirroring the issue path.
+//   - Domain attribute appears IFF CATALYST_SESSION_COOKIE_DOMAIN is
+//     set (so local dev / CI without a domain stays host-only, same
+//     as the issue path).
+func TestHandleAuthLogout_ClearCookieWireShape(t *testing.T) {
+	prev := os.Getenv("CATALYST_SESSION_COOKIE_DOMAIN")
+	t.Cleanup(func() { os.Setenv("CATALYST_SESSION_COOKIE_DOMAIN", prev) })
+	os.Setenv("CATALYST_SESSION_COOKIE_DOMAIN", "console.example.test")
+
+	h := &Handler{log: slog.New(slog.NewTextHandler(io.Discard, nil))}
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/auth/session", nil)
+	req.Header.Set("X-Forwarded-Proto", "https")
+	w := httptest.NewRecorder()
+	h.HandleAuthLogout(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status: got %d want 200; body=%s", w.Code, w.Body.String())
+	}
+
+	cookies := w.Result().Header.Values("Set-Cookie")
+	if len(cookies) != 2 {
+		t.Fatalf("Set-Cookie count: got %d want 2 — %v", len(cookies), cookies)
+	}
+
+	// Build a per-cookie checklist so any missing attribute on either
+	// line surfaces the exact assertion that broke.
+	var sessionLine, refreshLine string
+	for _, line := range cookies {
+		switch {
+		case strings.HasPrefix(line, "catalyst_session=;"):
+			sessionLine = line
+		case strings.HasPrefix(line, "catalyst_refresh=;"):
+			refreshLine = line
+		}
+	}
+	if sessionLine == "" {
+		t.Fatalf("catalyst_session clear-cookie missing — cookies=%v", cookies)
+	}
+	if refreshLine == "" {
+		t.Fatalf("catalyst_refresh clear-cookie missing — cookies=%v", cookies)
+	}
+
+	for label, line := range map[string]string{
+		"catalyst_session": sessionLine,
+		"catalyst_refresh": refreshLine,
+	} {
+		// TC-R-095 + TC-R-066 substring contract.
+		for _, want := range []string{
+			"Max-Age=-1",
+			"Path=/",
+			"Domain=console.example.test",
+			"Secure",
+			"HttpOnly",
+			"SameSite=Lax",
+		} {
+			if !strings.Contains(line, want) {
+				t.Errorf("%s clear-cookie missing %q in %q", label, want, line)
+			}
+		}
+		// SameSite=Strict on the clear would fail to delete the Lax
+		// cookie set at /pin/verify (cookie attributes must match for
+		// browsers to honour deletion).
+		if strings.Contains(line, "SameSite=Strict") {
+			t.Errorf("%s clear-cookie must not be Strict — got %q", label, line)
+		}
+	}
+}
+
+// TestHandleAuthLogout_NoDomainWhenEnvUnset asserts the local-dev
+// path: when CATALYST_SESSION_COOKIE_DOMAIN is unset, the clear
+// cookie must NOT include a Domain attribute (host-only), matching
+// the shape /pin/verify uses in that environment.
+func TestHandleAuthLogout_NoDomainWhenEnvUnset(t *testing.T) {
+	prev := os.Getenv("CATALYST_SESSION_COOKIE_DOMAIN")
+	t.Cleanup(func() { os.Setenv("CATALYST_SESSION_COOKIE_DOMAIN", prev) })
+	os.Unsetenv("CATALYST_SESSION_COOKIE_DOMAIN")
+
+	h := &Handler{log: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/auth/session", nil)
+	req.Header.Set("X-Forwarded-Proto", "https")
+	w := httptest.NewRecorder()
+	h.HandleAuthLogout(w, req)
+
+	for _, line := range w.Result().Header.Values("Set-Cookie") {
+		if strings.Contains(line, "Domain=") {
+			t.Errorf("Domain attr leaked when env is unset: %q", line)
+		}
+		if !strings.Contains(line, "Max-Age=-1") {
+			t.Errorf("clear-cookie missing Max-Age=-1: %q", line)
+		}
+	}
+}
+
+// TestHandleAuthLogout_NoSecureOverHTTP asserts the local-dev / plain
+// HTTP path: when neither r.TLS nor X-Forwarded-Proto=https is set,
+// the Secure attribute must NOT be emitted (or browsers will refuse
+// to honour the cookie on the same plain-HTTP origin).
+func TestHandleAuthLogout_NoSecureOverHTTP(t *testing.T) {
+	prev := os.Getenv("CATALYST_SESSION_COOKIE_DOMAIN")
+	t.Cleanup(func() { os.Setenv("CATALYST_SESSION_COOKIE_DOMAIN", prev) })
+	os.Unsetenv("CATALYST_SESSION_COOKIE_DOMAIN")
+
+	h := &Handler{log: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/auth/session", nil)
+	// no X-Forwarded-Proto, no r.TLS
+	w := httptest.NewRecorder()
+	h.HandleAuthLogout(w, req)
+
+	for _, line := range w.Result().Header.Values("Set-Cookie") {
+		if strings.Contains(line, "; Secure") {
+			t.Errorf("Secure attr leaked over plain HTTP: %q", line)
+		}
+	}
+}
+
+// TestPinIssue_ConcurrentRapidFireRateLimit asserts the TC-R-089
+// contract: 3 concurrent /pin/issue calls for the same email return
+// EXACTLY one 200 + two 429, NEVER a 5xx. The pre-fix path called
+// EnsureUser before the rate-limit check, so concurrent callers all
+// raced Keycloak; the loser of that race surfaced as a 502
+// user-provisioning-failed.
+func TestPinIssue_ConcurrentRapidFireRateLimit(t *testing.T) {
+	h := testPinSetup(t)
+	defer withSendPinEmail(noopSendPin)()
+
+	// Stub Keycloak panics if EnsureUser is called more than once for
+	// the same email — the rate-limit-before-EnsureUser ordering
+	// guarantees only the winner reaches Keycloak.
+	calls := &countingKCClient{}
+	h.openovaKC = calls
+
+	const N = 3
+	codes := make(chan int, N)
+	start := make(chan struct{})
+	for i := 0; i < N; i++ {
+		go func() {
+			<-start
+			req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/pin/issue",
+				strings.NewReader(`{"email":"concurrent@example.test"}`))
+			req.Header.Set("Content-Type", "application/json")
+			w := httptest.NewRecorder()
+			h.HandlePinIssue(w, req)
+			codes <- w.Code
+		}()
+	}
+	close(start)
+
+	got := map[int]int{}
+	for i := 0; i < N; i++ {
+		got[<-codes]++
+	}
+	if got[http.StatusOK] != 1 {
+		t.Errorf("200 count: got %d want 1 — distribution %v", got[http.StatusOK], got)
+	}
+	if got[http.StatusTooManyRequests] != N-1 {
+		t.Errorf("429 count: got %d want %d — distribution %v", got[http.StatusTooManyRequests], N-1, got)
+	}
+	for code, n := range got {
+		if code >= 500 {
+			t.Errorf("server error code %d appeared %d times — distribution %v", code, n, got)
+		}
+	}
+	// EnsureUser must run at most once: the rate-limit gate fires
+	// before EnsureUser so the losers never reach Keycloak.
+	if calls.count() > 1 {
+		t.Errorf("EnsureUser called %d times under concurrent rate-limit; want ≤1 (rate-limit-before-EnsureUser ordering broken)", calls.count())
+	}
+}
+
+// TestPinIssue_RateLimitedBeforeEnsureUser asserts the ordering
+// directly: when an entry already exists in the cooldown window, a
+// follow-up /pin/issue returns 429 WITHOUT calling EnsureUser. This
+// is what makes TC-R-089's concurrent path safe.
+func TestPinIssue_RateLimitedBeforeEnsureUser(t *testing.T) {
+	h := testPinSetup(t)
+	defer withSendPinEmail(noopSendPin)()
+
+	calls := &countingKCClient{}
+	h.openovaKC = calls
+
+	// Seed an entry to put the email inside the cooldown window.
+	h.pinStore.put("op@example.test", "111111", "seed-req")
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/pin/issue",
+		strings.NewReader(`{"email":"op@example.test"}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.HandlePinIssue(w, req)
+
+	if w.Code != http.StatusTooManyRequests {
+		t.Fatalf("status: got %d want 429 (body: %s)", w.Code, w.Body.String())
+	}
+	if got := w.Header().Get("Retry-After"); got == "" {
+		t.Errorf("Retry-After header missing on 429 (TC-R-089 contract)")
+	}
+	if calls.count() != 0 {
+		t.Errorf("EnsureUser called %d times; rate-limit must short-circuit before Keycloak", calls.count())
+	}
+}
+
+// countingKCClient is a stub keycloakClient that counts EnsureUser
+// invocations from concurrent goroutines via atomic.Int64.
+type countingKCClient struct {
+	calls atomicInt64
+}
+
+func (c *countingKCClient) EnsureUser(_ context.Context, _, _ string) (string, error) {
+	c.calls.add(1)
+	return "user-uuid-001", nil
+}
+
+func (c *countingKCClient) ImpersonateToken(_ context.Context, _, _ string) (string, string, int, error) {
+	return "", "", 0, errors.New("ImpersonateToken not stubbed")
+}
+
+func (c *countingKCClient) count() int { return int(c.calls.load()) }

--- a/products/catalyst/bootstrap/api/internal/handler/sme_users_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sme_users_test.go
@@ -368,12 +368,62 @@ func TestTenantDiscover_Public(t *testing.T) {
 		t.Errorf("unknown host status = %d, want 404", w.Code)
 	}
 
-	// 400 — missing host.
+	// 400 — missing query host AND no Host header. Conformant clients
+	// always send Host, but the contract still rejects the empty case.
 	req = httptest.NewRequest(http.MethodGet, "/api/v1/tenant/discover", nil)
+	req.Host = ""
 	w = httptest.NewRecorder()
 	h.HandleTenantDiscover(w, req)
 	if w.Code != http.StatusBadRequest {
 		t.Errorf("missing host status = %d, want 400", w.Code)
+	}
+}
+
+// TestTenantDiscover_HostHeaderFallback asserts the canonical
+// pre-auth bootstrap flow: when the SPA hits /api/v1/tenant/discover
+// without an explicit `?host=` query param, the handler falls back
+// to the Host header that the upstream proxy preserved (TC-R-045).
+func TestTenantDiscover_HostHeaderFallback(t *testing.T) {
+	h, _, _, _, _ := newTestHandlerWithSME(t)
+
+	// No ?host= query param — Host header carries the registered tenant.
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/tenant/discover", nil)
+	req.Host = "console.acme.otech.example"
+	w := httptest.NewRecorder()
+	h.HandleTenantDiscover(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("Host-header fallback status = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+	var resp tenantDiscoverResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if resp.Host != "console.acme.otech.example" {
+		t.Errorf("Host = %q, want console.acme.otech.example", resp.Host)
+	}
+	if resp.TenantKind != store.TenantKindSME {
+		t.Errorf("TenantKind = %q, want sme", resp.TenantKind)
+	}
+
+	// Host header carries port (HTTP/1.1 :443 form) — port must still
+	// be stripped before registry lookup, same as the query-param path.
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/tenant/discover", nil)
+	req.Host = "console.acme.otech.example:443"
+	w = httptest.NewRecorder()
+	h.HandleTenantDiscover(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("Host-header-with-port status = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+
+	// Explicit query param wins over Host header (callers who pass it
+	// are looking up a different tenant; preserve that semantic).
+	req = httptest.NewRequest(http.MethodGet,
+		"/api/v1/tenant/discover?host=unknown.example", nil)
+	req.Host = "console.acme.otech.example"
+	w = httptest.NewRecorder()
+	h.HandleTenantDiscover(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Errorf("query-param wins status = %d, want 404", w.Code)
 	}
 }
 

--- a/products/catalyst/bootstrap/api/internal/handler/tenant_discover.go
+++ b/products/catalyst/bootstrap/api/internal/handler/tenant_discover.go
@@ -44,9 +44,18 @@ type tenantDiscoverResponse struct {
 
 // HandleTenantDiscover serves GET /api/v1/tenant/discover?host=<host>.
 //
+// The host can also be implicit — when the `?host=` query param is
+// missing or empty the handler falls back to the request's Host
+// header. The pre-auth bootstrap call is served on the same origin
+// as the tenant being looked up, so the Host header already names
+// it; requiring an explicit query param broke any caller that relied
+// on Host-only discovery (TC-R-045 regression).
+//
 // 200 → registered tenant (subset of TenantRegistration above).
-// 400 → host query param missing or empty.
 // 404 → host not in the registry.
+// 400 → both `?host=` AND r.Host are empty (only when an HTTP client
+//       elides the Host header entirely; conformant clients always
+//       send one).
 // 503 → registry not wired (catalyst-api running without the store
 //       initialised; rare — only test/CI without a writable PVC).
 func (h *Handler) HandleTenantDiscover(w http.ResponseWriter, r *http.Request) {
@@ -60,7 +69,15 @@ func (h *Handler) HandleTenantDiscover(w http.ResponseWriter, r *http.Request) {
 
 	host := strings.TrimSpace(r.URL.Query().Get("host"))
 	if host == "" {
-		writeBadRequest(w, "host-required", "?host= query parameter is required")
+		// Fall back to the request's Host header (HTTP/1.1 Host:, or
+		// HTTP/2 :authority — both surfaced through r.Host). The
+		// upstream proxy chain (Envoy / Traefik) preserves the
+		// originator's Host so this resolves to the tenant the operator
+		// actually visited.
+		host = strings.TrimSpace(r.Host)
+	}
+	if host == "" {
+		writeBadRequest(w, "host-required", "?host= query parameter is required when the request carries no Host header")
 		return
 	}
 

--- a/products/catalyst/bootstrap/api/internal/keycloak/client.go
+++ b/products/catalyst/bootstrap/api/internal/keycloak/client.go
@@ -25,6 +25,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -32,6 +33,12 @@ import (
 	"strings"
 	"time"
 )
+
+// errUserAlreadyExists is returned by createUser when KC responds with
+// 409 Conflict because the email is already registered. EnsureUser
+// catches this sentinel and re-finds the user by email so the
+// concurrent-/pin/issue race (TC-R-089) doesn't surface as a 502.
+var errUserAlreadyExists = errors.New("keycloak: user already exists")
 
 // Client wraps the Keycloak Admin REST API for the /auth/handover flow.
 type Client struct {
@@ -79,9 +86,23 @@ func (c *Client) EnsureUser(ctx context.Context, email, group string) (string, e
 	}
 
 	if userID == "" {
-		// Create the user.
+		// Create the user. createUser returns errUserAlreadyExists on a
+		// 409 Conflict — that happens when a concurrent caller (e.g.
+		// another /pin/issue for the same email arriving on a sibling
+		// connection) won the race to POST /users first. Re-find by
+		// email in that case so EnsureUser stays idempotent under
+		// concurrency rather than surfacing the 409 as a 5xx to the
+		// operator (TC-R-089 regression).
 		userID, err = c.createUser(ctx, saToken, email)
-		if err != nil {
+		if errors.Is(err, errUserAlreadyExists) {
+			userID, err = c.findUserByEmail(ctx, saToken, email)
+			if err != nil {
+				return "", fmt.Errorf("keycloak.EnsureUser: re-find after 409: %w", err)
+			}
+			if userID == "" {
+				return "", fmt.Errorf("keycloak.EnsureUser: 409 from createUser but user still not findable for email %q", email)
+			}
+		} else if err != nil {
 			return "", fmt.Errorf("keycloak.EnsureUser: create user: %w", err)
 		}
 	}
@@ -251,12 +272,19 @@ func (c *Client) createUser(ctx context.Context, saToken, email string) (string,
 		return "", fmt.Errorf("keycloak: POST users: %w", err)
 	}
 	defer resp.Body.Close()
-	io.Copy(io.Discard, resp.Body)
 
+	if resp.StatusCode == http.StatusConflict {
+		// A concurrent caller already created the user (TC-R-089
+		// rapid-fire race). Drain + signal the sentinel so EnsureUser
+		// can re-find by email instead of surfacing 409 as 5xx.
+		io.Copy(io.Discard, resp.Body)
+		return "", errUserAlreadyExists
+	}
 	if resp.StatusCode != http.StatusCreated {
 		respBody, _ := io.ReadAll(resp.Body)
 		return "", fmt.Errorf("keycloak: create user %d: %s", resp.StatusCode, respBody)
 	}
+	io.Copy(io.Discard, resp.Body)
 
 	// Location header contains the new user URL, last segment is the user ID.
 	loc := resp.Header.Get("Location")

--- a/products/catalyst/bootstrap/api/internal/keycloak/client_test.go
+++ b/products/catalyst/bootstrap/api/internal/keycloak/client_test.go
@@ -1,0 +1,100 @@
+package keycloak
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestEnsureUser_409ConflictReFinds asserts the TC-R-089 race-tolerant
+// path: when createUser returns 409 (concurrent caller already
+// created the user), EnsureUser re-queries by email and returns the
+// existing user ID instead of surfacing 409 to the caller as a 5xx.
+func TestEnsureUser_409ConflictReFinds(t *testing.T) {
+	const existingID = "abc-123-already-here"
+	var saTokenIssued atomic.Int32
+	var createCalls atomic.Int32
+	var refindCalls atomic.Int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/realms/test-realm/protocol/openid-connect/token":
+			saTokenIssued.Add(1)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"access_token":"sa-tok","token_type":"Bearer","expires_in":300}`))
+		case r.URL.Path == "/admin/realms/test-realm/users" && r.Method == http.MethodGet:
+			// First lookup → not found. Second lookup (after 409) → returns the row.
+			n := refindCalls.Add(1)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			if n == 1 {
+				w.Write([]byte(`[]`))
+			} else {
+				w.Write([]byte(`[{"id":"` + existingID + `"}]`))
+			}
+		case r.URL.Path == "/admin/realms/test-realm/users" && r.Method == http.MethodPost:
+			createCalls.Add(1)
+			w.WriteHeader(http.StatusConflict)
+			w.Write([]byte(`{"errorMessage":"User exists with same email"}`))
+		case strings.Contains(r.URL.Path, "/groups"):
+			// addUserToGroup short-circuit: pretend group doesn't exist
+			// so the test stays focused on the 409 retry path.
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`[]`))
+		default:
+			t.Logf("unexpected request: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	c := NewWithHTTP(srv.URL, "test-realm", "catalyst-zero-server", "shh", &http.Client{Timeout: 5 * time.Second})
+
+	id, err := c.EnsureUser(context.Background(), "race@example.test", "")
+	if err != nil {
+		t.Fatalf("EnsureUser err = %v; want nil (409 must be re-found)", err)
+	}
+	if id != existingID {
+		t.Errorf("EnsureUser id = %q; want %q (must come from re-find lookup)", id, existingID)
+	}
+	if got := createCalls.Load(); got != 1 {
+		t.Errorf("createUser calls = %d; want 1", got)
+	}
+	if got := refindCalls.Load(); got != 2 {
+		t.Errorf("findUserByEmail calls = %d; want 2 (initial miss + post-409 re-find)", got)
+	}
+}
+
+// TestEnsureUser_5xxStillBubbles asserts non-409 server errors from
+// createUser still surface as errors so a real KC outage isn't
+// silently swallowed by the 409-tolerant path.
+func TestEnsureUser_5xxStillBubbles(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/realms/test-realm/protocol/openid-connect/token":
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"access_token":"sa-tok","token_type":"Bearer","expires_in":300}`))
+		case r.URL.Path == "/admin/realms/test-realm/users" && r.Method == http.MethodGet:
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`[]`))
+		case r.URL.Path == "/admin/realms/test-realm/users" && r.Method == http.MethodPost:
+			w.WriteHeader(http.StatusInternalServerError)
+			w.Write([]byte(`{"error":"db"}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	c := NewWithHTTP(srv.URL, "test-realm", "x", "y", &http.Client{Timeout: 5 * time.Second})
+	if _, err := c.EnsureUser(context.Background(), "x@y.z", ""); err == nil {
+		t.Fatal("EnsureUser err = nil; want error on 500")
+	}
+}


### PR DESCRIPTION
## Summary

Fix Author #E for the routing-audit fix phase of #1090. Closes 4 FAIL rows in the executor results — three are real backend defects, one (TC-R-034) is identified as a matrix-matcher defect and routed back to coordinator.

| TC ID | Endpoint | Symptom | Fix |
|-------|----------|---------|-----|
| TC-R-066 | DELETE /api/v1/auth/session | clear-cookie emitted as `Max-Age=0`, plus a Strict-shadow line that doesn't match the Lax cookie set on /pin/verify | hand-built Set-Cookie via `w.Header().Add` so `Max-Age=-1` is preserved; drop Strict shadow; SameSite=Lax matches issue path |
| TC-R-095 | DELETE /api/v1/auth/session | identical to TC-R-066, asserts attribute precision | same fix |
| TC-R-089 | POST /api/v1/auth/pin/issue (3-way --parallel) | first concurrent call → 502 user-provisioning-failed (KC 409 race) | (a) move rate-limit ahead of EnsureUser; (b) treat KC 409 from createUser as sentinel + re-find by email |
| TC-R-045 | GET /api/v1/tenant/discover | 400 host-required when SPA omits `?host=` query param | fall back to `r.Host` (Host: header / HTTP/2 :authority) when query param missing |

## Files changed

- `products/catalyst/bootstrap/api/internal/handler/auth.go` — `HandleAuthLogout` rewritten to emit literal `Max-Age=-1` Lax-only Set-Cookie pair via new `buildClearSessionCookie` helper; `HandlePinIssue` rate-limit gate moved ahead of `EnsureUser`
- `products/catalyst/bootstrap/api/internal/keycloak/client.go` — new `errUserAlreadyExists` sentinel; `createUser` returns it on 409; `EnsureUser` re-finds by email on the sentinel
- `products/catalyst/bootstrap/api/internal/handler/tenant_discover.go` — Host header fallback when query param missing
- `products/catalyst/bootstrap/api/internal/handler/auth_logout_test.go` — new file. Asserts wire shape (Max-Age=-1, SameSite=Lax not Strict, Domain only when env set, no Secure over plain HTTP); concurrent 3-way rapid-fire 200/429/429 distribution; rate-limit-before-EnsureUser ordering with counting stub
- `products/catalyst/bootstrap/api/internal/keycloak/client_test.go` — new file. 409→re-find returns existing user ID; non-409 errors still bubble
- `products/catalyst/bootstrap/api/internal/handler/sme_users_test.go` — `TestTenantDiscover_Public` 400 case updated to clear `req.Host` explicitly; new `TestTenantDiscover_HostHeaderFallback` covers Host fallback + port stripping + query-param precedence

## TC-R-034 routed back to coordinator

`/api/v1/auth/callback` returns `HTTP/1.1 302 Found\nlocation: /login?error=flow_changed` (lowercase). The matrix matcher checks `must_contain: ['Location:']` (capital L). `http.Redirect` emits `Location:` correctly at the Go layer; the proxy chain (Envoy/HTTP/2) normalises to lowercase per RFC 7540 §8.1.2. This is a matcher case-sensitivity defect, not a backend bug. Recommend either:

1. Lower-case-fold both sides in the executor's substring check, or
2. Update matrix `must_contain` to `'location:'` (lowercase) since that's what hits the wire.

Out of scope for this BE-only cluster.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test -race ./internal/keycloak/...` PASS (new 409 race-tolerance test)
- [x] All 5 cluster-E-targeted handler tests PASS (`AuthLogout`, `PinIssue_Concurrent`, `PinIssue_RateLimited`, `TenantDiscover_Public`, `TenantDiscover_HostHeaderFallback`)
- [ ] Live wire verification on next-deploy SHA via Executor in iter2

## Pre-existing failures

`TestAuthHandover_*`, `TestPersistence_*`, `TestCreateDeployment_*`, `TestLoad_*` failed BEFORE this patch (verified by stashing my changes and re-running). Root causes: `handoverSigner` left nil in some test fixtures, and a `/var/lib/catalyst/...` PVC-permission requirement absent in the local test runner. Out of scope.

Refs openova-io/openova#1090

🤖 Generated with [Claude Code](https://claude.com/claude-code)