### PR TITLE
docs(adr-0001): ratify Accepted with §2.3 K8s-Composition amendment (slice A1, #1095)

### DIFF
--- a/docs/adr/0001-catalyst-control-plane-architecture.md
+++ b/docs/adr/0001-catalyst-control-plane-architecture.md
@@ -2,12 +2,14 @@
 
 | | |
 |---|---|
-| **Status** | Proposed — pending founder approval |
+| **Status** | Accepted (2026-05-08) |
 | **Authors** | hatiyildiz, Claude (Opus 4.7) |
-| **Date** | 2026-05-01 |
+| **Date** | 2026-05-01 (Proposed); 2026-05-08 (Accepted with §2.3 amendment) |
 | **Supersedes** | — |
 | **Superseded by** | — |
-| **Related** | #309, #320, #321, #322, #324, #325, #326, #347, #68 |
+| **Related** | #309, #320, #321, #322, #324, #325, #326, #347, #68; ratified under #1094 / #1095 (Phase-0 Foundation) — see [`docs/EPICS-1-6-unified-design.md`](../EPICS-1-6-unified-design.md). |
+
+> **2026-05-08 amendment (rule 3 clarification)**: Reconciling RoleBindings, Kustomizations, ConfigMaps, and other K8s-to-K8s objects is the responsibility of Flux Kustomizations or thin in-cluster controllers — not Crossplane Compositions. The `useraccess-controller` is the canonical example: it watches `UserAccess` CRs and reconciles RoleBindings/ClusterRoleBindings via the kubernetes Go clientset. The earlier `XUserAccess` Composition that used `provider-kubernetes` is retired in EPIC-0 (#1095).
 
 ---
 


### PR DESCRIPTION
## Summary

Slice **A1** of EPIC-0 (#1095). Promotes ADR-0001 from Proposed → Accepted (2026-05-08) with one §2.3 amendment to make the in-cluster controller pattern canonical for K8s-to-K8s reconciliation.

## Why

Audit (`openova-private/.claude/audit-synthesis-2026-05-08.md`) confirmed:
- `XUserAccess` Composition references `provider-kubernetes` which is **not installed** on any Sovereign — silent P0 bug.
- ADR-0001 §2.3 already says Crossplane is cloud-only — but did not name the canonical replacement seam for K8s-to-K8s.

The amendment locks in `useraccess-controller` (slice C5 of this same EPIC-0) as the canonical replacement. Future K8s-to-K8s reconciliation follows the in-cluster controller pattern without re-debating.

## Test plan

- [x] ADR table renders correctly on GitHub
- [x] Amendment paragraph cites the retiring Composition + the new controller (slice C5)
- [x] Status flip to Accepted is the only behavioral change

🤖 Generated with [Claude Code](https://claude.com/claude-code)