### PR TITLE
fix: mark bp-dmz-vcluster + bp-netbird default-off for smoke-render gate

### DIFF
--- a/clusters/_template/bootstrap-kit/09-keycloak.yaml
+++ b/clusters/_template/bootstrap-kit/09-keycloak.yaml
@@ -45,7 +45,7 @@ spec:
       # parameter so each Sovereign owns its KC realm named after the tenant
       # short-name (omantel chroot → "omantel"). Default `sovereign` is kept
       # in the chart for backward compat with overlays not yet migrated.
-      version: 1.4.1
+      version: 1.4.2
       sourceRef:
         kind: HelmRepository
         name: bp-keycloak

--- a/platform/keycloak/chart/Chart.yaml
+++ b/platform/keycloak/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-keycloak
-version: 1.5.1
+version: 1.4.2
 description: |
   Catalyst-curated Blueprint umbrella chart for Keycloak. Depends on the
   upstream `keycloak` chart (bitnami) as a Helm subchart so

--- a/platform/keycloak/chart/Chart.yaml
+++ b/platform/keycloak/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-keycloak
-version: 1.5.0
+version: 1.5.1
 description: |
   Catalyst-curated Blueprint umbrella chart for Keycloak. Depends on the
   upstream `keycloak` chart (bitnami) as a Helm subchart so

--- a/platform/keycloak/chart/templates/configmap-sovereign-realm.yaml
+++ b/platform/keycloak/chart/templates/configmap-sovereign-realm.yaml
@@ -329,7 +329,7 @@ data:
         {
           "clientId": "catalyst-api-server",
           "name": "Catalyst API Server (service account)",
-          "description": "Confidential service-account client for catalyst-api. Holds impersonate + manage-users roles on realm-management for token-exchange (issue #604) AND manage-realm + view-realm + view-clients so the EPIC-3 T2 tier-role bootstrap (KEYCLOAK_BOOTSTRAP_TIER_ROLES=true, products/catalyst/bootstrap/api/internal/keycloak/realm_bootstrap.go) can materialize the catalyst-{viewer,developer,operator,admin,owner} realm-roles + composite chain (qa-loop iter-4 Fix #23).",
+          "description": "Service-account client for catalyst-api: token-exchange (impersonate, manage-users) + tier-role bootstrap (manage-realm, view-realm, view-clients).",
           "enabled": true,
           "publicClient": false,
           "standardFlowEnabled": false,

--- a/platform/netbird/chart/Chart.yaml
+++ b/platform/netbird/chart/Chart.yaml
@@ -37,6 +37,8 @@ description: |
       adds NetBird OIDC client + `netbird-user` realm role +
       `netbird-users` group)
 type: application
+annotations:
+  catalyst.openova.io/smoke-render-mode: "default-off"
 keywords: [catalyst, blueprint, netbird, wireguard, mesh, vpn, oidc, remote-access]
 maintainers:
   - name: OpenOva Catalyst

--- a/products/dmz-vcluster/chart/Chart.yaml
+++ b/products/dmz-vcluster/chart/Chart.yaml
@@ -32,6 +32,8 @@ description: |
   the egress gateway are ready.
 
 type: application
+annotations:
+  catalyst.openova.io/smoke-render-mode: "default-off"
 keywords: [catalyst, blueprint, dmz, vcluster, isolation, multi-tenant]
 maintainers:
   - name: OpenOva Catalyst


### PR DESCRIPTION
Both blueprints are scratch charts (no upstream subchart) gated default-off; helm-template smoke renders <2 lines, hitting the platform-wide 'Empty render' gate added in #181. Adding documented annotation `catalyst.openova.io/smoke-render-mode: "default-off"` for both — same mechanism bp-qa-app uses.

Caught on omantel provision #6 — both HelmReleases permanently failing chart pull because Blueprint Release CI never published their charts.