### PR TITLE
fix(sovereign-tls): restart cilium-operator before cilium-envoy (eliminates manual step)

### DIFF
--- a/clusters/_template/sovereign-tls/cilium-envoy-tls-restart-job.yaml
+++ b/clusters/_template/sovereign-tls/cilium-envoy-tls-restart-job.yaml
@@ -97,6 +97,23 @@ rules:
     resources: ["daemonsets"]
     resourceNames: ["cilium-envoy"]
     verbs: ["get", "patch"]
+  # ALSO patch the cilium-operator Deployment. Reason: on a fresh
+  # Sovereign, cilium-operator's first CEC reconciliation produces a
+  # CiliumEnvoyConfig WITHOUT the hostNetwork bind `additionalAddresses.
+  # socketAddress: 0.0.0.0:30443` — even though `gateway-api-hostnetwork-
+  # enabled=true` and `gateway-api-hostnetwork-nodelabelselector=kubernetes.io/os=linux`
+  # are correctly set in cilium-config. After an operator pod-restart
+  # the next CEC reconcile DOES populate the bind, and cilium-envoy
+  # binds host:30443 cleanly. Without this restart, Hetzner LB targets
+  # stay `unhealthy` on 30080/30443 forever and console.<sov-fqdn>
+  # never serves. Caught live on prov 492c81e2 (omantel.biz, 2026-05-15)
+  # plus every prior multi-region prov where operators were doing the
+  # restart manually. This rule lets the Job fix it without operator
+  # intervention.
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    resourceNames: ["cilium-operator"]
+    verbs: ["get", "patch"]
   # Read DaemonSet rollout status so the Job can wait for the new pods
   # to come up before exiting. `kubectl rollout status` issues GET on
   # the DaemonSet resource (no extra verbs needed).
@@ -203,7 +220,26 @@ spec:
                 sleep 10
               done
 
-              echo "[tls-restart] bumping ds/${DS_NAME} in ${DS_NS} to force envoy SDS re-subscribe"
+              # Step 1 — restart cilium-operator FIRST so it regenerates the
+              # CiliumEnvoyConfig with the hostNetwork bind
+              # `additionalAddresses.socketAddress: 0.0.0.0:30443`. On a
+              # fresh Sovereign, the FIRST CEC reconcile (driven by
+              # Gateway create) misses this bind even though the
+              # configmap keys gateway-api-hostnetwork-{enabled,
+              # nodelabelselector} are correct. An operator pod-restart
+              # forces a fresh CEC render that includes the bind. Without
+              # this, cilium-envoy is restarted in step 2 but binds only
+              # 127.0.0.1:* control sockets — host:30443 stays empty,
+              # Hetzner LB targets stay unhealthy, console returns 000.
+              echo "[tls-restart] bumping deploy/cilium-operator to regenerate CEC with hostNetwork bind"
+              kubectl rollout restart -n "${DS_NS}" deploy/cilium-operator
+              echo "[tls-restart] waiting for deploy/cilium-operator rollout"
+              kubectl rollout status -n "${DS_NS}" deploy/cilium-operator --timeout=3m
+
+              # Step 2 — restart cilium-envoy so it picks up (a) the
+              # freshly-regenerated CEC with the hostNetwork bind, AND
+              # (b) the now-existing sovereign-wildcard-tls SDS Secret.
+              echo "[tls-restart] bumping ds/${DS_NAME} in ${DS_NS} to force envoy SDS re-subscribe + CEC reload"
               kubectl rollout restart -n "${DS_NS}" "ds/${DS_NAME}"
 
               # Block until the new pods are Ready. `kubectl rollout
@@ -214,4 +250,4 @@ spec:
               echo "[tls-restart] waiting for ds/${DS_NAME} rollout"
               kubectl rollout status -n "${DS_NS}" "ds/${DS_NAME}" --timeout=5m
 
-              echo "[tls-restart] complete — cilium-envoy now serves SDS Secret ${SECRET_NAME}"
+              echo "[tls-restart] complete — cilium-operator regenerated hostNetwork CEC + cilium-envoy serves SDS Secret ${SECRET_NAME}"


### PR DESCRIPTION
## Summary
- On a fresh Sovereign, cilium-operator's first CEC reconcile misses the hostNetwork bind `additionalAddresses.socketAddress: 0.0.0.0:30443`. Without an operator-pod restart, cilium-envoy can't bind host:30443 and Hetzner LB targets stay unhealthy → `console.<sov-fqdn>` returns curl rc=000 forever.
- The existing `cilium-envoy-tls-restart` Job (sovereign-tls Kustomization) restarts only the envoy DS — not enough on a fresh prov.
- Fix: extend the Job to FIRST restart `deploy/cilium-operator` (RBAC patch + script ordering), THEN restart `ds/cilium-envoy`. ~10s extra Job time; eliminates the only manual step in the multi-region prov pipeline.

## Test plan
- [x] Reproduced manually on prov 22d35783 (omani.works) + prov 492c81e2 (omantel.biz, 2026-05-15) — both fixed by exact same restart sequence
- [ ] After roll: next fresh prov reaches `console.<sov>:443 → 200` without any kubectl exec / rollout-restart from operator
- [ ] E2E wall time drops by ~3-4 min (operator+envoy restart was previously gated on me)

🤖 Generated with [Claude Code](https://claude.com/claude-code)