### PR TITLE
feat(continuum): K-Cont-4 — Cloudflare Worker source + tofu wiring for lease witness (#1101)

### DIFF
--- a/.github/workflows/cloudflare-worker-leases-build.yaml
+++ b/.github/workflows/cloudflare-worker-leases-build.yaml
@@ -1,0 +1,102 @@
+name: cloudflare-worker-leases — build + test + lint
+
+# Slice K-Cont-4 of EPIC-6 (#1101). Verifies the OpenOva Continuum
+# lease-witness Worker source at `products/continuum/cloudflare-worker/`
+# and the OpenTofu module at `infra/cloudflare-worker-leases/`.
+#
+# Per CLAUDE.md "every workflow MUST be event-driven, NEVER scheduled":
+# this workflow is push-on-merge + pull-request-on-touch + manual
+# dispatch. NO cron triggers.
+#
+# This workflow does NOT auto-deploy the Worker. Per the K-Cont-4 brief
+# "DO NOT auto-deploy — operator manually runs tofu apply for the lease
+# witness deploy". The `wrangler deploy --dry-run` step verifies the
+# Worker compiles + bundles correctly without writing to Cloudflare.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'products/continuum/cloudflare-worker/**'
+      - 'infra/cloudflare-worker-leases/**'
+      - '.github/workflows/cloudflare-worker-leases-build.yaml'
+  pull_request:
+    paths:
+      - 'products/continuum/cloudflare-worker/**'
+      - 'infra/cloudflare-worker-leases/**'
+      - '.github/workflows/cloudflare-worker-leases-build.yaml'
+  workflow_dispatch:
+
+jobs:
+  worker-test:
+    name: Worker — npm ci + test + lint + build:dryrun
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        working-directory: products/continuum/cloudflare-worker
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          # Node 20 is the LTS that matches @cloudflare/workers-types
+          # 4.20240909+ tooling. Pin minor to keep CI deterministic.
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: products/continuum/cloudflare-worker/package-lock.json
+
+      - name: npm ci (clean install from lockfile)
+        run: npm ci
+
+      - name: ESLint
+        run: npm run lint
+
+      - name: TypeScript typecheck
+        run: npm run typecheck
+
+      - name: Vitest — handler + contract suites
+        # @cloudflare/vitest-pool-workers spawns a per-test workerd
+        # runtime with in-memory KV. No network, no CF account needed.
+        run: npm test
+
+      - name: Wrangler build dry-run
+        # `wrangler deploy --dry-run --outdir=dist` compiles + bundles
+        # the Worker WITHOUT pushing to Cloudflare. Catches syntax
+        # errors, missing imports, oversized bundles. The `dist/`
+        # output is what `infra/cloudflare-worker-leases/main.tf`
+        # reads as the script content at apply time.
+        run: npm run build:dryrun
+
+  tofu-validate:
+    name: OpenTofu — fmt + validate
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    defaults:
+      run:
+        working-directory: infra/cloudflare-worker-leases
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install OpenTofu
+        uses: opentofu/setup-opentofu@v1
+        with:
+          # Match infra/hetzner/'s pin (see infra/hetzner/.github/workflows/
+          # infra-hetzner-tofu.yaml). Bump in lockstep.
+          tofu_version: 1.8.5
+
+      - name: tofu init (backend=false — module-local checks only)
+        run: tofu init -backend=false
+
+      - name: tofu fmt -check
+        run: tofu fmt -check -recursive
+
+      - name: tofu validate
+        # `validate` requires `init` to have downloaded the cloudflare
+        # provider plugin (above). Validates HCL syntax + provider
+        # schema conformance — won't catch runtime issues like a wrong
+        # account_id but catches every authoring error.
+        run: tofu validate

--- a/infra/cloudflare-worker-leases/.terraform.lock.hcl
+++ b/infra/cloudflare-worker-leases/.terraform.lock.hcl
@@ -1,0 +1,19 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/cloudflare/cloudflare" {
+  version     = "5.19.1"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:mopYISyLkUVUwMjJbuPenxIUVDrna1/7ACB1hfMfciU=",
+    "zh:0651618000db705564dab5a25322b9d76ea54b7dd78931ed3565497b559babeb",
+    "zh:1a7847e9479fb6d21a65ef933ffae1416b1e4b44ca940c0d6c50fc4248cc4a0d",
+    "zh:5597cee5854131045eb9f201ae3a70b59c51955d31a647d9616863c746d902cb",
+    "zh:580786830d93e35b957754fd4c62d4681a3b19abc28b757e41acba26455663b1",
+    "zh:83c4bdfb0e74fd50e56fff3c461d76c1c1ec61af3f679e4de1aa70b5ed05a09f",
+    "zh:abb4d1052cee61d80f9cb51e5421e3c118312403afb7104b98bd7e310ac736ee",
+    "zh:b0aeeb3d66ea4d719989875e778c477065ba941e3a76e9a8caacc3be08208dd9",
+    "zh:e43b4b2dfcec1ce2115f5a5c86042d432deb49bee8eae103eb56d97ea02e2e3b",
+    "zh:f809ab383cca0a5f83072981c64208cbd7fa67e986a86ee02dd2c82333221e32",
+  ]
+}

--- a/infra/cloudflare-worker-leases/README.md
+++ b/infra/cloudflare-worker-leases/README.md
@@ -1,0 +1,61 @@
+# `infra/cloudflare-worker-leases/` — OpenTofu module for the Continuum lease-witness Worker
+
+Slice K-Cont-4 of EPIC-6 (#1101). Deploys the Worker source from `products/continuum/cloudflare-worker/` to Cloudflare alongside its KV namespace and env-bound bearer-token allow-list.
+
+## Inputs
+
+| Variable | Required | Description |
+|---|---|---|
+| `cloudflare_account_id` | yes | 32-char hex. Read from CF dashboard. |
+| `cloudflare_api_token` | yes (sensitive) | API token with `Workers Scripts: Edit` + `Workers KV Storage: Edit`. |
+| `bearer_tokens_csv` | yes (sensitive) | Comma-separated allow-list of bearer tokens. Source: per-Sovereign SealedSecret. |
+| `worker_name` | no (default `openova-continuum-lease-witness`) | Worker script name (becomes part of the URL). |
+| `kv_namespace_title` | no (default `openova-continuum-leases`) | KV namespace display title. |
+| `log_level` | no (default `info`) | One of `error` / `info` / `debug`. |
+| `worker_script_path` | no (default `../../products/continuum/cloudflare-worker/dist/index.js`) | Path to the bundled Worker JS. Run `npm run build:dryrun` in the worker dir first. |
+
+## Outputs
+
+| Output | Use for |
+|---|---|
+| `worker_url` | Paste into Continuum CR `spec.leaseClient.config.baseURL`. |
+| `kv_namespace_id` | Ad-hoc `wrangler kv:key list` introspection. |
+| `worker_name` | Deployed Worker script name. |
+
+## Operator runbook
+
+1. **Build the Worker bundle**:
+   ```sh
+   cd ../../products/continuum/cloudflare-worker
+   npm install && npm run build:dryrun
+   ```
+   This produces `dist/index.js` (the bundled Worker script).
+
+2. **Extract bearer tokens** from the per-Sovereign SealedSecret:
+   ```sh
+   kubectl --kubeconfig <sov-kubeconfig> get secret -n catalyst-system \
+     continuum-cf-witness-tokens -o jsonpath='{.data.token}' | base64 -d
+   ```
+   For rotation, prepare a `<new>,<old>` CSV.
+
+3. **Apply**:
+   ```sh
+   cd ../infra/cloudflare-worker-leases
+   tofu init
+   TF_VAR_cloudflare_account_id=<acct> \
+   TF_VAR_cloudflare_api_token=<token> \
+   TF_VAR_bearer_tokens_csv='<csv>' \
+     tofu apply
+   ```
+
+4. **Wire the Continuum CR** with the `worker_url` output. The catalyst-controllers reconciler picks up the change on next reconcile (~30s); verify via `kubectl logs -n catalyst-controllers continuum-controller-*`.
+
+## Why no `cloudflare_workers_route`?
+
+The Worker's default `*.workers.dev` URL is sufficient for the controller's HTTPS calls. A custom hostname (e.g. `lease.openova.io`) would require zone setup outside this module. Operators wanting a custom domain set `spec.leaseClient.config.baseURL` directly to the custom hostname AFTER setting up the route in the CF dashboard or a sibling tofu module.
+
+## What this module does NOT do
+
+- **Doesn't deploy automatically.** Per the K-Cont-4 brief, `tofu apply` is operator-run. CI only verifies `tofu validate` + `tofu fmt -check`.
+- **Doesn't manage the SealedSecret.** That's a `clusters/<sov>/...` overlay artifact; the operator extracts plaintext to feed this module's `bearer_tokens_csv` var.
+- **Doesn't tear down on Continuum CR deletion.** Worker + KV outlive the CR (they may serve other CRs). Manual `tofu destroy` when retiring a Sovereign.

--- a/infra/cloudflare-worker-leases/main.tf
+++ b/infra/cloudflare-worker-leases/main.tf
@@ -1,0 +1,95 @@
+# main.tf — deploys the OpenOva Continuum lease-witness Worker.
+#
+# Slice K-Cont-4 of EPIC-6 (#1101). The Worker source lives at
+# `products/continuum/cloudflare-worker/`; this module is the operator-
+# facing deploy surface that:
+#   1. Creates a Cloudflare Workers KV namespace (`OPENOVA_LEASES`)
+#   2. Uploads the bundled Worker script
+#   3. Binds the KV namespace + env vars to the script
+#   4. Optionally registers a custom subdomain route
+#
+# Per docs/INVIOLABLE-PRINCIPLES.md:
+#   - #4: every value is a variable — account id, KV name, bearer tokens
+#   - #5: bearer tokens come from a K8s SealedSecret (operator extracts
+#     via TF_VAR_bearer_tokens_csv at apply time; never committed)
+#
+# `tofu apply` is OPERATOR-RUN (per K-Cont-4 brief, "DO NOT actually run
+# tofu apply — module ships ready for operator action"). CI verifies via
+# `tofu validate` + `tofu fmt -check` only.
+
+provider "cloudflare" {
+  api_token = var.cloudflare_api_token
+}
+
+# ─── KV namespace ──────────────────────────────────────────────────────
+#
+# Per the K-Cont-3 Cloudflare KV Worker contract, keys live under
+# `lease:<slot-url-encoded>`. ONE namespace serves all Continuum CRs
+# this Worker is responsible for; per-CR isolation is via the slot
+# string, not via separate KV namespaces.
+resource "cloudflare_workers_kv_namespace" "leases" {
+  account_id = var.cloudflare_account_id
+  title      = var.kv_namespace_title
+}
+
+# ─── Worker script ─────────────────────────────────────────────────────
+#
+# `cloudflare_workers_script` v5 expects `content` to be the bundled JS
+# (the result of `wrangler deploy --dry-run --outdir=dist`). Operators
+# build the bundle out-of-band from `products/continuum/cloudflare-worker/`
+# and point `worker_script_path` at the result.
+#
+# The script binds:
+#   - kv_namespace OPENOVA_LEASES → the namespace above
+#   - plain_text_binding BEARER_TOKENS_CSV → operator-supplied
+#   - plain_text_binding LOG_LEVEL → operator-supplied
+#
+# `compatibility_date` MUST match wrangler.toml's value to keep the
+# runtime semantics identical between `wrangler dev` and the deployed
+# script.
+resource "cloudflare_workers_script" "lease_witness" {
+  account_id         = var.cloudflare_account_id
+  script_name        = var.worker_name
+  content            = file(var.worker_script_path)
+  main_module        = "index.js"
+  compatibility_date = "2024-09-09"
+
+  # KV binding — must match `wrangler.toml` `[[kv_namespaces]] binding`.
+  bindings = [
+    {
+      name         = "OPENOVA_LEASES"
+      type         = "kv_namespace"
+      namespace_id = cloudflare_workers_kv_namespace.leases.id
+    },
+    # NOTE on bearer tokens: in v5 of the cloudflare provider the
+    # canonical place for SECRETS is `cloudflare_workers_secret` (a
+    # separate resource); plain `vars` would expose the value via the
+    # CF dashboard read API. We therefore declare BEARER_TOKENS_CSV via
+    # the dedicated secret resource below, and only LOG_LEVEL inline as
+    # a plain text binding (non-sensitive).
+    {
+      name = "LOG_LEVEL"
+      type = "plain_text"
+      text = var.log_level
+    },
+  ]
+}
+
+# ─── Bearer-token allow-list (encrypted at rest in CF) ────────────────
+#
+# `cloudflare_workers_secret` writes a Worker-bound secret env var. The
+# value is encrypted at rest by Cloudflare and never visible via the
+# dashboard read API once written. Per Inviolable Principle #5 + the
+# Worker's auth.ts, the Worker reads this as `env.BEARER_TOKENS_CSV` and
+# parses it as a comma-separated list.
+#
+# Rotation: replace TF_VAR_bearer_tokens_csv with `<new>,<old>`, run
+# `tofu apply`. The Worker now accepts both. After one renew cycle
+# (default 10s) update controller-side SealedSecret, then run a final
+# `tofu apply` with just `<new>` to retire the old token.
+resource "cloudflare_workers_secret" "bearer_tokens_csv" {
+  account_id  = var.cloudflare_account_id
+  script_name = cloudflare_workers_script.lease_witness.script_name
+  name        = "BEARER_TOKENS_CSV"
+  text        = var.bearer_tokens_csv
+}

--- a/infra/cloudflare-worker-leases/main.tf
+++ b/infra/cloudflare-worker-leases/main.tf
@@ -54,42 +54,38 @@ resource "cloudflare_workers_script" "lease_witness" {
   main_module        = "index.js"
   compatibility_date = "2024-09-09"
 
-  # KV binding — must match `wrangler.toml` `[[kv_namespaces]] binding`.
+  # Bindings — must match `wrangler.toml`'s `[[kv_namespaces]] binding`
+  # + `[vars]` keys. Per the cloudflare/cloudflare v5 provider the
+  # binding `type` enum is one of: `kv_namespace`, `plain_text`,
+  # `secret_text`, ... (see `tofu providers schema`).
+  #
+  # On secret handling: `secret_text` is the v5 canonical seam for
+  # Worker-bound secrets — encrypted at rest by Cloudflare, never
+  # visible via the dashboard read API once written. (V4 had a
+  # separate `cloudflare_workers_secret` resource; v5 collapsed both
+  # into the inline binding.)  Per Inviolable Principle #5 the actual
+  # value comes from a K8s SealedSecret extracted into
+  # TF_VAR_bearer_tokens_csv at apply time — never inlined here.
+  #
+  # Rotation: replace TF_VAR_bearer_tokens_csv with `<new>,<old>`, run
+  # `tofu apply`. The Worker now accepts both. After one renew cycle
+  # (default 10s) update controller-side SealedSecret, then run a final
+  # `tofu apply` with just `<new>` to retire the old token.
   bindings = [
     {
       name         = "OPENOVA_LEASES"
       type         = "kv_namespace"
       namespace_id = cloudflare_workers_kv_namespace.leases.id
     },
-    # NOTE on bearer tokens: in v5 of the cloudflare provider the
-    # canonical place for SECRETS is `cloudflare_workers_secret` (a
-    # separate resource); plain `vars` would expose the value via the
-    # CF dashboard read API. We therefore declare BEARER_TOKENS_CSV via
-    # the dedicated secret resource below, and only LOG_LEVEL inline as
-    # a plain text binding (non-sensitive).
     {
       name = "LOG_LEVEL"
       type = "plain_text"
       text = var.log_level
     },
+    {
+      name = "BEARER_TOKENS_CSV"
+      type = "secret_text"
+      text = var.bearer_tokens_csv
+    },
   ]
-}
-
-# ─── Bearer-token allow-list (encrypted at rest in CF) ────────────────
-#
-# `cloudflare_workers_secret` writes a Worker-bound secret env var. The
-# value is encrypted at rest by Cloudflare and never visible via the
-# dashboard read API once written. Per Inviolable Principle #5 + the
-# Worker's auth.ts, the Worker reads this as `env.BEARER_TOKENS_CSV` and
-# parses it as a comma-separated list.
-#
-# Rotation: replace TF_VAR_bearer_tokens_csv with `<new>,<old>`, run
-# `tofu apply`. The Worker now accepts both. After one renew cycle
-# (default 10s) update controller-side SealedSecret, then run a final
-# `tofu apply` with just `<new>` to retire the old token.
-resource "cloudflare_workers_secret" "bearer_tokens_csv" {
-  account_id  = var.cloudflare_account_id
-  script_name = cloudflare_workers_script.lease_witness.script_name
-  name        = "BEARER_TOKENS_CSV"
-  text        = var.bearer_tokens_csv
 }

--- a/infra/cloudflare-worker-leases/outputs.tf
+++ b/infra/cloudflare-worker-leases/outputs.tf
@@ -1,0 +1,37 @@
+# outputs.tf — operator-facing outputs.
+#
+# `worker_url` is THE value the operator pastes into the Continuum
+# CR's `spec.leaseClient.config.baseURL`. The CFKVClient (K-Cont-3)
+# constructs requests as `${baseURL}/lease/<slot-url-encoded>`.
+
+output "worker_url" {
+  description = <<-EOT
+    HTTPS URL of the deployed lease-witness Worker. Set this on the
+    Continuum CR via:
+
+      spec:
+        leaseClient:
+          kind: cloudflare-kv
+          config:
+            baseURL: "<this output>"
+            tokenSecretRef:
+              name: continuum-cf-witness-tokens
+              key: token
+  EOT
+  # Cloudflare's default Workers route format. The actual URL depends
+  # on the operator's Workers subdomain (settable in the CF dashboard);
+  # this output assumes the default `.workers.dev` subdomain. For a
+  # custom domain route, override `spec.leaseClient.config.baseURL`
+  # directly with the custom hostname.
+  value = "https://${var.worker_name}.${var.cloudflare_account_id}.workers.dev"
+}
+
+output "kv_namespace_id" {
+  description = "Cloudflare KV namespace ID — useful for ad-hoc CLI introspection (`wrangler kv:key list`)."
+  value       = cloudflare_workers_kv_namespace.leases.id
+}
+
+output "worker_name" {
+  description = "Worker script name as deployed."
+  value       = cloudflare_workers_script.lease_witness.script_name
+}

--- a/infra/cloudflare-worker-leases/variables.tf
+++ b/infra/cloudflare-worker-leases/variables.tf
@@ -1,0 +1,139 @@
+# variables.tf — operator-supplied inputs for the lease-witness Worker.
+#
+# Per docs/INVIOLABLE-PRINCIPLES.md #4 (never hardcode), every value
+# this module needs comes from a variable — no inline account ids,
+# zone ids, or KV namespace names. Per #5 (sealed secrets), the bearer
+# token allow-list is sensitive and lives only in memory during apply.
+
+# ─── Cloudflare account ───────────────────────────────────────────────
+
+variable "cloudflare_account_id" {
+  type        = string
+  description = <<-EOT
+    Cloudflare account id (32-char hex). Required for every CF
+    Workers resource. Sourced from the operator's Cloudflare account
+    dashboard (Right sidebar → Account ID). Never inlined; passed
+    via tofu var (or a tfvars file outside git).
+  EOT
+  validation {
+    condition     = can(regex("^[0-9a-f]{32}$", var.cloudflare_account_id))
+    error_message = "cloudflare_account_id must be a 32-character hex string."
+  }
+}
+
+variable "cloudflare_api_token" {
+  type        = string
+  sensitive   = true
+  description = <<-EOT
+    Cloudflare API token with permissions:
+      - Account → Workers Scripts: Edit
+      - Account → Workers KV Storage: Edit
+    Generate via My Profile → API Tokens. Per Inviolable Principle
+    #5 the token never lives in tofu-vars files committed to git;
+    pass via TF_VAR_cloudflare_api_token at apply time.
+  EOT
+  validation {
+    # CF tokens are 40-char base64-style strings. We don't pin a
+    # precise format because CF may rotate the issuance shape.
+    condition     = length(var.cloudflare_api_token) >= 32
+    error_message = "cloudflare_api_token must be at least 32 characters."
+  }
+}
+
+# ─── Worker identity ──────────────────────────────────────────────────
+
+variable "worker_name" {
+  type        = string
+  description = <<-EOT
+    Cloudflare Worker script name. Becomes part of the Worker URL:
+    `https://<worker_name>.<account-subdomain>.workers.dev`. The
+    Continuum controller reads this URL from the Continuum CR's
+    `spec.leaseClient.config.baseURL`. Per Inviolable Principle #4
+    runtime-configurable; the default is documented for the common
+    case but every Sovereign can override it.
+  EOT
+  default     = "openova-continuum-lease-witness"
+  validation {
+    # Worker names must be lowercase RFC1035-compatible identifiers.
+    condition     = can(regex("^[a-z][a-z0-9-]{0,62}$", var.worker_name))
+    error_message = "worker_name must be a lowercase RFC1035 identifier (max 63 chars)."
+  }
+}
+
+variable "kv_namespace_title" {
+  type        = string
+  description = <<-EOT
+    Title (display name) of the KV namespace bound to the Worker as
+    `OPENOVA_LEASES`. Per the K-Cont-3 contract (canonical-seams.md
+    "Cloudflare KV Worker contract" entry) keys live under
+    `lease:<slot-url-encoded>`. Defaults to a per-Sovereign-friendly
+    name; operators may suffix the Sovereign FQDN to disambiguate
+    when multiple Sovereigns share an account.
+  EOT
+  default     = "openova-continuum-leases"
+  validation {
+    condition     = length(var.kv_namespace_title) > 0 && length(var.kv_namespace_title) <= 64
+    error_message = "kv_namespace_title must be 1-64 characters."
+  }
+}
+
+# ─── Auth ─────────────────────────────────────────────────────────────
+
+variable "bearer_tokens_csv" {
+  type        = string
+  sensitive   = true
+  description = <<-EOT
+    Comma-separated allow-list of valid bearer tokens. The Worker
+    accepts `Authorization: Bearer <token>` IFF the token appears in
+    this list. Per Inviolable Principle #5 sourced from a K8s
+    SealedSecret in the Sovereign cluster (typically
+    `catalyst-system/continuum-cf-witness-tokens`); the operator
+    extracts the plaintext via `kubectl --kubeconfig` ONLY long
+    enough to feed `TF_VAR_bearer_tokens_csv` to this module.
+
+    Generate per Inviolable Principle #5: `openssl rand -hex 32`
+    per token, 24+ chars, no dictionary words. Include 2 tokens
+    when rotating: the old one stays valid for one renew cycle
+    (default 10s) so the controller doesn't drop the lease during
+    rollout.
+  EOT
+  validation {
+    condition     = length(trim(var.bearer_tokens_csv, " ,")) > 0
+    error_message = "bearer_tokens_csv must contain at least one non-empty token."
+  }
+}
+
+variable "log_level" {
+  type        = string
+  description = <<-EOT
+    Worker LOG_LEVEL — one of "error" / "info" / "debug". `info`
+    logs request method + path + status; `debug` adds X-Holder +
+    If-Match. The Authorization header value is NEVER logged. Per
+    CLAUDE.md credential hygiene, prefer `info` in production;
+    `debug` only during incident response.
+  EOT
+  default     = "info"
+  validation {
+    condition     = contains(["error", "info", "debug"], var.log_level)
+    error_message = "log_level must be one of: error, info, debug."
+  }
+}
+
+# ─── Worker source ─────────────────────────────────────────────────────
+
+variable "worker_script_path" {
+  type        = string
+  description = <<-EOT
+    Path (relative to this module dir, or absolute) to the bundled
+    Worker script. Default expects the operator to have run
+    `npm run build:dryrun` in `products/continuum/cloudflare-worker/`
+    which produces `dist/index.js`. The build step is left out of
+    the tofu module so the bundle is reviewable + reproducible from
+    CI rather than synthesized at apply time.
+
+    For a pre-deploy dry-run that only needs `tofu plan` to succeed
+    with NO real Cloudflare credentials, point this at the source
+    `src/index.ts` directly — `tofu validate` doesn't read the file.
+  EOT
+  default     = "../../products/continuum/cloudflare-worker/dist/index.js"
+}

--- a/infra/cloudflare-worker-leases/versions.tf
+++ b/infra/cloudflare-worker-leases/versions.tf
@@ -1,0 +1,27 @@
+# versions.tf — provider pin for the lease-witness Worker module.
+#
+# Slice K-Cont-4 of EPIC-6 (#1101) — first Cloudflare-resource module
+# in this repo. We pin the official cloudflare/cloudflare provider
+# (https://registry.terraform.io/providers/cloudflare/cloudflare/) at
+# v5+ which exposes:
+#   - cloudflare_workers_script         (deploy the Worker source)
+#   - cloudflare_workers_kv_namespace   (create the KV namespace)
+#   - cloudflare_workers_secret         (env-bound bearer token list)
+#
+# Required version >= 1.6.0 to match the rest of `infra/`'s OpenTofu
+# version floor (see infra/hetzner/versions.tf).
+
+terraform {
+  required_version = ">= 1.6.0"
+
+  required_providers {
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      # 5.x renamed several Workers resources; pinning <6 prevents an
+      # accidental jump across a future breaking-change boundary. Bump
+      # the upper bound deliberately when CF ships v6 + we audit the
+      # rename diff.
+      version = "~> 5.0"
+    }
+  }
+}

