### PR TITLE
fix(bootstrap-kit): bump Fix #39 slot pins to latest published chart versions

### DIFF
--- a/clusters/_template/bootstrap-kit/51-bp-k8s-ws-proxy.yaml
+++ b/clusters/_template/bootstrap-kit/51-bp-k8s-ws-proxy.yaml
@@ -59,9 +59,12 @@ spec:
   chart:
     spec:
       chart: bp-k8s-ws-proxy
-      # 0.1.1: canonical workload name `k8s-ws-proxy`; first published
-      # version after Fix #39's CI workflow lands.
-      version: 0.1.1
+      # 0.1.3: canonical workload name `k8s-ws-proxy` (0.1.1 base) +
+      # auto-bumped values.yaml.image.tag from CI promote job (0.1.2)
+      # + chart render-test stale-tag fix (0.1.3, PR #1237). 0.1.1
+      # was unrenderable because values.yaml.image.tag was empty —
+      # CI bumps populate it.
+      version: 0.1.3
       sourceRef:
         kind: HelmRepository
         name: bp-k8s-ws-proxy

--- a/clusters/_template/bootstrap-kit/52-bp-guacamole.yaml
+++ b/clusters/_template/bootstrap-kit/52-bp-guacamole.yaml
@@ -81,10 +81,13 @@ spec:
   chart:
     spec:
       chart: bp-guacamole
-      # 0.1.1: canonical short resource names (guacd / guacamole-server
-      # / guacamole-recordings); GHCR-mirrored upstream images;
-      # realm-patch ConfigMap correctly lands in the keycloak namespace.
-      version: 0.1.1
+      # 0.1.2: canonical short resource names (guacd / guacamole-server
+      # / guacamole-recordings); GHCR-mirrored upstream images
+      # auto-published by build-bp-guacamole.yaml; realm-patch ConfigMap
+      # correctly lands in the keycloak namespace. (0.1.1 base + the
+      # CI promote-job auto-bump that materialized the GHCR mirror
+      # references in values.yaml.)
+      version: 0.1.2
       sourceRef:
         kind: HelmRepository
         name: bp-guacamole

--- a/clusters/omantel.omani.works/bootstrap-kit/51-bp-k8s-ws-proxy.yaml
+++ b/clusters/omantel.omani.works/bootstrap-kit/51-bp-k8s-ws-proxy.yaml
@@ -35,7 +35,9 @@ spec:
   chart:
     spec:
       chart: bp-k8s-ws-proxy
-      version: 0.1.1
+      # 0.1.3: 0.1.1 base + CI auto-bumped image.tag (0.1.2) +
+      # render-test stale-tag fix (0.1.3, PR #1237).
+      version: 0.1.3
       sourceRef:
         kind: HelmRepository
         name: bp-k8s-ws-proxy

--- a/clusters/omantel.omani.works/bootstrap-kit/52-bp-guacamole.yaml
+++ b/clusters/omantel.omani.works/bootstrap-kit/52-bp-guacamole.yaml
@@ -47,7 +47,9 @@ spec:
   chart:
     spec:
       chart: bp-guacamole
-      version: 0.1.1
+      # 0.1.2: 0.1.1 base + CI auto-bumped values.yaml to GHCR mirror
+      # of upstream Apache Guacamole 1.5.5.
+      version: 0.1.2
       sourceRef:
         kind: HelmRepository
         name: bp-guacamole


### PR DESCRIPTION
## Summary

Bumps slots 51 (bp-k8s-ws-proxy) + 52 (bp-guacamole) from 0.1.1 → latest published versions so the slots actually reconcile on Sovereigns.

The 0.1.1 chart artifact has an empty values.yaml `image.tag` (the CI promote job in `build-k8s-ws-proxy.yaml` populates it on every push, materializing 0.1.2/0.1.3). Without this bump, Flux on omantel reports:

```
HelmRelease bp-k8s-ws-proxy: Helm install failed for release k8s-ws-proxy with chart bp-k8s-ws-proxy@0.1.1: bp-k8s-ws-proxy: .Values.k8sWsProxy.image.tag is empty — SHA-pinned image required (CI populates this)
```

## Bumps

| Slot | From | To | Why |
|---|---|---|---|
| 51 (bp-k8s-ws-proxy) | 0.1.1 | 0.1.3 | 0.1.2 = CI auto-bumped image tag; 0.1.3 = PR #1237 render-test stale-tag fix |
| 52 (bp-guacamole)    | 0.1.1 | 0.1.2 | CI auto-bumped values.yaml to GHCR mirror of upstream 1.5.5 |

Both `_template/` + `omantel.omani.works/` slot files updated.

## Test plan

- [ ] After merge: omantel Flux reconciles → `bp-k8s-ws-proxy` HR Ready=True, `bp-guacamole` HR Ready=True
- [ ] `kubectl --context=omantel -n catalyst-system get deploy guacd guacamole-server` shows 1/1 each
- [ ] `kubectl --context=omantel -n catalyst-system get ds k8s-ws-proxy` shows 1/1
- [ ] Iter-8 confirms TC-228/230/236/237/245/246 flip PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)