### PR TITLE
fix(JobDetail): fall back to OpenovaFlow snapshot when legacy /jobs 404

### DIFF
--- a/products/catalyst/bootstrap/ui/src/lib/synthesizeJobFromFlowNode.ts
+++ b/products/catalyst/bootstrap/ui/src/lib/synthesizeJobFromFlowNode.ts
@@ -1,0 +1,81 @@
+/**
+ * synthesizeJobFromFlowNode — adapt an OpenovaFlow FlowNode to a flat Job.
+ *
+ * Why this exists:
+ *   JobDetail's primary lookup path is the legacy event-stream reducer +
+ *   live-jobs backfill (`useDeploymentEvents` + `useLiveJobsBackfill`).
+ *   For Sovereigns whose state lives ONLY in the OpenovaFlow snapshot —
+ *   post-flux-only provisions, fresh chroot consoles before the legacy
+ *   bridge has emitted any rows — that lookup misses and JobDetail used
+ *   to short-circuit to the "Job not found" panel, NEVER mounting the
+ *   FlowPage canvas. The canvas, however, has authoritative state for
+ *   those node ids (verified live 2026-05-11: GET /v1/flows/<id>/snapshot
+ *   returns 2 leaf nodes that GET /v1/deployments/<id>/jobs/<id> 404s on).
+ *
+ *   This adapter produces a Job stub from a FlowNode so JobDetail can
+ *   render its full surface (header, canvas, log pane) using the flow
+ *   snapshot as the source of truth. The synthesized Job is
+ *   intentionally minimal — it carries only what JobDetail.tsx + the
+ *   embedded FlowPage need to mount: `id`, a display label, a status,
+ *   and the required-but-empty navigation fields (`appId`, `parentId`,
+ *   `dependsOn`, `childIds`).
+ *
+ * Single source of truth:
+ *   The Job shape lives in `@/lib/jobs.types`. We never re-declare it
+ *   here — any future field added there is filled in via TypeScript
+ *   structural checks at the call site, not by hand at this layer.
+ *
+ * Inviolable principles cited (docs/INVIOLABLE-PRINCIPLES.md):
+ *   #1 (waterfall): target-state fallback, no MVP "show loading" stub.
+ *   #2 (no compromise): no field is faked with plausible data; absent
+ *     timestamps land as null / 0 so downstream `fmtTime` formatters
+ *     render "—" not a hallucinated time.
+ *   #4 (never hardcode): the synthesized type is `'install'` (the only
+ *     leaf type) — the call site is responsible for not passing a group
+ *     node here. The label falls back to the id when `label` is empty.
+ */
+
+import type { FlowNode } from '@openova/flow-core'
+import type { Job, JobStatus } from './jobs.types'
+
+/**
+ * FlowNode.status is a free-form string per `@openova/flow-core` (the
+ * adapter contract allows family-specific status vocabularies). For the
+ * canvas-bound JobDetail consumer we want the canonical four-bucket
+ * JobStatus. Anything outside the four buckets coerces to `'pending'`
+ * so the status chip + LogPane tone resolve cleanly.
+ */
+const JOB_STATUS_SET = new Set<JobStatus>([
+  'pending',
+  'running',
+  'succeeded',
+  'failed',
+])
+
+function coerceJobStatus(s: string | undefined): JobStatus {
+  if (s && (JOB_STATUS_SET as Set<string>).has(s)) return s as JobStatus
+  return 'pending'
+}
+
+/**
+ * Build a flat {@link Job} stub from a FlowNode. The result is safe to
+ * pass anywhere a Job is expected; it intentionally has no children and
+ * no execution backing, so the LogPane will fall through to its
+ * empty-state / global-stream path naturally.
+ */
+export function synthesizeJobFromFlowNode(n: FlowNode): Job {
+  return {
+    id: n.id,
+    jobName: n.label || n.id,
+    displayName: n.label || undefined,
+    type: 'install',
+    appId: '',
+    parentId: '',
+    dependsOn: [],
+    childIds: [],
+    status: coerceJobStatus(n.status),
+    startedAt: null,
+    finishedAt: null,
+    durationMs: 0,
+  }
+}

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/JobDetail.flow-fallback.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/JobDetail.flow-fallback.test.tsx
@@ -1,0 +1,238 @@
+/**
+ * JobDetail.flow-fallback.test.tsx — OpenovaFlow snapshot fallback.
+ *
+ * Regression coverage for the 2026-05-11 cluster of iter-1 FAILs
+ * (TC-019/020/021/023/024/025/027/028/033/034/036/037/038/039/040/041
+ * /042/053/054/060/064 against the OpenovaFlow canvas matrix):
+ *
+ *   For Sovereigns that exist ONLY in the openova-flow snapshot (no
+ *   legacy job-event-stream backing — verified live with deployment
+ *   12e194090631a885 where GET /v1/flows/<id>/snapshot returns 2 leaf
+ *   nodes but GET /v1/deployments/<id>/jobs/<id> 404s on those node
+ *   ids), navigating to /sovereign/provision/<id>/jobs/<nodeId> landed
+ *   in JobDetail. JobDetail built `jobsById` from the legacy reducer +
+ *   live-jobs backfill, found nothing, and short-circuited to the
+ *   "Job not found" panel — NEVER mounting FlowPage. The canvas, the
+ *   surface that WOULD have painted the node, never got the chance.
+ *
+ *   The fix wires JobDetail to read the same `useFlowStream` hook
+ *   FlowPage uses; when the legacy lookup misses, JobDetail
+ *   synthesizes a Job stub from the FlowNode so the canvas mounts
+ *   with the right hostJobId.
+ *
+ * Cases:
+ *   1. Legacy `jobsById` has the job → FlowPage renders, no fallback
+ *      path consulted (legacy still wins).
+ *   2. Legacy empty, openova-flow snapshot has the node → FlowPage
+ *      renders, fallback path mounted the synth Job.
+ *   3. Both legacy AND flow snapshot empty → "Job not found" panel.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, screen, cleanup, waitFor } from '@testing-library/react'
+import {
+  RouterProvider,
+  createRouter,
+  createRootRoute,
+  createRoute,
+  createMemoryHistory,
+  Outlet,
+} from '@tanstack/react-router'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import type { FlowNode, FlowInstance } from '@openova/flow-core'
+import type { Job } from '@/lib/jobs.types'
+import { useWizardStore } from '@/entities/deployment/store'
+import { INITIAL_WIZARD_STATE } from '@/entities/deployment/model'
+
+/* ────────────────────────────────────────────────────────────────────
+ * Module-level mock for useFlowStream — case 2 needs to make the SSE
+ * adapter "see" a flow node without a real EventSource. Tests that
+ * don't care about the stream get the default empty stream.
+ * ──────────────────────────────────────────────────────────────────── */
+
+const mockStreamState = {
+  flow: null as FlowInstance | null,
+  nodes: new Map<string, FlowNode>(),
+  relationships: new Map(),
+  streamStatus: 'completed' as const,
+  streamError: null as string | null,
+}
+
+vi.mock('@/lib/openflow-adapter-sse', () => ({
+  useFlowStream: () => mockStreamState,
+}))
+
+/**
+ * Import JobDetail AFTER the mock so the module sees the mocked hook.
+ */
+// eslint-disable-next-line import/first
+import { JobDetail } from './JobDetail'
+
+function renderDetail(deploymentId: string, jobId: string, liveJobs: Job[]) {
+  const rootRoute = createRootRoute({ component: () => <Outlet /> })
+  const detailRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/provision/$deploymentId/jobs/$jobId',
+    component: () => <JobDetail disableStream />,
+  })
+  const flowRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/provision/$deploymentId/flow',
+    component: () => <div data-testid="flow-target" />,
+  })
+  const jobsRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/provision/$deploymentId/jobs',
+    component: () => <div data-testid="jobs-target" />,
+  })
+  const homeRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/provision/$deploymentId',
+    component: () => <div data-testid="apps-target" />,
+  })
+  const tree = rootRoute.addChildren([detailRoute, flowRoute, jobsRoute, homeRoute])
+  const router = createRouter({
+    routeTree: tree,
+    history: createMemoryHistory({
+      initialEntries: [`/provision/${deploymentId}/jobs/${jobId}`],
+    }),
+  })
+
+  globalThis.fetch = ((input: RequestInfo | URL) => {
+    const url = typeof input === 'string' ? input : input.toString()
+    if (url.endsWith(`/v1/deployments/${encodeURIComponent(deploymentId)}/jobs`)) {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ jobs: liveJobs }),
+      } as unknown as Response)
+    }
+    return Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve({ events: [], state: undefined, done: false }),
+    } as unknown as Response)
+  }) as typeof fetch
+
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  })
+  return render(
+    <QueryClientProvider client={qc}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>,
+  )
+}
+
+beforeEach(() => {
+  useWizardStore.setState({ ...INITIAL_WIZARD_STATE })
+  // Reset the mock stream to empty before each test; case 2 explicitly
+  // seeds it before render.
+  mockStreamState.flow = null
+  mockStreamState.nodes = new Map()
+  mockStreamState.relationships = new Map()
+  mockStreamState.streamStatus = 'completed'
+  mockStreamState.streamError = null
+})
+
+afterEach(() => cleanup())
+
+describe('JobDetail — OpenovaFlow snapshot fallback (iter-1 FAIL cluster fix)', () => {
+  it('Case 1 — legacy jobsById has the job: renders FlowPage, no fallback', async () => {
+    const deploymentId = 'd-legacy'
+    const jobId = `${deploymentId}:install-cilium`
+    const liveJobs: Job[] = [
+      {
+        id: jobId,
+        jobName: 'install-cilium',
+        displayName: 'Install Cilium',
+        type: 'install',
+        appId: 'bp-cilium',
+        parentId: '',
+        dependsOn: [],
+        childIds: [],
+        status: 'running',
+        startedAt: '2026-05-11T10:00:00Z',
+        finishedAt: null,
+        durationMs: 1_000,
+      },
+    ]
+    // Intentionally seed the flow snapshot with a DIFFERENT node id so
+    // we can prove the legacy lookup wins when it has a hit.
+    mockStreamState.nodes = new Map<string, FlowNode>([
+      [
+        'contabo:bp-other',
+        {
+          id: 'contabo:bp-other',
+          flowId: deploymentId,
+          label: 'Other node',
+          status: 'pending',
+        },
+      ],
+    ])
+
+    renderDetail(deploymentId, jobId, liveJobs)
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('job-detail-not-found')).toBeNull()
+      expect(screen.queryByTestId(`job-detail-${jobId}`)).toBeTruthy()
+      expect(screen.queryByTestId('job-detail-canvas')).toBeTruthy()
+      expect(screen.queryByTestId('flow-page-embedded')).toBeTruthy()
+    })
+    // Legacy displayName wins.
+    expect(screen.getByTestId('portal-header-title').textContent).toBe('Install Cilium')
+  })
+
+  it('Case 2 — legacy empty, openova-flow snapshot has the node: renders FlowPage via synth job', async () => {
+    const deploymentId = '12e194090631a885'
+    const jobId = 'contabo:bp-openova-flow-server'
+    // No legacy jobs at all — mirrors the real-world wedge.
+    const liveJobs: Job[] = []
+    mockStreamState.nodes = new Map<string, FlowNode>([
+      [
+        jobId,
+        {
+          id: jobId,
+          flowId: deploymentId,
+          label: 'openova-flow-server',
+          status: 'succeeded',
+        },
+      ],
+      [
+        'contabo:bp-openova-flow-emitter',
+        {
+          id: 'contabo:bp-openova-flow-emitter',
+          flowId: deploymentId,
+          label: 'openova-flow-emitter',
+          status: 'succeeded',
+        },
+      ],
+    ])
+
+    renderDetail(deploymentId, jobId, liveJobs)
+
+    await waitFor(() => {
+      // The fallback prevents the not-found short-circuit.
+      expect(screen.queryByTestId('job-detail-not-found')).toBeNull()
+      // FlowPage canvas mounts with the synth job's id.
+      expect(screen.queryByTestId(`job-detail-${jobId}`)).toBeTruthy()
+      expect(screen.queryByTestId('job-detail-canvas')).toBeTruthy()
+      expect(screen.queryByTestId('flow-page-embedded')).toBeTruthy()
+    })
+    // Synth Job carried the FlowNode's label into the header.
+    expect(screen.getByTestId('portal-header-title').textContent).toBe('openova-flow-server')
+  })
+
+  it('Case 3 — both legacy AND flow snapshot empty: renders "Job not found"', async () => {
+    const deploymentId = 'd-empty'
+    const jobId = 'contabo:bp-nothing-here'
+    const liveJobs: Job[] = []
+    mockStreamState.nodes = new Map()
+
+    renderDetail(deploymentId, jobId, liveJobs)
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('job-detail-not-found')).toBeTruthy()
+    })
+    // And no canvas / embedded flow-page mounted.
+    expect(screen.queryByTestId('job-detail-canvas')).toBeNull()
+    expect(screen.queryByTestId('flow-page-embedded')).toBeNull()
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/JobDetail.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/JobDetail.tsx
@@ -55,6 +55,8 @@ import type { Job } from '@/lib/jobs.types'
 import { LogPane } from '@/components/LogPane'
 import type { LogLine, LogLevel } from '@/components/ExecutionLogs'
 import { FlowPage } from './FlowPage'
