### PR TITLE
fix(catalyst-api): tear down per-deployment reflectors on wipe (#156)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/wipe.go
+++ b/products/catalyst/bootstrap/api/internal/handler/wipe.go
@@ -303,13 +303,6 @@ func (h *Handler) WipeDeployment(w http.ResponseWriter, r *http.Request) {
 	dep.eventsCh = make(chan provisioner.Event, 256)
 	dep.mu.Unlock()
 
-	// Note: any live Phase-1 watcher for this deployment will exit
-	// naturally as `tofu destroy` removes the API server it's watching
-	// (the watch reconnect will fail with "no route to host" / "EOF" and
-	// the watcher's own context-deadline-exceeded path takes over).
-	// We don't need to explicitly cancel here.
-	_ = dep.liveWatcher
-
 	report := wipeResponse{
 		DeploymentID:  id,
 		SovereignFQDN: dep.Request.SovereignFQDN,
@@ -330,6 +323,40 @@ func (h *Handler) WipeDeployment(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	emit("wipe", "info", "Wipe initiated for "+dep.Request.SovereignFQDN+" (was: "+prevStatus+")")
+
+	// Cancel the per-deployment helmwatch.Watcher BEFORE we destroy the
+	// underlying apiserver. Issue #156: previously this site relied on
+	// the watcher exiting "naturally" once `tofu destroy` removed the
+	// apiserver — but the dynamicinformer's Reflector keeps reconnecting
+	// against the cached CA bundle on the destroyed control-plane IP,
+	// spamming `x509: certificate signed by unknown authority` hundreds
+	// of times per second for hours. The leaked goroutines burn CPU,
+	// hide real errors in catalyst-api logs, and (worst of all) hold
+	// stale Indexer state that subsequent fresh provisions inherit
+	// through the SSE event stream — exactly the "event stream stale at
+	// T+18 min" symptom Fix #151 surfaced on prov #25.
+	//
+	// Watcher.Cancel is safe pre-Start, post-terminate, and twice in a
+	// row; we read the pointer under dep.mu to race against the
+	// phase1_watch goroutine clearing it on its terminal exit.
+	dep.mu.Lock()
+	live := dep.liveWatcher
+	dep.mu.Unlock()
+	if live != nil {
+		live.Cancel()
+		emit("wipe", "info", "phase-1 watcher cancelled to stop reflector spam against the about-to-be-destroyed apiserver")
+	}
+
+	// Tear down the per-Sovereign k8scache informer set so its
+	// reflectors don't keep retrying against the destroyed apiserver
+	// either. Issue #156. Same canonical seam as Watcher.Cancel above:
+	// stop the goroutines BEFORE Hetzner cleanup makes the IP a
+	// sinkhole. Idempotent + nil-tolerant — production wires k8sCache
+	// via main.go; tests building Handler{} directly leave it nil.
+	if h.k8sCache != nil {
+		h.k8sCache.RemoveCluster(id)
+		emit("wipe", "info", "k8scache informer set removed for "+id)
+	}
 
 	// Step 1 — tofu destroy. Pass the freshly-prompted Hetzner token via
 	// the Request so writeTfvars renders it for the destroy run.

--- a/products/catalyst/bootstrap/api/internal/k8scache/factory.go
+++ b/products/catalyst/bootstrap/api/internal/k8scache/factory.go
@@ -208,6 +208,16 @@ type clusterState struct {
 	synced        map[string]bool                      // keyed by Kind.Name
 	lastEventAt   map[string]time.Time                 // keyed by Kind.Name
 	lastEventLock sync.RWMutex
+
+	// stop — per-cluster shutdown channel passed into
+	// dynamicinformer.Factory.Start. Closing it tears down every
+	// per-kind informer goroutine for THIS cluster only — a fan-out of
+	// the Factory-wide `f.stop` channel that survives until process
+	// exit. RemoveCluster closes this channel so a wiped Sovereign's
+	// reflectors stop their TLS-loop spam against the destroyed
+	// apiserver (issue #156). Idempotent close protected by stopOnce.
+	stop     chan struct{}
+	stopOnce sync.Once
 }
 
 // subscriber — one SSE consumer.
@@ -454,6 +464,7 @@ func (f *Factory) AddCluster(c ClusterRef) error {
 		indexers:    map[string]cache.Indexer{},
 		synced:      map[string]bool{},
 		lastEventAt: map[string]time.Time{},
+		stop:        make(chan struct{}),
 	}
 
 	// Spawn one informer per registered kind. AddCluster MUST stay
@@ -499,11 +510,71 @@ func (f *Factory) AddCluster(c ClusterRef) error {
 	}
 
 	f.mu.Lock()
+	// If a cluster with the same id was already registered, close its
+	// stop channel so its informer goroutines exit before we overwrite
+	// the map entry. Without this the previous reflectors would leak —
+	// a re-AddCluster after a kubeconfig rotation (or a chroot
+	// self-register that races a posted-back kubeconfig) silently
+	// stacked another set of informers on top of the dead ones.
+	if prev, ok := f.clusters[c.ID]; ok && prev != nil {
+		prev.stopOnce.Do(func() { close(prev.stop) })
+	}
 	f.clusters[c.ID] = cs
 	f.mu.Unlock()
 	f.log.Info("k8scache: cluster registered",
 		"cluster", c.ID, "kinds", len(cs.informers))
 	return nil
+}
+
+// RemoveCluster tears down the per-Sovereign informer factory for
+// `id` and removes it from the Factory's cluster map. Safe to call
+// from any goroutine and idempotent — calling on an unknown id, or
+// twice in succession, is a no-op.
+//
+// Issue #156 — when a Sovereign is wiped (POST /wipe → tofu destroy +
+// Hetzner orphan purge), the cluster's apiserver IP becomes
+// unreachable. Without RemoveCluster the per-kind reflectors keep
+// retrying with the cached CA bundle and spam catalyst-api logs
+// hundreds-per-second with x509: unknown-authority errors against
+// the destroyed control plane IP. They also burn CPU and (worst of
+// all) hold stale Indexer state that subsequent fresh provisions
+// see via the SSE event stream.
+//
+// Per docs/INVIOLABLE-PRINCIPLES.md #4 (event-driven, no polling):
+// stopping is via channel close, not a wait-loop. The
+// dynamicinformer factory's Start(stopCh) plumbs the channel down
+// into every per-resource Reflector; closing the channel triggers
+// the reflector goroutines to return on their next select tick.
+//
+// Optional snapshot cleanup: when SnapshotDir is configured, drop
+// the per-(cluster, kind) snapshot files so a Pod restart after
+// the wipe doesn't hydrate from stale disk state.
+func (f *Factory) RemoveCluster(id string) {
+	if id == "" {
+		return
+	}
+	f.mu.Lock()
+	cs, ok := f.clusters[id]
+	if ok {
+		delete(f.clusters, id)
+	}
+	f.mu.Unlock()
+	if !ok || cs == nil {
+		return
+	}
+	cs.stopOnce.Do(func() { close(cs.stop) })
+
+	if f.cfg.SnapshotDir != "" {
+		for kindName := range cs.informers {
+			path := snapshotPath(f.cfg.SnapshotDir, id, kindName)
+			if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+				f.log.Warn("k8scache: snapshot cleanup failed",
+					"cluster", id, "kind", kindName, "err", err)
+			}
+		}
+	}
+	f.log.Info("k8scache: cluster removed",
+		"cluster", id, "kinds", len(cs.informers))
 }
 
 // Start kicks off every informer + the snapshot loop. Safe to call
@@ -533,7 +604,21 @@ func (f *Factory) Start(ctx context.Context) error {
 	f.mu.RUnlock()
 
 	for _, cs := range clusters {
-		cs.factory.Start(f.stop)
+		// Start with the per-cluster stop channel so RemoveCluster can
+		// tear down THIS cluster's informers without affecting others.
+		// Issue #156. Process-shutdown semantics are preserved by the
+		// fan-out goroutine below: when f.stop closes (Factory.Stop),
+		// every per-cluster stop channel closes too.
+		cs.factory.Start(cs.stop)
+		cs := cs
+		go func() {
+			select {
+			case <-f.stop:
+				cs.stopOnce.Do(func() { close(cs.stop) })
+			case <-cs.stop:
+				// Already removed via RemoveCluster — exit goroutine.
+			}
+		}()
 	}
 
 	// Sync watcher per cluster.

--- a/products/catalyst/bootstrap/api/internal/k8scache/k8scache_test.go
+++ b/products/catalyst/bootstrap/api/internal/k8scache/k8scache_test.go
@@ -888,3 +888,123 @@ func TestPolicyReport_FlowsThroughSSEFanout(t *testing.T) {
 		}
 	}
 }
+
+// TestFactory_RemoveClusterIdempotentAndStops asserts the issue #156
+// reflector-cleanup contract:
+//
+//   - RemoveCluster on an unknown id is a no-op (no panic, no slog
+//     side effects observable at the test layer).
+//   - RemoveCluster removes the entry from Factory.Clusters() and
+//     subsequent List calls return "cluster not registered".
+//   - RemoveCluster called twice in a row on the same id is safe (no
+//     close-of-closed-channel panic).
+//
+// The third bullet is the contract the wipe handler relies on — a
+// repeat-wipe of the same deployment id must not crash catalyst-api.
+func TestFactory_RemoveClusterIdempotentAndStops(t *testing.T) {
+	pod := newPod("default", "x")
+	dyn, core := fakeClients(pod)
+
+	cfg := Config{
+		Logger:   quietLogger(),
+		Registry: minimalRegistry(),
+		Clusters: []ClusterRef{
+			{ID: "wiped-soon", DynamicClient: dyn, CoreClient: core},
+		},
+	}
+	f, err := NewFactory(cfg)
+	if err != nil {
+		t.Fatalf("NewFactory: %v", err)
+	}
+	defer f.Stop()
+	if err := f.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	// Sanity: cluster is registered.
+	clusters := f.Clusters()
+	found := false
+	for _, id := range clusters {
+		if id == "wiped-soon" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("cluster not registered before RemoveCluster: %v", clusters)
+	}
+
+	// Unknown id — no-op, no panic.
+	f.RemoveCluster("not-a-real-cluster")
+
+	// Empty id — no-op, no panic.
+	f.RemoveCluster("")
+
+	// Real removal.
+	f.RemoveCluster("wiped-soon")
+	clusters = f.Clusters()
+	for _, id := range clusters {
+		if id == "wiped-soon" {
+			t.Fatalf("cluster still present after RemoveCluster: %v", clusters)
+		}
+	}
+	if _, _, err := f.List("wiped-soon", "pod", labels.Everything()); err == nil {
+		t.Fatalf("List after RemoveCluster expected error, got nil")
+	}
+
+	// Idempotent — second RemoveCluster on the same id must NOT panic
+	// (close-of-closed-channel would surface here).
+	f.RemoveCluster("wiped-soon")
+}
+
+// TestFactory_AddClusterReplacesPriorEntry asserts that re-AddCluster
+// on the same id closes the previous stop channel (so its informers
+// exit) before swapping in the new clusterState. Without this an
+// operator rotating a kubeconfig — or chroot self-register racing a
+// posted-back kubeconfig with the same id — would silently leak the
+// prior reflector goroutines. Issue #156.
+func TestFactory_AddClusterReplacesPriorEntry(t *testing.T) {
+	pod := newPod("default", "x")
+	dyn1, core1 := fakeClients(pod)
+	dyn2, core2 := fakeClients(pod)
+
+	cfg := Config{
+		Logger:   quietLogger(),
+		Registry: minimalRegistry(),
+	}
+	f, err := NewFactory(cfg)
+	if err != nil {
+		t.Fatalf("NewFactory: %v", err)
+	}
+	defer f.Stop()
+
+	if err := f.AddCluster(ClusterRef{ID: "rotate", DynamicClient: dyn1, CoreClient: core1}); err != nil {
+		t.Fatalf("AddCluster #1: %v", err)
+	}
+	// Capture the first clusterState's stop channel via the internal
+	// map — a small reach into package internals so the test asserts
+	// the actual goroutine-shutdown contract, not just observable
+	// state.
+	f.mu.RLock()
+	prev := f.clusters["rotate"]
+	f.mu.RUnlock()
+	if prev == nil {
+		t.Fatalf("first AddCluster did not register clusterState")
+	}
+
+	if err := f.AddCluster(ClusterRef{ID: "rotate", DynamicClient: dyn2, CoreClient: core2}); err != nil {
+		t.Fatalf("AddCluster #2: %v", err)
+	}
+
+	// After the second AddCluster, the first cs.stop channel must be
+	// closed (drained without blocking).
+	select {
+	case <-prev.stop:
+	case <-time.After(time.Second):
+		t.Fatalf("prior clusterState.stop was not closed after re-AddCluster")
+	}
+
+	// Cleanup so the test doesn't leak.
+	f.RemoveCluster("rotate")
+}
+


### PR DESCRIPTION
## Summary

Stops the catalyst-api reflector cache leak that spammed
`x509: certificate signed by unknown authority` against the destroyed
control plane after every Sovereign wipe. Same leak path also held stale
Indexer state that surfaced on subsequent fresh provisions as
"event stream stale at T+18 min" (the symptom Fix #151 surfaced on prov
#25).

Two cooperating changes:

- `k8scache.Factory` gains a per-cluster stop channel + public
  `RemoveCluster(id)` (idempotent, nil-tolerant, drops stale snapshot
  files). `AddCluster` also closes the previous entry's stop channel on
  re-registering the same id.
- `WipeDeployment` (`handler/wipe.go`) calls
  `dep.liveWatcher.Cancel()` + `h.k8sCache.RemoveCluster(id)` BEFORE
  running tofu destroy / Hetzner purge, so the reflectors stop their
  TLS-loop spam against the IP we are about to remove.

## Claimed TCs

Infra-only fix; no UI surface. Reduces catalyst-api log noise on every
wipe and improves event-stream freshness for fresh provisions following
a wipe (relates to the prov #25 / iter-1 freshness gates in the bounded
provision cycle). No new TCs to claim — verify by tailing
`kubectl logs -n catalyst deploy/catalyst-api -f | grep x509` after the
next `/wipe` and confirming the spam stops within a few seconds of
wipe completion.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] New unit tests pass:
  - `TestFactory_RemoveClusterIdempotentAndStops` — unknown-id no-op,
    happy path, double-Remove safety
  - `TestFactory_AddClusterReplacesPriorEntry` — re-AddCluster closes
    the prior `cs.stop`
- [x] Existing `internal/k8scache/...` test suite passes
- [x] Existing `internal/handler/...` Wipe test suite passes (only
  pre-existing flaky `TestPinIssue_ConcurrentRapidFireRateLimit` remains
  intermittent — unrelated)
- [ ] Live verification: tail catalyst-api logs after a fresh
  Sovereign wipe and confirm reflector spam stops

## Rules followed

- Principle 17: isolated worktree (`/tmp/wt-156`)
- Principle 4: target-state — actual cache invalidation, not log
  suppression
- Principle 16: canonical seam = `k8scache.Factory` per-cluster
  lifecycle + `WipeDeployment` cleanup hook
- Principle 19: no secrets in logs
- Principle 20: conventional commit + Claude co-author footer
- Principle 21: openova (public) repo only