### PR TITLE
fix(qa-loop-iter4): register CRD GVR + add Catalog to install heading [Fix #24]

### DIFF
--- a/products/catalyst/bootstrap/api/internal/k8scache/k8scache_test.go
+++ b/products/catalyst/bootstrap/api/internal/k8scache/k8scache_test.go
@@ -127,6 +127,14 @@ func TestRegistry_PluralAliasResolution(t *testing.T) {
 		{name: "kubectl short ns", query: "ns", want: "namespace"},
 		{name: "kubectl short svc", query: "svc", want: "service"},
 		{name: "case-insensitive plural", query: "Pods", want: "pod"},
+		// QA-loop iter-4 Fix #24 — CRD aliases. Operators reach for
+		// `kubectl get crd` (short singular), `kubectl get crds` (short
+		// plural), and `kubectl get customresourcedefinitions` (full
+		// plural). All three must hit the same canonical Kind.
+		{name: "kubectl short crd", query: "crd", want: "customresourcedefinition"},
+		{name: "kubectl short crds", query: "crds", want: "customresourcedefinition"},
+		{name: "plural customresourcedefinitions", query: "customresourcedefinitions", want: "customresourcedefinition"},
+		{name: "case-insensitive CRD", query: "CRD", want: "customresourcedefinition"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -201,6 +209,13 @@ func TestDefaultKinds_GraphAndDashboardSurface(t *testing.T) {
 		// Caught live on omantel iter-2: TC-122/196/199/248 returned 404
 		// "unknown kind" for the cluster-wide RBAC list.
 		"clusterrole", "clusterrolebinding",
+		// QA-loop iter-4 Fix #24 — apiextensions.k8s.io
+		// /customresourcedefinitions surfaced through /k8s/{kind}. The
+		// Sovereign Console's CRD inventory pane consumes this. Caught
+		// live on omantel iter-4: TC-199 returned HTTP 404 "unknown kind"
+		// because the GVR was never registered. Both the canonical
+		// singular AND the kubectl-short forms must resolve.
+		"customresourcedefinition",
 	}
 	for _, name := range mandatory {
 		if _, ok := r.Get(name); !ok {

--- a/products/catalyst/bootstrap/api/internal/k8scache/kinds.go
+++ b/products/catalyst/bootstrap/api/internal/k8scache/kinds.go
@@ -197,6 +197,26 @@ var DefaultKinds = []Kind{
 	// secret material — so Sensitive=false is correct.
 	{Name: "clusterrole", GVR: schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "clusterroles"}, Namespaced: false},
 	{Name: "clusterrolebinding", GVR: schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "clusterrolebindings"}, Namespaced: false},
+
+	// QA-loop iter-4 Fix #24 — CustomResourceDefinitions surfaced through
+	// GET /api/v1/sovereigns/{id}/k8s/customresourcedefinitions. The
+	// generic /k8s/ surface returned 404 "unknown kind" because the GVR
+	// for apiextensions.k8s.io/v1/customresourcedefinitions was never
+	// registered. Caught live on omantel.biz iter-4: TC-199 returned
+	// HTTP 404 with body
+	//   {"availableKinds":[…],"error":"unknown kind","kind":"customresourcedefinitions"}
+	// CRDs are cluster-scoped (Namespaced=false). The kind carries a
+	// schema definition + reconciliation rules — no secret material — so
+	// Sensitive=false is correct.
+	//
+	// Per feedback_chroot_in_cluster_fallback.md: every new GVR added
+	// here MUST get a matching rule on catalyst-api-cutover-driver
+	// ClusterRole (clusterrole-cutover-driver.yaml). The chroot
+	// SovereignClient uses that SA via in-cluster fallback. Read-only
+	// verbs only — the Sovereign Console renders CRD inventory; CRD
+	// install/uninstall happens through Flux + the blueprint catalog,
+	// not direct apiextensions writes.
+	{Name: "customresourcedefinition", GVR: schema.GroupVersionResource{Group: "apiextensions.k8s.io", Version: "v1", Resource: "customresourcedefinitions"}, Namespaced: false},
 }
 
 // Registry is a runtime-mutable lookup keyed by the short Name. It
@@ -249,6 +269,13 @@ var kindShortAliases = map[string]string{
 	"ing":    "ingress",
 	"ep":     "endpointslice",
 	"ev":     "event",
+	// QA-loop iter-4 Fix #24 — `kubectl get crd` and `kubectl get crds`
+	// are the conventional ergonomic forms operators reach for. The
+	// plural-alias index handles "customresourcedefinitions" naturally
+	// (trim-trailing-s rule); these short forms are not derivable so
+	// they live here.
+	"crd":    "customresourcedefinition",
+	"crds":   "customresourcedefinition",
 }
 
 // NewRegistry — start empty; callers pass DefaultKinds (or the loaded

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/InstallPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/InstallPage.tsx
@@ -149,10 +149,23 @@ export function InstallPage({ preselectedBlueprint }: InstallPageProps = {}) {
 
   return (
     <div className="p-6" data-testid="install-page">
+      {/*
+       * QA-loop iter-4 Fix #24 — heading renamed from "Install Blueprint"
+       * to "Install — Blueprint Catalog" so the page surfaces both the
+       * action verb ("Install") AND the noun for the surface the operator
+       * is looking at ("Catalog"). The matrix (TC-031) asserts both words
+       * are present, matching the EPIC-2 Slice I narrative — "/install is
+       * the live catalog landing" — and the file-level comment above which
+       * has always called this the "catalog landing". Without "Catalog" in
+       * the rendered DOM operators landing here cold can't tell whether
+       * they're on a catalog browser or a single-blueprint installer.
+       */}
       <div className="mb-4 flex items-baseline justify-between">
-        <h1 className="text-2xl font-semibold text-[var(--color-text)]">Install Blueprint</h1>
+        <h1 className="text-2xl font-semibold text-[var(--color-text)]" data-testid="install-page-heading">
+          Install — Blueprint Catalog
+        </h1>
         <span className="text-sm text-[var(--color-text-dim)]">
-          {catalogQuery.data?.length ?? 0} blueprints visible
+          {catalogQuery.data?.length ?? 0} blueprints in catalog
         </span>
       </div>
 

--- a/products/catalyst/chart/templates/clusterrole-cutover-driver.yaml
+++ b/products/catalyst/chart/templates/clusterrole-cutover-driver.yaml
@@ -325,3 +325,23 @@ rules:
   - apiGroups: ["rbac.authorization.k8s.io"]
     resources: ["clusterroles", "clusterrolebindings"]
     verbs: ["get", "list", "watch"]
+
+  # ───────────────────────────────────────────────────────────────
+  # QA-loop iter-4 Fix #24 — CustomResourceDefinitions surfaced
+  # through the /k8s/{kind} generic surface. The Sovereign Console's
+  # CRD inventory pane lists every installed CRD on the cluster
+  # (TC-199). Without this rule the in-cluster catalyst-api SA gets
+  # 403 from the apiserver on every dynamic-client list.list call
+  # against apiextensions.k8s.io.
+  #
+  # Per feedback_chroot_in_cluster_fallback.md every new GVR added
+  # to internal/k8scache/kinds.go DefaultKinds MUST get a matching
+  # rule in this ClusterRole — the chroot SovereignClient uses this
+  # SA via in-cluster fallback. Read-only verbs only — the Sovereign
+  # Console renders CRD inventory; CRD install/uninstall happens
+  # through Flux + the blueprint catalog (HelmRelease → CRD), not
+  # through direct apiextensions writes.
+  # ───────────────────────────────────────────────────────────────
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["get", "list", "watch"]


### PR DESCRIPTION
## QA-loop iter-4 Fix #24

Cluster: `crds-list-404-and-install-catalog-text`
Two small unrelated issues bundled — both scoped, isolated text/registry changes.

## Sub-A — TC-199 (CRDs list 404)

**Live reproduction on omantel.biz:**
```
GET /api/v1/sovereigns/sovereign-omantel.biz/k8s/customresourcedefinitions
HTTP 404
{"availableKinds":[…],"error":"unknown kind","kind":"customresourcedefinitions"}
```

**Root cause**: `apiextensions.k8s.io/v1/customresourcedefinitions` GVR was never added to `k8scache.DefaultKinds`. Fix #18 (qa-loop iter-3) added `clusterroles` + `clusterrolebindings` but CRDs were missed.

**Fix**:
- Register CRD GVR in `DefaultKinds` (cluster-scoped, non-sensitive).
- Add `crd` / `crds` short aliases — kubectl ergonomic forms.
- Add matching ClusterRole rule on `catalyst-api-cutover-driver` per `feedback_chroot_in_cluster_fallback.md` (chroot SovereignClient uses this SA via in-cluster fallback). Read-only verbs only.

## Sub-B — TC-031 (install page missing "Catalog")

`/install` rendered heading `Install Blueprint` + `N blueprints visible`. Matrix expected both `Install` AND `Catalog`.

**Decision**: content drift, not matrix drift. The file-level comment in `InstallPage.tsx` has called this the "catalog landing" since EPIC-2 Slice I (`/install — catalog landing (live useCatalog list)`). Rendering should match the contract.

**Fix**:
- Heading: `Install Blueprint` → `Install — Blueprint Catalog`.
- Count label: `N blueprints visible` → `N blueprints in catalog`.
- Add `data-testid="install-page-heading"` anchor for future matrix runs.

## Files changed

- `products/catalyst/bootstrap/api/internal/k8scache/kinds.go` — CRD GVR + short aliases
- `products/catalyst/bootstrap/api/internal/k8scache/k8scache_test.go` — registry tests + presence check
- `products/catalyst/chart/templates/clusterrole-cutover-driver.yaml` — RBAC for apiextensions.k8s.io
- `products/catalyst/bootstrap/ui/src/pages/sovereign/InstallPage.tsx` — Catalog text in heading

## Tests

- `go test ./internal/k8scache/ -count=1` — PASS (full suite)
- New cases: `TestRegistry_PluralAliasResolution` gains `crd`, `crds`, `customresourcedefinitions`, `CRD`. `TestDefaultKinds_GraphAndDashboardSurface` gains `customresourcedefinition`.

## Test plan (post-merge live verification)

- [ ] `GET /k8s/customresourcedefinitions` returns HTTP 200 with `kind:"crd"` + items envelope (TC-199)
- [ ] `/install` DOM contains both `Install` AND `Catalog` (TC-031)

🤖 Generated with [Claude Code](https://claude.com/claude-code)