### PR TITLE
feat(keycloak): add Group CRUD + attributes + client-secret rotation (slice D1c, #1095)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/keycloak/admin_groups.go
+++ b/products/catalyst/bootstrap/api/internal/keycloak/admin_groups.go
@@ -1,0 +1,550 @@
+package keycloak
+
+// admin_groups.go — Keycloak group CRUD + attribute setters.
+//
+// Slice D1c of EPIC-0 #1095. organization-controller (slice C1) calls
+// these to materialize a Keycloak group per Organization. The group's
+// attributes carry the Catalyst custom claims (`org`, `tier`,
+// `openova_scopes`) that the auth/Claims fields parse on every token —
+// see slice D2's auth/session.go and the Keycloak group-mapper config
+// in platform/keycloak/chart/templates/configmap-sovereign-realm.yaml.
+//
+// Endpoints used (Keycloak Admin REST API, version 24.x):
+//
+//   GET    /admin/realms/{realm}/groups
+//   GET    /admin/realms/{realm}/groups/{group-uuid}
+//   POST   /admin/realms/{realm}/groups
+//   PUT    /admin/realms/{realm}/groups/{group-uuid}
+//   DELETE /admin/realms/{realm}/groups/{group-uuid}
+//   POST   /admin/realms/{realm}/groups/{parent-uuid}/children   (sub-groups)
+//
+// The existing client.go has unexported findGroupByName + createGroup +
+// addUserToGroup — those remain in service of EnsureUser and are not
+// touched here. This file adds the public Group CRUD surface for the
+// reconciler use case.
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+)
+
+// ErrGroupNotFound is returned by GetGroup / DeleteGroup on 404.
+var ErrGroupNotFound = errors.New("keycloak: group not found")
+
+// errGroupAlreadyExists is the internal sentinel for the EnsureGroup
+// 409 race path.
+var errGroupAlreadyExists = errors.New("keycloak: group already exists")
+
+// Group is the slice of fields catalyst-api consumes/sets when
+// reconciling per-Org groups. Mirrors the upstream GroupRepresentation
+// but only with the fields organization-controller actually uses.
+//
+// Attributes is the Keycloak-side join key for Catalyst RBAC: a per-Org
+// group typically carries `org=<slug>`, `tier=<viewer|developer|...>`,
+// and one or more `openova_scope=<key=value>` entries. The Keycloak
+// realm's group-mapper renders these into the access token's `org`,
+// `tier`, and `openova_scopes` claims (parsed by auth/Claims in slice D2).
+type Group struct {
+	// ID is the Keycloak-internal UUID. Empty before CreateGroup.
+	ID string `json:"id,omitempty"`
+
+	// Name is the leaf group name (e.g. "acme", "acme-admins"). For
+	// sub-groups, the parent context is implicit in the API path.
+	Name string `json:"name"`
+
+	// Path is the full Keycloak path with leading slash and slashes
+	// between sub-group levels (e.g. "/acme/admins"). Read-only —
+	// Keycloak populates this on read and ignores it on write.
+	Path string `json:"path,omitempty"`
+
+	// Attributes is a map of group attributes. Keycloak supports
+	// multi-value attributes — Catalyst uses single-value semantics
+	// for `org` and `tier`, multi-value for `openova_scope`.
+	Attributes map[string][]string `json:"attributes,omitempty"`
+
+	// SubGroups is populated on read for parent groups. Catalyst
+	// rarely uses nested groups in practice but the data shape is
+	// preserved so the access-matrix UI can render the hierarchy.
+	SubGroups []Group `json:"subGroups,omitempty"`
+
+	// RealmRoles is the legacy per-group realm-role list (Keycloak
+	// returns this when the group has direct role bindings via the
+	// pre-v24 API). For new code prefer ListGroupRealmRoles in
+	// admin_roles.go which uses the canonical role-mappings endpoint.
+	RealmRoles []string `json:"realmRoles,omitempty"`
+}
+
+// ListGroups returns all groups in the realm. The Keycloak Admin API
+// returns top-level groups only; sub-groups appear under each parent's
+// SubGroups field. Used by access-matrix UI to render the per-Org
+// group inventory.
+//
+// Pagination: realms with >1000 groups would need /count + paginated
+// reads, but Catalyst caps at 1 group per Organization per Sovereign,
+// so practical realms stay well under that bound.
+func (c *Client) ListGroups(ctx context.Context) ([]Group, error) {
+	saToken, err := c.serviceAccountToken(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("keycloak.ListGroups: service account token: %w", err)
+	}
+
+	u := fmt.Sprintf("%s/admin/realms/%s/groups?first=0&max=1000", c.addr, c.realm)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+saToken)
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("keycloak: GET groups: %w", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("keycloak: GET groups %d: %s", resp.StatusCode, body)
+	}
+	var groups []Group
+	if err := json.Unmarshal(body, &groups); err != nil {
+		return nil, fmt.Errorf("keycloak: decode groups: %w", err)
+	}
+	return groups, nil
+}
+
+// GetGroup looks up a group by Keycloak UUID. Returns ErrGroupNotFound
+// on 404 so reconciliation loops can branch on absence.
+func (c *Client) GetGroup(ctx context.Context, uuid string) (Group, error) {
+	saToken, err := c.serviceAccountToken(ctx)
+	if err != nil {
+		return Group{}, fmt.Errorf("keycloak.GetGroup: service account token: %w", err)
+	}
+
+	u := fmt.Sprintf("%s/admin/realms/%s/groups/%s", c.addr, c.realm, url.PathEscape(uuid))
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return Group{}, err
+	}
+	req.Header.Set("Authorization", "Bearer "+saToken)
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return Group{}, fmt.Errorf("keycloak: GET group: %w", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode == http.StatusNotFound {
+		return Group{}, ErrGroupNotFound
+	}
+	if resp.StatusCode != http.StatusOK {
+		return Group{}, fmt.Errorf("keycloak: GET group %d: %s", resp.StatusCode, body)
+	}
+	var g Group
+	if err := json.Unmarshal(body, &g); err != nil {
+		return Group{}, fmt.Errorf("keycloak: decode group: %w", err)
+	}
+	return g, nil
+}
+
+// FindGroupByPath resolves a group by its full path (e.g. "/acme" or
+// "/acme/admins") to a Group representation including the UUID. Returns
+// the empty struct + nil error on miss, mirroring FindClientByClientID.
+//
+// The Keycloak Admin API exposes /group-by-path for this exactly.
+func (c *Client) FindGroupByPath(ctx context.Context, path string) (Group, error) {
+	saToken, err := c.serviceAccountToken(ctx)
+	if err != nil {
+		return Group{}, fmt.Errorf("keycloak.FindGroupByPath: service account token: %w", err)
+	}
+
+	// Keycloak's /group-by-path expects the path WITHOUT URL-escaping
+	// the leading slash (it's part of the path segment, not a separator).
+	// Normalize to ensure exactly one leading slash, then percent-encode
+	// the remaining segments.
+	if path == "" {
+		return Group{}, errors.New("keycloak.FindGroupByPath: empty path")
+	}
+	if path[0] != '/' {
+		path = "/" + path
+	}
+
+	u := fmt.Sprintf("%s/admin/realms/%s/group-by-path/%s",
+		c.addr, c.realm, url.PathEscape(path[1:]))
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return Group{}, err
+	}
+	req.Header.Set("Authorization", "Bearer "+saToken)
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return Group{}, fmt.Errorf("keycloak: GET group-by-path: %w", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	switch resp.StatusCode {
+	case http.StatusOK:
+		var g Group
+		if err := json.Unmarshal(body, &g); err != nil {
+			return Group{}, fmt.Errorf("keycloak: decode group-by-path: %w", err)
+		}
+		return g, nil
+	case http.StatusNotFound:
+		return Group{}, nil
+	default:
+		return Group{}, fmt.Errorf("keycloak: GET group-by-path %d: %s", resp.StatusCode, body)
+	}
+}
+
+// CreateGroup creates a top-level group. Returns the new UUID extracted
+// from the Location header (mirrors CreateClient).
+//
+// On 409 returns errGroupAlreadyExists so EnsureGroup can re-find via
+// FindGroupByPath.
+func (c *Client) CreateGroup(ctx context.Context, g Group) (string, error) {
+	saToken, err := c.serviceAccountToken(ctx)
+	if err != nil {
+		return "", fmt.Errorf("keycloak.CreateGroup: service account token: %w", err)
+	}
+	return c.createGroupV2(ctx, saToken, g)
+}
+
+func (c *Client) createGroupV2(ctx context.Context, saToken string, g Group) (string, error) {
+	body, err := json.Marshal(g)
+	if err != nil {
+		return "", err
+	}
+	u := fmt.Sprintf("%s/admin/realms/%s/groups", c.addr, c.realm)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, u, bytes.NewReader(body))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Authorization", "Bearer "+saToken)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("keycloak: POST group: %w", err)
+	}
+	defer resp.Body.Close()
+	respBody, _ := io.ReadAll(resp.Body)
+
+	switch resp.StatusCode {
+	case http.StatusCreated:
+		loc := resp.Header.Get("Location")
+		if loc == "" {
+			return "", errors.New("keycloak: POST group 201 without Location header")
+		}
+		if seg := lastSegment(loc); seg != "" {
+			return seg, nil
+		}
+		return "", fmt.Errorf("keycloak: POST group 201 Location parse failed: %s", loc)
+	case http.StatusConflict:
+		return "", errGroupAlreadyExists
+	default:
+		return "", fmt.Errorf("keycloak: POST group %d: %s", resp.StatusCode, respBody)
+	}
+}
+
+// CreateSubGroup creates a child group under the given parent UUID.
+// Catalyst uses this rarely (typical Org-mapping is flat) but
+// access-matrix UI supports rendering hierarchical groups so the
+// API is surfaced for completeness.
+func (c *Client) CreateSubGroup(ctx context.Context, parentUUID string, g Group) (string, error) {
+	saToken, err := c.serviceAccountToken(ctx)
+	if err != nil {
+		return "", fmt.Errorf("keycloak.CreateSubGroup: service account token: %w", err)
+	}
+
+	body, err := json.Marshal(g)
+	if err != nil {
+		return "", err
+	}
+	u := fmt.Sprintf("%s/admin/realms/%s/groups/%s/children",
+		c.addr, c.realm, url.PathEscape(parentUUID))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, u, bytes.NewReader(body))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Authorization", "Bearer "+saToken)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("keycloak: POST sub-group: %w", err)
+	}
+	defer resp.Body.Close()
+	respBody, _ := io.ReadAll(resp.Body)
+
+	switch resp.StatusCode {
+	case http.StatusCreated:
+		loc := resp.Header.Get("Location")
+		if loc == "" {
+			return "", errors.New("keycloak: POST sub-group 201 without Location header")
+		}
+		if seg := lastSegment(loc); seg != "" {
+			return seg, nil
+		}
+		return "", fmt.Errorf("keycloak: POST sub-group 201 Location parse failed: %s", loc)
+	case http.StatusConflict:
+		return "", errGroupAlreadyExists
+	default:
+		return "", fmt.Errorf("keycloak: POST sub-group %d: %s", resp.StatusCode, respBody)
+	}
+}
+
+// UpdateGroup replaces the group representation. Used by SetGroupAttributes
+// internally. Caller must populate g.ID with the Keycloak UUID.
+func (c *Client) UpdateGroup(ctx context.Context, g Group) error {
+	if g.ID == "" {
+		return errors.New("keycloak.UpdateGroup: g.ID (Keycloak UUID) is required")
+	}
+	saToken, err := c.serviceAccountToken(ctx)
+	if err != nil {
+		return fmt.Errorf("keycloak.UpdateGroup: service account token: %w", err)
+	}
+	body, err := json.Marshal(g)
+	if err != nil {
+		return err
+	}
+	u := fmt.Sprintf("%s/admin/realms/%s/groups/%s",
+		c.addr, c.realm, url.PathEscape(g.ID))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, u, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+saToken)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return fmt.Errorf("keycloak: PUT group: %w", err)
+	}
+	defer resp.Body.Close()
+	respBody, _ := io.ReadAll(resp.Body)
+	switch resp.StatusCode {
+	case http.StatusNoContent, http.StatusOK:
+		return nil
+	case http.StatusNotFound:
+		return ErrGroupNotFound
+	default:
+		return fmt.Errorf("keycloak: PUT group %d: %s", resp.StatusCode, respBody)
+	}
+}
+
+// DeleteGroup removes a group by UUID. Returns ErrGroupNotFound on 404.
+func (c *Client) DeleteGroup(ctx context.Context, uuid string) error {
+	saToken, err := c.serviceAccountToken(ctx)
+	if err != nil {
+		return fmt.Errorf("keycloak.DeleteGroup: service account token: %w", err)
+	}
+	u := fmt.Sprintf("%s/admin/realms/%s/groups/%s", c.addr, c.realm, url.PathEscape(uuid))
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, u, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+saToken)
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return fmt.Errorf("keycloak: DELETE group: %w", err)
+	}
+	defer resp.Body.Close()
+	respBody, _ := io.ReadAll(resp.Body)
+	switch resp.StatusCode {
+	case http.StatusNoContent, http.StatusOK:
+		return nil
+	case http.StatusNotFound:
+		return ErrGroupNotFound
+	default:
+		return fmt.Errorf("keycloak: DELETE group %d: %s", resp.StatusCode, respBody)
+	}
+}
+
+// EnsureGroup is the find-or-create shorthand organization-controller
+// (slice C1) calls per Organization. Returns the existing group when
+// path resolves; otherwise creates and re-finds. The 409-race path
+// re-finds via FindGroupByPath.
+//
+// The first parameter is the full path the caller wants to ensure
+// (e.g. "/acme"); the Group's Name is derived from the path's last
+// segment if not set explicitly.
+func (c *Client) EnsureGroup(ctx context.Context, path string, attrs map[string][]string) (Group, error) {
+	saToken, err := c.serviceAccountToken(ctx)
+	if err != nil {
+		return Group{}, fmt.Errorf("keycloak.EnsureGroup: service account token: %w", err)
+	}
+
+	if path == "" {
+		return Group{}, errors.New("keycloak.EnsureGroup: empty path")
+	}
+	if path[0] != '/' {
+		path = "/" + path
+	}
+
+	// The leaf segment becomes the group's Name.
+	leaf := path
+	if i := lastSlashIndex(path); i >= 0 && i < len(path)-1 {
+		leaf = path[i+1:]
+	}
+
+	existing, err := c.findGroupByPathInternal(ctx, saToken, path)
+	if err != nil {
+		return Group{}, fmt.Errorf("keycloak.EnsureGroup: find: %w", err)
+	}
+	if existing.ID != "" {
+		// Already exists. If attrs differ, update; otherwise return as-is.
+		if !attributesEqual(existing.Attributes, attrs) && attrs != nil {
+			existing.Attributes = attrs
+			if err := c.updateGroupInternal(ctx, saToken, existing); err != nil {
+				return Group{}, fmt.Errorf("keycloak.EnsureGroup: update attrs: %w", err)
+			}
+		}
+		return existing, nil
+	}
+
+	uuid, err := c.createGroupV2(ctx, saToken, Group{Name: leaf, Attributes: attrs})
+	if errors.Is(err, errGroupAlreadyExists) {
+		// 409 race — re-find.
+		existing, ferr := c.findGroupByPathInternal(ctx, saToken, path)
+		if ferr != nil {
+			return Group{}, fmt.Errorf("keycloak.EnsureGroup: re-find after 409: %w", ferr)
+		}
+		if existing.ID == "" {
+			return Group{}, errors.New("keycloak.EnsureGroup: 409 conflict but path-resolve returned empty")
+		}
+		return existing, nil
+	}
+	if err != nil {
+		return Group{}, fmt.Errorf("keycloak.EnsureGroup: create: %w", err)
+	}
+
+	created, ferr := c.findGroupByPathInternal(ctx, saToken, path)
+	if ferr != nil {
+		return Group{}, fmt.Errorf("keycloak.EnsureGroup: re-find after create: %w", ferr)
+	}
+	if created.ID == "" {
+		// Defensive — extremely unlikely.
+		return Group{ID: uuid, Name: leaf, Attributes: attrs}, nil
+	}
+	return created, nil
+}
+
+// SetGroupAttributes is a convenience wrapper that GETs the group, sets
+// the attribute map, and PUTs. Per the Keycloak Admin API the attributes
+// field is a full replace (not a merge), so callers must merge themselves
+// if they want to preserve existing attributes — this helper takes the
+// caller's map as authoritative.
+func (c *Client) SetGroupAttributes(ctx context.Context, uuid string, attrs map[string][]string) error {
+	g, err := c.GetGroup(ctx, uuid)
+	if err != nil {
+		return fmt.Errorf("keycloak.SetGroupAttributes: get: %w", err)
+	}
+	g.Attributes = attrs
+	if err := c.UpdateGroup(ctx, g); err != nil {
+		return fmt.Errorf("keycloak.SetGroupAttributes: update: %w", err)
+	}
+	return nil
+}
+
+// ── internal helpers ────────────────────────────────────────────────────
+
+func (c *Client) findGroupByPathInternal(ctx context.Context, saToken, path string) (Group, error) {
+	if path == "" {
+		return Group{}, errors.New("findGroupByPathInternal: empty path")
+	}
+	if path[0] != '/' {
+		path = "/" + path
+	}
+	u := fmt.Sprintf("%s/admin/realms/%s/group-by-path/%s",
+		c.addr, c.realm, url.PathEscape(path[1:]))
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return Group{}, err
+	}
+	req.Header.Set("Authorization", "Bearer "+saToken)
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return Group{}, fmt.Errorf("keycloak: GET group-by-path: %w", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	switch resp.StatusCode {
+	case http.StatusOK:
+		var g Group
+		if err := json.Unmarshal(body, &g); err != nil {
+			return Group{}, fmt.Errorf("keycloak: decode group-by-path: %w", err)
+		}
+		return g, nil
+	case http.StatusNotFound:
+		return Group{}, nil
+	default:
+		return Group{}, fmt.Errorf("keycloak: GET group-by-path %d: %s", resp.StatusCode, body)
+	}
+}
+
+func (c *Client) updateGroupInternal(ctx context.Context, saToken string, g Group) error {
+	body, err := json.Marshal(g)
+	if err != nil {
+		return err
+	}
+	u := fmt.Sprintf("%s/admin/realms/%s/groups/%s",
+		c.addr, c.realm, url.PathEscape(g.ID))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, u, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+saToken)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return fmt.Errorf("keycloak: PUT group: %w", err)
+	}
+	defer resp.Body.Close()
+	respBody, _ := io.ReadAll(resp.Body)
+	switch resp.StatusCode {
+	case http.StatusNoContent, http.StatusOK:
+		return nil
+	case http.StatusNotFound:
+		return ErrGroupNotFound
+	default:
+		return fmt.Errorf("keycloak: PUT group %d: %s", resp.StatusCode, respBody)
+	}
+}
+
+// lastSlashIndex returns the index of the last `/` in s, or -1 if none.
+func lastSlashIndex(s string) int {
+	for i := len(s) - 1; i >= 0; i-- {
+		if s[i] == '/' {
+			return i
+		}
+	}
+	return -1
+}
+
+// attributesEqual compares two attribute maps for set-equality (length
+// + key-by-key value-slice equality). Used by EnsureGroup to detect
+// drift before issuing an UPDATE call.
+func attributesEqual(a, b map[string][]string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k, va := range a {
+		vb, ok := b[k]
+		if !ok || len(va) != len(vb) {
+			return false
+		}
+		for i := range va {
+			if va[i] != vb[i] {
+				return false
+			}
+		}
+	}
+	return true
+}