--- a/infra/cloudflare-worker-leases/versions.tf
+++ b/infra/cloudflare-worker-leases/versions.tf
@@ -16,7 +16,7 @@ terraform {
 
   required_providers {
     cloudflare = {
-      source  = "cloudflare/cloudflare"
+      source = "cloudflare/cloudflare"
       # 5.x renamed several Workers resources; pinning <6 prevents an
       # accidental jump across a future breaking-change boundary. Bump
       # the upper bound deliberately when CF ships v6 + we audit the

--- a/products/continuum/cloudflare-worker/.eslintrc.cjs
+++ b/products/continuum/cloudflare-worker/.eslintrc.cjs
@@ -1,0 +1,38 @@
+// .eslintrc.cjs — minimal ESLint config for the lease-witness Worker.
+//
+// Aligns with the @typescript-eslint/recommended ruleset plus a few
+// adjustments for Workers idioms:
+//   - `no-console` off — Workers Logs uses console.log
+//   - `@typescript-eslint/no-explicit-any` warn (we cast a few times
+//     for the Cloudflare KV types)
+//   - allow underscore-prefixed unused params (Worker handlers have
+//     unused `request` / `ctx` for some endpoints)
+
+/* eslint-env node */
+module.exports = {
+  root: true,
+  parser: "@typescript-eslint/parser",
+  parserOptions: {
+    ecmaVersion: 2022,
+    sourceType: "module",
+    project: "./tsconfig.json",
+  },
+  plugins: ["@typescript-eslint"],
+  extends: [
+    "eslint:recommended",
+    "plugin:@typescript-eslint/recommended",
+  ],
+  env: {
+    es2022: true,
+    worker: true,
+  },
+  ignorePatterns: ["dist/", ".wrangler/", "node_modules/"],
+  rules: {
+    "no-console": "off",
+    "@typescript-eslint/no-explicit-any": "warn",
+    "@typescript-eslint/no-unused-vars": [
+      "error",
+      { argsIgnorePattern: "^_", varsIgnorePattern: "^_" },
+    ],
+  },
+};

--- a/products/continuum/cloudflare-worker/.gitignore
+++ b/products/continuum/cloudflare-worker/.gitignore
@@ -1,0 +1,7 @@
+node_modules/
+dist/
+.wrangler/
+*.log
+.DS_Store
+.env
+.env.local

--- a/products/continuum/cloudflare-worker/DESIGN.md
+++ b/products/continuum/cloudflare-worker/DESIGN.md
@@ -1,0 +1,107 @@
+# Continuum Lease-Witness Worker — Design
+
+**Slice K-Cont-4 of EPIC-6 (#1101).**
+**Predecessor**: K-Cont-3 (`core/controllers/continuum/internal/witness/cloudflarekv/` — the Go client).
+
+This Worker is the **server side** of the Cloudflare KV witness pattern (per `docs/SRE.md` §2.4). The Continuum controller's `CFKVClient` (K-Cont-3) calls it for `Acquire` / `Renew` / `Release` / `Read` operations against a per-Continuum-CR slot stored in Cloudflare Workers KV.
+
+## Why a Worker (vs raw KV REST)?
+
+Cloudflare KV's REST API has no native CAS primitive — concurrent writers can clobber each other. A Worker fronts KV with read-then-CAS-write semantics enforced via the `If-Match` header pattern. This single endpoint also:
+
+- Centralises the bearer-token allow-list (one secret rotated in one place, not per-CR)
+- Stamps `acquiredAt`/`expiresAt` server-side (clock-skew immune across the controller fleet)
+- Bumps `generation` monotonically across the lifecycle (including Release) so a re-Acquire after Release sees `If-Match: <gen+1>` instead of rolling back to 0
+- Logs per-slot access for audit (visible in Workers Logs / CF dashboard)
+
+## HTTP contract (non-negotiable per K-Cont-3 #1158)
+
+| Method | Path | Required headers | Body | Success | Conflict | Auth fail |
+|---|---|---|---|---|---|---|
+| GET | `/lease/<slot-url-encoded>` | `Authorization: Bearer <token>` | — | 200 + LeaseState | 404 | 401 |
+| PUT | `/lease/<slot>` | `Authorization`, `If-Match: <gen-or-0>`, `Content-Type: application/json` | `{holder, ttlSeconds, op∈{acquire,renew}}` | 200 + LeaseState | 412 + LeaseState | 401 |
+| DELETE | `/lease/<slot>` | `Authorization`, `If-Match: <gen>`, `X-Holder: <region>` | — | 204 | 412 | 401 |
+
+`LeaseState` JSON shape: `{holder: string, acquiredAt: RFC3339, expiresAt: RFC3339, generation: int64}`.
+
+### 7 critical behaviors (per K-Cont-3 traps item h — all covered)
+
+1. **`If-Match: 0` = first-acquire-on-empty-slot signal.** Worker accepts on empty slot; rejects 412 if held. (`put.ts` CAS branch.)
+2. **Generation increments unconditionally on PUT/DELETE including Release.** (`put.ts` `next.generation = curGen + 1`; `kv.ts::clearLeaseBumpGen`.)
+3. **412 SHOULD include current state body** for diagnostics. (`index.ts::preconditionFailedResponse(cur)`.)
+4. **TTL eviction is server-authoritative in stamping, NOT in storage.** Worker computes `expiresAt = now + ttlSeconds`; reads return stored state regardless of expiry. The controller's `IsHeldBy(now)` decides eviction. (`put.ts`; verified by the "Read returns stored state regardless of expiry" test.)
+5. **`X-Holder` on DELETE = holder-identity check.** Stale region can't evict the new primary even with stale-but-matching `If-Match`. (`delete.ts` second 412 branch.)
+6. **Bearer token validation against env-bound allow-list** — no per-account path scoping. (`auth.ts`.)
+7. **Optional `X-Lease-Slot` header** for KV log granularity. (Logged in `index.ts::log` at debug level; never affects routing.)
+
+## Module layout
+
+```
+products/continuum/cloudflare-worker/
+├── package.json              # @cloudflare/workers-types, vitest, wrangler
+├── tsconfig.json             # ES2022 + strict + workers-types
+├── wrangler.toml             # name, KV binding (id REPLACE_ME via tofu),
+│                             # vars (BEARER_TOKENS_CSV, LOG_LEVEL),
+│                             # observability, cpu_ms=100
+├── vitest.config.ts          # @cloudflare/vitest-pool-workers config
+├── .eslintrc.cjs             # @typescript-eslint/recommended
+├── src/
+│   ├── index.ts              # entrypoint: routing + auth + dispatch + helpers
+│   ├── auth.ts               # bearer-token validation (no logging of token)
+│   ├── kv.ts                 # KV access wrapper; key shape `lease:<slot>`
+│   ├── types.ts              # LeaseState + LeaseWriteRequest + Env + ErrorBody
+│   └── handlers/
+│       ├── get.ts            # GET /lease/<slot>
+│       ├── put.ts            # PUT /lease/<slot> (acquire + renew)
+│       └── delete.ts         # DELETE /lease/<slot>
+├── test/
+│   ├── handlers.test.ts      # branch-coverage tests (auth, routing, all
+│   │                         # methods, every status code, edge cases)
+│   └── contract.test.ts      # exact-shape verification against K-Cont-3
+│                             # CFKVClient request bodies + header sets
+└── DESIGN.md                 # this file
+```
+
+## KV key/value shape
+
+- **Key**: `lease:<slot>` where `<slot>` is the URL-decoded path tail (e.g. `lease:ns/cr-main`).
+- **Value**: JSON `LeaseState` blob (see `types.ts`).
+- **TTL on KV record**: NONE. Records persist until DELETE replaces them with a `{holder: "", generation: gen+1}` shell. Per trap #4 the Worker does NOT delete records on TTL expiry — that's the controller's responsibility.
+
+## Auth model
+
+- Bearer tokens live in the `BEARER_TOKENS_CSV` env var, comma-separated. Per Inviolable Principle #5 the actual values are passed at deploy time via `wrangler secret put` (or the CF dashboard), NEVER inlined in `wrangler.toml`.
+- The OpenTofu module at `infra/cloudflare-worker-leases/` consumes a SealedSecret (per the Continuum CR's `spec.leaseClient.config.tokenSecretRef`) and writes the comma-separated list to the Worker's `vars` at apply time.
+- `Authorization: Bearer <token>` is checked on EVERY request (no per-method auth differences). Missing header / wrong scheme / unknown token → 401.
+- The Worker NEVER logs the token value, only the boolean outcome.
+
+## Operator runbook — deploy a new Sovereign
+
+To deploy the lease witness Worker for a new Sovereign:
+
+1. **Provision the SealedSecret** holding the bearer token allow-list. Use `kubeseal` to encrypt a Secret of shape `{token: "<32-char-random>"}`. The Continuum CR's `spec.leaseClient.config.tokenSecretRef` references this Secret. Generate the token with `openssl rand -hex 32` (Inviolable Principle #5: 24+ chars, fully random, no dictionary words). Commit the SealedSecret to the Sovereign's overlay directory under `clusters/<sovereign-fqdn>/`.
+2. **Run the tofu module** at `infra/cloudflare-worker-leases/`. Inputs: `cf_account_id`, `cf_zone_id` (optional), `kv_namespace_name` (defaults to `OPENOVA_LEASES`), and `bearer_tokens_csv` (read from the SealedSecret via `data.kubernetes_secret`). The module creates the KV namespace, deploys the Worker, and binds the namespace + env vars. Outputs: `worker_url` (e.g. `https://openova-continuum-lease-witness.<account>.workers.dev`).
+3. **Wire the Continuum CR**: set `spec.leaseClient.kind: cloudflare-kv` and `spec.leaseClient.config.baseURL: <tofu-output-worker-url>`. The catalyst-controllers reconciler picks up the change on the next reconcile (~30s) and the CFKVClient starts hitting the new Worker. Verify via `kubectl logs -n catalyst-controllers continuum-controller-* | grep cloudflarekv` — the first Acquire should succeed within one renew cycle.
+
+For per-Sovereign isolation, deploy ONE Worker per Sovereign (each with its own KV namespace + token); the slot-per-CR partitioning inside one Worker is sufficient for multiple Continuum CRs within a single Sovereign but does NOT isolate Sovereigns from each other if they share a Worker.
+
+## Local dev
+
+```sh
+cd products/continuum/cloudflare-worker
+npm install
+npm test                      # vitest contract + handler suites
+npm run lint                  # ESLint
+npm run typecheck             # tsc --noEmit
+npm run build:dryrun          # wrangler deploy --dry-run (verifies build)
+```
+
+Real local `wrangler dev` requires a CF account; the contract tests run against an in-process workerd via `@cloudflare/vitest-pool-workers` so no account needed for CI.
+
+## Out of scope
+
+- DO NOT couple this Worker to a Sovereign's other K8s state. It MUST work against any controller that speaks the contract.
+- DO NOT add a `/healthz` endpoint. Cloudflare's platform pings the Worker; an unauthed `/healthz` would be probe surface for nothing.
+- DO NOT add per-account path scoping. Auth is binary (allow-list); per-CR isolation is by `slot`.
+
+— Slice K-Cont-4

--- a/products/continuum/cloudflare-worker/package-lock.json
+++ b/products/continuum/cloudflare-worker/package-lock.json
@@ -1,0 +1,5204 @@
+{
+  "name": "@openova/continuum-lease-witness-worker",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@openova/continuum-lease-witness-worker",
+      "version": "0.1.0",
+      "license": "Apache-2.0",
+      "devDependencies": {
+        "@cloudflare/vitest-pool-workers": "^0.5.0",
+        "@cloudflare/workers-types": "^4.20240909.0",
+        "@typescript-eslint/eslint-plugin": "^7.18.0",
+        "@typescript-eslint/parser": "^7.18.0",
+        "eslint": "^8.57.0",
+        "typescript": "^5.5.4",
+        "vitest": "~2.1.0",
+        "wrangler": "^3.78.0"
+      }
+    },
+    "node_modules/@cloudflare/kv-asset-handler": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.3.4.tgz",
+      "integrity": "sha512-YLPHc8yASwjNkmcDMQMY35yiWjoKAKnhUbPRszBRS0YgH+IXtsMp61j+yTcnCE3oO2DgP0U3iejLC8FTtKDC8Q==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "mime": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.13"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers": {
+      "version": "0.5.41",
+      "resolved": "https://registry.npmjs.org/@cloudflare/vitest-pool-workers/-/vitest-pool-workers-0.5.41.tgz",
+      "integrity": "sha512-J0uYmOKJgyo/az5nV8QHlR6xQ+HHB6S65tOEutkvUPbuPDbFlBPRT+XHJhSTNNvZGeM1t2qZIzxp0WGmXLtNlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "birpc": "0.2.14",
+        "cjs-module-lexer": "^1.2.3",
+        "devalue": "^4.3.0",
+        "esbuild": "0.17.19",
+        "miniflare": "3.20241230.0",
+        "semver": "^7.5.1",
+        "wrangler": "3.100.0",
+        "zod": "^3.22.3"
+      },
+      "peerDependencies": {
+        "@vitest/runner": "2.0.x - 2.1.x",
+        "@vitest/snapshot": "2.0.x - 2.1.x",
+        "vitest": "2.0.x - 2.1.x"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/ohash": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/ohash/-/ohash-1.1.6.tgz",
+      "integrity": "sha512-TBu7PtV8YkAZn0tSxobKY2n2aAQva936lhRrj6957aDaCf9IEtqsKbgMzXE/F/sjqYOwmrukeORHNLe5glk7Cg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/unenv": {
+      "name": "unenv-nightly",
+      "version": "2.0.0-20241218-183400-5d6aec3",
+      "resolved": "https://registry.npmjs.org/unenv-nightly/-/unenv-nightly-2.0.0-20241218-183400-5d6aec3.tgz",
+      "integrity": "sha512-7Xpi29CJRbOV1/IrC03DawMJ0hloklDLq/cigSe+J2jkcC+iDres2Cy0r4ltj5f0x7DqsaGaB4/dLuCPPFZnZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "defu": "^6.1.4",
+        "mlly": "^1.7.3",
+        "ohash": "^1.1.4",
+        "pathe": "^1.1.2",
+        "ufo": "^1.5.4"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/wrangler": {
+      "version": "3.100.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-3.100.0.tgz",
+      "integrity": "sha512-+nsZK374Xnp2BEQQuB/18pnObgsOey0AHVlg75pAdwNaKAmB2aa0/E5rFb7i89DiiwFYoZMz3cARY1UKcm/WQQ==",
+      "deprecated": "Downgrade to 3.99.0",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@cloudflare/kv-asset-handler": "0.3.4",
+        "@esbuild-plugins/node-globals-polyfill": "^0.2.3",
+        "@esbuild-plugins/node-modules-polyfill": "^0.2.2",
+        "blake3-wasm": "^2.1.5",
+        "chokidar": "^4.0.1",
+        "date-fns": "^4.1.0",
+        "esbuild": "0.17.19",
+        "itty-time": "^1.0.6",
+        "miniflare": "3.20241230.0",
+        "nanoid": "^3.3.3",
+        "path-to-regexp": "^6.3.0",
+        "resolve": "^1.22.8",
+        "selfsigned": "^2.0.1",
+        "source-map": "^0.6.1",
+        "unenv": "npm:unenv-nightly@2.0.0-20241218-183400-5d6aec3",
+        "workerd": "1.20241230.0",
+        "xxhash-wasm": "^1.0.1"
+      },
+      "bin": {
+        "wrangler": "bin/wrangler.js",
+        "wrangler2": "bin/wrangler.js"
+      },
+      "engines": {
+        "node": ">=16.17.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      },
+      "peerDependencies": {
+        "@cloudflare/workers-types": "^4.20241230.0"
+      },
+      "peerDependenciesMeta": {
+        "@cloudflare/workers-types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-64": {
+      "version": "1.20241230.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20241230.0.tgz",
+      "integrity": "sha512-BZHLg4bbhNQoaY1Uan81O3FV/zcmWueC55juhnaI7NAobiQth9RppadPNpxNAmS9fK2mR5z8xrwMQSQrHmztyQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-arm64": {
+      "version": "1.20241230.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20241230.0.tgz",
+      "integrity": "sha512-lllxycj7EzYoJ0VOJh8M3palUgoonVrILnzGrgsworgWlIpgjfXGS7b41tEGCw6AxSxL9prmTIGtfSPUvn/rjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-64": {
+      "version": "1.20241230.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20241230.0.tgz",
+      "integrity": "sha512-Y3mHcW0KghOmWdNZyHYpEOG4Ba/ga8tht5vj1a+WXfagEjMO8Y98XhZUlCaYa9yB7Wh5jVcK5LM2jlO/BLgqpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-arm64": {
+      "version": "1.20241230.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20241230.0.tgz",
+      "integrity": "sha512-IAjhsWPlHzhhkJ6I49sDG6XfMnhPvv0szKGXxTWQK/IWMrbGdHm4RSfNKBSoLQm67jGMIzbmcrX9UIkms27Y1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-windows-64": {
+      "version": "1.20241230.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20241230.0.tgz",
+      "integrity": "sha512-y5SPIk9iOb2gz+yWtHxoeMnjPnkYQswiCJ480oHC6zexnJLlKTpcmBCjDH1nWCT4pQi8F25gaH8thgElf4NvXQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workers-types": {
+      "version": "4.20260509.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260509.1.tgz",
+      "integrity": "sha512-jFlTTD+0MK/01TdL5sHIsQ8RqzfmvBsGl4hSp87INv2+JIs/JF6EL9J8enuCz6z3fNdfOKISNbGCIrzZRXVrcw==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0"
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild-plugins/node-globals-polyfill": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@esbuild-plugins/node-globals-polyfill/-/node-globals-polyfill-0.2.3.tgz",
+      "integrity": "sha512-r3MIryXDeXDOZh7ih1l/yE9ZLORCd5e8vWg02azWRGj5SPTuoh69A2AIyn0Z31V/kHBfZ4HgWJ+OK3GTTwLmnw==",
+      "dev": true,
+      "license": "ISC",
+      "peerDependencies": {
+        "esbuild": "*"
+      }
+    },
+    "node_modules/@esbuild-plugins/node-modules-polyfill": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@esbuild-plugins/node-modules-polyfill/-/node-modules-polyfill-0.2.2.tgz",
+      "integrity": "sha512-LXV7QsWJxRuMYvKbiznh+U1ilIop3g2TeKRzUxOG5X3YITc8JyyTa90BmLwqqv0YnX4v32CSlG+vsziZp9dMvA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "escape-string-regexp": "^4.0.0",
+        "rollup-plugin-node-polyfills": "^0.2.1"
+      },
+      "peerDependencies": {
+        "esbuild": "*"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.17.19.tgz",
+      "integrity": "sha512-rIKddzqhmav7MSmoFCmDIb6e2W57geRsM94gV2l38fzhXMwq7hZoClug9USI2pFRGL06f4IOPHHpFNOkWieR8A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.17.19.tgz",
+      "integrity": "sha512-KBMWvEZooR7+kzY0BtbTQn0OAYY7CsiydT63pVEaPtVYF0hXbUaOyZog37DKxK7NF3XacBJOpYT4adIJh+avxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.17.19.tgz",
+      "integrity": "sha512-uUTTc4xGNDT7YSArp/zbtmbhO0uEEK9/ETW29Wk1thYUJBz3IVnvgEiEwEa9IeLyvnpKrWK64Utw2bgUmDveww==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.17.19.tgz",
+      "integrity": "sha512-80wEoCfF/hFKM6WE1FyBHc9SfUblloAWx6FJkFWTWiCoht9Mc0ARGEM47e67W9rI09YoUxJL68WHfDRYEAvOhg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.17.19.tgz",
+      "integrity": "sha512-IJM4JJsLhRYr9xdtLytPLSH9k/oxR3boaUIYiHkAawtwNOXKE8KoU8tMvryogdcT8AU+Bflmh81Xn6Q0vTZbQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.17.19.tgz",
+      "integrity": "sha512-pBwbc7DufluUeGdjSU5Si+P3SoMF5DQ/F/UmTSb8HXO80ZEAJmrykPyzo1IfNbAoaqw48YRpv8shwd1NoI0jcQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.17.19.tgz",
+      "integrity": "sha512-4lu+n8Wk0XlajEhbEffdy2xy53dpR06SlzvhGByyg36qJw6Kpfk7cp45DR/62aPH9mtJRmIyrXAS5UWBrJT6TQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.17.19.tgz",
+      "integrity": "sha512-cdmT3KxjlOQ/gZ2cjfrQOtmhG4HJs6hhvm3mWSRDPtZ/lP5oe8FWceS10JaSJC13GBd4eH/haHnqf7hhGNLerA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.17.19.tgz",
+      "integrity": "sha512-ct1Tg3WGwd3P+oZYqic+YZF4snNl2bsnMKRkb3ozHmnM0dGWuxcPTTntAF6bOP0Sp4x0PjSF+4uHQ1xvxfRKqg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.17.19.tgz",
+      "integrity": "sha512-w4IRhSy1VbsNxHRQpeGCHEmibqdTUx61Vc38APcsRbuVgK0OPEnQ0YD39Brymn96mOx48Y2laBQGqgZ0j9w6SQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.17.19.tgz",
+      "integrity": "sha512-2iAngUbBPMq439a+z//gE+9WBldoMp1s5GWsUSgqHLzLJ9WoZLZhpwWuym0u0u/4XmZ3gpHmzV84PonE+9IIdQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.17.19.tgz",
+      "integrity": "sha512-LKJltc4LVdMKHsrFe4MGNPp0hqDFA1Wpt3jE1gEyM3nKUvOiO//9PheZZHfYRfYl6AwdTH4aTcXSqBerX0ml4A==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.17.19.tgz",
+      "integrity": "sha512-/c/DGybs95WXNS8y3Ti/ytqETiW7EU44MEKuCAcpPto3YjQbyK3IQVKfF6nbghD7EcLUGl0NbiL5Rt5DMhn5tg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.17.19.tgz",
+      "integrity": "sha512-FC3nUAWhvFoutlhAkgHf8f5HwFWUL6bYdvLc/TTuxKlvLi3+pPzdZiFKSWz/PF30TB1K19SuCxDTI5KcqASJqA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.17.19.tgz",
+      "integrity": "sha512-IbFsFbxMWLuKEbH+7sTkKzL6NJmG2vRyy6K7JJo55w+8xDk7RElYn6xvXtDW8HCfoKBFK69f3pgBJSUSQPr+4Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.17.19.tgz",
+      "integrity": "sha512-68ngA9lg2H6zkZcyp22tsVt38mlhWde8l3eJLWkyLrp4HwMUr3c1s/M2t7+kHIhvMjglIBrFpncX1SzMckomGw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.17.19.tgz",
+      "integrity": "sha512-CwFq42rXCR8TYIjIfpXCbRX0rp1jo6cPIUPSaWwzbVI4aOfX96OXY8M6KNmtPcg7QjYeDmN+DD0Wp3LaBOLf4Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.17.19.tgz",
+      "integrity": "sha512-cnq5brJYrSZ2CF6c35eCmviIN3k3RczmHz8eYaVlNasVqsNY+JKohZU5MKmaOI+KkllCdzOKKdPs762VCPC20g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.17.19.tgz",
+      "integrity": "sha512-vCRT7yP3zX+bKWFeP/zdS6SqdWB8OIpaRq/mbXQxTGHnIxspRtigpkUcDMlSCOejlHowLqII7K2JKevwyRP2rg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.17.19.tgz",
+      "integrity": "sha512-yYx+8jwowUstVdorcMdNlzklLYhPxjniHWFKgRqH7IFlUEa0Umu3KuYplf1HUZZ422e3NU9F4LGb+4O0Kdcaag==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.17.19.tgz",
+      "integrity": "sha512-eggDKanJszUtCdlVs0RB+h35wNlb5v4TWEkq4vZcmVt5u/HiDZrTXe2bWFQUez3RgNHwx/x4sk5++4NSSicKkw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.17.19.tgz",
+      "integrity": "sha512-lAhycmKnVOuRYNtRtatQR1LPQf2oYCkRGkSFnseDAKPl8lu5SOsK/e1sXe5a0Pc5kHIHe6P2I/ilntNv2xf3cA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
+      "integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.12.4",
+        "debug": "^4.3.2",
+        "espree": "^9.6.0",
+        "globals": "^13.19.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.0",
+        "minimatch": "^3.1.2",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.1.tgz",
+      "integrity": "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@fastify/busboy": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
+      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@humanwhocodes/config-array": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
+      "integrity": "sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==",
+      "deprecated": "Use @eslint/config-array instead",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanwhocodes/object-schema": "^2.0.3",
+        "debug": "^4.3.1",
+        "minimatch": "^3.0.5"
+      },
+      "engines": {
+        "node": ">=10.10.0"
+      }
+    },
+    "node_modules/@humanwhocodes/config-array/node_modules/brace-expansion": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@humanwhocodes/config-array/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/object-schema": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
+      "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
+      "deprecated": "Use @eslint/object-schema instead",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.33.5.tgz",
+      "integrity": "sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.33.5.tgz",
+      "integrity": "sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.0.4.tgz",
+      "integrity": "sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.0.4.tgz",
+      "integrity": "sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.0.5.tgz",
+      "integrity": "sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.0.4.tgz",
+      "integrity": "sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.0.4.tgz",
+      "integrity": "sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.0.4.tgz",
+      "integrity": "sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.0.4.tgz",
+      "integrity": "sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.0.4.tgz",
+      "integrity": "sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.33.5.tgz",
+      "integrity": "sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.0.5"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.33.5.tgz",
+      "integrity": "sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.33.5.tgz",
+      "integrity": "sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.33.5.tgz",
+      "integrity": "sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.33.5.tgz",
+      "integrity": "sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.33.5.tgz",
+      "integrity": "sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.33.5.tgz",
+      "integrity": "sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.2.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.33.5.tgz",
+      "integrity": "sha512-T36PblLaTwuVJ/zw/LaH0PdZkRz5rd3SmMHX8GSmR7vtNSP5Z6bQkExdSK7xGWyxLw4sUknBuugTelgw2faBbQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.33.5.tgz",
+      "integrity": "sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.3.tgz",
+      "integrity": "sha512-x35CNW/ANXG3hE/EZpRU8MXX1JDN86hBb2wMGAtltkz7pc6cxgjpy1OMMfDosOQ+2hWqIkag/fGok1Yady9nGw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.3.tgz",
+      "integrity": "sha512-xw3xtkDApIOGayehp2+Rz4zimfkaX65r4t47iy+ymQB2G4iJCBBfj0ogVg5jpvjpn8UWn/+q9tprxleYeNp3Hw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.3.tgz",
+      "integrity": "sha512-vo6Y5Qfpx7/5EaamIwi0WqW2+zfiusVihKatLvtN1VFVy3D13uERk/6gZLU1UiHRL6fDXqj/ELIeVRGnvcTE1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.3.tgz",
+      "integrity": "sha512-D+0QGcZhBzTN82weOnsSlY7V7+RMmPuF1CkbxyMAGE8+ZHeUjyb76ZiWmBlCu//AQQONvxcqRbwZTajZKqjuOw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.3.tgz",
+      "integrity": "sha512-6HnvHCT7fDyj6R0Ph7A6x8dQS/S38MClRWeDLqc0MdfWkxjiu1HSDYrdPhqSILzjTIC/pnXbbJbo+ft+gy/9hQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.3.tgz",
+      "integrity": "sha512-KHLgC3WKlUYW3ShFKnnosZDOJ0xjg9zp7au3sIm2bs/tGBeC2ipmvRh/N7JKi0t9Ue20C0dpEshi8WUubg+cnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.3.tgz",
+      "integrity": "sha512-DV6fJoxEYWJOvaZIsok7KrYl0tPvga5OZ2yvKHNNYyk/2roMLqQAbGhr78EQ5YhHpnhLKJD3S1WFusAkmUuV5g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.3.tgz",
+      "integrity": "sha512-mQKoJAzvuOs6F+TZybQO4GOTSMUu7v0WdxEk24krQ/uUxXoPTtHjuaUuPmFhtBcM4K0ons8nrE3JyhTuCFtT/w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.3.tgz",
+      "integrity": "sha512-Whjj2qoiJ6+OOJMGptTYazaJvjOJm+iKHpXQM1P3LzGjt7Ff++Tp7nH4N8J/BUA7R9IHfDyx4DJIflifwnbmIA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.3.tgz",
+      "integrity": "sha512-4YTNHKqGng5+yiZt3mg77nmyuCfmNfX4fPmyUapBcIk+BdwSwmCWGXOUxhXbBEkFHtoN5boLj/5NON+u5QC9tg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.3.tgz",
+      "integrity": "sha512-SU3kNlhkpI4UqlUc2VXPGK9o886ZsSeGfMAX2ba2b8DKmMXq4AL7KUrkSWVbb7koVqx41Yczx6dx5PNargIrEA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.3.tgz",
+      "integrity": "sha512-6lDLl5h4TXpB1mTf2rQWnAk/LcXrx9vBfu/DT5TIPhvMhRWaZ5MxkIc8u4lJAmBo6klTe1ywXIUHFjylW505sg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.3.tgz",
+      "integrity": "sha512-BMo8bOw8evlup/8G+cj5xWtPyp93xPdyoSN16Zy90Q2QZ0ZYRhCt6ZJSwbrRzG9HApFabjwj2p25TUPDWrhzqQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.3.tgz",
+      "integrity": "sha512-E0L8X1dZN1/Rph+5VPF6Xj2G7JJvMACVXtamTJIDrVI44Y3K+G8gQaMEAavbqCGTa16InptiVrX6eM6pmJ+7qA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.3.tgz",
+      "integrity": "sha512-oZJ/WHaVfHUiRAtmTAeo3DcevNsVvH8mbvodjZy7D5QKvCefO371SiKRpxoDcCxB3PTRTLayWBkvmDQKTcX/sw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.3.tgz",
+      "integrity": "sha512-Dhbyh7j9FybM3YaTgaHmVALwA8AkUwTPccyCQ79TG9AJUsMQqgN1DDEZNr4+QUfwiWvLDumW5vdwzoeUF+TNxQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.3.tgz",
+      "integrity": "sha512-cJd1X5XhHHlltkaypz1UcWLA8AcoIi1aWhsvaWDskD1oz2eKCypnqvTQ8ykMNI0RSmm7NkTdSqSSD7zM0xa6Ig==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.3.tgz",
+      "integrity": "sha512-DAZDBHQfG2oQuhY7mc6I3/qB4LU2fQCjRvxbDwd/Jdvb9fypP4IJ4qmtu6lNjes6B531AI8cg1aKC2di97bUxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.3.tgz",
+      "integrity": "sha512-cRxsE8c13mZOh3vP+wLDxpQBRrOHDIGOWyDL93Sy0Ga8y515fBcC2pjUfFwUe5T7tqvTvWbCpg1URM/AXdWIXA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.3.tgz",
+      "integrity": "sha512-QaWcIgRxqEdQdhJqW4DJctsH6HCmo5vHxY0krHSX4jMtOqfzC+dqDGuHM87bu4H8JBeibWx7jFz+h6/4C8wA5Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.3.tgz",
+      "integrity": "sha512-AaXwSvUi3QIPtroAUw1t5yHGIyqKEXwH54WUocFolZhpGDruJcs8c+xPNDRn4XiQsS7MEwnYsHW2l0MBLDMkWg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.3.tgz",
+      "integrity": "sha512-65LAKM/bAWDqKNEelHlcHvm2V+Vfb8C6INFxQXRHCvaVN1rJfwr4NvdP4FyzUaLqWfaCGaadf6UbTm8xJeYfEg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.3.tgz",
+      "integrity": "sha512-EEM2gyhBF5MFnI6vMKdX1LAosE627RGBzIoGMdLloPZkXrUN0Ckqgr2Qi8+J3zip/8NVVro3/FjB+tjhZUgUHA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.3.tgz",
+      "integrity": "sha512-E5Eb5H/DpxaoXH++Qkv28RcUJboMopmdDUALBczvHMf7hNIxaDZqwY5lK12UK1BHacSmvupoEWGu+n993Z0y1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.3.tgz",
+      "integrity": "sha512-hPt/bgL5cE+Qp+/TPHBqptcAgPzgj46mPcg/16zNUmbQk0j+mOEQV/+Lqu8QRtDV3Ek95Q6FeFITpuhl6OTsAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "25.6.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.2.tgz",
+      "integrity": "sha512-sokuT28dxf9JT5Kady1fsXOvI4HVpjZa95NKT5y9PNTIrs2AsobR4GFAA90ZG8M+nxVRLysCXsVj6eGC7Vbrlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.19.0"
+      }
+    },
+    "node_modules/@types/node-forge": {
+      "version": "1.3.14",
+      "resolved": "https://registry.npmjs.org/@types/node-forge/-/node-forge-1.3.14.tgz",
+      "integrity": "sha512-mhVF2BnD4BO+jtOp7z1CdzaK4mbuK0LLQYAvdOLqHTavxFNq4zA1EmYkpnFjP8HOUzedfQkRnp0E2ulSAYSzAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.18.0.tgz",
+      "integrity": "sha512-94EQTWZ40mzBc42ATNIBimBEDltSJ9RQHCC8vc/PDbxi4k8dVwUAv4o98dk50M1zB+JGFxp43FP7f8+FP8R6Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.10.0",
+        "@typescript-eslint/scope-manager": "7.18.0",
+        "@typescript-eslint/type-utils": "7.18.0",
+        "@typescript-eslint/utils": "7.18.0",
+        "@typescript-eslint/visitor-keys": "7.18.0",
+        "graphemer": "^1.4.0",
+        "ignore": "^5.3.1",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^1.3.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^7.0.0",
+        "eslint": "^8.56.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.18.0.tgz",
+      "integrity": "sha512-4Z+L8I2OqhZV8qA132M4wNL30ypZGYOQVBfMgxDH/K5UX0PNqTu1c6za9ST5r9+tavvHiTWmBnKzpCJ/GlVFtg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "7.18.0",
+        "@typescript-eslint/types": "7.18.0",
+        "@typescript-eslint/typescript-estree": "7.18.0",
+        "@typescript-eslint/visitor-keys": "7.18.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.56.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.18.0.tgz",
+      "integrity": "sha512-jjhdIE/FPF2B7Z1uzc6i3oWKbGcHb87Qw7AWj6jmEqNOfDFbJWtjt/XfwCpvNkpGWlcJaog5vTR+VV8+w9JflA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "7.18.0",
+        "@typescript-eslint/visitor-keys": "7.18.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.18.0.tgz",
+      "integrity": "sha512-XL0FJXuCLaDuX2sYqZUUSOJ2sG5/i1AAze+axqmLnSkNEVMVYLF+cbwlB2w8D1tinFuSikHmFta+P+HOofrLeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/typescript-estree": "7.18.0",
+        "@typescript-eslint/utils": "7.18.0",
+        "debug": "^4.3.4",
+        "ts-api-utils": "^1.3.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.56.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.18.0.tgz",
+      "integrity": "sha512-iZqi+Ds1y4EDYUtlOOC+aUmxnE9xS/yCigkjA7XpTKV6nCBd3Hp/PRGGmdwnfkV2ThMyYldP1wRpm/id99spTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.18.0.tgz",
+      "integrity": "sha512-aP1v/BSPnnyhMHts8cf1qQ6Q1IFwwRvAQGRvBFkWlo3/lH29OXA3Pts+c10nxRxIBrDnoMqzhgdwVe5f2D6OzA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@typescript-eslint/types": "7.18.0",
+        "@typescript-eslint/visitor-keys": "7.18.0",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "minimatch": "^9.0.4",
+        "semver": "^7.6.0",
+        "ts-api-utils": "^1.3.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.18.0.tgz",
+      "integrity": "sha512-kK0/rNa2j74XuHVcoCZxdFBMF+aq/vH83CXAOHieC+2Gis4mF8jJXT5eAfyD3K0sAxtPuwxaIOIOvhwzVDt/kw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.4.0",
+        "@typescript-eslint/scope-manager": "7.18.0",
+        "@typescript-eslint/types": "7.18.0",
+        "@typescript-eslint/typescript-estree": "7.18.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.56.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.18.0.tgz",
+      "integrity": "sha512-cDF0/Gf81QpY3xYyJKDV14Zwdmid5+uuENhjH2EqFaF0ni+yAyq/LzMaIJdhNJXZI7uLzwIlA+V7oWoyn6Curg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "7.18.0",
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.1.tgz",
+      "integrity": "sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+      "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/array-union": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/as-table": {
+      "version": "1.0.55",
+      "resolved": "https://registry.npmjs.org/as-table/-/as-table-1.0.55.tgz",
+      "integrity": "sha512-xvsWESUJn0JN421Xb9MQw6AsMHRCUknCe0Wjlxvjud80mU4E6hQf1A6NzQKcYNmYw62MfzEtXc+badstZP3JpQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "printable-characters": "^1.0.42"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/birpc": {
+      "version": "0.2.14",
+      "resolved": "https://registry.npmjs.org/birpc/-/birpc-0.2.14.tgz",
+      "integrity": "sha512-37FHE8rqsYM5JEKCnXFyHpBCzvgHEExwVVTq+nUmloInU7l8ezD1TpOhKpS8oe1DTYFqEK27rFZVKG43oTqXRA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/blake3-wasm": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
+      "integrity": "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/capnp-ts": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/capnp-ts/-/capnp-ts-0.7.0.tgz",
+      "integrity": "sha512-XKxXAC3HVPv7r674zP0VC3RTXz+/JKhfyw94ljvF80yynK6VkTnqE3jMuN8b3dUVmmc43TjyxjW4KTsmB3c86g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.1",
+        "tslib": "^2.2.0"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/cjs-module-lexer": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
+      "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/color": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
+      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "color-convert": "^2.0.1",
+        "color-string": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=12.5.0"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/color-string": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/confbox": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-2.0.2.tgz",
+      "integrity": "sha512-ND9qDTLc6diwj+Xe5cdAgVTbLVdXbtxTJRXRhli8Mowuaan+0EJOtdqJ0QCHNSSPyoXGx9HX2/VMnKeC34AChA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/defu": {
+      "version": "6.1.7",
+      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
+      "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/devalue": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/devalue/-/devalue-4.3.3.tgz",
+      "integrity": "sha512-UH8EL6H2ifcY8TbD2QsxwCC/pr5xSwPvv85LrLXVihmHVC3T3YqTCIwnR5ak0yO1KYqlxrPVOA/JVZJYPy2ATg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/dir-glob": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-type": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.17.19.tgz",
+      "integrity": "sha512-XQ0jAPFkK/u3LcVRcvVHQcTIqD6E2H1fvZMA5dQPSOWb3suUbWbfbRf94pjc0bNzRYLfIrDRQXr7X+LHIm5oHw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/android-arm": "0.17.19",
+        "@esbuild/android-arm64": "0.17.19",
+        "@esbuild/android-x64": "0.17.19",
+        "@esbuild/darwin-arm64": "0.17.19",
+        "@esbuild/darwin-x64": "0.17.19",
+        "@esbuild/freebsd-arm64": "0.17.19",
+        "@esbuild/freebsd-x64": "0.17.19",
+        "@esbuild/linux-arm": "0.17.19",
+        "@esbuild/linux-arm64": "0.17.19",
+        "@esbuild/linux-ia32": "0.17.19",
+        "@esbuild/linux-loong64": "0.17.19",
+        "@esbuild/linux-mips64el": "0.17.19",
+        "@esbuild/linux-ppc64": "0.17.19",
+        "@esbuild/linux-riscv64": "0.17.19",
+        "@esbuild/linux-s390x": "0.17.19",
+        "@esbuild/linux-x64": "0.17.19",
+        "@esbuild/netbsd-x64": "0.17.19",
+        "@esbuild/openbsd-x64": "0.17.19",
+        "@esbuild/sunos-x64": "0.17.19",
+        "@esbuild/win32-arm64": "0.17.19",
+        "@esbuild/win32-ia32": "0.17.19",
+        "@esbuild/win32-x64": "0.17.19"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
+      "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
+      "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "@eslint-community/regexpp": "^4.6.1",
+        "@eslint/eslintrc": "^2.1.4",
+        "@eslint/js": "8.57.1",
+        "@humanwhocodes/config-array": "^0.13.0",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@nodelib/fs.walk": "^1.2.8",
+        "@ungap/structured-clone": "^1.2.0",
+        "ajv": "^6.12.4",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.2",
+        "debug": "^4.3.2",
+        "doctrine": "^3.0.0",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^7.2.2",
+        "eslint-visitor-keys": "^3.4.3",
+        "espree": "^9.6.1",
+        "esquery": "^1.4.2",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^6.0.1",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "globals": "^13.19.0",
+        "graphemer": "^1.4.0",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "is-path-inside": "^3.0.3",
+        "js-yaml": "^4.1.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.4.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.2",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3",
+        "strip-ansi": "^6.0.1",
+        "text-table": "^0.2.0"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
+      "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/brace-expansion": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/eslint/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/espree": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
+      "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.9.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^3.4.1"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/exit-hook": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-2.2.1.tgz",
+      "integrity": "sha512-eNTPlAD67BmP31LDINZ3U7HSF8l57TxOY2PmBJ1shpCvpnxBF93mWCE8YHBnXs8qiUZJc9WDcWIeC3a2HIAMfw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/exsolve": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.8.tgz",
+      "integrity": "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
+      "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^3.0.4"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz",
+      "integrity": "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.3",
+        "rimraf": "^3.0.2"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-source": {
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/get-source/-/get-source-2.0.12.tgz",
+      "integrity": "sha512-X5+4+iD+HoSeEED+uwrQ07BOQr0kEDFMVqqpBuI+RaZBpBpHCuXxo70bjar6f0b0u/DQJsJ7ssurpP0V60Az+w==",
+      "dev": true,
+      "license": "Unlicense",
+      "dependencies": {
+        "data-uri-to-buffer": "^2.0.0",
+        "source-map": "^0.6.1"
+      }
+    },
+    "node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/glob-to-regexp": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/globals": {
+      "version": "13.24.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+      "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.20.2"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/globby": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/graphemer": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
+      "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.4.tgz",
+      "integrity": "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-path-inside": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+      "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/itty-time": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/itty-time/-/itty-time-1.0.6.tgz",
+      "integrity": "sha512-+P8IZaLLBtFv8hCkIjcymZOp4UJ+xW6bSlQsXGqrkmJh7vSiMFSlNne0mCYagEE0N7HDNR5jJBRxwN0oYv61Rw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
+      "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/miniflare": {
+      "version": "3.20241230.0",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-3.20241230.0.tgz",
+      "integrity": "sha512-ZtWNoNAIj5Q0Vb3B4SPEKr7DDmVG8a0Stsp/AuRkYXoJniA5hsbKjFNIGhTXGMIHVP5bvDrKJWt/POIDGfpiKg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "0.8.1",
+        "acorn": "^8.8.0",
+        "acorn-walk": "^8.2.0",
+        "capnp-ts": "^0.7.0",
+        "exit-hook": "^2.2.1",
+        "glob-to-regexp": "^0.4.1",
+        "stoppable": "^1.1.0",
+        "undici": "^5.28.4",
+        "workerd": "1.20241230.0",
+        "ws": "^8.18.0",
+        "youch": "^3.2.2",
+        "zod": "^3.22.3"
+      },
+      "bin": {
+        "miniflare": "bootstrap.js"
+      },
+      "engines": {
+        "node": ">=16.13"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/mlly": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.2.tgz",
+      "integrity": "sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "pathe": "^2.0.3",
+        "pkg-types": "^1.3.1",
+        "ufo": "^1.6.3"
+      }
+    },
+    "node_modules/mlly/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mustache": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
+      "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mustache": "bin/mustache"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/node-forge": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
+      "integrity": "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==",
+      "dev": true,
+      "license": "(BSD-3-Clause OR GPL-2.0)",
+      "engines": {
+        "node": ">= 6.13.0"
+      }
+    },
+    "node_modules/ohash": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
+      "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pkg-types": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
+      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.1.8",
+        "mlly": "^1.7.4",
+        "pathe": "^2.0.1"
+      }
+    },
+    "node_modules/pkg-types/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/printable-characters": {
+      "version": "1.0.42",
+      "resolved": "https://registry.npmjs.org/printable-characters/-/printable-characters-1.0.42.tgz",
+      "integrity": "sha512-dKp+C4iXWK4vVYZmYSd0KBH5F/h1HoZRsbJ82AVKRO3PEo8L4lBS/vLwhVtpwwuYcoIsVY+1JYKR268yn480uQ==",
+      "dev": true,
+      "license": "Unlicense"
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.3.tgz",
+      "integrity": "sha512-pAQK9HalE84QSm4Po3EmWIZPd3FnjkShVkiMlz1iligWYkWQ7wHYd1PF/T7QZ5TVSD6uSTon5gBVMSM4JfBV+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.3",
+        "@rollup/rollup-android-arm64": "4.60.3",
+        "@rollup/rollup-darwin-arm64": "4.60.3",
+        "@rollup/rollup-darwin-x64": "4.60.3",
+        "@rollup/rollup-freebsd-arm64": "4.60.3",
+        "@rollup/rollup-freebsd-x64": "4.60.3",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.3",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.3",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.3",
+        "@rollup/rollup-linux-arm64-musl": "4.60.3",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.3",
+        "@rollup/rollup-linux-loong64-musl": "4.60.3",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.3",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.3",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.3",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.3",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.3",
+        "@rollup/rollup-linux-x64-gnu": "4.60.3",
+        "@rollup/rollup-linux-x64-musl": "4.60.3",
+        "@rollup/rollup-openbsd-x64": "4.60.3",
+        "@rollup/rollup-openharmony-arm64": "4.60.3",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.3",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.3",
+        "@rollup/rollup-win32-x64-gnu": "4.60.3",
+        "@rollup/rollup-win32-x64-msvc": "4.60.3",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rollup-plugin-inject": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-inject/-/rollup-plugin-inject-3.0.2.tgz",
+      "integrity": "sha512-ptg9PQwzs3orn4jkgXJ74bfs5vYz1NCZlSQMBUA0wKcGp5i5pA1AO3fOUEte8enhGUC+iapTCzEWw2jEFFUO/w==",
+      "deprecated": "This package has been deprecated and is no longer maintained. Please use @rollup/plugin-inject.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "estree-walker": "^0.6.1",
+        "magic-string": "^0.25.3",
+        "rollup-pluginutils": "^2.8.1"
+      }
+    },
+    "node_modules/rollup-plugin-inject/node_modules/estree-walker": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
+      "integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/rollup-plugin-inject/node_modules/magic-string": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
+      "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sourcemap-codec": "^1.4.8"
+      }
+    },
+    "node_modules/rollup-plugin-node-polyfills": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-node-polyfills/-/rollup-plugin-node-polyfills-0.2.1.tgz",
+      "integrity": "sha512-4kCrKPTJ6sK4/gLL/U5QzVT8cxJcofO0OU74tnB19F40cmuAKSzH5/siithxlofFEjwvw1YAhPmbvGNA6jEroA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "rollup-plugin-inject": "^3.0.0"
+      }
+    },
+    "node_modules/rollup-pluginutils": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz",
+      "integrity": "sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "estree-walker": "^0.6.1"
+      }
+    },
+    "node_modules/rollup-pluginutils/node_modules/estree-walker": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
+      "integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/rollup/node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/selfsigned": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-2.4.1.tgz",
+      "integrity": "sha512-th5B4L2U+eGLq1TVh7zNRGBapioSORUeymIydxgFpwww9d2qyKvtuPU2jJuHvYAwwqi2Y596QBL3eEqcPEYL8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node-forge": "^1.3.0",
+        "node-forge": "^1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sharp": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.33.5.tgz",
+      "integrity": "sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "color": "^4.2.3",
+        "detect-libc": "^2.0.3",
+        "semver": "^7.6.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.33.5",
+        "@img/sharp-darwin-x64": "0.33.5",
+        "@img/sharp-libvips-darwin-arm64": "1.0.4",
+        "@img/sharp-libvips-darwin-x64": "1.0.4",
+        "@img/sharp-libvips-linux-arm": "1.0.5",
+        "@img/sharp-libvips-linux-arm64": "1.0.4",
+        "@img/sharp-libvips-linux-s390x": "1.0.4",
+        "@img/sharp-libvips-linux-x64": "1.0.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.0.4",
+        "@img/sharp-linux-arm": "0.33.5",
+        "@img/sharp-linux-arm64": "0.33.5",
+        "@img/sharp-linux-s390x": "0.33.5",
+        "@img/sharp-linux-x64": "0.33.5",
+        "@img/sharp-linuxmusl-arm64": "0.33.5",
+        "@img/sharp-linuxmusl-x64": "0.33.5",
+        "@img/sharp-wasm32": "0.33.5",
+        "@img/sharp-win32-ia32": "0.33.5",
+        "@img/sharp-win32-x64": "0.33.5"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/simple-swizzle": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.4.tgz",
+      "integrity": "sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "is-arrayish": "^0.3.1"
+      }
+    },
+    "node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sourcemap-codec": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
+      "deprecated": "Please use @jridgewell/sourcemap-codec instead",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stacktracey": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/stacktracey/-/stacktracey-2.2.0.tgz",
+      "integrity": "sha512-ETyQEz+CzXiLjEbyJqpbp+/T79RQD/6wqFucRBIlVNZfYq2Ay7wbretD4cxpbymZlaPWx58aIhPEY1Cr8DlVvg==",
+      "dev": true,
+      "license": "Unlicense",
+      "dependencies": {
+        "as-table": "^1.0.36",
+        "get-source": "^2.0.12"
+      }
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stoppable": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/stoppable/-/stoppable-1.1.0.tgz",
+      "integrity": "sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/ts-api-utils": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.4.3.tgz",
+      "integrity": "sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.2.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/ufo": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.4.tgz",
+      "integrity": "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/undici": {
+      "version": "5.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
+      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/busboy": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unenv": {
+      "version": "2.0.0-rc.14",
+      "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.14.tgz",
+      "integrity": "sha512-od496pShMen7nOy5VmVJCnq8rptd45vh6Nx/r2iPbrba6pa6p+tS2ywuIHRZ/OBvSbQZB0kWvpO9XBNVFXHD3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "defu": "^6.1.4",
+        "exsolve": "^1.0.1",
+        "ohash": "^2.0.10",
+        "pathe": "^2.0.3",
+        "ufo": "^1.5.4"
+      }
+    },
+    "node_modules/unenv/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/workerd": {
+      "version": "1.20241230.0",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20241230.0.tgz",
+      "integrity": "sha512-EgixXP0JGXGq6J9lz17TKIZtfNDUvJNG+cl9paPMfZuYWT920fFpBx+K04YmnbQRLnglsivF1GT9pxh1yrlWhg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "workerd": "bin/workerd"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@cloudflare/workerd-darwin-64": "1.20241230.0",
+        "@cloudflare/workerd-darwin-arm64": "1.20241230.0",
+        "@cloudflare/workerd-linux-64": "1.20241230.0",
+        "@cloudflare/workerd-linux-arm64": "1.20241230.0",
+        "@cloudflare/workerd-windows-64": "1.20241230.0"
+      }
+    },
+    "node_modules/wrangler": {
+      "version": "3.114.17",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-3.114.17.tgz",
+      "integrity": "sha512-tAvf7ly+tB+zwwrmjsCyJ2pJnnc7SZhbnNwXbH+OIdVas3zTSmjcZOjmLKcGGptssAA3RyTKhcF9BvKZzMUycA==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@cloudflare/kv-asset-handler": "0.3.4",
+        "@cloudflare/unenv-preset": "2.0.2",
+        "@esbuild-plugins/node-globals-polyfill": "0.2.3",
+        "@esbuild-plugins/node-modules-polyfill": "0.2.2",
+        "blake3-wasm": "2.1.5",
+        "esbuild": "0.17.19",
+        "miniflare": "3.20250718.3",
+        "path-to-regexp": "6.3.0",
+        "unenv": "2.0.0-rc.14",
+        "workerd": "1.20250718.0"
+      },
+      "bin": {
+        "wrangler": "bin/wrangler.js",
+        "wrangler2": "bin/wrangler.js"
+      },
+      "engines": {
+        "node": ">=16.17.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2",
+        "sharp": "^0.33.5"
+      },
+      "peerDependencies": {
+        "@cloudflare/workers-types": "^4.20250408.0"
+      },
+      "peerDependenciesMeta": {
+        "@cloudflare/workers-types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/wrangler/node_modules/@cloudflare/unenv-preset": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.0.2.tgz",
+      "integrity": "sha512-nyzYnlZjjV5xT3LizahG1Iu6mnrCaxglJ04rZLpDwlDVDZ7v46lNsfxhV3A/xtfgQuSHmLnc6SVI+KwBpc3Lwg==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "peerDependencies": {
+        "unenv": "2.0.0-rc.14",
+        "workerd": "^1.20250124.0"
+      },
+      "peerDependenciesMeta": {
+        "workerd": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/wrangler/node_modules/@cloudflare/workerd-darwin-64": {
+      "version": "1.20250718.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20250718.0.tgz",
+      "integrity": "sha512-FHf4t7zbVN8yyXgQ/r/GqLPaYZSGUVzeR7RnL28Mwj2djyw2ZergvytVc7fdGcczl6PQh+VKGfZCfUqpJlbi9g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/wrangler/node_modules/@cloudflare/workerd-darwin-arm64": {
+      "version": "1.20250718.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20250718.0.tgz",
+      "integrity": "sha512-fUiyUJYyqqp4NqJ0YgGtp4WJh/II/YZsUnEb6vVy5Oeas8lUOxnN+ZOJ8N/6/5LQCVAtYCChRiIrBbfhTn5Z8Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/wrangler/node_modules/@cloudflare/workerd-linux-64": {
+      "version": "1.20250718.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20250718.0.tgz",
+      "integrity": "sha512-5+eb3rtJMiEwp08Kryqzzu8d1rUcK+gdE442auo5eniMpT170Dz0QxBrqkg2Z48SFUPYbj+6uknuA5tzdRSUSg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/wrangler/node_modules/@cloudflare/workerd-linux-arm64": {
+      "version": "1.20250718.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20250718.0.tgz",
+      "integrity": "sha512-Aa2M/DVBEBQDdATMbn217zCSFKE+ud/teS+fFS+OQqKABLn0azO2qq6ANAHYOIE6Q3Sq4CxDIQr8lGdaJHwUog==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/wrangler/node_modules/@cloudflare/workerd-windows-64": {
+      "version": "1.20250718.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20250718.0.tgz",
+      "integrity": "sha512-dY16RXKffmugnc67LTbyjdDHZn5NoTF1yHEf2fN4+OaOnoGSp3N1x77QubTDwqZ9zECWxgQfDLjddcH8dWeFhg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/wrangler/node_modules/acorn": {
+      "version": "8.14.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
+      "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/wrangler/node_modules/acorn-walk": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.2.tgz",
+      "integrity": "sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/wrangler/node_modules/miniflare": {
+      "version": "3.20250718.3",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-3.20250718.3.tgz",
+      "integrity": "sha512-JuPrDJhwLrNLEJiNLWO7ZzJrv/Vv9kZuwMYCfv0LskQDM6Eonw4OvywO3CH/wCGjgHzha/qyjUh8JQ068TjDgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "0.8.1",
+        "acorn": "8.14.0",
+        "acorn-walk": "8.3.2",
+        "exit-hook": "2.2.1",
+        "glob-to-regexp": "0.4.1",
+        "stoppable": "1.1.0",
+        "undici": "^5.28.5",
+        "workerd": "1.20250718.0",
+        "ws": "8.18.0",
+        "youch": "3.3.4",
+        "zod": "3.22.3"
+      },
+      "bin": {
+        "miniflare": "bootstrap.js"
+      },
+      "engines": {
+        "node": ">=16.13"
+      }
+    },
+    "node_modules/wrangler/node_modules/workerd": {
+      "version": "1.20250718.0",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20250718.0.tgz",
+      "integrity": "sha512-kqkIJP/eOfDlUyBzU7joBg+tl8aB25gEAGqDap+nFWb+WHhnooxjGHgxPBy3ipw2hnShPFNOQt5lFRxbwALirg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "workerd": "bin/workerd"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@cloudflare/workerd-darwin-64": "1.20250718.0",
+        "@cloudflare/workerd-darwin-arm64": "1.20250718.0",
+        "@cloudflare/workerd-linux-64": "1.20250718.0",
+        "@cloudflare/workerd-linux-arm64": "1.20250718.0",
+        "@cloudflare/workerd-windows-64": "1.20250718.0"
+      }
+    },
+    "node_modules/wrangler/node_modules/ws": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/wrangler/node_modules/zod": {
+      "version": "3.22.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.3.tgz",
+      "integrity": "sha512-EjIevzuJRiRPbVH4mGc8nApb/lVLKVpmUhAaR5R5doKGfAnGJ6Gr3CViAVjP+4FWSxCsybeWQdcgCtbX+7oZug==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xxhash-wasm": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/xxhash-wasm/-/xxhash-wasm-1.1.0.tgz",
+      "integrity": "sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/youch": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/youch/-/youch-3.3.4.tgz",
+      "integrity": "sha512-UeVBXie8cA35DS6+nBkls68xaBBXCye0CNznrhszZjTbRVnJKQuNsyLKBTTL4ln1o1rh2PKtv35twV7irj5SEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^0.7.1",
+        "mustache": "^4.2.0",
+        "stacktracey": "^2.1.8"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/products/continuum/cloudflare-worker/package.json
+++ b/products/continuum/cloudflare-worker/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@openova/continuum-lease-witness-worker",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Cloudflare Worker — lease witness for OpenOva Continuum DR (K-Cont-4 of EPIC-6 #1101). Implements the HTTP CAS contract consumed by core/controllers/continuum/internal/witness/cloudflarekv/.",
+  "license": "Apache-2.0",
+  "type": "module",
+  "main": "src/index.ts",
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "lint": "eslint . --ext .ts",
+    "lint:fix": "eslint . --ext .ts --fix",
+    "typecheck": "tsc --noEmit",
+    "build:dryrun": "wrangler deploy --dry-run --outdir=dist"
+  },
+  "devDependencies": {
+    "@cloudflare/vitest-pool-workers": "^0.5.0",
+    "@cloudflare/workers-types": "^4.20240909.0",
+    "@typescript-eslint/eslint-plugin": "^7.18.0",
+    "@typescript-eslint/parser": "^7.18.0",
+    "eslint": "^8.57.0",
+    "typescript": "^5.5.4",
+    "vitest": "~2.1.0",
+    "wrangler": "^3.78.0"
+  }
+}

--- a/products/continuum/cloudflare-worker/src/auth.ts
+++ b/products/continuum/cloudflare-worker/src/auth.ts
@@ -1,0 +1,79 @@
+// auth.ts — bearer-token validation for the lease-witness Worker.
+//
+// Per K-Cont-3 trap #6, "Bearer token validation against env-bound
+// allow-list (no per-account path scoping)". One Worker can serve
+// multiple Continuum CRs across multiple regions/holders; access
+// control is binary: any token in the allow-list is allowed to call
+// any path. Per-CR isolation is by `slot` (URL path), not by token
+// scoping.
+//
+// Per CLAUDE.md credential hygiene: NEVER log the token value, never
+// echo it in error responses, never persist it. Only the boolean
+// outcome of validation may be logged.
+
+import type { Env } from "./types";
+
+/**
+ * Parse the bearer-tokens allow-list from the env var. Tokens are
+ * comma-separated; whitespace around each token is trimmed. Empty
+ * tokens are filtered out.
+ *
+ * Defensively cached per-request: the parser is cheap and called once
+ * per request. If callers want to share the parsed set across requests
+ * they should pass it through; we explicitly do NOT cache at module
+ * scope to avoid the V8-isolate-shared-state surprise (one Worker
+ * isolate may serve many tenants if account allow-lists ever differ).
+ *
+ * @returns Set<string> of valid tokens. Empty when env var is unset.
+ */
+export function parseAllowList(env: Env): Set<string> {
+  const raw = env.BEARER_TOKENS_CSV ?? "";
+  const tokens = raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+  return new Set(tokens);
+}
+
+/**
+ * Extract the bearer token from an Authorization header and check it
+ * against the allow-list. Returns the boolean outcome ONLY — never
+ * the token itself, never the header value. Constant-time string
+ * compare is NOT used here because:
+ *
+ *   1. The allow-list lives in env (not user-controllable per request)
+ *      so timing-side-channel discovery would only leak which token
+ *      the operator chose, not the secret value.
+ *   2. Set.has() in V8 is O(1) hash; effective compare time depends on
+ *      hash distribution, not token length.
+ *
+ * If we later move to per-tenant tokens with attacker-controllable
+ * inputs, swap to a constant-time compare via crypto.subtle.timingSafeEqual.
+ *
+ * @param request — the incoming Request (we read its `Authorization` header)
+ * @param env     — Worker env containing BEARER_TOKENS_CSV
+ * @returns true when the request carries a valid bearer token; false
+ *          when the header is missing, malformed, or the token is not
+ *          in the allow-list.
+ */
+export function isAuthorized(request: Request, env: Env): boolean {
+  const header = request.headers.get("Authorization");
+  if (!header) return false;
+
+  // Match `Bearer <token>` exactly. The `Bearer` keyword is
+  // case-insensitive per RFC 6750 §2.1; we accept any casing.
+  const match = /^Bearer\s+(.+)$/i.exec(header);
+  if (!match) return false;
+
+  const token = match[1].trim();
+  if (!token) return false;
+
+  const allow = parseAllowList(env);
+  if (allow.size === 0) {
+    // Fail-closed when the operator forgot to set the allow-list.
+    // Better to refuse every request (loud Worker 401s in the
+    // controller's logs) than to default-allow.
+    return false;
+  }
+  return allow.has(token);
+}

--- a/products/continuum/cloudflare-worker/src/handlers/delete.ts
+++ b/products/continuum/cloudflare-worker/src/handlers/delete.ts
@@ -1,0 +1,102 @@
+// handlers/delete.ts — DELETE /lease/<slot> handler (release).
+//
+// Per the K-Cont-3 contract:
+//
+//   DELETE /lease/<slot>
+//     Authorization: Bearer <token>
+//     If-Match: <generation>
+//     X-Holder: <region>
+//
+//   → 204 No Content        success
+//   → 412 Precondition Failed
+//                            CAS lost (stale generation) OR
+//                            X-Holder doesn't match stored holder
+//                            (per trap #5: "stale region can't evict
+//                             the new primary")
+//   → 401 Unauthorized      bearer token missing or invalid
+//
+// Per K-Cont-3 trap #2 generation increments on Release too. The Go
+// fakeWorker writes `{Generation: cur.Generation + 1}` (empty holder)
+// on Release; we mirror that exact behavior so a subsequent Acquire
+// presents `If-Match: <gen+1>` rather than rolling back to 0.
+//
+// Empty-slot DELETE is treated as 204 success (idempotent — the
+// Release is the desired end state). The CFKVClient also has a
+// client-side idempotency guard (`if cur.Holder == "" || cur.Holder
+// != holder { return nil }`), so a stray DELETE on an empty slot
+// shouldn't reach us in production — but we accept it gracefully.
+
+import type { Env } from "../types";
+import { readLease, clearLeaseBumpGen } from "../kv";
+import {
+  emptyResponse,
+  preconditionFailedResponse,
+  badRequestResponse,
+} from "../index";
+
+export async function handleDelete(
+  request: Request,
+  env: Env,
+  slot: string,
+): Promise<Response> {
+  // ─── Parse If-Match ─────────────────────────────────────────────
+  const ifMatchRaw = request.headers.get("If-Match");
+  if (ifMatchRaw === null) {
+    return badRequestResponse("missing_if_match", "If-Match header is required");
+  }
+  const ifMatch = parseIfMatch(ifMatchRaw);
+  if (ifMatch === null) {
+    return badRequestResponse(
+      "invalid_if_match",
+      `If-Match must be a non-negative integer, got "${ifMatchRaw}"`,
+    );
+  }
+
+  // ─── Parse X-Holder ─────────────────────────────────────────────
+  const holder = request.headers.get("X-Holder");
+  if (holder === null || holder.trim().length === 0) {
+    return badRequestResponse("missing_x_holder", "X-Holder header is required");
+  }
+
+  const cur = await readLease(env.OPENOVA_LEASES, slot);
+  if (cur === null) {
+    // Idempotent — empty slot is the desired end state. 204.
+    return emptyResponse(204);
+  }
+
+  // ─── CAS + holder-identity check (trap #5) ──────────────────────
+  if (cur.generation !== ifMatch) {
+    return preconditionFailedResponse(cur);
+  }
+  if (cur.holder !== holder.trim()) {
+    // Stale region can't evict the new primary even with stale-but-
+    // matching `If-Match`. (This is theoretically impossible if
+    // generation matches because new-holder always bumps gen — but
+    // belt-and-suspenders against any future code path that forgets
+    // to bump.)
+    return preconditionFailedResponse(cur);
+  }
+
+  // ─── Apply Release: bump generation, clear holder ───────────────
+  await clearLeaseBumpGen(env.OPENOVA_LEASES, slot, cur.generation);
+  return emptyResponse(204);
+}
+
+/**
+ * Parse `If-Match` header. See put.ts for the spec.
+ *
+ * Duplicated rather than shared to keep handler files self-contained
+ * — extracting to a shared module would require a runtime barrel
+ * import that adds a few KB to the Worker bundle for no observable
+ * benefit. If a third caller appears, lift to `src/headers.ts`.
+ */
+function parseIfMatch(raw: string): number | null {
+  const trimmed = raw.trim();
+  const m = /^(?:W\/)?(?:"(.+)"|(.+))$/.exec(trimmed);
+  if (!m) return null;
+  const v = (m[1] ?? m[2] ?? "").trim();
+  if (!/^\d+$/.test(v)) return null;
+  const n = Number.parseInt(v, 10);
+  if (!Number.isFinite(n) || n < 0) return null;
+  return n;
+}

--- a/products/continuum/cloudflare-worker/src/handlers/get.ts
+++ b/products/continuum/cloudflare-worker/src/handlers/get.ts
@@ -1,0 +1,32 @@
+// handlers/get.ts — GET /lease/<slot> handler.
+//
+// Per the K-Cont-3 contract:
+//   - 200 + LeaseState body when the slot exists (whether or not it's
+//     expired — TTL eviction is controller-side per trap #4).
+//   - 404 when the slot is empty (KV returns null).
+//   - 401 when bearer-token validation fails (handled in index.ts;
+//     this handler runs only on authorized requests).
+//
+// The slot is the URL path tail after `/lease/`. The Worker's URL
+// parser already URL-decodes `%2F` back to `/`, so the slot we pass
+// downstream is the canonical "<namespace>/<name>" form the Go client
+// sent before encoding.
+
+import type { Env } from "../types";
+import { readLease } from "../kv";
+import { jsonResponse, notFoundResponse } from "../index";
+
+export async function handleGet(
+  _request: Request,
+  env: Env,
+  slot: string,
+): Promise<Response> {
+  const state = await readLease(env.OPENOVA_LEASES, slot);
+  if (!state) {
+    // Empty slot — the CFKVClient maps 404 to a zero-State with
+    // Generation=0, then PUTs with `If-Match: 0` to take the slot.
+    // (See client.go::Read switch on http.StatusNotFound.)
+    return notFoundResponse("lease not found");
+  }
+  return jsonResponse(200, state);
+}

--- a/products/continuum/cloudflare-worker/src/handlers/put.ts
+++ b/products/continuum/cloudflare-worker/src/handlers/put.ts
@@ -1,0 +1,189 @@
+// handlers/put.ts — PUT /lease/<slot> handler (acquire + renew).
+//
+// Per the K-Cont-3 contract this single endpoint serves two
+// operations distinguished by the `op` field of the request body:
+//
+//   - acquire — claim an empty slot OR re-acquire the same slot you
+//               already hold. The CAS guard is `If-Match` matching
+//               the stored generation (or 0 for a never-touched slot).
+//   - renew   — extend the TTL on a slot you already hold.
+//               REQUIRES stored.holder === requested.holder AND
+//               stored.expiresAt > now (per K-Cont-2 contract — Renew
+//               is for the holder only).
+//
+// CAS semantics on PUT (per K-Cont-3 trap #1, "If-Match: 0 = first-
+// acquire-on-empty-slot signal"):
+//
+//   stored generation | If-Match | accept?
+//   ───────────────────┼──────────┼─────────
+//   N/A (empty slot)   | 0        | YES (first acquire)
+//   N/A (empty slot)   | non-0    | 412 (CAS conflict — caller has
+//                                         stale view; client retries
+//                                         after a fresh Read)
+//   G                  | G        | YES if takeable (acquire-on-empty/
+//                                                    expired/sameHolder)
+//   G                  | != G     | 412 (CAS lost between caller's
+//                                         Read and PUT; retry)
+//
+// Per K-Cont-3 trap #2 generation increments UNCONDITIONALLY on every
+// successful write (including the case where the same holder
+// re-acquires/renews — bump preserves "newest write wins" semantics
+// for ANY observer, even one in our same region).
+//
+// Per K-Cont-3 trap #4 we stamp `expiresAt = now + ttlSeconds`
+// server-side. Per trap #3 we include the current state body on 412
+// so the client can use it for diagnostics.
+
+import type { Env, LeaseState, LeaseWriteRequest } from "../types";
+import { readLease, writeLease } from "../kv";
+import {
+  jsonResponse,
+  preconditionFailedResponse,
+  badRequestResponse,
+} from "../index";
+
+export async function handlePut(
+  request: Request,
+  env: Env,
+  slot: string,
+): Promise<Response> {
+  // ─── Parse + validate body ─────────────────────────────────────────
+  let body: LeaseWriteRequest;
+  try {
+    body = (await request.json()) as LeaseWriteRequest;
+  } catch (err) {
+    return badRequestResponse(
+      "invalid_json",
+      `body must be JSON: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+  if (!body || typeof body !== "object") {
+    return badRequestResponse("invalid_body", "body must be a JSON object");
+  }
+  if (typeof body.holder !== "string" || body.holder.length === 0) {
+    return badRequestResponse("invalid_holder", "holder must be a non-empty string");
+  }
+  if (typeof body.ttlSeconds !== "number" || body.ttlSeconds <= 0 || !Number.isFinite(body.ttlSeconds)) {
+    return badRequestResponse("invalid_ttl", "ttlSeconds must be a positive number");
+  }
+  if (body.op !== "acquire" && body.op !== "renew") {
+    return badRequestResponse("invalid_op", `op must be "acquire" or "renew", got "${body.op}"`);
+  }
+
+  // ─── Parse If-Match ────────────────────────────────────────────────
+  // Per the K-Cont-3 contract the header value is the integer
+  // generation, NOT a quoted ETag. We accept both forms (some HTTP
+  // clients quote by default) for forward compat.
+  const ifMatchRaw = request.headers.get("If-Match");
+  if (ifMatchRaw === null) {
+    return badRequestResponse("missing_if_match", "If-Match header is required");
+  }
+  const ifMatch = parseIfMatch(ifMatchRaw);
+  if (ifMatch === null) {
+    return badRequestResponse(
+      "invalid_if_match",
+      `If-Match must be a non-negative integer, got "${ifMatchRaw}"`,
+    );
+  }
+
+  const now = new Date();
+  const nowRFC = now.toISOString();
+  const cur = await readLease(env.OPENOVA_LEASES, slot);
+  const curGen = cur?.generation ?? 0;
+
+  // ─── CAS check ─────────────────────────────────────────────────────
+  if (ifMatch !== curGen) {
+    // CAS lost OR caller passed a stale generation.
+    return preconditionFailedResponse(cur);
+  }
+
+  // ─── Decide whether the slot is takeable ───────────────────────────
+  // Per K-Cont-3 trap #4, the Worker doesn't actively evict expired
+  // records — but a PUT-acquire from a NEW holder needs to succeed
+  // when the current holder's lease has expired. Mirror the Go
+  // fakeWorker logic in client_test.go::serveLease (which is the
+  // authoritative spec).
+  //
+  // "Released" record (post-DELETE) carries holder="" + bumped
+  // generation. Treat it the same as an empty slot for takeability
+  // — otherwise a re-acquire after Release would 412 forever
+  // because the empty-holder shell isn't sameHolder OR expired.
+  // (See `kv.ts::clearLeaseBumpGen` for the Release shape.)
+  const released = cur !== null && cur.holder === "";
+  const sameHolder = cur !== null && cur.holder !== "" && cur.holder === body.holder;
+  const expired = cur !== null && cur.expiresAt !== "" && !isAfter(cur.expiresAt, now);
+  const heldByOther = cur !== null && !released && !sameHolder && !expired;
+
+  if (heldByOther) {
+    // Slot is held by another, non-expired holder. Reject the acquire
+    // (and any renew which would have already bounced on the renew
+    // pre-check below). Include current state on 412 per trap #3.
+    return preconditionFailedResponse(cur);
+  }
+
+  if (body.op === "renew") {
+    // Renew requires sameHolder + non-expired. Reject otherwise per
+    // K-Cont-2 contract — Renew is for the holder only.
+    if (!sameHolder || expired) {
+      return preconditionFailedResponse(cur);
+    }
+  }
+
+  // ─── Compute new state ─────────────────────────────────────────────
+  // Preserve `acquiredAt` when the same holder re-acquires/renews
+  // a non-expired slot. Stamp a fresh `acquiredAt` when a NEW holder
+  // takes over (the previous holder's lease expired, or this is a
+  // first acquire on a never-held slot).
+  let acquiredAt: string;
+  if (sameHolder && !expired && cur && cur.acquiredAt !== "") {
+    acquiredAt = cur.acquiredAt;
+  } else {
+    acquiredAt = nowRFC;
+  }
+
+  const ttlMs = Math.floor(body.ttlSeconds * 1000);
+  const expiresAt = new Date(now.getTime() + ttlMs).toISOString();
+
+  const next: LeaseState = {
+    holder: body.holder,
+    acquiredAt,
+    expiresAt,
+    generation: curGen + 1,
+  };
+  await writeLease(env.OPENOVA_LEASES, slot, next);
+
+  // 200 always (not 201) — this matches the Go reference's
+  // fakeWorker which returns 200 on both first-acquire and renew.
+  // The CFKVClient accepts 200 and 201 but the contract is 200.
+  return jsonResponse(200, next);
+}
+
+/**
+ * Parse `If-Match` header. Accepts:
+ *   - bare integer:    `0`, `42`, `123456789`
+ *   - quoted ETag:     `"42"`, `W/"42"` (weak ETags accepted because
+ *                       some HTTP libraries auto-add the W/ prefix)
+ * Returns the parsed integer, or null when the value is malformed.
+ */
+function parseIfMatch(raw: string): number | null {
+  const trimmed = raw.trim();
+  // Strip optional W/ + surrounding quotes.
+  const m = /^(?:W\/)?(?:"(.+)"|(.+))$/.exec(trimmed);
+  if (!m) return null;
+  const v = (m[1] ?? m[2] ?? "").trim();
+  if (!/^\d+$/.test(v)) return null;
+  const n = Number.parseInt(v, 10);
+  if (!Number.isFinite(n) || n < 0) return null;
+  return n;
+}
+
+/**
+ * `isAfter(expiresAt, now)` — true when the RFC3339 `expiresAt` is
+ * strictly after `now`. Mirrors the Go `time.Time.Before(t)` check
+ * (`now.Before(t)` ↔ `t.After(now)`).
+ */
+function isAfter(rfc3339: string, now: Date): boolean {
+  const t = new Date(rfc3339);
+  if (Number.isNaN(t.getTime())) return false;
+  return t.getTime() > now.getTime();
+}

--- a/products/continuum/cloudflare-worker/src/index.ts
+++ b/products/continuum/cloudflare-worker/src/index.ts
@@ -1,0 +1,184 @@
+// index.ts — Cloudflare Worker entrypoint for the OpenOva Continuum
+// lease-witness Worker (K-Cont-4 of EPIC-6 #1101).
+//
+// Routes:
+//   GET    /lease/<slot-url-encoded>   → handlers/get.ts
+//   PUT    /lease/<slot-url-encoded>   → handlers/put.ts (acquire+renew)
+//   DELETE /lease/<slot-url-encoded>   → handlers/delete.ts
+//   *      anything-else               → 405 / 404
+//
+// Per the K-Cont-3 Cloudflare KV Worker contract entry in
+// .claude/architect-briefs/epic-0/01-canonical-seams.md THE FOUR
+// behaviors below are non-negotiable:
+//
+//   1. Slot is the URL path tail after `/lease/`. URL-decoded by
+//      the Worker's URL parser (so `%2F` becomes `/` again).
+//   2. Bearer-token validation against env-bound allow-list applies
+//      to ALL methods uniformly (no per-method auth differences).
+//   3. Server-authoritative timestamp + generation: every PUT/DELETE
+//      stamps `expiresAt = now + ttlSeconds` and bumps `generation`.
+//   4. 412 SHOULD include current state body so the client can use
+//      it for diagnostics.
+//
+// Per CLAUDE.md "10. CREDENTIAL HYGIENE" the bearer token is NEVER
+// logged. The X-Lease-Slot header (optional, per trap #7) is logged
+// for KV log granularity.
+
+import { handleGet } from "./handlers/get";
+import { handlePut } from "./handlers/put";
+import { handleDelete } from "./handlers/delete";
+import { isAuthorized } from "./auth";
+import type { Env, ErrorBody, LeaseState } from "./types";
+
+export default {
+  async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
+    void ctx; // ctx unused — no waitUntil/passThroughOnException needed here
+
+    const url = new URL(request.url);
+    const slot = extractSlot(url.pathname);
+
+    // ─── Routing layer ─────────────────────────────────────────────
+    if (slot === null) {
+      // Non-/lease/ path — 404. We deliberately don't expose a /healthz
+      // endpoint because the Worker has no warm-up state to report on
+      // and CF Workers are pinged by the platform itself; an unauthed
+      // /healthz would be a probe surface for nothing.
+      return notFoundResponse("not found");
+    }
+
+    // ─── Auth layer ────────────────────────────────────────────────
+    if (!isAuthorized(request, env)) {
+      log(env, "info", `auth_rejected method=${request.method} slot=${slot}`);
+      return unauthorizedResponse();
+    }
+
+    // ─── Method dispatch ───────────────────────────────────────────
+    log(
+      env,
+      "debug",
+      `method=${request.method} slot=${slot} if-match=${request.headers.get("If-Match") ?? "-"} x-holder=${request.headers.get("X-Holder") ?? "-"}`,
+    );
+
+    try {
+      switch (request.method) {
+        case "GET":
+          return await handleGet(request, env, slot);
+        case "PUT":
+          return await handlePut(request, env, slot);
+        case "DELETE":
+          return await handleDelete(request, env, slot);
+        case "OPTIONS":
+          // CORS pre-flight — controller is server-side Go, not a
+          // browser, but a future operator console could call this
+          // Worker directly. Allow the methods we serve.
+          return new Response(null, {
+            status: 204,
+            headers: {
+              "Allow": "GET, PUT, DELETE, OPTIONS",
+              "Access-Control-Allow-Methods": "GET, PUT, DELETE",
+              "Access-Control-Allow-Headers":
+                "Authorization, If-Match, X-Holder, X-Lease-Slot, Content-Type",
+            },
+          });
+        default:
+          return methodNotAllowedResponse();
+      }
+    } catch (err) {
+      // Defensive — the handlers should not throw under happy-path
+      // inputs, but a KV transient failure or a malformed JSON parse
+      // could surface here. 500 with an error message body so the
+      // CFKVClient's `readSnippet` logs something meaningful.
+      const msg = err instanceof Error ? err.message : String(err);
+      log(env, "error", `internal_error slot=${slot} method=${request.method} err=${msg}`);
+      return jsonResponse<ErrorBody>(500, { error: "internal_error", reason: msg });
+    }
+  },
+};
+
+// ─── Routing helpers ───────────────────────────────────────────────────
+
+/**
+ * Extract the slot from a `/lease/<slot>` URL path. Returns null when
+ * the path doesn't match `/lease/...`. The slot may contain `/` after
+ * URL decoding (e.g. `ns/cr-main`); we keep it intact.
+ */
+export function extractSlot(pathname: string): string | null {
+  // Strip trailing slash so `/lease/` (no slot) returns null cleanly.
+  // (Not strictly needed but defensive against client weirdness.)
+  if (!pathname.startsWith("/lease/")) return null;
+  const tail = pathname.slice("/lease/".length);
+  if (tail.length === 0) return null;
+  return tail;
+}
+
+// ─── Response helpers ─────────────────────────────────────────────────
+//
+// Centralised so handlers don't reinvent Response shapes. Each helper
+// sets `Content-Type` correctly and stamps the K-Cont-3 contract
+// status codes.
+
+export function jsonResponse<T = LeaseState | ErrorBody>(
+  status: number,
+  body: T,
+): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+export function emptyResponse(status: number): Response {
+  return new Response(null, { status });
+}
+
+export function notFoundResponse(reason: string): Response {
+  return jsonResponse<ErrorBody>(404, { error: "not_found", reason });
+}
+
+export function unauthorizedResponse(): Response {
+  // Per K-Cont-3 contract 401 → CFKVClient surfaces "auth rejected"
+  // error and the controller flags `LeaseHeld=False` Reason=AuthFailed.
+  return jsonResponse<ErrorBody>(401, { error: "unauthorized" });
+}
+
+export function methodNotAllowedResponse(): Response {
+  return jsonResponse<ErrorBody>(405, { error: "method_not_allowed" });
+}
+
+export function badRequestResponse(error: string, reason: string): Response {
+  return jsonResponse<ErrorBody>(400, { error, reason });
+}
+
+/**
+ * 412 Precondition Failed — CAS lost OR (DELETE) holder mismatch.
+ * Per K-Cont-3 trap #3 the body SHOULD include the current state
+ * when known so the client can diagnose. We always include the
+ * current state when non-null; on empty slots we send an empty body.
+ */
+export function preconditionFailedResponse(cur: LeaseState | null): Response {
+  if (cur === null) {
+    return new Response(null, { status: 412 });
+  }
+  return jsonResponse<LeaseState>(412, cur);
+}
+
+// ─── Logging helper ────────────────────────────────────────────────────
+//
+// Filters by LOG_LEVEL (default "info"). NEVER logs the Authorization
+// header value — only the boolean outcome of auth (logged as
+// "auth_rejected" with no token contents).
+
+const LEVELS: Record<string, number> = { error: 0, info: 1, debug: 2 };
+
+function log(env: Env, level: "error" | "info" | "debug", msg: string): void {
+  const want = LEVELS[env.LOG_LEVEL ?? "info"] ?? LEVELS.info;
+  const got = LEVELS[level];
+  if (got > want) return;
+  // Workers Logs picks up console.log / console.error via the
+  // observability binding declared in wrangler.toml.
+  if (level === "error") {
+    console.error(msg);
+  } else {
+    console.log(msg);
+  }
+}

--- a/products/continuum/cloudflare-worker/src/kv.ts
+++ b/products/continuum/cloudflare-worker/src/kv.ts
@@ -1,0 +1,82 @@
+// kv.ts — KV access wrapper for the lease-witness Worker.
+//
+// Centralises the key shape (`lease:<slot>`) and JSON marshaling so the
+// handlers stay focused on HTTP semantics. Per K-Cont-3 the value at
+// each key is a `LeaseState` JSON blob; per K-Cont-3 trap #4 the
+// Worker is server-authoritative for `acquiredAt`/`expiresAt` stamping
+// and `generation` monotonicity.
+
+import type { LeaseState } from "./types";
+
+/**
+ * Build the KV key for a slot. The slot has already been URL-decoded
+ * by the Worker's URL parser (`new URL(req.url)` decodes `%2F` back to
+ * `/`), so the canonical KV key is `lease:<slot>` — slashes preserved.
+ *
+ * KV doesn't care about characters in keys (per
+ * https://developers.cloudflare.com/kv/learning/key-naming/) up to the
+ * 512-byte limit. Slot length is bounded by Continuum CR
+ * `<namespace>/<name>` — both ≤ 253 chars per K8s naming rules.
+ */
+export function leaseKey(slot: string): string {
+  return `lease:${slot}`;
+}
+
+/**
+ * Read the current LeaseState for a slot. Returns `null` when the slot
+ * is empty (KV `get` returns `null` for missing keys — we surface that
+ * directly so callers can distinguish "no record" from "stored empty
+ * state with generation > 0" — the latter happens after Release.
+ */
+export async function readLease(
+  ns: KVNamespace,
+  slot: string,
+): Promise<LeaseState | null> {
+  // `type: "json"` instructs the runtime to JSON.parse the value
+  // before returning. Saves one `await` + a manual parse.
+  const v = await ns.get<LeaseState>(leaseKey(slot), { type: "json" });
+  return v ?? null;
+}
+
+/**
+ * Write a LeaseState. We do NOT pass `expirationTtl` to KV: per
+ * K-Cont-3 trap #4 TTL eviction is server-authoritative IN THE
+ * RESPONSE BODY (controller-side `IsHeldBy(now)` decides), not via KV
+ * record deletion. Letting KV expire records would cause a subsequent
+ * Acquire to see Generation=0 and re-take a slot the controller hasn't
+ * yet released — the K-Cont-3 contract says generation must be
+ * monotonic across the lifecycle, so the Worker keeps the record
+ * forever (or until DELETE).
+ */
+export async function writeLease(
+  ns: KVNamespace,
+  slot: string,
+  state: LeaseState,
+): Promise<void> {
+  await ns.put(leaseKey(slot), JSON.stringify(state));
+}
+
+/**
+ * Delete + bump-generation. Per K-Cont-3 trap #2, "Generation
+ * increments unconditionally on PUT/DELETE including Release". On
+ * Release we don't actually erase the record — we replace it with an
+ * empty-holder shell carrying `generation+1`. This way a subsequent
+ * Acquire sees `generation=N+1` and presents `If-Match: N+1`, NOT
+ * `If-Match: 0`. The CFKVClient + the K-Cont-3 reference impl both
+ * verify this behavior in their TestCFKV_GenerationBumpedOnRelease
+ * test.
+ */
+export async function clearLeaseBumpGen(
+  ns: KVNamespace,
+  slot: string,
+  prevGeneration: number,
+): Promise<LeaseState> {
+  const next: LeaseState = {
+    holder: "",
+    acquiredAt: "",
+    expiresAt: "",
+    generation: prevGeneration + 1,
+  };
+  await writeLease(ns, slot, next);
+  return next;
+}

--- a/products/continuum/cloudflare-worker/src/types.ts
+++ b/products/continuum/cloudflare-worker/src/types.ts
@@ -1,0 +1,85 @@
+// types.ts — wire shapes for the OpenOva Continuum lease-witness
+// Worker (K-Cont-4 of EPIC-6 #1101).
+//
+// The State + WriteRequest shapes mirror the Go `kvState` +
+// `kvWriteRequest` types in
+// core/controllers/continuum/internal/witness/cloudflarekv/client.go
+// — they ARE the contract. Any field-name change on either side
+// breaks the witness and must land in BOTH repos in the same PR.
+
+/**
+ * State stored under `lease:<slot-url-encoded>` in KV. Returned from
+ * GET 200 / PUT 200 / on PUT-412 conflict (per K-Cont-3 trap #3, "412
+ * SHOULD include current state body").
+ *
+ * - `holder` — the per-region identity holding the lease (e.g.
+ *   "fsn1-primary"). Empty after Release.
+ * - `acquiredAt` — RFC3339 timestamp the holder first acquired this
+ *   slot. Preserved on renew + re-acquire by the same holder; reset
+ *   to `now()` when a new holder takes over.
+ * - `expiresAt` — RFC3339 timestamp the lease expires
+ *   (`acquiredAt + ttlSeconds` for first acquire, `now() + ttlSeconds`
+ *   for renew). Per K-Cont-3 trap #4 the Worker is server-authoritative
+ *   for this stamp; the controller's `IsHeldBy(now)` decides eviction
+ *   client-side.
+ * - `generation` — monotonically increasing int64. Bumped on EVERY
+ *   successful PUT and DELETE (per K-Cont-3 trap #2 — including
+ *   Release, so the next Acquire's `If-Match` has a defined non-zero
+ *   baseline rather than rolling back to 0).
+ */
+export interface LeaseState {
+  holder: string;
+  acquiredAt: string; // RFC3339
+  expiresAt: string;  // RFC3339
+  generation: number;
+}
+
+/**
+ * PUT body. Both acquire and renew share this shape; `op` is the
+ * discriminator.
+ *
+ * - `holder` — the requesting region's identity. Compared against the
+ *   stored `holder` for renew (must match) and acquire (any value
+ *   allowed when slot is takeable).
+ * - `ttlSeconds` — lease TTL in whole seconds. Worker sets
+ *   `expiresAt = now + ttlSeconds`.
+ * - `op` — `"acquire"` or `"renew"`. `renew` REQUIRES that
+ *   `stored.holder === requested.holder` AND `stored.expiresAt > now`
+ *   (per the K-Cont-2 contract Renew is for the holder only). Worker
+ *   rejects renew with 412 otherwise.
+ */
+export interface LeaseWriteRequest {
+  holder: string;
+  ttlSeconds: number;
+  op: "acquire" | "renew";
+}
+
+/**
+ * Env shape — Cloudflare Worker bindings. Matches `wrangler.toml`'s
+ * `[vars]` and `[[kv_namespaces]]` declarations. Per INVIOLABLE-PRINCIPLES
+ * #4 every value here is bound at deploy time, never hardcoded in
+ * source.
+ *
+ * - `OPENOVA_LEASES` — KV namespace handle. Key shape:
+ *   `lease:<slot-url-encoded>` (see kv.ts).
+ * - `BEARER_TOKENS_CSV` — comma-separated allow-list of valid bearer
+ *   tokens. NEVER logged. The token itself is supplied via
+ *   `wrangler secret put` and exposed to the Worker as this var.
+ * - `LOG_LEVEL` — "error" | "info" | "debug". Defaults to "info".
+ */
+export interface Env {
+  OPENOVA_LEASES: KVNamespace;
+  BEARER_TOKENS_CSV: string;
+  LOG_LEVEL?: "error" | "info" | "debug";
+}
+
+/**
+ * The Worker's "everything-is-an-error-shape" envelope when the
+ * response body is NOT a LeaseState (i.e. 401/404/400/405/500). Lets
+ * the CFKVClient log a meaningful error message via `readSnippet` (see
+ * client.go).
+ */
+export interface ErrorBody {
+  error: string;
+  reason?: string;
+}

--- a/products/continuum/cloudflare-worker/test/contract.test.ts
+++ b/products/continuum/cloudflare-worker/test/contract.test.ts
@@ -1,0 +1,262 @@
+// contract.test.ts — verifies the Worker satisfies the EXACT request
+// shapes K-Cont-3's CFKVClient sends. If a test in this file changes,
+// the corresponding Go client method changed and the contract has
+// drifted — STOP and reconcile.
+//
+// The shapes are documented in
+// `core/controllers/continuum/internal/witness/cloudflarekv/client.go`
+// (search for `applyAuth`, `Read`, `write`, `Release`). The fakeWorker
+// in `client_test.go` is the authoritative reference impl on the Go
+// side.
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { SELF, env } from "cloudflare:test";
+
+const BEARER = "test-token";
+const SLOT_ENCODED = "ns%2Fcr-main"; // CFKVClient.pathEscapeSlot output
+
+async function clearKV(): Promise<void> {
+  await env.OPENOVA_LEASES.delete(`lease:ns/cr-main`);
+}
+
+describe("contract: GET — Read()", () => {
+  beforeEach(clearKV);
+
+  it("client sends Authorization + Accept + X-Lease-Slot, expects 200|404", async () => {
+    // Per CFKVClient.Read():
+    //   req.Header.Set("Authorization", "Bearer "+c.APIToken)
+    //   req.Header.Set("Accept", "application/json")
+    //   req.Header.Set("X-Lease-Slot", c.Slot)
+    const r = await SELF.fetch(`https://x/lease/${SLOT_ENCODED}`, {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${BEARER}`,
+        Accept: "application/json",
+        "X-Lease-Slot": "ns/cr-main",
+      },
+    });
+    // Empty slot → 404 per Read switch on http.StatusNotFound.
+    expect(r.status).toBe(404);
+  });
+
+  it("populated slot returns 200 with {holder, acquiredAt, expiresAt, generation}", async () => {
+    // Pre-populate via PUT.
+    await SELF.fetch(`https://x/lease/${SLOT_ENCODED}`, {
+      method: "PUT",
+      headers: {
+        Authorization: `Bearer ${BEARER}`,
+        Accept: "application/json",
+        "Content-Type": "application/json",
+        "If-Match": "0",
+        "X-Lease-Slot": "ns/cr-main",
+      },
+      body: JSON.stringify({ holder: "fsn1-primary", ttlSeconds: 30, op: "acquire" }),
+    });
+    // Now GET.
+    const r = await SELF.fetch(`https://x/lease/${SLOT_ENCODED}`, {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${BEARER}`,
+        Accept: "application/json",
+        "X-Lease-Slot": "ns/cr-main",
+      },
+    });
+    expect(r.status).toBe(200);
+    const body = (await r.json()) as Record<string, unknown>;
+    // Field-name contract — these are the EXACT JSON keys
+    // CFKVClient.kvState expects (json:"holder", "acquiredAt",
+    // "expiresAt", "generation"). Any rename here BREAKS the wire.
+    expect(body).toHaveProperty("holder");
+    expect(body).toHaveProperty("acquiredAt");
+    expect(body).toHaveProperty("expiresAt");
+    expect(body).toHaveProperty("generation");
+    expect(typeof body.holder).toBe("string");
+    expect(typeof body.acquiredAt).toBe("string");
+    expect(typeof body.expiresAt).toBe("string");
+    expect(typeof body.generation).toBe("number");
+    // RFC3339 — Go's time.Parse(time.RFC3339, ...) accepts the JS
+    // toISOString() output (which is RFC3339 with `.SSSZ`).
+    expect(body.acquiredAt).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
+    expect(body.expiresAt).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
+  });
+});
+
+describe("contract: PUT — Acquire() and write()", () => {
+  beforeEach(clearKV);
+
+  it("client sends If-Match + Content-Type + body{holder,ttlSeconds,op}", async () => {
+    // Per CFKVClient.write():
+    //   req.Header.Set("Content-Type", "application/json")
+    //   req.Header.Set("Accept", "application/json")
+    //   req.Header.Set("If-Match", strconv.FormatInt(ifMatch, 10))
+    // body = json.Marshal(kvWriteRequest{Holder, TTLSeconds, Op})
+    const r = await SELF.fetch(`https://x/lease/${SLOT_ENCODED}`, {
+      method: "PUT",
+      headers: {
+        Authorization: `Bearer ${BEARER}`,
+        "Content-Type": "application/json",
+        Accept: "application/json",
+        "If-Match": "0",
+        "X-Lease-Slot": "ns/cr-main",
+      },
+      body: JSON.stringify({
+        holder: "fsn1-primary",
+        ttlSeconds: 30,
+        op: "acquire",
+      }),
+    });
+    // Per CFKVClient.write switch on http.StatusOK | http.StatusCreated.
+    // Worker returns 200 always.
+    expect(r.status).toBe(200);
+    const body = (await r.json()) as Record<string, unknown>;
+    expect(body.holder).toBe("fsn1-primary");
+    expect(body.generation).toBe(1);
+  });
+
+  it("412 conflict body decodable to kvState (trap #3)", async () => {
+    // Acquire by holder A.
+    await SELF.fetch(`https://x/lease/${SLOT_ENCODED}`, {
+      method: "PUT",
+      headers: {
+        Authorization: `Bearer ${BEARER}`,
+        "Content-Type": "application/json",
+        Accept: "application/json",
+        "If-Match": "0",
+      },
+      body: JSON.stringify({ holder: "A", ttlSeconds: 60, op: "acquire" }),
+    });
+    // B tries with stale If-Match — Worker should return 412 with
+    // current state body. Per CFKVClient.write switch on 412:
+    //   var k kvState; _ = json.NewDecoder(resp.Body).Decode(&k)
+    //   st, _ := parseState(k)
+    //   return st, witness.ErrLeaseHeldByAnother
+    const r = await SELF.fetch(`https://x/lease/${SLOT_ENCODED}`, {
+      method: "PUT",
+      headers: {
+        Authorization: `Bearer ${BEARER}`,
+        "Content-Type": "application/json",
+        Accept: "application/json",
+        "If-Match": "0",
+      },
+      body: JSON.stringify({ holder: "B", ttlSeconds: 60, op: "acquire" }),
+    });
+    expect(r.status).toBe(412);
+    const body = (await r.json()) as Record<string, unknown>;
+    expect(body.holder).toBe("A");
+    expect(body.generation).toBe(1);
+  });
+
+  it("op:'renew' bumps generation when sameHolder + non-expired", async () => {
+    await SELF.fetch(`https://x/lease/${SLOT_ENCODED}`, {
+      method: "PUT",
+      headers: {
+        Authorization: `Bearer ${BEARER}`,
+        "Content-Type": "application/json",
+        Accept: "application/json",
+        "If-Match": "0",
+      },
+      body: JSON.stringify({ holder: "fsn1", ttlSeconds: 30, op: "acquire" }),
+    });
+    const r = await SELF.fetch(`https://x/lease/${SLOT_ENCODED}`, {
+      method: "PUT",
+      headers: {
+        Authorization: `Bearer ${BEARER}`,
+        "Content-Type": "application/json",
+        Accept: "application/json",
+        "If-Match": "1",
+      },
+      body: JSON.stringify({ holder: "fsn1", ttlSeconds: 30, op: "renew" }),
+    });
+    expect(r.status).toBe(200);
+    const body = (await r.json()) as Record<string, unknown>;
+    expect(body.generation).toBe(2);
+  });
+});
+
+describe("contract: DELETE — Release()", () => {
+  beforeEach(clearKV);
+
+  it("client sends If-Match + X-Holder, expects 204", async () => {
+    // Acquire first.
+    await SELF.fetch(`https://x/lease/${SLOT_ENCODED}`, {
+      method: "PUT",
+      headers: {
+        Authorization: `Bearer ${BEARER}`,
+        "Content-Type": "application/json",
+        Accept: "application/json",
+        "If-Match": "0",
+      },
+      body: JSON.stringify({ holder: "fsn1", ttlSeconds: 30, op: "acquire" }),
+    });
+    // Per CFKVClient.Release():
+    //   req.Header.Set("If-Match", strconv.FormatInt(cur.Generation, 10))
+    //   req.Header.Set("X-Holder", holder)
+    const r = await SELF.fetch(`https://x/lease/${SLOT_ENCODED}`, {
+      method: "DELETE",
+      headers: {
+        Authorization: `Bearer ${BEARER}`,
+        "If-Match": "1",
+        "X-Holder": "fsn1",
+        "X-Lease-Slot": "ns/cr-main",
+      },
+    });
+    // Per CFKVClient.Release switch:
+    //   case http.StatusNoContent || http.StatusOK: return nil
+    expect(r.status).toBe(204);
+  });
+});
+
+describe("contract: 401 surface", () => {
+  it("missing Authorization header → 401 (CFKVClient maps to 'auth rejected')", async () => {
+    const r = await SELF.fetch(`https://x/lease/${SLOT_ENCODED}`, {
+      method: "GET",
+    });
+    expect(r.status).toBe(401);
+  });
+
+  it("wrong bearer → 401", async () => {
+    const r = await SELF.fetch(`https://x/lease/${SLOT_ENCODED}`, {
+      method: "GET",
+      headers: { Authorization: "Bearer not-the-real-token" },
+    });
+    expect(r.status).toBe(401);
+  });
+});
+
+describe("contract: full lifecycle (mirrors TestCFKV_GenerationBumpedOnRelease)", () => {
+  beforeEach(clearKV);
+
+  it("Acquire → Release → Read shows generation bumped + empty holder", async () => {
+    // Acquire (gen 0 → 1).
+    const a = await SELF.fetch(`https://x/lease/${SLOT_ENCODED}`, {
+      method: "PUT",
+      headers: {
+        Authorization: `Bearer ${BEARER}`,
+        "Content-Type": "application/json",
+        "If-Match": "0",
+      },
+      body: JSON.stringify({ holder: "fsn", ttlSeconds: 30, op: "acquire" }),
+    });
+    const a1 = (await a.json()) as Record<string, unknown>;
+    expect(a1.generation).toBe(1);
+    // Release (gen 1 → 2).
+    const d = await SELF.fetch(`https://x/lease/${SLOT_ENCODED}`, {
+      method: "DELETE",
+      headers: {
+        Authorization: `Bearer ${BEARER}`,
+        "If-Match": "1",
+        "X-Holder": "fsn",
+      },
+    });
+    expect(d.status).toBe(204);
+    // Read shows generation 2 + holder cleared.
+    const g = await SELF.fetch(`https://x/lease/${SLOT_ENCODED}`, {
+      method: "GET",
+      headers: { Authorization: `Bearer ${BEARER}` },
+    });
+    expect(g.status).toBe(200);
+    const body = (await g.json()) as Record<string, unknown>;
+    expect(body.generation).toBe(2);
+    expect(body.holder).toBe("");
+  });
+});

