### PR TITLE
feat(keycloak): add realm-role + role-mapping CRUD (slice D1b, #1095)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/keycloak/admin_roles.go
+++ b/products/catalyst/bootstrap/api/internal/keycloak/admin_roles.go
@@ -1,0 +1,454 @@
+package keycloak
+
+// admin_roles.go — Keycloak realm-role + role-mapping CRUD.
+//
+// Slice D1b of EPIC-0 #1095. useraccess-controller (slice C5) calls
+// these to materialize the 5 catalog tier roles (viewer / developer /
+// operator / admin / owner) per Sovereign realm at startup, and to
+// bind realm roles to per-Organization Keycloak groups so a user's
+// `groups` claim resolves to the catalog tier via Keycloak's group→role
+// inheritance.
+//
+// Endpoints used (Keycloak Admin REST API, version 24.x):
+//
+//   Realm roles:
+//   GET    /admin/realms/{realm}/roles
+//   GET    /admin/realms/{realm}/roles/{role-name}
+//   POST   /admin/realms/{realm}/roles
+//   PUT    /admin/realms/{realm}/roles/{role-name}
+//   DELETE /admin/realms/{realm}/roles/{role-name}
+//
+//   User role-mappings:
+//   GET    /admin/realms/{realm}/users/{user-uuid}/role-mappings/realm
+//   POST   /admin/realms/{realm}/users/{user-uuid}/role-mappings/realm
+//   DELETE /admin/realms/{realm}/users/{user-uuid}/role-mappings/realm
+//
+//   Group role-mappings:
+//   GET    /admin/realms/{realm}/groups/{group-uuid}/role-mappings/realm
+//   POST   /admin/realms/{realm}/groups/{group-uuid}/role-mappings/realm
+//   DELETE /admin/realms/{realm}/groups/{group-uuid}/role-mappings/realm
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+)
+
+// ErrRoleNotFound is returned by GetRealmRole / DeleteRealmRole when
+// the role name does not resolve. Mirrors ErrClientNotFound.
+var ErrRoleNotFound = errors.New("keycloak: realm role not found")
+
+// errRoleAlreadyExists is the internal sentinel for the 409 path on
+// CreateRealmRole. EnsureRealmRole catches it and re-finds.
+var errRoleAlreadyExists = errors.New("keycloak: realm role already exists")
+
+// RealmRole is the slice of fields catalyst-api consumes/sets when
+// reconciling the catalog tier roles. Mirrors the upstream
+// RoleRepresentation but only with the fields useraccess-controller
+// needs.
+type RealmRole struct {
+	// ID is the Keycloak-internal UUID. Empty before CreateRealmRole.
+	ID string `json:"id,omitempty"`
+
+	// Name is the role name (e.g. "catalyst-admin", "catalyst-developer").
+	// Catalyst's convention is to prefix with `catalyst-` so realm-role
+	// lookup is unambiguous when other Keycloak features create their
+	// own (e.g. "uma_authorization", "default-roles-sovereign").
+	Name string `json:"name"`
+
+	// Description is free-form prose for the Keycloak admin UI.
+	Description string `json:"description,omitempty"`
+
+	// Composite = true means this role inherits from one or more other
+	// realm roles. Catalyst tier hierarchy uses this: `developer`
+	// composes `viewer`, `operator` composes `developer`, etc. so a
+	// user assigned `admin` automatically gets `developer` and
+	// `viewer` access via Keycloak's role-mapping resolver.
+	Composite bool `json:"composite,omitempty"`
+
+	// ClientRole = false for realm roles. Catalyst stays at realm scope
+	// for the 5 tier roles; per-OIDC-client roles are a future tier.
+	ClientRole bool `json:"clientRole,omitempty"`
+
+	// ContainerID is the realm UUID for realm roles. Keycloak populates
+	// this on read; we never set it on write.
+	ContainerID string `json:"containerId,omitempty"`
+
+	// Attributes is a map of role attributes (Keycloak v24+). Catalyst
+	// uses the `tier-level` attribute to encode the integer ordering
+	// (viewer=10, developer=20, operator=30, admin=40, owner=50) so
+	// the access-matrix UI (EPIC-3 #1098) can sort tiers without a
+	// hardcoded list.
+	Attributes map[string][]string `json:"attributes,omitempty"`
+}
+
+// ListRealmRoles returns every realm role. Used by access-matrix UI.
+// Realm role count is bounded (5 tier roles + per-Application roles
+// the application-controller creates), so no pagination is needed.
+func (c *Client) ListRealmRoles(ctx context.Context) ([]RealmRole, error) {
+	saToken, err := c.serviceAccountToken(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("keycloak.ListRealmRoles: service account token: %w", err)
+	}
+
+	u := fmt.Sprintf("%s/admin/realms/%s/roles", c.addr, c.realm)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+saToken)
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("keycloak: GET roles: %w", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("keycloak: GET roles %d: %s", resp.StatusCode, body)
+	}
+	var roles []RealmRole
+	if err := json.Unmarshal(body, &roles); err != nil {
+		return nil, fmt.Errorf("keycloak: decode roles: %w", err)
+	}
+	return roles, nil
+}
+
+// GetRealmRole looks up a realm role by name. Returns ErrRoleNotFound
+// on 404 so reconciliation loops can branch on absence.
+func (c *Client) GetRealmRole(ctx context.Context, name string) (RealmRole, error) {
+	saToken, err := c.serviceAccountToken(ctx)
+	if err != nil {
+		return RealmRole{}, fmt.Errorf("keycloak.GetRealmRole: service account token: %w", err)
+	}
+	return c.getRealmRole(ctx, saToken, name)
+}
+
+func (c *Client) getRealmRole(ctx context.Context, saToken, name string) (RealmRole, error) {
+	u := fmt.Sprintf("%s/admin/realms/%s/roles/%s",
+		c.addr, c.realm, url.PathEscape(name))
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return RealmRole{}, err
+	}
+	req.Header.Set("Authorization", "Bearer "+saToken)
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return RealmRole{}, fmt.Errorf("keycloak: GET role: %w", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode == http.StatusNotFound {
+		return RealmRole{}, ErrRoleNotFound
+	}
+	if resp.StatusCode != http.StatusOK {
+		return RealmRole{}, fmt.Errorf("keycloak: GET role %d: %s", resp.StatusCode, body)
+	}
+	var rr RealmRole
+	if err := json.Unmarshal(body, &rr); err != nil {
+		return RealmRole{}, fmt.Errorf("keycloak: decode role: %w", err)
+	}
+	return rr, nil
+}
+
+// CreateRealmRole creates a realm role. The Keycloak API returns 201
+// with no body and no Location header for role creation (unlike clients);
+// the caller must follow up with GetRealmRole if it needs the UUID.
+//
+// On 409 returns errRoleAlreadyExists so EnsureRealmRole can re-find.
+func (c *Client) CreateRealmRole(ctx context.Context, rr RealmRole) error {
+	saToken, err := c.serviceAccountToken(ctx)
+	if err != nil {
+		return fmt.Errorf("keycloak.CreateRealmRole: service account token: %w", err)
+	}
+	return c.createRealmRole(ctx, saToken, rr)
+}
+
+func (c *Client) createRealmRole(ctx context.Context, saToken string, rr RealmRole) error {
+	body, err := json.Marshal(rr)
+	if err != nil {
+		return err
+	}
+	u := fmt.Sprintf("%s/admin/realms/%s/roles", c.addr, c.realm)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, u, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+saToken)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return fmt.Errorf("keycloak: POST role: %w", err)
+	}
+	defer resp.Body.Close()
+	respBody, _ := io.ReadAll(resp.Body)
+	switch resp.StatusCode {
+	case http.StatusCreated, http.StatusNoContent:
+		return nil
+	case http.StatusConflict:
+		return errRoleAlreadyExists
+	default:
+		return fmt.Errorf("keycloak: POST role %d: %s", resp.StatusCode, respBody)
+	}
+}
+
+// UpdateRealmRole replaces a role's representation. The role is identified
+// by name (path segment) — Keycloak's PUT /roles/{role-name} replaces the
+// full body. Caller must call GetRealmRole first, mutate, then UpdateRealmRole.
+func (c *Client) UpdateRealmRole(ctx context.Context, name string, rr RealmRole) error {
+	if name == "" {
+		return errors.New("keycloak.UpdateRealmRole: name is required")
+	}
+	saToken, err := c.serviceAccountToken(ctx)
+	if err != nil {
+		return fmt.Errorf("keycloak.UpdateRealmRole: service account token: %w", err)
+	}
+	body, err := json.Marshal(rr)
+	if err != nil {
+		return err
+	}
+	u := fmt.Sprintf("%s/admin/realms/%s/roles/%s",
+		c.addr, c.realm, url.PathEscape(name))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, u, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+saToken)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return fmt.Errorf("keycloak: PUT role: %w", err)
+	}
+	defer resp.Body.Close()
+	respBody, _ := io.ReadAll(resp.Body)
+	switch resp.StatusCode {
+	case http.StatusNoContent, http.StatusOK:
+		return nil
+	case http.StatusNotFound:
+		return ErrRoleNotFound
+	default:
+		return fmt.Errorf("keycloak: PUT role %d: %s", resp.StatusCode, respBody)
+	}
+}
+
+// DeleteRealmRole removes a realm role by name. Returns ErrRoleNotFound
+// on 404 so reconciliation loops can treat absence-as-success.
+func (c *Client) DeleteRealmRole(ctx context.Context, name string) error {
+	saToken, err := c.serviceAccountToken(ctx)
+	if err != nil {
+		return fmt.Errorf("keycloak.DeleteRealmRole: service account token: %w", err)
+	}
+	u := fmt.Sprintf("%s/admin/realms/%s/roles/%s",
+		c.addr, c.realm, url.PathEscape(name))
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, u, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+saToken)
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return fmt.Errorf("keycloak: DELETE role: %w", err)
+	}
+	defer resp.Body.Close()
+	respBody, _ := io.ReadAll(resp.Body)
+	switch resp.StatusCode {
+	case http.StatusNoContent, http.StatusOK:
+		return nil
+	case http.StatusNotFound:
+		return ErrRoleNotFound
+	default:
+		return fmt.Errorf("keycloak: DELETE role %d: %s", resp.StatusCode, respBody)
+	}
+}
+
+// EnsureRealmRole is the find-or-create shorthand useraccess-controller
+// (slice C5) calls per catalog tier role at startup. If the role exists
+// the existing representation is returned (so the caller can compare
+// composite/attributes and call UpdateRealmRole if drift is detected);
+// otherwise CreateRealmRole runs and a fresh GetRealmRole follows.
+func (c *Client) EnsureRealmRole(ctx context.Context, rr RealmRole) (RealmRole, error) {
+	saToken, err := c.serviceAccountToken(ctx)
+	if err != nil {
+		return RealmRole{}, fmt.Errorf("keycloak.EnsureRealmRole: service account token: %w", err)
+	}
+
+	existing, err := c.getRealmRole(ctx, saToken, rr.Name)
+	if err == nil {
+		return existing, nil
+	}
+	if !errors.Is(err, ErrRoleNotFound) {
+		return RealmRole{}, fmt.Errorf("keycloak.EnsureRealmRole: get: %w", err)
+	}
+
+	if err := c.createRealmRole(ctx, saToken, rr); err != nil {
+		if !errors.Is(err, errRoleAlreadyExists) {
+			return RealmRole{}, fmt.Errorf("keycloak.EnsureRealmRole: create: %w", err)
+		}
+		// 409 race — fall through to the GET below.
+	}
+	created, err := c.getRealmRole(ctx, saToken, rr.Name)
+	if err != nil {
+		return RealmRole{}, fmt.Errorf("keycloak.EnsureRealmRole: re-get after create: %w", err)
+	}
+	return created, nil
+}
+
+// ── Role mappings ──────────────────────────────────────────────────────
+
+// ListUserRealmRoles returns the realm roles directly assigned to a user
+// (NOT including transitively-inherited roles via group membership).
+// Use ListUserEffectiveRealmRoles for the full effective set.
+func (c *Client) ListUserRealmRoles(ctx context.Context, userUUID string) ([]RealmRole, error) {
+	return c.listRoleMappingsRealm(ctx, "users", userUUID, false)
+}
+
+// ListUserEffectiveRealmRoles returns the realm roles a user effectively
+// has — direct + group-inherited + composite-expanded. This is what
+// the /token endpoint embeds in `realm_access.roles` claim.
+func (c *Client) ListUserEffectiveRealmRoles(ctx context.Context, userUUID string) ([]RealmRole, error) {
+	return c.listRoleMappingsRealm(ctx, "users", userUUID, true)
+}
+
+// AssignUserRealmRoles binds the given realm roles to a user. The role
+// list is additive — Keycloak's POST role-mappings/realm semantics.
+func (c *Client) AssignUserRealmRoles(ctx context.Context, userUUID string, roles []RealmRole) error {
+	return c.postRoleMappingsRealm(ctx, "users", userUUID, roles)
+}
+
+// UnassignUserRealmRoles removes the given realm roles from a user.
+func (c *Client) UnassignUserRealmRoles(ctx context.Context, userUUID string, roles []RealmRole) error {
+	return c.deleteRoleMappingsRealm(ctx, "users", userUUID, roles)
+}
+
+// ListGroupRealmRoles returns the realm roles directly assigned to a
+// group. Used by access-matrix UI to render the per-Org tier mapping.
+func (c *Client) ListGroupRealmRoles(ctx context.Context, groupUUID string) ([]RealmRole, error) {
+	return c.listRoleMappingsRealm(ctx, "groups", groupUUID, false)
+}
+
+// AssignGroupRealmRoles binds realm roles to a Keycloak group.
+// useraccess-controller calls this after creating the per-Org group:
+// every member of the group inherits the bound tier role.
+func (c *Client) AssignGroupRealmRoles(ctx context.Context, groupUUID string, roles []RealmRole) error {
+	return c.postRoleMappingsRealm(ctx, "groups", groupUUID, roles)
+}
+
+// UnassignGroupRealmRoles removes realm roles from a group.
+func (c *Client) UnassignGroupRealmRoles(ctx context.Context, groupUUID string, roles []RealmRole) error {
+	return c.deleteRoleMappingsRealm(ctx, "groups", groupUUID, roles)
+}
+
+// listRoleMappingsRealm is the shared GET helper for both user and group
+// role-mapping reads. resourceKind is "users" or "groups"; effective=true
+// switches to the /composite endpoint Keycloak exposes for transitive
+// resolution.
+func (c *Client) listRoleMappingsRealm(ctx context.Context, resourceKind, uuid string, effective bool) ([]RealmRole, error) {
+	saToken, err := c.serviceAccountToken(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("keycloak.listRoleMappingsRealm: service account token: %w", err)
+	}
+	suffix := ""
+	if effective {
+		suffix = "/composite"
+	}
+	u := fmt.Sprintf("%s/admin/realms/%s/%s/%s/role-mappings/realm%s",
+		c.addr, c.realm, resourceKind, url.PathEscape(uuid), suffix)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+saToken)
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("keycloak: GET role-mappings: %w", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("keycloak: GET role-mappings %d: %s", resp.StatusCode, body)
+	}
+	var roles []RealmRole
+	if err := json.Unmarshal(body, &roles); err != nil {
+		return nil, fmt.Errorf("keycloak: decode role-mappings: %w", err)
+	}
+	return roles, nil
+}
+
+// postRoleMappingsRealm assigns realm roles to a user or group. Both
+// the user and group endpoints accept a JSON array of RoleRepresentation
+// objects; the empty list is a no-op (Keycloak returns 204 immediately).
+func (c *Client) postRoleMappingsRealm(ctx context.Context, resourceKind, uuid string, roles []RealmRole) error {
+	if len(roles) == 0 {
+		return nil
+	}
+	saToken, err := c.serviceAccountToken(ctx)
+	if err != nil {
+		return fmt.Errorf("keycloak.postRoleMappingsRealm: service account token: %w", err)
+	}
+	body, err := json.Marshal(roles)
+	if err != nil {
+		return err
+	}
+	u := fmt.Sprintf("%s/admin/realms/%s/%s/%s/role-mappings/realm",
+		c.addr, c.realm, resourceKind, url.PathEscape(uuid))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, u, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+saToken)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return fmt.Errorf("keycloak: POST role-mappings: %w", err)
+	}
+	defer resp.Body.Close()
+	respBody, _ := io.ReadAll(resp.Body)
+	switch resp.StatusCode {
+	case http.StatusNoContent, http.StatusOK, http.StatusCreated:
+		return nil
+	default:
+		return fmt.Errorf("keycloak: POST role-mappings %d: %s", resp.StatusCode, respBody)
+	}
+}
+
+// deleteRoleMappingsRealm removes realm roles from a user or group.
+// DELETE with a JSON body is unusual but standard for this Keycloak
+// endpoint. Empty list is a no-op.
+func (c *Client) deleteRoleMappingsRealm(ctx context.Context, resourceKind, uuid string, roles []RealmRole) error {
+	if len(roles) == 0 {
+		return nil
+	}
+	saToken, err := c.serviceAccountToken(ctx)
+	if err != nil {
+		return fmt.Errorf("keycloak.deleteRoleMappingsRealm: service account token: %w", err)
+	}
+	body, err := json.Marshal(roles)
+	if err != nil {
+		return err
+	}
+	u := fmt.Sprintf("%s/admin/realms/%s/%s/%s/role-mappings/realm",
+		c.addr, c.realm, resourceKind, url.PathEscape(uuid))
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, u, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+saToken)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return fmt.Errorf("keycloak: DELETE role-mappings: %w", err)
+	}
+	defer resp.Body.Close()
+	respBody, _ := io.ReadAll(resp.Body)
+	switch resp.StatusCode {
+	case http.StatusNoContent, http.StatusOK:
+		return nil
+	default:
+		return fmt.Errorf("keycloak: DELETE role-mappings %d: %s", resp.StatusCode, respBody)
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/keycloak/admin_roles_test.go
+++ b/products/catalyst/bootstrap/api/internal/keycloak/admin_roles_test.go
@@ -1,0 +1,284 @@
+package keycloak
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// roleTestClient mirrors adminTestClient (in admin_test.go) but is
+// duplicated here to keep the role test surface independent — if a
+// future refactor moves admin.go elsewhere, this file still builds.
+func roleTestClient(t *testing.T, handler http.HandlerFunc) *Client {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	return NewWithHTTP(srv.URL, "test-realm", "catalyst-api-server", "sa-secret",
+		&http.Client{Timeout: 5 * time.Second})
+}
+
+func TestListRealmRoles_HappyPath(t *testing.T) {
+	client := roleTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/realms/test-realm/protocol/openid-connect/token":
+			saTokenHandler(w)
+		case "/admin/realms/test-realm/roles":
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`[
+				{"id":"r1","name":"catalyst-viewer","containerId":"realm"},
+				{"id":"r2","name":"catalyst-developer","containerId":"realm","composite":true},
+				{"id":"r3","name":"catalyst-admin","containerId":"realm","composite":true}
+			]`))
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	})
+	got, err := client.ListRealmRoles(context.Background())
+	if err != nil {
+		t.Fatalf("ListRealmRoles: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("expected 3 roles, got %d", len(got))
+	}
+	if got[1].Name != "catalyst-developer" || !got[1].Composite {
+		t.Fatalf("composite flag missing: %+v", got[1])
+	}
+}
+
+func TestGetRealmRole_NotFound(t *testing.T) {
+	client := roleTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/realms/test-realm/protocol/openid-connect/token":
+			saTokenHandler(w)
+		case r.URL.Path == "/admin/realms/test-realm/roles/missing":
+			w.WriteHeader(http.StatusNotFound)
+		default:
+			t.Errorf("unexpected: %s", r.URL.Path)
+		}
+	})
+	_, err := client.GetRealmRole(context.Background(), "missing")
+	if !errors.Is(err, ErrRoleNotFound) {
+		t.Fatalf("expected ErrRoleNotFound, got %v", err)
+	}
+}
+
+func TestCreateRealmRole_201Created(t *testing.T) {
+	var receivedName string
+	client := roleTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/realms/test-realm/protocol/openid-connect/token":
+			saTokenHandler(w)
+		case r.Method == http.MethodPost && r.URL.Path == "/admin/realms/test-realm/roles":
+			buf := make([]byte, 1024)
+			n, _ := r.Body.Read(buf)
+			if idx := strings.Index(string(buf[:n]), `"name":"`); idx >= 0 {
+				start := idx + len(`"name":"`)
+				end := strings.Index(string(buf[start:n]), `"`)
+				if end > 0 {
+					receivedName = string(buf[start : start+end])
+				}
+			}
+			w.WriteHeader(http.StatusCreated)
+		default:
+			t.Errorf("unexpected: %s %s", r.Method, r.URL.Path)
+		}
+	})
+	err := client.CreateRealmRole(context.Background(), RealmRole{Name: "catalyst-developer"})
+	if err != nil {
+		t.Fatalf("CreateRealmRole: %v", err)
+	}
+	if receivedName != "catalyst-developer" {
+		t.Fatalf("expected name catalyst-developer in body, got %q", receivedName)
+	}
+}
+
+func TestCreateRealmRole_409Conflict(t *testing.T) {
+	client := roleTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/realms/test-realm/protocol/openid-connect/token":
+			saTokenHandler(w)
+		case r.Method == http.MethodPost && r.URL.Path == "/admin/realms/test-realm/roles":
+			w.WriteHeader(http.StatusConflict)
+		default:
+			t.Errorf("unexpected: %s %s", r.Method, r.URL.Path)
+		}
+	})
+	err := client.CreateRealmRole(context.Background(), RealmRole{Name: "catalyst-developer"})
+	if !errors.Is(err, errRoleAlreadyExists) {
+		t.Fatalf("expected errRoleAlreadyExists, got %v", err)
+	}
+}
+
+func TestEnsureRealmRole_FindReturnsExisting(t *testing.T) {
+	var posted bool
+	client := roleTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/realms/test-realm/protocol/openid-connect/token":
+			saTokenHandler(w)
+		case r.Method == http.MethodGet && r.URL.Path == "/admin/realms/test-realm/roles/catalyst-admin":
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`{"id":"existing","name":"catalyst-admin","composite":true}`))
+		case r.Method == http.MethodPost:
+			posted = true
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	})
+	got, err := client.EnsureRealmRole(context.Background(), RealmRole{Name: "catalyst-admin"})
+	if err != nil {
+		t.Fatalf("EnsureRealmRole: %v", err)
+	}
+	if got.ID != "existing" || !got.Composite {
+		t.Fatalf("expected existing/composite, got %+v", got)
+	}
+	if posted {
+		t.Fatal("EnsureRealmRole must not POST when GET succeeds")
+	}
+}
+
+func TestEnsureRealmRole_CreateOn404(t *testing.T) {
+	var getCalls, postCalls int
+	client := roleTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/realms/test-realm/protocol/openid-connect/token":
+			saTokenHandler(w)
+		case r.Method == http.MethodGet && r.URL.Path == "/admin/realms/test-realm/roles/catalyst-admin":
+			getCalls++
+			if getCalls == 1 {
+				w.WriteHeader(http.StatusNotFound)
+				return
+			}
+			// Second GET (after CREATE) returns the row.
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`{"id":"new","name":"catalyst-admin"}`))
+		case r.Method == http.MethodPost && r.URL.Path == "/admin/realms/test-realm/roles":
+			postCalls++
+			w.WriteHeader(http.StatusCreated)
+		}
+	})
+	got, err := client.EnsureRealmRole(context.Background(), RealmRole{Name: "catalyst-admin"})
+	if err != nil {
+		t.Fatalf("EnsureRealmRole: %v", err)
+	}
+	if got.ID != "new" {
+		t.Fatalf("expected new ID, got %q", got.ID)
+	}
+	if getCalls != 2 || postCalls != 1 {
+		t.Fatalf("expected 2 GETs + 1 POST, got %d GETs + %d POSTs", getCalls, postCalls)
+	}
+}
+
+func TestUpdateRealmRole_RequiresName(t *testing.T) {
+	client := roleTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("UpdateRealmRole must fail before HTTP when name is empty: %s", r.URL.Path)
+	})
+	if err := client.UpdateRealmRole(context.Background(), "", RealmRole{}); err == nil {
+		t.Fatal("expected error for empty name")
+	}
+}
+
+func TestDeleteRealmRole_NotFound(t *testing.T) {
+	client := roleTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/realms/test-realm/protocol/openid-connect/token":
+			saTokenHandler(w)
+		case r.Method == http.MethodDelete && r.URL.Path == "/admin/realms/test-realm/roles/gone":
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+	if err := client.DeleteRealmRole(context.Background(), "gone"); !errors.Is(err, ErrRoleNotFound) {
+		t.Fatalf("expected ErrRoleNotFound, got %v", err)
+	}
+}
+
+func TestAssignGroupRealmRoles_PostBody(t *testing.T) {
+	var bodyLen int
+	client := roleTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/realms/test-realm/protocol/openid-connect/token":
+			saTokenHandler(w)
+		case r.Method == http.MethodPost && r.URL.Path == "/admin/realms/test-realm/groups/g1/role-mappings/realm":
+			buf := make([]byte, 4096)
+			n, _ := r.Body.Read(buf)
+			bodyLen = n
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			t.Errorf("unexpected: %s %s", r.Method, r.URL.Path)
+		}
+	})
+	err := client.AssignGroupRealmRoles(context.Background(), "g1", []RealmRole{
+		{ID: "r1", Name: "catalyst-developer"},
+	})
+	if err != nil {
+		t.Fatalf("AssignGroupRealmRoles: %v", err)
+	}
+	if bodyLen == 0 {
+		t.Fatal("expected non-empty POST body")
+	}
+}
+
+func TestAssignGroupRealmRoles_EmptyIsNoOp(t *testing.T) {
+	// Empty role list must NOT make any HTTP call.
+	client := roleTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("empty role list must not make any HTTP call; got %s", r.URL.Path)
+	})
+	if err := client.AssignGroupRealmRoles(context.Background(), "g1", nil); err != nil {
+		t.Fatalf("expected nil for empty roles, got %v", err)
+	}
+}
+
+func TestListUserEffectiveRealmRoles_HitsCompositeEndpoint(t *testing.T) {
+	var sawComposite bool
+	client := roleTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/realms/test-realm/protocol/openid-connect/token":
+			saTokenHandler(w)
+		case r.Method == http.MethodGet && r.URL.Path == "/admin/realms/test-realm/users/u1/role-mappings/realm/composite":
+			sawComposite = true
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`[{"id":"r1","name":"catalyst-viewer"},{"id":"r2","name":"catalyst-developer"}]`))
+		default:
+			t.Errorf("unexpected: %s %s", r.Method, r.URL.Path)
+		}
+	})
+	got, err := client.ListUserEffectiveRealmRoles(context.Background(), "u1")
+	if err != nil {
+		t.Fatalf("ListUserEffectiveRealmRoles: %v", err)
+	}
+	if !sawComposite {
+		t.Fatal("expected /composite suffix on URL")
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 effective roles, got %d", len(got))
+	}
+}
+
+func TestListUserRealmRoles_DirectEndpoint(t *testing.T) {
+	// Without /composite — should hit the direct endpoint only.
+	var sawDirect bool
+	client := roleTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/realms/test-realm/protocol/openid-connect/token":
+			saTokenHandler(w)
+		case r.Method == http.MethodGet && r.URL.Path == "/admin/realms/test-realm/users/u1/role-mappings/realm":
+			sawDirect = true
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`[{"id":"r1","name":"catalyst-viewer"}]`))
+		default:
+			t.Errorf("unexpected: %s %s", r.Method, r.URL.Path)
+		}
+	})
+	got, err := client.ListUserRealmRoles(context.Background(), "u1")
+	if err != nil {
+		t.Fatalf("ListUserRealmRoles: %v", err)
+	}
+	if !sawDirect {
+		t.Fatal("expected direct endpoint")
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 direct role, got %d", len(got))
+	}
+}


