### PR TITLE
fix(openova-flow): tsc paths for cross-workspace canvas source (B&D #16ec3399 fix)

### DIFF
--- a/products/catalyst/bootstrap/ui/tsconfig.app.json
+++ b/products/catalyst/bootstrap/ui/tsconfig.app.json
@@ -27,8 +27,15 @@
     "paths": {
       "@/*": ["./src/*"],
       "@openova/flow-core": ["../../../openova-flow/core/src/index.ts"],
-      "@openova/flow-canvas": ["../../../openova-flow/canvas/src/index.ts"]
+      "@openova/flow-canvas": ["../../../openova-flow/canvas/src/index.ts"],
+      "react": ["./node_modules/react"],
+      "react/*": ["./node_modules/react/*"],
+      "react-dom": ["./node_modules/react-dom"],
+      "react-dom/*": ["./node_modules/react-dom/*"],
+      "d3-force": ["./node_modules/d3-force"],
+      "d3-drag": ["./node_modules/d3-drag"],
+      "d3-selection": ["./node_modules/d3-selection"]
     }
   },
-  "include": ["src"]
+  "include": ["src", "../../../openova-flow/core/src/**/*", "../../../openova-flow/canvas/src/**/*"]
 }


### PR DESCRIPTION
## Bug

PR #1389 (merged at \`16ec3399\`) shipped OpenovaFlow foundation with Vite aliases for \`@openova/flow-core\` + \`@openova/flow-canvas\` plus bare-spec aliases for \`react\` / \`d3-*\`. Vite happily resolves those. Build-ui Docker image runs \`tsc\` separately and fails:

\`\`\`
../../../openova-flow/canvas/src/FlowCanvas.tsx(32,67): error TS2307: Cannot find module 'react'
../../../openova-flow/canvas/src/FlowCanvas.tsx(43,8):  error TS2307: Cannot find module 'd3-force'
... (~20 errors)
\`\`\`

Root cause: \`moduleResolution: "bundler"\` resolves from the *imported file's* directory. Canvas source is at \`products/openova-flow/canvas/src/\` with no sibling \`node_modules\`. Bare imports fall off the chain.

## Fix

Add explicit \`paths\` to \`products/catalyst/bootstrap/ui/tsconfig.app.json\` mirroring the \`vite.config.ts\` aliases — both resolvers now agree. Also extend \`include\` so canvas + core sources land in the catalyst-ui compilation root and any future regressions surface at PR CI, not build-image time.

Workspaces will supersede this once Agent #2+#3 wire real workspaces.