### PR TITLE
fix(bp-catalyst-platform): allow registry-pivot privileged container (Fix #113, prov #9 wedge)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -380,7 +380,17 @@ spec:
       # templates/catalyst-gitea-token-secret.yaml + post-install Job
       # auto-mints the Gitea PAT into catalyst-gitea-token (replaces
       # kubectl-applied operational hack).
-      version: 1.4.128
+      # 1.4.133 (qa-loop iter-1 prefetch Fix #113, prov #9 wedge):
+      # qa-fixtures Kyverno disallow-privileged-containers exclusion
+      # list now includes `catalyst` namespace so the registry-pivot
+      # DaemonSet shipped by bp-self-sovereign-cutover (which legitimately
+      # needs `securityContext.privileged: true` to rewrite
+      # /etc/rancher/k3s/registries.yaml on every node) is not blocked
+      # by the validating admission webhook. Without this, prov #9
+      # bp-self-sovereign-cutover HR went Ready=False and bp-catalyst-
+      # platform never reached Ready → console.<sov> Ingress never
+      # materialised → iter-1 was unrunnable.
+      version: 1.4.133
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -1,5 +1,32 @@
 apiVersion: v2
 name: bp-catalyst-platform
+# 1.4.133 (qa-loop iter-1 prefetch Fix #113, Kyverno catalyst-namespace
+# exemption for registry-pivot DaemonSet): adds `catalyst` to the
+# qa-fixtures Kyverno disallow-privileged-containers exclusion list.
+#
+# Root cause (prov #9 wedge, 2026-05-10):
+#   bp-self-sovereign-cutover HR went Ready=False with admission webhook
+#   `validate.kyverno.svc-fail` denying DaemonSet/catalyst/registry-pivot
+#   on `autogen-disallow-privileged` because the rule applied to every
+#   namespace not in the exclusion list — and `catalyst` (the DaemonSet's
+#   targetNamespace, see clusters/_template/bootstrap-kit/06a-bp-self-
+#   sovereign-cutover.yaml `targetNamespace: catalyst`) was missing from
+#   the list. registry-pivot legitimately needs `securityContext.privileged:
+#   true` + `hostPID: true` to atomically rewrite /etc/rancher/k3s/
+#   registries.yaml on every node when the cutover endpoint pivots
+#   from the upstream Harbor mirror to the local Sovereign one.
+#
+# Fix (Path A, narrowest change): list `catalyst` alongside the existing
+#   platform-namespace exemptions (kube-system, cnpg-system, flux-system,
+#   catalyst-system, kyverno, cilium, openbao, keycloak, gitea, powerdns,
+#   sme). The Kyverno policy stays in Enforce mode for tenant workloads;
+#   only the catalyst platform namespace gains the same exemption every
+#   other platform namespace already has.
+#
+# Unblocks (no TCs claimed directly): bp-self-sovereign-cutover HR
+#   Ready=True → bp-catalyst-platform reaches Ready → console.<sov>
+#   Ingress materialised → qa-loop iter-1 can run.
+#
 # 1.4.132 (qa-loop iter-1 prefetch Fix #110, Continuum DR third batch):
 # Adds the rest of the DR contract the SovereignConsole renders + the
 # matrix is expected to assert on going forward. Two seams move:
@@ -806,7 +833,7 @@ name: bp-catalyst-platform
 #   - values.yaml: new knobs `cnpgPairAliasName`,
 #     `cnpgPairPostSwitchoverPrimary`, `continuumPlatformNamespace` —
 #     all values-overridable per INVIOLABLE-PRINCIPLES #4.
-version: 1.4.132
+version: 1.4.133
 appVersion: 1.4.94
 # 1.4.129 (qa-loop iter-16 Fix #65): ship the missing
 # `openova-catalog` Flux v1 HelmRepository in flux-system. The

--- a/products/catalyst/chart/templates/qa-fixtures/kyverno-policies-qa.yaml
+++ b/products/catalyst/chart/templates/qa-fixtures/kyverno-policies-qa.yaml
@@ -33,7 +33,30 @@
   blocking the platform's own privileged pods (cilium-agent, csi
   drivers, postgres, etc.).
 */ -}}
