### PR TITLE
fix(bootstrap-kit): bp-catalyst-platform dependsOn + remediation hardening (chart-roll-rca PR-1+3)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -55,6 +55,16 @@ spec:
     # the umbrella install, eliminating the race.
     - name: bp-keycloak
     - name: bp-cnpg
+    # bp-crossplane-claims (chart-roll-rca iter-15, 2026-05-10): owns the
+    # access.openova.io/v1alpha1 XRD that qa-fixtures UserAccess CRs
+    # require. Without this dep, slot 13 races slot 14 and the umbrella
+    # upgrade fails admission with `no matches for kind "UserAccess" in
+    # version "access.openova.io/v1alpha1"`. The release Secret then
+    # enters `pending-upgrade` and waits the full 15m timeout × 3 retries
+    # before any operator-visible failure (the 2026-05-10 omantel.biz
+    # 90-min wedge). With this edge, the chart never enters the failing
+    # state on a fresh roll.
+    - name: bp-crossplane-claims
   chart:
     spec:
       chart: bp-catalyst-platform
@@ -389,16 +399,35 @@ spec:
   # specifically for this umbrella chart — every other bp-* chart
   # remains at its previous (or default) timeout because they install
   # in well under 5 minutes empirically.
+  #
+  # chart-roll-rca iter-15 (2026-05-10): timeout reduced 25m → 15m and
+  # remediation hardened with cleanupOnFail + strategy: rollback +
+  # remediateLastFailure. Background: the 25m ceiling existed to absorb
+  # the dep-ordering race RC-1 (qa-fixtures UserAccess CRs rendering
+  # before the bp-crossplane-claims XRD existed). With that race fixed
+  # via the bp-crossplane-claims dependsOn edge above, 15m is plenty for
+  # the umbrella's true install latency on a healthy cluster.
+  # cleanupOnFail purges partial release artifacts on retry; rollback
+  # strategy reverts to the last good release before retrying instead of
+  # leaving the release Secret pinned at `pending-upgrade` for the full
+  # timeout ceiling. Net effect: a failed-then-recoverable upgrade
+  # collapses from ~75m worst case → ~15m worst case.
   install:
     disableWait: true
-    timeout: 25m
+    timeout: 15m
     remediation:
       retries: 3
+      strategy: rollback
+      remediateLastFailure: true
+    cleanupOnFail: true
   upgrade:
     disableWait: true
-    timeout: 25m
+    timeout: 15m
     remediation:
       retries: 3
+      strategy: rollback
+      remediateLastFailure: true
+    cleanupOnFail: true
   # Per-Sovereign overrides for the umbrella — sovereign-FQDN-derived hostnames
   # for console/admin/api. All chart-level Catalyst service config (image refs,
   # OTel endpoints, NATS subjects) lives in products/catalyst/chart/values.yaml.

--- a/products/catalyst/chart/templates/qa-fixtures/useraccess-qa-test-tiers.yaml
+++ b/products/catalyst/chart/templates/qa-fixtures/useraccess-qa-test-tiers.yaml
@@ -23,7 +23,13 @@ Per qa-omantel naming conventions (see useraccess-qa-user1.yaml):
 - Scopes mirror qa-user1 so the test users live in the same env-type/app
   space the matrix's resource fixtures (qa-omantel ns, qa-wp app) use.
 */ -}}
-{{- if and .Values.qaFixtures.enabled .Values.qaFixtures.testSessionEnabled }}
+{{- /*
+chart-roll-rca iter-15 (2026-05-10) defense-in-depth: APIVersions.Has
+gate — see useraccess-qa-user1.yaml for full rationale. If the XRD
+is missing the file evaluates to empty bytes, eliminating the
+admission-rejection class of chart-roll wedges.
+*/ -}}
+{{- if and .Values.qaFixtures.enabled .Values.qaFixtures.testSessionEnabled (.Capabilities.APIVersions.Has "access.openova.io/v1alpha1/UserAccess") }}
 {{- $tiers := list "viewer" "developer" "operator" "admin" "owner" -}}
 {{- $sovRef := regexReplaceAll "\\..*$" (.Values.qaFixtures.sovereignRef | default "omantel.biz") "" -}}
 {{- range $tier := $tiers }}

--- a/products/catalyst/chart/templates/qa-fixtures/useraccess-qa-user1.yaml
+++ b/products/catalyst/chart/templates/qa-fixtures/useraccess-qa-user1.yaml
@@ -1,4 +1,12 @@
-{{- if .Values.qaFixtures.enabled }}
+{{- /*
+chart-roll-rca iter-15 (2026-05-10) defense-in-depth: APIVersions.Has
+gate ensures the manifest evaluates to empty bytes when the
+access.openova.io/v1alpha1 XRD is not yet registered (e.g., bp-crossplane-claims
+mid-install). Even if dependsOn ordering breaks again, the umbrella
+chart will not block on missing-CRD admission failure. The next
+reconcile pass once the XRD is live will render and apply the CR.
+*/ -}}
+{{- if and .Values.qaFixtures.enabled (.Capabilities.APIVersions.Has "access.openova.io/v1alpha1/UserAccess") }}
 apiVersion: access.openova.io/v1alpha1
 kind: UserAccess
 metadata:


