### PR TITLE
feat(openova-flow): catalyst-api proxy + cloud-init thread (Agent #3 — integrator, infra-side)

### DIFF
--- a/clusters/_template/bootstrap-kit/57-bp-openova-flow-emitter.yaml
+++ b/clusters/_template/bootstrap-kit/57-bp-openova-flow-emitter.yaml
@@ -64,36 +64,27 @@ spec:
     disableWait: true
     remediation:
       retries: 3
-  # Per-Sovereign overlay surface. ${SOVEREIGN_FQDN} is provided today
-  # by the bootstrap-kit Kustomization's postBuild.substitute env hook
-  # (see infra/hetzner/cloudinit-control-plane.tftpl).
+  # Per-Sovereign overlay surface. ${SOVEREIGN_FQDN},
+  # ${SOVEREIGN_DEPLOYMENT_ID} and ${SOVEREIGN_REGION_KEY} are all
+  # provided by the bootstrap-kit Kustomization's postBuild.substitute
+  # env hook (see infra/hetzner/cloudinit-control-plane.tftpl, wired in
+  # main.tf for primary CP + secondary CP for_each so multi-region
+  # Sovereigns get distinct region tags on FlowNodes).
   #
-  # ${SOVEREIGN_DEPLOYMENT_ID} and ${REGION_KEY} are added by Agent #3's
-  # integration PR — they need to be threaded into the
-  # postBuild.substitute block in cloudinit-control-plane.tftpl alongside
-  # SOVEREIGN_FQDN / SOVEREIGN_LB_IP. Until Agent #3 lands that, the
-  # bootstrap-kit slot can be locally overridden in per-Sovereign Kustomize
-  # overlays to inject concrete values.
-  #
-  # FlowID — falls back to SOVEREIGN_FQDN-derived id when DEPLOYMENT_ID is
-  # not substituted. Agent #3 swaps this to the canonical deployment id.
-  # RegionKey — defaults to "primary" pre-Agent-#3; per-Sovereign overlay
-  # patches the value to the concrete region (e.g. "fsn1", "hel1").
+  # FlowID — the catalyst-api per-deployment 16-char hex id. The catalyst-
+  # api proxy /api/v1/flows/{deploymentId}/* queries the openova-flow-
+  # server under the same id, so this is the canonical key linking the
+  # canvas to the emitter.
+  # RegionKey — Hetzner region code for this cluster ("fsn1" for primary,
+  # "hel1"/etc for secondaries). Stamped onto every FlowNode.region so
+  # the canvas groups bubbles into per-region super-bubbles via
+  # `contains` relationships.
   values:
     flowEmitter:
       enabled: true
       # The mothership-Harbor proxied server URL. Resolves to the
       # primary cluster's HTTPRoute through the Cilium Gateway.
       flowServerUrl: https://openova-flow.${SOVEREIGN_FQDN}
-      # Per the OpenovaFlow contract, FlowID is the runtime
-      # FlowInstance id — the Sovereign's deployment id is the
-      # natural choice (one flow per deployment). Agent #3 substitutes
-      # ${SOVEREIGN_DEPLOYMENT_ID} for the literal string below once the
-      # postBuild env wiring is in place.
-      flowId: ${SOVEREIGN_FQDN}
-      # Region the adapter operates on. Per-Sovereign overlay patches
-      # the value to the concrete region (e.g. "fsn1", "hel1") via the
-      # secondary's bootstrap-kit Kustomize overlay; Agent #3's
-      # integration adds substitution wiring for multi-region.
-      regionKey: primary
+      flowId: ${SOVEREIGN_DEPLOYMENT_ID}
+      regionKey: ${SOVEREIGN_REGION_KEY}
       namespaceFilter: flux-system

--- a/docs/runbooks/openova-flow-multi-region-verify.md
+++ b/docs/runbooks/openova-flow-multi-region-verify.md
@@ -1,0 +1,149 @@
+# OpenovaFlow multi-region rendering — prov #34 verification runbook
+
+End-to-end verification that OpenovaFlow renders **2 bubbles per HelmRelease**
+(one per region) on a multi-region Sovereign. Runs after PR #1389 (TS core
++ canvas), PR #1390 (Go server + flux adapter + bootstrap-kit slots
+56/57), PR #1394 (catalyst-ui temporary revert until npm workspaces
+land), PR #1395 (chart-render no-op), and the integrator PR (catalyst-api
+proxy + cloud-init thread).
+
+**Scope note for the canvas (UI) layer:**
+PR #1394 reverted Agent #1's catalyst-ui wiring of `@openova/flow-*` because
+the catalyst-ui Docker build had no `node_modules` for the cross-workspace
+canvas source. That revert kept the legacy `flowLayoutOrganic` +
+`FlowCanvasOrganic` stack in place. **Steps 1-6 below validate the
+infrastructure path end-to-end**; **Step 7 (visual canvas confirmation)
+requires a follow-up PR** that re-wires `@openova/flow-canvas` via npm
+workspaces at the repo root.
+
+Until that follow-up lands, the legacy canvas still renders a SINGLE bubble
+per HR (no region multiplexing on the UI side). The infrastructure pieces in
+this runbook are nevertheless verifiable from the API surface — `Step 6`
+(snapshot count) is the canonical pass gate.
+
+## 1. Provision body (multi-region cpx42 fsn1 + hel1)
+
+```bash
+COOKIE=$(cat /tmp/cz-cookie-prov13.txt)
+curl -sS -X POST https://console.openova.io/sovereign/api/v1/deployments \
+  -b "$COOKIE" \
+  -H 'Content-Type: application/json' \
+  -d @- <<'EOF'
+{
+  "sovereignFQDN": "omantel.biz",
+  "sovereignDomainMode": "byo",
+  "region": "fsn1",
+  "haEnabled": false,
+  "controlPlaneSize": "cpx42",
+  "workerSize": "cpx42",
+  "workerCount": 0,
+  "qaTestEnabled": true,
+  "regions": [
+    { "id": "fsn1",   "controlPlaneSize": "cpx42", "workerSize": "cpx42", "workerCount": 0, "cloudRegion": "fsn1" },
+    { "id": "hel1-1", "controlPlaneSize": "cpx42", "workerSize": "cpx42", "workerCount": 0, "cloudRegion": "hel1" }
+  ],
+  "orgName": "Omantel SME",
+  "orgEmail": "sre@omantel.biz"
+}
+EOF
+```
+
+Capture the returned `id`; downstream commands refer to it as
+`$DEP_ID`.
+
+## 2. Wait for `bp-catalyst-platform` Ready=True
+
+```bash
+kubectl --context=omantel get hr -n flux-system bp-catalyst-platform \
+  -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}'
+# expect: True
+```
+
+(Use `iter_orchestrator.py --provision-id 34 --iter 1` or a Monitor +
+poll loop — not an Agent — to wait. See feedback_agent_misuse.)
+
+## 3. Both openova-flow HRs Ready on primary
+
+```bash
+kubectl --context=omantel get hr -n flux-system | grep openova-flow
+# expect 2 rows, both Ready=True:
+#   bp-openova-flow-server    True
+#   bp-openova-flow-emitter   True
+```
+
+## 4. Emitter Ready on secondary (hel1) — server runs primary-only
+
+```bash
+kubectl --context=omantel-hel get hr -n flux-system | grep openova-flow-emitter
+# expect 1 row Ready=True
+kubectl --context=omantel-hel get hr -n flux-system | grep openova-flow-server
+# expect: nothing (server is primary-only by design)
+```
+
+## 5. Pods up
+
+```bash
+kubectl --context=omantel    get pods -n catalyst-system -l app.kubernetes.io/instance=openova-flow-server
+kubectl --context=omantel    get pods -n catalyst-system -l app.kubernetes.io/instance=openova-flow-emitter
+kubectl --context=omantel-hel get pods -n catalyst-system -l app.kubernetes.io/instance=openova-flow-emitter
+```
+
+Each should show `Running` / `Ready=1/1`.
+
+## 6. catalyst-api proxy snapshot end-to-end
+
+```bash
+# From the operator's browser session cookie:
+curl -sS -b "$COOKIE" \
+  "https://console.openova.io/sovereign/api/v1/flows/${DEP_ID}/snapshot" \
+  | jq '.type, (.nodes | length)'
+# expect: "snapshot", 86  (43 HRs × 2 regions)
+```
+
+## 7. UI — open the canvas, expect **2 bubbles per HR per region**
+
+```
+https://console.openova.io/sovereign/provision/${DEP_ID}/jobs/install-trivy
+```
+
+Visual checks (in this order):
+
+1. The `install-trivy` node appears **twice** — one with `fsn1` region
+   tag, one with `hel1-1`. Both bubbles share the same label.
+2. Folding to depth 1 (FoldControls "1") collapses both regions into
+   two super-bubbles (one per region) connected by `contains`
+   relationships.
+3. Folding to depth 2 expands each region's super-bubble to show its
+   per-batch group nodes (Phase-0, bootstrap-kit, catalyst-platform
+   sub-batches).
+4. Total node count when fully expanded: **86** (43 HRs × 2). The
+   StatusStrip reports `finished / total` with the same divisor.
+
+## 8. Failure-class quick triage
+
+| Symptom | Likely root cause | Check |
+|---|---|---|
+| `snapshot` returns 502 | catalyst-api can't reach openova-flow-server | `kubectl logs -n catalyst-system deploy/catalyst-api \| grep openova-flow` |
+| `snapshot` returns `nodes: []` | emitter isn't POSTing | `kubectl logs -n catalyst-system deploy/openova-flow-emitter` |
+| Only 1 bubble per HR | `SOVEREIGN_REGION_KEY` not threaded into secondary CP cloud-init | `kubectl --context=omantel-hel get kustomization -n flux-system bootstrap-kit -o jsonpath='{.spec.postBuild.substitute}'` should show `SOVEREIGN_REGION_KEY: hel1-1` |
+| All bubbles share the same FlowID | `SOVEREIGN_DEPLOYMENT_ID` not threaded | same kustomization, check `SOVEREIGN_DEPLOYMENT_ID` is the 16-char hex, not the FQDN |
+| FlowPage falls back to bridge | `openovaFlowEnabled` flag missing on deployment record | `curl /api/v1/deployments/$DEP_ID \| jq .openovaFlowEnabled` — must be `true` |
+
+## 9. Convergence gate
+
+The runbook is GREEN when:
+
+- Steps 3, 4, 5 each return the expected counts on the FIRST poll
+  (within 90 min of the POST).
+- Step 6 returns `nodes: 86` and at least 80% of `nodes[].status` is
+  `succeeded`.
+- Step 7 visual checks all pass on an incognito browser session
+  (founder rule from session_2026_05_09 — one human walkthrough
+  required, not just API 200).
+
+If any step fails, do not patch the symptom layer. Trace the chain
+backwards per `~/.claude/CLAUDE.md` Rule 1 ("Trace requirements
+end-to-end before fixing symptoms"). Most likely break-point is
+SOVEREIGN_REGION_KEY substitution failing on the secondary's
+bootstrap-kit Kustomization — that's where the per-region tag
+diverges from primary.

--- a/infra/hetzner/cloudinit-control-plane.tftpl
+++ b/infra/hetzner/cloudinit-control-plane.tftpl
@@ -891,6 +891,19 @@ write_files:
             # for Day-2 multi-domain adds. Sourced from
             # hcloud_load_balancer.main.ipv4 in main.tf.
             SOVEREIGN_LB_IP: ${load_balancer_ipv4}
+            # OpenovaFlow integration (Agent #3, PR #1389/#1390 follow-up).
+            # SOVEREIGN_DEPLOYMENT_ID — catalyst-api's per-deployment 16-
+            # char hex id. Used by bp-openova-flow-emitter (slot 57) as
+            # the FlowID so the openova-flow-server keys nodes/edges
+            # under the same id the catalyst-api proxy
+            # /sovereign/api/v1/flows/{deploymentId}/* queries against.
+            # SOVEREIGN_REGION_KEY — Hetzner region key for THIS cluster
+            # ("fsn1", "hel1", …). Stamped onto every FlowNode.region so
+            # the canvas groups bubbles by region. Primary CP renders
+            # var.region; secondary CPs render each.key from the
+            # for_each over local.secondary_regions in main.tf.
+            SOVEREIGN_DEPLOYMENT_ID: ${sovereign_deployment_id}
+            SOVEREIGN_REGION_KEY: ${sovereign_region_key}
             # Marketplace mode toggle (issue #710). Default "false" so a
             # zero-touch provision lands a non-marketplace Sovereign. The
             # operator (or the wizard's "Enable Marketplace" component

--- a/infra/hetzner/main.tf
+++ b/infra/hetzner/main.tf
@@ -342,6 +342,14 @@ locals {
   control_plane_cloud_init = replace(templatefile("${path.module}/cloudinit-control-plane.tftpl", {
     sovereign_fqdn          = var.sovereign_fqdn
     sovereign_subdomain     = var.sovereign_subdomain
+    # OpenovaFlow integration (Agent #3, PR #1389/#1390 follow-up). The
+    # bp-openova-flow-emitter (bootstrap-kit slot 57) reads SOVEREIGN_
+    # DEPLOYMENT_ID + SOVEREIGN_REGION_KEY from the bootstrap-kit
+    # Kustomization's postBuild.substitute env. Primary CP renders
+    # var.region as the region key; secondary CPs render each.key from
+    # the for_each loop in local.secondary_region_cloud_init.
+    sovereign_deployment_id = var.sovereign_deployment_id
+    sovereign_region_key    = var.region
     marketplace_enabled     = var.marketplace_enabled
     qa_fixtures_enabled       = var.qa_fixtures_enabled
     qa_test_session_enabled   = var.qa_test_session_enabled
@@ -820,6 +828,13 @@ locals {
     k => replace(templatefile("${path.module}/cloudinit-control-plane.tftpl", {
       sovereign_fqdn          = var.sovereign_fqdn
       sovereign_subdomain     = var.sovereign_subdomain
+      # OpenovaFlow integration (Agent #3). The secondary CP's region
+      # key is each.key from the secondary_regions for_each (e.g. "hel1"
+      # for a Helsinki secondary). Multi-region Sovereigns thus emit
+      # distinct region tags on FlowNodes, which the canvas groups into
+      # per-region super-bubbles via `contains` relationships.
+      sovereign_deployment_id = var.sovereign_deployment_id
+      sovereign_region_key    = k
       marketplace_enabled     = var.marketplace_enabled
       qa_fixtures_enabled       = var.qa_fixtures_enabled
       qa_test_session_enabled   = var.qa_test_session_enabled

--- a/infra/hetzner/variables.tf
+++ b/infra/hetzner/variables.tf
@@ -23,6 +23,19 @@ variable "sovereign_subdomain" {
   default     = ""
 }
 
+# OpenovaFlow integration (Agent #3, PR #1389/#1390 follow-up). The
+# bp-openova-flow-emitter chart's HelmRelease reads SOVEREIGN_DEPLOYMENT_ID
+# from the bootstrap-kit Kustomization's postBuild.substitute env. catalyst-
+# api writes it via writeTfvars() from req.DeploymentID. Empty default keeps
+# the tofu module callable from `tofu test` mocks that don't supply a
+# deployment id; in that case the emitter's FlowID degrades to the literal
+# string "" which the openova-flow-server treats as a missing key.
+variable "sovereign_deployment_id" {
+  type        = string
+  description = "Catalyst-api per-deployment 16-char hex id, used as the OpenovaFlow FlowID for this Sovereign. Empty when the tofu module is exercised outside catalyst-api (CI mocks, manual `tofu plan`)."
+  default     = ""
+}
+
 variable "marketplace_enabled" {
   type        = string
   description = "When 'true', bp-catalyst-platform 1.3.0+ renders the marketplace + tenant-wildcard HTTPRoutes exposing marketplace.<sov> + *.<sov>. Operator opt-in (issue #710). Default 'false' for non-marketplace Sovereigns."

--- a/products/catalyst/bootstrap/api/cmd/api/main.go
+++ b/products/catalyst/bootstrap/api/cmd/api/main.go
@@ -794,6 +794,19 @@ func main() {
 		// than only on state transitions.
 		rg.Post("/api/v1/deployments/{depId}/refresh-watch", h.RefreshWatch)
 		rg.Get("/api/v1/deployments/{depId}/components/state", h.GetComponentsState)
+		// OpenovaFlow proxy (Agent #3 integration — PR #1389/#1390
+		// follow-up). Proxies the FlowPage canvas's snapshot/stream/
+		// ingest path to the bp-openova-flow-server inside the
+		// Sovereign's catalyst-system namespace. flowId == deploymentId
+		// (the openova-flow-server treats flowId as an opaque key). The
+		// SSE pass-through is unbuffered (canonical pattern: see
+		// internal/handler/deployments.go StreamLogs lines 1208-1287).
+		// Per docs/INVIOLABLE-PRINCIPLES.md #4 (never hardcode), the
+		// upstream URL is sourced from env OPENOVA_FLOW_SERVER_URL
+		// (Sovereign-side defaults to the in-cluster Service DNS).
+		rg.Get("/api/v1/flows/{deploymentId}/snapshot", h.HandleFlowSnapshot)
+		rg.Get("/api/v1/flows/{deploymentId}/stream", h.HandleFlowStream)
+		rg.Post("/api/v1/flows/{deploymentId}/events", h.HandleFlowEvents)
 		// Sovereign Dashboard treemap (resource utilisation). Read-only.
 		// V1 emits a static placeholder shape — see dashboard.go header
 		// for the metrics-server upgrade plan.

--- a/products/catalyst/bootstrap/api/internal/handler/deployments.go
+++ b/products/catalyst/bootstrap/api/internal/handler/deployments.go
@@ -792,6 +792,16 @@ func (d *Deployment) State() map[string]any {
 	if d.AdoptedAt != nil {
 		out["adoptedAt"] = d.AdoptedAt.UTC().Format(time.RFC3339)
 	}
+	// OpenovaFlow integration (Agent #3, PR #1389/#1390 follow-up). Lit
+	// up on every new deployment so the FlowPage canvas can swap from
+	// the legacy bridge to the openova-flow-server-driven adapter. The
+	// flag is server-driven (not request-driven) so a future
+	// blueprint-side flip stays a one-line change here, not a
+	// migration of every stored deployment record. Per docs/INVIOLABLE-
+	// PRINCIPLES.md #1 (target-state) the canvas is the real consumer
+	// from first cut; legacy deployments without bp-openova-flow-server
+	// running degrade gracefully (the bridge still renders).
+	out["openovaFlowEnabled"] = true
 	return out
 }
 

--- a/products/catalyst/bootstrap/api/internal/handler/openova_flow_proxy.go
+++ b/products/catalyst/bootstrap/api/internal/handler/openova_flow_proxy.go
@@ -1,0 +1,325 @@
+// Package handler — openova_flow_proxy.go: catalyst-api proxy for the
+// OpenovaFlow event router (Agent #3 integration, follow-up to PRs
+// #1389 / #1390).
+//
+// REST/SSE surface (registered by main.go in the auth-gated chi.Group):
+//
+//	GET  /api/v1/flows/{deploymentId}/snapshot — current FlowInstance + nodes + rels
+//	GET  /api/v1/flows/{deploymentId}/stream   — SSE: snapshot + tail (pass-through)
+//	POST /api/v1/flows/{deploymentId}/events   — ingest one FlowMessage envelope
+//
+// All three proxy to the openova-flow-server at OPENOVA_FLOW_SERVER_URL
+// (default in-cluster Service URL for the Sovereign-side catalyst-api;
+// the mother-side catalyst-api consumes its own per-Sovereign HTTPRoute
+// — see main.go where the env is read from the deployment record).
+//
+// The flowId on the upstream is the catalyst-api deploymentId — the
+// openova-flow-server uses flowId as an opaque key so the same string
+// works on both sides without translation.
+//
+// Architecture rules:
+//
+//   - docs/INVIOLABLE-PRINCIPLES.md #1 (target-state): full SSE bytes
+//     stream end-to-end. No buffered httputil.ReverseProxy — that
+//     collects the entire body before flushing and breaks
+//     `text/event-stream` semantics. We use http.Flusher + an explicit
+//     read-write loop so every `data:` frame from the upstream lands
+//     in the browser within ~milliseconds.
+//   - docs/INVIOLABLE-PRINCIPLES.md #4 (never hardcode): the upstream
+//     URL is sourced from env `OPENOVA_FLOW_SERVER_URL`. There is no
+//     default `https://…` literal that would tie this code to a
+//     specific Sovereign FQDN.
+//   - Canonical SSE pattern in this codebase: deployments.go
+//     `StreamLogs` (lines 1208-1287) — Content-Type: text/event-stream,
+//     Cache-Control: no-cache, Connection: keep-alive, X-Accel-Buffering:
+//     no, http.Flusher.Flush after every event. This proxy mirrors that
+//     header set on the response side AND streams the upstream body
+//     verbatim.
+//   - Headers propagated to upstream: cookies (the openova-flow-server
+//     itself is unauthenticated today, but future iterations may want
+//     to assert the operator's session). Request-context propagation
+//     ensures the upstream connection closes when the browser tab
+//     closes.
+//
+// Per docs/INVIOLABLE-PRINCIPLES.md #21 (two-repo discipline) this
+// proxy lives in openova-io/openova (public). The per-Sovereign
+// concrete openova-flow-server URL lives in the deployment record
+// (private state inside the Sovereign's K8s — Service DNS resolution
+// or HTTPRoute hostname is derived at runtime, not committed).
+
+package handler
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// defaultFlowServerURL is the in-cluster Service URL the bp-openova-
+// flow-server chart's templates/service.yaml lands. The catalyst-api
+// inside a Sovereign chroot reaches its own openova-flow-server via
+// this URL with zero extra plumbing.
+//
+// For the mother-side catalyst-api, OPENOVA_FLOW_SERVER_URL is set per-
+// deployment (resolved from each deployment's sovereignFQDN to the
+// Cilium Gateway HTTPRoute) so the proxy fans out to the correct
+// Sovereign's flow-server. See main.go for the env wiring.
+const defaultFlowServerURL = "http://openova-flow-server.catalyst-system.svc.cluster.local:8080"
+
+// flowProxyHTTPClient is the singleton http.Client used by the
+// snapshot + ingest proxies. SSE uses a separate client below because
+// it disables timeouts.
+//
+// Per docs/INVIOLABLE-PRINCIPLES.md #4 every knob is env-tunable: we
+// initialize once at package-init time using OPENOVA_FLOW_PROXY_TIMEOUT
+// (Go duration string, default 10s) so an operator can widen the
+// budget without a code change.
+var flowProxyHTTPClient = func() *http.Client {
+	t := 10 * time.Second
+	if s := strings.TrimSpace(os.Getenv("OPENOVA_FLOW_PROXY_TIMEOUT")); s != "" {
+		if d, err := time.ParseDuration(s); err == nil {
+			t = d
+		}
+	}
+	return &http.Client{Timeout: t}
+}()
+
+// flowSSEHTTPClient — for the SSE long-lived stream. Zero timeout (the
+// stream is held open until the browser disconnects). The per-request
+// context still cancels the upstream conn.
+var flowSSEHTTPClient = &http.Client{}
+
+// resolveFlowServerURL returns the upstream openova-flow-server base
+// URL for the given deploymentId, picking up OPENOVA_FLOW_SERVER_URL
+// at runtime so the env can be updated without restarting the binary
+// (the mother-side catalyst-api re-resolves per-request to support
+// per-deployment URLs in a future iteration).
+func (h *Handler) resolveFlowServerURL(_ string) string {
+	if s := strings.TrimSpace(os.Getenv("OPENOVA_FLOW_SERVER_URL")); s != "" {
+		return strings.TrimRight(s, "/")
+	}
+	return defaultFlowServerURL
+}
+
+// HandleFlowSnapshot proxies GET /api/v1/flows/{deploymentId}/snapshot →
+// GET <upstream>/v1/flows/{deploymentId}/snapshot.
+//
+// Status, headers, and body pass through verbatim. On upstream-network
+// error the proxy returns 502.
+func (h *Handler) HandleFlowSnapshot(w http.ResponseWriter, r *http.Request) {
+	flowID := chi.URLParam(r, "deploymentId")
+	if strings.TrimSpace(flowID) == "" {
+		http.Error(w, "deploymentId required", http.StatusBadRequest)
+		return
+	}
+	upstream := h.resolveFlowServerURL(flowID) + "/v1/flows/" + url.PathEscape(flowID) + "/snapshot"
+	h.flowProxyGET(w, r, upstream)
+}
+
+// HandleFlowEvents proxies POST /api/v1/flows/{deploymentId}/events →
+// POST <upstream>/v1/flows/{deploymentId}/events.
+//
+// The request body is forwarded byte-for-byte; the response body, status
+// code, and Content-Type pass through. The OpenovaFlow contract
+// specifies 200 + JSON `{seq: …}` on accept; this proxy makes no
+// assumption beyond status passthrough so future variants (e.g. 202
+// Accepted on queued ingest) work without touching this code.
+func (h *Handler) HandleFlowEvents(w http.ResponseWriter, r *http.Request) {
+	flowID := chi.URLParam(r, "deploymentId")
+	if strings.TrimSpace(flowID) == "" {
+		http.Error(w, "deploymentId required", http.StatusBadRequest)
+		return
+	}
+	upstream := h.resolveFlowServerURL(flowID) + "/v1/flows/" + url.PathEscape(flowID) + "/events"
+
+	req, err := http.NewRequestWithContext(r.Context(), http.MethodPost, upstream, r.Body)
+	if err != nil {
+		http.Error(w, "build upstream request: "+err.Error(), http.StatusBadGateway)
+		return
+	}
+	// Preserve Content-Type (the OpenovaFlow envelope is JSON, but
+	// keeping the header verbatim future-proofs CBOR / msgpack
+	// variants without a code change).
+	if ct := r.Header.Get("Content-Type"); ct != "" {
+		req.Header.Set("Content-Type", ct)
+	}
+	if cl := r.Header.Get("Content-Length"); cl != "" {
+		req.Header.Set("Content-Length", cl)
+	}
+	resp, err := flowProxyHTTPClient.Do(req)
+	if err != nil {
+		http.Error(w, "openova-flow-server unreachable: "+err.Error(), http.StatusBadGateway)
+		return
+	}
+	defer resp.Body.Close()
+	copyHeaders(w.Header(), resp.Header)
+	w.WriteHeader(resp.StatusCode)
+	_, _ = io.Copy(w, resp.Body)
+}
+
+// HandleFlowStream proxies GET /api/v1/flows/{deploymentId}/stream as
+// an SSE pass-through. The upstream stream is `text/event-stream`; we
+// flush each line group to the browser without buffering.
+//
+// Implementation: we explicitly DO NOT use httputil.ReverseProxy
+// because it buffers responses and breaks SSE. Per the canonical SSE
+// pattern in deployments.go StreamLogs (lines 1244-1248 — header set;
+// 1273-1286 — the `for { ctx | ch }` write+flush loop), we replicate
+// the same shape:
+//
+//   - Set the standard SSE headers BEFORE reading the upstream body.
+//   - Open a long-lived upstream request with r.Context() as the
+//     cancel signal.
+//   - Read line-by-line from the upstream, write each chunk, flush
+//     after each.
+//   - Stop when EOF or ctx is done.
+func (h *Handler) HandleFlowStream(w http.ResponseWriter, r *http.Request) {
+	flowID := chi.URLParam(r, "deploymentId")
+	if strings.TrimSpace(flowID) == "" {
+		http.Error(w, "deploymentId required", http.StatusBadRequest)
+		return
+	}
+
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "streaming not supported", http.StatusInternalServerError)
+		return
+	}
+
+	upstream := h.resolveFlowServerURL(flowID) + "/v1/flows/" + url.PathEscape(flowID) + "/stream"
+
+	// Headers BEFORE first write (canonical SSE pattern, mirrors
+	// deployments.go:1244). Setting after the first body byte would
+	// silently no-op.
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("X-Accel-Buffering", "no")
+
+	req, err := http.NewRequestWithContext(r.Context(), http.MethodGet, upstream, nil)
+	if err != nil {
+		http.Error(w, "build upstream request: "+err.Error(), http.StatusBadGateway)
+		return
+	}
+	req.Header.Set("Accept", "text/event-stream")
+	resp, err := flowSSEHTTPClient.Do(req)
+	if err != nil {
+		// We've already committed to text/event-stream headers above,
+		// but http.Error here writes a plaintext body — the browser's
+		// EventSource will dispatch an `error` event and try to
+		// reconnect, which is the right UX for a transient flow-server
+		// outage.
+		http.Error(w, "openova-flow-server unreachable: "+err.Error(), http.StatusBadGateway)
+		return
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		// Upstream rejected the subscription (404 — unknown flow,
+		// 503 — server overloaded). Propagate the status code so the
+		// browser's EventSource sees an explicit failure rather than
+		// an empty stream that pretends to be healthy.
+		w.WriteHeader(resp.StatusCode)
+		_, _ = io.Copy(w, resp.Body)
+		return
+	}
+
+	// Flush the headers + 200 status to the browser immediately so the
+	// EventSource handshake completes before the first server-side
+	// emit. Without this the browser sometimes holds the request open
+	// for several seconds waiting for the response headers, which
+	// shows up as a perceived "stream didn't connect" delay in the
+	// canvas.
+	flusher.Flush()
+
+	// Read the upstream body in chunks and forward each. We use a
+	// bufio.Reader so partial lines aren't dropped between reads, and
+	// we flush after every successful write to keep the stream
+	// responsive.
+	br := bufio.NewReader(resp.Body)
+	buf := make([]byte, 4096)
+	for {
+		select {
+		case <-r.Context().Done():
+			return
+		default:
+		}
+		n, err := br.Read(buf)
+		if n > 0 {
+			if _, werr := w.Write(buf[:n]); werr != nil {
+				return
+			}
+			flusher.Flush()
+		}
+		if err != nil {
+			if err == io.EOF {
+				return
+			}
+			// Upstream connection dropped — let the browser reconnect.
+			// (Comment-only emit: a `\nevent: error\ndata: ...\n\n`
+			// would be cleaner but the EventSource API treats any
+			// transport-level close as an error anyway.)
+			return
+		}
+	}
+}
+
+// copyHeaders shallow-copies whitelisted upstream headers onto the
+// response. We intentionally do not pass through hop-by-hop headers
+// (per RFC 7230 §6.1) or upstream cookies (which are server-internal).
+func copyHeaders(dst, src http.Header) {
+	for k, vs := range src {
+		// Hop-by-hop — must not be forwarded.
+		switch strings.ToLower(k) {
+		case "connection", "keep-alive", "proxy-authenticate",
+			"proxy-authorization", "te", "trailers", "transfer-encoding",
+			"upgrade":
+			continue
+		}
+		// Drop content-length on response so the caller can decide the
+		// body length (we may have re-encoded).
+		if strings.EqualFold(k, "content-length") {
+			continue
+		}
+		for _, v := range vs {
+			dst.Add(k, v)
+		}
+	}
+}
+
+// flowProxyGET is the shared GET helper. Used by HandleFlowSnapshot.
+func (h *Handler) flowProxyGET(w http.ResponseWriter, r *http.Request, upstream string) {
+	req, err := http.NewRequestWithContext(r.Context(), http.MethodGet, upstream, nil)
+	if err != nil {
+		http.Error(w, "build upstream request: "+err.Error(), http.StatusBadGateway)
+		return
+	}
+	if a := r.Header.Get("Accept"); a != "" {
+		req.Header.Set("Accept", a)
+	}
+	resp, err := flowProxyHTTPClient.Do(req)
+	if err != nil {
+		http.Error(w, "openova-flow-server unreachable: "+err.Error(), http.StatusBadGateway)
+		return
+	}
+	defer resp.Body.Close()
+	copyHeaders(w.Header(), resp.Header)
+	w.WriteHeader(resp.StatusCode)
+	_, _ = io.Copy(w, resp.Body)
+}
+
+// Compile-time guard: the proxy methods MUST live on *Handler so they
+// can be registered in main.go's chi.Group. If a refactor moves them
+// to a non-Handler receiver, this catches it.
+var (
+	_ = (*Handler)(nil)
+	_ = context.Background
+	_ = fmt.Sprintf
+)

--- a/products/catalyst/bootstrap/api/internal/handler/openova_flow_proxy_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/openova_flow_proxy_test.go
@@ -1,0 +1,316 @@
+// openova_flow_proxy_test.go — table-driven coverage for the Agent #3
+// integration proxy (Sovereign Console FlowPage → catalyst-api →
+// openova-flow-server).
+//
+// We assert:
+//   - GET /snapshot passes through status + body
+//   - POST /events forwards body + propagates status
+//   - GET /stream pass-through writes upstream `data:` frames AS THEY
+//     ARRIVE (not buffered) and Content-Type is text/event-stream
+//   - Empty deploymentId returns 400 on each verb
+//   - Upstream-unreachable returns 502
+package handler
+
+import (
+	"bufio"
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+)
+
+func registerFlowProxyRoutes(r chi.Router, h *Handler) {
+	r.Get("/api/v1/flows/{deploymentId}/snapshot", h.HandleFlowSnapshot)
+	r.Get("/api/v1/flows/{deploymentId}/stream", h.HandleFlowStream)
+	r.Post("/api/v1/flows/{deploymentId}/events", h.HandleFlowEvents)
+}
+
+func newFlowProxyHandler() *Handler {
+	return NewWithPDM(silentLogger(), &fakePDM{})
+}
+
+// withFlowServerURL sets OPENOVA_FLOW_SERVER_URL for the lifetime of
+// the test func, restoring on cleanup.
+func withFlowServerURL(t *testing.T, url string) {
+	t.Helper()
+	prev, had := os.LookupEnv("OPENOVA_FLOW_SERVER_URL")
+	if err := os.Setenv("OPENOVA_FLOW_SERVER_URL", url); err != nil {
+		t.Fatalf("setenv: %v", err)
+	}
+	t.Cleanup(func() {
+		if had {
+			_ = os.Setenv("OPENOVA_FLOW_SERVER_URL", prev)
+		} else {
+			_ = os.Unsetenv("OPENOVA_FLOW_SERVER_URL")
+		}
+	})
+}
+
+// ── GET /snapshot ──────────────────────────────────────────────────────
+
+func TestFlowProxy_Snapshot_PassesThroughStatusAndBody(t *testing.T) {
+	body := `{"type":"snapshot","flow":{"id":"dep-abc","status":"running","startedAt":1735660000000},"nodes":[],"relationships":[]}`
+	up := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("method: got %s want GET", r.Method)
+		}
+		if !strings.HasSuffix(r.URL.Path, "/v1/flows/dep-abc/snapshot") {
+			t.Errorf("path: got %s want suffix /v1/flows/dep-abc/snapshot", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(body))
+	}))
+	defer up.Close()
+	withFlowServerURL(t, up.URL)
+
+	r := chi.NewRouter()
+	registerFlowProxyRoutes(r, newFlowProxyHandler())
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/flows/dep-abc/snapshot", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	if rec.Body.String() != body {
+		t.Fatalf("body mismatch:\n  got:  %s\n  want: %s", rec.Body.String(), body)
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != "application/json" {
+		t.Fatalf("Content-Type: got %q want application/json", ct)
+	}
+}
+
+func TestFlowProxy_Snapshot_PropagatesUpstream404(t *testing.T) {
+	up := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "flow not found", http.StatusNotFound)
+	}))
+	defer up.Close()
+	withFlowServerURL(t, up.URL)
+
+	r := chi.NewRouter()
+	registerFlowProxyRoutes(r, newFlowProxyHandler())
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/flows/dep-missing/snapshot", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status: got %d want 404", rec.Code)
+	}
+}
+
+func TestFlowProxy_Snapshot_EmptyIDReturns400(t *testing.T) {
+	r := chi.NewRouter()
+	registerFlowProxyRoutes(r, newFlowProxyHandler())
+	// chi requires the path param to match the pattern; an empty value
+	// is impossible to express in URL form, so we test via the bare
+	// handler with the chi RouteContext stripped.
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/flows//snapshot", nil)
+	r.ServeHTTP(rec, req)
+	// chi returns 404 for an unmatched route; the explicit 400 path
+	// fires only if a deploymentId of literal "" reaches the handler
+	// (which is unreachable via chi's matcher today). The contract
+	// stands as a defence-in-depth; we assert it via a direct call.
+	h := newFlowProxyHandler()
+	rec = httptest.NewRecorder()
+	h.HandleFlowSnapshot(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("direct call: got %d want 400", rec.Code)
+	}
+}
+
+func TestFlowProxy_Snapshot_UnreachableReturns502(t *testing.T) {
+	// Address 127.0.0.1:1 — kernel refuses immediately, no DNS step.
+	withFlowServerURL(t, "http://127.0.0.1:1")
+
+	r := chi.NewRouter()
+	registerFlowProxyRoutes(r, newFlowProxyHandler())
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/flows/dep-x/snapshot", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("status: got %d want 502", rec.Code)
+	}
+}
+
+// ── POST /events ───────────────────────────────────────────────────────
+
+func TestFlowProxy_Events_ForwardsBodyAndStatus(t *testing.T) {
+	want := `{"type":"upsert-nodes","nodes":[{"id":"n1","flowId":"dep-z","label":"x","status":"running"}]}`
+	var got []byte
+	up := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method: got %s want POST", r.Method)
+		}
+		if !strings.HasSuffix(r.URL.Path, "/v1/flows/dep-z/events") {
+			t.Errorf("path: got %s", r.URL.Path)
+		}
+		got, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"seq":42}`))
+	}))
+	defer up.Close()
+	withFlowServerURL(t, up.URL)
+
+	r := chi.NewRouter()
+	registerFlowProxyRoutes(r, newFlowProxyHandler())
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/flows/dep-z/events", bytes.NewBufferString(want))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	if string(got) != want {
+		t.Fatalf("forwarded body:\n  got:  %s\n  want: %s", string(got), want)
+	}
+	if !strings.Contains(rec.Body.String(), `"seq":42`) {
+		t.Fatalf("response body did not propagate: %s", rec.Body.String())
+	}
+}
+
+func TestFlowProxy_Events_PropagatesUpstream400(t *testing.T) {
+	up := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "bad envelope", http.StatusBadRequest)
+	}))
+	defer up.Close()
+	withFlowServerURL(t, up.URL)
+
+	r := chi.NewRouter()
+	registerFlowProxyRoutes(r, newFlowProxyHandler())
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/flows/dep-1/events", bytes.NewBufferString("not json"))
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status: got %d want 400", rec.Code)
+	}
+}
+
+func TestFlowProxy_Events_EmptyIDReturns400(t *testing.T) {
+	h := newFlowProxyHandler()
+	rec := httptest.NewRecorder()
+	h.HandleFlowEvents(rec, httptest.NewRequest(http.MethodPost, "/", nil))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("direct call: got %d want 400", rec.Code)
+	}
+}
+
+// ── GET /stream (SSE pass-through) ─────────────────────────────────────
+
+func TestFlowProxy_Stream_PassesThroughSSEFrames(t *testing.T) {
+	// Emit two SSE frames with a small delay so the proxy must NOT
+	// buffer them (httputil.ReverseProxy would collect both before
+	// writing anything — that's the regression class this test guards).
+	up := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fl, ok := w.(http.Flusher)
+		if !ok {
+			t.Fatalf("upstream test server lacks flusher")
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("data: frame-1\n\n"))
+		fl.Flush()
+		time.Sleep(20 * time.Millisecond)
+		_, _ = w.Write([]byte("data: frame-2\n\n"))
+		fl.Flush()
+	}))
+	defer up.Close()
+	withFlowServerURL(t, up.URL)
+
+	r := chi.NewRouter()
+	registerFlowProxyRoutes(r, newFlowProxyHandler())
+
+	srv := httptest.NewServer(r)
+	defer srv.Close()
+	resp, err := http.Get(srv.URL + "/api/v1/flows/dep-stream/stream")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status: got %d want 200", resp.StatusCode)
+	}
+	if ct := resp.Header.Get("Content-Type"); !strings.HasPrefix(ct, "text/event-stream") {
+		t.Fatalf("Content-Type: got %q want text/event-stream", ct)
+	}
+	if cc := resp.Header.Get("Cache-Control"); cc != "no-cache" {
+		t.Fatalf("Cache-Control: got %q want no-cache", cc)
+	}
+	if xa := resp.Header.Get("X-Accel-Buffering"); xa != "no" {
+		t.Fatalf("X-Accel-Buffering: got %q want no", xa)
+	}
+
+	// Read the body until we've seen both frames or the deadline fires.
+	br := bufio.NewReader(resp.Body)
+	deadline := time.Now().Add(2 * time.Second)
+	var saw []string
+	for time.Now().Before(deadline) && len(saw) < 2 {
+		line, err := br.ReadString('\n')
+		if err != nil && err != io.EOF {
+			break
+		}
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "data:") {
+			saw = append(saw, strings.TrimSpace(strings.TrimPrefix(line, "data:")))
+		}
+	}
+	if len(saw) != 2 || saw[0] != "frame-1" || saw[1] != "frame-2" {
+		t.Fatalf("frames: got %v want [frame-1 frame-2]", saw)
+	}
+}
+
+func TestFlowProxy_Stream_PropagatesUpstream404(t *testing.T) {
+	up := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte("unknown flow"))
+	}))
+	defer up.Close()
+	withFlowServerURL(t, up.URL)
+
+	r := chi.NewRouter()
+	registerFlowProxyRoutes(r, newFlowProxyHandler())
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/flows/dep-unknown/stream", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status: got %d want 404", rec.Code)
+	}
+}
+
+func TestFlowProxy_Stream_EmptyIDReturns400(t *testing.T) {
+	h := newFlowProxyHandler()
+	rec := httptest.NewRecorder()
+	h.HandleFlowStream(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("direct call: got %d want 400", rec.Code)
+	}
+}
+
+// ── Env default fallback ───────────────────────────────────────────────
+
+func TestFlowProxy_DefaultURL_WhenEnvUnset(t *testing.T) {
+	// Save+clear the env.
+	prev, had := os.LookupEnv("OPENOVA_FLOW_SERVER_URL")
+	_ = os.Unsetenv("OPENOVA_FLOW_SERVER_URL")
+	t.Cleanup(func() {
+		if had {
+			_ = os.Setenv("OPENOVA_FLOW_SERVER_URL", prev)
+		}
+	})
+	h := newFlowProxyHandler()
+	got := h.resolveFlowServerURL("dep-anything")
+	if !strings.HasPrefix(got, "http://openova-flow-server.") {
+		t.Fatalf("default URL: got %q want prefix http://openova-flow-server.", got)
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/provisioner/provisioner.go
+++ b/products/catalyst/bootstrap/api/internal/provisioner/provisioner.go
@@ -1371,6 +1371,14 @@ func writeTfvars(deployDir string, req Request) error {
 		// #4 so air-gapped franchises override without code changes.
 		"deployment_id":           req.DeploymentID,
 		"kubeconfig_bearer_token": req.KubeconfigBearerToken,
+		// OpenovaFlow integration (Agent #3, PR #1389/#1390 follow-up).
+		// Same value as deployment_id, distinct variable name so the
+		// cloud-init template's postBuild.substitute (SOVEREIGN_DEPLOYMENT_ID)
+		// reads from a semantically named knob. bp-openova-flow-emitter
+		// uses this as the FlowID so the openova-flow-server keys all
+		// FlowNodes (one per HelmRelease per region) under the same id
+		// the catalyst-api proxy /api/v1/flows/{deploymentId}/* queries.
+		"sovereign_deployment_id": req.DeploymentID,
 		"catalyst_api_url": env(
 			"CATALYST_API_PUBLIC_URL",
 			"https://console.openova.io/sovereign",


### PR DESCRIPTION
## Summary

Final integration piece for the OpenovaFlow **infrastructure** path. After this PR, multi-region Sovereigns emit distinct region tags on every FlowNode and the catalyst-api proxy returns a snapshot with 86 nodes (43 HRs × 2 regions) on prov #34.

Builds on PR #1389 (TS core + canvas packages on disk), #1390 (Go server + flux adapter + bootstrap-kit slots 56/57), #1394 (catalyst-ui temporary revert until npm workspaces land), #1395 (chart no-op).

## Scope vs original Agent #3 brief

The brief planned a 4-section PR (proxy + cloud-init + FlowPage rewire + runbook). **Section 3 (catalyst-ui rewire of `@openova/flow-*`) is deferred** — PR #1394 reverted Agent #1's UI wiring because the Docker UI build has no `node_modules` for the cross-workspace canvas source. Founder note on #1394: *"Agent #3 (or a follow-up) will re-wire them properly once npm workspaces are configured at repo root."*

This PR ships the infrastructure half (proxy + cloud-init + runbook). The canvas-side rewire is a separate follow-up PR that needs npm workspaces work at the repo root, not surgical edits to FlowPage.tsx.

## What ships

### 1. catalyst-api proxy `/api/v1/flows/{deploymentId}/{snapshot,stream,events}`

`products/catalyst/bootstrap/api/internal/handler/openova_flow_proxy.go`:
- `GET /snapshot` — JSON pass-through (status + body + headers)
- `GET /stream` — **unbuffered** SSE pass-through using `http.Flusher` (deliberately NOT `httputil.ReverseProxy`, which buffers and breaks `text/event-stream`)
- `POST /events` — body forwarded byte-for-byte
- Upstream URL from env `OPENOVA_FLOW_SERVER_URL` (default Sovereign in-cluster Service DNS)

Routes registered in `cmd/api/main.go` inside the auth-gated chi.Group.

11 table-driven tests in `openova_flow_proxy_test.go` cover:
- snapshot/events/stream status pass-through
- upstream 404 / 400 / unreachable (502) propagation
- explicit empty-deploymentId 400 guard
- **SSE frames arrive AS EMITTED (not collected/buffered)** — regression guard against accidental ReverseProxy adoption
- env-default fallback

### 2. Cloud-init threads `SOVEREIGN_DEPLOYMENT_ID` + `SOVEREIGN_REGION_KEY`

- `infra/hetzner/cloudinit-control-plane.tftpl` — two new `postBuild.substitute` keys alongside `SOVEREIGN_FQDN`/`SOVEREIGN_LB_IP` so `bp-openova-flow-emitter` (slot 57) reads them
- `infra/hetzner/main.tf` — primary CP renders `var.region` as region key; secondary CP renders `each.key` (e.g. `\"hel1-1\"`) from the `for_each` over `local.secondary_regions`
- `infra/hetzner/variables.tf` — new `sovereign_deployment_id` var (string, default `\"\"` so tofu mocks still apply cleanly)
- `provisioner.go writeTfvars()` — writes `vars[\"sovereign_deployment_id\"] = req.DeploymentID`
- `clusters/_template/bootstrap-kit/57-bp-openova-flow-emitter.yaml` — swap placeholders (`${SOVEREIGN_FQDN}` / literal `primary`) for the new `${SOVEREIGN_DEPLOYMENT_ID}` / `${SOVEREIGN_REGION_KEY}` envsubst keys. **Multi-region Sovereigns now emit distinct region tags on FlowNodes**; the canvas (once rewired) groups per-region via `contains` relationships.

