### PR TITLE
feat(catalyst-ui): RBAC management UI — multi-grant editor + KC user picker + group/role browsers (slice U1-U4, #1098)

### DIFF
--- a/products/catalyst/bootstrap/api/cmd/api/main.go
+++ b/products/catalyst/bootstrap/api/cmd/api/main.go
@@ -736,6 +736,22 @@ func main() {
 		rg.Post("/api/v1/sovereigns/{id}/rbac/assign", h.HandleRBACAssign)
 		rg.Get("/api/v1/sovereigns/{id}/rbac/access-matrix", h.HandleRBACAccessMatrix)
 
+		// EPIC-3 (#1098) slice U2/U3/U4 — Keycloak proxy endpoints
+		// powering the multi-grant editor's user picker (U2),
+		// sovereign-admin group browser (U3), and realm/role browser
+		// (U4). All proxy to the Sovereign realm's KC Admin REST API
+		// via the wired h.kc client. U2 requires tier-admin or higher
+		// (mirrors /rbac/assign); U3 + U4 require sovereign-admin
+		// (admin or owner) per INVIOLABLE-PRINCIPLES #5.
+		rg.Get("/api/v1/sovereigns/{id}/keycloak/users", h.HandleKeycloakUsersSearch)
+		rg.Get("/api/v1/sovereigns/{id}/keycloak/groups", h.HandleKeycloakGroupsList)
+		rg.Post("/api/v1/sovereigns/{id}/keycloak/groups", h.HandleKeycloakGroupsCreate)
+		rg.Put("/api/v1/sovereigns/{id}/keycloak/groups/{groupId}", h.HandleKeycloakGroupsUpdate)
+		rg.Delete("/api/v1/sovereigns/{id}/keycloak/groups/{groupId}", h.HandleKeycloakGroupsDelete)
+		rg.Get("/api/v1/sovereigns/{id}/keycloak/roles", h.HandleKeycloakRolesList)
+		rg.Get("/api/v1/sovereigns/{id}/keycloak/roles/{name}/members", h.HandleKeycloakRoleMembers)
+		rg.Get("/api/v1/sovereigns/{id}/keycloak/clients/{clientId}/roles", h.HandleKeycloakClientRolesList)
+
 		// EPIC-2 (#1097) slice I — live install flow. Operators submit
 		// Application install requests here; the handler validates
 		// parameters against Blueprint.spec.configSchema (via the

--- a/products/catalyst/bootstrap/api/internal/handler/handler.go
+++ b/products/catalyst/bootstrap/api/internal/handler/handler.go
@@ -336,6 +336,17 @@ type Handler struct {
 	// from CATALYST_CATALOG_URL; tests inject a stub via
 	// SetCatalogClient.
 	catalogClient CatalogClient
+
+	// ── Keycloak admin proxy (EPIC-3 #1098 slice U2/U3/U4) ─────────
+	// kcAdminClient — proxy seam the keycloak_proxy.go handlers
+	// consume to satisfy U2 (user search), U3 (group browser), U4
+	// (role browser). Nil-tolerant: when nil the proxy handlers
+	// resolve via h.keycloakClientFor() (auth_handover.go); when both
+	// are nil the endpoints return 503 ("keycloak-not-configured").
+	// Tests inject a stub directly via SetKCAdminClient — production
+	// leaves this nil and lets the lazy resolver in keycloak_proxy.go
+	// build the client from env on first call.
+	kcAdminClient KeycloakAdminClient
 }
 
 // powerdnsZoneClient is the narrow interface the parent-zone handler

--- a/products/catalyst/bootstrap/api/internal/handler/keycloak_proxy.go
+++ b/products/catalyst/bootstrap/api/internal/handler/keycloak_proxy.go
@@ -1,0 +1,731 @@
+// Package handler — keycloak_proxy.go: EPIC-3 (#1098) slice U2/U3/U4
+// Keycloak proxy endpoints for the multi-grant editor + group/role
+// browser pages.
+//
+// REST surface:
+//
+//	GET    /api/v1/sovereigns/{id}/keycloak/users?search=<q>&limit=20    (U2)
+//	GET    /api/v1/sovereigns/{id}/keycloak/groups                       (U3)
+//	POST   /api/v1/sovereigns/{id}/keycloak/groups                       (U3)
+//	PUT    /api/v1/sovereigns/{id}/keycloak/groups/{groupId}             (U3)
+//	DELETE /api/v1/sovereigns/{id}/keycloak/groups/{groupId}             (U3)
+//	GET    /api/v1/sovereigns/{id}/keycloak/roles                        (U4)
+//	GET    /api/v1/sovereigns/{id}/keycloak/roles/{name}/members         (U4)
+//	GET    /api/v1/sovereigns/{id}/keycloak/clients/{clientId}/roles     (U4)
+//
+// All endpoints proxy to the Sovereign realm's Keycloak Admin API via
+// the wired `h.kc` client (already used by /auth/handover) — same
+// realm as the rest of catalyst-api's KC-touching endpoints. The
+// catalyst-api running on the Sovereign chroot is co-located with the
+// realm it serves; the mothership catalyst-api uses the same client
+// against the management Sovereign realm.
+//
+// ── Authorization model ───────────────────────────────────────────────
+//
+//   - U2 (user search):   tier-admin or higher  (mirrors /rbac/assign)
+//   - U3 (group browser): sovereign-admin tier  (admin or owner)
+//   - U4 (role browser):  sovereign-admin tier  (admin or owner)
+//
+// `policyModeCallerAuthorized` (slice X #1147) is the canonical
+// sovereign-admin gate; rbac_assign.go's `rbacAssignCallerAuthorized`
+// is the canonical tier-admin-or-higher gate. Both are reused here —
+// no new authorization shapes are introduced.
+//
+// ── KeycloakAdminClient interface (test seam) ─────────────────────────
+//
+// The handlers consume a narrow interface (NOT the full *keycloak.Client)
+// so tests can inject a stub without standing up a real Keycloak. The
+// production wiring resolves to *keycloak.Client via the existing
+// `h.keycloakClientFor()` helper (auth_handover.go:343).
+package handler
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/auth"
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/keycloak"
+)
+
+// ── Wire shapes ──────────────────────────────────────────────────────
+
+// kcUserResult is one row in the user-search response. Field naming
+// mirrors the Keycloak UserRepresentation subset the picker needs.
+// `Source` discriminates between native Keycloak users and federated
+// IdP users (e.g. Azure AD via OIDC broker — populated from the
+// `federationLink` field on KC's GET /users response).
+type kcUserResult struct {
+	ID        string `json:"id"`
+	Username  string `json:"username"`
+	Email     string `json:"email,omitempty"`
+	FirstName string `json:"firstName,omitempty"`
+	LastName  string `json:"lastName,omitempty"`
+	// Source: "keycloak" for native users, "azure_ad_federated" for
+	// users brokered through an Azure-SSO Identity Provider, or the
+	// raw IdP alias for any other federation. Matches A2's
+	// `AccessMatrixUser.Source` contract so the picker output is
+	// composable into the access matrix without re-mapping.
+	Source string `json:"source"`
+}
+
+// kcUserListResponse is the shape returned by GET .../keycloak/users.
+type kcUserListResponse struct {
+	Items []kcUserResult `json:"items"`
+}
+
+// kcGroupResult mirrors keycloak.Group with json field naming the UI
+// reads (id/name/path/attributes/subGroups). `Children` mirrors KC's
+// `subGroups` to keep wire-shape stable across SDK versions.
+type kcGroupResult struct {
+	ID         string              `json:"id,omitempty"`
+	Name       string              `json:"name"`
+	Path       string              `json:"path,omitempty"`
+	Attributes map[string][]string `json:"attributes,omitempty"`
+	SubGroups  []kcGroupResult     `json:"subGroups,omitempty"`
+}
+
+type kcGroupListResponse struct {
+	Items []kcGroupResult `json:"items"`
+}
+
+// kcGroupCreateRequest — POST body for creating a group. `parentId`
+// optional: when set, the group is created as a sub-group of that
+// parent UUID (uses CreateSubGroup); otherwise top-level (CreateGroup).
+type kcGroupCreateRequest struct {
+	Name       string              `json:"name"`
+	ParentID   string              `json:"parentId,omitempty"`
+	Attributes map[string][]string `json:"attributes,omitempty"`
+}
+
+// kcGroupUpdateRequest — PUT body for updating a group's attributes.
+// Name remains immutable on update (matches KC semantics: changing
+// name renames the path which breaks every existing role-mapping).
+type kcGroupUpdateRequest struct {
+	Attributes map[string][]string `json:"attributes,omitempty"`
+}
+
+// kcRoleResult mirrors keycloak.RealmRole with the slim subset the
+// browser UI renders (id/name/description/composite + tier-level if
+// stamped on attributes per slice T2's bootstrap).
+type kcRoleResult struct {
+	ID          string              `json:"id,omitempty"`
+	Name        string              `json:"name"`
+	Description string              `json:"description,omitempty"`
+	Composite   bool                `json:"composite,omitempty"`
+	ClientRole  bool                `json:"clientRole,omitempty"`
+	ContainerID string              `json:"containerId,omitempty"`
+	Attributes  map[string][]string `json:"attributes,omitempty"`
+}
+
+type kcRoleListResponse struct {
+	Items []kcRoleResult `json:"items"`
+}
+
+type kcRoleMembersResponse struct {
+	Role  string         `json:"role"`
+	Items []kcUserResult `json:"items"`
+}
+
+// ── KeycloakAdminClient interface ────────────────────────────────────
+
+// KeycloakAdminClient is the narrow surface keycloak_proxy.go needs
+// from *keycloak.Client. Defined as an interface so the test file can
+// inject a stub without spinning up a Keycloak. Production resolves
+// to *keycloak.Client via h.keycloakClientFor() (extended with the
+// missing methods inline in this slice).
+type KeycloakAdminClient interface {
+	// SearchUsers — GET /admin/realms/{realm}/users?search=<q>&max=<limit>
+	SearchUsers(ctx context.Context, search string, limit int) ([]keycloak.User, error)
+
+	// ListGroups — GET /admin/realms/{realm}/groups
+	ListGroups(ctx context.Context) ([]keycloak.Group, error)
+	// CreateGroup — top-level POST.
+	CreateGroup(ctx context.Context, g keycloak.Group) (string, error)
+	// CreateSubGroup — POST /admin/realms/{realm}/groups/{parentUuid}/children.
+	CreateSubGroup(ctx context.Context, parentUUID string, g keycloak.Group) (string, error)
+	// UpdateGroup — PUT (g.ID required).
+	UpdateGroup(ctx context.Context, g keycloak.Group) error
+	// DeleteGroup — DELETE.
+	DeleteGroup(ctx context.Context, uuid string) error
+	// GetGroup — used after Create to fetch back the freshly-created group.
+	GetGroup(ctx context.Context, uuid string) (keycloak.Group, error)
+
+	// ListRealmRoles — GET /admin/realms/{realm}/roles.
+	ListRealmRoles(ctx context.Context) ([]keycloak.RealmRole, error)
+	// GetRealmRole — used to resolve the role's UUID prior to the members lookup.
+	GetRealmRole(ctx context.Context, name string) (keycloak.RealmRole, error)
+	// ListRealmRoleMembers — GET /admin/realms/{realm}/roles/{name}/users.
+	ListRealmRoleMembers(ctx context.Context, name string) ([]keycloak.User, error)
+	// ListClientRoles — GET /admin/realms/{realm}/clients/{clientUuid}/roles.
+	ListClientRoles(ctx context.Context, clientUUID string) ([]keycloak.RealmRole, error)
+}
+
+// kcAdminClientFor returns the wired KeycloakAdminClient or nil if
+// the catalyst-api is not yet configured for KC. The handlers return
+// 503 when nil so the UI can render a "Keycloak not configured" toast.
+//
+// Production resolves to *keycloak.Client via the same env-driven
+// pathway auth_handover.go uses — DRY across the two consumers. Tests
+// inject a stub via SetKCAdminClient.
+func (h *Handler) kcAdminClientFor() KeycloakAdminClient {
+	if h.kcAdminClient != nil {
+		return h.kcAdminClient
+	}
+	c := h.keycloakClientFor()
+	if c == nil {
+		return nil
+	}
+	if cli, ok := c.(*keycloak.Client); ok {
+		return cli
+	}
+	return nil
+}
+
+// SetKCAdminClient is a test-only seam for injecting a stub
+// KeycloakAdminClient. Production never calls this — the production
+// wiring resolves to *keycloak.Client via h.keycloakClientFor().
+func (h *Handler) SetKCAdminClient(c KeycloakAdminClient) { h.kcAdminClient = c }
+
+// ── U2: GET /keycloak/users ──────────────────────────────────────────
+
+// HandleKeycloakUsersSearch — GET /api/v1/sovereigns/{id}/keycloak/users
+//
+// Type-ahead search the multi-grant editor's user picker fires on
+// every keystroke (debounced client-side at 300ms). Caller must hold
+// tier-admin-or-higher on the Sovereign — same gate as /rbac/assign.
+//
+// Federated users (corporate Sovereigns where Org.spec.identity.federation
+// is wired to an Azure-AD / Okta IdP) are surfaced inline because KC's
+// GET /admin/realms/{realm}/users searches both native users AND any
+// users provisioned via the IdP broker (the IdP creates a "shadow"
+// federated user in the realm on first login, see KC docs). The
+// `source` discriminator on each result lets the UI badge them.
+func (h *Handler) HandleKeycloakUsersSearch(w http.ResponseWriter, r *http.Request) {
+	depID := chi.URLParam(r, "id")
+	dep, ok := h.lookupDeploymentForInfra(depID)
+	if !ok {
+		writeNotFound(w, depID)
+		return
+	}
+	if !rbacRequireTierAdmin(w, r) {
+		return
+	}
+	_ = dep // dep present so the URL shape is consistent with siblings
+	kc := h.kcAdminClientFor()
+	if kc == nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]string{
+			"error":  "keycloak-not-configured",
+			"detail": "catalyst-api has no Keycloak admin client wired (CATALYST_KC_SA_CLIENT_SECRET unset)",
+		})
+		return
+	}
+
+	q := strings.TrimSpace(r.URL.Query().Get("search"))
+	if q == "" {
+		writeBadRequest(w, "missing-search", "search query parameter is required")
+		return
+	}
+	limit := kcParseLimit(r.URL.Query().Get("limit"))
+
+	users, err := kc.SearchUsers(r.Context(), q, limit)
+	if err != nil {
+		h.log.Warn("keycloak.users.search: failed", "depId", depID, "err", err)
+		writeJSON(w, http.StatusBadGateway, map[string]string{
+			"error":  "keycloak-search-failed",
+			"detail": err.Error(),
+		})
+		return
+	}
+	out := kcUserListResponse{Items: make([]kcUserResult, 0, len(users))}
+	for _, u := range users {
+		out.Items = append(out.Items, kcUserToResult(u))
+	}
+	writeJSON(w, http.StatusOK, out)
+}
+
+// ── U3: GET/POST/PUT/DELETE /keycloak/groups ─────────────────────────
+
+// HandleKeycloakGroupsList — GET /api/v1/sovereigns/{id}/keycloak/groups
+//
+// Returns the full top-level group tree (subGroups nested inline per
+// KC's response shape). Sovereign-admin only.
+func (h *Handler) HandleKeycloakGroupsList(w http.ResponseWriter, r *http.Request) {
+	depID := chi.URLParam(r, "id")
+	dep, ok := h.lookupDeploymentForInfra(depID)
+	if !ok {
+		writeNotFound(w, depID)
+		return
+	}
+	if !rbacRequireSovereignAdmin(w, r) {
+		return
+	}
+	_ = dep
+	kc := h.kcAdminClientFor()
+	if kc == nil {
+		writeKCNotConfigured(w)
+		return
+	}
+	groups, err := kc.ListGroups(r.Context())
+	if err != nil {
+		h.log.Warn("keycloak.groups.list: failed", "depId", depID, "err", err)
+		writeJSON(w, http.StatusBadGateway, map[string]string{
+			"error":  "keycloak-list-failed",
+			"detail": err.Error(),
+		})
+		return
+	}
+	out := kcGroupListResponse{Items: make([]kcGroupResult, 0, len(groups))}
+	for _, g := range groups {
+		out.Items = append(out.Items, kcGroupToResult(g))
+	}
+	writeJSON(w, http.StatusOK, out)
+}
+
+// HandleKeycloakGroupsCreate — POST /api/v1/sovereigns/{id}/keycloak/groups
+//
+// Creates a top-level group OR a sub-group (when `parentId` is set).
+// Returns the created group's representation. Sovereign-admin only.
+func (h *Handler) HandleKeycloakGroupsCreate(w http.ResponseWriter, r *http.Request) {
+	depID := chi.URLParam(r, "id")
+	dep, ok := h.lookupDeploymentForInfra(depID)
+	if !ok {
+		writeNotFound(w, depID)
+		return
+	}
+	if !rbacRequireSovereignAdmin(w, r) {
+		return
+	}
+	_ = dep
+	kc := h.kcAdminClientFor()
+	if kc == nil {
+		writeKCNotConfigured(w)
+		return
+	}
+	var body kcGroupCreateRequest
+	if !decodeMutationBody(w, r, &body) {
+		return
+	}
+	if strings.TrimSpace(body.Name) == "" {
+		writeBadRequest(w, "missing-name", "group name is required")
+		return
+	}
+	g := keycloak.Group{Name: body.Name, Attributes: body.Attributes}
+	var (
+		uuid string
+		err  error
+	)
+	if strings.TrimSpace(body.ParentID) != "" {
+		uuid, err = kc.CreateSubGroup(r.Context(), body.ParentID, g)
+	} else {
+		uuid, err = kc.CreateGroup(r.Context(), g)
+	}
+	if err != nil {
+		h.log.Warn("keycloak.groups.create: failed", "depId", depID, "err", err)
+		writeJSON(w, http.StatusBadGateway, map[string]string{
+			"error":  "keycloak-create-failed",
+			"detail": err.Error(),
+		})
+		return
+	}
+	// Re-fetch so we return the canonical KC representation (KC fills
+	// in `path`, `id`, etc. server-side).
+	created, getErr := kc.GetGroup(r.Context(), uuid)
+	if getErr != nil {
+		// The group was created but we can't read it back. Surface a
+		// minimal representation so the UI can at least show what it
+		// just made.
+		writeJSON(w, http.StatusCreated, kcGroupResult{ID: uuid, Name: body.Name, Attributes: body.Attributes})
+		return
+	}
+	writeJSON(w, http.StatusCreated, kcGroupToResult(created))
+}
+
+// HandleKeycloakGroupsUpdate — PUT /api/v1/sovereigns/{id}/keycloak/groups/{groupId}
+//
+// Replaces the group's attributes. Name remains immutable per KC
+// semantics. Sovereign-admin only.
+func (h *Handler) HandleKeycloakGroupsUpdate(w http.ResponseWriter, r *http.Request) {
+	depID := chi.URLParam(r, "id")
+	groupID := chi.URLParam(r, "groupId")
+	dep, ok := h.lookupDeploymentForInfra(depID)
+	if !ok {
+		writeNotFound(w, depID)
+		return
+	}
+	if !rbacRequireSovereignAdmin(w, r) {
+		return
+	}
+	if strings.TrimSpace(groupID) == "" {
+		writeBadRequest(w, "missing-group-id", "group id is required")
+		return
+	}
+	_ = dep
+	kc := h.kcAdminClientFor()
+	if kc == nil {
+		writeKCNotConfigured(w)
+		return
+	}
+	// GET first so we preserve existing fields (Name, Path) the
+	// update body doesn't carry — same shape as SetGroupAttributes.
+	current, err := kc.GetGroup(r.Context(), groupID)
+	if err != nil {
+		if errors.Is(err, keycloak.ErrGroupNotFound) {
+			writeJSON(w, http.StatusNotFound, map[string]string{
+				"error":  "group-not-found",
+				"detail": "no Keycloak group with id " + groupID,
+			})
+			return
+		}
+		h.log.Warn("keycloak.groups.update: get failed", "depId", depID, "err", err)
+		writeJSON(w, http.StatusBadGateway, map[string]string{
+			"error":  "keycloak-get-failed",
+			"detail": err.Error(),
+		})
+		return
+	}
+	var body kcGroupUpdateRequest
+	if !decodeMutationBody(w, r, &body) {
+		return
+	}
+	current.Attributes = body.Attributes
+	if err := kc.UpdateGroup(r.Context(), current); err != nil {
+		if errors.Is(err, keycloak.ErrGroupNotFound) {
+			writeJSON(w, http.StatusNotFound, map[string]string{
+				"error":  "group-not-found",
+				"detail": "no Keycloak group with id " + groupID,
+			})
+			return
+		}
+		h.log.Warn("keycloak.groups.update: failed", "depId", depID, "err", err)
+		writeJSON(w, http.StatusBadGateway, map[string]string{
+			"error":  "keycloak-update-failed",
+			"detail": err.Error(),
+		})
+		return
+	}
+	// Re-fetch to return canonical state.
+	updated, _ := kc.GetGroup(r.Context(), groupID)
+	writeJSON(w, http.StatusOK, kcGroupToResult(updated))
+}
+
+// HandleKeycloakGroupsDelete — DELETE /api/v1/sovereigns/{id}/keycloak/groups/{groupId}
+//
+// Sovereign-admin only.
+func (h *Handler) HandleKeycloakGroupsDelete(w http.ResponseWriter, r *http.Request) {
+	depID := chi.URLParam(r, "id")
+	groupID := chi.URLParam(r, "groupId")
+	dep, ok := h.lookupDeploymentForInfra(depID)
+	if !ok {
+		writeNotFound(w, depID)
+		return
+	}
+	if !rbacRequireSovereignAdmin(w, r) {
+		return
+	}
+	if strings.TrimSpace(groupID) == "" {
+		writeBadRequest(w, "missing-group-id", "group id is required")
+		return
+	}
+	_ = dep
+	kc := h.kcAdminClientFor()
+	if kc == nil {
+		writeKCNotConfigured(w)
+		return
+	}
+	if err := kc.DeleteGroup(r.Context(), groupID); err != nil {
+		if errors.Is(err, keycloak.ErrGroupNotFound) {
+			writeJSON(w, http.StatusNotFound, map[string]string{
+				"error":  "group-not-found",
+				"detail": "no Keycloak group with id " + groupID,
+			})
+			return
+		}
+		h.log.Warn("keycloak.groups.delete: failed", "depId", depID, "err", err)
+		writeJSON(w, http.StatusBadGateway, map[string]string{
+			"error":  "keycloak-delete-failed",
+			"detail": err.Error(),
+		})
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// ── U4: GET /keycloak/roles + members + client roles ─────────────────
+
+// HandleKeycloakRolesList — GET /api/v1/sovereigns/{id}/keycloak/roles
+//
+// Lists every realm role. Sovereign-admin only. The slim
+// representation includes the `tier-level` attribute (when set by the
+// T2 bootstrap) so the UI can sort by precedence.
+func (h *Handler) HandleKeycloakRolesList(w http.ResponseWriter, r *http.Request) {
+	depID := chi.URLParam(r, "id")
+	dep, ok := h.lookupDeploymentForInfra(depID)
+	if !ok {
+		writeNotFound(w, depID)
+		return
+	}
+	if !rbacRequireSovereignAdmin(w, r) {
+		return
+	}
+	_ = dep
+	kc := h.kcAdminClientFor()
+	if kc == nil {
+		writeKCNotConfigured(w)
+		return
+	}
+	roles, err := kc.ListRealmRoles(r.Context())
+	if err != nil {
+		h.log.Warn("keycloak.roles.list: failed", "depId", depID, "err", err)
+		writeJSON(w, http.StatusBadGateway, map[string]string{
+			"error":  "keycloak-list-failed",
+			"detail": err.Error(),
+		})
+		return
+	}
+	out := kcRoleListResponse{Items: make([]kcRoleResult, 0, len(roles))}
+	for _, rr := range roles {
+		out.Items = append(out.Items, kcRoleToResult(rr))
+	}
+	writeJSON(w, http.StatusOK, out)
+}
+
+// HandleKeycloakRoleMembers — GET /api/v1/sovereigns/{id}/keycloak/roles/{name}/members
+//
+// Returns the users directly bound to the named realm role. Note: this
+// is the DIRECT-binding view; users transitively in the role via group
+// inheritance are not surfaced here (they're surfaced via the access-
+// matrix endpoint A2). The role-browser UI uses this endpoint to
+// answer "who can act under this role today?". Sovereign-admin only.
+func (h *Handler) HandleKeycloakRoleMembers(w http.ResponseWriter, r *http.Request) {
+	depID := chi.URLParam(r, "id")
+	roleName := chi.URLParam(r, "name")
+	dep, ok := h.lookupDeploymentForInfra(depID)
+	if !ok {
+		writeNotFound(w, depID)
+		return
+	}
+	if !rbacRequireSovereignAdmin(w, r) {
+		return
+	}
+	if strings.TrimSpace(roleName) == "" {
+		writeBadRequest(w, "missing-role-name", "role name is required")
+		return
+	}
+	_ = dep
+	kc := h.kcAdminClientFor()
+	if kc == nil {
+		writeKCNotConfigured(w)
+		return
+	}
+	users, err := kc.ListRealmRoleMembers(r.Context(), roleName)
+	if err != nil {
+		if errors.Is(err, keycloak.ErrRoleNotFound) {
+			writeJSON(w, http.StatusNotFound, map[string]string{
+				"error":  "role-not-found",
+				"detail": "no Keycloak realm role named " + roleName,
+			})
+			return
+		}
+		h.log.Warn("keycloak.roles.members: failed", "depId", depID, "role", roleName, "err", err)
+		writeJSON(w, http.StatusBadGateway, map[string]string{
+			"error":  "keycloak-list-failed",
+			"detail": err.Error(),
+		})
+		return
+	}
+	resp := kcRoleMembersResponse{Role: roleName, Items: make([]kcUserResult, 0, len(users))}
+	for _, u := range users {
+		resp.Items = append(resp.Items, kcUserToResult(u))
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// HandleKeycloakClientRolesList — GET /api/v1/sovereigns/{id}/keycloak/clients/{clientId}/roles
+//
+// Lists per-OIDC-client roles. The `clientId` path segment is the KC
+// client UUID (NOT the OIDC clientId string). Sovereign-admin only.
+func (h *Handler) HandleKeycloakClientRolesList(w http.ResponseWriter, r *http.Request) {
+	depID := chi.URLParam(r, "id")
+	clientUUID := chi.URLParam(r, "clientId")
+	dep, ok := h.lookupDeploymentForInfra(depID)
+	if !ok {
+		writeNotFound(w, depID)
+		return
+	}
+	if !rbacRequireSovereignAdmin(w, r) {
+		return
+	}
+	if strings.TrimSpace(clientUUID) == "" {
+		writeBadRequest(w, "missing-client-id", "client id is required")
+		return
+	}
+	_ = dep
+	kc := h.kcAdminClientFor()
+	if kc == nil {
+		writeKCNotConfigured(w)
+		return
+	}
+	roles, err := kc.ListClientRoles(r.Context(), clientUUID)
+	if err != nil {
+		h.log.Warn("keycloak.client.roles.list: failed", "depId", depID, "client", clientUUID, "err", err)
+		writeJSON(w, http.StatusBadGateway, map[string]string{
+			"error":  "keycloak-list-failed",
+			"detail": err.Error(),
+		})
+		return
+	}
+	out := kcRoleListResponse{Items: make([]kcRoleResult, 0, len(roles))}
+	for _, rr := range roles {
+		out.Items = append(out.Items, kcRoleToResult(rr))
+	}
+	writeJSON(w, http.StatusOK, out)
+}
+
+// ── Authorization gates ──────────────────────────────────────────────
+
+// rbacRequireTierAdmin enforces the same tier-admin-or-higher gate as
+// /rbac/assign. Returns true on pass; on fail writes 403 and returns
+// false. Nil-claims (test harnesses, pre-auth Sovereigns) fall
+// through — same lenient policy rbac_assign.go uses.
+func rbacRequireTierAdmin(w http.ResponseWriter, r *http.Request) bool {
+	claims := auth.ClaimsFromContext(r.Context())
+	if claims == nil {
+		return true
+	}
+	if rbacAssignCallerAuthorized(claims) {
+		return true
+	}
+	writeJSON(w, http.StatusForbidden, map[string]string{
+		"error":  "forbidden",
+		"detail": "endpoint requires tier-admin or higher",
+	})
+	return false
+}
+
+// rbacRequireSovereignAdmin enforces the strict sovereign-admin tier
+// gate (admin or owner only) for U3/U4 endpoints. Reuses the canonical
+// `policyModeCallerAuthorized` shape from slice X (#1147).
+//
+// The lenient nil-claims fall-through matches the pattern across every
+// other catalyst-api endpoint — the auth middleware is the single
+// source of truth for whether auth was required at all.
+func rbacRequireSovereignAdmin(w http.ResponseWriter, r *http.Request) bool {
+	claims := auth.ClaimsFromContext(r.Context())
+	if claims == nil {
+		return true
+	}
+	if policyModeCallerAuthorized(claims) {
+		return true
+	}
+	writeJSON(w, http.StatusForbidden, map[string]string{
+		"error":  "forbidden",
+		"detail": "endpoint requires sovereign-admin (admin or owner tier)",
+	})
+	return false
+}
+
+// ── Mappers + helpers ────────────────────────────────────────────────
+
+// kcUserToResult projects a keycloak.User onto the wire shape. The
+// `Source` discriminator is derived from the `federationLink` field:
+// non-empty → federated user (the value is the IdP alias, e.g.
+// "azure-sso-acme"). Empty → native Keycloak user.
+func kcUserToResult(u keycloak.User) kcUserResult {
+	src := "keycloak"
+	if alias := strings.TrimSpace(u.FederationLink); alias != "" {
+		// Map the alias prefix to the canonical Source label that A2
+		// emits. `azure-sso-*` is the deterministic alias slice F2
+		// stamps for Azure-SSO IdPs (per docs/01-canonical-seams.md
+		// "Deterministic IdP alias `<provider>-<orgSlug>`").
+		switch {
+		case strings.HasPrefix(alias, "azure-sso-"), strings.HasPrefix(alias, "azure-ad-"):
+			src = "azure_ad_federated"
+		default:
+			src = alias
+		}
+	}
+	return kcUserResult{
+		ID:        u.ID,
+		Username:  u.Username,
+		Email:     u.Email,
+		FirstName: u.FirstName,
+		LastName:  u.LastName,
+		Source:    src,
+	}
+}
+
+// kcGroupToResult recursively projects a keycloak.Group onto the wire
+// shape, preserving the SubGroups tree so the UI tree-renderer can
+// display the full hierarchy without a per-node round-trip.
+func kcGroupToResult(g keycloak.Group) kcGroupResult {
+	out := kcGroupResult{
+		ID:         g.ID,
+		Name:       g.Name,
+		Path:       g.Path,
+		Attributes: g.Attributes,
+	}
+	if len(g.SubGroups) > 0 {
+		out.SubGroups = make([]kcGroupResult, 0, len(g.SubGroups))
+		for _, child := range g.SubGroups {
+			out.SubGroups = append(out.SubGroups, kcGroupToResult(child))
+		}
+	}
+	return out
+}
+
+// kcRoleToResult projects a keycloak.RealmRole onto the wire shape.
+func kcRoleToResult(r keycloak.RealmRole) kcRoleResult {
+	return kcRoleResult{
+		ID:          r.ID,
+		Name:        r.Name,
+		Description: r.Description,
+		Composite:   r.Composite,
+		ClientRole:  r.ClientRole,
+		ContainerID: r.ContainerID,
+		Attributes:  r.Attributes,
+	}
+}
+
+// kcParseLimit clamps the user-search limit to a sane range. Defaults
+// to 20 (matches the brief). Caps at 100 to avoid pathological
+// /users?search=a&limit=10000 calls hammering Keycloak.
+func kcParseLimit(raw string) int {
+	const (
+		def = 20
+		max = 100
+	)
+	if raw == "" {
+		return def
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil || n <= 0 {
+		return def
+	}
+	if n > max {
+		return max
+	}
+	return n
+}
+
+// writeKCNotConfigured emits the canonical 503 the U2/U3/U4 endpoints
+// share when h.kc is unwired (Sovereign not yet through the OIDC bring-
+// up). Distinct error code so the UI can render an actionable empty
+// state instead of a generic toast.
+func writeKCNotConfigured(w http.ResponseWriter) {
+	writeJSON(w, http.StatusServiceUnavailable, map[string]string{
+		"error":  "keycloak-not-configured",
+		"detail": "catalyst-api has no Keycloak admin client wired (CATALYST_KC_SA_CLIENT_SECRET unset)",
+	})
+}
+
+// ── *keycloak.Client surface extensions ──────────────────────────────
+//
+// SearchUsers / ListRealmRoleMembers / ListClientRoles are defined on
+// *keycloak.Client in internal/keycloak/admin_users.go (this slice).
+// The production *keycloak.Client therefore satisfies the
+// KeycloakAdminClient interface without per-handler-file plumbing.

--- a/products/catalyst/bootstrap/api/internal/handler/keycloak_proxy_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/keycloak_proxy_test.go
@@ -1,0 +1,602 @@
+// keycloak_proxy_test.go — coverage for the EPIC-3 (#1098) U2/U3/U4
+// Keycloak proxy handlers. Stubs the KeycloakAdminClient interface so
+// the test can exercise the full handler surface without a Keycloak.
+//
+// Authorization paths exercised:
+//   - U2 user search: tier-admin gate via realm role + tier claim
+//   - U3 + U4: stricter sovereign-admin gate (admin/owner only)
+//   - 503 path when h.kc is nil
+//   - federated user surface (federationLink → source mapping)
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/auth"
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/keycloak"
+)
+
+// ── Stub KC client ───────────────────────────────────────────────────
+
+type fakeKCAdminClient struct {
+	users []keycloak.User
+	// SearchUsers
+	searchErr  error
+	lastSearch string
+	lastLimit  int
+	// ListGroups
+	groups    []keycloak.Group
+	listGrpErr error
+	// CreateGroup / CreateSubGroup
+	createUUID    string
+	createErr     error
+	lastParentID  string
+	lastCreatedG  keycloak.Group
+	// GetGroup
+	getGroup    keycloak.Group
+	getGroupErr error
+	// UpdateGroup
+	updateErr error
+	updatedG  keycloak.Group
+	// DeleteGroup
+	deleteErr error
+	deletedID string
+	// ListRealmRoles
+	roles      []keycloak.RealmRole
+	listRolesErr error
+	// GetRealmRole
+	getRole    keycloak.RealmRole
+	getRoleErr error
+	// ListRealmRoleMembers
+	roleMembers   []keycloak.User
+	roleMembersErr error
+	// ListClientRoles
+	clientRoles    []keycloak.RealmRole
+	clientRolesErr error
+}
+
+func (f *fakeKCAdminClient) SearchUsers(_ context.Context, search string, limit int) ([]keycloak.User, error) {
+	f.lastSearch = search
+	f.lastLimit = limit
+	if f.searchErr != nil {
+		return nil, f.searchErr
+	}
+	return f.users, nil
+}
+
+func (f *fakeKCAdminClient) ListGroups(_ context.Context) ([]keycloak.Group, error) {
+	if f.listGrpErr != nil {
+		return nil, f.listGrpErr
+	}
+	return f.groups, nil
+}
+
+func (f *fakeKCAdminClient) CreateGroup(_ context.Context, g keycloak.Group) (string, error) {
+	f.lastParentID = ""
+	f.lastCreatedG = g
+	if f.createErr != nil {
+		return "", f.createErr
+	}
+	return f.createUUID, nil
+}
+
+func (f *fakeKCAdminClient) CreateSubGroup(_ context.Context, parentUUID string, g keycloak.Group) (string, error) {
+	f.lastParentID = parentUUID
+	f.lastCreatedG = g
+	if f.createErr != nil {
+		return "", f.createErr
+	}
+	return f.createUUID, nil
+}
+
+func (f *fakeKCAdminClient) UpdateGroup(_ context.Context, g keycloak.Group) error {
+	f.updatedG = g
+	return f.updateErr
+}
+
+func (f *fakeKCAdminClient) DeleteGroup(_ context.Context, uuid string) error {
+	f.deletedID = uuid
+	return f.deleteErr
+}
+
+func (f *fakeKCAdminClient) GetGroup(_ context.Context, _ string) (keycloak.Group, error) {
+	if f.getGroupErr != nil {
+		return keycloak.Group{}, f.getGroupErr
+	}
+	return f.getGroup, nil
+}
+
+func (f *fakeKCAdminClient) ListRealmRoles(_ context.Context) ([]keycloak.RealmRole, error) {
+	if f.listRolesErr != nil {
+		return nil, f.listRolesErr
+	}
+	return f.roles, nil
+}
+
+func (f *fakeKCAdminClient) GetRealmRole(_ context.Context, _ string) (keycloak.RealmRole, error) {
+	if f.getRoleErr != nil {
+		return keycloak.RealmRole{}, f.getRoleErr
+	}
+	return f.getRole, nil
+}
+
+func (f *fakeKCAdminClient) ListRealmRoleMembers(_ context.Context, _ string) ([]keycloak.User, error) {
+	if f.roleMembersErr != nil {
+		return nil, f.roleMembersErr
+	}
+	return f.roleMembers, nil
+}
+
+func (f *fakeKCAdminClient) ListClientRoles(_ context.Context, _ string) ([]keycloak.RealmRole, error) {
+	if f.clientRolesErr != nil {
+		return nil, f.clientRolesErr
+	}
+	return f.clientRoles, nil
+}
+
+// ── Test scaffolding ─────────────────────────────────────────────────
+
+func registerKCProxyRoutes(r chi.Router, h *Handler) {
+	r.Get("/api/v1/sovereigns/{id}/keycloak/users", h.HandleKeycloakUsersSearch)
+	r.Get("/api/v1/sovereigns/{id}/keycloak/groups", h.HandleKeycloakGroupsList)
+	r.Post("/api/v1/sovereigns/{id}/keycloak/groups", h.HandleKeycloakGroupsCreate)
+	r.Put("/api/v1/sovereigns/{id}/keycloak/groups/{groupId}", h.HandleKeycloakGroupsUpdate)
+	r.Delete("/api/v1/sovereigns/{id}/keycloak/groups/{groupId}", h.HandleKeycloakGroupsDelete)
+	r.Get("/api/v1/sovereigns/{id}/keycloak/roles", h.HandleKeycloakRolesList)
+	r.Get("/api/v1/sovereigns/{id}/keycloak/roles/{name}/members", h.HandleKeycloakRoleMembers)
+	r.Get("/api/v1/sovereigns/{id}/keycloak/clients/{clientId}/roles", h.HandleKeycloakClientRolesList)
+}
+
+func newKCProxyHandler(t *testing.T) (*Handler, *Deployment, *fakeKCAdminClient) {
+	t.Helper()
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	dep := installUserAccessDeployment(t, h, "dep-kcproxy")
+	stub := &fakeKCAdminClient{}
+	h.SetKCAdminClient(stub)
+	return h, dep, stub
+}
+
+func reqWithClaims(method, path string, body string, claims *auth.Claims) *http.Request {
+	req := httptest.NewRequest(method, path, strings.NewReader(body))
+	if body != "" {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	if claims != nil {
+		ctx := context.WithValue(req.Context(), auth.ClaimsKey, claims)
+		req = req.WithContext(ctx)
+	}
+	return req
+}
+
+// adminClaims returns claims that pass both the tier-admin gate
+// (rbacAssignCallerAuthorized) and the sovereign-admin gate
+// (policyModeCallerAuthorized).
+func adminClaims() *auth.Claims {
+	return &auth.Claims{Tier: "admin"}
+}
+
+// developerClaims pass NEITHER gate — used to exercise 403 paths.
+func developerClaims() *auth.Claims {
+	return &auth.Claims{Tier: "developer"}
+}
+
+// ── U2: User search ──────────────────────────────────────────────────
+
+func TestKeycloakUsersSearch_HappyPath(t *testing.T) {
+	h, dep, stub := newKCProxyHandler(t)
+	stub.users = []keycloak.User{
+		{ID: "u1", Username: "alice", Email: "alice@acme.com", FirstName: "Alice", LastName: "A"},
+		{ID: "u2", Username: "bob.fed", Email: "bob@corp.com", FederationLink: "azure-sso-acme"},
+	}
+	r := chi.NewRouter()
+	registerKCProxyRoutes(r, h)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, reqWithClaims(http.MethodGet,
+		"/api/v1/sovereigns/"+dep.ID+"/keycloak/users?search=ali&limit=10",
+		"", adminClaims()))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	if stub.lastSearch != "ali" {
+		t.Errorf("search query: got %q want %q", stub.lastSearch, "ali")
+	}
+	if stub.lastLimit != 10 {
+		t.Errorf("limit: got %d want 10", stub.lastLimit)
+	}
+	var resp kcUserListResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Items) != 2 {
+		t.Fatalf("items: got %d want 2", len(resp.Items))
+	}
+	if resp.Items[0].Source != "keycloak" {
+		t.Errorf("native user source: got %q want keycloak", resp.Items[0].Source)
+	}
+	if resp.Items[1].Source != "azure_ad_federated" {
+		t.Errorf("federated user source: got %q want azure_ad_federated", resp.Items[1].Source)
+	}
+}
+
+func TestKeycloakUsersSearch_RequiresSearchParam(t *testing.T) {
+	h, dep, _ := newKCProxyHandler(t)
+	r := chi.NewRouter()
+	registerKCProxyRoutes(r, h)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, reqWithClaims(http.MethodGet,
+		"/api/v1/sovereigns/"+dep.ID+"/keycloak/users", "", adminClaims()))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status: got %d want 400; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestKeycloakUsersSearch_DefaultLimit(t *testing.T) {
+	h, dep, stub := newKCProxyHandler(t)
+	r := chi.NewRouter()
+	registerKCProxyRoutes(r, h)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, reqWithClaims(http.MethodGet,
+		"/api/v1/sovereigns/"+dep.ID+"/keycloak/users?search=foo",
+		"", adminClaims()))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d want 200", rec.Code)
+	}
+	if stub.lastLimit != 20 {
+		t.Errorf("default limit: got %d want 20", stub.lastLimit)
+	}
+}
+
+func TestKeycloakUsersSearch_LimitClampedTo100(t *testing.T) {
+	h, dep, stub := newKCProxyHandler(t)
+	r := chi.NewRouter()
+	registerKCProxyRoutes(r, h)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, reqWithClaims(http.MethodGet,
+		"/api/v1/sovereigns/"+dep.ID+"/keycloak/users?search=foo&limit=10000",
+		"", adminClaims()))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d", rec.Code)
+	}
+	if stub.lastLimit != 100 {
+		t.Errorf("clamped limit: got %d want 100", stub.lastLimit)
+	}
+}
+
+func TestKeycloakUsersSearch_403WhenDeveloper(t *testing.T) {
+	h, dep, _ := newKCProxyHandler(t)
+	r := chi.NewRouter()
+	registerKCProxyRoutes(r, h)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, reqWithClaims(http.MethodGet,
+		"/api/v1/sovereigns/"+dep.ID+"/keycloak/users?search=foo",
+		"", developerClaims()))
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status: got %d want 403; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestKeycloakUsersSearch_503WhenKCUnconfigured(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	dep := installUserAccessDeployment(t, h, "dep-kcproxy-unconfigured")
+	r := chi.NewRouter()
+	registerKCProxyRoutes(r, h)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, reqWithClaims(http.MethodGet,
+		"/api/v1/sovereigns/"+dep.ID+"/keycloak/users?search=foo",
+		"", adminClaims()))
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status: got %d want 503; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+// ── U3: Group browser ────────────────────────────────────────────────
+
+func TestKeycloakGroupsList_HappyPath(t *testing.T) {
+	h, dep, stub := newKCProxyHandler(t)
+	stub.groups = []keycloak.Group{
+		{ID: "g1", Name: "acme", Path: "/acme", Attributes: map[string][]string{"org": {"acme"}}},
+		{ID: "g2", Name: "platform", Path: "/platform", SubGroups: []keycloak.Group{
+			{ID: "g3", Name: "sre", Path: "/platform/sre"},
+		}},
+	}
+	r := chi.NewRouter()
+	registerKCProxyRoutes(r, h)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, reqWithClaims(http.MethodGet,
+		"/api/v1/sovereigns/"+dep.ID+"/keycloak/groups", "", adminClaims()))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d; body=%s", rec.Code, rec.Body.String())
+	}
+	var resp kcGroupListResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Items) != 2 {
+		t.Fatalf("items: got %d want 2", len(resp.Items))
+	}
+	if len(resp.Items[1].SubGroups) != 1 || resp.Items[1].SubGroups[0].Name != "sre" {
+		t.Errorf("subgroups not preserved: %+v", resp.Items[1].SubGroups)
+	}
+}
+
+func TestKeycloakGroupsList_403WhenDeveloper(t *testing.T) {
+	h, dep, _ := newKCProxyHandler(t)
+	r := chi.NewRouter()
+	registerKCProxyRoutes(r, h)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, reqWithClaims(http.MethodGet,
+		"/api/v1/sovereigns/"+dep.ID+"/keycloak/groups", "", developerClaims()))
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status: got %d want 403", rec.Code)
+	}
+}
+
+func TestKeycloakGroupsCreate_TopLevel(t *testing.T) {
+	h, dep, stub := newKCProxyHandler(t)
+	stub.createUUID = "new-uuid"
+	stub.getGroup = keycloak.Group{ID: "new-uuid", Name: "billing", Path: "/billing"}
+	r := chi.NewRouter()
+	registerKCProxyRoutes(r, h)
+	rec := httptest.NewRecorder()
+	body := `{"name":"billing","attributes":{"org":["billing"]}}`
+	r.ServeHTTP(rec, reqWithClaims(http.MethodPost,
+		"/api/v1/sovereigns/"+dep.ID+"/keycloak/groups", body, adminClaims()))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status: got %d want 201; body=%s", rec.Code, rec.Body.String())
+	}
+	if stub.lastCreatedG.Name != "billing" {
+		t.Errorf("created name: got %q want billing", stub.lastCreatedG.Name)
+	}
+	if stub.lastParentID != "" {
+		t.Errorf("parent id should be empty; got %q", stub.lastParentID)
+	}
+}
+
+func TestKeycloakGroupsCreate_SubGroup(t *testing.T) {
+	h, dep, stub := newKCProxyHandler(t)
+	stub.createUUID = "child-uuid"
+	stub.getGroup = keycloak.Group{ID: "child-uuid", Name: "sre", Path: "/platform/sre"}
+	r := chi.NewRouter()
+	registerKCProxyRoutes(r, h)
+	rec := httptest.NewRecorder()
+	body := `{"name":"sre","parentId":"parent-uuid"}`
+	r.ServeHTTP(rec, reqWithClaims(http.MethodPost,
+		"/api/v1/sovereigns/"+dep.ID+"/keycloak/groups", body, adminClaims()))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status: got %d; body=%s", rec.Code, rec.Body.String())
+	}
+	if stub.lastParentID != "parent-uuid" {
+		t.Errorf("parent id: got %q want parent-uuid", stub.lastParentID)
+	}
+}
+
+func TestKeycloakGroupsCreate_RejectsEmptyName(t *testing.T) {
+	h, dep, _ := newKCProxyHandler(t)
+	r := chi.NewRouter()
+	registerKCProxyRoutes(r, h)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, reqWithClaims(http.MethodPost,
+		"/api/v1/sovereigns/"+dep.ID+"/keycloak/groups", `{"name":""}`, adminClaims()))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status: got %d want 400", rec.Code)
+	}
+}
+
+func TestKeycloakGroupsUpdate_HappyPath(t *testing.T) {
+	h, dep, stub := newKCProxyHandler(t)
+	stub.getGroup = keycloak.Group{ID: "g1", Name: "acme", Path: "/acme"}
+	r := chi.NewRouter()
+	registerKCProxyRoutes(r, h)
+	rec := httptest.NewRecorder()
+	body := `{"attributes":{"tier":["admin"]}}`
+	r.ServeHTTP(rec, reqWithClaims(http.MethodPut,
+		"/api/v1/sovereigns/"+dep.ID+"/keycloak/groups/g1", body, adminClaims()))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d; body=%s", rec.Code, rec.Body.String())
+	}
+	if got := stub.updatedG.Attributes["tier"]; len(got) != 1 || got[0] != "admin" {
+		t.Errorf("attrs: got %v want tier=[admin]", stub.updatedG.Attributes)
+	}
+	// Name preserved from prior GET.
+	if stub.updatedG.Name != "acme" {
+		t.Errorf("name: got %q want acme", stub.updatedG.Name)
+	}
+}
+
+func TestKeycloakGroupsUpdate_404OnMissingGroup(t *testing.T) {
+	h, dep, stub := newKCProxyHandler(t)
+	stub.getGroupErr = keycloak.ErrGroupNotFound
+	r := chi.NewRouter()
+	registerKCProxyRoutes(r, h)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, reqWithClaims(http.MethodPut,
+		"/api/v1/sovereigns/"+dep.ID+"/keycloak/groups/missing", `{}`, adminClaims()))
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status: got %d want 404; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestKeycloakGroupsDelete_HappyPath(t *testing.T) {
+	h, dep, stub := newKCProxyHandler(t)
+	r := chi.NewRouter()
+	registerKCProxyRoutes(r, h)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, reqWithClaims(http.MethodDelete,
+		"/api/v1/sovereigns/"+dep.ID+"/keycloak/groups/g1", "", adminClaims()))
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("status: got %d; body=%s", rec.Code, rec.Body.String())
+	}
+	if stub.deletedID != "g1" {
+		t.Errorf("deleted id: got %q want g1", stub.deletedID)
+	}
+}
+
+func TestKeycloakGroupsDelete_404(t *testing.T) {
+	h, dep, stub := newKCProxyHandler(t)
+	stub.deleteErr = keycloak.ErrGroupNotFound
+	r := chi.NewRouter()
+	registerKCProxyRoutes(r, h)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, reqWithClaims(http.MethodDelete,
+		"/api/v1/sovereigns/"+dep.ID+"/keycloak/groups/g1", "", adminClaims()))
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status: got %d want 404", rec.Code)
+	}
+}
+
+// ── U4: Role browser ─────────────────────────────────────────────────
+
+func TestKeycloakRolesList_HappyPath(t *testing.T) {
+	h, dep, stub := newKCProxyHandler(t)
+	stub.roles = []keycloak.RealmRole{
+		{ID: "r1", Name: "catalyst-viewer", Composite: false, Attributes: map[string][]string{"tier-level": {"10"}}},
+		{ID: "r2", Name: "catalyst-developer", Composite: true, Attributes: map[string][]string{"tier-level": {"20"}}},
+	}
+	r := chi.NewRouter()
+	registerKCProxyRoutes(r, h)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, reqWithClaims(http.MethodGet,
+		"/api/v1/sovereigns/"+dep.ID+"/keycloak/roles", "", adminClaims()))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d", rec.Code)
+	}
+	var resp kcRoleListResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Items) != 2 {
+		t.Fatalf("items: got %d want 2", len(resp.Items))
+	}
+	if resp.Items[0].Attributes["tier-level"][0] != "10" {
+		t.Errorf("tier-level attr not preserved: %+v", resp.Items[0].Attributes)
+	}
+}
+
+func TestKeycloakRoleMembers_HappyPath(t *testing.T) {
+	h, dep, stub := newKCProxyHandler(t)
+	stub.roleMembers = []keycloak.User{
+		{ID: "u1", Username: "alice", Email: "alice@acme.com"},
+	}
+	r := chi.NewRouter()
+	registerKCProxyRoutes(r, h)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, reqWithClaims(http.MethodGet,
+		"/api/v1/sovereigns/"+dep.ID+"/keycloak/roles/catalyst-admin/members", "", adminClaims()))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d; body=%s", rec.Code, rec.Body.String())
+	}
+	var resp kcRoleMembersResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Role != "catalyst-admin" {
+		t.Errorf("role: got %q want catalyst-admin", resp.Role)
+	}
+	if len(resp.Items) != 1 {
+		t.Fatalf("items: got %d want 1", len(resp.Items))
+	}
+}
+
+func TestKeycloakRoleMembers_404OnMissingRole(t *testing.T) {
+	h, dep, stub := newKCProxyHandler(t)
+	stub.roleMembersErr = keycloak.ErrRoleNotFound
+	r := chi.NewRouter()
+	registerKCProxyRoutes(r, h)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, reqWithClaims(http.MethodGet,
+		"/api/v1/sovereigns/"+dep.ID+"/keycloak/roles/missing/members", "", adminClaims()))
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status: got %d want 404", rec.Code)
+	}
+}
+
+func TestKeycloakClientRoles_HappyPath(t *testing.T) {
+	h, dep, stub := newKCProxyHandler(t)
+	stub.clientRoles = []keycloak.RealmRole{
+		{ID: "cr1", Name: "wordpress-editor", ClientRole: true},
+	}
+	r := chi.NewRouter()
+	registerKCProxyRoutes(r, h)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, reqWithClaims(http.MethodGet,
+		"/api/v1/sovereigns/"+dep.ID+"/keycloak/clients/client-uuid/roles", "", adminClaims()))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d", rec.Code)
+	}
+	var resp kcRoleListResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Items) != 1 || !resp.Items[0].ClientRole {
+		t.Errorf("client role surface mismatch: %+v", resp.Items)
+	}
+}
+
+func TestKeycloakRolesList_403WhenDeveloper(t *testing.T) {
+	h, dep, _ := newKCProxyHandler(t)
+	r := chi.NewRouter()
+	registerKCProxyRoutes(r, h)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, reqWithClaims(http.MethodGet,
+		"/api/v1/sovereigns/"+dep.ID+"/keycloak/roles", "", developerClaims()))
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status: got %d want 403", rec.Code)
+	}
+}
+
+// ── Mappers ──────────────────────────────────────────────────────────
+
+func TestKCUserToResult_FederationMapping(t *testing.T) {
+	cases := []struct {
+		name, link, want string
+	}{
+		{"native", "", "keycloak"},
+		{"azure-sso", "azure-sso-acme", "azure_ad_federated"},
+		{"azure-ad", "azure-ad-corp", "azure_ad_federated"},
+		{"okta", "okta-acme", "okta-acme"},
+		{"generic-oidc", "oidc-customer", "oidc-customer"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := kcUserToResult(keycloak.User{ID: "u1", FederationLink: tc.link})
+			if r.Source != tc.want {
+				t.Errorf("source: got %q want %q", r.Source, tc.want)
+			}
+		})
+	}
+}
+
+func TestKCParseLimit(t *testing.T) {
+	cases := []struct {
+		in   string
+		want int
+	}{
+		{"", 20},
+		{"abc", 20},
+		{"-5", 20},
+		{"0", 20},
+		{"15", 15},
+		{"99", 99},
+		{"500", 100},
+	}
+	for _, tc := range cases {
+		if got := kcParseLimit(tc.in); got != tc.want {
+			t.Errorf("kcParseLimit(%q): got %d want %d", tc.in, got, tc.want)
+		}
+	}
+}
+
+// Sanity: the *keycloak.Client satisfies the KeycloakAdminClient interface.
+// Compile-time assertion via blank assignment.
+var _ KeycloakAdminClient = (*keycloak.Client)(nil)
+
+// Compile-time check on the errors export used in this file.
+var _ = errors.Is

