### PR TITLE
feat(catalyst-chart): land SecretPolicy + Runbook CRD skeletons (slices B6+B7, #1095)

### DIFF
--- a/products/catalyst/chart/crds/runbook.yaml
+++ b/products/catalyst/chart/crds/runbook.yaml
@@ -1,0 +1,179 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: runbooks.catalyst.openova.io
+  labels:
+    app.kubernetes.io/name: catalyst
+    app.kubernetes.io/component: runbook
+spec:
+  group: catalyst.openova.io
+  scope: Namespaced
+  names:
+    kind: Runbook
+    listKind: RunbookList
+    singular: runbook
+    plural: runbooks
+    shortNames:
+      - rb
+      - rbs
+    categories:
+      - catalyst
+      - openova
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      additionalPrinterColumns:
+        - name: Trigger
+          type: string
+          jsonPath: .spec.trigger.kind
+        - name: Action
+          type: string
+          jsonPath: .spec.action.kind
+        - name: Last
+          type: string
+          jsonPath: .status.lastFiredAt
+          priority: 1
+        - name: Fires
+          type: integer
+          jsonPath: .status.fireCount
+          priority: 1
+        - name: Age
+          type: date
+          jsonPath: .metadata.creationTimestamp
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
+          type: object
+          description: |
+            Runbook declares an auto-remediation rule: when a trigger
+            fires (alert from Prometheus, condition on a CR, audit event
+            on NATS), execute an action (scale, restart, rollback, run
+            a Job, switchover via Continuum, send-to-NATS).
+
+            Phase-0 lands the schema; the SRE Lead populates the rule
+            set per Sovereign post-Phase-0. The runbook executor is a
+            future thin in-cluster controller (out of scope here).
+
+            See docs/EPICS-1-6-unified-design.md §3.2.7 and
+            docs/SRE.md §3 (auto-remediation).
+          required: [spec]
+          properties:
+            spec:
+              type: object
+              required: [trigger, action]
+              properties:
+                description:
+                  type: string
+                  maxLength: 1024
+                trigger:
+                  type: object
+                  required: [kind]
+                  properties:
+                    kind:
+                      type: string
+                      enum:
+                        - prometheus-alert
+                        - cr-condition
+                        - nats-event
+                        - schedule
+                      description: |
+                        How this runbook is fired. prometheus-alert
+                        listens for Alertmanager webhook delivery.
+                        cr-condition watches a K8s resource for a
+                        specific condition. nats-event subscribes to
+                        a JetStream subject. schedule fires on cron.
+                    config:
+                      type: object
+                      description: |
+                        Kind-specific config. prometheus-alert wants
+                        alertName + matchers. cr-condition wants
+                        gvr + name + condition.{type,status}.
+                        nats-event wants subject + filter. schedule
+                        wants cron.
+                      x-kubernetes-preserve-unknown-fields: true
+                  x-kubernetes-preserve-unknown-fields: true
+                action:
+                  type: object
+                  required: [kind]
+                  properties:
+                    kind:
+                      type: string
+                      enum:
+                        - scale
+                        - restart
+                        - rollback
+                        - run-job
+                        - switchover
+                        - send-to-nats
+                        - create-incident
+                        - patch
+                      description: |
+                        What the runbook does when triggered.
+                    config:
+                      type: object
+                      description: Kind-specific config (target, args, gvr+patch, etc.).
+                      x-kubernetes-preserve-unknown-fields: true
+                  x-kubernetes-preserve-unknown-fields: true
+                cooldown:
+                  type: string
+                  pattern: '^[0-9]+(s|m|h)$'
+                  description: |
+                    Minimum interval between consecutive fires.
+                    Prevents flapping. Default 5m applied by controller.
+                approval:
+                  type: object
+                  description: |
+                    Optional approval gate. If approvers > 0, the
+                    runbook surfaces a pending action requiring N
+                    distinct human approvals before executing.
+                  properties:
+                    approvers:
+                      type: integer
+                      minimum: 0
+                      maximum: 10
+                      default: 0
+                    timeoutSeconds:
+                      type: integer
+                      minimum: 60
+                      maximum: 86400
+                      description: After timeout, the action is dropped.
+                  x-kubernetes-preserve-unknown-fields: true
+              x-kubernetes-preserve-unknown-fields: true
+            status:
+              type: object
+              properties:
+                fireCount:
+                  type: integer
+                  minimum: 0
+                lastFiredAt:
+                  type: string
+                  format: date-time
+                lastResult:
+                  type: string
+                  enum: [success, failure, skipped, awaiting-approval]
+                lastError:
+                  type: string
+                conditions:
+                  type: array
+                  items:
+                    type: object
+                    required: [type, status]
+                    properties:
+                      type:
+                        type: string
+                      status:
+                        type: string
+                        enum: ["True", "False", "Unknown"]
+                      reason:
+                        type: string
+                      message:
+                        type: string
+                      lastTransitionTime:
+                        type: string
+                        format: date-time
+                observedGeneration:
+                  type: integer
+                  format: int64
+              x-kubernetes-preserve-unknown-fields: true

--- a/products/catalyst/chart/crds/secretpolicy.yaml
+++ b/products/catalyst/chart/crds/secretpolicy.yaml
@@ -1,0 +1,163 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: secretpolicies.catalyst.openova.io
+  labels:
+    app.kubernetes.io/name: catalyst
+    app.kubernetes.io/component: secret-policy
+spec:
+  group: catalyst.openova.io
+  scope: Cluster
+  names:
+    kind: SecretPolicy
+    listKind: SecretPolicyList
+    singular: secretpolicy
+    plural: secretpolicies
+    shortNames:
+      - secpol
+      - secpols
+    categories:
+      - catalyst
+      - openova
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      additionalPrinterColumns:
+        - name: Rotations
+          type: integer
+          jsonPath: .status.rotationCount
+        - name: NextDue
+          type: string
+          jsonPath: .status.nextRotationDue
+          priority: 1
+        - name: Age
+          type: date
+          jsonPath: .metadata.creationTimestamp
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
+          type: object
+          description: |
+            SecretPolicy declares which Secrets within an Environment
+            (or globally) must rotate on what schedule and what to do
+            when a Secret exceeds its TTL.
+
+            Phase-0 lands the schema; the SRE Lead and Security Lead
+            populate the rotation list per Sovereign in EPIC-1 (#1096)
+            follow-up work. The rotation engine itself (Reflector +
+            ESO + a small Go reconciler) is out of scope until then —
+            this CRD is the contract.
+
+            See docs/EPICS-1-6-unified-design.md §3.2.6 and
+            docs/SECURITY.md for credential lifecycle conventions.
+          required: [spec]
+          properties:
+            spec:
+              type: object
+              properties:
+                rotation:
+                  type: array
+                  description: List of rotation rules. Each rule targets a credential class via labelSelector.
+                  items:
+                    type: object
+                    required: [kind, labelSelector, ttl]
+                    properties:
+                      kind:
+                        type: string
+                        description: |
+                          Credential class — drives which rotation handler
+                          is used. Common values: oauth-client-secret,
+                          tls-cert, db-password, api-key, jwt-signer,
+                          sealed-secret-master.
+                      labelSelector:
+                        type: object
+                        description: K8s labelSelector matching the Secret(s) this rule applies to.
+                        properties:
+                          matchLabels:
+                            type: object
+                            additionalProperties:
+                              type: string
+                          matchExpressions:
+                            type: array
+                            items:
+                              type: object
+                              required: [key, operator]
+                              properties:
+                                key:
+                                  type: string
+                                operator:
+                                  type: string
+                                  enum: [In, NotIn, Exists, DoesNotExist]
+                                values:
+                                  type: array
+                                  items:
+                                    type: string
+                        x-kubernetes-preserve-unknown-fields: true
+                      ttl:
+                        type: string
+                        pattern: '^[0-9]+(s|m|h|d)$'
+                        description: |
+                          Lifetime — Secrets older than ttl trigger the
+                          declared action. Examples: 24h, 30d, 90d.
+                      action:
+                        type: string
+                        enum: [rotate, warn, block]
+                        default: warn
+                        description: |
+                          rotate = automated rotation via the registered
+                          handler. warn = alert only. block = refuse new
+                          deployments referencing the expired Secret.
+                      gracePeriod:
+                        type: string
+                        pattern: '^[0-9]+(s|m|h|d)$'
+                        description: |
+                          Optional grace window after ttl during which
+                          old Secret remains valid. Common for tls-cert.
+                      handlerRef:
+                        type: object
+                        description: Optional named reference to a custom rotation handler.
+                        properties:
+                          name:
+                            type: string
+                          namespace:
+                            type: string
+                        x-kubernetes-preserve-unknown-fields: true
+              x-kubernetes-preserve-unknown-fields: true
+            status:
+              type: object
+              properties:
+                rotationCount:
+                  type: integer
+                  minimum: 0
+                  description: Number of rotation rules in spec.rotation[].
+                nextRotationDue:
+                  type: string
+                  format: date-time
+                  description: Earliest upcoming TTL boundary across all matched Secrets.
+                lastEvaluatedAt:
+                  type: string
+                  format: date-time
+                conditions:
+                  type: array
+                  items:
+                    type: object
+                    required: [type, status]
+                    properties:
+                      type:
+                        type: string
+                      status:
+                        type: string
+                        enum: ["True", "False", "Unknown"]
+                      reason:
+                        type: string
+                      message:
+                        type: string
+                      lastTransitionTime:
+                        type: string
+                        format: date-time
+                observedGeneration:
+                  type: integer
+                  format: int64
+              x-kubernetes-preserve-unknown-fields: true


### PR DESCRIPTION
## Summary

Slices **B6** + **B7** of EPIC-0 (#1095) bundled (both small skeleton CRDs). Realizes design doc §3.2.6 (SecretPolicy) and §3.2.7 (Runbook).

## Scope

Both are **schema-only contracts** — populated by SRE Lead / Security Lead post-Phase-0. The rotation engine (SecretPolicy executor) and runbook executor are future thin in-cluster controllers, out of scope here.

### SecretPolicy (cluster-scoped)
- \`spec.rotation[]\` — rules with kind (oauth-client-secret | tls-cert | db-password | api-key | jwt-signer | sealed-secret-master), labelSelector, ttl (\`^[0-9]+(s|m|h|d)$\`), action (rotate | warn | block, default warn), gracePeriod, handlerRef
- \`status.rotationCount\` + \`nextRotationDue\` printer columns

### Runbook (namespace-scoped)
- \`spec.trigger.kind\`: prometheus-alert | cr-condition | nats-event | schedule
- \`spec.action.kind\`: scale | restart | rollback | run-job | switchover | send-to-nats | create-incident | patch
- \`spec.cooldown\` — flapping protection
- \`spec.approval\` — optional human-approval gate (0-10 approvers, timeout)
- \`status.fireCount\` + \`lastFiredAt\` + \`lastResult\` enum

Both use \`x-kubernetes-preserve-unknown-fields\` under \`.config\` sub-trees so the Lead can extend without an apiVersion bump.

## Test plan

- [x] Both CRDs apply server-side cleanly (\`kubectl apply\`)
- [x] No structural-schema violations
- [x] Cleanup verified

## Out of scope

- SecretPolicy rotation engine — post-Phase-0
- Runbook executor — post-Phase-0
- Pre-populated rotation rules / runbooks — owned by SRE Lead per Sovereign

🤖 Generated with [Claude Code](https://claude.com/claude-code)