### PR TITLE
fix(chart): add ghcr-pull imagePullSecrets to 5 Group C controllers (qa-loop iter-1 follow-up)

### DIFF
--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -124,8 +124,8 @@ name: bp-catalyst-platform
 # otech113 2026-05-05 — chart 0.1.18 fixed the readiness-probe loop
 # but every trigger immediately got 502 in <10ms (synchronous
 # apiserver permission rejection). 2026-05-05.
-version: 1.4.90
-appVersion: 1.4.90
+version: 1.4.91
+appVersion: 1.4.91
 description: |
   Catalyst Platform — the unified Catalyst control plane umbrella chart for Catalyst-Zero.
   Composes the catalyst-{ui,api}, console, admin, marketplace UI modules and the marketplace-api backend.

--- a/products/catalyst/chart/templates/controllers/application-controller-deployment.yaml
+++ b/products/catalyst/chart/templates/controllers/application-controller-deployment.yaml
@@ -30,6 +30,9 @@ spec:
     spec:
       serviceAccountName: {{ include "controllers.fullname" "application" }}
       automountServiceAccountToken: true
+      # GHCR image is private — same pattern as catalyst-api / catalyst-ui.
+      imagePullSecrets:
+        - name: ghcr-pull
       securityContext:
         runAsNonRoot: true
         runAsUser: 65534

--- a/products/catalyst/chart/templates/controllers/blueprint-controller-deployment.yaml
+++ b/products/catalyst/chart/templates/controllers/blueprint-controller-deployment.yaml
@@ -26,6 +26,9 @@ spec:
     spec:
       serviceAccountName: {{ include "controllers.fullname" "blueprint" }}
       automountServiceAccountToken: true
+      # GHCR image is private — same pattern as catalyst-api / catalyst-ui.
+      imagePullSecrets:
+        - name: ghcr-pull
       securityContext:
         runAsNonRoot: true
         runAsUser: 65534

--- a/products/catalyst/chart/templates/controllers/environment-controller-deployment.yaml
+++ b/products/catalyst/chart/templates/controllers/environment-controller-deployment.yaml
@@ -34,6 +34,9 @@ spec:
     spec:
       serviceAccountName: {{ include "controllers.fullname" "environment" }}
       automountServiceAccountToken: true
+      # GHCR image is private — same pattern as catalyst-api / catalyst-ui.
+      imagePullSecrets:
+        - name: ghcr-pull
       securityContext:
         runAsNonRoot: true
         runAsUser: 65534

--- a/products/catalyst/chart/templates/controllers/organization-controller-deployment.yaml
+++ b/products/catalyst/chart/templates/controllers/organization-controller-deployment.yaml
@@ -34,6 +34,11 @@ spec:
     spec:
       serviceAccountName: {{ include "controllers.fullname" "organization" }}
       automountServiceAccountToken: true
+      # GHCR image is private — same pattern as catalyst-api / catalyst-ui
+      # / sme-services. The `ghcr-pull` Secret is rendered by the chart's
+      # cloud-init / bootstrap-kit path on every Sovereign.
+      imagePullSecrets:
+        - name: ghcr-pull
       securityContext:
         runAsNonRoot: true
         runAsUser: 65534

--- a/products/catalyst/chart/templates/controllers/useraccess-controller-deployment.yaml
+++ b/products/catalyst/chart/templates/controllers/useraccess-controller-deployment.yaml
@@ -35,6 +35,9 @@ spec:
     spec:
       serviceAccountName: {{ include "controllers.fullname" "useraccess" }}
       automountServiceAccountToken: true
+      # GHCR image is private — same pattern as catalyst-api / catalyst-ui.
+      imagePullSecrets:
+        - name: ghcr-pull
       securityContext:
         runAsNonRoot: true
         runAsUser: 65534


### PR DESCRIPTION
## Summary

Follow-up to PR #1194. After enabling the 4 Group C controllers (organization, environment, application, useraccess) on omantel, all 4 pods went `ErrImagePull` with `401 Unauthorized` from GHCR — the controller deployment templates were missing `imagePullSecrets: [{ name: ghcr-pull }]` that every other Pod in this chart already references.

## Root cause

Slice CC1 (#1095) scaffolded the 5 Group C controller deployments using a public-image template shape rather than mirroring the catalyst-api / catalyst-ui private-image template. Worked around by ImagePullPolicy=IfNotPresent for any image already cached locally; broke immediately on a Sovereign that didn't yet have the image.

## Files changed

- `products/catalyst/chart/templates/controllers/{organization,environment,blueprint,application,useraccess}-controller-deployment.yaml` — `imagePullSecrets: [{ name: ghcr-pull }]` added immediately after `automountServiceAccountToken: true`.
- `products/catalyst/chart/Chart.yaml` — bumped `1.4.90 → 1.4.91`.

## Test plan

- [x] `helm template` renders the imagePullSecrets block on all 5 controllers.
- [ ] After admin-merge + apply on omantel: 4 controller pods reach `Running 1/1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)