### PR TITLE
fix(ui): SPA route-guard probes /whoami before bouncing to /login (qa-loop iter-2)

### DIFF
--- a/products/catalyst/bootstrap/ui/src/app/auth-gate.test.ts
+++ b/products/catalyst/bootstrap/ui/src/app/auth-gate.test.ts
@@ -1,8 +1,9 @@
-import { describe, it, expect, beforeEach } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import {
   canonicalisePath,
   isPublicPath,
   hasCatalystSession,
+  probeWhoamiAndCacheMarker,
   PUBLIC_PATH_PREFIXES,
 } from './auth-gate'
 
@@ -119,6 +120,64 @@ describe('hasCatalystSession', () => {
   it('returns false on unrelated keys', () => {
     sessionStorage.setItem('something:else', 'foo')
     expect(hasCatalystSession()).toBe(false)
+  })
+})
+
+describe('probeWhoamiAndCacheMarker', () => {
+  const originalFetch = globalThis.fetch
+  beforeEach(() => {
+    sessionStorage.clear()
+  })
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+    vi.restoreAllMocks()
+  })
+
+  it('returns true and caches the marker on 200', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      status: 200,
+    } as Response) as typeof fetch
+    const result = await probeWhoamiAndCacheMarker('/api')
+    expect(result).toBe(true)
+    expect(sessionStorage.getItem('catalyst:authed')).toBe('1')
+  })
+
+  it('returns false on 401 and does NOT cache the marker', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      status: 401,
+    } as Response) as typeof fetch
+    const result = await probeWhoamiAndCacheMarker('/api')
+    expect(result).toBe(false)
+    expect(sessionStorage.getItem('catalyst:authed')).toBeNull()
+  })
+
+  it('returns null on 5xx (fail-open signal to caller)', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      status: 503,
+    } as Response) as typeof fetch
+    const result = await probeWhoamiAndCacheMarker('/api')
+    expect(result).toBeNull()
+    expect(sessionStorage.getItem('catalyst:authed')).toBeNull()
+  })
+
+  it('returns null on network error (fail-open signal to caller)', async () => {
+    globalThis.fetch = vi.fn().mockRejectedValue(new Error('network down')) as typeof fetch
+    const result = await probeWhoamiAndCacheMarker('/api')
+    expect(result).toBeNull()
+    expect(sessionStorage.getItem('catalyst:authed')).toBeNull()
+  })
+
+  it('uses credentials:include so the HttpOnly cookie is sent', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ status: 200 } as Response)
+    globalThis.fetch = fetchMock as typeof fetch
+    await probeWhoamiAndCacheMarker('/sovereign/api')
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/sovereign/api/v1/whoami',
+      expect.objectContaining({
+        method: 'GET',
+        credentials: 'include',
+      }),
+    )
   })
 })
 

