### PR TITLE
fix(chart): qa-continuum-status-seed FQN resource lookup (Fix #37 follow-up)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -272,7 +272,7 @@ spec:
       # through RBAC. Without this bump the chroot in-cluster fallback
       # bounces every mutation with 403 (TC-215, TC-218, TC-243, TC-247
       # in iter-7 matrix).
-      version: 1.4.102
+      version: 1.4.103
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -1,5 +1,16 @@
 apiVersion: v2
 name: bp-catalyst-platform
+# 1.4.103 (qa-loop iter-7 Fix #37 follow-up): qa-continuum-status-seed
+# Job in CrashLoopBackOff because `kubectl get continuum cont-omantel`
+# is ambiguous — `continuum` is BOTH the singular of
+# `continuums.dr.openova.io` AND the category that
+# `cnpgpairs.dr.openova.io` and `pdms.dr.openova.io` subscribe to.
+# kubectl returns "you must specify only one resource" when the named
+# lookup matches multiple kinds. Switch the seeder's get + patch to use
+# the FQN `continuums.dr.openova.io` so the lookup is unambiguous.
+# Other seeders (cnpgpair, pdm, scheduledbackup) are not affected
+# because their singular names are not also category aliases.
+#
 # 1.4.101 (qa-loop iter-7 Fix #37): EPIC-6 + EPIC-1 target-state qa-fixtures
 # closeout. Adds:
 #   - templates/qa-fixtures/cnpg-clusters-qa.yaml — `cluster-primary` +
@@ -261,7 +272,7 @@ name: bp-catalyst-platform
 # (PUT /k8s/{kind}/{ns}/{name}, /scale, /restart) so the chroot in-cluster
 # fallback (`feedback_chroot_in_cluster_fallback.md`) authorises through
 # RBAC instead of bouncing every mutation with 403.
-version: 1.4.102
+version: 1.4.103
 appVersion: 1.4.94
 description: |
   Catalyst Platform — the unified Catalyst control plane umbrella chart for Catalyst-Zero.

--- a/products/catalyst/chart/templates/qa-fixtures/continuum-qa.yaml
+++ b/products/catalyst/chart/templates/qa-fixtures/continuum-qa.yaml
@@ -136,7 +136,7 @@ spec:
               # Wait for the CR to exist (Helm orders apply→hooks but be
               # resilient to flux race).
               for _ in $(seq 1 60); do
-                kubectl -n "$NS" get continuum "$CN" >/dev/null 2>&1 && break
+                kubectl -n "$NS" get continuums.dr.openova.io "$CN" >/dev/null 2>&1 && break
                 sleep 2
               done
               # Patch status subresource with the matrix-required fields.
@@ -178,6 +178,6 @@ spec:
                 "observedGeneration":1
               }}
               EOF
-              kubectl -n "$NS" patch continuum "$CN" --type=merge --subresource=status --patch-file=/tmp/status.json
+              kubectl -n "$NS" patch continuums.dr.openova.io "$CN" --type=merge --subresource=status --patch-file=/tmp/status.json
               echo "seeded status for $NS/$CN"
 {{- end }}


### PR DESCRIPTION
## Summary

bp-catalyst-platform 1.4.102 → 1.4.103. Closes the qa-continuum-status-seed Job CrashLoopBackOff that blocks bp-catalyst-platform Helm upgrade hooks indefinitely.

Root cause: \`kubectl get continuum cont-omantel\` is ambiguous — \`continuum\` is both the singular of \`continuums.dr.openova.io\` AND the category that \`cnpgpairs.dr.openova.io\` + \`pdms.dr.openova.io\` subscribe to. kubectl returns "you must specify only one resource" when a named lookup matches multiple kinds.

Fix: switch wait loop + patch call to FQN \`continuums.dr.openova.io\`. Other seeders (cnpgpair, pdm, scheduledbackup) are unaffected because their singular names are not also category aliases.

Bumps bootstrap-kit/13-bp-catalyst-platform.yaml HR pin to 1.4.103 to flow the chart roll through Flux per `incidents.md` §"Chart 1.4.98 stuck".

## Test plan
- [ ] Chart 1.4.103 published
- [ ] HR upgrades cleanly to 1.4.103 (post-install hook completes)
- [ ] qa-continuum-status-seed Job goes Complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)