### PR TITLE
fix(infra/hetzner): add skip_region_validation to aws provider for Hetzner regions (#135)

### DIFF
--- a/infra/hetzner/versions.tf
+++ b/infra/hetzner/versions.tf
@@ -87,6 +87,7 @@ provider "aws" {
   skip_credentials_validation = true
   skip_metadata_api_check     = true
   skip_requesting_account_id  = true
+  skip_region_validation      = true
   s3_use_path_style           = true
 
   endpoints {


### PR DESCRIPTION
## Summary

Fix #133 (PR #1343) swapped to hashicorp/aws but missed `skip_region_validation = true`. The aws provider's region validator rejects Hetzner regions (`fsn1`/`nbg1`/`hel1`) at provider-init before any S3 call:

```
Error: invalid AWS Region: fsn1
provider["registry.opentofu.org/hashicorp/aws"]
```

Reproduced on prov #19 (`02c23fc20df90629`) — failed at `tofu plan` in 96s.

## Fix

One-line addition to the existing `provider \"aws\"` block in `infra/hetzner/versions.tf`:

```hcl
skip_region_validation      = true
```

Companion to the existing `skip_credentials_validation` + `skip_metadata_api_check` + `skip_requesting_account_id` flags. Region string still passes through to the S3 SDK as the SigV4 signing region (which Hetzner expects).

## Claimed TCs

(infra-only fix; unblocks ALL 410 TCs by allowing prov #20 to reach Phase 1 cluster bootstrap)

## Test plan

- [ ] Wipe + reprov #20 with `qaTestEnabled: true`
- [ ] Verify tofu plan + tofu apply both succeed within 2min
- [ ] Verify all subsequent fixes validate (Fix #131 gitea, Fix #129 keycloak, Fix #127 cutover)

🤖 Generated with [Claude Code](https://claude.com/claude-code)