### PR TITLE
fix(canvas): back-to-jobs chroot-scoped + group→group edge w/o M×N lift

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/flow_snapshot_local.go
+++ b/products/catalyst/bootstrap/api/internal/handler/flow_snapshot_local.go
@@ -309,21 +309,36 @@ func (h *Handler) flowSnapshotFromJobs(deploymentID string) (*flowSnapshotLocalM
 		}
 	}
 
-	// Intentionally NO group-to-group sequential edge between
-	// `provisioner` and `bootstrap-kit` here. An earlier revision
-	// emitted provisioner→bootstrap-kit as a finish-to-start edge so
-	// the canvas would visualise Phase-0/Phase-1 ordering — but the
-	// canvas layout (flowLayoutOrganic.ts lines 414-442) lifts an
-	// elided group's outbound deps onto each of its visible children,
-	// and if the dep target is ALSO an elided group, fans out to that
-	// group's visible children. With both groups elided at depth=all
-	// the single group→group edge cascades into M×N phantom edges
-	// (each install-* gaining a dependency on every tofu-* + the
-	// cluster-bootstrap step). The operator-reported "install-cnpg
-	// has 5 connections from terraform jobs" was exactly this fan-out.
-	// Leaving Phase-0 and Phase-1 as separate connected components is
-	// the correct minimum-edge rendering; the ordering between them
-	// is implicit in the timestamps + status flow.
+	// Group-level sequential edge — `provisioner` (Phase-0 tofu chain)
+	// must complete before `bootstrap-kit` (Phase-1 Flux reconcile)
+	// starts. This is the real temporal relationship between the two
+	// top-level groups. At ?depth=1 both groups render folded and this
+	// edge correctly shows the ordering between them. At ?depth=all
+	// the FE layout would normally LIFT this edge onto every child of
+	// each elided group (flowLayoutOrganic.ts lines 414-442), causing
+	// the spurious M×N fan-out the operator originally reported. The
+	// matching FE fix in flowLayoutOrganic skips the lift when BOTH
+	// endpoints of the elided-group edge are elided — so this edge is
+	// safe to emit unconditionally.
+	provisionerID := jobs.JobID(deploymentID, jobs.GroupProvisioner)
+	bootstrapID := jobs.JobID(deploymentID, jobs.GroupBootstrapKit)
+	hasProvisioner := false
+	hasBootstrap := false
+	for _, j := range js {
+		if j.ID == provisionerID {
+			hasProvisioner = true
+		}
+		if j.ID == bootstrapID {
+			hasBootstrap = true
+		}
+	}
+	if hasProvisioner && hasBootstrap {
+		rels = append(rels, flowSnapshotLocalRelationship{
+			FromID: provisionerID,
+			ToID:   bootstrapID,
+			Type:   "finish-to-start",
+		})
+	}
 
 	return &flowSnapshotLocalMessage{
 		Type: "snapshot",

--- a/products/catalyst/bootstrap/ui/src/lib/flowLayoutOrganic.ts
+++ b/products/catalyst/bootstrap/ui/src/lib/flowLayoutOrganic.ts
@@ -429,9 +429,17 @@ export function flowLayoutOrganic(
       for (const dep of deps) {
         const depJob = byId.get(dep)
         if (depJob && elidedIds.has(depJob.id)) {
-          for (const fanned of fanOutVisibleChildren(depJob.id)) {
-            if (fanned !== childId) addEdge(fanned, childId, 'depends-on')
-          }
+          // BOTH endpoints elided — skip the M×N fan-out. The
+          // server-side snapshot still emits the original
+          // group→group edge for the depth=1 (groups-folded) view
+          // where both endpoints render as folded bubbles and the
+          // edge between them is meaningful. When both groups elide
+          // (depth=all) every install-* in bootstrap-kit was getting
+          // a spurious dep on every tofu-* in provisioner. Operator-
+          // reported "install-cnpg has 5 connections from terraform
+          // jobs" — exactly this fan-out. The actual install-* deps
+          // are already visible via each leaf's own dependsOn, so
+          // skipping the lift here costs no information.
           continue
         }
         const depRep = visibleRepresentative(dep)

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/JobDetail.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/JobDetail.tsx
@@ -253,7 +253,7 @@ export function JobDetail({
       >
         <div className="mx-auto max-w-3xl py-8" data-testid="job-detail-not-found">
           <Link
-            to={`/jobs` as never}
+            to={(deploymentId ? `/provision/${deploymentId}/jobs` : `/jobs`) as never}
             className="text-xs text-[var(--color-text-dim)] hover:text-[var(--color-text)] no-underline"
             data-testid="job-detail-back"
           >
@@ -305,7 +305,7 @@ export function JobDetail({
          * does not. */}
         <header className="job-detail-header" data-testid="job-detail-header">
           <Link
-            to={`/jobs` as never}
+            to={(deploymentId ? `/provision/${deploymentId}/jobs` : `/jobs`) as never}
             className="job-detail-back"
             data-testid="job-detail-back"
           >

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/JobsTimeline.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/JobsTimeline.tsx
@@ -122,7 +122,7 @@ export function JobsTimeline({
       pageTitle="Jobs timeline"
       headerSlotLeft={
         <Link
-          to={`/jobs` as never}
+          to={(deploymentId ? `/provision/${deploymentId}/jobs` : `/jobs`) as never}
           className="text-[11px] text-[var(--color-text-dim)] hover:text-[var(--color-text)] no-underline"
           data-testid="sov-jobs-timeline-back"
         >


### PR DESCRIPTION
Three fixes: (1) Back-to-jobs chroot-scoped to /provision/<id>/jobs. (2) Re-add provisioner→bootstrap-kit edge + fix lift to skip when both endpoints elided. (3) Document right-click menu design (groups-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)