### PR TITLE
fix: F8 - double bp-catalyst-platform HR timeout (15m→30m) + catalyst-api phase1 budget (60m→120m)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -517,15 +517,26 @@ spec:
   # apply naturally to upgrades, and a failed first install is
   # remediated via retry without rollback (no prior release to roll
   # back to).
+  #
+  # F8 fix (2026-05-12, prov #44 RCA): bumped install + upgrade timeout
+  # 15m → 30m. F1-F7 ship live on main, qa-finalizer-strip Completed
+  # and autoscaler workers joined, but bp-catalyst-platform HR was
+  # still mid-retry (failures=3) at the catalyst-api 60m phase1 watch
+  # cap on d9399223c3caa4f9. Total bootstrap-kit install on a fresh
+  # cpx42×1 Sovereign genuinely exceeds the 15m PR #221 ceiling when
+  # the umbrella chart's full SME + Catalyst service stack rolls
+  # without a warm Harbor proxy-cache. Paired with the F8 catalyst-api
+  # DefaultWatchTimeout bump (60m → 120m) so the outer watch budget
+  # comfortably contains the new 30m × 3-retry inner HR ceiling.
   install:
     disableWait: true
-    timeout: 15m
+    timeout: 30m
     remediation:
       retries: 3
       remediateLastFailure: true
   upgrade:
     disableWait: true
-    timeout: 15m
+    timeout: 30m
     remediation:
       retries: 3
       strategy: rollback

--- a/products/catalyst/bootstrap/api/internal/handler/handler.go
+++ b/products/catalyst/bootstrap/api/internal/handler/handler.go
@@ -173,9 +173,9 @@ type Handler struct {
 	// (e.g. 100ms) to exercise the protection path in milliseconds.
 	//
 	// The threshold is sized vs the Phase-1 watcher's overall budget
-	// (DefaultWatchTimeout = 60m) so a deployment that's still
-	// converging gets at least half the watch budget before any
-	// external wipe can destroy it. otech106 incident, 2026-05-05:
+	// (DefaultWatchTimeout = 120m post-F8 2026-05-12) so a deployment
+	// that's still converging gets multiple watch-budget multiples
+	// before any external wipe can destroy it. otech106 incident, 2026-05-05:
 	// an external POST /wipe at T+24m killed a still-converging
 	// 28/40-installed Sovereign because no minimum-life guard
 	// existed.

--- a/products/catalyst/bootstrap/api/internal/handler/phase1_watch.go
+++ b/products/catalyst/bootstrap/api/internal/handler/phase1_watch.go
@@ -47,9 +47,11 @@ import (
 )
 
 // phase1WatchTimeoutEnv — env var override for the watch budget. The
-// default DefaultWatchTimeout (60 minutes) is sized for bp-catalyst-
-// platform's worst-observed install on the omantel.omani.works DoD run.
-// Tests inject a much shorter value via Handler.phase1WatchTimeout.
+// default DefaultWatchTimeout (120 minutes after F8 2026-05-12) must
+// comfortably contain bp-catalyst-platform's install.timeout × retries
+// (30m × 3 = 90m worst case per clusters/_template/bootstrap-kit/13-
+// bp-catalyst-platform.yaml). Tests inject a much shorter value via
+// Handler.phase1WatchTimeout.
 const phase1WatchTimeoutEnv = "CATALYST_PHASE1_WATCH_TIMEOUT"
 
 // phase1MinBootstrapKitHRsEnv — env var override for the lower bound

--- a/products/catalyst/bootstrap/api/internal/handler/phase1_watch_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/phase1_watch_test.go
@@ -519,6 +519,28 @@ func TestPhase1WatchConfig_FieldOverrideBeatsEnv(t *testing.T) {
 	}
 }
 
+// TestPhase1WatchConfig_ProductionDefaultIs120m pins the F8 production
+// default (2026-05-12, prov #44 RCA) so a future drift back to 60m gets
+// caught by CI. The outer watch budget MUST exceed the inner bp-
+// catalyst-platform HR install.timeout × retries (30m × 3 = 90m worst
+// case) or Phase-1 terminates while helm-controller still has remediation
+// attempts left — the wedge prov #44 hit on d9399223c3caa4f9.
+func TestPhase1WatchConfig_ProductionDefaultIs120m(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	// Explicitly clear the env so the production default-fallback path
+	// is exercised (prevents leakage from a parent process env).
+	t.Setenv("CATALYST_PHASE1_WATCH_TIMEOUT", "")
+
+	dep := makeDeploymentWithKubeconfig(t, h, "phase1-default-timeout", "fake-kubeconfig: yaml")
+	cfg := h.phase1WatchConfigForDeployment(dep, "fake-kubeconfig: yaml")
+	if cfg.WatchTimeout != helmwatch.DefaultWatchTimeout {
+		t.Errorf("WatchTimeout = %v, want helmwatch.DefaultWatchTimeout (%v)", cfg.WatchTimeout, helmwatch.DefaultWatchTimeout)
+	}
+	if helmwatch.DefaultWatchTimeout != 120*time.Minute {
+		t.Errorf("DefaultWatchTimeout = %v, want 120m (F8 floor)", helmwatch.DefaultWatchTimeout)
+	}
+}
+
 // TestPodRestart_ResumeRehydratesComponentStates proves that
 // ComponentStates + Phase1FinishedAt round-trip through the on-disk
 // store. A Pod restart that loads a completed Phase-1 deployment

