### PR TITLE
fix(chart): Application controller materializes qa-wp Pod (qa-loop iter-16 Fix #65)

### DIFF
--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -738,8 +738,28 @@ name: bp-catalyst-platform
 # documented in qa-loop-state/iter12-diagnostic-audit.md §"(e)
 # infra-blocked" TC-081 (per `feedback_no_mvp_no_workarounds.md`
 # rule #3 "no operational hacks instead of chart fixes").
-version: 1.4.128
+version: 1.4.129
 appVersion: 1.4.94
+# 1.4.129 (qa-loop iter-16 Fix #65): ship the missing
+# `openova-catalog` Flux v1 HelmRepository in flux-system. The
+# application-controller has always defaulted its rendered HelmRelease
+# `sourceRef.name` to `openova-catalog` (env: CATALOG_SOURCE_REF), but
+# no chart template ever shipped the matching CR. Result: every
+# Application reconciled by the controller produced a HelmRelease
+# pointing at a non-existent source, Flux's helm-controller logged
+# `Source 'HelmRepository/openova-catalog' not found`, and no Pod was
+# ever scheduled. The Application CR sat at status.phase=Pending
+# forever — the qa-wp Application on qa-omantel never materialised
+# its nginx Pod / Service / ConfigMap, blocking ~30 qa-loop matrix TCs
+# (TC-066/100/103/104/109/113/216/262 + every other qa-omantel
+# namespaced test). Per docs/INVIOLABLE-PRINCIPLES.md #1 (target-state)
+# the chart now ships the missing source CR; the controller's default
+# is now a non-dangling reference on every Sovereign install. Per
+# Inviolable Principle #4 every field is overridable via per-Sovereign
+# overlays (e.g. swing url to a local Harbor proxy_cache via the
+# cutover-driver). New file: templates/openova-catalog-helmrepository.
+# yaml. New values block: catalog.helmRepository.{enabled,name,
+# namespace,type,url,secretRef,interval}.
 description: |
   Catalyst Platform — the unified Catalyst control plane umbrella chart for Catalyst-Zero.
   Composes the catalyst-{ui,api}, console, admin, marketplace UI modules and the marketplace-api backend.

--- a/products/catalyst/chart/templates/openova-catalog-helmrepository.yaml
+++ b/products/catalyst/chart/templates/openova-catalog-helmrepository.yaml
@@ -1,0 +1,105 @@
+{{- /*
+Flux v1 HelmRepository — the `openova-catalog` source the
+application-controller's rendered HelmReleases reference by default.
+
+ROOT CAUSE (qa-loop iter-16 Fix #65):
+  The application-controller (core/controllers/application/internal/
+  controller/application_controller.go) renders every per-region
+  HelmRelease with `spec.chart.spec.sourceRef.name` defaulted via the
+  CATALOG_SOURCE_REF env var (default `openova-catalog`) when the
+  parent Blueprint omits an explicit `source.ref` (or sets only
+  `source.url`). The renderer in core/controllers/pkg/render/manifests.go
+  always emits a `name:` ref into a Flux `HelmRepository` — never an
+  inline `OCIRepository url:` form — because the control-plane wants ONE
+  registry handle (the named HelmRepository) that operators can
+  re-target per Sovereign (e.g. swing every catalog pull from
+  `oci://ghcr.io/openova-io` to a local Harbor proxy_cache via the
+  cutover-driver, see products/catalyst/bootstrap/api/internal/handler/
+  cutover.go) without re-rendering every Application's manifest set.
+
+  The chart shipped the controller + the default ref name, but NEVER
+  shipped the `HelmRepository` CR with that name. Result: every
+  Application reconciled by the controller emitted a HelmRelease
+  pointing at `sourceRef.name=openova-catalog` in `flux-system`, which
+  did not exist. Flux's helm-controller logged
+  `Source 'HelmRepository/openova-catalog' not found` and the workload
+  install never happened. The Application CR sat at
+  `status.phase=Pending` (then `Provisioning`) forever; no Pod, no
+  Service, no ConfigMap was ever created.
+
+  Live symptom on qa-omantel (provision #6, 2026-05-10):
+    - Application qa-wp exists in qa-omantel ns
+    - GET /api/v1/sovereigns/.../applications returns qa-wp in items
+    - GET /api/v1/sovereigns/.../resources/pods?ns=qa-omantel returns
+      empty (no qa-wp-0 pod ever scheduled)
+    - kubectl get pods -n qa-omantel → no qa-wp-* pods
+    - kubectl get hr -n qa-omantel qa-wp → Source not found
+
+  ~30 TCs assert on a running qa-wp Pod / Service / ConfigMap +
+  Application reaching `Ready=True`. All of them stayed FAIL until
+  this template lands on a fresh provision.
+
+FIX (target-state per docs/INVIOLABLE-PRINCIPLES.md #1):
+  Ship the missing piece. The chart now emits a `HelmRepository` named
+  `openova-catalog` in `flux-system` pointing at
+  `oci://ghcr.io/openova-io` (the canonical OpenOva blueprint registry
+  every other bootstrap-kit slot already uses — see clusters/_template/
+  bootstrap-kit/27-kyverno.yaml et al). The controller's default
+  `CATALOG_SOURCE_REF=openova-catalog` is now a non-dangling reference
+  on every Sovereign install.
+
+  Per Inviolable Principle #4 (never hardcode) the URL + secretRef +
+  interval are operator-overridable via `.Values.catalog.*`. Defaults
+  match the canonical openova-io GHCR org + the `ghcr-pull` Secret the
+  rest of the chart already deploys for catalyst-api / catalyst-ui /
+  controller image pulls.
+
+  Per Inviolable Principle #4a (CI is the only build path) the chart
+  bytes referenced via this HelmRepository (e.g. `bp-qa-app:0.1.0`,
+  `bp-wordpress:0.1.0`) are produced by .github/workflows/blueprint-
+  release.yaml on every commit to platform/<name>/chart/** — never
+  hand-pushed.
+
+WHY `flux-system` (matches controller default `SOURCE_NAMESPACE`):
+  The application-controller's render pipeline pins the HelmRelease's
+  `sourceRef.namespace` to `r.Cfg.SourceNamespace` which defaults to
+  `flux-system` (env: `SOURCE_NAMESPACE`). Flux's helm-controller
+  resolves cross-namespace HelmRepository refs only via this explicit
+  namespace pin. Putting the HelmRepository here means every
+  Application namespace can reference it without per-Application
+  ServiceAccount or RBAC plumbing.
+
+WHY type=oci (matches blueprint-release.yaml publish path):
+  blueprint-release.yaml pushes every chart as an OCI artifact via
+  `helm push <chart>.tgz oci://ghcr.io/openova-io`. The matching
+  HelmRepository MUST set `spec.type: oci` so Flux source-controller
+  uses the OCI client; the default (`http`) would 404 on a chart pull.
+
+WHY interval=15m (matches sibling bootstrap-kit HelmRepositories):
+  The chart bytes are immutable by version (Helm/OCI semver tagging
+  rules + cosign keyless signing in CI). 15m is the canonical interval
+  used by every other bootstrap-kit HelmRepository (kyverno, grafana,
+  trivy, cert-manager-powerdns-webhook). Tighter intervals waste GHCR
+  API quota; looser intervals delay the propagation of new chart
+  versions once a blueprint-release.yaml run lands.
+*/ -}}
+{{- if .Values.catalog.helmRepository.enabled }}
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: {{ .Values.catalog.helmRepository.name | default "openova-catalog" | quote }}
+  namespace: {{ .Values.catalog.helmRepository.namespace | default "flux-system" | quote }}
+  labels:
+    app.kubernetes.io/managed-by: helm
+    app.kubernetes.io/component: openova-catalog
+    catalyst.openova.io/managed-by: catalyst-platform-chart
+    helm.sh/chart-instance: {{ .Release.Name }}
+spec:
+  type: {{ .Values.catalog.helmRepository.type | default "oci" | quote }}
+  interval: {{ .Values.catalog.helmRepository.interval | default "15m" | quote }}
+  url: {{ .Values.catalog.helmRepository.url | default "oci://ghcr.io/openova-io" | quote }}
+  {{- if .Values.catalog.helmRepository.secretRef }}
+  secretRef:
+    name: {{ .Values.catalog.helmRepository.secretRef | quote }}
+  {{- end }}
+{{- end }}

--- a/products/catalyst/chart/values.yaml
+++ b/products/catalyst/chart/values.yaml
@@ -948,6 +948,54 @@ smeServices:
       repo: openova
       branch: main
 
+# ─── Catalog (qa-loop iter-16 Fix #65) ─────────────────────────────────
+# `openova-catalog` Flux HelmRepository — the named source ref every
+# Application's rendered HelmRelease points at by default.
+#
+# The application-controller (core/controllers/application/) renders
+# per-region HelmReleases with `sourceRef.name` = `controllers.application.
+# catalogSourceRef` (env: CATALOG_SOURCE_REF, default `openova-catalog`)
+# in `controllers.application.sourceNamespace` (env: SOURCE_NAMESPACE,
+# default `flux-system`). Without a HelmRepository CR at that
+# namespace/name pair, Flux's helm-controller cannot resolve the chart
+# bytes and the workload Pod is never scheduled — the qa-wp Application
+# CR sits at status.phase=Pending forever, blocking ~30 qa-loop TCs.
+#
+# This block ships the missing CR. Per Inviolable Principle #4 every
+# field is operator-overridable via per-Sovereign overlays (e.g. a
+# Sovereign with a local Harbor proxy_cache flips `url:` to its own
+# `oci://harbor.<sovereign-fqdn>` mirror without forking the chart).
+catalog:
+  helmRepository:
+    enabled: true
+    # MUST equal controllers.application.catalogSourceRef (default
+    # "openova-catalog"). Operators that re-target the controller's
+    # source ref (e.g. "openova-catalog-mirror") must also bump this so
+    # the HelmRepository name and the controller's render output stay
+    # in lockstep.
+    name: openova-catalog
+    # MUST equal controllers.application.sourceNamespace (default
+    # "flux-system"). Same lockstep rule as `name`.
+    namespace: flux-system
+    # `oci` — matches blueprint-release.yaml publish path (`helm push
+    # <chart>.tgz oci://ghcr.io/openova-io`). Default `http` would 404
+    # on a chart pull.
+    type: oci
+    # Canonical OpenOva blueprint registry. Per-Sovereign overlays may
+    # override to a local Harbor mirror (cutover.go re-targets every
+    # bp-* HelmRepository to `oci://harbor.<sovereign-fqdn>`; this CR
+    # follows the same convention).
+    url: oci://ghcr.io/openova-io
+    # `ghcr-pull` Secret is bootstrapped in flux-system by every
+    # Sovereign's bootstrap-kit (clusters/_template/bootstrap-kit/
+    # 03-flux.yaml et al). Empty disables auth (public packages only).
+    secretRef: ghcr-pull
+    # 15m matches sibling bootstrap-kit HelmRepositories
+    # (kyverno/grafana/trivy/cert-manager-powerdns-webhook). Tighter
+    # wastes GHCR API quota; looser delays new chart-version
+    # propagation post blueprint-release.yaml.
+    interval: 15m
+
 # qaFixtures — qa-loop iter-6 Cluster-F seeder for the test-matrix
 # fixtures (qa-omantel namespace, disposable-cm, qa-wp-creds, qa-user1
 # UserAccess + RoleBinding, bp-qa-custom Blueprint). DEFAULT-OFF;


### PR DESCRIPTION
## Root Cause

The application-controller (`core/controllers/application/internal/controller/application_controller.go`) renders every per-region HelmRelease with `spec.chart.spec.sourceRef.name` defaulted via the env var `CATALOG_SOURCE_REF` (default `openova-catalog`) in `flux-system` (env `SOURCE_NAMESPACE`). The renderer in `core/controllers/pkg/render/manifests.go` always emits a `name:` ref into a Flux `HelmRepository` — never an inline `OCIRepository url:` form — because the control-plane wants ONE registry handle that operators can re-target per Sovereign (e.g. swing every catalog pull from `oci://ghcr.io/openova-io` to a local Harbor proxy_cache via the cutover-driver).

The chart shipped the controller + the default ref name, but **never shipped the matching `HelmRepository` CR**. Result: every Application reconciled by the controller produced a HelmRelease pointing at a non-existent source. Flux's helm-controller logged `Source 'HelmRepository/openova-catalog' not found` and the workload install never happened. The Application CR sat at `status.phase=Pending` forever; no Pod, no Service, no ConfigMap was ever created.

**Live symptom on qa-omantel (provision #6, 2026-05-10):**
- Application `qa-wp` exists in `qa-omantel` ns
- `GET /api/v1/sovereigns/.../applications` returns qa-wp in items
- `GET /api/v1/sovereigns/.../resources/pods?ns=qa-omantel` returns empty (no qa-wp-0 pod)
- `kubectl get pods -n qa-omantel` → no qa-wp-* pods
- `kubectl get hr -n qa-omantel qa-wp` → Source not found

~30 TCs assert on a running qa-wp Pod / Service / ConfigMap + the Application reaching `Ready=True`.

## Fix

Per `docs/INVIOLABLE-PRINCIPLES.md` #1 (target-state, not MVP) — ship the missing piece.

- New template `products/catalyst/chart/templates/openova-catalog-helmrepository.yaml` emits a Flux v1 `HelmRepository` named `openova-catalog` in `flux-system` pointing at `oci://ghcr.io/openova-io` with the canonical `ghcr-pull` Secret + 15m interval (matches sibling bootstrap-kit HelmRepositories at `clusters/_template/bootstrap-kit/27-kyverno.yaml` et al).
- New values block `catalog.helmRepository.{enabled,name,namespace,type,url,secretRef,interval}` — every field operator-overridable per Inviolable Principle #4 (never hardcode). Per-Sovereign overlays may swing `url:` to a local Harbor proxy_cache via the cutover-driver without forking the chart.
- Chart bump `1.4.128` → `1.4.129`.

## Verification (on a fresh provision)

```bash
# 1. The new HelmRepository is installed
kubectl --context=<sovereign> -n flux-system get helmrepository openova-catalog
# → exists, Ready=True

# 2. The qa-wp HelmRelease resolves its source and installs
kubectl --context=<sovereign> -n qa-omantel get helmrelease qa-wp
# → Ready=True (was: Source not found)

# 3. The qa-wp Pod is scheduled and running
kubectl --context=<sovereign> -n qa-omantel get pods -l app.kubernetes.io/name=qa-wp
# → qa-wp-* Pod in Running phase

# 4. The qa-wp Application reaches Ready
kubectl --context=<sovereign> -n qa-omantel get application qa-wp -o jsonpath='{.status.phase}'
# → Ready (was: Pending)

# 5. API surface matches (replaces the iter-16 missing-pod symptom)
curl /api/v1/sovereigns/<id>/resources/pods?ns=qa-omantel | jq '.items[].metadata.name'
# → includes "qa-wp-0"
```

## Expected impact on fresh provision

~30 qa-omantel-namespaced TCs unblock — every test-case that asserts on the qa-wp Pod / Service / ConfigMap or on `Application.status.phase=Ready`:
- TC-066 (install→Ready transition)
- TC-100 / TC-103 / TC-104 (workload reachability)
- TC-109 / TC-113 / TC-117 (status surfacing)
- TC-216 (resource list under qa-omantel)
- TC-262 (per-pod detail page)
- And all sibling cohorts that depend on the qa-wp install completing.

## Files changed

- `products/catalyst/chart/templates/openova-catalog-helmrepository.yaml` (new)
- `products/catalyst/chart/values.yaml` (new `catalog.helmRepository.*` block)
- `products/catalyst/chart/Chart.yaml` (1.4.128 → 1.4.129)

## Smoke

`helm template smoke products/catalyst/chart --namespace catalyst-system` renders cleanly (2733 lines default, 5328 lines with `qaFixtures.enabled=true`); `enabled: false` cleanly omits the resource without leaving dangling references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Claimed TCs

- TC-066 (qa-wp HR install→Ready transition)
- TC-100 (workload reachability)
- TC-103 (workload reachability)
- TC-104 (workload reachability)
- TC-109 (status surfacing)
- TC-113 (status surfacing)
- TC-117 (status surfacing)
- TC-216 (resource list under qa-omantel)
- TC-262 (per-pod detail page)
