### PR TITLE
feat(catalog): catalyst-catalog HTTP service + chart wiring (slice L, #1097)

### DIFF
--- a/.github/workflows/catalyst-catalog-build.yaml
+++ b/.github/workflows/catalyst-catalog-build.yaml
@@ -1,0 +1,152 @@
+name: Build catalyst-catalog
+
+# catalyst-catalog — multi-source Blueprint catalog HTTP REST service
+# (EPIC-2 Slice L of #1097). REPLACES the per-Org SME catalog per
+# ADR-0001 §4.3.
+#
+# Per docs/INVIOLABLE-PRINCIPLES.md #4a "GitHub Actions is the only
+# build path" — this workflow is the canonical (and only) way to
+# produce a `ghcr.io/openova-io/openova/catalyst-catalog:<sha>` image.
+#
+# Trigger model is event-driven per the openova-private CLAUDE.md
+# coupled rule: push-on-main is the canonical trigger; workflow_dispatch
+# is the manual override for ad-hoc rebuilds. NO cron.
+#
+# Path filter watches:
+#   - core/services/catalyst-catalog/**       (the service itself)
+#   - core/controllers/pkg/gitea/**           (the imported Gitea client)
+#   - core/controllers/go.mod                 (replaced module)
+#   - core/controllers/go.sum                 (replaced module)
+#   - .github/workflows/catalyst-catalog-build.yaml (this file)
+
+on:
+  push:
+    paths:
+      - 'core/services/catalyst-catalog/**'
+      - 'core/controllers/pkg/gitea/**'
+      - 'core/controllers/go.mod'
+      - 'core/controllers/go.sum'
+      - '.github/workflows/catalyst-catalog-build.yaml'
+    branches: [main]
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - 'core/services/catalyst-catalog/**'
+      - 'core/controllers/pkg/gitea/**'
+      - 'core/controllers/go.mod'
+      - 'core/controllers/go.sum'
+      - '.github/workflows/catalyst-catalog-build.yaml'
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE: ghcr.io/openova-io/openova/catalyst-catalog
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.23'
+          cache-dependency-path: |
+            core/services/catalyst-catalog/go.sum
+            core/controllers/go.sum
+
+      - name: go vet (catalog service)
+        working-directory: core/services/catalyst-catalog
+        run: go vet ./...
+
+      - name: go test (catalog service, race + count=1)
+        working-directory: core/services/catalyst-catalog
+        # Race + count=1 catches flakes that a cached run would hide.
+        # Tests use httptest fakes (no real Gitea required).
+        run: go test -count=1 -race ./...
+
+      - name: go vet (gitea client — promoted to pkg/)
+        working-directory: core/controllers
+        # The Gitea client lives in core/controllers/pkg/gitea — exercising
+        # vet here ensures the promotion path stays linkable.
+        run: go vet ./pkg/gitea/...
+
+      - name: go test (gitea client)
+        working-directory: core/controllers
+        run: go test -count=1 -race ./pkg/gitea/...
+
+  build:
+    needs: test
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    outputs:
+      sha_short: ${{ steps.vars.outputs.sha_short }}
+      digest: ${{ steps.build.outputs.digest }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set short SHA
+        id: vars
+        run: echo "sha_short=$(echo $GITHUB_SHA | head -c 7)" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push image
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          # Build context is the repository root so the Containerfile's
+          # COPY paths can reach BOTH core/services/catalyst-catalog/
+          # AND core/controllers/pkg/gitea/ (the replaced module that
+          # supplies the unified Gitea client).
+          context: .
+          file: core/services/catalyst-catalog/Containerfile
+          push: true
+          # SHA-pinned tags. Two emitted:
+          #   :<short-sha>   — what cluster manifests reference
+          #   :<full-sha>    — long form for audit trails
+          tags: |
+            ${{ env.IMAGE }}:${{ steps.vars.outputs.sha_short }}
+            ${{ env.IMAGE }}:${{ github.sha }}
+          provenance: false
+
+  notify:
+    needs: build
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Trigger downstream chart-bump
+        # Same repository_dispatch pattern as the other Group C controllers'
+        # workflows (see useraccess-controller-build.yaml for the canonical
+        # template). The downstream chart-bump workflow stamps the SHA
+        # into products/catalyst/chart/values.yaml services.catalog.image.tag
+        # and opens the bump PR for review.
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          repository: ${{ github.repository }}
+          event-type: catalyst-catalog-image-built
+          client-payload: |
+            {
+              "sha_short": "${{ needs.build.outputs.sha_short }}",
+              "digest": "${{ needs.build.outputs.digest }}",
+              "git_sha": "${{ github.sha }}"
+            }

--- a/core/controllers/application/cmd/main.go
+++ b/core/controllers/application/cmd/main.go
@@ -59,7 +59,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 
 	"github.com/openova-io/openova/core/controllers/application/internal/controller"
-	"github.com/openova-io/openova/core/controllers/internal/gitea"
+	"github.com/openova-io/openova/core/controllers/pkg/gitea"
 )
 
 func main() {

--- a/core/controllers/application/internal/controller/application_controller.go
+++ b/core/controllers/application/internal/controller/application_controller.go
@@ -60,7 +60,7 @@ import (
 	"k8s.io/client-go/dynamic"
 
 	"github.com/openova-io/openova/core/controllers/application/internal/validate"
-	"github.com/openova-io/openova/core/controllers/internal/gitea"
+	"github.com/openova-io/openova/core/controllers/pkg/gitea"
 	"github.com/openova-io/openova/core/controllers/internal/placement"
 	"github.com/openova-io/openova/core/controllers/internal/render"
 	"github.com/openova-io/openova/core/controllers/internal/semver"

--- a/core/controllers/application/internal/controller/application_controller_test.go
+++ b/core/controllers/application/internal/controller/application_controller_test.go
@@ -40,7 +40,7 @@ import (
 	k8stypes "k8s.io/apimachinery/pkg/types"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
 
-	"github.com/openova-io/openova/core/controllers/internal/gitea"
+	"github.com/openova-io/openova/core/controllers/pkg/gitea"
 )
 
 // fakeGitea is a deterministic test double for the Gitea interface.

--- a/core/controllers/blueprint/cmd/main.go
+++ b/core/controllers/blueprint/cmd/main.go
@@ -37,7 +37,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 
 	"github.com/openova-io/openova/core/controllers/blueprint/internal/controller"
-	"github.com/openova-io/openova/core/controllers/internal/gitea"
+	"github.com/openova-io/openova/core/controllers/pkg/gitea"
 )
 
 func main() {

--- a/core/controllers/blueprint/internal/controller/blueprint_controller.go
+++ b/core/controllers/blueprint/internal/controller/blueprint_controller.go
@@ -57,7 +57,7 @@ import (
 	"k8s.io/client-go/dynamic"
 	"sigs.k8s.io/yaml"
 
-	"github.com/openova-io/openova/core/controllers/internal/gitea"
+	"github.com/openova-io/openova/core/controllers/pkg/gitea"
 	"github.com/openova-io/openova/core/controllers/blueprint/internal/validate"
 )
 

--- a/core/controllers/blueprint/internal/controller/blueprint_controller_test.go
+++ b/core/controllers/blueprint/internal/controller/blueprint_controller_test.go
@@ -15,7 +15,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
 
-	"github.com/openova-io/openova/core/controllers/internal/gitea"
+	"github.com/openova-io/openova/core/controllers/pkg/gitea"
 )
 
 // newScheme wires the Blueprint GVR into a runtime.Scheme so the fake

--- a/core/controllers/environment/cmd/main.go
+++ b/core/controllers/environment/cmd/main.go
@@ -28,7 +28,7 @@ import (
 
 	envv1 "github.com/openova-io/openova/core/controllers/environment/api/v1"
 	"github.com/openova-io/openova/core/controllers/environment/internal/controller"
-	"github.com/openova-io/openova/core/controllers/internal/gitea"
+	"github.com/openova-io/openova/core/controllers/pkg/gitea"
 )
 
 var (

--- a/core/controllers/environment/internal/controller/environment_controller.go
+++ b/core/controllers/environment/internal/controller/environment_controller.go
@@ -46,7 +46,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	envv1 "github.com/openova-io/openova/core/controllers/environment/api/v1"
-	"github.com/openova-io/openova/core/controllers/internal/gitea"
+	"github.com/openova-io/openova/core/controllers/pkg/gitea"
 	"github.com/openova-io/openova/core/controllers/environment/internal/gitops"
 )
 

--- a/core/controllers/environment/internal/controller/environment_controller_test.go
+++ b/core/controllers/environment/internal/controller/environment_controller_test.go
@@ -17,7 +17,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	envv1 "github.com/openova-io/openova/core/controllers/environment/api/v1"
-	"github.com/openova-io/openova/core/controllers/internal/gitea"
+	"github.com/openova-io/openova/core/controllers/pkg/gitea"
 )
 
 // fakeGitea is a deterministic test double for the GiteaClient

--- a/core/controllers/organization/cmd/main.go
+++ b/core/controllers/organization/cmd/main.go
@@ -24,7 +24,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
-	"github.com/openova-io/openova/core/controllers/internal/gitea"
+	"github.com/openova-io/openova/core/controllers/pkg/gitea"
 	"github.com/openova-io/openova/core/controllers/organization/internal/controller"
 	orgapi "github.com/openova-io/openova/core/controllers/organization/internal/orgapi"
 )

--- a/core/controllers/organization/internal/controller/organization_controller.go
+++ b/core/controllers/organization/internal/controller/organization_controller.go
@@ -36,7 +36,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/openova-io/openova/core/controllers/internal/gitea"
+	"github.com/openova-io/openova/core/controllers/pkg/gitea"
 	"github.com/openova-io/openova/core/controllers/organization/internal/gitops"
 	orgapi "github.com/openova-io/openova/core/controllers/organization/internal/orgapi"
 )

--- a/core/controllers/organization/internal/controller/organization_controller_test.go
+++ b/core/controllers/organization/internal/controller/organization_controller_test.go
@@ -36,7 +36,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	"github.com/openova-io/openova/core/controllers/internal/gitea"
+	"github.com/openova-io/openova/core/controllers/pkg/gitea"
 	orgapi "github.com/openova-io/openova/core/controllers/organization/internal/orgapi"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/core/controllers/pkg/gitea/DESIGN.md
+++ b/core/controllers/pkg/gitea/DESIGN.md
@@ -2,7 +2,7 @@
 
 Slice CC2 of EPIC-0 (#1095) consolidates the four divergent Gitea HTTP
 clients shipped by the Group C controllers (slices C1-C4) into a single
-shared `core/controllers/internal/gitea` package.
+shared `core/controllers/pkg/gitea` package.
 
 CC1 (#1135) explicitly DEFERRED this consolidation because the four
 `Client` surfaces collide on signature shape and return semantics.
@@ -44,7 +44,7 @@ behavior change.
 
 ## 2. The SUPERSET surface (output)
 
-The shared `core/controllers/internal/gitea/Client` exposes the
+The shared `core/controllers/pkg/gitea/Client` exposes the
 **union** of every operation currently in use. Naming separates Org/Repo
 CRUD from File CRUD so call sites read obviously.
 
@@ -248,3 +248,27 @@ new shared package's `client_test.go` covers:
 - No deploy-manifest changes.
 - No dep-version bumps.
 - No behavior change for any existing call site.
+
+## 6. Promotion to pkg/ (EPIC-2 Slice L, #1097)
+
+EPIC-2 Slice L (catalog-svc, `core/services/catalyst-catalog/`) introduced
+the FIRST consumer of this client OUTSIDE the `core/controllers/` Go module.
+Catalog-svc is a SERVICE not a CONTROLLER and lives in its own go.mod under
+`core/services/catalyst-catalog/`.
+
+Go's `internal/` packaging rule prohibits import from outside the parent
+sub-tree (`core/controllers/`). To preserve "one canonical Gitea client,
+zero per-service variants," CC2 promoted this package from
+`core/controllers/internal/gitea` to `core/controllers/pkg/gitea`.
+
+The 5 Group C controllers were updated atomically in the same PR. No
+behavior change — only the import path.
+
+After this promotion, ANY new Go module under the `openova` repo that
+needs Gitea access imports `github.com/openova-io/openova/core/controllers/pkg/gitea`
+via a `replace` directive (catalog-svc's go.mod uses
+`replace github.com/openova-io/openova/core/controllers => ../../controllers`)
+or a published-module path once the controllers module is tagged.
+
+The `internal/` → `pkg/` move is the canonical signal that this surface
+is a SHARED-LIBRARY contract, not a controllers-private helper.

--- a/core/controllers/pkg/gitea/client.go
+++ b/core/controllers/pkg/gitea/client.go
@@ -1,7 +1,7 @@
 // Package gitea is the SUPERSET Gitea HTTP client used by every Group
 // C controller. It consolidates the four divergent per-controller
 // clients (slices C1-C4) into a single shared surface promoted to
-// `core/controllers/internal/gitea/` by slice CC2 (#1095) per
+// `core/controllers/pkg/gitea/` by slice CC2 (#1095) per
 // `02-implementer-canon.md` §1+§2.
 //
 // The surface is the UNION of every operation any Group C controller
@@ -348,6 +348,80 @@ func (c *Client) GetRepo(ctx context.Context, owner, name string) (Repo, error) 
 			return Repo{}, ErrRepoNotFound
 		}
 		return Repo{}, err
+	}
+	return out, nil
+}
+
+// ListOrgRepos returns every repository under the named Org, walking
+// Gitea's pagination (page=1..N, limit=50). Added for EPIC-2 Slice L
+// catalog-svc (#1097) to enumerate Blueprint repos under the public
+// + sovereign-curated catalog Orgs.
+//
+// Returns ErrOrgNotFound on 404 from the first page; partial pagination
+// failures bubble up as HTTPError. Result order is the order Gitea
+// returns (no client-side sort).
+func (c *Client) ListOrgRepos(ctx context.Context, org string) ([]Repo, error) {
+	if org == "" {
+		return nil, errors.New("gitea: ListOrgRepos requires non-empty org")
+	}
+	const pageSize = 50
+	out := make([]Repo, 0, pageSize)
+	for page := 1; ; page++ {
+		endpoint := fmt.Sprintf("/orgs/%s/repos?limit=%d&page=%d",
+			url.PathEscape(org), pageSize, page)
+		var batch []Repo
+		status, _, err := c.do(ctx, http.MethodGet, endpoint, nil, &batch)
+		if err != nil {
+			if page == 1 && status == http.StatusNotFound {
+				return nil, ErrOrgNotFound
+			}
+			return nil, err
+		}
+		out = append(out, batch...)
+		if len(batch) < pageSize {
+			break
+		}
+	}
+	return out, nil
+}
+
+// ContentEntry is one element of a Gitea contents listing.
+//
+// Type is "file" or "dir"; Path is the relative path (matches what
+// Gitea returns); Name is the basename.
+type ContentEntry struct {
+	Name string `json:"name"`
+	Path string `json:"path"`
+	SHA  string `json:"sha,omitempty"`
+	Type string `json:"type"`
+	Size int64  `json:"size,omitempty"`
+}
+
+// ListContents lists the contents of `path` in the repo at `branch`.
+// `path` may be empty (root). Returns ErrFileNotFound if the path does
+// not exist, ErrRepoNotFound if the repository does not exist.
+//
+// Added for EPIC-2 Slice L catalog-svc to enumerate per-Blueprint
+// directories inside `<org>/shared-blueprints`.
+func (c *Client) ListContents(ctx context.Context, org, repo, branch, path string) ([]ContentEntry, error) {
+	if org == "" || repo == "" {
+		return nil, errors.New("gitea: ListContents requires non-empty org, repo")
+	}
+	endpoint := fmt.Sprintf("/repos/%s/%s/contents/%s",
+		url.PathEscape(org), url.PathEscape(repo), pathEscapeSegments(path))
+	if branch != "" {
+		endpoint += "?ref=" + url.QueryEscape(branch)
+	}
+	var out []ContentEntry
+	status, body, err := c.do(ctx, http.MethodGet, endpoint, nil, &out)
+	if err != nil {
+		if status == http.StatusNotFound {
+			if strings.Contains(strings.ToLower(string(body)), "repository") {
+				return nil, ErrRepoNotFound
+			}
+			return nil, ErrFileNotFound
+		}
+		return nil, err
 	}
 	return out, nil
 }

--- a/core/controllers/pkg/gitea/client_test.go
+++ b/core/controllers/pkg/gitea/client_test.go
@@ -29,6 +29,10 @@ type fakeGitea struct {
 	branches map[string]map[string]bool
 	files    map[string]fakeFile
 	calls    map[string]int
+	// dirs is the set of "exists as directory" paths, keyed by
+	// "<owner>/<repo>/<branch>/<path>". The empty path "" represents
+	// the repo root and is implicitly available when the repo exists.
+	dirs map[string]bool
 }
 
 type fakeFile struct {
@@ -43,6 +47,7 @@ func newFake() *fakeGitea {
 		branches: map[string]map[string]bool{},
 		files:    map[string]fakeFile{},
 		calls:    map[string]int{},
+		dirs:     map[string]bool{},
 	}
 }
 
@@ -98,6 +103,36 @@ func (f *fakeGitea) handler() http.Handler {
 			}
 			f.orgs[body.Username] = o
 			writeJSON(w, http.StatusCreated, o)
+			return
+		}
+
+		// GET /api/v1/orgs/{org}/repos — list repos under an Org with
+		// pagination. Added by EPIC-2 Slice L (#1097) for catalog-svc's
+		// repo enumeration.
+		if r.Method == http.MethodGet && strings.HasPrefix(p, "/api/v1/orgs/") && strings.HasSuffix(p, "/repos") {
+			owner := strings.TrimSuffix(strings.TrimPrefix(p, "/api/v1/orgs/"), "/repos")
+			f.mu.Lock()
+			_, exists := f.orgs[owner]
+			if !exists {
+				f.mu.Unlock()
+				http.Error(w, "no such org", http.StatusNotFound)
+				return
+			}
+			out := make([]Repo, 0)
+			for k, rp := range f.repos {
+				if strings.HasPrefix(k, owner+"/") {
+					out = append(out, rp)
+				}
+			}
+			f.mu.Unlock()
+			// Stable order (sort by name) — clients shouldn't depend on
+			// order but tests want determinism.
+			for i := 1; i < len(out); i++ {
+				for j := i; j > 0 && out[j-1].Name > out[j].Name; j-- {
+					out[j-1], out[j] = out[j], out[j-1]
+				}
+			}
+			writeJSON(w, http.StatusOK, out)
 			return
 		}
 
