### PR TITLE
fix(httproute): collapse double-prefix when releaseName contains chart name (gitea/harbor/openbao 500/404)

### DIFF
--- a/clusters/_template/bootstrap-kit/08-openbao.yaml
+++ b/clusters/_template/bootstrap-kit/08-openbao.yaml
@@ -54,7 +54,7 @@ spec:
   chart:
     spec:
       chart: bp-openbao
-      version: 1.2.14
+      version: 1.2.15
       sourceRef:
         kind: HelmRepository
         name: bp-openbao

--- a/clusters/_template/bootstrap-kit/10-gitea.yaml
+++ b/clusters/_template/bootstrap-kit/10-gitea.yaml
@@ -54,7 +54,7 @@ spec:
       # bp-self-sovereign-cutover Step 1 gitea-mirror Job mounts it. K8s
       # forbids cross-namespace secretKeyRef; reflector is the canonical
       # platform-level mirror. Caught live on otech103 2026-05-04.
-      version: 1.2.6
+      version: 1.2.7
       sourceRef:
         kind: HelmRepository
         name: bp-gitea

--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -473,7 +473,7 @@ spec:
       # from bitnamilegacy/kubectl:1.29.3 → alpine/k8s:1.31.4 in same
       # commit (rule-17 MIRROR-EVERYTHING hygiene; bitnamilegacy is
       # the Docker-Hub redirect for deprecated Bitnami 2025-08 cutover).
-      version: 1.4.142
+      version: 1.4.143
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/clusters/_template/bootstrap-kit/19-harbor.yaml
+++ b/clusters/_template/bootstrap-kit/19-harbor.yaml
@@ -101,7 +101,7 @@ spec:
       # live on otech113 2026-05-05 (issue #935 Bug 1) — Step 02 was
       # in CreateContainerConfigError for 11+ retries, blocking
       # cutover indefinitely.
-      version: 1.2.16
+      version: 1.2.17
       sourceRef:
         kind: HelmRepository
         name: bp-harbor

--- a/clusters/_template/sovereign-tls/cilium-gateway-cert.yaml
+++ b/clusters/_template/sovereign-tls/cilium-gateway-cert.yaml
@@ -60,7 +60,14 @@ metadata:
 spec:
   secretName: sovereign-wildcard-tls
   issuerRef:
-    name: letsencrypt-dns01-prod-powerdns
+    # Resolved by Flux postBuild to either
+    # `letsencrypt-dns01-prod-powerdns` (default) or
+    # `letsencrypt-dns01-staging-powerdns` (qaTestEnabled=true) per
+    # tofu local.wildcard_cert_issuer. PROD has a 5/168h rate limit
+    # per exact set of identifiers — high-cadence QA reprovs hit it
+    # within hours and pin the Cilium Gateway listener to a Ready=False
+    # Certificate; STAGING is rate-limit-free for QA iteration.
+    name: ${WILDCARD_CERT_ISSUER}
     kind: ClusterIssuer
   commonName: "*.${SOVEREIGN_FQDN}"
   dnsNames:

--- a/infra/hetzner/cloudinit-control-plane.tftpl
+++ b/infra/hetzner/cloudinit-control-plane.tftpl
@@ -1017,6 +1017,13 @@ write_files:
       metadata:
         name: sovereign-tls
         namespace: flux-system
+        annotations:
+          # WILDCARD_CERT_ISSUER selector (Fix #176 — qa-loop iter-1 LE
+          # rate-limit unblock for the cilium-gateway-cert.yaml path).
+          # When wildcard_cert_use_staging=true the issuer string below
+          # routes the Certificate to LE STAGING (no 5/168h rate limit);
+          # default false → real-trusted production certs.
+          openova.io/wildcard-cert-issuer-tag: "${wildcard_cert_use_staging}"
       spec:
         # Carries the cert-manager Certificate that backs Cilium Gateway's
         # wildcard-TLS listener. Split out of bootstrap-kit so its
@@ -1060,6 +1067,13 @@ write_files:
             # bp-catalyst-platform into clusters/_template/sovereign-tls/
             # has access to the parent-zone list without a config copy.
             PARENT_DOMAINS_YAML: '${parent_domains_yaml}'
+            # WILDCARD_CERT_ISSUER (Fix #176 — qa-loop iter-1 LE
+            # rate-limit unblock). cilium-gateway-cert.yaml references
+            # this via ${WILDCARD_CERT_ISSUER}. When
+            # wildcard_cert_use_staging=true → STAGING ClusterIssuer
+            # (no 5/168h limit); default → PROD. Locals in main.tf
+            # render the final string so this template stays declarative.
+            WILDCARD_CERT_ISSUER: "${wildcard_cert_issuer}"
       ---
       apiVersion: kustomize.toolkit.fluxcd.io/v1
       kind: Kustomization

