### PR TITLE
docs: flip 8 CRDs to 🚧 + amend ProvisioningState decision (slices A2+A3, #1095)

### DIFF
--- a/docs/EPICS-1-6-unified-design.md
+++ b/docs/EPICS-1-6-unified-design.md
@@ -1,6 +1,6 @@
 # EPICs 1–6: Unified Design
 
-**Status**: Authoritative target spec for the Phase 0/1 roll-out tracked under #1094.
+**Status**: Authoritative target spec for the Phase 0/1 roll-out tracked under #1094. Promoted to Authoritative on 2026-05-08 after Phase-0 Group B (CRD schemas) substantially landed.
 **Updated**: 2026-05-08
 **Audience**: Every Architect, Implementer, Reviewer, Test-Plan Author, Test Executor, Fix Author working on any of #1094–#1101.
 
@@ -422,7 +422,7 @@ Bundled into Phase 0 because every later EPIC trips on at least one of these.
 |---|---|---|
 | 1 | Cilium subchart 1.16.5 vs values.yaml claiming 1.19.3 | Pin to one stable, align values, update Chart.lock |
 | 2 | `omantel.omani.works/`, `otech.omani.works/` drifted from `_template/` | Reconcile to template; CI gate on diff |
-| 3 | `provisioningstate.yaml` CRD = 0 bytes | Delete (catalyst-api uses PVC + flat-file event log per ADR-0001 §4.1) |
+| 3 | `provisioningstate.yaml` CRD = 0 bytes | **AMENDED 2026-05-08**: Author the schema (was originally "delete"). The audit was incomplete — `catalyst-api/internal/store/crd_store.go` actively expects this CRD (GVR `catalyst.openova.io/v1alpha1/provisioningstates`) and silently no-ops in `CRDModeDisabled` when it isn't installed. Implemented in slice H3 / PR #1104. |
 | 4 | NATS JetStream chart has no `templates/` | Add Stream + KV CRs |
 | 5 | OTel Operator not deployed | Add HelmRelease |
 | 6 | `local-path` StorageClass blocks multi-node CNPG primary/replica | Add `hcloud-volumes` CSI as default for stateful |
@@ -811,7 +811,7 @@ Per EPIC, embedded across the whole journey (qa-loop is part of the team from da
 | 5 | Two catalogs (bp-* OCI vs SME catalog) | Unify under `catalog-svc` per ADR-0001 §4.3 | Founder via ADR |
 | 6 | omantel/otech bootstrap-kit drifted from `_template` | Reconcile + CI gate on diff | Coordinator |
 | 7 | NATS chart has no `templates/` | Add Stream + KV CRs per §3.9 | Coordinator |
-| 8 | `provisioningstate.yaml` = 0 bytes | Delete | Coordinator |
+| 8 | `provisioningstate.yaml` = 0 bytes | **AMENDED 2026-05-08**: Author (not delete) — `catalyst-api/internal/store/crd_store.go` actively expects this CRD. Audit-correction during EPIC-0 slice H3 (PR #1104). | Coordinator |
 | 9 | Apps run in vCluster-per-Org (already in NAMING §1.5) | Confirmed locked — internal-dept + customer-SME both get vClusters; only billing differs | Founder explicit response |
 | 10 | OTel Operator absent; only collector with all presets off | Add Operator + Instrumentation CRs (Java/.NET/Node/Python first; Go eBPF later) | Coordinator |
 | 11 | Failover-controller is README-only | Replace with Continuum product (`products/continuum/`); CRD `dr.openova.io/v1` | Coordinator |

--- a/docs/IMPLEMENTATION-STATUS.md
+++ b/docs/IMPLEMENTATION-STATUS.md
@@ -96,20 +96,22 @@ These run on **every host cluster** (mgt, rtz, dmz). Status is per-component REA
 
 ## 4. CRDs
 
-[`core/README.md`](../core/README.md) and [`ARCHITECTURE.md`](ARCHITECTURE.md) reference these CRDs:
+[`core/README.md`](../core/README.md) and [`ARCHITECTURE.md`](ARCHITECTURE.md) reference these CRDs. EPIC-0 (#1095) of the Phase-0/1 roll-out under #1094 lands the schema layer as committed YAML in `products/catalyst/chart/crds/` and validates them against a real K8s control plane; Go types + reconciliation controllers (Group C of #1095) follow.
 
 | CRD | Status | Notes |
 |---|---|---|
 | `Sovereign` | 📐 | Top-level deployment object. No Go type yet. |
-| `Organization` | 📐 | Multi-tenancy unit. No Go type yet. |
-| `Environment` | 📐 | `{org}-{env_type}` scope. No Go type yet. |
-| `Application` | 📐 | An installed Blueprint. No Go type yet. |
-| `Blueprint` | 📐 | The unified Blueprint CRD spec is in [`BLUEPRINT-AUTHORING.md`](BLUEPRINT-AUTHORING.md) §3 — that is the design contract for the Go type. |
-| `EnvironmentPolicy` | 📐 | Promotion gating. No Go type yet. |
-| `SecretPolicy` | 📐 | Rotation policy. No Go type yet. |
-| `Runbook` | 📐 | Auto-remediation. No Go type yet. |
+| `Organization` | 🚧 | Schema landed in `products/catalyst/chart/crds/organization.yaml` (slice B1, PR #1106). organization-controller is slice C1 — not yet built. |
+| `Environment` | 🚧 | Schema landed in `products/catalyst/chart/crds/environment.yaml` (slice B2, PR #1107). environment-controller is slice C2 — not yet built. |
+| `Application` | 🚧 | Schema landed in `products/catalyst/chart/crds/application.yaml` (slice B3, PR #1105). application-controller is slice C4 — not yet built. |
+| `Blueprint` | 🚧 | Schema landed in `products/catalyst/chart/crds/blueprint.yaml` (slice B4, PR #1112). Serves both `v1alpha1` (legacy) and `v1` (canonical). All 59 existing `platform/*/blueprint.yaml` and `products/*/blueprint.yaml` files validate against the schema (5 string-form `depends:` entries fixed in the same PR). blueprint-controller is slice C3 — not yet built. |
+| `EnvironmentPolicy` | 🚧 | Schema landed in `products/catalyst/chart/crds/environmentpolicy.yaml` (slice B5, PR #1108). Promotion gating + per-policy compliance weights and permissive/enforcing modes. Consumer (compliance-aggregator) lives in EPIC-1 #1096. |
+| `SecretPolicy` | 🚧 | Schema landed in `products/catalyst/chart/crds/secretpolicy.yaml` (slices B6+B7, PR #1111). Skeleton — populated by SRE Lead post-Phase-0; rotation engine is a future controller. |
+| `Runbook` | 🚧 | Schema landed in `products/catalyst/chart/crds/runbook.yaml` (slices B6+B7, PR #1111). Skeleton — auto-remediation hooks for prometheus-alert / cr-condition / nats-event / schedule triggers. Executor is a future controller. |
+| `Continuum` | 🚧 | Schema landed in `products/catalyst/chart/crds/continuum.yaml` (slice B8, PR #1110). Group `dr.openova.io/v1`. Switchover orchestration with Cloudflare-KV or DNS-quorum lease witness. continuum-controller is in EPIC-6 #1101. |
+| `ProvisioningState` | 🚧 | Schema landed in `products/catalyst/chart/crds/provisioningstate.yaml` (slice H3, PR #1104). The previous 0-byte placeholder caused every catalyst-api in production to silently no-op the CRD-projection path — closing this gap was an audit-correction during EPIC-0. Writer is `internal/store/crd_store.go` (already deployed); CRD will be live as soon as the chart rolls out. |
 
-`core/pkg/apis/v1alpha1/` is currently a `.gitkeep` directory. The Go types will be added when the control-plane services are scaffolded.
+`core/pkg/apis/v1alpha1/` is currently a `.gitkeep` directory. The Go types will be added when the control-plane services are scaffolded (slice C1..C5 of #1095).
 
 ---
 


### PR DESCRIPTION
## Summary

Slices **A2** + **A3** of EPIC-0 (#1095). Pure docs sync — no code changes.

## A2 — IMPLEMENTATION-STATUS.md §4

Reflects the 8 CRDs that landed via slices B1-B8 + H3 (PRs #1104-#1111):

- Organization, Environment, Application, Blueprint, EnvironmentPolicy, SecretPolicy, Runbook → 📐 to 🚧
- Continuum (in EPIC-6's domain but schema landed in EPIC-0 per design doc §3.2.8) → new 🚧 row
- ProvisioningState (was a 0-byte placeholder, audit-corrected by slice H3) → new 🚧 row

Each row now cites its slice + PR + remaining controller work (Group C of #1095).

## A3 — EPICS-1-6-unified-design.md

- **Status flip**: "Authoritative target spec" → "Authoritative ... promoted on 2026-05-08 after Phase-0 Group B (CRD schemas) substantially landed".
- **Amend §3.9 row 3 + §11 row 8** to reflect the H3 audit-correction: ProvisioningState decision changed from "Delete" to "Author the schema". The original audit missed \`catalyst-api/internal/store/crd_store.go\` which actively expects the CRD; without it, every catalyst-api silently no-ops the CRD-projection path in CRDModeDisabled.

## Test plan

- [x] Markdown renders cleanly on GitHub (tables + emoji + links)
- [x] All cited PR/slice numbers are correct (#1104-#1112)

🤖 Generated with [Claude Code](https://claude.com/claude-code)