--- a/products/catalyst/bootstrap/api/internal/keycloak/admin_users.go
+++ b/products/catalyst/bootstrap/api/internal/keycloak/admin_users.go
@@ -1,0 +1,163 @@
+package keycloak
+
+// admin_users.go — Keycloak user search + role-membership lookups.
+//
+// EPIC-3 (#1098) slice U2/U4 surface: the multi-grant editor's user
+// picker (U2) calls SearchUsers; the realm-role browser (U4) calls
+// ListRealmRoleMembers + ListClientRoles. The pre-existing
+// findUserByEmail in client.go (single exact-email lookup for
+// EnsureUser / /auth/handover) is kept untouched — it serves a
+// different contract (find-or-create one specific user) and shouldn't
+// be conflated with the type-ahead search surface.
+//
+// Endpoints used (Keycloak Admin REST API, version 24.x):
+//
+//   GET /admin/realms/{realm}/users?search=<q>&max=<limit>&briefRepresentation=true
+//   GET /admin/realms/{realm}/roles/{name}/users
+//   GET /admin/realms/{realm}/clients/{clientUuid}/roles
+//
+// All three honour the same SA-token authentication pathway as the
+// rest of the package via serviceAccountToken().
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+)
+
+// User is the slim subset of Keycloak's UserRepresentation that
+// catalyst-api needs for the U2 picker + U4 role-members panel.
+//
+// FederationLink is the originating IdP alias for users provisioned
+// via the broker (e.g. "azure-sso-acme" for an Azure-AD-federated
+// user); empty for native Keycloak users. The proxy handler maps
+// this to the canonical `source` discriminator in A2's contract.
+type User struct {
+	ID             string `json:"id"`
+	Username       string `json:"username,omitempty"`
+	Email          string `json:"email,omitempty"`
+	FirstName      string `json:"firstName,omitempty"`
+	LastName       string `json:"lastName,omitempty"`
+	Enabled        bool   `json:"enabled,omitempty"`
+	EmailVerified  bool   `json:"emailVerified,omitempty"`
+	FederationLink string `json:"federationLink,omitempty"`
+}
+
+// SearchUsers proxies GET /admin/realms/{realm}/users?search=<q>&max=<limit>.
+//
+// KC's `search` parameter matches against username / email / firstName /
+// lastName with a substring (LIKE) semantic. Returns up to `limit`
+// users. `briefRepresentation=true` keeps the response compact —
+// callers that need full attributes should follow up with GetUser.
+//
+// Federated IdP users are surfaced inline because KC's GET /users
+// returns the union of native + federated users (the broker creates
+// a "shadow" federated user on first login, with `federationLink`
+// set to the IdP alias).
+func (c *Client) SearchUsers(ctx context.Context, search string, limit int) ([]User, error) {
+	saToken, err := c.serviceAccountToken(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("keycloak.SearchUsers: service account token: %w", err)
+	}
+	if limit <= 0 {
+		limit = 20
+	}
+	u := fmt.Sprintf("%s/admin/realms/%s/users?search=%s&max=%d&briefRepresentation=true",
+		c.addr, c.realm, url.QueryEscape(search), limit)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+saToken)
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("keycloak: GET users: %w", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("keycloak: GET users %d: %s", resp.StatusCode, body)
+	}
+	var users []User
+	if err := json.Unmarshal(body, &users); err != nil {
+		return nil, fmt.Errorf("keycloak: decode users: %w", err)
+	}
+	return users, nil
+}
+
+// ListRealmRoleMembers proxies GET /admin/realms/{realm}/roles/{name}/users.
+//
+// Returns the users DIRECTLY bound to the named realm role. Users
+// transitively in the role via group membership are NOT included
+// (that's the access-matrix endpoint A2's job). The role-browser UI
+// uses this for "who can act under this role today?".
+//
+// Returns ErrRoleNotFound on 404 so the handler can surface a clean
+// 404 to the caller.
+func (c *Client) ListRealmRoleMembers(ctx context.Context, name string) ([]User, error) {
+	saToken, err := c.serviceAccountToken(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("keycloak.ListRealmRoleMembers: service account token: %w", err)
+	}
+	u := fmt.Sprintf("%s/admin/realms/%s/roles/%s/users",
+		c.addr, c.realm, url.PathEscape(name))
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+saToken)
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("keycloak: GET role members: %w", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, ErrRoleNotFound
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("keycloak: GET role members %d: %s", resp.StatusCode, body)
+	}
+	var users []User
+	if err := json.Unmarshal(body, &users); err != nil {
+		return nil, fmt.Errorf("keycloak: decode role members: %w", err)
+	}
+	return users, nil
+}
+
+// ListClientRoles proxies GET /admin/realms/{realm}/clients/{clientUuid}/roles.
+//
+// `clientUUID` is the Keycloak-internal UUID of the OIDC client (NOT
+// the public clientId string). The U4 role-browser UI obtains this
+// from the live ListClients call before drilling into per-client
+// roles.
+func (c *Client) ListClientRoles(ctx context.Context, clientUUID string) ([]RealmRole, error) {
+	saToken, err := c.serviceAccountToken(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("keycloak.ListClientRoles: service account token: %w", err)
+	}
+	u := fmt.Sprintf("%s/admin/realms/%s/clients/%s/roles",
+		c.addr, c.realm, url.PathEscape(clientUUID))
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+saToken)
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("keycloak: GET client roles: %w", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("keycloak: GET client roles %d: %s", resp.StatusCode, body)
+	}
+	var roles []RealmRole
+	if err := json.Unmarshal(body, &roles); err != nil {
+		return nil, fmt.Errorf("keycloak: decode client roles: %w", err)
+	}
+	return roles, nil
+}

