### PR TITLE
feat(rbac): Keycloak composite realm-role bootstrap on catalyst-api startup (slice T2, #1098)

### DIFF
--- a/products/catalyst/bootstrap/api/cmd/api/main.go
+++ b/products/catalyst/bootstrap/api/cmd/api/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"os"
@@ -138,6 +139,44 @@ func main() {
 			"addr", addr,
 			"realm", realm,
 		)
+	}
+
+	// EPIC-3 slice T2 (#1098) — Keycloak composite catalog-tier
+	// realm-role bootstrap. Gated by KEYCLOAK_BOOTSTRAP_TIER_ROLES
+	// (default false) so existing Sovereigns + the contabo mothership
+	// continue to start unchanged; opt in via the chart's catalyst-api
+	// Deployment env on the Sovereigns where the catalog-tier system
+	// is the source of UX truth.
+	//
+	// Why a goroutine: Keycloak may not be ready when catalyst-api
+	// starts (Flux reconciles bp-keycloak in parallel with
+	// bp-catalyst-platform). Blocking the HTTP listener on a Keycloak
+	// availability probe violates ADR-0001 §2 event-driven principle.
+	// Instead the bootstrap polls for KC readiness with capped backoff
+	// (5 attempts, ~30s total) and gives up — the next catalyst-api
+	// restart picks the bootstrap up again. Re-runs are no-ops once
+	// the realm-role chain is in place (idempotency anchor in
+	// EnsureTierRealmRoles).
+	if envBool("KEYCLOAK_BOOTSTRAP_TIER_ROLES", false) {
+		// Reuse the same SA credentials wired above for /auth/handover
+		// (CATALYST_KC_ADDR + CATALYST_KC_REALM + CATALYST_KC_SA_CLIENT_ID
+		// + CATALYST_KC_SA_CLIENT_SECRET). If any are missing the
+		// goroutine logs and exits — the operator opted into the
+		// bootstrap but didn't wire credentials, that's a config bug
+		// not an infra outage and shouldn't crashloop catalyst-api.
+		kcAddr := os.Getenv("CATALYST_KC_ADDR")
+		kcRealm := env("CATALYST_KC_REALM", "sovereign")
+		kcSAClient := os.Getenv("CATALYST_KC_SA_CLIENT_ID")
+		kcSASecret := os.Getenv("CATALYST_KC_SA_CLIENT_SECRET")
+		if kcAddr == "" || kcSAClient == "" || kcSASecret == "" {
+			log.Warn("kc-bootstrap: KEYCLOAK_BOOTSTRAP_TIER_ROLES=true but CATALYST_KC_ADDR/SA_CLIENT_ID/SA_CLIENT_SECRET incomplete; skipping tier-role bootstrap")
+		} else {
+			bootstrapKC := keycloak.New(kcAddr, kcRealm, kcSAClient, kcSASecret)
+			// Tied to a fresh background context — the goroutine's
+			// lifetime is the catalyst-api process. ctx (line ~213
+			// below) is reserved for the k8scache informer wiring.
+			go runTierRoleBootstrap(context.Background(), log, bootstrapKC, kcRealm)
+		}
 	}
 
 	// Multi-zone PowerDNS client (issue #827, parent epic #825). Wired
@@ -778,6 +817,106 @@ func env(key, fallback string) string {
 		return v
 	}
 	return fallback
+}
+
+// envBool returns the parsed boolean value of an env var, or fallback
+// when unset / unparseable. Truthy values: 1, t, T, true, TRUE, True.
+func envBool(key string, fallback bool) bool {
+	v := os.Getenv(key)
+	if v == "" {
+		return fallback
+	}
+	switch v {
+	case "1", "t", "T", "true", "TRUE", "True":
+		return true
+	case "0", "f", "F", "false", "FALSE", "False":
+		return false
+	default:
+		return fallback
+	}
+}
+
+// runTierRoleBootstrap waits for Keycloak to become reachable, then
+// runs EnsureTierRealmRoles with capped backoff. Errors are logged and
+// the goroutine exits — the next catalyst-api restart will pick the
+// bootstrap up again. Re-runs are idempotent no-ops.
+//
+// Backoff: 5 attempts at 0s, 5s, 10s, 20s, 40s = ~75s total wall-clock
+// at worst. Combined with the 30s Keycloak readiness wait, the bootstrap
+// has up to ~105s to converge before the goroutine gives up. The
+// Keycloak-config-cli Job (chart-install-time) is the orthogonal
+// lifecycle and runs separately.
+func runTierRoleBootstrap(ctx context.Context, log *slog.Logger, kc *keycloak.Client, realm string) {
+	if err := waitForKeycloak(ctx, kc, 30*time.Second); err != nil {
+		log.Error("kc-bootstrap: KC not reachable, skipping tier-role bootstrap",
+			"err", err,
+		)
+		return
+	}
+
+	delays := []time.Duration{0, 5 * time.Second, 10 * time.Second, 20 * time.Second, 40 * time.Second}
+	var lastErr error
+	for i, d := range delays {
+		if d > 0 {
+			select {
+			case <-ctx.Done():
+				log.Warn("kc-bootstrap: context cancelled during backoff",
+					"attempt", i+1,
+				)
+				return
+			case <-time.After(d):
+			}
+		}
+		err := kc.EnsureTierRealmRoles(ctx, realm)
+		if err == nil {
+			log.Info("kc-bootstrap: tier-role bootstrap converged",
+				"attempt", i+1,
+				"realm", realm,
+			)
+			return
+		}
+		lastErr = err
+		log.Warn("kc-bootstrap: tier-role ensure failed; will retry",
+			"attempt", i+1,
+			"err", err,
+		)
+	}
+	log.Error("kc-bootstrap: tier-role bootstrap gave up after all retries",
+		"realm", realm,
+		"err", lastErr,
+	)
+}
+
+// waitForKeycloak polls the Keycloak service-account token endpoint
+// until it returns a token (KC is up) or the timeout elapses. The
+// catalyst-api may start before Keycloak's HelmRelease finishes
+// reconciling on a fresh Sovereign — this poll keeps the bootstrap
+// goroutine quiet until KC is reachable, avoiding a flood of 5xx logs.
+func waitForKeycloak(ctx context.Context, kc *keycloak.Client, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	tick := 2 * time.Second
+	var lastErr error
+	for time.Now().Before(deadline) {
+		// EnsureTierRealmRoles is idempotent on a populated realm but
+		// expensive on a clean one — for the readiness check we only
+		// need a single GET to confirm KC is up. The simplest path is
+		// to call ListRealmRoles which exercises serviceAccountToken
+		// then a single Admin GET.
+		_, err := kc.ListRealmRoles(ctx)
+		if err == nil {
+			return nil
+		}
+		lastErr = err
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(tick):
+		}
+	}
+	if lastErr != nil {
+		return fmt.Errorf("keycloak readiness timeout: %w", lastErr)
+	}
+	return fmt.Errorf("keycloak readiness timeout (no error captured)")
 }
 
 // pathOnlyLogFormatter implements chi's middleware.LogFormatter so the