@@ -246,6 +281,55 @@ func (f *fakeGitea) handler() http.Handler {
 			case http.MethodGet:
 				ff, ok := f.files[fileKey]
 				if !ok {
+					// Directory listing path — used by ListContents.
+					// We treat the path as a directory if either:
+					//   (a) it was explicitly registered in f.dirs, or
+					//   (b) the path is "" (repo root, always implicit).
+					dirKey := repoKey + "/" + branch + "/" + filePath
+					if filePath == "" || f.dirs[dirKey] {
+						entries := make([]ContentEntry, 0)
+						prefix := filePath
+						if prefix != "" {
+							prefix += "/"
+						}
+						seen := map[string]bool{}
+						for k, ff := range f.files {
+							want := repoKey + "/" + branch + "/" + prefix
+							if !strings.HasPrefix(k, want) {
+								continue
+							}
+							rest := strings.TrimPrefix(k, want)
+							if rest == "" {
+								continue
+							}
+							head, _, hasSlash := strings.Cut(rest, "/")
+							if seen[head] {
+								continue
+							}
+							seen[head] = true
+							typ := "file"
+							size := int64(len(ff.content))
+							pathOut := prefix + head
+							if hasSlash {
+								typ = "dir"
+								size = 0
+							}
+							entries = append(entries, ContentEntry{
+								Name: head,
+								Path: pathOut,
+								Type: typ,
+								Size: size,
+							})
+						}
+						// Stable order.
+						for i := 1; i < len(entries); i++ {
+							for j := i; j > 0 && entries[j-1].Name > entries[j].Name; j-- {
+								entries[j-1], entries[j] = entries[j], entries[j-1]
+							}
+						}
+						writeJSON(w, http.StatusOK, entries)
+						return
+					}
 					http.Error(w, "no such file", http.StatusNotFound)
 					return
 				}
@@ -846,5 +930,136 @@ func TestFile_Decoded(t *testing.T) {
 	var nilF *File
 	if dec, err := nilF.Decoded(); err != nil || dec != nil {
 		t.Errorf("nil File should return nil bytes, got %v %v", dec, err)
+	}
+}
+
+// ----------------------------------------------------------------------
+// ListOrgRepos / ListContents (added by EPIC-2 Slice L #1097)
+// ----------------------------------------------------------------------
+
+func TestListOrgRepos_HappyPath(t *testing.T) {
+	t.Parallel()
+	fake := newFake()
+	fake.orgs["catalog"] = Org{Username: "catalog"}
+	fake.repos["catalog/bp-wordpress"] = Repo{Name: "bp-wordpress", FullName: "catalog/bp-wordpress"}
+	fake.repos["catalog/bp-redis"] = Repo{Name: "bp-redis", FullName: "catalog/bp-redis"}
+	fake.repos["catalog/bp-postgres"] = Repo{Name: "bp-postgres", FullName: "catalog/bp-postgres"}
+	c := newClientWithFake(t, fake)
+
+	got, err := c.ListOrgRepos(context.Background(), "catalog")
+	if err != nil {
+		t.Fatalf("ListOrgRepos: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("expected 3 repos, got %d", len(got))
+	}
+	// Order is sorted-by-name in our fake.
+	expected := []string{"bp-postgres", "bp-redis", "bp-wordpress"}
+	for i, want := range expected {
+		if got[i].Name != want {
+			t.Errorf("got[%d].Name = %q, want %q", i, got[i].Name, want)
+		}
+	}
+}
+
+func TestListOrgRepos_EmptyOrg(t *testing.T) {
+	t.Parallel()
+	fake := newFake()
+	fake.orgs["empty"] = Org{Username: "empty"}
+	c := newClientWithFake(t, fake)
+
+	got, err := c.ListOrgRepos(context.Background(), "empty")
+	if err != nil {
+		t.Fatalf("ListOrgRepos empty: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("expected 0 repos, got %d", len(got))
+	}
+}
+
+func TestListOrgRepos_OrgNotFound(t *testing.T) {
+	t.Parallel()
+	fake := newFake()
+	c := newClientWithFake(t, fake)
+
+	_, err := c.ListOrgRepos(context.Background(), "missing")
+	if !errors.Is(err, ErrOrgNotFound) {
+		t.Errorf("ListOrgRepos missing org err = %v, want ErrOrgNotFound", err)
+	}
+}
+
+func TestListOrgRepos_RejectsEmptyOrg(t *testing.T) {
+	t.Parallel()
+	c := New("http://x", "tok")
+	_, err := c.ListOrgRepos(context.Background(), "")
+	if err == nil {
+		t.Error("ListOrgRepos with empty org should fail")
+	}
+}
+
+func TestListContents_RootListing(t *testing.T) {
+	t.Parallel()
+	fake := newFake()
+	fake.orgs["acme"] = Org{Username: "acme"}
+	fake.repos["acme/shared-blueprints"] = Repo{Name: "shared-blueprints", FullName: "acme/shared-blueprints"}
+	fake.branches["acme/shared-blueprints"] = map[string]bool{"main": true}
+	fake.files["acme/shared-blueprints/main/bp-foo/blueprint.yaml"] = fakeFile{content: []byte("a"), sha: "s1"}
+	fake.files["acme/shared-blueprints/main/bp-bar/blueprint.yaml"] = fakeFile{content: []byte("b"), sha: "s2"}
+	fake.files["acme/shared-blueprints/main/README.md"] = fakeFile{content: []byte("# readme"), sha: "s3"}
+	c := newClientWithFake(t, fake)
+
+	got, err := c.ListContents(context.Background(), "acme", "shared-blueprints", "main", "")
+	if err != nil {
+		t.Fatalf("ListContents root: %v", err)
+	}
+	// We expect 3 entries: bp-bar (dir), bp-foo (dir), README.md (file).
+	if len(got) != 3 {
+		t.Fatalf("expected 3 entries, got %d: %+v", len(got), got)
+	}
+	want := []ContentEntry{
+		{Name: "README.md", Path: "README.md", Type: "file", Size: 8},
+		{Name: "bp-bar", Path: "bp-bar", Type: "dir"},
+		{Name: "bp-foo", Path: "bp-foo", Type: "dir"},
+	}
+	for i, w := range want {
+		if got[i].Name != w.Name || got[i].Type != w.Type {
+			t.Errorf("entry[%d] = %+v, want %+v", i, got[i], w)
+		}
+	}
+}
+
+func TestListContents_RepoNotFound(t *testing.T) {
+	t.Parallel()
+	fake := newFake()
+	c := newClientWithFake(t, fake)
+
+	_, err := c.ListContents(context.Background(), "acme", "missing", "main", "")
+	if !errors.Is(err, ErrRepoNotFound) {
+		t.Errorf("ListContents missing-repo err = %v, want ErrRepoNotFound", err)
+	}
+}
+
+func TestListContents_FileNotFound(t *testing.T) {
+	t.Parallel()
+	fake := newFake()
+	fake.orgs["acme"] = Org{Username: "acme"}
+	fake.repos["acme/repo"] = Repo{Name: "repo", FullName: "acme/repo"}
+	fake.branches["acme/repo"] = map[string]bool{"main": true}
+	c := newClientWithFake(t, fake)
+
+	_, err := c.ListContents(context.Background(), "acme", "repo", "main", "no-such-dir")
+	if !errors.Is(err, ErrFileNotFound) {
+		t.Errorf("ListContents missing-path err = %v, want ErrFileNotFound", err)
+	}
+}
+
+func TestListContents_RejectsEmptyOrgRepo(t *testing.T) {
+	t.Parallel()
+	c := New("http://x", "tok")
+	if _, err := c.ListContents(context.Background(), "", "r", "main", ""); err == nil {
+		t.Error("ListContents with empty org should fail")
+	}
+	if _, err := c.ListContents(context.Background(), "o", "", "main", ""); err == nil {
+		t.Error("ListContents with empty repo should fail")
 	}
 }

--- a/core/services/catalyst-catalog/Containerfile
+++ b/core/services/catalyst-catalog/Containerfile
@@ -1,0 +1,44 @@
+# catalyst-catalog — EPIC-2 Slice L of #1097.
+#
+# Distroless-static final image; non-root UID 65532; size ~25-35 MiB.
+#
+# Per docs/INVIOLABLE-PRINCIPLES.md #4a, this image must be built ONLY
+# by the GitHub Actions pipeline and tagged with the git SHA. Local
+# builds never reach GHCR.
+#
+# Build context: the repository root (so we can COPY the catalyst-catalog
+# tree alongside the unified Gitea client at core/controllers/pkg/gitea
+# referenced via a `replace` directive in catalyst-catalog/go.mod).
+
+FROM golang:1.23-alpine AS build
+WORKDIR /src
+
+# Pre-stage the controllers module (Gitea client + shared helpers).
+# catalyst-catalog/go.mod uses a replace directive pointing at this
+# path, so the source MUST be present before `go mod download` runs.
+COPY core/controllers/go.mod core/controllers/go.sum core/controllers/
+COPY core/controllers/internal/ core/controllers/internal/
+COPY core/controllers/pkg/ core/controllers/pkg/
+
+# Pre-stage the catalog go.mod / go.sum for cached dep resolution.
+COPY core/services/catalyst-catalog/go.mod core/services/catalyst-catalog/go.sum core/services/catalyst-catalog/
+
+WORKDIR /src/core/services/catalyst-catalog
+RUN go mod download
+
+# Now copy the catalog source.
+WORKDIR /src
+COPY core/services/catalyst-catalog/ core/services/catalyst-catalog/
+
+WORKDIR /src/core/services/catalyst-catalog
+RUN CGO_ENABLED=0 GOOS=linux go build \
+    -trimpath \
+    -ldflags="-s -w" \
+    -o /out/catalyst-catalog \
+    ./cmd/catalog
+
+FROM gcr.io/distroless/static-debian12:nonroot
+COPY --from=build /out/catalyst-catalog /catalyst-catalog
+USER 65532:65532
+EXPOSE 8080
+ENTRYPOINT ["/catalyst-catalog"]

--- a/core/services/catalyst-catalog/DESIGN.md
+++ b/core/services/catalyst-catalog/DESIGN.md
@@ -1,0 +1,154 @@
+# catalyst-catalog — EPIC-2 Slice L design notes
+
+EPIC-2 Slice L of #1097. Multi-source Blueprint catalog HTTP REST service
+that REPLACES the per-Org SME catalog (different scope) per ADR-0001 §4.3.
+
+## Module layout (decision)
+
+`core/services/catalyst-catalog/` lives in its OWN Go module —
+`github.com/openova-io/openova/core/services/catalyst-catalog`.
+
+Group `core/controllers/` is for **CRD reconcilers**; group
+`core/services/` is for **HTTP services**. Catalyst-catalog is a service,
+not a controller, so it doesn't share the controllers module. Co-located
+SME services (auth/billing/notification/etc.) each live in their own
+`core/services/<name>/` modules — this slice follows that pattern.
+
+We ship under the name `catalyst-catalog/` (rather than `catalog/`) to
+disambiguate from the existing `core/services/catalog/` SME service. SME
+catalog retirement is slice L3, deferred per the EPIC-2 master brief.
+
+## Importing the unified Gitea client
+
+The unified Gitea client (CC2 #1136) is the only sanctioned Gitea HTTP
+surface. Catalyst-catalog reuses it via:
+
+1. Promotion: `core/controllers/internal/gitea` →
+   `core/controllers/pkg/gitea`. Go's `internal/` packaging rule blocks
+   imports from outside the parent sub-tree, which would forbid catalog-
+   svc (a sibling Go module) from importing it. Promotion to `pkg/`
+   signals "shared library contract" and unblocks cross-module use.
+   The 5 Group C controllers (organization, environment, blueprint,
+   application, useraccess) were updated atomically in this slice's PR.
+2. `replace` directive in `catalyst-catalog/go.mod`:
+   `replace github.com/openova-io/openova/core/controllers => ../../controllers`.
+   This ties the catalog build to the in-tree version of the Gitea
+   client without publishing a versioned tag.
+
+The promotion is documented in `core/controllers/pkg/gitea/DESIGN.md` §6.
+
+This slice ALSO extended the unified Gitea client with two new methods
+needed for catalog enumeration (added at the canonical seam, NOT as
+catalog-private helpers):
+
+- `ListOrgRepos(ctx, org) ([]Repo, error)` — paginated repo listing
+  under an Org. Used to enumerate Blueprint repos in `catalog` and
+  `catalog-sovereign` Orgs.
+- `ListContents(ctx, org, repo, branch, path) ([]ContentEntry, error)`
+  — directory listing. Used to enumerate per-Blueprint dirs in
+  `<org>/shared-blueprints`.
+
+## Three sources, priority on collision
+
+| Origin | Repo layout | Visibility |
+|---|---|---|
+| Public (`catalog` Org) | `catalog/<bp-name>` repo, `blueprint.yaml` at root | Always |
+| Sovereign (`catalog-sovereign` Org) | same shape | Always |
+| Per-Org private (`<org>/shared-blueprints` repo) | one dir per Blueprint, each with `blueprint.yaml` | Only callers in `<org>` |
+
+**Resolution order**: PRIVATE > SOVEREIGN > PUBLIC. An Org's private
+copy of a Blueprint name overrides the sovereign-curated and public
+versions. This matches `docs/EPICS-1-6-unified-design.md` §5.4.
+
+## Auth model
+
+Catalyst-catalog is intended to run **behind catalyst-api** (Cilium
+Gateway HTTPRoute proxy). Catalyst-api validates the Keycloak JWT
+against JWKS and forwards the request. Catalog-svc parses the JWT
+payload (3 base64url segments + `exp` check) for `Claims.Groups[]` /
+`Claims.Org` to compute the caller's visible Orgs.
+
+When `CATALOG_ANONYMOUS_READS=true`, anonymous callers may list public +
+sovereign-curated Blueprints (no per-Org private). Default: false.
+
+A future hardening slice can add an optional `CATALOG_JWKS_URL` env-var
+to do in-process JWKS validation (e.g. when deployed without the proxy).
+
+## Cache
+
+In-memory LRU + per-entry TTL on every blueprint.yaml read. Default TTL
+30s, capacity 1024 entries. Cache key is
+`<origin>|<org>|<name>|<version>` — every (source, name) pair is
+independent. Invalidation is TTL-only; Gitea-side changes propagate
+within at most TTL seconds. This is a deliberate trade-off: a Blueprint
+publishing event in Gitea has no webhook to push-invalidate the cache,
+and a 30s lag on the catalog is acceptable.
+
+## REST endpoints
+
+```
+GET /healthz
+GET /api/v1/catalog?org=<slug>
+GET /api/v1/catalog/{name}
+GET /api/v1/catalog/{name}/versions
+GET /api/v1/catalog/{name}/versions/{version}
+```
+
+JSON shape (consumed by EPIC-2 Slice I `useCatalog()` hook):
+
+```json
+{
+  "items": [
+    {
+      "name": "bp-wordpress",
+      "version": "5.6.1",
+      "visibility": "listed",
+      "card": {
+        "title": "WordPress",
+        "summary": "...",
+        "icon": "wordpress",
+        "category": "cms",
+        "tags": ["php", "mysql"]
+      },
+      "placementSchema": {
+        "modes": ["single-region", "active-active", "active-hotstandby"],
+        "default": "single-region"
+      },
+      "upgradeFrom": ["5.5.0"],
+      "origin": 1,
+      "source": "public",
+      "org": ""
+    }
+  ]
+}
+```
+
+`origin` is an integer enum (1=public, 2=sovereign, 3=org-private);
+`source` is the human-readable form. `org` is populated only for
+org-private entries.
+
+The `GET /api/v1/catalog/{name}` and `GET /api/v1/catalog/{name}/versions/{version}`
+responses include the `raw` field — the full parsed Blueprint manifest
+(map[string]interface{}) — so the install flow can render the
+`configSchema` form without a second round-trip to Gitea.
+
+## GraphQL — DEFERRED
+
+Per the EPIC-2 master brief, GraphQL ("use gqlgen if not present; fall
+back to plain REST if gqlgen pull is heavy") is a deferred follow-up.
+catalyst-catalog ships REST-only in this slice. Adding gqlgen would pull
+~80MB of indirect deps for a feature no UI consumer has yet asked for.
+
+When the install flow needs nested-fetch shape (e.g. "give me Blueprint
++ all upgrade-target versions in one request") we'll either add a tiny
+in-process GraphQL surface (gqlgen) or compose REST calls in the UI's
+TanStack Query layer. Decision deferred until a real consumer arrives.
+
+## SME catalog retirement — DEFERRED
+
+Per the EPIC-2 master brief, slice L3 (migrating the SME catalog
+service's existing routes to catalyst-catalog or documenting them as
+retired) is deferred to a follow-up slice. The SME `core/services/catalog/`
+service continues to operate on its current scope (per-Org, MongoDB-backed)
+until that slice lands. **DO NOT remove or modify SME catalog code in
+the L1+L2 PR.**

--- a/core/services/catalyst-catalog/cmd/catalog/main.go
+++ b/core/services/catalyst-catalog/cmd/catalog/main.go
@@ -1,0 +1,129 @@
+// catalyst-catalog HTTP REST service entrypoint.
+//
+// Per docs/INVIOLABLE-PRINCIPLES.md #4 (no hardcoded URLs, regions, FQDNs)
+// every config value is sourced from environment variables. See
+// internal/config/config.go for the full schema.
+//
+// The Gitea client is the unified CC2 client at
+// `core/controllers/pkg/gitea` (promoted from internal/ by EPIC-2 Slice L
+// per the brief — Go internal/ rule blocks cross-module imports).
+package main
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/openova-io/openova/core/controllers/pkg/gitea"
+	"github.com/openova-io/openova/core/services/catalyst-catalog/internal/cache"
+	"github.com/openova-io/openova/core/services/catalyst-catalog/internal/config"
+	"github.com/openova-io/openova/core/services/catalyst-catalog/internal/handler"
+	"github.com/openova-io/openova/core/services/catalyst-catalog/internal/source"
+)
+
+func main() {
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	slog.SetDefault(logger)
+
+	cfg, err := config.Load()
+	if err != nil {
+		logger.Error("config load failed", "err", err)
+		os.Exit(1)
+	}
+	logger.Info("catalyst-catalog starting",
+		"listen", cfg.ListenAddr,
+		"public_org", cfg.PublicCatalogOrg,
+		"sovereign_org", cfg.SovereignCatalogOrg,
+		"private_repo", cfg.OrgPrivateRepoSuffix,
+		"cache_ttl", cfg.CacheTTL,
+		"cache_capacity", cfg.CacheCapacity,
+		"sovereign_fqdn", cfg.SovereignFQDN,
+		"anonymous_reads", cfg.AnonymousReads,
+	)
+
+	gc := gitea.NewWithHTTP(cfg.GiteaURL, cfg.GiteaToken, &http.Client{Timeout: 30 * time.Second})
+
+	c := cache.New(cfg.CacheCapacity, cfg.CacheTTL)
+	r := source.NewResolver(gc, cfg.PublicCatalogOrg, cfg.SovereignCatalogOrg, cfg.OrgPrivateRepoSuffix, c)
+	h := handler.New(cfg, r, c, logger)
+
+	mux := h.Routes()
+
+	srv := &http.Server{
+		Addr:              cfg.ListenAddr,
+		Handler:           withLogging(logger, withRecover(logger, mux)),
+		ReadHeaderTimeout: 10 * time.Second,
+		ReadTimeout:       30 * time.Second,
+		WriteTimeout:      60 * time.Second,
+		IdleTimeout:       2 * time.Minute,
+	}
+
+	idle := make(chan struct{})
+	go func() {
+		sigs := make(chan os.Signal, 1)
+		signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
+		<-sigs
+		logger.Info("shutdown initiated")
+		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+		defer cancel()
+		if err := srv.Shutdown(ctx); err != nil {
+			logger.Error("graceful shutdown failed", "err", err)
+		}
+		close(idle)
+	}()
+
+	logger.Info("listening", "addr", cfg.ListenAddr)
+	if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		logger.Error("ListenAndServe", "err", err)
+		os.Exit(1)
+	}
+	<-idle
+	logger.Info("stopped cleanly")
+}
+
+// withLogging is a tiny structured access logger. We log r.URL.Path
+// (NEVER r.URL.RawQuery) because the access_token query param can carry
+// the JWT — never let it land in logs.
+func withLogging(logger *slog.Logger, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+		sw := &statusWriter{ResponseWriter: w, status: 200}
+		next.ServeHTTP(sw, r)
+		logger.Info("http",
+			"method", r.Method,
+			"path", r.URL.Path,
+			"status", sw.status,
+			"duration_ms", time.Since(start).Milliseconds(),
+			"remote", r.RemoteAddr,
+		)
+	})
+}
+
+// withRecover converts panics into 500s so a single bad code path
+// can't take the process down.
+func withRecover(logger *slog.Logger, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer func() {
+			if rec := recover(); rec != nil {
+				logger.Error("panic", "err", rec, "path", r.URL.Path)
+				http.Error(w, `{"error":"internal","message":"panic"}`, http.StatusInternalServerError)
+			}
+		}()
+		next.ServeHTTP(w, r)
+	})
+}
+
+type statusWriter struct {
+	http.ResponseWriter
+	status int
+}
+
+func (s *statusWriter) WriteHeader(code int) {
+	s.status = code
+	s.ResponseWriter.WriteHeader(code)
+}

--- a/core/services/catalyst-catalog/go.mod
+++ b/core/services/catalyst-catalog/go.mod
@@ -1,0 +1,26 @@
+// Module path: github.com/openova-io/openova/core/services/catalyst-catalog
+//
+// catalyst-catalog is the Sovereign-wide Blueprint catalog HTTP REST
+// service shipped by EPIC-2 Slice L (#1097). It REPLACES the per-Org
+// SME `catalog` service (different scope: SME's was Org-bound; this is
+// Sovereign-wide multi-source) per ADR-0001 §4.3.
+//
+// SEAM DECISION: catalyst-catalog is a SERVICE not a CONTROLLER, so it
+// lives outside `core/controllers/go.mod`. Group `core/services/` is for
+// HTTP services; group `core/controllers/` is for CRD reconcilers.
+//
+// The unified Gitea client (CC2 #1136) lives at
+// `core/controllers/pkg/gitea` (promoted from `internal/gitea` by EPIC-2
+// Slice L, #1097 — Go's `internal/` rule blocks cross-module imports).
+// We import it via a `replace` directive so a single canonical client
+// surface is maintained across controllers + services.
+module github.com/openova-io/openova/core/services/catalyst-catalog
+
+go 1.23
+
+require (
+	github.com/openova-io/openova/core/controllers v0.0.0-00010101000000-000000000000
+	sigs.k8s.io/yaml v1.4.0
+)
+
+replace github.com/openova-io/openova/core/controllers => ../../controllers