--- a/products/catalyst/bootstrap/api/internal/keycloak/admin_users_test.go
+++ b/products/catalyst/bootstrap/api/internal/keycloak/admin_users_test.go
@@ -1,0 +1,122 @@
+package keycloak
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// usersTestClient mirrors the helper in admin_groups_test.go: a
+// httptest.Server-backed Keycloak that returns the SA token on
+// /protocol/openid-connect/token and delegates everything else to the
+// per-test handler.
+func usersTestClient(t *testing.T, handler http.HandlerFunc) *Client {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/protocol/openid-connect/token") {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"access_token":"sa-token"}`))
+			return
+		}
+		handler(w, r)
+	}))
+	t.Cleanup(srv.Close)
+	return New(srv.URL, "test-realm", "test-client", "test-secret")
+}
+
+func TestSearchUsers_HappyPath(t *testing.T) {
+	c := usersTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasPrefix(r.URL.Path, "/admin/realms/test-realm/users") {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("search"); got != "ali" {
+			t.Errorf("search query: got %q want ali", got)
+		}
+		if got := r.URL.Query().Get("max"); got != "10" {
+			t.Errorf("max: got %q want 10", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[
+			{"id":"u1","username":"alice","email":"alice@acme.com","firstName":"Alice","lastName":"A"},
+			{"id":"u2","username":"bob.fed","federationLink":"azure-sso-acme"}
+		]`))
+	})
+	users, err := c.SearchUsers(context.Background(), "ali", 10)
+	if err != nil {
+		t.Fatalf("SearchUsers: %v", err)
+	}
+	if len(users) != 2 {
+		t.Fatalf("users: got %d want 2", len(users))
+	}
+	if users[0].Username != "alice" {
+		t.Errorf("user[0] username: got %q want alice", users[0].Username)
+	}
+	if users[1].FederationLink != "azure-sso-acme" {
+		t.Errorf("user[1] federationLink: got %q want azure-sso-acme", users[1].FederationLink)
+	}
+}
+
+func TestSearchUsers_DefaultLimit(t *testing.T) {
+	var seenMax string
+	c := usersTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		seenMax = r.URL.Query().Get("max")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[]`))
+	})
+	if _, err := c.SearchUsers(context.Background(), "x", 0); err != nil {
+		t.Fatalf("SearchUsers: %v", err)
+	}
+	if seenMax != "20" {
+		t.Errorf("default max: got %q want 20", seenMax)
+	}
+}
+
+func TestListRealmRoleMembers_HappyPath(t *testing.T) {
+	c := usersTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/roles/catalyst-admin/users") {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[{"id":"u1","username":"alice"}]`))
+	})
+	users, err := c.ListRealmRoleMembers(context.Background(), "catalyst-admin")
+	if err != nil {
+		t.Fatalf("ListRealmRoleMembers: %v", err)
+	}
+	if len(users) != 1 {
+		t.Fatalf("users: got %d want 1", len(users))
+	}
+}
+
+func TestListRealmRoleMembers_404(t *testing.T) {
+	c := usersTestClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	})
+	_, err := c.ListRealmRoleMembers(context.Background(), "missing")
+	if !errors.Is(err, ErrRoleNotFound) {
+		t.Fatalf("err: got %v want ErrRoleNotFound", err)
+	}
+}
+
+func TestListClientRoles_HappyPath(t *testing.T) {
+	c := usersTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/clients/client-uuid/roles") {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[{"id":"cr1","name":"editor","clientRole":true}]`))
+	})
+	roles, err := c.ListClientRoles(context.Background(), "client-uuid")
+	if err != nil {
+		t.Fatalf("ListClientRoles: %v", err)
+	}
+	if len(roles) != 1 {
+		t.Fatalf("roles: got %d want 1", len(roles))
+	}
+	if !roles[0].ClientRole {
+		t.Errorf("expected ClientRole=true; got %+v", roles[0])
+	}
+}

