### PR TITLE
docs(chart): document CRD installation path for chroot Sovereigns (qa-loop iter-1 Fix #13)

### DIFF
--- a/products/catalyst/chart/CRDS.md
+++ b/products/catalyst/chart/CRDS.md
@@ -1,0 +1,74 @@
+# Catalyst Chart — CRD Installation Notes
+
+## Provenance
+
+The 9 catalyst-domain CRDs in `crds/` are auto-installed by Helm on
+`helm install` and `helm upgrade`:
+
+| File | API group | Kind |
+|------|-----------|------|
+| `application.yaml` | apps.openova.io | Application |
+| `blueprint.yaml` | catalyst.openova.io | Blueprint |
+| `continuum.yaml` | dr.openova.io | Continuum |
+| `environment.yaml` | catalyst.openova.io | Environment |
+| `environmentpolicy.yaml` | catalyst.openova.io | EnvironmentPolicy |
+| `organization.yaml` | orgs.openova.io | Organization |
+| `provisioningstate.yaml` | catalyst.openova.io | ProvisioningState |
+| `runbook.yaml` | catalyst.openova.io | Runbook |
+| `secretpolicy.yaml` | catalyst.openova.io | SecretPolicy |
+
+These are watched by the in-tree controllers under
+`core/controllers/{environment,organization,application,...}`. If any
+of them is missing from the API server, the matching controller logs:
+
+```
+controller-runtime.source.EventHandler   if kind is a CRD, it should be installed before calling Start
+```
+
+…and never reaches `Starting workers`.
+
+## UserAccess (out-of-tree CRD)
+
+`useraccesses.access.openova.io` is **not** in this chart — it is a
+Crossplane Composite Resource backed by an XRD shipped from
+`platform/crossplane-claims/chart/templates/xrds/useraccess.yaml`
+(per ADR-0001 §3: Crossplane is the day-2 IaC for IAM grants).
+
+A Sovereign that runs `catalyst-useraccess-controller` therefore
+requires both this catalyst chart **and** the `crossplane-claims`
+chart with `userAccess.enabled=true`.
+
+## Chroot Sovereign install path
+
+On the chroot (single-cluster) Sovereign topology:
+
+- Flux is **suspended** by design — `helm install` and `helm upgrade`
+  are not running on a schedule
+- Charts are applied operator-style during cutover (qa-loop / install
+  scripts), so `helm install --include-crds` (the default) takes care
+  of `crds/`
+- If a Sovereign was provisioned by `kubectl apply -f` of pre-rendered
+  templates (NOT `helm install`), the CRDs in `crds/` are **skipped**
+  by `helm template` — apply them explicitly:
+
+```bash
+for crd in products/catalyst/chart/crds/*.yaml; do
+  kubectl --context=<sovereign> apply -f "$crd"
+done
+
+# UserAccess XRD lives in the crossplane-claims chart:
+helm template platform/crossplane-claims/chart \
+  --set userAccess.enabled=true \
+  --show-only templates/xrds/useraccess.yaml \
+  | kubectl --context=<sovereign> apply -f -
+```
+
+The above sequence was used on 2026-05-09 to recover the omantel
+chroot Sovereign after a partial cutover (qa-loop iter-1, Fix #13).
+
+## Future-proofing
+
+For a fully event-driven Sovereign install path, ensure the cutover
+driver invokes `helm install/upgrade` (not `kubectl apply -f` of
+rendered manifests) so `crds/` is always applied. See
+`products/catalyst/bootstrap/cutover/` step-06 onward.


### PR DESCRIPTION
## qa-loop iter-1 — Fix #13 (cluster: crds-missing-on-omantel)

### Symptom

`environment-controller` + `useraccess-controller` on omantel chroot Sovereign logged forever:

```
controller-runtime.source.EventHandler   if kind is a CRD, it should be installed before calling Start
kind: Environment.catalyst.openova.io   error: no matches for kind "Environment" in version "catalyst.openova.io/v1"
kind: UserAccess.access.openova.io      error: no matches for kind "UserAccess" in version "access.openova.io/v1alpha1"
```

Neither controller ever reached `Starting workers`.

### Root cause

omantel chroot was missing **all 9** catalyst-domain CRDs from `products/catalyst/chart/crds/` plus the `useraccesses.access.openova.io` Crossplane XRD from `platform/crossplane-claims/chart/templates/xrds/useraccess.yaml`.

Flux is suspended on chroot Sovereigns by design, and cutover step-06 applied rendered templates via `kubectl apply -f` rather than `helm install --include-crds` — so the `crds/` directory was silently skipped.

### Fix (live, on omantel)

Operator-style apply of all 9 catalyst CRDs + the UserAccess XRD:

```bash
for crd in products/catalyst/chart/crds/*.yaml; do
  kubectl --context=omantel apply -f "$crd"
done

helm template platform/crossplane-claims/chart \
  --set userAccess.enabled=true \
  --show-only templates/xrds/useraccess.yaml \
  | kubectl --context=omantel apply -f -
```

Result on omantel:

```
$ kubectl --context=omantel get crd | grep openova.io | wc -l
17  # was 6 (crossplane composition only)
```

After restart, both controllers reached `Starting workers`:

```
{"msg":"Starting workers","controller":"environment-controller","controllerKind":"Environment","worker count":1}
{"msg":"Starting workers","controller":"useraccess-controller","controllerKind":"UserAccess","worker count":1}
```

No more `no matches for kind` errors.

### This PR

Docs-only change (no code, no manifests). Adds `products/catalyst/chart/CRDS.md` documenting:

- Inventory of the 9 catalyst CRDs and their controllers
- Why UserAccess XRD lives in the crossplane-claims chart (ADR-0001 §3)
- The operator-style apply sequence for chroot Sovereigns where `helm install` was bypassed
- Future-proofing note: cutover should invoke `helm install/upgrade`, not `kubectl apply -f` of rendered templates

### Out of scope (other parallel Fix Authors)

- Fix #11 — ConfigMap
- Fix #12 — application-controller flag
- application-controller CrashLoop (env vars / image pull) — separate cluster
- organization-controller CrashLoop (`CATALYST_KC_ADDR` env unset) — separate cluster

### Confidence

HIGH — controllers verified live on omantel.

🤖 Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>