### PR TITLE
fix(bp-cert-manager): add CRD-establishment gate to close ClusterIssuer race (#149)

### DIFF
--- a/clusters/_template/bootstrap-kit/02-cert-manager.yaml
+++ b/clusters/_template/bootstrap-kit/02-cert-manager.yaml
@@ -38,7 +38,7 @@ spec:
   chart:
     spec:
       chart: bp-cert-manager
-      version: 1.1.1
+      version: 1.2.0
       sourceRef:
         kind: HelmRepository
         name: bp-cert-manager

--- a/clusters/omantel.omani.works/bootstrap-kit/02-cert-manager.yaml
+++ b/clusters/omantel.omani.works/bootstrap-kit/02-cert-manager.yaml
@@ -38,7 +38,7 @@ spec:
   chart:
     spec:
       chart: bp-cert-manager
-      version: 1.1.1
+      version: 1.2.0
       sourceRef:
         kind: HelmRepository
         name: bp-cert-manager

--- a/clusters/otech.omani.works/bootstrap-kit/02-cert-manager.yaml
+++ b/clusters/otech.omani.works/bootstrap-kit/02-cert-manager.yaml
@@ -38,7 +38,7 @@ spec:
   chart:
     spec:
       chart: bp-cert-manager
-      version: 1.1.1
+      version: 1.2.0
       sourceRef:
         kind: HelmRepository
         name: bp-cert-manager

--- a/platform/cert-manager/blueprint.yaml
+++ b/platform/cert-manager/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-3-3-security-and-policy
 spec:
-  version: 1.1.2
+  version: 1.2.0
   card:
     title: cert-manager
     summary: TLS certificate automation. Lets Encrypt issuer with Dynadot DNS-01 for omani.works pool, HTTP-01 for BYO domains.

--- a/platform/cert-manager/chart/Chart.yaml
+++ b/platform/cert-manager/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-cert-manager
-version: 1.1.2
+version: 1.2.0
 description: |
   Catalyst-curated Blueprint umbrella chart for cert-manager. Depends on the
   upstream `cert-manager` chart (Jetstack) as a Helm subchart so

--- a/platform/cert-manager/chart/templates/crd-gate-hook.yaml
+++ b/platform/cert-manager/chart/templates/crd-gate-hook.yaml
@@ -1,0 +1,151 @@
+{{- /*
+cert-manager CRD-establishment gate (issue #149 / prov #24).
+
+Background — the race we close
+==============================
+This chart ships TWO ClusterIssuer CRs (letsencrypt-dns01-prod,
+letsencrypt-http01-prod) as Helm post-install hooks (weight 5). Those
+CRs are instances of the cert-manager.io/v1 ClusterIssuer CRD which
+the upstream Jetstack subchart installs as REGULAR templates (no
+helm.sh/hook annotation).
+
+Helm install ordering is:
+  1. Render every template in the chart
+  2. Apply main manifests (CRDs land here, in install-order)
+  3. Wait briefly for Pod readiness IF disableWait=false (we set
+     disableWait=true in the HR — see clusters/_template/bootstrap-kit/
+     02-cert-manager.yaml)
+  4. Run post-install hooks in weight order
+
+Step 2 calls `kubectl apply` on the CRD object — which CREATES the CRD
+resource but does NOT wait for the apiserver's CRD controller to set
+`status.conditions[?(@.type=="Established")].status == "True"`. The
+Established transition is asynchronous (typically <1s on a warm
+apiserver, observed up to 30s on a fresh Hetzner cold-start k3s where
+the apiextensions-apiserver is itself still warming up).
+
+Without this gate, the post-install ClusterIssuer hook (weight 5) can
+fire BEFORE the ClusterIssuer CRD is Established, and Helm reports:
+  "no matches for kind \"ClusterIssuer\" in version \"cert-manager.io/v1\""
+  → terminal HelmRelease failure on prov #24 (`c776423270f4ae30`).
+
+This Job actively polls every CRD in the gate's allowlist for
+condition Established=True and only exits 0 when all are present.
+Fails fast (300s budget) so a genuinely broken upstream surfaces in
+Flux conditions rather than in a 15-minute spin.
+
+Why post-install AND post-upgrade
+=================================
+Helm upgrade re-applies the ClusterIssuer post-install hook every
+upgrade pass. The CRDs are normally still present (kept via
+`crds.keep: true`), so the gate exits in <1s on the happy path — but
+during a chart-version bump that adds a new CRD (e.g. v1alpha2
+something), the gate ensures the new CRD is Established before any
+dependent CR applies.
+
+Why hook-weight -10
+===================
+Lower weight than the RBAC hook (-20) in templates/crd-gate-rbac.yaml
+so the ServiceAccount + ClusterRole + Binding land BEFORE this Job
+needs them; lower than the ClusterIssuer hooks (5) so the gate fires
+BEFORE those issuers attempt to apply.
+
+Pairs with:
+  - templates/crd-gate-rbac.yaml — SA + ClusterRole + Binding
+  - values.yaml `crdGate:` — knobs (enabled, crds, timeout, image)
+*/}}
+{{- $gate := .Values.crdGate | default dict -}}
+{{- $enabled := true -}}
+{{- if hasKey $gate "enabled" -}}
+{{-   $enabled = $gate.enabled -}}
+{{- end -}}
+{{- if $enabled }}
+{{- $crds := $gate.crds | default (list "clusterissuers.cert-manager.io" "issuers.cert-manager.io" "certificates.cert-manager.io") -}}
+{{- $timeout := $gate.timeoutSeconds | default 300 -}}
+{{- $interval := $gate.intervalSeconds | default 2 -}}
+{{- $image := $gate.image | default "bitnami/kubectl:1.30.4" -}}
+{{- $pullPolicy := $gate.imagePullPolicy | default "IfNotPresent" -}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ .Release.Name }}-crd-gate
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: bp-cert-manager
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    catalyst.openova.io/component: crd-gate
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "-10"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 0
+  ttlSecondsAfterFinished: 300
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: bp-cert-manager
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        catalyst.openova.io/component: crd-gate
+    spec:
+      serviceAccountName: {{ .Release.Name }}-crd-gate
+      restartPolicy: Never
+      containers:
+        - name: gate
+          image: {{ $image | quote }}
+          imagePullPolicy: {{ $pullPolicy | quote }}
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1001
+            runAsGroup: 1001
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: [ALL]
+            seccompProfile:
+              type: RuntimeDefault
+          env:
+            - name: CRDS
+              value: {{ join " " $crds | quote }}
+            - name: TIMEOUT_SECONDS
+              value: {{ $timeout | quote }}
+            - name: INTERVAL_SECONDS
+              value: {{ $interval | quote }}
+          command: ["/bin/bash", "-c"]
+          args:
+            - |
+              set -euo pipefail
+              echo "cert-manager CRD gate: wait for Established=True on: ${CRDS} (budget=${TIMEOUT_SECONDS}s, interval=${INTERVAL_SECONDS}s)"
+              deadline=$(( $(date +%s) + TIMEOUT_SECONDS ))
+              attempt=0
+              while [ "$(date +%s)" -lt "${deadline}" ]; do
+                attempt=$(( attempt + 1 ))
+                all_ok=true
+                missing=""
+                for crd in ${CRDS}; do
+                  # `kubectl wait` returns immediately if the resource exists
+                  # AND meets the condition; we use a per-CRD jsonpath check
+                  # instead so a single missing CRD doesn't crash the loop.
+                  status="$(kubectl get crd "${crd}" \
+                    --ignore-not-found \
+                    -o jsonpath='{.status.conditions[?(@.type=="Established")].status}' 2>/dev/null || true)"
+                  if [ "${status}" != "True" ]; then
+                    all_ok=false
+                    missing="${missing} ${crd}(=${status:-absent})"
+                  fi
+                done
+                if [ "${all_ok}" = "true" ]; then
+                  echo "All CRDs Established after ${attempt} attempt(s)."
+                  exit 0
+                fi
+                echo "Attempt ${attempt}: CRDs not yet Established:${missing}; sleeping ${INTERVAL_SECONDS}s."
+                sleep "${INTERVAL_SECONDS}"
+              done
+              echo "FATAL: cert-manager CRDs did not reach Established=True within ${TIMEOUT_SECONDS}s." >&2
+              echo "Still missing/not-Established:${missing}" >&2
+              echo "Diagnose with:" >&2
+              echo "  kubectl get crd | grep cert-manager.io" >&2
+              echo "  kubectl get pods -n {{ .Release.Namespace }}" >&2
+              echo "  kubectl describe crd clusterissuers.cert-manager.io" >&2
+              exit 1
+{{- end }}

