### PR TITLE
fix(bp-powerdns): raise zone-bootstrap Job deadline 300s -> 840s (#144)

### DIFF
--- a/clusters/_template/bootstrap-kit/11-powerdns.yaml
+++ b/clusters/_template/bootstrap-kit/11-powerdns.yaml
@@ -100,7 +100,15 @@ spec:
       # provisioning paths operative.
       # 1.2.1: zone-bootstrap Job needs /tmp emptyDir (readOnlyRootFS+
       # curl -o /tmp/zone-resp). Caught live on otech103 2026-05-04.
-      version: 1.2.1
+      # 1.2.2 (issue #144): zone-bootstrap Job activeDeadlineSeconds
+      # raised 300s → 840s. Cold Sovereign on prov #22 had bp-cnpg
+      # still synthesising the `pdns-pg-app` Secret when this Job
+      # ran; powerdns Pod was not Ready, curl against
+      # http://powerdns:8081 looped, Job hit 5m DeadlineExceeded,
+      # Helm post-install hook failed, HR FAILED 4× → terminal.
+      # New deadline (14m) sits below the HR install.timeout cap of
+      # 15m so Flux's remediation can still reclaim a true failure.
+      version: 1.2.2
       sourceRef:
         kind: HelmRepository
         name: bp-powerdns

--- a/platform/powerdns/chart/Chart.yaml
+++ b/platform/powerdns/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-powerdns
-version: 1.2.1
+version: 1.2.2
 description: |
   Catalyst-curated Blueprint wrapper for PowerDNS Authoritative.
   Carries Catalyst-specific values.yaml + templates (CNPG cluster, dnsdist

--- a/platform/powerdns/chart/values.yaml
+++ b/platform/powerdns/chart/values.yaml
@@ -521,6 +521,22 @@ zoneBootstrap:
   # backoffLimit — retries on transient API errors (powerdns Pod still
   # warming up, etc.) before the Job marks itself Failed.
   backoffLimit: 6
-  # activeDeadlineSeconds — upper bound on Job runtime. 5 minutes is
-  # ample for N=10 zones at a few hundred ms per zone API call.
-  activeDeadlineSeconds: 300
+  # activeDeadlineSeconds — upper bound on Job runtime.
+  #
+  # Issue #144: raised from 300s → 840s (14m, below the HR install.timeout
+  # of 15m in clusters/_template/bootstrap-kit/11-powerdns.yaml). Cold
+  # Sovereign provisioning observed on prov #22 (e2fc1004362ce765): bp-cnpg
+  # had not yet synthesised the `pdns-pg-app` Secret when this post-install
+  # hook Job started, so the powerdns Deployment was not Ready and curl
+  # against http://powerdns:8081 kept failing. With backoffLimit=6 +
+  # restartPolicy=OnFailure the script will keep retrying within the Job,
+  # but the 5-minute Job deadline triggered DeadlineExceeded → Helm hook
+  # failure → HR `post-install: timed out waiting for the condition` →
+  # 4 retries (one initial + 3 remediation) → terminal HR FAILED.
+  #
+  # 840s gives the upstream CNPG cluster + powerdns subchart Deployment
+  # ample time to converge on a cold k3s control plane while staying
+  # under the HR 15m wrapper cap (a Job that exceeded the HR cap would
+  # leave Flux waiting forever; a Job that fits inside the HR cap lets
+  # Flux's own remediation cycle reclaim the failure path).
+  activeDeadlineSeconds: 840


### PR DESCRIPTION
## Summary

Cold Sovereign on prov #22 (`e2fc1004362ce765`) hit terminal HR FAILED on `bp-powerdns`: post-install hook Job `DeadlineExceeded` after 5m, Helm hook reported `post-install: timed out waiting for the condition`, HelmRelease retried 4x then went terminal. This blocks DNS-01 cert-manager challenge (Fix #123 staging cert path), internal cluster DNS, and every downstream HR depending on `bp-powerdns`.

## Root cause

`zoneBootstrap.activeDeadlineSeconds` default of **300s** was shorter than the time `bp-cnpg` needed to synthesise the `pdns-pg-app` Secret on a cold k3s control plane.

Failure chain:
1. Helm post-install hook fires the `powerdns-zone-bootstrap` Job
2. Job's curl loop (`http://powerdns:8081`, `--max-time 10 --retry 3 --retry-delay 2 --retry-connrefused`) keeps failing because the powerdns Pod is not Ready (waiting on `pdns-pg-app` Secret from CNPG)
3. `restartPolicy: OnFailure` + `backoffLimit: 6` re-runs the script, but
4. Job-level `activeDeadlineSeconds: 300` triggers `DeadlineExceeded` first
5. Helm hook fails -> HR `post-install: timed out waiting for the condition`
6. `install.remediation.retries: 3` exhausts -> terminal HR FAILED

## Canonical seam

Chart `values.yaml` -> `zoneBootstrap.activeDeadlineSeconds`. The Job spec already templates this (`{{ .Values.zoneBootstrap.activeDeadlineSeconds | default 300 }}`) so principle 18 (templatable knob) was already satisfied; only the default needed to change.

## Fix

- `platform/powerdns/chart/values.yaml`: default 300s -> **840s** (14m)
- `platform/powerdns/chart/Chart.yaml`: chart 1.2.1 -> **1.2.2**
- `clusters/_template/bootstrap-kit/11-powerdns.yaml`: HR pin 1.2.1 -> **1.2.2** with comment explaining prov-#22 incident

840s sits below the HR `install.timeout: 15m` (already in place from a prior fix) so a true chart failure still surfaces via Flux's own remediation path rather than wedging on a Helm wait that outlives its outer wrapper.

Same family as #127, #131, #143 (HR/Job timeout-ladder alignment where a downstream Job's deadline must fit inside its HR wrapper cap).

## Out of scope

`clusters/omantel.omani.works/bootstrap-kit/11-powerdns.yaml` and `clusters/otech.omani.works/bootstrap-kit/11-powerdns.yaml` remain pinned to 1.1.5 (pre-existing drift). New Sovereign provisioning reads from `_template`.

## Claimed TCs

- `prov-22-bp-powerdns-hr-ready`
- `prov-22-zone-bootstrap-job-completes-cold-cnpg`

## Test plan

- [ ] Fresh provision picks up chart 1.2.2 via `_template`
- [ ] `bp-powerdns` HR reaches `Ready=True` within 15m on cold cluster
- [ ] `kubectl logs job/powerdns-zone-bootstrap -n powerdns` shows `Zone bootstrap complete.`
- [ ] No `DeadlineExceeded` on the Job