### PR TITLE
fix(openova-flow): chart image repo = direct ghcr.io

### DIFF
--- a/platform/openova-flow-emitter/chart/values.yaml
+++ b/platform/openova-flow-emitter/chart/values.yaml
@@ -20,7 +20,10 @@ flowEmitter:
   # per cluster (rare).
   workloadName: openova-flow-emitter
   image:
-    repository: harbor.openova.io/proxy-ghcr/openova-io/openova/openova-flow-adapter-flux
+    # Direct ghcr.io path — see openova-flow-server values.yaml for the
+    # full rationale. catalyst-api/catalyst-ui already use the same
+    # pattern. containerd rewrites at the wire.
+    repository: ghcr.io/openova-io/openova/openova-flow-adapter-flux
     # SHA-pinned by CI's build-openova-flow-adapter-flux.yaml (seds
     # this value with the short-SHA). Default `latest` lets Blueprint
     # Release smoke-render the chart with default values before the

--- a/platform/openova-flow-server/chart/values.yaml
+++ b/platform/openova-flow-server/chart/values.yaml
@@ -23,7 +23,18 @@ flowServer:
     # Mothership Harbor pull-through proxy. The Sovereign-local Harbor
     # rewrites this prefix to its own proxy at registry-pivot time per
     # platform/self-sovereign-cutover/chart/.
-    repository: harbor.openova.io/proxy-ghcr/openova-io/openova/openova-flow-server
+    # Direct ghcr.io path mirrors the catalyst-api/catalyst-ui pattern:
+    # kubelet auths with the ghcr-pull imagePullSecret (reflected by
+    # bp-reflector into every namespace that needs it), and the
+    # node's containerd registries.yaml transparently rewrites
+    # ghcr.io → harbor.openova.io/proxy-ghcr/ on the wire so the
+    # mothership Harbor still caches the bytes (MIRROR-EVERYTHING
+    # preserved at the containerd layer). Using `harbor.openova.io/
+    # proxy-ghcr/...` here directly bypassed that rewrite AND Harbor
+    # doesn't currently carry ghcr.io auth for private packages —
+    # pods CrashLoopped on `not found` (live regression on prov #34,
+    # 2026-05-11).
+    repository: ghcr.io/openova-io/openova/openova-flow-server
     # SHA-pinned by CI's build-openova-flow-server.yaml (seds this
     # value with the short-SHA). Default `latest` lets Blueprint
     # Release smoke-render the chart with default values before the


### PR DESCRIPTION
Unblocks prov #34 ImagePullBackOff. Matches catalyst-api/catalyst-ui pattern: direct ghcr.io ref + ghcr-pull imagePullSecret + containerd rewrite preserves MIRROR-EVERYTHING at the wire.