### PR TITLE
fix(ui): OverviewPanelProps compState type — qa-loop iter-12 Fix #50 hotfix

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -363,7 +363,7 @@ spec:
       # EnsureOrg / EnsureRepo blocking qa-wp Application reconcile.
       # bootstrap-kit qaFixtures.cnpgPairName default qa-cnpg → qa-cnpgpair
       # so TC-306's "cnpgpair" substring assertion passes.
-      version: 1.4.122
+      version: 1.4.123
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail.tsx
@@ -594,9 +594,14 @@ interface OverviewPanelProps {
   isServiceApp: boolean
   compState:
     | {
-        helmRelease?: string
-        namespace?: string
-        chartVersion?: string
+        // Aligned with ApplicationState in eventReducer.ts — those three
+        // fields are `string | null` on the wire (initial-state / unset),
+        // not `string | undefined`. Accepting both keeps OverviewPanel's
+        // signature compatible with both `compState={someApplicationState}`
+        // and the synthetic test-fixture object shape.
+        helmRelease?: string | null
+        namespace?: string | null
+        chartVersion?: string | null
       }
     | undefined
   deps: { id: string; name: string }[]

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -1,5 +1,16 @@
 apiVersion: v2
 name: bp-catalyst-platform
+# 1.4.123 (qa-loop iter-12 Fix #50 hotfix): Aligns OverviewPanelProps
+# `compState` field types with ApplicationState in eventReducer.ts —
+# helmRelease/namespace/chartVersion are `string | null` on the wire
+# (initial-state / unset), not `string | undefined`. Without this the
+# UI image build fails with TS2322 on AppDetail.tsx:448 (regression
+# introduced by Fix #51 PR #1273 not caught pre-merge by the cosmetic-
+# guards CI which doesn't run vitest/tsc-typecheck on PRs). Pure type-
+# signature fix; no behaviour change. Re-bumps the chart so Flux
+# reconciles the new image SHA the CI sed-bumps in
+# templates/ui-deployment.yaml.
+#
 # 1.4.122 (qa-loop iter-12 Fix #50): Resources surface — wires the
 # Sovereign Console's /resources family (list / search / apply /
 # pod-logs) to live cluster data via TanStack Query against the
@@ -656,7 +667,7 @@ name: bp-catalyst-platform
 #     so the matrix's `kubectl get cnpgpair` stdout contains the literal
 #     "cnpgpair" substring TC-306 asserts on (envsubst override beat the
 #     chart values default fixed in PR #1247).
-version: 1.4.122
+version: 1.4.123
 appVersion: 1.4.94
 description: |
   Catalyst Platform — the unified Catalyst control plane umbrella chart for Catalyst-Zero.


### PR DESCRIPTION
## Summary

Fixes the catalyst-ui build that's been red on main since f1ed253d (Fix #50 merge). Root cause is Fix #51 (PR #1273) AppDetail rewrite — declared `OverviewPanelProps.compState.helmRelease/namespace/chartVersion` as `string | undefined` but the real `ApplicationState` (eventReducer.ts:113) has those as `string | null`. Strict TS rejects the assignment.

This hotfix widens the prop signature to `string | null | undefined` so both the live ApplicationState and the synthetic test fixture round-trip cleanly. Existing usages in OverviewPanel already handle null correctly via `?? app.id` / truthy checks.

Chart bp-catalyst-platform 1.4.122 → 1.4.123 + bootstrap-kit pin.

## Test plan

- [x] `git diff` shows only the type widening + chart/pin bump
- [ ] CI build-ui succeeds (no more TS2322)
- [ ] Flux reconciles 1.4.123 on omantel; catalyst-ui restarts
- [ ] Resources family pages (Fix #50) render live data on omantel

🤖 Generated with [Claude Code](https://claude.com/claude-code)