### PR TITLE
fix(chart): bp-catalyst-platform 1.4.116 — chart re-publish + dispatch (qa-loop iter-10 Fix #44 follow-up)

### DIFF
--- a/.github/workflows/build-application-controller.yaml
+++ b/.github/workflows/build-application-controller.yaml
@@ -167,6 +167,7 @@ jobs:
           grep -A4 "^  application:" "${VALUES}" | head -10
 
       - name: Commit and push values.yaml bump
+        id: deploy_commit
         if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
         env:
           SHA_SHORT: ${{ steps.vars.outputs.sha_short }}
@@ -175,6 +176,7 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           if git diff --quiet products/catalyst/chart/values.yaml; then
             echo "no values.yaml change — already pinned to ${SHA_SHORT}"
+            echo "pushed=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           git add products/catalyst/chart/values.yaml
@@ -182,3 +184,28 @@ jobs:
           # Pull-rebase to avoid races with parallel build commits.
           git pull --rebase --autostash origin main || true
           git push origin HEAD:main
+          echo "pushed=true" >> "$GITHUB_OUTPUT"
+
+      # GitHub Actions does NOT trigger workflows from bot pushes by
+      # default (anti-recursion safeguard). The bot commit above changes
+      # products/catalyst/chart/values.yaml which would normally fire
+      # blueprint-release.yaml's path filter — but bot pushes are
+      # silently filtered. Without this dispatch the rebuilt image is
+      # NEVER baked into a new chart version, so Sovereigns keep
+      # installing the previous chart with the previous image tag, and
+      # `feedback_no_mvp_no_workarounds.md` rule 1 is violated (operator
+      # has to manually click "Run workflow" or push a Chart.yaml bump).
+      # Caught live 2026-05-10 (qa-loop iter-10 Fix #44) — chart 1.4.115
+      # was published from the merge commit (which still had the old
+      # image tag), so the chart shipped with the WRONG image despite
+      # the auto-bump landing seconds later.
+      - name: Dispatch blueprint-release for chart re-publish
+        if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main' && steps.deploy_commit.outputs.pushed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh workflow run blueprint-release.yaml \
+            --repo "${GITHUB_REPOSITORY}" \
+            --ref main \
+            -f blueprint=catalyst \
+            -f tree=products

--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -333,13 +333,17 @@ spec:
       # namespace is provisioned by helm-controller on install. Closes
       # matrix rows TC-068 / TC-100 / TC-204 / TC-262 / TC-263 (workload
       # Pod was landing in `omantel-platform` instead of `qa-omantel`).
+      # 1.4.116 (Fix #44 follow-up): chart re-publish to bake the
+      # rebuilt application-controller image (:24aab61) into values.yaml
+      # — chart 1.4.115 had stale tag (:a3ba200) because GH Actions
+      # silently filters bot pushes from triggering blueprint-release.
       # 1.4.109 (Fix #40 follow-up #2): drop /api/v1 from organization +
       # environment-controller GITEA URL defaults — Gitea client appends
       # it; the prior default produced /api/v1/api/v1/... 404s on
       # EnsureOrg / EnsureRepo blocking qa-wp Application reconcile.
       # bootstrap-kit qaFixtures.cnpgPairName default qa-cnpg → qa-cnpgpair
       # so TC-306's "cnpgpair" substring assertion passes.
-      version: 1.4.115
+      version: 1.4.116
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -1,5 +1,15 @@
 apiVersion: v2
 name: bp-catalyst-platform
+# 1.4.116 (qa-loop iter-10 Fix #44 follow-up — chart re-publish).
+# Chart 1.4.115 was published from the merge commit which still had
+# the OLD application-controller image tag (a3ba200) baked into
+# values.yaml — the auto-bump commit landed seconds later but
+# GitHub Actions does NOT trigger workflows from bot pushes by
+# default, so blueprint-release was never re-run. This bump
+# re-publishes the chart with the new tag (24aab61) AND extends
+# build-application-controller.yaml to dispatch blueprint-release
+# explicitly so the same race never happens again.
+#
 # 1.4.115 (qa-loop iter-10 Fix #44 — application-controller targetNamespace).
 # The application-controller previously rendered the per-Application
 # HelmRelease with `metadata.namespace = Org` and `spec.targetNamespace
@@ -461,7 +471,7 @@ name: bp-catalyst-platform
 #     so the matrix's `kubectl get cnpgpair` stdout contains the literal
 #     "cnpgpair" substring TC-306 asserts on (envsubst override beat the
 #     chart values default fixed in PR #1247).
-version: 1.4.115
+version: 1.4.116
 appVersion: 1.4.94
 description: |
   Catalyst Platform — the unified Catalyst control plane umbrella chart for Catalyst-Zero.


### PR DESCRIPTION
## Summary

Chart 1.4.115 (PR #1262) was published from the merge commit which still had the OLD application-controller image tag (a3ba200) baked into values.yaml — the auto-bump commit landed seconds later but GitHub Actions silently filters bot pushes from triggering workflows, so blueprint-release was never re-run.

## Fixes

- Bump bp-catalyst-platform 1.4.115 → 1.4.116 (this PR is human-authored so blueprint-release fires).
- Bump clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml pin to 1.4.116.
- Extend build-application-controller.yaml to dispatch blueprint-release explicitly after the bot bumps values.yaml — closes the race for any future controller image roll-out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)