--- a/products/catalyst/bootstrap/api/internal/keycloak/admin_roles.go
+++ b/products/catalyst/bootstrap/api/internal/keycloak/admin_roles.go
@@ -27,6 +27,11 @@ package keycloak
 //   GET    /admin/realms/{realm}/groups/{group-uuid}/role-mappings/realm
 //   POST   /admin/realms/{realm}/groups/{group-uuid}/role-mappings/realm
 //   DELETE /admin/realms/{realm}/groups/{group-uuid}/role-mappings/realm
+//
+//   Composite realm-role children (slice T2 — tier hierarchy bootstrap):
+//   GET    /admin/realms/{realm}/roles/{parent-role-name}/composites/realm
+//   POST   /admin/realms/{realm}/roles/{parent-role-name}/composites
+//   DELETE /admin/realms/{realm}/roles/{parent-role-name}/composites
 
 import (
 	"bytes"
@@ -451,4 +456,149 @@ func (c *Client) deleteRoleMappingsRealm(ctx context.Context, resourceKind, uuid
 	default:
 		return fmt.Errorf("keycloak: DELETE role-mappings %d: %s", resp.StatusCode, respBody)
 	}
+}
+
+// ── Composite realm-role children (slice T2) ──────────────────────────
+//
+// Catalyst's tier hierarchy (per docs/EPICS-1-6-unified-design.md §6.2)
+// uses Keycloak composite realm-roles to express transitive containment:
+// a user assigned the `catalyst-admin` realm role automatically inherits
+// every action on `catalyst-operator`, `catalyst-developer`, and
+// `catalyst-viewer` via Keycloak's role-resolver. The composition is
+// flat (each tier composes only its immediate child) — Keycloak expands
+// the chain transitively at token-mint time.
+//
+// The Keycloak Admin REST API for composite realm-roles is asymmetric:
+// the GET endpoint requires the `/realm` suffix to filter to realm-only
+// composites (excluding any client-role composites that may be attached),
+// but the POST/DELETE endpoints take the bare `/composites` path with a
+// JSON array of RoleRepresentation objects whose `clientRole=false`
+// distinguishes them as realm composites.
+
+// ListRealmRoleComposites returns the realm roles directly attached as
+// composites to the given parent role. Used by EnsureCompositeRealmRole
+// to short-circuit when the desired composite is already present
+// (idempotency anchor for re-runs of EnsureTierRealmRoles).
+func (c *Client) ListRealmRoleComposites(ctx context.Context, parentName string) ([]RealmRole, error) {
+	saToken, err := c.serviceAccountToken(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("keycloak.ListRealmRoleComposites: service account token: %w", err)
+	}
+	return c.listRealmRoleComposites(ctx, saToken, parentName)
+}
+
+func (c *Client) listRealmRoleComposites(ctx context.Context, saToken, parentName string) ([]RealmRole, error) {
+	u := fmt.Sprintf("%s/admin/realms/%s/roles/%s/composites/realm",
+		c.addr, c.realm, url.PathEscape(parentName))
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+saToken)
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("keycloak: GET composites: %w", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, ErrRoleNotFound
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("keycloak: GET composites %d: %s", resp.StatusCode, body)
+	}
+	var roles []RealmRole
+	if err := json.Unmarshal(body, &roles); err != nil {
+		return nil, fmt.Errorf("keycloak: decode composites: %w", err)
+	}
+	return roles, nil
+}
+
+// AddRealmRoleComposites attaches the given child realm roles to the
+// parent role. Each child must carry its `ID` (Keycloak UUID) and
+// `Name`; the marshalled body sets `clientRole=false` implicitly via the
+// RealmRole struct's zero-value `ClientRole`. Empty child list is a
+// no-op (Keycloak returns 204 for an empty array, but we short-circuit
+// to avoid the round-trip).
+//
+// Keycloak responds 204 No Content on success. Re-attaching an already-
+// composed child also returns 204 (idempotent on the server side), but
+// we still pre-filter via ListRealmRoleComposites to keep the audit log
+// quiet.
+func (c *Client) AddRealmRoleComposites(ctx context.Context, parentName string, children []RealmRole) error {
+	if len(children) == 0 {
+		return nil
+	}
+	saToken, err := c.serviceAccountToken(ctx)
+	if err != nil {
+		return fmt.Errorf("keycloak.AddRealmRoleComposites: service account token: %w", err)
+	}
+	return c.addRealmRoleComposites(ctx, saToken, parentName, children)
+}
+
+func (c *Client) addRealmRoleComposites(ctx context.Context, saToken, parentName string, children []RealmRole) error {
+	body, err := json.Marshal(children)
+	if err != nil {
+		return err
+	}
+	u := fmt.Sprintf("%s/admin/realms/%s/roles/%s/composites",
+		c.addr, c.realm, url.PathEscape(parentName))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, u, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+saToken)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return fmt.Errorf("keycloak: POST composites: %w", err)
+	}
+	defer resp.Body.Close()
+	respBody, _ := io.ReadAll(resp.Body)
+	switch resp.StatusCode {
+	case http.StatusNoContent, http.StatusOK, http.StatusCreated:
+		return nil
+	case http.StatusNotFound:
+		return ErrRoleNotFound
+	default:
+		return fmt.Errorf("keycloak: POST composites %d: %s", resp.StatusCode, respBody)
+	}
+}
+
+// EnsureCompositeRealmRole is the idempotent attach: if `child` is
+// already a composite of `parent`, the call is a no-op (one GET, no
+// write); otherwise the child is POSTed onto the parent's composite
+// list. Both `parent` and `child` are looked up by name to resolve their
+// Keycloak UUIDs (POST /composites requires the child's `id` field).
+//
+// Used by EnsureTierRealmRoles (realm_bootstrap.go) to wire the catalog
+// tier hierarchy at catalyst-api startup. Re-runs are no-ops.
+func (c *Client) EnsureCompositeRealmRole(ctx context.Context, parentName, childName string) error {
+	saToken, err := c.serviceAccountToken(ctx)
+	if err != nil {
+		return fmt.Errorf("keycloak.EnsureCompositeRealmRole: service account token: %w", err)
+	}
+
+	existing, err := c.listRealmRoleComposites(ctx, saToken, parentName)
+	if err != nil {
+		return fmt.Errorf("keycloak.EnsureCompositeRealmRole: list composites: %w", err)
+	}
+	for _, r := range existing {
+		if r.Name == childName {
+			// Already attached — idempotent no-op.
+			return nil
+		}
+	}
+
+	// Resolve the child role's UUID — Keycloak's POST /composites needs
+	// the `id` field, the `name` alone is not enough.
+	child, err := c.getRealmRole(ctx, saToken, childName)
+	if err != nil {
+		return fmt.Errorf("keycloak.EnsureCompositeRealmRole: resolve child %q: %w", childName, err)
+	}
+
+	if err := c.addRealmRoleComposites(ctx, saToken, parentName, []RealmRole{child}); err != nil {
+		return fmt.Errorf("keycloak.EnsureCompositeRealmRole: attach %q→%q: %w", childName, parentName, err)
+	}
+	return nil
 }

