### PR TITLE
fix(bp-keycloak): truncate catalyst-api-server desc <255 chars (1.4.2 backport)

### DIFF
--- a/clusters/_template/bootstrap-kit/09-keycloak.yaml
+++ b/clusters/_template/bootstrap-kit/09-keycloak.yaml
@@ -45,7 +45,7 @@ spec:
       # parameter so each Sovereign owns its KC realm named after the tenant
       # short-name (omantel chroot → "omantel"). Default `sovereign` is kept
       # in the chart for backward compat with overlays not yet migrated.
-      version: 1.4.1
+      version: 1.4.2
       sourceRef:
         kind: HelmRepository
         name: bp-keycloak

--- a/platform/keycloak/chart/Chart.yaml
+++ b/platform/keycloak/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-keycloak
-version: 1.5.1
+version: 1.4.2
 description: |
   Catalyst-curated Blueprint umbrella chart for Keycloak. Depends on the
   upstream `keycloak` chart (bitnami) as a Helm subchart so

--- a/platform/keycloak/chart/Chart.yaml
+++ b/platform/keycloak/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-keycloak
-version: 1.5.0
+version: 1.5.1
 description: |
   Catalyst-curated Blueprint umbrella chart for Keycloak. Depends on the
   upstream `keycloak` chart (bitnami) as a Helm subchart so

--- a/platform/keycloak/chart/templates/configmap-sovereign-realm.yaml
+++ b/platform/keycloak/chart/templates/configmap-sovereign-realm.yaml
@@ -329,7 +329,7 @@ data:
         {
           "clientId": "catalyst-api-server",
           "name": "Catalyst API Server (service account)",
-          "description": "Confidential service-account client for catalyst-api. Holds impersonate + manage-users roles on realm-management for token-exchange (issue #604) AND manage-realm + view-realm + view-clients so the EPIC-3 T2 tier-role bootstrap (KEYCLOAK_BOOTSTRAP_TIER_ROLES=true, products/catalyst/bootstrap/api/internal/keycloak/realm_bootstrap.go) can materialize the catalyst-{viewer,developer,operator,admin,owner} realm-roles + composite chain (qa-loop iter-4 Fix #23).",
+          "description": "Service-account client for catalyst-api: token-exchange (impersonate, manage-users) + tier-role bootstrap (manage-realm, view-realm, view-clients).",
           "enabled": true,
           "publicClient": false,
           "standardFlowEnabled": false,


### PR DESCRIPTION
## Root cause
Keycloak DB column `CLIENT.DESCRIPTION = varchar(255)`. The catalyst-api-server description in the sovereign-realm template was 458 chars, causing PSQLException 'value too long' on `realm-config-cli` post-install Job.

## Caught on
omantel provision #6 — keycloak-config-cli CrashLoop wedged bp-keycloak HR False; upstream HRs blocked from converging.

## Fix
- Truncate description to 159 chars (well under 255)
- Bump chart 1.4.1 → 1.4.2 (backport on 1.4.x stream; 1.5.0 had separate breaking realm-rename reverted via #1282)
- Update bootstrap-kit pin to 1.4.2