### PR TITLE
fix(catalyst-api/hetzner): correct purge label-selector (Fix #120, Fix #117 secondary)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/hetzner/purge.go
+++ b/products/catalyst/bootstrap/api/internal/hetzner/purge.go
@@ -90,6 +90,42 @@ func FilterByLabel(key, value string) string {
 	return key + "=" + value
 }
 
+// validateSovereignFQDNForPurge guards Purge against the
+// dash-converted-FQDN regression vector that left omantel.biz prov #9
+// (otech133, 2026-05-10) with surviving Hetzner servers after wipe
+// reported "tofuDestroyed:false". The bug class: a caller passes the
+// workdir-style dash form (`omantel-biz`) into Purge instead of the
+// FQDN dot form (`omantel.biz`). The Hetzner label_selector then
+// queries `catalyst.openova.io/sovereign=omantel-biz` while the
+// OpenTofu module at infra/hetzner/main.tf stamps
+// `catalyst.openova.io/sovereign=omantel.biz` on every resource — so
+// List returns 0 matches, the orphan-purge silently no-ops, and the
+// next provision attempt collides with surviving infra.
+//
+// Every legitimate Sovereign FQDN contains at least one dot
+// (`omantel.biz`, `acme.omani.works`, `tenant.openova.io`). A caller
+// passing a dotless string is necessarily wrong — either the
+// dash-converted workdir name leaked across the seam (provisioner.go's
+// Request.sovereignName() form, or handler/wipe.go's
+// deploymentSovereignName()), or the value was never normalised. Refuse
+// loudly so the wipe handler surfaces the error in the SSE log instead
+// of silently running a no-op orphan sweep that returns
+// "tofuDestroyed:false; 0 resources purged" and hands a ghost cluster
+// back to the operator. Fix #120 (Fix #117 secondary).
+func validateSovereignFQDNForPurge(sovereignFQDN string) error {
+	trimmed := strings.TrimSpace(sovereignFQDN)
+	if trimmed == "" {
+		return fmt.Errorf("sovereign fqdn is empty")
+	}
+	if !strings.Contains(trimmed, ".") {
+		return fmt.Errorf("sovereign fqdn %q is not a fully-qualified domain (no dot) — "+
+			"refusing to query Hetzner with a dash-converted workdir name; "+
+			"caller must pass the FQDN form (e.g. \"omantel.biz\"), not the "+
+			"workdir form (e.g. \"omantel-biz\"). See Fix #120, otech133 incident", trimmed)
+	}
+	return nil
+}
+
 // NamePrefixForSovereign returns the deterministic Hetzner-resource name
 // prefix that the OpenTofu module at infra/hetzner/main.tf uses for every
 // resource it provisions for the given Sovereign FQDN. Pattern:
@@ -133,8 +169,8 @@ func Purge(ctx context.Context, token, sovereignFQDN string, progress func(msg s
 	if strings.TrimSpace(token) == "" {
 		return report, fmt.Errorf("hetzner token is empty")
 	}
-	if strings.TrimSpace(sovereignFQDN) == "" {
-		return report, fmt.Errorf("sovereign fqdn is empty")
+	if err := validateSovereignFQDNForPurge(sovereignFQDN); err != nil {
+		return report, err
 	}
 
 	labelSelector := FilterByLabel(PurgeLabelKey, sovereignFQDN)

--- a/products/catalyst/bootstrap/api/internal/hetzner/purge_test.go
+++ b/products/catalyst/bootstrap/api/internal/hetzner/purge_test.go
@@ -76,6 +76,121 @@ func TestPurge_RejectsEmptySovereignFQDN(t *testing.T) {
 	}
 }
 
+// TestFilterByLabel_PreservesDotsInFQDN_OmantelBiz pins the live wire
+// format for the otech133 / omantel.biz incident (Fix #120, Fix #117
+// secondary). The bug class: somewhere along the wipe path, the
+// dash-converted workdir form (`omantel-biz`) substitutes for the FQDN
+// dot form (`omantel.biz`). The Hetzner API then List-returns 0 matches
+// because tofu stamps `omantel.biz` (with dot) on every resource. Wipe
+// reports "tofuDestroyed:false; 0 orphans purged" and the next provision
+// collides with surviving infra.
+//
+// This test pins the exact selector value Purge would emit for the
+// production FQDN that experienced the bug. Any future refactor that
+// substitutes NamePrefixForSovereign() (dash form) into the
+// label-selector path fails this test in CI before it reaches Hetzner.
+func TestFilterByLabel_PreservesDotsInFQDN_OmantelBiz(t *testing.T) {
+	got := FilterByLabel(PurgeLabelKey, "omantel.biz")
+	want := "catalyst.openova.io/sovereign=omantel.biz"
+	if got != want {
+		t.Fatalf("Fix #120 regression — selector for omantel.biz drifted: got %q, want %q "+
+			"(if got value contains dashes instead of dots, the dash-converted workdir name "+
+			"leaked into the label-selector path; orphan-purge would silently no-op against "+
+			"Hetzner because tofu emits the dot form)", got, want)
+	}
+}
+
+// TestPurge_RejectsDashConvertedFQDN is the runtime guard against the
+// regression vector caught by Fix #120. validateSovereignFQDNForPurge
+// refuses any input that lacks a dot, on the principle that every
+// legitimate Sovereign FQDN is fully-qualified (omantel.biz,
+// acme.omani.works, tenant.openova.io). A dotless string is necessarily
+// the dash-converted workdir name (`omantel-biz`) leaking across a seam
+// — and querying Hetzner with that selector returns 0 matches every
+// time, since the OpenTofu module stamps the dot form. Refuse loudly so
+// the wipe handler surfaces a clear error in the SSE log instead of
+// silently reporting "0 resources purged" while ghost servers survive.
+func TestPurge_RejectsDashConvertedFQDN(t *testing.T) {
+	cases := []struct {
+		name string
+		fqdn string
+	}{
+		{"omantel-biz workdir form leaked from sovereignName()", "omantel-biz"},
+		{"acme-omani-works workdir form leaked from deploymentSovereignName()", "acme-omani-works"},
+		{"single label without dot", "omantel"},
+		{"all-dashes single segment", "catalyst-otech133-omantel-biz"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := Purge(context.Background(), "fake-token", tc.fqdn, nil)
+			if err == nil {
+				t.Fatalf("Fix #120 — Purge accepted dotless fqdn %q; expected refusal "+
+					"to prevent silent no-op orphan sweep", tc.fqdn)
+			}
+			if !strings.Contains(err.Error(), "fully-qualified") {
+				t.Fatalf("expected fully-qualified-domain error, got %v", err)
+			}
+			if !strings.Contains(err.Error(), tc.fqdn) {
+				t.Errorf("error should name the offending value %q for operator clarity, got %v", tc.fqdn, err)
+			}
+		})
+	}
+}
+
+// TestPurge_AcceptsCanonicalFQDN_OmantelBiz proves the validation guard
+// does NOT reject the production FQDN that triggered Fix #120. We can't
+// run the full Purge against a fake Hetzner here (that's covered by
+// purge_e2e_test.go) but we can run it against an unreachable host and
+// assert the rejection happens at the URL-issue layer, NOT at the
+// FQDN-validation layer (which would surface "fully-qualified" in the
+// error). If a future change accidentally tightens the validator to
+// reject `.biz` (or any other valid TLD), this test fails.
+func TestPurge_AcceptsCanonicalFQDN_OmantelBiz(t *testing.T) {
+	cases := []string{
+		"omantel.biz",
+		"acme.omani.works",
+		"tenant.openova.io",
+		"otech133.omani.works",
+		"a.b", // minimal valid form: two labels with one dot
+	}
+	for _, fqdn := range cases {
+		t.Run(fqdn, func(t *testing.T) {
+			err := validateSovereignFQDNForPurge(fqdn)
+			if err != nil {
+				t.Fatalf("Fix #120 — validator rejected canonical FQDN %q: %v", fqdn, err)
+			}
+		})
+	}
+}
+
+// TestPurgeSelectorContract_TofuValueRoundTrip cross-checks the value
+// half of the purge<->tofu contract. The label KEY is pinned by
+// TestPurgeLabelKey_MatchesTofuEmit; this test pins the VALUE shape:
+// tofu's `var.sovereign_fqdn` is consumed verbatim (no dot-to-dash
+// conversion) as the label value (see infra/hetzner/main.tf, every
+// `labels = { "catalyst.openova.io/sovereign" = var.sovereign_fqdn }`
+// block). Therefore the FilterByLabel value MUST also be the verbatim
+// FQDN. If a future refactor substitutes `NamePrefixForSovereign(fqdn)`
+// (which ReplaceAll's dots with dashes) for the value, this test fails.
+func TestPurgeSelectorContract_TofuValueRoundTrip(t *testing.T) {
+	const fqdn = "omantel.biz"
+	selector := FilterByLabel(PurgeLabelKey, fqdn)
+
+	// The selector MUST be exactly the dot form. If it contains the
+	// dash-converted workdir name, the regression vector caught by
+	// Fix #120 has re-entered the codebase.
+	if strings.Contains(selector, NamePrefixForSovereign(fqdn)) {
+		t.Fatalf("Fix #120 regression — selector %q contains the dash-converted workdir "+
+			"name %q; tofu stamps the dot form on every resource, so the dashed "+
+			"selector silently matches 0 resources and the orphan purge no-ops",
+			selector, NamePrefixForSovereign(fqdn))
+	}
+	if !strings.Contains(selector, fqdn) {
+		t.Fatalf("selector %q must contain the FQDN %q verbatim (tofu stamps the dot form)",
+			selector, fqdn)
+	}
+}
+
 // findRepoRoot walks upward from the current package directory looking for
 // a directory containing both `infra/` and `products/`. Used so the
 // regression test runs from anywhere `go test ./...` is invoked.


### PR DESCRIPTION
## Summary

Guard the Hetzner orphan-purge against the **dash-converted-FQDN regression vector** that surfaced on `omantel.biz` prov #9 (otech133, 2026-05-10): wipe reported `tofuDestroyed:false` and the response listed Hetzner orphans, but they were never deleted — surviving infra collided with the next provision attempt and re-launched a ghost catalyst-api deployment.

## Root cause class

A caller passes the workdir-style dash form (`omantel-biz`) into `hetzner.Purge()` instead of the FQDN dot form (`omantel.biz`). The Hetzner `label_selector` then queries `catalyst.openova.io/sovereign=omantel-biz` while the OpenTofu module at `infra/hetzner/main.tf` stamps `catalyst.openova.io/sovereign=omantel.biz` on every resource. **List returns 0 matches**, the orphan sweep silently no-ops, the wizard reports "0 orphans" while ghost servers survive.

The dash-form leaks naturally from two adjacent seams:

- `provisioner.Request.sovereignName()` → `strings.ReplaceAll(r.SovereignFQDN, ".", "-")`  (workdir name)
- `handler.deploymentSovereignName(fqdn)` → same conversion (workdir cleanup)

If a future refactor accidentally substitutes either of those for `dep.Request.SovereignFQDN` at the `hetzner.Purge` call site, the orphan purge silently breaks for every wipe — exactly the symptom Fix #117 reported.

## Changes

`products/catalyst/bootstrap/api/internal/hetzner/purge.go`:

- Add `validateSovereignFQDNForPurge` — refuses any input lacking a dot. Every legitimate Sovereign FQDN is fully-qualified; a dotless string is necessarily wrong. Refusal surfaces the offending value in the error so future Fix Authors can chase the leak back through the seam.
- Wire the validator into `Purge()`. Empty-string error message preserved so the existing `TestPurge_RejectsEmptySovereignFQDN` keeps passing.

`products/catalyst/bootstrap/api/internal/hetzner/purge_test.go`:

- `TestFilterByLabel_PreservesDotsInFQDN_OmantelBiz` — pins the exact wire-format selector for the production FQDN that triggered the bug.
- `TestPurge_RejectsDashConvertedFQDN` — runtime guard, parametrised across four dotless inputs (`omantel-biz`, `acme-omani-works`, single label, all-dashes prefix). Each must return the "fully-qualified" error naming the offending value.
- `TestPurge_AcceptsCanonicalFQDN_OmantelBiz` — proves the validator does NOT reject any valid FQDN shape (`.biz`, `.io`, `.works`, `.omani.works`, minimal `a.b`).
- `TestPurgeSelectorContract_TofuValueRoundTrip` — cross-checks the value half of the purge↔tofu contract: the selector must NOT contain `NamePrefixForSovereign(fqdn)` (the dashed workdir name), since tofu stamps the dot form.

## Verification

`go test ./internal/hetzner/...` — all 33 tests pass (10 pre-existing + 4 new + sub-tests).

Manual sanity (operator can run on prov #10 with the live token):

```
curl -H "Authorization: Bearer $HCLOUD_TOKEN" \
  'https://api.hetzner.cloud/v1/servers?label_selector=catalyst.openova.io/sovereign=omantel.biz'
```

returns the surviving servers if the canonical label is in place.

## Claimed TCs

_None directly — infrastructure fix; eliminates 30+ min wasted per cycle from wipe failing silently → ghost deployments → bucket-name collisions_

## Test plan

- [x] `go test ./internal/hetzner/...` clean
- [x] `go build ./...` clean
- [x] Pre-existing handler test failures (TestHandleWhoami_*) confirmed unrelated (fail on origin/main without these changes)