### PR TITLE
fix(bootstrap-kit): drop install.cleanupOnFail + install.remediation.strategy (HR v2 schema; prov7 unblock)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -412,14 +412,24 @@ spec:
   # leaving the release Secret pinned at `pending-upgrade` for the full
   # timeout ceiling. Net effect: a failed-then-recoverable upgrade
   # collapses from ~75m worst case → ~15m worst case.
+  #
+  # post-prov7 fix (2026-05-10, refs chart-roll-rca-iter15): the
+  # HelmRelease v2 schema only allows `cleanupOnFail` and
+  # `remediation.strategy` on the `upgrade` block. The previous version
+  # of this file placed both fields on the `install` block as well,
+  # which caused the bootstrap-kit Kustomization to fail dry-run on a
+  # fresh Sovereign with `field not declared in schema`, blocking ALL
+  # HRs from rendering. The install block here keeps only the schema-
+  # legal fields (`retries`, `remediateLastFailure`); rollback semantics
+  # apply naturally to upgrades, and a failed first install is
+  # remediated via retry without rollback (no prior release to roll
+  # back to).
   install:
     disableWait: true
     timeout: 15m
     remediation:
       retries: 3
-      strategy: rollback
       remediateLastFailure: true
-    cleanupOnFail: true
   upgrade:
     disableWait: true
     timeout: 15m


### PR DESCRIPTION
## Summary

PR #1302 placed `cleanupOnFail` and `remediation.strategy` on **both** the `install` and `upgrade` blocks of the bp-catalyst-platform HelmRelease. The HelmRelease v2 CRD schema only declares those fields on the `upgrade` block. As a result, the bootstrap-kit Kustomization fails dry-run on every fresh Sovereign:

```
HelmRelease/flux-system/bp-catalyst-platform dry-run failed:
  .spec.install.remediation.strategy: field not declared in schema
  .spec.install.cleanupOnFail: field not declared in schema
```

This blocks **all** 40+ HRs from being applied (umbrella Kustomization fail-fast).

Observed live on omantel.biz provision #7 (qa-loop bounded-cycle validation, 2026-05-10): Phase-1 watcher reports `watcher-watching` but `kubectl get hr -A` returns "No resources found" indefinitely.

## Fix

- Keep `cleanupOnFail` + `remediation.strategy: rollback` on `upgrade` (where they're schema-legal AND meaningful — rollback only makes sense if a prior release exists).
- On `install`, retain only schema-legal fields: `retries`, `remediateLastFailure`.

## Schema reference

```
$ kubectl get crd helmreleases.helm.toolkit.fluxcd.io -o jsonpath=...
install.remediation.properties: [ignoreTestFailures, remediateLastFailure, retries]
upgrade.remediation.properties: [ignoreTestFailures, remediateLastFailure, retries, strategy]
upgrade.properties: [..., cleanupOnFail, ...]   # install does NOT have cleanupOnFail
```

## Test plan

- [ ] Next fresh provision: `kubectl get kustomization -n flux-system bootstrap-kit` reaches Ready=True without dry-run schema errors
- [ ] `kubectl get hr -A` shows 40+ HRs progressing within ~2 min of bootstrap-kit reconciliation
- [ ] bp-catalyst-platform retains all PR #1302 hardening on `upgrade` (rollback + cleanupOnFail)

Refs: companion to #1302 (chart-roll-rca-iter15 PR-3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Claimed TCs

_None — infrastructure fix that enables but doesn't directly unblock any specific TC. See `/home/openova/repos/openova-private/.claude/qa-loop-state/wave4-5-tc-backfill.md` for reasoning._

(HelmRelease v2 schema fix; chart-apply infrastructure; every TC implicitly
depends on the chart applying but no TC verifies the schema fix directly.)