--- a/products/catalyst/bootstrap/api/internal/helmwatch/helmwatch.go
+++ b/products/catalyst/bootstrap/api/internal/helmwatch/helmwatch.go
@@ -90,10 +90,22 @@ const FluxNamespace = "flux-system"
 const HelmControllerSelector = "app=helm-controller"
 
 // Default watch timeout — bp-catalyst-platform has the longest install
-// because it depends on Crossplane CRDs settling. 60 minutes is the
-// upper bound observed in DoD runs against omantel.omani.works; the
-// median is closer to 8 minutes.
-const DefaultWatchTimeout = 60 * time.Minute
+// because it depends on Crossplane CRDs settling. The watch budget
+// must comfortably contain the inner HR install timeout × retries.
+//
+// F8 fix (2026-05-12, prov #44 RCA): bumped 60m → 120m. The companion
+// bp-catalyst-platform HR install/upgrade timeout was bumped 15m → 30m
+// (see clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml).
+// prov #44 (d9399223c3caa4f9) hit the prior 60m phase1 cap with the
+// umbrella HR still mid-retry (failures=3) and 41/45 HRs True. The
+// outer watch budget MUST be larger than the inner HR's worst-case
+// retry chain (30m × 3 = 90m) so the watch never terminates while
+// helm-controller still has remediation attempts left.
+//
+// Runtime override remains via CATALYST_PHASE1_WATCH_TIMEOUT — wired
+// into products/catalyst/chart/templates/api-deployment.yaml so the
+// operator can dial it down for capacity-bounded environments.
+const DefaultWatchTimeout = 120 * time.Minute
 
 // MinComponentCount — historical minimum bootstrap-kit cardinality.
 // The Watch terminates when the informer's initial List has synced

--- a/products/catalyst/chart/templates/api-deployment.yaml
+++ b/products/catalyst/chart/templates/api-deployment.yaml
@@ -301,6 +301,21 @@ spec:
             # kit had drifted to 37. The HasSynced gate is drift-proof.
             - name: CATALYST_PHASE1_MIN_BOOTSTRAP_KIT_HRS
               value: "1"
+            # CATALYST_PHASE1_WATCH_TIMEOUT — overall budget for the
+            # Phase-1 HelmRelease watch (helmwatch.DefaultWatchTimeout).
+            # F8 fix (2026-05-12, prov #44 RCA): the previous 60m default
+            # was tighter than the inner bp-catalyst-platform HR install
+            # × retries chain after that chart's timeout was raised
+            # 15m → 30m. With retries=3 and strategy=rollback, worst-case
+            # inner HR is 30m × 3 = 90m; the outer watch budget MUST be
+            # larger so it never terminates while helm-controller still
+            # has remediation attempts left. Per docs/INVIOLABLE-
+            # PRINCIPLES.md #4 the knob is runtime-configurable here so
+            # capacity-bounded sandboxes can dial it down without a
+            # code change. Parsed by helmwatch.CompileWatchTimeout —
+            # accepts any time.ParseDuration value (e.g. "120m", "2h").
+            - name: CATALYST_PHASE1_WATCH_TIMEOUT
+              value: "120m"
             # CATALYST_KUBECONFIGS_DIR — sibling directory on the same
             # PVC for the plaintext kubeconfigs the new Sovereign POSTs
             # back via the bearer-token endpoint (issue #183, Option D).


### PR DESCRIPTION
## Summary

prov #44 (d9399223c3caa4f9) hit the catalyst-api 60m phase1 watch cap with bp-catalyst-platform HR still mid-retry (failures=3) and 41/45 HRs True. F1–F7 are live on main and correct; the remaining wall is total bootstrap-kit install time exceeding the outer watch budget on a fresh cpx42×1 Sovereign.

Two lock-step changes:

1. **HR install/upgrade 15m → 30m** in `clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml`
2. **`DefaultWatchTimeout` 60m → 120m** in `products/catalyst/bootstrap/api/internal/helmwatch/helmwatch.go`

Worst-case inner HR retry chain is now 30m × 3 = 90m; the outer phase1 budget MUST be larger so the watch never terminates while helm-controller still has remediation attempts left. `CATALYST_PHASE1_WATCH_TIMEOUT` was already env-var-tunable; the chart template `products/catalyst/chart/templates/api-deployment.yaml` now declares the explicit `120m` value so the runtime knob is discoverable. Per INVIOLABLE-PRINCIPLES.md #4 the knob remains runtime-configurable.

New unit test `TestPhase1WatchConfig_ProductionDefaultIs120m` pins the F8 floor against future regression.

## Test plan

- [x] `go vet ./...` clean
- [x] `go test ./internal/handler/ -run 'TestPhase1Watch'` — all 7 phase1_watch tests pass (incl. new ProductionDefaultIs120m)
- [x] `go test ./internal/helmwatch/...` clean (15.3s)
- [x] YAML parse: `13-bp-catalyst-platform.yaml` install.timeout/upgrade.timeout both report `30m`
- [x] Chart env: `CATALYST_PHASE1_WATCH_TIMEOUT=120m` present in api-deployment.yaml
- [ ] CI: build-catalyst-api passes
- [ ] CI: chart-tag auto-bump commit observed; new catalyst-api SHA captured for Coordinator's next reprov

🤖 Generated with [Claude Code](https://claude.com/claude-code)