--- a/products/continuum/cloudflare-worker/test/env.d.ts
+++ b/products/continuum/cloudflare-worker/test/env.d.ts
@@ -1,0 +1,15 @@
+// env.d.ts — type augmentation so vitest tests can read `env.OPENOVA_LEASES`
+// without `any` casts.
+//
+// `@cloudflare/vitest-pool-workers` exposes `env` from `cloudflare:test`
+// typed as `ProvidedEnv` — a project-augmentable interface. We declare
+// the bindings the Worker uses so test files get full typing on
+// `env.OPENOVA_LEASES.delete(...)` etc.
+
+declare module "cloudflare:test" {
+  interface ProvidedEnv {
+    OPENOVA_LEASES: KVNamespace;
+    BEARER_TOKENS_CSV: string;
+    LOG_LEVEL?: "error" | "info" | "debug";
+  }
+}

--- a/products/continuum/cloudflare-worker/test/handlers.test.ts
+++ b/products/continuum/cloudflare-worker/test/handlers.test.ts
@@ -1,0 +1,539 @@
+// handlers.test.ts — branch-coverage tests for the lease-witness
+// Worker handlers. Verifies every status code + body shape per the
+// K-Cont-3 contract (see DESIGN.md).
+//
+// Strategy: spin up a real workerd runtime via @cloudflare/vitest-pool-
+// workers (configured in vitest.config.ts) and drive it via plain
+// `fetch` against the Worker's bound URL. KV is in-memory + per-test
+// isolated so tests don't bleed state.
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { SELF, env } from "cloudflare:test";
+
+const BEARER = "test-token";
+const SLOT = "ns/cr-main";
+const SLOT_ENC = encodeURIComponent(SLOT); // "ns%2Fcr-main"
+
+function authHeaders(extra: Record<string, string> = {}): HeadersInit {
+  return { Authorization: `Bearer ${BEARER}`, ...extra };
+}
+
+async function clearKV(): Promise<void> {
+  // KV doesn't expose "delete all" — we have no leftover keys per
+  // test because miniflare's storage is per-test-isolation. But for
+  // belt-and-suspenders within a single test scope, delete the slot
+  // key.
+  await env.OPENOVA_LEASES.delete(`lease:${SLOT}`);
+}
+
+describe("auth", () => {
+  beforeEach(clearKV);
+
+  it("rejects missing Authorization header with 401", async () => {
+    const r = await SELF.fetch(`https://x/lease/${SLOT_ENC}`);
+    expect(r.status).toBe(401);
+    const body = await r.json();
+    expect(body).toEqual({ error: "unauthorized" });
+  });
+
+  it("rejects malformed Authorization header with 401", async () => {
+    const r = await SELF.fetch(`https://x/lease/${SLOT_ENC}`, {
+      headers: { Authorization: "NotBearer xxx" },
+    });
+    expect(r.status).toBe(401);
+  });
+
+  it("rejects wrong bearer token with 401", async () => {
+    const r = await SELF.fetch(`https://x/lease/${SLOT_ENC}`, {
+      headers: { Authorization: "Bearer wrong-token" },
+    });
+    expect(r.status).toBe(401);
+  });
+
+  it("accepts second token from the comma-separated allow-list", async () => {
+    // GET on empty slot returns 404 (not 401) → auth passed.
+    const r = await SELF.fetch(`https://x/lease/${SLOT_ENC}`, {
+      headers: { Authorization: "Bearer second-token" },
+    });
+    expect(r.status).toBe(404);
+  });
+});
+
+describe("routing", () => {
+  it("returns 404 for non-/lease/ paths", async () => {
+    const r = await SELF.fetch("https://x/some/other/path", {
+      headers: authHeaders(),
+    });
+    expect(r.status).toBe(404);
+  });
+
+  it("returns 404 for /lease/ with no slot tail", async () => {
+    const r = await SELF.fetch("https://x/lease/", {
+      headers: authHeaders(),
+    });
+    expect(r.status).toBe(404);
+  });
+
+  it("returns 405 for unsupported methods", async () => {
+    const r = await SELF.fetch(`https://x/lease/${SLOT_ENC}`, {
+      method: "PATCH",
+      headers: authHeaders(),
+    });
+    expect(r.status).toBe(405);
+  });
+
+  it("answers OPTIONS preflight with 204 + Allow header", async () => {
+    const r = await SELF.fetch(`https://x/lease/${SLOT_ENC}`, {
+      method: "OPTIONS",
+      headers: authHeaders(),
+    });
+    expect(r.status).toBe(204);
+    expect(r.headers.get("Allow")).toContain("GET");
+    expect(r.headers.get("Allow")).toContain("PUT");
+    expect(r.headers.get("Allow")).toContain("DELETE");
+  });
+});
+
+describe("GET", () => {
+  beforeEach(clearKV);
+
+  it("returns 404 for an empty slot", async () => {
+    const r = await SELF.fetch(`https://x/lease/${SLOT_ENC}`, {
+      headers: authHeaders(),
+    });
+    expect(r.status).toBe(404);
+  });
+
+  it("returns 200 + LeaseState after acquire", async () => {
+    // First acquire to populate the slot.
+    const acq = await SELF.fetch(`https://x/lease/${SLOT_ENC}`, {
+      method: "PUT",
+      headers: authHeaders({
+        "If-Match": "0",
+        "Content-Type": "application/json",
+      }),
+      body: JSON.stringify({ holder: "fsn1", ttlSeconds: 30, op: "acquire" }),
+    });
+    expect(acq.status).toBe(200);
+    // Now read it back.
+    const r = await SELF.fetch(`https://x/lease/${SLOT_ENC}`, {
+      headers: authHeaders(),
+    });
+    expect(r.status).toBe(200);
+    const body = (await r.json()) as Record<string, unknown>;
+    expect(body.holder).toBe("fsn1");
+    expect(body.generation).toBe(1);
+    expect(typeof body.acquiredAt).toBe("string");
+    expect(typeof body.expiresAt).toBe("string");
+  });
+});
+
+describe("PUT acquire", () => {
+  beforeEach(clearKV);
+
+  it("first acquire on empty slot accepts If-Match: 0 (trap #1)", async () => {
+    const r = await SELF.fetch(`https://x/lease/${SLOT_ENC}`, {
+      method: "PUT",
+      headers: authHeaders({
+        "If-Match": "0",
+        "Content-Type": "application/json",
+      }),
+      body: JSON.stringify({ holder: "fsn1", ttlSeconds: 30, op: "acquire" }),
+    });
+    expect(r.status).toBe(200);
+    const body = (await r.json()) as Record<string, unknown>;
+    expect(body.holder).toBe("fsn1");
+    expect(body.generation).toBe(1);
+  });
+
+  it("rejects acquire on empty slot with non-zero If-Match (412)", async () => {
+    const r = await SELF.fetch(`https://x/lease/${SLOT_ENC}`, {
+      method: "PUT",
+      headers: authHeaders({
+        "If-Match": "5",
+        "Content-Type": "application/json",
+      }),
+      body: JSON.stringify({ holder: "fsn1", ttlSeconds: 30, op: "acquire" }),
+    });
+    expect(r.status).toBe(412);
+  });
+
+  it("rejects acquire when slot held by another non-expired holder (412 + body)", async () => {
+    // First holder acquires.
+    await SELF.fetch(`https://x/lease/${SLOT_ENC}`, {
+      method: "PUT",
+      headers: authHeaders({ "If-Match": "0", "Content-Type": "application/json" }),
+      body: JSON.stringify({ holder: "fsn1", ttlSeconds: 60, op: "acquire" }),
+    });
+    // Second holder tries with stale If-Match.
+    const r = await SELF.fetch(`https://x/lease/${SLOT_ENC}`, {
+      method: "PUT",
+      headers: authHeaders({ "If-Match": "0", "Content-Type": "application/json" }),
+      body: JSON.stringify({ holder: "nbg1", ttlSeconds: 60, op: "acquire" }),
+    });
+    expect(r.status).toBe(412);
+    // Per trap #3 the 412 SHOULD include the current state body.
+    const body = (await r.json()) as Record<string, unknown>;
+    expect(body.holder).toBe("fsn1");
+    expect(body.generation).toBe(1);
+  });
+
+  it("re-acquire by same holder bumps generation (trap #2 monotonicity)", async () => {
+    // First acquire.
+    const r1 = await SELF.fetch(`https://x/lease/${SLOT_ENC}`, {
+      method: "PUT",
+      headers: authHeaders({ "If-Match": "0", "Content-Type": "application/json" }),
+      body: JSON.stringify({ holder: "fsn1", ttlSeconds: 30, op: "acquire" }),
+    });
+    const b1 = (await r1.json()) as Record<string, unknown>;
+    expect(b1.generation).toBe(1);
+    // Re-acquire by same holder with current generation.
+    const r2 = await SELF.fetch(`https://x/lease/${SLOT_ENC}`, {
+      method: "PUT",
+      headers: authHeaders({ "If-Match": "1", "Content-Type": "application/json" }),
+      body: JSON.stringify({ holder: "fsn1", ttlSeconds: 30, op: "acquire" }),
+    });
+    expect(r2.status).toBe(200);
+    const b2 = (await r2.json()) as Record<string, unknown>;
+    expect(b2.generation).toBe(2);
+    // acquiredAt is preserved on same-holder re-acquire.
+    expect(b2.acquiredAt).toBe(b1.acquiredAt);
+  });
+
+  it("acquire by NEW holder after expiry stamps fresh acquiredAt", async () => {
+    // First acquire with 1-second TTL.
+    await SELF.fetch(`https://x/lease/${SLOT_ENC}`, {
+      method: "PUT",
+      headers: authHeaders({ "If-Match": "0", "Content-Type": "application/json" }),
+      body: JSON.stringify({ holder: "fsn1", ttlSeconds: 1, op: "acquire" }),
+    });
+    // Wait until expiry.
+    await new Promise((r) => setTimeout(r, 1100));
+    // New holder takes over.
+    const r2 = await SELF.fetch(`https://x/lease/${SLOT_ENC}`, {
+      method: "PUT",
+      headers: authHeaders({ "If-Match": "1", "Content-Type": "application/json" }),
+      body: JSON.stringify({ holder: "nbg1", ttlSeconds: 30, op: "acquire" }),
+    });
+    expect(r2.status).toBe(200);
+    const b = (await r2.json()) as Record<string, unknown>;
+    expect(b.holder).toBe("nbg1");
+    expect(b.generation).toBe(2);
+  });
+
+  it("rejects PUT without If-Match header with 400", async () => {
+    const r = await SELF.fetch(`https://x/lease/${SLOT_ENC}`, {
+      method: "PUT",
+      headers: authHeaders({ "Content-Type": "application/json" }),
+      body: JSON.stringify({ holder: "fsn1", ttlSeconds: 30, op: "acquire" }),
+    });
+    expect(r.status).toBe(400);
+  });
+
+  it("rejects PUT with malformed If-Match (non-integer) with 400", async () => {
+    const r = await SELF.fetch(`https://x/lease/${SLOT_ENC}`, {
+      method: "PUT",
+      headers: authHeaders({
+        "If-Match": "not-a-number",
+        "Content-Type": "application/json",
+      }),
+      body: JSON.stringify({ holder: "fsn1", ttlSeconds: 30, op: "acquire" }),
+    });
+    expect(r.status).toBe(400);
+  });
+
+  it("accepts quoted ETag-style If-Match", async () => {
+    const r = await SELF.fetch(`https://x/lease/${SLOT_ENC}`, {
+      method: "PUT",
+      headers: authHeaders({
+        "If-Match": '"0"',
+        "Content-Type": "application/json",
+      }),
+      body: JSON.stringify({ holder: "fsn1", ttlSeconds: 30, op: "acquire" }),
+    });
+    expect(r.status).toBe(200);
+  });
+
+  it("rejects malformed JSON body with 400", async () => {
+    const r = await SELF.fetch(`https://x/lease/${SLOT_ENC}`, {
+      method: "PUT",
+      headers: authHeaders({ "If-Match": "0", "Content-Type": "application/json" }),
+      body: "not-json",
+    });
+    expect(r.status).toBe(400);
+  });
+
+  it("rejects body with missing holder with 400", async () => {
+    const r = await SELF.fetch(`https://x/lease/${SLOT_ENC}`, {
+      method: "PUT",
+      headers: authHeaders({ "If-Match": "0", "Content-Type": "application/json" }),
+      body: JSON.stringify({ ttlSeconds: 30, op: "acquire" }),
+    });
+    expect(r.status).toBe(400);
+  });
+
+  it("rejects body with negative ttlSeconds with 400", async () => {
+    const r = await SELF.fetch(`https://x/lease/${SLOT_ENC}`, {
+      method: "PUT",
+      headers: authHeaders({ "If-Match": "0", "Content-Type": "application/json" }),
+      body: JSON.stringify({ holder: "fsn1", ttlSeconds: -1, op: "acquire" }),
+    });
+    expect(r.status).toBe(400);
+  });
+
+  it("rejects body with invalid op with 400", async () => {
+    const r = await SELF.fetch(`https://x/lease/${SLOT_ENC}`, {
+      method: "PUT",
+      headers: authHeaders({ "If-Match": "0", "Content-Type": "application/json" }),
+      body: JSON.stringify({ holder: "fsn1", ttlSeconds: 30, op: "BOGUS" }),
+    });
+    expect(r.status).toBe(400);
+  });
+});
+
+describe("PUT renew", () => {
+  beforeEach(clearKV);
+
+  it("rejects renew on empty slot with 412", async () => {
+    const r = await SELF.fetch(`https://x/lease/${SLOT_ENC}`, {
+      method: "PUT",
+      headers: authHeaders({ "If-Match": "0", "Content-Type": "application/json" }),
+      body: JSON.stringify({ holder: "fsn1", ttlSeconds: 30, op: "renew" }),
+    });
+    expect(r.status).toBe(412);
+  });
+
+  it("happy-path renew bumps generation, preserves acquiredAt", async () => {
+    // Acquire.
+    const r1 = await SELF.fetch(`https://x/lease/${SLOT_ENC}`, {
+      method: "PUT",
+      headers: authHeaders({ "If-Match": "0", "Content-Type": "application/json" }),
+      body: JSON.stringify({ holder: "fsn1", ttlSeconds: 30, op: "acquire" }),
+    });
+    const b1 = (await r1.json()) as Record<string, unknown>;
+    // Renew.
+    const r2 = await SELF.fetch(`https://x/lease/${SLOT_ENC}`, {
+      method: "PUT",
+      headers: authHeaders({ "If-Match": "1", "Content-Type": "application/json" }),
+      body: JSON.stringify({ holder: "fsn1", ttlSeconds: 30, op: "renew" }),
+    });
+    expect(r2.status).toBe(200);
+    const b2 = (await r2.json()) as Record<string, unknown>;
+    expect(b2.generation).toBe(2);
+    expect(b2.acquiredAt).toBe(b1.acquiredAt);
+  });
+
+  it("rejects renew by wrong holder with 412", async () => {
+    // Acquire by fsn1.
+    await SELF.fetch(`https://x/lease/${SLOT_ENC}`, {
+      method: "PUT",
+      headers: authHeaders({ "If-Match": "0", "Content-Type": "application/json" }),
+      body: JSON.stringify({ holder: "fsn1", ttlSeconds: 30, op: "acquire" }),
+    });
+    // nbg1 tries to renew with the right generation but wrong holder.
+    const r = await SELF.fetch(`https://x/lease/${SLOT_ENC}`, {
+      method: "PUT",
+      headers: authHeaders({ "If-Match": "1", "Content-Type": "application/json" }),
+      body: JSON.stringify({ holder: "nbg1", ttlSeconds: 30, op: "renew" }),
+    });
+    expect(r.status).toBe(412);
+  });
+
+  it("rejects renew on expired lease with 412", async () => {
+    // Acquire with 1-second TTL.
+    await SELF.fetch(`https://x/lease/${SLOT_ENC}`, {
+      method: "PUT",
+      headers: authHeaders({ "If-Match": "0", "Content-Type": "application/json" }),
+      body: JSON.stringify({ holder: "fsn1", ttlSeconds: 1, op: "acquire" }),
+    });
+    await new Promise((r) => setTimeout(r, 1100));
+    const r = await SELF.fetch(`https://x/lease/${SLOT_ENC}`, {
+      method: "PUT",
+      headers: authHeaders({ "If-Match": "1", "Content-Type": "application/json" }),
+      body: JSON.stringify({ holder: "fsn1", ttlSeconds: 30, op: "renew" }),
+    });
+    expect(r.status).toBe(412);
+  });
+});
+
+describe("DELETE", () => {
+  beforeEach(clearKV);
+
+  it("returns 204 on empty slot (idempotent)", async () => {
+    const r = await SELF.fetch(`https://x/lease/${SLOT_ENC}`, {
+      method: "DELETE",
+      headers: authHeaders({ "If-Match": "0", "X-Holder": "fsn1" }),
+    });
+    expect(r.status).toBe(204);
+  });
+
+  it("happy-path release bumps generation (trap #2)", async () => {
+    // Acquire.
+    await SELF.fetch(`https://x/lease/${SLOT_ENC}`, {
+      method: "PUT",
+      headers: authHeaders({ "If-Match": "0", "Content-Type": "application/json" }),
+      body: JSON.stringify({ holder: "fsn1", ttlSeconds: 30, op: "acquire" }),
+    });
+    // Release.
+    const r = await SELF.fetch(`https://x/lease/${SLOT_ENC}`, {
+      method: "DELETE",
+      headers: authHeaders({ "If-Match": "1", "X-Holder": "fsn1" }),
+    });
+    expect(r.status).toBe(204);
+    // Read back — generation must be 2 (bumped on release).
+    const r2 = await SELF.fetch(`https://x/lease/${SLOT_ENC}`, {
+      headers: authHeaders(),
+    });
+    expect(r2.status).toBe(200);
+    const body = (await r2.json()) as Record<string, unknown>;
+    expect(body.generation).toBe(2);
+    expect(body.holder).toBe("");
+  });
+
+  it("rejects release with stale If-Match (412)", async () => {
+    await SELF.fetch(`https://x/lease/${SLOT_ENC}`, {
+      method: "PUT",
+      headers: authHeaders({ "If-Match": "0", "Content-Type": "application/json" }),
+      body: JSON.stringify({ holder: "fsn1", ttlSeconds: 30, op: "acquire" }),
+    });
+    const r = await SELF.fetch(`https://x/lease/${SLOT_ENC}`, {
+      method: "DELETE",
+      headers: authHeaders({ "If-Match": "0", "X-Holder": "fsn1" }),
+    });
+    expect(r.status).toBe(412);
+  });
+
+  it("rejects release with X-Holder mismatch (trap #5)", async () => {
+    // Acquire by fsn1.
+    await SELF.fetch(`https://x/lease/${SLOT_ENC}`, {
+      method: "PUT",
+      headers: authHeaders({ "If-Match": "0", "Content-Type": "application/json" }),
+      body: JSON.stringify({ holder: "fsn1", ttlSeconds: 30, op: "acquire" }),
+    });
+    // nbg1 tries to release with right If-Match but wrong X-Holder.
+    const r = await SELF.fetch(`https://x/lease/${SLOT_ENC}`, {
+      method: "DELETE",
+      headers: authHeaders({ "If-Match": "1", "X-Holder": "nbg1" }),
+    });
+    expect(r.status).toBe(412);
+  });
+
+  it("rejects DELETE without If-Match (400)", async () => {
+    const r = await SELF.fetch(`https://x/lease/${SLOT_ENC}`, {
+      method: "DELETE",
+      headers: authHeaders({ "X-Holder": "fsn1" }),
+    });
+    expect(r.status).toBe(400);
+  });
+
+  it("rejects DELETE without X-Holder (400)", async () => {
+    const r = await SELF.fetch(`https://x/lease/${SLOT_ENC}`, {
+      method: "DELETE",
+      headers: authHeaders({ "If-Match": "0" }),
+    });
+    expect(r.status).toBe(400);
+  });
+
+  it("re-acquire after release sees generation+1 (NOT 0) — trap #2 cross-cycle", async () => {
+    // Acquire → Release → Acquire-again. The second Acquire MUST
+    // present If-Match=2 (= post-release generation), NOT 0.
+    await SELF.fetch(`https://x/lease/${SLOT_ENC}`, {
+      method: "PUT",
+      headers: authHeaders({ "If-Match": "0", "Content-Type": "application/json" }),
+      body: JSON.stringify({ holder: "fsn1", ttlSeconds: 30, op: "acquire" }),
+    });
+    await SELF.fetch(`https://x/lease/${SLOT_ENC}`, {
+      method: "DELETE",
+      headers: authHeaders({ "If-Match": "1", "X-Holder": "fsn1" }),
+    });
+    // If we tried If-Match=0 here, it would be 412 because the stored
+    // gen is 2, not 0.
+    const stale = await SELF.fetch(`https://x/lease/${SLOT_ENC}`, {
+      method: "PUT",
+      headers: authHeaders({ "If-Match": "0", "Content-Type": "application/json" }),
+      body: JSON.stringify({ holder: "nbg1", ttlSeconds: 30, op: "acquire" }),
+    });
+    expect(stale.status).toBe(412);
+    // Now use the correct generation = 2.
+    const ok = await SELF.fetch(`https://x/lease/${SLOT_ENC}`, {
+      method: "PUT",
+      headers: authHeaders({ "If-Match": "2", "Content-Type": "application/json" }),
+      body: JSON.stringify({ holder: "nbg1", ttlSeconds: 30, op: "acquire" }),
+    });
+    expect(ok.status).toBe(200);
+    const body = (await ok.json()) as Record<string, unknown>;
+    expect(body.generation).toBe(3);
+    expect(body.holder).toBe("nbg1");
+  });
+});
+
+describe("TTL stamping (trap #4)", () => {
+  beforeEach(clearKV);
+
+  it("expiresAt = now + ttlSeconds (within 5s tolerance)", async () => {
+    const before = Date.now();
+    const r = await SELF.fetch(`https://x/lease/${SLOT_ENC}`, {
+      method: "PUT",
+      headers: authHeaders({ "If-Match": "0", "Content-Type": "application/json" }),
+      body: JSON.stringify({ holder: "fsn1", ttlSeconds: 60, op: "acquire" }),
+    });
+    expect(r.status).toBe(200);
+    const body = (await r.json()) as Record<string, unknown>;
+    const expiresAt = new Date(body.expiresAt as string).getTime();
+    expect(expiresAt - before).toBeGreaterThanOrEqual(60_000 - 5_000);
+    expect(expiresAt - before).toBeLessThanOrEqual(60_000 + 5_000);
+  });
+
+  it("Read returns stored state regardless of expiry (Worker doesn't auto-evict)", async () => {
+    // Acquire with 1s TTL.
+    await SELF.fetch(`https://x/lease/${SLOT_ENC}`, {
+      method: "PUT",
+      headers: authHeaders({ "If-Match": "0", "Content-Type": "application/json" }),
+      body: JSON.stringify({ holder: "fsn1", ttlSeconds: 1, op: "acquire" }),
+    });
+    await new Promise((r) => setTimeout(r, 1100));
+    // Read MUST still return the (expired) record per trap #4.
+    const r = await SELF.fetch(`https://x/lease/${SLOT_ENC}`, {
+      headers: authHeaders(),
+    });
+    expect(r.status).toBe(200);
+    const body = (await r.json()) as Record<string, unknown>;
+    expect(body.holder).toBe("fsn1");
+    expect(body.generation).toBe(1);
+  });
+});
+
+describe("slot encoding", () => {
+  it("URL-decodes %2F back to /", async () => {
+    // The slot has slashes; the URL parser decodes %2F.
+    const r = await SELF.fetch(
+      `https://x/lease/${encodeURIComponent("ns/cr-with-slash")}`,
+      {
+        method: "PUT",
+        headers: authHeaders({ "If-Match": "0", "Content-Type": "application/json" }),
+        body: JSON.stringify({ holder: "fsn1", ttlSeconds: 30, op: "acquire" }),
+      },
+    );
+    expect(r.status).toBe(200);
+    // Read it back via the same encoding.
+    const r2 = await SELF.fetch(
+      `https://x/lease/${encodeURIComponent("ns/cr-with-slash")}`,
+      { headers: authHeaders() },
+    );
+    expect(r2.status).toBe(200);
+  });
+
+  it("isolates different slots", async () => {
+    // Acquire slot A.
+    await SELF.fetch(`https://x/lease/${encodeURIComponent("ns/cr-A")}`, {
+      method: "PUT",
+      headers: authHeaders({ "If-Match": "0", "Content-Type": "application/json" }),
+      body: JSON.stringify({ holder: "fsn1", ttlSeconds: 30, op: "acquire" }),
+    });
+    // Slot B is independent — empty 404 read.
+    const r = await SELF.fetch(`https://x/lease/${encodeURIComponent("ns/cr-B")}`, {
+      headers: authHeaders(),
+    });
+    expect(r.status).toBe(404);
+  });
+});

