### PR TITLE
deploy: update catalyst images to 0a11107 (Fix #50 + hotfix)

### DIFF
--- a/products/catalyst/chart/templates/api-deployment.yaml
+++ b/products/catalyst/chart/templates/api-deployment.yaml
@@ -160,7 +160,7 @@ spec:
           # values.yaml `images.catalystApi.tag` is also bumped (but
           # unused for catalyst-api; kept for SME services that DO read
           # from values).
-          image: "ghcr.io/openova-io/openova/catalyst-api:f072ab3"
+          image: "ghcr.io/openova-io/openova/catalyst-api:0a11107"
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080
@@ -198,7 +198,7 @@ spec:
             # field so dashboards can correlate api-version <-> chart-
             # version on a single probe.
             - name: CATALYST_BUILD_SHA
-              value: "f072ab3"
+              value: "0a11107"
             - name: CATALYST_CHART_VERSION
               value: "1.4.95"
             - name: CORS_ORIGIN

--- a/products/catalyst/chart/templates/ui-deployment.yaml
+++ b/products/catalyst/chart/templates/ui-deployment.yaml
@@ -24,7 +24,7 @@ spec:
           # Auto-bumped by .github/workflows/catalyst-build.yaml's deploy
           # step on every push to main, so Sovereigns AND contabo both
           # roll to the latest catalyst-ui SHA.
-          image: "ghcr.io/openova-io/openova/catalyst-ui:f072ab3"
+          image: "ghcr.io/openova-io/openova/catalyst-ui:0a11107"
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080

--- a/products/catalyst/chart/values.yaml
+++ b/products/catalyst/chart/values.yaml
@@ -125,9 +125,9 @@ images:
   organization: "openova-io/openova"
   # SHA tags — bump these via CI when building new images.
   catalystApi:
-    tag: "f072ab3"
+    tag: "0a11107"
   catalystUi:
-    tag: "f072ab3"
+    tag: "0a11107"
   marketplaceApi:
     tag: "3c2f7e4"
   console:


### PR DESCRIPTION
Manual deploy bump — the CI deploy step in catalyst-build.yaml kept losing the git push race (3 attempts) against other concurrent commits on main. Image SHAs are built and live on GHCR, this just bumps the SHA references in chart values + deployment templates so Flux reconciles the new bytes on omantel.

Includes:
- Fix #50 (PR #1272) Resources family wired pages
- Fix #50 hotfix (PR #1277) OverviewPanelProps null types

🤖 Generated with [Claude Code](https://claude.com/claude-code)