### PR TITLE
fix(api): POST /auth/session for logout (qa-loop iter-4)

### DIFF
--- a/products/catalyst/bootstrap/api/cmd/api/main.go
+++ b/products/catalyst/bootstrap/api/cmd/api/main.go
@@ -352,6 +352,11 @@ func main() {
 		http.Redirect(w, r, "/login?error=flow_changed", http.StatusFound)
 	})
 	r.Delete("/api/v1/auth/session", h.HandleAuthLogout)
+	// POST /auth/session — SPA-driven logout (qa-loop iter-4
+	// auth-session-logout-405). DELETE remains for backwards-compat;
+	// POST is the canonical SPA path because some proxies strip
+	// body+credentials from DELETE on cross-origin XHR.
+	r.Post("/api/v1/auth/session", h.HandleAuthSessionLogout)
 
 	// Unauthenticated tenant-discovery endpoint (issue #802) — the SPA
 	// calls this on bootstrap to learn which Keycloak realm to OIDC

--- a/products/catalyst/bootstrap/api/internal/handler/auth.go
+++ b/products/catalyst/bootstrap/api/internal/handler/auth.go
@@ -694,6 +694,61 @@ func (h *Handler) HandleAuthLogout(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+// HandleAuthSessionLogout handles POST /api/v1/auth/session as the
+// canonical SPA-driven logout (issue #qa-loop-iter4 auth-session-logout-405).
+//
+// The SPA's logout flow uses POST (idempotent intent: "create a logout
+// event") rather than DELETE (resource-deletion semantics) because some
+// browsers + reverse proxies strip body+credentials from DELETE on
+// cross-origin XHR, while POST is universally honoured. The legacy
+// DELETE handler stays in place for backwards compatibility with any
+// in-flight clients; this POST variant produces an equivalent result
+// but with a Max-Age=0 wire shape (RFC 6265bis non-positive max-age =
+// immediate expiry) and SameSite=Strict — a stricter posture than the
+// DELETE handler's Lax, appropriate for an explicit user-initiated
+// logout where no cross-site redirect is involved.
+//
+// Response body is the minimal `{ok:true, loggedOut:true}` JSON the
+// matrix asserts; the keycloakLogoutURL hop is intentionally omitted
+// here because POST-driven logout is invoked by the SPA AFTER it has
+// already chosen its own post-logout redirect (the DELETE handler still
+// returns the URL for the legacy redirect-driven flow).
+func (h *Handler) HandleAuthSessionLogout(w http.ResponseWriter, r *http.Request) {
+	cookieDomain := os.Getenv("CATALYST_SESSION_COOKIE_DOMAIN")
+	secure := r.TLS != nil || r.Header.Get("X-Forwarded-Proto") == "https"
+	w.Header().Add("Set-Cookie", buildPostLogoutClearCookie(auth.SessionCookieName, cookieDomain, secure))
+	w.Header().Add("Set-Cookie", buildPostLogoutClearCookie("catalyst_refresh", cookieDomain, secure))
+
+	h.log.Info("auth/session: POST logout", "remoteAddr", r.RemoteAddr)
+	writeJSON(w, http.StatusOK, map[string]any{
+		"ok":        true,
+		"loggedOut": true,
+	})
+}
+
+// buildPostLogoutClearCookie returns a Set-Cookie header value of shape:
+//
+//	<name>=; Path=/[; Domain=<domain>][; Secure]; HttpOnly; SameSite=Strict; Max-Age=0
+//
+// `Max-Age=0` is emitted literally (RFC 6265bis: any non-positive value
+// = immediate expiry). SameSite=Strict because the POST logout is an
+// explicit same-origin XHR from the SPA — there is no cross-site
+// navigation to honour, so the strictest posture applies.
+func buildPostLogoutClearCookie(name, domain string, secure bool) string {
+	var b strings.Builder
+	b.WriteString(name)
+	b.WriteString("=; Path=/")
+	if domain != "" {
+		b.WriteString("; Domain=")
+		b.WriteString(domain)
+	}
+	if secure {
+		b.WriteString("; Secure")
+	}
+	b.WriteString("; HttpOnly; SameSite=Strict; Max-Age=0")
+	return b.String()
+}
+
 // buildClearSessionCookie returns a Set-Cookie header value that
 // instructs the browser to delete `name` immediately. The shape is
 // fixed and assertable on the wire:

--- a/products/catalyst/bootstrap/api/internal/handler/auth_logout_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/auth_logout_test.go
@@ -126,6 +126,111 @@ func TestHandleAuthLogout_NoDomainWhenEnvUnset(t *testing.T) {
 	}
 }
 
