### PR TITLE
fix(chart): bp-catalyst-platform 1.4.96 -> 1.4.97 [Fix #24 follow-up]

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -246,7 +246,17 @@ spec:
       # found` — caught live on omantel 2026-05-09 attempting 1.4.84 ->
       # 1.4.95. Bump pin so omantel + every other Sovereign sourcing
       # this template picks up the fix on the next reconcile.
-      version: 1.4.96
+      # 1.4.97 (qa-loop iter-4 Fix #24): apiextensions.k8s.io/v1
+      # customresourcedefinitions GVR added to k8scache.DefaultKinds +
+      # matching get/list/watch verbs on catalyst-api-cutover-driver
+      # ClusterRole (TC-199). Pairs with UI heading rename "Install
+      # Blueprint" → "Install — Blueprint Catalog" (TC-031). Per
+      # feedback_chroot_in_cluster_fallback.md every new GVR added to
+      # k8scache.DefaultKinds MUST get a matching rule on the cutover-
+      # driver SA — the chroot SovereignClient uses this SA via
+      # in-cluster fallback. Bump pin so omantel + every other Sovereign
+      # sourcing this template picks up the fix on the next reconcile.
+      version: 1.4.97
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -1,5 +1,16 @@
 apiVersion: v2
 name: bp-catalyst-platform
+# 1.4.97 (qa-loop iter-4 Fix #24): apiextensions.k8s.io/v1
+# customresourcedefinitions GVR added to k8scache.DefaultKinds + matching
+# get/list/watch verbs on catalyst-api-cutover-driver ClusterRole. Fixes
+# TC-199 (CRDs list 404 — generic /k8s/{kind} surface returned "unknown
+# kind" because the CRD GVR was never registered). Pairs with the same-PR
+# UI heading rename "Install Blueprint" → "Install — Blueprint Catalog"
+# (TC-031 missing "Catalog" text). Per feedback_chroot_in_cluster_fallback.md
+# every new GVR added to k8scache.DefaultKinds MUST get a matching rule
+# in this ClusterRole — the chroot SovereignClient uses this SA via
+# in-cluster fallback.
+#
 # 1.4.96 (qa-loop iter-3 Fix #18 follow-up): exclude crds/tests/ from
 # the packaged chart via .helmignore. Helm's `crds/` directory installs
 # every YAML file inside as a CRD at the pre-render install hook,
@@ -189,7 +200,7 @@ name: bp-catalyst-platform
 # precedence so openbao auto-rotation of the source doesn't thrash the
 # controller pod. Caught live on omantel 2026-05-09 during qa-loop
 # iter-1 Executor run.
-version: 1.4.96
+version: 1.4.97
 appVersion: 1.4.94
 description: |
   Catalyst Platform — the unified Catalyst control plane umbrella chart for Catalyst-Zero.


### PR DESCRIPTION
Follow-up to #1212. Chart-template change (apiextensions.k8s.io ClusterRole rule on catalyst-api-cutover-driver) requires a chart version bump for Flux HelmController to apply the new template — without a version bump the OCI artifact at 1.4.96 was rebuilt with the new templates but Helm sees same version → no-op.

Bumps Chart.yaml 1.4.96 -> 1.4.97 + matching pin in `clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml` so omantel picks up the new ClusterRole on next reconcile.

Refs: TC-199, TC-031, qa-loop iter-4 Fix #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)