### PR TITLE
fix(infra/hetzner): escape ${VAR:-default} in tftpl comment (PROV-9 BLOCKER)

### DIFF
--- a/infra/hetzner/cloudinit-control-plane.tftpl
+++ b/infra/hetzner/cloudinit-control-plane.tftpl
@@ -930,7 +930,7 @@ write_files:
             # namespace + Organization names when the wizard / API
             # caller sets Request.QATestEnabled=true (QA Sovereigns
             # only). The bp-catalyst-platform chart's bootstrap-kit
-            # slot 13 reads via ${QA_FIXTURES_ENABLED:-false} and the
+            # slot 13 reads via $${QA_FIXTURES_ENABLED:-false} and the
             # other three placeholders below — see
             # clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
             # lines 496/510/511/519.


### PR DESCRIPTION
## Summary

PR #1311 (Fix #73) introduced a YAML comment in `cloudinit-control-plane.tftpl` line 933 referencing the envsubst placeholder `${QA_FIXTURES_ENABLED:-false}`. tofu's `templatefile()` function parses ALL `${...}` sequences regardless of YAML/HCL/shell context, and the colon inside the interpolation makes it choke at parse time:

```
Extra characters after interpolation expression; Template
interpolation doesn't expect a colon at this location. Did you
intend this to be a literal sequence to be processed as part of
another language? If so, you can escape it by starting with "$${"
instead of just "${"..
```

**Result:** every prov-* attempt since #1311 merged tofu-plans EXIT 1 in ~2 seconds. **Prov #9 (`4204f0b0c5e37a80`) failed at 18:51 UTC** with this exact error before any Hetzner resource was created.

## Fix

Change the comment from `${QA_FIXTURES_ENABLED:-false}` to `$${QA_FIXTURES_ENABLED:-false}`. The `$$` is HCL's escape — it renders as a literal `$` in the cloud-init output, which envsubst then interprets at apply time.

Same precedent: commit `7e5c4375` "escape `$` in tftpl comments referencing envsubst placeholders" — exact same class of bug, exact same fix.

This is a **1-character change** (added one `$`) on a comment line. **No runtime behavior change.**

## Impact

- Unblocks the qa-loop bounded-provision-cycle (prov #9 retry).
- Confirms regression-test gap: `tofu plan -input=false -no-color` should be added to a `pre-merge` guardrail. Out of scope for this hotfix.

## Test plan

- [x] Local: `grep -nE '^\s*#.*\$\{[A-Z_]+:-' infra/hetzner/*.tftpl` shows only the now-escaped occurrence
- [ ] CI: build-api smoke (`Smoke test API — verify infra/hetzner/ is bundled`) green
- [ ] Post-merge: re-attempt prov #9 → tofu plan succeeds → phase1-watching reached

Refs Fix #98, Fix #95, Fix #73 (regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Claimed TCs

_None directly — infrastructure regression hotfix; one-character escape ($${} → $${}) on a tftpl comment that broke every prov-* tofu plan since PR #1311. Unblocks the bounded-provision-cycle (prov #9 retry) so any TC depending on a fresh provision can run._