### PR TITLE
fix(api): include tier + realm_access.roles in /whoami response (qa-loop iter-2)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/auth.go
+++ b/products/catalyst/bootstrap/api/internal/handler/auth.go
@@ -816,13 +816,24 @@ func resolvePostLogoutPath() string {
 // discover its sovereign context from a single round-trip without a
 // follow-up /api/v1/sovereign/self call. This is the contract
 // SovereignConsoleLayout + chroot SPA features assert in TC-232.
+//
+// Tier + RealmAccess surface the RBAC claims the SPA route-guard
+// relies on to decide whether to admit an operator into the chroot
+// Sovereign Console post-PIN-login. Fix #2 (#1184) stamps tier=owner
+// and realm_access.roles=[catalyst-owner] into the PIN session JWT;
+// without these fields on the wire the SPA bounces the operator back
+// to /login (qa-loop iter-2 cluster B). Both are `omitempty` so an
+// unprivileged session (no tier, no realm roles) yields the original
+// pre-RBAC wire shape and existing callers keep working.
 type whoamiResponse struct {
-	Email         string `json:"email"`
-	Sub           string `json:"sub"`
-	Verified      bool   `json:"verified"`
-	DeploymentID  string `json:"deploymentId,omitempty"`
-	SovereignFQDN string `json:"sovereignFQDN,omitempty"`
-	Mode          string `json:"mode,omitempty"`
+	Email         string            `json:"email"`
+	Sub           string            `json:"sub"`
+	Verified      bool              `json:"verified"`
+	DeploymentID  string            `json:"deploymentId,omitempty"`
+	SovereignFQDN string            `json:"sovereignFQDN,omitempty"`
+	Mode          string            `json:"mode,omitempty"`
+	Tier          string            `json:"tier,omitempty"`
+	RealmAccess   *auth.RealmAccess `json:"realm_access,omitempty"`
 }
 
 // HandleWhoami handles GET /api/v1/whoami.
@@ -870,6 +881,17 @@ func (h *Handler) HandleWhoami(w http.ResponseWriter, r *http.Request) {
 		Email:    claims.Email,
 		Sub:      claims.Sub,
 		Verified: claims.EmailVerified,
+		Tier:     claims.Tier,
+	}
+
+	// RBAC realm-role enrichment — surface the realm role list the SPA
+	// route-guard reads to admit an operator into the chroot Sovereign
+	// Console. Only emit when at least one role is set so an unprivileged
+	// session continues to omit the field entirely (omitempty preserves
+	// the pre-RBAC wire shape for non-RBAC callers).
+	if len(claims.RealmAccess.Roles) > 0 {
+		ra := claims.RealmAccess
+		resp.RealmAccess = &ra
 	}
 
 	// Sovereign-context enrichment — same precedence as HandleSovereignSelf

--- a/products/catalyst/bootstrap/api/internal/handler/whoami_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/whoami_test.go
@@ -148,6 +148,107 @@ func TestHandleWhoami_ChrootFromEnv(t *testing.T) {
 	}
 }
 
