### PR TITLE
docs(sovereign): pin multi-region DoD contract — never divert from D1-D14

### DIFF
--- a/docs/SOVEREIGN-MULTI-REGION-DOD.md
+++ b/docs/SOVEREIGN-MULTI-REGION-DOD.md
@@ -1,0 +1,64 @@
+# Sovereign Multi-Region Definition of Done
+
+**This file is the convergence contract.** Every wipe → create → test cycle must validate every gate below before claiming a Sovereign is converged. Founder ruling 2026-05-15: silent compromise from these gates is a quality violation.
+
+Mirrored to auto-memory at `~/.claude/projects/-home-openova-repos-openova-private/memory/sovereign_multiregion_dod.md`.
+
+---
+
+## Architecture invariants (never compromise)
+
+| ID | Rule |
+|---|---|
+| A1 | **3 regions minimum.** If a provider has capacity/zone constraints, swap regions — never silently drop to 2. |
+| A2 | **Inter-region link = DMZ WireGuard over PUBLIC IPs.** No `hcloud_network` cross-region, no VPC peering, no Huawei VPC — provider-agnostic, always over the DMZ WG endpoint. |
+| A3 | **Cilium ClusterMesh apiserver Service = LoadBalancer** (public IP through DMZ WG). The word `NodePort` must never appear in clustermesh-apiserver Service spec on any Sovereign. |
+| A4 | **vCluster topology:** primary region = MGMT+DMZ; each secondary region = DMZ+RTZ. Cross-vCluster intra-region traffic stays inside host k3s via Cilium. |
+| A5 | **Zero public exposure of K8s control-plane endpoints.** `kubectl get svc -A` on a converged Sovereign returns no NodePort for clustermesh-apiserver, kube-apiserver, or etcd. |
+| A6 | **Provider-mix is the canonical case.** Assume 1 region Hetzner, 1 AWS, 1 Huawei. Code must work for that even when the active test prov is all-Hetzner. |
+
+---
+
+## DoD gates (D1–D14)
+
+Every gate must pass on a SINGLE fresh provision in one continuous run. No partial credit.
+
+| # | Gate | Verifier |
+|---|---|---|
+| D1 | `dig console.<fqdn> @1.1.1.1` returns primary LB IP (auto-written by catalyst-api after Phase-0) | dig |
+| D2 | `curl https://console.<fqdn>/` → 200, cert publicly trusted (verify=0) | curl |
+| D3 | PIN-login: enter email → receive PIN via IMAP → enter PIN → dashboard | Playwright MCP |
+| D4 | Keycloak SSO: PIN-login bounces through Keycloak once, lands on `/dashboard` with session cookie | Playwright MCP |
+| D5 | `/cloud` view: renders **all 3 regions**, no stuck spinners | Playwright MCP |
+| D6 | `/jobs` view: **0 pending, 0 running** — every job in terminal state | Playwright MCP |
+| D7 | Mothership flow Jobs ≡ child Sovereign Jobs (same IDs, same statuses) | Playwright MCP diff |
+| D8 | `kubectl --context <child> get hr -A` shows **all 135 HRs Ready=True** across all clusters | kubectl |
+| D9 | clustermesh-apiserver Pod Ready in every region, no restarts, no x509 errors | kubectl |
+| D10 | `cilium clustermesh status` shows OK for every peer cluster | cilium CLI |
+| D11 | Inter-region pod-to-pod packet test passes, hubble-flow shows WireGuard traversal | kubectl + hubble |
+| D12 | `kubectl get svc -A \| grep clustermesh` shows only `LoadBalancer` (no NodePort) | kubectl |
+| D13 | Canvas flow page: sibling-deps edges render, no orphan bubbles, no phantom pillars | Playwright MCP |
+| D14 | Operator re-login after browser refresh works without re-PIN within session TTL | Playwright MCP |
+
+---
+
+## Trigger phrases that mean STOP — about to compromise
+
+- "for now let's just do 2 regions"
+- "the matrix expects X — let me synth X into the response"
+- "Hetzner private net spans zones, let me use that for cross-region"
+- "ClusterMesh on NodePort is fine for testing"
+- "ash/sin is different zone, let me just stay in eu-central"
+- "private NIC link between regions is faster"
+
+If any of these appear in your reasoning → STOP, re-read this file, fix the root cause.
+
+---
+
+## Cycle protocol
+
+Before any `tofu apply` or `POST /api/v1/deployments`:
+
+1. Read this file (or the memory mirror).
+2. Log the D1–D14 list to the loop output.
+3. Refuse to mark convergence until each D1–D14 has been individually checked.


### PR DESCRIPTION
## Summary

Pins the multi-region Sovereign Definition of Done (DoD) into the repo as `docs/SOVEREIGN-MULTI-REGION-DOD.md`. The same content is mirrored to Claude auto-memory at `~/.claude/projects/-home-openova-repos-openova-private/memory/sovereign_multiregion_dod.md` so it loads at every session start.

Founder ruling 2026-05-15: every silent compromise from this contract is a quality violation. This file locks the convergence shape so the next 100 Claude sessions can't drift.

## Architecture invariants (A1–A6)

| ID | Rule |
|---|---|
| A1 | 3 regions minimum, never silently reduce to 2 |
| A2 | Inter-region link = DMZ WireGuard over PUBLIC IPs, ALWAYS |
| A3 | Cilium ClusterMesh apiserver = LoadBalancer (NEVER NodePort) |
| A4 | vCluster topology: primary = MGMT+DMZ, secondary = DMZ+RTZ |
| A5 | Zero public exposure of K8s control-plane endpoints |
| A6 | Provider-mix canonical: assume 1 Hetzner + 1 AWS + 1 Huawei |

## DoD gates (D1–D14)

Every gate must pass on a SINGLE fresh provision in one continuous run.

- D1 DNS auto-write → LB IP
- D2 cert publicly trusted
- D3 PIN-login → dashboard
- D4 Keycloak SSO transition
- D5 Cloud view shows all 3 regions
- D6 0 pending / 0 running jobs
- D7 Mothership Jobs ≡ child Jobs
- D8 All 135 HRs Ready=True across all clusters
- D9 clustermesh-apiserver healthy in every region
- D10 `cilium clustermesh status` OK for every peer
- D11 Inter-region pod-to-pod packet test passes via Cilium WG
- D12 Zero NodePort exposure of clustermesh-apiserver
- D13 Canvas sibling-deps edges render, no orphans
- D14 Re-login works without re-PIN

## Test plan

- [x] Doc committed; mirrored to auto-memory
- [x] CI doc-build passes (no broken anchors)
- [ ] Sibling PRs landing: per-region `hcloud_network` refactor + auto-establish ClusterMesh
- [ ] First validation prov (t112) against the gates

## Why this is its own PR

The architecture-implementation PRs (per-region tofu, auto-mesh-connect) take longer; this one ships the contract independently so it's reviewable, mergeable, and on disk before the implementation iterations begin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)