### PR TITLE
fix(bp-self-sovereign-cutover): backfill harbor.<fqdn> auth into ghcr-pull secret post-install (bounded-cycle backfill)

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -204,7 +204,23 @@ spec:
       #   commits, and pushes. Subsequent reconciles see local Harbor
       #   as steady-state. Image bumped to alpine/k8s:1.31.4 (kubectl
       #   + git in one image; verified live on otech116).
-      version: 0.1.23
+      # 0.1.24: Step-06 phase-0 ghcr-pull harbor.<sov-fqdn> auth merge
+      #   (#1184, bounded-cycle backfill). Once 0.1.20's phase-1 pivots
+      #   HelmRepository URLs to oci://harbor.<sov-fqdn>/openova-io,
+      #   source-controller hits a 401 on every pull because the
+      #   ghcr-pull Secret only carries auth for ghcr.io and
+      #   harbor.openova.io (cloud-init writes those two; harbor.<sov
+      #   -fqdn> is a per-Sovereign coordinate that doesn't exist at
+      #   bake time). Manually fixed on omantel 2026-05-10 (session
+      #   5c468708) — bp-guacamole / bp-netbird / bp-dmz-vcluster all
+      #   stuck Reconciling until `kubectl patch secret ghcr-pull` was
+      #   run by hand. 0.1.24 codifies that patch as Phase-0 of Step-06
+      #   so the next fresh `tofu apply` comes up GREEN with zero
+      #   manual intervention. Idempotent (no-op when entry already
+      #   matches), reads HARBOR_PASSWORD from the harbor-admin Secret
+      #   already mirrored into `catalyst` ns by bp-harbor 1.2.14+.
+      #   Adds `secrets: [update,patch]` to the runner ClusterRole.
+      version: 0.1.24
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-self-sovereign-cutover
-version: 0.1.23
+version: 0.1.24
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/templates/06-helmrepository-patches-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/06-helmrepository-patches-job.yaml
@@ -1,9 +1,26 @@
 {{- /*
 Step 06 — helmrepository-patches.
 
-For each HelmRepository in .Values.helmRepositories.names, patches
-spec.url from oci://ghcr.io/openova-io/<name> to
-oci://harbor.<sov-fqdn>/openova-io/<name>.
+Three phases run in this Job:
+
+  Phase 0  Merge harbor.<sov-fqdn> auth into the flux-system/ghcr-pull
+           dockerconfigjson Secret so source-controller can pull from the
+           per-Sovereign Harbor mirror once the URLs are pivoted in
+           Phase 1. Without this, every HelmRepository pivoted to
+           oci://harbor.<sov-fqdn>/openova-io 401s on the very first
+           reconcile because ghcr-pull only carries auth for
+           ghcr.io / harbor.openova.io. Caught manually on omantel
+           2026-05-10 (session 5c468708) — bp-guacamole / bp-netbird /
+           bp-dmz-vcluster all stuck Reconciling until a manual
+           `kubectl patch secret ghcr-pull` was run. Idempotent: if
+           harbor.<sov-fqdn> already maps to an auth entry the script
+           no-ops. (#1184)
+  Phase 1  Live K8s patches: for each HelmRepository in
+           .Values.helmRepositories.names, patches spec.url from
+           oci://ghcr.io/openova-io/<name> to
+           oci://harbor.<sov-fqdn>/openova-io/<name>.
+  Phase 2  Push the YAML edit to local Gitea so the bootstrap-kit
+           Kustomization reconcile doesn't revert Phase 1 within ~1m.
 
 Image phase: post.
 */ -}}
@@ -58,6 +75,27 @@ data:
             value: {{ .Values.gitea.org | quote }}
           - name: GITEA_REPO
             value: {{ .Values.gitea.repo | quote }}
