### PR TITLE
fix(application-controller): copy core/controllers/pkg into Containerfile (unblock CI build)

### DIFF
--- a/core/controllers/application/Containerfile
+++ b/core/controllers/application/Containerfile
@@ -25,10 +25,12 @@ COPY core/controllers/go.mod core/controllers/go.sum core/controllers/
 WORKDIR /workspace/core/controllers
 RUN go mod download
 
-# Copy source + build. The shared internal/ packages and the per-
-# controller tree are both needed at compile time.
+# Copy source + build. The shared internal/ packages, the shared pkg/
+# packages (gitea/render/validate consolidated under CC2 #1095) and the
+# per-controller tree are all needed at compile time.
 WORKDIR /workspace
 COPY core/controllers/internal /workspace/core/controllers/internal
+COPY core/controllers/pkg /workspace/core/controllers/pkg
 COPY core/controllers/application /workspace/core/controllers/application
 
 WORKDIR /workspace/core/controllers/application


### PR DESCRIPTION
## Symptom
Every push-on-main build of `build-application-controller.yaml` since
2026-05-08 21:18 UTC has failed:
```
no required module provides package github.com/openova-io/openova/core/controllers/pkg/gitea
no required module provides package github.com/openova-io/openova/core/controllers/pkg/render
no required module provides package github.com/openova-io/openova/core/controllers/pkg/validate
```

## Root cause
PR #1136 (CC2 consolidation, commit 1b29c71) promoted gitea/render/
validate from per-controller `internal/` packages to a shared
`core/controllers/pkg/` tree. The application controller's
`Containerfile` was never updated to copy this new directory into the
build stage.

## Fix
Single-line addition: `COPY core/controllers/pkg` alongside the existing
`COPY core/controllers/internal`.

## Why this falls under qa-loop iter-1
PR #1196 (the qa-loop iter-1 application-controller-flag fix) merged
correctly but its image cannot ship to omantel until the build path is
unblocked. Per Inviolable Principle #4a, GitHub Actions is the only
build path — fixing CI is the only sanctioned route.

Refs qa-loop iter-1, follow-up to #1196.