### PR TITLE
fix(pdm/dynadot): auto-register NS glue records before set_ns

### DIFF
--- a/core/pool-domain-manager/cmd/pdm/main.go
+++ b/core/pool-domain-manager/cmd/pdm/main.go
@@ -22,6 +22,14 @@
 //	DYNADOT_DOMAIN             — legacy single-domain fallback
 //	DYNADOT_API_KEY            — kept for the registrar adapter (#170 BYO flow)
 //	DYNADOT_API_SECRET         — kept for the registrar adapter (#170 BYO flow)
+//	POOL_DOMAIN_MANAGER_NS_GLUE_IP — IPv4 of the mothership PowerDNS LB. When
+//	                              set, the Dynadot registrar adapter pre-
+//	                              registers every out-of-bailiwick NS hostname
+//	                              against the customer's Dynadot account before
+//	                              set_ns, fixing the parent-domain onboard
+//	                              flow that previously failed on Dynadot's
+//	                              "'ns3.openova.io' needs to be registered
+//	                              with an ip address" rejection (issue #1500).
 //	PDM_RESERVATION_TTL        — go duration string, default "10m"
 //	PDM_SWEEPER_INTERVAL       — go duration string, default "30s"
 //	PDM_LOG_LEVEL              — debug | info | warn | error (default info)