+          # Phase 0 (#1184) — harbor.<sov-fqdn> auth merge into ghcr-pull.
+          # HARBOR_PASSWORD comes from the Reflector-mirrored
+          # harbor-admin Secret in this namespace (bp-harbor 1.2.14+
+          # emits it in the harbor ns with allowed-namespaces=catalyst).
+          - name: HARBOR_USERNAME
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.harbor.adminSecretRef.name }}
+                key: {{ .Values.harbor.adminSecretRef.usernameKey }}
+                optional: true
+          - name: HARBOR_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.harbor.adminSecretRef.name }}
+                key: {{ .Values.harbor.adminSecretRef.passwordKey }}
+          - name: GHCR_PULL_SECRET_NAME
+            value: {{ .Values.harbor.ghcrSecretRef.name | quote }}
+          - name: GHCR_PULL_SECRET_NAMESPACE
+            value: {{ .Values.harbor.ghcrSecretRef.namespace | quote }}
+          - name: GHCR_PULL_SECRET_KEY
+            value: {{ .Values.harbor.ghcrSecretRef.dockerConfigKey | quote }}
         volumeMounts:
           - name: helmrepository-list
             mountPath: /work
@@ -72,6 +110,88 @@ data:
             local_prefix="oci://${harbor_host}/openova-io"
 
             echo "[helmrepository-patches] upstream=${UPSTREAM_PREFIX} -> local=${local_prefix}"
