### PR TITLE
fix(chart): auto-provision catalyst-organization-controller-keycloak Secret on Sovereign install (qa-loop iter-1 Fix #14)

### DIFF
--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -135,8 +135,26 @@ name: bp-catalyst-platform
 # Defaults under .Values.runtime.* match the canonical in-cluster
 # Service FQDNs of bp-keycloak / bp-gitea. Caught live on omantel
 # 2026-05-09. 2026-05-09.
-version: 1.4.92
-appVersion: 1.4.92
+#
+# 1.4.93 (qa-loop iter-1 Fix #14, 2026-05-09):
+# Auto-provision the `catalyst-organization-controller-keycloak` Secret
+# from the canonical `keycloak/catalyst-kc-sa-credentials` source on
+# every Sovereign install. organization-controller's binary calls
+# `mustEnv("CATALYST_KC_SA_CLIENT_ID")` + `mustEnv("CATALYST_KC_SA_CLIENT_SECRET")`
+# (cmd/main.go:60-61) and CrashLoopBackOffs until the Secret exists.
+# Pre-1.4.93 the deployment template referenced the Secret with
+# `optional: true` on the secretKeyRef → the env vars collapsed to
+# empty → mustEnv panicked. New template
+# templates/secret-organization-controller-keycloak.yaml mirrors the
+# Sovereign-vs-Mothership lookup gate from
+# templates/catalyst-openova-kc-credentials-secret.yaml: renders only
+# when `lookup "v1" "Secret" "keycloak" "catalyst-kc-sa-credentials"`
+# returns non-nil (i.e. on a Sovereign), with EXISTING-TARGET-WINS
+# precedence so openbao auto-rotation of the source doesn't thrash the
+# controller pod. Caught live on omantel 2026-05-09 during qa-loop
+# iter-1 Executor run.
+version: 1.4.93
+appVersion: 1.4.93
 description: |
   Catalyst Platform — the unified Catalyst control plane umbrella chart for Catalyst-Zero.
   Composes the catalyst-{ui,api}, console, admin, marketplace UI modules and the marketplace-api backend.

--- a/products/catalyst/chart/templates/secret-organization-controller-keycloak.yaml
+++ b/products/catalyst/chart/templates/secret-organization-controller-keycloak.yaml
@@ -1,0 +1,109 @@
+{{- /*
+Auto-provision catalyst-organization-controller-keycloak Secret on Sovereign install
+(qa-loop iter-1 Fix #14, organization-controller CrashLoopBackOff chain).
+
+Why this template exists
+========================
+templates/controllers/organization-controller-deployment.yaml lines 75-86
+reference a secretKeyRef on `catalyst-organization-controller-keycloak` for:
+  - client-id (CATALYST_KC_SA_CLIENT_ID env, mustEnv in cmd/main.go:60)
+  - client-secret (CATALYST_KC_SA_CLIENT_SECRET env, mustEnv in cmd/main.go:61)
+
+Both env vars are mandatory on the controller binary side (`mustEnv` panics
+with "required env var unset" if missing). Until this Secret exists, the
+controller CrashLoopBackOffs from start-up.
+
+On Catalyst-Zero (contabo-mkt) the canonical KC SA bytes live in
+`keycloak-zero/catalyst-kc-sa-credentials` — a separate Helm release in its
+own namespace. There is NO `catalyst-kc-sa-credentials` Secret in the
+`keycloak` namespace there; the operator hand-rolls catalyst-organization-
+controller-keycloak under clusters/contabo-mkt/apps/... if/when they enable
+the controller on the mothership.
+
+On a freshly franchised Sovereign nothing equivalent existed before this
+template — the controller pod CrashLoopBackOff'd indefinitely. Caught live
+on omantel during qa-loop iter-1 (2026-05-09).
+
+Sovereign-vs-Mothership gate (load-bearing, mirrors the
+catalyst-openova-kc-credentials pattern)
+========================================================
+The canonical KC SA source on a Sovereign is the `catalyst-kc-sa-credentials`
+Secret in the `keycloak` namespace (created by bp-keycloak's openbao-bridge
+post-install hook — see platform/keycloak/chart/templates/, issue #781).
+
+We gate render on `lookup "v1" "Secret" "keycloak" "catalyst-kc-sa-credentials"`
+returning non-nil. This means:
+  - On a Sovereign: lookup returns the secret → template renders → the
+    chart auto-provisions catalyst-organization-controller-keycloak in
+    catalyst-system from the keycloak SA Secret.
+  - On contabo-mkt: lookup returns nil → template renders empty bytes →
+    if the operator hand-rolled the Secret under clusters/contabo-mkt/apps/...
+    it is untouched (no helm-vs-kustomize ownership flap).
+
+Why a SEPARATE Secret rather than re-using catalyst-openova-kc-credentials
+==========================================================================
+The two Secrets share the SAME source bytes (client-id + client-secret from
+keycloak/catalyst-kc-sa-credentials) but serve different consumers:
+  - catalyst-openova-kc-credentials: catalyst-api PIN-auth flow (kc-addr,
+    kc-realm, kc-sa-client-id, kc-sa-client-secret, kc-audience + SMTP)
+  - catalyst-organization-controller-keycloak: organization-controller
+    binary (client-id, client-secret) — KEYS DIFFER (no `kc-sa-` prefix
+    because the controller's mustEnv reads `CATALYST_KC_SA_CLIENT_ID` from
+    secret key `client-id`, not `kc-sa-client-id`)
+
+A single Secret with both key shapes would work but conflates two
+consumers' lifecycles. Per docs/INVIOLABLE-PRINCIPLES.md #4 (one source of
+truth per concern) we keep them separate; the source-of-truth is still the
+single keycloak/catalyst-kc-sa-credentials Secret, both targets are
+projections of it.
+
+Persistence across reconciles
+=============================
+helm.sh/resource-policy: keep — survives helm uninstall so a re-install
+picks up the same bytes via lookup. EXISTING TARGET WINS over source —
+matches the catalyst-openova-kc-credentials KC-fields contract: openbao
+auto-rotates the source Secret's client-secret on every Helm upgrade; we
+must NOT thrash the controller Pod's secretKeyRef on every reconcile.
+Operator forces a re-mirror by deleting the target Secret.
+
+Per docs/INVIOLABLE-PRINCIPLES.md #10: NO plaintext credentials in this
+template. All values flow through Helm `lookup` of existing K8s Secrets.
+*/}}
+{{- $kcSrc := lookup "v1" "Secret" "keycloak" "catalyst-kc-sa-credentials" -}}
+{{- if and $kcSrc $kcSrc.data -}}
+{{- $secretName := "catalyst-organization-controller-keycloak" -}}
+{{- $namespace := .Release.Namespace -}}
+{{- /* ---- Persistent target lookup ---- */ -}}
+{{- $existing := lookup "v1" "Secret" $namespace $secretName -}}
+{{- /* ---- KC fields: prefer existing target → fall back to source Secret ---- */ -}}
+{{- $clientID := "" -}}
+{{- $clientSecret := "" -}}
+{{- if and $existing $existing.data (index $existing.data "client-id") -}}
+  {{- $clientID = index $existing.data "client-id" | b64dec -}}
+{{- else if (index $kcSrc.data "client-id") -}}
+  {{- $clientID = index $kcSrc.data "client-id" | b64dec -}}
+{{- end -}}
+{{- if and $existing $existing.data (index $existing.data "client-secret") -}}
+  {{- $clientSecret = index $existing.data "client-secret" | b64dec -}}
+{{- else if (index $kcSrc.data "client-secret") -}}
+  {{- $clientSecret = index $kcSrc.data "client-secret" | b64dec -}}
+{{- end -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $secretName }}
+  namespace: {{ $namespace }}
+  labels:
+    catalyst.openova.io/blueprint: bp-catalyst-platform
+    catalyst.openova.io/component: organization-controller
+    app.kubernetes.io/part-of: catalyst
+  annotations:
+    # Survive helm uninstall — the Secret outlives the release. A
+    # subsequent helm install picks up the bytes via lookup against the
+    # source Secret (and the persisted target if still present).
+    helm.sh/resource-policy: keep
+type: Opaque
+data:
+  client-id: {{ $clientID | b64enc | quote }}
+  client-secret: {{ $clientSecret | b64enc | quote }}
+{{- end }}


### PR DESCRIPTION
## Summary

qa-loop iter-1 Fix #14 — cluster `kc-sa-secret-organization-controller`.

After Fix #11 created the `catalyst-runtime-config` ConfigMap, organization-controller advanced past `CATALYST_KC_ADDR` but CrashLoopBackOff'd on:

```
{"level":"error","logger":"organization-controller","msg":"required env var unset","key":"CATALYST_KC_SA_CLIENT_ID"}
```

Root cause: the deployment template references `secretKeyRef` on `catalyst-organization-controller-keycloak` (keys `client-id`, `client-secret`) with `optional: true`, but no chart template ever **created** that Secret. The controller binary calls `mustEnv("CATALYST_KC_SA_CLIENT_ID")` + `mustEnv("CATALYST_KC_SA_CLIENT_SECRET")` (`cmd/main.go:60-61`) which panics on empty.

## Changes

- **NEW** `products/catalyst/chart/templates/secret-organization-controller-keycloak.yaml` — auto-provisions the Secret on every Sovereign install. Mirrors the Sovereign-vs-Mothership lookup gate already used by `templates/catalyst-openova-kc-credentials-secret.yaml`:
  - Renders only when `lookup "v1" "Secret" "keycloak" "catalyst-kc-sa-credentials"` returns non-nil (i.e. on a Sovereign — the canonical bp-keycloak openbao-bridge source).
  - On contabo-mkt the lookup is nil → template renders empty bytes → no helm-vs-kustomize ownership flap.
  - EXISTING-TARGET-WINS precedence: openbao auto-rotates the source's `client-secret`; we must NOT thrash the controller Pod's secretKeyRef on every reconcile.
  - `helm.sh/resource-policy: keep` so the Secret survives uninstall.
- **BUMP** `products/catalyst/chart/Chart.yaml` 1.4.92 → 1.4.93 with full reasoning comment.

## Live verification (omantel)

Manual hot-fix already applied to omantel using the same bytes the chart will produce:

```
$ kubectl --context=omantel -n catalyst-system get pods -l app.kubernetes.io/name=organization-controller
NAME                                               READY   STATUS    RESTARTS   AGE
catalyst-organization-controller-ff55c78df-s7m9n   1/1     Running   0          46s

$ kubectl --context=omantel -n catalyst-system logs deploy/catalyst-organization-controller --tail=10
{"level":"info","msg":"starting manager","host_cluster":"catalyst-zero","keycloak_addr":"http://keycloak.keycloak.svc.cluster.local:80","keycloak_realm":"sovereign",...}
I0509 11:59:53.787427       1 leaderelection.go:268] successfully acquired lease ...
{"level":"info","msg":"Starting EventSource","controller":"organization",...}
{"level":"info","msg":"Starting workers","controller":"organization","worker count":1}
```

No 403 from KC, leader-elected, watching Organizations. Catalyst-api logs show no `realm-management`/`manage-realm` 403s either — the SA already has the needed scopes (Fix #10's prior worry not currently triggering).

## Test plan

- [x] `helm lint products/catalyst/chart/` passes
- [x] `helm template test products/catalyst/chart/` produces 43 manifests cleanly (new template gates on lookup-success → emits nothing without a live cluster, expected)
- [x] organization-controller Pod Running 1/1, 0 restarts on omantel
- [ ] Next Sovereign provision (after merge) auto-renders the Secret without operator hot-fix

## Hard-rule compliance

- One root-cause cluster (missing Secret was the actual blocker; SA-permission worry from Fix #10 not currently triggering)
- No edits to BE handlers / UI / CRD installs / catalyst-runtime-config CM / application-controller binary
- No plaintext credentials in template (lookup-only, per INVIOLABLE-PRINCIPLES.md #10)
- No hardcoded values (per #4)