### PR TITLE
fix(bootstrap-kit): bump bp-catalyst-platform HR pin to 1.4.101 (Fix #37 follow-up)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -265,7 +265,7 @@ spec:
       # ClusterRole to grant continuums/cnpgpairs/pdms verbs (TC-344).
       # Bp-crossplane-claims 1.1.2 carries the matching tier-operator
       # extras update.
-      version: 1.4.100
+      version: 1.4.101
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform


### PR DESCRIPTION
## Summary

Pairs with PR #1228 — bumps the HR.spec.chart.spec.version pin in clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml so the chart 1.4.101 fixtures (cnpg-clusters-qa.yaml + kyverno-policies-qa.yaml + cnpgpair CRD printer columns) actually flow through to the cluster. Without this, Flux keeps re-applying the 1.4.100 pin every reconcile and the fixtures never land.

Per `.claude/qa-loop-state/incidents.md` §"Chart 1.4.98 stuck at HR.spec.version=1.4.97" — known issue documented during iter-6.

## Test plan
- [ ] CI pre-merge checks pass
- [ ] HelmChart artifact updates to 1.4.101
- [ ] `kubectl get cluster.postgresql.cnpg.io -n qa-omantel` shows cluster-primary + cluster-replica
- [ ] `kubectl get clusterpolicy` shows 19 baseline policies

🤖 Generated with [Claude Code](https://claude.com/claude-code)