### PR TITLE
fix(sovereign-tls): tls-restart Job needs list+watch verbs

### DIFF
--- a/clusters/_template/sovereign-tls/cilium-envoy-tls-restart-job.yaml
+++ b/clusters/_template/sovereign-tls/cilium-envoy-tls-restart-job.yaml
@@ -96,7 +96,7 @@ rules:
   - apiGroups: ["apps"]
     resources: ["daemonsets"]
     resourceNames: ["cilium-envoy"]
-    verbs: ["get", "patch"]
+    verbs: ["get", "patch", "list", "watch"]
   # ALSO patch the cilium-operator Deployment. Reason: on a fresh
   # Sovereign, cilium-operator's first CEC reconciliation produces a
   # CiliumEnvoyConfig WITHOUT the hostNetwork bind `additionalAddresses.
@@ -113,10 +113,16 @@ rules:
   - apiGroups: ["apps"]
     resources: ["deployments"]
     resourceNames: ["cilium-operator"]
-    verbs: ["get", "patch"]
-  # Read DaemonSet rollout status so the Job can wait for the new pods
-  # to come up before exiting. `kubectl rollout status` issues GET on
-  # the DaemonSet resource (no extra verbs needed).
+    verbs: ["get", "patch", "list", "watch"]
+  # Read rollout status so the Job can wait for new pods to come up
+  # before exiting. `kubectl rollout status` does NOT just GET — it
+  # uses client-go informerwatcher to LIST+WATCH the
+  # Deployment/DaemonSet resource. Without list+watch verbs the
+  # informer fails with "forbidden: cannot list resource ..." and the
+  # Job stalls at the rollout-status check until activeDeadlineSeconds.
+  # Caught on prov t110.omani.works (fe09897a1b6b3c1d, 2026-05-15):
+  # tls-restart Job stuck Running 10m+ on the cilium-operator rollout
+  # check, never restarted cilium-envoy, console.<fqdn> never served.
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/infra/hetzner/cloudinit-control-plane.tftpl
+++ b/infra/hetzner/cloudinit-control-plane.tftpl
@@ -651,6 +651,21 @@ write_files:
       # in clusters/_template/bootstrap-kit/01-cilium.yaml. See the
       # comment block immediately above this write_files entry, and
       # cilium_values_parity_test.go for the regression guard.
+      # cluster.name + cluster.id — set from the FIRST helm install so
+      # cilium-agent announces with the correct identity from boot. If
+      # we relied on the post-bootstrap Flux helm-upgrade to fix these,
+      # the agent would NOT pick up the change without a DaemonSet
+      # rollout (it reads cilium-config once at startup) and downstream
+      # consumers (hubble-relay, clustermesh-apiserver, kvstoremesh)
+      # would x509-fail their TLS handshakes because the cert SAN list
+      # contains the new cluster.name but the peer announcements still
+      # carry "default". Caught on prov t105.omani.works
+      # (a6c0f5dfebd63bd0, 2026-05-15) — hubble-relay crashlooping with
+      # `certificate is valid for *.t105-mesh.hubble-grpc.cilium.io,
+      # not catalyst-t105-omani-works-cp1.default.hubble-grpc.cilium.io`.
+      cluster:
+        name: "${cluster_mesh_name}"
+        id: ${cluster_mesh_id}
       kubeProxyReplacement: true
       # k8sServiceHost: the LOCAL CP's stable private IP per region.
       # Primary cluster: 10.0.1.2 (main.tf:317). Each secondary region's

