### PR TITLE
deploy: bump env+app controller image SHAs to :a3ba200, chart 1.4.113

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -320,13 +320,16 @@ spec:
       # mapping to ErrRepoNotFound, dropping the controller into a
       # permanent re-queue loop. Will need an env-controller image
       # rebuild before the chart actually consumes the fix.
+      # 1.4.113 (Fix #42 image bump #2): env+app controllers bumped to
+      # :a3ba200 — env-controller has EnsureBranch (PR #1257);
+      # app-controller drops cross-namespace ownerRefs.
       # 1.4.109 (Fix #40 follow-up #2): drop /api/v1 from organization +
       # environment-controller GITEA URL defaults — Gitea client appends
       # it; the prior default produced /api/v1/api/v1/... 404s on
       # EnsureOrg / EnsureRepo blocking qa-wp Application reconcile.
       # bootstrap-kit qaFixtures.cnpgPairName default qa-cnpg → qa-cnpgpair
       # so TC-306's "cnpgpair" substring assertion passes.
-      version: 1.4.112
+      version: 1.4.113
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -1,5 +1,12 @@
 apiVersion: v2
 name: bp-catalyst-platform
+# 1.4.113 (qa-loop iter-8 Fix #42 image bump #2): env+app controllers
+# bumped to :a3ba200 — env-controller has EnsureBranch (PR #1257);
+# app-controller drops cross-namespace ownerRefs (was being silently
+# GC'd because Application is in qa-omantel but the host Flux CRs
+# live in flux-system; cross-namespace ownerRefs trigger immediate
+# K8s GC delete).
+#
 # 1.4.112 (qa-loop iter-8 Fix #42 follow-up: env-controller EnsureBranch).
 # environment-controller now calls EnsureBranch right after EnsureRepo
 # so the env-type-mapped branch (`develop` for envType=dev) exists
@@ -412,7 +419,7 @@ name: bp-catalyst-platform
 #     so the matrix's `kubectl get cnpgpair` stdout contains the literal
 #     "cnpgpair" substring TC-306 asserts on (envsubst override beat the
 #     chart values default fixed in PR #1247).
-version: 1.4.112
+version: 1.4.113
 appVersion: 1.4.94
 description: |
   Catalyst Platform — the unified Catalyst control plane umbrella chart for Catalyst-Zero.

--- a/products/catalyst/chart/values.yaml
+++ b/products/catalyst/chart/values.yaml
@@ -234,9 +234,11 @@ controllers:
     enabled: true
     image:
       repository: "ghcr.io/openova-io/openova/environment-controller"
-      # 72e3f08 = qa-loop iter-8 Fix #42 (#1252 + Containerfile fix-up
-      # #1253) — fixes Bug 2 (per-Env repo self-heal via EnsureRepo).
-      tag: "72e3f08"
+      # a3ba200 = qa-loop iter-8 Fix #42 follow-up (#1257) — adds
+      # EnsureBranch before PutFile so Gitea's branch-missing 404
+      # (mapped to ErrRepoNotFound by the client) no longer dead-loops
+      # the env-controller.
+      tag: "a3ba200"
       pullPolicy: IfNotPresent
     replicas: 1
     leaderElection:
@@ -293,13 +295,11 @@ controllers:
     enabled: true
     image:
       repository: "ghcr.io/openova-io/openova/application-controller"
-      # b321ada = qa-loop iter-8 Fix #42 (#1252) — fixes Bug 3
-      # (host-side Flux GitRepository + Kustomization upsert so the
-      # per-Application manifests get pulled by Flux on the host
-      # cluster). Application Containerfile already shipped with
-      # `COPY core/controllers/pkg`, so the env+org Containerfile
-      # fix-up #1253 didn't rebuild this image.
-      tag: "b321ada"
+      # a3ba200 = qa-loop iter-8 Fix #42 follow-up (#1257) — drops
+      # cross-namespace ownerRef on the host-side Flux CRs (was being
+      # silently GC'd by the K8s collector because Application lives
+      # in a different namespace from flux-system).
+      tag: "a3ba200"
       pullPolicy: IfNotPresent
     replicas: 1
     leaderElection:


### PR DESCRIPTION
## Summary
Bumps env+app controller image tags to :a3ba200 (PR #1257 merge SHA):
- environment-controller :72e3f08 → :a3ba200 (EnsureBranch fix)
- application-controller :b321ada → :a3ba200 (drop cross-NS ownerRef)

org-controller stays at :72e3f08 (unchanged in this PR).

Chart bp-catalyst-platform 1.4.112 → 1.4.113 + bootstrap-kit pin.

## Test plan
- [ ] Flux on omantel reconciles bp-catalyst-platform to 1.4.113
- [ ] env-controller stops looping on "gitea repo not found"
- [ ] catalyst-app-* GitRepository + Kustomization persist in flux-system
- [ ] qa-wp Pod scheduled in qa-omantel

Refs: #1257, #1095.

🤖 Generated with [Claude Code](https://claude.com/claude-code)