### PR TITLE
feat(continuum): K-Cont-1 — Continuum product skeleton (#1101)

### DIFF
--- a/.github/workflows/build-continuum-controller.yaml
+++ b/.github/workflows/build-continuum-controller.yaml
@@ -1,0 +1,206 @@
+name: Build continuum-controller
+
+# continuum-controller — slice K-Cont-1 of EPIC-6 (#1101). Watches
+# Continuum.dr.openova.io/v1 CRs and orchestrates per-Application DR.
+# K-Cont-1 ships the SKELETON; K-Cont-2 fills in the reconcile loop.
+#
+# Per docs/INVIOLABLE-PRINCIPLES.md #4a (GitHub Actions is the only
+# build path) every image that runs on OpenOva infra MUST be produced
+# by a CI workflow from a committed git SHA. Mirrors the existing
+# build-application-controller.yaml shape — same auth flow, same
+# cosign keyless signing, same SBOM attestation.
+#
+# Per `feedback_inviolable_principles.md`: event-driven only, NO cron.
+# Triggers on push-to-main with paths filter (so unrelated commits
+# don't burn CI minutes), pull_request for reviewers, and
+# workflow_dispatch for manual re-runs.
+
+on:
+  push:
+    paths:
+      - 'core/controllers/continuum/**'
+      - 'core/controllers/internal/**'
+      - 'core/controllers/go.mod'
+      - 'core/controllers/go.sum'
+      - 'products/continuum/**'
+      - '.github/workflows/build-continuum-controller.yaml'
+    branches: [main]
+  pull_request:
+    paths:
+      - 'core/controllers/continuum/**'
+      - 'core/controllers/internal/**'
+      - 'core/controllers/go.mod'
+      - 'core/controllers/go.sum'
+      - 'products/continuum/**'
+      - '.github/workflows/build-continuum-controller.yaml'
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE: ghcr.io/openova-io/openova/continuum-controller
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      # id-token write is required by cosign keyless signing (Sigstore).
+      id-token: write
+    outputs:
+      sha_short: ${{ steps.vars.outputs.sha_short }}
+      digest: ${{ steps.build.outputs.digest }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set short SHA
+        id: vars
+        run: echo "sha_short=$(echo $GITHUB_SHA | head -c 7)" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.23'
+          cache-dependency-path: |
+            core/controllers/go.sum
+
+      - name: go vet
+        working-directory: core/controllers
+        # Slice CC1 (#1095) consolidated the 5 Group C controllers into
+        # a single shared go.mod. K-Cont-1 (#1101) joined that module
+        # for Continuum's reconciler. Vet scoped to this controller's
+        # tree plus the shared internal/ helpers it depends on.
+        run: go vet ./continuum/... ./internal/...
+
+      - name: Run unit tests
+        working-directory: core/controllers
+        run: go test -count=1 -race ./continuum/... ./internal/...
+
+      - name: helm template — default (continuum.enabled=false → 0 resources)
+        run: |
+          set -euo pipefail
+          out=$(helm template bp-continuum products/continuum/chart/ --namespace openova-system)
+          # Render must produce ZERO resources when continuum.enabled=false.
+          # (helm prints `---` separators and possibly NOTES; a real K8s
+          # resource will have an `apiVersion:` line at column 0.)
+          if printf '%s\n' "$out" | grep -E '^apiVersion:' > /dev/null; then
+            echo "::error::default render produced resources but continuum.enabled=false should be a no-op"
+            printf '%s\n' "$out"
+            exit 1
+          fi
+
+      - name: helm template — enabled (continuum.enabled=true → full set)
+        run: |
+          set -euo pipefail
+          out=$(helm template bp-continuum products/continuum/chart/ \
+            --namespace openova-system \
+            --set continuum.enabled=true \
+            --set continuum.image.tag=ci-test)
+          # Expect: ServiceAccount + ClusterRole + ClusterRoleBinding +
+          # Deployment + Service + NetworkPolicy = 6 resources.
+          count=$(printf '%s\n' "$out" | grep -cE '^kind:' || true)
+          if [ "$count" -lt 6 ]; then
+            echo "::error::enabled render produced only $count resources, expected ≥ 6"
+            printf '%s\n' "$out"
+            exit 1
+          fi
+          echo "OK: enabled render produced $count resources"
+
+      - name: helm template — fail-fast on empty image.tag
+        run: |
+          set +e
+          helm template bp-continuum products/continuum/chart/ \
+            --namespace openova-system \
+            --set continuum.enabled=true 2>&1 | tee /tmp/render.out
+          rc=${PIPESTATUS[0]}
+          set -e
+          if [ "$rc" -eq 0 ]; then
+            echo "::error::expected helm template to FAIL when continuum.enabled=true and image.tag is empty"
+            exit 1
+          fi
+          if ! grep -q "image.tag is empty" /tmp/render.out; then
+            echo "::error::expected fail-fast error mentioning empty image.tag"
+            exit 1
+          fi
+          echo "OK: fail-fast on empty image.tag works"
+
+      # On pull_request runs we stop here — image push requires
+      # `packages: write` which only main-branch authors hold.
+      - name: Login to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        if: github.event_name != 'pull_request'
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push image
+        id: build
+        if: github.event_name != 'pull_request'
+        uses: docker/build-push-action@v6
+        with:
+          # Build context is the repository root so the Containerfile's
+          # COPY paths can reach core/controllers/continuum/.
+          context: .
+          file: core/controllers/continuum/Containerfile
+          push: true
+          tags: |
+            ${{ env.IMAGE }}:${{ steps.vars.outputs.sha_short }}
+            ${{ env.IMAGE }}:latest
+          labels: |
+            org.opencontainers.image.source=https://github.com/openova-io/openova
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.title=continuum-controller
+            org.opencontainers.image.description=Reconciles Continuum.dr.openova.io/v1 → per-Application DR orchestration (slice K-Cont-1 of EPIC-6 #1101)
+          # provenance=false: containerd 1.7.x on k3s mis-resolves the
+          # provenance attestation manifest. SBOM attestation handled by
+          # the cosign attest step below.
+          provenance: false
+          sbom: false
+
+      - name: Install cosign
+        if: github.event_name != 'pull_request'
+        uses: sigstore/cosign-installer@v3
+
+      - name: Sign image with cosign (keyless)
+        if: github.event_name != 'pull_request'
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          cosign sign --yes "${IMAGE}@${DIGEST}"
+
+      - name: Generate and attest SBOM
+        if: github.event_name != 'pull_request'
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          cosign attest --yes \
+            --predicate <(echo '{"sbom":"in-toto-spdx attached at build time"}') \
+            --type spdx \
+            "${IMAGE}@${DIGEST}"
+
+  notify:
+    # repository_dispatch on success → triggers downstream chart-bump
+    # workflow that stamps the image SHA into per-Sovereign overlay
+    # values.yaml. Same pattern the 5 Group C controllers use.
+    needs: build
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Dispatch chart-bump event
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SHA_SHORT: ${{ needs.build.outputs.sha_short }}
+        run: |
+          gh api repos/${{ github.repository }}/dispatches \
+            --method POST \
+            -f event_type=continuum-controller-built \
+            -F client_payload[sha]="${SHA_SHORT}" \
+            -F client_payload[image]="${{ env.IMAGE }}:${SHA_SHORT}"

--- a/core/controllers/continuum/Containerfile
+++ b/core/controllers/continuum/Containerfile
@@ -1,0 +1,60 @@
+# continuum-controller — slice K-Cont-1 of EPIC-6 (#1101).
+#
+# Watches Continuum.dr.openova.io/v1 CRs (and, in K-Cont-2, the
+# active-hotstandby Application CRs they reference) and orchestrates
+# per-Application DR. K-Cont-1 ships the binary skeleton + chart + CI
+# workflow; the Reconcile body itself lands in K-Cont-2.
+#
+# Per docs/INVIOLABLE-PRINCIPLES.md #4a (GitHub Actions is the only
+# build path) every image that runs on OpenOva infra MUST be produced
+# by a CI workflow from a committed git SHA. This Containerfile is
+# invoked by .github/workflows/build-continuum-controller.yaml with
+# the repository ROOT as the build context.
+#
+# Slice CC1 (#1095) consolidated the 5 Group C controllers under a
+# single shared go.mod at core/controllers/go.mod and shared helpers
+# under core/controllers/internal/. Per Option A in the K-Cont-1 brief,
+# Continuum's Go binary joins this same shared module — the chart +
+# Containerfile + DESIGN.md live at products/continuum/, but the Go
+# tree lives at core/controllers/continuum/. The COPY layout below
+# mirrors that.
+#
+# Two stages:
+#   build  — golang:1.23-alpine, vendored stdlib + module cache
+#   final  — alpine:3.20 minimal runtime (CA certs + the binary)
+
+FROM docker.io/library/golang:1.23-alpine AS build
+WORKDIR /workspace
+
+# Cache module downloads — go.mod/go.sum live at the shared module root.
+COPY core/controllers/go.mod core/controllers/go.sum core/controllers/
+
+WORKDIR /workspace/core/controllers
+RUN go mod download
+
+# Copy source + build. The shared internal/ packages and the per-
+# controller tree are both needed at compile time.
+WORKDIR /workspace
+COPY core/controllers/internal /workspace/core/controllers/internal
+COPY core/controllers/continuum /workspace/core/controllers/continuum
+
+WORKDIR /workspace/core/controllers/continuum
+RUN CGO_ENABLED=0 GOOS=linux go build \
+    -ldflags="-s -w" \
+    -o /continuum-controller ./cmd
+
+FROM docker.io/library/alpine:3.20
+
+# CA certs for HTTPS calls to PDM, the lease witness (Cloudflare KV),
+# and cross-Sovereign instances. tzdata so log timestamps render
+# correctly.
+RUN apk add --no-cache ca-certificates tzdata
+
+COPY --from=build /continuum-controller /continuum-controller
+
+# UID 65534 (nobody on Alpine 3.20) — non-root, satisfies the
+# `runAsNonRoot: true` securityContext check k8s requires when the
+# spec uses numeric form (not the name `nobody`).
+USER 65534:65534
+
+ENTRYPOINT ["/continuum-controller"]

--- a/core/controllers/continuum/cmd/main.go
+++ b/core/controllers/continuum/cmd/main.go
@@ -1,0 +1,157 @@
+// Command continuum-controller — slice K-Cont-1 of EPIC-6 (#1101).
+//
+// Watches `Continuum.dr.openova.io/v1` CRs (and, in K-Cont-2, the
+// `active-hotstandby` Application CRs they reference) and orchestrates
+// per-Application DR — lease maintenance, replication-health watching,
+// switchover sequence per docs/SRE.md §2 + docs/MULTI-REGION-DNS.md.
+//
+// K-Cont-1 ships the binary + chart + CI workflow ONLY — the
+// Reconcile() body is a no-op. The reconcile loop lands in K-Cont-2
+// (lease witness wiring is K-Cont-3, Cloudflare Worker source is
+// K-Cont-4). Per INVIOLABLE-PRINCIPLES #1 the FULL chart + binary
+// shape ships first time so K-Cont-2 only needs to fill in the
+// Reconcile body without restructuring.
+//
+// Configuration is environment-only — per
+// docs/INVIOLABLE-PRINCIPLES.md #4 nothing is hardcoded:
+//
+//	METRICS_ADDR        — :8080 default; metrics endpoint
+//	HEALTH_ADDR         — :8081 default; /healthz + /readyz
+//	LEADER_ELECT        — "true" | "false" (default true in-cluster)
+//	LEADER_ELECT_NS     — namespace for the leader-election Lease
+//	                       (default: in-cluster pod namespace; falls
+//	                       back to "openova-system" if unreadable)
+//	LOG_LEVEL           — debug | info | warn | error (default info)
+//
+// Sketches for K-Cont-2 + K-Cont-3 env vars (DESIGN.md captures the
+// full list — out of scope for K-Cont-1):
+//
+//	PDM_API_URL         — pool-domain-manager /v1/commit endpoint
+//	NATS_URL            — for catalyst.audit publishing
+//	LEASE_TTL_SECONDS   — default 30
+//	LEASE_RENEW_SECONDS — default 10
+//	WITNESS_KIND        — cloudflare-kv | dns-quorum
+//	WITNESS_CONFIG_*    — per-kind config (read from Continuum CR
+//	                       spec.leaseClient.config, not env)
+//
+// The binary uses controller-runtime's Manager which gives leader
+// election (Lease-backed), graceful shutdown on SIGINT/SIGTERM, and a
+// shared informer cache for all watched kinds.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+
+	"github.com/openova-io/openova/core/controllers/continuum/internal/controller"
+)
+
+var scheme = runtime.NewScheme()
+
+func init() {
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+}
+
+func main() {
+	var (
+		metricsAddr          string
+		probeAddr            string
+		enableLeaderElection bool
+		leaderElectNS        string
+	)
+	flag.StringVar(&metricsAddr, "metrics-bind-address", env("METRICS_ADDR", ":8080"), "Address the metric endpoint binds to.")
+	flag.StringVar(&probeAddr, "health-probe-bind-address", env("HEALTH_ADDR", ":8081"), "Address the probe endpoint binds to.")
+	flag.BoolVar(&enableLeaderElection, "leader-elect", envBool("LEADER_ELECT", true), "Enable leader election for the controller manager.")
+	flag.StringVar(&leaderElectNS, "leader-elect-namespace", env("LEADER_ELECT_NS", podNamespace()), "Namespace for the leader-election Lease.")
+	opts := zap.Options{Development: false}
+	opts.BindFlags(flag.CommandLine)
+	flag.Parse()
+
+	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
+
+	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
+		Scheme: scheme,
+		Metrics: metricsserver.Options{
+			BindAddress: metricsAddr,
+		},
+		HealthProbeBindAddress:  probeAddr,
+		LeaderElection:          enableLeaderElection,
+		LeaderElectionID:        "continuum-controller.openova.io",
+		LeaderElectionNamespace: leaderElectNS,
+	})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "manager init: %v\n", err)
+		os.Exit(1)
+	}
+
+	r := &controller.ContinuumReconciler{
+		Client: mgr.GetClient(),
+		Scheme: mgr.GetScheme(),
+	}
+	if err := r.SetupWithManager(mgr); err != nil {
+		fmt.Fprintf(os.Stderr, "setup reconciler: %v\n", err)
+		os.Exit(1)
+	}
+
+	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
+		fmt.Fprintf(os.Stderr, "healthz: %v\n", err)
+		os.Exit(1)
+	}
+	if err := mgr.AddReadyzCheck("readyz", healthz.Ping); err != nil {
+		fmt.Fprintf(os.Stderr, "readyz: %v\n", err)
+		os.Exit(1)
+	}
+
+	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
+		fmt.Fprintf(os.Stderr, "manager exit: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+// env reads a string env var with a default fallback.
+func env(key, fallback string) string {
+	if v, ok := os.LookupEnv(key); ok && v != "" {
+		return v
+	}
+	return fallback
+}
+
+// envBool reads a bool env var; the empty value or invalid input
+// returns the fallback.
+func envBool(key string, fallback bool) bool {
+	v, ok := os.LookupEnv(key)
+	if !ok {
+		return fallback
+	}
+	switch v {
+	case "true", "1", "yes":
+		return true
+	case "false", "0", "no":
+		return false
+	default:
+		return fallback
+	}
+}
+
+// podNamespace reads /var/run/secrets/kubernetes.io/serviceaccount/namespace
+// (the in-cluster ServiceAccount projection). When run out of cluster
+// (`go run ./cmd`) it falls back to "openova-system" — the canonical
+// home for Catalyst control-plane components per
+// docs/EPICS-1-6-unified-design.md §1.2.
+func podNamespace() string {
+	const path = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return "openova-system"
+	}
+	return string(b)
+}

