### PR TITLE
fix(catalyst-ui): unused ReactNode import (#180) — unblocks Fix #178 build

### DIFF
--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/DeploymentsList.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/DeploymentsList.test.tsx
@@ -27,7 +27,7 @@ import {
   createMemoryHistory,
   Outlet,
 } from '@tanstack/react-router'
-import type { ReactNode } from 'react'
+import type  from 'react'
 
 import { DeploymentsList } from './DeploymentsList'
 import type { DeploymentListEntry } from '@/shared/lib/useInflightDeployment'


### PR DESCRIPTION
## Summary

Fix #178 PR #1382 build failed: `error TS6133: 'ReactNode' is declared but its value is never read.` in DeploymentsList.test.tsx:30. Build & Deploy Catalyst CI blocked → Fix #178 features never deployed.

1-line removal of unused import.

## Claimed TCs

(no direct TC; unblocks Fix #178 deployments-list features reaching production)

🤖 Generated with [Claude Code](https://claude.com/claude-code)