+import { useFlowStream } from '@/lib/openflow-adapter-sse'
+import { synthesizeJobFromFlowNode } from '@/lib/synthesizeJobFromFlowNode'
 
 interface JobDetailProps {
   /** Test seam — disables the live SSE EventSource attach. */
@@ -127,7 +129,34 @@ export function JobDetail({
     }
     return out
   }, [jobs])
-  const job = jobsById[jobId]
+
+  // OpenovaFlow fallback. The legacy `useDeploymentEvents` reducer +
+  // `useLiveJobsBackfill` polling only see jobs that have flowed
+  // through the catalyst-api event bridge. Sovereigns whose state
+  // lives ONLY in the openova-flow snapshot (post-flux-only flow,
+  // fresh chroot before the bridge has emitted any rows) produce an
+  // empty `jobsById[jobId]` lookup even though the canvas has
+  // authoritative state for the node. Without this fallback JobDetail
+  // short-circuits to the "Job not found" panel and never mounts
+  // FlowPage — which is the very surface that would have painted the
+  // node. The fix: read the same SSE stream FlowPage uses, build a
+  // FlowNode lookup, and when the legacy lookup misses, synthesize a
+  // Job stub from the FlowNode so the canvas mounts with the real
+  // hostJobId. Behaviour for Sovereigns WITH an active event stream
+  // is unchanged — the legacy `jobsById[jobId]` wins and the
+  // synthesized stub is never read.
+  const flowStream = useFlowStream({ deploymentId, disableStream })
+  const flowNodeById = useMemo(
+    () => flowStream.nodes,
+    [flowStream.nodes],
+  )
+  const legacyJob = jobsById[jobId]
+  const job: Job | undefined = useMemo(() => {
+    if (legacyJob) return legacyJob
+    const flowNode = flowNodeById.get(jobId)
+    if (flowNode) return synthesizeJobFromFlowNode(flowNode)
+    return undefined
+  }, [legacyJob, flowNodeById, jobId])
 
   // Host job = the page owner. The canvas paints a persistent teal
   // ring on this id and the LogPane defaults to the host's logs.


