### PR TITLE
fix(api): target-state response fields on /pin/issue + /version + /tenant/discover (qa-loop iter-6 Cluster-B)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/auth.go
+++ b/products/catalyst/bootstrap/api/internal/handler/auth.go
@@ -193,7 +193,16 @@ type pinIssueRequest struct {
 }
 
 type pinIssueResponse struct {
-	OK           bool   `json:"ok"`
+	// OK — legacy success flag retained for any existing UI/SDK that
+	// pins on it. New code SHOULD prefer Sent (matches the QA matrix +
+	// the wider OpenOva email-dispatch verb conventions).
+	OK bool `json:"ok"`
+	// Sent — true when the PIN email was successfully handed off to
+	// the SMTP relay. Mirrors OK at the same instant; added in
+	// qa-loop iter-6 (TC-001) so the response shape exposes the verb
+	// operators / monitoring recognise without removing the historical
+	// `ok` key.
+	Sent         bool   `json:"sent"`
 	RequestID    string `json:"requestId"`
 	ExpiresInSec int    `json:"expiresInSec"`
 }
@@ -318,6 +327,7 @@ func (h *Handler) HandlePinIssue(w http.ResponseWriter, r *http.Request) {
 
 	writeJSON(w, http.StatusOK, pinIssueResponse{
 		OK:           true,
+		Sent:         true,
 		RequestID:    requestID,
 		ExpiresInSec: int(pinTTL.Seconds()),
 	})
@@ -689,7 +699,7 @@ func (h *Handler) HandleAuthLogout(w http.ResponseWriter, r *http.Request) {
 	// In that case the UI just clears local state and stays on /login.
 	logoutURL := buildKeycloakLogoutURL(r)
 	writeJSON(w, http.StatusOK, map[string]any{
-		"ok":               true,
+		"ok":                true,
 		"keycloakLogoutURL": logoutURL,
 	})
 }

--- a/products/catalyst/bootstrap/api/internal/handler/auth_pin_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/auth_pin_test.go
@@ -89,6 +89,12 @@ func TestPinIssue_HappyPath(t *testing.T) {
 	if !body.OK {
 		t.Error("ok: got false want true")
 	}
+	// qa-loop iter-6 TC-001 — Sent flag must mirror OK so callers
+	// pinning on the canonical email-dispatch verb resolve the same
+	// way as legacy callers pinning on `ok`.
+	if !body.Sent {
+		t.Error("sent: got false want true (qa-loop iter-6 TC-001 contract)")
+	}
 	if body.RequestID == "" {
 		t.Error("requestId: got empty")
 	}
@@ -403,8 +409,8 @@ func TestPinVerify_ExpiredReturns410(t *testing.T) {
 func TestPinVerify_MalformedPINReturns400(t *testing.T) {
 	h := testPinSetup(t)
 	cases := []string{
-		`{"email":"op@example.com","pin":"abc123","requestId":"r"}`, // letters
-		`{"email":"op@example.com","pin":"12345","requestId":"r"}`,  // too short
+		`{"email":"op@example.com","pin":"abc123","requestId":"r"}`,  // letters
+		`{"email":"op@example.com","pin":"12345","requestId":"r"}`,   // too short
 		`{"email":"op@example.com","pin":"1234567","requestId":"r"}`, // too long
 	}
 	for _, b := range cases {

--- a/products/catalyst/bootstrap/api/internal/handler/tenant_discover.go
+++ b/products/catalyst/bootstrap/api/internal/handler/tenant_discover.go
@@ -25,6 +25,7 @@ package handler
 
 import (
 	"net/http"
+	"os"
 	"strings"
 
 	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/store"
@@ -34,12 +35,41 @@ import (
 // 200 OK. It is intentionally a public-safe subset of
 // store.TenantRegistration — the SME-admin admin-API URL (used by the
 // hook) is NOT exposed here.
+//
+// Fields added in qa-loop iter-6 TC-013 (DeploymentID, TenantHost,
+// Realm, OIDCIssuer) are camelCase aliases for the existing snake_case
+// keys so both legacy SPA bootstrap callers and the QA matrix's
+// target-state keyword set resolve against the same payload without a
+// breaking rename.
 type tenantDiscoverResponse struct {
-	Host             string            `json:"host"`
-	TenantID         string            `json:"tenant_id"`
-	TenantKind       store.TenantKind  `json:"tenant_kind"`
-	KeycloakRealmURL string            `json:"keycloak_realm_url"`
-	KeycloakClientID string            `json:"keycloak_client_id"`
+	Host             string           `json:"host"`
+	TenantID         string           `json:"tenant_id"`
+	TenantKind       store.TenantKind `json:"tenant_kind"`
+	KeycloakRealmURL string           `json:"keycloak_realm_url"`
+	KeycloakClientID string           `json:"keycloak_client_id"`
+
+	// DeploymentID — Sovereign deployment id this tenant resolves to.
+	// On a chroot Sovereign self-discovery branch this is the same id
+	// HandleSovereignSelf reports (synthesized as `sovereign-<fqdn>`
+	// when the orchestrator hasn't stamped CATALYST_SELF_DEPLOYMENT_ID
+	// yet). Required by qa-loop iter-6 TC-013.
+	DeploymentID string `json:"deploymentId,omitempty"`
+
+	// TenantHost — camelCase alias of Host. Same value; emitted as a
+	// separate key so the QA matrix's keyword assertion on
+	// "tenantHost" + "deploymentId" matches without breaking the
+	// legacy `host` consumer.
+	TenantHost string `json:"tenantHost,omitempty"`
+
+	// Realm — Keycloak realm name (the trailing path segment of
+	// KeycloakRealmURL). Convenience field for the SPA bootstrap path
+	// that needs the realm name without parsing the URL.
+	Realm string `json:"realm,omitempty"`
+
+	// OIDCIssuer — same value as KeycloakRealmURL; emitted under the
+	// canonical OIDC vocabulary so SPA / SDK code that bootstraps via
+	// `issuer` resolves directly.
+	OIDCIssuer string `json:"oidcIssuer,omitempty"`
 }
 
 // HandleTenantDiscover serves GET /api/v1/tenant/discover?host=<host>.
@@ -54,19 +84,14 @@ type tenantDiscoverResponse struct {
 // 200 → registered tenant (subset of TenantRegistration above).
 // 404 → host not in the registry.
 // 400 → both `?host=` AND r.Host are empty (only when an HTTP client
-//       elides the Host header entirely; conformant clients always
-//       send one).
+//
+//	elides the Host header entirely; conformant clients always
+//	send one).
+//
 // 503 → registry not wired (catalyst-api running without the store
-//       initialised; rare — only test/CI without a writable PVC).
+//
+//	initialised; rare — only test/CI without a writable PVC).
 func (h *Handler) HandleTenantDiscover(w http.ResponseWriter, r *http.Request) {
-	if h.tenantRegistry == nil {
-		writeJSON(w, http.StatusServiceUnavailable, map[string]string{
-			"error":  "tenant-registry-unavailable",
-			"detail": "catalyst-api was started without a tenant registry; /tenant/discover disabled",
-		})
-		return
-	}
-
 	host := strings.TrimSpace(r.URL.Query().Get("host"))
 	if host == "" {
 		// Fall back to the request's Host header (HTTP/1.1 Host:, or
@@ -75,6 +100,21 @@ func (h *Handler) HandleTenantDiscover(w http.ResponseWriter, r *http.Request) {
 		// originator's Host so this resolves to the tenant the operator
 		// actually visited.
 		host = strings.TrimSpace(r.Host)
+	}
+	// qa-loop iter-6 TC-013 — the matrix probes
+	// `?email=<addr>` (no `host=`) and expects the chroot to
+	// self-discover from the request authority. When the email param
+	// is set but host is still empty AFTER the Host fallback, that's
+	// fine — Host header always carries something in practice. The
+	// email is parsed for the domain only as a last-resort hint
+	// (the matrix's emrah.baysal@openova.io maps to no specific
+	// tenant; the chroot's SOVEREIGN_FQDN owns the response).
+	if host == "" {
+		if email := strings.TrimSpace(r.URL.Query().Get("email")); email != "" {
+			if at := strings.LastIndexByte(email, '@'); at >= 0 && at+1 < len(email) {
+				host = strings.TrimSpace(email[at+1:])
+			}
+		}
 	}
 	if host == "" {
 		writeBadRequest(w, "host-required", "?host= query parameter is required when the request carries no Host header")
@@ -87,6 +127,45 @@ func (h *Handler) HandleTenantDiscover(w http.ResponseWriter, r *http.Request) {
 		host = host[:i]
 	}
 
+	// ── Chroot self-discovery branch ────────────────────────────────────
+	//
+	// qa-loop iter-6 (TC-013) live failure on console.omantel.biz: the
+	// chroot's tenant registry is empty (the cutover orchestrator
+	// hasn't POSTed a TenantRegistration back to the Sovereign yet,
+	// and on BYO it never will). Without a fallback every visitor
+	// to /api/v1/tenant/discover sees 404 tenant-not-registered and
+	// the SPA bootstrap path can't resolve OIDC config.
+	//
+	// On a chroot we already KNOW which tenant we're serving — the
+	// Pod was launched with SOVEREIGN_FQDN env (canonical) and
+	// CATALYST_OTECH_FQDN (legacy alias) injected from the
+	// bp-catalyst-platform sovereign-fqdn ConfigMap. When the
+	// requested host matches that FQDN (or the conventional
+	// `console.<fqdn>` fronting), synthesize the discovery payload
+	// from the chroot's own config. The payload mirrors what the
+	// orchestrator WOULD have POSTed: realm `openova` (chart
+	// default), oidcIssuer `https://console.<fqdn>/auth/realms/openova`,
+	// deploymentId derived as `sovereign-<fqdn>` (matches
+	// HandleSovereignSelf's stable-id convention so the SPA's
+	// subsequent /sovereigns/{id}/* calls resolve to the same
+	// chroot k8s alias).
+	//
+	// This branch runs BEFORE the registry lookup so a chroot
+	// without tenantRegistry wired (test envs, early cutover) still
+	// returns 200 for its own host.
+	if resp, ok := chrootSelfDiscover(host); ok {
+		writeJSON(w, http.StatusOK, resp)
+		return
+	}
+
+	if h.tenantRegistry == nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]string{
+			"error":  "tenant-registry-unavailable",
+			"detail": "catalyst-api was started without a tenant registry; /tenant/discover disabled",
+		})
+		return
+	}
+
 	t, ok := h.tenantRegistry.Get(host)
 	if !ok {
 		writeJSON(w, http.StatusNotFound, map[string]string{
@@ -96,13 +175,88 @@ func (h *Handler) HandleTenantDiscover(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	realm := realmFromIssuer(t.KeycloakRealmURL)
 	writeJSON(w, http.StatusOK, tenantDiscoverResponse{
 		Host:             t.Host,
 		TenantID:         t.TenantID,
 		TenantKind:       t.TenantKind,
 		KeycloakRealmURL: t.KeycloakRealmURL,
 		KeycloakClientID: t.KeycloakClientID,
+		DeploymentID:     t.TenantID,
+		TenantHost:       t.Host,
+		Realm:            realm,
+		OIDCIssuer:       t.KeycloakRealmURL,
 	})
+}
+
+// chrootSelfDiscover returns a synthesized tenantDiscoverResponse
+// when `host` matches the chroot Sovereign's own FQDN (or the
+// `console.<fqdn>` fronting). Returns (zero, false) when this Pod is
+// not running as a chroot or the host doesn't match. Caller MUST
+// fall through to the normal registry lookup on false.
+//
+// The realm + clientID values mirror the bp-catalyst-platform chart
+// defaults baked into every Sovereign rollout: realm "openova",
+// client "catalyst-ui". A future BYO-realm Sovereign can override
+// via CATALYST_DISCOVERY_REALM / CATALYST_DISCOVERY_CLIENT_ID env
+// without changing this signature.
+func chrootSelfDiscover(host string) (tenantDiscoverResponse, bool) {
+	fqdn := strings.TrimSpace(os.Getenv("SOVEREIGN_FQDN"))
+	if fqdn == "" {
+		fqdn = strings.TrimSpace(os.Getenv("CATALYST_OTECH_FQDN"))
+	}
+	if fqdn == "" {
+		return tenantDiscoverResponse{}, false
+	}
+	h := strings.ToLower(host)
+	f := strings.ToLower(fqdn)
+	matches := h == f ||
+		h == "console."+f ||
+		strings.HasSuffix(h, "."+f)
+	if !matches {
+		return tenantDiscoverResponse{}, false
+	}
+	realm := envOrTrim("CATALYST_DISCOVERY_REALM", "openova")
+	clientID := envOrTrim("CATALYST_DISCOVERY_CLIENT_ID", "catalyst-ui")
+	// Issuer URL: chart convention is
+	// https://console.<fqdn>/auth/realms/<realm>. Override via
+	// CATALYST_DISCOVERY_ISSUER for non-default fronting.
+	issuer := envOrTrim("CATALYST_DISCOVERY_ISSUER", "https://console."+f+"/auth/realms/"+realm)
+	deploymentID := strings.TrimSpace(os.Getenv("CATALYST_SELF_DEPLOYMENT_ID"))
+	if deploymentID == "" {
+		// Match the stable-id convention from sovereign_self.go so
+		// downstream /sovereigns/{id}/* resolves to the same chroot
+		// k8s alias.
+		deploymentID = "sovereign-" + f
+	}
+	tenantHost := host
+	return tenantDiscoverResponse{
+		Host:             tenantHost,
+		TenantID:         deploymentID,
+		TenantKind:       store.TenantKindOTECH,
+		KeycloakRealmURL: issuer,
+		KeycloakClientID: clientID,
+		DeploymentID:     deploymentID,
+		TenantHost:       tenantHost,
+		Realm:            realm,
+		OIDCIssuer:       issuer,
+	}, true
+}
+
+// realmFromIssuer extracts the trailing realm segment from a Keycloak
+// realm URL (`https://.../auth/realms/<realm>`). Returns the URL
+// unchanged on no-match so the caller always has a non-empty realm
+// hint.
+func realmFromIssuer(issuer string) string {
+	if issuer == "" {
+		return ""
+	}
+	// Strip trailing slash for tolerance.
+	s := strings.TrimRight(issuer, "/")
+	if i := strings.LastIndexByte(s, '/'); i >= 0 && i+1 < len(s) {
+		return s[i+1:]
+	}
+	return s
 }
 
 // SetTenantRegistry wires a tenant registry into the Handler. Called

--- a/products/catalyst/bootstrap/api/internal/handler/tenant_discover_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/tenant_discover_test.go
@@ -1,0 +1,155 @@
+// tenant_discover_test.go — pins the chroot self-discovery + alias
+// fields added in qa-loop iter-6 TC-013.
+//
+// The contract under test:
+//
+//   - When SOVEREIGN_FQDN is set on the Pod env (chroot mode) and the
+//     incoming request asks for that FQDN (or `console.<fqdn>`, or any
+//     subdomain of <fqdn>), HandleTenantDiscover returns 200 with a
+//     synthesized payload that carries `deploymentId` + `tenantHost`
+//     containing the FQDN. The matrix's keyword assertion
+//     (`omantel.biz` + `deploymentId` for the omantel.biz chroot)
+//     resolves on this branch alone — the chroot's tenant registry is
+//     intentionally empty until the cutover orchestrator POSTs a
+//     TenantRegistration back, which on BYO domains never happens.
+//
+//   - The legacy snake_case keys (`host`, `tenant_id`,
+//     `keycloak_realm_url`) remain populated so older SPA bundles
+//     keep working unchanged.
+//
+//   - When SOVEREIGN_FQDN is unset (mothership mode) and the host
+//     does NOT match a registered tenant, the response is 404
+//     tenant-not-registered as before — the new branch never
+//     short-circuits the registry lookup for non-chroot hosts.
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestHandleTenantDiscover_ChrootSelfDiscovery_ByHost(t *testing.T) {
+	t.Setenv("SOVEREIGN_FQDN", "omantel.biz")
+
+	h := &Handler{}
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/tenant/discover?host=console.omantel.biz", nil)
+	w := httptest.NewRecorder()
+	h.HandleTenantDiscover(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body: %s)", w.Code, w.Body.String())
+	}
+	var resp tenantDiscoverResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.DeploymentID == "" {
+		t.Errorf("deploymentId: got empty, want non-empty (TC-013 contract)")
+	}
+	if !strings.Contains(resp.TenantHost, "omantel.biz") {
+		t.Errorf("tenantHost = %q, want substring omantel.biz", resp.TenantHost)
+	}
+	if !strings.Contains(resp.Host, "omantel.biz") {
+		t.Errorf("host = %q, want substring omantel.biz (legacy alias)", resp.Host)
+	}
+	if resp.Realm == "" {
+		t.Errorf("realm: got empty, want non-empty default")
+	}
+	if resp.OIDCIssuer == "" {
+		t.Errorf("oidcIssuer: got empty, want non-empty default")
+	}
+}
+
+// TestHandleTenantDiscover_ChrootSelfDiscovery_ByEmailParam covers the
+// matrix's TC-013 URL shape — `?email=<addr>` with no `?host=`. The
+// handler MUST fall back to the request's Host header (set by the
+// proxy chain to the tenant origin) so chroot self-discovery still
+// resolves.
+func TestHandleTenantDiscover_ChrootSelfDiscovery_HostHeaderFallback(t *testing.T) {
+	t.Setenv("SOVEREIGN_FQDN", "omantel.biz")
+
+	h := &Handler{}
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/tenant/discover?email=emrah.baysal@openova.io", nil)
+	req.Host = "console.omantel.biz"
+	w := httptest.NewRecorder()
+	h.HandleTenantDiscover(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body: %s)", w.Code, w.Body.String())
+	}
+	var resp tenantDiscoverResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.DeploymentID == "" {
+		t.Errorf("deploymentId: got empty, want non-empty")
+	}
+	if !strings.Contains(resp.TenantHost, "omantel.biz") {
+		t.Errorf("tenantHost = %q, want substring omantel.biz", resp.TenantHost)
+	}
+}
+
+// TestHandleTenantDiscover_DeploymentIDOverride pins that an
+// orchestrator-stamped CATALYST_SELF_DEPLOYMENT_ID env wins over the
+// `sovereign-<fqdn>` fallback so post-handover responses carry the
+// stable mothership-issued id.
+func TestHandleTenantDiscover_DeploymentIDOverride(t *testing.T) {
+	t.Setenv("SOVEREIGN_FQDN", "omantel.biz")
+	t.Setenv("CATALYST_SELF_DEPLOYMENT_ID", "dep-omantel-12345")
+
+	h := &Handler{}
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/tenant/discover?host=console.omantel.biz", nil)
+	w := httptest.NewRecorder()
+	h.HandleTenantDiscover(w, req)
+
+	var resp tenantDiscoverResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.DeploymentID != "dep-omantel-12345" {
+		t.Errorf("deploymentId = %q, want dep-omantel-12345 (env override)", resp.DeploymentID)
+	}
+}
+
+// TestHandleTenantDiscover_NonChrootHostStillRegistry confirms the
+// chroot branch is gated on host-matches-FQDN — a Pod with
+// SOVEREIGN_FQDN=omantel.biz that receives a discovery request for
+// some-other.example.com does NOT short-circuit; it falls through to
+// the registry path (which for an unwired registry returns 503
+// tenant-registry-unavailable, the legacy behaviour).
+func TestHandleTenantDiscover_NonChrootHostFallsThrough(t *testing.T) {
+	t.Setenv("SOVEREIGN_FQDN", "omantel.biz")
+
+	h := &Handler{}
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/tenant/discover?host=acme.example.com", nil)
+	w := httptest.NewRecorder()
+	h.HandleTenantDiscover(w, req)
+
+	// Registry is nil in this test; chroot branch did NOT match;
+	// fallthrough emits 503 tenant-registry-unavailable.
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503 (chroot branch must NOT swallow non-matching hosts; body=%s)", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "tenant-registry-unavailable") {
+		t.Errorf("body = %s, want tenant-registry-unavailable error", w.Body.String())
+	}
+}
+
+// TestRealmFromIssuer pins the helper's URL-trail extraction logic.
+func TestRealmFromIssuer(t *testing.T) {
+	cases := map[string]string{
+		"https://console.openova.io/auth/realms/openova":  "openova",
+		"https://console.openova.io/auth/realms/openova/": "openova",
+		"https://kc.example.com/realms/sme":               "sme",
+		"":                                                "",
+		"plainstring":                                     "plainstring",
+	}
+	for in, want := range cases {
+		if got := realmFromIssuer(in); got != want {
+			t.Errorf("realmFromIssuer(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/handler/version.go
+++ b/products/catalyst/bootstrap/api/internal/handler/version.go
@@ -37,6 +37,7 @@ import (
 	"os"
 	"runtime"
 	"strings"
+	"time"
 )
 
 // buildSHA / buildVersion / chartVersion are populated by the build
@@ -53,7 +54,20 @@ var (
 	buildSHA     = "dev"
 	buildVersion = "0.0.0"
 	chartVersion = ""
+	// buildTime — RFC3339 UTC timestamp of when the binary was linked.
+	// CI sets this via -ldflags="-X .../handler.buildTime=$(date -u +%Y-%m-%dT%H:%M:%SZ)".
+	// When the ldflag is unset the variable stays empty and the
+	// handler falls back to processStartTime (set at package init)
+	// so /version always returns a non-empty buildTime — the QA
+	// matrix (TC-014) requires the key to be present + parseable.
+	buildTime = ""
 )
+
+// processStartTime — captured once at package init so a /version
+// caller without ldflag-injected buildTime still gets a stable
+// timestamp instead of a per-request `time.Now()` (which would make
+// scrape-based monitoring see the field flap every poll).
+var processStartTime = time.Now().UTC().Format(time.RFC3339)
 
 // VersionResponse — wire shape of GET /api/v1/version.
 //
@@ -72,7 +86,16 @@ type VersionResponse struct {
 
 	// SHA — git commit the image was built from. Truthful resolution:
 	// CATALYST_BUILD_SHA env var > buildSHA ldflag > "dev".
+	// Retained as the legacy key; new callers SHOULD prefer GitSha
+	// (added qa-loop iter-6 to match the QA matrix TC-014 contract).
 	SHA string `json:"sha"`
+
+	// GitSha — alias of SHA stamped under the canonical
+	// camelCase-with-explicit-vcs name. Always equals SHA; emitted as a
+	// separate field rather than a remap so existing dashboards keyed
+	// on "sha" keep working in lockstep with new callers keyed on
+	// "gitSha". Required by qa-loop iter-6 TC-014.
+	GitSha string `json:"gitSha"`
 
 	// Version — semver of the release. Truthful resolution:
 	// CATALYST_BUILD_VERSION env var > buildVersion ldflag > "0.0.0".
@@ -82,6 +105,12 @@ type VersionResponse struct {
 	// or catalyst chart) responsible for this rollout. Set by the
 	// chart's deployment template via env if known.
 	ChartVersion string `json:"chartVersion,omitempty"`
+
+	// BuildTime — RFC3339 UTC timestamp the binary was linked.
+	// Resolution order: CATALYST_BUILD_TIME env > buildTime ldflag >
+	// processStartTime (computed once at package init). Always
+	// present + parseable per qa-loop iter-6 TC-014.
+	BuildTime string `json:"buildTime"`
 
 	// Go — runtime version (debug aid; e.g. "go1.26.0"). Useful when
 	// chasing a regression that correlates with a Go upgrade.
@@ -93,11 +122,18 @@ type VersionResponse struct {
 // Returns the running build's SHA + version. Always 200, always
 // JSON. No auth gate (probe-friendly).
 func (h *Handler) HandleVersion(w http.ResponseWriter, r *http.Request) {
+	sha := envOrTrim("CATALYST_BUILD_SHA", buildSHA)
+	bt := envOrTrim("CATALYST_BUILD_TIME", buildTime)
+	if bt == "" {
+		bt = processStartTime
+	}
 	resp := VersionResponse{
 		Service:      "catalyst-api",
-		SHA:          envOrTrim("CATALYST_BUILD_SHA", buildSHA),
+		SHA:          sha,
+		GitSha:       sha,
 		Version:      envOrTrim("CATALYST_BUILD_VERSION", buildVersion),
 		ChartVersion: envOrTrim("CATALYST_CHART_VERSION", chartVersion),
+		BuildTime:    bt,
 		Go:           runtime.Version(),
 	}
 	writeJSON(w, http.StatusOK, resp)

--- a/products/catalyst/bootstrap/api/internal/handler/version_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/version_test.go
@@ -40,6 +40,18 @@ func TestHandleVersion_AlwaysJSON(t *testing.T) {
 	if resp.Go == "" {
 		t.Errorf("Go must be non-empty (runtime.Version())")
 	}
+	// qa-loop iter-6 TC-014 — gitSha alias of sha must be present and
+	// equal; buildTime must be non-empty + RFC3339-parseable so any
+	// monitor can sort by it.
+	if resp.GitSha == "" {
+		t.Errorf("GitSha must be non-empty (mirror of SHA)")
+	}
+	if resp.GitSha != resp.SHA {
+		t.Errorf("GitSha=%q must equal SHA=%q (alias)", resp.GitSha, resp.SHA)
+	}
+	if resp.BuildTime == "" {
+		t.Errorf("BuildTime must be non-empty (fallback: processStartTime)")
+	}
 }
 
 // TestHandleVersion_EnvOverride asserts the env-var truth override
@@ -87,5 +99,30 @@ func TestHandleVersion_TrimsWhitespace(t *testing.T) {
 	}
 	if resp.SHA != "cafef00d" {
 		t.Errorf("SHA = %q, want cafef00d (trimmed)", resp.SHA)
+	}
+	if resp.GitSha != "cafef00d" {
+		t.Errorf("GitSha = %q, want cafef00d (trimmed mirror)", resp.GitSha)
+	}
+}
+
+// TestHandleVersion_BuildTimeEnvOverride pins that the chart-injected
+// CATALYST_BUILD_TIME wins over the processStartTime fallback. The QA
+// matrix (TC-014) expects the field to track the deployed image so
+// the operator can see "this Pod was linked at <ts>" without diffing
+// against `kubectl describe`.
+func TestHandleVersion_BuildTimeEnvOverride(t *testing.T) {
+	t.Setenv("CATALYST_BUILD_TIME", "2026-05-09T20:00:00Z")
+
+	h := &Handler{}
+	r := httptest.NewRequest(http.MethodGet, "/api/v1/version", nil)
+	w := httptest.NewRecorder()
+	h.HandleVersion(w, r)
+
+	var resp VersionResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("response is not JSON: %v", err)
+	}
+	if resp.BuildTime != "2026-05-09T20:00:00Z" {
+		t.Errorf("BuildTime = %q, want 2026-05-09T20:00:00Z (env override)", resp.BuildTime)
 	}
 }


### PR DESCRIPTION
## Summary

qa-loop iter-6 Cluster-B (api-contract-drift) — TC-001 / TC-013 / TC-014.

The matrix expects target-state response fields under names that catalyst-api currently emits under different keys. Founder rule: matrix is the contract, BE matches. This PR adds the missing keys ADDITIVELY so legacy callers keep working.

| TC | URL | Expected | Fix |
|---|---|---|---|
| TC-001 | POST `/api/v1/auth/pin/issue` | `must_contain: ["sent"]` | Add `"sent": true` alongside `"ok": true` |
| TC-014 | GET `/api/v1/version` | `must_contain: ["gitSha","buildTime"]` | Add `"gitSha"` (alias of `"sha"`) + `"buildTime"` (RFC3339 UTC, env > ldflag > processStartTime) |
| TC-013 | GET `/api/v1/tenant/discover?email=...` | `must_contain: ["omantel.biz","deploymentId"]` | Add chroot self-discovery branch keyed on `SOVEREIGN_FQDN`; synthesize `deploymentId` + `tenantHost` + `realm` + `oidcIssuer` when host matches |

## Live root-cause — TC-013

`console.omantel.biz/api/v1/tenant/discover?host=console.omantel.biz` was returning 404 `tenant-not-registered` because the chroot's tenant registry is empty (the cutover orchestrator never POSTs a `TenantRegistration` back to the Sovereign on BYO domains). The new branch reads `SOVEREIGN_FQDN` (canonical chroot identifier from the bp-catalyst-platform `sovereign-fqdn` ConfigMap) and, when the requested host matches that FQDN / `console.<fqdn>` / any subdomain, returns a synthesized payload that mirrors what the orchestrator WOULD have POSTed:

- `deploymentId`: `CATALYST_SELF_DEPLOYMENT_ID` env when stamped, else `sovereign-<fqdn>` (matches `HandleSovereignSelf` convention so `/api/v1/sovereigns/{id}/*` calls resolve to the same chroot k8s alias)
- `realm`: `CATALYST_DISCOVERY_REALM` env > `openova` (chart default)
- `oidcIssuer`: `CATALYST_DISCOVERY_ISSUER` env > `https://console.<fqdn>/auth/realms/<realm>`
- `keycloakClientID`: `CATALYST_DISCOVERY_CLIENT_ID` env > `catalyst-ui`

Self-discovery is gated on host-matches-FQDN so non-chroot Pods still fall through to the registry. Existing snake_case keys (`host`, `tenant_id`, `keycloak_realm_url`, `keycloak_client_id`, `tenant_kind`) remain populated for legacy SPA bundles.

## Files changed

- `products/catalyst/bootstrap/api/internal/handler/auth.go` — add `Sent` field to `pinIssueResponse`, stamp it `true` on success
- `products/catalyst/bootstrap/api/internal/handler/auth_pin_test.go` — assert `Sent==true` alongside `OK==true`
- `products/catalyst/bootstrap/api/internal/handler/version.go` — add `GitSha`, `BuildTime` fields; `processStartTime` package-init fallback
- `products/catalyst/bootstrap/api/internal/handler/version_test.go` — pin gitSha+buildTime presence + env override
- `products/catalyst/bootstrap/api/internal/handler/tenant_discover.go` — `chrootSelfDiscover` helper; `realmFromIssuer` helper; `?email=` parse fallback; new camelCase alias fields
- `products/catalyst/bootstrap/api/internal/handler/tenant_discover_test.go` (new) — 5 cases covering chroot-by-host, chroot-by-Host-header-with-`?email=`, deployment-id env override, non-chroot fallthrough preserves 503 legacy behaviour, `realmFromIssuer` table-test

## Test plan

- [x] CI go test — covered by added unit tests in version_test.go, auth_pin_test.go, tenant_discover_test.go
- [ ] Live verification on omantel.biz post-image-roll:
  - `curl /api/v1/version | jq` → `gitSha` + `buildTime` present
  - `curl -X POST /api/v1/auth/pin/issue` → response has `"sent": true`
  - `curl '/api/v1/tenant/discover?host=console.omantel.biz'` → 200 with `deploymentId` + `tenantHost: "console.omantel.biz"`

## Backwards compatibility

All changes are additive. Legacy `ok` / `sha` / `host` / `tenant_id` / etc. keys are untouched. The chroot self-discovery branch is gated on `SOVEREIGN_FQDN` env match — a mothership Pod (no SOVEREIGN_FQDN, no host match) takes the existing registry path unchanged.

Refs: qa-loop iter-6 Cluster-B (api-contract-drift) Fix #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)