### PR TITLE
fix(bp-guacamole): webapp replicas=1 + 256Mi for single-node profile (qa-loop iter-9 infra)

### DIFF
--- a/platform/guacamole/chart/Chart.yaml
+++ b/platform/guacamole/chart/Chart.yaml
@@ -15,7 +15,7 @@ name: bp-guacamole
 # readOnlyRootFilesystem=true. Without it pods crash-looped with
 # `mkdir: cannot create directory '/home/guacamole/.guacamole':
 # Read-only file system`.
-version: 0.1.6
+version: 0.1.7
 appVersion: "1.5.5"
 description: |
   Catalyst-authored Blueprint chart for Apache Guacamole — a clientless

--- a/platform/guacamole/chart/values.yaml
+++ b/platform/guacamole/chart/values.yaml
@@ -61,13 +61,18 @@ guacamole:
       repository: ghcr.io/openova-io/openova/guacamole-server
       tag: "1.5.5"
       pullPolicy: IfNotPresent
-    replicas: 2
+    # Single replica + 256Mi request: omantel chroot single-node-per-region
+    # capacity profile. catalyst-api PVC pins it to one worker (w3 on
+    # omantel), and 2× 512Mi guacamole webapp replicas saturated w3 so
+    # catalyst-api Pod couldn't reschedule on chart roll. Sovereigns with
+    # >1 worker per region can override via values.guacamole.webapp.replicas.
+    replicas: 1
     resources:
       requests:
-        cpu: 200m
-        memory: 512Mi
+        cpu: 100m
+        memory: 256Mi
       limits:
-        memory: 1Gi
+        memory: 768Mi
     port: 8080
   # ── Recording (SeaweedFS PVC) ──────────────────────────────────
   recordings:


### PR DESCRIPTION
Reduces guacamole-server webapp footprint from 2x 512Mi to 1x 256Mi to free w3 worker memory on omantel chroot. catalyst-api PVC node-affinity pins it to w3; chart upgrades repeatedly stalled with catalyst-api Pod Pending due to 99% memory allocation. Multi-node Sovereigns can override. Bumps chart 0.1.6 → 0.1.7.