### PR TITLE
fix(cilium): gatewayAPI hostNetwork nodes.matchLabels — fixes console.<fqdn> dead Sovereign TLS

### DIFF
--- a/clusters/_template/bootstrap-kit/01-cilium.yaml
+++ b/clusters/_template/bootstrap-kit/01-cilium.yaml
@@ -63,7 +63,7 @@ spec:
       # 1.3.0 (qa-loop iter-12 Fix #53C+D): adds the Hubble UI HTTPRoute
       # overlay (slice H7 #1095) that the catalystOverlay.hubbleUI block
       # below depends on.
-      version: 1.3.4
+      version: 1.3.5
       sourceRef:
         kind: HelmRepository
         name: bp-cilium

--- a/platform/cilium/chart/Chart.yaml
+++ b/platform/cilium/chart/Chart.yaml
@@ -32,7 +32,7 @@ name: bp-cilium
 # + socketLB.hostNamespaceOnly=true defaults so fresh worker pods can
 # resolve DNS reliably on first-join (cilium/cilium#28456 mitigation).
 # Backward-compat: per-Sovereign overlays MAY override either knob.
-version: 1.3.4
+version: 1.3.5
 description: |
   Catalyst-curated Blueprint umbrella chart for Cilium. Depends on the
   upstream `cilium` chart as a Helm subchart so `helm dependency build`

--- a/platform/cilium/chart/values.yaml
+++ b/platform/cilium/chart/values.yaml
@@ -183,6 +183,30 @@ cilium:
     # but TLS handshake never completes.
     hostNetwork:
       enabled: true
+      # nodes.matchLabels MUST be non-empty for Cilium hostNetwork
+      # mode to activate. An empty selector becomes the configmap key
+      # `gateway-api-hostnetwork-nodelabelselector =` (empty value),
+      # which Cilium docs explicitly call out as DISABLED state:
+      # https://docs.cilium.io/en/stable/network/servicemesh/gateway-api/host-network/
+      # Without this, the Gateway listener config has empty bind
+      # address, eBPF never programs a redirect for the gateway
+      # NodePorts, and incoming traffic on 30443/30080 never reaches
+      # envoy. Hetzner LB health checks against those NodePorts
+      # report `unhealthy` indefinitely.
+      #
+      # Caught live on prov #76 (2026-05-14): TLS handshake initiates
+      # at the Hetzner LB, then SSL_ERROR_SYSCALL because no backend
+      # answers — envoy is running with the listener config but not
+      # bound to a socket because hostNetwork mode is silently OFF.
+      #
+      # Match labels are conservative — `kubernetes.io/os: linux` is
+      # universally present on every k3s node we ship, so the gateway
+      # listener is exposed on every node in single- and multi-CP
+      # Sovereign topologies. Operators that want gateway-only-on-
+      # primary-region can tighten this in their per-cluster overlay.
+      nodes:
+        matchLabels:
+          kubernetes.io/os: linux
 
   # L7 proxy via Envoy — for HTTPRoute, gRPCRoute, L7 NetworkPolicy
   envoy:


### PR DESCRIPTION
Root cause for prov #76 console.omantel.biz returning SSL_ERROR_SYSCALL: empty nodes.matchLabels disables Cilium hostNetwork gateway mode. Set kubernetes.io/os: linux.