### PR TITLE
fix(ui): add HSTS + security headers to nginx (qa-loop iter-6 Cluster-E)

### DIFF
--- a/products/catalyst/bootstrap/ui/nginx.conf
+++ b/products/catalyst/bootstrap/ui/nginx.conf
@@ -7,10 +7,19 @@ server {
     absolute_redirect off;
     port_in_redirect off;
 
-    # Security headers
-    add_header X-Frame-Options "SAMEORIGIN" always;
+    # Security headers (qa-loop iter-6 Cluster-E: TC-017 + adjacent header coverage).
+    # HSTS: 1y + includeSubDomains + preload — TLS is mandatory for console.<sov>.
+    # CSP: 'unsafe-inline'/'unsafe-eval' on script-src is required by Vite/React-runtime
+    # bootstrap and Keycloak adapter; img/connect/font sources cover SSE (wss:),
+    # avatar URLs (data:/https:), and webfont assets.
+    # X-Frame-Options DENY: SPA is never legitimately framed (Keycloak login redirect
+    # is a top-level navigation, not an iframe); align with hardened-baseline.
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
+    add_header X-Frame-Options "DENY" always;
     add_header X-Content-Type-Options "nosniff" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; connect-src 'self' wss: https:; font-src 'self' data:; frame-ancestors 'none'; base-uri 'self'; form-action 'self' https:" always;
+    add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
 
     # Gzip
     gzip on;
@@ -36,12 +45,30 @@ server {
         proxy_read_timeout 300s;
         chunked_transfer_encoding on;
         add_header X-Accel-Buffering no;
+
+        # Re-emit security headers — nginx's add_header is inherited only when the
+        # current level defines NO add_header at all; declaring X-Accel-Buffering
+        # above shadows the server-level set, so we must restate them here.
+        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
+        add_header X-Frame-Options "DENY" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; connect-src 'self' wss: https:; font-src 'self' data:; frame-ancestors 'none'; base-uri 'self'; form-action 'self' https:" always;
+        add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
     }
 
     # Cache static assets
     location ~* \.(js|css|png|jpg|svg|woff2|ico)$ {
         expires 1y;
         add_header Cache-Control "public, immutable";
+
+        # Re-emit security headers (see /api/ comment for nginx inheritance rule).
+        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
+        add_header X-Frame-Options "DENY" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; connect-src 'self' wss: https:; font-src 'self' data:; frame-ancestors 'none'; base-uri 'self'; form-action 'self' https:" always;
+        add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
     }
 
     # SPA fallback — all routes serve index.html.


### PR DESCRIPTION
## Summary
- qa-loop iter-6 Cluster-E (Fix Author #30): TC-017 caught `/login` missing `Strict-Transport-Security` plus the rest of the hardened-baseline security header set.
- Adds HSTS, CSP, Permissions-Policy at the nginx server level; promotes `X-Frame-Options` from `SAMEORIGIN` to `DENY`.
- Re-emits the full set in `/api/` and the static-asset `location` because each already declares `add_header`, which shadows server-level inheritance per nginx semantics.

## Headers now emitted on `/login` (and elsewhere)
- `Strict-Transport-Security: max-age=31536000; includeSubDomains; preload`
- `X-Frame-Options: DENY`
- `X-Content-Type-Options: nosniff`
- `Referrer-Policy: strict-origin-when-cross-origin`
- `Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; connect-src 'self' wss: https:; font-src 'self' data:; frame-ancestors 'none'; base-uri 'self'; form-action 'self' https:`
- `Permissions-Policy: camera=(), microphone=(), geolocation=()`

## CSP rationale
- `'unsafe-inline'`/`'unsafe-eval'` on `script-src`: required by Vite/React runtime bootstrap and the Keycloak adapter — tightening to nonce-based is a follow-up.
- `connect-src wss: https:`: SSE log streams + Keycloak token endpoints.
- `img-src data: blob: https:`: avatar URLs, in-memory canvas exports.
- `frame-ancestors 'none'`: defence-in-depth alongside `X-Frame-Options: DENY`.

## Test plan
- [ ] CI green on this PR (lint + nginx config sanity in image build).
- [ ] After image roll on omantel: `curl -sS -k -I 'https://console.omantel.biz/login' | grep -iE "strict-transport|x-frame|x-content|referrer|content-security|permissions"` shows all six headers.
- [ ] Spot-check SPA still loads (no CSP violations in browser console for the dashboard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)