### PR TITLE
feat(catalyst-chart): land EnvironmentPolicy CRD catalyst.openova.io/v1 (slice B5, #1095)

### DIFF
--- a/products/catalyst/chart/crds/environmentpolicy.yaml
+++ b/products/catalyst/chart/crds/environmentpolicy.yaml
@@ -1,0 +1,166 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: environmentpolicies.catalyst.openova.io
+  labels:
+    app.kubernetes.io/name: catalyst
+    app.kubernetes.io/component: environment-policy
+spec:
+  group: catalyst.openova.io
+  scope: Cluster
+  names:
+    kind: EnvironmentPolicy
+    listKind: EnvironmentPolicyList
+    singular: environmentpolicy
+    plural: environmentpolicies
+    shortNames:
+      - envpol
+      - envpols
+    categories:
+      - catalyst
+      - openova
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      additionalPrinterColumns:
+        - name: Approvers
+          type: integer
+          jsonPath: .spec.promotion.requiredApprovers
+        - name: SoakHrs
+          type: integer
+          jsonPath: .spec.promotion.soakHours
+        - name: Policies
+          type: integer
+          jsonPath: .status.policyCount
+        - name: Age
+          type: date
+          jsonPath: .metadata.creationTimestamp
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
+          type: object
+          description: |
+            EnvironmentPolicy gates promotion (approvers + soak duration)
+            and configures compliance scoring (per-policy weight + mode
+            permissive|enforcing) for a given Environment.
+
+            Referenced by Environment.spec.policyRef. Consumed by:
+            - environment-controller for promotion gating (slice C2)
+            - compliance-aggregator for weighted score rollups (#1096)
+            - Kyverno policy renderer (#1096) — `mode` flips between
+              `validationFailureAction: Audit` (permissive) and `Enforce`
+
+            See docs/EPICS-1-6-unified-design.md §3.2.5 and §4 (EPIC-1).
+          required: [spec]
+          properties:
+            spec:
+              type: object
+              properties:
+                promotion:
+                  type: object
+                  description: Promotion gates between Environments (e.g. dev → prod).
+                  properties:
+                    requiredApprovers:
+                      type: integer
+                      minimum: 0
+                      maximum: 10
+                      default: 0
+                      description: |
+                        Number of distinct human approvers required to
+                        promote into THIS Environment from a lower
+                        env_type. 0 = automatic.
+                    soakHours:
+                      type: integer
+                      minimum: 0
+                      maximum: 720
+                      default: 0
+                      description: |
+                        Required time the candidate version must have run
+                        in the lower env_type before promotion. 0 = no soak.
+                    requiredComplianceScore:
+                      type: integer
+                      minimum: 0
+                      maximum: 100
+                      description: |
+                        Optional compliance-score floor. If set, the
+                        candidate Application's score in the lower
+                        Environment must meet or exceed this value before
+                        promotion. Tied to spec.compliance.weights.
+                compliance:
+                  type: object
+                  description: |
+                    Per-Environment compliance configuration. The set of
+                    policy names is the public contract (mirror the docs);
+                    weights and modes are tunable.
+                  properties:
+                    weights:
+                      type: object
+                      description: |
+                        Policy name → weight config. Each entry carries
+                        a numeric weight (0-100) and an optional scope
+                        (stateful|stateless|all — default 'all' applied
+                        by the compliance-aggregator at read time, not
+                        by the schema, per K8s structural-schema rules).
+                        Sum is normalized across applicable policies;
+                        scope=stateful entries are dropped from the
+                        denominator on stateless workloads.
+                      additionalProperties:
+                        type: object
+                        required: [weight]
+                        properties:
+                          weight:
+                            type: integer
+                            minimum: 0
+                            maximum: 100
+                          scope:
+                            type: string
+                            enum: [stateful, stateless, all]
+                            description: |
+                              Restrict this policy to a workload class.
+                              Compliance-aggregator treats unset as 'all'.
+                    modes:
+                      type: object
+                      description: |
+                        Policy name → mode (permissive|enforcing). Permissive
+                        = audit-only (Kyverno validationFailureAction=Audit).
+                        Enforcing = blocks at admission (=Enforce).
+                      additionalProperties:
+                        type: string
+                        enum: [permissive, enforcing]
+                  x-kubernetes-preserve-unknown-fields: true
+              x-kubernetes-preserve-unknown-fields: true
+            status:
+              type: object
+              properties:
+                policyCount:
+                  type: integer
+                  minimum: 0
+                  description: Number of compliance policies declared in spec.compliance.weights.
+                appliedAt:
+                  type: string
+                  format: date-time
+                  description: When environment-controller last reconciled this policy onto its Environments.
+                conditions:
+                  type: array
+                  items:
+                    type: object
+                    required: [type, status]
+                    properties:
+                      type:
+                        type: string
+                      status:
+                        type: string
+                        enum: ["True", "False", "Unknown"]
+                      reason:
+                        type: string
+                      message:
+                        type: string
+                      lastTransitionTime:
+                        type: string
+                        format: date-time
+                observedGeneration:
+                  type: integer
+                  format: int64
+              x-kubernetes-preserve-unknown-fields: true

--- a/products/catalyst/chart/crds/tests/environmentpolicy-sample-invalid.yaml
+++ b/products/catalyst/chart/crds/tests/environmentpolicy-sample-invalid.yaml
@@ -1,0 +1,23 @@
+# Invalid sample — must FAIL schema validation. Seeded errors:
+#   promotion.requiredApprovers: 99 — exceeds maximum 10
+#   promotion.soakHours: -1 — below minimum
+#   promotion.requiredComplianceScore: 150 — exceeds 100
+#   weights value: 200 — exceeds 100
+#   weights.{name}.scope: "ephemeral" — not in enum stateful|stateless|all
+#   modes value: "block" — not in enum permissive|enforcing
+apiVersion: catalyst.openova.io/v1
+kind: EnvironmentPolicy
+metadata:
+  name: bad-policy
+spec:
+  promotion:
+    requiredApprovers: 99
+    soakHours: -1
+    requiredComplianceScore: 150
+  compliance:
+    weights:
+      multiReplica:    { weight: 200 }
+      pvcExpansion:    { weight: 5, scope: ephemeral }
+      noWeightField:   {}
+    modes:
+      multiReplica: block

--- a/products/catalyst/chart/crds/tests/environmentpolicy-sample-valid.yaml
+++ b/products/catalyst/chart/crds/tests/environmentpolicy-sample-valid.yaml
@@ -1,0 +1,58 @@
+# Valid sample — full bank-tier compliance config matching design doc §3.2.5.
+# Weights use the object form `{weight, scope}` per K8s structural-schema rules.
+apiVersion: catalyst.openova.io/v1
+kind: EnvironmentPolicy
+metadata:
+  name: acme-prod-policy
+spec:
+  promotion:
+    requiredApprovers: 2
+    soakHours: 4
+    requiredComplianceScore: 80
+  compliance:
+    weights:
+      multiReplica:           { weight: 15 }
+      pdb:                    { weight: 15 }
+      topologySpread:         { weight: 10 }
+      probesPresent:          { weight: 5 }
+      resourceRequests:       { weight: 8 }
+      resourceLimits:         { weight: 4 }
+      pvcExpansion:           { weight: 5,  scope: stateful }
+      hpaEffective:           { weight: 8 }
+      cilium-l7-mtls:         { weight: 10 }
+      flux-managed:           { weight: 10 }
+      harbor-proxy-pull:      { weight: 5 }
+      image-tag-pinned:       { weight: 5 }
+      prometheus-scrape:      { weight: 5 }
+      networkpolicy-present:  { weight: 0 }
+      otel-injected:          { weight: 0 }
+      hubble-flows-seen:      { weight: 0 }
+      run-as-non-root:        { weight: 0 }
+      readonly-root-fs:       { weight: 0 }
+      cosign-verified:        { weight: 0 }
+      secret-not-in-env:      { weight: 0 }
+      backup-configured:      { weight: 0, scope: stateful }
+    modes:
+      multiReplica: permissive
+      pdb: permissive
+      topologySpread: permissive
+      probesPresent: enforcing
+      resourceRequests: enforcing
+      resourceLimits: permissive
+      pvcExpansion: permissive
+      hpaEffective: permissive
+      cilium-l7-mtls: enforcing
+      flux-managed: enforcing
+      harbor-proxy-pull: enforcing
+      image-tag-pinned: enforcing
+      prometheus-scrape: permissive
+---
+# Minimal sample — promotion-only, no compliance config
+apiVersion: catalyst.openova.io/v1
+kind: EnvironmentPolicy
+metadata:
+  name: dev-policy-loose
+spec:
+  promotion:
+    requiredApprovers: 0
+    soakHours: 0


### PR DESCRIPTION
## Summary

Slice **B5** of EPIC-0 (#1095). EnvironmentPolicy CRD per design doc §3.2.5 and §4 (EPIC-1 #1096).

## Why

EnvironmentPolicy holds two concerns for a given Environment: promotion gating + compliance scoring config. Referenced by \`Environment.spec.policyRef\` and consumed by both the environment-controller (slice C2) and the compliance-aggregator (#1096). Without it, EPIC-1 has no per-Environment knob to flip permissive/enforcing per policy and no place to override default weights.

## Schema highlights

- \`spec.promotion\` — requiredApprovers (0-10), soakHours (0-720), optional requiredComplianceScore (0-100) floor before promotion
- \`spec.compliance.weights\` — per-policy \`{weight: 0-100, scope: stateful|stateless|all}\`. Object form (not bare int) because K8s structural-schema rules forbid \`anyOf\` with mixed primitive types and defaults inside \`anyOf\` branches
- \`spec.compliance.modes\` — per-policy \`permissive | enforcing\`; permissive maps to Kyverno \`Audit\`, enforcing to \`Enforce\`

## Test plan

- [x] CRD applies cleanly server-side (after structural-schema fix — original \`anyOf\` form was rejected, switched to single object form)
- [x] 2 valid samples accepted: bank-tier acme-prod-policy (21 policies) + minimal dev-policy-loose
- [x] 1 invalid sample REJECTED with all 7 seeded errors: requiredApprovers=99, soakHours=-1, requiredComplianceScore=150, weights.x.weight=200, weights.x.scope=ephemeral, weights.x missing weight, modes=block

## Out of scope

- compliance-aggregator implementation — #1096
- Kyverno policy renderer that consumes spec.compliance.modes — #1096
- environment-controller promotion gating logic — slice C2

🤖 Generated with [Claude Code](https://claude.com/claude-code)