### PR TITLE
fix(api+chart): clusterroles GVR + CATALYST_BUILD_SHA env injection (qa-loop iter-3)

### DIFF
--- a/.github/workflows/catalyst-build.yaml
+++ b/.github/workflows/catalyst-build.yaml
@@ -351,8 +351,19 @@ jobs:
           UI_TPL="products/catalyst/chart/templates/ui-deployment.yaml"
           sed -i -E "s|(image: \"ghcr\.io/openova-io/openova/catalyst-api:)[^\"]*\"|\1${SHA_SHORT}\"|" "${API_TPL}"
           sed -i -E "s|(image: \"ghcr\.io/openova-io/openova/catalyst-ui:)[^\"]*\"|\1${SHA_SHORT}\"|"  "${UI_TPL}"
+          # qa-loop iter-3 Fix #18 — also bump the CATALYST_BUILD_SHA env
+          # literal in the api-deployment so /api/v1/version returns the
+          # SHA the Pod is actually running. Without this, the env stays
+          # frozen at whatever value was committed manually and the live
+          # version probe lies. The env block uses literal values (not
+          # Helm directives) per the dual-mode contract — this sed
+          # targets the literal directly. Pattern: 6-12 hex chars in
+          # double-quotes immediately after `name: CATALYST_BUILD_SHA`
+          # + newline + `              value:`.
+          sed -i -E "/name: CATALYST_BUILD_SHA/{n;s|(value: )\"[a-f0-9]+\"|\1\"${SHA_SHORT}\"|;}" "${API_TPL}"
           echo "templates after update:"
           grep -E "image: \".*catalyst-(api|ui):" "${API_TPL}" "${UI_TPL}"
+          grep -A1 "CATALYST_BUILD_SHA" "${API_TPL}" | head -2
 
           # contabo's catalyst-platform Kustomization at
           # ./products/catalyst/chart/templates reconciles every 10 min

--- a/products/catalyst/bootstrap/api/internal/k8scache/k8scache_test.go
+++ b/products/catalyst/bootstrap/api/internal/k8scache/k8scache_test.go
@@ -195,6 +195,12 @@ func TestDefaultKinds_GraphAndDashboardSurface(t *testing.T) {
 		// "unknown kind" 404 surface seen on omantel iter-2.
 		"helmrelease", "useraccess", "application", "blueprint",
 		"organization", "environment",
+		// QA-loop iter-3 Fix #18 — RBAC kinds surfaced through
+		// /k8s/{kind}. The Sovereign Console's RBAC pane consumes
+		// rbac.authorization.k8s.io/clusterroles + clusterrolebindings.
+		// Caught live on omantel iter-2: TC-122/196/199/248 returned 404
+		// "unknown kind" for the cluster-wide RBAC list.
+		"clusterrole", "clusterrolebinding",
 	}
 	for _, name := range mandatory {
 		if _, ok := r.Get(name); !ok {

--- a/products/catalyst/bootstrap/api/internal/k8scache/kinds.go
+++ b/products/catalyst/bootstrap/api/internal/k8scache/kinds.go
@@ -182,6 +182,21 @@ var DefaultKinds = []Kind{
 	// dimension (one Environment realised by N Clusters per
 	// docs/NAMING-CONVENTION.md). Surfaced on the /environments page.
 	{Name: "environment", GVR: schema.GroupVersionResource{Group: "catalyst.openova.io", Version: "v1alpha1", Resource: "environments"}, Namespaced: true},
+
+	// QA-loop iter-3 Fix #18 — RBAC ClusterRole + ClusterRoleBinding
+	// surfaced through GET /api/v1/sovereigns/{id}/k8s/clusterroles and
+	// /clusterrolebindings. Both are cluster-scoped (Namespaced=false).
+	// The matrix expects these on TC-122/196/199/248 to render the RBAC
+	// section of the Sovereign Console; without them the generic /k8s/
+	// surface returned 404 "unknown kind".
+	//
+	// Per feedback_chroot_in_cluster_fallback.md: every new GVR added
+	// here MUST get a matching rule on catalyst-api-cutover-driver
+	// ClusterRole (clusterrole-cutover-driver.yaml). Both RBAC kinds
+	// carry binding metadata only (subject + roleRef references) — no
+	// secret material — so Sensitive=false is correct.
+	{Name: "clusterrole", GVR: schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "clusterroles"}, Namespaced: false},
+	{Name: "clusterrolebinding", GVR: schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "clusterrolebindings"}, Namespaced: false},
 }
 
 // Registry is a runtime-mutable lookup keyed by the short Name. It

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -1,5 +1,16 @@
 apiVersion: v2
 name: bp-catalyst-platform
