### PR TITLE
feat(catalyst-chart): land Continuum CRD dr.openova.io/v1 (slice B8, #1095)

### DIFF
--- a/products/catalyst/chart/crds/continuum.yaml
+++ b/products/catalyst/chart/crds/continuum.yaml
@@ -1,0 +1,265 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: continuums.dr.openova.io
+  labels:
+    app.kubernetes.io/name: catalyst
+    app.kubernetes.io/component: continuum
+spec:
+  group: dr.openova.io
+  scope: Namespaced
+  names:
+    kind: Continuum
+    listKind: ContinuumList
+    singular: continuum
+    plural: continuums
+    shortNames:
+      - dr
+    categories:
+      - catalyst
+      - openova
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      additionalPrinterColumns:
+        - name: Application
+          type: string
+          jsonPath: .spec.applicationRef
+        - name: Primary
+          type: string
+          jsonPath: .status.primaryRegion
+        - name: Lease
+          type: string
+          jsonPath: .status.leaseHolder
+        - name: Lag
+          type: string
+          jsonPath: .status.maxReplicationLag
+          priority: 1
+        - name: RTO
+          type: string
+          jsonPath: .spec.rto
+          priority: 1
+        - name: RPO
+          type: string
+          jsonPath: .spec.rpo
+          priority: 1
+        - name: Phase
+          type: string
+          jsonPath: .status.phase
+        - name: Age
+          type: date
+          jsonPath: .metadata.creationTimestamp
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
+          type: object
+          description: |
+            Continuum is the declarative DR contract for an Application
+            running with placement: active-hotstandby across two or more
+            regions. Watched by the continuum-controller (EPIC-6 #1101).
+
+            Per docs/SRE.md §2.4 + docs/MULTI-REGION-DNS.md, switchover
+            is gated by a lease witness (Cloudflare KV or 3-DNS quorum)
+            and effected by flipping a PowerDNS lua-record probe target
+            via PDM /v1/commit. ClusterMesh carries the replication
+            traffic; Application.spec.placement remains the single
+            source of truth for which regions exist.
+
+            See docs/EPICS-1-6-unified-design.md §3.2.8 and §9.
+          required: [spec]
+          properties:
+            spec:
+              type: object
+              required: [applicationRef, primaryRegion, hotStandbyRegions, leaseClient]
+              properties:
+                applicationRef:
+                  type: string
+                  description: |
+                    Name of the Application CR this Continuum governs.
+                    Application.spec.placement MUST be active-hotstandby
+                    (the controller refuses other modes at admission).
+                primaryRegion:
+                  type: string
+                  description: Currently-primary host cluster name. Switched on failover.
+                  pattern: '^[a-z]+-[a-z]+-[a-z]+-[a-z]+$'
+                hotStandbyRegions:
+                  type: array
+                  minItems: 1
+                  maxItems: 4
+                  description: Host clusters running standby replicas. Promoted on failover.
+                  items:
+                    type: string
+                    pattern: '^[a-z]+-[a-z]+-[a-z]+-[a-z]+$'
+                leaseClient:
+                  type: object
+                  required: [kind]
+                  properties:
+                    kind:
+                      type: string
+                      enum: [cloudflare-kv, dns-quorum]
+                      description: |
+                        cloudflare-kv = lease in a Cloudflare Worker KV
+                        namespace (recommended per SRE.md §2.4).
+                        dns-quorum = 2-of-3 DNS resolver quorum
+                        (fallback when CF KV is unavailable).
+                    config:
+                      type: object
+                      description: |
+                        Kind-specific config. cloudflare-kv expects
+                        kvNamespaceId + accountId + tokenSecretRef.
+                        dns-quorum expects resolvers[] (2-of-3 voting set).
+                      properties:
+                        kvNamespaceId:
+                          type: string
+                        accountId:
+                          type: string
+                        tokenSecretRef:
+                          type: object
+                          required: [name, key]
+                          description: SealedSecret reference; plaintext NEVER on the CR.
+                          properties:
+                            name:
+                              type: string
+                            key:
+                              type: string
+                              default: token
+                          x-kubernetes-preserve-unknown-fields: true
+                        resolvers:
+                          type: array
+                          minItems: 3
+                          maxItems: 5
+                          items:
+                            type: string
+                            description: IPv4 resolver address.
+                            pattern: '^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$'
+                        ttlSeconds:
+                          type: integer
+                          minimum: 5
+                          maximum: 600
+                          description: Lease TTL. Default applied by controller (30s).
+                        renewSeconds:
+                          type: integer
+                          minimum: 1
+                          maximum: 60
+                          description: Lease renewal interval (must be < ttlSeconds/2). Default 10s.
+                      x-kubernetes-preserve-unknown-fields: true
+                  x-kubernetes-preserve-unknown-fields: true
+                luaRecord:
+                  type: object
+                  description: |
+                    Per docs/MULTI-REGION-DNS.md, the controller writes
+                    the Application's HTTPRoute hostnames as PowerDNS
+                    lua-records via PDM /v1/commit. selector picks the
+                    behaviour; healthCheck drives the probe target.
+                  properties:
+                    selector:
+                      type: string
+                      enum: [ifurlup, pickclosest, pickfirst, pickwhashed]
+                      default: ifurlup
+                    healthCheck:
+                      type: object
+                      required: [url]
+                      properties:
+                        url:
+                          type: string
+                          pattern: '^https?://.+'
+                        intervalSeconds:
+                          type: integer
+                          minimum: 1
+                          maximum: 60
+                          default: 5
+                        timeoutSeconds:
+                          type: integer
+                          minimum: 1
+                          maximum: 30
+                          default: 2
+                rto:
+                  type: string
+                  description: Recovery Time Objective. Format `^[0-9]+(s|m|h)$`.
+                  pattern: '^[0-9]+(s|m|h)$'
+                rpo:
+                  type: string
+                  description: Recovery Point Objective. Format `^[0-9]+(s|m|h)$`.
+                  pattern: '^[0-9]+(s|m|h)$'
+                autoFailover:
+                  type: boolean
+                  default: false
+                  description: |
+                    If true, controller initiates switchover when health
+                    check fails for ≥3 consecutive intervals + lease
+                    quorum confirms primary unreachable. If false,
+                    controller surfaces alarm only and waits for manual
+                    switchover via the Application page (UI in #1101).
+              x-kubernetes-preserve-unknown-fields: true
+            status:
+              type: object
+              properties:
+                phase:
+                  type: string
+                  enum:
+                    - Pending
+                    - Healthy
+                    - Degraded
+                    - SwitchingOver
+                    - FailedOver
+                    - Failed
+                primaryRegion:
+                  type: string
+                leaseHolder:
+                  type: string
+                  description: Cluster that currently holds the lease.
+                leaseExpiresAt:
+                  type: string
+                  format: date-time
+                replicationLag:
+                  type: object
+                  description: 'Per-standby-region replication lag — keyed by host-cluster name, value is a duration string.'
+                  additionalProperties:
+                    type: string
+                maxReplicationLag:
+                  type: string
+                  description: Convenience printer column = max(replicationLag values).
+                lastSwitchover:
+                  type: object
+                  properties:
+                    at:
+                      type: string
+                      format: date-time
+                    from:
+                      type: string
+                    to:
+                      type: string
+                    reason:
+                      type: string
+                    rtoObserved:
+                      type: string
+                    rpoObserved:
+                      type: string
+                    initiatedBy:
+                      type: string
+                      description: User email or 'auto-failover'.
+                  x-kubernetes-preserve-unknown-fields: true
+                conditions:
+                  type: array
+                  items:
+                    type: object
+                    required: [type, status]
+                    properties:
+                      type:
+                        type: string
+                      status:
+                        type: string
+                        enum: ["True", "False", "Unknown"]
+                      reason:
+                        type: string
+                      message:
+                        type: string
+                      lastTransitionTime:
+                        type: string
+                        format: date-time
+                observedGeneration:
+                  type: integer
+                  format: int64
+              x-kubernetes-preserve-unknown-fields: true

--- a/products/catalyst/chart/crds/tests/continuum-sample-invalid.yaml
+++ b/products/catalyst/chart/crds/tests/continuum-sample-invalid.yaml
@@ -1,0 +1,44 @@
+# Invalid sample — must FAIL schema validation. Seeded errors:
+#   primaryRegion pattern: "fsn" - too short
+#   hotStandbyRegions: empty - minItems=1
+#   leaseClient.kind: "etcd" - not in enum
+#   luaRecord.selector: "round-robin" - not in enum
+#   luaRecord.healthCheck.url: "marketing.acme.com/health" - missing scheme
+#   rto: "1minute" - wrong format
+#   rpo: "fast" - wrong format
+apiVersion: dr.openova.io/v1
+kind: Continuum
+metadata:
+  name: bad-dr
+  namespace: acme
+spec:
+  applicationRef: marketing-site
+  primaryRegion: fsn
+  hotStandbyRegions: []
+  leaseClient:
+    kind: etcd
+  luaRecord:
+    selector: round-robin
+    healthCheck:
+      url: marketing.acme.com/health
+  rto: 1minute
+  rpo: fast
+---
+# Second invalid case — dns-quorum with too few resolvers
+apiVersion: dr.openova.io/v1
+kind: Continuum
+metadata:
+  name: bad-dr-2
+  namespace: bank
+spec:
+  applicationRef: api
+  primaryRegion: hz-fsn-rtz-prod
+  hotStandbyRegions:
+    - hz-hel-rtz-prod
+  leaseClient:
+    kind: dns-quorum
+    config:
+      resolvers:
+        - 8.8.8.8
+        - "not-an-ip"
+      ttlSeconds: 1

--- a/products/catalyst/chart/crds/tests/continuum-sample-valid.yaml
+++ b/products/catalyst/chart/crds/tests/continuum-sample-valid.yaml
@@ -1,0 +1,61 @@
+# Valid sample — tier-1 bank DR config: Cloudflare-KV lease, ifurlup
+# lua-record selector, RTO 60s / RPO 5s.
+apiVersion: dr.openova.io/v1
+kind: Continuum
+metadata:
+  name: marketing-site-dr
+  namespace: acme
+spec:
+  applicationRef: marketing-site
+  primaryRegion: hz-fsn-rtz-prod
+  hotStandbyRegions:
+    - hz-hel-rtz-prod
+  leaseClient:
+    kind: cloudflare-kv
+    config:
+      kvNamespaceId: 9b1c0a2eXXXXXXXXXXXXXXXXXXXXXXXX
+      accountId: a1b2c3d4XXXXXXXXXXXXXXXXXXXXXXXX
+      tokenSecretRef:
+        name: continuum-cf-token
+        key: token
+      ttlSeconds: 30
+      renewSeconds: 10
+  luaRecord:
+    selector: ifurlup
+    healthCheck:
+      url: https://marketing.acme-prod.omantel.openova.io/health
+      intervalSeconds: 5
+      timeoutSeconds: 2
+  rto: 60s
+  rpo: 5s
+  autoFailover: true
+---
+# Manual-failover sample — DNS-quorum lease (no Cloudflare), 2-of-3 resolvers,
+# pickclosest selector for latency-aware routing.
+apiVersion: dr.openova.io/v1
+kind: Continuum
+metadata:
+  name: api-active-passive
+  namespace: bank
+spec:
+  applicationRef: api-gateway
+  primaryRegion: hz-fsn-rtz-prod
+  hotStandbyRegions:
+    - hz-hel-rtz-prod
+    - hz-nbg-rtz-prod
+  leaseClient:
+    kind: dns-quorum
+    config:
+      resolvers:
+        - 8.8.8.8
+        - 1.1.1.1
+        - 9.9.9.9
+      ttlSeconds: 60
+      renewSeconds: 20
+  luaRecord:
+    selector: pickclosest
+    healthCheck:
+      url: https://api.bank-prod.bank.example/healthz
+  rto: 5m
+  rpo: 1m
+  autoFailover: false


### PR DESCRIPTION
## Summary

Slice **B8** of EPIC-0 (#1095). Lands the Continuum CRD shape per design doc §3.2.8 + §9 (EPIC-6 #1101). The controller and chart land in #1101; this slice provides the schema EPIC-6 watches.

## Why

\`platform/failover-controller/\` is README-only — no chart, no Go code, image not built. Without a CRD shape, EPIC-6's continuum-controller has no resource to watch. This slice provides the contract.

## Schema highlights

- Namespace-scoped (matches parent Application)
- \`spec.applicationRef\` — controller refuses non-active-hotstandby Applications at admission
- \`spec.leaseClient.kind\` — \`cloudflare-kv\` (recommended per SRE.md §2.4) | \`dns-quorum\` (fallback, requires 3+ resolvers)
- \`spec.luaRecord.selector\` — \`ifurlup | pickclosest | pickfirst | pickwhashed\` (per MULTI-REGION-DNS.md)
- \`spec.{rto,rpo}\` — \`^[0-9]+(s|m|h)$\` pattern
- \`spec.autoFailover\` — false = alarm-only / manual switchover via Application page
- \`status.replicationLag\` — per-host-cluster duration map
- \`status.maxReplicationLag\` — convenience printer column
- \`status.lastSwitchover\` — full audit record (at, from, to, reason, rtoObserved, rpoObserved, initiatedBy)

## Test plan

Validated against a real k3s control plane:

- [x] CRD applies cleanly server-side (after fixing one YAML gotcha — unquoted descriptive \`{key: value}\` was parsed as a flow map; quoted)
- [x] 2 valid samples accepted: tier-1 bank Cloudflare-KV (auto-failover) + 3-region dns-quorum (manual)
- [x] 2 invalid samples REJECTED with all 10 seeded error vectors (primaryRegion pattern, hotStandbyRegions=[], leaseClient.kind=etcd enum, luaRecord.selector=round-robin enum, healthCheck.url missing scheme, rto=1minute format, rpo=fast format, dns-quorum ttl<5, resolvers="not-an-ip" pattern, resolvers minItems=3)

## Out of scope

- continuum-controller — #1101
- products/continuum/ chart + Cloudflare Worker source — #1101
- bp-cnpg-pair Blueprint — #1101
- Topology editor UI on Application page — #1101

🤖 Generated with [Claude Code](https://claude.com/claude-code)