--- a/products/catalyst/bootstrap/ui/src/app/auth-gate.ts
+++ b/products/catalyst/bootstrap/ui/src/app/auth-gate.ts
@@ -40,17 +40,25 @@ export function canonicalisePath(pathname: string): string {
 }
 
 /**
- * Synchronous best-effort check that the operator has a session.
+ * Synchronous best-effort check that the operator has a session marker
+ * cached in JS-readable storage.
+ *
  * The catalyst_session cookie is HttpOnly so we cannot read it from JS;
  * instead we look at sessionStorage:
  *   - any oidc:* key (legacy PKCE flow tokens)
- *   - 'catalyst:authed' marker set by SovereignConsoleLayout after a
- *     successful /whoami probe
+ *   - 'catalyst:authed' marker set by VerifyPinPage on successful PIN
+ *     verify, /auth/handover route's beforeLoad, and SovereignConsoleLayout
+ *     after a successful /whoami probe
  *
- * Conservative: false positives (claiming authed when no session) are
- * caught downstream by the layout's /whoami probe, which redirects to
- * /login with proper error context. False negatives would break
- * navigation, so we err on the side of "let it through."
+ * Returning `false` ONLY means "we don't have a fast cached marker" — it
+ * does NOT mean the operator is unauthenticated. Iter-2 fix
+ * (qa-loop iter-2 cluster `spa-route-guard-rejects-pin-session`):
+ * callers that act on `false` MUST follow up with an async /whoami probe
+ * via `probeWhoamiAndCacheMarker()` before redirecting to /login. The
+ * catalyst_session cookie is HttpOnly + arrives via Set-Cookie on
+ * /auth/pin/verify and /auth/handover — opening a new tab, refreshing
+ * after sessionStorage cleared, or pasting a deep-link URL into a fresh
+ * window all leave the cookie intact while losing the JS-side marker.
  */
 export function hasCatalystSession(): boolean {
   if (typeof window === 'undefined' || typeof sessionStorage === 'undefined') return true
@@ -62,4 +70,53 @@ export function hasCatalystSession(): boolean {
     /* private browsing may throw */
   }
   return false
+}
+
+/**
+ * Async authoritative check via GET /api/v1/whoami.
+ *
+ * Probes the catalyst-api with the HttpOnly `catalyst_session` cookie.
+ * On 200 the cookie is valid — cache the `catalyst:authed=1` marker so
+ * subsequent navigations short-circuit through `hasCatalystSession()`
+ * without re-fetching, and return true. On 401 the cookie is missing
+ * or expired — return false so the caller can redirect to /login. On
+ * any other status (5xx, network error) return null so the caller can
+ * decide whether to fail open (let the route render and let downstream
+ * handlers surface the error) or redirect.
+ *
+ * Why this exists (qa-loop iter-2 cluster
+ * `spa-route-guard-rejects-pin-session`): the synchronous gate that
+ * read sessionStorage alone bounced operators with valid HttpOnly
+ * cookies but no JS-side marker — a regression caught when the founder
+ * could not deep-link into /dashboard from a fresh tab on omantel.biz
+ * after a PIN-verify in a sibling tab. The async fallback keeps the
+ * sync fast-path for the common case (just-verified) and adds an
+ * authoritative check for the cookie-but-no-marker case.
+ *
+ * This is a pure helper: no React, no router. Callers (router.tsx
+ * rootBeforeLoad) own the redirect decision.
+ */
+export async function probeWhoamiAndCacheMarker(
+  apiBase: string,
+): Promise<true | false | null> {
+  if (typeof window === 'undefined' || typeof fetch === 'undefined') return null
+  try {
+    const res = await fetch(`${apiBase}/v1/whoami`, {
+      method: 'GET',
+      credentials: 'include',
+      headers: { Accept: 'application/json' },
+    })
+    if (res.status === 200) {
+      try {
+        sessionStorage.setItem('catalyst:authed', '1')
+      } catch {
+        /* private browsing may throw */
+      }
+      return true
+    }
+    if (res.status === 401) return false
+    return null
+  } catch {
+    return null
+  }
 }

--- a/products/catalyst/bootstrap/ui/src/app/router.tsx
+++ b/products/catalyst/bootstrap/ui/src/app/router.tsx
@@ -100,25 +100,51 @@ import { UsersPage as SMEUsersPage } from '@/pages/sme/UsersPage'
 import { RolesPage as SMERolesPage } from '@/pages/sme/RolesPage'
 import { CreateTenantPage as SMECreateTenantPage } from '@/pages/sme/CreateTenantPage'
 import { SovereigntyPreviewPage } from '@/pages/sovereignty/SovereigntyPreviewPage'
-import { canonicalisePath, hasCatalystSession, isPublicPath } from './auth-gate'
+import {
+  canonicalisePath,
+  hasCatalystSession,
+  isPublicPath,
+  probeWhoamiAndCacheMarker,
+} from './auth-gate'
 
 /**
- * rootBeforeLoad — universal auth gate (#1090 cluster A2).
+ * rootBeforeLoad — universal auth gate (#1090 cluster A2,
+ * extended for qa-loop iter-2 cluster `spa-route-guard-rejects-pin-session`).
  *
- * Runs before EVERY route's beforeLoad in the tree. Two responsibilities:
+ * Runs before EVERY route's beforeLoad in the tree. Three responsibilities:
  *
  *   1. Path canonicalisation — redirect malformed paths (//x, /x/, /X)
  *      to canonical /x so deep-link variants don't slip past the gate.
  *
- *   2. Sovereign-mode auth gate — when no session is detected and the
- *      canonical path is NOT in PUBLIC_PATH_PREFIXES, redirect to
- *      /login?next=<canonical> with the original deep-link preserved.
+ *   2. Sovereign-mode auth fast-path — when a `catalyst:authed` marker
+ *      is present in sessionStorage (set by VerifyPinPage on PIN verify,
+ *      /auth/handover beforeLoad, or SovereignConsoleLayout on whoami
+ *      200), allow the route through without a network round-trip.
+ *
+ *   3. Sovereign-mode auth authoritative-check — when no marker is
+ *      present, fall through to GET /api/v1/whoami to authoritatively
+ *      detect the HttpOnly `catalyst_session` cookie. On 200, cache the
+ *      marker and allow through. On 401, redirect to /login with the
+ *      original deep-link preserved as ?next=. On 5xx/network error,
+ *      fail open (let the route render so the layout's own probe can
+ *      surface the failure with proper context).
+ *
+ *  Why responsibility 3 was added (2026-05-09): the previous gate
+ *  bounced any deep-link load that lacked the `catalyst:authed` marker,
+ *  even when a valid HttpOnly catalyst_session cookie was present. The
+ *  cookie is set by /auth/pin/verify and /auth/handover but is invisible
+ *  to JS — opening a new tab, refreshing after sessionStorage cleared,
+ *  or pasting a deep-link URL into a fresh window all left the cookie
+ *  intact while losing the JS-side marker, so operators with valid
+ *  sessions were redirected to /login on every fresh entry. Caught on
+ *  console.omantel.biz when the founder could not deep-link to
+ *  /dashboard from a sibling tab after a successful PIN verify.
  *
  * Mothership (catalyst-zero) mode handles its own auth via
  * provisionAuthGuard / wizardAuthGuard for its routes — the gate is a
  * no-op in non-sovereign mode (other than canonicalisation).
  */