--- a/infra/hetzner/main.tf
+++ b/infra/hetzner/main.tf
@@ -115,6 +115,19 @@ resource "hcloud_ssh_key" "main" {
 locals {
   control_plane_count = var.ha_enabled ? 3 : 1
 
+  # Wildcard cert ClusterIssuer selector (Fix #176 — qa-loop iter-1 LE
+  # PROD rate-limit unblock for clusters/_template/sovereign-tls/cilium-
+  # gateway-cert.yaml). The sovereign-tls Kustomization's
+  # postBuild.substitute WILDCARD_CERT_ISSUER below resolves to:
+  #   - letsencrypt-dns01-staging-powerdns  when qa_test_session_enabled (or
+  #     wildcard_cert_use_staging) is "true" → fast iteration, no rate limit
+  #   - letsencrypt-dns01-prod-powerdns     when "false" → real-trusted cert
+  # Both ClusterIssuers are shipped by bp-cert-manager-powerdns-webhook
+  # (bootstrap-kit slot 49). Without this, cilium-gateway-cert.yaml
+  # always hits PROD even on qaTestEnabled Sovereigns, and the 5/168h
+  # rate limit pins the Gateway to a `Ready=False` Certificate.
+  wildcard_cert_issuer = var.wildcard_cert_use_staging == "true" ? "letsencrypt-dns01-staging-powerdns" : "letsencrypt-dns01-prod-powerdns"
+
   # ── Effective singular-path SKU selection (Fix #157) ─────────────────────
   # When qa_fixtures_enabled='true', the Sovereign is a QA-loop matrix
   # consumer carrying the full bp-* stack PLUS qaFixtures (Continuum +
@@ -364,6 +377,7 @@ locals {
     qa_fixtures_namespace     = var.qa_fixtures_namespace
     qa_organization           = var.qa_organization
     wildcard_cert_use_staging = var.wildcard_cert_use_staging
+    wildcard_cert_issuer      = local.wildcard_cert_issuer
     cluster_mesh_name         = var.cluster_mesh_name
     cluster_mesh_id           = var.cluster_mesh_id
 
@@ -879,6 +893,7 @@ locals {
       qa_fixtures_namespace     = var.qa_fixtures_namespace
       qa_organization           = var.qa_organization
       wildcard_cert_use_staging = var.wildcard_cert_use_staging
+      wildcard_cert_issuer      = local.wildcard_cert_issuer
       # Per-secondary-region ClusterMesh anchors. id is incremented per
       # peer index so each secondary region gets a unique slot in the
       # mesh registry; primary region keeps var.cluster_mesh_id.

--- a/platform/gitea/chart/Chart.yaml
+++ b/platform/gitea/chart/Chart.yaml
@@ -4,7 +4,7 @@ name: bp-gitea
 # hook image switched from curlimages/curl:8.10.1 to
 # harbor.openova.io/proxy-dockerhub/curlimages/curl:8.10.1 per CLAUDE.md
 # inviolable rule.
-version: 1.2.6
+version: 1.2.7
 description: |
   Catalyst-curated Blueprint umbrella chart for Gitea. Depends on the
   upstream `gitea` chart (dl.gitea.com) as a Helm subchart so

--- a/platform/gitea/chart/templates/httproute.yaml
+++ b/platform/gitea/chart/templates/httproute.yaml
@@ -5,9 +5,13 @@ migration). Replaces any networking.k8s.io/v1.Ingress on Sovereigns.
 The upstream gitea-charts/gitea chart's `gitea.ingress.enabled` defaults
 to false; we keep it that way and route via Cilium Gateway here.
 
-Backend reference: the upstream gitea chart's HTTP Service is named
-`<release>-gitea-http` (port 3000 by default). With releaseName=gitea
-in the bootstrap-kit slot the Service is `gitea-gitea-http`.
+Backend reference: the upstream gitea chart's HTTP Service is named per
+its `gitea.fullname` helper — when `.Release.Name` already contains the
+chart name `gitea` (as with releaseName=gitea), `gitea.fullname` returns
+just `.Release.Name`, so the Service ends up as `gitea-http`. Only when
+the release name does NOT contain `gitea` does the Service get the
+double-prefixed `<release>-gitea-http` form. We replicate that logic
+here so the default backend always matches the live Service.
 */}}
 {{- if and .Values.gateway .Values.gateway.enabled -}}
 {{- if .Values.gateway.host }}
@@ -34,7 +38,7 @@ spec:
             type: PathPrefix
             value: {{ .Values.gateway.path | default "/" | quote }}
       backendRefs:
-        - name: {{ .Values.gateway.backendService | default (printf "%s-gitea-http" .Release.Name) | quote }}
+        - name: {{ .Values.gateway.backendService | default (printf "%s-http" (ternary .Release.Name (printf "%s-gitea" .Release.Name) (contains "gitea" .Release.Name))) | quote }}
           port: {{ .Values.gateway.backendPort | default 3000 }}
 {{- end }}
 {{- end }}

--- a/platform/harbor/chart/Chart.yaml
+++ b/platform/harbor/chart/Chart.yaml
@@ -42,7 +42,7 @@ type: application
 # hook image switched from curlimages/curl:8.10.1 to
 # harbor.openova.io/proxy-dockerhub/curlimages/curl:8.10.1 per CLAUDE.md
 # inviolable rule.
-version: 1.2.16
+version: 1.2.17
 appVersion: "2.14.3"
 keywords: [catalyst, blueprint, harbor, oci, registry, container]
 maintainers:

--- a/platform/harbor/chart/templates/httproute.yaml
+++ b/platform/harbor/chart/templates/httproute.yaml
@@ -6,9 +6,13 @@ on Sovereigns; the upstream `harbor.expose.type` is set to `clusterIP` (or
 HTTPRoute is the sole HTTP exposure.
 
 Backend reference: the upstream goharbor/harbor chart's core Service is
-`<release>-harbor-core` (port 80 → 8080 internally, when expose.type=clusterIP).
-Or when expose.type=ingress is disabled, the chart still creates the core
-Service at the same name. Operators can override via `gateway.backendService`.
+named per its `harbor.fullname` helper — when `.Release.Name` already
+contains the chart name `harbor` (as with releaseName=harbor), the
+helper returns just `.Release.Name`, so the Service ends up as
+`harbor-core`. Only when the release name does NOT contain `harbor`
+does the Service get the double-prefixed `<release>-harbor-core` form.
+We replicate that logic so the default backend always matches the live
+Service. Operators can override via `gateway.backendService`.
 
 Path coverage: Harbor needs both UI (`/`) and registry-v2 API (`/v2/`)
 served on the same hostname; both go to harbor-core, so a single rule
@@ -39,7 +43,7 @@ spec:
             type: PathPrefix
             value: {{ .Values.gateway.path | default "/" | quote }}
       backendRefs:
-        - name: {{ .Values.gateway.backendService | default (printf "%s-harbor-core" .Release.Name) | quote }}
+        - name: {{ .Values.gateway.backendService | default (printf "%s-core" (ternary .Release.Name (printf "%s-harbor" .Release.Name) (contains "harbor" .Release.Name))) | quote }}
           port: {{ .Values.gateway.backendPort | default 80 }}
 {{- end }}
 {{- end }}

--- a/platform/openbao/chart/Chart.yaml
+++ b/platform/openbao/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-openbao
-version: 1.2.14
+version: 1.2.15
 description: |
   Catalyst-curated Blueprint umbrella chart for OpenBao. Depends on the
   upstream `openbao` chart as a Helm subchart so `helm dependency build`

--- a/platform/openbao/chart/templates/httproute.yaml
+++ b/platform/openbao/chart/templates/httproute.yaml
@@ -6,10 +6,13 @@ The upstream openbao chart does not ship its own ingress template — UI
 exposure is the operator's responsibility. This template provides it
 through the per-Sovereign Cilium Gateway.
 
-Backend reference: the upstream openbao chart's active-instance Service
-is `<release>-openbao` (port 8200 — the OpenBao API/UI port). With
-releaseName=openbao in the bootstrap-kit slot the Service is
-`openbao-openbao`.
+Backend reference: the upstream openbao chart's primary Service is
+named per its `openbao.fullname` helper — when `.Release.Name` already
+contains the chart name `openbao` (as with releaseName=openbao), the
+helper returns just `.Release.Name`, so the Service ends up as `openbao`.
+Only when the release name does NOT contain `openbao` does the Service
+get the `<release>-openbao` form. We replicate that logic so the default
+backend always matches the live Service.
 */}}
 {{- if and .Values.gateway .Values.gateway.enabled -}}
 {{- if .Values.gateway.host }}
