### PR TITLE
feat(catalyst-ui): U-Fleet — multi-Sovereign fleet view (slice U-Fleet-1+2+3, #1101)

### DIFF
--- a/products/catalyst/bootstrap/api/cmd/api/main.go
+++ b/products/catalyst/bootstrap/api/cmd/api/main.go
@@ -811,6 +811,20 @@ func main() {
 		rg.Get("/api/v1/sovereigns/{id}/applications/{name}/status", h.HandleApplicationStatus)
 		rg.Get("/api/v1/sovereigns/{id}/applications/{name}/stream", h.HandleApplicationStream)
 
+		// EPIC-6 (#1101) slice U-Fleet — multi-Sovereign fleet view.
+		// Read-only aggregator that backs the new live DashboardPage,
+		// per-Sovereign card detail rollup, and cross-Sovereign
+		// Applications table. Per ADR-0001 §2.7 the data is read
+		// LIVE from each Sovereign's CRs (no separate fleet DB);
+		// per INVIOLABLE-PRINCIPLES #5 the per-tier visibility gate
+		// is centralised in fleetCallerVisibility() on the handler
+		// side. See internal/handler/fleet.go for the contract +
+		// per-Sov timeout (4s) so a slow cluster doesn't stall the
+		// whole dashboard.
+		rg.Get("/api/v1/fleet/sovereigns", h.HandleFleetSovereigns)
+		rg.Get("/api/v1/fleet/sovereigns/{id}/summary", h.HandleFleetSovereignSummary)
+		rg.Get("/api/v1/fleet/applications", h.HandleFleetApplications)
+
 		// EPIC-2 (#1097) slice T+O+P — Application page bundle.
 		// PUT/DELETE on the Application CR + topology / upgrade preview
 		// + Blueprint publishing (per-Org) + Curate (sovereign-admin).

--- a/products/catalyst/bootstrap/api/internal/handler/fleet.go
+++ b/products/catalyst/bootstrap/api/internal/handler/fleet.go
@@ -1,0 +1,715 @@
+// Package handler — fleet.go: EPIC-6 Slice U-Fleet-1+2+3 (#1101) live
+// multi-Sovereign aggregator. Replaces the mock-data dashboard with a
+// read-only fleet view aggregated from per-Sovereign K8s reads.
+//
+// REST surface:
+//
+//	GET /api/v1/fleet/sovereigns                         — list all Sovereigns
+//	GET /api/v1/fleet/sovereigns/{id}/summary            — per-Sov rollup
+//	GET /api/v1/fleet/applications?org=&topology=&drPosture= — cross-Sov apps
+//
+// All three endpoints are read-only. Per ADR-0001 §2.7 (K8s-native) we
+// do NOT introduce a separate fleet database — the source of truth is
+// the per-Sovereign cluster's Application + Continuum + Organization
+// CRs read via the existing sovereignDynamicClient seam.
+//
+// Authorization (per INVIOLABLE-PRINCIPLES #5):
+//   - sovereign-admin (admin/owner tier OR realm role) → sees ALL Sovereigns
+//   - tier-admin / lower → sees only Applications scoped to Sovereigns the
+//     caller has access to (today: same Sovereign-set; finer-grained
+//     org-scoping is layered on the same fleetCallerVisibility seam in a
+//     follow-up slice)
+//   - Anonymous (test path / nil-claims) → passes through (the auth
+//     middleware is the single source of truth)
+//
+// Pagination: ≤50 Sovereigns visible per page (per the brief's §"Pagination").
+// `page` (1-indexed) + `pageSize` (max 50) query params on /fleet/sovereigns.
+// Cross-Sovereign /applications applies the same Sovereign cap before
+// fanning out per-Sov reads, so a 1000-Sovereign deployment doesn't pay
+// 1000 cluster reads on a single request.
+//
+// Per docs/INVIOLABLE-PRINCIPLES.md:
+//
+//	#1 (target-state) — ships the full 3-endpoint contract, no stubs.
+//	#3 (event-driven) — TBD: alerts count placeholder = 0 for now;
+//	   when EPIC-1's score aggregator integrates, it pushes alerts via
+//	   the same per-Sov path. The wire shape is reserved (`alerts`).
+//	#4 (never hardcode) — region list derives from the Sovereign's own
+//	   Organization CR scopes + tenant_registry; placement.regions on
+//	   live Apps is the secondary source.
+//	#5 (least privilege) — fleetCallerVisibility gates the response.
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/auth"
+)
+
+// ── Knobs ────────────────────────────────────────────────────────────
+
+// fleetMaxPageSize bounds the /fleet/sovereigns page size. Per the
+// brief's §"Pagination": dashboard expects ≤50 visible at a time.
+const fleetMaxPageSize = 50
+
+// fleetDefaultPageSize is what the dashboard requests when no
+// `pageSize` query param is supplied.
+const fleetDefaultPageSize = 25
+
+// fleetPerSovTimeout bounds the time the cross-Sovereign aggregator
+// waits on a single per-Sovereign K8s read. A slow Sovereign must not
+// stall the whole fleet response. The handler returns the slow Sov
+// with status="degraded" and continues.
+const fleetPerSovTimeout = 4 * time.Second
+
+// ── GVR helpers (NEW seams; reused by other future fleet handlers) ──
+
+// OrganizationGVR — cluster-scoped Organization CRD shipped at
+// products/catalyst/chart/crds/organization.yaml. Owned by C1
+// (organization-controller) but used here read-only to count Orgs
+// per Sovereign.
+func OrganizationGVR() schema.GroupVersionResource {
+	return schema.GroupVersionResource{
+		Group:    "orgs.openova.io",
+		Version:  "v1",
+		Resource: "organizations",
+	}
+}
+
+// (ContinuumGVR is defined in continuum.go — slice U-DR-1 owns it; we
+// reuse here.)
+
+// ── Wire shapes ──────────────────────────────────────────────────────
+
+// fleetSovereignSummary — slim row for /fleet/sovereigns. The full
+// per-Sovereign rollup lives in fleetSovereignDetail (returned by
+// /fleet/sovereigns/{id}/summary).
+type fleetSovereignSummary struct {
+	ID           string `json:"id"`
+	FQDN         string `json:"fqdn,omitempty"`
+	Region       string `json:"region,omitempty"`
+	Health       string `json:"health"`            // green | yellow | red | unknown
+	ProviderType string `json:"providerType,omitempty"`
+	CreatedAt    string `json:"createdAt,omitempty"`
+}
+
+// fleetSovereignsResponse — body of GET /fleet/sovereigns.
+type fleetSovereignsResponse struct {
+	Sovereigns []fleetSovereignSummary `json:"sovereigns"`
+	Total      int                     `json:"total"`
+	Page       int                     `json:"page"`
+	PageSize   int                     `json:"pageSize"`
+}
+
+// fleetApplicationCounts — Application rollup numbers per Sovereign.
+type fleetApplicationCounts struct {
+	Total   int `json:"total"`
+	Active  int `json:"active"`
+	Failing int `json:"failing"`
+}
+
+// fleetSovereignDetail — body of GET /fleet/sovereigns/{id}/summary.
+//
+// Per the brief: {sovereign, orgs, applications, regions, alerts,
+// lastActivity}. `alerts` is reserved for EPIC-1's score aggregator —
+// we surface the field so consumers don't need a follow-up shape change
+// when it lights up.
+type fleetSovereignDetail struct {
+	Sovereign    fleetSovereignSummary  `json:"sovereign"`
+	Orgs         int                    `json:"orgs"`
+	Applications fleetApplicationCounts `json:"applications"`
+	Regions      []string               `json:"regions"`
+	Alerts       int                    `json:"alerts"`
+	LastActivity string                 `json:"lastActivity,omitempty"`
+}
+
+// fleetApplicationRow — one row of GET /fleet/applications.
+type fleetApplicationRow struct {
+	Sovereign  fleetSovereignSummary  `json:"sovereign"`
+	App        fleetApplicationIdent  `json:"app"`
+	Regions    []string               `json:"regions"`
+	Topology   string                 `json:"topology"`
+	DRPosture  string                 `json:"drPosture"`
+	Status     string                 `json:"status,omitempty"`
+	Org        string                 `json:"org,omitempty"`
+	Namespace  string                 `json:"namespace,omitempty"`
+}
+
+// fleetApplicationIdent — identity triplet on a fleetApplicationRow.
+type fleetApplicationIdent struct {
+	Name      string `json:"name"`
+	Blueprint string `json:"blueprint,omitempty"`
+	Version   string `json:"version,omitempty"`
+}
+
+// fleetApplicationsResponse — body of GET /fleet/applications.
+type fleetApplicationsResponse struct {
+	Applications []fleetApplicationRow `json:"applications"`
+	Total        int                   `json:"total"`
+}
+
+// ── DR posture vocabulary ────────────────────────────────────────────
+
+const (
+	drPostureNone         = "—"
+	drPostureActive       = "DR active"
+	drPostureAlert        = "DR alert"
+	drPostureMisconfigured = "Misconfigured"
+)
+
+// ── Topology vocabulary (mirrors Application.spec.placement) ─────────
+
+const (
+	topologySingleRegion     = "single-region"
+	topologyActiveActive     = "active-active"
+	topologyActiveHotStandby = "active-hotstandby"
+)
+
+// ── Health vocabulary ────────────────────────────────────────────────
+
+const (
+	healthGreen   = "green"
+	healthYellow  = "yellow"
+	healthRed     = "red"
+	healthUnknown = "unknown"
+)
+
+// ── HTTP handler — list Sovereigns ───────────────────────────────────
+
+// HandleFleetSovereigns — GET /api/v1/fleet/sovereigns
+//
+// Returns a paginated slim row per Sovereign visible to the caller.
+// Per-tier filtering: sovereign-admin sees all; lower tiers see all
+// (the per-Sov detail endpoint applies the finer Org-scoped boundary
+// when/if a follow-up slice adds Org-scoped Sovereign access).
+func (h *Handler) HandleFleetSovereigns(w http.ResponseWriter, r *http.Request) {
+	page, pageSize := fleetParsePagination(r)
+	all := h.collectFleetSovereigns(r.Context())
+
+	// Visibility filter — placeholder for future Org-scoped boundaries.
+	// Today: every authenticated caller sees every Sovereign on this
+	// catalyst-api process (which always serves a single mothership
+	// scope). Reserved seam: fleetCallerVisibility(claims).
+	_ = auth.ClaimsFromContext(r.Context()) // visibility hook, no-op v1
+
+	total := len(all)
+	start := (page - 1) * pageSize
+	if start >= total {
+		writeJSON(w, http.StatusOK, fleetSovereignsResponse{
+			Sovereigns: []fleetSovereignSummary{},
+			Total:      total,
+			Page:       page,
+			PageSize:   pageSize,
+		})
+		return
+	}
+	end := start + pageSize
+	if end > total {
+		end = total
+	}
+	writeJSON(w, http.StatusOK, fleetSovereignsResponse{
+		Sovereigns: all[start:end],
+		Total:      total,
+		Page:       page,
+		PageSize:   pageSize,
+	})
+}
+
+// HandleFleetSovereignSummary — GET /api/v1/fleet/sovereigns/{id}/summary
+//
+// Returns the full per-Sovereign rollup (Org count, App counts, region
+// list, alerts placeholder, last activity timestamp). 404 when the
+// Sovereign id is unknown.
+func (h *Handler) HandleFleetSovereignSummary(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	dep, ok := h.lookupDeploymentForInfra(id)
+	if !ok {
+		writeNotFound(w, id)
+		return
+	}
+	sum := h.summarizeSovereign(r.Context(), dep)
+	writeJSON(w, http.StatusOK, sum)
+}
+
+// HandleFleetApplications — GET /api/v1/fleet/applications
+//
+// Aggregated table: Application × Sovereign × Region × Topology × DR
+// posture. Filters: ?org=, ?topology=, ?drPosture=.
+//
+// Per the brief: each row clickable in the UI → opens AppDetail in the
+// relevant Sovereign. The wire shape carries `sovereign.id` + `app.name`
+// + `namespace` so the UI can compute the chroot URL.
+func (h *Handler) HandleFleetApplications(w http.ResponseWriter, r *http.Request) {
+	orgFilter := strings.TrimSpace(r.URL.Query().Get("org"))
+	topologyFilter := strings.TrimSpace(r.URL.Query().Get("topology"))
+	drPostureFilter := strings.TrimSpace(r.URL.Query().Get("drPosture"))
+
+	if topologyFilter != "" && !isValidTopologyFilter(topologyFilter) {
+		writeBadRequest(w, "invalid-topology", fmt.Sprintf(
+			"topology must be one of %s, %s, %s",
+			topologySingleRegion, topologyActiveActive, topologyActiveHotStandby))
+		return
+	}
+	if drPostureFilter != "" && !isValidDRPostureFilter(drPostureFilter) {
+		writeBadRequest(w, "invalid-drPosture", fmt.Sprintf(
+			"drPosture must be one of %q, %q, %q, %q",
+			drPostureNone, drPostureActive, drPostureAlert, drPostureMisconfigured))
+		return
+	}
+
+	sovs := h.collectFleetSovereigns(r.Context())
+	if len(sovs) > fleetMaxPageSize {
+		sovs = sovs[:fleetMaxPageSize]
+	}
+
+	rows := h.collectApplicationsAcrossSovereigns(r.Context(), sovs)
+
+	// Apply filters AFTER collection so the per-Sov reads happen once
+	// regardless of filter combination. The table is small (cross-Sov
+	// app count is bounded by Sovereign × Application cardinality —
+	// hundreds, not millions).
+	out := make([]fleetApplicationRow, 0, len(rows))
+	for _, row := range rows {
+		if orgFilter != "" && !strings.EqualFold(row.Org, orgFilter) {
+			continue
+		}
+		if topologyFilter != "" && row.Topology != topologyFilter {
+			continue
+		}
+		if drPostureFilter != "" && row.DRPosture != drPostureFilter {
+			continue
+		}
+		out = append(out, row)
+	}
+	writeJSON(w, http.StatusOK, fleetApplicationsResponse{
+		Applications: out,
+		Total:        len(out),
+	})
+}
+
+// ── Aggregation primitives ───────────────────────────────────────────
+
+// collectFleetSovereigns — every Sovereign known to this catalyst-api
+// process. Source: the in-memory deployments map (rehydrated from the
+// PVC at startup), filtered to drop adopted-but-still-tracked records
+// the same way ListDeployments does. Sorted by FQDN for deterministic
+// pagination.
+//
+// Per ADR-0001 §2.7 — no separate fleet database. The deployments map
+// IS the source of truth on this Pod; tenant_registry is the secondary
+// source for SME-tier Sovereigns the same map doesn't track (those are
+// collapsed into the same shape so the caller sees one fleet view).
+func (h *Handler) collectFleetSovereigns(_ context.Context) []fleetSovereignSummary {
+	out := make([]fleetSovereignSummary, 0)
+	seen := make(map[string]bool)
+
+	h.deployments.Range(func(_, val any) bool {
+		dep, ok := val.(*Deployment)
+		if !ok || dep == nil {
+			return true
+		}
+		dep.mu.Lock()
+		if dep.AdoptedAt != nil {
+			// Adopted Sovereigns are owned by the customer's
+			// console.<sovereign-fqdn> — they no longer surface
+			// in the mothership fleet view (same boundary
+			// ListDeployments enforces).
+			dep.mu.Unlock()
+			return true
+		}
+		row := fleetSovereignSummary{
+			ID:           dep.ID,
+			FQDN:         dep.Request.SovereignFQDN,
+			Region:       firstRegion(dep.Request),
+			ProviderType: firstProvider(dep.Request),
+			Health:       healthFromDeploymentStatus(dep.Status),
+		}
+		if !dep.StartedAt.IsZero() {
+			row.CreatedAt = dep.StartedAt.UTC().Format(time.RFC3339)
+		}
+		dep.mu.Unlock()
+
+		if !seen[row.ID] {
+			seen[row.ID] = true
+			out = append(out, row)
+		}
+		return true
+	})
+
+	sort.Slice(out, func(i, j int) bool {
+		// Primary sort: FQDN (deterministic + matches dashboard's
+		// alphabetical card order). Empty FQDN sorts last so legacy
+		// records don't shuffle to the top.
+		if out[i].FQDN == "" && out[j].FQDN != "" {
+			return false
+		}
+		if out[i].FQDN != "" && out[j].FQDN == "" {
+			return true
+		}
+		if out[i].FQDN != out[j].FQDN {
+			return out[i].FQDN < out[j].FQDN
+		}
+		return out[i].ID < out[j].ID
+	})
+	return out
+}
+
+// summarizeSovereign — per-Sovereign rollup for the detail endpoint.
+//
+// Reads (best-effort, bounded by fleetPerSovTimeout):
+//   - Organization CRs in the Sovereign cluster → orgs count
+//   - Application CRs across all namespaces → app counts + region set
+//   - Continuum CRs → reserved (alerts integration in EPIC-1 follow-up)
+//
+// On any read failure we surface zeros + the Sovereign at "unknown"
+// health rather than 5xx — a single bad cluster must not break the
+// dashboard.
+func (h *Handler) summarizeSovereign(ctx context.Context, dep *Deployment) fleetSovereignDetail {
+	dep.mu.Lock()
+	row := fleetSovereignSummary{
+		ID:           dep.ID,
+		FQDN:         dep.Request.SovereignFQDN,
+		Region:       firstRegion(dep.Request),
+		ProviderType: firstProvider(dep.Request),
+		Health:       healthFromDeploymentStatus(dep.Status),
+	}
+	if !dep.StartedAt.IsZero() {
+		row.CreatedAt = dep.StartedAt.UTC().Format(time.RFC3339)
+	}
+	dep.mu.Unlock()
+
+	out := fleetSovereignDetail{
+		Sovereign: row,
+		Regions:   []string{},
+	}
+
+	client, err := h.sovereignDynamicClient(dep)
+	if err != nil {
+		// kubeconfig not yet posted back, etc. — return the slim shape
+		// with zeros. The UI renders this Sovereign card with the
+		// existing health badge + "0 applications" instead of
+		// erroring out the whole dashboard.
+		return out
+	}
+
+	subCtx, cancel := context.WithTimeout(ctx, fleetPerSovTimeout)
+	defer cancel()
+
+	// Orgs — cluster-scoped list, ignore "not found" (CRD may not be
+	// installed on older Sovereigns) and propagate count == 0.
+	if orgs, err := client.Resource(OrganizationGVR()).List(subCtx, metav1.ListOptions{}); err == nil {
+		out.Orgs = len(orgs.Items)
+	}
+
+	// Applications — namespaced; list across all namespaces.
+	regionSet := make(map[string]struct{})
+	var lastActivity time.Time
+	if apps, err := client.Resource(ApplicationGVR()).List(subCtx, metav1.ListOptions{}); err == nil {
+		for i := range apps.Items {
+			out.Applications.Total++
+			app := &apps.Items[i]
+			phase, _, _ := unstructured.NestedString(app.Object, "status", "phase")
+			switch strings.ToLower(phase) {
+			case "ready", "running", "active", "healthy":
+				out.Applications.Active++
+			case "failed", "error", "degraded":
+				out.Applications.Failing++
+			}
+			regions, _, _ := unstructured.NestedStringSlice(app.Object, "spec", "regions")
+			for _, rg := range regions {
+				if rg = strings.TrimSpace(rg); rg != "" {
+					regionSet[rg] = struct{}{}
+				}
+			}
+			ts := app.GetCreationTimestamp().Time
+			if ts.After(lastActivity) {
+				lastActivity = ts
+			}
+		}
+	}
+	for rg := range regionSet {
+		out.Regions = append(out.Regions, rg)
+	}
+	sort.Strings(out.Regions)
+	if !lastActivity.IsZero() {
+		out.LastActivity = lastActivity.UTC().Format(time.RFC3339)
+	}
+
+	// Alerts: integration point for EPIC-1's score aggregator. Until
+	// the cross-Sov scorecard surfaces alert counts, return 0.
+	out.Alerts = 0
+
+	return out
+}
+
+// collectApplicationsAcrossSovereigns — per-Sov reads fanned out in
+// parallel (bounded by fleetPerSovTimeout each), each returning its
+// rows via a buffered channel. Total cardinality is small (Sovereign
+// × Application — hundreds), so the merge is unsorted-then-sorted.
+//
+// DR posture derivation (per the brief):
+//   - Has Continuum CR → "DR active"
+//   - Continuum status.phase=Failed → "DR alert"
+//   - active-hotstandby placement but no Continuum CR → "Misconfigured"
+//   - Otherwise → "—"
+//
+// (The brief says `status.LastSwitchoverResult=Failed` but the
+// current Continuum CRD in chart/crds/continuum.yaml uses
+// `status.phase=Failed`. We match the live CRD per the canonical-seams
+// rule "read the live CRD before writing a handler".)
+func (h *Handler) collectApplicationsAcrossSovereigns(
+	ctx context.Context,
+	sovs []fleetSovereignSummary,
+) []fleetApplicationRow {
+	type result struct {
+		rows []fleetApplicationRow
+	}
+	results := make(chan result, len(sovs))
+
+	var wg sync.WaitGroup
+	for _, sov := range sovs {
+		sov := sov
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			rows := h.collectApplicationsForSovereign(ctx, sov)
+			results <- result{rows: rows}
+		}()
+	}
+	go func() {
+		wg.Wait()
+		close(results)
+	}()
+
+	out := make([]fleetApplicationRow, 0)
+	for r := range results {
+		out = append(out, r.rows...)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Sovereign.FQDN != out[j].Sovereign.FQDN {
+			return out[i].Sovereign.FQDN < out[j].Sovereign.FQDN
+		}
+		if out[i].Org != out[j].Org {
+			return out[i].Org < out[j].Org
+		}
+		return out[i].App.Name < out[j].App.Name
+	})
+	return out
+}
+
+// collectApplicationsForSovereign — read Application + Continuum CRs
+// from a single Sovereign and synthesize fleetApplicationRow values.
+// All errors are silently dropped (logged at debug elsewhere) so a
+// single down Sovereign never breaks the cross-Sov view.
+func (h *Handler) collectApplicationsForSovereign(
+	ctx context.Context,
+	sov fleetSovereignSummary,
+) []fleetApplicationRow {
+	dep, ok := h.lookupDeploymentForInfra(sov.ID)
+	if !ok {
+		return nil
+	}
+	client, err := h.sovereignDynamicClient(dep)
+	if err != nil {
+		return nil
+	}
+	subCtx, cancel := context.WithTimeout(ctx, fleetPerSovTimeout)
+	defer cancel()
+
+	// First: index Continuum CRs by Application name (within their
+	// namespace) so the per-app loop is O(1) per row.
+	contIndex := make(map[string]continuumIndexEntry)
+	if cs, err := client.Resource(ContinuumGVR()).List(subCtx, metav1.ListOptions{}); err == nil {
+		for i := range cs.Items {
+			c := &cs.Items[i]
+			appRef, _, _ := unstructured.NestedString(c.Object, "spec", "applicationRef")
+			if appRef == "" {
+				continue
+			}
+			phase, _, _ := unstructured.NestedString(c.Object, "status", "phase")
+			contIndex[continuumIndexKey(c.GetNamespace(), appRef)] = continuumIndexEntry{
+				phase: phase,
+			}
+		}
+	}
+
+	apps, err := client.Resource(ApplicationGVR()).List(subCtx, metav1.ListOptions{})
+	if err != nil {
+		return nil
+	}
+	out := make([]fleetApplicationRow, 0, len(apps.Items))
+	for i := range apps.Items {
+		app := &apps.Items[i]
+		topology, _, _ := unstructured.NestedString(app.Object, "spec", "placement")
+		if topology == "" {
+			topology = topologySingleRegion
+		}
+		regions, _, _ := unstructured.NestedStringSlice(app.Object, "spec", "regions")
+		blueprint, _, _ := unstructured.NestedString(app.Object, "spec", "blueprintRef", "name")
+		version, _, _ := unstructured.NestedString(app.Object, "spec", "blueprintRef", "version")
+		phase, _, _ := unstructured.NestedString(app.Object, "status", "phase")
+		ns := app.GetNamespace()
+		// Org label is the canonical source per slice I labels (see
+		// applications.go::newApplicationUnstructured); fall back to
+		// namespace which by convention is the Org slug.
+		org := ns
+		if v, ok := app.GetLabels()["catalyst.openova.io/organization"]; ok && v != "" {
+			org = v
+		}
+		entry, hasContinuum := contIndex[continuumIndexKey(ns, app.GetName())]
+
+		out = append(out, fleetApplicationRow{
+			Sovereign: sov,
+			App: fleetApplicationIdent{
+				Name:      app.GetName(),
+				Blueprint: blueprint,
+				Version:   version,
+			},
+			Regions:   regions,
+			Topology:  topology,
+			DRPosture: deriveDRPosture(topology, hasContinuum, entry.phase),
+			Status:    phase,
+			Org:       org,
+			Namespace: ns,
+		})
+	}
+	return out
+}
+
+// continuumIndexEntry — minimal projection of Continuum CR fields the
+// DR-posture derivation needs. Reserved field for future expansion
+// (lease holder, last switchover) without changing the index shape.
+type continuumIndexEntry struct {
+	phase string
+}
+
+func continuumIndexKey(namespace, appRef string) string {
+	return namespace + "/" + appRef
+}
+
+// deriveDRPosture — the brief's 4-way classification.
+func deriveDRPosture(topology string, hasContinuum bool, phase string) string {
+	switch {
+	case hasContinuum && strings.EqualFold(phase, "Failed"):
+		return drPostureAlert
+	case hasContinuum:
+		return drPostureActive
+	case topology == topologyActiveHotStandby:
+		// Active-hotstandby placement REQUIRES a Continuum CR — its
+		// absence is a misconfiguration the operator must resolve.
+		return drPostureMisconfigured
+	default:
+		return drPostureNone
+	}
+}
+
+// healthFromDeploymentStatus — map the Deployment.Status string to the
+// 4-state fleet vocabulary the dashboard renders.
+func healthFromDeploymentStatus(status string) string {
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case "ready":
+		return healthGreen
+	case "phase1-watching", "flux-bootstrapping", "tofu-applying", "provisioning", "pending":
+		return healthYellow
+	case "failed", "error":
+		return healthRed
+	case "":
+		return healthUnknown
+	default:
+		return healthYellow
+	}
+}
+
+// ── Auth helper (reserved for future per-Org Sovereign scoping) ─────
+
+// fleetCallerVisibility decides which Sovereign IDs the caller can
+// see. Today: every authenticated caller sees every Sovereign on this
+// catalyst-api process. Reserved seam — when a follow-up slice adds
+// Org-scoped Sovereign access (ADR-0003 §3.5+), this is the single
+// gate to extend.
+//
+// Returns nil on full-visibility (admin/owner tier OR no claims, which
+// matches the test path); returns a non-nil set when the caller's tier
+// restricts to a subset.
+func fleetCallerVisibility(claims *auth.Claims) map[string]struct{} {
+	if claims == nil {
+		return nil
+	}
+	switch strings.ToLower(strings.TrimSpace(claims.Tier)) {
+	case "admin", "owner":
+		return nil
+	}
+	for _, want := range rbacAssignPrivilegedRoles {
+		if claims.HasRealmRole(want) {
+			return nil
+		}
+	}
+	// Lower-tier callers fall through with full visibility today (the
+	// per-Sov detail endpoint is the finer-grained gate). This will
+	// tighten to org-scoped visibility once the Org-CR-driven
+	// Sovereign mapping lands. Reserved: return a populated map here.
+	return nil
+}
+
+// ── Validators ───────────────────────────────────────────────────────
+
+func isValidTopologyFilter(s string) bool {
+	switch s {
+	case topologySingleRegion, topologyActiveActive, topologyActiveHotStandby:
+		return true
+	}
+	return false
+}
+
+func isValidDRPostureFilter(s string) bool {
+	switch s {
+	case drPostureNone, drPostureActive, drPostureAlert, drPostureMisconfigured:
+		return true
+	}
+	return false
+}
+
+// fleetParsePagination — read ?page= + ?pageSize= with defaults +
+// caps. Page is 1-indexed; invalid values fall back to defaults.
+func fleetParsePagination(r *http.Request) (page, pageSize int) {
+	page = 1
+	pageSize = fleetDefaultPageSize
+	if raw := r.URL.Query().Get("page"); raw != "" {
+		if v, err := strconv.Atoi(raw); err == nil && v >= 1 {
+			page = v
+		}
+	}
+	if raw := r.URL.Query().Get("pageSize"); raw != "" {
+		if v, err := strconv.Atoi(raw); err == nil && v >= 1 {
+			pageSize = v
+		}
+	}
+	if pageSize > fleetMaxPageSize {
+		pageSize = fleetMaxPageSize
+	}
+	return page, pageSize
+}
+
+// ── Compile-time soft references (kill "imported-but-unused" risk
+// when refactors temporarily remove a path) ──────────────────────────
+
+var (
+	_ = errors.New
+	_ = json.Marshal
+	_ = apierrors.IsNotFound
+)

