### PR TITLE
fix(cnpg-pair tests): exclude helm-test hook resources from non-test count

### DIFF
--- a/platform/cnpg-pair/chart/tests/cnpg-pair-render.sh
+++ b/platform/cnpg-pair/chart/tests/cnpg-pair-render.sh
@@ -63,16 +63,40 @@ helm template smoke-cnpg-pair . \
 }
 
 # Expect 1×Cluster (primary) + 1×Cluster (replica) + 1×Deployment
-# (probe) + 3×NetworkPolicy + 1×ConfigMap = 7 kinds. The replication
-# Service is now CNPG-managed via primary.spec.managed.services.additional,
-# so it is NOT a kind in the rendered manifest.
-EXPECTED=7
-GOT=$(grep -cE "^kind: " "$TMP/enabled.yaml" || true)
-if [ "$GOT" -ne "$EXPECTED" ]; then
-  echo "FAIL: expected $EXPECTED resources, got $GOT." >&2
+# (probe) + 3×NetworkPolicy + 1×ConfigMap = 7 non-test kinds. The
+# replication Service is now CNPG-managed via the primary Cluster's
+# spec.managed.services.additional, so it is NOT a kind in the
+# rendered manifest. Helm-test resources (Pod + ServiceAccount + Role
+# + RoleBinding under templates/tests/) ARE rendered by `helm template`
+# but are filtered at install time by Helm's hook semantics; we
+# count them separately.
+EXPECTED_NONTEST=7
+EXPECTED_TEST=4
+if ! python3 - "$TMP/enabled.yaml" > "$TMP/render-counts" <<'PYEOF'
+import sys, yaml
+docs = list(yaml.safe_load_all(open(sys.argv[1])))
+docs = [d for d in docs if d]
+test = [d for d in docs if 'helm.sh/hook' in (d.get('metadata',{}).get('annotations') or {})]
+nontest = [d for d in docs if d not in test]
+print(f"NONTEST={len(nontest)}")
+print(f"TEST={len(test)}")
+PYEOF
+then
+  echo "FAIL: helm template output failed to parse as YAML" >&2
+  exit 1
+fi
+NONTEST=$(grep -E '^NONTEST=' "$TMP/render-counts" | cut -d= -f2)
+TEST=$(grep -E '^TEST=' "$TMP/render-counts" | cut -d= -f2)
+if [ "$NONTEST" -ne "$EXPECTED_NONTEST" ]; then
+  echo "FAIL: expected $EXPECTED_NONTEST non-test resources, got $NONTEST." >&2
   grep -E "^kind: " "$TMP/enabled.yaml" >&2
   exit 1
 fi
+if [ "$TEST" -ne "$EXPECTED_TEST" ]; then
+  echo "FAIL: expected $EXPECTED_TEST helm-test resources, got $TEST." >&2
+  exit 1
+fi
+GOT="$NONTEST non-test + $TEST test"
 
 # Spot-check a few load-bearing assertions:
 grep -q "kind: Cluster" "$TMP/enabled.yaml" || {
@@ -182,7 +206,17 @@ if [ "$SERVICES" -ne 0 ]; then
   echo "FAIL: clusterMesh disabled but standalone Service still rendered." >&2
   exit 1
 fi
-if grep -q 'service.cilium.io/global' "$TMP/nomesh.yaml"; then
+# Strip comment lines + helm-test resources before checking for the
+# annotation; the helm-test Pod's command body contains the literal
+# string "service.cilium.io/global" as part of an assertion message,
+# which would otherwise false-positive.
+python3 - "$TMP/nomesh.yaml" > "$TMP/nomesh-nontest.yaml" <<'PYEOF'
+import sys, yaml
+docs = list(yaml.safe_load_all(open(sys.argv[1])))
+nontest = [d for d in docs if d and 'helm.sh/hook' not in (d.get('metadata',{}).get('annotations') or {})]
+print(yaml.safe_dump_all(nontest))
+PYEOF
+if sed 's/#.*//' "$TMP/nomesh-nontest.yaml" | grep -q 'service\.cilium\.io/global'; then
   echo "FAIL: clusterMesh disabled but service.cilium.io/global annotation still rendered." >&2
   exit 1
 fi


### PR DESCRIPTION
Follow-up to #1223. The chart 0.1.1 added templates/tests/test-replication.yaml (helm-test Pod + ServiceAccount + Role + RoleBinding) which \`helm template\` renders unconditionally. The render-gate test was counting those into EXPECTED=7 producing GOT=11 in CI.

## Fixes

- Switch to a python+yaml split that counts non-test resources (helm.sh/hook annotation absent) and helm-test resources separately. Both are asserted against fixed counts so a future regression that drops the test Pod or grows the non-test set would still fail.
- Case 5 false-positive: the helm-test Pod's command body contains the literal string \`service.cilium.io/global=true\` as part of an assertion error message; strip helm-test docs out before the comment-stripped grep.

## Test plan

- [x] \`bash platform/cnpg-pair/chart/tests/cnpg-pair-render.sh\` PASS locally (all 5 cases)
- [ ] CI Blueprint Release builds bp-cnpg-pair@0.1.1 to GHCR

🤖 Generated with [Claude Code](https://claude.com/claude-code)