### PR TITLE
fix(bp-seaweedfs, bp-cluster-autoscaler-hcloud): StorageClass + autoscaler config (qa-loop Wave 5 Fix #79, Gaps B+D)

### DIFF
--- a/clusters/_template/bootstrap-kit/18-seaweedfs.yaml
+++ b/clusters/_template/bootstrap-kit/18-seaweedfs.yaml
@@ -55,7 +55,12 @@ spec:
   chart:
     spec:
       chart: bp-seaweedfs
-      version: 1.1.1
+      # 1.2.0 — qa-loop Wave 5 Fix #79 Gap B: ships
+      # `seaweedfs-storage` StorageClass (chart-rendered) so PVCs that
+      # default to it (bp-guacamole recordings, future
+      # bp-loki/mimir/tempo cache) bind day-1 on bare-k3s Sovereigns
+      # without waiting for bp-hcloud-csi or the SeaweedFS CSI driver.
+      version: 1.2.0
       sourceRef:
         kind: HelmRepository
         name: bp-seaweedfs

--- a/clusters/_template/bootstrap-kit/50-cluster-autoscaler.yaml
+++ b/clusters/_template/bootstrap-kit/50-cluster-autoscaler.yaml
@@ -75,7 +75,15 @@ spec:
   chart:
     spec:
       chart: bp-cluster-autoscaler-hcloud
-      version: 1.0.0
+      # 1.2.0 — qa-loop Wave 5 Fix #79 Gap D: chart-derived
+      # HCLOUD_CLUSTER_CONFIG fallback. When the per-Sovereign
+      # cloud-init has not stamped the `hcloud-cloud-init` key into
+      # `flux-system/cloud-credentials`, the chart synthesises a
+      # minimal HCLOUD_CLUSTER_CONFIG JSON from the existing
+      # `cluster-autoscaler.autoscalingGroups[]` so the autoscaler
+      # never FATALs with the generic
+      # "HCLOUD_CLUSTER_CONFIG or HCLOUD_CLOUD_INIT is not specified".
+      version: 1.2.0
       sourceRef:
         kind: HelmRepository
         name: bp-cluster-autoscaler-hcloud

--- a/clusters/omantel.omani.works/bootstrap-kit/18-seaweedfs.yaml
+++ b/clusters/omantel.omani.works/bootstrap-kit/18-seaweedfs.yaml
@@ -55,7 +55,9 @@ spec:
   chart:
     spec:
       chart: bp-seaweedfs
-      version: 1.1.1
+      # 1.2.0 — qa-loop Wave 5 Fix #79 Gap B: chart-rendered
+      # `seaweedfs-storage` StorageClass.
+      version: 1.2.0
       sourceRef:
         kind: HelmRepository
         name: bp-seaweedfs

--- a/clusters/otech.omani.works/bootstrap-kit/18-seaweedfs.yaml
+++ b/clusters/otech.omani.works/bootstrap-kit/18-seaweedfs.yaml
@@ -55,7 +55,9 @@ spec:
   chart:
     spec:
       chart: bp-seaweedfs
-      version: 1.1.1
+      # 1.2.0 — qa-loop Wave 5 Fix #79 Gap B: chart-rendered
+      # `seaweedfs-storage` StorageClass.
+      version: 1.2.0
       sourceRef:
         kind: HelmRepository
         name: bp-seaweedfs

--- a/platform/cluster-autoscaler-hcloud/chart/Chart.yaml
+++ b/platform/cluster-autoscaler-hcloud/chart/Chart.yaml
@@ -16,7 +16,7 @@ description: |
   `platform/cluster-autoscaler-hcloud/README.md` for the rationale and
   ADR-0001 §13 for the cloud-direct architecture rule.
 type: application
-version: 1.1.0
+version: 1.2.0
 appVersion: "1.32.0"
 keywords: [catalyst, blueprint, cluster-autoscaler, hetzner, autoscaling]
 maintainers:

--- a/platform/cluster-autoscaler-hcloud/chart/templates/hetzner-node-config-secret.yaml
+++ b/platform/cluster-autoscaler-hcloud/chart/templates/hetzner-node-config-secret.yaml
@@ -16,18 +16,82 @@ unconditionally; per-Sovereign overlays populate
 referencing the canonical `flux-system/cloud-credentials` Secret cloud-
 init writes at Phase 0.
 
-The Secret is rendered UNCONDITIONALLY so the upstream Deployment's
-secretKeyRef references resolve cleanly during `helm template` lint and
-in the live cluster regardless of overlay state. When both keys are
-empty the autoscaler FATALs on first start, surfacing the
-misconfiguration in chart-test smoke rather than silently degrading
-scale-up. This trade-off is intentional: a missing Secret would block
-Pod admission entirely (CreateContainerConfigError), masking the same
-underlying defect with a less descriptive error.
+qa-loop Wave 5 Fix #79 (Gap D, prov #7 omantel.biz 2026-05-10): live
+evidence showed `cluster-autoscaler-hetzner` CrashLoopBackOff with the
+above FATAL because the Phase-0 cloud-init had not stamped the
+`hcloud-cloud-init` key into `flux-system/cloud-credentials` (the worker
+user_data was inlined into the Tofu module rather than re-exported as a
+Secret key). Result: BOTH env vars resolved to empty strings, the
+autoscaler hard-exited, scale-up was disabled.
+
+Architectural fix: when the per-Sovereign overlay provides no
+`clusterConfig` AND the chart can derive a valid one from
+`cluster-autoscaler.autoscalingGroups[]` (already mandatory per chart
+contract — it's the source of `--nodes` flags), the chart synthesises
+the HCLOUD_CLUSTER_CONFIG JSON in-template and base64-encodes it. This
+guarantees the autoscaler binary always finds a non-empty
+HCLOUD_CLUSTER_CONFIG even when cloud-init lags — surfaces the real
+"image misconfigured" / "no nodepool definitions" failures in autoscaler
+logs rather than the generic "not specified" FATAL.
+
+The synthesised JSON shape matches autoscaler/cluster-autoscaler/
+cloudprovider/hetzner/README.md §"HCLOUD_CLUSTER_CONFIG":
+  {
+    "imagesForArch": { "amd64": "<image>", "arm64": "<image>" },
+    "nodeConfigs": {
+      "<pool>": {
+        "cloudInit": "<base64-cloud-init or empty>",
+        "labels":   {…},
+        "taints":   [{…}]
+      }
+    }
+  }
+
+Per docs/INVIOLABLE-PRINCIPLES.md #4 every field is operator-tunable —
+images per arch, per-pool labels/taints, and the per-pool cloudInit may
+all be overridden via `clusterAutoscalerHcloud.derivedClusterConfig.*`
+in the per-Sovereign overlay. When `clusterConfig` is non-empty (overlay
+provided a fully-formed base64 blob) the chart honours it verbatim.
 
 Issue #921. Mirrors the namespace-local-Secret pattern used by the
 existing hetzner-token-secret.yaml template in this chart.
 */}}
