### PR TITLE
fix(vcluster): canonical region label substitute + per-role enable flags (A4)

### DIFF
--- a/clusters/_template/bootstrap-kit/54-bp-dmz-vcluster.yaml
+++ b/clusters/_template/bootstrap-kit/54-bp-dmz-vcluster.yaml
@@ -86,15 +86,18 @@ spec:
       role: every-region
       nodeSelector:
         regionLabelKey: openova.io/region
-        # Substituted per region by the bootstrap-kit Kustomization.
-        # Primary CP renders the bare region (e.g. `nbg1`); secondary
-        # CPs render their region key (e.g. `hel1-2`). The DMZ vCluster
-        # pod MUST land on the region's own CP so the inter-region WG
-        # endpoint binds the correct region's public IP.
-        regionLabelValue: ${SOVEREIGN_REGION_KEY}
+        # Substituted by the bootstrap-kit Kustomization with the THIS
+        # region's CANONICAL k3s node-label value (e.g.
+        # `hz-hel-rtz-prod` on hel1, `hz-nbg-rtz-prod` on nbg1,
+        # `hz-sin-rtz-prod` on sin). Caught on t126 (2026-05-16): the
+        # prior `${SOVEREIGN_REGION_KEY}` ("hel1"/"nbg1-1"/"sin-2")
+        # didn't match the node label written by cloud-init (which uses
+        # `region_canonical_label` not `sovereign_region_key`) so every
+        # DMZ vCluster Pod sat Pending with FailedScheduling.
+        regionLabelValue: ${SOVEREIGN_REGION_CANONICAL_LABEL}
     vcluster:
       controlPlane:
         statefulSet:
           scheduling:
             nodeSelector:
-              openova.io/region: ${SOVEREIGN_REGION_KEY}
+              openova.io/region: ${SOVEREIGN_REGION_CANONICAL_LABEL}

--- a/clusters/_template/bootstrap-kit/58-bp-mgmt-vcluster.yaml
+++ b/clusters/_template/bootstrap-kit/58-bp-mgmt-vcluster.yaml
@@ -101,26 +101,26 @@ spec:
   # cloud-init).
   values:
     mgmtVcluster:
-      # Default off until tofu's primary-CP postBuild flips it; see
-      # the slot header comment for the migration plan.
-      enabled: false
+      # Flipped on for the primary region by tofu's primary postBuild
+      # (mgmt_vcluster_enabled=true). Secondaries render this slot but
+      # tofu sets the substitute false → chart renders zero resources.
+      enabled: ${MGMT_VCLUSTER_ENABLED:=false}
       hostNamespace: mgmt
       vclusterName: mgmt
       role: primary
       nodeSelector:
         regionLabelKey: openova.io/region
-        # Substituted by the bootstrap-kit Kustomization. Primary CP
-        # renders the bare region (e.g. `nbg1`); secondary CPs render
-        # their region key (e.g. `hel1-2`). The MGMT vCluster pod is
-        # node-pinned to this label so it never lands on a foreign
-        # region's worker.
-        regionLabelValue: ${SOVEREIGN_REGION_KEY}
-    # Subchart values overlay — pinned to the per-region label too so
-    # the upstream vcluster StatefulSet's nodeSelector binds the same
+        # Canonical region label (hz-<stem>-rtz-prod) — matches the
+        # k3s node-label written at install time. See slot 54 + the
+        # SOVEREIGN_REGION_CANONICAL_LABEL substitute in
+        # infra/hetzner/cloudinit-control-plane.tftpl.
+        regionLabelValue: ${SOVEREIGN_REGION_CANONICAL_LABEL}
+    # Subchart values overlay — pinned to the per-region canonical label
+    # so the upstream vcluster StatefulSet's nodeSelector binds the same
     # CP node as the umbrella's nodeSelector helper.
     vcluster:
       controlPlane:
         statefulSet:
           scheduling:
             nodeSelector:
-              openova.io/region: ${SOVEREIGN_REGION_KEY}
+              openova.io/region: ${SOVEREIGN_REGION_CANONICAL_LABEL}

--- a/clusters/_template/bootstrap-kit/59-bp-rtz-vcluster.yaml
+++ b/clusters/_template/bootstrap-kit/59-bp-rtz-vcluster.yaml
@@ -79,18 +79,19 @@ spec:
       retries: 3
   values:
     rtzVcluster:
-      # Default off until tofu's secondary-CP postBuild flips it; see
-      # the slot header comment for the migration plan.
-      enabled: false
+      # Flipped on by tofu's secondary-CP postBuild (rtz_vcluster_enabled=true).
+      # Primary renders this slot too but tofu sets the substitute false →
+      # chart renders zero resources on the primary.
+      enabled: ${RTZ_VCLUSTER_ENABLED:=false}
       hostNamespace: rtz
       vclusterName: rtz
       role: secondary
       nodeSelector:
         regionLabelKey: openova.io/region
-        regionLabelValue: ${SOVEREIGN_REGION_KEY}
+        regionLabelValue: ${SOVEREIGN_REGION_CANONICAL_LABEL}
     vcluster:
       controlPlane:
         statefulSet:
           scheduling:
             nodeSelector:
