### PR TITLE
fix(routes): preserve basepath on canonical hard-nav + normalize PIN-login next (404 page-not-found)

### DIFF
--- a/products/catalyst/bootstrap/ui/src/app/router.tsx
+++ b/products/catalyst/bootstrap/ui/src/app/router.tsx
@@ -167,7 +167,29 @@ async function rootBeforeLoad({ location }: { location: { pathname: string } }) 
   const pathname = location.pathname
   const canonical = canonicalisePath(pathname)
   if (canonical !== pathname) {
-    const newURL = canonical + window.location.search + window.location.hash
+    // TanStack Router's `location.pathname` is POST-basepath — i.e. on
+    // contabo (basepath='/sovereign') a visit to
+    // `/sovereign/provision/$id/jobs/install-X%3AY` arrives here with
+    // pathname=`/provision/$id/jobs/install-X%3AY`. `canonicalisePath`
+    // lowercases, so `%3A` → `%3a` and the comparison triggers a
+    // hard-nav to `canonical`. But `window.location.replace` operates
+    // on the FULL URL — calling replace(canonical) navigates to a
+    // bare `/provision/...` URL without the `/sovereign/` prefix,
+    // which nginx (which only serves the SPA under `/sovereign/*`)
+    // 404s. Re-add the basepath here for the hard-nav target.
+    //
+    // Caught live on prov #82 + #84 (omani.works, 2026-05-14): the
+    // canvas-row-click + open-link patterns produced `install-X%3AY`
+    // URLs that the operator opened, canonicalisation lowercased the
+    // hex, and the resulting hard-nav landed on a bare `/provision/`
+    // path → nginx 404 "page not found". The `<Link to>` and
+    // `navigate({to})` paths are fine because the router re-adds
+    // basepath on internal navigation; only this hard-nav escape was
+    // broken.
+    const basepath = window.location.pathname.startsWith('/sovereign')
+      ? '/sovereign'
+      : ''
+    const newURL = basepath + canonical + window.location.search + window.location.hash
     window.location.replace(newURL)
     throw redirect({ to: canonical as never, replace: true })
   }

--- a/products/catalyst/bootstrap/ui/src/pages/auth/VerifyPinPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/auth/VerifyPinPage.tsx
@@ -99,23 +99,26 @@ export function VerifyPinPage() {
         // sanitizes `next`, we sanitize again here in case a future
         // caller bypasses the route's validateSearch. qa-loop iter-4
         // cluster `users-page-null-map-and-open-redirect`.
-        const target = sanitizeNextParam(next) ?? '/wizard'
+        let target = sanitizeNextParam(next) ?? '/wizard'
         if (typeof window !== 'undefined') {
           // window.location.replace is a HARD navigation — it bypasses
           // the TanStack Router's basepath config. On contabo the SPA
           // mounts under `/sovereign/*`; nginx 404s any request that
           // doesn't start with that prefix. The sanitized `next` value
-          // is post-basepath (see basepathRelative.ts: e.g. `next` of
-          // `/provision/$id/jobs` represents the route the router
-          // would navigate to AT `/sovereign/provision/$id/jobs`). So
-          // we must re-prefix `/sovereign` before the hard nav,
-          // otherwise the operator lands on a bare `/provision/...`
-          // URL that nginx never routes to the SPA.
+          // may arrive in EITHER form depending on which redirectToLogin
+          // variant produced it: SovereignConsoleLayout.tsx:91 (variant
+          // A) sets next = window.location.pathname which INCLUDES the
+          // basepath, while :178 (variant B) uses
+          // currentPathRelativeToBasepath() which STRIPS it. Normalize
+          // both forms to "post-basepath" before re-prefixing so we
+          // never double-prefix and never miss-prefix.
           //
-          // Caught live on prov #82 (omani.works, 2026-05-14): after
-          // PIN-login from console.openova.io/sovereign/login,
-          // window.location.replace('/provision/$id/jobs') went to a
-          // raw `/provision/...` URL → nginx 404 page-not-found.
+          // Caught live on prov #82 + #84 (omani.works, 2026-05-14):
+          // variant-A produced `next=/sovereign/provision/...` which my
+          // original #1486 fix would double-prefix to
+          // `/sovereign/sovereign/...` → nginx 404.
+          if (target.startsWith('/sovereign/')) target = target.slice('/sovereign'.length)
+          else if (target === '/sovereign') target = '/'
           const basepath =
             window.location.pathname.startsWith('/sovereign')
               ? '/sovereign'


### PR DESCRIPTION
## Summary
Two basepath-stripping bugs in `window.location.{replace,assign}` paths:

- **router.tsx rootBeforeLoad** — canonicalisePath lowercases `%3A`→`%3a` in encoded job IDs, sees diff, calls `replace(canonical)` — but TanStack Router strips basepath from `location.pathname`, so the bare `/provision/...` URL bypasses the SPA mount and nginx 404s. Fix: re-add `/sovereign/` prefix on the hard-nav target.
- **VerifyPinPage** — the sanitized `next` arrives in two forms (one with basepath included, one without) depending on which `redirectToLogin` variant produced it. #1486 unconditionally re-prefixed, which double-prefixed the first form. Fix: strip any existing `/sovereign/` prefix first, then re-add exactly once.

Same root-cause shape as #1486 — every hard-nav escape from the SPA must explicitly preserve basepath, because `window.location` operates on the full URL while TanStack Router strips/adds basepath transparently for `<Link>` / `navigate()`.

## Test plan
- [x] Reproduced: `curl /provision/$id/jobs/install-nbg1-1%3Asyft-grype → 404` (nginx) vs `/sovereign/provision/... → 200` (SPA)
- [x] Identified both hard-nav sites via grep + line-by-line trace
- [ ] After roll: canvas row-click opens `/sovereign/provision/$id/jobs/...` consistently
- [ ] After roll: PIN-login with `next` in either form lands correctly without double-prefix or strip

🤖 Generated with [Claude Code](https://claude.com/claude-code)