+
+            # ---- Phase 0: merge harbor.<sov-fqdn> auth into ghcr-pull (#1184) ----
+            #
+            # source-controller pulls Helm OCI charts from
+            # oci://harbor.<sov-fqdn>/openova-io using the imagePullSecret
+            # named on each HelmRepository (`secretRef.name: ghcr-pull`,
+            # see clusters/_template/bootstrap-kit/*.yaml). The ghcr-pull
+            # Secret ships from cloud-init carrying ghcr.io +
+            # harbor.openova.io auth only — it has NO entry for
+            # harbor.<sov-fqdn>. Once Phase-1 below pivots HelmRepository
+            # URLs, every reconcile against the local Harbor 401s.
+            #
+            # Manual fix done on omantel 2026-05-10 (session 5c468708):
+            #   HARBOR_AUTH=$(echo -n "admin:${HADMIN_PW}" | base64 -w0)
+            #   NEW=$(jq --arg auth "$HARBOR_AUTH" \
+            #           '.auths["harbor.omantel.biz"] = {
+            #              "username":"admin","auth":$auth }' <existing>)
+            #   kubectl patch secret ghcr-pull -n flux-system \
+            #     --type=merge -p "{\"data\":{...}}"
+            #
+            # Phase 0 codifies that patch so the next fresh `tofu apply`
+            # comes up GREEN without operator intervention.
+            : "${HARBOR_USERNAME:=admin}"
+            if [ -z "${HARBOR_PASSWORD:-}" ]; then
+              echo "[helmrepository-patches] FATAL: HARBOR_PASSWORD env empty — cannot derive harbor.${harbor_host} auth" >&2
+              exit 1
+            fi
+
+            # Bracket-form jsonpath quotes the key literally so the
+            # leading dot in `.dockerconfigjson` is not interpreted as
+            # path traversal.
+            existing_b64=$(kubectl get secret "${GHCR_PULL_SECRET_NAME}" \
+              -n "${GHCR_PULL_SECRET_NAMESPACE}" \
+              -o "jsonpath={.data['${GHCR_PULL_SECRET_KEY}']}" 2>/dev/null || echo "")
+            if [ -z "${existing_b64}" ]; then
+              echo "[helmrepository-patches] FATAL: ghcr-pull Secret has no ${GHCR_PULL_SECRET_KEY} key — cloud-init did not run?" >&2
+              exit 1
+            fi
+
+            existing_json=$(printf '%s' "${existing_b64}" | base64 -d)
+
+            # Idempotency guard: if harbor.<sov-fqdn> already maps to an
+            # auth entry, no-op. Re-runs of step-06 (catalyst-api may
+            # retry) MUST NOT churn the Secret resourceVersion every
+            # time — that triggers a noisy reflector cascade.
+            already=$(printf '%s' "${existing_json}" | jq -r --arg h "${harbor_host}" \
+              '.auths[$h].auth // empty')
+            harbor_auth=$(printf '%s:%s' "${HARBOR_USERNAME}" "${HARBOR_PASSWORD}" | base64 -w0)
+            if [ -n "${already}" ] && [ "${already}" = "${harbor_auth}" ]; then
+              echo "[helmrepository-patches] Phase-0 skip: ghcr-pull already carries auth for ${harbor_host}"
+            else
+              new_json=$(printf '%s' "${existing_json}" | jq --arg h "${harbor_host}" \
+                --arg user "${HARBOR_USERNAME}" --arg auth "${harbor_auth}" \
+                '.auths[$h] = {"username":$user,"auth":$auth}')
+              new_b64=$(printf '%s' "${new_json}" | base64 -w0)
+              # Merge-patch the data field. Quoting note: ${GHCR_PULL_SECRET_KEY}
+              # is `.dockerconfigjson` which is a literal key (the leading
+              # dot is part of the field name); JSON merge-patch treats it
+              # as a single key, no path traversal.
+              patch_payload=$(printf '{"data":{"%s":"%s"}}' "${GHCR_PULL_SECRET_KEY}" "${new_b64}")
+              if kubectl patch secret "${GHCR_PULL_SECRET_NAME}" \
+                  -n "${GHCR_PULL_SECRET_NAMESPACE}" \
+                  --type=merge --patch "${patch_payload}" >/dev/null; then
+                echo "[helmrepository-patches] Phase-0 OK: merged ${harbor_host} auth into ${GHCR_PULL_SECRET_NAMESPACE}/${GHCR_PULL_SECRET_NAME}"
+              else
+                echo "[helmrepository-patches] FATAL: kubectl patch ${GHCR_PULL_SECRET_NAME} failed" >&2
+                exit 1
+              fi
+              # Trigger an immediate refresh of every HelmRepository so
+              # source-controller re-loads the Secret on next pull.
+              # Phase 1 below only annotates HRs in HELMREPO_NAMESPACE
+              # whose URL it pivots — but the auth merge benefits every
+              # HR pulling from harbor.<sov-fqdn>, so kick all of them.
+              now_ts=$(date +%s)
+              kubectl get helmrepositories -A \
+                -o jsonpath='{range .items[*]}{.metadata.namespace}{" "}{.metadata.name}{"\n"}{end}' \
+                2>/dev/null | while read -r ns name; do
+                [ -z "${ns}" ] && continue
+                kubectl annotate --overwrite -n "${ns}" "helmrepository/${name}" \
+                  "reconcile.fluxcd.io/requestedAt=${now_ts}" >/dev/null 2>&1 || true
+              done || true
+            fi
 
             # ---- Phase 1: live K8s patches (immediate) ----
             ok=0

--- a/platform/self-sovereign-cutover/chart/templates/rbac.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/rbac.yaml
@@ -15,7 +15,10 @@ The cutover runner needs cluster-scope reach because:
   - Step 02 reads ghcr-pull Secret in `flux-system` namespace.
   - Step 03 only writes to local Harbor over HTTP (no K8s API).
   - Step 05 patches GitRepository in `flux-system` namespace.
