### PR TITLE
fix(omantel): bp-guacamole storageClass=local-path + webapp replicas=1 (Fix #39 follow-up)

### DIFF
--- a/clusters/omantel.omani.works/bootstrap-kit/52-bp-guacamole.yaml
+++ b/clusters/omantel.omani.works/bootstrap-kit/52-bp-guacamole.yaml
@@ -79,4 +79,15 @@ spec:
         # matches bp-keycloak's realm-config-cli default.
         issuer: https://auth.omantel.biz/realms/catalyst
       recordings:
-        storageClass: seaweedfs-storage
+        # omantel chroot is currently single-CSI (local-path).
+        # SeaweedFS-CSI is not deployed here; once it is, switch
+        # back to `seaweedfs-storage` for RWX session-recording
+        # streaming. local-path is RWO but the recording-shipper
+        # (when added) reads asynchronously, so RWO is acceptable.
+        storageClass: local-path
+      webapp:
+        # Memory-constrained omantel cluster — only one webapp
+        # replica fits alongside the rest of the catalyst-system
+        # stack. Multi-region Sovereigns scale this to chart default
+        # (2) via per-Sovereign overlay.
+        replicas: 1


### PR DESCRIPTION
## Summary

Live omantel reconciliation surfaced two single-cluster realities for bp-guacamole:

1. **`seaweedfs-storage` StorageClass not present on omantel chroot** (only `local-path`). Chart default `seaweedfs-storage` is the correct multi-region target-state shape; omantel overlay overrides to `local-path` until SeaweedFS-CSI is deployed.

2. **Memory-constrained omantel** (3 of 4 worker nodes "Insufficient memory" for 512Mi-request webapp pod). Single-replica is acceptable for single-tenant chroot; multi-region Sovereigns keep the chart default (2).

Both are **per-Sovereign overlay overrides, NOT chart-default changes** — chart defaults stay at the canonical multi-region target-state shape per `feedback_no_mvp_no_workarounds.md` rule #1 ("test matrix scope = target-state, not omantel-can-do-it scope").

## Test plan

- [ ] After merge: omantel reconciles → guacamole-recordings PVC binds (local-path) → guacamole-server schedules with replicas=1 → 1/1 Available
- [ ] `kubectl --context=omantel -n catalyst-system get deploy guacamole-server` 1/1 Available
- [ ] Iter-8 confirms TC-228 / TC-230 / TC-245 / TC-246 flip PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)