### PR TITLE
fix(bp-k8s-ws-proxy): bootstrap Job for k8s-ws-proxy-hmac Secret (qa-loop bounded-cycle Wave 5 Fix #78, Gap E)

### DIFF
--- a/clusters/_template/bootstrap-kit/51-bp-k8s-ws-proxy.yaml
+++ b/clusters/_template/bootstrap-kit/51-bp-k8s-ws-proxy.yaml
@@ -64,7 +64,15 @@ spec:
       # in values.yaml. The imagePullSecrets default is required so
       # omantel pods can pull from private GHCR without per-Sovereign
       # overlay (the catalyst-system `ghcr-pull` secret is canonical).
-      version: 0.1.5
+      # 0.1.6 (qa-loop bounded-cycle Wave 5 Fix #78, Gap E): adds
+      # pre-install hook-weight -10 Job that auto-generates the
+      # `k8s-ws-proxy-hmac` Secret from /dev/urandom when absent.
+      # Pre-this, every fresh Sovereign sat with three k8s-ws-proxy
+      # pods ContainerCreating forever — the chart referenced a
+      # Secret that nothing ever created. Idempotent on upgrade
+      # (preserves the existing key — rotating it would invalidate
+      # every in-flight catalyst-api signature).
+      version: 0.1.6
       sourceRef:
         kind: HelmRepository
         name: bp-k8s-ws-proxy

--- a/clusters/omantel.omani.works/bootstrap-kit/51-bp-k8s-ws-proxy.yaml
+++ b/clusters/omantel.omani.works/bootstrap-kit/51-bp-k8s-ws-proxy.yaml
@@ -38,7 +38,15 @@ spec:
       # 0.1.5: 0.1.4 (default imagePullSecrets) + CI auto-bumped
       # image.tag. imagePullSecrets default required for omantel pods
       # to pull from private GHCR.
-      version: 0.1.5
+      # 0.1.6 (qa-loop bounded-cycle Wave 5 Fix #78, Gap E): adds
+      # pre-install hook-weight -10 Job that auto-generates the
+      # `k8s-ws-proxy-hmac` Secret from /dev/urandom. Without this,
+      # every fresh Sovereign provision left k8s-ws-proxy pods stuck
+      # ContainerCreating forever — the chart referenced a Secret
+      # that nothing ever created. Idempotent on upgrade (preserves
+      # the existing key — rotating it would invalidate every
+      # in-flight catalyst-api signature).
+      version: 0.1.6
       sourceRef:
         kind: HelmRepository
         name: bp-k8s-ws-proxy

--- a/platform/k8s-ws-proxy/chart/Chart.yaml
+++ b/platform/k8s-ws-proxy/chart/Chart.yaml
@@ -14,7 +14,18 @@ name: bp-k8s-ws-proxy
 # 0.1.5 on merge (with the new image SHA in values.yaml). Slot pin
 # at 0.1.5 so omantel reconciles against the chart that carries
 # BOTH the imagePullSecrets default AND the new image SHA.
-version: 0.1.5
+# 0.1.6 (qa-loop bounded-cycle Wave 5 Fix #78, Gap E): adds
+# templates/hmac-bootstrap-job.yaml — a Helm pre-install/pre-upgrade
+# hook (weight -10) that auto-generates the `k8s-ws-proxy-hmac` Secret
+# from /dev/urandom when absent. Pre-this, on every fresh Sovereign
+# the DaemonSet pods sat ContainerCreating forever with
+# "secret k8s-ws-proxy-hmac not found" because the chart referenced
+# but never created it (audit prov #7 Gap E). Idempotent on upgrade
+# (preserves existing key — rotating it would invalidate every
+# in-flight catalyst-api signature). build-k8s-ws-proxy.yaml's promote
+# job will auto-bump this to 0.1.7 on merge with the new image SHA;
+# slot pins should be lifted to 0.1.7 once that promote runs.
+version: 0.1.6
 appVersion: "0.1.0"
 description: |
   Catalyst-authored Blueprint chart for the k8s-ws-proxy DaemonSet —

--- a/platform/k8s-ws-proxy/chart/templates/hmac-bootstrap-job.yaml
+++ b/platform/k8s-ws-proxy/chart/templates/hmac-bootstrap-job.yaml
@@ -1,0 +1,288 @@
+{{- /*
+HMAC Secret bootstrap Job (qa-loop bounded-cycle Wave 5 Fix #78, Gap E).
+
+ROOT CAUSE
+----------
+Pre-this-fix the chart's _helpers.tpl `bp-k8s-ws-proxy.hmacSecretName`
+fails-fast if `.Values.k8sWsProxy.hmacSecret.name` is empty, BUT with the
+default `name: k8s-ws-proxy-hmac` set in values.yaml, render proceeds and
+the DaemonSet mounts a Secret that NOTHING in the chart, sibling chart, or
+bootstrap-kit ever creates. On a fresh provision (prov #7 audit, Gap E)
+all three k8s-ws-proxy pods sat ContainerCreating for 25+ min with:
+
+   MountVolume.SetUp failed for volume "hmac-secret":
+     secret "k8s-ws-proxy-hmac" not found
+
+Impact: Phase-1 Sovereign Console in-browser kubectl/exec broken on every
+fresh Sovereign — operator UI's exec tunnel (catalyst-api ➜ k8s-ws-proxy
+DaemonSet) cannot mint signed URLs because the upstream caller and the
+DaemonSet have no shared HMAC key.
+
+FIX PATTERN
+-----------
+Helm pre-install/pre-upgrade Job (hook-weight: "-10" so it runs BEFORE
+the DaemonSet rolls) that:
+
+  1. Idempotency check — GET the target Secret. If it exists, exit 0
+     immediately (operator-pre-provisioned via SealedSecret + bp-sealed-
+     secrets reflector path is still respected; idempotent re-runs on
+     `helm upgrade` skip the generate path).
+  2. Generate 32 random bytes via `head -c 32 /dev/urandom`, pipe DIRECTLY
+     to `base64 | tr -d '\n'`, then INTO the JSON body posted to the
+     apiserver. Per global CLAUDE.md §10 the bytes are NEVER echoed to
+     stdout, NEVER written to a file outside the in-pod tmpfs, and never
+     leave the apiserver→kubelet→Job-pod path.
+  3. POST to /api/v1/namespaces/<ns>/secrets. On 409 Already-Exists treat
+     as success (race with operator pre-provision is benign). Any other
+     non-2xx is FATAL.
+
+The Job runs as a Helm pre-install AND pre-upgrade hook so:
+  - Fresh install: Secret created BEFORE DaemonSet → no ContainerCreating
+    blackout window.
+  - Helm upgrade: idempotent skip (Secret exists from prior install) →
+    HMAC key is preserved across chart upgrades. CRITICAL — rotating the
+    key would invalidate every in-flight catalyst-api signature, and the
+    chart upgrade path must not be a silent break.
+
+KEY ROTATION
+------------
+Operator-driven: `kubectl delete secret k8s-ws-proxy-hmac -n catalyst-
+system && flux reconcile helmrelease bp-k8s-ws-proxy -n flux-system` will
+trigger this Job to regenerate. Coupled rotation of the upstream caller's
+HMAC env var is the operator's responsibility — out of scope here.
+
+RBAC SPLIT
+----------
+Per memory/feedback_rbac_create_no_resourcenames.md: `create` MUST be in
+its own rule WITHOUT resourceNames. The combined-rule pattern (verbs:
+[create, get, patch] resourceNames: [k8s-ws-proxy-hmac]) was the silent
+root cause of bp-openbao 1.2.5..1.2.11's "POST 403 swallowed by
+busybox-wget" loop.
+
+CANONICAL SEAM
+--------------
+Modelled after platform/gitea/chart/templates/database-secret-sync-job.yaml:
+  - curlimages/curl:8.10.1 (alpine + curl + sh; no kubectl required;
+    proven image — bitnami/kubectl moved to sha256-only tags, rancher/
+    kubectl is distroless and has no /bin/sh).
+  - In-cluster ServiceAccount token from the projected
+    /var/run/secrets/kubernetes.io/serviceaccount path.
+  - Hook-weight 0 for SA/Role/RoleBinding (must exist before -10 Job
+    pod's API calls); -10 for the Job itself.
+  - hook-delete-policy: before-hook-creation,hook-succeeded — every
+    upgrade replaces the prior Job artefacts; succeeded ones are reaped.
+*/}}
+{{- if .Values.k8sWsProxy.enabled -}}
+{{- $secretName := include "bp-k8s-ws-proxy.hmacSecretName" . }}
+{{- $secretKey := .Values.k8sWsProxy.hmacSecret.key }}
+{{- $ns := .Release.Namespace }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: k8s-ws-proxy-hmac-bootstrap
+  namespace: {{ $ns }}
+  labels:
+    catalyst.openova.io/blueprint: bp-k8s-ws-proxy
+    catalyst.openova.io/component: hmac-bootstrap
+  annotations:
+    "helm.sh/hook": "pre-install,pre-upgrade"
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": "before-hook-creation"
+{{- with .Values.k8sWsProxy.imagePullSecrets }}
+imagePullSecrets:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+---
+# Per memory/feedback_rbac_create_no_resourcenames.md:
+# `create` is in a SEPARATE rule WITH NO resourceNames. The apiserver
+# rejects POST /secrets with 403 if `create` carries resourceNames, and
+# the silent failure historically wedged 6+ chart iterations of bp-openbao
+# debugging the wrong layer (busybox-wget exit codes, image versions,
+# etc.). Splitting the verbs makes the create path correct AND keeps the
+# read/update path scoped to ONLY this Secret name.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: k8s-ws-proxy-hmac-bootstrap
+  namespace: {{ $ns }}
+  labels:
+    catalyst.openova.io/blueprint: bp-k8s-ws-proxy
+    catalyst.openova.io/component: hmac-bootstrap
+  annotations:
+    "helm.sh/hook": "pre-install,pre-upgrade"
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": "before-hook-creation"
+rules:
+  # Rule 1: create — NO resourceNames (apiserver authz rejects otherwise).
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["create"]
+  # Rule 2: read/update — scoped to the single Secret this Job manages.
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames: [{{ $secretName | quote }}]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: k8s-ws-proxy-hmac-bootstrap
+  namespace: {{ $ns }}
+  labels:
+    catalyst.openova.io/blueprint: bp-k8s-ws-proxy
+    catalyst.openova.io/component: hmac-bootstrap
+  annotations:
+    "helm.sh/hook": "pre-install,pre-upgrade"
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": "before-hook-creation"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: k8s-ws-proxy-hmac-bootstrap
+subjects:
+  - kind: ServiceAccount
+    name: k8s-ws-proxy-hmac-bootstrap
+    namespace: {{ $ns }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: k8s-ws-proxy-hmac-bootstrap
+  namespace: {{ $ns }}
+  labels:
+    catalyst.openova.io/blueprint: bp-k8s-ws-proxy
+    catalyst.openova.io/component: hmac-bootstrap
+  annotations:
+    "helm.sh/hook": "pre-install,pre-upgrade"
+    "helm.sh/hook-weight": "-10"
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
+spec:
+  backoffLimit: 6
+  ttlSecondsAfterFinished: 300
+  template:
+    metadata:
+      labels:
+        catalyst.openova.io/blueprint: bp-k8s-ws-proxy
+        catalyst.openova.io/component: hmac-bootstrap
+    spec:
+      serviceAccountName: k8s-ws-proxy-hmac-bootstrap
+      restartPolicy: Never
+      {{- with .Values.k8sWsProxy.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: bootstrap
+          # curlimages/curl is the canonical Catalyst seam for in-chart
+          # k8s-API operations from a Job — alpine-based, has /bin/sh,
+          # has /dev/urandom, has base64. No kubectl dependency.
+          image: curlimages/curl:8.10.1
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: SECRET_NAME
+              value: {{ $secretName | quote }}
+            - name: SECRET_KEY
+              value: {{ $secretKey | quote }}
+            - name: NAMESPACE
+              value: {{ $ns | quote }}
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -eu
+              APISERVER="https://kubernetes.default.svc"
+              TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
+              CA=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+
+              echo "[hmac-bootstrap] target: ${NAMESPACE}/${SECRET_NAME} (key=${SECRET_KEY})"
+
+              # ─── Step 1: idempotency probe ─────────────────────────────
+              # GET /secrets/<name>. 200 = exists → operator pre-provisioned
+              # OR a prior install ran this Job → skip generate. 404 = not
+              # found → proceed to create. Any other code is FATAL.
+              code=$(curl -sS -o /tmp/probe.json -w '%{http_code}' \
+                --cacert "${CA}" \
+                -H "Authorization: Bearer ${TOKEN}" \
+                "${APISERVER}/api/v1/namespaces/${NAMESPACE}/secrets/${SECRET_NAME}")
+              if [ "${code}" = "200" ]; then
+                echo "[hmac-bootstrap] Secret already exists — idempotent skip (preserves HMAC across upgrades)"
+                exit 0
+              fi
+              if [ "${code}" != "404" ]; then
+                echo "[hmac-bootstrap] FATAL: idempotency probe returned HTTP ${code}" >&2
+                cat /tmp/probe.json >&2 || true
+                exit 1
+              fi
+
+              # ─── Step 2: generate 32 random bytes → base64 ──────────────
+              # CRITICAL (global CLAUDE.md §10): the HMAC bytes are NEVER
+              # echoed/cat/printed. /dev/urandom → base64 → variable
+              # consumed only by the JSON-builder printf. The Secret data
+              # field is itself base64 (k8s wire format) — so the value
+              # we POST is base64(<random_bytes>). The proxy decodes once
+              # via the ConfigMap-style projection (subPath), getting the
+              # raw 32 bytes back as the HMAC key file content.
+              HMAC_B64=$(head -c 32 /dev/urandom | base64 | tr -d '\n')
+              if [ -z "${HMAC_B64}" ]; then
+                echo "[hmac-bootstrap] FATAL: empty random output (no entropy?)" >&2
+                exit 1
+              fi
+              # The Secret data value must itself be base64 of the file
+              # content. We want the file content to BE the base64 of the
+              # raw bytes (a printable token), so the wire-format value
+              # is base64(base64(raw_bytes)).
+              WIRE_B64=$(printf '%s' "${HMAC_B64}" | base64 | tr -d '\n')
+
+              # ─── Step 3: POST Secret ────────────────────────────────────
+              BODY=$(printf '{"apiVersion":"v1","kind":"Secret","metadata":{"name":"%s","namespace":"%s","labels":{"catalyst.openova.io/blueprint":"bp-k8s-ws-proxy","catalyst.openova.io/component":"hmac-bootstrap","app.kubernetes.io/managed-by":"Helm"}},"type":"Opaque","data":{"%s":"%s"}}' \
+                "${SECRET_NAME}" "${NAMESPACE}" "${SECRET_KEY}" "${WIRE_B64}")
+              code=$(curl -sS -o /tmp/create.json -w '%{http_code}' \
+                --cacert "${CA}" \
+                -H "Authorization: Bearer ${TOKEN}" \
+                -H "Content-Type: application/json" \
+                -X POST --data "${BODY}" \
+                "${APISERVER}/api/v1/namespaces/${NAMESPACE}/secrets")
+              # Clear the secret bytes from the env immediately after POST.
+              HMAC_B64="" ; WIRE_B64="" ; BODY=""
+              if [ "${code}" = "201" ] || [ "${code}" = "200" ]; then
+                echo "[hmac-bootstrap] Secret ${NAMESPACE}/${SECRET_NAME} created"
+                exit 0
+              fi
+              # 409 — race with operator pre-provision (or another concurrent
+              # bootstrap on a multi-replica HelmRelease retry). Treat as
+              # success: the existing Secret is preserved.
+              if [ "${code}" = "409" ]; then
+                echo "[hmac-bootstrap] Secret already created concurrently (HTTP 409) — accepting (preserves existing key)"
+                exit 0
+              fi
+              echo "[hmac-bootstrap] FATAL: POST returned HTTP ${code}" >&2
+              cat /tmp/create.json >&2 || true
+              exit 1
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              cpu: 100m
+              memory: 64Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir:
+            medium: Memory
+            sizeLimit: 8Mi
+{{- end }}

--- a/platform/k8s-ws-proxy/chart/tests/render.sh
+++ b/platform/k8s-ws-proxy/chart/tests/render.sh
@@ -4,7 +4,11 @@
 # Verifies:
 #   - default-OFF renders 0 resources
 #   - empty image.tag fails fast
-#   - full-ON renders DaemonSet + Service + ServiceAccount + ClusterRole + ClusterRoleBinding (5 resources)
+#   - full-ON renders DaemonSet + Service + ServiceAccount (DS) + ClusterRole + ClusterRoleBinding +
+#     ServiceAccount (HMAC bootstrap) + Role + RoleBinding + Job (HMAC bootstrap) = 9 resources
+#   - HMAC bootstrap Job is a pre-install/pre-upgrade hook with weight -10
+#   - HMAC bootstrap Role splits `create` (no resourceNames) from `get`
+#     per memory/feedback_rbac_create_no_resourcenames.md
 
 set -euo pipefail
 
@@ -51,17 +55,51 @@ fi
 echo "PASS: empty image.tag fails fast"
 
 # 3. Full-ON
+# Pre-Fix-#78 expected 5 resources (DaemonSet + Service + ServiceAccount +
+# ClusterRole + ClusterRoleBinding). Fix #78 (Gap E) added 4 more for
+# the HMAC-bootstrap pre-install hook (ServiceAccount + Role +
+# RoleBinding + Job), bringing the full-ON total to 9.
 on_render="$TMP/on.yaml"
 helm template bp-k8s-ws-proxy . \
   --set k8sWsProxy.enabled=true \
   --set k8sWsProxy.image.tag=abc1234 > "$on_render"
 on="$(grep -cE '^kind:' "$on_render" || true)"
-if [[ "$on" != "5" ]]; then
-  echo "FAIL: full-ON rendered $on resources, want 5"
+if [[ "$on" != "9" ]]; then
+  echo "FAIL: full-ON rendered $on resources, want 9"
   grep -E '^kind:' "$on_render"
   exit 1
 fi
-echo "PASS: full-ON = 5 resources"
+echo "PASS: full-ON = 9 resources"
+
+# 3a. HMAC-bootstrap Job present with correct hook annotations (Fix #78).
+# The Job MUST be a pre-install/pre-upgrade hook with weight -10 so it
+# runs BEFORE the DaemonSet rolls — without this the DS pods stick in
+# ContainerCreating waiting for the absent Secret.
+if ! grep -qE '^  name: k8s-ws-proxy-hmac-bootstrap$' "$on_render"; then
+  echo "FAIL: hmac-bootstrap resources not rendered (Fix #78 missing)"
+  exit 1
+fi
+if ! grep -qE '"helm\.sh/hook-weight": *"-10"' "$on_render"; then
+  echo "FAIL: hmac-bootstrap Job missing pre-install hook-weight -10"
+  grep -E 'helm.sh/hook' "$on_render"
+  exit 1
+fi
+if ! grep -qE '"helm\.sh/hook": *"pre-install,pre-upgrade"' "$on_render"; then
+  echo "FAIL: hmac-bootstrap Job missing pre-install,pre-upgrade hook"
+  grep -E 'helm.sh/hook' "$on_render"
+  exit 1
+fi
+# 3b. RBAC split per memory/feedback_rbac_create_no_resourcenames.md:
+# the Role MUST have a `create` rule WITHOUT resourceNames, and the
+# `get` rule WITH resourceNames as a separate rule. Combined-rule
+# pattern (verbs:[create,get] resourceNames:[...]) is the silent-403
+# trap that wedged bp-openbao 6+ chart iterations.
+if ! grep -qE 'verbs: \[ *"create" *\]|verbs:\s*-\s*create|verbs: \[create\]' "$on_render"; then
+  echo "FAIL: hmac-bootstrap Role missing isolated 'create' verb"
+  grep -E 'verbs:|resourceNames:' "$on_render"
+  exit 1
+fi
+echo "PASS: hmac-bootstrap Job + RBAC rendered with correct hook-weight + split verbs"
 
 # 4. Canonical workload name. Per qa-loop iter-7 Fix #39, the test
 #    matrix (TC-236, TC-237) and the catalyst-api shells/issue handler


### PR DESCRIPTION
## Root cause

Audit prov #7 [Gap E](../blob/main/.claude/qa-loop-state/bounded-cycle-audit-prov7.md) — on every fresh Sovereign all three `k8s-ws-proxy-*` DaemonSet pods sit `ContainerCreating` for 25+ min with:

```
MountVolume.SetUp failed for volume "hmac-secret":
  secret "k8s-ws-proxy-hmac" not found
```

The chart's `daemonset.yaml` mounts `Values.k8sWsProxy.hmacSecret.name` (default `k8s-ws-proxy-hmac`) but **nothing in the chart, sibling chart, or bootstrap-kit ever creates it**. The fail-fast in `_helpers.tpl` only catches the empty-name path; with the default name set, render proceeds and the DaemonSet rolls before the Secret exists.

**Impact**: BLOCKS Phase-1 Sovereign Console — in-browser kubectl/exec via the operator UI can't sign requests because the upstream caller (catalyst-api) and the per-node proxy have no shared HMAC key.

## Fix pattern

Helm pre-install/pre-upgrade Job (hook-weight `-10`, runs **before** the DaemonSet rolls):

1. **Idempotency probe** — GET the target Secret. 200 = exists → exit 0 (preserves operator-pre-provisioned SealedSecret OR prior-install key). 404 = proceed. Any other code = FATAL.
2. **Generate** 32 random bytes via `head -c 32 /dev/urandom`, pipe directly through `base64 | tr -d '\n'` into the JSON body posted to the apiserver. **Never echoed/cat'd/printed** per global CLAUDE.md §10.
3. **POST** Secret to `catalyst-system`. 201/200 → success. 409 → success (race-with-operator path is benign, existing key preserved). Other → FATAL.

## RBAC

Per [`memory/feedback_rbac_create_no_resourcenames.md`](../../../home/openova/.claude/projects/-home-openova-repos-openova-private/memory/feedback_rbac_create_no_resourcenames.md): `create` is in its **own** rule **without** `resourceNames`. `get` is a separate rule with `resourceNames: [k8s-ws-proxy-hmac]`. The combined-rule pattern was the silent root cause of bp-openbao 6+ chart iterations (1.2.5..1.2.11). The Role is namespace-scoped to `catalyst-system` — no cluster-wide blast radius.

## Idempotency proof

| Scenario | Behaviour |
|---|---|
| Fresh install, no Secret | Job generates random key, POSTs Secret, DaemonSet rolls cleanly. |
| `helm upgrade` (chart bump) | GET probe = 200 → Job exits 0 → existing key preserved. **CRITICAL** — rotating the key would invalidate every in-flight catalyst-api signature. |
| Operator pre-provisioned via SealedSecret + bp-sealed-secrets | Reflector creates the Secret first → GET probe = 200 → Job exits 0. |
| Concurrent bootstrap race (HelmRelease retry) | First POST = 201; second POST = 409 → treated as success. |
| Operator-driven rotation | `kubectl delete secret k8s-ws-proxy-hmac -n catalyst-system && flux reconcile helmrelease bp-k8s-ws-proxy -n flux-system` → Job re-runs, GET = 404, generates new key. |

## Canonical seam

Modelled after `platform/gitea/chart/templates/database-secret-sync-job.yaml`:

- `curlimages/curl:8.10.1` — alpine + sh + `/dev/urandom` + `base64`. Proven seam (bitnami/kubectl moved to sha256-only tags; rancher/kubectl is distroless and has no `/bin/sh`).
- In-cluster ServiceAccount token from the projected `/var/run/secrets/kubernetes.io/serviceaccount` path.
- Hook-weight `0` for SA / Role / RoleBinding (must exist **before** the `-10` Job pod's API calls); `-10` for the Job itself.
- `hook-delete-policy: before-hook-creation,hook-succeeded` — every upgrade replaces the prior Job artefacts; succeeded ones reaped.

## Render-test verification

`platform/k8s-ws-proxy/chart/tests/render.sh` extended with two new assertions; all 5 cases PASS under helm 3.20.2:

```
PASS: default-OFF = 0 resources
PASS: empty image.tag fails fast
PASS: full-ON = 9 resources                              (was 5; +4 for SA + Role + RoleBinding + Job)
PASS: hmac-bootstrap Job + RBAC rendered with correct hook-weight + split verbs
PASS: canonical workload name 'k8s-ws-proxy' on 6 resources (release-name-independent)
```

## Fresh-provision verification path

Once merged, `build-k8s-ws-proxy.yaml`'s promote job auto-bumps Chart.yaml `0.1.6 -> 0.1.7` with the new image SHA, then triggers `blueprint-release` to publish to GHCR. Bootstrap-kit slots in this PR pin `0.1.6`; **a follow-up auto-deploy commit will lift them to 0.1.7** once CI completes. The next fresh provision (prov #8) will then exercise the bootstrap Job before the DaemonSet rolls — `kubectl -n catalyst-system get secret k8s-ws-proxy-hmac` returns Found within ~30s of bp-k8s-ws-proxy HR Reconciling, and `kubectl -n catalyst-system get pod -l app.kubernetes.io/name=bp-k8s-ws-proxy` shows all DS pods Ready (no ContainerCreating wedge).

## Files

- `platform/k8s-ws-proxy/chart/templates/hmac-bootstrap-job.yaml` (new) — SA + Role + RoleBinding + Job
- `platform/k8s-ws-proxy/chart/Chart.yaml` — `0.1.5 -> 0.1.6`
- `platform/k8s-ws-proxy/chart/tests/render.sh` — assertion 3a (Job + RBAC verb split)
- `clusters/_template/bootstrap-kit/51-bp-k8s-ws-proxy.yaml` — pin `0.1.6`
- `clusters/omantel.omani.works/bootstrap-kit/51-bp-k8s-ws-proxy.yaml` — pin `0.1.6`

## Test plan

- [x] `helm template` full-ON renders 9 resources (DS + Service + DS-SA + ClusterRole + ClusterRoleBinding + bootstrap-SA + Role + RoleBinding + Job)
- [x] Bootstrap Job is `pre-install,pre-upgrade` hook with weight `-10`
- [x] Bootstrap Role splits `create` (no resourceNames) from `get` (with resourceNames)
- [x] Default-OFF still renders 0 resources
- [x] Empty `image.tag` still fails fast
- [x] Canonical workload name `k8s-ws-proxy` preserved across release-name overrides
- [ ] Fresh prov #8: `kubectl get secret k8s-ws-proxy-hmac -n catalyst-system` Found within 60s of HR reconciling
- [ ] Fresh prov #8: all `k8s-ws-proxy-*` pods Ready (no ContainerCreating wedge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Claimed TCs

k8s-ws-proxy DaemonSet was stuck `ContainerCreating` (missing hmac Secret).
The 3 daemonset pods back wss:// connections from catalyst-ui to per-node
kubelet for `kubectl exec` / `logs` / `port-forward` in the browser.

- TC-224 (pod log streaming via wss://.../k8s/.../logs/follow)
- TC-225 (pod terminal exec via wss://.../k8s/.../exec)

(Other kubectl:// FAILs in iter-16 use a separate non-ws-proxy runner and
are NOT claimed here.)
