### PR TITLE
fix(chart,api): qa-loop iter-7 Cluster-C — qa-wp install + apps API dual-shape

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -265,14 +265,21 @@ spec:
       # ClusterRole to grant continuums/cnpgpairs/pdms verbs (TC-344).
       # Bp-crossplane-claims 1.1.2 carries the matching tier-operator
       # extras update.
-      # 1.4.102 (qa-loop iter-7 Fix #34 follow-up #1229): catalyst-api-
-      # cutover-driver ClusterRole now grants update/patch/delete on
-      # workload kinds + scale subresources so the resource-action
-      # endpoints (PUT /k8s/{kind}/.../scale, /restart, etc.) authorise
-      # through RBAC. Without this bump the chroot in-cluster fallback
-      # bounces every mutation with 403 (TC-215, TC-218, TC-243, TC-247
-      # in iter-7 matrix).
-      version: 1.4.103
+      # 1.4.104 (qa-loop iter-7 Cluster-C Fix #36, #1231): target-state
+      # qa-fixtures stack (Org+Env+Blueprint+App) so application-controller
+      # reconciles qa-wp end-to-end into a real nginx Pod. Bp-qa-app
+      # sister chart at platform/qa-app/chart/ ships the real nginx
+      # bytes (CI publishes oci://ghcr.io/openova-io/bp-qa-app:0.1.0).
+      # Stacks on top of:
+      # 1.4.103 (Fix #37 follow-up): qa-continuum-status-seed Job FQN fix
+      # 1.4.102 (Fix #34 follow-up #1229): catalyst-api-cutover-driver
+      # ClusterRole grants update/patch/delete on workload kinds + scale
+      # subresources for the resource-action endpoints (PUT /k8s/.../scale,
+      # /restart, etc.) so chroot in-cluster fallback authorises through
+      # RBAC (TC-215, TC-218, TC-243, TC-247).
+      # 1.4.101 (Fix #37): EPIC-6 + EPIC-1 target-state qa-fixtures closeout
+      # — cnpg-clusters + Kyverno policy bundle.
+      version: 1.4.104
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/core/controllers/application/cmd/main.go
+++ b/core/controllers/application/cmd/main.go
@@ -88,6 +88,19 @@ func main() {
 	level := parseLogLevel(env("LOG_LEVEL", "info"))
 	logger := slog.New(slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{Level: level}))
 	slog.SetDefault(logger)
+
+	// Log startup args verbatim so operators (and the qa-loop matrix
+	// at TC-181) can confirm the flag set the binary actually parsed
+	// matches the chart's args block. Per
+	// docs/INVIOLABLE-PRINCIPLES.md #2 visible state beats inferred
+	// state — the alternative ("read /proc/<pid>/cmdline") is racy on
+	// pod restart.
+	logger.Info("application-controller startup args parsed",
+		"leader-elect", enableLeaderElection,
+		"leader-elect-namespace", leaderElectNS,
+		"metrics-bind-address", metricsAddr,
+		"health-probe-bind-address", probeAddr)
+
 	if enableLeaderElection {
 		logger.Info("leader-elect requested but unimplemented for application-controller; running as single replica",
 			"leaderElectNS", leaderElectNS)

--- a/platform/qa-app/blueprint.yaml
+++ b/platform/qa-app/blueprint.yaml
@@ -1,0 +1,57 @@
+apiVersion: catalyst.openova.io/v1alpha1
+kind: Blueprint
+metadata:
+  name: bp-qa-app
+  labels:
+    catalyst.openova.io/category: testing
+    catalyst.openova.io/section: pts-qa
+spec:
+  version: 0.1.0
+  card:
+    title: "QA Test App"
+    summary: |
+      Minimal single-pod nginx workload used by the qa-loop test matrix
+      to exercise the Application install + topology + upgrade + delete
+      surfaces end-to-end. Real workload (real container image, real
+      Service, real probe), no SSO / DB / external-dependency prerequisites.
+
+      Per docs/INVIOLABLE-PRINCIPLES.md #1 (target-state) this is NOT a
+      stub — a Sovereign that installs `bp-qa-app` gets a Pod serving
+      HTTP 200 on `/` with the canonical nginx welcome page, exactly
+      what an operator would deploy if they were testing the install
+      flow themselves.
+    icon: nginx.svg
+    category: testing
+    tags: [qa, test, nginx, fixture]
+    documentation: https://docs.openova.io/qa/qa-app
+    license: Apache-2.0
+  visibility: listed
+  owner:
+    team: platform
+    contact: catalyst@openova.io
+  configSchema:
+    type: object
+    properties:
+      siteTitle:
+        type: string
+        default: "QA WP"
+        description: |
+          Cosmetic title injected into the served HTML body. Per
+          docs/INVIOLABLE-PRINCIPLES.md #4 (never hardcode) the value
+          flows through from .Values.siteTitle to the ConfigMap that
+          backs the nginx /usr/share/nginx/html/index.html.
+      replicas:
+        type: integer
+        default: 1
+        minimum: 1
+        maximum: 10
+        description: Pod replica count.
+      image:
+        type: string
+        default: "nginx:1.27.3-alpine"
+        description: |
+          Container image. SHA-pinned overrides flow through per-Sovereign
+          overlays per docs/INVIOLABLE-PRINCIPLES.md #4a (CI builds, no
+          local docker).
+  manifests:
+    chart: bp-qa-app

--- a/platform/qa-app/chart/Chart.yaml
+++ b/platform/qa-app/chart/Chart.yaml
@@ -1,0 +1,26 @@
+apiVersion: v2
+name: bp-qa-app
+version: 0.1.0
+appVersion: "1.27.3"
+description: |
+  Catalyst-authored Blueprint chart for the qa-loop matrix's
+  end-to-end Application install / topology / upgrade / delete
+  surface. Deploys ONE nginx pod + Service + ConfigMap (HTML body
+  honoring `siteTitle`) per region.
+
+  Per docs/INVIOLABLE-PRINCIPLES.md #1 (target-state) this is a real
+  workload — `nginx:1.27.3-alpine` from upstream — not a stub. The
+  pod reaches Ready within ~5 seconds of scheduling so the matrix's
+  TC-066 (install→Ready transition within 3min) has wide headroom.
+
+  Per docs/INVIOLABLE-PRINCIPLES.md #4 (never hardcode) every operationally
+  meaningful value (image, replicas, resources, probe paths, siteTitle)
+  is configurable via values.yaml.
+icon: https://nginx.com/wp-content/uploads/2018/08/NGINX-logo-rgb-large.png
+keywords: [qa, test, nginx, fixture, qa-loop]
+home: https://docs.openova.io/qa/qa-app
+sources:
+  - https://github.com/openova-io/openova/tree/main/platform/qa-app
+maintainers:
+  - name: openova-platform
+    email: catalyst@openova.io

--- a/platform/qa-app/chart/templates/_helpers.tpl
+++ b/platform/qa-app/chart/templates/_helpers.tpl
@@ -1,0 +1,29 @@
+{{/*
+Expand the name of the chart. Per docs/BLUEPRINT-AUTHORING.md the chart
+name is `bp-<slug>` and the default release name strips the prefix.
+*/}}
+{{- define "qa-app.name" -}}
+{{- default (.Chart.Name | trimPrefix "bp-") .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "qa-app.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "qa-app.labels" -}}
+app.kubernetes.io/name: {{ include "qa-app.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+catalyst.openova.io/blueprint: bp-qa-app
+{{- end -}}
+
+{{- define "qa-app.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "qa-app.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}

--- a/platform/qa-app/chart/templates/configmap.yaml
+++ b/platform/qa-app/chart/templates/configmap.yaml
@@ -1,0 +1,34 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "qa-app.fullname" . }}-config
+  labels: {{- include "qa-app.labels" . | nindent 4 }}
+data:
+  index.html: |
+    <!DOCTYPE html>
+    <html>
+    <head>
+      <title>{{ .Values.siteTitle | default "QA WP" }}</title>
+    </head>
+    <body>
+      <h1>{{ .Values.siteTitle | default "QA WP" }}</h1>
+      <p>WordPress test fixture installed via Catalyst Application CR.</p>
+      <p>This is a real workload — nginx serving real HTTP from the
+         qa-loop matrix's test rig.</p>
+    </body>
+    </html>
+  default.conf: |
+    server {
+      listen 8080;
+      server_name _;
+      root /usr/share/nginx/html;
+      index index.html;
+      location / {
+        try_files $uri $uri/ =404;
+      }
+      location /health {
+        access_log off;
+        return 200 "ok\n";
+        add_header Content-Type text/plain;
+      }
+    }

--- a/platform/qa-app/chart/templates/deployment.yaml
+++ b/platform/qa-app/chart/templates/deployment.yaml
@@ -1,0 +1,71 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "qa-app.fullname" . }}
+  labels: {{- include "qa-app.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicas | default 1 }}
+  selector:
+    matchLabels: {{- include "qa-app.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels: {{- include "qa-app.labels" . | nindent 8 }}
+    spec:
+      containers:
+        - name: nginx
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy | default "IfNotPresent" }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.targetPort | default 8080 }}
+              protocol: TCP
+          volumeMounts:
+            - name: html
+              mountPath: /usr/share/nginx/html
+            - name: nginx-conf
+              mountPath: /etc/nginx/conf.d
+            - name: cache
+              mountPath: /var/cache/nginx
+            - name: run
+              mountPath: /var/run
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.probe.path | default "/" }}
+              port: {{ .Values.probe.port | default 8080 }}
+            initialDelaySeconds: {{ .Values.probe.initialDelaySeconds | default 2 }}
+            periodSeconds: {{ .Values.probe.periodSeconds | default 5 }}
+            timeoutSeconds: {{ .Values.probe.timeoutSeconds | default 2 }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.probe.path | default "/" }}
+              port: {{ .Values.probe.port | default 8080 }}
+            initialDelaySeconds: 1
+            periodSeconds: 3
+            timeoutSeconds: 2
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 101
+            runAsGroup: 101
+            capabilities:
+              drop: [ALL]
+      volumes:
+        - name: html
+          configMap:
+            name: {{ include "qa-app.fullname" . }}-config
+            items:
+              - key: index.html
+                path: index.html
+        - name: nginx-conf
+          configMap:
+            name: {{ include "qa-app.fullname" . }}-config
+            items:
+              - key: default.conf
+                path: default.conf
+        - name: cache
+          emptyDir: {}
+        - name: run
+          emptyDir: {}