--- a/products/continuum/cloudflare-worker/tsconfig.json
+++ b/products/continuum/cloudflare-worker/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022"],
+    "types": ["@cloudflare/workers-types/2023-07-01", "@cloudflare/vitest-pool-workers"],
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "esModuleInterop": true,
+    "isolatedModules": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "allowSyntheticDefaultImports": true,
+    "noEmit": true,
+    "rootDir": ".",
+    "baseUrl": "."
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts", "vitest.config.ts"],
+  "exclude": ["node_modules", "dist", ".wrangler"]
+}

--- a/products/continuum/cloudflare-worker/vitest.config.ts
+++ b/products/continuum/cloudflare-worker/vitest.config.ts
@@ -1,0 +1,35 @@
+// vitest.config.ts — uses @cloudflare/vitest-pool-workers to run the
+// tests INSIDE a real Workers runtime (workerd), with a real KV
+// namespace bound. This is the canonical way to test a Worker without
+// mocking Web APIs by hand.
+//
+// The pool spawns a per-test workerd instance. KV is implemented by
+// Miniflare under the hood — same storage semantics as production but
+// in-memory + per-test isolated.
+
+import { defineWorkersConfig } from "@cloudflare/vitest-pool-workers/config";
+
+export default defineWorkersConfig({
+  test: {
+    poolOptions: {
+      workers: {
+        // The Worker source under test. The pool loads it as the
+        // default-export `fetch` handler.
+        main: "./src/index.ts",
+        // wrangler.toml supplies the KV binding declaration; the
+        // pool wires up an in-memory KV under that binding name.
+        wrangler: { configPath: "./wrangler.toml" },
+        miniflare: {
+          // Override env vars set in wrangler.toml so each test starts
+          // with a deterministic allow-list — the actual production
+          // tokens are operator-supplied via `wrangler secret put`,
+          // but in tests we use this fixed value.
+          bindings: {
+            BEARER_TOKENS_CSV: "test-token,second-token",
+            LOG_LEVEL: "error", // suppress chatter during tests
+          },
+        },
+      },
+    },
+  },
+});

