### PR TITLE
fix(chart): catalyst-api RBAC for resource-action mutation surface (qa-loop iter-7 Fix #34 follow-up)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -265,7 +265,14 @@ spec:
       # ClusterRole to grant continuums/cnpgpairs/pdms verbs (TC-344).
       # Bp-crossplane-claims 1.1.2 carries the matching tier-operator
       # extras update.
-      version: 1.4.101
+      # 1.4.102 (qa-loop iter-7 Fix #34 follow-up #1229): catalyst-api-
+      # cutover-driver ClusterRole now grants update/patch/delete on
+      # workload kinds + scale subresources so the resource-action
+      # endpoints (PUT /k8s/{kind}/.../scale, /restart, etc.) authorise
+      # through RBAC. Without this bump the chroot in-cluster fallback
+      # bounces every mutation with 403 (TC-215, TC-218, TC-243, TC-247
+      # in iter-7 matrix).
+      version: 1.4.102
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -253,7 +253,15 @@ name: bp-catalyst-platform
 # precedence so openbao auto-rotation of the source doesn't thrash the
 # controller pod. Caught live on omantel 2026-05-09 during qa-loop
 # iter-1 Executor run.
-version: 1.4.101
+# 1.4.102 (qa-loop iter-7 Fix #34 follow-up): catalyst-api-cutover-driver
+# ClusterRole now grants update/patch/delete on workload kinds (deployments,
+# statefulsets, daemonsets, replicasets, pods, services, configmaps,
+# ingresses, networkpolicies, cronjobs) + scale subresources, plus delete
+# on configmaps. Required by the resource-action endpoints PR #1229 added
+# (PUT /k8s/{kind}/{ns}/{name}, /scale, /restart) so the chroot in-cluster
+# fallback (`feedback_chroot_in_cluster_fallback.md`) authorises through
+# RBAC instead of bouncing every mutation with 403.
+version: 1.4.102
 appVersion: 1.4.94
 description: |
   Catalyst Platform — the unified Catalyst control plane umbrella chart for Catalyst-Zero.

--- a/products/catalyst/chart/templates/clusterrole-cutover-driver.yaml
+++ b/products/catalyst/chart/templates/clusterrole-cutover-driver.yaml
@@ -76,10 +76,33 @@ rules:
   # ───────────────────────────────────────────────────────────────
   - apiGroups: [""]
     resources: ["configmaps"]
-    verbs: ["update", "patch"]
+    verbs: ["update", "patch", "delete"]
   - apiGroups: ["batch"]
     resources: ["jobs"]
     verbs: ["delete", "patch", "update"]
+  # qa-loop iter-7 Fix #34 follow-up — Sovereign Console mutation
+  # surface (PR #1229) added PUT/POST/DELETE semantics on every
+  # workload kind. The cutover-driver SA needs apiserver verbs to
+  # match: scale (patch /spec/replicas), restart (patch
+  # /spec/template/metadata/annotations), apply (update via Update),
+  # and delete. Per ADR-0001 §5 the in-cluster fallback runs as
+  # this SA, so without these verbs every mutation surfaces as 403
+  # (TC-215, TC-218, TC-243, TC-247 in iter-7 matrix).
+  - apiGroups: ["apps"]
+    resources: ["deployments", "statefulsets", "daemonsets", "replicasets"]
+    verbs: ["update", "patch", "delete"]
+  - apiGroups: ["apps"]
+    resources: ["deployments/scale", "statefulsets/scale", "replicasets/scale"]
+    verbs: ["update", "patch", "get"]
+  - apiGroups: [""]
+    resources: ["pods", "services", "endpoints", "persistentvolumeclaims"]
+    verbs: ["update", "patch", "delete"]
+  - apiGroups: ["networking.k8s.io"]
+    resources: ["ingresses", "networkpolicies"]
+    verbs: ["update", "patch", "delete"]
+  - apiGroups: ["batch"]
+    resources: ["cronjobs"]
+    verbs: ["update", "patch", "delete", "create"]
 
   # ───────────────────────────────────────────────────────────────
   # TokenReview — required by HandleCutoverInternalTrigger to


### PR DESCRIPTION
## Summary

Pairs with PR #1229 (k8s resource action vocab widening). Adds the apiserver verbs the new mutation endpoints (PUT /k8s/{kind}/{ns}/{name}, /scale, /restart, /apply, DELETE) need to authorise through RBAC.

Caught LIVE on omantel.biz post-deploy: every mutation endpoint surfaced 403 from the chroot in-cluster fallback because the catalyst-api-cutover-driver SA only had get/list/watch on workload kinds.

## Changes

- Chart 1.4.101 → 1.4.102 + matching bootstrap-kit pin bump.
- New RBAC verbs on catalyst-api-cutover-driver ClusterRole:
  - apps/deployments,statefulsets,daemonsets,replicasets: update + patch + delete
  - apps/.../scale subresources: update + patch + get
  - core/pods,services,endpoints,persistentvolumeclaims: update + patch + delete
  - networking.k8s.io/ingresses,networkpolicies: update + patch + delete
  - batch/cronjobs: create + update + patch + delete
  - core/configmaps: delete (update/patch already present)

## Expected matrix flips in iter-8

TC-215, TC-218, TC-243 (P0). Other TC failures (TC-080, TC-206, TC-222) require fixtures (qa-wp deployment, qa-wp-config CM) to exist — Cluster-F's scope.

## Test plan

- [x] yaml lint passes (no new fields beyond standard rbac.authorization.k8s.io/v1 schema)
- [ ] Post-deploy smoke on omantel: TC-218 restart → 200 + restarted:true; TC-215 scale → 200 + replicas:3 (when qa-wp exists)

🤖 Generated with [Claude Code](https://claude.com/claude-code)