--- a/core/services/catalyst-catalog/go.sum
+++ b/core/services/catalyst-catalog/go.sum
@@ -1,0 +1,7 @@
+github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+sigs.k8s.io/yaml v1.4.0 h1:Mk1wCc2gy/F0THH0TAp1QYyJNzRm2KCLy3o5ASXVI5E=
+sigs.k8s.io/yaml v1.4.0/go.mod h1:Ejl7/uTz7PSA4eKMyQCUTnhZYNmLIl+5c2lQPGR2BPY=

--- a/core/services/catalyst-catalog/internal/auth/claims.go
+++ b/core/services/catalyst-catalog/internal/auth/claims.go
@@ -1,0 +1,199 @@
+// Package auth extracts the caller's Keycloak claims from incoming
+// HTTP requests so per-Org access filtering in the source resolver can
+// honor the session's Group memberships.
+//
+// CONTRACT: catalyst-catalog is deployed behind catalyst-api (Cilium
+// Gateway HTTPRoute proxy) per the EPIC-2 Slice L brief — catalyst-api
+// validates the JWT signature against Keycloak JWKS and forwards the
+// validated request. Catalog-svc therefore extracts claims from the
+// already-validated session token without re-running JWKS validation
+// on the hot path.
+//
+// Per docs/INVIOLABLE-PRINCIPLES.md #1 we still validate the JWT
+// shape (3 base64url segments), parse claims, check `exp`, and reject
+// anonymous reads unless `CATALOG_ANONYMOUS_READS=true` is set. JWKS
+// signature verification is not done in-process — it is the proxy's
+// responsibility. A future hardening slice can add an optional
+// `CATALOG_JWKS_URL` env-var to verify in-process when not deployed
+// behind catalyst-api.
+//
+// SEAM: this file mirrors the `Claims` struct from
+// products/catalyst/bootstrap/api/internal/auth/session.go (slice D2)
+// — Groups, Org, Tier, RealmAccess. Catalog-svc cannot import that
+// package directly (different Go module + internal/ rule), so the
+// shape is reproduced here. If catalyst-api's Claims shape grows new
+// fields the catalog will need, add them here in the same migration.
+package auth
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// Claims is the subset of Keycloak claims the catalog uses. Mirrors
+// the canonical `auth.Claims` shape in catalyst-api.
+type Claims struct {
+	Sub           string   `json:"sub"`
+	Email         string   `json:"email"`
+	PreferredName string   `json:"preferred_username"`
+	Groups        []string `json:"groups,omitempty"`
+	Org           string   `json:"org,omitempty"`
+	Tier          string   `json:"tier,omitempty"`
+	RealmAccess   struct {
+		Roles []string `json:"roles,omitempty"`
+	} `json:"realm_access,omitempty"`
+	Exp int64 `json:"exp,omitempty"`
+}
+
+// ErrNoSession is returned when no session cookie / bearer header is
+// present.
+var ErrNoSession = errors.New("auth: no session token")
+
+// ErrInvalidSession wraps malformed-JWT / expired-token failures.
+var ErrInvalidSession = errors.New("auth: invalid session token")
+
+// ExtractFromRequest reads the session token from (1) Authorization
+// Bearer header, (2) ?access_token=… query param, or (3) the named
+// session cookie — first match wins. Returns ErrNoSession when none
+// is present.
+func ExtractFromRequest(r *http.Request, cookieName string) (string, error) {
+	if hdr := r.Header.Get("Authorization"); hdr != "" {
+		const prefix = "Bearer "
+		if len(hdr) > len(prefix) && strings.EqualFold(hdr[:len(prefix)], prefix) {
+			tok := strings.TrimSpace(hdr[len(prefix):])
+			if isJWTShape(tok) {
+				return tok, nil
+			}
+		}
+	}
+	if qtok := strings.TrimSpace(r.URL.Query().Get("access_token")); qtok != "" {
+		if isJWTShape(qtok) {
+			return qtok, nil
+		}
+	}
+	if c, err := r.Cookie(cookieName); err == nil && c.Value != "" {
+		// catalyst-api wraps the cookie value as `<jwt>.<hmac>` when
+		// CookieSecret is set. We accept either: 3 segments = raw JWT,
+		// 4 segments = HMAC-wrapped (we strip the trailing HMAC).
+		v := c.Value
+		parts := strings.Split(v, ".")
+		switch len(parts) {
+		case 3:
+			return v, nil
+		case 4:
+			// Drop the trailing HMAC suffix.
+			return strings.Join(parts[:3], "."), nil
+		}
+	}
+	return "", ErrNoSession
+}
+
+// ParseClaims decodes the JWT payload (no signature verification — see
+// package doc) and validates `exp`.
+func ParseClaims(token string) (*Claims, error) {
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		return nil, fmt.Errorf("%w: malformed JWT (got %d parts)", ErrInvalidSession, len(parts))
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return nil, fmt.Errorf("%w: decode payload: %v", ErrInvalidSession, err)
+	}
+	var c Claims
+	if err := json.Unmarshal(payload, &c); err != nil {
+		return nil, fmt.Errorf("%w: parse payload: %v", ErrInvalidSession, err)
+	}
+	if c.Exp > 0 && time.Unix(c.Exp, 0).Before(time.Now()) {
+		return nil, fmt.Errorf("%w: token expired at %s", ErrInvalidSession, time.Unix(c.Exp, 0))
+	}
+	return &c, nil
+}
+
+// VisibleOrgs returns the set of Org slugs whose private blueprints
+// the caller may see. The slugs come from:
+//
+//   - Claims.Org (single-Org sessions per docs/EPICS-1-6-unified-design.md §6.2)
+//   - Claims.Groups[] paths of the form "/<org>/..." or "<org>/..." —
+//     the leading segment is the Org slug. Both Keycloak v22 and v24
+//     conventions are accepted.
+//
+// Result is deterministic (sorted, de-duplicated).
+func VisibleOrgs(c *Claims) []string {
+	if c == nil {
+		return nil
+	}
+	seen := make(map[string]struct{})
+	if c.Org != "" {
+		seen[c.Org] = struct{}{}
+	}
+	for _, g := range c.Groups {
+		g = strings.TrimPrefix(g, "/")
+		if g == "" {
+			continue
+		}
+		head, _, _ := strings.Cut(g, "/")
+		if head != "" {
+			seen[head] = struct{}{}
+		}
+	}
+	out := make([]string, 0, len(seen))
+	for k := range seen {
+		out = append(out, k)
+	}
+	sortStrings(out)
+	return out
+}
+
+// HasOrg reports whether the caller may see private blueprints for
+// the named Org slug.
+func HasOrg(c *Claims, org string) bool {
+	if c == nil || org == "" {
+		return false
+	}
+	if c.Org == org {
+		return true
+	}
+	want := strings.TrimPrefix(org, "/")
+	for _, g := range c.Groups {
+		g = strings.TrimPrefix(g, "/")
+		head, _, _ := strings.Cut(g, "/")
+		if head == want {
+			return true
+		}
+	}
+	return false
+}
+
+// isJWTShape returns true when s looks like a 3-segment compact JWT.
+// Used as a cheap first-pass guard before any base64 decode.
+func isJWTShape(s string) bool {
+	if s == "" {
+		return false
+	}
+	parts := strings.Split(s, ".")
+	if len(parts) != 3 {
+		return false
+	}
+	for _, p := range parts {
+		if p == "" {
+			return false
+		}
+	}
+	return true
+}
+
+// sortStrings is an inlined sort.Strings that avoids pulling sort/strings
+// dependency drift through the test surface.
+func sortStrings(s []string) {
+	// insertion sort — bounded n (<= number of Groups, typically <10).
+	for i := 1; i < len(s); i++ {
+		for j := i; j > 0 && s[j-1] > s[j]; j-- {
+			s[j-1], s[j] = s[j], s[j-1]
+		}
+	}
+}

--- a/core/services/catalyst-catalog/internal/auth/claims_test.go
+++ b/core/services/catalyst-catalog/internal/auth/claims_test.go
@@ -1,0 +1,175 @@
+package auth
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+	"time"
+)
+
+// makeJWT builds an unsigned JWT (signature is gibberish — we don't
+// verify in catalog-svc).
+func makeJWT(t *testing.T, claims map[string]interface{}) string {
+	t.Helper()
+	header := map[string]string{"alg": "RS256", "typ": "JWT"}
+	hb, _ := json.Marshal(header)
+	pb, err := json.Marshal(claims)
+	if err != nil {
+		t.Fatalf("marshal claims: %v", err)
+	}
+	enc := base64.RawURLEncoding.EncodeToString
+	return fmt.Sprintf("%s.%s.%s", enc(hb), enc(pb), enc([]byte("sig")))
+}
+
+func TestExtractFromRequest_BearerHeader(t *testing.T) {
+	tok := makeJWT(t, map[string]interface{}{"sub": "alice"})
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.Header.Set("Authorization", "Bearer "+tok)
+	got, err := ExtractFromRequest(r, "catalyst_session")
+	if err != nil || got != tok {
+		t.Errorf("ExtractFromRequest = (%q, %v), want (%q, nil)", got, err, tok)
+	}
+}
+
+func TestExtractFromRequest_QueryParam(t *testing.T) {
+	tok := makeJWT(t, map[string]interface{}{"sub": "alice"})
+	r := httptest.NewRequest(http.MethodGet, "/?access_token="+tok, nil)
+	got, err := ExtractFromRequest(r, "catalyst_session")
+	if err != nil || got != tok {
+		t.Errorf("ExtractFromRequest = (%q, %v), want (%q, nil)", got, err, tok)
+	}
+}
+
+func TestExtractFromRequest_RawCookie(t *testing.T) {
+	tok := makeJWT(t, map[string]interface{}{"sub": "alice"})
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.AddCookie(&http.Cookie{Name: "catalyst_session", Value: tok})
+	got, err := ExtractFromRequest(r, "catalyst_session")
+	if err != nil || got != tok {
+		t.Errorf("ExtractFromRequest = (%q, %v), want (%q, nil)", got, err, tok)
+	}
+}
+
+func TestExtractFromRequest_HMACWrappedCookie(t *testing.T) {
+	tok := makeJWT(t, map[string]interface{}{"sub": "alice"})
+	wrapped := tok + ".hmac-suffix"
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.AddCookie(&http.Cookie{Name: "catalyst_session", Value: wrapped})
+	got, err := ExtractFromRequest(r, "catalyst_session")
+	if err != nil || got != tok {
+		t.Errorf("ExtractFromRequest = (%q, %v), want (%q, nil)", got, err, tok)
+	}
+}
+
+func TestExtractFromRequest_NoSession(t *testing.T) {
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	_, err := ExtractFromRequest(r, "catalyst_session")
+	if !errors.Is(err, ErrNoSession) {
+		t.Errorf("ExtractFromRequest err = %v, want ErrNoSession", err)
+	}
+}
+
+func TestParseClaims_HappyPath(t *testing.T) {
+	tok := makeJWT(t, map[string]interface{}{
+		"sub":    "alice",
+		"email":  "alice@acme.example",
+		"groups": []string{"/acme/admins", "/acme/developers"},
+		"org":    "acme",
+		"tier":   "admin",
+		"exp":    time.Now().Add(time.Hour).Unix(),
+	})
+	c, err := ParseClaims(tok)
+	if err != nil {
+		t.Fatalf("ParseClaims: %v", err)
+	}
+	if c.Sub != "alice" || c.Email != "alice@acme.example" || c.Org != "acme" || c.Tier != "admin" {
+		t.Errorf("Claims mismatch: %+v", c)
+	}
+	if !reflect.DeepEqual(c.Groups, []string{"/acme/admins", "/acme/developers"}) {
+		t.Errorf("Groups mismatch: %v", c.Groups)
+	}
+}
+
+func TestParseClaims_Expired(t *testing.T) {
+	tok := makeJWT(t, map[string]interface{}{
+		"sub": "alice",
+		"exp": time.Now().Add(-time.Hour).Unix(),
+	})
+	_, err := ParseClaims(tok)
+	if !errors.Is(err, ErrInvalidSession) {
+		t.Errorf("ParseClaims expired err = %v, want ErrInvalidSession", err)
+	}
+}
+
+func TestParseClaims_Malformed(t *testing.T) {
+	_, err := ParseClaims("not.a.jwt")
+	if !errors.Is(err, ErrInvalidSession) {
+		t.Errorf("ParseClaims malformed err = %v, want ErrInvalidSession", err)
+	}
+}
+
+func TestVisibleOrgs(t *testing.T) {
+	cases := []struct {
+		name string
+		c    *Claims
+		want []string
+	}{
+		{"nil", nil, nil},
+		{"only-org", &Claims{Org: "acme"}, []string{"acme"}},
+		{
+			"groups-leading-slash",
+			&Claims{Groups: []string{"/acme/admins", "/contoso/devs"}},
+			[]string{"acme", "contoso"},
+		},
+		{
+			"groups-no-slash",
+			&Claims{Groups: []string{"acme/admins", "fabrikam/viewers"}},
+			[]string{"acme", "fabrikam"},
+		},
+		{
+			"org-and-groups-deduped",
+			&Claims{Org: "acme", Groups: []string{"/acme/admins"}},
+			[]string{"acme"},
+		},
+		{
+			"empty-paths-ignored",
+			&Claims{Groups: []string{"", "/", "/acme"}},
+			[]string{"acme"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := VisibleOrgs(tc.c)
+			if len(got) == 0 && len(tc.want) == 0 {
+				return
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("VisibleOrgs = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestHasOrg(t *testing.T) {
+	c := &Claims{Org: "acme", Groups: []string{"/contoso/admins"}}
+	if !HasOrg(c, "acme") {
+		t.Error("HasOrg(acme) should be true via Org claim")
+	}
+	if !HasOrg(c, "contoso") {
+		t.Error("HasOrg(contoso) should be true via Groups")
+	}
+	if HasOrg(c, "fabrikam") {
+		t.Error("HasOrg(fabrikam) should be false")
+	}
+	if HasOrg(nil, "acme") {
+		t.Error("HasOrg(nil, ...) should be false")
+	}
+	if HasOrg(c, "") {
+		t.Error("HasOrg(c, \"\") should be false")
+	}
+}

--- a/core/services/catalyst-catalog/internal/cache/cache.go
+++ b/core/services/catalyst-catalog/internal/cache/cache.go
@@ -1,0 +1,140 @@
+// Package cache implements a thread-safe LRU cache with per-entry TTL
+// for blueprint.yaml reads. The cache key is opaque (string); callers
+// compose keys from `(source, org, name, version)` per the brief.
+//
+// Invalidation is TTL-only — Gitea-side changes propagate within at
+// most CacheTTL seconds. The trade-off is documented in DESIGN.md.
+package cache
+
+import (
+	"container/list"
+	"sync"
+	"time"
+)
+
+// LRU is a fixed-capacity LRU cache with per-entry TTL.
+//
+// Methods are safe for concurrent use.
+type LRU struct {
+	mu       sync.Mutex
+	capacity int
+	ttl      time.Duration
+	clock    func() time.Time
+
+	ll      *list.List
+	items   map[string]*list.Element
+
+	// metrics
+	hits   uint64
+	misses uint64
+}
+
+type entry struct {
+	key       string
+	value     []byte
+	expiresAt time.Time
+}
+
+// New returns a new LRU. capacity must be > 0; ttl == 0 disables
+// expiry (entries only evicted by LRU).
+func New(capacity int, ttl time.Duration) *LRU {
+	if capacity <= 0 {
+		capacity = 1
+	}
+	return &LRU{
+		capacity: capacity,
+		ttl:      ttl,
+		clock:    time.Now,
+		ll:       list.New(),
+		items:    make(map[string]*list.Element),
+	}
+}
+
+// Get returns (value, true) on hit (and refreshes the item's recency)
+// or (nil, false) on miss/expiry.
+func (c *LRU) Get(key string) ([]byte, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	el, ok := c.items[key]
+	if !ok {
+		c.misses++
+		return nil, false
+	}
+	en := el.Value.(*entry)
+	if c.ttl > 0 && c.clock().After(en.expiresAt) {
+		c.removeElement(el)
+		c.misses++
+		return nil, false
+	}
+	c.ll.MoveToFront(el)
+	c.hits++
+	// Defensive copy so callers cannot mutate the cached payload.
+	out := make([]byte, len(en.value))
+	copy(out, en.value)
+	return out, true
+}
+
+// Put inserts or refreshes the entry under key. Defensively copies
+// value so the caller can mutate without affecting cached state.
+func (c *LRU) Put(key string, value []byte) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if el, ok := c.items[key]; ok {
+		en := el.Value.(*entry)
+		en.value = append(en.value[:0], value...)
+		en.expiresAt = c.clock().Add(c.ttl)
+		c.ll.MoveToFront(el)
+		return
+	}
+	cp := make([]byte, len(value))
+	copy(cp, value)
+	en := &entry{
+		key:       key,
+		value:     cp,
+		expiresAt: c.clock().Add(c.ttl),
+	}
+	el := c.ll.PushFront(en)
+	c.items[key] = el
+	if c.ll.Len() > c.capacity {
+		oldest := c.ll.Back()
+		if oldest != nil {
+			c.removeElement(oldest)
+		}
+	}
+}
+
+// Invalidate removes the entry for key (no-op if absent).
+func (c *LRU) Invalidate(key string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if el, ok := c.items[key]; ok {
+		c.removeElement(el)
+	}
+}
+
+// Stats returns hit/miss counts. Useful for /healthz and tests.
+func (c *LRU) Stats() (hits, misses uint64) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.hits, c.misses
+}
+
+// Len returns the current number of cached entries (mostly for tests).
+func (c *LRU) Len() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.ll.Len()
+}
+
+// SetClock injects a deterministic clock for tests.
+func (c *LRU) SetClock(now func() time.Time) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.clock = now
+}
+
+func (c *LRU) removeElement(el *list.Element) {
+	en := el.Value.(*entry)
+	delete(c.items, en.key)
+	c.ll.Remove(el)
+}

--- a/core/services/catalyst-catalog/internal/cache/cache_test.go
+++ b/core/services/catalyst-catalog/internal/cache/cache_test.go
@@ -1,0 +1,120 @@
+package cache
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestLRU_HitMiss(t *testing.T) {
+	c := New(3, 30*time.Second)
+	if _, ok := c.Get("a"); ok {
+		t.Fatal("Get on empty cache returned hit")
+	}
+	c.Put("a", []byte("alpha"))
+	v, ok := c.Get("a")
+	if !ok || string(v) != "alpha" {
+		t.Fatalf("Get(a) = (%q, %v), want (alpha, true)", v, ok)
+	}
+	hits, misses := c.Stats()
+	if hits != 1 || misses != 1 {
+		t.Errorf("Stats = (%d, %d), want (1, 1)", hits, misses)
+	}
+}
+
+func TestLRU_TTLExpiry(t *testing.T) {
+	c := New(3, 30*time.Second)
+	now := time.Unix(0, 0)
+	c.SetClock(func() time.Time { return now })
+
+	c.Put("k", []byte("v"))
+	if _, ok := c.Get("k"); !ok {
+		t.Fatal("Get immediately after Put missed")
+	}
+
+	// Advance past TTL.
+	now = now.Add(31 * time.Second)
+	if _, ok := c.Get("k"); ok {
+		t.Fatal("Get after TTL elapsed returned hit (should expire)")
+	}
+	// After miss, the entry should be removed.
+	if c.Len() != 0 {
+		t.Errorf("Len after expiry = %d, want 0", c.Len())
+	}
+}
+
+func TestLRU_LRUEviction(t *testing.T) {
+	c := New(2, 30*time.Second)
+	c.Put("a", []byte("1"))
+	c.Put("b", []byte("2"))
+	// Access a so b is the LRU.
+	c.Get("a")
+	// Add c — should evict b.
+	c.Put("c", []byte("3"))
+	if _, ok := c.Get("b"); ok {
+		t.Fatal("b should have been evicted (was LRU)")
+	}
+	if v, ok := c.Get("a"); !ok || string(v) != "1" {
+		t.Errorf("a should still be cached, got (%q, %v)", v, ok)
+	}
+	if v, ok := c.Get("c"); !ok || string(v) != "3" {
+		t.Errorf("c should be cached, got (%q, %v)", v, ok)
+	}
+}
+
+func TestLRU_Invalidate(t *testing.T) {
+	c := New(3, 30*time.Second)
+	c.Put("a", []byte("alpha"))
+	c.Invalidate("a")
+	if _, ok := c.Get("a"); ok {
+		t.Fatal("Get after Invalidate returned hit")
+	}
+}
+
+func TestLRU_PutRefresh(t *testing.T) {
+	c := New(3, 30*time.Second)
+	now := time.Unix(0, 0)
+	c.SetClock(func() time.Time { return now })
+
+	c.Put("k", []byte("v1"))
+	now = now.Add(20 * time.Second)
+	c.Put("k", []byte("v2")) // should refresh expiry to now+30s
+	now = now.Add(20 * time.Second)
+	v, ok := c.Get("k")
+	if !ok || string(v) != "v2" {
+		t.Errorf("Get after refresh = (%q, %v), want (v2, true)", v, ok)
+	}
+}
+
+func TestLRU_DefensiveCopy(t *testing.T) {
+	c := New(3, 30*time.Second)
+	val := []byte("alpha")
+	c.Put("k", val)
+	val[0] = 'X' // mutate caller copy
+	got, ok := c.Get("k")
+	if !ok || string(got) != "alpha" {
+		t.Errorf("cache mutated by caller: got %q", got)
+	}
+	got[0] = 'Y' // mutate returned copy
+	got2, _ := c.Get("k")
+	if string(got2) != "alpha" {
+		t.Errorf("cache mutated by returned-value mutation: got %q", got2)
+	}
+}
+
+func TestLRU_ConcurrentSafe(t *testing.T) {
+	c := New(64, 30*time.Second)
+	var wg sync.WaitGroup
+	for i := 0; i < 32; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			key := string(rune('a' + i%8))
+			for j := 0; j < 100; j++ {
+				c.Put(key, []byte{byte(i)})
+				c.Get(key)
+			}
+		}(i)
+	}
+	wg.Wait()
+}