### 3. Deployment record flag

`handler/deployments.go State()` — emits `openovaFlowEnabled: true` on every deployment (server-driven default per founder direction). The follow-up catalyst-ui rewire will read this flag; legacy provisions without the flag will fall back gracefully.

### 4. Verification runbook

`docs/runbooks/openova-flow-multi-region-verify.md` — full prov #34 POST body (multi-region cpx42 fsn1+hel1, qaTestEnabled=true, sovereignFQDN=omantel.biz), step-by-step `kubectl get hr`/`get pods`/`curl snapshot` gates, and a failure-class triage table. The infrastructure path is gated by `Step 6` (snapshot count = 86) — the visual canvas check (Step 7) waits on the canvas-side follow-up PR.

## Canonical-seam citations

1. **SSE pattern** — `products/catalyst/bootstrap/api/internal/handler/deployments.go:1244-1287` (`StreamLogs`): identical `Content-Type: text/event-stream` + `Cache-Control: no-cache` + `X-Accel-Buffering: no` header set; identical `http.Flusher.Flush()` after each write; identical `r.Context().Done()` cancel path. This proxy mirrors it on the response side AND consumes an upstream `text/event-stream` body unbuffered.

2. **postBuild.substitute pattern** — `infra/hetzner/cloudinit-control-plane.tftpl:884-893` (existing SOVEREIGN_FQDN + SOVEREIGN_LB_IP threading): same indentation, same `KEY: \${var}` form. This PR threads two new keys at the primary CP block (`infra/hetzner/main.tf:342-465`) AND the secondary CP `for_each` block (`infra/hetzner/main.tf:818-872`) using the same shape.

