### PR TITLE
fix(bp-k8s-ws-proxy): hmac-bootstrap Job/SA hook-weight ordering (Fix #95, regression of Fix #78)

### DIFF
--- a/clusters/_template/bootstrap-kit/51-bp-k8s-ws-proxy.yaml
+++ b/clusters/_template/bootstrap-kit/51-bp-k8s-ws-proxy.yaml
@@ -72,7 +72,15 @@ spec:
       # Secret that nothing ever created. Idempotent on upgrade
       # (preserves the existing key — rotating it would invalidate
       # every in-flight catalyst-api signature).
-      version: 0.1.6
+      # 0.1.9 (qa-loop bounded-cycle Fix #95, regression of Fix #78):
+      # explicit hook-weight ordering for the hmac-bootstrap quartet
+      # (SA=-20, Role+RoleBinding=-15, Job=-10) so the SA lands BEFORE
+      # the Job that references it. Pre-this, prov #8 failed with
+      # `serviceaccount "k8s-ws-proxy-hmac-bootstrap" not found`
+      # because the Job (weight -10, lower=earlier in Helm) was
+      # applied before its SA (weight 0). Bumps Chart.yaml 0.1.7 ->
+      # 0.1.8; CI promote auto-bumps to 0.1.9 with new image SHA.
+      version: 0.1.9
       sourceRef:
         kind: HelmRepository
         name: bp-k8s-ws-proxy

--- a/clusters/omantel.omani.works/bootstrap-kit/51-bp-k8s-ws-proxy.yaml
+++ b/clusters/omantel.omani.works/bootstrap-kit/51-bp-k8s-ws-proxy.yaml
@@ -46,7 +46,15 @@ spec:
       # that nothing ever created. Idempotent on upgrade (preserves
       # the existing key — rotating it would invalidate every
       # in-flight catalyst-api signature).
-      version: 0.1.6
+      # 0.1.9 (qa-loop bounded-cycle Fix #95, regression of Fix #78):
+      # explicit hook-weight ordering for the hmac-bootstrap quartet
+      # (SA=-20, Role+RoleBinding=-15, Job=-10) so the SA lands BEFORE
+      # the Job that references it. Pre-this, prov #8 failed with
+      # `serviceaccount "k8s-ws-proxy-hmac-bootstrap" not found`
+      # because the Job (weight -10, lower=earlier in Helm) was
+      # applied before its SA (weight 0). CI promote auto-bumps from
+      # Chart.yaml 0.1.8 to 0.1.9 with the new image SHA on merge.
+      version: 0.1.9
       sourceRef:
         kind: HelmRepository
         name: bp-k8s-ws-proxy

--- a/platform/k8s-ws-proxy/chart/Chart.yaml
+++ b/platform/k8s-ws-proxy/chart/Chart.yaml
@@ -25,7 +25,21 @@ name: bp-k8s-ws-proxy
 # in-flight catalyst-api signature). build-k8s-ws-proxy.yaml's promote
 # job will auto-bump this to 0.1.7 on merge with the new image SHA;
 # slot pins should be lifted to 0.1.7 once that promote runs.
-version: 0.1.7
+# 0.1.8 (qa-loop bounded-cycle Fix #95, regression of Fix #78):
+# explicit hook-weight ordering for the hmac-bootstrap quartet so the
+# ServiceAccount lands BEFORE the Job that references it. Fix #78 set
+# SA/Role/RoleBinding=0 and Job=-10; per Helm semantics (lower weights
+# run first within the same hook phase) this caused the Job to be
+# applied BEFORE its SA, surfacing on prov #8 as
+# `serviceaccount "k8s-ws-proxy-hmac-bootstrap" not found` →
+# CrashLoopBackOff → bp-k8s-ws-proxy HR Stalled → bp-guacamole blocked.
+# Fix #95 weights: SA=-20 (first), Role+RoleBinding=-15, Job=-10
+# (last; preserves Fix #78 render-test gate 3a). Render gate 9 added
+# in tests/render.sh asserts the four-tier ordering. build-k8s-ws-
+# proxy.yaml's promote job will auto-bump to 0.1.9 with the new image
+# SHA on merge; bootstrap-kit slot pins should be lifted to 0.1.9 once
+# that promote runs.
+version: 0.1.8
 appVersion: "0.1.0"
 description: |
   Catalyst-authored Blueprint chart for the k8s-ws-proxy DaemonSet —

--- a/platform/k8s-ws-proxy/chart/templates/hmac-bootstrap-job.yaml
+++ b/platform/k8s-ws-proxy/chart/templates/hmac-bootstrap-job.yaml
@@ -67,8 +67,22 @@ Modelled after platform/gitea/chart/templates/database-secret-sync-job.yaml:
     kubectl is distroless and has no /bin/sh).
   - In-cluster ServiceAccount token from the projected
     /var/run/secrets/kubernetes.io/serviceaccount path.
