### PR TITLE
fix(qa-fixtures): sanitize illegal "/" in label values (Fix #119, prov #10 wedge)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -407,7 +407,16 @@ spec:
       #      creation rejected → 15m hook timeout → loop forever.
       # This Job runs at the very start of every install attempt and
       # guarantees a clean slate.
-      version: 1.4.134
+      # 1.4.135 (qa-loop bounded-provision-cycle Fix #119): sanitize
+      # illegal `/` in qa-fixtures Continuum mirror label value. Prov
+      # #10 wedge — helm install crashed on Continuum CR validation
+      # because the Fix #102 platform-mirror label
+      # `openova.io/continuum-mirror-of: <ns>/<name>` violates k8s
+      # label-value spec (`/` forbidden in values, allowed only in
+      # keys as the prefix separator). Split into two valid labels:
+      # `openova.io/continuum-mirror-of-namespace` +
+      # `openova.io/continuum-mirror-of-name`. Unblocks prov #11+.
+      version: 1.4.135
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -1,5 +1,41 @@
 apiVersion: v2
 name: bp-catalyst-platform
+# 1.4.135 (qa-loop bounded-provision-cycle Fix #119, sanitize illegal
+# `/` in qa-fixtures Continuum mirror label value — unblocks prov #11):
+#
+# Root cause (prov #10 wedge, 2026-05-10):
+#   The platform-mirror Continuum CR (added by Fix #102, PR #1326)
+#   in `templates/qa-fixtures/continuum-qa.yaml` carried label
+#   `openova.io/continuum-mirror-of: <namespace>/<name>` which renders
+#   to `qa-omantel/cont-omantel`. K8s rejects label VALUES containing
+#   `/` (the regex `^[a-z0-9A-Z]([-_.a-z0-9A-Z]*[a-z0-9A-Z])?$`
+#   forbids `/` — only label KEYS may use it as the prefix separator).
+#   Helm install of bp-catalyst-platform crashes on CR validation:
+#     Continuum.dr.openova.io "cont-omantel" is invalid:
+#     metadata.labels: Invalid value: "qa-omantel/cont-omantel": a
+#     valid label must be an empty string or consist of alphanumeric...
+#   This cascade-wedges every fresh Sovereign provision because the
+#   chart never reaches Ready=True.
+#
+# Fix:
+#   Split the cross-namespace reference into two separate, valid
+#   labels — both keys carry the canonical `openova.io/` prefix:
+#     openova.io/continuum-mirror-of-namespace: qa-omantel
+#     openova.io/continuum-mirror-of-name:      cont-omantel
+#   The information is preserved (still queryable via `kubectl get
+#   continuums -A -l openova.io/continuum-mirror-of-namespace=...`
+#   and `...-name=...`) and target-state per OpenOva canonical
+#   pattern (label keys may have `/`, label values never).
+#
+# Per principle 4 / `feedback_inviolable_principles.md` #4 both
+# halves stay values-overridable through `qaFixtures.namespace` and
+# `qaFixtures.continuumName`.
+#
+# Closes/unblocks via fresh chart roll (Fix #119 claimed TCs):
+#   _None directly — infrastructure fix; unblocks bp-catalyst-platform
+#   install on prov #11+ (Continuum/Application/UserAccess CRs no
+#   longer fail label validation)._
+#
 # 1.4.134 (qa-loop iter-1 prefetch Fix #114, qa-fixtures finalizer
 # strip pre-install hook to break the rollback-orphan deadlock):
 #
@@ -888,7 +924,7 @@ name: bp-catalyst-platform
 #   - values.yaml: new knobs `cnpgPairAliasName`,
 #     `cnpgPairPostSwitchoverPrimary`, `continuumPlatformNamespace` —
 #     all values-overridable per INVIOLABLE-PRINCIPLES #4.
-version: 1.4.134
+version: 1.4.135
 appVersion: 1.4.94
 # 1.4.129 (qa-loop iter-16 Fix #65): ship the missing
 # `openova-catalog` Flux v1 HelmRepository in flux-system. The

--- a/products/catalyst/chart/templates/qa-fixtures/continuum-qa.yaml
+++ b/products/catalyst/chart/templates/qa-fixtures/continuum-qa.yaml
@@ -244,7 +244,20 @@ metadata:
   labels:
     openova.io/managed-by: qa-fixtures
     openova.io/scope: platform
-    openova.io/continuum-mirror-of: {{ printf "%s/%s" (.Values.qaFixtures.namespace | default "qa-omantel") (.Values.qaFixtures.continuumName | default "cont-omantel") }}
+    # Fix #119 (qa-loop bounded-provision-cycle prov #11 unblocker):
+    # k8s label VALUES may not contain `/` (only label KEYS may). The
+    # original single-label `<namespace>/<name>` form rendered to
+    # `qa-omantel/cont-omantel` which violates the metadata.labels
+    # validation regex `^[a-z0-9A-Z]([-_.a-z0-9A-Z]*[a-z0-9A-Z])?$`,
+    # crashing helm install of bp-catalyst-platform on every fresh
+    # Sovereign. Split into two labels so the cross-namespace reference
+    # (parent-namespace + parent-name) is still queryable via
+    # `kubectl get -l openova.io/continuum-mirror-of-namespace=<ns>`
+    # without forming an illegal value. Per
+    # `feedback_inviolable_principles.md` #4 both halves stay
+    # values-overridable.
+    openova.io/continuum-mirror-of-namespace: {{ .Values.qaFixtures.namespace | default "qa-omantel" | quote }}
+    openova.io/continuum-mirror-of-name: {{ .Values.qaFixtures.continuumName | default "cont-omantel" | quote }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/instance: {{ .Release.Name }}
 spec:


### PR DESCRIPTION
## Summary

Fix #102 (PR #1326) added a platform-mirror Continuum CR with the label `openova.io/continuum-mirror-of: <ns>/<name>` which renders to the illegal value `qa-omantel/cont-omantel`. K8s label VALUES may not contain `/` (regex `^[a-z0-9A-Z]([-_.a-z0-9A-Z]*[a-z0-9A-Z])?$`) — only label KEYS may use `/` as the prefix separator.

bp-catalyst-platform helm install crashed on Continuum CR validation:

```
Continuum.dr.openova.io "cont-omantel" is invalid:
metadata.labels: Invalid value: "qa-omantel/cont-omantel": a valid
label must be an empty string or consist of alphanumeric...
```

This cascade-wedged every fresh Sovereign provision (live evidence: prov #10 = `c460bd7078dda0f1`).

## Fix

Split the cross-namespace reference into two separate, valid labels — both with the canonical `openova.io/` prefix:

```yaml
openova.io/continuum-mirror-of-namespace: qa-omantel
openova.io/continuum-mirror-of-name:      cont-omantel
```

Information preserved (still queryable via `kubectl get continuums -A -l openova.io/continuum-mirror-of-namespace=<ns>` and `...-name=<name>`) and target-state per OpenOva canonical pattern: label keys may have `/`, label values never.

Per principle 4 (`feedback_inviolable_principles.md` #4) both halves stay values-overridable through `qaFixtures.namespace` and `qaFixtures.continuumName` — no hardcoding.

## Files changed

| File | Change |
|------|--------|
| `products/catalyst/chart/templates/qa-fixtures/continuum-qa.yaml` | Split single illegal label into two valid labels (both quoted, both values-overridable). |
| `products/catalyst/chart/Chart.yaml` | Bump 1.4.134 → 1.4.135 with Fix #119 changelog. |
| `clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml` | Pin 1.4.134 → 1.4.135. |

## Before / After (rendered)

Before:
```yaml
openova.io/continuum-mirror-of: qa-omantel/cont-omantel  # ILLEGAL — `/` in value
```

After:
```yaml
openova.io/continuum-mirror-of-namespace: "qa-omantel"
openova.io/continuum-mirror-of-name: "cont-omantel"
```

## Verification

```bash
helm template testrel products/catalyst/chart \
  --set qaFixtures.enabled=true --set sovereign.fqdn=omantel.biz \
  | grep -A1 'continuum-mirror'
# →   openova.io/continuum-mirror-of-namespace: "qa-omantel"
#     openova.io/continuum-mirror-of-name: "cont-omantel"

# Full label-value validity scan across rendered chart:
# → 0 illegal values

# kubectl client-side validation:
kubectl create --dry-run=client -f /tmp/rendered.yaml
# → no errors
```

## Scope of audit

Scanned **all** qa-fixture templates for label values containing `/`. Only this one occurrence existed — confirmed via `helm template` rendering + Python label-value regex check. The other `printf "%s/%s"` usage (`qa-wp-creds.yaml`) is inside `sha256sum` and produces no illegal value.

## Claimed TCs

_None directly — infrastructure fix; unblocks bp-catalyst-platform install on prov #11+ (Continuum/Application/UserAccess CRs no longer fail label validation)_

## Test plan

- [ ] Wait for CI green on this PR
- [ ] After merge, OCI publish workflow rolls bp-catalyst-platform 1.4.135
- [ ] qa-loop bounded-provision-cycle prov #11 — verify bp-catalyst-platform HR reaches Ready=True with platform-mirror Continuum CR present
- [ ] `kubectl get continuum -n catalyst-system cont-omantel -o yaml | yq .metadata.labels` shows the two split labels with no `/` in values

🤖 Generated with [Claude Code](https://claude.com/claude-code)