+// TestHandleAuthSessionLogout_PostWireShape asserts the wire shape of
+// the Set-Cookie header emitted by POST /auth/session (the SPA-driven
+// logout path added to fix qa-loop iter-4 auth-session-logout-405).
+//
+// Contract:
+//   - HTTP 200 with body {"ok":true,"loggedOut":true}.
+//   - Two Set-Cookie lines (catalyst_session + catalyst_refresh), each
+//     with the literal token "Max-Age=0" (non-positive max-age =
+//     immediate expiry per RFC 6265bis).
+//   - SameSite=Strict (POST logout is same-origin XHR; strictest
+//     posture applies — no cross-site redirect to honour).
+//   - Path=/ + HttpOnly.
+//   - Secure when X-Forwarded-Proto=https.
+//   - Domain attribute appears IFF CATALYST_SESSION_COOKIE_DOMAIN set.
+func TestHandleAuthSessionLogout_PostWireShape(t *testing.T) {
+	prev := os.Getenv("CATALYST_SESSION_COOKIE_DOMAIN")
+	t.Cleanup(func() { os.Setenv("CATALYST_SESSION_COOKIE_DOMAIN", prev) })
+	os.Setenv("CATALYST_SESSION_COOKIE_DOMAIN", "console.example.test")
+
+	h := &Handler{log: slog.New(slog.NewTextHandler(io.Discard, nil))}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/session", nil)
+	req.Header.Set("X-Forwarded-Proto", "https")
+	w := httptest.NewRecorder()
+	h.HandleAuthSessionLogout(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status: got %d want 200; body=%s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), `"loggedOut":true`) {
+		t.Errorf("body missing loggedOut:true — got %q", w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), `"ok":true`) {
+		t.Errorf("body missing ok:true — got %q", w.Body.String())
+	}
+
+	cookies := w.Result().Header.Values("Set-Cookie")
+	if len(cookies) != 2 {
+		t.Fatalf("Set-Cookie count: got %d want 2 — %v", len(cookies), cookies)
+	}
+
+	var sessionLine, refreshLine string
+	for _, line := range cookies {
+		switch {
+		case strings.HasPrefix(line, "catalyst_session=;"):
+			sessionLine = line
+		case strings.HasPrefix(line, "catalyst_refresh=;"):
+			refreshLine = line
+		}
+	}
+	if sessionLine == "" {
+		t.Fatalf("catalyst_session clear-cookie missing — cookies=%v", cookies)
+	}
+	if refreshLine == "" {
+		t.Fatalf("catalyst_refresh clear-cookie missing — cookies=%v", cookies)
+	}
+
+	for label, line := range map[string]string{
+		"catalyst_session": sessionLine,
+		"catalyst_refresh": refreshLine,
+	} {
+		for _, want := range []string{
+			"Max-Age=0",
+			"Path=/",
+			"Domain=console.example.test",
+			"Secure",
+			"HttpOnly",
+			"SameSite=Strict",
+		} {
+			if !strings.Contains(line, want) {
+				t.Errorf("%s clear-cookie missing %q in %q", label, want, line)
+			}
+		}
+		if strings.Contains(line, "Max-Age=-1") {
+			t.Errorf("%s POST logout cookie must use Max-Age=0 not -1: %q", label, line)
+		}
+	}
+}
+
+// TestHandleAuthSessionLogout_NoDomainWhenEnvUnset asserts that without
+// CATALYST_SESSION_COOKIE_DOMAIN set, the POST-logout cookie is host-only.
+func TestHandleAuthSessionLogout_NoDomainWhenEnvUnset(t *testing.T) {
+	prev := os.Getenv("CATALYST_SESSION_COOKIE_DOMAIN")
+	t.Cleanup(func() { os.Setenv("CATALYST_SESSION_COOKIE_DOMAIN", prev) })
+	os.Unsetenv("CATALYST_SESSION_COOKIE_DOMAIN")
+
+	h := &Handler{log: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/session", nil)
+	req.Header.Set("X-Forwarded-Proto", "https")
+	w := httptest.NewRecorder()
+	h.HandleAuthSessionLogout(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status: got %d want 200", w.Code)
+	}
+	for _, line := range w.Result().Header.Values("Set-Cookie") {
+		if strings.Contains(line, "Domain=") {
+			t.Errorf("Domain attr leaked when env is unset: %q", line)
+		}
+		if !strings.Contains(line, "Max-Age=0") {
+			t.Errorf("clear-cookie missing Max-Age=0: %q", line)
+		}
+	}
+}
+
 // TestHandleAuthLogout_NoSecureOverHTTP asserts the local-dev / plain
 // HTTP path: when neither r.TLS nor X-Forwarded-Proto=https is set,
 // the Secure attribute must NOT be emitted (or browsers will refuse


### PR DESCRIPTION
## Summary
Cluster: `auth-session-logout-405` — TC-010.

POST /api/v1/auth/session previously returned HTTP 405 because only DELETE was registered. The SPA logout flow uses POST (some browsers + reverse proxies strip body+credentials from DELETE on cross-origin XHR). This PR adds the POST handler so the SPA-driven logout path works.

## Changes
- `cmd/api/main.go` — register `r.Post("/api/v1/auth/session", h.HandleAuthSessionLogout)` alongside the existing DELETE.
- `internal/handler/auth.go` — new `HandleAuthSessionLogout` + `buildPostLogoutClearCookie` helper. Returns HTTP 200 + body `{"ok":true,"loggedOut":true}` + Set-Cookie lines for `catalyst_session` and `catalyst_refresh` with the literal token `Max-Age=0`, `SameSite=Strict`, `Path=/`, `HttpOnly`, `Secure` (when X-Forwarded-Proto=https), `Domain=` (when CATALYST_SESSION_COOKIE_DOMAIN set).
- `internal/handler/auth_logout_test.go` — two new tests asserting the wire shape of the POST logout response (with and without cookie domain).

## Why POST + Strict (vs DELETE + Lax)
The legacy DELETE handler returns Max-Age=-1 + SameSite=Lax intentionally — Lax matches the cookie set on `/pin/verify` so the browser actually deletes the cookie when the KC post-logout-redirect lands a cross-site nav back to this origin. The POST path is invoked by the SPA AFTER it has chosen its own redirect, so there is no cross-site nav to honour and the strictest posture applies.

## Test plan
- [x] `go build ./...` — clean
- [x] `go test ./internal/handler/ -run "HandleAuthSessionLogout|HandleAuthLogout"` — pass
- [ ] Live: `curl -X POST https://console.omantel.biz/api/v1/auth/session -i` returns HTTP 200 + Set-Cookie with Max-Age=0

🤖 Generated with [Claude Code](https://claude.com/claude-code)