--- a/products/continuum/cloudflare-worker/wrangler.toml
+++ b/products/continuum/cloudflare-worker/wrangler.toml
@@ -1,0 +1,71 @@
+# wrangler.toml — Cloudflare Worker config for the OpenOva Continuum
+# lease-witness Worker (K-Cont-4 of EPIC-6 #1101).
+#
+# Per docs/INVIOLABLE-PRINCIPLES.md #4 (never hardcode), the bindings
+# below carry only the Worker SHAPE — every concrete value (account id,
+# KV namespace id, allowed bearer tokens) is supplied at deploy time
+# by `infra/cloudflare-worker-leases/` (OpenTofu module) or by `vars.*`
+# overrides for local-dev `wrangler dev`.
+#
+# `name = "openova-continuum-lease-witness"` — the Worker route is
+# usually `<name>.<account>.workers.dev`. The tofu module exposes this
+# URL as an output so the Continuum controller can configure the
+# CFKVClient `baseURL` per the K-Cont-3 Lease witness contract entry in
+# .claude/architect-briefs/epic-0/01-canonical-seams.md.
+
+name = "openova-continuum-lease-witness"
+main = "src/index.ts"
+compatibility_date = "2024-09-09"
+
+# `nodejs_compat` is required by `@cloudflare/vitest-pool-workers`
+# (the test runner). It also harmlessly enables a subset of Node
+# built-ins in production. The Worker source itself uses ONLY Web
+# APIs (Request, Response, URL, console) and @cloudflare/workers-types,
+# so the flag is a tooling requirement rather than a runtime dependency.
+compatibility_flags = ["nodejs_compat"]
+
+# ─── KV namespace binding ──────────────────────────────────────────────
+# Per the K-Cont-3 contract, the Worker stores one record per slot.
+# Key shape: `lease:<slot-url-encoded>` (slot = "<namespace>/<name>").
+# Value: JSON of the State object (holder, acquiredAt, expiresAt,
+# generation).
+#
+# `id` is filled in by the operator's tofu apply (the CF API's
+# create_namespace returns the id; we store it in tofu state) — this
+# file ships with `id = "REPLACE_ME"` so a stray `wrangler deploy`
+# without tofu wiring fails fast instead of writing into the wrong
+# namespace.
+[[kv_namespaces]]
+binding = "OPENOVA_LEASES"
+id = "REPLACE_ME_VIA_TOFU"
+
+# ─── Vars (env-bound configuration) ────────────────────────────────────
+# `BEARER_TOKENS_CSV` is a comma-separated allow-list of valid bearer
+# tokens. The Worker validates `Authorization: Bearer <token>` against
+# this list. Per INVIOLABLE-PRINCIPLES #5 the actual values are passed
+# at deploy time from a SealedSecret -> wrangler secret -> Worker env;
+# `vars` here only documents the variable name and its *empty-string*
+# default (so a non-deployed dev session fails closed). Do NOT inline
+# tokens here.
+#
+# `LOG_LEVEL` controls request logging verbosity. `info` logs request
+# method + path + status + slot; `debug` adds X-Holder + If-Match.
+# `error` logs only failures. Per CLAUDE.md credential hygiene the
+# bearer token is NEVER logged.
+[vars]
+BEARER_TOKENS_CSV = ""
+LOG_LEVEL = "info"
+
+# ─── Observability ─────────────────────────────────────────────────────
+# Workers Logs (formerly Logpush) — enable so the operator can grep
+# audit trails for `slot=<x>` requests via the CF dashboard. Per
+# CLAUDE.md never log Authorization header values.
+[observability]
+enabled = true
+
+# ─── Limits ────────────────────────────────────────────────────────────
+# CPU limit (ms) per request. Lease ops are tiny: parse + KV get + KV
+# put + json encode = << 50ms. 100ms gives ample headroom for KV
+# replication anomalies without letting a runaway request burn budget.
+[limits]
+cpu_ms = 100


