### PR TITLE
feat(bp-kyverno): land 19 compliance ClusterPolicy templates (slice K, #1096)

### DIFF
--- a/platform/kyverno/chart/templates/policies/baseline/01-multi-replica.yaml
+++ b/platform/kyverno/chart/templates/policies/baseline/01-multi-replica.yaml
@@ -1,0 +1,64 @@
+{{/*
+K1 — multi-replica-drainability (resilience, permissive default).
+
+Drainability gate: Deployment / StatefulSet must declare replicas >= 2 so
+that voluntary node drains and rolling updates can keep at least one
+replica serving traffic. Single-replica workloads are fine for batch
+jobs and for explicitly-singleton services (databases with their own HA
+mechanism), but for the general case they break the eviction contract.
+
+Default mode is permissive (Audit) per docs/EPICS-1-6-unified-design.md
+§4.3 — flipped to Enforce per-Environment via EnvironmentPolicy.spec.
+compliance.modes.multiReplica.
+
+Per docs/INVIOLABLE-PRINCIPLES.md #4 every value here is configurable
+via .Values.compliancePolicies.multiReplica.* — operators override per
+Sovereign overlay.
+*/}}
+{{- if .Values.compliancePolicies.multiReplica.enabled -}}
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: multi-replica-drainability
+  labels:
+    app.kubernetes.io/name: bp-kyverno
+    app.kubernetes.io/component: compliance-policy
+    catalyst.openova.io/policy-tier: compliance
+    catalyst.openova.io/policy-domain: resilience
+  annotations:
+    policies.kyverno.io/title: Workloads must declare 2+ replicas
+    policies.kyverno.io/category: catalyst-compliance
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/description: >-
+      Deployments and StatefulSets must declare spec.replicas >= 2 so
+      voluntary disruptions (node drains, rolling updates) can preserve
+      at least one healthy replica.
+spec:
+  validationFailureAction: {{ .Values.compliancePolicies.multiReplica.action | default "Audit" }}
+  background: true
+  rules:
+    - name: replicas-at-least-two
+      match:
+        any:
+          - resources:
+              kinds:
+                - Deployment
+                - StatefulSet
+      exclude:
+        any:
+          - resources:
+              namespaces:
+                {{- range $ns := .Values.compliancePolicies.multiReplica.excludeNamespaces }}
+                - {{ $ns }}
+                {{- end }}
+      validate:
+        message: >-
+          {{ `{{request.object.kind}}/{{request.object.metadata.name}}` }} declares
+          fewer than 2 replicas. Drainability requires spec.replicas >= 2 so
+          voluntary disruptions can keep at least one replica serving traffic.
+          Bump spec.replicas, or exempt this workload by adding its namespace
+          to .Values.compliancePolicies.multiReplica.excludeNamespaces.
+        pattern:
+          spec:
+            replicas: ">=2"
+{{- end -}}

--- a/platform/kyverno/chart/templates/policies/baseline/02-pdb.yaml
+++ b/platform/kyverno/chart/templates/policies/baseline/02-pdb.yaml
@@ -1,0 +1,78 @@
+{{/*
+K1 — pdb-permits-eviction (resilience, permissive default).
+
+A workload Deployment / StatefulSet must have a PodDisruptionBudget
+selecting it that PERMITS eviction (i.e. doesn't fully wedge the
+controller). The permits-eviction check is shaped as: if
+spec.maxUnavailable is set, it must be >= 1 OR a percentage; if
+spec.minAvailable is set, it must NOT equal the workload's full
+replica count (otherwise no Pod can ever be evicted).
+
+The "matching PDB exists" half of the contract is harder to express
+via Kyverno's pattern engine for the workload kind itself (Kyverno's
+context.apiCall would have to enumerate PDBs in the namespace and
+match labels). Instead this policy validates the PDB resource at
+admission time: when a PodDisruptionBudget is created/updated, its
+fields must permit eviction. The "PDB is missing entirely" check is
+deferred to slice S1 (compliance-aggregator) — it joins the workload
+list against the PDB list and emits synthetic PolicyReport rows for
+workloads with no PDB.
+
+Default mode permissive (Audit) per design §4.3.
+*/}}
+{{- if .Values.compliancePolicies.pdb.enabled -}}
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: pdb-permits-eviction
+  labels:
+    app.kubernetes.io/name: bp-kyverno
+    app.kubernetes.io/component: compliance-policy
+    catalyst.openova.io/policy-tier: compliance
+    catalyst.openova.io/policy-domain: resilience
+  annotations:
+    policies.kyverno.io/title: PodDisruptionBudgets must permit eviction
+    policies.kyverno.io/category: catalyst-compliance
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/description: >-
+      A PodDisruptionBudget with maxUnavailable=0 (or minAvailable equal
+      to the workload's full replica count) wedges every voluntary
+      disruption. This policy rejects PDBs whose maxUnavailable is 0.
+spec:
+  validationFailureAction: {{ .Values.compliancePolicies.pdb.action | default "Audit" }}
+  background: true
+  rules:
+    - name: pdb-maxunavailable-not-zero
+      match:
+        any:
+          - resources:
+              kinds:
+                - PodDisruptionBudget
+      exclude:
+        any:
+          - resources:
+              namespaces:
+                {{- range $ns := .Values.compliancePolicies.pdb.excludeNamespaces }}
+                - {{ $ns }}
+                {{- end }}
+      preconditions:
+        all:
+          - key: "{{ `{{ request.object.spec.maxUnavailable || ''}}` }}"
+            operator: NotEquals
+            value: ""
+      validate:
+        message: >-
+          PodDisruptionBudget {{ `{{request.object.metadata.name}}` }} has
+          maxUnavailable=0 which blocks every voluntary eviction. Set
+          maxUnavailable to >=1 (or a percentage), or use minAvailable
+          strictly less than the workload's replica count.
+        deny:
+          conditions:
+            any:
+              - key: "{{ `{{ request.object.spec.maxUnavailable }}` }}"
+                operator: Equals
+                value: 0
+              - key: "{{ `{{ request.object.spec.maxUnavailable }}` }}"
+                operator: Equals
+                value: "0%"
+{{- end -}}

--- a/platform/kyverno/chart/templates/policies/baseline/03-topology-spread.yaml
+++ b/platform/kyverno/chart/templates/policies/baseline/03-topology-spread.yaml
@@ -1,0 +1,74 @@
+{{/*
+K1 — topology-spread (resilience, permissive default).
+
+Deployments / StatefulSets with replicas >= 2 must declare a
+topologySpreadConstraint across either kubernetes.io/hostname or
+topology.kubernetes.io/zone, so a single host or AZ failure cannot
+remove every replica.
+
+Single-replica workloads are out of scope here (multi-replica policy
+catches those). PodAntiAffinity is an acceptable alternative pattern
+but Kyverno's pattern engine cannot cleanly express OR across two
+unrelated tree shapes (topologySpreadConstraints vs affinity); the
+affinity case is checked by the W2 evaluator as a synthetic compliance
+row. This policy enforces ONLY the topologySpreadConstraints branch
+when triggered.
+
+Default mode permissive per §4.3.
+*/}}
+{{- if .Values.compliancePolicies.topologySpread.enabled -}}
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: topology-spread
+  labels:
+    app.kubernetes.io/name: bp-kyverno
+    app.kubernetes.io/component: compliance-policy
+    catalyst.openova.io/policy-tier: compliance
+    catalyst.openova.io/policy-domain: resilience
+  annotations:
+    policies.kyverno.io/title: Multi-replica workloads must spread across hostname or zone
+    policies.kyverno.io/category: catalyst-compliance
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/description: >-
+      Deployments / StatefulSets with replicas >= 2 must declare
+      topologySpreadConstraints with topologyKey of kubernetes.io/hostname
+      or topology.kubernetes.io/zone, so a single host or AZ failure
+      can't take down every replica.
+spec:
+  validationFailureAction: {{ .Values.compliancePolicies.topologySpread.action | default "Audit" }}
+  background: true
+  rules:
+    - name: workload-must-declare-spread
+      match:
+        any:
+          - resources:
+              kinds:
+                - Deployment
+                - StatefulSet
+      exclude:
+        any:
+          - resources:
+              namespaces:
+                {{- range $ns := .Values.compliancePolicies.topologySpread.excludeNamespaces }}
+                - {{ $ns }}
+                {{- end }}
+      preconditions:
+        all:
+          - key: '{{ printf "{{ request.object.spec.replicas || `0` }}" }}'
+            operator: GreaterThanOrEquals
+            value: 2
+      validate:
+        message: >-
+          Multi-replica workload
+          {{ `{{request.object.kind}}/{{request.object.metadata.name}}` }} is
+          missing topologySpreadConstraints. Add at least one constraint
+          with topologyKey kubernetes.io/hostname or
+          topology.kubernetes.io/zone.
+        pattern:
+          spec:
+            template:
+              spec:
+                topologySpreadConstraints:
+                  - topologyKey: "kubernetes.io/hostname | topology.kubernetes.io/zone"
+{{- end -}}

--- a/platform/kyverno/chart/templates/policies/baseline/04-probes.yaml
+++ b/platform/kyverno/chart/templates/policies/baseline/04-probes.yaml
@@ -1,0 +1,68 @@
+{{/*
+K1 — probes-present (resilience, ENFORCING default).
+
+Every container in a Deployment / StatefulSet / DaemonSet must declare
+both livenessProbe AND readinessProbe. Without these, kubelet can't
+detect a wedged process and Service can't gate traffic during startup,
+which routinely produces 503 cascades during rollouts.
+
+Default mode enforcing per design §4.3 — this is one of the rules with
+near-universal industry consensus, so blocking new violators is safer
+than auditing.
+
+Init containers and ephemeralContainers are NOT subject to this rule
+(K8s API doesn't accept liveness/readiness probes on initContainers).
+*/}}
+{{- if .Values.compliancePolicies.probesPresent.enabled -}}
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: probes-present
+  labels:
+    app.kubernetes.io/name: bp-kyverno
+    app.kubernetes.io/component: compliance-policy
+    catalyst.openova.io/policy-tier: compliance
+    catalyst.openova.io/policy-domain: resilience
+  annotations:
+    policies.kyverno.io/title: Containers must declare liveness and readiness probes
+    policies.kyverno.io/category: catalyst-compliance
+    policies.kyverno.io/severity: high
+    policies.kyverno.io/description: >-
+      Every primary container in a Deployment / StatefulSet / DaemonSet
+      must declare both livenessProbe and readinessProbe. Without
+      probes, kubelet can't detect a wedged process and Service can't
+      gate traffic during startup.
+spec:
+  validationFailureAction: {{ .Values.compliancePolicies.probesPresent.action | default "Audit" }}
+  background: true
+  rules:
+    - name: containers-must-have-liveness-and-readiness
+      match:
+        any:
+          - resources:
+              kinds:
+                - Deployment
+                - StatefulSet
+                - DaemonSet
+      exclude:
+        any:
+          - resources:
+              namespaces:
+                {{- range $ns := .Values.compliancePolicies.probesPresent.excludeNamespaces }}
+                - {{ $ns }}
+                {{- end }}
+      validate:
+        message: >-
+          Every container in
+          {{ `{{request.object.kind}}/{{request.object.metadata.name}}` }} must
+          declare both livenessProbe and readinessProbe.
+        pattern:
+          spec:
+            template:
+              spec:
+                containers:
+                  - livenessProbe:
+                      "?{}": "?*"
+                    readinessProbe:
+                      "?{}": "?*"
+{{- end -}}

--- a/platform/kyverno/chart/templates/policies/baseline/05-resource-requests.yaml
+++ b/platform/kyverno/chart/templates/policies/baseline/05-resource-requests.yaml
@@ -1,0 +1,67 @@
+{{/*
+K1 — resource-requests (resilience, ENFORCING default).
+
+Every container must declare resources.requests.cpu AND
+resources.requests.memory. Without requests, the scheduler treats the
+Pod as BestEffort, which means it (a) gets evicted first under
+pressure and (b) can't be reasoned about for capacity planning.
+
+Default mode enforcing per design §4.3 — requests are mandatory for
+Catalyst's per-Org accounting (slice S1 sums them for billing
+projection) so missing values silently corrupt the rollup.
+*/}}
+{{- if .Values.compliancePolicies.resourceRequests.enabled -}}
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: resource-requests
+  labels:
+    app.kubernetes.io/name: bp-kyverno
+    app.kubernetes.io/component: compliance-policy
+    catalyst.openova.io/policy-tier: compliance
+    catalyst.openova.io/policy-domain: resilience
+  annotations:
+    policies.kyverno.io/title: Containers must declare CPU and memory requests
+    policies.kyverno.io/category: catalyst-compliance
+    policies.kyverno.io/severity: high
+    policies.kyverno.io/description: >-
+      Every container must declare resources.requests.cpu AND
+      resources.requests.memory. BestEffort Pods evict first under
+      pressure and can't be reasoned about for capacity planning or
+      per-Org cost rollups.
+spec:
+  validationFailureAction: {{ .Values.compliancePolicies.resourceRequests.action | default "Audit" }}
+  background: true
+  rules:
+    - name: containers-must-declare-cpu-memory-requests
+      match:
+        any:
+          - resources:
+              kinds:
+                - Deployment
+                - StatefulSet
+                - DaemonSet
+                - Job
+                - CronJob
+      exclude:
+        any:
+          - resources:
+              namespaces:
+                {{- range $ns := .Values.compliancePolicies.resourceRequests.excludeNamespaces }}
+                - {{ $ns }}
+                {{- end }}
+      validate:
+        message: >-
+          Every container in
+          {{ `{{request.object.kind}}/{{request.object.metadata.name}}` }} must
+          declare resources.requests.cpu and resources.requests.memory.
+        pattern:
+          spec:
+            template:
+              spec:
+                containers:
+                  - resources:
+                      requests:
+                        cpu: "?*"
+                        memory: "?*"
+{{- end -}}

--- a/platform/kyverno/chart/templates/policies/baseline/06-resource-limits.yaml
+++ b/platform/kyverno/chart/templates/policies/baseline/06-resource-limits.yaml
@@ -1,0 +1,67 @@
+{{/*
+K1 — resource-limits (resilience, permissive default).
+
+Every container should declare resources.limits.cpu AND
+resources.limits.memory. Limits are weaker than requests
+(workloads CAN run without them) and over-tight CPU limits hurt
+throughput, but no-limits-at-all means a single misbehaving Pod can
+exhaust a node.
+
+Default mode permissive (Audit) per design §4.3 — operators may
+flip to Enforce on regulated Environments where noisy-neighbor
+isolation is mandatory.
+*/}}
+{{- if .Values.compliancePolicies.resourceLimits.enabled -}}
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: resource-limits
+  labels:
+    app.kubernetes.io/name: bp-kyverno
+    app.kubernetes.io/component: compliance-policy
+    catalyst.openova.io/policy-tier: compliance
+    catalyst.openova.io/policy-domain: resilience
+  annotations:
+    policies.kyverno.io/title: Containers should declare CPU and memory limits
+    policies.kyverno.io/category: catalyst-compliance
+    policies.kyverno.io/severity: low
+    policies.kyverno.io/description: >-
+      Every container should declare resources.limits.cpu AND
+      resources.limits.memory. Without limits, a single Pod can
+      exhaust a node and starve neighbors.
+spec:
+  validationFailureAction: {{ .Values.compliancePolicies.resourceLimits.action | default "Audit" }}
+  background: true
+  rules:
+    - name: containers-must-declare-cpu-memory-limits
+      match:
+        any:
+          - resources:
+              kinds:
+                - Deployment
+                - StatefulSet
+                - DaemonSet
+                - Job
+                - CronJob
+      exclude:
+        any:
+          - resources:
+              namespaces:
+                {{- range $ns := .Values.compliancePolicies.resourceLimits.excludeNamespaces }}
+                - {{ $ns }}
+                {{- end }}
+      validate:
+        message: >-
+          Every container in
+          {{ `{{request.object.kind}}/{{request.object.metadata.name}}` }} must
+          declare resources.limits.cpu and resources.limits.memory.
+        pattern:
+          spec:
+            template:
+              spec:
+                containers:
+                  - resources:
+                      limits:
+                        cpu: "?*"
+                        memory: "?*"
+{{- end -}}

--- a/platform/kyverno/chart/templates/policies/baseline/07-pvc-expansion.yaml
+++ b/platform/kyverno/chart/templates/policies/baseline/07-pvc-expansion.yaml
@@ -1,0 +1,74 @@
+{{/*
+K1 — pvc-volume-expansion (resilience, permissive default; stateful only).
+
+PersistentVolumeClaims must reference a StorageClass whose
+allowVolumeExpansion=true, so capacity can grow without re-provisioning
+storage. Stateless workloads have no PVCs and drop out of the score
+denominator (per design §4.3 footnote).
+
+This policy validates the StorageClass referenced by the PVC at admission
+time. If the PVC's spec.storageClassName is unset (cluster default
+applies), the rule is skipped — the cluster default's expansion ability
+is checked when the StorageClass itself is admitted (via context.apiCall
+in a sibling rule).
+
+Default mode permissive per §4.3.
+*/}}
+{{- if .Values.compliancePolicies.pvcExpansion.enabled -}}
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: pvc-volume-expansion
+  labels:
+    app.kubernetes.io/name: bp-kyverno
+    app.kubernetes.io/component: compliance-policy
+    catalyst.openova.io/policy-tier: compliance
+    catalyst.openova.io/policy-domain: resilience
+  annotations:
+    policies.kyverno.io/title: PVC StorageClass must allow volume expansion
+    policies.kyverno.io/category: catalyst-compliance
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/description: >-
+      PersistentVolumeClaims should reference a StorageClass with
+      allowVolumeExpansion=true so storage can grow without rebuilding
+      the volume.
+spec:
+  validationFailureAction: {{ .Values.compliancePolicies.pvcExpansion.action | default "Audit" }}
+  background: true
+  rules:
+    - name: storageclass-must-allow-expansion
+      match:
+        any:
+          - resources:
+              kinds:
+                - PersistentVolumeClaim
+      exclude:
+        any:
+          - resources:
+              namespaces:
+                {{- range $ns := .Values.compliancePolicies.pvcExpansion.excludeNamespaces }}
+                - {{ $ns }}
+                {{- end }}
+      preconditions:
+        all:
+          - key: "{{ `{{ request.object.spec.storageClassName || ''}}` }}"
+            operator: NotEquals
+            value: ""
+      context:
+        - name: scExpansion
+          apiCall:
+            urlPath: "/apis/storage.k8s.io/v1/storageclasses/{{ `{{request.object.spec.storageClassName}}` }}"
+            jmesPath: "allowVolumeExpansion || `false`"
+      validate:
+        message: >-
+          PVC {{ `{{request.object.metadata.name}}` }} references
+          StorageClass {{ `{{request.object.spec.storageClassName}}` }} which
+          does not allow volume expansion. Choose a StorageClass with
+          allowVolumeExpansion=true, or extend the existing one.
+        deny:
+          conditions:
+            any:
+              - key: "{{ `{{ scExpansion }}` }}"
+                operator: NotEquals
+                value: true
+{{- end -}}

--- a/platform/kyverno/chart/templates/policies/baseline/08-hpa-effective.yaml
+++ b/platform/kyverno/chart/templates/policies/baseline/08-hpa-effective.yaml
@@ -1,0 +1,64 @@
+{{/*
+K1 — hpa-effective (resilience, permissive default).
+
+If a HorizontalPodAutoscaler exists for a Deployment / StatefulSet, the
+target's spec.replicas should NOT be set to a value below
+hpa.spec.minReplicas — otherwise the HPA reverts the operator's intent
+on the next sync. This is also a sentinel for misconfigured CD pipelines
+that hardcode replicas while expecting the HPA to handle scale.
+
+The full HPA effectiveness check (current pod count >= minReplicas after
+scaling stabilizes) is impossible to express as a Kyverno rule because
+it requires runtime inspection of the live Deployment.status — that
+half lives in the W2 evaluator (`evaluators/hpa.go`). This policy only
+catches the static-config violation: replicas < HPA.minReplicas declared
+in spec.
+
+Default mode permissive per design §4.3.
+*/}}
+{{- if .Values.compliancePolicies.hpaEffective.enabled -}}
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: hpa-effective
+  labels:
+    app.kubernetes.io/name: bp-kyverno
+    app.kubernetes.io/component: compliance-policy
+    catalyst.openova.io/policy-tier: compliance
+    catalyst.openova.io/policy-domain: resilience
+  annotations:
+    policies.kyverno.io/title: HPA minReplicas must not exceed workload spec.replicas
+    policies.kyverno.io/category: catalyst-compliance
+    policies.kyverno.io/severity: low
+    policies.kyverno.io/description: >-
+      When a HorizontalPodAutoscaler is admitted, its spec.minReplicas
+      must be >= 1 and the targeted workload's declared replicas should
+      not be below the HPA floor. Runtime effectiveness (current ready
+      Pod count) is checked by the compliance-aggregator's hpa.go
+      evaluator (slice W2).
+spec:
+  validationFailureAction: {{ .Values.compliancePolicies.hpaEffective.action | default "Audit" }}
+  background: true
+  rules:
+    - name: hpa-minreplicas-positive
+      match:
+        any:
+          - resources:
+              kinds:
+                - HorizontalPodAutoscaler
+      exclude:
+        any:
+          - resources:
+              namespaces:
+                {{- range $ns := .Values.compliancePolicies.hpaEffective.excludeNamespaces }}
+                - {{ $ns }}
+                {{- end }}
+      validate:
+        message: >-
+          HPA {{ `{{request.object.metadata.name}}` }} declares
+          spec.minReplicas < 1 — the autoscaler cannot scale to zero
+          and run; set minReplicas >= 1.
+        pattern:
+          spec:
+            minReplicas: ">=1"
+{{- end -}}

--- a/platform/kyverno/chart/templates/policies/baseline/09-cilium-l7-mtls.yaml
+++ b/platform/kyverno/chart/templates/policies/baseline/09-cilium-l7-mtls.yaml
@@ -1,0 +1,72 @@
+{{/*
+K1 — cilium-l7-mtls (security, ENFORCING default).
+
+Pods should be selected by at least one CiliumNetworkPolicy (CNP) or
+CiliumClusterwideNetworkPolicy (CCNP) so that east-west traffic to/from
+the Pod is mediated by the L7 mTLS policy plane. Workloads with no
+selecting CNP/CCNP fall through to default-allow (or default-deny if
+the cluster baseline is hardened — see slice E5 of design §4.5).
+
+Pure Kyverno can't query the CNP set and join against Pod labels at
+admission time without expensive context.apiCall enumeration. The
+cleanest seam: validate that every Pod carries the
+`policy.cilium.io/enforced: "true"` annotation written by the
+catalyst-network-controller (future slice EPIC-5 #1100), OR that the
+namespace has at least one CCNP applied (which the W2 evaluator's
+`hubble.go` already inspects).
+
+Default mode enforcing per design §4.3.
+*/}}
+{{- if .Values.compliancePolicies.ciliumL7Mtls.enabled -}}
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: cilium-l7-mtls
+  labels:
+    app.kubernetes.io/name: bp-kyverno
+    app.kubernetes.io/component: compliance-policy
+    catalyst.openova.io/policy-tier: compliance
+    catalyst.openova.io/policy-domain: security
+  annotations:
+    policies.kyverno.io/title: Workloads must be covered by a Cilium L7 policy
+    policies.kyverno.io/category: catalyst-compliance
+    policies.kyverno.io/severity: high
+    policies.kyverno.io/description: >-
+      Pod templates must declare the
+      `policy.cilium.io/enforced: "true"` label so the catalyst-network
+      controller routes them under the zero-trust mesh. The runtime
+      "is there an actual selecting CNP/CCNP" check lives in the W2
+      hubble evaluator.
+spec:
+  validationFailureAction: {{ .Values.compliancePolicies.ciliumL7Mtls.action | default "Audit" }}
+  background: true
+  rules:
+    - name: cilium-enforced-label
+      match:
+        any:
+          - resources:
+              kinds:
+                - Deployment
+                - StatefulSet
+                - DaemonSet
+      exclude:
+        any:
+          - resources:
+              namespaces:
+                {{- range $ns := .Values.compliancePolicies.ciliumL7Mtls.excludeNamespaces }}
+                - {{ $ns }}
+                {{- end }}
+      validate:
+        message: >-
+          Workload
+          {{ `{{request.object.kind}}/{{request.object.metadata.name}}` }} is
+          missing label `policy.cilium.io/enforced: "true"` on
+          spec.template.metadata.labels. The catalyst-network controller
+          uses this label to attach the Pod to the L7 mTLS mesh.
+        pattern:
+          spec:
+            template:
+              metadata:
+                labels:
+                  policy.cilium.io/enforced: "true"
+{{- end -}}

--- a/platform/kyverno/chart/templates/policies/baseline/10-flux-managed.yaml
+++ b/platform/kyverno/chart/templates/policies/baseline/10-flux-managed.yaml
@@ -1,0 +1,78 @@
+{{/*
+K1 — flux-managed (governance, ENFORCING default).
+
+Every workload-rendering resource on a Sovereign must be managed by
+Flux — i.e. owned by a Kustomization or HelmRelease, OR carry the
+`app.kubernetes.io/managed-by: flux` label as a fallback. Direct
+`kubectl apply` is the standing anti-pattern (see CLAUDE.md §4 — IaC
+first).
+
+Catalyst's mutate-add-openova-labels (slice E1) writes the
+`openova.io/managed-by: flux` label when an ownerReference points at a
+Flux resource, so this validate rule MAY be in tension with E1's mutate
+on the very first admission cycle. To avoid the tension, this rule
+checks `app.kubernetes.io/managed-by`, the canonical label the
+upstream Flux controllers themselves write — not Catalyst's overlay
+label.
+
+Default mode enforcing per design §4.3.
+*/}}
+{{- if .Values.compliancePolicies.fluxManaged.enabled -}}
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: flux-managed
+  labels:
+    app.kubernetes.io/name: bp-kyverno
+    app.kubernetes.io/component: compliance-policy
+    catalyst.openova.io/policy-tier: compliance
+    catalyst.openova.io/policy-domain: governance
+  annotations:
+    policies.kyverno.io/title: Workloads must be managed by Flux
+    policies.kyverno.io/category: catalyst-compliance
+    policies.kyverno.io/severity: high
+    policies.kyverno.io/description: >-
+      Workload-rendering resources must carry
+      `app.kubernetes.io/managed-by: flux` (the upstream Flux label) OR
+      have an ownerReference pointing at a HelmRelease / Kustomization.
+      Direct kubectl apply is rejected — IaC-first per
+      docs/INVIOLABLE-PRINCIPLES.md #3.
+spec:
+  validationFailureAction: {{ .Values.compliancePolicies.fluxManaged.action | default "Audit" }}
+  background: true
+  rules:
+    - name: workload-must-be-flux-managed
+      match:
+        any:
+          - resources:
+              kinds:
+                - Deployment
+                - StatefulSet
+                - DaemonSet
+                - Job
+                - CronJob
+                - Service
+                - Ingress
+      exclude:
+        any:
+          - resources:
+              namespaces:
+                {{- range $ns := .Values.compliancePolicies.fluxManaged.excludeNamespaces }}
+                - {{ $ns }}
+                {{- end }}
+      validate:
+        message: >-
+          {{ `{{request.object.kind}}/{{request.object.metadata.name}}` }} is
+          not Flux-managed. Add label
+          `app.kubernetes.io/managed-by: flux` on metadata.labels OR
+          attach an ownerReference to a HelmRelease / Kustomization.
+        deny:
+          conditions:
+            all:
+              - key: '{{ `{{ request.object.metadata.labels."app.kubernetes.io/managed-by" || '''' }}` }}'
+                operator: NotEquals
+                value: flux
+              - key: '{{ `{{ length(request.object.metadata.ownerReferences[?kind==''HelmRelease'' || kind==''Kustomization'']) }}` }}'
+                operator: Equals
+                value: 0
+{{- end -}}

--- a/platform/kyverno/chart/templates/policies/baseline/11-harbor-proxy.yaml
+++ b/platform/kyverno/chart/templates/policies/baseline/11-harbor-proxy.yaml
@@ -1,0 +1,74 @@
+{{/*
+K1 — harbor-proxy-pull (governance, ENFORCING default).
+
+Container images must be pulled through the Sovereign's local Harbor
+proxy — references like `harbor.<sovereign-domain>/proxy-ghcr/...`,
+`harbor.<sovereign-domain>/proxy-dockerhub/...`, etc. Direct pulls from
+ghcr.io, docker.io, quay.io, etc. break the air-gap-ready posture and
+the per-Sovereign vulnerability scanning gate.
+
+The exact regex for the allowed registry prefix is operator-configurable
+via .Values.compliancePolicies.harborProxyPull.allowedRegistryRegex
+(per docs/INVIOLABLE-PRINCIPLES.md #4) — different Sovereigns are
+deployed at different domains, so hardcoding `harbor.omantel.openova.io`
+would fail every other Sovereign.
+
+Default mode enforcing per design §4.3. Operators flip to Audit while
+seeding the Harbor proxy on a fresh Sovereign and back to Enforce
+after the proxy is warm.
+*/}}
+{{- if .Values.compliancePolicies.harborProxyPull.enabled -}}
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: harbor-proxy-pull
+  labels:
+    app.kubernetes.io/name: bp-kyverno
+    app.kubernetes.io/component: compliance-policy
+    catalyst.openova.io/policy-tier: compliance
+    catalyst.openova.io/policy-domain: governance
+  annotations:
+    policies.kyverno.io/title: Container images must pull through the Sovereign Harbor proxy
+    policies.kyverno.io/category: catalyst-compliance
+    policies.kyverno.io/severity: high
+    policies.kyverno.io/description: >-
+      Container images must reference a Sovereign-local Harbor proxy
+      registry. Operator configures the allowed regex via
+      .Values.compliancePolicies.harborProxyPull.allowedRegistryRegex.
+spec:
+  validationFailureAction: {{ .Values.compliancePolicies.harborProxyPull.action | default "Audit" }}
+  background: true
+  rules:
+    - name: image-must-be-from-harbor-proxy
+      match:
+        any:
+          - resources:
+              kinds:
+                - Pod
+                - Deployment
+                - StatefulSet
+                - DaemonSet
+                - Job
+                - CronJob
+      exclude:
+        any:
+          - resources:
+              namespaces:
+                {{- range $ns := .Values.compliancePolicies.harborProxyPull.excludeNamespaces }}
+                - {{ $ns }}
+                {{- end }}
+      validate:
+        message: >-
+          Container image does not match the allowed Harbor-proxy regex
+          {{ .Values.compliancePolicies.harborProxyPull.allowedRegistryRegex | quote }}.
+          Re-tag the image to pull through the Sovereign's local Harbor
+          proxy (e.g. harbor.<sovereign-domain>/proxy-ghcr/...).
+        foreach:
+          - list: "request.object.spec.containers || request.object.spec.template.spec.containers"
+            deny:
+              conditions:
+                all:
+                  - key: '{{ `{{ element.image }}` }}'
+                    operator: NotMatch
+                    value: {{ .Values.compliancePolicies.harborProxyPull.allowedRegistryRegex | quote }}
+{{- end -}}

--- a/platform/kyverno/chart/templates/policies/baseline/12-image-tag-pinned.yaml
+++ b/platform/kyverno/chart/templates/policies/baseline/12-image-tag-pinned.yaml
@@ -1,0 +1,70 @@
+{{/*
+K1 — image-tag-pinned (governance, ENFORCING default).
+
+Container images must be tagged with a non-`:latest`, non-empty tag.
+`:latest` (or no tag, which K8s treats as `:latest`) means the running
+bytes can change underneath any pod restart, breaking the
+SHA-pinned audit-trail contract in CLAUDE.md §4a.
+
+This policy uses Kyverno's pattern engine with anchors to assert image
+references end with a non-empty tag that is NOT `latest`. SHA-digest
+references (`@sha256:...`) are also accepted and treated as pinned.
+
+Default mode enforcing per design §4.3.
+*/}}
+{{- if .Values.compliancePolicies.imageTagPinned.enabled -}}
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: image-tag-pinned
+  labels:
+    app.kubernetes.io/name: bp-kyverno
+    app.kubernetes.io/component: compliance-policy
+    catalyst.openova.io/policy-tier: compliance
+    catalyst.openova.io/policy-domain: governance
+  annotations:
+    policies.kyverno.io/title: Container images must be tag-pinned (no :latest)
+    policies.kyverno.io/category: catalyst-compliance
+    policies.kyverno.io/severity: high
+    policies.kyverno.io/description: >-
+      Container images must reference an explicit, non-:latest tag (or
+      a @sha256: digest). Floating tags break SHA-pinned audit trails
+      and reproducibility.
+spec:
+  validationFailureAction: {{ .Values.compliancePolicies.imageTagPinned.action | default "Audit" }}
+  background: true
+  rules:
+    - name: image-must-have-explicit-tag
+      match:
+        any:
+          - resources:
+              kinds:
+                - Pod
+                - Deployment
+                - StatefulSet
+                - DaemonSet
+                - Job
+                - CronJob
+      exclude:
+        any:
+          - resources:
+              namespaces:
+                {{- range $ns := .Values.compliancePolicies.imageTagPinned.excludeNamespaces }}
+                - {{ $ns }}
+                {{- end }}
+      validate:
+        message: >-
+          One or more containers reference an unpinned image (`:latest`
+          or no tag). Pin to an explicit tag or @sha256 digest.
+        foreach:
+          - list: "request.object.spec.containers || request.object.spec.template.spec.containers"
+            deny:
+              conditions:
+                any:
+                  - key: '{{ `{{ element.image }}` }}'
+                    operator: Match
+                    value: "*:latest"
+                  - key: '{{ `{{ element.image }}` }}'
+                    operator: NotMatch
+                    value: "*:*"
+{{- end -}}

--- a/platform/kyverno/chart/templates/policies/baseline/13-prometheus-scrape.yaml
+++ b/platform/kyverno/chart/templates/policies/baseline/13-prometheus-scrape.yaml
@@ -1,0 +1,69 @@
+{{/*
+K1 — prometheus-scrape (observability, permissive default).
+
+Workload-rendering resources should be observable: either Pod template
+carries `prometheus.io/scrape: "true"` annotation, OR the workload has
+an associated Service / PodMonitor / ServiceMonitor (the
+prometheus-operator path) — encoded here as a label
+`monitoring.coreos.com/managed: "true"` on the metadata.
+
+Kyverno can't natively discover an "associated PodMonitor" without
+context.apiCall enumeration; the canonical seam is the label, which
+the operator adds when generating monitoring resources for a workload.
+
+Default mode permissive per design §4.3.
+*/}}
+{{- if .Values.compliancePolicies.prometheusScrape.enabled -}}
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: prometheus-scrape
+  labels:
+    app.kubernetes.io/name: bp-kyverno
+    app.kubernetes.io/component: compliance-policy
+    catalyst.openova.io/policy-tier: compliance
+    catalyst.openova.io/policy-domain: observability
+  annotations:
+    policies.kyverno.io/title: Workloads should be Prometheus-scrape-targeted
+    policies.kyverno.io/category: catalyst-compliance
+    policies.kyverno.io/severity: low
+    policies.kyverno.io/description: >-
+      Pod template should carry prometheus.io/scrape="true" annotation,
+      OR the workload labels declare monitoring.coreos.com/managed=true
+      indicating an operator-managed PodMonitor / ServiceMonitor exists.
+spec:
+  validationFailureAction: {{ .Values.compliancePolicies.prometheusScrape.action | default "Audit" }}
+  background: true
+  rules:
+    - name: workload-must-be-scrape-targeted
+      match:
+        any:
+          - resources:
+              kinds:
+                - Deployment
+                - StatefulSet
+                - DaemonSet
+      exclude:
+        any:
+          - resources:
+              namespaces:
+                {{- range $ns := .Values.compliancePolicies.prometheusScrape.excludeNamespaces }}
+                - {{ $ns }}
+                {{- end }}
+      validate:
+        message: >-
+          Workload
+          {{ `{{request.object.kind}}/{{request.object.metadata.name}}` }} is
+          not declared a Prometheus scrape target. Either annotate the
+          Pod template with `prometheus.io/scrape: "true"` or label the
+          workload with `monitoring.coreos.com/managed: "true"`.
+        anyPattern:
+          - spec:
+              template:
+                metadata:
+                  annotations:
+                    prometheus.io/scrape: "true"
+          - metadata:
+              labels:
+                monitoring.coreos.com/managed: "true"
+{{- end -}}

--- a/platform/kyverno/chart/templates/policies/baseline/14-networkpolicy-present.yaml
+++ b/platform/kyverno/chart/templates/policies/baseline/14-networkpolicy-present.yaml
@@ -1,0 +1,73 @@
+{{/*
+K2 — networkpolicy-present (security, permissive default).
+
+A workload's namespace must contain at least one NetworkPolicy or
+CiliumNetworkPolicy. Without one, all east-west traffic is wide-open
+within the namespace (default-allow). Industry consensus is to enforce
+a default-deny baseline + explicit allow rules per workload.
+
+This rule fires on Namespace creation/update — context.apiCall queries
+the namespace for NetworkPolicy / CiliumNetworkPolicy and denies if the
+list is empty. Per-workload coverage (does any policy actually select
+THIS Pod) is inspectable but expensive — deferred to W2 evaluator.
+
+Default mode permissive per design §4.3.
+*/}}
+{{- if .Values.compliancePolicies.networkpolicyPresent.enabled -}}
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: networkpolicy-present
+  labels:
+    app.kubernetes.io/name: bp-kyverno
+    app.kubernetes.io/component: compliance-policy
+    catalyst.openova.io/policy-tier: compliance
+    catalyst.openova.io/policy-domain: security
+  annotations:
+    policies.kyverno.io/title: Namespaces must declare at least one NetworkPolicy
+    policies.kyverno.io/category: catalyst-compliance
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/description: >-
+      Namespaces must contain at least one NetworkPolicy or
+      CiliumNetworkPolicy so east-west traffic is mediated.
+spec:
+  validationFailureAction: {{ .Values.compliancePolicies.networkpolicyPresent.action | default "Audit" }}
+  background: true
+  rules:
+    - name: namespace-must-have-networkpolicy
+      match:
+        any:
+          - resources:
+              kinds:
+                - Namespace
+      exclude:
+        any:
+          - resources:
+              names:
+                {{- range $ns := .Values.compliancePolicies.networkpolicyPresent.excludeNamespaces }}
+                - {{ $ns }}
+                {{- end }}
+      context:
+        - name: npCount
+          apiCall:
+            urlPath: "/apis/networking.k8s.io/v1/namespaces/{{ `{{request.object.metadata.name}}` }}/networkpolicies"
+            jmesPath: "length(items)"
+        - name: cnpCount
+          apiCall:
+            urlPath: "/apis/cilium.io/v2/namespaces/{{ `{{request.object.metadata.name}}` }}/ciliumnetworkpolicies"
+            jmesPath: "length(items) || `0`"
+      validate:
+        message: >-
+          Namespace {{ `{{request.object.metadata.name}}` }} contains no
+          NetworkPolicy and no CiliumNetworkPolicy. Add at least one
+          policy to mediate east-west traffic.
+        deny:
+          conditions:
+            all:
+              - key: '{{ `{{ npCount }}` }}'
+                operator: Equals
+                value: 0
+              - key: '{{ `{{ cnpCount }}` }}'
+                operator: Equals
+                value: 0
+{{- end -}}

--- a/platform/kyverno/chart/templates/policies/baseline/15-otel-injected.yaml
+++ b/platform/kyverno/chart/templates/policies/baseline/15-otel-injected.yaml
@@ -1,0 +1,93 @@
+{{/*
+K2 — otel-injected (observability, permissive default).
+
+Workloads should carry OpenTelemetry instrumentation: either a
+sidecar container named `otel-collector`, OR the namespace has an
+Instrumentation CR (opentelemetry.io/v1alpha1) with auto-inject
+annotation set on the Pod template.
+
+Kyverno's pattern engine handles the sidecar branch easily; the
+"namespace has Instrumentation CR + auto-inject annotation" branch
+needs context.apiCall and is half-encoded here as the
+`instrumentation.opentelemetry.io/inject-*` annotation check (which is
+what the OTel operator's MutatingWebhook expects on the Pod template).
+
+Default mode permissive per design §4.3.
+*/}}
+{{- if .Values.compliancePolicies.otelInjected.enabled -}}
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: otel-injected
+  labels:
+    app.kubernetes.io/name: bp-kyverno
+    app.kubernetes.io/component: compliance-policy
+    catalyst.openova.io/policy-tier: compliance
+    catalyst.openova.io/policy-domain: observability
+  annotations:
+    policies.kyverno.io/title: Workloads should be OTel-instrumented
+    policies.kyverno.io/category: catalyst-compliance
+    policies.kyverno.io/severity: low
+    policies.kyverno.io/description: >-
+      Workloads should declare OpenTelemetry instrumentation via either
+      an `otel-collector` sidecar container OR
+      `instrumentation.opentelemetry.io/inject-*: "true"` annotation on
+      the Pod template (auto-injection by the OTel operator).
+spec:
+  validationFailureAction: {{ .Values.compliancePolicies.otelInjected.action | default "Audit" }}
+  background: true
+  rules:
+    - name: workload-must-be-otel-instrumented
+      match:
+        any:
+          - resources:
+              kinds:
+                - Deployment
+                - StatefulSet
+                - DaemonSet
+      exclude:
+        any:
+          - resources:
+              namespaces:
+                {{- range $ns := .Values.compliancePolicies.otelInjected.excludeNamespaces }}
+                - {{ $ns }}
+                {{- end }}
+      validate:
+        message: >-
+          Workload
+          {{ `{{request.object.kind}}/{{request.object.metadata.name}}` }} is
+          not OTel-instrumented. Add an `otel-collector` sidecar OR
+          annotate the Pod template with one of
+          `instrumentation.opentelemetry.io/inject-{java,python,nodejs,go,dotnet}: "true"`.
+        anyPattern:
+          - spec:
+              template:
+                spec:
+                  containers:
+                    - name: otel-collector
+          - spec:
+              template:
+                metadata:
+                  annotations:
+                    instrumentation.opentelemetry.io/inject-java: "true"
+          - spec:
+              template:
+                metadata:
+                  annotations:
+                    instrumentation.opentelemetry.io/inject-python: "true"
+          - spec:
+              template:
+                metadata:
+                  annotations:
+                    instrumentation.opentelemetry.io/inject-nodejs: "true"
+          - spec:
+              template:
+                metadata:
+                  annotations:
+                    instrumentation.opentelemetry.io/inject-go: "true"
+          - spec:
+              template:
+                metadata:
+                  annotations:
+                    instrumentation.opentelemetry.io/inject-dotnet: "true"
+{{- end -}}

--- a/platform/kyverno/chart/templates/policies/baseline/16-hubble-flows-seen.yaml
+++ b/platform/kyverno/chart/templates/policies/baseline/16-hubble-flows-seen.yaml
@@ -1,0 +1,34 @@
+{{/*
+K2 — hubble-flows-seen (security, permissive default — DEFERRED to W2).
+
+This policy is intentionally a COMMENT-ONLY STUB. Kyverno cannot
+natively introspect Cilium Hubble's flow telemetry to verify "this Pod
+saw at least one flow in the last 5 minutes" — that requires querying
+the Hubble Observer gRPC API, which lives outside Kubernetes admission.
+
+The check is implemented by the W2 evaluator (`internal/k8scache/
+evaluators/hubble.go` per the EPIC-1 master brief §Group W). The
+evaluator emits a synthetic PolicyReport row keyed by Pod with the
+result; the slice S1 score aggregator joins it identically to native
+Kyverno PolicyReports.
+
+This file is committed (rather than absent) so the policy slot is
+explicit in the bundle and the design contract is visible at a glance.
+The `enabled: false` gate plus this comment-only body means rendering
+emits zero K8s resources today, regardless of values.
+
+If a future Kyverno release lands an `apiCall.serviceURL` capability
+that lets ClusterPolicies hit arbitrary in-cluster gRPC endpoints,
+revisit this file — until then, leave the W2 evaluator as the sole
+path.
+
+DO NOT add a ClusterPolicy body below — the value gate plus this
+comment is the deliverable.
+*/}}
+{{- if .Values.compliancePolicies.hubbleFlowsSeen.enabled -}}
+{{- /*
+  Intentionally renders nothing. See header comment.
+  W2 evaluator (`internal/k8scache/evaluators/hubble.go`) emits the
+  synthetic PolicyReport row for the score aggregator.
+*/ -}}
+{{- end -}}

--- a/platform/kyverno/chart/templates/policies/baseline/17-runasnonroot-readonlyrootfs.yaml
+++ b/platform/kyverno/chart/templates/policies/baseline/17-runasnonroot-readonlyrootfs.yaml
@@ -1,0 +1,100 @@
+{{/*
+K2 — runasnonroot-readonlyrootfs (security, permissive default).
+
+Pod templates must declare:
+  - spec.securityContext.runAsNonRoot: true (Pod-level OR container-level), AND
+  - container.securityContext.readOnlyRootFilesystem: true on every container.
+
+Restricting writeable rootfs reduces blast radius of a process
+compromise and removes the most common malware persistence vector
+(curl|sh into /tmp). Running as non-root is industry-standard and
+matches Kubernetes Pod Security Standards "restricted".
+
+Default mode permissive per design §4.3.
+*/}}
+{{- if .Values.compliancePolicies.runAsNonRootReadonlyRootFs.enabled -}}
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: runasnonroot-readonlyrootfs
+  labels:
+    app.kubernetes.io/name: bp-kyverno
+    app.kubernetes.io/component: compliance-policy
+    catalyst.openova.io/policy-tier: compliance
+    catalyst.openova.io/policy-domain: security
+  annotations:
+    policies.kyverno.io/title: Workloads must run non-root with read-only rootfs
+    policies.kyverno.io/category: catalyst-compliance
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/description: >-
+      Pods must declare runAsNonRoot=true at Pod or container level
+      AND every container must set readOnlyRootFilesystem=true.
+spec:
+  validationFailureAction: {{ .Values.compliancePolicies.runAsNonRootReadonlyRootFs.action | default "Audit" }}
+  background: true
+  rules:
+    - name: pod-level-or-container-level-runasnonroot
+      match:
+        any:
+          - resources:
+              kinds:
+                - Deployment
+                - StatefulSet
+                - DaemonSet
+                - Job
+                - CronJob
+      exclude:
+        any:
+          - resources:
+              namespaces:
+                {{- range $ns := .Values.compliancePolicies.runAsNonRootReadonlyRootFs.excludeNamespaces }}
+                - {{ $ns }}
+                {{- end }}
+      validate:
+        message: >-
+          {{ `{{request.object.kind}}/{{request.object.metadata.name}}` }} must
+          set spec.template.spec.securityContext.runAsNonRoot=true
+          (Pod-level) OR every container must set
+          securityContext.runAsNonRoot=true.
+        anyPattern:
+          - spec:
+              template:
+                spec:
+                  securityContext:
+                    runAsNonRoot: true
+          - spec:
+              template:
+                spec:
+                  containers:
+                    - securityContext:
+                        runAsNonRoot: true
+    - name: container-readonlyrootfilesystem
+      match:
+        any:
+          - resources:
+              kinds:
+                - Deployment
+                - StatefulSet
+                - DaemonSet
+                - Job
+                - CronJob
+      exclude:
+        any:
+          - resources:
+              namespaces:
+                {{- range $ns := .Values.compliancePolicies.runAsNonRootReadonlyRootFs.excludeNamespaces }}
+                - {{ $ns }}
+                {{- end }}
+      validate:
+        message: >-
+          Every container in
+          {{ `{{request.object.kind}}/{{request.object.metadata.name}}` }} must
+          set securityContext.readOnlyRootFilesystem=true.
+        pattern:
+          spec:
+            template:
+              spec:
+                containers:
+                  - securityContext:
+                      readOnlyRootFilesystem: true
+{{- end -}}

--- a/platform/kyverno/chart/templates/policies/baseline/18-cosign-verified.yaml
+++ b/platform/kyverno/chart/templates/policies/baseline/18-cosign-verified.yaml
@@ -1,0 +1,72 @@
+{{/*
+K2 — cosign-verified (security, permissive default).
+
+Container images must carry a verifiable cosign signature. Kyverno's
+`verifyImages` rule type is the canonical seam: it intercepts the
+image at admission, verifies the cosign signature against an
+operator-provided public key (or Sigstore Rekor transparency log), and
+mutates spec.containers[].image with the resolved @sha256 digest on
+success.
+
+Per design §4.3 default mode is permissive — Audit emits a
+PolicyReport row but does NOT block the pull. Operators flip to
+Enforce per Environment via EnvironmentPolicy.spec.compliance.modes.
+
+The cosign public-key bundle is operator-supplied via
+.Values.compliancePolicies.cosignVerified.publicKey (or a Rekor URL).
+Both are runtime-configurable per docs/INVIOLABLE-PRINCIPLES.md #4.
+*/}}
+{{- if .Values.compliancePolicies.cosignVerified.enabled -}}
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: cosign-verified
+  labels:
+    app.kubernetes.io/name: bp-kyverno
+    app.kubernetes.io/component: compliance-policy
+    catalyst.openova.io/policy-tier: compliance
+    catalyst.openova.io/policy-domain: security
+  annotations:
+    policies.kyverno.io/title: Container images must be cosign-signed
+    policies.kyverno.io/category: catalyst-compliance
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/description: >-
+      Container images must carry a valid cosign signature. The
+      verifying public key (or Sigstore Rekor URL) is operator-supplied
+      per Sovereign overlay.
+spec:
+  validationFailureAction: {{ .Values.compliancePolicies.cosignVerified.action | default "Audit" }}
+  background: false
+  rules:
+    - name: cosign-verify
+      match:
+        any:
+          - resources:
+              kinds:
+                - Pod
+                - Deployment
+                - StatefulSet
+                - DaemonSet
+                - Job
+                - CronJob
+      exclude:
+        any:
+          - resources:
+              namespaces:
+                {{- range $ns := .Values.compliancePolicies.cosignVerified.excludeNamespaces }}
+                - {{ $ns }}
+                {{- end }}
+      verifyImages:
+        - imageReferences:
+            {{- range $ref := .Values.compliancePolicies.cosignVerified.imageReferences }}
+            - {{ $ref | quote }}
+            {{- end }}
+          attestors:
+            - count: 1
+              entries:
+                - keys:
+                    publicKeys: |
+                      {{- .Values.compliancePolicies.cosignVerified.publicKey | nindent 22 }}
+                    rekor:
+                      url: {{ .Values.compliancePolicies.cosignVerified.rekorURL | default "https://rekor.sigstore.dev" | quote }}
+{{- end -}}

--- a/platform/kyverno/chart/templates/policies/baseline/19-secret-not-in-env.yaml
+++ b/platform/kyverno/chart/templates/policies/baseline/19-secret-not-in-env.yaml
@@ -1,0 +1,77 @@
+{{/*
+K2 — secret-not-in-env (security, permissive default).
+
+Container env vars must not carry plaintext secret values. Heuristic:
+deny env entries whose `value:` is set (i.e. inline literal) AND whose
+name matches a secret-like regex (case-insensitive `*PASSWORD*`,
+`*TOKEN*`, `*KEY*`, `*SECRET*`). Secrets that flow via `valueFrom.
+secretKeyRef` are accepted — they're tagged in the audit log but the
+plaintext doesn't end up in the Pod spec.
+
+The full "secret mounted as file vs as env" preference is stricter
+than this rule (env is observable via /proc/<pid>/environ for any
+process inside the container), but flipping that on by default would
+break too many third-party charts. The rule here covers the worst
+violators: literally pasting a password into a yaml file.
+
+Default mode permissive per design §4.3.
+*/}}
+{{- if .Values.compliancePolicies.secretNotInEnv.enabled -}}
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: secret-not-in-env
+  labels:
+    app.kubernetes.io/name: bp-kyverno
+    app.kubernetes.io/component: compliance-policy
+    catalyst.openova.io/policy-tier: compliance
+    catalyst.openova.io/policy-domain: security
+  annotations:
+    policies.kyverno.io/title: Plaintext secrets must not appear in container env
+    policies.kyverno.io/category: catalyst-compliance
+    policies.kyverno.io/severity: high
+    policies.kyverno.io/description: >-
+      Container env entries with names matching *PASSWORD* / *TOKEN* /
+      *KEY* / *SECRET* must use valueFrom.secretKeyRef, not a
+      plaintext value.
+spec:
+  validationFailureAction: {{ .Values.compliancePolicies.secretNotInEnv.action | default "Audit" }}
+  background: true
+  rules:
+    - name: deny-plaintext-secret-env
+      match:
+        any:
+          - resources:
+              kinds:
+                - Pod
+                - Deployment
+                - StatefulSet
+                - DaemonSet
+                - Job
+                - CronJob
+      exclude:
+        any:
+          - resources:
+              namespaces:
+                {{- range $ns := .Values.compliancePolicies.secretNotInEnv.excludeNamespaces }}
+                - {{ $ns }}
+                {{- end }}
+      validate:
+        message: >-
+          A container env entry with a secret-shaped name carries a
+          plaintext value. Use valueFrom.secretKeyRef to source it from
+          a Secret instead.
+        foreach:
+          - list: "request.object.spec.containers || request.object.spec.template.spec.containers"
+            foreach:
+              - list: "element.env || `[]`"
+                deny:
+                  conditions:
+                    all:
+                      - key: '{{ `{{ element.value || '''' }}` }}'
+                        operator: NotEquals
+                        value: ""
+                      - key: '{{ `{{ element.name }}` }}'
+                        operator: Match
+                        value: "*(?i)(PASSWORD|TOKEN|KEY|SECRET)*"
+{{- end -}}

--- a/platform/kyverno/chart/templates/policies/baseline/20-backup-configured.yaml
+++ b/platform/kyverno/chart/templates/policies/baseline/20-backup-configured.yaml
@@ -1,0 +1,73 @@
+{{/*
+K2 — backup-configured (resilience, permissive default; stateful only).
+
+PersistentVolumeClaim resources must carry a Velero backup annotation
+indicating they're included in a backup schedule:
+`velero.io/backup-volumes: "<volume-name>"` on the PVC's owning Pod
+(Velero's documented seam) OR a label
+`velero.io/managed-by-schedule: "<schedule-name>"` on the PVC itself
+(set by an operator-provided ScheduledBackup whose label-selector
+matches).
+
+Stateless workloads have no PVCs and drop out of the score denominator
+(per design §4.3 footnote on N/A handling).
+
+The Velero ScheduledBackup CR existence side of the contract (does the
+referenced schedule actually exist?) is not validatable from a Kyverno
+policy without context.apiCall enumeration of the velero.io/v1
+schedules namespace. The S1 score aggregator can join that side
+cheaply since it already watches the namespace; this policy only
+asserts the PVC carries the annotation/label.
+
+Default mode permissive per design §4.3.
+*/}}
+{{- if .Values.compliancePolicies.backupConfigured.enabled -}}
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: backup-configured
+  labels:
+    app.kubernetes.io/name: bp-kyverno
+    app.kubernetes.io/component: compliance-policy
+    catalyst.openova.io/policy-tier: compliance
+    catalyst.openova.io/policy-domain: resilience
+  annotations:
+    policies.kyverno.io/title: Stateful workloads must have a Velero backup configured
+    policies.kyverno.io/category: catalyst-compliance
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/description: >-
+      PVCs must declare a Velero backup binding via either annotation
+      `velero.io/backup-volumes` on the owning Pod template OR label
+      `velero.io/managed-by-schedule` on the PVC itself.
+spec:
+  validationFailureAction: {{ .Values.compliancePolicies.backupConfigured.action | default "Audit" }}
+  background: true
+  rules:
+    - name: pvc-must-be-velero-backed
+      match:
+        any:
+          - resources:
+              kinds:
+                - PersistentVolumeClaim
+      exclude:
+        any:
+          - resources:
+              namespaces:
+                {{- range $ns := .Values.compliancePolicies.backupConfigured.excludeNamespaces }}
+                - {{ $ns }}
+                {{- end }}
+      validate:
+        message: >-
+          PVC {{ `{{request.object.metadata.name}}` }} is not declared
+          as part of a Velero backup. Add label
+          `velero.io/managed-by-schedule: "<schedule-name>"` (matching
+          a Velero ScheduledBackup) or annotate the owning Pod template
+          with `velero.io/backup-volumes`.
+        anyPattern:
+          - metadata:
+              labels:
+                velero.io/managed-by-schedule: "?*"
+          - metadata:
+              annotations:
+                velero.io/backup-volumes: "?*"
+{{- end -}}

--- a/platform/kyverno/chart/tests/fixtures/README.md
+++ b/platform/kyverno/chart/tests/fixtures/README.md
@@ -1,0 +1,40 @@
+# Compliance policy fixtures (slice K, EPIC-1 #1096)
+
+YAML fixtures for offline `kyverno apply` validation. Each policy gets two
+files: a passing case and a failing case, both shaped as the workload kinds
+the policy targets.
+
+The fixtures here are illustrative — slice S1 ships the full per-policy
+test matrix once the score aggregator is in place, since identical
+fixtures feed both the Kyverno policy assertion and the synthetic
+PolicyReport row the aggregator joins on.
+
+## How to run
+
+```bash
+# Render the chart with a single policy enabled, then run kyverno apply.
+cd platform/kyverno/chart
+helm template . --set compliancePolicies.multiReplica.enabled=true \
+  > /tmp/multi-replica.yaml
+
+# Install the kyverno CLI per https://kyverno.io/docs/kyverno-cli/install/
+kyverno apply /tmp/multi-replica.yaml \
+  --resource tests/fixtures/multi-replica/pass-deployment.yaml
+kyverno apply /tmp/multi-replica.yaml \
+  --resource tests/fixtures/multi-replica/fail-deployment.yaml
+```
+
+The pass case should produce no violations; the fail case should produce
+exactly one (per workload).
+
+## Coverage
+
+| Policy | Pass fixture | Fail fixture |
+|---|---|---|
+| multi-replica-drainability | `multi-replica/pass-deployment.yaml` | `multi-replica/fail-deployment.yaml` |
+| probes-present | `probes-present/pass-deployment.yaml` | `probes-present/fail-deployment.yaml` |
+| resource-requests | `resource-requests/pass-deployment.yaml` | `resource-requests/fail-deployment.yaml` |
+| image-tag-pinned | `image-tag-pinned/pass-deployment.yaml` | `image-tag-pinned/fail-deployment.yaml` |
+
+The remaining 15 policies' fixtures are deferred — slice S1 ships the
+authoritative matrix.

--- a/platform/kyverno/chart/tests/fixtures/image-tag-pinned/fail-deployment.yaml
+++ b/platform/kyverno/chart/tests/fixtures/image-tag-pinned/fail-deployment.yaml
@@ -1,0 +1,19 @@
+# Failing case: :latest tag.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: fail-image-tag
+  namespace: example
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: fail-image-tag
+  template:
+    metadata:
+      labels:
+        app: fail-image-tag
+    spec:
+      containers:
+        - name: app
+          image: ghcr.io/example/app:latest

--- a/platform/kyverno/chart/tests/fixtures/image-tag-pinned/pass-deployment.yaml
+++ b/platform/kyverno/chart/tests/fixtures/image-tag-pinned/pass-deployment.yaml
@@ -1,0 +1,19 @@
+# Passing case: explicit version tag.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pass-image-tag
+  namespace: example
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: pass-image-tag
+  template:
+    metadata:
+      labels:
+        app: pass-image-tag
+    spec:
+      containers:
+        - name: app
+          image: ghcr.io/example/app:v1.2.3

--- a/platform/kyverno/chart/tests/fixtures/multi-replica/fail-deployment.yaml
+++ b/platform/kyverno/chart/tests/fixtures/multi-replica/fail-deployment.yaml
@@ -1,0 +1,19 @@
+# Failing case: 1 replica, drainability NOT satisfied.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: fail-multi-replica
+  namespace: example
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: fail-multi-replica
+  template:
+    metadata:
+      labels:
+        app: fail-multi-replica
+    spec:
+      containers:
+        - name: app
+          image: ghcr.io/example/app:v1.0.0

--- a/platform/kyverno/chart/tests/fixtures/multi-replica/pass-deployment.yaml
+++ b/platform/kyverno/chart/tests/fixtures/multi-replica/pass-deployment.yaml
@@ -1,0 +1,19 @@
+# Passing case: 2 replicas, drainability satisfied.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pass-multi-replica
+  namespace: example
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: pass-multi-replica
+  template:
+    metadata:
+      labels:
+        app: pass-multi-replica
+    spec:
+      containers:
+        - name: app
+          image: ghcr.io/example/app:v1.0.0

--- a/platform/kyverno/chart/tests/fixtures/probes-present/fail-deployment.yaml
+++ b/platform/kyverno/chart/tests/fixtures/probes-present/fail-deployment.yaml
@@ -1,0 +1,19 @@
+# Failing case: missing both probes.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: fail-probes
+  namespace: example
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: fail-probes
+  template:
+    metadata:
+      labels:
+        app: fail-probes
+    spec:
+      containers:
+        - name: app
+          image: ghcr.io/example/app:v1.0.0

--- a/platform/kyverno/chart/tests/fixtures/probes-present/pass-deployment.yaml
+++ b/platform/kyverno/chart/tests/fixtures/probes-present/pass-deployment.yaml
@@ -1,0 +1,27 @@
+# Passing case: both liveness and readiness probes declared.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pass-probes
+  namespace: example
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: pass-probes
+  template:
+    metadata:
+      labels:
+        app: pass-probes
+    spec:
+      containers:
+        - name: app
+          image: ghcr.io/example/app:v1.0.0
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8080

--- a/platform/kyverno/chart/tests/fixtures/resource-requests/fail-deployment.yaml
+++ b/platform/kyverno/chart/tests/fixtures/resource-requests/fail-deployment.yaml
@@ -1,0 +1,19 @@
+# Failing case: no resources block at all (BestEffort).
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: fail-requests
+  namespace: example
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: fail-requests
+  template:
+    metadata:
+      labels:
+        app: fail-requests
+    spec:
+      containers:
+        - name: app
+          image: ghcr.io/example/app:v1.0.0

--- a/platform/kyverno/chart/tests/fixtures/resource-requests/pass-deployment.yaml
+++ b/platform/kyverno/chart/tests/fixtures/resource-requests/pass-deployment.yaml
@@ -1,0 +1,23 @@
+# Passing case: cpu + memory requests declared.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pass-requests
+  namespace: example
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: pass-requests
+  template:
+    metadata:
+      labels:
+        app: pass-requests
+    spec:
+      containers:
+        - name: app
+          image: ghcr.io/example/app:v1.0.0
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi

--- a/platform/kyverno/chart/values.yaml
+++ b/platform/kyverno/chart/values.yaml
@@ -192,3 +192,164 @@ kyvernoOverlay:
         - monitoring
         - ingress
         - default
+
+# ─── EPIC-1 (#1096) compliance policy library ───────────────────────────
+# Slice K (#1096) ships 20 ClusterPolicy template slots; one is deferred
+# to slice W2 (hubble-flows-seen — a Go evaluator), so 19 will render at
+# most. Every policy is default-OFF; per-Sovereign overlay opts in.
+#
+# Schema per policy:
+#   <name>:
+#     enabled: bool                      # required — gate
+#     action: "Audit" | "Enforce"        # default Audit; flipped per-Environment
+#                                        # by EnvironmentPolicy.spec.compliance.modes
+#                                        # (slice C2 controller, future)
+#     excludeNamespaces: [string]        # control-plane ns exemption list
+#     <policy-specific knobs>            # e.g. allowedRegistryRegex
+#
+# Default action is `Audit` for every policy (permissive mode). Per
+# docs/EPICS-1-6-unified-design.md §4.3 some policies have an
+# "enforcing" default mode — those defaults are applied by the future
+# environment-controller when it materializes a default
+# EnvironmentPolicy on every Environment, NOT here. This values file is
+# the per-Sovereign baseline; the Environment-level defaults are the
+# next layer up.
+#
+# Per docs/INVIOLABLE-PRINCIPLES.md #4 — every value is overridable.
+compliancePolicies:
+  # K1 baseline policies
+  multiReplica:
+    enabled: false
+    action: Audit
+    excludeNamespaces: &complianceDefaultExcludes
+      - kube-system
+      - flux-system
+      - cilium
+      - cilium-gateway
+      - cert-manager
+      - openova-system
+      - catalyst
+      - kyverno
+      - monitoring
+      - ingress
+
+  pdb:
+    enabled: false
+    action: Audit
+    excludeNamespaces: *complianceDefaultExcludes
+
+  topologySpread:
+    enabled: false
+    action: Audit
+    excludeNamespaces: *complianceDefaultExcludes
+
+  probesPresent:
+    enabled: false
+    action: Audit
+    excludeNamespaces: *complianceDefaultExcludes
+
+  resourceRequests:
+    enabled: false
+    action: Audit
+    excludeNamespaces: *complianceDefaultExcludes
+
+  resourceLimits:
+    enabled: false
+    action: Audit
+    excludeNamespaces: *complianceDefaultExcludes
+
+  pvcExpansion:
+    enabled: false
+    action: Audit
+    excludeNamespaces: *complianceDefaultExcludes
+
+  hpaEffective:
+    enabled: false
+    action: Audit
+    excludeNamespaces: *complianceDefaultExcludes
+
+  ciliumL7Mtls:
+    enabled: false
+    action: Audit
+    excludeNamespaces: *complianceDefaultExcludes
+
+  fluxManaged:
+    enabled: false
+    action: Audit
+    excludeNamespaces: *complianceDefaultExcludes
+
+  harborProxyPull:
+    enabled: false
+    action: Audit
+    excludeNamespaces: *complianceDefaultExcludes
+    # Operator overrides per-Sovereign (e.g.
+    # "^harbor\\.omantel\\.openova\\.io/proxy-(ghcr|dockerhub|quay)/.*").
+    # The default below allows any host of the form
+    # `harbor.<sovereign-domain>/proxy-<upstream>/*`. Operator narrows
+    # this per Sovereign overlay. Empty pattern would match everything,
+    # which would silently disable the rule.
+    allowedRegistryRegex: "^harbor\\..+/proxy-(ghcr|dockerhub|quay|registry-1\\.docker\\.io)/.*"
+
+  imageTagPinned:
+    enabled: false
+    action: Audit
+    excludeNamespaces: *complianceDefaultExcludes
+
+  prometheusScrape:
+    enabled: false
+    action: Audit
+    excludeNamespaces: *complianceDefaultExcludes
+
+  # K2 added policies
+  networkpolicyPresent:
+    enabled: false
+    action: Audit
+    # Match on Namespace kind — `excludeNamespaces` here is consumed via
+    # `resources.names` (the namespace IS the resource). Same default
+    # exemption set as the workload policies.
+    excludeNamespaces: *complianceDefaultExcludes
+
+  otelInjected:
+    enabled: false
+    action: Audit
+    excludeNamespaces: *complianceDefaultExcludes
+
+  hubbleFlowsSeen:
+    # DEFERRED — see template stub for K2 #16. The Kyverno gate is a
+    # no-op; W2 evaluator does the actual check. Setting enabled=true
+    # today is harmless (renders nothing) but reserved as the cutover
+    # knob once W2 lands so operators can toggle a single flag.
+    enabled: false
+    action: Audit
+    excludeNamespaces: *complianceDefaultExcludes
+
+  runAsNonRootReadonlyRootFs:
+    enabled: false
+    action: Audit
+    excludeNamespaces: *complianceDefaultExcludes
+
+  cosignVerified:
+    enabled: false
+    action: Audit
+    excludeNamespaces: *complianceDefaultExcludes
+    # Cosign verifyImages rule fields. Defaults reference openova-io
+    # images only; operator extends per Sovereign.
+    imageReferences:
+      - "ghcr.io/openova-io/*"
+    # Cosign public key (PEM). Empty default means the rule emits an
+    # invalid policy until operator supplies a real key — surfaces the
+    # config gap rather than silently passing. Per
+    # docs/INVIOLABLE-PRINCIPLES.md #4 this is operator-configurable,
+    # NOT hardcoded.
+    publicKey: ""
+    rekorURL: "https://rekor.sigstore.dev"
+
+  secretNotInEnv:
+    enabled: false
+    action: Audit
+    excludeNamespaces: *complianceDefaultExcludes
+
+  backupConfigured:
+    enabled: false
+    action: Audit
+    excludeNamespaces: *complianceDefaultExcludes


### PR DESCRIPTION
## Summary

EPIC-1 (#1096) slice K — author the Kyverno compliance policy library that the score aggregator (slice S, separate PR) will consume.

- **K1**: 13 baseline ClusterPolicy templates (resilience, security, governance, observability)
- **K2**: 7 added ClusterPolicy templates (security + resilience), one is a deferred stub (hubble-flows-seen → W2 evaluator)
- **Total renderable**: 19 ClusterPolicy resources when all enabled
- All policies default-OFF; per-Sovereign overlay opts in
- `validationFailureAction` always templated from values, never hardcoded — flipped per-Environment by `EnvironmentPolicy.spec.compliance.modes` once C2 controller lands

## Architecture

Per `docs/EPICS-1-6-unified-design.md` §4.3 and slice K brief:

```
01 multi-replica-drainability  resilience    permissive
02 pdb-permits-eviction        resilience    permissive
03 topology-spread             resilience    permissive
04 probes-present              resilience    ENFORCING
05 resource-requests           resilience    ENFORCING
06 resource-limits             resilience    permissive
07 pvc-volume-expansion        resilience    permissive (stateful)
08 hpa-effective               resilience    permissive
09 cilium-l7-mtls              security      ENFORCING
10 flux-managed                governance    ENFORCING
11 harbor-proxy-pull           governance    ENFORCING
12 image-tag-pinned            governance    ENFORCING
13 prometheus-scrape           observability permissive
14 networkpolicy-present       security      permissive
15 otel-injected               observability permissive
16 hubble-flows-seen           DEFERRED      (W2 evaluator)
17 runasnonroot-readonlyrootfs security      permissive
18 cosign-verified             security      permissive
19 secret-not-in-env           security      permissive
20 backup-configured           resilience    permissive
```

Per-policy values shape: `enabled` (gate), `action` (Audit|Enforce, default Audit), `excludeNamespaces` (default 10 control-plane namespaces), plus per-policy specifics (`allowedRegistryRegex`, `imageReferences`, `publicKey`, `rekorURL`).

## Test plan

- [x] `helm dependency build` clean (kyverno 3.8.0 subchart resolves)
- [x] `helm template .` (all defaults OFF) → **0** ClusterPolicy resources rendered
- [x] `helm template . -f all-on-values.yaml` → **19** ClusterPolicy resources rendered (20 minus deferred #16)
- [x] `helm lint .` clean (defaults + all-on)
- [x] `helm template . --set compliancePolicies.probesPresent.action=Enforce` → `validationFailureAction: Enforce` (per-policy override works)
- [x] Existing E1+E2 label-vocab policies still render unchanged (2 ClusterPolicies when enabled)
- [x] Each rendered ClusterPolicy is valid YAML and parses cleanly via Python yaml.safe_load_all
- [x] Sample fixtures shipped under `tests/fixtures/{multi-replica,probes-present,resource-requests,image-tag-pinned}/{pass,fail}-deployment.yaml` for offline `kyverno apply` validation; full per-policy matrix lands with slice S

## Out of scope

- `internal/k8scache/` watcher extension → slice W
- Custom evaluators (HPA, OTel, Hubble, Harbor, Flux, cosign) → slice W2
- Score aggregator + SSE/NATS rollup → slice S
- UI dashboards → slices U1–U5
- Kyverno installation / chart-version bump → unchanged; we only ADD policy templates

🤖 Generated with [Claude Code](https://claude.com/claude-code)