### PR TITLE
deploy: pin bootstrap-kit bp-catalyst-platform to 1.4.119

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -363,7 +363,7 @@ spec:
       # EnsureOrg / EnsureRepo blocking qa-wp Application reconcile.
       # bootstrap-kit qaFixtures.cnpgPairName default qa-cnpg → qa-cnpgpair
       # so TC-306's "cnpgpair" substring assertion passes.
-      version: 1.4.118
+      version: 1.4.119
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform


### PR DESCRIPTION
## Summary

Pin the bootstrap-kit's bp-catalyst-platform HelmRelease to chart 1.4.119 so the chroot Sovereign at console.omantel.biz rolls to qa-loop iter-11 Fix #46:
- New `POST /api/v1/auth/test-session?tier=<tier>` endpoint (gated, default-off)
- New canonical Playwright runner with nav-interrupted recovery

Same pattern as the prior 1.4.111 → 1.4.118 pin bumps. Without this, the chroot stays on 1.4.118 indefinitely (HelmRelease's chart `version` is an exact pin, not a range).

🤖 Generated with [Claude Code](https://claude.com/claude-code)