### PR TITLE
fix(bp-crossplane-claims): composition-validate test post-#1309 retirement (Fix #89)

### DIFF
--- a/platform/crossplane-claims/chart/tests/composition-validate.sh
+++ b/platform/crossplane-claims/chart/tests/composition-validate.sh
@@ -3,19 +3,25 @@
 #
 # This is the chart-level lint+template+kubectl-dry-run pass that runs
 # against every render of bp-crossplane's templates/xrds + templates/compositions
-# directory tree. The 7 XRDs and 7 Compositions composed here back the
-# catalyst-api Day-2 CRUD endpoints (RegionClaim, ClusterClaim,
-# NodePoolClaim, LoadBalancerClaim, PeeringClaim, NodeActionClaim) plus
-# the Sovereign IAM access plane (UserAccess — issue #322).
+# directory tree. The 7 XRDs back the catalyst-api Day-2 CRUD endpoints
+# (RegionClaim, ClusterClaim, NodePoolClaim, LoadBalancerClaim, PeeringClaim,
+# NodeActionClaim) plus the Sovereign IAM access plane (UserAccess —
+# issue #322). The default render ships 6 Compositions (one per Hetzner
+# CRUD kind); the legacy useraccess Composition was retired by PR #1309
+# (qa-loop iter-16 Fix #71) — it now only renders when
+# --set userAccess.compositionEnabled=true. The canonical day-2 IaC for
+# IAM grants is the catalyst-useraccess-controller.
 #
 # Verifies, in order:
 #   1. `helm template` renders without error (no Go-template breakage).
-#   2. The render contains exactly 6 XRDs (one per CRUD kind) and at least
-#      6 Compositions (NodePool/LoadBalancer compose multiple sub-resources
-#      so the count for those families ≥ 6).
-#   3. Each XRD's `claimNames.kind` matches the catalyst-api expectation:
+#   2. The render contains exactly 7 XRDs (6 Hetzner CRUD kinds + UserAccess).
+#   3. The render contains the 6 expected default Compositions by name,
+#      AND the legacy useraccess Composition is gated off by default,
+#      AND the back-compat path (`--set userAccess.compositionEnabled=true`)
+#      still renders the legacy Composition.
+#   4. Each XRD's `claimNames.kind` matches the catalyst-api expectation:
 #      RegionClaim, ClusterClaim, NodePoolClaim, LoadBalancerClaim,
-#      PeeringClaim, NodeActionClaim.
+#      PeeringClaim, NodeActionClaim, UserAccess.
 #   4. `kubectl --dry-run=client` accepts every rendered XRD + Composition
 #      (schema-shape verification — does NOT require a live cluster).
 #   5. Each XRC sample fixture under tests/fixtures/ refers to a kind that
@@ -63,13 +69,71 @@ if [ "$XRD_COUNT" -ne 7 ]; then
 fi
 echo "  PASS ($XRD_COUNT XRDs)"
 
-echo "[composition-validate] Case 3: render contains ≥ 7 Compositions"
+echo "[composition-validate] Case 3: render contains the 6 expected default Compositions"
+# Explicit-name check (qa-loop iter-16 Fix #89, post PR #1309).
+#
+# Pre-#1309 the chart shipped 7 Compositions including the legacy
+# useraccess.compose.openova.io. PR #1309 retired that Composition by
+# default — it now only renders when --set userAccess.compositionEnabled=true.
+# The canonical day-2 IaC for IAM grants is the catalyst-useraccess-controller.
+#
+# We assert the EXACT 6 default-rendered Composition names rather than a
+# magic-number count so this gate is robust against future
+# additions/retirements (Principle 4: target-state, never hardcode the wrong
+# magic number; the names ARE the contract).
+EXPECTED_COMPOSITIONS=(
+  hetzner-cluster.compose.openova.io
+  hetzner-load-balancer-claim.compose.openova.io
+  hetzner-node-action.compose.openova.io
+  hetzner-node-pool.compose.openova.io
+  hetzner-peering.compose.openova.io
+  hetzner-region.compose.openova.io
+)
 COMPOSITION_COUNT="$(grep -c '^kind: Composition$' "$TMP/render.yaml" || true)"
