### PR TITLE
fix(bp-external-secrets-stores): bump webhookGate timeout 60s -> 300s (#141)

### DIFF
--- a/clusters/_template/bootstrap-kit/15a-external-secrets-stores.yaml
+++ b/clusters/_template/bootstrap-kit/15a-external-secrets-stores.yaml
@@ -48,13 +48,18 @@ spec:
   chart:
     spec:
       chart: bp-external-secrets-stores
+      # 1.0.2 (issue #141 / prov #21): bump webhookGate.timeoutSeconds
+      # 60 -> 300. Fix #137's 60s budget raced on prov #21
+      # (`f84f6c3ff2b60296`, HR FAILED `failed pre-install: timed out`)
+      # where webhook convergence took 75-105s on slow Hetzner cold-start.
+      #
       # 1.0.1 (issue #137 / prov #20): pre-install hook gates the
       # ClusterSecretStore apply on the upstream ESO admission webhook
       # actually being dial-able (Pod-Ready ≠ Endpoints-populated +
       # cert-manager Cert mounted + CABundle injected). Without it the
       # HR FAILED with `exceeded max retries` on cold-cluster provisions
       # even though dependsOn (bp-external-secrets) was satisfied.
-      version: 1.0.1
+      version: 1.0.2
       sourceRef:
         kind: HelmRepository
         name: bp-external-secrets-stores

--- a/platform/external-secrets-stores/chart/Chart.yaml
+++ b/platform/external-secrets-stores/chart/Chart.yaml
@@ -1,10 +1,17 @@
 apiVersion: v2
 name: bp-external-secrets-stores
+# 1.0.2 (issue #141 / prov #21): bump webhookGate.timeoutSeconds 60 -> 300.
+# Fix #137's 60s budget caught most cases but raced on prov #21
+# (`f84f6c3ff2b60296`) where the full webhook convergence (Pod Ready +
+# cert-manager TLS Secret mount + cainjector CA bundle patch + Endpoints
+# populate) took 75-105s on a slow Hetzner cold-start node. 300s gives
+# ~3x headroom while still failing fast on a genuinely broken upstream.
+#
 # 1.0.1 (issue #137 / prov #20): pre-install hook gates ClusterSecretStore
 # apply on the upstream ESO admission webhook being dial-able. Closes the
 # Pod-Ready ≠ webhook-serving race that wedged prov #20 with `exceeded
 # max retries`.
-version: 1.0.1
+version: 1.0.2
 description: |
   Catalyst-curated Blueprint chart for the default ESO ClusterSecretStore(s)
   that wire each Sovereign's bp-external-secrets controller to its bp-openbao

--- a/platform/external-secrets-stores/chart/values.yaml
+++ b/platform/external-secrets-stores/chart/values.yaml
@@ -49,12 +49,20 @@ webhookGate:
   service:
     name: external-secrets-webhook
     namespace: external-secrets-system
-  # Total wait budget; 60s is enough for a Ready webhook Pod's Endpoints
-  # object to populate + cert-manager Certificate to be mounted. Past that,
-  # something is wrong upstream and we want the install to fail loudly so
-  # Flux remediation surfaces the real cause (don't paper over with longer
-  # retries — see PRINCIPLE 4).
-  timeoutSeconds: 60
+  # Total wait budget. Originally 60s (1.0.1) — proved too tight on prov #21
+  # (`f84f6c3ff2b60296`) where the upstream ESO webhook took ~75-105s to
+  # reach a fully serving state on a fresh Hetzner cold-start k3s. The full
+  # convergence path is:
+  #   1. external-secrets-webhook Pod Ready          (~30-60s after install)
+  #   2. cert-manager TLS Secret created + mounted   (~30s after Pod Ready)
+  #   3. cainjector patches ValidatingWebhookConfig CA (~10s)
+  #   4. Endpoints object populates                  (~5s)
+  # Total: 75-105s end-to-end. 300s gives ~3x headroom for the slowest
+  # observed cold-start while still failing fast on a genuinely broken
+  # upstream (5min vs an unbounded Helm timeout). This is target-state per
+  # docs/INVIOLABLE-PRINCIPLES.md #4 — sized to the real worst-case, not
+  # padded retry-bandaid.
+  timeoutSeconds: 300
   # Poll interval. 2s gives ~30 attempts in the 60s budget.
   intervalSeconds: 2
   # Hook image. bitnami/kubectl is the canonical chart-side tooling across


### PR DESCRIPTION
## Summary

Closes the Fix #137 regression that wedged prov #21 (`f84f6c3ff2b60296`) with `bp-external-secrets-stores` HR FAILED `failed pre-install: timed out`.

Fix #137 (PR #1345) shipped a pre-install hook polling the ESO admission webhook with a 60s budget. The Fix #137 commit message itself documented that realistic convergence is 75-105s end-to-end on a fresh k3s. Prov #21 hit the slow path.

**Fix:** bump `webhookGate.timeoutSeconds` 60 -> 300. ~3x the worst-observed convergence path. Still fails fast on a genuinely broken upstream.

## Why target-state, not bandaid

Per docs/INVIOLABLE-PRINCIPLES.md #4:
- 300s is sized to the **real** worst-case (~105s observed) with safety multiplier — not arbitrary padding
- timeoutSeconds remains operator-overridable from cluster overlays (no hardcode)
- The hook still fails loudly on genuine breakage (vs unbounded Helm timeout)

Alternative considered (rejected): also poll cert-manager TLS Secret + ValidatingWebhookConfiguration CA bundle independently. Better signal but doubles chart logic + adds 3 RBAC verbs. Simple budget bump fixes prov #21 with less surface area.

## Changes

- `platform/external-secrets-stores/chart/values.yaml`: `webhookGate.timeoutSeconds` 60 -> 300 (with rationale comment)
- `platform/external-secrets-stores/chart/Chart.yaml`: 1.0.1 -> 1.0.2
- `clusters/_template/bootstrap-kit/15a-external-secrets-stores.yaml`: HR pin 1.0.1 -> 1.0.2

## Claimed TCs

- prov #21 bp-external-secrets-stores HR reaches Ready=True on fresh Hetzner provision (no `failed pre-install: timed out`)
- ClusterSecretStore `vault-region1` admitted by ESO webhook on first install (no `connection refused` from apiserver)
- `webhookGate.timeoutSeconds` remains overridable from cluster overlays

## Test plan

- [ ] Provision fresh Sovereign on Hetzner cold-start node
- [ ] Confirm `bp-external-secrets-stores` HR reaches Ready=True within 300s of `bp-external-secrets` Ready
- [ ] Confirm `clustersecretstore/vault-region1` exists + admitted

🤖 Generated with [Claude Code](https://claude.com/claude-code)