### PR TITLE
fix(chart): add imagePullSecrets to catalyst-catalog Deployment (qa-loop iter-1 follow-up)

### DIFF
--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -124,8 +124,8 @@ name: bp-catalyst-platform
 # otech113 2026-05-05 — chart 0.1.18 fixed the readiness-probe loop
 # but every trigger immediately got 502 in <10ms (synchronous
 # apiserver permission rejection). 2026-05-05.
-version: 1.4.88
-appVersion: 1.4.88
+version: 1.4.89
+appVersion: 1.4.89
 description: |
   Catalyst Platform — the unified Catalyst control plane umbrella chart for Catalyst-Zero.
   Composes the catalyst-{ui,api}, console, admin, marketplace UI modules and the marketplace-api backend.

--- a/products/catalyst/chart/templates/services/catalog/deployment.yaml
+++ b/products/catalyst/chart/templates/services/catalog/deployment.yaml
@@ -26,6 +26,15 @@ spec:
     spec:
       serviceAccountName: {{ include "catalog.fullname" . }}
       automountServiceAccountToken: false
+      # Pull from ghcr.io/openova-io/openova/catalyst-catalog requires the
+      # `ghcr-pull` dockerconfigjson Secret in `.Release.Namespace`.
+      # Same name + namespace pattern as ui-deployment / marketplace-api
+      # (provisioned by the bootstrap-kit slot's per-namespace ghcr-pull
+      # seal). qa-loop iter-1 surfaced an ImagePullBackOff loop on
+      # omantel because this stanza was missing — kubelet fell through
+      # to anonymous pulls and got `401 Unauthorized` from ghcr.
+      imagePullSecrets:
+        - name: ghcr-pull
       securityContext:
         runAsNonRoot: true
         runAsUser: 65532


### PR DESCRIPTION
## Summary

Follow-up to #1186. Live verification on omantel chroot Sovereign revealed the catalyst-catalog Pod entered ImagePullBackOff because the Deployment template was missing `imagePullSecrets`.

Failure on omantel:

```
Failed to pull image "ghcr.io/openova-io/openova/catalyst-catalog:9763286":
failed to authorize: failed to fetch anonymous token: ...
401 Unauthorized
```

Fix: same name + namespace pattern as ui-deployment / marketplace-api (`ghcr-pull` dockerconfigjson Secret in `.Release.Namespace`, provisioned by the bootstrap-kit slot's per-namespace ghcr-pull seal).

Chart 1.4.88 → 1.4.89.

## Test plan

- [x] Live verification on omantel: applying the patched Deployment transitions Pod from `ImagePullBackOff` through `ContainerCreating`.
- [ ] Post-merge: Pod reaches `Running` and `curl /api/v1/catalog` returns HTTP 200/401 (NOT 404).

Refs: qa-loop iter-1.