### PR DESCRIPTION
## Problem

For every Sovereign that exists ONLY in the OpenovaFlow snapshot (no legacy
job-event-stream backing), navigating to
`/sovereign/provision/<deploymentId>/jobs/<nodeId>` lands in `JobDetail.tsx`,
which builds `jobsById` from the legacy `useDeploymentEvents` reducer +
`useLiveJobsBackfill` polling. For those Sovereigns the legacy lookup is
empty, so `JobDetail` short-circuited to the "Job not found" panel and
NEVER mounted `FlowPage` — the very surface that has authoritative state
for the node.

Verified live against deployment `12e194090631a885`:

- `GET /api/v1/flows/12e194090631a885/snapshot` → 200, 2 leaf nodes
  (`contabo:bp-openova-flow-server` + `contabo:bp-openova-flow-emitter`)
- `GET /api/v1/deployments/12e194090631a885/jobs/<nodeId>` → 404

This blocks ~20 of 26 iter-1 FAILs on the OpenovaFlow canvas test matrix:
TC-019, TC-020, TC-021, TC-023, TC-024, TC-025, TC-027, TC-028, TC-033,
TC-034, TC-036, TC-037, TC-038, TC-039, TC-040, TC-041, TC-042, TC-053,
TC-054, TC-060, TC-064.

