### PR TITLE
feat(bp-cilium): add Hubble UI HTTPRoute overlay (slice H7, #1095)

### DIFF
--- a/platform/cilium/blueprint.yaml
+++ b/platform/cilium/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/category: per-host-cluster-infrastructure
     catalyst.openova.io/section: pts-3-1-networking-and-service-mesh
 spec:
-  version: 1.2.1
+  version: 1.3.0
   card:
     title: Cilium
     summary: Unified CNI + Service Mesh (eBPF). mTLS via WireGuard, Hubble observability, Gateway API.

--- a/platform/cilium/chart/Chart.yaml
+++ b/platform/cilium/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-cilium
-version: 1.2.1
+version: 1.3.0
 description: |
   Catalyst-curated Blueprint umbrella chart for Cilium. Depends on the
   upstream `cilium` chart as a Helm subchart so `helm dependency build`

--- a/platform/cilium/chart/templates/hubble-ui-httproute.yaml
+++ b/platform/cilium/chart/templates/hubble-ui-httproute.yaml
@@ -1,0 +1,49 @@
+{{/*
+Hubble UI HTTPRoute — exposes the Cilium-managed Hubble UI Service via
+the Sovereign's Cilium Gateway with the wildcard cert from
+clusters/_template/sovereign-tls/.
+
+Default-OFF: the gate `.Values.catalystOverlay.hubbleUI.enabled` is
+false in the chart values. Operator opts in per Sovereign once:
+  1. cilium.hubble.relay.enabled = true   (in same overlay)
+  2. cilium.hubble.ui.enabled    = true   (in same overlay)
+  3. Keycloak realm has a `hubble-ui` OIDC client (slice D1)
+  4. catalystOverlay.hubbleUI.hostname is set to a hostname under the
+     Sovereign domain.
+
+Per docs/EPICS-1-6-unified-design.md §3.9 row 7 + §8 (EPIC-5).
+
+The OIDC enforcement at the gateway boundary is NOT yet wired here —
+Cilium's L7 OIDC filter is the target (configured via CiliumEnvoyConfig
+or HTTPRoute filter once bp-keycloak ships the realm). For Phase-0 this
+template gives EPIC-5 the seam to extend; today the route forwards
+unauthenticated, so flipping the gate without the OIDC layer leaves
+Hubble UI publicly accessible — DO NOT enable in production until EPIC-5
+delivers the OIDC enforcement.
+*/}}
+{{- if and .Values.catalystOverlay.hubbleUI.enabled .Values.catalystOverlay.hubbleUI.hostname -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: hubble-ui
+  namespace: {{ .Values.catalystOverlay.hubbleUI.serviceRef.namespace | quote }}
+  labels:
+    app.kubernetes.io/name: bp-cilium
+    app.kubernetes.io/component: hubble-ui-overlay
+    catalyst.openova.io/blueprint: bp-cilium
+    catalyst.openova.io/blueprint-version: {{ .Chart.Version | quote }}
+spec:
+  parentRefs:
+    - name: {{ .Values.catalystOverlay.hubbleUI.gatewayRef.name | quote }}
+      namespace: {{ .Values.catalystOverlay.hubbleUI.gatewayRef.namespace | quote }}
+  hostnames:
+    - {{ .Values.catalystOverlay.hubbleUI.hostname | quote }}
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: {{ .Values.catalystOverlay.hubbleUI.serviceRef.name | quote }}
+          port: {{ .Values.catalystOverlay.hubbleUI.serviceRef.port }}
+{{- end -}}

--- a/platform/cilium/chart/values.yaml
+++ b/platform/cilium/chart/values.yaml
@@ -98,6 +98,9 @@ cilium:
   hubble:
     enabled: true
     relay:
+      # Default false — every Sovereign in production runs without the relay.
+      # EPIC-5 (#1100) flips this on per-Sovereign via clusters/<sov>/bootstrap-kit/01-cilium.yaml
+      # values overlay alongside the catalystOverlay.hubbleUI block below.
       enabled: false
     ui:
       enabled: false
@@ -179,3 +182,45 @@ cilium:
     enabled: false
     serviceMonitor:
       enabled: false
+
+# ─── Catalyst overlay templates (chart/templates/) ─────────────────────
+#
+# Templates that ride alongside the upstream cilium subchart. Every block
+# is gated by an explicit `enabled: false` so installing the chart never
+# regresses production behaviour — operator opts in via per-Sovereign
+# overlay at clusters/<sov>/bootstrap-kit/01-cilium.yaml.
+
+catalystOverlay:
+  # Hubble UI exposed via Cilium Gateway with Keycloak OIDC. Activated
+  # by EPIC-5 (#1100) as part of the zero-trust observability roll-out.
+  #
+  # Prerequisite to enable:
+  #   1. cilium.hubble.relay.enabled = true
+  #   2. cilium.hubble.ui.enabled    = true
+  #   3. Keycloak realm has a `hubble-ui` OIDC client (ConfigMap
+  #      configmap-sovereign-realm.yaml in bp-keycloak — wired by
+  #      slice D1).
+  #   4. Cilium Gateway exists with the wildcard cert (every Sovereign
+  #      has this from clusters/_template/sovereign-tls/).
+  hubbleUI:
+    enabled: false
+    # Hostname under the Sovereign domain. Per docs/NAMING-CONVENTION.md
+    # §5.1 the canonical form is `{component}.{location-code}.{sovereign-domain}`,
+    # but operators MAY pick a flat `hubble.{sovereign-domain}` for SME
+    # Sovereigns where the location-code prefix is not yet wired. Empty
+    # = no HTTPRoute rendered.
+    hostname: ""
+    # Reference to the Cilium Gateway that fronts this Sovereign's wildcard
+    # cert. Defaults match clusters/_template/sovereign-tls/cilium-gateway.yaml.
+    gatewayRef:
+      name: cilium-gateway
+      namespace: cilium-gateway
+    # Authentication mode at the gateway boundary. `oidc` requires the
+    # Keycloak realm to have an `hubble-ui` client (slice D1). `none` is
+    # only acceptable for fully air-gapped lab Sovereigns.
+    auth: oidc
+    # Hubble UI Service ref in the cilium namespace.
+    serviceRef:
+      name: hubble-ui
+      namespace: cilium
+      port: 80


### PR DESCRIPTION
## Summary

Slice **H7** of EPIC-0 (#1095). Default-OFF scaffold for Hubble UI exposed via Cilium Gateway with OIDC.

## What ships

- \`platform/cilium/chart/templates/hubble-ui-httproute.yaml\` — HTTPRoute parented to \`cilium-gateway\` with backendRef to \`hubble-ui\` Service. Gated by \`catalystOverlay.hubbleUI.{enabled,hostname}\` — both must be set or no resource renders.
- \`platform/cilium/chart/values.yaml\` new \`catalystOverlay:\` block with hubbleUI sub-tree (gatewayRef, serviceRef, auth=oidc, hostname). Every parameter operator-overrideable per INVIOLABLE-PRINCIPLES #4.

## Why default-OFF

1. Hubble relay/UI in production today are off (issue #182 — bp-kube-prometheus-stack ServiceMonitor CRD chicken-and-egg).
2. **OIDC enforcement at the gateway boundary is the missing piece** — Cilium's L7 OIDC filter wires to bp-keycloak's \`hubble-ui\` client which lands in slice D1.
3. Flipping the gate without OIDC would leave Hubble UI publicly accessible. Comments in the template explicitly warn against this.

EPIC-5 (#1100) flips it on per Sovereign once the zero-trust observability tier is ready (Hubble relay + bp-kube-prometheus-stack + OIDC client + DNS + cert all in place).

## Test plan

- [x] \`helm template\` with default values: **0** HTTPRoute resources rendered (gate works)
- [x] \`helm template\` with \`catalystOverlay.hubbleUI.enabled=true\` + hostname: **1** HTTPRoute rendered
- [x] No regression to existing 34-resource render count in default mode

## Out of scope

- OIDC enforcement filter (CiliumEnvoyConfig + Keycloak hubble-ui client) — slice D1 + EPIC-5
- Hubble metrics ServiceMonitor wiring — issue #182, not this slice
- Per-Sovereign DNS A-record for the hubble.<sovereign> hostname — bp-external-dns picks it up automatically once HTTPRoute exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)