### PR TITLE
fix(catalyst-api): add OPENOVA_FLOW_SERVER_URL env to chart

### DIFF
--- a/products/catalyst/chart/templates/api-deployment.yaml
+++ b/products/catalyst/chart/templates/api-deployment.yaml
@@ -168,6 +168,24 @@ spec:
           env:
             - name: PORT
               value: "8080"
+            # OPENOVA_FLOW_SERVER_URL — catalyst-api proxy upstream for
+            # /api/v1/flows/{deploymentId}/snapshot|stream|events. When
+            # set, the proxy short-circuits per-deployment FQDN lookup
+            # (see openova_flow_proxy.go resolveFlowServerURL) and uses
+            # this URL for every flow id. Used by the mothership
+            # (contabo) and by Sovereign chroots that install the
+            # openova-flow chart in the same cluster — both can reach
+            # their LOCAL openova-flow-server via in-cluster Service DNS
+            # without needing the public HTTPRoute. Empty on Sovereigns
+            # that rely on per-deployment FQDN resolution.
+            #
+            # Without this env, the proxy returns 502 on every
+            # /api/v1/flows/{id}/snapshot because the resolver tries to
+            # reach https://openova-flow.<sovereignFQDN> which only
+            # exists on a Sovereign that has installed bootstrap-kit
+            # slot 56 with httproute.enabled=true.
+            - name: OPENOVA_FLOW_SERVER_URL
+              value: "http://openova-flow-server.catalyst.svc.cluster.local"
             # CATALYST_BUILD_SHA / CATALYST_CHART_VERSION — qa-loop iter-3
             # Fix #18 (TC-261). The /api/v1/version handler resolves these
             # env vars first (envOrTrim) before falling back to the ldflag


### PR DESCRIPTION
## Summary
- Adds OPENOVA_FLOW_SERVER_URL=http://openova-flow-server.catalyst.svc.cluster.local to api-deployment.yaml env so the openova_flow_proxy short-circuits per-deployment FQDN lookup
- Fixes live "No nodes to render" regression on console.openova.io after Flux reconcile wiped the manual kubectl set env

## Test plan
- [x] catalyst-api Pod restarts with new env
- [x] /api/v1/flows/<id>/snapshot returns 200 with real flow data
- [x] Canvas at /sovereign/provision/12e194090631a885/jobs/<jobName> renders bubbles

🤖 Generated with [Claude Code](https://claude.com/claude-code)