## Fix

- `JobDetail` now reads the same `useFlowStream({deploymentId})` hook that
  `FlowPage` uses (canonical SSE seam in `lib/openflow-adapter-sse.ts`).
- When `jobsById[jobId]` is undefined, look up the node in the flow
  snapshot's `nodes` Map. If found, synthesize a flat `Job` stub from the
  `FlowNode` (id, label, status) via a new helper
  `lib/synthesizeJobFromFlowNode.ts` — so the canvas mounts with the right
  `hostJobId`.
- Behaviour for Sovereigns WITH an active event stream is unchanged: the
  legacy `jobsById[jobId]` lookup wins and the synth stub is never read.
- "Job not found" panel renders ONLY when BOTH lookups miss.

## Test coverage

New unit test `JobDetail.flow-fallback.test.tsx` (vitest):
1. Legacy `jobsById` has the job → `FlowPage` renders, no fallback.
2. Legacy empty, flow snapshot has the node → `FlowPage` renders via
   synth job (the iter-1 FAIL scenario).
3. Both legacy AND flow snapshot empty → "Job not found" panel.

All 3 new + 5 existing `JobDetail` tests pass. `tsc --noEmit` produces
27 errors with the change applied vs 27 errors on `origin/main` — same
baseline noise in `flow-canvas`/`flow-core` packages, no new errors in
the changed files.

## Files changed

- `products/catalyst/bootstrap/ui/src/pages/sovereign/JobDetail.tsx`
- `products/catalyst/bootstrap/ui/src/lib/synthesizeJobFromFlowNode.ts` (new)
- `products/catalyst/bootstrap/ui/src/pages/sovereign/JobDetail.flow-fallback.test.tsx` (new)

## Inviolable principles cited

- #1 (waterfall): target-state fallback, no MVP "show loading" stub.
- #2 (no compromise): no field is faked with plausible data; absent
  timestamps land as `null` / `0` so `fmtTime` renders `"—"`.
- #4 (never hardcode): the synth helper coerces `FlowNode.status` into
  the canonical `JobStatus` vocabulary; the label falls back to the node
  id when `label` is empty.