### PR TITLE
fix(api): factory.List resolves plural alias (qa-loop iter-1 followup)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/k8scache/factory.go
+++ b/products/catalyst/bootstrap/api/internal/k8scache/factory.go
@@ -806,7 +806,17 @@ func (f *Factory) List(clusterID, kindName string, sel labels.Selector) ([]*unst
 	if !ok {
 		return nil, 0, fmt.Errorf("k8scache: cluster %q not registered", clusterID)
 	}
-	idx, ok := cs.indexers[CanonicalKindName(kindName)]
+	// Resolve the inbound kind name (which may be a plural alias like
+	// "services" or a kubectl short-form like "pvc") to the canonical
+	// singular Name informers are keyed under. Registry.Get handles the
+	// alias mapping; without this hop the indexer lookup below would
+	// see "services" / "pvc" and return "kind not registered" even
+	// though the registry resolved the same query at the handler tier.
+	canonName := CanonicalKindName(kindName)
+	if k, ok := f.registry.Get(kindName); ok {
+		canonName = CanonicalKindName(k.Name)
+	}
+	idx, ok := cs.indexers[canonName]
 	if !ok {
 		return nil, 0, fmt.Errorf("k8scache: kind %q not registered", kindName)
 	}
@@ -819,16 +829,19 @@ func (f *Factory) List(clusterID, kindName string, sel labels.Selector) ([]*unst
 		if sel != nil && !sel.Matches(labels.Set(u.GetLabels())) {
 			continue
 		}
-		out = append(out, redactObject(mustKind(f.registry, kindName), u))
+		out = append(out, redactObject(mustKind(f.registry, canonName), u))
 	}
 	cs.lastEventLock.RLock()
-	last := cs.lastEventAt[CanonicalKindName(kindName)]
+	last := cs.lastEventAt[canonName]
 	cs.lastEventLock.RUnlock()
 	var age time.Duration
 	if !last.IsZero() {
 		age = time.Since(last)
 	}
-	metricCacheSize.WithLabelValues(clusterID, kindName).Set(float64(len(out)))
+	// Use the canonical singular Name on the metric label so prometheus
+	// rolls up alias forms (services + service + svc) into one
+	// time-series instead of fanning out to N inflated cardinalities.
+	metricCacheSize.WithLabelValues(clusterID, canonName).Set(float64(len(out)))
 	return out, age, nil
 }
 

--- a/products/catalyst/bootstrap/api/internal/k8scache/k8scache_test.go
+++ b/products/catalyst/bootstrap/api/internal/k8scache/k8scache_test.go
@@ -281,6 +281,70 @@ func TestFactory_StartAndList(t *testing.T) {
 	t.Fatalf("informer never synced")
 }
 
+// TestFactory_ListResolvesPluralAlias asserts that the indexer lookup
+// in Factory.List honours the same plural / short-form aliases the
+// REST handler tier already accepts. Without this the handler would
+// resolve `/k8s/services` at the registry level (200 path) but the
+// downstream factory.List would still see "services" and return
+// "kind not registered" — exactly the iter-1 cloud-list 404 chain
+// surfaced live on omantel for TC-084 / TC-085 / TC-090 / TC-091.
+func TestFactory_ListResolvesPluralAlias(t *testing.T) {
+	pod := newPod("default", "x")
+	dyn, core := fakeClients(pod)
+
+	cfg := Config{
+		Logger:   quietLogger(),
+		Registry: minimalRegistry(),
+		Clusters: []ClusterRef{
+			{ID: "alpha", DynamicClient: dyn, CoreClient: core},
+		},
+	}
+	f, err := NewFactory(cfg)
+	if err != nil {
+		t.Fatalf("NewFactory: %v", err)
+	}
+	defer f.Stop()
+	if err := f.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	// Wait for sync via the canonical singular form first.
+	deadline := time.Now().Add(2 * time.Second)
+	synced := false
+	for time.Now().Before(deadline) {
+		items, _, err := f.List("alpha", "pod", labels.Everything())
+		if err == nil && len(items) == 1 {
+			synced = true
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if !synced {
+		t.Fatalf("informer never synced via singular form")
+	}
+
+	// Now exercise alias forms — every one MUST resolve to the same Pod.
+	for _, alias := range []string{"pods", "Pod", "PODS", "po"} {
+		items, _, err := f.List("alpha", alias, labels.Everything())
+		if err != nil {
+			t.Errorf("List(%q): %v — alias should resolve via Registry", alias, err)
+			continue
+		}
+		if len(items) != 1 {
+			t.Errorf("List(%q): got %d items; want 1", alias, len(items))
+			continue
+		}
+		if items[0].GetName() != "x" {
+			t.Errorf("List(%q): unexpected pod name %q", alias, items[0].GetName())
+		}
+	}
+
+	// Negative — a truly unknown kind still returns "not registered".
+	if _, _, err := f.List("alpha", "notakind", labels.Everything()); err == nil {
+		t.Fatalf("List(notakind) should error — Registry has no entry")
+	}
+}
+
 func TestFactory_ListUnknownClusterErrors(t *testing.T) {
 	cfg := Config{
 		Logger:   quietLogger(),

--- a/products/catalyst/bootstrap/api/internal/k8scache/tree.go
+++ b/products/catalyst/bootstrap/api/internal/k8scache/tree.go
@@ -96,7 +96,10 @@ func (f *Factory) GetResourcesBySelector(clusterID, targetKind, ns, selector str
 	if !ok {
 		return nil, fmt.Errorf("k8scache: kind %q not registered", targetKind)
 	}
-	idx, ok := cs.indexers[CanonicalKindName(targetKind)]
+	// Indexers are keyed by canonical singular Kind.Name (set in
+	// AddCluster). Resolve via the Kind we just looked up — `targetKind`
+	// itself may be a plural alias ("services") or short-form ("svc").
+	idx, ok := cs.indexers[CanonicalKindName(kind.Name)]
 	if !ok {
 		return nil, fmt.Errorf("k8scache: kind %q has no indexer on cluster %q", targetKind, clusterID)
 	}


### PR DESCRIPTION
## Summary

Followup to #1191. The handler-tier Registry.Get already accepts
plural / short-form aliases (\"services\", \"pvc\") since #1191, but
the downstream indexer lookups in Factory.List and
Factory.GetResourcesBySelector re-canonicalised the raw inbound
\`kindName\` and so still keyed off the plural form — the indexers
map is populated with singular canonical Names from AddCluster, so
\"services\" missed and the call returned
\`k8scache: kind \"services\" not registered\`.

## Live evidence

After rolling :ae24194 (the #1191 image) on omantel:

\`\`\`
$ curl -sS -k -b cookies 'https://console.omantel.biz/api/v1/sovereigns/sovereign-omantel.biz/k8s/services'
k8scache: kind \"services\" not registered
HTTP 404
\`\`\`

The error message changed (\"unknown kind\" → \"not registered\"),
proving the handler resolves the alias but the factory tier still
doesn't. This PR closes the gap.

## Fix

Both lookups go through Registry.Get first to obtain the canonical
singular Name, then index into \`cs.indexers\` with that. The
\`metricCacheSize\` prometheus label switches to the canonical form
too so plural and singular variants of the same query roll up to
one time-series instead of fanning out cardinality.

## Tests

- [x] \`TestFactory_ListResolvesPluralAlias\` — alias forms (\"pods\",
  \"Pod\", \"PODS\", \"po\") all return the same Pod the canonical
  \"pod\" call returns; \"notakind\" still errors.
- [x] All k8scache + handler tests still pass.
- [x] Live re-verify on omantel after image roll: TC-084/085/090/091/130 return 200.