### PR TITLE
fix(JobsPage): use FlowNode.id in row anchor href (region prefix)

### DIFF
--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/JobsPage.flow-merge.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/JobsPage.flow-merge.test.tsx
@@ -244,6 +244,55 @@ describe('JobsPage — OpenovaFlow snapshot merge (TC-035 fix)', () => {
     })
   })
 
+  it('Case 4 — openova-flow row anchor href carries the full region-prefixed id (TC-035)', async () => {
+    // TC-035 (2026-05-11): the canonical OpenovaFlow node id is
+    // "<region>:<jobName>" (e.g. "contabo:bp-openova-flow-server").
+    // Iter-2 surfaced that JobsTable's link builder USED to slice off
+    // the "<prefix>:" segment, producing an href of
+    //   /sovereign/provision/<id>/jobs/bp-openova-flow-server
+    // and dropping the region identity. The matrix asserts the
+    // verbatim form "/jobs/contabo:bp-openova-flow-server" must
+    // appear in the rendered DOM — which means the row anchor's
+    // href attribute must contain the literal "contabo:" prefix.
+    // FlowPage canvas navigation (PR #1411) + JobDetail flow-fallback
+    // (PR #1412) both depend on this same colon-present form and are
+    // already PASSING, so preserving the colon round-trips end-to-end.
+    const deploymentId = '12e194090631a885'
+    const liveJobs: Job[] = [
+      makeLegacyJob(`${deploymentId}:install-cilium`, 'install-cilium'),
+    ]
+    mockStreamState.nodes = new Map<string, FlowNode>([
+      [
+        'contabo:bp-openova-flow-server',
+        {
+          id: 'contabo:bp-openova-flow-server',
+          flowId: deploymentId,
+          label: 'openova-flow-server',
+          status: 'succeeded',
+        },
+      ],
+    ])
+
+    renderJobs(deploymentId, liveJobs)
+
+    await screen.findByTestId('jobs-table')
+    const link = await waitFor(() => {
+      const el = screen.queryByTestId(
+        'jobs-row-link-contabo:bp-openova-flow-server',
+      ) as HTMLAnchorElement | null
+      if (!el) throw new Error('flow row link not yet mounted')
+      return el
+    })
+    const href = link.getAttribute('href') ?? ''
+    // The matrix's literal substring assertion — the region prefix
+    // MUST survive into the URL path segment, not be stripped or
+    // %3A-encoded.
+    expect(href).toContain('/jobs/contabo:bp-openova-flow-server')
+    // And the row must NOT degrade to the bare-jobName form that the
+    // pre-fix slice produced (regression guard).
+    expect(href).not.toMatch(/\/jobs\/bp-openova-flow-server$/)
+  })
+
   it('Case 3 — legacy 5 / flow has 1 ID-collision + 1 new: legacy wins, total 6 rows', async () => {
     const deploymentId = 'd-case3'
     const collidingId = `${deploymentId}:install-cilium`

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/JobsTable.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/JobsTable.tsx
@@ -365,19 +365,22 @@ function useJobLinkBuilder(): (jobId: string) => string {
   const params = useParams({ strict: false }) as { deploymentId?: string }
   const isSovereign = DETECTED_MODE.mode === 'sovereign'
   const depId = params.deploymentId ?? ''
-  // Strip the "<deploymentId>:" prefix from the canonical Job id so the
-  // URL carries the bare jobName ("install-keycloak", not
-  // "69e73b3abe673840:install-keycloak"). Traefik (and other upstream
-  // proxies) silently drop the URL-encoding of `:` in path segments,
-  // so a route URL like `/jobs/<id>%3Ainstall-keycloak` arrives at the
-  // backend with %3A unprocessed and Store.GetJob's exact-match path
-  // misses. The bare-jobName lookup is unambiguous per (depId, name)
-  // and is the path Store.GetJob already documents (lines 781–789).
-  // URL-encode the rest so live K8s job ids that contain `/` (e.g.
-  // "job/syft-grype/...") don't fragment the route.
+  // Encode the Job id for use as a URL path segment, but preserve the
+  // literal `:` so region-prefixed OpenovaFlow ids
+  // ("contabo:bp-openova-flow-server" — TC-035, 2026-05-11) survive
+  // verbatim into the href. Previously we stripped the "<prefix>:"
+  // segment entirely to dodge a documented Traefik bug that dropped
+  // the URL-encoding of `:` in path segments — but stripping the
+  // region prefix loses the entity identity that the OpenovaFlow
+  // contract carries (the same node id is used by FlowPage canvas
+  // navigation + JobDetail flow-fallback, both PASSING with the
+  // colon-present form). `encodeURIComponent` is still used so live
+  // K8s job ids containing `/` (e.g. "job/syft-grype/…") stay safe
+  // path segments; we then restore the literal `:` because RFC 3986
+  // permits it inside a path segment (a `pchar`) and JobDetail's
+  // `useParams` lookup keys both the full id AND the bare jobName.
   return (jobId: string) => {
-    const bare = jobId.includes(':') ? jobId.slice(jobId.indexOf(':') + 1) : jobId
-    const encoded = encodeURIComponent(bare)
+    const encoded = encodeURIComponent(jobId).replace(/%3A/g, ':')
     return isSovereign || !depId
       ? `/jobs/${encoded}`
       : `/provision/${depId}/jobs/${encoded}`


### PR DESCRIPTION
## TC-035 (iter-2, 2026-05-11)

PR #1413 successfully merged the OpenovaFlow snapshot rows into the JobsPage table — row TEXT + `data-testid` carry the colon-prefixed id `contabo:bp-openova-flow-server`. But the anchor `href` builds to `/sovereign/provision/<id>/jobs/bp-openova-flow-server` — the `contabo:` region prefix is stripped. The matrix asserts `must_contain: ['/jobs/contabo:bp-openova-flow-server']`; that literal substring is absent.

## Root cause

`JobsTable.tsx → useJobLinkBuilder` carries a `jobId.slice(jobId.indexOf(':') + 1)` that was designed to strip the legacy `<deploymentId>:install-keycloak` prefix (originally added because Traefik dropped `%3A` encoding in path segments). The slice is overzealous — it also strips `contabo:` from OpenovaFlow ids, losing the region identity the OpenovaFlow contract carries.

## Fix

One-line change in `useJobLinkBuilder`: drop the slice, encode the full id, then restore the literal `:` (RFC 3986 permits it as a path-segment `pchar`). `encodeURIComponent` still escapes truly unsafe chars (`/` for live K8s ids like `job/syft-grype/...`).

```diff
- const bare = jobId.includes(':') ? jobId.slice(jobId.indexOf(':') + 1) : jobId
- const encoded = encodeURIComponent(bare)
+ const encoded = encodeURIComponent(jobId).replace(/%3A/g, ':')
```

End-to-end: FlowPage canvas navigation (PR #1411) and JobDetail flow-fallback (PR #1412) already PASS on the colon-present form. JobDetail's `jobsById` is keyed by BOTH the canonical id AND the bare jobName (`JobDetail.tsx:124-131`), so the legacy `<deploymentId>:install-keycloak` form still resolves.

## Test coverage

New **Case 4** in `JobsPage.flow-merge.test.tsx` asserts the openova-flow row's anchor `href` contains `/jobs/contabo:bp-openova-flow-server` verbatim AND is not the bare-jobName form (regression guard).

| File | Pass | Fail |
|---|---|---|
| `JobsPage.flow-merge.test.tsx` | 4/4 | 0 |
| `JobsPage.test.tsx` | 10/13 | 3 (baseline) |

The 3 pre-existing JobsPage.test.tsx failures (back-to-apps href, canonical-columns header, Show-as-Flow button) are the documented iter-2 baseline — untouched. `tsc --noEmit -p tsconfig.app.json` exits 0.

## Test plan

- [x] vitest `JobsPage.flow-merge.test.tsx` 4/4 PASS
- [x] vitest `JobsPage.test.tsx` 10/13 PASS (3 pre-existing baseline FAILs unchanged)
- [x] tsc --noEmit clean (0 NEW errors)
- [ ] Live re-run of matrix TC-035 on next executor cycle

Closes iter-2 TC-035 cluster (P1, last FAIL before 2x GREEN convergence).