### PR TITLE
fix(infra/hetzner): hel1 network_zone is eu-north not eu-central (#179)

### DIFF
--- a/infra/hetzner/main.tf
+++ b/infra/hetzner/main.tf
@@ -149,7 +149,7 @@ locals {
   hetzner_network_zones = {
     fsn1 = "eu-central"
     nbg1 = "eu-central"
-    hel1 = "eu-central"
+    hel1 = "eu-north"
     ash  = "us-east"
     hil  = "us-west"
     sin  = "ap-southeast"


### PR DESCRIPTION
## Summary

prov #29 + #30 both failed at +90s with:
\`\`\`
Error: hcloud/inlineAttachServerToNetwork: attach server to network: IP not available
with hcloud_server.secondary_control_plane["hel1-1"]
\`\`\`

Root cause: hardcoded `local.hetzner_network_zones { hel1 = "eu-central" }` in `infra/hetzner/main.tf:152`. **Helsinki is eu-north**, not eu-central. Hetzner subnets are zone-bound — cross-zone attach fails.

## Fix

One-line change: `hel1 = "eu-central"` → `hel1 = "eu-north"`.

## Claimed TCs

(infra-only fix; unblocks ALL 410 TCs by allowing 2-region provisions to actually converge — currently 100% blocked)

## Test plan

- [ ] Wipe Hetzner state
- [ ] Reprov #31 with `/tmp/prov-body-multiregion.json` (2-region fsn1+hel1)
- [ ] Verify both region CPs attach successfully (no `ip_not_available` error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)