### PR TITLE
fix(api): BE handler 5xx/4xx errors + items envelope (qa-loop iter-2)

### DIFF
--- a/products/catalyst/bootstrap/api/cmd/api/main.go
+++ b/products/catalyst/bootstrap/api/cmd/api/main.go
@@ -307,6 +307,13 @@ func main() {
 	r.Get("/readyz", h.Ready)
 	r.Handle("/metrics", promhttp.Handler())
 
+	// /api/v1/version — build identification (git SHA + chart version).
+	// Always 200, no auth gate (probe-friendly). Operators + the QA
+	// matrix probe this to confirm "what version is live right now"
+	// without scraping the Pod spec. See handler/version.go for the
+	// truth-resolution rules + wire shape.
+	r.Get("/api/v1/version", h.HandleVersion)
+
 	// Unauthenticated auth endpoints — 6-digit PIN issue + verify (#688)
 	// and logout. These MUST remain outside the session gate (the user is
 	// not yet authenticated when they hit /pin/issue and /pin/verify).

--- a/products/catalyst/bootstrap/api/internal/handler/blueprints.go
+++ b/products/catalyst/bootstrap/api/internal/handler/blueprints.go
@@ -376,10 +376,16 @@ func (h *Handler) HandleBlueprintListCuratable(w http.ResponseWriter, r *http.Re
 		return
 	}
 
+	// QA-loop iter-2 Fix #17 — when the Gitea client is unwired (chroot
+	// Sovereign mode pre-cutover, or any environment that hasn't booted
+	// the embedded Gitea yet) return a well-formed empty list rather than
+	// a 503. The 503 broke the /blueprints page which interpreted any
+	// non-2xx as an unrecoverable error and surfaced "Failed to fetch"
+	// to the operator. The empty list lets the UI render its "No
+	// blueprints yet — publish from your Org repo" empty state.
 	if h.giteaClient == nil {
-		writeJSON(w, http.StatusServiceUnavailable, map[string]string{
-			"error":  "gitea-not-wired",
-			"detail": "Gitea client unconfigured; curate listing requires Gitea",
+		writeJSON(w, http.StatusOK, curatableBlueprintsResponse{
+			Items: []curatableBlueprint{},
 		})
 		return
 	}

--- a/products/catalyst/bootstrap/api/internal/handler/blueprints_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/blueprints_test.go
@@ -385,6 +385,36 @@ func TestHandleBlueprintListCuratable_EnumeratesOrgRepos(t *testing.T) {
 	}
 }
 
+// TestHandleBlueprintListCuratable_GiteaUnwiredReturnsEmptyList — QA-loop
+// iter-2 Fix #17. When the Gitea client is unwired (chroot Sovereign mode
+// pre-cutover, test environments, or any deploy that hasn't booted the
+// embedded Gitea yet), the handler must return a well-formed empty list
+// envelope rather than 503. The 503 broke the /blueprints page which
+// surfaced "Failed to fetch" to the operator. The empty list lets the
+// UI render its "No blueprints yet" empty state.
+func TestHandleBlueprintListCuratable_GiteaUnwiredReturnsEmptyList(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	// Deliberately do NOT call h.SetGiteaClient() — h.giteaClient stays nil.
+	dep := installUserAccessDeployment(t, h, "dep-bp-no-gitea")
+
+	rec := callUserAccess(t, h, http.MethodGet,
+		"/api/v1/sovereigns/"+dep.ID+"/blueprints/curatable?orgs=acme",
+		nil, registerBlueprintRoutes)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d want 200 (gitea-unwired graceful path); body=%s", rec.Code, rec.Body.String())
+	}
+	var resp curatableBlueprintsResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Items == nil {
+		t.Fatalf("Items must be a non-nil empty slice (so JSON encodes as [])")
+	}
+	if len(resp.Items) != 0 {
+		t.Fatalf("items: got %d want 0", len(resp.Items))
+	}
+}
+
 // ── Edit-PR (slice Z3) ────────────────────────────────────────────────
 
 func TestHandleBlueprintEditPR_OpensPR(t *testing.T) {

--- a/products/catalyst/bootstrap/api/internal/handler/version.go
+++ b/products/catalyst/bootstrap/api/internal/handler/version.go
@@ -1,0 +1,117 @@
+// Package handler — version.go: build-info endpoint.
+//
+// QA-loop iter-2 Fix #17. The matrix expects /api/v1/version to return
+// a JSON document carrying the running image's git SHA + chart
+// version, so operators (and the QA matrix) have a single
+// non-authenticated probe to confirm "what version is live right now"
+// without curling /healthz (plain "ok") or scraping the Pod spec.
+//
+// This is the canonical pattern for every long-running daemon at
+// OpenOva: every service exposes a small /version document under its
+// own API root with no auth gate. The body fields are stable across
+// releases — adding new keys is fine, removing keys is a contract
+// break tested by version_test.go.
+//
+// The implementation prefers, in order:
+//
+//  1. CATALYST_BUILD_SHA env var (injected by the chart via the image
+//     tag; deployment-controller maps the image tag to this env). When
+//     set this is the truth.
+//  2. CATALYST_BUILD_VERSION env var (semver — set by chart values
+//     when a tagged release is rolled out).
+//  3. The buildSHA / buildVersion ldflags variables (`go build
+//     -ldflags="-X .../handler.buildSHA=$SHA"`). Used by CI so the
+//     version is baked into the binary even when env vars are
+//     unset.
+//  4. The literal "dev" / "0.0.0" — surfaced when neither env nor
+//     ldflags carries a value, so the response is always well-formed
+//     instead of empty.
+//
+// The handler is registered on the public router (no session gate) so
+// CI smoke tests + external monitoring can probe it without a cookie.
+// It carries no privileged data.
+package handler
+
+import (
+	"net/http"
+	"os"
+	"runtime"
+	"strings"
+)
+
+// buildSHA / buildVersion / chartVersion are populated by the build
+// pipeline via -ldflags. Default values keep the response well-formed
+// when running from `go run` during development.
+//
+// CI invocation:
+//
+//	go build -ldflags="\
+//	  -X github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/handler.buildSHA=$GITHUB_SHA \
+//	  -X github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/handler.buildVersion=$VERSION \
+//	"
+var (
+	buildSHA     = "dev"
+	buildVersion = "0.0.0"
+	chartVersion = ""
+)
+
+// VersionResponse — wire shape of GET /api/v1/version.
+//
+// The fields mirror what `kubectl get pod -o jsonpath` would tell an
+// operator: the git SHA the image was built from, the semver tag, the
+// chart version that mounted this Pod, and the Go runtime version.
+//
+// Adding new keys is non-breaking; existing keys MUST keep their JSON
+// names so dashboards + the QA matrix can pin against them.
+type VersionResponse struct {
+	// Service — fixed identifier of which OpenOva service is responding.
+	// Lets a single dashboard probe multiple /version endpoints across
+	// services (catalyst-api, catalyst-application-controller, …) and
+	// disambiguate them by `service`.
+	Service string `json:"service"`
+
+	// SHA — git commit the image was built from. Truthful resolution:
+	// CATALYST_BUILD_SHA env var > buildSHA ldflag > "dev".
+	SHA string `json:"sha"`
+
+	// Version — semver of the release. Truthful resolution:
+	// CATALYST_BUILD_VERSION env var > buildVersion ldflag > "0.0.0".
+	Version string `json:"version"`
+
+	// ChartVersion — the umbrella chart version (bp-catalyst-platform
+	// or catalyst chart) responsible for this rollout. Set by the
+	// chart's deployment template via env if known.
+	ChartVersion string `json:"chartVersion,omitempty"`
+
+	// Go — runtime version (debug aid; e.g. "go1.26.0"). Useful when
+	// chasing a regression that correlates with a Go upgrade.
+	Go string `json:"go"`
+}
+
+// HandleVersion — GET /api/v1/version
+//
+// Returns the running build's SHA + version. Always 200, always
+// JSON. No auth gate (probe-friendly).
+func (h *Handler) HandleVersion(w http.ResponseWriter, r *http.Request) {
+	resp := VersionResponse{
+		Service:      "catalyst-api",
+		SHA:          envOrTrim("CATALYST_BUILD_SHA", buildSHA),
+		Version:      envOrTrim("CATALYST_BUILD_VERSION", buildVersion),
+		ChartVersion: envOrTrim("CATALYST_CHART_VERSION", chartVersion),
+		Go:           runtime.Version(),
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// envOrTrim returns the trimmed value of `env` when non-empty, else
+// `fallback`. Distinct from the marketplace_settings.go envOr helper
+// (which returns the raw env value) because version-handler callers
+// rely on trimming — env values injected via the K8s downward API
+// frequently arrive with trailing newlines that would render as
+// "abc1234\n" in JSON without the trim.
+func envOrTrim(env, fallback string) string {
+	if v := strings.TrimSpace(os.Getenv(env)); v != "" {
+		return v
+	}
+	return fallback
+}

--- a/products/catalyst/bootstrap/api/internal/handler/version_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/version_test.go
@@ -1,0 +1,91 @@
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestHandleVersion_AlwaysJSON pins the wire shape — keys MUST stay
+// stable so the QA matrix + monitoring dashboards keep working across
+// releases.
+func TestHandleVersion_AlwaysJSON(t *testing.T) {
+	h := &Handler{}
+	r := httptest.NewRequest(http.MethodGet, "/api/v1/version", nil)
+	w := httptest.NewRecorder()
+	h.HandleVersion(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	if got := w.Header().Get("Content-Type"); got != "application/json" {
+		t.Fatalf("Content-Type = %q, want application/json", got)
+	}
+	var resp VersionResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("response is not JSON: %v\nbody=%s", err, w.Body.String())
+	}
+	if resp.Service != "catalyst-api" {
+		t.Errorf("Service = %q, want catalyst-api", resp.Service)
+	}
+	// SHA + Version + Go must always be non-empty (defaults are "dev"
+	// / "0.0.0" / runtime.Version()) so dashboards never see blanks.
+	if resp.SHA == "" {
+		t.Errorf("SHA must be non-empty (default: dev)")
+	}
+	if resp.Version == "" {
+		t.Errorf("Version must be non-empty (default: 0.0.0)")
+	}
+	if resp.Go == "" {
+		t.Errorf("Go must be non-empty (runtime.Version())")
+	}
+}
+
+// TestHandleVersion_EnvOverride asserts the env-var truth override
+// works — the chart can inject CATALYST_BUILD_SHA via the deployment
+// template and that value wins over the ldflag default.
+func TestHandleVersion_EnvOverride(t *testing.T) {
+	t.Setenv("CATALYST_BUILD_SHA", "abc1234")
+	t.Setenv("CATALYST_BUILD_VERSION", "1.2.3")
+	t.Setenv("CATALYST_CHART_VERSION", "0.5.0")
+
+	h := &Handler{}
+	r := httptest.NewRequest(http.MethodGet, "/api/v1/version", nil)
+	w := httptest.NewRecorder()
+	h.HandleVersion(w, r)
+
+	var resp VersionResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("response is not JSON: %v", err)
+	}
+	if resp.SHA != "abc1234" {
+		t.Errorf("SHA = %q, want abc1234 (env override)", resp.SHA)
+	}
+	if resp.Version != "1.2.3" {
+		t.Errorf("Version = %q, want 1.2.3 (env override)", resp.Version)
+	}
+	if resp.ChartVersion != "0.5.0" {
+		t.Errorf("ChartVersion = %q, want 0.5.0 (env override)", resp.ChartVersion)
+	}
+}
+
+// TestHandleVersion_TrimsWhitespace covers the trailing-newline case
+// — env values injected via downward API frequently arrive with
+// trailing whitespace; the handler must trim before reporting.
+func TestHandleVersion_TrimsWhitespace(t *testing.T) {
+	t.Setenv("CATALYST_BUILD_SHA", "  cafef00d\n")
+
+	h := &Handler{}
+	r := httptest.NewRequest(http.MethodGet, "/api/v1/version", nil)
+	w := httptest.NewRecorder()
+	h.HandleVersion(w, r)
+
+	var resp VersionResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("response is not JSON: %v", err)
+	}
+	if resp.SHA != "cafef00d" {
+		t.Errorf("SHA = %q, want cafef00d (trimmed)", resp.SHA)
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/k8scache/k8scache_test.go
+++ b/products/catalyst/bootstrap/api/internal/k8scache/k8scache_test.go
@@ -188,6 +188,13 @@ func TestDefaultKinds_GraphAndDashboardSurface(t *testing.T) {
 		"podmetrics",
 		// EPIC-1 (#1096) compliance — Kyverno PolicyReports.
 		"policyreport", "clusterpolicyreport",
+		// QA-loop iter-2 Fix #17 — CRDs surfaced through /k8s/{kind}.
+		// The /components, /apps, /users, /organizations, /environments,
+		// and /blueprints pages all consume one of these via the SSE
+		// stream. A regression here would silently re-introduce the
+		// "unknown kind" 404 surface seen on omantel iter-2.
+		"helmrelease", "useraccess", "application", "blueprint",
+		"organization", "environment",
 	}
 	for _, name := range mandatory {
 		if _, ok := r.Get(name); !ok {

--- a/products/catalyst/bootstrap/api/internal/k8scache/kinds.go
+++ b/products/catalyst/bootstrap/api/internal/k8scache/kinds.go
@@ -145,6 +145,43 @@ var DefaultKinds = []Kind{
 	// widget; the server-side stream surface (existing ?fieldSelector=
 	// grammar) supports metadata-level filtering today.
 	{Name: "event", GVR: schema.GroupVersionResource{Group: "events.k8s.io", Version: "v1", Resource: "events"}, Namespaced: true},
+
+	// QA-loop iter-2 Fix #17 — CRDs surfaced through /k8s/{kind} need
+	// matching registry entries; otherwise the handler returns
+	// `{"error":"unknown kind",...}` even when the CRD is installed
+	// and the apiserver would happily serve it. Caught live on
+	// omantel.biz: TC-070..075, TC-184/192/194/227 all returned the
+	// "unknown kind" body for helmreleases / applications / blueprints
+	// / useraccesses / organizations / environments — the kinds were
+	// reachable individually via the existing per-CRD handlers
+	// (HandleListUserAccesses, etc.) but the generic SSE / list surface
+	// at /api/v1/sovereigns/{id}/k8s/{kind} did not know about them.
+	//
+	// Per feedback_chroot_in_cluster_fallback.md: every new GVR added
+	// here MUST get a matching rule on catalyst-api-cutover-driver
+	// ClusterRole (clusterrole-cutover-driver.yaml) — the chroot
+	// SovereignClient uses that SA via in-cluster fallback.
+	//
+	// helm.toolkit.fluxcd.io/v2 HelmReleases — Flux's release records
+	// for every blueprint installed on the cluster. The dashboard's
+	// platform-health view + the components page both consume this.
+	{Name: "helmrelease", GVR: schema.GroupVersionResource{Group: "helm.toolkit.fluxcd.io", Version: "v2", Resource: "helmreleases"}, Namespaced: true},
+	// access.openova.io/v1alpha1 UserAccess — RBAC binding CRD
+	// surfaced on the /users page.
+	{Name: "useraccess", GVR: schema.GroupVersionResource{Group: "access.openova.io", Version: "v1alpha1", Resource: "useraccesses"}, Namespaced: true},
+	// apps.openova.io/v1alpha1 Application — workload CRD owning the
+	// `/apps` and AppDetail pages (EPIC-2 slice T+O+P).
+	{Name: "application", GVR: schema.GroupVersionResource{Group: "apps.openova.io", Version: "v1alpha1", Resource: "applications"}, Namespaced: true},
+	// catalyst.openova.io/v1alpha1 Blueprint — published blueprint
+	// records the curate/publish handlers operate on.
+	{Name: "blueprint", GVR: schema.GroupVersionResource{Group: "catalyst.openova.io", Version: "v1alpha1", Resource: "blueprints"}, Namespaced: true},
+	// orgs.openova.io/v1alpha1 Organization — top-level tenancy CRD
+	// surfaced on the /organizations page.
+	{Name: "organization", GVR: schema.GroupVersionResource{Group: "orgs.openova.io", Version: "v1alpha1", Resource: "organizations"}, Namespaced: false},
+	// catalyst.openova.io/v1alpha1 Environment — logical environment
+	// dimension (one Environment realised by N Clusters per
+	// docs/NAMING-CONVENTION.md). Surfaced on the /environments page.
+	{Name: "environment", GVR: schema.GroupVersionResource{Group: "catalyst.openova.io", Version: "v1alpha1", Resource: "environments"}, Namespaced: true},
 }
 
 // Registry is a runtime-mutable lookup keyed by the short Name. It

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -1,5 +1,18 @@
 apiVersion: v2
 name: bp-catalyst-platform
+# 1.4.94 (qa-loop iter-2 Fix #17): expand catalyst-api-cutover-driver
+# ClusterRole with get/list/watch verbs on the CRDs needed by the
+# generic /k8s/{kind} surface — catalyst.openova.io/blueprints,
+# catalyst.openova.io/environments, orgs.openova.io/organizations.
+# Pairs with the same-PR addition of helmrelease/useraccess/
+# application/blueprint/organization/environment to k8scache.DefaultKinds
+# and the new GET /api/v1/version probe endpoint. Fixes the matrix
+# "unknown kind" 404 on TC-070..075 and the missing /version endpoint
+# on TC-261. Per feedback_chroot_in_cluster_fallback.md: every new GVR
+# added to k8scache.DefaultKinds MUST get a matching rule in this
+# ClusterRole — the chroot SovereignClient uses this SA via in-cluster
+# fallback.
+#
 # 1.4.22 (#915 SME blockers — issues #934/#940/#941/#942/#943/#944): six
 # coupled chart + orchestrator fixes that unblock alice signup gates 2-6
 # on a freshly franchised Sovereign. C5-final got Gate 1 GREEN on
@@ -153,8 +166,8 @@ name: bp-catalyst-platform
 # precedence so openbao auto-rotation of the source doesn't thrash the
 # controller pod. Caught live on omantel 2026-05-09 during qa-loop
 # iter-1 Executor run.
-version: 1.4.93
-appVersion: 1.4.93
+version: 1.4.94
+appVersion: 1.4.94
 description: |
   Catalyst Platform — the unified Catalyst control plane umbrella chart for Catalyst-Zero.
   Composes the catalyst-{ui,api}, console, admin, marketplace UI modules and the marketplace-api backend.

--- a/products/catalyst/chart/templates/clusterrole-cutover-driver.yaml
+++ b/products/catalyst/chart/templates/clusterrole-cutover-driver.yaml
@@ -269,3 +269,26 @@ rules:
   - apiGroups: ["dr.openova.io"]
     resources: ["continuums"]
     verbs: ["get", "list", "watch", "update", "patch", "delete"]
+
+  # ───────────────────────────────────────────────────────────────
+  # QA-loop iter-2 Fix #17 — additional CRDs the generic /k8s/{kind}
+  # surface needs to enumerate. These live alongside the per-CRD
+  # handlers (HandleListUserAccesses, HandleBlueprintPublish, …) but
+  # the k8scache.Factory's dynamic informer pool is the read path for
+  # the SSE stream + dashboard treemap + components page.
+  #
+  # Per feedback_chroot_in_cluster_fallback.md every new GVR added to
+  # internal/k8scache/kinds.go DefaultKinds MUST get a matching rule
+  # in this ClusterRole — the chroot SovereignClient uses this SA.
+  # ───────────────────────────────────────────────────────────────
+  # Blueprint CRD — published blueprint records (already used by
+  # HandleBlueprintListCuratable etc.; the k8scache surface needs
+  # explicit list+watch verbs).
+  - apiGroups: ["catalyst.openova.io"]
+    resources: ["blueprints", "environments"]
+    verbs: ["get", "list", "watch"]
+  # Organization CRD — top-level tenancy resource surfaced on the
+  # /organizations page.
+  - apiGroups: ["orgs.openova.io"]
+    resources: ["organizations"]
+    verbs: ["get", "list", "watch"]


### PR DESCRIPTION
## Summary

QA-loop iter-2 Fix #17 — cluster `be-handler-errors-5xx-4xx`.

After Fix #15 (SPA route guard) + Fix #16 (whoami) shipped, the remaining BE-handler symptom cluster on omantel.biz is:

- **ITEMS-ENVELOPE FAILs** (TC-070..075, TC-184/192/194/227): `/api/v1/sovereigns/{id}/k8s/{kind}` returned `{"error":"unknown kind",...}` for `helmreleases`/`applications`/`blueprints`/`useraccesses`/`organizations`/`environments`. The kinds were reachable via per-CRD handlers but `k8scache.Factory`'s dynamic informer pool didn't know about them.
  - **Fix**: added six entries to `DefaultKinds` (helmrelease, useraccess, application, blueprint, organization, environment) with matching `catalyst-api-cutover-driver` ClusterRole verbs per `feedback_chroot_in_cluster_fallback.md`.

- **TC-261** (`HTTP 404 on /api/v1/version`): endpoint didn't exist.
  - **Fix**: new `handler/version.go` returning git SHA + chart version + Go runtime, with env override (`CATALYST_BUILD_SHA`/`_VERSION`/`_CHART_VERSION`) for chart-injected truth and ldflag fallback for CI-baked-in values. Public route, no auth gate.

- **TC-089** (`HTTP 503 on /blueprints/curatable when Gitea unwired`): broke the `/blueprints` page with "Failed to fetch".
  - **Fix**: return `200 + {"items":[]}` so the empty-state renders.

## Per-TC outcomes

| Cluster | Resolution |
|---|---|
| HTTP 500 (TC-061..068, TC-149) | Already 200 after Fix #15+#16 — no code change |
| ITEMS-ENVELOPE (TC-070..075, TC-184/192/194/227) | Fixed via DefaultKinds + RBAC |
| TC-261 `/api/v1/version` 404 | New handler |
| TC-089 `/blueprints/curatable` 503 | Graceful empty list |
| TC-088 `/blueprints/curate` 405 | Matrix-drift (POST not GET) — handed back |
| TC-090 `/blueprints/publish` 405 | Matrix-drift (POST not GET) — handed back |
| TC-235 `/auth/pin/issue` 405 | Matrix-drift (POST not GET) — handed back |
| TC-236 `/deployments/{id}/wipe` 405 | Matrix-drift (POST not GET) — handed back |
| TC-244 `/marketplace` 405 | Matrix-drift (POST not GET) — handed back |
| TC-078 `/k8s/Pod/.../catalyst-api-0` 404 | Matrix-drift (hardcoded pod name doesn't exist) — handed back |
| TC-128, TC-137 | Already 200 — no code change |
| TC-210, TC-211 keycloak proxy 502 | Out of scope (chroot keycloak SA misconfig) |

## Test plan

- [x] Unit tests added: `TestHandleVersion_AlwaysJSON`, `TestHandleVersion_EnvOverride`, `TestHandleVersion_TrimsWhitespace`, `TestHandleBlueprintListCuratable_GiteaUnwiredReturnsEmptyList`, plus `TestDefaultKinds_GraphAndDashboardSurface` extended with the six new CRDs
- [x] Full handler test suite passes locally (`go test ./internal/handler/`)
- [x] Full k8scache test suite passes locally (`go test ./internal/k8scache/`)
- [ ] Post-merge: rollout to omantel via image_roll, then re-curl all touched TCs

## Chart bump

`bp-catalyst-platform` 1.4.93 → 1.4.94 (ClusterRole change requires Helm release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)