### PR TITLE
fix(bp-keycloak): retune install retries to fit HR envelope (#146)

### DIFF
--- a/clusters/_template/bootstrap-kit/09-keycloak.yaml
+++ b/clusters/_template/bootstrap-kit/09-keycloak.yaml
@@ -45,6 +45,16 @@ spec:
       # parameter so each Sovereign owns its KC realm named after the tenant
       # short-name (omantel chroot → "omantel"). Default `sovereign` is kept
       # in the chart for backward compat with overlays not yet migrated.
+      # 1.4.5 (issue #146, prov #21+#22 hung 30+ min on bp-keycloak install):
+      # post-#140 retune. (a) availabilityCheck.timeout 900s → 300s — coarser
+      # retry was busting HR window before backoff could retry; faster
+      # failure means more attempts fit. (b) startupProbe enabled with 30m
+      # budget so slow Liquibase doesn't get killed by livenessProbe mid-
+      # migration. (c) livenessProbe.initialDelaySeconds 300 → 60 (cold-
+      # start protection now lives in startupProbe). Coupled HR change
+      # below: install/upgrade.remediation.retries 3 → 1 (Job's own
+      # backoffLimit handles retries without losing state across Helm
+      # restarts). Together: ≤ 30m wall-clock vs. 90m+ before.
       # 1.4.4 (issue #140, post-upgrade hook regression on prov #21): bumps
       # keycloakConfigCli.availabilityCheck.timeout 600s → 900s + adds
       # cleanupAfterFinished (1h TTL) so stale hook Pods don't race
@@ -53,7 +63,7 @@ spec:
       # outer hook-wait accommodates the inner 15m availability window.
       # 1.4.3 (issue #129): bumped keycloakConfigCli.availabilityCheck.timeout
       # 120s → 600s + backoffLimit 1 → 5 (fresh-install wedge).
-      version: 1.4.4
+      version: 1.4.5
       sourceRef:
         kind: HelmRepository
         name: bp-keycloak
@@ -74,16 +84,27 @@ spec:
   # window. 30m gives Helm room to wait out one full inner attempt plus
   # exponential backoff if needed, without blowing past Flux's HR timer.
   # If you bump availabilityCheck.timeout further, bump THIS too.
+  # remediation.retries 3 → 1 (issue #146, prov #21+#22 hung 30+ min):
+  # Flux HR remediation does a full Helm uninstall+reinstall on each retry,
+  # losing all hook-Pod state and restarting Liquibase from zero. With 3
+  # retries × 30m HR timeout = up to 90m of wasted work before Flux gives
+  # up. The keycloak-config-cli Job already retries internally via
+  # `backoffLimit: 5` (set in chart values.yaml) — Job-level backoff
+  # preserves Keycloak's state and only re-runs the realm-import sidecar.
+  # HR-level remediation is reserved for genuine release-failure (e.g.
+  # invalid manifest) where a clean reinstall is the right answer; one
+  # retry is sufficient for that. Job-level vs. HR-level retry is the
+  # correct separation per the bitnami subchart's design.
   install:
     disableWait: true
     timeout: 30m
     remediation:
-      retries: 3
+      retries: 1
   upgrade:
     disableWait: true
     timeout: 30m
     remediation:
-      retries: 3
+      retries: 1
   # Per-Sovereign overrides — issue #387 + #604 + qa-loop iter-12 Fix #53A:
   # Wire the per-Sovereign hostname into the HTTPRoute template and
   # sovereign realm ConfigMap (catalyst-ui redirect URIs). The HTTPRoute

--- a/platform/keycloak/chart/Chart.yaml
+++ b/platform/keycloak/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-keycloak
-version: 1.4.4
+version: 1.4.5
 description: |
   Catalyst-curated Blueprint umbrella chart for Keycloak. Depends on the
   upstream `keycloak` chart (bitnami) as a Helm subchart so
@@ -36,6 +36,37 @@ description: |
   credentials Secret `realm` key flow from the same value, keeping
   Keycloak realm and catalyst-api CATALYST_KC_REALM env in sync. Closes
   TC-124, TC-125, TC-159, TC-160, TC-161, TC-176, TC-190, TC-285.
+  1.4.5 (issue #146, post-#140 retune — prov #21 + #22 hung 30+ min on
+  bp-keycloak install): Fix #140 set availabilityCheck.timeout=900s +
+  HR install/upgrade.timeout=30m + remediation.retries=3. In practice
+  the 900s per-attempt window meant a single failed availability check
+  busted the 30m HR window before Job-level backoff could retry —
+  AND each HR remediation triggered a full Helm uninstall+reinstall,
+  losing all hook-Pod state and restarting Liquibase from zero
+  (90m+ wasted wall-clock). On top, Liquibase + JVM cold-start
+  legitimately took 5-10min before the StatefulSet's Service had
+  Endpoints, but the Bitnami Pod's livenessProbe (initialDelaySeconds
+  300) was killing it mid-migration on slower-disk Sovereigns.
+  Three coupled changes for target-state fix:
+    - keycloakConfigCli.availabilityCheck.timeout 900s → 300s. Faster
+      failure means more attempts fit inside 30m HR envelope (~5 vs.
+      ~1.5 with 900s). Each 300s window still covers one full
+      Liquibase pass + JVM warm-up (typical 90-180s).
+    - HR install.remediation.retries + upgrade.remediation.retries
+      3 → 1 (in clusters/_template/bootstrap-kit/09-keycloak.yaml).
+      The Job's own backoffLimit=5 handles transient races without
+      losing state; HR-level remediation is reserved for genuine
+      release-failure.
+    - keycloak.startupProbe.enabled=true (failureThreshold 360 ×
+      periodSeconds 5 = 30m budget). startupProbe is an exclusive
+      kubelet gate — livenessProbe + readinessProbe are SUSPENDED
+      until startupProbe passes, so slow Liquibase isn't killed
+      mid-migration. keycloak.livenessProbe.initialDelaySeconds
+      300 → 60 (cold-start protection now lives in startupProbe).
+  All knobs operator-overridable via valuesFrom (Principle #4). TODO
+  follow-up: move realm-import OUT of the bitnami post-install Helm
+  hook into a Catalyst-owned Job that runs after Keycloak Service
+  has Endpoints — decouples HR-Ready from realm-imported.
   1.4.4 (issue #140, post-upgrade hook regression on prov #21): Fix #129
   set 600s + backoffLimit=5, which works for fresh-install but races on
   upgrade. On prov #21 (f84f6c3ff2b60296, 2026-05-11) the chart-roll on

--- a/platform/keycloak/chart/values.yaml
+++ b/platform/keycloak/chart/values.yaml
@@ -242,6 +242,40 @@ keycloak:
   resources:
     requests: { cpu: 250m, memory: 512Mi }
     limits: { memory: 2Gi }
+  # ─── Probes — issue #146 (decouple slow Liquibase from livenessProbe) ─────
+  #
+  # Diagnostic finding (prov #21 + #22): the Keycloak StatefulSet's Service
+  # had no Endpoints for 5-10 min after Pod start because Liquibase
+  # migrations + JVM cold-start + first realm load take that long before
+  # `/realms/master` answers 200. With ONLY a livenessProbe (initialDelay
+  # 300s), Liquibase that legitimately runs longer than the probe's grace
+  # window is killed mid-flight by the kubelet, restarting the cycle from
+  # zero — Pod never reaches Ready.
+  #
+  # Fix: enable a startupProbe with a 30m budget (failureThreshold 360 ×
+  # periodSeconds 5 = 1800s). The kubelet treats startupProbe as an
+  # exclusive gate — livenessProbe + readinessProbe are SUSPENDED until
+  # startupProbe passes. Once Keycloak first answers /realms/master,
+  # liveness+readiness take over with their normal cadence.
+  #
+  # livenessProbe.initialDelaySeconds dropped 300 → 60 because cold-start
+  # protection is now the startupProbe's job; lower initial delay means
+  # we detect a genuinely-hung Keycloak ~4 min sooner post-startup.
+  #
+  # All knobs operator-overridable via per-Sovereign overlay valuesFrom
+  # (Inviolable Principle #4: no hardcoding):
+  #   keycloak.startupProbe.failureThreshold
+  #   keycloak.startupProbe.periodSeconds
+  #   keycloak.livenessProbe.initialDelaySeconds
+  startupProbe:
+    enabled: true
+    failureThreshold: 360
+    periodSeconds: 5
+    timeoutSeconds: 5
+    successThreshold: 1
+  livenessProbe:
+    enabled: true
+    initialDelaySeconds: 60
   # ─── keycloak-config-cli: Sovereign realm + kubectl OIDC client (issue #326) ──
   #
   # Bootstrap a `sovereign` realm with a public OIDC client `kubectl` so
@@ -325,11 +359,20 @@ keycloak:
     #     60m+, which BLOWS PAST the parent HR's 15m upgrade.timeout →
     #     Helm aborts the hook → "post-upgrade hooks failed".
     #
-    # Target-state fix (issue #140, NOT a workaround per Principle #3):
-    #   - Bump availabilityCheck.timeout 600s → 900s (15m) — covers a
-    #     legitimate StatefulSet rolling-restart + Liquibase re-validation
-    #     window in a single Pod attempt, eliminating most retries.
-    #   - Keep backoffLimit at 5 (no need to bump; first attempt now fits).
+    # Target-state fix (issue #146, post-#140 retune — prov #21 + #22 hung
+    # 30+ min on bp-keycloak install). Diagnostic finding: 900s (15m) per
+    # availability attempt was TOO COARSE — a single failed attempt busts
+    # the 30m HR window before Job-level backoff has any chance to retry.
+    # Faster failure beats coarser retry: shrink the per-attempt window so
+    # MORE attempts fit inside the HR's 30m envelope.
+    #   - availabilityCheck.timeout 900s → 300s (5m). At backoffLimit=5
+    #     and 10s..6m exponential backoff this fits ~5 attempts inside
+    #     the parent HR's 30m install/upgrade timeout, vs. ~1.5 at 900s.
+    #     Each attempt is still long enough to cover one Liquibase pass +
+    #     JVM warm-up (typical 90-180s) on a fresh-provisioned node.
+    #   - Keep backoffLimit at 5 (Job-level retry handles transient races
+    #     without losing state across Helm hook restarts — see HR-side
+    #     `install.remediation.retries: 1` in 09-keycloak.yaml).
     #   - cleanupAfterFinished.enabled: true with 1h TTL — without this,
     #     stale Failed/Completed Job pods accumulate across upgrades and
     #     `helm.sh/hook-delete-policy: before-hook-creation` may race with
@@ -338,11 +381,12 @@ keycloak:
     #     ttlSecondsAfterFinished hook surfaces this knob via .seconds.
     #
     # Coupled HR change (clusters/_template/bootstrap-kit/09-keycloak.yaml):
-    # bumps install.timeout AND upgrade.timeout 15m → 30m so Helm's
-    # outer hook-wait gracefully accommodates the inner 15m availability
-    # window plus normal backoff (the realistic worst case is now ≤ 25m).
-    # The two timeouts MUST move together — chart-side tuning without HR
-    # outer-bound is a half-fix.
+    # install.remediation.retries 3 → 1 + upgrade.remediation.retries 3 → 1.
+    # Flux HR remediation retries do a FULL Helm rollback + reinstall on
+    # each attempt — losing all hook-Pod state, restarting Liquibase from
+    # zero, and consuming a fresh 30m HR timeout per loop. The Job's own
+    # backoffLimit=5 already provides retry semantics WITHOUT losing
+    # state. HR-level retries on top compound to 90m of wasted work.
     #
     # All knobs remain operator-overridable via per-Sovereign overlay
     # valuesFrom paths (Inviolable Principle #4: no hardcoding):
@@ -352,6 +396,14 @@ keycloak:
     #   keycloak.keycloakConfigCli.cleanupAfterFinished.seconds
     # Operators with faster substrates may shorten them.
     #
+    # TODO (issue #146 follow-up — out of scope for this fix per diagnostic
+    # "ship knob bumps first to validate hypothesis"): move realm-import
+    # OUT of the bitnami post-install Helm hook into a Catalyst-owned
+    # Job that runs after Keycloak Service has Endpoints. The Helm-hook
+    # design forces the entire HR Ready-state to depend on hook
+    # completion; a Catalyst-owned Job decouples HR-Ready from realm-
+    # imported and lets the orchestrator wait on the Job CR directly.
+    #
     # NOT a workaround per Inviolable Principle #3. The workaround would
     # be disabling the hook semantics entirely (set annotations: {}); that
     # breaks the documented contract that the realm is imported before
@@ -360,7 +412,7 @@ keycloak:
     # AND the outer Helm hook-wait both respect the contract.
     availabilityCheck:
       enabled: true
-      timeout: "900s"
+      timeout: "300s"
     backoffLimit: 5
     # Bitnami exposes ttlSecondsAfterFinished via .cleanupAfterFinished.
     # 3600s = 1h — long enough for an operator post-mortem on a Failed


### PR DESCRIPTION
## Summary

Diagnostic finding: prov #21 + #22 hung 30+ min on bp-keycloak install. Three coupled root causes from Fix #140 retune:

1. `availabilityCheck.timeout=900s` meant a single failed attempt busted the 30m HR window before Job-level backoff retried
2. `install/upgrade.remediation.retries=3` triggered up to 3 full Helm uninstall+reinstall cycles, losing Liquibase state each time (90m+ wall-clock worst case)
3. Liquibase + JVM cold-start legitimately took 5-10 min before Keycloak Service had Endpoints, but bitnami's livenessProbe (`initialDelaySeconds: 300`) killed Pods mid-migration

## Changes (chart 1.4.4 -> 1.4.5)

**`platform/keycloak/chart/values.yaml`**
- `keycloakConfigCli.availabilityCheck.timeout` 900s -> 300s. ~5 attempts fit in 30m HR envelope vs. ~1.5 at 900s. Each 300s window still covers one Liquibase pass + JVM warm-up.
- `keycloak.startupProbe.enabled: true` with `failureThreshold: 360` x `periodSeconds: 5` = 30m budget. startupProbe is an exclusive kubelet gate — livenessProbe + readinessProbe are SUSPENDED until startupProbe passes.
- `keycloak.livenessProbe.initialDelaySeconds` 300 -> 60 (cold-start protection now lives in startupProbe).

**`clusters/_template/bootstrap-kit/09-keycloak.yaml`**
- `install.remediation.retries` + `upgrade.remediation.retries` 3 -> 1. The Job's own `backoffLimit: 5` handles retries without losing state across Helm hook restarts.
- Chart pin: 1.4.4 -> 1.4.5.

All knobs remain operator-overridable via per-Sovereign overlay `valuesFrom` (Inviolable Principle #4: no hardcoding).

## TODO (follow-up, out of scope)

Per diagnostic guidance ("ship knob bumps first to validate hypothesis"): move realm-import OUT of the bitnami post-install Helm hook into a Catalyst-owned Job that runs after Keycloak Service has Endpoints. Decouples HR-Ready from realm-imported and lets the orchestrator wait on the Job CR directly. TODO comment added in chart values.yaml.

## Claimed TCs

Infra-only fix; unblocks all 410 TCs that depend on bp-keycloak reaching `Ready=True` during fresh-Sovereign provision.

## Test plan

- [ ] Next bounded-cycle re-provision: bp-keycloak HR reaches `Ready=True` within HR's 30m install window
- [ ] keycloak-config-cli post-install hook Pod completes without exhausting backoffLimit
- [ ] Keycloak StatefulSet Pod survives initial Liquibase migration without livenessProbe-induced restart

Refs #146.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

Generated with Claude Code