### PR TITLE
fix(openova-flow-proxy): derive upstream URL from deployment FQDN (HTTPRoute) — Agent #8

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/openova_flow_proxy.go
+++ b/products/catalyst/bootstrap/api/internal/handler/openova_flow_proxy.go
@@ -8,10 +8,22 @@
 //	GET  /api/v1/flows/{deploymentId}/stream   — SSE: snapshot + tail (pass-through)
 //	POST /api/v1/flows/{deploymentId}/events   — ingest one FlowMessage envelope
 //
-// All three proxy to the openova-flow-server at OPENOVA_FLOW_SERVER_URL
-// (default in-cluster Service URL for the Sovereign-side catalyst-api;
-// the mother-side catalyst-api consumes its own per-Sovereign HTTPRoute
-// — see main.go where the env is read from the deployment record).
+// Two deploy contexts share this handler:
+//
+//   - Sovereign chroot (catalyst-api running INSIDE a Sovereign) — talks
+//     to its own openova-flow-server via the in-cluster Service DNS.
+//     The env `OPENOVA_FLOW_SERVER_URL` is set so the resolver returns
+//     it verbatim and the per-deployment lookup is skipped.
+//   - Mothership (catalyst-api on contabo) — must talk to a DIFFERENT
+//     Sovereign per request because the in-cluster DNS only points at
+//     its OWN cluster. We resolve the upstream URL from the deployment
+//     record's sovereignFQDN: each Sovereign exposes its flow-server
+//     publicly via the bp-openova-flow-server chart's HTTPRoute as
+//     `openova-flow.<sovereign-fqdn>` (see
+//     `platform/openova-flow-server/chart/values.yaml` →
+//     `httproute.hostname`, and the per-Sovereign overlay in
+//     `clusters/_template/bootstrap-kit/56-bp-openova-flow-server.yaml`
+//     which sets `hostname: openova-flow.${SOVEREIGN_FQDN}`).
 //
 // The flowId on the upstream is the catalyst-api deploymentId — the
 // openova-flow-server uses flowId as an opaque key so the same string
@@ -26,32 +38,41 @@
 //     read-write loop so every `data:` frame from the upstream lands
 //     in the browser within ~milliseconds.
 //   - docs/INVIOLABLE-PRINCIPLES.md #4 (never hardcode): the upstream
-//     URL is sourced from env `OPENOVA_FLOW_SERVER_URL`. There is no
-//     default `https://…` literal that would tie this code to a
-//     specific Sovereign FQDN.
+//     URL is either explicitly env-driven (chroot mode) or derived at
+//     runtime from the deployment record's sovereignFQDN (mother mode).
+//     No hostname suffix or region literal is baked into this file —
+//     only the public hostname prefix `openova-flow.` which is itself
+//     the chart's documented convention.
 //   - Canonical SSE pattern in this codebase: deployments.go
 //     `StreamLogs` (lines 1208-1287) — Content-Type: text/event-stream,
 //     Cache-Control: no-cache, Connection: keep-alive, X-Accel-Buffering:
 //     no, http.Flusher.Flush after every event. This proxy mirrors that
 //     header set on the response side AND streams the upstream body
 //     verbatim.
-//   - Headers propagated to upstream: cookies (the openova-flow-server
-//     itself is unauthenticated today, but future iterations may want
-//     to assert the operator's session). Request-context propagation
-//     ensures the upstream connection closes when the browser tab
-//     closes.
+//   - Canonical PDM-by-deploymentId lookup pattern: deployments.go
+//     `GetDeployment` (lines 1201-1216) — `h.deployments.Load(id)` →
+//     `(*Deployment).Request.SovereignFQDN`. The `chrootEnsureDeployment`
+//     fallback (jobs.go lines 53-86) covers the chroot mode where the
+//     deployment record isn't pre-populated; on the mother that
+//     fallback is a no-op so we surface 404.
+//   - Canonical self-signed-TLS pattern: deployment_handover_export.go
+//     line 62 — `&tls.Config{InsecureSkipVerify: true}` is only used
+//     when explicitly opted-in. Here we gate it on the env
+//     `OPENOVA_FLOW_TLS_SKIP_VERIFY=true` so a qa-loop Sovereign with
+//     LE-staging certs (Fake LE Intermediate X1) is reachable, while
+//     production deployments default to strict TLS verification.
 //
 // Per docs/INVIOLABLE-PRINCIPLES.md #21 (two-repo discipline) this