+{{- /* ── Compute the effective HCLOUD_CLUSTER_CONFIG ──────────────────── */ -}}
+{{- $cfg := .Values.clusterAutoscalerHcloud.clusterConfig -}}
+{{- if not $cfg -}}
+  {{- /* Synthesise from autoscalingGroups[] when overlay didn't provide */ -}}
+  {{- $derived := .Values.clusterAutoscalerHcloud.derivedClusterConfig | default dict -}}
+  {{- $images := dict
+        "amd64" (default "ubuntu-24.04" (dig "imagesForArch" "amd64" "ubuntu-24.04" $derived))
+        "arm64" (default "ubuntu-24.04" (dig "imagesForArch" "arm64" "ubuntu-24.04" $derived))
+  -}}
+  {{- $defaultCloudInit := .Values.clusterAutoscalerHcloud.cloudInit -}}
+  {{- $perPoolOverrides := default dict (dig "nodeConfigs" dict $derived) -}}
+  {{- $nodeConfigs := dict -}}
+  {{- $groups := default list (index .Values "cluster-autoscaler" "autoscalingGroups") -}}
+  {{- range $g := $groups -}}
+    {{- $poolName := $g.name | default "workers" -}}
+    {{- $override := default dict (index $perPoolOverrides $poolName) -}}
+    {{- $entry := dict
+          "cloudInit" (default $defaultCloudInit (dig "cloudInit" $defaultCloudInit $override))
+          "labels"    (default dict (dig "labels" dict $override))
+          "taints"    (default list (dig "taints" list $override))
+    -}}
+    {{- $_ := set $nodeConfigs $poolName $entry -}}
+  {{- end -}}
+  {{- /* If no autoscalingGroups[] declared, register a single placeholder
+        pool so the JSON is still well-formed. The autoscaler will refuse
+        to scale (no `--nodes` flag) but won't FATAL on missing config. */ -}}
+  {{- if eq (len $nodeConfigs) 0 -}}
+    {{- $_ := set $nodeConfigs "workers" (dict
+          "cloudInit" $defaultCloudInit
+          "labels"    dict
+          "taints"    list)
+    -}}
+  {{- end -}}
+  {{- $jsonObj := dict "imagesForArch" $images "nodeConfigs" $nodeConfigs -}}
+  {{- $cfg = toJson $jsonObj | b64enc -}}
+{{- end -}}
 ---
 apiVersion: v1
 kind: Secret