--- a/core/controllers/continuum/internal/controller/continuum_controller.go
+++ b/core/controllers/continuum/internal/controller/continuum_controller.go
@@ -1,0 +1,123 @@
+// Package controller — continuum-controller reconciler.
+//
+// Reconciles `Continuum.dr.openova.io/v1` CRs into per-Application DR
+// orchestration: lease maintenance, replication-health watching, and
+// switchover sequence (drain HTTP traffic via HTTPRoute weight=0,
+// flip lua-record probe target via PDM /v1/commit, flip CNPG primary,
+// publish audit event on NATS `catalyst.audit`).
+//
+// K-Cont-1 (this slice) ships the SKELETON ONLY. Reconcile() is a
+// no-op that logs at V(1). The full reconcile loop — lease state
+// machine, switchover sequencer, lua-record body synthesizer — lands
+// in K-Cont-2 (#1101). The lease-witness client (Cloudflare KV +
+// 3-DNS quorum fallback) lands in K-Cont-3.
+//
+// Per docs/INVIOLABLE-PRINCIPLES.md #3 + ADR-0001 §2.7 (matching the
+// pattern of all 5 Catalyst controllers + useraccess-controller) the
+// CRD shape is owned by the chart and authored by hand. We do NOT
+// generate Go types via controller-gen. The dynamic client +
+// `unstructured.Unstructured` suffices for read/write needs and
+// avoids a code-generation step in the build pipeline.
+//
+// Wire shape mirrors the existing CRD at
+//
+//	products/catalyst/chart/crds/continuum.yaml
+//
+// The Continuum CR is namespaced (per the CRD: scope=Namespaced) and
+// the reconciler watches every namespace. Per-Continuum-CR state
+// (lease holder, last-renew time, switchover in-flight) lives in
+// memory in K-Cont-2; on controller restart the lease is re-acquired
+// from the witness if quorum says we still hold it, else relinquished.
+package controller
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Continuum GVK / GVR — pinned to the CRD shipped by
+// products/catalyst/chart/crds/continuum.yaml. A drift here vs the
+// chart YAML is a packaging bug and surfaces as a 404 on the dynamic
+// client at startup.
+const (
+	ContinuumGroup    = "dr.openova.io"
+	ContinuumVersion  = "v1"
+	ContinuumKind     = "Continuum"
+	ContinuumListKind = "ContinuumList"
+	ContinuumResource = "continuums"
+)
+
+// ContinuumGVR is consumed by the dynamic client + by tests building
+// fake clients.
+var ContinuumGVR = schema.GroupVersionResource{
+	Group:    ContinuumGroup,
+	Version:  ContinuumVersion,
+	Resource: ContinuumResource,
+}
+
+// continuumGVK is the corresponding GroupVersionKind, used to set up
+// the controller-runtime watch via unstructured.Unstructured.
+var continuumGVK = schema.GroupVersionKind{
+	Group:   ContinuumGroup,
+	Version: ContinuumVersion,
+	Kind:    ContinuumKind,
+}
+
+// ContinuumReconciler is the no-op skeleton for K-Cont-1. K-Cont-2
+// extends this with:
+//   - PDMClient: pool-domain-manager /v1/commit client
+//   - NATSPublisher: catalyst.audit event publisher
+//   - WitnessClient: lease witness (cloudflare-kv | dns-quorum) — wired
+//     in K-Cont-3
+//   - per-Continuum-CR goroutine map keyed by NamespacedName
+type ContinuumReconciler struct {
+	client.Client
+	Scheme *runtime.Scheme
+}
+
+// Reconcile is a no-op for K-Cont-1. K-Cont-2 ships the actual
+// reconcile loop:
+//
+//  1. Fetch the Continuum CR (namespaced). Not-found → cancel any
+//     running per-CR goroutine + relinquish lease.
+//  2. Validate the referenced Application has placement:
+//     active-hotstandby. Otherwise → status.phase=Failed.
+//  3. Validate primaryRegion ∈ Application.spec.regions[].
+//  4. Start (or update) the per-CR goroutine that:
+//     - acquires the lease via WitnessClient
+//     - watches CNPG `cnpg.io/cluster.replicationLag` per replica
+//     - on autoFailover trigger or operator-initiated switchover,
+//     executes the §9.3 sequence
+//  5. Patch status (phase, primaryRegion, leaseHolder, leaseExpiresAt,
+//     replicationLag map, conditions).
+func (r *ContinuumReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	log := ctrl.LoggerFrom(ctx)
+	log.V(1).Info("continuum reconcile (skeleton K-Cont-1 — no-op)",
+		"namespace", req.Namespace,
+		"name", req.Name)
+	return ctrl.Result{}, nil
+}
+
+// SetupWithManager wires the reconciler into the controller-runtime
+// Manager. K-Cont-1 watches Continuum CRs only — K-Cont-2 will add
+// `Watches(&unstructured.Unstructured{...Application}, ...)` for the
+// referenced active-hotstandby Application CRs (with EnqueueRequestsFromMapFunc
+// translating Application name → owning Continuum CR).
+//
+// The watch uses unstructured.Unstructured per ADR-0001 §2.7 — no
+// generated types, no controller-gen. The Manager's caching layer
+// works fine with unstructured.
+func (r *ContinuumReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	u := &unstructured.Unstructured{}
+	u.SetGroupVersionKind(continuumGVK)
+
+	return ctrl.NewControllerManagedBy(mgr).
+		Named("continuum").
+		For(u).
+		Complete(r)
+}

