### PR TITLE
fix(chart): flip services.catalog.enabled=true + wire CATALYST_CATALOG_URL (qa-loop iter-1)

### DIFF
--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -124,8 +124,8 @@ name: bp-catalyst-platform
 # otech113 2026-05-05 — chart 0.1.18 fixed the readiness-probe loop
 # but every trigger immediately got 502 in <10ms (synchronous
 # apiserver permission rejection). 2026-05-05.
-version: 1.4.87
-appVersion: 1.4.87
+version: 1.4.88
+appVersion: 1.4.88
 description: |
   Catalyst Platform — the unified Catalyst control plane umbrella chart for Catalyst-Zero.
   Composes the catalyst-{ui,api}, console, admin, marketplace UI modules and the marketplace-api backend.

--- a/products/catalyst/chart/templates/api-deployment.yaml
+++ b/products/catalyst/chart/templates/api-deployment.yaml
@@ -858,6 +858,28 @@ spec:
             # over this default at template-render time).
             - name: CATALYST_SESSION_COOKIE_DOMAIN
               value: ""
+            # CATALYST_CATALOG_URL — in-cluster Service URL of
+            # catalyst-catalog (EPIC-2 Slice L, #1148). Consumed by
+            # internal/handler/catalog_client.go::NewCatalogClientFromEnv
+            # for live-install and preview flows. The default literal
+            # below matches the Service rendered by templates/services/
+            # catalog/service.yaml: name `catalyst-catalog`, namespace
+            # `.Release.Namespace` (catalyst-system on Sovereigns), port
+            # 8080. The literal keeps the dual-mode contract (Helm +
+            # Kustomize on contabo) working without Helm directives in
+            # `value:` fields. Per Inviolable Principle #4 per-Sovereign
+            # overlays MAY override via the `catalystApi.env` additional-
+            # env patch when the catalog ships in a different namespace.
+            #
+            # qa-loop iter-1 root cause: services.catalog.enabled was
+            # default false → the Service didn't exist → catalyst-api's
+            # in-code default URL pointed at a non-existent endpoint →
+            # every /api/v1/catalog* call returned 404 from the upstream
+            # round-trip wrapper. Flipping enabled=true (above) renders
+            # the Service; this env var documents the wiring contract
+            # in the manifest itself rather than only in Go source.
+            - name: CATALYST_CATALOG_URL
+              value: "http://catalyst-catalog.catalyst-system.svc.cluster.local:8080"
           resources:
             requests:
               cpu: 50m

--- a/products/catalyst/chart/values.yaml
+++ b/products/catalyst/chart/values.yaml
@@ -295,13 +295,24 @@ controllers:
 # emits ZERO catalog-related resources.
 services:
   catalog:
-    enabled: false
+    # Flipped ON per qa-loop iter-1 (TC-035..037 surfaced
+    # /api/v1/sovereigns/{id}/catalog* 404s — the catalog HTTPRoute
+    # was never rendered because this gate was off). Default-ON is
+    # safe: catalyst-api treats a 502/503 from the catalog upstream
+    # as a clean error path (handler/applications.go surfaces the
+    # "catalog upstream" detail). Per Inviolable Principle #4 the
+    # gate stays runtime-overridable — disable here for offline /
+    # CI render checks that don't have a Gitea backend wired.
+    enabled: true
     image:
       repository: "ghcr.io/openova-io/openova/catalyst-catalog"
-      # Empty `tag` fail-fasts at render time per Inviolable Principle #4a.
-      # CI stamps the SHA on every push to main via the catalyst-catalog
-      # GitHub Actions workflow.
-      tag: ""
+      # SHA-pinned per Inviolable Principle #4a (no :latest). Stamped
+      # from the latest SUCCESS run of the catalyst-catalog
+      # GitHub Actions workflow at PR-author time. Future CI bumps
+      # land via the catalyst-catalog-image-built repository_dispatch
+      # hop (catalyst-catalog-build.yaml notify job → downstream
+      # bumper PR).
+      tag: "9763286"
       pullPolicy: IfNotPresent
     replicas: 1
     # Gitea endpoint — empty defaults to in-cluster Service URL.


### PR DESCRIPTION
## Summary

Fix Author #5, qa-loop iter-1, cluster `catalog-svc-deployment-and-proxy`.

Root cause for TC-035..037 (and ~10 related catalog 404s on the omantel chroot Sovereign Console): `services.catalog.enabled` shipped default `false` (Slice L #1148), so the catalyst-catalog Service / Deployment / HTTPRoute were never rendered. Every `/api/v1/catalog*` call therefore 404'd at the Cilium Gateway.

## Changes (chart 1.4.87 → 1.4.88)

1. `values.yaml`: `services.catalog.enabled: true` (default-on, runtime-overridable per Inviolable Principle #4).
2. `values.yaml`: `services.catalog.image.tag: "9763286"` — pinned to the latest SUCCESS run of the catalyst-catalog GitHub Actions workflow (Inviolable Principle #4a — no `:latest`).
3. `templates/api-deployment.yaml`: explicit `CATALYST_CATALOG_URL=http://catalyst-catalog.catalyst-system.svc.cluster.local:8080` env var on catalyst-api (matches the Service rendered in `.Release.Namespace`).

## Test plan

- [x] `helm template` (default render) — Service / Deployment / SA / RBAC for catalyst-catalog all render. `CATALYST_CATALOG_URL` env var on catalyst-api Pod.
- [x] `helm template` (with `ingress.hosts.api.host` set) — `HTTPRoute` for `/api/v1/catalog` PathPrefix renders cleanly attached to `cilium-gateway`.
- [ ] Post-merge: catalog Pod `Running` on omantel chroot Sovereign + `curl /api/v1/catalog` returns HTTP 200 or 401 (NOT 404).

Refs: qa-loop iter-1.