### PR TITLE
fix(bootstrap-kit): add install/upgrade timeout: 15m to all HR templates (#154)

### DIFF
--- a/clusters/_template/bootstrap-kit/01-cilium.yaml
+++ b/clusters/_template/bootstrap-kit/01-cilium.yaml
@@ -62,10 +62,12 @@ spec:
   # SAME chart installs — legitimate slow-Ready). Replaces blanket
   # spec.timeout: 15m band-aid from PR #221.
   install:
+    timeout: 15m
     disableWait: true
     remediation:
       retries: 3
   upgrade:
+    timeout: 15m
     disableWait: true
     remediation:
       retries: 3

--- a/clusters/_template/bootstrap-kit/01a-gateway-api.yaml
+++ b/clusters/_template/bootstrap-kit/01a-gateway-api.yaml
@@ -71,10 +71,12 @@ spec:
   # `dependsOn: bp-gateway-api` so Flux gates them on this release's
   # Ready condition.
   install:
+    timeout: 15m
     disableWait: true
     remediation:
       retries: 3
   upgrade:
+    timeout: 15m
     disableWait: true
     remediation:
       retries: 3

--- a/clusters/_template/bootstrap-kit/02-cert-manager.yaml
+++ b/clusters/_template/bootstrap-kit/02-cert-manager.yaml
@@ -49,10 +49,12 @@ spec:
   # Helm install completes when manifests apply; subsequent dependsOn
   # checks Ready=True independently. Replaces PR #221 spec.timeout: 15m.
   install:
+    timeout: 15m
     disableWait: true
     remediation:
       retries: 3
   upgrade:
+    timeout: 15m
     disableWait: true
     remediation:
       retries: 3

--- a/clusters/_template/bootstrap-kit/03-flux.yaml
+++ b/clusters/_template/bootstrap-kit/03-flux.yaml
@@ -69,6 +69,7 @@ spec:
   # a target of the chart, so blocking on Ready=True is structurally
   # impossible. disableWait avoids the deadlock. Replaces PR #221 timeout.
   install:
+    timeout: 15m
     disableWait: true
     # Adopt cloud-init-installed Flux objects rather than fail on
     # ownership conflict (the objects exist before the HelmRelease ever
@@ -77,6 +78,7 @@ spec:
     remediation:
       retries: 3
   upgrade:
+    timeout: 15m
     disableWait: true
     # Keep operator-supplied values (e.g. resource overrides applied via
     # helm-controller out-of-band, or dry-run patches during incident

--- a/clusters/_template/bootstrap-kit/04-crossplane.yaml
+++ b/clusters/_template/bootstrap-kit/04-crossplane.yaml
@@ -45,8 +45,10 @@ spec:
         name: bp-crossplane
         namespace: flux-system
   install:
+    timeout: 15m
     remediation:
       retries: 3
   upgrade:
+    timeout: 15m
     remediation:
       retries: 3

--- a/clusters/_template/bootstrap-kit/05-sealed-secrets.yaml
+++ b/clusters/_template/bootstrap-kit/05-sealed-secrets.yaml
@@ -42,10 +42,12 @@ spec:
   # Event-driven install: single-replica controller + CRD; install
   # completes when manifests apply. Replaces PR #221 spec.timeout: 15m.
   install:
+    timeout: 15m
     disableWait: true
     remediation:
       retries: 3
   upgrade:
+    timeout: 15m
     disableWait: true
     remediation:
       retries: 3

--- a/clusters/_template/bootstrap-kit/05a-reflector.yaml
+++ b/clusters/_template/bootstrap-kit/05a-reflector.yaml
@@ -55,10 +55,12 @@ spec:
   # when manifests apply. disableWait per architecture convention —
   # replaces blanket spec.timeout band-aid.
   install:
+    timeout: 15m
     disableWait: true
     remediation:
       retries: 3
   upgrade:
+    timeout: 15m
     disableWait: true
     remediation:
       retries: 3

--- a/clusters/_template/bootstrap-kit/07-nats-jetstream.yaml
+++ b/clusters/_template/bootstrap-kit/07-nats-jetstream.yaml
@@ -50,10 +50,12 @@ spec:
   # cold start. Helm install completes when manifests apply; downstream
   # dependsOn checks Ready=True independently. Replaces PR #221 timeout.
   install:
+    timeout: 15m
     disableWait: true
     remediation:
       retries: 3
   upgrade:
+    timeout: 15m
     disableWait: true
     remediation:
       retries: 3

--- a/clusters/_template/bootstrap-kit/11-powerdns.yaml
+++ b/clusters/_template/bootstrap-kit/11-powerdns.yaml
@@ -123,10 +123,12 @@ spec:
   # cleanly; runtime convergence (powerdns pods becoming Ready once
   # CNPG lands) is observed via kubectl, not gated on Helm.
   install:
+    timeout: 15m
     disableWait: true
     remediation:
       retries: 3
   upgrade:
+    timeout: 15m
     disableWait: true
     remediation:
       retries: 3

--- a/clusters/_template/bootstrap-kit/12-external-dns.yaml
+++ b/clusters/_template/bootstrap-kit/12-external-dns.yaml
@@ -71,10 +71,12 @@ spec:
   # slow-Ready cascade. Helm install completes when manifests apply.
   # Replaces PR #221 spec.timeout: 15m.
   install:
+    timeout: 15m
     disableWait: true
     remediation:
       retries: 3
   upgrade:
+    timeout: 15m
     disableWait: true
     remediation:
       retries: 3

--- a/clusters/_template/bootstrap-kit/14-crossplane-claims.yaml
+++ b/clusters/_template/bootstrap-kit/14-crossplane-claims.yaml
@@ -65,10 +65,12 @@ spec:
   # HR on the upstream CRDs being live; disableWait replaces PR #221's
   # blanket spec.timeout: 15m band-aid.
   install:
+    timeout: 15m
     disableWait: true
     remediation:
       retries: 3
   upgrade:
+    timeout: 15m
     disableWait: true
     remediation:
       retries: 3

--- a/clusters/_template/bootstrap-kit/15-external-secrets.yaml
+++ b/clusters/_template/bootstrap-kit/15-external-secrets.yaml
@@ -66,10 +66,12 @@ spec:
   # dependsOn is the gate, not Helm timeout). Replaces blanket
   # spec.timeout: 15m band-aid pattern from PR #221, removed in PR #250.
   install:
+    timeout: 15m
     disableWait: true
     remediation:
       retries: 3
   upgrade:
+    timeout: 15m
     disableWait: true
     remediation:
       retries: 3

--- a/clusters/_template/bootstrap-kit/16-cnpg.yaml
+++ b/clusters/_template/bootstrap-kit/16-cnpg.yaml
@@ -62,10 +62,12 @@ spec:
         namespace: flux-system
   # Event-driven install per docs/INVIOLABLE-PRINCIPLES.md #3.
   install:
+    timeout: 15m
     disableWait: true
     remediation:
       retries: 3
   upgrade:
+    timeout: 15m
     disableWait: true
     remediation:
       retries: 3

--- a/clusters/_template/bootstrap-kit/17-valkey.yaml
+++ b/clusters/_template/bootstrap-kit/17-valkey.yaml
@@ -53,10 +53,12 @@ spec:
         namespace: flux-system
   # Event-driven install per docs/INVIOLABLE-PRINCIPLES.md #3.
   install:
+    timeout: 15m
     disableWait: true
     remediation:
       retries: 3
   upgrade:
+    timeout: 15m
     disableWait: true
     remediation:
       retries: 3

--- a/clusters/_template/bootstrap-kit/18-seaweedfs.yaml
+++ b/clusters/_template/bootstrap-kit/18-seaweedfs.yaml
@@ -67,10 +67,12 @@ spec:
         namespace: flux-system
   # Event-driven install per docs/INVIOLABLE-PRINCIPLES.md #3.
   install:
+    timeout: 15m
     disableWait: true
     remediation:
       retries: 3
   upgrade:
+    timeout: 15m
     disableWait: true
     remediation:
       retries: 3

--- a/clusters/_template/bootstrap-kit/20-opentelemetry.yaml
+++ b/clusters/_template/bootstrap-kit/20-opentelemetry.yaml
@@ -65,10 +65,12 @@ spec:
         name: bp-opentelemetry
         namespace: flux-system
   install:
+    timeout: 15m
     disableWait: true
     remediation:
       retries: 3
   upgrade:
+    timeout: 15m
     disableWait: true
     remediation:
       retries: 3

--- a/clusters/_template/bootstrap-kit/21-alloy.yaml
+++ b/clusters/_template/bootstrap-kit/21-alloy.yaml
@@ -62,10 +62,12 @@ spec:
         name: bp-alloy
         namespace: flux-system
   install:
+    timeout: 15m
     disableWait: true
     remediation:
       retries: 3
   upgrade:
+    timeout: 15m
     disableWait: true
     remediation:
       retries: 3

--- a/clusters/_template/bootstrap-kit/22-loki.yaml
+++ b/clusters/_template/bootstrap-kit/22-loki.yaml
@@ -59,10 +59,12 @@ spec:
         name: bp-loki
         namespace: flux-system
   install:
+    timeout: 15m
     disableWait: true
     remediation:
       retries: 3
   upgrade:
+    timeout: 15m
     disableWait: true
     remediation:
       retries: 3

--- a/clusters/_template/bootstrap-kit/23-mimir.yaml
+++ b/clusters/_template/bootstrap-kit/23-mimir.yaml
@@ -59,10 +59,12 @@ spec:
         name: bp-mimir
         namespace: flux-system
   install:
+    timeout: 15m
     disableWait: true
     remediation:
       retries: 3
   upgrade:
+    timeout: 15m
     disableWait: true
     remediation:
       retries: 3

--- a/clusters/_template/bootstrap-kit/24-tempo.yaml
+++ b/clusters/_template/bootstrap-kit/24-tempo.yaml
@@ -57,10 +57,12 @@ spec:
         name: bp-tempo
         namespace: flux-system
   install:
+    timeout: 15m
     disableWait: true
     remediation:
       retries: 3
   upgrade:
+    timeout: 15m
     disableWait: true
     remediation:
       retries: 3

--- a/clusters/_template/bootstrap-kit/25-grafana.yaml
+++ b/clusters/_template/bootstrap-kit/25-grafana.yaml
@@ -69,10 +69,12 @@ spec:
         name: bp-grafana
         namespace: flux-system
   install:
+    timeout: 15m
     disableWait: true
     remediation:
       retries: 3
   upgrade:
+    timeout: 15m
     disableWait: true
     remediation:
       retries: 3

--- a/clusters/_template/bootstrap-kit/27-kyverno.yaml
+++ b/clusters/_template/bootstrap-kit/27-kyverno.yaml
@@ -64,10 +64,12 @@ spec:
   # past the point where downstream HRs could legitimately reconcile.
   # disableWait lets Flux mark this Ready as soon as manifests apply.
   install:
+    timeout: 15m
     disableWait: true
     remediation:
       retries: 3
   upgrade:
+    timeout: 15m
     disableWait: true
     remediation:
       retries: 3

--- a/clusters/_template/bootstrap-kit/28-reloader.yaml
+++ b/clusters/_template/bootstrap-kit/28-reloader.yaml
@@ -58,10 +58,12 @@ spec:
   # HR Ready signal aligned with manifest apply rather than runtime
   # convergence, matching the rest of the bootstrap-kit.
   install:
+    timeout: 15m
     disableWait: true
     remediation:
       retries: 3
   upgrade:
+    timeout: 15m
     disableWait: true
     remediation:
       retries: 3

--- a/clusters/_template/bootstrap-kit/29-vpa.yaml
+++ b/clusters/_template/bootstrap-kit/29-vpa.yaml
@@ -57,10 +57,12 @@ spec:
   # updater, admission-controller) plus admission webhook TLS bootstrap.
   # disableWait keeps Flux's Ready signal aligned with manifest apply.
   install:
+    timeout: 15m
     disableWait: true
     remediation:
       retries: 3
   upgrade:
+    timeout: 15m
     disableWait: true
     remediation:
       retries: 3

--- a/clusters/_template/bootstrap-kit/30-trivy.yaml
+++ b/clusters/_template/bootstrap-kit/30-trivy.yaml
@@ -62,10 +62,12 @@ spec:
   # mark this Ready as soon as manifests apply; runtime convergence
   # (DB hydration, first scan reports landing) is observed via kubectl.
   install:
+    timeout: 15m
     disableWait: true
     remediation:
       retries: 3
   upgrade:
+    timeout: 15m
     disableWait: true
     remediation:
       retries: 3

--- a/clusters/_template/bootstrap-kit/31-falco.yaml
+++ b/clusters/_template/bootstrap-kit/31-falco.yaml
@@ -60,10 +60,12 @@ spec:
   # Helm `--wait`. disableWait keeps Flux's signal aligned with
   # manifest apply.
   install:
+    timeout: 15m
     disableWait: true
     remediation:
       retries: 3
   upgrade:
+    timeout: 15m
     disableWait: true
     remediation:
       retries: 3

--- a/clusters/_template/bootstrap-kit/32-sigstore.yaml
+++ b/clusters/_template/bootstrap-kit/32-sigstore.yaml
@@ -62,10 +62,12 @@ spec:
   # Certificate is issued + bound. disableWait avoids holding the HR
   # signal on a runtime-convergence event.
   install:
+    timeout: 15m
     disableWait: true
     remediation:
       retries: 3
   upgrade:
+    timeout: 15m
     disableWait: true
     remediation:
       retries: 3

--- a/clusters/_template/bootstrap-kit/33-syft-grype.yaml
+++ b/clusters/_template/bootstrap-kit/33-syft-grype.yaml
@@ -59,10 +59,12 @@ spec:
   # meaningful — disableWait is the correct shape so Flux marks Ready
   # as soon as manifests apply.
   install:
+    timeout: 15m
     disableWait: true
     remediation:
       retries: 3
   upgrade:
+    timeout: 15m
     disableWait: true
     remediation:
       retries: 3

--- a/clusters/_template/bootstrap-kit/34-velero.yaml
+++ b/clusters/_template/bootstrap-kit/34-velero.yaml
@@ -76,10 +76,12 @@ spec:
   # observes via the BSL CR phase, not via Helm `--wait`. disableWait
   # keeps the HR's Ready signal aligned with manifest apply.
   install:
+    timeout: 15m
     disableWait: true
     remediation:
       retries: 3
   upgrade:
+    timeout: 15m
     disableWait: true
     remediation:
       retries: 3

--- a/clusters/_template/bootstrap-kit/35-coraza.yaml
+++ b/clusters/_template/bootstrap-kit/35-coraza.yaml
@@ -61,10 +61,12 @@ spec:
         name: bp-coraza
         namespace: flux-system
   install:
+    timeout: 15m
     disableWait: true
     remediation:
       retries: 3
   upgrade:
+    timeout: 15m
     disableWait: true
     remediation:
       retries: 3

--- a/clusters/_template/bootstrap-kit/49-bp-cert-manager-powerdns-webhook.yaml
+++ b/clusters/_template/bootstrap-kit/49-bp-cert-manager-powerdns-webhook.yaml
@@ -105,10 +105,12 @@ spec:
   # so blocking on Helm `--wait` for the leaf Certificate to reach
   # Ready is unnecessary. Replaces blanket spec.timeout band-aids.
   install:
+    timeout: 15m
     disableWait: true
     remediation:
       retries: 3
   upgrade:
+    timeout: 15m
     disableWait: true
     remediation:
       retries: 3

--- a/clusters/_template/bootstrap-kit/50-cluster-autoscaler.yaml
+++ b/clusters/_template/bootstrap-kit/50-cluster-autoscaler.yaml
@@ -94,10 +94,12 @@ spec:
   # not a Helm-wait concern. disableWait keeps Flux's Ready signal
   # aligned with manifest apply.
   install:
+    timeout: 15m
     disableWait: true
     remediation:
       retries: 3
   upgrade:
+    timeout: 15m
     disableWait: true
     remediation:
       retries: 3

--- a/clusters/_template/bootstrap-kit/51-bp-k8s-ws-proxy.yaml
+++ b/clusters/_template/bootstrap-kit/51-bp-k8s-ws-proxy.yaml
@@ -86,10 +86,12 @@ spec:
         name: bp-k8s-ws-proxy
         namespace: flux-system
   install:
+    timeout: 15m
     disableWait: true
     remediation:
       retries: 3
   upgrade:
+    timeout: 15m
     disableWait: true
     remediation:
       retries: 3

--- a/clusters/_template/bootstrap-kit/52-bp-guacamole.yaml
+++ b/clusters/_template/bootstrap-kit/52-bp-guacamole.yaml
@@ -95,10 +95,12 @@ spec:
         name: bp-guacamole
         namespace: flux-system
   install:
+    timeout: 15m
     disableWait: true
     remediation:
       retries: 3
   upgrade:
+    timeout: 15m
     disableWait: true
     remediation:
       retries: 3

--- a/clusters/_template/bootstrap-kit/55-bp-hcloud-ccm.yaml
+++ b/clusters/_template/bootstrap-kit/55-bp-hcloud-ccm.yaml
@@ -81,10 +81,12 @@ spec:
   # not a Helm-wait concern. disableWait keeps Flux's Ready signal
   # aligned with manifest apply.
   install:
+    timeout: 15m
     disableWait: true
     remediation:
       retries: 3
   upgrade:
+    timeout: 15m
     disableWait: true
     remediation:
       retries: 3

--- a/clusters/_template/bootstrap-kit/80-newapi.yaml
+++ b/clusters/_template/bootstrap-kit/80-newapi.yaml
@@ -112,10 +112,12 @@ spec:
   # ~10 s once the Postgres DSN Secret is present; the long pole is
   # waiting for the operator's Crossplane claim to materialise the DB.
   install:
+    timeout: 15m
     disableWait: true
     remediation:
       retries: 3
   upgrade:
+    timeout: 15m
     disableWait: true
     remediation:
       retries: 3


### PR DESCRIPTION
## Summary

Audit of `clusters/_template/bootstrap-kit/` found **36 HelmRelease templates** without an explicit `timeout:` under `install:` / `upgrade:` — relying on Helm's default 5m which races on cold-start hooks (CRD apply, post-install Jobs, PVC binding on fresh nodes).

PRs #127 / #131 / #143 / #150 already added `timeout: 15m` to bp-self-sovereign-cutover, bp-gitea, bp-external-secrets-stores and bp-harbor — each one a reactive fix after a new blueprint hit a 5m race in qa-loop. This PR preempts the next 30+ reactive PRs by sweeping the full template surface.

Pattern matches the existing fixes — `timeout: 15m` lives alongside `disableWait: true` where present. The two are complementary:
- `disableWait: true` — Helm doesn't wait for workload Ready (event-driven readiness)
- `timeout: 15m` — protects the Helm install/upgrade transaction itself (manifest apply, CRD establishment, hook Job)

## What changed

36 files modified, +72 lines (2 lines per file: install + upgrade). Existing fields (`disableWait`, `remediation`, `preserveValues`, etc.) preserved verbatim.

Skipped (already had timeout from PRs #127 / #131 / #143 / #150 / earlier reactive fixes):
- 06a-bp-self-sovereign-cutover.yaml
- 08-openbao.yaml
- 09-keycloak.yaml (timeout: 30m — kept)
- 10-gitea.yaml
- 13-bp-catalyst-platform.yaml
- 15a-external-secrets-stores.yaml
- 19-harbor.yaml

## Claimed TCs

Infra-only template change — preempts future Helm 5m-default cold-start race wedges across the full bootstrap-kit. The validation surface is the next fresh Sovereign provision: zero-touch provision should reach `Ready=True` on all HRs without per-blueprint timeout fix-forwards. No qa-loop test cases changed.

## Test plan

- [x] All 36 templates parse as valid YAML (`yaml.safe_load_all`)
- [x] Audit script confirms every `install:` / `upgrade:` block now has `timeout:` (0 missing post-patch)
- [x] Diffs verified clean — only timeout lines added, nothing else mutated
- [ ] Next fresh provision validates 0 HRs hit 5m default-timeout failures (next bounded-cycle iter, no per-blueprint reactive PRs needed)

Refs #154, #127, #131, #143, #150.

Per principle 16 (HR-level install/upgrade timeout is the canonical seam).
Per principle 4 (target-state — preempt rather than react).
Per principle 21 (only openova public repo bootstrap-kit `_template/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)