### PR TITLE
fix(auth): VerifyPinPage success path sets auth-gate marker — closes login bounce loop (#1090 cluster A3)

### DIFF
--- a/products/catalyst/bootstrap/ui/src/app/router.tsx
+++ b/products/catalyst/bootstrap/ui/src/app/router.tsx
@@ -246,6 +246,13 @@ const authHandoverRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: '/auth/handover',
   beforeLoad: () => {
+    // The server-side AuthHandover handler has already set the
+    // HttpOnly catalyst_session cookie before redirecting here. Mark
+    // the rootRoute auth gate (#1090 cluster A2) as satisfied so the
+    // next navigation to /dashboard isn't bounced to /login.
+    if (typeof window !== 'undefined') {
+      try { sessionStorage.setItem('catalyst:authed', '1') } catch { /* private */ }
+    }
     throw redirect({ to: '/dashboard' as never, replace: true })
   },
   component: () => null,

--- a/products/catalyst/bootstrap/ui/src/pages/auth/VerifyPinPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/auth/VerifyPinPage.tsx
@@ -83,12 +83,21 @@ export function VerifyPinPage() {
         attemptsRemaining?: number
       }
       if (res.ok && body.ok) {
-        // Success — navigate to the next page (wizard by default).
-        const target = (next as never) ?? ('/wizard' as never)
-        // Hard navigation isn't required here — the cookie is set on
-        // the same origin and TanStack router's beforeLoad guard will
-        // re-poll /whoami when /wizard mounts.
-        navigate({ to: target, replace: true })
+        // Mark the rootRoute auth gate (#1090 cluster A2) as satisfied
+        // BEFORE navigating. The catalyst_session cookie just set is
+        // HttpOnly + invisible to JS, so the gate's hasCatalystSession()
+        // check would otherwise fail and bounce the operator right back
+        // to /login (regression on omantel 2026-05-09).
+        try { sessionStorage.setItem('catalyst:authed', '1') } catch { /* private browsing */ }
+        // Hard navigation so the next page boot reads the cookie via
+        // /whoami fresh and the auth gate sees the marker. Mirrors the
+        // pattern Fix #A (PR #1093) uses on the unauth path.
+        const target = next ?? '/wizard'
+        if (typeof window !== 'undefined') {
+          window.location.replace(target)
+          return
+        }
+        navigate({ to: target as never, replace: true })
         return
       }
       if (res.status === 401 && body.error === 'pin-invalid') {


### PR DESCRIPTION
**LIVE BUG**: post-PIN-verify SPA bounces operator back to /login despite BE logs showing successful 200 + session cookie set.

**Root cause**: PR #1109's rootRoute.beforeLoad reads sessionStorage['catalyst:authed'] which the HttpOnly cookie can't set; SovereignConsoleLayout was the only place setting it (after async /whoami), but post-PIN navigation hits the gate BEFORE that layout mounts.

**Fix**: VerifyPinPage + /auth/handover set the marker BEFORE navigating + use window.location.replace so the next page boot is fresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)