### PR TITLE
fix(blueprints): vcluster charts smoke-render annotation = "default-off"

### DIFF
--- a/platform/bp-dmz-vcluster/chart/Chart.yaml
+++ b/platform/bp-dmz-vcluster/chart/Chart.yaml
@@ -41,7 +41,14 @@ description: |
   bp-hcloud-ccm.
 type: application
 annotations:
-  catalyst.openova.io/smoke-render-mode: "every-region"
+  # CI Blueprint Release smoke-render gate accepts the literal token
+  # "default-off" to bypass the "render < 5 lines" failure for charts
+  # whose top-level condition (dmzVcluster.enabled) is false at default
+  # values. The bootstrap-kit slot 54 flips it on for every region via
+  # postBuild.substitute (DMZ_VCLUSTER_ENABLED=true). The full-ON path
+  # is exercised by chart/tests/render.sh which CI doesn't run as a
+  # Release gate.
+  catalyst.openova.io/smoke-render-mode: "default-off"
 keywords: [catalyst, blueprint, vcluster, dmz, isolation, multi-region, dod-a4, wireguard]
 maintainers:
   - name: OpenOva Catalyst

--- a/platform/bp-mgmt-vcluster/chart/Chart.yaml
+++ b/platform/bp-mgmt-vcluster/chart/Chart.yaml
@@ -37,7 +37,13 @@ description: |
   bp-hcloud-ccm.
 type: application
 annotations:
-  catalyst.openova.io/smoke-render-mode: "primary-only"
+  # CI Blueprint Release smoke-render gate accepts the literal token
+  # "default-off" to bypass the "render < 5 lines" failure for charts
+  # whose top-level condition (mgmtVcluster.enabled) is false at default
+  # values. The bootstrap-kit slot flips it on for the primary region
+  # via postBuild.substitute. The full-ON path is exercised by
+  # chart/tests/render.sh which CI doesn't run as a Release gate.
+  catalyst.openova.io/smoke-render-mode: "default-off"
 keywords: [catalyst, blueprint, vcluster, mgmt, isolation, multi-region, dod-a4]
 maintainers:
   - name: OpenOva Catalyst

--- a/platform/bp-rtz-vcluster/chart/Chart.yaml
+++ b/platform/bp-rtz-vcluster/chart/Chart.yaml
@@ -36,7 +36,13 @@ description: |
   bp-mgmt-vcluster + bp-dmz-vcluster.
 type: application
 annotations:
-  catalyst.openova.io/smoke-render-mode: "secondary-only"
+  # CI Blueprint Release smoke-render gate accepts the literal token
+  # "default-off" to bypass the "render < 5 lines" failure for charts
+  # whose top-level condition (rtzVcluster.enabled) is false at default
+  # values. The bootstrap-kit slot flips it on for every secondary region
+  # via postBuild.substitute. The full-ON path is exercised by
+  # chart/tests/render.sh which CI doesn't run as a Release gate.
+  catalyst.openova.io/smoke-render-mode: "default-off"
 keywords: [catalyst, blueprint, vcluster, rtz, isolation, multi-region, dod-a4]
 maintainers:
   - name: OpenOva Catalyst


### PR DESCRIPTION
## Summary

Blueprint Release CI smoke-render gate accepts only the literal token `"default-off"`. PR #1526 used descriptive tokens (`primary-only` / `every-region` / `secondary-only`) so the gate failed for bp-mgmt-vcluster (renders 1 line at default values). All 3 vCluster charts default-OFF; bootstrap-kit slots flip them on via postBuild.substitute. Aligning all 3 to `"default-off"`.

## Test plan

- [x] Push branch → Blueprint Release CI green
- [ ] Merge → main rolls all 3 charts as OCI artifacts
- [ ] Next prov has bp-dmz-vcluster HR Ready in every region (DoD A4 partial)

🤖 Generated with [Claude Code](https://claude.com/claude-code)