--- a/products/catalyst/bootstrap/api/internal/handler/phase1_watch.go
+++ b/products/catalyst/bootstrap/api/internal/handler/phase1_watch.go
@@ -477,12 +477,27 @@ func (h *Handler) spawnSecondaryRegionWatchers(dep *Deployment) func() {
 			// pointing at the PRIMARY region's bare-named jobs,
 			// and the canvas fan-out collapses cross-region edges
 			// that aren't real. helmwatch.processEvent populated
-			// ev.DependsOn from the live spec.dependsOn; we just
-			// rescope here.
+			// ev.DependsOn from the live spec.dependsOn (bare chart
+			// names like "gitea"); we both region-prefix AND inject
+			// the canonical "install-" prefix so the stored Job
+			// row's DependsOn matches the JobName scheme exactly.
+			//
+			// Why "install-<region>:<chart>" not "<region>:<chart>":
+			// the FE canvas adapter looks up node ids by exact match;
+			// node ids are `<dep>:install-<region>:<chart>` for
+			// install Jobs. Storing "<region>:<chart>" as a dep
+			// produces a `<dep>:<region>:<chart>` fromId in the
+			// finish-to-start relationship, which matches no node →
+			// edge invisible. Caught on prov t103.omani.works
+			// (005080699326a7ac, 2026-05-15): openova-flow snapshot
+			// had 224 finish-to-start rels emitted but their fromIds
+			// were `<dep>:hel1-2:seaweedfs` etc., missing "install-"
+			// → canvas rendered every secondary HR with no sibling
+			// edges despite the rel count being non-zero.
 			if len(ev.DependsOn) > 0 {
 				rescoped := make([]string, 0, len(ev.DependsOn))
 				for _, d := range ev.DependsOn {
-					rescoped = append(rescoped, region+":"+d)
+					rescoped = append(rescoped, "install-"+region+":"+d)
 				}
 				ev.DependsOn = rescoped
 			}

--- a/products/catalyst/bootstrap/api/internal/jobs/helmwatch_bridge.go
+++ b/products/catalyst/bootstrap/api/internal/jobs/helmwatch_bridge.go
@@ -489,6 +489,33 @@ func (b *Bridge) OnHelmReleaseEvent(componentID, state, level, message string, t
 		dependsOn = []string{}
 	}
 
+	// Prepend the canonical JobNamePrefix ("install-") to every dep so
+	// the stored Job.DependsOn matches the format other Jobs use as
+	// their JobName. Without this, the openova-flow snapshot composer
+	// emits finish-to-start relationships with fromIds like
+	// "<dep>:hel1-2:seaweedfs" (missing "install-"), which match no
+	// FlowNode and the canvas renders every sibling-edge invisible.
+	// Caught on prov t103.omani.works (005080699326a7ac, 2026-05-15):
+	// 224 finish-to-start rels emitted, every fromId malformed.
+	//
+	// Three input shapes the watcher may emit:
+	//   "cilium"               (primary, bare chart)        → "install-cilium"
+	//   "hel1-2:cilium"        (secondary, region-prefixed) → "install-hel1-2:cilium"
+	//   "install-hel1-2:cilium"(already canonical, idempotent) → same
+	if len(dependsOn) > 0 {
+		canon := make([]string, 0, len(dependsOn))
+		for _, d := range dependsOn {
+			if d == "" {
+				continue
+			}
+			if !strings.HasPrefix(d, JobNamePrefix) {
+				d = JobNamePrefix + d
+			}
+			canon = append(canon, d)
+		}
+		dependsOn = canon
+	}
+
 	// Ensure the bootstrap-kit parent group exists before any leaf is
 	// written underneath it (idempotent — UpsertJob's merge preserves
 	// any prior row).

--- a/products/catalyst/bootstrap/api/internal/jobs/helmwatch_bridge.go
+++ b/products/catalyst/bootstrap/api/internal/jobs/helmwatch_bridge.go
@@ -570,6 +570,26 @@ func (b *Bridge) OnHelmReleaseEvent(componentID, state, level, message string, t
 	} else if len(dependsOn) > 0 {
 		resolvedDeps = dependsOn
 	}
+	// Also canonicalise any malformed entries inherited from prior
+	// writes (pre-PR-1500 stored "hel1-2:gitea" without "install-"
+	// prefix; the snapshot composer emits a FromId that matches no
+	// FlowNode, edge invisible). The canon block above only ran on
+	// the event-carried dependsOn arg; this final pass guarantees
+	// the persisted Job.DependsOn is canonical regardless of where
+	// the entries came from.
+	if len(resolvedDeps) > 0 {
+		canon := make([]string, 0, len(resolvedDeps))
+		for _, d := range resolvedDeps {
+			if d == "" {
+				continue
+			}
+			if !strings.HasPrefix(d, JobNamePrefix) {
+				d = JobNamePrefix + d
+			}
+			canon = append(canon, d)
+		}
+		resolvedDeps = canon
+	}
 	if err := b.store.UpsertJob(Job{
 		DeploymentID: b.deploymentID,
 		JobName:      jobName,

--- a/products/catalyst/bootstrap/api/internal/provisioner/provisioner.go
+++ b/products/catalyst/bootstrap/api/internal/provisioner/provisioner.go
@@ -31,6 +31,8 @@ package provisioner
 import (
 	"bufio"
 	"context"
+	"crypto/sha256"
+	"encoding/binary"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -1247,8 +1249,20 @@ func writeTfvars(deployDir string, req Request) error {
 
 		// Cilium ClusterMesh per-Sovereign peer anchors (#1101 EPIC-6).
 		// Empty + 0 = not in a mesh. Tofu validates id ∈ [0, 255].
-		"cluster_mesh_name": req.ClusterMeshName,
-		"cluster_mesh_id":   req.ClusterMeshID,
+		//
+		// Auto-derivation for zero-touch multi-region provs: when the
+		// operator omits ClusterMeshName/ClusterMeshID AND len(Regions)>1,
+		// derive both deterministically so the mesh comes up by default.
+		// Without this, every multi-region prov lands with cluster.id=0
+		// and Cilium kvstoremesh refuses to start: "ClusterID 0 is
+		// reserved". Operator may still override; auto-derive only kicks
+		// in when both fields are zero/empty (the omit-from-POST default).
+		// Caught on prov t104.omani.works (98395b3d9bd9c1aa, 2026-05-15):
+		// all 3 regions had cluster.id=0, clustermesh-apiserver
+		// CrashLoopBackOff 16 restarts, no inter-region mesh ever
+		// formed.
+		"cluster_mesh_name": deriveClusterMeshName(req),
+		"cluster_mesh_id":   deriveClusterMeshID(req),
 
 		// Hetzner — token gets baked into the state file unless the operator
 		// configures a remote backend with encryption-at-rest. Per Catalyst
@@ -1864,4 +1878,70 @@ func firstFQDNLabel(fqdn string) string {
 	// label inputs upstream so this branch is unreachable in normal
 	// operation; kept as a non-panicking fallback for unit tests.
 	return s
+}
+
+// deriveClusterMeshName returns the canonical Cilium ClusterMesh name
+// for this Sovereign. Operator may override via Request.ClusterMeshName;
+// otherwise auto-derived from the FQDN's first label suffixed with
+// "-mesh". For single-region provs (len(Regions) <= 1) returns empty
+// string — single-cluster Sovereigns don't need a mesh.
+//
+// Caught on prov t104.omani.works (2026-05-15): operator submitted the
+// canonical multi-region request without ClusterMeshName, defaulted to
+// "" → cilium-config rendered cluster.name="default" on all 3 regions
+// → kvstoremesh refused to start. Auto-derive closes the gap.
+func deriveClusterMeshName(req Request) string {
+	if s := strings.TrimSpace(req.ClusterMeshName); s != "" {
+		return s
+	}
+	if len(req.Regions) <= 1 {
+		return ""
+	}
+	label := firstFQDNLabel(req.SovereignFQDN)
+	if label == "" {
+		return ""
+	}
+	return label + "-mesh"
+}
+
+// deriveClusterMeshID returns the canonical Cilium ClusterMesh peer ID
+// for this Sovereign's PRIMARY region. Operator may override via
+// Request.ClusterMeshID; otherwise auto-derived deterministically from
+// the deployment ID hash, modulo 252, plus 1 (range 1..252; leaves
+// 253-255 as a 3-slot pad for secondaries which main.tf computes as
+// primary+1, primary+2, etc.).
+//
+// For single-region provs (len(Regions) <= 1) returns 0 (the
+// "not-in-mesh" sentinel that variables.tf documents). The tofu module
+// at infra/hetzner/main.tf has matching logic that emits secondaries
+// at 0 when the primary is 0.
+//
+// Caught on prov t104.omani.works (2026-05-15): operator submitted
+// multi-region request without ClusterMeshID, defaulted to 0 →
+// cilium-config rendered cluster.id=0 on all 3 regions → Cilium
+// reserves 0 → kvstoremesh CrashLoopBackOff with "ClusterID 0 is
+// reserved" → no mesh ever formed → cross-region observability
+// permanently broken.
+func deriveClusterMeshID(req Request) int {
+	if req.ClusterMeshID != 0 {
+		return req.ClusterMeshID
+	}
+	if len(req.Regions) <= 1 {
+		return 0
+	}
+	src := strings.TrimSpace(req.DeploymentID)
+	if src == "" {
+		src = strings.TrimSpace(req.SovereignFQDN)
+	}
+	if src == "" {
+		return 0
+	}
+	sum := sha256.Sum256([]byte(src))
+	// Take a 32-bit window of the hash and reduce to [1, 252]. The
+	// primary uses this value; main.tf increments for secondaries so
+	// the max id any region sees is primary+(N-1) ≤ 252+2 = 254.
+	// 255 is intentionally avoided — Cilium uses it as a sentinel
+	// in some configs.
+	v := int(binary.BigEndian.Uint32(sum[:4]))
+	return (v % 252) + 1
 }

--- a/products/sandbox/README.md
+++ b/products/sandbox/README.md
@@ -1,0 +1,48 @@
+# OpenOva Sandbox (design)
+
+**Status:** Design. Not yet implemented. **Created:** 2026-05-15.
+
+OpenOva Sandbox is the per-user, per-Organization coding-agent plane that runs **inside** every OpenOva Sovereign. It hosts long-lived sessions of the agents developers already use (Claude Code, Cursor, Qwen Code, Aider, Opencode) — server-side, cluster-aware, identity-scoped — and surfaces them through a native terminal in the browser plus a card-stream view on mobile, both backed by the same persistent process.
+
+Sandbox is also the conversational front-door to provisioning a brand-new Sovereign: the same shell, scoped to a narrower MCP tool surface, lets a non-technical user talk (text or voice) through standing up their cloud instead of filling in a wizard.
+
+## Naming
+
+The chosen name is **OpenOva Sandbox**. Alternatives we considered:
+
+| Name | Positioning | Why we did not pick it |
+|---|---|---|
+| **Sandbox** *(chosen)* | "The cloud sandbox where your agents do real work" | Plain noun, matches `Sovereign` / `Catalyst` style. Inherits the moat directly: a real cloud sandbox per user, not a browser tab. |
+| Forge | Active and agentic ("forge production code") | "Forge" is taken by smaller dev tools; trademark friction. |
+| Studio | Lineage with Android/Visual Studio / Codespaces | Generic — nothing about the cluster-aware moat is implied in the name. |
+
+## Contents
+
+- [`docs/business-requirements.md`](docs/business-requirements.md) — what we are solving, who for, the moat, success criteria.
+- [`docs/user-journey.md`](docs/user-journey.md) — end-to-end wireframe storyboard for the developer (Nova user) and the Sovereign admin, including multi-device handoff and the EventForge build walkthrough.
+- [`docs/architecture.md`](docs/architecture.md) — technical architecture: native TUI in the browser via xterm.js + WebSocket + PTY, the card protocol for mobile, the MCP server tool catalogue, the four knowledge layers (static / procedural / live / corpus), and exact integration points with the existing OpenOva primitives (vcluster per Org, Keycloak modes, Gitea, marketplace BYOD, JetStream, SSE).
+- [`docs/provisioning-chat.md`](docs/provisioning-chat.md) — the conversational alternative to the catalyst-ui wizard; text + voice; same shell, narrower MCP surface.
+
+## What is already there, what we still need
+
+Confirmed against the codebase (2026-05-15):
+
+| Foundation primitive | State | Reference |
+|---|---|---|
+| `Organization` CRD (`orgs.openova.io/v1`) | Shipped | `products/catalyst/chart/crds/organization.yaml` |
+| vcluster per Org | Shipped | `core/controllers/organization/internal/gitops/manifests.go` |
+| Keycloak realm (sovereign-shared vs per-Org SME mode) | Shipped | `platform/keycloak/chart/values.yaml`, `chart/templates/configmap-{sovereign,tenant}-realm.yaml` |
+| Gitea Org + `catalyst-tenant` repo auto-provisioned per Org | Shipped | `core/controllers/organization/internal/controller/organization_controller.go` |
+| UserAccess CR → RoleBindings (RBAC fan-out) | Shipped | same controller |
+| Marketplace: subdomain + BYO custom domain | Shipped | `core/services/domain/handlers/handlers.go` (`POST /domain/byod`), `core/marketplace-api/handlers/handlers.go` |
+| JetStream subject convention `catalyst.<domain>.<event>` | Shipped (ADR-0001 §6) | `core/services/shared/events/nats.go` |
+| SSE feeds for deployments / cutover / flow / RBAC / K8s / continuum / openova-flow | Shipped (7+ endpoints) | `products/catalyst/bootstrap/api/internal/handler/*.go`, `products/openova-flow/server/internal/api/stream.go` |
+| Harbor / SeaweedFS at host-cluster scope (multi-Org via projects/buckets) | Shipped (by design — not per-Org instances) | `platform/harbor/README.md`, `platform/seaweedfs/README.md` |
+
+The **one** prerequisite Sandbox needs that does not exist today:
+
+| Gap | What we need | Where to wire |
+|---|---|---|
+| Long-lived API token carrying `org_id` claim | A persistent token issued by Keycloak (or `core/services/auth`) that includes `org`, `groups`, and a Sandbox capability set. Today only a 15-minute JWT with `{sub, email, role}` exists; the tenant-realm Keycloak import has a `groups` mapper but not an `org` mapper. | `core/services/auth/handlers/handlers.go` (token issuance) + `platform/keycloak/chart/templates/configmap-tenant-realm.yaml` (add `org` protocolMapper) |
+
+Everything else Sandbox needs is greenfield product work and is described in the linked docs.

--- a/products/sandbox/docs/architecture.md
+++ b/products/sandbox/docs/architecture.md
@@ -1,0 +1,248 @@
+# Sandbox — architecture
+
+This is the technical contract. It documents:
+
+1. The two surfaces (native TUI in the browser; card protocol on mobile) and how they share one persistent process.
+2. The `pty-server` shim — what it does, what tmux would have done wrong.
+3. The MCP server tool catalogue (`openova-sandbox-mcp`).
+4. The four knowledge layers (static / procedural / live / corpus).
+5. Integration with the existing OpenOva primitives, with code citations.
+6. The one prerequisite gap (long-lived API token with `org_id` claim).
+7. The `Sandbox` CRD shape and the controller responsibilities (sketch — to be detailed when we implement).
+
+---
+
+## 1. Surfaces
+
+### Web / PC — 100% native agent TUI in the browser
+
+The `claude` (or `cursor-agent`, `qwen-code`, `aider`, `opencode`) **binary itself** runs in a pod inside the user's vcluster. Its stdout/stderr — ANSI escape codes, animations, plan-mode cards, all of it — is piped over a WebSocket to **xterm.js** in the user's browser tab. Keystrokes flow back over the same socket.
+
+```
+┌──────────────────────────────────┐       ┌─────────────────────────────────────────┐
+│        BROWSER  (user tab)        │       │     SANDBOX POD  (in the Org vcluster)  │
+│                                  │       │                                          │
+│   xterm.js                       │       │   pty-server  (Go, ~300 LOC)             │
+│   ├─ ANSI renderer (canvas/DOM)  │  WS   │   ├─ opens a PTY                         │
+│   ├─ keyboard -> bytes ──────────┼──────►│   ├─ writes WS frames to PTY stdin       │
+│   ├─ scrollback buffer           │◄──────┤   ├─ reads PTY stdout, fans out to WS    │
+│   └─ resize events               │       │   ├─ ring buffer (256 KB) for replay     │
+│                                  │       │   └─ SIGWINCH on browser resize          │
+└──────────────────────────────────┘       │              │                           │
+                                           │              ▼ spawns once per session   │
+                                           │   ┌──────────────────────────────────┐  │
+                                           │   │  claude  (the CLI binary)         │  │
+                                           │   │  --dangerously-skip-permissions   │  │
+                                           │   │  Ink/React writes ANSI to stdout  │  │
+                                           │   │  cwd = /repo/<repo>               │  │
+                                           │   │  MCP client config attached       │  │
+                                           │   └──────────────────────────────────┘  │
+                                           └──────────────────────────────────────────┘
+```
+
+We do **not** re-implement Claude Code. We do **not** translate its output. xterm.js renders ANSI; the agent writes ANSI; they meet by accident.
+
+### Mobile — card protocol on the same session
+
+xterm on a 5" screen is unreadable. The mobile PWA opens a second WebSocket to the same `session_id` with a `mode=cards` query parameter. The pty-server then runs an in-pod card-translator that parses agent output into structured cards (`text`, `tool-call`, `diff`, `bash`, `preview-link`) and ships them as a separate JSON stream over a parallel WebSocket frame channel. The same session, two surfaces.
+
+Both surfaces observe the same persistent process. Closing a tab does not stop the agent.
+
+---
+
+## 2. The `pty-server` shim — explicitly not tmux
+
+```
+pty-server  (per Sandbox pod, listens on :7681)
+├── POST /sessions                  spawn  <agent> in a fresh PTY,
+│                                   return session_id, write to JetStream
+├── WS   /sessions/{id}/attach      bidi: WS bytes ↔ PTY fd
+│                                   on connect, replay ring buffer
+├── WS   /sessions/{id}/cards       JSON cards (alt surface, mobile)
+├── POST /sessions/{id}/resize      cols/rows -> SIGWINCH
+├── POST /sessions/{id}/signal      INT / QUIT for user-driven aborts
+└── DELETE /sessions/{id}           graceful stop, then SIGKILL
+```
+
+| We want | tmux gives us | Use tmux? |
+|---|---|---|
+| Persist a PTY across client disconnects | YES | No |
+| Fan out PTY stdout to N concurrent WS clients | YES | No |
+| Replay last N KB on reconnect | (via screen) | No |
+| SIGWINCH on browser resize | YES | No |
+
+| We do not want | tmux forces | Why bad |
+|---|---|---|
+| A second TUI rendering on top of the agent | Status bar, borders, panes | Fights with Ink redraw |
+| A prefix-key input model (Ctrl-B) | YES | Hijacks keys the agent and user want |
+| Window-manager features (split, detach UI) | YES | Bloat |
+| Mobile-hostile rendering at small widths | YES | Breaks card view fallback |
+
+The tmux **behaviour model** (one PTY, multiple clients, persistent across disconnect) is what we keep. The tmux **stack** is not in the picture.
+
+---
+
+## 3. MCP server — `openova-sandbox-mcp`
+
+One MCP server per Sandbox session (sidecar in the same pod). The agent process speaks MCP over stdio. The server speaks to the Sovereign control plane over HTTPS using the user's token.
+
+### Tool namespaces
+
+```
+gitea.*           repos, PRs, issues, releases on this Sovereign's Gitea
+gitea-actions.*   workflow dispatch, run logs, artifact fetch
+github.*          present ONLY if iOS/macOS-runner work is detected;
+                  scoped GH PAT for that pipeline only
+sandbox.db.*      provision / drop / dump  CNPG clusters in this Sandbox
+sandbox.auth.*    provisionRealm, listClients, registerClient (Keycloak)
+sandbox.stripe.*  bindAccount, listProducts (uses Sandbox secret store)
+sandbox.secrets.* read/write Sandbox-scoped secrets (never echoes)
+sandbox.storage.* bindBucket / signedUploadURL (SeaweedFS-backed)
+sandbox.preview.* status, rebuild, teardown
+sandbox.deploy.*  staging / production (production gated on RBAC)
+marketplace.*     domain.byod, domain.subdomain  (BYOD live today)
+flux.*            status, reconcile, suspend  (scoped)
+k8s.read.*        get / list / watch within Org vcluster
+k8s.write.*       create / patch / delete   (only Sandbox namespace)
+sovereign.*       describe, listOrgs        (super-admin only)
+rag.search        per-Org hybrid index over repos + manifests + audit
+skills.list/get   versioned OCI skill packs
+```
+
+### Subscriptions (the moat)
+
+The agent calls MCP `resources/subscribe` once at session start with:
+
+```
+openova://flux/*
+openova://hr/*
+openova://preview/*
+openova://gitea/pr/*
+openova://gha/run/*
+```
+
+The MCP server consumes from the existing JetStream subjects under `catalyst.<domain>.<event>` (ADR-0001 §6 — `core/services/shared/events/nats.go:34-45`) and forwards them as MCP `notifications/resources/updated`. The agent gets *push* updates with no polling. The same JetStream subjects power the existing browser SSE feeds (`core/services/shared/events/nats.go`, `products/openova-flow/server/internal/api/stream.go`).
+
+Browser and agent are subscribers to the **same** event bus, in their native protocols. One source of truth.
+
+### RBAC enforcement
+
+Every tool call is authorised against the bearer token's claims `{sovereign_id, org_id, roles[]}`. Tools annotated `super-admin only` (e.g., `sovereign.listOrgs`) require the `sovereign-admin` role. Tools annotated `org-admin only` (e.g., `sandbox.deploy.production`) require `org:<id>:admin`. The shape is a single permission string per tool, no role-graph traversal at call time.
+
+---
+
+## 4. Knowledge layers
+
+Sandbox layers four flavours of "knowing the cloud", each chosen for what its time/freshness/size profile justifies:
+
+| Layer | Answers | Mechanism | Loaded |
+|---|---|---|---|
+| **Static identity** | "What is OpenOva? Inviolable rules. Architecture invariants." | `CLAUDE.md` / `AGENTS.md` / `.cursorrules` — same content, each agent's native file. Mounted into `/repo/.claude/`, `/repo/AGENTS.md`, etc. at session start. | Every prompt. |
+| **Procedural runbooks** | "How do I provision a CNPG cluster? How do I bind a domain via marketplace?" | **Skills** in `.claude/skills/openova-sandbox/*.md` (Claude) + parallel `.cursor/rules/*.mdc` / `aider/conventions/*.md` files. Versioned OCI artifact `ghcr.io/openova-io/sandbox-skills:<semver>`. | On demand. |
+| **Live cluster state** | "What HRs are reconciling? Did the preview build finish?" | **MCP subscriptions** (above) translated from JetStream `catalyst.<domain>.<event>`. | Pushed. |
+| **Corpus** | "Where in the repo is X defined? What did we ship last week?" | Per-Org **RAG** — hybrid (vector + BM25 + recency) over `/repo`, manifests, audit log, ADRs. NATS-watched for incremental reindex. | On `rag.search`. |
+
+The Sandbox Pack distribution is one command:
+
+```
+openova pack install --agent=claude    # or cursor / qwen / aider / opencode
+```
+
+It drops the right CLAUDE.md / .cursorrules / aider conventions / skills directory / `.mcp.json` into the user's repo or global config.
+
+---
+
+## 5. Integration with existing OpenOva primitives
+
+Every plumbing point below is verified against the codebase as of 2026-05-15.
+
+| Sandbox use | Existing primitive | Reference |
+|---|---|---|
+| One vcluster per Org | `Organization` CRD + organization-controller renders vcluster HelmRelease into per-Org Gitea repo | `products/catalyst/chart/crds/organization.yaml:1-322`, `core/controllers/organization/internal/gitops/manifests.go:65-146` |
+| One Keycloak realm per Sovereign (corporate) or per Org (SME) | mutually exclusive chart modes | `platform/keycloak/chart/values.yaml:24-192`, `chart/templates/configmap-{sovereign,tenant}-realm.yaml` |
+| One Gitea Org per Org | auto-provisioned at Org create | `core/controllers/organization/internal/controller/organization_controller.go:177-198` |
+| Marketplace subdomain + BYOD custom domain | `POST /domain/byod` returns CNAME target after validation | `core/services/domain/handlers/handlers.go:206-290`, `core/marketplace-api/handlers/handlers.go` |
+| JetStream subject convention | `catalyst.<domain>.<event>`, tenancy in payload (`TenantID`) — ADR-0001 §6 | `core/services/shared/events/nats.go:34-45` |
+| Browser SSE subscribers | Existing endpoints for deployments, cutover, RBAC audit, k8s, continuum, flow snapshot, openova-flow native (snapshot/upsert-*/delete-*) | `products/catalyst/bootstrap/api/internal/handler/*.go`, `products/openova-flow/server/internal/api/stream.go:23` |
+| Harbor (host-cluster scope) | One Harbor per host cluster, proxy-pull mode | `platform/harbor/README.md:1-5, 73-96` |
+| SeaweedFS (host-cluster scope) | Unified S3 endpoint `seaweedfs.storage.svc:8333` shared by all consumers | `platform/seaweedfs/README.md:1-4, 59-71` |
+| CNPG (provisioned by apps on demand) | `Cluster.postgresql.cnpg.io` CRs created by `sandbox.db.provision` MCP tool | `platform/cnpg/README.md` |
+| UserAccess CRs (RBAC fan-out) | One per Org owner, materialised to RoleBindings by useraccess-controller | `core/controllers/organization/internal/controller/organization_controller.go:227-234, 323-375` |
+
+**Sandbox builds on top — it does not duplicate any of these.**
+
+---
+
+## 6. The one prerequisite — long-lived org-scoped tokens
+
+Today the only access token in the system is a 15-minute JWT with claims `{sub, email, role}` (`core/services/auth/handlers/handlers.go:271-292`). The Keycloak tenant-realm has a `groups` protocol mapper but **no `org` mapper** (`platform/keycloak/chart/templates/configmap-tenant-realm.yaml:365-386`). The 5-minute handover JWT only carries `{email, sovereign_fqdn, deployment_id, role="sovereign-admin"}` (`catalyst/bootstrap/api/internal/handoverjwt/signer.go:79-99`).
+
+Sandbox needs a token that:
+
+- Lasts long enough for a coding session (hours, refreshable).
+- Carries `org_id` and the user's role within that org as first-class claims.
+- Carries a Sandbox capability set so the MCP server can authorise tool calls without round-tripping to Keycloak per call.
+
+The minimal change:
+
+1. Add an `org` protocol mapper to both `configmap-sovereign-realm.yaml` and `configmap-tenant-realm.yaml` — emits the user's Keycloak group attribute `org` into the token.
+2. Extend `core/services/auth/handlers/handlers.go` to:
+   - Read the user's groups from the Keycloak claim.
+   - Include `org_id`, `groups[]`, and `capabilities[]` in the JWT it issues.
+   - Add a personal-access-token issuance endpoint (`POST /auth/pat`) with admin-configurable TTL.
+3. Document the claim contract in `core/services/shared/auth/claims.go` (new file) so the MCP server, sandbox-controller, and any future consumer share one definition.
+
+No other prerequisite blocks Sandbox.
+
+---
+
+## 7. The `Sandbox` CRD (sketch — to be detailed at implementation)
+
+```yaml
+apiVersion: sandbox.openova.io/v1
+kind: Sandbox
+metadata:
+  name: emrah
+  namespace: acme            # = the Org's namespace
+spec:
+  owner:
+    email: emrah@acme.com
+    orgRef:
+      slug: acme
+  quota:
+    cpu: "4"
+    memory: "8Gi"
+    storage: "50Gi"
+    concurrentSessions: 3
+  repos:
+    - giteaRepo: acme/eventforge          # auto-cloned to a PVC
+    - giteaRepo: acme/internal-tools
+  agentCatalogue:                          # subset of Sovereign-enabled
+    - claude-code
+    - cursor-agent
+  previewDomain: sb-emrah.rzk7.openova.io
+status:
+  sessions: 3
+  storageUsed: 8.2Gi
+  spend30d: "USD 42.10"
+  previews:
+    - prNumber: 1483
+      url: https://pr-1483.eventforge.sb-emrah.rzk7.openova.io
+      sha: a8f3c12
+```
+
+### Controller responsibilities
+
+The `sandbox-controller` (new — sister to `organization-controller`) reconciles:
+
+- A namespace `sandbox-<owner-uid>` inside the Org vcluster (not the host).
+- PVCs for each `spec.repos[]` entry, with initContainer that does `git clone` against the Org's Gitea using a Sandbox-scoped deploy key.
+- A shared build-cache pod (per Org, not per Sandbox) bound to a Sovereign-wide SeaweedFS bucket.
+- A `pty-server` StatefulSet (1 replica, stable identity) per Sandbox.
+- A `openova-sandbox-mcp` Deployment per Sandbox.
+- The HTTPRoute / Gateway resources that publish `<pr>.<app>.<sb-<owner>>.<sov>.openova.io` (extends the marketplace subdomain registration).
+- Keycloak ServiceAccount + ClientScope bindings for the Sandbox's long-lived token.
+
+The controller writes its desired-state manifests into the Org's `catalyst-tenant` Gitea repo at `sandbox/<owner-uid>/`, exactly the same idiom `organization-controller` already uses for vcluster manifests. Flux on the host picks it up and reconciles into the Org's vcluster.
+
+This is the only new controller Sandbox adds.

--- a/products/sandbox/docs/business-requirements.md
+++ b/products/sandbox/docs/business-requirements.md
@@ -1,0 +1,64 @@
+# Sandbox — business requirements
+
+## The problem we are solving
+
+Developers using modern coding agents (Claude Code, Cursor, Qwen Code, Aider, Opencode) hit three structural ceilings:
+
+1. **The agent dies when the laptop closes.** All current agents are local processes bound to a TTY and a workstation. Long-running work (multi-hour refactors, end-to-end provisioning, watching a deploy roll) can not survive a closed lid, a flaky Wi-Fi, or moving devices.
+2. **The agent has zero awareness of the cloud the developer is shipping to.** It can edit code competently and run shell commands, but it does not know what Sovereign you operate, what cluster state exists right now, what your DNS topology is, what your secrets vault holds. Every cross-cluster question is a `kubectl` round-trip the developer has to wire by hand.
+3. **The user has no way to use the agent from a phone, a tablet, a Chromebook, or a borrowed machine.** SSH + tmux + Termius is the workaround and it is brittle, ugly on mobile, and breaks down on every device boundary.
+
+Beyond developers, there is a fourth problem at the on-ramp: **non-technical users cannot provision a Sovereign through a wizard.** The current `catalyst-ui` wizard is excellent for power users and integrators but presents 20+ fields at first contact. We are losing potential customers who would rather describe their need in two sentences than fill a form.
+
+## Who Sandbox is for
+
+| Audience | What they get | Pricing fit |
+|---|---|---|
+| **Sovereign super-admin** (the operator of the Sovereign) | Fleet view of every Org's Sandbox usage, agent catalogue control, org-level quotas, audit, cost attribution. Plus their own developer Sandbox in the same UI. | Bundled with Sovereign subscription. |
+| **Org admin** (e.g., CTO of a customer Org inside a corporate Sovereign) | Org-scoped admin view: invite developers, set per-developer quotas, bind Org-level secrets (Stripe live, Resend prod), publish Org skill packs. Plus their own developer Sandbox. | Per-seat add-on on the Org subscription. |
+| **Nova user — developer** (an engineer working inside an Org) | One personal Sandbox: persistent sessions, all approved agent brands, PVC-mounted repos, Org-shared build cache, auto preview URLs per PR, native-TUI in browser. | Per-seat. Pre-paid agent-token budget on top. |
+| **Prospective Sovereign customer** (no Sovereign yet) | A conversational entry point that talks them through provisioning — text, or voice. The same Sandbox shell, scoped to provisioning MCP tools only. | Free conversion path; paid once the Sovereign is up. |
+
+## Value proposition
+
+Sandbox is not "another IDE." It is the **agent host platform** that is missing between "raw agent on a laptop" and "managed AI tooling SaaS." The differentiators that matter:
+
+- **The Sovereign is the sandbox.** The agent runs inside the customer's own tenant cloud (vcluster per Org), under their own RBAC, against their own data, signing as them. Nothing leaves the tenant.
+- **Live cluster awareness is native, not retrofitted.** OpenovaFlow's existing watcher fabric and JetStream subjects already publish the events. Sandbox makes the agent a first-class subscriber via MCP `resources/subscribe`. No `kubectl get` loops.
+- **The same session is on every device.** Native Claude Code TUI in the browser via xterm.js + persistent PTY. Same session re-attaches from PC, iPad, or phone. The pty-server fans out multi-client like tmux but with no tmux in the stack.
+- **Preview-per-PR is one click.** Every PR the agent opens auto-resolves to a live URL under the Org's marketplace subdomain (which already exists today). Click on phone, ship from laptop.
+- **Conversational provisioning.** New customers describe what they need; the agent calls catalyst-api directly. This is the first surface where AI-first replaces forms.
+
+## The moat
+
+OpenOva already runs a **per-tenant vcluster cloud** with Keycloak identity, Gitea, Harbor, SeaweedFS, NATS JetStream, CNPG, marketplace DNS + BYOD, Crossplane reconcilers, Flux GitOps, and a live event fabric. No competitor in the AI-coding tools category has any of that. They have an editor with chat. We have a cloud with an agent host.
+
+Every other "AI coding" tool tries to bolt cluster-awareness onto an editor. Sandbox does the inverse: it bolts an editor experience onto a cluster the user already owns.
+
+## Success criteria
+
+We will know Sandbox is the right product when:
+
+- A developer on an iPad in a cab can ship a PR to production from a session that started on their desktop that morning, without re-attaching by hand.
+- A new customer goes from `console.openova.io` to a working Sovereign by speaking three sentences. No wizard fields touched.
+- The Sovereign admin can see "Org X spent $42 on agent tokens this week, 8 sessions, 3 production deploys" without writing a query.
+- A Cursor user and a Claude Code user inside the same Org open each other's PRs and the cards in each session reference the other's diffs because both subscribed to the same JetStream subjects.
+- The marketing pitch for Sovereign no longer leads with "secure tenant cloud" — it leads with "the only place where your agents can ship for you."
+
+## Non-goals
+
+- Sandbox is **not** an editor. It does not replace VS Code / Cursor / IntelliJ. It hosts agents; developers keep their editors.
+- Sandbox is **not** a Codespaces clone. Codespaces hosts a dev environment; Sandbox hosts an *agent*. The dev environment is incidental.
+- Sandbox does **not** ship its own model. Users bring their model subscription (Anthropic, OpenAI, Qwen, etc.) — the Sovereign holds the API key in its secret store.
+- Sandbox does **not** replace `catalyst-ui` wizard for provisioning. The conversational entry is an alternative path for new users. Power users keep the wizard.
+
+## Cost surface (for billing design)
+
+Sandbox usage rolls up into the existing JetStream usage stream (`catalyst.usage.recorded`), tagged with `org_id` in the payload (the existing convention — `core/services/shared/events/nats.go`). The cost dimensions:
+
+- **Compute** — vcluster pod CPU/memory hours per Sandbox session.
+- **Storage** — PVC GB-hours for repo workdirs and build caches.
+- **Agent tokens** — model API spend attributed to the session's owner.
+- **Preview hosting** — pod-hours for live preview deployments under the Org's marketplace subdomain.
+
+The super-admin dashboard shows per-Org rollup; the org admin dashboard shows per-developer rollup; the developer sees their own only.

--- a/products/sandbox/docs/provisioning-chat.md
+++ b/products/sandbox/docs/provisioning-chat.md
@@ -1,0 +1,215 @@
+# Sandbox — conversational provisioning
+
+## The pitch
+
+The current `catalyst-ui` wizard is a good tool for power users and integrators. It presents region, cluster size, blueprint catalogue, identity mode, DNS choice, and 15+ further fields on first contact. That works for people who already know what those words mean.
+
+It does **not** work for the customer we lose most often: a non-technical founder who wants a Sovereign for their business and would describe their need in two sentences if we let them.
+
+**Conversational provisioning** is the same Sandbox shell — text *and* voice — scoped to a narrower MCP toolbox, available at `console.openova.io/start` *before* the user has a Sovereign. The agent asks what they need, calls catalyst-api with the right body, watches the provisioning SSE stream, and hands them off into their new Sovereign's Sandbox when it is ready.
+
+This is the first OpenOva surface where AI-first replaces forms. It is also the demonstration moment: the prospect's first impression of OpenOva is "this platform is alive."
+
+## Wizard vs chat — when each wins
+
+|  | Wizard (`catalyst-ui`) | Conversational (Sandbox shell) |
+|---|---|---|
+| Power user who already knows region SKUs | Best | Slower |
+| Integrator using `POST /api/v1/deployments` directly | Best (API stays canonical) | Not relevant |
+| Repeat ops (provision 5 environments today) | Best | Slower |
+| Non-technical founder, first contact | Friction | Best |
+| Voice-only / accessibility need | Not available | Best |
+| Mobile-first prospect | Fields-on-glass is painful | Native |
+| Demonstrating AI capability on the homepage | Static | The whole point |
+
+Both paths terminate at the **same** catalyst-api endpoint. The chat is not a parallel system — it is a different *interaction* against the same backend. Anything the wizard can do, the chat can do, because the chat reads the same OpenAPI surface.
+
+## End-user journey — text-first
+
+The user lands on `console.openova.io/start`. They are not authenticated yet beyond an email gate (Magic link or OIDC social login).
+
+```
+┌─ OpenOva — Start your Sovereign ─────────────────────────────┐
+│                                                              │
+│  Hi. I am the OpenOva concierge. I can stand up a Sovereign  │
+│  cloud for you — privately hosted, with your own apps,       │
+│  domain, and team. Tell me what you are building, and I'll   │
+│  ask anything I need to know.                                │
+│                                                              │
+│  [ Mic v ]   [ Voice on / off ]                              │
+│  > _                                                          │
+│                                                              │
+└──────────────────────────────────────────────────────────────┘
+```
+
+The user types:
+
+```
+> I run a small OB-GYN clinic in Muscat. I need patient records,
+  scheduling, billing, and a way for patients to book online.
+  We are 6 staff, growing.
+```
+
+The agent reads the catalyst-api OpenAPI spec via MCP, reads the marketplace catalogue (`core/marketplace-api/handlers`), reads compliance hints from a small skill pack:
+
+```
+> v catalyst.openapi                     loaded
+> v marketplace.catalog.list             4 healthcare apps known
+> v skills.healthcare-compliance         loaded
+
+   I can help with that. A few quick things so I size your cloud
+   right:
+
+   1. Region — I suggest Frankfurt (Germany) for low latency to
+      Oman. We can also do Helsinki or Bahrain. Which?
+   2. Patient data residency — Germany keeps you under GDPR; some
+      Oman ministries require local. Any preference?
+   3. Domain — do you have one (e.g. clinicname.om), or shall I
+      give you a free subdomain like clinicname.openova.io to
+      start, and we move to your domain later?
+   4. Apps — I will install:
+        - OpenClaw (patient records, scheduling, billing — HIPAA-grade)
+        - Stalwart (secure email for the clinic)
+        - WordPress (your public booking page)
+      OK to proceed, or strike any?
+
+> _
+```
+
+User answers in one message (`Frankfurt fine, GDPR is fine, no domain yet, all three apps`). The agent calls catalyst-api:
+
+```
+> v POST /api/v1/deployments
+      provider          hetzner
+      region            fsn1
+      tier              sme
+      domain            clinicname.openova.io        (subdomain)
+      apps              [openclaw, stalwart, wordpress]
+      orgSlug           clinicname
+      ownerEmail        <signed-in email>
+                                                     queued (id: dep-2841)
+```
+
+The agent then subscribes to the existing provisioning SSE feed (`/api/v1/deployments/{id}/events` — `products/catalyst/bootstrap/api/internal/handler/deployments.go:1186`) and renders progress as cards in the chat:
+
+```
+> v Provisioning           dep-2841            queued -> running
+> v Hetzner project        created             nbg1-rtz                  OK
+> v Network                 10.0.0.0/16        created                    OK
+> v Control plane           3 x cpx42          booting...                 (180s)
+> v k3s installed           apiserver healthy                              OK
+> v cilium                  default-deny CCNP applied                      OK
+> v cert-manager            Let's Encrypt staging issuer ready             OK
+> v Catalyst-Zero handover  HR Ready                                       OK
+> v Keycloak realm          sovereign  created                             OK
+> v Gitea                   running                                        OK
+> v Harbor                  running, proxy-pull configured                 OK
+> v SeaweedFS               running, 4 volumes                             OK
+> v JetStream               5 streams created                              OK
+> v OpenClaw                installed                                      OK
+> v Stalwart                installed                                      OK
+> v WordPress               installed                                      OK
+> v DNS                     clinicname.openova.io   propagated             OK
+> v TLS                     LE PROD cert issued for all subdomains         OK
+
+   Your Sovereign is ready.
+
+   Console:   https://console.clinicname.openova.io
+   OpenClaw:  https://openclaw.clinicname.openova.io
+   Stalwart:  https://mail.clinicname.openova.io
+   Website:   https://clinicname.openova.io
+
+   I have created your first user (you) with the password I just
+   emailed. Want me to walk you through OpenClaw for ten minutes
+   to get the first patient record in, or are you good on your own?
+```
+
+End-to-end the user typed ~3 messages and never saw a form field.
+
+## End-user journey — voice
+
+The exact same flow with voice ingestion (browser Web Speech API, supports Arabic, Turkish, English, French, German, Spanish, and 60+ others — already an open Web Platform feature). Each user utterance is transcribed in-tab, sent to the chat as a normal user message, the agent responds with text **and** TTS playback. The user can keep talking or switch to typing at any moment; the modes are not separate sessions.
+
+TTS provider options (any work):
+
+- **Native Web Speech `speechSynthesis`** — zero cost, no API, voice quality varies by OS.
+- **OpenAI TTS** — best voices, pay per character.
+- **Local model** in the Sovereign once it is up — for the post-provision Sandbox sessions; provisioning runs on mothership so it cannot use the Sovereign's model.
+
+For the launch surface, default to Web Speech for ingestion + OpenAI TTS for response, with a toggle to Web Speech-only for users who want zero external calls.
+
+## Architecture
+
+```
+                user (browser, voice or text)
+                          │
+                          ▼
+            ┌──────────────────────────────────┐
+            │  console.openova.io/start        │
+            │  (Sandbox shell in chat mode,    │
+            │   card-protocol view only —      │
+            │   no terminal, no agent install) │
+            └────────────────┬─────────────────┘
+                             │ WebSocket
+                             ▼
+            ┌──────────────────────────────────┐
+            │  mothership Sandbox concierge     │
+            │  (single pod, shared across all   │
+            │   prospects; per-user session)    │
+            │  agent: claude-code or qwen-code  │
+            └────────────────┬─────────────────┘
+                             │ MCP
+                             ▼
+            ┌──────────────────────────────────┐
+            │  concierge-mcp  (narrow surface)  │
+            │                                   │
+            │  catalyst.openapi                 │
+            │  catalyst.deployments.create      │
+            │  catalyst.deployments.events      │
+            │  catalyst.deployments.get         │
+            │  marketplace.catalog.list         │
+            │  marketplace.region.list          │
+            │  marketplace.sku.list             │
+            │  skills.healthcare-compliance     │
+            │  skills.education-compliance      │
+            │  skills.finance-compliance        │
+            │  ...                              │
+            │                                   │
+            │  (NO sandbox.*, NO k8s.*,         │
+            │   NO sovereign.* — the prospect    │
+            │   has no Sovereign yet)            │
+            └────────────────┬─────────────────┘
+                             │
+                             ▼
+                    existing catalyst-api
+                    /api/v1/deployments
+                    /api/v1/deployments/{id}/events  (SSE)
+```
+
+The concierge is a shared mothership service (one pod, many simultaneous user sessions). Once provisioning completes, the chat hands the user off to **their own Sovereign's** Sandbox, where the full MCP surface is available, the agent runs in their own vcluster, and identity has fully transferred to their Keycloak realm. The mothership concierge session ends.
+
+## Why this is not a separate product
+
+Architecturally, conversational provisioning is just Sandbox with:
+
+- A narrower MCP toolbox (provisioning instead of operations).
+- A shared mothership pod instead of per-user vcluster pods.
+- Card-protocol-only surface (no terminal — the prospect has no agent installed and no repo).
+- A pre-login state (email magic link instead of Org-scoped OIDC).
+
+Same code path for: WebSocket, card translator, MCP client wiring, session persistence, SSE subscription, voice ingestion. One product, two scopes.
+
+## Implementation requirements (when we revisit)
+
+- **Mothership pod** — `sandbox-concierge`, single Deployment in the OpenOva mothership cluster. Long-lived to amortise model warm-up.
+- **`concierge-mcp`** — a MCP server bundling the narrow toolbox above; deployed as a sidecar to the concierge pod.
+- **Card-only Sandbox front-end** — reuses the mobile mode of the main Sandbox PWA, rendered at `console.openova.io/start`.
+- **Voice in/out toggle** — browser Web Speech for ingestion, OpenAI TTS for response (configurable).
+- **Skill packs for verticals** — `healthcare-compliance`, `education-compliance`, `finance-compliance`, `retail-ecommerce` so the concierge knows region/data-residency hints per industry. Each is a versioned markdown file in the same skill-library OCI artifact.
+- **Hand-off ritual** — when the deployment reaches `phase: ready`, the concierge issues the handover JWT (already in `catalyst/bootstrap/api/internal/handoverjwt/signer.go`) and redirects the browser to `https://console.<new-sov>/sandbox` with the user signed in to their new Sovereign.
+
+No new backend endpoints required on catalyst-api beyond what `catalyst-ui` already calls.
+
+## Where the wizard still wins
+
+We keep `catalyst-ui`. The user who knows what they want will always be faster filling a form than narrating to an agent. Two paths, same destination, the user picks. The chat is the path that grows the top of the funnel — the wizard is the path that converts the user who already arrived.

--- a/products/sandbox/docs/user-journey.md
+++ b/products/sandbox/docs/user-journey.md
@@ -1,0 +1,229 @@
+# Sandbox — user journey
+
+This document is the canonical wireframe storyboard for the two primary roles: the **developer** (Nova user inside an Org) and the **Sovereign admin** (operator). The flows are end-to-end, no wizards-in-prose.
+
+## Native Claude Code is preserved
+
+The developer's muscle memory survives. Inside the Sandbox terminal they keep:
+
+- `/plan`, `/think hard`, `/compact`, `/clear`, `/status`, `/model`
+- `Read`, `Edit`, `Write`, `Bash`, `TaskCreate`, `Grep`, `Glob` tool cards
+- `--continue` resumption (now across devices, not just sessions)
+- `CLAUDE.md` precedence (global, project, local) — Sandbox auto-merges a layer on top with the cluster context
+- Plan mode card with Approve / Edit / Cancel
+
+The same applies to Cursor, Qwen Code, Aider, Opencode — their native UX renders in the same xterm. Sandbox does not wrap or skin any agent.
+
+---
+
+## Developer journey — building EventForge in a Sandbox
+
+The developer is an experienced Claude Code user. They are signed into their Org inside Sovereign `rzk7` and have just been invited to a Sandbox.
+
+### Scene 1 — Enter the Sandbox
+
+```
+┌─ Sovereign Console — console.rzk7.openova.io ─────────────┐
+│  Overview   Canvas   Sandbox   Workloads   Settings        │
+└────────────────────────────────────────────────────────────┘
+```
+
+Click **Sandbox**, then **New session**.
+
+```
+┌─ New session ────────────────────────────────────────────┐
+│   Agent     ( claude-code   v )                            │
+│   Repo      ( + Create new repo... v )                     │
+│              Name:    [ eventforge                       ] │
+│              Owner:   ( emrah-baysal v )                   │
+│              Visibility: ( private v )                     │
+│   Branch    main (will be created)                          │
+│   Sandbox   workshop-emrah · 50 GB · hel1                  │
+│                                                              │
+│   [ Start session -> ]                                       │
+└──────────────────────────────────────────────────────────────┘
+```
+
+One click. Sandbox creates the Gitea repo in the Org's Gitea Org (already auto-provisioned by `organization-controller`), mounts a fresh PVC at `/repo/eventforge`, mints an MCP token scoped to the Sandbox, and drops the user into the Claude Code session.
+
+### Scene 2 — The session opens, and it looks like home
+
+```
+╭─────────────────────────────────────────────────────────────╮
+│  Welcome to Claude Code on OpenOva Sandbox                   │
+│                                                              │
+│  cwd       /repo/eventforge                                  │
+│  model     claude-opus-4-7 [1m]                              │
+│  CLAUDE.md global + sandbox (no project CLAUDE.md yet)       │
+│  skills    23 loaded  (openova-sandbox skill pack)           │
+│  mcp       openova-sandbox-mcp  *connected*                  │
+│                                                              │
+│  /help  /status  /clear  /compact  /model                    │
+╰─────────────────────────────────────────────────────────────╯
+> _
+```
+
+Exact same shell as the developer's laptop. Only `skills` and `mcp` lines are new — those announce the cluster-aware moat.
+
+### Scene 3 — Describe the product, request a plan
+
+```
+> I want to build an event management webapp. Organizers create events,
+  sell tickets via Stripe Connect. Two surfaces:
+   - Organizer dashboard (auth, create event, set tiers, see sales)
+   - Public event pages (no auth, buy ticket, get email confirmation)
+  Next.js 15 App Router, Postgres, Tailwind, Resend for email.  /plan
+```
+
+Plan mode dispatches Explore-style sub-tasks against the Sandbox skill library and the RAG corpus:
+
+```
+[PLAN MODE — read only]
+  v Read .claude/skills/openova-sandbox/sandbox-primitives.md
+  v Read .claude/skills/openova-sandbox/stripe-connect.md
+  v Read .claude/skills/openova-sandbox/postgres-via-cnpg.md
+  v Read .claude/skills/openova-sandbox/auth-via-keycloak.md
+  v rag.search  "Next.js 15 + Keycloak OIDC patterns"  8 hits
+```
+
+ExitPlanMode returns the familiar plan card:
+
+```
+┌─ Plan ──────────────────────────────────────────────────────┐
+│  1. Scaffold Next.js 15 App Router + Tailwind in /repo      │
+│  2. Provision Postgres via sandbox.db.provision             │
+│  3. Drizzle schema: orgs, events, tiers, orders, tickets    │
+│  4. Auth: Keycloak realm  eventforge-orgs                   │
+│  5. Organizer dashboard:  /dashboard/events                  │
+│  6. Public pages:         /e/[slug]                          │
+│  7. Stripe Connect onboarding (sandbox.stripe.bindAccount)  │
+│  8. Email: Resend (sandbox.secrets.resend)                   │
+│  9. PR -> preview at eventforge.sb-rzk7.openova.io           │
+│                                                              │
+│  [ Approve & build ]   [ Edit plan ]   [ Cancel ]            │
+└──────────────────────────────────────────────────────────────┘
+```
+
+### Scene 4 — Sandbox primitives appear as cards
+
+```
+> v sandbox.db.provision  { name: eventforge, version: 16 }
+      Provisioned CNPG cluster  eventforge-db
+      Endpoint  eventforge-db-rw.workshop-emrah.svc
+      Credential bound to secret  eventforge-db-app
+      URI written to /repo/eventforge/.env.local              (600)
+      Backups: daily to SeaweedFS                              OK
+
+> v sandbox.auth.provisionRealm   { app: eventforge }
+      realm     eventforge-orgs
+      client    eventforge-web   (confidential, PKCE)
+      issuer    https://auth.rzk7.openova.io/realms/...
+      redirect  https://eventforge.sb-rzk7.openova.io/...
+                http://localhost:3000/...
+      secret    bound to  eventforge-auth                      OK
+
+> v sandbox.stripe.bindAccount    { mode: test }
+      Connected to acct_1MxxxxxxxxxK
+      Webhook endpoint  /api/stripe/webhook
+      Webhook secret bound to  eventforge-stripe               OK
+```
+
+No secret ever prints to the terminal. Each binding lands in `.env.local` (mode 600, never staged).
+
+### Scene 5 — Preview URL appears as a card
+
+After the first push, JetStream pushes a `sandbox.preview.ready` event into the session. The card renders:
+
+```
+  v sandbox.preview.ready
+      eventforge.sb-rzk7.openova.io        open ->
+      build sha     a8f3c12
+      cold start    1.4 s
+      health        /api/health  200
+```
+
+The URL works on phone, tablet, laptop — anywhere the user has a browser pointed at their Sovereign domain.
+
+### Scene 6 — Mobile handoff
+
+The developer leaves the office, opens the Sandbox PWA on their phone, taps the same session. The session is in card-protocol mode on mobile (xterm on a 5" screen is unreadable; the card-stream view is a second client into the same persistent process). They type:
+
+```
+> the buy page is missing tier selection. tiers should render as cards
+  with name/price/remaining. selecting one carries through to Stripe
+  Checkout as the line item.
+```
+
+Agent reads, edits, typechecks, commits, opens a PR, preview rebuilds. They tap the URL, complete a test purchase. Switch the laptop back on later — terminal view, same session, scrollback intact.
+
+### Scene 7 — Ship to production
+
+```
+> resume
+> the product feels right. let's go to production.
+   - domain: eventforge.io  (bring-your-own via marketplace BYOD)
+   - prod database is a separate CNPG cluster, NOT the sandbox one
+   - prod Stripe is live mode, switch the secret binding
+   - turn on Sentry for error tracking
+  /think hard then /plan
+```
+
+The agent calls `marketplace.domain.byod` (which is `POST /domain/byod` — `core/services/domain/handlers/handlers.go:206`) to register `eventforge.io`, returns the CNAME target as a card, validates after DNS propagates, binds the cert, ships the production HelmRelease, watches the Flux roll. Final card:
+
+```
+  v Live
+      eventforge.io                served by  sha a8f3c12
+      staging.eventforge.io        served by  sha a8f3c12
+      sandbox preview              eventforge.sb-rzk7.openova.io
+```
+
+The user closes the laptop. The agent stays alive in the Sandbox.
+
+---
+
+## Sovereign admin journey
+
+The admin sees an extra tab in the Sandbox surface — the **Admin** view — gated by their `org` and `role` claims in the token. Their own personal Sandbox sessions live in the **Sessions** tab exactly the same as a developer.
+
+```
+┌─ Sandbox · Admin · console.rzk7.openova.io ─────────────────┐
+│                                                              │
+│  [ Sandboxes ]  [ Quotas ]  [ Agents ]  [ Skills ]           │
+│  [ Secrets ]    [ Domains ] [ Audit ]   [ Costs ]            │
+│                                                              │
+│  Sandboxes (4 active across 2 Orgs)                          │
+│  ┌──────────────────────────────────────────────────────┐  │
+│  │ Org    User         Sessions  Storage  Spend(30d)    │  │
+│  │ acme   emrah         3        8.2 GB   $42           │  │
+│  │ acme   ali           1        2.1 GB   $11           │  │
+│  │ blue   pelin         2        4.7 GB   $19           │  │
+│  │ blue   contractor-1  0        0.4 GB   $0   paused   │  │
+│  └──────────────────────────────────────────────────────┘  │
+│                                                              │
+│  Agent catalogue (Sovereign-wide)                            │
+│  [x] claude-code  [x] cursor-agent  [x] qwen-code            │
+│  [ ] aider        [ ] opencode                               │
+│                                                              │
+└──────────────────────────────────────────────────────────────┘
+```
+
+Per-Org admins see the same UI, scoped to one Org. The RBAC is the same model already in `Organization.spec.owners[].role` and propagated via `UserAccess` CRs by `organization-controller`. No new RBAC model is required — Sandbox is one more consumer of the existing identity fan-out.
+
+---
+
+## Multi-device coherence
+
+| Action | Surface |
+|---|---|
+| Same session open in two tabs | Both tabs receive the same PTY byte stream; either tab can type; that is by design. |
+| Close laptop, open phone | New WebSocket to the same `session_id`; the pty-server replays its ring buffer (~256 KB) on connect, then streams live. |
+| Pod restart (rare) | PTY dies. Agent restarts via `<agent> --continue` (each agent has an equivalent flag). Conversation history in `~/.claude/projects/...` or equivalent is preserved; in-flight tool call may be lost. |
+| Same session on watch-style device | Card protocol view only — no terminal. Read-only by default, opt-in to a single-line input. |
+
+The pty-server (described in [`architecture.md`](architecture.md)) is the only piece that makes this work. **No tmux.**
+
+---
+
+## Conversational provisioning (pre-Sandbox)
+
+A prospective customer who does not have a Sovereign yet lands on `console.openova.io/start` and meets the same Sandbox-style shell — text-only or text+voice — scoped to a much smaller MCP toolbox (catalyst-api provisioning surface). See [`provisioning-chat.md`](provisioning-chat.md) for the full journey.


### PR DESCRIPTION
kubectl rollout status uses LIST+WATCH; the Role only had get+patch → Job stalled on cilium-operator rollout, never restarted cilium-envoy.

🤖 Generated with Claude Code