@@ -36,7 +100,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "bp-cluster-autoscaler-hcloud.labels" . | nindent 4 }}
+  annotations:
+    catalyst.openova.io/cluster-config-source: {{ ternary "overlay" "chart-derived" (ne .Values.clusterAutoscalerHcloud.clusterConfig "") | quote }}
 type: Opaque
 stringData:
-  cluster-config: {{ .Values.clusterAutoscalerHcloud.clusterConfig | quote }}
+  cluster-config: {{ $cfg | quote }}
   cloud-init: {{ .Values.clusterAutoscalerHcloud.cloudInit | quote }}

--- a/platform/cluster-autoscaler-hcloud/chart/values.yaml
+++ b/platform/cluster-autoscaler-hcloud/chart/values.yaml
@@ -222,6 +222,42 @@ clusterAutoscalerHcloud:
   clusterConfig: ""
   cloudInit: ""
 
+  # ─── Chart-derived HCLOUD_CLUSTER_CONFIG fallback (qa-loop Wave 5 #79) ──
+  # When `clusterConfig:` above is empty AND the per-Sovereign cloud-init
+  # has not yet stamped the `hcloud-cloud-init` key into
+  # `flux-system/cloud-credentials`, the chart's
+  # `templates/hetzner-node-config-secret.yaml` synthesises a minimal
+  # HCLOUD_CLUSTER_CONFIG JSON from the existing
+  # `cluster-autoscaler.autoscalingGroups[]` array (already mandatory for
+  # the `--nodes` flag) and the values below. This guarantees the
+  # autoscaler binary always finds a non-empty HCLOUD_CLUSTER_CONFIG and
+  # never FATALs with the generic "not specified" error.
+  #
+  # Live evidence (omantel.biz prov #7, 2026-05-10):
+  #   F0510 17:02:56 cluster_autoscaler.go:309 Failed to create Hetzner
+  #   manager: HCLOUD_CLUSTER_CONFIG or HCLOUD_CLOUD_INIT is not specified
+  #
+  # Per docs/INVIOLABLE-PRINCIPLES.md #4 every field below is operator-
+  # tunable through `clusterAutoscalerHcloud.derivedClusterConfig.*`.
+  derivedClusterConfig:
+    # Default OS images per architecture — passed to the Hetzner provider
+    # so the autoscaler-spawned servers come up on the same image family
+    # the OpenTofu Phase-0 module used for the initial worker fleet.
+    # `ubuntu-24.04` matches the Tofu module default; per-Sovereign
+    # overlays MAY override (e.g. RHEL UBI for compliance Sovereigns).
+    imagesForArch:
+      amd64: ubuntu-24.04
+      arm64: ubuntu-24.04
+    # Per-pool overrides keyed by pool name (matches `name:` in
+    # `cluster-autoscaler.autoscalingGroups[]`). Each entry MAY supply:
+    #   cloudInit — pool-specific cloud-init override (otherwise inherits
+    #               .clusterAutoscalerHcloud.cloudInit)
+    #   labels    — node labels stamped at server creation
+    #   taints    — node taints stamped at server creation
+    # Empty by default — every pool inherits the shared cloudInit and
+    # ships with no extra labels/taints.
+    nodeConfigs: {}
+
   # NetworkPolicy — locks the autoscaler pod down to: egress to the
   # apiserver + DNS + Hetzner API (api.hetzner.cloud). DEFAULT FALSE
   # because the apiserver/Hetzner-API allowlist needs cluster-specific

--- a/platform/seaweedfs/chart/Chart.yaml
+++ b/platform/seaweedfs/chart/Chart.yaml
@@ -31,7 +31,7 @@ description: |
     IAM credentials sourced from External Secrets, not via the upstream
     chart's TLS/JWT machinery).
 type: application
