### PR TITLE
fix(chart): UserAccess sovereignRef regex args order (Sprig pipeline bug)

### DIFF
--- a/products/catalyst/chart/templates/qa-fixtures/useraccess-qa-user1.yaml
+++ b/products/catalyst/chart/templates/qa-fixtures/useraccess-qa-user1.yaml
@@ -19,7 +19,7 @@ spec:
   # — single-label only (no dots). Strip the TLD/SLD from the FQDN
   # so {qaFixtures.sovereignRef = "omantel.biz"} renders as "omantel".
   # Other CRDs (Organization, Environment) want the FQDN as-is.
-  sovereignRef: {{ .Values.qaFixtures.sovereignRef | default "omantel.biz" | regexReplaceAll "\\..*$" "" | quote }}
+  sovereignRef: {{ regexReplaceAll "\\..*$" (.Values.qaFixtures.sovereignRef | default "omantel.biz") "" | quote }}
   tierRoleRef: openova:tier-developer
   user:
     keycloakSubject: {{ .Values.qaFixtures.qaUser.keycloakSubject | default "qa-user1" | quote }}


### PR DESCRIPTION
Sprig regexReplaceAll(pattern, input, replacement) — pipeline form put value in REPLACEMENT slot. Switch to positional. Unblocks bp-catalyst-platform 1.4.106 HR.