### PR TITLE
fix(bp-catalyst-platform): switch gitea-token-mint Job image to alpine/k8s (curl + kubectl)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -370,7 +370,7 @@ spec:
       # templates/catalyst-gitea-token-secret.yaml + post-install Job
       # auto-mints the Gitea PAT into catalyst-gitea-token (replaces
       # kubectl-applied operational hack).
-      version: 1.4.127
+      version: 1.4.128
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -738,7 +738,7 @@ name: bp-catalyst-platform
 # documented in qa-loop-state/iter12-diagnostic-audit.md §"(e)
 # infra-blocked" TC-081 (per `feedback_no_mvp_no_workarounds.md`
 # rule #3 "no operational hacks instead of chart fixes").
-version: 1.4.127
+version: 1.4.128
 appVersion: 1.4.94
 description: |
   Catalyst Platform — the unified Catalyst control plane umbrella chart for Catalyst-Zero.

--- a/products/catalyst/chart/templates/catalyst-gitea-token-secret.yaml
+++ b/products/catalyst/chart/templates/catalyst-gitea-token-secret.yaml
@@ -229,7 +229,7 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: mint
-          image: docker.io/bitnamilegacy/kubectl:1.29.3
+          image: docker.io/alpine/k8s:1.31.4
           command: ["sh","-c"]
           args:
             - |


### PR DESCRIPTION
## Root cause
`bitnamilegacy/kubectl:1.29.3` lacks curl. The post-install Job `catalyst-gitea-token-mint` CrashLoops with `sh: 4: curl: not found`. Without minted token, `catalyst-gitea-token` Secret stays empty, breaking catalyst-catalog + catalyst-organization-controller + catalyst-useraccess-controller (`CATALYST_GITEA_TOKEN is required` → CrashLoopBackOff).

## Fix
Switch to `alpine/k8s:1.31.4` which bundles both kubectl 1.31.4 (matches k3s) and curl. Bumps chart 1.4.127 → 1.4.128 + bootstrap-kit pin.

## Caught on
omantel provision #6 — bp-catalyst-platform install never completed because mint Job kept failing.