### PR TITLE
fix(bootstrap-kit): Organization sovereignRef defaults to $SOVEREIGN_FQDN (Fix #38 follow-up #3)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -373,6 +373,13 @@ spec:
       enabled: ${QA_FIXTURES_ENABLED:-false}
       namespace: ${QA_FIXTURES_NAMESPACE:-qa-omantel}
       appName: ${QA_FIXTURES_APP:-qa-wp}
+      # Sovereign FQDN for Organization.spec.sovereignRef. CRD validation
+      # `^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+$`
+      # requires a dotted FQDN (single label "omantel" rejected). Defaults
+      # to ${SOVEREIGN_FQDN} from the Kustomization postBuild substitute
+      # so every Sovereign gets its own correct FQDN automatically.
+      sovereignRef: ${SOVEREIGN_FQDN:-omantel.biz}
+      organization: ${QA_ORGANIZATION:-omantel-platform}
       continuumName: ${QA_CONTINUUM_NAME:-cont-omantel}
       cnpgPairName: ${QA_CNPGPAIR_NAME:-qa-cnpg}
       # 4-segment canonical region label per Application + Environment


### PR DESCRIPTION
## Summary
- Adds `qaFixtures.sovereignRef` to bootstrap-kit/13 wired to the Kustomization postBuild substitute `${SOVEREIGN_FQDN}`
- Fixes Organization CRD admission failure: `spec.sovereignRef "omantel" should match '^[a-z0-9](...)+$'` (must contain a dot)
- Pairs with #1243 (primaryRegion fix); together they unblock bp-catalyst-platform 1.4.105 HR upgrade on omantel
- Caught live during qa-loop iter-8 — Organization fixture failed admission, cascading into all qa-wp dependent TCs (~33 rows)

## Test plan
- [ ] Helm template renders Organization with sovereignRef matching Sovereign FQDN
- [ ] HR upgrade on omantel succeeds (status Ready=True)
- [ ] kubectl get organization omantel-platform succeeds with sovereignRef=omantel.biz

🤖 Generated with [Claude Code](https://claude.com/claude-code)