--- a/core/services/catalyst-catalog/internal/config/config.go
+++ b/core/services/catalyst-catalog/internal/config/config.go
@@ -1,0 +1,121 @@
+// Package config parses runtime configuration from environment
+// variables. Per docs/INVIOLABLE-PRINCIPLES.md #4 nothing here is
+// hardcoded — every URL, FQDN, and scope name is operator-overridable.
+package config
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Config carries the runtime configuration for catalyst-catalog.
+type Config struct {
+	// ListenAddr is the HTTP listen address. Default ":8080".
+	ListenAddr string
+
+	// GiteaURL is the Gitea root URL WITHOUT `/api/v1` (the unified
+	// Gitea client appends it). Per ADR-0001 §2.7 catalog data lives in
+	// Gitea — there is no separate database.
+	GiteaURL string
+
+	// GiteaToken is the static Gitea admin access token used for HTTP
+	// API auth. Must be present at startup.
+	GiteaToken string
+
+	// PublicCatalogOrg is the Gitea Org slug holding the public-mirror
+	// blueprint repositories. Defaults to "catalog" per
+	// docs/EPICS-1-6-unified-design.md §5.4.
+	PublicCatalogOrg string
+
+	// SovereignCatalogOrg is the Gitea Org slug holding the Sovereign-
+	// curated blueprint repositories. Defaults to "catalog-sovereign".
+	SovereignCatalogOrg string
+
+	// OrgPrivateRepoSuffix is the per-Org private blueprint repo name
+	// (one repo per Org under the Org's namespace). Defaults to
+	// "shared-blueprints".
+	OrgPrivateRepoSuffix string
+
+	// CacheTTL is the in-memory cache TTL for blueprint.yaml reads.
+	// Defaults to 30s.
+	CacheTTL time.Duration
+
+	// CacheCapacity is the max number of cache entries (LRU eviction).
+	// Defaults to 1024.
+	CacheCapacity int
+
+	// SovereignFQDN is purely informational (logged at startup) — the
+	// catalog never embeds it in URLs since the Gitea client targets the
+	// in-cluster Service. Empty when not set.
+	SovereignFQDN string
+
+	// SessionCookieName is the name of the session cookie carrying the
+	// caller's Keycloak JWT. Default "catalyst_session" (matches
+	// catalyst-api's seam at products/catalyst/bootstrap/api/internal/auth).
+	SessionCookieName string
+
+	// AnonymousReads — when true, callers without a session can list the
+	// public + sovereign-curated catalog (no per-Org private). Default
+	// false (closed by default per docs/INVIOLABLE-PRINCIPLES.md #1).
+	AnonymousReads bool
+}
+
+// Load returns a Config populated from the environment, applying
+// defaults for omitted values and validating required fields.
+func Load() (Config, error) {
+	c := Config{
+		ListenAddr:           envDefault("CATALOG_LISTEN_ADDR", ":8080"),
+		GiteaURL:             os.Getenv("CATALYST_GITEA_URL"),
+		GiteaToken:           os.Getenv("CATALYST_GITEA_TOKEN"),
+		PublicCatalogOrg:     envDefault("CATALOG_PUBLIC_ORG", "catalog"),
+		SovereignCatalogOrg:  envDefault("CATALOG_SOVEREIGN_ORG", "catalog-sovereign"),
+		OrgPrivateRepoSuffix: envDefault("CATALOG_ORG_PRIVATE_REPO", "shared-blueprints"),
+		SovereignFQDN:        os.Getenv("SOVEREIGN_FQDN"),
+		SessionCookieName:    envDefault("CATALOG_SESSION_COOKIE", "catalyst_session"),
+		AnonymousReads:       parseBool(os.Getenv("CATALOG_ANONYMOUS_READS")),
+	}
+
+	ttlStr := envDefault("CATALOG_CACHE_TTL_SECONDS", "30")
+	ttlSec, err := strconv.Atoi(ttlStr)
+	if err != nil || ttlSec < 0 {
+		return Config{}, fmt.Errorf("config: CATALOG_CACHE_TTL_SECONDS must be a non-negative integer, got %q", ttlStr)
+	}
+	c.CacheTTL = time.Duration(ttlSec) * time.Second
+
+	capStr := envDefault("CATALOG_CACHE_CAPACITY", "1024")
+	cap, err := strconv.Atoi(capStr)
+	if err != nil || cap <= 0 {
+		return Config{}, fmt.Errorf("config: CATALOG_CACHE_CAPACITY must be a positive integer, got %q", capStr)
+	}
+	c.CacheCapacity = cap
+
+	if c.GiteaURL == "" {
+		return Config{}, errors.New("config: CATALYST_GITEA_URL is required")
+	}
+	if strings.HasSuffix(c.GiteaURL, "/api/v1") {
+		return Config{}, fmt.Errorf("config: CATALYST_GITEA_URL must NOT include /api/v1 (per pkg/gitea convention); got %q", c.GiteaURL)
+	}
+	if c.GiteaToken == "" {
+		return Config{}, errors.New("config: CATALYST_GITEA_TOKEN is required")
+	}
+	return c, nil
+}
+
+func envDefault(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
+}
+
+func parseBool(s string) bool {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "1", "true", "yes", "on":
+		return true
+	}
+	return false
+}

--- a/core/services/catalyst-catalog/internal/config/config_test.go
+++ b/core/services/catalyst-catalog/internal/config/config_test.go
@@ -1,0 +1,120 @@
+package config
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestLoad_Defaults(t *testing.T) {
+	t.Setenv("CATALYST_GITEA_URL", "http://gitea-http.gitea.svc.cluster.local:3000")
+	t.Setenv("CATALYST_GITEA_TOKEN", "deadbeef")
+
+	c, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if c.ListenAddr != ":8080" {
+		t.Errorf("ListenAddr default = %q, want :8080", c.ListenAddr)
+	}
+	if c.PublicCatalogOrg != "catalog" {
+		t.Errorf("PublicCatalogOrg default = %q, want catalog", c.PublicCatalogOrg)
+	}
+	if c.SovereignCatalogOrg != "catalog-sovereign" {
+		t.Errorf("SovereignCatalogOrg default = %q, want catalog-sovereign", c.SovereignCatalogOrg)
+	}
+	if c.OrgPrivateRepoSuffix != "shared-blueprints" {
+		t.Errorf("OrgPrivateRepoSuffix default = %q, want shared-blueprints", c.OrgPrivateRepoSuffix)
+	}
+	if c.CacheTTL != 30*time.Second {
+		t.Errorf("CacheTTL default = %v, want 30s", c.CacheTTL)
+	}
+	if c.CacheCapacity != 1024 {
+		t.Errorf("CacheCapacity default = %d, want 1024", c.CacheCapacity)
+	}
+	if c.AnonymousReads {
+		t.Error("AnonymousReads default = true, want false (closed by default per Inviolable Principle #1)")
+	}
+}
+
+func TestLoad_RequiresGiteaURL(t *testing.T) {
+	t.Setenv("CATALYST_GITEA_URL", "")
+	t.Setenv("CATALYST_GITEA_TOKEN", "deadbeef")
+	_, err := Load()
+	if err == nil {
+		t.Fatal("Load with empty CATALYST_GITEA_URL must fail")
+	}
+	if !strings.Contains(err.Error(), "CATALYST_GITEA_URL") {
+		t.Errorf("expected error to mention CATALYST_GITEA_URL, got %v", err)
+	}
+}
+
+func TestLoad_RequiresGiteaToken(t *testing.T) {
+	t.Setenv("CATALYST_GITEA_URL", "http://gitea")
+	t.Setenv("CATALYST_GITEA_TOKEN", "")
+	_, err := Load()
+	if err == nil {
+		t.Fatal("Load with empty CATALYST_GITEA_TOKEN must fail")
+	}
+	if !strings.Contains(err.Error(), "CATALYST_GITEA_TOKEN") {
+		t.Errorf("expected error to mention CATALYST_GITEA_TOKEN, got %v", err)
+	}
+}
+
+func TestLoad_RejectsApiV1Suffix(t *testing.T) {
+	t.Setenv("CATALYST_GITEA_URL", "http://gitea/api/v1")
+	t.Setenv("CATALYST_GITEA_TOKEN", "deadbeef")
+	_, err := Load()
+	if err == nil {
+		t.Fatal("Load with /api/v1 suffix must fail")
+	}
+	if !strings.Contains(err.Error(), "/api/v1") {
+		t.Errorf("expected error to mention /api/v1, got %v", err)
+	}
+}
+
+func TestLoad_AnonymousReadsToggle(t *testing.T) {
+	t.Setenv("CATALYST_GITEA_URL", "http://gitea")
+	t.Setenv("CATALYST_GITEA_TOKEN", "deadbeef")
+	t.Setenv("CATALOG_ANONYMOUS_READS", "true")
+	c, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if !c.AnonymousReads {
+		t.Error("CATALOG_ANONYMOUS_READS=true should set AnonymousReads=true")
+	}
+}
+
+func TestLoad_CacheTTLOverride(t *testing.T) {
+	t.Setenv("CATALYST_GITEA_URL", "http://gitea")
+	t.Setenv("CATALYST_GITEA_TOKEN", "deadbeef")
+	t.Setenv("CATALOG_CACHE_TTL_SECONDS", "120")
+	c, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if c.CacheTTL != 120*time.Second {
+		t.Errorf("CacheTTL = %v, want 120s", c.CacheTTL)
+	}
+}
+
+func TestLoad_RejectsNegativeCacheTTL(t *testing.T) {
+	t.Setenv("CATALYST_GITEA_URL", "http://gitea")
+	t.Setenv("CATALYST_GITEA_TOKEN", "deadbeef")
+	t.Setenv("CATALOG_CACHE_TTL_SECONDS", "-1")
+	_, err := Load()
+	if err == nil {
+		t.Fatal("Load with negative cache TTL must fail")
+	}
+}
+
+func TestLoad_RejectsZeroCapacity(t *testing.T) {
+	t.Setenv("CATALYST_GITEA_URL", "http://gitea")
+	t.Setenv("CATALYST_GITEA_TOKEN", "deadbeef")
+	t.Setenv("CATALOG_CACHE_CAPACITY", "0")
+	_, err := Load()
+	if err == nil {
+		t.Fatal("Load with zero capacity must fail")
+	}
+}

