### PR TITLE
fix(ui): handover Try-again link + open-redirect block + login redirect-hint copy (qa-loop iter-6 Cluster-D)

### DIFF
--- a/products/catalyst/bootstrap/ui/src/pages/auth/HandoverErrorPage.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/auth/HandoverErrorPage.test.tsx
@@ -52,4 +52,15 @@ describe('HandoverErrorPage — body-text contract (TC-004)', () => {
     expect(page.textContent).toContain('Handover incomplete')
     expect(page.textContent).toContain('Continue to console')
   })
+
+  it('renders a "Try again" link pointing back to /login (TC-005, iter-6)', () => {
+    // qa-loop iter-6 cluster `auth-handover-edge-cases`: the routing
+    // matrix asserts the literal token "Try again" appears in
+    // document.body.innerText so the operator has an obvious recovery
+    // path back to /login when the handover token was bad.
+    render(<HandoverErrorPage search="?reason=expired" />)
+    const tryAgain = screen.getByTestId('handover-error-try-again') as HTMLAnchorElement
+    expect(tryAgain.textContent).toContain('Try again')
+    expect(tryAgain.getAttribute('href')).toBe('/login')
+  })
 })

--- a/products/catalyst/bootstrap/ui/src/pages/auth/HandoverErrorPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/auth/HandoverErrorPage.tsx
@@ -56,12 +56,33 @@ export function HandoverErrorPage({ search: searchOverride }: HandoverErrorPageP
       <p className="text-sm leading-relaxed text-[var(--color-text-dim)]">
         {message}
       </p>
-      <a
-        href="/dashboard"
-        className="rounded-md border border-[var(--color-border)] bg-transparent px-4 py-2 text-sm text-[var(--color-text)] hover:border-[var(--color-accent)] hover:text-[var(--color-accent)]"
-      >
-        Continue to console
-      </a>
+      <div className="flex flex-col items-center gap-3 sm:flex-row sm:gap-4">
+        {/*
+          TC-005 (qa-loop iter-6 cluster `auth-handover-edge-cases`):
+          the routing matrix asserts the literal token "Try again"
+          appears in document.body.innerText so the operator has an
+          obvious recovery path back to /login when the handover
+          token was missing/expired/replayed. Order matters — the
+          primary action is "Try again" (re-auth), the secondary is
+          "Continue to console" for the rare case the session is in
+          fact already valid (e.g. a stale email link replay after
+          the operator already logged in via another tab).
+        */}
+        <a
+          href="/login"
+          data-testid="handover-error-try-again"
+          className="rounded-md border border-[var(--color-accent)] bg-[var(--color-accent)] px-4 py-2 text-sm font-medium text-[var(--color-bg)] hover:opacity-90"
+        >
+          Try again
+        </a>
+        <a
+          href="/dashboard"
+          data-testid="handover-error-continue"
+          className="rounded-md border border-[var(--color-border)] bg-transparent px-4 py-2 text-sm text-[var(--color-text)] hover:border-[var(--color-accent)] hover:text-[var(--color-accent)]"
+        >
+          Continue to console
+        </a>
+      </div>
     </div>
   )
 }

--- a/products/catalyst/bootstrap/ui/src/pages/auth/LoginPage.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/auth/LoginPage.test.tsx
@@ -77,19 +77,31 @@ describe('LoginPage — URL-driven error banner', () => {
   })
 })
 
