### PR TITLE
fix(ui): null-guard compliance dashboard render path (qa-loop iter-1)

### DIFF
--- a/products/catalyst/bootstrap/ui/src/pages/admin/compliance/SREDashboardPage.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/admin/compliance/SREDashboardPage.test.tsx
@@ -195,3 +195,59 @@ describe('SecLeadDashboardPage', () => {
     expect(legend.textContent).toContain('Hardened')
   })
 })
+
+/* ── Null-slice payloads (cold-start sovereign with no rollup data) ───
+ *
+ * Regression for qa-loop iter-1 (TC-024 + TC-025): Go's encoding/json
+ * serializes a nil `[]Score` to JSON `null`. When that wire payload
+ * landed in the SRE Lead / Security Lead dashboards, `.map()` /
+ * `.filter()` / `.length` on `null` crashed the render and surfaced
+ * the global "Something went wrong" fallback for both
+ * `/sre/compliance` and `/sec/compliance` routes.
+ *
+ * These tests render with the worst-case wire payload (every slice =
+ * null, sovereign = null) and assert the dashboard renders the empty
+ * state instead of throwing.
+ */
+describe('SREDashboardPage — null-slice wire payload', () => {
+  // The cast erases ScorecardResponse's "non-null array" guarantee so
+  // we can simulate the actual wire shape catalyst-api emits before
+  // any rollup data exists.
+  const nullSlicePayload = {
+    sovereign: null,
+    organizations: null,
+    environments: null,
+    applications: null,
+    generatedAt: NOW,
+  } as unknown as ScorecardResponse
+
+  it('SRE Lead — renders the empty state instead of crashing', async () => {
+    renderRoute(
+      '/admin/compliance/sre',
+      <SREDashboardPage disableStream initialDataOverride={nullSlicePayload} />,
+    )
+    expect(await screen.findByTestId('compliance-dashboard-title')).toBeTruthy()
+    expect(await screen.findByTestId('compliance-empty')).toBeTruthy()
+  })
+
+  it('Security Lead — renders the empty state instead of crashing', async () => {
+    renderRoute(
+      '/admin/compliance/security',
+      <SecLeadDashboardPage disableStream initialDataOverride={nullSlicePayload} />,
+    )
+    expect(await screen.findByTestId('compliance-dashboard-title')).toBeTruthy()
+    expect(await screen.findByTestId('compliance-empty')).toBeTruthy()
+  })
+
+  it('SRE Lead — renders empty state when initialDataOverride is undefined and stream is silent', async () => {
+    // No override + disabled stream + no deploymentId → loading false,
+    // merged undefined, isEmpty false → renders the loading / pending
+    // surface but still mounts the title + treemap-frame anchors.
+    renderRoute(
+      '/admin/compliance/sre',
+      <SREDashboardPage disableStream />,
+    )
+    expect(await screen.findByTestId('compliance-dashboard-title')).toBeTruthy()
+    expect(await screen.findByTestId('compliance-treemap-frame')).toBeTruthy()
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/pages/admin/compliance/SREDashboardPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/admin/compliance/SREDashboardPage.tsx
@@ -32,6 +32,7 @@ import { scorecardToTreemapNodes } from '@/widgets/compliance/scorecardToTreemap
 import type { ComplianceTreemapNode } from '@/widgets/compliance/ComplianceTreemapNode'
 import {
   getScorecard,
+  normalizeScorecard,
   scoreColor,
   scoreLabel,
   type ColorPalette,
@@ -89,9 +90,16 @@ export function SREDashboardPage({
 
   // Merge: REST scorecard provides initial rollups; SSE scores
   // override + add live updates. Keyed by scope:id.
+  //
+  // Both `initialDataOverride` (test seam) and `query.data` (live
+  // wire) are normalized through `normalizeScorecard` so a Go nil
+  // slice serialized as JSON `null` (cold-start sovereign with no
+  // rollup data yet) cannot crash the render path. See
+  // `normalizeScorecard` for the full rationale.
   const merged: ScorecardResponse | undefined = useMemo(() => {
-    const base = initialDataOverride ?? query.data
-    if (!base) return undefined
+    const raw = initialDataOverride ?? query.data
+    if (!raw) return undefined
+    const base = normalizeScorecard(raw)
     if (stream.scores.length === 0) return base
     // Build a lookup of streamed scores keyed by scope:id.
     const streamMap = new Map<string, Score>()
@@ -154,9 +162,9 @@ export function SREDashboardPage({
     } as never)
   }
 
-  const isEmpty =
-    (!!initialDataOverride && initialDataOverride.applications.length === 0) ||
-    (!query.isLoading && !!merged && merged.applications.length === 0)
+  // Use `merged` (already normalized) so a nil-slice payload from the
+  // backend is treated as "empty", not as a crash.
+  const isEmpty = !query.isLoading && !!merged && merged.applications.length === 0
 
   return (
     <PortalShell deploymentId={deploymentId} pageTitle="Compliance">

--- a/products/catalyst/bootstrap/ui/src/pages/admin/compliance/compliance.api.ts
+++ b/products/catalyst/bootstrap/ui/src/pages/admin/compliance/compliance.api.ts
@@ -123,7 +123,45 @@ export async function getScorecard(sovereignId: string): Promise<ScorecardRespon
   if (!res.ok) {
     throw new Error(`scorecard: HTTP ${res.status}`)
   }
-  return res.json()
+  const raw = (await res.json()) as Partial<ScorecardResponse> | null
+  return normalizeScorecard(raw)
+}
+
+/**
+ * normalizeScorecard — defensively coerce a partial / nullable wire
+ * payload into a fully-shaped ScorecardResponse.
+ *
+ * Why: the catalyst-api Go handler returns nil slices when a sovereign
+ * has no rollup data yet (cold-start, fresh cluster, scorecard not
+ * computed). Go's `encoding/json` serializes a nil `[]Score` to JSON
+ * `null` rather than `[]`, so consumers see `applications: null` on
+ * the wire. Calling `.map()` / `.filter()` / `.length` on `null`
+ * crashes the React render — surfacing the global "Something went
+ * wrong" fallback for the whole compliance dashboard.
+ *
+ * Coercing here gives every downstream caller (this hook, the SSE
+ * merge, the treemap helper) a guaranteed array shape, so a
+ * not-yet-computed scorecard renders the empty state instead of
+ * crashing. Mirrors the same pattern other API wrappers in this
+ * codebase use to absorb Go nil-slice quirks.
+ */
+export function normalizeScorecard(raw: Partial<ScorecardResponse> | null | undefined): ScorecardResponse {
+  const safe = raw ?? {}
+  const fallbackSovereign: Score = {
+    scope: 'sovereign',
+    id: '',
+    total: null,
+    numerator: 0,
+    denominator: 0,
+    updatedAt: new Date().toISOString(),
+  }
+  return {
+    sovereign: safe.sovereign ?? fallbackSovereign,
+    organizations: Array.isArray(safe.organizations) ? safe.organizations : [],
+    environments: Array.isArray(safe.environments) ? safe.environments : [],
+    applications: Array.isArray(safe.applications) ? safe.applications : [],
+    generatedAt: safe.generatedAt ?? new Date().toISOString(),
+  }
 }
 
 export async function getPolicies(sovereignId: string): Promise<PoliciesResponse> {

--- a/products/catalyst/bootstrap/ui/src/widgets/compliance/ComplianceTreemap.tsx
+++ b/products/catalyst/bootstrap/ui/src/widgets/compliance/ComplianceTreemap.tsx
@@ -99,6 +99,7 @@ function renderTreemapCell(
 
     const isLeaf = !payload.children || payload.children.length === 0
     const total = payload.total ?? null
+    const name = payload.name ?? '—'
     const fill = isLeaf
       ? scoreColor(total, palette)
       : 'rgba(255, 255, 255, 0.04)'
@@ -110,7 +111,7 @@ function renderTreemapCell(
 
     return (
       <g
-        data-testid={`compliance-treemap-cell-${payload.name}`}
+        data-testid={`compliance-treemap-cell-${name}`}
         style={{ cursor }}
         onClick={() => {
           if (isLeaf && onLeafClick) onLeafClick(payload)
@@ -133,7 +134,7 @@ function renderTreemapCell(
             fontWeight={600}
             style={{ pointerEvents: 'none' }}
           >
-            {truncateLabel(payload.name, width)}
+            {truncateLabel(name, width)}
           </text>
           {isLeaf ? (
             <text


### PR DESCRIPTION
## Summary

qa-loop iter-1 — Fix #4 — cluster `compliance-dashboard-crash` (TC-024 + TC-025).

`/sre/compliance` and `/sec/compliance` were crashing on cold-start sovereigns with `Something went wrong` + a `TypeError`. Root cause: catalyst-api's `HandleComplianceScorecard` builds the response by appending to nil `[]Score` slices, and Go's `encoding/json` serializes a nil slice as JSON `null`. The frontend then called `.map()` / `.filter()` / `.length` on `null`.

Frontend-only fix per qa-loop Fix #4 scope (BE handlers off-limits).

## Changes

- `compliance.api.ts` — new `normalizeScorecard()` coerces nil slices to `[]` and supplies a sovereign fallback. `getScorecard` runs every wire payload through it.
- `SREDashboardPage.tsx` — also normalize `initialDataOverride`, rebase `isEmpty` off the (now-safe) `merged` value.
- `ComplianceTreemap.tsx` — fall back to `'—'` when a node has no `name`.
- New regression tests render both dashboards with an all-null wire payload and assert the empty state, not a crash.

## Test plan

- [x] `npx vitest run src/pages/admin/compliance/SREDashboardPage.test.tsx` — 10/10 pass (5 SRE + 2 SecLead + 3 new null-slice)
- [x] `npx tsc -b --noEmit` — clean
- [x] `npx eslint` on touched files — clean
- [ ] Post-merge: image roll on omantel + curl-test of `/sre/compliance` and `/sec/compliance` shells