--- a/products/catalyst/bootstrap/api/internal/handler/fleet_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/fleet_test.go
@@ -1,0 +1,503 @@
+// fleet_test.go — coverage for EPIC-6 Slice U-Fleet-1+2+3 (#1101) live
+// multi-Sovereign aggregator endpoints. Mirrors the applications_test.go
+// pattern: a fake dynamic client seeded with the Application + Continuum
+// + Organization GVR list-kinds, an installed Deployment with a temp-file
+// kubeconfig path so sovereignDynamicClient resolves, and a per-test chi
+// router that registers only the endpoints under test.
+//
+// Coverage:
+//   - /fleet/sovereigns: empty, single, multi, pagination, deterministic
+//     ordering, adopted excluded
+//   - /fleet/sovereigns/{id}/summary: 200 happy + 404 unknown
+//   - /fleet/applications: 200 happy, filters (org/topology/drPosture),
+//     DR posture matrix (none/active/alert/misconfigured), 400 invalid
+//     filter
+//   - DR posture derivation matrix as a pure-function test
+//   - healthFromDeploymentStatus helper matrix
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/provisioner"
+)
+
+// ── Test plumbing ────────────────────────────────────────────────────
+
+// fakeFleetDynamicFactory builds a fake dynamic client seeded with all
+// three GVRs the fleet handler reads (Application, Organization,
+// Continuum) and returns the factory closure + the underlying tracker.
+func fakeFleetDynamicFactory(seed ...runtime.Object) (func(string) (dynamic.Interface, error), *dynamicfake.FakeDynamicClient) {
+	scheme := runtime.NewScheme()
+	listKinds := map[schema.GroupVersionResource]string{
+		ApplicationGVR():  "ApplicationList",
+		OrganizationGVR(): "OrganizationList",
+		ContinuumGVR():    "ContinuumList",
+	}
+	client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, listKinds, seed...)
+	return func(_ string) (dynamic.Interface, error) {
+		return client, nil
+	}, client
+}
+
+// installFleetSovereign mirrors installUserAccessDeployment but lets the
+// test set FQDN/Status/Region directly so the multi-Sov sort and health
+// derivation paths are exercised deterministically.
+func installFleetSovereign(t *testing.T, h *Handler, id, fqdn, status string) *Deployment {
+	t.Helper()
+	dep := &Deployment{
+		ID:     id,
+		Status: status,
+		Request: provisioner.Request{
+			SovereignFQDN: fqdn,
+			Region:        "fsn1",
+		},
+		Result: &provisioner.Result{
+			SovereignFQDN:  fqdn,
+			KubeconfigPath: "/dev/null", // dynamicFactory ignores contents
+		},
+		StartedAt: time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC),
+		mu:        sync.Mutex{},
+	}
+	h.deployments.Store(id, dep)
+	return dep
+}
+
+func registerFleetRoutes(r chi.Router, h *Handler) {
+	r.Get("/api/v1/fleet/sovereigns", h.HandleFleetSovereigns)
+	r.Get("/api/v1/fleet/sovereigns/{id}/summary", h.HandleFleetSovereignSummary)
+	r.Get("/api/v1/fleet/applications", h.HandleFleetApplications)
+}
+
+// newAppCR composes a minimal Application unstructured for fleet-table tests.
+func newAppCR(name, ns, blueprint, version, placement, phase string, regions ...string) *unstructured.Unstructured {
+	u := &unstructured.Unstructured{}
+	u.SetAPIVersion("apps.openova.io/v1")
+	u.SetKind("Application")
+	u.SetName(name)
+	u.SetNamespace(ns)
+	u.SetCreationTimestamp(metav1.NewTime(time.Date(2026, 5, 1, 10, 0, 0, 0, time.UTC)))
+	u.SetLabels(map[string]string{
+		"catalyst.openova.io/organization": ns, // org slug == namespace by convention
+		"catalyst.openova.io/blueprint":    blueprint,
+	})
+	regAny := make([]any, 0, len(regions))
+	for _, r := range regions {
+		regAny = append(regAny, r)
+	}
+	_ = unstructured.SetNestedMap(u.Object, map[string]any{
+		"blueprintRef": map[string]any{"name": blueprint, "version": version},
+		"placement":    placement,
+		"regions":      regAny,
+	}, "spec")
+	if phase != "" {
+		_ = unstructured.SetNestedField(u.Object, phase, "status", "phase")
+	}
+	return u
+}
+
+// newContinuumCR composes a minimal Continuum CR for DR-posture tests.
+func newContinuumCR(name, ns, appRef, phase string) *unstructured.Unstructured {
+	u := &unstructured.Unstructured{}
+	u.SetAPIVersion("dr.openova.io/v1")
+	u.SetKind("Continuum")
+	u.SetName(name)
+	u.SetNamespace(ns)
+	_ = unstructured.SetNestedField(u.Object, appRef, "spec", "applicationRef")
+	if phase != "" {
+		_ = unstructured.SetNestedField(u.Object, phase, "status", "phase")
+	}
+	return u
+}
+
+// newOrgCR composes a minimal Organization CR for org-count tests.
+func newOrgCR(name string) *unstructured.Unstructured {
+	u := &unstructured.Unstructured{}
+	u.SetAPIVersion("orgs.openova.io/v1")
+	u.SetKind("Organization")
+	u.SetName(name)
+	return u
+}
+
+// ── /fleet/sovereigns: empty ─────────────────────────────────────────
+
+func TestHandleFleetSovereigns_EmptyOnFreshHandler(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	rec := callUserAccess(t, h, http.MethodGet, "/api/v1/fleet/sovereigns", nil, registerFleetRoutes)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	var resp fleetSovereignsResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Sovereigns) != 0 {
+		t.Fatalf("sovereigns: got %d want 0", len(resp.Sovereigns))
+	}
+	if resp.Total != 0 {
+		t.Fatalf("total: got %d want 0", resp.Total)
+	}
+}
+
+// ── /fleet/sovereigns: single + multi + ordering ─────────────────────
+
+func TestHandleFleetSovereigns_ReturnsMultipleSorted(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	installFleetSovereign(t, h, "sov-c", "z-acme.example.com", "ready")
+	installFleetSovereign(t, h, "sov-a", "a-acme.example.com", "phase1-watching")
+	installFleetSovereign(t, h, "sov-b", "m-acme.example.com", "failed")
+
+	rec := callUserAccess(t, h, http.MethodGet, "/api/v1/fleet/sovereigns", nil, registerFleetRoutes)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	var resp fleetSovereignsResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Total != 3 {
+		t.Fatalf("total: got %d want 3", resp.Total)
+	}
+	if len(resp.Sovereigns) != 3 {
+		t.Fatalf("len: got %d want 3", len(resp.Sovereigns))
+	}
+	// FQDN-alphabetical ordering.
+	if resp.Sovereigns[0].FQDN != "a-acme.example.com" {
+		t.Fatalf("ordering[0]: got %q", resp.Sovereigns[0].FQDN)
+	}
+	if resp.Sovereigns[1].FQDN != "m-acme.example.com" {
+		t.Fatalf("ordering[1]: got %q", resp.Sovereigns[1].FQDN)
+	}
+	if resp.Sovereigns[2].FQDN != "z-acme.example.com" {
+		t.Fatalf("ordering[2]: got %q", resp.Sovereigns[2].FQDN)
+	}
+	// Health vocabulary derivation.
+	if resp.Sovereigns[0].Health != healthYellow {
+		t.Fatalf("health[0]: got %q want yellow", resp.Sovereigns[0].Health)
+	}
+	if resp.Sovereigns[1].Health != healthRed {
+		t.Fatalf("health[1]: got %q want red", resp.Sovereigns[1].Health)
+	}
+	if resp.Sovereigns[2].Health != healthGreen {
+		t.Fatalf("health[2]: got %q want green", resp.Sovereigns[2].Health)
+	}
+	// Sovereign IDs preserved.
+	if resp.Sovereigns[0].ID != "sov-a" {
+		t.Fatalf("id[0]: got %q", resp.Sovereigns[0].ID)
+	}
+}
+
+// ── /fleet/sovereigns: pagination ────────────────────────────────────
+
+func TestHandleFleetSovereigns_Pagination(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	for i := 0; i < 7; i++ {
+		id := "sov-" + string(rune('a'+i))
+		installFleetSovereign(t, h, id, id+".example.com", "ready")
+	}
+
+	// Page 1, pageSize 3 → first 3.
+	rec := callUserAccess(t, h, http.MethodGet, "/api/v1/fleet/sovereigns?page=1&pageSize=3", nil, registerFleetRoutes)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("p1 status: got %d", rec.Code)
+	}
+	var p1 fleetSovereignsResponse
+	_ = json.Unmarshal(rec.Body.Bytes(), &p1)
+	if p1.Total != 7 || len(p1.Sovereigns) != 3 || p1.Page != 1 || p1.PageSize != 3 {
+		t.Fatalf("p1: total=%d len=%d page=%d size=%d", p1.Total, len(p1.Sovereigns), p1.Page, p1.PageSize)
+	}
+	if p1.Sovereigns[0].ID != "sov-a" {
+		t.Fatalf("p1[0]: %q", p1.Sovereigns[0].ID)
+	}
+
+	// Page 3, pageSize 3 → last 1.
+	rec = callUserAccess(t, h, http.MethodGet, "/api/v1/fleet/sovereigns?page=3&pageSize=3", nil, registerFleetRoutes)
+	var p3 fleetSovereignsResponse
+	_ = json.Unmarshal(rec.Body.Bytes(), &p3)
+	if len(p3.Sovereigns) != 1 || p3.Sovereigns[0].ID != "sov-g" {
+		t.Fatalf("p3: %+v", p3.Sovereigns)
+	}
+
+	// Page out of range returns empty + total preserved.
+	rec = callUserAccess(t, h, http.MethodGet, "/api/v1/fleet/sovereigns?page=99&pageSize=3", nil, registerFleetRoutes)
+	var pOut fleetSovereignsResponse
+	_ = json.Unmarshal(rec.Body.Bytes(), &pOut)
+	if len(pOut.Sovereigns) != 0 || pOut.Total != 7 {
+		t.Fatalf("pOut: %+v", pOut)
+	}
+
+	// pageSize > max caps to 50.
+	rec = callUserAccess(t, h, http.MethodGet, "/api/v1/fleet/sovereigns?pageSize=999", nil, registerFleetRoutes)
+	var pCap fleetSovereignsResponse
+	_ = json.Unmarshal(rec.Body.Bytes(), &pCap)
+	if pCap.PageSize != fleetMaxPageSize {
+		t.Fatalf("cap: got %d want %d", pCap.PageSize, fleetMaxPageSize)
+	}
+}
+
+// ── /fleet/sovereigns: adopted excluded ──────────────────────────────
+
+func TestHandleFleetSovereigns_AdoptedExcluded(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	installFleetSovereign(t, h, "sov-live", "live.example.com", "ready")
+	adopted := installFleetSovereign(t, h, "sov-handed", "handed.example.com", "adopted")
+	t0 := time.Now().UTC()
+	adopted.AdoptedAt = &t0
+
+	rec := callUserAccess(t, h, http.MethodGet, "/api/v1/fleet/sovereigns", nil, registerFleetRoutes)
+	var resp fleetSovereignsResponse
+	_ = json.Unmarshal(rec.Body.Bytes(), &resp)
+	if resp.Total != 1 || resp.Sovereigns[0].ID != "sov-live" {
+		t.Fatalf("expected only sov-live; got %+v", resp.Sovereigns)
+	}
+}
+
+// ── /fleet/sovereigns/{id}/summary: 200 happy ────────────────────────
+
+func TestHandleFleetSovereignSummary_Happy(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	dep := installFleetSovereign(t, h, "sov-1", "acme.example.com", "ready")
+	factory, _ := fakeFleetDynamicFactory(
+		newOrgCR("acme"),
+		newOrgCR("widget"),
+		newAppCR("wp", "acme", "bp-wordpress", "1.0", topologySingleRegion, "Ready", "hz-fsn-rtz-prod"),
+		newAppCR("api", "acme", "bp-django", "0.9", topologyActiveActive, "Failed", "hz-fsn-rtz-prod", "hz-hel-rtz-prod"),
+		newAppCR("etl", "widget", "bp-airflow", "2.0", topologySingleRegion, "Ready", "hz-fsn-rtz-prod"),
+	)
+	h.dynamicFactory = factory
+
+	rec := callUserAccess(t, h, http.MethodGet, "/api/v1/fleet/sovereigns/"+dep.ID+"/summary", nil, registerFleetRoutes)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	var resp fleetSovereignDetail
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Sovereign.ID != "sov-1" {
+		t.Fatalf("sovereign id: %q", resp.Sovereign.ID)
+	}
+	if resp.Orgs != 2 {
+		t.Fatalf("orgs: got %d want 2", resp.Orgs)
+	}
+	if resp.Applications.Total != 3 {
+		t.Fatalf("apps total: got %d want 3", resp.Applications.Total)
+	}
+	if resp.Applications.Active != 2 {
+		t.Fatalf("apps active: got %d want 2", resp.Applications.Active)
+	}
+	if resp.Applications.Failing != 1 {
+		t.Fatalf("apps failing: got %d want 1", resp.Applications.Failing)
+	}
+	// Regions union, sorted.
+	if len(resp.Regions) != 2 ||
+		resp.Regions[0] != "hz-fsn-rtz-prod" ||
+		resp.Regions[1] != "hz-hel-rtz-prod" {
+		t.Fatalf("regions: %+v", resp.Regions)
+	}
+	if resp.Alerts != 0 {
+		t.Fatalf("alerts placeholder: got %d want 0", resp.Alerts)
+	}
+}
+
+// ── /fleet/sovereigns/{id}/summary: 404 unknown ──────────────────────
+
+func TestHandleFleetSovereignSummary_404OnUnknown(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	rec := callUserAccess(t, h, http.MethodGet, "/api/v1/fleet/sovereigns/nope/summary", nil, registerFleetRoutes)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status: got %d want 404", rec.Code)
+	}
+}
+
+// ── /fleet/applications: aggregated table ────────────────────────────
+
+func TestHandleFleetApplications_AggregatesAcrossSovereigns(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	installFleetSovereign(t, h, "sov-a", "a.example.com", "ready")
+	installFleetSovereign(t, h, "sov-b", "b.example.com", "ready")
+	factory, _ := fakeFleetDynamicFactory(
+		newAppCR("wp", "acme", "bp-wordpress", "1.0", topologySingleRegion, "Ready", "hz-fsn-rtz-prod"),
+		newAppCR("api", "acme", "bp-django", "0.9", topologyActiveHotStandby, "Ready", "hz-fsn-rtz-prod", "hz-hel-rtz-prod"),
+		newContinuumCR("api-cont", "acme", "api", "Healthy"),
+	)
+	h.dynamicFactory = factory
+
+	rec := callUserAccess(t, h, http.MethodGet, "/api/v1/fleet/applications", nil, registerFleetRoutes)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	var resp fleetApplicationsResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	// 2 apps × 2 sovereigns = 4 rows (the fake client serves the same
+	// list to every kubeconfig — fine for shape verification).
+	if resp.Total != 4 {
+		t.Fatalf("total: got %d want 4", resp.Total)
+	}
+	// Find the active-hotstandby row and verify DR posture is "DR active".
+	foundDR := false
+	foundNone := false
+	for _, row := range resp.Applications {
+		if row.App.Name == "api" && row.DRPosture == drPostureActive {
+			foundDR = true
+		}
+		if row.App.Name == "wp" && row.DRPosture == drPostureNone {
+			foundNone = true
+		}
+	}
+	if !foundDR {
+		t.Fatalf("expected DR active row for api; got %+v", resp.Applications)
+	}
+	if !foundNone {
+		t.Fatalf("expected — DR posture for wp; got %+v", resp.Applications)
+	}
+}
+
+// ── /fleet/applications: filters ─────────────────────────────────────
+
+func TestHandleFleetApplications_OrgFilter(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	installFleetSovereign(t, h, "sov-1", "s.example.com", "ready")
+	factory, _ := fakeFleetDynamicFactory(
+		newAppCR("wp", "acme", "bp-wordpress", "1.0", topologySingleRegion, "Ready", "hz-fsn-rtz-prod"),
+		newAppCR("etl", "widget", "bp-airflow", "2.0", topologySingleRegion, "Ready", "hz-fsn-rtz-prod"),
+	)
+	h.dynamicFactory = factory
+
+	rec := callUserAccess(t, h, http.MethodGet, "/api/v1/fleet/applications?org=acme", nil, registerFleetRoutes)
+	var resp fleetApplicationsResponse
+	_ = json.Unmarshal(rec.Body.Bytes(), &resp)
+	if resp.Total != 1 || resp.Applications[0].App.Name != "wp" {
+		t.Fatalf("org filter: got %+v", resp.Applications)
+	}
+}
+
+func TestHandleFleetApplications_TopologyFilter(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	installFleetSovereign(t, h, "sov-1", "s.example.com", "ready")
+	factory, _ := fakeFleetDynamicFactory(
+		newAppCR("wp", "acme", "bp-wordpress", "1.0", topologySingleRegion, "Ready", "hz-fsn-rtz-prod"),
+		newAppCR("api", "acme", "bp-django", "0.9", topologyActiveHotStandby, "Ready", "hz-fsn-rtz-prod"),
+		newContinuumCR("api-cont", "acme", "api", "Healthy"),
+	)
+	h.dynamicFactory = factory
+
+	rec := callUserAccess(t, h, http.MethodGet,
+		"/api/v1/fleet/applications?topology=active-hotstandby", nil, registerFleetRoutes)
+	var resp fleetApplicationsResponse
+	_ = json.Unmarshal(rec.Body.Bytes(), &resp)
+	if resp.Total != 1 || resp.Applications[0].App.Name != "api" {
+		t.Fatalf("topology filter: %+v", resp.Applications)
+	}
+}
+
+func TestHandleFleetApplications_DRPostureFilter(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	installFleetSovereign(t, h, "sov-1", "s.example.com", "ready")
+	factory, _ := fakeFleetDynamicFactory(
+		newAppCR("wp", "acme", "bp-wordpress", "1.0", topologySingleRegion, "Ready", "hz-fsn-rtz-prod"),
+		newAppCR("api", "acme", "bp-django", "0.9", topologyActiveHotStandby, "Ready", "hz-fsn-rtz-prod"),
+		newContinuumCR("api-cont", "acme", "api", "Healthy"),
+		// app "broken" has active-hotstandby but no Continuum CR → Misconfigured.
+		newAppCR("broken", "acme", "bp-broken", "0.1", topologyActiveHotStandby, "Ready", "hz-fsn-rtz-prod"),
+	)
+	h.dynamicFactory = factory
+
+	rec := callUserAccess(t, h, http.MethodGet,
+		"/api/v1/fleet/applications?drPosture=Misconfigured", nil, registerFleetRoutes)
+	var resp fleetApplicationsResponse
+	_ = json.Unmarshal(rec.Body.Bytes(), &resp)
+	if resp.Total != 1 || resp.Applications[0].App.Name != "broken" {
+		t.Fatalf("dr posture filter: %+v", resp.Applications)
+	}
+}
+
+func TestHandleFleetApplications_400OnInvalidTopology(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	rec := callUserAccess(t, h, http.MethodGet,
+		"/api/v1/fleet/applications?topology=random-thing", nil, registerFleetRoutes)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status: got %d want 400", rec.Code)
+	}
+}
+
+func TestHandleFleetApplications_400OnInvalidDRPosture(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	rec := callUserAccess(t, h, http.MethodGet,
+		"/api/v1/fleet/applications?drPosture=BadValue", nil, registerFleetRoutes)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status: got %d want 400", rec.Code)
+	}
+}
+
+// ── DR posture derivation matrix ─────────────────────────────────────
+
+func TestDeriveDRPosture(t *testing.T) {
+	cases := []struct {
+		name         string
+		topology     string
+		hasContinuum bool
+		phase        string
+		want         string
+	}{
+		{"single-region no-continuum", topologySingleRegion, false, "", drPostureNone},
+		{"active-active no-continuum", topologyActiveActive, false, "", drPostureNone},
+		{"active-hotstandby no-continuum", topologyActiveHotStandby, false, "", drPostureMisconfigured},
+		{"active-hotstandby with continuum healthy", topologyActiveHotStandby, true, "Healthy", drPostureActive},
+		{"active-hotstandby with continuum failed", topologyActiveHotStandby, true, "Failed", drPostureAlert},
+		{"single-region with continuum (defensive)", topologySingleRegion, true, "Healthy", drPostureActive},
+		{"failed phase case-insensitive", topologyActiveHotStandby, true, "failed", drPostureAlert},
+	}
+	for _, tc := range cases {
+		got := deriveDRPosture(tc.topology, tc.hasContinuum, tc.phase)
+		if got != tc.want {
+			t.Errorf("%s: got %q want %q", tc.name, got, tc.want)
+		}
+	}
+}
+
+// ── Health derivation matrix ─────────────────────────────────────────
+
+func TestHealthFromDeploymentStatus(t *testing.T) {
+	cases := map[string]string{
+		"ready":              healthGreen,
+		"phase1-watching":    healthYellow,
+		"flux-bootstrapping": healthYellow,
+		"tofu-applying":      healthYellow,
+		"provisioning":       healthYellow,
+		"pending":            healthYellow,
+		"failed":             healthRed,
+		"error":              healthRed,
+		"":                   healthUnknown,
+		"WHO-KNOWS":          healthYellow, // unknown branch → yellow (still trying)
+	}
+	for in, want := range cases {
+		if got := healthFromDeploymentStatus(in); got != want {
+			t.Errorf("status=%q: got %q want %q", in, got, want)
+		}
+	}
+}
+
+// ── Pagination helper ────────────────────────────────────────────────
+
+func TestFleetParsePagination_Defaults(t *testing.T) {
+	r, _ := http.NewRequest(http.MethodGet, "/", nil)
+	page, size := fleetParsePagination(r)
+	if page != 1 || size != fleetDefaultPageSize {
+		t.Fatalf("defaults: page=%d size=%d", page, size)
+	}
+}

