### PR TITLE
deploy: bump catalyst controller image SHAs to qa-loop iter-8 Fix #42

### DIFF
--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -1,5 +1,19 @@
 apiVersion: v2
 name: bp-catalyst-platform
+# 1.4.111 (qa-loop iter-8 Fix #42 controller image bump): bumps the
+# 3 controller image tags so the Sovereign actually consumes the
+# Fix #42 code:
+#   - organization-controller :1b29c71 → :72e3f08
+#     (Bug 1 — UserAccess Claim namespace)
+#   - environment-controller :1b29c71 → :72e3f08
+#     (Bug 2 — per-Env repo self-heal via EnsureRepo)
+#   - application-controller :3d1deef → :b321ada
+#     (Bug 3 — host-side Flux GitRepository + Kustomization upsert)
+# The catalyst-build deploy job auto-bumps catalyst{Api,Ui} tags but
+# NOT the per-controller tags, so this is a manual one-line bump per
+# tag. Once 1.4.111 reconciles on omantel via Flux, the qa-wp
+# Application materialises a real nginx Pod within ~60s.
+#
 # 1.4.110 (qa-loop iter-8 Fix #42 RETRY): three-bug controller closeout
 # that unblocks the qa-wp end-to-end Pod-spawn path on omantel.
 #
@@ -388,7 +402,7 @@ name: bp-catalyst-platform
 #     so the matrix's `kubectl get cnpgpair` stdout contains the literal
 #     "cnpgpair" substring TC-306 asserts on (envsubst override beat the
 #     chart values default fixed in PR #1247).
-version: 1.4.110
+version: 1.4.111
 appVersion: 1.4.94
 description: |
   Catalyst Platform — the unified Catalyst control plane umbrella chart for Catalyst-Zero.

--- a/products/catalyst/chart/values.yaml
+++ b/products/catalyst/chart/values.yaml
@@ -200,9 +200,9 @@ controllers:
     enabled: true
     image:
       repository: "ghcr.io/openova-io/openova/organization-controller"
-      # SHA pinned to the latest GHCR-published push-on-main build per
-      # docs/INVIOLABLE-PRINCIPLES.md #4a. CI bumps this on every push.
-      tag: "1b29c71"
+      # 72e3f08 = qa-loop iter-8 Fix #42 (#1252 + Containerfile fix-up
+      # #1253) — fixes Bug 1 (UserAccess Claim namespace).
+      tag: "72e3f08"
       pullPolicy: IfNotPresent
     replicas: 1
     leaderElection:
@@ -234,8 +234,9 @@ controllers:
     enabled: true
     image:
       repository: "ghcr.io/openova-io/openova/environment-controller"
-      # SHA pinned to the latest GHCR-published push-on-main build.
-      tag: "1b29c71"
+      # 72e3f08 = qa-loop iter-8 Fix #42 (#1252 + Containerfile fix-up
+      # #1253) — fixes Bug 2 (per-Env repo self-heal via EnsureRepo).
+      tag: "72e3f08"
       pullPolicy: IfNotPresent
     replicas: 1
     leaderElection:
@@ -292,10 +293,13 @@ controllers:
     enabled: true
     image:
       repository: "ghcr.io/openova-io/openova/application-controller"
-      # SHA pinned to the latest GHCR-published push-on-main build.
-      # 3d1deef = qa-loop iter-1 application-controller-flag-mismatch fix
-      # (PR #1196 main.go + PR #1199 Containerfile pkg/ COPY).
-      tag: "3d1deef"
+      # b321ada = qa-loop iter-8 Fix #42 (#1252) — fixes Bug 3
+      # (host-side Flux GitRepository + Kustomization upsert so the
+      # per-Application manifests get pulled by Flux on the host
+      # cluster). Application Containerfile already shipped with
+      # `COPY core/controllers/pkg`, so the env+org Containerfile
+      # fix-up #1253 didn't rebuild this image.
+      tag: "b321ada"
       pullPolicy: IfNotPresent
     replicas: 1
     leaderElection:


### PR DESCRIPTION
## Summary

Bumps the 3 controller image tags so the Sovereign actually consumes the Fix #42 (#1252 + Containerfile fix-up #1253) code:

| Controller | Old | New | Bug |
|---|---|---|---|
| organization-controller | \`:1b29c71\` | \`:72e3f08\` | Bug 1 — UA Claim namespace |
| environment-controller | \`:1b29c71\` | \`:72e3f08\` | Bug 2 — per-Env repo self-heal via EnsureRepo |
| application-controller | \`:3d1deef\` | \`:b321ada\` | Bug 3 — host-side Flux GitRepository + Kustomization upsert |

Chart \`bp-catalyst-platform\`: 1.4.110 → 1.4.111.

The catalyst-build deploy job auto-bumps catalyst{Api,Ui} tags but NOT the per-controller tags, so this is a manual one-line bump per tag (CI/CD gap to address separately).

## Test plan
- [ ] CI green on \`Blueprint Release\` for chart 1.4.111
- [ ] Image SHAs land on omantel via Flux reconcile (~1 min after merge)
- [ ] organization-controller logs no longer show \`an empty namespace may not be set when a resource name is provided\`
- [ ] environment-controller no longer logs \`gitea repo not found — re-queueing\` (the per-Env repo is created)
- [ ] \`kubectl --context=omantel -n flux-system get gitrepository,kustomization | grep catalyst-app-omantel-platform-qa-wp\` shows both registered
- [ ] qa-wp Pod scheduled in qa-omantel within ~60s of roll

Refs: #1252, #1253, #1095.

🤖 Generated with [Claude Code](https://claude.com/claude-code)