### PR TITLE
fix(bootstrap-kit): qaFixtures.primaryRegion default = hz-fsn-rtz-prod (Fix #38 follow-up #2)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -272,6 +272,13 @@ spec:
       # bytes (CI publishes oci://ghcr.io/openova-io/bp-qa-app:0.1.0).
       # Stacks on top of:
       # 1.4.103 (Fix #37 follow-up): qa-continuum-status-seed Job FQN fix
+      # 1.4.105 (Fix #38 follow-up): qa-fixtures Application + Environment
+      # region defaults bumped to canonical 4-segment label
+      # `hz-fsn-rtz-prod` so the qa-wp Application from Fix #36 (#1231)
+      # validates against the CRD pattern `^[a-z]+-[a-z]+-[a-z]+-[a-z]+$`.
+      # Without this fix, `spec.regions[0]: Invalid value: "fsn1"` rejected
+      # the chart upgrade at admission and pinned omantel on the prior
+      # image SHA, blocking Fix #38's TC-141/TC-090/TC-383 from rolling.
       # 1.4.102 (Fix #34 follow-up #1229): catalyst-api-cutover-driver
       # ClusterRole grants update/patch/delete on workload kinds + scale
       # subresources for the resource-action endpoints (PUT /k8s/.../scale,
@@ -279,7 +286,7 @@ spec:
       # RBAC (TC-215, TC-218, TC-243, TC-247).
       # 1.4.101 (Fix #37): EPIC-6 + EPIC-1 target-state qa-fixtures closeout
       # — cnpg-clusters + Kyverno policy bundle.
-      version: 1.4.104
+      version: 1.4.105
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -375,7 +375,13 @@ spec:
       appName: ${QA_FIXTURES_APP:-qa-wp}
       continuumName: ${QA_CONTINUUM_NAME:-cont-omantel}
       cnpgPairName: ${QA_CNPGPAIR_NAME:-qa-cnpg}
-      primaryRegion: ${QA_PRIMARY_REGION:-fsn1}
+      # 4-segment canonical region label per Application + Environment
+      # CRD validation `^[a-z]+-[a-z]+-[a-z]+-[a-z]+$`. Legacy "fsn1"
+      # rejected at admission and pinned omantel on the prior image SHA
+      # (Fix #38 follow-up — caught after chart 1.4.105 still failed
+      # because the bootstrap-kit's release-config override beat the
+      # chart values.yaml default).
+      primaryRegion: ${QA_PRIMARY_REGION:-hz-fsn-rtz-prod}
       standbyRegion: ${QA_STANDBY_REGION:-hz-hel-rtz-prod}
       pdmZone: ${QA_PDM_ZONE:-openova.io}
       # CNPG Cluster CR fixtures (Fix #37) — single-region by default;

--- a/products/catalyst/bootstrap/ui/src/pages/dashboard/DashboardPage.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/dashboard/DashboardPage.test.tsx
@@ -10,15 +10,20 @@
  * What this file proves:
  *   - The breadcrumb renders with the literal text "Dashboard".
  *   - The page H1 still reads "Sovereign Fleet" (no redesign rollback).
- *   - The breadcrumb has the correct `aria-label` and stable testid.
+ *   - The breadcrumb is a <nav> with `aria-label="Breadcrumb"` for AT.
+ *   - The current page in the trail is marked with `aria-current=page`.
  *
  * Routing: TanStack Router renders <Link to="/wizard"> via the provider.
  * We mount the bare DashboardPage with stub routes for /wizard and
  * /dashboard/applications so the Link components don't blow up.
+ *
+ * Assertion style: vanilla vitest matchers (no @testing-library/jest-dom)
+ * because the existing src/test/setup.ts doesn't import jest-dom and
+ * adding it here would diverge from the established convention.
  */
 
-import { describe, it, expect, afterEach } from 'vitest'
-import { render, screen, cleanup, within } from '@testing-library/react'
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { render, screen, cleanup, waitFor, within } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import {
   RouterProvider,
@@ -32,6 +37,23 @@ import {
 import { DashboardPage } from './DashboardPage'
 
 afterEach(() => cleanup())
+
+// Stub the fleet fetch so DashboardPage's useFleet query resolves
+// quickly and the page mounts past the loading state. The breadcrumb
+// renders independently of fetch state, but TanStack Router needs at
+// least one tick before the route component is mounted.
+let originalFetch: typeof globalThis.fetch
+beforeEach(() => {
+  originalFetch = globalThis.fetch
+  globalThis.fetch = (async () =>
+    new Response(JSON.stringify({ sovereigns: [], total: 0, page: 1, pageSize: 25 }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    })) as never
+})
+afterEach(() => {
+  globalThis.fetch = originalFetch
+})
 
 function makeRouter() {
   const rootRoute = createRootRoute({ component: () => <Outlet /> })
@@ -72,31 +94,37 @@ function renderPage() {
 }
 
 describe('DashboardPage breadcrumb (qa-loop iter-7 TC-383)', () => {
-  it('renders the literal "Dashboard" label in the breadcrumb', () => {
+  it('renders the literal "Dashboard" label in the breadcrumb', async () => {
     renderPage()
-    const crumb = screen.getByTestId('dashboard-breadcrumb')
-    expect(crumb).toBeInTheDocument()
+    const crumb = await waitFor(() => screen.getByTestId('dashboard-breadcrumb'))
     // The literal "Dashboard" string MUST be present — the matrix's
     // anti-regression test will fail otherwise.
-    expect(within(crumb).getByText('Dashboard')).toBeInTheDocument()
+    const dash = within(crumb).getByText('Dashboard')
+    expect(dash).not.toBeNull()
+    // Belt-and-braces: the page body as a whole MUST contain
+    // "Dashboard" verbatim, since that's exactly what the matrix's
+    // must_contain check looks for in the rendered DOM.
+    const root = screen.getByTestId('dashboard-page')
+    expect(root.textContent ?? '').toContain('Dashboard')
   })
 
-  it('keeps the H1 as "Sovereign Fleet" so the redesign is preserved', () => {
+  it('keeps the H1 as "Sovereign Fleet" so the redesign is preserved', async () => {
     renderPage()
-    expect(
-      screen.getByRole('heading', { level: 1, name: 'Sovereign Fleet' }),
-    ).toBeInTheDocument()
+    await waitFor(() => screen.getByTestId('dashboard-page'))
+    const h1 = screen.getByRole('heading', { level: 1, name: 'Sovereign Fleet' })
+    expect(h1).not.toBeNull()
   })
 
-  it('exposes the breadcrumb with aria-label="Breadcrumb" for AT users', () => {
+  it('exposes the breadcrumb with aria-label="Breadcrumb" for AT users', async () => {
     renderPage()
-    const crumb = screen.getByLabelText('Breadcrumb')
+    const crumb = await waitFor(() => screen.getByLabelText('Breadcrumb'))
     expect(crumb.tagName.toLowerCase()).toBe('nav')
   })
 
-  it('marks the current page in the trail with aria-current', () => {
+  it('marks the current page in the trail with aria-current', async () => {
     renderPage()
+    await waitFor(() => screen.getByTestId('dashboard-breadcrumb'))
     const current = screen.getByText('Sovereign Fleet', { selector: 'li' })
-    expect(current).toHaveAttribute('aria-current', 'page')
+    expect(current.getAttribute('aria-current')).toBe('page')
   })
 })

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -1,5 +1,14 @@
 apiVersion: v2
 name: bp-catalyst-platform
+# 1.4.105 (qa-loop iter-7 Fix #38 follow-up): qa-fixtures Application +
+# Environment region defaults bumped to canonical 4-segment label
+# `hz-fsn-rtz-prod` so the qa-wp Application from Fix #36 (#1231) and
+# the qa-omantel Environment validate against the CRD pattern
+# `^[a-z]+-[a-z]+-[a-z]+-[a-z]+$`. Without this fix the chart upgrade
+# rejected at admission with `spec.regions[0]: Invalid value: "fsn1"`,
+# pinning omantel on the prior catalyst-api/ui image SHA and blocking
+# Fix #38's TC-141 / TC-090 / TC-383 from rolling.
+#
 # 1.4.104 (qa-loop iter-7 Cluster-C Fix #36, #1231): target-state qa-fixtures
 # stack — Organization + Environment + Blueprint(bp-qa-app) +
 # Application(qa-wp) so the application-controller reconciles qa-wp
@@ -273,7 +282,7 @@ name: bp-catalyst-platform
 # (PUT /k8s/{kind}/{ns}/{name}, /scale, /restart) so the chroot in-cluster
 # fallback (`feedback_chroot_in_cluster_fallback.md`) authorises through
 # RBAC instead of bouncing every mutation with 403.
-version: 1.4.104
+version: 1.4.105
 appVersion: 1.4.94
 description: |
   Catalyst Platform — the unified Catalyst control plane umbrella chart for Catalyst-Zero.

--- a/products/catalyst/chart/templates/qa-fixtures/application-qa-wp.yaml
+++ b/products/catalyst/chart/templates/qa-fixtures/application-qa-wp.yaml
@@ -48,7 +48,10 @@ spec:
     version: "0.1.0"
   placement: single-region
   regions:
-    - {{ .Values.qaFixtures.primaryRegion | default "fsn1" | quote }}
+    # 4-segment canonical region label per CRD validation
+    # `^[a-z]+-[a-z]+-[a-z]+-[a-z]+$`. The legacy "fsn1" default
+    # rejected the Application at admission (Fix #38 follow-up).
+    - {{ .Values.qaFixtures.primaryRegion | default "hz-fsn-rtz-prod" | quote }}
   parameters:
     siteTitle: "QA WP"
     replicas: 1

--- a/products/catalyst/chart/templates/qa-fixtures/environment-qa-omantel.yaml
+++ b/products/catalyst/chart/templates/qa-fixtures/environment-qa-omantel.yaml
@@ -30,6 +30,10 @@ spec:
   placement: single-region
   regions:
     - provider: hetzner
-      region: {{ .Values.qaFixtures.primaryRegion | default "fsn1" | quote }}
+      # 4-segment canonical region label per CRD validation. Inline
+      # default upgraded to hz-fsn-rtz-prod alongside the values.yaml
+      # default so a chart upgrade with the prior values.yaml still
+      # renders a valid region (Fix #38 follow-up).
+      region: {{ .Values.qaFixtures.primaryRegion | default "hz-fsn-rtz-prod" | quote }}
       buildingBlock: rtz
 {{- end }}

--- a/products/catalyst/chart/values.yaml
+++ b/products/catalyst/chart/values.yaml
@@ -943,11 +943,18 @@ qaFixtures:
   qaWpPassword: ""
   # ── Continuum DR fixture knobs (Fix #32, Fix #37) ────────────────
   # CNPGPair name + region pair the matrix asserts on. The default pair
-  # (fsn1 ↔ hz-hel-rtz-prod) reflects the omantel test Sovereign's
-  # ClusterMesh peering. Override on a per-Sovereign basis.
+  # (hz-fsn-rtz-prod ↔ hz-hel-rtz-prod) reflects the omantel test
+  # Sovereign's ClusterMesh peering. Override on a per-Sovereign basis.
+  #
+  # Region values MUST match the canonical 4-segment region label
+  # `^[a-z]+-[a-z]+-[a-z]+-[a-z]+$` enforced by Application + Continuum
+  # CRD validation (Fix #38 follow-up — Fix #36's qa-wp Application
+  # rejected at admission with `spec.regions[0]: Invalid value: "fsn1"`
+  # which blocked the chart upgrade and pinned omantel on the prior
+  # image SHA, preventing TC-141/TC-090/TC-383 from rolling).
   continuumName: cont-omantel
   cnpgPairName: qa-cnpg
-  primaryRegion: fsn1
+  primaryRegion: hz-fsn-rtz-prod
   standbyRegion: hz-hel-rtz-prod
   pdmZone: openova.io
   publicHost: openova.io


### PR DESCRIPTION
## Summary

PR #1239 (Fix #38 follow-up #1) fixed the chart's values.yaml default for `qaFixtures.primaryRegion` but missed the bootstrap-kit's release-config override that beats it in Helm's value-merge order. omantel still rendered qa-wp Application with `spec.regions[0]: "fsn1"` and Application admission rejected the chart upgrade.

Verified by extracting the helm release secret v17 from omantel — chart values had "hz-fsn-rtz-prod" (correct) but release config (from bootstrap-kit) had "fsn1" (the override).

## Test plan

- [ ] After merge, Flux re-reconciles bp-catalyst-platform on omantel
- [ ] qa-wp Application admits successfully
- [ ] catalyst-api + catalyst-ui :7eae9f1 images live on omantel
- [ ] Fix #38's TC-141 / TC-090 / TC-383 verifications pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)