### PR TITLE
feat(g3-flux): per-region Flux Kustomization path

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -256,7 +256,12 @@ spec:
       # platform-wide migration off bitnami/kubectl (deleted from
       # Docker Hub 2025-08). This Blueprint already uses alpine/k8s
       # + alpine since 0.1.10; no functional image change here.
-      version: 0.1.29
+      # 0.1.30 (slice G3-flux, 2026-05-11): per-region Flux Kustomization
+      # git paths. Step-01 gitea-mirror materialises per-region
+      # bootstrap-kit subtrees under clusters/${SOVEREIGN_FQDN}/<region_key>/;
+      # step-05 flux-gitrepository-patch pivots the local Kustomization
+      # spec.path to its own region subtree post-cutover.
+      version: 0.1.30
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover
@@ -281,3 +286,23 @@ spec:
       harborPublicURL: https://harbor.${SOVEREIGN_FQDN}
       giteaInternalURL: http://gitea-http.gitea.svc.cluster.local:3000
       giteaPublicURL: https://gitea.${SOVEREIGN_FQDN}
+      # Per-region Flux Kustomization paths (slice G3-flux). Comma-
+      # separated list of the Sovereign's region keys — substituted by
+      # Flux postBuild.substitute from a list rendered by catalyst-api's
+      # writeTfvars + cloud-init flow (primary region key + each
+      # secondary's local.secondary_regions map key). Single-region
+      # Sovereigns default to one entry; multi-region Sovereigns get N.
+      # Step-01 gitea-mirror reads this list and materialises one
+      # clusters/${SOVEREIGN_FQDN}/<region_key>/bootstrap-kit subtree
+      # per entry. Format: comma-separated string parsed inside the
+      # mirror Job script (Helm string-list -> shell-friendly). CSV
+      # required because Flux postBuild.substitute can only inject
+      # string values — a real YAML list cannot be reliably emitted.
+      regionsCSV: "${SOVEREIGN_REGION_KEYS_CSV}"
+      # THIS k3s's own region key (slice G3-flux). One entry from
+      # regionsCSV — primary CP renders with `var.region` (e.g. "fsn1"),
+      # every secondary CP renders with its own local.secondary_regions
+      # map key (e.g. "hel1-1"). Step-05 flux-gitrepository-patch reads
+      # this to pivot the bootstrap-kit Kustomization spec.path to the
+      # per-region subtree post-cutover.
+      regionKey: "${SOVEREIGN_REGION_KEY}"

--- a/infra/hetzner/cloudinit-control-plane.tftpl
+++ b/infra/hetzner/cloudinit-control-plane.tftpl
@@ -809,6 +809,41 @@ write_files:
   # per-FQDN copy that prior provisioning depended on becomes a no-op:
   # one shared tree serves every Sovereign, with the Sovereign's FQDN
   # injected by Flux on the cluster instead of by sed in the repo.
+  #
+  # ── Per-region Kustomization path (slice G3-flux) ────────────────────
+  #
+  # Multi-region Sovereigns (var.regions[] with len > 1) provision N
+  # independent k3s clusters in N Hetzner regions. Before this slice the
+  # primary's AND every secondary's Flux Kustomization rendered the
+  # SAME spec.path (`./clusters/_template/bootstrap-kit`), so the only
+  # thing differentiating each region's reconcile loop was which k3s
+  # API server happened to receive the apply. That left no architectural
+  # surface for region-specific overrides (different chart versions per
+  # region, different bp-* slot lists, region-pinned worker shapes…).
+  # Founder caught this on prov #33 (multi-region fsn1+hel1, 2026-05-11):
+  # /sovereign/provision/<id>/jobs/install-trivy showed ONE bubble — the
+  # UI fan-out assumes one bp-trivy install bubble per region.
+  #
+  # Slice G3-flux refines path separation. The `SOVEREIGN_REGION_KEY`
+  # envsubst variable below carries each region's stable identifier
+  # ("fsn1" on the primary, "hel1-1" / "ash-2" / … on secondaries —
+  # matches the local.secondary_regions map key in main.tf). Manifests
+  # in clusters/_template/bootstrap-kit/*.yaml that need per-region
+  # labels / namespaces / Job names consume it via
+  # `$${SOVEREIGN_REGION_KEY}` (the $$ escape avoids tftpl interp).
+  #
+  # The Kustomization spec.path STILL points at the shared `_template/`
+  # tree pre-cutover — that's the path that exists in the upstream
+  # openova-io public repo every Sovereign pulls Phase-1 from. Slice
+  # G3-flux's per-Sovereign per-region subtree path
+  # (`./clusters/<sovereign_fqdn>/<region_key>/bootstrap-kit`) is
+  # materialised by self-sovereign-cutover step-01 gitea-mirror at
+  # cutover time — see 01-gitea-mirror-job.yaml. After cutover step-05
+  # (flux-gitrepository-patch) pivots both the GitRepository URL AND
+  # this Kustomization's spec.path onto the per-region subtree. Pre-
+  # cutover the SOVEREIGN_REGION_KEY substitute is the entire signal a
+  # region's bp-* manifests have to differentiate themselves; post-
+  # cutover the per-region git path adds physical isolation.
   - path: /var/lib/catalyst/flux-bootstrap.yaml
     permissions: '0644'
     content: |
@@ -884,6 +919,30 @@ write_files:
         postBuild:
           substitute:
             SOVEREIGN_FQDN: ${sovereign_fqdn}
+            # Per-region Kustomization marker (slice G3-flux). Carries
+            # this cluster's stable region key — "fsn1" on the primary
+            # (matches var.region) or "<cloudRegion>-<index>" on a
+            # secondary (matches the local.secondary_regions map key in
+            # main.tf, e.g. "hel1-1", "ash-2"). Manifests in
+            # clusters/_template/bootstrap-kit/*.yaml that need per-
+            # region labels / namespaces / Job names consume this via
+            # $${SOVEREIGN_REGION_KEY}. Single-region Sovereigns get
+            # a single non-empty key (no special-casing); secondary
+            # CPs render with their own key from secondary_region_cloud_init
+            # in main.tf locals. Per docs/INVIOLABLE-PRINCIPLES.md #4
+            # the value flows from runtime — never hardcoded in the
+            # template.
+            SOVEREIGN_REGION_KEY: ${sovereign_region_key}
+            # Per-region Sovereign topology — CSV list of every region
+            # key in the Sovereign's regions[] body (slice G3-flux).
+            # Only consumed by the bp-self-sovereign-cutover HelmRelease
+            # values block (06a-bp-self-sovereign-cutover.yaml's
+            # `sovereign.regionsCSV`) — gitea-mirror reads it at cutover
+            # time and materialises one bootstrap-kit subtree per entry.
+            # Format = "fsn1" (single region) or "fsn1,hel1-1,ash-2"
+            # (multi-region). Threaded from tofu var.region (primary) +
+            # local.secondary_regions keys (joined comma-no-space).
+            SOVEREIGN_REGION_KEYS_CSV: "${sovereign_region_keys_csv}"
             # SOVEREIGN_LB_IP — Hetzner load balancer's public IPv4 (issue
             # #900). Threaded into bp-catalyst-platform's
             # `global.sovereignLBIP` so catalyst-api can pre-register glue
