### PR TITLE
revert(bootstrap-kit): bp-keycloak 1.5.0 → 1.4.1 — Fix #53A blocks fresh provision

### DIFF
--- a/clusters/_template/bootstrap-kit/09-keycloak.yaml
+++ b/clusters/_template/bootstrap-kit/09-keycloak.yaml
@@ -45,7 +45,7 @@ spec:
       # parameter so each Sovereign owns its KC realm named after the tenant
       # short-name (omantel chroot → "omantel"). Default `sovereign` is kept
       # in the chart for backward compat with overlays not yet migrated.
-      version: 1.5.0
+      version: 1.4.1
       sourceRef:
         kind: HelmRepository
         name: bp-keycloak


### PR DESCRIPTION
Fresh omantel re-provision hung phase1-watching 30+min: bp-keycloak 1.5.0 keycloak-config-cli BackoffLimitExceeded. Cascade-blocks bp-gitea/guacamole/netbird/grafana/newapi/catalyst-platform. Reverting pin to 1.4.1 (last-good). Fix #53A chart-side bug to be re-investigated separately.