### PR TITLE
feat(bp-opentelemetry-operator): scaffold operator + default Instrumentation CR (slice H5, #1095)

### DIFF
--- a/platform/opentelemetry-operator/README.md
+++ b/platform/opentelemetry-operator/README.md
@@ -1,0 +1,68 @@
+# bp-opentelemetry-operator
+
+**Status**: Phase-0 scaffold (#1095 slice H5). Activated by EPIC-5 (#1100).
+**Updated**: 2026-05-08
+
+The OpenTelemetry Operator. Provides the `Instrumentation` CRD that
+auto-injects OTel SDK sidecars into Pods based on annotations:
+
+```yaml
+metadata:
+  annotations:
+    instrumentation.opentelemetry.io/inject-java: "true"
+    # or inject-dotnet / inject-nodejs / inject-python
+```
+
+When the annotation is set, the operator's mutating admission webhook
+adds an init container that copies the OTel SDK into a shared volume and
+edits the main container's env vars (`OTEL_EXPORTER_OTLP_ENDPOINT`,
+`OTEL_RESOURCE_ATTRIBUTES`, `OTEL_TRACES_EXPORTER`, etc.) to point at the
+collector deployed by `bp-opentelemetry`.
+
+This Blueprint is **separate from** `bp-opentelemetry`. The latter is the
+collector (DaemonSet/Deployment scraping + forwarding to Tempo/Loki/Mimir);
+this one is the operator that injects per-Pod instrumentation. Two
+distinct upgrade cycles, two distinct opt-ins.
+
+## What it ships
+
+| Template | Effect |
+|---|---|
+| Upstream `opentelemetry-operator` Helm subchart | The operator Pod + Instrumentation CRD. |
+| `instrumentation-default.yaml` | A default `Instrumentation` CR named `default` in each Org namespace. Operator + per-Org overlays opt in to Java/.NET/Node/Python auto-injection. |
+
+## Activation contract
+
+```yaml
+# values.yaml override (or per-Sovereign overlay)
+enabled: true
+defaultInstrumentation:
+  enabled: true
+  # Where the auto-injected SDK ships traces/logs/metrics. The collector
+  # Service is created by bp-opentelemetry; this references it.
+  exporter:
+    endpoint: http://opentelemetry-collector.monitoring.svc:4317
+  java: { enabled: true, image: "ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-java:latest" }
+  nodejs: { enabled: true }
+  python: { enabled: true }
+  dotnet: { enabled: false }
+```
+
+When `enabled: false` (the default), no resources render — installing
+this chart is a no-op until the operator opts in.
+
+## Why default-OFF
+
+1. The Operator's mutating admission webhook intercepts every Pod creation
+   in the cluster. A misconfigured CR can break workloads cluster-wide.
+2. The Instrumentation CR ties traces to a collector endpoint —
+   `bp-opentelemetry` (collector) must be reconciled FIRST and reachable
+   on the configured Service URL.
+3. EPIC-5 (#1100) sequences both: collector first, exporters wired
+   (Tempo/Loki/Mimir), then operator + Instrumentation CR.
+
+## References
+
+- docs/EPICS-1-6-unified-design.md §3.9 row 5 + §8.4 (EPIC-5)
+- platform/opentelemetry/README.md — the collector
+- Upstream: https://github.com/open-telemetry/opentelemetry-operator

--- a/platform/opentelemetry-operator/blueprint.yaml
+++ b/platform/opentelemetry-operator/blueprint.yaml
@@ -1,0 +1,67 @@
+apiVersion: catalyst.openova.io/v1
+kind: Blueprint
+metadata:
+  name: bp-opentelemetry-operator
+  labels:
+    catalyst.openova.io/section: pts-3-2-observability-and-tracing
+spec:
+  version: 1.0.0
+  card:
+    title: OpenTelemetry Operator
+    summary: |
+      Auto-injection of OTel SDK sidecars into Pods via Instrumentation
+      CRs. Companion to bp-opentelemetry (the collector). Activated by
+      EPIC-5 (#1100).
+    family: observability
+    documentation: ./README.md
+  visibility: unlisted
+  owner:
+    team: platform
+    contact: platform@openova.io
+  configSchema:
+    type: object
+    properties:
+      enabled:
+        type: boolean
+        default: false
+        description: Master gate. Default off — installing this Blueprint is a no-op until flipped.
+      defaultInstrumentation:
+        type: object
+        description: Default Instrumentation CR rendered into every Org namespace.
+        properties:
+          enabled:
+            type: boolean
+            default: false
+          exporterEndpoint:
+            type: string
+            description: OTLP gRPC endpoint of the collector. Default points at bp-opentelemetry's Service.
+          java:
+            type: object
+            properties:
+              enabled: { type: boolean, default: true }
+          nodejs:
+            type: object
+            properties:
+              enabled: { type: boolean, default: true }
+          python:
+            type: object
+            properties:
+              enabled: { type: boolean, default: true }
+          dotnet:
+            type: object
+            properties:
+              enabled: { type: boolean, default: false }
+  placementSchema:
+    modes: [single-region, active-active]
+    default: active-active
+    minRegions: 1
+    maxRegions: 5
+  manifests:
+    chart: ./chart
+  depends:
+    - blueprint: bp-opentelemetry
+      version: ^1
+    - blueprint: bp-cert-manager
+      version: ^1
+  upgrades:
+    from: ["0.x"]

--- a/platform/opentelemetry-operator/chart/Chart.yaml
+++ b/platform/opentelemetry-operator/chart/Chart.yaml
@@ -1,0 +1,20 @@
+apiVersion: v2
+name: bp-opentelemetry-operator
+version: 1.0.0
+description: |
+  Catalyst-curated Blueprint umbrella chart for the OpenTelemetry
+  Operator. Wraps the upstream open-telemetry/opentelemetry-helm-charts
+  `opentelemetry-operator` chart and ships the default Instrumentation CR.
+  Default off — operator opts in deliberately per-Sovereign per
+  docs/INVIOLABLE-PRINCIPLES.md #4.
+type: application
+keywords: [catalyst, blueprint, opentelemetry, observability, instrumentation]
+maintainers:
+  - name: OpenOva Catalyst
+    email: catalyst@openova.io
+
+dependencies:
+  - name: opentelemetry-operator
+    version: "0.61.0"
+    repository: "https://open-telemetry.github.io/opentelemetry-helm-charts"
+    condition: enabled

--- a/platform/opentelemetry-operator/chart/templates/instrumentation-default.yaml
+++ b/platform/opentelemetry-operator/chart/templates/instrumentation-default.yaml
@@ -1,0 +1,52 @@
+{{/*
+Default Instrumentation CR. When enabled, Pods in the configured namespace
+opt-in to per-language auto-injection via these annotations:
+
+  instrumentation.opentelemetry.io/inject-java:    "default"
+  instrumentation.opentelemetry.io/inject-nodejs:  "default"
+  instrumentation.opentelemetry.io/inject-python:  "default"
+  instrumentation.opentelemetry.io/inject-dotnet:  "default"
+
+Where "default" is the name of THIS Instrumentation CR.
+
+Default OFF (.Values.defaultInstrumentation.enabled). The CRD itself is
+installed by the upstream operator subchart; the operator runs without
+this CR and only mutates Pods that opt in via annotation, so an empty
+Instrumentation set is a safe baseline.
+
+Per docs/EPICS-1-6-unified-design.md §3.9 row 5 + §8.4 (EPIC-5).
+*/}}
+{{- if and .Values.enabled .Values.defaultInstrumentation.enabled -}}
+apiVersion: opentelemetry.io/v1alpha1
+kind: Instrumentation
+metadata:
+  name: {{ .Values.defaultInstrumentation.name | quote }}
+  namespace: {{ .Values.defaultInstrumentation.namespace | quote }}
+  labels:
+    app.kubernetes.io/name: bp-opentelemetry-operator
+    app.kubernetes.io/component: instrumentation-default
+    catalyst.openova.io/blueprint: bp-opentelemetry-operator
+    catalyst.openova.io/blueprint-version: {{ .Chart.Version | quote }}
+spec:
+  exporter:
+    endpoint: {{ .Values.defaultInstrumentation.exporterEndpoint | quote }}
+  propagators:
+    - tracecontext
+    - baggage
+    - b3
+  sampler:
+    type: {{ .Values.defaultInstrumentation.sampler.type | quote }}
+    argument: {{ .Values.defaultInstrumentation.sampler.argument | quote }}
+{{- if .Values.defaultInstrumentation.java.enabled }}
+  java: {}
+{{- end }}
+{{- if .Values.defaultInstrumentation.nodejs.enabled }}
+  nodejs: {}
+{{- end }}
+{{- if .Values.defaultInstrumentation.python.enabled }}
+  python: {}
+{{- end }}
+{{- if .Values.defaultInstrumentation.dotnet.enabled }}
+  dotnet: {}
+{{- end }}
+{{- end -}}

--- a/platform/opentelemetry-operator/chart/values.yaml
+++ b/platform/opentelemetry-operator/chart/values.yaml
@@ -1,0 +1,59 @@
+# Master gate. Default off — installing this Blueprint is a no-op until
+# flipped. EPIC-5 (#1100) flips it as part of the observability roll-out
+# AFTER bp-opentelemetry (the collector) is reconciled and reachable.
+enabled: false
+
+catalystBlueprint:
+  upstream: { chart: opentelemetry-operator, version: "0.61.0", repo: "https://open-telemetry.github.io/opentelemetry-helm-charts" }
+
+# Default Instrumentation CR rendered when enabled. The CR is created in
+# the namespace .Values.defaultInstrumentation.namespace (default cilium).
+# Per-Application overrides live in per-namespace Instrumentation CRs that
+# application-controller (slice C4 of #1095) renders from
+# Blueprint.spec.observability.traces=otlp.
+defaultInstrumentation:
+  enabled: false
+  namespace: cilium
+  name: default
+  # OTLP gRPC endpoint of the collector. Default targets bp-opentelemetry's
+  # Service (created by the upstream collector chart in the monitoring
+  # namespace).
+  exporterEndpoint: "http://opentelemetry-collector.monitoring.svc:4317"
+  # Sampler — parentbased_traceidratio is the bank-tier default. Operator
+  # tunes per-Sovereign.
+  sampler:
+    type: "parentbased_traceidratio"
+    argument: "0.25"
+  # Per-language toggles. Each populates the corresponding section of
+  # the Instrumentation spec — disabled languages won't auto-inject when
+  # an annotation requests them.
+  java:
+    enabled: true
+  nodejs:
+    enabled: true
+  python:
+    enabled: true
+  dotnet:
+    enabled: false
+
+# ─── Upstream subchart values (subchart key: opentelemetry-operator) ──
+opentelemetry-operator:
+  manager:
+    # The upstream chart REQUIRES manager.collectorImage.repository to
+    # be set (the operator needs to know which collector image to deploy
+    # when an OpenTelemetryCollector CR is created without an explicit
+    # image). Pin to the upstream contrib distribution; operators bump
+    # via overlay per docs/INVIOLABLE-PRINCIPLES.md #4.
+    collectorImage:
+      repository: "otel/opentelemetry-collector-contrib"
+    # cert-manager is the canonical webhook cert provider (bp-cert-manager
+    # is in every Sovereign's bootstrap-kit). Operator uses
+    # cert-manager-issued cert for its admission webhook.
+    serviceAccount:
+      create: true
+    resources:
+      requests: { cpu: 50m, memory: 64Mi }
+      limits: { memory: 256Mi }
+  admissionWebhooks:
+    certManager:
+      enabled: true


### PR DESCRIPTION
## Summary

Slice **H5** of EPIC-0 (#1095). New \`platform/opentelemetry-operator/\` Blueprint scaffold. Companion to \`bp-opentelemetry\` (the collector) — this Blueprint ships the OTel Operator that auto-injects OTel SDK sidecars into Pods based on annotations.

## Why a separate Blueprint from bp-opentelemetry

Two distinct upgrade cycles, two distinct scopes:
- **bp-opentelemetry** — collector DaemonSet/Deployment scraping + forwarding to Tempo/Loki/Mimir
- **bp-opentelemetry-operator** — mutating admission webhook that injects per-Pod auto-instrumentation

Mixing them couples observability cadence to auto-instrumentation cadence, and the operator's webhook intercepts every Pod creation cluster-wide so misconfiguration is high-blast-radius.

## Default-OFF (two layers)

1. \`.Values.enabled: false\` → upstream subchart's \`condition: enabled\` fires, 0 resources rendered
2. Even with \`enabled=true\`, the Catalyst Instrumentation CR is gated by \`defaultInstrumentation.enabled=false\` — installing the chart doesn't auto-inject anywhere by default

## Test plan

- [x] \`helm dependency build\` pulls upstream cleanly
- [x] \`helm template\` with default values: **0** resources rendered
- [x] \`helm template\` with \`enabled=true defaultInstrumentation.enabled=true\`: **22** resources (upstream operator manager Deployment, CRDs, RBAC, mutating+validating webhooks, cert-manager Issuer+Certificate, plus the Catalyst Instrumentation CR)
- [x] All parameters in values.yaml per INVIOLABLE-PRINCIPLES #4

## Sampler defaults

\`parentbased_traceidratio\` @ 0.25 (bank-tier default — operator tunes per Sovereign). Propagators: tracecontext + baggage + b3.

## Out of scope

- Add to bootstrap-kit — EPIC-5 (#1100) sequences both Blueprints
- Per-Application Instrumentation CRs from \`Blueprint.spec.observability.traces=otlp\` — slice C4 application-controller renders those

🤖 Generated with [Claude Code](https://claude.com/claude-code)