### PR TITLE
deploy: pin bootstrap-kit bp-catalyst-platform to 1.4.120

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -363,7 +363,7 @@ spec:
       # EnsureOrg / EnsureRepo blocking qa-wp Application reconcile.
       # bootstrap-kit qaFixtures.cnpgPairName default qa-cnpg → qa-cnpgpair
       # so TC-306's "cnpgpair" substring assertion passes.
-      version: 1.4.119
+      version: 1.4.120
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform


### PR DESCRIPTION
## Summary

Roll the chroot Sovereign at console.omantel.biz to qa-loop iter-11 Fix #48 (#1267):
- 5 new `/sovereigns/{id}/networking/{slug}` REST endpoints
- Sovereign Console Networking page rewritten to surface live data
- default-deny CCNP + 11 per-namespace CNP allow templates ship as qa-fixtures
- dmz + netbird namespaces seeded as part of qa-fixtures

Same pattern as the prior 1.4.111..1.4.119 pin bumps.

## Test plan
- [ ] After merge + Flux reconcile, `kubectl --context=omantel get hr bp-catalyst-platform -n flux-system -o jsonpath='{.spec.chart.spec.version}'` returns 1.4.120
- [ ] `kubectl --context=omantel get ccnp default-deny` returns the policy (was NotFound)
- [ ] `kubectl --context=omantel get cnp -A | wc -l` >= 12
- [ ] `curl https://console.omantel.biz/api/v1/sovereigns/sovereign-omantel.biz/networking/policies` returns CNPs

🤖 Generated with [Claude Code](https://claude.com/claude-code)