-// proxy lives in openova-io/openova (public). The per-Sovereign
-// concrete openova-flow-server URL lives in the deployment record
-// (private state inside the Sovereign's K8s — Service DNS resolution
-// or HTTPRoute hostname is derived at runtime, not committed).
+// proxy lives in openova-io/openova (public). Per-Sovereign concrete
+// FQDNs live in the deployment record (in-memory + on-disk store under
+// CATALYST_DEPLOYMENTS_DIR — private state inside the cluster).
 
 package handler
 
 import (
 	"bufio"
 	"context"
+	"crypto/tls"
 	"fmt"
 	"io"
 	"net/http"
@@ -63,20 +84,45 @@ import (
 	"github.com/go-chi/chi/v5"
 )
 
-// defaultFlowServerURL is the in-cluster Service URL the bp-openova-
-// flow-server chart's templates/service.yaml lands. The catalyst-api
-// inside a Sovereign chroot reaches its own openova-flow-server via
-// this URL with zero extra plumbing.
-//
-// For the mother-side catalyst-api, OPENOVA_FLOW_SERVER_URL is set per-
-// deployment (resolved from each deployment's sovereignFQDN to the
-// Cilium Gateway HTTPRoute) so the proxy fans out to the correct
-// Sovereign's flow-server. See main.go for the env wiring.
+// defaultFlowServerURL — the in-cluster Service URL the
+// bp-openova-flow-server chart's `templates/service.yaml` exposes. Used
+// ONLY when the env `OPENOVA_FLOW_SERVER_URL` is set explicitly (chroot
+// catalyst-api), since the in-cluster DNS doesn't resolve from the
+// mother. The mother path derives the URL from the deployment record's
+// sovereignFQDN.
 const defaultFlowServerURL = "http://openova-flow-server.catalyst-system.svc.cluster.local:8080"
 
-// flowProxyHTTPClient is the singleton http.Client used by the
-// snapshot + ingest proxies. SSE uses a separate client below because
-// it disables timeouts.
+// flowServerHostnamePrefix — the canonical hostname prefix the
+// bp-openova-flow-server chart's HTTPRoute uses on every Sovereign:
+// `openova-flow.<sovereign-fqdn>` (see chart values.yaml comment + the
+// bootstrap-kit overlay 56-bp-openova-flow-server.yaml which sets
+// `hostname: openova-flow.${SOVEREIGN_FQDN}`). This is a chart-level
+// convention, NOT a region/domain hardcoding — the FQDN suffix itself
+// comes from the per-deployment record at runtime.
+const flowServerHostnamePrefix = "openova-flow."
+
+// flowProxyTLSSkipVerify is the boot-time setting for whether the
+// per-deployment HTTPS dial trusts self-signed certs. Used while
+// qa-loop Sovereigns mint LE-staging "Fake LE Intermediate X1" certs
+// (see infra `qa_acme_use_staging` tofu var). Set
+// OPENOVA_FLOW_TLS_SKIP_VERIFY=true to enable. Production stays strict
+// (false).
+var flowProxyTLSSkipVerify = strings.EqualFold(strings.TrimSpace(os.Getenv("OPENOVA_FLOW_TLS_SKIP_VERIFY")), "true")
+
+// flowProxyTransport — shared http.Transport with the env-gated
+// TLSClientConfig. Mirrors the canonical pattern in
+// deployment_handover_export.go (handler exporting to a Sovereign whose
+// LE cert may be seconds behind handover).
+func newFlowProxyTransport() *http.Transport {
+	t := &http.Transport{}
+	if flowProxyTLSSkipVerify {
+		t.TLSClientConfig = &tls.Config{InsecureSkipVerify: true} //nolint:gosec // gated by OPENOVA_FLOW_TLS_SKIP_VERIFY=true; only set in qa-loop where Sovereigns mint LE-staging certs
+	}
+	return t
+}
+
+// flowProxyHTTPClient — singleton http.Client for snapshot + ingest.
+// SSE uses a separate client below because it disables timeouts.
 //
 // Per docs/INVIOLABLE-PRINCIPLES.md #4 every knob is env-tunable: we
 // initialize once at package-init time using OPENOVA_FLOW_PROXY_TIMEOUT
@@ -89,38 +135,76 @@ var flowProxyHTTPClient = func() *http.Client {
 			t = d
 		}
 	}
