### PR TITLE
fix(bootstrap-kit/_template): wire NetBird/DMZ/Hubble/BGP via envsubst — qa-loop iter-12 Fix #53C+D follow-up

### DIFF
--- a/clusters/_template/bootstrap-kit/01-cilium.yaml
+++ b/clusters/_template/bootstrap-kit/01-cilium.yaml
@@ -36,7 +36,11 @@ spec:
   chart:
     spec:
       chart: bp-cilium
-      version: 1.2.0
+      # 1.3.0 (qa-loop iter-12 Fix #53C+D): adds the Hubble UI HTTPRoute
+      # overlay (slice H7 #1095) that the catalystOverlay.hubbleUI block
+      # below depends on. Backward-compat: catalystOverlay.hubbleUI defaults
+      # to enabled=false; only Sovereigns that flip it on get the route.
+      version: 1.3.0
       sourceRef:
         kind: HelmRepository
         name: bp-cilium
@@ -76,10 +80,20 @@ spec:
           enabled: null
           serviceMonitor:
             enabled: false
+        # qa-loop iter-12 Fix #53C: envsubst-gated hubble-relay + hubble-ui
+        # so per-Sovereign overlay flips them on (HUBBLE_ENABLED=true) for
+        # network observability. Default false → backward-compat.
         relay:
-          enabled: false
+          enabled: ${HUBBLE_ENABLED:=false}
         ui:
-          enabled: false
+          enabled: ${HUBBLE_ENABLED:=false}
+
+      # qa-loop iter-12 Fix #53C: BGP control plane (default off, opt-in
+      # via BGP_ENABLED=true). Per ADR-0001 §9 the BGP control plane is the
+      # canonical path for Sovereign-to-customer-router prefix advertisement
+      # (LoadBalancer VIPs, Pod CIDRs to customer's existing core network).
+      bgpControlPlane:
+        enabled: ${BGP_ENABLED:=false}
 
       # ── Cilium ClusterMesh — multi-region peering ──────────────────
       #
@@ -114,8 +128,34 @@ spec:
         useAPIServer: true
         apiserver:
           service:
-            type: NodePort
+            # qa-loop iter-12 Fix #53D: ${CLUSTERMESH_SERVICE_TYPE:=NodePort}
+            # Default NodePort keeps backward-compat (existing Sovereigns
+            # don't break). Sovereigns that need cross-region peering set
+            # CLUSTERMESH_SERVICE_TYPE=LoadBalancer in their bootstrap-kit
+            # Kustomization substitute (requires Hetzner CCM bootstrap).
+            type: ${CLUSTERMESH_SERVICE_TYPE:=NodePort}
             nodePort: 32379
+
+    # ── Catalyst overlay templates (chart/templates/) ────────────────────
+    # qa-loop iter-12 Fix #53C: Hubble UI HTTPRoute (envsubst-gated).
+    # Enabled per-Sovereign by setting HUBBLE_ENABLED=true and
+    # HUBBLE_HOSTNAME=hubble.<sovereign-fqdn> on the bootstrap-kit
+    # Kustomization substitute. Default off → backward-compat.
+    catalystOverlay:
+      hubbleUI:
+        enabled: ${HUBBLE_ENABLED:=false}
+        hostname: ${HUBBLE_HOSTNAME:=}
+        gatewayRef:
+          name: cilium-gateway
+          namespace: cilium-gateway
+        # `none` until the Keycloak `hubble-ui` OIDC client is wired by
+        # bp-keycloak realm-config; flip to `oidc` per per-Sovereign
+        # overlay once that lands.
+        auth: ${HUBBLE_AUTH:=none}
+        serviceRef:
+          name: hubble-ui
+          namespace: kube-system
+          port: 80
 ---
 # ─── Per-Sovereign Gateway API resources (issue #387) ────────────────────
 #

