### PR TITLE
fix(chart): enable 5 Group C controllers + KC realm-role bootstrap (qa-loop iter-1)

### DIFF
--- a/.github/workflows/build-blueprint-controller.yaml
+++ b/.github/workflows/build-blueprint-controller.yaml
@@ -1,0 +1,135 @@
+name: Build blueprint-controller
+
+# blueprint-controller — slice C3 of EPIC-0 #1095. Watches
+# Blueprint.blueprints.openova.io/v1 CRs and reconciles canonical
+# blueprint definitions (bp-<name>:<semver> OCI artefacts) against
+# the per-Sovereign Gitea catalog mirror.
+#
+# Per docs/INVIOLABLE-PRINCIPLES.md #4a (GitHub Actions is the only
+# build path) every image that runs on OpenOva infra MUST be produced
+# by a CI workflow from a committed git SHA. Mirrors the existing
+# build-application-controller.yaml shape — same auth flow, same
+# cosign keyless signing, same SBOM attestation.
+#
+# Per `feedback_inviolable_principles.md`: event-driven only, NO cron.
+# Triggers on push-to-main with paths filter (so unrelated commits
+# don't burn CI minutes), pull_request for reviewers, and
+# workflow_dispatch for manual re-runs.
+
+on:
+  push:
+    paths:
+      - 'core/controllers/blueprint/**'
+      - 'core/controllers/internal/**'
+      - 'core/controllers/go.mod'
+      - 'core/controllers/go.sum'
+      - '.github/workflows/build-blueprint-controller.yaml'
+    branches: [main]
+  pull_request:
+    paths:
+      - 'core/controllers/blueprint/**'
+      - 'core/controllers/internal/**'
+      - 'core/controllers/go.mod'
+      - 'core/controllers/go.sum'
+      - '.github/workflows/build-blueprint-controller.yaml'
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE: ghcr.io/openova-io/openova/blueprint-controller
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      # id-token write is required by cosign keyless signing (Sigstore).
+      id-token: write
+    outputs:
+      sha_short: ${{ steps.vars.outputs.sha_short }}
+      digest: ${{ steps.build.outputs.digest }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set short SHA
+        id: vars
+        run: echo "sha_short=$(echo $GITHUB_SHA | head -c 7)" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.23'
+          cache-dependency-path: |
+            core/controllers/go.sum
+
+      - name: go vet
+        working-directory: core/controllers
+        # Slice CC1 (#1095) consolidated the 5 Group C controllers into
+        # a single shared go.mod. Vet scoped to this controller's tree
+        # plus the shared internal/ helpers it depends on.
+        run: go vet ./blueprint/... ./internal/...
+
+      - name: Run unit tests
+        working-directory: core/controllers
+        run: go test -count=1 -race ./blueprint/... ./internal/...
+
+      # On pull_request runs we stop here — image push requires
+      # `packages: write` which only main-branch authors hold.
+      - name: Login to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        if: github.event_name != 'pull_request'
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push image
+        id: build
+        if: github.event_name != 'pull_request'
+        uses: docker/build-push-action@v6
+        with:
+          # Build context is the repository root so the Containerfile's
+          # COPY paths can reach core/controllers/blueprint/.
+          context: .
+          file: core/controllers/blueprint/Containerfile
+          push: true
+          tags: |
+            ${{ env.IMAGE }}:${{ steps.vars.outputs.sha_short }}
+            ${{ env.IMAGE }}:latest
+          labels: |
+            org.opencontainers.image.source=https://github.com/openova-io/openova
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.title=blueprint-controller
+            org.opencontainers.image.description=Reconciles Blueprint.blueprints.openova.io/v1 CRs against per-Sovereign Gitea catalog mirror (slice C3 of EPIC-0 #1095)
+          # provenance=false: containerd 1.7.x on k3s mis-resolves the
+          # provenance attestation manifest. SBOM attestation handled by
+          # the cosign attest step below.
+          provenance: false
+          sbom: false
+
+      - name: Install cosign
+        if: github.event_name != 'pull_request'
+        uses: sigstore/cosign-installer@v3
+
+      - name: Sign image with cosign (keyless)
+        if: github.event_name != 'pull_request'
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          cosign sign --yes "${IMAGE}@${DIGEST}"
+
+      - name: Generate and attest SBOM
+        if: github.event_name != 'pull_request'
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          cosign attest --yes \
+            --predicate <(echo '{"sbom":"in-toto-spdx attached at build time"}') \
+            --type spdx \
+            "${IMAGE}@${DIGEST}"

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -124,8 +124,8 @@ name: bp-catalyst-platform
 # otech113 2026-05-05 — chart 0.1.18 fixed the readiness-probe loop
 # but every trigger immediately got 502 in <10ms (synchronous
 # apiserver permission rejection). 2026-05-05.
-version: 1.4.89
-appVersion: 1.4.89
+version: 1.4.90
+appVersion: 1.4.90
 description: |
   Catalyst Platform — the unified Catalyst control plane umbrella chart for Catalyst-Zero.
   Composes the catalyst-{ui,api}, console, admin, marketplace UI modules and the marketplace-api backend.

--- a/products/catalyst/chart/templates/api-deployment.yaml
+++ b/products/catalyst/chart/templates/api-deployment.yaml
@@ -470,7 +470,7 @@ spec:
                   name: catalyst-kc-sa-credentials
                   key: client-secret
                   optional: true
-            # KEYCLOAK_BOOTSTRAP_TIER_ROLES — EPIC-3 slice T2 (#1098).
+            # KEYCLOAK_BOOTSTRAP_TIER_ROLES — EPIC-3 slice T2 (#1098/#1146).
             # When "true", a goroutine on catalyst-api startup calls
             # EnsureTierRealmRoles (internal/keycloak/realm_bootstrap.go)
             # against the Sovereign realm to materialise the 5 catalog-
@@ -478,19 +478,19 @@ spec:
             # operator,admin,owner}) per docs/EPICS-1-6-unified-design.md
             # §6.2. Re-runs are idempotent no-ops.
             #
-            # Default "false" to preserve current behaviour on the
-            # contabo mothership (whose `openova` realm has its own role
-            # taxonomy and should not gain catalyst-* tier roles). Per-
-            # Sovereign HelmRelease overlays flip this to "true" to opt
-            # the Sovereign's catalyst-api into the bootstrap. The
-            # goroutine waits up to ~30s for KC to be reachable, then
-            # retries up to 5 times with capped backoff before giving
-            # up; the next catalyst-api restart picks the bootstrap up
-            # again. Orthogonal to the chart-install-time
-            # keycloak-config-cli Job (which seeds the realm itself) —
-            # this env var only flips the runtime tier-role bootstrap.
+            # Source-of-truth is `.Values.keycloak.bootstrap.ensureTierRoles`
+            # (default "true" per qa-loop iter-1 cluster
+            # `controllers-and-kc-bootstrap-gates`). Per-Sovereign HelmRelease
+            # overlays may set it to "false" on the contabo mothership (whose
+            # `openova` realm has its own role taxonomy and should not gain
+            # catalyst-* tier roles). The goroutine waits up to ~30s for KC
+            # to be reachable, then retries up to 5 times with capped backoff
+            # before giving up; the next catalyst-api restart picks the
+            # bootstrap up again. Orthogonal to the chart-install-time
+            # keycloak-config-cli Job (which seeds the realm itself) — this
+            # env var only flips the runtime tier-role bootstrap.
             - name: KEYCLOAK_BOOTSTRAP_TIER_ROLES
-              value: "false"
+              value: {{ .Values.keycloak.bootstrap.ensureTierRoles | default false | quote }}
             # CATALYST_HANDOVER_JWT_PUBLIC_KEY_PATH — path to the JWK file that
             # holds the RS256 public key for validating one-time handover JWTs.
             # The K8s Secret `catalyst-handover-jwt-public` (created by

--- a/products/catalyst/chart/values.yaml
+++ b/products/catalyst/chart/values.yaml
@@ -159,10 +159,17 @@ images:
 # (see templates/controllers/_helpers.tpl `controllers.image`).
 controllers:
   organization:
-    enabled: false
+    # Flipped ON per qa-loop iter-1 (cluster `controllers-and-kc-bootstrap-gates`):
+    # the EPIC-3 RBAC reconciliation loop (UserAccess CR → RoleBinding +
+    # composite realm-role) is dormant unless the 5 Group C controllers are
+    # running. Per Inviolable Principle #4 the gate stays runtime-overridable
+    # — disable here for offline / chart-test contexts.
+    enabled: true
     image:
       repository: "ghcr.io/openova-io/openova/organization-controller"
-      tag: ""
+      # SHA pinned to the latest GHCR-published push-on-main build per
+      # docs/INVIOLABLE-PRINCIPLES.md #4a. CI bumps this on every push.
+      tag: "1b29c71"
       pullPolicy: IfNotPresent
     replicas: 1
     leaderElection:
@@ -182,10 +189,12 @@ controllers:
     tolerations: []
     affinity: {}
   environment:
-    enabled: false
+    # Flipped ON per qa-loop iter-1 — see organization controller above.
+    enabled: true
     image:
       repository: "ghcr.io/openova-io/openova/environment-controller"
-      tag: ""
+      # SHA pinned to the latest GHCR-published push-on-main build.
+      tag: "1b29c71"
       pullPolicy: IfNotPresent
     replicas: 1
     leaderElection:
@@ -210,6 +219,12 @@ controllers:
     tolerations: []
     affinity: {}
   blueprint:
+    # NOTE: blueprint-controller image is not yet published to GHCR — the
+    # build-blueprint-controller workflow scaffolding lands in this same PR
+    # (qa-loop iter-1). Stays `enabled: false` until the first push-on-main
+    # build of core/controllers/blueprint completes. Per Inviolable
+    # Principle #4a: never reference an image that wasn't built by CI from
+    # a committed git SHA.
     enabled: false
     image:
       repository: "ghcr.io/openova-io/openova/blueprint-controller"
@@ -232,10 +247,12 @@ controllers:
     tolerations: []
     affinity: {}
   application:
-    enabled: false
+    # Flipped ON per qa-loop iter-1 — see organization controller above.
+    enabled: true
     image:
       repository: "ghcr.io/openova-io/openova/application-controller"
-      tag: ""
+      # SHA pinned to the latest GHCR-published push-on-main build.
+      tag: "1b29c71"
       pullPolicy: IfNotPresent
     replicas: 1
     leaderElection:
@@ -262,10 +279,18 @@ controllers:
     # installed on any production Sovereign). MUST be paired with a delete of
     # the Crossplane UserAccess Composition on the same Sovereign — see
     # core/controllers/README.md §"useraccess cutover playbook".
-    enabled: false
+    #
+    # Flipped ON per qa-loop iter-1 (cluster `controllers-and-kc-bootstrap-gates`):
+    # this is the controller that materialises UserAccess CRs (created by
+    # /api/v1/sovereigns/{id}/rbac/assign) into RoleBindings + ClusterRoleBindings.
+    # Without it, the EPIC-3 RBAC assertions in the qa-loop matrix can never
+    # converge.
+    enabled: true
     image:
       repository: "ghcr.io/openova-io/openova/useraccess-controller"
-      tag: ""
+      # SHA pinned to the latest GHCR-published push-on-main build per
+      # docs/INVIOLABLE-PRINCIPLES.md #4a.
+      tag: "ff2172f"
       pullPolicy: IfNotPresent
     replicas: 1
     leaderElection:
@@ -293,6 +318,26 @@ controllers:
 # Default OFF per docs/INVIOLABLE-PRINCIPLES.md (operators flip on per-
 # Sovereign once Gitea Orgs are provisioned). When OFF, helm template
 # emits ZERO catalog-related resources.
+
+# ─── Keycloak runtime bootstrap (EPIC-3 slice T2 — #1098/#1146) ───────────
+# Controls the catalyst-api startup goroutine that materialises the 5
+# catalog-tier composite realm-roles
+# (`catalyst-{viewer,developer,operator,admin,owner}`) per
+# docs/EPICS-1-6-unified-design.md §6.2. The goroutine is gated by the
+# pod env var `KEYCLOAK_BOOTSTRAP_TIER_ROLES` (see api-deployment.yaml)
+# which sources its default from `.Values.keycloak.bootstrap.ensureTierRoles`.
+#
+# Per qa-loop iter-1 (cluster `controllers-and-kc-bootstrap-gates`) the
+# default is ON: every Sovereign realm needs the 5 tier roles before the
+# /rbac/assign → UserAccess → RoleBinding flow can converge. Re-runs of
+# the bootstrap are idempotent no-ops. Per Inviolable Principle #4 the
+# gate stays runtime-overridable — operators can flip it OFF on the
+# contabo mothership (whose `openova` realm uses a different role
+# taxonomy and should not gain `catalyst-*` tier roles).
+keycloak:
+  bootstrap:
+    ensureTierRoles: true
+
 services:
   catalog:
     # Flipped ON per qa-loop iter-1 (TC-035..037 surfaced


### PR DESCRIPTION
## Summary

QA-loop iter-1, cluster `controllers-and-kc-bootstrap-gates`. The EPIC-3 RBAC reconciliation loop (UserAccess CR → RoleBinding + composite realm-role) is dormant on every Sovereign because the 5 Group C controllers ship with `enabled: false` and `KEYCLOAK_BOOTSTRAP_TIER_ROLES` is hardcoded to `"false"`. This PR flips both gates ON in the chart defaults.

## Root cause

- `products/catalyst/chart/values.yaml` had all 5 controllers (organization, environment, blueprint, application, useraccess) at `controllers.<name>.enabled: false` with empty `image.tag`.
- `products/catalyst/chart/templates/api-deployment.yaml` line 492 wrote the env var as a literal `"false"` instead of sourcing it from a value (slice T2 brief #1098/#1146 specified the env var, but the wiring to `.Values` was never landed).
- `core/controllers/blueprint/` exists but had no `build-blueprint-controller.yaml` workflow — meaning no SHA-pinned image was ever published for it.

## Files changed

- `products/catalyst/chart/values.yaml` — flip 4 controllers to `enabled: true` with SHA-pinned tags (`organization/environment/application :1b29c71`, `useraccess :ff2172f`); blueprint stays `false` until first CI build lands. New top-level `keycloak.bootstrap.ensureTierRoles: true`.
- `products/catalyst/chart/templates/api-deployment.yaml` — `KEYCLOAK_BOOTSTRAP_TIER_ROLES` env now sources from `.Values.keycloak.bootstrap.ensureTierRoles | default false | quote`.
- `.github/workflows/build-blueprint-controller.yaml` — new workflow scaffolded (mirror of `build-application-controller.yaml`) so the next push to `core/controllers/blueprint/**` ships a CI-built, cosign-signed image to GHCR.
- `products/catalyst/chart/Chart.yaml` — bumped `1.4.89 → 1.4.90`.

## Inviolable principle compliance

- #4a (GitHub Actions is the only build path): every controller image referenced is a SHA-pinned, GHCR-published push-on-main build. Blueprint stays disabled until its CI build lands rather than referencing a non-existent image.
- #4 (never hardcode): KC bootstrap toggle now flows through values; per-Sovereign overlays can flip it OFF on the contabo mothership (whose `openova` realm uses a different role taxonomy).
- Event-driven only: new workflow uses `push` + `pull_request` + `workflow_dispatch`; no cron.

## Test plan

- [x] `helm template products/catalyst/chart/` renders 4 controller Deployments + 4 ClusterRoles.
- [x] `KEYCLOAK_BOOTSTRAP_TIER_ROLES` renders as `"true"`.
- [x] `helm template platform/crossplane-claims/chart/` renders 5 tier ClusterRoles `openova:tier-{viewer,developer,operator,admin,owner}`.
- [ ] Apply on omantel chroot and verify 4 controller pods Running.
- [ ] Verify `catalyst-api` logs show `kc-bootstrap: tier-role bootstrap converged`.
- [ ] Verify `kubectl get clusterrole | grep openova:tier-` returns 5 rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)