### PR TITLE
fix(bp-qa-app): annotate no-upstream (unblocks qa-wp Application install)

### DIFF
--- a/platform/qa-app/chart/Chart.yaml
+++ b/platform/qa-app/chart/Chart.yaml
@@ -1,5 +1,10 @@
 apiVersion: v2
 name: bp-qa-app
+# Catalyst-authored umbrella with no upstream Helm chart dependency —
+# ships only the in-repo nginx Deployment+Service+ConfigMap. Opt out
+# of the hollow-chart guard per docs/BLUEPRINT-AUTHORING.md §11.1.
+annotations:
+  catalyst.openova.io/no-upstream: "true"
 version: 0.1.0
 appVersion: "1.27.3"
 description: |


### PR DESCRIPTION
Adds catalyst.openova.io/no-upstream: true annotation to satisfy hollow-chart guard per BLUEPRINT-AUTHORING §11.1. bp-qa-app ships only Catalyst-authored resources (nginx Deployment+Service+ConfigMap); no upstream Helm dep needed. Unblocks qa-wp HelmRelease on omantel.