### PR TITLE
fix(bp-cilium): align declared upstream version with Chart.lock (slice H1, #1095)

### DIFF
--- a/platform/cilium/blueprint.yaml
+++ b/platform/cilium/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/category: per-host-cluster-infrastructure
     catalyst.openova.io/section: pts-3-1-networking-and-service-mesh
 spec:
-  version: 1.2.0
+  version: 1.2.1
   card:
     title: Cilium
     summary: Unified CNI + Service Mesh (eBPF). mTLS via WireGuard, Hubble observability, Gateway API.

--- a/platform/cilium/chart/Chart.yaml
+++ b/platform/cilium/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-cilium
-version: 1.2.0
+version: 1.2.1
 description: |
   Catalyst-curated Blueprint umbrella chart for Cilium. Depends on the
   upstream `cilium` chart as a Helm subchart so `helm dependency build`
@@ -32,5 +32,11 @@ maintainers:
 # nodeEncryption — all unchanged.
 dependencies:
   - name: cilium
-    version: "1.19.3"
+    # Pinned to match Chart.lock (truth-on-disk). The previous "1.19.3"
+    # value was provenance drift caught in EPIC-0 #1095 audit — Chart.lock
+    # had been resolving to 1.16.5 the whole time. Aligning the declared
+    # constraint with the locked version eliminates the lie. Bumping to a
+    # newer Cilium minor is a separate slice that needs real upgrade
+    # testing on a live data-plane cluster.
+    version: "1.16.5"
     repository: "https://helm.cilium.io"

--- a/platform/cilium/chart/values.yaml
+++ b/platform/cilium/chart/values.yaml
@@ -19,7 +19,10 @@ global:
   imageRegistry: ""
 
 catalystBlueprint:
-  upstream: { chart: cilium, version: "1.19.3", repo: "https://helm.cilium.io" }
+  # Pinned to match Chart.lock (truth-on-disk). Aligned with Chart.yaml's
+  # dependencies version. The previous "1.19.3" was provenance drift —
+  # Chart.lock had been resolving 1.16.5 the whole time (EPIC-0 #1095 audit).
+  upstream: { chart: cilium, version: "1.16.5", repo: "https://helm.cilium.io" }
 
 # Catalyst-curated Cilium values per platform/cilium/README.md.
 #


### PR DESCRIPTION
## Summary

Slice **H1** of EPIC-0 (#1095). Pure metadata fix.

## Why

Audit found provenance drift:

| File | Declared | Reality |
|---|---|---|
| \`Chart.yaml\` dependencies | 1.19.3 | — |
| \`values.yaml\` catalystBlueprint.upstream.version | 1.19.3 | — |
| \`Chart.lock\` | — | **1.16.5** |

The declared "1.19.3" was never installed anywhere — every Sovereign has been running Cilium 1.16.5 the whole time. Aligning the declared values to truth-on-disk eliminates the lie.

## What this is NOT

This is **not** an upstream Cilium upgrade. Rolling forward to 1.17.x or 1.18.x is a separate slice that needs:
- k3s \`--flannel-backend=none\` + \`--disable-network-policy\` compat verification
- Gateway API CRD compat verification
- WireGuard transparent mTLS config check
- Live data-plane cluster upgrade test

## Test plan

- [x] \`helm dependency build\` re-resolves cleanly to 1.16.5
- [x] Chart.lock unchanged (already had 1.16.5)
- [x] Chart version bump 1.2.0 → 1.2.1 (patch — metadata only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)