-  - Hook-weight 0 for SA/Role/RoleBinding (must exist before -10 Job
-    pod's API calls); -10 for the Job itself.
+  - Hook-weight ORDERING (Fix #95, regression of Fix #78). Helm hook-
+    weight semantics: within the same hook phase, LOWER weights run
+    FIRST. Pre-Fix-#95 the SA/Role/RoleBinding had weight "0" while
+    the Job had weight "-10", so the Job (lower number) was applied
+    BEFORE its ServiceAccount, surfacing on prov #8 as
+    `pods "k8s-ws-proxy-hmac-bootstrap-" is forbidden: error looking
+    up service account catalyst-system/k8s-ws-proxy-hmac-bootstrap:
+    serviceaccount "k8s-ws-proxy-hmac-bootstrap" not found`. Fix #95
+    re-orders to explicit weights so the dependency graph (SA → Role
+    → RoleBinding → Job) materialises in apiserver order regardless
+    of YAML order in this template:
+      ServiceAccount:        helm.sh/hook-weight: "-20" (first)
+      Role + RoleBinding:    helm.sh/hook-weight: "-15"
+      Job:                   helm.sh/hook-weight: "-10" (last)
+    The Job weight is preserved at -10 to keep the Fix #78 render-
+    test gate 3a stable (`grep "helm.sh/hook-weight": "-10"`).
   - hook-delete-policy: before-hook-creation,hook-succeeded — every
     upgrade replaces the prior Job artefacts; succeeded ones are reaped.
 */}}
@@ -87,7 +101,8 @@ metadata:
     catalyst.openova.io/component: hmac-bootstrap
   annotations:
     "helm.sh/hook": "pre-install,pre-upgrade"
-    "helm.sh/hook-weight": "0"
+    # Fix #95: -20 (lowest = applied FIRST, before Role/RoleBinding/Job).
+    "helm.sh/hook-weight": "-20"
     "helm.sh/hook-delete-policy": "before-hook-creation"
 {{- with .Values.k8sWsProxy.imagePullSecrets }}
 imagePullSecrets:
@@ -111,7 +126,8 @@ metadata:
     catalyst.openova.io/component: hmac-bootstrap
   annotations:
     "helm.sh/hook": "pre-install,pre-upgrade"
-    "helm.sh/hook-weight": "0"
+    # Fix #95: -15 (after SA at -20, before Job at -10).
+    "helm.sh/hook-weight": "-15"
     "helm.sh/hook-delete-policy": "before-hook-creation"
 rules:
   # Rule 1: create — NO resourceNames (apiserver authz rejects otherwise).
@@ -134,7 +150,8 @@ metadata:
     catalyst.openova.io/component: hmac-bootstrap
   annotations:
     "helm.sh/hook": "pre-install,pre-upgrade"
-    "helm.sh/hook-weight": "0"
+    # Fix #95: -15 (with Role; both must exist before Job at -10).
+    "helm.sh/hook-weight": "-15"
     "helm.sh/hook-delete-policy": "before-hook-creation"
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/platform/k8s-ws-proxy/chart/tests/render.sh
+++ b/platform/k8s-ws-proxy/chart/tests/render.sh
@@ -101,6 +101,68 @@ if ! grep -qE 'verbs: \[ *"create" *\]|verbs:\s*-\s*create|verbs: \[create\]' "$
 fi
 echo "PASS: hmac-bootstrap Job + RBAC rendered with correct hook-weight + split verbs"
 
