### PR TITLE
fix(bp-keycloak): grant catalyst-api SA manage-realm + view-realm (qa-loop iter-4 Fix #23)

### DIFF
--- a/platform/keycloak/chart/Chart.yaml
+++ b/platform/keycloak/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-keycloak
-version: 1.4.0
+version: 1.4.1
 description: |
   Catalyst-curated Blueprint umbrella chart for Keycloak. Depends on the
   upstream `keycloak` chart (bitnami) as a Helm subchart so
@@ -20,6 +20,13 @@ description: |
   bp-wordpress-tenant / bp-openclaw / bp-stalwart-tenant charts consume
   via secretKeyRef. Sovereign-mode unchanged. Closes the chart-side gap
   left by orchestrator PR #911 (which already emits realmConfig.tenant.*).
+  1.4.1 (qa-loop iter-4 Fix #23): grant catalyst-api-server service-account
+  manage-realm + view-realm + view-clients on realm-management so the
+  EPIC-3 T2 tier-role bootstrap goroutine (KEYCLOAK_BOOTSTRAP_TIER_ROLES=
+  true) can materialize the catalog-tier realm-roles + composite chain
+  at catalyst-api startup. Without these, GET /admin/realms/<r>/roles/<n>
+  returned 403 and EnsureRealmRole gave up after 5 retries → TC-248
+  failure on the access-matrix UI.
 type: application
 keywords: [catalyst, blueprint, keycloak]
 maintainers:

--- a/platform/keycloak/chart/templates/configmap-sovereign-realm.yaml
+++ b/platform/keycloak/chart/templates/configmap-sovereign-realm.yaml
@@ -16,7 +16,13 @@ What this file emits
      values.yaml keycloak.keycloakConfigCli.existingConfigmap).
    - Defines the `sovereign` realm: catalyst-ui (PKCE), kubectl (public),
      catalyst-api-server (confidential service-account with realm-management
-     impersonate + manage-users + view-users + query-users role mappings).
+     impersonate + manage-users + view-users + query-users + manage-realm +
+     view-realm + view-clients role mappings — manage-realm/view-realm let
+     the catalyst-api EPIC-3 T2 tier-role bootstrap goroutine create the
+     catalyst-{viewer,developer,operator,admin,owner} realm-roles + composite
+     chain at startup; view-clients is needed to inspect the realm during
+     reconciliation. See products/catalyst/bootstrap/api/internal/keycloak/
+     realm_bootstrap.go for the bootstrap plan).
 
 2. Secret    catalyst-kc-sa-credentials (keycloak ns)
    - Mirrored cross-namespace into catalyst-system by emberstack/reflector
@@ -321,7 +327,7 @@ data:
         {
           "clientId": "catalyst-api-server",
           "name": "Catalyst API Server (service account)",
-          "description": "Confidential service-account client for catalyst-api. Holds impersonate + manage-users roles on realm-management so it can use token-exchange to mint user tokens for the seamless handover flow (issue #604).",
+          "description": "Confidential service-account client for catalyst-api. Holds impersonate + manage-users roles on realm-management for token-exchange (issue #604) AND manage-realm + view-realm + view-clients so the EPIC-3 T2 tier-role bootstrap (KEYCLOAK_BOOTSTRAP_TIER_ROLES=true, products/catalyst/bootstrap/api/internal/keycloak/realm_bootstrap.go) can materialize the catalyst-{viewer,developer,operator,admin,owner} realm-roles + composite chain (qa-loop iter-4 Fix #23).",
           "enabled": true,
           "publicClient": false,
           "standardFlowEnabled": false,
@@ -358,7 +364,10 @@ data:
               "impersonation",
               "manage-users",
               "view-users",
-              "query-users"
+              "query-users",
+              "manage-realm",
+              "view-realm",
+              "view-clients"
             ]
           }
         ]
@@ -373,7 +382,10 @@ data:
               "impersonation",
               "manage-users",
               "view-users",
-              "query-users"
+              "query-users",
+              "manage-realm",
+              "view-realm",
+              "view-clients"
             ]
           }
         }

--- a/products/catalyst/bootstrap/api/internal/keycloak/realm_bootstrap_test.go
+++ b/products/catalyst/bootstrap/api/internal/keycloak/realm_bootstrap_test.go
@@ -350,6 +350,54 @@ func TestEnsureTierRealmRoles_RoleCreate401_SurfacesError(t *testing.T) {
 	}
 }
 
