### PR TITLE
fix(chart): UserAccess regexReplaceAll uses direct form not pipe (Fix #38 follow-up #4)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -298,7 +298,14 @@ spec:
       # Blueprint CR alias resolved by chained catalog client; node-labels
       # seeder Job patches Nodes with topology.kubernetes.io/region short
       # form derived from openova.io/region; CNPGPair renamed to qa-cnpgpair.
-      version: 1.4.107
+      # 1.4.108 (qa-loop iter-7 Fix #38 follow-up #4): the regexReplaceAll
+      # in PR #1246's UserAccess template was using Sprig's pipe form
+      # which mis-routes the FQDN value into the `repl` arg slot, producing
+      # an empty sovereignRef on every render. Switched to direct call form
+      # so the strip actually fires (omantel.biz → omantel). Without this
+      # the chart upgrade fails admission on UserAccess.spec.sovereignRef
+      # and pins omantel on the prior image SHA.
+      version: 1.4.108
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -1,5 +1,24 @@
 apiVersion: v2
 name: bp-catalyst-platform
+# 1.4.108 (qa-loop iter-7 Fix #38 follow-up #4 — actual fix for #1246):
+# UserAccess sovereignRef regexReplaceAll signature fix. PR #1246 used
+# Sprig's pipe form `value | regexReplaceAll "regex" "repl"` but the
+# Sprig signature is `regexReplaceAll(regex, src, repl)` — when piped,
+# the pipe value lands in the LAST positional arg → `repl`, NOT `src`.
+# The empty `""` (intended as `repl`) became `src`, the FQDN became
+# `repl`, and every UserAccess rendered `sovereignRef: ""`. CRD
+# validation `^[a-z0-9][a-z0-9-]{0,62}$` then rejected the empty value
+# and the chart upgrade failed (HR Stalled, MissingRollbackTarget) on
+# omantel even after PRs #1239+#1243+#1244+#1245+#1246+#1247 stacked.
+# Fix: call regexReplaceAll directly so the FQDN value lands in `src`
+# and the `\..*$` strip actually fires (omantel.biz → omantel).
+#
+# 1.4.107 (Fix #40 / iter-8 Cluster-A+B, PR #1247): comprehensive
+# qa-fixtures sovereignRef chain (qaFixtures.sovereignFQDN →
+# global.sovereignFQDN → qaFixtures.sovereignRef-if-FQDN → omantel.biz)
+# + cnpg pair fixture knobs. Did NOT fix the regexReplaceAll signature
+# bug (only relaxed downstream); 1.4.108 ships the actual fix.
+#
 # 1.4.106 (qa-loop iter-7 Fix #38 follow-up #3): qa-fixtures
 # sovereignRef default = "omantel.biz" so the Organization +
 # Application + Environment + Blueprint + UserAccess CRs validate
@@ -316,7 +335,7 @@ name: bp-catalyst-platform
 #   - Organization sovereignRef resolution chain (qaFixtures.sovereignFQDN
 #     → global.sovereignFQDN → qaFixtures.sovereignRef-if-FQDN → omantel.biz)
 #     consolidated alongside #1244+#1245+#1246 fixes.
-version: 1.4.107
+version: 1.4.108
 appVersion: 1.4.94
 description: |
   Catalyst Platform — the unified Catalyst control plane umbrella chart for Catalyst-Zero.

--- a/products/catalyst/chart/templates/qa-fixtures/useraccess-qa-user1.yaml
+++ b/products/catalyst/chart/templates/qa-fixtures/useraccess-qa-user1.yaml
@@ -19,7 +19,15 @@ spec:
   # — single-label only (no dots). Strip the TLD/SLD from the FQDN
   # so {qaFixtures.sovereignRef = "omantel.biz"} renders as "omantel".
   # Other CRDs (Organization, Environment) want the FQDN as-is.
-  sovereignRef: {{ .Values.qaFixtures.sovereignRef | default "omantel.biz" | regexReplaceAll "\\..*$" "" | quote }}
+  #
+  # IMPORTANT: Sprig's regexReplaceAll signature is `(regex, src, repl)`,
+  # so when piped (`value | regexReplaceAll "regex" "repl"`) the pipe
+  # value lands in the LAST positional arg → `repl`, NOT `src`. PR #1246
+  # used the pipe form and consequently rendered every UserAccess with
+  # `sovereignRef: ""` (the empty `repl` was treated as `src`). This
+  # form calls regexReplaceAll directly so the FQDN value lands in
+  # `src` and the `\..*$` strip actually fires (Fix #38 follow-up #4).
+  sovereignRef: {{ regexReplaceAll "\\..*$" (.Values.qaFixtures.sovereignRef | default "omantel.biz") "" | quote }}
   tierRoleRef: openova:tier-developer
   user:
     keycloakSubject: {{ .Values.qaFixtures.qaUser.keycloakSubject | default "qa-user1" | quote }}


### PR DESCRIPTION
## Summary

PR #1246 used Sprig's pipe form `value | regexReplaceAll "regex" "repl"` to strip the dot-suffix off the qa-fixtures sovereignRef FQDN for the UserAccess CR. But Sprig's `regexReplaceAll(regex, src, repl)` puts pipe value in the LAST arg → `repl`, not `src`. So the empty `""` (intended as `repl`) became `src`, the FQDN became `repl`, and every UserAccess rendered `sovereignRef: ""` — rejected by the CRD pattern `^[a-z0-9][a-z0-9-]{0,62}$`. omantel chart upgrade has been Stalled on this since chart 1.4.105 landed.

Verified by inspecting helm release secret v22 on omantel: rendered manifest shows `sovereignRef: ""` despite release config having `qaFixtures.sovereignRef: "omantel.biz"`.

Fix: switch to direct call `regexReplaceAll "\\..*$" value ""` so the value actually lands in `src`. Chart bumped 1.4.107 → 1.4.108.

## Test plan

- [ ] After Blueprint Release of 1.4.108, Flux on omantel installs the chart cleanly
- [ ] qa-user1 UserAccess admits with sovereignRef = "omantel"
- [ ] catalyst-api + catalyst-ui :7eae9f1 (Fix #38) live on omantel
- [ ] Fix #38 TC-141 / TC-090 / TC-383 verifications pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)