### PR TITLE
fix(clustermesh): default clustermesh-apiserver to LoadBalancer (DoD A3)

### DIFF
--- a/clusters/_template/bootstrap-kit/01-cilium.yaml
+++ b/clusters/_template/bootstrap-kit/01-cilium.yaml
@@ -179,13 +179,32 @@ spec:
         useAPIServer: true
         apiserver:
           service:
-            # qa-loop iter-12 Fix #53D: ${CLUSTERMESH_SERVICE_TYPE:=NodePort}
-            # Default NodePort keeps backward-compat (existing Sovereigns
-            # don't break). Sovereigns that need cross-region peering set
-            # CLUSTERMESH_SERVICE_TYPE=LoadBalancer in their bootstrap-kit
-            # Kustomization substitute (requires Hetzner CCM bootstrap).
-            type: ${CLUSTERMESH_SERVICE_TYPE:=NodePort}
-            nodePort: 32379
+            # 2026-05-15: default flipped NodePort → LoadBalancer per DoD A3
+            # (docs/SOVEREIGN-MULTI-REGION-DOD.md). Founder ruling:
+            # "ClusterMesh apiserver Service = LoadBalancer (NEVER NodePort)".
+            #
+            # On Hetzner, hcloud-ccm allocates a public-IPv4 LB per peer
+            # region; AutoEstablishClusterMesh (handler/clustermesh.go,
+            # PR #1508) hard-fails on type != LoadBalancer and reads the
+            # LB ingress IP for the peer endpoint. Cilium WG node
+            # encryption secures the LB→node→pod path end-to-end.
+            #
+            # ${CLUSTERMESH_SERVICE_TYPE:=LoadBalancer} keeps the
+            # operator escape hatch (e.g. bare-metal Sovereigns with
+            # MetalLB or non-cloud peers can override to NodePort) but
+            # the cloud-Hetzner default is now A3-compliant out of the
+            # box.
+            type: ${CLUSTERMESH_SERVICE_TYPE:=LoadBalancer}
+            # Hetzner CCM requires location OR network-zone annotation
+            # to allocate the LB. ${HCLOUD_LB_LOCATION} flows from the
+            # bootstrap-kit Kustomization substitute (provisioner.go
+            # emits the primary region by default; per-region overlays
+            # can override).
+            annotations:
+              load-balancer.hetzner.cloud/location: "${HCLOUD_LB_LOCATION:=hel1}"
+              load-balancer.hetzner.cloud/type: "lb11"
+              load-balancer.hetzner.cloud/use-private-ip: "false"
+              load-balancer.hetzner.cloud/name: "${SOVEREIGN_FQDN_SLUG:=catalyst}-clustermesh"
 
     # ── Catalyst overlay templates (chart/templates/) ────────────────────
     # qa-loop iter-16 Fix #70: Hubble UI HTTPRoute now defaults ON for

--- a/infra/hetzner/cloudinit-control-plane.tftpl
+++ b/infra/hetzner/cloudinit-control-plane.tftpl
@@ -978,6 +978,17 @@ write_files:
             # template at provision time.
             CLUSTER_MESH_NAME: "${cluster_mesh_name}"
             CLUSTER_MESH_ID: "${cluster_mesh_id}"
+            # 2026-05-15 DoD A3 wiring: bp-cilium chart defaults
+            # clustermesh-apiserver Service to LoadBalancer for cloud
+            # Sovereigns. Per-Sovereign overrides flow through these
+            # substitutes (see clusters/_template/bootstrap-kit/01-cilium.yaml
+            # apiserver.service block). HCLOUD_LB_LOCATION carries this
+            # region's Hetzner location so hcloud-ccm allocates the LB
+            # in the right datacenter; SOVEREIGN_FQDN_SLUG names the LB
+            # so operator can find it in the Hetzner Console.
+            CLUSTERMESH_SERVICE_TYPE: "LoadBalancer"
+            HCLOUD_LB_LOCATION: "${region}"
+            SOVEREIGN_FQDN_SLUG: "${sovereign_fqdn_slug}"
             # QA fixtures auto-enable (Fix #73 — qa-loop bounded-cycle
             # iter-16). Default "false" so a customer-facing zero-touch
             # provision lands a Sovereign with NO qaFixtures stack

--- a/infra/hetzner/main.tf
+++ b/infra/hetzner/main.tf
@@ -467,6 +467,10 @@ locals {
     cluster_cidr        = local.region_cluster_cidr["primary"]
     service_cidr        = local.region_service_cidr["primary"]
     sovereign_fqdn      = var.sovereign_fqdn
+    # Slug form of the FQDN (dots → dashes) used to name per-Sovereign
+    # Hetzner LBs (e.g. clustermesh-apiserver LB). Hetzner LB names are
+    # limited to 63 chars and exclude dots; the slug is safe.
+    sovereign_fqdn_slug = replace(var.sovereign_fqdn, ".", "-")
     sovereign_subdomain = var.sovereign_subdomain
     # OpenovaFlow integration (Agent #3, PR #1389/#1390 follow-up). The
     # bp-openova-flow-emitter (bootstrap-kit slot 57) reads SOVEREIGN_


### PR DESCRIPTION
## Summary

DoD A3 mandates `clustermesh-apiserver` Service MUST be `LoadBalancer`. The chart was defaulting to `NodePort`, breaking `AutoEstablishClusterMesh` (PR #1508) which hard-fails on the type check.

Caught on t112 (`f2e7f02e6ffb6a18`):
- 135/135 HRs Ready in all 3 regions ✅
- D12 ❌ clustermesh-apiserver = NodePort (A3 violation)
- D10 ❌ 0 peer entries in `cilium-clustermesh` secret (orchestrator hard-failed)

## Changes
- `clusters/_template/bootstrap-kit/01-cilium.yaml`: default `${CLUSTERMESH_SERVICE_TYPE:=LoadBalancer}` + Hetzner CCM annotations (`load-balancer.hetzner.cloud/{location,type,name,use-private-ip}`)
- `infra/hetzner/cloudinit-control-plane.tftpl`: emit `CLUSTERMESH_SERVICE_TYPE` + `HCLOUD_LB_LOCATION` + `SOVEREIGN_FQDN_SLUG` substitutes
- `infra/hetzner/main.tf`: pass `sovereign_fqdn_slug` to the template

## Test plan
- [ ] Merge → catalyst-build rolls → next Sovereign prov's bp-cilium HR renders clustermesh-apiserver Service as LoadBalancer + Hetzner CCM allocates LB
- [ ] AutoEstablishClusterMesh fires → cilium-clustermesh secret gets peer entries
- [ ] D10 + D12 both pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)