### PR TITLE
fix(openova-flow): COPY go.sum + go mod download

### DIFF
--- a/products/openova-flow/server/Dockerfile
+++ b/products/openova-flow/server/Dockerfile
@@ -6,7 +6,8 @@
 # for shipment.
 FROM golang:1.22-alpine AS build
 WORKDIR /src
-COPY go.mod ./
+COPY go.mod go.sum ./
+RUN go mod download
 COPY cmd ./cmd
 COPY internal ./internal
 COPY test ./test


### PR DESCRIPTION
Build failure post-pgx rewrite — missing go.sum entry. Add go.sum to COPY + explicit go mod download.