### PR TITLE
fix(chart): bp-k8s-ws-proxy render test explicitly clears image.tag (Fix #39 follow-up)

### DIFF
--- a/platform/k8s-ws-proxy/chart/tests/render.sh
+++ b/platform/k8s-ws-proxy/chart/tests/render.sh
@@ -29,8 +29,16 @@ if [[ "$off" != "0" ]]; then
 fi
 echo "PASS: default-OFF = 0 resources"
 
-# 2. Fail-fast on empty image tag
-if helm template bp-k8s-ws-proxy . --set k8sWsProxy.enabled=true \
+# 2. Fail-fast on empty image tag (operator-override path).
+#    qa-loop iter-7 Fix #39 follow-up: build-k8s-ws-proxy.yaml's promote
+#    job auto-bumps values.yaml `image.tag` to a real SHA on every push,
+#    so testing the fail-fast contract requires explicitly clearing the
+#    tag with --set. Without the explicit clear, the test stops
+#    exercising the contract once any build commit lands. The contract
+#    itself (empty tag → render fail per _helpers.tpl) is unchanged.
+if helm template bp-k8s-ws-proxy . \
+    --set k8sWsProxy.enabled=true \
+    --set k8sWsProxy.image.tag= \
     >/dev/null 2>"$TMP/err"; then
   echo "FAIL: empty tag did not abort render"
   exit 1


### PR DESCRIPTION
## Summary

Blueprint Release [run 25612688419](https://github.com/openova-io/openova/actions/runs/25612688419) caught a stale-tag assertion in `platform/k8s-ws-proxy/chart/tests/render.sh` test #2. After the `build-k8s-ws-proxy.yaml` promote job auto-bumped `values.yaml` `image.tag` to a real SHA on PR #1236's merge, the test's `--set k8sWsProxy.enabled=true` (without explicitly clearing the tag) rendered fine and tripped "FAIL: empty tag did not abort render".

The fail-fast contract (empty tag → render fail per `_helpers.tpl`) is unchanged; the test now explicitly `--set k8sWsProxy.image.tag=` to exercise the operator-override path. Mirrors the same pattern already applied to the bp-guacamole render test in the parent PR.

## Test plan

- [x] `bash platform/k8s-ws-proxy/chart/tests/render.sh` — all 4 PASS
- [ ] After merge: blueprint-release re-runs; bp-k8s-ws-proxy:0.1.3 publishes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)