### PR TITLE
feat(catalyst-ui): Continuum DR UI — switchover + status panel + history (slice U-DR-1, #1101)

### DIFF
--- a/products/catalyst/bootstrap/api/cmd/api/main.go
+++ b/products/catalyst/bootstrap/api/cmd/api/main.go
@@ -828,6 +828,27 @@ func main() {
 		rg.Post("/api/v1/sovereigns/{id}/blueprints/curate", h.HandleBlueprintCurate)
 		rg.Get("/api/v1/sovereigns/{id}/blueprints/curatable", h.HandleBlueprintListCuratable)
 
+		// EPIC-6 (#1101) slice U-DR-1 — Continuum DR UI surface.
+		// GET surfaces the CR for the AppDetail Topology DR section.
+		// POST switchover/failback patches spec — the K-Cont-2
+		// reconciler picks up the change and runs the 7-step Sequencer
+		// + emits the 9 reserved continuum-* audit events on NATS.
+		// /audit/continuum mirrors the rbac audit endpoints (slice
+		// U5-U8 #1098) but filters on the continuum-* type prefix so
+		// future audit-type additions (slice F-1 may add 3 more)
+		// require zero handler-side change. Per ADR-0001 §2.7 the CR
+		// is the source of truth; per INVIOLABLE-PRINCIPLES #5 the
+		// switchover + failback gates enforce owner tier on the
+		// Application server-side, the approve gate enforces
+		// sovereign-admin server-side, the audit endpoints enforce
+		// tier-admin or higher.
+		rg.Get("/api/v1/sovereigns/{id}/continuums/{name}", h.HandleContinuumGet)
+		rg.Post("/api/v1/sovereigns/{id}/continuums/{name}/switchover", h.HandleContinuumSwitchoverRequest)
+		rg.Post("/api/v1/sovereigns/{id}/continuums/{name}/failback", h.HandleContinuumFailbackRequest)
+		rg.Post("/api/v1/sovereigns/{id}/continuums/{name}/failback/approve", h.HandleContinuumFailbackApprove)
+		rg.Get("/api/v1/sovereigns/{id}/audit/continuum", h.HandleContinuumAuditList)
+		rg.Get("/api/v1/sovereigns/{id}/audit/continuum/stream", h.HandleContinuumAuditStream)
+
 		// SME-tier user CRUD + role mapping (issue #802, ADR-0003).
 		// Owned by the unified-rbac slice of catalyst-api. Tenant
 		// scoping is by X-Tenant-Host header (sent by the SPA from

--- a/products/catalyst/bootstrap/api/internal/handler/continuum.go
+++ b/products/catalyst/bootstrap/api/internal/handler/continuum.go
@@ -1,0 +1,834 @@
+// Package handler — continuum.go: EPIC-6 Slice U-DR-1 (#1101) Continuum
+// DR REST + SSE surface backed by the dynamic client + the audit Bus.
+//
+// REST surface added on top of the K-Cont-2 reconciler:
+//
+//	GET  /api/v1/sovereigns/{id}/continuums/{name}
+//	     — Continuum CR snapshot (spec + status) for the DR section
+//	POST /api/v1/sovereigns/{id}/continuums/{name}/switchover
+//	     — operator-initiated switchover; patches spec.switchover.requested
+//	       and spec.switchover.targetRegion, returns 202 Accepted
+//	POST /api/v1/sovereigns/{id}/continuums/{name}/failback
+//	     — operator-requested failback; patches spec.failback.requested
+//	POST /api/v1/sovereigns/{id}/continuums/{name}/failback/approve
+//	     — sovereign-admin gate flip; patches spec.failback.approved
+//	GET  /api/v1/sovereigns/{id}/audit/continuum
+//	     — paginated list of Continuum audit events (mirrors /audit/rbac)
+//	GET  /api/v1/sovereigns/{id}/audit/continuum/stream
+//	     — SSE live tail of Continuum audit events
+//
+// Architecture rules:
+//
+//   - Per ADR-0001 §2.7 the Continuum CR is the source of truth — this
+//     handler patches spec; the K-Cont-2 reconciler executes the 7-step
+//     sequence and emits NATS audit events. NO direct invocation of the
+//     reconciler's Sequencer from here.
+//   - Per ADR-0001 §3 audit events flow through the SAME `catalyst.audit`
+//     subject that slice U5-U8 reads. The handler reuses the existing
+//     in-process audit.Bus + a continuum-specific predicate. The K-Cont-2
+//     reconciler publishes events with audit-type prefix `continuum-*`
+//     (the 9 reserved type names live in
+//     core/controllers/continuum/internal/events) — production wiring
+//     binds the BUS adapter so chart-deployed reconcilers fan into the
+//     same Bus the catalyst-api serves /audit/continuum* from.
+//   - Per INVIOLABLE-PRINCIPLES.md #5 (least-privilege, server-enforced):
+//     switchover + failback require owner tier on the Application
+//     (REUSES applicationInstallCallerAuthorized — same gate as PUT
+//     /applications). Approve requires sovereign-admin (REUSES
+//     rbacRequireSovereignAdmin). Audit-list + stream require tier-admin
+//     or higher (mirrors /audit/rbac).
+//   - Per docs/INVIOLABLE-PRINCIPLES.md #4 every URL is env-derived;
+//     nothing is hardcoded.
+//
+// ── Why reuse the audit.Bus event shape ───────────────────────────────
+//
+// Slice U5-U8's audit.Event is a SUPERSET schema (per its file-level
+// doc: "consumers tag only what's relevant"). Continuum events fit by
+// stamping AuditType + Actor + SovereignID + Detail. Per-event wire
+// fields specific to switchover (FromPrimary/ToPrimary/Step) are
+// surfaced via Detail + a flat `target*` fields slot — the UI parses
+// the auditType prefix to interpret semantics.
+//
+// The K-Cont-2 reconciler's events package defines the 9 reserved
+// audit-type names; this handler's IsContinuumAuditType matches the
+// `continuum-*` prefix so a future audit-type addition (slice F-1 may
+// add 3 more) plugs in without a handler-side code change.
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/audit"
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/auth"
+)
+
+// ContinuumGVR — the Namespaced Continuum CRD shipped at
+// products/catalyst/chart/crds/continuum.yaml.
+//
+// Mirrors core/controllers/continuum/internal/controller.ContinuumGVR
+// — duplicated here because catalyst-api intentionally avoids importing
+// `core/controllers/continuum/...` (that package brings the whole
+// controller-runtime dep tree). The GVR is a 3-string contract; if it
+// drifts, the dynamic client returns 404 immediately on first call.
+func ContinuumGVR() schema.GroupVersionResource {
+	return schema.GroupVersionResource{
+		Group:    "dr.openova.io",
+		Version:  "v1",
+		Resource: "continuums",
+	}
+}
+
+// ── Audit-type predicate ─────────────────────────────────────────────
+
+// continuumAuditPrefix matches the K-Cont-2 reservation in
+// core/controllers/continuum/internal/events/events.go. The 9 reserved
+// types all carry the `continuum-` prefix; this predicate is intentionally
+// prefix-based so a future addition (F-1 may add 3 more) doesn't require
+// a handler-side change.
+const continuumAuditPrefix = "continuum-"
+
+// IsContinuumAuditType reports whether `t` belongs to the Continuum
+// audit-type namespace. Used by the GET /audit/continuum handler to
+// filter the ring buffer + SSE stream.
+//
+// Per K-Cont-2 the 9 reserved types are:
+//
+//	continuum-switchover, continuum-failback-pending,
+//	continuum-failback-completed, continuum-lease-lost,
+//	continuum-lease-acquired, continuum-cnpg-lag-breach,
+//	continuum-cnpg-promotable, continuum-error,
+//	continuum-reconcile-success
+func IsContinuumAuditType(t string) bool {
+	return strings.HasPrefix(t, continuumAuditPrefix)
+}
+
+// ── Wire shapes ──────────────────────────────────────────────────────
+
+// continuumGetResponse — body of GET /continuums/{name}. Surfaces the
+// shape the UI's StatusPanel + LuaRecordView need without leaking the
+// raw Unstructured.
+type continuumGetResponse struct {
+	Name      string                 `json:"name"`
+	Namespace string                 `json:"namespace"`
+	UID       string                 `json:"uid"`
+	Spec      map[string]interface{} `json:"spec,omitempty"`
+	Status    map[string]interface{} `json:"status,omitempty"`
+}
+
+// continuumSwitchoverRequest — body of POST .../switchover.
+//
+// `targetRegion` is REQUIRED (handler rejects 400 otherwise). `reason`
+// is a free-form short string surfaced on the audit event's Detail
+// field. The handler stamps `requestedAt = now` server-side.
+type continuumSwitchoverRequest struct {
+	TargetRegion string `json:"targetRegion"`
+	Reason       string `json:"reason,omitempty"`
+}
+
+// continuumSwitchoverResponse — 202 Accepted body. The reconciler picks
+// up the spec patch on its next loop iteration and emits the 7-step
+// audit events on NATS.
+type continuumSwitchoverResponse struct {
+	Name         string `json:"name"`
+	Namespace    string `json:"namespace"`
+	TargetRegion string `json:"targetRegion"`
+	Reason       string `json:"reason,omitempty"`
+	RequestedAt  string `json:"requestedAt"`
+	RequestedBy  string `json:"requestedBy,omitempty"`
+	Message      string `json:"message"`
+}
+
+// continuumFailbackRequest — body of POST .../failback.
+type continuumFailbackRequest struct {
+	Reason string `json:"reason,omitempty"`
+}
+
+// continuumFailbackResponse — 202 Accepted body.
+type continuumFailbackResponse struct {
+	Name        string `json:"name"`
+	Namespace   string `json:"namespace"`
+	RequestedAt string `json:"requestedAt"`
+	RequestedBy string `json:"requestedBy,omitempty"`
+	// ApprovalRequired echoes the spec.failback.approvalRequired bool
+	// so the UI can render the "Awaiting approval" state immediately
+	// without re-fetching.
+	ApprovalRequired bool   `json:"approvalRequired"`
+	Message          string `json:"message"`
+}
+
+// continuumFailbackApproveResponse — 202 Accepted body.
+type continuumFailbackApproveResponse struct {
+	Name       string `json:"name"`
+	Namespace  string `json:"namespace"`
+	ApprovedAt string `json:"approvedAt"`
+	ApprovedBy string `json:"approvedBy,omitempty"`
+	Message    string `json:"message"`
+}
+
+// continuumAuditListResponse — body returned by GET /audit/continuum.
+// Mirrors rbacAuditListResponse so the UI's audit-row renderer can
+// reuse the same shape.
+type continuumAuditListResponse struct {
+	Items      []audit.Event `json:"items"`
+	NextOffset int           `json:"nextOffset,omitempty"`
+	Total      int           `json:"total"`
+}
+
+// ── HTTP handlers ────────────────────────────────────────────────────
+
+// HandleContinuumGet — GET /api/v1/sovereigns/{id}/continuums/{name}
+//
+// Returns the Continuum CR's spec + status. No auth gate (read) —
+// matches the lenient policy the application-status endpoint uses for
+// the same reason: viewers need to see DR posture.
+func (h *Handler) HandleContinuumGet(w http.ResponseWriter, r *http.Request) {
+	depID := chi.URLParam(r, "id")
+	name := chi.URLParam(r, "name")
+	if strings.TrimSpace(name) == "" {
+		writeBadRequest(w, "missing-name", "continuum name is required")
+		return
+	}
+	dep, ok := h.lookupDeploymentForInfra(depID)
+	if !ok {
+		writeNotFound(w, depID)
+		return
+	}
+	client, err := h.sovereignDynamicClient(dep)
+	if err != nil {
+		writeUserAccessUnavailable(w, err)
+		return
+	}
+	ns := strings.TrimSpace(r.URL.Query().Get("namespace"))
+	cr, getErr := getContinuumCR(r.Context(), client, name, ns)
+	if getErr != nil {
+		if apierrors.IsNotFound(getErr) {
+			writeJSON(w, http.StatusNotFound, map[string]string{
+				"error":  "continuum-not-found",
+				"detail": fmt.Sprintf("Continuum %q not found", name),
+			})
+			return
+		}
+		writeJSON(w, http.StatusInternalServerError, map[string]string{
+			"error":  "continuum-get-failed",
+			"detail": getErr.Error(),
+		})
+		return
+	}
+	resp := continuumGetResponse{
+		Name:      cr.GetName(),
+		Namespace: cr.GetNamespace(),
+		UID:       string(cr.GetUID()),
+	}
+	if specObj, ok, _ := unstructured.NestedMap(cr.Object, "spec"); ok {
+		resp.Spec = specObj
+	}
+	if statusObj, ok, _ := unstructured.NestedMap(cr.Object, "status"); ok {
+		resp.Status = statusObj
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// HandleContinuumSwitchoverRequest — POST
+// /api/v1/sovereigns/{id}/continuums/{name}/switchover
+//
+// Patches `spec.switchover.requested = true`, stamps requestedAt + the
+// caller's identity in requestedBy, and writes the targetRegion. The
+// K-Cont-2 reconciler observes the change on its next renew tick and
+// kicks off the 7-step Sequencer.
+//
+// Auth: owner tier on the Application (REUSES
+// applicationInstallCallerAuthorized — same gate as PUT /applications).
+//
+// Returns 202 Accepted; the response body echoes back what was patched
+// so the UI can immediately render an "in flight" state without
+// waiting for the reconciler to update status.
+func (h *Handler) HandleContinuumSwitchoverRequest(w http.ResponseWriter, r *http.Request) {
+	depID := chi.URLParam(r, "id")
+	name := chi.URLParam(r, "name")
+	if strings.TrimSpace(name) == "" {
+		writeBadRequest(w, "missing-name", "continuum name is required")
+		return
+	}
+	dep, ok := h.lookupDeploymentForInfra(depID)
+	if !ok {
+		writeNotFound(w, depID)
+		return
+	}
+	if claims := auth.ClaimsFromContext(r.Context()); claims != nil {
+		if !applicationInstallCallerAuthorized(claims) {
+			writeJSON(w, http.StatusForbidden, map[string]string{
+				"error":  "forbidden",
+				"detail": "POST /continuums/{name}/switchover requires owner tier on the Application",
+			})
+			return
+		}
+	}
+	var body continuumSwitchoverRequest
+	if !decodeMutationBody(w, r, &body) {
+		return
+	}
+	if strings.TrimSpace(body.TargetRegion) == "" {
+		writeBadRequest(w, "missing-target-region", "targetRegion is required")
+		return
+	}
+	client, err := h.sovereignDynamicClient(dep)
+	if err != nil {
+		writeUserAccessUnavailable(w, err)
+		return
+	}
+	ns := strings.TrimSpace(r.URL.Query().Get("namespace"))
+	cr, getErr := getContinuumCR(r.Context(), client, name, ns)
+	if getErr != nil {
+		if apierrors.IsNotFound(getErr) {
+			writeJSON(w, http.StatusNotFound, map[string]string{
+				"error":  "continuum-not-found",
+				"detail": fmt.Sprintf("Continuum %q not found", name),
+			})
+			return
+		}
+		writeJSON(w, http.StatusInternalServerError, map[string]string{
+			"error":  "continuum-get-failed",
+			"detail": getErr.Error(),
+		})
+		return
+	}
+
+	// Reject when the switchover targetRegion equals the current primary
+	// — the reconciler would treat it as a no-op but a 409 here gives the
+	// UI a clean error instead of a silent failure.
+	curPrimary, _, _ := unstructured.NestedString(cr.Object, "spec", "primaryRegion")
+	if curPrimary != "" && curPrimary == body.TargetRegion {
+		writeJSON(w, http.StatusConflict, map[string]string{
+			"error":  "switchover-noop",
+			"detail": fmt.Sprintf("targetRegion %q already primary; nothing to switchover", body.TargetRegion),
+		})
+		return
+	}
+
+	now := h.continuumNow()
+	requestedBy := actorFromClaims(auth.ClaimsFromContext(r.Context()))
+
+	patched := cr.DeepCopy()
+	_ = unstructured.SetNestedField(patched.Object, true, "spec", "switchover", "requested")
+	_ = unstructured.SetNestedField(patched.Object, body.TargetRegion, "spec", "switchover", "targetRegion")
+	_ = unstructured.SetNestedField(patched.Object, now.UTC().Format(time.RFC3339), "spec", "switchover", "requestedAt")
+	if requestedBy != "" {
+		_ = unstructured.SetNestedField(patched.Object, requestedBy, "spec", "switchover", "requestedBy")
+	}
+	if strings.TrimSpace(body.Reason) != "" {
+		_ = unstructured.SetNestedField(patched.Object, body.Reason, "spec", "switchover", "reason")
+	}
+
+	if err := updateContinuumCR(r.Context(), client, patched); err != nil {
+		if apierrors.IsConflict(err) {
+			writeJSON(w, http.StatusConflict, map[string]string{
+				"error":  "continuum-conflict",
+				"detail": err.Error(),
+			})
+			return
+		}
+		writeJSON(w, http.StatusInternalServerError, map[string]string{
+			"error":  "continuum-update-failed",
+			"detail": err.Error(),
+		})
+		return
+	}
+
+	// Publish a UI-facing audit event. K-Cont-2 emits its own
+	// `continuum-switchover` event on the NATS subject when the
+	// reconciler picks up the patch; this one is the operator-initiated
+	// audit row so the audit trail captures who pressed the button even
+	// if the reconciler hasn't run yet.
+	if h.auditBus != nil {
+		h.auditBus.Publish(r.Context(), audit.Event{
+			AuditType:         "continuum-switchover-requested",
+			SovereignID:       depID,
+			Actor:             requestedBy,
+			TargetApplication: continuumApplicationRef(cr),
+			Detail: fmt.Sprintf(
+				"switchover requested: %s → %s (reason: %s)",
+				curPrimary, body.TargetRegion, displayReason(body.Reason),
+			),
+		})
+	}
+
+	resp := continuumSwitchoverResponse{
+		Name:         patched.GetName(),
+		Namespace:    patched.GetNamespace(),
+		TargetRegion: body.TargetRegion,
+		Reason:       body.Reason,
+		RequestedAt:  now.UTC().Format(time.RFC3339),
+		RequestedBy:  requestedBy,
+		Message:      "switchover requested; reconciler will execute the 7-step sequence",
+	}
+	writeJSON(w, http.StatusAccepted, resp)
+}
+
+// HandleContinuumFailbackRequest — POST
+// /api/v1/sovereigns/{id}/continuums/{name}/failback
+//
+// Patches `spec.failback.requested = true`. If the CR's
+// `spec.failback.approvalRequired = true`, the reconciler emits
+// `continuum-failback-pending` and waits for the approve endpoint
+// below; otherwise the reconciler executes the same 7-step sequence in
+// reverse direction immediately.
+//
+// Auth: owner tier on the Application (REUSES
+// applicationInstallCallerAuthorized).
+func (h *Handler) HandleContinuumFailbackRequest(w http.ResponseWriter, r *http.Request) {
+	depID := chi.URLParam(r, "id")
+	name := chi.URLParam(r, "name")
+	if strings.TrimSpace(name) == "" {
+		writeBadRequest(w, "missing-name", "continuum name is required")
+		return
+	}
+	dep, ok := h.lookupDeploymentForInfra(depID)
+	if !ok {
+		writeNotFound(w, depID)
+		return
+	}
+	if claims := auth.ClaimsFromContext(r.Context()); claims != nil {
+		if !applicationInstallCallerAuthorized(claims) {
+			writeJSON(w, http.StatusForbidden, map[string]string{
+				"error":  "forbidden",
+				"detail": "POST /continuums/{name}/failback requires owner tier on the Application",
+			})
+			return
+		}
+	}
+	// Body is OPTIONAL — the caller may POST without one. Decode only
+	// when Content-Length suggests there's content; never use
+	// decodeMutationBody (it 400s on empty body).
+	var body continuumFailbackRequest
+	if r.ContentLength > 0 || r.Header.Get("Content-Type") == "application/json" {
+		dec := json.NewDecoder(http.MaxBytesReader(w, r.Body, 1<<16))
+		// Be lenient — an empty body decodes to a zero-value struct.
+		_ = dec.Decode(&body)
+	}
+
+	client, err := h.sovereignDynamicClient(dep)
+	if err != nil {
+		writeUserAccessUnavailable(w, err)
+		return
+	}
+	ns := strings.TrimSpace(r.URL.Query().Get("namespace"))
+	cr, getErr := getContinuumCR(r.Context(), client, name, ns)
+	if getErr != nil {
+		if apierrors.IsNotFound(getErr) {
+			writeJSON(w, http.StatusNotFound, map[string]string{
+				"error":  "continuum-not-found",
+				"detail": fmt.Sprintf("Continuum %q not found", name),
+			})
+			return
+		}
+		writeJSON(w, http.StatusInternalServerError, map[string]string{
+			"error":  "continuum-get-failed",
+			"detail": getErr.Error(),
+		})
+		return
+	}
+
+	now := h.continuumNow()
+	requestedBy := actorFromClaims(auth.ClaimsFromContext(r.Context()))
+	approvalRequired, _, _ := unstructured.NestedBool(cr.Object, "spec", "failback", "approvalRequired")
+
+	patched := cr.DeepCopy()
+	_ = unstructured.SetNestedField(patched.Object, true, "spec", "failback", "requested")
+	_ = unstructured.SetNestedField(patched.Object, now.UTC().Format(time.RFC3339), "spec", "failback", "requestedAt")
+	if requestedBy != "" {
+		_ = unstructured.SetNestedField(patched.Object, requestedBy, "spec", "failback", "requestedBy")
+	}
+	if strings.TrimSpace(body.Reason) != "" {
+		_ = unstructured.SetNestedField(patched.Object, body.Reason, "spec", "failback", "reason")
+	}
+
+	if err := updateContinuumCR(r.Context(), client, patched); err != nil {
+		if apierrors.IsConflict(err) {
+			writeJSON(w, http.StatusConflict, map[string]string{
+				"error":  "continuum-conflict",
+				"detail": err.Error(),
+			})
+			return
+		}
+		writeJSON(w, http.StatusInternalServerError, map[string]string{
+			"error":  "continuum-update-failed",
+			"detail": err.Error(),
+		})
+		return
+	}
+
+	if h.auditBus != nil {
+		h.auditBus.Publish(r.Context(), audit.Event{
+			AuditType:         "continuum-failback-requested",
+			SovereignID:       depID,
+			Actor:             requestedBy,
+			TargetApplication: continuumApplicationRef(cr),
+			Detail: fmt.Sprintf(
+				"failback requested (approvalRequired: %t, reason: %s)",
+				approvalRequired, displayReason(body.Reason),
+			),
+		})
+	}
+
+	msg := "failback requested; reconciler will execute the reverse switchover"
+	if approvalRequired {
+		msg = "failback requested; awaiting sovereign-admin approval"
+	}
+	resp := continuumFailbackResponse{
+		Name:             patched.GetName(),
+		Namespace:        patched.GetNamespace(),
+		RequestedAt:      now.UTC().Format(time.RFC3339),
+		RequestedBy:      requestedBy,
+		ApprovalRequired: approvalRequired,
+		Message:          msg,
+	}
+	writeJSON(w, http.StatusAccepted, resp)
+}
+
+// HandleContinuumFailbackApprove — POST
+// /api/v1/sovereigns/{id}/continuums/{name}/failback/approve
+//
+// Patches `spec.failback.approved = true`. Required only when the CR's
+// `spec.failback.approvalRequired = true`; the K-Cont-2 reconciler
+// blocks on this flag before running the failback sequence.
+//
+// Auth: sovereign-admin (admin or owner tier — REUSES
+// rbacRequireSovereignAdmin).
+func (h *Handler) HandleContinuumFailbackApprove(w http.ResponseWriter, r *http.Request) {
+	depID := chi.URLParam(r, "id")
+	name := chi.URLParam(r, "name")
+	if strings.TrimSpace(name) == "" {
+		writeBadRequest(w, "missing-name", "continuum name is required")
+		return
+	}
+	dep, ok := h.lookupDeploymentForInfra(depID)
+	if !ok {
+		writeNotFound(w, depID)
+		return
+	}
+	if !rbacRequireSovereignAdmin(w, r) {
+		// Response already written by helper.
+		return
+	}
+	client, err := h.sovereignDynamicClient(dep)
+	if err != nil {
+		writeUserAccessUnavailable(w, err)
+		return
+	}
+	ns := strings.TrimSpace(r.URL.Query().Get("namespace"))
+	cr, getErr := getContinuumCR(r.Context(), client, name, ns)
+	if getErr != nil {
+		if apierrors.IsNotFound(getErr) {
+			writeJSON(w, http.StatusNotFound, map[string]string{
+				"error":  "continuum-not-found",
+				"detail": fmt.Sprintf("Continuum %q not found", name),
+			})
+			return
+		}
+		writeJSON(w, http.StatusInternalServerError, map[string]string{
+			"error":  "continuum-get-failed",
+			"detail": getErr.Error(),
+		})
+		return
+	}
+
+	now := h.continuumNow()
+	approver := actorFromClaims(auth.ClaimsFromContext(r.Context()))
+
+	patched := cr.DeepCopy()
+	_ = unstructured.SetNestedField(patched.Object, true, "spec", "failback", "approved")
+	_ = unstructured.SetNestedField(patched.Object, now.UTC().Format(time.RFC3339), "spec", "failback", "approvedAt")
+	if approver != "" {
+		_ = unstructured.SetNestedField(patched.Object, approver, "spec", "failback", "approvedBy")
+	}
+
+	if err := updateContinuumCR(r.Context(), client, patched); err != nil {
+		if apierrors.IsConflict(err) {
+			writeJSON(w, http.StatusConflict, map[string]string{
+				"error":  "continuum-conflict",
+				"detail": err.Error(),
+			})
+			return
+		}
+		writeJSON(w, http.StatusInternalServerError, map[string]string{
+			"error":  "continuum-update-failed",
+			"detail": err.Error(),
+		})
+		return
+	}
+
+	if h.auditBus != nil {
+		h.auditBus.Publish(r.Context(), audit.Event{
+			AuditType:         "continuum-failback-approved",
+			SovereignID:       depID,
+			Actor:             approver,
+			TargetApplication: continuumApplicationRef(cr),
+			Detail:            fmt.Sprintf("failback approved by %s", approver),
+		})
+	}
+
+	resp := continuumFailbackApproveResponse{
+		Name:       patched.GetName(),
+		Namespace:  patched.GetNamespace(),
+		ApprovedAt: now.UTC().Format(time.RFC3339),
+		ApprovedBy: approver,
+		Message:    "failback approved; reconciler will execute the failback sequence",
+	}
+	writeJSON(w, http.StatusAccepted, resp)
+}
+
+// HandleContinuumAuditList — GET
+// /api/v1/sovereigns/{id}/audit/continuum
+//
+// Mirrors HandleRBACAuditList but filters on the continuum-* prefix.
+// Auth: tier-admin or higher (mirrors /audit/rbac).
+//
+// Query params:
+//
+//	?limit=<n>     — page size, default 100, max 500
+//	?offset=<n>    — page offset, default 0
+//	?actor=<q>     — filter to actor substring (case-insensitive)
+//	?since=<rfc3339> — only events at or after this timestamp
+//	?type=<prefix>   — narrow further (e.g. "continuum-switchover")
+func (h *Handler) HandleContinuumAuditList(w http.ResponseWriter, r *http.Request) {
+	depID := chi.URLParam(r, "id")
+	if _, ok := h.lookupDeploymentForInfra(depID); !ok {
+		writeNotFound(w, depID)
+		return
+	}
+	if claims := auth.ClaimsFromContext(r.Context()); claims != nil {
+		if !rbacAssignCallerAuthorized(claims) {
+			writeJSON(w, http.StatusForbidden, map[string]string{
+				"error":  "forbidden",
+				"detail": "/audit/continuum requires tier-admin or higher",
+			})
+			return
+		}
+	}
+	if h.auditBus == nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]string{
+			"error":  "audit-bus-not-wired",
+			"detail": "audit handler not initialized",
+		})
+		return
+	}
+
+	limit := parseRBACAuditIntParam(r.URL.Query().Get("limit"), 100, 1, 500)
+	offset := parseRBACAuditIntParam(r.URL.Query().Get("offset"), 0, 0, 1<<30)
+	actorQ := r.URL.Query().Get("actor")
+	sinceQ := r.URL.Query().Get("since")
+	typeQ := strings.TrimSpace(r.URL.Query().Get("type"))
+	var since time.Time
+	if sinceQ != "" {
+		if t, err := time.Parse(time.RFC3339, sinceQ); err == nil {
+			since = t
+		}
+	}
+
+	const maxRingPull = 5000
+	predicate := IsContinuumAuditType
+	if typeQ != "" {
+		// Narrow further — exact-match (caller passes the full audit-type name).
+		want := typeQ
+		predicate = func(t string) bool {
+			return IsContinuumAuditType(t) && t == want
+		}
+	}
+	all := h.auditBus.List(depID, predicate, maxRingPull)
+	filtered := make([]audit.Event, 0, len(all))
+	for _, ev := range all {
+		if !since.IsZero() && ev.Timestamp.Before(since) {
+			continue
+		}
+		if actorQ != "" && !containsFold(ev.Actor, actorQ) {
+			continue
+		}
+		filtered = append(filtered, ev)
+	}
+
+	page := filtered
+	if offset > 0 {
+		if offset >= len(page) {
+			page = []audit.Event{}
+		} else {
+			page = page[offset:]
+		}
+	}
+	if len(page) > limit {
+		page = page[:limit]
+	}
+
+	resp := continuumAuditListResponse{
+		Items: page,
+		Total: len(filtered),
+	}
+	if offset+len(page) < len(filtered) {
+		resp.NextOffset = offset + len(page)
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// HandleContinuumAuditStream — GET
+// /api/v1/sovereigns/{id}/audit/continuum/stream
+//
+// SSE: `text/event-stream`. One JSON document per `data:` frame.
+// Heartbeat ping every rbacAuditStreamHeartbeat. Connection closes on
+// client disconnect (r.Context().Done()).
+//
+// Auth: tier-admin or higher (mirrors /audit/rbac/stream).
+func (h *Handler) HandleContinuumAuditStream(w http.ResponseWriter, r *http.Request) {
+	depID := chi.URLParam(r, "id")
+	if _, ok := h.lookupDeploymentForInfra(depID); !ok {
+		writeNotFound(w, depID)
+		return
+	}
+	if claims := auth.ClaimsFromContext(r.Context()); claims != nil {
+		if !rbacAssignCallerAuthorized(claims) {
+			writeJSON(w, http.StatusForbidden, map[string]string{
+				"error":  "forbidden",
+				"detail": "/audit/continuum/stream requires tier-admin or higher",
+			})
+			return
+		}
+	}
+	if h.auditBus == nil {
+		http.Error(w, "audit bus not wired", http.StatusServiceUnavailable)
+		return
+	}
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "streaming not supported", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("X-Accel-Buffering", "no")
+
+	ch, unsub := h.auditBus.Subscribe(depID, IsContinuumAuditType)
+	defer unsub()
+
+	_, _ = fmt.Fprintf(w, ": connected sovereign=%s topic=continuum\n\n", depID)
+	flusher.Flush()
+
+	pingT := time.NewTicker(rbacAuditStreamHeartbeat)
+	defer pingT.Stop()
+
+	enc := json.NewEncoder(w)
+	for {
+		select {
+		case <-r.Context().Done():
+			return
+		case <-pingT.C:
+			if _, err := fmt.Fprintf(w, ": ping %d\n\n", time.Now().Unix()); err != nil {
+				return
+			}
+			flusher.Flush()
+		case ev, ok := <-ch:
+			if !ok {
+				return
+			}
+			if _, err := w.Write([]byte("data: ")); err != nil {
+				return
+			}
+			if err := enc.Encode(ev); err != nil {
+				return
+			}
+			if _, err := w.Write([]byte("\n")); err != nil {
+				return
+			}
+			flusher.Flush()
+		}
+	}
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+// getContinuumCR fetches a Continuum CR by name, falling back to a
+// list-across-all-namespaces when `ns` is empty (mirrors
+// getApplicationCR's chroot-friendly pattern).
+func getContinuumCR(
+	ctx context.Context,
+	client dynamic.Interface,
+	name, ns string,
+) (*unstructured.Unstructured, error) {
+	if ns != "" {
+		return client.Resource(ContinuumGVR()).Namespace(ns).Get(ctx, name, metav1.GetOptions{})
+	}
+	list, err := client.Resource(ContinuumGVR()).Namespace("").List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+	for i := range list.Items {
+		if list.Items[i].GetName() == name {
+			return list.Items[i].DeepCopy(), nil
+		}
+	}
+	return nil, apierrors.NewNotFound(
+		schema.GroupResource{Group: ContinuumGVR().Group, Resource: ContinuumGVR().Resource},
+		name,
+	)
+}
+
+// updateContinuumCR writes the patched Unstructured back to the cluster.
+func updateContinuumCR(
+	ctx context.Context,
+	client dynamic.Interface,
+	cr *unstructured.Unstructured,
+) error {
+	_, err := client.Resource(ContinuumGVR()).Namespace(cr.GetNamespace()).Update(
+		ctx, cr, metav1.UpdateOptions{})
+	return err
+}
+
+// continuumApplicationRef extracts spec.applicationRef as a convenience
+// for audit-event tagging.
+func continuumApplicationRef(cr *unstructured.Unstructured) string {
+	v, _, _ := unstructured.NestedString(cr.Object, "spec", "applicationRef")
+	return v
+}
+
+// actorFromClaims returns the operator email/subject for stamping into
+// spec.switchover.requestedBy + audit Actor. Mirrors
+// rbacAuditActorFromClaims.
+func actorFromClaims(claims *auth.Claims) string {
+	if claims == nil {
+		return ""
+	}
+	if claims.Email != "" {
+		return claims.Email
+	}
+	return claims.Sub
+}
+
+// displayReason returns a non-empty fallback for log lines.
+func displayReason(s string) string {
+	if strings.TrimSpace(s) == "" {
+		return "n/a"
+	}
+	return s
+}
+
+// continuumNow returns the current time, overridable via h.now (tests).
+func (h *Handler) continuumNow() time.Time {
+	if h.continuumClock != nil {
+		return h.continuumClock()
+	}
+	return time.Now()
+}
+
+// SetContinuumClock — test seam wiring. Production leaves this nil.
+func (h *Handler) SetContinuumClock(now func() time.Time) { h.continuumClock = now }

--- a/products/catalyst/bootstrap/api/internal/handler/continuum_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/continuum_test.go
@@ -1,0 +1,595 @@
+// continuum_test.go — coverage for the EPIC-6 Slice U-DR-1 (#1101)
+// Continuum DR REST + SSE handlers.
+//
+// Test strategy mirrors applications_test.go + rbac_audit_test.go:
+//   - Fake dynamic client seeded with the Continuum GVR's list-kind so
+//     sovereignDynamicClient resolves to a deterministic in-memory CR.
+//   - Installed Deployment with a temp-file kubeconfig path
+//     (installUserAccessDeployment helper, shared with slice U).
+//   - Per-test chi router that registers only the endpoint under test.
+//   - Fixed-clock injection via SetContinuumClock so requestedAt is
+//     reproducible across runs.
+//   - For audit-list/stream tests the in-process audit.Bus is wired
+//     directly (mirrors rbac_audit_test.go).
+package handler
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/audit"
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/auth"
+)
+
+// withClaims is a tiny test helper that injects Claims into a request
+// context via the canonical auth.ClaimsKey.
+func withClaims(ctx context.Context, claims *auth.Claims) context.Context {
+	return context.WithValue(ctx, auth.ClaimsKey, claims)
+}
+
+// ── Test helpers ─────────────────────────────────────────────────────
+
+func continuumListKinds() map[schema.GroupVersionResource]string {
+	return map[schema.GroupVersionResource]string{
+		ContinuumGVR(): "ContinuumList",
+	}
+}
+
+func fakeContinuumDynamicFactory(seed ...runtime.Object) (func(string) (dynamic.Interface, error), *dynamicfake.FakeDynamicClient) {
+	scheme := runtime.NewScheme()
+	client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, continuumListKinds(), seed...)
+	return func(_ string) (dynamic.Interface, error) {
+		return client, nil
+	}, client
+}
+
+// newContinuumUnstructured composes a minimum-viable Continuum CR for
+// the handler tests. The CRD fields populated mirror the docs at
+// products/catalyst/chart/crds/continuum.yaml.
+func newContinuumUnstructured(name, namespace, appRef, primaryRegion string, hotStandbys []string) *unstructured.Unstructured {
+	u := &unstructured.Unstructured{}
+	u.SetAPIVersion("dr.openova.io/v1")
+	u.SetKind("Continuum")
+	u.SetName(name)
+	u.SetNamespace(namespace)
+	hotAny := make([]interface{}, 0, len(hotStandbys))
+	for _, hs := range hotStandbys {
+		hotAny = append(hotAny, hs)
+	}
+	_ = unstructured.SetNestedMap(u.Object, map[string]interface{}{
+		"applicationRef":    appRef,
+		"primaryRegion":     primaryRegion,
+		"hotStandbyRegions": hotAny,
+		"leaseClient": map[string]interface{}{
+			"kind": "in-memory",
+		},
+	}, "spec")
+	_ = unstructured.SetNestedMap(u.Object, map[string]interface{}{
+		"phase":         "Healthy",
+		"primaryRegion": primaryRegion,
+		"leaseHolder":   primaryRegion,
+	}, "status")
+	return u
+}
+
+func registerContinuumRoutes(r chi.Router, h *Handler) {
+	r.Get("/api/v1/sovereigns/{id}/continuums/{name}", h.HandleContinuumGet)
+	r.Post("/api/v1/sovereigns/{id}/continuums/{name}/switchover", h.HandleContinuumSwitchoverRequest)
+	r.Post("/api/v1/sovereigns/{id}/continuums/{name}/failback", h.HandleContinuumFailbackRequest)
+	r.Post("/api/v1/sovereigns/{id}/continuums/{name}/failback/approve", h.HandleContinuumFailbackApprove)
+	r.Get("/api/v1/sovereigns/{id}/audit/continuum", h.HandleContinuumAuditList)
+}
+
+// ── IsContinuumAuditType pure-function tests ─────────────────────────
+
+func TestIsContinuumAuditType(t *testing.T) {
+	tests := []struct {
+		in   string
+		want bool
+	}{
+		{"continuum-switchover", true},
+		{"continuum-failback-pending", true},
+		{"continuum-failback-completed", true},
+		{"continuum-lease-lost", true},
+		{"continuum-lease-acquired", true},
+		{"continuum-cnpg-lag-breach", true},
+		{"continuum-cnpg-promotable", true},
+		{"continuum-error", true},
+		{"continuum-reconcile-success", true},
+		{"continuum-switchover-requested", true},
+		{"continuum-failback-requested", true},
+		{"continuum-failback-approved", true},
+		{"rbac-grant-created", false},
+		{"continuum", false},
+		{"", false},
+	}
+	for _, tc := range tests {
+		got := IsContinuumAuditType(tc.in)
+		if got != tc.want {
+			t.Errorf("IsContinuumAuditType(%q): got %v want %v", tc.in, got, tc.want)
+		}
+	}
+}
+
+// ── GET /continuums/{name} ───────────────────────────────────────────
+
+func TestHandleContinuumGet_HappyPath(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	cr := newContinuumUnstructured("dr-wp", "acme", "wp-prod", "hz-fsn-rtz-prod", []string{"hz-hel-rtz-prod"})
+	factory, _ := fakeContinuumDynamicFactory(cr)
+	h.dynamicFactory = factory
+	dep := installUserAccessDeployment(t, h, "dep-cont-get")
+
+	r := chi.NewRouter()
+	registerContinuumRoutes(r, h)
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/v1/sovereigns/"+dep.ID+"/continuums/dr-wp", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	var resp continuumGetResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Name != "dr-wp" || resp.Namespace != "acme" {
+		t.Errorf("identity: got %+v want dr-wp/acme", resp)
+	}
+	if appRef, _, _ := unstructured.NestedString(resp.Spec, "applicationRef"); appRef != "wp-prod" {
+		t.Errorf("applicationRef: got %q want wp-prod", appRef)
+	}
+	if phase, _, _ := unstructured.NestedString(resp.Status, "phase"); phase != "Healthy" {
+		t.Errorf("phase: got %q want Healthy", phase)
+	}
+}
+
+func TestHandleContinuumGet_404WhenMissing(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	factory, _ := fakeContinuumDynamicFactory()
+	h.dynamicFactory = factory
+	dep := installUserAccessDeployment(t, h, "dep-cont-get-404")
+
+	r := chi.NewRouter()
+	registerContinuumRoutes(r, h)
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/v1/sovereigns/"+dep.ID+"/continuums/missing", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status: got %d want 404; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+// ── POST /continuums/{name}/switchover ──────────────────────────────
+
+func TestHandleContinuumSwitchover_PatchesSpec(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	cr := newContinuumUnstructured("dr-wp", "acme", "wp-prod", "hz-fsn-rtz-prod", []string{"hz-hel-rtz-prod"})
+	factory, client := fakeContinuumDynamicFactory(cr)
+	h.dynamicFactory = factory
+	bus := audit.NewBus(audit.BusConfig{RingCapacity: 50})
+	h.SetAuditBus(bus)
+	fixed := time.Date(2026, 5, 9, 10, 30, 0, 0, time.UTC)
+	h.SetContinuumClock(func() time.Time { return fixed })
+	dep := installUserAccessDeployment(t, h, "dep-cont-sw")
+
+	body := continuumSwitchoverRequest{
+		TargetRegion: "hz-hel-rtz-prod",
+		Reason:       "operator-drill",
+	}
+	raw, _ := json.Marshal(body)
+
+	r := chi.NewRouter()
+	registerContinuumRoutes(r, h)
+	req := httptest.NewRequest(http.MethodPost,
+		"/api/v1/sovereigns/"+dep.ID+"/continuums/dr-wp/switchover", bytes.NewReader(raw))
+	req.Header.Set("Content-Type", "application/json")
+	// Inject claims so authorization passes.
+	req = req.WithContext(withClaims(req.Context(), &auth.Claims{Email: "owner@acme.io", Tier: "owner"}))
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("status: got %d want 202; body=%s", rec.Code, rec.Body.String())
+	}
+
+	// Read back the CR via the fake client.
+	got, err := client.Resource(ContinuumGVR()).Namespace("acme").Get(context.Background(), "dr-wp", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("re-fetch: %v", err)
+	}
+	requested, _, _ := unstructured.NestedBool(got.Object, "spec", "switchover", "requested")
+	if !requested {
+		t.Error("spec.switchover.requested: got false want true")
+	}
+	target, _, _ := unstructured.NestedString(got.Object, "spec", "switchover", "targetRegion")
+	if target != "hz-hel-rtz-prod" {
+		t.Errorf("targetRegion: got %q want hz-hel-rtz-prod", target)
+	}
+	requestedBy, _, _ := unstructured.NestedString(got.Object, "spec", "switchover", "requestedBy")
+	if requestedBy != "owner@acme.io" {
+		t.Errorf("requestedBy: got %q want owner@acme.io", requestedBy)
+	}
+	requestedAt, _, _ := unstructured.NestedString(got.Object, "spec", "switchover", "requestedAt")
+	if requestedAt != fixed.Format(time.RFC3339) {
+		t.Errorf("requestedAt: got %q want %q", requestedAt, fixed.Format(time.RFC3339))
+	}
+	reason, _, _ := unstructured.NestedString(got.Object, "spec", "switchover", "reason")
+	if reason != "operator-drill" {
+		t.Errorf("reason: got %q want operator-drill", reason)
+	}
+
+	// Audit Bus should have one continuum-switchover-requested event.
+	auditEvents := bus.List(dep.ID, IsContinuumAuditType, 100)
+	if len(auditEvents) != 1 {
+		t.Fatalf("audit events: got %d want 1", len(auditEvents))
+	}
+	if auditEvents[0].AuditType != "continuum-switchover-requested" {
+		t.Errorf("audit-type: got %q want continuum-switchover-requested", auditEvents[0].AuditType)
+	}
+	if auditEvents[0].Actor != "owner@acme.io" {
+		t.Errorf("actor: got %q want owner@acme.io", auditEvents[0].Actor)
+	}
+	if auditEvents[0].TargetApplication != "wp-prod" {
+		t.Errorf("targetApp: got %q want wp-prod", auditEvents[0].TargetApplication)
+	}
+}
+
+func TestHandleContinuumSwitchover_403WhenNotOwner(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	cr := newContinuumUnstructured("dr-wp", "acme", "wp-prod", "hz-fsn-rtz-prod", []string{"hz-hel-rtz-prod"})
+	factory, _ := fakeContinuumDynamicFactory(cr)
+	h.dynamicFactory = factory
+	dep := installUserAccessDeployment(t, h, "dep-cont-sw-403")
+
+	body := continuumSwitchoverRequest{TargetRegion: "hz-hel-rtz-prod"}
+	raw, _ := json.Marshal(body)
+
+	r := chi.NewRouter()
+	registerContinuumRoutes(r, h)
+	req := httptest.NewRequest(http.MethodPost,
+		"/api/v1/sovereigns/"+dep.ID+"/continuums/dr-wp/switchover", bytes.NewReader(raw))
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(withClaims(req.Context(), &auth.Claims{Email: "viewer@acme.io", Tier: "viewer"}))
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status: got %d want 403; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestHandleContinuumSwitchover_404WhenContinuumMissing(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	factory, _ := fakeContinuumDynamicFactory()
+	h.dynamicFactory = factory
+	dep := installUserAccessDeployment(t, h, "dep-cont-sw-404")
+
+	body := continuumSwitchoverRequest{TargetRegion: "hz-hel-rtz-prod"}
+	raw, _ := json.Marshal(body)
+
+	r := chi.NewRouter()
+	registerContinuumRoutes(r, h)
+	req := httptest.NewRequest(http.MethodPost,
+		"/api/v1/sovereigns/"+dep.ID+"/continuums/dr-wp/switchover", bytes.NewReader(raw))
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(withClaims(req.Context(), &auth.Claims{Email: "owner@acme.io", Tier: "owner"}))
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status: got %d want 404; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestHandleContinuumSwitchover_400WhenTargetRegionMissing(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	cr := newContinuumUnstructured("dr-wp", "acme", "wp-prod", "hz-fsn-rtz-prod", []string{"hz-hel-rtz-prod"})
+	factory, _ := fakeContinuumDynamicFactory(cr)
+	h.dynamicFactory = factory
+	dep := installUserAccessDeployment(t, h, "dep-cont-sw-400")
+
+	body := continuumSwitchoverRequest{Reason: "missing-target"}
+	raw, _ := json.Marshal(body)
+
+	r := chi.NewRouter()
+	registerContinuumRoutes(r, h)
+	req := httptest.NewRequest(http.MethodPost,
+		"/api/v1/sovereigns/"+dep.ID+"/continuums/dr-wp/switchover", bytes.NewReader(raw))
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(withClaims(req.Context(), &auth.Claims{Email: "owner@acme.io", Tier: "owner"}))
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status: got %d want 400; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestHandleContinuumSwitchover_409WhenTargetEqualsCurrent(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	cr := newContinuumUnstructured("dr-wp", "acme", "wp-prod", "hz-fsn-rtz-prod", []string{"hz-hel-rtz-prod"})
+	factory, _ := fakeContinuumDynamicFactory(cr)
+	h.dynamicFactory = factory
+	dep := installUserAccessDeployment(t, h, "dep-cont-sw-409")
+
+	body := continuumSwitchoverRequest{TargetRegion: "hz-fsn-rtz-prod"}
+	raw, _ := json.Marshal(body)
+
+	r := chi.NewRouter()
+	registerContinuumRoutes(r, h)
+	req := httptest.NewRequest(http.MethodPost,
+		"/api/v1/sovereigns/"+dep.ID+"/continuums/dr-wp/switchover", bytes.NewReader(raw))
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(withClaims(req.Context(), &auth.Claims{Email: "owner@acme.io", Tier: "owner"}))
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("status: got %d want 409; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+// ── POST /continuums/{name}/failback ────────────────────────────────
+
+func TestHandleContinuumFailback_PatchesSpec(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	cr := newContinuumUnstructured("dr-wp", "acme", "wp-prod", "hz-fsn-rtz-prod", []string{"hz-hel-rtz-prod"})
+	// Mark approvalRequired so the response carries it through.
+	_ = unstructured.SetNestedMap(cr.Object, map[string]interface{}{
+		"approvalRequired": true,
+	}, "spec", "failback")
+	factory, client := fakeContinuumDynamicFactory(cr)
+	h.dynamicFactory = factory
+	bus := audit.NewBus(audit.BusConfig{RingCapacity: 50})
+	h.SetAuditBus(bus)
+	fixed := time.Date(2026, 5, 9, 11, 0, 0, 0, time.UTC)
+	h.SetContinuumClock(func() time.Time { return fixed })
+	dep := installUserAccessDeployment(t, h, "dep-cont-fb")
+
+	body := continuumFailbackRequest{Reason: "lag-recovered"}
+	raw, _ := json.Marshal(body)
+
+	r := chi.NewRouter()
+	registerContinuumRoutes(r, h)
+	req := httptest.NewRequest(http.MethodPost,
+		"/api/v1/sovereigns/"+dep.ID+"/continuums/dr-wp/failback", bytes.NewReader(raw))
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(withClaims(req.Context(), &auth.Claims{Email: "owner@acme.io", Tier: "owner"}))
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("status: got %d want 202; body=%s", rec.Code, rec.Body.String())
+	}
+	var resp continuumFailbackResponse
+	_ = json.Unmarshal(rec.Body.Bytes(), &resp)
+	if !resp.ApprovalRequired {
+		t.Error("response.ApprovalRequired: got false want true")
+	}
+	if !strings.Contains(resp.Message, "approval") {
+		t.Errorf("message should mention approval; got %q", resp.Message)
+	}
+
+	got, _ := client.Resource(ContinuumGVR()).Namespace("acme").Get(context.Background(), "dr-wp", metav1.GetOptions{})
+	requested, _, _ := unstructured.NestedBool(got.Object, "spec", "failback", "requested")
+	if !requested {
+		t.Error("spec.failback.requested: got false want true")
+	}
+
+	auditEvents := bus.List(dep.ID, IsContinuumAuditType, 100)
+	if len(auditEvents) != 1 || auditEvents[0].AuditType != "continuum-failback-requested" {
+		t.Fatalf("audit events: %+v", auditEvents)
+	}
+}
+
+func TestHandleContinuumFailback_AcceptsEmptyBody(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	cr := newContinuumUnstructured("dr-wp", "acme", "wp-prod", "hz-fsn-rtz-prod", []string{"hz-hel-rtz-prod"})
+	factory, _ := fakeContinuumDynamicFactory(cr)
+	h.dynamicFactory = factory
+	dep := installUserAccessDeployment(t, h, "dep-cont-fb-empty")
+
+	r := chi.NewRouter()
+	registerContinuumRoutes(r, h)
+	req := httptest.NewRequest(http.MethodPost,
+		"/api/v1/sovereigns/"+dep.ID+"/continuums/dr-wp/failback", nil)
+	req = req.WithContext(withClaims(req.Context(), &auth.Claims{Email: "owner@acme.io", Tier: "owner"}))
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("status: got %d want 202; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestHandleContinuumFailback_403WhenNotOwner(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	cr := newContinuumUnstructured("dr-wp", "acme", "wp-prod", "hz-fsn-rtz-prod", []string{"hz-hel-rtz-prod"})
+	factory, _ := fakeContinuumDynamicFactory(cr)
+	h.dynamicFactory = factory
+	dep := installUserAccessDeployment(t, h, "dep-cont-fb-403")
+
+	r := chi.NewRouter()
+	registerContinuumRoutes(r, h)
+	req := httptest.NewRequest(http.MethodPost,
+		"/api/v1/sovereigns/"+dep.ID+"/continuums/dr-wp/failback", nil)
+	req = req.WithContext(withClaims(req.Context(), &auth.Claims{Email: "dev@acme.io", Tier: "developer"}))
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status: got %d want 403; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+// ── POST /continuums/{name}/failback/approve ────────────────────────
+
+func TestHandleContinuumFailbackApprove_PatchesSpec(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	cr := newContinuumUnstructured("dr-wp", "acme", "wp-prod", "hz-fsn-rtz-prod", []string{"hz-hel-rtz-prod"})
+	factory, client := fakeContinuumDynamicFactory(cr)
+	h.dynamicFactory = factory
+	bus := audit.NewBus(audit.BusConfig{RingCapacity: 50})
+	h.SetAuditBus(bus)
+	dep := installUserAccessDeployment(t, h, "dep-cont-fb-ap")
+
+	r := chi.NewRouter()
+	registerContinuumRoutes(r, h)
+	req := httptest.NewRequest(http.MethodPost,
+		"/api/v1/sovereigns/"+dep.ID+"/continuums/dr-wp/failback/approve", nil)
+	req = req.WithContext(withClaims(req.Context(), &auth.Claims{Email: "admin@acme.io", Tier: "admin"}))
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("status: got %d want 202; body=%s", rec.Code, rec.Body.String())
+	}
+
+	got, _ := client.Resource(ContinuumGVR()).Namespace("acme").Get(context.Background(), "dr-wp", metav1.GetOptions{})
+	approved, _, _ := unstructured.NestedBool(got.Object, "spec", "failback", "approved")
+	if !approved {
+		t.Error("spec.failback.approved: got false want true")
+	}
+
+	auditEvents := bus.List(dep.ID, IsContinuumAuditType, 100)
+	if len(auditEvents) != 1 || auditEvents[0].AuditType != "continuum-failback-approved" {
+		t.Fatalf("audit events: %+v", auditEvents)
+	}
+}
+
+func TestHandleContinuumFailbackApprove_403WhenNotSovereignAdmin(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	cr := newContinuumUnstructured("dr-wp", "acme", "wp-prod", "hz-fsn-rtz-prod", []string{"hz-hel-rtz-prod"})
+	factory, _ := fakeContinuumDynamicFactory(cr)
+	h.dynamicFactory = factory
+	dep := installUserAccessDeployment(t, h, "dep-cont-fb-ap-403")
+
+	r := chi.NewRouter()
+	registerContinuumRoutes(r, h)
+	req := httptest.NewRequest(http.MethodPost,
+		"/api/v1/sovereigns/"+dep.ID+"/continuums/dr-wp/failback/approve", nil)
+	req = req.WithContext(withClaims(req.Context(), &auth.Claims{Email: "dev@acme.io", Tier: "developer"}))
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status: got %d want 403; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+// ── GET /audit/continuum ────────────────────────────────────────────
+
+func TestHandleContinuumAuditList_FiltersOnPrefix(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	bus := audit.NewBus(audit.BusConfig{RingCapacity: 50})
+	h.SetAuditBus(bus)
+	dep := installUserAccessDeployment(t, h, "dep-cont-audit")
+
+	// Seed a mix of continuum + rbac events.
+	for i, ty := range []string{
+		"continuum-switchover",
+		"continuum-failback-pending",
+		"continuum-failback-completed",
+		"continuum-error",
+		"rbac-grant-created",
+	} {
+		bus.Publish(context.Background(), audit.Event{
+			AuditType:   ty,
+			SovereignID: dep.ID,
+			Actor:       "alice@acme.io",
+			Timestamp:   time.Now().UTC().Add(time.Duration(i) * time.Second),
+		})
+	}
+
+	r := chi.NewRouter()
+	registerContinuumRoutes(r, h)
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/v1/sovereigns/"+dep.ID+"/audit/continuum", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	var resp continuumAuditListResponse
+	_ = json.Unmarshal(rec.Body.Bytes(), &resp)
+	if resp.Total != 4 {
+		t.Errorf("total: got %d want 4", resp.Total)
+	}
+	for _, item := range resp.Items {
+		if !IsContinuumAuditType(item.AuditType) {
+			t.Errorf("non-continuum item leaked: %+v", item)
+		}
+	}
+}
+
+func TestHandleContinuumAuditList_503WhenBusNotWired(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	dep := installUserAccessDeployment(t, h, "dep-cont-audit-503")
+
+	r := chi.NewRouter()
+	registerContinuumRoutes(r, h)
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/v1/sovereigns/"+dep.ID+"/audit/continuum", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status: got %d want 503; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestHandleContinuumAuditList_TypeNarrowing(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	bus := audit.NewBus(audit.BusConfig{RingCapacity: 50})
+	h.SetAuditBus(bus)
+	dep := installUserAccessDeployment(t, h, "dep-cont-audit-narrow")
+
+	for i, ty := range []string{
+		"continuum-switchover",
+		"continuum-switchover",
+		"continuum-failback-completed",
+		"continuum-error",
+	} {
+		bus.Publish(context.Background(), audit.Event{
+			AuditType:   ty,
+			SovereignID: dep.ID,
+			Actor:       "alice@acme.io",
+			Timestamp:   time.Now().UTC().Add(time.Duration(i) * time.Second),
+		})
+	}
+
+	r := chi.NewRouter()
+	registerContinuumRoutes(r, h)
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/v1/sovereigns/"+dep.ID+"/audit/continuum?type=continuum-switchover", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	var resp continuumAuditListResponse
+	_ = json.Unmarshal(rec.Body.Bytes(), &resp)
+	if resp.Total != 2 {
+		t.Errorf("total: got %d want 2 (only continuum-switchover events)", resp.Total)
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/handler/handler.go
+++ b/products/catalyst/bootstrap/api/internal/handler/handler.go
@@ -373,6 +373,13 @@ type Handler struct {
 	// fails because audit isn't wired. Wired from main.go at startup
 	// (in-process by default; tests inject a deterministic instance).
 	auditBus *audit.Bus
+
+	// ── Continuum DR clock (EPIC-6 #1101 slice U-DR-1) ─────────────
+	// continuumClock — test seam for the Continuum switchover/failback
+	// handlers. nil ⇒ time.Now. Tests inject a deterministic clock so
+	// the audit-event timestamps + spec.switchover.requestedAt are
+	// reproducible. continuum.go is the only consumer.
+	continuumClock func() time.Time
 }
 
 // powerdnsZoneClient is the narrow interface the parent-zone handler

--- a/products/catalyst/bootstrap/ui/e2e/continuum-dr-section.spec.ts
+++ b/products/catalyst/bootstrap/ui/e2e/continuum-dr-section.spec.ts
@@ -1,0 +1,286 @@
+/**
+ * continuum-dr-section.spec.ts — Playwright E2E for the EPIC-6 Slice
+ * U-DR-1 (#1101) Continuum DR section embedded in the AppDetail
+ * Topology tab.
+ *
+ * What this asserts (per `feedback_per_issue_playwright_verification.md`
+ * — N issues = N snapshots, never collapse):
+ *
+ *  1. DR section renders + status panel populated from /continuums/{name}
+ *  2. Switchover dialog opens + 7-step list visible + cancel
+ *  3. Switchover dialog confirm → POST switchover endpoint hit
+ *  4. SwitchingOver in-progress widget renders when status reports
+ *  5. Switchover history table + detail modal
+ *
+ * Each test mounts mock catalyst-api responses so the page renders
+ * deterministically without a live backend, then captures one
+ * 1440x900 screenshot per assertion.
+ */
+
+import { test, expect, type Page, type Route } from '@playwright/test'
+
+const DEPLOYMENT_ID = 'dr-1101'
+const APP_NAME = 'wp-prod'
+const NAMESPACE = 'acme'
+const CONTINUUM_NAME = `dr-${APP_NAME}` // matches DRSection's default convention
+
+const HOTSTANDBY_BP = {
+  name: 'bp-wordpress',
+  version: '1.2.3',
+  card: { title: 'WordPress', summary: 'PHP CMS' },
+  origin: 1,
+  source: 'public',
+  placementSchema: {
+    modes: ['single-region', 'active-active', 'active-hotstandby'],
+    default: 'active-hotstandby',
+    minRegions: 2,
+    maxRegions: 5,
+  },
+  raw: {
+    spec: {
+      version: '1.2.3',
+      configSchema: { type: 'object', properties: {} },
+      placementSchema: {
+        modes: ['single-region', 'active-active', 'active-hotstandby'],
+        default: 'active-hotstandby',
+      },
+    },
+  },
+}
+
+const APP_STATUS = {
+  name: APP_NAME,
+  namespace: NAMESPACE,
+  phase: 'Ready',
+  spec: {
+    blueprintRef: { name: 'bp-wordpress', version: '1.2.3' },
+    parameters: { domain: 'shop.acme.com' },
+    placement: 'active-hotstandby',
+    regions: ['hz-fsn-rtz-prod', 'hz-hel-rtz-prod'],
+    environmentRef: 'acme-prod',
+  },
+  status: {
+    phase: 'Ready',
+    regions: [
+      { name: 'hz-fsn-rtz-prod', role: 'primary', replicas: 2, ready: 2, lastTransitionTime: '2026-05-08T12:00:00Z' },
+      { name: 'hz-hel-rtz-prod', role: 'standby', replicas: 2, ready: 2, lastTransitionTime: '2026-05-08T12:00:00Z' },
+    ],
+  },
+}
+
+function continuumStatusBody(opts: { switchingOver?: boolean; switchoverStep?: string; lagSec?: number; lastResult?: string } = {}) {
+  return {
+    name: CONTINUUM_NAME,
+    namespace: NAMESPACE,
+    uid: 'uid-test',
+    spec: {
+      applicationRef: APP_NAME,
+      primaryRegion: 'hz-fsn-rtz-prod',
+      hotStandbyRegions: ['hz-hel-rtz-prod'],
+      leaseClient: { kind: 'cloudflare-kv' },
+    },
+    status: {
+      phase: opts.switchingOver ? 'SwitchingOver' : 'Healthy',
+      primaryRegion: 'hz-fsn-rtz-prod',
+      leaseHolder: 'hz-fsn-rtz-prod',
+      replicationLagSeconds: opts.lagSec ?? 12,
+      switchoverInProgress: !!opts.switchingOver,
+      switchoverStep: opts.switchoverStep ?? '',
+      lastSwitchover: opts.lastResult
+        ? { result: opts.lastResult, from: 'hz-fsn-rtz-prod', to: 'hz-hel-rtz-prod', at: '2026-05-08T14:23:11Z' }
+        : undefined,
+    },
+  }
+}
+
+function continuumAuditBody(extras: Array<{ auditType: string; ts: string; detail: string; actor?: string }> = []) {
+  const base = [
+    {
+      auditType: 'continuum-switchover',
+      ts: '2026-05-08T14:23:11Z',
+      sovereignId: DEPLOYMENT_ID,
+      actor: 'owner@acme.io',
+      targetApp: APP_NAME,
+      detail: 'switchover requested: hz-fsn-rtz-prod → hz-hel-rtz-prod (reason: drill)',
+      result: 'ok',
+    },
+    {
+      auditType: 'continuum-cnpg-promotable',
+      ts: '2026-05-08T14:23:09Z',
+      sovereignId: DEPLOYMENT_ID,
+      targetApp: APP_NAME,
+      detail: 'standby promotable; lag=4s',
+    },
+    {
+      auditType: 'continuum-lease-acquired',
+      ts: '2026-05-08T14:23:13Z',
+      sovereignId: DEPLOYMENT_ID,
+      targetApp: APP_NAME,
+      detail: 'acquired lease for region hz-hel-rtz-prod',
+    },
+  ]
+  return { items: [...extras, ...base], total: base.length + extras.length }
+}
+
+async function mockDRApi(page: Page, opts: { continuumStatus?: ReturnType<typeof continuumStatusBody>; switchoverPostHook?: () => void } = {}) {
+  const continuumBody = opts.continuumStatus ?? continuumStatusBody()
+
+  // Auth + self stubs.
+  await page.route(/.*\/api\/v1\/sovereign\/self$/, (route: Route) => {
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ deploymentId: DEPLOYMENT_ID, sovereignFQDN: 'dr.example' }),
+    })
+  })
+  await page.route(/.*\/api\/v1\/whoami$/, (route: Route) => {
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ sub: 'owner', email: 'owner@acme.io', tier: 'owner' }),
+    })
+  })
+  await page.route(/.*\/api\/v1\/deployments\/[^/]+$/, (route: Route) => {
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ deploymentId: DEPLOYMENT_ID }),
+    })
+  })
+
+  // Catalog endpoints.
+  await page.route(/.*\/api\/v1\/catalog\/bp-wordpress$/, (route: Route) => {
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(HOTSTANDBY_BP) })
+  })
+  await page.route(/.*\/api\/v1\/catalog\/bp-wordpress\/versions$/, (route: Route) => {
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ name: 'bp-wordpress', versions: [{ version: '1.2.3', origin: 'public' }], upgradeMatrix: {} }),
+    })
+  })
+  await page.route(/.*\/api\/v1\/catalog\/bp-wordpress\/versions\/[^/]+$/, (route: Route) => {
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(HOTSTANDBY_BP) })
+  })
+
+  // Application status — placement = active-hotstandby so DRSection renders.
+  await page.route(/.*\/api\/v1\/sovereigns\/[^/]+\/applications\/wp-prod\/status.*$/, (route: Route) => {
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(APP_STATUS) })
+  })
+
+  // Continuum endpoints.
+  await page.route(/.*\/api\/v1\/sovereigns\/[^/]+\/continuums\/dr-wp-prod(\?.*)?$/, (route: Route) => {
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(continuumBody) })
+  })
+  await page.route(/.*\/api\/v1\/sovereigns\/[^/]+\/continuums\/dr-wp-prod\/switchover(\?.*)?$/, (route: Route) => {
+    if (opts.switchoverPostHook) opts.switchoverPostHook()
+    route.fulfill({
+      status: 202,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        name: CONTINUUM_NAME,
+        namespace: NAMESPACE,
+        targetRegion: 'hz-hel-rtz-prod',
+        requestedAt: '2026-05-09T10:30:00Z',
+        requestedBy: 'owner@acme.io',
+        message: 'switchover requested',
+      }),
+    })
+  })
+  await page.route(/.*\/api\/v1\/sovereigns\/[^/]+\/audit\/continuum(\?.*)?$/, (route: Route) => {
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(continuumAuditBody()) })
+  })
+
+  // Compliance / RBAC stubs that the AppDetail page brings up.
+  await page.route(/.*\/api\/v1\/sovereigns\/[^/]+\/compliance\/.*$/, (route: Route) => {
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ items: [], applications: [] }) })
+  })
+  await page.route(/.*\/api\/v1\/sovereigns\/[^/]+\/rbac\/access-matrix.*$/, (route: Route) => {
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ users: [], applications: [], tiers: ['viewer', 'developer', 'operator', 'admin', 'owner'] }),
+    })
+  })
+  await page.route(/.*\/api\/v1\/sovereigns\/[^/]+\/clusters$/, (route: Route) => {
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ clusters: ['hz-fsn-rtz-prod', 'hz-hel-rtz-prod'] }) })
+  })
+}
+
+test.describe('Continuum DR section (slice U-DR-1, #1101)', () => {
+  test.use({ viewport: { width: 1440, height: 900 } })
+
+  test('DR1: DR section renders + status panel populated', async ({ page }) => {
+    await mockDRApi(page)
+    await page.goto(`/provision/${DEPLOYMENT_ID}/app/${APP_NAME}`)
+    await page.getByTestId('sov-app-tab-topology').click()
+    await expect(page.getByTestId('continuum-dr-section')).toBeVisible()
+    await expect(page.getByTestId('continuum-status-panel')).toBeVisible()
+    await expect(page.getByTestId('continuum-status-phase-Healthy')).toBeVisible()
+    await expect(page.getByTestId('continuum-status-lag-bucket-green')).toBeVisible()
+    await page.screenshot({ path: 'test-results/continuum-dr-section/DR1-status-panel.png', fullPage: true })
+  })
+
+  test('DR2: Switchover dialog opens + 7 steps + cancel', async ({ page }) => {
+    await mockDRApi(page)
+    await page.goto(`/provision/${DEPLOYMENT_ID}/app/${APP_NAME}`)
+    await page.getByTestId('sov-app-tab-topology').click()
+    await page.getByTestId('continuum-dr-switchover-btn').click()
+    await expect(page.getByTestId('continuum-switchover-dialog')).toBeVisible()
+    for (let i = 1; i <= 7; i++) {
+      await expect(page.getByTestId(`continuum-switchover-dialog-step-${i}`)).toBeVisible()
+    }
+    await page.screenshot({ path: 'test-results/continuum-dr-section/DR2-dialog-open.png', fullPage: true })
+    await page.getByTestId('continuum-switchover-dialog-cancel').click()
+    await expect(page.getByTestId('continuum-switchover-dialog')).toBeHidden()
+  })
+
+  test('DR3: Switchover confirm POSTs to /continuums/{name}/switchover', async ({ page }) => {
+    let posted = false
+    await mockDRApi(page, { switchoverPostHook: () => { posted = true } })
+    await page.goto(`/provision/${DEPLOYMENT_ID}/app/${APP_NAME}`)
+    await page.getByTestId('sov-app-tab-topology').click()
+    await page.getByTestId('continuum-dr-switchover-btn').click()
+    await page.getByTestId('continuum-switchover-dialog-reason').fill('e2e-test')
+    await page.getByTestId('continuum-switchover-dialog-confirm').click()
+    await expect(page.getByTestId('continuum-switchover-dialog')).toBeHidden({ timeout: 5000 })
+    expect(posted).toBe(true)
+    await page.screenshot({ path: 'test-results/continuum-dr-section/DR3-confirm-posted.png', fullPage: true })
+  })
+
+  test('DR4: live progress widget renders when status reports SwitchingOver', async ({ page }) => {
+    await mockDRApi(page, {
+      continuumStatus: continuumStatusBody({ switchingOver: true, switchoverStep: 'step 3/7 — drain-http' }),
+    })
+    await page.goto(`/provision/${DEPLOYMENT_ID}/app/${APP_NAME}`)
+    await page.getByTestId('sov-app-tab-topology').click()
+    await expect(page.getByTestId('continuum-status-switching-over')).toBeVisible()
+    const stepText = await page.getByTestId('continuum-status-switching-over-step').textContent()
+    expect(stepText).toContain('3/7')
+    expect(stepText).toContain('drain-http')
+    await page.screenshot({ path: 'test-results/continuum-dr-section/DR4-switching-over.png', fullPage: true })
+  })
+
+  test('DR5: Switchover history table + detail modal', async ({ page }) => {
+    await mockDRApi(page)
+    await page.goto(`/provision/${DEPLOYMENT_ID}/app/${APP_NAME}`)
+    await page.getByTestId('sov-app-tab-topology').click()
+    await expect(page.getByTestId('continuum-history')).toBeVisible()
+    await expect(page.getByTestId('continuum-history-row-0')).toBeVisible()
+    await page.getByTestId('continuum-history-row-0').click()
+    await expect(page.getByTestId('continuum-history-modal')).toBeVisible()
+    await expect(page.getByTestId('continuum-history-modal-step-0')).toBeVisible()
+    await page.screenshot({ path: 'test-results/continuum-dr-section/DR5-history-modal.png', fullPage: true })
+  })
+
+  test('DR6: Failback panel surfaces when LastSwitchoverResult=Success', async ({ page }) => {
+    await mockDRApi(page, {
+      continuumStatus: continuumStatusBody({ lastResult: 'Success' }),
+    })
+    await page.goto(`/provision/${DEPLOYMENT_ID}/app/${APP_NAME}`)
+    await page.getByTestId('sov-app-tab-topology').click()
+    await expect(page.getByTestId('continuum-failback-panel')).toBeVisible()
+    await expect(page.getByTestId('continuum-failback-request-btn')).toBeVisible()
+    await page.screenshot({ path: 'test-results/continuum-dr-section/DR6-failback-panel.png', fullPage: true })
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/lib/continuum.api.ts
+++ b/products/catalyst/bootstrap/ui/src/lib/continuum.api.ts
@@ -1,0 +1,329 @@
+/**
+ * continuum.api.ts — typed REST client wrappers for the EPIC-6 Slice
+ * U-DR-1 (#1101) Continuum DR endpoints on catalyst-api.
+ *
+ * Wire path:
+ *
+ *   browser ──/api/v1/sovereigns/{id}/continuums/...──▶ catalyst-api
+ *
+ * The handlers patch the Continuum CR's spec — the K-Cont-2 reconciler
+ * (the per-CR goroutine in core/controllers/continuum) observes the
+ * change on its next loop iteration and either runs the 7-step
+ * Sequencer (switchover / failback) or waits for the failback approval
+ * gate.
+ *
+ * Per docs/INVIOLABLE-PRINCIPLES.md #4 every URL derives from
+ * `API_BASE` so the contabo strip-sovereign / direct-Sovereign
+ * distinction is resolved at config-time, not in components.
+ */
+
+import { API_BASE } from '@/shared/config/urls'
+import { authedFetch } from '@/shared/lib/authedFetch'
+
+/* ── Wire types ──────────────────────────────────────────────────── */
+
+/** ContinuumGetResponse — body of GET /continuums/{name}. */
+export interface ContinuumGetResponse {
+  name: string
+  namespace: string
+  uid: string
+  spec?: Record<string, unknown>
+  status?: Record<string, unknown>
+}
+
+/** ContinuumSwitchoverRequest — body of POST .../switchover. */
+export interface ContinuumSwitchoverRequest {
+  targetRegion: string
+  reason?: string
+}
+
+/** ContinuumSwitchoverResponse — 202 Accepted body. */
+export interface ContinuumSwitchoverResponse {
+  name: string
+  namespace: string
+  targetRegion: string
+  reason?: string
+  requestedAt: string
+  requestedBy?: string
+  message: string
+}
+
+/** ContinuumFailbackRequest — body of POST .../failback. */
+export interface ContinuumFailbackRequest {
+  reason?: string
+}
+
+/** ContinuumFailbackResponse — 202 Accepted body. */
+export interface ContinuumFailbackResponse {
+  name: string
+  namespace: string
+  requestedAt: string
+  requestedBy?: string
+  approvalRequired: boolean
+  message: string
+}
+
+/** ContinuumFailbackApproveResponse — 202 Accepted body. */
+export interface ContinuumFailbackApproveResponse {
+  name: string
+  namespace: string
+  approvedAt: string
+  approvedBy?: string
+  message: string
+}
+
+/**
+ * ContinuumAuditEvent — one row from the audit ring buffer / SSE
+ * stream. Mirrors `audit.Event` in the catalyst-api package — the
+ * superset shape every audit-type populates only the fields it owns.
+ */
+export interface ContinuumAuditEvent {
+  auditType: string
+  ts: string
+  actor?: string
+  sovereignId?: string
+  result?: string
+  targetUser?: string
+  targetUserEmail?: string
+  targetApp?: string
+  tier?: string
+  detail?: string
+  // Continuum events tag these via the superset shape's free fields.
+  // The reconciler (K-Cont-2) emits its 9 reserved types via
+  // `core/controllers/continuum/internal/events.Event` — that struct
+  // serializes as a separate body shape (`type`, `continuumName`,
+  // `fromPrimary`, `toPrimary`, `lagSeconds`, `step`) on the NATS
+  // subject; the handler-side audit Bus exposes its `audit.Event`
+  // shape. The bridge is up to the future NATS forwarder; for the
+  // initial UI we render off the REST handler's catalyst-api side
+  // shape which already carries `auditType` + `actor` + `detail`.
+}
+
+export interface ContinuumAuditListResponse {
+  items: ContinuumAuditEvent[]
+  nextOffset?: number
+  total: number
+}
+
+/* ── Endpoint helpers ────────────────────────────────────────────── */
+
+function continuumsBase(sovereignId: string): string {
+  return `${API_BASE}/v1/sovereigns/${encodeURIComponent(sovereignId)}/continuums`
+}
+
+function auditBase(sovereignId: string): string {
+  return `${API_BASE}/v1/sovereigns/${encodeURIComponent(sovereignId)}/audit`
+}
+
+/* ── REST calls ──────────────────────────────────────────────────── */
+
+export async function getContinuum(
+  sovereignId: string,
+  name: string,
+  opts: { namespace?: string } = {},
+): Promise<ContinuumGetResponse> {
+  const params = new URLSearchParams()
+  if (opts.namespace) params.set('namespace', opts.namespace)
+  const qs = params.toString()
+  const url = `${continuumsBase(sovereignId)}/${encodeURIComponent(name)}${qs ? '?' + qs : ''}`
+  const res = await authedFetch(url, { headers: { Accept: 'application/json' } })
+  if (!res.ok) {
+    throw new Error(`continuum get: HTTP ${res.status}`)
+  }
+  return res.json()
+}
+
+export async function requestSwitchover(
+  sovereignId: string,
+  name: string,
+  body: ContinuumSwitchoverRequest,
+  opts: { namespace?: string } = {},
+): Promise<ContinuumSwitchoverResponse> {
+  const params = new URLSearchParams()
+  if (opts.namespace) params.set('namespace', opts.namespace)
+  const qs = params.toString()
+  const url = `${continuumsBase(sovereignId)}/${encodeURIComponent(name)}/switchover${qs ? '?' + qs : ''}`
+  const res = await authedFetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+    body: JSON.stringify(body),
+  })
+  if (!res.ok) {
+    const detail = await res.text().catch(() => '')
+    throw new Error(`switchover: HTTP ${res.status} ${detail}`)
+  }
+  return res.json()
+}
+
+export async function requestFailback(
+  sovereignId: string,
+  name: string,
+  body: ContinuumFailbackRequest = {},
+  opts: { namespace?: string } = {},
+): Promise<ContinuumFailbackResponse> {
+  const params = new URLSearchParams()
+  if (opts.namespace) params.set('namespace', opts.namespace)
+  const qs = params.toString()
+  const url = `${continuumsBase(sovereignId)}/${encodeURIComponent(name)}/failback${qs ? '?' + qs : ''}`
+  const res = await authedFetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+    body: JSON.stringify(body),
+  })
+  if (!res.ok) {
+    const detail = await res.text().catch(() => '')
+    throw new Error(`failback: HTTP ${res.status} ${detail}`)
+  }
+  return res.json()
+}
+
+export async function approveFailback(
+  sovereignId: string,
+  name: string,
+  opts: { namespace?: string } = {},
+): Promise<ContinuumFailbackApproveResponse> {
+  const params = new URLSearchParams()
+  if (opts.namespace) params.set('namespace', opts.namespace)
+  const qs = params.toString()
+  const url = `${continuumsBase(sovereignId)}/${encodeURIComponent(name)}/failback/approve${qs ? '?' + qs : ''}`
+  const res = await authedFetch(url, {
+    method: 'POST',
+    headers: { Accept: 'application/json' },
+  })
+  if (!res.ok) {
+    const detail = await res.text().catch(() => '')
+    throw new Error(`approve-failback: HTTP ${res.status} ${detail}`)
+  }
+  return res.json()
+}
+
+export async function listContinuumAudit(
+  sovereignId: string,
+  opts: { limit?: number; offset?: number; type?: string; actor?: string; since?: string } = {},
+): Promise<ContinuumAuditListResponse> {
+  const params = new URLSearchParams()
+  if (opts.limit) params.set('limit', String(opts.limit))
+  if (opts.offset) params.set('offset', String(opts.offset))
+  if (opts.type) params.set('type', opts.type)
+  if (opts.actor) params.set('actor', opts.actor)
+  if (opts.since) params.set('since', opts.since)
+  const qs = params.toString()
+  const url = `${auditBase(sovereignId)}/continuum${qs ? '?' + qs : ''}`
+  const res = await authedFetch(url, { headers: { Accept: 'application/json' } })
+  if (!res.ok) {
+    throw new Error(`continuum audit list: HTTP ${res.status}`)
+  }
+  return res.json()
+}
+
+/**
+ * continuumAuditStreamURL — SSE endpoint for live audit events. Mirrors
+ * `applicationStreamURL` from catalog.api: when an access_token is
+ * supplied it's stamped on the query string for the EventSource (which
+ * cannot send Authorization headers) — same pattern slice U5-U8 uses
+ * for /audit/rbac/stream.
+ */
+export function continuumAuditStreamURL(sovereignId: string, accessToken?: string): string {
+  const params = new URLSearchParams()
+  if (accessToken) params.set('access_token', accessToken)
+  const qs = params.toString()
+  return `${auditBase(sovereignId)}/continuum/stream${qs ? '?' + qs : ''}`
+}
+
+/* ── Switchover step constants ───────────────────────────────────── */
+
+/**
+ * SWITCHOVER_STEPS — 7-step sequence shipped by the K-Cont-2
+ * Sequencer (`core/controllers/continuum/internal/switchover/sequence.go`).
+ * The names below MUST stay in lock-step with the Sequencer's `name:`
+ * fields — the SwitchoverDialog renders them so the operator sees
+ * exactly what the Sequencer will execute.
+ *
+ * Per the brief these are hardcoded here (the alternative — pulling
+ * them from a /continuums/{name}/steps endpoint — adds an extra round
+ * trip with no payoff; the reconciler's step names are a stable
+ * contract per K-Cont-2).
+ */
+export const SWITCHOVER_STEPS: { id: number; name: string; description: string }[] = [
+  {
+    id: 1,
+    name: 'validate-lease',
+    description: 'Validate the witness lease holder is the current primary (or quorum allows takeover).',
+  },
+  {
+    id: 2,
+    name: 'cordon-old-primary',
+    description: 'Annotate the old primary CNPG Cluster CR to demote it; CNPG operator stops accepting writes.',
+  },
+  {
+    id: 3,
+    name: 'drain-http',
+    description: 'Set Cilium HTTPRoute weight to 0 toward the old primary; in-flight traffic drains over a short window.',
+  },
+  {
+    id: 4,
+    name: 'flip-dns',
+    description: 'Flip the lua-record probe target to the new primary via PowerDNS Manager (low-TTL DNS, ~5s).',
+  },
+  {
+    id: 5,
+    name: 'swap-lease',
+    description: 'Release the lease on the old primary; acquire it on the new primary.',
+  },
+  {
+    id: 6,
+    name: 'uncordon-new-primary',
+    description: 'Clear the demotion annotation; flip CNPG replica.enabled flags so the new primary stops following WAL.',
+  },
+  {
+    id: 7,
+    name: 'audit-emit',
+    description: 'Emit `continuum-switchover` audit event on the catalyst.audit JetStream subject.',
+  },
+]
+
+/* ── Helpers ──────────────────────────────────────────────────────── */
+
+/**
+ * parseLagSeconds — Continuum status surfaces `replicationLagSeconds`
+ * as int64 (number) but legacy paths may carry a duration string;
+ * accept both.
+ */
+export function parseLagSeconds(value: unknown): number | null {
+  if (value == null) return null
+  if (typeof value === 'number' && Number.isFinite(value)) return value
+  if (typeof value === 'string') {
+    const trimmed = value.trim()
+    if (trimmed === '') return null
+    const n = Number(trimmed)
+    if (Number.isFinite(n)) return n
+    // Try `Ns` / `Nm` shape used by older payloads.
+    const m = /^(\d+)(s|m|h)$/.exec(trimmed)
+    if (m) {
+      const n = Number(m[1])
+      switch (m[2]) {
+        case 's':
+          return n
+        case 'm':
+          return n * 60
+        case 'h':
+          return n * 3600
+      }
+    }
+  }
+  return null
+}
+
+/**
+ * lagBucket — bucketizes lag seconds for the StatusPanel's progress
+ * bar color. Thresholds per the brief: green <30s, yellow 30-60s,
+ * red >60s.
+ */
+export type LagBucket = 'green' | 'yellow' | 'red' | 'unknown'
+
+export function lagBucket(lag: number | null): LagBucket {
+  if (lag == null) return 'unknown'
+  if (lag < 30) return 'green'
+  if (lag <= 60) return 'yellow'
+  return 'red'
+}

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/TopologyTab.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/TopologyTab.tsx
@@ -28,6 +28,7 @@ import {
   type CatalogItem,
 } from '@/lib/catalog.api'
 import { TopologyEditor } from '@/widgets/topology/TopologyEditor'
