### PR TITLE
fix(canvas): canonicalise resolved DependsOn too — kill malformed prior values

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/phase1_watch.go
+++ b/products/catalyst/bootstrap/api/internal/handler/phase1_watch.go
@@ -477,12 +477,27 @@ func (h *Handler) spawnSecondaryRegionWatchers(dep *Deployment) func() {
 			// pointing at the PRIMARY region's bare-named jobs,
 			// and the canvas fan-out collapses cross-region edges
 			// that aren't real. helmwatch.processEvent populated
-			// ev.DependsOn from the live spec.dependsOn; we just
-			// rescope here.
+			// ev.DependsOn from the live spec.dependsOn (bare chart
+			// names like "gitea"); we both region-prefix AND inject
+			// the canonical "install-" prefix so the stored Job
+			// row's DependsOn matches the JobName scheme exactly.
+			//
+			// Why "install-<region>:<chart>" not "<region>:<chart>":
+			// the FE canvas adapter looks up node ids by exact match;
+			// node ids are `<dep>:install-<region>:<chart>` for
+			// install Jobs. Storing "<region>:<chart>" as a dep
+			// produces a `<dep>:<region>:<chart>` fromId in the
+			// finish-to-start relationship, which matches no node →
+			// edge invisible. Caught on prov t103.omani.works
+			// (005080699326a7ac, 2026-05-15): openova-flow snapshot
+			// had 224 finish-to-start rels emitted but their fromIds
+			// were `<dep>:hel1-2:seaweedfs` etc., missing "install-"
+			// → canvas rendered every secondary HR with no sibling
+			// edges despite the rel count being non-zero.
 			if len(ev.DependsOn) > 0 {
 				rescoped := make([]string, 0, len(ev.DependsOn))
 				for _, d := range ev.DependsOn {
-					rescoped = append(rescoped, region+":"+d)
+					rescoped = append(rescoped, "install-"+region+":"+d)
 				}
 				ev.DependsOn = rescoped
 			}

--- a/products/catalyst/bootstrap/api/internal/jobs/helmwatch_bridge.go
+++ b/products/catalyst/bootstrap/api/internal/jobs/helmwatch_bridge.go
@@ -489,6 +489,33 @@ func (b *Bridge) OnHelmReleaseEvent(componentID, state, level, message string, t
 		dependsOn = []string{}
 	}
 
+	// Prepend the canonical JobNamePrefix ("install-") to every dep so
+	// the stored Job.DependsOn matches the format other Jobs use as
+	// their JobName. Without this, the openova-flow snapshot composer
+	// emits finish-to-start relationships with fromIds like
+	// "<dep>:hel1-2:seaweedfs" (missing "install-"), which match no
+	// FlowNode and the canvas renders every sibling-edge invisible.
+	// Caught on prov t103.omani.works (005080699326a7ac, 2026-05-15):
+	// 224 finish-to-start rels emitted, every fromId malformed.
+	//
+	// Three input shapes the watcher may emit:
+	//   "cilium"               (primary, bare chart)        → "install-cilium"
+	//   "hel1-2:cilium"        (secondary, region-prefixed) → "install-hel1-2:cilium"
+	//   "install-hel1-2:cilium"(already canonical, idempotent) → same
+	if len(dependsOn) > 0 {
+		canon := make([]string, 0, len(dependsOn))
+		for _, d := range dependsOn {
+			if d == "" {
+				continue
+			}
+			if !strings.HasPrefix(d, JobNamePrefix) {
+				d = JobNamePrefix + d
+			}
+			canon = append(canon, d)
+		}
+		dependsOn = canon
+	}
+
 	// Ensure the bootstrap-kit parent group exists before any leaf is
 	// written underneath it (idempotent — UpsertJob's merge preserves
 	// any prior row).

--- a/products/catalyst/bootstrap/api/internal/jobs/helmwatch_bridge.go
+++ b/products/catalyst/bootstrap/api/internal/jobs/helmwatch_bridge.go
@@ -570,6 +570,26 @@ func (b *Bridge) OnHelmReleaseEvent(componentID, state, level, message string, t
 	} else if len(dependsOn) > 0 {
 		resolvedDeps = dependsOn
 	}
+	// Also canonicalise any malformed entries inherited from prior
+	// writes (pre-PR-1500 stored "hel1-2:gitea" without "install-"
+	// prefix; the snapshot composer emits a FromId that matches no
+	// FlowNode, edge invisible). The canon block above only ran on
+	// the event-carried dependsOn arg; this final pass guarantees
+	// the persisted Job.DependsOn is canonical regardless of where
+	// the entries came from.
+	if len(resolvedDeps) > 0 {
+		canon := make([]string, 0, len(resolvedDeps))
+		for _, d := range resolvedDeps {
+			if d == "" {
+				continue
+			}
+			if !strings.HasPrefix(d, JobNamePrefix) {
+				d = JobNamePrefix + d
+			}
+			canon = append(canon, d)
+		}
+		resolvedDeps = canon
+	}
 	if err := b.store.UpsertJob(Job{
 		DeploymentID: b.deploymentID,
 		JobName:      jobName,


### PR DESCRIPTION
Follow-up to PR #1500. Resolved-deps preserved malformed existing-store entries. Now canonicalises all resolved entries before persist.

🤖 Generated with Claude Code