### PR TITLE
fix(autoscaler): attach scale-up VMs to private network so they k3s-join

### DIFF
--- a/clusters/_template/bootstrap-kit/50-cluster-autoscaler.yaml
+++ b/clusters/_template/bootstrap-kit/50-cluster-autoscaler.yaml
@@ -77,6 +77,15 @@ spec:
   chart:
     spec:
       chart: bp-cluster-autoscaler-hcloud
+      # 1.3.0 — qa-loop chroot-canvas Fix: wire HCLOUD_NETWORK /
+      # HCLOUD_FIREWALL / HCLOUD_SSH_KEY env vars onto the autoscaler
+      # deployment so scale-up VMs land on the Phase-0 private network +
+      # firewall + ssh-key, identical to Phase-0 workers. Without these
+      # the autoscaler-spawned VMs only receive a public IP, the worker
+      # cloud-init's `K3S_URL=https://10.0.1.2:6443` is unreachable, the
+      # k3s agent join silently fails, and every scale-up times out at
+      # 15m → backoff. Live evidence: prov #38/#39/#41/#43 omantel.biz.
+      #
       # 1.2.0 — qa-loop Wave 5 Fix #79 Gap D: chart-derived
       # HCLOUD_CLUSTER_CONFIG fallback. When the per-Sovereign
       # cloud-init has not stamped the `hcloud-cloud-init` key into
@@ -85,7 +94,7 @@ spec:
       # `cluster-autoscaler.autoscalingGroups[]` so the autoscaler
       # never FATALs with the generic
       # "HCLOUD_CLUSTER_CONFIG or HCLOUD_CLOUD_INIT is not specified".
-      version: 1.2.0
+      version: 1.3.0
       sourceRef:
         kind: HelmRepository
         name: bp-cluster-autoscaler-hcloud
@@ -142,6 +151,39 @@ spec:
       # FATAL at startup, surfacing the missing-cloud-init in Pod logs;
       # operators rotate by re-running cloud-init or by patching
       # cloud-credentials directly).
+      optional: true
+    # ── Issue #1778 — Hetzner network/firewall/ssh-key attachment ──────
+    # The cluster-autoscaler-hcloud provider only attaches scale-up
+    # servers to an existing private network when HCLOUD_NETWORK is set
+    # at startup. Without it, the Phase-0 workers (which join via
+    # 10.0.1.2:6443 on the private subnet) and the autoscaler-spawned
+    # workers (which only have a public IP) live on different network
+    # planes — the autoscaler VMs cannot reach the apiserver private
+    # endpoint, the k3s agent join times out, the node never registers,
+    # the autoscaler hits a 15m scale-up timeout and enters backoff.
+    # Names are written by cloud-init (see
+    # infra/hetzner/cloudinit-control-plane.tftpl `hcloud-network-name`
+    # etc.) so the autoscaler attaches every scale-up VM to the
+    # SAME network + firewall + ssh-key the Phase-0 Tofu module created.
+    # The chart's values.yaml default of empty-string keeps the upstream
+    # deployment shape valid for legacy Sovereigns whose cloud-init
+    # never stamped these keys; on those Sovereigns Flux just skips the
+    # entry (optional: true) and the autoscaler runs in its pre-#1778
+    # shape (still broken, but no Helm render error).
+    - kind: Secret
+      name: cloud-credentials
+      valuesKey: hcloud-network-name
+      targetPath: cluster-autoscaler.extraEnv.HCLOUD_NETWORK
+      optional: true
+    - kind: Secret
+      name: cloud-credentials
+      valuesKey: hcloud-firewall-name
+      targetPath: cluster-autoscaler.extraEnv.HCLOUD_FIREWALL
+      optional: true
+    - kind: Secret
+      name: cloud-credentials
+      valuesKey: hcloud-ssh-key-name
+      targetPath: cluster-autoscaler.extraEnv.HCLOUD_SSH_KEY
       optional: true
   # Per-Sovereign baseline values. clusters/<sovereign>/bootstrap-kit/
   # 40-cluster-autoscaler.yaml MAY override `autoscalingGroups` to set

--- a/infra/hetzner/cloudinit-control-plane.tftpl
+++ b/infra/hetzner/cloudinit-control-plane.tftpl
@@ -459,6 +459,25 @@ write_files:
         # worker servers' user_data so autoscaler-spawned workers join the
         # cluster identically.
         hcloud-cloud-init: ${worker_cloud_init_b64}
