### PR TITLE
fix(chart): create catalyst-runtime-config ConfigMap with KC/Gitea env (qa-loop iter-1)

### DIFF
--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -124,8 +124,19 @@ name: bp-catalyst-platform
 # otech113 2026-05-05 — chart 0.1.18 fixed the readiness-probe loop
 # but every trigger immediately got 502 in <10ms (synchronous
 # apiserver permission rejection). 2026-05-05.
-version: 1.4.91
-appVersion: 1.4.91
+# 1.4.92 (qa-loop iter-1, cluster `catalyst-runtime-config-missing`):
+# adds templates/configmap-catalyst-runtime-config.yaml so the Group C
+# controller deployments (organization, environment, application) can
+# successfully resolve their `catalyst-runtime-config` configMapKeyRef
+# (CATALYST_KC_ADDR, CATALYST_KC_REALM, GITEA_PUBLIC_URL). Until this
+# release the CM did not exist and `optional: true` collapsed every key
+# to ""; organization-controller fail-fasted on
+# `mustEnv("CATALYST_KC_ADDR")` and CrashLoopBackOff'd indefinitely.
+# Defaults under .Values.runtime.* match the canonical in-cluster
+# Service FQDNs of bp-keycloak / bp-gitea. Caught live on omantel
+# 2026-05-09. 2026-05-09.
+version: 1.4.92
+appVersion: 1.4.92
 description: |
   Catalyst Platform — the unified Catalyst control plane umbrella chart for Catalyst-Zero.
   Composes the catalyst-{ui,api}, console, admin, marketplace UI modules and the marketplace-api backend.

