### PR TITLE
feat(auth): parse groups + realm_access.roles + RBAC custom claims (slice D2, #1095)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/auth/session.go
+++ b/products/catalyst/bootstrap/api/internal/auth/session.go
@@ -26,6 +26,21 @@ const (
 	sessionCookieDuration = 4 * time.Hour
 )
 
+// RealmAccess mirrors the Keycloak `realm_access` claim — list of realm
+// roles the bearer holds (e.g. `catalyst-admin`, `viewer`). Used by
+// useraccess-controller (slice C5 of #1095) to materialize per-cluster
+// RoleBindings.
+type RealmAccess struct {
+	Roles []string `json:"roles,omitempty"`
+}
+
+// ResourceAccess mirrors the Keycloak `resource_access` claim — map of
+// OIDC client name → roles assigned to the bearer for that client.
+// Used to express per-client (per-Application) role grants.
+type ResourceAccess map[string]struct {
+	Roles []string `json:"roles,omitempty"`
+}
+
 // Claims represents the parsed claims from a Keycloak-issued ID/access token.
 type Claims struct {
 	Sub           string `json:"sub"`
@@ -44,6 +59,82 @@ type Claims struct {
 	// Sovereign Console reads this via /api/v1/sovereign/self so
 	// useResolvedDeploymentId never returns empty post-handover.
 	DeploymentID string `json:"deployment_id"`
+
+	// ── RBAC claims (slice D2 of #1095, EPIC-3 #1098 consumer) ─────────
+	//
+	// These fields carry the authorization context Keycloak emits on
+	// every access token. Parsed but not enforced in catalyst-api
+	// itself — the useraccess-controller (slice C5) and the per-handler
+	// @RequireResourceAccess decorator (slice D2 follow-up) consume them.
+	//
+	// All omitempty so existing tokens (without these claims) parse
+	// cleanly without zero-valued slices polluting downstream JSON.
+
+	// Groups carries the Keycloak `groups` claim — full group paths
+	// (e.g. "/acme/admins", "/openova-internal/sre"). Mapped to
+	// Organizations + tier via the configured Keycloak group mapper.
+	Groups []string `json:"groups,omitempty"`
+
+	// RealmAccess carries the Keycloak realm-role list. Mapped to the
+	// 5 catalog tiers (viewer/developer/operator/admin/owner) per
+	// docs/EPICS-1-6-unified-design.md §6.2.
+	RealmAccess RealmAccess `json:"realm_access,omitempty"`
+
+	// ResourceAccess carries per-OIDC-client role assignments. Used for
+	// per-Application role grants where a customer Org has its own OIDC
+	// client (corporate Sovereign federation pattern).
+	ResourceAccess ResourceAccess `json:"resource_access,omitempty"`
+
+	// Org is a custom Keycloak claim populated by the realm's group-to-
+	// attribute mapper. Set to the Organization slug (e.g. "acme") so
+	// catalyst-api handlers can scope queries without re-parsing groups.
+	Org string `json:"org,omitempty"`
+
+	// Tier is a custom Keycloak claim that flattens RealmAccess.Roles
+	// to the highest-precedence catalog tier (viewer < developer <
+	// operator < admin < owner). Computed by the Keycloak protocol
+	// mapper at token-mint time. Empty when no tier role is assigned.
+	Tier string `json:"tier,omitempty"`
+
+	// Scopes carries label-based scope tags per the Manara model
+	// (docs/EPICS-1-6-unified-design.md §6.3). Each entry is a
+	// `key=value` label expression (e.g. "application=wordpress",
+	// "env-type=dev"). Populated by the Keycloak group-attribute
+	// mapper that flattens UserAccess CR scopes into the access token.
+	Scopes []string `json:"openova_scopes,omitempty"`
+}
+
+// HasRealmRole returns true if the bearer holds the given Keycloak
+// realm role. Convenience helper for handler authorization checks
+// before useraccess-controller wires the full label-based scope
+// matching (slice C5 of #1095).
+func (c *Claims) HasRealmRole(role string) bool {
+	if c == nil {
+		return false
+	}
+	for _, r := range c.RealmAccess.Roles {
+		if r == role {
+			return true
+		}
+	}
+	return false
+}
+
+// HasGroup returns true if the bearer's group list contains the given
+// path. Both `/acme/admins` and `acme/admins` (leading slash optional)
+// are accepted to absorb the Keycloak group-path convention difference
+// between v22 and v24.
+func (c *Claims) HasGroup(path string) bool {
+	if c == nil {
+		return false
+	}
+	want := strings.TrimPrefix(path, "/")
+	for _, g := range c.Groups {
+		if strings.TrimPrefix(g, "/") == want {
+			return true
+		}
+	}
+	return false
 }
 
 // Config holds the runtime configuration for the auth package.

--- a/products/catalyst/bootstrap/api/internal/auth/session_test.go
+++ b/products/catalyst/bootstrap/api/internal/auth/session_test.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"encoding/base64"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -144,4 +145,104 @@ func TestReadSessionToken_QueryParamWhitespace(t *testing.T) {
 	if got := cfg.ReadSessionToken(r2); got != "" {
 		t.Fatalf("expected empty for whitespace-only token, got %q", got)
 	}
+}
+
+// ── RBAC field tests (slice D2 of #1095) ────────────────────────────────
+
+func TestParseJWTClaims_LegacyTokenStillParses(t *testing.T) {
+	// A token without any of the new RBAC claims must continue to parse —
+	// every existing Catalyst-Zero session falls in this bucket.
+	payload := `{"sub":"u-1","email":"a@b.com","email_verified":true,"preferred_username":"a","sovereign_fqdn":"omantel.omani.works","deployment_id":"dep-x"}`
+	tok := makeJWT(t, payload)
+	c, err := parseJWTClaims(tok)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if c.Email != "a@b.com" || c.SovereignFQDN != "omantel.omani.works" {
+		t.Fatalf("unexpected legacy parse: %+v", c)
+	}
+	if len(c.Groups) != 0 || len(c.RealmAccess.Roles) != 0 || c.Org != "" || c.Tier != "" || len(c.Scopes) != 0 {
+		t.Fatalf("legacy token populated RBAC fields: %+v", c)
+	}
+}
+
+func TestParseJWTClaims_RBACFields(t *testing.T) {
+	// A token with the full Keycloak shape: groups, realm_access.roles,
+	// resource_access.<client>.roles, plus the Catalyst custom claims
+	// (org, tier, openova_scopes).
+	payload := `{
+		"sub":"u-2",
+		"email":"ops@acme.com",
+		"email_verified":true,
+		"preferred_username":"ops",
+		"groups":["/acme/admins","/openova-internal/sre"],
+		"realm_access":{"roles":["catalyst-admin","viewer"]},
+		"resource_access":{"hubble-ui":{"roles":["read"]},"catalyst-ui":{"roles":["operator"]}},
+		"org":"acme",
+		"tier":"admin",
+		"openova_scopes":["application=wordpress","env-type=dev"]
+	}`
+	tok := makeJWT(t, payload)
+	c, err := parseJWTClaims(tok)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if c.Org != "acme" || c.Tier != "admin" {
+		t.Fatalf("custom claims: %+v", c)
+	}
+	if len(c.Groups) != 2 || c.Groups[0] != "/acme/admins" {
+		t.Fatalf("groups: %+v", c.Groups)
+	}
+	if len(c.RealmAccess.Roles) != 2 || c.RealmAccess.Roles[0] != "catalyst-admin" {
+		t.Fatalf("realm roles: %+v", c.RealmAccess.Roles)
+	}
+	if got := c.ResourceAccess["catalyst-ui"].Roles; len(got) != 1 || got[0] != "operator" {
+		t.Fatalf("resource access: %+v", c.ResourceAccess)
+	}
+	if len(c.Scopes) != 2 || c.Scopes[0] != "application=wordpress" {
+		t.Fatalf("scopes: %+v", c.Scopes)
+	}
+}
+
+func TestClaims_HasRealmRole(t *testing.T) {
+	c := &Claims{RealmAccess: RealmAccess{Roles: []string{"viewer", "developer"}}}
+	if !c.HasRealmRole("developer") {
+		t.Fatal("should match developer")
+	}
+	if c.HasRealmRole("admin") {
+		t.Fatal("should not match admin")
+	}
+	if (*Claims)(nil).HasRealmRole("viewer") {
+		t.Fatal("nil receiver should return false, not panic")
+	}
+}
+
+func TestClaims_HasGroup_LeadingSlashTolerant(t *testing.T) {
+	// Keycloak v22 emits "acme/admins"; v24 emits "/acme/admins". The
+	// helper must accept both equally so a Keycloak version bump doesn't
+	// silently break authorization.
+	c := &Claims{Groups: []string{"/acme/admins", "openova-internal/sre"}}
+	if !c.HasGroup("/acme/admins") {
+		t.Fatal("with-leading-slash query should match with-leading-slash group")
+	}
+	if !c.HasGroup("acme/admins") {
+		t.Fatal("no-leading-slash query should match with-leading-slash group")
+	}
+	if !c.HasGroup("/openova-internal/sre") {
+		t.Fatal("with-leading-slash query should match no-leading-slash group")
+	}
+	if c.HasGroup("/acme/devs") {
+		t.Fatal("non-member should not match")
+	}
+}
+
+// makeJWT crafts a JWT-shaped string with `header.payload.sig`. The
+// signature is a placeholder — parseJWTClaims doesn't verify, it just
+// base64-decodes the payload.
+func makeJWT(t *testing.T, payload string) string {
+	t.Helper()
+	h := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"RS256","typ":"JWT"}`))
+	p := base64.RawURLEncoding.EncodeToString([]byte(payload))
+	s := base64.RawURLEncoding.EncodeToString([]byte("sig"))
+	return h + "." + p + "." + s
 }


### PR DESCRIPTION
## Summary

Slice **D2** of EPIC-0 (#1095). Extends \`auth/Claims\` to absorb the Keycloak RBAC claims that every access token already carries but every handler had to re-parse.

## What ships

| Field | Source | Use |
|---|---|---|
| \`Groups []string\` | \`groups\` claim | Full Keycloak group paths |
| \`RealmAccess.Roles []string\` | \`realm_access.roles\` | Catalog tier mapping (viewer/dev/op/admin/owner) |
| \`ResourceAccess map[client]{Roles []}\` | \`resource_access.<client>.roles\` | Per-OIDC-client role grants |
| \`Org string\` | \`org\` (Catalyst custom) | Organization slug, flattened from group hierarchy |
| \`Tier string\` | \`tier\` (Catalyst custom) | Highest-precedence catalog tier |
| \`Scopes []string\` | \`openova_scopes\` (Catalyst custom) | Label-based scope tags per Manara model |

All \`omitempty\` — legacy tokens parse cleanly.

## Helpers

- \`Claims.HasRealmRole(role string) bool\`
- \`Claims.HasGroup(path string) bool\` — leading-slash-tolerant so a Keycloak v22 → v24 bump doesn't silently break authorization checks.

## Why no middleware change yet

The useraccess-controller (slice C5) and the \`@RequireResourceAccess\` decorator (D2 follow-up) are the consumers. This slice only ensures the data is available; enforcement is in EPIC-3 (#1098).

## Test plan

- [x] \`TestParseJWTClaims_LegacyTokenStillParses\` — regression guard for existing sessions
- [x] \`TestParseJWTClaims_RBACFields\` — full Keycloak shape with groups + realm_access + resource_access + 3 custom claims
- [x] \`TestClaims_HasRealmRole\` — including nil-receiver no-panic
- [x] \`TestClaims_HasGroup_LeadingSlashTolerant\` — both Keycloak path conventions
- [x] \`go test ./internal/auth/...\` — all pass
- [x] \`go build ./... && go vet ./...\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)