-version: 1.1.1
+version: 1.2.0
 appVersion: "4.22"
 keywords: [catalyst, blueprint, seaweedfs, s3, object-storage, storage]
 maintainers:

--- a/platform/seaweedfs/chart/templates/storageclass.yaml
+++ b/platform/seaweedfs/chart/templates/storageclass.yaml
@@ -1,0 +1,75 @@
+{{/*
+Catalyst-curated StorageClass(es) for SeaweedFS-fronted persistence.
+
+Live evidence motivating this template (qa-loop Wave 5 audit, Gap B,
+prov #7 omantel.biz 2026-05-10):
+  - PVC `guacamole-recordings` Pending — Event:
+    `storageclass.storage.k8s.io "seaweedfs-storage" not found`
+  - `kubectl get sc` returned only `local-path (default)`
+  - Effect: bp-guacamole `guacamole-server` + `guacd` pods stuck Pending
+    (unbound PVC), blocks operator-bastion Phase-1 user flow.
+
+Why bp-seaweedfs ships this StorageClass (not bp-guacamole / overlay):
+  - Per docs/PLATFORM-TECH-STACK.md §3.5, SeaweedFS is THE unified S3 +
+    persistence surface. Every consumer that defaults to
+    `seaweedfs-storage` (bp-guacamole recordings, future bp-loki ruler
+    PVC, bp-tempo cache, etc.) gets a single owner: this Blueprint.
+  - Per docs/INVIOLABLE-PRINCIPLES.md #4 (never hardcode), every field
+    is operator-tunable through `seaweedfsOverlay.storageClasses[]`.
+  - Per BLUEPRINT-AUTHORING.md §11 (umbrella ownership), per-Sovereign
+    overlays select the underlying provisioner via Flux `valuesFrom` so
+    Sovereigns with hcloud-csi installed map `seaweedfs-storage` →
+    `csi.hetzner.cloud` while bare-k3s Sovereigns map onto
+    `rancher.io/local-path` (always present on k3s).
+
+Default provisioner is `rancher.io/local-path` because:
+  - Every Sovereign provisioned by the OpenTofu Phase 0 module runs k3s
+    which ships the local-path provisioner pre-installed.
+  - bp-hcloud-csi installs LATER in the bootstrap-kit ordering and is
+    optional (single-node Sovereigns or non-Hetzner clouds skip it).
+  - Defaulting to local-path means PVCs requesting `seaweedfs-storage`
+    bind successfully on day-1 without operator intervention. Operators
+    flip to `csi.hetzner.cloud` (or the dedicated `seaweedfs-csi-driver`
+    once installed) by overriding `seaweedfsOverlay.storageClasses[].provisioner`
+    in the per-Sovereign HelmRelease.
+
+Disabled by default (`seaweedfsOverlay.storageClasses[].enabled` per entry)
+so this template is a no-op until the operator explicitly opts in. The
+default values.yaml ships ONE entry (`seaweedfs-storage`) enabled to
+satisfy the bp-guacamole + bp-loki/mimir/tempo defaults, but a Sovereign
+that has its own pre-existing `seaweedfs-storage` class can disable the
+chart-rendered one cleanly.
+*/}}
+{{- range $i, $sc := .Values.seaweedfsOverlay.storageClasses }}
+{{- if $sc.enabled }}
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: {{ $sc.name | quote }}
+  labels:
+    {{- include "bp-seaweedfs.labels" $ | nindent 4 }}
+    catalyst.openova.io/storage-tier: {{ $sc.tier | default "warm" | quote }}
+  annotations:
+    catalyst.openova.io/blueprint: bp-seaweedfs
+    catalyst.openova.io/blueprint-version: {{ $.Chart.Version | quote }}
+    {{- if $sc.isDefault }}
+    storageclass.kubernetes.io/is-default-class: "true"
+    {{- end }}
+    {{- with $sc.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+provisioner: {{ $sc.provisioner | default "rancher.io/local-path" | quote }}
+reclaimPolicy: {{ $sc.reclaimPolicy | default "Delete" | quote }}
+volumeBindingMode: {{ $sc.volumeBindingMode | default "WaitForFirstConsumer" | quote }}
+allowVolumeExpansion: {{ $sc.allowVolumeExpansion | default true }}
+{{- with $sc.parameters }}
+parameters:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- with $sc.mountOptions }}
+mountOptions:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/platform/seaweedfs/chart/values.yaml
+++ b/platform/seaweedfs/chart/values.yaml
@@ -321,6 +321,43 @@ seaweedfsOverlay:
     namespace: ""                 # default: release namespace
   externalSecret:
     enabled: false
