### PR TITLE
fix(chart): qa-fixture seeder Job image (1.4.99 -> 1.4.100)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -265,7 +265,7 @@ spec:
       # ClusterRole to grant continuums/cnpgpairs/pdms verbs (TC-344).
       # Bp-crossplane-claims 1.1.2 carries the matching tier-operator
       # extras update.
-      version: 1.4.99
+      version: 1.4.100
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -214,7 +214,7 @@ name: bp-catalyst-platform
 # precedence so openbao auto-rotation of the source doesn't thrash the
 # controller pod. Caught live on omantel 2026-05-09 during qa-loop
 # iter-1 Executor run.
-version: 1.4.99
+version: 1.4.100
 appVersion: 1.4.94
 description: |
   Catalyst Platform — the unified Catalyst control plane umbrella chart for Catalyst-Zero.

--- a/products/catalyst/chart/templates/qa-fixtures/cnpgpair-qa.yaml
+++ b/products/catalyst/chart/templates/qa-fixtures/cnpgpair-qa.yaml
@@ -86,7 +86,7 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: seed
-          image: bitnami/kubectl:1.30
+          image: docker.io/bitnamilegacy/kubectl:1.29.3
           command: ["sh", "-c"]
           args:
             - |

--- a/products/catalyst/chart/templates/qa-fixtures/continuum-qa.yaml
+++ b/products/catalyst/chart/templates/qa-fixtures/continuum-qa.yaml
@@ -124,7 +124,7 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: seed
-          image: bitnami/kubectl:1.30
+          image: docker.io/bitnamilegacy/kubectl:1.29.3
           command: ["sh", "-c"]
           args:
             - |

--- a/products/catalyst/chart/templates/qa-fixtures/pdm-qa.yaml
+++ b/products/catalyst/chart/templates/qa-fixtures/pdm-qa.yaml
@@ -94,7 +94,7 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: seed
-          image: bitnami/kubectl:1.30
+          image: docker.io/bitnamilegacy/kubectl:1.29.3
           env:
             - name: PDNS_ZONE
               value: {{ .Values.qaFixtures.pdmZone | default "openova.io" | quote }}

--- a/products/catalyst/chart/templates/qa-fixtures/scheduledbackup-qa.yaml
+++ b/products/catalyst/chart/templates/qa-fixtures/scheduledbackup-qa.yaml
@@ -95,7 +95,7 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: seed
-          image: bitnami/kubectl:1.30
+          image: docker.io/bitnamilegacy/kubectl:1.29.3
           command: ["sh", "-c"]
           args:
             - |


### PR DESCRIPTION
## Summary
- 1.4.99 shipped the qa-fixture status-seeder Jobs with `bitnami/kubectl:1.30` which fails harbor.openova.io's proxy-docker auth (401).
- 1.4.100 switches to `docker.io/bitnamilegacy/kubectl:1.29.3` — already cached on omantel, pulls cleanly through Harbor.
- Unblocks iter-7 chart re-install on any Sovereign that flips qaFixtures.enabled=true.

## Test plan
- [x] CI publishes 1.4.100 chart artifact
- [x] live HR bumped to 1.4.100; helm hooks succeed; Continuum/CNPGPair/PDM/Backup status fields present without manual kubectl patch

🤖 Generated with [Claude Code](https://claude.com/claude-code)