### PR TITLE
fix(catalyst-api/wipe): purge ALL S3 buckets matching catalyst-<fqdn-slug> prefix (#153)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/wipe.go
+++ b/products/catalyst/bootstrap/api/internal/handler/wipe.go
@@ -393,9 +393,22 @@ func (h *Handler) WipeDeployment(w http.ResponseWriter, r *http.Request) {
 			func(msg string) { emit("wipe", "info", "object-storage: "+msg) },
 		)
 		bucketCancel()
-		if removed > 0 {
-			report.HetznerPurge.S3Buckets = append(report.HetznerPurge.S3Buckets,
-				hetzner.BucketNameForSovereign(dep.Request.SovereignFQDN, dep.ID))
+		// Issue #153 — PurgeBuckets is now prefix-match: every bucket
+		// matching `catalyst-<fqdn-slug>` (legacy) or
+		// `catalyst-<fqdn-slug>-*` (Fix #111+ deployment-id-suffixed)
+		// gets emptied + deleted. Pre-fix this only purged the ONE
+		// bucket whose suffix matched the CURRENT deployment-id,
+		// leaving every prior provision's bucket orphaned (4+ stale
+		// catalyst-omantel-biz-* buckets observed live).
+		//
+		// Log the prefix actually swept so an operator inspecting the
+		// SSE log can correlate with the `removed` count without
+		// re-deriving the deterministic name. The S3Buckets slice gets
+		// one entry per removed bucket (name not surfaced from the
+		// purge layer; the SSE log already carries per-bucket detail).
+		bucketPrefix := hetzner.BucketNamePrefixForSovereign(dep.Request.SovereignFQDN)
+		for i := 0; i < removed; i++ {
+			report.HetznerPurge.S3Buckets = append(report.HetznerPurge.S3Buckets, bucketPrefix+"-*")
 		}
 		if berr != nil {
 			report.HetznerPurge.Errors = append(report.HetznerPurge.Errors,

--- a/products/catalyst/bootstrap/api/internal/hetzner/buckets.go
+++ b/products/catalyst/bootstrap/api/internal/hetzner/buckets.go
@@ -157,25 +157,45 @@ type PurgeBucketsConfig struct {
 	Region    string
 }
 
-// PurgeBuckets empties + deletes the per-Sovereign Hetzner Object
-// Storage bucket. The bucket name is derived deterministically from
-// (sovereignFQDN, deploymentID) — see BucketNameForSovereign.
+// PurgeBuckets empties + deletes EVERY Hetzner Object Storage bucket
+// owned by the (Hetzner Object Storage credentials) tenant whose name
+// matches the per-Sovereign prefix (see BucketNamePrefixForSovereign).
 //
-// deploymentID is the catalyst-api's per-deployment ID (16-hex from
-// newID()). It is used as the bucket-name suffix to disambiguate
-// across the global Hetzner Object Storage namespace. Pass empty
-// only for legacy records where the on-disk Deployment pre-dates
-// Fix #111; the function falls back to a fqdn-derived sha256 prefix
-// in that case (see bucketSuffix).
+// Why prefix-match instead of a single deterministic name (issue
+// #153): every fresh provision of the same Sovereign FQDN gets a new
+// deployment-id, and post Fix #111 the bucket name carries an 8-hex
+// suffix derived from that deployment-id. So a sequence of
+// provision -> wipe -> re-provision -> wipe -> ... left one bucket
+// per provision behind because the wipe-time deployment-id suffix
+// only ever matched the CURRENT provision, never the previous ones.
+// Hetzner Object Storage caps each tenant at a finite bucket quota,
+// so the leak was unbounded tech debt (4+ stale catalyst-omantel-biz-*
+// buckets observed live for omantel.biz alone).
 //
-// Returns the number of buckets actually removed (0 or 1) and an
-// error only on a non-recoverable failure (network, auth, partial
-// delete that left the bucket non-empty). A 404 NoSuchBucket is
-// idempotent success: BucketsRemoved=0, err=nil.
+// The matched set is ANY bucket whose name == "catalyst-<fqdn-slug>"
+// (legacy pre-Fix-#111 records, no suffix) OR starts with
+// "catalyst-<fqdn-slug>-" (Fix #111 onward, 8-hex deployment-id
+// suffix). The dash boundary in the prefix prevents accidental
+// matches against unrelated Sovereigns whose slug shares a prefix
+// (e.g. "catalyst-omantel-biz-" never matches "catalyst-omantel-bizz-...").
+//
+// deploymentID is retained on the signature for caller backward-
+// compatibility (the wipe handler still passes it) but is no longer
+// used to derive a single bucket name — the prefix-match strategy
+// above purges the current AND any prior deployment-id's bucket in
+// one call.
+//
+// Returns the number of buckets actually removed and an error
+// only on the FIRST non-recoverable failure encountered while
+// iterating the matched set. Per-bucket failures are accumulated
+// and returned in aggregate (best-effort: one wedged bucket must
+// not block the remaining N-1). A 404 NoSuchBucket on any individual
+// bucket is treated as idempotent success.
 //
 // progress is called for human-readable status updates to feed the
 // SSE log. Pass nil to silence.
 func PurgeBuckets(ctx context.Context, cfg PurgeBucketsConfig, sovereignFQDN, deploymentID string, progress func(msg string)) (int, error) {
+	_ = deploymentID // kept for caller compat; prefix-match supersedes
 	if progress == nil {
 		progress = func(string) {}
 	}
@@ -202,8 +222,74 @@ func PurgeBuckets(ctx context.Context, cfg PurgeBucketsConfig, sovereignFQDN, de
 		return 0, fmt.Errorf("construct minio client: %w", err)
 	}
 
-	bucketName := BucketNameForSovereign(sovereignFQDN, deploymentID)
-	return purgeBucket(ctx, client, bucketName, progress)
+	return purgeBucketsByPrefix(ctx, client, sovereignFQDN, progress)
+}
+
+// BucketNamePrefixForSovereign returns the prefix that every per-
+// Sovereign Hetzner Object Storage bucket name shares for a given
+// FQDN. The legacy bucket name (no Fix #111 suffix) equals the
+// prefix exactly; the Fix #111+ bucket names extend the prefix with
+// "-<8-hex-deployment-id>".
+//
+// Exposed so the wipe handler can log the prefix it is purging
+// without re-deriving it, and so unit tests can pin both halves of
+// the contract from one place.
+func BucketNamePrefixForSovereign(fqdn string) string {
+	return "catalyst-" + strings.ReplaceAll(fqdn, ".", "-")
+}
+
+// purgeBucketsByPrefix lists every bucket the credentials can see
+// and purges any whose name matches the per-Sovereign prefix
+// (exact match for legacy no-suffix, or prefix + "-" for Fix #111+).
+//
+// Split out from PurgeBuckets so tests can drive a real fake S3
+// server without depending on Hetzner's region table or credential
+// validation.
+func purgeBucketsByPrefix(ctx context.Context, client *minio.Client, sovereignFQDN string, progress func(string)) (int, error) {
+	if progress == nil {
+		progress = func(string) {}
+	}
+
+	prefix := BucketNamePrefixForSovereign(sovereignFQDN)
+	prefixDash := prefix + "-"
+
+	all, err := client.ListBuckets(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("list buckets: %w", err)
+	}
+
+	var matched []string
+	for _, b := range all {
+		if b.Name == prefix || strings.HasPrefix(b.Name, prefixDash) {
+			matched = append(matched, b.Name)
+		}
+	}
+	if len(matched) == 0 {
+		progress(fmt.Sprintf("no buckets matched prefix %s — clean tenant", prefix))
+		return 0, nil
+	}
+	progress(fmt.Sprintf("found %d bucket(s) matching prefix %s — purging each", len(matched), prefix))
+
+	totalRemoved := 0
+	var perBucketErrs []string
+	for _, name := range matched {
+		removed, perr := purgeBucket(ctx, client, name, progress)
+		totalRemoved += removed
+		if perr != nil {
+			// Best-effort across the matched set: log + continue. One
+			// wedged bucket must NOT block the remaining N-1 from being
+			// cleaned up. Errors are accumulated and returned in
+			// aggregate so the SSE banner can surface "investigate the
+			// log; M of N buckets failed".
+			progress(fmt.Sprintf("bucket %s: purge failed (continuing): %v", name, perr))
+			perBucketErrs = append(perBucketErrs, fmt.Sprintf("%s: %v", name, perr))
+		}
+	}
+	if len(perBucketErrs) > 0 {
+		return totalRemoved, fmt.Errorf("%d of %d bucket purges failed: %s",
+			len(perBucketErrs), len(matched), strings.Join(perBucketErrs, "; "))
+	}
+	return totalRemoved, nil
 }
 
 // purgeBucket runs the empty + delete sequence against a single

--- a/products/catalyst/bootstrap/api/internal/hetzner/buckets_test.go
+++ b/products/catalyst/bootstrap/api/internal/hetzner/buckets_test.go
@@ -621,3 +621,208 @@ func TestBucketPurge_Progress_Receives_Messages(t *testing.T) {
 		t.Errorf("progress callback never emitted 'deleted bucket' message; got %v", msgs)
 	}
 }
+
+// --- Multi-bucket fake + tests for purgeBucketsByPrefix (issue #153) ---
+//
+// The fakeS3 above is single-tenant by design. For the prefix-match
+// purge (issue #153) we need a richer fake that (a) reports a list of
+// buckets via ListBuckets (`GET /`) and (b) handles per-bucket purges
+// for any matching name. We compose multiple fakeS3 instances behind
+// a single router so we can re-use the existing per-bucket purge
+// handlers.
+
+type multiBucketFake struct {
+	mu      sync.Mutex
+	buckets map[string]*fakeS3 // bucket name -> per-bucket state
+}
+
+func newMultiBucketFake(names ...string) *multiBucketFake {
+	m := &multiBucketFake{buckets: map[string]*fakeS3{}}
+	for _, n := range names {
+		m.buckets[n] = &fakeS3{bucket: n, exists: true}
+	}
+	return m
+}
+
+type listAllMyBucketsResult struct {
+	XMLName xml.Name           `xml:"ListAllMyBucketsResult"`
+	Owner   listBucketsOwner   `xml:"Owner"`
+	Buckets listBucketsWrapper `xml:"Buckets"`
+}
+
+type listBucketsOwner struct {
+	ID          string `xml:"ID"`
+	DisplayName string `xml:"DisplayName"`
+}
+
+type listBucketsWrapper struct {
+	Bucket []listBucketEntry `xml:"Bucket"`
+}
+
+type listBucketEntry struct {
+	Name         string `xml:"Name"`
+	CreationDate string `xml:"CreationDate"`
+}
+
+func (m *multiBucketFake) handler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		p := strings.TrimPrefix(r.URL.Path, "/")
+
+		// GET / -> ListBuckets
+		if r.Method == http.MethodGet && p == "" {
+			m.mu.Lock()
+			defer m.mu.Unlock()
+			res := listAllMyBucketsResult{
+				Owner: listBucketsOwner{ID: "test", DisplayName: "test"},
+			}
+			for name := range m.buckets {
+				res.Buckets.Bucket = append(res.Buckets.Bucket, listBucketEntry{
+					Name:         name,
+					CreationDate: "2026-01-01T00:00:00Z",
+				})
+			}
+			w.Header().Set("Content-Type", "application/xml")
+			_ = xml.NewEncoder(w).Encode(res)
+			return
+		}
+
+		// Per-bucket: dispatch to the matching fakeS3 handler. First
+		// path segment is the bucket name.
+		var bucket string
+		if i := strings.IndexByte(p, '/'); i >= 0 {
+			bucket = p[:i]
+		} else {
+			bucket = p
+		}
+
+		m.mu.Lock()
+		f, ok := m.buckets[bucket]
+		m.mu.Unlock()
+		if !ok {
+			w.WriteHeader(http.StatusNotFound)
+			_ = xmlError(w, "NoSuchBucket", "bucket does not exist")
+			return
+		}
+		f.handler().ServeHTTP(w, r)
+	})
+}
+
+// TestPurgeBucketsByPrefix_PurgesAllMatching is the core regression
+// for issue #153 — a sequence of provisions for the same Sovereign
+// FQDN must be cleaned up by ONE wipe call, not one orphan bucket
+// left per prior provision.
+func TestPurgeBucketsByPrefix_PurgesAllMatching(t *testing.T) {
+	// Setup: tenant has 4 catalyst buckets for omantel.biz across 4
+	// different deployment-id suffixes (the orphan accumulation
+	// pattern observed live), plus 2 unrelated buckets that must NOT
+	// be touched.
+	fake := newMultiBucketFake(
+		"catalyst-omantel-biz-aaaaaaaa",
+		"catalyst-omantel-biz-bbbbbbbb",
+		"catalyst-omantel-biz-cccccccc",
+		"catalyst-omantel-biz-dddddddd",
+		"catalyst-other-customer-eeeeeeee",
+		"unrelated-bucket",
+	)
+	srv := httptest.NewServer(fake.handler())
+	defer srv.Close()
+	client := newTestMinio(t, srv)
+
+	var msgs []string
+	progress := func(s string) { msgs = append(msgs, s) }
+
+	removed, err := purgeBucketsByPrefix(context.Background(), client, "omantel.biz", progress)
+	if err != nil {
+		t.Fatalf("purgeBucketsByPrefix: %v", err)
+	}
+	if removed != 4 {
+		t.Errorf("removed = %d, want 4 (one per deployment-id suffix for omantel.biz)", removed)
+	}
+	// The 4 matched buckets must be deleted; the 2 unrelated ones
+	// must remain.
+	matchedDeleted := 0
+	for _, name := range []string{
+		"catalyst-omantel-biz-aaaaaaaa",
+		"catalyst-omantel-biz-bbbbbbbb",
+		"catalyst-omantel-biz-cccccccc",
+		"catalyst-omantel-biz-dddddddd",
+	} {
+		if fake.buckets[name].bucketDel.Load() {
+			matchedDeleted++
+		}
+	}
+	if matchedDeleted != 4 {
+		t.Errorf("matched-bucket DeleteBucket count = %d, want 4", matchedDeleted)
+	}
+	if fake.buckets["catalyst-other-customer-eeeeeeee"].bucketDel.Load() {
+		t.Errorf("unrelated catalyst bucket for a DIFFERENT Sovereign was deleted — prefix match too greedy")
+	}
+	if fake.buckets["unrelated-bucket"].bucketDel.Load() {
+		t.Errorf("non-catalyst bucket was deleted — prefix match too greedy")
+	}
+}
+
+// TestPurgeBucketsByPrefix_LegacyNoSuffix exercises the legacy
+// pre-Fix-#111 record where the bucket name equals the prefix
+// exactly (no -<8-hex> suffix). The wipe must still find + delete
+// such a bucket so legacy Sovereigns aren't permanently orphaned
+// after the new code lands.
+func TestPurgeBucketsByPrefix_LegacyNoSuffix(t *testing.T) {
+	fake := newMultiBucketFake(
+		"catalyst-otech50-omani-works", // legacy: prefix only
+	)
+	srv := httptest.NewServer(fake.handler())
+	defer srv.Close()
+	client := newTestMinio(t, srv)
+
+	removed, err := purgeBucketsByPrefix(context.Background(), client, "otech50.omani.works", nil)
+	if err != nil {
+		t.Fatalf("purgeBucketsByPrefix legacy: %v", err)
+	}
+	if removed != 1 {
+		t.Errorf("removed = %d, want 1 (legacy single bucket)", removed)
+	}
+	if !fake.buckets["catalyst-otech50-omani-works"].bucketDel.Load() {
+		t.Errorf("legacy bucket was not deleted")
+	}
+}
+
+// TestPurgeBucketsByPrefix_NoMatch returns 0 + nil err when the
+// tenant has no matching buckets — wipe of an FQDN that never
+// completed Phase 0 must not error.
+func TestPurgeBucketsByPrefix_NoMatch(t *testing.T) {
+	fake := newMultiBucketFake(
+		"catalyst-someone-else-12345678",
+		"random-tenant-bucket",
+	)
+	srv := httptest.NewServer(fake.handler())
+	defer srv.Close()
+	client := newTestMinio(t, srv)
+
+	removed, err := purgeBucketsByPrefix(context.Background(), client, "neverexisted.biz", nil)
+	if err != nil {
+		t.Fatalf("purgeBucketsByPrefix no-match: %v", err)
+	}
+	if removed != 0 {
+		t.Errorf("removed = %d, want 0", removed)
+	}
+}
+
+// TestBucketNamePrefixForSovereign pins the prefix derivation so
+// a future rename of the bucket-naming scheme can't silently
+// orphan buckets from prior versions.
+func TestBucketNamePrefixForSovereign(t *testing.T) {
+	cases := []struct {
+		fqdn string
+		want string
+	}{
+		{"omantel.biz", "catalyst-omantel-biz"},
+		{"otech50.omani.works", "catalyst-otech50-omani-works"},
+		{"acme.example.com", "catalyst-acme-example-com"},
+	}
+	for _, c := range cases {
+		if got := BucketNamePrefixForSovereign(c.fqdn); got != c.want {
+			t.Errorf("BucketNamePrefixForSovereign(%q) = %q, want %q", c.fqdn, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Fix #153 — every Sovereign provision creates an S3 bucket
`catalyst-${fqdn-slug}-${deployment-id-prefix}` (Fix #133/#136 swap to
`hashicorp/aws` provider; Fix #111 added the deployment-id suffix).
The wipe handler's existing `PurgeBuckets` only deleted the ONE bucket
whose suffix matched the CURRENT deployment-id, leaving every prior
provision's bucket orphaned. 4+ stale `catalyst-omantel-biz-*` buckets
observed live for omantel.biz alone — unbounded leak that will hit
Hetzner Object Storage tenant quota.

This PR replaces the single-name lookup with a prefix-match purge:
`PurgeBuckets` now calls `ListBuckets`, filters to names that equal
`catalyst-<fqdn-slug>` (legacy pre-Fix-#111) OR start with
`catalyst-<fqdn-slug>-` (Fix #111+), and purges each. Per-bucket
errors are accumulated + returned in aggregate (best-effort per task
brief) so one wedged bucket can't block the remaining N-1.

## Claimed TCs

- `TestPurgeBucketsByPrefix_PurgesAllMatching` — 4 orphan
  `catalyst-omantel-biz-<8hex>` buckets all cleaned in one wipe; 2
  unrelated buckets (different Sovereign + non-catalyst) untouched.
- `TestPurgeBucketsByPrefix_LegacyNoSuffix` — pre-Fix-#111 records
  (no suffix; bucket name == prefix) still purgeable.
- `TestPurgeBucketsByPrefix_NoMatch` — wipe of an FQDN that never
  reached Phase 0 returns `(0, nil)` cleanly.
- `TestBucketNamePrefixForSovereign` — pins the prefix derivation
  so a future rename can't silently orphan buckets again.
- All 9 pre-existing bucket tests still pass (purgeBucket per-bucket
  helper is unchanged; the multi-bucket wrapper composes it).

## Test plan

- [x] `go build ./...` clean in `products/catalyst/bootstrap/api`
- [x] `go test ./internal/hetzner/` — 13 PASS / 0 FAIL
- [x] `go test ./internal/handler/` — PASS (no wipe regressions)
- [ ] On next omantel.biz wipe via wizard, verify SSE log shows
      `found N bucket(s) matching prefix catalyst-omantel-biz` and
      `report.HetznerPurge.S3Buckets` count matches the live
      bucket-list count
- [ ] After verification, confirm `aws s3api list-buckets` against
      the Hetzner tenant returns 0 `catalyst-omantel-biz-*` entries

## Notes

- Stayed on `minio-go` (already in `go.mod`) instead of adding
  `aws-sdk-go-v2` — minio-go speaks vanilla S3 against Hetzner
  Object Storage's endpoint and provides every call we need
  (`ListBuckets`, `BucketExists`, `ListObjects`, `RemoveObjects`,
  `RemoveBucket`, `ListIncompleteUploads`, `RemoveIncompleteUpload`).
  Smaller dep footprint; same wire protocol.
- New exported helper `BucketNamePrefixForSovereign` so the wipe
  handler can log the swept prefix without re-deriving.
- Best-effort: S3 errors append to `report.Errors` but do NOT block
  the rest of the wipe (Hetzner orphan purge / PDM release / local
  cleanup all still run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)