### PR TITLE
feat(bp-nats-jetstream): land Stream + KV CR templates (slice H4, #1095)

### DIFF
--- a/platform/nats-jetstream/blueprint.yaml
+++ b/platform/nats-jetstream/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
 spec:
-  version: 1.1.2
+  version: 1.2.0
   card:
     title: nats-jetstream
     summary: Event spine for the Catalyst control plane. JetStream Streams + KV. Per-Organization Accounts. Replaces what was previously specified as Redpanda + Valkey for the control plane.

--- a/platform/nats-jetstream/chart/Chart.yaml
+++ b/platform/nats-jetstream/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-nats-jetstream
-version: 1.1.2
+version: 1.2.0
 description: |
   Catalyst-curated Blueprint umbrella chart for NATS JetStream. Depends on
   the upstream `nats` chart (nats-io) as a Helm subchart so

--- a/platform/nats-jetstream/chart/templates/_helpers.tpl
+++ b/platform/nats-jetstream/chart/templates/_helpers.tpl
@@ -1,0 +1,28 @@
+{{/*
+Common labels for every Catalyst-overlay resource in this chart.
+The upstream nats subchart owns its own labels; we only stamp these
+on Catalyst-authored resources (Streams, KVs, NetworkPolicies, etc.).
+*/}}
+{{- define "catalyst-nats.labels" -}}
+app.kubernetes.io/name: nats-jetstream
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/component: messaging
+app.kubernetes.io/part-of: catalyst
+catalyst.openova.io/blueprint: bp-nats-jetstream
+catalyst.openova.io/blueprint-version: {{ .Chart.Version | quote }}
+{{- end -}}
+
+{{/*
+The K8s Service that fronts the upstream nats subchart's StatefulSet.
+Default `<release>-nats` matches the upstream chart's templating; the
+operator can override per-Sovereign via .Values.catalystStreams.servers.
+*/}}
+{{- define "catalyst-nats.servers" -}}
+{{- $servers := .Values.catalystStreams.servers -}}
+{{- if $servers -}}
+{{- $servers -}}
+{{- else -}}
+nats://{{ .Release.Name }}-nats.{{ .Release.Namespace }}.svc.cluster.local:4222
+{{- end -}}
+{{- end -}}

--- a/platform/nats-jetstream/chart/templates/kv-buckets.yaml
+++ b/platform/nats-jetstream/chart/templates/kv-buckets.yaml
@@ -1,0 +1,67 @@
+{{/*
+Catalyst-curated JetStream KeyValue buckets. Same NACK gate as Streams —
+templates render only when `.Values.catalystStreams.enabled` is true.
+
+Per docs/EPICS-1-6-unified-design.md §3.9 row 7:
+  - idempotency  : idempotency keys for HTTP write paths (catalyst-api,
+                   provisioner). 24h TTL is enough for the longest
+                   provision-and-confirm window in the wizard flow.
+  - dr-leases    : DR lease witness for Continuum (#1101) when the
+                   leaseClient.kind is dns-quorum (Cloudflare-KV path
+                   uses CF KV instead of this bucket).
+  - policy-rollup: Compliance scorer (#1096) per-Application + per-Org
+                   weighted-score snapshots. Replayable for 7 days.
+
+KeyValue buckets are JetStream Streams under the hood, so they
+inherit replicas + storage from the same R=3 settings unless
+overridden.
+*/}}
+{{- if .Values.catalystStreams.enabled -}}
+---
+apiVersion: jetstream.nats.io/v1beta2
+kind: KeyValue
+metadata:
+  name: catalyst-idempotency
+  labels: {{- include "catalyst-nats.labels" . | nindent 4 }}
+    catalyst.openova.io/kv: idempotency
+spec:
+  bucket: idempotency
+  servers:
+    - {{ include "catalyst-nats.servers" . }}
+  replicas: {{ .Values.catalystStreams.replicas | default 3 }}
+  history: 1
+  ttl: {{ .Values.catalystStreams.idempotency.ttl | default "24h" | quote }}
+  maxBytes: {{ .Values.catalystStreams.idempotency.maxBytes | default 268435456 }}
+  storage: file
+---
+apiVersion: jetstream.nats.io/v1beta2
+kind: KeyValue
+metadata:
+  name: catalyst-dr-leases
+  labels: {{- include "catalyst-nats.labels" . | nindent 4 }}
+    catalyst.openova.io/kv: dr-leases
+spec:
+  bucket: dr-leases
+  servers:
+    - {{ include "catalyst-nats.servers" . }}
+  replicas: {{ .Values.catalystStreams.replicas | default 3 }}
+  history: 5
+  ttl: {{ .Values.catalystStreams.drLeases.ttl | default "60s" | quote }}
+  storage: memory
+---
+apiVersion: jetstream.nats.io/v1beta2
+kind: KeyValue
+metadata:
+  name: catalyst-policy-rollup
+  labels: {{- include "catalyst-nats.labels" . | nindent 4 }}
+    catalyst.openova.io/kv: policy-rollup
+spec:
+  bucket: policy-rollup
+  servers:
+    - {{ include "catalyst-nats.servers" . }}
+  replicas: {{ .Values.catalystStreams.replicas | default 3 }}
+  history: 10
+  ttl: {{ .Values.catalystStreams.policyRollup.ttl | default "168h" | quote }}
+  maxBytes: {{ .Values.catalystStreams.policyRollup.maxBytes | default 1073741824 }}
+  storage: file
+{{- end -}}

--- a/platform/nats-jetstream/chart/templates/streams.yaml
+++ b/platform/nats-jetstream/chart/templates/streams.yaml
@@ -1,0 +1,88 @@
+{{/*
+Catalyst-curated JetStream Streams. Reconciled by NACK (nats-io/nack)
+when it is installed and `.Values.catalystStreams.enabled` is true.
+
+Default: disabled. NACK is NOT a current dependency of this Blueprint
+— a follow-up slice installs it as a sibling Blueprint, then the
+operator flips this toggle in the per-Sovereign overlay.
+
+Per docs/EPICS-1-6-unified-design.md §3.9 row 7 + ADR-0001 §6:
+  - catalyst.audit  : every operator action, RBAC mutation, Sovereign
+                      lifecycle event. R=3 quorum. 90-day retention.
+                      Mirrored to DR region (#1101).
+  - catalyst.events : cross-replica fan-out for SSE consumers. R=3.
+                      24-hour retention (replay window for cold-start).
+  - catalyst.billing: subscription / invoice events. R=3. Long retention.
+                      Consumed by the billing service (post-Phase-1).
+
+Per-Org and per-Application streams (org.<id>.events, app.<id>.events)
+are NOT shipped here — they are created dynamically by organization-
+controller (slice C1) and application-controller (slice C4) at install
+time so they can scale per tenant.
+*/}}
+{{- if .Values.catalystStreams.enabled -}}
+---
+apiVersion: jetstream.nats.io/v1beta2
+kind: Stream
+metadata:
+  name: catalyst-audit
+  labels: {{- include "catalyst-nats.labels" . | nindent 4 }}
+    catalyst.openova.io/stream: audit
+spec:
+  name: catalyst.audit
+  servers:
+    - {{ include "catalyst-nats.servers" . }}
+  subjects:
+    - catalyst.audit.>
+  storage: file
+  replicas: {{ .Values.catalystStreams.replicas | default 3 }}
+  retention: limits
+  discard: old
+  maxAge: {{ .Values.catalystStreams.audit.maxAge | default "2160h" | quote }}
+  maxBytes: {{ .Values.catalystStreams.audit.maxBytes | default -1 }}
+  duplicates: {{ .Values.catalystStreams.audit.duplicateWindow | default "5m" | quote }}
+{{- with .Values.catalystStreams.audit.placement }}
+  placement:
+    cluster: {{ .cluster | quote }}
+{{- end }}
+---
+apiVersion: jetstream.nats.io/v1beta2
+kind: Stream
+metadata:
+  name: catalyst-events
+  labels: {{- include "catalyst-nats.labels" . | nindent 4 }}
+    catalyst.openova.io/stream: events
+spec:
+  name: catalyst.events
+  servers:
+    - {{ include "catalyst-nats.servers" . }}
+  subjects:
+    - catalyst.events.>
+  storage: file
+  replicas: {{ .Values.catalystStreams.replicas | default 3 }}
+  retention: limits
+  discard: old
+  maxAge: {{ .Values.catalystStreams.events.maxAge | default "24h" | quote }}
+  maxBytes: {{ .Values.catalystStreams.events.maxBytes | default -1 }}
+  duplicates: 2m
+---
+apiVersion: jetstream.nats.io/v1beta2
+kind: Stream
+metadata:
+  name: catalyst-billing
+  labels: {{- include "catalyst-nats.labels" . | nindent 4 }}
+    catalyst.openova.io/stream: billing
+spec:
+  name: catalyst.billing
+  servers:
+    - {{ include "catalyst-nats.servers" . }}
+  subjects:
+    - catalyst.billing.>
+  storage: file
+  replicas: {{ .Values.catalystStreams.replicas | default 3 }}
+  retention: limits
+  discard: old
+  maxAge: {{ .Values.catalystStreams.billing.maxAge | default "8760h" | quote }}
+  maxBytes: {{ .Values.catalystStreams.billing.maxBytes | default -1 }}
+  duplicates: 5m
+{{- end -}}

--- a/platform/nats-jetstream/chart/values.yaml
+++ b/platform/nats-jetstream/chart/values.yaml
@@ -50,3 +50,57 @@ nats:
     enabled: false
     podMonitor:
       enabled: false
+
+# ─── Catalyst-curated JetStream Streams + KV buckets ─────────────────────
+#
+# Reconciled by NACK (nats-io/nack) when it's installed in the same
+# cluster. NACK is NOT a current dependency of this chart — install it
+# as a sibling Blueprint, then flip `enabled: true` here.
+#
+# Per docs/EPICS-1-6-unified-design.md §3.9 row 7 + ADR-0001 §6,
+# Catalyst's own events flow on these streams:
+#   catalyst.audit  / catalyst.events / catalyst.billing  → Stream CRs
+#   idempotency / dr-leases / policy-rollup               → KeyValue CRs
+#
+# Per-Org and per-Application streams are created at runtime by
+# organization-controller (slice C1) and application-controller (slice
+# C4), not statically here.
+#
+# Per docs/INVIOLABLE-PRINCIPLES.md #4 (never hardcode), every retention
+# value is a variable and operator-overrideable.
+catalystStreams:
+  enabled: false
+  # JetStream replication factor. R=3 is the bank-tier default for
+  # in-region quorum; the DR Mirror to a second region is a separate
+  # follow-up wired by Continuum (#1101).
+  replicas: 3
+  # Override the upstream nats Service URL — defaults to
+  # nats://<release>-nats.<release-namespace>.svc.cluster.local:4222
+  servers: ""
+  audit:
+    # 90 days. Audit-log retention horizon.
+    maxAge: "2160h"
+    maxBytes: -1
+    duplicateWindow: "5m"
+    placement: {}
+  events:
+    # 24 hours. Cross-replica fan-out + cold-start replay window.
+    maxAge: "24h"
+    maxBytes: -1
+  billing:
+    # 1 year. Billing reconciliation horizon.
+    maxAge: "8760h"
+    maxBytes: -1
+  idempotency:
+    ttl: "24h"
+    # 256 MiB upper bound on the bucket.
+    maxBytes: 268435456
+  drLeases:
+    # 60 seconds — matches Continuum.spec.leaseClient.config.ttlSeconds
+    # default. DR-quorum lease path; Cloudflare-KV path bypasses this.
+    ttl: "60s"
+  policyRollup:
+    # 7 days. Replayable window for the compliance scorer.
+    ttl: "168h"
+    # 1 GiB upper bound.
+    maxBytes: 1073741824


### PR DESCRIPTION
## Summary

Slice **H4** of EPIC-0 (#1095). Lands the Catalyst-curated NATS JetStream Stream and KeyValue templates that ADR-0001 §6 mandates as the event spine. The chart had **no \`templates/\` directory** — Stream C audit caught this.

## What ships

\`platform/nats-jetstream/chart/templates/\` now contains:

- \`_helpers.tpl\` — common labels + servers helper.
- \`streams.yaml\` — 3 Streams: \`catalyst.audit\` (90d), \`catalyst.events\` (24h), \`catalyst.billing\` (1y). All R=3.
- \`kv-buckets.yaml\` — 3 KeyValues: \`idempotency\` (24h, 256 MiB), \`dr-leases\` (60s, memory), \`policy-rollup\` (7d, 1 GiB).

Per-tenant streams (\`org.<id>.events\`, \`app.<id>.events\`) are intentionally NOT shipped here — they'll be created at runtime by organization-controller (slice C1) and application-controller (slice C4).

## Reconciliation gate

All Catalyst resources render only when \`.Values.catalystStreams.enabled\` is \`true\`. **NACK is not a current dependency** — installing it as a sibling Blueprint and flipping this toggle is a follow-up slice. Same default-off pattern as \`promExporter.podMonitor\` (issue #182) so fresh Sovereigns boot cleanly without NACK.

## Test plan

- [x] \`helm dependency build\` succeeds (pulls upstream nats:1.2.0)
- [x] \`helm template\` with default values: 0 catalyst-* resources rendered
- [x] \`helm template\` with \`catalystStreams.enabled=true\`: exactly 6 resources rendered (3 Streams + 3 KeyValues), all in \`jetstream.nats.io/v1beta2\`
- [x] All retention / TTL / replicas / maxBytes are values.yaml variables (no hardcoded numbers per INVIOLABLE-PRINCIPLES #4)

## Chart version bump

1.1.2 → 1.2.0 (minor — new templates, no breaking change). Blueprint.yaml mirrored.

## Out of scope

- Install NACK (nats-io/nack) — separate slice
- Cross-region Mirror streams to DR region — #1101 wires those once 3-region substrate is up
- ExternalSecret + NetworkPolicy templates mentioned in Chart.yaml description — not yet added

🤖 Generated with [Claude Code](https://claude.com/claude-code)