--- a/products/catalyst/bootstrap/ui/e2e/rbac-management.spec.ts
+++ b/products/catalyst/bootstrap/ui/e2e/rbac-management.spec.ts
@@ -1,0 +1,363 @@
+/**
+ * rbac-management.spec.ts — Playwright E2E for the EPIC-3 (#1098)
+ * RBAC management UI bundle (slice U1+U2+U3+U4).
+ *
+ * Six 1440x900 snapshots (per `feedback_per_issue_playwright_verification.md` —
+ * one per page, never collapsed):
+ *
+ *   1. multi-grant editor renders the full form
+ *   2. KCUserPicker search → results dropdown
+ *   3. multi-grant editor submit → toast "created"
+ *   4. group browser tree renders
+ *   5. group browser add subgroup
+ *   6. role browser realm-roles list + members panel
+ *
+ * Each test mocks the catalyst-api endpoints so the page renders
+ * deterministically without a live backend.
+ */
+
+import { test, expect, type Page, type Route } from '@playwright/test'
+
+const DEPLOYMENT_ID = 'rbac-1098'
+
+// ── Stub fixtures ──────────────────────────────────────────────────
+
+const ALICE = {
+  id: 'kc-uuid-alice',
+  username: 'alice',
+  email: 'alice@acme.com',
+  firstName: 'Alice',
+  lastName: 'Example',
+  source: 'keycloak',
+}
+
+const BOB_FED = {
+  id: 'kc-uuid-bob',
+  username: 'bob.fed',
+  email: 'bob@corp.com',
+  source: 'azure_ad_federated',
+}
+
+const KCROLES = [
+  {
+    id: 'r1',
+    name: 'catalyst-viewer',
+    composite: false,
+    attributes: { 'tier-level': ['10'] },
+    description: 'read-only',
+  },
+  {
+    id: 'r2',
+    name: 'catalyst-developer',
+    composite: true,
+    attributes: { 'tier-level': ['20'] },
+  },
+  {
+    id: 'r3',
+    name: 'catalyst-admin',
+    composite: true,
+    attributes: { 'tier-level': ['40'] },
+  },
+]
+
+const KCGROUPS = [
+  {
+    id: 'g1',
+    name: 'acme',
+    path: '/acme',
+    attributes: { org: ['acme'] },
+    subGroups: [
+      { id: 'g3', name: 'sre', path: '/acme/sre' },
+    ],
+  },
+  { id: 'g2', name: 'platform', path: '/platform' },
+]
+
+// ── Mock harness ───────────────────────────────────────────────────
+
+async function mockRBACAPI(page: Page) {
+  await page.route(/.*\/api\/v1\/whoami$/, (route: Route) => {
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ sub: 'test-admin', email: 'admin@example.com' }),
+    })
+  })
+
+  await page.route(/.*\/api\/v1\/sovereign\/self$/, (route: Route) => {
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ deploymentId: DEPLOYMENT_ID, sovereignFQDN: 'rbac.example' }),
+    })
+  })
+  await page.route(/.*\/api\/v1\/deployments\/[^/]+$/, (route: Route) => {
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ deploymentId: DEPLOYMENT_ID }),
+    })
+  })
+
+  // U2 — user search.
+  await page.route(/.*\/api\/v1\/sovereigns\/[^/]+\/keycloak\/users\?.*/, (route: Route) => {
+    const url = new URL(route.request().url())
+    const search = url.searchParams.get('search') ?? ''
+    let items = [ALICE, BOB_FED]
+    if (search.length > 0) {
+      const q = search.toLowerCase()
+      items = items.filter(
+        (u) =>
+          u.username.toLowerCase().includes(q) ||
+          (u.email ?? '').toLowerCase().includes(q),
+      )
+    }
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ items }),
+    })
+  })
+
+  // A1 — /rbac/assign — happy path returns "created".
+  let assignCount = 0
+  await page.route(/.*\/api\/v1\/sovereigns\/[^/]+\/rbac\/assign$/, (route: Route) => {
+    if (route.request().method() !== 'POST') {
+      route.continue()
+      return
+    }
+    assignCount += 1
+    route.fulfill({
+      status: 201,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        userAccess: { name: 'rbac-aliceacmecom-12345678', uid: 'fake-uid', namespace: '' },
+        tierClusterRole: 'openova:tier-developer',
+        applied: assignCount === 1 ? 'created' : 'no-op',
+      }),
+    })
+  })
+
+  // U3 — groups.
+  let groupsState = JSON.parse(JSON.stringify(KCGROUPS)) as typeof KCGROUPS
+  await page.route(/.*\/api\/v1\/sovereigns\/[^/]+\/keycloak\/groups$/, (route: Route) => {
+    const m = route.request().method()
+    if (m === 'GET') {
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ items: groupsState }),
+      })
+      return
+    }
+    if (m === 'POST') {
+      const body = route.request().postDataJSON()
+      const newG = {
+        id: 'gnew',
+        name: body.name,
+        path: body.parentId ? `/parent/${body.name}` : `/${body.name}`,
+        attributes: body.attributes ?? {},
+      }
+      groupsState = [...groupsState, newG]
+      route.fulfill({
+        status: 201,
+        contentType: 'application/json',
+        body: JSON.stringify(newG),
+      })
+      return
+    }
+    route.continue()
+  })
+  await page.route(
+    /.*\/api\/v1\/sovereigns\/[^/]+\/keycloak\/groups\/[^/]+$/,
+    (route: Route) => {
+      const m = route.request().method()
+      if (m === 'PUT') {
+        route.fulfill({ status: 200, contentType: 'application/json', body: '{}' })
+        return
+      }
+      if (m === 'DELETE') {
+        route.fulfill({ status: 204, body: '' })
+        return
+      }
+      route.continue()
+    },
+  )
+
+  // U4 — roles + members + client roles.
+  await page.route(/.*\/api\/v1\/sovereigns\/[^/]+\/keycloak\/roles$/, (route: Route) => {
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ items: KCROLES }),
+    })
+  })
+  await page.route(
+    /.*\/api\/v1\/sovereigns\/[^/]+\/keycloak\/roles\/[^/]+\/members$/,
+    (route: Route) => {
+      const url = route.request().url()
+      const m = url.match(/\/roles\/([^/]+)\/members$/)
+      const role = m ? decodeURIComponent(m[1]) : ''
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ role, items: [ALICE] }),
+      })
+    },
+  )
+  await page.route(
+    /.*\/api\/v1\/sovereigns\/[^/]+\/keycloak\/clients\/[^/]+\/roles$/,
+    (route: Route) => {
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ items: [{ id: 'cr1', name: 'wp-editor', clientRole: true }] }),
+      })
+    },
+  )
+}
+
+// ── Tests ──────────────────────────────────────────────────────────
+
+test.describe('RBAC management UI (slice U1+U2+U3+U4, #1098)', () => {
+  test.use({ viewport: { width: 1440, height: 900 } })
+
+  test('U1.1: multi-grant editor renders form scaffold', async ({ page }) => {
+    await mockRBACAPI(page)
+    await page.goto(`/provision/${DEPLOYMENT_ID}/rbac/grant`)
+    await page.waitForLoadState('domcontentloaded')
+    await page.waitForTimeout(600)
+    await expect(page.getByTestId('multi-grant-edit-page')).toBeVisible()
+    await expect(page.getByTestId('multi-grant-tier-picker')).toBeVisible()
+    await expect(page.getByTestId('multi-grant-scope-picker')).toBeVisible()
+    await expect(page.getByTestId('multi-grant-user-fieldset')).toBeVisible()
+    // Default tier action preview visible.
+    await expect(page.getByTestId('multi-grant-tier-preview-viewer')).toBeVisible()
+    await page.screenshot({
+      path: `playwright-report/rbac-u1-multi-grant-form-${DEPLOYMENT_ID}.png`,
+      fullPage: false,
+    })
+  })
+
+  test('U1.2: scope chip add + remove works against canonical vocab', async ({ page }) => {
+    await mockRBACAPI(page)
+    await page.goto(`/provision/${DEPLOYMENT_ID}/rbac/grant`)
+    await page.waitForTimeout(600)
+    // Pick scope key + value, click Add.
+    await page
+      .getByTestId('multi-grant-scope-key-input')
+      .selectOption('openova.io/application')
+    await page.getByTestId('multi-grant-scope-value-input').fill('wordpress')
+    await page.getByTestId('multi-grant-scope-add').click()
+    await expect(page.getByTestId('multi-grant-scope-chip-0')).toBeVisible()
+    await expect(page.getByTestId('multi-grant-scope-chip-0')).toContainText(
+      'openova.io/application=wordpress',
+    )
+    // Remove it again.
+    await page.getByTestId('multi-grant-scope-remove-0').click()
+    await expect(page.getByTestId('multi-grant-scope-empty')).toBeVisible()
+    await page.screenshot({
+      path: `playwright-report/rbac-u1-scope-chips-${DEPLOYMENT_ID}.png`,
+      fullPage: false,
+    })
+  })
+
+  test('U2: user picker search → results → click selects user', async ({ page }) => {
+    await mockRBACAPI(page)
+    await page.goto(`/provision/${DEPLOYMENT_ID}/rbac/grant`)
+    await page.waitForTimeout(600)
+    await page.getByTestId('kc-user-picker-input').fill('alice')
+    await page.waitForTimeout(500) // debounce + fetch
+    await expect(page.getByTestId('kc-user-picker-listbox')).toBeVisible()
+    await expect(page.getByTestId('kc-user-picker-result-kc-uuid-alice')).toBeVisible()
+    await page.screenshot({
+      path: `playwright-report/rbac-u2-user-picker-results-${DEPLOYMENT_ID}.png`,
+      fullPage: false,
+    })
+    await page.getByTestId('kc-user-picker-result-kc-uuid-alice').click()
+    await expect(page.getByTestId('multi-grant-user-pinned')).toBeVisible()
+  })
+
+  test('U1.3: full submit shows "created" toast', async ({ page }) => {
+    await mockRBACAPI(page)
+    await page.goto(`/provision/${DEPLOYMENT_ID}/rbac/grant`)
+    await page.waitForTimeout(600)
+    // Pick developer tier.
+    await page.getByTestId('multi-grant-tier-developer').click()
+    // Add a scope.
+    await page
+      .getByTestId('multi-grant-scope-key-input')
+      .selectOption('openova.io/application')
+    await page.getByTestId('multi-grant-scope-value-input').fill('wordpress')
+    await page.getByTestId('multi-grant-scope-add').click()
+    // Pick user.
+    await page.getByTestId('kc-user-picker-input').fill('alice')
+    await page.waitForTimeout(500)
+    await page.getByTestId('kc-user-picker-result-kc-uuid-alice').click()
+    // Apply.
+    await page.getByTestId('multi-grant-apply').click()
+    await page.waitForTimeout(500)
+    await expect(page.getByTestId('multi-grant-toast-ok')).toBeVisible()
+    await expect(page.getByTestId('multi-grant-toast-ok')).toContainText('Granted developer')
+    await page.screenshot({
+      path: `playwright-report/rbac-u1-toast-created-${DEPLOYMENT_ID}.png`,
+      fullPage: false,
+    })
+  })
+
+  test('U3: group browser tree renders', async ({ page }) => {
+    await mockRBACAPI(page)
+    await page.goto(`/provision/${DEPLOYMENT_ID}/rbac/groups`)
+    await page.waitForTimeout(600)
+    await expect(page.getByTestId('group-browser-page')).toBeVisible()
+    await expect(page.getByTestId('group-browser-tree')).toBeVisible()
+    await expect(page.getByTestId('group-browser-node-g1')).toBeVisible()
+    await expect(page.getByTestId('group-browser-node-g2')).toBeVisible()
+    // Sub-group rendered nested.
+    await expect(page.getByTestId('group-browser-node-g3')).toBeVisible()
+    await page.screenshot({
+      path: `playwright-report/rbac-u3-group-tree-${DEPLOYMENT_ID}.png`,
+      fullPage: false,
+    })
+  })
+
+  test('U3: add subgroup form posts to /keycloak/groups', async ({ page }) => {
+    await mockRBACAPI(page)
+    let lastCreate: unknown = null
+    page.on('request', (req) => {
+      if (req.method() === 'POST' && /\/keycloak\/groups$/.test(req.url())) {
+        lastCreate = req.postDataJSON()
+      }
+    })
+    await page.goto(`/provision/${DEPLOYMENT_ID}/rbac/groups`)
+    await page.waitForTimeout(600)
+    await page.getByTestId('group-browser-new-name').fill('billing')
+    await page.getByTestId('group-browser-new-submit').click()
+    await page.waitForTimeout(500)
+    expect(lastCreate).toMatchObject({ name: 'billing' })
+    await page.screenshot({
+      path: `playwright-report/rbac-u3-add-group-${DEPLOYMENT_ID}.png`,
+      fullPage: false,
+    })
+  })
+
+  test('U4: realm-roles list + members panel', async ({ page }) => {
+    await mockRBACAPI(page)
+    await page.goto(`/provision/${DEPLOYMENT_ID}/rbac/roles`)
+    await page.waitForTimeout(600)
+    await expect(page.getByTestId('role-browser-page')).toBeVisible()
+    await expect(page.getByTestId('role-browser-table')).toBeVisible()
+    await expect(page.getByTestId('role-browser-row-catalyst-viewer')).toBeVisible()
+    await expect(page.getByTestId('role-browser-row-catalyst-developer')).toBeVisible()
+    await expect(page.getByTestId('role-browser-row-catalyst-admin')).toBeVisible()
+    // Click a row → members panel renders.
+    await page.getByTestId('role-browser-row-catalyst-admin').click()
+    await page.waitForTimeout(500)
+    await expect(page.getByTestId('role-browser-members-catalyst-admin')).toBeVisible()
+    await expect(page.getByTestId('role-browser-member-kc-uuid-alice')).toBeVisible()
+    await page.screenshot({
+      path: `playwright-report/rbac-u4-realm-roles-${DEPLOYMENT_ID}.png`,
+      fullPage: false,
+    })
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/app/router.tsx
+++ b/products/catalyst/bootstrap/ui/src/app/router.tsx
@@ -68,6 +68,9 @@ import { CloudPage } from '@/pages/sovereign/CloudPage'
 import { DecommissionPage } from '@/pages/sovereign/DecommissionPage'
 import { UserAccessListPage } from '@/pages/admin/user-access/UserAccessListPage'
 import { UserAccessEditPage } from '@/pages/admin/user-access/UserAccessEditPage'
+import { MultiGrantEditPage } from '@/pages/admin/rbac/MultiGrantEditPage'
+import { GroupBrowserPage } from '@/pages/admin/rbac/GroupBrowserPage'
+import { RoleBrowserPage } from '@/pages/admin/rbac/RoleBrowserPage'
 import { ParentDomainsPage } from '@/pages/admin/parent-domains/ParentDomainsPage'
 import { SREDashboardPage } from '@/pages/admin/compliance/SREDashboardPage'
 import { SecLeadDashboardPage } from '@/pages/admin/compliance/SecLeadDashboardPage'
@@ -676,6 +679,34 @@ const provisionUsersEditRoute = createRoute({
   beforeLoad: provisionAuthGuard,
 })
 
+/* ── Sovereign IAM — multi-grant editor + group/role browser
+ *      (EPIC-3 #1098 slice U1+U3+U4) ───────────────────────────────
+ *
+ * Mounted under /provision/$deploymentId/rbac/* (mothership) and
+ * /rbac/* (chroot Sovereign Console — see consoleLayoutRoute below).
+ * The legacy /users routes (UserAccessEditPage) stay in place during
+ * the deprecation grace period; the multi-grant editor lives on a
+ * dedicated path so the UI surfaces both side-by-side.
+ */
+const provisionRBACMultiGrantRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/provision/$deploymentId/rbac/grant',
+  component: MultiGrantEditPage,
+  beforeLoad: provisionAuthGuard,
+})
+const provisionRBACGroupsRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/provision/$deploymentId/rbac/groups',
+  component: GroupBrowserPage,
+  beforeLoad: provisionAuthGuard,
+})
+const provisionRBACRolesRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/provision/$deploymentId/rbac/roles',
+  component: RoleBrowserPage,
+  beforeLoad: provisionAuthGuard,
+})
+
 /* ── Sovereign Settings (issue #516) ─────────────────────────────
  *
  * Deployment-scoped Settings surface. Replaces the legacy sidebar
@@ -896,6 +927,24 @@ const consoleUsersEditRoute = createRoute({
   path: '/users/$name',
   component: UserAccessEditPage,
 })
+
+// EPIC-3 (#1098) slice U1+U3+U4 — RBAC management chroot routes.
+const consoleRBACMultiGrantRoute = createRoute({
+  getParentRoute: () => consoleLayoutRoute,
+  path: '/rbac/grant',
+  component: MultiGrantEditPage,
+})
+const consoleRBACGroupsRoute = createRoute({
+  getParentRoute: () => consoleLayoutRoute,
+  path: '/rbac/groups',
+  component: GroupBrowserPage,
+})
+const consoleRBACRolesRoute = createRoute({
+  getParentRoute: () => consoleLayoutRoute,
+  path: '/rbac/roles',
+  component: RoleBrowserPage,
+})
+
 const consoleSettingsRoute = createRoute({
   getParentRoute: () => consoleLayoutRoute,
   path: '/settings',
@@ -1125,6 +1174,10 @@ const routeTree = rootRoute.addChildren([
   provisionUsersListRoute,
   provisionUsersNewRoute,
   provisionUsersEditRoute,
+  // EPIC-3 (#1098) slice U1+U3+U4 — multi-grant editor + group/role browsers.
+  provisionRBACMultiGrantRoute,
+  provisionRBACGroupsRoute,
+  provisionRBACRolesRoute,
   provisionSettingsRoute,
   provisionNotificationsRoute,
   // Compliance — slice U (#1096). Mother-side admin routes.
@@ -1150,6 +1203,10 @@ const routeTree = rootRoute.addChildren([
     consoleUsersRoute,
     consoleUsersNewRoute,
     consoleUsersEditRoute,
+    // EPIC-3 (#1098) slice U1+U3+U4 — RBAC management chroot routes.
+    consoleRBACMultiGrantRoute,
+    consoleRBACGroupsRoute,
+    consoleRBACRolesRoute,
     consoleSettingsRoute,
     consoleSettingsMarketplaceRoute,
     consoleSMEUsersRoute,

--- a/products/catalyst/bootstrap/ui/src/pages/admin/rbac/GroupBrowserPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/admin/rbac/GroupBrowserPage.tsx
@@ -1,0 +1,371 @@
+/**
+ * GroupBrowserPage — Keycloak group browser for sovereign-admin
+ * (EPIC-3 #1098 slice U3).
+ *
+ * Renders the realm's group tree (top-level → sub-groups, recursive).
+ * Supports add subgroup, delete, and inline attribute editing per the
+ * brief. The page is sovereign-admin only — the catalyst-api enforces
+ * the gate (returns 403 to non-admin callers); the UI surfaces the
+ * 403 as a banner so the operator knows their session lacks the
+ * permission rather than silently rendering an empty tree.
+ *
+ * Per the canonical-seam map, this page reuses:
+ *   - `authedFetch` via the rbac.api wrappers
+ *   - `useResolvedDeploymentId` for chroot vs mothership URL shape
+ *   - `PortalShell` for the chrome (sidebar + page-title bar)
+ *   - TanStack Query for cache + invalidation (no per-page state lib)
+ */
+
+import { useState } from 'react'
+import { useParams } from '@tanstack/react-router'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+
+import { PortalShell } from '@/pages/sovereign/PortalShell'
+import { useResolvedDeploymentId } from '@/shared/lib/useResolvedDeploymentId'
+import {
+  createKCGroup,
+  deleteKCGroup,
+  listKCGroups,
+  updateKCGroup,
+  type KCGroup,
+} from './rbac.api'
+
+interface GroupBrowserPageProps {
+  initialDeploymentId?: string
+}
+
+export function GroupBrowserPage({ initialDeploymentId }: GroupBrowserPageProps = {}) {
+  const params = useParams({ strict: false }) as { deploymentId?: string }
+  const { deploymentId: resolvedId } = useResolvedDeploymentId()
+  const deploymentId = initialDeploymentId ?? params.deploymentId ?? resolvedId ?? ''
+
+  const queryClient = useQueryClient()
+
+  const { data, isLoading, isError, error, refetch } = useQuery({
+    queryKey: ['kc-groups', deploymentId],
+    queryFn: () => listKCGroups(deploymentId),
+    enabled: !!deploymentId,
+    staleTime: 30_000,
+  })
+
+  const groups = data ?? []
+  const [newName, setNewName] = useState('')
+  const [parentId, setParentId] = useState<string>('')
+  const [createErr, setCreateErr] = useState<string | null>(null)
+
+  const createMutation = useMutation({
+    mutationFn: () =>
+      createKCGroup(deploymentId, {
+        name: newName.trim(),
+        parentId: parentId || undefined,
+      }),
+    onSuccess: () => {
+      setNewName('')
+      setParentId('')
+      setCreateErr(null)
+      queryClient.invalidateQueries({ queryKey: ['kc-groups', deploymentId] })
+    },
+    onError: (e: Error) => setCreateErr(e.message),
+  })
+
+  const deleteMutation = useMutation({
+    mutationFn: (id: string) => deleteKCGroup(deploymentId, id),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['kc-groups', deploymentId] }),
+  })
+
+  function handleCreate(e: React.FormEvent) {
+    e.preventDefault()
+    if (!newName.trim()) {
+      setCreateErr('group name is required')
+      return
+    }
+    createMutation.mutate()
+  }
+
+  function handleDelete(g: KCGroup) {
+    if (!g.id) return
+    if (!confirm(`Delete Keycloak group "${g.name}"?\nPath: ${g.path}\nThis revokes any role-mapping bound to this group.`)) {
+      return
+    }
+    deleteMutation.mutate(g.id)
+  }
+
+  // 403 surface (auth gate failed). Surface it explicitly so the
+  // operator knows to escalate vs assuming the realm is empty.
+  const isForbidden = isError && /HTTP 403/.test((error as Error)?.message ?? '')
+
+  return (
+    <PortalShell deploymentId={deploymentId} pageTitle="Keycloak Groups">
+      <div data-testid="group-browser-page" className="px-6 py-4">
+        <div className="mb-4 flex items-start justify-between">
+          <div>
+            <h1 className="text-xl font-semibold text-[var(--color-text-strong)]">Keycloak Groups</h1>
+            <p className="text-sm text-[var(--color-text-dim)]">
+              Browse, create, edit, and delete groups in the Sovereign realm. Sovereign-admin only.
+            </p>
+          </div>
+          <button
+            type="button"
+            data-testid="group-browser-refresh"
+            onClick={() => refetch()}
+            className="rounded-md border border-[var(--color-border)] px-3 py-1.5 text-xs hover:bg-[var(--color-bg-2)]"
+          >
+            Refresh
+          </button>
+        </div>
+
+        {isForbidden ? (
+          <div data-testid="group-browser-forbidden" className="mb-3 rounded-md border border-red-500/40 bg-red-500/10 px-3 py-2 text-sm text-red-300">
+            Forbidden — this page requires the sovereign-admin tier (admin or owner). Escalate via your Org owner.
+          </div>
+        ) : isError ? (
+          <div data-testid="group-browser-error" className="mb-3 rounded-md border border-red-500/40 bg-red-500/10 px-3 py-2 text-sm text-red-300">
+            {(error as Error)?.message ?? 'Failed to load groups'}
+          </div>
+        ) : null}
+
+        {isLoading ? (
+          <div data-testid="group-browser-loading" className="text-sm text-[var(--color-text-dim)]">
+            Loading…
+          </div>
+        ) : groups.length === 0 && !isError ? (
+          <div data-testid="group-browser-empty" className="rounded-md border border-[var(--color-border)] px-4 py-8 text-center text-sm text-[var(--color-text-dim)]">
+            No groups in the realm. Use the form below to add the first one.
+          </div>
+        ) : (
+          <ul data-testid="group-browser-tree" className="space-y-1 rounded-md border border-[var(--color-border)] p-3">
+            {groups.map((g) => (
+              <GroupNode
+                key={g.id ?? g.path ?? g.name}
+                group={g}
+                depth={0}
+                deploymentId={deploymentId}
+                onDelete={handleDelete}
+              />
+            ))}
+          </ul>
+        )}
+
+        <form onSubmit={handleCreate} className="mt-6 rounded-md border border-[var(--color-border)] p-3">
+          <h2 className="text-xs uppercase text-[var(--color-text-dim)]">Add group</h2>
+          <div className="mt-2 flex flex-wrap items-center gap-2">
+            <input
+              data-testid="group-browser-new-name"
+              type="text"
+              value={newName}
+              onChange={(e) => setNewName(e.target.value)}
+              placeholder="group name"
+              className="rounded border border-[var(--color-border)] bg-[var(--color-bg)] px-2 py-1 text-sm font-mono"
+            />
+            <select
+              data-testid="group-browser-new-parent"
+              value={parentId}
+              onChange={(e) => setParentId(e.target.value)}
+              className="rounded border border-[var(--color-border)] bg-[var(--color-bg)] px-2 py-1 text-sm font-mono"
+              aria-label="Parent group (optional)"
+            >
+              <option value="">No parent (top-level)</option>
+              {flattenGroups(groups).map((g) => (
+                <option key={g.id ?? g.path ?? g.name} value={g.id ?? ''}>
+                  {g.path ?? g.name}
+                </option>
+              ))}
+            </select>
+            <button
+              type="submit"
+              data-testid="group-browser-new-submit"
+              disabled={createMutation.isPending}
+              className="rounded-md bg-[var(--color-accent)] px-3 py-1 text-sm font-medium text-white hover:opacity-90 disabled:opacity-50"
+            >
+              {createMutation.isPending ? 'Creating…' : 'Add'}
+            </button>
+          </div>
+          {createErr ? (
+            <p data-testid="group-browser-new-err" className="mt-1 text-xs text-red-300">
+              {createErr}
+            </p>
+          ) : null}
+        </form>
+      </div>
+    </PortalShell>
+  )
+}
+
+interface GroupNodeProps {
+  group: KCGroup
+  depth: number
+  deploymentId: string
+  onDelete: (g: KCGroup) => void
+}
+
+function GroupNode({ group, depth, deploymentId, onDelete }: GroupNodeProps) {
+  const [editing, setEditing] = useState(false)
+  return (
+    <li
+      data-testid={`group-browser-node-${group.id ?? group.name}`}
+      className="text-sm"
+      style={{ paddingLeft: `${depth * 12}px` }}
+    >
+      <div className="flex items-center justify-between gap-2 py-1">
+        <span className="font-mono text-[var(--color-text)]">
+          <span className="text-[var(--color-text-dim)]">{depth > 0 ? '↳ ' : ''}</span>
+          {group.name}
+          {group.path ? (
+            <span className="ml-2 text-xs text-[var(--color-text-dim)]">{group.path}</span>
+          ) : null}
+        </span>
+        <span className="flex items-center gap-2">
+          <button
+            type="button"
+            data-testid={`group-browser-edit-${group.id ?? group.name}`}
+            onClick={() => setEditing((v) => !v)}
+            className="text-xs text-[var(--color-text-dim)] hover:text-[var(--color-text)]"
+          >
+            {editing ? 'Close' : 'Edit attrs'}
+          </button>
+          <button
+            type="button"
+            data-testid={`group-browser-delete-${group.id ?? group.name}`}
+            onClick={() => onDelete(group)}
+            className="text-xs text-red-400 hover:underline"
+          >
+            Delete
+          </button>
+        </span>
+      </div>
+      {editing && group.id ? (
+        <AttributesEditor
+          deploymentId={deploymentId}
+          groupId={group.id}
+          attributes={group.attributes ?? {}}
+        />
+      ) : null}
+      {group.subGroups && group.subGroups.length > 0 ? (
+        <ul className="space-y-0.5">
+          {group.subGroups.map((c) => (
+            <GroupNode
+              key={c.id ?? c.path ?? c.name}
+              group={c}
+              depth={depth + 1}
+              deploymentId={deploymentId}
+              onDelete={onDelete}
+            />
+          ))}
+        </ul>
+      ) : null}
+    </li>
+  )
+}
+
+interface AttributesEditorProps {
+  deploymentId: string
+  groupId: string
+  attributes: Record<string, string[]>
+}
+
+function AttributesEditor({ deploymentId, groupId, attributes }: AttributesEditorProps) {
+  const queryClient = useQueryClient()
+  const [rows, setRows] = useState<Array<{ key: string; value: string }>>(() => {
+    const out: Array<{ key: string; value: string }> = []
+    for (const [k, vs] of Object.entries(attributes)) {
+      for (const v of vs) {
+        out.push({ key: k, value: v })
+      }
+    }
+    return out
+  })
+  const [error, setError] = useState<string | null>(null)
+
+  const mutation = useMutation({
+    mutationFn: () => {
+      const grouped: Record<string, string[]> = {}
+      for (const r of rows) {
+        const k = r.key.trim()
+        const v = r.value.trim()
+        if (!k) continue
+        if (!grouped[k]) grouped[k] = []
+        grouped[k].push(v)
+      }
+      return updateKCGroup(deploymentId, groupId, { attributes: grouped })
+    },
+    onSuccess: () => {
+      setError(null)
+      queryClient.invalidateQueries({ queryKey: ['kc-groups', deploymentId] })
+    },
+    onError: (e: Error) => setError(e.message),
+  })
+
+  return (
+    <div
+      data-testid={`group-browser-attrs-editor-${groupId}`}
+      className="ml-4 mt-1 rounded border border-[var(--color-border)] bg-[var(--color-bg-2)] p-2"
+    >
+      {rows.map((r, i) => (
+        <div key={i} className="mb-1 flex items-center gap-2">
+          <input
+            type="text"
+            value={r.key}
+            onChange={(e) =>
+              setRows((rs) => rs.map((x, j) => (j === i ? { ...x, key: e.target.value } : x)))
+            }
+            placeholder="key"
+            className="rounded border border-[var(--color-border)] bg-[var(--color-bg)] px-2 py-0.5 text-xs font-mono"
+            data-testid={`group-browser-attrs-key-${groupId}-${i}`}
+          />
+          <input
+            type="text"
+            value={r.value}
+            onChange={(e) =>
+              setRows((rs) => rs.map((x, j) => (j === i ? { ...x, value: e.target.value } : x)))
+            }
+            placeholder="value"
+            className="flex-1 rounded border border-[var(--color-border)] bg-[var(--color-bg)] px-2 py-0.5 text-xs font-mono"
+            data-testid={`group-browser-attrs-value-${groupId}-${i}`}
+          />
+          <button
+            type="button"
+            onClick={() => setRows((rs) => rs.filter((_, j) => j !== i))}
+            className="text-xs text-red-400 hover:underline"
+            data-testid={`group-browser-attrs-remove-${groupId}-${i}`}
+          >
+            ×
+          </button>
+        </div>
+      ))}
+      <div className="mt-1 flex items-center gap-2">
+        <button
+          type="button"
+          onClick={() => setRows((rs) => [...rs, { key: '', value: '' }])}
+          className="text-xs text-[var(--color-text-dim)] hover:text-[var(--color-text)]"
+          data-testid={`group-browser-attrs-add-${groupId}`}
+        >
+          + Add row
+        </button>
+        <button
+          type="button"
+          onClick={() => mutation.mutate()}
+          disabled={mutation.isPending}
+          className="rounded-md bg-[var(--color-accent)] px-2 py-0.5 text-xs font-medium text-white hover:opacity-90 disabled:opacity-50"
+          data-testid={`group-browser-attrs-save-${groupId}`}
+        >
+          {mutation.isPending ? 'Saving…' : 'Save'}
+        </button>
+      </div>
+      {error ? (
+        <p className="mt-1 text-xs text-red-300" data-testid={`group-browser-attrs-err-${groupId}`}>
+          {error}
+        </p>
+      ) : null}
+    </div>
+  )
+}
+
+function flattenGroups(groups: KCGroup[]): KCGroup[] {
+  const out: KCGroup[] = []
+  function walk(g: KCGroup) {
+    out.push(g)
+    if (g.subGroups) for (const c of g.subGroups) walk(c)
+  }
+  for (const g of groups) walk(g)
+  return out
+}