+// ── Test 4b: GET role returns 403 (SA lacks view-realm/manage-realm)
+//
+// This is the qa-loop iter-4 Fix #23 regression test. On omantel the
+// catalyst-api-server SA in the sovereign realm only had
+// `impersonation+manage-users+view-users+query-users` on
+// realm-management. Phase 1 of EnsureTierRealmRoles starts with an
+// EnsureRealmRole on `catalyst-viewer`, which in turn does a
+// GetRealmRole — the underlying GET /admin/realms/<r>/roles/<n>
+// returns 403 Forbidden because the SA cannot read realm-roles.
+//
+// This test asserts the bootstrap surfaces a meaningful, debuggable
+// 403 error chain (so the operator can immediately spot the missing
+// realm-management roles in Keycloak) rather than masking it as a
+// generic "create failed".
+func TestEnsureTierRealmRoles_GetRole403_SurfacesPermissionError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Service-account token endpoint succeeds — the SA can
+		// authenticate, it just lacks realm-roles authorization.
+		if r.URL.Path == "/realms/test-realm/protocol/openid-connect/token" {
+			saTokenHandler(w)
+			return
+		}
+		// Every Admin-API call returns 403 Forbidden — same shape as
+		// Keycloak emits when the SA's client-roles on
+		// realm-management are insufficient.
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"error":"HTTP 403 Forbidden"}`))
+	}))
+	t.Cleanup(srv.Close)
+	client := NewWithHTTP(srv.URL, "test-realm", "catalyst-api-server", "sa-secret",
+		&http.Client{Timeout: 5 * time.Second})
+
+	err := client.EnsureTierRealmRoles(context.Background(), "test-realm")
+	if err == nil {
+		t.Fatal("expected EnsureTierRealmRoles to surface 403 error")
+	}
+	// The error chain must include both the role name (so the operator
+	// knows which step blew up) AND the 403 status (so they know it's
+	// a permissions issue, not a connectivity / 5xx issue).
+	msg := err.Error()
+	if !strings.Contains(msg, "catalyst-viewer") {
+		t.Errorf("expected error to mention failing role 'catalyst-viewer', got %v", err)
+	}
+	if !strings.Contains(msg, "403") {
+		t.Errorf("expected error to mention 403 status, got %v", err)
+	}
+}
+
 // ── Test 5: realm-mismatch is rejected at the API boundary. ───────────
 
 func TestEnsureTierRealmRoles_RealmMismatch_Rejects(t *testing.T) {


### PR DESCRIPTION
## Summary

- Root cause of TC-248 (catalyst-* realm-roles missing in Keycloak `sovereign` realm): the `catalyst-api-server` service-account had `impersonation+manage-users+view-users+query-users` on `realm-management` but was MISSING `manage-realm` + `view-realm`. The EPIC-3 T2 tier-role bootstrap goroutine (`KEYCLOAK_BOOTSTRAP_TIER_ROLES=true`, `products/catalyst/bootstrap/api/internal/keycloak/realm_bootstrap.go`) hit `GET /admin/realms/sovereign/roles/catalyst-viewer` → 403 Forbidden, gave up after 5 retries, and the catalog-tier realm-roles were never materialized.
- Adds `manage-realm` + `view-realm` + `view-clients` to BOTH `clientScopeMappings.realm-management` AND `users[].clientRoles.realm-management` in the sovereign realm import. Bumps `bp-keycloak` chart `1.4.0 → 1.4.1`.
- Adds `TestEnsureTierRealmRoles_GetRole403_SurfacesPermissionError` regression test (asserts the failing role name + 403 surface in the error chain so the next regression is one log line away from "missing realm-management role").

## Live verification on omantel

Runtime fix (assigned the missing roles to the live SA + restarted `catalyst-api`) before pushing the chart change:

```
kc-bootstrap: tier-role bootstrap converged (attempt 1, realm=sovereign)
```

```
$ curl /admin/realms/sovereign/roles | jq '.[].name'
catalyst-admin       composite=true   tier-level=40
catalyst-developer   composite=true   tier-level=20
catalyst-operator    composite=true   tier-level=30
catalyst-owner       composite=true   tier-level=50
catalyst-viewer      composite=false  tier-level=10
```

Composite chain: `owner → admin → operator → developer → viewer` (each parent composes its immediate child).

## Test plan

- [x] `go test ./internal/keycloak/...` — 9/9 PASS (8 existing + 1 new 403 regression test)
- [x] `go vet ./internal/keycloak/ ./cmd/api/` — clean
- [x] `helm lint platform/keycloak/chart` — `1 chart(s) linted, 0 chart(s) failed`
- [x] Live: catalyst-api on omantel converges bootstrap on attempt 1; sovereign realm contains all 5 catalyst-* roles + composite chain.
- [ ] Post-merge CI publishes `bp-keycloak:1.4.1` to GHCR; verified by re-running on a fresh Sovereign install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)