--- a/core/services/catalyst-catalog/internal/handler/handler.go
+++ b/core/services/catalyst-catalog/internal/handler/handler.go
@@ -1,0 +1,284 @@
+// Package handler implements the HTTP REST surface of catalyst-catalog.
+//
+// Endpoints (all under `/api/v1/catalog/...`):
+//
+//   GET /api/v1/catalog                          — list blueprints visible to caller
+//   GET /api/v1/catalog/{name}                   — single blueprint (latest visible version)
+//   GET /api/v1/catalog/{name}/versions          — version list with upgrade matrix
+//   GET /api/v1/catalog/{name}/versions/{version} — full Blueprint at specific version
+//   GET /healthz                                 — liveness/readiness
+//
+// All blueprint-listing endpoints honor the caller's session: per-Org
+// private blueprints are only returned for Orgs the caller has Group
+// membership in. See `internal/auth/claims.go`.
+package handler
+
+import (
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+	"strings"
+
+	"github.com/openova-io/openova/core/services/catalyst-catalog/internal/auth"
+	"github.com/openova-io/openova/core/services/catalyst-catalog/internal/cache"
+	"github.com/openova-io/openova/core/services/catalyst-catalog/internal/config"
+	"github.com/openova-io/openova/core/services/catalyst-catalog/internal/source"
+)
+
+// Handler aggregates the catalog REST endpoints.
+type Handler struct {
+	Cfg      config.Config
+	Resolver *source.Resolver
+	Cache    *cache.LRU
+	Logger   *slog.Logger
+}
+
+// New returns a Handler.
+func New(cfg config.Config, resolver *source.Resolver, c *cache.LRU, logger *slog.Logger) *Handler {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Handler{Cfg: cfg, Resolver: resolver, Cache: c, Logger: logger}
+}
+
+// Routes installs the handler on a fresh http.ServeMux. Caller is
+// responsible for wrapping it with logging/recovery middleware.
+func (h *Handler) Routes() *http.ServeMux {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /healthz", h.Healthz)
+	mux.HandleFunc("GET /api/v1/catalog", h.List)
+	mux.HandleFunc("GET /api/v1/catalog/{name}", h.Get)
+	mux.HandleFunc("GET /api/v1/catalog/{name}/versions", h.ListVersions)
+	mux.HandleFunc("GET /api/v1/catalog/{name}/versions/{version}", h.GetVersion)
+	return mux
+}
+
+// errorResponse is the JSON shape for all 4xx/5xx replies.
+type errorResponse struct {
+	Error   string `json:"error"`
+	Message string `json:"message,omitempty"`
+}
+
+func writeJSON(w http.ResponseWriter, code int, body interface{}) {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(code)
+	_ = json.NewEncoder(w).Encode(body)
+}
+
+func writeError(w http.ResponseWriter, code int, errCode, msg string) {
+	writeJSON(w, code, errorResponse{Error: errCode, Message: msg})
+}
+
+// authenticate extracts and parses Claims from the request. Returns
+// (claims, true) when a valid session is present, (nil, false) when
+// the caller is anonymous + AnonymousReads is allowed, or writes a
+// 401 and returns (nil, false) otherwise.
+func (h *Handler) authenticate(w http.ResponseWriter, r *http.Request) (*auth.Claims, bool) {
+	tok, err := auth.ExtractFromRequest(r, h.Cfg.SessionCookieName)
+	if errors.Is(err, auth.ErrNoSession) {
+		if h.Cfg.AnonymousReads {
+			return nil, true
+		}
+		writeError(w, http.StatusUnauthorized, "unauthorized", "no session token")
+		return nil, false
+	}
+	if err != nil {
+		writeError(w, http.StatusUnauthorized, "unauthorized", err.Error())
+		return nil, false
+	}
+	c, err := auth.ParseClaims(tok)
+	if err != nil {
+		writeError(w, http.StatusUnauthorized, "unauthorized", err.Error())
+		return nil, false
+	}
+	return c, true
+}
+
+// Healthz reports liveness + cache stats. Always 200.
+func (h *Handler) Healthz(w http.ResponseWriter, r *http.Request) {
+	hits, misses := uint64(0), uint64(0)
+	if h.Cache != nil {
+		hits, misses = h.Cache.Stats()
+	}
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"status":      "ok",
+		"cache_hits":  hits,
+		"cache_misses": misses,
+	})
+}
+
+// listResponse is the shape returned by GET /api/v1/catalog.
+type listResponse struct {
+	Items []source.Blueprint `json:"items"`
+}
+
+// List handles GET /api/v1/catalog?org=<slug>. The optional ?org=
+// query parameter restricts the per-Org private fan-out to a single
+// Org (still subject to caller permission).
+func (h *Handler) List(w http.ResponseWriter, r *http.Request) {
+	claims, ok := h.authenticate(w, r)
+	if !ok {
+		return
+	}
+	visible := auth.VisibleOrgs(claims)
+	if filterOrg := strings.TrimSpace(r.URL.Query().Get("org")); filterOrg != "" {
+		if !auth.HasOrg(claims, filterOrg) && !h.Cfg.AnonymousReads {
+			writeError(w, http.StatusForbidden, "forbidden", "caller has no access to org "+filterOrg)
+			return
+		}
+		visible = []string{filterOrg}
+	}
+	list, err := h.Resolver.List(r.Context(), visible)
+	if err != nil {
+		h.Logger.Error("catalog list failed", "err", err)
+		writeError(w, http.StatusBadGateway, "upstream_error", err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, listResponse{Items: list})
+}
+
+// Get handles GET /api/v1/catalog/{name}. Returns the highest-priority
+// Blueprint at its declared `spec.version`. The caller's visible Orgs
+// are honored when resolving the priority winner.
+func (h *Handler) Get(w http.ResponseWriter, r *http.Request) {
+	claims, ok := h.authenticate(w, r)
+	if !ok {
+		return
+	}
+	name := r.PathValue("name")
+	if name == "" {
+		writeError(w, http.StatusBadRequest, "bad_request", "blueprint name is required")
+		return
+	}
+	bp, err := h.Resolver.Get(r.Context(), name, "", auth.VisibleOrgs(claims))
+	if err != nil {
+		if errors.Is(err, source.ErrBlueprintNotFound) {
+			writeError(w, http.StatusNotFound, "not_found", "no such blueprint: "+name)
+			return
+		}
+		h.Logger.Error("catalog get failed", "name", name, "err", err)
+		writeError(w, http.StatusBadGateway, "upstream_error", err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, bp)
+}
+
+// versionsResponse is the shape returned by GET /api/v1/catalog/{name}/versions.
+//
+// Today the resolver exposes a single declared version per source
+// (= `spec.version` of the latest blueprint.yaml on `main`). The
+// catalog therefore returns N versions where N is the count of distinct
+// `spec.version` values across the visible sources for `name`.
+//
+// `upgradeMatrix[v]` lists the prior versions an install at v can
+// upgrade FROM (mirrored from `spec.upgrades.from` on the version v
+// blueprint).
+type versionsResponse struct {
+	Name          string              `json:"name"`
+	Versions      []versionEntry      `json:"versions"`
+	UpgradeMatrix map[string][]string `json:"upgradeMatrix"`
+}
+
+type versionEntry struct {
+	Version string `json:"version"`
+	Origin  string `json:"origin"`
+	Org     string `json:"org,omitempty"`
+}
+
+// ListVersions handles GET /api/v1/catalog/{name}/versions.
+func (h *Handler) ListVersions(w http.ResponseWriter, r *http.Request) {
+	claims, ok := h.authenticate(w, r)
+	if !ok {
+		return
+	}
+	name := r.PathValue("name")
+	if name == "" {
+		writeError(w, http.StatusBadRequest, "bad_request", "blueprint name is required")
+		return
+	}
+	visible := auth.VisibleOrgs(claims)
+
+	out := versionsResponse{
+		Name:          name,
+		Versions:      []versionEntry{},
+		UpgradeMatrix: map[string][]string{},
+	}
+
+	// Collect candidates from each source. We do not collapse to the
+	// resolver Get because the brief asks for multi-version visibility
+	// (each source contributing its own `spec.version`).
+	addCandidate := func(bp *source.Blueprint) {
+		if bp == nil {
+			return
+		}
+		entry := versionEntry{Version: bp.Version, Origin: bp.Source, Org: bp.Org}
+		// De-dupe by (version, origin, org) tuple.
+		for _, e := range out.Versions {
+			if e.Version == entry.Version && e.Origin == entry.Origin && e.Org == entry.Org {
+				return
+			}
+		}
+		out.Versions = append(out.Versions, entry)
+		out.UpgradeMatrix[bp.Version] = bp.UpgradeFrom
+	}
+
+	for _, org := range visible {
+		bp, err := source.NewOrgPrivate(h.Resolver.GC, org, h.Resolver.OrgPrivateRepoSuffix, h.Resolver.Cache).
+			Get(r.Context(), name, "")
+		if err != nil {
+			h.Logger.Error("catalog versions: org-private fetch failed", "org", org, "err", err)
+			writeError(w, http.StatusBadGateway, "upstream_error", err.Error())
+			return
+		}
+		addCandidate(bp)
+	}
+	if bp, err := source.NewSovereign(h.Resolver.GC, h.Resolver.SovereignOrg, h.Resolver.Cache).
+		Get(r.Context(), name, ""); err != nil {
+		h.Logger.Error("catalog versions: sovereign fetch failed", "err", err)
+		writeError(w, http.StatusBadGateway, "upstream_error", err.Error())
+		return
+	} else {
+		addCandidate(bp)
+	}
+	if bp, err := source.NewPublic(h.Resolver.GC, h.Resolver.PublicOrg, h.Resolver.Cache).
+		Get(r.Context(), name, ""); err != nil {
+		h.Logger.Error("catalog versions: public fetch failed", "err", err)
+		writeError(w, http.StatusBadGateway, "upstream_error", err.Error())
+		return
+	} else {
+		addCandidate(bp)
+	}
+
+	if len(out.Versions) == 0 {
+		writeError(w, http.StatusNotFound, "not_found", "no such blueprint: "+name)
+		return
+	}
+	writeJSON(w, http.StatusOK, out)
+}
+
+// GetVersion handles GET /api/v1/catalog/{name}/versions/{version}.
+// Returns the full Blueprint at the requested version (priority-resolved).
+func (h *Handler) GetVersion(w http.ResponseWriter, r *http.Request) {
+	claims, ok := h.authenticate(w, r)
+	if !ok {
+		return
+	}
+	name := r.PathValue("name")
+	version := r.PathValue("version")
+	if name == "" || version == "" {
+		writeError(w, http.StatusBadRequest, "bad_request", "name and version required")
+		return
+	}
+	bp, err := h.Resolver.Get(r.Context(), name, version, auth.VisibleOrgs(claims))
+	if err != nil {
+		if errors.Is(err, source.ErrBlueprintNotFound) {
+			writeError(w, http.StatusNotFound, "not_found", "no such blueprint version: "+name+"@"+version)
+			return
+		}
+		h.Logger.Error("catalog version-get failed", "name", name, "version", version, "err", err)
+		writeError(w, http.StatusBadGateway, "upstream_error", err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, bp)
+}

--- a/core/services/catalyst-catalog/internal/handler/handler_test.go
+++ b/core/services/catalyst-catalog/internal/handler/handler_test.go
@@ -1,0 +1,407 @@
+package handler
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/openova-io/openova/core/controllers/pkg/gitea"
+	"github.com/openova-io/openova/core/services/catalyst-catalog/internal/cache"
+	"github.com/openova-io/openova/core/services/catalyst-catalog/internal/config"
+	"github.com/openova-io/openova/core/services/catalyst-catalog/internal/source"
+)
+
+// fakeGitea is a minimal stand-in matching the source/source_test.go
+// fixture; duplicated here to avoid an internal-test cross-package
+// import.
+type fakeGitea struct {
+	mu    sync.Mutex
+	repos map[string][]string
+	files map[string]map[string]map[string][]byte
+}
+
+func newFakeGitea() *fakeGitea {
+	return &fakeGitea{
+		repos: map[string][]string{},
+		files: map[string]map[string]map[string][]byte{},
+	}
+}
+
+func (f *fakeGitea) AddFile(org, repo, path string, content []byte) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.files[org] == nil {
+		f.files[org] = map[string]map[string][]byte{}
+	}
+	if f.files[org][repo] == nil {
+		f.files[org][repo] = map[string][]byte{}
+		f.repos[org] = append(f.repos[org], repo)
+	}
+	f.files[org][repo][path] = content
+}
+
+func (f *fakeGitea) handler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") == "" {
+			http.Error(w, "no auth", http.StatusUnauthorized)
+			return
+		}
+		p := r.URL.Path
+		if r.Method == http.MethodGet && strings.HasPrefix(p, "/api/v1/orgs/") && strings.HasSuffix(p, "/repos") {
+			org := strings.TrimSuffix(strings.TrimPrefix(p, "/api/v1/orgs/"), "/repos")
+			f.mu.Lock()
+			repos, ok := f.repos[org]
+			f.mu.Unlock()
+			if !ok {
+				http.Error(w, "no such org", http.StatusNotFound)
+				return
+			}
+			out := make([]gitea.Repo, 0, len(repos))
+			for _, name := range repos {
+				out = append(out, gitea.Repo{Name: name, FullName: org + "/" + name})
+			}
+			writeJSONResp(w, http.StatusOK, out)
+			return
+		}
+		if r.Method == http.MethodGet && strings.HasPrefix(p, "/api/v1/repos/") && strings.Contains(p, "/contents/") {
+			rest := strings.TrimPrefix(p, "/api/v1/repos/")
+			idx := strings.Index(rest, "/contents/")
+			ownerRepo := rest[:idx]
+			filePath := strings.TrimSuffix(rest[idx+len("/contents/"):], "/")
+			parts := strings.SplitN(ownerRepo, "/", 2)
+			if len(parts) != 2 {
+				http.Error(w, "bad", http.StatusBadRequest)
+				return
+			}
+			org, repo := parts[0], parts[1]
+			f.mu.Lock()
+			repoFiles, repoOK := f.files[org][repo]
+			f.mu.Unlock()
+			if !repoOK {
+				http.Error(w, `{"message":"repository not found"}`, http.StatusNotFound)
+				return
+			}
+			if content, ok := repoFiles[filePath]; ok {
+				writeJSONResp(w, http.StatusOK, gitea.File{
+					Path:          filePath,
+					SHA:           "sha-" + filePath,
+					Type:          "file",
+					ContentBase64: base64.StdEncoding.EncodeToString(content),
+				})
+				return
+			}
+			prefix := filePath
+			if prefix != "" {
+				prefix += "/"
+			}
+			entries := []gitea.ContentEntry{}
+			seen := map[string]bool{}
+			f.mu.Lock()
+			for path, body := range repoFiles {
+				if !strings.HasPrefix(path, prefix) {
+					continue
+				}
+				rest := strings.TrimPrefix(path, prefix)
+				if rest == "" {
+					continue
+				}
+				head, _, hasSlash := strings.Cut(rest, "/")
+				if seen[head] {
+					continue
+				}
+				seen[head] = true
+				typ := "file"
+				size := int64(len(body))
+				if hasSlash {
+					typ = "dir"
+					size = 0
+				}
+				entries = append(entries, gitea.ContentEntry{Name: head, Path: prefix + head, Type: typ, Size: size})
+			}
+			f.mu.Unlock()
+			if len(entries) == 0 && filePath != "" {
+				http.Error(w, "no such path", http.StatusNotFound)
+				return
+			}
+			writeJSONResp(w, http.StatusOK, entries)
+			return
+		}
+		http.Error(w, "unhandled", http.StatusNotFound)
+	})
+}
+
+func writeJSONResp(w http.ResponseWriter, code int, v interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+func newTestHandler(t *testing.T, fake *fakeGitea, anonymous bool) (*Handler, func()) {
+	srv := httptest.NewServer(fake.handler())
+	gc := gitea.New(srv.URL, "test-token")
+	gc.HTTP = srv.Client()
+
+	cfg := config.Config{
+		ListenAddr:           ":0",
+		GiteaURL:             srv.URL,
+		GiteaToken:           "test-token",
+		PublicCatalogOrg:     "catalog",
+		SovereignCatalogOrg:  "catalog-sovereign",
+		OrgPrivateRepoSuffix: "shared-blueprints",
+		CacheTTL:             30 * time.Second,
+		CacheCapacity:        64,
+		SessionCookieName:    "catalyst_session",
+		AnonymousReads:       anonymous,
+	}
+	c := cache.New(64, 30*time.Second)
+	r := source.NewResolver(gc, cfg.PublicCatalogOrg, cfg.SovereignCatalogOrg, cfg.OrgPrivateRepoSuffix, c)
+	h := New(cfg, r, c, slog.Default())
+	return h, srv.Close
+}
+
+// makeJWT builds an unsigned JWT (signature is gibberish — catalog-svc
+// does not verify in-process; see auth/claims.go package doc).
+func makeJWT(t *testing.T, claims map[string]interface{}) string {
+	t.Helper()
+	header := map[string]string{"alg": "RS256", "typ": "JWT"}
+	hb, _ := json.Marshal(header)
+	if _, ok := claims["exp"]; !ok {
+		claims["exp"] = time.Now().Add(time.Hour).Unix()
+	}
+	pb, err := json.Marshal(claims)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	enc := base64.RawURLEncoding.EncodeToString
+	return fmt.Sprintf("%s.%s.%s", enc(hb), enc(pb), enc([]byte("sig")))
+}
+
+func blueprintYAML(name, version, title string, upgradeFrom ...string) []byte {
+	uf := ""
+	if len(upgradeFrom) > 0 {
+		var b strings.Builder
+		b.WriteString("\n  upgrades:\n    from:\n")
+		for _, v := range upgradeFrom {
+			b.WriteString("      - " + v + "\n")
+		}
+		uf = b.String()
+	}
+	return []byte(fmt.Sprintf(`apiVersion: catalyst.openova.io/v1
+kind: Blueprint
+metadata:
+  name: %s
+spec:
+  version: %s
+  visibility: listed
+  card:
+    title: %s
+    summary: A blueprint for %s%s
+`, name, version, title, name, uf))
+}
+
+func doRequest(t *testing.T, h *Handler, method, target, bearer string) (int, []byte) {
+	t.Helper()
+	req := httptest.NewRequest(method, target, nil)
+	if bearer != "" {
+		req.Header.Set("Authorization", "Bearer "+bearer)
+	}
+	rec := httptest.NewRecorder()
+	h.Routes().ServeHTTP(rec, req)
+	body, _ := io.ReadAll(rec.Body)
+	return rec.Code, body
+}
+
+func TestHealthz(t *testing.T) {
+	fake := newFakeGitea()
+	h, cleanup := newTestHandler(t, fake, true)
+	defer cleanup()
+	code, body := doRequest(t, h, http.MethodGet, "/healthz", "")
+	if code != 200 {
+		t.Errorf("status = %d, body = %s", code, body)
+	}
+}
+
+func TestList_RequiresAuthByDefault(t *testing.T) {
+	fake := newFakeGitea()
+	h, cleanup := newTestHandler(t, fake, false)
+	defer cleanup()
+	code, _ := doRequest(t, h, http.MethodGet, "/api/v1/catalog", "")
+	if code != http.StatusUnauthorized {
+		t.Errorf("anon list status = %d, want 401", code)
+	}
+}
+
+func TestList_AnonymousReadsWhenAllowed(t *testing.T) {
+	fake := newFakeGitea()
+	fake.AddFile("catalog", "bp-foo", "blueprint.yaml", blueprintYAML("bp-foo", "1.0.0", "Foo"))
+	h, cleanup := newTestHandler(t, fake, true)
+	defer cleanup()
+	code, body := doRequest(t, h, http.MethodGet, "/api/v1/catalog", "")
+	if code != 200 {
+		t.Fatalf("status = %d, body = %s", code, body)
+	}
+	var resp listResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Items) != 1 {
+		t.Errorf("len = %d, want 1", len(resp.Items))
+	}
+}
+
+func TestList_PerOrgPrivateRequiresMembership(t *testing.T) {
+	fake := newFakeGitea()
+	fake.AddFile("acme", "shared-blueprints", "bp-acme/blueprint.yaml",
+		blueprintYAML("bp-acme", "1.0.0", "ACME Internal"))
+	fake.AddFile("contoso", "shared-blueprints", "bp-contoso/blueprint.yaml",
+		blueprintYAML("bp-contoso", "1.0.0", "Contoso Internal"))
+	h, cleanup := newTestHandler(t, fake, false)
+	defer cleanup()
+
+	// User in Org acme — sees only bp-acme.
+	tok := makeJWT(t, map[string]interface{}{
+		"sub":    "alice",
+		"groups": []string{"/acme/admins"},
+	})
+	code, body := doRequest(t, h, http.MethodGet, "/api/v1/catalog", tok)
+	if code != 200 {
+		t.Fatalf("status = %d, body = %s", code, body)
+	}
+	var resp listResponse
+	json.Unmarshal(body, &resp)
+	names := []string{}
+	for _, bp := range resp.Items {
+		names = append(names, bp.Name)
+	}
+	hasAcme := false
+	for _, n := range names {
+		if n == "bp-acme" {
+			hasAcme = true
+		}
+		if n == "bp-contoso" {
+			t.Errorf("acme user MUST NOT see bp-contoso, got %v", names)
+		}
+	}
+	if !hasAcme {
+		t.Errorf("acme user should see bp-acme, got %v", names)
+	}
+}
+
+func TestList_OrgFilterDeniesNonMembers(t *testing.T) {
+	fake := newFakeGitea()
+	fake.AddFile("acme", "shared-blueprints", "bp-acme/blueprint.yaml",
+		blueprintYAML("bp-acme", "1.0.0", "ACME"))
+	h, cleanup := newTestHandler(t, fake, false)
+	defer cleanup()
+	tok := makeJWT(t, map[string]interface{}{"sub": "bob", "groups": []string{"/contoso/admins"}})
+	code, body := doRequest(t, h, http.MethodGet, "/api/v1/catalog?org=acme", tok)
+	if code != http.StatusForbidden {
+		t.Errorf("status = %d, body = %s — want 403", code, body)
+	}
+}
+
+func TestGet_HappyPath(t *testing.T) {
+	fake := newFakeGitea()
+	fake.AddFile("catalog", "bp-foo", "blueprint.yaml", blueprintYAML("bp-foo", "1.0.0", "Foo"))
+	h, cleanup := newTestHandler(t, fake, true)
+	defer cleanup()
+	code, body := doRequest(t, h, http.MethodGet, "/api/v1/catalog/bp-foo", "")
+	if code != 200 {
+		t.Fatalf("status = %d, body = %s", code, body)
+	}
+	var bp source.Blueprint
+	if err := json.Unmarshal(body, &bp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if bp.Card.Title != "Foo" {
+		t.Errorf("Card.Title = %q", bp.Card.Title)
+	}
+	if bp.Raw == nil {
+		t.Error("Raw should be populated for /catalog/{name}")
+	}
+}
+
+func TestGet_NotFound(t *testing.T) {
+	fake := newFakeGitea()
+	h, cleanup := newTestHandler(t, fake, true)
+	defer cleanup()
+	code, _ := doRequest(t, h, http.MethodGet, "/api/v1/catalog/bp-missing", "")
+	if code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", code)
+	}
+}
+
+func TestListVersions_AggregatesAcrossSources(t *testing.T) {
+	fake := newFakeGitea()
+	fake.AddFile("catalog", "bp-X", "blueprint.yaml", blueprintYAML("bp-X", "1.0.0", "PUBLIC", "0.9.0"))
+	fake.AddFile("catalog-sovereign", "bp-X", "blueprint.yaml", blueprintYAML("bp-X", "1.1.0", "SOVEREIGN", "1.0.0"))
+	fake.AddFile("acme", "shared-blueprints", "bp-X/blueprint.yaml", blueprintYAML("bp-X", "1.2.0-acme", "PRIVATE", "1.1.0"))
+	h, cleanup := newTestHandler(t, fake, false)
+	defer cleanup()
+
+	tok := makeJWT(t, map[string]interface{}{"sub": "alice", "groups": []string{"/acme/admins"}})
+	code, body := doRequest(t, h, http.MethodGet, "/api/v1/catalog/bp-X/versions", tok)
+	if code != 200 {
+		t.Fatalf("status = %d, body = %s", code, body)
+	}
+	var resp versionsResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Versions) != 3 {
+		t.Errorf("expected 3 versions, got %d: %+v", len(resp.Versions), resp.Versions)
+	}
+	if from, ok := resp.UpgradeMatrix["1.2.0-acme"]; !ok || len(from) != 1 || from[0] != "1.1.0" {
+		t.Errorf("UpgradeMatrix[1.2.0-acme] = %v, want [1.1.0]", from)
+	}
+}
+
+func TestGetVersion_FollowsPriority(t *testing.T) {
+	fake := newFakeGitea()
+	fake.AddFile("catalog", "bp-X", "blueprint.yaml", blueprintYAML("bp-X", "1.0.0", "PUBLIC"))
+	fake.AddFile("acme", "shared-blueprints", "bp-X/blueprint.yaml", blueprintYAML("bp-X", "1.0.0", "PRIVATE"))
+	h, cleanup := newTestHandler(t, fake, false)
+	defer cleanup()
+
+	tok := makeJWT(t, map[string]interface{}{"sub": "alice", "groups": []string{"/acme/admins"}})
+	code, body := doRequest(t, h, http.MethodGet, "/api/v1/catalog/bp-X/versions/1.0.0", tok)
+	if code != 200 {
+		t.Fatalf("status = %d, body = %s", code, body)
+	}
+	var bp source.Blueprint
+	json.Unmarshal(body, &bp)
+	if bp.Card.Title != "PRIVATE" {
+		t.Errorf("Card.Title = %q, want PRIVATE", bp.Card.Title)
+	}
+}
+
+func TestGetVersion_VersionMismatch_404(t *testing.T) {
+	fake := newFakeGitea()
+	fake.AddFile("catalog", "bp-X", "blueprint.yaml", blueprintYAML("bp-X", "1.0.0", "X"))
+	h, cleanup := newTestHandler(t, fake, true)
+	defer cleanup()
+	code, _ := doRequest(t, h, http.MethodGet, "/api/v1/catalog/bp-X/versions/9.9.9", "")
+	if code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", code)
+	}
+}
+
+func TestList_RejectsExpiredToken(t *testing.T) {
+	fake := newFakeGitea()
+	h, cleanup := newTestHandler(t, fake, false)
+	defer cleanup()
+	// expired token
+	tok := makeJWT(t, map[string]interface{}{"sub": "alice", "exp": time.Now().Add(-time.Hour).Unix()})
+	code, _ := doRequest(t, h, http.MethodGet, "/api/v1/catalog", tok)
+	if code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401", code)
+	}
+}