--- a/products/catalyst/bootstrap/ui/src/pages/admin/rbac/MultiGrantEditPage.test.ts
+++ b/products/catalyst/bootstrap/ui/src/pages/admin/rbac/MultiGrantEditPage.test.ts
@@ -1,0 +1,132 @@
+/**
+ * MultiGrantEditPage.test.ts — pure-function tests for the form-state
+ * reducer + validator (EPIC-3 #1098 slice U1).
+ *
+ * The full DOM render path is exercised in the Playwright E2E suite
+ * (per the brief — vitest covers the testable seams in isolation
+ * because TanStack Router is hard to bootstrap inside jsdom).
+ */
+
+import { describe, expect, it } from 'vitest'
+
+import {
+  INITIAL_FORM_STATE,
+  multiGrantReducer,
+  validateMultiGrantForm,
+} from './multiGrantState'
+import type { KCUser } from './rbac.api'
+
+const ALICE: KCUser = {
+  id: 'kc-uuid-alice',
+  username: 'alice',
+  email: 'alice@acme.com',
+  source: 'keycloak',
+}
+
+describe('multiGrantReducer', () => {
+  it('starts empty (viewer tier, no scope, no user)', () => {
+    expect(INITIAL_FORM_STATE.tier).toBe('viewer')
+    expect(INITIAL_FORM_STATE.scope).toEqual([])
+    expect(INITIAL_FORM_STATE.user).toBeNull()
+  })
+
+  it('set-tier replaces the tier without touching scope/user', () => {
+    const s1 = multiGrantReducer(INITIAL_FORM_STATE, { type: 'set-tier', tier: 'admin' })
+    expect(s1.tier).toBe('admin')
+    expect(s1.scope).toEqual([])
+    expect(s1.user).toBeNull()
+  })
+
+  it('set-user pins the user', () => {
+    const s1 = multiGrantReducer(INITIAL_FORM_STATE, { type: 'set-user', user: ALICE })
+    expect(s1.user).toEqual(ALICE)
+  })
+
+  it('add-scope appends a (key,value) chip', () => {
+    const s1 = multiGrantReducer(INITIAL_FORM_STATE, {
+      type: 'add-scope',
+      key: 'openova.io/application',
+      value: 'wordpress',
+    })
+    expect(s1.scope).toEqual([{ key: 'openova.io/application', value: 'wordpress' }])
+  })
+
+  it('add-scope dedupes (key,value) — re-adding is a no-op', () => {
+    const s1 = multiGrantReducer(INITIAL_FORM_STATE, {
+      type: 'add-scope',
+      key: 'openova.io/application',
+      value: 'wordpress',
+    })
+    const s2 = multiGrantReducer(s1, {
+      type: 'add-scope',
+      key: 'openova.io/application',
+      value: 'wordpress',
+    })
+    expect(s2.scope).toHaveLength(1)
+  })
+
+  it('add-scope clears pending fields', () => {
+    const s1: typeof INITIAL_FORM_STATE = {
+      ...INITIAL_FORM_STATE,
+      pendingKey: 'openova.io/env-type',
+      pendingValue: 'dev',
+    }
+    const s2 = multiGrantReducer(s1, {
+      type: 'add-scope',
+      key: 'openova.io/env-type',
+      value: 'dev',
+    })
+    expect(s2.pendingKey).toBe('')
+    expect(s2.pendingValue).toBe('')
+  })
+
+  it('remove-scope removes by index', () => {
+    let s = INITIAL_FORM_STATE
+    s = multiGrantReducer(s, { type: 'add-scope', key: 'openova.io/application', value: 'a' })
+    s = multiGrantReducer(s, { type: 'add-scope', key: 'openova.io/application', value: 'b' })
+    s = multiGrantReducer(s, { type: 'remove-scope', index: 0 })
+    expect(s.scope).toEqual([{ key: 'openova.io/application', value: 'b' }])
+  })
+
+  it('reset returns to INITIAL_FORM_STATE', () => {
+    let s = INITIAL_FORM_STATE
+    s = multiGrantReducer(s, { type: 'set-user', user: ALICE })
+    s = multiGrantReducer(s, { type: 'set-tier', tier: 'admin' })
+    s = multiGrantReducer(s, { type: 'reset' })
+    expect(s).toEqual(INITIAL_FORM_STATE)
+  })
+})
+
+describe('validateMultiGrantForm', () => {
+  it('rejects when no user is picked', () => {
+    expect(validateMultiGrantForm(INITIAL_FORM_STATE)).toBe('Pick a Keycloak user')
+  })
+
+  it('passes with user + viewer + no scope (global grant)', () => {
+    const s = multiGrantReducer(INITIAL_FORM_STATE, { type: 'set-user', user: ALICE })
+    expect(validateMultiGrantForm(s)).toBeNull()
+  })
+
+  it('rejects unknown scope keys', () => {
+    let s = multiGrantReducer(INITIAL_FORM_STATE, { type: 'set-user', user: ALICE })
+    s = { ...s, scope: [{ key: 'unknownkey', value: 'foo' }] }
+    expect(validateMultiGrantForm(s)).toMatch(/unknown scope key/)
+  })
+
+  it('rejects empty scope value', () => {
+    let s = multiGrantReducer(INITIAL_FORM_STATE, { type: 'set-user', user: ALICE })
+    s = { ...s, scope: [{ key: 'openova.io/application', value: '' }] }
+    expect(validateMultiGrantForm(s)).toBe('scope value is required')
+  })
+
+  it('passes a fully composed grant', () => {
+    let s = multiGrantReducer(INITIAL_FORM_STATE, { type: 'set-user', user: ALICE })
+    s = multiGrantReducer(s, { type: 'set-tier', tier: 'developer' })
+    s = multiGrantReducer(s, {
+      type: 'add-scope',
+      key: 'openova.io/application',
+      value: 'wordpress',
+    })
+    expect(validateMultiGrantForm(s)).toBeNull()
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/pages/admin/rbac/MultiGrantEditPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/admin/rbac/MultiGrantEditPage.tsx
@@ -1,0 +1,382 @@
+/**
+ * MultiGrantEditPage — multi-grant role assignment editor for the
+ * Sovereign IAM (EPIC-3 #1098 slice U1).
+ *
+ * Replaces the legacy single-grant `UserAccessEditPage` (issue #323)
+ * with the find-or-create-role contract from slice A1 (#1143):
+ *
+ *   1. Operator picks a tier (radio, with action-set tooltip preview).
+ *   2. Operator adds scope chips (label-key + label-value, validated
+ *      against NAMING-CONVENTION.md §6 vocab — INVIOLABLE-PRINCIPLES #4).
+ *   3. Operator picks a Keycloak user via the U2 KCUserPicker widget.
+ *   4. Apply → POST /rbac/assign — backend resolves to created /
+ *      updated / no-op based on whether a UserAccess CR for the
+ *      (user, scope) pair already exists.
+ *
+ * Per the canonical-seam map: this page extends the existing user-access
+ * file tree in place rather than spawning a parallel surface. The
+ * router still mounts UserAccessListPage at `/users` (read-only list);
+ * the multi-grant editor lives at `/users/multi-grant` and the legacy
+ * UserAccessEditPage stays at `/users/new` + `/users/$name` for the
+ * deprecation grace period.
+ *
+ * Per the post-merge response semantics:
+ *   - `applied: created` → 201; toast "Granted <tier> to <user>"
+ *   - `applied: updated` → 200; toast "Updated <user> from <prevTier> to <tier>"
+ *   - `applied: no-op`   → 200; toast "Already granted — no change"
+ */
+
+import { useMemo, useReducer, useState } from 'react'
+import { useNavigate, useParams } from '@tanstack/react-router'
+import { useMutation } from '@tanstack/react-query'
+
+import { DETECTED_MODE } from '@/shared/lib/detectMode'
+import { PortalShell } from '@/pages/sovereign/PortalShell'
+import { useResolvedDeploymentId } from '@/shared/lib/useResolvedDeploymentId'
+import { KCUserPicker } from '@/widgets/rbac/KCUserPicker'
+import {
+  RBAC_TIERS,
+  RBAC_SCOPE_KEYS,
+  TIER_ACTION_SETS,
+  TIER_AUTO_INJECTED_SCOPES,
+  rbacAssign,
+  validateScopeKey,
+  validateScopeValue,
+  type RBACAssignResponse,
+  type RBACTier,
+} from './rbac.api'
+import {
+  INITIAL_FORM_STATE,
+  multiGrantReducer,
+  validateMultiGrantForm,
+} from './multiGrantState'
+
+/* ── Page ─────────────────────────────────────────────────────────── */
+
+export interface MultiGrantEditPageProps {
+  /** Test seam — pre-fills the deployment id without TanStack Router. */
+  initialDeploymentId?: string
+  /** Test seam — prevents navigate-on-success. */
+  disableNavigate?: boolean
+}
+
+export function MultiGrantEditPage({
+  initialDeploymentId,
+  disableNavigate = false,
+}: MultiGrantEditPageProps = {}) {
+  const params = useParams({ strict: false }) as { deploymentId?: string }
+  const { deploymentId: resolvedId } = useResolvedDeploymentId()
+  const deploymentId = initialDeploymentId ?? params.deploymentId ?? resolvedId ?? ''
+  const navigate = useNavigate()
+
+  const [form, dispatch] = useReducer(multiGrantReducer, INITIAL_FORM_STATE)
+  const [toast, setToast] = useState<{ kind: 'ok' | 'err'; msg: string } | null>(null)
+  const [pendingErr, setPendingErr] = useState<string | null>(null)
+
+  const validationError = useMemo(() => validateMultiGrantForm(form), [form])
+
+  const mutation = useMutation({
+    mutationFn: async () => {
+      const body = {
+        user: form.user!.email
+          ? { email: form.user!.email, keycloakSubject: form.user!.id }
+          : { keycloakSubject: form.user!.id },
+        tier: form.tier,
+        scope: form.scope,
+      }
+      return rbacAssign(deploymentId, body)
+    },
+    onSuccess: (resp: RBACAssignResponse) => {
+      const userLabel = form.user?.email ?? form.user?.username ?? '<user>'
+      switch (resp.applied) {
+        case 'created':
+          setToast({
+            kind: 'ok',
+            msg: `Granted ${form.tier} to ${userLabel}. Bound to ${resp.tierClusterRole}.`,
+          })
+          break
+        case 'updated':
+          setToast({
+            kind: 'ok',
+            msg: `Updated ${userLabel}'s grant. Now ${form.tier} (was a different tier on the same scope).`,
+          })
+          break
+        case 'no-op':
+          setToast({
+            kind: 'ok',
+            msg: `Already granted — ${userLabel} already has ${form.tier} on this scope. No change.`,
+          })
+          break
+      }
+      // Navigate back to the list view after a short delay, unless the
+      // test seam pins us in place.
+      if (disableNavigate) return
+      setTimeout(() => {
+        navigate({
+          to: (DETECTED_MODE.mode === 'sovereign' || !deploymentId
+            ? '/users'
+            : `/provision/${deploymentId}/users`) as never,
+          params: { deploymentId } as never,
+        })
+      }, 800)
+    },
+    onError: (err: Error) => {
+      setToast({ kind: 'err', msg: err.message })
+    },
+  })
+
+  function onAddScope(e: React.FormEvent) {
+    e.preventDefault()
+    setPendingErr(null)
+    const ke = validateScopeKey(form.pendingKey)
+    if (ke) {
+      setPendingErr(ke)
+      return
+    }
+    const ve = validateScopeValue(form.pendingValue)
+    if (ve) {
+      setPendingErr(ve)
+      return
+    }
+    dispatch({ type: 'add-scope', key: form.pendingKey, value: form.pendingValue })
+  }
+
+  function onSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault()
+    if (validationError) {
+      setToast({ kind: 'err', msg: validationError })
+      return
+    }
+    setToast(null)
+    mutation.mutate()
+  }
+
+  return (
+    <PortalShell deploymentId={deploymentId} pageTitle="New User Access Grant">
+      <div data-testid="multi-grant-edit-page" className="mx-auto max-w-2xl px-6 py-4">
+        <p className="mb-4 text-sm text-[var(--color-text-dim)]">
+          Pick a tier, add scopes, choose a Keycloak user. We resolve to the right UserAccess CR
+          (find-or-create) so re-granting the same user on the same scope is idempotent.
+        </p>
+
+        {toast ? (
+          <div
+            data-testid={toast.kind === 'ok' ? 'multi-grant-toast-ok' : 'multi-grant-toast-err'}
+            className={`mb-3 rounded-md border px-3 py-2 text-sm ${
+              toast.kind === 'ok'
+                ? 'border-emerald-500/40 bg-emerald-500/10 text-emerald-300'
+                : 'border-red-500/40 bg-red-500/10 text-red-300'
+            }`}
+          >
+            {toast.msg}
+          </div>
+        ) : null}
+
+        <form onSubmit={onSubmit} className="flex flex-col gap-5">
+          {/* Tier picker */}
+          <fieldset data-testid="multi-grant-tier-picker">
+            <legend className="text-xs uppercase text-[var(--color-text-dim)]">Tier</legend>
+            <div className="mt-2 grid grid-cols-1 gap-2 sm:grid-cols-5">
+              {RBAC_TIERS.map((t) => (
+                <TierRadio
+                  key={t}
+                  tier={t}
+                  selected={form.tier === t}
+                  onSelect={() => dispatch({ type: 'set-tier', tier: t })}
+                />
+              ))}
+            </div>
+            <TierActionPreview tier={form.tier} />
+          </fieldset>
+
+          {/* Scope chips */}
+          <fieldset data-testid="multi-grant-scope-picker">
+            <legend className="text-xs uppercase text-[var(--color-text-dim)]">Scope</legend>
+
+            <div className="mt-2 flex flex-wrap gap-2">
+              {form.scope.length === 0 ? (
+                <span data-testid="multi-grant-scope-empty" className="text-xs text-[var(--color-text-dim)]">
+                  No scopes — grant will be GLOBAL across this Sovereign.
+                </span>
+              ) : (
+                form.scope.map((s, i) => (
+                  <span
+                    key={`${s.key}=${s.value}`}
+                    data-testid={`multi-grant-scope-chip-${i}`}
+                    className="inline-flex items-center gap-1 rounded-full border border-[var(--color-border)] bg-[var(--color-bg-2)] px-2 py-0.5 text-xs"
+                  >
+                    <span className="font-mono">
+                      {s.key}={s.value}
+                    </span>
+                    <button
+                      type="button"
+                      data-testid={`multi-grant-scope-remove-${i}`}
+                      aria-label={`Remove scope ${s.key}=${s.value}`}
+                      onClick={() => dispatch({ type: 'remove-scope', index: i })}
+                      className="rounded-full px-1 text-[var(--color-text-dim)] hover:text-red-400"
+                    >
+                      ×
+                    </button>
+                  </span>
+                ))
+              )}
+            </div>
+
+            {/* Auto-injected scope notice (e.g. developer→env-type=dev). */}
+            {TIER_AUTO_INJECTED_SCOPES[form.tier]?.length ? (
+              <p className="mt-2 text-xs text-[var(--color-text-dim)]" data-testid="multi-grant-auto-scope-notice">
+                Auto-injected by the controller for tier <code className="font-mono">{form.tier}</code>:{' '}
+                {TIER_AUTO_INJECTED_SCOPES[form.tier]!
+                  .map((s) => `${s.key}=${s.value}`)
+                  .join(', ')}
+              </p>
+            ) : null}
+
+            <div className="mt-3 flex flex-wrap gap-2">
+              <select
+                data-testid="multi-grant-scope-key-input"
+                value={form.pendingKey}
+                onChange={(e) => dispatch({ type: 'set-pending-key', value: e.target.value })}
+                className="rounded border border-[var(--color-border)] bg-[var(--color-bg)] px-2 py-1 text-xs font-mono"
+                aria-label="Scope key"
+              >
+                <option value="">Select key…</option>
+                {RBAC_SCOPE_KEYS.map((k) => (
+                  <option key={k} value={k}>
+                    {k}
+                  </option>
+                ))}
+              </select>
+              <input
+                data-testid="multi-grant-scope-value-input"
+                type="text"
+                value={form.pendingValue}
+                onChange={(e) => dispatch({ type: 'set-pending-value', value: e.target.value })}
+                placeholder="value (e.g. wordpress)"
+                className="flex-1 rounded border border-[var(--color-border)] bg-[var(--color-bg)] px-2 py-1 text-xs font-mono"
+                aria-label="Scope value"
+              />
+              <button
+                type="button"
+                data-testid="multi-grant-scope-add"
+                onClick={onAddScope}
+                className="rounded-md border border-[var(--color-border)] px-2 py-1 text-xs hover:bg-[var(--color-bg-2)]"
+              >
+                + Add scope
+              </button>
+            </div>
+            {pendingErr ? (
+              <p data-testid="multi-grant-scope-err" className="mt-1 text-xs text-red-300">
+                {pendingErr}
+              </p>
+            ) : null}
+          </fieldset>
+
+          {/* User picker (U2) */}
+          <fieldset data-testid="multi-grant-user-fieldset">
+            <legend className="text-xs uppercase text-[var(--color-text-dim)]">User</legend>
+            <div className="mt-2">
+              <KCUserPicker
+                sovereignId={deploymentId}
+                onSelect={(u) => dispatch({ type: 'set-user', user: u })}
+                initialQuery={form.user?.email ?? form.user?.username ?? ''}
+              />
+            </div>
+            {form.user ? (
+              <p data-testid="multi-grant-user-pinned" className="mt-1 text-xs text-[var(--color-text-dim)]">
+                Selected:{' '}
+                <code className="font-mono text-[var(--color-text)]">
+                  {form.user.email ?? form.user.username}
+                </code>{' '}
+                (source: <code className="font-mono">{form.user.source}</code>)
+              </p>
+            ) : null}
+          </fieldset>
+
+          {/* Submit row */}
+          <div className="flex items-center justify-end gap-2 pt-2">
+            <button
+              type="button"
+              data-testid="multi-grant-cancel"
+              onClick={() => {
+                if (disableNavigate) return
+                navigate({
+                  to: (DETECTED_MODE.mode === 'sovereign' || !deploymentId
+                    ? '/users'
+                    : `/provision/${deploymentId}/users`) as never,
+                  params: { deploymentId } as never,
+                })
+              }}
+              className="rounded-md border border-[var(--color-border)] px-3 py-1.5 text-sm hover:bg-[var(--color-bg-2)]"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              data-testid="multi-grant-apply"
+              disabled={!!validationError || mutation.isPending}
+              className="rounded-md bg-[var(--color-accent)] px-3 py-1.5 text-sm font-medium text-white hover:opacity-90 disabled:opacity-50"
+              title={validationError ?? 'Apply this grant'}
+            >
+              {mutation.isPending ? 'Applying…' : 'Apply'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </PortalShell>
+  )
+}
+
+/* ── Sub-components ───────────────────────────────────────────────── */
+
+function TierRadio({
+  tier,
+  selected,
+  onSelect,
+}: {
+  tier: RBACTier
+  selected: boolean
+  onSelect: () => void
+}) {
+  return (
+    <label
+      data-testid={`multi-grant-tier-${tier}`}
+      className={`cursor-pointer rounded-md border px-3 py-2 text-center text-sm transition-colors ${
+        selected
+          ? 'border-emerald-500/60 bg-emerald-500/10 text-emerald-200'
+          : 'border-[var(--color-border)] bg-[var(--color-bg-2)] text-[var(--color-text)] hover:border-[var(--color-border)]'
+      }`}
+      title={TIER_ACTION_SETS[tier].join('\n')}
+    >
+      <input
+        type="radio"
+        name="tier"
+        value={tier}
+        checked={selected}
+        onChange={onSelect}
+        className="sr-only"
+      />
+      <span className="block font-mono uppercase">{tier}</span>
+    </label>
+  )
+}
+
+function TierActionPreview({ tier }: { tier: RBACTier }) {
+  return (
+    <div
+      data-testid={`multi-grant-tier-preview-${tier}`}
+      className="mt-2 rounded-md border border-[var(--color-border)] bg-[var(--color-bg-2)] px-3 py-2"
+    >
+      <p className="text-xs uppercase text-[var(--color-text-dim)]">
+        Actions granted by <code className="font-mono">{tier}</code>:
+      </p>
+      <ul className="mt-1 list-disc pl-5 text-xs text-[var(--color-text-dim)]">
+        {TIER_ACTION_SETS[tier].map((a) => (
+          <li key={a} className="font-mono">
+            {a}
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/products/catalyst/bootstrap/ui/src/pages/admin/rbac/RoleBrowserPage.test.ts
+++ b/products/catalyst/bootstrap/ui/src/pages/admin/rbac/RoleBrowserPage.test.ts
@@ -1,0 +1,56 @@
+/**
+ * RoleBrowserPage.test.ts — pure-function tests for the helpers
+ * exported by the role browser (EPIC-3 #1098 slice U4).
+ */
+
+import { describe, expect, it } from 'vitest'
+
+import { readTierLevel, sortRolesByTierLevel } from './roleHelpers'
+import type { KCRole } from './rbac.api'
+
+const role = (name: string, level?: string): KCRole => ({
+  name,
+  attributes: level ? { 'tier-level': [level] } : undefined,
+})
+
+describe('readTierLevel', () => {
+  it('returns the integer when tier-level attribute is set', () => {
+    expect(readTierLevel(role('catalyst-viewer', '10'))).toBe(10)
+    expect(readTierLevel(role('catalyst-owner', '50'))).toBe(50)
+  })
+
+  it('returns null when tier-level is unset', () => {
+    expect(readTierLevel(role('custom-role'))).toBeNull()
+  })
+
+  it('returns null when tier-level is non-numeric', () => {
+    expect(readTierLevel(role('weird', 'abc'))).toBeNull()
+  })
+})
+
+describe('sortRolesByTierLevel', () => {
+  it('sorts ascending by tier-level, then alphabetical', () => {
+    const roles: KCRole[] = [
+      role('catalyst-admin', '40'),
+      role('catalyst-viewer', '10'),
+      role('zz-untiered'),
+      role('aa-untiered'),
+      role('catalyst-developer', '20'),
+    ]
+    const sorted = sortRolesByTierLevel(roles).map((r) => r.name)
+    expect(sorted).toEqual([
+      'catalyst-viewer',
+      'catalyst-developer',
+      'catalyst-admin',
+      'aa-untiered',
+      'zz-untiered',
+    ])
+  })
+
+  it('does not mutate the input array', () => {
+    const input: KCRole[] = [role('z', '50'), role('a', '10')]
+    const inputCopy = [...input]
+    sortRolesByTierLevel(input)
+    expect(input).toEqual(inputCopy)
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/pages/admin/rbac/RoleBrowserPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/admin/rbac/RoleBrowserPage.tsx
@@ -1,0 +1,304 @@
+/**
+ * RoleBrowserPage — Keycloak realm-role + per-OIDC-client-role browser
+ * for sovereign-admin (EPIC-3 #1098 slice U4).
+ *
+ * Layout:
+ *   • Top tabs: "Realm roles" | "Client roles" (per OIDC client)
+ *   • Realm roles tab: list w/ tier-level sort, click row → members panel
+ *   • Client roles tab: select client → list of client roles
+ *
+ * Sovereign-admin only. The catalyst-api enforces the gate; the UI
+ * surfaces 403 explicitly so the operator knows their session lacks
+ * the privilege.
+ */
+
+import { useMemo, useState } from 'react'
+import { useParams } from '@tanstack/react-router'
+import { useQuery } from '@tanstack/react-query'
+
+import { PortalShell } from '@/pages/sovereign/PortalShell'
+import { useResolvedDeploymentId } from '@/shared/lib/useResolvedDeploymentId'
+import {
+  listKCClientRoles,
+  listKCRoleMembers,
+  listKCRoles,
+} from './rbac.api'
+import { readTierLevel, sortRolesByTierLevel } from './roleHelpers'
+
+interface RoleBrowserPageProps {
+  initialDeploymentId?: string
+  /** Test seam — start on a specific tab without TanStack Router. */
+  initialTab?: 'realm' | 'client'
+}
+
+export function RoleBrowserPage({
+  initialDeploymentId,
+  initialTab = 'realm',
+}: RoleBrowserPageProps = {}) {
+  const params = useParams({ strict: false }) as { deploymentId?: string }
+  const { deploymentId: resolvedId } = useResolvedDeploymentId()
+  const deploymentId = initialDeploymentId ?? params.deploymentId ?? resolvedId ?? ''
+
+  const [tab, setTab] = useState<'realm' | 'client'>(initialTab)
+  const [clientUUID, setClientUUID] = useState('')
+
+  return (
+    <PortalShell deploymentId={deploymentId} pageTitle="Keycloak Roles">
+      <div data-testid="role-browser-page" className="px-6 py-4">
+        <div className="mb-4">
+          <h1 className="text-xl font-semibold text-[var(--color-text-strong)]">Keycloak Roles</h1>
+          <p className="text-sm text-[var(--color-text-dim)]">
+            Realm-scoped + per-OIDC-client roles in the Sovereign realm. Sovereign-admin only.
+          </p>
+        </div>
+
+        <div className="mb-3 flex items-center gap-2 border-b border-[var(--color-border)]">
+          <button
+            type="button"
+            data-testid="role-browser-tab-realm"
+            onClick={() => setTab('realm')}
+            className={`-mb-px px-3 py-2 text-sm transition-colors ${
+              tab === 'realm'
+                ? 'border-b-2 border-[var(--color-accent)] text-[var(--color-text-strong)]'
+                : 'text-[var(--color-text-dim)] hover:text-[var(--color-text)]'
+            }`}
+          >
+            Realm roles
+          </button>
+          <button
+            type="button"
+            data-testid="role-browser-tab-client"
+            onClick={() => setTab('client')}
+            className={`-mb-px px-3 py-2 text-sm transition-colors ${
+              tab === 'client'
+                ? 'border-b-2 border-[var(--color-accent)] text-[var(--color-text-strong)]'
+                : 'text-[var(--color-text-dim)] hover:text-[var(--color-text)]'
+            }`}
+          >
+            Client roles
+          </button>
+        </div>
+
+        {tab === 'realm' ? (
+          <RealmRolesPanel deploymentId={deploymentId} />
+        ) : (
+          <ClientRolesPanel
+            deploymentId={deploymentId}
+            clientUUID={clientUUID}
+            onClientUUIDChange={setClientUUID}
+          />
+        )}
+      </div>
+    </PortalShell>
+  )
+}
+
+/* ── Realm-roles tab ──────────────────────────────────────────────── */
+
+function RealmRolesPanel({ deploymentId }: { deploymentId: string }) {
+  const { data, isLoading, isError, error } = useQuery({
+    queryKey: ['kc-roles', deploymentId],
+    queryFn: () => listKCRoles(deploymentId),
+    enabled: !!deploymentId,
+    staleTime: 30_000,
+  })
+
+  const sorted = useMemo(() => sortRolesByTierLevel(data ?? []), [data])
+  const [selectedName, setSelectedName] = useState<string | null>(null)
+
+  const isForbidden = isError && /HTTP 403/.test((error as Error)?.message ?? '')
+
+  return (
+    <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+      <div>
+        {isForbidden ? (
+          <div data-testid="role-browser-forbidden" className="mb-3 rounded-md border border-red-500/40 bg-red-500/10 px-3 py-2 text-sm text-red-300">
+            Forbidden — sovereign-admin tier (admin or owner) required.
+          </div>
+        ) : isError ? (
+          <div data-testid="role-browser-error" className="mb-3 rounded-md border border-red-500/40 bg-red-500/10 px-3 py-2 text-sm text-red-300">
+            {(error as Error)?.message ?? 'Failed to load roles'}
+          </div>
+        ) : null}
+        {isLoading ? (
+          <div data-testid="role-browser-loading" className="text-sm text-[var(--color-text-dim)]">
+            Loading roles…
+          </div>
+        ) : sorted.length === 0 && !isError ? (
+          <div data-testid="role-browser-empty" className="rounded-md border border-[var(--color-border)] px-4 py-8 text-center text-sm text-[var(--color-text-dim)]">
+            No realm roles yet — the T2 bootstrap may not have run.
+          </div>
+        ) : (
+          <table data-testid="role-browser-table" className="w-full border-collapse text-sm">
+            <thead>
+              <tr className="border-b border-[var(--color-border)] text-left text-xs uppercase text-[var(--color-text-dim)]">
+                <th className="py-2 pr-3">Name</th>
+                <th className="py-2 pr-3">Tier-level</th>
+                <th className="py-2 pr-3">Composite</th>
+                <th className="py-2 pr-3">Description</th>
+              </tr>
+            </thead>
+            <tbody>
+              {sorted.map((r) => (
+                <tr
+                  key={r.id ?? r.name}
+                  data-testid={`role-browser-row-${r.name}`}
+                  onClick={() => setSelectedName(r.name)}
+                  className={`cursor-pointer border-b border-[var(--color-border)] hover:bg-[var(--color-bg-2)] ${
+                    selectedName === r.name ? 'bg-[var(--color-bg-2)]' : ''
+                  }`}
+                >
+                  <td className="py-2 pr-3 font-mono">{r.name}</td>
+                  <td className="py-2 pr-3 text-xs text-[var(--color-text-dim)]">
+                    {readTierLevel(r) ?? '—'}
+                  </td>
+                  <td className="py-2 pr-3 text-xs">{r.composite ? '✓' : '—'}</td>
+                  <td className="py-2 pr-3 text-xs text-[var(--color-text-dim)]">
+                    {r.description ?? '—'}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+
+      <div>
+        {selectedName ? (
+          <RoleMembersPanel deploymentId={deploymentId} roleName={selectedName} />
+        ) : (
+          <div data-testid="role-browser-members-placeholder" className="rounded-md border border-[var(--color-border)] px-4 py-8 text-center text-sm text-[var(--color-text-dim)]">
+            Click a role to see its members.
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function RoleMembersPanel({
+  deploymentId,
+  roleName,
+}: {
+  deploymentId: string
+  roleName: string
+}) {
+  const { data, isLoading, isError, error } = useQuery({
+    queryKey: ['kc-role-members', deploymentId, roleName],
+    queryFn: () => listKCRoleMembers(deploymentId, roleName),
+    enabled: !!deploymentId && !!roleName,
+    staleTime: 30_000,
+  })
+
+  return (
+    <div
+      data-testid={`role-browser-members-${roleName}`}
+      className="rounded-md border border-[var(--color-border)] p-3"
+    >
+      <h2 className="text-xs uppercase text-[var(--color-text-dim)]">
+        Members of <code className="font-mono text-[var(--color-text)]">{roleName}</code>
+      </h2>
+      {isLoading ? (
+        <p className="mt-2 text-xs text-[var(--color-text-dim)]">Loading members…</p>
+      ) : isError ? (
+        <p className="mt-2 text-xs text-red-300">{(error as Error)?.message}</p>
+      ) : !data || data.items.length === 0 ? (
+        <p className="mt-2 text-xs text-[var(--color-text-dim)]">
+          No direct members. (Users may still inherit this role via group membership — see the
+          Access Matrix view.)
+        </p>
+      ) : (
+        <ul className="mt-2 space-y-1">
+          {data.items.map((u) => (
+            <li
+              key={u.id}
+              data-testid={`role-browser-member-${u.id}`}
+              className="text-xs font-mono text-[var(--color-text)]"
+            >
+              {u.email ?? u.username}
+              <span className="ml-2 text-[var(--color-text-dim)]">({u.source})</span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}
+
+/* ── Client-roles tab ─────────────────────────────────────────────── */
+
+function ClientRolesPanel({
+  deploymentId,
+  clientUUID,
+  onClientUUIDChange,
+}: {
+  deploymentId: string
+  clientUUID: string
+  onClientUUIDChange: (v: string) => void
+}) {
+  const { data, isLoading, isError, error, isFetching } = useQuery({
+    queryKey: ['kc-client-roles', deploymentId, clientUUID],
+    queryFn: () => listKCClientRoles(deploymentId, clientUUID),
+    enabled: !!deploymentId && !!clientUUID,
+    staleTime: 30_000,
+  })
+
+  return (
+    <div data-testid="role-browser-client-tab">
+      <div className="mb-3 flex items-center gap-2">
+        <label className="text-xs text-[var(--color-text-dim)]">
+          Client UUID:
+          <input
+            data-testid="role-browser-client-uuid"
+            type="text"
+            value={clientUUID}
+            onChange={(e) => onClientUUIDChange(e.target.value)}
+            placeholder="paste a Keycloak client UUID"
+            className="ml-2 rounded border border-[var(--color-border)] bg-[var(--color-bg)] px-2 py-1 text-xs font-mono"
+          />
+        </label>
+        {isFetching ? <span className="text-xs text-[var(--color-text-dim)]">loading…</span> : null}
+      </div>
+      {!clientUUID ? (
+        <div data-testid="role-browser-client-empty" className="rounded-md border border-[var(--color-border)] px-4 py-8 text-center text-sm text-[var(--color-text-dim)]">
+          Paste a client UUID above to list its roles. (Realm roles are on the other tab.)
+        </div>
+      ) : isLoading ? (
+        <div className="text-sm text-[var(--color-text-dim)]">Loading client roles…</div>
+      ) : isError ? (
+        <div data-testid="role-browser-client-err" className="rounded-md border border-red-500/40 bg-red-500/10 px-3 py-2 text-sm text-red-300">
+          {(error as Error)?.message ?? 'Failed to load client roles'}
+        </div>
+      ) : !data || data.length === 0 ? (
+        <div data-testid="role-browser-client-no-roles" className="rounded-md border border-[var(--color-border)] px-4 py-8 text-center text-sm text-[var(--color-text-dim)]">
+          No roles on this client.
+        </div>
+      ) : (
+        <table data-testid="role-browser-client-table" className="w-full border-collapse text-sm">
+          <thead>
+            <tr className="border-b border-[var(--color-border)] text-left text-xs uppercase text-[var(--color-text-dim)]">
+              <th className="py-2 pr-3">Name</th>
+              <th className="py-2 pr-3">Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            {data.map((r) => (
+              <tr
+                key={r.id ?? r.name}
+                data-testid={`role-browser-client-row-${r.name}`}
+                className="border-b border-[var(--color-border)]"
+              >
+                <td className="py-2 pr-3 font-mono">{r.name}</td>
+                <td className="py-2 pr-3 text-xs text-[var(--color-text-dim)]">
+                  {r.description ?? '—'}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
+  )
+}
+
+/* ── Helpers — see roleHelpers.ts ─────────────────────────────────── */

--- a/products/catalyst/bootstrap/ui/src/pages/admin/rbac/multiGrantState.ts
+++ b/products/catalyst/bootstrap/ui/src/pages/admin/rbac/multiGrantState.ts
@@ -1,0 +1,90 @@
+/**
+ * multiGrantState.ts — pure form-state reducer + validator for the
+ * EPIC-3 (#1098) slice U1 multi-grant editor.
+ *
+ * Extracted from MultiGrantEditPage.tsx so the file's exports stay
+ * component-only (lint react-refresh/only-export-components).
+ */
+
+import {
+  validateScopeKey,
+  validateScopeValue,
+  type KCUser,
+  type RBACScope,
+  type RBACTier,
+} from './rbac.api'
+
+export interface MultiGrantFormState {
+  user: KCUser | null
+  tier: RBACTier
+  scope: RBACScope[]
+  // Pending fields for the "add scope" composer below the chip list.
+  pendingKey: string
+  pendingValue: string
+}
+
+export type MultiGrantAction =
+  | { type: 'set-user'; user: KCUser | null }
+  | { type: 'set-tier'; tier: RBACTier }
+  | { type: 'add-scope'; key: string; value: string }
+  | { type: 'remove-scope'; index: number }
+  | { type: 'set-pending-key'; value: string }
+  | { type: 'set-pending-value'; value: string }
+  | { type: 'reset' }
+
+export const INITIAL_FORM_STATE: MultiGrantFormState = {
+  user: null,
+  tier: 'viewer',
+  scope: [],
+  pendingKey: '',
+  pendingValue: '',
+}
+
+export function multiGrantReducer(
+  state: MultiGrantFormState,
+  action: MultiGrantAction,
+): MultiGrantFormState {
+  switch (action.type) {
+    case 'set-user':
+      return { ...state, user: action.user }
+    case 'set-tier':
+      return { ...state, tier: action.tier }
+    case 'add-scope': {
+      const key = action.key.trim()
+      const value = action.value.trim()
+      // Dedupe by (key, value).
+      if (state.scope.some((s) => s.key === key && s.value === value)) {
+        return { ...state, pendingKey: '', pendingValue: '' }
+      }
+      return {
+        ...state,
+        scope: [...state.scope, { key, value }],
+        pendingKey: '',
+        pendingValue: '',
+      }
+    }
+    case 'remove-scope':
+      return {
+        ...state,
+        scope: state.scope.filter((_, i) => i !== action.index),
+      }
+    case 'set-pending-key':
+      return { ...state, pendingKey: action.value }
+    case 'set-pending-value':
+      return { ...state, pendingValue: action.value }
+    case 'reset':
+      return INITIAL_FORM_STATE
+  }
+}
+
+/** validateMultiGrantForm — pure function exposed for tests. */
+export function validateMultiGrantForm(state: MultiGrantFormState): string | null {
+  if (!state.user) return 'Pick a Keycloak user'
+  for (const s of state.scope) {
+    const ke = validateScopeKey(s.key)
+    if (ke) return ke
+    const ve = validateScopeValue(s.value)
+    if (ve) return ve
+  }
+  return null
+}

--- a/products/catalyst/bootstrap/ui/src/pages/admin/rbac/rbac.api.test.ts
+++ b/products/catalyst/bootstrap/ui/src/pages/admin/rbac/rbac.api.test.ts
@@ -1,0 +1,91 @@
+/**
+ * rbac.api.test.ts — pure-function tests for the RBAC management
+ * API module (EPIC-3 #1098 slice U1+U2+U3+U4).
+ *
+ * Network calls are tested where they live (per-page Playwright
+ * E2Es). This file pins the validators + the canonical vocabularies
+ * so a typo in the JS scope-key set surfaces immediately rather than
+ * waiting for a Playwright failure.
+ */
+
+import { describe, expect, it } from 'vitest'
+
+import {
+  RBAC_SCOPE_KEYS,
+  RBAC_TIERS,
+  TIER_ACTION_SETS,
+  TIER_AUTO_INJECTED_SCOPES,
+  TIER_LEVEL,
+  validateScopeKey,
+  validateScopeValue,
+} from './rbac.api'
+
+describe('RBAC tier vocabulary', () => {
+  it('enumerates the 5 catalog tiers in ascending precedence', () => {
+    expect([...RBAC_TIERS]).toEqual(['viewer', 'developer', 'operator', 'admin', 'owner'])
+  })
+
+  it('declares one TIER_LEVEL entry per tier with strict 10-step precedence', () => {
+    expect(TIER_LEVEL.viewer).toBe(10)
+    expect(TIER_LEVEL.developer).toBe(20)
+    expect(TIER_LEVEL.operator).toBe(30)
+    expect(TIER_LEVEL.admin).toBe(40)
+    expect(TIER_LEVEL.owner).toBe(50)
+  })
+
+  it('declares one TIER_ACTION_SETS entry per tier (no missing tiers)', () => {
+    for (const t of RBAC_TIERS) {
+      expect(TIER_ACTION_SETS[t]).toBeDefined()
+      expect(TIER_ACTION_SETS[t].length).toBeGreaterThan(0)
+    }
+  })
+
+  it('developer auto-injects env-type=dev (per design doc §6.2)', () => {
+    expect(TIER_AUTO_INJECTED_SCOPES.developer).toEqual([
+      { key: 'openova.io/env-type', value: 'dev' },
+    ])
+  })
+
+  it('only developer has auto-injected scope (rest are undefined or empty)', () => {
+    for (const t of RBAC_TIERS) {
+      if (t === 'developer') continue
+      const v = TIER_AUTO_INJECTED_SCOPES[t]
+      expect(v == null || v.length === 0).toBe(true)
+    }
+  })
+})
+
+describe('validateScopeKey', () => {
+  it('accepts every canonical key in NAMING-CONVENTION.md §6 vocab', () => {
+    for (const k of RBAC_SCOPE_KEYS) {
+      expect(validateScopeKey(k)).toBeNull()
+    }
+  })
+
+  it('accepts whitespace-padded canonical keys', () => {
+    expect(validateScopeKey('  openova.io/application  ')).toBeNull()
+  })
+
+  it('rejects empty keys', () => {
+    expect(validateScopeKey('')).toBe('scope key is required')
+    expect(validateScopeKey('   ')).toBe('scope key is required')
+  })
+
+  it('rejects non-canonical keys', () => {
+    expect(validateScopeKey('app')).toMatch(/unknown scope key: app/)
+    expect(validateScopeKey('openova.io/app')).toMatch(/unknown scope key/)
+    expect(validateScopeKey('whatever')).toMatch(/unknown scope key/)
+  })
+})
+
+describe('validateScopeValue', () => {
+  it('accepts non-empty values', () => {
+    expect(validateScopeValue('wordpress')).toBeNull()
+    expect(validateScopeValue('  wordpress  ')).toBeNull()
+  })
+
+  it('rejects empty values', () => {
+    expect(validateScopeValue('')).toBe('scope value is required')
+    expect(validateScopeValue('   ')).toBe('scope value is required')
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/pages/admin/rbac/rbac.api.ts
+++ b/products/catalyst/bootstrap/ui/src/pages/admin/rbac/rbac.api.ts
@@ -1,0 +1,392 @@
+/**
+ * rbac.api.ts — typed REST client wrappers for the EPIC-3 (#1098)
+ * RBAC management surfaces (slice U1+U2+U3+U4).
+ *
+ * Wire shape mirrors the Go handlers:
+ *   - rbac_assign.go  (A1, merged)            → POST /rbac/assign
+ *   - rbac_matrix.go  (A2, merged)            → GET  /rbac/access-matrix
+ *   - keycloak_proxy.go (this slice)          → GET  /keycloak/users/groups/roles
+ *
+ * Per docs/INVIOLABLE-PRINCIPLES.md #4 (never hardcode) every URL
+ * derives from API_BASE. All API calls go through `authedFetch` so the
+ * OIDC bearer is attached on chroot consoles.
+ *
+ * Per the canonical-seam map (Frontend Compliance UI patterns), this
+ * file follows the `compliance.api.ts` shape: one wire type per
+ * endpoint, REST baseline, TanStack Query consumes from `rbac` hook
+ * file.
+ */
+
+import { API_BASE } from '@/shared/config/urls'
+import { authedFetch } from '@/shared/lib/authedFetch'
+
+/* ── Tier vocab ───────────────────────────────────────────────────── */
+
+/** The 5 catalog tiers per docs/EPICS-1-6-unified-design.md §6.2. */
+export type RBACTier = 'viewer' | 'developer' | 'operator' | 'admin' | 'owner'
+
+export const RBAC_TIERS: readonly RBACTier[] = [
+  'viewer',
+  'developer',
+  'operator',
+  'admin',
+  'owner',
+] as const
+
+/** Tier numeric precedence, mirrors core/controllers/internal/labels TierLevel. */
+export const TIER_LEVEL: Record<RBACTier, number> = {
+  viewer: 10,
+  developer: 20,
+  operator: 30,
+  admin: 40,
+  owner: 50,
+}
+
+/**
+ * TIER_ACTION_SETS — frozen action-set table per docs/EPICS-1-6-unified-
+ * design.md §6.2. Used by the multi-grant editor to render tooltip
+ * previews per tier. Each tier inherits from the prior (transitive
+ * via Keycloak composite realm-role chain in slice T2 #1146).
+ *
+ * Per INVIOLABLE-PRINCIPLES #4 these are the canonical contract. If the
+ * design doc table evolves, this table is the single point of update
+ * on the UI side.
+ */
+export const TIER_ACTION_SETS: Record<RBACTier, readonly string[]> = {
+  viewer: ['*.read'],
+  developer: [
+    '… inherits viewer',
+    'workloads.exec',
+    'workloads.console',
+    'tickets.create',
+    'tickets.update',
+    'sessions.playback',
+  ],
+  operator: [
+    '… inherits developer',
+    'console.connect.admin',
+    'sam.manage',
+    'patches.manage',
+    'tickets.accept',
+  ],
+  admin: [
+    '… inherits operator',
+    'compute.* (except delete)',
+    'credentials.*',
+    'applications.*',
+    'actions.*',
+    'accounts.*',
+    'networks.*',
+    'sessions.*',
+  ],
+  owner: ['… inherits admin', 'rbac.*', 'organization.*'],
+}
+
+/**
+ * TIER_AUTO_INJECTED_SCOPES — scopes the backend's useraccess-controller
+ * auto-injects when a UserAccess CR is created with the matching tier
+ * label. Surface on the UI so the operator sees "developer always
+ * scoped to env-type=dev — even if you don't add it" before submit.
+ */
+export const TIER_AUTO_INJECTED_SCOPES: Partial<Record<RBACTier, ReadonlyArray<RBACScope>>> = {
+  developer: [{ key: 'openova.io/env-type', value: 'dev' }],
+}
+
+/* ── Scope vocab (NAMING-CONVENTION.md §6) ────────────────────────── */
+
+/**
+ * RBAC_SCOPE_KEYS — the canonical label-key vocabulary the backend
+ * accepts on a UserAccess scope per docs/NAMING-CONVENTION.md §6.1+§6.2.
+ * The multi-grant editor validates user-typed keys against this set
+ * (per INVIOLABLE-PRINCIPLES #4 — never invent label keys).
+ *
+ * Sources of truth:
+ *   §6.1 — cloud-resource tags (provider/region/building-block/env-type/cluster/managed-by)
+ *   §6.2 — Catalyst resource tags (sovereign/organization/environment/vcluster/host-cluster/application/blueprint/blueprint-version)
+ *
+ * Synthetic keys also supported by the Manara matcher: `*` (wildcard,
+ * valid in scopeMatchesAny but rejected on user input — wildcard scope
+ * is the empty-array case at the UserAccess CR level, not a typed
+ * scope key).
+ */
+export const RBAC_SCOPE_KEYS: readonly string[] = [
+  // §6.1 — cloud resource tags
+  'openova.io/provider',
+  'openova.io/region',
+  'openova.io/building-block',
+  'openova.io/env-type',
+  'openova.io/cluster',
+  'openova.io/managed-by',
+  // §6.2 — catalyst resource tags
+  'openova.io/sovereign',
+  'openova.io/organization',
+  'openova.io/org', // alias, used by access-matrix filters
+  'openova.io/environment',
+  'openova.io/vcluster',
+  'openova.io/host-cluster',
+  'openova.io/application',
+  'openova.io/blueprint',
+  'openova.io/blueprint-version',
+] as const
+
+const RBAC_SCOPE_KEY_SET: ReadonlySet<string> = new Set(RBAC_SCOPE_KEYS)
+
+/** validateScopeKey — returns null on valid, error string on invalid. */
+export function validateScopeKey(key: string): string | null {
+  const trimmed = key.trim()
+  if (!trimmed) return 'scope key is required'
+  if (!RBAC_SCOPE_KEY_SET.has(trimmed)) {
+    return `unknown scope key: ${trimmed} — valid: ${RBAC_SCOPE_KEYS.join(', ')}`
+  }
+  return null
+}
+
+/** validateScopeValue — non-empty after trim. The backend further
+ * validates against per-key vocab where applicable; the UI only
+ * enforces presence to keep the form responsive.
+ */
+export function validateScopeValue(value: string): string | null {
+  return value.trim() ? null : 'scope value is required'
+}
+
+/* ── /rbac/assign wire shapes ─────────────────────────────────────── */
+
+export interface RBACScope {
+  key: string
+  value: string
+}
+
+export interface RBACAssignUser {
+  email?: string
+  keycloakSubject?: string
+}
+
+export interface RBACAssignRequest {
+  user: RBACAssignUser
+  tier: RBACTier
+  scope: RBACScope[]
+}
+
+export interface RBACAssignResponse {
+  userAccess: { name: string; uid: string; namespace: string }
+  tierClusterRole: string
+  applied: 'created' | 'updated' | 'no-op'
+}
+
+/* ── /keycloak/users wire shapes ──────────────────────────────────── */
+
+export type KCUserSource = 'keycloak' | 'azure_ad_federated' | string
+
+export interface KCUser {
+  id: string
+  username: string
+  email?: string
+  firstName?: string
+  lastName?: string
+  /** "keycloak" | "azure_ad_federated" | <federation IdP alias>. */
+  source: KCUserSource
+}
+
+export interface KCUserListResponse {
+  items: KCUser[]
+}
+
+/* ── /keycloak/groups wire shapes ─────────────────────────────────── */
+
+export interface KCGroup {
+  id?: string
+  name: string
+  path?: string
+  attributes?: Record<string, string[]>
+  subGroups?: KCGroup[]
+}
+
+export interface KCGroupListResponse {
+  items: KCGroup[]
+}
+
+export interface KCGroupCreateRequest {
+  name: string
+  parentId?: string
+  attributes?: Record<string, string[]>
+}
+
+export interface KCGroupUpdateRequest {
+  attributes?: Record<string, string[]>
+}
+
+/* ── /keycloak/roles wire shapes ──────────────────────────────────── */
+
+export interface KCRole {
+  id?: string
+  name: string
+  description?: string
+  composite?: boolean
+  clientRole?: boolean
+  containerId?: string
+  attributes?: Record<string, string[]>
+}
+
+export interface KCRoleListResponse {
+  items: KCRole[]
+}
+
+export interface KCRoleMembersResponse {
+  role: string
+  items: KCUser[]
+}
+
+/* ── Endpoint helpers ─────────────────────────────────────────────── */
+
+function rbacBase(sovereignId: string): string {
+  return `${API_BASE}/v1/sovereigns/${encodeURIComponent(sovereignId)}/rbac`
+}
+
+function kcBase(sovereignId: string): string {
+  return `${API_BASE}/v1/sovereigns/${encodeURIComponent(sovereignId)}/keycloak`
+}
+
+/* ── /rbac/assign ─────────────────────────────────────────────────── */
+
+export async function rbacAssign(
+  sovereignId: string,
+  body: RBACAssignRequest,
+): Promise<RBACAssignResponse> {
+  const res = await authedFetch(`${rbacBase(sovereignId)}/assign`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+    body: JSON.stringify(body),
+  })
+  if (!res.ok) {
+    const detail = await res.text().catch(() => '')
+    throw new Error(`rbac/assign: HTTP ${res.status} ${detail}`)
+  }
+  return res.json()
+}
+
+/* ── /keycloak/users (U2) ─────────────────────────────────────────── */
+
+export async function searchKCUsers(
+  sovereignId: string,
+  search: string,
+  limit = 20,
+): Promise<KCUser[]> {
+  const params = new URLSearchParams()
+  params.set('search', search)
+  params.set('limit', String(limit))
+  const res = await authedFetch(`${kcBase(sovereignId)}/users?${params.toString()}`, {
+    headers: { Accept: 'application/json' },
+  })
+  if (!res.ok) {
+    const detail = await res.text().catch(() => '')
+    throw new Error(`keycloak/users: HTTP ${res.status} ${detail}`)
+  }
+  const body: KCUserListResponse = await res.json()
+  return body.items ?? []
+}
+
+/* ── /keycloak/groups (U3) ────────────────────────────────────────── */
+
+export async function listKCGroups(sovereignId: string): Promise<KCGroup[]> {
+  const res = await authedFetch(`${kcBase(sovereignId)}/groups`, {
+    headers: { Accept: 'application/json' },
+  })
+  if (!res.ok) {
+    const detail = await res.text().catch(() => '')
+    throw new Error(`keycloak/groups: HTTP ${res.status} ${detail}`)
+  }
+  const body: KCGroupListResponse = await res.json()
+  return body.items ?? []
+}
+
+export async function createKCGroup(
+  sovereignId: string,
+  body: KCGroupCreateRequest,
+): Promise<KCGroup> {
+  const res = await authedFetch(`${kcBase(sovereignId)}/groups`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+    body: JSON.stringify(body),
+  })
+  if (!res.ok) {
+    const detail = await res.text().catch(() => '')
+    throw new Error(`keycloak/groups create: HTTP ${res.status} ${detail}`)
+  }
+  return res.json()
+}
+
+export async function updateKCGroup(
+  sovereignId: string,
+  groupId: string,
+  body: KCGroupUpdateRequest,
+): Promise<KCGroup> {
+  const res = await authedFetch(
+    `${kcBase(sovereignId)}/groups/${encodeURIComponent(groupId)}`,
+    {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+      body: JSON.stringify(body),
+    },
+  )
+  if (!res.ok) {
+    const detail = await res.text().catch(() => '')
+    throw new Error(`keycloak/groups update: HTTP ${res.status} ${detail}`)
+  }
+  return res.json()
+}
+
+export async function deleteKCGroup(sovereignId: string, groupId: string): Promise<void> {
+  const res = await authedFetch(
+    `${kcBase(sovereignId)}/groups/${encodeURIComponent(groupId)}`,
+    { method: 'DELETE', headers: { Accept: 'application/json' } },
+  )
+  if (!res.ok && res.status !== 204) {
+    const detail = await res.text().catch(() => '')
+    throw new Error(`keycloak/groups delete: HTTP ${res.status} ${detail}`)
+  }
+}
+
+/* ── /keycloak/roles (U4) ─────────────────────────────────────────── */
+
+export async function listKCRoles(sovereignId: string): Promise<KCRole[]> {
+  const res = await authedFetch(`${kcBase(sovereignId)}/roles`, {
+    headers: { Accept: 'application/json' },
+  })
+  if (!res.ok) {
+    const detail = await res.text().catch(() => '')
+    throw new Error(`keycloak/roles: HTTP ${res.status} ${detail}`)
+  }
+  const body: KCRoleListResponse = await res.json()
+  return body.items ?? []
+}
+
+export async function listKCRoleMembers(
+  sovereignId: string,
+  roleName: string,
+): Promise<KCRoleMembersResponse> {
+  const res = await authedFetch(
+    `${kcBase(sovereignId)}/roles/${encodeURIComponent(roleName)}/members`,
+    { headers: { Accept: 'application/json' } },
+  )
+  if (!res.ok) {
+    const detail = await res.text().catch(() => '')
+    throw new Error(`keycloak/roles/members: HTTP ${res.status} ${detail}`)
+  }
+  return res.json()
+}
+
+export async function listKCClientRoles(
+  sovereignId: string,
+  clientUUID: string,
+): Promise<KCRole[]> {
+  const res = await authedFetch(
+    `${kcBase(sovereignId)}/clients/${encodeURIComponent(clientUUID)}/roles`,
+    { headers: { Accept: 'application/json' } },
+  )
+  if (!res.ok) {
+    const detail = await res.text().catch(() => '')
+    throw new Error(`keycloak/clients/roles: HTTP ${res.status} ${detail}`)
+  }
+  const body: KCRoleListResponse = await res.json()
+  return body.items ?? []
+}

--- a/products/catalyst/bootstrap/ui/src/pages/admin/rbac/roleHelpers.ts
+++ b/products/catalyst/bootstrap/ui/src/pages/admin/rbac/roleHelpers.ts
@@ -1,0 +1,27 @@
+/**
+ * roleHelpers.ts — pure helpers used by the EPIC-3 (#1098) slice U4
+ * RoleBrowserPage. Extracted so the page file's exports stay
+ * component-only (lint react-refresh/only-export-components).
+ */
+
+import type { KCRole } from './rbac.api'
+
+/** sortRolesByTierLevel — tier-level attribute (per slice T2 bootstrap)
+ *  is the primary sort key; alphabetical within ties. */
+export function sortRolesByTierLevel(roles: KCRole[]): KCRole[] {
+  return [...roles].sort((a, b) => {
+    const la = readTierLevel(a) ?? Number.MAX_SAFE_INTEGER
+    const lb = readTierLevel(b) ?? Number.MAX_SAFE_INTEGER
+    if (la !== lb) return la - lb
+    return a.name.localeCompare(b.name)
+  })
+}
+
+/** readTierLevel — pulls the integer `tier-level` attribute (slice T2)
+ *  off a Keycloak realm role. Returns null when absent or non-numeric. */
+export function readTierLevel(r: KCRole): number | null {
+  const raw = r.attributes?.['tier-level']?.[0]
+  if (!raw) return null
+  const n = Number.parseInt(raw, 10)
+  return Number.isFinite(n) ? n : null
+}

--- a/products/catalyst/bootstrap/ui/src/widgets/rbac/KCUserPicker.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/widgets/rbac/KCUserPicker.test.tsx
@@ -1,0 +1,114 @@
+/**
+ * KCUserPicker.test.tsx — DOM tests for the reusable Keycloak user
+ * picker widget (EPIC-3 #1098 slice U2).
+ *
+ * The widget consumes TanStack Query so the tests stand up a fresh
+ * QueryClient per case; the searchKCUsers fetch is mocked via
+ * `vi.mock('@/pages/admin/rbac/rbac.api')` so the test runs without
+ * a network.
+ */
+
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { render, screen, cleanup, fireEvent, waitFor, act } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+import { KCUserPicker } from './KCUserPicker'
+import type { KCUser } from '@/pages/admin/rbac/rbac.api'
+
+vi.mock('@/pages/admin/rbac/rbac.api', async () => {
+  const actual = await vi.importActual<typeof import('@/pages/admin/rbac/rbac.api')>(
+    '@/pages/admin/rbac/rbac.api',
+  )
+  return {
+    ...actual,
+    searchKCUsers: vi.fn(),
+  }
+})
+
+const { searchKCUsers } = await import('@/pages/admin/rbac/rbac.api')
+const mockedSearch = searchKCUsers as unknown as ReturnType<typeof vi.fn>
+
+afterEach(() => {
+  cleanup()
+  mockedSearch.mockReset()
+})
+
+function renderPicker(props: Partial<React.ComponentProps<typeof KCUserPicker>> = {}) {
+  const onSelect = props.onSelect ?? vi.fn()
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false, staleTime: 0, gcTime: 0 } },
+  })
+  return {
+    onSelect,
+    ...render(
+      <QueryClientProvider client={qc}>
+        <KCUserPicker
+          sovereignId="dep-1"
+          onSelect={onSelect}
+          noDebounce
+          {...props}
+        />
+      </QueryClientProvider>,
+    ),
+  }
+}
+
+describe('KCUserPicker', () => {
+  it('renders the input', () => {
+    renderPicker()
+    expect(screen.getByTestId('kc-user-picker-input')).toBeTruthy()
+  })
+
+  it('does NOT fire search until the query is at least 2 chars', async () => {
+    mockedSearch.mockResolvedValue([])
+    renderPicker()
+    fireEvent.change(screen.getByTestId('kc-user-picker-input'), { target: { value: 'a' } })
+    // Wait a tick to let the effect run.
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 10))
+    })
+    expect(mockedSearch).not.toHaveBeenCalled()
+  })
+
+  it('fires search and renders results', async () => {
+    const users: KCUser[] = [
+      { id: 'u1', username: 'alice', email: 'alice@acme.com', source: 'keycloak' },
+      { id: 'u2', username: 'bob.fed', source: 'azure_ad_federated' },
+    ]
+    mockedSearch.mockResolvedValue(users)
+    renderPicker()
+    fireEvent.change(screen.getByTestId('kc-user-picker-input'), { target: { value: 'al' } })
+    await waitFor(() => {
+      expect(mockedSearch).toHaveBeenCalledWith('dep-1', 'al', 20)
+    })
+    await waitFor(() => {
+      expect(screen.getByTestId('kc-user-picker-result-u1')).toBeTruthy()
+    })
+    expect(screen.getByTestId('kc-user-picker-result-u2')).toBeTruthy()
+    // Federation badge for u2.
+    expect(screen.getByTestId('kc-user-picker-badge-azure')).toBeTruthy()
+  })
+
+  it('selecting a result fires onSelect', async () => {
+    const users: KCUser[] = [
+      { id: 'u1', username: 'alice', email: 'alice@acme.com', source: 'keycloak' },
+    ]
+    mockedSearch.mockResolvedValue(users)
+    const { onSelect } = renderPicker()
+    fireEvent.change(screen.getByTestId('kc-user-picker-input'), { target: { value: 'al' } })
+    await waitFor(() => {
+      expect(screen.getByTestId('kc-user-picker-result-u1')).toBeTruthy()
+    })
+    fireEvent.click(screen.getByTestId('kc-user-picker-result-u1'))
+    expect(onSelect).toHaveBeenCalledWith(users[0])
+  })
+
+  it('renders empty state for zero results', async () => {
+    mockedSearch.mockResolvedValue([])
+    renderPicker()
+    fireEvent.change(screen.getByTestId('kc-user-picker-input'), { target: { value: 'zz' } })
+    await waitFor(() => {
+      expect(screen.getByTestId('kc-user-picker-empty')).toBeTruthy()
+    })
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/widgets/rbac/KCUserPicker.tsx
+++ b/products/catalyst/bootstrap/ui/src/widgets/rbac/KCUserPicker.tsx
@@ -1,0 +1,231 @@
+/**
+ * KCUserPicker — reusable Keycloak user-picker widget (EPIC-3 #1098,
+ * slice U2).
+ *
+ * Type-ahead search with 300ms debounce against catalyst-api's
+ * `GET /api/v1/sovereigns/{id}/keycloak/users?search=<q>&limit=20`
+ * proxy endpoint.
+ *
+ * Federated users (corporate Sovereigns where Org.spec.identity.federationProvider
+ * is set to e.g. azure-sso-acme) surface inline because catalyst-api's
+ * proxy maps KC's `federationLink` → `source` discriminator. The picker
+ * badges them so the operator can tell native KC users from Azure-AD-
+ * federated users at a glance.
+ *
+ * Per the canonical-seam map (`Frontend (TypeScript) — Compliance UI`):
+ * No new state library. TanStack Query + an internal debounce hook
+ * is sufficient.
+ *
+ * Per docs/INVIOLABLE-PRINCIPLES.md #4 (never hardcode), every URL
+ * derives from the central `searchKCUsers()` wrapper which composes
+ * API_BASE.
+ */
+
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+
+import { searchKCUsers, type KCUser } from '@/pages/admin/rbac/rbac.api'
+
+export interface KCUserPickerProps {
+  sovereignId: string
+  /** Called when the operator clicks a user in the dropdown. */
+  onSelect: (user: KCUser) => void
+  /** When provided, surfaces the federation badge for users brokered
+   *  through this IdP (e.g. "azure-sso-acme"). The picker still calls
+   *  the SAME endpoint — this prop only controls the badge tooltip
+   *  copy, since KC's federation lookup happens server-side. */
+  federatedIdpAlias?: string
+  /** Pre-fill input (edit-mode use). */
+  initialQuery?: string
+  /** When true, the input is read-only — used by the multi-grant
+   *  editor on edit views where the user is already pinned. */
+  disabled?: boolean
+  /** Test seam — bypasses the debounce. */
+  noDebounce?: boolean
+  /** Placeholder copy for the input. Defaults to "Search by email or name…". */
+  placeholder?: string
+}
+
+const DEBOUNCE_MS = 300
+const MIN_QUERY_LEN = 2
+const QUERY_STALE_MS = 30_000
+
+/** Stable query key per (sovereign, query). */
+function userQueryKey(sovereignId: string, q: string) {
+  return ['kc-user-picker', sovereignId, q] as const
+}
+
+export function KCUserPicker({
+  sovereignId,
+  onSelect,
+  federatedIdpAlias,
+  initialQuery = '',
+  disabled = false,
+  noDebounce = false,
+  placeholder = 'Search by email or name…',
+}: KCUserPickerProps) {
+  const [raw, setRaw] = useState(initialQuery)
+  const [debounced, setDebounced] = useState(initialQuery)
+  const [open, setOpen] = useState(false)
+  const containerRef = useRef<HTMLDivElement | null>(null)
+
+  // Debounce the input. The 300ms window matches the brief. The
+  // `noDebounce` test seam still routes through setTimeout(0) so the
+  // setState happens on the next microtask, not synchronously inside
+  // the effect body — keeps lint's "set-state-in-effect" rule happy.
+  useEffect(() => {
+    const wait = noDebounce ? 0 : DEBOUNCE_MS
+    const t = setTimeout(() => setDebounced(raw), wait)
+    return () => clearTimeout(t)
+  }, [raw, noDebounce])
+
+  // Click-away handler.
+  useEffect(() => {
+    function onDocMouseDown(e: MouseEvent) {
+      if (!containerRef.current) return
+      if (!containerRef.current.contains(e.target as Node)) {
+        setOpen(false)
+      }
+    }
+    document.addEventListener('mousedown', onDocMouseDown)
+    return () => document.removeEventListener('mousedown', onDocMouseDown)
+  }, [])
+
+  const enabled = useMemo(
+    () => debounced.trim().length >= MIN_QUERY_LEN && !!sovereignId && !disabled,
+    [debounced, sovereignId, disabled],
+  )
+
+  const { data, isLoading, isError, error } = useQuery({
+    queryKey: userQueryKey(sovereignId, debounced.trim()),
+    queryFn: () => searchKCUsers(sovereignId, debounced.trim(), 20),
+    enabled,
+    staleTime: QUERY_STALE_MS,
+  })
+
+  const results = data ?? []
+
+  return (
+    <div
+      ref={containerRef}
+      data-testid="kc-user-picker"
+      className="relative w-full"
+    >
+      <input
+        type="search"
+        autoComplete="off"
+        spellCheck={false}
+        value={raw}
+        disabled={disabled}
+        onChange={(e) => {
+          setRaw(e.target.value)
+          setOpen(true)
+        }}
+        onFocus={() => setOpen(true)}
+        placeholder={placeholder}
+        data-testid="kc-user-picker-input"
+        className="w-full rounded border border-[var(--color-border)] bg-[var(--color-bg)] px-2 py-1 text-sm font-mono disabled:opacity-50"
+        aria-label="Search Keycloak users"
+        role="combobox"
+        aria-autocomplete="list"
+        aria-expanded={open}
+        aria-controls="kc-user-picker-listbox"
+      />
+      {open && enabled ? (
+        <div
+          id="kc-user-picker-listbox"
+          role="listbox"
+          data-testid="kc-user-picker-listbox"
+          className="absolute z-30 mt-1 max-h-72 w-full overflow-y-auto rounded-md border border-[var(--color-border)] bg-[var(--color-bg-2)] shadow-lg"
+        >
+          {isLoading ? (
+            <div data-testid="kc-user-picker-loading" className="px-3 py-2 text-xs text-[var(--color-text-dim)]">
+              Searching…
+            </div>
+          ) : isError ? (
+            <div data-testid="kc-user-picker-error" className="px-3 py-2 text-xs text-red-300">
+              {(error as Error)?.message ?? 'search failed'}
+            </div>
+          ) : results.length === 0 ? (
+            <div data-testid="kc-user-picker-empty" className="px-3 py-2 text-xs text-[var(--color-text-dim)]">
+              No users match "{debounced}"
+            </div>
+          ) : (
+            <ul>
+              {results.map((u) => (
+                <li
+                  key={u.id}
+                  role="option"
+                  data-testid={`kc-user-picker-result-${u.id}`}
+                  aria-selected={false}
+                  className="cursor-pointer border-b border-[var(--color-border)] px-3 py-2 text-sm hover:bg-[var(--color-bg-3)]"
+                  onClick={() => {
+                    onSelect(u)
+                    setRaw(u.email ?? u.username)
+                    setOpen(false)
+                  }}
+                >
+                  <div className="flex items-center justify-between gap-2">
+                    <span className="font-mono text-[var(--color-text)]">
+                      {u.email ?? u.username}
+                    </span>
+                    <SourceBadge source={u.source} />
+                  </div>
+                  {u.firstName || u.lastName ? (
+                    <span className="block text-xs text-[var(--color-text-dim)]">
+                      {[u.firstName, u.lastName].filter(Boolean).join(' ')}
+                    </span>
+                  ) : null}
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      ) : null}
+      {federatedIdpAlias ? (
+        <p className="mt-1 text-xs text-[var(--color-text-dim)]">
+          Federated identities from <code className="font-mono">{federatedIdpAlias}</code> appear
+          inline with the source badge.
+        </p>
+      ) : null}
+    </div>
+  )
+}
+
+interface SourceBadgeProps {
+  source: string
+}
+
+function SourceBadge({ source }: SourceBadgeProps) {
+  if (source === 'keycloak') {
+    return (
+      <span
+        data-testid="kc-user-picker-badge-keycloak"
+        className="rounded-full border border-[var(--color-border)] px-2 py-0.5 text-[10px] uppercase text-[var(--color-text-dim)]"
+        title="Native Keycloak user"
+      >
+        keycloak
+      </span>
+    )
+  }
+  if (source === 'azure_ad_federated') {
+    return (
+      <span
+        data-testid="kc-user-picker-badge-azure"
+        className="rounded-full border border-blue-500/40 bg-blue-500/10 px-2 py-0.5 text-[10px] uppercase text-blue-300"
+        title="Federated via Azure AD (Keycloak Identity Provider broker)"
+      >
+        azure-ad
+      </span>
+    )
+  }
+  return (
+    <span
+      data-testid={`kc-user-picker-badge-${source}`}
+      className="rounded-full border border-amber-500/40 bg-amber-500/10 px-2 py-0.5 text-[10px] uppercase text-amber-300"
+      title={`Federated via ${source}`}
+    >
+      {source}
+    </span>
+  )
+}


### PR DESCRIPTION
## Summary

EPIC-3 slice U1+U2+U3+U4 — RBAC management UI bundle backed by /rbac/assign (slice A1, merged).

- **U1 — MultiGrantEditPage**: replaces single-grant `UserAccessEditPage`. Tier picker (5 catalog tiers w/ action-set tooltips) + scope chips (validated against canonical NAMING-CONVENTION.md §6 vocab) + KC user picker → POST /rbac/assign. Surfaces auto-injected scope hints (e.g. `developer → env-type=dev`).
- **U2 — KCUserPicker**: reusable 300ms-debounced type-ahead widget. Surfaces federated IdP users inline with a source badge (`keycloak` vs `azure_ad_federated`).
- **U3 — GroupBrowserPage**: KC group tree, create/delete/attribute-edit. Sovereign-admin only (admin or owner tier).
- **U4 — RoleBrowserPage**: realm-roles list (sorted by tier-level) with members panel + per-OIDC-client role tab. Sovereign-admin only.

8 new server-side endpoints under `/api/v1/sovereigns/{id}/keycloak/*` proxy to the Sovereign realm's KC Admin API via the existing `h.kc` seam (no new client). U2 reuses /rbac/assign's tier-admin gate; U3 + U4 use the stricter sovereign-admin gate per INVIOLABLE-PRINCIPLES #5.

## Test coverage

| Layer | Files | Tests | Pass |
|---|---|---|---|
| Go unit (handler) | `keycloak_proxy_test.go` | 22 | ✓ |
| Go unit (keycloak) | `admin_users_test.go` | 5 | ✓ |
| UI vitest | `rbac.api.test.ts`, `MultiGrantEditPage.test.ts`, `RoleBrowserPage.test.ts`, `KCUserPicker.test.tsx` | 34 | ✓ |
| Playwright E2E | `rbac-management.spec.ts` (7 snapshots @ 1440x900) | 7 | ✓ |

`go test -count=1 -race ./internal/handler ./internal/keycloak` clean against this slice's surface; `npm run typecheck` clean; `npm run lint` matches main baseline (59 errors / 10 warnings — no new violations).

## Pre-existing CI failures (per canon §7)

- Go: `TestPinIssue_ConcurrentRapidFireRateLimit` race-detector flake — pre-existing on main.
- UI: 98 vitest failures in `pages/wizard/steps/StepComponents.test.tsx` + cosmetic-guards / SME-demo Playwright — pre-existing on main per slice I (#1152) verification.

## Test plan
- [x] Vitest pure-function suite (tier vocab, scope validators, reducer, role helpers, KCUserPicker DOM)
- [x] Go handler tests (auth gates, federation mapping, limit clamp, 404 paths)
- [x] Playwright E2E with 6+ 1440x900 snapshots — one per page, never collapsed
- [x] Production `npm run build` succeeds
- [x] Lint baseline matches main

🤖 Generated with [Claude Code](https://claude.com/claude-code)