### PR TITLE
fix(provisioner): key tofu workdir by DeploymentID — kill reprov tfstate carryover

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/handover.go
+++ b/products/catalyst/bootstrap/api/internal/handler/handover.go
@@ -200,7 +200,7 @@ func (h *Handler) FinaliseHandover(w http.ResponseWriter, r *http.Request) {
 	// `secret/catalyst/tofu-phase0-archive` and replies 200 OK; only on
 	// that confirmation do we delete the local workdir.
 	prov := provisioner.New()
-	tofuWorkdir := filepath.Join(prov.WorkDir, deploymentSovereignName(dep.Request.SovereignFQDN))
+	tofuWorkdir := filepath.Join(prov.WorkDir, id)
 	archive, err := buildTofuArchive(tofuWorkdir)
 	if err != nil {
 		resp.Errors = append(resp.Errors, "build tofu archive: "+err.Error())

--- a/products/catalyst/bootstrap/api/internal/handler/wipe.go
+++ b/products/catalyst/bootstrap/api/internal/handler/wipe.go
@@ -583,7 +583,12 @@ func (h *Handler) WipeDeployment(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	tofuWorkDir := filepath.Join(prov.WorkDir, deploymentSovereignName(dep.Request.SovereignFQDN))
+	// Key the workdir by the deployment ID — the provisioner does the same
+// (provisioner.go:workdirKey()), so this matches what was actually
+// created at provision time. FQDN-keyed lookups would miss when two
+// reprovs of the same FQDN existed in sequence.
+tofuWorkDir := filepath.Join(prov.WorkDir, id)
+_ = deploymentSovereignName // retained for backwards-compat callers; unused on the wipe path now
 	if err := os.RemoveAll(tofuWorkDir); err != nil {
 		report.Errors = append(report.Errors, "remove tofu workdir: "+err.Error())
 	}

--- a/products/catalyst/bootstrap/api/internal/provisioner/provisioner.go
+++ b/products/catalyst/bootstrap/api/internal/provisioner/provisioner.go
@@ -966,7 +966,7 @@ func (p *Provisioner) Provision(ctx context.Context, req Request, events chan<- 
 
 	// Per-deployment workdir keyed by Sovereign FQDN — re-running with the
 	// same FQDN is idempotent (tofu apply on existing state).
-	deployDir := filepath.Join(p.WorkDir, req.sovereignName())
+	deployDir := filepath.Join(p.WorkDir, req.workdirKey())
 	if err := os.MkdirAll(deployDir, 0o700); err != nil {
 		return nil, fmt.Errorf("create workdir: %w", err)
 	}
@@ -1049,7 +1049,7 @@ func (p *Provisioner) Destroy(ctx context.Context, req Request, events chan<- Ev
 		}
 	}
 
-	deployDir := filepath.Join(p.WorkDir, req.sovereignName())
+	deployDir := filepath.Join(p.WorkDir, req.workdirKey())
 
 	// If the workdir doesn't exist, there's no tofu state to destroy —
 	// either the deployment never made it past CreateDeployment, or it
@@ -1466,8 +1466,42 @@ func stageModule(src, dst string) error {
 	return nil
 }
 
-func (r Request) sovereignName() string {
+// workdirKey returns the per-deployment tofu workdir name. Keyed by
+// DeploymentID (not FQDN) so concurrent or sequential reprovisions of the
+// SAME SovereignFQDN never share state — each POST /deployments gets a
+// unique workdir because CreateDeployment generates a fresh DeploymentID
+// on every call (deployments.go:CreateDeployment).
+//
+// History: this was originally keyed by `strings.ReplaceAll(FQDN, ".", "-")`
+// so wizard-resume on the same FQDN would re-enter the same workdir and
+// idempotently `tofu apply` on existing state. The downside surfaced on
+// prov #82 (omani.works, 2026-05-14): a force-wipe whose `tofu destroy`
+// failed (because of a stale-tftpl bug in the workdir) left tfstate
+// referencing destroyed-via-Hetzner-purge cloud resources. The NEXT
+// reprov of the same FQDN inherited the dirty tfstate and `tofu apply`
+// failed with "Saved plan is stale" / "resource already exists". By
+// keying on DeploymentID every reprov is hermetic; wizard-resume can
+// re-use the same DeploymentID via an explicit retry endpoint instead.
+//
+// Tests-load-bearing: the workdir name is referenced from wipe.go and
+// handover.go via dep.ID directly (no shared helper). The on-disk
+// kubeconfig naming was ALREADY keyed by DeploymentID, so this brings
+// the tofu workdir into alignment.
+func (r Request) workdirKey() string {
+	if r.DeploymentID != "" {
+		return r.DeploymentID
+	}
+	// Fallback only used by the legacy Destroy code-path that was called
+	// without a DeploymentID set on Request. Modern paths always set it
+	// in CreateDeployment before invoking Provision/Destroy.
 	return strings.ReplaceAll(r.SovereignFQDN, ".", "-")
+}
+
+// sovereignName is the legacy name retained for documentation references
+// in handler/wipe.go and hetzner/purge.go comments. New callers use
+// workdirKey() above.
+func (r Request) sovereignName() string {
+	return r.workdirKey()
 }
 
 func env(key, def string) string {


### PR DESCRIPTION
## Summary
- Per-prov tofu workdir was keyed by `<fqdn-slug>` (e.g. `omani-works`). Every reprovision of the same FQDN reused the same dir → carryover of tfstate, lockfile, tftpl across deployment IDs.
- Caught live on prov #82 → #83 → #84 (omani.works, 2026-05-14): wipe's `tofu destroy` failed (workdir held a pre-#1485 stale tftpl), Hetzner-purge fallback cleaned cloud, but tfstate stayed → next reprov inherited dirty state → `tofu apply` failed with "Saved plan is stale" / "resource already exists".
- Fix: workdir keyed by `DeploymentID` everywhere (provisioner, wipe, handover). Each POST /deployments generates a unique DeploymentID, so reprovs are hermetic by construction. Kubeconfig path was already keyed by DeploymentID — this brings the tofu workdir into alignment.

## Test plan
- [x] `go build` clean
- [x] `go test ./internal/provisioner/... ./internal/handler/...` pass
- [ ] After roll: reprov omani.works on cpx52 succeeds end-to-end (clean workdir each time)
- [ ] After roll: wipe + immediate reprov of same FQDN works without stale-state errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)