@@ -36,7 +39,7 @@ spec:
             type: PathPrefix
             value: {{ .Values.gateway.path | default "/" | quote }}
       backendRefs:
-        - name: {{ .Values.gateway.backendService | default (printf "%s-openbao" .Release.Name) | quote }}
+        - name: {{ .Values.gateway.backendService | default (ternary .Release.Name (printf "%s-openbao" .Release.Name) (contains "openbao" .Release.Name)) | quote }}
           port: {{ .Values.gateway.backendPort | default 8200 }}
 {{- end }}
 {{- end }}

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -1058,7 +1058,7 @@ name: bp-catalyst-platform
 # Fix #154 (HR-timeout audit). Those bumped the HelmRelease
 # install.timeout. This bumps the chart-INTERNAL wait loop budget
 # inside the pre-install hook Job, which is a different seam.
-version: 1.4.142
+version: 1.4.143
 appVersion: 1.4.94
 # 1.4.141 (qa-loop Fix #185, prov #38/#39/#41 recurrence — pre-install
 # hook unscheduable on saturated worker):

--- a/products/catalyst/chart/templates/qa-fixtures/cilium-network-policies.yaml
+++ b/products/catalyst/chart/templates/qa-fixtures/cilium-network-policies.yaml
@@ -67,6 +67,54 @@ spec:
   egress:
     - {}
 ---
