### PR TITLE
fix(catalyst-api): Cloud Resources EPIC handler bugs (qa-loop iter-15 Fix #59)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/iter12_phase2_codemods_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/iter12_phase2_codemods_test.go
@@ -339,6 +339,154 @@ func TestFlattenK8sListItems_NodeHoistsRegion(t *testing.T) {
 	}
 }
 
+// TestFlattenK8sListItems_EventV1HoistsLastTimestampAndReason — Events
+// at events.k8s.io/v1 carry `eventTime` / `note` (instead of legacy
+// core/v1 `lastTimestamp` / `message`); the flatten helper must read
+// the v1 schema AND fall back to the legacy fields so TC-211's
+// `must_contain: [items, lastTimestamp, reason]` passes regardless of
+// which schema the apiserver emits. qa-loop iter-15 Fix #59.
+func TestFlattenK8sListItems_EventV1HoistsLastTimestampAndReason(t *testing.T) {
+	v1Event := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion":             "events.k8s.io/v1",
+			"kind":                   "Event",
+			"metadata":               map[string]interface{}{"name": "qa-wp.evt", "namespace": "qa-omantel"},
+			"eventTime":              "2026-05-10T10:30:00.000000Z",
+			"note":                   "Successfully assigned qa-omantel/qa-wp-0 to hz-fsn-rtz-prod-1",
+			"reason":                 "Scheduled",
+			"reportingController":    "default-scheduler",
+			"regarding": map[string]interface{}{
+				"kind":      "Pod",
+				"name":      "qa-wp-0",
+				"namespace": "qa-omantel",
+			},
+		},
+	}
+	out := flattenK8sListItems("event", []*unstructured.Unstructured{v1Event})
+	got := out[0].Object
+	if got["lastTimestamp"] != "2026-05-10T10:30:00.000000Z" {
+		t.Errorf("expected lastTimestamp from eventTime, got %v", got["lastTimestamp"])
+	}
+	if got["reason"] != "Scheduled" {
+		t.Errorf("expected reason=Scheduled, got %v", got["reason"])
+	}
+	if got["message"] != "Successfully assigned qa-omantel/qa-wp-0 to hz-fsn-rtz-prod-1" {
+		t.Errorf("expected message hoisted from note, got %v", got["message"])
+	}
+	if io, ok := got["involvedObject"].(map[string]interface{}); !ok || io["kind"] != "Pod" {
+		t.Errorf("expected involvedObject hoisted from regarding, got %v", got["involvedObject"])
+	}
+}
+
+// TestFlattenK8sListItems_EventV1SeriesPrefersLastObservedTime — Events
+// that have repeated emit `series.lastObservedTime` (events.k8s.io/v1).
+// That field wins over the single-occurrence `eventTime`.
+func TestFlattenK8sListItems_EventV1SeriesPrefersLastObservedTime(t *testing.T) {
+	v1Event := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "events.k8s.io/v1",
+			"kind":       "Event",
+			"metadata":   map[string]interface{}{"name": "qa-wp.evt", "namespace": "qa-omantel"},
+			"eventTime":  "2026-05-10T10:00:00.000000Z",
+			"reason":     "BackOff",
+			"note":       "Back-off pulling image",
+			"series": map[string]interface{}{
+				"count":            int64(7),
+				"lastObservedTime": "2026-05-10T10:30:00.000000Z",
+			},
+		},
+	}
+	out := flattenK8sListItems("event", []*unstructured.Unstructured{v1Event})
+	got := out[0].Object
+	if got["lastTimestamp"] != "2026-05-10T10:30:00.000000Z" {
+		t.Errorf("expected series.lastObservedTime to win over eventTime; got %v", got["lastTimestamp"])
+	}
+}
+
+// TestFlattenK8sListItems_EventLegacyCoreV1Compat — older core/v1
+// Events still flow through the apiserver translation layer; the
+// flatten helper MUST keep surfacing them.
+func TestFlattenK8sListItems_EventLegacyCoreV1Compat(t *testing.T) {
+	legacyEvent := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion":     "v1",
+			"kind":           "Event",
+			"metadata":       map[string]interface{}{"name": "old.evt", "namespace": "qa-omantel"},
+			"lastTimestamp":  "2026-05-09T08:00:00Z",
+			"firstTimestamp": "2026-05-09T07:55:00Z",
+			"reason":         "FailedScheduling",
+			"message":        "0/3 nodes are available",
+			"involvedObject": map[string]interface{}{
+				"kind":      "Pod",
+				"name":      "qa-wp-0",
+				"namespace": "qa-omantel",
+			},
+		},
+	}
+	out := flattenK8sListItems("event", []*unstructured.Unstructured{legacyEvent})
+	got := out[0].Object
+	if got["lastTimestamp"] != "2026-05-09T08:00:00Z" {
+		t.Errorf("legacy lastTimestamp should still hoist; got %v", got["lastTimestamp"])
+	}
+	if got["reason"] != "FailedScheduling" {
+		t.Errorf("expected reason=FailedScheduling, got %v", got["reason"])
+	}
+	if got["message"] != "0/3 nodes are available" {
+		t.Errorf("legacy message should hoist; got %v", got["message"])
+	}
+	if io, ok := got["involvedObject"].(map[string]interface{}); !ok || io["name"] != "qa-wp-0" {
+		t.Errorf("legacy involvedObject should hoist; got %v", got["involvedObject"])
+	}
+}
+
+// TestFlattenK8sListItems_NodeFallbackLabels — when canonical
+// topology.kubernetes.io labels are absent, the flatten helper falls
+// back to failure-domain.beta + Hetzner location labels so legacy
+// kubelets and multi-location Sovereigns still light up the matrix
+// asserts (TC-260 / TC-261).
+func TestFlattenK8sListItems_NodeFallbackLabels(t *testing.T) {
+	node := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "Node",
+			"metadata": map[string]interface{}{
+				"name": "hz-fsn-1",
+				"labels": map[string]interface{}{
+					"failure-domain.beta.kubernetes.io/region": "fsn1",
+					"failure-domain.beta.kubernetes.io/zone":   "fsn1-dc14",
+					"node.kubernetes.io/instance-type":         "cx21",
+				},
+			},
+			"status": map[string]interface{}{
+				"conditions": []interface{}{
+					map[string]interface{}{"type": "Ready", "status": "True"},
+				},
+				"addresses": []interface{}{
+					map[string]interface{}{"type": "InternalIP", "address": "10.0.0.5"},
+					map[string]interface{}{"type": "Hostname", "address": "hz-fsn-1"},
+				},
+			},
+		},
+	}
+	out := flattenK8sListItems("node", []*unstructured.Unstructured{node})
+	got := out[0].Object
+	if got["region"] != "fsn1" {
+		t.Errorf("expected region=fsn1 from failure-domain.beta, got %v", got["region"])
+	}
+	if got["zone"] != "fsn1-dc14" {
+		t.Errorf("expected zone=fsn1-dc14 from failure-domain.beta, got %v", got["zone"])
+	}
+	if got["instanceType"] != "cx21" {
+		t.Errorf("expected instanceType=cx21, got %v", got["instanceType"])
+	}
+	if got["ready"] != true {
+		t.Errorf("expected ready=true, got %v", got["ready"])
+	}
+	if got["internalIP"] != "10.0.0.5" {
+		t.Errorf("expected internalIP=10.0.0.5, got %v", got["internalIP"])
+	}
+}
+
 // TestFlattenK8sListItems_DoesNotMutateInput — the cached Indexer
 // returns the same pointer to every reader; the flatten helper MUST
 // produce a fresh map so concurrent readers don't race on top-level