--- a/platform/cert-manager/chart/templates/crd-gate-rbac.yaml
+++ b/platform/cert-manager/chart/templates/crd-gate-rbac.yaml
@@ -1,0 +1,83 @@
+{{- /*
+RBAC for the cert-manager CRD-establishment gate (issue #149 / prov #24).
+
+Per docs/INVIOLABLE-PRINCIPLES.md #3 (least-privilege): the gate Job
+ONLY needs `get` + `list` on CustomResourceDefinitions. Cluster-scoped
+because CRDs are cluster-scoped — a namespaced Role cannot grant access
+to apiextensions.k8s.io/v1 CRDs.
+
+Hook timing — post-install (NOT pre-install)
+============================================
+The CRDs we wait for (cert-manager.io ClusterIssuer/Issuer/Certificate
+etc.) are installed by the upstream cert-manager subchart's main
+manifests. Pre-install hooks fire BEFORE main apply, so the CRDs
+don't yet exist at pre-install time — a pre-install gate would never
+see them. The gate must be a post-install hook ordered BEFORE the
+ClusterIssuer post-install hooks (weight 5) so the CRDs are guaranteed
+Established by the time the issuer manifests apply.
+
+Hook ordering inside the post-install phase:
+  weight -20 → SA + ClusterRole + ClusterRoleBinding (this file)
+  weight -10 → CRD-gate Job (templates/crd-gate-hook.yaml)
+  weight   5 → ClusterIssuer letsencrypt-* (clusterissuer-letsencrypt-dns01.yaml)
+
+Pairs with templates/crd-gate-hook.yaml.
+*/}}
+{{- $gate := .Values.crdGate | default dict -}}
+{{- $enabled := true -}}
+{{- if hasKey $gate "enabled" -}}
+{{-   $enabled = $gate.enabled -}}
+{{- end -}}
+{{- if $enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Release.Name }}-crd-gate
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: bp-cert-manager
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    catalyst.openova.io/component: crd-gate
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "-20"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Release.Name }}-crd-gate
+  labels:
+    app.kubernetes.io/name: bp-cert-manager
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    catalyst.openova.io/component: crd-gate
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "-20"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+rules:
+  - apiGroups: [apiextensions.k8s.io]
+    resources: [customresourcedefinitions]
+    verbs: [get, list]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Release.Name }}-crd-gate
+  labels:
+    app.kubernetes.io/name: bp-cert-manager
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    catalyst.openova.io/component: crd-gate
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "-20"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Release.Name }}-crd-gate
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Release.Name }}-crd-gate
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/platform/cert-manager/chart/values.yaml
+++ b/platform/cert-manager/chart/values.yaml
@@ -86,6 +86,51 @@ cert-manager:
 # runtime-configurable; cluster overlays in clusters/<sovereign>/ may set
 # certManager.issuers.* to flip between issuers without rebuilding the
 # Blueprint OCI artifact.