-{{- $excludedNamespaces := list "kube-system" "cnpg-system" "flux-system" "catalyst-system" "kyverno" "cilium" "openbao" "keycloak" "gitea" "powerdns" "sme" }}
+{{- /*
+  Fix #113 (prov #9 wedge, 2026-05-10):
+  Added `catalyst` to the exclusion list. The bp-self-sovereign-cutover
+  chart deploys the `registry-pivot` DaemonSet into the `catalyst`
+  namespace (NOT `catalyst-system`) — see clusters/_template/bootstrap-kit/
+  06a-bp-self-sovereign-cutover.yaml `targetNamespace: catalyst` and
+  platform/self-sovereign-cutover/chart/templates/04-registry-pivot-daemonset.yaml.
+  registry-pivot legitimately requires `securityContext.privileged: true`
+  + `hostPID: true` to atomically rewrite /etc/rancher/k3s/registries.yaml
+  on every node when the cutover endpoint pivots from the upstream
+  Harbor mirror to the local Sovereign one. With the namespace not
+  exempt, the autogen-disallow-privileged rule denied the DaemonSet
+  via the validating admission webhook (`validate.kyverno.svc-fail`),
+  blocking bp-self-sovereign-cutover Ready=True and therefore stalling
+  bp-catalyst-platform → console.<sov> Ingress → iter-1.
+
+  Path A chosen (per Fix #113 brief): exempt the specific platform
+  namespace, keep the policy in Enforce mode for tenant workloads.
+  This matches the existing pattern for kube-system / cnpg-system /
+  flux-system / cilium / openbao / keycloak / gitea / powerdns / sme,
+  all of which are platform namespaces that legitimately host pods
+  with privileged-class capabilities (CSI drivers, CNI, etc.).
+*/ -}}
+{{- $excludedNamespaces := list "kube-system" "cnpg-system" "flux-system" "catalyst-system" "catalyst" "kyverno" "cilium" "openbao" "keycloak" "gitea" "powerdns" "sme" }}
 {{- $enforceMode := .Values.qaFixtures.kyvernoEnforceMode | default "Enforce" }}
 {{- $auditMode := "Audit" }}
 ---


### PR DESCRIPTION
## Summary

Adds `catalyst` to the qa-fixtures Kyverno `disallow-privileged-containers` exclusion list so the `bp-self-sovereign-cutover` `registry-pivot` DaemonSet stops being denied by the validating admission webhook on fresh provisions.

## Root cause (prov #9 = `b3b837a22d7a8e5c`)

`bp-self-sovereign-cutover` HR went `Ready=False` with:

```
admission webhook "validate.kyverno.svc-fail" denied the request:
resource DaemonSet/catalyst/registry-pivot ... rule
autogen-disallow-privileged failed at
/spec/template/spec/containers/0/securityContext/privileged/
```

The cutover chart deploys `registry-pivot` into the **`catalyst`** namespace (`clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml` `targetNamespace: catalyst`, plus `platform/self-sovereign-cutover/chart/templates/04-registry-pivot-daemonset.yaml`). The DaemonSet legitimately needs `securityContext.privileged: true` + `hostPID: true` to atomically rewrite `/etc/rancher/k3s/registries.yaml` on every node when the cutover endpoint pivots from the upstream Harbor mirror to the local Sovereign one.

The qa-fixtures Kyverno policy excluded every other platform namespace (`kube-system`, `cnpg-system`, `flux-system`, `catalyst-system`, `kyverno`, `cilium`, `openbao`, `keycloak`, `gitea`, `powerdns`, `sme`) but had no exemption for `catalyst`. With the rule in `Enforce` mode, the DaemonSet was rejected, blocking `bp-self-sovereign-cutover` `Ready=True` and stalling `bp-catalyst-platform` -> `console.<sov>` Ingress -> iter-1.

## Path chosen — A (narrowest namespace exemption)

| Path | Choice | Rationale |
|---|---|---|
| **A — exempt `catalyst` namespace in the Kyverno policy** | YES | Matches existing pattern for sister platform namespaces; keeps policy authoritative for tenant workloads; one-line list addition; minimal blast radius. |
| B — annotation on the DaemonSet | NO | Annotation drift across multiple charts is harder to maintain than a single policy-level list. |
| C — refactor registry-pivot to drop privileged | NO | Rewriting `/etc/rancher/k3s/registries.yaml` on the host requires either privileged + hostPID or a custom CSI shim; both are heavier than the privilege we need to grant. |

The Kyverno policy stays in **Enforce mode** for tenant workloads. Only the `catalyst` platform namespace gains the same exemption every other platform namespace already has.

## Files

- `products/catalyst/chart/templates/qa-fixtures/kyverno-policies-qa.yaml`: add `catalyst` to `$excludedNamespaces` list with explanatory comment.
- `products/catalyst/chart/Chart.yaml`: bump `1.4.132 -> 1.4.133` with changelog entry.
- `clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml`: bump bootstrap-kit pin `1.4.128 -> 1.4.133` so a fresh franchised Sovereign picks up the fix automatically.

## Verification

`helm template products/catalyst/chart --set qaFixtures.enabled=true` shows the `catalyst` namespace now appears in the `disallow-privileged-containers` ClusterPolicy's `exclude.any[].resources.namespaces` list, right after `catalyst-system`:

```yaml
              namespaces: ["catalyst-system"]
              namespaces: ["catalyst"]
              namespaces: ["kyverno"]
```

## Claimed TCs

_None directly — infrastructure fix; unblocks bp-self-sovereign-cutover + bp-catalyst-platform HRs on prov #9, enables console.<sov> reachability + iter-1_

## Test plan

- [ ] On next fresh provision, `kubectl --context=<sov> -n flux-system get hr bp-self-sovereign-cutover` reaches `Ready=True`.
- [ ] `kubectl --context=<sov> -n catalyst get ds registry-pivot` shows `DESIRED == READY` (one Pod per node, all running).
- [ ] `bp-catalyst-platform` HR reaches `Ready=True` and `console.<sov>` Ingress materialises.

DO NOT MERGE — Coordinator owns the merge after sequencing.

Generated with [Claude Code](https://claude.com/claude-code)