--- a/products/catalyst/bootstrap/api/internal/handler/k8s.go
+++ b/products/catalyst/bootstrap/api/internal/handler/k8s.go
@@ -284,12 +284,47 @@ func flattenK8sListItems(kind string, items []*unstructured.Unstructured) []*uns
 			}
 			base["ready"] = podReady(it.Object)
 		case "node":
-			// Node objects carry the region directly on their labels.
-			if region := it.GetLabels()["topology.kubernetes.io/region"]; region != "" {
+			// Node objects carry region/zone via topology labels. The
+			// canonical K8s topology labels (post-1.17) win; older
+			// failure-domain labels are accepted as fallback so legacy
+			// kubelets registered with the v1.16- ecosystem still light
+			// up the matrix asserts (TC-260/261).
+			//
+			// Hetzner CCM also publishes location-flavoured labels for
+			// the boundary cases where a Sovereign cluster joins
+			// nodes from multiple Hetzner locations under one
+			// topology zone — `instance.hetzner.cloud/location`
+			// disambiguates fsn1 vs hel1 vs nbg1 even when both
+			// register `topology.kubernetes.io/region=eu-central`.
+			labels := it.GetLabels()
+			if region := firstNonEmptyLabel(labels,
+				"topology.kubernetes.io/region",
+				"failure-domain.beta.kubernetes.io/region",
+				"instance.hetzner.cloud/location",
+				"csi.hetzner.cloud/location",
+			); region != "" {
 				base["region"] = region
 			}
-			if zone := it.GetLabels()["topology.kubernetes.io/zone"]; zone != "" {
+			if zone := firstNonEmptyLabel(labels,
+				"topology.kubernetes.io/zone",
+				"failure-domain.beta.kubernetes.io/zone",
+			); zone != "" {
 				base["zone"] = zone
+			}
+			// Hoist the worker's instance type — drives the per-node
+			// SKU column on the Resources / Nodes table (TC-269 family).
+			if instType := firstNonEmptyLabel(labels,
+				"node.kubernetes.io/instance-type",
+				"beta.kubernetes.io/instance-type",
+			); instType != "" {
+				base["instanceType"] = instType
+			}
+			// Hoist Ready/SchedulingDisabled status — the Nodes table
+			// renders these as the first two columns. Without the
+			// hoist consumers need to walk status.conditions client-side.
+			base["ready"] = nodeReady(it.Object)
+			if t := nodeFirstAddress(it.Object, "InternalIP"); t != "" {
+				base["internalIP"] = t
 			}
 		case "service":
 			if ports, ok, _ := unstructured.NestedSlice(it.Object, "spec", "ports"); ok {
@@ -303,19 +338,165 @@ func flattenK8sListItems(kind string, items []*unstructured.Unstructured) []*uns
 				base["rules"] = rules
 			}
 		case "event":
-			if ts, ok, _ := unstructured.NestedString(it.Object, "lastTimestamp"); ok && ts != "" {
-				base["lastTimestamp"] = ts
-			}
-			if reason, ok, _ := unstructured.NestedString(it.Object, "reason"); ok && reason != "" {
+			// Events live at events.k8s.io/v1 (canonical from K8s 1.19+).
+			// The v1 schema renamed/moved fields vs the legacy core/v1
+			// Event shape that earlier Catalyst code expected:
+			//
+			//   core/v1 Event              events.k8s.io/v1 Event
+			//   ────────────────────────── ─────────────────────────────────
+			//   .lastTimestamp             .series.lastObservedTime (when
+			//                              the event repeats; otherwise
+			//                              .eventTime carries the single
+			//                              occurrence)
+			//   .firstTimestamp            .eventTime
+			//   .message                   .note
+			//   .reason                    .reason (unchanged)
+			//   .count                     .series.count (or absent)
+			//   .source.component          .reportingController
+			//
+			// To stay backward-compatible (some Sovereigns still emit
+			// core/v1 Events through the legacy gateway, and apiserver
+			// translation can populate `deprecated*` fields on either
+			// shape) we fall back across all three schemas, in priority
+			// order: v1 → deprecated* mirror → legacy core/v1. Whichever
+			// produces a non-empty value first wins. The matrix asserts
+			// (TC-211) on hoisted top-level `lastTimestamp` + `reason`,
+			// so we always emit those keys when ANY source has data —
+			// the "raw" Object stays embedded so consumers reading the
+			// canonical apiserver shape still see the original fields.
+			if reason := firstNonEmptyString(it.Object,
+				[]string{"reason"},
+			); reason != "" {
 				base["reason"] = reason
 			}
-			if msg, ok, _ := unstructured.NestedString(it.Object, "message"); ok && msg != "" {
+			if ts := firstNonEmptyString(it.Object,
+				[]string{"series", "lastObservedTime"}, // events.k8s.io/v1 (repeating)
+				[]string{"eventTime"},                  // events.k8s.io/v1 (single occurrence)
+				[]string{"deprecatedLastTimestamp"},    // apiserver compat shim
+				[]string{"lastTimestamp"},              // legacy core/v1
+				[]string{"deprecatedFirstTimestamp"},   // apiserver compat shim
+				[]string{"firstTimestamp"},             // legacy core/v1 fallback
+			); ts != "" {
+				base["lastTimestamp"] = ts
+			}
+			if msg := firstNonEmptyString(it.Object,
+				[]string{"note"},    // events.k8s.io/v1
+				[]string{"message"}, // legacy core/v1
+			); msg != "" {
 				base["message"] = msg
+			}
+			// Hoist a stable involvedObject snapshot so the EventsPanel
+			// widget (TC-211) can render kind/name without mode-aware
+			// branches. events.k8s.io/v1 calls this `regarding`; legacy
+			// core/v1 calls it `involvedObject`. Both carry the same
+			// {kind, namespace, name} triple.
+			if io := firstNonEmptyMap(it.Object,
+				[]string{"regarding"},      // events.k8s.io/v1
+				[]string{"involvedObject"}, // legacy core/v1
+			); io != nil {
+				base["involvedObject"] = io
 			}
 		}
 		out = append(out, &unstructured.Unstructured{Object: base})
 	}
 	return out
+}
+
+// firstNonEmptyLabel returns the first non-empty label value found
+// across the supplied label keys, in priority order. Used to fold
+// canonical-vs-deprecated label pairs (topology.kubernetes.io vs
+// failure-domain.beta.kubernetes.io) into a single hoist.
+func firstNonEmptyLabel(labels map[string]string, keys ...string) string {
+	for _, k := range keys {
+		if v := labels[k]; v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+// nodeReady reports whether a Node's Ready condition is True. Mirrors
+// `kubectl get nodes` Ready column. Returns false when the conditions
+// list is missing or no Ready entry has status=True.
+func nodeReady(obj map[string]interface{}) bool {
+	conds, ok, _ := unstructured.NestedSlice(obj, "status", "conditions")
+	if !ok {
+		return false
+	}
+	for _, ci := range conds {
+		c, ok := ci.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		t, _ := c["type"].(string)
+		s, _ := c["status"].(string)
+		if t == "Ready" && s == "True" {
+			return true
+		}
+	}
+	return false
+}
+
+// nodeFirstAddress returns the first .status.addresses entry whose
+// `type` matches `wantType`. Empty when missing. Drives the InternalIP
+// column on the Nodes table.
+func nodeFirstAddress(obj map[string]interface{}, wantType string) string {
+	addrs, ok, _ := unstructured.NestedSlice(obj, "status", "addresses")
+	if !ok {
+		return ""
+	}
+	for _, ai := range addrs {
+		a, ok := ai.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		t, _ := a["type"].(string)
+		if t != wantType {
+			continue
+		}
+		v, _ := a["address"].(string)
+		if v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+// firstNonEmptyString walks a list of nested key paths against `obj`
+// and returns the first string value that is non-empty. Each path is a
+// slice of map keys (sequential `unstructured.NestedString` lookups).
+// Paths are tried in order, so callers MUST list the canonical / most
+// preferred location first and fallbacks afterwards.
+//
+// Used by the event flatten path to bridge the events.k8s.io/v1 vs
+// legacy core/v1 schema split (TC-211): a single hoist call site stays
+// readable instead of branching on schema version inline.
+func firstNonEmptyString(obj map[string]interface{}, paths ...[]string) string {
+	for _, p := range paths {
+		if len(p) == 0 {
+			continue
+		}
+		if v, ok, _ := unstructured.NestedString(obj, p...); ok && v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+// firstNonEmptyMap mirrors firstNonEmptyString for nested map fields.
+// Returns the first non-nil non-empty map at any of the supplied paths.
+// The returned reference points into the source object; callers that
+// mutate it must clone first (the flatten path does NOT mutate).
+func firstNonEmptyMap(obj map[string]interface{}, paths ...[]string) map[string]interface{} {
+	for _, p := range paths {
+		if len(p) == 0 {
+			continue
+		}
+		if v, ok, _ := unstructured.NestedMap(obj, p...); ok && len(v) > 0 {
+			return v
+		}
+	}
+	return nil
 }
 
 // podReady reports whether a Pod's Ready condition is True. Returns

--- a/products/catalyst/bootstrap/api/internal/handler/k8s_search.go
+++ b/products/catalyst/bootstrap/api/internal/handler/k8s_search.go
@@ -43,10 +43,31 @@ type k8sSearchHit struct {
 
 // k8sSearchResponse — body of GET /sovereigns/{id}/k8s/search. Canonical
 // `{items, total}` envelope per the matrix contract.
+//
+// Per qa-loop iter-15 Fix #59 (TC-265) the response also carries:
+//
+//   - `kind: "search"`        — schema discriminator. Mirrors the
+//     K8sListResponse envelope's `kind` so SPA components and the
+//     matrix asserts can identify the response shape uniformly. The
+//     matrix asserts `must_contain: ["items","qa-wp","kind"]` even
+//     when the search hit set is empty — without this top-level key
+//     the body emitted no `kind` token and the row failed.
+//   - `cluster: "<sovereignID>"` — surface the source cluster the
+//     search ran against, matching K8sListResponse parity. Lets the
+//     SPA verify the response wasn't routed to an unexpected
+//     Sovereign during a chroot/regional handoff.
+//   - `searchedKinds: [...]`  — the registered kind names actually
+//     iterated. Honest debug surface when callers narrow with
+//     `?kinds=` and want to confirm the server agreed with their
+//     filter. Per `feedback_no_mvp_no_workarounds.md` this is REAL
+//     data, not a placeholder.
 type k8sSearchResponse struct {
-	Items []k8sSearchHit `json:"items"`
-	Total int            `json:"total"`
-	Query string         `json:"query,omitempty"`
+	Kind          string         `json:"kind"`
+	Cluster       string         `json:"cluster,omitempty"`
+	Items         []k8sSearchHit `json:"items"`
+	Total         int            `json:"total"`
+	Query         string         `json:"query,omitempty"`
+	SearchedKinds []string       `json:"searchedKinds,omitempty"`
 }
 
 // HandleK8sSearch — GET /api/v1/sovereigns/{id}/k8s/search?q=<substr>
@@ -54,7 +75,10 @@ type k8sSearchResponse struct {
 // qa-loop iter-9 Fix #43, Cluster-B (TC-265).
 func (h *Handler) HandleK8sSearch(w http.ResponseWriter, r *http.Request) {
 	if h.k8sCache == nil {
-		writeJSON(w, http.StatusOK, k8sSearchResponse{Items: []k8sSearchHit{}})
+		writeJSON(w, http.StatusOK, k8sSearchResponse{
+			Kind:  "search",
+			Items: []k8sSearchHit{},
+		})
 		return
 	}
 	clusterID := chi.URLParam(r, "id")
@@ -69,8 +93,10 @@ func (h *Handler) HandleK8sSearch(w http.ResponseWriter, r *http.Request) {
 		// Empty query → empty items envelope (matches the matrix
 		// contract — no 400 for an empty search).
 		writeJSON(w, http.StatusOK, k8sSearchResponse{
-			Items: []k8sSearchHit{},
-			Query: "",
+			Kind:    "search",
+			Cluster: clusterID,
+			Items:   []k8sSearchHit{},
+			Query:   "",
 		})
 		return
 	}
@@ -154,8 +180,11 @@ func (h *Handler) HandleK8sSearch(w http.ResponseWriter, r *http.Request) {
 	})
 
 	writeJSON(w, http.StatusOK, k8sSearchResponse{
-		Items: hits,
-		Total: len(hits),
-		Query: q,
+		Kind:          "search",
+		Cluster:       clusterID,
+		Items:         hits,
+		Total:         len(hits),
+		Query:         q,
+		SearchedKinds: kinds,
 	})
 }


### PR DESCRIPTION
## Summary

Three handler-level bugs in catalyst-api surfaced by qa-loop iter-15 against console.omantel.biz (sha=3d0755f, chart=1.4.95). Each fix is target-state shape per `feedback_no_mvp_no_workarounds.md` — no MVP, no workaround.

| # | Handler | TC(s) unblocked | Severity |
|---|---|---|---|
| 1 | `flattenK8sListItems` events branch | TC-211 | P0 |
| 2 | `HandleK8sSearch` envelope | TC-265 | P1 |
| 3 | `flattenK8sListItems` node branch | TC-260, TC-261 | P0 / P0 |

### 1. Events flatten — events.k8s.io/v1 schema (TC-211)

The flatten path read top-level `lastTimestamp` / `reason` / `message` — those are core/v1 Event field names. The kind is registered as `events.k8s.io/v1/events` (kinds.go L155, canonical from K8s 1.19+) where the schema renames them:

| core/v1 Event | events.k8s.io/v1 Event |
|---|---|
| `.lastTimestamp` | `.series.lastObservedTime` (when repeating) or `.eventTime` (single occurrence) |
| `.firstTimestamp` | `.eventTime` |
| `.message` | `.note` |
| `.reason` | `.reason` (preserved) |
| `.involvedObject` | `.regarding` |

Cache returned events but the hoisted top-level keys the matrix asserts (`lastTimestamp`, `reason`) were never populated. Matrix `must_contain: ['items','lastTimestamp','reason']` failed even when the cache was warm.

**Fix:** `firstNonEmptyString` helper walks v1 → deprecated mirror → legacy core/v1 in priority order; same for `involvedObject` vs `regarding` via `firstNonEmptyMap`. Both schemas now hoist to the same canonical top-level keys. Three new tests cover v1 single-occurrence, v1 series-repeat, and legacy core/v1 paths.

### 2. Search response envelope (TC-265)

Matrix asserts `must_contain: ['items','qa-wp','kind']` on `GET /k8s/search`. The previous shape only set `kind` on each hit (`hits[].kind`) — when the result set was empty no `kind` token appeared anywhere in the body and the row failed.

**Fix:** K8sListResponse parity — top-level `kind: "search"` (schema discriminator), `cluster: <sovereignID>`, `searchedKinds: [...]` (the registered kinds actually iterated). Always emitted, even on empty / k8sCache-disabled / empty-query branches. Per `feedback_no_mvp_no_workarounds.md` `searchedKinds` carries REAL data (registry slice from a single iteration) so the SPA can verify the server agreed with its `?kinds=` filter.

### 3. Node flatten — fallback labels + Ready/IP hoist (TC-260, TC-261)

Node hoist only read `topology.kubernetes.io/region` + `/zone`. On Sovereigns where:

- the kubelet predates K8s 1.17 (still emits `failure-domain.beta.kubernetes.io/region`);
- or one Hetzner cluster joins nodes from multiple locations under one topology zone (Hetzner's `instance.hetzner.cloud/location` is the discriminator);

the `region` key was never hoisted and TC-260's `must_contain: ['fsn1']` could miss when the canonical label was absent.

**Fix:**
- region/zone fall back across canonical → `failure-domain.beta` → Hetzner location labels;
- new `instanceType` hoist (drives the SKU column on the Nodes table, TC-269 family);
- `ready` boolean (mirrors `kubectl get nodes` Ready column);
- `internalIP` (drives the InternalIP column).

Two helpers added: `nodeReady` (mirrors `podReady` for the Conditions walk) and `nodeFirstAddress` (status.addresses search by type). New `TestFlattenK8sListItems_NodeFallbackLabels` covers the `failure-domain.beta` + Hetzner label paths plus the new ready/internalIP hoist.

## Out of scope (deferred to other Fix Authors)

- 54 of 58 Cloud Resources FAILs are fixture-blocked (qa-wp Application not deployed → `/k8s/<kind>?namespace=qa-omantel` returns `items=[]` → matrix `must_contain: 'qa-wp'` fails). The Applications EPIC Fix Author owns the qa-fixtures landing.
- The handful of POST/PUT TCs returning `{"detail":"EOF","error":"invalid-body"}` (TC-206/208/215/243/244/271) are executor-level issues — the test command did not send a body. Filed as test-design items, not handler bugs.

Per `feedback_chroot_in_cluster_fallback.md` no new GVRs added, so no ClusterRole rule changes required. The `k8scache.DefaultKinds` registry stays unchanged.

## Test plan

- [x] `go build ./...` clean across `products/catalyst/bootstrap/api/...`
- [x] `go test ./internal/handler/ -run TestFlatten` — 8/8 PASS (3 new event tests + 1 new node fallback test)
- [x] Full handler suite `go test ./internal/handler/` — green in 27s
- [x] Full api module `go test ./...` — green
- [ ] Build + roll catalyst-api image to console.omantel.biz, re-run qa-loop iter-16, expect TC-211 / TC-260 / TC-261 / TC-265 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)