### PR TITLE
fix(openbao): make auth-bootstrap Job idempotent on post-upgrade replay (unblock #1483 rollout)

### DIFF
--- a/clusters/_template/bootstrap-kit/08-openbao.yaml
+++ b/clusters/_template/bootstrap-kit/08-openbao.yaml
@@ -54,7 +54,7 @@ spec:
   chart:
     spec:
       chart: bp-openbao
-      version: 1.2.15
+      version: 1.2.16
       sourceRef:
         kind: HelmRepository
         name: bp-openbao

--- a/platform/openbao/chart/Chart.yaml
+++ b/platform/openbao/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: bp-openbao
-version: 1.2.15
+version: 1.2.16
 description: |
   Catalyst-curated Blueprint umbrella chart for OpenBao. Depends on the
   upstream `openbao` chart as a Helm subchart so `helm dependency build`

--- a/platform/openbao/chart/templates/auth-bootstrap-job.yaml
+++ b/platform/openbao/chart/templates/auth-bootstrap-job.yaml
@@ -137,6 +137,24 @@ spec:
                 sleep 5
               done
 
+              # ─── Token-validity gate (post-upgrade no-op) ─────────────
+              # On post-install (first run) BAO_TOKEN is the freshly-minted
+              # root token from openbao-root-token Secret and is valid.
+              # On post-upgrade re-runs the same root token has ALREADY
+              # been revoked by the previous run (see "revoke + cleanup"
+              # section below) so every privileged call returns 403. There
+              # is nothing meaningful for this Job to do on a re-run — the
+              # auth method, the role, and the kv backend are already
+              # configured. Detect the revoked-token case and exit 0 so a
+              # routine chart bump doesn't fail the HR's post-upgrade hook
+              # and rollback the release. Caught live on prov #80 when
+              # bp-openbao 1.2.14 → 1.2.15 (an HTTPRoute-only bump) replayed
+              # the hook and 403'd on `bao auth enable`.
+              if ! bao token lookup >/dev/null 2>&1; then
+                echo "[openbao-auth-bootstrap] BAO_TOKEN no longer valid (likely revoked by a prior successful run); nothing to do — exiting 0"
+                exit 0
+              fi
+
               # ─── Idempotency: skip if auth method + role already exist ─
               # `bao auth list` returns 200 and the JSON includes the mount
               # path key (e.g. "kubernetes/") when the method is enabled.


### PR DESCRIPTION
## Summary
- bp-openbao 1.2.15 (the HTTPRoute backend-collapse fix from #1483) replayed the `auth-bootstrap` post-install/post-upgrade hook against an already-bootstrapped OpenBao. The hook hit `403 permission denied` on `bao auth enable`, the upgrade failed, and Flux auto-rolled the release back to 1.2.14 — in a loop.
- Root cause: at the end of its FIRST run the hook revokes its own root token (acceptance criterion #6: no root token persists). On post-upgrade replay BAO_TOKEN is REVOKED — every privileged call 403s. The existing idempotency `bao auth list | grep kubernetes/` silently fails too (the `|| echo "{}"` mask makes the script think auth is missing).
- Fix: after the "initialized+unsealed" wait, call `bao token lookup`. If it 403s, BAO_TOKEN was revoked by a prior successful run → exit 0 (auth method, role, kv backend, ESO policy are all already configured). One-line additive gate.
- Chart bump: bp-openbao 1.2.15 → 1.2.16.
- Caught live on prov #80 — bp-openbao loop blocks bp-newapi's `dependsOn` and stalls bootstrap-kit Kustomization across regions (nbg1-1 HR Ready dropped to 27/45 mid-incident).

## Test plan
- [x] Diagnosed via auth-bootstrap pod log: `Error enabling kubernetes auth ... 403 permission denied`
- [x] Confirmed root-token revocation logic in the same Job's tail
- [ ] After chart roll: bp-openbao 1.2.16 reaches Ready=True on all 3 regions of prov #80
- [ ] bp-newapi dependency unblocks; full HR ready ≥45 per region

🤖 Generated with [Claude Code](https://claude.com/claude-code)