-	return &http.Client{Timeout: t}
+	return &http.Client{Timeout: t, Transport: newFlowProxyTransport()}
 }()
 
 // flowSSEHTTPClient — for the SSE long-lived stream. Zero timeout (the
 // stream is held open until the browser disconnects). The per-request
 // context still cancels the upstream conn.
-var flowSSEHTTPClient = &http.Client{}
+var flowSSEHTTPClient = &http.Client{Transport: newFlowProxyTransport()}
 
 // resolveFlowServerURL returns the upstream openova-flow-server base
-// URL for the given deploymentId, picking up OPENOVA_FLOW_SERVER_URL
-// at runtime so the env can be updated without restarting the binary
-// (the mother-side catalyst-api re-resolves per-request to support
-// per-deployment URLs in a future iteration).
-func (h *Handler) resolveFlowServerURL(_ string) string {
+// URL for the given deploymentId.
+//
+// Resolution order:
+//
+//  1. OPENOVA_FLOW_SERVER_URL env override — when set, win. This is
+//     the Sovereign chroot path: catalyst-api inside a Sovereign sets
+//     this to the in-cluster Service DNS and the per-deployment lookup
+//     is skipped entirely.
+//
+//  2. Per-deployment derivation — look up the deployment record by ID
+//     and build `https://openova-flow.<sovereignFQDN>` from
+//     `dep.Request.SovereignFQDN`. This is the mothership path.
+//
+// Returns the resolved URL (trimmed of trailing `/`) and a nil error
+// on success. Returns a non-nil error when neither path resolves —
+// caller should respond 502 (upstream not configured for this
+// deployment) or 404 (deployment not known).
+func (h *Handler) resolveFlowServerURL(deploymentID string) (string, error) {
 	if s := strings.TrimSpace(os.Getenv("OPENOVA_FLOW_SERVER_URL")); s != "" {
-		return strings.TrimRight(s, "/")
+		return strings.TrimRight(s, "/"), nil
 	}
-	return defaultFlowServerURL
+	// Canonical per-deployment lookup, mirroring deployments.go
+	// GetDeployment (lines 1201-1216): `h.deployments.Load(id)` →
+	// (*Deployment).Request.SovereignFQDN. On the chroot,
+	// chrootEnsureDeployment synthesises a record when the in-memory
+	// map is empty (jobs.go lines 53-86); on the mother it returns
+	// nil and we propagate the 404 to the caller.
+	val, ok := h.deployments.Load(deploymentID)
+	var dep *Deployment
+	if ok {
+		dep = val.(*Deployment)
+	} else if dep = h.chrootEnsureDeployment(deploymentID); dep == nil {
+		return "", fmt.Errorf("deployment %q not found", deploymentID)
+	}
+	fqdn := strings.TrimSpace(dep.Request.SovereignFQDN)
+	if fqdn == "" {
+		return "", fmt.Errorf("deployment %q has no sovereignFQDN", deploymentID)
+	}
+	// The HTTPRoute always serves on the gateway's default HTTPS port
+	// (443); leaving the port off the URL keeps the scheme+host shape
+	// canonical and lets the Go http client pick the right default.
+	return "https://" + flowServerHostnamePrefix + fqdn, nil
 }
 
 // HandleFlowSnapshot proxies GET /api/v1/flows/{deploymentId}/snapshot →
 // GET <upstream>/v1/flows/{deploymentId}/snapshot.
 //
 // Status, headers, and body pass through verbatim. On upstream-network
-// error the proxy returns 502.
+// error or unresolvable deploymentId, the proxy returns 502 / 404.
 func (h *Handler) HandleFlowSnapshot(w http.ResponseWriter, r *http.Request) {
 	flowID := chi.URLParam(r, "deploymentId")
 	if strings.TrimSpace(flowID) == "" {
 		http.Error(w, "deploymentId required", http.StatusBadRequest)
 		return
 	}
-	upstream := h.resolveFlowServerURL(flowID) + "/v1/flows/" + url.PathEscape(flowID) + "/snapshot"
+	base, err := h.resolveFlowServerURL(flowID)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusNotFound)
+		return
+	}
+	upstream := base + "/v1/flows/" + url.PathEscape(flowID) + "/snapshot"
 	h.flowProxyGET(w, r, upstream)
 }
 