--- a/core/services/catalyst-catalog/internal/source/org_private.go
+++ b/core/services/catalyst-catalog/internal/source/org_private.go
@@ -1,0 +1,93 @@
+package source
+
+import (
+	"context"
+	"fmt"
+	"path"
+
+	"github.com/openova-io/openova/core/controllers/pkg/gitea"
+	"github.com/openova-io/openova/core/services/catalyst-catalog/internal/cache"
+)
+
+// OrgPrivate reads Blueprints from a single per-Org `<org>/<repoName>`
+// repository. Layout: one directory per Blueprint, each containing
+// `blueprint.yaml`.
+//
+// One OrgPrivate instance per visible Org. The Resolver constructs them
+// on-demand from the caller's Claims (see VisibleOrgs).
+type OrgPrivate struct {
+	GC       *gitea.Client
+	Org      string // the Org slug, e.g. "acme"
+	RepoName string // "shared-blueprints" by default
+	Cache    *cache.LRU
+}
+
+func NewOrgPrivate(gc *gitea.Client, org, repoName string, c *cache.LRU) *OrgPrivate {
+	return &OrgPrivate{GC: gc, Org: org, RepoName: repoName, Cache: c}
+}
+
+func (s *OrgPrivate) Origin() Origin { return OriginOrgPrivate }
+
+func (s *OrgPrivate) List(ctx context.Context) ([]Blueprint, error) {
+	entries, err := s.GC.ListContents(ctx, s.Org, s.RepoName, "main", "")
+	if err != nil {
+		if IsNotFound(err) {
+			return nil, nil // Repo not provisioned — empty private catalog is OK.
+		}
+		return nil, fmt.Errorf("source.orgPrivate.List: %w", err)
+	}
+	out := make([]Blueprint, 0, len(entries))
+	for _, e := range entries {
+		if e.Type != "dir" {
+			continue
+		}
+		bp, err := s.fetch(ctx, e.Name)
+		if err != nil {
+			if IsNotFound(err) {
+				continue
+			}
+			return nil, fmt.Errorf("source.orgPrivate.List: read %s/%s: %w", s.Org, e.Name, err)
+		}
+		if bp == nil {
+			continue
+		}
+		out = append(out, *bp)
+	}
+	return out, nil
+}
+
+func (s *OrgPrivate) Get(ctx context.Context, name, version string) (*Blueprint, error) {
+	bp, err := s.fetch(ctx, name)
+	if err != nil {
+		if IsNotFound(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	if bp == nil {
+		return nil, nil
+	}
+	if version != "" && bp.Version != version {
+		return nil, nil
+	}
+	return bp, nil
+}
+
+func (s *OrgPrivate) fetch(ctx context.Context, name string) (*Blueprint, error) {
+	key := CacheKey(s.Origin(), s.Org, name, "")
+	if s.Cache != nil {
+		if cached, ok := s.Cache.Get(key); ok {
+			bp, err := ParseBlueprint(cached, s.Origin(), s.Org, name)
+			return bp, err
+		}
+	}
+	relPath := path.Join(name, "blueprint.yaml")
+	data, err := readBlueprintYAML(ctx, s.GC, s.Org, s.RepoName, relPath)
+	if err != nil {
+		return nil, err
+	}
+	if s.Cache != nil {
+		s.Cache.Put(key, data)
+	}
+	return ParseBlueprint(data, s.Origin(), s.Org, name)
+}

--- a/core/services/catalyst-catalog/internal/source/public.go
+++ b/core/services/catalyst-catalog/internal/source/public.go
@@ -1,0 +1,82 @@
+package source
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/openova-io/openova/core/controllers/pkg/gitea"
+	"github.com/openova-io/openova/core/services/catalyst-catalog/internal/cache"
+)
+
+// Public reads Blueprints from the public-mirror Gitea Org. Layout:
+// one repo per Blueprint; `blueprint.yaml` at the repo root on `main`.
+type Public struct {
+	GC    *gitea.Client
+	Org   string // "catalog" by default
+	Cache *cache.LRU
+}
+
+func NewPublic(gc *gitea.Client, org string, c *cache.LRU) *Public {
+	return &Public{GC: gc, Org: org, Cache: c}
+}
+
+func (s *Public) Origin() Origin { return OriginPublic }
+
+func (s *Public) List(ctx context.Context) ([]Blueprint, error) {
+	repos, err := s.GC.ListOrgRepos(ctx, s.Org)
+	if err != nil {
+		if IsNotFound(err) {
+			return nil, nil // Org not provisioned — empty catalog is OK.
+		}
+		return nil, fmt.Errorf("source.public.List: %w", err)
+	}
+	out := make([]Blueprint, 0, len(repos))
+	for _, r := range repos {
+		bp, err := s.fetch(ctx, r.Name)
+		if err != nil {
+			if IsNotFound(err) {
+				continue // repo without blueprint.yaml — skip silently
+			}
+			return nil, fmt.Errorf("source.public.List: read %s: %w", r.Name, err)
+		}
+		if bp == nil {
+			continue
+		}
+		out = append(out, *bp)
+	}
+	return out, nil
+}
+
+func (s *Public) Get(ctx context.Context, name, version string) (*Blueprint, error) {
+	bp, err := s.fetch(ctx, name)
+	if err != nil {
+		if IsNotFound(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	if bp == nil {
+		return nil, nil
+	}
+	if version != "" && bp.Version != version {
+		return nil, nil
+	}
+	return bp, nil
+}
+
+func (s *Public) fetch(ctx context.Context, name string) (*Blueprint, error) {
+	key := CacheKey(s.Origin(), s.Org, name, "")
+	if s.Cache != nil {
+		if cached, ok := s.Cache.Get(key); ok {
+			return ParseBlueprint(cached, s.Origin(), "", name)
+		}
+	}
+	data, err := readBlueprintYAML(ctx, s.GC, s.Org, name, "blueprint.yaml")
+	if err != nil {
+		return nil, err
+	}
+	if s.Cache != nil {
+		s.Cache.Put(key, data)
+	}
+	return ParseBlueprint(data, s.Origin(), "", name)
+}

--- a/core/services/catalyst-catalog/internal/source/resolver.go
+++ b/core/services/catalyst-catalog/internal/source/resolver.go
@@ -1,0 +1,123 @@
+package source
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"github.com/openova-io/openova/core/controllers/pkg/gitea"
+	"github.com/openova-io/openova/core/services/catalyst-catalog/internal/cache"
+)
+
+// Resolver aggregates the three sources (public + sovereign + per-Org
+// private) into a single visible-to-caller catalog. It enforces the
+// priority order on name collisions: PRIVATE > SOVEREIGN > PUBLIC.
+//
+// Construction is per-request (cheap; sources are stateless wrappers
+// around the shared Gitea client + LRU cache).
+type Resolver struct {
+	GC                   *gitea.Client
+	PublicOrg            string
+	SovereignOrg         string
+	OrgPrivateRepoSuffix string
+	Cache                *cache.LRU
+}
+
+// NewResolver constructs a Resolver wired to the shared Gitea client
+// and cache.
+func NewResolver(gc *gitea.Client, publicOrg, sovereignOrg, orgPrivateRepoSuffix string, c *cache.LRU) *Resolver {
+	return &Resolver{
+		GC:                   gc,
+		PublicOrg:            publicOrg,
+		SovereignOrg:         sovereignOrg,
+		OrgPrivateRepoSuffix: orgPrivateRepoSuffix,
+		Cache:                c,
+	}
+}
+
+// List returns the de-duplicated, priority-resolved Blueprint list
+// visible to a caller whose visible Orgs are `visibleOrgs`. Pass an
+// empty slice for anonymous / public-only listings.
+//
+// Priority on name collision: private > sovereign > public.
+//
+// Result is sorted by Name for stable client-side rendering.
+func (r *Resolver) List(ctx context.Context, visibleOrgs []string) ([]Blueprint, error) {
+	merged := make(map[string]Blueprint)
+
+	// Public — always visible, lowest priority.
+	pub := NewPublic(r.GC, r.PublicOrg, r.Cache)
+	pubList, err := pub.List(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("resolver.List: public: %w", err)
+	}
+	for _, bp := range pubList {
+		merged[bp.Name] = bp
+	}
+
+	// Sovereign — always visible, mid priority.
+	sov := NewSovereign(r.GC, r.SovereignOrg, r.Cache)
+	sovList, err := sov.List(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("resolver.List: sovereign: %w", err)
+	}
+	for _, bp := range sovList {
+		merged[bp.Name] = bp
+	}
+
+	// Per-Org private — only visible Orgs, highest priority.
+	for _, org := range visibleOrgs {
+		orgSrc := NewOrgPrivate(r.GC, org, r.OrgPrivateRepoSuffix, r.Cache)
+		privList, err := orgSrc.List(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("resolver.List: org-private/%s: %w", org, err)
+		}
+		for _, bp := range privList {
+			merged[bp.Name] = bp
+		}
+	}
+
+	out := make([]Blueprint, 0, len(merged))
+	for _, bp := range merged {
+		// Strip the Raw payload from List results to keep response
+		// size bounded — clients call /catalog/{name} for full detail.
+		bp.Raw = nil
+		out = append(out, bp)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out, nil
+}
+
+// Get returns the highest-priority Blueprint matching name, optionally
+// pinned to version. Returns nil + ErrBlueprintNotFound if no source
+// has a copy.
+func (r *Resolver) Get(ctx context.Context, name, version string, visibleOrgs []string) (*Blueprint, error) {
+	// Walk in PRIORITY ORDER: private (per-Org) → sovereign → public.
+	for _, org := range visibleOrgs {
+		orgSrc := NewOrgPrivate(r.GC, org, r.OrgPrivateRepoSuffix, r.Cache)
+		bp, err := orgSrc.Get(ctx, name, version)
+		if err != nil {
+			return nil, fmt.Errorf("resolver.Get: org-private/%s: %w", org, err)
+		}
+		if bp != nil {
+			return bp, nil
+		}
+	}
+	sov := NewSovereign(r.GC, r.SovereignOrg, r.Cache)
+	bp, err := sov.Get(ctx, name, version)
+	if err != nil {
+		return nil, fmt.Errorf("resolver.Get: sovereign: %w", err)
+	}
+	if bp != nil {
+		return bp, nil
+	}
+	pub := NewPublic(r.GC, r.PublicOrg, r.Cache)
+	bp, err = pub.Get(ctx, name, version)
+	if err != nil {
+		return nil, fmt.Errorf("resolver.Get: public: %w", err)
+	}
+	if bp != nil {
+		return bp, nil
+	}
+	return nil, ErrBlueprintNotFound
+}

--- a/core/services/catalyst-catalog/internal/source/source.go
+++ b/core/services/catalyst-catalog/internal/source/source.go
@@ -1,0 +1,301 @@
+// Package source implements the multi-source Blueprint catalog
+// resolver that backs every catalog-svc HTTP endpoint.
+//
+// Three sources, each implementing the Source interface (List, Get):
+//
+//   - Public mirror (`catalog` Gitea Org): always visible.
+//   - Sovereign-curated (`catalog-sovereign` Gitea Org): always visible.
+//   - Per-Org private (`<org>/shared-blueprints` Gitea repo): visible
+//     ONLY to callers whose claims grant access to that Org.
+//
+// Source resolution order on listing — higher priority wins on a name
+// collision: PRIVATE > SOVEREIGN > PUBLIC. This matches the design
+// rationale in docs/EPICS-1-6-unified-design.md §5.4: an Org-private
+// override of a sovereign-curated Blueprint is the explicit
+// override-the-default knob.
+//
+// Each blueprint repo under the public + sovereign-curated Orgs is
+// expected to ship `blueprint.yaml` at the repo root. For the per-Org
+// private case the layout is a single `<org>/shared-blueprints` repo
+// with `<bp-name>/blueprint.yaml` per Blueprint (one repo, many
+// Blueprints) — see EPIC-2 master brief.
+//
+// The sources accept a Gitea client (the unified CC2 client at
+// `core/controllers/pkg/gitea`) injected at construction time so the
+// in-process integration test can swap in an httptest-backed instance.
+package source
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/openova-io/openova/core/controllers/pkg/gitea"
+	sigsyaml "sigs.k8s.io/yaml"
+)
+
+// Origin identifies which source produced a Blueprint. Lower values are
+// LOWER priority (higher integer = higher priority on collision).
+type Origin int
+
+const (
+	// OriginPublic — the public mirror Org. Lowest priority.
+	OriginPublic Origin = iota + 1
+	// OriginSovereign — the sovereign-curated Org. Mid priority.
+	OriginSovereign
+	// OriginOrgPrivate — the caller's Org's `shared-blueprints` repo.
+	// Highest priority.
+	OriginOrgPrivate
+)
+
+func (o Origin) String() string {
+	switch o {
+	case OriginPublic:
+		return "public"
+	case OriginSovereign:
+		return "sovereign"
+	case OriginOrgPrivate:
+		return "org-private"
+	default:
+		return "unknown"
+	}
+}
+
+// Blueprint is the catalog-svc projection of a Blueprint CR — exposes
+// only the fields the UI consumes plus `Raw` (the parsed YAML for
+// /versions/{version} responses) and `Origin` (which source produced
+// this entry).
+type Blueprint struct {
+	// Name is the Blueprint repo name (without "bp-" prefix when
+	// authored consistently — we use whatever the repo name happens
+	// to be).
+	Name string `json:"name"`
+
+	// Version is `spec.version` — semver per the CRD pattern.
+	Version string `json:"version"`
+
+	// Visibility mirrors `spec.visibility`. May be empty.
+	Visibility string `json:"visibility,omitempty"`
+
+	// Card is the user-facing metadata block.
+	Card BlueprintCard `json:"card"`
+
+	// PlacementSchema (subset) — surfaced so the UI knows allowed
+	// topology modes without re-fetching the full Blueprint.
+	PlacementSchema *BlueprintPlacement `json:"placementSchema,omitempty"`
+
+	// UpgradeFrom is `spec.upgrades.from` — the list of versions an
+	// install at THIS version can upgrade FROM. Used for the version
+	// matrix.
+	UpgradeFrom []string `json:"upgradeFrom,omitempty"`
+
+	// UpgradeBlocks is `spec.upgrades.blocks`.
+	UpgradeBlocks []string `json:"upgradeBlocks,omitempty"`
+
+	// Origin records which source produced this entry (private /
+	// sovereign / public). Useful for the UI to show a badge.
+	Origin Origin `json:"origin"`
+
+	// Source is the human-readable origin name (string form of Origin).
+	// Convenience field for JSON consumers that don't decode the int.
+	Source string `json:"source"`
+
+	// Org — populated only for OriginOrgPrivate entries (the caller's
+	// Org slug whose `shared-blueprints` repo this Blueprint came from).
+	Org string `json:"org,omitempty"`
+
+	// Raw is the full parsed Blueprint YAML as a generic map. Returned
+	// only by GET /catalog/{name}/versions/{version} and List* helpers
+	// that opt-in.
+	Raw map[string]interface{} `json:"raw,omitempty"`
+}
+
+// BlueprintCard mirrors the CRD's `spec.card` block.
+type BlueprintCard struct {
+	Title       string   `json:"title"`
+	Summary     string   `json:"summary,omitempty"`
+	Description string   `json:"description,omitempty"`
+	Tagline     string   `json:"tagline,omitempty"`
+	Icon        string   `json:"icon,omitempty"`
+	Category    string   `json:"category,omitempty"`
+	Family      string   `json:"family,omitempty"`
+	Tags        []string `json:"tags,omitempty"`
+	License     string   `json:"license,omitempty"`
+	Docs        string   `json:"docs,omitempty"`
+}
+
+// BlueprintPlacement mirrors `spec.placementSchema` (subset).
+type BlueprintPlacement struct {
+	Modes      []string `json:"modes,omitempty"`
+	Default    string   `json:"default,omitempty"`
+	MinRegions int      `json:"minRegions,omitempty"`
+	MaxRegions int      `json:"maxRegions,omitempty"`
+}
+
+// Source abstracts a Blueprint provider. Implementations: Public,
+// Sovereign, OrgPrivate.
+type Source interface {
+	// Origin reports which Origin tier this Source represents.
+	Origin() Origin
+
+	// List returns Blueprints visible from this source. Per the brief
+	// the implementation reads ALL Blueprints (every repo under the
+	// configured Org for public/sovereign; every directory under the
+	// `<org>/shared-blueprints` repo for per-Org).
+	List(ctx context.Context) ([]Blueprint, error)
+
+	// Get returns the Blueprint at the requested version, or nil + nil
+	// when the source has no copy of name@version. (nil + non-nil err
+	// is reserved for transport / parse errors.)
+	Get(ctx context.Context, name, version string) (*Blueprint, error)
+}
+
+// ErrBlueprintNotFound is returned by Resolver.Get when no source has
+// the requested name (potentially version-pinned).
+var ErrBlueprintNotFound = errors.New("source: blueprint not found")
+
+// ParseBlueprint converts a YAML blueprint manifest into the catalog-
+// svc projection. Exported so the per-source loaders can share the
+// same parse path AND the integration test can build expected
+// fixtures without going through the resolver.
+func ParseBlueprint(yamlBytes []byte, origin Origin, org, repoName string) (*Blueprint, error) {
+	var raw map[string]interface{}
+	if err := sigsyaml.Unmarshal(yamlBytes, &raw); err != nil {
+		return nil, fmt.Errorf("source: parse blueprint.yaml: %w", err)
+	}
+	bp := Blueprint{
+		Origin: origin,
+		Source: origin.String(),
+		Org:    org,
+		Raw:    raw,
+		Name:   repoName,
+	}
+	spec, _ := raw["spec"].(map[string]interface{})
+	if spec == nil {
+		return nil, fmt.Errorf("source: blueprint.yaml has no spec")
+	}
+	if v, ok := spec["version"].(string); ok {
+		bp.Version = v
+	}
+	if v, ok := spec["visibility"].(string); ok {
+		bp.Visibility = v
+	}
+	if metaName, ok := raw["metadata"].(map[string]interface{}); ok {
+		if n, ok := metaName["name"].(string); ok && n != "" {
+			bp.Name = n
+		}
+	}
+	if cardRaw, ok := spec["card"].(map[string]interface{}); ok {
+		bp.Card = parseCard(cardRaw)
+	}
+	if pl, ok := spec["placementSchema"].(map[string]interface{}); ok {
+		bp.PlacementSchema = parsePlacement(pl)
+	}
+	if upg, ok := spec["upgrades"].(map[string]interface{}); ok {
+		if from, ok := upg["from"].([]interface{}); ok {
+			bp.UpgradeFrom = strSlice(from)
+		}
+		if blocks, ok := upg["blocks"].([]interface{}); ok {
+			bp.UpgradeBlocks = strSlice(blocks)
+		}
+	}
+	return &bp, nil
+}
+
+func parseCard(c map[string]interface{}) BlueprintCard {
+	out := BlueprintCard{}
+	if v, ok := c["title"].(string); ok {
+		out.Title = v
+	}
+	if v, ok := c["summary"].(string); ok {
+		out.Summary = v
+	}
+	if v, ok := c["description"].(string); ok {
+		out.Description = v
+	}
+	if v, ok := c["tagline"].(string); ok {
+		out.Tagline = v
+	}
+	if v, ok := c["icon"].(string); ok {
+		out.Icon = v
+	}
+	if v, ok := c["category"].(string); ok {
+		out.Category = v
+	}
+	if v, ok := c["family"].(string); ok {
+		out.Family = v
+	}
+	if v, ok := c["license"].(string); ok {
+		out.License = v
+	}
+	if v, ok := c["docs"].(string); ok {
+		out.Docs = v
+	}
+	if v, ok := c["documentation"].(string); ok && out.Docs == "" {
+		out.Docs = v
+	}
+	if tags, ok := c["tags"].([]interface{}); ok {
+		out.Tags = strSlice(tags)
+	}
+	return out
+}
+
+func parsePlacement(p map[string]interface{}) *BlueprintPlacement {
+	out := &BlueprintPlacement{}
+	if modes, ok := p["modes"].([]interface{}); ok {
+		out.Modes = strSlice(modes)
+	}
+	if v, ok := p["default"].(string); ok {
+		out.Default = v
+	}
+	if v, ok := p["minRegions"].(float64); ok {
+		out.MinRegions = int(v)
+	}
+	if v, ok := p["maxRegions"].(float64); ok {
+		out.MaxRegions = int(v)
+	}
+	if out.Modes == nil && out.Default == "" && out.MinRegions == 0 && out.MaxRegions == 0 {
+		return nil
+	}
+	return out
+}
+
+func strSlice(in []interface{}) []string {
+	out := make([]string, 0, len(in))
+	for _, v := range in {
+		if s, ok := v.(string); ok {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+// CacheKey composes the LRU cache key for a Blueprint read.
+func CacheKey(origin Origin, org, name, version string) string {
+	return fmt.Sprintf("%s|%s|%s|%s", origin, org, name, version)
+}
+
+// readBlueprintYAML fetches blueprint.yaml at the configured path on
+// the repo's main branch, returning typed Gitea sentinels through
+// IsNotFound when applicable.
+func readBlueprintYAML(ctx context.Context, gc *gitea.Client, org, repo, path string) ([]byte, error) {
+	f, err := gc.GetFile(ctx, org, repo, "main", path)
+	if err != nil {
+		return nil, err
+	}
+	return f.Decoded()
+}
+
+// IsNotFound surfaces the gitea client's typed-sentinel test (so callers
+// here don't need to import the gitea package directly).
+func IsNotFound(err error) bool {
+	return gitea.IsNotFound(err)
+}
+
+// trimBPPrefix strips the conventional "bp-" prefix from a name. Used
+// when matching repo-name → Blueprint name. Idempotent on names that
+// don't carry the prefix.
+func trimBPPrefix(s string) string {
+	return strings.TrimPrefix(s, "bp-")
+}

--- a/core/services/catalyst-catalog/internal/source/source_test.go
+++ b/core/services/catalyst-catalog/internal/source/source_test.go
@@ -1,0 +1,541 @@
+package source
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/openova-io/openova/core/controllers/pkg/gitea"
+	"github.com/openova-io/openova/core/services/catalyst-catalog/internal/cache"
+)
+
+// fakeGitea is a focused httptest-backed Gitea fixture for the source
+// + resolver tests. It supports:
+//
+//   GET /orgs/{org}/repos       → list repos
+//   GET /repos/{owner}/{repo}/contents/{path}?ref=main → file or dir
+//
+// Repos register via AddRepo(); files via AddFile(); directories are
+// implied by file paths.
+type fakeGitea struct {
+	mu    sync.Mutex
+	repos map[string][]string                // org → repo names
+	files map[string]map[string]map[string][]byte // org → repo → path → bytes
+}
+
+func newFakeGitea() *fakeGitea {
+	return &fakeGitea{
+		repos: map[string][]string{},
+		files: map[string]map[string]map[string][]byte{},
+	}
+}
+
+func (f *fakeGitea) AddRepo(org, repo string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.repos[org] = append(f.repos[org], repo)
+	if f.files[org] == nil {
+		f.files[org] = map[string]map[string][]byte{}
+	}
+	if f.files[org][repo] == nil {
+		f.files[org][repo] = map[string][]byte{}
+	}
+}
+
+func (f *fakeGitea) AddFile(org, repo, path string, content []byte) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.files[org] == nil {
+		f.files[org] = map[string]map[string][]byte{}
+	}
+	if f.files[org][repo] == nil {
+		f.files[org][repo] = map[string][]byte{}
+		f.repos[org] = append(f.repos[org], repo)
+	}
+	f.files[org][repo][path] = content
+}
+
+func (f *fakeGitea) handler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") == "" {
+			http.Error(w, "no auth", http.StatusUnauthorized)
+			return
+		}
+		p := r.URL.Path
+		// GET /api/v1/orgs/{org}/repos
+		if r.Method == http.MethodGet && strings.HasPrefix(p, "/api/v1/orgs/") && strings.HasSuffix(p, "/repos") {
+			org := strings.TrimSuffix(strings.TrimPrefix(p, "/api/v1/orgs/"), "/repos")
+			f.mu.Lock()
+			repos, ok := f.repos[org]
+			f.mu.Unlock()
+			if !ok {
+				http.Error(w, "no such org", http.StatusNotFound)
+				return
+			}
+			out := make([]gitea.Repo, 0, len(repos))
+			for _, name := range repos {
+				out = append(out, gitea.Repo{Name: name, FullName: org + "/" + name})
+			}
+			writeJSON(w, http.StatusOK, out)
+			return
+		}
+		// /api/v1/repos/{owner}/{repo}/contents/{path}
+		if r.Method == http.MethodGet && strings.HasPrefix(p, "/api/v1/repos/") && strings.Contains(p, "/contents/") {
+			rest := strings.TrimPrefix(p, "/api/v1/repos/")
+			idx := strings.Index(rest, "/contents/")
+			ownerRepo := rest[:idx]
+			filePath := strings.TrimSuffix(rest[idx+len("/contents/"):], "/")
+			parts := strings.SplitN(ownerRepo, "/", 2)
+			if len(parts) != 2 {
+				http.Error(w, "bad", http.StatusBadRequest)
+				return
+			}
+			org, repo := parts[0], parts[1]
+			f.mu.Lock()
+			repoFiles, repoOK := f.files[org][repo]
+			f.mu.Unlock()
+			if !repoOK {
+				http.Error(w, `{"message":"repository not found"}`, http.StatusNotFound)
+				return
+			}
+			// File hit?
+			if content, ok := repoFiles[filePath]; ok {
+				writeJSON(w, http.StatusOK, gitea.File{
+					Path:          filePath,
+					SHA:           "sha-" + filePath,
+					Type:          "file",
+					ContentBase64: base64.StdEncoding.EncodeToString(content),
+				})
+				return
+			}
+			// Directory listing?
+			prefix := filePath
+			if prefix != "" {
+				prefix += "/"
+			}
+			entries := []gitea.ContentEntry{}
+			seen := map[string]bool{}
+			f.mu.Lock()
+			for path, body := range repoFiles {
+				if !strings.HasPrefix(path, prefix) {
+					continue
+				}
+				rest := strings.TrimPrefix(path, prefix)
+				if rest == "" {
+					continue
+				}
+				head, _, hasSlash := strings.Cut(rest, "/")
+				if seen[head] {
+					continue
+				}
+				seen[head] = true
+				typ := "file"
+				size := int64(len(body))
+				if hasSlash {
+					typ = "dir"
+					size = 0
+				}
+				entries = append(entries, gitea.ContentEntry{
+					Name: head,
+					Path: prefix + head,
+					Type: typ,
+					Size: size,
+				})
+			}
+			f.mu.Unlock()
+			if len(entries) == 0 && filePath != "" {
+				http.Error(w, "no such path", http.StatusNotFound)
+				return
+			}
+			writeJSON(w, http.StatusOK, entries)
+			return
+		}
+		http.Error(w, "unhandled", http.StatusNotFound)
+	})
+}
+
+func writeJSON(w http.ResponseWriter, code int, v interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+func newGiteaClient(t *testing.T, fake *fakeGitea) *gitea.Client {
+	t.Helper()
+	srv := httptest.NewServer(fake.handler())
+	t.Cleanup(srv.Close)
+	c := gitea.New(srv.URL, "test-token")
+	c.HTTP = srv.Client()
+	return c
+}
+
+// blueprintYAML is a helper that emits a minimal but realistic
+// blueprint.yaml fixture.
+func blueprintYAML(name, version, title string) []byte {
+	return []byte(`apiVersion: catalyst.openova.io/v1
+kind: Blueprint
+metadata:
+  name: ` + name + `
+spec:
+  version: ` + version + `
+  visibility: listed
+  card:
+    title: ` + title + `
+    summary: A blueprint for ` + name + `
+  upgrades:
+    from:
+      - 0.0.1
+      - 0.1.0
+`)
+}
+
+func TestParseBlueprint_HappyPath(t *testing.T) {
+	bp, err := ParseBlueprint(blueprintYAML("bp-foo", "1.2.3", "Foo App"), OriginPublic, "", "bp-foo")
+	if err != nil {
+		t.Fatalf("ParseBlueprint: %v", err)
+	}
+	if bp.Name != "bp-foo" {
+		t.Errorf("Name = %q", bp.Name)
+	}
+	if bp.Version != "1.2.3" {
+		t.Errorf("Version = %q", bp.Version)
+	}
+	if bp.Card.Title != "Foo App" {
+		t.Errorf("Card.Title = %q", bp.Card.Title)
+	}
+	if bp.Card.Summary == "" {
+		t.Error("Card.Summary should be populated")
+	}
+	if len(bp.UpgradeFrom) != 2 {
+		t.Errorf("UpgradeFrom = %v", bp.UpgradeFrom)
+	}
+	if bp.Source != "public" {
+		t.Errorf("Source = %q, want public", bp.Source)
+	}
+}
+
+func TestParseBlueprint_RejectsNoSpec(t *testing.T) {
+	_, err := ParseBlueprint([]byte(`apiVersion: x
+kind: Y
+metadata:
+  name: foo
+`), OriginPublic, "", "foo")
+	if err == nil {
+		t.Fatal("ParseBlueprint without spec should fail")
+	}
+}
+
+func TestPublic_ListAndGet(t *testing.T) {
+	t.Parallel()
+	fake := newFakeGitea()
+	fake.AddFile("catalog", "bp-wordpress", "blueprint.yaml", blueprintYAML("bp-wordpress", "1.0.0", "WordPress"))
+	fake.AddFile("catalog", "bp-redis", "blueprint.yaml", blueprintYAML("bp-redis", "0.5.0", "Redis"))
+	gc := newGiteaClient(t, fake)
+	c := cache.New(64, 30*time.Second)
+	src := NewPublic(gc, "catalog", c)
+
+	list, err := src.List(context.Background())
+	if err != nil {
+		t.Fatalf("Public.List: %v", err)
+	}
+	if len(list) != 2 {
+		t.Fatalf("len = %d, want 2", len(list))
+	}
+	for _, bp := range list {
+		if bp.Origin != OriginPublic {
+			t.Errorf("Origin = %v, want public", bp.Origin)
+		}
+	}
+
+	bp, err := src.Get(context.Background(), "bp-wordpress", "")
+	if err != nil || bp == nil {
+		t.Fatalf("Get(bp-wordpress) = (%v, %v)", bp, err)
+	}
+	if bp.Card.Title != "WordPress" {
+		t.Errorf("Card.Title = %q", bp.Card.Title)
+	}
+
+	// Version mismatch returns nil (no error).
+	bp, err = src.Get(context.Background(), "bp-wordpress", "9.9.9")
+	if err != nil {
+		t.Fatalf("Get version-pinned err: %v", err)
+	}
+	if bp != nil {
+		t.Errorf("expected nil for unmatched version, got %+v", bp)
+	}
+
+	// Unknown name returns nil.
+	bp, err = src.Get(context.Background(), "bp-missing", "")
+	if err != nil {
+		t.Fatalf("Get(bp-missing) err: %v", err)
+	}
+	if bp != nil {
+		t.Errorf("expected nil for missing, got %+v", bp)
+	}
+}
+
+func TestPublic_OrgNotProvisioned_ReturnsEmpty(t *testing.T) {
+	fake := newFakeGitea()
+	gc := newGiteaClient(t, fake)
+	src := NewPublic(gc, "catalog", cache.New(8, 30*time.Second))
+
+	list, err := src.List(context.Background())
+	if err != nil {
+		t.Fatalf("List on missing Org: %v", err)
+	}
+	if list != nil && len(list) != 0 {
+		t.Errorf("expected empty list, got %v", list)
+	}
+}
+
+func TestPublic_RepoWithoutBlueprintYAML_Skipped(t *testing.T) {
+	fake := newFakeGitea()
+	fake.AddRepo("catalog", "bp-empty")
+	fake.AddFile("catalog", "bp-good", "blueprint.yaml", blueprintYAML("bp-good", "1.0.0", "Good"))
+	gc := newGiteaClient(t, fake)
+	src := NewPublic(gc, "catalog", cache.New(8, 30*time.Second))
+
+	list, err := src.List(context.Background())
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(list) != 1 || list[0].Name != "bp-good" {
+		t.Errorf("expected only bp-good, got %v", list)
+	}
+}
+
+func TestSovereign_ReadsFromSovereignOrg(t *testing.T) {
+	fake := newFakeGitea()
+	fake.AddFile("catalog-sovereign", "bp-omantel-edge", "blueprint.yaml",
+		blueprintYAML("bp-omantel-edge", "2.0.0", "Omantel Edge"))
+	gc := newGiteaClient(t, fake)
+	src := NewSovereign(gc, "catalog-sovereign", cache.New(8, 30*time.Second))
+
+	list, err := src.List(context.Background())
+	if err != nil {
+		t.Fatalf("Sovereign.List: %v", err)
+	}
+	if len(list) != 1 || list[0].Origin != OriginSovereign {
+		t.Errorf("expected 1 sovereign-origin entry, got %+v", list)
+	}
+}
+
+func TestOrgPrivate_ListsPerOrg(t *testing.T) {
+	fake := newFakeGitea()
+	fake.AddFile("acme", "shared-blueprints", "bp-internal-app/blueprint.yaml",
+		blueprintYAML("bp-internal-app", "0.1.0", "Internal App"))
+	fake.AddFile("acme", "shared-blueprints", "bp-team-tool/blueprint.yaml",
+		blueprintYAML("bp-team-tool", "0.2.0", "Team Tool"))
+	gc := newGiteaClient(t, fake)
+	src := NewOrgPrivate(gc, "acme", "shared-blueprints", cache.New(8, 30*time.Second))
+
+	list, err := src.List(context.Background())
+	if err != nil {
+		t.Fatalf("OrgPrivate.List: %v", err)
+	}
+	if len(list) != 2 {
+		t.Fatalf("len = %d, want 2", len(list))
+	}
+	// Every Blueprint must be tagged with the Org slug for downstream
+	// access enforcement.
+	for _, bp := range list {
+		if bp.Org != "acme" {
+			t.Errorf("Org = %q, want acme", bp.Org)
+		}
+		if bp.Origin != OriginOrgPrivate {
+			t.Errorf("Origin = %v, want org-private", bp.Origin)
+		}
+	}
+
+	// Targeted Get.
+	bp, err := src.Get(context.Background(), "bp-internal-app", "0.1.0")
+	if err != nil || bp == nil {
+		t.Fatalf("Get(bp-internal-app, 0.1.0) = (%v, %v)", bp, err)
+	}
+}
+
+func TestOrgPrivate_RepoNotProvisioned_ReturnsEmpty(t *testing.T) {
+	fake := newFakeGitea()
+	gc := newGiteaClient(t, fake)
+	src := NewOrgPrivate(gc, "no-such-org", "shared-blueprints", cache.New(8, 30*time.Second))
+
+	list, err := src.List(context.Background())
+	if err != nil {
+		t.Fatalf("OrgPrivate.List on missing repo: %v", err)
+	}
+	if len(list) != 0 {
+		t.Errorf("expected empty, got %v", list)
+	}
+}
+
+func TestResolver_PriorityOnCollision(t *testing.T) {
+	t.Parallel()
+	// Three sources publish the SAME Blueprint name `bp-shared` with
+	// different titles to make the priority winner identifiable.
+	fake := newFakeGitea()
+	fake.AddFile("catalog", "bp-shared", "blueprint.yaml",
+		blueprintYAML("bp-shared", "1.0.0-public", "PUBLIC TITLE"))
+	fake.AddFile("catalog-sovereign", "bp-shared", "blueprint.yaml",
+		blueprintYAML("bp-shared", "1.0.0-sovereign", "SOVEREIGN TITLE"))
+	fake.AddFile("acme", "shared-blueprints", "bp-shared/blueprint.yaml",
+		blueprintYAML("bp-shared", "1.0.0-private", "PRIVATE TITLE"))
+	gc := newGiteaClient(t, fake)
+	r := NewResolver(gc, "catalog", "catalog-sovereign", "shared-blueprints", cache.New(64, 30*time.Second))
+
+	// Caller in Org "acme" — should see PRIVATE winning.
+	list, err := r.List(context.Background(), []string{"acme"})
+	if err != nil {
+		t.Fatalf("Resolver.List: %v", err)
+	}
+	if len(list) != 1 {
+		t.Fatalf("expected 1 entry (deduped), got %d: %+v", len(list), list)
+	}
+	if list[0].Card.Title != "PRIVATE TITLE" {
+		t.Errorf("Card.Title = %q, want PRIVATE TITLE (private should win)", list[0].Card.Title)
+	}
+	if list[0].Origin != OriginOrgPrivate {
+		t.Errorf("Origin = %v, want org-private", list[0].Origin)
+	}
+
+	// Caller in Org "fabrikam" (no private copy) — should see SOVEREIGN winning.
+	list, err = r.List(context.Background(), []string{"fabrikam"})
+	if err != nil {
+		t.Fatalf("Resolver.List(fabrikam): %v", err)
+	}
+	if list[0].Card.Title != "SOVEREIGN TITLE" {
+		t.Errorf("fabrikam Card.Title = %q, want SOVEREIGN TITLE", list[0].Card.Title)
+	}
+
+	// Anonymous caller — should see SOVEREIGN winning over PUBLIC.
+	list, err = r.List(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("Resolver.List(anon): %v", err)
+	}
+	if list[0].Card.Title != "SOVEREIGN TITLE" {
+		t.Errorf("anon Card.Title = %q, want SOVEREIGN TITLE", list[0].Card.Title)
+	}
+}
+
+func TestResolver_PerOrgAccessFilter(t *testing.T) {
+	t.Parallel()
+	// Two Orgs publish DISTINCT private blueprints.
+	fake := newFakeGitea()
+	fake.AddFile("acme", "shared-blueprints", "bp-acme-secret/blueprint.yaml",
+		blueprintYAML("bp-acme-secret", "1.0.0", "ACME Secret"))
+	fake.AddFile("contoso", "shared-blueprints", "bp-contoso-secret/blueprint.yaml",
+		blueprintYAML("bp-contoso-secret", "1.0.0", "Contoso Secret"))
+	gc := newGiteaClient(t, fake)
+	r := NewResolver(gc, "catalog", "catalog-sovereign", "shared-blueprints", cache.New(64, 30*time.Second))
+
+	// User in Org "acme" sees ONLY their private blueprints.
+	list, err := r.List(context.Background(), []string{"acme"})
+	if err != nil {
+		t.Fatalf("List(acme): %v", err)
+	}
+	names := blueprintNames(list)
+	if !contains(names, "bp-acme-secret") {
+		t.Errorf("acme should see bp-acme-secret, got %v", names)
+	}
+	if contains(names, "bp-contoso-secret") {
+		t.Errorf("acme MUST NOT see bp-contoso-secret, got %v", names)
+	}
+
+	// Cross-check: Contoso user sees only their own.
+	list, err = r.List(context.Background(), []string{"contoso"})
+	if err != nil {
+		t.Fatalf("List(contoso): %v", err)
+	}
+	names = blueprintNames(list)
+	if contains(names, "bp-acme-secret") {
+		t.Errorf("contoso MUST NOT see bp-acme-secret, got %v", names)
+	}
+}
+
+func TestResolver_GetFollowsPriorityOrder(t *testing.T) {
+	t.Parallel()
+	fake := newFakeGitea()
+	fake.AddFile("catalog", "bp-X", "blueprint.yaml", blueprintYAML("bp-X", "1.0.0", "PUBLIC"))
+	fake.AddFile("catalog-sovereign", "bp-X", "blueprint.yaml", blueprintYAML("bp-X", "1.0.0", "SOVEREIGN"))
+	fake.AddFile("acme", "shared-blueprints", "bp-X/blueprint.yaml", blueprintYAML("bp-X", "1.0.0", "PRIVATE"))
+	gc := newGiteaClient(t, fake)
+	r := NewResolver(gc, "catalog", "catalog-sovereign", "shared-blueprints", cache.New(64, 30*time.Second))
+
+	bp, err := r.Get(context.Background(), "bp-X", "", []string{"acme"})
+	if err != nil || bp == nil {
+		t.Fatalf("Get: %v %v", bp, err)
+	}
+	if bp.Card.Title != "PRIVATE" {
+		t.Errorf("Get returned %q, want PRIVATE", bp.Card.Title)
+	}
+}
+
+func TestResolver_GetUnknownReturnsNotFound(t *testing.T) {
+	fake := newFakeGitea()
+	gc := newGiteaClient(t, fake)
+	r := NewResolver(gc, "catalog", "catalog-sovereign", "shared-blueprints", cache.New(8, 30*time.Second))
+
+	_, err := r.Get(context.Background(), "bp-nope", "", nil)
+	if !errors.Is(err, ErrBlueprintNotFound) {
+		t.Errorf("Get unknown err = %v, want ErrBlueprintNotFound", err)
+	}
+}
+
+func TestPublic_CacheReducesGiteaCalls(t *testing.T) {
+	// Wrap a fake server to count how many GET requests reach it for
+	// the file path. After the first read, cached subsequent reads
+	// must NOT hit the server.
+	hitCount := 0
+	var mu sync.Mutex
+	fake := newFakeGitea()
+	fake.AddFile("catalog", "bp-foo", "blueprint.yaml", blueprintYAML("bp-foo", "1.0.0", "Foo"))
+	upstream := fake.handler()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/contents/blueprint.yaml") {
+			mu.Lock()
+			hitCount++
+			mu.Unlock()
+		}
+		upstream.ServeHTTP(w, r)
+	}))
+	defer srv.Close()
+	gc := gitea.New(srv.URL, "test-token")
+	gc.HTTP = srv.Client()
+
+	cs := cache.New(8, 30*time.Second)
+	src := NewPublic(gc, "catalog", cs)
+	for i := 0; i < 5; i++ {
+		bp, err := src.Get(context.Background(), "bp-foo", "")
+		if err != nil || bp == nil {
+			t.Fatalf("iter %d: %v", i, err)
+		}
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if hitCount != 1 {
+		t.Errorf("expected 1 server hit after caching, got %d", hitCount)
+	}
+}
+
+func blueprintNames(list []Blueprint) []string {
+	out := make([]string, 0, len(list))
+	for _, bp := range list {
+		out = append(out, bp.Name)
+	}
+	return out
+}
+
+func contains(haystack []string, needle string) bool {
+	for _, s := range haystack {
+		if s == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/core/services/catalyst-catalog/internal/source/sovereign.go
+++ b/core/services/catalyst-catalog/internal/source/sovereign.go
@@ -1,0 +1,83 @@
+package source
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/openova-io/openova/core/controllers/pkg/gitea"
+	"github.com/openova-io/openova/core/services/catalyst-catalog/internal/cache"
+)
+
+// Sovereign reads Blueprints from the Sovereign-curated Gitea Org.
+// Layout matches the public mirror: one repo per Blueprint, with
+// `blueprint.yaml` at the repo root.
+type Sovereign struct {
+	GC    *gitea.Client
+	Org   string // "catalog-sovereign" by default
+	Cache *cache.LRU
+}
+
+func NewSovereign(gc *gitea.Client, org string, c *cache.LRU) *Sovereign {
+	return &Sovereign{GC: gc, Org: org, Cache: c}
+}
+
+func (s *Sovereign) Origin() Origin { return OriginSovereign }
+
+func (s *Sovereign) List(ctx context.Context) ([]Blueprint, error) {
+	repos, err := s.GC.ListOrgRepos(ctx, s.Org)
+	if err != nil {
+		if IsNotFound(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("source.sovereign.List: %w", err)
+	}
+	out := make([]Blueprint, 0, len(repos))
+	for _, r := range repos {
+		bp, err := s.fetch(ctx, r.Name)
+		if err != nil {
+			if IsNotFound(err) {
+				continue
+			}
+			return nil, fmt.Errorf("source.sovereign.List: read %s: %w", r.Name, err)
+		}
+		if bp == nil {
+			continue
+		}
+		out = append(out, *bp)
+	}
+	return out, nil
+}
+
+func (s *Sovereign) Get(ctx context.Context, name, version string) (*Blueprint, error) {
+	bp, err := s.fetch(ctx, name)
+	if err != nil {
+		if IsNotFound(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	if bp == nil {
+		return nil, nil
+	}
+	if version != "" && bp.Version != version {
+		return nil, nil
+	}
+	return bp, nil
+}
+
+func (s *Sovereign) fetch(ctx context.Context, name string) (*Blueprint, error) {
+	key := CacheKey(s.Origin(), s.Org, name, "")
+	if s.Cache != nil {
+		if cached, ok := s.Cache.Get(key); ok {
+			return ParseBlueprint(cached, s.Origin(), "", name)
+		}
+	}
+	data, err := readBlueprintYAML(ctx, s.GC, s.Org, name, "blueprint.yaml")
+	if err != nil {
+		return nil, err
+	}
+	if s.Cache != nil {
+		s.Cache.Put(key, data)
+	}
+	return ParseBlueprint(data, s.Origin(), "", name)
+}

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -124,7 +124,7 @@ name: bp-catalyst-platform
 # otech113 2026-05-05 — chart 0.1.18 fixed the readiness-probe loop
 # but every trigger immediately got 502 in <10ms (synchronous
 # apiserver permission rejection). 2026-05-05.
-version: 1.4.85
+version: 1.4.86
 appVersion: 1.4.84
 description: |
   Catalyst Platform — the unified Catalyst control plane umbrella chart for Catalyst-Zero.

--- a/products/catalyst/chart/templates/services/catalog/_helpers.tpl
+++ b/products/catalyst/chart/templates/services/catalog/_helpers.tpl
@@ -1,0 +1,60 @@
+{{/*
+Helpers for the catalyst-catalog HTTP service shipped by EPIC-2 Slice L
+of #1097.
+
+The service is opt-in via `.Values.services.catalog.enabled` (default
+false). Operators flip the flag to true once the catalog backend has
+been validated against the Sovereign's Gitea (catalog + catalog-sovereign
++ <org>/shared-blueprints repos).
+
+Conventions enforced here mirror the controllers' chart pattern (see
+templates/controllers/_helpers.tpl):
+
+  - Image refs come from `.Values.services.catalog.image.{repository,tag,pullPolicy}`
+    with NO :latest fallback. Empty `tag` fails fast at render time per
+    docs/INVIOLABLE-PRINCIPLES.md #4a. CI stamps the SHA.
+  - Service / Deployment / SA / RBAC names follow `catalyst-catalog`.
+  - Standard pod-security shape: runAsNonRoot, runAsUser=65532 (matches
+    the distroless:nonroot UID), seccompProfile RuntimeDefault, drop
+    ALL caps, readOnlyRootFilesystem.
+  - Resources requests + limits set per Inviolable Principle #4.
+
+*/}}
+
+{{- define "catalog.fullname" -}}
+catalyst-catalog
+{{- end -}}
+
+{{- define "catalog.labels" -}}
+app.kubernetes.io/name: catalyst-catalog
+app.kubernetes.io/component: service
+app.kubernetes.io/part-of: catalyst
+app.kubernetes.io/managed-by: {{ .root.Release.Service | default "Helm" }}
+catalyst.openova.io/service: catalog
+{{- end -}}
+
+{{- define "catalog.selectorLabels" -}}
+app.kubernetes.io/name: catalyst-catalog
+app.kubernetes.io/component: service
+catalyst.openova.io/service: catalog
+{{- end -}}
+
+{{/* Resolve the image reference for the catalog, fail-fast if tag empty.
+     Param: dict "cfg" .Values.services.catalog "root" . */}}
+{{- define "catalog.image" -}}
+{{- $cfg := .cfg -}}
+{{- $root := .root -}}
+{{- $tag := $cfg.image.tag | default "" -}}
+{{- if eq $tag "" -}}
+{{- fail "services.catalog.image.tag is empty — CI must stamp a SHA before render. Per docs/INVIOLABLE-PRINCIPLES.md #4a no :latest is permitted." -}}
+{{- end -}}
+{{- $repo := $cfg.image.repository -}}
+{{- $globalRegistry := $root.Values.global.imageRegistry | default "" -}}
+{{- if ne $globalRegistry "" -}}
+{{- $parts := splitList "/" $repo -}}
+{{- $rest := slice $parts 1 -}}
+{{- printf "%s/%s:%s" $globalRegistry (join "/" $rest) $tag -}}
+{{- else -}}
+{{- printf "%s:%s" $repo $tag -}}
+{{- end -}}
+{{- end -}}

--- a/products/catalyst/chart/templates/services/catalog/deployment.yaml
+++ b/products/catalyst/chart/templates/services/catalog/deployment.yaml
@@ -1,0 +1,108 @@
+{{- /*
+catalyst-catalog Deployment.
+
+Reads Blueprint manifests from the Sovereign's Gitea instance over the
+in-cluster Service URL (no Internet egress required). The Gitea admin
+token is sourced from the existing `catalyst-gitea-token` Secret used
+by the Group C controllers (one secret, one rotation surface).
+*/ -}}
+{{- if .Values.services.catalog.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "catalog.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "catalog.labels" (dict "root" .) | nindent 4 }}
+spec:
+  replicas: {{ .Values.services.catalog.replicas | default 1 }}
+  selector:
+    matchLabels:
+      {{- include "catalog.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "catalog.labels" (dict "root" .) | nindent 8 }}
+    spec:
+      serviceAccountName: {{ include "catalog.fullname" . }}
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: catalog
+          image: {{ include "catalog.image" (dict "cfg" .Values.services.catalog "root" .) | quote }}
+          imagePullPolicy: {{ .Values.services.catalog.image.pullPolicy | default "IfNotPresent" }}
+          env:
+            - name: CATALOG_LISTEN_ADDR
+              value: ":8080"
+            - name: CATALYST_GITEA_URL
+              value: {{ .Values.services.catalog.giteaURL | default "http://gitea-http.gitea.svc.cluster.local:3000" | quote }}
+            - name: CATALYST_GITEA_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.services.catalog.giteaSecretRef | default "catalyst-gitea-token" }}
+                  key: token
+            - name: CATALOG_PUBLIC_ORG
+              value: {{ .Values.services.catalog.publicOrg | default "catalog" | quote }}
+            - name: CATALOG_SOVEREIGN_ORG
+              value: {{ .Values.services.catalog.sovereignOrg | default "catalog-sovereign" | quote }}
+            - name: CATALOG_ORG_PRIVATE_REPO
+              value: {{ .Values.services.catalog.orgPrivateRepo | default "shared-blueprints" | quote }}
+            - name: CATALOG_CACHE_TTL_SECONDS
+              value: {{ .Values.services.catalog.cache.ttlSeconds | default 30 | quote }}
+            - name: CATALOG_CACHE_CAPACITY
+              value: {{ .Values.services.catalog.cache.capacity | default 1024 | quote }}
+            - name: CATALOG_SESSION_COOKIE
+              value: {{ .Values.services.catalog.sessionCookieName | default "catalyst_session" | quote }}
+            - name: CATALOG_ANONYMOUS_READS
+              value: {{ .Values.services.catalog.anonymousReads | default false | quote }}
+            - name: SOVEREIGN_FQDN
+              valueFrom:
+                configMapKeyRef:
+                  name: sovereign-fqdn
+                  key: fqdn
+                  optional: true
+            {{- range $k, $v := .Values.services.catalog.env }}
+            - name: {{ $k | quote }}
+              value: {{ $v | quote }}
+            {{- end }}
+          ports:
+            - name: http
+              containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 20
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 2
+            periodSeconds: 10
+          resources:
+            {{- toYaml .Values.services.catalog.resources | nindent 12 }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+            readOnlyRootFilesystem: true
+      {{- with .Values.services.catalog.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.services.catalog.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.services.catalog.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      terminationGracePeriodSeconds: 30
+{{- end }}

--- a/products/catalyst/chart/templates/services/catalog/httproute.yaml
+++ b/products/catalyst/chart/templates/services/catalog/httproute.yaml
@@ -1,0 +1,60 @@
+{{- /*
+catalyst-catalog HTTPRoute (Gateway API).
+
+Per the EPIC-2 Slice L brief, catalyst-catalog runs BEHIND catalyst-api
+for auth-wiring simplicity (catalyst-api validates the Keycloak JWT
+against JWKS; catalyst-catalog parses the already-validated claims to
+compute per-Org access).
+
+This HTTPRoute exposes catalyst-catalog at:
+
+  https://api.<sovereign>/api/v1/catalog
+  https://api.<sovereign>/api/v1/catalog/{name}
+  https://api.<sovereign>/api/v1/catalog/{name}/versions
+  https://api.<sovereign>/api/v1/catalog/{name}/versions/{version}
+
+…by adding a `/api/v1/catalog` PathPrefix rule that backendRefs to the
+catalyst-catalog Service. The rule is INDEPENDENT of templates/httproute.yaml
+(which routes the api hostname's catch-all to catalyst-api) and is
+attached to the same Gateway parentRef.
+
+Operators who prefer to keep the catalog endpoint behind catalyst-api
+(rather than via a standalone HTTPRoute on the api hostname) can disable
+this template via `.Values.services.catalog.httpRoute.enabled=false`
+and add a proxy rule in catalyst-api instead — that path is left open
+as a follow-up so catalyst-api can do additional auth/audit wrapping.
+*/ -}}
+{{- if and .Values.services.catalog.enabled
+          (or (not (hasKey .Values.services.catalog "httpRoute"))
+              .Values.services.catalog.httpRoute.enabled)
+          .Values.ingress
+          .Values.ingress.gateway
+          .Values.ingress.gateway.enabled }}
+{{- $apiHost := (((.Values.ingress.hosts).api).host) }}
+{{- if $apiHost }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "catalog.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "catalog.labels" (dict "root" .) | nindent 4 }}
+spec:
+  parentRefs:
+    - name: {{ .Values.ingress.gateway.parentRef.name | default "cilium-gateway" | quote }}
+      namespace: {{ .Values.ingress.gateway.parentRef.namespace | default "kube-system" | quote }}
+      {{- with .Values.ingress.gateway.parentRef.sectionName }}
+      sectionName: {{ . | quote }}
+      {{- end }}
+  hostnames:
+    - {{ $apiHost | quote }}
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: "/api/v1/catalog"
+      backendRefs:
+        - name: {{ include "catalog.fullname" . }}
+          port: 8080
+{{- end }}
+{{- end }}

--- a/products/catalyst/chart/templates/services/catalog/rbac.yaml
+++ b/products/catalyst/chart/templates/services/catalog/rbac.yaml
@@ -1,0 +1,38 @@
+{{- /*
+RBAC for catalyst-catalog (EPIC-2 Slice L of #1097).
+
+The service does not interact with the K8s API server: it reads
+Blueprints from Gitea over HTTP using a static admin access token.
+The chart still ships a ClusterRole + Binding scoped to ZERO resources
+(empty rules) so an operator can add audit grants later without
+schema-churn — and so the kustomize/flux audit always sees a paired
+trio (SA + Role + RoleBinding) for the workload.
+
+If a future enhancement teaches catalyst-catalog to read
+Blueprint.catalyst.openova.io CRs (e.g. for cluster-scoped catalog
+caching), grant the rule HERE in the chart, never in the binary.
+*/ -}}
+{{- if .Values.services.catalog.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "catalog.fullname" . }}
+  labels:
+    {{- include "catalog.labels" (dict "root" .) | nindent 4 }}
+rules: []
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "catalog.fullname" . }}
+  labels:
+    {{- include "catalog.labels" (dict "root" .) | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "catalog.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "catalog.fullname" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/products/catalyst/chart/templates/services/catalog/service.yaml
+++ b/products/catalyst/chart/templates/services/catalog/service.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.services.catalog.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "catalog.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "catalog.labels" (dict "root" .) | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http
+      protocol: TCP
+  selector:
+    {{- include "catalog.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/products/catalyst/chart/templates/services/catalog/serviceaccount.yaml
+++ b/products/catalyst/chart/templates/services/catalog/serviceaccount.yaml
@@ -1,0 +1,18 @@
+{{- /*
+ServiceAccount for catalyst-catalog (EPIC-2 Slice L of #1097).
+
+The catalog service does NOT touch the K8s API — it only makes outbound
+HTTP calls to the in-cluster Gitea Service. The SA is therefore minimal
+(no ClusterRole binding required for K8s resources). The Gitea API token
+is mounted as a Secret env-var, NOT via the SA token.
+*/ -}}
+{{- if .Values.services.catalog.enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "catalog.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "catalog.labels" (dict "root" .) | nindent 4 }}
+automountServiceAccountToken: false
+{{- end }}

--- a/products/catalyst/chart/values.yaml
+++ b/products/catalyst/chart/values.yaml
@@ -283,6 +283,66 @@ controllers:
     tolerations: []
     affinity: {}
 
+# ─── catalyst-catalog HTTP service (EPIC-2 Slice L, #1097) ───────────────
+# Multi-source Blueprint catalog backed by Gitea (3 sources: public mirror,
+# sovereign-curated, per-Org private). Fed by the unified Gitea client at
+# core/controllers/pkg/gitea (CC2 #1136). REPLACES the per-Org SME catalog
+# per ADR-0001 §4.3 (different scope: SME's was Org-bound; catalyst-catalog
+# is Sovereign-wide multi-source).
+#
+# Default OFF per docs/INVIOLABLE-PRINCIPLES.md (operators flip on per-
+# Sovereign once Gitea Orgs are provisioned). When OFF, helm template
+# emits ZERO catalog-related resources.
+services:
+  catalog:
+    enabled: false
+    image:
+      repository: "ghcr.io/openova-io/openova/catalyst-catalog"
+      # Empty `tag` fail-fasts at render time per Inviolable Principle #4a.
+      # CI stamps the SHA on every push to main via the catalyst-catalog
+      # GitHub Actions workflow.
+      tag: ""
+      pullPolicy: IfNotPresent
+    replicas: 1
+    # Gitea endpoint — empty defaults to in-cluster Service URL.
+    giteaURL: ""
+    # Secret + key holding the Gitea admin access token. Reuses the same
+    # secret as the Group C controllers — one rotation surface.
+    giteaSecretRef: "catalyst-gitea-token"
+    # Per-Org private blueprint repo name. One repo per Org (e.g.
+    # "acme/shared-blueprints").
+    orgPrivateRepo: "shared-blueprints"
+    # Public-mirror Gitea Org (always visible to every caller).
+    publicOrg: "catalog"
+    # Sovereign-curated Gitea Org (always visible to every caller).
+    sovereignOrg: "catalog-sovereign"
+    # Session cookie name (must match catalyst-api's IssueSessionCookie
+    # name; default matches catalyst-api 1.4.x).
+    sessionCookieName: "catalyst_session"
+    # When true, anonymous callers may list public + sovereign-curated
+    # blueprints (no per-Org private). Default false (closed).
+    anonymousReads: false
+    # In-memory LRU cache for blueprint.yaml reads.
+    cache:
+      ttlSeconds: 30
+      capacity: 1024
+    # Gateway API HTTPRoute — exposes /api/v1/catalog on the api.<sov>
+    # hostname. Disable here if the operator prefers to proxy catalog
+    # calls through catalyst-api instead (follow-up).
+    httpRoute:
+      enabled: true
+    resources:
+      requests:
+        cpu: 25m
+        memory: 64Mi
+      limits:
+        cpu: 250m
+        memory: 256Mi
+    env: {}
+    nodeSelector: {}
+    tolerations: []
+    affinity: {}
+
 # bp-catalyst-platform umbrella values
 #
 # As of 1.1.9 this umbrella ships ONLY the Catalyst-Zero control-plane


### PR DESCRIPTION
## Summary

EPIC-2 Slice L of #1097. Multi-source Blueprint catalog HTTP REST service backed by Gitea (3 sources: public mirror, sovereign-curated, per-Org private). Replaces the per-Org SME catalog per ADR-0001 §4.3.

- **L1**: `core/services/catalyst-catalog/` Go service. Separate go.mod (services group is for HTTP services, controllers group is for CRD reconcilers). Imports the unified Gitea client via `replace` directive after promoting `core/controllers/internal/gitea` → `pkg/gitea` (Go's `internal/` rule blocks cross-module imports). 5 Group C controllers updated atomically.
- **L2**: `products/catalyst/chart/templates/services/catalog/` — 5 templates + _helpers.tpl. Default-OFF gate. `helm template` renders 0 catalog resources OFF, 6 ON (SA, ClusterRole, ClusterRoleBinding, Service, Deployment, HTTPRoute).
- **Gitea seam extended (not duplicated)**: +`ListOrgRepos` and +`ListContents` on the unified client.
- **CI**: `.github/workflows/catalyst-catalog-build.yaml` — event-driven (push paths + PR + workflow_dispatch, NO cron). Builds + tests + GHCR push + repository_dispatch chart-bump fan-out.

L3 (SME catalog retirement) is deferred per the EPIC-2 master brief. GraphQL deferred (REST first).

## REST contract (consumed by EPIC-2 Slice I `useCatalog()`)

```
GET /api/v1/catalog?org=<slug>           → { "items": [Blueprint, ...] }
GET /api/v1/catalog/{name}               → Blueprint (with .raw)
GET /api/v1/catalog/{name}/versions      → { "name", "versions": [{version,origin,org}], "upgradeMatrix": {v: [from,...]} }
GET /api/v1/catalog/{name}/versions/{v}  → Blueprint (with .raw)
GET /healthz
```

`Blueprint` JSON shape:
```json
{ "name": "bp-wordpress", "version": "5.6.1", "visibility": "listed",
  "card": {"title", "summary", "description", "tagline", "icon", "category",
           "family", "tags": [...], "license", "docs"},
  "placementSchema": {"modes": [...], "default", "minRegions", "maxRegions"},
  "upgradeFrom": [...], "upgradeBlocks": [...],
  "origin": 3, "source": "org-private", "org": "acme", "raw": {...} }
```

`origin` = 1 (public) | 2 (sovereign) | 3 (org-private). `source` is the human-readable form. Resolution priority on collision: private > sovereign > public.

## Architecture compliance

- ADR-0001 §2.7: K8s-native — catalog data lives in Gitea, no separate database.
- ADR-0001 §4.3: REPLACES the SME catalog (different scope).
- INVIOLABLE-PRINCIPLES #1: target-state shape (3-source aggregator, priority-on-collision, per-Org access — no stub).
- INVIOLABLE-PRINCIPLES #4: every URL/Org/repo via env vars.
- INVIOLABLE-PRINCIPLES #4a: SHA-pinned image, GitHub-Actions-only build path.

## Test plan

- [x] `go test -count=1 -race ./...` clean (catalog service: config, cache, auth, source, handler).
- [x] `go test -count=1 -race ./pkg/gitea/...` clean (incl. new `ListOrgRepos` + `ListContents`).
- [x] `go vet ./...` clean for both modules.
- [x] All 5 Group C controllers still compile + test green after `internal/gitea` → `pkg/gitea` promotion.
- [x] `helm template` OFF: 0 catalog resources rendered.
- [x] `helm template` ON: 6 catalog resources rendered (SA + ClusterRole + ClusterRoleBinding + Service + Deployment + HTTPRoute).
- [x] `helm template` empty `image.tag` fails fast with the documented error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)