--- a/core/controllers/continuum/internal/controller/continuum_controller_test.go
+++ b/core/controllers/continuum/internal/controller/continuum_controller_test.go
@@ -1,0 +1,78 @@
+// Reconcile() skeleton smoke test for K-Cont-1.
+//
+// K-Cont-1 ships a NO-OP Reconcile(); the only invariant we can
+// assert here is that calling Reconcile against an empty/missing CR
+// does not panic and returns no error + no requeue. K-Cont-2 will
+// replace this with envtest-backed integration tests covering the
+// lease / switchover / replication-watch state machine.
+package controller
+
+import (
+	"context"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestReconcile_Skeleton_NoOp_NoCR(t *testing.T) {
+	t.Parallel()
+
+	s := newScheme(t)
+	c := fake.NewClientBuilder().WithScheme(s).Build()
+	r := &ContinuumReconciler{Client: c, Scheme: s}
+
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Namespace: "openova-system", Name: "missing"},
+	})
+	if err != nil {
+		t.Fatalf("Reconcile returned error: %v", err)
+	}
+	if res.RequeueAfter != 0 || res.Requeue {
+		t.Fatalf("expected zero-value Result, got %+v", res)
+	}
+}
+
+func TestReconcile_Skeleton_NoOp_WithCR(t *testing.T) {
+	t.Parallel()
+
+	cr := &unstructured.Unstructured{}
+	cr.SetGroupVersionKind(continuumGVK)
+	cr.SetName("test-continuum")
+	cr.SetNamespace("openova-system")
+	cr.Object["spec"] = map[string]any{
+		"applicationRef":    "demo-app",
+		"primaryRegion":     "hz-fsn-rtz-prod",
+		"hotStandbyRegions": []any{"hz-hel-rtz-prod"},
+		"leaseClient": map[string]any{
+			"kind": "cloudflare-kv",
+		},
+	}
+
+	s := newScheme(t)
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(cr).Build()
+	r := &ContinuumReconciler{Client: c, Scheme: s}
+
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Namespace: "openova-system", Name: "test-continuum"},
+	})
+	if err != nil {
+		t.Fatalf("Reconcile returned error: %v", err)
+	}
+	if res.RequeueAfter != 0 || res.Requeue {
+		t.Fatalf("expected zero-value Result, got %+v", res)
+	}
+}
+
+func newScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(s); err != nil {
+		t.Fatalf("add clientgo scheme: %v", err)
+	}
+	return s
+}

