### PR TITLE
fix(bp-harbor): explicit install/upgrade timeout 15m (HR-level)

### DIFF
--- a/clusters/_template/bootstrap-kit/19-harbor.yaml
+++ b/clusters/_template/bootstrap-kit/19-harbor.yaml
@@ -105,11 +105,18 @@ spec:
         name: bp-harbor
         namespace: flux-system
   # Event-driven install per docs/INVIOLABLE-PRINCIPLES.md #3.
+  # timeout: 15m — Harbor's post-install hooks (DB migration, job-service
+  # init) legitimately need >5m on cold k3s. Same canonical-seam pattern
+  # as Fix #127 (cutover), Fix #131 (gitea), Fix #143 (es-stores):
+  # explicit HR-level timeout overrides Helm's 5m default which expires
+  # before Harbor reaches Ready (prov #24 c776423270f4ae30 04:17 incident).
   install:
+    timeout: 15m
     disableWait: true
     remediation:
       retries: 3
   upgrade:
+    timeout: 15m
     disableWait: true
     remediation:
       retries: 3


### PR DESCRIPTION
## Summary

bp-harbor HR FAILED on prov #24 (`c776423270f4ae30`) at 04:17 with `timed out waiting` on the Helm post-install hook.

**Root cause:** HR had no explicit `install.timeout`, so Helm applied its 5m default, which expired before Harbor's DB migration / job-service init completed on cold k3s.

**Fix:** Same canonical seam as Fix #127 (cutover), Fix #131 (gitea), Fix #143 (es-stores) — set `install.timeout` + `upgrade.timeout` to 15m at the HR level. `disableWait: true` and `remediation.retries: 3` preserved.

Per principle 4 (target-state): Harbor cold-start legitimately needs >5m on k3s; raising the HR timeout to match observed behavior is the correct fix, not a workaround.

## Claimed TCs

- prov #24 bp-harbor HR FAILED `timed out waiting` (canonical seam: HR-level Helm timeout)
- Convergence on iter-1 of next fresh provision: bp-harbor HR Ready=True within 15m

## Test plan

- [x] YAML edit limited to `install.timeout` + `upgrade.timeout` additions
- [x] `disableWait: true` and `remediation.retries: 3` preserved
- [ ] Next fresh Sovereign provision: bp-harbor HR reaches Ready=True within 15m