### PR TITLE
fix(bp-keycloak): post-upgrade hook regression on prov #21 (#140)

### DIFF
--- a/clusters/_template/bootstrap-kit/09-keycloak.yaml
+++ b/clusters/_template/bootstrap-kit/09-keycloak.yaml
@@ -45,12 +45,15 @@ spec:
       # parameter so each Sovereign owns its KC realm named after the tenant
       # short-name (omantel chroot → "omantel"). Default `sovereign` is kept
       # in the chart for backward compat with overlays not yet migrated.
-      # 1.4.3 (issue #129): bumps keycloakConfigCli.availabilityCheck.timeout
-      # 120s → 600s + backoffLimit 1 → 5. Fixes "post-upgrade hooks failed:
-      # timed out waiting for the condition" wedge on fresh provisions where
-      # Postgres+Liquibase bootstrap exceeds the bitnami subchart's 120s
-      # default Keycloak-availability window for the realm-import Job.
-      version: 1.4.3
+      # 1.4.4 (issue #140, post-upgrade hook regression on prov #21): bumps
+      # keycloakConfigCli.availabilityCheck.timeout 600s → 900s + adds
+      # cleanupAfterFinished (1h TTL) so stale hook Pods don't race
+      # before-hook-creation deletes on subsequent upgrades. Coupled with
+      # the install/upgrade timeout bump below (15m → 30m) so Helm's
+      # outer hook-wait accommodates the inner 15m availability window.
+      # 1.4.3 (issue #129): bumped keycloakConfigCli.availabilityCheck.timeout
+      # 120s → 600s + backoffLimit 1 → 5 (fresh-install wedge).
+      version: 1.4.4
       sourceRef:
         kind: HelmRepository
         name: bp-keycloak
@@ -60,14 +63,25 @@ spec:
   # 100+ Liquibase changesets). Helm install completes when manifests
   # apply; downstream dependsOn checks Ready=True independently.
   # Replaces PR #221 spec.timeout: 15m.
+  #
+  # 15m → 30m bump (issue #140, post-upgrade hook regression on prov #21):
+  # `disableWait: true` skips Pod-Ready waits but does NOT skip Helm hook
+  # waits — Helm always blocks on hook-Pod completion bounded by this
+  # timeout. The bp-keycloak chart's keycloak-config-cli post-install/
+  # post-upgrade hook now has an inner availabilityCheck.timeout of 900s
+  # (15m), and on chart-roll-triggered upgrades the keycloak StatefulSet
+  # rolling-restart + Liquibase re-validation can consume that full
+  # window. 30m gives Helm room to wait out one full inner attempt plus
+  # exponential backoff if needed, without blowing past Flux's HR timer.
+  # If you bump availabilityCheck.timeout further, bump THIS too.
   install:
     disableWait: true
-    timeout: 15m
+    timeout: 30m
     remediation:
       retries: 3
   upgrade:
     disableWait: true
-    timeout: 15m
+    timeout: 30m
     remediation:
       retries: 3
   # Per-Sovereign overrides — issue #387 + #604 + qa-loop iter-12 Fix #53A:

--- a/platform/keycloak/chart/Chart.yaml
+++ b/platform/keycloak/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-keycloak
-version: 1.4.3
+version: 1.4.4
 description: |
   Catalyst-curated Blueprint umbrella chart for Keycloak. Depends on the
   upstream `keycloak` chart (bitnami) as a Helm subchart so
@@ -36,6 +36,29 @@ description: |
   credentials Secret `realm` key flow from the same value, keeping
   Keycloak realm and catalyst-api CATALYST_KC_REALM env in sync. Closes
   TC-124, TC-125, TC-159, TC-160, TC-161, TC-176, TC-190, TC-285.
