### PR TITLE
fix(cloud-init): accept private-NIC DHCP routes (LB asymmetric-routing root cause)

### DIFF
--- a/infra/hetzner/cloudinit-control-plane.tftpl
+++ b/infra/hetzner/cloudinit-control-plane.tftpl
@@ -1293,7 +1293,27 @@ runcmd:
           dhcp4: true
           dhcp4-overrides:
             use-dns: false
-            use-routes: false
+            # use-routes: true — accept Hetzner DHCP's classless static
+            # routes (including the per-subnet route that lets the kernel
+            # reach OTHER hosts on the private network without going
+            # through eth0's default route). Without this, Hetzner LB ->
+            # backend asymmetric routing breaks LB health checks:
+            # inbound SYN arrives on enp7s0 (private NIC), but the
+            # kernel routes SYN-ACK via eth0 because 10.0.0.0/8 has no
+            # route on the private NIC. Hetzner drops the reply at the
+            # LB and the target stays unhealthy forever.
+            #
+            # The default route (0.0.0.0/0 via eth0) wins because eth0's
+            # DHCP route is set first (metric 100). Hetzner private-net
+            # DHCP routes get a default metric of 200+, so eth0 stays
+            # the default. We DO need the per-subnet 10.0.0.0/N route
+            # from private DHCP for cross-host private traffic.
+            #
+            # Caught live on prov omani.works/6dfade27 (2026-05-14):
+            # interface had 10.0.1.2/32 (host route only, no subnet),
+            # LB health checks for 80/443/53 all unhealthy → public
+            # surface blackholed.
+            use-routes: true
     NETPLAN
         chmod 0600 /etc/netplan/60-private-network.yaml
         netplan apply || true


### PR DESCRIPTION
## Summary
- Hetzner LB-to-backend health checks fail on every fresh BYO prov (caught live on omani.works/6dfade27, 2026-05-14). All 3 LBs unhealthy on 53/80/443 even though envoy is listening, 45/45 HRs Ready, PROD cert valid.
- Root cause via tcpdump: SYN arrives on `enp7s0` (private NIC) but kernel sends SYN-ACK via `eth0` (public) because the interface only has `10.0.1.2/32` (no subnet route).
- Netplan stanza had `dhcp4-overrides.use-routes: false` which discards Hetzner DHCP's classless static routes for the private network.
- Fix: `use-routes: true`. The public default route on eth0 (metric=100) stays the default since Hetzner DHCP routes get metric=200+; we just gain the per-subnet route for symmetric routing.

## Test plan
- [x] Reproduced via tcpdump on prov 6dfade27 — asymmetric SYN-ACK on wrong NIC
- [x] Manually adding `10.0.1.0/24 dev enp7s0 src 10.0.1.2` route via privileged pod made the kernel respond correctly (separate session)
- [ ] After roll: next fresh prov has interface with /N mask + 10.0.0.0/8 route — LB target health flips to `healthy` within 30s

🤖 Generated with [Claude Code](https://claude.com/claude-code)