### PR TITLE
fix(chart): UserAccess sovereignRef strips dots (Fix #38 follow-up #4)

### DIFF
--- a/products/catalyst/chart/templates/qa-fixtures/useraccess-qa-user1.yaml
+++ b/products/catalyst/chart/templates/qa-fixtures/useraccess-qa-user1.yaml
@@ -15,7 +15,11 @@ metadata:
     catalyst.openova.io/user-email: {{ .Values.qaFixtures.qaUser.email | default "qa-user1@openova.io" | quote }}
     catalyst.openova.io/user-name: {{ .Values.qaFixtures.qaUser.name | default "qa-user1" | quote }}
 spec:
-  sovereignRef: {{ .Values.qaFixtures.sovereignRef | default "omantel.biz" | quote }}
+  # UserAccess CRD validates spec.sovereignRef against `^[a-z0-9][a-z0-9-]{0,62}$`
+  # — single-label only (no dots). Strip the TLD/SLD from the FQDN
+  # so {qaFixtures.sovereignRef = "omantel.biz"} renders as "omantel".
+  # Other CRDs (Organization, Environment) want the FQDN as-is.
+  sovereignRef: {{ .Values.qaFixtures.sovereignRef | default "omantel.biz" | regexReplaceAll "\\..*$" "" | quote }}
   tierRoleRef: openova:tier-developer
   user:
     keycloakSubject: {{ .Values.qaFixtures.qaUser.keycloakSubject | default "qa-user1" | quote }}


### PR DESCRIPTION
Strips TLD from qaFixtures.sovereignRef for UserAccess template only. UserAccess CRD wants single-label, other CRDs want dotted FQDN. Unblocks bp-catalyst-platform 1.4.105 HR.