### PR TITLE
fix(controllers): create per-Org/App Gitea repos as PUBLIC (Fix #42 follow-up)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -323,13 +323,16 @@ spec:
       # 1.4.113 (Fix #42 image bump #2): env+app controllers bumped to
       # :a3ba200 — env-controller has EnsureBranch (PR #1257);
       # app-controller drops cross-namespace ownerRefs.
+      # 1.4.114 (Fix #42 follow-up #3): env+app controllers create the
+      # per-Org/per-App Gitea repos as PUBLIC so Flux can clone them
+      # anonymously (was failing on "authentication required").
       # 1.4.109 (Fix #40 follow-up #2): drop /api/v1 from organization +
       # environment-controller GITEA URL defaults — Gitea client appends
       # it; the prior default produced /api/v1/api/v1/... 404s on
       # EnsureOrg / EnsureRepo blocking qa-wp Application reconcile.
       # bootstrap-kit qaFixtures.cnpgPairName default qa-cnpg → qa-cnpgpair
       # so TC-306's "cnpgpair" substring assertion passes.
-      version: 1.4.113
+      version: 1.4.114
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/core/controllers/application/internal/controller/application_controller.go
+++ b/core/controllers/application/internal/controller/application_controller.go
@@ -489,10 +489,22 @@ func (r *Reconciler) Reconcile(ctx context.Context, app *unstructured.Unstructur
 	}
 
 	// 8. Ensure the per-Application Gitea repo exists.
+	//
+	// private=false: the in-cluster Gitea is on the K8s service cordon
+	// (host-only, no external network access via gitea-http svc), so
+	// "private" is redundant security theater that breaks Flux's
+	// anonymous clone path. Without anonymous-clone the host-side Flux
+	// GitRepository requires a token Secret in flux-system, which would
+	// be yet another bootstrapped state. Public-on-cordon is the
+	// architecturally clean default; operators who want hard isolation
+	// can swap private=true + bootstrap the Secret in a follow-up.
+	// qa-loop iter-8 Fix #42 follow-up #2: live on omantel, private=true
+	// caused `failed to checkout: authentication required` on the
+	// Flux side.
 	branch := branchForEnvType(envSpec.EnvType)
 	if _, err := r.Gitea.EnsureRepo(ctx, envSpec.OrganizationRef, app.GetName(),
 		"Application manifests — auto-managed by application-controller. Do not edit manually.",
-		true); err != nil {
+		false); err != nil {
 		if r.GiteaErrors != nil && r.GiteaErrors.IsOrgNotFound(err) {
 			return r.markPending(ctx, app, ReasonOrgGiteaMissing,
 				fmt.Sprintf("Gitea Org %q does not exist; organization-controller (C1) creates it",

--- a/core/controllers/environment/internal/controller/environment_controller.go
+++ b/core/controllers/environment/internal/controller/environment_controller.go
@@ -245,7 +245,7 @@ func (r *EnvironmentReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		repo,
 		fmt.Sprintf("Per-Environment Flux GitRepository manifests for %s/%s — auto-managed by environment-controller. Do not edit manually.",
 			env.Spec.OrganizationRef, envName),
-		true, // private
+		false, // public on the K8s service cordon — see app-controller comment
 	); err != nil {
 		if errors.Is(err, gitea.ErrOrgNotFound) {
 			// Org disappeared between step 2 and step 3a — surface a

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -1,5 +1,15 @@
 apiVersion: v2
 name: bp-catalyst-platform
+# 1.4.114 (qa-loop iter-8 Fix #42 follow-up #3): env+app controllers
+# now create per-Org/per-App Gitea repos as PUBLIC (private=false).
+# In-cluster Gitea is on the K8s service cordon (host-only); the
+# private flag was redundant security theater that broke Flux's
+# anonymous clone path with "authentication required". Operators who
+# need hard isolation can flip back via a future config knob +
+# bootstrap a Secret in flux-system. Without this fix Flux GitRepository
+# (catalyst-app-{org}-{app}) created by app-controller's host-Flux
+# bootstrap couldn't pull the manifests it just wrote — Pods never spawn.
+#
 # 1.4.113 (qa-loop iter-8 Fix #42 image bump #2): env+app controllers
 # bumped to :a3ba200 — env-controller has EnsureBranch (PR #1257);
 # app-controller drops cross-namespace ownerRefs (was being silently
@@ -419,7 +429,7 @@ name: bp-catalyst-platform
 #     so the matrix's `kubectl get cnpgpair` stdout contains the literal
 #     "cnpgpair" substring TC-306 asserts on (envsubst override beat the
 #     chart values default fixed in PR #1247).
-version: 1.4.113
+version: 1.4.114
 appVersion: 1.4.94
 description: |
   Catalyst Platform — the unified Catalyst control plane umbrella chart for Catalyst-Zero.


### PR DESCRIPTION
## Summary
Live on omantel after PRs #1257+#1258 rolled: Flux GitRepository \`catalyst-app-omantel-platform-qa-wp\` returned \`failed to checkout: authentication required\`.

Root cause: app-controller's EnsureRepo created the per-Application repo with private=true, but the host-side Flux GitRepository has no Secret reference (FluxGiteaSecretRef defaults to empty for the in-cluster Gitea on the K8s service cordon).

Fix: env-controller + app-controller both pass private=false to EnsureRepo. Operators who need hard isolation can flip back via a future config knob + bootstrap a Gitea token Secret in flux-system.

Chart \`bp-catalyst-platform\` 1.4.113 → 1.4.114 + bootstrap-kit pin.

## Test plan
- [ ] env+app controller images rebuild
- [ ] On omantel, catalyst-app-* GitRepository becomes Ready=True
- [ ] HelmRelease qa-wp progresses (separate openova-catalog-missing issue is out of scope)

Refs: #1252, #1253, #1254, #1255, #1257, #1258, #1095.

🤖 Generated with [Claude Code](https://claude.com/claude-code)