### PR TITLE
fix(cloudinit): escape ${WILDCARD_CERT_ISSUER} in comment so tofu plan succeeds

### DIFF
--- a/infra/hetzner/cloudinit-control-plane.tftpl
+++ b/infra/hetzner/cloudinit-control-plane.tftpl
@@ -1069,7 +1069,7 @@ write_files:
             PARENT_DOMAINS_YAML: '${parent_domains_yaml}'
             # WILDCARD_CERT_ISSUER (Fix #176 — qa-loop iter-1 LE
             # rate-limit unblock). cilium-gateway-cert.yaml references
-            # this via ${WILDCARD_CERT_ISSUER}. When
+            # this via $${WILDCARD_CERT_ISSUER}. When
             # wildcard_cert_use_staging=true → STAGING ClusterIssuer
             # (no 5/168h limit); default → PROD. Locals in main.tf
             # render the final string so this template stays declarative.


### PR DESCRIPTION
## Summary
- `tofu plan` failed on prov #81 (`omani.works`) with `vars map does not contain key "WILDCARD_CERT_ISSUER"` — the FIRST provision after #1481 landed the Kustomization postBuild threading.
- Root cause: a documentation comment on line 1072 of `cloudinit-control-plane.tftpl` literally said *"references this via `${WILDCARD_CERT_ISSUER}`"*. OpenTofu's `templatefile()` parses `${…}` everywhere (even in comments) and tries to look up the key.
- Fix: escape with `$${WILDCARD_CERT_ISSUER}` so the comment is emitted as literal text. The actual binding `WILDCARD_CERT_ISSUER: "${wildcard_cert_issuer}"` two lines below stays as-is (correctly lowercase-to-uppercase mapped).
- omantel.biz never exercised this path because that prov was started BEFORE #1481 merged — first hit was on omani.works re-prov today.

## Test plan
- [ ] After merge, the next provision passes `tofu plan` cleanly
- [x] No behavior change for omantel.biz provisions already in flight (the literal text was unused at runtime)

🤖 Generated with [Claude Code](https://claude.com/claude-code)