### PR TITLE
fix(canvas): persist DependsOn on every event + /refresh-watch respawns secondaries

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/jobs_backfill.go
+++ b/products/catalyst/bootstrap/api/internal/handler/jobs_backfill.go
@@ -428,6 +428,19 @@ func (h *Handler) RefreshWatch(w http.ResponseWriter, r *http.Request) {
 	dep.liveWatcher = watcher
 	dep.mu.Unlock()
 
+	// Also respawn secondary-region watchers (multi-region) — without
+	// this, /refresh-watch only restores PRIMARY's HR.spec.dependsOn
+	// into Job.DependsOn, leaving the secondaries' 90 install Jobs
+	// permanently flat. spawnSecondaryRegionWatchers reads kubeconfig
+	// files from <kubeconfigsDir>/<id>-<region>.yaml and wires the
+	// region-aware seeder hook (attachSecondaryBridgeSeederHook). It
+	// is idempotent — re-spawning watchers for regions that are
+	// already up is a no-op because the spawn() inner func short-
+	// circuits when stopWatchers[region] is already set. Caught on
+	// prov #75 (2026-05-14): /refresh-watch fixed fsn1's 71 edges but
+	// hel1-2 + nbg1-1 stayed at 0 edges until this fan-out was added.
+	h.spawnSecondaryRegionWatchers(dep)
+
 	go func() {
 		// Background context so the HTTP request finishing does not
 		// cancel the multi-minute watch. The watcher's own

--- a/products/catalyst/bootstrap/api/internal/jobs/helmwatch_bridge.go
+++ b/products/catalyst/bootstrap/api/internal/jobs/helmwatch_bridge.go
@@ -499,13 +499,30 @@ func (b *Bridge) OnHelmReleaseEvent(componentID, state, level, message string, t
 	// no-op merge; if it wasn't (e.g. the bootstrap-kit hot-shipped a
 	// new chart helmwatch wasn't seeded with) the bridge still
 	// auto-creates a row so no event is dropped.
+	//
+	// IMPORTANT: explicitly carry forward the existing Job's DependsOn
+	// rather than passing []string{}. The canvas snapshot's Layer-1
+	// dep-edge derivation reads Job.DependsOn from the store, and the
+	// catalyst-api Pod's in-memory hrDeps cache is RESET on every
+	// restart — so the persisted DependsOn is the only durable source
+	// of HR-graph wiring once the live informer is gone. Relying on
+	// mergeJob's prev.DependsOn preservation is correct on paper but
+	// fragile in practice (caught on prov #75 2026-05-14 after a PR
+	// #1469 pod restart wiped Layer-2 → all 135 install Jobs ended up
+	// with `dependsOn: []` in the store → canvas showed flat fan-out).
+	// Same pattern as OnRawComponentLog at line ~939: query then
+	// preserve.
+	existingDeps := []string{}
+	if existing, _, err := b.store.GetJob(b.deploymentID, JobID(b.deploymentID, jobName)); err == nil && len(existing.DependsOn) > 0 {
+		existingDeps = existing.DependsOn
+	}
 	if err := b.store.UpsertJob(Job{
 		DeploymentID: b.deploymentID,
 		JobName:      jobName,
 		AppID:        componentID,
 		Type:         JobTypeInstall,
 		ParentID:     JobID(b.deploymentID, GroupBootstrapKit),
-		DependsOn:    []string{},
+		DependsOn:    existingDeps,
 		Status:       nextStatus,
 	}); err != nil {
 		return err


### PR DESCRIPTION
Founder caught on prov #75: pod restart from PR #1469 deploy wiped in-memory hrDeps and all 3 regions lost their wirings. Root cause: deps were never in Job.DependsOn — only in Layer-2 in-memory cache. Two fixes restore durability.