### PR TITLE
fix(flow_snapshot): drop duplicate live-watcher multi-region block

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/flow_snapshot_local.go
+++ b/products/catalyst/bootstrap/api/internal/handler/flow_snapshot_local.go
@@ -236,13 +236,45 @@ func (h *Handler) flowSnapshotFromJobs(deploymentID string) (*flowSnapshotLocalM
 
 	nodes := make([]flowSnapshotLocalNode, 0, len(js))
 	rels := make([]flowSnapshotLocalRelationship, 0, len(js)*2)
+	// Track secondary-region keys discovered from persisted Job names
+	// like "install-nbg1-1/cilium" — emitted as `<region>/<chart>` by
+	// spawnSecondaryRegionWatchers' callback in phase1_watch.go:457.
+	// We synthesize one bootstrap-kit sub-group per region AFTER the
+	// per-Job loop so the canvas can fold each region independently
+	// AND so the temporal-endpoint cascade in flowLayoutOrganic.ts
+	// stops at region boundaries (not at the flat bootstrap-kit set
+	// of 135 leaves). Caught on prov #59 (a43364f11c10cde3, 2026-05-13):
+	// after phase 1 terminates, dep.secondaryWatchers clears, the
+	// multi-region snapshot block below (line ~363) becomes a no-op,
+	// and all 135 secondary install Jobs render flat as direct children
+	// of bootstrap-kit with the provision-hetzner→bootstrap-kit edge
+	// fanning M×N onto every leaf. The persisted Job rows are the
+	// durable source of truth — derive region from them.
+	regionsFromJobs := map[string]bool{}
+	bootstrapID := jobs.JobID(deploymentID, jobs.GroupBootstrapKit)
 	for _, j := range js {
+		// Derive region prefix from JobName of the form
+		// "install-<region>/<chart>". The "/" separator is the
+		// canonical multi-region marker emitted by phase1_watch.go.
+		// Single-region (primary) install jobs have no `/` so this
+		// branch is a no-op for them.
+		jobRegion := ""
+		if j.Type == jobs.JobTypeInstall && j.AppID != "" {
+			if slash := strings.IndexByte(j.AppID, '/'); slash > 0 {
+				jobRegion = j.AppID[:slash]
+				regionsFromJobs[jobRegion] = true
+			}
+		}
 		n := flowSnapshotLocalNode{
 			ID:     j.ID,
 			FlowID: deploymentID,
 			Label:  jobDisplayLabel(j),
 			Status: jobStatusToFlowStatus(j.Status),
 			Family: jobFamilyForJob(j),
+		}
+		if jobRegion != "" {
+			rs := jobRegion
+			n.Region = &rs
 		}
 		if j.StartedAt != nil {
 			t := j.StartedAt.Unix()
@@ -259,10 +291,28 @@ func (h *Handler) flowSnapshotFromJobs(deploymentID string) (*flowSnapshotLocalM
 		// id goes in FromID and the parent in ToID — NOT the
 		// intuitive "parent → child" reading. Skipped for top-level
 		// Jobs whose ParentID is empty (root group jobs themselves).
-		if j.ParentID != "" {
+		//
+		// For multi-region install Jobs (JobName "install-<region>/<chart>"),
+		// REPARENT under the synthesized "<deploymentId>:<region>:bootstrap-kit"
+		// group so the canvas's organic layout renders each region as
+		// its own sub-bubble. The region groups themselves are
+		// synthesised after this loop and `contains`-edged under
+		// bootstrap-kit, so the tree shape is:
+		//   bootstrap-kit
+		//   ├── 45 primary install-* (legacy parent)
+		//   ├── <region-A>:bootstrap-kit ── 45 install-*
+		//   └── <region-B>:bootstrap-kit ── 45 install-*
+		// The temporal-endpoint cascade in flowLayoutOrganic then
+		// finds region-bounded initials/terminals instead of fanning
+		// out M×N across all 135 leaves.
+		parentID := j.ParentID
+		if jobRegion != "" {
+			parentID = deploymentID + ":" + jobRegion + ":bootstrap-kit"
+		}
+		if parentID != "" {
 			rels = append(rels, flowSnapshotLocalRelationship{
 				FromID: j.ID,
-				ToID:   j.ParentID,
+				ToID:   parentID,
 				Type:   "contains",
 			})
 		}
@@ -324,6 +374,41 @@ func (h *Handler) flowSnapshotFromJobs(deploymentID string) (*flowSnapshotLocalM
 		}
 	}
 
+	// Synthesise one bootstrap-kit sub-group per discovered region.
+	// These node IDs match the parent IDs the per-Job loop above
+	// re-parented multi-region install Jobs to. Without this
+	// post-loop append, those re-parent edges would dangle (the FE
+	// adapter's `contains` index would point at IDs with no
+	// corresponding node row).
+	//
+	// Status "running" is a placeholder — the FE rolls per-group
+	// status up from descendants on the read path. Same family/group
+	// shape as the secondaryWatchers block below so the canvas
+	// renders both code paths' region bubbles identically.
+	{
+		regionFamily := "group"
+		for region := range regionsFromJobs {
+			regionGroupID := deploymentID + ":" + region + ":bootstrap-kit"
+			regionStr := region
+			nodes = append(nodes, flowSnapshotLocalNode{
+				ID:     regionGroupID,
+				FlowID: deploymentID,
+				Label:  "Bootstrap (" + region + ")",
+				Status: "running",
+				Family: &regionFamily,
+				Region: &regionStr,
+			})
+			// Hierarchy: this region's group is contained by the
+			// top-level bootstrap-kit so the canvas can fold all
+			// regions under one parent.
+			rels = append(rels, flowSnapshotLocalRelationship{
+				FromID: regionGroupID,
+				ToID:   bootstrapID,
+				Type:   "contains",
+			})
+		}
+	}
+
 	// Group-level sequential edge — `provisioner` (Phase-0 tofu chain)
 	// must complete before `bootstrap-kit` (Phase-1 Flux reconcile)
 	// starts. This is the real temporal relationship between the two
@@ -336,7 +421,6 @@ func (h *Handler) flowSnapshotFromJobs(deploymentID string) (*flowSnapshotLocalM
 	// endpoints of the elided-group edge are elided — so this edge is
 	// safe to emit unconditionally.
 	provisionerID := jobs.JobID(deploymentID, jobs.GroupProvisioner)
-	bootstrapID := jobs.JobID(deploymentID, jobs.GroupBootstrapKit)
 	hasProvisioner := false
 	hasBootstrap := false
 	for _, j := range js {

--- a/products/catalyst/bootstrap/api/internal/handler/flow_snapshot_local.go
+++ b/products/catalyst/bootstrap/api/internal/handler/flow_snapshot_local.go
@@ -439,108 +439,20 @@ func (h *Handler) flowSnapshotFromJobs(deploymentID string) (*flowSnapshotLocalM
 		})
 	}
 
-	// Multi-region — append one synthetic group bubble per secondary
-	// region + one FlowNode per HR observed in that region's watcher
-	// + contains edges parent→child + finish-to-start edges between
-	// siblings (same-region only). Region tag is set so the canvas
-	// can colour-group by region.
-	if len(secondaryWatchers) > 0 {
-		statusToFlow := func(state string) string {
-			switch state {
-			case "installed":
-				return "succeeded"
-			case "failed":
-				return "failed"
-			case "installing", "pending", "degraded":
-				return "running"
-			}
-			return "pending"
-		}
-		for region, sw := range secondaryWatchers {
-			if sw == nil {
-				continue
-			}
-			snap := sw.SnapshotComponents()
-			if len(snap) == 0 {
-				continue
-			}
-			regionGroupID := deploymentID + ":" + region + ":bootstrap-kit"
-			regionStr := region
-			regionFamily := "group"
-			nodes = append(nodes, flowSnapshotLocalNode{
-				ID:     regionGroupID,
-				FlowID: deploymentID,
-				Label:  "Bootstrap (" + region + ")",
-				Status: "running",
-				Family: &regionFamily,
-				Region: &regionStr,
-			})
-			// Hierarchy: this region's group is contained by the
-			// top-level bootstrap-kit (so the canvas can fold all
-			// regions under one parent).
-			rels = append(rels, flowSnapshotLocalRelationship{
-				FromID: regionGroupID,
-				ToID:   bootstrapID,
-				Type:   "contains",
-			})
-
-			// Index this region's components for intra-region dep edges.
-			regionAppIDs := map[string]string{} // appID → full node id
-			for _, cs := range snap {
-				appID := cs.AppID
-				if appID == "" {
-					continue
-				}
-				nodeID := deploymentID + ":" + region + ":install-" + appID
-				regionAppIDs[appID] = nodeID
-			}
-
-			installFamily := "install"
-			for _, cs := range snap {
-				appID := cs.AppID
-				if appID == "" {
-					continue
-				}
-				nodeID := regionAppIDs[appID]
-				startedAt := int64(0)
-				if !cs.LastTransitionAt.IsZero() {
-					startedAt = cs.LastTransitionAt.Unix()
-				}
-				node := flowSnapshotLocalNode{
-					ID:     nodeID,
-					FlowID: deploymentID,
-					Label:  "install-" + appID,
-					Status: statusToFlow(cs.Status),
-					Family: &installFamily,
-					Region: &regionStr,
-				}
-				if startedAt > 0 {
-					node.StartedAt = &startedAt
-				}
-				nodes = append(nodes, node)
-				// Hierarchy
-				rels = append(rels, flowSnapshotLocalRelationship{
-					FromID: nodeID,
-					ToID:   regionGroupID,
-					Type:   "contains",
-				})
-				// Intra-region deps (same region only — DO NOT cross
-				// region edges, since each region is an independent
-				// fault domain per NAMING-CONVENTION §1.3).
-				for _, depApp := range cs.DependsOn {
-					depID, ok := regionAppIDs[depApp]
-					if !ok {
-						continue
-					}
-					rels = append(rels, flowSnapshotLocalRelationship{
-						FromID: depID,
-						ToID:   nodeID,
-						Type:   "finish-to-start",
-					})
-				}
-			}
-		}
-	}
+	// NOTE — the legacy live-watcher multi-region composition block was
+	// removed in PR #1455 (2026-05-13). The per-Job loop above already
+	// derives region from `j.AppID` containing `/` and synthesises the
+	// region sub-groups from persisted Job rows, which is the durable
+	// source of truth. The old code path read dep.secondaryWatchers
+	// (transient — cleared by stopSecondaries() when phase 1
+	// terminates) AND emitted nodes with the SAME region-group IDs as
+	// the new path, double-counting children + duplicating the region
+	// group bubbles during phase 1 (caught on prov #61: 90 children
+	// per region group, not 45). Reading secondaryWatchers earlier
+	// (lines ~182-205) still serves the hrDeps lookup for the primary
+	// region's intra-cluster dep edges; that path is unchanged.
+	// _ = secondaryWatchers — intentionally unused after this rewrite.
+	_ = secondaryWatchers
 
 	return &flowSnapshotLocalMessage{
 		Type: "snapshot",

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/JobsTable.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/JobsTable.tsx
@@ -365,22 +365,29 @@ function useJobLinkBuilder(): (jobId: string) => string {
   const params = useParams({ strict: false }) as { deploymentId?: string }
   const isSovereign = DETECTED_MODE.mode === 'sovereign'
   const depId = params.deploymentId ?? ''
-  // Encode the Job id for use as a URL path segment, but preserve the
-  // literal `:` so region-prefixed OpenovaFlow ids
-  // ("contabo:bp-openova-flow-server" — TC-035, 2026-05-11) survive
-  // verbatim into the href. Previously we stripped the "<prefix>:"
-  // segment entirely to dodge a documented Traefik bug that dropped
-  // the URL-encoding of `:` in path segments — but stripping the
-  // region prefix loses the entity identity that the OpenovaFlow
-  // contract carries (the same node id is used by FlowPage canvas
-  // navigation + JobDetail flow-fallback, both PASSING with the
-  // colon-present form). `encodeURIComponent` is still used so live
-  // K8s job ids containing `/` (e.g. "job/syft-grype/…") stay safe
-  // path segments; we then restore the literal `:` because RFC 3986
-  // permits it inside a path segment (a `pchar`) and JobDetail's
-  // `useParams` lookup keys both the full id AND the bare jobName.
+  // Strip the "<deploymentId>:" prefix from the FULL canvas JobID form
+  // before encoding. The mothership canvas emits ids like
+  // "<deploymentId>:install-X" (single-region) and
+  // "<deploymentId>:<region>:install-X" (multi-region per
+  // flow_snapshot_local.go:410). jobs.Store.GetJob keys by the BARE
+  // jobName ("install-X" or "<region>:install-X" for secondary
+  // regions) — exact-match URL lookup of the full prefix-bearing form
+  // returns 404. FlowPage.handleNodeDoubleClick already strips the
+  // first `:` prefix (FlowPage.tsx:355); this JobsTable build path
+  // must do the same so a /jobs row click and a canvas drill-down
+  // resolve to the SAME backend endpoint.
+  //
+  // Caught on prov #59 (a43364f11c10cde3, 2026-05-13): clicking a
+  // running secondary-region install-* row on /sovereign/provision/
+  // <id>/jobs landed on /provision/<id>/jobs/<id>:install-nbg1-1/
+  // self-sovereign-cutover → 404 "page not found" at the SPA boundary
+  // because no Job ID matches the prefix-bearing form in jobs.Store.
+  // Note: keep encodeURIComponent so the `/` inside multi-region bare
+  // names ("nbg1-1/self-sovereign-cutover") stays safe in a path
+  // segment; jobs.Store.GetJob URL-decodes its lookup key on the BE.
   return (jobId: string) => {
-    const encoded = encodeURIComponent(jobId).replace(/%3A/g, ':')
+    const bare = jobId.includes(':') ? jobId.slice(jobId.indexOf(':') + 1) : jobId
+    const encoded = encodeURIComponent(bare)
     return isSovereign || !depId
       ? `/jobs/${encoded}`
       : `/provision/${depId}/jobs/${encoded}`


### PR DESCRIPTION
## Summary
PR #1454 added region-group synthesis from persisted Job rows. The pre-existing live-watcher block emitted nodes with the SAME region-group IDs, double-counting children on prov #61 (90 per region instead of 45). Removed the legacy block; the per-Job path is the durable source of truth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)