### PR TITLE
fix(self-sovereign-cutover): set HR timeout 15m + lower hook deadlines (#127)

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -241,10 +241,12 @@ spec:
         namespace: flux-system
   install:
     disableWait: true
+    timeout: 15m
     remediation:
       retries: 3
   upgrade:
     disableWait: true
+    timeout: 15m
     remediation:
       retries: 3
   # Per-Sovereign overrides — the chart's values.yaml carries

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-self-sovereign-cutover
-version: 0.1.25
+version: 0.1.26
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/values.yaml
+++ b/platform/self-sovereign-cutover/chart/values.yaml
@@ -331,14 +331,19 @@ trigger:
   catalystAPIURL: "http://catalyst-api.catalyst-system.svc.cluster.local:8080"
   # How long the auto-trigger Job will wait for catalyst-api to be
   # reachable before giving up (and exiting 0 so the operator can fire
-  # manually). 5 minutes is enough for a Sovereign mid-cold-start.
-  autoWaitForAPISeconds: 300
+  # manually). Must finish below the HelmRelease install/upgrade
+  # timeout (15m for bp-self-sovereign-cutover) AND the activeDeadline
+  # below so the Job exits cleanly even when catalyst-api never comes
+  # up — 12 minutes leaves a healthy 3m buffer below the 15m HR cap.
+  autoWaitForAPISeconds: 720
   # Overall cap on the auto-trigger Job runtime. activeDeadlineSeconds
   # on the Job spec — anything longer means catalyst-api is sick and
   # the operator should investigate. The Job exiting at this deadline
   # is non-fatal for the chart install (the cutover engine already
   # runs detached inside catalyst-api once /start returns 200).
-  autoTimeoutSeconds: 600
+  # Must stay below the HelmRelease install/upgrade timeout (15m =
+  # 900s) so the Job ends and the hook unblocks before Helm gives up.
+  autoTimeoutSeconds: 840
   # TTL on the completed Job — kept for audit so operators can read
   # the trigger Pod logs if something looks wrong.
   autoJobTTLSeconds: 86400


### PR DESCRIPTION
## Summary

Two prior provisions (#12 `d22b6d4dada2aef2`, #14 `12e194090631a885`) wedged identically at `phase1-watching`:
- `bp-self-sovereign-cutover@0.1.25` post-install hook timed out at 5m (Helm default)
- Flux marked release Failed, retried 3× via remediation, gave up
- catalyst-api never received kubeconfig PUT-back → handover never completed

## Root cause

`HelmRelease` for `bp-self-sovereign-cutover` had no explicit `install.timeout` / `upgrade.timeout` → Helm default = 5m. The auto-trigger Job's `activeDeadlineSeconds` (600s) and `WAIT_TIMEOUT_SECONDS` (300s) were ≥ that 5m → Helm gave up before the Job had a chance to exit cleanly.

## Fix

| Knob | Before | After | Why |
|---|---|---|---|
| HR `install.timeout` / `upgrade.timeout` | (default 5m) | 15m | Covers cold-start cluster + auto-trigger Job |
| `values.autoWaitForAPISeconds` | 300 | 720 | Wait 12m for catalyst-api → exits 0 below 15m HR cap |
| `values.autoTimeoutSeconds` | 600 | 840 | Job activeDeadline 14m, below 15m HR cap |
| Chart version | 0.1.25 | 0.1.26 | |

Hook deadlines now strictly less than HR timeout: 720s wait → 840s Job cap → 900s HR cap.

## Claimed TCs

(infra-only fix; unblocks ALL 410 TCs by allowing prov #15 to converge through phase1 → handover → iter-1)

## Test plan

- [ ] Wait for chart 0.1.26 publish + Flux roll into `clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml` digest
- [ ] Wipe + reprov #15 with `qaTestEnabled: true` (Fix #123 staging cert path)
- [ ] Verify `bp-self-sovereign-cutover` HR Ready=True within 15m of install
- [ ] Verify kubeconfig PUT-back received by catalyst-api → handover completes
- [ ] Verify console.<sov> reachable via staging cert within ~5m of cert-manager
- [ ] Verify catalyst-catalog Pod Running (Fix #124) + guacamole-server Running (Fix #125)

🤖 Generated with [Claude Code](https://claude.com/claude-code)