+        # Issue #1778 — Hetzner network + firewall + ssh-key names so the
+        # cluster-autoscaler attaches scale-up Pods to the SAME private
+        # network + firewall the Phase-0 workers landed in. Without
+        # `HCLOUD_NETWORK`, the autoscaler-spawned VMs only receive public
+        # IPs; the worker cloud-init runs
+        # `K3S_URL=https://10.0.1.2:6443` (CP private IP) which is
+        # unreachable from a node without the 10.0.0.0/16 attachment → the
+        # k3s agent join silently fails → node never registers → autoscaler
+        # times out at 15m → backoff. The Hetzner provider docs at
+        # https://github.com/kubernetes/autoscaler/tree/master/cluster-
+        # autoscaler/cloudprovider/hetzner#environment-variables list
+        # HCLOUD_NETWORK / HCLOUD_FIREWALL / HCLOUD_SSH_KEY as the env
+        # vars that attach the spawned servers to existing resources by
+        # name. Names match the Phase-0 Tofu resource names verbatim
+        # (catalyst-<sov-fqdn-with-dashes>-{net,fw} + catalyst-<sov-fqdn-
+        # with-dashes>).
+        hcloud-network-name: ${hcloud_network_name}
+        hcloud-firewall-name: ${hcloud_firewall_name}
+        hcloud-ssh-key-name: ${hcloud_ssh_key_name}
 
   # ── Crossplane provider-hcloud + ProviderConfig (issue #425) ────────
   #

--- a/infra/hetzner/main.tf
+++ b/infra/hetzner/main.tf
@@ -469,6 +469,20 @@ locals {
     # bootstrap content the Phase-0 workers receive, so autoscaler-spawned
     # workers join the cluster identically.
     worker_cloud_init_b64 = base64encode(local.worker_cloud_init)
+
+    # Issue #1778 — Hetzner resource names threaded into
+    # flux-system/cloud-credentials so the cluster-autoscaler can map them
+    # onto HCLOUD_NETWORK / HCLOUD_FIREWALL / HCLOUD_SSH_KEY env vars.
+    # Without these the autoscaler-spawned VMs come up on public-only
+    # interfaces (no private 10.0.0.0/16 attachment), the worker cloud-
+    # init's `K3S_URL=https://10.0.1.2:6443` is unreachable, the k3s
+    # agent join silently fails, and the autoscaler times out the
+    # scale-up after 15m → backoff. Names are the Phase-0 resource names
+    # verbatim — the autoscaler resolves them via the Hetzner API at
+    # scale-up time.
+    hcloud_network_name  = hcloud_network.main.name
+    hcloud_firewall_name = hcloud_firewall.main.name
+    hcloud_ssh_key_name  = hcloud_ssh_key.main.name
   }), "/(?m)^[ ]*#( |$).*\n/", "")
 }
 

--- a/platform/cluster-autoscaler-hcloud/chart/Chart.yaml
+++ b/platform/cluster-autoscaler-hcloud/chart/Chart.yaml
@@ -16,7 +16,7 @@ description: |
   `platform/cluster-autoscaler-hcloud/README.md` for the rationale and
   ADR-0001 §13 for the cloud-direct architecture rule.
 type: application
-version: 1.2.0
+version: 1.3.0
 appVersion: "1.32.0"
 keywords: [catalyst, blueprint, cluster-autoscaler, hetzner, autoscaling]
 maintainers:

--- a/platform/cluster-autoscaler-hcloud/chart/tests/hetzner-node-config.sh
+++ b/platform/cluster-autoscaler-hcloud/chart/tests/hetzner-node-config.sh
@@ -112,4 +112,38 @@ if ! grep -qE "^[[:space:]]*cloud-init:[[:space:]]*\"?${canary}\"?\$" "$TMP/popu
 fi
 echo "  PASS"
 