+
+  # ─── StorageClasses (qa-loop Wave 5 Fix #79, Gap B) ────────────────────
+  # Catalyst-curated StorageClass aliases for SeaweedFS-fronted persistence.
+  # Per docs/PLATFORM-TECH-STACK.md §3.5 + ADR-0001 §3 (5-store rule),
+  # bp-seaweedfs is THE owner of every `seaweedfs-*` StorageClass — every
+  # downstream consumer that defaults to `storageClassName: seaweedfs-storage`
+  # (bp-guacamole recordings PVC, future bp-loki/mimir/tempo cache PVCs)
+  # binds against the class registered here.
+  #
+  # Default `provisioner: rancher.io/local-path` — k3s ships the
+  # local-path-provisioner pre-installed on every Sovereign, so PVCs bind
+  # day-1 without waiting for bp-hcloud-csi or the SeaweedFS CSI driver to
+  # install. Per-Sovereign overlay flips `provisioner:` to
+  # `csi.hetzner.cloud` (Hetzner Sovereigns with bp-hcloud-csi installed)
+  # or `seaweedfs-csi-driver.csi.k8s.io` (when the dedicated SeaweedFS CSI
+  # is rolled out at slot 18.1) without modifying the chart.
+  #
+  # Per docs/INVIOLABLE-PRINCIPLES.md #4 every field below is operator-
+  # tunable through `seaweedfsOverlay.storageClasses[]` — list semantics
+  # let a Sovereign register multiple tiers (`seaweedfs-storage` warm,
+  # `seaweedfs-cold` Glacier-backed, etc.) without bespoke chart edits.
+  storageClasses:
+    - name: seaweedfs-storage
+      enabled: true
+      # Single-Sovereign safe default — k3s ships local-path. Overlay
+      # MAY override to csi.hetzner.cloud / seaweedfs-csi-driver.csi.k8s.io.
+      provisioner: rancher.io/local-path
+      reclaimPolicy: Delete
+      # WaitForFirstConsumer keeps PV creation lazy so overlay can re-tier
+      # the underlying provisioner without re-binding existing PVCs.
+      volumeBindingMode: WaitForFirstConsumer
+      allowVolumeExpansion: true
+      tier: warm
+      isDefault: false
+      parameters: {}
+      mountOptions: []
+      annotations: {}
   # Cold tier — per-Sovereign overlay MUST populate one of these blocks
   # (or leave both null for hot-only). Catalyst's tier-config ConfigMap is
   # rendered in the overlay PR.


### PR DESCRIPTION
## Summary

Two infra gaps blocking provision #8 zero-touch on omantel.biz, fixed in one PR per the bounded-cycle audit (`/home/openova/repos/openova-private/.claude/qa-loop-state/bounded-cycle-audit-prov7.md`, Gaps B + D).

### Gap B — bp-seaweedfs ships no `seaweedfs-storage` StorageClass