--- a/products/catalyst/chart/templates/configmap-catalyst-runtime-config.yaml
+++ b/products/catalyst/chart/templates/configmap-catalyst-runtime-config.yaml
@@ -1,0 +1,39 @@
+{{- /*
+catalyst-runtime-config ConfigMap — single source of truth for runtime
+service coordinates the Group C controllers (organization, environment,
+application) source via configMapKeyRef.
+
+Why this exists:
+  All three controller deployments reference `catalyst-runtime-config`
+  with `optional: true` (templates/controllers/*-deployment.yaml). Until
+  this template was added the ConfigMap simply did not exist on any
+  Sovereign — `optional: true` resolved every key to "", and the Go
+  process at core/controllers/organization/cmd/main.go:58 fail-fasted on
+  `mustEnv("CATALYST_KC_ADDR")` with `required env var unset`. Caught
+  live on omantel 2026-05-09 (qa-loop iter-1, cluster
+  `catalyst-runtime-config-missing`).
+
+Per docs/INVIOLABLE-PRINCIPLES.md #4 (never hardcode) every value here
+is operator-overridable from the per-Sovereign overlay via the
+`runtime.*` block in values.yaml. Defaults match the canonical
+in-cluster Service FQDNs that bp-keycloak / bp-gitea / bp-nats-jetstream
+register on every Sovereign.
+
+Keys (all required by at least one controller):
+  - keycloak-addr      — organization-controller (CATALYST_KC_ADDR)
+  - keycloak-realm     — organization-controller (CATALYST_KC_REALM)
+  - gitea-public-url   — application-controller, environment-controller
+                         (GITEA_PUBLIC_URL)
+*/ -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: catalyst-runtime-config
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/managed-by: helm
+    app.kubernetes.io/component: catalyst-runtime-config
+data:
+  keycloak-addr: {{ .Values.runtime.keycloakAddr | quote }}
+  keycloak-realm: {{ .Values.runtime.keycloakRealm | quote }}
+  gitea-public-url: {{ .Values.runtime.giteaPublicURL | quote }}

--- a/products/catalyst/chart/values.yaml
+++ b/products/catalyst/chart/values.yaml
@@ -135,6 +135,39 @@ images:
   # All 10 SME microservices share one SHA tag (built from the same mono-repo commit).
   smeTag: "b0ed216"
 
+# ─── Runtime service coordinates (qa-loop iter-1, cluster
+# `catalyst-runtime-config-missing`) ────────────────────────────────────
+# Single source of truth for the in-cluster Service URLs the Group C
+# controllers (organization, environment, application) consume via the
+# `catalyst-runtime-config` ConfigMap (templates/configmap-catalyst-
+# runtime-config.yaml). Each controller deployment references this CM
+# with `optional: true`; before this block was added, the CM did not
+# exist on any Sovereign and `mustEnv("CATALYST_KC_ADDR")` in
+# core/controllers/organization/cmd/main.go fail-fasted on every Pod
+# start. Caught live on omantel 2026-05-09.
+#
+# Per docs/INVIOLABLE-PRINCIPLES.md #4 (never hardcode) every value here
+# is operator-overridable from the per-Sovereign overlay. Defaults match
+# the canonical in-cluster Service FQDNs that bp-keycloak / bp-gitea
+# register on every Sovereign (see clusters/_template/bootstrap-kit/
+# 11-bp-keycloak.yaml + 12-bp-gitea.yaml).
+runtime:
+  # Keycloak admin API base URL. Consumed as CATALYST_KC_ADDR by
+  # organization-controller (per-Org realm provisioning via the KC
+  # Admin API).
+  keycloakAddr: "http://keycloak.keycloak.svc.cluster.local:80"
+  # Keycloak realm the per-Org realms are nested under. Default
+  # `sovereign` matches the bp-keycloak chart's auto-provisioned
+  # tenant realm (the contabo mothership uses `openova` instead).
+  keycloakRealm: "sovereign"
+  # Gitea public base URL stamped on Application/Environment per-Org
+  # repos. Consumed as GITEA_PUBLIC_URL by application-controller and
+  # environment-controller. Default points at the in-cluster Service;
+  # operators MAY override to the public Gitea host
+  # (https://gitea.<sovereign-fqdn>) once the parent zone's HTTPRoute
+  # is reconciled.
+  giteaPublicURL: "http://gitea-http.gitea.svc.cluster.local:3000"
+
 # ─── Group C controllers (slice CC3 of EPIC-0 #1095) ────────────────────────
 # The 5 K8s-native reconcilers consolidated by CC1 (#1135) + CC2 (#1136):
 #


### PR DESCRIPTION
## Summary

Group C controller deployments (organization, environment, application) reference the `catalyst-runtime-config` ConfigMap via `configMapKeyRef` with `optional: true`, but the ConfigMap was never templated by the chart. On every Sovereign, `optional: true` collapsed every key to `""` and `mustEnv("CATALYST_KC_ADDR")` in `core/controllers/organization/cmd/main.go` fail-fasted on every Pod start.

Caught live on omantel 2026-05-09 during qa-loop iter-1 (cluster `catalyst-runtime-config-missing`):

```
catalyst-organization-controller   0/1   CrashLoopBackOff
catalyst-application-controller    0/1   CrashLoopBackOff
```

Pod logs:
```
{"level":"error","msg":"required env var unset","key":"CATALYST_KC_ADDR","error":"missing env"}
```

## Changes

- `templates/configmap-catalyst-runtime-config.yaml` — NEW, the missing ConfigMap. Keys: `keycloak-addr`, `keycloak-realm`, `gitea-public-url`.
- `values.yaml` — new `runtime.*` block with operator-overridable defaults matching the canonical in-cluster Service FQDNs of bp-keycloak + bp-gitea.
- `Chart.yaml` — version bump 1.4.91 -> 1.4.92.

Per `docs/INVIOLABLE-PRINCIPLES.md` #4 (never hardcode) every value is overridable from the per-Sovereign overlay. The contabo Kustomize path enumerates resources explicitly in `templates/kustomization.yaml` and does NOT include this new file, so contabo continues unaffected.

## Test plan

- [x] `helm template products/catalyst/chart/` renders without error
- [x] `helm template products/catalyst/chart/ --show-only templates/configmap-catalyst-runtime-config.yaml` shows the ConfigMap with all 3 keys populated
- [ ] Apply on omantel; organization-controller + application-controller transition from CrashLoopBackOff to Running