### PR TITLE
fix(canvas): canonicalise Job.DependsOn entries with install- prefix

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/phase1_watch.go
+++ b/products/catalyst/bootstrap/api/internal/handler/phase1_watch.go
@@ -477,12 +477,27 @@ func (h *Handler) spawnSecondaryRegionWatchers(dep *Deployment) func() {
 			// pointing at the PRIMARY region's bare-named jobs,
 			// and the canvas fan-out collapses cross-region edges
 			// that aren't real. helmwatch.processEvent populated
-			// ev.DependsOn from the live spec.dependsOn; we just
-			// rescope here.
+			// ev.DependsOn from the live spec.dependsOn (bare chart
+			// names like "gitea"); we both region-prefix AND inject
+			// the canonical "install-" prefix so the stored Job
+			// row's DependsOn matches the JobName scheme exactly.
+			//
+			// Why "install-<region>:<chart>" not "<region>:<chart>":
+			// the FE canvas adapter looks up node ids by exact match;
+			// node ids are `<dep>:install-<region>:<chart>` for
+			// install Jobs. Storing "<region>:<chart>" as a dep
+			// produces a `<dep>:<region>:<chart>` fromId in the
+			// finish-to-start relationship, which matches no node →
+			// edge invisible. Caught on prov t103.omani.works
+			// (005080699326a7ac, 2026-05-15): openova-flow snapshot
+			// had 224 finish-to-start rels emitted but their fromIds
+			// were `<dep>:hel1-2:seaweedfs` etc., missing "install-"
+			// → canvas rendered every secondary HR with no sibling
+			// edges despite the rel count being non-zero.
 			if len(ev.DependsOn) > 0 {
 				rescoped := make([]string, 0, len(ev.DependsOn))
 				for _, d := range ev.DependsOn {
-					rescoped = append(rescoped, region+":"+d)
+					rescoped = append(rescoped, "install-"+region+":"+d)
 				}
 				ev.DependsOn = rescoped
 			}

--- a/products/catalyst/bootstrap/api/internal/jobs/helmwatch_bridge.go
+++ b/products/catalyst/bootstrap/api/internal/jobs/helmwatch_bridge.go
@@ -489,6 +489,33 @@ func (b *Bridge) OnHelmReleaseEvent(componentID, state, level, message string, t
 		dependsOn = []string{}
 	}
 
+	// Prepend the canonical JobNamePrefix ("install-") to every dep so
+	// the stored Job.DependsOn matches the format other Jobs use as
+	// their JobName. Without this, the openova-flow snapshot composer
+	// emits finish-to-start relationships with fromIds like
+	// "<dep>:hel1-2:seaweedfs" (missing "install-"), which match no
+	// FlowNode and the canvas renders every sibling-edge invisible.
+	// Caught on prov t103.omani.works (005080699326a7ac, 2026-05-15):
+	// 224 finish-to-start rels emitted, every fromId malformed.
+	//
+	// Three input shapes the watcher may emit:
+	//   "cilium"               (primary, bare chart)        → "install-cilium"
+	//   "hel1-2:cilium"        (secondary, region-prefixed) → "install-hel1-2:cilium"
+	//   "install-hel1-2:cilium"(already canonical, idempotent) → same
+	if len(dependsOn) > 0 {
+		canon := make([]string, 0, len(dependsOn))
+		for _, d := range dependsOn {
+			if d == "" {
+				continue
+			}
+			if !strings.HasPrefix(d, JobNamePrefix) {
+				d = JobNamePrefix + d
+			}
+			canon = append(canon, d)
+		}
+		dependsOn = canon
+	}
+
 	// Ensure the bootstrap-kit parent group exists before any leaf is
 	// written underneath it (idempotent — UpsertJob's merge preserves
 	// any prior row).


### PR DESCRIPTION
## Summary
Completes the fix for "sibling deps invisible on canvas." PR #1499 plumbed spec.dependsOn through every event, but the resulting `Job.DependsOn` values were stored as bare chart names (`gitea`) or region-only-prefixed (`hel1-2:gitea`) — both miss the `install-` prefix that the openova-flow snapshot composer needs to emit matching FlowNode fromIds. Result: 224 finish-to-start rels emitted by catalyst-api → openova-flow-server, but every fromId malformed → canvas renders 0 sibling edges.

## Fix
- `phase1_watch.go`: secondary emit rescopes to `install-<region>:<chart>` (was `<region>:<chart>`)
- `helmwatch_bridge.go`: `OnHelmReleaseEvent` canonicalises every dep entry by prepending `JobNamePrefix` (`install-`) if not already present — idempotent, covers primary path too

## Test plan
- [x] `go build` + `go test ./internal/jobs/... ./internal/helmwatch/...` green
- [ ] After image roll: wipe t103 + provision t104 — verify openova-flow snapshot's finish-to-start fromIds match real FlowNode ids, canvas renders sibling edges

🤖 Generated with [Claude Code](https://claude.com/claude-code)