### PR TITLE
fix(catalyst-api): widen handlers to accept canonical UAT matrix vocabulary

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/applications.go
+++ b/products/catalyst/bootstrap/api/internal/handler/applications.go
@@ -113,6 +113,35 @@ type applicationPlacement struct {
 
 // applicationInstallRequest is the body of POST
 // /api/v1/sovereigns/{id}/applications.
+//
+// Two equivalent body shapes are accepted (per
+// `feedback_no_mvp_no_workarounds.md` — the matrix is the canonical
+// contract; the handler conforms):
+//
+//  1. Long form (production internal callers):
+//     { "blueprintRef": {"name":"bp-x","version":"1.0"},
+//     "name":"app", "organizationRef":"org",
+//     "environmentRef":"org-prod",
+//     "parameters":{...},
+//     "placement":{"mode":"single-region","regions":["fsn1"]} }
+//
+//  2. Short form (canonical UAT matrix + ergonomic CLI):
+//     { "blueprint":"bp-x", "version":"1.0",
+//     "namespace":"qa-omantel", "name":"app",
+//     "values":{...} }
+//
+// The short-form fields collapse onto the long-form via
+// applicationInstallRequestNormalize:
+//
+//	blueprint  → BlueprintRef.Name
+//	version    → BlueprintRef.Version
+//	namespace  → OrganizationRef (one Org per Sovereign in EPIC-2)
+//	values     → Parameters
+//
+// EnvironmentRef defaults to "<org>-prod" when omitted (matches the
+// matrix's omission). Placement defaults to single-region with a
+// "primary" sentinel that the validator surfaces as a clear 400 if
+// the caller forgot to set regions[].
 type applicationInstallRequest struct {
 	BlueprintRef    applicationBlueprintRef `json:"blueprintRef"`
 	Name            string                  `json:"name"`
@@ -120,6 +149,45 @@ type applicationInstallRequest struct {
 	EnvironmentRef  string                  `json:"environmentRef"`
 	Parameters      map[string]interface{}  `json:"parameters,omitempty"`
 	Placement       applicationPlacement    `json:"placement"`
+
+	// Short-form aliases (collapsed via
+	// applicationInstallRequestNormalize). Keeping them as struct
+	// fields rather than a side-map preserves the strict
+	// DisallowUnknownFields gate while letting the matrix's
+	// minimal-body shape decode cleanly.
+	BlueprintShort string                 `json:"blueprint,omitempty"`
+	VersionShort   string                 `json:"version,omitempty"`
+	NamespaceShort string                 `json:"namespace,omitempty"`
+	ValuesShort    map[string]interface{} `json:"values,omitempty"`
+}
+
+// applicationInstallRequestNormalize collapses the short-form aliases
+// onto the canonical fields. Long-form values win on conflict so a
+// caller mixing both shapes (rare; typically a script-generated body)
+// gets predictable behaviour.
+func applicationInstallRequestNormalize(b applicationInstallRequest) applicationInstallRequest {
+	if b.BlueprintRef.Name == "" && strings.TrimSpace(b.BlueprintShort) != "" {
+		b.BlueprintRef.Name = strings.TrimSpace(b.BlueprintShort)
+	}
+	if b.BlueprintRef.Version == "" && strings.TrimSpace(b.VersionShort) != "" {
+		b.BlueprintRef.Version = strings.TrimSpace(b.VersionShort)
+	}
+	if b.OrganizationRef == "" && strings.TrimSpace(b.NamespaceShort) != "" {
+		b.OrganizationRef = strings.TrimSpace(b.NamespaceShort)
+	}
+	if b.EnvironmentRef == "" && b.OrganizationRef != "" {
+		b.EnvironmentRef = b.OrganizationRef + "-prod"
+	}
+	if len(b.Parameters) == 0 && len(b.ValuesShort) > 0 {
+		b.Parameters = b.ValuesShort
+	}
+	if strings.TrimSpace(b.Placement.Mode) == "" {
+		b.Placement.Mode = "single-region"
+	}
+	if len(b.Placement.Regions) == 0 {
+		b.Placement.Regions = []string{"primary"}
+	}
+	return b
 }
 
 // applicationInstallResponse is the body returned on 201.
@@ -163,6 +231,7 @@ func (h *Handler) HandleApplicationInstall(w http.ResponseWriter, r *http.Reques
 	if !decodeMutationBody(w, r, &body) {
 		return
 	}
+	body = applicationInstallRequestNormalize(body)
 	if msg, ok := validateApplicationInstallRequest(body); !ok {
 		writeBadRequest(w, "invalid-application-install", msg)
 		return

--- a/products/catalyst/bootstrap/api/internal/handler/applications_preview.go
+++ b/products/catalyst/bootstrap/api/internal/handler/applications_preview.go
@@ -80,6 +80,14 @@ import (
 
 // applicationPreviewRequest is the body of POST .../applications/preview.
 // Same shape as applicationInstallRequest except `name` is optional.
+//
+// Accepts the same SHORT FORM as applicationInstallRequest (canonical
+// UAT matrix vocabulary):
+//
+//	{ "blueprint":"bp-x", "version":"1.0", "namespace":"qa-omantel",
+//	  "values":{...} }
+//
+// Collapsed via applicationPreviewRequestNormalize before validation.
 type applicationPreviewRequest struct {
 	BlueprintRef    applicationBlueprintRef `json:"blueprintRef"`
 	Name            string                  `json:"name,omitempty"`
@@ -87,6 +95,42 @@ type applicationPreviewRequest struct {
 	EnvironmentRef  string                  `json:"environmentRef"`
 	Parameters      map[string]interface{}  `json:"parameters,omitempty"`
 	Placement       applicationPlacement    `json:"placement"`
+
+	// Short-form aliases — see applicationInstallRequest doc.
+	BlueprintShort string                 `json:"blueprint,omitempty"`
+	VersionShort   string                 `json:"version,omitempty"`
+	NamespaceShort string                 `json:"namespace,omitempty"`
+	ValuesShort    map[string]interface{} `json:"values,omitempty"`
+}
+
+// applicationPreviewRequestNormalize collapses the short-form aliases
+// onto the canonical fields. Mirrors
+// applicationInstallRequestNormalize so a body that previews
+// successfully will install successfully (one source of truth for
+// the shape coercion).
+func applicationPreviewRequestNormalize(b applicationPreviewRequest) applicationPreviewRequest {
+	if b.BlueprintRef.Name == "" && strings.TrimSpace(b.BlueprintShort) != "" {
+		b.BlueprintRef.Name = strings.TrimSpace(b.BlueprintShort)
+	}
+	if b.BlueprintRef.Version == "" && strings.TrimSpace(b.VersionShort) != "" {
+		b.BlueprintRef.Version = strings.TrimSpace(b.VersionShort)
+	}
+	if b.OrganizationRef == "" && strings.TrimSpace(b.NamespaceShort) != "" {
+		b.OrganizationRef = strings.TrimSpace(b.NamespaceShort)
+	}
+	if b.EnvironmentRef == "" && b.OrganizationRef != "" {
+		b.EnvironmentRef = b.OrganizationRef + "-prod"
+	}
+	if len(b.Parameters) == 0 && len(b.ValuesShort) > 0 {
+		b.Parameters = b.ValuesShort
+	}
+	if strings.TrimSpace(b.Placement.Mode) == "" {
+		b.Placement.Mode = "single-region"
+	}
+	if len(b.Placement.Regions) == 0 {
+		b.Placement.Regions = []string{"primary"}
+	}
+	return b
 }
 
 // PreviewManifest is one rendered file in the preview output. Path is
@@ -135,6 +179,7 @@ func (h *Handler) HandleApplicationPreview(w http.ResponseWriter, r *http.Reques
 	if !decodeMutationBody(w, r, &body) {
 		return
 	}
+	body = applicationPreviewRequestNormalize(body)
 	if msg, ok := validateApplicationPreviewRequest(body); !ok {
 		writeBadRequest(w, "invalid-application-preview", msg)
 		return

--- a/products/catalyst/bootstrap/api/internal/handler/applications_update.go
+++ b/products/catalyst/bootstrap/api/internal/handler/applications_update.go
@@ -49,6 +49,10 @@ import (
 // /api/v1/sovereigns/{id}/applications/{name}. All fields are optional:
 // the handler patches only the keys that are non-zero. A bare `{}` body
 // is a no-op (returns 200 with the CR's current spec).
+//
+// Accepts both the long form (`parameters`) and the canonical UAT
+// matrix's short form (`values`) per
+// `feedback_no_mvp_no_workarounds.md`. Long form wins on conflict.
 type applicationUpdateRequest struct {
 	// BlueprintRef — when Version is non-empty, the version is updated.
 	// (We never let a UI rename the blueprint; that's an uninstall +
@@ -61,6 +65,40 @@ type applicationUpdateRequest struct {
 	// spec.regions. The handler rejects active-active → single-region
 	// (or anything that drops regions) without ?force=true.
 	Placement *applicationPlacement `json:"placement,omitempty"`
+
+	// ValuesShort is the canonical UAT matrix's alias for Parameters.
+	// Collapsed via applicationUpdateRequestNormalize.
+	ValuesShort map[string]interface{} `json:"values,omitempty"`
+	// VersionShort is the canonical UAT matrix's short alias for
+	// `BlueprintRef.Version` on a version-only update — equivalent to
+	// `{"blueprintRef":{"version":"x.y.z"}}`.
+	VersionShort string `json:"version,omitempty"`
+	// ToVersionShort mirrors the upgrade-preview endpoint's `toVersion`
+	// shorthand so a caller can issue a one-shot upgrade via PUT
+	// `/applications/{name}` with `{"toVersion":"x.y.z"}`. Same
+	// resolution path as VersionShort.
+	ToVersionShort string `json:"toVersion,omitempty"`
+}
+
+// applicationUpdateRequestNormalize collapses the short-form aliases
+// onto the canonical fields. Long-form values win on conflict.
+func applicationUpdateRequestNormalize(b applicationUpdateRequest) applicationUpdateRequest {
+	if b.Parameters == nil && len(b.ValuesShort) > 0 {
+		b.Parameters = b.ValuesShort
+	}
+	short := strings.TrimSpace(b.ToVersionShort)
+	if short == "" {
+		short = strings.TrimSpace(b.VersionShort)
+	}
+	if short != "" {
+		if b.BlueprintRef == nil {
+			b.BlueprintRef = &applicationBlueprintRef{}
+		}
+		if strings.TrimSpace(b.BlueprintRef.Version) == "" {
+			b.BlueprintRef.Version = short
+		}
+	}
+	return b
 }
 
 // applicationUpdateResponse mirrors applicationStatusResponse — the UI
@@ -115,6 +153,7 @@ func (h *Handler) HandleApplicationUpdate(w http.ResponseWriter, r *http.Request
 	if !decodeMutationBody(w, r, &body) {
 		return
 	}
+	body = applicationUpdateRequestNormalize(body)
 	if msg, ok := validateApplicationUpdateRequest(body); !ok {
 		writeBadRequest(w, "invalid-application-update", msg)
 		return
@@ -401,11 +440,52 @@ func (h *Handler) HandleApplicationUpgradePreview(w http.ResponseWriter, r *http
 // applicationChangePreviewRequest is the body of the topology / upgrade
 // preview endpoints. Everything is optional; missing fields fall back to
 // the current Application CR.
+//
+// Accepts the canonical UAT matrix's short form for the upgrade-preview
+// case: `{"toVersion":"x.y.z"}` is equivalent to
+// `{"blueprintRef":{"version":"x.y.z"}}`. The `values` alias maps to
+// `parameters` (matches the install/update bodies).
 type applicationChangePreviewRequest struct {
 	Placement      *applicationPlacement    `json:"placement,omitempty"`
 	Parameters     map[string]interface{}   `json:"parameters,omitempty"`
 	BlueprintRef   *applicationBlueprintRef `json:"blueprintRef,omitempty"`
 	EnvironmentRef string                   `json:"environmentRef,omitempty"`
+
+	// Short-form aliases per the canonical UAT matrix.
+	ToVersionShort string                 `json:"toVersion,omitempty"`
+	VersionShort   string                 `json:"version,omitempty"`
+	ValuesShort    map[string]interface{} `json:"values,omitempty"`
+	BlueprintShort string                 `json:"blueprint,omitempty"`
+}
+
+// applicationChangePreviewRequestNormalize collapses the short-form
+// aliases onto the canonical fields so renderApplicationPreview never
+// has to know about the matrix vocabulary.
+func applicationChangePreviewRequestNormalize(b applicationChangePreviewRequest) applicationChangePreviewRequest {
+	short := strings.TrimSpace(b.ToVersionShort)
+	if short == "" {
+		short = strings.TrimSpace(b.VersionShort)
+	}
+	if short != "" {
+		if b.BlueprintRef == nil {
+			b.BlueprintRef = &applicationBlueprintRef{}
+		}
+		if strings.TrimSpace(b.BlueprintRef.Version) == "" {
+			b.BlueprintRef.Version = short
+		}
+	}
+	if strings.TrimSpace(b.BlueprintShort) != "" {
+		if b.BlueprintRef == nil {
+			b.BlueprintRef = &applicationBlueprintRef{}
+		}
+		if strings.TrimSpace(b.BlueprintRef.Name) == "" {
+			b.BlueprintRef.Name = strings.TrimSpace(b.BlueprintShort)
+		}
+	}
+	if b.Parameters == nil && len(b.ValuesShort) > 0 {
+		b.Parameters = b.ValuesShort
+	}
+	return b
 }
 
 // handleApplicationChangePreview is the shared core for topology +
@@ -446,6 +526,7 @@ func (h *Handler) handleApplicationChangePreview(w http.ResponseWriter, r *http.
 	if !decodeMutationBody(w, r, &body) {
 		return
 	}
+	body = applicationChangePreviewRequestNormalize(body)
 
 	client, err := h.sovereignDynamicClient(dep)
 	if err != nil {

--- a/products/catalyst/bootstrap/api/internal/handler/continuum.go
+++ b/products/catalyst/bootstrap/api/internal/handler/continuum.go
@@ -129,12 +129,23 @@ type continuumGetResponse struct {
 
 // continuumSwitchoverRequest — body of POST .../switchover.
 //
-// `targetRegion` is REQUIRED (handler rejects 400 otherwise). `reason`
-// is a free-form short string surfaced on the audit event's Detail
-// field. The handler stamps `requestedAt = now` server-side.
+// `targetRegion` (or its short-form alias `target`) is REQUIRED
+// (handler rejects 400 otherwise). `reason` is a free-form short
+// string surfaced on the audit event's Detail field. The handler
+// stamps `requestedAt = now` server-side.
+//
+// The `target` alias matches the canonical UAT matrix vocabulary —
+// see `feedback_no_mvp_no_workarounds.md`. The matrix is the
+// contract; the handler conforms by accepting both names.
+// `continuumSwitchoverPreviewRequest` already established this
+// pattern (see continuum_extras.go:100).
 type continuumSwitchoverRequest struct {
 	TargetRegion string `json:"targetRegion"`
-	Reason       string `json:"reason,omitempty"`
+	// Target is the canonical UAT matrix's short alias for
+	// TargetRegion. When set and TargetRegion is empty, the handler
+	// promotes Target to TargetRegion before validation.
+	Target string `json:"target,omitempty"`
+	Reason string `json:"reason,omitempty"`
 }
 
 // continuumSwitchoverResponse — 202 Accepted body. The reconciler picks
@@ -279,8 +290,13 @@ func (h *Handler) HandleContinuumSwitchoverRequest(w http.ResponseWriter, r *htt
 	if !decodeMutationBody(w, r, &body) {
 		return
 	}
+	// Short-form alias: promote `target` to `targetRegion` when the
+	// canonical field was omitted. Long form wins on conflict.
+	if strings.TrimSpace(body.TargetRegion) == "" && strings.TrimSpace(body.Target) != "" {
+		body.TargetRegion = strings.TrimSpace(body.Target)
+	}
 	if strings.TrimSpace(body.TargetRegion) == "" {
-		writeBadRequest(w, "missing-target-region", "targetRegion is required")
+		writeBadRequest(w, "missing-target-region", "targetRegion (or its alias `target`) is required")
 		return
 	}
 	client, err := h.sovereignDynamicClient(dep)

--- a/products/catalyst/bootstrap/api/internal/handler/policy_mode.go
+++ b/products/catalyst/bootstrap/api/internal/handler/policy_mode.go
@@ -155,6 +155,15 @@ func ClusterPolicyGVR() schema.GroupVersionResource {
 //     400 because decodeMutationBody calls DisallowUnknownFields().
 //   - applied:     ignored. Read-only field on the response.
 //
+// `mode` (and optional `policy`) is the SHORT form the canonical UAT
+// matrix uses — `{"mode":"Audit"}` or `{"mode":"Enforce","policy":"<name>"}`.
+// When `mode` is set, the handler synthesises a single-entry `Modes`
+// map keyed on `policy` (or, when `policy` is empty, on the special
+// sentinel "*" which means "apply this mode to every known compliance
+// policy on this Environment" — the bulk-toggle case). This is the
+// target-state vocabulary per `feedback_no_mvp_no_workarounds.md`:
+// the handler conforms to the matrix, never the other way around.
+//
 // Removing DisallowUnknownFields globally would weaken every other
 // mutation handler that benefits from strict typo detection. The
 // targeted fix is to model the optional fields explicitly here so
@@ -163,6 +172,43 @@ type policyModeRequest struct {
 	Modes       map[string]string `json:"modes"`
 	Environment string            `json:"environment,omitempty"`
 	Applied     any               `json:"applied,omitempty"`
+	// Mode is the single-policy short form. When non-empty, expanded
+	// into Modes server-side (see expandShortFormMode below).
+	Mode string `json:"mode,omitempty"`
+	// Policy targets the single-policy short form. When empty alongside
+	// Mode, the bulk-apply sentinel "*" is used so every known
+	// compliance policy receives the requested mode.
+	Policy string `json:"policy,omitempty"`
+}
+
+// policyModeBulkSentinel — when the short-form body specifies `mode`
+// without `policy`, the handler applies the mode to EVERY known
+// compliance policy on the Sovereign. The sentinel survives the
+// expansion step and is replaced inline once policyModeKnownPolicies
+// returns.
+const policyModeBulkSentinel = "*"
+
+// expandShortFormMode synthesises a Modes map from the short-form body
+// fields (`mode` + optional `policy`). When `mode` is empty the call is
+// a no-op (the long-form `modes` map already populated). Returns the
+// possibly-mutated request body.
+//
+// The expansion happens BEFORE policy-name validation so the bulk
+// sentinel "*" does not collide with a user-supplied `modes` entry.
+func expandShortFormMode(body policyModeRequest) policyModeRequest {
+	mode := strings.TrimSpace(body.Mode)
+	if mode == "" {
+		return body
+	}
+	if body.Modes == nil {
+		body.Modes = map[string]string{}
+	}
+	target := strings.TrimSpace(body.Policy)
+	if target == "" {
+		target = policyModeBulkSentinel
+	}
+	body.Modes[target] = mode
+	return body
 }
 
 // policyModeResponse is the body returned on success. The `modes` map
@@ -199,8 +245,9 @@ func (h *Handler) HandleEnvironmentPolicyMode(w http.ResponseWriter, r *http.Req
 	if !decodeMutationBody(w, r, &body) {
 		return
 	}
+	body = expandShortFormMode(body)
 	if len(body.Modes) == 0 {
-		writeBadRequest(w, "empty-modes", "modes map must contain at least one entry")
+		writeBadRequest(w, "empty-modes", "modes map must contain at least one entry (or set top-level `mode`)")
 		return
 	}
 	// Normalize mode values to the OpenOva vocabulary (permissive |
@@ -266,6 +313,32 @@ func (h *Handler) HandleEnvironmentPolicyMode(w http.ResponseWriter, r *http.Req
 			"detail": knownErr.Error(),
 		})
 		return
+	}
+	// Expand the bulk-apply sentinel "*" into one entry per known
+	// compliance policy. Done AFTER policyModeKnownPolicies so the
+	// short-form `{"mode":"Audit"}` body fans out to every policy in
+	// scope without forcing the caller to enumerate them. When no
+	// known policies are registered (fresh Sovereign without Kyverno
+	// installed) the sentinel is dropped — there is nothing to apply.
+	if v, ok := body.Modes[policyModeBulkSentinel]; ok {
+		delete(body.Modes, policyModeBulkSentinel)
+		for name := range known {
+			if _, exists := body.Modes[name]; !exists {
+				body.Modes[name] = v
+			}
+		}
+		if len(body.Modes) == 0 {
+			// No known policies on this Sovereign and no explicit
+			// per-policy entry survived the expansion. Surface a 200
+			// no-op rather than a 400 so the caller sees the request
+			// was accepted but the cluster has nothing to toggle.
+			writeJSON(w, http.StatusOK, policyModeResponse{
+				Environment: envName,
+				Modes:       map[string]string{},
+				Applied:     "no-op",
+			})
+			return
+		}
 	}
 	if len(known) > 0 {
 		for name := range body.Modes {

--- a/products/catalyst/bootstrap/api/internal/handler/rbac_assign.go
+++ b/products/catalyst/bootstrap/api/internal/handler/rbac_assign.go
@@ -91,15 +91,38 @@ const (
 	rbacAssignNamespace = "catalyst-system"
 )
 
-// rbacAssignAllowedTiers is the canonical 5-tier catalog. Any other
+// rbacAssignAllowedTiers is the canonical tier catalog. Any other
 // value on the request body is rejected with 400. The list is the
 // public contract docs/EPICS-1-6-unified-design.md §6.2 declares.
+//
+// `super-admin` is the cross-org sentinel the canonical UAT matrix
+// uses for the "global escalation" scope (TC-168 et al.) — it
+// resolves to the same ClusterRole as `owner` (openova:tier-owner)
+// but is reserved for grants that span multiple Sovereigns / orgs.
+// Per `feedback_no_mvp_no_workarounds.md` the matrix vocabulary is
+// the contract; the handler accepts and audits it as a first-class
+// tier rather than rejecting with 400.
 var rbacAssignAllowedTiers = map[string]struct{}{
-	"viewer":    {},
-	"developer": {},
-	"operator":  {},
-	"admin":     {},
-	"owner":     {},
+	"viewer":      {},
+	"developer":   {},
+	"operator":    {},
+	"admin":       {},
+	"owner":       {},
+	"super-admin": {},
+}
+
+// rbacAssignTierResolved maps a request-body tier value to the
+// underlying ClusterRole name suffix. `super-admin` resolves to
+// `owner` so the existing 5-tier ClusterRole shipped by EPIC-3 T1
+// (#1142) provides the binding without a chart change. The audit
+// trail still records the request-vocabulary tier (`super-admin`)
+// for grep-ability.
+func rbacAssignTierResolved(tier string) string {
+	t := strings.ToLower(strings.TrimSpace(tier))
+	if t == "super-admin" {
+		return "owner"
+	}
+	return t
 }
 
 // rbacAssignPrivilegedRoles is the set of realm roles a caller MUST
@@ -126,10 +149,82 @@ type rbacAssignScopeBody struct {
 }
 
 // rbacAssignRequest is the body of POST /rbac/assign.
+//
+// Two equivalent body shapes are accepted (per
+// `feedback_no_mvp_no_workarounds.md` the matrix is the contract;
+// the handler conforms):
+//
+//  1. Long form (production internal callers, multi-grant editor):
+//     { "user":{"email":"...","keycloakSubject":"..."},
+//     "tier":"developer",
+//     "scope":[{"key":"openova.io/application","value":"qa-wp"}] }
+//
+//  2. Short form (canonical UAT matrix):
+//     { "email":"qa-user1@openova.io",
+//     "tier":"developer",
+//     "scopeType":"application",
+//     "scopeName":"qa-wp" }
+//
+// The short form collapses onto the long form via
+// rbacAssignRequestNormalize:
+//
+//	email      → User.Email
+//	scopeType  → Scope[0].Key  ("application" → openova.io/application,
+//	                            "organization" → openova.io/org,
+//	                            "env-type"    → openova.io/env-type;
+//	                            else passes through unchanged)
+//	scopeName  → Scope[0].Value
+//
+// Bare `{"email":"x","tier":"super-admin"}` (TC-168 — global
+// escalation) collapses to a global grant: empty Scope set + tier
+// "super-admin" → tier-owner ClusterRole binding scoped to no
+// resource label, which the useraccess-controller treats as
+// "applies to all".
 type rbacAssignRequest struct {
 	User  rbacAssignUserBody    `json:"user"`
 	Tier  string                `json:"tier"`
 	Scope []rbacAssignScopeBody `json:"scope"`
+
+	// Short-form aliases (canonical UAT matrix vocabulary).
+	EmailShort     string `json:"email,omitempty"`
+	ScopeTypeShort string `json:"scopeType,omitempty"`
+	ScopeNameShort string `json:"scopeName,omitempty"`
+}
+
+// rbacAssignScopeKeyForType maps the matrix's friendly scope-type
+// vocabulary to the canonical NAMING-CONVENTION.md §6 label key.
+// Unknown scope-types pass through unchanged so a future addition
+// (e.g. `cluster`, `region`) doesn't require a code change.
+func rbacAssignScopeKeyForType(scopeType string) string {
+	switch strings.ToLower(strings.TrimSpace(scopeType)) {
+	case "application", "app":
+		return scopeKeyApplication
+	case "organization", "org":
+		return scopeKeyOrg
+	case "env-type", "envtype", "environment-type", "environmenttype":
+		return scopeKeyEnvType
+	}
+	return strings.TrimSpace(scopeType)
+}
+
+// rbacAssignRequestNormalize collapses the short-form aliases onto
+// the long-form fields. Long form wins on conflict so a body that
+// supplies BOTH shapes ends up with the long-form values.
+func rbacAssignRequestNormalize(b rbacAssignRequest) rbacAssignRequest {
+	if strings.TrimSpace(b.User.Email) == "" && strings.TrimSpace(b.EmailShort) != "" {
+		b.User.Email = strings.TrimSpace(b.EmailShort)
+	}
+	scopeType := strings.TrimSpace(b.ScopeTypeShort)
+	scopeName := strings.TrimSpace(b.ScopeNameShort)
+	if len(b.Scope) == 0 && (scopeType != "" || scopeName != "") {
+		// Both empty short-form -> nothing to add. Both set -> single
+		// scope entry. Either-only -> single entry with the empty
+		// counterpart trimmed (validation later catches a half-set
+		// scope as a clear 400).
+		key := rbacAssignScopeKeyForType(scopeType)
+		b.Scope = []rbacAssignScopeBody{{Key: key, Value: scopeName}}
+	}
+	return b
 }
 
 type rbacAssignUserAccessRef struct {
@@ -162,6 +257,7 @@ func (h *Handler) HandleRBACAssign(w http.ResponseWriter, r *http.Request) {
 	if !decodeMutationBody(w, r, &body) {
 		return
 	}
+	body = rbacAssignRequestNormalize(body)
 	if msg, ok := validateRBACAssignRequest(body); !ok {
 		writeBadRequest(w, "invalid-rbac-assign", msg)
 		return
@@ -315,6 +411,13 @@ func rbacAssignFindOrCreate(
 ) (rbacAssignResponse, int, string, error) {
 	wantScope := normalizeScopeSlice(body.Scope)
 	wantTier := strings.ToLower(strings.TrimSpace(body.Tier))
+	// resolvedTier is what the ClusterRole binding actually points at.
+	// For `super-admin` this collapses to `owner`; for everything else
+	// it equals wantTier. Persisted on the CR's spec.tierRoleRef +
+	// echoed in the response's TierClusterRole. The audit/label tier
+	// remains wantTier so the audit trail records the requested
+	// vocabulary.
+	resolvedTier := rbacAssignTierResolved(wantTier)
 	keycloakSubject := strings.TrimSpace(body.User.KeycloakSubject)
 
 	var lastErr error
@@ -337,7 +440,7 @@ func rbacAssignFindOrCreate(
 				// CRD not installed yet → fall through to create. The
 				// create will surface its own NotFound for the missing
 				// CRD with a more actionable error to the caller.
-				resp, status, err := rbacAssignCreate(ctx, client, body, wantScope, wantTier, dep)
+				resp, status, err := rbacAssignCreate(ctx, client, body, wantScope, wantTier, resolvedTier, dep)
 				return resp, status, "", err
 			}
 			return rbacAssignResponse{}, http.StatusInternalServerError, "", fmt.Errorf("list useraccesses: %w", err)
@@ -353,14 +456,14 @@ func rbacAssignFindOrCreate(
 						UID:       string(match.GetUID()),
 						Namespace: match.GetNamespace(),
 					},
-					TierClusterRole: tierClusterRolePrefix + wantTier,
+					TierClusterRole: tierClusterRolePrefix + resolvedTier,
 					Applied:         "no-op",
 				}, http.StatusOK, currentTier, nil
 			}
 			// Path 2b: same scope, different tier → update tier label
 			// + spec.tierRoleRef. Use ResourceVersion to surface a 409
 			// on concurrent edit; the loop re-evaluates and retries.
-			updated, err := rbacAssignUpdateTier(ctx, client, match, wantTier)
+			updated, err := rbacAssignUpdateTier(ctx, client, match, wantTier, resolvedTier)
 			if err != nil {
 				if apierrors.IsConflict(err) {
 					// Concurrent writer mutated the CR — retry the
@@ -377,12 +480,12 @@ func rbacAssignFindOrCreate(
 					UID:       string(updated.GetUID()),
 					Namespace: updated.GetNamespace(),
 				},
-				TierClusterRole: tierClusterRolePrefix + wantTier,
+				TierClusterRole: tierClusterRolePrefix + resolvedTier,
 				Applied:         "updated",
 			}, http.StatusOK, currentTier, nil
 		}
 		// Path 3: no match → create.
-		resp, status, err := rbacAssignCreate(ctx, client, body, wantScope, wantTier, dep)
+		resp, status, err := rbacAssignCreate(ctx, client, body, wantScope, wantTier, resolvedTier, dep)
 		if err != nil && apierrors.IsAlreadyExists(err) {
 			// Concurrent creator won the race for the same name. Retry
 			// the list+evaluate cycle so we catch their CR and either
@@ -418,6 +521,7 @@ func rbacAssignCreate(
 	body rbacAssignRequest,
 	wantScope []rbacAssignScopeBody,
 	wantTier string,
+	resolvedTier string,
 	dep *Deployment,
 ) (rbacAssignResponse, int, error) {
 	keycloakSubject := strings.TrimSpace(body.User.KeycloakSubject)
@@ -439,7 +543,7 @@ func rbacAssignCreate(
 	spec := map[string]any{
 		"user":         user,
 		"sovereignRef": rbacAssignSovereignRef(dep),
-		"tierRoleRef":  tierClusterRolePrefix + wantTier,
+		"tierRoleRef":  tierClusterRolePrefix + resolvedTier,
 	}
 	if len(wantScope) > 0 {
 		scopes := make([]any, 0, len(wantScope))
@@ -470,7 +574,7 @@ func rbacAssignCreate(
 			UID:       string(created.GetUID()),
 			Namespace: created.GetNamespace(),
 		},
-		TierClusterRole: tierClusterRolePrefix + wantTier,
+		TierClusterRole: tierClusterRolePrefix + resolvedTier,
 		Applied:         "created",
 	}, http.StatusCreated, nil
 }
@@ -478,11 +582,16 @@ func rbacAssignCreate(
 // rbacAssignUpdateTier patches the tier label + spec.tierRoleRef on an
 // existing UserAccess CR. Preserves resourceVersion so concurrent edits
 // surface as a 409 — the caller retries via the find-or-create loop.
+//
+// `wantTier` is the audit/label tier (carries the request-vocabulary,
+// e.g. "super-admin"). `resolvedTier` is the underlying ClusterRole
+// suffix (e.g. "owner") wired into spec.tierRoleRef.
 func rbacAssignUpdateTier(
 	ctx context.Context,
 	client dynamic.Interface,
 	current *unstructured.Unstructured,
 	wantTier string,
+	resolvedTier string,
 ) (*unstructured.Unstructured, error) {
 	desired := current.DeepCopy()
 	labels := desired.GetLabels()
@@ -493,7 +602,7 @@ func rbacAssignUpdateTier(
 	desired.SetLabels(labels)
 	_ = unstructured.SetNestedField(
 		desired.Object,
-		tierClusterRolePrefix+wantTier,
+		tierClusterRolePrefix+resolvedTier,
 		"spec", "tierRoleRef",
 	)
 	// Update on a namespaced CRD requires the same namespace path as
@@ -733,7 +842,7 @@ func validateRBACAssignRequest(req rbacAssignRequest) (string, bool) {
 		return "tier is required", false
 	}
 	if _, ok := rbacAssignAllowedTiers[tier]; !ok {
-		return "tier must be one of viewer, developer, operator, admin, owner", false
+		return "tier must be one of viewer, developer, operator, admin, owner, super-admin", false
 	}
 	for i, s := range req.Scope {
 		k := strings.TrimSpace(s.Key)

--- a/products/catalyst/bootstrap/api/internal/handler/short_form_vocab_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/short_form_vocab_test.go
@@ -1,0 +1,399 @@
+// Package handler — short_form_vocab_test.go: unit coverage for the
+// canonical UAT matrix's short-form vocabulary aliases added in
+// iter-7 fix #35 (qa-loop). One file covers every endpoint that
+// widened to accept short-form bodies so the matrix's vocabulary
+// becomes a regression-tested contract.
+//
+// Per `feedback_no_mvp_no_workarounds.md` the matrix is the contract;
+// these tests assert the handler conforms (no `unknown field` 400s on
+// the matrix's body shapes).
+package handler
+
+import (
+	"testing"
+)
+
+// ── policy_mode.go: short-form `mode` (+ optional `policy`) ──
+
+func TestExpandShortFormMode_Bare(t *testing.T) {
+	body := policyModeRequest{Mode: "Audit"}
+	out := expandShortFormMode(body)
+	if out.Modes == nil {
+		t.Fatalf("Modes should be populated")
+	}
+	if v, ok := out.Modes[policyModeBulkSentinel]; !ok || v != "Audit" {
+		t.Fatalf("expected sentinel %q to map to Audit, got %v", policyModeBulkSentinel, out.Modes)
+	}
+}
+
+func TestExpandShortFormMode_WithPolicy(t *testing.T) {
+	body := policyModeRequest{Mode: "Enforce", Policy: "runasnonroot"}
+	out := expandShortFormMode(body)
+	if v, ok := out.Modes["runasnonroot"]; !ok || v != "Enforce" {
+		t.Fatalf("expected runasnonroot=Enforce, got %v", out.Modes)
+	}
+	if _, ok := out.Modes[policyModeBulkSentinel]; ok {
+		t.Fatalf("sentinel should NOT be set when policy is supplied")
+	}
+}
+
+func TestExpandShortFormMode_LongFormPreserved(t *testing.T) {
+	body := policyModeRequest{
+		Modes: map[string]string{"alreadyHere": "permissive"},
+		Mode:  "Enforce",
+	}
+	out := expandShortFormMode(body)
+	if out.Modes["alreadyHere"] != "permissive" {
+		t.Fatalf("long-form modes entry must be preserved")
+	}
+	if out.Modes[policyModeBulkSentinel] != "Enforce" {
+		t.Fatalf("short-form sentinel must coexist with long-form entries")
+	}
+}
+
+func TestExpandShortFormMode_NoMode_Noop(t *testing.T) {
+	body := policyModeRequest{Modes: map[string]string{"x": "permissive"}}
+	out := expandShortFormMode(body)
+	if len(out.Modes) != 1 || out.Modes["x"] != "permissive" {
+		t.Fatalf("expected unchanged Modes map, got %v", out.Modes)
+	}
+}
+
+// ── applications.go: install short form ──
+
+func TestApplicationInstallRequestNormalize_ShortForm(t *testing.T) {
+	body := applicationInstallRequest{
+		BlueprintShort: "bp-wordpress",
+		VersionShort:   "latest",
+		NamespaceShort: "qa-omantel",
+		Name:           "qa-wp",
+		ValuesShort:    map[string]interface{}{"siteTitle": "QA WP"},
+	}
+	out := applicationInstallRequestNormalize(body)
+	if out.BlueprintRef.Name != "bp-wordpress" {
+		t.Errorf("BlueprintRef.Name=%q, want bp-wordpress", out.BlueprintRef.Name)
+	}
+	if out.BlueprintRef.Version != "latest" {
+		t.Errorf("BlueprintRef.Version=%q, want latest", out.BlueprintRef.Version)
+	}
+	if out.OrganizationRef != "qa-omantel" {
+		t.Errorf("OrganizationRef=%q, want qa-omantel", out.OrganizationRef)
+	}
+	if out.EnvironmentRef != "qa-omantel-prod" {
+		t.Errorf("EnvironmentRef=%q, want qa-omantel-prod (default)", out.EnvironmentRef)
+	}
+	if out.Parameters["siteTitle"] != "QA WP" {
+		t.Errorf("Parameters not collapsed from values; got %v", out.Parameters)
+	}
+	if out.Placement.Mode != "single-region" {
+		t.Errorf("Placement.Mode=%q, want single-region default", out.Placement.Mode)
+	}
+}
+
+func TestApplicationInstallRequestNormalize_LongFormWins(t *testing.T) {
+	body := applicationInstallRequest{
+		BlueprintRef:    applicationBlueprintRef{Name: "bp-x", Version: "1.0"},
+		OrganizationRef: "real-org",
+		EnvironmentRef:  "real-org-stg",
+		Parameters:      map[string]interface{}{"a": 1},
+		Placement:       applicationPlacement{Mode: "active-active", Regions: []string{"r1", "r2"}},
+		BlueprintShort:  "bp-y",
+		VersionShort:    "2.0",
+		NamespaceShort:  "ns-y",
+	}
+	out := applicationInstallRequestNormalize(body)
+	if out.BlueprintRef.Name != "bp-x" {
+		t.Errorf("long-form BlueprintRef.Name should win; got %q", out.BlueprintRef.Name)
+	}
+	if out.OrganizationRef != "real-org" {
+		t.Errorf("long-form OrganizationRef should win; got %q", out.OrganizationRef)
+	}
+	if out.EnvironmentRef != "real-org-stg" {
+		t.Errorf("long-form EnvironmentRef should win; got %q", out.EnvironmentRef)
+	}
+	if out.Placement.Mode != "active-active" {
+		t.Errorf("Placement preserved; got %q", out.Placement.Mode)
+	}
+}
+
+// ── applications_preview.go: preview short form ──
+
+func TestApplicationPreviewRequestNormalize_ShortForm(t *testing.T) {
+	body := applicationPreviewRequest{
+		BlueprintShort: "bp-wordpress",
+		VersionShort:   "latest",
+		NamespaceShort: "qa-omantel",
+		ValuesShort:    map[string]interface{}{"siteTitle": "QA"},
+	}
+	out := applicationPreviewRequestNormalize(body)
+	if out.BlueprintRef.Name != "bp-wordpress" || out.BlueprintRef.Version != "latest" {
+		t.Errorf("Blueprint not collapsed: %+v", out.BlueprintRef)
+	}
+	if out.OrganizationRef != "qa-omantel" {
+		t.Errorf("OrganizationRef=%q, want qa-omantel", out.OrganizationRef)
+	}
+	if out.Parameters["siteTitle"] != "QA" {
+		t.Errorf("values→parameters: got %v", out.Parameters)
+	}
+}
+
+// ── applications_update.go: update short form ──
+
+func TestApplicationUpdateRequestNormalize_Values(t *testing.T) {
+	body := applicationUpdateRequest{
+		ValuesShort: map[string]interface{}{"siteTitle": "QA Updated"},
+	}
+	out := applicationUpdateRequestNormalize(body)
+	if v, ok := out.Parameters["siteTitle"]; !ok || v != "QA Updated" {
+		t.Errorf("values not promoted to parameters; got %v", out.Parameters)
+	}
+}
+
+func TestApplicationUpdateRequestNormalize_ToVersion(t *testing.T) {
+	body := applicationUpdateRequest{ToVersionShort: "5.6.1"}
+	out := applicationUpdateRequestNormalize(body)
+	if out.BlueprintRef == nil || out.BlueprintRef.Version != "5.6.1" {
+		t.Errorf("toVersion not promoted to BlueprintRef.Version; got %+v", out.BlueprintRef)
+	}
+}
+
+func TestApplicationUpdateRequestNormalize_Version(t *testing.T) {
+	body := applicationUpdateRequest{VersionShort: "5.7.0"}
+	out := applicationUpdateRequestNormalize(body)
+	if out.BlueprintRef == nil || out.BlueprintRef.Version != "5.7.0" {
+		t.Errorf("version not promoted to BlueprintRef.Version; got %+v", out.BlueprintRef)
+	}
+}
+
+func TestApplicationUpdateRequestNormalize_LongFormWins(t *testing.T) {
+	body := applicationUpdateRequest{
+		Parameters:     map[string]interface{}{"long": "form"},
+		ValuesShort:    map[string]interface{}{"short": "form"},
+		ToVersionShort: "5.6.1",
+		BlueprintRef:   &applicationBlueprintRef{Version: "5.0.0"},
+	}
+	out := applicationUpdateRequestNormalize(body)
+	if out.Parameters["long"] != "form" || out.Parameters["short"] != nil {
+		t.Errorf("long-form parameters should win; got %v", out.Parameters)
+	}
+	if out.BlueprintRef.Version != "5.0.0" {
+		t.Errorf("long-form version should win; got %q", out.BlueprintRef.Version)
+	}
+}
+
+// ── applications_update.go: change-preview (upgrade/topology) short form ──
+
+func TestApplicationChangePreviewRequestNormalize_ToVersion(t *testing.T) {
+	body := applicationChangePreviewRequest{ToVersionShort: "5.7.0"}
+	out := applicationChangePreviewRequestNormalize(body)
+	if out.BlueprintRef == nil || out.BlueprintRef.Version != "5.7.0" {
+		t.Errorf("toVersion not promoted; got %+v", out.BlueprintRef)
+	}
+}
+
+func TestApplicationChangePreviewRequestNormalize_BlueprintAndValues(t *testing.T) {
+	body := applicationChangePreviewRequest{
+		BlueprintShort: "bp-x",
+		ValuesShort:    map[string]interface{}{"k": "v"},
+	}
+	out := applicationChangePreviewRequestNormalize(body)
+	if out.BlueprintRef == nil || out.BlueprintRef.Name != "bp-x" {
+		t.Errorf("blueprint not promoted; got %+v", out.BlueprintRef)
+	}
+	if out.Parameters["k"] != "v" {
+		t.Errorf("values not promoted to parameters; got %v", out.Parameters)
+	}
+}
+
+// ── rbac_assign.go: short-form email/scopeType/scopeName + super-admin ──
+
+func TestRBACAssignRequestNormalize_ShortForm(t *testing.T) {
+	body := rbacAssignRequest{
+		EmailShort:     "qa-user1@openova.io",
+		Tier:           "developer",
+		ScopeTypeShort: "application",
+		ScopeNameShort: "qa-wp",
+	}
+	out := rbacAssignRequestNormalize(body)
+	if out.User.Email != "qa-user1@openova.io" {
+		t.Errorf("Email not promoted; got %q", out.User.Email)
+	}
+	if len(out.Scope) != 1 {
+		t.Fatalf("Scope length=%d, want 1", len(out.Scope))
+	}
+	if out.Scope[0].Key != scopeKeyApplication {
+		t.Errorf("Scope[0].Key=%q, want %q", out.Scope[0].Key, scopeKeyApplication)
+	}
+	if out.Scope[0].Value != "qa-wp" {
+		t.Errorf("Scope[0].Value=%q, want qa-wp", out.Scope[0].Value)
+	}
+}
+
+func TestRBACAssignRequestNormalize_OrgScope(t *testing.T) {
+	body := rbacAssignRequest{
+		EmailShort:     "crossOrg@x.io",
+		Tier:           "admin",
+		ScopeTypeShort: "organization",
+		ScopeNameShort: "org-B",
+	}
+	out := rbacAssignRequestNormalize(body)
+	if out.Scope[0].Key != scopeKeyOrg {
+		t.Errorf("Scope[0].Key=%q, want %q", out.Scope[0].Key, scopeKeyOrg)
+	}
+	if out.Scope[0].Value != "org-B" {
+		t.Errorf("Scope[0].Value=%q, want org-B", out.Scope[0].Value)
+	}
+}
+
+func TestRBACAssignRequestNormalize_Global(t *testing.T) {
+	body := rbacAssignRequest{
+		EmailShort: "qa@openova.io",
+		Tier:       "super-admin",
+	}
+	out := rbacAssignRequestNormalize(body)
+	if len(out.Scope) != 0 {
+		t.Errorf("Scope must be empty for global super-admin grant; got %v", out.Scope)
+	}
+	if out.User.Email != "qa@openova.io" {
+		t.Errorf("Email not promoted; got %q", out.User.Email)
+	}
+}
+
+func TestRBACAssignAllowedTiers_SuperAdmin(t *testing.T) {
+	if _, ok := rbacAssignAllowedTiers["super-admin"]; !ok {
+		t.Errorf("super-admin must be in rbacAssignAllowedTiers")
+	}
+}
+
+func TestRBACAssignTierResolved_SuperAdminToOwner(t *testing.T) {
+	if got := rbacAssignTierResolved("super-admin"); got != "owner" {
+		t.Errorf("super-admin should resolve to owner; got %q", got)
+	}
+	if got := rbacAssignTierResolved("admin"); got != "admin" {
+		t.Errorf("admin should resolve to admin; got %q", got)
+	}
+	if got := rbacAssignTierResolved("DEVELOPER"); got != "developer" {
+		t.Errorf("case-insensitive; got %q", got)
+	}
+}
+
+func TestRBACAssignScopeKeyForType_Mappings(t *testing.T) {
+	cases := map[string]string{
+		"application":  scopeKeyApplication,
+		"app":          scopeKeyApplication,
+		"organization": scopeKeyOrg,
+		"org":          scopeKeyOrg,
+		"env-type":     scopeKeyEnvType,
+		"envType":      scopeKeyEnvType,
+		"custom":       "custom", // pass-through
+	}
+	for in, want := range cases {
+		if got := rbacAssignScopeKeyForType(in); got != want {
+			t.Errorf("%q→%q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestValidateRBACAssignRequest_SuperAdmin(t *testing.T) {
+	body := rbacAssignRequest{
+		User: rbacAssignUserBody{Email: "qa@openova.io"},
+		Tier: "super-admin",
+	}
+	if msg, ok := validateRBACAssignRequest(body); !ok {
+		t.Errorf("super-admin should validate; got %q", msg)
+	}
+}
+
+// ── user_access.go: short-form email/tier ──
+
+func TestUserAccessRequestNormalize_PostShortForm(t *testing.T) {
+	body := userAccessRequest{
+		EmailShort: "qa-user2@openova.io",
+		TierShort:  "viewer",
+	}
+	out := userAccessRequestNormalize(body, "sovereign-omantel.biz", "")
+	if out.Name == "" {
+		t.Errorf("Name should be derived from email")
+	}
+	if out.Spec.User.KeycloakSubject != "qa-user2@openova.io" {
+		t.Errorf("KeycloakSubject not derived from email; got %q", out.Spec.User.KeycloakSubject)
+	}
+	if out.Spec.SovereignRef != "sovereign-omantel.biz" {
+		t.Errorf("SovereignRef not derived from depID; got %q", out.Spec.SovereignRef)
+	}
+	if len(out.Spec.Applications) != 1 {
+		t.Fatalf("Applications length=%d, want 1", len(out.Spec.Applications))
+	}
+	if out.Spec.Applications[0].App != "*" {
+		t.Errorf("App=%q, want *", out.Spec.Applications[0].App)
+	}
+	if out.Spec.Applications[0].Role != "viewer" {
+		t.Errorf("Role=%q, want viewer", out.Spec.Applications[0].Role)
+	}
+}
+
+func TestUserAccessRequestNormalize_PutShortForm(t *testing.T) {
+	body := userAccessRequest{TierShort: "developer"}
+	out := userAccessRequestNormalize(body, "sov", "qa-user2")
+	if out.Name != "qa-user2" {
+		t.Errorf("Name should come from urlName; got %q", out.Name)
+	}
+	if len(out.Spec.Applications) != 1 || out.Spec.Applications[0].Role != "editor" {
+		t.Errorf("developer should map to editor; got %+v", out.Spec.Applications)
+	}
+}
+
+func TestUserAccessTierToRole(t *testing.T) {
+	cases := map[string]string{
+		"viewer":      "viewer",
+		"developer":   "editor",
+		"operator":    "editor",
+		"admin":       "admin",
+		"owner":       "admin",
+		"super-admin": "admin",
+		"DEVELOPER":   "editor",
+		"unknown":     "unknown", // pass-through
+	}
+	for in, want := range cases {
+		if got := userAccessTierToRole(in); got != want {
+			t.Errorf("%q→%q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestIsUserAccessShortFormPut(t *testing.T) {
+	cases := []struct {
+		name string
+		body userAccessRequest
+		want bool
+	}{
+		{"bare-tier", userAccessRequest{TierShort: "developer"}, true},
+		{"bare-email", userAccessRequest{EmailShort: "x@y.io"}, true},
+		{"long-form-no-aliases", userAccessRequest{Spec: userAccessSpecBody{Applications: []userAccessAppGrantBody{{App: "wp", Role: "editor"}}}}, false},
+		{"mixed-with-real-app", userAccessRequest{TierShort: "x", Spec: userAccessSpecBody{Applications: []userAccessAppGrantBody{{App: "wp", Role: "editor"}}}}, false},
+		{"groups-set", userAccessRequest{TierShort: "x", Spec: userAccessSpecBody{User: userAccessUserBody{KeycloakGroups: []string{"g1"}}}}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isUserAccessShortFormPut(tc.body); got != tc.want {
+				t.Errorf("got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// ── continuum.go: short-form `target` alias ──
+//
+// The handler-level promotion (Target → TargetRegion) lives inline in
+// HandleContinuumSwitchoverRequest; this assertion guards the struct
+// shape so a future refactor can't silently drop the alias field.
+
+func TestContinuumSwitchoverRequest_TargetAlias(t *testing.T) {
+	body := continuumSwitchoverRequest{Target: "hz-hel-rtz-prod"}
+	if body.Target != "hz-hel-rtz-prod" {
+		t.Errorf("Target field must be present and round-trip; got %q", body.Target)
+	}
+	if body.TargetRegion != "" {
+		t.Errorf("TargetRegion not auto-populated by struct (handler does it); got %q", body.TargetRegion)
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/handler/user_access.go
+++ b/products/catalyst/bootstrap/api/internal/handler/user_access.go
@@ -50,6 +50,7 @@ package handler
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"strings"
 
@@ -91,9 +92,167 @@ var userAccessRoles = map[string]struct{}{
 
 /* ── Wire shapes — match the CRD .spec verbatim ─────────────────── */
 
+// userAccessRequest is the body of POST /admin/user-access and PUT
+// /admin/user-access/{name}.
+//
+// Two equivalent shapes are accepted (per
+// `feedback_no_mvp_no_workarounds.md` — the canonical UAT matrix is
+// the contract):
+//
+//  1. Long form (production internal callers + the IAM editor UI):
+//     { "name":"acme-rb-1",
+//     "spec":{ "user":{...}, "sovereignRef":"acme",
+//     "applications":[{...}] } }
+//
+//  2. Short form (canonical UAT matrix vocabulary):
+//     POST { "email":"qa-user2@openova.io", "tier":"viewer" }
+//     PUT  { "tier":"developer" }   (name comes from the URL)
+//
+// The short form collapses onto the long form via
+// userAccessRequestNormalize:
+//
+//	email      → User.KeycloakSubject (until Keycloak resolves it; the
+//	             controller will rotate this to the real subject UUID
+//	             on first reconcile via a sub-claim lookup)
+//	tier       → Applications[0].Role  (via userAccessTierToRole)
+//	            + Applications[0].App = "*" (sovereign-wide grant)
+//
+// The depId path-param drives sovereignRef when the body omits it.
 type userAccessRequest struct {
 	Name string             `json:"name"`
 	Spec userAccessSpecBody `json:"spec"`
+
+	// Short-form aliases (canonical UAT matrix vocabulary).
+	EmailShort string `json:"email,omitempty"`
+	TierShort  string `json:"tier,omitempty"`
+}
+
+// userAccessTierToRole maps the canonical 6-tier vocabulary onto the
+// 3-role short-form the UserAccess CRD's enum allows. Aligns with the
+// EPIC-3 T1 (#1142) 5-tier ClusterRoles + the cross-org `super-admin`
+// sentinel.
+//
+//	viewer       → viewer
+//	developer    → editor
+//	operator     → editor
+//	admin        → admin
+//	owner        → admin
+//	super-admin  → admin
+//
+// Unknown tiers fall through to the input — validation later rejects
+// them with a clear 400 listing the allowed set.
+func userAccessTierToRole(tier string) string {
+	switch strings.ToLower(strings.TrimSpace(tier)) {
+	case "viewer":
+		return "viewer"
+	case "developer", "operator":
+		return "editor"
+	case "admin", "owner", "super-admin":
+		return "admin"
+	}
+	return strings.TrimSpace(tier)
+}
+
+// userAccessRequestNormalize collapses the short-form aliases onto
+// the long-form fields. The `depID` is the path-param so the handler
+// can derive sovereignRef when the body omits it (the matrix's short
+// form does). `urlName` is the {name} URL-param (PUT path) when set.
+func userAccessRequestNormalize(b userAccessRequest, depID, urlName string) userAccessRequest {
+	if strings.TrimSpace(b.Name) == "" {
+		if strings.TrimSpace(urlName) != "" {
+			b.Name = strings.TrimSpace(urlName)
+		} else if strings.TrimSpace(b.EmailShort) != "" {
+			b.Name = userAccessSanitizeName(strings.ToLower(strings.TrimSpace(b.EmailShort)))
+			if b.Name == "" {
+				b.Name = fmt.Sprintf("ua-%08x", userAccessFNV32a(strings.TrimSpace(b.EmailShort)))
+			}
+			if len(b.Name) > 63 {
+				b.Name = b.Name[:63]
+			}
+		}
+	}
+	if strings.TrimSpace(b.Spec.User.KeycloakSubject) == "" && strings.TrimSpace(b.EmailShort) != "" {
+		b.Spec.User.KeycloakSubject = strings.TrimSpace(b.EmailShort)
+	}
+	if strings.TrimSpace(b.Spec.SovereignRef) == "" && strings.TrimSpace(depID) != "" {
+		b.Spec.SovereignRef = strings.TrimSpace(depID)
+	}
+	if strings.TrimSpace(b.TierShort) != "" {
+		role := userAccessTierToRole(b.TierShort)
+		if len(b.Spec.Applications) == 0 {
+			b.Spec.Applications = []userAccessAppGrantBody{{
+				App:  "*",
+				Role: role,
+			}}
+		} else {
+			// PUT short-form on an existing-shape CR: rotate every app's
+			// role to the new tier-derived role.
+			for i := range b.Spec.Applications {
+				b.Spec.Applications[i].Role = role
+			}
+		}
+	}
+	return b
+}
+
+// isUserAccessShortFormPut reports whether the request body looks like
+// the canonical UAT matrix's PUT short form — only `tier` (or `email`)
+// supplied, no full long-form spec. Used by UpdateUserAccess to merge
+// the existing CR's user/sovereignRef/applications when the body omits
+// them rather than replacing with empty values.
+func isUserAccessShortFormPut(b userAccessRequest) bool {
+	if strings.TrimSpace(b.TierShort) == "" && strings.TrimSpace(b.EmailShort) == "" {
+		return false
+	}
+	// Long-form indicators: explicit applications list, or explicit
+	// keycloakGroups, or explicit sovereignRef. When ANY of those are
+	// present the caller is doing a real long-form replace.
+	if len(b.Spec.Applications) > 1 {
+		return false
+	}
+	if len(b.Spec.Applications) == 1 && b.Spec.Applications[0].App != "*" {
+		return false
+	}
+	if len(b.Spec.User.KeycloakGroups) > 0 {
+		return false
+	}
+	return true
+}
+
+// userAccessSanitizeName — RFC 1123 lowercase alphanumeric + hyphens
+// (no leading/trailing hyphen). Mirrors sanitizeK8sNameSegment in
+// rbac_assign.go but local to user_access.go to avoid a cross-file
+// dependency on the package-private helper while keeping the import
+// graph clean.
+func userAccessSanitizeName(s string) string {
+	var sb strings.Builder
+	for _, r := range strings.ToLower(s) {
+		switch {
+		case r >= 'a' && r <= 'z':
+			sb.WriteRune(r)
+		case r >= '0' && r <= '9':
+			sb.WriteRune(r)
+		case r == '-':
+			sb.WriteRune(r)
+		}
+	}
+	return strings.Trim(sb.String(), "-")
+}
+
+// userAccessFNV32a — FNV-1a 32-bit hash. Mirrors fnv32a in
+// rbac_assign.go. Local copy keeps user_access.go independently
+// re-orderable in the package.
+func userAccessFNV32a(s string) uint32 {
+	const (
+		offset32 = 2166136261
+		prime32  = 16777619
+	)
+	var h uint32 = offset32
+	for i := 0; i < len(s); i++ {
+		h ^= uint32(s[i])
+		h *= prime32
+	}
+	return h
 }
 
 type userAccessSpecBody struct {
@@ -188,6 +347,7 @@ func (h *Handler) CreateUserAccess(w http.ResponseWriter, r *http.Request) {
 	if !decodeMutationBody(w, r, &body) {
 		return
 	}
+	body = userAccessRequestNormalize(body, depID, "")
 	if msg, ok := validateUserAccess(body); !ok {
 		writeBadRequest(w, "invalid-user-access", msg)
 		return
@@ -239,10 +399,7 @@ func (h *Handler) UpdateUserAccess(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	body.Name = name
-	if msg, ok := validateUserAccess(body); !ok {
-		writeBadRequest(w, "invalid-user-access", msg)
-		return
-	}
+	body = userAccessRequestNormalize(body, depID, name)
 	client, err := h.sovereignDynamicClient(dep)
 	if err != nil {
 		writeUserAccessUnavailable(w, err)
@@ -261,6 +418,43 @@ func (h *Handler) UpdateUserAccess(w http.ResponseWriter, r *http.Request) {
 			"error":  "get-failed",
 			"detail": err.Error(),
 		})
+		return
+	}
+	// PUT short-form merge: the canonical UAT matrix sends `{"tier":"X"}`
+	// expecting the existing CR's user/sovereignRef/applications to be
+	// preserved with only the role rotated. Pull the current CR's spec
+	// in as a baseline and re-run normalize so the tier rotation
+	// applies on top of the existing applications list.
+	if isUserAccessShortFormPut(body) {
+		curItem := unstructuredToUserAccess(current)
+		// Carry forward the current CR's identity + scope.
+		if strings.TrimSpace(body.Spec.User.KeycloakSubject) == "" {
+			body.Spec.User.KeycloakSubject = curItem.Spec.User.KeycloakSubject
+		}
+		if len(body.Spec.User.KeycloakGroups) == 0 {
+			body.Spec.User.KeycloakGroups = curItem.Spec.User.KeycloakGroups
+		}
+		if strings.TrimSpace(body.Spec.SovereignRef) == "" {
+			body.Spec.SovereignRef = curItem.Spec.SovereignRef
+		}
+		if len(body.Spec.Applications) == 0 || (len(body.Spec.Applications) == 1 && body.Spec.Applications[0].App == "*") {
+			// Either nothing yet (tier wasn't supplied — no change), or
+			// the tier-rotation sentinel ("*"). When the CR already has
+			// per-app grants, rotate THOSE to the new tier-derived role
+			// instead of replacing them with the wildcard sentinel.
+			if len(curItem.Spec.Applications) > 0 && strings.TrimSpace(body.TierShort) != "" {
+				role := userAccessTierToRole(body.TierShort)
+				rotated := make([]userAccessAppGrantBody, 0, len(curItem.Spec.Applications))
+				for _, app := range curItem.Spec.Applications {
+					app.Role = role
+					rotated = append(rotated, app)
+				}
+				body.Spec.Applications = rotated
+			}
+		}
+	}
+	if msg, ok := validateUserAccess(body); !ok {
+		writeBadRequest(w, "invalid-user-access", msg)
 		return
 	}
 	desired := userAccessToUnstructured(body)


### PR DESCRIPTION
## Summary

Iter-7 of the qa-loop on omantel surfaced 21 FAILs all with the same shape: handlers reject POST/PUT bodies with `{"error":"invalid-body","detail":"json: unknown field \"X\""}` for fields the canonical UAT matrix sends.

Per `feedback_no_mvp_no_workarounds.md` the matrix is the target-state contract; the handlers MUST conform to it. This PR widens 7 handler request structs to accept the matrix's short-form vocabulary while preserving the strict `DisallowUnknownFields()` typo-detection gate.

## Endpoints widened

| Endpoint | Field(s) added |
|---|---|
| PUT  /environments/{env}/policy | `mode`, `policy` (single + bulk-via-`*` sentinel) |
| POST /applications | `blueprint`, `version`, `namespace`, `values` |
| POST /applications/preview | `blueprint`, `version`, `namespace`, `values` |
| PUT  /applications/{name} | `values`, `version`, `toVersion` |
| POST /applications/{name}/upgrade/preview | `toVersion`, `version`, `blueprint`, `values` |
| POST /rbac/assign | `email`, `scopeType`, `scopeName` (+ `super-admin` tier) |
| POST /admin/user-access | `email`, `tier` |
| PUT  /admin/user-access/{name} | `tier` (with merge-from-current) |
| POST /continuum/{name}/switchover | `target` (alias for `targetRegion`) |

Each alias actively wires through to the underlying business logic — `toVersion` becomes `BlueprintRef.Version` on the upgrade renderer; `email` becomes `User.Email` on rbac/assign; `target` becomes `TargetRegion` on the Continuum CR patch. The audit trail records the request-vocabulary tier ("super-admin") even when the resolved ClusterRole binding collapses to "owner".

## TC IDs that should flip PASS in iter-8

- **EPIC-1 policy:** TC-027, TC-028, TC-041
- **EPIC-2 apps:** TC-064, TC-065, TC-078, TC-108
- **EPIC-3 rbac:** TC-128, TC-135, TC-156, TC-157, TC-168
- **EPIC-6 continuum:** TC-312, TC-315, TC-316, TC-319, TC-320, TC-321, TC-322, TC-323, TC-324

## Test plan

- [x] Add `short_form_vocab_test.go` with unit coverage for every normalize function + helper (~25 sub-tests)
- [x] Existing unit tests unaffected (every alias is `omitempty` so existing struct literals continue to compile)
- [x] CI runs `test-bootstrap-api.yaml` on push
- [ ] After merge: `catalyst-build.yaml` produces SHA-pinned image, omantel rolls automatically
- [ ] Iter-8 Executor verifies the 21 affected TCs flip PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)