-if [ "$COMPOSITION_COUNT" -lt 7 ]; then
-  echo "FAIL: expected ≥ 7 Compositions, found $COMPOSITION_COUNT" >&2
+if [ "$COMPOSITION_COUNT" -ne ${#EXPECTED_COMPOSITIONS[@]} ]; then
+  echo "FAIL: expected exactly ${#EXPECTED_COMPOSITIONS[@]} Compositions (default render), found $COMPOSITION_COUNT" >&2
+  echo "      hint: did you add/remove a Composition in templates/compositions/? update EXPECTED_COMPOSITIONS in tests/composition-validate.sh" >&2
+  grep -E '^(kind|  name): ' "$TMP/render.yaml" | grep -B1 'compose.openova.io' >&2 || true
   exit 1
 fi
-echo "  PASS ($COMPOSITION_COUNT Compositions)"
+for name in "${EXPECTED_COMPOSITIONS[@]}"; do
+  if ! grep -q "^  name: $name$" "$TMP/render.yaml"; then
+    echo "FAIL: expected Composition $name not found in render" >&2
+    exit 1
+  fi
+done
+echo "  PASS ($COMPOSITION_COUNT Compositions, all expected names present)"
+
+echo "[composition-validate] Case 3a: legacy useraccess Composition is gated off by default"
+# Per PR #1309: useraccess.compose.openova.io must NOT render with default
+# values. It can be re-enabled with --set userAccess.compositionEnabled=true
+# but that's an opt-in path; the default render must omit it so the
+# catalyst-useraccess-controller owns IAM grants without composite-controller
+# status fights.
+if grep -q '^  name: useraccess.compose.openova.io$' "$TMP/render.yaml"; then
+  echo "FAIL: useraccess.compose.openova.io rendered with default values — PR #1309 regression?" >&2
+  exit 1
+fi
+echo "  PASS (useraccess Composition correctly gated off)"
+
+echo "[composition-validate] Case 3a-back-compat: --set userAccess.compositionEnabled=true re-enables the legacy Composition"
+# Back-compat assertion: opt-in path still renders the legacy Composition
+# so operators with the override on get the expected 7-Composition shape.
+helm template smoke-cp . --set userAccess.compositionEnabled=true > "$TMP/render-compat.yaml" 2> "$TMP/render-compat.err" || {
+  echo "FAIL: helm template with --set userAccess.compositionEnabled=true failed:" >&2
+  cat "$TMP/render-compat.err" >&2
+  exit 1
+}
+COMPAT_COUNT="$(grep -c '^kind: Composition$' "$TMP/render-compat.yaml" || true)"
+if [ "$COMPAT_COUNT" -ne $((${#EXPECTED_COMPOSITIONS[@]} + 1)) ]; then
+  echo "FAIL: expected $((${#EXPECTED_COMPOSITIONS[@]} + 1)) Compositions with compositionEnabled=true, found $COMPAT_COUNT" >&2
+  exit 1
+fi
+if ! grep -q '^  name: useraccess.compose.openova.io$' "$TMP/render-compat.yaml"; then
+  echo "FAIL: useraccess.compose.openova.io did not render under --set userAccess.compositionEnabled=true" >&2
+  exit 1
+fi
+echo "  PASS ($COMPAT_COUNT Compositions including legacy useraccess)"
 
 echo "[composition-validate] Case 3b: render contains 8 ClusterRoles (Sovereign IAM + 5 catalog tiers)"
 # 3 legacy openova:application-{admin,editor,viewer} + 5 EPIC-3 tier-*


### PR DESCRIPTION
## Summary

PR #1309 (Fix #71) retired the legacy `XUserAccess` Composition by default (`userAccess.compositionEnabled: false`), dropping the chart's default render from **7 → 6** Compositions. The chart-level test gate `composition-validate.sh` case 3 still required `≥ 7 Compositions`, so blueprint-release CI failed on every push, **chart 1.1.3 never published to GHCR** (bootstrap-kit pin says 1.1.3 but GHCR only has 1.1.2), and **prov #8 wedged on 3 dependent HRs** (bp-catalyst-platform + downstream).

This PR replaces the magic-number `≥ 7` count check with an **explicit-name list** of the 6 default-rendered Compositions, plus a regression guard for the gated-off useraccess Composition, plus a back-compat assertion for the opt-in path.

## What changed

`platform/crossplane-claims/chart/tests/composition-validate.sh`:

- **Case 3** (was `≥ 7 Compositions`): now asserts the **EXACT 6 default Compositions by name**:
  - `hetzner-cluster.compose.openova.io`
  - `hetzner-load-balancer-claim.compose.openova.io`
  - `hetzner-node-action.compose.openova.io`
  - `hetzner-node-pool.compose.openova.io`
  - `hetzner-peering.compose.openova.io`
  - `hetzner-region.compose.openova.io`

- **Case 3a** (new): asserts `useraccess.compose.openova.io` is **NOT** rendered with default values — guards against accidental re-introduction of the post-#1309 bug.

- **Case 3a-back-compat** (new): re-renders the chart with `--set userAccess.compositionEnabled=true` and asserts the legacy `useraccess.compose.openova.io` Composition **does** render in that opt-in path. Total Composition count = 7 in back-compat mode. Operators who flip the override still get the expected shape.

- **Header docstring**: updated to explain the post-#1309 reality (default ships 6 Compositions, opt-in path adds the 7th).

Per inviolable principle #4 (target-state, never hardcode the wrong magic number; the names ARE the contract). Future addition/removal of a Composition will fail the gate with a clear hint pointing at `EXPECTED_COMPOSITIONS` rather than silently drifting.

## Local verification

```
$ bash tests/composition-validate.sh
[composition-validate] Case 1: chart renders cleanly                                                           PASS
[composition-validate] Case 2: render contains 7 XRDs                                                          PASS (7 XRDs)
[composition-validate] Case 3: render contains the 6 expected default Compositions                             PASS (6 Compositions, all expected names present)
[composition-validate] Case 3a: legacy useraccess Composition is gated off by default                          PASS
[composition-validate] Case 3a-back-compat: --set userAccess.compositionEnabled=true re-enables the legacy ... PASS (7 Compositions including legacy useraccess)
[composition-validate] Case 3b: render contains 8 ClusterRoles                                                 PASS
[composition-validate] Case 3c: render contains 1 ClusterPolicy                                                PASS
[composition-validate] Case 4: every expected claim kind is present                                            PASS (all 7 claim kinds present)
[composition-validate] Case 5: every rendered document is valid YAML                                           PASS
[composition-validate] Case 6: every fixture XRC kind is matched by an XRD                                     PASS
[composition-validate] Case 7: server-side dry-run for each fixture                                            SKIP (no live cluster)
[composition-validate] All bp-crossplane Day-2 CRUD Composition gates green.
```

## Expected effect

1. blueprint-release CI for `platform/crossplane-claims` now passes the test gate.
2. Chart **1.1.3** publishes to GHCR (`ghcr.io/openova-io/charts/bp-crossplane-claims:1.1.3`).
3. prov #8's `bp-crossplane-claims` HR rolls 1.1.2 → 1.1.3 with the retired-Composition fix.
4. The 3 dependent HRs (bp-catalyst-platform + downstream) unwedge.
5. UserAccess CRs reconcile via `catalyst-useraccess-controller` only — no more composite-controller status fights.

This is a meta-fix: chart version is unchanged (still 1.1.3 — the version was bumped by PR #1309 but the chart never published because of this CI gate). The fix is ON the test gate so the existing 1.1.3 chart can publish.

## Claimed TCs

_None — infrastructure fix that unblocks chart 1.1.3 GHCR publish, which unblocks prov #8 chart roll for bp-catalyst-platform + 3 dependent HRs._

## Test plan

- [x] `bash tests/composition-validate.sh` PASSes locally (all 11 cases)
- [x] Default render: 6 Compositions, no `useraccess.compose.openova.io`
- [x] `--set userAccess.compositionEnabled=true` render: 7 Compositions, includes `useraccess.compose.openova.io`
- [ ] CI: `blueprint-release` workflow on `main` after merge passes the composition-validate gate
- [ ] CI: chart 1.1.3 lands in `ghcr.io/openova-io/charts/bp-crossplane-claims:1.1.3`
- [ ] prov #8: bp-crossplane-claims HR rolls 1.1.2 → 1.1.3
- [ ] prov #8: 3 dependent HRs (bp-catalyst-platform + downstream) reach Ready=True

Refs: PR #1309 (Fix #71), failed CI run https://github.com/openova-io/openova/actions/runs/25634647637

🤖 Generated with [Claude Code](https://claude.com/claude-code)