@@ -987,6 +1046,12 @@ write_files:
         postBuild:
           substitute:
             SOVEREIGN_FQDN: ${sovereign_fqdn}
+            # Per-region Kustomization marker (slice G3-flux) — see the
+            # bootstrap-kit Kustomization's substitute block above for
+            # the full rationale. Mirrored here so sovereign-tls
+            # manifests that need per-region labels / cert names
+            # consume the same source of truth.
+            SOVEREIGN_REGION_KEY: ${sovereign_region_key}
             # SOVEREIGN_LB_IP — Hetzner load balancer's public IPv4 (issue
             # #900). Threaded into bp-catalyst-platform's
             # `global.sovereignLBIP` so catalyst-api can pre-register glue
@@ -1031,6 +1096,11 @@ write_files:
         postBuild:
           substitute:
             SOVEREIGN_FQDN: ${sovereign_fqdn}
+            # Per-region Kustomization marker (slice G3-flux) — see the
+            # bootstrap-kit Kustomization's substitute block above for
+            # the full rationale. Mirrored here so infrastructure-config
+            # manifests stay consistent with their per-region peers.
+            SOVEREIGN_REGION_KEY: ${sovereign_region_key}
             # SOVEREIGN_LB_IP — Hetzner load balancer's public IPv4 (issue
             # #900). Threaded into bp-catalyst-platform's
             # `global.sovereignLBIP` so catalyst-api can pre-register glue

