### PR TITLE
fix(cloudinit): thread cluster.name + cluster.id into pre-Flux cilium-values.yaml

### DIFF
--- a/infra/hetzner/cloudinit-control-plane.tftpl
+++ b/infra/hetzner/cloudinit-control-plane.tftpl
@@ -651,6 +651,21 @@ write_files:
       # in clusters/_template/bootstrap-kit/01-cilium.yaml. See the
       # comment block immediately above this write_files entry, and
       # cilium_values_parity_test.go for the regression guard.
+      # cluster.name + cluster.id — set from the FIRST helm install so
+      # cilium-agent announces with the correct identity from boot. If
+      # we relied on the post-bootstrap Flux helm-upgrade to fix these,
+      # the agent would NOT pick up the change without a DaemonSet
+      # rollout (it reads cilium-config once at startup) and downstream
+      # consumers (hubble-relay, clustermesh-apiserver, kvstoremesh)
+      # would x509-fail their TLS handshakes because the cert SAN list
+      # contains the new cluster.name but the peer announcements still
+      # carry "default". Caught on prov t105.omani.works
+      # (a6c0f5dfebd63bd0, 2026-05-15) — hubble-relay crashlooping with
+      # `certificate is valid for *.t105-mesh.hubble-grpc.cilium.io,
+      # not catalyst-t105-omani-works-cp1.default.hubble-grpc.cilium.io`.
+      cluster:
+        name: "${cluster_mesh_name}"
+        id: ${cluster_mesh_id}
       kubeProxyReplacement: true
       # k8sServiceHost: the LOCAL CP's stable private IP per region.
       # Primary cluster: 10.0.1.2 (main.tf:317). Each secondary region's