@@ -138,7 +222,12 @@ func (h *Handler) HandleFlowEvents(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "deploymentId required", http.StatusBadRequest)
 		return
 	}
-	upstream := h.resolveFlowServerURL(flowID) + "/v1/flows/" + url.PathEscape(flowID) + "/events"
+	base, err := h.resolveFlowServerURL(flowID)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusNotFound)
+		return
+	}
+	upstream := base + "/v1/flows/" + url.PathEscape(flowID) + "/events"
 
 	req, err := http.NewRequestWithContext(r.Context(), http.MethodPost, upstream, r.Body)
 	if err != nil {
@@ -194,7 +283,12 @@ func (h *Handler) HandleFlowStream(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	upstream := h.resolveFlowServerURL(flowID) + "/v1/flows/" + url.PathEscape(flowID) + "/stream"
+	base, err := h.resolveFlowServerURL(flowID)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusNotFound)
+		return
+	}
+	upstream := base + "/v1/flows/" + url.PathEscape(flowID) + "/stream"
 
 	// Headers BEFORE first write (canonical SSE pattern, mirrors
 	// deployments.go:1244). Setting after the first body byte would

--- a/products/catalyst/bootstrap/api/internal/handler/openova_flow_proxy_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/openova_flow_proxy_test.go
@@ -9,6 +9,13 @@
 //     ARRIVE (not buffered) and Content-Type is text/event-stream
 //   - Empty deploymentId returns 400 on each verb
 //   - Upstream-unreachable returns 502