--- a/core/controllers/continuum/internal/events/doc.go
+++ b/core/controllers/continuum/internal/events/doc.go
@@ -1,0 +1,36 @@
+// Package events is a placeholder for the K-Cont-2 NATS audit
+// publisher.
+//
+// K-Cont-2 will land a publisher that emits the following audit
+// event types onto the `catalyst.audit` JetStream subject (per
+// docs/EPICS-1-6-unified-design.md §9 + master-brief F-1):
+//
+//	continuum-switchover-started
+//	continuum-switchover-completed
+//	continuum-switchover-failed
+//	continuum-failback-started
+//	continuum-failback-completed
+//	continuum-lease-acquired
+//	continuum-lease-lost
+//	continuum-replication-degraded
+//	continuum-replication-recovered
+//
+// Event payload shape (draft, finalized in K-Cont-2):
+//
+//	{
+//	  "type":           "continuum-switchover-completed",
+//	  "continuumRef":   "<namespace>/<name>",
+//	  "applicationRef": "<namespace>/<name>",
+//	  "from":           "<region>",
+//	  "to":             "<region>",
+//	  "reason":         "operator | auto-failover | lease-loss",
+//	  "rtoObserved":    "23s",
+//	  "rpoObserved":    "0s",
+//	  "initiatedBy":    "<user-email> | auto-failover",
+//	  "ts":             "<RFC3339>"
+//	}
+//
+// The U-DR-1 UI subscribes to `catalyst.audit` filtered by
+// `audit-type=continuum-*` to render the switchover history panel
+// (master-brief U-DR-1).
+package events

