### PR TITLE
fix(chart): exclude crds/tests/ from packaged bp-catalyst-platform (qa-loop iter-3 Fix #18 follow-up)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -237,9 +237,16 @@ spec:
       # (TC-122/196/199/248). Pairs with new CATALYST_BUILD_SHA +
       # CATALYST_CHART_VERSION env vars on api-deployment.yaml so
       # /api/v1/version returns the live SHA instead of `dev`/`0.0.0`
-      # (TC-261). Bump pin so omantel + every other Sovereign sourcing
-      # this template picks up the chart on the next reconcile.
-      version: 1.4.95
+      # (TC-261).
+      # 1.4.96 (qa-loop iter-3 Fix #18 follow-up): chart-packaging fix —
+      # .helmignore excludes crds/tests/ so Helm's pre-render CRD install
+      # no longer tries to apply the invalid Application sample as a CRD
+      # (the test fixture introduced by PR #1105). Without this every
+      # chart upgrade since 1.4.85 failed with `namespaces "acme" not
+      # found` — caught live on omantel 2026-05-09 attempting 1.4.84 ->
+      # 1.4.95. Bump pin so omantel + every other Sovereign sourcing
+      # this template picks up the fix on the next reconcile.
+      version: 1.4.96
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/chart/.helmignore
+++ b/products/catalyst/chart/.helmignore
@@ -25,3 +25,16 @@ templates/clusterrolebinding-cutover-driver-kustomize.yaml
 # `{{- if and .Values.ingress.marketplace .Values.ingress.marketplace.enabled }}`
 # (issue #710). Non-marketplace Sovereigns get an empty render; marketplace
 # operators flip the toggle and the SME stack + HTTPRoutes deploy together.
+
+# qa-loop iter-3 Fix #18 (#1206 follow-up): exclude crds/tests/ from
+# the packaged chart. Helm's `crds/` directory installs every YAML file
+# inside as a CRD at the pre-render install hook — Helm does NOT filter
+# by `kind:` and does NOT honour resource Namespaces in this directory.
+# The sample fixtures (added by PR #1105 for chart-author validation)
+# include `kind: Application` instances in `namespace: acme`, so on every
+# Sovereign upgrade Helm tries to create them as CRDs and fails with
+# `failed to create CustomResourceDefinition bad-app: namespaces "acme"
+# not found` — caught live on omantel 2026-05-09 attempting 1.4.84 ->
+# 1.4.95. The samples are intentionally invalid for chart-author dry-runs;
+# they MUST never reach a real cluster.
+crds/tests/

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -1,5 +1,17 @@
 apiVersion: v2
 name: bp-catalyst-platform
+# 1.4.96 (qa-loop iter-3 Fix #18 follow-up): exclude crds/tests/ from
+# the packaged chart via .helmignore. Helm's `crds/` directory installs
+# every YAML file inside as a CRD at the pre-render install hook,
+# regardless of the file's `kind:` field or resource namespace. The
+# sample fixtures added by PR #1105 (Application CRs in `namespace: acme`,
+# intentionally invalid for chart-author dry-run testing) were therefore
+# being submitted to the apiserver as real CRDs on every Sovereign
+# upgrade — every install of any chart ≥ 1.4.85 failed with
+# `failed to create CustomResourceDefinition bad-app: namespaces
+# "acme" not found`. Caught live on omantel 2026-05-09 attempting
+# 1.4.84 -> 1.4.95.
+#
 # 1.4.95 (qa-loop iter-3 Fix #18): clusterroles + clusterrolebindings GVR
 # added to k8scache.DefaultKinds + matching get/list/watch verbs on
 # catalyst-api-cutover-driver ClusterRole. Pairs with new
@@ -177,7 +189,7 @@ name: bp-catalyst-platform
 # precedence so openbao auto-rotation of the source doesn't thrash the
 # controller pod. Caught live on omantel 2026-05-09 during qa-loop
 # iter-1 Executor run.
-version: 1.4.95
+version: 1.4.96
 appVersion: 1.4.94
 description: |
   Catalyst Platform — the unified Catalyst control plane umbrella chart for Catalyst-Zero.


### PR DESCRIPTION
## Summary

Pre-existing chart-packaging bug surfaced by qa-loop iter-3 Fix #18 pin bump (#1207).

Helm's `crds/` directory installs every YAML file inside as a CRD at the pre-render install hook, regardless of `kind:` field or resource namespace. PR #1105 added invalid Application sample fixtures under `crds/tests/` for chart-author dry-run validation — these were being submitted to the apiserver as real CRDs on every Sovereign upgrade since 1.4.85.

Result: every chart >= 1.4.85 install/upgrade has been failing with `failed to create CustomResourceDefinition bad-app: namespaces "acme" not found` — caught live on omantel 2026-05-09 attempting 1.4.84 -> 1.4.95.

Fix: add `crds/tests/` to .helmignore. The test fixtures remain in the source tree for chart-author validation (`kubectl apply --dry-run=server -f ...`); they just don't ship in the OCI artifact.

Chart bumped 1.4.95 -> 1.4.96 + bootstrap-kit pin.

## Test plan

- [x] .helmignore parses
- [x] Chart.yaml parses, version bumped 1.4.95 -> 1.4.96
- [x] _template/bootstrap-kit/13-bp-catalyst-platform.yaml pin bumped to 1.4.96
- [ ] After merge: blueprint-release publishes chart 1.4.96
- [ ] omantel Flux reconciles bootstrap-kit Kustomization, picks up version 1.4.96
- [ ] HelmRelease `bp-catalyst-platform` upgrades successfully (no `bad-app` CRD error)
- [ ] catalyst-api Pod rolls to image `:b24475e` (or newer)
- [ ] /api/v1/version returns sha=b24475e, chartVersion=1.4.96
- [ ] /api/v1/sovereigns/sovereign-omantel.biz/k8s/clusterroles returns 200 with items envelope

🤖 Generated with [Claude Code](https://claude.com/claude-code)