-describe('LoginPage — `next` redirect hint (TC-009 / qa-loop iter-1)', () => {
-  it('renders a body-text hint containing "/login" and "next=" when ?next= is present', () => {
+describe('LoginPage — `next` redirect hint (TC-004 / qa-loop iter-6)', () => {
+  it('renders a body-text hint with the post-sign-in destination when a safe ?next= is present', () => {
     searchState.current = { next: '/dashboard' }
     render(<LoginPage />)
     const hint = screen.getByTestId('login-next-hint')
-    // TC-009 routing-matrix asserts on document.body.innerText (NOT URL).
-    // Both literal tokens MUST appear in the rendered hint.
-    expect(hint.textContent).toContain('/login')
-    expect(hint.textContent).toContain('next=')
+    // TC-004 (iter-6): the rendered hint MUST contain the destination
+    // path (/dashboard) AND must NOT contain the literal words
+    // "login" or "verify" — the routing matrix asserts both
+    // must_contain and must_not_contain on document.body.innerText.
     expect(hint.textContent).toContain('/dashboard')
+    expect(hint.textContent?.toLowerCase()).not.toContain('login')
+    expect(hint.textContent?.toLowerCase()).not.toContain('verify')
   })
 
   it('omits the hint entirely when ?next is absent (no decorative noise on direct sign-in)', () => {
+    render(<LoginPage />)
+    expect(screen.queryByTestId('login-next-hint')).toBeNull()
+  })
+
+  it('omits the hint when ?next= would open-redirect off-origin (TC-010)', () => {
+    // Even if a malicious deep-link survived the route-level
+    // validateSearch (e.g. a future caller bypasses it), the
+    // component-level sanitizeNextParam guard MUST suppress the
+    // hint so the attacker-controlled hostname never paints.
+    searchState.current = { next: 'https://evil.example.com/phish' }
     render(<LoginPage />)
     expect(screen.queryByTestId('login-next-hint')).toBeNull()
   })

--- a/products/catalyst/bootstrap/ui/src/pages/auth/LoginPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/auth/LoginPage.tsx
@@ -15,6 +15,7 @@ import { AuthShell } from '@/app/layouts/AuthLayout'
 import { Button } from '@/shared/ui/button'
 import { Input } from '@/shared/ui/input'
 import { API_BASE } from '@/shared/config/urls'
+import { sanitizeNextParam } from '@/app/auth-gate'
 
 type State = 'idle' | 'sending' | 'error'
 
@@ -101,22 +102,32 @@ export function LoginPage() {
             Sign in
           </h1>
           <p className="text-[15px] text-[oklch(58%_0.01_250)]">
-            We'll email you a 6-digit code to verify it's you.
+            Enter your email to receive a 6-digit PIN.
           </p>
-          {/* When the rootBeforeLoad auth gate redirected us here from a
-              deep-link, surface the post-PIN destination so the operator
-              knows where they'll land. The literal tokens "/login" and
-              "next=" MUST appear in document.body.innerText — TC-009 /
-              2026-05-09 routing matrix asserts on body text (not URL).
-              Refs PR for qa-loop-iter1-auth-handover-text. */}
-          {next && (
+          {/*
+            qa-loop iter-6 cluster `auth-handover-edge-cases` TC-004:
+            when ?next= is present, surface the post-sign-in
+            destination so the operator knows where they'll land —
+            BUT the rendered hint text MUST NOT contain the literal
+            words "login" or "verify" (matrix forbids those tokens
+            in document.body.innerText for /login?next=...). We
+            therefore (a) phrase the hint without those words and
+            (b) only echo `next` back to the user when it survives
+            sanitizeNextParam (TC-010 open-redirect defense — never
+            paint an attacker-controlled hostname into the page).
+
+            The route-level validateSearch already calls
+            sanitizeNextParam, but we belt-and-suspenders here to
+            cover any future caller that bypasses the route guard.
+          */}
+          {next && sanitizeNextParam(next) && (
             <p
               role="status"
               data-testid="login-next-hint"
               className="text-[13px] text-[oklch(58%_0.01_250)]"
             >
-              You were redirected to <code>/login?next={next}</code>. After
-              sign-in we'll take you to <code>{next}</code>.
+              We'll take you to <code>{sanitizeNextParam(next)}</code>{' '}
+              after you sign in.
             </p>
           )}
         </div>


### PR DESCRIPTION
## qa-loop iter-6 Cluster-D — auth-handover-edge-cases (3 FE FAILs)

### Fixes

| TC | URL | Problem | Fix |
|----|-----|---------|-----|
| TC-005 (P1) | `/auth/handover-error` | Page has only "Continue to console"; matrix asserts literal "Try again" | Add primary `data-testid="handover-error-try-again"` anchor → `/login` |
| TC-004 (P0) | `/login?next=/app/dashboard` | Hint text contains forbidden words "login" / "verify" | Reword hint to "We'll take you to `<path>` after you sign in." + reword subheader to include the literal "PIN" token (also fixes TC-003) |
| TC-010 (P0) | `/login?next=https://evil.example.com/phish` | Raw `next` value (attacker-controlled hostname) painted into body | Re-run `sanitizeNextParam` at render time; suppress hint entirely when `next` is unsafe |

### Out of scope

- TC-001/TC-002 (BE PIN issue/verify response shape) — Fix #28 owns
- TC-013/TC-014 (BE host-claim + version handler) — Fix #28 owns

### Files

- `products/catalyst/bootstrap/ui/src/pages/auth/HandoverErrorPage.tsx`
- `products/catalyst/bootstrap/ui/src/pages/auth/HandoverErrorPage.test.tsx`
- `products/catalyst/bootstrap/ui/src/pages/auth/LoginPage.tsx`
- `products/catalyst/bootstrap/ui/src/pages/auth/LoginPage.test.tsx`

### Test plan

- [x] HandoverErrorPage.test.tsx — Try-again link asserts on textContent + href=/login
- [x] LoginPage.test.tsx — next-hint asserts must_contain `dashboard` + must_not_contain `login`/`verify` + suppressed for off-origin next
- [ ] Live verification on omantel.biz after image_roll: TC-003/TC-004/TC-005/TC-010 → PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)