--- a/products/catalyst/bootstrap/api/internal/keycloak/admin_groups_test.go
+++ b/products/catalyst/bootstrap/api/internal/keycloak/admin_groups_test.go
@@ -1,0 +1,351 @@
+package keycloak
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func groupTestClient(t *testing.T, handler http.HandlerFunc) *Client {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	return NewWithHTTP(srv.URL, "test-realm", "catalyst-api-server", "sa-secret",
+		&http.Client{Timeout: 5 * time.Second})
+}
+
+func TestListGroups_HappyPath(t *testing.T) {
+	client := groupTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/realms/test-realm/protocol/openid-connect/token":
+			saTokenHandler(w)
+		case r.Method == http.MethodGet && r.URL.Path == "/admin/realms/test-realm/groups":
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`[
+				{"id":"g1","name":"acme","path":"/acme","attributes":{"org":["acme"],"tier":["admin"]}},
+				{"id":"g2","name":"bank","path":"/bank","attributes":{"org":["bank"]}}
+			]`))
+		default:
+			t.Errorf("unexpected: %s %s", r.Method, r.URL.Path)
+		}
+	})
+	got, err := client.ListGroups(context.Background())
+	if err != nil {
+		t.Fatalf("ListGroups: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 groups, got %d", len(got))
+	}
+	if got[0].Attributes["tier"][0] != "admin" {
+		t.Fatalf("tier attribute lost: %+v", got[0])
+	}
+}
+
+func TestGetGroup_NotFound(t *testing.T) {
+	client := groupTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/realms/test-realm/protocol/openid-connect/token":
+			saTokenHandler(w)
+		case r.Method == http.MethodGet && r.URL.Path == "/admin/realms/test-realm/groups/missing":
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+	_, err := client.GetGroup(context.Background(), "missing")
+	if !errors.Is(err, ErrGroupNotFound) {
+		t.Fatalf("expected ErrGroupNotFound, got %v", err)
+	}
+}
+
+func TestFindGroupByPath_Found(t *testing.T) {
+	client := groupTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/realms/test-realm/protocol/openid-connect/token":
+			saTokenHandler(w)
+		case r.Method == http.MethodGet && r.URL.Path == "/admin/realms/test-realm/group-by-path/acme":
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`{"id":"g1","name":"acme","path":"/acme"}`))
+		default:
+			t.Errorf("unexpected: %s %s", r.Method, r.URL.Path)
+		}
+	})
+	got, err := client.FindGroupByPath(context.Background(), "/acme")
+	if err != nil {
+		t.Fatalf("FindGroupByPath: %v", err)
+	}
+	if got.ID != "g1" {
+		t.Fatalf("expected g1, got %q", got.ID)
+	}
+}
+
+func TestFindGroupByPath_LeadingSlashOptional(t *testing.T) {
+	client := groupTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/realms/test-realm/protocol/openid-connect/token":
+			saTokenHandler(w)
+		case r.Method == http.MethodGet && r.URL.Path == "/admin/realms/test-realm/group-by-path/acme":
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`{"id":"g1","name":"acme","path":"/acme"}`))
+		default:
+			t.Errorf("unexpected: %s %s", r.Method, r.URL.Path)
+		}
+	})
+	// Caller may pass either "acme" or "/acme" — both must work.
+	got, err := client.FindGroupByPath(context.Background(), "acme")
+	if err != nil {
+		t.Fatalf("FindGroupByPath: %v", err)
+	}
+	if got.ID != "g1" {
+		t.Fatalf("expected g1, got %q", got.ID)
+	}
+}
+
+func TestFindGroupByPath_404IsEmptyResult(t *testing.T) {
+	client := groupTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/realms/test-realm/protocol/openid-connect/token":
+			saTokenHandler(w)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+	got, err := client.FindGroupByPath(context.Background(), "/missing")
+	if err != nil {
+		t.Fatalf("FindGroupByPath should not error on 404, got %v", err)
+	}
+	if got.ID != "" {
+		t.Fatalf("expected empty group, got %+v", got)
+	}
+}
+
+func TestCreateGroup_201Location(t *testing.T) {
+	client := groupTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/realms/test-realm/protocol/openid-connect/token":
+			saTokenHandler(w)
+		case r.Method == http.MethodPost && r.URL.Path == "/admin/realms/test-realm/groups":
+			w.Header().Set("Location", "http://kc.local/admin/realms/test-realm/groups/new-uuid")
+			w.WriteHeader(http.StatusCreated)
+		default:
+			t.Errorf("unexpected: %s %s", r.Method, r.URL.Path)
+		}
+	})
+	uuid, err := client.CreateGroup(context.Background(), Group{Name: "acme"})
+	if err != nil {
+		t.Fatalf("CreateGroup: %v", err)
+	}
+	if uuid != "new-uuid" {
+		t.Fatalf("expected new-uuid, got %q", uuid)
+	}
+}
+
+func TestCreateSubGroup_201Location(t *testing.T) {
+	client := groupTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/realms/test-realm/protocol/openid-connect/token":
+			saTokenHandler(w)
+		case r.Method == http.MethodPost && r.URL.Path == "/admin/realms/test-realm/groups/parent-uuid/children":
+			w.Header().Set("Location", "http://kc/admin/realms/test-realm/groups/child-uuid")
+			w.WriteHeader(http.StatusCreated)
+		default:
+			t.Errorf("unexpected: %s %s", r.Method, r.URL.Path)
+		}
+	})
+	uuid, err := client.CreateSubGroup(context.Background(), "parent-uuid", Group{Name: "admins"})
+	if err != nil {
+		t.Fatalf("CreateSubGroup: %v", err)
+	}
+	if uuid != "child-uuid" {
+		t.Fatalf("expected child-uuid, got %q", uuid)
+	}
+}
+
+func TestEnsureGroup_FindFirstReturnsExisting(t *testing.T) {
+	var posted bool
+	client := groupTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/realms/test-realm/protocol/openid-connect/token":
+			saTokenHandler(w)
+		case r.Method == http.MethodGet && r.URL.Path == "/admin/realms/test-realm/group-by-path/acme":
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`{"id":"existing","name":"acme","path":"/acme","attributes":{"org":["acme"]}}`))
+		case r.Method == http.MethodPost:
+			posted = true
+		}
+	})
+	got, err := client.EnsureGroup(context.Background(), "/acme", map[string][]string{"org": {"acme"}})
+	if err != nil {
+		t.Fatalf("EnsureGroup: %v", err)
+	}
+	if got.ID != "existing" {
+		t.Fatalf("expected existing UUID, got %q", got.ID)
+	}
+	if posted {
+		t.Fatal("EnsureGroup must not POST when path resolves and attrs match")
+	}
+}
+
+func TestEnsureGroup_DriftTriggersUpdate(t *testing.T) {
+	var puts int
+	client := groupTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/realms/test-realm/protocol/openid-connect/token":
+			saTokenHandler(w)
+		case r.Method == http.MethodGet && r.URL.Path == "/admin/realms/test-realm/group-by-path/acme":
+			// Existing has tier=viewer; caller wants tier=admin → drift.
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`{"id":"g-existing","name":"acme","path":"/acme","attributes":{"tier":["viewer"]}}`))
+		case r.Method == http.MethodPut && r.URL.Path == "/admin/realms/test-realm/groups/g-existing":
+			puts++
+			w.WriteHeader(http.StatusNoContent)
+		}
+	})
+	got, err := client.EnsureGroup(context.Background(), "/acme", map[string][]string{"tier": {"admin"}})
+	if err != nil {
+		t.Fatalf("EnsureGroup: %v", err)
+	}
+	if got.ID != "g-existing" {
+		t.Fatalf("expected g-existing, got %q", got.ID)
+	}
+	if puts != 1 {
+		t.Fatalf("expected 1 PUT to update attrs, got %d", puts)
+	}
+}
+
+func TestEnsureGroup_CreateOnMiss(t *testing.T) {
+	var pathCalls int
+	var posted bool
+	client := groupTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/realms/test-realm/protocol/openid-connect/token":
+			saTokenHandler(w)
+		case r.Method == http.MethodGet && r.URL.Path == "/admin/realms/test-realm/group-by-path/acme":
+			pathCalls++
+			if pathCalls == 1 {
+				// First lookup: not found → caller branches to create.
+				w.WriteHeader(http.StatusNotFound)
+				return
+			}
+			// Second lookup (after create): the new row.
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`{"id":"g-new","name":"acme","path":"/acme","attributes":{"tier":["developer"]}}`))
+		case r.Method == http.MethodPost && r.URL.Path == "/admin/realms/test-realm/groups":
+			posted = true
+			w.Header().Set("Location", "http://kc/admin/realms/test-realm/groups/g-new")
+			w.WriteHeader(http.StatusCreated)
+		default:
+			t.Errorf("unexpected: %s %s", r.Method, r.URL.Path)
+		}
+	})
+	got, err := client.EnsureGroup(context.Background(), "/acme",
+		map[string][]string{"tier": {"developer"}})
+	if err != nil {
+		t.Fatalf("EnsureGroup: %v", err)
+	}
+	if got.ID != "g-new" {
+		t.Fatalf("expected g-new, got %q", got.ID)
+	}
+	if !posted {
+		t.Fatal("EnsureGroup must POST when find returns 404")
+	}
+	if pathCalls != 2 {
+		t.Fatalf("expected 2 path lookups, got %d", pathCalls)
+	}
+}
+
+func TestSetGroupAttributes_ReplacesAll(t *testing.T) {
+	var putBody string
+	client := groupTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/realms/test-realm/protocol/openid-connect/token":
+			saTokenHandler(w)
+		case r.Method == http.MethodGet && r.URL.Path == "/admin/realms/test-realm/groups/g1":
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`{"id":"g1","name":"acme","attributes":{"old":["value"]}}`))
+		case r.Method == http.MethodPut && r.URL.Path == "/admin/realms/test-realm/groups/g1":
+			buf := make([]byte, 4096)
+			n, _ := r.Body.Read(buf)
+			putBody = string(buf[:n])
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			t.Errorf("unexpected: %s %s", r.Method, r.URL.Path)
+		}
+	})
+	err := client.SetGroupAttributes(context.Background(), "g1",
+		map[string][]string{"tier": {"admin"}})
+	if err != nil {
+		t.Fatalf("SetGroupAttributes: %v", err)
+	}
+	// The PUT body must include the new tier=admin and exclude the old=value
+	// because attributes is full-replace per the Keycloak API.
+	if !strings.Contains(putBody, `"tier":["admin"]`) {
+		t.Fatalf("expected tier=admin in PUT body, got %q", putBody)
+	}
+	if strings.Contains(putBody, `"old":["value"]`) {
+		t.Fatalf("old attribute should have been replaced, got %q", putBody)
+	}
+}
+
+func TestUpdateGroup_RequiresUUID(t *testing.T) {
+	client := groupTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("UpdateGroup must fail before HTTP when ID is empty: %s", r.URL.Path)
+	})
+	if err := client.UpdateGroup(context.Background(), Group{Name: "no-id"}); err == nil {
+		t.Fatal("expected error for empty UUID")
+	}
+}
+
+func TestDeleteGroup_NotFound(t *testing.T) {
+	client := groupTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/realms/test-realm/protocol/openid-connect/token":
+			saTokenHandler(w)
+		case r.Method == http.MethodDelete && r.URL.Path == "/admin/realms/test-realm/groups/gone":
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+	if err := client.DeleteGroup(context.Background(), "gone"); !errors.Is(err, ErrGroupNotFound) {
+		t.Fatalf("expected ErrGroupNotFound, got %v", err)
+	}
+}
+
+func TestAttributesEqual(t *testing.T) {
+	cases := []struct {
+		name string
+		a, b map[string][]string
+		want bool
+	}{
+		{"both nil", nil, nil, true},
+		{"both empty", map[string][]string{}, map[string][]string{}, true},
+		{"identical single", map[string][]string{"k": {"v"}}, map[string][]string{"k": {"v"}}, true},
+		{"identical multi", map[string][]string{"k": {"a", "b"}}, map[string][]string{"k": {"a", "b"}}, true},
+		{"different value", map[string][]string{"k": {"v1"}}, map[string][]string{"k": {"v2"}}, false},
+		{"different length", map[string][]string{"k": {"v"}}, map[string][]string{"k": {"v"}, "k2": {"v2"}}, false},
+		{"missing key", map[string][]string{"k": {"v"}}, map[string][]string{"j": {"v"}}, false},
+		{"order matters in slice", map[string][]string{"k": {"a", "b"}}, map[string][]string{"k": {"b", "a"}}, false},
+	}
+	for _, c := range cases {
+		if got := attributesEqual(c.a, c.b); got != c.want {
+			t.Errorf("%s: got %v, want %v", c.name, got, c.want)
+		}
+	}
+}
+
+func TestLastSlashIndex(t *testing.T) {
+	cases := map[string]int{
+		"/acme":      0,
+		"/acme/sub":  5,
+		"acme":       -1,
+		"":           -1,
+		"/":          0,
+		"a/b/c":      3,
+	}
+	for in, want := range cases {
+		if got := lastSlashIndex(in); got != want {
+			t.Errorf("lastSlashIndex(%q) = %d, want %d", in, got, want)
+		}
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/keycloak/admin_secrets.go
+++ b/products/catalyst/bootstrap/api/internal/keycloak/admin_secrets.go
@@ -1,0 +1,115 @@
+package keycloak
+
+// admin_secrets.go — Per-OIDC-client client-secret read + rotation.
+//
+// Slice D1c of EPIC-0 #1095. organization-controller (slice C1) calls
+// these when it provisions a new OIDC client for a per-Org integration:
+// the freshly-generated secret is fetched from Keycloak, written into
+// a SealedSecret on the cluster, and never persisted in catalyst-api's
+// own state.
+//
+// Per docs/CLAUDE.md §10 the secret is in memory only long enough to
+// be handed to the SealedSecret writer.
+//
+// Endpoints used:
+//   GET  /admin/realms/{realm}/clients/{uuid}/client-secret
+//   POST /admin/realms/{realm}/clients/{uuid}/client-secret  (regenerate)
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+)
+
+// ClientSecret carries the secret value Keycloak emits on read or
+// rotation. The Type field is constant ("secret") for OIDC clients
+// in client-secret authenticator mode but is preserved here so the
+// access-matrix UI can detect any future authenticator types.
+type ClientSecret struct {
+	Type  string `json:"type,omitempty"`
+	Value string `json:"value"`
+}
+
+// GetClientSecret fetches the current client_secret of an OIDC client
+// (by Keycloak UUID). Returns ErrClientNotFound on 404.
+//
+// The returned ClientSecret.Value is plaintext — caller MUST write it
+// to a SealedSecret immediately and never log it.
+func (c *Client) GetClientSecret(ctx context.Context, uuid string) (ClientSecret, error) {
+	saToken, err := c.serviceAccountToken(ctx)
+	if err != nil {
+		return ClientSecret{}, fmt.Errorf("keycloak.GetClientSecret: service account token: %w", err)
+	}
+
+	u := fmt.Sprintf("%s/admin/realms/%s/clients/%s/client-secret",
+		c.addr, c.realm, url.PathEscape(uuid))
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return ClientSecret{}, err
+	}
+	req.Header.Set("Authorization", "Bearer "+saToken)
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return ClientSecret{}, fmt.Errorf("keycloak: GET client-secret: %w", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode == http.StatusNotFound {
+		return ClientSecret{}, ErrClientNotFound
+	}
+	if resp.StatusCode != http.StatusOK {
+		return ClientSecret{}, fmt.Errorf("keycloak: GET client-secret %d: %s", resp.StatusCode, body)
+	}
+	var s ClientSecret
+	if err := json.Unmarshal(body, &s); err != nil {
+		return ClientSecret{}, fmt.Errorf("keycloak: decode client-secret: %w", err)
+	}
+	return s, nil
+}
+
+// RotateClientSecret asks Keycloak to generate a new client_secret for
+// the OIDC client (by Keycloak UUID). The new secret is returned in
+// the response body; the previous secret is invalidated immediately
+// (no overlap window — callers must write the new value to the
+// SealedSecret + restart consumers atomically).
+//
+// Used by the SecretPolicy reconciler (post-Phase-0) per
+// docs/EPICS-1-6-unified-design.md §3.2.6.
+//
+// Returns ErrClientNotFound on 404.
+func (c *Client) RotateClientSecret(ctx context.Context, uuid string) (ClientSecret, error) {
+	saToken, err := c.serviceAccountToken(ctx)
+	if err != nil {
+		return ClientSecret{}, fmt.Errorf("keycloak.RotateClientSecret: service account token: %w", err)
+	}
+
+	u := fmt.Sprintf("%s/admin/realms/%s/clients/%s/client-secret",
+		c.addr, c.realm, url.PathEscape(uuid))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, u, nil)
+	if err != nil {
+		return ClientSecret{}, err
+	}
+	req.Header.Set("Authorization", "Bearer "+saToken)
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return ClientSecret{}, fmt.Errorf("keycloak: POST client-secret: %w", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode == http.StatusNotFound {
+		return ClientSecret{}, ErrClientNotFound
+	}
+	if resp.StatusCode != http.StatusOK {
+		return ClientSecret{}, fmt.Errorf("keycloak: POST client-secret %d: %s", resp.StatusCode, body)
+	}
+	var s ClientSecret
+	if err := json.Unmarshal(body, &s); err != nil {
+		return ClientSecret{}, fmt.Errorf("keycloak: decode rotated secret: %w", err)
+	}
+	return s, nil
+}

--- a/products/catalyst/bootstrap/api/internal/keycloak/admin_secrets_test.go
+++ b/products/catalyst/bootstrap/api/internal/keycloak/admin_secrets_test.go
@@ -1,0 +1,98 @@
+package keycloak
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func secretTestClient(t *testing.T, handler http.HandlerFunc) *Client {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	return NewWithHTTP(srv.URL, "test-realm", "catalyst-api-server", "sa-secret",
+		&http.Client{Timeout: 5 * time.Second})
+}
+
+func TestGetClientSecret_HappyPath(t *testing.T) {
+	client := secretTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/realms/test-realm/protocol/openid-connect/token":
+			saTokenHandler(w)
+		case r.Method == http.MethodGet && r.URL.Path == "/admin/realms/test-realm/clients/uuid-1/client-secret":
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`{"type":"secret","value":"abc-1234567890"}`))
+		default:
+			t.Errorf("unexpected: %s %s", r.Method, r.URL.Path)
+		}
+	})
+	got, err := client.GetClientSecret(context.Background(), "uuid-1")
+	if err != nil {
+		t.Fatalf("GetClientSecret: %v", err)
+	}
+	if got.Value != "abc-1234567890" {
+		t.Fatalf("expected secret value, got %q", got.Value)
+	}
+	if got.Type != "secret" {
+		t.Fatalf("expected type=secret, got %q", got.Type)
+	}
+}
+
+func TestGetClientSecret_NotFound(t *testing.T) {
+	client := secretTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/realms/test-realm/protocol/openid-connect/token":
+			saTokenHandler(w)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+	_, err := client.GetClientSecret(context.Background(), "missing")
+	if !errors.Is(err, ErrClientNotFound) {
+		t.Fatalf("expected ErrClientNotFound, got %v", err)
+	}
+}
+
+func TestRotateClientSecret_HappyPath(t *testing.T) {
+	var posted bool
+	client := secretTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/realms/test-realm/protocol/openid-connect/token":
+			saTokenHandler(w)
+		case r.Method == http.MethodPost && r.URL.Path == "/admin/realms/test-realm/clients/uuid-1/client-secret":
+			posted = true
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`{"type":"secret","value":"new-rotated-value"}`))
+		default:
+			t.Errorf("unexpected: %s %s", r.Method, r.URL.Path)
+		}
+	})
+	got, err := client.RotateClientSecret(context.Background(), "uuid-1")
+	if err != nil {
+		t.Fatalf("RotateClientSecret: %v", err)
+	}
+	if !posted {
+		t.Fatal("RotateClientSecret must POST")
+	}
+	if got.Value != "new-rotated-value" {
+		t.Fatalf("expected new-rotated-value, got %q", got.Value)
+	}
+}
+
+func TestRotateClientSecret_NotFound(t *testing.T) {
+	client := secretTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/realms/test-realm/protocol/openid-connect/token":
+			saTokenHandler(w)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+	_, err := client.RotateClientSecret(context.Background(), "missing")
+	if !errors.Is(err, ErrClientNotFound) {
+		t.Fatalf("expected ErrClientNotFound, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Slice **D1c** of EPIC-0 (#1095). Final D1 sub-slice. Two new files:

- \`internal/keycloak/admin_groups.go\` — full Group CRUD + EnsureGroup with drift-detection + SetGroupAttributes
- \`internal/keycloak/admin_secrets.go\` — per-OIDC-client \`GetClientSecret\` + \`RotateClientSecret\`

## Group API (admin_groups.go)

| Function | Endpoint |
|---|---|
| \`ListGroups\` | GET /groups |
| \`GetGroup\` | GET /groups/{uuid} → \`ErrGroupNotFound\` |
| \`FindGroupByPath\` | GET /group-by-path/{path} (leading-slash tolerant) |
| \`CreateGroup\` | POST /groups (UUID from Location) |
| \`CreateSubGroup\` | POST /groups/{parent}/children |
| \`UpdateGroup\` | PUT /groups/{uuid} (full replace) |
| \`DeleteGroup\` | DELETE /groups/{uuid} → \`ErrGroupNotFound\` |
| \`EnsureGroup\` | find-or-create with **drift-detection** — PUTs new attrs if existing group has different ones |
| \`SetGroupAttributes\` | GET-mutate-PUT helper |

## Secret API (admin_secrets.go)

| Function | Endpoint |
|---|---|
| \`GetClientSecret\` | GET /clients/{uuid}/client-secret |
| \`RotateClientSecret\` | POST /clients/{uuid}/client-secret |

Caller MUST write the plaintext value to a SealedSecret immediately and never log it (per CLAUDE.md §10).

## Group attributes — the join key

Per-Org groups carry \`org=<slug>\`, \`tier=<viewer|developer|...>\`, \`openova_scope=<key=value>\` attributes. The Keycloak realm's group-mapper renders these into the access token's \`org\`, \`tier\`, \`openova_scopes\` claims (parsed by auth/Claims in slice D2 #1118).

## Test plan

- 15 group test cases + 4 secret test cases
- \`go test ./internal/keycloak/...\` — all pass (~36 tests across admin.go, admin_roles.go, admin_groups.go, admin_secrets.go)
- \`go build ./... && go vet ./...\` — clean
- Rebased on main after D1b (#1124) merged

## D1 status: COMPLETE

D1a (#1123) Client CRUD + D1b (#1124) Role + RoleMapping + D1c (this) Group + Secret = full Keycloak admin surface useraccess-controller (slice C5) and organization-controller (slice C1) need.

Identity Provider CRUD for corporate Azure-SSO federation remains post-Phase-0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)