### PR TITLE
fix(cnpg-pair): drop bp-cnpg: prefix from upgrades.from semver range

### DIFF
--- a/platform/cnpg-pair/blueprint.yaml
+++ b/platform/cnpg-pair/blueprint.yaml
@@ -195,4 +195,4 @@ spec:
     # installing this Blueprint and running a one-shot promotion
     # job (delivered in C-DB-3 acceptance harness). Documented in
     # DESIGN.md "single→pair migration".
-    from: ["bp-cnpg:1.x"]
+    from: ["1.x"]


### PR DESCRIPTION
## Summary

C-DB-1 (#1153) shipped `platform/cnpg-pair/blueprint.yaml` with `upgrades.from: ["bp-cnpg:1.x"]`. C3 blueprint-controller's validate package rejects this as an invalid semver range — every PR after #1153 sees `TestValidate_ExistingBlueprintCorpus` fail.

Other platform/*/blueprint.yaml files use bare semver-range strings (e.g. `["0.x"]`) without the `bp-name:` prefix. This PR drops the prefix.

Discovered by EPIC-6 K-Cont-2 (#1155).

## Test plan

- [x] `go test ./products/catalyst/bootstrap/api/internal/provisioner/...` for `TestValidate_ExistingBlueprintCorpus` (verifies the fix on CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)