### PR TITLE
fix(bp-external-secrets-stores): HR install/upgrade timeout=15m (#143)

### DIFF
--- a/clusters/_template/bootstrap-kit/15a-external-secrets-stores.yaml
+++ b/clusters/_template/bootstrap-kit/15a-external-secrets-stores.yaml
@@ -68,9 +68,11 @@ spec:
   # dependsOn is the gate, not Helm timeout).
   install:
     disableWait: true
+    timeout: 15m
     remediation:
       retries: 3
   upgrade:
     disableWait: true
+    timeout: 15m
     remediation:
       retries: 3


### PR DESCRIPTION
## Summary

prov #22 chart 1.0.2 (Fix #141) hit HR `install.timeout` default 5m before its `webhookGate.timeoutSeconds=300` could complete. Same canonical-seam pattern as Fix #127 (cutover) and Fix #131 (gitea).

## Fix

| Knob | Before | After |
|---|---|---|
| HR `install.timeout` | (default 5m) | 15m |
| HR `upgrade.timeout` | (default 5m) | 15m |

## Claimed TCs

(infra-only fix; unblocks bp-external-secrets-stores and downstream HRs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)