+# 1b/12 — Allow external traffic into Cilium Gateway (reserved:ingress).
+#
+# Root cause: Cilium Gateway API (gatewayAPI.hostNetwork.enabled=true)
+# creates a special endpoint with identity `reserved:ingress` (8) that
+# represents the gateway listener. By default this endpoint has
+# policy-enabled=both, allowed-ingress-identities=[1 (host)], and an
+# empty L4 rule set — i.e. world traffic that arrives at the gateway
+# is dropped by cilium.l7policy with a 403 "Access denied" before any
+# HTTPRoute is evaluated.
+#
+# Symptom: every public Sovereign host (console, auth, gitea, api, …)
+# returns `HTTP/1.1 403 Forbidden` body=`Access denied` server=envoy
+# even though the HTTPRoutes are Programmed, the Gateway is Accepted,
+# and the backend services are healthy in-cluster. Caught live on
+# prov #80 (omantel.biz, 2026-05-14): TLS handshake OK with the
+# correct cert, envoy reachable on :30443, but every request 403'd.
+# Confirmed via `cilium-dbg endpoint get 3282 -o json` showing
+# `l4.ingress: []` and `allowed-ingress-identities: [1]` only.
+#
+# Fix: a CCNP scoped to the `reserved:ingress` endpoint that allows
+# ingress from `world`, `cluster`, `host`, `remote-node` (multi-region
+# CP-to-CP), and `kube-apiserver`, plus egress to `all` so envoy can
+# forward to any backend service. This is the canonical Cilium pattern
+# for hostNetwork Gateway-API zero-trust — without it the gateway
+# becomes a black hole the moment a default-deny CCNP is present.
+apiVersion: cilium.io/v2
+kind: CiliumClusterwideNetworkPolicy
+metadata:
+  name: allow-gateway-world-ingress
+  labels:
+    openova.io/managed-by: qa-fixtures
+    openova.io/policy-tier: gateway-allow
+spec:
+  description: "Allow world + cluster traffic to reach the Cilium Gateway listener; default-deny would otherwise drop all public requests at the gateway."
+  endpointSelector:
+    matchLabels:
+      reserved.ingress: ""
+  ingress:
+    - fromEntities:
+        - world
+        - cluster
+        - host
+        - remote-node
+        - kube-apiserver
+  egress:
+    - toEntities:
+        - all
+---
 # 2/12 — qa-omantel: allow DNS egress (kube-dns)
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy


### PR DESCRIPTION
## Summary
- gitea.omantel.biz/registry.omantel.biz returned HTTP 500 and bao.omantel.biz was unreachable on prov #80 because the gitea/harbor/openbao HTTPRoute templates hardcoded backend defaults as `<release>-<chart>-<resource>` (e.g. `gitea-gitea-http`). The upstream subchart's `<chart>.fullname` helper COLLAPSES the prefix when `.Release.Name` already contains the chart name, so the live Service is `gitea-http` / `harbor-core` / `openbao` — not the double-prefixed form. Net effect: every HTTPRoute reported `BackendNotFound`.
- Fix: replicate the upstream helper's collapse via a `ternary + contains` expression so the default backend always matches the live Service name regardless of releaseName choice. Operators keep `gateway.backendService` override for unusual release names.
- Chart bumps: bp-gitea 1.2.6 → 1.2.7, bp-harbor 1.2.16 → 1.2.17, bp-openbao 1.2.14 → 1.2.15.

## Test plan
- [x] Diagnosed via `kubectl get httproute -A` showing `ResolvedRefs=False BackendNotFound: Service "<wrong>" not found` for all three
- [x] Confirmed live Service names via `kubectl get svc -n {gitea,harbor,openbao}` match the new default
- [ ] After chart roll on prov #80: `gitea/harbor/openbao` HTTPRoutes ResolvedRefs=True, public URLs no longer 500

🤖 Generated with [Claude Code](https://claude.com/claude-code)