+# 3c. (Fix #95, regression of Fix #78) Hook-weight ORDERING across the
+# hmac-bootstrap quartet. Helm semantics: within the same hook phase,
+# LOWER weights run FIRST. The Job references its ServiceAccount, so
+# the SA MUST be applied before the Job — i.e. the SA's weight MUST be
+# numerically LESS than the Job's (-10). Pre-Fix-#95 SA/Role/RoleBinding
+# all had weight 0 (later than the Job at -10), causing prov #8 to fail
+# with `serviceaccount "k8s-ws-proxy-hmac-bootstrap" not found`. Target
+# ordering: SA=-20, Role+RoleBinding=-15, Job=-10.
+#
+# Use awk to walk each `kind:` block in the rendered YAML and capture
+# its hook-weight; assert the ServiceAccount weight is the most
+# negative, the Job weight is -10, and the Role/RoleBinding sit between.
+weights="$(awk '
+  /^kind:/                                      { kind=$2; weight="" }
+  /name: k8s-ws-proxy-hmac-bootstrap$/          { is_hmac=1 }
+  /"helm\.sh\/hook-weight"/                     { gsub(/.*"helm\.sh\/hook-weight":[ ]*"/,""); gsub(/".*/,""); weight=$0 }
+  /^---$/ {
+    if (is_hmac && weight != "") print kind"="weight
+    is_hmac=0; kind=""; weight=""
+  }
+  END {
+    if (is_hmac && weight != "") print kind"="weight
+  }
+' "$on_render")"
+
+sa_w="$(echo "$weights" | grep -E '^ServiceAccount=' | head -1 | cut -d= -f2)"
+role_w="$(echo "$weights" | grep -E '^Role=' | head -1 | cut -d= -f2)"
+rb_w="$(echo "$weights" | grep -E '^RoleBinding=' | head -1 | cut -d= -f2)"
+job_w="$(echo "$weights" | grep -E '^Job=' | head -1 | cut -d= -f2)"
+
+if [[ -z "$sa_w" || -z "$role_w" || -z "$rb_w" || -z "$job_w" ]]; then
+  echo "FAIL: gate-9 could not extract all four hmac-bootstrap hook-weights"
+  echo "Captured: SA=$sa_w Role=$role_w RoleBinding=$rb_w Job=$job_w"
+  echo "All weights:"
+  echo "$weights"
+  exit 1
+fi
+# Ordering invariant: SA < Role <= RoleBinding < Job (numerically; all negative).
+# Lower number = applied first by Helm.
+if (( sa_w >= role_w )); then
+  echo "FAIL: gate-9 ordering — SA weight ($sa_w) must be LESS THAN Role weight ($role_w) so SA lands first"
+  exit 1
+fi
+if (( sa_w >= rb_w )); then
+  echo "FAIL: gate-9 ordering — SA weight ($sa_w) must be LESS THAN RoleBinding weight ($rb_w) so SA lands first"
+  exit 1
+fi
+if (( role_w >= job_w )); then
+  echo "FAIL: gate-9 ordering — Role weight ($role_w) must be LESS THAN Job weight ($job_w)"
+  exit 1
+fi
+if (( rb_w >= job_w )); then
+  echo "FAIL: gate-9 ordering — RoleBinding weight ($rb_w) must be LESS THAN Job weight ($job_w)"
+  exit 1
+fi
+# Belt-and-suspenders: Job MUST stay at -10 (Fix #78 gate 3a requires it).
+if [[ "$job_w" != "-10" ]]; then
+  echo "FAIL: gate-9 — Job weight is $job_w, want -10 (Fix #78 gate 3a invariant)"
+  exit 1
+fi
+echo "PASS: gate-9 hook-weight ordering — SA=$sa_w < Role=$role_w / RoleBinding=$rb_w < Job=$job_w"
+
 # 4. Canonical workload name. Per qa-loop iter-7 Fix #39, the test
 #    matrix (TC-236, TC-237) and the catalyst-api shells/issue handler
 #    address the DaemonSet + Service by `k8s-ws-proxy` regardless of


### PR DESCRIPTION
## Claimed TCs

_None — infrastructure fix; unblocks bp-k8s-ws-proxy + bp-guacamole HRs on fresh provisions, enables console reachability + qa-fixture render_

## Regression of Fix #78 (PR #1313)

Fix #78 added the `hmac-bootstrap` pre-install Job to the bp-k8s-ws-proxy chart. The Job's `helm.sh/hook-weight` was set to `"-10"` while its ServiceAccount, Role, and RoleBinding were left at `"0"`.

