### PR TITLE
feat(infra,cilium): wire Cilium ClusterMesh anchors via tofu→cloudinit→envsubst (#1101)

### DIFF
--- a/clusters/_template/bootstrap-kit/01-cilium.yaml
+++ b/clusters/_template/bootstrap-kit/01-cilium.yaml
@@ -80,6 +80,42 @@ spec:
           enabled: false
         ui:
           enabled: false
+
+      # ── Cilium ClusterMesh — multi-region peering ──────────────────
+      #
+      # Per ADR-0001 §9 + EPIC-6 #1101 (multi-region active-hotstandby DR),
+      # ClusterMesh is the canonical inter-region transport for replication
+      # and Service-of-type-global traffic between Sovereign peer clusters.
+      #
+      # cluster.name + cluster.id are PER-SOVEREIGN anchors; per
+      # docs/INVIOLABLE-PRINCIPLES.md #4 (never hardcode), they MUST come
+      # from the Flux Kustomization's postBuild.substitute block — which
+      # in turn flows from infra/hetzner/cloudinit-control-plane.tftpl
+      # (CLUSTER_MESH_NAME, CLUSTER_MESH_ID) and ultimately from the
+      # operator-supplied request.cluster_mesh_name + cluster_mesh_id at
+      # provision time. Mesh registry: docs/CLUSTERMESH-CLUSTER-IDS.md
+      # tracks the cluster.id allocation across the OpenOva fleet.
+      #
+      # NodePort 32379: clustermesh-apiserver Pod is exposed on every
+      # Cilium node so peers reach it over the Hetzner private network on
+      # `<cp-private-ip>:32379` WITHOUT requiring a Hetzner LoadBalancer
+      # per peer (LB count is project-quota'd). Hetzner firewall must
+      # open 32379/tcp from peer Sovereigns' Hetzner CIDRs.
+      #
+      # A Sovereign that does NOT join a mesh leaves CLUSTER_MESH_NAME
+      # empty (Flux envsubst rule: ${VAR:=default} -> "default" when
+      # unset/empty). The cilium subchart accepts an empty cluster.name
+      # provided cluster.id stays 0; the clustermesh-apiserver Pod still
+      # runs but no peer connects (single-cluster no-op).
+      cluster:
+        name: ${CLUSTER_MESH_NAME:=}
+        id: ${CLUSTER_MESH_ID:=0}
+      clustermesh:
+        useAPIServer: true
+        apiserver:
+          service:
+            type: NodePort
+            nodePort: 32379
 ---
 # ─── Per-Sovereign Gateway API resources (issue #387) ────────────────────
 #

--- a/infra/hetzner/cloudinit-control-plane.tftpl
+++ b/infra/hetzner/cloudinit-control-plane.tftpl
@@ -908,6 +908,20 @@ write_files:
             # explicit list: single-zone array derived from
             # sovereign_fqdn (rendered in main.tf via coalesce()).
             PARENT_DOMAINS_YAML: '${parent_domains_yaml}'
+            # Cilium ClusterMesh per-Sovereign anchors (#1101 EPIC-6).
+            # Empty string + 0 = not joined to any mesh (single-cluster
+            # Sovereign); set to the registered values from
+            # docs/CLUSTERMESH-CLUSTER-IDS.md when the operator joins
+            # this Sovereign to a multi-region mesh. The bootstrap-kit
+            # cilium HelmRelease consumes via ${CLUSTER_MESH_NAME} +
+            # ${CLUSTER_MESH_ID} envsubst placeholders. Per
+            # docs/INVIOLABLE-PRINCIPLES.md #4 (never hardcode), the
+            # operator-supplied request.cluster_mesh_name +
+            # cluster_mesh_id flow through tofu vars
+            # cluster_mesh_name/cluster_mesh_id (variables.tf) into this
+            # template at provision time.
+            CLUSTER_MESH_NAME: "${cluster_mesh_name}"
+            CLUSTER_MESH_ID: "${cluster_mesh_id}"
       ---
       apiVersion: kustomize.toolkit.fluxcd.io/v1
       kind: Kustomization

--- a/infra/hetzner/cloudinit-control-plane.tftpl
+++ b/infra/hetzner/cloudinit-control-plane.tftpl
@@ -913,9 +913,10 @@ write_files:
             # Sovereign); set to the registered values from
             # docs/CLUSTERMESH-CLUSTER-IDS.md when the operator joins
             # this Sovereign to a multi-region mesh. The bootstrap-kit
-            # cilium HelmRelease consumes via ${CLUSTER_MESH_NAME} +
-            # ${CLUSTER_MESH_ID} envsubst placeholders. Per
-            # docs/INVIOLABLE-PRINCIPLES.md #4 (never hardcode), the
+            # cilium HelmRelease consumes via $${CLUSTER_MESH_NAME} +
+            # $${CLUSTER_MESH_ID} envsubst placeholders (the $$ escape
+            # is required so tofu does NOT treat them as tftpl vars).
+            # Per docs/INVIOLABLE-PRINCIPLES.md #4 (never hardcode), the
             # operator-supplied request.cluster_mesh_name +
             # cluster_mesh_id flow through tofu vars
             # cluster_mesh_name/cluster_mesh_id (variables.tf) into this

--- a/infra/hetzner/main.tf
+++ b/infra/hetzner/main.tf
@@ -192,6 +192,35 @@ locals {
     k => format("10.0.%d.0/24", 10 + index(keys(local.secondary_regions), k))
   }
 
+  # Per-secondary-region Cilium ClusterMesh peer anchors (#1101 EPIC-6).
+  # Auto-derive cluster.name as `<sovereign-stem>-<region-code-no-digits>`
+  # (e.g. omantel + hel1 -> omantel-hel) when the operator left
+  # var.cluster_mesh_name empty, OR honour the explicit override per
+  # region (RegionSpec.cluster_mesh_name when present).  cluster.id is
+  # derived as `var.cluster_mesh_id + 1 + index(secondary_regions, k)`
+  # so the primary region keeps id=cluster_mesh_id and each peer claims
+  # the next free id within the mesh — matching the registry convention
+  # in docs/CLUSTERMESH-CLUSTER-IDS.md (mesh-omantel: fsn=1, hel=2, ...).
+  # When var.cluster_mesh_name is empty AND there are no secondary
+  # regions, the peer name remains empty (single-cluster Sovereign).
+  secondary_region_cluster_mesh_name = {
+    for k, r in local.secondary_regions :
+    k => coalesce(
+      try(r.clusterMeshName, ""),
+      var.cluster_mesh_name == "" ? "" : format(
+        "%s-%s",
+        split(".", var.sovereign_fqdn)[0],
+        replace(r.cloudRegion, "/[0-9]+/", "")
+      )
+    )
+  }
+  secondary_region_cluster_mesh_id = {
+    for k, _ in local.secondary_regions :
+    k => var.cluster_mesh_id == 0 ? 0 : (
+      var.cluster_mesh_id + 1 + index(keys(local.secondary_regions), k)
+    )
+  }
+
   # Per-secondary-region first-IP for control plane. Mirrors the legacy
   # singular path's "10.0.1.2" — first usable host of the subnet. Workers
   # in the same region count up from .10 within their own subnet.
@@ -274,6 +303,8 @@ locals {
     sovereign_fqdn      = var.sovereign_fqdn
     sovereign_subdomain = var.sovereign_subdomain
     marketplace_enabled = var.marketplace_enabled
+    cluster_mesh_name   = var.cluster_mesh_name
+    cluster_mesh_id     = var.cluster_mesh_id
 
     # Multi-domain Sovereign (issue #827). When the wizard supplies an
     # explicit parent-domain list, use it verbatim. Otherwise default to a
@@ -707,6 +738,11 @@ locals {
       sovereign_fqdn      = var.sovereign_fqdn
       sovereign_subdomain = var.sovereign_subdomain
       marketplace_enabled = var.marketplace_enabled
+      # Per-secondary-region ClusterMesh anchors. id is incremented per
+      # peer index so each secondary region gets a unique slot in the
+      # mesh registry; primary region keeps var.cluster_mesh_id.
+      cluster_mesh_name = local.secondary_region_cluster_mesh_name[k]
+      cluster_mesh_id   = local.secondary_region_cluster_mesh_id[k]
       parent_domains_yaml = coalesce(
         var.parent_domains_yaml,
         format("[{name: \"%s\", role: \"primary\"}]", var.sovereign_fqdn)

--- a/infra/hetzner/main.tf
+++ b/infra/hetzner/main.tf
@@ -203,10 +203,13 @@ locals {
   # in docs/CLUSTERMESH-CLUSTER-IDS.md (mesh-omantel: fsn=1, hel=2, ...).
   # When var.cluster_mesh_name is empty AND there are no secondary
   # regions, the peer name remains empty (single-cluster Sovereign).
+  # `coalesce` is intentionally NOT used here: it errors when every
+  # argument is empty (e.g. tofu test mock with var.cluster_mesh_name="").
+  # The conditional yields "" when both the per-region override AND the
+  # umbrella var are empty (the not-in-mesh path).
   secondary_region_cluster_mesh_name = {
     for k, r in local.secondary_regions :
-    k => coalesce(
-      try(r.clusterMeshName, ""),
+    k => try(r.clusterMeshName, "") != "" ? r.clusterMeshName : (
       var.cluster_mesh_name == "" ? "" : format(
         "%s-%s",
         split(".", var.sovereign_fqdn)[0],

--- a/infra/hetzner/variables.tf
+++ b/infra/hetzner/variables.tf
@@ -55,6 +55,31 @@ variable "parent_domains_yaml" {
   default     = ""
 }
 
+# Cilium ClusterMesh per-Sovereign anchors (#1101 EPIC-6 multi-region DR).
+# Empty + 0 = not joined to any mesh (single-cluster Sovereign — the chart
+# still installs the clustermesh-apiserver Pod but no peer connects). When
+# the operator joins this Sovereign to a multi-region mesh (e.g. omantel-fsn
+# + omantel-hel), set both to the registered values from
+# docs/CLUSTERMESH-CLUSTER-IDS.md. Per docs/INVIOLABLE-PRINCIPLES.md #4
+# (never hardcode), the values flow operator-request → catalyst-api
+# Request.ClusterMeshName/ClusterMeshID → tofu vars → cloudinit
+# postBuild.substitute → bootstrap-kit slot 01-cilium.yaml.
+variable "cluster_mesh_name" {
+  type        = string
+  description = "Cilium ClusterMesh peer name for this Sovereign (e.g. omantel-fsn). Empty = not in a mesh. Convention: <sovereign-stem>-<region-code>. Allocated via docs/CLUSTERMESH-CLUSTER-IDS.md."
+  default     = ""
+}
+
+variable "cluster_mesh_id" {
+  type        = number
+  description = "Cilium ClusterMesh peer id (1-255 unique within a mesh; 0 reserved for not-in-mesh). Allocated via docs/CLUSTERMESH-CLUSTER-IDS.md — every PR adding a new peer MUST claim a row in that registry."
+  default     = 0
+  validation {
+    condition     = var.cluster_mesh_id >= 0 && var.cluster_mesh_id <= 255
+    error_message = "cluster_mesh_id must be 0 (not-in-mesh) or 1-255 (peer id)."
+  }
+}
+
 variable "org_name" {
   type        = string
   description = "Organisation name for resource labels + initial sovereign-admin Org name"

--- a/products/catalyst/bootstrap/api/internal/provisioner/provisioner.go
+++ b/products/catalyst/bootstrap/api/internal/provisioner/provisioner.go
@@ -160,6 +160,16 @@ type RegionSpec struct {
 	ControlPlaneSize string `json:"controlPlaneSize"`
 	WorkerSize       string `json:"workerSize"`
 	WorkerCount      int    `json:"workerCount"`
+
+	// ClusterMeshName — Cilium ClusterMesh peer name override for this
+	// secondary region. Empty = auto-derive as
+	// `<sovereign-stem>-<region-code-no-digits>` (e.g. omantel + hel1
+	// -> omantel-hel) when the umbrella Request.ClusterMeshName is set.
+	// Allocated via docs/CLUSTERMESH-CLUSTER-IDS.md. Per
+	// docs/INVIOLABLE-PRINCIPLES.md #4 (never hardcode), the operator
+	// MAY override per-region when the auto-derive convention conflicts
+	// with an existing peer name in the registry.
+	ClusterMeshName string `json:"clusterMeshName,omitempty"`
 }
 
 // Request carries the wizard inputs the OpenTofu module needs.
@@ -217,6 +227,20 @@ type Request struct {
 	// — operator opts in via wizard's "Enable Marketplace" component
 	// checkbox.
 	MarketplaceEnabled bool `json:"marketplaceEnabled"`
+
+	// ClusterMeshName + ClusterMeshID — Cilium ClusterMesh per-Sovereign
+	// peer anchors (#1101 EPIC-6 multi-region DR). Both empty/zero =
+	// single-cluster Sovereign (not in a mesh). When set, must match the
+	// allocation in docs/CLUSTERMESH-CLUSTER-IDS.md (every PR that adds
+	// a new peer claims a row in that registry). Threaded through:
+	// catalyst-api Request → tofu vars cluster_mesh_name/cluster_mesh_id
+	// → cloudinit postBuild.substitute (CLUSTER_MESH_NAME / CLUSTER_MESH_ID)
+	// → bootstrap-kit slot 01-cilium.yaml's spec.values.cilium.cluster.{name,id}.
+	// Per docs/INVIOLABLE-PRINCIPLES.md #4 (never hardcode), there is NO
+	// chart-side default — operator request OR per-Sovereign overlay must
+	// supply the values when ClusterMesh is enabled.
+	ClusterMeshName string `json:"clusterMeshName,omitempty"`
+	ClusterMeshID   int    `json:"clusterMeshId,omitempty"`
 
 	// Per-region sizing payload — canonical from the per-provider rework
 	// onwards. The wizard always emits this. Multi-region tofu wiring is
@@ -1126,6 +1150,11 @@ func writeTfvars(deployDir string, req Request) error {
 		// Kustomization postBuild.substitute block at cloud-init render
 		// time without quoting surprises.
 		"marketplace_enabled": map[bool]string{true: "true", false: "false"}[req.MarketplaceEnabled],
+
+		// Cilium ClusterMesh per-Sovereign peer anchors (#1101 EPIC-6).
+		// Empty + 0 = not in a mesh. Tofu validates id ∈ [0, 255].
+		"cluster_mesh_name": req.ClusterMeshName,
+		"cluster_mesh_id":   req.ClusterMeshID,
 
 		// Hetzner — token gets baked into the state file unless the operator
 		// configures a remote backend with encryption-at-rest. Per Catalyst


### PR DESCRIPTION
Follow-up to #1223. The Flux Kustomization on every Sovereign points at \`clusters/_template/bootstrap-kit/\` and post-build-substitutes per-Sovereign vars. The per-Sovereign overlay file at \`clusters/<sov>/bootstrap-kit/01-cilium.yaml\` that #1223 added is therefore dead code (Flux doesn't read that path). The canonical mechanism is to extend the template with envsubst placeholders + thread the values through tofu vars.

## Layers wired end-to-end

1. \`clusters/_template/bootstrap-kit/01-cilium.yaml\` — \`cluster.name: \${CLUSTER_MESH_NAME:=}\`, \`cluster.id: \${CLUSTER_MESH_ID:=0}\`, \`clustermesh.useAPIServer: true\`, NodePort 32379.
2. \`infra/hetzner/cloudinit-control-plane.tftpl\` — adds CLUSTER_MESH_NAME / CLUSTER_MESH_ID to the bootstrap-kit Kustomization's \`postBuild.substitute\` block.
3. \`infra/hetzner/variables.tf\` — declares cluster_mesh_name (string) and cluster_mesh_id (number, validated 0-255).
4. \`infra/hetzner/main.tf\` — primary cloud-init passes var.cluster_mesh_{name,id} verbatim; secondary regions auto-derive each peer's name + increment id, per-region override via new RegionSpec.ClusterMeshName.
5. \`products/catalyst/bootstrap/api/internal/provisioner/provisioner.go\` — adds ClusterMeshName + ClusterMeshID to Request, threads them into writeTfvars(); RegionSpec gains ClusterMeshName.

Per \`docs/INVIOLABLE-PRINCIPLES.md\` #4 (never hardcode), the chart-side default is intentionally empty — operator request OR per-Sovereign overlay must supply values when ClusterMesh is enabled. Registry: \`docs/CLUSTERMESH-CLUSTER-IDS.md\` (introduced in #1223).

## Test plan

- [x] \`tofu validate\` on infra/hetzner — vars validation passes
- [ ] CI tofu validate workflow GREEN
- [ ] Live verification on omantel-fsn: patch the live Kustomization with CLUSTER_MESH_NAME=omantel-fsn / CLUSTER_MESH_ID=1 to test envsubst flow without re-provisioning

Refs: #1101 (EPIC-6), qa-loop iter-6 fix-33 follow-up to #1223

🤖 Generated with [Claude Code](https://claude.com/claude-code)