@@ -107,15 +115,30 @@ func main() {
 	// because the customer's API token is supplied per request, not at
 	// service-start. Disabling an adapter would only mean omitting it from
 	// the map; today we ship all 5.
+	//
+	// Dynadot adapter is constructed with NSGlueIP from
+	// POOL_DOMAIN_MANAGER_NS_GLUE_IP (when set) so SetNameservers can
+	// pre-register every out-of-bailiwick NS hostname against the
+	// customer's account before set_ns. This unblocks the mothership
+	// parent-domain onboard flow for fresh Dynadot domains that haven't
+	// yet had ns1/ns2/ns3.openova.io registered as glue records (issue
+	// #1500, 2026-05-15). Empty value → adapter falls back to its
+	// pre-fix behaviour and the handler-level glueIP path (BYO Flow B)
+	// remains authoritative for per-request glue.
+	dynadotAdapter := regDynadot.New()
+	dynadotAdapter.NSGlueIP = strings.TrimSpace(os.Getenv("POOL_DOMAIN_MANAGER_NS_GLUE_IP"))
 	reg := registrar.Registry{
 		regCloudflare.New().Name(): regCloudflare.New(),
 		regGoDaddy.New().Name():    regGoDaddy.New(),
 		regNamecheap.New().Name():  regNamecheap.New(),
 		regOVH.New().Name():        regOVH.New(),
-		regDynadot.New().Name():    regDynadot.New(),
+		dynadotAdapter.Name():      dynadotAdapter,
 	}
 	h.SetRegistry(reg)
-	log.Info("registrar adapters wired", "registrars", reg.Names())
+	log.Info("registrar adapters wired",
+		"registrars", reg.Names(),
+		"dynadotGlueAutoRegister", dynadotAdapter.NSGlueIP != "",
+	)
 
 	root := chi.NewRouter()
 	root.Use(middleware.RequestID)

--- a/core/pool-domain-manager/internal/registrar/dynadot/dynadot.go
+++ b/core/pool-domain-manager/internal/registrar/dynadot/dynadot.go
@@ -58,13 +58,33 @@ import (
 )
 
 // Adapter implements registrar.Registrar by speaking Dynadot api3.json.
+//
+// NSGlueIP, when non-empty, opts-in to the adapter-level auto-glue path:
+// SetNameservers will pre-register every out-of-bailiwick NS hostname
+// against the customer's account (via RegisterGlueRecord, idempotent)
+// BEFORE issuing set_ns. This is required for the mothership parent-
+// domain onboard flow (issue #1500 — fresh Dynadot domains pick set_ns
+// rejection on ns3.openova.io until it is registered as a glue record).
+//
+// The IP is the mothership PowerDNS LoadBalancer public IPv4 — the
+// ground-truth A-record value for ns1/ns2/ns3.openova.io. Sourced from
+// POOL_DOMAIN_MANAGER_NS_GLUE_IP at PDM startup (cmd/pdm/main.go); plumbed
+// through the openova-private deployment.yaml so the value is operator-
+// configurable and never hardcoded (Inviolable Principle #4).
+//
+// When NSGlueIP is empty (no env var set), SetNameservers preserves its
+// historical pass-through behaviour — the handler-level glueIP path
+// (handler/registrar.go SetNS, BYO Flow B) is still authoritative for
+// per-request glue, so customer Sovereign flows are unaffected.
 type Adapter struct {
-	BaseURL string
-	HTTP    *http.Client
+	BaseURL  string
+	HTTP     *http.Client
+	NSGlueIP string
 }
 
 // New returns a Dynadot registrar adapter pointing at the production
-// api3.json endpoint. Override BaseURL after construction in tests.
+// api3.json endpoint. Override BaseURL / NSGlueIP after construction in
+// tests and at PDM startup respectively.
 func New() *Adapter {
 	return &Adapter{
 		BaseURL: "https://api.dynadot.com/api3.json",
@@ -204,6 +224,21 @@ func (a *Adapter) ValidateToken(ctx context.Context, token, domain string) error
 // SetNameservers replaces the domain's nameserver list via set_ns.
 // Dynadot accepts up to 13 nameservers; the API uses indexed params
 // ns0, ns1, ... — same as the DNS records writer.
+//
+// When the adapter is configured with NSGlueIP (POOL_DOMAIN_MANAGER_NS_GLUE_IP
+// at PDM startup) — the mothership parent-domain onboard path — every
+// out-of-bailiwick NS hostname is pre-registered as a Dynadot glue
+// record BEFORE set_ns. This is non-optional and idempotent: the
+// underlying RegisterGlueRecord short-circuits on already-registered
+// hosts with the same IP, and updates via set_ns_ip on a different IP.
+// Without this, Dynadot rejects set_ns the first time a previously-
+// unregistered NS (e.g. ns3.openova.io for a fresh parent domain) is
+// referenced — the live blocker that motivated this change (issue
+// #1500, 2026-05-15 omani.homes onboard).
+//
+// When NSGlueIP is empty, this method preserves its prior pass-through
+// behaviour — the handler-level glueIP path (BYO Flow B) is the
+// authoritative per-request seam and is unchanged.
 func (a *Adapter) SetNameservers(ctx context.Context, token, domain string, ns []string) error {
 	if len(ns) == 0 {
 		return errors.New("dynadot: nameservers list is empty")
@@ -212,6 +247,25 @@ func (a *Adapter) SetNameservers(ctx context.Context, token, domain string, ns [
 	if err != nil {
 		return err
 	}
+
+	// Adapter-level glue auto-registration — runs before set_ns when the
+	// mothership PowerDNS LB IPv4 is configured on the adapter. Per the
+	// issue header above, set_ns will fail with "needs to be registered
+	// with an ip address" otherwise. In-bailiwick NS hostnames (children
+	// of the domain whose NS we are setting) are skipped: Dynadot
+	// resolves those via the child-zone's own DNS and they do NOT need
+	// an account-level registered-host entry.
+	if a.NSGlueIP != "" {
+		for _, host := range ns {
+			if isInBailiwickHost(host, domain) {
+				continue
+			}
+			if err := a.RegisterGlueRecord(ctx, token, host, a.NSGlueIP); err != nil {
+				return fmt.Errorf("dynadot: pre-register glue %s: %w", host, err)
+			}
+		}
+	}
+
 	params := url.Values{}
 	params.Set("key", key)
 	params.Set("secret", secret)
@@ -487,6 +541,27 @@ func (a *Adapter) RegisterGlueRecord(ctx context.Context, token, host, ip string
 		return fmt.Errorf("dynadot: parse register_ns: %w", err)
 	}
 	return classifyDynadotError(raw.RegisterNsResponse.respHeader)
+}
+
+// isInBailiwickHost reports whether nsHost is a child of zone (the
+// domain whose NS we are flipping). Used by SetNameservers to skip
+// glue pre-registration for in-bailiwick NS hostnames (RFC 1034
+// §4.2.1) — those resolve via the customer's own DNS and never
+// require an account-level registered-host entry on Dynadot.
+//
+// Mirrors handler.isInBailiwick (kept package-local so the adapter
+// has zero dependency on the handler layer). Both arguments are
+// case-insensitive; a trailing dot on either is tolerated.
+func isInBailiwickHost(nsHost, zone string) bool {
+	nsHost = strings.ToLower(strings.TrimSuffix(strings.TrimSpace(nsHost), "."))
+	zone = strings.ToLower(strings.TrimSuffix(strings.TrimSpace(zone), "."))
+	if nsHost == "" || zone == "" {
+		return false
+	}
+	if nsHost == zone {
+		return true
+	}
+	return strings.HasSuffix(nsHost, "."+zone)
 }
 
 // compile-time guards.

--- a/core/pool-domain-manager/internal/registrar/dynadot/dynadot_test.go
+++ b/core/pool-domain-manager/internal/registrar/dynadot/dynadot_test.go
@@ -502,3 +502,259 @@ func TestAdapterImplementsGlueRegistrar(t *testing.T) {
 		t.Fatal("New() does not implement registrar.GlueRegistrar")
 	}
 }
+
+// ── Adapter-level auto-glue-registration on SetNameservers (issue #1500) ──
+//
+// These tests cover the mothership parent-domain onboard path: when the
+// adapter is constructed with NSGlueIP set (POOL_DOMAIN_MANAGER_NS_GLUE_IP),
+// SetNameservers MUST pre-register every out-of-bailiwick NS hostname as a
+// Dynadot glue record before issuing set_ns. Each NS hostname costs a
+// get_ns probe; only the ones that are missing or stale incur a
+// register_ns / set_ns_ip write.
+
+// TestSetNameserversAutoGlue_AllFresh — 3 NS hostnames, none yet
+// registered. Adapter must run 3 (get_ns + register_ns) pairs followed
+// by 1 set_ns. Total: 7 API calls.
+func TestSetNameserversAutoGlue_AllFresh(t *testing.T) {
+	calls := 0
+	a, _ := newTestAdapter(t, func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		cmd := r.URL.Query().Get("command")
+		switch calls {
+		case 1, 3, 5: // get_ns probes (one per NS hostname) → all "not found"
+			if cmd != "get_ns" {
+				t.Errorf("call %d: command = %q, want get_ns", calls, cmd)
+			}
+			fmt.Fprintln(w, `{"GetNsResponse":{"ResponseCode":"-1","Status":"error","Error":"Name server not found"}}`)
+		case 2, 4, 6: // register_ns writes
+			if cmd != "register_ns" {
+				t.Errorf("call %d: command = %q, want register_ns", calls, cmd)
+			}
+			if got := r.URL.Query().Get("ip0"); got != "192.0.2.10" {
+				t.Errorf("call %d: ip0 = %q, want 192.0.2.10", calls, got)
+			}
+			fmt.Fprintln(w, `{"RegisterNsResponse":{"ResponseCode":0,"Status":"success"}}`)
+		case 7: // set_ns flip
+			if cmd != "set_ns" {
+				t.Errorf("call %d: command = %q, want set_ns", calls, cmd)
+			}
+			if got := r.URL.Query().Get("domain"); got != "omani.homes" {
+				t.Errorf("set_ns domain = %q, want omani.homes", got)
+			}
+			fmt.Fprintln(w, `{"SetNsResponse":{"ResponseCode":0,"Status":"success"}}`)
+		default:
+			t.Errorf("unexpected call %d (cmd=%s)", calls, cmd)
+		}
+	})
+	a.NSGlueIP = "192.0.2.10"
+	if err := a.SetNameservers(context.Background(), "k:s", "omani.homes",
+		[]string{"ns1.openova.io", "ns2.openova.io", "ns3.openova.io"}); err != nil {
+		t.Fatalf("SetNameservers err = %v", err)
+	}
+	if calls != 7 {
+		t.Fatalf("expected 7 api calls (3× get_ns + 3× register_ns + set_ns), got %d", calls)
+	}
+}
+
+// TestSetNameserversAutoGlue_OneAlreadyRegistered — 3 NS hostnames, the
+// second is already registered at the same IP. Adapter must short-circuit
+// only that one (no register_ns), still register the other two, then
+// set_ns. Total: 6 API calls (3× get_ns + 2× register_ns + set_ns).
+func TestSetNameserversAutoGlue_OneAlreadyRegistered(t *testing.T) {
+	calls := 0
+	a, _ := newTestAdapter(t, func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		cmd := r.URL.Query().Get("command")
+		ns := r.URL.Query().Get("ns")
+		switch cmd {
+		case "get_ns":
+			if ns == "ns2.openova.io" {
+				// Already registered at the same IP — short-circuits.
+				fmt.Fprintln(w, `{
+				  "GetNsResponse":{
+				    "ResponseCode":0,"Status":"success",
+				    "NsInfo":{"NameServer":{"Host":"ns2.openova.io","IP":["192.0.2.10"]}}
+				  }
+				}`)
+			} else {
+				fmt.Fprintln(w, `{"GetNsResponse":{"ResponseCode":"-1","Status":"error","Error":"Name server not found"}}`)
+			}
+		case "register_ns":
+			if ns == "ns2.openova.io" {
+				t.Errorf("unexpected register_ns for ns2.openova.io (it was already registered)")
+			}
+			fmt.Fprintln(w, `{"RegisterNsResponse":{"ResponseCode":0,"Status":"success"}}`)
+		case "set_ns":
+			fmt.Fprintln(w, `{"SetNsResponse":{"ResponseCode":0,"Status":"success"}}`)
+		default:
+			t.Errorf("unexpected command %q on call %d", cmd, calls)
+		}
+	})
+	a.NSGlueIP = "192.0.2.10"
+	if err := a.SetNameservers(context.Background(), "k:s", "omani.homes",
+		[]string{"ns1.openova.io", "ns2.openova.io", "ns3.openova.io"}); err != nil {
+		t.Fatalf("SetNameservers err = %v", err)
+	}
+	if calls != 6 {
+		t.Fatalf("expected 6 api calls (3× get_ns + 2× register_ns + set_ns), got %d", calls)
+	}
+}
+
+// TestSetNameserversAutoGlue_RegisterFails_SetNsNotCalled — when
+// register_ns returns a non-idempotent error mid-loop, set_ns MUST NOT
+// be called. The error surfaces unwrapped so the HTTP handler can map
+// it to the right status code (this scenario uses a 429 → ErrRateLimited).
+func TestSetNameserversAutoGlue_RegisterFails_SetNsNotCalled(t *testing.T) {
+	calls := 0
+	setNsCalled := false
+	a, _ := newTestAdapter(t, func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		cmd := r.URL.Query().Get("command")
+		switch cmd {
+		case "get_ns":
+			fmt.Fprintln(w, `{"GetNsResponse":{"ResponseCode":"-1","Status":"error","Error":"Name server not found"}}`)
+		case "register_ns":
+			// Surface a rate-limit so the typed registrar.ErrRateLimited
+			// is the chain head. classifyHTTP maps 429 to that error.
+			w.WriteHeader(http.StatusTooManyRequests)
+		case "set_ns":
+			setNsCalled = true
+			fmt.Fprintln(w, `{"SetNsResponse":{"ResponseCode":0,"Status":"success"}}`)
+		default:
+			t.Errorf("unexpected command %q on call %d", cmd, calls)
+		}
+	})
+	a.NSGlueIP = "192.0.2.10"
+	err := a.SetNameservers(context.Background(), "k:s", "omani.homes",
+		[]string{"ns1.openova.io", "ns2.openova.io"})
+	if err == nil {
+		t.Fatal("expected error when register_ns fails")
+	}
+	if !errors.Is(err, registrar.ErrRateLimited) {
+		t.Fatalf("err = %v, want ErrRateLimited unwrapped through pre-register wrap", err)
+	}
+	if setNsCalled {
+		t.Fatal("set_ns must NOT be called when register_ns failed")
+	}
+}
+
+// TestSetNameserversAutoGlue_SetNsFailsAfterRegister — register_ns
+// completes successfully for both NS hostnames, but set_ns then returns
+// a Dynadot error. The error must surface; nothing in the register path
+// should mask it. (Covers the legitimate-failure case after pre-register.)
+func TestSetNameserversAutoGlue_SetNsFailsAfterRegister(t *testing.T) {
+	calls := 0
+	a, _ := newTestAdapter(t, func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		cmd := r.URL.Query().Get("command")
+		switch cmd {
+		case "get_ns":
+			fmt.Fprintln(w, `{"GetNsResponse":{"ResponseCode":"-1","Status":"error","Error":"Name server not found"}}`)
+		case "register_ns":
+			fmt.Fprintln(w, `{"RegisterNsResponse":{"ResponseCode":0,"Status":"success"}}`)
+		case "set_ns":
+			fmt.Fprintln(w, `{"SetNsResponse":{"ResponseCode":"-1","Status":"error","Error":"Domain not in your account"}}`)
+		default:
+			t.Errorf("unexpected command %q on call %d", cmd, calls)
+		}
+	})
+	a.NSGlueIP = "192.0.2.10"
+	err := a.SetNameservers(context.Background(), "k:s", "not-mine.homes",
+		[]string{"ns1.openova.io", "ns2.openova.io"})
+	if err == nil {
+		t.Fatal("expected error from set_ns")
+	}
+	if !errors.Is(err, registrar.ErrDomainNotInAccount) {
+		t.Fatalf("err = %v, want ErrDomainNotInAccount", err)
+	}
+	// Walk: 2× get_ns + 2× register_ns + 1× set_ns = 5
+	if calls != 5 {
+		t.Fatalf("expected 5 api calls, got %d", calls)
+	}
+}
+
+// TestSetNameserversAutoGlue_SkipsInBailiwick — when an NS hostname is
+// a child of the domain being set (in-bailiwick per RFC 1034), the
+// adapter MUST skip glue registration for that host. It still registers
+// the out-of-bailiwick siblings and runs set_ns.
+func TestSetNameserversAutoGlue_SkipsInBailiwick(t *testing.T) {
+	calls := 0
+	a, _ := newTestAdapter(t, func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		cmd := r.URL.Query().Get("command")
+		ns := r.URL.Query().Get("ns")
+		switch cmd {
+		case "get_ns":
+			if ns == "ns1.customer.tld" {
+				t.Errorf("unexpected get_ns for in-bailiwick host %q (must be skipped)", ns)
+			}
+			fmt.Fprintln(w, `{"GetNsResponse":{"ResponseCode":"-1","Status":"error","Error":"Name server not found"}}`)
+		case "register_ns":
+			if ns == "ns1.customer.tld" {
+				t.Errorf("unexpected register_ns for in-bailiwick host %q", ns)
+			}
+			fmt.Fprintln(w, `{"RegisterNsResponse":{"ResponseCode":0,"Status":"success"}}`)
+		case "set_ns":
+			fmt.Fprintln(w, `{"SetNsResponse":{"ResponseCode":0,"Status":"success"}}`)
+		default:
+			t.Errorf("unexpected command %q on call %d", cmd, calls)
+		}
+	})
+	a.NSGlueIP = "192.0.2.10"
+	if err := a.SetNameservers(context.Background(), "k:s", "customer.tld",
+		[]string{"ns1.customer.tld", "ns1.openova.io"}); err != nil {
+		t.Fatalf("SetNameservers err = %v", err)
+	}
+	// 1× get_ns + 1× register_ns (for ns1.openova.io) + 1× set_ns = 3
+	if calls != 3 {
+		t.Fatalf("expected 3 api calls (1 NS registered, in-bailiwick skipped, set_ns), got %d", calls)
+	}
+}
+
+// TestSetNameserversAutoGlue_DisabledWhenNSGlueIPEmpty — when NSGlueIP
+// is not configured (empty string, the default), SetNameservers MUST
+// preserve its pre-fix behaviour: a single set_ns call, no glue
+// pre-registration. Guards backward-compat with the handler-level
+// glueIP path (BYO Flow B) and non-Dynadot adapter parity.
+func TestSetNameserversAutoGlue_DisabledWhenNSGlueIPEmpty(t *testing.T) {
+	calls := 0
+	a, _ := newTestAdapter(t, func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		cmd := r.URL.Query().Get("command")
+		if cmd != "set_ns" {
+			t.Errorf("unexpected command %q (NSGlueIP empty → only set_ns expected)", cmd)
+		}
+		fmt.Fprintln(w, `{"SetNsResponse":{"ResponseCode":0,"Status":"success"}}`)
+	})
+	// NSGlueIP intentionally left empty.
+	if err := a.SetNameservers(context.Background(), "k:s", "customer.tld",
+		[]string{"ns1.openova.io", "ns2.openova.io"}); err != nil {
+		t.Fatalf("SetNameservers err = %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("expected 1 api call (set_ns only), got %d", calls)
+	}
+}
+
+// TestIsInBailiwickHost — case- and dot-tolerant; non-children fall
+// through to glue registration. Mirrors handler.TestIsInBailiwick.
+func TestIsInBailiwickHost(t *testing.T) {
+	cases := []struct {
+		nsHost, zone string
+		want         bool
+	}{
+		{"ns1.example.com", "example.com", true},
+		{"NS1.Example.COM", "example.com", true},
+		{"ns1.example.com.", "example.com.", true},
+		{"example.com", "example.com", true},
+		{"ns1.openova.io", "example.com", false},
+		{"ns1.notexample.com", "example.com", false},
+		{"", "example.com", false},
+		{"ns1.example.com", "", false},
+	}
+	for _, tc := range cases {
+		if got := isInBailiwickHost(tc.nsHost, tc.zone); got != tc.want {
+			t.Errorf("isInBailiwickHost(%q, %q) = %v, want %v", tc.nsHost, tc.zone, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Dynadot adapter's `SetNameservers` now pre-registers every out-of-bailiwick NS hostname as a Dynadot glue record **before** `set_ns`, closing the architectural gap that the existing 31-line code comment above the method has documented since #900 but the implementation never landed.
- The IP to register against is the **mothership PowerDNS LoadBalancer public IPv4**, threaded via a new `POOL_DOMAIN_MANAGER_NS_GLUE_IP` env var (canonical operator-config pattern). Empty value preserves the prior pass-through behaviour so BYO Flow B (per-request `glueIP` from the handler) remains authoritative for Sovereign add-domain calls.
- The pre-register loop reuses the adapter's existing idempotent `RegisterGlueRecord` (get_ns probe → short-circuit on identical IP → set_ns_ip on stale IP → register_ns on missing), so a SetNameservers retry costs only get_ns probes, not extra writes.

## Live blocker (2026-05-15)

Founder attempted zero-touch onboard of fresh parent domain `omani.homes`. The flow stalled because `ns3.openova.io` had never been registered as a Dynadot glue record on this account (`ns1`/`ns2` were registered long ago, when `openova.io` itself was onboarded). Failure surface:

> `'ns3.openova.io' needs to be registered with an ip address before it can be used.`

Required out-of-band manual API calls to unblock — defeating the architecture's zero-touch property.

## Why adapter-layer, not handler-layer

The handler-layer glue path (handler/registrar.go SetNS, BYO Flow B) requires the caller to thread `glueIP`. That works for Sovereign add-domain calls (catalyst-api `pdmFlipNS` already does it). But the mothership parent-domain onboard path does NOT supply `glueIP`, leaving every fresh Dynadot parent-domain onboard exposed to the same wedge. Fixing it at the adapter (always-on when configured, no per-request flag) means PDM's own architectural promise holds independently of caller knowledge.

## Test plan

- [x] `go build ./...` in `core/pool-domain-manager` — green
- [x] `go test ./...` in `core/pool-domain-manager` — all packages green
- [x] 7 new httptest-backed cases in `dynadot_test.go`:
  - AllFresh — 3 NS unregistered → 3× (get_ns + register_ns) + set_ns
  - OneAlreadyRegistered — middle NS short-circuits, others register, set_ns runs
  - RegisterFails_SetNsNotCalled — 429 mid-register surfaces `ErrRateLimited`; `set_ns` MUST NOT execute
  - SetNsFailsAfterRegister — pre-register completes, set_ns Dynadot error surfaces as `ErrDomainNotInAccount`
  - SkipsInBailiwick — in-bailiwick NS hostname skipped entirely
  - DisabledWhenNSGlueIPEmpty — backward-compat (single `set_ns` call when env unset)
  - IsInBailiwickHost — case + dot tolerance table test
- [ ] **Live verification** — re-run `omani.homes` onboard once the new PDM image is rolled out via the `openova-private` `clusters/contabo-mkt/apps/pool-domain-manager/deployment.yaml` SHA bump (separate PR; the env var is wired there in the same fix-set).

## Related

Adapter-layer companion to #900 (handler-layer glue path). Removes the implementation drift between the 31-line code comment above `SetNameservers` and the actual call sequence.