+import { DRSection } from '@/widgets/continuum/DRSection'
 
 export interface TopologyTabProps {
   /** Sovereign id (deploymentId on chroot, mother). */
@@ -40,6 +41,10 @@ export interface TopologyTabProps {
   initialApp?: ApplicationStatus
   /** Test seam — bypass apply network call. */
   disableNetwork?: boolean
+  /** Caller's tier (slice U-DR-1) — controls render of switchover/failback buttons. */
+  callerTier?: string
+  /** Continuum CR name (slice U-DR-1) — when omitted, derived as `dr-<applicationName>`. */
+  continuumName?: string
 }
 
 interface ApplicationStatus {
@@ -71,6 +76,8 @@ export function TopologyTab({
   namespace,
   initialApp,
   disableNetwork = false,
+  callerTier,
+  continuumName,
 }: TopologyTabProps) {
   const qc = useQueryClient()
   const [refreshTick, setRefreshTick] = useState(0)
@@ -225,6 +232,21 @@ export function TopologyTab({
           </div>
         </div>
       </div>
+
+      {/* EPIC-6 Slice U-DR-1 (#1101) — DR section. Visible only when
+          the Application's placement is active-hotstandby. Composes the
+          live Continuum status, switchover button, failback panel, and
+          switchover history. */}
+      {currentMode === 'active-hotstandby' ? (
+        <DRSection
+          sovereignId={sovereignId}
+          continuumName={continuumName ?? `dr-${applicationName}`}
+          applicationName={applicationName}
+          namespace={namespace}
+          callerTier={callerTier}
+          disableNetwork={disableNetwork}
+        />
+      ) : null}
     </div>
   )
 }

--- a/products/catalyst/bootstrap/ui/src/widgets/continuum/DRSection.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/widgets/continuum/DRSection.test.tsx
@@ -1,0 +1,144 @@
+/**
+ * DRSection.test.tsx — Vitest unit tests for the EPIC-6 Slice U-DR-1
+ * (#1101) DR section orchestrator. Uses the initialContinuum +
+ * disableNetwork test seams to render without a real fetch.
+ */
+import { describe, it, expect, afterEach } from 'vitest'
+import { render, screen, cleanup, fireEvent } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+import { DRSection } from './DRSection'
+import type { ContinuumGetResponse } from '@/lib/continuum.api'
+
+function withProviders(node: React.ReactNode) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return <QueryClientProvider client={qc}>{node}</QueryClientProvider>
+}
+
+afterEach(() => cleanup())
+
+const sampleCR: ContinuumGetResponse = {
+  name: 'dr-wp',
+  namespace: 'acme',
+  uid: 'uid-1',
+  spec: {
+    applicationRef: 'wp-prod',
+    primaryRegion: 'hz-fsn-rtz-prod',
+    hotStandbyRegions: ['hz-hel-rtz-prod'],
+    leaseClient: { kind: 'cloudflare-kv' },
+  },
+  status: {
+    phase: 'Healthy',
+    primaryRegion: 'hz-fsn-rtz-prod',
+    leaseHolder: 'hz-fsn-rtz-prod',
+    replicationLagSeconds: 12,
+  },
+}
+
+describe('DRSection', () => {
+  it('renders the DR header + status panel from initialContinuum', () => {
+    render(
+      withProviders(
+        <DRSection
+          sovereignId="dep-1"
+          continuumName="dr-wp"
+          applicationName="wp-prod"
+          callerTier="owner"
+          initialContinuum={sampleCR}
+          disableNetwork
+        />,
+      ),
+    )
+    expect(screen.getByTestId('continuum-dr-section')).toBeTruthy()
+    expect(screen.getByTestId('continuum-status-panel')).toBeTruthy()
+  })
+
+  it('shows the Switchover button for owner tier with a hot-standby target', () => {
+    render(
+      withProviders(
+        <DRSection
+          sovereignId="dep-1"
+          continuumName="dr-wp"
+          applicationName="wp-prod"
+          callerTier="owner"
+          initialContinuum={sampleCR}
+          disableNetwork
+        />,
+      ),
+    )
+    expect(screen.getByTestId('continuum-dr-switchover-btn')).toBeTruthy()
+  })
+
+  it('hides the Switchover button for viewer tier', () => {
+    render(
+      withProviders(
+        <DRSection
+          sovereignId="dep-1"
+          continuumName="dr-wp"
+          applicationName="wp-prod"
+          callerTier="viewer"
+          initialContinuum={sampleCR}
+          disableNetwork
+        />,
+      ),
+    )
+    expect(screen.queryByTestId('continuum-dr-switchover-btn')).toBeNull()
+    expect(screen.getByTestId('continuum-dr-switchover-disabled')).toBeTruthy()
+  })
+
+  it('clicking Switchover opens the SwitchoverDialog', () => {
+    render(
+      withProviders(
+        <DRSection
+          sovereignId="dep-1"
+          continuumName="dr-wp"
+          applicationName="wp-prod"
+          callerTier="owner"
+          initialContinuum={sampleCR}
+          disableNetwork
+        />,
+      ),
+    )
+    fireEvent.click(screen.getByTestId('continuum-dr-switchover-btn'))
+    expect(screen.getByTestId('continuum-switchover-dialog')).toBeTruthy()
+  })
+
+  it('renders the Failback panel when the last switchover succeeded', () => {
+    const cr: ContinuumGetResponse = {
+      ...sampleCR,
+      status: {
+        ...sampleCR.status,
+        lastSwitchover: { result: 'Success', from: 'a', to: 'b', at: '2026-05-08T14:23:11Z' },
+      },
+    }
+    render(
+      withProviders(
+        <DRSection
+          sovereignId="dep-1"
+          continuumName="dr-wp"
+          applicationName="wp-prod"
+          callerTier="owner"
+          initialContinuum={cr}
+          disableNetwork
+        />,
+      ),
+    )
+    expect(screen.getByTestId('continuum-failback-panel')).toBeTruthy()
+  })
+
+  it('renders the lua-record view collapsed', () => {
+    render(
+      withProviders(
+        <DRSection
+          sovereignId="dep-1"
+          continuumName="dr-wp"
+          applicationName="wp-prod"
+          callerTier="owner"
+          initialContinuum={sampleCR}
+          disableNetwork
+        />,
+      ),
+    )
+    expect(screen.getByTestId('continuum-lua-view')).toBeTruthy()
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/widgets/continuum/DRSection.tsx
+++ b/products/catalyst/bootstrap/ui/src/widgets/continuum/DRSection.tsx
@@ -1,0 +1,224 @@
+/**
+ * DRSection — EPIC-6 Slice U-DR-1 (#1101).
+ *
+ * Composite Disaster-Recovery section embedded in the AppDetail
+ * Topology tab when the Application's placement is `active-hotstandby`.
+ * Composes:
+ *
+ *   - StatusPanel (live phase / lease / lag / switchover-in-progress)
+ *   - LuaRecordView (read-only PowerDNS lua-record body)
+ *   - "Switchover…" button → SwitchoverDialog
+ *   - FailbackPanel (rendered when LastSwitchoverResult = Success)
+ *   - SwitchoverHistory (audit-event table from /audit/continuum)
+ *
+ * Wires data via React Query: GET /continuums/{name} polled every 10s
+ * for spec/status, and GET /audit/continuum polled every 15s for
+ * history (the SSE stream is wired only in production; for the test
+ * + initial-render-fast path the polling fallback is sufficient and
+ * keeps the dependency surface minimal — slice F-2 may layer SSE on
+ * top via the same handler endpoint).
+ *
+ * Per docs/INVIOLABLE-PRINCIPLES.md #4 every URL derives from
+ * `API_BASE` via the continuum.api helpers. Per #5 the underlying
+ * handlers enforce tier server-side; the widget uses the caller's
+ * Claims tier to render-or-hide entry-points.
+ */
+
+import { useMemo, useState } from 'react'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+
+import {
+  getContinuum,
+  listContinuumAudit,
+  type ContinuumGetResponse,
+} from '@/lib/continuum.api'
+import { FailbackPanel } from './FailbackPanel'
+import { LuaRecordView } from './LuaRecordView'
+import { StatusPanel } from './StatusPanel'
+import { SwitchoverDialog } from './SwitchoverDialog'
+import { SwitchoverHistory } from './SwitchoverHistory'
+
+export interface DRSectionProps {
+  /** Sovereign id (deploymentId on chroot, mother). */
+  sovereignId: string
+  /** Continuum CR name — the AppDetail page derives this from the
+   *  Application name (typical convention: `dr-<app>` or matching
+   *  Application metadata.name). The parent passes whichever the
+   *  Application controller created. */
+  continuumName: string
+  /** Application name surfaced in headings + audit filtering. */
+  applicationName: string
+  /** Org namespace. */
+  namespace?: string
+  /** Caller's tier — controls render of switchover/failback/approve buttons. */
+  callerTier?: string
+  /** Test seam — pre-fill the Continuum CR + audit list, skip network. */
+  initialContinuum?: ContinuumGetResponse
+  /** Test seam — bypass the audit fetch + network calls. */
+  disableNetwork?: boolean
+}
+
+export function DRSection({
+  sovereignId,
+  continuumName,
+  applicationName,
+  namespace,
+  callerTier,
+  initialContinuum,
+  disableNetwork = false,
+}: DRSectionProps) {
+  const qc = useQueryClient()
+  const [showSwitchover, setShowSwitchover] = useState(false)
+
+  const continuumQ = useQuery({
+    queryKey: ['continuum', sovereignId, continuumName, namespace],
+    queryFn: () => getContinuum(sovereignId, continuumName, { namespace }),
+    enabled: !initialContinuum && !disableNetwork && !!sovereignId && !!continuumName,
+    refetchInterval: 10_000,
+  })
+
+  const auditQ = useQuery({
+    queryKey: ['continuum-audit', sovereignId, applicationName],
+    queryFn: () => listContinuumAudit(sovereignId, { limit: 100 }),
+    enabled: !disableNetwork && !!sovereignId,
+    refetchInterval: 15_000,
+  })
+
+  const cr: ContinuumGetResponse | undefined = initialContinuum ?? continuumQ.data
+  const spec = (cr?.spec ?? {}) as Record<string, unknown>
+  const status = (cr?.status ?? {}) as Record<string, unknown>
+
+  const primaryRegion = useMemo(() => {
+    const fromStatus = status['primaryRegion'] as string | undefined
+    if (fromStatus) return fromStatus
+    return (spec['primaryRegion'] as string | undefined) ?? ''
+  }, [spec, status])
+
+  const hotStandbys = useMemo(() => {
+    const arr = spec['hotStandbyRegions']
+    return Array.isArray(arr) ? (arr as string[]) : []
+  }, [spec])
+
+  const failoverTarget = useMemo(() => {
+    for (const r of hotStandbys) {
+      if (r !== primaryRegion) return r
+    }
+    return ''
+  }, [hotStandbys, primaryRegion])
+
+  const failbackSpec = (spec['failback'] as Record<string, unknown> | undefined) ?? {}
+  const failbackRequested = Boolean(failbackSpec['requested'] ?? false)
+  const failbackApproved = Boolean(failbackSpec['approved'] ?? false)
+  const approvalRequired = Boolean(failbackSpec['approvalRequired'] ?? false)
+
+  const lastSwitchover = (status['lastSwitchover'] as Record<string, unknown> | undefined) ?? undefined
+  const lastResult = lastSwitchover ? (lastSwitchover['result'] as string | undefined) : undefined
+
+  const tier = (callerTier ?? '').toLowerCase()
+  const isOwner = tier === 'owner' || tier === 'admin'
+  const isSovereignAdmin = tier === 'admin' || tier === 'owner'
+
+  return (
+    <section
+      className="continuum-dr-section mt-6 rounded-md border border-[var(--color-border)] bg-[var(--color-bg)] p-4"
+      data-testid="continuum-dr-section"
+    >
+      <div className="mb-3 flex items-baseline justify-between">
+        <h3 className="text-sm font-semibold text-[var(--color-text-strong)]">
+          Disaster Recovery (active-hotstandby)
+        </h3>
+        {isOwner && failoverTarget ? (
+          <button
+            type="button"
+            data-testid="continuum-dr-switchover-btn"
+            className="rounded-md border border-[var(--color-accent)] bg-[var(--color-accent)] px-3 py-1.5 text-xs text-[var(--color-bg)] hover:opacity-90"
+            onClick={() => setShowSwitchover(true)}
+          >
+            Switchover…
+          </button>
+        ) : !isOwner ? (
+          <span
+            data-testid="continuum-dr-switchover-disabled"
+            className="text-xs text-[var(--color-text-dim)]"
+          >
+            Owner tier required to switchover
+          </span>
+        ) : (
+          <span
+            data-testid="continuum-dr-switchover-no-target"
+            className="text-xs text-[var(--color-text-dim)]"
+          >
+            No standby region available
+          </span>
+        )}
+      </div>
+
+      {!cr ? (
+        <p
+          data-testid="continuum-dr-loading"
+          className="text-xs text-[var(--color-text-dim)]"
+        >
+          Loading Continuum status…
+        </p>
+      ) : (
+        <>
+          <StatusPanel
+            status={status}
+            primaryRegion={primaryRegion}
+            hotStandbyRegions={hotStandbys}
+          />
+
+          <div className="mt-4">
+            <LuaRecordView status={status} />
+          </div>
+
+          {lastResult === 'Success' || failbackRequested ? (
+            <div className="mt-4">
+              <FailbackPanel
+                sovereignId={sovereignId}
+                continuumName={continuumName}
+                namespace={namespace}
+                isOwner={isOwner}
+                isSovereignAdmin={isSovereignAdmin}
+                approvalRequired={approvalRequired}
+                failbackRequested={failbackRequested}
+                failbackApproved={failbackApproved}
+                disableNetwork={disableNetwork}
+                onChanged={() => {
+                  void qc.invalidateQueries({ queryKey: ['continuum', sovereignId, continuumName] })
+                }}
+              />
+            </div>
+          ) : null}
+
+          <div className="mt-4">
+            <h4 className="mb-2 text-xs font-semibold uppercase tracking-wide text-[var(--color-text-dim)]">
+              Switchover history
+            </h4>
+            <SwitchoverHistory
+              events={auditQ.data?.items ?? []}
+              applicationName={applicationName}
+            />
+          </div>
+        </>
+      )}
+
+      {showSwitchover && failoverTarget ? (
+        <SwitchoverDialog
+          sovereignId={sovereignId}
+          continuumName={continuumName}
+          namespace={namespace}
+          fromRegion={primaryRegion}
+          toRegion={failoverTarget}
+          applicationName={applicationName}
+          disableNetwork={disableNetwork}
+          onClose={() => setShowSwitchover(false)}
+          onConfirmed={() => {
+            void qc.invalidateQueries({ queryKey: ['continuum', sovereignId, continuumName] })
+            void qc.invalidateQueries({ queryKey: ['continuum-audit', sovereignId] })
+          }}
+        />
+      ) : null}
+    </section>
+  )
+}

--- a/products/catalyst/bootstrap/ui/src/widgets/continuum/FailbackPanel.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/widgets/continuum/FailbackPanel.test.tsx
@@ -1,0 +1,129 @@
+/**
+ * FailbackPanel.test.tsx — Vitest unit tests for the EPIC-6 Slice
+ * U-DR-1 (#1101) failback handler UI.
+ */
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { render, screen, cleanup, fireEvent } from '@testing-library/react'
+
+import { FailbackPanel } from './FailbackPanel'
+
+afterEach(() => cleanup())
+
+describe('FailbackPanel — gating', () => {
+  it('shows "owner required" when caller is not owner', () => {
+    render(
+      <FailbackPanel
+        sovereignId="dep-1"
+        continuumName="dr-wp"
+        isOwner={false}
+        isSovereignAdmin={false}
+        approvalRequired={false}
+        failbackRequested={false}
+        failbackApproved={false}
+      />,
+    )
+    expect(screen.getByTestId('continuum-failback-request-disabled')).toBeTruthy()
+  })
+
+  it('shows the request button when caller is owner + nothing requested yet', () => {
+    render(
+      <FailbackPanel
+        sovereignId="dep-1"
+        continuumName="dr-wp"
+        isOwner
+        isSovereignAdmin={false}
+        approvalRequired={false}
+        failbackRequested={false}
+        failbackApproved={false}
+      />,
+    )
+    expect(screen.getByTestId('continuum-failback-request-btn')).toBeTruthy()
+  })
+
+  it('shows pending + approve button when approvalRequired and caller is sovereign-admin', () => {
+    render(
+      <FailbackPanel
+        sovereignId="dep-1"
+        continuumName="dr-wp"
+        isOwner
+        isSovereignAdmin
+        approvalRequired
+        failbackRequested
+        failbackApproved={false}
+      />,
+    )
+    expect(screen.getByTestId('continuum-failback-pending')).toBeTruthy()
+    expect(screen.getByTestId('continuum-failback-approve-btn')).toBeTruthy()
+  })
+
+  it('hides approve button for non-sovereign-admin even when approvalRequired', () => {
+    render(
+      <FailbackPanel
+        sovereignId="dep-1"
+        continuumName="dr-wp"
+        isOwner
+        isSovereignAdmin={false}
+        approvalRequired
+        failbackRequested
+        failbackApproved={false}
+      />,
+    )
+    expect(screen.queryByTestId('continuum-failback-approve-btn')).toBeNull()
+    expect(screen.getByTestId('continuum-failback-approve-hidden')).toBeTruthy()
+  })
+
+  it('shows in-progress message after approval / when no approval needed', () => {
+    render(
+      <FailbackPanel
+        sovereignId="dep-1"
+        continuumName="dr-wp"
+        isOwner
+        isSovereignAdmin={false}
+        approvalRequired={false}
+        failbackRequested
+        failbackApproved={false}
+      />,
+    )
+    expect(screen.getByTestId('continuum-failback-in-progress')).toBeTruthy()
+  })
+})
+
+describe('FailbackPanel — actions', () => {
+  it('clicking request fires onChanged when network is disabled', () => {
+    const onChanged = vi.fn()
+    render(
+      <FailbackPanel
+        sovereignId="dep-1"
+        continuumName="dr-wp"
+        isOwner
+        isSovereignAdmin={false}
+        approvalRequired={false}
+        failbackRequested={false}
+        failbackApproved={false}
+        disableNetwork
+        onChanged={onChanged}
+      />,
+    )
+    fireEvent.click(screen.getByTestId('continuum-failback-request-btn'))
+    expect(onChanged).toHaveBeenCalled()
+  })
+
+  it('clicking approve fires onChanged when network is disabled', () => {
+    const onChanged = vi.fn()
+    render(
+      <FailbackPanel
+        sovereignId="dep-1"
+        continuumName="dr-wp"
+        isOwner
+        isSovereignAdmin
+        approvalRequired
+        failbackRequested
+        failbackApproved={false}
+        disableNetwork
+        onChanged={onChanged}
+      />,
+    )
+    fireEvent.click(screen.getByTestId('continuum-failback-approve-btn'))
+    expect(onChanged).toHaveBeenCalled()
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/widgets/continuum/FailbackPanel.tsx
+++ b/products/catalyst/bootstrap/ui/src/widgets/continuum/FailbackPanel.tsx
@@ -1,0 +1,180 @@
+/**
+ * FailbackPanel — EPIC-6 Slice U-DR-1 (#1101).
+ *
+ * Failback handler UI shown WHEN
+ * `Continuum.status.lastSwitchover.result == 'Success'`. Surfaces:
+ *
+ *   - "Failback to Primary" button (owner tier on Application)
+ *   - Confirm dialog → POST /continuums/{name}/failback
+ *   - When `spec.failback.approvalRequired = true`, an "Awaiting
+ *     approval" pill appears with an Approve button (sovereign-admin
+ *     only — gate enforced server-side; UI hides the button when the
+ *     caller doesn't claim admin/owner)
+ *   - On approve → POST /continuums/{name}/failback/approve
+ *
+ * The "owner-only" + "sovereign-admin-only" decisions are evaluated
+ * client-side as a UX convenience (show / hide); the server is the
+ * single source of truth for authorization.
+ */
+
+import { useState } from 'react'
+
+import { approveFailback, requestFailback } from '@/lib/continuum.api'
+
+export interface FailbackPanelProps {
+  sovereignId: string
+  continuumName: string
+  namespace?: string
+  /** True when the caller's tier permits the failback request. */
+  isOwner: boolean
+  /** True when the caller's tier permits approving the failback. */
+  isSovereignAdmin: boolean
+  /** Whether spec.failback.approvalRequired is set. */
+  approvalRequired: boolean
+  /** Whether spec.failback.requested has already been set. */
+  failbackRequested: boolean
+  /** Whether spec.failback.approved has been set. */
+  failbackApproved: boolean
+  /** Test seam — bypass the network call. */
+  disableNetwork?: boolean
+  /** Fired after a successful POST so the parent can refetch. */
+  onChanged?: () => void
+}
+
+export function FailbackPanel({
+  sovereignId,
+  continuumName,
+  namespace,
+  isOwner,
+  isSovereignAdmin,
+  approvalRequired,
+  failbackRequested,
+  failbackApproved,
+  disableNetwork = false,
+  onChanged,
+}: FailbackPanelProps) {
+  const [busy, setBusy] = useState<'request' | 'approve' | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [info, setInfo] = useState<string | null>(null)
+
+  const onRequest = async () => {
+    setError(null)
+    setInfo(null)
+    if (disableNetwork) {
+      setInfo('Failback requested (test seam).')
+      onChanged?.()
+      return
+    }
+    setBusy('request')
+    try {
+      const resp = await requestFailback(sovereignId, continuumName, {}, { namespace })
+      setInfo(resp.message)
+      onChanged?.()
+    } catch (e) {
+      setError((e as Error).message)
+    } finally {
+      setBusy(null)
+    }
+  }
+
+  const onApprove = async () => {
+    setError(null)
+    setInfo(null)
+    if (disableNetwork) {
+      setInfo('Failback approved (test seam).')
+      onChanged?.()
+      return
+    }
+    setBusy('approve')
+    try {
+      const resp = await approveFailback(sovereignId, continuumName, { namespace })
+      setInfo(resp.message)
+      onChanged?.()
+    } catch (e) {
+      setError((e as Error).message)
+    } finally {
+      setBusy(null)
+    }
+  }
+
+  return (
+    <div
+      className="continuum-failback rounded-md border border-[var(--color-border)] bg-[var(--color-bg-2)] p-3"
+      data-testid="continuum-failback-panel"
+    >
+      <h4 className="mb-2 text-xs font-semibold uppercase tracking-wide text-[var(--color-text-dim)]">
+        Failback
+      </h4>
+      <p className="mb-2 text-xs text-[var(--color-text-dim)]">
+        Returns the primary role to the original region after a switchover.
+      </p>
+
+      {!failbackRequested ? (
+        isOwner ? (
+          <button
+            type="button"
+            data-testid="continuum-failback-request-btn"
+            className="rounded-md bg-[var(--color-accent)] px-3 py-1.5 text-xs text-[var(--color-bg)] hover:opacity-90 disabled:opacity-40"
+            onClick={onRequest}
+            disabled={busy !== null}
+          >
+            {busy === 'request' ? 'Requesting…' : 'Failback to Primary'}
+          </button>
+        ) : (
+          <div
+            data-testid="continuum-failback-request-disabled"
+            className="text-xs text-[var(--color-text-dim)]"
+          >
+            Owner tier required to request failback.
+          </div>
+        )
+      ) : approvalRequired && !failbackApproved ? (
+        <div
+          data-testid="continuum-failback-pending"
+          className="rounded-md border border-yellow-500/40 bg-yellow-500/10 p-2 text-xs text-yellow-300"
+        >
+          <div className="mb-2 font-semibold">Awaiting sovereign-admin approval</div>
+          {isSovereignAdmin ? (
+            <button
+              type="button"
+              data-testid="continuum-failback-approve-btn"
+              className="rounded-md bg-[var(--color-accent)] px-3 py-1.5 text-xs text-[var(--color-bg)] hover:opacity-90 disabled:opacity-40"
+              onClick={onApprove}
+              disabled={busy !== null}
+            >
+              {busy === 'approve' ? 'Approving…' : 'Approve'}
+            </button>
+          ) : (
+            <div data-testid="continuum-failback-approve-hidden">
+              Approval requires sovereign-admin (admin or owner tier).
+            </div>
+          )}
+        </div>
+      ) : (
+        <div
+          data-testid="continuum-failback-in-progress"
+          className="text-xs text-[var(--color-text-dim)]"
+        >
+          Failback requested; reconciler is executing the reverse switchover.
+        </div>
+      )}
+
+      {error ? (
+        <div
+          data-testid="continuum-failback-error"
+          className="mt-2 rounded-md border border-red-500/40 bg-red-500/10 px-3 py-2 text-xs text-red-400"
+        >
+          {error}
+        </div>
+      ) : null}
+      {info ? (
+        <div
+          data-testid="continuum-failback-info"
+          className="mt-2 rounded-md border border-green-500/40 bg-green-500/10 px-3 py-2 text-xs text-green-400"
+        >
+          {info}
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/products/catalyst/bootstrap/ui/src/widgets/continuum/LuaRecordView.tsx
+++ b/products/catalyst/bootstrap/ui/src/widgets/continuum/LuaRecordView.tsx
@@ -1,0 +1,83 @@
+/**
+ * LuaRecordView — EPIC-6 Slice U-DR-1 (#1101).
+ *
+ * Read-only display of the lua-record body the Continuum reconciler
+ * has written via PDM /v1/commit. Source: Continuum CR's
+ * `status.lastLuaRecord` (when surfaced by K-Cont-2). When absent,
+ * shows a friendly empty state — flagged as a follow-up in the
+ * reporting back to the Coordinator.
+ */
+
+import { useState } from 'react'
+
+export interface LuaRecordViewProps {
+  /** Continuum CR's status map. */
+  status?: Record<string, unknown>
+}
+
+export function LuaRecordView({ status }: LuaRecordViewProps) {
+  const [open, setOpen] = useState(false)
+  const lastLua = status?.['lastLuaRecord'] as Record<string, unknown> | string | undefined
+
+  const lines = parseLuaRecord(lastLua)
+
+  return (
+    <div
+      className="continuum-lua rounded-md border border-[var(--color-border)] bg-[var(--color-bg-2)] p-3"
+      data-testid="continuum-lua-view"
+    >
+      <button
+        type="button"
+        className="flex w-full items-baseline justify-between text-left text-xs font-semibold uppercase tracking-wide text-[var(--color-text-dim)] hover:text-[var(--color-text)]"
+        onClick={() => setOpen((v) => !v)}
+        data-testid="continuum-lua-toggle"
+      >
+        <span>Active lua-record (PowerDNS)</span>
+        <span className="font-mono">{open ? '▾' : '▸'}</span>
+      </button>
+      {open ? (
+        lines.length === 0 ? (
+          <p
+            data-testid="continuum-lua-empty"
+            className="mt-2 text-xs text-[var(--color-text-dim)]"
+          >
+            Continuum has not yet written a lua-record (or the controller is not surfacing it on
+            status.lastLuaRecord).
+          </p>
+        ) : (
+          <pre
+            data-testid="continuum-lua-body"
+            className="mt-2 overflow-auto rounded-md border border-[var(--color-border)] bg-[var(--color-bg)] p-2 text-[11px] leading-5 text-[var(--color-text)]"
+          >
+            {lines.join('\n')}
+          </pre>
+        )
+      ) : null}
+    </div>
+  )
+}
+
+function parseLuaRecord(raw: unknown): string[] {
+  if (raw == null) return []
+  if (typeof raw === 'string') return raw.split('\n')
+  if (typeof raw === 'object') {
+    // Common shapes: { hostname: <str>, body: <str> } or
+    // { records: [{hostname, body}, ...] }.
+    const r = raw as Record<string, unknown>
+    if (typeof r['body'] === 'string') return [`# ${String(r['hostname'] ?? '')}`, String(r['body'])]
+    if (Array.isArray(r['records'])) {
+      const out: string[] = []
+      for (const rec of r['records'] as Array<Record<string, unknown>>) {
+        out.push(`# ${String(rec['hostname'] ?? '')}`)
+        out.push(String(rec['body'] ?? ''))
+      }
+      return out
+    }
+    try {
+      return [JSON.stringify(raw, null, 2)]
+    } catch {
+      return []
+    }
+  }
+  return []
+}

--- a/products/catalyst/bootstrap/ui/src/widgets/continuum/StatusPanel.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/widgets/continuum/StatusPanel.test.tsx
@@ -1,0 +1,88 @@
+/**
+ * StatusPanel.test.tsx — Vitest unit tests for the EPIC-6 Slice U-DR-1
+ * (#1101) live-status panel.
+ */
+import { describe, it, expect, afterEach } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+
+import { StatusPanel } from './StatusPanel'
+
+afterEach(() => cleanup())
+
+describe('StatusPanel — phase rendering', () => {
+  it('shows the Healthy badge', () => {
+    render(<StatusPanel status={{ phase: 'Healthy' }} primaryRegion="hz-fsn-rtz-prod" />)
+    expect(screen.getByTestId('continuum-status-phase-Healthy')).toBeTruthy()
+  })
+
+  it('shows the SwitchingOver badge + step', () => {
+    render(
+      <StatusPanel
+        status={{ phase: 'SwitchingOver', switchoverInProgress: true, switchoverStep: 'step 3/7 — drain-http' }}
+        primaryRegion="hz-fsn-rtz-prod"
+      />,
+    )
+    expect(screen.getByTestId('continuum-status-switching-over')).toBeTruthy()
+    const step = screen.getByTestId('continuum-status-switching-over-step')
+    expect(step.textContent).toContain('3/7')
+    expect(step.textContent).toContain('drain-http')
+  })
+})
+
+describe('StatusPanel — lag color thresholds', () => {
+  it('green when lag < 30s', () => {
+    render(<StatusPanel status={{ replicationLagSeconds: 12 }} primaryRegion="a" />)
+    expect(screen.getByTestId('continuum-status-lag-bucket-green')).toBeTruthy()
+  })
+
+  it('yellow when lag in 30..60', () => {
+    render(<StatusPanel status={{ replicationLagSeconds: 45 }} primaryRegion="a" />)
+    expect(screen.getByTestId('continuum-status-lag-bucket-yellow')).toBeTruthy()
+  })
+
+  it('red when lag > 60', () => {
+    render(<StatusPanel status={{ replicationLagSeconds: 75 }} primaryRegion="a" />)
+    expect(screen.getByTestId('continuum-status-lag-bucket-red')).toBeTruthy()
+  })
+
+  it('unknown when lag missing', () => {
+    render(<StatusPanel status={{}} primaryRegion="a" />)
+    expect(screen.getByTestId('continuum-status-lag-bucket-unknown')).toBeTruthy()
+  })
+})
+
+describe('StatusPanel — last switchover side panel', () => {
+  it('renders when status.lastSwitchover is present', () => {
+    render(
+      <StatusPanel
+        status={{
+          phase: 'FailedOver',
+          lastSwitchover: { at: '2026-05-08T14:23:11Z', from: 'hz-fsn-rtz-prod', to: 'hz-hel-rtz-prod', result: 'Success' },
+        }}
+        primaryRegion="hz-hel-rtz-prod"
+      />,
+    )
+    const panel = screen.getByTestId('continuum-status-last-switchover')
+    expect(panel.textContent).toContain('hz-hel-rtz-prod')
+    expect(screen.getByTestId('continuum-status-last-switchover-result').textContent).toBe('Success')
+  })
+
+  it('omits the panel when lastSwitchover is empty', () => {
+    render(<StatusPanel status={{ phase: 'Healthy' }} primaryRegion="a" />)
+    expect(screen.queryByTestId('continuum-status-last-switchover')).toBeNull()
+  })
+})
+
+describe('StatusPanel — hot-standby badges', () => {
+  it('renders one badge per hot-standby region', () => {
+    render(
+      <StatusPanel
+        status={{ phase: 'Healthy' }}
+        primaryRegion="hz-fsn-rtz-prod"
+        hotStandbyRegions={['hz-hel-rtz-prod', 'hz-nbg-rtz-prod']}
+      />,
+    )
+    expect(screen.getByTestId('continuum-status-hotstandby-hz-hel-rtz-prod')).toBeTruthy()
+    expect(screen.getByTestId('continuum-status-hotstandby-hz-nbg-rtz-prod')).toBeTruthy()
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/widgets/continuum/StatusPanel.tsx
+++ b/products/catalyst/bootstrap/ui/src/widgets/continuum/StatusPanel.tsx
@@ -1,0 +1,202 @@
+/**
+ * StatusPanel — EPIC-6 Slice U-DR-1 (#1101).
+ *
+ * Renders the live Continuum CR status the K-Cont-2 reconciler patches
+ * on every reconcile loop:
+ *
+ *   - Phase pill (Healthy / Degraded / SwitchingOver / FailedOver / ...)
+ *   - Primary region badge
+ *   - Lease holder + expiresAt
+ *   - Replication lag with progress bar (green <30s, yellow 30-60s, red >60s)
+ *   - Switchover-in-progress: "Step N/7 — <name>" live progress widget
+ *   - LastSwitchover side panel (at, from, to, result)
+ *
+ * Pure presentation — receives the parsed Continuum CR's `status` map
+ * via prop. Parent (DRSection) refetches via React Query and feeds in
+ * fresh data.
+ */
+
+import { lagBucket, parseLagSeconds } from '@/lib/continuum.api'
+
+export interface StatusPanelProps {
+  /** Parsed Continuum CR status map (from GET /continuums/{name}). */
+  status?: Record<string, unknown>
+  /** Region claimed primary (carried separately so we can render a placeholder). */
+  primaryRegion?: string
+  /** Hot-standby regions for context. */
+  hotStandbyRegions?: string[]
+}
+
+export function StatusPanel({ status, primaryRegion, hotStandbyRegions }: StatusPanelProps) {
+  const phase = (status?.['phase'] as string | undefined) ?? 'Pending'
+  const leaseHolder = (status?.['leaseHolder'] as string | undefined) ?? ''
+  const leaseExpiresAt = (status?.['leaseExpiresAt'] as string | undefined) ?? ''
+  const switchoverInProgress = Boolean(status?.['switchoverInProgress'] ?? false)
+  const switchoverStep = (status?.['switchoverStep'] as string | undefined) ?? ''
+  const lag = parseLagSeconds(status?.['replicationLagSeconds'])
+  const last = (status?.['lastSwitchover'] as Record<string, unknown> | undefined) ?? undefined
+
+  const bucket = lagBucket(lag)
+  const lagBarColor =
+    bucket === 'green'
+      ? 'bg-green-500'
+      : bucket === 'yellow'
+        ? 'bg-yellow-500'
+        : bucket === 'red'
+          ? 'bg-red-500'
+          : 'bg-[var(--color-border)]'
+  const lagPct = lag == null ? 0 : Math.min(100, Math.round((lag / 90) * 100))
+
+  return (
+    <div className="continuum-status-panel" data-testid="continuum-status-panel">
+      <div className="mb-3 grid grid-cols-1 gap-3 md:grid-cols-2">
+        <div
+          data-testid="continuum-status-phase"
+          className="rounded-md border border-[var(--color-border)] bg-[var(--color-bg-2)] p-3 text-sm"
+        >
+          <div className="mb-1 text-xs uppercase tracking-wide text-[var(--color-text-dim)]">Phase</div>
+          <span
+            className={`inline-flex rounded-md px-2 py-0.5 text-xs font-semibold uppercase ${
+              phase === 'Healthy'
+                ? 'bg-green-500/10 text-green-400'
+                : phase === 'SwitchingOver'
+                  ? 'bg-blue-500/10 text-blue-400'
+                  : phase === 'Degraded'
+                    ? 'bg-yellow-500/10 text-yellow-400'
+                    : phase === 'FailedOver'
+                      ? 'bg-purple-500/10 text-purple-400'
+                      : phase === 'Failed'
+                        ? 'bg-red-500/10 text-red-400'
+                        : 'bg-[var(--color-border)]/40 text-[var(--color-text-dim)]'
+            }`}
+            data-testid={`continuum-status-phase-${phase}`}
+          >
+            {phase}
+          </span>
+        </div>
+
+        <div
+          data-testid="continuum-status-primary"
+          className="rounded-md border border-[var(--color-border)] bg-[var(--color-bg-2)] p-3 text-sm"
+        >
+          <div className="mb-1 text-xs uppercase tracking-wide text-[var(--color-text-dim)]">Primary region</div>
+          <code className="font-mono text-[var(--color-text)]">{primaryRegion ?? '—'}</code>
+        </div>
+      </div>
+
+      <div className="mb-3 grid grid-cols-1 gap-3 md:grid-cols-2">
+        <div
+          data-testid="continuum-status-lease"
+          className="rounded-md border border-[var(--color-border)] bg-[var(--color-bg-2)] p-3 text-sm"
+        >
+          <div className="mb-1 text-xs uppercase tracking-wide text-[var(--color-text-dim)]">Lease holder</div>
+          <code className="font-mono text-[var(--color-text)]">{leaseHolder || '—'}</code>
+          {leaseExpiresAt ? (
+            <span className="ml-2 text-xs text-[var(--color-text-dim)]">
+              expires {new Date(leaseExpiresAt).toLocaleTimeString()}
+            </span>
+          ) : null}
+        </div>
+
+        <div
+          data-testid="continuum-status-lag"
+          className="rounded-md border border-[var(--color-border)] bg-[var(--color-bg-2)] p-3 text-sm"
+        >
+          <div className="mb-1 text-xs uppercase tracking-wide text-[var(--color-text-dim)]">Replication lag</div>
+          <div className="flex items-baseline gap-2">
+            <span className="font-mono text-[var(--color-text)]" data-testid="continuum-status-lag-value">
+              {lag == null ? '—' : `${lag}s`}
+            </span>
+            <span
+              className={`inline-flex rounded-md px-1.5 py-0.5 text-[10px] font-semibold uppercase ${
+                bucket === 'green'
+                  ? 'bg-green-500/10 text-green-400'
+                  : bucket === 'yellow'
+                    ? 'bg-yellow-500/10 text-yellow-400'
+                    : bucket === 'red'
+                      ? 'bg-red-500/10 text-red-400'
+                      : 'bg-[var(--color-border)]/40 text-[var(--color-text-dim)]'
+              }`}
+              data-testid={`continuum-status-lag-bucket-${bucket}`}
+            >
+              {bucket}
+            </span>
+          </div>
+          <div
+            className="mt-1.5 h-1.5 w-full overflow-hidden rounded-full bg-[var(--color-border)]/30"
+            aria-label="lag-bar"
+          >
+            <div
+              className={`h-full ${lagBarColor}`}
+              style={{ width: `${lagPct}%` }}
+              data-testid="continuum-status-lag-bar"
+            />
+          </div>
+        </div>
+      </div>
+
+      {switchoverInProgress ? (
+        <div
+          data-testid="continuum-status-switching-over"
+          className="mb-3 rounded-md border border-blue-500/40 bg-blue-500/10 p-3 text-sm text-blue-300"
+        >
+          <div className="mb-1 text-xs uppercase tracking-wide">Switchover in progress</div>
+          <div className="font-mono text-xs" data-testid="continuum-status-switching-over-step">
+            {switchoverStep || 'step ?/7 — starting'}
+          </div>
+        </div>
+      ) : null}
+
+      {last && Object.keys(last).length > 0 ? (
+        <div
+          data-testid="continuum-status-last-switchover"
+          className="rounded-md border border-[var(--color-border)] bg-[var(--color-bg-2)] p-3 text-xs text-[var(--color-text-dim)]"
+        >
+          <div className="mb-1 uppercase tracking-wide text-[var(--color-text-dim)]">Last switchover</div>
+          <div className="grid grid-cols-2 gap-2">
+            <div>
+              <strong className="text-[var(--color-text)]">at</strong>:{' '}
+              {(last['at'] as string | undefined) ?? '—'}
+            </div>
+            <div>
+              <strong className="text-[var(--color-text)]">result</strong>:{' '}
+              <span data-testid="continuum-status-last-switchover-result">
+                {(last['result'] as string | undefined) ?? '—'}
+              </span>
+            </div>
+            <div>
+              <strong className="text-[var(--color-text)]">from</strong>:{' '}
+              <code className="font-mono text-[var(--color-text)]">
+                {(last['from'] as string | undefined) ?? '—'}
+              </code>
+            </div>
+            <div>
+              <strong className="text-[var(--color-text)]">to</strong>:{' '}
+              <code className="font-mono text-[var(--color-text)]">
+                {(last['to'] as string | undefined) ?? '—'}
+              </code>
+            </div>
+          </div>
+        </div>
+      ) : null}
+
+      {hotStandbyRegions && hotStandbyRegions.length > 0 ? (
+        <div
+          data-testid="continuum-status-hotstandbys"
+          className="mt-3 text-xs text-[var(--color-text-dim)]"
+        >
+          <strong className="text-[var(--color-text)]">Hot standbys</strong>:{' '}
+          {hotStandbyRegions.map((r) => (
+            <code
+              key={r}
+              data-testid={`continuum-status-hotstandby-${r}`}
+              className="ml-2 inline-block rounded-md border border-[var(--color-border)] px-1.5 py-0.5 font-mono"
+            >
+              {r}
+            </code>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/products/catalyst/bootstrap/ui/src/widgets/continuum/SwitchoverDialog.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/widgets/continuum/SwitchoverDialog.test.tsx
@@ -1,0 +1,105 @@
+/**
+ * SwitchoverDialog.test.tsx — Vitest unit tests for the EPIC-6 Slice
+ * U-DR-1 (#1101) confirm dialog. Uses disableNetwork seam so no fetch
+ * is required.
+ */
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { render, screen, cleanup, fireEvent } from '@testing-library/react'
+
+import { SwitchoverDialog } from './SwitchoverDialog'
+import { SWITCHOVER_STEPS } from '@/lib/continuum.api'
+
+afterEach(() => cleanup())
+
+describe('SwitchoverDialog', () => {
+  it('renders the diff with from-region → to-region', () => {
+    render(
+      <SwitchoverDialog
+        sovereignId="dep-1"
+        continuumName="dr-wp"
+        applicationName="wp-prod"
+        fromRegion="hz-fsn-rtz-prod"
+        toRegion="hz-hel-rtz-prod"
+        onClose={() => {}}
+        disableNetwork
+      />,
+    )
+    const diff = screen.getByTestId('continuum-switchover-dialog-diff')
+    expect(diff.textContent).toContain('hz-fsn-rtz-prod')
+    expect(diff.textContent).toContain('hz-hel-rtz-prod')
+  })
+
+  it('renders all 7 steps from K-Cont-2 SWITCHOVER_STEPS', () => {
+    render(
+      <SwitchoverDialog
+        sovereignId="dep-1"
+        continuumName="dr-wp"
+        applicationName="wp-prod"
+        fromRegion="a"
+        toRegion="b"
+        onClose={() => {}}
+        disableNetwork
+      />,
+    )
+    for (const step of SWITCHOVER_STEPS) {
+      expect(screen.getByTestId(`continuum-switchover-dialog-step-${step.id}`)).toBeTruthy()
+    }
+  })
+
+  it('cancel calls onClose without triggering confirm', () => {
+    const onClose = vi.fn()
+    const onConfirmed = vi.fn()
+    render(
+      <SwitchoverDialog
+        sovereignId="dep-1"
+        continuumName="dr-wp"
+        applicationName="wp-prod"
+        fromRegion="a"
+        toRegion="b"
+        onClose={onClose}
+        onConfirmed={onConfirmed}
+        disableNetwork
+      />,
+    )
+    fireEvent.click(screen.getByTestId('continuum-switchover-dialog-cancel'))
+    expect(onClose).toHaveBeenCalled()
+    expect(onConfirmed).not.toHaveBeenCalled()
+  })
+
+  it('confirm calls onConfirmed when network is disabled', () => {
+    const onClose = vi.fn()
+    const onConfirmed = vi.fn()
+    render(
+      <SwitchoverDialog
+        sovereignId="dep-1"
+        continuumName="dr-wp"
+        applicationName="wp-prod"
+        fromRegion="a"
+        toRegion="b"
+        onClose={onClose}
+        onConfirmed={onConfirmed}
+        disableNetwork
+      />,
+    )
+    fireEvent.click(screen.getByTestId('continuum-switchover-dialog-confirm'))
+    expect(onConfirmed).toHaveBeenCalled()
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('renders estimated duration + write-disruption block', () => {
+    render(
+      <SwitchoverDialog
+        sovereignId="dep-1"
+        continuumName="dr-wp"
+        applicationName="wp-prod"
+        fromRegion="a"
+        toRegion="b"
+        onClose={() => {}}
+        disableNetwork
+      />,
+    )
+    const est = screen.getByTestId('continuum-switchover-dialog-estimates')
+    expect(est.textContent).toContain('60s')
+    expect(est.textContent).toContain('5s')
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/widgets/continuum/SwitchoverDialog.tsx
+++ b/products/catalyst/bootstrap/ui/src/widgets/continuum/SwitchoverDialog.tsx
@@ -1,0 +1,218 @@
+/**
+ * SwitchoverDialog — EPIC-6 Slice U-DR-1 (#1101).
+ *
+ * Confirm dialog the operator clicks through before the catalyst-api
+ * patches the Continuum CR's `spec.switchover.requested = true`. Shows:
+ *
+ *   - The diff: "Primary will move from <fromRegion> → <toRegion>"
+ *   - The 7-step list from K-Cont-2's Sequencer (SWITCHOVER_STEPS)
+ *   - Estimated duration <60s, write disruption <5s
+ *   - Cancel / Confirm buttons
+ *
+ * On Confirm → POST /api/v1/sovereigns/{id}/continuums/{name}/switchover
+ * (via continuum.api.requestSwitchover). Returns 202 Accepted; the
+ * K-Cont-2 reconciler picks up the patch on its next loop iteration
+ * and emits the 7-step audit events on NATS.
+ *
+ * Per docs/INVIOLABLE-PRINCIPLES.md #5 the underlying handler enforces
+ * owner tier on the Application server-side. The widget renders
+ * regardless of tier; the parent (DRSection) hides the entry-point
+ * button when the caller lacks owner. On a 403 from the API the dialog
+ * surfaces the error inline.
+ *
+ * Disable-network seam mirrors TopologyEditor — tests render the
+ * dialog without a real fetch.
+ */
+
+import { useState } from 'react'
+
+import {
+  requestSwitchover,
+  SWITCHOVER_STEPS,
+  type ContinuumSwitchoverResponse,
+} from '@/lib/continuum.api'
+
+export interface SwitchoverDialogProps {
+  /** Sovereign id (deploymentId on chroot, mother). */
+  sovereignId: string
+  /** Continuum CR name. */
+  continuumName: string
+  /** Org namespace (optional; falls back to handler-side cross-namespace lookup). */
+  namespace?: string
+  /** Current primary region (for the diff). */
+  fromRegion: string
+  /** Switchover target — typically the first hot-standby region. */
+  toRegion: string
+  /** Application name surfaced in the dialog header for context. */
+  applicationName: string
+  /** Fired when the operator dismisses the dialog (cancel or after success). */
+  onClose: () => void
+  /** Fired on a successful POST. */
+  onConfirmed?: (resp: ContinuumSwitchoverResponse) => void
+  /** Test seam — bypass the network call. */
+  disableNetwork?: boolean
+}
+
+export function SwitchoverDialog({
+  sovereignId,
+  continuumName,
+  namespace,
+  fromRegion,
+  toRegion,
+  applicationName,
+  onClose,
+  onConfirmed,
+  disableNetwork = false,
+}: SwitchoverDialogProps) {
+  const [reason, setReason] = useState<string>('')
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const onConfirm = async () => {
+    setError(null)
+    if (disableNetwork) {
+      const stub: ContinuumSwitchoverResponse = {
+        name: continuumName,
+        namespace: namespace ?? '',
+        targetRegion: toRegion,
+        reason,
+        requestedAt: new Date().toISOString(),
+        requestedBy: 'test-seam',
+        message: 'switchover requested (test seam)',
+      }
+      onConfirmed?.(stub)
+      onClose()
+      return
+    }
+    setBusy(true)
+    try {
+      const resp = await requestSwitchover(
+        sovereignId,
+        continuumName,
+        { targetRegion: toRegion, reason: reason.trim() || undefined },
+        { namespace },
+      )
+      onConfirmed?.(resp)
+      onClose()
+    } catch (e) {
+      setError((e as Error).message)
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      data-testid="continuum-switchover-dialog"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-4"
+    >
+      <div className="max-h-[85vh] w-full max-w-2xl overflow-auto rounded-lg border border-[var(--color-border)] bg-[var(--color-bg)] p-5">
+        <div className="mb-3 flex items-baseline justify-between">
+          <h3 className="text-base font-semibold text-[var(--color-text)]">
+            Switchover — {applicationName}
+          </h3>
+          <button
+            type="button"
+            data-testid="continuum-switchover-dialog-close"
+            className="text-xs text-[var(--color-text-dim)] hover:text-[var(--color-text)]"
+            onClick={onClose}
+          >
+            Close
+          </button>
+        </div>
+
+        <div
+          className="mb-4 rounded-md border border-[var(--color-border)] bg-[var(--color-bg-2)] p-3 text-sm"
+          data-testid="continuum-switchover-dialog-diff"
+        >
+          <p className="font-medium text-[var(--color-text)]">
+            Primary will move{' '}
+            <code className="font-mono text-[var(--color-accent)]">{fromRegion}</code>
+            {' → '}
+            <code className="font-mono text-[var(--color-accent)]">{toRegion}</code>
+          </p>
+        </div>
+
+        <div className="mb-4">
+          <h4 className="mb-2 text-xs font-semibold uppercase tracking-wide text-[var(--color-text-dim)]">
+            What happens (7 steps)
+          </h4>
+          <ol
+            data-testid="continuum-switchover-dialog-steps"
+            className="space-y-1.5 text-xs text-[var(--color-text)]"
+          >
+            {SWITCHOVER_STEPS.map((s) => (
+              <li
+                key={s.id}
+                data-testid={`continuum-switchover-dialog-step-${s.id}`}
+                className="grid grid-cols-[1.25rem_8rem_1fr] items-baseline gap-2"
+              >
+                <span className="font-mono text-[var(--color-text-dim)]">{s.id}.</span>
+                <code className="font-mono text-[var(--color-accent)]">{s.name}</code>
+                <span className="text-[var(--color-text-dim)]">{s.description}</span>
+              </li>
+            ))}
+          </ol>
+        </div>
+
+        <div
+          className="mb-4 grid grid-cols-2 gap-3 rounded-md border border-yellow-500/40 bg-yellow-500/10 px-3 py-2 text-xs text-yellow-300"
+          data-testid="continuum-switchover-dialog-estimates"
+        >
+          <div>
+            <strong>Estimated duration</strong>: &lt;60s (happy path)
+          </div>
+          <div>
+            <strong>Write disruption</strong>: &lt;5s
+          </div>
+        </div>
+
+        <label className="mb-3 block text-xs">
+          <span className="text-[var(--color-text-dim)]">
+            Reason (optional, surfaced on the audit row)
+          </span>
+          <input
+            type="text"
+            value={reason}
+            onChange={(e) => setReason(e.target.value)}
+            placeholder="e.g. fsn-hetzner-az-degraded"
+            data-testid="continuum-switchover-dialog-reason"
+            className="mt-1 w-full rounded-md border border-[var(--color-border)] bg-[var(--color-bg-2)] px-2 py-1 font-mono text-xs text-[var(--color-text)] focus:border-[var(--color-accent)] focus:outline-none"
+          />
+        </label>
+
+        {error ? (
+          <div
+            className="mb-3 rounded-md border border-red-500/40 bg-red-500/10 px-3 py-2 text-xs text-red-400"
+            data-testid="continuum-switchover-dialog-error"
+          >
+            {error}
+          </div>
+        ) : null}
+
+        <div className="flex justify-end gap-2">
+          <button
+            type="button"
+            data-testid="continuum-switchover-dialog-cancel"
+            className="rounded-md border border-[var(--color-border)] px-3 py-1.5 text-xs hover:border-[var(--color-accent)]"
+            onClick={onClose}
+            disabled={busy}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            data-testid="continuum-switchover-dialog-confirm"
+            className="rounded-md bg-[var(--color-accent)] px-3 py-1.5 text-xs text-[var(--color-bg)] hover:opacity-90 disabled:opacity-40"
+            onClick={onConfirm}
+            disabled={busy}
+          >
+            {busy ? 'Confirming…' : 'Confirm Switchover'}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/products/catalyst/bootstrap/ui/src/widgets/continuum/SwitchoverHistory.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/widgets/continuum/SwitchoverHistory.test.tsx
@@ -1,0 +1,84 @@
+/**
+ * SwitchoverHistory.test.tsx — Vitest unit tests for the EPIC-6 Slice
+ * U-DR-1 (#1101) audit-history table.
+ */
+import { describe, it, expect, afterEach } from 'vitest'
+import { render, screen, cleanup, fireEvent } from '@testing-library/react'
+
+import { SwitchoverHistory } from './SwitchoverHistory'
+import type { ContinuumAuditEvent } from '@/lib/continuum.api'
+
+afterEach(() => cleanup())
+
+const sampleEvents: ContinuumAuditEvent[] = [
+  {
+    auditType: 'continuum-switchover',
+    ts: '2026-05-08T14:23:11Z',
+    actor: 'owner@acme.io',
+    sovereignId: 'dep-1',
+    targetApp: 'wp-prod',
+    detail: 'switchover requested: hz-fsn-rtz-prod → hz-hel-rtz-prod (reason: drill)',
+    result: 'ok',
+  },
+  {
+    auditType: 'continuum-cnpg-promotable',
+    ts: '2026-05-08T14:23:09Z',
+    sovereignId: 'dep-1',
+    targetApp: 'wp-prod',
+    detail: 'standby promotable; lag=4s',
+  },
+  {
+    auditType: 'continuum-lease-acquired',
+    ts: '2026-05-08T14:23:13Z',
+    sovereignId: 'dep-1',
+    targetApp: 'wp-prod',
+    detail: 'acquired lease for region hz-hel-rtz-prod',
+  },
+  {
+    auditType: 'continuum-error',
+    ts: '2026-05-08T14:23:14Z',
+    sovereignId: 'dep-1',
+    targetApp: 'wp-prod',
+    detail: 'transient error',
+    result: 'error',
+  },
+  // Different app — should be filtered out when applicationName provided.
+  {
+    auditType: 'continuum-switchover',
+    ts: '2026-05-09T01:00:00Z',
+    actor: 'someone-else@acme.io',
+    sovereignId: 'dep-1',
+    targetApp: 'other-app',
+    detail: 'unrelated',
+    result: 'ok',
+  },
+]
+
+describe('SwitchoverHistory', () => {
+  it('renders a row per switchover event matching the application', () => {
+    render(<SwitchoverHistory events={sampleEvents} applicationName="wp-prod" />)
+    expect(screen.getByTestId('continuum-history-row-0')).toBeTruthy()
+    // Only one matching switchover row for wp-prod (the second is "other-app").
+    expect(screen.queryByTestId('continuum-history-row-1')).toBeNull()
+  })
+
+  it('renders empty state when no events match', () => {
+    render(<SwitchoverHistory events={[]} applicationName="wp-prod" />)
+    expect(screen.getByTestId('continuum-history-empty')).toBeTruthy()
+  })
+
+  it('clicking a row opens the detail modal with bundled step events', () => {
+    render(<SwitchoverHistory events={sampleEvents} applicationName="wp-prod" />)
+    fireEvent.click(screen.getByTestId('continuum-history-row-0'))
+    expect(screen.getByTestId('continuum-history-modal')).toBeTruthy()
+    // The modal should bundle nearby step events (cnpg-promotable, lease-acquired, error).
+    expect(screen.getByTestId('continuum-history-modal-step-0')).toBeTruthy()
+  })
+
+  it('parses from→to from detail string into table columns', () => {
+    render(<SwitchoverHistory events={sampleEvents} applicationName="wp-prod" />)
+    const row = screen.getByTestId('continuum-history-row-0')
+    expect(row.textContent).toContain('hz-fsn-rtz-prod')
+    expect(row.textContent).toContain('hz-hel-rtz-prod')
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/widgets/continuum/SwitchoverHistory.tsx
+++ b/products/catalyst/bootstrap/ui/src/widgets/continuum/SwitchoverHistory.tsx
@@ -1,0 +1,206 @@
+/**
+ * SwitchoverHistory — EPIC-6 Slice U-DR-1 (#1101).
+ *
+ * Tabular view of past switchover audit events from
+ * GET /api/v1/sovereigns/{id}/audit/continuum (filtered to the
+ * `continuum-switchover` audit-type). Click a row → modal with the 7
+ * step audit events that made up that switchover (matched by
+ * timestamp proximity to the row's event).
+ *
+ * Pure presentation — receives the audit events as a prop. The parent
+ * (DRSection) wires the React Query subscription + the SSE stream so
+ * the table updates as new events arrive.
+ */
+
+import { useMemo, useState } from 'react'
+
+import type { ContinuumAuditEvent } from '@/lib/continuum.api'
+
+export interface SwitchoverHistoryProps {
+  events: ContinuumAuditEvent[]
+  /** Optional filter — only render events whose Application matches. */
+  applicationName?: string
+}
+
+interface Row {
+  ev: ContinuumAuditEvent
+  /** Step events bundled by timestamp proximity (within 60s before+after). */
+  stepEvents: ContinuumAuditEvent[]
+}
+
+const SWITCHOVER_TYPES = new Set([
+  'continuum-switchover',
+  'continuum-switchover-requested',
+])
+
+const STEP_TYPES = new Set([
+  'continuum-switchover',
+  'continuum-cnpg-promotable',
+  'continuum-cnpg-lag-breach',
+  'continuum-lease-acquired',
+  'continuum-lease-lost',
+  'continuum-failback-pending',
+  'continuum-failback-completed',
+  'continuum-error',
+])
+
+export function SwitchoverHistory({ events, applicationName }: SwitchoverHistoryProps) {
+  const [openIdx, setOpenIdx] = useState<number | null>(null)
+
+  const rows: Row[] = useMemo(() => {
+    const filtered = events.filter((e) => {
+      if (!SWITCHOVER_TYPES.has(e.auditType)) return false
+      if (applicationName && e.targetApp && e.targetApp !== applicationName) return false
+      return true
+    })
+    // Newest-first per the catalyst-api list endpoint contract.
+    return filtered.map((ev) => ({
+      ev,
+      stepEvents: bundleStepEvents(events, ev),
+    }))
+  }, [events, applicationName])
+
+  if (rows.length === 0) {
+    return (
+      <div
+        data-testid="continuum-history-empty"
+        className="rounded-md border border-[var(--color-border)] bg-[var(--color-bg-2)] p-3 text-xs text-[var(--color-text-dim)]"
+      >
+        No switchover events recorded yet.
+      </div>
+    )
+  }
+
+  return (
+    <div className="continuum-history" data-testid="continuum-history">
+      <table className="w-full text-xs">
+        <thead className="text-left text-[var(--color-text-dim)]">
+          <tr>
+            <th className="pb-1.5">Timestamp</th>
+            <th className="pb-1.5">From</th>
+            <th className="pb-1.5">To</th>
+            <th className="pb-1.5">Result</th>
+            <th className="pb-1.5">Initiated by</th>
+            <th className="pb-1.5">Detail</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row, idx) => {
+            const fromTo = parseFromTo(row.ev.detail)
+            return (
+              <tr
+                key={`${row.ev.ts}-${idx}`}
+                data-testid={`continuum-history-row-${idx}`}
+                className="cursor-pointer border-t border-[var(--color-border)] hover:bg-[var(--color-bg-2)]"
+                onClick={() => setOpenIdx(idx)}
+              >
+                <td className="py-1.5 font-mono text-[var(--color-text)]">
+                  {new Date(row.ev.ts).toLocaleString()}
+                </td>
+                <td className="py-1.5 font-mono text-[var(--color-text-dim)]">{fromTo.from}</td>
+                <td className="py-1.5 font-mono text-[var(--color-text-dim)]">{fromTo.to}</td>
+                <td className="py-1.5">
+                  <span
+                    className={`inline-flex rounded-md px-1.5 py-0.5 text-[10px] font-semibold uppercase ${
+                      (row.ev.result ?? 'ok') === 'ok'
+                        ? 'bg-green-500/10 text-green-400'
+                        : 'bg-red-500/10 text-red-400'
+                    }`}
+                  >
+                    {row.ev.result ?? 'ok'}
+                  </span>
+                </td>
+                <td className="py-1.5 text-[var(--color-text-dim)]">{row.ev.actor ?? '—'}</td>
+                <td className="py-1.5 text-[var(--color-text-dim)]">{row.ev.detail ?? ''}</td>
+              </tr>
+            )
+          })}
+        </tbody>
+      </table>
+
+      {openIdx !== null ? (
+        <div
+          role="dialog"
+          aria-modal="true"
+          data-testid="continuum-history-modal"
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-4"
+          onClick={() => setOpenIdx(null)}
+        >
+          <div
+            className="max-h-[80vh] w-full max-w-2xl overflow-auto rounded-lg border border-[var(--color-border)] bg-[var(--color-bg)] p-5"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="mb-3 flex items-baseline justify-between">
+              <h3 className="text-base font-semibold text-[var(--color-text)]">
+                Switchover audit trail
+              </h3>
+              <button
+                type="button"
+                data-testid="continuum-history-modal-close"
+                className="text-xs text-[var(--color-text-dim)] hover:text-[var(--color-text)]"
+                onClick={() => setOpenIdx(null)}
+              >
+                Close
+              </button>
+            </div>
+            <p className="mb-3 text-xs text-[var(--color-text-dim)]">
+              Events emitted by the K-Cont-2 reconciler around{' '}
+              {new Date(rows[openIdx].ev.ts).toLocaleString()} (per K-Cont-2 the 7 steps emit one
+              audit event each).
+            </p>
+            <ul className="space-y-1.5 text-xs">
+              {rows[openIdx].stepEvents.map((s, i) => (
+                <li
+                  key={i}
+                  data-testid={`continuum-history-modal-step-${i}`}
+                  className="grid grid-cols-[10rem_8rem_1fr] items-baseline gap-2"
+                >
+                  <code className="font-mono text-[var(--color-text-dim)]">
+                    {new Date(s.ts).toLocaleTimeString()}
+                  </code>
+                  <code className="font-mono text-[var(--color-accent)]">{s.auditType}</code>
+                  <span className="text-[var(--color-text)]">{s.detail ?? ''}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  )
+}
+
+/**
+ * bundleStepEvents picks all step-shaped audit events within ±90s of
+ * the row's timestamp. The K-Cont-2 sequencer happy path is <60s end
+ * to end so a 90s window catches every step + any retry padding
+ * without bleeding into adjacent switchovers.
+ */
+function bundleStepEvents(all: ContinuumAuditEvent[], row: ContinuumAuditEvent): ContinuumAuditEvent[] {
+  const rowTs = new Date(row.ts).getTime()
+  if (!Number.isFinite(rowTs)) return [row]
+  const windowMs = 90_000
+  const out = all.filter((e) => {
+    if (!STEP_TYPES.has(e.auditType)) return false
+    const t = new Date(e.ts).getTime()
+    if (!Number.isFinite(t)) return false
+    return Math.abs(t - rowTs) <= windowMs
+  })
+  // Sort oldest-first so the modal reads chronologically.
+  out.sort((a, b) => new Date(a.ts).getTime() - new Date(b.ts).getTime())
+  if (out.length === 0) return [row]
+  return out
+}
+
+/**
+ * parseFromTo extracts a "<from> → <to>" pair from the audit event's
+ * Detail string (the catalyst-api stamps it as "switchover requested:
+ * <from> → <to> (...)"). Returns "—" placeholders when the format
+ * doesn't match.
+ */
+function parseFromTo(detail: string | undefined): { from: string; to: string } {
+  if (!detail) return { from: '—', to: '—' }
+  const m = /([a-z0-9-]+)\s*(?:→|->|→|to)\s*([a-z0-9-]+)/i.exec(detail)
+  if (!m) return { from: '—', to: '—' }
+  return { from: m[1], to: m[2] }
+}


### PR DESCRIPTION
## Summary

EPIC-6 Slice U-DR-1 (#1101) — Disaster-Recovery UI extending the AppDetail Topology tab (slice T+O+P #1160) for Applications with `placement: active-hotstandby`. Composes a switchover dialog with the K-Cont-2 7-step Sequencer list, a live status panel reading the Continuum CR status, a switchover history table backed by the slice U5-U8 audit Bus, a failback handler with optional sovereign-admin approval gate, and a read-only lua-record view.

- UI: `src/widgets/continuum/{DRSection,SwitchoverDialog,StatusPanel,SwitchoverHistory,FailbackPanel,LuaRecordView}.tsx` + `src/lib/continuum.api.ts` + extended `pages/sovereign/AppDetail/TopologyTab.tsx`.
- Server: `internal/handler/continuum.go` ships 6 handlers (GET cr, POST switchover, POST failback, POST failback/approve, GET audit, GET audit/stream); routes mounted in `cmd/api/main.go`. REUSES `applicationInstallCallerAuthorized` (owner+admin) for switchover/failback and `rbacRequireSovereignAdmin` for approve. REUSES the slice U5-U8 in-process `audit.Bus` with a `continuum-*` prefix predicate so future audit-type additions (slice F-1) require zero handler-side change.

## Test plan

- [x] `go test -count=1 -race ./internal/handler/...` clean (13 new TestHandleContinuum* + TestIsContinuumAuditType cases)
- [x] `go vet ./...` clean
- [x] `npm run typecheck` clean
- [x] 31 vitest unit assertions across SwitchoverDialog, StatusPanel, SwitchoverHistory, FailbackPanel, DRSection
- [x] 6 Playwright @1440x900 specs in `e2e/continuum-dr-section.spec.ts` (DR1 status panel, DR2 dialog open + cancel, DR3 confirm POST, DR4 switching-over progress, DR5 history modal, DR6 failback panel)
- [x] Pre-existing UI failures on `main` confirmed not introduced by this slice (per canon §7): SettingsTab/AppDetail.test.tsx 9 cases fail on clean origin/main

🤖 Generated with [Claude Code](https://claude.com/claude-code)