### PR TITLE
fix(bootstrap-kit): bump bp-catalyst-platform pin 1.4.84 -> 1.4.95 (qa-loop iter-3 Fix #18)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -231,7 +231,15 @@ spec:
       # fallback (data renders the moment cutover-import lands without
       # waiting for the orchestrator's chart-values overlay write).
       # 2026-05-05.
-      version: 1.4.84
+      # 1.4.95 (qa-loop iter-3 Fix #18, #1206): clusterroles +
+      # clusterrolebindings GVR added to k8scache.DefaultKinds + matching
+      # get/list/watch verbs on catalyst-api-cutover-driver ClusterRole
+      # (TC-122/196/199/248). Pairs with new CATALYST_BUILD_SHA +
+      # CATALYST_CHART_VERSION env vars on api-deployment.yaml so
+      # /api/v1/version returns the live SHA instead of `dev`/`0.0.0`
+      # (TC-261). Bump pin so omantel + every other Sovereign sourcing
+      # this template picks up the chart on the next reconcile.
+      version: 1.4.95
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform


### PR DESCRIPTION
## Summary

Pin bump only — picks up chart 1.4.95 published by #1206 + the deploy commit's blueprint-release run.

Without this bump:
- omantel + otech.omani.works stay on chart 1.4.84
- /api/v1/version returns dev/0.0.0 (the env injection from #1206 stays unrendered)
- /k8s/clusterroles returns 404 "unknown kind" (the new GVR registration stays unloaded)

Test plan:
- [x] chart 1.4.95 already published to ghcr.io/openova-io/bp-catalyst-platform via blueprint-release run 25602921459 (success)
- [ ] Flux on omantel reconciles to 1.4.95 within 5 min of merge
- [ ] /api/v1/version returns sha=b24475e (or newer), chartVersion=1.4.95
- [ ] /k8s/clusterroles returns 200 with items envelope

🤖 Generated with [Claude Code](https://claude.com/claude-code)