### PR TITLE
feat(openova-flow): extract flow-core + flow-canvas packages (drop parentId, adopt PMI temporal types)

### DIFF
--- a/products/catalyst/bootstrap/ui/src/lib/flow-bridge.test.ts
+++ b/products/catalyst/bootstrap/ui/src/lib/flow-bridge.test.ts
@@ -1,0 +1,156 @@
+/**
+ * flow-bridge — translates legacy `Job[]` → new FlowNode + Relationship[].
+ */
+
+import { describe, it, expect } from 'vitest'
+import { adaptJobsToFlow, buildFlowFromJobs } from './flow-bridge'
+import type { Job } from './jobs.types'
+
+function leaf(id: string, parentId = '', dependsOn: string[] = []): Job {
+  return {
+    id,
+    jobName: id,
+    type: 'install',
+    appId: 'bp-' + id,
+    parentId,
+    dependsOn,
+    childIds: [],
+    status: 'pending',
+    startedAt: null,
+    finishedAt: null,
+    durationMs: 0,
+  }
+}
+
+function group(id: string, childIds: string[]): Job {
+  return {
+    id,
+    jobName: id,
+    displayName: id,
+    type: 'group',
+    appId: '',
+    parentId: '',
+    dependsOn: [],
+    childIds,
+    status: 'pending',
+    startedAt: null,
+    finishedAt: null,
+    durationMs: 0,
+  }
+}
+
+describe('flow-bridge — adaptJobsToFlow', () => {
+  it('emits one FlowNode per Job with flowId propagated', () => {
+    const jobs: Job[] = [leaf('a'), leaf('b'), group('grp', ['a', 'b'])]
+    const { nodes } = adaptJobsToFlow(jobs, 'dep-1')
+    expect(nodes.length).toBe(3)
+    for (const n of nodes) {
+      expect(n.flowId).toBe('dep-1')
+    }
+  })
+
+  it('emits a `contains` Relationship for each non-empty parentId', () => {
+    const jobs: Job[] = [
+      group('grp', ['a', 'b']),
+      leaf('a', 'grp'),
+      leaf('b', 'grp'),
+    ]
+    const { relationships } = adaptJobsToFlow(jobs, 'dep-1')
+    const containsRels = relationships.filter((r) => r.type === 'contains')
+    expect(containsRels.length).toBe(2)
+    expect(containsRels.find((r) => r.fromId === 'a' && r.toId === 'grp')).toBeTruthy()
+    expect(containsRels.find((r) => r.fromId === 'b' && r.toId === 'grp')).toBeTruthy()
+  })
+
+  it('emits a `finish-to-start` Relationship per dependsOn entry', () => {
+    const jobs: Job[] = [leaf('a'), leaf('b', '', ['a'])]
+    const { relationships } = adaptJobsToFlow(jobs, 'dep-1')
+    const blocking = relationships.filter((r) => r.type === 'finish-to-start')
+    expect(blocking.length).toBe(1)
+    expect(blocking[0].fromId).toBe('a')
+    expect(blocking[0].toId).toBe('b')
+    expect(blocking[0].condition).toBe('on-success')
+  })
+
+  it('drops dependsOn entries pointing at unknown ids (safer than dangling)', () => {
+    const jobs: Job[] = [leaf('b', '', ['nonexistent', 'self-ref'])]
+    const { relationships } = adaptJobsToFlow(jobs, 'dep-1')
+    expect(relationships.length).toBe(0)
+  })
+
+  it('preserves appId / jobName / durationMs in meta', () => {
+    const j: Job = {
+      ...leaf('x'),
+      appId: 'bp-cilium',
+      jobName: 'install-cilium',
+      durationMs: 1500,
+    }
+    const { nodes } = adaptJobsToFlow([j], 'dep-1')
+    expect(nodes[0].meta?.appId).toBe('bp-cilium')
+    expect(nodes[0].meta?.jobName).toBe('install-cilium')
+    expect(nodes[0].meta?.durationMs).toBe(1500)
+  })
+
+  it('label falls back to jobName stripped of leading `install-`', () => {
+    const j: Job = { ...leaf('x'), jobName: 'install-cilium' }
+    const { nodes } = adaptJobsToFlow([j], 'dep-1')
+    expect(nodes[0].label).toBe('cilium')
+  })
+
+  it('label uses displayName when present', () => {
+    const j: Job = { ...leaf('x'), displayName: 'Apply Cilium' }
+    const { nodes } = adaptJobsToFlow([j], 'dep-1')
+    expect(nodes[0].label).toBe('Apply Cilium')
+  })
+
+  it('parses ISO timestamps to unix ms', () => {
+    const j: Job = {
+      ...leaf('x'),
+      startedAt: '2026-05-01T00:00:00.000Z',
+      finishedAt: '2026-05-01T00:00:01.000Z',
+    }
+    const { nodes } = adaptJobsToFlow([j], 'dep-1')
+    expect(nodes[0].startedAt).toBe(Date.parse('2026-05-01T00:00:00.000Z'))
+    expect(nodes[0].endedAt).toBe(Date.parse('2026-05-01T00:00:01.000Z'))
+  })
+})
+
+describe('flow-bridge — buildFlowFromJobs', () => {
+  it('rolls up flow.status from leaf statuses (failed wins if all terminal)', () => {
+    const jobs: Job[] = [
+      { ...leaf('a'), status: 'succeeded' },
+      { ...leaf('b'), status: 'failed' },
+    ]
+    const out = buildFlowFromJobs({ jobs, flowId: 'dep-1' })
+    expect(out.flow.status).toBe('failed')
+  })
+
+  it('rolls up flow.status to running while any job is still pending', () => {
+    const jobs: Job[] = [
+      { ...leaf('a'), status: 'succeeded' },
+      { ...leaf('b'), status: 'pending' },
+    ]
+    const out = buildFlowFromJobs({ jobs, flowId: 'dep-1' })
+    expect(out.flow.status).toBe('running')
+  })
+
+  it('preserves an explicit flowStatus override', () => {
+    const jobs: Job[] = [{ ...leaf('a'), status: 'succeeded' }]
+    const out = buildFlowFromJobs({ jobs, flowId: 'dep-1', flowStatus: 'archived' })
+    expect(out.flow.status).toBe('archived')
+  })
+
+  it('region/multi-region sanity: bridge forwards `meta` opaquely so prov-#34 can paint regions even pre-server', () => {
+    // The bridge does NOT compute region — the host still owns that
+    // via perNodeHints. But the bridge preserves `meta.region` if a
+    // future Job shape carries it, so the new layout has somewhere to
+    // pick it up without the catalyst-api needing to bump first.
+    const jobs: Job[] = [leaf('a')]
+    const out = buildFlowFromJobs({ jobs, flowId: 'dep-1' })
+    expect(out.nodes[0].meta).toBeDefined()
+    // The legacy Job shape doesn't have `region`; the bridge doesn't
+    // INVENT one. Region remains a host concern routed via
+    // perNodeHints — which is exactly the Agent #1 contract.
+    expect(out.nodes[0].region).toBeUndefined()
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/lib/flow-bridge.ts
+++ b/products/catalyst/bootstrap/ui/src/lib/flow-bridge.ts
@@ -1,0 +1,184 @@
+/**
+ * flow-bridge — single-responsibility shim translating the legacy
+ * Catalyst Job tree into the OpenovaFlow contract
+ * (`FlowInstance` + `FlowNode[]` + `Relationship[]`).
+ *
+ * # Why this file is the ONLY place that knows about Job
+ *
+ * The OpenovaFlow Foundation refactor (2026-05-11) split visualisation
+ * out of Catalyst into the standalone @openova/flow-core + @openova/
+ * flow-canvas packages. Those packages know nothing about
+ * `parentId`/`dependsOn`/`appId` — they speak FlowNode + Relationship.
+ *
+ * Agent #2 will ship a proper FlowAdapter against catalyst-api that
+ * emits FlowMessage events directly; Agent #3 will replace this bridge
+ * with that adapter. Until then, the bridge keeps catalyst-ui working
+ * against the existing `/api/v1/deployments/{id}/jobs` endpoint.
+ *
+ * # Mapping
+ *
+ *   Job.parentId             → Relationship { fromId:job, toId:parent, type:'contains' }
+ *   Job.dependsOn[i]         → Relationship { fromId:deps[i], toId:job, type:'finish-to-start', condition:'on-success' }
+ *   Job.appId                → FlowNode.meta.appId (preserved opaque)
+ *   Job.id                   → FlowNode.id
+ *   Job.status               → FlowNode.status
+ *   Job.startedAt / Job.finishedAt (ISO) → unix ms timestamps
+ *   Job.type ('install' | 'group')        → encoded via `meta.kind`; group-ness is now
+ *                                          inferred from contains-edges anyway, so the
+ *                                          bridge only needs to preserve the kind for
+ *                                          downstream consumers that still distinguish.
+ *
+ * # Region/family hints
+ *
+ * The legacy code computed region+family hints at the layout-input
+ * boundary (`useJobHints`). The bridge does NOT compute them — it
+ * forwards the upstream hint computation to the new layout's
+ * `perNodeHints` slot. Catalyst-ui still owns the `applicationCatalog`
+ * + `BLUEPRINT_DEPS` resolution; the bridge is only the shape adapter.
+ */
+
+import type {
+  FlowInstance,
+  FlowNode,
+  Relationship,
+} from '@openova/flow-core'
+import type { Job, JobStatus } from './jobs.types'
+
+/**
+ * Translate a `Job[]` into FlowNode[] + Relationship[] for the given
+ * flowId. The caller supplies the FlowInstance separately (it carries
+ * deployment status + startedAt; those don't come from individual
+ * jobs).
+ *
+ * Determinism: nodes and relationships are emitted in the same order
+ * as the input `jobs` array (and inside each job, parent-rel comes
+ * before depends-on rels). Stable across reloads.
+ */
+export function adaptJobsToFlow(
+  jobs: readonly Job[],
+  flowId: string,
+): { nodes: FlowNode[]; relationships: Relationship[] } {
+  const nodes: FlowNode[] = []
+  const relationships: Relationship[] = []
+  const knownIds = new Set<string>()
+  for (const j of jobs) knownIds.add(j.id)
+
+  for (const j of jobs) {
+    nodes.push({
+      id: j.id,
+      flowId,
+      label: labelFor(j),
+      status: j.status,
+      startedAt: parseIsoToMs(j.startedAt),
+      endedAt: parseIsoToMs(j.finishedAt),
+      meta: {
+        kind: j.type, // 'install' | 'group'
+        appId: j.appId,
+        jobName: j.jobName,
+        displayName: j.displayName ?? '',
+        durationMs: j.durationMs,
+        // legacy parentId / dependsOn copied through opaque for
+        // anyone who still wants to read them via meta.
+        parentId: j.parentId,
+        dependsOn: [...j.dependsOn],
+      },
+    })
+
+    // contains edge — job is contained by its parent.
+    if (j.parentId && knownIds.has(j.parentId)) {
+      relationships.push({
+        fromId: j.id,
+        toId: j.parentId,
+        type: 'contains',
+      })
+    }
+
+    // finish-to-start / on-success for each dependsOn entry.
+    for (const depId of j.dependsOn) {
+      if (depId === j.id) continue
+      if (!knownIds.has(depId)) continue
+      relationships.push({
+        fromId: depId,
+        toId: j.id,
+        type: 'finish-to-start',
+        condition: 'on-success',
+      })
+    }
+  }
+
+  return { nodes, relationships }
+}
+
+/**
+ * Convenience: build the full triple (FlowInstance + nodes + rels)
+ * suitable for passing straight into FlowCanvas / layout().
+ *
+ *   • `flowId` — typically the deploymentId.
+ *   • `definitionId` — optional template id (the upstream
+ *                       "applicationCatalogVersion" or similar). The
+ *                       UI uses this for "DAG vs DAG-run" disambiguation
+ *                       when the catalyst-api begins emitting it.
+ */
+export function buildFlowFromJobs(args: {
+  jobs: readonly Job[]
+  flowId: string
+  definitionId?: string
+  flowStatus?: string
+  startedAt?: number
+  endedAt?: number
+}): { flow: FlowInstance; nodes: FlowNode[]; relationships: Relationship[] } {
+  const { jobs, flowId, definitionId, flowStatus, startedAt, endedAt } = args
+  const { nodes, relationships } = adaptJobsToFlow(jobs, flowId)
+  const rolledStatus = flowStatus ?? rollupStatus(jobs)
+  const inferredStartedAt = startedAt ?? earliestStarted(jobs) ?? 0
+  return {
+    flow: {
+      id: flowId,
+      definitionId,
+      status: rolledStatus,
+      startedAt: inferredStartedAt,
+      endedAt,
+    },
+    nodes,
+    relationships,
+  }
+}
+
+/* ────────────────────────────────────────────────────────────────────
+ * Helpers
+ * ──────────────────────────────────────────────────────────────────── */
+
+function labelFor(j: Job): string {
+  if (j.displayName && j.displayName.length > 0) return j.displayName
+  return j.jobName.replace(/^install-/, '')
+}
+
+function parseIsoToMs(iso: string | null | undefined): number | undefined {
+  if (!iso) return undefined
+  const t = Date.parse(iso)
+  return Number.isFinite(t) ? t : undefined
+}
+
+function rollupStatus(jobs: readonly Job[]): JobStatus {
+  if (jobs.length === 0) return 'pending'
+  const leafJobs = jobs.filter((j) => j.type !== 'group')
+  if (leafJobs.length === 0) return 'pending'
+  const buckets = new Set<JobStatus>(leafJobs.map((j) => j.status))
+  if (buckets.has('failed')) {
+    const allTerminal = leafJobs.every((j) => j.status === 'succeeded' || j.status === 'failed')
+    return allTerminal ? 'failed' : 'running'
+  }
+  if (buckets.has('running') || buckets.has('pending')) return 'running'
+  return 'succeeded'
+}
+
+function earliestStarted(jobs: readonly Job[]): number | null {
+  let earliest: number | null = null
+  for (const j of jobs) {
+    if (!j.startedAt) continue
+    const t = Date.parse(j.startedAt)
+    if (!Number.isFinite(t)) continue
+    if (earliest === null || t < earliest) earliest = t
+  }
+  return earliest
+}

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/FlowPage.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/FlowPage.test.tsx
@@ -121,10 +121,14 @@ describe('FlowPage — render', () => {
     expect(await screen.findByTestId('flow-canvas-svg')).toBeTruthy()
   })
 
-  it('renders at least one job bubble (default catalog)', async () => {
+  it('renders at least one node bubble (default catalog)', async () => {
     renderFlow('/provision/d-1/flow')
     await screen.findByTestId('flow-canvas-svg')
-    const bubbles = document.querySelectorAll('[data-testid^="flow-job-"]')
+    // OpenovaFlow Foundation: bubbles are now `data-testid="flow-node-*"`
+    // (was `flow-job-*` under the legacy FlowCanvasOrganic). The legacy
+    // testid is retained by the deprecated FlowCanvasOrganic so its own
+    // tests still pass; FlowPage now drives @openova/flow-canvas.
+    const bubbles = document.querySelectorAll('[data-testid^="flow-node-"]')
     expect(bubbles.length).toBeGreaterThan(0)
   })
 

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/FlowPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/FlowPage.tsx
@@ -37,7 +37,6 @@ import {
   useMemo,
   useRef,
   useState,
-  type MouseEvent as ReactMouseEvent,
 } from 'react'
 import { Link, useNavigate, useParams, useSearch } from '@tanstack/react-router'
 import { useWizardStore } from '@/entities/deployment/store'
@@ -48,23 +47,72 @@ import { useDeploymentEvents } from './useDeploymentEvents'
 import { deriveJobs } from './jobs'
 import { adaptDerivedJobsToFlat } from './jobsAdapter'
 import { useLiveJobsBackfill, mergeJobs } from './useLiveJobsBackfill'
-import {
-  flowLayoutOrganic,
-  defaultFoldedAtDepth,
-  FALLBACK_REGION_ID,
-  type OrganicFamily,
-  type OrganicRegion,
-  type OrganicNodeHints,
-} from '@/lib/flowLayoutOrganic'
+// OpenovaFlow Foundation — the page used to consume the legacy
+// flowLayoutOrganic + FlowCanvasOrganic pair directly. It now drives
+// the standalone @openova/flow-canvas via the flow-bridge adapter.
+// The legacy modules remain in `lib/` for non-canvas consumers (JobsTable
+// rollups, JobDetail breadcrumbs) while Agent #2/#3 retire them in
+// follow-ups.
+import { buildFlowFromJobs } from '@/lib/flow-bridge'
+import { defaultFoldedAtDepth } from '@openova/flow-core'
+import { FlowCanvas } from '@openova/flow-canvas'
+import type {
+  FamilyDescriptor,
+  RegionDescriptor,
+  StatusTone,
+  FlowLayoutHint,
+} from '@openova/flow-core'
 import { DEFAULT_FAMILIES } from '@/lib/flowFamilyPalette'
 import type { Job } from '@/lib/jobs.types'
+import { FALLBACK_REGION_ID as LEGACY_FALLBACK_REGION_ID } from '@/lib/flowLayoutOrganic'
 import {
   StatusStrip,
   type ProvisioningStatus,
 } from '@/components/StatusStrip'
-import { FlowCanvasOrganic } from './FlowCanvasOrganic'
 import { FoldControls, hasGroupJobs, resolveDepth, type FoldDepth } from './FoldControls'
 import { PRODUCTS } from '@/pages/wizard/steps/componentGroups'
+
+/** Status palette adapter — mirrors the legacy `--bubble-*` CSS-var
+ *  tokens onto the new `StatusTone` shape so the OpenOva theme flips
+ *  (dark/light) continue to drive the canvas. */
+const CATALYST_STATUS_PALETTE: Record<string, StatusTone> = {
+  pending: {
+    fill: 'var(--bubble-fill-pending)',
+    ring: 'var(--bubble-ring-pending)',
+    glyph: 'var(--bubble-glyph-pending)',
+    glow: 'var(--bubble-glow-pending)',
+    edge: 'var(--bubble-edge-pending)',
+    arrow: '#94A3B8',
+    label: 'Pending',
+  },
+  running: {
+    fill: 'var(--bubble-fill-running)',
+    ring: 'var(--bubble-ring-running)',
+    glyph: 'var(--bubble-glyph-running)',
+    glow: 'var(--bubble-glow-running)',
+    edge: 'var(--bubble-edge-running)',
+    arrow: '#38BDF8',
+    label: 'Running',
+  },
+  succeeded: {
+    fill: 'var(--bubble-fill-succeeded)',
+    ring: 'var(--bubble-ring-succeeded)',
+    glyph: 'var(--bubble-glyph-succeeded)',
+    glow: 'var(--bubble-glow-succeeded)',
+    edge: 'var(--bubble-edge-succeeded)',
+    arrow: '#16A34A',
+    label: 'Succeeded',
+  },
+  failed: {
+    fill: 'var(--bubble-fill-failed)',
+    ring: 'var(--bubble-ring-failed)',
+    glyph: 'var(--bubble-glyph-failed)',
+    glow: 'var(--bubble-glow-failed)',
+    edge: 'var(--bubble-edge-failed)',
+    arrow: '#B91C1C',
+    label: 'Failed',
+  },
+}
 
 /* ──────────────────────────────────────────────────────────────────
  * URL helpers
@@ -85,7 +133,7 @@ export function resolveFolded(raw: unknown): Set<string> {
  * Family palette + per-job hints
  * ────────────────────────────────────────────────────────────────── */
 
-function useFamilyPalette(): OrganicFamily[] {
+function useFamilyPalette(): FamilyDescriptor[] {
   return useMemo(() => {
     const fromCatalog = PRODUCTS.map((p) => {
       const fallback = DEFAULT_FAMILIES.find((f) => f.id === p.id)
@@ -93,7 +141,7 @@ function useFamilyPalette(): OrganicFamily[] {
         id: p.id,
         label: p.name,
         color: fallback?.color ?? '#94A3B8',
-      } satisfies OrganicFamily
+      } satisfies FamilyDescriptor
     })
     const seen = new Set(fromCatalog.map((f) => f.id))
     for (const f of DEFAULT_FAMILIES) {
@@ -117,18 +165,18 @@ const BOOTSTRAP_KIT_DEPS: Record<string, string[]> = BLUEPRINT_DEPS
 function useJobHints(args: {
   jobs: readonly Job[]
   applications: readonly ApplicationDescriptor[]
-  regions: readonly OrganicRegion[]
-}): Map<string, OrganicNodeHints> {
+  regions: readonly RegionDescriptor[]
+}): Map<string, FlowLayoutHint> {
   const { jobs, applications, regions } = args
   return useMemo(() => {
-    const out = new Map<string, OrganicNodeHints>()
+    const out = new Map<string, FlowLayoutHint>()
     const appById = new Map<string, ApplicationDescriptor>()
     const appByBareId = new Map<string, ApplicationDescriptor>()
     for (const a of applications) {
       appById.set(a.id, a)
       appByBareId.set(a.bareId, a)
     }
-    const fallbackRegion = regions[0]?.id ?? FALLBACK_REGION_ID
+    const fallbackRegion = regions[0]?.id ?? LEGACY_FALLBACK_REGION_ID
 
     const liveIdByBare = new Map<string, string>()
     for (const j of jobs) {
@@ -212,7 +260,7 @@ function useJobHints(args: {
         }
       }
 
-      out.set(j.id, { regionId, familyId, extraDepIds })
+      out.set(j.id, { region: regionId, family: familyId, extraDepIds })
     }
     return out
   }, [jobs, applications, regions])
@@ -299,7 +347,7 @@ export function FlowPage({
 
   /* ── Region descriptors (multi-region support) ───────────────── */
 
-  const regions = useMemo<OrganicRegion[]>(() => {
+  const regions = useMemo<RegionDescriptor[]>(() => {
     if (store.regions && store.regions.length > 0) {
       return store.regions.map((r) => ({
         id: r.id,
@@ -309,7 +357,7 @@ export function FlowPage({
     }
     return [
       {
-        id: FALLBACK_REGION_ID,
+        id: LEGACY_FALLBACK_REGION_ID,
         label: sovereignFQDN ? `${sovereignFQDN}` : 'Primary Region',
         meta: 'Single-region cluster',
       },
@@ -327,14 +375,27 @@ export function FlowPage({
   const depth: FoldDepth = initialDepth ?? urlDepth
   const urlFoldedSet = useMemo(() => resolveFolded(search?.folded), [search?.folded])
 
+  // Build the new contract triple once per allJobs change — used both
+  // by the FoldControls (for hasGroupJobs / fold-toggle navigation) and
+  // by the canvas (via FlowCanvas + FlowLayoutHint).
+  const flowTriple = useMemo(
+    () =>
+      buildFlowFromJobs({
+        jobs: allJobs,
+        flowId: deploymentId,
+        definitionId: undefined,
+      }),
+    [allJobs, deploymentId],
+  )
+
   const foldedSet = useMemo(() => {
-    const baseline = depth === 'all' ? new Set<string>() : defaultFoldedAtDepth(allJobs, depth)
-    // Manual per-node overrides: an id present in `?folded=` forces folded
-    // (additive) — the UI's Expand-all sets `?folded=` to empty, so this
-    // composition reads cleanly.
+    const baseline =
+      depth === 'all'
+        ? new Set<string>()
+        : defaultFoldedAtDepth(flowTriple.nodes, flowTriple.relationships, depth)
     for (const id of urlFoldedSet) baseline.add(id)
     return baseline
-  }, [allJobs, depth, urlFoldedSet])
+  }, [flowTriple.nodes, flowTriple.relationships, depth, urlFoldedSet])
 
   const setSearchPatch = useCallback(
     (patch: { folded?: string | undefined; depth?: string | undefined }) => {
@@ -391,12 +452,9 @@ export function FlowPage({
     [allJobs, foldedSet, urlFoldedSet, setSearchPatch],
   )
 
-  /* ── Layout ───────────────────────────────────────────────────── */
-
-  const layout = useMemo(
-    () => flowLayoutOrganic(allJobs, { hints, regions, families, folded: foldedSet }),
-    [allJobs, hints, regions, families, foldedSet],
-  )
+  /* ── Layout is computed inside FlowCanvas from the contract +
+   *      hints; no upfront `flowLayoutOrganic()` call here. The canvas
+   *      receives nodes/relationships/folded directly. ──────────── */
 
   /* ── Click semantics (single vs double, debounced 220ms) ────── */
 
@@ -421,55 +479,37 @@ export function FlowPage({
     [onOpenJobChange],
   )
 
-  const clickTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-  const cancelPendingClick = useCallback(() => {
-    if (clickTimerRef.current) {
-      clearTimeout(clickTimerRef.current)
-      clickTimerRef.current = null
-    }
-  }, [])
-  useEffect(() => () => cancelPendingClick(), [cancelPendingClick])
-
-  const handleJobClick = useCallback(
-    (jobId: string, _event: ReactMouseEvent<SVGGElement>) => {
-      cancelPendingClick()
-      clickTimerRef.current = setTimeout(() => {
-        setOpenJobId(jobId)
-        clickTimerRef.current = null
-      }, 220)
+  // FlowCanvas handles the single-vs-double debounce internally; the
+  // page only supplies the callbacks. We funnel onNodeOpen → setOpenJobId
+  // and onNodeNavigate → router navigation to keep the host's URL contract.
+  const handleNodeOpen = useCallback(
+    (nodeId: string) => {
+      setOpenJobId(nodeId)
     },
-    [cancelPendingClick],
+    [setOpenJobId],
   )
 
-  const handleJobDoubleClick = useCallback(
-    (jobId: string) => {
-      cancelPendingClick()
-      const job = allJobs.find((j) => j.id === jobId)
-      // Group: toggle fold in place (rest of the canvas keeps its
-      // current fold state — operator spec).
-      if (job?.type === 'group') {
-        toggleFold(jobId)
-        return
-      }
-      // Leaf: navigate to its own home. Chroot-aware target: when the
-      // operator is on the mother's monitoring surface (deploymentId
-      // present in URL params), stay scoped under
-      // /provision/<id>/jobs/<jobId>; on the Sovereign's adult
-      // hostname the deploymentId is implicit so the clean root form
-      // /jobs/<jobId> is correct.
+  const handleNodeNavigate = useCallback(
+    (nodeId: string) => {
       const target =
         deploymentId && DETECTED_MODE.mode !== 'sovereign'
-          ? `/provision/${deploymentId}/jobs/${jobId}`
-          : `/jobs/${jobId}`
+          ? `/provision/${deploymentId}/jobs/${nodeId}`
+          : `/jobs/${nodeId}`
       navigate({ to: target as never })
     },
-    [navigate, deploymentId, cancelPendingClick, allJobs, toggleFold],
+    [navigate, deploymentId],
+  )
+
+  const handleFoldToggle = useCallback(
+    (nodeId: string) => {
+      toggleFold(nodeId)
+    },
+    [toggleFold],
   )
 
   const handleCanvasBackgroundClick = useCallback(() => {
-    cancelPendingClick()
     setOpenJobId(hostJobId)
-  }, [cancelPendingClick, hostJobId])
+  }, [setOpenJobId, hostJobId])
 
   /* ── StatusStrip rollup ──────────────────────────────────────── */
 
@@ -537,14 +577,21 @@ export function FlowPage({
   /* ── Render ──────────────────────────────────────────────────── */
 
   const canvas = (
-    <FlowCanvasOrganic
-      layout={layout}
-      embedded={embedded}
-      hostJobId={hostJobId}
-      openJobId={openJobId}
-      onJobClick={handleJobClick}
-      onJobDoubleClick={handleJobDoubleClick}
-      onCanvasBackgroundClick={handleCanvasBackgroundClick}
+    <FlowCanvas
+      flow={flowTriple.flow}
+      nodes={flowTriple.nodes}
+      relationships={flowTriple.relationships}
+      folded={foldedSet}
+      hostNodeId={hostJobId}
+      selectedNodeId={openJobId}
+      palette={CATALYST_STATUS_PALETTE}
+      families={families}
+      regions={regions}
+      perNodeHints={hints}
+      onNodeOpen={handleNodeOpen}
+      onNodeNavigate={handleNodeNavigate}
+      onFoldToggle={handleFoldToggle}
+      onBackgroundClick={handleCanvasBackgroundClick}
     />
   )
 

--- a/products/catalyst/bootstrap/ui/tsconfig.app.json
+++ b/products/catalyst/bootstrap/ui/tsconfig.app.json
@@ -25,7 +25,9 @@
     "noUncheckedSideEffectImports": true,
     "baseUrl": ".",
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": ["./src/*"],
+      "@openova/flow-core": ["../../../openova-flow/core/src/index.ts"],
+      "@openova/flow-canvas": ["../../../openova-flow/canvas/src/index.ts"]
     }
   },
   "include": ["src"]

--- a/products/catalyst/bootstrap/ui/vite.config.ts
+++ b/products/catalyst/bootstrap/ui/vite.config.ts
@@ -73,9 +73,12 @@ export default defineConfig({
       // pre-build step. CI replaces these with proper package resolution
       // once a top-level workspace is wired (Agent #2 step).
       //
-      // ORDER MATTERS: @rollup/plugin-alias matches in definition order;
-      // longer/more-specific keys MUST come before shorter ones. '@' is a
-      // prefix that would otherwise shadow '@openova/...'.
+      // NB on alias matching: Vite (and @rollup/plugin-alias) match an
+      // alias key against an importee with EXACT equality OR prefix
+      // followed by `/`. The bare `@` alias below therefore only matches
+      // `@/...` paths — it does NOT shadow `@openova/...`. Order between
+      // these three is irrelevant for correctness; keeping the longer
+      // keys first is purely a readability convention.
       '@openova/flow-core': resolve(__dirname, '../../../openova-flow/core/src/index.ts'),
       '@openova/flow-canvas': resolve(__dirname, '../../../openova-flow/canvas/src/index.ts'),
       '@': resolve(__dirname, './src'),
@@ -83,13 +86,17 @@ export default defineConfig({
       // this package and have no node_modules tree of their own (the
       // workspace wiring lands in Agent #2). Until then, force their peer
       // deps (react, react-dom, d3-*) to resolve to THIS package's own
-      // installs — otherwise Vite/Rolldown walks up from the canvas
-      // source path and finds nothing, breaking the production build with
-      // "Rolldown failed to resolve import 'react' from .../FlowLogFeed.tsx".
+      // installs — otherwise Vite walks up from the canvas source path
+      // and finds nothing, breaking `vite dev` (`/wizard` returns an
+      // un-hydrated shell because the import graph reachable from
+      // main.tsx → router → JobDetail → FlowPage → @openova/flow-canvas
+      // throws "Failed to resolve import 'd3-drag'", which Vite surfaces
+      // as a top-level module load failure on the browser side). The
+      // same fix unblocks `vite build` (Rolldown emits the same error)
+      // and vitest (which shares this resolver).
       // Each entry maps the bare-spec import to the absolute path of the
-      // dep in this package's node_modules. Using resolve.dedupe is
-      // insufficient here because Node's resolution fails before dedupe
-      // ever runs.
+      // dep in this package's node_modules. `resolve.dedupe` alone is
+      // insufficient because Node's resolution fails before dedupe runs.
       react: resolve(__dirname, './node_modules/react'),
       'react-dom': resolve(__dirname, './node_modules/react-dom'),
       'd3-force': resolve(__dirname, './node_modules/d3-force'),

--- a/products/catalyst/bootstrap/ui/vite.config.ts
+++ b/products/catalyst/bootstrap/ui/vite.config.ts
@@ -69,6 +69,12 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': resolve(__dirname, './src'),
+      // OpenovaFlow Foundation — alias the workspace packages to their
+      // source so `npm run dev` / vitest can pick them up without a
+      // pre-build step. CI replaces these with proper package resolution
+      // once a top-level workspace is wired (Agent #2 step).
+      '@openova/flow-core': resolve(__dirname, '../../../openova-flow/core/src/index.ts'),
+      '@openova/flow-canvas': resolve(__dirname, '../../../openova-flow/canvas/src/index.ts'),
     },
   },
   server: {

--- a/products/catalyst/bootstrap/ui/vite.config.ts
+++ b/products/catalyst/bootstrap/ui/vite.config.ts
@@ -68,14 +68,35 @@ export default defineConfig({
   plugins: [tailwindcss(), react(), rebuildCatalogOnYamlChange()],
   resolve: {
     alias: {
-      '@': resolve(__dirname, './src'),
       // OpenovaFlow Foundation — alias the workspace packages to their
       // source so `npm run dev` / vitest can pick them up without a
       // pre-build step. CI replaces these with proper package resolution
       // once a top-level workspace is wired (Agent #2 step).
+      //
+      // ORDER MATTERS: @rollup/plugin-alias matches in definition order;
+      // longer/more-specific keys MUST come before shorter ones. '@' is a
+      // prefix that would otherwise shadow '@openova/...'.
       '@openova/flow-core': resolve(__dirname, '../../../openova-flow/core/src/index.ts'),
       '@openova/flow-canvas': resolve(__dirname, '../../../openova-flow/canvas/src/index.ts'),
+      '@': resolve(__dirname, './src'),
+      // The aliased @openova/flow-{core,canvas} source files live OUTSIDE
+      // this package and have no node_modules tree of their own (the
+      // workspace wiring lands in Agent #2). Until then, force their peer
+      // deps (react, react-dom, d3-*) to resolve to THIS package's own
+      // installs — otherwise Vite/Rolldown walks up from the canvas
+      // source path and finds nothing, breaking the production build with
+      // "Rolldown failed to resolve import 'react' from .../FlowLogFeed.tsx".
+      // Each entry maps the bare-spec import to the absolute path of the
+      // dep in this package's node_modules. Using resolve.dedupe is
+      // insufficient here because Node's resolution fails before dedupe
+      // ever runs.
+      react: resolve(__dirname, './node_modules/react'),
+      'react-dom': resolve(__dirname, './node_modules/react-dom'),
+      'd3-force': resolve(__dirname, './node_modules/d3-force'),
+      'd3-drag': resolve(__dirname, './node_modules/d3-drag'),
+      'd3-selection': resolve(__dirname, './node_modules/d3-selection'),
     },
+    dedupe: ['react', 'react-dom'],
   },
   server: {
     port: 5173,

--- a/products/openova-flow/CONTRACT.md
+++ b/products/openova-flow/CONTRACT.md
@@ -1,0 +1,140 @@
+# OpenovaFlow wire contract — `FlowMessage` JSON schema
+
+Schema version: **1** (Foundation release, 2026-05-11)
+
+## Discriminator
+
+Every `FlowMessage` has a `type` field that discriminates the variant:
+
+```
+"snapshot" | "upsert-flow" | "upsert-nodes" | "upsert-rels" | "delete-nodes" | "delete-rels"
+```
+
+Agent #2 (server) implements message emission; Agent #3 (catalyst-api
+adapter) wires it to a concrete backend. The shape below is normative.
+
+## Object schemas
+
+### `FlowInstance`
+
+```json
+{
+  "id": "string (unique, required)",
+  "definitionId": "string (optional, template id)",
+  "parentFlowId": "string (optional)",
+  "triggeredBy": [
+    { "flowId": "string", "when": "success | failure | always" }
+  ],
+  "status": "string (open vocabulary)",
+  "startedAt": "number (unix ms)",
+  "endedAt": "number (unix ms, optional)",
+  "meta": { "...adapter-defined": "..." }
+}
+```
+
+### `FlowNode`
+
+```json
+{
+  "id": "string (unique within flowId, required)",
+  "flowId": "string (required)",
+  "label": "string (required)",
+  "status": "string (open vocabulary, required)",
+  "family": "string (optional)",
+  "region": "string (optional)",
+  "startedAt": "number (unix ms, optional)",
+  "endedAt": "number (unix ms, optional)",
+  "meta": { "...adapter-defined": "..." }
+}
+```
+
+### `Relationship`
+
+```json
+{
+  "fromId": "string (required)",
+  "toId": "string (required)",
+  "fromFlowId": "string (optional, omit if same-flow)",
+  "toFlowId": "string (optional, omit if same-flow)",
+  "type": "contains | finish-to-start | start-to-start | finish-to-finish | start-to-finish | triggers",
+  "condition": "on-success | on-failure | always",
+  "lag": "number (seconds, optional)"
+}
+```
+
+## Message variants
+
+### `snapshot`
+Full state for a single flow.
+```json
+{
+  "type": "snapshot",
+  "flow": { "...FlowInstance": "..." },
+  "nodes": [{ "...FlowNode": "..." }],
+  "relationships": [{ "...Relationship": "..." }]
+}
+```
+
+### `upsert-flow`
+Flow-level metadata changed (status, endedAt, meta).
+```json
+{ "type": "upsert-flow", "flow": { "...FlowInstance": "..." } }
+```
+
+### `upsert-nodes`
+One or more nodes added/updated. Consumer merges by `(flowId, id)`.
+```json
+{ "type": "upsert-nodes", "nodes": [{ "...FlowNode": "..." }] }
+```
+
+### `upsert-rels`
+One or more relationships added/updated. Consumer merges by
+`(fromId, toId, type)` — the natural key.
+```json
+{ "type": "upsert-rels", "relationships": [{ "...Relationship": "..." }] }
+```
+
+### `delete-nodes`
+Remove nodes by id. Relationships pointing to/from the removed nodes
+are pruned by the consumer.
+```json
+{ "type": "delete-nodes", "ids": ["string"] }
+```
+
+### `delete-rels`
+Remove specific edges by their natural key.
+```json
+{
+  "type": "delete-rels",
+  "pairs": [{ "fromId": "string", "toId": "string", "type": "RelationshipType" }]
+}
+```
+
+## RelationshipType vocabulary
+
+| Type | Semantics |
+|---|---|
+| `contains` | Structural / hierarchical. `toId` (parent) contains `fromId` (child). Replaces the legacy `parentId` field on nodes. Not rendered as an edge — drives grouping only. |
+| `finish-to-start` | PMI FS. `toId` starts after `fromId` finishes. The default temporal dependency. |
+| `start-to-start` | PMI SS. `toId` starts when (or after) `fromId` starts. |
+| `finish-to-finish` | PMI FF. `toId` finishes when (or after) `fromId` finishes. |
+| `start-to-finish` | PMI SF. `toId` finishes after `fromId` starts. Rare; usually inventory / scheduling-driven. |
+| `triggers` | Event-driven. `fromId` emits an event that triggers `toId`. No temporal constraint beyond the event itself. |
+
+## Conventions per adapter
+
+| Adapter | Typical relationship emissions |
+|---|---|
+| Catalyst (Flux + helmwatch + jobs) | `contains` for batches → installs; `finish-to-start` / `on-success` for `dependsOn`. No SS/FF/SF/triggers yet. |
+| Temporal | `triggers` for signal-driven children; `contains` for parent-child workflow nesting. Failure paths emit `on-failure` finish-to-start. |
+| Argo Workflows | `finish-to-start` for `dependencies`; `triggers` for sensor-triggered children. |
+| Flux Reconcilers | `triggers` (event-driven by GitOps push); `finish-to-start` for `dependsOn`. |
+| Custom user code | Whatever fits the domain; the canvas renders all 6 types. |
+
+## Versioning
+
+The schema version is pinned at `1` on `FlowAdapter.schemaVersion`.
+Future incompatible changes (renaming a discriminator, changing a
+required field) bump to `2` — adapters and hosts negotiate at
+subscribe time. Backwards-compatible additions (new optional fields,
+new relationship types in a future PMI extension) do NOT bump.

--- a/products/openova-flow/canvas/README.md
+++ b/products/openova-flow/canvas/README.md
@@ -1,0 +1,79 @@
+# `@openova/flow-canvas`
+
+React SVG canvas for OpenovaFlow. Props-driven, **zero OpenOva imports**.
+
+## Props
+
+```tsx
+<FlowCanvas
+  flow={flowInstance}
+  nodes={flowNodes}
+  relationships={relationships}
+  folded={foldedSet}
+  selectedNodeId={null}
+  hostNodeId={null}
+  palette={statusPalette}         // adapter-supplied
+  families={familyDescriptors}
+  regions={regionDescriptors}
+  perNodeHints={hintMap}
+  onNodeOpen={(id) => /* open log pane */}
+  onNodeNavigate={(id) => /* deep link */}
+  onFoldToggle={(groupId) => /* toggle */}
+  onBackgroundClick={() => /* dismiss selection */}
+  renderDetail={(id) => <YourLogPane id={id} />}
+/>
+```
+
+## Theming via CSS variables
+
+Import the default theme once at app root:
+
+```css
+@import '@openova/flow-canvas/theme.css';
+```
+
+All canvas styling is driven by `--flow-*` CSS variables scoped under
+`.flow-canvas-host`. Override individual tokens in your own stylesheet
+to reskin without forking. The theme ships dark + light (light is opted
+in via `[data-theme="light"]`).
+
+## Edge visual style table (founder-locked)
+
+| Relationship type | Stroke | Annotation | Counted for depth? |
+|---|---|---|---|
+| `finish-to-start` | solid | normal arrow | yes |
+| `start-to-start` | solid | "SS" tag near origin | yes |
+| `finish-to-finish` | solid | "FF" tag near terminus | yes |
+| `start-to-finish` | dashed | "SF" tag at midpoint | yes |
+| `triggers` | solid | ⚡ at midpoint | yes |
+| `contains` | NOT rendered as an edge — used for grouping only | n/a | n/a |
+| any with `condition === 'on-failure'` | red dashed, low-opacity until pred is failed | normal arrow | **NO** |
+
+## Embedding example
+
+```tsx
+import { FlowCanvas } from '@openova/flow-canvas'
+import '@openova/flow-canvas/theme.css'
+
+function MyPage() {
+  return (
+    <div style={{ height: '80vh' }}>
+      <FlowCanvas
+        flow={{ id: 'my-flow', status: 'running', startedAt: Date.now() }}
+        nodes={[/* FlowNode[] */]}
+        relationships={[/* Relationship[] */]}
+        folded={new Set()}
+      />
+    </div>
+  )
+}
+```
+
+## Testing
+
+```sh
+npm test               # vitest --pool=threads --maxWorkers=2 --no-isolate
+npm run typecheck      # tsc --noEmit -p tsconfig.json
+```
+
+NEVER `npm run build` / `playwright install` / `playwright test`.

--- a/products/openova-flow/canvas/package.json
+++ b/products/openova-flow/canvas/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "@openova/flow-canvas",
+  "private": true,
+  "version": "0.1.0",
+  "description": "React SVG canvas for OpenovaFlow — props-driven, zero OpenOva imports",
+  "type": "module",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "import": "./src/index.ts"
+    },
+    "./theme.css": "./src/_theme.css"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit -p tsconfig.json",
+    "test": "vitest run --pool=threads --maxWorkers=2 --no-isolate"
+  },
+  "peerDependencies": {
+    "@openova/flow-core": "*",
+    "d3-drag": "^3.0.0",
+    "d3-force": "^3.0.0",
+    "d3-selection": "^3.0.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  },
+  "devDependencies": {
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@types/d3-drag": "^3.0.7",
+    "@types/d3-force": "^3.0.10",
+    "@types/d3-selection": "^3.0.11",
+    "@types/react": "^19.2.14",
+    "@types/react-dom": "^19.2.3",
+    "jsdom": "^29.1.0",
+    "typescript": "~5.9.3",
+    "vitest": "^4.1.5"
+  }
+}

--- a/products/openova-flow/canvas/src/FlowCanvas.tsx
+++ b/products/openova-flow/canvas/src/FlowCanvas.tsx
@@ -1,0 +1,1036 @@
+/**
+ * @openova/flow-canvas — props-driven SVG canvas.
+ *
+ * Receives:
+ *   • A FlowInstance + FlowNode[] + Relationship[] triple from the
+ *     host (typically piped through `layout()` in @openova/flow-core).
+ *   • A status palette, family + region descriptors, and event
+ *     handlers from the host (typically supplied by the adapter).
+ *
+ * Renders:
+ *   • One SVG <g> per visible node, positioned by a d3-force
+ *     simulation anchored on per-depth columns + per-bucket Y rank.
+ *   • One SVG edge per Relationship (excluding `contains`), styled
+ *     by relType per the founder-locked table:
+ *
+ *       FS       — solid stroke, normal arrow, counted for depth
+ *       SS       — solid stroke + "↓" tag at origin
+ *       FF       — solid stroke + "↓" tag at terminus
+ *       SF       — dashed stroke
+ *       triggers — solid stroke + lightning glyph at midpoint
+ *       on-failure — red dashed, low opacity until source 'failed'
+ *
+ *   • Three highlight rings:
+ *       1. amber (`--flow-selection-ring`) — current selected node
+ *       2. teal  (`--flow-host-ring`)      — page's host node
+ *       3. status tone                     — default
+ *
+ * ZERO OpenOva imports: no `@/entities`, no Catalyst Job type, no
+ * router. Everything is supplied by the caller via props.
+ */
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import type { CSSProperties, MouseEvent as ReactMouseEvent, ReactNode } from 'react'
+import {
+  forceSimulation,
+  forceCollide,
+  forceX,
+  forceY,
+  forceLink,
+  type Simulation,
+  type SimulationNodeDatum,
+  type SimulationLinkDatum,
+} from 'd3-force'
+import { drag as d3drag } from 'd3-drag'
+import { select } from 'd3-selection'
+import {
+  layout as computeLayout,
+  type FlowInstance,
+  type FlowNode,
+  type Relationship,
+  type RelationshipType,
+  type StatusTone,
+  type FamilyDescriptor,
+  type RegionDescriptor,
+  type LayoutHints,
+  type LayoutOutput,
+  type PositionedNode,
+  type PositionedEdge,
+} from '@openova/flow-core'
+
+/* ─── Layout constants ────────────────────────────────────────────── */
+
+const MIN_NODE_RADIUS = 16
+const MAX_NODE_RADIUS = 40
+const GROUP_RADIUS_DELTA = 8
+const COLLIDE_PADDING = 12
+const MIN_HOST_W = 1200
+const MIN_HOST_H = 700
+const MIN_PER_DEPTH_X = 110
+const MAX_PER_DEPTH_X = 200
+const FORCE_X_STRENGTH = 0.18
+const FORCE_Y_STRENGTH = 0.22
+const FORCE_LINK_STRENGTH = 0.18
+const MAX_TICKS = 120
+
+/* ─── Sim node type ───────────────────────────────────────────────── */
+
+type SimNode = SimulationNodeDatum & {
+  id: string
+  depth: number
+  depRank: number
+  region: string
+  family: string
+  status: string
+  isGroup: boolean
+}
+
+/* ─── Default status palette (used when adapter doesn't supply one) ── */
+
+const DEFAULT_PALETTE: Record<string, StatusTone> = {
+  pending: {
+    fill: 'var(--flow-bubble-fill-pending)',
+    ring: 'var(--flow-bubble-ring-pending)',
+    glyph: 'var(--flow-bubble-glyph-pending)',
+    glow: 'var(--flow-bubble-glow-pending)',
+    edge: 'var(--flow-bubble-edge-pending)',
+    arrow: '#94A3B8',
+    label: 'Pending',
+  },
+  running: {
+    fill: 'var(--flow-bubble-fill-running)',
+    ring: 'var(--flow-bubble-ring-running)',
+    glyph: 'var(--flow-bubble-glyph-running)',
+    glow: 'var(--flow-bubble-glow-running)',
+    edge: 'var(--flow-bubble-edge-running)',
+    arrow: '#38BDF8',
+    label: 'Running',
+  },
+  succeeded: {
+    fill: 'var(--flow-bubble-fill-succeeded)',
+    ring: 'var(--flow-bubble-ring-succeeded)',
+    glyph: 'var(--flow-bubble-glyph-succeeded)',
+    glow: 'var(--flow-bubble-glow-succeeded)',
+    edge: 'var(--flow-bubble-edge-succeeded)',
+    arrow: '#16A34A',
+    label: 'Succeeded',
+  },
+  failed: {
+    fill: 'var(--flow-bubble-fill-failed)',
+    ring: 'var(--flow-bubble-ring-failed)',
+    glyph: 'var(--flow-bubble-glyph-failed)',
+    glow: 'var(--flow-bubble-glow-failed)',
+    edge: 'var(--flow-bubble-edge-failed)',
+    arrow: '#B91C1C',
+    label: 'Failed',
+  },
+}
+
+function toneFor(palette: Record<string, StatusTone>, status: string): StatusTone {
+  return palette[status] ?? DEFAULT_PALETTE[status] ?? DEFAULT_PALETTE.pending
+}
+
+/* ─── Props ───────────────────────────────────────────────────────── */
+
+export interface FlowCanvasProps {
+  flow: FlowInstance
+  nodes: FlowNode[]
+  relationships: Relationship[]
+  folded: Set<string>
+  selectedNodeId?: string | null
+  hostNodeId?: string | null
+  palette?: Record<string, StatusTone>
+  families?: FamilyDescriptor[]
+  regions?: RegionDescriptor[]
+  /** Per-node hints (region / family / extraDepIds). */
+  perNodeHints?: ReadonlyMap<string, { region?: string; family?: string; extraDepIds?: string[] }>
+  onNodeOpen?: (nodeId: string) => void
+  onNodeNavigate?: (nodeId: string) => void
+  onFoldToggle?: (groupId: string) => void
+  onBackgroundClick?: () => void
+  renderDetail?: (nodeId: string) => ReactNode
+  /** Test seam: pre-computed layout (skips the internal `computeLayout`
+   *  call). Used in tests + adapters that already have a layout. */
+  precomputedLayout?: LayoutOutput
+}
+
+/* ─── Component ───────────────────────────────────────────────────── */
+
+export function FlowCanvas(props: FlowCanvasProps) {
+  const {
+    flow,
+    nodes,
+    relationships,
+    folded,
+    selectedNodeId = null,
+    hostNodeId = null,
+    palette = DEFAULT_PALETTE,
+    families,
+    regions,
+    perNodeHints,
+    onNodeOpen,
+    onNodeNavigate,
+    onFoldToggle,
+    onBackgroundClick,
+    precomputedLayout,
+  } = props
+
+  const hostRef = useRef<HTMLDivElement | null>(null)
+  const svgRef = useRef<SVGSVGElement | null>(null)
+  const simRef = useRef<Simulation<SimNode, SimulationLinkDatum<SimNode>> | null>(null)
+  const nodesRef = useRef<Map<string, SimNode>>(new Map())
+  const tickCountRef = useRef<number>(0)
+  const [, setTick] = useState(0)
+  const [hostSize, setHostSize] = useState<{ w: number; h: number }>({
+    w: MIN_HOST_W,
+    h: MIN_HOST_H,
+  })
+
+  /* ── Compute (or accept) the layout ───────────────────────────── */
+
+  const layoutOut: LayoutOutput = useMemo(() => {
+    if (precomputedLayout) return precomputedLayout
+    const hints: LayoutHints = {
+      perNode: perNodeHints,
+      families,
+      regions,
+    }
+    return computeLayout({
+      flow,
+      nodes,
+      relationships,
+      folded,
+      hints,
+    })
+  }, [precomputedLayout, flow, nodes, relationships, folded, perNodeHints, families, regions])
+
+  /* ── ResizeObserver — debounced + epsilon-gated ───────────────── */
+
+  useEffect(() => {
+    const el = hostRef.current
+    if (!el) return
+    let timer: ReturnType<typeof setTimeout> | null = null
+    let pending: { w: number; h: number } | null = null
+    const RESIZE_DEBOUNCE_MS = 60
+    const RESIZE_EPSILON_PX = 4
+    const ro = new ResizeObserver((entries) => {
+      const e = entries[0]
+      if (!e) return
+      const rect = e.contentRect
+      const w = Math.round(rect.width) || MIN_HOST_W
+      const h = Math.round(rect.height) || MIN_HOST_H
+      pending = { w, h }
+      if (timer) clearTimeout(timer)
+      timer = setTimeout(() => {
+        if (!pending) return
+        const next = pending
+        pending = null
+        setHostSize((prev) => {
+          if (
+            Math.abs(prev.w - next.w) < RESIZE_EPSILON_PX &&
+            Math.abs(prev.h - next.h) < RESIZE_EPSILON_PX
+          ) {
+            return prev
+          }
+          return next
+        })
+      }, RESIZE_DEBOUNCE_MS)
+    })
+    ro.observe(el)
+    return () => {
+      if (timer) clearTimeout(timer)
+      ro.disconnect()
+    }
+  }, [])
+
+  /* ── Layout metrics (R, per-depth slots) ─────────────────────── */
+
+  const layoutMetrics = useMemo(() => {
+    const buckets = new Map<number, number>()
+    let maxBucket = 0
+    let maxDepth = 0
+    for (const n of layoutOut.positionedNodes) {
+      const c = (buckets.get(n.depth) ?? 0) + 1
+      buckets.set(n.depth, c)
+      if (c > maxBucket) maxBucket = c
+      if (n.depth > maxDepth) maxDepth = n.depth
+    }
+    const depthCount = maxDepth + 1
+    const targetRowsFor = (count: number) =>
+      Math.max(1, Math.round(Math.sqrt(Math.max(1, count) / 1.6)))
+    let r = MAX_NODE_RADIUS
+    if (maxBucket > 1) {
+      const usableH = Math.max(60, hostSize.h - 2 * (MAX_NODE_RADIUS + COLLIDE_PADDING))
+      const denseRows = targetRowsFor(maxBucket)
+      const pitchAvail = usableH / denseRows
+      const rFit = (pitchAvail - COLLIDE_PADDING) / 2
+      r = Math.min(MAX_NODE_RADIUS, Math.max(MIN_NODE_RADIUS, Math.floor(rFit)))
+    }
+    r = Math.max(MIN_NODE_RADIUS, Math.min(MAX_NODE_RADIUS, Math.round(r / 4) * 4))
+    const ROW_PITCH = r * 2 + COLLIDE_PADDING
+    const Y_RANGE = Math.max(r * 2, hostSize.h - 2 * (r + COLLIDE_PADDING))
+    const hardRowCap = Math.max(1, Math.floor(Y_RANGE / ROW_PITCH))
+    const slotInfo = new Map<number, { cols: number; rows: number; width: number }>()
+    for (const [d, count] of buckets) {
+      const baseRows = targetRowsFor(count)
+      const rows = Math.min(Math.max(1, baseRows), hardRowCap, count)
+      const cols = Math.max(1, Math.ceil(count / rows))
+      const naturalW = cols > 1
+        ? (cols - 1) * (r * 2 + COLLIDE_PADDING) + r * 2
+        : r * 2
+      const width = Math.round(Math.max(naturalW, r * 2) / 8) * 8
+      slotInfo.set(d, { cols, rows, width })
+    }
+    const gap = Math.max(MIN_PER_DEPTH_X, Math.min(MAX_PER_DEPTH_X, r * 4))
+    const xByDepth = new Map<number, number>()
+    let cursor = r + COLLIDE_PADDING
+    for (let d = 0; d <= maxDepth; d++) {
+      const w = slotInfo.get(d)?.width ?? r * 2
+      xByDepth.set(d, cursor + w / 2)
+      cursor += w + gap
+    }
+    const totalWidth = cursor - gap + r + COLLIDE_PADDING
+    const linkDistance = gap * 0.625
+    const gr = r + GROUP_RADIUS_DELTA
+    return { r, gr, gap, slotInfo, xByDepth, totalWidth, linkDistance, depthCount }
+  }, [layoutOut.positionedNodes, hostSize.w, hostSize.h])
+
+  const R = layoutMetrics.r
+  const GR = layoutMetrics.gr
+  const PER_DEPTH_X = layoutMetrics.gap
+  const LINK_DISTANCE = layoutMetrics.linkDistance
+
+  const depthToX = useCallback(
+    (depth: number) =>
+      layoutMetrics.xByDepth.get(depth) ?? R + COLLIDE_PADDING + depth * (R * 4),
+    [layoutMetrics, R],
+  )
+
+  /* ── Per-bucket Y rank ─────────────────────────────────────── */
+
+  const Y_CENTER = hostSize.h / 2
+  const PITCH = R * 2 + COLLIDE_PADDING
+  const ZIGZAG_AMPLITUDE = Math.min(R * 3, hostSize.h * 0.12)
+
+  const bucketRank = useMemo(() => {
+    const rank = new Map<string, { idx: number; size: number }>()
+    const seen = new Map<number, PositionedNode[]>()
+    for (const n of layoutOut.positionedNodes) {
+      let arr = seen.get(n.depth)
+      if (!arr) {
+        arr = []
+        seen.set(n.depth, arr)
+      }
+      arr.push(n)
+    }
+    for (const arr of seen.values()) {
+      arr.sort((a, b) => a.depRank - b.depRank)
+      arr.forEach((n, i) => rank.set(n.id, { idx: i, size: arr.length }))
+    }
+    return rank
+  }, [layoutOut.positionedNodes])
+
+  const depthByNodeId = useMemo(() => {
+    const m = new Map<string, number>()
+    for (const n of layoutOut.positionedNodes) m.set(n.id, n.depth)
+    return m
+  }, [layoutOut.positionedNodes])
+
+  const yForBucket = useCallback(
+    (id: string) => {
+      const b = bucketRank.get(id)
+      if (!b) return Y_CENTER
+      if (b.size === 1) {
+        const d = depthByNodeId.get(id) ?? 0
+        const sign = d % 2 === 0 ? -1 : 1
+        return Y_CENTER + sign * ZIGZAG_AMPLITUDE
+      }
+      return Y_CENTER + (b.idx - (b.size - 1) / 2) * PITCH
+    },
+    [bucketRank, Y_CENTER, PITCH, ZIGZAG_AMPLITUDE, depthByNodeId],
+  )
+
+  const familyById = useMemo(() => {
+    const m = new Map<string, FamilyDescriptor>()
+    for (const f of layoutOut.families) m.set(f.id, f)
+    return m
+  }, [layoutOut.families])
+
+  /* ── SimNodes ───────────────────────────────────────────────── */
+
+  const simNodes = useMemo<SimNode[]>(() => {
+    const next: SimNode[] = []
+    const seen = new Set<string>()
+    for (const n of layoutOut.positionedNodes) {
+      seen.add(n.id)
+      const existing = nodesRef.current.get(n.id)
+      if (existing) {
+        existing.depth = n.depth
+        existing.depRank = n.depRank
+        existing.region = n.region
+        existing.family = n.family
+        existing.status = n.status
+        existing.isGroup = n.isGroup
+        next.push(existing)
+      } else {
+        const seed = hashSeed(n.id)
+        const initX = depthToX(n.depth) + (seed.fx - 0.5) * R * 1.5
+        const initY = yForBucket(n.id) + (seed.fy - 0.5) * R * 0.6
+        const fresh: SimNode = {
+          id: n.id,
+          depth: n.depth,
+          depRank: n.depRank,
+          region: n.region,
+          family: n.family,
+          status: n.status,
+          isGroup: n.isGroup,
+          x: initX,
+          y: initY,
+        }
+        nodesRef.current.set(n.id, fresh)
+        next.push(fresh)
+      }
+    }
+    for (const id of Array.from(nodesRef.current.keys())) {
+      if (!seen.has(id)) nodesRef.current.delete(id)
+    }
+    return next
+  }, [layoutOut.positionedNodes, depthToX, yForBucket, R])
+
+  /* ── d3-force simulation ─────────────────────────────────────── */
+
+  useEffect(() => {
+    if (simNodes.length === 0) {
+      simRef.current?.stop()
+      simRef.current = null
+      return
+    }
+    const links: SimulationLinkDatum<SimNode>[] = []
+    for (const e of layoutOut.edges) {
+      const s = nodesRef.current.get(e.fromId)
+      const t = nodesRef.current.get(e.toId)
+      if (s && t) links.push({ source: s, target: t })
+    }
+    tickCountRef.current = 0
+    for (const n of simNodes) {
+      if (typeof n.fx === 'number' && typeof n.fy === 'number') continue
+      const seed = hashSeed(n.id)
+      n.x = depthToX(n.depth) + (seed.fx - 0.5) * R * 1.5
+      n.y = yForBucket(n.id) + (seed.fy - 0.5) * R * 0.6
+      n.vx = 0
+      n.vy = 0
+    }
+    const sim = forceSimulation<SimNode>(simNodes)
+      .alpha(0.9)
+      .alphaDecay(0.06)
+      .alphaMin(0.01)
+      .velocityDecay(0.3)
+      .force(
+        'collide',
+        forceCollide<SimNode>()
+          .radius((d) => (d.isGroup ? GR : R) + COLLIDE_PADDING)
+          .strength(0.95)
+          .iterations(2),
+      )
+      .force('x', forceX<SimNode>().x((d) => depthToX(d.depth)).strength(FORCE_X_STRENGTH))
+      .force('y', forceY<SimNode>().y((d) => yForBucket(d.id)).strength(FORCE_Y_STRENGTH))
+      .force(
+        'link',
+        forceLink<SimNode, SimulationLinkDatum<SimNode>>(links)
+          .id((d) => d.id)
+          .distance(LINK_DISTANCE)
+          .strength(FORCE_LINK_STRENGTH),
+      )
+      .on('tick', () => {
+        for (const n of simNodes) {
+          if (typeof n.fx === 'number' && typeof n.fy === 'number') continue
+          const baseX = depthToX(n.depth)
+          const xMin = Math.max(R, baseX - PER_DEPTH_X)
+          const xMax = Math.min(layoutMetrics.totalWidth - R, baseX + PER_DEPTH_X)
+          if (typeof n.x === 'number') {
+            if (n.x < xMin) n.x = xMin
+            else if (n.x > xMax) n.x = xMax
+          }
+          const targetY = yForBucket(n.id)
+          const Y_HALF_BAND = R * 2 + COLLIDE_PADDING
+          const yMin = Math.max(R, targetY - Y_HALF_BAND)
+          const yMax = Math.min(hostSize.h - R, targetY + Y_HALF_BAND)
+          if (typeof n.y === 'number') {
+            if (n.y < yMin) n.y = yMin
+            else if (n.y > yMax) n.y = yMax
+          }
+        }
+        tickCountRef.current++
+        if (tickCountRef.current >= MAX_TICKS) {
+          sim.stop()
+        }
+        setTick((t) => t + 1)
+      })
+    simRef.current = sim
+    return () => {
+      sim.stop()
+    }
+  }, [simNodes, layoutOut.edges, depthToX, yForBucket, hostSize.h, R, GR, PER_DEPTH_X, LINK_DISTANCE, layoutMetrics.totalWidth])
+
+  /* ── Drag wiring ────────────────────────────────────────────── */
+
+  const nodeIdsKey = simNodes.map((n) => n.id).join(',')
+  useEffect(() => {
+    if (!svgRef.current) return
+    const sim = simRef.current
+    if (!sim) return
+    const dragBehavior = d3drag<SVGGElement, unknown>()
+      .on('start', function (event) {
+        tickCountRef.current = 0
+        if (!event.active) sim.alphaTarget(0.3).restart()
+        const id = (this as SVGGElement).getAttribute('data-node-id')
+        const d = id ? nodesRef.current.get(id) : null
+        if (d) {
+          d.fx = d.x ?? 0
+          d.fy = d.y ?? 0
+        }
+      })
+      .on('drag', function (event) {
+        const id = (this as SVGGElement).getAttribute('data-node-id')
+        const d = id ? nodesRef.current.get(id) : null
+        if (d) {
+          d.fx = event.x
+          d.fy = event.y
+        }
+      })
+      .on('end', function (event) {
+        if (!event.active) sim.alphaTarget(0)
+      })
+    const sel = select(svgRef.current).selectAll<SVGGElement, unknown>('g[data-flow-draggable]')
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(sel as any).call(dragBehavior)
+  }, [nodeIdsKey])
+
+  /* ── Click handlers (single vs double, 220ms debounce) ──────── */
+
+  const clickTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const cancelPendingClick = useCallback(() => {
+    if (clickTimerRef.current) {
+      clearTimeout(clickTimerRef.current)
+      clickTimerRef.current = null
+    }
+  }, [])
+  useEffect(() => () => cancelPendingClick(), [cancelPendingClick])
+
+  const handleNodeClick = useCallback(
+    (nodeId: string, _event: ReactMouseEvent<SVGGElement>) => {
+      cancelPendingClick()
+      clickTimerRef.current = setTimeout(() => {
+        onNodeOpen?.(nodeId)
+        clickTimerRef.current = null
+      }, 220)
+    },
+    [cancelPendingClick, onNodeOpen],
+  )
+
+  const handleNodeDoubleClick = useCallback(
+    (nodeId: string) => {
+      cancelPendingClick()
+      const positioned = layoutOut.positionedNodes.find((n) => n.id === nodeId)
+      if (positioned?.isGroup) {
+        onFoldToggle?.(nodeId)
+        return
+      }
+      onNodeNavigate?.(nodeId)
+    },
+    [cancelPendingClick, layoutOut.positionedNodes, onFoldToggle, onNodeNavigate],
+  )
+
+  const handleBackgroundClick = useCallback(() => {
+    cancelPendingClick()
+    onBackgroundClick?.()
+  }, [cancelPendingClick, onBackgroundClick])
+
+  /* ── Render ────────────────────────────────────────────────── */
+
+  if (layoutOut.positionedNodes.length === 0) {
+    return (
+      <div
+        ref={hostRef}
+        className="flow-canvas-host"
+        data-testid="flow-canvas-empty"
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          padding: '2rem',
+          fontSize: '0.875rem',
+          color: 'var(--flow-bubble-sublabel)',
+        }}
+      >
+        No nodes to render.
+      </div>
+    )
+  }
+
+  const livePos = new Map<string, { x: number; y: number }>()
+  for (const n of simNodes) {
+    if (typeof n.x === 'number' && typeof n.y === 'number') {
+      livePos.set(n.id, { x: n.x, y: n.y })
+    }
+  }
+
+  const neighborIds = new Set<string>()
+  if (selectedNodeId) {
+    for (const e of layoutOut.edges) {
+      if (e.fromId === selectedNodeId) neighborIds.add(e.toId)
+      else if (e.toId === selectedNodeId) neighborIds.add(e.fromId)
+    }
+  }
+
+  const vbW = Math.max(hostSize.w, layoutMetrics.totalWidth)
+  const vbH = hostSize.h
+  const CLAMP_INSET = R + 8
+  const project = (p: { x: number; y: number }) => ({
+    x: Math.min(vbW - CLAMP_INSET, Math.max(CLAMP_INSET, p.x)),
+    y: Math.min(vbH - CLAMP_INSET, Math.max(CLAMP_INSET, p.y)),
+  })
+  const renderPos = new Map<string, { x: number; y: number }>()
+  for (const [id, p] of livePos) renderPos.set(id, project(p))
+
+  return (
+    <div
+      ref={hostRef}
+      className="flow-canvas-host"
+      data-testid="flow-canvas-host"
+      style={{
+        overflowX: layoutMetrics.totalWidth > hostSize.w ? 'auto' : 'hidden',
+        overflowY: 'hidden',
+      }}
+    >
+      <svg
+        ref={svgRef}
+        width={vbW}
+        height="100%"
+        viewBox={`0 0 ${vbW} ${vbH}`}
+        preserveAspectRatio="xMinYMin meet"
+        className="flow-canvas-svg"
+        data-testid="flow-canvas-svg"
+        role="img"
+        aria-label={`Flow ${flow.id}`}
+        style={{ display: 'block', minWidth: '100%', height: '100%' }}
+        onClick={(e) => {
+          if (e.target === e.currentTarget) handleBackgroundClick()
+        }}
+      >
+        <FlowArrowDefs palette={palette} />
+        {layoutOut.edges.map((e) => {
+          const s = renderPos.get(e.fromId)
+          const t = renderPos.get(e.toId)
+          if (!s || !t) return null
+          const onSelectionPath =
+            selectedNodeId !== null && (e.fromId === selectedNodeId || e.toId === selectedNodeId)
+          const onHostPath =
+            hostNodeId !== null && !onSelectionPath && (e.fromId === hostNodeId || e.toId === hostNodeId)
+          return (
+            <FlowEdge
+              key={`${e.fromId}-${e.toId}-${e.relType}`}
+              edge={e}
+              from={s}
+              to={t}
+              palette={palette}
+              highlighted={onSelectionPath ? 'selection' : onHostPath ? 'host' : 'none'}
+              r={R}
+            />
+          )
+        })}
+        {layoutOut.positionedNodes.map((node) => {
+          const pos = renderPos.get(node.id)
+          if (!pos) return null
+          const family = familyById.get(node.family) ?? null
+          const isNeighbor = neighborIds.has(node.id)
+          const isOpen = selectedNodeId === node.id
+          const isHost = hostNodeId === node.id
+          return (
+            <FlowNodeView
+              key={node.id}
+              node={node}
+              x={pos.x}
+              y={pos.y}
+              family={family}
+              palette={palette}
+              isOpen={isOpen}
+              isHost={isHost}
+              isNeighbor={isNeighbor}
+              isDimmed={selectedNodeId !== null && !isNeighbor && !isOpen && !isHost}
+              onClick={(e) => handleNodeClick(node.id, e)}
+              onDoubleClick={() => handleNodeDoubleClick(node.id)}
+              r={R}
+              gr={GR}
+            />
+          )
+        })}
+      </svg>
+    </div>
+  )
+}
+
+/* ─── Edge defs (SVG <marker> for arrowheads) ────────────────────── */
+
+function FlowArrowDefs({ palette }: { palette: Record<string, StatusTone> }) {
+  const statuses = Object.keys({ ...DEFAULT_PALETTE, ...palette })
+  return (
+    <defs>
+      {statuses.map((s) => {
+        const tone = toneFor(palette, s)
+        return (
+          <marker
+            key={s}
+            id={`flow-arrow-${cssId(s)}`}
+            viewBox="0 0 10 10"
+            refX="9"
+            refY="5"
+            markerWidth="6"
+            markerHeight="6"
+            orient="auto-start-reverse"
+          >
+            <path d="M0,1 L9,5 L0,9 Z" fill={tone.arrow} opacity="0.92" />
+          </marker>
+        )
+      })}
+      <marker
+        id="flow-arrow-host"
+        viewBox="0 0 10 10"
+        refX="9"
+        refY="5"
+        markerWidth="7"
+        markerHeight="7"
+        orient="auto-start-reverse"
+      >
+        <path d="M0,1 L9,5 L0,9 Z" fill="var(--flow-host-ring, #14B8A6)" opacity="1" />
+      </marker>
+      <marker
+        id="flow-arrow-selection"
+        viewBox="0 0 10 10"
+        refX="9"
+        refY="5"
+        markerWidth="7"
+        markerHeight="7"
+        orient="auto-start-reverse"
+      >
+        <path d="M0,1 L9,5 L0,9 Z" fill="var(--flow-selection-ring, #FBBF24)" opacity="1" />
+      </marker>
+    </defs>
+  )
+}
+
+function cssId(s: string): string {
+  return s.replace(/[^a-zA-Z0-9_-]/g, '-')
+}
+
+/* ─── FlowEdge ────────────────────────────────────────────────────── */
+
+interface FlowEdgeProps {
+  edge: PositionedEdge
+  from: { x: number; y: number }
+  to: { x: number; y: number }
+  palette: Record<string, StatusTone>
+  highlighted: 'none' | 'selection' | 'host'
+  r: number
+}
+
+function FlowEdge({ edge, from, to, palette, highlighted, r }: FlowEdgeProps) {
+  const tone = toneFor(palette, edge.fromStatus)
+  const dx = to.x - from.x
+  const dy = to.y - from.y
+  const len = Math.hypot(dx, dy) || 1
+  const trim = r + 6
+  const fx = from.x + (dx / len) * r
+  const fy = from.y + (dy / len) * r
+  const tx = to.x - (dx / len) * trim
+  const ty = to.y - (dy / len) * trim
+
+  /* Style table from the spec:
+   *   FS       — solid, normal arrow
+   *   SS       — solid, "↓" inline tag near origin (handled as glyph below)
+   *   FF       — solid, "↓" inline tag near terminus
+   *   SF       — dashed
+   *   triggers — solid + lightning glyph at midpoint
+   *   on-failure — red dashed, low opacity until source is 'failed'
+   */
+  const isFailure = edge.condition === 'on-failure'
+  const sourceFailed = edge.fromStatus === 'failed'
+  const baseStroke =
+    highlighted === 'selection'
+      ? 'var(--flow-selection-ring, #FBBF24)'
+      : highlighted === 'host'
+        ? 'var(--flow-host-ring, #14B8A6)'
+        : isFailure
+          ? 'var(--flow-bubble-edge-failed, #F87171)'
+          : tone.edge
+  const opacity =
+    highlighted !== 'none'
+      ? 1
+      : isFailure
+        ? sourceFailed
+          ? 0.85
+          : 0.25
+        : 0.7
+  const width = highlighted !== 'none' ? 2.6 : 1.4
+  const marker =
+    highlighted === 'selection'
+      ? 'flow-arrow-selection'
+      : highlighted === 'host'
+        ? 'flow-arrow-host'
+        : `flow-arrow-${cssId(edge.fromStatus)}`
+  const dashArray =
+    isFailure || edge.relType === 'start-to-finish' ? '4 3' : undefined
+
+  // Midpoint annotations for SS/FF/triggers.
+  const midX = (fx + tx) / 2
+  const midY = (fy + ty) / 2
+  const annotation = (() => {
+    if (highlighted !== 'none') return null
+    if (edge.relType === 'start-to-start') {
+      // Near origin.
+      const ox = fx + (tx - fx) * 0.18
+      const oy = fy + (ty - fy) * 0.18
+      return (
+        <text
+          x={ox}
+          y={oy}
+          fontSize={10}
+          fill={baseStroke}
+          pointerEvents="none"
+          textAnchor="middle"
+          fontFamily="ui-monospace, monospace"
+        >
+          SS
+        </text>
+      )
+    }
+    if (edge.relType === 'finish-to-finish') {
+      // Near terminus.
+      const ox = fx + (tx - fx) * 0.82
+      const oy = fy + (ty - fy) * 0.82
+      return (
+        <text
+          x={ox}
+          y={oy}
+          fontSize={10}
+          fill={baseStroke}
+          pointerEvents="none"
+          textAnchor="middle"
+          fontFamily="ui-monospace, monospace"
+        >
+          FF
+        </text>
+      )
+    }
+    if (edge.relType === 'triggers') {
+      return (
+        <text
+          x={midX}
+          y={midY - 4}
+          fontSize={12}
+          fill={baseStroke}
+          pointerEvents="none"
+          textAnchor="middle"
+        >
+          ⚡
+        </text>
+      )
+    }
+    if (edge.relType === 'start-to-finish') {
+      return (
+        <text
+          x={midX}
+          y={midY - 4}
+          fontSize={10}
+          fill={baseStroke}
+          pointerEvents="none"
+          textAnchor="middle"
+          fontFamily="ui-monospace, monospace"
+        >
+          SF
+        </text>
+      )
+    }
+    return null
+  })()
+
+  return (
+    <g data-flow-edge="" data-rel-type={edge.relType} data-condition={edge.condition}>
+      <line
+        x1={fx.toFixed(1)}
+        y1={fy.toFixed(1)}
+        x2={tx.toFixed(1)}
+        y2={ty.toFixed(1)}
+        stroke={baseStroke}
+        strokeWidth={width}
+        strokeDasharray={dashArray}
+        markerEnd={`url(#${marker})`}
+        opacity={opacity}
+      />
+      {annotation}
+    </g>
+  )
+}
+
+/* ─── FlowNodeView ────────────────────────────────────────────────── */
+
+interface FlowNodeViewProps {
+  node: PositionedNode
+  x: number
+  y: number
+  family: FamilyDescriptor | null
+  palette: Record<string, StatusTone>
+  isOpen: boolean
+  isHost: boolean
+  isNeighbor: boolean
+  isDimmed: boolean
+  onClick: (e: ReactMouseEvent<SVGGElement>) => void
+  onDoubleClick: () => void
+  r: number
+  gr: number
+}
+
+function FlowNodeView({
+  node,
+  x,
+  y,
+  family,
+  palette,
+  isOpen,
+  isHost,
+  isNeighbor,
+  isDimmed,
+  onClick,
+  onDoubleClick,
+  r,
+  gr,
+}: FlowNodeViewProps) {
+  const tone = toneFor(palette, node.status)
+  const innerRing = isOpen
+    ? 'var(--flow-selection-ring, #FBBF24)'
+    : isNeighbor
+      ? 'var(--flow-neighbor-ring, #FCD34D)'
+      : isHost
+        ? 'var(--flow-host-ring, #14B8A6)'
+        : tone.ring
+  const familyColor = family?.color ?? 'rgba(148,163,184,0.55)'
+  const radius = node.isGroup ? gr : r
+  const grpStyle: CSSProperties = { cursor: 'grab' }
+  const groupOpacity = isDimmed ? 0.35 : 1
+  const innerWidth = isOpen ? 4 : isNeighbor ? 3 : isHost ? 3.5 : 2
+
+  return (
+    <g
+      data-testid={`flow-node-${node.id}`}
+      data-flow-draggable=""
+      data-node-id={node.id}
+      data-status={node.status}
+      data-region={node.region}
+      data-family={node.family}
+      data-flow={node.flowId}
+      data-kind={node.isGroup ? 'group' : 'leaf'}
+      data-folded={node.isFolded ? 'true' : 'false'}
+      data-open={isOpen ? 'true' : 'false'}
+      data-host={isHost ? 'true' : 'false'}
+      data-neighbor={isNeighbor ? 'true' : 'false'}
+      data-dimmed={isDimmed ? 'true' : 'false'}
+      onClick={onClick}
+      onDoubleClick={onDoubleClick}
+      style={grpStyle}
+      transform={`translate(${x.toFixed(1)}, ${y.toFixed(1)})`}
+      opacity={groupOpacity}
+    >
+      <title>
+        {`${node.label} — ${tone.label}${isHost ? ' · host' : ''}`}
+      </title>
+      {isHost ? (
+        <circle r={radius + 12} fill="rgba(20,184,166,0.30)" />
+      ) : isOpen ? (
+        <circle r={radius + 10} fill="rgba(251,191,36,0.30)" />
+      ) : isNeighbor ? (
+        <circle r={radius + 8} fill="rgba(252,211,77,0.18)" />
+      ) : tone.glow !== 'transparent' ? (
+        <circle r={radius + 8} fill={tone.glow} />
+      ) : null}
+      {isHost ? (
+        <circle
+          r={radius + 6}
+          fill="none"
+          stroke="var(--flow-host-ring, #14B8A6)"
+          strokeWidth={3.5}
+          opacity={0.95}
+        />
+      ) : null}
+      <circle
+        r={radius + 2}
+        fill="none"
+        stroke={familyColor}
+        strokeWidth={node.isGroup ? 2.5 : 1}
+        opacity={0.55}
+      />
+      <circle r={radius} fill={tone.fill} stroke={innerRing} strokeWidth={innerWidth} />
+      {node.isFolded ? (
+        <text
+          x={0}
+          y={6}
+          textAnchor="middle"
+          fontSize={node.childCount > 99 ? 14 : 18}
+          fontWeight={700}
+          fill={tone.glyph}
+          fontFamily="ui-sans-serif, system-ui, sans-serif"
+          pointerEvents="none"
+        >
+          {node.childCount}
+        </text>
+      ) : (
+        <text
+          x={0}
+          y={6}
+          textAnchor="middle"
+          fontSize={node.isGroup ? 16 : 18}
+          fontWeight={700}
+          fill={tone.glyph}
+          fontFamily="ui-sans-serif, system-ui, sans-serif"
+          pointerEvents="none"
+        >
+          {node.isGroup ? '◇' : glyphFor(node.status)}
+        </text>
+      )}
+      <text
+        x={0}
+        y={radius + 14}
+        textAnchor="middle"
+        fontSize={10}
+        fill="var(--flow-bubble-label)"
+        fontFamily="var(--font-mono, ui-monospace, monospace)"
+        pointerEvents="none"
+      >
+        {node.label.length > 18 ? node.label.slice(0, 17) + '…' : node.label}
+      </text>
+    </g>
+  )
+}
+
+function glyphFor(status: string): string {
+  if (status === 'succeeded') return '✓'
+  if (status === 'failed') return '✗'
+  if (status === 'running') return '◐'
+  return '○'
+}
+
+function hashSeed(id: string): { fx: number; fy: number } {
+  let h = 2166136261
+  for (let i = 0; i < id.length; i++) {
+    h ^= id.charCodeAt(i)
+    h = Math.imul(h, 16777619)
+  }
+  const fx = ((h >>> 0) % 1000) / 1000
+  let h2 = h
+  h2 = Math.imul(h2 ^ (h2 >>> 13), 2654435761)
+  const fy = ((h2 >>> 0) % 1000) / 1000
+  return { fx, fy }
+}
+
+/* Re-export the RelationshipType for callers that need to switch on
+ * the rel type without importing flow-core directly. */
+export type { RelationshipType }

--- a/products/openova-flow/canvas/src/FlowLogFeed.tsx
+++ b/products/openova-flow/canvas/src/FlowLogFeed.tsx
@@ -1,0 +1,114 @@
+/**
+ * @openova/flow-canvas — FlowLogFeed slot.
+ *
+ * A *bare* container component for a per-node detail pane (log tail,
+ * execution panel, kubectl describe). The host supplies the actual
+ * content via the `renderDetail` prop on FlowCanvas; FlowLogFeed only
+ * wraps that content with the canonical dock chrome (Esc close,
+ * focused-node label, optional toolbar slot).
+ *
+ * Hosts that want a fancier log pane (xterm tail, search) embed their
+ * component INSIDE the renderDetail callback. The canvas does not
+ * own that.
+ */
+
+import type { ReactNode } from 'react'
+import { useEffect } from 'react'
+
+export interface FlowLogFeedProps {
+  /** Which node's detail to render. `null` collapses the pane. */
+  selectedNodeId: string | null
+  /** Render-prop for the actual detail content. */
+  renderDetail?: (nodeId: string) => ReactNode
+  /** Close handler — host wires this to its selection state. */
+  onClose?: () => void
+  /** Title slot — defaults to the node id. */
+  title?: ReactNode
+  /** Optional left-side toolbar slot (actions, status badges). */
+  toolbar?: ReactNode
+}
+
+export function FlowLogFeed({
+  selectedNodeId,
+  renderDetail,
+  onClose,
+  title,
+  toolbar,
+}: FlowLogFeedProps) {
+  useEffect(() => {
+    if (!selectedNodeId) return
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') {
+        e.stopPropagation()
+        onClose?.()
+      }
+    }
+    document.addEventListener('keydown', onKey)
+    return () => document.removeEventListener('keydown', onKey)
+  }, [selectedNodeId, onClose])
+
+  if (!selectedNodeId) return null
+  return (
+    <aside
+      className="flow-log-feed"
+      data-testid="flow-log-feed"
+      data-node-id={selectedNodeId}
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        height: '100%',
+        background: 'var(--flow-canvas-bg)',
+        border: '1px solid var(--flow-canvas-border)',
+        borderRadius: 12,
+      }}
+    >
+      <header
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          padding: '8px 12px',
+          borderBottom: '1px solid var(--flow-canvas-border)',
+          color: 'var(--flow-bubble-label)',
+          fontSize: 12,
+        }}
+      >
+        <span data-testid="flow-log-feed-title">{title ?? selectedNodeId}</span>
+        <span style={{ display: 'inline-flex', gap: 8, alignItems: 'center' }}>
+          {toolbar}
+          {onClose ? (
+            <button
+              type="button"
+              onClick={onClose}
+              data-testid="flow-log-feed-close"
+              style={{
+                background: 'transparent',
+                color: 'inherit',
+                border: '1px solid var(--flow-canvas-border)',
+                borderRadius: 4,
+                cursor: 'pointer',
+                padding: '2px 6px',
+                fontSize: 11,
+              }}
+            >
+              Esc
+            </button>
+          ) : null}
+        </span>
+      </header>
+      <div
+        style={{
+          flex: 1,
+          minHeight: 0,
+          overflow: 'auto',
+          padding: 12,
+          color: 'var(--flow-bubble-label)',
+          fontFamily: 'var(--font-mono, ui-monospace, monospace)',
+          fontSize: 12,
+        }}
+      >
+        {renderDetail ? renderDetail(selectedNodeId) : null}
+      </div>
+    </aside>
+  )
+}

--- a/products/openova-flow/canvas/src/_theme.css
+++ b/products/openova-flow/canvas/src/_theme.css
@@ -1,0 +1,118 @@
+/**
+ * @openova/flow-canvas — default theme tokens.
+ *
+ * Hosts import this CSS once via `@openova/flow-canvas/theme.css` to
+ * get the standard OpenovaFlow look. Override individual tokens in
+ * your own stylesheet to reskin without forking the package.
+ *
+ * The canvas itself reads `var(--flow-bubble-*)` inline so token
+ * changes hot-reload without remounting. All tokens are scoped under
+ * `.flow-canvas-host` so they do NOT leak into the host page's
+ * cascade.
+ *
+ * Dark theme is the default; light theme is opted in via
+ * `[data-theme="light"] .flow-canvas-host`.
+ */
+
+.flow-canvas-host {
+  /* Bubble surface (status === 'pending' / 'running' / 'succeeded' /
+   * 'failed'). Adapters supply their OWN statusPalette via the
+   * FlowAdapter contract — these tokens are the canvas's defaults
+   * when a status string has no palette entry. */
+  --flow-bubble-fill-pending:    #0F1A2A;
+  --flow-bubble-ring-pending:    rgba(148,163,184,0.55);
+  --flow-bubble-glyph-pending:   rgba(148,163,184,0.75);
+  --flow-bubble-glow-pending:    transparent;
+  --flow-bubble-edge-pending:    rgba(148,163,184,0.32);
+  --flow-bubble-arrow-pending:   rgba(148,163,184,0.60);
+
+  --flow-bubble-fill-running:    #0E1A33;
+  --flow-bubble-ring-running:    rgba(56,189,248,0.85);
+  --flow-bubble-glyph-running:   #BAE6FD;
+  --flow-bubble-glow-running:    rgba(56,189,248,0.30);
+  --flow-bubble-edge-running:    rgba(56,189,248,0.65);
+  --flow-bubble-arrow-running:   #38BDF8;
+
+  --flow-bubble-fill-succeeded:  #16A34A;
+  --flow-bubble-ring-succeeded:  rgba(22,163,74,0.95);
+  --flow-bubble-glyph-succeeded: #FFFFFF;
+  --flow-bubble-glow-succeeded:  rgba(74,222,128,0.20);
+  --flow-bubble-edge-succeeded:  rgba(74,222,128,0.55);
+  --flow-bubble-arrow-succeeded: #4ADE80;
+
+  --flow-bubble-fill-failed:     #23070A;
+  --flow-bubble-ring-failed:     rgba(248,113,113,0.85);
+  --flow-bubble-glyph-failed:    #FCA5A5;
+  --flow-bubble-glow-failed:     rgba(248,113,113,0.30);
+  --flow-bubble-edge-failed:     rgba(248,113,113,0.65);
+  --flow-bubble-arrow-failed:    #F87171;
+
+  /* Label text (drawn below each bubble). */
+  --flow-bubble-label:           rgba(255,255,255,0.85);
+  --flow-bubble-sublabel:        rgba(255,255,255,0.45);
+
+  /* Selection rings — host (teal), selection (amber), neighbour
+   * (lighter amber). These are NOT status tones — they sit above
+   * the status ring as overlays. */
+  --flow-host-ring:              #14B8A6;
+  --flow-selection-ring:         #FBBF24;
+  --flow-neighbor-ring:          #FCD34D;
+
+  /* Canvas backdrop. */
+  --flow-canvas-bg:              radial-gradient(ellipse at 20% 0%, rgba(11,28,58,0.85) 0%, rgba(7,10,18,0.85) 75%);
+  --flow-canvas-border:          rgba(255,255,255,0.04);
+}
+
+[data-theme="light"] .flow-canvas-host {
+  --flow-bubble-fill-pending:    #E2E8F0;
+  --flow-bubble-ring-pending:    rgba(100,116,139,0.65);
+  --flow-bubble-glyph-pending:   rgba(71,85,105,0.85);
+  --flow-bubble-glow-pending:    transparent;
+  --flow-bubble-edge-pending:    rgba(100,116,139,0.45);
+  --flow-bubble-arrow-pending:   rgba(100,116,139,0.70);
+
+  --flow-bubble-fill-running:    #DBEAFE;
+  --flow-bubble-ring-running:    rgba(37,99,235,0.85);
+  --flow-bubble-glyph-running:   #1E3A8A;
+  --flow-bubble-glow-running:    rgba(56,189,248,0.30);
+  --flow-bubble-edge-running:    rgba(37,99,235,0.65);
+  --flow-bubble-arrow-running:   #2563EB;
+
+  --flow-bubble-fill-succeeded:  #15803D;
+  --flow-bubble-ring-succeeded:  rgba(21,128,61,0.95);
+  --flow-bubble-glyph-succeeded: #FFFFFF;
+  --flow-bubble-glow-succeeded:  rgba(34,197,94,0.18);
+  --flow-bubble-edge-succeeded:  rgba(21,128,61,0.65);
+  --flow-bubble-arrow-succeeded: #15803D;
+
+  --flow-bubble-fill-failed:     #FEE2E2;
+  --flow-bubble-ring-failed:     rgba(220,38,38,0.95);
+  --flow-bubble-glyph-failed:    #7F1D1D;
+  --flow-bubble-glow-failed:     rgba(248,113,113,0.20);
+  --flow-bubble-edge-failed:     rgba(220,38,38,0.65);
+  --flow-bubble-arrow-failed:    #DC2626;
+
+  --flow-bubble-label:           rgba(15,23,42,0.85);
+  --flow-bubble-sublabel:        rgba(15,23,42,0.55);
+
+  --flow-canvas-bg:              radial-gradient(ellipse at 20% 0%, #f1f5f9 0%, #e2e8f0 75%);
+  --flow-canvas-border:          #cbd5e1;
+}
+
+.flow-canvas-host {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  min-width: 0;
+  min-height: 0;
+  background: var(--flow-canvas-bg);
+  border-radius: 12px;
+  border: 1px solid var(--flow-canvas-border);
+  overflow: auto;
+}
+
+.flow-canvas-svg {
+  display: block;
+  width: 100%;
+  height: 100%;
+}

--- a/products/openova-flow/canvas/src/index.ts
+++ b/products/openova-flow/canvas/src/index.ts
@@ -1,0 +1,8 @@
+/**
+ * @openova/flow-canvas — barrel exports.
+ */
+
+export { FlowCanvas } from './FlowCanvas'
+export type { FlowCanvasProps } from './FlowCanvas'
+export { FlowLogFeed } from './FlowLogFeed'
+export type { FlowLogFeedProps } from './FlowLogFeed'

--- a/products/openova-flow/canvas/test/FlowCanvas.test.tsx
+++ b/products/openova-flow/canvas/test/FlowCanvas.test.tsx
@@ -1,0 +1,174 @@
+/**
+ * @openova/flow-canvas — basic render + interaction tests.
+ *
+ * Verifies the canvas:
+ *   • renders one <g data-testid="flow-node-X"> per visible node
+ *   • renders one edge per non-`contains` Relationship
+ *   • tags edges with data-rel-type for each of the 6 PMI types
+ *   • shows the empty-state message when there are no nodes
+ *   • surfaces the host ring via `data-host="true"` on the right node
+ *   • surfaces the selection ring via `data-open="true"`
+ *   • calls onNodeOpen after the single-click debounce
+ *   • calls onFoldToggle on double-click of a group node
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent, act } from '@testing-library/react'
+import { FlowCanvas } from '../src/FlowCanvas'
+import type { FlowInstance, FlowNode, Relationship } from '@openova/flow-core'
+
+const FLOW: FlowInstance = { id: 'f1', status: 'running', startedAt: 0 }
+
+function leaf(id: string, status = 'pending'): FlowNode {
+  return { id, flowId: FLOW.id, label: id, status }
+}
+
+describe('FlowCanvas — render', () => {
+  it('renders an empty-state placeholder when there are no nodes', () => {
+    render(
+      <FlowCanvas flow={FLOW} nodes={[]} relationships={[]} folded={new Set()} />,
+    )
+    expect(screen.getByTestId('flow-canvas-empty')).toBeTruthy()
+  })
+
+  it('renders one node group per visible FlowNode', () => {
+    const nodes: FlowNode[] = [leaf('a'), leaf('b'), leaf('c')]
+    render(
+      <FlowCanvas flow={FLOW} nodes={nodes} relationships={[]} folded={new Set()} />,
+    )
+    expect(screen.getByTestId('flow-node-a')).toBeTruthy()
+    expect(screen.getByTestId('flow-node-b')).toBeTruthy()
+    expect(screen.getByTestId('flow-node-c')).toBeTruthy()
+  })
+
+  it('tags edges with data-rel-type for each non-contains relationship', () => {
+    const nodes: FlowNode[] = [leaf('a'), leaf('b'), leaf('c'), leaf('d'), leaf('e'), leaf('f')]
+    const rels: Relationship[] = [
+      { fromId: 'a', toId: 'b', type: 'finish-to-start' },
+      { fromId: 'b', toId: 'c', type: 'start-to-start' },
+      { fromId: 'c', toId: 'd', type: 'finish-to-finish' },
+      { fromId: 'd', toId: 'e', type: 'start-to-finish' },
+      { fromId: 'e', toId: 'f', type: 'triggers' },
+    ]
+    const { container } = render(
+      <FlowCanvas flow={FLOW} nodes={nodes} relationships={rels} folded={new Set()} />,
+    )
+    const edgeGroups = container.querySelectorAll('g[data-flow-edge]')
+    const seenTypes = new Set<string>()
+    edgeGroups.forEach((g) => {
+      const t = g.getAttribute('data-rel-type')
+      if (t) seenTypes.add(t)
+    })
+    expect(seenTypes.has('finish-to-start')).toBe(true)
+    expect(seenTypes.has('start-to-start')).toBe(true)
+    expect(seenTypes.has('finish-to-finish')).toBe(true)
+    expect(seenTypes.has('start-to-finish')).toBe(true)
+    expect(seenTypes.has('triggers')).toBe(true)
+  })
+
+  it('does NOT render `contains` edges (hierarchy is grouping, not an edge)', () => {
+    const nodes: FlowNode[] = [leaf('group-a'), leaf('child-1')]
+    const rels: Relationship[] = [
+      { fromId: 'child-1', toId: 'group-a', type: 'contains' },
+    ]
+    const { container } = render(
+      <FlowCanvas flow={FLOW} nodes={nodes} relationships={rels} folded={new Set(['group-a'])} />,
+    )
+    const containsEdges = container.querySelectorAll('g[data-flow-edge][data-rel-type="contains"]')
+    expect(containsEdges.length).toBe(0)
+  })
+
+  it('marks the host node via data-host="true"', () => {
+    const nodes: FlowNode[] = [leaf('a'), leaf('b')]
+    render(
+      <FlowCanvas
+        flow={FLOW}
+        nodes={nodes}
+        relationships={[]}
+        folded={new Set()}
+        hostNodeId="b"
+      />,
+    )
+    const host = screen.getByTestId('flow-node-b')
+    expect(host.getAttribute('data-host')).toBe('true')
+    const other = screen.getByTestId('flow-node-a')
+    expect(other.getAttribute('data-host')).toBe('false')
+  })
+
+  it('marks the selected node via data-open="true"', () => {
+    const nodes: FlowNode[] = [leaf('a'), leaf('b')]
+    render(
+      <FlowCanvas
+        flow={FLOW}
+        nodes={nodes}
+        relationships={[]}
+        folded={new Set()}
+        selectedNodeId="a"
+      />,
+    )
+    expect(screen.getByTestId('flow-node-a').getAttribute('data-open')).toBe('true')
+    expect(screen.getByTestId('flow-node-b').getAttribute('data-open')).toBe('false')
+  })
+})
+
+describe('FlowCanvas — interaction', () => {
+  it('calls onNodeOpen after the single-click debounce', async () => {
+    vi.useFakeTimers()
+    const onNodeOpen = vi.fn()
+    const nodes: FlowNode[] = [leaf('a')]
+    render(
+      <FlowCanvas
+        flow={FLOW}
+        nodes={nodes}
+        relationships={[]}
+        folded={new Set()}
+        onNodeOpen={onNodeOpen}
+      />,
+    )
+    fireEvent.click(screen.getByTestId('flow-node-a'))
+    expect(onNodeOpen).not.toHaveBeenCalled()
+    act(() => {
+      vi.advanceTimersByTime(250)
+    })
+    expect(onNodeOpen).toHaveBeenCalledWith('a')
+    vi.useRealTimers()
+  })
+
+  it('calls onFoldToggle on double-click of a group node', () => {
+    // A group node is one that is the `toId` of at least one
+    // `contains` edge.
+    const nodes: FlowNode[] = [leaf('grp'), leaf('child')]
+    const rels: Relationship[] = [
+      { fromId: 'child', toId: 'grp', type: 'contains' },
+    ]
+    const onFoldToggle = vi.fn()
+    render(
+      <FlowCanvas
+        flow={FLOW}
+        nodes={nodes}
+        relationships={rels}
+        folded={new Set(['grp'])}
+        onFoldToggle={onFoldToggle}
+      />,
+    )
+    const grpNode = screen.getByTestId('flow-node-grp')
+    fireEvent.doubleClick(grpNode)
+    expect(onFoldToggle).toHaveBeenCalledWith('grp')
+  })
+
+  it('calls onNodeNavigate on double-click of a leaf node', () => {
+    const onNodeNavigate = vi.fn()
+    const nodes: FlowNode[] = [leaf('a')]
+    render(
+      <FlowCanvas
+        flow={FLOW}
+        nodes={nodes}
+        relationships={[]}
+        folded={new Set()}
+        onNodeNavigate={onNodeNavigate}
+      />,
+    )
+    fireEvent.doubleClick(screen.getByTestId('flow-node-a'))
+    expect(onNodeNavigate).toHaveBeenCalledWith('a')
+  })
+})

--- a/products/openova-flow/canvas/test/setup.ts
+++ b/products/openova-flow/canvas/test/setup.ts
@@ -1,0 +1,28 @@
+/**
+ * @openova/flow-canvas test setup — polyfill browser APIs that jsdom
+ * does not implement, and wire @testing-library cleanup between tests.
+ */
+
+import { afterEach } from 'vitest'
+import { cleanup } from '@testing-library/react'
+
+afterEach(() => {
+  cleanup()
+})
+
+class MockResizeObserver {
+  observe(): void {
+    /* noop */
+  }
+  unobserve(): void {
+    /* noop */
+  }
+  disconnect(): void {
+    /* noop */
+  }
+}
+
+if (typeof globalThis.ResizeObserver === 'undefined') {
+  ;(globalThis as unknown as { ResizeObserver: typeof MockResizeObserver }).ResizeObserver =
+    MockResizeObserver
+}

--- a/products/openova-flow/canvas/tsconfig.json
+++ b/products/openova-flow/canvas/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ES2023",
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "skipLibCheck": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "verbatimModuleSyntax": true,
+    "moduleDetection": "force",
+    "esModuleInterop": true,
+    "noEmit": true,
+    "baseUrl": ".",
+    "paths": {
+      "@openova/flow-core": ["../core/src/index.ts"]
+    },
+    "types": []
+  },
+  "include": ["src/**/*", "test/**/*"]
+}

--- a/products/openova-flow/canvas/vitest.config.ts
+++ b/products/openova-flow/canvas/vitest.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vitest/config'
+import { fileURLToPath } from 'node:url'
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@openova/flow-core': fileURLToPath(new URL('../core/src/index.ts', import.meta.url)),
+    },
+  },
+  test: {
+    environment: 'jsdom',
+    include: ['test/**/*.test.ts', 'test/**/*.test.tsx'],
+    setupFiles: ['./test/setup.ts'],
+  },
+})

--- a/products/openova-flow/core/README.md
+++ b/products/openova-flow/core/README.md
@@ -1,0 +1,86 @@
+# `@openova/flow-core`
+
+Plugin-shaped contract + pure layout engine for OpenovaFlow — the
+standalone, OpenOva-independent flow-visualization product.
+
+This package has **zero runtime side effects**, **zero network code**,
+**zero React-DOM** dependencies. It is the only package callers need
+to type their data against before subscribing to a `FlowAdapter`.
+
+## Concepts
+
+- **FlowInstance** — a runtime DAG-run. Carries `id`, optional
+  `definitionId` (the template id, for DAG vs DAG-run), optional
+  `parentFlowId` (nested child workflow), and a `triggeredBy[]`
+  chain for event-triggered flows.
+- **FlowNode** — one node inside a flow. Belongs to **exactly one**
+  flow via `flowId`. Cross-flow references travel on Relationships,
+  not on the node.
+- **Relationship** — a typed directed edge. Six types: `contains` for
+  structural hierarchy + the five PMI temporal types (`finish-to-start`,
+  `start-to-start`, `finish-to-finish`, `start-to-finish`) + `triggers`
+  for event-driven edges. Edges may be `on-success` (default),
+  `on-failure` (overlay, not counted for depth), or `always`.
+- **FlowAdapter** — the plugin interface. Implements `subscribe()` to
+  push `FlowMessage` events to a sink, supplies a `statusPalette`,
+  `families`, `regions`, and optional `renderDetail` / `actions`.
+- **FlowMessage** — the wire protocol. Six variants: `snapshot`,
+  `upsert-flow`, `upsert-nodes`, `upsert-rels`, `delete-nodes`,
+  `delete-rels`.
+
+## Usage
+
+```ts
+import { layout, type FlowAdapter } from '@openova/flow-core'
+
+const myAdapter: FlowAdapter = {
+  schemaVersion: 1,
+  subscribe(flowId, sink) {
+    const es = new EventSource(`/flow/${flowId}/events`)
+    es.onmessage = (e) => sink(JSON.parse(e.data))
+    return () => es.close()
+  },
+  statusPalette: {
+    pending: { fill: '...', ring: '...', /* ... */, label: 'Pending' },
+    running: { /* ... */ },
+    succeeded: { /* ... */ },
+    failed: { /* ... */ },
+  },
+}
+
+// Later, when you have a snapshot:
+const positioned = layout({
+  flow,
+  nodes,
+  relationships,
+  folded: new Set<string>(),
+  hints: {
+    perNode: new Map([
+      ['n1', { region: 'eu', family: 'platform' }],
+    ]),
+    families: myAdapter.families,
+    regions: myAdapter.regions,
+  },
+})
+// → positioned.positionedNodes, positioned.edges, positioned.components
+```
+
+## Layout semantics — locked invariants
+
+| Invariant | Origin |
+|---|---|
+| Cycle safety in parent-chain walks (no infinite loops on malformed inputs) | Bug #476 |
+| Fold-aware rewiring — folded groups emit ONE node | Issue #351 |
+| Parent-elision — unfolded groups with visible children disappear from the bubble set; their inbound + outbound deps fan out / lift onto the visible children ("parent calling their parents") | Bug #481 round 2 |
+| `MAX_VISIBLE_DEPTH = 8` defence-in-depth cap | Bug #481 round 2 |
+| Global topological-sort `depRank` for stable Y-axis order | Issue #532 |
+| `on-failure` edges are NOT counted toward depth | Founder locked 2026-05-11 |
+
+## Testing
+
+```sh
+npm test               # vitest --pool=threads --maxWorkers=2 --no-isolate
+npm run typecheck      # tsc --noEmit -p tsconfig.json
+```
+
+NEVER `npm run build` / `playwright install` / `playwright test`.

--- a/products/openova-flow/core/package.json
+++ b/products/openova-flow/core/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@openova/flow-core",
+  "private": true,
+  "version": "0.1.0",
+  "description": "Plugin-shaped contract + pure layout engine for OpenovaFlow",
+  "type": "module",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "import": "./src/index.ts"
+    }
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit -p tsconfig.json",
+    "test": "vitest run --pool=threads --maxWorkers=2 --no-isolate"
+  },
+  "peerDependencies": {
+    "react": "^19.0.0"
+  },
+  "devDependencies": {
+    "@types/react": "^19.2.14",
+    "typescript": "~5.9.3",
+    "vitest": "^4.1.5"
+  }
+}

--- a/products/openova-flow/core/src/index.ts
+++ b/products/openova-flow/core/src/index.ts
@@ -1,0 +1,36 @@
+/**
+ * @openova/flow-core — barrel.
+ *
+ * Public surface: types (FlowInstance, FlowNode, Relationship,
+ * FlowMessage, FlowAdapter, StatusTone, FamilyDescriptor,
+ * RegionDescriptor, NodeAction) + the pure `layout` function and the
+ * `defaultFoldedAtDepth` helper.
+ *
+ * Nothing else is exported — callers reach into core/src/* directly
+ * only in tests.
+ */
+
+export type {
+  FlowInstance,
+  FlowNode,
+  Relationship,
+  RelationshipType,
+  FlowMessage,
+  FlowAdapter,
+  StatusTone,
+  FamilyDescriptor,
+  RegionDescriptor,
+  NodeAction,
+} from './types'
+export { isBlockingRelationship } from './types'
+
+export type {
+  LayoutInput,
+  LayoutOutput,
+  LayoutHints,
+  FlowLayoutHint,
+  PositionedNode,
+  PositionedEdge,
+  ComponentInfo,
+} from './layout'
+export { layout, defaultFoldedAtDepth, FALLBACK_REGION_ID, MAX_VISIBLE_DEPTH } from './layout'

--- a/products/openova-flow/core/src/layout.ts
+++ b/products/openova-flow/core/src/layout.ts
@@ -1,0 +1,773 @@
+/**
+ * @openova/flow-core — layout module.
+ *
+ * Pure (no DOM, no React, no side effects) topology computation:
+ *
+ *   Input  — { flow, nodes, relationships, folded, hints? }
+ *   Output — positioned nodes (depth + depRank + region + family),
+ *            tagged edges (per-relationship-type + crossRegion flag),
+ *            and connected-component metadata for gutters.
+ *
+ * # Migration from the legacy `flowLayoutOrganic`
+ *
+ * The legacy layout took a `readonly Job[]` (with `parentId` +
+ * `dependsOn` on each node) and emitted `kind: 'depends-on' |
+ * 'parent-child'`. This version takes `FlowNode[] + Relationship[]`
+ * and emits `relType: RelationshipType` per edge. Internally:
+ *
+ *   • Hierarchy graph = `relationships.filter(r => r.type === 'contains')`.
+ *     `r.toId` is the parent (container); `r.fromId` is the child.
+ *   • Blocking-DAG graph = `relationships.filter(r => isBlocking(r.type))`.
+ *     All FS/SS/FF/SF/triggers edges are counted for depth.
+ *   • `condition === 'on-failure'` edges are emitted as overlay
+ *     edges but NOT counted for depth (they only fire on a failed
+ *     predecessor; they should not push successors deeper into the
+ *     canvas).
+ *
+ * # Founder-locked invariants preserved verbatim from the legacy:
+ *
+ *   • Cycle-safety in the parent-chain walks (bug #476) — every
+ *     traversal tracks visited ids and exits gracefully on cycles.
+ *   • Fold-aware rewiring: a folded `contains`-parent emits ONE node
+ *     and its dep edges fan out to the parent.
+ *   • Parent-elision (bug #481): when a `contains`-parent is unfolded
+ *     AND has at least one visible child, the parent is elided. Its
+ *     inbound deps are rewired to its visible children; its outbound
+ *     deps are lifted onto each child ("parent calling their parents").
+ *   • `MAX_VISIBLE_DEPTH = 8` defence-in-depth depth cap.
+ *   • Global topological-sort rank for Y-axis positioning (issue
+ *     #532) — dense, stable across same-depth siblings.
+ *   • Legacy `extraDepIds` hint stays supported via the new `hints`
+ *     map; adapters use it to inject component-graph deps that aren't
+ *     present in the per-node Relationship list.
+ */
+
+import type {
+  FlowInstance,
+  FlowNode,
+  Relationship,
+  RelationshipType,
+  FamilyDescriptor,
+  RegionDescriptor,
+} from './types'
+import { isBlockingRelationship } from './types'
+
+/* ────────────────────────────────────────────────────────────────────
+ * Hint shape (region / family / extra deps, per-node)
+ * ──────────────────────────────────────────────────────────────────── */
+
+/** A per-node hint — used when the host wants to inject region/family
+ *  overrides or `extraDepIds` (blocking deps not present in the
+ *  relationship feed). Mirrors the legacy `OrganicNodeHints`. */
+export interface FlowLayoutHint {
+  region?: string
+  family?: string
+  /** Extra blocking-dep node ids — treated as `finish-to-start` /
+   *  `on-success` edges synthesised onto this node's inbound side. */
+  extraDepIds?: string[]
+}
+
+export interface LayoutHints {
+  perNode?: ReadonlyMap<string, FlowLayoutHint>
+  /** Adapter's family descriptor list — used for family-id validation
+   *  and to forward as the layout output's family palette. */
+  families?: readonly FamilyDescriptor[]
+  /** Adapter's region descriptor list — used for region-id validation
+   *  and forwarded as the layout output's region palette. */
+  regions?: readonly RegionDescriptor[]
+}
+
+/* ────────────────────────────────────────────────────────────────────
+ * Input / output types
+ * ──────────────────────────────────────────────────────────────────── */
+
+export interface LayoutInput {
+  flow: FlowInstance
+  nodes: readonly FlowNode[]
+  relationships: readonly Relationship[]
+  folded: ReadonlySet<string>
+  hints?: LayoutHints
+}
+
+export interface PositionedNode {
+  /** Stable id — equals FlowNode.id. */
+  id: string
+  /** Originating flow id. */
+  flowId: string
+  /** 0-based longest-path depth in the fold-respecting visible graph. */
+  depth: number
+  /** Dense topological-sort rank, [0, N-1]. Used by the canvas as
+   *  the Y target so visual reading order matches dependency order. */
+  depRank: number
+  /** Resolved region id (may equal hint region or fall back to the
+   *  first descriptor / `FALLBACK_REGION_ID`). */
+  region: string
+  /** Resolved family id. */
+  family: string
+  /** Display label — pass-through from FlowNode.label. */
+  label: string
+  /** Status — open string from the upstream FlowNode. */
+  status: string
+  /** True when this node represents a `contains`-parent (group). */
+  isGroup: boolean
+  /** True when this node is a folded group (children hidden). */
+  isFolded: boolean
+  /** Count of direct children — surfaced as a badge on folded groups. */
+  childCount: number
+  /** Forwarded for tooltip / click handlers. */
+  node: FlowNode
+}
+
+export interface PositionedEdge {
+  fromId: string
+  toId: string
+  /** The relationship type that produced this edge. `contains` edges
+   *  are NEVER emitted here — `contains` is used to drive grouping
+   *  only, the canvas does not render a `contains` edge. */
+  relType: Exclude<RelationshipType, 'contains'>
+  /** Source-node status — used for tone selection on the edge stroke. */
+  fromStatus: string
+  /** Cross-region edge — drawn with a different tone. */
+  crossRegion: boolean
+  /** Cross-flow edge — drawn dashed by convention. */
+  crossFlow: boolean
+  /** Edge condition (`on-success` is the canvas default; `on-failure`
+   *  edges are drawn with a fail-path style and NOT counted for
+   *  depth). */
+  condition: 'on-success' | 'on-failure' | 'always'
+  /** Optional temporal lag in seconds — annotation. */
+  lag?: number
+}
+
+export interface ComponentInfo {
+  /** Stable id of the component: smallest member id in the rank order. */
+  id: string
+  /** Members of this weakly-connected component (excluding `contains`
+   *  edges — components are computed on the blocking-DAG graph). */
+  memberIds: string[]
+  /** Inclusive depRank range — used by hosts to draw component gutters. */
+  depRankMin: number
+  depRankMax: number
+}
+
+export interface LayoutOutput {
+  positionedNodes: PositionedNode[]
+  edges: PositionedEdge[]
+  components: ComponentInfo[]
+  maxDepth: number
+  families: FamilyDescriptor[]
+  regions: RegionDescriptor[]
+}
+
+/* ────────────────────────────────────────────────────────────────────
+ * Constants
+ * ──────────────────────────────────────────────────────────────────── */
+
+/** Reserved id for the default region descriptor when adapters
+ *  don't supply one. */
+export const FALLBACK_REGION_ID = 'primary'
+
+/** Defence-in-depth depth cap. Real provisioning graphs after
+ *  parent-elision collapse to ~5; this is the safety net for
+ *  malformed inputs. */
+export const MAX_VISIBLE_DEPTH = 8
+
+/* ────────────────────────────────────────────────────────────────────
+ * Layout entry point
+ * ──────────────────────────────────────────────────────────────────── */
+
+export function layout(input: LayoutInput): LayoutOutput {
+  const { flow, nodes, relationships, folded } = input
+  const hints = input.hints ?? {}
+  const perNode = hints.perNode ?? new Map<string, FlowLayoutHint>()
+  const families = hints.families ?? []
+  const regions = hints.regions ?? []
+
+  /* ── 1. Resolve fallback region descriptor ────────────────────── */
+
+  const fallbackRegion: RegionDescriptor =
+    regions.find((r) => r.id === FALLBACK_REGION_ID) ??
+    regions[0] ?? { id: FALLBACK_REGION_ID, label: 'Primary' }
+
+  /* ── 2. Index nodes by id (last-write-wins for collisions, same
+   *      semantics as the legacy byId.set loop). Cycle-safety is in
+   *      the parent-chain walks below, not here. ──────────────────── */
+
+  const byId = new Map<string, FlowNode>()
+  for (const n of nodes) byId.set(n.id, n)
+
+  /* ── 3. Partition relationships into hierarchy vs blocking. ──── */
+
+  // Hierarchy: parent map (child id → parent id). `contains` edges
+  // have toId=parent, fromId=child.
+  const parentOf = new Map<string, string>()
+  // childrenOf used for visibleChildCount + fan-out logic.
+  const childrenOf = new Map<string, string[]>()
+  // Blocking deps per node: nodeId → list of (predId, condition, type).
+  type BlockingDep = { predId: string; condition: 'on-success' | 'on-failure' | 'always'; type: Exclude<RelationshipType, 'contains'>; lag?: number }
+  const blockingDepsOf = new Map<string, BlockingDep[]>()
+  // Outbound blocking deps per node (used for parent-elision lift).
+  const blockingOutOf = new Map<string, BlockingDep[]>()
+
+  for (const r of relationships) {
+    if (r.type === 'contains') {
+      // `contains`: toId contains fromId (parent = toId).
+      parentOf.set(r.fromId, r.toId)
+      const arr = childrenOf.get(r.toId) ?? []
+      arr.push(r.fromId)
+      childrenOf.set(r.toId, arr)
+      continue
+    }
+    if (!isBlockingRelationship(r.type)) continue
+    const cond = r.condition ?? 'on-success'
+    const dep: BlockingDep = {
+      predId: r.fromId,
+      condition: cond,
+      type: r.type,
+      lag: r.lag,
+    }
+    const inArr = blockingDepsOf.get(r.toId) ?? []
+    inArr.push(dep)
+    blockingDepsOf.set(r.toId, inArr)
+    const outArr = blockingOutOf.get(r.fromId) ?? []
+    outArr.push({ ...dep, predId: r.toId })
+    blockingOutOf.set(r.fromId, outArr)
+  }
+  // Synthesise edges from per-node hint extraDepIds — treat as
+  // finish-to-start / on-success.
+  for (const [nodeId, h] of perNode) {
+    if (!h.extraDepIds) continue
+    for (const pred of h.extraDepIds) {
+      const dep: BlockingDep = {
+        predId: pred,
+        condition: 'on-success',
+        type: 'finish-to-start',
+      }
+      const inArr = blockingDepsOf.get(nodeId) ?? []
+      inArr.push(dep)
+      blockingDepsOf.set(nodeId, inArr)
+      const outArr = blockingOutOf.get(pred) ?? []
+      outArr.push({ ...dep, predId: nodeId })
+      blockingOutOf.set(pred, outArr)
+    }
+  }
+
+  /* ── 4. isVisible: a node is visible when no ancestor is folded.
+   *      Walks parentOf; cycle-safe via `seen` set (bug #476). ── */
+
+  function isVisible(n: FlowNode): boolean {
+    let pid = parentOf.get(n.id)
+    const seen = new Set<string>([n.id])
+    while (pid) {
+      if (seen.has(pid)) return true
+      seen.add(pid)
+      if (folded.has(pid)) return false
+      const parent = byId.get(pid)
+      if (!parent) break
+      pid = parentOf.get(pid)
+    }
+    return true
+  }
+
+  /* ── 5. Identify "group" nodes — a node IS a group iff it appears
+   *      as the parent (toId) of any `contains` edge. ──────────── */
+
+  function isGroupNode(nodeId: string): boolean {
+    const ch = childrenOf.get(nodeId)
+    return !!ch && ch.length > 0
+  }
+
+  /* ── 6. Build the visible node list. Reuses isVisible/folded
+   *      semantics from the legacy. ──────────────────────────── */
+
+  const allVisibleNodes: FlowNode[] = []
+  for (const n of nodes) {
+    if (isVisible(n)) allVisibleNodes.push(n)
+  }
+
+  /* ── 7. Parent-elision (bug #481 round 2): an unfolded group with
+   *      at least one visible child disappears from the bubble set.
+   *      Inbound deps rewire to visible children; outbound deps lift
+   *      onto each visible child. ─────────────────────────────── */
+
+  // A `contains` cycle between two nodes (a-contains-b, b-contains-a)
+  // would make both eligible for elision; eliding both removes every
+  // bubble from the canvas. To stay cycle-safe we mark "child" as
+  // visible only when the child is not an ancestor of the candidate
+  // group in the `contains` graph (walk parentOf with a visited set).
+  function isAncestorOf(maybeAncestor: string, descendant: string): boolean {
+    let cursor = parentOf.get(descendant)
+    const seen = new Set<string>([descendant])
+    while (cursor) {
+      if (seen.has(cursor)) return false
+      seen.add(cursor)
+      if (cursor === maybeAncestor) return true
+      const next: string | undefined = parentOf.get(cursor)
+      if (!next) return false
+      cursor = next
+    }
+    return false
+  }
+  const elidedIds = new Set<string>()
+  for (const n of allVisibleNodes) {
+    if (!isGroupNode(n.id)) continue
+    if (folded.has(n.id)) continue
+    if (byId.get(n.id) !== n) continue // last-wins collision protection
+    const ch = childrenOf.get(n.id) ?? []
+    let visibleChildCount = 0
+    for (const childId of ch) {
+      if (childId === n.id) continue
+      const child = byId.get(childId)
+      if (!child) continue
+      if (child === n) continue
+      if (!isVisible(child)) continue
+      // Cycle guard: if "child" is also an ancestor of n (contains
+      // cycle), don't count it — otherwise both nodes get elided and
+      // the canvas renders nothing.
+      if (isAncestorOf(childId, n.id)) continue
+      visibleChildCount++
+    }
+    if (visibleChildCount > 0) elidedIds.add(n.id)
+  }
+
+  const visibleNodes: FlowNode[] = allVisibleNodes.filter((n) => {
+    if (!elidedIds.has(n.id)) return true
+    return byId.get(n.id) !== n
+  })
+  const visibleIdSet = new Set(visibleNodes.map((n) => n.id))
+
+  /* ── 8. visibleRepresentative — resolve any dep target to the
+   *      nearest visible-AND-not-elided ancestor. Cycle-safe. ── */
+
+  function visibleRepresentative(id: string): string | null {
+    let cursor: FlowNode | undefined = byId.get(id)
+    const seen = new Set<string>()
+    while (cursor) {
+      if (seen.has(cursor.id)) return cursor.id
+      seen.add(cursor.id)
+      const nodeVisible = isVisible(cursor)
+      const nodeIsElided = elidedIds.has(cursor.id)
+      const isGroup = isGroupNode(cursor.id)
+      if (nodeVisible && !nodeIsElided && (!isGroup || !folded.has(cursor.id))) {
+        return cursor.id
+      }
+      if (nodeVisible && !nodeIsElided) return cursor.id
+      const pid = parentOf.get(cursor.id)
+      if (!pid) break
+      cursor = byId.get(pid)
+    }
+    return null
+  }
+
+  /* ── 9. fanOutVisibleChildren — when an inbound dep targets an
+   *      elided group, fan it across the elided group's visible
+   *      (non-elided) leaves. Cycle-safe. ─────────────────────── */
+
+  function fanOutVisibleChildren(nodeId: string): string[] {
+    const root = byId.get(nodeId)
+    if (!root) return []
+    if (!elidedIds.has(nodeId)) return [nodeId]
+    const out: string[] = []
+    const seen = new Set<string>([nodeId])
+    const stack: string[] = [...(childrenOf.get(nodeId) ?? [])]
+    while (stack.length > 0) {
+      const cid = stack.pop()!
+      if (seen.has(cid)) continue
+      seen.add(cid)
+      const c = byId.get(cid)
+      if (!c) continue
+      if (!isVisible(c)) continue
+      if (elidedIds.has(cid)) {
+        for (const gc of childrenOf.get(cid) ?? []) stack.push(gc)
+      } else {
+        out.push(cid)
+      }
+    }
+    return out
+  }
+
+  /* ── 10. Build the visible edge set. ──────────────────────────── */
+
+  // Edge dedup: per (fromId, toId) we keep the strongest edge metadata —
+  // mirroring the legacy `kind: 'depends-on' | 'parent-child'` priority
+  // (depends-on dominated parent-child). With the new contract we keep
+  // the FIRST non-failure edge per pair as the canonical render; failure
+  // edges live separately as overlays.
+  type EdgeKey = string
+  const edgeMap = new Map<EdgeKey, PositionedEdge>()
+  function key(from: string, to: string): EdgeKey {
+    return `${from}${to}`
+  }
+  function addEdge(
+    from: string,
+    to: string,
+    relType: Exclude<RelationshipType, 'contains'>,
+    fromStatus: string,
+    crossRegion: boolean,
+    crossFlow: boolean,
+    condition: 'on-success' | 'on-failure' | 'always',
+    lag: number | undefined,
+  ) {
+    if (!visibleIdSet.has(from) || !visibleIdSet.has(to)) return
+    if (from === to) return
+    const k = key(from, to)
+    const existing = edgeMap.get(k)
+    // Promotion rule: an `on-success` non-failure edge dominates
+    // `on-failure`; among non-failure edges the first wins to stay
+    // deterministic. `triggers` is treated as ordinary blocking.
+    if (existing) {
+      if (existing.condition === 'on-failure' && condition !== 'on-failure') {
+        // Replace failure-overlay with a true blocking edge.
+        edgeMap.set(k, {
+          fromId: from,
+          toId: to,
+          relType,
+          fromStatus,
+          crossRegion,
+          crossFlow,
+          condition,
+          lag,
+        })
+      }
+      return
+    }
+    edgeMap.set(k, {
+      fromId: from,
+      toId: to,
+      relType,
+      fromStatus,
+      crossRegion,
+      crossFlow,
+      condition,
+      lag,
+    })
+  }
+
+  function statusOf(id: string): string {
+    return byId.get(id)?.status ?? 'pending'
+  }
+  function regionOf(id: string): string {
+    const n = byId.get(id)
+    if (!n) return fallbackRegion.id
+    const hintRegion = perNode.get(id)?.region
+    const candidate = hintRegion ?? n.region
+    if (candidate && (regions.length === 0 || regions.some((r) => r.id === candidate))) {
+      return candidate
+    }
+    return fallbackRegion.id
+  }
+  function flowOf(id: string): string {
+    return byId.get(id)?.flowId ?? flow.id
+  }
+
+  // Iterate every blocking dep entry; emit rewired/lifted edges.
+  for (const node of visibleNodes) {
+    const fromRep = visibleRepresentative(node.id)
+    if (!fromRep) continue
+    const deps = blockingDepsOf.get(node.id) ?? []
+    for (const d of deps) {
+      const predJob = byId.get(d.predId)
+      // Elided source: fan out from each visible child of the elided
+      // pred to this node.
+      if (predJob && elidedIds.has(predJob.id)) {
+        for (const fanned of fanOutVisibleChildren(predJob.id)) {
+          if (fanned !== fromRep) {
+            addEdge(
+              fanned,
+              fromRep,
+              d.type,
+              statusOf(fanned),
+              regionOf(fanned) !== regionOf(fromRep),
+              flowOf(fanned) !== flowOf(fromRep),
+              d.condition,
+              d.lag,
+            )
+          }
+        }
+        continue
+      }
+      const depRep = visibleRepresentative(d.predId)
+      if (!depRep) continue
+      if (depRep === fromRep) continue
+      addEdge(
+        depRep,
+        fromRep,
+        d.type,
+        statusOf(depRep),
+        regionOf(depRep) !== regionOf(fromRep),
+        flowOf(depRep) !== flowOf(fromRep),
+        d.condition,
+        d.lag,
+      )
+    }
+  }
+  // Lift outbound deps from elided groups onto each visible child.
+  for (const elidedId of elidedIds) {
+    const elided = byId.get(elidedId)
+    if (!elided) continue
+    const outDeps = blockingOutOf.get(elidedId) ?? []
+    if (outDeps.length === 0) continue
+    const visibleChildren = fanOutVisibleChildren(elidedId)
+    for (const childId of visibleChildren) {
+      for (const d of outDeps) {
+        // predId is the OTHER end of the original outbound dep.
+        const targetRep = visibleRepresentative(d.predId)
+        const targetCandidates =
+          d.predId && byId.get(d.predId) && elidedIds.has(d.predId)
+            ? fanOutVisibleChildren(d.predId)
+            : targetRep
+              ? [targetRep]
+              : []
+        for (const tgt of targetCandidates) {
+          if (tgt === childId) continue
+          addEdge(
+            childId,
+            tgt,
+            d.type,
+            statusOf(childId),
+            regionOf(childId) !== regionOf(tgt),
+            flowOf(childId) !== flowOf(tgt),
+            d.condition,
+            d.lag,
+          )
+        }
+      }
+    }
+  }
+  // Fan INBOUND deps that target elided groups onto each visible
+  // child of the elided group. A "foundation → apps" edge with apps
+  // elided becomes "foundation → c1", "foundation → c2", ...
+  //
+  // We iterate elidedIds and pull their inbound deps from
+  // blockingDepsOf (the per-target map). Each dep's predId is the
+  // edge source; resolve to its visible representative (or fan out
+  // again if the source itself is elided).
+  for (const elidedId of elidedIds) {
+    const inDeps = blockingDepsOf.get(elidedId) ?? []
+    if (inDeps.length === 0) continue
+    const fannedChildren = fanOutVisibleChildren(elidedId)
+    if (fannedChildren.length === 0) continue
+    for (const d of inDeps) {
+      const predJob = byId.get(d.predId)
+      const sources: string[] = predJob && elidedIds.has(predJob.id)
+        ? fanOutVisibleChildren(predJob.id)
+        : (() => {
+            const rep = visibleRepresentative(d.predId)
+            return rep ? [rep] : []
+          })()
+      for (const src of sources) {
+        for (const childId of fannedChildren) {
+          if (src === childId) continue
+          addEdge(
+            src,
+            childId,
+            d.type,
+            statusOf(src),
+            regionOf(src) !== regionOf(childId),
+            flowOf(src) !== flowOf(childId),
+            d.condition,
+            d.lag,
+          )
+        }
+      }
+    }
+  }
+
+  /* ── 11. Depth = longest-path from any root in the BLOCKING graph
+   *       (failure-conditioned edges are NOT counted, per the
+   *       founder-locked rule). ──────────────────────────────── */
+
+  // Build adjacency excluding on-failure edges.
+  const blockingIn = new Map<string, Set<string>>()
+  for (const n of visibleNodes) blockingIn.set(n.id, new Set())
+  for (const e of edgeMap.values()) {
+    if (e.condition === 'on-failure') continue
+    blockingIn.get(e.toId)!.add(e.fromId)
+  }
+
+  const depth = new Map<string, number>()
+  for (const n of visibleNodes) depth.set(n.id, 0)
+  let changed = true
+  let iterations = 0
+  const cap = visibleNodes.length + 2
+  while (changed && iterations < cap) {
+    changed = false
+    iterations++
+    for (const n of visibleNodes) {
+      const ins = blockingIn.get(n.id)!
+      let bestParent = -1
+      for (const p of ins) bestParent = Math.max(bestParent, depth.get(p) ?? 0)
+      const want = bestParent + 1
+      if (want > 0 && want > (depth.get(n.id) ?? 0)) {
+        depth.set(n.id, want)
+        changed = true
+      }
+    }
+  }
+  for (const [id, d] of depth) {
+    if (d > MAX_VISIBLE_DEPTH) depth.set(id, MAX_VISIBLE_DEPTH)
+  }
+
+  /* ── 12. depRank — dense topological-sort rank for Y-axis. ──── */
+
+  const indexInVisible = new Map<string, number>()
+  visibleNodes.forEach((n, i) => indexInVisible.set(n.id, i))
+  const sortedByDep = visibleNodes
+    .slice()
+    .sort((a, b) => {
+      const da = depth.get(a.id) ?? 0
+      const db = depth.get(b.id) ?? 0
+      if (da !== db) return da - db
+      return (indexInVisible.get(a.id) ?? 0) - (indexInVisible.get(b.id) ?? 0)
+    })
+  const depRank = new Map<string, number>()
+  sortedByDep.forEach((n, i) => depRank.set(n.id, i))
+
+  /* ── 13. Emit positioned nodes. ─────────────────────────────── */
+
+  const positionedNodes: PositionedNode[] = visibleNodes.map((n) => {
+    const h = perNode.get(n.id)
+    const familyId = h?.family ?? n.family ?? (families[0]?.id ?? 'platform')
+    const isGroup = isGroupNode(n.id)
+    const isFolded = isGroup && folded.has(n.id)
+    const childCount = (childrenOf.get(n.id) ?? []).length
+    return {
+      id: n.id,
+      flowId: n.flowId,
+      depth: depth.get(n.id) ?? 0,
+      depRank: depRank.get(n.id) ?? 0,
+      region: regionOf(n.id),
+      family: familyId,
+      label: n.label,
+      status: n.status,
+      isGroup,
+      isFolded,
+      childCount,
+      node: n,
+    }
+  })
+
+  /* ── 14. Emit positioned edges (filtered by visible-id set). ── */
+
+  const edges: PositionedEdge[] = []
+  for (const e of edgeMap.values()) {
+    if (!visibleIdSet.has(e.fromId)) continue
+    if (!visibleIdSet.has(e.toId)) continue
+    edges.push(e)
+  }
+
+  /* ── 15. Connected components (weak) on the blocking-DAG graph
+   *       — used by hosts to draw component gutters. ─────────── */
+
+  const components = computeComponents(positionedNodes, edges)
+
+  const maxDepth = positionedNodes.reduce((m, n) => Math.max(m, n.depth), 0)
+
+  return {
+    positionedNodes,
+    edges,
+    components,
+    maxDepth,
+    families: [...families],
+    regions: regions.length > 0 ? [...regions] : [fallbackRegion],
+  }
+}
+
+/* ────────────────────────────────────────────────────────────────────
+ * Connected-component helper
+ * ──────────────────────────────────────────────────────────────────── */
+
+function computeComponents(
+  nodes: PositionedNode[],
+  edges: PositionedEdge[],
+): ComponentInfo[] {
+  const parent = new Map<string, string>()
+  for (const n of nodes) parent.set(n.id, n.id)
+  function find(x: string): string {
+    let r = x
+    while (parent.get(r)! !== r) r = parent.get(r)!
+    // Path compression.
+    let cursor = x
+    while (parent.get(cursor)! !== r) {
+      const nxt = parent.get(cursor)!
+      parent.set(cursor, r)
+      cursor = nxt
+    }
+    return r
+  }
+  function union(a: string, b: string) {
+    const ra = find(a)
+    const rb = find(b)
+    if (ra !== rb) parent.set(ra, rb)
+  }
+  for (const e of edges) {
+    if (parent.has(e.fromId) && parent.has(e.toId)) union(e.fromId, e.toId)
+  }
+  const groups = new Map<string, PositionedNode[]>()
+  for (const n of nodes) {
+    const r = find(n.id)
+    const arr = groups.get(r) ?? []
+    arr.push(n)
+    groups.set(r, arr)
+  }
+  const components: ComponentInfo[] = []
+  for (const arr of groups.values()) {
+    arr.sort((a, b) => a.depRank - b.depRank)
+    components.push({
+      id: arr[0]?.id ?? '',
+      memberIds: arr.map((n) => n.id),
+      depRankMin: arr[0]?.depRank ?? 0,
+      depRankMax: arr[arr.length - 1]?.depRank ?? 0,
+    })
+  }
+  components.sort((a, b) => a.depRankMin - b.depRankMin)
+  return components
+}
+
+/* ────────────────────────────────────────────────────────────────────
+ * Default fold helper — cycle-safe, walks parent chain.
+ * ──────────────────────────────────────────────────────────────────── */
+
+/**
+ * Produce the default-fold set: every `contains`-parent at or below
+ * `depth` in the parent tree is folded by default. depth=1 keeps top-
+ * level groups folded; depth=all returns an empty set.
+ */
+export function defaultFoldedAtDepth(
+  nodes: readonly FlowNode[],
+  relationships: readonly Relationship[],
+  depth: number | 'all',
+): Set<string> {
+  if (depth === 'all') return new Set()
+  const containsRels = relationships.filter((r) => r.type === 'contains')
+  const parentOf = new Map<string, string>()
+  const childrenOf = new Map<string, string[]>()
+  for (const r of containsRels) {
+    parentOf.set(r.fromId, r.toId)
+    const arr = childrenOf.get(r.toId) ?? []
+    arr.push(r.fromId)
+    childrenOf.set(r.toId, arr)
+  }
+  const byId = new Map<string, FlowNode>()
+  for (const n of nodes) byId.set(n.id, n)
+  // A node is a group iff it has at least one child.
+  if (depth <= 0) {
+    return new Set([...childrenOf.keys()])
+  }
+  const out = new Set<string>()
+  for (const groupId of childrenOf.keys()) {
+    let d = 1
+    let pid = parentOf.get(groupId)
+    const seen = new Set<string>([groupId])
+    while (pid) {
+      if (seen.has(pid)) break
+      seen.add(pid)
+      d++
+      const ppid: string | undefined = parentOf.get(pid)
+      if (!ppid) break
+      pid = ppid
+    }
+    if (d >= depth) out.add(groupId)
+  }
+  return out
+}

--- a/products/openova-flow/core/src/types.ts
+++ b/products/openova-flow/core/src/types.ts
@@ -1,0 +1,310 @@
+/**
+ * @openova/flow-core — type contract for any backend that wants to
+ * drive the OpenovaFlow canvas. The contract is plugin-shaped: a
+ * `FlowAdapter` produces `FlowMessage` events; the canvas renders.
+ *
+ * NO OpenOva-specific values, NO Catalyst-specific shapes — every
+ * domain concept (statuses, families, regions, actions) is a
+ * descriptor the adapter supplies.
+ *
+ * Design canon — locked 2026-05-11 ("OpenovaFlow Foundation"):
+ *   • A flow is a first-class entity (FlowInstance) with a unique
+ *     runtime id and optional templateId (definitionId), parent flow,
+ *     and triggered-by chain. This is the "DAG vs DAG-run" distinction
+ *     that Argo/Temporal/Flux all need.
+ *   • Nodes belong to exactly one flow (FlowNode.flowId).
+ *   • Edges (Relationships) are typed using PMI temporal dependency
+ *     names — `finish-to-start`, `start-to-start`, `finish-to-finish`,
+ *     `start-to-finish`, plus `triggers` (event-based, no temporal
+ *     constraint) and `contains` (structural: toId contains fromId).
+ *   • `contains` replaces the legacy `parentId` field on the node —
+ *     hierarchy is now expressed in the edge graph, not on the node.
+ *
+ * Per the architecture canon every layer (palette, family, region,
+ * status) is supplied by the adapter. No hardcoded enums leak into
+ * core; canvas reads what core typed.
+ */
+
+import type { ReactNode } from 'react'
+
+/* ────────────────────────────────────────────────────────────────────
+ * Flow + Node
+ * ──────────────────────────────────────────────────────────────────── */
+
+/**
+ * A flow runtime instance.
+ *
+ *   • `id` — unique within the runtime universe (DAG-run id, workflow
+ *           execution id, deploymentId, etc.).
+ *   • `definitionId` — optional template id (DAG id, workflow type id).
+ *           Two FlowInstances with the same definitionId are two runs
+ *           of the same template.
+ *   • `parentFlowId` — when this flow was spawned as a child of
+ *           another flow (Temporal child workflow, Argo workflow
+ *           template-of-templates, nested provisioning step).
+ *   • `triggeredBy` — flows whose terminal state triggered this one.
+ *           Each entry pairs the triggering flow id with the gating
+ *           condition (`success` / `failure` / `always`).
+ *   • `status` — open string. The adapter's `statusPalette` keys this
+ *           into a visual tone; the canvas never inspects the value.
+ *   • `startedAt`/`endedAt` — unix ms. `endedAt` is undefined while
+ *           the flow is still running.
+ *   • `meta` — adapter-defined opaque payload. Surfaced via
+ *           `renderDetail` if the adapter implements it.
+ */
+export interface FlowInstance {
+  id: string
+  definitionId?: string
+  parentFlowId?: string
+  triggeredBy?: Array<{
+    flowId: string
+    when: 'success' | 'failure' | 'always'
+  }>
+  status: string
+  startedAt: number
+  endedAt?: number
+  meta?: Record<string, unknown>
+}
+
+/**
+ * A node inside a flow.
+ *
+ *   • `id` — unique within the parent `flowId`. Two flows MAY contain
+ *           nodes with the same id; consumers always carry the
+ *           `(flowId, id)` pair to disambiguate.
+ *   • `flowId` — the flow this node belongs to. A node belongs to
+ *           exactly one flow; cross-flow relationships are expressed
+ *           through `Relationship` with `fromFlowId`/`toFlowId`.
+ *   • `label` — display label (no markdown, no HTML).
+ *   • `status` — open string, palette-keyed by the adapter.
+ *   • `family` — grouping axis: drives the colour band/ring.
+ *           Adapter-defined; canvas uses adapter's `families`
+ *           descriptor list to map id → colour + display label.
+ *   • `region` — grouping axis: drives swimlane / band assignment.
+ *           Adapter-defined; canvas uses adapter's `regions`
+ *           descriptor list.
+ *   • `startedAt`/`endedAt` — unix ms; both optional (a queued node
+ *           has neither, a running one has only startedAt).
+ *   • `meta` — adapter-defined opaque payload (job appId, pod name,
+ *           execution id, etc.) used by `renderDetail`/`actions`.
+ */
+export interface FlowNode {
+  id: string
+  flowId: string
+  label: string
+  status: string
+  family?: string
+  region?: string
+  startedAt?: number
+  endedAt?: number
+  meta?: Record<string, unknown>
+}
+
+/* ────────────────────────────────────────────────────────────────────
+ * Relationships
+ * ──────────────────────────────────────────────────────────────────── */
+
+/**
+ * Edge type vocabulary. PMI temporal dependency taxonomy + two
+ * non-temporal kinds: `triggers` (event-driven, no temporal lag) and
+ * `contains` (structural / hierarchical).
+ *
+ *   • `contains` — `toId` (parent) contains `fromId` (child). This is
+ *                  the replacement for the legacy `Node.parentId`
+ *                  field. It is structural, not temporal; the layout
+ *                  treats it as the grouping axis.
+ *   • `finish-to-start` (FS) — `toId` starts after `fromId` finishes.
+ *                              The PMI default ordering. Counted for
+ *                              depth.
+ *   • `start-to-start` (SS) — `toId` starts when (or after) `fromId`
+ *                             starts. Counted for depth.
+ *   • `finish-to-finish` (FF) — `toId` finishes when (or after)
+ *                                `fromId` finishes. Counted for depth.
+ *   • `start-to-finish` (SF) — `toId` finishes after `fromId` starts.
+ *                              Rare; counted for depth.
+ *   • `triggers` — `fromId` emits an event that triggers `toId`. No
+ *                  temporal constraint beyond the event itself.
+ *                  Counted for depth.
+ */
+export type RelationshipType =
+  | 'contains'
+  | 'finish-to-start'
+  | 'start-to-start'
+  | 'finish-to-finish'
+  | 'start-to-finish'
+  | 'triggers'
+
+/**
+ * Convenience predicate: returns true for blocking-DAG relationship
+ * types (FS/SS/FF/SF/triggers), false for `contains` (structural).
+ *
+ * Used by the layout to filter the edge set into "hierarchy" vs
+ * "blocking-DAG" graphs without an inline string switch in three
+ * places.
+ */
+export function isBlockingRelationship(t: RelationshipType): boolean {
+  return t !== 'contains'
+}
+
+/**
+ * A directed relationship between two nodes.
+ *
+ *   • `fromId`/`toId` — node ids.
+ *   • `fromFlowId`/`toFlowId` — flow ids; both omitted when the edge
+ *           lives entirely inside the parent flow context. The
+ *           `toFlowId` is required (and `fromFlowId` if it differs)
+ *           when the edge crosses flow boundaries.
+ *   • `type` — see {@link RelationshipType}.
+ *   • `condition` — gates the edge: `on-success` (default for
+ *           FS/SS/FF/SF), `on-failure` (renders as a fail-path edge,
+ *           NOT counted for depth), `always` (independent of source
+ *           state).
+ *   • `lag` — seconds to wait after the trigger point before the
+ *           successor starts. `0` is the default.
+ */
+export interface Relationship {
+  fromId: string
+  toId: string
+  fromFlowId?: string
+  toFlowId?: string
+  type: RelationshipType
+  condition?: 'on-success' | 'on-failure' | 'always'
+  lag?: number
+}
+
+/* ────────────────────────────────────────────────────────────────────
+ * Adapter descriptors (palette, families, regions, actions)
+ * ──────────────────────────────────────────────────────────────────── */
+
+/**
+ * Status → visual tone. Tone values are CSS-color strings (hex, rgb,
+ * hsl, or `var(--token)`). Canvas does NOT add `var(--…)` wrapping;
+ * if the adapter wants theme-token resolution it MUST supply tokens
+ * itself (e.g. `'var(--bubble-fill-succeeded)'`).
+ *
+ * The tone vocabulary is fixed at 6 facets so a status descriptor is
+ * symmetric across adapters; an adapter that only cares about fill
+ * can supply the same value for the other 5.
+ */
+export interface StatusTone {
+  /** Inner circle fill colour. */
+  fill: string
+  /** Inner ring stroke colour (drawn on the bubble itself). */
+  ring: string
+  /** Status glyph / icon text colour. */
+  glyph: string
+  /** Soft halo / glow underlay colour (no-glow = `'transparent'`). */
+  glow: string
+  /** Outgoing-edge stroke colour. */
+  edge: string
+  /** Outgoing-edge arrow-head colour (concrete hex — SVG marker
+   *  defs need a resolvable colour at definition time, not CSS vars). */
+  arrow: string
+  /** Human-readable label, used in tooltips / a11y text. */
+  label: string
+}
+
+/** Family descriptor — colour-coded grouping axis used as the ring. */
+export interface FamilyDescriptor {
+  id: string
+  label: string
+  /** CSS colour (hex, rgb, hsl, or `var(--…)`). */
+  color: string
+}
+
+/** Region descriptor — used to label/swimlane multi-region flows. */
+export interface RegionDescriptor {
+  id: string
+  label: string
+  meta?: string
+}
+
+/**
+ * A custom action the canvas can surface in a per-node context menu /
+ * floating tray. Adapters use this for "open in Argo UI", "stream
+ * logs", "retry job", etc.
+ */
+export interface NodeAction {
+  id: string
+  label: string
+  /** Optional icon (any React node — Tabler/Lucide/raw SVG). */
+  icon?: ReactNode
+  /** Predicate — return false to hide the action for a given node. */
+  enabled?: (nodeId: string) => boolean
+  /** Invoked when the operator chooses the action. */
+  invoke: (nodeId: string) => void | Promise<void>
+}
+
+/* ────────────────────────────────────────────────────────────────────
+ * Wire protocol — FlowMessage
+ * ──────────────────────────────────────────────────────────────────── */
+
+/**
+ * Wire messages emitted by an adapter / server. The canvas + host
+ * consume the discriminated union and update local state accordingly.
+ *
+ *   • `snapshot` — full state for a flow. Emitted on subscribe; later
+ *                  upserts mutate the local cache.
+ *   • `upsert-flow` — flow-level metadata changed (status, endedAt).
+ *   • `upsert-nodes` — one or more nodes updated; merge by `id` keyed
+ *                      within `flowId`.
+ *   • `upsert-rels` — one or more relationships added/updated; merge
+ *                     by `(fromId, toId, type)`.
+ *   • `delete-nodes` — remove nodes by id (relationships to/from the
+ *                      removed nodes are automatically pruned by the
+ *                      consumer).
+ *   • `delete-rels` — remove specific edges by their natural key.
+ *
+ * `snapshot` carries the full triple (flow + nodes + relationships)
+ * so a re-subscribing client doesn't need a separate fetch path.
+ */
+export type FlowMessage =
+  | { type: 'snapshot'; flow: FlowInstance; nodes: FlowNode[]; relationships: Relationship[] }
+  | { type: 'upsert-flow'; flow: FlowInstance }
+  | { type: 'upsert-nodes'; nodes: FlowNode[] }
+  | { type: 'upsert-rels'; relationships: Relationship[] }
+  | { type: 'delete-nodes'; ids: string[] }
+  | {
+      type: 'delete-rels'
+      pairs: Array<{ fromId: string; toId: string; type: RelationshipType }>
+    }
+
+/* ────────────────────────────────────────────────────────────────────
+ * FlowAdapter — the plugin interface
+ * ──────────────────────────────────────────────────────────────────── */
+
+/**
+ * The plugin shape any backend implements to drive the canvas.
+ *
+ *   • `schemaVersion` — current contract version (always 1 for the
+ *                       foundation release). Adapter authors bump this
+ *                       when emitting messages that violate v1.
+ *   • `subscribe` — open a live subscription for a flow. Sink is
+ *                   called with one or more FlowMessage values; the
+ *                   first should be a `snapshot`. Returns an
+ *                   unsubscribe function.
+ *   • `fetchSnapshot` — optional one-shot fetch for the initial
+ *                       render before any live event arrives. Hosts
+ *                       use this for SSR or pre-rendered shells.
+ *   • `statusPalette` — status (open string) → StatusTone. Must cover
+ *                       every status value the adapter emits.
+ *   • `families`/`regions` — descriptors for the grouping axes the
+ *                            adapter uses. May be empty.
+ *   • `renderDetail` — optional slot for a per-node detail pane (log
+ *                      tail, execution panel, kubectl describe).
+ *   • `actions` — optional custom action list for the per-node tray.
+ */
+export interface FlowAdapter {
+  schemaVersion: 1
+  subscribe(flowId: string, sink: (msg: FlowMessage) => void): () => void
+  fetchSnapshot?(flowId: string): Promise<{
+    flow: FlowInstance
+    nodes: FlowNode[]
+    relationships: Relationship[]
+  }>
+  statusPalette: Record<string, StatusTone>
+  families?: FamilyDescriptor[]
+  regions?: RegionDescriptor[]
+  renderDetail?: (nodeId: string) => ReactNode
+  actions?: NodeAction[]
+}

--- a/products/openova-flow/core/test/layout.test.ts
+++ b/products/openova-flow/core/test/layout.test.ts
@@ -1,0 +1,432 @@
+/**
+ * @openova/flow-core — layout regression suite. Ports
+ * `flowLayoutOrganic.test.ts` to the new contract:
+ *
+ *   • Legacy `Job` shape (parentId / dependsOn) → new
+ *     FlowNode + Relationship[] (contains / finish-to-start).
+ *   • Same cycle-protection, parent-elision, MAX_VISIBLE_DEPTH cap
+ *     assertions.
+ *
+ * Every test exercises the founder-locked invariants documented in
+ * the legacy: bug #476 (cycle hangs), bug #481 round 2 (parent
+ * elision + lift + fan-out), MAX_VISIBLE_DEPTH defence-in-depth.
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  layout,
+  defaultFoldedAtDepth,
+  FALLBACK_REGION_ID,
+  MAX_VISIBLE_DEPTH,
+  type FlowLayoutHint,
+} from '../src/index'
+import type { FlowInstance, FlowNode, Relationship } from '../src/index'
+
+const FLOW: FlowInstance = {
+  id: 'test-flow',
+  status: 'running',
+  startedAt: 0,
+}
+
+const REGIONS = [{ id: FALLBACK_REGION_ID, label: 'Primary' }]
+const FAMILIES = [{ id: 'catalyst', label: 'Catalyst', color: '#fff' }]
+const HINTS = new Map<string, FlowLayoutHint>()
+
+function deadline<T>(label: string, fn: () => T, ms: number): T {
+  const t0 = Date.now()
+  const r = fn()
+  const dt = Date.now() - t0
+  if (dt > ms) {
+    throw new Error(`${label} took ${dt}ms (budget ${ms}ms)`)
+  }
+  return r
+}
+
+function leaf(id: string): FlowNode {
+  return { id, flowId: FLOW.id, label: id, status: 'pending' }
+}
+
+function group(id: string): FlowNode {
+  return { id, flowId: FLOW.id, label: id, status: 'pending' }
+}
+
+function contains(parent: string, child: string): Relationship {
+  return { fromId: child, toId: parent, type: 'contains' }
+}
+
+function fs(from: string, to: string): Relationship {
+  return { fromId: from, toId: to, type: 'finish-to-start', condition: 'on-success' }
+}
+
+describe('@openova/flow-core layout — cycle protection (bug #476)', () => {
+  it('returns within 100ms when a leaf has parentId === its own id (self-cycle)', () => {
+    const nodes: FlowNode[] = [leaf('a')]
+    // Synthesise the original pathology: a `contains` rel pointing
+    // from a node to itself. The cycle guard in isVisible /
+    // visibleRepresentative must terminate.
+    const rels: Relationship[] = [{ fromId: 'a', toId: 'a', type: 'contains' }]
+    const out = deadline(
+      'self-cycle layout',
+      () =>
+        layout({
+          flow: FLOW,
+          nodes,
+          relationships: rels,
+          folded: new Set(),
+          hints: { perNode: HINTS, regions: REGIONS, families: FAMILIES },
+        }),
+      100,
+    )
+    expect(out.positionedNodes.length).toBe(1)
+  })
+
+  it('returns within 100ms when two ids collide and produce a self-reference (original #476 shape)', () => {
+    const nodes: FlowNode[] = [
+      { ...group('cluster-bootstrap'), label: 'Cluster Bootstrap' },
+      leaf('cluster-bootstrap'),
+    ]
+    const rels: Relationship[] = [
+      // The original group had childIds=['cluster-bootstrap'] AND the
+      // leaf's parentId='cluster-bootstrap'. Both shapes encoded as
+      // `contains` edges below — self-pointing on the collided id.
+      { fromId: 'cluster-bootstrap', toId: 'cluster-bootstrap', type: 'contains' },
+    ]
+    const out = deadline(
+      'collision layout',
+      () =>
+        layout({
+          flow: FLOW,
+          nodes,
+          relationships: rels,
+          folded: new Set(),
+          hints: { perNode: HINTS, regions: REGIONS, families: FAMILIES },
+        }),
+      100,
+    )
+    expect(out.positionedNodes.length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('returns within 100ms when a leaf chain forms a multi-step cycle (a→b→a)', () => {
+    const nodes: FlowNode[] = [leaf('a'), leaf('b')]
+    const rels: Relationship[] = [
+      { fromId: 'a', toId: 'b', type: 'contains' },
+      { fromId: 'b', toId: 'a', type: 'contains' },
+    ]
+    const out = deadline(
+      'a-b-a cycle',
+      () =>
+        layout({
+          flow: FLOW,
+          nodes,
+          relationships: rels,
+          folded: new Set(),
+          hints: { perNode: HINTS, regions: REGIONS, families: FAMILIES },
+        }),
+      100,
+    )
+    expect(out.positionedNodes.length).toBe(2)
+  })
+})
+
+describe('@openova/flow-core layout — parent-elision (bug #481 round 2)', () => {
+  it('elides an unfolded group when its children are visible', () => {
+    const nodes: FlowNode[] = [
+      group('apps'),
+      leaf('c1'),
+      leaf('c2'),
+      leaf('c3'),
+    ]
+    const rels: Relationship[] = [
+      contains('apps', 'c1'),
+      contains('apps', 'c2'),
+      contains('apps', 'c3'),
+    ]
+    const out = layout({
+      flow: FLOW,
+      nodes,
+      relationships: rels,
+      folded: new Set(),
+      hints: { perNode: HINTS, regions: REGIONS, families: FAMILIES },
+    })
+    const ids = new Set(out.positionedNodes.map((n) => n.id))
+    expect(ids.has('apps')).toBe(false)
+    expect(ids.has('c1')).toBe(true)
+    expect(ids.has('c2')).toBe(true)
+    expect(ids.has('c3')).toBe(true)
+    expect(out.positionedNodes.length).toBe(3)
+    for (const e of out.edges) {
+      expect(e.fromId).not.toBe('apps')
+      expect(e.toId).not.toBe('apps')
+    }
+  })
+
+  it('keeps a folded group as a single node and hides its children', () => {
+    const nodes: FlowNode[] = [group('apps'), leaf('c1'), leaf('c2')]
+    const rels: Relationship[] = [contains('apps', 'c1'), contains('apps', 'c2')]
+    const out = layout({
+      flow: FLOW,
+      nodes,
+      relationships: rels,
+      folded: new Set(['apps']),
+      hints: { perNode: HINTS, regions: REGIONS, families: FAMILIES },
+    })
+    const ids = new Set(out.positionedNodes.map((n) => n.id))
+    expect(ids.has('apps')).toBe(true)
+    expect(ids.has('c1')).toBe(false)
+    expect(ids.has('c2')).toBe(false)
+  })
+
+  it('rewires inbound deps to children: foundation→apps becomes foundation→{c1,c2}', () => {
+    const nodes: FlowNode[] = [
+      leaf('foundation'),
+      group('apps'),
+      leaf('c1'),
+      leaf('c2'),
+    ]
+    const rels: Relationship[] = [
+      contains('apps', 'c1'),
+      contains('apps', 'c2'),
+      fs('foundation', 'apps'),
+    ]
+    const out = layout({
+      flow: FLOW,
+      nodes,
+      relationships: rels,
+      folded: new Set(),
+      hints: { perNode: HINTS, regions: REGIONS, families: FAMILIES },
+    })
+    const edgeKeys = new Set(out.edges.map((e) => `${e.fromId}→${e.toId}`))
+    expect(edgeKeys.has('foundation→c1')).toBe(true)
+    expect(edgeKeys.has('foundation→c2')).toBe(true)
+    for (const e of out.edges) {
+      expect(e.fromId).not.toBe('apps')
+      expect(e.toId).not.toBe('apps')
+    }
+  })
+
+  it('fans an inbound depends-on edge across all visible children of an elided group', () => {
+    const nodes: FlowNode[] = [
+      group('apps'),
+      leaf('c1'),
+      leaf('c2'),
+      leaf('sentinel'),
+    ]
+    const rels: Relationship[] = [
+      contains('apps', 'c1'),
+      contains('apps', 'c2'),
+      fs('apps', 'sentinel'),
+    ]
+    const out = layout({
+      flow: FLOW,
+      nodes,
+      relationships: rels,
+      folded: new Set(),
+      hints: { perNode: HINTS, regions: REGIONS, families: FAMILIES },
+    })
+    const edgeKeys = new Set(out.edges.map((e) => `${e.fromId}→${e.toId}`))
+    expect(edgeKeys.has('c1→sentinel')).toBe(true)
+    expect(edgeKeys.has('c2→sentinel')).toBe(true)
+    for (const e of out.edges) {
+      expect(e.fromId).not.toBe('apps')
+      expect(e.toId).not.toBe('apps')
+    }
+  })
+
+  it('caps depth at MAX_VISIBLE_DEPTH for malformed deep chains (defence-in-depth)', () => {
+    const CHAIN = 50
+    const nodes: FlowNode[] = []
+    const rels: Relationship[] = []
+    for (let i = 0; i < CHAIN; i++) {
+      nodes.push(leaf(`n${i}`))
+      if (i > 0) rels.push(fs(`n${i - 1}`, `n${i}`))
+    }
+    const out = layout({
+      flow: FLOW,
+      nodes,
+      relationships: rels,
+      folded: new Set(),
+      hints: { perNode: HINTS, regions: REGIONS, families: FAMILIES },
+    })
+    for (const n of out.positionedNodes) {
+      expect(n.depth).toBeLessThanOrEqual(MAX_VISIBLE_DEPTH)
+    }
+    expect(out.maxDepth).toBeLessThanOrEqual(MAX_VISIBLE_DEPTH)
+  })
+
+  it('collapses a real-shape graph (foundation → apps[c1..c9] → sentinel) to ≤4 visible depths', () => {
+    const nodes: FlowNode[] = [
+      leaf('foundation'),
+      group('apps'),
+      ...Array.from({ length: 10 }, (_, i) => leaf(`c${i}`)),
+      leaf('sentinel'),
+    ]
+    const rels: Relationship[] = [
+      ...Array.from({ length: 10 }, (_, i) => contains('apps', `c${i}`)),
+      fs('foundation', 'apps'),
+      fs('apps', 'sentinel'),
+    ]
+    const out = layout({
+      flow: FLOW,
+      nodes,
+      relationships: rels,
+      folded: new Set(),
+      hints: { perNode: HINTS, regions: REGIONS, families: FAMILIES },
+    })
+    // 1 (foundation) + 10 (children) + 1 (sentinel) = 12 nodes.
+    expect(out.positionedNodes.length).toBe(12)
+    expect(out.maxDepth).toBeLessThanOrEqual(2)
+  })
+
+  it('handles an empty group gracefully (no children → group still renders)', () => {
+    const nodes: FlowNode[] = [group('orphan-group')]
+    const rels: Relationship[] = []
+    const out = layout({
+      flow: FLOW,
+      nodes,
+      relationships: rels,
+      folded: new Set(),
+      hints: { perNode: HINTS, regions: REGIONS, families: FAMILIES },
+    })
+    // No children → no elision; the group still renders even though
+    // technically it has no `contains` edges (and thus isn't a
+    // "group" under the new contract). The node MUST still appear.
+    expect(out.positionedNodes.map((n) => n.id)).toEqual(['orphan-group'])
+  })
+})
+
+describe('@openova/flow-core layout — relationship-type edge tagging', () => {
+  it('preserves FS / SS / FF / SF / triggers as separate edge tags', () => {
+    const nodes: FlowNode[] = [leaf('a'), leaf('b'), leaf('c'), leaf('d'), leaf('e'), leaf('f')]
+    const rels: Relationship[] = [
+      { fromId: 'a', toId: 'b', type: 'finish-to-start' },
+      { fromId: 'b', toId: 'c', type: 'start-to-start' },
+      { fromId: 'c', toId: 'd', type: 'finish-to-finish' },
+      { fromId: 'd', toId: 'e', type: 'start-to-finish' },
+      { fromId: 'e', toId: 'f', type: 'triggers' },
+    ]
+    const out = layout({
+      flow: FLOW,
+      nodes,
+      relationships: rels,
+      folded: new Set(),
+      hints: { perNode: HINTS, regions: REGIONS, families: FAMILIES },
+    })
+    const byKey = new Map(out.edges.map((e) => [`${e.fromId}→${e.toId}`, e.relType]))
+    expect(byKey.get('a→b')).toBe('finish-to-start')
+    expect(byKey.get('b→c')).toBe('start-to-start')
+    expect(byKey.get('c→d')).toBe('finish-to-finish')
+    expect(byKey.get('d→e')).toBe('start-to-finish')
+    expect(byKey.get('e→f')).toBe('triggers')
+  })
+
+  it('does NOT count on-failure edges toward depth', () => {
+    const nodes: FlowNode[] = [leaf('a'), leaf('b'), leaf('c')]
+    const rels: Relationship[] = [
+      { fromId: 'a', toId: 'b', type: 'finish-to-start', condition: 'on-success' },
+      // failure overlay from b → c — must not push c past depth 1
+      // (since b is the only blocking pred of c is a failure-only edge).
+      { fromId: 'b', toId: 'c', type: 'finish-to-start', condition: 'on-failure' },
+    ]
+    const out = layout({
+      flow: FLOW,
+      nodes,
+      relationships: rels,
+      folded: new Set(),
+      hints: { perNode: HINTS, regions: REGIONS, families: FAMILIES },
+    })
+    const depthOf = new Map(out.positionedNodes.map((n) => [n.id, n.depth]))
+    expect(depthOf.get('a')).toBe(0)
+    expect(depthOf.get('b')).toBe(1)
+    expect(depthOf.get('c')).toBe(0)
+  })
+
+  it('tags cross-region edges with crossRegion=true', () => {
+    const regions = [
+      { id: 'eu', label: 'EU' },
+      { id: 'us', label: 'US' },
+    ]
+    const nodes: FlowNode[] = [
+      { ...leaf('a'), region: 'eu' },
+      { ...leaf('b'), region: 'us' },
+    ]
+    const rels: Relationship[] = [fs('a', 'b')]
+    const out = layout({
+      flow: FLOW,
+      nodes,
+      relationships: rels,
+      folded: new Set(),
+      hints: { perNode: HINTS, regions, families: FAMILIES },
+    })
+    expect(out.edges.length).toBe(1)
+    expect(out.edges[0].crossRegion).toBe(true)
+  })
+
+  it('tags cross-flow edges with crossFlow=true', () => {
+    const nodes: FlowNode[] = [
+      { id: 'a', flowId: 'flow-1', label: 'a', status: 'pending' },
+      { id: 'b', flowId: 'flow-2', label: 'b', status: 'pending' },
+    ]
+    const rels: Relationship[] = [
+      {
+        fromId: 'a',
+        toId: 'b',
+        fromFlowId: 'flow-1',
+        toFlowId: 'flow-2',
+        type: 'triggers',
+      },
+    ]
+    const out = layout({
+      flow: FLOW,
+      nodes,
+      relationships: rels,
+      folded: new Set(),
+      hints: { perNode: HINTS, regions: REGIONS, families: FAMILIES },
+    })
+    expect(out.edges.length).toBe(1)
+    expect(out.edges[0].crossFlow).toBe(true)
+  })
+})
+
+describe('@openova/flow-core layout — component metadata', () => {
+  it('emits connected-component info covering every node', () => {
+    const nodes: FlowNode[] = [leaf('a'), leaf('b'), leaf('c'), leaf('d')]
+    const rels: Relationship[] = [
+      fs('a', 'b'),
+      // c, d are isolated from a/b.
+      fs('c', 'd'),
+    ]
+    const out = layout({
+      flow: FLOW,
+      nodes,
+      relationships: rels,
+      folded: new Set(),
+      hints: { perNode: HINTS, regions: REGIONS, families: FAMILIES },
+    })
+    expect(out.components.length).toBe(2)
+    const memberCounts = out.components.map((c) => c.memberIds.length).sort()
+    expect(memberCounts).toEqual([2, 2])
+  })
+})
+
+describe('@openova/flow-core defaultFoldedAtDepth — cycle protection (bug #476)', () => {
+  it('returns within 100ms when a group references its own id as parent', () => {
+    const nodes: FlowNode[] = [group('g1')]
+    const rels: Relationship[] = [
+      // Self-pointing contains edge: g1 contains itself.
+      { fromId: 'g1', toId: 'g1', type: 'contains' },
+    ]
+    const out = deadline(
+      'self-cycle defaultFoldedAtDepth',
+      () => defaultFoldedAtDepth(nodes, rels, 1),
+      100,
+    )
+    expect(out.has('g1')).toBe(true)
+  })
+
+  it('depth=all returns an empty fold set', () => {
+    const nodes: FlowNode[] = [group('a'), leaf('b')]
+    const rels: Relationship[] = [contains('a', 'b')]
+    const out = defaultFoldedAtDepth(nodes, rels, 'all')
+    expect(out.size).toBe(0)
+  })
+})

--- a/products/openova-flow/core/test/types.test.ts
+++ b/products/openova-flow/core/test/types.test.ts
@@ -1,0 +1,100 @@
+/**
+ * @openova/flow-core — types snapshot. Compile-time only; the actual
+ * assertions are that the test type-checks. Runtime tests assert that
+ * the discriminated `FlowMessage` union has the documented set of
+ * variants.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { isBlockingRelationship } from '../src/index'
+import type {
+  FlowInstance,
+  FlowNode,
+  Relationship,
+  RelationshipType,
+  FlowMessage,
+  FlowAdapter,
+  StatusTone,
+} from '../src/index'
+
+describe('@openova/flow-core types — runtime predicates', () => {
+  it('classifies relationship types — `contains` is non-blocking, all others are blocking', () => {
+    const cases: Array<[RelationshipType, boolean]> = [
+      ['contains', false],
+      ['finish-to-start', true],
+      ['start-to-start', true],
+      ['finish-to-finish', true],
+      ['start-to-finish', true],
+      ['triggers', true],
+    ]
+    for (const [t, expected] of cases) {
+      expect(isBlockingRelationship(t)).toBe(expected)
+    }
+  })
+})
+
+describe('@openova/flow-core types — FlowMessage discriminator coverage', () => {
+  function describeMessage(m: FlowMessage): string {
+    switch (m.type) {
+      case 'snapshot':
+        return 'snapshot'
+      case 'upsert-flow':
+        return 'upsert-flow'
+      case 'upsert-nodes':
+        return 'upsert-nodes'
+      case 'upsert-rels':
+        return 'upsert-rels'
+      case 'delete-nodes':
+        return 'delete-nodes'
+      case 'delete-rels':
+        return 'delete-rels'
+    }
+  }
+
+  it('exhaustively handles all 6 wire messages', () => {
+    const flow: FlowInstance = { id: 'f', status: 'running', startedAt: 0 }
+    const node: FlowNode = { id: 'n', flowId: 'f', label: 'n', status: 'pending' }
+    const rel: Relationship = { fromId: 'a', toId: 'b', type: 'finish-to-start' }
+
+    const msgs: FlowMessage[] = [
+      { type: 'snapshot', flow, nodes: [node], relationships: [rel] },
+      { type: 'upsert-flow', flow },
+      { type: 'upsert-nodes', nodes: [node] },
+      { type: 'upsert-rels', relationships: [rel] },
+      { type: 'delete-nodes', ids: ['n'] },
+      { type: 'delete-rels', pairs: [{ fromId: 'a', toId: 'b', type: 'finish-to-start' }] },
+    ]
+    expect(msgs.map(describeMessage)).toEqual([
+      'snapshot',
+      'upsert-flow',
+      'upsert-nodes',
+      'upsert-rels',
+      'delete-nodes',
+      'delete-rels',
+    ])
+  })
+})
+
+describe('@openova/flow-core types — adapter shape compiles', () => {
+  it('accepts a minimum-viable FlowAdapter', () => {
+    const tone: StatusTone = {
+      fill: '#fff',
+      ring: '#000',
+      glyph: '#000',
+      glow: 'transparent',
+      edge: '#000',
+      arrow: '#000',
+      label: 'Test',
+    }
+    const adapter: FlowAdapter = {
+      schemaVersion: 1,
+      subscribe: (_id, _sink) => {
+        return () => {
+          /* noop */
+        }
+      },
+      statusPalette: { pending: tone },
+    }
+    expect(adapter.schemaVersion).toBe(1)
+  })
+})

--- a/products/openova-flow/core/tsconfig.json
+++ b/products/openova-flow/core/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2023",
+    "lib": ["ES2023", "DOM"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "skipLibCheck": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "verbatimModuleSyntax": true,
+    "moduleDetection": "force",
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "noEmit": true,
+    "types": []
+  },
+  "include": ["src/**/*", "test/**/*"]
+}

--- a/products/openova-flow/core/vitest.config.ts
+++ b/products/openova-flow/core/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['test/**/*.test.ts', 'test/**/*.test.tsx'],
+  },
+})


### PR DESCRIPTION
## OpenovaFlow Foundation — Agent #1 of 3

This PR ships the TypeScript foundation for the standalone OpenovaFlow product. It is Agent #1 of a 3-agent fan-out; Agents #2 (server) and #3 (catalyst-api adapter) follow.

```
                ┌───────────────────────────────────────────────────────┐
                │                  OpenovaFlow Foundation                │
                │                                                       │
   Agent #1 ──> │  @openova/flow-core   (types + pure layout)           │
                │  @openova/flow-canvas (React SVG, zero OpenOva imports)│
                │  lib/flow-bridge.ts   (Job[] → FlowNode + Relationship)│
                │                                                       │
   Agent #2 ──> │  catalyst-api server: SSE FlowMessage stream          │
                │  per CONTRACT.md                                      │
                │                                                       │
   Agent #3 ──> │  FlowAdapter implementation against catalyst-api      │
                │  retire lib/flowLayoutOrganic.ts +                    │
                │  sovereign/FlowCanvasOrganic.tsx                      │
                └───────────────────────────────────────────────────────┘
```

## Summary

- **`@openova/flow-core`** — plugin-shaped contract (`FlowInstance`, `FlowNode`, `Relationship`, `FlowMessage`, `FlowAdapter`) + pure layout engine. Zero runtime side effects, zero React-DOM.
- **`@openova/flow-canvas`** — React SVG canvas, zero OpenOva imports. Theme-decoupled via `--flow-*` CSS variables. Renders all 6 RelationshipTypes per the founder-locked visual style table.
- **`flow-bridge.ts`** — single-responsibility adapter that converts the legacy Catalyst `Job[]` into `FlowNode + Relationship[]`. Mediates between the existing catalyst-api SSE endpoint and the new contract.
- **`FlowPage.tsx`** — refactored to drive `@openova/flow-canvas` via the bridge. Legacy `FlowCanvasOrganic` + `flowLayoutOrganic` remain in place for non-FlowPage consumers (JobsTable rollups, JobDetail breadcrumbs) until Agent #3 retires them.

## Canonical seams cited (ARCHITECT-FIRST)

1. **Layout algorithm** — port of `products/catalyst/bootstrap/ui/src/lib/flowLayoutOrganic.ts`. Preserves: cycle-safety in parent-chain walks (bug #476), fold-aware rewiring + parent-elision + outbound/inbound fan-out (bug #481 round 2), `MAX_VISIBLE_DEPTH=8` defence-in-depth cap, global topological-sort `depRank` (issue #532).
2. **CSS-variable theming pattern** — mirrors `products/catalyst/bootstrap/ui/src/app/globals.css` (`--bubble-*` tokens + `[data-theme="light"]` flips). New tokens namespaced as `--flow-*` inside `.flow-canvas-host` so they don't leak into the host page's cascade.
3. **Monorepo workspace decision** — the repo has NO root `workspaces:` field today (`package.json` files exist independently per `products/<x>` and `core/<x>`). This PR follows that pattern: each package has its own `package.json` + `tsconfig.json`; consumers wire via tsconfig `paths` + Vite resolve aliases. A real `npm workspaces` setup is a follow-up that doesn't need to gate this PR.

## Migration table — old type → new type

| Legacy (`jobs.types.ts`) | New (`@openova/flow-core`) |
|---|---|
| `Job.id` | `FlowNode.id` |
| `Job.appId / jobName / displayName` | `FlowNode.meta.appId / jobName / displayName` (opaque) |
| `Job.parentId` | `Relationship { fromId:job, toId:parent, type:'contains' }` |
| `Job.dependsOn[]` | `Relationship { fromId:dep, toId:job, type:'finish-to-start', condition:'on-success' }` |
| `Job.childIds[]` | derived from inbound `contains` relationships |
| `Job.status: 'pending' \| 'running' \| 'succeeded' \| 'failed'` | `FlowNode.status: string` (open vocab; adapter palette keys it) |
| `Job.startedAt / finishedAt: string \| null` (ISO) | `FlowNode.startedAt / endedAt: number \| undefined` (unix ms) |
| `OrganicNodeHints.regionId / familyId` | `FlowLayoutHint.region / family` |
| `OrganicEdge.kind: 'depends-on' \| 'parent-child'` | `PositionedEdge.relType: RelationshipType` (6 types + condition) |

## Edge visual style table (founder-locked)

| Relationship type | Stroke | Annotation | Counted for depth? |
|---|---|---|---|
| `finish-to-start` (FS) | solid | normal arrow | yes |
| `start-to-start` (SS) | solid | "SS" tag near origin | yes |
| `finish-to-finish` (FF) | solid | "FF" tag near terminus | yes |
| `start-to-finish` (SF) | dashed | "SF" tag at midpoint | yes |
| `triggers` | solid | ⚡ at midpoint | yes |
| `contains` | NOT rendered as an edge | grouping only | n/a |
| `condition: 'on-failure'` | red dashed, low-opacity until pred failed | normal arrow | **NO** |

## Test plan

### CI gate (this PR)
- [x] `tsc --noEmit` clean on `core/` (`tsconfig.json`)
- [x] `tsc --noEmit` clean on `canvas/` (`tsconfig.json`)
- [x] `tsc --noEmit` clean on `catalyst-ui` (`tsconfig.app.json`)
- [x] `vitest run --pool=threads --maxWorkers=2 --no-isolate` — `core/` (20 tests pass)
- [x] `vitest run --pool=threads --maxWorkers=2 --no-isolate` — `canvas/` (9 tests pass)
- [x] `vitest run --pool=threads --maxWorkers=2 --no-isolate` — `flow-bridge.test.ts` (11 tests pass)
- [x] `vitest run --pool=threads --maxWorkers=2 --no-isolate` — `FlowPage.test.tsx` (9 tests pass)
- [x] Legacy `flowLayoutOrganic.test.ts` still passes (12/12)

### Post-merge integration with Agents #2/#3
- [ ] On prov #34 (multi-region fixture), catalyst-ui renders cross-region bubbles via `lib/flow-bridge.ts` alone — even WITHOUT the new server. The bridge maps `Job.region` (when catalyst-api begins emitting it) into `FlowNode.region` opaquely, so the UI is shape-ready before Agent #2's SSE endpoint exists.
- [ ] After Agent #2 ships, point `useDeploymentEvents` at the new endpoint; bridge becomes pass-through.
- [ ] After Agent #3 ships the proper `FlowAdapter`, delete `lib/flow-bridge.ts` + legacy `FlowCanvasOrganic.tsx` + `flowLayoutOrganic.ts`.

### Founder UAT (post-Agent #3, on console.openova.io)
- [ ] Open `/sovereign/provision/<id>/flow` — bubbles render, edges connect, fold controls work.
- [ ] Single-click on a bubble opens the log pane (LogPane unchanged).
- [ ] Double-click on a leaf navigates to `/jobs/<id>`.
- [ ] Double-click on a group toggles fold.
- [ ] Multi-region prov shows distinct region descriptors (post-Agent #2).
- [ ] Light/dark theme flip works without remount.

## Constraints honoured
- Two-repo discipline: lands entirely in `openova-io/openova` (public). No openova-private touched.
- No `npm run build` / `next build` / `vite build` / `playwright install` / `playwright test`.
- No `kubectl apply`. No chart manifests touched.
- No hardcoded URLs, region names, k3s flags, chart versions.
- All image refs (none in this PR) would flow through Harbor mirrors per MIRROR-EVERYTHING.
- `vitest --pool=threads --maxWorkers=2 --no-isolate` everywhere.
- `isolation: "worktree"` — this PR was authored entirely in an agent worktree.

## Notes
- Some pre-existing test failures in `src/pages/sovereign/AppsPage.test.tsx` / `SettingsPage.test.tsx` / `AppDetail.test.tsx` exist on `main` (No QueryClient set — test infra issue). Verified independently by running them on `origin/main` — unrelated to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)