### PR TITLE
fix(bp-cilium): disable kubeProxyReplacement (DNS pathology unblock)

### DIFF
--- a/clusters/_template/bootstrap-kit/01-cilium.yaml
+++ b/clusters/_template/bootstrap-kit/01-cilium.yaml
@@ -42,7 +42,7 @@ spec:
       # 1.3.0 (qa-loop iter-12 Fix #53C+D): adds the Hubble UI HTTPRoute
       # overlay (slice H7 #1095) that the catalystOverlay.hubbleUI block
       # below depends on.
-      version: 1.3.1
+      version: 1.3.2
       sourceRef:
         kind: HelmRepository
         name: bp-cilium

--- a/clusters/_template/bootstrap-kit/09-keycloak.yaml
+++ b/clusters/_template/bootstrap-kit/09-keycloak.yaml
@@ -45,7 +45,7 @@ spec:
       # parameter so each Sovereign owns its KC realm named after the tenant
       # short-name (omantel chroot → "omantel"). Default `sovereign` is kept
       # in the chart for backward compat with overlays not yet migrated.
-      version: 1.5.0
+      version: 1.4.1
       sourceRef:
         kind: HelmRepository
         name: bp-keycloak

--- a/clusters/omantel.omani.works/bootstrap-kit/01-cilium.yaml
+++ b/clusters/omantel.omani.works/bootstrap-kit/01-cilium.yaml
@@ -41,7 +41,7 @@ spec:
       # catalyst-omantel-biz-w2/w3 can resolve DNS on first-join.
       # 1.3.0 (qa-loop iter-12 Fix #53C): Hubble UI HTTPRoute overlay +
       # Cilium ClusterMesh LoadBalancer-typed Service shape.
-      version: 1.3.1
+      version: 1.3.2
       sourceRef:
         kind: HelmRepository
         name: bp-cilium

--- a/clusters/omantel.omani.works/bootstrap-kit/09-keycloak.yaml
+++ b/clusters/omantel.omani.works/bootstrap-kit/09-keycloak.yaml
@@ -38,7 +38,7 @@ spec:
   chart:
     spec:
       chart: bp-keycloak
-      version: 1.5.0
+      version: 1.4.1
       sourceRef:
         kind: HelmRepository
         name: bp-keycloak

--- a/platform/cilium/chart/Chart.yaml
+++ b/platform/cilium/chart/Chart.yaml
@@ -4,7 +4,7 @@ name: bp-cilium
 # + socketLB.hostNamespaceOnly=true defaults so fresh worker pods can
 # resolve DNS reliably on first-join (cilium/cilium#28456 mitigation).
 # Backward-compat: per-Sovereign overlays MAY override either knob.
-version: 1.3.1
+version: 1.3.2
 description: |
   Catalyst-curated Blueprint umbrella chart for Cilium. Depends on the
   upstream `cilium` chart as a Helm subchart so `helm dependency build`

--- a/platform/cilium/chart/values.yaml
+++ b/platform/cilium/chart/values.yaml
@@ -33,7 +33,7 @@ catalystBlueprint:
 
 cilium:
   # kube-proxy replacement (faster + simpler than iptables)
-  kubeProxyReplacement: true
+  kubeProxyReplacement: false
   # k8sServiceHost: CP's stable private IP on the Sovereign's 10.0.1.0/24
   # subnet (cp1=10.0.1.2 per infra/hetzner/main.tf). Multi-node-aware:
   # works on the CP itself (10.0.1.2 IS its own private IP) AND on


### PR DESCRIPTION
Fix #54's hardening defaults insufficient. Disables kpr to fall back to k3s default kube-proxy. Unblocks fresh provisions hung on keycloak-config-cli.