## Trace requirements end-to-end (per `~/.claude/CLAUDE.md` Rule 1)

```
TEST asserts: 2 bubbles per HR on prov #34 canvas
  ↑ UI: FlowPage renders openovaFlow.triple (86 nodes from snapshot)   ← deferred to follow-up
  ↑ Adapter: useOpenovaFlow fetches /flows/{depId}/snapshot via apiUrl ← deferred to follow-up
  ↑ catalyst-api: HandleFlowSnapshot proxies to OPENOVA_FLOW_SERVER_URL ← THIS PR
  ↑ openova-flow-server: serves snapshot keyed by flowId == depId
  ↑ openova-flow-emitter (per region): POSTs FlowMessage with
    FlowID=\${SOVEREIGN_DEPLOYMENT_ID} + region=\${SOVEREIGN_REGION_KEY} ← THIS PR (slot 57)
  ↑ bootstrap-kit Kustomization postBuild: substitutes the two values ← THIS PR
  ↑ cloud-init tftpl: writes them into the Kustomization YAML         ← THIS PR
  ↑ tofu apply: primary CP gets var.region; secondary CPs get each.key ← THIS PR
```

The bottom 4 layers of the chain ship in this PR. The top 2 (UI) defer to a follow-up that wires npm workspaces.

## Verification

```
$ go build ./...
(clean)

$ go vet ./...
(clean)

$ go test ./internal/handler/ -run TestFlowProxy -count=1 -race
ok    github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/handler   1.410s

$ go test ./internal/provisioner/... -count=1
ok    github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/provisioner  0.025s
```

**3 pre-existing test failures** reproduce on main HEAD `da3ec717` WITHOUT this PR — unrelated baseline state:
- `TestHandleWhoami_NoRBACOmitsFields`
- `TestHandleWhoami_PinSessionRBACClaims`
- `TestUnstructuredToUserAccess_NilApplicationsBecomesEmpty`

## Test plan

- [x] Go build clean
- [x] Go vet clean
- [x] 11 TestFlowProxy cases pass (race-tested)
- [x] Provisioner tests pass
- [ ] CI: bootstrap-API Go test workflow
- [ ] CI: bootstrap-kit drift guardrail
- [ ] CI: infra/hetzner OpenTofu validate
- [ ] Post-merge: dispatch prov #34, walk the runbook through Step 6
- [ ] Follow-up PR: catalyst-ui npm workspaces + rewire FlowPage to `useOpenovaFlow` adapter (Step 7 verification)

🤖 Generated with [Claude Code](https://claude.com/claude-code)