--- a/clusters/_template/bootstrap-kit/53-bp-netbird.yaml
+++ b/clusters/_template/bootstrap-kit/53-bp-netbird.yaml
@@ -1,0 +1,84 @@
+# bp-netbird — Catalyst bootstrap-kit Blueprint slot 53. NetBird
+# WireGuard-based zero-trust mesh + remote-access overlay.
+#
+# Per ADR-0001 §3.2.8 + EPIC-5 leftovers slice NB #1100: NetBird is the
+# canonical operator/engineer remote-access path into Sovereign workloads.
+#
+# qa-loop iter-12 Fix #53C: matrix asserts the netbird namespace +
+# management/signal/coturn Deployments exist (TC-281, TC-282, TC-283,
+# TC-284). Without this slot the chart was authored but never installed.
+#
+# Wrapper chart: platform/netbird/chart/
+# Reconciled by: Flux on the new Sovereign's k3s control plane.
+#
+# Default-OFF gate: NETBIRD_ENABLED defaults to "false" via envsubst —
+# Sovereigns that want NetBird flip it to "true" in the bootstrap-kit
+# Kustomization substitute.
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: netbird
+  labels:
+    catalyst.openova.io/sovereign: ${SOVEREIGN_FQDN}
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: bp-netbird
+  namespace: flux-system
+spec:
+  type: oci
+  interval: 15m
+  url: oci://ghcr.io/openova-io
+  secretRef:
+    name: ghcr-pull
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: bp-netbird
+  namespace: flux-system
+spec:
+  interval: 15m
+  releaseName: netbird
+  targetNamespace: netbird
+  dependsOn:
+    - name: bp-cilium
+    - name: bp-cert-manager
+    - name: bp-keycloak
+    - name: bp-sealed-secrets
+    - name: bp-nats-jetstream
+  chart:
+    spec:
+      chart: bp-netbird
+      version: 0.1.1
+      sourceRef:
+        kind: HelmRepository
+        name: bp-netbird
+        namespace: flux-system
+  install:
+    disableWait: true
+    remediation:
+      retries: 3
+  upgrade:
+    disableWait: true
+    remediation:
+      retries: 3
+  values:
+    netbird:
+      enabled: ${NETBIRD_ENABLED:=false}
+      management:
+        domain: netbird.${SOVEREIGN_FQDN}
+      coturn:
+        realm: netbird.${SOVEREIGN_FQDN}
+      oidc:
+        issuer: https://keycloak.${SOVEREIGN_FQDN}/realms/${SOVEREIGN_REALM_NAME:=sovereign}
+        redirectURI: https://netbird.${SOVEREIGN_FQDN}/
+        audience: netbird
+      httproute:
+        hostname: netbird.${SOVEREIGN_FQDN}
+      realmConfig:
+        enabled: true
+        realm: ${SOVEREIGN_REALM_NAME:=sovereign}

--- a/clusters/_template/bootstrap-kit/54-bp-dmz-vcluster.yaml
+++ b/clusters/_template/bootstrap-kit/54-bp-dmz-vcluster.yaml
@@ -1,0 +1,71 @@
+# bp-dmz-vcluster — Catalyst bootstrap-kit Blueprint slot 54. DMZ
+# isolated virtual Kubernetes cluster running inside the management
+# cluster.
+#
+# Per ADR-0001 §3.2.8 + EPIC-5 leftovers slice DMZ #1100: every
+# Sovereign that publishes customer-facing APIs / webhooks gets a
+# DMZ vCluster.
+#
+# qa-loop iter-12 Fix #53C: matrix asserts dmz namespace + vcluster
+# CRD registered + omantel-dmz kubeconfig context (TC-286, TC-287,
+# TC-288). Without this slot the chart was authored but never installed.
+#
+# Wrapper chart: products/dmz-vcluster/chart/
+# Reconciled by: Flux on the new Sovereign's k3s control plane.
+#
+# Default-OFF gate: DMZ_VCLUSTER_ENABLED defaults to "false" via envsubst.
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: dmz
+  labels:
+    catalyst.openova.io/sovereign: ${SOVEREIGN_FQDN}
+    catalyst.openova.io/isolation: dmz
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: bp-dmz-vcluster
+  namespace: flux-system
+spec:
+  type: oci
+  interval: 15m
+  url: oci://ghcr.io/openova-io
+  secretRef:
+    name: ghcr-pull
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: bp-dmz-vcluster
+  namespace: flux-system
+spec:
+  interval: 15m
+  releaseName: dmz-vcluster
+  targetNamespace: dmz
+  dependsOn:
+    - name: bp-cilium
+    - name: bp-cert-manager
+  chart:
+    spec:
+      chart: bp-dmz-vcluster
+      version: 0.1.1
+      sourceRef:
+        kind: HelmRepository
+        name: bp-dmz-vcluster
+        namespace: flux-system
+  install:
+    disableWait: true
+    remediation:
+      retries: 3
+  upgrade:
+    disableWait: true
+    remediation:
+      retries: 3
+  values:
+    dmz:
+      enabled: ${DMZ_VCLUSTER_ENABLED:=false}
+      hostNamespace: dmz
+      vclusterName: ${DMZ_VCLUSTER_NAME:=dmz}