### PR DESCRIPTION
## Summary

Implements the **server side** of the Cloudflare KV lease-witness pattern that K-Cont-3's `CFKVClient` (in `core/controllers/continuum/internal/witness/cloudflarekv/`) speaks to. This Worker is the K-Cont-4 deliverable of EPIC-6 (#1101).

## Contract (per K-Cont-3 #1158, item d — non-negotiable)

| Method | Path | Required headers | Body | Success | Conflict | Auth fail |
|---|---|---|---|---|---|---|
| GET | `/lease/<slot-url-encoded>` | `Authorization: Bearer <token>` | — | 200 + LeaseState | 404 | 401 |
| PUT | `/lease/<slot>` | `Authorization`, `If-Match`, `Content-Type` | `{holder, ttlSeconds, op}` | 200 + LeaseState | 412 + state | 401 |
| DELETE | `/lease/<slot>` | `Authorization`, `If-Match`, `X-Holder` | — | 204 | 412 | 401 |

`LeaseState` shape: `{holder, acquiredAt: RFC3339, expiresAt: RFC3339, generation: int64}`.

## All 7 K-Cont-3 trap behaviors covered

1. `If-Match: 0` accepted on empty slot, 412 if held — verified
2. Generation monotonic across acquire/renew/release — verified  
3. 412 includes current state body — verified
4. TTL stamping server-authoritative; reads return stored state regardless of expiry — verified
5. `X-Holder` mismatch on DELETE returns 412 — verified
6. Bearer token validation via env-bound allow-list — verified
7. Optional `X-Lease-Slot` header — logged at debug level

## Files

- `products/continuum/cloudflare-worker/` — Worker source (TypeScript) + tests
- `infra/cloudflare-worker-leases/` — OpenTofu module (4 .tf + README)
- `.github/workflows/cloudflare-worker-leases-build.yaml` — event-driven CI (NO cron)

## Test plan

- [x] `npm test` — 46/46 vitest pass (37 handler tests + 9 contract tests)
- [x] `npm run lint` — clean
- [x] `npm run typecheck` (`tsc --noEmit`) — clean
- [x] `npm run build:dryrun` (`wrangler deploy --dry-run`) — produces 9.47 KiB bundle, all bindings resolved
- [ ] CI run — pending PR open

## Out of scope (per brief)

- `tofu apply` is operator-run; CI only validates HCL
- Worker is NOT auto-deployed; SHA bundle review then operator runs `tofu apply`
- DOES NOT modify CFKVClient (K-Cont-3 final), Continuum reconciler (K-Cont-2 final), or DNS-quorum impl (K-Cont-3 final)

🤖 Generated with [Claude Code](https://claude.com/claude-code)