### PR TITLE
fix(bp-gitea): set HR install/upgrade timeout=15m for fresh-prov mirror push (#131)

### DIFF
--- a/clusters/_template/bootstrap-kit/10-gitea.yaml
+++ b/clusters/_template/bootstrap-kit/10-gitea.yaml
@@ -63,10 +63,12 @@ spec:
   # checks Ready=True independently. Replaces PR #221 spec.timeout: 15m.
   install:
     disableWait: true
+    timeout: 15m
     remediation:
       retries: 3
   upgrade:
     disableWait: true
+    timeout: 15m
     remediation:
       retries: 3
   values:


### PR DESCRIPTION
## Summary

prov #15 (`0ad3687ddd72deb7`) and prov #16 (`083f8c9abbcf64d4`) both wedged at `phase1-watching` for 35+ minutes. Diagnostic on prov #16 event stream (2285 events) found:

**bp-gitea HR loops in 5-minute install attempts** — Helm post-install hook (gitea init + Catalyst-Zero blueprint mirror push per `feedback_gitea_mirror_blocks_cutover_push.md`) takes >5m on cold control plane. After each timeout flux-helm-controller uninstalls + reinstalls → hook restarts from scratch → never completes.

```
Attempt #1: 23:03:01 → 23:08:02 timeout (5m exact)
Attempt #2: 23:08:13 → 23:13:14 timeout (5m exact)
Attempt #3: 23:13:26 → 23:18:26 timeout (5m exact)
Attempt #4: 23:18:40 → 23:23:41 timeout (5m exact)
```

Cascade:
- bp-gitea blocked → bp-self-sovereign-cutover gated on `dependency 'flux-system/bp-gitea' is not ready`
- cutover auto-trigger Job never spawns
- kubeconfig PUT-back to catalyst-api never happens
- phase1-watching wedges forever

## Verified NOT the root cause
- Fix #127 (cutover HR timeout=15m): IS deployed but never reached
- Fix #129 (bp-keycloak chart 1.4.3): IS deployed AND working (Ready=True at 23:01:47, no hook failure)
- bp-cnpg/bp-openbao: Healthy

## Fix

| Knob | Before | After |
|---|---|---|
| HR `install.timeout` | (default 5m) | 15m |
| HR `upgrade.timeout` | (default 5m) | 15m |

Same canonical-seam pattern as #127 (cutover) and #129 (keycloak). disableWait + remediation preserved.

## Claimed TCs

(infra-only fix; unblocks ALL 410 TCs by allowing prov #17 to converge through phase1 → kubeconfig PUT-back → handover → iter-1)

## Test plan

- [ ] Wipe prov #16 + reprov #17 with qaTestEnabled: true
- [ ] Verify bp-gitea HR Ready=True within 15min (single attempt, no uninstall/reinstall loop)
- [ ] Verify bp-self-sovereign-cutover deps satisfied → auto-trigger Job runs
- [ ] Verify kubeconfig PUT-back received by catalyst-api → phase2 reached
- [ ] Verify console.<sov> reachable via staging cert (Fix #123)

🤖 Generated with [Claude Code](https://claude.com/claude-code)