### PR TITLE
fix(JobsPage): merge openova-flow snapshot rows into legacy /jobs table

### DIFF
--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/JobsPage.flow-merge.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/JobsPage.flow-merge.test.tsx
@@ -1,0 +1,303 @@
+/**
+ * JobsPage.flow-merge.test.tsx — OpenovaFlow snapshot row merge.
+ *
+ * Regression coverage for TC-035 (iter-1, 2026-05-11):
+ *
+ *   For Sovereigns where some HelmReleases exist ONLY in the OpenovaFlow
+ *   snapshot — verified live with deployment 12e194090631a885: GET
+ *   /v1/flows/<id>/snapshot returns 2 leaf nodes (contabo:bp-openova-
+ *   flow-server, contabo:bp-openova-flow-emitter) whose ids never appear
+ *   in the legacy /api/v1/deployments/<id>/jobs payload — the JobsTable
+ *   would silently drop those rows. JobsPage now wires `useFlowStream`
+ *   alongside the legacy reducer + live-backfill, synthesizes a Job stub
+ *   per FlowNode via `synthesizeJobFromFlowNode` (PR #1412), and appends
+ *   the rows whose ids are absent from the legacy set.
+ *
+ *   Dedup rule: legacy wins. Legacy rows carry real execution timeline,
+ *   appId, parentId, dependsOn, etc. — the flow synth is a minimal stub
+ *   intended only to surface a row that would otherwise be missing.
+ *
+ * Cases:
+ *   1. Legacy returns 5 jobs, flow stream empty → table shows the 5
+ *      legacy rows, no flow rows (no behavior change).
+ *   2. Legacy returns 5 jobs, flow stream has 2 distinct ids → table
+ *      shows 7 rows with the `contabo:bp-…` flow ids present.
+ *   3. Legacy returns 5 jobs INCLUDING one id that also appears in flow
+ *      stream → table shows 5 rows (legacy wins dedup).
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, screen, cleanup, waitFor } from '@testing-library/react'
+import {
+  RouterProvider,
+  createRouter,
+  createRootRoute,
+  createRoute,
+  createMemoryHistory,
+  Outlet,
+} from '@tanstack/react-router'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import type { FlowNode, FlowInstance } from '@openova/flow-core'
+import type { Job } from '@/lib/jobs.types'
+import { useWizardStore } from '@/entities/deployment/store'
+import { INITIAL_WIZARD_STATE } from '@/entities/deployment/model'
+
+/* ────────────────────────────────────────────────────────────────────
+ * Module-level mock for useFlowStream — exact same pattern as
+ * JobDetail.flow-fallback.test.tsx. Each test seeds `mockStreamState`
+ * before render; the JobsPage's `useFlowStream({deploymentId})` reads
+ * directly from this object (no async transport).
+ * ──────────────────────────────────────────────────────────────────── */
+
+const mockStreamState = {
+  flow: null as FlowInstance | null,
+  nodes: new Map<string, FlowNode>(),
+  relationships: new Map(),
+  streamStatus: 'completed' as const,
+  streamError: null as string | null,
+}
+
+vi.mock('@/lib/openflow-adapter-sse', () => ({
+  useFlowStream: () => mockStreamState,
+}))
+
+// eslint-disable-next-line import/first
+import { JobsPage } from './JobsPage'
+
+function makeLegacyJob(id: string, jobName: string): Job {
+  return {
+    id,
+    jobName,
+    displayName: jobName,
+    type: 'install',
+    appId: jobName.replace(/^install-/, 'bp-'),
+    parentId: '',
+    dependsOn: [],
+    childIds: [],
+    status: 'succeeded',
+    startedAt: '2026-05-11T10:00:00Z',
+    finishedAt: '2026-05-11T10:01:00Z',
+    durationMs: 60_000,
+  }
+}
+
+function renderJobs(deploymentId: string, liveJobs: Job[]) {
+  const rootRoute = createRootRoute({ component: () => <Outlet /> })
+  const jobsRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/provision/$deploymentId/jobs',
+    // disableStream gates `useDeploymentEvents` (the legacy SSE event
+    // stream) — JSDOM has no EventSource and `useDeploymentEvents`
+    // unconditionally attaches one. `useFlowStream` is mocked at
+    // module level above so `disableStream` doesn't affect flow data.
+    // `disableJobsBackfill=false` keeps the legacy backfill fetcher
+    // active so the injected `liveJobs` list reaches mergeJobs.
+    component: () => <JobsPage disableStream />,
+  })
+  const homeRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/provision/$deploymentId',
+    component: () => <div data-testid="apps-target" />,
+  })
+  const detailRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/provision/$deploymentId/app/$componentId',
+    component: () => <div data-testid="app-detail-target" />,
+  })
+  const jobDetailRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/provision/$deploymentId/jobs/$jobId',
+    component: () => <div data-testid="job-detail-target" />,
+  })
+  const flowRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/provision/$deploymentId/flow',
+    component: () => <div data-testid="flow-target" />,
+  })
+  const wizardRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/wizard',
+    component: () => <div data-testid="wizard-target" />,
+  })
+  const tree = rootRoute.addChildren([
+    jobsRoute,
+    homeRoute,
+    detailRoute,
+    jobDetailRoute,
+    flowRoute,
+    wizardRoute,
+  ])
+  const router = createRouter({
+    routeTree: tree,
+    history: createMemoryHistory({ initialEntries: [`/provision/${deploymentId}/jobs`] }),
+  })
+
+  // Stub fetch: legacy /jobs returns the injected list; the SSE
+  // event-stream endpoint returns an inert empty payload (the
+  // useDeploymentEvents reducer is harmless without a real stream).
+  globalThis.fetch = ((input: RequestInfo | URL) => {
+    const url = typeof input === 'string' ? input : input.toString()
+    if (url.endsWith(`/v1/deployments/${encodeURIComponent(deploymentId)}/jobs`)) {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ jobs: liveJobs }),
+      } as unknown as Response)
+    }
+    return Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve({ events: [], state: undefined, done: false }),
+    } as unknown as Response)
+  }) as typeof fetch
+
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  })
+  return render(
+    <QueryClientProvider client={qc}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>,
+  )
+}
+
+beforeEach(() => {
+  useWizardStore.setState({ ...INITIAL_WIZARD_STATE })
+  // Reset the mock stream to empty before each test.
+  mockStreamState.flow = null
+  mockStreamState.nodes = new Map()
+  mockStreamState.relationships = new Map()
+  mockStreamState.streamStatus = 'completed'
+  mockStreamState.streamError = null
+})
+
+afterEach(() => cleanup())
+
+describe('JobsPage — OpenovaFlow snapshot merge (TC-035 fix)', () => {
+  it('Case 1 — legacy 5 / flow empty: 5 rows, no behavior change', async () => {
+    const deploymentId = 'd-case1'
+    const liveJobs: Job[] = [
+      makeLegacyJob(`${deploymentId}:install-cilium`, 'install-cilium'),
+      makeLegacyJob(`${deploymentId}:install-cert-manager`, 'install-cert-manager'),
+      makeLegacyJob(`${deploymentId}:install-flux`, 'install-flux'),
+      makeLegacyJob(`${deploymentId}:install-keycloak`, 'install-keycloak'),
+      makeLegacyJob(`${deploymentId}:install-gitea`, 'install-gitea'),
+    ]
+    // mockStreamState.nodes left empty from beforeEach reset.
+
+    renderJobs(deploymentId, liveJobs)
+
+    await screen.findByTestId('jobs-table')
+    await waitFor(() => {
+      // All 5 legacy rows present by their deterministic per-id testid.
+      for (const j of liveJobs) {
+        expect(screen.queryByTestId(`jobs-table-row-${j.id}`)).toBeTruthy()
+      }
+    })
+    // No flow-only rows appended.
+    expect(screen.queryByTestId('jobs-table-row-contabo:bp-openova-flow-server')).toBeNull()
+    expect(screen.queryByTestId('jobs-table-row-contabo:bp-openova-flow-emitter')).toBeNull()
+  })
+
+  it('Case 2 — legacy 5 / flow has 2 distinct ids: table shows 7 rows', async () => {
+    const deploymentId = '12e194090631a885'
+    const liveJobs: Job[] = [
+      makeLegacyJob(`${deploymentId}:install-cilium`, 'install-cilium'),
+      makeLegacyJob(`${deploymentId}:install-cert-manager`, 'install-cert-manager'),
+      makeLegacyJob(`${deploymentId}:install-flux`, 'install-flux'),
+      makeLegacyJob(`${deploymentId}:install-keycloak`, 'install-keycloak'),
+      makeLegacyJob(`${deploymentId}:install-gitea`, 'install-gitea'),
+    ]
+    mockStreamState.nodes = new Map<string, FlowNode>([
+      [
+        'contabo:bp-openova-flow-server',
+        {
+          id: 'contabo:bp-openova-flow-server',
+          flowId: deploymentId,
+          label: 'openova-flow-server',
+          status: 'succeeded',
+        },
+      ],
+      [
+        'contabo:bp-openova-flow-emitter',
+        {
+          id: 'contabo:bp-openova-flow-emitter',
+          flowId: deploymentId,
+          label: 'openova-flow-emitter',
+          status: 'succeeded',
+        },
+      ],
+    ])
+
+    renderJobs(deploymentId, liveJobs)
+
+    await screen.findByTestId('jobs-table')
+    await waitFor(() => {
+      // All 5 legacy rows present.
+      for (const j of liveJobs) {
+        expect(screen.queryByTestId(`jobs-table-row-${j.id}`)).toBeTruthy()
+      }
+      // Both flow-only rows appended.
+      expect(
+        screen.queryByTestId('jobs-table-row-contabo:bp-openova-flow-server'),
+      ).toBeTruthy()
+      expect(
+        screen.queryByTestId('jobs-table-row-contabo:bp-openova-flow-emitter'),
+      ).toBeTruthy()
+    })
+  })
+
+  it('Case 3 — legacy 5 / flow has 1 ID-collision + 1 new: legacy wins, total 6 rows', async () => {
+    const deploymentId = 'd-case3'
+    const collidingId = `${deploymentId}:install-cilium`
+    const liveJobs: Job[] = [
+      makeLegacyJob(collidingId, 'install-cilium'),
+      makeLegacyJob(`${deploymentId}:install-cert-manager`, 'install-cert-manager'),
+      makeLegacyJob(`${deploymentId}:install-flux`, 'install-flux'),
+      makeLegacyJob(`${deploymentId}:install-keycloak`, 'install-keycloak'),
+      makeLegacyJob(`${deploymentId}:install-gitea`, 'install-gitea'),
+    ]
+    mockStreamState.nodes = new Map<string, FlowNode>([
+      [
+        // SAME id as a legacy entry — legacy must win dedup, so the
+        // synth Job's `pending` status / empty appId never reaches the
+        // table.
+        collidingId,
+        {
+          id: collidingId,
+          flowId: deploymentId,
+          label: 'cilium-from-flow',
+          status: 'pending',
+        },
+      ],
+      [
+        'contabo:bp-openova-flow-server',
+        {
+          id: 'contabo:bp-openova-flow-server',
+          flowId: deploymentId,
+          label: 'openova-flow-server',
+          status: 'succeeded',
+        },
+      ],
+    ])
+
+    renderJobs(deploymentId, liveJobs)
+
+    await screen.findByTestId('jobs-table')
+    await waitFor(() => {
+      // All 5 legacy rows present.
+      for (const j of liveJobs) {
+        expect(screen.queryByTestId(`jobs-table-row-${j.id}`)).toBeTruthy()
+      }
+      // The non-colliding flow id is appended.
+      expect(
+        screen.queryByTestId('jobs-table-row-contabo:bp-openova-flow-server'),
+      ).toBeTruthy()
+    })
+    // The colliding id appears ONCE — legacy row only. Count
+    // direct DOM nodes with that testid; querySelectorAll is the
+    // canonical seam (used in JobsPage.test.tsx for the same anti-
+    // duplication check).
+    const collidedRows = document.querySelectorAll(
+      `[data-testid="jobs-table-row-${collidingId}"]`,
+    )
+    expect(collidedRows.length).toBe(1)
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/JobsPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/JobsPage.tsx
@@ -28,6 +28,9 @@ import { deriveJobs } from './jobs'
 import { adaptDerivedJobsToFlat } from './jobsAdapter'
 import { useLiveJobsBackfill, mergeJobs } from './useLiveJobsBackfill'
 import { DETECTED_MODE } from '@/shared/lib/detectMode'
+import { useFlowStream } from '@/lib/openflow-adapter-sse'
+import { synthesizeJobFromFlowNode } from '@/lib/synthesizeJobFromFlowNode'
+import type { Job } from '@/lib/jobs.types'
 
 interface JobsPageProps {
   /** Test seam — disables the live SSE EventSource attach. */
@@ -82,10 +85,48 @@ export function JobsPage({
     disablePolling: disableJobsBackfill || (!inFlight && !isSovereignMode),
   })
 
-  const flatJobs = useMemo(
+  const legacyMerged = useMemo(
     () => mergeJobs(reducerJobs, liveJobs),
     [reducerJobs, liveJobs],
   )
+
+  // OpenovaFlow snapshot merge — TC-035 (2026-05-11). Some Sovereign
+  // jobs (notably the openova-flow-server + openova-flow-emitter HRs)
+  // exist ONLY in the OpenovaFlow snapshot — the legacy
+  // /api/v1/deployments/<id>/jobs endpoint has no entry for those ids.
+  // Without this merge the JobsTable misses entire HelmReleases for any
+  // Sovereign with an active flow surface. Verified live: GET
+  // /v1/flows/<id>/snapshot returns 2 leaf nodes (contabo:bp-openova-
+  // flow-server, contabo:bp-openova-flow-emitter) whose ids never
+  // appear in the legacy /jobs payload. Reuses the same SSE seam +
+  // FlowNode→Job adapter the JobDetail flow-fallback (PR #1412) shipped.
+  const flowStream = useFlowStream({ deploymentId, disableStream })
+  const flowJobs = useMemo(
+    () =>
+      Array.from(flowStream.nodes.values()).map(synthesizeJobFromFlowNode),
+    [flowStream.nodes],
+  )
+
+  // Final merge: legacy (reducer + live backfill) is authoritative on
+  // id collisions because it carries real execution timeline / status
+  // / appId / parentId — the flow-stream synth job is a minimal stub.
+  // Flow rows whose id is NOT present in legacy are appended so the
+  // table covers HRs that live only in the OpenovaFlow snapshot.
+  // Behavior unchanged when the flow stream is empty (Sovereigns
+  // without openova-flow-server deployed) — flowJobs.length === 0 and
+  // the dedupe loop returns legacyMerged untouched.
+  const flatJobs: Job[] = useMemo(() => {
+    if (flowJobs.length === 0) return legacyMerged
+    const seen = new Set(legacyMerged.map((j) => j.id))
+    const extra: Job[] = []
+    for (const fj of flowJobs) {
+      if (seen.has(fj.id)) continue
+      seen.add(fj.id)
+      extra.push(fj)
+    }
+    if (extra.length === 0) return legacyMerged
+    return [...legacyMerged, ...extra]
+  }, [legacyMerged, flowJobs])
 
   const liveBackfillActive = liveJobs.length > 0
 


### PR DESCRIPTION
## TC-035 iter-1 FAIL (qa-loop 2026-05-11)

`/sovereign/provision/12e194090631a885/jobs` asserts rows for the
openova-flow-server + openova-flow-emitter HRs, but `JobsPage` only
fetches `/api/v1/deployments/<id>/jobs` (legacy event stream). Verified
live:

- `GET /api/v1/flows/12e194090631a885/snapshot` → 200 with 2 leaf nodes
  `contabo:bp-openova-flow-server` + `contabo:bp-openova-flow-emitter`.
- `GET /api/v1/deployments/12e194090631a885/jobs` → 200 with a legacy
  list that **excludes** those two ids.
- `JobsTable` rendered only the legacy rows.

Sovereigns whose state lives only in the OpenovaFlow snapshot silently
dropped those HelmRelease rows from the table — a whole product surface
was invisible to the operator.

## Fix mechanics

In `JobsPage.tsx`:

1. Wire `useFlowStream({ deploymentId, disableStream })` alongside the
   existing legacy reducer + `useLiveJobsBackfill` polling.
2. Memoize `flowJobs = Array.from(stream.nodes.values()).map(synthesizeJobFromFlowNode)`.
3. After the existing `mergeJobs(reducerJobs, liveJobs)` (legacy merge),
   append flow rows whose `id` is **not** already in the legacy set.
4. Legacy wins dedup on id collisions — it carries real execution
   timeline / `appId` / `parentId` / `dependsOn`; the flow synth is
   intentionally minimal.
5. Sort order unchanged — `JobsTable` does its own sorting on the
   merged list.
6. Sovereigns without an active flow stream: `flowJobs.length === 0` →
   `legacyMerged` passes through untouched. No behavior change.

Reuses the canonical seam shipped in #1412:

- `@/lib/openflow-adapter-sse` → `useFlowStream` (FlowPage + JobDetail
  share this hook).
- `@/lib/synthesizeJobFromFlowNode` (the same `FlowNode → Job` adapter
  JobDetail's flow-fallback path uses).
- `@/lib/jobs.types` → `Job` (single source of truth).

No new module, no new endpoint, no new adapter.

## Test coverage

`products/catalyst/bootstrap/ui/src/pages/sovereign/JobsPage.flow-merge.test.tsx`
— **3 cases, all PASS**:

| Case | Setup | Assertion |
|---|---|---|
| 1 | Legacy 5 / flow empty | Table shows 5 legacy rows, no flow rows appended. |
| 2 | Legacy 5 / flow has 2 distinct ids | Table shows 7 rows; both `contabo:bp-openova-flow-*` ids present. |
| 3 | Legacy 5 / flow has 1 id-collision + 1 new | Table shows 6 rows; the colliding `jobs-table-row-<id>` testid appears exactly once (legacy wins dedup). |

Pattern matches `JobDetail.flow-fallback.test.tsx` (PR #1412) — module-
level `vi.mock('@/lib/openflow-adapter-sse', …)` so JSDOM doesn't need
a real EventSource, and `disableStream` is passed to the JobsPage prop
to gate the legacy SSE attach (the flow-stream mock makes the flag
irrelevant to flow data).

## Validation

- `npx vitest run --pool=threads --maxWorkers=2 --no-isolate <both files>` →
  16 tests, **3 new PASS on JobsPage.flow-merge.test.tsx**, 10/13 PASS
  on JobsPage.test.tsx with **3 pre-existing failures unchanged from
  origin/main baseline** (chrome / canonical-columns / Show-as-Flow —
  unrelated to this fix; baseline confirmed by re-running on
  origin/main before applying the change).
- `npx tsc --noEmit -p products/catalyst/bootstrap/ui/tsconfig.app.json` →
  27 errors, **all pre-existing in `@openova/flow-canvas` + `@openova/
  flow-core` workspaces** (baseline). **Zero new errors** in `src/`.

## Files changed

- `products/catalyst/bootstrap/ui/src/pages/sovereign/JobsPage.tsx`
- `products/catalyst/bootstrap/ui/src/pages/sovereign/JobsPage.flow-merge.test.tsx` (new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)