+# 1.4.95 (qa-loop iter-3 Fix #18): clusterroles + clusterrolebindings GVR
+# added to k8scache.DefaultKinds + matching get/list/watch verbs on
+# catalyst-api-cutover-driver ClusterRole. Pairs with new
+# CATALYST_BUILD_SHA + CATALYST_CHART_VERSION env vars on api-deployment.yaml
+# so /api/v1/version returns the live SHA + chart-version instead of the
+# `dev` / `0.0.0` ldflag fallbacks. Fixes TC-122/196/199/248 (RBAC list
+# 404) + TC-261 (/version returns "dev"). Per
+# feedback_chroot_in_cluster_fallback.md: every new GVR added to
+# k8scache.DefaultKinds MUST get a matching rule in this ClusterRole —
+# the chroot SovereignClient uses this SA via in-cluster fallback.
+#
 # 1.4.94 (qa-loop iter-2 Fix #17): expand catalyst-api-cutover-driver
 # ClusterRole with get/list/watch verbs on the CRDs needed by the
 # generic /k8s/{kind} surface — catalyst.openova.io/blueprints,
@@ -166,7 +177,7 @@ name: bp-catalyst-platform
 # precedence so openbao auto-rotation of the source doesn't thrash the
 # controller pod. Caught live on omantel 2026-05-09 during qa-loop
 # iter-1 Executor run.
-version: 1.4.94
+version: 1.4.95
 appVersion: 1.4.94
 description: |
   Catalyst Platform — the unified Catalyst control plane umbrella chart for Catalyst-Zero.

--- a/products/catalyst/chart/templates/api-deployment.yaml
+++ b/products/catalyst/chart/templates/api-deployment.yaml
@@ -168,6 +168,39 @@ spec:
           env:
             - name: PORT
               value: "8080"
+            # CATALYST_BUILD_SHA / CATALYST_CHART_VERSION — qa-loop iter-3
+            # Fix #18 (TC-261). The /api/v1/version handler resolves these
+            # env vars first (envOrTrim) before falling back to the ldflag
+            # defaults `dev` / `0.0.0`. Without this injection the live
+            # version probe returned `{"sha":"dev","version":"0.0.0"}` on
+            # every Sovereign — masking which image was actually live.
+            #
+            # LITERAL values (not Helm template directives) are mandatory
+            # here: this file is consumed by both Helm (per-Sovereign
+            # install via bp-catalyst-platform OCI) AND Kustomize
+            # (clusters/contabo-mkt/apps/catalyst-platform). Helm
+            # directives in `value:` fields break the Kustomize build
+            # with `yaml: invalid map key` (see DUAL-MODE CONTRACT note
+            # on CATALYST_POWERDNS_API_URL below).
+            #
+            # The CATALYST_BUILD_SHA literal is bumped by the same CI
+            # sed-pass that bumps the catalyst-api image tag literal in
+            # this file — see .github/workflows/catalyst-build.yaml's
+            # "Bump literal image refs in chart templates" step. Both
+            # sides converge on the same SHA on every push to main, so
+            # /api/v1/version returns the SHA the Pod is actually
+            # running (no drift between image tag and reported SHA).
+            #
+            # CATALYST_CHART_VERSION mirrors Chart.yaml's `version:` —
+            # bumped manually whenever the chart shape changes, per the
+            # existing bp-catalyst-platform release discipline. The
+            # value carries through to /api/v1/version's `chartVersion`
+            # field so dashboards can correlate api-version <-> chart-
+            # version on a single probe.
+            - name: CATALYST_BUILD_SHA
+              value: "c5bfa34"
+            - name: CATALYST_CHART_VERSION
+              value: "1.4.95"
             - name: CORS_ORIGIN
               value: "https://console.openova.io"
             - name: DYNADOT_API_KEY

--- a/products/catalyst/chart/templates/clusterrole-cutover-driver.yaml
+++ b/products/catalyst/chart/templates/clusterrole-cutover-driver.yaml
@@ -292,3 +292,23 @@ rules:
   - apiGroups: ["orgs.openova.io"]
     resources: ["organizations"]
     verbs: ["get", "list", "watch"]
+
+  # ───────────────────────────────────────────────────────────────
+  # QA-loop iter-3 Fix #18 — RBAC kinds surfaced through the
+  # /k8s/{kind} generic surface. The Sovereign Console's RBAC pane
+  # lists ClusterRoles + ClusterRoleBindings (TC-122/196/199/248).
+  # Without this rule the in-cluster catalyst-api SA gets 403 from
+  # the apiserver on every dynamic-client list.list call against
+  # rbac.authorization.k8s.io.
+  #
+  # Per feedback_chroot_in_cluster_fallback.md every new GVR added
+  # to internal/k8scache/kinds.go DefaultKinds MUST get a matching
+  # rule in this ClusterRole — the chroot SovereignClient uses this
+  # SA via in-cluster fallback. Read-only verbs only — the Sovereign
+  # Console renders RBAC inventory; mutation goes through the
+  # UserAccess CR reconciliation loop, not through direct ClusterRole/
+  # ClusterRoleBinding writes.
+  # ───────────────────────────────────────────────────────────────
+  - apiGroups: ["rbac.authorization.k8s.io"]
+    resources: ["clusterroles", "clusterrolebindings"]
+    verbs: ["get", "list", "watch"]


