### PR TITLE
fix(catalyst-api): catalyst-catalog + organization-controller GITEA_TOKEN secretKeyRef alignment (Fix #124, Fix #122 secondary)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -407,6 +407,17 @@ spec:
       #      creation rejected → 15m hook timeout → loop forever.
       # This Job runs at the very start of every install attempt and
       # guarantees a clean slate.
+      # 1.4.136 (qa-loop iter-1 Fix #124, secondary Fix #122): convert
+      # catalyst-gitea-token bootstrap from post-install to pre-install
+      # hook so catalyst-catalog + catalyst-organization-controller
+      # (which validate non-empty CATALYST_GITEA_TOKEN at startup) see
+      # a populated Secret at first container start. Prior post-install
+      # ordering caused chicken-and-egg deadlock: Deployments crashed
+      # because Secret was empty; mint Job ran AFTER Deployments,
+      # exponential back-off blew past Helm's 15m install timeout,
+      # remediation looped forever. Pre-install hook (weight=10) now
+      # populates the Secret (weight=5) BEFORE any consumer Deployment
+      # rolls. See Chart.yaml top comment for the full diagnostic chain.
       # 1.4.135 (qa-loop bounded-provision-cycle Fix #119): sanitize
       # illegal `/` in qa-fixtures Continuum mirror label value. Prov
       # #10 wedge — helm install crashed on Continuum CR validation
@@ -416,7 +427,7 @@ spec:
       # keys as the prefix separator). Split into two valid labels:
       # `openova.io/continuum-mirror-of-namespace` +
       # `openova.io/continuum-mirror-of-name`. Unblocks prov #11+.
-      version: 1.4.135
+      version: 1.4.136
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -1,5 +1,59 @@
 apiVersion: v2
 name: bp-catalyst-platform
+# 1.4.136 (qa-loop iter-1 Fix #124, secondary Fix #122 — convert
+# catalyst-gitea-token bootstrap to pre-install hook so consumers
+# (catalog + organization-controller + api) see a populated token at
+# their first container start):
+#
+# Root cause (qa-loop iter-1 monitor Fix #122 surfaced 2026-05-10):
+#   On every fresh Sovereign install of bp-catalyst-platform 1.4.135
+#   the `catalyst-catalog` and `catalyst-organization-controller`
+#   Pods enter CrashLoopBackOff with:
+#     {"level":"ERROR","msg":"config load failed",
+#      "err":"config: CATALYST_GITEA_TOKEN is required"}
+#   even though the Secret `catalyst-system/catalyst-gitea-token`
+#   exists. Inspection shows `data.token: ""` — the Secret was
+#   created empty by the chart's lookup-existing-target idempotency
+#   path (lookup returns nil on a fresh install → token bytes are
+#   empty), and the post-install mint Job that was supposed to
+#   populate it ran AFTER the Deployments had already crashed and
+#   accumulated exponential back-off windows. Helm's 15m install
+#   timeout lapsed before the Pods could pick up the patched token,
+#   triggering uninstall-remediation → reinstall → loop.
+#
+#   This is the chicken-and-egg ordering hazard documented in
+#   docs/INVIOLABLE-PRINCIPLES.md #1 (waterfall, not iterative MVP):
+#   credential bootstrap MUST land before the consumers it serves.
+#
+# Fix (chart-side, no app-code change required):
+#   Move the entire token-bootstrap flow (Secret, ServiceAccount,
+#   Roles, RoleBinding, Job) from `helm.sh/hook: post-install,
+#   post-upgrade` to `helm.sh/hook: pre-install,pre-upgrade`. The
+#   Secret is created at hook-weight=5; the mint Job at hook-weight=
+#   10. Helm runs the entire pre-install hook chain to completion
+#   BEFORE applying any regular release resource. Result: when the
+#   catalog / organization-controller Deployments are applied, the
+#   Secret already carries a real PAT, the kubelet mounts it as
+#   CATALYST_GITEA_TOKEN, and the Pods start cleanly on first try.
+#
+#   Defensive alignment in services/catalog/deployment.yaml: add
+#   `optional: true` to the secretKeyRef so the wiring matches the
+#   existing api-deployment + organization-controller convention
+#   (cosmetic — the Secret always exists in the pre-install path,
+#   but `optional: true` keeps kubelet from blocking Pod start
+#   should any future reordering regress this).
+#
+# Lookup contract preserved: on upgrades, `lookup` returns the
+# existing Secret with the populated token, the template re-emits
+# the same bytes, and the mint Job's runtime check (`EXISTING_TOKEN
+# != ""`) short-circuits with exit 0. helm.sh/resource-policy: keep
+# is retained on the Secret so it survives helm uninstalls.
+#
+# Per principle 4 / feedback_inviolable_principles.md #1: target
+# state, not MVP. The pre-install hook IS the canonical seam for
+# Sovereign credential bootstrap (mirrors bp-keycloak's keycloak-
+# config-cli pre-install pattern).
+#
 # 1.4.135 (qa-loop bounded-provision-cycle Fix #119, sanitize illegal
 # `/` in qa-fixtures Continuum mirror label value — unblocks prov #11):
 #
@@ -924,7 +978,7 @@ name: bp-catalyst-platform
 #   - values.yaml: new knobs `cnpgPairAliasName`,
 #     `cnpgPairPostSwitchoverPrimary`, `continuumPlatformNamespace` —
 #     all values-overridable per INVIOLABLE-PRINCIPLES #4.
-version: 1.4.135
+version: 1.4.136
 appVersion: 1.4.94
 # 1.4.129 (qa-loop iter-16 Fix #65): ship the missing
 # `openova-catalog` Flux v1 HelmRepository in flux-system. The

--- a/products/catalyst/chart/templates/catalyst-gitea-token-secret.yaml
+++ b/products/catalyst/chart/templates/catalyst-gitea-token-secret.yaml
@@ -2,15 +2,48 @@
 Auto-provision catalyst-gitea-token Secret on Sovereign install
 (qa-loop iter-12 Fix #54 Workstream 4, follow-up to Fix #53B).
 
-Why this template exists
-========================
+qa-loop iter-1 Fix #124 (chart 1.4.136) — PRE-INSTALL HOOK CONVERSION
+=====================================================================
+Prior post-install hook ordering caused a chicken-and-egg deadlock:
+  1. Helm applies regular release resources (catalog Deployment,
+     organization-controller Deployment, api Deployment etc.) which
+     mount CATALYST_GITEA_TOKEN from data.token of this Secret.
+  2. The Secret was created at this stage with `data.token: ""`
+     (empty bytes, since `lookup` returned nil on a fresh install).
+  3. catalyst-catalog and catalyst-organization-controller validate
+     non-empty tokens at startup (config: CATALYST_GITEA_TOKEN is
+     required) and immediately exit code=1 → CrashLoopBackOff.
+  4. Helm's post-install hook then ran the mint Job, which patched
+     the Secret with a real token. But:
+       (a) The crashlooping Pods' env was already evaluated against
+           the empty value at first start. K8s re-evaluates secretKeyRef
+           env on each container restart, so eventually the back-off
+           Pods could pick up the new token — but the back-off window
+           grows exponentially (10s → 20s → 40s → ... → 5m) and on
+           install #1 the post-install hook had to wait both for Gitea
+           API to become ready AND for the apps to leave back-off.
+       (b) The Helm install timeout (15m) lapsed before all Pods
+           reached Ready, the release flipped to InstallFailed,
+           remediation kicked off `helm uninstall` — which itself
+           timed out — and the loop repeated.
+
+The fix below moves the entire token-bootstrap flow to a `pre-install,
+pre-upgrade` hook so the Secret is populated with a real token BEFORE
+any Deployment that consumes it is rolled out. Result: catalog +
+organization-controller see a valid CATALYST_GITEA_TOKEN at first
+container start; no CrashLoop, no backoff, no Helm timeout.
+
+Why this template exists (background)
+=====================================
 api-deployment.yaml lines 538-543 reference a secretKeyRef on
 `catalyst-gitea-token` for the CATALYST_GITEA_TOKEN env var consumed by
 internal/handler/blueprints.go giteaClientFromEnv(). Without this
 Secret the /api/v1/sovereigns/.../blueprints/{publish,curatable,curate,
 edit-pr} endpoints return the 503 "Gitea client unconfigured" error
 (blueprints.go:184 + blueprints.go:493) — matrix TC-081, TC-082,
-TC-083, TC-085 FAIL.
+TC-083, TC-085 FAIL. catalyst-catalog (services/catalog) and
+catalyst-organization-controller (controllers/organization) consume
+the same Secret for the same Gitea calls.
 
 Pre-Fix #54 the Secret was kubectl-applied as an operational hack
 (see qa-loop-state/iter12-diagnostic-audit.md §"(e) infra-blocked"
@@ -35,7 +68,7 @@ manifest, and `gitea-admin-secret` lives in a different namespace.
 We gate render on `lookup "v1" "Secret" "gitea" "gitea-admin-secret"`
 returning non-nil. This means:
   - On a Sovereign: lookup returns the Secret → template renders the
-    Secret + the post-install Job that mints the PAT zero-touch.
+    Secret + the pre-install Job that mints the PAT zero-touch.
   - On contabo: lookup returns nil → template renders empty bytes →
     the existing hand-rolled wiring (operator-managed via
     clusters/contabo-mkt/apps/.../secret.yaml) is untouched (no helm-
@@ -45,10 +78,9 @@ Persistence across reconciles
 =============================
 The lookup contract is EXISTING-TARGET-WINS: once a PAT is minted into
 catalyst-gitea-token, every subsequent reconcile re-emits the SAME
-bytes. The Job below is gated on `not $existing` so it ONLY fires on
-first install (or after operator deletes the target Secret to force
-re-mint). This is the same pattern as catalyst-openova-kc-credentials-
-secret.yaml — the canonical Sovereign chart-side seam.
+bytes via the lookup result. The Job's first action checks for an
+existing non-empty token in the in-cluster Secret and short-circuits
+(exit 0) when present. So on upgrades the Job runs but is a no-op.
 
 helm.sh/resource-policy: keep — survives helm uninstall so a re-install
 picks up the same bytes via lookup.
@@ -70,6 +102,24 @@ value lives only in the Secret bytes after the Job completes.
   {{- $token = index $existing.data "token" | b64dec -}}
 {{- end -}}
 ---
+{{- /* ---- Secret as pre-install hook ----
+       Created BEFORE regular release resources so that catalog +
+       organization-controller Deployments mount a populated token at
+       first container start.
+
+       Hook delete policy notes:
+       - `before-hook-creation`: on next install the prior hook Secret
+         is deleted before re-create. This is OK because the lookup
+         above runs at template-render time and captures the existing
+         token bytes; the new hook Secret is created with the same
+         bytes.
+       - We DO NOT include `hook-succeeded` because we want the Secret
+         to persist after the hook completes (the Deployments need to
+         mount it for the entire lifetime of the release).
+       - `helm.sh/resource-policy: keep` is retained as belt-and-
+         braces against any future helm-uninstall cleanup of hook
+         resources.
+*/}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -80,6 +130,9 @@ metadata:
     catalyst.openova.io/component: catalyst-gitea-token
     app.kubernetes.io/part-of: catalyst
   annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "5"
+    helm.sh/hook-delete-policy: before-hook-creation
     # Survive helm uninstall — the Secret outlives the release. A
     # subsequent helm install picks up the bytes via lookup against the
     # source Secrets.
@@ -96,24 +149,33 @@ data:
   token: {{ $token | b64enc | quote }}
 {{- if not $token }}
 ---
-{{- /* ---- First-install token-mint Job ----
-       Runs ONCE per fresh install (gated on token=="" above). The Job
-       (a) reads gitea-admin-secret to extract user+pass, (b) waits for
-       Gitea API to be Ready, (c) POSTs /api/v1/users/{admin}/tokens to
-       mint a Personal Access Token with admin scope, (d) writes the
-       PAT into catalyst-gitea-token via kubectl patch on the Secret
-       data.token field.
+{{- /* ---- First-install token-mint Job (pre-install hook) ----
+       Runs ONCE per fresh install (gated on token=="" at template-
+       render time). The Job:
+         (a) reads gitea-admin-secret to extract user+pass
+         (b) waits for Gitea API to be Ready
+         (c) POSTs /api/v1/users/{admin}/tokens to mint a Personal
+             Access Token with admin scope
+         (d) writes the PAT into catalyst-gitea-token via kubectl patch
+             on the Secret data.token field
 
-       Subsequent reconciles see token!="" in the Secret above → this
-       Job branch skips (no annotation re-emit means Helm doesn't
-       re-stamp the Job; even if it did, helm.sh/hook-delete-policy
-       cleans up).
+       Subsequent reconciles see token!="" in the Secret (via lookup) →
+       this Job branch is skipped at template-render time. Even if a
+       prior install left the Job lying around, hook-delete-policy
+       cleans it up before-hook-creation.
 
        Per ADR-0001 §11.3: this is the canonical seam for
        Sovereign-side credential-bootstrap that requires a runtime API
        call rather than pure Helm-template generation. Mirrors
        guacamole-recordings-pvc-migrate Job pattern (qa-loop iter-7
-       Fix #39) and bp-keycloak's keycloak-config-cli post-install hook. */}}
+       Fix #39) and bp-keycloak's keycloak-config-cli pre-install hook.
+
+       Why pre-install (not post-install) — qa-loop iter-1 Fix #124
+       =============================================================
+       See top-of-file note. tl;dr: catalog + organization-controller
+       refuse to start with empty CATALYST_GITEA_TOKEN, so the token
+       MUST be populated BEFORE those Deployments roll. Pre-install
+       hooks run before Helm applies regular release resources. */}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -123,7 +185,7 @@ metadata:
     catalyst.openova.io/blueprint: bp-catalyst-platform
     catalyst.openova.io/component: catalyst-gitea-token-minter
   annotations:
-    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "5"
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 ---
@@ -135,7 +197,7 @@ metadata:
   labels:
     catalyst.openova.io/blueprint: bp-catalyst-platform
   annotations:
-    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "5"
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 rules:
@@ -152,7 +214,7 @@ metadata:
   labels:
     catalyst.openova.io/blueprint: bp-catalyst-platform
   annotations:
-    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "5"
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 subjects:
@@ -175,7 +237,7 @@ metadata:
   labels:
     catalyst.openova.io/blueprint: bp-catalyst-platform
   annotations:
-    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "5"
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 rules:
@@ -192,7 +254,7 @@ metadata:
   labels:
     catalyst.openova.io/blueprint: bp-catalyst-platform
   annotations:
-    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "5"
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 subjects:
@@ -213,7 +275,7 @@ metadata:
     catalyst.openova.io/blueprint: bp-catalyst-platform
     catalyst.openova.io/component: catalyst-gitea-token-mint
   annotations:
-    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "10"
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 spec:

--- a/products/catalyst/chart/templates/services/catalog/deployment.yaml
+++ b/products/catalyst/chart/templates/services/catalog/deployment.yaml
@@ -51,10 +51,19 @@ spec:
             - name: CATALYST_GITEA_URL
               value: {{ .Values.services.catalog.giteaURL | default "http://gitea-http.gitea.svc.cluster.local:3000" | quote }}
             - name: CATALYST_GITEA_TOKEN
+              # qa-loop iter-1 Fix #124 alignment: the canonical wiring
+              # for this Secret reference is the pre-install hook in
+              # templates/catalyst-gitea-token-secret.yaml (chart 1.4.136+).
+              # `optional: true` matches api-deployment + organization-
+              # controller-deployment so a missing Secret does not block
+              # the kubelet from starting the Pod (the app will still
+              # error at startup if CATALYST_GITEA_TOKEN is empty — which
+              # is the contract it requires from the in-cluster Gitea).
               valueFrom:
                 secretKeyRef:
                   name: {{ .Values.services.catalog.giteaSecretRef | default "catalyst-gitea-token" }}
                   key: token
+                  optional: true
             - name: CATALOG_PUBLIC_ORG
               value: {{ .Values.services.catalog.publicOrg | default "catalog" | quote }}
             - name: CATALOG_SOVEREIGN_ORG


### PR DESCRIPTION
## Summary

Convert catalyst-gitea-token bootstrap (Secret + ServiceAccount + Roles + RoleBinding + mint Job) from `helm.sh/hook: post-install,post-upgrade` to `helm.sh/hook: pre-install,pre-upgrade` so the Secret is fully populated with a real Gitea PAT BEFORE any Deployment that consumes it is rolled out. Bumps chart `bp-catalyst-platform` 1.4.135 → 1.4.136.

## Root cause (qa-loop iter-1 monitor Fix #122 surfaced 2026-05-10)

On every fresh Sovereign install of bp-catalyst-platform 1.4.135 the `catalyst-catalog` and `catalyst-organization-controller` Pods enter `CrashLoopBackOff` with:

```
{"level":"ERROR","msg":"config load failed","err":"config: CATALYST_GITEA_TOKEN is required"}
```

Even though Secret `catalyst-system/catalyst-gitea-token` exists, its `data.token` is empty bytes — the Secret was created via the chart's lookup-existing-target idempotency path (lookup returns nil on first install → token is `""`) and the post-install mint Job that was supposed to populate it ran AFTER the Deployments had already crashed. By the time the Job patched the Secret, the Pods were ~5 min between restarts and Helm's 15m install timeout lapsed:

```
Helm install failed for release catalyst-system/catalyst-platform with chart bp-catalyst-platform@1.4.135: failed post-install: 1 error occurred: * timed out waiting for the condition
```

Helm flipped to `InstallFailed`, remediation kicked off `helm uninstall` (which itself timed out), then reinstalled — looping forever.

This is the chicken-and-egg ordering hazard: credential bootstrap MUST land before the consumers it serves.

Live evidence (omantel @ chart 1.4.135):

```
catalyst-catalog-564b4fbfb5-cl669                   0/1     CrashLoopBackOff   5
catalyst-organization-controller-67d8978d75-8j475   0/1     CrashLoopBackOff   5
catalyst-api-6869bf67d9-9sww6                       1/1     Running            0
catalyst-application-controller-78b9b6f4c4-psln7    1/1     Running            0
catalyst-environment-controller-844cbd5946-82s9n    1/1     Running            0
catalyst-useraccess-controller-55f99468fc-nvczk     1/1     Running            0
```

(api / application / environment / useraccess controllers tolerate the empty token because their startup paths defer the Gitea call; catalog + organization-controller validate at boot.)

Secret state on omantel before fix:

```
$ kubectl -n catalyst-system get secret catalyst-gitea-token -o jsonpath='{.data}' | jq 'keys[]'
"token"
"url"
$ kubectl -n catalyst-system get secret catalyst-gitea-token -o yaml | grep token:
  token: ""
```

## Fix

1. **Move the entire token-bootstrap chain to `pre-install,pre-upgrade`** in `templates/catalyst-gitea-token-secret.yaml`:
   - Secret (hook-weight=5, delete-policy `before-hook-creation` only — no `hook-succeeded` so the Secret persists for release lifetime)
   - ServiceAccount (hook-weight=5)
   - Role + RoleBinding in `catalyst-system` (hook-weight=5)
   - Role + RoleBinding in `gitea` (hook-weight=5)
   - Mint Job (hook-weight=10)

   Helm runs pre-install hooks to completion BEFORE applying any regular release resource. Result: when the catalog / organization-controller Deployments are applied, the Secret already carries a real PAT.

2. **Defensive alignment in `services/catalog/deployment.yaml`** — add `optional: true` to the secretKeyRef so the wiring matches the existing `api-deployment` + `organization-controller-deployment` convention.

3. **Bump chart 1.4.135 → 1.4.136** (`Chart.yaml` + bootstrap-kit pin in `clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml`).

## Lookup contract preserved

On upgrades, `lookup` returns the existing Secret with the populated token, the template re-emits the same bytes, and the mint Job's runtime check (`EXISTING_TOKEN != ""`) short-circuits with exit 0. `helm.sh/resource-policy: keep` is retained on the Secret so it survives helm uninstalls.

Per principle 4 / `feedback_inviolable_principles.md` #1: target state, not MVP. The pre-install hook IS the canonical seam for Sovereign credential bootstrap (mirrors bp-keycloak's keycloak-config-cli pre-install pattern, ADR-0001 §11.3).

## Claimed TCs

- **TC-081** — blueprint publish (catalyst-api → Gitea via PAT)
- **TC-082** — blueprint curatable list
- **TC-083** — blueprint curate transition
- **TC-085** — blueprint edit-PR roundtrip
- **TC-090..TC-099** — catalog browse / search / detail (catalyst-catalog service must reach Ready=1/1 to serve any catalog endpoint)
- **TC-110..TC-115** — organization CRUD via organization-controller (per-Org Gitea slug provisioning depends on a working PAT at controller startup)

## Test plan

- [ ] Wait for chart 1.4.136 to land in the bp-catalyst-platform HelmRepository
- [ ] Wipe + re-provision a fresh Sovereign (e.g. otech-fix124)
- [ ] Verify on first install:
  - `kubectl -n catalyst-system get secret catalyst-gitea-token -o jsonpath='{.data.token}' | base64 -d | wc -c` returns >0 BEFORE any Deployment Pod is created
  - `kubectl -n catalyst-system get pod -l app=catalyst-catalog -w` reaches `1/1 Running` within 5 min, no `CrashLoopBackOff`
  - `kubectl -n catalyst-system get pod -l app.kubernetes.io/name=organization-controller -w` reaches `1/1 Running` within 5 min, no `CrashLoopBackOff`
  - `kubectl -n flux-system get hr bp-catalyst-platform -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}'` returns `True` within 10 min
- [ ] Verify upgrade idempotency: bump release annotation, observe mint Job logs `catalyst-gitea-token.token already set; skipping mint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)