+//   - When OPENOVA_FLOW_SERVER_URL is UNSET, the upstream URL is
+//     derived from the deployment record's sovereignFQDN as
+//     `https://openova-flow.<fqdn>` (HTTPRoute pattern, Agent #8)
+//   - When the deploymentId isn't in the store AND no env override is
+//     set, the proxy returns 404 (deployment not found) rather than
+//     silently falling through to an in-cluster Service URL the
+//     mothership can't dial
 package handler
 
 import (
@@ -23,6 +30,8 @@ import (
 	"time"
 
 	"github.com/go-chi/chi/v5"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/provisioner"
 )
 
 func registerFlowProxyRoutes(r chi.Router, h *Handler) {
@@ -297,10 +306,15 @@ func TestFlowProxy_Stream_EmptyIDReturns400(t *testing.T) {
 	}
 }
 
-// ── Env default fallback ───────────────────────────────────────────────
+// ── URL resolution (Agent #8 — per-deployment + env override) ──────────
 
-func TestFlowProxy_DefaultURL_WhenEnvUnset(t *testing.T) {
-	// Save+clear the env.
+// withFlowServerURLUnset clears OPENOVA_FLOW_SERVER_URL for the test
+// duration and restores on cleanup. Used by the per-deployment
+// derivation tests below — when the env is set, resolveFlowServerURL
+// returns it verbatim and the deployment lookup never runs, which
+// would defeat the test.
+func withFlowServerURLUnset(t *testing.T) {
+	t.Helper()
 	prev, had := os.LookupEnv("OPENOVA_FLOW_SERVER_URL")
 	_ = os.Unsetenv("OPENOVA_FLOW_SERVER_URL")
 	t.Cleanup(func() {
@@ -308,9 +322,125 @@ func TestFlowProxy_DefaultURL_WhenEnvUnset(t *testing.T) {
 			_ = os.Setenv("OPENOVA_FLOW_SERVER_URL", prev)
 		}
 	})
+}
+
+// TestFlowProxy_EnvOverride_TakesPrecedence — when
+// OPENOVA_FLOW_SERVER_URL is set (chroot catalyst-api case), the
+// resolver returns it verbatim and ignores any deployment record. This
+// preserves the original Agent #3 behaviour.
+func TestFlowProxy_EnvOverride_TakesPrecedence(t *testing.T) {
+	withFlowServerURL(t, "http://override.local:9999")
 	h := newFlowProxyHandler()
-	got := h.resolveFlowServerURL("dep-anything")
-	if !strings.HasPrefix(got, "http://openova-flow-server.") {
-		t.Fatalf("default URL: got %q want prefix http://openova-flow-server.", got)
+	// Stash a deployment with a different FQDN — must NOT be picked.
+	h.deployments.Store("dep-x", &Deployment{
+		ID:      "dep-x",
+		Request: provisioner.Request{SovereignFQDN: "should-not-be-used.example"},
+	})
+	got, err := h.resolveFlowServerURL("dep-x")
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if got != "http://override.local:9999" {
+		t.Fatalf("env override: got %q want http://override.local:9999", got)
+	}
+}
+
+// TestFlowProxy_DerivesURLFromDeploymentFQDN — the mothership path:
+// no env override, look up the deployment by ID, build
+// `https://openova-flow.<sovereignFQDN>` from the record. This is
+// the canonical HTTPRoute hostname pattern documented in
+// platform/openova-flow-server/chart/values.yaml + the bootstrap-kit
+// overlay 56-bp-openova-flow-server.yaml.
+func TestFlowProxy_DerivesURLFromDeploymentFQDN(t *testing.T) {
+	withFlowServerURLUnset(t)
+	h := newFlowProxyHandler()
+	h.deployments.Store("5a175e0a88c99cec", &Deployment{
+		ID:      "5a175e0a88c99cec",
+		Request: provisioner.Request{SovereignFQDN: "tenant-7.example.org"},
+	})
+	got, err := h.resolveFlowServerURL("5a175e0a88c99cec")
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	want := "https://openova-flow.tenant-7.example.org"
+	if got != want {
+		t.Fatalf("derived URL: got %q want %q", got, want)
+	}
+}
+
+// TestFlowProxy_DerivedURL_NotFoundReturns404 — when the env isn't
+// set and the deploymentId isn't in the store, the resolver returns
+// an error and the proxy responds 404. Previously the code silently
+// fell back to the in-cluster Service URL — on the mothership that
+// produced a 502 with a confusing DNS-lookup error.
+func TestFlowProxy_DerivedURL_NotFoundReturns404(t *testing.T) {
+	withFlowServerURLUnset(t)
+	r := chi.NewRouter()
+	registerFlowProxyRoutes(r, newFlowProxyHandler())
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/flows/dep-missing/snapshot", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status: got %d want 404; body=%s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "not found") {
+		t.Fatalf("body should mention 'not found'; got %q", rec.Body.String())
+	}
+}
+
+// TestFlowProxy_DerivedURL_EmptyFQDNReturns404 — deployment exists
+// but its Request.SovereignFQDN is empty (pre-FQDN-assignment, or a
+// half-persisted record). Same 404 as missing-deployment so the
+// browser surfaces a clear error rather than a silent 502.
+func TestFlowProxy_DerivedURL_EmptyFQDNReturns404(t *testing.T) {
+	withFlowServerURLUnset(t)
+	h := newFlowProxyHandler()
+	h.deployments.Store("dep-half", &Deployment{
+		ID:      "dep-half",
+		Request: provisioner.Request{SovereignFQDN: ""},
+	})
+	r := chi.NewRouter()
+	registerFlowProxyRoutes(r, h)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/flows/dep-half/snapshot", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status: got %d want 404; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+// TestFlowProxy_DerivedURL_RoutesFullPath — end-to-end check that the
+// snapshot path appends `/v1/flows/<id>/snapshot` onto the derived
+// base URL. We point the derived hostname at a localhost httptest
+// server by abusing OPENOVA_FLOW_SERVER_URL — but the assertion below
+// proves the SECOND code path (per-deployment derivation) works in
+// isolation via the resolveFlowServerURL unit test above; this
+// end-to-end test re-validates the request path assembly.
+func TestFlowProxy_DerivedURL_PathAssembly(t *testing.T) {
+	// Use a fake upstream as a stand-in; we only check that the URL
+	// the proxy dials carries the right suffix `/v1/flows/<id>/snapshot`.
+	got := ""
+	up := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"type":"snapshot"}`))
+	}))
+	defer up.Close()
+	// Set the env so the dial actually reaches the test server; the
+	// derivation path is unit-tested above. This test additionally
+	// asserts the suffix is built correctly.
+	withFlowServerURL(t, up.URL)
+
+	r := chi.NewRouter()
+	registerFlowProxyRoutes(r, newFlowProxyHandler())
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/flows/5a175e0a88c99cec/snapshot", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d want 200", rec.Code)
+	}
+	if !strings.HasSuffix(got, "/v1/flows/5a175e0a88c99cec/snapshot") {
+		t.Fatalf("upstream path: got %q want suffix /v1/flows/5a175e0a88c99cec/snapshot", got)
 	}
 }


### PR DESCRIPTION
## Summary

Mothership catalyst-api serves `/sovereign/api/v1/flows/{deploymentId}/*` for every Sovereign's user-facing job view (`https://console.openova.io/sovereign/provision/{id}/jobs/install-gateway-api`). Agent #3's original proxy resolved the upstream URL from `OPENOVA_FLOW_SERVER_URL` (with an in-cluster Service DNS default). On the mothership both fall back to a name the kernel can't resolve, so prov #34 (2026-05-11) hit:

```
HTTP/2 502 openova-flow-server unreachable:
  Get "http://openova-flow-server.catalyst-system.svc.cluster.local:8080/v1/flows/5a175e0a88c99cec/snapshot":
  dial tcp: lookup openova-flow-server.catalyst-system.svc.cluster.local: no such host
```

This PR makes the mothership resolve the upstream URL **per request** from the deployment record's `sovereignFQDN`, mirroring the public HTTPRoute pattern that `bp-openova-flow-server` already provisions on every Sovereign.

## Resolution order

1. `OPENOVA_FLOW_SERVER_URL` env override — wins (chroot catalyst-api dialing its own in-cluster Service).
2. `h.deployments.Load(deploymentId)` → `Request.SovereignFQDN` → build `https://openova-flow.<sovereignFQDN>` — the HTTPRoute hostname pattern documented in `platform/openova-flow-server/chart/values.yaml` and applied per-Sovereign by `clusters/_template/bootstrap-kit/56-bp-openova-flow-server.yaml` (`hostname: openova-flow.${SOVEREIGN_FQDN}`).
3. No record + no env override → 404 (was: silently 502 with confusing DNS error).

## Canonical patterns cited (ARCHITECT-FIRST)

- **PDM-by-deploymentId lookup** — `products/catalyst/bootstrap/api/internal/handler/deployments.go` `GetDeployment` (lines 1201–1216): `h.deployments.Load(id)` → `(*Deployment).Request.SovereignFQDN`. `chrootEnsureDeployment` (jobs.go lines 53–86) covers the chroot path; on the mother it returns nil and the proxy surfaces 404.
- **Self-signed TLS skip-verify** — `products/catalyst/bootstrap/api/internal/handler/deployment_handover_export.go` line 62: `&tls.Config{InsecureSkipVerify: true}` with `//nolint:gosec`, opt-in via explicit operator config. Replicated here gated on `OPENOVA_FLOW_TLS_SKIP_VERIFY=true` (qa-loop only, since Sovereigns mint LE-staging "Fake LE Intermediate X1" certs while `qa_acme_use_staging=true`). Production stays strict.

## What didn't change

- SSE streaming logic (http.Flusher + bufio.Reader, no buffered ReverseProxy) — unchanged. Only URL derivation moved.
- Env-override path (`OPENOVA_FLOW_SERVER_URL`) still wins so chroot catalyst-api keeps using its in-cluster Service URL with zero ops change.
- No region / domain suffix hardcoded — only the chart-documented prefix `openova-flow.` (the suffix comes from the deployment record).

## Test plan

- [x] `go vet ./...` clean
- [x] `go build ./cmd/api` clean
- [x] `go test ./internal/handler -run TestFlowProxy -count=1` — all 15 tests pass (10 pre-existing + 5 new)
  - New: `TestFlowProxy_EnvOverride_TakesPrecedence` (chroot path)
  - New: `TestFlowProxy_DerivesURLFromDeploymentFQDN` (mother path → `https://openova-flow.<fqdn>`)
  - New: `TestFlowProxy_DerivedURL_NotFoundReturns404`
  - New: `TestFlowProxy_DerivedURL_EmptyFQDNReturns404`
  - New: `TestFlowProxy_DerivedURL_PathAssembly`
- [ ] Post-merge: catalyst-api roll on contabo → `curl -k -b /tmp/cz-cookie-prov27.txt 'https://console.openova.io/sovereign/api/v1/flows/<deployment-id>/snapshot' | jq .` returns 200 + JSON FlowMessage snapshot (may be empty if openova-flow-emitter Pods haven't started — separate concern).

Note: the two pre-existing `TestHandleWhoami_*` failures on `origin/main` are unrelated to this PR (verified by running them against the baseline before applying my change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)