### PR TITLE
fix(clustermesh): derive cluster name + ID at orchestrator if request unset

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/clustermesh.go
+++ b/products/catalyst/bootstrap/api/internal/handler/clustermesh.go
@@ -348,6 +348,20 @@ func (h *Handler) AutoEstablishClusterMesh(ctx context.Context, dep *Deployment)
 				st.Peers = append(st.Peers, peer)
 				continue
 			}
+			if strings.TrimSpace(b.clusterName) == "" {
+				// Empty cluster name would become an empty Secret data
+				// key and Kubernetes rejects empty keys ("Invalid value:
+				// '': a valid config key must consist of alphanumeric
+				// characters, '-', '_' or '.'"). Skip this peer pair
+				// loudly rather than silently producing a Secret-Create
+				// error that kills the whole region's write. Caught on
+				// t125 (2026-05-16) — fixed in same PR by deriving
+				// clusterName from SovereignFQDN when the operator body
+				// omits ClusterMeshName.
+				peer.Error = "peer cluster name empty (operator ClusterMeshName unset AND auto-derive failed — check FQDN)"
+				st.Peers = append(st.Peers, peer)
+				continue
+			}
 			// Mint A-as-client cert signed by A's CA (so B can verify
 			// using the same trust root the rest of A's cluster uses).
 			clientCert, clientKey, err := h.mintPeerClientCert(a.caCert, a.caKey, a.clusterName)
@@ -497,15 +511,22 @@ func (h *Handler) buildRegionSlots(
 
 	// Cilium cluster IDs are deterministic: primary gets the derived id,
 	// each secondary gets primary+1, primary+2, … (matching infra
-	// /hetzner/main.tf's allocation).
-	primaryID := dep.Request.ClusterMeshID
-	if primaryID == 0 {
-		// Fallback: derive via the same hash main.tf uses. Per
-		// docs/INVIOLABLE-PRINCIPLES.md #3 we don't reach into the
-		// provisioner package's private helper here; we accept that
-		// if Request.ClusterMeshID is unset, the slot.ClusterID is
-		// 0 and the status row reports it that way.
-		primaryID = 0
+	// /hetzner/main.tf's allocation). When dep.Request.ClusterMeshID is
+	// unset (operator submitted the canonical multi-region body without
+	// pinning IDs), derive via the same hash main.tf uses so the
+	// orchestrator + tofu + cilium-config agree byte-identically.
+	// Caught on t125 (2026-05-16): primaryID stayed 0 → every peer's
+	// clusterName fell back to dep.Request.ClusterMeshName which was
+	// also empty → empty-string key in cilium-clustermesh Secret →
+	// "Invalid value" Create rejection.
+	primaryID := provisioner.DeriveClusterMeshID(dep.Request)
+
+	// Derive primary mesh name once for consistent secondary suffixing.
+	// Same trio of fallbacks as the per-region loop below, but lifted
+	// out so secondaries don't re-derive on every iteration.
+	primaryMeshName := strings.TrimSpace(dep.Request.ClusterMeshName)
+	if primaryMeshName == "" {
+		primaryMeshName = provisioner.DeriveClusterMeshName(dep.Request)
 	}
 
 	for idx, rs := range regions {
@@ -520,10 +541,14 @@ func (h *Handler) buildRegionSlots(
 
 		clusterName := strings.TrimSpace(rs.ClusterMeshName)
 		if clusterName == "" {
-			clusterName = strings.TrimSpace(dep.Request.ClusterMeshName)
+			clusterName = primaryMeshName
 			if !isPrimary && clusterName != "" {
 				// Auto-derive secondary peer name per the convention
-				// in deriveClusterMeshName: "<sovereign-stem>-<region>".
+				// in DeriveClusterMeshName: "<sovereign-stem>-<region>".
+				// tofu's main.tf computes secondary_region_cluster_mesh_name
+				// as the same pattern, so the orchestrator's Secret
+				// entries match cilium's cluster.name override on the
+				// secondary regions byte-identically.
 				clusterName = clusterName + "-" + key
 			}
 		}

--- a/products/catalyst/bootstrap/api/internal/provisioner/provisioner.go
+++ b/products/catalyst/bootstrap/api/internal/provisioner/provisioner.go
@@ -1891,6 +1891,15 @@ func firstFQDNLabel(fqdn string) string {
 // "" → cilium-config rendered cluster.name="default" on all 3 regions
 // → kvstoremesh refused to start. Auto-derive closes the gap.
 func deriveClusterMeshName(req Request) string {
+	return DeriveClusterMeshName(req)
+}
+
+// DeriveClusterMeshName is the exported wrapper around deriveClusterMeshName
+// so the handler package can derive a consistent default at orchestrator
+// time without duplicating the firstFQDNLabel logic. Same semantics as
+// the unexported version: operator override > FQDN-based default >
+// empty string for single-region provs.
+func DeriveClusterMeshName(req Request) string {
 	if s := strings.TrimSpace(req.ClusterMeshName); s != "" {
 		return s
 	}
@@ -1923,6 +1932,14 @@ func deriveClusterMeshName(req Request) string {
 // reserved" → no mesh ever formed → cross-region observability
 // permanently broken.
 func deriveClusterMeshID(req Request) int {
+	return DeriveClusterMeshID(req)
+}
+
+// DeriveClusterMeshID is the exported wrapper around deriveClusterMeshID
+// so the handler package can derive a consistent default at orchestrator
+// time. Same semantics: operator override > deterministic hash(DepID|FQDN)
+// % 252 + 1 > 0 for single-region.
+func DeriveClusterMeshID(req Request) int {
 	if req.ClusterMeshID != 0 {
 		return req.ClusterMeshID
 	}


### PR DESCRIPTION
## Summary

When operator submits the canonical multi-region body **without** `ClusterMeshName` / `ClusterMeshID`, the in-memory `dep.Request` fields stay empty. tofu derives them internally and the cilium chart on each region renders correctly, but the catalyst-api orchestrator was reading from `dep.Request` directly → `slot.clusterName=""` → peerEntries dict got `""` keys → `Create Secret kube-system/cilium-clustermesh: data[]: Invalid value: "": a valid config key must consist of alphanumeric characters` rejection in all 3 regions.

## Caught on t125

`590ab1490d00c452` (2026-05-16): PR #1525 unblocked kubeconfig-path resolution; new bug surfaced 3× as:

```
clustermesh: Secret apply failed ... err="Create Secret kube-system/cilium-clustermesh:
  Secret \"cilium-clustermesh\" is invalid: data[]: Invalid value: \"\":
  a valid config key must consist of alphanumeric characters..."
```

with empty `region` + `cluster` log fields.

## Changes

1. Export `DeriveClusterMeshName` + `DeriveClusterMeshID` from provisioner package → canonical seam shared with tofu writeTfvars.
2. `buildRegionSlots` falls back to these when `dep.Request.*` is empty. Primary mesh name derived once and reused for secondary suffixing.
3. Defensive guard: per-peer loop skips peers with empty clusterName loudly (`peer.Error = "peer cluster name empty"`) rather than silently corrupting peerEntries.

## Test plan

- [x] `go build ./internal/handler/` + `./internal/provisioner/` clean
- [x] `go test -run TestAutoEstablishClusterMesh -count=1` passes
- [ ] Next prov: `cilium-clustermesh` Secret seeded in all 3 regions → D10 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)