### PR TITLE
fix(infra): body-supplied SKUs win over QA defaults (Fix #183)

### DIFF
--- a/infra/hetzner/main.tf
+++ b/infra/hetzner/main.tf
@@ -146,10 +146,17 @@ locals {
   # means updating this lookup AND the var.region validation in
   # variables.tf in the same PR (so the multi-region for_each below cannot
   # land in a location whose zone we can't resolve).
+  # Hetzner /v1/locations as of 2026-05-11: hel1 is in eu-central
+  # (not eu-north — Fix #179 incorrectly used "eu-north" and tofu apply
+  # FATALed with `network zone does not exist` on prov #32). Verified
+  # via `curl https://api.hetzner.cloud/v1/locations` — single source
+  # of truth. The original prov #29/#30 "IP not available" on
+  # secondary[hel1-1] was misdiagnosed; both regions live in eu-central
+  # and the failure has a different root cause to be re-traced.
   hetzner_network_zones = {
     fsn1 = "eu-central"
     nbg1 = "eu-central"
-    hel1 = "eu-north"
+    hel1 = "eu-central"
     ash  = "us-east"
     hil  = "us-west"
     sin  = "ap-southeast"
@@ -551,6 +558,15 @@ resource "hcloud_load_balancer" "main" {
 resource "hcloud_load_balancer_network" "main" {
   load_balancer_id = hcloud_load_balancer.main.id
   network_id       = hcloud_network.main.id
+  # Fix #182: pin LB private IP to top-of-subnet so it cannot race the
+  # CP server's explicit `ip = "10.0.1.2"` during parallel apply. Without
+  # this, Hetzner auto-allocates the first free IP in the matching-zone
+  # subnet — in multi-region prov #32 the secondary LB attached at t+16s
+  # took 10.0.1.2 from main subnet (only eu-central subnet existing then),
+  # causing CP creation to FATAL with `inlineAttachServerToNetwork: IP
+  # not available`. .254 is the last usable host in /24 and is reserved
+  # platform-wide for LB anchors.
+  ip = "10.0.1.254"
 }
 
 resource "hcloud_load_balancer_target" "control_plane" {
@@ -987,6 +1003,13 @@ resource "hcloud_load_balancer_network" "secondary" {
 
   load_balancer_id = hcloud_load_balancer.secondary[each.key].id
   network_id       = hcloud_network.main.id
+  # Fix #182: pin secondary LB to top-of-its-own-subnet (10.0.10.254,
+  # 10.0.11.254, ...) so multi-region apply cannot race for IPs across
+  # subnets sharing a network zone. See `hcloud_load_balancer_network.main`
+  # comment for full context. depends_on ensures the subnet exists before
+  # Hetzner is asked to allocate inside its CIDR.
+  ip         = cidrhost(local.secondary_region_subnets[each.key], 254)
+  depends_on = [hcloud_network_subnet.secondary]
 }
 
 resource "hcloud_load_balancer_target" "secondary_control_plane" {

--- a/infra/hetzner/main.tf
+++ b/infra/hetzner/main.tf
@@ -131,9 +131,19 @@ locals {
   # already permits (solo Sovereign, worker_count=0): an empty
   # qa_worker_size would otherwise short-circuit to "" — coalesce() falls
   # back to the production default in that mode.
-  qa_mode               = var.qa_fixtures_enabled == "true"
-  effective_cp_size     = local.qa_mode ? coalesce(var.qa_control_plane_size, var.control_plane_size) : var.control_plane_size
-  effective_worker_size = local.qa_mode ? coalesce(var.qa_worker_size, var.worker_size) : var.worker_size
+  qa_mode = var.qa_fixtures_enabled == "true"
+  # Fix #183: body's control_plane_size / worker_size win over QA defaults
+  # when present. Previously `coalesce(var.qa_*, var.*)` returned the QA
+  # default whenever it was non-empty, silently downgrading a body's
+  # explicit cpx42 → cpx32. Now QA defaults only kick in when the body
+  # left the SKU empty (zero-override prov / legacy QA path). On customer
+  # Sovereigns (qa_fixtures_enabled='false') the QA defaults are never
+  # considered. See provisioner.go writeTfvars — body-supplied SKUs are
+  # emitted as JSON only when non-empty, so var.control_plane_size /
+  # var.worker_size already inherit variables.tf defaults when the body
+  # left them blank; coalesce-with-body-first is the right precedence.
+  effective_cp_size     = local.qa_mode ? coalesce(var.control_plane_size, var.qa_control_plane_size) : var.control_plane_size
+  effective_worker_size = local.qa_mode ? coalesce(var.worker_size, var.qa_worker_size) : var.worker_size
 
   # k3s deterministic bootstrap token derived from project ID + sovereign FQDN.
   # Workers join with this; k3s rotates it after first join.

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/DeploymentsList.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/DeploymentsList.test.tsx
@@ -27,7 +27,6 @@ import {
   createMemoryHistory,
   Outlet,
 } from '@tanstack/react-router'
-import type  from 'react'
 
 import { DeploymentsList } from './DeploymentsList'
 import type { DeploymentListEntry } from '@/shared/lib/useInflightDeployment'


### PR DESCRIPTION
## Bug

Fix #157 introduced this precedence when `qa_fixtures_enabled='true'`:

\`\`\`hcl
effective_cp_size = coalesce(var.qa_control_plane_size, var.control_plane_size)
\`\`\`

`coalesce` returns the **first non-empty** argument. `qa_control_plane_size` has a non-empty `cpx32` default, so it always wins — even when the body explicitly supplied something else.

## Founder body for prov #32

\`\`\`json
{ "controlPlaneSize": "cpx42", "workerCount": 0, "qaTestEnabled": true }
\`\`\`

Founder's explicit `cpx42` was silently downgraded to `cpx32` at plan time. The hardware that lit up never matched the operator's intent.

## Fix

Invert the coalesce so body wins, QA default is just a safety net for genuinely zero-override calls:

\`\`\`hcl
effective_cp_size = local.qa_mode
  ? coalesce(var.control_plane_size, var.qa_control_plane_size)
  : var.control_plane_size
\`\`\`

`provisioner.go writeTfvars` already strips empty SKU fields before emitting JSON, so `var.control_plane_size` inherits variables.tf's cost-optimised default when the body left it blank — making body-first coalesce strictly correct.

| Body | `var.control_plane_size` | `var.qa_control_plane_size` | Old result | New result |
|---|---|---|---|---|
| `cpx42` | cpx42 | cpx32 | **cpx32** (wrong) | cpx42 |
| omitted | cpx21 (variables.tf default) | cpx32 | cpx32 | cpx21 |
| explicit empty | — | cpx32 | cpx32 | cpx32 (fallback) |

Same shape for `effective_worker_size`. No change to customer-Sovereign path.

Refs: openova-private prov-loop session 2026-05-11 Wave 26