### PR TITLE
fix(catalyst-api provisioner): qaTestEnabled flag auto-sets QA_FIXTURES_ENABLED for QA Sovereigns (qa-loop bounded-cycle Fix #73)

### DIFF
--- a/infra/hetzner/cloudinit-control-plane.tftpl
+++ b/infra/hetzner/cloudinit-control-plane.tftpl
@@ -923,6 +923,28 @@ write_files:
             # template at provision time.
             CLUSTER_MESH_NAME: "${cluster_mesh_name}"
             CLUSTER_MESH_ID: "${cluster_mesh_id}"
+            # QA fixtures auto-enable (Fix #73 — qa-loop bounded-cycle
+            # iter-16). Default "false" so a customer-facing zero-touch
+            # provision lands a Sovereign with NO qaFixtures stack
+            # rendered. Catalyst-api flips to "true" + populates the
+            # namespace + Organization names when the wizard / API
+            # caller sets Request.QATestEnabled=true (QA Sovereigns
+            # only). The bp-catalyst-platform chart's bootstrap-kit
+            # slot 13 reads via ${QA_FIXTURES_ENABLED:-false} and the
+            # other three placeholders below — see
+            # clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+            # lines 496/510/511/519.
+            #
+            # QA_FIXTURES_NAMESPACE / QA_ORGANIZATION are derived
+            # server-side from SovereignFQDN's first label per
+            # docs/INVIOLABLE-PRINCIPLES.md #4 — "qa-omantel" /
+            # "omantel-platform" for omantel.biz, etc. — so a
+            # non-omantel QA Sovereign never inherits the chart's
+            # legacy bootstrapping defaults.
+            QA_FIXTURES_ENABLED: "${qa_fixtures_enabled}"
+            QA_TEST_SESSION_ENABLED: "${qa_test_session_enabled}"
+            QA_FIXTURES_NAMESPACE: "${qa_fixtures_namespace}"
+            QA_ORGANIZATION: "${qa_organization}"
       ---
       apiVersion: kustomize.toolkit.fluxcd.io/v1
       kind: Kustomization

--- a/infra/hetzner/main.tf
+++ b/infra/hetzner/main.tf
@@ -303,11 +303,15 @@ locals {
   # Guardrail in this same module: see `validate_user_data_size` precondition
   # below — any future bloat that pushes user_data ≥ 30 KiB fails at plan-time.
   control_plane_cloud_init = replace(templatefile("${path.module}/cloudinit-control-plane.tftpl", {
-    sovereign_fqdn      = var.sovereign_fqdn
-    sovereign_subdomain = var.sovereign_subdomain
-    marketplace_enabled = var.marketplace_enabled
-    cluster_mesh_name   = var.cluster_mesh_name
-    cluster_mesh_id     = var.cluster_mesh_id
+    sovereign_fqdn          = var.sovereign_fqdn
+    sovereign_subdomain     = var.sovereign_subdomain
+    marketplace_enabled     = var.marketplace_enabled
+    qa_fixtures_enabled     = var.qa_fixtures_enabled
+    qa_test_session_enabled = var.qa_test_session_enabled
+    qa_fixtures_namespace   = var.qa_fixtures_namespace
+    qa_organization         = var.qa_organization
+    cluster_mesh_name       = var.cluster_mesh_name
+    cluster_mesh_id         = var.cluster_mesh_id
 
     # Multi-domain Sovereign (issue #827). When the wizard supplies an
     # explicit parent-domain list, use it verbatim. Otherwise default to a
@@ -738,9 +742,13 @@ locals {
   secondary_region_cloud_init = {
     for k, r in local.secondary_regions :
     k => replace(templatefile("${path.module}/cloudinit-control-plane.tftpl", {
-      sovereign_fqdn      = var.sovereign_fqdn
-      sovereign_subdomain = var.sovereign_subdomain
-      marketplace_enabled = var.marketplace_enabled
+      sovereign_fqdn          = var.sovereign_fqdn
+      sovereign_subdomain     = var.sovereign_subdomain
+      marketplace_enabled     = var.marketplace_enabled
+      qa_fixtures_enabled     = var.qa_fixtures_enabled
+      qa_test_session_enabled = var.qa_test_session_enabled
+      qa_fixtures_namespace   = var.qa_fixtures_namespace
+      qa_organization         = var.qa_organization
       # Per-secondary-region ClusterMesh anchors. id is incremented per
       # peer index so each secondary region gets a unique slot in the
       # mesh registry; primary region keeps var.cluster_mesh_id.

--- a/infra/hetzner/variables.tf
+++ b/infra/hetzner/variables.tf
@@ -33,6 +33,75 @@ variable "marketplace_enabled" {
   }
 }
 
+# ── QA fixtures auto-enable (Fix #73 — qa-loop bounded-cycle iter-16) ──
+# When set, bp-catalyst-platform's qaFixtures stack (qa-<sov> namespace +
+# qa-wp Application + Continuum CR + CNPGPair + PDM CRs + ScheduledBackup
+# + status-seeder Jobs + tier-bound UserAccess seeder) renders so the
+# qa-loop matrix Test Executor finds every Sovereign-side fixture it
+# asserts on. Customer-facing Sovereigns provision with the default
+# 'false' → no fixture artifacts. QA Sovereigns (omantel.biz, qa.<x>)
+# provision with 'true' (set by catalyst-api from
+# Request.QATestEnabled). Threaded into bootstrap-kit Kustomization
+# postBuild.substitute as QA_FIXTURES_ENABLED — the chart reads via
+# `${QA_FIXTURES_ENABLED:-false}` so this var is the canonical
+# operator-controlled seam.
+variable "qa_fixtures_enabled" {
+  type        = string
+  description = "When 'true', the Sovereign provisions with the bp-catalyst-platform qaFixtures stack rendered (qa-loop matrix consumers). Default 'false' for customer Sovereigns. Set 'true' only on QA Sovereigns."
+  default     = "false"
+  validation {
+    condition     = contains(["true", "false"], var.qa_fixtures_enabled)
+    error_message = "qa_fixtures_enabled must be the string 'true' or 'false'."
+  }
+}
+
+# Tier-scoped test-session minting endpoint (qa-loop iter-11 Cluster-A).
+# Companion to qa_fixtures_enabled — defaults 'true' inside the chart
+# already (because every Sovereign that has qaFixtures.enabled is by
+# definition a QA Sovereign), but we still thread the toggle so an
+# operator can disable the endpoint on an otherwise-QA Sovereign that
+# wants only the resource fixtures. Defaults 'false' here (NOT 'true')
+# because catalyst-api stamps 'true' alongside qa_fixtures_enabled when
+# QATestEnabled fires; leaving the default 'false' ensures a Sovereign
+# that omits qa_fixtures_enabled entirely (production) cannot accidentally
+# expose the test-session endpoint.
+variable "qa_test_session_enabled" {
+  type        = string
+  description = "When 'true', catalyst-api on the Sovereign exposes POST /api/v1/auth/test-session for tier-scoped session minting (qa-loop matrix executor needs this for tier-boundary 403/200 contracts). Auto-set to match qa_fixtures_enabled on QA Sovereigns; default 'false' for customer Sovereigns."
+  default     = "false"
+  validation {
+    condition     = contains(["true", "false"], var.qa_test_session_enabled)
+    error_message = "qa_test_session_enabled must be the string 'true' or 'false'."
+  }
+}
+
+# qa-fixtures namespace + Organization names. Default to derivation-friendly
+# fallbacks that survive when qa_fixtures_enabled='false' (the chart
+# short-circuits before materialising them). When qa_fixtures_enabled='true',
+# catalyst-api derives "qa-<first-FQDN-label>" + "<first-FQDN-label>-platform"
+# from Request.SovereignFQDN per docs/INVIOLABLE-PRINCIPLES.md #4 (never
+# hardcode) so a non-omantel QA Sovereign doesn't inherit "qa-omantel" /
+# "omantel-platform" from the chart's bootstrapping defaults.
+variable "qa_fixtures_namespace" {
+  type        = string
+  description = "QA fixtures namespace name. Inert when qa_fixtures_enabled='false'. catalyst-api derives 'qa-<first-FQDN-label>' from SovereignFQDN at provision time."
+  default     = "qa-default"
+  validation {
+    condition     = can(regex("^[a-z0-9]([a-z0-9-]*[a-z0-9])?$", var.qa_fixtures_namespace))
+    error_message = "qa_fixtures_namespace must be a valid DNS-1123 label."
+  }
+}
+
+variable "qa_organization" {
+  type        = string
+  description = "qa-fixtures Organization CR name. Inert when qa_fixtures_enabled='false'. catalyst-api derives '<first-FQDN-label>-platform' from SovereignFQDN at provision time."
+  default     = "default-platform"
+  validation {
+    condition     = can(regex("^[a-z0-9]([a-z0-9-]*[a-z0-9])?$", var.qa_organization))
+    error_message = "qa_organization must be a valid DNS-1123 label."
+  }
+}
+
 # ── Multi-domain Sovereign (issue #827, parent epic #825) ─────────────────
 #
 # The Sovereign supports N parent zones, NOT one. The wizard captures the

--- a/products/catalyst/bootstrap/api/internal/provisioner/provisioner.go
+++ b/products/catalyst/bootstrap/api/internal/provisioner/provisioner.go
@@ -228,6 +228,49 @@ type Request struct {
 	// checkbox.
 	MarketplaceEnabled bool `json:"marketplaceEnabled"`
 
+	// QATestEnabled — when true, bp-catalyst-platform's qaFixtures stack
+	// (qa-<sov> namespace + qa-wp Application + Continuum CR + CNPGPair
+	// + PDM CRs + ScheduledBackup + status-seeder Jobs + tier-bound
+	// UserAccess seeder) renders so the qa-loop matrix Test Executor
+	// finds every Sovereign-side fixture it asserts on. Default false —
+	// customer-facing Sovereigns NEVER auto-enable this. QA Sovereigns
+	// (omantel.biz, qa.<anything>) provision with `qaTestEnabled: true`.
+	//
+	// Threaded into tofu via var.qa_fixtures_enabled +
+	// var.qa_test_session_enabled + var.qa_fixtures_namespace +
+	// var.qa_organization, then into the bootstrap-kit Flux Kustomization
+	// postBuild.substitute as QA_FIXTURES_ENABLED / QA_TEST_SESSION_ENABLED
+	// / QA_FIXTURES_NAMESPACE / QA_ORGANIZATION (the four envsubst
+	// placeholders the chart reads at clusters/_template/bootstrap-kit/
+	// 13-bp-catalyst-platform.yaml lines 496/510/511/519).
+	//
+	// Per docs/INVIOLABLE-PRINCIPLES.md #4 (never hardcode), the namespace
+	// and organization names DERIVE from SovereignFQDN's first label at
+	// writeTfvars() time — `qa-<label>` and `<label>-platform`. There is
+	// no chart-side default of "qa-omantel" / "omantel-platform" leaking
+	// onto a non-omantel QA Sovereign.
+	//
+	// Fix #73 (qa-loop bounded-cycle iter-16): provision #7 came up
+	// zero-touch but qaFixtures defaulted false because the provisioner
+	// never threaded the toggle. ~140 matrix TCs were inherently fixture-
+	// blocked. This field is the canonical seam.
+	QATestEnabled bool `json:"qaTestEnabled"`
+
+	// QAFixturesNamespace — explicit override for the qa-fixtures
+	// namespace name. Empty (default) → derived from SovereignFQDN's
+	// first label as "qa-<label>" at writeTfvars() time. Operator may
+	// override when a Sovereign hosts multiple isolated QA tenants
+	// (extremely rare; reserved for future use). Ignored when
+	// QATestEnabled=false.
+	QAFixturesNamespace string `json:"qaFixturesNamespace,omitempty"`
+
+	// QAOrganization — explicit override for the qa-fixtures Organization
+	// name (Organization.metadata.name in the qa-fixtures stack). Empty
+	// (default) → derived from SovereignFQDN's first label as
+	// "<label>-platform" at writeTfvars() time. Ignored when
+	// QATestEnabled=false.
+	QAOrganization string `json:"qaOrganization,omitempty"`
+
 	// ClusterMeshName + ClusterMeshID — Cilium ClusterMesh per-Sovereign
 	// peer anchors (#1101 EPIC-6 multi-region DR). Both empty/zero =
 	// single-cluster Sovereign (not in a mesh). When set, must match the
@@ -1151,6 +1194,27 @@ func writeTfvars(deployDir string, req Request) error {
 		// time without quoting surprises.
 		"marketplace_enabled": map[bool]string{true: "true", false: "false"}[req.MarketplaceEnabled],
 
+		// QA fixtures auto-enable (Fix #73 — qa-loop bounded-cycle iter-16).
+		// Stringified for symmetric reasons as marketplace_enabled. When
+		// QATestEnabled=true the bp-catalyst-platform qaFixtures stack
+		// renders on the Sovereign so the qa-loop matrix executor finds
+		// every fixture (qa-<label> ns + qa-wp Application + Continuum CR
+		// + CNPGPair + PDM CRs + tier-bound UserAccess seeder).
+		// Customer-facing Sovereigns provision with QATestEnabled=false
+		// (default) → no fixture artifacts.
+		"qa_fixtures_enabled":     map[bool]string{true: "true", false: "false"}[req.QATestEnabled],
+		"qa_test_session_enabled": map[bool]string{true: "true", false: "false"}[req.QATestEnabled],
+
+		// QA namespace + Organization names — derived from the Sovereign
+		// FQDN's first label at provision time per principle #4 (never
+		// hardcode). The chart's defaults (qa-omantel / omantel-platform)
+		// are correct ONLY for omantel.biz and would leak onto every other
+		// QA Sovereign without this derivation. Operator may override
+		// via Request.QAFixturesNamespace / QAOrganization for the rare
+		// multi-tenant-per-Sovereign QA case.
+		"qa_fixtures_namespace": deriveQAFixturesNamespace(req),
+		"qa_organization":       deriveQAOrganization(req),
+
 		// Cilium ClusterMesh per-Sovereign peer anchors (#1101 EPIC-6).
 		// Empty + 0 = not in a mesh. Tofu validates id ∈ [0, 255].
 		"cluster_mesh_name": req.ClusterMeshName,
@@ -1659,4 +1723,73 @@ func mapDomainModeForTofu(wizardMode string) string {
 		return "pool"
 	}
 	return "byo"
+}
+
+// deriveQAFixturesNamespace returns the qa-fixtures namespace name to thread
+// into the bootstrap-kit Kustomization's QA_FIXTURES_NAMESPACE substitute
+// envvar. Resolution order:
+//
+//  1. req.QAFixturesNamespace if non-empty (operator override).
+//  2. "qa-<first-label-of-FQDN>" derived from req.SovereignFQDN — e.g.
+//     "omantel.biz" → "qa-omantel", "qa.example.com" → "qa-qa".
+//  3. "qa-default" fallback when SovereignFQDN is empty (defensive — the
+//     Validate() pass already guarantees non-empty FQDN at provision time).
+//
+// Per docs/INVIOLABLE-PRINCIPLES.md #4 (never hardcode), the chart's default
+// of "qa-omantel" is correct ONLY for omantel.biz; deriving from FQDN here
+// guarantees every QA Sovereign gets its own unambiguous namespace name
+// without relying on operator-set values.
+//
+// When req.QATestEnabled=false this value still computes (cheap) but is
+// inert: the chart's `qaFixtures.enabled: false` short-circuits before
+// the namespace name is materialised.
+func deriveQAFixturesNamespace(req Request) string {
+	if s := strings.TrimSpace(req.QAFixturesNamespace); s != "" {
+		return s
+	}
+	label := firstFQDNLabel(req.SovereignFQDN)
+	if label == "" {
+		return "qa-default"
+	}
+	return "qa-" + label
+}
+
+// deriveQAOrganization returns the qa-fixtures Organization CR name (the
+// `organization` chart value at clusters/_template/bootstrap-kit/
+// 13-bp-catalyst-platform.yaml line 519). Same resolution shape as
+// deriveQAFixturesNamespace: explicit override → derived "<label>-platform"
+// → "default-platform" defensive fallback.
+//
+// "default-platform" is the safe degenerate value (validates against the
+// Organization CRD's name regex `^[a-z0-9]([a-z0-9-]*[a-z0-9])?$` and
+// avoids any cross-Sovereign collision because Validate() blocks
+// SovereignFQDN-empty requests upstream).
+func deriveQAOrganization(req Request) string {
+	if s := strings.TrimSpace(req.QAOrganization); s != "" {
+		return s
+	}
+	label := firstFQDNLabel(req.SovereignFQDN)
+	if label == "" {
+		return "default-platform"
+	}
+	return label + "-platform"
+}
+
+// firstFQDNLabel returns the first DNS label of an FQDN — "omantel" from
+// "omantel.biz", "qa" from "qa.example.com", "" from "" or a single-label
+// input (single-label inputs are caught upstream by the FQDN regex
+// validator at variables.tf line 14, but the helper degrades gracefully
+// here so unit tests against partial requests don't panic).
+func firstFQDNLabel(fqdn string) string {
+	s := strings.ToLower(strings.TrimSpace(fqdn))
+	if s == "" {
+		return ""
+	}
+	if i := strings.Index(s, "."); i > 0 {
+		return s[:i]
+	}
+	// No dot — return as-is. The Validate() FQDN regex rejects single-
+	// label inputs upstream so this branch is unreachable in normal
+	// operation; kept as a non-panicking fallback for unit tests.
+	return s
 }

--- a/products/catalyst/bootstrap/api/internal/provisioner/provisioner_test.go
+++ b/products/catalyst/bootstrap/api/internal/provisioner/provisioner_test.go
@@ -552,3 +552,161 @@ func TestWriteTfvars_EmitsSingularSizesWhenSet(t *testing.T) {
 		t.Fatalf("worker_size must round-trip operator override: got %q want cpx41", v)
 	}
 }
+
+// TestWriteTfvars_QAFixtures_DefaultDisabled proves writeTfvars emits
+// qa_fixtures_enabled="false" + qa_test_session_enabled="false" when the
+// caller does NOT set Request.QATestEnabled. This is the customer-Sovereign
+// invariant: a zero-touch provision MUST NOT spawn the qaFixtures stack
+// (qa-<sov> ns + qa-wp Application + Continuum CR + CNPGPair + PDM CRs +
+// status-seeder Jobs + tier-bound UserAccess seeder) on a customer's
+// production Sovereign — those resources are QA scaffolding, not customer
+// workloads. Fix #73 root-cause: the provisioner never threaded the
+// toggle so the chart's `${QA_FIXTURES_ENABLED:-false}` default fired
+// uniformly — including on QA Sovereigns where ~140 matrix TCs depend
+// on the fixtures being present.
+func TestWriteTfvars_QAFixtures_DefaultDisabled(t *testing.T) {
+	dir, err := os.MkdirTemp("", "writeTfvars-qa-*")
+	if err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	defer os.RemoveAll(dir)
+
+	req := Request{
+		SovereignFQDN:    "acme-customer.openova.io",
+		OrgName:          "Acme",
+		OrgEmail:         "ops@acme.io",
+		HetznerToken:     "tok",
+		HetznerProjectID: "p1",
+		Region:           "fsn1",
+		WorkerCount:      2,
+		// QATestEnabled intentionally false (customer Sovereign).
+	}
+	if err := writeTfvars(dir, req); err != nil {
+		t.Fatalf("writeTfvars: %v", err)
+	}
+	raw, err := os.ReadFile(dir + "/tofu.auto.tfvars.json")
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	var parsed map[string]any
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if v, _ := parsed["qa_fixtures_enabled"].(string); v != "false" {
+		t.Fatalf("qa_fixtures_enabled MUST default 'false' on customer Sovereigns, got %q", v)
+	}
+	if v, _ := parsed["qa_test_session_enabled"].(string); v != "false" {
+		t.Fatalf("qa_test_session_enabled MUST default 'false' on customer Sovereigns, got %q", v)
+	}
+}
+
+// TestWriteTfvars_QAFixtures_EnabledDerivesNamespaceAndOrg proves that when
+// QATestEnabled=true, writeTfvars emits qa_fixtures_enabled="true" AND
+// derives qa_fixtures_namespace + qa_organization from the SovereignFQDN's
+// first DNS label per docs/INVIOLABLE-PRINCIPLES.md #4 (never hardcode).
+//
+// "qa.example.com" → "qa-qa" / "qa-platform"  (first label is "qa")
+// "omantel.biz"    → "qa-omantel" / "omantel-platform"
+// "demo.openova.io" → "qa-demo" / "demo-platform"
+//
+// Without this derivation the chart's bootstrapping defaults
+// ("qa-omantel" / "omantel-platform") would leak onto every QA Sovereign
+// — exactly the cross-Sovereign collision shape principle #4 forbids.
+func TestWriteTfvars_QAFixtures_EnabledDerivesNamespaceAndOrg(t *testing.T) {
+	cases := []struct {
+		name        string
+		fqdn        string
+		wantNs      string
+		wantOrgName string
+	}{
+		{name: "omantel", fqdn: "omantel.biz", wantNs: "qa-omantel", wantOrgName: "omantel-platform"},
+		{name: "qa-prefix", fqdn: "qa.example.com", wantNs: "qa-qa", wantOrgName: "qa-platform"},
+		{name: "demo-openova", fqdn: "demo.openova.io", wantNs: "qa-demo", wantOrgName: "demo-platform"},
+		{name: "uppercase-input-normalised", fqdn: "QA.Example.COM", wantNs: "qa-qa", wantOrgName: "qa-platform"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir, err := os.MkdirTemp("", "writeTfvars-qa-on-*")
+			if err != nil {
+				t.Fatalf("mkdir: %v", err)
+			}
+			defer os.RemoveAll(dir)
+
+			req := Request{
+				SovereignFQDN:    tc.fqdn,
+				OrgName:          "QA",
+				OrgEmail:         "qa@openova.io",
+				HetznerToken:     "tok",
+				HetznerProjectID: "p1",
+				Region:           "fsn1",
+				WorkerCount:      2,
+				QATestEnabled:    true,
+			}
+			if err := writeTfvars(dir, req); err != nil {
+				t.Fatalf("writeTfvars: %v", err)
+			}
+			raw, err := os.ReadFile(dir + "/tofu.auto.tfvars.json")
+			if err != nil {
+				t.Fatalf("read: %v", err)
+			}
+			var parsed map[string]any
+			if err := json.Unmarshal(raw, &parsed); err != nil {
+				t.Fatalf("parse: %v", err)
+			}
+			if v, _ := parsed["qa_fixtures_enabled"].(string); v != "true" {
+				t.Errorf("qa_fixtures_enabled: got %q want \"true\"", v)
+			}
+			if v, _ := parsed["qa_test_session_enabled"].(string); v != "true" {
+				t.Errorf("qa_test_session_enabled: got %q want \"true\"", v)
+			}
+			if v, _ := parsed["qa_fixtures_namespace"].(string); v != tc.wantNs {
+				t.Errorf("qa_fixtures_namespace: got %q want %q (derived from FQDN first label)", v, tc.wantNs)
+			}
+			if v, _ := parsed["qa_organization"].(string); v != tc.wantOrgName {
+				t.Errorf("qa_organization: got %q want %q (derived from FQDN first label)", v, tc.wantOrgName)
+			}
+		})
+	}
+}
+
+// TestWriteTfvars_QAFixtures_OperatorOverrideWins proves that explicit
+// Request.QAFixturesNamespace / QAOrganization values take precedence
+// over the FQDN-derived defaults. Reserved for the rare future case
+// where one Sovereign hosts multiple isolated QA tenants.
+func TestWriteTfvars_QAFixtures_OperatorOverrideWins(t *testing.T) {
+	dir, err := os.MkdirTemp("", "writeTfvars-qa-override-*")
+	if err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	defer os.RemoveAll(dir)
+
+	req := Request{
+		SovereignFQDN:       "omantel.biz",
+		OrgName:             "QA",
+		OrgEmail:            "qa@openova.io",
+		HetznerToken:        "tok",
+		HetznerProjectID:    "p1",
+		Region:              "fsn1",
+		WorkerCount:         2,
+		QATestEnabled:       true,
+		QAFixturesNamespace: "qa-team-alpha",
+		QAOrganization:      "team-alpha-platform",
+	}
+	if err := writeTfvars(dir, req); err != nil {
+		t.Fatalf("writeTfvars: %v", err)
+	}
+	raw, err := os.ReadFile(dir + "/tofu.auto.tfvars.json")
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	var parsed map[string]any
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if v, _ := parsed["qa_fixtures_namespace"].(string); v != "qa-team-alpha" {
+		t.Errorf("qa_fixtures_namespace: operator override must win, got %q", v)
+	}
+	if v, _ := parsed["qa_organization"].(string); v != "team-alpha-platform" {
+		t.Errorf("qa_organization: operator override must win, got %q", v)
+	}
+}


### PR DESCRIPTION
## Summary

Provision #7 came up zero-touch but the bp-catalyst-platform `qaFixtures` stack stayed off because the chart template defaults to `${QA_FIXTURES_ENABLED:-false}` and the catalyst-api provisioner never threaded the toggle. Result: ~140 of the qa-loop matrix's TCs were inherently fixture-blocked on every QA Sovereign.

This PR adds a server-controlled `qaTestEnabled` flag on the provisioning payload. When `true`, the provisioner threads `QA_FIXTURES_ENABLED=true` + `QA_TEST_SESSION_ENABLED=true` + derived `QA_FIXTURES_NAMESPACE` + `QA_ORGANIZATION` into the bootstrap-kit Flux Kustomization's `postBuild.substitute` so the chart's qa-fixtures stack renders on the Sovereign.

## Payload field shape

New `Request` fields in `internal/provisioner/provisioner.go`:

```go
QATestEnabled       bool   `json:"qaTestEnabled"`             // default false
QAFixturesNamespace string `json:"qaFixturesNamespace,omitempty"` // default derived
QAOrganization      string `json:"qaOrganization,omitempty"`      // default derived
```

`QAFixturesNamespace` and `QAOrganization` derive from `SovereignFQDN`'s first DNS label per [INVIOLABLE-PRINCIPLES.md #4](docs/INVIOLABLE-PRINCIPLES.md) (never hardcode):

| SovereignFQDN | QA_FIXTURES_NAMESPACE | QA_ORGANIZATION |
|---|---|---|
| `omantel.biz` | `qa-omantel` | `omantel-platform` |
| `qa.example.com` | `qa-qa` | `qa-platform` |
| `demo.openova.io` | `qa-demo` | `demo-platform` |

The chart's bootstrap defaults (`qa-omantel` / `omantel-platform`) are correct ONLY for omantel.biz; deriving here guarantees a non-omantel QA Sovereign never inherits them.

## Default behaviour: customer Sovereigns OFF

`QATestEnabled` defaults to `false`. Customer-facing Sovereigns provisioning without the flag get NO `qa-fixtures` artifacts (qa-* namespace, qa-wp Application, Continuum CR, CNPGPair, PDM CRs, status-seeder Jobs, tier-bound UserAccess seeder). The fixture stack is QA scaffolding, not customer workload.

## QA Sovereign provisioning command

```bash
curl -X POST https://console.openova.io/sovereign/api/v1/deployments \
  -H 'Content-Type: application/json' \
  -d '{
    "orgName": "OpenOva QA",
    "orgEmail": "qa@openova.io",
    "sovereignFQDN": "omantel.biz",
    "sovereignDomainMode": "byo",
    "hetznerToken": "...",
    "hetznerProjectID": "...",
    "region": "fsn1",
    "sshPublicKey": "ssh-ed25519 ...",
    "qaTestEnabled": true
  }'
```

## Wiring

| Layer | File | Change |
|---|---|---|
| Go provisioner | `products/catalyst/bootstrap/api/internal/provisioner/provisioner.go` | Request struct + writeTfvars + deriveQAFixturesNamespace + deriveQAOrganization + firstFQDNLabel |
| Tofu vars | `infra/hetzner/variables.tf` | 4 new string vars (`true`/`false` validated) |
| Cloud-init | `infra/hetzner/cloudinit-control-plane.tftpl` | 4 substitute envvars on bootstrap-kit Kustomization |
| Tofu wiring | `infra/hetzner/main.tf` | pass new vars into both templatefile invocations (primary + per-secondary-region) |
| Tests | `products/catalyst/bootstrap/api/internal/provisioner/provisioner_test.go` | 3 new tests (default-disabled, enabled-derivation matrix, operator-override-wins) |

## Test plan

- [x] `go test ./internal/provisioner/...` PASS (0.019s)
- [x] `go build ./...` clean
- [ ] Live verification: provision a fresh QA Sovereign with `qaTestEnabled: true` -> `kubectl get ns qa-<label>` returns the namespace
- [ ] Live verification: provision a customer Sovereign with `qaTestEnabled` omitted -> NO `qa-*` namespace exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Claimed TCs

`qaTestEnabled` is the **master gate** for the entire qa-fixtures stack.
Without it: no `qa-wp` Application CR, no `qa-omantel` namespace, no QA
UserAccess CRs. ~140 of the 410 matrix TCs reference these resources
directly.

The list below is the iter-16 FAIL subset whose URL contains `qa-wp`,
`qa-wordpress`, `qa-omantel`, or `useraccess` (80 TCs). All flip from
fixture-blocked to runnable once the flag flips on.

Note on overlap with PR #1304: some claimed TCs (TC-103, TC-216, TC-262, etc)
also appear in #1304's claim set. This is correct — #1304 fixes the chart
RENDERER (so qa-wp HR materializes correctly when fixtures are enabled);
this PR turns the flag ON. Both are required.

- TC-029
- TC-030
- TC-032
- TC-036
- TC-068
- TC-069
- TC-070
- TC-071
- TC-072
- TC-075
- TC-076
- TC-077
- TC-078
- TC-079
- TC-080
- TC-101
- TC-102
- TC-103
- TC-106
- TC-107
- TC-108
- TC-109
- TC-112
- TC-113
- TC-132
- TC-186
- TC-187
- TC-197
- TC-199
- TC-200
- TC-201
- TC-202
- TC-204
- TC-205
- TC-206
- TC-207
- TC-210
- TC-212
- TC-215
- TC-216
- TC-217
- TC-218
- TC-220
- TC-221
- TC-222
- TC-223
- TC-224
- TC-225
- TC-226
- TC-227
- TC-228
- TC-229
- TC-241
- TC-243
- TC-244
- TC-245
- TC-246
- TC-248
- TC-252
- TC-255
- TC-257
- TC-258
- TC-262
- TC-263
- TC-264
- TC-266
- TC-268
- TC-269
- TC-277
- TC-279
- TC-307
- TC-308
- TC-309
- TC-310
- TC-311
- TC-337
- TC-338
- TC-346
- TC-348
- TC-376
