### PR TITLE
fix(api): emit immediate snapshot frame on SSE connect (qa-loop iter-1)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/applications.go
+++ b/products/catalyst/bootstrap/api/internal/handler/applications.go
@@ -393,13 +393,34 @@ func (h *Handler) HandleApplicationStream(w http.ResponseWriter, r *http.Request
 	defer pollT.Stop()
 
 	var lastPhase string
-	emit := func() {
+	// emitSnapshot writes a `data:` frame for the current Application
+	// state. Always emits at least one frame on first call so probes /
+	// EventSource consumers see a wire event without waiting 2s for the
+	// poll tick — even when the Application CR doesn't exist yet
+	// (returns a `notFound` snapshot in that case).
+	emitSnapshot := func(force bool) {
 		obj, err := getApplicationCR(r.Context(), client, name, ns)
 		if err != nil {
+			if !force {
+				return
+			}
+			// First-call fallback: emit a "notFound" snapshot so the
+			// stream consumer always sees an initial `data:` frame.
+			// The UI renders this as the empty / not-installed state.
+			_, _ = w.Write([]byte("data: "))
+			_ = enc.Encode(map[string]interface{}{
+				"name":      name,
+				"namespace": ns,
+				"phase":     "",
+				"status":    map[string]interface{}{},
+				"notFound":  true,
+			})
+			_, _ = w.Write([]byte("\n"))
+			flusher.Flush()
 			return
 		}
 		phase, _, _ := unstructured.NestedString(obj.Object, "status", "phase")
-		if phase == lastPhase {
+		if !force && phase == lastPhase {
 			return
 		}
 		lastPhase = phase
@@ -414,10 +435,13 @@ func (h *Handler) HandleApplicationStream(w http.ResponseWriter, r *http.Request
 		_, _ = w.Write([]byte("\n"))
 		flusher.Flush()
 	}
+	emit := func() { emitSnapshot(false) }
 
 	// Emit initial state immediately so subscribers see today's snapshot
-	// without waiting for the first poll tick.
-	emit()
+	// without waiting for the first poll tick. Forces a `data:` frame
+	// even when the CR doesn't exist yet so probes never time out
+	// waiting for a wire event.
+	emitSnapshot(true)
 	for {
 		select {
 		case <-r.Context().Done():

--- a/products/catalyst/bootstrap/api/internal/handler/compliance.go
+++ b/products/catalyst/bootstrap/api/internal/handler/compliance.go
@@ -1442,10 +1442,44 @@ func (h *Handler) HandleComplianceStream(w http.ResponseWriter, r *http.Request)
 	_, _ = fmt.Fprintf(w, ": connected cluster=%s\n\n", clusterID)
 	flusher.Flush()
 
+	enc := json.NewEncoder(w)
+
+	// Emit an immediate snapshot `data:` frame on connect so subscribers
+	// (and probes / tests) see at least one event without waiting for
+	// the next score recompute or heartbeat. The snapshot reuses the
+	// existing /scorecard rollups; a fresh Sovereign with no
+	// PolicyReports yet will see an event with score=null which the UI
+	// renders as "no data yet" — same shape as the steady-state stream.
+	rolls := h.compliance.rollupsFor(clusterID)
+	var snapScore Score
+	for _, s := range rolls {
+		if s.Scope == "sovereign" {
+			snapScore = s
+			break
+		}
+	}
+	if snapScore.Scope == "" {
+		snapScore = Score{Scope: "sovereign", ID: clusterID, UpdatedAt: time.Now().UTC()}
+	}
+	snapEv := complianceEvent{
+		Type:    "snapshot",
+		Cluster: clusterID,
+		Score:   snapScore,
+		At:      time.Now().UTC(),
+	}
+	if _, err := w.Write([]byte("data: ")); err != nil {
+		return
+	}
+	if err := enc.Encode(snapEv); err != nil {
+		return
+	}
+	if _, err := w.Write([]byte("\n")); err != nil {
+		return
+	}
+	flusher.Flush()
+
 	pingT := time.NewTicker(h.compliance.cfg.SSEHeartbeatInterval)
 	defer pingT.Stop()
-
-	enc := json.NewEncoder(w)
 	for {
 		select {
 		case <-r.Context().Done():

--- a/products/catalyst/bootstrap/api/internal/handler/compliance_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/compliance_test.go
@@ -33,6 +33,7 @@
 package handler
 
 import (
+	"bufio"
 	"context"
 	"encoding/json"
 	"io"
@@ -798,5 +799,78 @@ func TestCompliance_LabelOr(t *testing.T) {
 	}
 	if got := labelOr(lbls, "z"); got != "" {
 		t.Fatalf("labelOr missing: %s", got)
+	}
+}
+
+// TestHandleComplianceStream_ImmediateSnapshotFrame asserts the SSE
+// /compliance/stream endpoint emits a `data:` snapshot frame on
+// connect — even when the cluster has no compliance state yet.
+//
+// Regression test for qa-loop iter-1 TC-030: the prior implementation
+// only sent a `: connected ...` comment line on connect and waited up
+// to SSEHeartbeatInterval (15s default) for the next event, causing
+// 6s probe timeouts on quiet clusters.
+func TestHandleComplianceStream_ImmediateSnapshotFrame(t *testing.T) {
+	h, _, _, _ := newComplianceTestRig(t)
+
+	r := chi.NewRouter()
+	r.Get("/api/v1/sovereigns/{id}/compliance/stream", h.HandleComplianceStream)
+	srv := httptest.NewServer(r)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/api/v1/sovereigns/acme/compliance/stream")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status: %d", resp.StatusCode)
+	}
+	if ct := resp.Header.Get("Content-Type"); !strings.HasPrefix(ct, "text/event-stream") {
+		t.Fatalf("content-type: %q", ct)
+	}
+
+	// Expect at least one `data:` line within 1s.
+	type result struct {
+		payload string
+		err     error
+	}
+	doneCh := make(chan result, 1)
+	go func() {
+		br := bufio.NewReader(resp.Body)
+		for {
+			line, err := br.ReadString('\n')
+			if err != nil {
+				doneCh <- result{err: err}
+				return
+			}
+			if strings.HasPrefix(line, "data: ") {
+				doneCh <- result{payload: strings.TrimSpace(strings.TrimPrefix(line, "data: "))}
+				return
+			}
+		}
+	}()
+
+	select {
+	case got := <-doneCh:
+		if got.err != nil {
+			t.Fatalf("never received `data:` frame: %v", got.err)
+		}
+		var ev complianceEvent
+		if err := json.Unmarshal([]byte(got.payload), &ev); err != nil {
+			t.Fatalf("decode payload %q: %v", got.payload, err)
+		}
+		if ev.Type != "snapshot" {
+			t.Fatalf("first event type: want snapshot, got %q", ev.Type)
+		}
+		if ev.Cluster != "acme" {
+			t.Fatalf("event cluster: want acme, got %q", ev.Cluster)
+		}
+		if ev.Score.Scope != "sovereign" {
+			t.Fatalf("snapshot score scope: want sovereign, got %q", ev.Score.Scope)
+		}
+	case <-time.After(1 * time.Second):
+		_ = resp.Body.Close()
+		t.Fatalf("timed out waiting for initial `data:` snapshot frame")
 	}
 }

--- a/products/catalyst/bootstrap/api/internal/handler/k8s.go
+++ b/products/catalyst/bootstrap/api/internal/handler/k8s.go
@@ -270,6 +270,35 @@ func (h *Handler) HandleK8sStream(w http.ResponseWriter, r *http.Request) {
 	_, _ = fmt.Fprintf(w, ": connected cluster=%s kinds=%s\n\n", clusterID, kindsParam)
 	flusher.Flush()
 
+	enc := json.NewEncoder(w)
+
+	// Emit an immediate "ready" `data:` snapshot frame on connect so
+	// probes / EventSource consumers see a wire event without waiting
+	// for the next watch event or the 15s heartbeat. The ready frame is
+	// idempotent — UI clients filter `type:"ready"` and treat it as a
+	// connection ack; consumers that just listen for any `data:` line
+	// (smoke tests, probes) get one immediately.
+	readyKinds := make([]string, 0, len(kindsFilter))
+	for k := range kindsFilter {
+		readyKinds = append(readyKinds, k)
+	}
+	sort.Strings(readyKinds)
+	if _, err := w.Write([]byte("data: ")); err != nil {
+		return
+	}
+	if err := enc.Encode(map[string]interface{}{
+		"type":    "ready",
+		"cluster": clusterID,
+		"kinds":   readyKinds,
+		"at":      time.Now().UTC(),
+	}); err != nil {
+		return
+	}
+	if _, err := w.Write([]byte("\n")); err != nil {
+		return
+	}
+	flusher.Flush()
+
 	// Initial-state snapshot — on connect, optionally emit a synthetic
 	// ADDED for every object currently in the Indexer for the
 	// requested kinds. Triggered by ?initialState=1; off by default
@@ -283,8 +312,6 @@ func (h *Handler) HandleK8sStream(w http.ResponseWriter, r *http.Request) {
 	// Heartbeat + main loop.
 	pingT := time.NewTicker(15 * time.Second)
 	defer pingT.Stop()
-
-	enc := json.NewEncoder(w)
 
 	for {
 		select {


### PR DESCRIPTION
## Summary

QA-loop iter-1 fix #6 — cluster `sse-timeout-handler-shape` (TC-030 / TC-041 / TC-092).

Three SSE handlers (`compliance/stream`, `applications/{name}/stream`, `k8s/stream`) only sent a `: connected ...` comment line on connect, then waited up to 15s for the next event/heartbeat. Probes / EventSource consumers timed out at 6s never seeing a `data:` frame.

## What changed

- **compliance.go** — emit `{type:"snapshot",cluster,score:<sovereign-rollup>}` immediately after subscribe.
- **applications.go** — `emitSnapshot(true)` forces a `data:` frame on connect even when the Application CR doesn't exist (`notFound:true`), so probes never wait the 2s poll cycle.
- **k8s.go** — emit `{type:"ready",cluster,kinds}` immediately after subscribe; UI clients filter on `type:"ready"` as the connection ack, smoke tests get a `data:` line on the first round-trip.

Pure producer-side addition; the existing event-driven path (`Factory.Subscribe`) is unchanged. No UI / auth / chart / audit / PUT-DELETE changes.

## Live reproduction (before fix)

```
$ timeout 8 curl -k -N -b cookies.txt \
    'https://console.omantel.biz/api/v1/sovereigns/sovereign-omantel.biz/compliance/stream'
: connected cluster=sovereign-omantel.biz
(then nothing — exit code 143)
```

## Test plan

- [x] `go test ./internal/handler/ -run TestHandleComplianceStream_ImmediateSnapshotFrame -v` (added)
- [x] `go test ./internal/handler/` — full suite passes (17.5s)
- [ ] Live: `timeout 8 curl ... /compliance/stream | grep data:` — expect a `data:` line within 1s on omantel after image roll.
- [ ] Live: `timeout 8 curl ... /k8s/stream?kinds=pod | grep data:` — expect ready frame.
- [ ] Live: `timeout 8 curl ... /applications/foo/stream | grep data:` — expect notFound snapshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)