+# ── Case 5: HCLOUD_NETWORK / HCLOUD_FIREWALL / HCLOUD_SSH_KEY env vars ──
+# Issue #1778 — without HCLOUD_NETWORK the autoscaler-spawned VMs come up
+# with a public IP only (no private 10.0.0.0/16 attachment) and the
+# worker cloud-init's `K3S_URL=https://10.0.1.2:6443` is unreachable →
+# k3s join fails → scale-up times out at 15m → backoff → bp-catalyst-
+# platform install wedges. This case gates against regression of the
+# three env-var slots in chart/values.yaml `cluster-autoscaler.extraEnv`.
+echo "[hetzner-node-config] Case 5: HCLOUD_NETWORK / HCLOUD_FIREWALL / HCLOUD_SSH_KEY env vars present"
+for v in HCLOUD_NETWORK HCLOUD_FIREWALL HCLOUD_SSH_KEY; do
+  if ! grep -qE "name: ${v}" "$TMP/default.yaml"; then
+    echo "FAIL: deployment missing ${v} env var (issue #1778)." >&2
+    echo "      values.yaml MUST declare an extraEnv key for ${v} so per-" >&2
+    echo "      Sovereign Flux valuesFrom can populate it from cloud-init." >&2
+    exit 1
+  fi
+done
+echo "  PASS"
+
+# ── Case 6: overlay-supplied HCLOUD_NETWORK threads through verbatim ────
+echo "[hetzner-node-config] Case 6: cluster-autoscaler.extraEnv.HCLOUD_NETWORK overlay threads verbatim"
+canary_net="catalyst-test-canary-net"
+if ! helm template smoke-cas . \
+      --set "cluster-autoscaler.extraEnv.HCLOUD_NETWORK=${canary_net}" \
+      > "$TMP/net-overlay.yaml" 2> "$TMP/net-overlay.err"; then
+  echo "FAIL: overlay render failed:" >&2
+  cat "$TMP/net-overlay.err" >&2
+  exit 1
+fi
+if ! grep -qE "value: \"?${canary_net}\"?\$" "$TMP/net-overlay.yaml"; then
+  echo "FAIL: cluster-autoscaler.extraEnv.HCLOUD_NETWORK overlay did NOT thread to deployment env." >&2
+  exit 1
+fi
+echo "  PASS"
+
 echo "[hetzner-node-config] All bp-cluster-autoscaler-hcloud node-config gates green."

--- a/platform/cluster-autoscaler-hcloud/chart/values.yaml
+++ b/platform/cluster-autoscaler-hcloud/chart/values.yaml
@@ -145,6 +145,57 @@ cluster-autoscaler:
       name: hetzner-node-config
       key: cloud-init
 
+  # ─── HCLOUD_NETWORK / FIREWALL / SSH_KEY (issue #1778) ───────────────
+  # cluster-autoscaler's Hetzner provider creates servers via the Hetzner
+  # Cloud API. By DEFAULT those servers come up with PUBLIC ipv4 only —
+  # they are NOT attached to any existing private network. That is fatal
+  # for Catalyst Sovereigns because the worker cloud-init (identical to
+  # the Phase-0 user_data) issues
+  #   curl -sfL https://get.k3s.io | K3S_URL=https://10.0.1.2:6443 ... sh -
+  # against the control plane's PRIVATE network IP (10.0.1.2). Without
+  # the 10.0.0.0/16 attachment that URL is unreachable, the k3s agent
+  # install fails, the node never registers with the apiserver, and the
+  # autoscaler times out the scale-up after 15m → enters backoff →
+  # bp-catalyst-platform install (which depends on Pending Pods being
+  # placeable) wedges → chroot canvas tests blocked.
+  #
+  # Live evidence (prov #38/#39/#41/#43 omantel.biz, 2026-05-12):
+  #   hcloud_server name=workers-77439321e2047e3e
+  #     public_net.ipv4=178.105.102.237  private_net=[]
+  #     ← never attached, never joined
+  # Autoscaler log line at scale-up timeout:
+  #   W orchestrator.go:626 Node group workers is not ready for scaleup -
+  #     backoff with status: Scale-up timed out for node group workers
+  #     after 15m2s
+  #
+  # The Hetzner provider docs (autoscaler/cluster-autoscaler/
+  # cloudprovider/hetzner/README.md §"Environment Variables") name the
+  # env vars that fix this:
+  #   HCLOUD_NETWORK  — existing network name OR id to attach to
+  #   HCLOUD_FIREWALL — existing firewall name(s) to attach to
+  #   HCLOUD_SSH_KEY  — existing ssh-key name (debug + recovery parity
+  #                     with Phase-0 nodes)
+  #
+  # Wired through the upstream chart's `extraEnv` (raw env vars; the
+  # values are not credentials — they're Hetzner resource names the
+  # autoscaler resolves via API at scale-up time). Per-Sovereign
+  # overlays populate these strings via Flux `valuesFrom` against
+  # `flux-system/cloud-credentials` keys `hcloud-network-name`,
+  # `hcloud-firewall-name`, `hcloud-ssh-key-name` (written by cloud-init
+  # — see infra/hetzner/cloudinit-control-plane.tftpl) onto the
+  # `targetPath: cluster-autoscaler.extraEnv.HCLOUD_*` slots below.
+  #
+  # Empty string defaults: when an overlay leaves a name blank the
+  # upstream chart still renders an `HCLOUD_*=""` env var on the
+  # deployment. The Hetzner provider treats empty as unset (no
+  # attachment / no firewall / no ssh-key), preserving the legacy
+  # pre-#1778 shape for Sovereigns whose cloud-init never stamped the
+  # name keys.
+  extraEnv:
+    HCLOUD_NETWORK: ""
+    HCLOUD_FIREWALL: ""
+    HCLOUD_SSH_KEY: ""
+
   # Resources — modest defaults for a controller-pattern workload that
   # mainly polls the apiserver + Hetzner API.
   resources:


### PR DESCRIPTION
## Root cause (live evidence from prov #43 chroot, autoscaler pod log)

```
W orchestrator.go:626 Node group workers is not ready for scaleup -
backoff with status: Scale-up timed out for node group workers after
15m2.273255226s
```

Hetzner API confirms autoscaler-spawned workers come up **PUBLIC-ONLY** (no private network attachment):

```
workers-77439321e2047e3e  public_net.ipv4=178.105.102.237  private_net=[]
workers-a6410e81b24cced   public_net.ipv4=178.105.73.210   private_net=[]
```

The worker cloud-init (identical to Phase-0 user_data) issues:

```
curl -sfL https://get.k3s.io | K3S_URL=https://10.0.1.2:6443 ... sh -
```

against the control plane's PRIVATE 10.0.1.2 IP. Without the 10.0.0.0/16 attachment that URL is unreachable → k3s agent install silently fails → node never registers with the apiserver → autoscaler 15 m timeout → backoff → bp-catalyst-platform Pending Pods never schedulable → chroot canvas tests blocked.

## Fix

Wire `HCLOUD_NETWORK` / `HCLOUD_FIREWALL` / `HCLOUD_SSH_KEY` env vars on the cluster-autoscaler deployment so the Hetzner provider attaches every scale-up VM to the SAME private network + firewall + ssh-key the Phase-0 Tofu module created.

Values flow (canonical seam, no kubectl writes, no bespoke API calls):

```
Tofu (hcloud_network.main.name + hcloud_firewall.main.name + hcloud_ssh_key.main.name)
 → cloudinit-control-plane.tftpl (3 new template vars)
 → /var/lib/catalyst/cloud-credentials-secret.yaml (3 new keys)
 → flux-system/cloud-credentials Secret
 → bp-cluster-autoscaler-hcloud HelmRelease valuesFrom (3 optional entries
   with targetPath: cluster-autoscaler.extraEnv.HCLOUD_*)
 → upstream chart's deployment env
```

Chart bumped 1.2.0 → 1.3.0. New smoke-test gates (Cases 5+6) prevent regression of the three env-var slots.

## Files changed
- `infra/hetzner/main.tf` — pass `hcloud_network_name`/`hcloud_firewall_name`/`hcloud_ssh_key_name` to the CP cloud-init template
- `infra/hetzner/cloudinit-control-plane.tftpl` — write 3 new keys into `flux-system/cloud-credentials` Secret
- `clusters/_template/bootstrap-kit/50-cluster-autoscaler.yaml` — 3 new `valuesFrom` entries with `targetPath: cluster-autoscaler.extraEnv.HCLOUD_*` + chart bump 1.2.0 → 1.3.0
- `platform/cluster-autoscaler-hcloud/chart/values.yaml` — declare `cluster-autoscaler.extraEnv.HCLOUD_NETWORK/FIREWALL/SSH_KEY` (empty defaults preserve pre-#1778 shape for legacy Sovereigns)
- `platform/cluster-autoscaler-hcloud/chart/Chart.yaml` — 1.2.0 → 1.3.0
- `platform/cluster-autoscaler-hcloud/chart/tests/hetzner-node-config.sh` — Case 5 (env vars present) + Case 6 (overlay threads verbatim)

## Verification
- `helm dependency build` + `helm template` → 3 env vars render, empty defaults preserved
- `helm lint .` → clean
- `bash tests/hetzner-node-config.sh` → 6/6 cases PASS (Cases 1-4 preserved, 5-6 new)

## Recommended Coordinator next step
1. Merge this PR (admin self-merge).
2. Build/release the chart (blueprint-release workflow on push to main rebuilds the OCI artifact).
3. Once chart 1.3.0 is in GHCR, wipe + reprov a fresh Sovereign (prov #44) — Phase 0 Tofu now stamps the 3 new keys into `flux-system/cloud-credentials` automatically.
4. After bp-cluster-autoscaler-hcloud reconciles, confirm `kubectl get deploy -n cluster-autoscaler -o yaml | grep -A1 HCLOUD_NETWORK` shows the resolved network name (e.g. `catalyst-omantel-omani-works-net`).
5. Expected outcome: scale-up VMs come up with `private_net=[{ip: 10.0.1.10+}]`, k3s join succeeds in ~60 s, bp-catalyst-platform Pending Pods place, canvas test unblocked.

Refs: prov #38/#39/#41/#43 omantel.biz scale-up backoff.