### PR TITLE
fix(verify-pin): re-prefix basepath on hard nav after PIN success (mothership 404)

### DIFF
--- a/products/catalyst/bootstrap/ui/src/pages/auth/VerifyPinPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/auth/VerifyPinPage.tsx
@@ -101,7 +101,27 @@ export function VerifyPinPage() {
         // cluster `users-page-null-map-and-open-redirect`.
         const target = sanitizeNextParam(next) ?? '/wizard'
         if (typeof window !== 'undefined') {
-          window.location.replace(target)
+          // window.location.replace is a HARD navigation — it bypasses
+          // the TanStack Router's basepath config. On contabo the SPA
+          // mounts under `/sovereign/*`; nginx 404s any request that
+          // doesn't start with that prefix. The sanitized `next` value
+          // is post-basepath (see basepathRelative.ts: e.g. `next` of
+          // `/provision/$id/jobs` represents the route the router
+          // would navigate to AT `/sovereign/provision/$id/jobs`). So
+          // we must re-prefix `/sovereign` before the hard nav,
+          // otherwise the operator lands on a bare `/provision/...`
+          // URL that nginx never routes to the SPA.
+          //
+          // Caught live on prov #82 (omani.works, 2026-05-14): after
+          // PIN-login from console.openova.io/sovereign/login,
+          // window.location.replace('/provision/$id/jobs') went to a
+          // raw `/provision/...` URL → nginx 404 page-not-found.
+          const basepath =
+            window.location.pathname.startsWith('/sovereign')
+              ? '/sovereign'
+              : ''
+          const fullTarget = basepath + target
+          window.location.replace(fullTarget)
           return
         }
         navigate({ to: target as never, replace: true })


### PR DESCRIPTION
## Summary
- After PIN-login on console.openova.io/sovereign/login the SPA does `window.location.replace(target)` where `target` is the post-basepath path (e.g. `/provision/$id/jobs`).
- Hard nav bypasses TanStack Router's basepath config, so the browser lands at `https://console.openova.io/provision/$id/jobs` — nginx 404s because the SPA only mounts under `/sovereign/*`.
- Fix: detect `window.location.pathname.startsWith('/sovereign')` and prefix the hard-nav target with `/sovereign` so the URL stays consistent with the router-managed forms.

## Test plan
- [x] Reproduced live on prov #82 — PIN-login → 404 on `/provision/.../jobs`
- [ ] After roll: PIN-login lands on `/sovereign/provision/$id/jobs` (SPA renders the page)
- [ ] No regression on chroot Sovereigns (basepath='', target unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)