### PR DESCRIPTION
## Root Cause (chart-roll-rca-iter15.md executive summary)

bp-catalyst-platform 1.4.128 wedged for 90+ min on omantel.biz (provision #6, 2026-05-10) because the umbrella's `dependsOn` (`[bp-gitea, bp-gateway-api, bp-keycloak, bp-cnpg]`) **does NOT include `bp-crossplane-claims`** — the chart that owns the `access.openova.io/v1alpha1` XRD. qa-fixtures `UserAccess` plain manifests rendered before the XRD was live, Helm rejected them at admission with `no matches for kind "UserAccess" in version "access.openova.io/v1alpha1"`, the release Secret entered `pending-upgrade`, and the install/upgrade blocks' `timeout: 25m` × `remediation.retries: 3` ceiling allowed the wedge to compound for ~75 min worst case before any operator-visible failure.

## PR-1 (CRITICAL) — `dependsOn += bp-crossplane-claims`

**File**: `clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml`

Adds the missing `bp-crossplane-claims` edge to the umbrella's `dependsOn` list. Flux now blocks bp-catalyst-platform install until the `access.openova.io/v1alpha1` XRD is live, eliminating the race entirely on a fresh roll.

## PR-3 — `install`/`upgrade` remediation hardening

**File**: `clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml`

- `cleanupOnFail: true` on both blocks — purges partial release artifacts on retry.
- `remediation.strategy: rollback` — rolls back to last good release before retrying instead of pinning at `pending-upgrade`.
- `remediation.remediateLastFailure: true` — ensures remediation runs on Failed state.
- `timeout: 25m` → `15m` — the 25m ceiling existed to absorb the dep-ordering race PR-1 fixes; with that fixed, 15m is plenty for the umbrella's true install latency on a healthy cluster. Faster failure = faster automatic recovery.

Net: failed-then-recoverable upgrade collapses from ~75 min worst case → ~15 min worst case (~5× speed-up). Insurance for any future intra-chart Job-timeout or admission-failure regression.

## PR-2 (defense-in-depth) — `APIVersions.Has` gate on UserAccess templates

**Files**:
- `products/catalyst/chart/templates/qa-fixtures/useraccess-qa-user1.yaml`
- `products/catalyst/chart/templates/qa-fixtures/useraccess-qa-test-tiers.yaml`

Wraps each gating `if` with `(.Capabilities.APIVersions.Has "access.openova.io/v1alpha1/UserAccess")`. When the XRD is not yet registered the manifest evaluates to empty bytes — the chart upgrade succeeds, the next reconcile pass picks up the CR once the GVR is live. Belt-and-suspenders against any future XRD-pinning bug or dep-ordering regression.

Note: in normal production rolls the live Flux controller has APIVersions populated by the time the chart renders (because PR-1 ensures bp-crossplane-claims is Ready first), so this gate only activates in the regression-protection path.

## Acceptance test (next fresh provision, e.g., provision #7)

- [ ] `kubectl get hr -n flux-system bp-catalyst-platform` reaches `Ready=True` on the **first** install action — no `pending-upgrade` row in `helm history catalyst-platform -n catalyst-system`.
- [ ] Chart roll completes in **< 15 min, zero-touch** — no manual `flux reconcile`, no Bucket-A `kubectl apply` of fixtures.
- [ ] `kubectl get useraccess -A` shows `qa-user1` + 5 `qa-test-{viewer,developer,operator,admin,owner}` CRs without operator intervention.
- [ ] If the dep-ordering breaks again (artificial test: `flux suspend hr bp-crossplane-claims`), bp-catalyst-platform still reaches `Ready=True` (with the qa-fixtures UserAccess CRs absent — PR-2 gate engaged). Restore the dep → next reconcile renders the CRs.

## Verification done in this PR

- YAML parses cleanly (3 docs in `13-bp-catalyst-platform.yaml`).
- `dependsOn` now lists 5 entries: `[bp-gitea, bp-gateway-api, bp-keycloak, bp-cnpg, bp-crossplane-claims]`.
- `install` and `upgrade` blocks both have `timeout: 15m`, `cleanupOnFail: true`, `remediation: { retries: 3, strategy: rollback, remediateLastFailure: true }`.
- UserAccess templates' top-level `if` includes the `APIVersions.Has` clause.

## Refs

- RCA report: `openova-private:.claude/qa-loop-state/chart-roll-rca-iter15.md` (PR-1, PR-2, PR-3 sections).
- Live incident: omantel.biz provision #6, 2026-05-10, 90-min wedge unblocked by manual reconcile + Bucket-A kubectl-apply.
- Per `feedback_bounded_provision_cycle.md`: this PR's purpose is to make provision #7 chart-roll complete zero-touch in <15 min instead of wedging for 90 min.