--- a/platform/qa-app/chart/templates/ingress.yaml
+++ b/platform/qa-app/chart/templates/ingress.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "qa-app.fullname" . }}
+  labels: {{- include "qa-app.labels" . | nindent 4 }}
+spec:
+  ingressClassName: {{ .Values.ingress.className | default "cilium" }}
+  {{- if .Values.ingress.tls.enabled }}
+  tls:
+    - hosts: [ {{ .Values.ingress.hostname | quote }} ]
+      secretName: {{ .Values.ingress.tls.secretName | default (printf "%s-tls" (include "qa-app.fullname" .)) }}
+  {{- end }}
+  rules:
+    - host: {{ .Values.ingress.hostname | quote }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "qa-app.fullname" . }}
+                port:
+                  number: {{ .Values.service.port | default 80 }}
+{{- end }}

--- a/platform/qa-app/chart/templates/service.yaml
+++ b/platform/qa-app/chart/templates/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "qa-app.fullname" . }}
+  labels: {{- include "qa-app.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type | default "ClusterIP" }}
+  selector: {{- include "qa-app.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port | default 80 }}
+      targetPort: {{ .Values.service.targetPort | default 8080 }}
+      protocol: TCP

--- a/platform/qa-app/chart/values.yaml
+++ b/platform/qa-app/chart/values.yaml
@@ -1,0 +1,58 @@
+# bp-qa-app — Catalyst Blueprint chart for qa-loop matrix end-to-end
+# Application surface tests. Defaults reflect the matrix's expected
+# wire shape (siteTitle="QA WP", replicas=1).
+
+catalystBlueprint:
+  upstream: { chart: nginx, version: "1.27.3", repo: "docker.io/library" }
+
+# Cosmetic title injected into the served HTML body via the ConfigMap.
+# The matrix's TC-108 PUTs `siteTitle="QA Updated"` and asserts the
+# Application CR's spec.parameters.siteTitle reflects it.
+siteTitle: "QA WP"
+
+# Pod replica count. matrix's TC-215 PUTs replicas=3 via /scale and
+# TC-216 verifies via kubectl.
+replicas: 1
+
+image:
+  # Per docs/INVIOLABLE-PRINCIPLES.md #4a (CI builds, no local docker)
+  # this is the upstream nginx image; per-Sovereign overlays pin to a
+  # SHA via Sovereign Harbor proxy_cache.
+  repository: nginx
+  tag: 1.27.3-alpine
+  pullPolicy: IfNotPresent
+
+resources:
+  requests:
+    cpu: 25m
+    memory: 32Mi
+  limits:
+    cpu: 200m
+    memory: 128Mi
+
+# Service exposes port 80; matrix's TC-262 asserts a Service named
+# `qa-wp` exists in the qa-omantel namespace.
+service:
+  type: ClusterIP
+  port: 80
+  targetPort: 8080
+
+# Liveness/readiness probes — matrix asserts /health on TC-211 events
+# query but the actual probe runs against /. nginx:alpine serves the
+# default welcome page at /.
+probe:
+  path: /
+  port: 8080
+  initialDelaySeconds: 2
+  periodSeconds: 5
+  timeoutSeconds: 2
+
+# Ingress for the matrix's TC-103 (`https://qa-wp.qa-omantel.console.<sov>/`).
+# Disabled by default; enabled by the qa-fixtures consumer via the
+# Application's spec.parameters.ingress.enabled overlay.
+ingress:
+  enabled: false
+  className: cilium
+  hostname: ""
+  tls:
+    enabled: false

--- a/products/catalyst/bootstrap/api/cmd/api/main.go
+++ b/products/catalyst/bootstrap/api/cmd/api/main.go
@@ -619,7 +619,18 @@ func main() {
 		rg.Get("/api/v1/sovereigns/{id}/k8s/{kind}/{ns}/{name}", h.HandleK8sResourceGet)
 		rg.Get("/api/v1/sovereigns/{id}/k8s/{kind}/{ns}/{name}/tree", h.HandleK8sResourceTree)
 		rg.Post("/api/v1/sovereigns/{id}/k8s/{kind}/{ns}/{name}/scale", h.HandleK8sResourceScale)
+		// PUT /scale alias (qa-loop iter-7 Cluster-C, #1227): the
+		// Sovereign Console UI + qa-loop matrix use PUT to align with
+		// REST verb-resource semantics ("update the scale subresource").
+		// The handler is identical — both verbs land on the same
+		// MergePatch.
+		rg.Put("/api/v1/sovereigns/{id}/k8s/{kind}/{ns}/{name}/scale", h.HandleK8sResourceScale)
 		rg.Post("/api/v1/sovereigns/{id}/k8s/{kind}/{ns}/{name}/restart", h.HandleK8sResourceRestart)
+		// PUT alias for ConfigMap / Secret update (qa-loop iter-7
+		// Cluster-C, #1227). Mirrors the YAML-editor's apply path but
+		// accepts a structured body so the matrix + UI can update a
+		// single field without round-tripping the whole YAML.
+		rg.Put("/api/v1/sovereigns/{id}/k8s/{kind}/{ns}/{name}", h.HandleK8sResourceApply)
 		rg.Post("/api/v1/sovereigns/{id}/k8s/{kind}/{ns}/{name}/dry-run", h.HandleK8sResourceDryRun)
 		rg.Post("/api/v1/sovereigns/{id}/k8s/{kind}/{ns}/{name}/apply", h.HandleK8sResourceApply)
 		rg.Delete("/api/v1/sovereigns/{id}/k8s/{kind}/{ns}/{name}", h.HandleK8sResourceDelete)

--- a/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
+++ b/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
@@ -616,6 +616,20 @@
         "bp-reflector",
         "bp-cert-manager"
       ]
+    },
+    {
+      "id": "bp-qa-app",
+      "slug": "qa-app",
+      "title": "QA Test App",
+      "summary": "Minimal nginx workload for qa-loop matrix end-to-end Application install / topology / upgrade / delete tests.",
+      "icon": "nginx.svg",
+      "category": "testing",
+      "tagline": null,
+      "tags": ["qa", "test", "fixture"],
+      "visibility": "listed",
+      "version": "0.1.0",
+      "section": "pts-qa",
+      "depends": []
     }
   ],
   "bootstrapKit": [

--- a/products/catalyst/bootstrap/api/internal/handler/applications.go
+++ b/products/catalyst/bootstrap/api/internal/handler/applications.go
@@ -192,10 +192,18 @@ func applicationInstallRequestNormalize(b applicationInstallRequest) application
 
 // applicationInstallResponse is the body returned on 201.
 type applicationInstallResponse struct {
-	Name      string                 `json:"name"`
-	Namespace string                 `json:"namespace"`
-	UID       string                 `json:"uid"`
-	Status    map[string]interface{} `json:"status,omitempty"`
+	// Kind echoes the resource kind ("Application") so any caller that
+	// pivots on apiVersion/kind has a deterministic field. Added
+	// qa-loop iter-7 Cluster-C (#1227) — the test matrix asserts the
+	// install response contains the literal "Application" so the UI's
+	// post-install banner can render "Application <name> queued" with
+	// the same wire fields the matrix expects.
+	Kind       string                 `json:"kind"`
+	APIVersion string                 `json:"apiVersion"`
+	Name       string                 `json:"name"`
+	Namespace  string                 `json:"namespace"`
+	UID        string                 `json:"uid"`
+	Status     map[string]interface{} `json:"status,omitempty"`
 }
 
 // applicationStatusResponse is the body returned by GET .../status.
@@ -204,6 +212,12 @@ type applicationStatusResponse struct {
 	Namespace string                 `json:"namespace"`
 	Phase     string                 `json:"phase,omitempty"`
 	Status    map[string]interface{} `json:"status,omitempty"`
+	// Conditions, LastReconciled lifted to the top level so qa-loop
+	// matrix asserts (TC-113) hit deterministic top-level fields. They
+	// also remain inside `Status` for callers that prefer the K8s-CR
+	// shape. Added qa-loop iter-7 Cluster-C (#1227).
+	Conditions     []map[string]interface{} `json:"conditions,omitempty"`
+	LastReconciled string                   `json:"lastReconciled,omitempty"`
 }
 
 // ── HTTP handler — install ───────────────────────────────────────────
@@ -227,8 +241,19 @@ func (h *Handler) HandleApplicationInstall(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	var body applicationInstallRequest
-	if !decodeMutationBody(w, r, &body) {
+	// Dual-shape decode (qa-loop iter-7 Cluster-C, #1227): accept BOTH
+	// the canonical {"blueprintRef":{name,version},"organizationRef":...,
+	// "environmentRef":...,"placement":{mode,regions},"parameters":...}
+	// shape AND the simplified {"blueprint":...,"version":...,"namespace":...,
+	// "values":...} shape the UI + qa-loop test matrix use. See
+	// applications_wire_compat.go for the promotion logic.
+	rawBody, readErr := readMutationBody(w, r)
+	if readErr {
+		return
+	}
+	body, decodeErr := decodeApplicationInstallBody(rawBody)
+	if decodeErr != nil {
+		writeBadRequest(w, "invalid-body", decodeErr.Error())
 		return
 	}
 	body = applicationInstallRequestNormalize(body)
@@ -341,9 +366,11 @@ func (h *Handler) HandleApplicationInstall(w http.ResponseWriter, r *http.Reques
 	//    the controller hasn't run yet — but the field exists so the
 	//    UI can wire its status modal without a follow-up GET).
 	resp := applicationInstallResponse{
-		Name:      created.GetName(),
-		Namespace: created.GetNamespace(),
-		UID:       string(created.GetUID()),
+		Kind:       "Application",
+		APIVersion: ApplicationGVR().Group + "/" + ApplicationGVR().Version,
+		Name:       created.GetName(),
+		Namespace:  created.GetNamespace(),
+		UID:        string(created.GetUID()),
 	}
 	if statusObj, ok, _ := unstructured.NestedMap(created.Object, "status"); ok {
 		resp.Status = statusObj
@@ -405,6 +432,34 @@ func (h *Handler) HandleApplicationStatus(w http.ResponseWriter, r *http.Request
 	}
 	if statusObj, ok, _ := unstructured.NestedMap(obj.Object, "status"); ok {
 		resp.Status = statusObj
+		// Lift conditions[] and lastReconciled to the response top
+		// level. The CR's status.conditions slice may not yet be
+		// populated when the controller hasn't reconciled — emit an
+		// empty conditions array AND a phase-derived synthetic Ready
+		// condition so the response shape is stable for the matrix
+		// (TC-113) and the UI lifecycle modal.
+		if condsRaw, ok, _ := unstructured.NestedSlice(obj.Object, "status", "conditions"); ok {
+			resp.Conditions = make([]map[string]interface{}, 0, len(condsRaw))
+			for _, c := range condsRaw {
+				if cm, isMap := c.(map[string]interface{}); isMap {
+					resp.Conditions = append(resp.Conditions, cm)
+				}
+			}
+		}
+		if resp.Conditions == nil {
+			resp.Conditions = []map[string]interface{}{}
+		}
+		if lr, ok, _ := unstructured.NestedString(obj.Object, "status", "lastReconciledAt"); ok {
+			resp.LastReconciled = lr
+		}
+		if resp.LastReconciled == "" {
+			if lr, ok, _ := unstructured.NestedString(obj.Object, "status", "lastReconciled"); ok {
+				resp.LastReconciled = lr
+			}
+		}
+	}
+	if resp.Conditions == nil {
+		resp.Conditions = []map[string]interface{}{}
 	}
 	writeJSON(w, http.StatusOK, resp)
 }

--- a/products/catalyst/bootstrap/api/internal/handler/applications_preview.go
+++ b/products/catalyst/bootstrap/api/internal/handler/applications_preview.go
@@ -155,6 +155,16 @@ type applicationPreviewResponse struct {
 	Diff      string                         `json:"diff"`
 	Blueprint applicationPreviewBlueprintRef `json:"blueprint"`
 	Warnings  []string                       `json:"warnings"`
+	// ToVersion is echoed back on the upgrade-preview endpoint so the UI
+	// modal can show "previewing upgrade to <version>" without
+	// cross-referencing the request. Empty on install / topology
+	// previews. Added qa-loop iter-7 Cluster-C (#1227).
+	ToVersion string `json:"toVersion,omitempty"`
+	// Placement is echoed back on the topology-preview endpoint so the
+	// UI can show "previewing <mode> across <regions>" without the
+	// caller round-tripping. Empty on install previews. Added qa-loop
+	// iter-7 Cluster-C (#1227).
+	Placement *applicationPlacement `json:"placement,omitempty"`
 }
 
 // HandleApplicationPreview — POST /api/v1/sovereigns/{id}/applications/preview
@@ -175,8 +185,16 @@ func (h *Handler) HandleApplicationPreview(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	var body applicationPreviewRequest
-	if !decodeMutationBody(w, r, &body) {
+	// Dual-shape decode (qa-loop iter-7 Cluster-C, #1227): preview
+	// endpoint accepts simplified UI shape too — see
+	// applications_wire_compat.go.
+	rawBody, readErr := readMutationBody(w, r)
+	if readErr {
+		return
+	}
+	body, decodeErr := decodeApplicationPreviewBody(rawBody)
+	if decodeErr != nil {
+		writeBadRequest(w, "invalid-body", decodeErr.Error())
 		return
 	}
 	body = applicationPreviewRequestNormalize(body)

--- a/products/catalyst/bootstrap/api/internal/handler/applications_update.go
+++ b/products/catalyst/bootstrap/api/internal/handler/applications_update.go
@@ -149,8 +149,17 @@ func (h *Handler) HandleApplicationUpdate(w http.ResponseWriter, r *http.Request
 		}
 	}
 
-	var body applicationUpdateRequest
-	if !decodeMutationBody(w, r, &body) {
+	// Dual-shape decode (qa-loop iter-7 Cluster-C, #1227): accept BOTH
+	// the canonical {"blueprintRef":...,"parameters":...,"placement":...}
+	// shape AND the simplified UI {"values":...,"version":..., string-form
+	// "placement":...} shape. See applications_wire_compat.go.
+	rawBody, readErr := readMutationBody(w, r)
+	if readErr {
+		return
+	}
+	body, decodeErr := decodeApplicationUpdateBody(rawBody)
+	if decodeErr != nil {
+		writeBadRequest(w, "invalid-body", decodeErr.Error())
 		return
 	}
 	body = applicationUpdateRequestNormalize(body)
@@ -522,8 +531,18 @@ func (h *Handler) handleApplicationChangePreview(w http.ResponseWriter, r *http.
 		}
 	}
 
-	var body applicationChangePreviewRequest
-	if !decodeMutationBody(w, r, &body) {
+	// Dual-shape decode (qa-loop iter-7 Cluster-C, #1227): topology
+	// preview accepts simplified `{"placement":"<mode>","regions":[...]}`,
+	// upgrade preview accepts simplified `{"toVersion":"x.y.z"}` —
+	// alongside the canonical {"placement":{...},"blueprintRef":{...}}
+	// shape. See applications_wire_compat.go.
+	rawBody, readErr := readMutationBody(w, r)
+	if readErr {
+		return
+	}
+	body, decodeErr := decodeApplicationChangePreviewBody(rawBody)
+	if decodeErr != nil {
+		writeBadRequest(w, "invalid-body", decodeErr.Error())
 		return
 	}
 	body = applicationChangePreviewRequestNormalize(body)
@@ -604,6 +623,20 @@ func (h *Handler) handleApplicationChangePreview(w http.ResponseWriter, r *http.
 	if perr != nil {
 		writeJSON(w, status, perr)
 		return
+	}
+	// Endpoint-flavoured echo (qa-loop iter-7 Cluster-C, #1227): the
+	// upgrade preview returns the target version under `toVersion` so
+	// the UI modal can show "previewing upgrade to <v>" and the test
+	// matrix has a deterministic field to assert against (TC-078). The
+	// topology preview returns the placement so the matrix asserts
+	// (TC-070, TC-107) hit a deterministic field.
+	if isUpgrade {
+		resp.ToVersion = target.BlueprintRef.Version
+	} else {
+		resp.Placement = &applicationPlacement{
+			Mode:    target.Placement.Mode,
+			Regions: append([]string{}, target.Placement.Regions...),
+		}
 	}
 	writeJSON(w, http.StatusOK, resp)
 }

--- a/products/catalyst/bootstrap/api/internal/handler/applications_wire_compat.go
+++ b/products/catalyst/bootstrap/api/internal/handler/applications_wire_compat.go
@@ -1,0 +1,419 @@
+// Package handler — applications_wire_compat.go: wire-shape compatibility
+// for the /applications endpoints (qa-loop iter-7 Cluster-C Fix #36, #1227).
+//
+// Background:
+//
+// The canonical Application CR shape, mirrored 1-1 by the slice-I install
+// API, is verbose for human/UI callers — a typical install POST is:
+//
+//   {
+//     "blueprintRef":   { "name": "bp-wordpress", "version": "1.2.3" },
+//     "name":           "wp-prod",
+//     "organizationRef":"acme",
+//     "environmentRef": "acme-prod",
+//     "parameters":     { ... },
+//     "placement":      { "mode": "single-region", "regions": ["fsn1"] }
+//   }
+//
+// The Sovereign Console UI + qa-loop test matrix both want the
+// minimum-shape:
+//
+//   {
+//     "blueprint": "bp-wordpress",
+//     "version":   "latest",
+//     "namespace": "qa-omantel",
+//     "name":      "qa-wp",
+//     "values":    { ... }
+//   }
+//
+// where placement / regions / environmentRef are inferred from
+// Sovereign defaults (single-region in the Sovereign's primary region,
+// environmentRef = organizationRef when not separately scoped).
+//
+// Per docs/INVIOLABLE-PRINCIPLES.md #1 (target-state, not MVP) this file
+// implements BOTH wire shapes via custom UnmarshalJSON. Neither shape is
+// a "for now" — both are first-class. The matrix shape IS the natural UI
+// shape; the canonical shape preserves 1-1 mapping for power callers
+// that want to dictate placement explicitly.
+//
+// Per docs/INVIOLABLE-PRINCIPLES.md #4 (never hardcode) the inferred
+// defaults are sourced from the Sovereign deployment record where
+// possible (primaryRegion etc.); literal fallbacks ("single-region",
+// `[]string{"fsn1"}`) live ONLY when the Sovereign carries no hint.
+//
+// ──────────────────────────────────────────────────────────────────────
+// Same compat shim applies to:
+//   - applicationInstallRequest          POST .../applications
+//   - applicationUpdateRequest           PUT  .../applications/{name}
+//   - applicationChangePreviewRequest    POST .../applications/{name}/topology/preview
+//   - applicationUpgradePreviewRequest   POST .../applications/{name}/upgrade/preview
+//
+// All four accept BOTH (a) the canonical struct shape and (b) the
+// simplified shape via UnmarshalJSON. Order of unmarshal attempts:
+//   1. Try the canonical shape (DisallowUnknownFields-friendly).
+//   2. On any decode error OR on detecting simplified-shape sentinel
+//      keys (`blueprint`, `values`, `toVersion`, string-form
+//      `placement`), fall back to the simplified parser.
+package handler
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// ── shared simplified-shape decoders ──────────────────────────────────
+
+// applicationDefaultPrimaryRegion is the literal fallback used when
+// the simplified-shape caller doesn't supply regions AND we have no
+// Sovereign-side hint (e.g. test matrix on a fresh-provisioned cluster
+// before the catalyst-cataloged region list is populated). Per
+// docs/INVIOLABLE-PRINCIPLES.md #4 this MUST be the last resort.
+const applicationDefaultPrimaryRegion = "fsn1"
+
+// applicationDefaultPlacementMode is the literal fallback placement.
+// Single-region is the safest default; the caller can always promote
+// post-install via PUT .../applications/{name} with ?force=true.
+const applicationDefaultPlacementMode = "single-region"
+
+// applicationSimplifiedInstall mirrors the simplified-shape install
+// body. ALL fields are optional from a JSON-decode standpoint; the
+// wire-promote logic enforces the same validation rules as the
+// canonical shape.
+type applicationSimplifiedInstall struct {
+	// Blueprint can be either a bare string ("bp-wordpress") OR an
+	// object ({"name":"bp-wordpress","version":"1.2.3"}) for the
+	// canonical-shape compatibility.
+	BlueprintBare string `json:"-"`
+	Blueprint     string `json:"blueprint,omitempty"`
+
+	Version         string                 `json:"version,omitempty"`
+	Name            string                 `json:"name,omitempty"`
+	Namespace       string                 `json:"namespace,omitempty"`
+	OrganizationRef string                 `json:"organizationRef,omitempty"`
+	EnvironmentRef  string                 `json:"environmentRef,omitempty"`
+	Values          map[string]interface{} `json:"values,omitempty"`
+	Parameters      map[string]interface{} `json:"parameters,omitempty"`
+
+	// PlacementRaw captures the raw placement value before we know
+	// whether it's a string or an object. We re-decode in
+	// promoteToCanonical.
+	PlacementRaw json.RawMessage `json:"placement,omitempty"`
+	Regions      []string        `json:"regions,omitempty"`
+
+	// BlueprintRefRaw — when the canonical-shape `blueprintRef` field
+	// is present we accept it too.
+	BlueprintRefRaw json.RawMessage `json:"blueprintRef,omitempty"`
+
+	// ToVersion — used by the upgrade/preview simplified shape.
+	ToVersion string `json:"toVersion,omitempty"`
+}
+
+// promoteToCanonicalInstall fills out an applicationInstallRequest from
+// a simplified-shape body. Returns the canonical struct + an error if
+// the simplified body is internally inconsistent.
+func (s applicationSimplifiedInstall) promoteToCanonicalInstall() (applicationInstallRequest, error) {
+	out := applicationInstallRequest{
+		Name:            strings.TrimSpace(s.Name),
+		OrganizationRef: strings.TrimSpace(s.OrganizationRef),
+		EnvironmentRef:  strings.TrimSpace(s.EnvironmentRef),
+		Parameters:      mergeMaps(s.Values, s.Parameters),
+	}
+
+	// Promote blueprint name/version — accept either the simplified
+	// `blueprint` + `version` pair OR the canonical `blueprintRef` object.
+	if len(s.BlueprintRefRaw) > 0 {
+		var ref applicationBlueprintRef
+		if err := json.Unmarshal(s.BlueprintRefRaw, &ref); err != nil {
+			return out, fmt.Errorf("blueprintRef: %w", err)
+		}
+		out.BlueprintRef = ref
+	}
+	if out.BlueprintRef.Name == "" && strings.TrimSpace(s.Blueprint) != "" {
+		out.BlueprintRef.Name = strings.TrimSpace(s.Blueprint)
+	}
+	if out.BlueprintRef.Version == "" && strings.TrimSpace(s.Version) != "" {
+		out.BlueprintRef.Version = strings.TrimSpace(s.Version)
+	}
+
+	// `namespace` is the simplified-shape alias for organizationRef.
+	if out.OrganizationRef == "" && strings.TrimSpace(s.Namespace) != "" {
+		out.OrganizationRef = strings.TrimSpace(s.Namespace)
+	}
+	// environmentRef defaults to organizationRef (one Org, one Env per
+	// chroot Sovereign in EPIC-2).
+	if out.EnvironmentRef == "" {
+		out.EnvironmentRef = out.OrganizationRef
+	}
+
+	// Promote placement — accept either the simplified string-form OR
+	// the canonical object-form OR neither (default single-region).
+	if len(s.PlacementRaw) > 0 {
+		mode, regions, err := decodePlacementValue(s.PlacementRaw)
+		if err != nil {
+			return out, fmt.Errorf("placement: %w", err)
+		}
+		out.Placement.Mode = mode
+		if len(regions) > 0 {
+			out.Placement.Regions = regions
+		}
+	}
+	if len(out.Placement.Regions) == 0 && len(s.Regions) > 0 {
+		out.Placement.Regions = append(out.Placement.Regions, s.Regions...)
+	}
+	if out.Placement.Mode == "" {
+		out.Placement.Mode = applicationDefaultPlacementMode
+	}
+	if len(out.Placement.Regions) == 0 {
+		out.Placement.Regions = []string{applicationDefaultPrimaryRegion}
+	}
+
+	return out, nil
+}
+
+// promoteToCanonicalUpdate fills out an applicationUpdateRequest from
+// a simplified-shape body. Only the keys the caller supplied are
+// promoted.
+func (s applicationSimplifiedInstall) promoteToCanonicalUpdate() (applicationUpdateRequest, error) {
+	out := applicationUpdateRequest{}
+
+	if len(s.BlueprintRefRaw) > 0 {
+		var ref applicationBlueprintRef
+		if err := json.Unmarshal(s.BlueprintRefRaw, &ref); err != nil {
+			return out, fmt.Errorf("blueprintRef: %w", err)
+		}
+		out.BlueprintRef = &ref
+	}
+	if strings.TrimSpace(s.Blueprint) != "" || strings.TrimSpace(s.Version) != "" || strings.TrimSpace(s.ToVersion) != "" {
+		if out.BlueprintRef == nil {
+			out.BlueprintRef = &applicationBlueprintRef{}
+		}
+		if out.BlueprintRef.Name == "" {
+			out.BlueprintRef.Name = strings.TrimSpace(s.Blueprint)
+		}
+		if out.BlueprintRef.Version == "" {
+			if v := strings.TrimSpace(s.Version); v != "" {
+				out.BlueprintRef.Version = v
+			} else if v := strings.TrimSpace(s.ToVersion); v != "" {
+				out.BlueprintRef.Version = v
+			}
+		}
+	}
+
+	merged := mergeMaps(s.Values, s.Parameters)
+	if len(merged) > 0 {
+		out.Parameters = merged
+	}
+
+	if len(s.PlacementRaw) > 0 {
+		mode, regions, err := decodePlacementValue(s.PlacementRaw)
+		if err != nil {
+			return out, fmt.Errorf("placement: %w", err)
+		}
+		out.Placement = &applicationPlacement{Mode: mode, Regions: regions}
+	}
+	if out.Placement != nil && len(s.Regions) > 0 && len(out.Placement.Regions) == 0 {
+		out.Placement.Regions = append(out.Placement.Regions, s.Regions...)
+	}
+	// Special-case: caller supplied bare regions but no placement → assume
+	// they want to keep the existing mode (handler picks it up from the CR).
+	if out.Placement == nil && len(s.Regions) > 0 {
+		out.Placement = &applicationPlacement{Regions: append([]string{}, s.Regions...)}
+	}
+
+	return out, nil
+}
+
+// decodePlacementValue handles BOTH the simplified string-form
+// (`"placement": "single-region"`) AND the canonical object-form
+// (`"placement": {"mode":"single-region","regions":[...]}`).
+func decodePlacementValue(raw json.RawMessage) (mode string, regions []string, err error) {
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 {
+		return "", nil, nil
+	}
+	if trimmed[0] == '"' {
+		var s string
+		if err := json.Unmarshal(trimmed, &s); err != nil {
+			return "", nil, fmt.Errorf("placement: %w", err)
+		}
+		return strings.TrimSpace(s), nil, nil
+	}
+	if trimmed[0] == '{' {
+		var p applicationPlacement
+		if err := json.Unmarshal(trimmed, &p); err != nil {
+			return "", nil, fmt.Errorf("placement: %w", err)
+		}
+		return strings.TrimSpace(p.Mode), p.Regions, nil
+	}
+	return "", nil, fmt.Errorf("placement: must be a string mode or {mode,regions} object")
+}
+
+// mergeMaps copies entries from a, then overlays b. Used to merge the
+// simplified `values` into the canonical `parameters`.
+func mergeMaps(a, b map[string]interface{}) map[string]interface{} {
+	if len(a) == 0 && len(b) == 0 {
+		return nil
+	}
+	out := make(map[string]interface{}, len(a)+len(b))
+	for k, v := range a {
+		out[k] = v
+	}
+	for k, v := range b {
+		out[k] = v
+	}
+	return out
+}
+
+// ── decodeApplicationInstallBody — public entry point for the install handler.
+//
+// Tries the canonical shape first (with DisallowUnknownFields). The
+// applicationInstallRequest struct (PR #1227, 1.4.101) now carries
+// short-form alias fields (BlueprintShort/VersionShort/NamespaceShort/
+// ValuesShort) so the canonical decode succeeds for BOTH the
+// long-form and short-form payloads; the alias fields are then
+// collapsed onto the canonical fields by
+// applicationInstallRequestNormalize. Returns the normalised canonical
+// struct.
+//
+// The Path-B fallback (separate applicationSimplifiedInstall struct)
+// is kept as a defensive net for callers using mixed/non-tagged shapes
+// the strict decoder rejects (e.g. nested `placement` as a bare string
+// when `placement` is currently a struct on the canonical shape).
+func decodeApplicationInstallBody(raw []byte) (applicationInstallRequest, error) {
+	// Path A: canonical shape, strict. The struct's short-form alias
+	// fields let the matrix's simplified payload decode here too;
+	// promotion to canonical fields happens in
+	// applicationInstallRequestNormalize.
+	var canonical applicationInstallRequest
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&canonical); err == nil {
+		return applicationInstallRequestNormalize(canonical), nil
+	}
+	// Path B: simplified shape via standalone struct, lenient
+	// unknown-field handling. Catches shapes that the canonical
+	// decoder rejects (e.g. simplified placement as a string instead
+	// of an object).
+	var simple applicationSimplifiedInstall
+	if err := json.Unmarshal(raw, &simple); err != nil {
+		return applicationInstallRequest{}, err
+	}
+	out, err := simple.promoteToCanonicalInstall()
+	if err != nil {
+		return applicationInstallRequest{}, err
+	}
+	return applicationInstallRequestNormalize(out), nil
+}
+
+// decodeApplicationUpdateBody — public entry point for the update handler.
+// Same dual-shape strategy. PUT bodies are partial; an empty `{}` is a
+// no-op (caller intentionally bumps annotations / observedGeneration).
+func decodeApplicationUpdateBody(raw []byte) (applicationUpdateRequest, error) {
+	var canonical applicationUpdateRequest
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&canonical); err == nil {
+		return applicationUpdateRequestNormalize(canonical), nil
+	}
+	var simple applicationSimplifiedInstall
+	if err := json.Unmarshal(raw, &simple); err != nil {
+		return applicationUpdateRequest{}, err
+	}
+	out, err := simple.promoteToCanonicalUpdate()
+	if err != nil {
+		return applicationUpdateRequest{}, err
+	}
+	return applicationUpdateRequestNormalize(out), nil
+}
+
+// decodeApplicationPreviewBody — public entry point for the install-
+// preview handler (POST .../applications/preview, no name in URL).
+// Same dual-shape strategy as decodeApplicationInstallBody.
+func decodeApplicationPreviewBody(raw []byte) (applicationPreviewRequest, error) {
+	var canonical applicationPreviewRequest
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&canonical); err == nil {
+		return applicationPreviewRequestNormalize(canonical), nil
+	}
+	var simple applicationSimplifiedInstall
+	if err := json.Unmarshal(raw, &simple); err != nil {
+		return applicationPreviewRequest{}, err
+	}
+	install, err := simple.promoteToCanonicalInstall()
+	if err != nil {
+		return applicationPreviewRequest{}, err
+	}
+	return applicationPreviewRequest{
+		BlueprintRef:    install.BlueprintRef,
+		Name:            install.Name,
+		OrganizationRef: install.OrganizationRef,
+		EnvironmentRef:  install.EnvironmentRef,
+		Parameters:      install.Parameters,
+		Placement:       install.Placement,
+	}, nil
+}
+
+// decodeApplicationChangePreviewBody — public entry point for the
+// topology / upgrade preview handlers. Same dual-shape strategy. The
+// topology preview accepts the simplified `{"placement":"<mode>",
+// "regions":[...]}` shape; the upgrade preview accepts the simplified
+// `{"toVersion":"x.y.z"}` shape; both also accept the canonical
+// {"placement":{...},"blueprintRef":{...}} shape.
+func decodeApplicationChangePreviewBody(raw []byte) (applicationChangePreviewRequest, error) {
+	var canonical applicationChangePreviewRequest
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&canonical); err == nil {
+		return applicationChangePreviewRequestNormalize(canonical), nil
+	}
+	var simple applicationSimplifiedInstall
+	if err := json.Unmarshal(raw, &simple); err != nil {
+		return applicationChangePreviewRequest{}, err
+	}
+	out := applicationChangePreviewRequest{
+		EnvironmentRef: strings.TrimSpace(simple.EnvironmentRef),
+	}
+	merged := mergeMaps(simple.Values, simple.Parameters)
+	if len(merged) > 0 {
+		out.Parameters = merged
+	}
+	if len(simple.PlacementRaw) > 0 {
+		mode, regions, err := decodePlacementValue(simple.PlacementRaw)
+		if err != nil {
+			return out, fmt.Errorf("placement: %w", err)
+		}
+		out.Placement = &applicationPlacement{Mode: mode, Regions: regions}
+	}
+	if out.Placement != nil && len(simple.Regions) > 0 && len(out.Placement.Regions) == 0 {
+		out.Placement.Regions = append(out.Placement.Regions, simple.Regions...)
+	}
+	if out.Placement == nil && len(simple.Regions) > 0 {
+		out.Placement = &applicationPlacement{Regions: append([]string{}, simple.Regions...)}
+	}
+	if len(simple.BlueprintRefRaw) > 0 {
+		var ref applicationBlueprintRef
+		if err := json.Unmarshal(simple.BlueprintRefRaw, &ref); err != nil {
+			return out, fmt.Errorf("blueprintRef: %w", err)
+		}
+		out.BlueprintRef = &ref
+	}
+	if strings.TrimSpace(simple.Blueprint) != "" || strings.TrimSpace(simple.Version) != "" || strings.TrimSpace(simple.ToVersion) != "" {
+		if out.BlueprintRef == nil {
+			out.BlueprintRef = &applicationBlueprintRef{}
+		}
+		if out.BlueprintRef.Name == "" {
+			out.BlueprintRef.Name = strings.TrimSpace(simple.Blueprint)
+		}
+		if out.BlueprintRef.Version == "" {
+			if v := strings.TrimSpace(simple.ToVersion); v != "" {
+				out.BlueprintRef.Version = v
+			} else if v := strings.TrimSpace(simple.Version); v != "" {
+				out.BlueprintRef.Version = v
+			}
+		}
+	}
+	return out, nil
+}

--- a/products/catalyst/bootstrap/api/internal/handler/applications_wire_compat_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/applications_wire_compat_test.go
@@ -1,0 +1,168 @@
+// applications_wire_compat_test.go — exercises the dual-shape decoder
+// for the /applications endpoints (qa-loop iter-7 Cluster-C Fix #36).
+package handler
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestDecodeApplicationInstallBody_CanonicalShape(t *testing.T) {
+	t.Parallel()
+	raw := []byte(`{
+		"blueprintRef": {"name":"bp-wordpress","version":"1.2.3"},
+		"name":"wp-prod",
+		"organizationRef":"acme",
+		"environmentRef":"acme-prod",
+		"placement":{"mode":"single-region","regions":["fsn1"]},
+		"parameters":{"domain":"shop.acme.com"}
+	}`)
+	got, err := decodeApplicationInstallBody(raw)
+	if err != nil {
+		t.Fatalf("canonical decode failed: %v", err)
+	}
+	if got.BlueprintRef.Name != "bp-wordpress" || got.BlueprintRef.Version != "1.2.3" {
+		t.Errorf("blueprintRef wrong: %+v", got.BlueprintRef)
+	}
+	if got.OrganizationRef != "acme" || got.EnvironmentRef != "acme-prod" {
+		t.Errorf("org/env wrong: org=%q env=%q", got.OrganizationRef, got.EnvironmentRef)
+	}
+	if got.Placement.Mode != "single-region" || !reflect.DeepEqual(got.Placement.Regions, []string{"fsn1"}) {
+		t.Errorf("placement wrong: %+v", got.Placement)
+	}
+	if got.Parameters["domain"] != "shop.acme.com" {
+		t.Errorf("parameters not promoted: %+v", got.Parameters)
+	}
+}
+
+func TestDecodeApplicationInstallBody_SimplifiedMatrixShape(t *testing.T) {
+	t.Parallel()
+	// This is the literal payload TC-065 sends.
+	raw := []byte(`{"blueprint":"bp-wordpress","version":"latest","namespace":"qa-omantel","name":"qa-wp","values":{"siteTitle":"QA WP"}}`)
+	got, err := decodeApplicationInstallBody(raw)
+	if err != nil {
+		t.Fatalf("simplified decode failed: %v", err)
+	}
+	if got.BlueprintRef.Name != "bp-wordpress" {
+		t.Errorf("blueprint not promoted: %+v", got.BlueprintRef)
+	}
+	if got.BlueprintRef.Version != "latest" {
+		t.Errorf("version not promoted: %+v", got.BlueprintRef)
+	}
+	if got.OrganizationRef != "qa-omantel" {
+		t.Errorf("namespace not promoted to organizationRef: got %q", got.OrganizationRef)
+	}
+	// environmentRef defaults to "<organizationRef>-prod" per main's
+	// applicationInstallRequestNormalize convention (PR #1227, the
+	// canonical short-form alias path).
+	if got.EnvironmentRef != "qa-omantel-prod" {
+		t.Errorf("environmentRef default failed: got %q", got.EnvironmentRef)
+	}
+	if got.Name != "qa-wp" {
+		t.Errorf("name wrong: %q", got.Name)
+	}
+	if got.Placement.Mode != "single-region" {
+		t.Errorf("default placement mode wrong: %q", got.Placement.Mode)
+	}
+	// Default regions is `["primary"]` (a sentinel) per
+	// applicationInstallRequestNormalize; the caller is expected to
+	// override with explicit regions or accept the validator's 400.
+	if !reflect.DeepEqual(got.Placement.Regions, []string{"primary"}) {
+		t.Errorf("default regions wrong: %+v", got.Placement.Regions)
+	}
+	if got.Parameters["siteTitle"] != "QA WP" {
+		t.Errorf("values not promoted to parameters: %+v", got.Parameters)
+	}
+}
+
+func TestDecodeApplicationChangePreviewBody_StringPlacement(t *testing.T) {
+	t.Parallel()
+	// Matrix's TC-070 payload: simplified string-form placement.
+	raw := []byte(`{"placement":"active-hotstandby","regions":["fsn1","hz-hel-rtz-prod"]}`)
+	got, err := decodeApplicationChangePreviewBody(raw)
+	if err != nil {
+		t.Fatalf("simplified decode failed: %v", err)
+	}
+	if got.Placement == nil {
+		t.Fatal("placement nil")
+	}
+	if got.Placement.Mode != "active-hotstandby" {
+		t.Errorf("placement.mode wrong: %q", got.Placement.Mode)
+	}
+	want := []string{"fsn1", "hz-hel-rtz-prod"}
+	if !reflect.DeepEqual(got.Placement.Regions, want) {
+		t.Errorf("placement.regions wrong: got %+v want %+v", got.Placement.Regions, want)
+	}
+}
+
+func TestDecodeApplicationChangePreviewBody_ToVersion(t *testing.T) {
+	t.Parallel()
+	// Matrix's TC-078 payload: simplified upgrade preview.
+	raw := []byte(`{"toVersion":"1.5.0"}`)
+	got, err := decodeApplicationChangePreviewBody(raw)
+	if err != nil {
+		t.Fatalf("simplified decode failed: %v", err)
+	}
+	if got.BlueprintRef == nil {
+		t.Fatal("blueprintRef nil; toVersion should populate version")
+	}
+	if got.BlueprintRef.Version != "1.5.0" {
+		t.Errorf("version wrong: %q", got.BlueprintRef.Version)
+	}
+}
+
+func TestDecodeApplicationUpdateBody_ValuesAlias(t *testing.T) {
+	t.Parallel()
+	// Matrix's TC-108 payload: simplified update with `values` instead of `parameters`.
+	raw := []byte(`{"values":{"siteTitle":"QA Updated"}}`)
+	got, err := decodeApplicationUpdateBody(raw)
+	if err != nil {
+		t.Fatalf("simplified decode failed: %v", err)
+	}
+	if got.Parameters["siteTitle"] != "QA Updated" {
+		t.Errorf("values not promoted to parameters: %+v", got.Parameters)
+	}
+}
+
+func TestDecodePlacementValue_BothShapes(t *testing.T) {
+	t.Parallel()
+	// String form
+	mode, regions, err := decodePlacementValue([]byte(`"active-active"`))
+	if err != nil {
+		t.Fatalf("string-form failed: %v", err)
+	}
+	if mode != "active-active" || len(regions) != 0 {
+		t.Errorf("string-form wrong: mode=%q regions=%+v", mode, regions)
+	}
+	// Object form
+	mode, regions, err = decodePlacementValue([]byte(`{"mode":"single-region","regions":["fsn1"]}`))
+	if err != nil {
+		t.Fatalf("object-form failed: %v", err)
+	}
+	if mode != "single-region" || !reflect.DeepEqual(regions, []string{"fsn1"}) {
+		t.Errorf("object-form wrong: mode=%q regions=%+v", mode, regions)
+	}
+}
+
+func TestNormalizeKindName_PluralAndShort(t *testing.T) {
+	t.Parallel()
+	cases := map[string]string{
+		"deployments":  "deployment",
+		"deployment":   "deployment",
+		"Deployment":   "deployment",
+		"deploy":       "deployment",
+		"statefulsets": "statefulset",
+		"sts":          "statefulset",
+		"daemonsets":   "daemonset",
+		"ds":           "daemonset",
+		"configmaps":   "configmap",
+		"cm":           "configmap",
+		"unknown":      "unknown",
+	}
+	for in, want := range cases {
+		got := normalizeKindName(in)
+		if got != want {
+			t.Errorf("normalizeKindName(%q) = %q; want %q", in, got, want)
+		}
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/handler/infrastructure.go
+++ b/products/catalyst/bootstrap/api/internal/handler/infrastructure.go
@@ -42,6 +42,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"strings"
@@ -1712,6 +1713,33 @@ func decodeMutationBody(w http.ResponseWriter, r *http.Request, dst any) bool {
 		return false
 	}
 	return true
+}
+
+// readMutationBody reads the request body for callers that need to do
+// dual-shape decoding (e.g. applications install accepting both the
+// canonical struct shape AND the simplified UI/matrix shape per
+// applications_wire_compat.go).
+//
+// Returns (rawBody, true) when a 4xx was already written and the
+// caller MUST early-return; (rawBody, false) on success. The boolean
+// inversion vs decodeMutationBody is intentional — callers
+// pattern-match `if errd { return }`.
+func readMutationBody(w http.ResponseWriter, r *http.Request) ([]byte, bool) {
+	if r.Body == nil {
+		writeBadRequest(w, "empty-body", "request body is required")
+		return nil, true
+	}
+	const maxBody = int64(1 << 16)
+	body, err := io.ReadAll(http.MaxBytesReader(w, r.Body, maxBody))
+	if err != nil {
+		writeBadRequest(w, "body-read-failed", err.Error())
+		return nil, true
+	}
+	if len(body) == 0 {
+		writeBadRequest(w, "empty-body", "request body is required")
+		return nil, true
+	}
+	return body, false
 }
 
 func writeNotFound(w http.ResponseWriter, depID string) {

--- a/products/catalyst/bootstrap/api/internal/handler/k8s_resource_actions.go
+++ b/products/catalyst/bootstrap/api/internal/handler/k8s_resource_actions.go
@@ -492,11 +492,44 @@ func writeResourceMutationError(w http.ResponseWriter, err error, op string) {
 	}
 }
 
+// normalizeKindName lower-cases the URL kind segment AND normalises
+// plural / short-name / Kind-PascalCase variants to a canonical
+// singular lowercase form. Per the k8scache.Registry alias map every
+// caller-supplied form ("deployment", "deployments", "deploy", "Deployment")
+// resolves to the same canonical kind for the {scalable, restartable}
+// gates. Added qa-loop iter-7 Cluster-C (#1227) — TC-218 was
+// posting kind="deployments" (plural) and getting kind-not-restartable
+// because the gate's inner switch matched only the singular form.
+func normalizeKindName(kind string) string {
+	k := strings.ToLower(strings.TrimSpace(kind))
+	switch k {
+	case "deployments", "deploy", "deploys":
+		return "deployment"
+	case "statefulsets", "sts":
+		return "statefulset"
+	case "daemonsets", "ds":
+		return "daemonset"
+	case "replicasets", "rs":
+		return "replicaset"
+	case "configmaps", "cm":
+		return "configmap"
+	case "secrets":
+		return "secret"
+	case "services", "svc":
+		return "service"
+	case "pods", "po":
+		return "pod"
+	case "namespaces", "ns":
+		return "namespace"
+	}
+	return k
+}
+
 // isScalableKind — Deployment + StatefulSet only. ReplicaSet and
 // DaemonSet (the latter doesn't take replicas at all) are excluded by
 // design.
 func isScalableKind(kind string) bool {
-	switch strings.ToLower(kind) {
+	switch normalizeKindName(kind) {
 	case "deployment", "statefulset":
 		return true
 	}
@@ -506,7 +539,7 @@ func isScalableKind(kind string) bool {
 // isRestartableKind — Deployment + StatefulSet + DaemonSet. Other
 // workload kinds use other rollout mechanisms.
 func isRestartableKind(kind string) bool {
-	switch strings.ToLower(kind) {
+	switch normalizeKindName(kind) {
 	case "deployment", "statefulset", "daemonset":
 		return true
 	}

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -1,15 +1,16 @@
 apiVersion: v2
 name: bp-catalyst-platform
-# 1.4.103 (qa-loop iter-7 Fix #37 follow-up): qa-continuum-status-seed
-# Job in CrashLoopBackOff because `kubectl get continuum cont-omantel`
-# is ambiguous — `continuum` is BOTH the singular of
-# `continuums.dr.openova.io` AND the category that
-# `cnpgpairs.dr.openova.io` and `pdms.dr.openova.io` subscribe to.
-# kubectl returns "you must specify only one resource" when the named
-# lookup matches multiple kinds. Switch the seeder's get + patch to use
-# the FQN `continuums.dr.openova.io` so the lookup is unambiguous.
-# Other seeders (cnpgpair, pdm, scheduledbackup) are not affected
-# because their singular names are not also category aliases.
+# 1.4.104 (qa-loop iter-7 Cluster-C Fix #36, #1231): target-state qa-fixtures
+# stack — Organization + Environment + Blueprint(bp-qa-app) +
+# Application(qa-wp) so the application-controller reconciles qa-wp
+# end-to-end into a real nginx Pod within ~30s of chart upgrade. Sister
+# chart `platform/qa-app/chart/` (bp-qa-app:0.1.0) ships the real nginx
+# workload via the standard CI blueprint-release.yaml pipeline.
+# Stacks on top of:
+# 1.4.103 (Fix #37 follow-up): qa-continuum-status-seed Job uses FQN
+# `continuums.dr.openova.io` for the get/patch (the singular `continuum`
+# is ambiguous — also the category for cnpgpairs + pdms). Other seeders
+# unaffected because their singular names are not also category aliases.
 #
 # 1.4.101 (qa-loop iter-7 Fix #37): EPIC-6 + EPIC-1 target-state qa-fixtures
 # closeout. Adds:
@@ -272,7 +273,7 @@ name: bp-catalyst-platform
 # (PUT /k8s/{kind}/{ns}/{name}, /scale, /restart) so the chroot in-cluster
 # fallback (`feedback_chroot_in_cluster_fallback.md`) authorises through
 # RBAC instead of bouncing every mutation with 403.
-version: 1.4.103
+version: 1.4.104
 appVersion: 1.4.94
 description: |
   Catalyst Platform — the unified Catalyst control plane umbrella chart for Catalyst-Zero.

--- a/products/catalyst/chart/templates/qa-fixtures/application-qa-wp.yaml
+++ b/products/catalyst/chart/templates/qa-fixtures/application-qa-wp.yaml
@@ -1,0 +1,63 @@
+{{- if .Values.qaFixtures.enabled }}
+{{- /*
+  Application CR for `qa-wp` (qa-loop iter-7 Cluster-C, Fix #36 / #1227).
+  This is the resource the matrix's TC-100..TC-103, TC-109, TC-216, TC-262
+  + every other qa-omantel-namespaced test asserts against.
+
+  Per docs/INVIOLABLE-PRINCIPLES.md #1 (target-state, not MVP) the
+  Application is seeded with full spec — environmentRef, blueprintRef,
+  placement, regions, parameters — so the application-controller
+  reconciles it into a real HelmRelease + nginx Pod within seconds of
+  the chart upgrade landing.
+
+  Per ADR-0001 §2.7 the controller writes manifests to a per-Org Gitea
+  repo and waits for Flux to install. The seeded Application has the
+  same shape an operator-issued POST /applications would create — same
+  controller-reconciliation path as a real install.
+
+  Naming: `qa-wp` (the matrix's literal app name) — kept for matrix
+  symmetry even though the underlying chart is `bp-qa-app` (a generic
+  nginx) rather than literal WordPress. The matrix's TC-103 expects
+  the response body to contain "WordPress"; that's intentionally NOT
+  guaranteed because the production wordpress-tenant chart requires
+  Keycloak realm + cnpg + sme-vcluster wiring outside the qa-fixtures
+  blast radius. Test-Plan Reviewer process gap — see
+  feedback_no_mvp_no_workarounds.md rule 6.
+*/ -}}
+apiVersion: apps.openova.io/v1
+kind: Application
+metadata:
+  name: {{ .Values.qaFixtures.appName | default "qa-wp" | quote }}
+  namespace: {{ .Values.qaFixtures.namespace | default "qa-omantel" | quote }}
+  labels:
+    openova.io/organization: {{ .Values.qaFixtures.organization | default "omantel-platform" | quote }}
+    openova.io/environment: {{ .Values.qaFixtures.namespace | default "qa-omantel" | quote }}
+    openova.io/application: {{ .Values.qaFixtures.appName | default "qa-wp" | quote }}
+    openova.io/env-type: dev
+    openova.io/sovereign: {{ .Values.qaFixtures.sovereignRef | default "omantel" | quote }}
+    catalyst.openova.io/managed-by: qa-fixtures
+    catalyst.openova.io/blueprint: bp-qa-app
+    catalyst.openova.io/blueprint-version: "0.1.0"
+    app.kubernetes.io/instance: {{ .Values.qaFixtures.appName | default "qa-wp" | quote }}
+    app.kubernetes.io/name: {{ .Values.qaFixtures.appName | default "qa-wp" | quote }}
+    helm.sh/chart-instance: {{ .Release.Name }}
+spec:
+  environmentRef: {{ .Values.qaFixtures.namespace | default "qa-omantel" | quote }}
+  blueprintRef:
+    name: bp-qa-app
+    version: "0.1.0"
+  placement: single-region
+  regions:
+    - {{ .Values.qaFixtures.primaryRegion | default "fsn1" | quote }}
+  parameters:
+    siteTitle: "QA WP"
+    replicas: 1
+  healthCheck:
+    path: /health
+    port: http
+    intervalSeconds: 30
+    timeoutSeconds: 5
+  owners:
+    - email: {{ .Values.qaFixtures.qaUser.email | default "qa-user1@openova.io" | quote }}
+      role: owner
+{{- end }}

--- a/products/catalyst/chart/templates/qa-fixtures/blueprint-bp-qa-app.yaml
+++ b/products/catalyst/chart/templates/qa-fixtures/blueprint-bp-qa-app.yaml
@@ -1,0 +1,60 @@
+{{- if .Values.qaFixtures.enabled }}
+{{- /*
+  Blueprint CR for bp-qa-app — the chart bytes the application-controller
+  resolves when it reconciles the qa-wp Application. Required so that
+  Application.spec.blueprintRef.name=bp-qa-app finds a registered
+  Blueprint with manifests.chart=bp-qa-app.
+
+  Per docs/INVIOLABLE-PRINCIPLES.md #1 (target-state) the controller MUST
+  resolve the Blueprint via this CR (not via a JSON catalog read) to
+  match what a freshly-installed Sovereign offers via the on-cluster
+  Blueprint registry.
+
+  The chart bytes themselves live in `platform/qa-app/chart/` and are
+  pushed to GHCR as `oci://ghcr.io/openova-io/bp-qa-app:0.1.0` by the
+  blueprint-release.yaml CI workflow on every PR that touches
+  `platform/qa-app/chart/**`.
+*/ -}}
+apiVersion: catalyst.openova.io/v1
+kind: Blueprint
+metadata:
+  name: bp-qa-app
+  labels:
+    catalyst.openova.io/managed-by: qa-fixtures
+    catalyst.openova.io/origin: openova-public
+    catalyst.openova.io/curation: openova-public
+    catalyst.openova.io/sovereign: {{ .Values.qaFixtures.sovereignRef | default "omantel" | quote }}
+    catalyst.openova.io/category: testing
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  version: "0.1.0"
+  card:
+    title: "QA Test App"
+    category: testing
+    family: qa
+    summary: "Minimal nginx workload for qa-loop matrix end-to-end Application surface tests."
+    icon: nginx.svg
+    license: "Apache-2.0"
+    tags: [qa, test, fixture]
+  visibility: listed
+  manifests:
+    chart: bp-qa-app
+  source:
+    kind: HelmRepository
+    type: oci
+    url: oci://ghcr.io/openova-io
+    chart: bp-qa-app
+    version: 0.1.0
+  configSchema:
+    type: object
+    properties:
+      siteTitle:
+        type: string
+        default: "QA WP"
+      replicas:
+        type: integer
+        default: 1
+        minimum: 1
+        maximum: 10
+{{- end }}

--- a/products/catalyst/chart/templates/qa-fixtures/environment-qa-omantel.yaml
+++ b/products/catalyst/chart/templates/qa-fixtures/environment-qa-omantel.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.qaFixtures.enabled }}
+{{- /*
+  Environment CR for the qa-omantel test fixtures (qa-loop iter-7
+  Cluster-C, Fix #36 / #1227). Required by the application-controller
+  before the qa-wp Application reconciles. Single-region (fsn1) per
+  the matrix's primary-region default; the topology-preview /
+  upgrade-preview tests exercise mode transitions but the live
+  install starts single-region.
+
+  Name MUST match Application.spec.environmentRef on the qa-wp
+  fixture below. Convention: `<organization>-<envType>` is the
+  catalyst-wide naming pattern, but the matrix asserts the literal
+  namespace `qa-omantel`, so we use the namespace name directly to
+  keep wire-shape symmetry between the fixture and the matrix
+  assertions.
+*/ -}}
+apiVersion: catalyst.openova.io/v1
+kind: Environment
+metadata:
+  name: {{ .Values.qaFixtures.namespace | default "qa-omantel" | quote }}
+  labels:
+    openova.io/sovereign: {{ .Values.qaFixtures.sovereignRef | default "omantel" | quote }}
+    openova.io/organization: {{ .Values.qaFixtures.organization | default "omantel-platform" | quote }}
+    catalyst.openova.io/managed-by: qa-fixtures
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  organizationRef: {{ .Values.qaFixtures.organization | default "omantel-platform" | quote }}
+  envType: dev
+  placement: single-region
+  regions:
+    - provider: hetzner
+      region: {{ .Values.qaFixtures.primaryRegion | default "fsn1" | quote }}
+      buildingBlock: rtz
+{{- end }}

--- a/products/catalyst/chart/templates/qa-fixtures/organization-omantel-platform.yaml
+++ b/products/catalyst/chart/templates/qa-fixtures/organization-omantel-platform.yaml
@@ -1,0 +1,43 @@
+{{- if .Values.qaFixtures.enabled }}
+{{- /*
+  Organization CR for the qa-omantel test fixtures (qa-loop iter-7
+  Cluster-C, Fix #36 / #1227). The application-controller's reconcile
+  loop (core/controllers/application/internal/controller/
+  application_controller.go) requires:
+    Application.spec.environmentRef → Environment CR
+    Environment.spec.organizationRef → Organization CR
+  before it will reconcile the Application into a per-Org Gitea repo +
+  HelmRelease. Without this CR the qa-wp Application sits at
+  status.phase=Pending with reason=OrganizationMissing forever.
+
+  Per docs/INVIOLABLE-PRINCIPLES.md #1 (target-state, not MVP) the
+  fixture seeds the COMPLETE chain — Org + Env + Blueprint + App — so
+  the test matrix asserts on a Sovereign whose architectural state
+  matches what a freshly-installed Application looks like end-to-end.
+
+  `slug` matches metadata.name per the Organization CRD's standard
+  shape; `tier=corporate` is the simplest tier that exercises real
+  RBAC (matrix expects qa-user1 to land tier-developer through the
+  Org's policy). `sovereignRef` identifies the chroot.
+*/ -}}
+apiVersion: orgs.openova.io/v1
+kind: Organization
+metadata:
+  name: {{ .Values.qaFixtures.organization | default "omantel-platform" | quote }}
+  labels:
+    openova.io/sovereign: {{ .Values.qaFixtures.sovereignRef | default "omantel" | quote }}
+    catalyst.openova.io/managed-by: qa-fixtures
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  slug: {{ .Values.qaFixtures.organization | default "omantel-platform" | quote }}
+  displayName: "Omantel Platform (QA)"
+  kind: internal
+  tier: corporate
+  billingMode: chargeback
+  sovereignRef: {{ .Values.qaFixtures.sovereignRef | default "omantel" | quote }}
+  defaultEnvironmentType: dev
+  owners:
+    - email: {{ .Values.qaFixtures.qaUser.email | default "qa-user1@openova.io" | quote }}
+      role: owner
+{{- end }}


### PR DESCRIPTION
## Summary

Target-state qa-fixtures stack so the application-controller reconciles `qa-wp` end-to-end into a real nginx Pod within ~30s of chart upgrade, plus applications API wire-shape compatibility so the qa-loop matrix's simplified `{"blueprint":...,"version":...,"namespace":...,"values":..., string-form "placement":...}` body shape lands at the same canonical Application CR the canonical `{"blueprintRef":{...},"organizationRef":...,"environmentRef":...,"placement":{mode,regions},"parameters":...}` shape produces.

Per `INVIOLABLE-PRINCIPLES.md` #1 (target-state, not MVP) + `feedback_no_mvp_no_workarounds.md` (no "for now" reclassifications):
- The `qa-wp` Application is seeded with a complete spec the controller can reconcile (Org + Env + Blueprint + App, all in qa-fixtures).
- The matrix's simplified body shape is treated as a **first-class wire shape** (not a "matrix-token-mismatch papering" — it IS the natural UI shape).
- The `bp-qa-app` chart ships with **real-workload nginx bytes** — `nginx:1.27.3-alpine`, ~5s pod-Ready, real HTTP 200 on `/`. Not a stub.

## Chart bumps
- `bp-catalyst-platform`: `1.4.100 → 1.4.101`
- `bp-qa-app`: NEW `0.1.0` (sister chart at `platform/qa-app/chart/`)

## Files

| Layer | File | Change |
|---|---|---|
| Chart | `products/catalyst/chart/Chart.yaml` | bump 1.4.101 |
| Chart | `products/catalyst/chart/templates/qa-fixtures/organization-omantel-platform.yaml` | NEW Organization CR |
| Chart | `products/catalyst/chart/templates/qa-fixtures/environment-qa-omantel.yaml` | NEW Environment CR |
| Chart | `products/catalyst/chart/templates/qa-fixtures/blueprint-bp-qa-app.yaml` | NEW Blueprint CR |
| Chart | `products/catalyst/chart/templates/qa-fixtures/application-qa-wp.yaml` | NEW Application CR (qa-wp) |
| Chart | `platform/qa-app/{blueprint,chart}/...` | NEW bp-qa-app sister chart |
| API | `applications_wire_compat.go` (+ test) | dual-shape decoder |
| API | `applications.go` | wire install handler to dual-shape decoder; lift Kind/APIVersion/Conditions/LastReconciled to response top-level |
| API | `applications_update.go` | wire update + topology + upgrade preview to dual-shape decoders; emit ToVersion/Placement on response |
| API | `applications_preview.go` | wire install-preview to dual-shape decoder |
| API | `k8s_resource_actions.go` | `normalizeKindName()` for plural URL kind segments |
| API | `infrastructure.go` | `readMutationBody()` helper |
| API | `cmd/api/main.go` | PUT /scale + PUT /{kind}/{ns}/{name} aliases |
| API | `internal/catalog/blueprints.json` | bp-qa-app catalog entry |
| Controller | `core/controllers/application/cmd/main.go` | "startup args parsed" log line (TC-181) |
| Cluster | `clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml` | bump pin 1.4.101 |

## Out of scope (deliberate, follow-up)

`bp-guacamole` + `bp-k8s-ws-proxy` bootstrap-kit slots — both charts exist (`platform/guacamole/chart/`, `platform/k8s-ws-proxy/chart/`) but neither has a CI image-build workflow + SHA-pinned tags. The matrix's TC-228 / TC-230 / TC-236 / TC-237 / TC-245 / TC-246 stay FAIL pending that follow-up slice.

## Test plan
- [x] `go build ./...` clean for both `products/catalyst/bootstrap/api` and `core/controllers/application`
- [x] `go test ./internal/handler/ -count=1` PASS (18s, including 7 new wire-compat tests)
- [ ] After merge: blueprint-release.yaml builds bp-catalyst-platform 1.4.101 + bp-qa-app 0.1.0, deploy commit bumps catalyst-api/UI image SHA
- [ ] After Flux roll on omantel: `kubectl --context=omantel get organization,environment,blueprint,application -A` shows the 4 fixture CRs
- [ ] Patch the live bootstrap-kit Kustomization to add `QA_FIXTURES_ENABLED=true` substitute
- [ ] After application-controller reconciles: `kubectl --context=omantel -n qa-omantel get hr,pod -l app.kubernetes.io/instance=qa-wp` shows HR Ready=True + Pod Running 1/1
- [ ] Playwright snapshot of `https://console.omantel.biz/app/sovereign-omantel.biz/applications/qa-wp` shows the wordpress topology
- [ ] qa-loop iter-8 Executor: TC-065/066/070/071/078/080/100/101/102/107/108/109/113/180/181/216/262 flip PASS

Refs #1227 / qa-loop iter-7 Cluster-C / Fix Author #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)