### PR TITLE
fix(chart,bootstrap-kit): default imagePullSecrets to ghcr-pull (Fix #39 follow-up)

### DIFF
--- a/clusters/_template/bootstrap-kit/51-bp-k8s-ws-proxy.yaml
+++ b/clusters/_template/bootstrap-kit/51-bp-k8s-ws-proxy.yaml
@@ -59,12 +59,12 @@ spec:
   chart:
     spec:
       chart: bp-k8s-ws-proxy
-      # 0.1.3: canonical workload name `k8s-ws-proxy` (0.1.1 base) +
-      # auto-bumped values.yaml.image.tag from CI promote job (0.1.2)
-      # + chart render-test stale-tag fix (0.1.3, PR #1237). 0.1.1
-      # was unrenderable because values.yaml.image.tag was empty —
-      # CI bumps populate it.
-      version: 0.1.3
+      # 0.1.5: 0.1.4 (default imagePullSecrets per this PR) +
+      # post-merge CI auto-bump that materializes the new image.tag
+      # in values.yaml. The imagePullSecrets default is required so
+      # omantel pods can pull from private GHCR without per-Sovereign
+      # overlay (the catalyst-system `ghcr-pull` secret is canonical).
+      version: 0.1.5
       sourceRef:
         kind: HelmRepository
         name: bp-k8s-ws-proxy

--- a/clusters/_template/bootstrap-kit/52-bp-guacamole.yaml
+++ b/clusters/_template/bootstrap-kit/52-bp-guacamole.yaml
@@ -81,13 +81,13 @@ spec:
   chart:
     spec:
       chart: bp-guacamole
-      # 0.1.2: canonical short resource names (guacd / guacamole-server
-      # / guacamole-recordings); GHCR-mirrored upstream images
-      # auto-published by build-bp-guacamole.yaml; realm-patch ConfigMap
-      # correctly lands in the keycloak namespace. (0.1.1 base + the
-      # CI promote-job auto-bump that materialized the GHCR mirror
-      # references in values.yaml.)
-      version: 0.1.2
+      # 0.1.4: 0.1.3 (default imagePullSecrets per this PR) +
+      # post-merge CI auto-bump that materializes the latest GHCR
+      # mirror image refs. imagePullSecrets default is required so
+      # guacd + guacamole-server pods can pull from private GHCR
+      # without per-Sovereign overlay (the catalyst-system
+      # `ghcr-pull` secret is canonical).
+      version: 0.1.4
       sourceRef:
         kind: HelmRepository
         name: bp-guacamole

--- a/clusters/omantel.omani.works/bootstrap-kit/51-bp-k8s-ws-proxy.yaml
+++ b/clusters/omantel.omani.works/bootstrap-kit/51-bp-k8s-ws-proxy.yaml
@@ -35,9 +35,10 @@ spec:
   chart:
     spec:
       chart: bp-k8s-ws-proxy
-      # 0.1.3: 0.1.1 base + CI auto-bumped image.tag (0.1.2) +
-      # render-test stale-tag fix (0.1.3, PR #1237).
-      version: 0.1.3
+      # 0.1.5: 0.1.4 (default imagePullSecrets) + CI auto-bumped
+      # image.tag. imagePullSecrets default required for omantel pods
+      # to pull from private GHCR.
+      version: 0.1.5
       sourceRef:
         kind: HelmRepository
         name: bp-k8s-ws-proxy

--- a/clusters/omantel.omani.works/bootstrap-kit/52-bp-guacamole.yaml
+++ b/clusters/omantel.omani.works/bootstrap-kit/52-bp-guacamole.yaml
@@ -47,9 +47,10 @@ spec:
   chart:
     spec:
       chart: bp-guacamole
-      # 0.1.2: 0.1.1 base + CI auto-bumped values.yaml to GHCR mirror
-      # of upstream Apache Guacamole 1.5.5.
-      version: 0.1.2
+      # 0.1.4: 0.1.3 (default imagePullSecrets) + CI auto-bumped
+      # values.yaml. imagePullSecrets default required for omantel pods
+      # to pull from private GHCR.
+      version: 0.1.4
       sourceRef:
         kind: HelmRepository
         name: bp-guacamole

--- a/platform/guacamole/chart/Chart.yaml
+++ b/platform/guacamole/chart/Chart.yaml
@@ -6,7 +6,15 @@ name: bp-guacamole
 # realm-patch ConfigMap lands in `keycloak` namespace (was: realm-name,
 # which would have failed on every Sovereign); `realmConfig.namespace`
 # override surface for non-default bp-keycloak placements.
-version: 0.1.2
+# 0.1.3 (Fix #39 follow-up): default imagePullSecrets to [{name:
+# ghcr-pull}] so the Deployments can pull from private GHCR without
+# per-Sovereign overlay. The `ghcr-pull` secret is the canonical
+# pull-credential surface across every Sovereign.
+# Note: build-bp-guacamole.yaml will auto-bump this to 0.1.4 on
+# merge. Slot pin at 0.1.4 so omantel reconciles against the chart
+# that carries BOTH the imagePullSecrets default AND the latest
+# upstream-mirror image refs.
+version: 0.1.3
 appVersion: "1.5.5"
 description: |
   Catalyst-authored Blueprint chart for Apache Guacamole — a clientless

--- a/platform/guacamole/chart/values.yaml
+++ b/platform/guacamole/chart/values.yaml
@@ -174,4 +174,10 @@ guacamole:
     capabilities:
       drop: [ALL]
   # ── Image pull secret ─────────────────────────────────────────
-  imagePullSecrets: []
+  # GHCR pull credentials. The catalyst-system namespace's `ghcr-pull`
+  # secret is the canonical pull-credential surface across every
+  # Sovereign (catalyst-api / catalyst-ui / guacd / guacamole-server /
+  # all mount it), so the chart defaults to it. Operator overrides per
+  # Sovereign for non-canonical credential names.
+  imagePullSecrets:
+    - name: ghcr-pull

--- a/platform/k8s-ws-proxy/chart/Chart.yaml
+++ b/platform/k8s-ws-proxy/chart/Chart.yaml
@@ -5,7 +5,16 @@ name: bp-k8s-ws-proxy
 # ClusterRoleBinding all named `k8s-ws-proxy` so the catalyst-api
 # shells/issue handler + qa-loop test matrix (TC-236, TC-237) can
 # address them without release-name knowledge.
-version: 0.1.3
+# 0.1.4 (Fix #39 follow-up): default imagePullSecrets to [{name:
+# ghcr-pull}] so the DaemonSet can pull from private GHCR without
+# per-Sovereign overlay. The `ghcr-pull` secret is the canonical
+# pull-credential surface across every Sovereign (catalyst-api,
+# catalyst-ui, k8s-ws-proxy all mount it).
+# Note: build-k8s-ws-proxy.yaml's promote job will auto-bump this to
+# 0.1.5 on merge (with the new image SHA in values.yaml). Slot pin
+# at 0.1.5 so omantel reconciles against the chart that carries
+# BOTH the imagePullSecrets default AND the new image SHA.
+version: 0.1.4
 appVersion: "0.1.0"
 description: |
   Catalyst-authored Blueprint chart for the k8s-ws-proxy DaemonSet —

--- a/platform/k8s-ws-proxy/chart/values.yaml
+++ b/platform/k8s-ws-proxy/chart/values.yaml
@@ -77,5 +77,11 @@ k8sWsProxy:
   nodeSelector:
     kubernetes.io/os: linux
   tolerations: []
-  imagePullSecrets: []
+  # GHCR pull credentials. The catalyst-system namespace's `ghcr-pull`
+  # secret is the canonical pull-credential surface across every
+  # Sovereign (catalyst-api / catalyst-ui / k8s-ws-proxy / etc. all
+  # mount it), so the chart defaults to it. Operator overrides per
+  # Sovereign for non-canonical credential names.
+  imagePullSecrets:
+    - name: ghcr-pull
   logLevel: info


### PR DESCRIPTION
## Summary

Live omantel reconciliation surfaced that bp-k8s-ws-proxy DaemonSet pods (and bp-guacamole Deployments) cannot pull from private `ghcr.io/openova-io/openova/*` images without imagePullSecrets:

```
Failed to pull image "ghcr.io/openova-io/openova/k8s-ws-proxy:650696d":
failed to authorize: failed to fetch anonymous token ... 401 Unauthorized
```

The catalyst-system namespace's `ghcr-pull` secret is the canonical pull-credential surface across every Sovereign. Defaulting both charts to `imagePullSecrets: [{name: ghcr-pull}]` removes the per-Sovereign overlay requirement.

## Changes

| File | Change |
|---|---|
| `platform/k8s-ws-proxy/chart/values.yaml` | `imagePullSecrets` default → `[{name: ghcr-pull}]` |
| `platform/k8s-ws-proxy/chart/Chart.yaml`  | 0.1.3 → 0.1.4 |
| `platform/guacamole/chart/values.yaml`    | `imagePullSecrets` default → `[{name: ghcr-pull}]` |
| `platform/guacamole/chart/Chart.yaml`     | 0.1.2 → 0.1.3 |
| `clusters/{_template,omantel.omani.works}/bootstrap-kit/51-bp-k8s-ws-proxy.yaml` | pin → 0.1.5 (post-CI auto-bump) |
| `clusters/{_template,omantel.omani.works}/bootstrap-kit/52-bp-guacamole.yaml`    | pin → 0.1.4 (post-CI auto-bump) |

Both charts will auto-bump again to 0.1.5/0.1.4 when the build/mirror workflows fire on this PR's chart-touch — slot pins target those post-CI versions.

## Test plan

- [x] `helm template + tests/render.sh` — both charts pass
- [ ] After merge: build-* workflows auto-bump charts to 0.1.5/0.1.4 → omantel Flux reconciles → DaemonSet + Deployments Running with imagePullSecrets resolving GHCR auth
- [ ] `kubectl --context=omantel -n catalyst-system get ds k8s-ws-proxy` 1/1 Ready
- [ ] `kubectl --context=omantel -n catalyst-system get deploy guacd guacamole-server` 1/1 Available each

🤖 Generated with [Claude Code](https://claude.com/claude-code)