### PR TITLE
fix(infra): pin LB private IPs + revert hel1 zone (Fix #182)

### DIFF
--- a/infra/hetzner/main.tf
+++ b/infra/hetzner/main.tf
@@ -146,10 +146,17 @@ locals {
   # means updating this lookup AND the var.region validation in
   # variables.tf in the same PR (so the multi-region for_each below cannot
   # land in a location whose zone we can't resolve).
+  # Hetzner /v1/locations as of 2026-05-11: hel1 is in eu-central
+  # (not eu-north — Fix #179 incorrectly used "eu-north" and tofu apply
+  # FATALed with `network zone does not exist` on prov #32). Verified
+  # via `curl https://api.hetzner.cloud/v1/locations` — single source
+  # of truth. The original prov #29/#30 "IP not available" on
+  # secondary[hel1-1] was misdiagnosed; both regions live in eu-central
+  # and the failure has a different root cause to be re-traced.
   hetzner_network_zones = {
     fsn1 = "eu-central"
     nbg1 = "eu-central"
-    hel1 = "eu-north"
+    hel1 = "eu-central"
     ash  = "us-east"
     hil  = "us-west"
     sin  = "ap-southeast"
@@ -551,6 +558,15 @@ resource "hcloud_load_balancer" "main" {
 resource "hcloud_load_balancer_network" "main" {
   load_balancer_id = hcloud_load_balancer.main.id
   network_id       = hcloud_network.main.id
+  # Fix #182: pin LB private IP to top-of-subnet so it cannot race the
+  # CP server's explicit `ip = "10.0.1.2"` during parallel apply. Without
+  # this, Hetzner auto-allocates the first free IP in the matching-zone
+  # subnet — in multi-region prov #32 the secondary LB attached at t+16s
+  # took 10.0.1.2 from main subnet (only eu-central subnet existing then),
+  # causing CP creation to FATAL with `inlineAttachServerToNetwork: IP
+  # not available`. .254 is the last usable host in /24 and is reserved
+  # platform-wide for LB anchors.
+  ip = "10.0.1.254"
 }
 
 resource "hcloud_load_balancer_target" "control_plane" {
@@ -987,6 +1003,13 @@ resource "hcloud_load_balancer_network" "secondary" {
 
   load_balancer_id = hcloud_load_balancer.secondary[each.key].id
   network_id       = hcloud_network.main.id
+  # Fix #182: pin secondary LB to top-of-its-own-subnet (10.0.10.254,
+  # 10.0.11.254, ...) so multi-region apply cannot race for IPs across
+  # subnets sharing a network zone. See `hcloud_load_balancer_network.main`
+  # comment for full context. depends_on ensures the subnet exists before
+  # Hetzner is asked to allocate inside its CIDR.
+  ip         = cidrhost(local.secondary_region_subnets[each.key], 254)
+  depends_on = [hcloud_network_subnet.secondary]
 }
 
 resource "hcloud_load_balancer_target" "secondary_control_plane" {

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/DeploymentsList.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/DeploymentsList.test.tsx
@@ -27,7 +27,6 @@ import {
   createMemoryHistory,
   Outlet,
 } from '@tanstack/react-router'
-import type  from 'react'
 
 import { DeploymentsList } from './DeploymentsList'
 import type { DeploymentListEntry } from '@/shared/lib/useInflightDeployment'


### PR DESCRIPTION
## Root cause (prov #32)

`hcloud_load_balancer_network.{main,secondary}` attached to the shared `hcloud_network.main` **without** an explicit `ip` argument, so Hetzner auto-allocated the first free address in the first matching-zone subnet.

In multi-region apply the secondary LB-network completed at t+16s and took **10.0.1.2** from the only eu-central subnet existing at that moment (`main` = `10.0.1.0/24`), which is the address the primary CP claims explicitly via `ip = "10.0.1.${count.index + 2}"`. Tofu apply FATALed:

```
Error: hcloud/inlineAttachServerToNetwork: attach server to network: IP not available
  with hcloud_server.control_plane[0]
```

## Fix #182

Pin LB anchors to **top-of-subnet (.254)** so they live outside the CP/worker IP range (.2..N for CPs, .10+ for workers):

| Anchor | Pinned IP |
|---|---|
| `hcloud_load_balancer_network.main`            | `10.0.1.254`   |
| `hcloud_load_balancer_network.secondary[k]`    | `cidrhost(secondary_region_subnets[k], 254)` |

`depends_on = [hcloud_network_subnet.secondary]` ensures the secondary subnet exists before Hetzner is asked to allocate inside its CIDR.

## Revert of Fix #179

`hetzner_network_zones.hel1` was changed `eu-central → eu-north` in Fix #179 based on a misdiagnosis. **Hetzner /v1/locations on 2026-05-11 returns `network_zone=eu-central` for hel1** — verified by direct API call. Fix #179 made prov #32's secondary subnet FATAL with `invalid input in field 'network_zone' [network zone does not exist]`.

The original prov #29/#30 "IP not available on secondary[hel1-1]" was the **same LB-IP collision documented above**, not a zone issue. This PR resolves both.

## Layout after merge

```
10.0.0.0/16  hcloud_network.main
  10.0.1.0/24    main subnet (eu-central)
    .2           primary CP (cp1)
    .254         primary LB anchor
  10.0.10.0/24   secondary subnet (hel1, eu-central)
    .2           secondary CP (hel1-1)
    .254         secondary LB anchor (hel1-1)
```

Single-region Sovereigns are unaffected (only `main` LB-network exists; .254 pin is silently in-range).

Refs: openova-private prov-loop session 2026-05-11 Wave 26