### PR TITLE
feat(catalyst-chart): land Application CRD apps.openova.io/v1 (slice B3, #1095)

### DIFF
--- a/products/catalyst/chart/crds/application.yaml
+++ b/products/catalyst/chart/crds/application.yaml
@@ -1,0 +1,247 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: applications.apps.openova.io
+  labels:
+    app.kubernetes.io/name: catalyst
+    app.kubernetes.io/component: application
+spec:
+  group: apps.openova.io
+  scope: Namespaced
+  names:
+    kind: Application
+    listKind: ApplicationList
+    singular: application
+    plural: applications
+    shortNames:
+      - app
+      - apps
+    categories:
+      - catalyst
+      - openova
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      additionalPrinterColumns:
+        - name: Blueprint
+          type: string
+          jsonPath: .spec.blueprintRef.name
+        - name: Version
+          type: string
+          jsonPath: .spec.blueprintRef.version
+        - name: Environment
+          type: string
+          jsonPath: .spec.environmentRef
+        - name: Placement
+          type: string
+          jsonPath: .spec.placement
+        - name: Phase
+          type: string
+          jsonPath: .status.phase
+        - name: Primary
+          type: string
+          jsonPath: .status.primaryRegion
+          priority: 1
+        - name: Age
+          type: date
+          jsonPath: .metadata.creationTimestamp
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
+          type: object
+          description: |
+            Application is an installed instance of a Blueprint, owned by an
+            Organization, deployed into one or more regions per its Placement,
+            managed by Flux.
+
+            One Application = one Gitea repo at
+            gitea.{location-code}.{sovereign-domain}/{org}/{app}; branches
+            develop/staging/main map to dev/stg/prod Environments.
+
+            See docs/EPICS-1-6-unified-design.md §3.2.3 and
+            docs/BLUEPRINT-AUTHORING.md §3 for the contract.
+          required: [spec]
+          properties:
+            spec:
+              type: object
+              required: [environmentRef, blueprintRef, placement, regions]
+              properties:
+                environmentRef:
+                  type: string
+                  description: |
+                    Name of the Environment CR (e.g. acme-prod) this Application
+                    belongs to. Environment determines vCluster targets and
+                    Gitea branch.
+                  pattern: '^[a-z][a-z0-9-]{2,63}$'
+                blueprintRef:
+                  type: object
+                  required: [name, version]
+                  properties:
+                    name:
+                      type: string
+                      description: Blueprint name (e.g. bp-wordpress).
+                      pattern: '^bp-[a-z][a-z0-9-]{1,62}$'
+                    version:
+                      type: string
+                      description: Semver of the Blueprint OCI artifact.
+                      pattern: '^[0-9]+\.[0-9]+\.[0-9]+(-[a-z0-9.-]+)?$'
+                placement:
+                  type: string
+                  enum:
+                    - single-region
+                    - active-active
+                    - active-hotstandby
+                  description: |
+                    DR posture. single-region = one cluster only. active-active
+                    = manifests fan out to all regions[]. active-hotstandby =
+                    primary in regions[0], standby in regions[1..] with
+                    replica:0; failover managed by the Continuum controller.
+                regions:
+                  type: array
+                  minItems: 1
+                  maxItems: 5
+                  description: |
+                    Host clusters this Application targets, in priority order.
+                    For active-hotstandby, regions[0] is the primary.
+                  items:
+                    type: string
+                    pattern: '^[a-z]+-[a-z]+-[a-z]+-[a-z]+$'
+                parameters:
+                  type: object
+                  description: |
+                    User-supplied values, validated against the Blueprint's
+                    spec.configSchema (BLUEPRINT-AUTHORING.md §3-§4).
+                    Free-form here; the application-controller and the
+                    blueprint-controller's admission webhook enforce the
+                    schema match at admission.
+                  x-kubernetes-preserve-unknown-fields: true
+                healthCheck:
+                  type: object
+                  required: [path, port]
+                  properties:
+                    path:
+                      type: string
+                      description: HTTP(S) path probed for liveness from outside the cluster.
+                      pattern: '^/.*'
+                    port:
+                      x-kubernetes-int-or-string: true
+                      description: Service port name or numeric port.
+                    intervalSeconds:
+                      type: integer
+                      minimum: 5
+                      maximum: 300
+                      default: 30
+                    timeoutSeconds:
+                      type: integer
+                      minimum: 1
+                      maximum: 60
+                      default: 5
+                owners:
+                  type: array
+                  description: Per-Application owner list. Roles materialize as UserAccess via useraccess-controller.
+                  items:
+                    type: object
+                    required: [email, role]
+                    properties:
+                      email:
+                        type: string
+                        format: email
+                      role:
+                        type: string
+                        enum: [owner, admin, developer, viewer]
+                topology:
+                  type: object
+                  description: DR / scaling knobs read by the Continuum controller (#1101).
+                  properties:
+                    autoFailover:
+                      type: boolean
+                      default: false
+                      description: Only meaningful for placement=active-hotstandby.
+                    rto:
+                      type: string
+                      pattern: '^[0-9]+(s|m|h)$'
+                      description: Recovery Time Objective (e.g. "60s", "5m").
+                    rpo:
+                      type: string
+                      pattern: '^[0-9]+(s|m|h)$'
+                      description: Recovery Point Objective (e.g. "5s", "1m").
+                    minReplicas:
+                      type: integer
+                      minimum: 1
+                      description: Lower bound for any HPA the Blueprint declares.
+                  x-kubernetes-preserve-unknown-fields: true
+              x-kubernetes-preserve-unknown-fields: true
+            status:
+              type: object
+              properties:
+                phase:
+                  type: string
+                  enum:
+                    - Pending
+                    - Provisioning
+                    - Ready
+                    - Degraded
+                    - Failed
+                    - Uninstalling
+                primaryRegion:
+                  type: string
+                  description: Currently-primary host cluster. Switched by the Continuum controller on failover.
+                regions:
+                  type: array
+                  description: Per-region rollout state.
+                  items:
+                    type: object
+                    required: [name]
+                    properties:
+                      name:
+                        type: string
+                      role:
+                        type: string
+                        enum: [primary, standby, active]
+                      replicas:
+                        type: integer
+                        minimum: 0
+                      ready:
+                        type: integer
+                        minimum: 0
+                      lastTransitionTime:
+                        type: string
+                        format: date-time
+                giteaRepo:
+                  type: string
+                  description: Full URL of the per-Application Gitea repo (e.g. gitea.hfmp.omantel.openova.io/acme/marketing-site).
+                installedBlueprint:
+                  type: object
+                  description: Snapshot of the Blueprint actually rendered (post upgrade-resolve).
+                  properties:
+                    name:
+                      type: string
+                    version:
+                      type: string
+                    digest:
+                      type: string
+                      description: OCI artifact digest for reproducibility.
+                conditions:
+                  type: array
+                  items:
+                    type: object
+                    required: [type, status]
+                    properties:
+                      type:
+                        type: string
+                      status:
+                        type: string
+                        enum: ["True", "False", "Unknown"]
+                      reason:
+                        type: string
+                      message:
+                        type: string
+                      lastTransitionTime:
+                        type: string
+                        format: date-time
+                observedGeneration:
+                  type: integer
+                  format: int64
+              x-kubernetes-preserve-unknown-fields: true

--- a/products/catalyst/chart/crds/tests/application-sample-invalid.yaml
+++ b/products/catalyst/chart/crds/tests/application-sample-invalid.yaml
@@ -1,0 +1,38 @@
+# Invalid sample — must FAIL schema validation. Each field below carries an
+# error vector the schema MUST catch:
+#
+#   placement: "round-robin"           — not in enum
+#   blueprintRef.name: "wordpress"     — missing bp- prefix
+#   blueprintRef.version: "1.3"        — not strict semver
+#   regions: []                        — minItems=1
+#   environmentRef: "ACME PROD"        — uppercase + space, fails pattern
+#   topology.rto: "1 minute"           — wrong format
+#   owners[0].role: "superuser"        — not in enum
+#   healthCheck.intervalSeconds: 600   — exceeds maximum
+#
+# Run via:
+#   kubectl apply --dry-run=server -f application-sample-invalid.yaml
+# Expect: rejection citing every offending field.
+apiVersion: apps.openova.io/v1
+kind: Application
+metadata:
+  name: bad-app
+  namespace: acme
+spec:
+  environmentRef: "ACME PROD"
+  blueprintRef:
+    name: wordpress
+    version: "1.3"
+  placement: round-robin
+  regions: []
+  healthCheck:
+    path: /health
+    port: http
+    intervalSeconds: 600
+  owners:
+    - email: ops@acme.com
+      role: superuser
+  topology:
+    autoFailover: true
+    rto: "1 minute"
+    rpo: 5s

--- a/products/catalyst/chart/crds/tests/application-sample-valid.yaml
+++ b/products/catalyst/chart/crds/tests/application-sample-valid.yaml
@@ -1,0 +1,46 @@
+# Valid sample — covers active-hotstandby placement, healthCheck, owners,
+# topology with rto/rpo. Verified via:
+#   kubectl apply --dry-run=server -f application-sample-valid.yaml
+# (server-side dry-run requires the CRD applied to a real cluster first).
+apiVersion: apps.openova.io/v1
+kind: Application
+metadata:
+  name: marketing-site
+  namespace: acme
+  labels:
+    openova.io/organization: acme
+    openova.io/environment: acme-prod
+    openova.io/application: marketing-site
+spec:
+  environmentRef: acme-prod
+  blueprintRef:
+    name: bp-wordpress
+    version: 1.3.0
+  placement: active-hotstandby
+  regions:
+    - hz-fsn-rtz-prod
+    - hz-hel-rtz-prod
+  parameters:
+    domain: marketing.acme-prod.omantel.openova.io
+    adminEmail: ops@acme.com
+    replicas: 2
+    postgres:
+      mode: external
+      ref: shared-postgres
+  healthCheck:
+    path: /health
+    port: http
+    intervalSeconds: 30
+    timeoutSeconds: 5
+  owners:
+    - email: ops@acme.com
+      role: admin
+    - email: dev@acme.com
+      role: developer
+    - email: ceo@acme.com
+      role: owner
+  topology:
+    autoFailover: true
+    rto: 60s
+    rpo: 5s
+    minReplicas: 2


### PR DESCRIPTION
## Summary

Slice **B3** of EPIC-0 (#1095). Land the Application CRD per the design contract in \`docs/EPICS-1-6-unified-design.md\` §3.2.3 and \`docs/BLUEPRINT-AUTHORING.md\` §3.

## Why

- Today \`Application\` is a label heuristic (\`dashboard.go:284-297\`) and a static client-side stub (\`applicationCatalog.ts\`). Not a K8s object.
- Without the CRD, EPIC-2 (#1097) \`application-controller\` has no resource to watch, and EPIC-6 (#1101) Continuum has no Application.spec.placement / topology.{rto,rpo} to reconcile against.
- This slice makes Application a first-class object — controllers in slice C4 (#1097) and #1101 attach later.

## Schema highlights

| Field | Notes |
|---|---|
| \`spec.environmentRef\` | FK to Environment CR; pattern \`^[a-z][a-z0-9-]{2,63}$\` |
| \`spec.blueprintRef.{name,version}\` | name pattern \`^bp-[a-z][a-z0-9-]{1,62}$\`; version strict semver |
| \`spec.placement\` | enum \`single-region | active-active | active-hotstandby\` |
| \`spec.regions[]\` | minItems=1, maxItems=5 |
| \`spec.parameters\` | free-form (validated against Blueprint.spec.configSchema by the controller — preserveUnknownFields) |
| \`spec.healthCheck\` | path/port required; interval 5-300s; timeout 1-60s |
| \`spec.owners[]\` | role enum owner/admin/developer/viewer |
| \`spec.topology\` | autoFailover, rto/rpo (\`^[0-9]+(s|m|h)$\`), minReplicas |
| \`status.phase\` | Pending/Provisioning/Ready/Degraded/Failed/Uninstalling |
| \`status.primaryRegion\` | Switched on Continuum failover |
| \`status.regions[]\` | Per-region rollout state |
| \`status.giteaRepo\` | Full URL of the per-Application Gitea repo |
| \`status.installedBlueprint.digest\` | OCI artifact digest for reproducibility |

## Test plan

Validated against a real k3s control plane:

- [x] Valid sample passes server-side dry-run (\`crds/tests/application-sample-valid.yaml\`)
- [x] Invalid sample triggers ALL 8 seeded error vectors (placement enum, blueprintRef.name pattern, blueprintRef.version pattern, regions minItems, environmentRef pattern, topology.rto format, owners[].role enum, healthCheck.intervalSeconds maximum) — \`crds/tests/application-sample-invalid.yaml\`
- [x] \`kubectl apply --dry-run=client\` accepts the CRD itself
- [x] Cleanup verified — local cluster artifacts removed after test

## Out of scope

- application-controller — slice C4 (#1097)
- Continuum reconciliation — #1101
- Live install flow UI — #1097
- Documentation update of design doc §3.9 row 3 → "author not delete" for ProvisioningState — separate PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)