+  1.4.4 (issue #140, post-upgrade hook regression on prov #21): Fix #129
+  set 600s + backoffLimit=5, which works for fresh-install but races on
+  upgrade. On prov #21 (f84f6c3ff2b60296, 2026-05-11) the chart-roll on
+  contabo (PR #1346/#1347 stack) triggered an HR UPGRADE; the keycloak
+  StatefulSet rolled, Helm fired the post-upgrade hook before the new
+  Pod's admin endpoint recovered (Liquibase re-validation + JVM cold
+  start on freshly-provisioned node), and the inner 600s availability
+  window expired before the first attempt found Keycloak Ready. With
+  backoffLimit=5 + 10s..6m exponential backoff the worst-case wall clock
+  exceeds the parent HR's 15m upgrade.timeout → Helm aborts the hook →
+  "post-upgrade hooks failed". Target-state fix:
+    - keycloakConfigCli.availabilityCheck.timeout 600s → 900s (15m inner
+      wait covers a single rolling-restart + Liquibase cycle without
+      retry, eliminating most backoff time)
+    - keycloakConfigCli.cleanupAfterFinished.enabled true (1h TTL) so
+      stale hook Pods don't race the before-hook-creation delete on
+      subsequent upgrades
+    - HR install.timeout + upgrade.timeout 15m → 30m
+      (clusters/_template/bootstrap-kit/09-keycloak.yaml) so Helm's
+      outer hook-wait accommodates the inner 15m availability window
+      plus normal backoff.
+  Coupled chart + HR move per Principle #3 (no half-fix). All knobs stay
+  operator-overridable via valuesFrom (Principle #4).
   1.4.3 (issue #129, post-upgrade hook timeout wedge): bump bitnami
   keycloakConfigCli.availabilityCheck.timeout 120s → 600s and
   backoffLimit 1 → 5. Fresh-Sovereign provision #15 (otech

--- a/platform/keycloak/chart/values.yaml
+++ b/platform/keycloak/chart/values.yaml
@@ -286,7 +286,7 @@ keycloak:
       registry: docker.io
       repository: bitnamilegacy/keycloak-config-cli
       tag: 6.4.0-debian-12-r11
-    # ─── Hook timing — issue #129 (post-upgrade hook timeout wedge) ─────────
+    # ─── Hook timing — issue #129 (install) + #140 (post-upgrade) ───────────
     #
     # Root cause history (prov #15, otech 0ad3687ddd72deb7, 2026-05-10):
     # Flux's first install of bp-keycloak races against PostgreSQL readiness;
@@ -304,35 +304,70 @@ keycloak:
     # (dependsOn keycloak OIDC) never installs → bp-self-sovereign-cutover
     # never converges → fresh provision wedges at phase1-watching.
     #
-    # Fix per Inviolable Principle #4 (no hardcoding) — both knobs are
-    # operator-overridable via per-Sovereign overlay valuesFrom path:
+    # Post-upgrade regression (prov #21, f84f6c3ff2b60296, 2026-05-11):
+    # bp-keycloak@1.4.3 HR FAILED with `post-upgrade hooks failed` AFTER
+    # Fix #129. Different code path than fresh-install:
+    #   - chart-roll on contabo (PR #1346/#1347 stack) triggered an HR
+    #     UPGRADE on the new Sovereign. Helm post-upgrade hook fires when
+    #     manifests apply (`upgrade.disableWait: true` does NOT skip hooks
+    #     — Helm always waits for hook-Pod completion).
+    #   - Keycloak StatefulSet pods restart during upgrade (config delta
+    #     rolls them); during the rolling restart the Service has 0
+    #     Endpoints for tens of seconds.
+    #   - Even with availabilityCheck.timeout=600s (10m for inner wait), if
+    #     Keycloak's admin endpoint takes > 10m to recover under load
+    #     (Liquibase migrations re-validate on restart, JVM warm-up cold
+    #     after image-pull on a freshly-provisioned node), the FIRST Pod
+    #     attempt times out. With backoffLimit=5 we get up to 6 attempts
+    #     total — but each subsequent retry adds an exponential delay
+    #     (10s, 20s, 40s, … capped 6m). Worst-case wall-clock for the
+    #     hook to complete: 6 × (10m availability + up to 6m backoff) ≈
+    #     60m+, which BLOWS PAST the parent HR's 15m upgrade.timeout →
+    #     Helm aborts the hook → "post-upgrade hooks failed".
+    #
+    # Target-state fix (issue #140, NOT a workaround per Principle #3):
+    #   - Bump availabilityCheck.timeout 600s → 900s (15m) — covers a
+    #     legitimate StatefulSet rolling-restart + Liquibase re-validation
+    #     window in a single Pod attempt, eliminating most retries.
+    #   - Keep backoffLimit at 5 (no need to bump; first attempt now fits).
+    #   - cleanupAfterFinished.enabled: true with 1h TTL — without this,
+    #     stale Failed/Completed Job pods accumulate across upgrades and
+    #     `helm.sh/hook-delete-policy: before-hook-creation` may race with
+    #     a still-being-deleted Pod from the previous upgrade, causing
+    #     spurious "object is being deleted" hook errors. Bitnami's
+    #     ttlSecondsAfterFinished hook surfaces this knob via .seconds.
+    #
+    # Coupled HR change (clusters/_template/bootstrap-kit/09-keycloak.yaml):
+    # bumps install.timeout AND upgrade.timeout 15m → 30m so Helm's
+    # outer hook-wait gracefully accommodates the inner 15m availability
+    # window plus normal backoff (the realistic worst case is now ≤ 25m).
+    # The two timeouts MUST move together — chart-side tuning without HR
+    # outer-bound is a half-fix.
+    #
+    # All knobs remain operator-overridable via per-Sovereign overlay
+    # valuesFrom paths (Inviolable Principle #4: no hardcoding):
     #   keycloak.keycloakConfigCli.availabilityCheck.timeout
     #   keycloak.keycloakConfigCli.backoffLimit
-    # The chart defaults below are tuned for the documented worst case
-    # (slow Postgres + cold image-pull); operators with faster substrates
-    # may shorten them.
-    #
-    # Numbers picked to fit inside the parent HR's 15m install/upgrade
-    # timeout while leaving headroom for Job pod scheduling + image pull:
-    #   - availabilityCheck.timeout 600s (10 min) — keycloak-config-cli
-    #     polls Keycloak's /admin REST endpoint; this caps the single-Pod
-    #     wait. Covers Postgres bootstrap + Liquibase + Keycloak internal
-    #     startup with margin.
-    #   - backoffLimit 5 — Job retries with exponential backoff (cap 6m by
-    #     default). Combined with a 10m availability poll the realistic
-    #     worst case is one Pod hitting the timeout, then a successful
-    #     retry once Keycloak Ready.
+    #   keycloak.keycloakConfigCli.cleanupAfterFinished.enabled
+    #   keycloak.keycloakConfigCli.cleanupAfterFinished.seconds
+    # Operators with faster substrates may shorten them.
     #
     # NOT a workaround per Inviolable Principle #3. The workaround would
     # be disabling the hook semantics entirely (set annotations: {}); that
     # breaks the documented contract that the realm is imported before
     # the Helm release reaches Ready (downstream bp-gitea + catalyst-api
     # depend on the realm existing). Tuning the hook's internal timing
-    # respects the contract.
+    # AND the outer Helm hook-wait both respect the contract.
     availabilityCheck:
       enabled: true
-      timeout: "600s"
+      timeout: "900s"
     backoffLimit: 5
+    # Bitnami exposes ttlSecondsAfterFinished via .cleanupAfterFinished.
+    # 3600s = 1h — long enough for an operator post-mortem on a Failed
+    # hook Pod, short enough that a re-upgrade an hour later starts clean.
+    cleanupAfterFinished:
+      enabled: true
+      seconds: 3600
     # ─── Phase-8b realm ConfigMap (issue #604, #899) ─────────────────────────
     # The realm import JSON is now owned by the parent bp-keycloak chart's
     # templates/configmap-sovereign-realm.yaml template. That template has


### PR DESCRIPTION
## Summary
- prov #21 (`f84f6c3ff2b60296`, 2026-05-11): bp-keycloak@1.4.3 HR FAILED with `post-upgrade hooks failed` — different code path than Fix #129's fresh-install scenario.
- Root cause: chart-roll on contabo (PR #1346/#1347 stack) triggered an HR upgrade on the new Sovereign. Helm fired the post-upgrade hook (keycloak-config-cli Job) before the rolling keycloak StatefulSet's admin endpoint recovered. Even with Fix #129's `availabilityCheck.timeout: 600s`, the legitimate worst-case wall clock for 6 retry attempts × (10m wait + up to 6m backoff) ≈ 60m+ blew past the parent HR's `upgrade.timeout: 15m`.
- `disableWait: true` on the HR does NOT skip Helm hooks — Helm always blocks on hook completion bounded by the outer `timeout`. The two timeouts MUST move together.
- Target-state fix per Principle #3 (no half-fix): chart inner timeout + HR outer timeout + Job cleanup all move together.

## Files
- `platform/keycloak/chart/values.yaml` — `keycloakConfigCli.availabilityCheck.timeout` 600s → 900s; `cleanupAfterFinished.enabled: true` with 1h TTL.
- `platform/keycloak/chart/Chart.yaml` — `version: 1.4.3 → 1.4.4` + 1.4.4 changelog block.
- `clusters/_template/bootstrap-kit/09-keycloak.yaml` — HR `install.timeout` + `upgrade.timeout` `15m → 30m`; chart pin `1.4.3 → 1.4.4`.

## Why this is target-state, not a workaround (Principle #3)
- Hook semantics intact — disabling annotations would break the documented contract that the realm exists before HR Ready (downstream `bp-gitea` + `catalyst-api` depend on it).
- All knobs remain operator-overridable via per-Sovereign `valuesFrom` (Principle #4).
- Coupled chart + HR change — chart-side tuning without HR outer-bound is a half-fix.
- Canonical seam (Principle #16): `bitnami/keycloak/templates/keycloak-config-cli-job.yaml` honours `availabilityCheck.timeout` + `cleanupAfterFinished` knobs natively; HR `install/upgrade.timeout` is the only path Helm honours for hook-wait.

## Claimed TCs
Infra-level fix. Unblocks every downstream provision-dependent TC on prov #22+:
- All 410 qa-loop matrix TCs (prov #21 wedged at `bp-keycloak` post-upgrade → bp-gitea + bp-self-sovereign-cutover blocked).
- Directly Keycloak-dependent: TC-124, TC-125, TC-159, TC-160, TC-161, TC-176, TC-190, TC-248, TC-285.
- Indirectly blocked (~370): every row that requires a Sovereign reaching `phase1-ready`/`handover-complete`.

## Test plan
- [ ] CI builds chart `bp-keycloak:1.4.4` and pushes to `oci://ghcr.io/openova-io`.
- [ ] Next provision cycle (#22+) reaches `phase1-ready`/`handover-complete` instead of wedging on bp-keycloak post-upgrade hook.
- [ ] On chart-roll triggered upgrade: `kubectl get hr -n flux-system bp-keycloak -o yaml` shows `Ready=True` within 30 min.
- [ ] keycloak-config-cli hook Job logs show single successful availability poll (no retry attempts) under normal conditions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)