--- a/products/catalyst/bootstrap/api/internal/keycloak/realm_bootstrap.go
+++ b/products/catalyst/bootstrap/api/internal/keycloak/realm_bootstrap.go
@@ -1,0 +1,162 @@
+package keycloak
+
+// realm_bootstrap.go — EPIC-3 slice T2 (#1098) Keycloak composite
+// realm-role bootstrap.
+//
+// At catalyst-api startup (when KEYCLOAK_BOOTSTRAP_TIER_ROLES=true), a
+// goroutine in cmd/api/main.go calls EnsureTierRealmRoles to materialize
+// the 5 catalog-tier realm-roles + their composite chain in the
+// Sovereign Keycloak realm. Re-runs are no-ops once the chain is in
+// place.
+//
+// Architectural rules (locked in by the master brief + canon):
+//
+//   1. ADR-0001 §2.7 — tier ClusterRoles are the on-cluster RBAC truth;
+//      these Keycloak realm-roles are a UX layer (groups → tiers →
+//      composites) that mirror but do NOT replace.
+//
+//   2. INVIOLABLE-PRINCIPLES #4 — the tier names + composite chain live
+//      in this file (Go-source) NOT in template strings or env vars.
+//      The `TierBootstrapPlan` slice IS the configuration; operators
+//      who want a different chain author a different plan.
+//
+//   3. Idempotency anchor — every step calls Ensure* against Keycloak's
+//      current state and short-circuits on the no-op path. A re-run on
+//      a populated realm performs 5 GETs + 4 GETs (composite-list
+//      reads) and ZERO writes.
+//
+//   4. Non-blocking — main.go's wire-up runs this in a goroutine. A
+//      Keycloak that's slow to come up does NOT block catalyst-api's
+//      HTTP listener. Errors are logged + the goroutine exits; the
+//      next catalyst-api restart will pick up the bootstrap again.
+//
+// Per docs/EPICS-1-6-unified-design.md §6.2 the canonical chain is:
+//
+//     catalyst-viewer    (level 10, leaf, composite=false)
+//     catalyst-developer (level 20) → composes catalyst-viewer
+//     catalyst-operator  (level 30) → composes catalyst-developer
+//     catalyst-admin     (level 40) → composes catalyst-operator
+//     catalyst-owner     (level 50) → composes catalyst-admin
+
+import (
+	"context"
+	"fmt"
+)
+
+// TierBootstrapStep is one row of the canonical catalog-tier chain.
+// The Parent name is the realm role to ensure; ComposeChild is the
+// realm role that should be attached as a composite (empty for the leaf
+// `catalyst-viewer` tier). Level mirrors the ClusterRole's
+// `catalyst.openova.io/tier-level` label so the access-matrix UI can
+// sort tiers without a hardcoded order.
+type TierBootstrapStep struct {
+	Name         string
+	Description  string
+	Level        int
+	ComposeChild string // empty when this tier is the leaf
+}
+
+// CatalogTierBootstrapPlan is the canonical 5-tier plan per
+// docs/EPICS-1-6-unified-design.md §6.2. Order matters: viewer must be
+// created BEFORE developer (so the EnsureCompositeRealmRole call for
+// developer can resolve viewer's UUID), and so on up the chain.
+//
+// This slice is the configuration. INVIOLABLE-PRINCIPLES #4 forbids
+// hardcoding values in templates / env vars; this file IS the
+// canonical source. The Sovereign Keycloak realm name is supplied by
+// the caller (cfg.Keycloak.Realm — env-driven), but the tier names
+// themselves are fixed by the catalog tier system contract.
+var CatalogTierBootstrapPlan = []TierBootstrapStep{
+	{
+		Name:         "catalyst-viewer",
+		Description:  "Read-only access to in-scope resources (catalog tier 10).",
+		Level:        10,
+		ComposeChild: "",
+	},
+	{
+		Name:         "catalyst-developer",
+		Description:  "Viewer + workload exec/console + ticket update (catalog tier 20).",
+		Level:        20,
+		ComposeChild: "catalyst-viewer",
+	},
+	{
+		Name:         "catalyst-operator",
+		Description:  "Developer + console connect admin + SAM/patch/ticket-accept (catalog tier 30).",
+		Level:        30,
+		ComposeChild: "catalyst-developer",
+	},
+	{
+		Name:         "catalyst-admin",
+		Description:  "Operator + compute/credentials/applications/actions/networks/sessions admin (catalog tier 40).",
+		Level:        40,
+		ComposeChild: "catalyst-operator",
+	},
+	{
+		Name:         "catalyst-owner",
+		Description:  "Admin + RBAC + organization (catalog tier 50).",
+		Level:        50,
+		ComposeChild: "catalyst-admin",
+	},
+}
+
+// EnsureTierRealmRoles is idempotent: re-runs are no-ops when the 5
+// catalog-tier realm-roles already exist with the correct composite
+// chain.
+//
+// Logic (per master brief 04-T2-keycloak-realm-role-bootstrap.md):
+//
+//   1. For each tier viewer → owner:
+//      EnsureRealmRole with composite=true for non-viewer tiers and a
+//      `tier-level` attribute encoding the integer ordering.
+//
+//   2. For each tier ≠ viewer:
+//      EnsureCompositeRealmRole(parent, child) reads the parent's
+//      current composites first; only POSTs the missing child.
+//
+//   3. On error, return — the caller (the goroutine in main.go) logs
+//      the error and exits without retrying within the process. The
+//      next catalyst-api restart picks up where this run failed.
+//
+// Note: the `realm` parameter is informational here — the underlying
+// `Client` was constructed with its realm at New() time, so all
+// HTTP requests are already scoped to the right realm. The parameter
+// is kept on the API for symmetry with the master brief signature
+// (`func (c *Client) EnsureTierRealmRoles(ctx, realm) error`) and so
+// future refactors that route a single Client across multiple
+// Sovereign realms have a clear extension point.
+func (c *Client) EnsureTierRealmRoles(ctx context.Context, realm string) error {
+	if realm != "" && realm != c.realm {
+		return fmt.Errorf("keycloak.EnsureTierRealmRoles: realm mismatch: caller=%q client=%q (Client is constructed with a fixed realm; per-call realm override not supported in this slice)",
+			realm, c.realm)
+	}
+
+	// Phase 1 — ensure the 5 realm roles exist.
+	for _, step := range CatalogTierBootstrapPlan {
+		composite := step.ComposeChild != ""
+		rr := RealmRole{
+			Name:        step.Name,
+			Description: step.Description,
+			Composite:   composite,
+			Attributes: map[string][]string{
+				// Encoded as a string array per Keycloak v24 schema.
+				"tier-level": {fmt.Sprintf("%d", step.Level)},
+			},
+		}
+		if _, err := c.EnsureRealmRole(ctx, rr); err != nil {
+			return fmt.Errorf("ensure realm role %q: %w", step.Name, err)
+		}
+	}
+
+	// Phase 2 — wire the composite chain. This MUST run after phase 1
+	// because EnsureCompositeRealmRole calls getRealmRole on the child
+	// to resolve its UUID; that GET needs the role to exist.
+	for _, step := range CatalogTierBootstrapPlan {
+		if step.ComposeChild == "" {
+			continue // viewer is the leaf
+		}
+		if err := c.EnsureCompositeRealmRole(ctx, step.Name, step.ComposeChild); err != nil {
+			return fmt.Errorf("ensure composite %q→%q: %w", step.ComposeChild, step.Name, err)
+		}
+	}
+	return nil
+}