+# ─── CRD-establishment gate (templates/crd-gate-{hook,rbac}.yaml) ────────
+# Closes #149 — bp-cert-manager terminal failure on prov #24
+# (`c776423270f4ae30`): the post-install ClusterIssuer hook (weight 5)
+# fired before the cert-manager.io ClusterIssuer CRD reached
+# `status.conditions[?(@.type=="Established")].status == "True"`. The
+# upstream Jetstack subchart installs the CRD as a regular template
+# (no helm.sh/hook), so `kubectl apply` returns when the resource is
+# CREATED — not when the apiextensions-apiserver controller has finished
+# Establishing it. Asynchronous in the apiserver; observed up to 30s on
+# fresh Hetzner cold-start k3s.
+#
+# This Job (post-install,post-upgrade hook-weight -10) polls every CRD
+# in `crds` for Established=True before the ClusterIssuer hook (weight
+# 5) fires. Per docs/INVIOLABLE-PRINCIPLES.md #4 (no hardcoded band-
+# aids, target-state every time): closes the race rather than papering
+# with `helm.sh/hook-weight: 50` or a longer Flux retry loop.
+crdGate:
+  enabled: true
+  # CRDs the gate waits for. Defaults cover the cert-manager.io types
+  # the Catalyst overlay templates instantiate (ClusterIssuer ships in
+  # this chart; Issuer + Certificate are consumed by dependent
+  # Blueprints — gating them here too means downstream HRs that
+  # immediately apply Certificate CRs don't have to ship their own
+  # gate). Cluster overlays MAY append CRDs here (e.g. when a custom
+  # webhook ships its own CRD that should also be Established before
+  # any dependent CR applies).
+  crds:
+    - clusterissuers.cert-manager.io
+    - issuers.cert-manager.io
+    - certificates.cert-manager.io
+  # Total wait budget. 300s gives ~10x headroom over the worst-case
+  # observed Established latency (~30s on a fresh Hetzner cold-start)
+  # while still failing fast on a genuinely broken upstream (5min vs
+  # an unbounded Helm timeout). Same sizing rationale as
+  # bp-external-secrets-stores webhookGate.timeoutSeconds (#143).
+  timeoutSeconds: 300
+  # Poll interval. 2s matches bp-external-secrets-stores; <1s would
+  # spam the apiserver, >5s would over-pad the success path.
+  intervalSeconds: 2
+  # kubectl image. Default is a known-good bitnami tag that ships bash
+  # + kubectl 1.30 (matches k3s 1.30 on Hetzner Sovereigns). Cluster
+  # overlays MAY pin to a digest for air-gap or supply-chain reasons.
+  image: bitnami/kubectl:1.30.4
+  imagePullPolicy: IfNotPresent
+
 certManager:
   issuers:
     # ACME account email used for renewal notifications. Per Sovereign


