### PR TITLE
fix(catalyst-ui): remove malformed import line (Fix #181 — repairs Fix #180)

### DIFF
--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/DeploymentsList.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/DeploymentsList.test.tsx
@@ -27,7 +27,6 @@ import {
   createMemoryHistory,
   Outlet,
 } from '@tanstack/react-router'
-import type  from 'react'
 
 import { DeploymentsList } from './DeploymentsList'
 import type { DeploymentListEntry } from '@/shared/lib/useInflightDeployment'


### PR DESCRIPTION
Fix #180 sed-output was malformed: `import type  from 'react'` is syntactically invalid. This deletes the broken line so the build can proceed. Unblocks Fix #178 deploy.