### PR TITLE
fix(chart): qa-fixtures sovereignRef = FQDN (Fix #38 follow-up #3)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -272,6 +272,11 @@ spec:
       # bytes (CI publishes oci://ghcr.io/openova-io/bp-qa-app:0.1.0).
       # Stacks on top of:
       # 1.4.103 (Fix #37 follow-up): qa-continuum-status-seed Job FQN fix
+      # 1.4.106 (Fix #38 follow-up #3): qa-fixtures sovereignRef default
+      # = "omantel.biz" so Organization + Environment + Application +
+      # Blueprint + UserAccess validate against the FQDN pattern. Legacy
+      # "omantel" rejected at admission and blocked the chart upgrade
+      # even after the region-pattern fix.
       # 1.4.105 (Fix #38 follow-up): qa-fixtures Application + Environment
       # region defaults bumped to canonical 4-segment label
       # `hz-fsn-rtz-prod` so the qa-wp Application from Fix #36 (#1231)
@@ -286,7 +291,7 @@ spec:
       # RBAC (TC-215, TC-218, TC-243, TC-247).
       # 1.4.101 (Fix #37): EPIC-6 + EPIC-1 target-state qa-fixtures closeout
       # — cnpg-clusters + Kyverno policy bundle.
-      version: 1.4.105
+      version: 1.4.106
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -1,5 +1,13 @@
 apiVersion: v2
 name: bp-catalyst-platform
+# 1.4.106 (qa-loop iter-7 Fix #38 follow-up #3): qa-fixtures
+# sovereignRef default = "omantel.biz" so the Organization +
+# Application + Environment + Blueprint + UserAccess CRs validate
+# against `^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]...)+$`. Without
+# this, qa-fixtures rejected at admission with `spec.sovereignRef:
+# Invalid value: "omantel"` and chart 1.4.105 still failed to install
+# on omantel even after the region-pattern fix landed.
+#
 # 1.4.105 (qa-loop iter-7 Fix #38 follow-up): qa-fixtures Application +
 # Environment region defaults bumped to canonical 4-segment label
 # `hz-fsn-rtz-prod` so the qa-wp Application from Fix #36 (#1231) and
@@ -282,7 +290,7 @@ name: bp-catalyst-platform
 # (PUT /k8s/{kind}/{ns}/{name}, /scale, /restart) so the chroot in-cluster
 # fallback (`feedback_chroot_in_cluster_fallback.md`) authorises through
 # RBAC instead of bouncing every mutation with 403.
-version: 1.4.105
+version: 1.4.106
 appVersion: 1.4.94
 description: |
   Catalyst Platform — the unified Catalyst control plane umbrella chart for Catalyst-Zero.

--- a/products/catalyst/chart/templates/qa-fixtures/application-qa-wp.yaml
+++ b/products/catalyst/chart/templates/qa-fixtures/application-qa-wp.yaml
@@ -34,7 +34,7 @@ metadata:
     openova.io/environment: {{ .Values.qaFixtures.namespace | default "qa-omantel" | quote }}
     openova.io/application: {{ .Values.qaFixtures.appName | default "qa-wp" | quote }}
     openova.io/env-type: dev
-    openova.io/sovereign: {{ .Values.qaFixtures.sovereignRef | default "omantel" | quote }}
+    openova.io/sovereign: {{ .Values.qaFixtures.sovereignRef | default "omantel.biz" | quote }}
     catalyst.openova.io/managed-by: qa-fixtures
     catalyst.openova.io/blueprint: bp-qa-app
     catalyst.openova.io/blueprint-version: "0.1.0"

--- a/products/catalyst/chart/templates/qa-fixtures/blueprint-bp-qa-app.yaml
+++ b/products/catalyst/chart/templates/qa-fixtures/blueprint-bp-qa-app.yaml
@@ -23,7 +23,7 @@ metadata:
     catalyst.openova.io/managed-by: qa-fixtures
     catalyst.openova.io/origin: openova-public
     catalyst.openova.io/curation: openova-public
-    catalyst.openova.io/sovereign: {{ .Values.qaFixtures.sovereignRef | default "omantel" | quote }}
+    catalyst.openova.io/sovereign: {{ .Values.qaFixtures.sovereignRef | default "omantel.biz" | quote }}
     catalyst.openova.io/category: testing
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/products/catalyst/chart/templates/qa-fixtures/blueprint-bp-qa-custom.yaml
+++ b/products/catalyst/chart/templates/qa-fixtures/blueprint-bp-qa-custom.yaml
@@ -7,7 +7,7 @@ metadata:
     catalyst.openova.io/managed-by: qa-fixtures
     catalyst.openova.io/origin: org-private
     catalyst.openova.io/curation: org-private
-    catalyst.openova.io/sovereign: {{ .Values.qaFixtures.sovereignRef | default "omantel" }}
+    catalyst.openova.io/sovereign: {{ .Values.qaFixtures.sovereignRef | default "omantel.biz" }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/instance: {{ .Release.Name }}
 spec:

--- a/products/catalyst/chart/templates/qa-fixtures/environment-qa-omantel.yaml
+++ b/products/catalyst/chart/templates/qa-fixtures/environment-qa-omantel.yaml
@@ -19,7 +19,7 @@ kind: Environment
 metadata:
   name: {{ .Values.qaFixtures.namespace | default "qa-omantel" | quote }}
   labels:
-    openova.io/sovereign: {{ .Values.qaFixtures.sovereignRef | default "omantel" | quote }}
+    openova.io/sovereign: {{ .Values.qaFixtures.sovereignRef | default "omantel.biz" | quote }}
     openova.io/organization: {{ .Values.qaFixtures.organization | default "omantel-platform" | quote }}
     catalyst.openova.io/managed-by: qa-fixtures
     app.kubernetes.io/managed-by: {{ .Release.Service }}

--- a/products/catalyst/chart/templates/qa-fixtures/organization-omantel-platform.yaml
+++ b/products/catalyst/chart/templates/qa-fixtures/organization-omantel-platform.yaml
@@ -25,7 +25,7 @@ kind: Organization
 metadata:
   name: {{ .Values.qaFixtures.organization | default "omantel-platform" | quote }}
   labels:
-    openova.io/sovereign: {{ .Values.qaFixtures.sovereignRef | default "omantel" | quote }}
+    openova.io/sovereign: {{ .Values.qaFixtures.sovereignRef | default "omantel.biz" | quote }}
     catalyst.openova.io/managed-by: qa-fixtures
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/instance: {{ .Release.Name }}
@@ -35,7 +35,7 @@ spec:
   kind: internal
   tier: corporate
   billingMode: chargeback
-  sovereignRef: {{ .Values.qaFixtures.sovereignRef | default "omantel" | quote }}
+  sovereignRef: {{ .Values.qaFixtures.sovereignRef | default "omantel.biz" | quote }}
   defaultEnvironmentType: dev
   owners:
     - email: {{ .Values.qaFixtures.qaUser.email | default "qa-user1@openova.io" | quote }}

--- a/products/catalyst/chart/templates/qa-fixtures/useraccess-qa-user1.yaml
+++ b/products/catalyst/chart/templates/qa-fixtures/useraccess-qa-user1.yaml
@@ -15,7 +15,7 @@ metadata:
     catalyst.openova.io/user-email: {{ .Values.qaFixtures.qaUser.email | default "qa-user1@openova.io" | quote }}
     catalyst.openova.io/user-name: {{ .Values.qaFixtures.qaUser.name | default "qa-user1" | quote }}
 spec:
-  sovereignRef: {{ .Values.qaFixtures.sovereignRef | default "omantel" | quote }}
+  sovereignRef: {{ .Values.qaFixtures.sovereignRef | default "omantel.biz" | quote }}
   tierRoleRef: openova:tier-developer
   user:
     keycloakSubject: {{ .Values.qaFixtures.qaUser.keycloakSubject | default "qa-user1" | quote }}

--- a/products/catalyst/chart/values.yaml
+++ b/products/catalyst/chart/values.yaml
@@ -929,7 +929,12 @@ qaFixtures:
   enabled: false
   namespace: qa-omantel
   appName: qa-wp
-  sovereignRef: omantel
+  # sovereignRef MUST be a FQDN per Organization CRD validation
+  # (pattern '^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]...)+$').
+  # Operators override per-Sovereign. Default chosen to match the
+  # qa-omantel test Sovereign's actual hostname (Fix #38 follow-up #3 —
+  # legacy "omantel" rejected at admission and blocked the qa-wp roll).
+  sovereignRef: omantel.biz
   organization: omantel-platform
   qaUser:
     email: qa-user1@openova.io


### PR DESCRIPTION
## Summary

Chart 1.4.105 still failed to install on omantel even after the region-pattern fix (#1239 + #1243), this time on `Organization.spec.sovereignRef: Invalid value: "omantel"`. Organization CRD requires FQDN (`omantel.biz`).

This PR fixes the defaults across values.yaml + 6 inline template defaults and bumps chart to 1.4.106 + bootstrap-kit pin.

## Test plan

- [ ] Chart 1.4.106 installs on omantel
- [ ] catalyst-api + catalyst-ui :7eae9f1 images live on omantel
- [ ] Fix #38 verifications pass (TC-141, TC-090, TC-383)

🤖 Generated with [Claude Code](https://claude.com/claude-code)