-  - Step 06 patches HelmRepositories in `flux-system` namespace.
+  - Step 06 patches HelmRepositories in `flux-system` namespace, AND
+    (phase-0, #1184) merges harbor.<sov-fqdn> auth into the ghcr-pull
+    Secret in `flux-system` so source-controller can pull from the
+    per-Sovereign Harbor mirror without manual kubectl patch.
   - Step 07 patches Deployment in `catalyst-platform` namespace.
   - Step 08 creates+deletes a CiliumNetworkPolicy cluster-wide and
     queries HelmRelease/Kustomization status across all namespaces.
@@ -91,6 +94,9 @@ rules:
   - apiGroups: [""]
     resources: ["configmaps"]
     verbs: ["update", "patch"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["update", "patch"]   # step 06 phase-0 merges harbor.<sov-fqdn> auth into ghcr-pull (#1184)
   - apiGroups: ["apps"]
     resources: ["deployments"]
     verbs: ["update", "patch"]   # step 07 sets env on catalyst-api deployment

--- a/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
+++ b/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
@@ -267,6 +267,35 @@ if ! grep -q 'gitea_host=' "$TMP/render.yaml"; then
 fi
 echo "  PASS (Step-01 has DNS readiness probe)"
 
+echo "[cutover-contract] Case 17: Step-06 phase-0 merges harbor.<sov-fqdn> auth into ghcr-pull (#1184)"
+# 0.1.23 only patched HelmRepository URLs; the pivoted URLs 401 on
+# first reconcile because ghcr-pull lacks auth for harbor.<sov-fqdn>.
+# 0.1.24 adds Phase-0 to Step-06 that merges admin:<password> into the
+# Secret. Guard against future regressions that drop the merge.
+if ! grep -q 'Phase 0: merge harbor' "$TMP/render.yaml"; then
+  echo "FAIL: Step-06 missing Phase 0 (harbor.<sov-fqdn> auth merge into ghcr-pull) (#1184)" >&2
+  exit 1
+fi
+if ! grep -q 'GHCR_PULL_SECRET_NAME' "$TMP/render.yaml"; then
+  echo "FAIL: Step-06 PodSpec missing GHCR_PULL_SECRET_NAME env (#1184)" >&2
+  exit 1
+fi
+if ! grep -q 'GHCR_PULL_SECRET_NAMESPACE' "$TMP/render.yaml"; then
+  echo "FAIL: Step-06 PodSpec missing GHCR_PULL_SECRET_NAMESPACE env (#1184)" >&2
+  exit 1
+fi
+if ! grep -q 'HARBOR_PASSWORD' "$TMP/render.yaml"; then
+  echo "FAIL: Step-06 PodSpec missing HARBOR_PASSWORD env (#1184)" >&2
+  exit 1
+fi
+# RBAC must allow patching Secrets cluster-wide for the merge.
+if ! awk '/^kind: ClusterRole$/,/^---$/' "$TMP/render.yaml" \
+     | grep -B1 -A2 '"secrets"' | grep -E 'verbs:.*"patch"|verbs:.*"update"' >/dev/null; then
+  echo "FAIL: ClusterRole missing secrets [update|patch] (Phase-0 will 403) (#1184)" >&2
+  exit 1
+fi
+echo "  PASS (Step-06 Phase-0 ghcr-pull merge wired)"
+
 echo "[cutover-contract] Case 16: Step-06 helmrepository-patches pushes YAML edit to local Gitea (#970)"
 # 0.1.19 Step-06 only ran kubectl patch against live HelmRepository
 # objects. bootstrap-kit Kustomization reconciled YAML from local


### PR DESCRIPTION
## Summary

Codifies the manual `kubectl patch secret ghcr-pull` performed on
omantel 2026-05-10 (session 5c468708) so the next fresh `tofu apply`
comes up GREEN with zero operator intervention. Bounded-cycle backfill
per `feedback_bounded_provision_cycle.md`.

## Why (root cause)

bp-self-sovereign-cutover 0.1.20 added Phase-1 to Step-06 that pivots
HelmRepository URLs from `oci://ghcr.io/openova-io` to
`oci://harbor.<sov-fqdn>/openova-io`. The `ghcr-pull` Secret in
`flux-system` (ships from cloud-init) only carries auth for `ghcr.io`
and `harbor.openova.io` — it has no entry for `harbor.<sov-fqdn>`
because that's a per-Sovereign coordinate that doesn't exist at bake
time. Result: every HelmRepository pivoted in Phase-1 401s on first
reconcile from source-controller. On omantel today, bp-guacamole /
bp-netbird / bp-dmz-vcluster all sat Reconciling for hours until the
operator hand-patched ghcr-pull:

```sh
HADMIN_PW=$(kubectl -n harbor get secret harbor-admin -o jsonpath='{.data.HARBOR_ADMIN_PASSWORD}' | base64 -d)
HARBOR_AUTH=$(echo -n "admin:${HADMIN_PW}" | base64 -w0)
NEW=$(echo "$EXISTING" | jq --arg auth "$HARBOR_AUTH" '.auths["harbor.omantel.biz"] = {"username":"admin","auth":$auth}')
kubectl -n flux-system patch secret ghcr-pull --type=merge -p "{\"data\":{\".dockerconfigjson\":\"$(echo -n "$NEW" | base64 -w0)\"}}"
```

## What

Step-06 gains a **Phase-0** (runs before the URL pivot) that:

1. Reads `HARBOR_PASSWORD` from the `harbor-admin` Secret (already mirrored into the `catalyst` ns by bp-harbor 1.2.14+ via Reflector).
2. Reads the existing `flux-system/ghcr-pull` dockerconfigjson.
3. **Idempotency guard**: if `.auths[\"harbor.<sov-fqdn>\"].auth` already equals `base64(\"admin:<password>\")`, no-op (no Secret churn, no reflector cascade noise on Step-06 retries).
4. Otherwise jq-merges `{\"username\":\"admin\",\"auth\":\"<b64>\"}` under `.auths[\"harbor.<sov-fqdn>\"]`, base64-encodes the result, and `kubectl patch --type=merge` writes it back.
5. Annotates every HelmRepository cluster-wide with `reconcile.fluxcd.io/requestedAt` so source-controller refreshes the Secret immediately.

**RBAC**: adds `secrets: [update, patch]` to the runner ClusterRole. The existing `secrets: [get, list, watch]` rule remains unchanged. The create/resourceNames split (anchor: `feedback_rbac_create_no_resourcenames.md`) is preserved.

**Idempotency proof**: contract test gate-17 now asserts the Phase-0 sentinel + `GHCR_PULL_SECRET_NAME`/`NAMESPACE` env + `secrets [update|patch]` verb. All 17 gates pass on `helm template smoke .` + `bash tests/cutover-contract.sh`.

## Files

- `platform/self-sovereign-cutover/chart/Chart.yaml` (0.1.23 → 0.1.24)
- `platform/self-sovereign-cutover/chart/templates/06-helmrepository-patches-job.yaml` (Phase-0 + env)
- `platform/self-sovereign-cutover/chart/templates/rbac.yaml` (secrets update/patch)
- `platform/self-sovereign-cutover/chart/tests/cutover-contract.sh` (gate 17)
- `clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml` (pin 0.1.23 → 0.1.24)

## Test plan

- [x] `helm template smoke .` renders cleanly (1805 lines)
- [x] `bash tests/cutover-contract.sh` — 17/17 gates PASS
- [x] python3 yaml.safe_load on rendered podSpec — parses
- [x] grep sentinels for Phase 0 / GHCR_PULL_SECRET_NAME / `jq --arg h` / idempotency `already=` — all present
- [ ] Live verification on next fresh otechN provision: bp-guacamole / bp-netbird / bp-dmz-vcluster reach Ready=True without manual `kubectl patch secret ghcr-pull`
- [ ] Live verification: re-run Step-06 (catalyst-api retry) does NOT bump `flux-system/ghcr-pull` resourceVersion (idempotency guard fires)

## Mental model check

> "if I wipe omantel and re-provision tomorrow, does this Job run automatically and merge harbor auth before any HR tries to pull from harbor?"

YES. Step-06 fires after Step-04 (registry-pivot DaemonSet flips to v2), Step-05 (Flux GitRepository patch), and BEFORE bootstrap-kit Kustomization re-reconciles the helmrepository YAML edits in Phase-2. The new Phase-0 runs FIRST in Step-06's container args, so the Secret is patched before the URL pivot, before any HR gets a chance to fail the first reconcile.

Refs: bounded-provision-cycle backfill strategy (`feedback_bounded_provision_cycle.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)