### PR TITLE
fix(infra): restore newline escape in secondary CP regex

### DIFF
--- a/infra/hetzner/main.tf
+++ b/infra/hetzner/main.tf
@@ -922,8 +922,7 @@ locals {
       # <kubeconfigsDir>/<id>-<k>.yaml and phase1Watch can spawn a
       # per-region helmwatch.Bridge.
       kubeconfig_postback_region = k
-    }), "/(?m)^[ ]*#( |$).*
-/", "")
+    }), "/(?m)^[ ]*#( |$).*\n/", "")
   }
 
   # Per-secondary-region worker cloud-init — joins the secondary region's


### PR DESCRIPTION
Forward-fix #1444 conflict resolution corrupted the \n escape.