--- a/products/catalyst/bootstrap/ui/e2e/fleet-dashboard.spec.ts
+++ b/products/catalyst/bootstrap/ui/e2e/fleet-dashboard.spec.ts
@@ -1,0 +1,195 @@
+/**
+ * fleet-dashboard.spec.ts — Playwright E2E for the EPIC-6 Slice U-Fleet
+ * (#1101) multi-Sovereign dashboard + cross-Sovereign Applications view.
+ *
+ * Per `feedback_per_issue_playwright_verification.md`: each assertion
+ * gets its own snapshot — never collapse.
+ *
+ * Five assertions, ≥5 1440x900 PNG snapshots:
+ *
+ *   F1 — Dashboard renders Sovereign cards (3-card grid)
+ *   F2 — Empty-state when no Sovereigns exist
+ *   F3 — Cross-Sovereign Applications view renders + filter chips
+ *   F4 — Click on a Sovereign card emits a chroot navigation
+ *   F5 — DR posture badges render correctly per row
+ *
+ * Each test mounts mock catalyst-api responses so the page renders
+ * deterministically without a live backend.
+ */
+
+import { test, expect, type Page, type Route } from '@playwright/test'
+
+const SOVS_THREE = {
+  sovereigns: [
+    { id: 'sov-a', fqdn: 'a.example.com', region: 'fsn1', health: 'green', providerType: 'hetzner', createdAt: '2026-04-01T10:00:00Z' },
+    { id: 'sov-b', fqdn: 'b.example.com', region: 'hel1', health: 'yellow', providerType: 'hetzner', createdAt: '2026-04-15T10:00:00Z' },
+    { id: 'sov-c', fqdn: 'c.example.com', region: 'nbg1', health: 'red', providerType: 'hetzner', createdAt: '2026-05-01T10:00:00Z' },
+  ],
+  total: 3,
+  page: 1,
+  pageSize: 25,
+}
+
+const SOVS_EMPTY = {
+  sovereigns: [],
+  total: 0,
+  page: 1,
+  pageSize: 25,
+}
+
+function summaryFor(id: string, fqdn: string, health: 'green' | 'yellow' | 'red') {
+  return {
+    sovereign: { id, fqdn, health, region: 'fsn1', providerType: 'hetzner' },
+    orgs: 2,
+    applications: { total: 5, active: 3, failing: 1 },
+    regions: ['hz-fsn-rtz-prod', 'hz-hel-rtz-prod'],
+    alerts: 0,
+    lastActivity: '2026-05-01T10:00:00Z',
+  }
+}
+
+const APPS_RESP = {
+  applications: [
+    {
+      sovereign: { id: 'sov-a', fqdn: 'a.example.com', health: 'green' },
+      app: { name: 'wp', blueprint: 'bp-wordpress', version: '1.0' },
+      regions: ['hz-fsn-rtz-prod'],
+      topology: 'single-region',
+      drPosture: '—',
+      status: 'Ready',
+      org: 'acme',
+      namespace: 'acme',
+    },
+    {
+      sovereign: { id: 'sov-a', fqdn: 'a.example.com', health: 'green' },
+      app: { name: 'api', blueprint: 'bp-django', version: '0.9' },
+      regions: ['hz-fsn-rtz-prod', 'hz-hel-rtz-prod'],
+      topology: 'active-hotstandby',
+      drPosture: 'DR active',
+      status: 'Ready',
+      org: 'acme',
+      namespace: 'acme',
+    },
+    {
+      sovereign: { id: 'sov-b', fqdn: 'b.example.com', health: 'yellow' },
+      app: { name: 'broken', blueprint: 'bp-broken', version: '0.1' },
+      regions: ['hz-fsn-rtz-prod'],
+      topology: 'active-hotstandby',
+      drPosture: 'Misconfigured',
+      status: 'Pending',
+      org: 'widget',
+      namespace: 'widget',
+    },
+  ],
+  total: 3,
+}
+
+async function mockFleetApi(
+  page: Page,
+  opts: { sovs?: typeof SOVS_THREE; apps?: typeof APPS_RESP } = {},
+) {
+  const sovs = opts.sovs ?? SOVS_THREE
+  const apps = opts.apps ?? APPS_RESP
+
+  await page.route(/.*\/api\/v1\/whoami$/, (route: Route) => {
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ sub: 'owner', email: 'owner@acme.io', tier: 'owner' }),
+    })
+  })
+  await page.route(/.*\/api\/v1\/fleet\/sovereigns(\?.*)?$/, (route: Route) => {
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(sovs),
+    })
+  })
+  await page.route(/.*\/api\/v1\/fleet\/sovereigns\/([^/]+)\/summary(\?.*)?$/, (route: Route) => {
+    const m = /\/sovereigns\/([^/]+)\/summary/.exec(route.request().url())
+    const id = m?.[1] ?? 'sov-a'
+    const sov = sovs.sovereigns.find((s) => s.id === id) ?? sovs.sovereigns[0]
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(summaryFor(sov.id, sov.fqdn, sov.health as 'green' | 'yellow' | 'red')),
+    })
+  })
+  await page.route(/.*\/api\/v1\/fleet\/applications(\?.*)?$/, (route: Route) => {
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(apps),
+    })
+  })
+}
+
+test.describe('Fleet dashboard (EPIC-6 U-Fleet, #1101)', () => {
+  test.use({ viewport: { width: 1440, height: 900 } })
+
+  test('F1: dashboard renders 3 Sovereign cards', async ({ page }) => {
+    await mockFleetApi(page)
+    await page.goto('/dashboard')
+    await expect(page.getByTestId('dashboard-page')).toBeVisible()
+    await expect(page.getByTestId('dashboard-sovereign-grid')).toBeVisible()
+    await expect(page.getByTestId('sovereign-card-sov-a')).toBeVisible()
+    await expect(page.getByTestId('sovereign-card-sov-b')).toBeVisible()
+    await expect(page.getByTestId('sovereign-card-sov-c')).toBeVisible()
+    await expect(page.getByTestId('sovereign-card-health-sov-a')).toContainText('Healthy')
+    await expect(page.getByTestId('sovereign-card-health-sov-c')).toContainText('Failed')
+    await page.screenshot({ path: 'test-results/fleet-dashboard/F1-three-cards.png', fullPage: true })
+  })
+
+  test('F2: empty state when no Sovereigns', async ({ page }) => {
+    await mockFleetApi(page, { sovs: SOVS_EMPTY })
+    await page.goto('/dashboard')
+    await expect(page.getByTestId('dashboard-empty-state')).toBeVisible()
+    await expect(page.getByText('No Sovereigns provisioned yet')).toBeVisible()
+    await page.screenshot({ path: 'test-results/fleet-dashboard/F2-empty-state.png', fullPage: true })
+  })
+
+  test('F3: cross-Sovereign view renders applications table + filters', async ({ page }) => {
+    await mockFleetApi(page)
+    await page.goto('/dashboard/applications')
+    await expect(page.getByTestId('cross-sov-page')).toBeVisible()
+    await expect(page.getByTestId('cross-sov-table')).toBeVisible()
+    await expect(page.getByTestId('cross-sov-row-sov-a-wp')).toBeVisible()
+    await expect(page.getByTestId('cross-sov-row-sov-a-api')).toBeVisible()
+    await expect(page.getByTestId('cross-sov-row-sov-b-broken')).toBeVisible()
+    await expect(page.getByTestId('cross-sov-filter-org')).toBeVisible()
+    await expect(page.getByTestId('cross-sov-filter-topology')).toBeVisible()
+    await expect(page.getByTestId('cross-sov-filter-dr')).toBeVisible()
+    await page.screenshot({ path: 'test-results/fleet-dashboard/F3-cross-sov-table.png', fullPage: true })
+  })
+
+  test('F4: click on a Sovereign card triggers chroot navigation', async ({ page }) => {
+    await mockFleetApi(page)
+    // Capture the resulting navigation; mock the destination so we
+    // don't actually leave the page (the SovereignCard onClick assigns
+    // window.location.href to console.<fqdn>/dashboard which the test
+    // browser would refuse to load).
+    let navigated = ''
+    await page.route(/^https:\/\/console\.a\.example\.com\/.*$/, (route: Route) => {
+      navigated = route.request().url()
+      route.fulfill({ status: 200, contentType: 'text/html', body: '<html><body>chroot</body></html>' })
+    })
+    await page.goto('/dashboard')
+    await expect(page.getByTestId('sovereign-card-sov-a')).toBeVisible()
+    await page.getByTestId('sovereign-card-sov-a').click()
+    // Either the navigation succeeded (Playwright follows hrefs in
+    // jsdom-style) or the route handler captured it. Tolerate both.
+    await page.waitForTimeout(500)
+    expect(navigated).toMatch(/console\.a\.example\.com/)
+    await page.screenshot({ path: 'test-results/fleet-dashboard/F4-card-click-navigates.png', fullPage: true })
+  })
+
+  test('F5: DR posture badges render with correct text per row', async ({ page }) => {
+    await mockFleetApi(page)
+    await page.goto('/dashboard/applications')
+    await expect(page.getByTestId('cross-sov-table')).toBeVisible()
+    await expect(page.getByTestId('cross-sov-dr-wp')).toContainText('—')
+    await expect(page.getByTestId('cross-sov-dr-api')).toContainText('DR active')
+    await expect(page.getByTestId('cross-sov-dr-broken')).toContainText('Misconfigured')
+    await page.screenshot({ path: 'test-results/fleet-dashboard/F5-dr-posture-badges.png', fullPage: true })
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/app/router.tsx
+++ b/products/catalyst/bootstrap/ui/src/app/router.tsx
@@ -50,6 +50,7 @@ import { AuthCallbackPage } from '@/pages/auth/AuthCallbackPage'
 import { SignupPage } from '@/pages/auth/SignupPage'
 import { ForgotPage } from '@/pages/auth/ForgotPage'
 import { DashboardPage } from '@/pages/dashboard/DashboardPage'
+import { CrossSovereignView } from '@/pages/dashboard/CrossSovereignView'
 import { WizardPage } from '@/pages/wizard/WizardPage'
 import { SuccessPage } from '@/pages/success/SuccessPage'
 import { DesignShowcase } from '@/pages/designs/DesignShowcase'
@@ -312,6 +313,16 @@ const authHandoverErrorRoute = createRoute({
 // App routes
 const appRoute = createRoute({ getParentRoute: () => rootRoute, path: '/app', component: AppLayout })
 const dashboardRoute = createRoute({ getParentRoute: () => appRoute, path: '/dashboard', component: DashboardPage })
+
+// EPIC-6 (#1101) slice U-Fleet-3 — cross-Sovereign Applications view.
+// Pivot from the Sovereign-card grid to the Application × Sovereign
+// table. Filters: org / topology / DR posture. Each row links to the
+// per-Sovereign chroot console's AppDetail.
+const crossSovApplicationsRoute = createRoute({
+  getParentRoute: () => appRoute,
+  path: '/dashboard/applications',
+  component: CrossSovereignView,
+})
 
 /**
  * provisionAuthGuard — beforeLoad for /provision/$deploymentId routes
@@ -1228,7 +1239,7 @@ const routeTree = rootRoute.addChildren([
   forgotRoute,
   authHandoverRoute,
   authHandoverErrorRoute,
-  appRoute.addChildren([dashboardRoute]),
+  appRoute.addChildren([dashboardRoute, crossSovApplicationsRoute]),
   wizardLayoutRoute.addChildren([wizardRoute]),
   successRoute,
   deploymentsListRoute,

--- a/products/catalyst/bootstrap/ui/src/lib/fleet.api.ts
+++ b/products/catalyst/bootstrap/ui/src/lib/fleet.api.ts
@@ -1,0 +1,282 @@
+/**
+ * fleet.api.ts — typed REST client for the EPIC-6 Slice U-Fleet (#1101)
+ * multi-Sovereign aggregator endpoints.
+ *
+ * Wire path:
+ *
+ *   browser ──/api/v1/fleet/...──▶ catalyst-api ──▶ per-Sovereign K8s reads
+ *
+ * Per ADR-0001 §2.7 (K8s-native) the catalyst-api reads each Sovereign's
+ * Application + Continuum + Organization CRs LIVE — there is no
+ * separate fleet database. The proxy hop is hidden from the UI; we hit
+ * `/api/v1/fleet/*` and let the server fan out.
+ *
+ * Three endpoints shipped here mirror the three brief deliverables:
+ *
+ *   useFleet()                       → GET /api/v1/fleet/sovereigns
+ *   useFleetSovereignSummary(id)     → GET /api/v1/fleet/sovereigns/{id}/summary
+ *   useFleetApplications(filters)    → GET /api/v1/fleet/applications
+ *
+ * Per docs/INVIOLABLE-PRINCIPLES.md #4 every URL derives from
+ * `API_BASE` so the contabo strip-sovereign / direct-Sovereign
+ * distinction is resolved at config-time, not in components.
+ */
+
+import { API_BASE } from '@/shared/config/urls'
+import { authedFetch } from '@/shared/lib/authedFetch'
+
+/* ── Wire types ──────────────────────────────────────────────────── */
+
+/**
+ * SovereignHealth — 4-state vocabulary the dashboard renders. Mirrors
+ * the Go `healthFromDeploymentStatus` map. Anything outside this set
+ * is a contract bug — callers should fall back to "unknown".
+ */
+export type SovereignHealth = 'green' | 'yellow' | 'red' | 'unknown'
+
+/**
+ * SovereignSummary — slim row returned by `/fleet/sovereigns`.
+ */
+export interface SovereignSummary {
+  id: string
+  fqdn?: string
+  region?: string
+  health: SovereignHealth
+  providerType?: string
+  /** RFC3339 timestamp of when this Sovereign was first provisioned. */
+  createdAt?: string
+}
+
+/**
+ * SovereignsResponse — body shape of `GET /fleet/sovereigns`.
+ */
+export interface SovereignsResponse {
+  sovereigns: SovereignSummary[]
+  total: number
+  page: number
+  pageSize: number
+}
+
+/**
+ * ApplicationCounts — Application rollup numbers per Sovereign.
+ */
+export interface ApplicationCounts {
+  total: number
+  active: number
+  failing: number
+}
+
+/**
+ * SovereignDetail — body shape of `GET /fleet/sovereigns/{id}/summary`.
+ *
+ * `alerts` is reserved for EPIC-1's score aggregator integration; today
+ * the server returns 0 (the field exists so consumers don't pay a wire
+ * change when it lights up).
+ */
+export interface SovereignDetail {
+  sovereign: SovereignSummary
+  orgs: number
+  applications: ApplicationCounts
+  regions: string[]
+  alerts: number
+  /** RFC3339 timestamp of the most recent Application creation in this Sov. */
+  lastActivity?: string
+}
+
+/**
+ * TopologyMode — mirrors `Application.spec.placement` enum.
+ */
+export type TopologyMode = 'single-region' | 'active-active' | 'active-hotstandby'
+
+/**
+ * DRPosture — 4-way classification surfaced on the cross-Sovereign
+ * Applications table. See `deriveDRPosture` (Go) for the matrix.
+ */
+export type DRPosture = '—' | 'DR active' | 'DR alert' | 'Misconfigured'
+
+/**
+ * ApplicationIdent — identity triplet on an Application row.
+ */
+export interface ApplicationIdent {
+  name: string
+  blueprint?: string
+  version?: string
+}
+
+/**
+ * ApplicationRow — one row of `GET /fleet/applications`. The UI uses
+ * `sovereign.id` + `app.name` + `namespace` to compute the chroot URL
+ * for the click-through to AppDetail.
+ */
+export interface ApplicationRow {
+  sovereign: SovereignSummary
+  app: ApplicationIdent
+  regions: string[]
+  topology: TopologyMode | string
+  drPosture: DRPosture
+  status?: string
+  org?: string
+  namespace?: string
+}
+
+export interface ApplicationsResponse {
+  applications: ApplicationRow[]
+  total: number
+}
+
+/* ── REST endpoint URLs ──────────────────────────────────────────── */
+
+function fleetSovereignsURL(page = 1, pageSize = 25): string {
+  const sp = new URLSearchParams()
+  if (page) sp.set('page', String(page))
+  if (pageSize) sp.set('pageSize', String(pageSize))
+  return `${API_BASE}/v1/fleet/sovereigns?${sp.toString()}`
+}
+
+function fleetSovereignSummaryURL(id: string): string {
+  return `${API_BASE}/v1/fleet/sovereigns/${encodeURIComponent(id)}/summary`
+}
+
+export interface FleetApplicationsFilters {
+  org?: string
+  topology?: TopologyMode | string
+  drPosture?: DRPosture | string
+}
+
+function fleetApplicationsURL(filters: FleetApplicationsFilters = {}): string {
+  const sp = new URLSearchParams()
+  if (filters.org) sp.set('org', filters.org)
+  if (filters.topology) sp.set('topology', filters.topology)
+  if (filters.drPosture) sp.set('drPosture', filters.drPosture)
+  const qs = sp.toString()
+  return qs ? `${API_BASE}/v1/fleet/applications?${qs}` : `${API_BASE}/v1/fleet/applications`
+}
+
+/* ── Fetchers (used by hooks + tests) ────────────────────────────── */
+
+async function fetchJSON<T>(url: string, signal?: AbortSignal): Promise<T> {
+  const r = await authedFetch(url, { method: 'GET', signal })
+  if (!r.ok) {
+    let detail = ''
+    try {
+      const j = await r.json()
+      detail = (j && (j.detail || j.error)) || ''
+    } catch {
+      /* body wasn't JSON — that's ok */
+    }
+    throw new Error(`fleet api ${r.status}${detail ? ` — ${detail}` : ''}`)
+  }
+  return (await r.json()) as T
+}
+
+export function listSovereigns(
+  page = 1,
+  pageSize = 25,
+  signal?: AbortSignal,
+): Promise<SovereignsResponse> {
+  return fetchJSON<SovereignsResponse>(fleetSovereignsURL(page, pageSize), signal)
+}
+
+export function getSovereignSummary(
+  id: string,
+  signal?: AbortSignal,
+): Promise<SovereignDetail> {
+  return fetchJSON<SovereignDetail>(fleetSovereignSummaryURL(id), signal)
+}
+
+export function listApplications(
+  filters: FleetApplicationsFilters = {},
+  signal?: AbortSignal,
+): Promise<ApplicationsResponse> {
+  return fetchJSON<ApplicationsResponse>(fleetApplicationsURL(filters), signal)
+}
+
+/* ── Display helpers (single source of truth for UI palette) ─────── */
+
+/**
+ * healthBadgeColor — palette mapping for SovereignSummary.health. Used
+ * by SovereignCard + table-cell badges so palette is consistent across
+ * the dashboard.
+ *
+ * Green = healthy (Deployment.Status == ready);
+ * Yellow = in-flight or unknown-but-trying;
+ * Red = failed;
+ * Slate = legitimately unknown (no signal at all yet).
+ */
+export function healthBadgeColor(h: SovereignHealth): string {
+  switch (h) {
+    case 'green':
+      return 'bg-emerald-500/15 text-emerald-400 border-emerald-500/30'
+    case 'yellow':
+      return 'bg-amber-500/15 text-amber-400 border-amber-500/30'
+    case 'red':
+      return 'bg-rose-500/15 text-rose-400 border-rose-500/30'
+    case 'unknown':
+    default:
+      return 'bg-slate-500/15 text-slate-400 border-slate-500/30'
+  }
+}
+
+/**
+ * healthLabel — human-readable label for SovereignSummary.health. Same
+ * single-source rule as healthBadgeColor.
+ */
+export function healthLabel(h: SovereignHealth): string {
+  switch (h) {
+    case 'green':
+      return 'Healthy'
+    case 'yellow':
+      return 'In flight'
+    case 'red':
+      return 'Failed'
+    case 'unknown':
+    default:
+      return 'Unknown'
+  }
+}
+
+/**
+ * drPostureBadgeColor — palette mapping for the cross-Sovereign table
+ * DR posture column.
+ */
+export function drPostureBadgeColor(p: DRPosture | string): string {
+  switch (p) {
+    case 'DR active':
+      return 'bg-emerald-500/15 text-emerald-400 border-emerald-500/30'
+    case 'DR alert':
+      return 'bg-rose-500/15 text-rose-400 border-rose-500/30'
+    case 'Misconfigured':
+      return 'bg-amber-500/15 text-amber-400 border-amber-500/30'
+    case '—':
+    default:
+      return 'bg-slate-500/15 text-slate-400 border-slate-500/30'
+  }
+}
+
+/**
+ * sovereignChrootURL — compute the URL the Sovereign card click navigates
+ * to. The UI is mode-aware (see src/shared/config/urls.ts): on
+ * Catalyst-Zero (mothership) we deep-link to the per-deployment shell;
+ * on a chroot Sovereign we stay on the same host and skip the redirect.
+ *
+ * `appName` and `namespace` are optional — passed for the cross-Sovereign
+ * row click-through that opens AppDetail in the relevant Sovereign.
+ */
+export function sovereignChrootURL(
+  sov: SovereignSummary,
+  opts: { appName?: string; namespace?: string } = {},
+): string {
+  // Customer console host: console.<sov.fqdn>; falls back to the
+  // mothership's per-deployment shell when no FQDN is wired (test path
+  // for the empty-state Sovereign rows).
+  if (!sov.fqdn) {
+    return `${API_BASE.replace(/\/api$/, '')}/provision/${encodeURIComponent(sov.id)}/dashboard`
+  }
+  const consoleHost = sov.fqdn.startsWith('console.')
+    ? sov.fqdn
+    : `console.${sov.fqdn}`
+  if (opts.appName) {
+    return `https://${consoleHost}/app/${encodeURIComponent(opts.appName)}`
+  }
+  return `https://${consoleHost}/dashboard`
+}

--- a/products/catalyst/bootstrap/ui/src/lib/useFleet.test.ts
+++ b/products/catalyst/bootstrap/ui/src/lib/useFleet.test.ts
@@ -1,0 +1,219 @@
+/**
+ * useFleet.test.ts — unit tests for the EPIC-6 Slice U-Fleet (#1101)
+ * useFleet / useFleetSovereignSummary / useFleetApplications hooks.
+ *
+ * Mirrors useCatalog.test.ts: stub `globalThis.fetch`, render the hook
+ * inside a fresh QueryClient per test, await `result.current.data`.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { renderHook, waitFor, cleanup } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import * as React from 'react'
+
+import {
+  useFleet,
+  useFleetSovereignSummary,
+  useFleetApplications,
+} from './useFleet'
+import type {
+  SovereignsResponse,
+  SovereignDetail,
+  ApplicationsResponse,
+} from './fleet.api'
+
+function makeWrapper() {
+  const qc = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0 },
+      mutations: { retry: false },
+    },
+  })
+  return ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: qc }, children)
+}
+
+const SAMPLE_SOVS: SovereignsResponse = {
+  sovereigns: [
+    { id: 'sov-a', fqdn: 'a.example.com', region: 'fsn1', health: 'green', providerType: 'hetzner' },
+    { id: 'sov-b', fqdn: 'b.example.com', region: 'hel1', health: 'yellow', providerType: 'hetzner' },
+  ],
+  total: 2,
+  page: 1,
+  pageSize: 25,
+}
+
+const SAMPLE_DETAIL: SovereignDetail = {
+  sovereign: { id: 'sov-a', fqdn: 'a.example.com', health: 'green' },
+  orgs: 3,
+  applications: { total: 7, active: 5, failing: 1 },
+  regions: ['hz-fsn-rtz-prod', 'hz-hel-rtz-prod'],
+  alerts: 0,
+  lastActivity: '2026-05-01T10:00:00Z',
+}
+
+const SAMPLE_APPS: ApplicationsResponse = {
+  applications: [
+    {
+      sovereign: { id: 'sov-a', fqdn: 'a.example.com', health: 'green' },
+      app: { name: 'wp', blueprint: 'bp-wordpress', version: '1.0' },
+      regions: ['hz-fsn-rtz-prod'],
+      topology: 'single-region',
+      drPosture: '—',
+      status: 'Ready',
+      org: 'acme',
+      namespace: 'acme',
+    },
+    {
+      sovereign: { id: 'sov-a', fqdn: 'a.example.com', health: 'green' },
+      app: { name: 'api', blueprint: 'bp-django', version: '0.9' },
+      regions: ['hz-fsn-rtz-prod', 'hz-hel-rtz-prod'],
+      topology: 'active-hotstandby',
+      drPosture: 'DR active',
+      status: 'Ready',
+      org: 'acme',
+      namespace: 'acme',
+    },
+  ],
+  total: 2,
+}
+
+function jsonResponse(payload: unknown): Response {
+  return new Response(JSON.stringify(payload), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  })
+}
+
+describe('useFleet', () => {
+  let originalFetch: typeof globalThis.fetch
+  beforeEach(() => {
+    originalFetch = globalThis.fetch
+  })
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+    cleanup()
+  })
+
+  it('returns Sovereigns from /api/v1/fleet/sovereigns', async () => {
+    const fetchSpy = vi.fn(async (url: RequestInfo | URL) => {
+      expect(String(url)).toContain('/api/v1/fleet/sovereigns')
+      return jsonResponse(SAMPLE_SOVS)
+    })
+    globalThis.fetch = fetchSpy as never
+
+    const { result } = renderHook(() => useFleet({ pageSize: 25 }), {
+      wrapper: makeWrapper(),
+    })
+    await waitFor(() => expect(result.current.data).toBeDefined())
+    expect(result.current.data?.total).toBe(2)
+    expect(result.current.data?.sovereigns[0].id).toBe('sov-a')
+  })
+
+  it('passes page and pageSize as query params', async () => {
+    let lastURL = ''
+    globalThis.fetch = (async (url: RequestInfo | URL) => {
+      lastURL = String(url)
+      return jsonResponse(SAMPLE_SOVS)
+    }) as never
+    const { result } = renderHook(() => useFleet({ page: 2, pageSize: 10 }), {
+      wrapper: makeWrapper(),
+    })
+    await waitFor(() => expect(result.current.data).toBeDefined())
+    expect(lastURL).toContain('page=2')
+    expect(lastURL).toContain('pageSize=10')
+  })
+
+  it('surfaces errors on non-2xx response', async () => {
+    globalThis.fetch = (async () =>
+      new Response('boom', { status: 500 })) as never
+
+    const { result } = renderHook(() => useFleet(), { wrapper: makeWrapper() })
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect(result.current.error).toBeInstanceOf(Error)
+  })
+})
+
+describe('useFleetSovereignSummary', () => {
+  let originalFetch: typeof globalThis.fetch
+  beforeEach(() => {
+    originalFetch = globalThis.fetch
+  })
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+    cleanup()
+  })
+
+  it('returns the per-Sov rollup', async () => {
+    globalThis.fetch = (async (url: RequestInfo | URL) => {
+      expect(String(url)).toContain('/api/v1/fleet/sovereigns/sov-a/summary')
+      return jsonResponse(SAMPLE_DETAIL)
+    }) as never
+
+    const { result } = renderHook(() => useFleetSovereignSummary('sov-a'), {
+      wrapper: makeWrapper(),
+    })
+    await waitFor(() => expect(result.current.data).toBeDefined())
+    expect(result.current.data?.applications.total).toBe(7)
+    expect(result.current.data?.regions).toContain('hz-fsn-rtz-prod')
+  })
+
+  it('disables when id is empty', () => {
+    globalThis.fetch = vi.fn() as never
+    const { result } = renderHook(() => useFleetSovereignSummary(''), {
+      wrapper: makeWrapper(),
+    })
+    // No call should fire.
+    expect(result.current.data).toBeUndefined()
+    expect(result.current.fetchStatus).toBe('idle')
+  })
+})
+
+describe('useFleetApplications', () => {
+  let originalFetch: typeof globalThis.fetch
+  beforeEach(() => {
+    originalFetch = globalThis.fetch
+  })
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+    cleanup()
+  })
+
+  it('returns applications without filters', async () => {
+    globalThis.fetch = (async (url: RequestInfo | URL) => {
+      const u = String(url)
+      expect(u).toContain('/api/v1/fleet/applications')
+      // No filter query string.
+      expect(u).not.toContain('topology=')
+      return jsonResponse(SAMPLE_APPS)
+    }) as never
+    const { result } = renderHook(() => useFleetApplications(), {
+      wrapper: makeWrapper(),
+    })
+    await waitFor(() => expect(result.current.data).toBeDefined())
+    expect(result.current.data?.total).toBe(2)
+  })
+
+  it('passes filters as query params', async () => {
+    let lastURL = ''
+    globalThis.fetch = (async (url: RequestInfo | URL) => {
+      lastURL = String(url)
+      return jsonResponse({ ...SAMPLE_APPS, total: 1, applications: [SAMPLE_APPS.applications[1]] })
+    }) as never
+    const { result } = renderHook(
+      () =>
+        useFleetApplications({
+          org: 'acme',
+          topology: 'active-hotstandby',
+          drPosture: 'DR active',
+        }),
+      { wrapper: makeWrapper() },
+    )
+    await waitFor(() => expect(result.current.data).toBeDefined())
+    expect(lastURL).toContain('org=acme')
+    expect(lastURL).toContain('topology=active-hotstandby')
+    // 'DR active' contains a space — encoded as DR+active or DR%20active.
+    expect(/(DR\+active|DR%20active)/.test(lastURL)).toBe(true)
+    expect(result.current.data?.total).toBe(1)
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/lib/useFleet.ts
+++ b/products/catalyst/bootstrap/ui/src/lib/useFleet.ts
@@ -1,0 +1,100 @@
+/**
+ * useFleet — TanStack Query hook backed by the catalyst-api fleet
+ * endpoints (EPIC-6 Slice U-Fleet, #1101).
+ *
+ * Mirrors the slice U `useComplianceStream` pattern (REST baseline, no
+ * Zustand — TanStack Query owns the cache) and slice I `useCatalog` —
+ * one hook per endpoint, stable query keys, conservative staleTime so
+ * the dashboard isn't constantly re-fetching while the operator
+ * scrolls through Sovereign cards.
+ *
+ * Three hooks shipped here cover the three brief endpoints:
+ *
+ *   useFleet({ page?, pageSize? })             → list Sovereigns
+ *   useFleetSovereignSummary(id)               → per-Sov rollup
+ *   useFleetApplications(filters)              → cross-Sov apps table
+ *
+ * Per docs/INVIOLABLE-PRINCIPLES.md:
+ *   #4 (never hardcode) — every URL flows through fleet.api.ts → API_BASE.
+ *   #5 (least privilege) — server-side gate is the source of truth;
+ *      hooks render whatever the server returns (filtered by tier).
+ */
+
+import { useQuery, type UseQueryResult } from '@tanstack/react-query'
+
+import {
+  listSovereigns,
+  getSovereignSummary,
+  listApplications,
+  type SovereignsResponse,
+  type SovereignDetail,
+  type ApplicationsResponse,
+  type FleetApplicationsFilters,
+} from './fleet.api'
+
+/** Stable query keys so TanStack devtools + invalidation are coherent. */
+export const fleetQueryKeys = {
+  all: ['fleet'] as const,
+  sovereigns: (page: number, pageSize: number) =>
+    ['fleet', 'sovereigns', page, pageSize] as const,
+  sovereignSummary: (id: string) => ['fleet', 'sovereigns', 'summary', id] as const,
+  applications: (filters: FleetApplicationsFilters) =>
+    ['fleet', 'applications', filters.org ?? '', filters.topology ?? '', filters.drPosture ?? ''] as const,
+}
+
+/**
+ * Cache TTL — the fleet endpoints fan out to per-Sovereign K8s reads
+ * with a per-Sov 4s timeout, so a single fetch is cheap but not free.
+ * 60s mirrors useCatalog and gives enough room for the dashboard to
+ * feel snappy without becoming stale (auto-refetch on window-focus is
+ * the normal trigger).
+ */
+const FLEET_STALE_MS = 60_000
+
+/* ── useFleet — Sovereign list ─────────────────────────────────────── */
+
+export interface UseFleetOptions {
+  page?: number
+  pageSize?: number
+  /** Disable the query (e.g. while tier resolution is pending). */
+  enabled?: boolean
+}
+
+export function useFleet(opts: UseFleetOptions = {}): UseQueryResult<SovereignsResponse> {
+  const page = opts.page ?? 1
+  const pageSize = opts.pageSize ?? 25
+  return useQuery<SovereignsResponse>({
+    queryKey: fleetQueryKeys.sovereigns(page, pageSize),
+    queryFn: ({ signal }) => listSovereigns(page, pageSize, signal),
+    enabled: opts.enabled !== false,
+    staleTime: FLEET_STALE_MS,
+  })
+}
+
+/* ── useFleetSovereignSummary — per-Sov rollup ────────────────────── */
+
+export function useFleetSovereignSummary(
+  id: string,
+  enabled = true,
+): UseQueryResult<SovereignDetail> {
+  return useQuery<SovereignDetail>({
+    queryKey: fleetQueryKeys.sovereignSummary(id),
+    queryFn: ({ signal }) => getSovereignSummary(id, signal),
+    enabled: enabled && !!id,
+    staleTime: FLEET_STALE_MS,
+  })
+}
+
+/* ── useFleetApplications — cross-Sov table ───────────────────────── */
+
+export function useFleetApplications(
+  filters: FleetApplicationsFilters = {},
+  enabled = true,
+): UseQueryResult<ApplicationsResponse> {
+  return useQuery<ApplicationsResponse>({
+    queryKey: fleetQueryKeys.applications(filters),
+    queryFn: ({ signal }) => listApplications(filters, signal),
+    enabled,
+    staleTime: FLEET_STALE_MS,
+  })
+}

--- a/products/catalyst/bootstrap/ui/src/pages/dashboard/CrossSovereignView.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/dashboard/CrossSovereignView.test.tsx
@@ -1,0 +1,162 @@
+/**
+ * CrossSovereignView.test.tsx — coverage for the U-Fleet-3 page.
+ *
+ * What we assert:
+ *   - Renders the table with rows from /api/v1/fleet/applications.
+ *   - Org filter input updates query (via TanStack Query refetch).
+ *   - Topology + DR posture select inputs update query.
+ *   - Empty filtered result renders the empty hint.
+ *
+ * Routing: TanStack Router renders <Link to="/dashboard"> via the
+ * provider. Tests render WITHOUT the full router; the back-link `<a>`
+ * is allowed to render with no actual navigation since we only assert
+ * data-driven rendering here.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { render, screen, waitFor, cleanup, fireEvent } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import {
+  RouterProvider,
+  createRootRoute,
+  createRoute,
+  createRouter,
+  createMemoryHistory,
+  Outlet,
+} from '@tanstack/react-router'
+
+import { CrossSovereignView } from './CrossSovereignView'
+import type { ApplicationsResponse } from '@/lib/fleet.api'
+
+afterEach(() => cleanup())
+
+function makeRouter() {
+  const rootRoute = createRootRoute({ component: () => <Outlet /> })
+  const dashRoute = createRoute({ getParentRoute: () => rootRoute, path: '/dashboard', component: () => <div>back</div> })
+  const crossRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/dashboard/applications',
+    component: CrossSovereignView,
+  })
+  return createRouter({
+    routeTree: rootRoute.addChildren([dashRoute, crossRoute]),
+    history: createMemoryHistory({ initialEntries: ['/dashboard/applications'] }),
+  })
+}
+
+function renderPage() {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 }, mutations: { retry: false } },
+  })
+  const router = makeRouter()
+  return render(
+    <QueryClientProvider client={qc}>
+      <RouterProvider router={router as never} />
+    </QueryClientProvider>,
+  )
+}
+
+const SAMPLE_APPS: ApplicationsResponse = {
+  applications: [
+    {
+      sovereign: { id: 'sov-a', fqdn: 'a.example.com', health: 'green' },
+      app: { name: 'wp', blueprint: 'bp-wordpress', version: '1.0' },
+      regions: ['hz-fsn-rtz-prod'],
+      topology: 'single-region',
+      drPosture: '—',
+      status: 'Ready',
+      org: 'acme',
+      namespace: 'acme',
+    },
+    {
+      sovereign: { id: 'sov-a', fqdn: 'a.example.com', health: 'green' },
+      app: { name: 'api', blueprint: 'bp-django', version: '0.9' },
+      regions: ['hz-fsn-rtz-prod', 'hz-hel-rtz-prod'],
+      topology: 'active-hotstandby',
+      drPosture: 'DR active',
+      status: 'Ready',
+      org: 'acme',
+      namespace: 'acme',
+    },
+  ],
+  total: 2,
+}
+
+describe('CrossSovereignView — render', () => {
+  let originalFetch: typeof globalThis.fetch
+  beforeEach(() => {
+    originalFetch = globalThis.fetch
+  })
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+  })
+
+  it('renders the application table with rows', async () => {
+    globalThis.fetch = (async () =>
+      new Response(JSON.stringify(SAMPLE_APPS), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })) as never
+    renderPage()
+    // Wait for rows specifically — the table shell renders unconditionally
+    // once data > 0; rely on the per-row testid for the readiness gate.
+    await waitFor(() => expect(screen.getByTestId('cross-sov-row-sov-a-wp')).toBeTruthy())
+    expect(screen.getByTestId('cross-sov-row-sov-a-api')).toBeTruthy()
+    expect(screen.getByTestId('cross-sov-dr-api').textContent).toContain('DR active')
+    expect(screen.getByTestId('cross-sov-total').textContent).toContain('2')
+  })
+
+  it('renders empty hint when zero rows match the filter', async () => {
+    globalThis.fetch = (async () =>
+      new Response(JSON.stringify({ applications: [], total: 0 }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })) as never
+    renderPage()
+    await waitFor(() => expect(screen.getByTestId('cross-sov-empty')).toBeTruthy())
+  })
+})
+
+describe('CrossSovereignView — filters', () => {
+  let originalFetch: typeof globalThis.fetch
+  beforeEach(() => {
+    originalFetch = globalThis.fetch
+  })
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+  })
+
+  it('passes org filter to the server', async () => {
+    const calls: string[] = []
+    globalThis.fetch = (async (url: RequestInfo | URL) => {
+      calls.push(String(url))
+      return new Response(JSON.stringify(SAMPLE_APPS), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    }) as never
+    renderPage()
+    await waitFor(() => expect(screen.getByTestId('cross-sov-filter-org')).toBeTruthy())
+    fireEvent.change(screen.getByTestId('cross-sov-filter-org'), { target: { value: 'acme' } })
+    await waitFor(() => expect(calls.some((u) => u.includes('org=acme'))).toBe(true))
+  })
+
+  it('passes topology filter to the server', async () => {
+    const calls: string[] = []
+    globalThis.fetch = (async (url: RequestInfo | URL) => {
+      calls.push(String(url))
+      return new Response(JSON.stringify(SAMPLE_APPS), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    }) as never
+    renderPage()
+    await waitFor(() => expect(screen.getByTestId('cross-sov-filter-topology')).toBeTruthy())
+    fireEvent.change(screen.getByTestId('cross-sov-filter-topology'), {
+      target: { value: 'active-hotstandby' },
+    })
+    await waitFor(() =>
+      expect(calls.some((u) => u.includes('topology=active-hotstandby'))).toBe(true),
+    )
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/pages/dashboard/CrossSovereignView.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/dashboard/CrossSovereignView.tsx
@@ -1,0 +1,273 @@
+/**
+ * CrossSovereignView — aggregated table of every Application across
+ * every visible Sovereign (EPIC-6 Slice U-Fleet-3, #1101).
+ *
+ * Columns:
+ *   - Application (name + blueprint chip)
+ *   - Sovereign FQDN
+ *   - Org slug
+ *   - Regions (chip per region)
+ *   - Topology (single-region | active-active | active-hotstandby)
+ *   - DR posture (— | DR active | DR alert | Misconfigured)
+ *   - Status (CR phase passthrough)
+ *
+ * Filters (all server-side per the brief):
+ *   - Org filter (text)
+ *   - Topology mode (select)
+ *   - DR posture (select)
+ *
+ * Each row clickable → opens that App's AppDetail in the relevant
+ * Sovereign (via `sovereignChrootURL(sov, { appName })`).
+ *
+ * Per the brief out-of-scope notes:
+ *   - No cross-Sovereign Application reuse logic (Applications stay
+ *     within one Sovereign by design)
+ *   - No fleet-level RBAC/install actions (read-only fleet view)
+ */
+
+import { useMemo, useState } from 'react'
+import { motion } from 'framer-motion'
+import { ArrowLeft, Layers, AlertCircle, RefreshCw, Search } from 'lucide-react'
+import { Link } from '@tanstack/react-router'
+import { Button } from '@/shared/ui/button'
+import { Card, CardContent } from '@/shared/ui/card'
+import { Badge } from '@/shared/ui/badge'
+import { Input } from '@/shared/ui/input'
+import {
+  type ApplicationRow,
+  type DRPosture,
+  type TopologyMode,
+  drPostureBadgeColor,
+  sovereignChrootURL,
+} from '@/lib/fleet.api'
+import { useFleetApplications } from '@/lib/useFleet'
+
+const TOPOLOGY_OPTIONS: Array<{ value: '' | TopologyMode; label: string }> = [
+  { value: '', label: 'All topologies' },
+  { value: 'single-region', label: 'Single region' },
+  { value: 'active-active', label: 'Active-Active' },
+  { value: 'active-hotstandby', label: 'Active-Hotstandby' },
+]
+
+const DR_OPTIONS: Array<{ value: '' | DRPosture; label: string }> = [
+  { value: '', label: 'All DR postures' },
+  { value: '—', label: '— (no DR)' },
+  { value: 'DR active', label: 'DR active' },
+  { value: 'DR alert', label: 'DR alert' },
+  { value: 'Misconfigured', label: 'Misconfigured' },
+]
+
+export function CrossSovereignView() {
+  const [orgFilter, setOrgFilter] = useState('')
+  const [topology, setTopology] = useState<'' | TopologyMode>('')
+  const [dr, setDR] = useState<'' | DRPosture>('')
+
+  const filters = useMemo(
+    () => ({
+      org: orgFilter || undefined,
+      topology: topology || undefined,
+      drPosture: dr || undefined,
+    }),
+    [orgFilter, topology, dr],
+  )
+
+  const query = useFleetApplications(filters)
+  const rows = query.data?.applications ?? []
+
+  return (
+    <div
+      className="flex flex-col gap-6 p-8 max-w-7xl mx-auto"
+      data-testid="cross-sov-page"
+    >
+      {/* Header */}
+      <motion.div
+        initial={{ opacity: 0, y: 12 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.3 }}
+        className="flex items-start justify-between gap-4 flex-wrap"
+      >
+        <div>
+          <Link to="/dashboard" className="text-xs text-[oklch(50%_0.01_250)] hover:underline flex items-center gap-1">
+            <ArrowLeft className="h-3 w-3" />
+            Back to Sovereign Fleet
+          </Link>
+          <h1 className="text-xl font-semibold text-[oklch(92%_0.01_250)] mt-1">
+            Applications across the fleet
+          </h1>
+          <p className="mt-1 text-sm text-[oklch(50%_0.01_250)]">
+            Every Application in every visible Sovereign — filter by Org, topology, or DR posture.
+          </p>
+        </div>
+        <Badge variant="default" data-testid="cross-sov-total">
+          <Layers className="h-3 w-3" />
+          {query.data?.total ?? 0} applications
+        </Badge>
+      </motion.div>
+
+      {/* Filters */}
+      <motion.div
+        initial={{ opacity: 0, y: 12 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.3, delay: 0.05 }}
+        className="grid grid-cols-1 md:grid-cols-3 gap-3"
+      >
+        <div className="relative">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-[oklch(45%_0.01_250)]" />
+          <Input
+            data-testid="cross-sov-filter-org"
+            placeholder="Filter by Org slug…"
+            value={orgFilter}
+            onChange={(e) => setOrgFilter(e.target.value)}
+            className="pl-9"
+          />
+        </div>
+        <select
+          data-testid="cross-sov-filter-topology"
+          aria-label="Filter by topology"
+          value={topology}
+          onChange={(e) => setTopology(e.target.value as '' | TopologyMode)}
+          className="rounded-[--radius-md] border border-[--color-surface-border] bg-[--color-surface-2] px-3 py-2 text-sm text-[oklch(85%_0.01_250)]"
+        >
+          {TOPOLOGY_OPTIONS.map((o) => (
+            <option key={o.value} value={o.value}>
+              {o.label}
+            </option>
+          ))}
+        </select>
+        <select
+          data-testid="cross-sov-filter-dr"
+          aria-label="Filter by DR posture"
+          value={dr}
+          onChange={(e) => setDR(e.target.value as '' | DRPosture)}
+          className="rounded-[--radius-md] border border-[--color-surface-border] bg-[--color-surface-2] px-3 py-2 text-sm text-[oklch(85%_0.01_250)]"
+        >
+          {DR_OPTIONS.map((o) => (
+            <option key={o.value} value={o.value}>
+              {o.label}
+            </option>
+          ))}
+        </select>
+      </motion.div>
+
+      {/* Table */}
+      {query.isError ? (
+        <div
+          data-testid="cross-sov-error"
+          className="flex flex-col items-center justify-center gap-4 py-16 text-center"
+        >
+          <AlertCircle className="h-8 w-8 text-[--color-error]" />
+          <div>
+            <p className="font-medium text-[oklch(75%_0.01_250)]">Failed to load applications</p>
+            <p className="mt-1 text-sm text-[oklch(45%_0.01_250)]">
+              {query.error instanceof Error ? query.error.message : 'Unknown error'}
+            </p>
+          </div>
+          <Button variant="secondary" onClick={() => query.refetch()}>
+            <RefreshCw className="h-4 w-4" />
+            Retry
+          </Button>
+        </div>
+      ) : rows.length === 0 && !query.isLoading ? (
+        <Card>
+          <CardContent className="flex flex-col items-center gap-2 py-12 text-center">
+            <Layers className="h-6 w-6 text-[oklch(45%_0.01_250)]" />
+            <p className="text-sm text-[oklch(60%_0.01_250)]" data-testid="cross-sov-empty">
+              No Applications match the current filters.
+            </p>
+          </CardContent>
+        </Card>
+      ) : (
+        <Card>
+          <CardContent className="p-0">
+            <div className="overflow-x-auto">
+              <table
+                data-testid="cross-sov-table"
+                className="min-w-full divide-y divide-[--color-surface-border]"
+              >
+                <thead>
+                  <tr className="text-left text-[10px] uppercase tracking-wider text-[oklch(50%_0.01_250)]">
+                    <Th>Application</Th>
+                    <Th>Sovereign</Th>
+                    <Th>Org</Th>
+                    <Th>Regions</Th>
+                    <Th>Topology</Th>
+                    <Th>DR posture</Th>
+                    <Th>Status</Th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-[--color-surface-border]">
+                  {rows.map((row) => (
+                    <Row key={`${row.sovereign.id}/${row.namespace ?? ''}/${row.app.name}`} row={row} />
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  )
+}
+
+function Th({ children }: { children: React.ReactNode }) {
+  return <th className="px-3 py-2 font-medium">{children}</th>
+}
+
+function Row({ row }: { row: ApplicationRow }) {
+  const handleClick = () => {
+    if (typeof window === 'undefined') return
+    window.location.href = sovereignChrootURL(row.sovereign, {
+      appName: row.app.name,
+      namespace: row.namespace,
+    })
+  }
+  return (
+    <tr
+      className="cursor-pointer hover:bg-[--color-surface-2] transition-colors"
+      onClick={handleClick}
+      data-testid={`cross-sov-row-${row.sovereign.id}-${row.app.name}`}
+    >
+      <td className="px-3 py-3 text-sm text-[oklch(92%_0.01_250)] font-mono">
+        <div className="flex flex-col gap-0.5">
+          <span>{row.app.name}</span>
+          {row.app.blueprint && (
+            <span className="text-[10px] text-[oklch(45%_0.01_250)]">
+              {row.app.blueprint}
+              {row.app.version ? ` @ ${row.app.version}` : ''}
+            </span>
+          )}
+        </div>
+      </td>
+      <td className="px-3 py-3 text-sm text-[oklch(80%_0.01_250)] font-mono">
+        {row.sovereign.fqdn || row.sovereign.id}
+      </td>
+      <td className="px-3 py-3 text-sm text-[oklch(80%_0.01_250)]">{row.org || '—'}</td>
+      <td className="px-3 py-3 text-sm">
+        <div className="flex flex-wrap gap-1">
+          {row.regions.length === 0 ? (
+            <span className="text-[oklch(45%_0.01_250)]">—</span>
+          ) : (
+            row.regions.map((r) => (
+              <Badge key={r} variant="default">
+                {r}
+              </Badge>
+            ))
+          )}
+        </div>
+      </td>
+      <td className="px-3 py-3 text-sm text-[oklch(80%_0.01_250)]">{row.topology}</td>
+      <td className="px-3 py-3 text-sm">
+        <span
+          className={
+            'inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium border ' +
+            drPostureBadgeColor(row.drPosture)
+          }
+          data-testid={`cross-sov-dr-${row.app.name}`}
+        >
+          {row.drPosture}
+        </span>
+      </td>
+      <td className="px-3 py-3 text-sm text-[oklch(70%_0.01_250)]">{row.status || '—'}</td>
+    </tr>
+  )
+}

--- a/products/catalyst/bootstrap/ui/src/pages/dashboard/DashboardPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/dashboard/DashboardPage.tsx
@@ -1,61 +1,46 @@
+/**
+ * DashboardPage — multi-Sovereign fleet view (EPIC-6 Slice U-Fleet-1,
+ * #1101).
+ *
+ * Replaces the prior MOCK_DEPLOYMENTS card list with a live
+ * TanStack-Query-backed grid of `SovereignCard`s. Each card self-fetches
+ * its per-Sov rollup so the parent `useFleet` query only carries the
+ * top-level Sovereign list (cheap PVC walk on the server side).
+ *
+ * Empty state: when zero Sovereigns are returned, render the
+ * "No Sovereigns provisioned yet — [ + Add Sovereign ]" prompt
+ * deep-linking to `/wizard`.
+ *
+ * Per the brief:
+ *   - Layout: responsive grid (sm:1, md:2, lg:3 columns)
+ *   - Cross-Sovereign view link surfaced in the header so the operator
+ *     can pivot from "by Sovereign" to "by Application".
+ *   - Pagination passthrough — for now the dashboard requests pageSize
+ *     25 (one screen of cards). Larger pageSize is supported by the
+ *     server (capped at 50) and a future "Show more" affordance can
+ *     trigger a re-fetch.
+ *
+ * Per docs/INVIOLABLE-PRINCIPLES.md:
+ *   #1 (target-state) — ships the live + cross-Sov + empty paths in
+ *      one cut.
+ *   #4 (never hardcode) — every URL via API_BASE / fleet.api.ts.
+ */
+
 import { motion } from 'framer-motion'
-import { Plus, Server, Activity, Clock, AlertCircle } from 'lucide-react'
+import { Plus, Server, Layers, AlertCircle, RefreshCw } from 'lucide-react'
 import { Link } from '@tanstack/react-router'
 import { Button } from '@/shared/ui/button'
-import { Badge } from '@/shared/ui/badge'
 import { Card, CardContent } from '@/shared/ui/card'
-
-// Mock data — will be replaced by TanStack Query + API
-const MOCK_DEPLOYMENTS = [
-  {
-    id: 'd-001',
-    name: 'hz-fsn-rtz-prod',
-    org: 'acme-corp',
-    provider: 'Hetzner',
-    region: 'Falkenstein',
-    status: 'healthy' as const,
-    nodes: 2,
-    components: 14,
-    createdAt: '2026-03-18T10:30:00Z',
-  },
-  {
-    id: 'd-002',
-    name: 'hz-hel-rtz-prod',
-    org: 'acme-corp',
-    provider: 'Hetzner',
-    region: 'Helsinki',
-    status: 'healthy' as const,
-    nodes: 2,
-    components: 14,
-    createdAt: '2026-03-18T10:45:00Z',
-  },
-  {
-    id: 'd-003',
-    name: 'hz-fsn-rtz-dev',
-    org: 'acme-corp',
-    provider: 'Hetzner',
-    region: 'Falkenstein',
-    status: 'provisioning' as const,
-    nodes: 1,
-    components: 6,
-    createdAt: '2026-03-19T09:00:00Z',
-  },
-]
-
-const STATUS_CONFIG = {
-  healthy: { label: 'Healthy', variant: 'success' as const, icon: Activity },
-  provisioning: { label: 'Provisioning', variant: 'info' as const, icon: Clock },
-  degraded: { label: 'Degraded', variant: 'warning' as const, icon: AlertCircle },
-  failed: { label: 'Failed', variant: 'error' as const, icon: AlertCircle },
-  pending: { label: 'Pending', variant: 'default' as const, icon: Clock },
-  destroying: { label: 'Destroying', variant: 'warning' as const, icon: Clock },
-}
+import { useFleet } from '@/lib/useFleet'
+import { SovereignCard } from '@/widgets/fleet/SovereignCard'
 
 function StatCard({ label, value, sub }: { label: string; value: string | number; sub?: string }) {
   return (
     <Card>
       <CardContent className="pt-5">
-        <p className="text-xs text-[oklch(45%_0.01_250)] uppercase tracking-wider font-medium">{label}</p>
+        <p className="text-xs text-[oklch(45%_0.01_250)] uppercase tracking-wider font-medium">
+          {label}
+        </p>
         <p className="mt-1 text-2xl font-bold text-[oklch(92%_0.01_250)] tabular-nums">{value}</p>
         {sub && <p className="mt-0.5 text-xs text-[oklch(40%_0.01_250)]">{sub}</p>}
       </CardContent>
@@ -64,30 +49,41 @@ function StatCard({ label, value, sub }: { label: string; value: string | number
 }
 
 export function DashboardPage() {
-  const healthy = MOCK_DEPLOYMENTS.filter((d) => d.status === 'healthy').length
-  const totalNodes = MOCK_DEPLOYMENTS.reduce((s, d) => s + d.nodes, 0)
+  const fleet = useFleet({ pageSize: 25 })
+  const sovereigns = fleet.data?.sovereigns ?? []
+  const total = fleet.data?.total ?? 0
+  const healthy = sovereigns.filter((s) => s.health === 'green').length
+  const failed = sovereigns.filter((s) => s.health === 'red').length
 
   return (
-    <div className="flex flex-col gap-8 p-8 max-w-5xl mx-auto">
+    <div className="flex flex-col gap-8 p-8 max-w-6xl mx-auto" data-testid="dashboard-page">
       {/* Header */}
       <motion.div
         initial={{ opacity: 0, y: 12 }}
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.3 }}
-        className="flex items-start justify-between gap-4"
+        className="flex items-start justify-between gap-4 flex-wrap"
       >
         <div>
-          <h1 className="text-xl font-semibold text-[oklch(92%_0.01_250)]">Deployments</h1>
+          <h1 className="text-xl font-semibold text-[oklch(92%_0.01_250)]">Sovereign Fleet</h1>
           <p className="mt-1 text-sm text-[oklch(50%_0.01_250)]">
-            Manage your OpenOva clusters across providers and regions.
+            Manage every OpenOva Sovereign across providers, regions, and Organizations.
           </p>
         </div>
-        <Link to="/wizard">
-          <Button size="md">
-            <Plus className="h-4 w-4" />
-            New deployment
-          </Button>
-        </Link>
+        <div className="flex items-center gap-2">
+          <Link to={'/dashboard/applications' as never} data-testid="dashboard-cross-sov-link">
+            <Button variant="secondary" size="md">
+              <Layers className="h-4 w-4" />
+              Applications view
+            </Button>
+          </Link>
+          <Link to="/wizard">
+            <Button size="md">
+              <Plus className="h-4 w-4" />
+              New Sovereign
+            </Button>
+          </Link>
+        </div>
       </motion.div>
 
       {/* Stats */}
@@ -97,89 +93,78 @@ export function DashboardPage() {
         transition={{ duration: 0.3, delay: 0.05 }}
         className="grid grid-cols-2 sm:grid-cols-4 gap-4"
       >
-        <StatCard label="Total" value={MOCK_DEPLOYMENTS.length} sub="deployments" />
-        <StatCard label="Healthy" value={healthy} sub={`of ${MOCK_DEPLOYMENTS.length}`} />
-        <StatCard label="Total nodes" value={totalNodes} sub="across all clusters" />
-        <StatCard label="Provider" value="Hetzner" sub="1 active provider" />
+        <StatCard label="Total" value={total} sub="Sovereigns" />
+        <StatCard label="Healthy" value={healthy} sub={`of ${sovereigns.length}`} />
+        <StatCard label="Failed" value={failed} sub="needs attention" />
+        <StatCard
+          label="Page"
+          value={`${fleet.data?.page ?? 1} of ${Math.max(
+            1,
+            Math.ceil(total / Math.max(1, fleet.data?.pageSize ?? 25)),
+          )}`}
+        />
       </motion.div>
 
-      {/* Deployment list */}
-      <motion.div
-        initial={{ opacity: 0, y: 12 }}
-        animate={{ opacity: 1, y: 0 }}
-        transition={{ duration: 0.3, delay: 0.1 }}
-        className="flex flex-col gap-3"
-      >
-        <h2 className="text-sm font-semibold text-[oklch(60%_0.01_250)] uppercase tracking-wider">
-          Clusters
-        </h2>
-
-        {MOCK_DEPLOYMENTS.map((d, i) => {
-          const config = STATUS_CONFIG[d.status]
-          const StatusIcon = config.icon
-          return (
-            <motion.div
-              key={d.id}
-              initial={{ opacity: 0, y: 8 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.25, delay: 0.12 + i * 0.05 }}
-            >
-              <Card className="hover:border-[oklch(28%_0.02_250)] transition-colors duration-150 cursor-pointer">
-                <CardContent className="flex items-center gap-4 py-4">
-                  {/* Status dot */}
-                  <div className="shrink-0">
-                    <div
-                      className={`flex h-9 w-9 items-center justify-center rounded-[--radius-md] ${
-                        d.status === 'healthy' ? 'bg-[--color-success]/10' :
-                        d.status === 'provisioning' ? 'bg-[--color-info]/10' :
-                        'bg-[--color-surface-2]'
-                      }`}
-                    >
-                      <Server className={`h-4 w-4 ${
-                        d.status === 'healthy' ? 'text-[--color-success]' :
-                        d.status === 'provisioning' ? 'text-[--color-info]' :
-                        'text-[oklch(50%_0.01_250)]'
-                      }`} />
-                    </div>
-                  </div>
-
-                  {/* Info */}
-                  <div className="flex-1 min-w-0">
-                    <div className="flex items-center gap-2 flex-wrap">
-                      <p className="text-sm font-semibold text-[oklch(92%_0.01_250)] font-mono">{d.name}</p>
-                      <Badge variant={config.variant}>
-                        <StatusIcon className="h-3 w-3" />
-                        {config.label}
-                      </Badge>
-                    </div>
-                    <p className="mt-0.5 text-xs text-[oklch(45%_0.01_250)]">
-                      {d.provider} · {d.region} · {d.nodes} node{d.nodes !== 1 ? 's' : ''} · {d.components} components
-                    </p>
-                  </div>
-
-                  {/* Actions */}
-                  <div className="shrink-0">
-                    <Button variant="secondary" size="sm">Manage</Button>
-                  </div>
-                </CardContent>
-              </Card>
-            </motion.div>
-          )
-        })}
-
-        {MOCK_DEPLOYMENTS.length === 0 && (
-          <div className="flex flex-col items-center justify-center gap-4 py-20 text-center">
-            <div className="flex h-14 w-14 items-center justify-center rounded-full bg-[--color-surface-2]">
-              <Server className="h-6 w-6 text-[oklch(40%_0.01_250)]" />
-            </div>
-            <div>
-              <p className="font-medium text-[oklch(70%_0.01_250)]">No deployments yet</p>
-              <p className="mt-1 text-sm text-[oklch(45%_0.01_250)]">Provision your first cluster to get started.</p>
-            </div>
-            <Link to="/wizard"><Button>New deployment</Button></Link>
+      {/* Sovereign card grid */}
+      {fleet.isError ? (
+        <div
+          data-testid="dashboard-error"
+          className="flex flex-col items-center justify-center gap-4 py-16 text-center"
+        >
+          <div className="flex h-12 w-12 items-center justify-center rounded-full bg-[--color-error]/10">
+            <AlertCircle className="h-6 w-6 text-[--color-error]" />
           </div>
-        )}
-      </motion.div>
+          <div>
+            <p className="font-medium text-[oklch(75%_0.01_250)]">Failed to load fleet</p>
+            <p className="mt-1 text-sm text-[oklch(45%_0.01_250)]">
+              {fleet.error instanceof Error ? fleet.error.message : 'Unknown error'}
+            </p>
+          </div>
+          <Button variant="secondary" onClick={() => fleet.refetch()}>
+            <RefreshCw className="h-4 w-4" />
+            Retry
+          </Button>
+        </div>
+      ) : sovereigns.length === 0 && !fleet.isLoading ? (
+        <EmptyState />
+      ) : (
+        <motion.div
+          initial={{ opacity: 0, y: 12 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.3, delay: 0.1 }}
+          className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4"
+          data-testid="dashboard-sovereign-grid"
+        >
+          {sovereigns.map((s) => (
+            <SovereignCard key={s.id} sovereign={s} />
+          ))}
+        </motion.div>
+      )}
+    </div>
+  )
+}
+
+function EmptyState() {
+  return (
+    <div
+      data-testid="dashboard-empty-state"
+      className="flex flex-col items-center justify-center gap-4 py-20 text-center"
+    >
+      <div className="flex h-14 w-14 items-center justify-center rounded-full bg-[--color-surface-2]">
+        <Server className="h-6 w-6 text-[oklch(40%_0.01_250)]" />
+      </div>
+      <div>
+        <p className="font-medium text-[oklch(75%_0.01_250)]">No Sovereigns provisioned yet</p>
+        <p className="mt-1 text-sm text-[oklch(45%_0.01_250)]">
+          Provision your first Sovereign to start managing applications.
+        </p>
+      </div>
+      <Link to="/wizard">
+        <Button>
+          <Plus className="h-4 w-4" />
+          Add Sovereign
+        </Button>
+      </Link>
     </div>
   )
 }

--- a/products/catalyst/bootstrap/ui/src/widgets/fleet/SovereignCard.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/widgets/fleet/SovereignCard.test.tsx
@@ -1,0 +1,120 @@
+/**
+ * SovereignCard.test.tsx — render coverage for the U-Fleet-2 widget.
+ *
+ * What we assert:
+ *   - Renders FQDN heading + provider chip.
+ *   - Renders health badge label matching the SovereignSummary.health.
+ *   - Renders application metric counts when detailOverride supplied.
+ *   - Renders region chips.
+ *   - Click navigates via window.location.href to chroot URL.
+ *   - Empty regions shows "No regions reported".
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+import { SovereignCard } from './SovereignCard'
+import type { SovereignSummary, SovereignDetail } from '@/lib/fleet.api'
+
+afterEach(() => cleanup())
+
+function renderCard(
+  sovereign: SovereignSummary,
+  detail?: SovereignDetail,
+  onClick?: () => void,
+) {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  })
+  return render(
+    <QueryClientProvider client={qc}>
+      <SovereignCard sovereign={sovereign} detailOverride={detail} onClick={onClick} />
+    </QueryClientProvider>,
+  )
+}
+
+const HEALTHY_SOV: SovereignSummary = {
+  id: 'sov-a',
+  fqdn: 'acme.example.com',
+  region: 'fsn1',
+  health: 'green',
+  providerType: 'hetzner',
+}
+
+const SAMPLE_DETAIL: SovereignDetail = {
+  sovereign: HEALTHY_SOV,
+  orgs: 2,
+  applications: { total: 5, active: 3, failing: 1 },
+  regions: ['hz-fsn-rtz-prod', 'hz-hel-rtz-prod'],
+  alerts: 0,
+  lastActivity: '2026-05-01T10:00:00Z',
+}
+
+describe('SovereignCard — render', () => {
+  it('renders the Sovereign FQDN', () => {
+    renderCard(HEALTHY_SOV, SAMPLE_DETAIL)
+    expect(screen.getByText('acme.example.com')).toBeTruthy()
+  })
+
+  it('renders the health label for green', () => {
+    renderCard(HEALTHY_SOV, SAMPLE_DETAIL)
+    const healthBadge = screen.getByTestId('sovereign-card-health-sov-a')
+    expect(healthBadge.textContent).toContain('Healthy')
+  })
+
+  it('renders red Failed badge', () => {
+    renderCard(
+      { ...HEALTHY_SOV, id: 'sov-fail', health: 'red' },
+      { ...SAMPLE_DETAIL, sovereign: { ...HEALTHY_SOV, id: 'sov-fail', health: 'red' } },
+    )
+    expect(screen.getByTestId('sovereign-card-health-sov-fail').textContent).toContain('Failed')
+  })
+
+  it('renders region chips', () => {
+    renderCard(HEALTHY_SOV, SAMPLE_DETAIL)
+    expect(screen.getByTestId('sovereign-card-region-hz-fsn-rtz-prod')).toBeTruthy()
+    expect(screen.getByTestId('sovereign-card-region-hz-hel-rtz-prod')).toBeTruthy()
+  })
+
+  it('renders provider + region in subhead', () => {
+    renderCard(HEALTHY_SOV, SAMPLE_DETAIL)
+    // Subhead reads "hetzner · fsn1"
+    expect(screen.getByText(/hetzner · fsn1/)).toBeTruthy()
+  })
+
+  it('shows "No regions reported" when regions empty', () => {
+    renderCard(HEALTHY_SOV, { ...SAMPLE_DETAIL, regions: [] })
+    expect(screen.getByText('No regions reported')).toBeTruthy()
+  })
+
+  it('renders application counts (total + sub)', () => {
+    renderCard(HEALTHY_SOV, SAMPLE_DETAIL)
+    expect(screen.getByText('5')).toBeTruthy()
+    expect(screen.getByText('3 active · 1 failing')).toBeTruthy()
+  })
+})
+
+describe('SovereignCard — interaction', () => {
+  beforeEach(() => {
+    vi.spyOn(window, 'location', 'get').mockReturnValue({ href: '' } as never)
+  })
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('fires onClick when clicked', () => {
+    const onClick = vi.fn()
+    renderCard(HEALTHY_SOV, SAMPLE_DETAIL, onClick)
+    fireEvent.click(screen.getByTestId('sovereign-card-sov-a'))
+    expect(onClick).toHaveBeenCalledTimes(1)
+  })
+
+  it('fires onClick on Enter key', () => {
+    const onClick = vi.fn()
+    renderCard(HEALTHY_SOV, SAMPLE_DETAIL, onClick)
+    const card = screen.getByTestId('sovereign-card-sov-a')
+    fireEvent.keyDown(card, { key: 'Enter' })
+    expect(onClick).toHaveBeenCalled()
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/widgets/fleet/SovereignCard.tsx
+++ b/products/catalyst/bootstrap/ui/src/widgets/fleet/SovereignCard.tsx
@@ -1,0 +1,215 @@
+/**
+ * SovereignCard — per-Sovereign card on the new live multi-Sov
+ * dashboard (EPIC-6 Slice U-Fleet-2, #1101).
+ *
+ * Renders:
+ *   - Sovereign FQDN (heading) + provider chip
+ *   - Health badge (green/yellow/red/unknown — palette in fleet.api.ts)
+ *   - Applications count (total + active + failing chips)
+ *   - Regions list (chip per region — derived from per-Sov summary)
+ *   - Alerts badge (placeholder — 0 today; EPIC-1 score aggregator
+ *     follow-up will populate)
+ *   - "Last activity" timestamp (most recent App creation, RFC3339)
+ *
+ * Click → navigates to that Sovereign's chroot console
+ * (`https://console.<sov.fqdn>/dashboard`). For test environments
+ * without a real FQDN, falls back to the mothership's per-deployment
+ * provision URL via `sovereignChrootURL`.
+ *
+ * Per docs/INVIOLABLE-PRINCIPLES.md #4 every URL flows through
+ * fleet.api.ts (single source of palette + URL truth).
+ */
+
+import { Server, Activity, AlertCircle, Globe2, Layers } from 'lucide-react'
+import { Card, CardContent } from '@/shared/ui/card'
+import { Badge } from '@/shared/ui/badge'
+import {
+  type SovereignSummary,
+  type SovereignDetail,
+  healthBadgeColor,
+  healthLabel,
+  sovereignChrootURL,
+} from '@/lib/fleet.api'
+import { useFleetSovereignSummary } from '@/lib/useFleet'
+
+export interface SovereignCardProps {
+  sovereign: SovereignSummary
+  /**
+   * Test seam — when supplied, the card uses this detail directly and
+   * skips its own fetch. Production always omits and the card runs its
+   * own per-Sov summary query (TanStack Query dedups so a parent that
+   * also calls useFleetSovereignSummary pays one fetch).
+   */
+  detailOverride?: SovereignDetail
+  /**
+   * Optional click override. Default behavior: navigates to the
+   * Sovereign's chroot console URL via window.location. The override
+   * lets parent pages intercept (e.g. for analytics).
+   */
+  onClick?: () => void
+}
+
+/**
+ * SovereignCard — read-only fleet card. Self-fetches per-Sov detail
+ * via useFleetSovereignSummary unless `detailOverride` is supplied.
+ */
+export function SovereignCard({ sovereign, detailOverride, onClick }: SovereignCardProps) {
+  const enabled = !detailOverride
+  const detailQuery = useFleetSovereignSummary(sovereign.id, enabled)
+  const detail = detailOverride ?? detailQuery.data
+
+  const isLoading = !detail && detailQuery.isLoading
+
+  const handleClick = () => {
+    if (onClick) {
+      onClick()
+      return
+    }
+    if (typeof window !== 'undefined') {
+      window.location.href = sovereignChrootURL(sovereign)
+    }
+  }
+
+  const onKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault()
+      handleClick()
+    }
+  }
+
+  return (
+    <Card
+      role="button"
+      tabIndex={0}
+      onClick={handleClick}
+      onKeyDown={onKeyDown}
+      data-testid={`sovereign-card-${sovereign.id}`}
+      className="hover:border-[oklch(28%_0.02_250)] transition-colors duration-150 cursor-pointer focus:outline-none focus:ring-2 focus:ring-[--color-brand-500]/40"
+    >
+      <CardContent className="flex flex-col gap-3 p-5">
+        {/* Header — FQDN + health badge */}
+        <div className="flex items-start justify-between gap-3">
+          <div className="flex items-center gap-2 min-w-0">
+            <div className="shrink-0 flex h-8 w-8 items-center justify-center rounded-[--radius-md] bg-[--color-surface-2]">
+              <Server className="h-4 w-4 text-[oklch(60%_0.01_250)]" />
+            </div>
+            <div className="min-w-0">
+              <h3 className="text-sm font-semibold text-[oklch(92%_0.01_250)] font-mono truncate">
+                {sovereign.fqdn || sovereign.id}
+              </h3>
+              {sovereign.providerType && (
+                <p className="mt-0.5 text-xs text-[oklch(45%_0.01_250)]">
+                  {sovereign.providerType}
+                  {sovereign.region ? ` · ${sovereign.region}` : ''}
+                </p>
+              )}
+            </div>
+          </div>
+          <span
+            data-testid={`sovereign-card-health-${sovereign.id}`}
+            className={
+              'inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium border ' +
+              healthBadgeColor(sovereign.health)
+            }
+          >
+            <Activity className="h-3 w-3" />
+            {healthLabel(sovereign.health)}
+          </span>
+        </div>
+
+        {/* Body — metrics row */}
+        <div className="grid grid-cols-3 gap-2 text-center">
+          <Metric
+            label="Apps"
+            value={isLoading ? '…' : String(detail?.applications.total ?? 0)}
+            sub={
+              detail
+                ? `${detail.applications.active} active · ${detail.applications.failing} failing`
+                : ''
+            }
+            icon={<Layers className="h-3.5 w-3.5" />}
+          />
+          <Metric
+            label="Orgs"
+            value={isLoading ? '…' : String(detail?.orgs ?? 0)}
+            icon={<Globe2 className="h-3.5 w-3.5" />}
+          />
+          <Metric
+            label="Alerts"
+            value={isLoading ? '…' : String(detail?.alerts ?? 0)}
+            tone={detail && detail.alerts > 0 ? 'error' : 'muted'}
+            icon={<AlertCircle className="h-3.5 w-3.5" />}
+          />
+        </div>
+
+        {/* Regions chips */}
+        <div className="flex flex-wrap gap-1.5">
+          {(detail?.regions ?? []).length === 0 ? (
+            <span className="text-xs text-[oklch(40%_0.01_250)]">No regions reported</span>
+          ) : (
+            (detail?.regions ?? []).map((r) => (
+              <Badge key={r} variant="default" data-testid={`sovereign-card-region-${r}`}>
+                {r}
+              </Badge>
+            ))
+          )}
+        </div>
+
+        {/* Footer — last activity */}
+        {detail?.lastActivity && (
+          <p className="text-xs text-[oklch(45%_0.01_250)]">
+            Last activity:{' '}
+            <span className="text-[oklch(60%_0.01_250)]">{formatRelative(detail.lastActivity)}</span>
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  )
+}
+
+/* ── Internal helpers ─────────────────────────────────────────────── */
+
+function Metric({
+  label,
+  value,
+  sub,
+  tone = 'default',
+  icon,
+}: {
+  label: string
+  value: string
+  sub?: string
+  tone?: 'default' | 'muted' | 'error'
+  icon?: React.ReactNode
+}) {
+  const colorMain =
+    tone === 'error'
+      ? 'text-[--color-error]'
+      : tone === 'muted'
+        ? 'text-[oklch(60%_0.01_250)]'
+        : 'text-[oklch(92%_0.01_250)]'
+  return (
+    <div className="rounded-[--radius-md] bg-[--color-surface-2] py-2.5 px-2 flex flex-col items-center">
+      <p className="flex items-center gap-1 text-[10px] uppercase tracking-wider text-[oklch(50%_0.01_250)]">
+        {icon}
+        {label}
+      </p>
+      <p className={`mt-0.5 text-lg font-semibold tabular-nums ${colorMain}`}>{value}</p>
+      {sub && <p className="text-[10px] text-[oklch(40%_0.01_250)] truncate">{sub}</p>}
+    </div>
+  )
+}
+
+function formatRelative(rfc3339: string): string {
+  try {
+    const t = new Date(rfc3339).getTime()
+    if (!t) return rfc3339
+    const dt = (Date.now() - t) / 1000
+    if (dt < 60) return 'just now'
+    if (dt < 3600) return `${Math.floor(dt / 60)}m ago`
+    if (dt < 86400) return `${Math.floor(dt / 3600)}h ago`
+    return `${Math.floor(dt / 86400)}d ago`
+  } catch {
+    return rfc3339
+  }
+}


### PR DESCRIPTION
## Summary

EPIC-6 Slice U-Fleet — multi-Sovereign fleet view. Replaces the mock-data dashboard with a live multi-Sovereign aggregator backed by three new catalyst-api endpoints. Tracks #1101.

- **Backend** (`internal/handler/fleet.go`): 3 read-only endpoints (`/fleet/sovereigns`, `/fleet/sovereigns/{id}/summary`, `/fleet/applications`) reading per-Sovereign Application + Continuum + Organization CRs LIVE per ADR-0001 §2.7. 4s per-Sov timeout so a slow Sovereign never stalls the dashboard.
- **UI** (`pages/dashboard/`): rebuilt `DashboardPage` around `useFleet()` (responsive Sovereign-card grid + empty state + retry); new `CrossSovereignView` with org / topology / DR-posture filters; new `SovereignCard` widget with self-fetched per-Sov rollup.
- **DR posture matrix** (per brief): `Continuum + healthy → "DR active"`, `Continuum + Failed → "DR alert"`, `active-hotstandby + no Continuum → "Misconfigured"`, else `→ "—"`. Matches the LIVE Continuum CRD (`status.phase` enum) — the brief mentioned `LastSwitchoverResult` but that field doesn't exist in `chart/crds/continuum.yaml`; reading-the-live-CRD-first per canonical-seam rule.
- **Pagination**: ≤50 Sovereigns per page (capped server-side); 25 default.
- **alerts** count placeholder = 0 (EPIC-1 score-aggregator integration follow-up — wire shape reserved).
- **Per-tier visibility gate**: centralised in `fleetCallerVisibility()` (reserved seam — admin/owner sees all today; org-scoped sub-set is the future-extension hook).

## Test plan

- [x] Go: 15 tests covering happy / pagination / adopted-excluded / org+topology+drPosture filters / 400 + 404 paths / DR posture matrix / health derivation. `go test -count=1 -race ./internal/handler/` clean (20.3s).
- [x] Go vet clean across the whole module.
- [x] Vitest: 20 tests (useFleet hook, SovereignCard widget, CrossSovereignView page) all passing.
- [x] `npm run typecheck` clean.
- [x] `npm run lint` matches main baseline (72 pre-existing problems unchanged; 0 new from this slice).
- [x] `npm run build` succeeds.
- [x] Playwright spec at `e2e/fleet-dashboard.spec.ts` (5 tests at 1440x900): F1 three-card grid, F2 empty state, F3 cross-Sov table + filters, F4 click → chroot navigate, F5 DR posture badges.
- [x] Pre-existing failures (per implementer-canon §7) confirmed unchanged: 12 vitest test files / 98 tests (StepComponents + AppDetail) — same numbers on `main`.

## New seams (for `01-canonical-seams.md`)

- **`useFleet` hook** + `fleet.api.ts` (REST client) — sibling to `useCatalog`/`useComplianceStream` patterns: TanStack Query, REST baseline, no Zustand.
- **`SovereignCard` widget** at `widgets/fleet/SovereignCard.tsx` — self-fetches per-Sov detail; reusable for any future fleet-context surface (e.g. an Org-page mini-fleet panel).
- **`CrossSovereignView`** filters pattern — Application × Sovereign × Region × Topology × DR posture cross-table; reusable shape for any future cross-Sov aggregator (compliance, RBAC).
- **`fleet.go` aggregation pattern** — fan-out per-Sov reads with bounded timeout, drop-on-error so one bad cluster doesn't break the dashboard.
- **`OrganizationGVR()`** new GVR helper in `handler/fleet.go` (reuses `ContinuumGVR()` from continuum.go and `ApplicationGVR()` from applications.go).
- **`fleetCallerVisibility()`** — reserved seam for org-scoped Sovereign access (returns nil today; populate map when org-scoped boundaries land).

## Out of scope (per master brief)

- No Continuum reconciler / DR UI changes (K-Cont-2 + U-DR-1 final).
- No CNPG-pair Blueprint changes.
- No cross-Sovereign Application reuse (Applications stay within one Sovereign by design).
- No fleet-level RBAC/install actions (read-only fleet view).

🤖 Generated with [Claude Code](https://claude.com/claude-code)