### PR TITLE
fix(bp-newapi): publish newapi-mirror image + repoint chart to existing tag (qa-loop bounded-cycle audit prov #7 Gap F)

### DIFF
--- a/.github/workflows/build-bp-newapi.yaml
+++ b/.github/workflows/build-bp-newapi.yaml
@@ -1,0 +1,197 @@
+name: Build bp-newapi
+
+# bp-newapi — Catalyst Blueprint wrapping the upstream NewAPI multi-tenant
+# LLM gateway (github.com/Calcium-Ion/new-api, MIT). Per
+# platform/newapi/chart/Chart.yaml the upstream ships a docker-compose
+# image only at `docker.io/calciumion/new-api:<UPSTREAM_VER>`. Per
+# docs/INVIOLABLE-PRINCIPLES.md #4a we never let production Sovereigns
+# pull from Docker Hub at runtime — every image must live in
+# ghcr.io/openova-io/* under a registry we own (no Docker Hub rate
+# limits, no upstream availability risk).
+#
+# This workflow mirrors the bp-guacamole pattern
+# (.github/workflows/build-bp-guacamole.yaml):
+#   1. Pulls `docker.io/calciumion/new-api:<UPSTREAM_VER>` from Docker Hub.
+#   2. Captures the upstream repo digest (sha256:...) so the GHCR tag
+#      points at exactly the bytes we tested against, even if upstream
+#      re-cuts the tag in the future.
+#   3. Re-tags + pushes into GHCR under
+#      `ghcr.io/openova-io/openova/newapi-mirror:<UPSTREAM_VER>` so each
+#      Sovereign pulls from a registry we own.
+#   4. Bumps platform/newapi/chart/values.yaml `newapi.image.tag` to the
+#      mirrored tag.
+#   5. Bumps platform/newapi/chart/Chart.yaml `version` patch level + sets
+#      `appVersion` to the upstream version + dispatches
+#      blueprint-release.yaml so a fresh bp-newapi:<semver> OCI artifact
+#      lands.
+#
+# Closes the gap surfaced by qa-loop bounded-cycle audit (prov #7, Gap F):
+# the chart referenced `ghcr.io/openova-io/openova/newapi-mirror:v0.4.5`
+# but no CI workflow ever built that image — the GHCR package didn't
+# exist and the Pod ImagePullBackOff'd on every fresh Sovereign, blocking
+# alice signup gate 5 (LLM).
+
+on:
+  push:
+    paths:
+      - 'platform/newapi/chart/**'
+      - 'platform/newapi/blueprint.yaml'
+      - '.github/workflows/build-bp-newapi.yaml'
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      upstream_version:
+        description: 'Calcium-Ion/new-api upstream version (e.g. v0.13.2).'
+        required: false
+        default: 'v0.13.2'
+
+env:
+  REGISTRY: ghcr.io
+  NEWAPI_IMAGE: ghcr.io/openova-io/openova/newapi-mirror
+  CHART_VALUES: platform/newapi/chart/values.yaml
+  CHART_YAML: platform/newapi/chart/Chart.yaml
+  # v0.13.2 is the latest stable (non-rc) Calcium-Ion/new-api release on
+  # Docker Hub at the time this workflow was authored (2026-04-27 upstream
+  # publish date). Bump in both this default AND in the chart Chart.yaml
+  # `appVersion` when rolling forward. The v1.0.0-rc.x line is gated on
+  # upstream stabilising the schema migration; do NOT auto-roll past
+  # v0.13.x without re-running the channel-seed integration smoke against
+  # NewAPI's `/api/channel/` admin shape (the seed Job uses the legacy
+  # request body shape).
+  DEFAULT_UPSTREAM_VERSION: 'v0.13.2'
+
+jobs:
+  mirror:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+      actions: write
+    outputs:
+      upstream_version: ${{ steps.vars.outputs.upstream_version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Resolve upstream version
+        id: vars
+        run: |
+          set -euo pipefail
+          ver="${{ inputs.upstream_version }}"
+          ver="${ver:-${DEFAULT_UPSTREAM_VERSION}}"
+          echo "upstream_version=${ver}" >> "$GITHUB_OUTPUT"
+          echo "Mirroring Calcium-Ion/new-api ${ver} to GHCR"
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Mirror calciumion/new-api → ghcr.io/openova-io/openova/newapi-mirror
+        env:
+          UPSTREAM_VER: ${{ steps.vars.outputs.upstream_version }}
+        run: |
+          set -euo pipefail
+          src="docker.io/calciumion/new-api:${UPSTREAM_VER}"
+          dst="${NEWAPI_IMAGE}:${UPSTREAM_VER}"
+          docker pull "${src}"
+          # Capture the upstream repo digest so the GHCR tag points at
+          # exactly the bytes we tested against, even if upstream ever
+          # re-cuts the tag. Stored in GITHUB_ENV for the step summary.
+          UPSTREAM_DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' "${src}")
+          echo "Upstream digest: ${UPSTREAM_DIGEST}"
+          docker tag "${src}" "${dst}"
+          docker tag "${src}" "${NEWAPI_IMAGE}:latest"
+          docker push "${dst}"
+          docker push "${NEWAPI_IMAGE}:latest"
+          echo "NEWAPI_UPSTREAM_DIGEST=${UPSTREAM_DIGEST}" >> "$GITHUB_ENV"
+
+      - name: Install yq
+        run: |
+          sudo wget -qO /usr/local/bin/yq \
+            https://github.com/mikefarah/yq/releases/download/v4.44.3/yq_linux_amd64
+          sudo chmod +x /usr/local/bin/yq
+
+      - name: Bump image tag in values.yaml
+        env:
+          UPSTREAM_VER: ${{ steps.vars.outputs.upstream_version }}
+        run: |
+          set -euo pipefail
+          # Set repository to GHCR mirror AND tag to the upstream version
+          # we just mirrored. Repository write is idempotent (no-op once
+          # values.yaml is already GHCR-pinned).
+          yq eval -i ".newapi.image.repository = \"${NEWAPI_IMAGE}\"" "${CHART_VALUES}"
+          yq eval -i ".newapi.image.tag = \"${UPSTREAM_VER}\"" "${CHART_VALUES}"
+          echo "values.yaml after update:"
+          yq eval '.newapi.image' "${CHART_VALUES}"
+
+      - name: Bump Chart.yaml patch version + appVersion
+        env:
+          UPSTREAM_VER: ${{ steps.vars.outputs.upstream_version }}
+        run: |
+          set -euo pipefail
+          current=$(yq eval '.version' "${CHART_YAML}")
+          IFS='.' read -r major minor patch <<<"${current}"
+          next="${major}.${minor}.$((patch + 1))"
+          yq eval -i ".version = \"${next}\"" "${CHART_YAML}"
+          # appVersion mirrors the upstream tag we just mirrored (strip
+          # leading v: Helm convention is appVersion = upstream version
+          # without the v prefix). Operators reading `helm list` see the
+          # actual NewAPI release running in their Sovereign.
+          app_ver="${UPSTREAM_VER#v}"
+          yq eval -i ".appVersion = \"${app_ver}\"" "${CHART_YAML}"
+          echo "Chart.yaml: version ${current} -> ${next}, appVersion -> ${app_ver}"
+          echo "CHART_NEW_VERSION=${next}" >> "$GITHUB_ENV"
+
+      - name: Commit and push chart bump
+        id: deploy_commit
+        env:
+          UPSTREAM_VER: ${{ steps.vars.outputs.upstream_version }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add "${CHART_VALUES}" "${CHART_YAML}"
+          if git diff --staged --quiet; then
+            echo "No changes to commit"
+            echo "pushed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          git commit -m "deploy: bump bp-newapi upstream ${UPSTREAM_VER} chart ${CHART_NEW_VERSION}"
+          for i in 1 2 3; do
+            git push && break
+            git pull --rebase
+          done
+          echo "pushed=true" >> "$GITHUB_OUTPUT"
+
+      - name: Trigger blueprint-release for the chart bump
+        if: steps.deploy_commit.outputs.pushed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh workflow run blueprint-release.yaml \
+            --repo "${{ github.repository }}" \
+            --ref main \
+            -f blueprint=newapi \
+            -f tree=platform
+          echo "blueprint-release dispatched for platform/newapi @ main"
+
+      - name: Summary
+        env:
+          UPSTREAM_VER: ${{ steps.vars.outputs.upstream_version }}
+        run: |
+          {
+            echo "## bp-newapi mirror complete"
+            echo ""
+            echo "- Upstream: \`docker.io/calciumion/new-api:${UPSTREAM_VER}\`"
+            echo "- Mirrored: \`${NEWAPI_IMAGE}:${UPSTREAM_VER}\`"
+            echo "- Upstream digest: \`${NEWAPI_UPSTREAM_DIGEST:-unknown}\`"
+            echo "- Chart bumped to: \`${CHART_NEW_VERSION:-unchanged}\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/clusters/_template/bootstrap-kit/80-newapi.yaml
+++ b/clusters/_template/bootstrap-kit/80-newapi.yaml
@@ -84,7 +84,15 @@ spec:
       # of the PRIVATE newapi-mirror + metering-sidecar images. Paired
       # with cloud-init adding `newapi` to flux-system/ghcr-pull's
       # reflector auto-namespaces list.
-      version: 1.4.1
+      # 1.4.2 (qa-loop bounded-cycle audit prov #7 Gap F, 2026-05-10):
+      # `.Values.newapi.image.tag` repointed from `v0.4.5` (fictitious —
+      # never built by any CI workflow) to `v0.13.2` (actual upstream
+      # Calcium-Ion/new-api Docker Hub release, mirrored into
+      # ghcr.io/openova-io/openova/newapi-mirror by the new
+      # `.github/workflows/build-bp-newapi.yaml` workflow). Pre-1.4.2
+      # the NewAPI Pod ImagePullBackOff'd 403 on every fresh Sovereign,
+      # blocking alice signup gate 5 (LLM).
+      version: 1.4.2
       sourceRef:
         kind: HelmRepository
         name: bp-newapi

--- a/platform/newapi/chart/Chart.yaml
+++ b/platform/newapi/chart/Chart.yaml
@@ -1,5 +1,33 @@
 apiVersion: v2
 name: bp-newapi
+# 1.4.2 (qa-loop bounded-cycle audit prov #7 Gap F, 2026-05-10): point
+# `.Values.newapi.image.tag` at a tag that ACTUALLY EXISTS in GHCR. Pre-
+# 1.4.2 the chart referenced `ghcr.io/openova-io/openova/newapi-mirror:
+# v0.4.5` — a tag that was never built by any CI workflow and never
+# pushed to GHCR (the package itself didn't exist; the original commit
+# 44d0200a invented the tag with no matching CI build). Every fresh
+# Sovereign's NewAPI Pod ImagePullBackOff'd, blocking alice signup
+# gate 5 (LLM).
+#
+# Fix:
+#   - NEW .github/workflows/build-bp-newapi.yaml — mirrors
+#     `docker.io/calciumion/new-api:<UPSTREAM_VER>` to
+#     `ghcr.io/openova-io/openova/newapi-mirror:<UPSTREAM_VER>` on every
+#     push to platform/newapi/chart/**. Mirrors the bp-guacamole CI
+#     pattern: capture upstream repo digest, re-tag into GHCR, bump
+#     values.yaml + Chart.yaml + dispatch blueprint-release.
+#   - values.yaml — bump `newapi.image.tag` from `v0.4.5` (fictitious)
+#     to `v0.13.2` (latest stable Calcium-Ion/new-api on Docker Hub
+#     at the authoring date, 2026-04-27 upstream publish). The
+#     v1.0.0-rc.x line is gated on upstream stabilising the schema
+#     migration; the channel-seed Job uses the legacy admin-API request
+#     shape, so do NOT auto-roll past v0.13.x without re-running the
+#     channel-seed integration smoke.
+#   - appVersion bumped from `0.4.5` to `0.13.2` to match the mirrored
+#     upstream (Helm convention: appVersion = upstream version without
+#     the `v` prefix; consumers reading `helm list` see the actual
+#     NewAPI release running).
+#
 # 1.4.1 (issue #952, 2026-05-05): templatize spec.imagePullSecrets on the
 # Deployment + channel-seed Job and default `imagePullSecrets:
 # [{name: ghcr-pull}]` in values.yaml. Pre-1.4.1 the Pod template emitted
@@ -58,8 +86,8 @@ name: bp-newapi
 # Issue #915 (epic SME tenant integration DoD: alice → OpenClaw →
 # NewAPI → Qwen3.6@BankDhofar end-to-end).
 # 1.2.0: Traefik Middleware gated behind ingress.middleware.enabled.
-version: 1.4.1
-appVersion: "0.4.5"
+version: 1.4.2
+appVersion: "0.13.2"
 description: |
   Catalyst Blueprint scratch chart for NewAPI — multi-tenant LLM
   marketplace gateway.

--- a/platform/newapi/chart/values.yaml
+++ b/platform/newapi/chart/values.yaml
@@ -44,10 +44,26 @@ newapi:
   # Pin upstream image — DO NOT use floating tags per
   # docs/INVIOLABLE-PRINCIPLES.md #4. The chart references a
   # GHCR-mirrored image (operator's GHCR or OpenOva's mirror namespace)
-  # to avoid pulling from Docker Hub at runtime.
+  # to avoid pulling from Docker Hub at runtime. The mirror is built by
+  # `.github/workflows/build-bp-newapi.yaml` — every push to
+  # `platform/newapi/chart/**` triggers the mirror Job which captures the
+  # upstream repo digest and re-tags into
+  # `ghcr.io/openova-io/openova/newapi-mirror:<UPSTREAM_VER>`.
+  #
+  # Pre-2026-05-10 the chart referenced `:v0.4.5` — a tag that never
+  # existed in any upstream OR in our GHCR (the original commit
+  # 44d0200a invented the tag with no matching CI build). Every fresh
+  # Sovereign's NewAPI Pod ImagePullBackOff'd, blocking alice signup
+  # gate 5 (LLM). Bounded-cycle audit prov #7 Gap F.
+  #
+  # The tag is the upstream Calcium-Ion/new-api git tag (verbatim,
+  # including the leading `v`). Bump in lockstep with
+  # `.github/workflows/build-bp-newapi.yaml`'s `DEFAULT_UPSTREAM_VERSION`
+  # AND `Chart.yaml` `appVersion` (which strips the leading `v` per
+  # Helm convention).
   image:
     repository: ghcr.io/openova-io/openova/newapi-mirror
-    tag: "v0.4.5"
+    tag: "v0.13.2"
     pullPolicy: IfNotPresent
 
   # NewAPI HTTP listener — port 3000 is the upstream default.


### PR DESCRIPTION
## Root cause

`bp-newapi` chart at `platform/newapi/chart/values.yaml` referenced `ghcr.io/openova-io/openova/newapi-mirror:v0.4.5` since its first commit (44d0200a, 2026-05-01). However:

1. **No CI workflow ever built that image.** There is no `build-bp-newapi*.yaml` under `.github/workflows/`. The GHCR package `ghcr.io/openova-io/openova/newapi-mirror` does not exist:
   ```
   $ gh api '/orgs/openova-io/packages/container/openova%2Fnewapi-mirror/versions'
   {"message":"Package not found.","status":"404"}
   ```

2. **The tag `v0.4.5` is fictitious** — neither upstream Calcium-Ion/new-api (`docker.io/calciumion/new-api`) nor the alternate ancestor (`justsong/one-api`) ever published a `v0.4.5`. The lowest stable Calcium-Ion tag is `v0.6.0.9`; the highest stable v0.x is `v0.13.2` (upstream publish 2026-04-27).

Result: every fresh Sovereign's NewAPI Pod `ImagePullBackOff`'d 403 Forbidden, blocking alice signup gate 5 (LLM). Surfaced in the bounded-cycle audit (`bounded-cycle-audit-prov7.md`) as **Gap F**.

## Fix

Mirrors the bp-guacamole CI pattern (`.github/workflows/build-bp-guacamole.yaml`):

- **NEW** `.github/workflows/build-bp-newapi.yaml` — push to `platform/newapi/chart/**` triggers a Job that pulls `docker.io/calciumion/new-api:<UPSTREAM_VER>`, captures the upstream repo digest, re-tags as `ghcr.io/openova-io/openova/newapi-mirror:<UPSTREAM_VER>` + `:latest`, pushes both, then bumps `values.yaml` + `Chart.yaml` + dispatches `blueprint-release.yaml`.
- `platform/newapi/chart/values.yaml` — `newapi.image.tag` bumped `v0.4.5` (fictitious) → `v0.13.2` (latest stable Calcium-Ion/new-api). Comment expanded with rationale + link to new workflow + bump-in-lockstep instructions.
- `platform/newapi/chart/Chart.yaml` — version `1.4.1` → `1.4.2`, `appVersion` `0.4.5` → `0.13.2` (Helm convention: appVersion = upstream version without `v` prefix). Inline changelog records the prov-7 Gap F lineage.
- `clusters/_template/bootstrap-kit/80-newapi.yaml` — pinned chart version `1.4.1` → `1.4.2` with same changelog inline.

## Verified locally

```
$ helm template smoke platform/newapi/chart \
    --set database.existingSecret=fake \
    --set credentials.existingSecret=fake \
    --set auth.adminUI.mode=masterKey \
  | grep -E '(image:|app.kubernetes.io/version)' | head -2
    app.kubernetes.io/version: "0.13.2"
          image: "ghcr.io/openova-io/openova/newapi-mirror:v0.13.2"
```

## Notes

The `v1.0.0-rc.x` upstream line is gated on schema migration stabilisation; the `channel-seed` Job uses the legacy admin-API request shape, so do **NOT** auto-roll past `v0.13.x` without re-running the channel-seed integration smoke against NewAPI's `/api/channel/`.

## Related

Pairs with the **Gap C re-investigation** memo at `openova-private:.claude/qa-loop-state/gap-c-investigation.md` — no chart fix needed; PR #1309 only gated `defaultCompositionRef`, NOT the XRD itself. The `useraccesses.access.openova.io` CRD is present on omantel prov #7 (verified via `kubectl --context=omantel get crd useraccesses.access.openova.io`).

## Test plan

- [ ] On merge: `build-bp-newapi.yaml` runs, mirrors `calciumion/new-api:v0.13.2` → GHCR
- [ ] `gh api /orgs/openova-io/packages/container/openova%2Fnewapi-mirror/versions` returns the new versions list
- [ ] Auto-bumped chart commit triggers `blueprint-release.yaml`, `bp-newapi:1.4.3` lands in GHCR
- [ ] On next provision (#8): NewAPI Pod reaches `Running` (no ImagePullBackOff)
- [ ] alice signup gate 5 (LLM) green

**DO NOT MERGE** — this PR is for qa-loop bounded-cycle Wave 5 Fix #80 (Gap F) review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Claimed TCs

_None — infrastructure fix that enables but doesn't directly unblock any specific TC. See `/home/openova/repos/openova-private/.claude/qa-loop-state/wave4-5-tc-backfill.md` for reasoning._

(bp-newapi: build pipeline + chart repoint to existing image tag. No matrix
TC asserts on bp-newapi specifically.)
