### PR TITLE
fix(bp-self-sovereign-cutover): Phase-0 secret probe idempotency fix (qa-loop bounded-cycle Wave 5 Fix #77, Gap A)

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -220,7 +220,21 @@ spec:
       #   matches), reads HARBOR_PASSWORD from the harbor-admin Secret
       #   already mirrored into `catalyst` ns by bp-harbor 1.2.14+.
       #   Adds `secrets: [update,patch]` to the runner ClusterRole.
-      version: 0.1.24
+      # 0.1.25: Step-06 Phase-0 probe brittleness fix (qa-loop bounded-
+      #   cycle Wave 5 Fix #77, Gap A). 0.1.24 used kubectl jsonpath
+      #   `{.data['.dockerconfigjson']}` which silently returns EMPTY
+      #   because kubectl interprets the leading dot inside the bracket
+      #   as a child accessor (escape `\.dockerconfigjson` would work
+      #   but is a footgun). Caught live on omantel prov #7 2026-05-10:
+      #   `cutover-helmrepository-patches` Job FAILED 4× with
+      #   `FATAL: ghcr-pull Secret has no .dockerconfigjson key —
+      #   cloud-init did not run?` despite `kubectl get secret -o yaml`
+      #   showing the key present. 0.1.25 replaces the probe with
+      #   `kubectl get -o json | jq -r --arg k ...` (escape-free), adds
+      #   a 60s wait-loop for Reflector lag, and falls back to the
+      #   source namespace (flux-system) if the local copy is still
+      #   missing. Idempotent path unchanged.
+      version: 0.1.25
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-self-sovereign-cutover
-version: 0.1.24
+version: 0.1.25
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/templates/06-helmrepository-patches-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/06-helmrepository-patches-job.yaml
@@ -138,14 +138,54 @@ data:
               exit 1
             fi
 
-            # Bracket-form jsonpath quotes the key literally so the
-            # leading dot in `.dockerconfigjson` is not interpreted as
-            # path traversal.
-            existing_b64=$(kubectl get secret "${GHCR_PULL_SECRET_NAME}" \
-              -n "${GHCR_PULL_SECRET_NAMESPACE}" \
-              -o "jsonpath={.data['${GHCR_PULL_SECRET_KEY}']}" 2>/dev/null || echo "")
+            # Read the dockerconfigjson via `-o json | jq` (NOT kubectl
+            # jsonpath bracket-form). kubectl jsonpath interprets the
+            # leading dot in `.dockerconfigjson` as a child accessor
+            # INSIDE the bracket, returning empty even though the key
+            # exists. Fix #77 (Gap A) — caught live on omantel prov #7
+            # 2026-05-10: Job logged
+            # `FATAL: ghcr-pull Secret has no .dockerconfigjson key`
+            # despite `kubectl get secret ... -o yaml` clearly showing
+            # the key present. Confirmed reproducer:
+            #   kubectl get secret ghcr-pull -n flux-system \
+            #     -o "jsonpath={.data['.dockerconfigjson']}"   → empty
+            #   kubectl get secret ghcr-pull -n flux-system \
+            #     -o "jsonpath={.data['\.dockerconfigjson']}"  → b64
+            # Using `-o json | jq` avoids the escape ambiguity entirely
+            # and works regardless of the literal key name.
+            #
+            # Wait-loop (up to 60s) handles the case where Reflector has
+            # not yet propagated the Secret into ${GHCR_PULL_SECRET_NAMESPACE}
+            # when this Job stamps. Falls back to the source namespace
+            # (flux-system, where cloud-init writes the original) if the
+            # local copy is still missing after the timeout.
+            read_secret_key() {
+              # $1 = namespace
+              # Echoes base64 value of GHCR_PULL_SECRET_KEY or empty.
+              kubectl get secret "${GHCR_PULL_SECRET_NAME}" -n "$1" -o json 2>/dev/null \
+                | jq -r --arg k "${GHCR_PULL_SECRET_KEY}" '.data[$k] // empty'
+            }
+            existing_b64=""
+            target_ns="${GHCR_PULL_SECRET_NAMESPACE}"
+            for i in $(seq 1 12); do
+              existing_b64=$(read_secret_key "${target_ns}")
+              if [ -n "${existing_b64}" ]; then
+                break
+              fi
+              echo "[helmrepository-patches] Phase-0: ${target_ns}/${GHCR_PULL_SECRET_NAME} key ${GHCR_PULL_SECRET_KEY} not yet readable (attempt ${i}/12) — sleeping 5s"
+              sleep 5
+            done
+            if [ -z "${existing_b64}" ] && [ "${target_ns}" != "flux-system" ]; then
+              # Fallback: read from the source ns (flux-system) where
+              # cloud-init wrote the original. Reflector copies into
+              # ${GHCR_PULL_SECRET_NAMESPACE} but the source is always
+              # readable by the runner ClusterRole.
+              echo "[helmrepository-patches] Phase-0: falling back to flux-system/${GHCR_PULL_SECRET_NAME} (Reflector lag suspected)"
+              target_ns="flux-system"
+              existing_b64=$(read_secret_key "${target_ns}")
+            fi
             if [ -z "${existing_b64}" ]; then
-              echo "[helmrepository-patches] FATAL: ghcr-pull Secret has no ${GHCR_PULL_SECRET_KEY} key — cloud-init did not run?" >&2
+              echo "[helmrepository-patches] FATAL: ${GHCR_PULL_SECRET_NAME} Secret has no ${GHCR_PULL_SECRET_KEY} key in ${GHCR_PULL_SECRET_NAMESPACE} or flux-system after 60s — cloud-init did not run?" >&2
               exit 1
             fi
 

--- a/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
+++ b/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
@@ -320,4 +320,43 @@ if ! grep -q 'clusters/_template/bootstrap-kit' "$TMP/render.yaml"; then
 fi
 echo "  PASS (Step-06 pushes YAML edit to local Gitea)"
 
+echo "[cutover-contract] Case 18: Step-06 Phase-0 probe is escape-free + has wait-loop (Fix #77, Gap A)"
+# 0.1.24 used kubectl jsonpath `{.data['.dockerconfigjson']}` which
+# silently returns EMPTY because the leading dot inside bracket-form
+# is interpreted as a child accessor. 0.1.25 replaces the probe with
+# `kubectl get -o json | jq -r --arg k` and adds a wait-loop +
+# flux-system fallback for Reflector lag.
+#
+# Guard against future regressions that re-introduce the brittle
+# jsonpath form against the dockerconfigjson key. The check anchors on
+# `-o "jsonpath=` so the documentation example in the inline-comment
+# block (which appears verbatim as `-o "jsonpath={.data['.dockerconfigjson']}"`
+# in the comment for posterity, prefixed with a `#` and three leading
+# spaces of comment indentation) is excluded — comment-prefixed lines
+# never start with `kubectl`/`-o` at any indent level recognized by
+# this check.
+if grep -E "^[[:space:]]*-o[[:space:]]+\"jsonpath=\{\.data\['.dockerconfigjson'\]\}\"" "$TMP/render.yaml" >/dev/null; then
+  echo "FAIL: Step-06 Phase-0 still uses brittle jsonpath bracket-form for .dockerconfigjson (Fix #77, Gap A)" >&2
+  exit 1
+fi
+# Must use jq-based read OR escaped jsonpath. Assert the new pattern.
+if ! grep -E "jq -r --arg k .* GHCR_PULL_SECRET_KEY|jq -r --arg k \"\\\$\\{GHCR_PULL_SECRET_KEY\\}\"" "$TMP/render.yaml" >/dev/null; then
+  # Looser fallback: any `jq -r --arg k` reading .data[$k] is acceptable.
+  if ! grep -E "jq -r --arg k .* '\.data\[\\\$k\]" "$TMP/render.yaml" >/dev/null; then
+    echo "FAIL: Step-06 Phase-0 missing jq-based read of .data[\$k] (Fix #77, Gap A)" >&2
+    exit 1
+  fi
+fi
+# Wait-loop + fallback presence — assert Phase-0 explicitly handles
+# Reflector lag without cratering on first miss.
+if ! grep -q 'Reflector lag suspected' "$TMP/render.yaml"; then
+  echo "FAIL: Step-06 Phase-0 missing Reflector-lag fallback to flux-system (Fix #77, Gap A)" >&2
+  exit 1
+fi
+if ! grep -q 'sleep 5' "$TMP/render.yaml"; then
+  echo "FAIL: Step-06 Phase-0 missing wait-loop sleep (Fix #77, Gap A)" >&2
+  exit 1
+fi
+echo "  PASS (Phase-0 probe escape-free + wait-loop + fallback)"
+
 echo "[cutover-contract] All gates green."


### PR DESCRIPTION
## Summary

PR #1301 (chart 0.1.24) added Phase-0 to Step-06 to merge `harbor.<sov-fqdn>` auth into the `ghcr-pull` dockerconfigjson Secret. The probe used kubectl jsonpath bracket-form `{.data['.dockerconfigjson']}` which **silently returns EMPTY** because kubectl interprets the leading dot inside the bracket as a child accessor.

Caught live on omantel prov #7 2026-05-10: `cutover-helmrepository-patches` Job FAILED 4× with `FATAL: ghcr-pull Secret has no .dockerconfigjson key — cloud-init did not run?` despite `kubectl get secret -o yaml` clearly showing the key present.

## Root cause (live reproducer)

```
kubectl get secret ghcr-pull -n flux-system \
  -o "jsonpath={.data['.dockerconfigjson']}"   --> empty (BUG)
kubectl get secret ghcr-pull -n flux-system \
  -o "jsonpath={.data['\.dockerconfigjson']}"  --> base64 payload (escape works)
kubectl get secret ghcr-pull -n flux-system -o json \
  | jq -r '.data[".dockerconfigjson"]'         --> base64 payload (escape-free)
```

The leading `.` in `.dockerconfigjson` is part of the literal field name (set by the `kubernetes.io/dockerconfigjson` Secret type). kubectl's bracket-form jsonpath treats it as a path traversal accessor unless escaped with `\.` — but `\.` inside a bash double-quoted string is a footgun (escape consumed by the shell first).

## Fix

`platform/self-sovereign-cutover/chart/templates/06-helmrepository-patches-job.yaml`:

1. Replace probe with `kubectl get -o json | jq -r --arg k "$GHCR_PULL_SECRET_KEY" '.data[$k] // empty'` (escape-free, works regardless of leading dots).
2. Add 60s wait-loop (12× 5s) for Reflector lag — handles fresh-provision races where `catalyst/ghcr-pull` hasn't yet been mirrored from `flux-system`.
3. Fall back to source namespace `flux-system` if the local copy is still missing after timeout.
4. Idempotency path unchanged — Phase-0 still skips cleanly when `harbor.<sov-fqdn>` auth already matches.

## Live job log (prov #7, before fix)

```
$ kubectl --context=omantel -n catalyst get job | grep helmrepo
cutover-helmrepository-patches-1778431704     Failed     0/1           19m

$ kubectl --context=omantel -n catalyst logs cutover-helmrepository-patches-1778431704-7km9z
[helmrepository-patches] upstream=oci://ghcr.io/openova-io -> local=oci://harbor.omantel.biz/openova-io
[helmrepository-patches] FATAL: ghcr-pull Secret has no .dockerconfigjson key — cloud-init did not run?

$ kubectl --context=omantel -n flux-system get secret ghcr-pull -o jsonpath='{.data.\.dockerconfigjson}' | base64 -d | jq '.auths | keys'
[
  "ghcr.io"   <-- key IS present, but jsonpath bracket-form returned empty
]
```

## Idempotency proof (real-bytes dry-run against live omantel ghcr-pull)

```
PROBE-OK: jq read existing_b64 (248 bytes)
pre-merge auths keys:  ["ghcr.io"]
post-merge auths keys: ["ghcr.io","harbor.omantel.biz"]
re-run idempotency check: WOULD SKIP (already matches)
```

## Test plan

- [x] `helm template smoke .` renders cleanly (1848 lines)
- [x] `bash tests/cutover-contract.sh` — **18/18 gates PASS** (was 17, added gate 18)
- [x] Gate 18 asserts: brittle `-o "jsonpath={.data['.dockerconfigjson']}"` form is absent from rendered output, jq-based probe present, wait-loop sleep present, Reflector-lag fallback present
- [x] Real-bytes simulation against live omantel `flux-system/ghcr-pull` secret — probe + merge + idempotent skip all OK
- [ ] Live verification: next fresh otechN provision Step-06 completes without manual intervention (will validate on next bounded-cycle wipe + re-provision)

## Files

- `platform/self-sovereign-cutover/chart/Chart.yaml` (0.1.24 → 0.1.25)
- `platform/self-sovereign-cutover/chart/templates/06-helmrepository-patches-job.yaml` (Phase-0 probe rewrite)
- `platform/self-sovereign-cutover/chart/tests/cutover-contract.sh` (gate 18)
- `clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml` (pin 0.1.24 → 0.1.25 + changelog comment)

Refs: Wave 5 Fix #77 / Gap A — bounded-cycle audit prov #7 (`.claude/qa-loop-state/bounded-cycle-audit-prov7.md` §2 Gap A). Closes the regression introduced by #1301.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Claimed TCs

_None — infrastructure fix that enables but doesn't directly unblock any specific TC. See `/home/openova/repos/openova-private/.claude/qa-loop-state/wave4-5-tc-backfill.md` for reasoning._

(Phase-0 jsonpath bracket-form idempotency bug in cutover Job. No TC
asserts on the cutover Job specifically.)