--- a/infra/hetzner/main.tf
+++ b/infra/hetzner/main.tf
@@ -342,6 +342,26 @@ locals {
   control_plane_cloud_init = replace(templatefile("${path.module}/cloudinit-control-plane.tftpl", {
     sovereign_fqdn          = var.sovereign_fqdn
     sovereign_subdomain     = var.sovereign_subdomain
+    # Per-region Flux Kustomization marker (slice G3-flux). Primary CP
+    # carries the singular `region` field as its key — same shape secondary
+    # CPs use ("hel1-1", "ash-2" — see local.secondary_regions) so chart
+    # manifests reading $${SOVEREIGN_REGION_KEY} get a consistent identifier
+    # whether they land on the primary or a secondary cluster. Per
+    # docs/INVIOLABLE-PRINCIPLES.md #4 the value flows from runtime; the
+    # singular region field is the canonical primary-region identifier.
+    sovereign_region_key    = var.region
+    # Comma-separated list of every region key the Sovereign was
+    # provisioned across (slice G3-flux). Primary region first, then
+    # every secondary in local.secondary_regions iteration order.
+    # Consumed by the cutover gitea-mirror Job to materialise one
+    # bootstrap-kit subtree per region under
+    # clusters/<sovereign_fqdn>/<region_key>/. Empty secondary_regions
+    # map yields a CSV of just the primary key — keeps single-region
+    # Sovereigns on the same per-region layout (no special-casing).
+    sovereign_region_keys_csv = join(",", concat(
+      [var.region],
+      [for k, _ in local.secondary_regions : k]
+    ))
     marketplace_enabled     = var.marketplace_enabled
     qa_fixtures_enabled       = var.qa_fixtures_enabled
     qa_test_session_enabled   = var.qa_test_session_enabled
@@ -820,6 +840,21 @@ locals {
     k => replace(templatefile("${path.module}/cloudinit-control-plane.tftpl", {
       sovereign_fqdn          = var.sovereign_fqdn
       sovereign_subdomain     = var.sovereign_subdomain
+      # Per-region Flux Kustomization marker (slice G3-flux). Secondary
+      # CPs use the local.secondary_regions map key as their region
+      # identifier (e.g. "hel1-1", "ash-2") — the same key threaded into
+      # node labels (catalyst.openova.io/region-id) and used by the
+      # post-cutover gitea-mirror step to materialise per-region subtrees
+      # at clusters/<sovereign_fqdn>/<region_key>/bootstrap-kit/.
+      sovereign_region_key      = k
+      # Same CSV as the primary CP receives — every CP renders the
+      # SAME list because the cutover gitea-mirror Job runs on the
+      # primary and the bp-self-sovereign-cutover HelmRelease's
+      # values must agree across every region's reconciliation.
+      sovereign_region_keys_csv = join(",", concat(
+        [var.region],
+        [for kk, _ in local.secondary_regions : kk]
+      ))
       marketplace_enabled     = var.marketplace_enabled
       qa_fixtures_enabled       = var.qa_fixtures_enabled
       qa_test_session_enabled   = var.qa_test_session_enabled

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -14,7 +14,17 @@ name: bp-self-sovereign-cutover
 # pre-cutover Jobs can reach the explicit URL just fine. Operator
 # override via .Values.global.imageRegistry remains intact for true
 # air-gap or alternate mirror deployments.
-version: 0.1.29
+#
+# 0.1.30 (slice G3-flux, 2026-05-11): per-region Flux Kustomization
+# git paths. Step-01 gitea-mirror now reads sovereign.regionsCSV and
+# materialises one bootstrap-kit subtree per region under
+# clusters/${SOVEREIGN_FQDN}/<region_key>/ + writes a top-level
+# kustomization.yaml index. Step-05 flux-gitrepository-patch reads
+# sovereign.regionKey and pivots the local cluster's bootstrap-kit
+# Flux Kustomization spec.path to its per-region subtree post-cutover.
+# Empty regionKey is a no-op (back-compat with pre-G3-flux Sovereigns
+# already running on `./clusters/_template/bootstrap-kit`).
+version: 0.1.30
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/templates/01-gitea-mirror-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/01-gitea-mirror-job.yaml
@@ -51,6 +51,17 @@ data:
             value: {{ .Values.gitea.repo | quote }}
           - name: MIRROR_INTERVAL
             value: {{ .Values.upstream.mirrorInterval | quote }}
+          # Slice G3-flux — per-region Flux Kustomization paths.
+          # Comma-separated list of region keys ("fsn1" or
+          # "fsn1,hel1-1,ash-2"). The script materialises one
+          # bootstrap-kit subtree per entry under
+          # clusters/${SOVEREIGN_FQDN}/<region_key>/. SOVEREIGN_FQDN
+          # is the per-Sovereign git path root; sovereign.fqdn flows
+          # in from the bp-self-sovereign-cutover HelmRelease values.
+          - name: SOVEREIGN_FQDN
+            value: {{ .Values.sovereign.fqdn | quote }}
+          - name: SOVEREIGN_REGION_KEYS_CSV
+            value: {{ .Values.sovereign.regionsCSV | quote }}
           - name: GITEA_USERNAME
             valueFrom:
               secretKeyRef:
@@ -215,6 +226,116 @@ data:
             if printf '%s' "${repo_meta}" | grep -q '"mirror":false'; then
               echo "[gitea-mirror] verified: mirror=false on ${GITEA_ORG}/${GITEA_REPO} (writable for cutover step-06)"
             fi
+
+            # 5. Slice G3-flux — materialise per-region bootstrap-kit
+            #    subtrees so each cluster's Flux Kustomization can target
+            #    its own git path post-cutover.
+            #
+            #    Pre-cutover every cluster's Flux Kustomization renders
+            #    `./clusters/_template/bootstrap-kit` from the upstream
+            #    openova-io public repo (the per-Sovereign tree doesn't
+            #    exist upstream — see cloudinit-control-plane.tftpl). At
+            #    cutover step-05 the GitRepository URL flips to local
+            #    Gitea AND the Kustomization spec.path pivots to the per-
+            #    region subtree this step materialises here. The pre/post
+            #    cutover layouts agree on chart content (we just `cp -r`
+            #    _template into each per-region dir) — the only thing
+            #    that changes is the path Flux watches AND the per-region
+            #    SOVEREIGN_REGION_KEY envsubst marker each cluster's Flux
+            #    independently substitutes into its own subtree.
+            #
+            #    Layout after this block lands:
+            #      clusters/${SOVEREIGN_FQDN}/
+            #        kustomization.yaml         # top-level index
+            #        <region_key>/              # one per CSV entry
+            #          bootstrap-kit/
+            #            <every file copied from clusters/_template/bootstrap-kit/>
+            #
+            #    Empty SOVEREIGN_REGION_KEYS_CSV is a noop — keeps the
+            #    upgrade path open for a Sovereign provisioned before
+            #    slice G3-flux landed. SOVEREIGN_FQDN identifies the
+            #    per-Sovereign tree root.
+            if [ -z "${SOVEREIGN_REGION_KEYS_CSV}" ] || [ -z "${SOVEREIGN_FQDN}" ]; then
+              echo "[gitea-mirror] G3-flux: SOVEREIGN_REGION_KEYS_CSV or SOVEREIGN_FQDN empty, skipping per-region subtree materialisation"
+              echo "[gitea-mirror] step complete"
+              exit 0
+            fi
+            echo "[gitea-mirror] G3-flux: materialising per-region subtrees for ${SOVEREIGN_REGION_KEYS_CSV}"
+
+            # Fresh work-tree clone (NOT --bare) so we can edit files.
+            work2=$(mktemp -d)
+            cd "${work2}"
+            if ! git clone "${local_url}" worktree >/dev/null 2>&1; then
+              echo "[gitea-mirror] FATAL: G3-flux failed to clone local Gitea for per-region materialisation" >&2
+              exit 1
+            fi
+            cd worktree
+            git checkout "${UPSTREAM_BRANCH}" >/dev/null 2>&1 || true
+
+            template_dir="clusters/_template/bootstrap-kit"
+            if [ ! -d "${template_dir}" ]; then
+              echo "[gitea-mirror] FATAL: G3-flux: ${template_dir} missing in upstream — cannot materialise per-region subtrees" >&2
+              exit 1
+            fi
+
+            sovereign_dir="clusters/${SOVEREIGN_FQDN}"
+            mkdir -p "${sovereign_dir}"
+
+            # Walk the CSV, copy template into each region's subtree.
+            # IFS=, parses CSV without temp files. The shell-builtin
+            # `set --` is busybox-safe word-splitting.
+            old_ifs="${IFS}"
+            IFS=,
+            set -- ${SOVEREIGN_REGION_KEYS_CSV}
+            IFS="${old_ifs}"
+
+            region_dirs=""
+            for region_key in "$@"; do
+              # Strip whitespace; busybox tr is reliably present in alpine/git.
+              region_key=$(printf '%s' "${region_key}" | tr -d ' ')
+              if [ -z "${region_key}" ]; then
+                continue
+              fi
+              echo "[gitea-mirror] G3-flux:   region=${region_key}"
+              region_dst="${sovereign_dir}/${region_key}/bootstrap-kit"
+              rm -rf "${region_dst}"
+              mkdir -p "$(dirname ${region_dst})"
+              cp -R "${template_dir}" "${region_dst}"
+              region_dirs="${region_dirs} ${region_key}"
+            done
+
+            # Top-level index — Kustomize-format index referencing each
+            # per-region bootstrap-kit subtree. Post-cutover step-05
+            # patches each cluster's Flux Kustomization spec.path to its
+            # OWN region subtree (not this index), but the index is a
+            # convenient single-pane manifest of "what regions does this
+            # Sovereign have?" for ops + auditing.
+            {
+              echo "# Slice G3-flux — per-region bootstrap-kit index for ${SOVEREIGN_FQDN}."
+              echo "# Materialised by self-sovereign-cutover step-01 gitea-mirror."
+              echo "# Each entry is the bootstrap-kit subtree the corresponding"
+              echo "# region's Flux Kustomization targets at spec.path."
+              echo "apiVersion: kustomize.config.k8s.io/v1beta1"
+              echo "kind: Kustomization"
+              echo "resources:"
+              for region_key in ${region_dirs}; do
+                echo "  - ${region_key}/bootstrap-kit"
+              done
+            } > "${sovereign_dir}/kustomization.yaml"
+
+            # Commit + push (idempotent: empty diff = no commit, no push).
+            git add "${sovereign_dir}"
+            if git diff --cached --quiet; then
+              echo "[gitea-mirror] G3-flux: no diff to commit (idempotent re-run)"
+            else
+              git commit -m "chore(cutover): materialise per-region bootstrap-kit subtrees for ${SOVEREIGN_FQDN}" >/dev/null
+              if ! git push "${local_url}" "${UPSTREAM_BRANCH}" >/dev/null 2>&1; then
+                echo "[gitea-mirror] FATAL: G3-flux: failed to push per-region subtree commit" >&2
+                exit 1
+              fi
+              echo "[gitea-mirror] G3-flux: per-region subtrees pushed to local Gitea"
+            fi
+
             echo "[gitea-mirror] step complete"
         resources:
           requests: { cpu: 100m, memory: 256Mi }

--- a/platform/self-sovereign-cutover/chart/templates/05-flux-gitrepository-patch-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/05-flux-gitrepository-patch-job.yaml
@@ -5,6 +5,17 @@ Patches `flux-system/<gitopsRepository.name>` GitRepository.spec.url
 to the local Sovereign Gitea URL. After this patch source-controller
 reconciles against the in-cluster Gitea Service.
 
+Slice G3-flux: ALSO patches the bootstrap-kit Kustomization spec.path
+from the pre-cutover shared template (`./clusters/_template/bootstrap-kit`)
+to the per-region subtree this Sovereign's gitea-mirror materialised
+in step-01 (`./clusters/<SOVEREIGN_FQDN>/<SOVEREIGN_REGION_KEY>/bootstrap-kit`).
+Each region's Flux Kustomization is patched independently — the patch
+matches THIS k3s's Kustomization (Flux is per-cluster), so the primary
+CP's Flux gets primary-region path, every secondary CP gets its own.
+SOVEREIGN_REGION_KEY is sourced from the catalyst-api-rendered
+cloud-init substitute (cloudinit-control-plane.tftpl) and threaded
+through the bp-self-sovereign-cutover overlay values.
+
 Image phase: post.
 */ -}}
 apiVersion: v1
@@ -44,6 +55,16 @@ data:
           # "kustomization path not found".
           - name: SOVEREIGN_FQDN
             value: {{ .Values.sovereign.fqdn | quote }}
+          # Slice G3-flux — per-region Kustomization path pivot. The
+          # SOVEREIGN_REGION_KEY env var carries the local cluster's
+          # region key (e.g. "fsn1" on the primary, "hel1-1" on a
+          # secondary), sourced from this chart's Helm values where
+          # the overlay's $${SOVEREIGN_REGION_KEY} envsubst landed it.
+          # When empty (legacy single-region Sovereign provisioned
+          # before slice G3-flux), the Kustomization-path patch is
+          # skipped — GitRepository URL pivot still runs.
+          - name: SOVEREIGN_REGION_KEY
+            value: {{ .Values.sovereign.regionKey | default "" | quote }}
         command: ["/bin/sh", "-c"]
         args:
           - |
@@ -72,6 +93,31 @@ data:
             kubectl annotate --overwrite gitrepository "${GITREPO_NAME}" \
               -n "${GITREPO_NAMESPACE}" \
               "reconcile.fluxcd.io/requestedAt=$(date +%s)"
+
+            # Slice G3-flux — pivot the bootstrap-kit Flux Kustomization
+            # spec.path from the pre-cutover shared template to the per-
+            # region subtree that step-01 gitea-mirror just materialised.
+            # Each CP's Flux is per-cluster, so we patch THIS cluster's
+            # Kustomization with THIS cluster's region key. SOVEREIGN_REGION_KEY
+            # empty = legacy single-region Sovereign provisioned before
+            # G3-flux landed → skip path pivot to keep upgrade idempotent.
+            if [ -n "${SOVEREIGN_REGION_KEY}" ]; then
+              new_path="./clusters/${SOVEREIGN_FQDN}/${SOVEREIGN_REGION_KEY}/bootstrap-kit"
+              echo "[flux-gitrepository-patch] G3-flux: pivoting bootstrap-kit Kustomization path -> ${new_path}"
+              cat >/tmp/ks-patch.yaml <<EOF
+            spec:
+              path: ${new_path}
+            EOF
+              kubectl patch kustomization "bootstrap-kit" \
+                -n "${GITREPO_NAMESPACE}" \
+                --type=merge --patch-file /tmp/ks-patch.yaml
+              kubectl annotate --overwrite kustomization "bootstrap-kit" \
+                -n "${GITREPO_NAMESPACE}" \
+                "reconcile.fluxcd.io/requestedAt=$(date +%s)"
+            else
+              echo "[flux-gitrepository-patch] G3-flux: SOVEREIGN_REGION_KEY empty, skipping per-region path pivot (legacy single-region path)"
+            fi
+
             echo "[flux-gitrepository-patch] done"
         resources:
           requests: { cpu: 50m, memory: 64Mi }

--- a/platform/self-sovereign-cutover/chart/values.yaml
+++ b/platform/self-sovereign-cutover/chart/values.yaml
@@ -45,6 +45,29 @@ sovereign:
   giteaInternalURL: "http://gitea-http.gitea.svc.cluster.local:3000"
   # ↓ overlay supplies https://gitea.${SOVEREIGN_FQDN} (informational; jobs use internal URL).
   giteaPublicURL: "https://gitea.example.local"
+  # ── Per-region Flux Kustomization paths (slice G3-flux) ──────────────
+  # Comma-separated list of region keys the Sovereign was provisioned
+  # across. Primary region first ("fsn1"), secondary regions appended
+  # in local.secondary_regions iteration order ("hel1-1", "ash-2", …).
+  # Step-01 gitea-mirror materialises ONE bootstrap-kit subtree per
+  # entry at clusters/<sovereign.fqdn>/<region_key>/bootstrap-kit/ so
+  # each region's Flux Kustomization can target its own git path
+  # post-cutover. Default = "fsn1" keeps single-region Sovereigns on
+  # the same per-region layout (no special-casing); the overlay
+  # populates the real list via $${SOVEREIGN_REGION_KEYS_CSV} envsubst.
+  # CSV is the wire format because Flux postBuild.substitute is string-
+  # substitution (a YAML list literal cannot be reliably emitted from a
+  # substitute value); the Job parses CSV with shell IFS=,
+  regionsCSV: "fsn1"
+  # ── Per-cluster region key (slice G3-flux) ───────────────────────────
+  # THIS k3s's own region key — one entry from the regionsCSV list.
+  # Primary CP gets "fsn1" (= var.region in tofu); secondaries get
+  # their local.secondary_regions map key (e.g. "hel1-1"). Step-05
+  # flux-gitrepository-patch reads this to pivot the bootstrap-kit
+  # Kustomization spec.path post-cutover. Empty default lets `helm
+  # template` smoke-render cleanly in CI; runtime overlay supplies
+  # the real value via $${SOVEREIGN_REGION_KEY} envsubst.
+  regionKey: ""
 
 # Upstream openova-io read-only public clone — the source for cutover
 # step 01. Step-1 calls Gitea's /repos/migrate API with mirror=true so

--- a/products/catalyst/bootstrap/api/internal/provisioner/cloudinit_path_test.go
+++ b/products/catalyst/bootstrap/api/internal/provisioner/cloudinit_path_test.go
@@ -162,6 +162,47 @@ func TestCloudInit_PostBuildSubstituteFQDN(t *testing.T) {
 	}
 }
 
+// TestCloudInit_PostBuildSubstituteRegionKey proves every Flux
+// Kustomization renders a SOVEREIGN_REGION_KEY postBuild.substitute.
+// Slice G3-flux uses this token to mark per-region cluster manifests
+// (labels, namespaces, Job names) so a Sovereign provisioned across
+// fsn1 + hel1 has each region's bp-* charts independently identifiable.
+// The pre-G3-flux cloud-init was missing this substitute, so secondary
+// CPs reconciled byte-identical manifests and the UI's per-region
+// fan-out (e.g. /sovereign/provision/<id>/jobs/install-trivy) saw one
+// install bubble instead of N.
+func TestCloudInit_PostBuildSubstituteRegionKey(t *testing.T) {
+	tpl := readCloudInit(t)
+
+	const want = "SOVEREIGN_REGION_KEY: ${sovereign_region_key}"
+	if !strings.Contains(tpl, want) {
+		t.Errorf("Flux Kustomization postBuild.substitute must include %q so each region's manifests can carry distinct labels/names (slice G3-flux)", want)
+	}
+	// Every Kustomization needs the substitute (same partial-fix
+	// regression class as SOVEREIGN_FQDN — three Kustomizations
+	// in the cloud-init: bootstrap-kit, sovereign-tls,
+	// infrastructure-config). Expect ≥3 occurrences.
+	count := strings.Count(tpl, want)
+	if count < 3 {
+		t.Errorf("expected SOVEREIGN_REGION_KEY substitute on every Kustomization (got %d occurrences, want ≥3 — slice G3-flux partial-fix regression)", count)
+	}
+}
+
+// TestCloudInit_PostBuildSubstituteRegionKeysCSV proves the
+// bootstrap-kit Kustomization carries the SOVEREIGN_REGION_KEYS_CSV
+// substitute. The cutover step-01 gitea-mirror Job reads this list
+// at cutover time and materialises one bootstrap-kit subtree per
+// entry under clusters/<sovereign_fqdn>/<region_key>/ — without it
+// only a single region's subtree would land in local Gitea.
+func TestCloudInit_PostBuildSubstituteRegionKeysCSV(t *testing.T) {
+	tpl := readCloudInit(t)
+
+	const want = "SOVEREIGN_REGION_KEYS_CSV: \"${sovereign_region_keys_csv}\""
+	if !strings.Contains(tpl, want) {
+		t.Errorf("Flux Kustomization postBuild.substitute must include %q so cutover step-01 gitea-mirror materialises one bootstrap-kit subtree per region (slice G3-flux)", want)
+	}
+}
+
 // TestCloudInit_NoPerFQDNPathReferences is the catch-all regression
 // guard: NO substring of the form `clusters/${sovereign_fqdn}`
 // appears as an actual Flux resource path/ignore selector anywhere

--- a/products/catalyst/bootstrap/api/internal/provisioner/gitea_mirror_per_region_test.go
+++ b/products/catalyst/bootstrap/api/internal/provisioner/gitea_mirror_per_region_test.go
@@ -1,0 +1,180 @@
+// gitea_mirror_per_region_test.go — slice G3-flux contract guards for
+// the self-sovereign-cutover step-01 gitea-mirror Job script.
+//
+// Slice G3-flux moves Sovereigns from a single shared
+// `clusters/_template/bootstrap-kit` git path that every region's k3s
+// reconciles against → per-region subtrees under
+// `clusters/<sovereign_fqdn>/<region_key>/bootstrap-kit`. The cutover
+// step-01 gitea-mirror Job (platform/self-sovereign-cutover/chart/
+// templates/01-gitea-mirror-job.yaml) is the engine that materialises
+// those subtrees: after `git push --mirror`-ing the upstream openova-io
+// repo into the local Sovereign Gitea, the script walks the CSV-encoded
+// region key list (sovereign.regionsCSV → SOVEREIGN_REGION_KEYS_CSV env
+// var) and copies the _template subtree into each region's directory.
+//
+// These tests pin the shape of that script. A regression that drops
+// the SOVEREIGN_REGION_KEYS_CSV env var, the per-region loop, or the
+// final commit + push lands as a test failure in CI rather than as a
+// silent single-region cutover on a real Sovereign.
+package provisioner
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// readGiteaMirrorTemplate loads the raw chart template file. We read
+// the raw template (not a helm-rendered output) because the Sprig
+// expressions inside `{{ ... }}` are not the part this test cares
+// about — we care about the script body, which is pure shell + envsubst
+// markers and renders byte-identical regardless of values.
+func readGiteaMirrorTemplate(t *testing.T) string {
+	t.Helper()
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	// products/catalyst/bootstrap/api/internal/provisioner → repo root
+	repoRoot := filepath.Clean(filepath.Join(cwd, "..", "..", "..", "..", "..", ".."))
+	p := filepath.Join(repoRoot, "platform", "self-sovereign-cutover", "chart", "templates", "01-gitea-mirror-job.yaml")
+	raw, err := os.ReadFile(p)
+	if err != nil {
+		t.Fatalf("read %s: %v", p, err)
+	}
+	return string(raw)
+}
+
+// TestGiteaMirror_HasPerRegionEnvVars proves the Job ConfigMap declares
+// SOVEREIGN_FQDN + SOVEREIGN_REGION_KEYS_CSV env vars sourced from the
+// chart's sovereign values block. Without these the per-region loop has
+// no input — gitea-mirror would silently skip subtree materialisation
+// and leave every cluster's Flux Kustomization targetting a path that
+// step-05 will later patch into nonexistence.
+func TestGiteaMirror_HasPerRegionEnvVars(t *testing.T) {
+	tpl := readGiteaMirrorTemplate(t)
+
+	for _, want := range []string{
+		"- name: SOVEREIGN_FQDN",
+		`value: {{ .Values.sovereign.fqdn | quote }}`,
+		"- name: SOVEREIGN_REGION_KEYS_CSV",
+		`value: {{ .Values.sovereign.regionsCSV | quote }}`,
+	} {
+		if !strings.Contains(tpl, want) {
+			t.Errorf("gitea-mirror Job must declare %q for slice G3-flux per-region subtree materialisation", want)
+		}
+	}
+}
+
+// TestGiteaMirror_HasPerRegionLoop proves the script body iterates the
+// CSV-encoded region key list and copies the _template bootstrap-kit
+// subtree into each region's directory. The exact shape is locked
+// (IFS=, parse, cp -R from `clusters/_template/bootstrap-kit` into
+// `clusters/${SOVEREIGN_FQDN}/<region_key>/bootstrap-kit`) so a
+// refactor that breaks the regex-style guarantees here gets flagged.
+func TestGiteaMirror_HasPerRegionLoop(t *testing.T) {
+	tpl := readGiteaMirrorTemplate(t)
+
+	for _, want := range []string{
+		// The "skip when CSV empty" guard — keeps the upgrade path
+		// idempotent for legacy single-region Sovereigns.
+		`if [ -z "${SOVEREIGN_REGION_KEYS_CSV}" ] || [ -z "${SOVEREIGN_FQDN}" ]; then`,
+		// The CSV parser — IFS=, is the BusyBox-safe split.
+		"IFS=,",
+		"set -- ${SOVEREIGN_REGION_KEYS_CSV}",
+		// The source-of-truth template directory.
+		`template_dir="clusters/_template/bootstrap-kit"`,
+		// The per-region destination root.
+		`sovereign_dir="clusters/${SOVEREIGN_FQDN}"`,
+		// The copy step.
+		`cp -R "${template_dir}" "${region_dst}"`,
+		// The commit + push gate (idempotent on empty diff).
+		"git diff --cached --quiet",
+		`git push "${local_url}" "${UPSTREAM_BRANCH}"`,
+	} {
+		if !strings.Contains(tpl, want) {
+			t.Errorf("gitea-mirror per-region materialisation regressed — missing %q", want)
+		}
+	}
+}
+
+// TestGiteaMirror_WritesSovereignIndexKustomization proves the script
+// emits a top-level kustomization.yaml index at the Sovereign root
+// listing every region's bootstrap-kit subtree. The index isn't what
+// each cluster's Flux watches at spec.path (that pivots to the per-
+// region subtree post-cutover), but it provides a single-pane manifest
+// of "what regions does this Sovereign have?" for ops + future audits.
+func TestGiteaMirror_WritesSovereignIndexKustomization(t *testing.T) {
+	tpl := readGiteaMirrorTemplate(t)
+
+	for _, want := range []string{
+		`echo "apiVersion: kustomize.config.k8s.io/v1beta1"`,
+		`echo "kind: Kustomization"`,
+		`echo "resources:"`,
+		`echo "  - ${region_key}/bootstrap-kit"`,
+		`} > "${sovereign_dir}/kustomization.yaml"`,
+	} {
+		if !strings.Contains(tpl, want) {
+			t.Errorf("gitea-mirror Sovereign-root kustomization index regressed — missing %q", want)
+		}
+	}
+}
+
+// TestGiteaMirror_ChartValuesCarryRegionsCSV proves the chart's
+// values.yaml exposes the per-region CSV key. Without this the Helm
+// template wouldn't resolve {{ .Values.sovereign.regionsCSV }} and
+// the Job rendering would fail.
+func TestGiteaMirror_ChartValuesCarryRegionsCSV(t *testing.T) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	repoRoot := filepath.Clean(filepath.Join(cwd, "..", "..", "..", "..", "..", ".."))
+	p := filepath.Join(repoRoot, "platform", "self-sovereign-cutover", "chart", "values.yaml")
+	raw, err := os.ReadFile(p)
+	if err != nil {
+		t.Fatalf("read %s: %v", p, err)
+	}
+	body := string(raw)
+
+	for _, want := range []string{
+		"regionsCSV:",
+		"regionKey:",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("cutover chart values.yaml must expose %q for slice G3-flux", want)
+		}
+	}
+}
+
+// TestFluxGitRepositoryPatch_PivotsKustomizationPath proves step-05
+// (flux-gitrepository-patch) reads the per-cluster region key and
+// patches the bootstrap-kit Kustomization spec.path to the per-region
+// subtree post-cutover. Without this pivot, even though gitea-mirror
+// materialised the per-region subtrees in step-01, each cluster's
+// Flux would keep reconciling the shared `_template` path.
+func TestFluxGitRepositoryPatch_PivotsKustomizationPath(t *testing.T) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	repoRoot := filepath.Clean(filepath.Join(cwd, "..", "..", "..", "..", "..", ".."))
+	p := filepath.Join(repoRoot, "platform", "self-sovereign-cutover", "chart", "templates", "05-flux-gitrepository-patch-job.yaml")
+	raw, err := os.ReadFile(p)
+	if err != nil {
+		t.Fatalf("read %s: %v", p, err)
+	}
+	body := string(raw)
+
+	for _, want := range []string{
+		"- name: SOVEREIGN_REGION_KEY",
+		`value: {{ .Values.sovereign.regionKey | default "" | quote }}`,
+		`new_path="./clusters/${SOVEREIGN_FQDN}/${SOVEREIGN_REGION_KEY}/bootstrap-kit"`,
+		`kubectl patch kustomization "bootstrap-kit"`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("step-05 flux-gitrepository-patch must pivot Kustomization spec.path to per-region subtree (slice G3-flux) — missing %q", want)
+		}
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/provisioner/provisioner.go
+++ b/products/catalyst/bootstrap/api/internal/provisioner/provisioner.go
@@ -1273,7 +1273,7 @@ func writeTfvars(deployDir string, req Request) error {
 		// `tofu plan`. Live failure on otech86 (DID 103c52d08510006f,
 		// 2026-05-04 11:12:43Z). The variables.tf default = [] is what
 		// the validator expects; emit that shape explicitly.
-		"regions": coalesceRegions(req.Regions),
+		"regions": coalesceRegions(req),
 
 		// SSH key — module creates an hcloud_ssh_key from this and attaches
 		// to all servers. We never generate keys here; sovereign-admin
@@ -1691,18 +1691,56 @@ func defaultRegistrarKindFromEnv() string {
 	return defaultRegistrarKind
 }
 
-// coalesceRegions normalises a nil RegionSpec slice to an empty slice so
-// JSON marshalling emits `[]` instead of `null`. The OpenTofu module's
-// `variable "regions"` validator runs `for r in var.regions` which fails
-// on null with "Error: Iteration over null value" but accepts an empty
-// list (the variables.tf default). Live failure on otech86 (DID
-// 103c52d08510006f, 2026-05-04 11:12:43Z) when the autopilot zero-touch
-// cycle launched without any per-region overrides.
-func coalesceRegions(rs []RegionSpec) []RegionSpec {
-	if rs == nil {
-		return []RegionSpec{}
+// coalesceRegions returns the request's regions[] slice with a guarantee
+// of at least one entry: when the request supplies a non-empty list it
+// is returned verbatim, otherwise a single entry is synthesised from
+// the legacy singular fields (req.Region / ControlPlaneSize / WorkerSize /
+// WorkerCount). This makes the tofu side a single-shape consumer —
+// `var.regions` is always non-empty, so every for_each + iteration in
+// main.tf can drop conditional fallbacks to the legacy singular fields.
+//
+// Slice G3-flux refactor: previously this function only normalised nil →
+// []. That left tofu with a "len(regions) ∈ {0, ≥1}" branch every time
+// the legacy single-region request shape arrived, which forced
+// duplicate logic in main.tf and the cloud-init templates. The
+// architectural shape the wizard intends is "one entry per topology
+// slot, ALWAYS" — the legacy singular fields exist only for back-compat
+// with older wizard payloads + handler/load_test.go fixtures, and the
+// synthesis happens here at the catalyst-api boundary so tofu only ever
+// sees the canonical multi-region shape.
+//
+// Pre-G3-flux failure mode (now removed): the empty-slice contract used
+// to live in tofu — variables.tf `default = []`, validation `for r in
+// var.regions` — and main.tf had to read singular var.region /
+// var.control_plane_size whenever regions[] was empty. That created two
+// parallel render paths (singular + per-region), each maintained in
+// step with the other. The canonical legacy failure was otech86 (DID
+// 103c52d08510006f, 2026-05-04 11:12:43Z) where Go's nil slice
+// marshalled as JSON null and broke the validator; that fix shipped
+// the nil→[] guard. Slice G3-flux closes the remaining divergence by
+// always producing the multi-region shape.
+//
+// `req` is passed by value because writeTfvars's parameter is already
+// `Request` by value — no aliasing concern.
+func coalesceRegions(req Request) []RegionSpec {
+	if len(req.Regions) > 0 {
+		return req.Regions
 	}
-	return rs
+	// Synthesise a single entry from the singular fields. Validate()
+	// requires req.Region to be non-empty before writeTfvars runs, so
+	// the synthesised entry always has a non-empty cloudRegion. The
+	// ControlPlaneSize / WorkerSize may legitimately be empty — that's
+	// the "default-cost-optimised" path documented in the writeTfvars
+	// comment above (variables.tf carries the SKU defaults). Tofu's
+	// `var.regions` validation accepts empty SKU strings; the per-
+	// region for_each in main.tf reads them via local lookup.
+	return []RegionSpec{{
+		Provider:         "hetzner",
+		CloudRegion:      req.Region,
+		ControlPlaneSize: req.ControlPlaneSize,
+		WorkerSize:       req.WorkerSize,
+		WorkerCount:      req.WorkerCount,
+	}}
 }
 
 // coalesceParentDomains is the parent-domain analogue of coalesceRegions.

--- a/products/catalyst/bootstrap/api/internal/provisioner/provisioner_test.go
+++ b/products/catalyst/bootstrap/api/internal/provisioner/provisioner_test.go
@@ -464,14 +464,23 @@ func TestWriteTfvars_OmitsEmptySingularSizes(t *testing.T) {
 	}
 }
 
-// TestWriteTfvars_EmitsRegionsAsEmptyArrayNotNull proves writeTfvars
-// emits an empty JSON array for `regions` when the request has no
-// per-region overrides — never JSON null. The OpenTofu module's
-// variables.tf has a validation block (`for r in var.regions`) that
-// fails on null with "Error: Iteration over null value" but accepts
-// an empty list. Live failure on otech86 (DID 103c52d08510006f,
-// 2026-05-04 11:12:43Z).
-func TestWriteTfvars_EmitsRegionsAsEmptyArrayNotNull(t *testing.T) {
+// TestWriteTfvars_RegionsAlwaysNonEmpty proves writeTfvars emits a
+// non-empty JSON array for `regions` — never JSON null, never `[]`.
+//
+// Slice G3-flux refactor: the OpenTofu module is now a single-shape
+// consumer ("len(var.regions) ≥ 1, always"). writeTfvars closes the
+// gap at the catalyst-api boundary by synthesising a single entry
+// from the legacy singular fields (Region / ControlPlaneSize /
+// WorkerSize / WorkerCount) whenever the request body doesn't carry
+// per-region overrides. This eliminates the "regions empty?" branch
+// from main.tf, cloud-init, and downstream chart wiring.
+//
+// The pre-G3-flux behaviour (regions: []) traced back to otech86 (DID
+// 103c52d08510006f, 2026-05-04 11:12:43Z) where Go's nil slice
+// marshalled as JSON null and broke OpenTofu's `for r in var.regions`
+// validator. That fix shipped the nil→[] guard. This test now guards
+// the stronger contract: empty becomes a synthesised len=1 slice.
+func TestWriteTfvars_RegionsAlwaysNonEmpty(t *testing.T) {
 	dir, err := os.MkdirTemp("", "writeTfvars-*")
 	if err != nil {
 		t.Fatalf("mkdir: %v", err)
@@ -485,8 +494,10 @@ func TestWriteTfvars_EmitsRegionsAsEmptyArrayNotNull(t *testing.T) {
 		HetznerToken:     "tok",
 		HetznerProjectID: "p1",
 		Region:           "fsn1",
+		ControlPlaneSize: "cpx21",
+		WorkerSize:       "cpx31",
 		WorkerCount:      2,
-		// Regions intentionally nil — the legacy singular path.
+		// Regions intentionally nil — exercises the synth path.
 	}
 	if err := writeTfvars(dir, req); err != nil {
 		t.Fatalf("writeTfvars: %v", err)
@@ -495,9 +506,8 @@ func TestWriteTfvars_EmitsRegionsAsEmptyArrayNotNull(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read: %v", err)
 	}
-	// Must contain `"regions": []` — never `"regions": null`.
 	if strings.Contains(string(raw), `"regions": null`) {
-		t.Fatalf("regions must serialise as [] (not null) so OpenTofu's `for r in var.regions` validator accepts the input. Got:\n%s", string(raw))
+		t.Fatalf("regions must serialise as a non-null JSON array. Got:\n%s", string(raw))
 	}
 	var parsed map[string]any
 	if err := json.Unmarshal(raw, &parsed); err != nil {
@@ -507,8 +517,67 @@ func TestWriteTfvars_EmitsRegionsAsEmptyArrayNotNull(t *testing.T) {
 	if !ok {
 		t.Fatalf("regions must be a JSON array, got %T (%v)", parsed["regions"], parsed["regions"])
 	}
-	if len(regions) != 0 {
-		t.Fatalf("regions must be empty when request has none, got %d entries", len(regions))
+	if len(regions) != 1 {
+		t.Fatalf("legacy single-region body must synthesise exactly one regions[] entry, got %d", len(regions))
+	}
+	entry, ok := regions[0].(map[string]any)
+	if !ok {
+		t.Fatalf("regions[0] must be an object, got %T (%v)", regions[0], regions[0])
+	}
+	if entry["cloudRegion"] != "fsn1" {
+		t.Fatalf("synth regions[0].cloudRegion = %v, want fsn1", entry["cloudRegion"])
+	}
+	if entry["provider"] != "hetzner" {
+		t.Fatalf("synth regions[0].provider = %v, want hetzner (legacy singular path is hetzner-only)", entry["provider"])
+	}
+	if entry["controlPlaneSize"] != "cpx21" {
+		t.Fatalf("synth regions[0].controlPlaneSize = %v, want cpx21 (from req.ControlPlaneSize)", entry["controlPlaneSize"])
+	}
+	if entry["workerSize"] != "cpx31" {
+		t.Fatalf("synth regions[0].workerSize = %v, want cpx31", entry["workerSize"])
+	}
+	wc, _ := entry["workerCount"].(float64)
+	if int(wc) != 2 {
+		t.Fatalf("synth regions[0].workerCount = %v, want 2", entry["workerCount"])
+	}
+}
+
+// TestWriteTfvars_MultiRegionBodyPreserved proves writeTfvars preserves
+// an operator-supplied regions[] slice unchanged — synthesis only
+// triggers on empty input.
+func TestWriteTfvars_MultiRegionBodyPreserved(t *testing.T) {
+	dir, err := os.MkdirTemp("", "writeTfvars-mr-*")
+	if err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	defer os.RemoveAll(dir)
+
+	req := Request{
+		SovereignFQDN:    "otech.omani.works",
+		OrgName:          "Acme",
+		OrgEmail:         "ops@acme.io",
+		HetznerToken:     "tok",
+		HetznerProjectID: "p1",
+		Region:           "fsn1",
+		Regions: []RegionSpec{
+			{Provider: "hetzner", CloudRegion: "fsn1", ControlPlaneSize: "cpx32", WorkerSize: "cpx41", WorkerCount: 2},
+			{Provider: "hetzner", CloudRegion: "hel1", ControlPlaneSize: "cpx32", WorkerSize: "cpx41", WorkerCount: 1},
+		},
+	}
+	if err := writeTfvars(dir, req); err != nil {
+		t.Fatalf("writeTfvars: %v", err)
+	}
+	raw, err := os.ReadFile(dir + "/tofu.auto.tfvars.json")
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	var parsed map[string]any
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	regions, _ := parsed["regions"].([]any)
+	if len(regions) != 2 {
+		t.Fatalf("multi-region body must emit two entries verbatim, got %d", len(regions))
 	}
 }
 


### PR DESCRIPTION
## Summary

Multi-region Sovereigns now reconcile per-region bootstrap-kit subtrees under `clusters/<sovereign_fqdn>/<region_key>/bootstrap-kit/` instead of every CP racing against the same shared `clusters/_template/bootstrap-kit` path against its own etcd.

Founder caught the symptom live on prov #33 (`0a594b66`, multi-region fsn1+hel1): `/sovereign/provision/<id>/jobs/install-trivy` showed ONE install bubble — the UI's per-region fan-out expects N. Root cause: secondary CP's Flux Kustomization rendered the SAME `spec.path` as the primary's, so the only thing differentiating each region's reconciliation was which k3s API server happened to receive the apply. No architectural surface for region-specific overrides (different chart versions per region, per-region SKU shapes, etc.).

This slice (G3-flux) ships the per-region path separation that unlocks G3-mesh, G3-handler, G3-ui.

## Canonical seams cited

| Seam | File:line |
|------|-----------|
| Flux GitRepository + Kustomization cloud-init block | `infra/hetzner/cloudinit-control-plane.tftpl:812` (pre-G3-flux shared-template paths) |
| Per-secondary-region cloud-init render | `infra/hetzner/main.tf:818` (`local.secondary_region_cloud_init` templatefile) |
| step-01 gitea-mirror Job ConfigMap | `platform/self-sovereign-cutover/chart/templates/01-gitea-mirror-job.yaml:1` |
| Per-Sovereign cutover HelmRelease values overlay | `clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml:277` |
| `writeTfvars` regions[] emit | `products/catalyst/bootstrap/api/internal/provisioner/provisioner.go:1276` |

## Two existing patterns this implementation mirrors

1. **`SOVEREIGN_FQDN` postBuild.substitute pattern (issue #218)** — the per-region `SOVEREIGN_REGION_KEY` substitute follows the exact same shape as the existing `SOVEREIGN_FQDN` substitute on all three Kustomizations (bootstrap-kit / sovereign-tls / infrastructure-config). Both flow from tofu var → tftpl interp → Flux envsubst → chart manifests. Test guard `TestCloudInit_PostBuildSubstituteRegionKey` follows the existing `TestCloudInit_PostBuildSubstituteFQDN` partial-fix regression-class pattern.
2. **step-05 flux-gitrepository-patch ignore-widening pattern (issue #891)** — the new Kustomization `spec.path` pivot reuses the existing kubectl-patch-via-`/tmp/patch.yaml` + `reconcile.fluxcd.io/requestedAt` annotation that step-05 already performs to widen the GitRepository ignore filter to `/clusters/<sov-fqdn>/`.

## Changes

### A — `infra/hetzner` cloud-init template
- New `${sovereign_region_key}` + `${sovereign_region_keys_csv}` tftpl vars.
- 3× new `SOVEREIGN_REGION_KEY` Flux `postBuild.substitute` entries (one per Kustomization).
- 1× new `SOVEREIGN_REGION_KEYS_CSV` substitute (bootstrap-kit only — consumed by the cutover HelmRelease values).
- `main.tf` threads `var.region` (primary) / `each.key` (secondary) into `sovereign_region_key`; `join(",", concat([var.region], [for k, _ in local.secondary_regions : k]))` into `sovereign_region_keys_csv`.

### B — `platform/self-sovereign-cutover` chart (0.1.29 → 0.1.30)
- `values.yaml` exposes `sovereign.regionsCSV` (default `"fsn1"`) + `sovereign.regionKey` (default `""`).
- **Step-01 gitea-mirror Job** extended: after `git push --mirror` of upstream, walks `SOVEREIGN_REGION_KEYS_CSV` and `cp -R`s `clusters/_template/bootstrap-kit/` into `clusters/<SOVEREIGN_FQDN>/<region_key>/bootstrap-kit/` per CSV entry. Writes a top-level `kustomization.yaml` index at the Sovereign root. Commits + pushes back to local Gitea (idempotent on empty diff).
- **Step-05 flux-gitrepository-patch Job** extended: alongside the existing GitRepository URL pivot, also patches THIS cluster's `bootstrap-kit` Kustomization `spec.path` to `./clusters/<SOVEREIGN_FQDN>/<SOVEREIGN_REGION_KEY>/bootstrap-kit`. Each region's Flux gets its own region's subtree.
- Overlay (`06a-bp-self-sovereign-cutover.yaml`) wires `${SOVEREIGN_REGION_KEYS_CSV}` + `${SOVEREIGN_REGION_KEY}` into the HelmRelease values; HR chart version pin bumped to 0.1.30.

### C — `provisioner.go writeTfvars`
- `coalesceRegions` promoted from nil→[] guard to a synthesis function returning **always len≥1**. Empty `req.Regions` synthesises a single `RegionSpec{Provider: "hetzner", CloudRegion: req.Region, ControlPlaneSize: req.ControlPlaneSize, ...}` from the legacy singular fields. Tofu's `var.regions` consumer now always sees the canonical multi-region shape — eliminates the "regions empty?" branch from downstream consumers.

## Tests

- **`cloudinit_path_test.go`** — 2 new tests guard `SOVEREIGN_REGION_KEY` (≥3 occurrences, one per Kustomization) + `SOVEREIGN_REGION_KEYS_CSV` (bootstrap-kit substitute).
- **`provisioner_test.go`** — replaces `TestWriteTfvars_EmitsRegionsAsEmptyArrayNotNull` with `TestWriteTfvars_RegionsAlwaysNonEmpty` (asserts synthesised single-entry from legacy fields) + new `TestWriteTfvars_MultiRegionBodyPreserved` (operator-supplied regions[] verbatim).
- **`gitea_mirror_per_region_test.go`** (new) — pins the per-region loop env vars + script tokens + index kustomization emit + step-05 path-pivot logic.
- **`tofu validate` + `tofu test multi_region.tftest.hcl`** — 6/6 G1 multi-region scenarios still pass (2 pre-existing `qa_mode_on_respects_explicit_overrides` failures unrelated to this slice — same on `main`).
- **`bash platform/self-sovereign-cutover/chart/tests/cutover-contract.sh`** — all 18 gates green.

## Manual-test runbook for prov #34 (after merge + catalyst-api roll)

- [ ] `curl https://console.openova.io/sovereign/api/v1/deployments/<id> | jq .regions` → `len(regions) = N` (e.g. 2 for fsn1+hel1).
- [ ] On primary CP: `kubectl logs job/cutover-step-01-gitea-mirror -n catalyst` → grep `"G3-flux: materialising per-region subtrees"` + `"per-region subtrees pushed to local Gitea"`.
- [ ] On primary CP: `kubectl -n gitea exec -it gitea-0 -- git -C /tmp clone http://127.0.0.1:3000/openova/openova /tmp/openova && find /tmp/openova/clusters/<fqdn>/ -maxdepth 3 -type d` → expect `clusters/<fqdn>/fsn1/bootstrap-kit` + `clusters/<fqdn>/hel1-1/bootstrap-kit` (or whatever the secondary key is) + `clusters/<fqdn>/kustomization.yaml`.
- [ ] `kubectl --context=<primary> get kustomization bootstrap-kit -n flux-system -o jsonpath='{.spec.path}'` → `./clusters/<fqdn>/fsn1/bootstrap-kit`.
- [ ] `kubectl --context=<secondary-hel> get kustomization bootstrap-kit -n flux-system -o jsonpath='{.spec.path}'` → `./clusters/<fqdn>/hel1-1/bootstrap-kit`.
- [ ] `kubectl --context=<secondary-hel> get hr -A | wc -l` → matches primary's HR count (~43 bp-* installs per region).
- [ ] `/sovereign/provision/<id>/jobs/install-trivy` UI page → N bubbles (one per region) instead of one.

## Constraint compliance

- No `npm`/`next build`/`vite`/Playwright commands used.
- No `helm` CLI direct invocation outside `helm template` smoke verification (no `helm install` etc.).
- No hardcoded region/SKU/cluster/git-path/k3s-flag.
- All public-repo (`openova-io/openova`). Nothing in `openova-private`.
- New chart manifests do not introduce direct external registry references (`docker.io/...` etc.) — existing harbor.openova.io/proxy-* refs untouched.
- Conventional commit + Claude co-author footer on the single commit.
- `git worktree add` isolated worktree per parent-agent isolation arg.

🤖 Generated with [Claude Code](https://claude.com/claude-code)