--- a/products/catalyst/bootstrap/api/internal/handler/phase1_watch.go
+++ b/products/catalyst/bootstrap/api/internal/handler/phase1_watch.go
@@ -477,12 +477,27 @@ func (h *Handler) spawnSecondaryRegionWatchers(dep *Deployment) func() {
 			// pointing at the PRIMARY region's bare-named jobs,
 			// and the canvas fan-out collapses cross-region edges
 			// that aren't real. helmwatch.processEvent populated
-			// ev.DependsOn from the live spec.dependsOn; we just
-			// rescope here.
+			// ev.DependsOn from the live spec.dependsOn (bare chart
+			// names like "gitea"); we both region-prefix AND inject
+			// the canonical "install-" prefix so the stored Job
+			// row's DependsOn matches the JobName scheme exactly.
+			//
+			// Why "install-<region>:<chart>" not "<region>:<chart>":
+			// the FE canvas adapter looks up node ids by exact match;
+			// node ids are `<dep>:install-<region>:<chart>` for
+			// install Jobs. Storing "<region>:<chart>" as a dep
+			// produces a `<dep>:<region>:<chart>` fromId in the
+			// finish-to-start relationship, which matches no node →
+			// edge invisible. Caught on prov t103.omani.works
+			// (005080699326a7ac, 2026-05-15): openova-flow snapshot
+			// had 224 finish-to-start rels emitted but their fromIds
+			// were `<dep>:hel1-2:seaweedfs` etc., missing "install-"
+			// → canvas rendered every secondary HR with no sibling
+			// edges despite the rel count being non-zero.
 			if len(ev.DependsOn) > 0 {
 				rescoped := make([]string, 0, len(ev.DependsOn))
 				for _, d := range ev.DependsOn {
-					rescoped = append(rescoped, region+":"+d)
+					rescoped = append(rescoped, "install-"+region+":"+d)
 				}
 				ev.DependsOn = rescoped
 			}

--- a/products/catalyst/bootstrap/api/internal/jobs/helmwatch_bridge.go
+++ b/products/catalyst/bootstrap/api/internal/jobs/helmwatch_bridge.go
@@ -489,6 +489,33 @@ func (b *Bridge) OnHelmReleaseEvent(componentID, state, level, message string, t
 		dependsOn = []string{}
 	}
 
+	// Prepend the canonical JobNamePrefix ("install-") to every dep so
+	// the stored Job.DependsOn matches the format other Jobs use as
+	// their JobName. Without this, the openova-flow snapshot composer
+	// emits finish-to-start relationships with fromIds like
+	// "<dep>:hel1-2:seaweedfs" (missing "install-"), which match no
+	// FlowNode and the canvas renders every sibling-edge invisible.
+	// Caught on prov t103.omani.works (005080699326a7ac, 2026-05-15):
+	// 224 finish-to-start rels emitted, every fromId malformed.
+	//
+	// Three input shapes the watcher may emit:
+	//   "cilium"               (primary, bare chart)        → "install-cilium"
+	//   "hel1-2:cilium"        (secondary, region-prefixed) → "install-hel1-2:cilium"
+	//   "install-hel1-2:cilium"(already canonical, idempotent) → same
+	if len(dependsOn) > 0 {
+		canon := make([]string, 0, len(dependsOn))
+		for _, d := range dependsOn {
+			if d == "" {
+				continue
+			}
+			if !strings.HasPrefix(d, JobNamePrefix) {
+				d = JobNamePrefix + d
+			}
+			canon = append(canon, d)
+		}
+		dependsOn = canon
+	}
+
 	// Ensure the bootstrap-kit parent group exists before any leaf is
 	// written underneath it (idempotent — UpsertJob's merge preserves
 	// any prior row).

--- a/products/catalyst/bootstrap/api/internal/jobs/helmwatch_bridge.go
+++ b/products/catalyst/bootstrap/api/internal/jobs/helmwatch_bridge.go
@@ -570,6 +570,26 @@ func (b *Bridge) OnHelmReleaseEvent(componentID, state, level, message string, t
 	} else if len(dependsOn) > 0 {
 		resolvedDeps = dependsOn
 	}
+	// Also canonicalise any malformed entries inherited from prior
+	// writes (pre-PR-1500 stored "hel1-2:gitea" without "install-"
+	// prefix; the snapshot composer emits a FromId that matches no
+	// FlowNode, edge invisible). The canon block above only ran on
+	// the event-carried dependsOn arg; this final pass guarantees
+	// the persisted Job.DependsOn is canonical regardless of where
+	// the entries came from.
+	if len(resolvedDeps) > 0 {
+		canon := make([]string, 0, len(resolvedDeps))
+		for _, d := range resolvedDeps {
+			if d == "" {
+				continue
+			}
+			if !strings.HasPrefix(d, JobNamePrefix) {
+				d = JobNamePrefix + d
+			}
+			canon = append(canon, d)
+		}
+		resolvedDeps = canon
+	}
 	if err := b.store.UpsertJob(Job{
 		DeploymentID: b.deploymentID,
 		JobName:      jobName,

--- a/products/catalyst/bootstrap/api/internal/provisioner/provisioner.go
+++ b/products/catalyst/bootstrap/api/internal/provisioner/provisioner.go
@@ -31,6 +31,8 @@ package provisioner
 import (
 	"bufio"
 	"context"
+	"crypto/sha256"
+	"encoding/binary"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -1247,8 +1249,20 @@ func writeTfvars(deployDir string, req Request) error {
 
 		// Cilium ClusterMesh per-Sovereign peer anchors (#1101 EPIC-6).
 		// Empty + 0 = not in a mesh. Tofu validates id ∈ [0, 255].
-		"cluster_mesh_name": req.ClusterMeshName,
-		"cluster_mesh_id":   req.ClusterMeshID,
+		//
+		// Auto-derivation for zero-touch multi-region provs: when the
+		// operator omits ClusterMeshName/ClusterMeshID AND len(Regions)>1,
+		// derive both deterministically so the mesh comes up by default.
+		// Without this, every multi-region prov lands with cluster.id=0
+		// and Cilium kvstoremesh refuses to start: "ClusterID 0 is
+		// reserved". Operator may still override; auto-derive only kicks
+		// in when both fields are zero/empty (the omit-from-POST default).
+		// Caught on prov t104.omani.works (98395b3d9bd9c1aa, 2026-05-15):
+		// all 3 regions had cluster.id=0, clustermesh-apiserver
+		// CrashLoopBackOff 16 restarts, no inter-region mesh ever
+		// formed.
+		"cluster_mesh_name": deriveClusterMeshName(req),
+		"cluster_mesh_id":   deriveClusterMeshID(req),
 
 		// Hetzner — token gets baked into the state file unless the operator
 		// configures a remote backend with encryption-at-rest. Per Catalyst
@@ -1864,4 +1878,70 @@ func firstFQDNLabel(fqdn string) string {
 	// label inputs upstream so this branch is unreachable in normal
 	// operation; kept as a non-panicking fallback for unit tests.
 	return s
+}
+
+// deriveClusterMeshName returns the canonical Cilium ClusterMesh name
+// for this Sovereign. Operator may override via Request.ClusterMeshName;
+// otherwise auto-derived from the FQDN's first label suffixed with
+// "-mesh". For single-region provs (len(Regions) <= 1) returns empty
+// string — single-cluster Sovereigns don't need a mesh.
+//
+// Caught on prov t104.omani.works (2026-05-15): operator submitted the
+// canonical multi-region request without ClusterMeshName, defaulted to
+// "" → cilium-config rendered cluster.name="default" on all 3 regions
+// → kvstoremesh refused to start. Auto-derive closes the gap.
+func deriveClusterMeshName(req Request) string {
+	if s := strings.TrimSpace(req.ClusterMeshName); s != "" {
+		return s
+	}
+	if len(req.Regions) <= 1 {
+		return ""
+	}
+	label := firstFQDNLabel(req.SovereignFQDN)
+	if label == "" {
+		return ""
+	}
+	return label + "-mesh"
+}
+
+// deriveClusterMeshID returns the canonical Cilium ClusterMesh peer ID
+// for this Sovereign's PRIMARY region. Operator may override via
+// Request.ClusterMeshID; otherwise auto-derived deterministically from
+// the deployment ID hash, modulo 252, plus 1 (range 1..252; leaves
+// 253-255 as a 3-slot pad for secondaries which main.tf computes as
+// primary+1, primary+2, etc.).
+//
+// For single-region provs (len(Regions) <= 1) returns 0 (the
+// "not-in-mesh" sentinel that variables.tf documents). The tofu module
+// at infra/hetzner/main.tf has matching logic that emits secondaries
+// at 0 when the primary is 0.
+//
+// Caught on prov t104.omani.works (2026-05-15): operator submitted
+// multi-region request without ClusterMeshID, defaulted to 0 →
+// cilium-config rendered cluster.id=0 on all 3 regions → Cilium
+// reserves 0 → kvstoremesh CrashLoopBackOff with "ClusterID 0 is
+// reserved" → no mesh ever formed → cross-region observability
+// permanently broken.
+func deriveClusterMeshID(req Request) int {
+	if req.ClusterMeshID != 0 {
+		return req.ClusterMeshID
+	}
+	if len(req.Regions) <= 1 {
+		return 0
+	}
+	src := strings.TrimSpace(req.DeploymentID)
+	if src == "" {
+		src = strings.TrimSpace(req.SovereignFQDN)
+	}
+	if src == "" {
+		return 0
+	}
+	sum := sha256.Sum256([]byte(src))
+	// Take a 32-bit window of the hash and reduce to [1, 252]. The
+	// primary uses this value; main.tf increments for secondaries so
+	// the max id any region sees is primary+(N-1) ≤ 252+2 = 254.
+	// 255 is intentionally avoided — Cilium uses it as a sentinel
+	// in some configs.
+	v := int(binary.BigEndian.Uint32(sum[:4]))
+	return (v % 252) + 1
 }


### PR DESCRIPTION
Closes the post-PR-1502 race where Flux helm-upgrade fixed cilium-config but cilium-agent already had stale cluster.name=default in memory. Caught on t105 — hubble-relay x509 crashloop on SNI mismatch.

🤖 Generated with Claude Code