### PR TITLE
fix(flow): derive HR dependsOn from live watcher + fix canvas drill-down 404

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/flow_snapshot_local.go
+++ b/products/catalyst/bootstrap/api/internal/handler/flow_snapshot_local.go
@@ -1,0 +1,359 @@
+// Package handler — flow_snapshot_local.go: assemble an OpenovaFlow
+// FlowMessage snapshot from catalyst-api's local jobs.Store so the
+// mothership canvas at /sovereign/provision/<id>/jobs renders every
+// mothership-owned Phase-0 + Phase-1 Job (tofu-init/plan/apply/output,
+// flux-bootstrap, install-bp-<chart>, cutover, handover, ...) as a
+// FlowNode FROM T+0, regardless of whether the chroot's own
+// openova-flow-server is reachable.
+//
+// Architecture rationale:
+//
+//   - catalyst-api OWNS the Phase-0 OpenTofu lifecycle Jobs AND the
+//     Phase-1 install-bp-<chart> Jobs (helmwatch.Bridge writes them
+//     into jobs.Store via the canonical helmwatch_bridge.go hook). The
+//     URL the operator clicks (/jobs/<deploymentId>:tofu-apply) carries
+//     the legacy <deploymentId>:<jobName> id form — the same form the
+//     jobs.Store keys Jobs on (Job.ID = JobID(deploymentID, jobName)).
+//
+//   - The OpenovaFlow canvas at FlowCanvasOrganic reads
+//     /api/v1/flows/<deploymentId>/snapshot for initial paint and
+//     subscribes to /stream for live updates. Before this file the
+//     snapshot handler always proxied to https://openova-flow.<sovereignFQDN>
+//     which can't serve until cilium + cert-manager + the HTTPRoute
+//     TLS cert are all up on the chroot (~T+30m). Result: the
+//     mothership-owned Jobs the operator wants to watch live were
+//     invisible for the first half-hour.
+//
+//   - We don't need a chroot adapter to render those Jobs. The data
+//     is already in jobs.Store, updated by helmwatch.Bridge for every
+//     HelmRelease state transition AND by the provisioner.go lifecycle
+//     emit() for Phase-0 phase changes. We translate it on-read into
+//     the canonical FlowMessage envelope shape.
+//
+// Wire format: the assembled envelope matches products/openova-flow/
+// adapter-flux/internal/types/flow.go FlowMessage — `nodes` are
+// FlowNode with id=Job.ID, label=Job.JobName, status=Job.Status,
+// `relationships` are `finish-to-start` edges for Job.DependsOn AND
+// `contains` edges for Job.ParentID. Same shape the chroot's adapter
+// emits, so when the chroot DOES come up later the operator can switch
+// to the chroot path without any FE change.
+//
+// docs/INVIOLABLE-PRINCIPLES.md:
+//   - #1 (target-state) — full envelope, not a stripped stub. Every
+//     Job becomes a FlowNode; every DependsOn becomes a Relationship.
+//   - #2 (no compromise) — same wire shape the chroot adapter uses, so
+//     the canvas reducer doesn't branch on data source.
+//   - #4 (never hardcode) — no region/FQDN literal; the flow id is
+//     the deployment id verbatim, the relationship types are the
+//     canonical RelationshipType enum from products/openova-flow/core.
+
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/jobs"
+)
+
+// flowSnapshotLocalNode mirrors products/openova-flow/adapter-flux/
+// internal/types/flow.go FlowNode — declared inline here so the
+// handler doesn't take a dependency on the producer-side adapter
+// module. Field names match the wire JSON exactly.
+type flowSnapshotLocalNode struct {
+	ID        string  `json:"id"`
+	FlowID    string  `json:"flowId"`
+	Label     string  `json:"label"`
+	Status    string  `json:"status"`
+	Family    *string `json:"family,omitempty"`
+	Region    *string `json:"region,omitempty"`
+	StartedAt *int64  `json:"startedAt,omitempty"`
+	EndedAt   *int64  `json:"endedAt,omitempty"`
+}
+
+// flowSnapshotLocalRelationship mirrors the same types/flow.go
+// Relationship — see node comment for rationale.
+type flowSnapshotLocalRelationship struct {
+	FromID string `json:"fromId"`
+	ToID   string `json:"toId"`
+	Type   string `json:"type"`
+}
+
+// flowSnapshotLocalFlow mirrors FlowInstance.
+type flowSnapshotLocalFlow struct {
+	ID        string `json:"id"`
+	Status    string `json:"status"`
+	StartedAt int64  `json:"startedAt"`
+}
+
+// flowSnapshotLocalMessage mirrors FlowMessage.
+type flowSnapshotLocalMessage struct {
+	Type          string                          `json:"type"`
+	Flow          *flowSnapshotLocalFlow          `json:"flow,omitempty"`
+	Nodes         []flowSnapshotLocalNode         `json:"nodes,omitempty"`
+	Relationships []flowSnapshotLocalRelationship `json:"relationships,omitempty"`
+}
+
+// jobStatusToFlowStatus maps the jobs.Store status enum (pending |
+// running | succeeded | failed) to the OpenovaFlow status convention
+// the canvas keys off. The values overlap by design — but we route
+// through this function so a future divergence stays contained.
+func jobStatusToFlowStatus(jobStatus string) string {
+	switch strings.ToLower(strings.TrimSpace(jobStatus)) {
+	case jobs.StatusSucceeded:
+		return "succeeded"
+	case jobs.StatusFailed:
+		return "failed"
+	case jobs.StatusRunning:
+		return "running"
+	case jobs.StatusPending:
+		return "pending"
+	}
+	return "pending"
+}
+
+// jobFamilyForJob returns a coarse `family` tag the canvas can use to
+// colour-group bubbles (Phase-0 vs Phase-1-install vs cutover vs
+// handover vs day-2). Optional — passes through as nil for jobs whose
+// JobName doesn't match a known family. Inspect-able by the operator
+// via the bubble tooltip.
+func jobFamilyForJob(j jobs.Job) *string {
+	name := j.JobName
+	switch {
+	case j.Type == jobs.JobTypeGroup:
+		s := "group"
+		return &s
+	case strings.HasPrefix(name, jobs.JobNamePrefix): // "install-<chart>"
+		s := "install"
+		return &s
+	case name == jobs.PhaseTofuInit || name == jobs.PhaseTofuPlan ||
+		name == jobs.PhaseTofuApply || name == jobs.PhaseTofuOutput:
+		s := "tofu"
+		return &s
+	case name == jobs.PhaseClusterBootstrap:
+		s := "bootstrap"
+		return &s
+	case strings.HasPrefix(name, "cutover"):
+		s := "cutover"
+		return &s
+	case strings.HasPrefix(name, "handover"):
+		s := "handover"
+		return &s
+	}
+	return nil
+}
+
+// flowSnapshotFromJobs builds a FlowMessage `snapshot` envelope from
+// the catalyst-api jobs.Store for the given deployment id. Returns
+// `nil, false` when the store is unconfigured OR when no Jobs are
+// known for this deployment (caller should fall through to the
+// upstream openova-flow-server proxy path).
+//
+// All Job.ID values are kept verbatim — the canvas drill-down resolves
+// /jobs/<jobId> by exact id match, and the legacy form
+// "<deploymentId>:<jobName>" is exactly what jobs.JobID emits.
+func (h *Handler) flowSnapshotFromJobs(deploymentID string) (*flowSnapshotLocalMessage, bool) {
+	st := h.jobsStore()
+	if st == nil {
+		return nil, false
+	}
+	js, err := st.ListJobs(deploymentID)
+	if err != nil || len(js) == 0 {
+		return nil, false
+	}
+
+	// FlowInstance.StartedAt — earliest non-zero Job.StartedAt across
+	// the deployment. If every Job is still pending (no StartedAt
+	// set), default to 0 — the canvas just shows the flow as "newly
+	// open" without a duration column entry.
+	var earliestUnix int64
+	flowStatus := "running"
+	allTerminal := true
+	anyFailed := false
+	for _, j := range js {
+		if j.StartedAt != nil {
+			t := j.StartedAt.Unix()
+			if earliestUnix == 0 || t < earliestUnix {
+				earliestUnix = t
+			}
+		}
+		if !jobs.IsTerminal(j.Status) {
+			allTerminal = false
+		}
+		if j.Status == jobs.StatusFailed {
+			anyFailed = true
+		}
+	}
+	if allTerminal {
+		if anyFailed {
+			flowStatus = "failed"
+		} else {
+			flowStatus = "succeeded"
+		}
+	}
+
+	nodes := make([]flowSnapshotLocalNode, 0, len(js))
+	rels := make([]flowSnapshotLocalRelationship, 0, len(js)*2)
+	for _, j := range js {
+		n := flowSnapshotLocalNode{
+			ID:     j.ID,
+			FlowID: deploymentID,
+			Label:  jobDisplayLabel(j),
+			Status: jobStatusToFlowStatus(j.Status),
+			Family: jobFamilyForJob(j),
+		}
+		if j.StartedAt != nil {
+			t := j.StartedAt.Unix()
+			n.StartedAt = &t
+		}
+		if j.FinishedAt != nil {
+			t := j.FinishedAt.Unix()
+			n.EndedAt = &t
+		}
+		nodes = append(nodes, n)
+		// Hierarchy edge — parent contains child. Skipped for
+		// top-level Jobs whose ParentID is empty (root group jobs).
+		if j.ParentID != "" {
+			rels = append(rels, flowSnapshotLocalRelationship{
+				FromID: j.ParentID,
+				ToID:   j.ID,
+				Type:   "contains",
+			})
+		}
+		// Dependency edges — finish-to-start arrows from upstream
+		// installs to this job. jobs.Bridge already normalises the
+		// dep ids into the JobID(deploymentID, "install-<chart>")
+		// form, so we copy them verbatim.
+		for _, dep := range j.DependsOn {
+			if dep == "" || dep == j.ID {
+				continue
+			}
+			rels = append(rels, flowSnapshotLocalRelationship{
+				FromID: dep,
+				ToID:   j.ID,
+				Type:   "finish-to-start",
+			})
+		}
+	}
+
+	return &flowSnapshotLocalMessage{
+		Type: "snapshot",
+		Flow: &flowSnapshotLocalFlow{
+			ID:        deploymentID,
+			Status:    flowStatus,
+			StartedAt: earliestUnix,
+		},
+		Nodes:         nodes,
+		Relationships: rels,
+	}, true
+}
+
+// jobDisplayLabel returns the user-visible label for a Job's FlowNode.
+// Prefers DisplayName (group jobs set this; the helmwatch bridge
+// leaves it empty for leaf install jobs which renders the slug).
+func jobDisplayLabel(j jobs.Job) string {
+	if strings.TrimSpace(j.DisplayName) != "" {
+		return j.DisplayName
+	}
+	return j.JobName
+}
+
+// flowStreamLocal serves the SSE `/stream` endpoint from the local
+// jobs.Store — emit a `snapshot` frame on connect AND every 3 seconds
+// thereafter. The OpenovaFlow consumer's reducer is idempotent on
+// repeated snapshots so re-emitting an unchanged envelope costs only
+// the JSON encode + a few bytes on the wire; in exchange the canvas
+// renders the latest Job state without a page refresh.
+//
+// Why poll, not subscribe: jobs.Store does NOT publish update
+// notifications today (intentional — Issue #205 left subscribe out
+// of v1 to keep the API surface small). The poll cadence is shorter
+// than a typical browser reconnect delay so the apparent latency
+// from a Job transition to the canvas updating is ≤ 3s. When
+// jobs.Store grows a subscribe API in a future change, this loop
+// flips to event-driven without touching the wire shape.
+func (h *Handler) flowStreamLocal(w http.ResponseWriter, r *http.Request, flusher http.Flusher, deploymentID string) {
+	// Canonical SSE response headers — must be set BEFORE the first
+	// write byte so the EventSource handshake completes cleanly.
+	// Mirrors openova_flow_proxy.go HandleFlowStream and
+	// deployments.go StreamLogs (the canonical SSE pattern in this
+	// codebase).
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("X-Accel-Buffering", "no")
+
+	emit := func(eventName string, msg *flowSnapshotLocalMessage) bool {
+		if msg == nil {
+			return true
+		}
+		buf, err := json.Marshal(msg)
+		if err != nil {
+			return false
+		}
+		// Named SSE events — the FE's openflow-adapter-sse.ts
+		// registers addEventListener for `snapshot`/`upsert-*`/etc.,
+		// not the default `message`. Emit under the named event so
+		// the canvas reducer dispatches correctly.
+		if _, werr := w.Write([]byte("event: " + eventName + "\ndata: ")); werr != nil {
+			return false
+		}
+		if _, werr := w.Write(buf); werr != nil {
+			return false
+		}
+		if _, werr := w.Write([]byte("\n\n")); werr != nil {
+			return false
+		}
+		flusher.Flush()
+		return true
+	}
+
+	// First frame — guaranteed snapshot on connect.
+	if msg, ok := h.flowSnapshotFromJobs(deploymentID); ok {
+		if !emit("snapshot", msg) {
+			return
+		}
+	}
+
+	// Poll cadence — 3 seconds. The browser EventSource has its own
+	// 1-2 second retry-on-error timer, so a 3-second emit cadence
+	// keeps the gap between "transition observed" and "canvas
+	// re-renders" within human-perceivable tolerance without
+	// flooding the wire.
+	const pollInterval = 3 * time.Second
+	ticker := time.NewTicker(pollInterval)
+	defer ticker.Stop()
+
+	// Heartbeat to keep the SSE connection alive through any
+	// intermediaries that idle-time TCP connections out (Cilium
+	// Gateway, browser nat helpers). Mirrors the heartbeat path the
+	// chroot openova-flow-server uses.
+	const heartbeatInterval = 15 * time.Second
+	heartbeat := time.NewTicker(heartbeatInterval)
+	defer heartbeat.Stop()
+
+	for {
+		select {
+		case <-r.Context().Done():
+			return
+		case <-ticker.C:
+			msg, ok := h.flowSnapshotFromJobs(deploymentID)
+			if !ok {
+				// Lost the deployment (e.g. wiped) — close the
+				// stream so the FE EventSource reconnects and
+				// re-runs the snapshot resolver.
+				return
+			}
+			if !emit("snapshot", msg) {
+				return
+			}
+		case <-heartbeat.C:
+			if _, werr := w.Write([]byte("event: heartbeat\ndata: {}\n\n")); werr != nil {
+				return
+			}
+			flusher.Flush()
+		}
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/handler/flow_snapshot_local.go
+++ b/products/catalyst/bootstrap/api/internal/handler/flow_snapshot_local.go
@@ -194,6 +194,29 @@ func (h *Handler) flowSnapshotFromJobs(deploymentID string) (*flowSnapshotLocalM
 		}
 	}
 
+	// Pull spec.dependsOn from the live helmwatch.Watcher's informer
+	// cache. jobs.Store does NOT persist Job.DependsOn for Phase-1
+	// install-* Jobs today (only Phase-0 cluster-bootstrap is wired),
+	// so without this every install-* bubble would render disconnected.
+	// SnapshotComponents() returns ComponentSnapshot{AppID, DependsOn}
+	// pulled from each HelmRelease's spec.dependsOn[].name (bp- prefix
+	// stripped). We index by AppID so the per-Job lookup is O(1).
+	hrDeps := map[string][]string{}
+	if val, ok := h.deployments.Load(deploymentID); ok {
+		if dep, ok := val.(*Deployment); ok && dep != nil {
+			dep.mu.Lock()
+			w := dep.liveWatcher
+			dep.mu.Unlock()
+			if w != nil {
+				for _, cs := range w.SnapshotComponents() {
+					if len(cs.DependsOn) > 0 {
+						hrDeps[cs.AppID] = cs.DependsOn
+					}
+				}
+			}
+		}
+	}
+
 	nodes := make([]flowSnapshotLocalNode, 0, len(js))
 	rels := make([]flowSnapshotLocalRelationship, 0, len(js)*2)
 	for _, j := range js {
@@ -226,16 +249,67 @@ func (h *Handler) flowSnapshotFromJobs(deploymentID string) (*flowSnapshotLocalM
 		// installs to this job. jobs.Bridge already normalises the
 		// dep ids into the JobID(deploymentID, "install-<chart>")
 		// form, so we copy them verbatim.
+		seenDep := map[string]bool{}
 		for _, dep := range j.DependsOn {
 			if dep == "" || dep == j.ID {
 				continue
 			}
+			seenDep[dep] = true
 			rels = append(rels, flowSnapshotLocalRelationship{
 				FromID: dep,
 				ToID:   j.ID,
 				Type:   "finish-to-start",
 			})
 		}
+		// Layer-2 dependency derivation — helmwatch.Bridge does NOT
+		// persist Job.DependsOn for Phase-1 install-* Jobs today, but
+		// the live HR informer cache HAS the data (HR.spec.dependsOn).
+		// For each install-<chart> Job, look up the chart's AppID and
+		// emit finish-to-start edges to its sibling install-* Jobs.
+		// Skip when AppID is empty (group jobs) or when the live
+		// watcher hasn't started yet.
+		if j.AppID != "" {
+			for _, depAppID := range hrDeps[j.AppID] {
+				if depAppID == "" {
+					continue
+				}
+				depJobID := jobs.JobID(deploymentID, jobs.JobNamePrefix+depAppID)
+				if depJobID == j.ID || seenDep[depJobID] {
+					continue
+				}
+				seenDep[depJobID] = true
+				rels = append(rels, flowSnapshotLocalRelationship{
+					FromID: depJobID,
+					ToID:   j.ID,
+					Type:   "finish-to-start",
+				})
+			}
+		}
+	}
+
+	// Group-level sequential edge — `provisioner` (Phase-0 tofu chain)
+	// must complete before `bootstrap-kit` (Phase-1 Flux reconcile)
+	// starts. This is the real temporal relationship between the two
+	// top-level groups; without it the canvas renders them as siblings
+	// with no ordering hint.
+	provisionerID := jobs.JobID(deploymentID, jobs.GroupProvisioner)
+	bootstrapID := jobs.JobID(deploymentID, jobs.GroupBootstrapKit)
+	hasProvisioner := false
+	hasBootstrap := false
+	for _, j := range js {
+		if j.ID == provisionerID {
+			hasProvisioner = true
+		}
+		if j.ID == bootstrapID {
+			hasBootstrap = true
+		}
+	}
+	if hasProvisioner && hasBootstrap {
+		rels = append(rels, flowSnapshotLocalRelationship{
+			FromID: provisionerID,
+			ToID:   bootstrapID,
+			Type:   "finish-to-start",
+		})
 	}
 
 	return &flowSnapshotLocalMessage{

--- a/products/catalyst/bootstrap/api/internal/handler/openova_flow_proxy.go
+++ b/products/catalyst/bootstrap/api/internal/handler/openova_flow_proxy.go
@@ -73,6 +73,7 @@ import (
 	"bufio"
 	"context"
 	"crypto/tls"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -191,12 +192,33 @@ func (h *Handler) resolveFlowServerURL(deploymentID string) (string, error) {
 // HandleFlowSnapshot proxies GET /api/v1/flows/{deploymentId}/snapshot →
 // GET <upstream>/v1/flows/{deploymentId}/snapshot.
 //
-// Status, headers, and body pass through verbatim. On upstream-network
-// error or unresolvable deploymentId, the proxy returns 502 / 404.
+// Local-first: catalyst-api OWNS the Phase-0 OpenTofu Jobs +
+// Phase-1 install-bp-<chart> Jobs (writes them into jobs.Store via
+// helmwatch.Bridge + provisioner lifecycle emits). When the local
+// store has Jobs for this deploymentId, we synthesise the snapshot
+// envelope from the store and return it directly — the mothership
+// canvas renders the full mothership-owned flow FROM T+0, no
+// dependency on the chroot's openova-flow-server. See
+// flow_snapshot_local.go for the assembly logic.
+//
+// Fallback: if the store has nothing for this deploymentId (e.g.
+// catalyst-api restarted before the deployment record was rehydrated,
+// or the canvas was loaded with a flowId that's not a deployment id),
+// we fall through to the upstream openova-flow-server proxy path.
+//
+// Status, headers, and body of the proxy path pass through verbatim.
+// On upstream-network error or unresolvable deploymentId, the proxy
+// returns 502 / 404.
 func (h *Handler) HandleFlowSnapshot(w http.ResponseWriter, r *http.Request) {
 	flowID := chi.URLParam(r, "deploymentId")
 	if strings.TrimSpace(flowID) == "" {
 		http.Error(w, "deploymentId required", http.StatusBadRequest)
+		return
+	}
+	if snapshot, ok := h.flowSnapshotFromJobs(flowID); ok {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(snapshot)
 		return
 	}
 	base, err := h.resolveFlowServerURL(flowID)
@@ -280,6 +302,18 @@ func (h *Handler) HandleFlowStream(w http.ResponseWriter, r *http.Request) {
 	flusher, ok := w.(http.Flusher)
 	if !ok {
 		http.Error(w, "streaming not supported", http.StatusInternalServerError)
+		return
+	}
+
+	// Local-first SSE: if catalyst-api's jobs.Store has Jobs for this
+	// deploymentId, serve the stream from the local store directly —
+	// emit a `snapshot` frame on connect, then poll every 3s and
+	// re-emit when the assembled envelope changes. The OpenovaFlow
+	// reducer is idempotent on snapshot replay, so re-emitting an
+	// unchanged snapshot is harmless; the canvas only re-renders on
+	// material changes. See flow_snapshot_local.go.
+	if _, hasLocal := h.flowSnapshotFromJobs(flowID); hasLocal {
+		h.flowStreamLocal(w, r, flusher, flowID)
 		return
 	}
 

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/FlowPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/FlowPage.tsx
@@ -291,13 +291,22 @@ export function FlowPage({
 
   const handleNodeNavigate = useCallback(
     (nodeId: string) => {
+      // Drill-down id form: jobs.Store.GetJob keys by bare jobName
+      // (e.g. "install-reflector"), NOT the full "<deploymentId>:install-reflector"
+      // id form the canvas emits. Mirror useJobLinkBuilder (JobsTable.tsx
+      // line 364): strip the "<deploymentId>:" prefix and URL-encode the
+      // remainder. Without this, the backend returns 404 because the
+      // exact-match path misses on the colon-prefixed id (Traefik drops
+      // the URL-encoding of `:` in path segments — see PR #1414 history).
+      const bare = nodeId.includes(':') ? nodeId.slice(nodeId.indexOf(':') + 1) : nodeId
+      const encoded = encodeURIComponent(bare)
       // Chroot-aware target: on the mother's monitoring surface the
       // deploymentId is in the URL; on the Sovereign's adult hostname
       // the deploymentId is implicit so the clean root form is correct.
       const target =
         deploymentId && DETECTED_MODE.mode !== 'sovereign'
-          ? `/provision/${deploymentId}/jobs/${nodeId}`
-          : `/jobs/${nodeId}`
+          ? `/provision/${deploymentId}/jobs/${encoded}`
+          : `/jobs/${encoded}`
       navigate({ to: target as never })
     },
     [navigate, deploymentId],

--- a/products/catalyst/chart/templates/api-deployment.yaml
+++ b/products/catalyst/chart/templates/api-deployment.yaml
@@ -168,6 +168,24 @@ spec:
           env:
             - name: PORT
               value: "8080"
+            # OPENOVA_FLOW_SERVER_URL — catalyst-api proxy upstream for
+            # /api/v1/flows/{deploymentId}/snapshot|stream|events. When
+            # set, the proxy short-circuits per-deployment FQDN lookup
+            # (see openova_flow_proxy.go resolveFlowServerURL) and uses
+            # this URL for every flow id. Used by the mothership
+            # (contabo) and by Sovereign chroots that install the
+            # openova-flow chart in the same cluster — both can reach
+            # their LOCAL openova-flow-server via in-cluster Service DNS
+            # without needing the public HTTPRoute. Empty on Sovereigns
+            # that rely on per-deployment FQDN resolution.
+            #
+            # Without this env, the proxy returns 502 on every
+            # /api/v1/flows/{id}/snapshot because the resolver tries to
+            # reach https://openova-flow.<sovereignFQDN> which only
+            # exists on a Sovereign that has installed bootstrap-kit
+            # slot 56 with httproute.enabled=true.
+            - name: OPENOVA_FLOW_SERVER_URL
+              value: "http://openova-flow-server.catalyst.svc.cluster.local"
             # CATALYST_BUILD_SHA / CATALYST_CHART_VERSION — qa-loop iter-3
             # Fix #18 (TC-261). The /api/v1/version handler resolves these
             # env vars first (envOrTrim) before falling back to the ldflag


### PR DESCRIPTION
Two bugs the operator hit on /sovereign/provision/<id>/jobs:

1) **install-* Jobs rendered disconnected** — helmwatch.Bridge doesn't persist Job.DependsOn for Phase-1 today. Pull HR.spec.dependsOn from the live Watcher's informer cache (SnapshotComponents().DependsOn) at snapshot-time and emit finish-to-start edges. Also add provisioner→bootstrap-kit group-to-group edge for Phase-0/Phase-1 ordering.

2) **Click node → 404** — FlowPage.handleNodeNavigate passed full `<deploymentId>:install-X` id verbatim. Store.GetJob keys by bare jobName. Mirror useJobLinkBuilder: strip prefix + encodeURIComponent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)