### PR TITLE
feat(catalyst-chart): land Environment CRD catalyst.openova.io/v1 (slice B2, #1095)

### DIFF
--- a/products/catalyst/chart/crds/environment.yaml
+++ b/products/catalyst/chart/crds/environment.yaml
@@ -1,0 +1,194 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: environments.catalyst.openova.io
+  labels:
+    app.kubernetes.io/name: catalyst
+    app.kubernetes.io/component: environment
+spec:
+  group: catalyst.openova.io
+  scope: Cluster
+  names:
+    kind: Environment
+    listKind: EnvironmentList
+    singular: environment
+    plural: environments
+    shortNames:
+      - env
+      - envs
+    categories:
+      - catalyst
+      - openova
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      additionalPrinterColumns:
+        - name: Org
+          type: string
+          jsonPath: .spec.organizationRef
+        - name: Type
+          type: string
+          jsonPath: .spec.envType
+        - name: Placement
+          type: string
+          jsonPath: .spec.placement
+        - name: Regions
+          type: integer
+          jsonPath: .status.regionCount
+          priority: 1
+        - name: Phase
+          type: string
+          jsonPath: .status.phase
+        - name: Age
+          type: date
+          jsonPath: .metadata.creationTimestamp
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
+          type: object
+          description: |
+            Environment is the user-facing scope where Applications are
+            installed. Logical concept: one Environment can be realized by
+            N vClusters across regions × building blocks.
+
+            Naming: spec.organizationRef + spec.envType compose the
+            Environment name `{org}-{envType}` per NAMING-CONVENTION.md
+            §11. Examples: acme-prod, bankdhofar-uat.
+
+            DR is a Placement on the *Application*, not an Env Type — there
+            is no `*-dr` Environment. Multi-region disaster-recovery
+            topology lives on Application.spec.placement.
+
+            See docs/EPICS-1-6-unified-design.md §3.2.2 and
+            docs/NAMING-CONVENTION.md §11.
+          required: [spec]
+          properties:
+            spec:
+              type: object
+              required: [organizationRef, envType, placement, regions]
+              properties:
+                organizationRef:
+                  type: string
+                  description: Slug of the parent Organization CR.
+                  pattern: '^[a-z][a-z0-9-]{2,31}$'
+                envType:
+                  type: string
+                  enum: [prod, stg, uat, dev, poc]
+                  description: |
+                    Per NAMING §2.4. The full Env name is composed as
+                    {organizationRef}-{envType} (e.g. acme-prod). DR is
+                    NOT an envType — see Application.spec.placement.
+                placement:
+                  type: string
+                  enum: [single-region, multi-region]
+                  description: |
+                    single-region = exactly 1 region in regions[].
+                    multi-region = 2+ regions, vClusters realized in each.
+                regions:
+                  type: array
+                  minItems: 1
+                  maxItems: 5
+                  description: |
+                    Host clusters this Environment is realized on. For
+                    single-region, exactly 1 entry. For multi-region, 2+.
+                    Format mirrors NAMING §4.1: {provider}-{region}-{bb}-{envType}
+                  items:
+                    type: object
+                    required: [provider, region, buildingBlock]
+                    properties:
+                      provider:
+                        type: string
+                        enum: [hetzner, huawei, oci, aws, gcp, azure, contabo]
+                      region:
+                        type: string
+                        pattern: '^[a-z]{3}[a-z0-9]?$'
+                      buildingBlock:
+                        type: string
+                        enum: [rtz, dmz, mgt]
+                      hostCluster:
+                        type: string
+                        description: |
+                          Optional explicit host-cluster name override. If empty,
+                          environment-controller derives {provider}-{region}-{buildingBlock}-{envType}.
+                policyRef:
+                  type: string
+                  description: |
+                    Optional name of an EnvironmentPolicy CR that gates
+                    promotion (approvers, soak duration) and configures
+                    compliance weights for this Environment.
+              x-kubernetes-preserve-unknown-fields: true
+            status:
+              type: object
+              properties:
+                phase:
+                  type: string
+                  enum:
+                    - Pending
+                    - Provisioning
+                    - Ready
+                    - Degraded
+                    - Failed
+                regionCount:
+                  type: integer
+                  minimum: 0
+                  description: Number of regions in spec.regions[] — convenient printer column.
+                vclusters:
+                  type: array
+                  description: Per-region vCluster realization summary.
+                  items:
+                    type: object
+                    required: [host, name]
+                    properties:
+                      host:
+                        type: string
+                        description: Host cluster name.
+                      name:
+                        type: string
+                        description: vCluster name (typically equals organizationRef).
+                      phase:
+                        type: string
+                        enum: [Pending, Provisioning, Ready, Failed]
+                      lastTransitionTime:
+                        type: string
+                        format: date-time
+                giteaRepoRef:
+                  type: object
+                  description: |
+                    Per Naming §11.2 each Application gets its own Gitea
+                    repo; the Environment maps to a *branch* across those
+                    repos (develop/staging/main ↔ dev/stg/prod).
+                  properties:
+                    org:
+                      type: string
+                    branch:
+                      type: string
+                jetstreamSubjectPrefix:
+                  type: string
+                  description: |
+                    Per ARCHITECTURE.md §5 + NAMING §11.2 item 4, the
+                    JetStream subject prefix for this Environment is
+                    ws.{organizationRef}-{envType}.>
+                conditions:
+                  type: array
+                  items:
+                    type: object
+                    required: [type, status]
+                    properties:
+                      type:
+                        type: string
+                      status:
+                        type: string
+                        enum: ["True", "False", "Unknown"]
+                      reason:
+                        type: string
+                      message:
+                        type: string
+                      lastTransitionTime:
+                        type: string
+                        format: date-time
+                observedGeneration:
+                  type: integer
+                  format: int64
+              x-kubernetes-preserve-unknown-fields: true

--- a/products/catalyst/chart/crds/tests/environment-sample-invalid.yaml
+++ b/products/catalyst/chart/crds/tests/environment-sample-invalid.yaml
@@ -1,0 +1,29 @@
+# Invalid sample — must FAIL schema validation. Seeded errors:
+#   organizationRef pattern: "ACME" uppercase
+#   envType: "dr" — not in enum (DR is a Placement on Application, not an Env Type)
+#   placement: "active-active" — not in enum (multi-region/single-region only here)
+#   regions: empty — minItems=1
+#   regions[0].provider: "linode" — not in enum
+#   regions[0].buildingBlock: "core" — not in enum
+apiVersion: catalyst.openova.io/v1
+kind: Environment
+metadata:
+  name: bad-env
+spec:
+  organizationRef: ACME
+  envType: dr
+  placement: active-active
+  regions:
+    - provider: linode
+      region: fra
+      buildingBlock: core
+---
+apiVersion: catalyst.openova.io/v1
+kind: Environment
+metadata:
+  name: empty-regions
+spec:
+  organizationRef: acme
+  envType: prod
+  placement: multi-region
+  regions: []

--- a/products/catalyst/chart/crds/tests/environment-sample-valid.yaml
+++ b/products/catalyst/chart/crds/tests/environment-sample-valid.yaml
@@ -1,0 +1,30 @@
+# Valid samples: single-region prod and multi-region prod for the same Org.
+apiVersion: catalyst.openova.io/v1
+kind: Environment
+metadata:
+  name: acme-dev
+spec:
+  organizationRef: acme
+  envType: dev
+  placement: single-region
+  regions:
+    - provider: hetzner
+      region: fsn
+      buildingBlock: rtz
+---
+apiVersion: catalyst.openova.io/v1
+kind: Environment
+metadata:
+  name: acme-prod
+spec:
+  organizationRef: acme
+  envType: prod
+  placement: multi-region
+  regions:
+    - provider: hetzner
+      region: fsn
+      buildingBlock: rtz
+    - provider: hetzner
+      region: hel
+      buildingBlock: rtz
+  policyRef: acme-prod-policy


### PR DESCRIPTION
## Summary

Slice **B2** of EPIC-0 (#1095). Lands the Environment CRD per \`docs/EPICS-1-6-unified-design.md\` §3.2.2 and \`NAMING-CONVENTION.md\` §11.

## Why

Environment is the user-facing scope where Applications are installed. Today the Environment is implicit (in directory paths and label conventions). Without the CRD, environment-controller (slice C2) has no resource to watch, and the per-Environment Gitea branch / vCluster fan-out / JetStream subject mapping has no parent.

## DR is a Placement, not an Env Type

This is the most important rule in the schema, per NAMING §11.1: there is no \`*-dr\` envType. \`envType\` is enum \`prod|stg|uat|dev|poc\`. Disaster-recovery topology lives on \`Application.spec.placement\` (active-active | active-hotstandby) inside the \`*-prod\` Environment.

## Schema highlights

| Field | Notes |
|---|---|
| Cluster-scoped | Environments span vClusters across regions |
| \`spec.organizationRef\` | FK to Organization.spec.slug; matching pattern |
| \`spec.envType\` | enum prod/stg/uat/dev/poc; NO 'dr' value |
| \`spec.placement\` | enum single-region | multi-region (structural, not failover) |
| \`spec.regions[]\` | minItems=1; provider/region/buildingBlock enums per NAMING §2 |
| \`spec.policyRef\` | optional EnvironmentPolicy CR for promotion gating |
| \`status.regionCount\` | Convenience printer column |
| \`status.vclusters[]\` | Per-region realization summary |
| \`status.giteaRepoRef.{org,branch}\` | Per NAMING §11.2 develop/staging/main ↔ dev/stg/prod |
| \`status.jetstreamSubjectPrefix\` | Per ARCHITECTURE.md §5: \`ws.{org}-{envType}.>\` |

## Test plan

Validated against a real k3s control plane:

- [x] 2 valid samples accepted: single-region acme-dev + multi-region acme-prod with policyRef
- [x] 2 invalid samples REJECTED with all 6 seeded error vectors (organizationRef pattern, envType=dr enum, placement=active-active enum, provider=linode enum, buildingBlock=core enum, regions=[] minItems)
- [x] Cleanup verified

## Out of scope

- environment-controller — slice C2
- per-Environment JetStream subject creation — slice H4
- per-Environment Gitea branch automation — slice C2 + Group F vCluster scaffold

🤖 Generated with [Claude Code](https://claude.com/claude-code)