--- a/products/continuum/DESIGN.md
+++ b/products/continuum/DESIGN.md
@@ -1,0 +1,158 @@
+# Continuum — Design Notes (K-Cont-1)
+
+This file captures the architectural decisions made by slice K-Cont-1
+of EPIC-6 (#1101). It is the entry point for the K-Cont-2, K-Cont-3,
+and K-Cont-4 implementers.
+
+## Module split — chart vs binary
+
+Per ADR-0001 §3.2.8, Continuum is a **customer-facing capability**, so
+the product lives at `products/continuum/`. But Continuum is *also* a
+controller-runtime reconciler that wants to share `internal/labels`,
+`internal/placement`, `pkg/gitea`, and the same canonical
+controller-runtime scaffolding as the 5 Group C controllers.
+
+We pick **Option A** from the K-Cont-1 brief: the **Go binary lives
+under the shared `core/controllers/` module**, and the
+**chart + Containerfile + DESIGN** live under `products/continuum/`:
+
+```
+core/controllers/
+├── go.mod                                        # ONE module (CC1)
+├── internal/{labels,semver,placement,render}/    # SHARED helpers
+├── pkg/gitea/                                    # SHARED Gitea client
+├── application/cmd/main.go                       # slice C4
+├── ...                                           # slices C1–C5
+└── continuum/                                    # NEW — K-Cont-1
+    ├── cmd/main.go
+    ├── internal/controller/continuum_controller.go
+    ├── internal/events/                          # placeholder K-Cont-2
+    └── Containerfile
+
+products/continuum/
+├── DESIGN.md                                     # this file
+└── chart/
+    ├── Chart.yaml                                # bp-continuum 0.1.0
+    ├── values.yaml                               # default-OFF
+    ├── crds/README.md                            # CRD lives in catalyst chart
+    ├── templates/{_helpers.tpl,deployment,service,
+    │              serviceaccount,rbac,networkpolicy}.yaml
+    ├── blueprint.yaml                            # OpenOva Blueprint manifest
+    └── README.md
+```
+
+This split mirrors the precedent set by `core/services/catalyst-catalog/`
+(the Slice L pattern): controllers / services that are part of the
+shared module live under `core/`, while customer-facing chart +
+Blueprint metadata lives under `products/`.
+
+If product separation requires real module isolation later (e.g. a
+go-private build flag, or a dependency the other 5 controllers
+shouldn't pull), a future slice can split this out — same trade-off
+Slice L navigated for catalog-svc. Until then, sharing the module is
+the cleanest path.
+
+## What K-Cont-1 ships (skeleton ONLY)
+
+- `cmd/main.go` — controller-runtime Manager bootstrap; leader
+  election; `/healthz`, `/readyz`, `/metrics`.
+- `internal/controller/continuum_controller.go` — `ContinuumReconciler`
+  with a no-op `Reconcile()` and a `SetupWithManager()` watching the
+  Continuum GVR via `unstructured.Unstructured` (per ADR-0001 §2.7 —
+  no `controller-gen`).
+- `internal/events/` — placeholder package with audit-event-type list
+  for K-Cont-2 NATS publisher.
+- `Containerfile` — multi-stage Go build → alpine runtime, UID 65534.
+- `chart/` — full Helm chart shape: deployment, service, SA, RBAC,
+  NetworkPolicy, blueprint.yaml. Default-OFF (`continuum.enabled:
+  false`); fail-fast on empty `image.tag` (per Inviolable Principle
+  #4a — no `:latest` in production).
+- `.github/workflows/build-continuum-controller.yaml` — event-driven
+  CI workflow (NO cron) mirroring the 5 sibling controllers'
+  per-controller workflows.
+
+## What K-Cont-2 fills in
+
+The Reconcile body. Concretely:
+
+1. **Per-Continuum-CR goroutine map** keyed by NamespacedName. On a
+   Reconcile that surfaces a CR the controller hasn't seen, start a
+   long-lived goroutine that maintains the lease (10s renew, 30s
+   TTL), watches CNPG `cnpg.io/cluster.replicationLag` per replica,
+   and emits status updates. On Reconcile-after-deletion, cancel the
+   goroutine + release the lease.
+2. **Application validation**: fetch the referenced Application,
+   confirm `spec.placement == active-hotstandby` and
+   `spec.regions[] ⊇ {primaryRegion} ∪ hotStandbyRegions`. On
+   mismatch, set `status.phase=Failed` + Condition Ready=False.
+3. **Lease state machine**: Pending → Acquiring → Healthy → Renewing
+   loop; lease loss → Degraded → re-acquire or relinquish.
+4. **Switchover sequencer** per `docs/EPICS-1-6-unified-design.md`
+   §9.3 step-by-step.
+5. **Status writer**: phase, primaryRegion, leaseHolder,
+   leaseExpiresAt, replicationLag map, lastSwitchover, conditions,
+   observedGeneration.
+6. **NATS audit publisher** (`internal/events/` package fills out).
+
+## What K-Cont-3 fills in (lease witness)
+
+The `WitnessClient` interface (sketched in `chart/README.md`) and two
+implementations:
+
+- **cloudflare-kv** — POSTs to a Worker URL with a CF API token from a
+  SealedSecret reference. Worker enforces TTL + atomic CAS via KV.
+- **dns-quorum** — TXT-record reads against 3 resolvers (8.8.8.8 /
+  1.1.1.1 / 9.9.9.9), 2-of-3 voting, with fence-token expiry. The
+  controller writes the TXT record by calling PDM `/v1/commit` (same
+  client K-Cont-2 uses for lua-records).
+
+K-Cont-3 also wires the SealedSecret reference for the CF API token —
+per CLAUDE.md credential-hygiene rules, the plaintext token never
+appears in the Continuum CR.
+
+## What K-Cont-4 fills in (Cloudflare Worker)
+
+The TypeScript Worker source + tofu deploy module. The Worker exposes
+a small API (acquire / renew / release / read) backed by a CF KV
+namespace + a Durable Object for atomic CAS. Deployed via the existing
+`tofu apply` pattern that already manages our Cloudflare zones
+(MULTI-REGION-DNS.md §3).
+
+## Lease witness API contract — sketch for K-Cont-2
+
+K-Cont-2 wires its switchover sequencer against a `WitnessClient`
+interface with the methods sketched in `chart/README.md`. K-Cont-2
+ships an in-memory stub for tests; K-Cont-3 swaps in the real CF-KV
++ DNS-quorum clients.
+
+## RBAC — least-privilege today, extension list for K-Cont-2
+
+K-Cont-1 ships:
+
+- `continuums.dr.openova.io` get/list/watch/update/patch + status +
+  finalizers
+- `applications.apps.openova.io` get/list/watch (read-only — K-Cont-2
+  may upgrade to update for primaryRegion writes)
+- `httproutes.gateway.networking.k8s.io` get/list/watch
+- `coordination.k8s.io/leases` full (leader election)
+- `""/namespaces` get/list/watch
+- `""/events` create/patch
+
+K-Cont-2 will EXTEND with:
+
+- `clusters.postgresql.cnpg.io` get/list/watch + patch on annotations
+- `clusters.postgresql.cnpg.io/status` get
+- `httproutes.*` update/patch (weight=0 drain at switchover)
+- `""/configmaps` full (per-CR state)
+- `""/secrets` get (CF KV token, PDM token)
+
+## Out of scope (per the K-Cont-1 brief)
+
+- Reconcile body (K-Cont-2)
+- Lease witness implementations (K-Cont-3)
+- Cloudflare Worker source (K-Cont-4)
+- bp-cnpg-pair Blueprint (C-DB-1)
+- Application controller changes (C4 final)
+- UI (U-DR-1)
+
+— K-Cont-1 (#1101)

--- a/products/continuum/chart/Chart.yaml
+++ b/products/continuum/chart/Chart.yaml
@@ -1,0 +1,30 @@
+apiVersion: v2
+name: bp-continuum
+description: |
+  OpenOva Continuum — DR orchestration for active-hotstandby
+  Applications. Watches Continuum.dr.openova.io/v1 CRs and orchestrates
+  per-Application DR (lease maintenance, replication-health watch,
+  switchover sequence). Slice K-Cont-1 of EPIC-6 (#1101) ships the
+  product skeleton; K-Cont-2 fills the reconcile loop.
+type: application
+version: 0.1.0
+appVersion: "0.1.0"
+home: https://openova.io
+sources:
+  - https://github.com/openova-io/openova/tree/main/products/continuum
+keywords:
+  - openova
+  - catalyst
+  - continuum
+  - dr
+  - disaster-recovery
+  - multi-region
+  - active-hotstandby
+maintainers:
+  - name: OpenOva
+    email: hati.yildiz@openova.io
+annotations:
+  openova.io/product: continuum
+  openova.io/category: customer-facing-capability
+  openova.io/epic: "6"
+  openova.io/depends-on: bp-cnpg-pair,bp-powerdns,pdm

--- a/products/continuum/chart/README.md
+++ b/products/continuum/chart/README.md
@@ -1,0 +1,106 @@
+# bp-continuum
+
+OpenOva Continuum — DR orchestration for active-hotstandby
+Applications. Slice K-Cont-1 of EPIC-6 (#1101).
+
+## What this ships
+
+K-Cont-1 ships the **skeleton**: chart + Containerfile + binary
+scaffold + GHA workflow. The Reconcile() body is a no-op. K-Cont-2
+fills in the reconcile loop:
+
+- per-Continuum-CR goroutine maintaining a lease (10s renew, 30s TTL)
+- watches CNPG replication metrics
+- switchover sequencer (drain HTTPRoute → flip lua-record → flip CNPG
+  primary → audit on NATS)
+- failback handler (manual approval gate)
+
+K-Cont-3 wires the lease witness (Cloudflare KV per SRE.md §2.4, with
+3-DNS-quorum fallback). K-Cont-4 ships the Cloudflare Worker source.
+
+## Install
+
+```bash
+# Default-OFF gate keeps the controller stopped until the operator
+# installs bp-cnpg-pair + bp-powerdns and configures the witness.
+helm install bp-continuum ./products/continuum/chart \
+  --namespace openova-system \
+  --create-namespace
+```
+
+To enable on a per-Sovereign overlay:
+
+```yaml
+# clusters/<sovereign>/values-continuum.yaml
+continuum:
+  enabled: true
+  image:
+    tag: "<sha-stamped-by-CI>"
+  pdmURL: "http://pool-domain-manager.openova-system.svc.cluster.local:8080"
+  natsURL: "nats://nats.openova-system.svc.cluster.local:4222"
+```
+
+## CRD
+
+The `Continuum.dr.openova.io/v1` CRD lives in the Catalyst chart at
+`products/catalyst/chart/crds/continuum.yaml` (slice B8 of EPIC-0,
+#1110). It is **not duplicated** here — see `crds/README.md`.
+
+## Reconcile contract (K-Cont-2)
+
+The K-Cont-2 reconciler will:
+
+1. Fetch the Continuum CR. Validate the referenced Application has
+   `placement: active-hotstandby`. Validate `primaryRegion` ∈
+   `Application.spec.regions[]`.
+2. Acquire / renew the lease via the witness (kind from
+   `spec.leaseClient.kind`).
+3. Watch CNPG `cnpg.io/cluster.replicationLag` per replica.
+4. On switchover (operator-initiated or auto-failover when health
+   check + witness quorum agree primary is unreachable), execute the
+   sequence in `docs/EPICS-1-6-unified-design.md` §9.3.
+5. Patch status (phase, primaryRegion, leaseHolder, leaseExpiresAt,
+   replicationLag map, conditions, lastSwitchover).
+
+## Reading order for K-Cont-2 implementer
+
+1. `docs/EPICS-1-6-unified-design.md` §9 (full Continuum DR spec)
+2. `docs/SRE.md` §2 (DR runbook + lease witness pattern)
+3. `docs/MULTI-REGION-DNS.md` (lua-record DNS pattern)
+4. `products/catalyst/chart/crds/continuum.yaml` (CRD shape)
+5. `core/controllers/continuum/DESIGN.md` (this slice's design notes)
+6. `core/controllers/internal/placement/` (Plan + RegionPlan — reuse
+   for failover region resolution)
+
+## Lease witness API contract (K-Cont-3 sketch)
+
+The K-Cont-2 reconciler talks to a `WitnessClient` interface; K-Cont-3
+will land the cloudflare-kv + dns-quorum implementations. Sketched
+shape (subject to finalization in K-Cont-3):
+
+```go
+type WitnessClient interface {
+    // Acquire attempts to claim the lease for `holder` with the
+    // configured TTL. Returns the granted lease (with lease-id +
+    // expiry) or an error. ErrLeaseHeldByAnother is returned when
+    // another holder already owns the lease.
+    Acquire(ctx context.Context, key string, holder string, ttl time.Duration) (Lease, error)
+
+    // Renew extends the lease for the same holder. Returns
+    // ErrLeaseLost if the lease was reassigned.
+    Renew(ctx context.Context, lease Lease) (Lease, error)
+
+    // Release relinquishes the lease. Idempotent — releasing a lost
+    // lease is not an error.
+    Release(ctx context.Context, lease Lease) error
+
+    // Read returns the current lease holder + expiry without
+    // attempting to acquire. Used for diagnostic / dry-run.
+    Read(ctx context.Context, key string) (LeaseInfo, error)
+}
+```
+
+K-Cont-2 wires against this interface with a stub implementation;
+K-Cont-3 swaps in the real cloudflare-kv + dns-quorum clients.
+
+— K-Cont-1 (#1101)

--- a/products/continuum/chart/blueprint.yaml
+++ b/products/continuum/chart/blueprint.yaml
@@ -1,0 +1,86 @@
+apiVersion: catalyst.openova.io/v1alpha1
+kind: Blueprint
+metadata:
+  name: bp-continuum
+  labels:
+    catalyst.openova.io/section: pts-9-disaster-recovery
+    openova.io/category: customer-facing-capability
+spec:
+  version: 0.1.0
+  card:
+    title: Continuum
+    summary: |
+      DR orchestration for active-hotstandby Applications. Watches
+      Continuum.dr.openova.io/v1 CRs, maintains a multi-region lease,
+      observes CNPG replication health, and executes the switchover
+      sequence (drain HTTPRoute → flip lua-record → flip CNPG primary
+      → audit on NATS) per docs/SRE.md §2 + docs/MULTI-REGION-DNS.md.
+    icon: continuum.svg
+    category: disaster-recovery
+  visibility: listed
+
+  # K-Cont-1 ships the SKELETON — operators install but flip
+  # `continuum.enabled` only once dependencies (bp-cnpg-pair,
+  # bp-powerdns, lease witness) are ready. K-Cont-2 fills the
+  # reconcile loop; downstream slices wire the witness + worker.
+  configSchema:
+    type: object
+    properties:
+      continuum:
+        type: object
+        properties:
+          enabled:
+            type: boolean
+            default: false
+            description: |
+              Default-OFF gate. Flip true on a per-Sovereign overlay
+              once bp-cnpg-pair + bp-powerdns + lease witness are
+              ready.
+          replicas:
+            type: integer
+            default: 1
+            minimum: 1
+            description: |
+              Replica count for the controller Deployment. Leader
+              election ensures only one Pod reconciles at a time;
+              spare replicas exist for HA.
+          pdmURL:
+            type: string
+            description: |
+              pool-domain-manager /v1/commit endpoint. Empty = use
+              the in-cluster Service default. Per Inviolable
+              Principle #4 fully runtime-configurable.
+          natsURL:
+            type: string
+            description: |
+              NATS endpoint for catalyst.audit publishing. Empty =
+              use the in-cluster default.
+
+  placementSchema:
+    # Continuum is itself a single-region controller — it lives on the
+    # MANAGEMENT cluster (per docs/EPICS-1-6-unified-design.md §9) and
+    # observes data-plane regions over Cilium ClusterMesh + the witness.
+    # The Application CRs it reconciles are active-hotstandby; the
+    # Continuum controller itself is single-region.
+    modes: [single-region]
+    minRegions: 1
+    maxRegions: 1
+
+  manifests:
+    chart: ./
+
+  depends:
+    # bp-cnpg-pair (C-DB-1) is the proof-point Postgres workload:
+    # primary in fsn, replica in hel via WAL streaming over Cilium
+    # ClusterMesh.
+    - blueprint: bp-cnpg-pair
+      version: ^0
+      alias: cnpg
+    # bp-powerdns + the in-cluster pool-domain-manager service are
+    # how we flip lua-record probe targets at switchover time.
+    - blueprint: bp-powerdns
+      version: ^1
+      alias: dns
+
+  upgrades:
+    from: []

--- a/products/continuum/chart/crds/README.md
+++ b/products/continuum/chart/crds/README.md
@@ -1,0 +1,20 @@
+# Continuum CRD
+
+The `Continuum.dr.openova.io/v1` CRD lives at
+`products/catalyst/chart/crds/continuum.yaml` and is shipped via the
+Catalyst platform chart (slice B8 of EPIC-0, merged via #1110).
+
+It is **NOT duplicated here** — duplicating CRDs across charts causes
+the helm-controller / kustomize-controller ownership flap that bit
+sovereign-wildcard-tls (see `products/catalyst/chart/values.yaml`
+comment on `parentZones`).
+
+If a future change makes Continuum installable on a cluster that
+doesn't run the Catalyst chart, that's the moment to extract the CRD
+into a shared location (e.g. a `bp-openova-crds` chart) — NOT to
+duplicate it here.
+
+This directory exists only to make the layout obvious to operators who
+read `helm show crds bp-continuum`. The empty `crds/` is intentional.
+
+— K-Cont-1 (#1101)

--- a/products/continuum/chart/templates/_helpers.tpl
+++ b/products/continuum/chart/templates/_helpers.tpl
@@ -1,0 +1,68 @@
+{{/*
+Helpers for bp-continuum (slice K-Cont-1 of EPIC-6 #1101).
+
+Same conventions as the 5 Group C controllers' chart helpers
+(products/catalyst/chart/templates/controllers/_helpers.tpl):
+
+  - Image refs come from `.Values.continuum.image.{repository,tag,pullPolicy}`
+    with NO :latest fallback. If `tag` is empty the chart fails-fast at
+    render time so the operator sees the misconfig BEFORE the Pod
+    crashlooping. CI stamps the SHA on every push to main per
+    docs/INVIOLABLE-PRINCIPLES.md #4a.
+  - ServiceAccount / ClusterRole / ClusterRoleBinding / Deployment names
+    follow `continuum-controller` (no `bp-` prefix on K8s resource names).
+  - Standard pod-security shape: runAsNonRoot, runAsUser=65534,
+    seccompProfile RuntimeDefault, drop ALL caps, readOnlyRootFilesystem.
+  - Resources/requests + limits set per Inviolable Principle #4 (no
+    unbounded pods).
+*/}}
+
+{{/* Canonical name for every K8s object the chart renders. */}}
+{{- define "continuum.fullname" -}}
+continuum-controller
+{{- end -}}
+
+{{/* Standard labels applied to every Continuum resource. */}}
+{{- define "continuum.labels" -}}
+app.kubernetes.io/name: continuum-controller
+app.kubernetes.io/component: controller
+app.kubernetes.io/part-of: continuum
+app.kubernetes.io/managed-by: {{ .Release.Service | default "Helm" }}
+catalyst.openova.io/controller: continuum
+openova.io/product: continuum
+{{- end -}}
+
+{{/* Selector labels (subset that does not change between releases). */}}
+{{- define "continuum.selectorLabels" -}}
+app.kubernetes.io/name: continuum-controller
+app.kubernetes.io/component: controller
+catalyst.openova.io/controller: continuum
+{{- end -}}
+
+{{/*
+Resolve the image reference for the continuum-controller. Fail-fast
+when image.tag is empty (per Inviolable Principle #4a — no :latest in
+production). Honours `.Values.global.imageRegistry` rewrite when set
+(Sovereign-local Harbor proxy_cache; same pattern catalyst chart uses).
+
+Param shape: `dict "root" .` — root context (so we can read both
+`.Values.continuum.image.*` and `.Values.global.imageRegistry`).
+*/}}
+{{- define "continuum.image" -}}
+{{- $root := .root -}}
+{{- $cfg := $root.Values.continuum -}}
+{{- $tag := $cfg.image.tag | default "" -}}
+{{- if eq $tag "" -}}
+{{- fail "continuum.image.tag is empty — CI must stamp a SHA before render. Per docs/INVIOLABLE-PRINCIPLES.md #4a no :latest is permitted." -}}
+{{- end -}}
+{{- $repo := $cfg.image.repository -}}
+{{- $globalRegistry := $root.Values.global.imageRegistry | default "" -}}
+{{- if ne $globalRegistry "" -}}
+{{- /* Strip the leading registry from $repo and prepend the global override. */ -}}
+{{- $parts := splitList "/" $repo -}}
+{{- $rest := slice $parts 1 -}}
+{{- printf "%s/%s:%s" $globalRegistry (join "/" $rest) $tag -}}
+{{- else -}}
+{{- printf "%s:%s" $repo $tag -}}
+{{- end -}}
+{{- end -}}

--- a/products/continuum/chart/templates/deployment.yaml
+++ b/products/continuum/chart/templates/deployment.yaml
@@ -1,0 +1,103 @@
+{{- /*
+continuum-controller Deployment (slice K-Cont-1 of EPIC-6 #1101).
+
+K-Cont-1 ships the SKELETON: a controller-runtime Manager wired to a
+no-op Reconcile() over Continuum.dr.openova.io/v1 CRs. K-Cont-2 fills
+in the reconcile loop (lease + replication watch + switchover
+sequencer); K-Cont-3 wires the lease witness; K-Cont-4 ships the
+Cloudflare Worker source.
+
+All configuration env-driven per Inviolable Principle #4.
+*/ -}}
+{{- if .Values.continuum.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "continuum.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "continuum.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.continuum.replicas | default 1 }}
+  selector:
+    matchLabels:
+      {{- include "continuum.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "continuum.labels" . | nindent 8 }}
+    spec:
+      serviceAccountName: {{ include "continuum.fullname" . }}
+      automountServiceAccountToken: true
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: controller
+          image: {{ include "continuum.image" (dict "root" .) | quote }}
+          imagePullPolicy: {{ .Values.continuum.image.pullPolicy | default "IfNotPresent" }}
+          args:
+            - "--leader-elect={{ .Values.continuum.leaderElection.enabled }}"
+            - "--metrics-bind-address=:{{ .Values.continuum.metrics.port | default 9090 }}"
+            - "--health-probe-bind-address=:{{ .Values.continuum.health.port | default 8081 }}"
+          env:
+            - name: LEADER_ELECT_NS
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            # K-Cont-2 / K-Cont-3 seams (sketched here; values currently
+            # unused by the no-op Reconcile but part of the target-state
+            # shape per Inviolable Principle #1).
+            - name: PDM_API_URL
+              value: {{ .Values.continuum.pdmURL | default "" | quote }}
+            - name: NATS_URL
+              value: {{ .Values.continuum.natsURL | default "" | quote }}
+            - name: LEASE_TTL_SECONDS
+              value: {{ .Values.continuum.lease.ttlSeconds | default 30 | quote }}
+            - name: LEASE_RENEW_SECONDS
+              value: {{ .Values.continuum.lease.renewSeconds | default 10 | quote }}
+            {{- range $k, $v := .Values.continuum.env }}
+            - name: {{ $k | quote }}
+              value: {{ $v | quote }}
+            {{- end }}
+          ports:
+            - name: metrics
+              containerPort: {{ .Values.continuum.metrics.port | default 9090 }}
+            - name: health
+              containerPort: {{ .Values.continuum.health.port | default 8081 }}
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: health
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: health
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            {{- toYaml .Values.continuum.resources | nindent 12 }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+            readOnlyRootFilesystem: true
+      {{- with .Values.continuum.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.continuum.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.continuum.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      terminationGracePeriodSeconds: 15
+{{- end }}

--- a/products/continuum/chart/templates/networkpolicy.yaml
+++ b/products/continuum/chart/templates/networkpolicy.yaml
@@ -1,0 +1,79 @@
+{{- /*
+NetworkPolicy for continuum-controller — default-deny except for
+explicit ingress (metrics scrape from Prometheus + health probe from
+kubelet) and egress (Kubernetes API server, in-cluster CNPG status,
+NATS, PDM, lease witness URL).
+
+K-Cont-1 ships the SKELETON envelope. K-Cont-2 / K-Cont-3 will tighten
+egress rules per witness kind:
+  cloudflare-kv → egress to api.cloudflare.com:443 (TCP)
+  dns-quorum    → egress to 8.8.8.8:53 / 1.1.1.1:53 / 9.9.9.9:53 (UDP+TCP)
+
+Per docs/INVIOLABLE-PRINCIPLES.md #4 the NetworkPolicy is opt-in via
+`.Values.networkPolicy.enabled` so per-Sovereign overlays may disable
+it during initial bring-up if their CNI doesn't enforce the policy
+shape (e.g. a vCluster running on a non-Cilium host).
+*/ -}}
+{{- if and .Values.continuum.enabled .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "continuum.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "continuum.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "continuum.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    # Prometheus scrape on /metrics. Restrict by namespace label so
+    # only the monitoring namespace can hit the metrics port.
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: monitoring
+      ports:
+        - port: metrics
+          protocol: TCP
+    # kubelet liveness/readiness probes — NetworkPolicy can't restrict
+    # source by node IP cleanly, so allow any source on health port.
+    # The endpoints (/healthz + /readyz) only return literal "ok".
+    - ports:
+        - port: health
+          protocol: TCP
+  egress:
+    # Kubernetes API server (controller-runtime watch + status writes).
+    # The actual API server CIDR varies per cluster — use a label-less
+    # rule so this works on every distro. K-Cont-2 may tighten by
+    # depending on a per-Sovereign overlay value.
+    - ports:
+        - port: 443
+          protocol: TCP
+        - port: 6443
+          protocol: TCP
+    # DNS resolution (kube-dns / coredns).
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+      ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+    # NATS for catalyst.audit publishing (K-Cont-2). The default
+    # in-cluster nats Service runs in openova-system; override the
+    # namespace label match per Sovereign overlay if your NATS
+    # instance lives elsewhere.
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openova-system
+      ports:
+        - port: 4222
+          protocol: TCP
+{{- end }}

--- a/products/continuum/chart/templates/rbac.yaml
+++ b/products/continuum/chart/templates/rbac.yaml
@@ -1,0 +1,71 @@
+{{- /*
+ClusterRole + ClusterRoleBinding for continuum-controller.
+
+K-Cont-1 ships least-privilege grants for the SKELETON path:
+
+  resource                                                       verbs
+  ────────────────────────────────────────────────────────────────────
+  continuums.dr.openova.io                                       get,list,watch,update,patch
+  continuums.dr.openova.io/status                                get,update,patch
+  continuums.dr.openova.io/finalizers                            update
+  applications.apps.openova.io                                   get,list,watch
+  httproutes.gateway.networking.k8s.io                           get,list,watch
+  coordination.k8s.io/leases                                     get,list,watch,create,update,patch,delete
+  ""/namespaces                                                  get,list,watch
+  ""/events                                                      create,patch
+
+K-Cont-2 will EXTEND this with:
+  clusters.postgresql.cnpg.io                                    get,list,watch (+ patch on cluster annotations)
+  clusters.postgresql.cnpg.io/status                             get
+  httproutes.gateway.networking.k8s.io                           update,patch (weight=0 drain)
+  ""/configmaps                                                  get,list,watch,create,update,patch (per-CR state)
+  ""/secrets                                                     get (CF KV token, PDM token)
+*/ -}}
+{{- if .Values.continuum.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "continuum.fullname" . }}
+  labels:
+    {{- include "continuum.labels" . | nindent 4 }}
+rules:
+  - apiGroups: ["dr.openova.io"]
+    resources: ["continuums"]
+    verbs: ["get", "list", "watch", "update", "patch"]
+  - apiGroups: ["dr.openova.io"]
+    resources: ["continuums/status"]
+    verbs: ["get", "update", "patch"]
+  - apiGroups: ["dr.openova.io"]
+    resources: ["continuums/finalizers"]
+    verbs: ["update"]
+  - apiGroups: ["apps.openova.io"]
+    resources: ["applications"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["gateway.networking.k8s.io"]
+    resources: ["httproutes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "continuum.fullname" . }}
+  labels:
+    {{- include "continuum.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "continuum.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "continuum.fullname" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/products/continuum/chart/templates/service.yaml
+++ b/products/continuum/chart/templates/service.yaml
@@ -1,0 +1,30 @@
+{{- /*
+Service for continuum-controller — exposes /metrics + /healthz +
+/readyz inside the cluster. Consumed by Prometheus ServiceMonitor +
+k8s liveness/readiness probes.
+
+Per Inviolable Principle #4 ports are configurable via
+.Values.continuum.metrics.port + .Values.continuum.health.port.
+*/ -}}
+{{- if .Values.continuum.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "continuum.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "continuum.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  selector:
+    {{- include "continuum.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: metrics
+      port: {{ .Values.continuum.metrics.port | default 9090 }}
+      targetPort: metrics
+      protocol: TCP
+    - name: health
+      port: {{ .Values.continuum.health.port | default 8081 }}
+      targetPort: health
+      protocol: TCP
+{{- end }}

--- a/products/continuum/chart/templates/serviceaccount.yaml
+++ b/products/continuum/chart/templates/serviceaccount.yaml
@@ -1,0 +1,16 @@
+{{- /*
+ServiceAccount for continuum-controller (slice K-Cont-1 of EPIC-6 #1101).
+
+Reconciles Continuum.dr.openova.io/v1 CRs. Default-OFF — operator
+opts in per-Sovereign overlay once bp-cnpg-pair + bp-powerdns + lease
+witness are ready.
+*/ -}}
+{{- if .Values.continuum.enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "continuum.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "continuum.labels" . | nindent 4 }}
+{{- end }}

--- a/products/continuum/chart/values.yaml
+++ b/products/continuum/chart/values.yaml
@@ -1,0 +1,101 @@
+# bp-continuum values — slice K-Cont-1 of EPIC-6 (#1101).
+#
+# Continuum is a customer-facing capability (per ADR-0001 §3.2.8 — NOT
+# under platform/) that orchestrates per-Application DR for placement:
+# active-hotstandby Applications. This chart deploys the
+# continuum-controller alongside its RBAC + NetworkPolicy.
+#
+# Default-OFF gate: `continuum.enabled: false`. Operators flip this in
+# a per-Sovereign overlay once they have:
+#   - bp-cnpg-pair installed (C-DB-1 — primary + replica CNPG cluster)
+#   - bp-powerdns + pool-domain-manager reachable (lua-record commits)
+#   - lease witness configured (Cloudflare KV per K-Cont-3, or DNS
+#     quorum fallback)
+#
+# Per docs/INVIOLABLE-PRINCIPLES.md #4 (never hardcode) every value
+# below is overridable per-Sovereign overlay. Per #4a (image SHA-pinned
+# from CI) `image.tag` is empty by default; the chart fail-fasts at
+# render time when `enabled: true` and `image.tag` is empty (see
+# templates/_helpers.tpl `continuum.image`). CI stamps the SHA on every
+# push to main via .github/workflows/build-continuum-controller.yaml.
+
+# ─── Global registry rewrite (matches catalyst chart pattern) ──────────
+# When set, ALL Continuum image pulls route through this registry.
+# Per-Sovereign overlays set this to harbor.<sovereign-fqdn> so every
+# image pull hits the Sovereign's own Harbor proxy_cache rather than
+# ghcr.io directly. Empty = no rewrite.
+global:
+  imageRegistry: ""
+
+# ─── Continuum controller deployment ───────────────────────────────────
+continuum:
+  # Default-OFF. Flip to true on a Sovereign overlay once dependencies
+  # (bp-cnpg-pair, bp-powerdns, lease witness) are ready.
+  enabled: false
+
+  image:
+    repository: "ghcr.io/openova-io/openova/continuum-controller"
+    # tag is empty by default — CI stamps a SHA on every push to main.
+    # Render-time fail-fast (see templates/_helpers.tpl) prevents a
+    # half-configured deploy from accidentally running with `:latest`.
+    tag: ""
+    pullPolicy: IfNotPresent
+
+  replicas: 1
+  leaderElection:
+    enabled: true
+
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+
+  # ─── Metrics / health endpoints ──────────────────────────────────────
+  metrics:
+    enabled: true
+    # Port exposed on the controller Deployment + Service.
+    port: 9090
+
+  health:
+    # /healthz + /readyz endpoint port (separate from metrics so the
+    # ServiceMonitor scrape can hit /metrics without exposing health
+    # publicly).
+    port: 8081
+
+  # ─── K-Cont-2 / K-Cont-3 config seams (sketch — finalized in
+  # downstream slices) ─────────────────────────────────────────────────
+  #
+  # PDM endpoint that the controller calls /v1/commit on for lua-record
+  # writes. Empty = use the in-cluster Service default. Per Inviolable
+  # Principle #4 the value is fully runtime-configurable; per-Sovereign
+  # overlays may repoint at a Sovereign-local PDM instance.
+  pdmURL: ""
+
+  # NATS endpoint for catalyst.audit publishing. Empty = use the
+  # in-cluster nats.openova-system.svc.cluster.local default.
+  natsURL: ""
+
+  # Lease witness defaults (overridden per-CR via Continuum.spec.leaseClient).
+  # These are CONTROLLER-WIDE defaults; per-Continuum-CR config wins.
+  lease:
+    ttlSeconds: 30
+    renewSeconds: 10
+
+  # Free-form extra env vars threaded into the Pod (advanced; for one-off
+  # operator-side knobs not yet promoted to a top-level value).
+  env: {}
+
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+# ─── NetworkPolicy ────────────────────────────────────────────────────
+# Default-deny except for explicit egress to Kubernetes API server,
+# in-cluster CNPG status, NATS, PDM, and the lease witness URL. K-Cont-2
+# extends with witness-specific egress when WITNESS_KIND=cloudflare-kv
+# (egress to CF API at api.cloudflare.com:443).
+networkPolicy:
+  enabled: true


### PR DESCRIPTION
## Summary

Slice K-Cont-1 of EPIC-6 (#1101) — Continuum product skeleton. Skeleton ONLY: chart + binary scaffold + GHA workflow. The reconcile body is K-Cont-2; the lease witness is K-Cont-3; the Cloudflare Worker source is K-Cont-4.

## What this ships

- **`core/controllers/continuum/`** (Go binary, joins shared `core/controllers/go.mod` per Option A in the K-Cont-1 brief)
  - `cmd/main.go` — controller-runtime Manager bootstrap; leader election; `/healthz` `/readyz` `/metrics`; env-only config per Inviolable Principle #4
  - `internal/controller/continuum_controller.go` — `ContinuumReconciler` with **no-op `Reconcile()`** + `SetupWithManager()` watching the Continuum GVR via `unstructured.Unstructured` (per ADR-0001 §2.7 — no controller-gen)
  - `internal/events/doc.go` — placeholder package listing K-Cont-2's NATS audit-event types
  - `Containerfile` — multi-stage Go → alpine:3.20 runtime, UID 65534
- **`products/continuum/chart/`** (full chart shape, default-OFF)
  - `Chart.yaml` + `values.yaml` (`continuum.enabled: false`; `image.tag: ""`; render-time fail-fast on empty tag per #4a)
  - `templates/{_helpers.tpl, deployment, service, serviceaccount, rbac, networkpolicy}.yaml`
  - `blueprint.yaml` — OpenOva Blueprint with `configSchema` + `placementSchema` (single-region: management cluster) + `depends: [bp-cnpg-pair, bp-powerdns]`
  - `crds/README.md` — pointer to the Continuum CRD shipped in the Catalyst chart (B8 #1110); **not duplicated**
- **`products/continuum/DESIGN.md`** — chart-vs-binary split decision (Option A confirmed), K-Cont-2 fill list, K-Cont-3 lease witness API contract sketch
- **`.github/workflows/build-continuum-controller.yaml`** — event-driven CI (push/pull_request/workflow_dispatch — **NO cron**); jobs: `go vet` + `go test -race` + helm template ON/OFF resource gates + fail-fast verification + GHCR build & push (cosign keyless signed + SBOM) + `repository_dispatch` for chart-bump fan-out

## Verification

- `go vet ./continuum/...` → clean
- `go test -count=1 -race ./continuum/...` → green (2 skeleton tests)
- All sibling packages in `core/controllers/...` still pass (unchanged)
- `helm template` on `products/continuum/chart/`:
  - default → **0 resources** (default OFF works)
  - `--set continuum.enabled=true --set continuum.image.tag=ci-test` → **6 resources** (ServiceAccount, ClusterRole, ClusterRoleBinding, Deployment, Service, NetworkPolicy)
  - `--set continuum.enabled=true` (empty tag) → **render fails** with `image.tag is empty — CI must stamp a SHA` (per #4a)
  - `--set global.imageRegistry=harbor.omantel.biz` → image rewritten to `harbor.omantel.biz/...` (Sovereign Harbor proxy_cache pattern)

## Architecture decisions

- **Option A** — Continuum's Go binary joins the shared `core/controllers/go.mod` module (same as the 5 Group C controllers). Chart + Containerfile + DESIGN live at `products/continuum/`. Documented in `DESIGN.md`.
- **Default-OFF gate** — `continuum.enabled: false`. Operators flip true on a per-Sovereign overlay only after `bp-cnpg-pair` (C-DB-1) + `bp-powerdns` + lease witness are ready.
- **CRD ownership** — Continuum CRD lives in the Catalyst chart (B8 #1110); not duplicated to avoid the helm-controller / kustomize-controller ownership flap.
- **Watch via unstructured** — per ADR-0001 §2.7 + canon §4 the watch uses `unstructured.Unstructured`; no `controller-gen`, no generated types.
- **Lease witness API contract** sketched in `DESIGN.md` + `chart/README.md` so K-Cont-2 can wire against a stub interface and K-Cont-3 swaps in the real cloudflare-kv + dns-quorum implementations.

## Out of scope

- Reconcile body — **K-Cont-2**
- Lease witness implementations — **K-Cont-3**
- Cloudflare Worker source — **K-Cont-4**
- `bp-cnpg-pair` Blueprint — **C-DB-1**
- Application-page topology UI — **U-DR-1**

## Test plan

- [x] `go vet ./core/controllers/continuum/...` clean
- [x] `go test -count=1 -race ./core/controllers/continuum/...` green
- [x] `go test -count=1 -race ./core/controllers/...` all sibling packages green (no regression)
- [x] `helm template` default render = 0 resources
- [x] `helm template --set continuum.enabled=true --set continuum.image.tag=ci-test` = 6 resources (valid YAML)
- [x] `helm template --set continuum.enabled=true` (empty tag) = render fails per #4a
- [ ] CI workflow runs green on this PR (build job will run on push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)