-function rootBeforeLoad({ location }: { location: { pathname: string } }) {
+async function rootBeforeLoad({ location }: { location: { pathname: string } }) {
   if (typeof window === 'undefined') return
   const pathname = location.pathname
   const canonical = canonicalisePath(pathname)
@@ -130,6 +156,12 @@ function rootBeforeLoad({ location }: { location: { pathname: string } }) {
   if (DETECTED_MODE.mode !== 'sovereign') return
   if (isPublicPath(canonical)) return
   if (hasCatalystSession()) return
+  // No JS-side marker — authoritatively probe /whoami to detect the
+  // HttpOnly catalyst_session cookie before redirecting to /login.
+  const whoami = await probeWhoamiAndCacheMarker(API_BASE)
+  if (whoami === true) return
+  if (whoami === null) return // 5xx / network error — fail open
+  // 401 — genuinely unauthenticated. Redirect with deep-link.
   throw redirect({
     to: '/login',
     search: { next: pathname + window.location.search },


### PR DESCRIPTION
## Summary

When the operator has a valid HttpOnly `catalyst_session` cookie but no JS-side `catalyst:authed` sessionStorage marker (fresh tab, refresh after sessionStorage cleared, deep-link paste into a fresh window), the synchronous `rootBeforeLoad` gate redirected them to /login despite holding a valid session.

Caught on console.omantel.biz when deep-link loads of /dashboard from a sibling tab kept bouncing back to the PIN page even after a successful PIN verify in another tab.

## Root cause

`hasCatalystSession()` reads sessionStorage only — the `catalyst_session` cookie is HttpOnly so JS cannot see it. The marker is set by `VerifyPinPage` on PIN verify and `SovereignConsoleLayout` on whoami 200, but a fresh-tab navigation neither runs `VerifyPinPage` nor mounts the layout before the gate fires, so the gate never sees the operator as authed.

## Fix

- Keep the sync fast-path (`catalyst:authed` marker present → allow through, no network round-trip)
- On missing marker, fall through to an authoritative `GET /api/v1/whoami`:
  - **200** → cache the marker and allow through
  - **401** → redirect to `/login?next=...` with deep-link preserved
  - **5xx / network error** → fail open so `SovereignConsoleLayout`'s own probe surfaces the failure with proper context

## Files

- `products/catalyst/bootstrap/ui/src/app/auth-gate.ts` — new `probeWhoamiAndCacheMarker()` helper
- `products/catalyst/bootstrap/ui/src/app/router.tsx` — `rootBeforeLoad` async; falls through to whoami probe when marker missing
- `products/catalyst/bootstrap/ui/src/app/auth-gate.test.ts` — +5 tests covering 200/401/5xx/network/credentials-include

## Test plan

- [x] Unit tests: 29/29 pass (`src/app/auth-gate.test.ts`)
- [x] Typecheck: clean (`tsc -b --noEmit`)
- [x] Live PIN flow on console.omantel.biz: /login → email → PIN verify → /dashboard renders fully (treemap, sidebar, header)
- [x] Per-issue Playwright verification (per `feedback_per_issue_playwright_verification.md`): 6 deep-link routes verified individually (/dashboard, /cloud, /apps, /jobs, /users, /settings) — all render
- [x] Founder hard gate (per `session_2026_05_09_closed_unverified.md`): incognito PIN walkthrough confirmed end-to-end before requesting merge

Refs: qa-loop iter-2 cluster `spa-route-guard-rejects-pin-session`
Refs: `session_2026_05_09_closed_unverified.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)