### PR DESCRIPTION
## Summary

Slice **D1b** of EPIC-0 (#1095). Second sub-slice of D1 (Keycloak full-CRUD client extension). Lands realm-role CRUD + user/group role-mapping CRUD in a new \`internal/keycloak/admin_roles.go\`.

## Public API

**Realm roles**: \`ListRealmRoles\`, \`GetRealmRole\`, \`CreateRealmRole\`, \`UpdateRealmRole\`, \`DeleteRealmRole\`, \`EnsureRealmRole\` (find-or-create with 409 race tolerance).

**User role-mappings**: \`ListUserRealmRoles\` (direct), \`ListUserEffectiveRealmRoles\` (composite — what \`/token\` embeds in \`realm_access.roles\`), \`AssignUserRealmRoles\`, \`UnassignUserRealmRoles\`.

**Group role-mappings**: \`ListGroupRealmRoles\`, \`AssignGroupRealmRoles\`, \`UnassignGroupRealmRoles\`.

**Sentinels**: \`ErrRoleNotFound\` (exported), \`errRoleAlreadyExists\` (internal).

## How useraccess-controller will use this

1. **Startup**: For each catalog tier in the 5-tier ordering (viewer/developer/operator/admin/owner), call \`EnsureRealmRole({Name: "catalyst-<tier>", Composite: true, ...})\`. The Composite flag + a future RoleHierarchy slice makes \`developer\` compose \`viewer\`, etc.
2. **Per-Org reconciliation**: When an Organization CR is created, useraccess-controller creates a Keycloak group (slice D1c will land group-CRUD), then calls \`AssignGroupRealmRoles(groupUUID, [{Name: "catalyst-<tier>"}])\` to bind the Org's tier.
3. **Per-User audit**: Access-matrix UI calls \`ListUserEffectiveRealmRoles\` to render the user's full effective tier set including group inheritance.

## Empty-list optimization

\`AssignXRealmRoles\` / \`UnassignXRealmRoles\` short-circuit on empty slice — 0 HTTP calls. Catches the common reconciliation case where desired-set matches actual-set.

## Test plan

- [x] 11 test cases covering happy paths, error sentinels, race tolerance, and empty-list short-circuit
- [x] \`go test ./internal/keycloak/...\` — all pass (24 tests across admin.go + admin_roles.go)
- [x] \`go build ./... && go vet ./...\` — clean
- [x] Rebased on \`main\` after D1a (#1123) merged so the shared \`saTokenHandler\` test helper is visible

## Out of scope (deferred to D1c)

- Group hierarchy + group-attribute setters
- Per-OIDC-client client-secret rotation
- Identity Provider CRUD for corporate Azure-SSO federation

🤖 Generated with [Claude Code](https://claude.com/claude-code)