### PR TITLE
chore(openova-flow): bump chart 0.1.0 → 0.1.1 (force chroot re-pull)

### DIFF
--- a/clusters/_template/bootstrap-kit/56-bp-openova-flow-server.yaml
+++ b/clusters/_template/bootstrap-kit/56-bp-openova-flow-server.yaml
@@ -61,7 +61,7 @@ spec:
   chart:
     spec:
       chart: bp-openova-flow-server
-      version: 0.1.0
+      version: 0.1.1
       sourceRef:
         kind: HelmRepository
         name: bp-openova-flow-server

--- a/clusters/_template/bootstrap-kit/57-bp-openova-flow-emitter.yaml
+++ b/clusters/_template/bootstrap-kit/57-bp-openova-flow-emitter.yaml
@@ -51,7 +51,7 @@ spec:
   chart:
     spec:
       chart: bp-openova-flow-emitter
-      version: 0.1.0
+      version: 0.1.1
       sourceRef:
         kind: HelmRepository
         name: bp-openova-flow-emitter

--- a/platform/openova-flow-emitter/chart/Chart.yaml
+++ b/platform/openova-flow-emitter/chart/Chart.yaml
@@ -5,7 +5,7 @@ name: bp-openova-flow-emitter
 # Opt out of the hollow-chart guard per docs/BLUEPRINT-AUTHORING.md §11.1.
 annotations:
   catalyst.openova.io/no-upstream: "true"
-version: 0.1.0
+version: 0.1.1
 appVersion: "0.1.0"
 description: |
   Catalyst Blueprint chart for the openova-flow-adapter-flux emitter

--- a/platform/openova-flow-server/chart/Chart.yaml
+++ b/platform/openova-flow-server/chart/Chart.yaml
@@ -5,7 +5,7 @@ name: bp-openova-flow-server
 # Opt out of the hollow-chart guard per docs/BLUEPRINT-AUTHORING.md §11.1.
 annotations:
   catalyst.openova.io/no-upstream: "true"
-version: 0.1.0
+version: 0.1.1
 appVersion: "0.1.0"
 description: |
   Catalyst Blueprint chart for the openova-flow-server — the


### PR DESCRIPTION
Forces chroot Flux to re-pull bp-openova-flow-{server,emitter} with ghcr.io repo after the same-tag republish couldn't trigger reconcile.