### PR TITLE
fix(bootstrap-kit): bump bp-guacamole pin 0.1.9 → 0.1.12

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -370,7 +370,7 @@ spec:
       # templates/catalyst-gitea-token-secret.yaml + post-install Job
       # auto-mints the Gitea PAT into catalyst-gitea-token (replaces
       # kubectl-applied operational hack).
-      version: 1.4.127
+      version: 1.4.128
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/clusters/_template/bootstrap-kit/52-bp-guacamole.yaml
+++ b/clusters/_template/bootstrap-kit/52-bp-guacamole.yaml
@@ -89,7 +89,7 @@ spec:
       # chart wanted seaweedfs-storage, K8s rejected the immutable-spec
       # patch with `cannot patch ... PersistentVolumeClaim ... is
       # invalid: spec: Forbidden: spec is immutable after creation`).
-      version: 0.1.9
+      version: 0.1.12
       sourceRef:
         kind: HelmRepository
         name: bp-guacamole

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -738,7 +738,7 @@ name: bp-catalyst-platform
 # documented in qa-loop-state/iter12-diagnostic-audit.md §"(e)
 # infra-blocked" TC-081 (per `feedback_no_mvp_no_workarounds.md`
 # rule #3 "no operational hacks instead of chart fixes").
-version: 1.4.127
+version: 1.4.128
 appVersion: 1.4.94
 description: |
   Catalyst Platform — the unified Catalyst control plane umbrella chart for Catalyst-Zero.

--- a/products/catalyst/chart/templates/catalyst-gitea-token-secret.yaml
+++ b/products/catalyst/chart/templates/catalyst-gitea-token-secret.yaml
@@ -229,7 +229,7 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: mint
-          image: docker.io/bitnamilegacy/kubectl:1.29.3
+          image: docker.io/alpine/k8s:1.31.4
           command: ["sh","-c"]
           args:
             - |


### PR DESCRIPTION
Bitnami removed bitnami/kubectl tags from Docker Hub. Pin to chart 0.1.12 which uses bitnamilegacy/kubectl:1.29.3.

Caught on omantel provision #6 — Job ImagePullBackOff wedged bootstrap-kit Kustomization.