+// TestHandleWhoami_PinSessionRBACClaims — qa-loop iter-2 cluster B
+// regression. Fix #2 (#1184) stamps tier=owner +
+// realm_access.roles=[catalyst-owner] into the PIN session JWT so the
+// chroot SPA route-guard admits the operator into the Sovereign
+// Console after PIN login. Before this fix, HandleWhoami silently
+// dropped both claims; the SPA bounced the operator back to /login.
+//
+// Pins the wire contract: when the session carries Tier + RealmAccess
+// roles, /whoami MUST surface them with the JSON shape the SPA
+// guard reads — `tier` (top-level string) and `realm_access.roles`
+// (nested array). Drift on either side breaks the post-PIN-login
+// flow that 4 failing test rows (TC-003, TC-091, TC-122, TC-196)
+// depend on.
+func TestHandleWhoami_PinSessionRBACClaims(t *testing.T) {
+	t.Setenv("SOVEREIGN_FQDN", "")
+	t.Setenv("CATALYST_OTECH_FQDN", "")
+	t.Setenv("CATALYST_SELF_DEPLOYMENT_ID", "")
+
+	h := New(slog.New(slog.NewTextHandler(os.Stderr, nil)))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/whoami", nil)
+	ctx := context.WithValue(req.Context(), auth.ClaimsKey, &auth.Claims{
+		Sub:           "kc-sub-pin",
+		Email:         "operator@openova.io",
+		EmailVerified: true,
+		Tier:          "owner",
+		RealmAccess: auth.RealmAccess{
+			Roles: []string{"catalyst-owner"},
+		},
+	})
+	req = req.WithContext(ctx)
+	rr := httptest.NewRecorder()
+
+	h.HandleWhoami(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status: want 200, got %d (body=%s)", rr.Code, rr.Body.String())
+	}
+
+	// Decode into a generic map so the assertion exercises the actual
+	// wire JSON shape the SPA route-guard reads (not the typed Go
+	// struct, which would mask a bad json tag).
+	var got map[string]any
+	if err := json.Unmarshal(rr.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v (body=%s)", err, rr.Body.String())
+	}
+
+	if got["tier"] != "owner" {
+		t.Errorf("tier: want %q, got %v", "owner", got["tier"])
+	}
+
+	ra, ok := got["realm_access"].(map[string]any)
+	if !ok {
+		t.Fatalf("realm_access: want object, got %T (%v)", got["realm_access"], got["realm_access"])
+	}
+	roles, ok := ra["roles"].([]any)
+	if !ok {
+		t.Fatalf("realm_access.roles: want array, got %T (%v)", ra["roles"], ra["roles"])
+	}
+	if len(roles) != 1 || roles[0] != "catalyst-owner" {
+		t.Errorf("realm_access.roles: want [catalyst-owner], got %v", roles)
+	}
+}
+
+// TestHandleWhoami_NoRBACOmitsFields — pre-RBAC wire-shape regression.
+// A session without Tier or RealmAccess roles must not introduce
+// `tier` or `realm_access` keys (omitempty preserves the original
+// shape so existing callers parse cleanly).
+func TestHandleWhoami_NoRBACOmitsFields(t *testing.T) {
+	t.Setenv("SOVEREIGN_FQDN", "")
+	t.Setenv("CATALYST_OTECH_FQDN", "")
+	t.Setenv("CATALYST_SELF_DEPLOYMENT_ID", "")
+
+	h := New(slog.New(slog.NewTextHandler(os.Stderr, nil)))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/whoami", nil)
+	ctx := context.WithValue(req.Context(), auth.ClaimsKey, &auth.Claims{
+		Sub:           "kc-sub-norbac",
+		Email:         "ops@openova.io",
+		EmailVerified: true,
+	})
+	req = req.WithContext(ctx)
+	rr := httptest.NewRecorder()
+
+	h.HandleWhoami(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status: want 200, got %d (body=%s)", rr.Code, rr.Body.String())
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal(rr.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	for _, k := range []string{"tier", "realm_access"} {
+		if _, present := got[k]; present {
+			t.Errorf("no-RBAC response must not include %q (got %v)", k, got[k])
+		}
+	}
+}
+
 // TestHandleWhoami_NilClaims — defensive: RequireSession should always
 // inject claims, but a logic bug stripping the middleware must surface
 // as 401, not a panic / empty 200.


### PR DESCRIPTION
## qa-loop iter-2 — Fix #16
**Cluster**: `whoami-response-missing-tier-role`

## Problem

`GET /api/v1/whoami` silently dropped `Tier` and `RealmAccess.Roles` even though Fix #2 (#1184) stamps `tier=owner` + `realm_access.roles=[catalyst-owner]` into the PIN session JWT.

Live evidence on omantel:
```
$ curl -sS -k -b /tmp/iter2-cookies.txt 'https://console.omantel.biz/api/v1/whoami'
{"email":"emrah.baysal@openova.io","sub":"...","verified":true,"deploymentId":"sovereign-omantel.biz","sovereignFQDN":"omantel.biz","mode":"sovereign"}
# Missing: tier, realm_access.roles
```

The chroot SPA route-guard reads these fields to decide whether to admit the operator into the Sovereign Console post-PIN-login. Without them on the wire the SPA bounced back to `/login`, breaking 4 failing test rows: TC-003, TC-091, TC-122, TC-196.

## Fix

Surface both fields with the JSON shape the SPA expects:
- top-level `tier` (string)
- nested `realm_access`:`{roles:[...]}` (object)

Both `omitempty` so non-RBAC sessions (no tier, no realm roles) continue to emit the original pre-RBAC wire shape. Existing callers are unaffected.

## Tests

- `TestHandleWhoami_PinSessionRBACClaims` — pins the wire contract for the PIN-stamped session. Decodes into a generic map (not the typed Go struct) so a bad json tag would fail loudly.
- `TestHandleWhoami_NoRBACOmitsFields` — pins the omitempty regression: no-RBAC session must not introduce `tier`/`realm_access` keys.

All 6 whoami tests pass; full handler test suite GREEN.

## Coordination

- Coordinates with **Fix #15** (SPA route-guard) on the same downstream symptom — BE serializes the claims, SPA reads them.
- Does **not** touch `auth/session.go`'s `Claims` struct — Fix #2 (#1184)'s `tier=owner` stamping path preserved.

Files changed:
- `products/catalyst/bootstrap/api/internal/handler/auth.go` — `whoamiResponse` struct + `HandleWhoami` populate `Tier` + `RealmAccess`
- `products/catalyst/bootstrap/api/internal/handler/whoami_test.go` — 2 new tests

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>