--- a/clusters/_template/bootstrap-kit/kustomization.yaml
+++ b/clusters/_template/bootstrap-kit/kustomization.yaml
@@ -59,6 +59,12 @@ resources:
   # installs proxy → gateway.
   - 51-bp-k8s-ws-proxy.yaml
   - 52-bp-guacamole.yaml
+  # qa-loop iter-12 Fix #53C — EPIC-5 leftovers (NetBird zero-trust mesh
+  # + DMZ vCluster isolation). Slots 53/54. Both default-OFF; flip on
+  # via NETBIRD_ENABLED=true / DMZ_VCLUSTER_ENABLED=true on the
+  # bootstrap-kit Kustomization substitute.
+  - 53-bp-netbird.yaml
+  - 54-bp-dmz-vcluster.yaml
   # bp-newapi (slot 80) — multi-tenant LLM marketplace gateway. Sequenced
   # after the W2.K1 dependency wave (cnpg/keycloak/openbao Ready) so
   # NewAPI's ExternalSecret + DSN dependencies resolve on first reconcile.

--- a/scripts/expected-bootstrap-deps.yaml
+++ b/scripts/expected-bootstrap-deps.yaml
@@ -348,6 +348,32 @@ slots:
       - bp-k8s-ws-proxy
     wave: present
 
+  # ---- Slot 53 — bp-netbird WireGuard zero-trust mesh + remote-access overlay.
+  # qa-loop iter-12 Fix #53C (EPIC-5 leftovers slice NB #1100). Sovereign-side
+  # NetBird management + signal + coturn services. Default-OFF gate via
+  # NETBIRD_ENABLED=true on the bootstrap-kit Kustomization substitute.
+  - slot: 53
+    name: bp-netbird
+    depends_on:
+      - bp-cilium
+      - bp-cert-manager
+      - bp-keycloak
+      - bp-sealed-secrets
+      - bp-nats-jetstream
+    wave: present
+
+  # ---- Slot 54 — bp-dmz-vcluster isolated customer-internet-facing vCluster.
+  # qa-loop iter-12 Fix #53C (EPIC-5 leftovers slice DMZ #1100). Customer
+  # workloads needing direct internet exposure land here; host-side
+  # NetworkPolicy + Cilium identity isolation keeps them off the Catalyst
+  # control plane. Default-OFF gate via DMZ_VCLUSTER_ENABLED=true.
+  - slot: 54
+    name: bp-dmz-vcluster
+    depends_on:
+      - bp-cilium
+      - bp-cert-manager
+    wave: present
+
   # ---- Slot 80 — bp-newapi multi-tenant LLM marketplace gateway. Issue #799.
   # Sequenced past the W2.K4 numbering plan (slots 36-48) so it never
   # collides with the AI-runtime / observability / livekit cohort. The


### PR DESCRIPTION
## Summary
PR #1275 wired NetBird/DMZ/Hubble/BGP/clustermesh-LB into the omantel.omani.works overlay only. The omantel chroot reconciles from \`clusters/_template/bootstrap-kit/\` not the per-Sovereign overlay. This PR mirrors the same changes into _template via envsubst defaults so chroot Sovereigns also get them.

- 01-cilium.yaml: chart 1.2.0 → 1.3.0 + envsubst-gated hubble UI / BGP / clustermesh-LB
- 53-bp-netbird.yaml NEW: NetBird slot, default-OFF via NETBIRD_ENABLED
- 54-bp-dmz-vcluster.yaml NEW: DMZ vCluster slot, default-OFF via DMZ_VCLUSTER_ENABLED
- kustomization.yaml: added slots 53/54

Live substitutes already patched on omantel for immediate effect once chart 1.3.0 is fetched.

## Test plan
- [ ] Flux reconciles bootstrap-kit on omantel; bp-cilium upgrades to 1.3.0
- [ ] hubble.console.omantel.biz HTTPRoute renders; \`dig hubble.console.omantel.biz\` resolves
- [ ] netbird namespace + management/signal/coturn Pods Running
- [ ] dmz namespace + omantel-dmz vcluster Pod Running
- [ ] iter-13 Executor flips TC-281, TC-282, TC-283, TC-284, TC-286, TC-287, TC-288, TC-289, TC-290, TC-349 to PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)