### PR TITLE
fix(catalyst-api chart): restore dual-mode contract — api-deployment.yaml literal env values (CRITICAL Fix #98)

### DIFF
--- a/products/catalyst/chart/templates/api-deployment.yaml
+++ b/products/catalyst/chart/templates/api-deployment.yaml
@@ -560,8 +560,18 @@ spec:
             # bootstrap up again. Orthogonal to the chart-install-time
             # keycloak-config-cli Job (which seeds the realm itself) — this
             # env var only flips the runtime tier-role bootstrap.
+            # LITERAL value (not Helm template directive) — dual-mode contract:
+            # this file is consumed by both Helm AND Kustomize (contabo-mkt's
+            # clusters/contabo-mkt/apps/catalyst-platform). Helm directives in
+            # `value:` fields break the Kustomize build with `yaml: invalid map
+            # key` (caught live on contabo 2026-05-10 from #1311 regression at
+            # commit 92228bc — Flux Kustomization stuck for 2 days, blocking
+            # catalyst-api roll on contabo). Default OFF; per-Sovereign
+            # HelmRelease overlays MAY set this to "true" via the
+            # `catalystApi.env` additional-env patch (Helm-only codepath, takes
+            # precedence over this default at template-render time).
             - name: KEYCLOAK_BOOTSTRAP_TIER_ROLES
-              value: {{ .Values.keycloak.bootstrap.ensureTierRoles | default false | quote }}
+              value: "false"
             # CATALYST_HANDOVER_JWT_PUBLIC_KEY_PATH — path to the JWK file that
             # holds the RS256 public key for validating one-time handover JWTs.
             # The K8s Secret `catalyst-handover-jwt-public` (created by
@@ -980,8 +990,14 @@ spec:
             # can mint per-tier session cookies and assert tier-boundary
             # 403/200 contracts. Per qaFixtures.testSessionEnabled in
             # values.yaml. NEVER enable on customer Sovereigns.
+            # LITERAL value (not Helm template directive) — dual-mode contract,
+            # see KEYCLOAK_BOOTSTRAP_TIER_ROLES block above. Default OFF (404 on
+            # public Sovereigns). qa-loop chroot Sovereigns enable it via the
+            # `catalystApi.env` additional-env patch in their per-cluster
+            # HelmRelease (Helm-only codepath, takes precedence over this
+            # default). NEVER enable on customer Sovereigns.
             - name: CATALYST_TEST_SESSION_ENABLED
-              value: {{ and .Values.qaFixtures .Values.qaFixtures.testSessionEnabled | default false | toString | quote }}
+              value: "false"
           resources:
             requests:
               cpu: 50m


### PR DESCRIPTION
## Summary

Reverts lines 564 + 984 of `products/catalyst/chart/templates/api-deployment.yaml` from Helm template directives back to literal `"false"` defaults. Restores the dual-mode (Helm + Kustomize) chart contract that PR #1311 unintentionally broke.

## Claimed TCs

_None directly — infrastructure fix that unblocks Flux Kustomization on contabo, enabling catalyst-api to roll to latest SHA with Fix #73 (qaTestEnabled flag), which enables qa-fixtures auto-install on prov #9 → unblocks ~140 fixture-dependent TCs_

## Regression source

PR #1311 (Fix #73) introduced two `value: {{ ... }}` Helm directives:

- L564: `value: {{ .Values.keycloak.bootstrap.ensureTierRoles | default false | quote }}`
- L984: `value: {{ and .Values.qaFixtures .Values.qaFixtures.testSessionEnabled | default false | toString | quote }}`

## Dual-mode contract violation

The chart is consumed by BOTH paths:
- **Helm**: per-Sovereign install via `bp-catalyst-platform` OCI chart (renders templates → applies)
- **Kustomize**: contabo-mkt's `clusters/contabo-mkt/apps/catalyst-platform` Kustomization at `path: ./products/catalyst/chart/templates` (parses raw YAML, NO template rendering)

The contract is documented inline in this same file at:
- L173-188 (CATALYST_BUILD_SHA / CATALYST_CHART_VERSION)
- L588-600 (SOVEREIGN_FQDN / CATALYST_POWERDNS_API_URL)
- L944-950 (CATALYST_SESSION_COOKIE_DOMAIN)

A `{{ ... }}` block in `value:` becomes `yaml: invalid map key` to Kustomize.

## Live evidence

```
$ kubectl kustomize products/catalyst/chart/templates/
error: map[string]interface{}(nil): yaml: invalid map key:
  map[string]interface{}{".Values.keycloak.bootstrap.ensureTierRoles
  | default false | quote":""}
```

**Impact**: Flux Kustomization on contabo stuck at `92228bc` for 2 days → catalyst-api on contabo stuck at SHA `09b35d0` → Fix #73 (PR #1311 — qaTestEnabled flag) not live → prov #9 can't get qa-fixtures → bounded-cycle blocked.

## Path A rationale (chosen — target-state per Inviolable Principle #4)

Two valid paths existed:
1. **Path A (chosen)**: Revert to literal strings + move toggle to per-Sovereign HelmRelease overlay (`catalystApi.env` additional-env patch). Loses dynamic chart-render but **restores dual-mode** and is target-state — the toggle was always per-Sovereign overlay anyway.
2. **Path B (rejected)**: Sibling file pattern (`api-deployment-kustomize.yaml` mirror) — preserves both modes but doubles maintenance surface for two env vars.

Path A is target-state because per-Sovereign environment variation is a **deployment-time concern** (HelmRelease overlay), not a chart-template concern. The chart default is "off" (safe for customer Sovereigns); QA chroot Sovereigns enable via overlay.

## Verification (local)

```
$ kubectl kustomize products/catalyst/chart/templates/
→ exit 0, 17 manifests rendered
$ grep -A1 "KEYCLOAK_BOOTSTRAP_TIER_ROLES\|CATALYST_TEST_SESSION_ENABLED" out.yaml
        - name: KEYCLOAK_BOOTSTRAP_TIER_ROLES
          value: "false"
        - name: CATALYST_TEST_SESSION_ENABLED
          value: "false"

$ helm template products/catalyst/chart
→ exit 0, both env vars render as literal "false"
```

## Test plan

- [ ] Merge → contabo Flux Kustomization re-reconciles `92228bc → HEAD`
- [ ] catalyst-api on contabo rolls to latest SHA (currently stuck at `09b35d0`)
- [ ] Fix #73 (qaTestEnabled flag) goes live on contabo
- [ ] prov #9 qa-fixtures auto-install completes
- [ ] bounded-cycle resumes; ~140 fixture-dependent TCs eligible to PASS

## Inline doc updates

Added explicit dual-mode contract notes above each reverted env block referencing the 2026-05-10 regression so future Fix Authors don't re-introduce it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)