### PR TITLE
fix(auth): rootRoute auth gate closes route-bypass on /app/$id /users/$userId /apps + path-normalization edges (#1090 cluster A2)

### DIFF
--- a/products/catalyst/bootstrap/ui/src/app/auth-gate.test.ts
+++ b/products/catalyst/bootstrap/ui/src/app/auth-gate.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  canonicalisePath,
+  isPublicPath,
+  hasCatalystSession,
+  PUBLIC_PATH_PREFIXES,
+} from './auth-gate'
+
+describe('canonicalisePath', () => {
+  it('lowercases paths', () => {
+    expect(canonicalisePath('/Dashboard')).toBe('/dashboard')
+    expect(canonicalisePath('/APP/MyComponent')).toBe('/app/mycomponent')
+  })
+
+  it('collapses duplicate slashes', () => {
+    expect(canonicalisePath('//dashboard')).toBe('/dashboard')
+    expect(canonicalisePath('///app//foo')).toBe('/app/foo')
+  })
+
+  it('strips trailing slash except root', () => {
+    expect(canonicalisePath('/dashboard/')).toBe('/dashboard')
+    expect(canonicalisePath('/')).toBe('/')
+    expect(canonicalisePath('/apps/')).toBe('/apps')
+  })
+
+  it('passes already-canonical paths through unchanged', () => {
+    expect(canonicalisePath('/dashboard')).toBe('/dashboard')
+    expect(canonicalisePath('/users/some-user@example.org')).toBe('/users/some-user@example.org')
+  })
+})
+
+describe('isPublicPath', () => {
+  it('treats / as gated (not public — index redirects to /login or /dashboard)', () => {
+    expect(isPublicPath('/')).toBe(false)
+  })
+
+  it('matches /login + nested', () => {
+    expect(isPublicPath('/login')).toBe(true)
+    expect(isPublicPath('/login/verify')).toBe(true)
+  })
+
+  it('matches /auth/handover and /auth/callback', () => {
+    expect(isPublicPath('/auth/handover')).toBe(true)
+    expect(isPublicPath('/auth/handover-error')).toBe(true)
+    expect(isPublicPath('/auth/callback')).toBe(true)
+  })
+
+  it('matches /forgot, /signup', () => {
+    expect(isPublicPath('/forgot')).toBe(true)
+    expect(isPublicPath('/signup')).toBe(true)
+  })
+
+  it('matches /readyz, /healthz, /sovereignty/preview, /designs', () => {
+    expect(isPublicPath('/readyz')).toBe(true)
+    expect(isPublicPath('/healthz')).toBe(true)
+    expect(isPublicPath('/sovereignty/preview')).toBe(true)
+    expect(isPublicPath('/designs')).toBe(true)
+    expect(isPublicPath('/designs/showcase')).toBe(true)
+  })
+
+  it('rejects gated paths (the bug rows from #1090 cluster A2)', () => {
+    expect(isPublicPath('/dashboard')).toBe(false)
+    expect(isPublicPath('/apps')).toBe(false)
+    expect(isPublicPath('/app/some-component-id')).toBe(false)
+    expect(isPublicPath('/users/some-user@example.org')).toBe(false)
+    expect(isPublicPath('/jobs/timeline')).toBe(false)
+    expect(isPublicPath('/cloud')).toBe(false)
+    expect(isPublicPath('/settings')).toBe(false)
+    expect(isPublicPath('/notifications')).toBe(false)
+  })
+
+  it('rejects prefix-collisions where the gated path starts with a public token', () => {
+    // /loginz is gated even though /login is public — we use exact-or-slash match
+    expect(isPublicPath('/loginz')).toBe(false)
+    expect(isPublicPath('/auth/handovers')).toBe(false)
+  })
+
+  it('PUBLIC_PATH_PREFIXES contains the expected set', () => {
+    expect(PUBLIC_PATH_PREFIXES).toEqual([
+      '/login',
+      '/signup',
+      '/forgot',
+      '/auth/handover',
+      '/auth/handover-error',
+      '/auth/callback',
+      '/readyz',
+      '/healthz',
+      '/sovereignty/preview',
+      '/designs',
+      '/api/',
+    ])
+  })
+})
+
+describe('hasCatalystSession', () => {
+  beforeEach(() => {
+    sessionStorage.clear()
+  })
+
+  it('returns false when sessionStorage is empty', () => {
+    expect(hasCatalystSession()).toBe(false)
+  })
+
+  it('returns true when an oidc:* key is present (legacy PKCE flow)', () => {
+    sessionStorage.setItem('oidc:access_token', 'eyJ...')
+    expect(hasCatalystSession()).toBe(true)
+  })
+
+  it('returns true when catalyst:authed marker is set (new cookie flow)', () => {
+    sessionStorage.setItem('catalyst:authed', '1')
+    expect(hasCatalystSession()).toBe(true)
+  })
+
+  it('returns false when catalyst:authed has a different value', () => {
+    sessionStorage.setItem('catalyst:authed', '0')
+    expect(hasCatalystSession()).toBe(false)
+  })
+
+  it('returns false on unrelated keys', () => {
+    sessionStorage.setItem('something:else', 'foo')
+    expect(hasCatalystSession()).toBe(false)
+  })
+})
+
+describe('integration — anti-regression for #1090 cluster A2 bypass routes', () => {
+  // For each of the 7 routes that bypassed the layout-only gate, the
+  // rootBeforeLoad gate should now redirect to /login. We verify the
+  // pure helpers say "not public" and "not authed" — the actual
+  // redirect happens in router.tsx and is validated end-to-end via
+  // Playwright (matrix file /tmp/test-matrix-routing-bypass.json).
+  beforeEach(() => sessionStorage.clear())
+
+  const bypassRoutes = [
+    '/app/some-component-id',
+    '/users/some-user@example.org',
+    '/dashboard/',          // canonicalisePath → /dashboard
+    '/Dashboard',           // canonicalisePath → /dashboard
+    '//dashboard',          // canonicalisePath → /dashboard
+    '/apps',
+    '/dashboard',           // regression check (already PASSED in iter-2)
+  ]
+
+  it.each(bypassRoutes)('%s → canonicalises + isPublicPath false + would gate', (raw) => {
+    const canonical = canonicalisePath(raw)
+    expect(isPublicPath(canonical)).toBe(false)
+    expect(hasCatalystSession()).toBe(false)
+    // Together → rootBeforeLoad would throw redirect to /login?next=...
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/app/auth-gate.ts
+++ b/products/catalyst/bootstrap/ui/src/app/auth-gate.ts
@@ -1,0 +1,65 @@
+/**
+ * auth-gate.ts — pure helpers for the rootRoute auth gate (#1090
+ * cluster A2). Extracted from router.tsx so the canonicalisation +
+ * public-path matching logic can be unit-tested without booting the
+ * router or React.
+ */
+
+/** Public paths that bypass the rootRoute auth gate. Prefix-matched. */
+export const PUBLIC_PATH_PREFIXES = [
+  '/login',
+  '/signup',
+  '/forgot',
+  '/auth/handover',
+  '/auth/handover-error',
+  '/auth/callback',
+  '/readyz',
+  '/healthz',
+  '/sovereignty/preview',
+  '/designs',
+  '/api/',
+] as const
+
+export function isPublicPath(canonical: string): boolean {
+  if (canonical === '/') return false
+  return PUBLIC_PATH_PREFIXES.some(
+    (prefix) => canonical === prefix || canonical.startsWith(prefix + '/'),
+  )
+}
+
+/**
+ * Canonicalise a request pathname:
+ *   - collapse duplicate slashes (//foo → /foo)
+ *   - strip trailing slash (/dashboard/ → /dashboard, except '/')
+ *   - lowercase the path (/Dashboard → /dashboard)
+ */
+export function canonicalisePath(pathname: string): string {
+  let p = pathname.replace(/\/+/g, '/')
+  if (p.length > 1 && p.endsWith('/')) p = p.slice(0, -1)
+  return p.toLowerCase()
+}
+
+/**
+ * Synchronous best-effort check that the operator has a session.
+ * The catalyst_session cookie is HttpOnly so we cannot read it from JS;
+ * instead we look at sessionStorage:
+ *   - any oidc:* key (legacy PKCE flow tokens)
+ *   - 'catalyst:authed' marker set by SovereignConsoleLayout after a
+ *     successful /whoami probe
+ *
+ * Conservative: false positives (claiming authed when no session) are
+ * caught downstream by the layout's /whoami probe, which redirects to
+ * /login with proper error context. False negatives would break
+ * navigation, so we err on the side of "let it through."
+ */
+export function hasCatalystSession(): boolean {
+  if (typeof window === 'undefined' || typeof sessionStorage === 'undefined') return true
+  try {
+    const ssKeys = Object.keys(sessionStorage)
+    if (ssKeys.some((k) => k.startsWith('oidc:'))) return true
+    if (sessionStorage.getItem('catalyst:authed') === '1') return true
+  } catch {
+    /* private browsing may throw */
+  }
+  return false
+}

--- a/products/catalyst/bootstrap/ui/src/app/layouts/SovereignConsoleLayout.tsx
+++ b/products/catalyst/bootstrap/ui/src/app/layouts/SovereignConsoleLayout.tsx
@@ -162,6 +162,8 @@ export function SovereignConsoleLayout() {
       if (!sovereignFQDN) {
         const cookieClaims = await probeSessionCookie()
         if (cookieClaims) {
+          // Mark the rootRoute auth gate (#1090 cluster A2) as satisfied.
+          try { sessionStorage.setItem('catalyst:authed', '1') } catch { /* private browsing */ }
           setAuthState({ status: 'cookie-authenticated', claims: cookieClaims })
           return
         }
@@ -188,6 +190,7 @@ export function SovereignConsoleLayout() {
       // server-issued session.
       const cookieClaims = await probeSessionCookie()
       if (cookieClaims) {
+        try { sessionStorage.setItem('catalyst:authed', '1') } catch { /* private browsing */ }
         setAuthState({ status: 'cookie-authenticated', claims: cookieClaims })
         return
       }

--- a/products/catalyst/bootstrap/ui/src/app/router.tsx
+++ b/products/catalyst/bootstrap/ui/src/app/router.tsx
@@ -83,9 +83,45 @@ import { UsersPage as SMEUsersPage } from '@/pages/sme/UsersPage'
 import { RolesPage as SMERolesPage } from '@/pages/sme/RolesPage'
 import { CreateTenantPage as SMECreateTenantPage } from '@/pages/sme/CreateTenantPage'
 import { SovereigntyPreviewPage } from '@/pages/sovereignty/SovereigntyPreviewPage'
+import { canonicalisePath, hasCatalystSession, isPublicPath } from './auth-gate'
+
+/**
+ * rootBeforeLoad — universal auth gate (#1090 cluster A2).
+ *
+ * Runs before EVERY route's beforeLoad in the tree. Two responsibilities:
+ *
+ *   1. Path canonicalisation — redirect malformed paths (//x, /x/, /X)
+ *      to canonical /x so deep-link variants don't slip past the gate.
+ *
+ *   2. Sovereign-mode auth gate — when no session is detected and the
+ *      canonical path is NOT in PUBLIC_PATH_PREFIXES, redirect to
+ *      /login?next=<canonical> with the original deep-link preserved.
+ *
+ * Mothership (catalyst-zero) mode handles its own auth via
+ * provisionAuthGuard / wizardAuthGuard for its routes — the gate is a
+ * no-op in non-sovereign mode (other than canonicalisation).
+ */
+function rootBeforeLoad({ location }: { location: { pathname: string } }) {
+  if (typeof window === 'undefined') return
+  const pathname = location.pathname
+  const canonical = canonicalisePath(pathname)
+  if (canonical !== pathname) {
+    const newURL = canonical + window.location.search + window.location.hash
+    window.location.replace(newURL)
+    throw redirect({ to: canonical as never, replace: true })
+  }
+  if (DETECTED_MODE.mode !== 'sovereign') return
+  if (isPublicPath(canonical)) return
+  if (hasCatalystSession()) return
+  throw redirect({
+    to: '/login',
+    search: { next: pathname + window.location.search },
+    replace: true,
+  })
+}
 
 // Root
-const rootRoute = createRootRoute({ component: RootLayout })
+const rootRoute = createRootRoute({ component: RootLayout, beforeLoad: rootBeforeLoad })
 
 /**
  * Index redirect — mode-aware.


### PR DESCRIPTION
Closes 7 route-bypass FAILs from iter-2 of the #1090 routing audit. Lifts auth gate from per-route SovereignConsoleLayout to rootRoute.beforeLoad so no route can bypass. Adds path canonicalisation (//x, /x/, /X → /x).

24 unit tests pass; production build clean.

Anti-regression: rows that PASSED in iter-2 (/dashboard family) still PASS by design — same gate, just earlier in the route lifecycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)