### PR TITLE
fix(bp-guacamole): bootstrap Job for guacamole-oidc Secret (Fix #125, prov #11 secondary)

### DIFF
--- a/platform/guacamole/chart/Chart.yaml
+++ b/platform/guacamole/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-guacamole
-version: 0.1.0
+version: 0.1.1
 appVersion: "1.5.5"
 description: |
   Catalyst-authored Blueprint chart for Apache Guacamole — a clientless

--- a/platform/guacamole/chart/templates/oidc-secret-bootstrap-job.yaml
+++ b/platform/guacamole/chart/templates/oidc-secret-bootstrap-job.yaml
@@ -1,0 +1,303 @@
+{{- /*
+OIDC client-secret bootstrap Job (qa-loop iter-1 monitor Fix #125,
+prov #11 secondary).
+
+ROOT CAUSE
+----------
+The chart's guacamole-deployment.yaml mounts an OIDC client-secret via
+`secretKeyRef.name = .Values.guacamole.oidc.clientSecretRef.name`
+(default: `guacamole-oidc`) with `optional: false`. Pre-this-fix the
+ONLY chart artefact carrying this name is `keycloak-client-secret.yaml`,
+which renders a SealedSecret with an EMPTY `encryptedData.client-secret`
+placeholder. The two failure modes seen in prov #11 (TC-230 / TC-370 /
+TC-402):
+
+  1. Sovereigns without bp-sealed-secrets pre-provisioned: the
+     SealedSecret CRD is absent → controller never materialises a
+     downstream `Secret guacamole-oidc` → the webapp pod sits in
+     `CreateContainerConfigError`:
+
+        Error: secret "guacamole-oidc" not found
+
+  2. Sovereigns WITH bp-sealed-secrets but operator has not yet sealed
+     a real value: the SealedSecret renders as `encryptedData.client-
+     secret: ""`, the controller refuses to decrypt the empty bundle
+     → no downstream Secret → same `CreateContainerConfigError`.
+
+Either way the webapp Deployment is permanently wedged because the
+chart NEVER provisions a usable `guacamole-oidc` Secret on its own,
+and Fix #78's lesson (Gap E for k8s-ws-proxy-hmac) is the same here
+applied to a different Secret name.
+
+FIX PATTERN (mirrors Fix #78 + Fix #95 hook-weight ordering)
+-----------------------------------------------------------
+Helm pre-install/pre-upgrade Job that:
+
+  1. Idempotency probe — GET the target Secret. 200 = exists (operator
+     pre-provisioned via SealedSecret OR a prior install ran this Job)
+     → exit 0. 404 = proceed to create. Any other code = FATAL.
+  2. Generate 32 random bytes via `head -c 32 /dev/urandom`, pipe
+     DIRECTLY to `base64 | tr -d '\n'`, and use only as the
+     in-process value for the Secret POST body. Per global CLAUDE.md
+     §10 the bytes are NEVER echoed/cat'd/printed; the env vars
+     holding them are unset immediately after the POST.
+  3. POST to /api/v1/namespaces/<ns>/secrets. 201/200 = success.
+     409 = race-with-operator pre-provision → accept (preserves
+     existing key, never rotates). Any other = FATAL.
+
+Rationale for runtime-generated client secret: every Sovereign is
+isolated; the OIDC client Keycloak holds for `guacamole` is unique to
+that Sovereign. The bp-keycloak realm-config Job uses the SAME
+`guacamole-oidc` Secret (when present) to register the client value —
+so generating once before either side comes up keeps both ends in
+sync.
+
+KEY ROTATION
+------------
+Operator-driven: `kubectl delete secret guacamole-oidc -n catalyst-
+system && flux reconcile helmrelease bp-guacamole -n flux-system`. The
+Job re-runs and regenerates a new value. Coupled rotation in Keycloak
+(via `keycloak-config-cli` re-run) is the operator's responsibility.
+
+HOOK ORDERING (Fix #95 lesson)
+------------------------------
+Within the same hook phase, LOWER weights run FIRST. The Job
+references its ServiceAccount + Role + RoleBinding, so those MUST be
+applied BEFORE the Job. Target ordering:
+
+  ServiceAccount:        helm.sh/hook-weight: "-20" (first)
+  Role:                  helm.sh/hook-weight: "-15"
+  RoleBinding:           helm.sh/hook-weight: "-15"
+  Job:                   helm.sh/hook-weight: "-10" (last)
+
+Same-phase same-weight ordering is undefined (Helm sorts by weight
+then file path then name). Always: SA most-negative, RBAC
+intermediate, Job last.
+
+RBAC SPLIT (feedback_rbac_create_no_resourcenames.md)
+-----------------------------------------------------
+`create` MUST be in its own rule WITHOUT resourceNames. The combined-
+rule pattern (verbs:[create,get,patch] resourceNames:[guacamole-oidc])
+is rejected silently with HTTP 403 by the apiserver authz layer; this
+was the silent root cause of the bp-openbao 6+ chart-iteration debug
+loop.
+
+CANONICAL SEAM
+--------------
+Modelled directly after platform/k8s-ws-proxy/chart/templates/
+hmac-bootstrap-job.yaml (Fix #78 + Fix #95). Same image
+(curlimages/curl:8.10.1), same RBAC split, same ordering, same
+hook-delete policy, same idempotency probe.
+*/}}
+{{- if .Values.guacamole.enabled -}}
+{{- $secretName := .Values.guacamole.oidc.clientSecretRef.name }}
+{{- $secretKey := .Values.guacamole.oidc.clientSecretRef.key }}
+{{- $ns := .Release.Namespace }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: bp-guacamole-oidc-bootstrap
+  namespace: {{ $ns }}
+  labels:
+    {{- include "bp-guacamole.labels" . | nindent 4 }}
+    catalyst.openova.io/component: oidc-bootstrap
+  annotations:
+    "helm.sh/hook": "pre-install,pre-upgrade"
+    "helm.sh/hook-weight": "-20"
+    "helm.sh/hook-delete-policy": "before-hook-creation"
+{{- with .Values.guacamole.imagePullSecrets }}
+imagePullSecrets:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+---
+# Per memory/feedback_rbac_create_no_resourcenames.md:
+# `create` is in a SEPARATE rule WITH NO resourceNames. The apiserver
+# rejects POST /secrets with 403 if `create` carries resourceNames.
+# Splitting the verbs makes the create path correct AND keeps the
+# read path scoped to ONLY this Secret name.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: bp-guacamole-oidc-bootstrap
+  namespace: {{ $ns }}
+  labels:
+    {{- include "bp-guacamole.labels" . | nindent 4 }}
+    catalyst.openova.io/component: oidc-bootstrap
+  annotations:
+    "helm.sh/hook": "pre-install,pre-upgrade"
+    "helm.sh/hook-weight": "-15"
+    "helm.sh/hook-delete-policy": "before-hook-creation"
+rules:
+  # Rule 1: create — NO resourceNames (apiserver authz rejects otherwise).
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["create"]
+  # Rule 2: read — scoped to the single Secret this Job manages.
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames: [{{ $secretName | quote }}]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: bp-guacamole-oidc-bootstrap
+  namespace: {{ $ns }}
+  labels:
+    {{- include "bp-guacamole.labels" . | nindent 4 }}
+    catalyst.openova.io/component: oidc-bootstrap
+  annotations:
+    "helm.sh/hook": "pre-install,pre-upgrade"
+    "helm.sh/hook-weight": "-15"
+    "helm.sh/hook-delete-policy": "before-hook-creation"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: bp-guacamole-oidc-bootstrap
+subjects:
+  - kind: ServiceAccount
+    name: bp-guacamole-oidc-bootstrap
+    namespace: {{ $ns }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: bp-guacamole-oidc-bootstrap
+  namespace: {{ $ns }}
+  labels:
+    {{- include "bp-guacamole.labels" . | nindent 4 }}
+    catalyst.openova.io/component: oidc-bootstrap
+  annotations:
+    "helm.sh/hook": "pre-install,pre-upgrade"
+    "helm.sh/hook-weight": "-10"
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
+spec:
+  backoffLimit: 6
+  ttlSecondsAfterFinished: 300
+  template:
+    metadata:
+      labels:
+        {{- include "bp-guacamole.labels" . | nindent 8 }}
+        catalyst.openova.io/component: oidc-bootstrap
+    spec:
+      serviceAccountName: bp-guacamole-oidc-bootstrap
+      restartPolicy: Never
+      {{- with .Values.guacamole.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: bootstrap
+          # curlimages/curl is the canonical Catalyst seam for in-chart
+          # k8s-API operations from a Job — alpine-based, has /bin/sh,
+          # has /dev/urandom, has base64. Identical to the image used
+          # by Fix #78 (k8s-ws-proxy hmac-bootstrap).
+          image: curlimages/curl:8.10.1
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: SECRET_NAME
+              value: {{ $secretName | quote }}
+            - name: SECRET_KEY
+              value: {{ $secretKey | quote }}
+            - name: NAMESPACE
+              value: {{ $ns | quote }}
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -eu
+              APISERVER="https://kubernetes.default.svc"
+              TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
+              CA=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+
+              echo "[oidc-bootstrap] target: ${NAMESPACE}/${SECRET_NAME} (key=${SECRET_KEY})"
+
+              # ─── Step 1: idempotency probe ─────────────────────────────
+              # GET /secrets/<name>. 200 = exists → operator pre-provisioned
+              # OR a prior install ran this Job → skip generate. 404 = not
+              # found → proceed to create. Any other code is FATAL.
+              code=$(curl -sS -o /tmp/probe.json -w '%{http_code}' \
+                --cacert "${CA}" \
+                -H "Authorization: Bearer ${TOKEN}" \
+                "${APISERVER}/api/v1/namespaces/${NAMESPACE}/secrets/${SECRET_NAME}")
+              if [ "${code}" = "200" ]; then
+                echo "[oidc-bootstrap] Secret already exists — idempotent skip (preserves OIDC client-secret across upgrades)"
+                exit 0
+              fi
+              if [ "${code}" != "404" ]; then
+                echo "[oidc-bootstrap] FATAL: idempotency probe returned HTTP ${code}" >&2
+                cat /tmp/probe.json >&2 || true
+                exit 1
+              fi
+
+              # ─── Step 2: generate 32 random bytes → base64 ──────────────
+              # CRITICAL (global CLAUDE.md §10): the OIDC client-secret
+              # bytes are NEVER echoed/cat/printed. /dev/urandom → base64
+              # → variable consumed only by the JSON-builder printf. The
+              # Secret data field is itself base64 (k8s wire format) — so
+              # the value POSTed is base64(<random_bytes_b64>). Guacamole
+              # consumes the inner base64 string as the OIDC client-secret
+              # via the secretKeyRef in guacamole-deployment.yaml.
+              CLIENT_SECRET_B64=$(head -c 32 /dev/urandom | base64 | tr -d '\n')
+              if [ -z "${CLIENT_SECRET_B64}" ]; then
+                echo "[oidc-bootstrap] FATAL: empty random output (no entropy?)" >&2
+                exit 1
+              fi
+              # The Secret data value must itself be base64 of the file
+              # content. Inner content is the printable token Guacamole
+              # uses; wire-format value is base64(base64(raw_bytes)).
+              WIRE_B64=$(printf '%s' "${CLIENT_SECRET_B64}" | base64 | tr -d '\n')
+
+              # ─── Step 3: POST Secret ────────────────────────────────────
+              BODY=$(printf '{"apiVersion":"v1","kind":"Secret","metadata":{"name":"%s","namespace":"%s","labels":{"catalyst.openova.io/blueprint":"bp-guacamole","catalyst.openova.io/component":"oidc-bootstrap","app.kubernetes.io/managed-by":"Helm"}},"type":"Opaque","data":{"%s":"%s"}}' \
+                "${SECRET_NAME}" "${NAMESPACE}" "${SECRET_KEY}" "${WIRE_B64}")
+              code=$(curl -sS -o /tmp/create.json -w '%{http_code}' \
+                --cacert "${CA}" \
+                -H "Authorization: Bearer ${TOKEN}" \
+                -H "Content-Type: application/json" \
+                -X POST --data "${BODY}" \
+                "${APISERVER}/api/v1/namespaces/${NAMESPACE}/secrets")
+              # Clear the secret bytes from env immediately after POST.
+              CLIENT_SECRET_B64="" ; WIRE_B64="" ; BODY=""
+              if [ "${code}" = "201" ] || [ "${code}" = "200" ]; then
+                echo "[oidc-bootstrap] Secret ${NAMESPACE}/${SECRET_NAME} created"
+                exit 0
+              fi
+              # 409 — race with operator pre-provision (or another concurrent
+              # bootstrap on a multi-replica HelmRelease retry). Treat as
+              # success: the existing Secret is preserved.
+              if [ "${code}" = "409" ]; then
+                echo "[oidc-bootstrap] Secret already created concurrently (HTTP 409) — accepting (preserves existing key)"
+                exit 0
+              fi
+              echo "[oidc-bootstrap] FATAL: POST returned HTTP ${code}" >&2
+              cat /tmp/create.json >&2 || true
+              exit 1
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              cpu: 100m
+              memory: 64Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir:
+            medium: Memory
+            sizeLimit: 8Mi
+{{- end }}

--- a/platform/guacamole/chart/tests/render.sh
+++ b/platform/guacamole/chart/tests/render.sh
@@ -77,7 +77,15 @@ fi
 echo "PASS: empty image.tag fails fast"
 
 # ─────────────────────────────────────────────────────────────────────
-# 3. Full-ON: the canonical 9-resource bundle.
+# 3. Full-ON: the canonical 13-resource bundle.
+#
+# Pre-Fix-#125: 9 resources (Deployment x2, Service x2, HTTPRoute, PVC,
+# SealedSecret, NetworkPolicy, ConfigMap).
+#
+# Fix #125 (qa-loop iter-1 monitor) adds 4 more for the OIDC client-
+# secret bootstrap quartet (ServiceAccount + Role + RoleBinding + Job)
+# so the chart guarantees a usable `guacamole-oidc` Secret exists
+# BEFORE the webapp Deployment rolls. Total = 13.
 # ─────────────────────────────────────────────────────────────────────
 render_on="$TMP/on.yaml"
 helm template bp-guacamole . \
@@ -88,11 +96,7 @@ helm template bp-guacamole . \
   --set guacamole.oidc.issuer=https://kc.test/realms/catalyst \
   > "$render_on"
 
-# Check each canonical kind appears exactly once. We assert 9 distinct
-# `name:` headers under `^kind:` lines that start with one of the
-# expected kinds. `Deployment` appears twice (guacd + webapp) — Service
-# also appears twice — total = 9.
-expect_total=9
+expect_total=13
 got_total="$(grep -cE '^kind:' "$render_on")"
 if [[ "$got_total" != "$expect_total" ]]; then
   echo "FAIL: full-ON rendered $got_total resources, want $expect_total"
@@ -110,6 +114,10 @@ required_kinds=(
   SealedSecret
   NetworkPolicy
   ConfigMap
+  ServiceAccount
+  Role
+  RoleBinding
+  Job
 )
 for k in "${required_kinds[@]}"; do
   if ! grep -qE "^kind: ${k}$" "$render_on"; then
@@ -129,6 +137,73 @@ if ! grep -q "https://guacamole.test" "$render_on"; then
   exit 1
 fi
 echo "PASS: keycloak realm-config wires OIDC client"
+
+# ─────────────────────────────────────────────────────────────────────
+# 4. (Fix #125, qa-loop iter-1 monitor) OIDC bootstrap Job + RBAC.
+#
+# Asserts the bootstrap quartet exists with split RBAC verbs (per
+# memory/feedback_rbac_create_no_resourcenames.md) and the hook-weight
+# ordering invariant from Fix #95 (SA most-negative, Role/RoleBinding
+# intermediate, Job at -10 — lower number runs first).
+# ─────────────────────────────────────────────────────────────────────
+if ! grep -q 'name: bp-guacamole-oidc-bootstrap' "$render_on"; then
+  echo "FAIL: OIDC bootstrap Job/SA/Role/RoleBinding not rendered"
+  exit 1
+fi
+# `create` must appear in its own rule (no resourceNames on that line).
+if ! grep -qE 'verbs: \[ *"create" *\]|verbs:\s*-\s*create|verbs: \[create\]' "$render_on"; then
+  echo "FAIL: OIDC bootstrap Role missing split-out create verb"
+  exit 1
+fi
+echo "PASS: OIDC bootstrap quartet rendered with split verbs"
+
+# Hook-weight ordering — SA < Role <= RoleBinding < Job AND Job == -10.
+weights="$(awk '
+  /^kind:/                                           { kind=$2; weight="" }
+  /name: bp-guacamole-oidc-bootstrap$/               { is_oidc=1 }
+  /"helm\.sh\/hook-weight"/                          { gsub(/.*"helm\.sh\/hook-weight":[ ]*"/,""); gsub(/".*/,""); weight=$0 }
+  /^---$/ {
+    if (is_oidc && weight != "") print kind"="weight
+    is_oidc=0; kind=""; weight=""
+  }
+  END {
+    if (is_oidc && weight != "") print kind"="weight
+  }
+' "$render_on")"
+
+sa_w="$(echo "$weights" | grep -E '^ServiceAccount=' | head -1 | cut -d= -f2)"
+role_w="$(echo "$weights" | grep -E '^Role=' | head -1 | cut -d= -f2)"
+rb_w="$(echo "$weights" | grep -E '^RoleBinding=' | head -1 | cut -d= -f2)"
+job_w="$(echo "$weights" | grep -E '^Job=' | head -1 | cut -d= -f2)"
+
+if [[ -z "$sa_w" || -z "$role_w" || -z "$rb_w" || -z "$job_w" ]]; then
+  echo "FAIL: could not extract all four oidc-bootstrap hook-weights"
+  echo "Captured: SA=$sa_w Role=$role_w RoleBinding=$rb_w Job=$job_w"
+  echo "All weights:"
+  echo "$weights"
+  exit 1
+fi
+if (( sa_w >= role_w )); then
+  echo "FAIL: ordering — SA weight ($sa_w) must be LESS THAN Role weight ($role_w)"
+  exit 1
+fi
+if (( sa_w >= rb_w )); then
+  echo "FAIL: ordering — SA weight ($sa_w) must be LESS THAN RoleBinding weight ($rb_w)"
+  exit 1
+fi
+if (( role_w >= job_w )); then
+  echo "FAIL: ordering — Role weight ($role_w) must be LESS THAN Job weight ($job_w)"
+  exit 1
+fi
+if (( rb_w >= job_w )); then
+  echo "FAIL: ordering — RoleBinding weight ($rb_w) must be LESS THAN Job weight ($job_w)"
+  exit 1
+fi
+if [[ "$job_w" != "-10" ]]; then
+  echo "FAIL: Job weight is $job_w, want -10 (mirrors Fix #78 invariant)"
+  exit 1
+fi
+echo "PASS: hook-weight ordering — SA=$sa_w < Role=$role_w / RoleBinding=$rb_w < Job=$job_w"
 
 echo ""
 echo "All render tests passed."


### PR DESCRIPTION
## Summary

qa-loop iter-1 monitor (Fix #122) caught `guacamole-server` pods stuck in `CreateContainerConfigError` on every fresh provision because Secret `guacamole-oidc` is never created — the chart's `keycloak-client-secret.yaml` only emits a SealedSecret with an empty placeholder, and nothing else provisions the consumed Secret. Same Gap-E pattern Fix #78 fixed for `k8s-ws-proxy-hmac`, applied here to the OIDC client-secret.

This PR adds a Helm pre-install/pre-upgrade Job (`bp-guacamole-oidc-bootstrap`) that:

- Idempotency-probes the target Secret (200 = skip → preserves operator-pre-provisioned SealedSecret OR prior-install key)
- Generates 32 random bytes via `head -c 32 /dev/urandom` → base64 → POST to apiserver (bytes NEVER echoed; env vars unset immediately after POST per global CLAUDE.md §10)
- Treats 409 as success (race-with-operator path is benign)

Hook ordering follows Fix #95: `ServiceAccount=-20 < Role=-15 / RoleBinding=-15 < Job=-10` so SA + RBAC land before the Job runs. RBAC verb split per `feedback_rbac_create_no_resourcenames.md` (`create` in its own rule WITHOUT resourceNames).

Mirrors `platform/k8s-ws-proxy/chart/templates/hmac-bootstrap-job.yaml` (Fix #78 + Fix #95) line-for-line on idempotency, image (`curlimages/curl:8.10.1`), env-clearing, and hook-delete policy.

## Files

- `platform/guacamole/chart/templates/oidc-secret-bootstrap-job.yaml` (new) — SA + Role + RoleBinding + Job quartet
- `platform/guacamole/chart/Chart.yaml` — version `0.1.0` → `0.1.1`
- `platform/guacamole/chart/tests/render.sh` — full-ON resource count `9` → `13`; new gates for split verbs + hook-weight ordering

## Claimed TCs

This Fix unblocks the iter-16 guacamole cohort:

- **TC-230** — `guacd` + `guacamole-server` Deployments READY 1/1 in `catalyst-system` (currently 0/1 because the webapp pod can't start)
- **TC-370** — cluster-wide pod scan reports no CrashLoopBackOff/Pending guacamole pods (currently `Pending` because the Secret mount fails)
- **TC-402** — `guacamole-server-egress` NetworkPolicy active (currently rendered but the matched pod never starts)

## Test plan

- [x] `bash platform/guacamole/chart/tests/render.sh` — all 7 gates PASS (helm 3.20.2)
- [ ] On merge: bp-guacamole `:0.1.1` (CI auto-bumps to `:0.1.2` with new image SHA), then re-provision a fresh Sovereign and confirm `guacamole-server` reaches READY 1/1 within 5 minutes
- [ ] Confirm idempotency: `helm upgrade` on the same release skips the Job's create path (probe returns 200) — preserves the OIDC client-secret across upgrades

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>