### PR DESCRIPTION
## Summary

QA-loop iter-3 Fix #18 — cluster `clusterroles-gvr-and-sha-injection`. Two coupled backend fixes (~30 LOC):

**Sub-A — clusterroles GVR (TC-122/196/199/248)**

`GET /api/v1/sovereigns/{id}/k8s/clusterroles` returned 404 because `clusterroles` GVR was missing from `internal/k8scache/kinds.go::DefaultKinds`. Same for `clusterrolebindings`.

- Added `rbac.authorization.k8s.io/v1` ClusterRole + ClusterRoleBinding to `DefaultKinds` (both cluster-scoped).
- Added matching `get/list/watch` rule on `catalyst-api-cutover-driver` ClusterRole (chroot SovereignClient uses this SA via in-cluster fallback).
- Pinned both names in `TestDefaultKinds_GraphAndDashboardSurface`.

**Sub-B — CATALYST_BUILD_SHA env injection (TC-261)**

`GET /api/v1/version` returned `{"sha":"dev","version":"0.0.0"}` because no SHA was injected at runtime (handler reads `CATALYST_BUILD_SHA` env via `envOrTrim`, but the env wasn't set on the Pod).

- `api-deployment.yaml`: injected `CATALYST_BUILD_SHA` + `CATALYST_CHART_VERSION` env vars with LITERAL values. NOT Helm directives, per the dual-mode contract — Kustomize on contabo cannot render `{{ .Values... }}` in `value:` fields.
- `.github/workflows/catalyst-build.yaml`: extended the existing "bump literal image refs in chart templates" `sed` pass to also bump the `CATALYST_BUILD_SHA` env literal on every push. Both image tag and env value now converge on the same SHA per push.
- `version.go` was already correct (no changes needed); existing `TestHandleVersion_EnvOverride` covers the env path.

Chart bumped 1.4.94 -> 1.4.95.

## Files changed

- `products/catalyst/bootstrap/api/internal/k8scache/kinds.go` (+15)
- `products/catalyst/bootstrap/api/internal/k8scache/k8scache_test.go` (+6)
- `products/catalyst/chart/templates/clusterrole-cutover-driver.yaml` (+18)
- `products/catalyst/chart/templates/api-deployment.yaml` (+33 env block)
- `products/catalyst/chart/Chart.yaml` (1.4.94 -> 1.4.95 + comment)
- `.github/workflows/catalyst-build.yaml` (+11 sed)

## Test plan

- [x] `go test ./internal/k8scache/...` — `TestRegistry_*`, `TestDefaultKinds_GraphAndDashboardSurface` pass with new `clusterrole`+`clusterrolebinding` mandatory entries
- [x] `go test ./internal/handler/... -run TestHandleVersion` — `AlwaysJSON`, `EnvOverride`, `TrimsWhitespace` all pass
- [x] `go build ./...` clean
- [x] `clusterrole-cutover-driver.yaml` parses as YAML
- [x] `Chart.yaml` parses
- [x] sed pattern verified on a copy of api-deployment.yaml — replaces `value: "c5bfa34"` -> `value: "<new-sha>"` correctly
- [ ] **Live verify after merge + image roll** on omantel:
  ```
  curl -sS -k https://console.omantel.biz/api/v1/version | jq .
  # expect sha=<new-7-char>, chartVersion=1.4.95
  curl -sS -k -b /tmp/iter3-cookies.txt https://console.omantel.biz/api/v1/sovereigns/sovereign-omantel.biz/k8s/clusterroles | jq 'keys'
  # expect [items, kind, ...] (200), not 404 "unknown kind"
  ```

## Notes

- The pre-existing `value: {{ .Values.keycloak.bootstrap.ensureTierRoles | default false | quote }}` Helm directive on api-deployment.yaml line 493 (added by PR #1194) currently breaks contabo's Kustomize render with `yaml: invalid map key`. This Fix #18 PR carefully uses LITERAL values to avoid making that worse — separate fix-up needed for line 493 (out of scope for this fix).
- Per `feedback_chroot_in_cluster_fallback.md`: every new GVR added to `DefaultKinds` MUST get a matching ClusterRole rule. This PR follows that rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)