### PR TITLE
feat(catalyst-chart): land Blueprint CRD + fix 5 string-form depends (slice B4, #1095)

### DIFF
--- a/platform/cert-manager-dynadot-webhook/blueprint.yaml
+++ b/platform/cert-manager-dynadot-webhook/blueprint.yaml
@@ -23,7 +23,7 @@ spec:
     # waterfall locked in by docs/INVIOLABLE-PRINCIPLES.md (intra-chart
     # CRD ordering) this chart MUST be installed AFTER bp-cert-manager
     # is Ready — Flux dependsOn enforces that at the HelmRelease level.
-    - bp-cert-manager
+    - blueprint: bp-cert-manager
   outputs:
     # Tells dependents (bp-cilium-gateway's wildcard Certificate, etc.)
     # which solverName the ClusterIssuer's solvers[].dns01.webhook

--- a/platform/cert-manager-powerdns-webhook/blueprint.yaml
+++ b/platform/cert-manager-powerdns-webhook/blueprint.yaml
@@ -26,7 +26,7 @@ spec:
     # waterfall locked in by docs/INVIOLABLE-PRINCIPLES.md (intra-chart
     # CRD ordering) this chart MUST be installed AFTER bp-cert-manager
     # is Ready — Flux dependsOn enforces that at the HelmRelease level.
-    - bp-cert-manager
+    - blueprint: bp-cert-manager
     # NOTE: bp-powerdns dependency intentionally REMOVED. The webhook
     # calls contabo's central PowerDNS (https://pdns.openova.io) — an
     # out-of-cluster endpoint — not the Sovereign's local PowerDNS. The

--- a/platform/crossplane-claims/blueprint.yaml
+++ b/platform/crossplane-claims/blueprint.yaml
@@ -19,4 +19,4 @@ spec:
   manifests:
     chart: ./chart
   depends:
-    - bp-crossplane
+    - blueprint: bp-crossplane

--- a/platform/powerdns/blueprint.yaml
+++ b/platform/powerdns/blueprint.yaml
@@ -61,6 +61,6 @@ spec:
   #   - traefik.io/v1alpha1.Middleware CRD — Traefik is the Catalyst-Zero
   #     ingress controller and is a fixture of every Sovereign.
   depends:
-    - bp-cert-manager
+    - blueprint: bp-cert-manager
   upgrades:
     from: ["0.x"]

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -23,5 +23,5 @@ spec:
   manifests:
     chart: ./chart
   depends:
-    - bp-gitea
-    - bp-harbor
+    - blueprint: bp-gitea
+    - blueprint: bp-harbor

--- a/products/catalyst/chart/crds/blueprint.yaml
+++ b/products/catalyst/chart/crds/blueprint.yaml
@@ -1,0 +1,267 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: blueprints.catalyst.openova.io
+  labels:
+    app.kubernetes.io/name: catalyst
+    app.kubernetes.io/component: blueprint
+spec:
+  group: catalyst.openova.io
+  scope: Cluster
+  names:
+    kind: Blueprint
+    listKind: BlueprintList
+    singular: blueprint
+    plural: blueprints
+    shortNames:
+      - bp
+      - bps
+    categories:
+      - catalyst
+      - openova
+  # Two versions served from identical inline schemas. v1 is storage. v1alpha1
+  # stays served so the 38 existing v1alpha1 files validate as-is. Future
+  # tightening / migration to v1 is a follow-up slice.
+  versions:
+    - &VERSION_v1
+      name: v1alpha1
+      served: true
+      storage: false
+      additionalPrinterColumns: &PRINTER_COLS
+        - name: Version
+          type: string
+          jsonPath: .spec.version
+        - name: Visibility
+          type: string
+          jsonPath: .spec.visibility
+        - name: Title
+          type: string
+          jsonPath: .spec.card.title
+          priority: 1
+        - name: Age
+          type: date
+          jsonPath: .metadata.creationTimestamp
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema: &SCHEMA
+          type: object
+          description: |
+            Blueprint is the unified unit of installable software. See
+            docs/BLUEPRINT-AUTHORING.md §3 for the contract.
+
+            Schema is intentionally permissive (x-kubernetes-preserve-unknown-fields
+            on free-form sub-trees: configSchema, manifests.values, depends[].values,
+            and the spec root) because:
+              - configSchema is per-Blueprint JSON Schema — its shape is
+                arbitrary by design.
+              - 58 existing blueprint.yaml files (38 v1alpha1 + 20 v1) carry
+                a union of card variants (summary|description, category|family,
+                docs|documentation), optional manifests blocks for catalog-
+                metadata-only entries, and one-off fields (outputs, etc.).
+              - Tightening happens via follow-up slices that author specific
+                ClusterPolicies or schema bumps.
+
+            Required at this layer: spec.version, spec.card.title. Everything
+            else is optional / preserve-unknown.
+          required: [spec]
+          properties:
+            spec:
+              type: object
+              required: [version, card]
+              properties:
+                version:
+                  type: string
+                  pattern: '^[0-9]+\.[0-9]+\.[0-9]+(-[a-z0-9.-]+)?$'
+                card:
+                  type: object
+                  required: [title]
+                  properties:
+                    title:
+                      type: string
+                      minLength: 1
+                    summary:
+                      type: string
+                    description:
+                      type: string
+                    tagline:
+                      type: string
+                    icon:
+                      type: string
+                    category:
+                      type: string
+                    family:
+                      type: string
+                    tags:
+                      type: array
+                      items:
+                        type: string
+                    documentation:
+                      type: string
+                    docs:
+                      type: string
+                    license:
+                      type: string
+                    screenshots:
+                      type: array
+                      items:
+                        type: string
+                  x-kubernetes-preserve-unknown-fields: true
+                visibility:
+                  type: string
+                  enum: [listed, unlisted, private]
+                owner:
+                  type: object
+                  properties:
+                    team:
+                      type: string
+                    contact:
+                      type: string
+                  x-kubernetes-preserve-unknown-fields: true
+                configSchema:
+                  type: object
+                  description: |
+                    Per-Blueprint JSON Schema that drives the install form
+                    in the console. Free-form by design — preserve-unknown.
+                  x-kubernetes-preserve-unknown-fields: true
+                placementSchema:
+                  type: object
+                  properties:
+                    modes:
+                      type: array
+                      minItems: 1
+                      items:
+                        type: string
+                        enum: [single-region, active-active, active-hotstandby]
+                    default:
+                      type: string
+                      enum: [single-region, active-active, active-hotstandby]
+                    minRegions:
+                      type: integer
+                      minimum: 1
+                      maximum: 5
+                    maxRegions:
+                      type: integer
+                      minimum: 1
+                      maximum: 5
+                  x-kubernetes-preserve-unknown-fields: true
+                depends:
+                  type: array
+                  items:
+                    type: object
+                    required: [blueprint]
+                    properties:
+                      blueprint:
+                        type: string
+                        pattern: '^(bp-)?[a-z][a-z0-9-]{1,62}$'
+                      version:
+                        type: string
+                      alias:
+                        type: string
+                      when:
+                        type: string
+                      values:
+                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
+                    x-kubernetes-preserve-unknown-fields: true
+                manifests:
+                  type: object
+                  properties:
+                    chart:
+                      type: string
+                    source:
+                      type: object
+                      properties:
+                        kind:
+                          type: string
+                          enum: [HelmChart, Kustomize, OAM]
+                        ref:
+                          type: string
+                      x-kubernetes-preserve-unknown-fields: true
+                    overlays:
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                    values:
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                  x-kubernetes-preserve-unknown-fields: true
+                upgrades:
+                  type: object
+                  properties:
+                    from:
+                      type: array
+                      items:
+                        type: string
+                    blocks:
+                      type: array
+                      items:
+                        type: string
+                  x-kubernetes-preserve-unknown-fields: true
+                rotation:
+                  type: array
+                  items:
+                    type: object
+                    required: [kind]
+                    properties:
+                      kind:
+                        type: string
+                      name:
+                        type: string
+                      ttl:
+                        type: string
+                        pattern: '^[0-9]+(s|m|h|d)$'
+                    x-kubernetes-preserve-unknown-fields: true
+                observability:
+                  type: object
+                  properties:
+                    metrics:
+                      type: string
+                    logs:
+                      type: string
+                    traces:
+                      type: string
+                  x-kubernetes-preserve-unknown-fields: true
+                outputs:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+              x-kubernetes-preserve-unknown-fields: true
+            status:
+              type: object
+              properties:
+                phase:
+                  type: string
+                  enum: [Draft, Published, Deprecated, Withdrawn]
+                publishedAt:
+                  type: string
+                  format: date-time
+                deprecatedAt:
+                  type: string
+                  format: date-time
+                ociDigest:
+                  type: string
+                  description: cosign-signed OCI artifact digest (set by CI on publish).
+                conditions:
+                  type: array
+                  items:
+                    type: object
+                    required: [type, status]
+                    properties:
+                      type:
+                        type: string
+                      status:
+                        type: string
+                        enum: ["True", "False", "Unknown"]
+                      reason:
+                        type: string
+                      message:
+                        type: string
+                      lastTransitionTime:
+                        type: string
+                        format: date-time
+                observedGeneration:
+                  type: integer
+                  format: int64
+              x-kubernetes-preserve-unknown-fields: true
+    - <<: *VERSION_v1
+      name: v1
+      storage: true

--- a/products/catalyst/chart/crds/tests/blueprint-sample-invalid.yaml
+++ b/products/catalyst/chart/crds/tests/blueprint-sample-invalid.yaml
@@ -1,0 +1,33 @@
+# Invalid sample — must FAIL schema validation. Seeded errors:
+#   spec.version: "1.3" — not strict semver
+#   spec.card missing — required
+#   spec.visibility: "secret" — not in enum listed|unlisted|private
+#   spec.placementSchema.modes[0]: "round-robin" — not in enum
+#   spec.depends[0]: bare string — must be object {blueprint: ...}
+#   spec.depends[1].blueprint: "Foo" — uppercase fails pattern
+#   spec.rotation[0].ttl: "5 days" — wrong format
+apiVersion: catalyst.openova.io/v1
+kind: Blueprint
+metadata:
+  name: bp-bad
+spec:
+  version: "1.3"
+  visibility: secret
+  placementSchema:
+    modes: [round-robin]
+  depends:
+    - bp-bad-string
+    - blueprint: Foo
+  rotation:
+    - kind: oauth-client-secret
+      ttl: "5 days"
+---
+# Second invalid case — title missing in card
+apiVersion: catalyst.openova.io/v1
+kind: Blueprint
+metadata:
+  name: bp-bad-2
+spec:
+  version: 1.0.0
+  card:
+    summary: A card without a title.

--- a/products/catalyst/chart/crds/tests/blueprint-sample-valid.yaml
+++ b/products/catalyst/chart/crds/tests/blueprint-sample-valid.yaml
@@ -1,0 +1,93 @@
+# Valid sample — uses every documented field per BLUEPRINT-AUTHORING.md §3
+# example. Confirms the canonical shape continues to validate.
+apiVersion: catalyst.openova.io/v1
+kind: Blueprint
+metadata:
+  name: bp-wordpress-test
+  labels:
+    catalyst.openova.io/category: application
+spec:
+  version: 1.3.0
+  card:
+    title: WordPress
+    summary: Self-hosted CMS
+    description: A self-hosted WordPress instance with optional embedded Postgres.
+    category: cms
+    tags: [cms, blog, php]
+    icon: ./card/icon.svg
+    license: GPL-2.0
+    documentation: https://wordpress.org/documentation
+  visibility: listed
+  owner:
+    team: apps
+    contact: apps@openova.io
+  configSchema:
+    type: object
+    required: [domain, adminEmail]
+    properties:
+      domain:
+        type: string
+        format: hostname
+      adminEmail:
+        type: string
+        format: email
+      replicas:
+        type: integer
+        default: 2
+        minimum: 1
+        maximum: 20
+  placementSchema:
+    modes: [single-region, active-active, active-hotstandby]
+    default: single-region
+    minRegions: 1
+    maxRegions: 5
+  depends:
+    - blueprint: bp-postgres
+      version: ^1.4
+      alias: db
+      when: "{{ .config.postgres.mode == 'embedded' }}"
+      values:
+        databases: ["wp"]
+        size: medium
+  manifests:
+    source:
+      kind: HelmChart
+      ref: oci://ghcr.io/openova-io/bp-wordpress:1.3.0
+    overlays:
+      small:
+        replicas: 1
+      medium:
+        replicas: 2
+      large:
+        replicas: 5
+  upgrades:
+    from:
+      - 1.2.x
+      - 1.1.x
+    blocks:
+      - 1.0.x
+  rotation:
+    - kind: oauth-client-secret
+      name: wp-keycloak-client
+      ttl: 90d
+  observability:
+    metrics: prometheus
+    logs: stdout
+    traces: otlp
+---
+# Legacy v1alpha1 form with manifests.chart short-form must also pass.
+apiVersion: catalyst.openova.io/v1alpha1
+kind: Blueprint
+metadata:
+  name: bp-legacy-test
+spec:
+  version: 0.5.2
+  card:
+    title: Legacy
+    summary: Legacy short-form blueprint.
+  visibility: unlisted
+  manifests:
+    chart: ./chart
+  placementSchema:
+    modes: [single-region]
+    default: single-region


### PR DESCRIPTION
## Summary

Slice **B4** of EPIC-0 (#1095). Promotes Blueprint from doc-contract (\`docs/BLUEPRINT-AUTHORING.md\` §3) to a schema-validated CRD, then validates ALL 59 existing \`platform/*/blueprint.yaml\` and \`products/*/blueprint.yaml\` files against it. Fixes 5 files that used the legacy string-form \`depends:\`.

## Schema design

- **Two versions** served from one inline schema (YAML anchors): \`v1alpha1\` (legacy, served, not storage) and \`v1\` (canonical, served, storage). The shared schema means the 38 existing v1alpha1 files validate as-is; migration to v1 is a follow-up slice.
- **Required**: \`spec.version\` (strict semver pattern), \`spec.card.title\` (minLength=1).
- **Card variants** accommodated as documented: \`summary | description | tagline\` interchangeable; \`category | family\`; \`docs | documentation\`. All optional except title.
- **visibility** enum: \`listed | unlisted | private\`.
- **placementSchema.modes** enum matches Application.spec.placement.
- **depends[].blueprint** pattern accepts both \`bp-*\` and bare-name (legacy).
- **manifests** accepts both \`manifests.chart\` (legacy short-form) AND \`manifests.source.{kind,ref}\` (canonical). Source kinds: HelmChart | Kustomize | OAM.
- **rotation[].ttl** pattern \`^[0-9]+(s|m|h|d)$\`.
- **x-kubernetes-preserve-unknown-fields** on configSchema (per-Blueprint JSON Schema is arbitrary by design), card, manifests, owner, observability, outputs, etc.

## Existing-files validation

- Surveyed all 59 blueprint.yaml files (38 v1alpha1 + 21 v1).
- Card field frequency: \`title\` 59, \`summary\` 38, \`description\` 21, \`category\` 25, \`family\` 20, \`docs\` 20, \`documentation\` 15, \`icon\` 25, \`tags\` 14, \`license\` 14.
- **54 of 59** passed the new schema unchanged.
- **5 files** used \`depends: [- bp-name]\` (string form) instead of canonical \`[- blueprint: bp-name]\`. Fixed in this PR:
  - \`platform/cert-manager-powerdns-webhook/blueprint.yaml\`
  - \`platform/cert-manager-dynadot-webhook/blueprint.yaml\`
  - \`platform/crossplane-claims/blueprint.yaml\`
  - \`platform/powerdns/blueprint.yaml\`
  - \`platform/self-sovereign-cutover/blueprint.yaml\`
- **After fix: ALL 59 files pass** \`kubectl apply --dry-run=server\` against the new CRD.

## Negative validation

\`tests/blueprint-sample-invalid.yaml\` triggers all 8 seeded error vectors:

- \`spec.version\` "1.3" → semver pattern
- \`spec.card\` missing → required
- \`spec.card.title\` missing → required (second invalid case)
- \`spec.visibility\` "secret" → enum
- \`spec.placementSchema.modes\` "round-robin" → enum
- \`spec.depends[0]\` bare string → must be object
- \`spec.depends[1].blueprint\` "Foo" → pattern (uppercase)
- \`spec.rotation[0].ttl\` "5 days" → pattern

## Out of scope

- Migrate the 38 v1alpha1 files to v1 (separate slice — purely apiVersion bump per file)
- blueprint-controller (slice C3)
- catalog-svc that mirrors blueprints into per-Sovereign Gitea (#1097)
- CI workflow that publishes signed OCI artifacts on tag (#1097 / BLUEPRINT-AUTHORING.md §2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)