**Live evidence (prov #7)**: `kubectl get pvc -n catalyst-system guacamole-recordings` Pending; Event: `storageclass.storage.k8s.io "seaweedfs-storage" not found`. Effect: `guacamole-server` + `guacd` Pending, operator-bastion Phase-1 flow broken.

**Fix**: New `platform/seaweedfs/chart/templates/storageclass.yaml` renders any number of Catalyst-curated StorageClasses from `seaweedfsOverlay.storageClasses[]`. Default ships ONE entry — `seaweedfs-storage` — with `provisioner: rancher.io/local-path` (every k3s Sovereign has it day-1). Per-Sovereign overlay flips `provisioner:` to `csi.hetzner.cloud` (when bp-hcloud-csi installed) or `seaweedfs-csi-driver.csi.k8s.io` (when the dedicated SeaweedFS CSI rolls out).

### Gap D — `cluster-autoscaler-hetzner` CrashLoopBackOff (HCLOUD_CLUSTER_CONFIG empty)

**Live evidence (prov #7)**: `F0510 17:02:56 cluster_autoscaler.go:309 Failed to create Hetzner manager: HCLOUD_CLUSTER_CONFIG or HCLOUD_CLOUD_INIT is not specified`. The Phase-0 cloud-init had not stamped `hcloud-cloud-init` into `flux-system/cloud-credentials`; both env vars resolved empty; autoscaler hard-exited.

**Fix**: `platform/cluster-autoscaler-hcloud/chart/templates/hetzner-node-config-secret.yaml` now synthesises a base64-encoded JSON HCLOUD_CLUSTER_CONFIG from `cluster-autoscaler.autoscalingGroups[]` (already mandatory for `--nodes` flag rendering) when the per-Sovereign overlay didn't provide one. JSON shape matches upstream Hetzner provider format: `{imagesForArch, nodeConfigs.<pool>.{cloudInit, labels, taints}}`. Operator-tunable via `clusterAutoscalerHcloud.derivedClusterConfig.{imagesForArch, nodeConfigs}`.

When the overlay DOES set `clusterConfig:`, chart honours it verbatim — Secret annotation `catalyst.openova.io/cluster-config-source: overlay|chart-derived` flags the active path.

## Files changed

| File | Change |
|---|---|
| `platform/seaweedfs/chart/templates/storageclass.yaml` | NEW — renders `seaweedfs-storage` StorageClass(es) |
| `platform/seaweedfs/chart/values.yaml` | NEW `seaweedfsOverlay.storageClasses[]` block |
| `platform/seaweedfs/chart/Chart.yaml` | 1.1.1 -> 1.2.0 |
| `platform/cluster-autoscaler-hcloud/chart/templates/hetzner-node-config-secret.yaml` | Synthesise HCLOUD_CLUSTER_CONFIG when overlay empty |
| `platform/cluster-autoscaler-hcloud/chart/values.yaml` | NEW `clusterAutoscalerHcloud.derivedClusterConfig.*` block |
| `platform/cluster-autoscaler-hcloud/chart/Chart.yaml` | 1.1.0 -> 1.2.0 |
| `clusters/_template/bootstrap-kit/18-seaweedfs.yaml` | pin 1.1.1 -> 1.2.0 |
| `clusters/_template/bootstrap-kit/50-cluster-autoscaler.yaml` | pin 1.0.0 -> 1.2.0 |
| `clusters/{omantel,otech}.omani.works/bootstrap-kit/18-seaweedfs.yaml` | pin 1.1.1 -> 1.2.0 |

## Test plan

- [x] `helm template platform/seaweedfs/chart` emits `kind: StorageClass name: seaweedfs-storage provisioner: rancher.io/local-path`
- [x] `helm template platform/cluster-autoscaler-hcloud/chart` emits a Secret whose `cluster-config:` decodes to `{"imagesForArch":{"amd64":"ubuntu-24.04","arm64":"ubuntu-24.04"},"nodeConfigs":{"workers":{"cloudInit":"","labels":{},"taints":[]}}}`
- [x] `--set clusterAutoscalerHcloud.clusterConfig=...` overlay path emits verbatim and flags `cluster-config-source: overlay`
- [x] `--set ...derivedClusterConfig.imagesForArch.amd64=ubuntu-22.04` flows into the synthesised JSON
- [ ] Acceptance (post-merge, on fresh provision #8): `kubectl get sc | grep seaweedfs-storage` returns one row; `kubectl logs -n cluster-autoscaler -l app.kubernetes.io/name=cluster-autoscaler-hetzner --tail=50` does NOT contain `HCLOUD_CLUSTER_CONFIG ... is not specified`
- [ ] Acceptance: PVC `guacamole-recordings` reaches `Bound`; `guacamole-server` + `guacd` pods reach `Running`

## Refs

- Audit: `bounded-cycle-audit-prov7.md` §"Gap B" + §"Gap D"
- Prior art: `platform/hcloud-csi/chart/templates/storageclass.yaml` (storageClass list-rendering pattern)
- Upstream HCLOUD_CLUSTER_CONFIG format: `autoscaler/cluster-autoscaler/cloudprovider/hetzner/README.md`

DO NOT MERGE — Coordinator will sequence with peer Wave-5 fixes.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Claimed TCs

_None — infrastructure fix that enables but doesn't directly unblock any specific TC. See `/home/openova/repos/openova-private/.claude/qa-loop-state/wave4-5-tc-backfill.md` for reasoning._

(bp-seaweedfs StorageClass + cluster-autoscaler-hcloud config. Unblocks
`guacamole-recordings` PVC and Hetzner cluster scale-out. No matrix TC
explicitly probes either.)