Per [Helm docs on hook weights](https://helm.sh/docs/topics/charts_hooks/#hook-weights):

> Hook weights can be positive or negative numbers but must be represented as strings. When Helm starts the execution cycle of hooks of a particular Kind it will sort those hooks in ASCENDING order.

Within the same hook phase (`pre-install,pre-upgrade`), **lower weights run first**. Fix #78's weights inverted the dependency graph: the Job (`-10`) was applied BEFORE its SA (`0`).

## Live evidence (prov #8 = `5dcbba1022ed993b`)

```
kubectl --context=omantel -n catalyst-system get hr bp-k8s-ws-proxy
NAME                AGE     READY   STATUS
bp-k8s-ws-proxy     ...     False   Stalled

# Job pod failure:
pods "k8s-ws-proxy-hmac-bootstrap-" is forbidden: error looking up
service account catalyst-system/k8s-ws-proxy-hmac-bootstrap:
serviceaccount "k8s-ws-proxy-hmac-bootstrap" not found
```

The Job sat in CrashLoopBackOff, the HelmRelease wedged Stalled=True, and `bp-guacamole`'s `dependsOn: bp-k8s-ws-proxy` blocked its install. The bounded-provision-cycle stopped at prov #8.

## Fix

Re-weight the four hmac-bootstrap resources with explicit ordering so the dependency graph materialises in apiserver-apply order **regardless of YAML order in the template**:

| Resource | Old weight | New weight | Rationale |
|---|---|---|---|
| ServiceAccount | `"0"` | `"-20"` | First — referenced by Job |
| Role | `"0"` | `"-15"` | After SA, before Job |
| RoleBinding | `"0"` | `"-15"` | With Role; both must precede Job |
| Job | `"-10"` | `"-10"` (unchanged) | Last; preserves Fix #78 gate-3a invariant |

The Job weight is preserved at `-10` to keep Fix #78's render-test gate 3a stable (`grep "helm.sh/hook-weight": "-10"`).

## Verification

`chart/tests/render.sh` adds gate 3c ("gate-9") that walks the rendered YAML, captures each hmac-bootstrap resource's hook-weight, and asserts the strict ordering invariant: `SA < Role <= RoleBinding < Job` AND `Job == -10`. Without the fix, gate-9 fails. With the fix, helm 3.20.2:

```
PASS: default-OFF = 0 resources
PASS: empty image.tag fails fast
PASS: full-ON = 9 resources
PASS: hmac-bootstrap Job + RBAC rendered with correct hook-weight + split verbs
PASS: gate-9 hook-weight ordering — SA=-20 < Role=-15 / RoleBinding=-15 < Job=-10
PASS: canonical workload name 'k8s-ws-proxy' on 6 resources (release-name-independent)
All render tests passed.
```

Rendered annotations:

```
ServiceAccount k8s-ws-proxy-hmac-bootstrap:
    "helm.sh/hook": "pre-install,pre-upgrade"
    "helm.sh/hook-weight": "-20"
    "helm.sh/hook-delete-policy": "before-hook-creation"
Role k8s-ws-proxy-hmac-bootstrap:
    "helm.sh/hook": "pre-install,pre-upgrade"
    "helm.sh/hook-weight": "-15"
    "helm.sh/hook-delete-policy": "before-hook-creation"
RoleBinding k8s-ws-proxy-hmac-bootstrap:
    "helm.sh/hook": "pre-install,pre-upgrade"
    "helm.sh/hook-weight": "-15"
    "helm.sh/hook-delete-policy": "before-hook-creation"
Job k8s-ws-proxy-hmac-bootstrap:
    "helm.sh/hook": "pre-install,pre-upgrade"
    "helm.sh/hook-weight": "-10"
    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
```

## Chart + slot bumps

- `platform/k8s-ws-proxy/chart/Chart.yaml`: 0.1.7 → 0.1.8 (CI promote auto-bumps to 0.1.9 with the new image SHA on merge per `build-k8s-ws-proxy.yaml`)
- `clusters/_template/bootstrap-kit/51-bp-k8s-ws-proxy.yaml`: 0.1.6 → 0.1.9
- `clusters/omantel.omani.works/bootstrap-kit/51-bp-k8s-ws-proxy.yaml`: 0.1.6 → 0.1.9

## Lesson for future hook-ordering work

Whenever a hook-phase Job depends on hook-phase RBAC (which it always does in this seam), the RBAC weights MUST be numerically LESS than the Job's. Same-phase same-weight ordering is undefined (Helm sorts by weight then by file path then by name — not by reference graph). Always: **SA most-negative, Role/RoleBinding intermediate, Job last.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)