--- a/products/catalyst/bootstrap/api/internal/keycloak/realm_bootstrap_test.go
+++ b/products/catalyst/bootstrap/api/internal/keycloak/realm_bootstrap_test.go
@@ -1,0 +1,406 @@
+package keycloak
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// realmBootstrapState models the in-memory shape of a Keycloak realm's
+// roles + composite-children graph for the fake test server below. The
+// state machine is sufficient to assert idempotency at the byte level:
+// "given state X, EnsureTierRealmRoles makes only the writes needed to
+// reach the target chain — and zero writes when X is already at target".
+type realmBootstrapState struct {
+	mu       sync.Mutex
+	roles    map[string]*RealmRole          // name → role (with assigned id)
+	children map[string]map[string]struct{} // parent name → set of child names
+
+	// Counters give per-test assertions a clean view of the network
+	// activity without parsing the whole request log.
+	posts            int
+	getsRoles        int
+	getsComposites   int
+	postsComposites  int
+	roleCreatesByName map[string]int
+
+	// Token-refresh shenanigans. When forceTokenRetryOnce is true, the
+	// FIRST role-create POST returns 401, the HTTP transport surfaces
+	// that and the caller retries — the second attempt succeeds. This
+	// validates the implicit "retry on 401" behaviour the master brief
+	// asks for in test path #4.
+	forceTokenRetryOnce bool
+	tokenRetryFired     bool
+}
+
+func newRealmBootstrapState() *realmBootstrapState {
+	return &realmBootstrapState{
+		roles:             map[string]*RealmRole{},
+		children:          map[string]map[string]struct{}{},
+		roleCreatesByName: map[string]int{},
+	}
+}
+
+func (s *realmBootstrapState) seedRole(name string, composite bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.roles[name] = &RealmRole{
+		ID:        "id-" + name,
+		Name:      name,
+		Composite: composite,
+	}
+}
+
+func (s *realmBootstrapState) seedComposite(parent, child string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.children[parent]; !ok {
+		s.children[parent] = map[string]struct{}{}
+	}
+	s.children[parent][child] = struct{}{}
+}
+
+// realmBootstrapServer is an httptest.Server that mimics the subset of
+// the Keycloak Admin REST API the bootstrap touches:
+//
+//   - POST /realms/test-realm/protocol/openid-connect/token (SA token)
+//   - GET  /admin/realms/test-realm/roles/{name}
+//   - POST /admin/realms/test-realm/roles
+//   - GET  /admin/realms/test-realm/roles/{name}/composites/realm
+//   - POST /admin/realms/test-realm/roles/{name}/composites
+func realmBootstrapServer(t *testing.T, state *realmBootstrapState) *Client {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		state.mu.Lock()
+		defer state.mu.Unlock()
+
+		// Service-account token endpoint.
+		if r.URL.Path == "/realms/test-realm/protocol/openid-connect/token" {
+			saTokenHandler(w)
+			return
+		}
+
+		const adminPrefix = "/admin/realms/test-realm/roles"
+		if !strings.HasPrefix(r.URL.Path, adminPrefix) {
+			t.Errorf("unexpected path: %s %s", r.Method, r.URL.Path)
+			http.NotFound(w, r)
+			return
+		}
+		rest := strings.TrimPrefix(r.URL.Path, adminPrefix)
+
+		switch {
+		case rest == "" || rest == "/":
+			// POST /roles — create role.
+			if r.Method != http.MethodPost {
+				http.NotFound(w, r)
+				return
+			}
+			body, _ := io.ReadAll(r.Body)
+			var rr RealmRole
+			if err := json.Unmarshal(body, &rr); err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			state.posts++
+			state.roleCreatesByName[rr.Name]++
+			if state.forceTokenRetryOnce && !state.tokenRetryFired {
+				state.tokenRetryFired = true
+				w.WriteHeader(http.StatusUnauthorized)
+				_, _ = w.Write([]byte(`{"error":"token_expired"}`))
+				return
+			}
+			if _, exists := state.roles[rr.Name]; exists {
+				w.WriteHeader(http.StatusConflict)
+				return
+			}
+			rr.ID = "id-" + rr.Name
+			state.roles[rr.Name] = &rr
+			w.WriteHeader(http.StatusCreated)
+			return
+
+		case strings.HasSuffix(rest, "/composites/realm"):
+			// GET composites — list realm composites attached to parent.
+			if r.Method != http.MethodGet {
+				http.NotFound(w, r)
+				return
+			}
+			parent := strings.TrimPrefix(rest, "/")
+			parent = strings.TrimSuffix(parent, "/composites/realm")
+			state.getsComposites++
+			if _, ok := state.roles[parent]; !ok {
+				w.WriteHeader(http.StatusNotFound)
+				return
+			}
+			out := []RealmRole{}
+			for childName := range state.children[parent] {
+				if rr, ok := state.roles[childName]; ok {
+					out = append(out, *rr)
+				}
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(out)
+			return
+
+		case strings.HasSuffix(rest, "/composites"):
+			// POST composites — attach a list of realm-roles as composites.
+			if r.Method != http.MethodPost {
+				http.NotFound(w, r)
+				return
+			}
+			parent := strings.TrimPrefix(rest, "/")
+			parent = strings.TrimSuffix(parent, "/composites")
+			state.postsComposites++
+			if _, ok := state.roles[parent]; !ok {
+				w.WriteHeader(http.StatusNotFound)
+				return
+			}
+			body, _ := io.ReadAll(r.Body)
+			var children []RealmRole
+			if err := json.Unmarshal(body, &children); err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			if state.children[parent] == nil {
+				state.children[parent] = map[string]struct{}{}
+			}
+			for _, c := range children {
+				state.children[parent][c.Name] = struct{}{}
+			}
+			w.WriteHeader(http.StatusNoContent)
+			return
+
+		default:
+			// GET /roles/{name} — find role by name.
+			if r.Method != http.MethodGet {
+				http.NotFound(w, r)
+				return
+			}
+			name := strings.TrimPrefix(rest, "/")
+			state.getsRoles++
+			rr, ok := state.roles[name]
+			if !ok {
+				w.WriteHeader(http.StatusNotFound)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(rr)
+			return
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return NewWithHTTP(srv.URL, "test-realm", "catalyst-api-server", "sa-secret",
+		&http.Client{Timeout: 5 * time.Second})
+}
+
+// ── Test 1: clean-slate bootstrap creates 5 roles + 4 composites. ─────
+
+func TestEnsureTierRealmRoles_CleanSlate(t *testing.T) {
+	state := newRealmBootstrapState()
+	client := realmBootstrapServer(t, state)
+
+	if err := client.EnsureTierRealmRoles(context.Background(), "test-realm"); err != nil {
+		t.Fatalf("EnsureTierRealmRoles: %v", err)
+	}
+
+	// 5 roles created.
+	if state.posts != 5 {
+		t.Errorf("expected 5 role POSTs on clean slate, got %d", state.posts)
+	}
+	for _, want := range []string{
+		"catalyst-viewer", "catalyst-developer", "catalyst-operator",
+		"catalyst-admin", "catalyst-owner",
+	} {
+		if state.roleCreatesByName[want] != 1 {
+			t.Errorf("role %q should have been POSTed once, got %d",
+				want, state.roleCreatesByName[want])
+		}
+	}
+
+	// 4 composite chain links.
+	if state.postsComposites != 4 {
+		t.Errorf("expected 4 composite POSTs on clean slate, got %d",
+			state.postsComposites)
+	}
+	for parent, child := range map[string]string{
+		"catalyst-developer": "catalyst-viewer",
+		"catalyst-operator":  "catalyst-developer",
+		"catalyst-admin":     "catalyst-operator",
+		"catalyst-owner":     "catalyst-admin",
+	} {
+		set, ok := state.children[parent]
+		if !ok {
+			t.Errorf("expected composite chain to wire %q (parent missing)", parent)
+			continue
+		}
+		if _, has := set[child]; !has {
+			t.Errorf("expected %q to compose %q, got children=%v",
+				parent, child, set)
+		}
+	}
+
+	// tier-level attribute round-tripped.
+	if rr := state.roles["catalyst-admin"]; rr == nil {
+		t.Error("catalyst-admin role missing")
+	} else {
+		levels := rr.Attributes["tier-level"]
+		if len(levels) != 1 || levels[0] != "40" {
+			t.Errorf("catalyst-admin tier-level want [40], got %v", levels)
+		}
+	}
+}
+
+// ── Test 2: re-run on populated state writes nothing. ─────────────────
+
+func TestEnsureTierRealmRoles_AlreadyPopulated_NoWrites(t *testing.T) {
+	state := newRealmBootstrapState()
+	for _, step := range CatalogTierBootstrapPlan {
+		state.seedRole(step.Name, step.ComposeChild != "")
+	}
+	for _, step := range CatalogTierBootstrapPlan {
+		if step.ComposeChild != "" {
+			state.seedComposite(step.Name, step.ComposeChild)
+		}
+	}
+
+	client := realmBootstrapServer(t, state)
+	if err := client.EnsureTierRealmRoles(context.Background(), "test-realm"); err != nil {
+		t.Fatalf("EnsureTierRealmRoles: %v", err)
+	}
+	if state.posts != 0 {
+		t.Errorf("expected 0 role POSTs on populated state, got %d",
+			state.posts)
+	}
+	if state.postsComposites != 0 {
+		t.Errorf("expected 0 composite POSTs on populated state, got %d",
+			state.postsComposites)
+	}
+	if state.getsComposites != 4 {
+		t.Errorf("expected 4 composite-list GETs (one per non-leaf), got %d",
+			state.getsComposites)
+	}
+}
+
+// ── Test 3: only the missing role + its composite link get written. ────
+
+func TestEnsureTierRealmRoles_OneMissing_PartialWrites(t *testing.T) {
+	state := newRealmBootstrapState()
+	// Seed everything except catalyst-operator + its parent's composite link.
+	for _, step := range CatalogTierBootstrapPlan {
+		if step.Name == "catalyst-operator" {
+			continue
+		}
+		state.seedRole(step.Name, step.ComposeChild != "")
+	}
+	// Wire viewer→developer (already there before operator) and owner→admin
+	// — admin→operator and operator→developer are missing.
+	state.seedComposite("catalyst-developer", "catalyst-viewer")
+	state.seedComposite("catalyst-owner", "catalyst-admin")
+
+	client := realmBootstrapServer(t, state)
+	if err := client.EnsureTierRealmRoles(context.Background(), "test-realm"); err != nil {
+		t.Fatalf("EnsureTierRealmRoles: %v", err)
+	}
+	// Exactly 1 role POST: catalyst-operator.
+	if state.posts != 1 {
+		t.Errorf("expected 1 role POST, got %d", state.posts)
+	}
+	if state.roleCreatesByName["catalyst-operator"] != 1 {
+		t.Errorf("expected catalyst-operator to be POSTed once, got %d",
+			state.roleCreatesByName["catalyst-operator"])
+	}
+	// Exactly 2 composite POSTs: admin→operator and operator→developer.
+	if state.postsComposites != 2 {
+		t.Errorf("expected 2 composite POSTs, got %d", state.postsComposites)
+	}
+	if _, ok := state.children["catalyst-admin"]["catalyst-operator"]; !ok {
+		t.Error("admin→operator composite missing post-bootstrap")
+	}
+	if _, ok := state.children["catalyst-operator"]["catalyst-developer"]; !ok {
+		t.Error("operator→developer composite missing post-bootstrap")
+	}
+}
+
+// ── Test 4: 401 on token-refresh path bubbles up cleanly. ─────────────
+
+// Because the catalyst-api Client does NOT cache service-account tokens
+// at this layer (each Admin call refreshes via serviceAccountToken),
+// a 401 from a single role-POST surfaces to EnsureTierRealmRoles as an
+// error. The retry happens at the higher startup goroutine: the brief's
+// "5-attempt backoff" lives in main.go, not here. This test asserts
+// that the error is surfaced (does NOT silently no-op) so the goroutine
+// can decide whether to retry.
+func TestEnsureTierRealmRoles_RoleCreate401_SurfacesError(t *testing.T) {
+	state := newRealmBootstrapState()
+	state.forceTokenRetryOnce = true
+	client := realmBootstrapServer(t, state)
+
+	err := client.EnsureTierRealmRoles(context.Background(), "test-realm")
+	if err == nil {
+		t.Fatal("expected EnsureTierRealmRoles to surface 401 error")
+	}
+	if !strings.Contains(err.Error(), "401") {
+		t.Errorf("expected error to mention 401, got %v", err)
+	}
+}
+
+// ── Test 5: realm-mismatch is rejected at the API boundary. ───────────
+
+func TestEnsureTierRealmRoles_RealmMismatch_Rejects(t *testing.T) {
+	state := newRealmBootstrapState()
+	client := realmBootstrapServer(t, state)
+	// Client was constructed for "test-realm"; passing a different realm
+	// surfaces an error rather than silently bootstrapping the wrong one.
+	if err := client.EnsureTierRealmRoles(context.Background(), "wrong-realm"); err == nil {
+		t.Fatal("expected realm-mismatch rejection")
+	}
+}
+
+// ── Test 6: EnsureCompositeRealmRole idempotent on already-attached. ──
+
+func TestEnsureCompositeRealmRole_AlreadyAttached_NoWrite(t *testing.T) {
+	state := newRealmBootstrapState()
+	state.seedRole("catalyst-developer", true)
+	state.seedRole("catalyst-viewer", false)
+	state.seedComposite("catalyst-developer", "catalyst-viewer")
+
+	client := realmBootstrapServer(t, state)
+	if err := client.EnsureCompositeRealmRole(context.Background(),
+		"catalyst-developer", "catalyst-viewer"); err != nil {
+		t.Fatalf("EnsureCompositeRealmRole: %v", err)
+	}
+	if state.postsComposites != 0 {
+		t.Errorf("expected 0 composite POSTs, got %d", state.postsComposites)
+	}
+}
+
+// ── Test 7: ListRealmRoleComposites errors propagate with a 404. ──────
+
+func TestListRealmRoleComposites_NotFound(t *testing.T) {
+	state := newRealmBootstrapState()
+	client := realmBootstrapServer(t, state)
+	_, err := client.ListRealmRoleComposites(context.Background(), "no-such-role")
+	if !errors.Is(err, ErrRoleNotFound) {
+		t.Fatalf("expected ErrRoleNotFound, got %v", err)
+	}
+}
+
+// ── Test 8: empty children list short-circuits to a no-op. ────────────
+
+func TestAddRealmRoleComposites_EmptyChildren_NoHTTP(t *testing.T) {
+	// Server fails the test if any HTTP call is made.
+	client := roleTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("AddRealmRoleComposites with empty children must not call HTTP: %s",
+			r.URL.Path)
+	})
+	if err := client.AddRealmRoleComposites(context.Background(),
+		"catalyst-admin", nil); err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+}

--- a/products/catalyst/chart/templates/api-deployment.yaml
+++ b/products/catalyst/chart/templates/api-deployment.yaml
@@ -470,6 +470,27 @@ spec:
                   name: catalyst-kc-sa-credentials
                   key: client-secret
                   optional: true
+            # KEYCLOAK_BOOTSTRAP_TIER_ROLES — EPIC-3 slice T2 (#1098).
+            # When "true", a goroutine on catalyst-api startup calls
+            # EnsureTierRealmRoles (internal/keycloak/realm_bootstrap.go)
+            # against the Sovereign realm to materialise the 5 catalog-
+            # tier composite realm-roles (catalyst-{viewer,developer,
+            # operator,admin,owner}) per docs/EPICS-1-6-unified-design.md
+            # §6.2. Re-runs are idempotent no-ops.
+            #
+            # Default "false" to preserve current behaviour on the
+            # contabo mothership (whose `openova` realm has its own role
+            # taxonomy and should not gain catalyst-* tier roles). Per-
+            # Sovereign HelmRelease overlays flip this to "true" to opt
+            # the Sovereign's catalyst-api into the bootstrap. The
+            # goroutine waits up to ~30s for KC to be reachable, then
+            # retries up to 5 times with capped backoff before giving
+            # up; the next catalyst-api restart picks the bootstrap up
+            # again. Orthogonal to the chart-install-time
+            # keycloak-config-cli Job (which seeds the realm itself) —
+            # this env var only flips the runtime tier-role bootstrap.
+            - name: KEYCLOAK_BOOTSTRAP_TIER_ROLES
+              value: "false"
             # CATALYST_HANDOVER_JWT_PUBLIC_KEY_PATH — path to the JWK file that
             # holds the RS256 public key for validating one-time handover JWTs.
             # The K8s Secret `catalyst-handover-jwt-public` (created by


### PR DESCRIPTION
## Summary

EPIC-3 slice T2 — at catalyst-api startup, an opt-in goroutine materialises the 5 catalog-tier composite realm-roles (`catalyst-{viewer,developer,operator,admin,owner}`) per `docs/EPICS-1-6-unified-design.md` §6.2 in the Sovereign Keycloak realm. Re-runs are idempotent no-ops.

- New `internal/keycloak/admin_roles.go` methods: `ListRealmRoleComposites`, `AddRealmRoleComposites`, `EnsureCompositeRealmRole`.
- New `internal/keycloak/realm_bootstrap.go`: `EnsureTierRealmRoles` driver + `CatalogTierBootstrapPlan` (Go-source canonical chain per INVIOLABLE-PRINCIPLES #4).
- Wire-up in `cmd/api/main.go` behind `KEYCLOAK_BOOTSTRAP_TIER_ROLES` (default `false`) with a non-blocking goroutine, 30s readiness wait, 5-attempt capped backoff.
- Chart `api-deployment.yaml` env wiring with default `"false"` (contabo-mkt safety; per-Sovereign HelmRelease overlays flip to `"true"`).

## Test plan

- [x] `go test -count=1 -race ./internal/keycloak/...` — all 8 new tests pass + existing suite green
- [x] `go vet ./...` — clean
- [x] `go build ./...` — clean
- [x] Pre-existing failure `TestPinIssue_ConcurrentRapidFireRateLimit` confirmed pre-existing per canon §7 (timing flake, unrelated)
- [x] Pre-existing failure `TestBootstrapKit_BlueprintCardsHaveRequiredFields/gitea` lives in `tests/e2e/bootstrap-kit/` — outside this slice's package per canon §7

## Coverage matrix (8 unit-test paths)

| # | Test | Asserts |
|---|---|---|
| 1 | `TestEnsureTierRealmRoles_CleanSlate` | 5 role POSTs + 4 composite POSTs from empty realm; `tier-level` attribute round-trip |
| 2 | `TestEnsureTierRealmRoles_AlreadyPopulated_NoWrites` | 0 writes when chain already present (4 composite-list GETs only) |
| 3 | `TestEnsureTierRealmRoles_OneMissing_PartialWrites` | exactly 1 role POST + 2 composite POSTs when `catalyst-operator` + its two links are missing |
| 4 | `TestEnsureTierRealmRoles_RoleCreate401_SurfacesError` | 401 on POST surfaces error so the startup goroutine retries |
| 5 | `TestEnsureTierRealmRoles_RealmMismatch_Rejects` | per-call realm override is rejected (Client is bound to one realm) |
| 6 | `TestEnsureCompositeRealmRole_AlreadyAttached_NoWrite` | idempotent attach: already-present child triggers 0 POSTs |
| 7 | `TestListRealmRoleComposites_NotFound` | parent 404 surfaces `ErrRoleNotFound` |
| 8 | `TestAddRealmRoleComposites_EmptyChildren_NoHTTP` | empty-children list short-circuits without touching the network |

## Architecture notes

- ADR-0001 §2.7: ClusterRoles are on-cluster RBAC truth (slice T1, #1142); KC composite realm-roles are the UX layer this slice writes.
- INVIOLABLE-PRINCIPLES #4: tier names + composite chain live in `CatalogTierBootstrapPlan` Go slice, NOT in templates / env vars.
- Non-blocking startup per ADR-0001 event-driven principle: KC unavailability never blocks `catalyst-api` HTTP listener.
- Orthogonal lifecycle: chart-install-time `keycloak-config-cli` Job (slice not touched) seeds realm structure; this api-startup goroutine only ensures tier roles + composite chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)