-              openova.io/region: ${SOVEREIGN_REGION_KEY}
+              openova.io/region: ${SOVEREIGN_REGION_CANONICAL_LABEL}

--- a/infra/hetzner/cloudinit-control-plane.tftpl
+++ b/infra/hetzner/cloudinit-control-plane.tftpl
@@ -1004,6 +1004,27 @@ write_files:
             # but their qaFixtures Pods stay Pending by design (no node
             # carries the primary's label on a secondary cluster).
             QA_PRIMARY_REGION: "${primary_region_canonical_label}"
+            # SOVEREIGN_REGION_CANONICAL_LABEL — THIS region's canonical
+            # k3s node label value (e.g. "hz-hel-rtz-prod" for hel1,
+            # "hz-nbg-rtz-prod" for nbg1, "hz-sin-rtz-prod" for sin).
+            # Used by bp-{mgmt,dmz,rtz}-vcluster slots 54/58/59 for the
+            # vCluster Pod nodeSelector — the SOVEREIGN_REGION_KEY
+            # ("hel1", "nbg1-1") does NOT match the k3s node-label value
+            # written at install time. Caught on t126 (2026-05-16): DMZ
+            # vCluster Pods Pending on every region because nodeSelector
+            # `openova.io/region=hel1` didn't match node label
+            # `openova.io/region=hz-hel-rtz-prod`.
+            SOVEREIGN_REGION_CANONICAL_LABEL: "${region_canonical_label}"
+            # Per-role vCluster enable flags (DoD A4 topology):
+            #   primary    region → MGMT  + DMZ  vCluster
+            #   secondary  region → DMZ   + RTZ  vCluster
+            # The bp-dmz-vcluster slot 54 stays ${DMZ_VCLUSTER_ENABLED:=true}
+            # since DMZ runs everywhere by design — both fall through to
+            # the chart-side default. MGMT_VCLUSTER_ENABLED/RTZ_VCLUSTER_ENABLED
+            # are flipped here per-region so the bootstrap-kit slot reads
+            # the right value at apply time.
+            MGMT_VCLUSTER_ENABLED: "${mgmt_vcluster_enabled}"
+            RTZ_VCLUSTER_ENABLED: "${rtz_vcluster_enabled}"
             # QA fixtures auto-enable (Fix #73 — qa-loop bounded-cycle
             # iter-16). Default "false" so a customer-facing zero-touch
             # provision lands a Sovereign with NO qaFixtures stack

--- a/infra/hetzner/main.tf
+++ b/infra/hetzner/main.tf
@@ -549,6 +549,13 @@ locals {
     # primaryRegion follows the actual Sovereign primary, never the
     # chart's hardcoded `hz-fsn-rtz-prod` default.
     primary_region_canonical_label = local.region_canonical_label["primary"]
+    # Per-role vCluster enable flags (DoD A4 topology). Primary region
+    # renders MGMT+DMZ vClusters → mgmt_vcluster_enabled=true. RTZ stays
+    # off here — secondary regions flip RTZ on. The bp-dmz-vcluster slot
+    # 54 chart-side default already enables DMZ everywhere, so no flag
+    # for DMZ here. See clusters/_template/bootstrap-kit/54,58,59-*.yaml.
+    mgmt_vcluster_enabled          = "true"
+    rtz_vcluster_enabled           = "false"
     ha_enabled                     = var.ha_enabled
     worker_count                   = var.worker_count
     k3s_version                    = var.k3s_version
@@ -1074,6 +1081,11 @@ locals {
       # Sovereign-wide primary region (qaFixtures.primaryRegion is
       # singular per the chart contract).
       primary_region_canonical_label = local.region_canonical_label["primary"]
+      # Per-role vCluster enable flags (DoD A4). Secondary region
+      # renders DMZ+RTZ vCluster → rtz_vcluster_enabled=true. MGMT
+      # stays off on secondaries (single MGMT vCluster on primary).
+      mgmt_vcluster_enabled          = "false"
+      rtz_vcluster_enabled           = "true"
       ha_enabled                     = false # secondary regions land single-CP in slice G1; G3 introduces per-region HA
       worker_count                   = r.workerCount
       k3s_version                    = var.k3s_version


### PR DESCRIPTION
## Summary

Three slot-level + two tofu changes:
- tofu cloud-init: add `SOVEREIGN_REGION_CANONICAL_LABEL` + `MGMT_VCLUSTER_ENABLED` + `RTZ_VCLUSTER_ENABLED` substitutes (per primary/secondary)
- bootstrap-kit slots 54/58/59: use canonical label not `SOVEREIGN_REGION_KEY`; 58/59 read the per-role enable flag

## Caught on t126

DMZ vCluster Pods Pending on every region with FailedScheduling — nodeSelector `openova.io/region=hel1` didn't match node label `openova.io/region=hz-hel-rtz-prod` (canonical from PR #1512).

## Test plan

- [ ] Next prov: DMZ vCluster Pods Running on every region; MGMT on primary only; RTZ on secondaries only

🤖 Generated with [Claude Code](https://claude.com/claude-code)