### PR DESCRIPTION
## Summary

Closes #149 (prov #24, `c776423270f4ae30`): bp-cert-manager terminal failure `no matches for kind "ClusterIssuer" in version "cert-manager.io/v1"` — the post-install ClusterIssuer hook (weight 5) fires before the cert-manager.io ClusterIssuer CRD reaches `status.conditions[?(@.type=="Established")].status == "True"`. The upstream Jetstack subchart installs CRDs as regular templates (no `helm.sh/hook`), so `kubectl apply` returns when the resource is CREATED — not when the apiextensions-apiserver has finished Establishing it. Async in the apiserver; observed up to 30s on fresh Hetzner cold-start k3s.

## Fix

Target-state per `docs/INVIOLABLE-PRINCIPLES.md` #4 (no hardcoded band-aids): a `post-install,post-upgrade` hook-weight `-10` Job that polls every CRD in `values.crdGate.crds` for `Established=True`. Only after the gate exits 0 does the ClusterIssuer hook (weight 5) fire. Models the canonical webhook-gate pattern from bp-external-secrets-stores (#137 / #143) — same SA + ClusterRole + ClusterRoleBinding + Job triplet.

- New: `platform/cert-manager/chart/templates/crd-gate-hook.yaml` (Job, weight `-10`)
- New: `platform/cert-manager/chart/templates/crd-gate-rbac.yaml` (SA + ClusterRole + binding, weight `-20`)
- New values stanza: `crdGate:` (`enabled`, `crds`, `timeoutSeconds`, `intervalSeconds`, `image`, `imagePullPolicy`) — all knobs templatable per principle 18
- Chart `1.1.2` -> `1.2.0` (minor bump: new templates + new values stanza)
- HR pins bumped in `clusters/_template`, `clusters/omantel.omani.works`, `clusters/otech.omani.works`

300s budget gives ~10x headroom over worst-case observed Established latency (~30s) while still failing fast on a genuinely broken upstream.

## Why post-install (not pre-install) hook

The CRDs we wait for are installed by the upstream subchart's main manifests. Pre-install hooks fire BEFORE main apply, so the CRDs don't yet exist at pre-install time — a pre-install gate would never see them. The gate must be a post-install hook ordered BEFORE the ClusterIssuer post-install hooks (weight 5).

## Claimed TCs

- prov #24 bp-cert-manager Ready=True
- All downstream HRs that depend on cert-manager (bp-cilium-gateway, bp-harbor, bp-gitea, bp-keycloak, bp-openbao, bp-catalyst-platform) unblocked once cert-manager goes Ready

## Test plan

- [x] `helm template` renders the new SA/ClusterRole/ClusterRoleBinding/Job with correct hook annotations + weights
- [ ] On next prov: bp-cert-manager HR reaches Ready=True without `no matches for kind "ClusterIssuer"` error
- [ ] Gate Job (`cert-manager-crd-gate-*` in `cert-manager` namespace) completes within ~5s on warm path

Per principle 16: canonical seam = the chart's `templates/clusterissuer-*.yaml` post-install hook. Per principle 21: openova (public) repo only.