### PR TITLE
fix(controllers): COPY core/controllers/pkg into env+org Containerfiles

### DIFF
--- a/core/controllers/environment/Containerfile
+++ b/core/controllers/environment/Containerfile
@@ -28,6 +28,14 @@ RUN go mod download
 # Copy source + build.
 WORKDIR /workspace
 COPY core/controllers/internal /workspace/core/controllers/internal
+# Slice CC2 (#1095) consolidated the gitea HTTP client + render +
+# validate helpers under core/controllers/pkg. The env-controller
+# imports github.com/openova-io/openova/core/controllers/pkg/gitea —
+# without this COPY the `go build` step fails with `no required module
+# provides package github.com/openova-io/openova/core/controllers/pkg/gitea`.
+# qa-loop iter-8 Fix #42 follow-up: latent bug in the bot-generated
+# Containerfile (PR #1252's first build surfaced it).
+COPY core/controllers/pkg /workspace/core/controllers/pkg
 COPY core/controllers/environment /workspace/core/controllers/environment
 
 WORKDIR /workspace/core/controllers/environment

--- a/core/controllers/organization/Containerfile
+++ b/core/controllers/organization/Containerfile
@@ -28,6 +28,14 @@ RUN go mod download
 # Stage 2: copy source + build.
 WORKDIR /workspace
 COPY core/controllers/internal /workspace/core/controllers/internal
+# Slice CC2 (#1095) consolidated the gitea HTTP client + render +
+# validate helpers under core/controllers/pkg. The org-controller
+# imports github.com/openova-io/openova/core/controllers/pkg/gitea —
+# without this COPY the `go build` step fails with `no required module
+# provides package github.com/openova-io/openova/core/controllers/pkg/gitea`.
+# qa-loop iter-8 Fix #42 follow-up: latent bug in the bot-generated
+# Containerfile (PR #1252's first build surfaced it).
+COPY core/controllers/pkg /workspace/core/controllers/pkg
 COPY core/controllers/organization /workspace/core/controllers/organization
 
 WORKDIR /workspace/core/controllers/organization


### PR DESCRIPTION
## Summary

Containerfile fix-up for PR #1252. The bot-generated Containerfiles for environment-controller and organization-controller were missing \`COPY core/controllers/pkg\` — both controllers import \`pkg/gitea\` so \`go build\` fails with \`no required module provides package github.com/openova-io/openova/core/controllers/pkg/gitea\`.

Latent bug; the build-*-controller workflows hadn't fired since \`core/controllers/pkg/*\` was last modified, so it sat unnoticed. PR #1252's first push-to-main build surfaced it.

application-controller's Containerfile was already correct.

## Test plan
- [ ] \`Build organization-controller\` and \`Build environment-controller\` workflows go green on merge

Refs: #1252, #1095.

🤖 Generated with [Claude Code](https://claude.com/claude-code)