### PR TITLE
fix(chroot): seed Request.Regions[] from SOVEREIGN_REGIONS_JSON env (D5)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -609,6 +609,21 @@ spec:
     # bp-cert-manager-powerdns-webhook 1.1.0+) as an overridable default.
     wildcardCert:
       useStaging: ${WILDCARD_CERT_USE_STAGING:-false}
+    # ─── Sovereign-side region seeding (DoD D5) ─────────────────────
+    # regionsJson — JSON-array literal of the canonical multi-region
+    # RegionSpec[] this Sovereign was provisioned with. Threaded
+    # through from the mothership prov body via the tofu cloud-init
+    # `SOVEREIGN_REGIONS_JSON` envsubst placeholder. The chart writes
+    # this string into the `sovereign-fqdn` ConfigMap's `regionsJson`
+    # key (sovereign-fqdn-configmap.yaml); the catalyst-api Pod reads
+    # via env `SOVEREIGN_REGIONS_JSON`; chrootEnsureDeployment parses
+    # and stamps Request.Regions so /infrastructure/topology emits
+    # the right per-region tree and /cloud?view=graph renders all
+    # N regions correctly. Without this the chroot fell back to the
+    # live-Nodes path and emitted "1 cluster 1 region" on every
+    # multi-region Sovereign (caught on t126, 2026-05-16).
+    sovereign:
+      regionsJson: ${SOVEREIGN_REGIONS_JSON:-}
     # ─── QA fixtures (qa-loop iter-6 Cluster-F + EPIC-6 iter-6) ────────
     # Default-OFF on production; flipped to true via envsubst
     # QA_FIXTURES_ENABLED=true on the per-Sovereign overlay for any

--- a/infra/hetzner/cloudinit-control-plane.tftpl
+++ b/infra/hetzner/cloudinit-control-plane.tftpl
@@ -1029,6 +1029,17 @@ write_files:
             # failure mode (caught on t127, 2026-05-16).
             MGMT_VCLUSTER_ENABLED: "${mgmt_vcluster_enabled}"
             RTZ_VCLUSTER_ENABLED: "${rtz_vcluster_enabled}"
+            # SOVEREIGN_REGIONS_JSON — JSON-encoded RegionSpec[] from
+            # mothership prov body. Read by bp-catalyst-platform slot 13
+            # (sovereign.regionsJson) → sovereign-fqdn ConfigMap
+            # `regionsJson` → catalyst-api env SOVEREIGN_REGIONS_JSON →
+            # chrootEnsureDeployment seeds Request.Regions[] →
+            # /cloud?view=graph renders multi-region (DoD D5).
+            # Single-quoted so YAML treats JSON braces/quotes/commas
+            # as literal. Caught on t126 (2026-05-16): UI showed
+            # "1 cluster 1 region" because chroot fell back to
+            # live-Nodes enumeration.
+            SOVEREIGN_REGIONS_JSON: '${sovereign_regions_json}'
             # QA fixtures auto-enable (Fix #73 — qa-loop bounded-cycle
             # iter-16). Default "false" so a customer-facing zero-touch
             # provision lands a Sovereign with NO qaFixtures stack

--- a/infra/hetzner/main.tf
+++ b/infra/hetzner/main.tf
@@ -533,6 +533,15 @@ locals {
       var.parent_domains_yaml,
       format("[{name: \"%s\", role: \"primary\"}]", var.sovereign_fqdn)
     )
+    # sovereign_regions_json — canonical multi-region RegionSpec[]
+    # JSON literal. Threaded into bp-catalyst-platform's
+    # .Values.sovereign.regionsJson via the bootstrap-kit slot 13
+    # postBuild.substitute `SOVEREIGN_REGIONS_JSON`. Catalyst-api on
+    # the Sovereign side reads via the `sovereign-fqdn` ConfigMap env
+    # `SOVEREIGN_REGIONS_JSON` and uses to seed Request.Regions on the
+    # chroot Deployment so /infrastructure/topology returns the
+    # full multi-region tree (DoD D5).
+    sovereign_regions_json = jsonencode(var.regions)
     org_name  = var.org_name
     org_email = var.org_email
     region    = var.region
@@ -1067,6 +1076,10 @@ locals {
         var.parent_domains_yaml,
         format("[{name: \"%s\", role: \"primary\"}]", var.sovereign_fqdn)
       )
+      # Same JSON-encoded RegionSpec[] as the primary CP — every region's
+      # bp-catalyst-platform renders the same sovereign.regionsJson value
+      # (the cluster topology is Sovereign-wide, not per-region).
+      sovereign_regions_json = jsonencode(var.regions)
       org_name  = var.org_name
       org_email = var.org_email
       region    = r.cloudRegion

--- a/products/catalyst/bootstrap/api/internal/handler/jobs.go
+++ b/products/catalyst/bootstrap/api/internal/handler/jobs.go
@@ -22,6 +22,7 @@ package handler
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"os"
@@ -70,10 +71,24 @@ func (h *Handler) chrootEnsureDeployment(depID string) *Deployment {
 	closedDone := make(chan struct{})
 	close(closedCh)
 	close(closedDone)
+	// SOVEREIGN_REGIONS_JSON — chroot-side region list, threaded in by
+	// bp-catalyst-platform Helm values (Sovereign-side env). When
+	// present, populate Request.Regions so the topology loader emits
+	// one Region per spec entry instead of falling into the chroot
+	// "single-region from live Nodes" path — without this the
+	// /cloud?view=graph view shows "1 cluster 1 region" on every
+	// multi-region Sovereign because the live-Nodes path only sees
+	// THIS cluster's Nodes, not the cross-region peers. Caught on
+	// t126 (84c0848406dd6fdd, 2026-05-16) — operator reported
+	// `console.t126.omani.works/cloud?view=graph` rendered as
+	// single-region despite the mothership openova-flow snapshot
+	// holding all 3 regions correctly.
+	regions := chrootRegionsFromEnv()
 	dep := &Deployment{
 		ID: depID,
 		Request: provisioner.Request{
 			SovereignFQDN: selfFQDN,
+			Regions:       regions,
 		},
 		Status:   "ready",
 		eventsCh: closedCh,
@@ -81,8 +96,27 @@ func (h *Handler) chrootEnsureDeployment(depID string) *Deployment {
 	}
 	h.deployments.Store(depID, dep)
 	h.log.Info("chroot: synthesised in-memory deployment record",
-		"depId", depID, "sovereignFQDN", selfFQDN)
+		"depId", depID, "sovereignFQDN", selfFQDN,
+		"regionCount", len(regions))
 	return dep
+}
+
+// chrootRegionsFromEnv parses SOVEREIGN_REGIONS_JSON (the canonical
+// regions list threaded in by bp-catalyst-platform). Returns empty
+// slice when unset or malformed — the caller falls back to the live-
+// Nodes path. The JSON shape matches the wizard's request.regions
+// array: [{provider, cloudRegion, controlPlaneSize, workerSize,
+// workerCount}, ...].
+func chrootRegionsFromEnv() []provisioner.RegionSpec {
+	raw := strings.TrimSpace(os.Getenv("SOVEREIGN_REGIONS_JSON"))
+	if raw == "" {
+		return nil
+	}
+	var out []provisioner.RegionSpec
+	if err := json.Unmarshal([]byte(raw), &out); err != nil {
+		return nil
+	}
+	return out
 }
 
 // chrootSeedJobsStoreIfEmpty — when the chroot Sovereign-side

--- a/products/catalyst/chart/templates/api-deployment.yaml
+++ b/products/catalyst/chart/templates/api-deployment.yaml
@@ -650,6 +650,25 @@ spec:
                   name: sovereign-fqdn
                   key: fqdn
                   optional: true
+            # SOVEREIGN_REGIONS_JSON — the canonical multi-region request
+            # array threaded from the mothership's prov body via the
+            # `sovereign-fqdn` ConfigMap key `regionsJson`. Read by the
+            # chroot Sovereign-side catalyst-api so its
+            # chrootEnsureDeployment populates Request.Regions →
+            # /api/v1/.../infrastructure/topology emits all 3 regions →
+            # /cloud?view=graph renders the multi-region topology
+            # correctly. Without this the chroot synth fell back to
+            # buildRegionFromLiveNodes which only sees THIS cluster's
+            # Nodes → operator sees "1 cluster 1 region" on every
+            # multi-region Sovereign. Caught on t126 (2026-05-16).
+            # optional=true so single-region Sovereigns / chart bring-up
+            # before the ConfigMap key is wired don't crash on missing.
+            - name: SOVEREIGN_REGIONS_JSON
+              valueFrom:
+                configMapKeyRef:
+                  name: sovereign-fqdn
+                  key: regionsJson
+                  optional: true
             # CATALYST_OTECH_FQDN — same value as SOVEREIGN_FQDN, but read by
             # the SME tenant create handler (sme_tenant.go) and the
             # sovereign-parent-domains seed (sovereign_parent_domains.go).

--- a/products/catalyst/chart/templates/sovereign-fqdn-configmap.yaml
+++ b/products/catalyst/chart/templates/sovereign-fqdn-configmap.yaml
@@ -108,4 +108,16 @@ data:
   {{-   $apps = default (list) .Values.qaFixtures.applications }}
   {{- end }}
   qaApplications: {{ join "," $apps | quote }}
+  # regionsJson — canonical multi-region RegionSpec[] JSON. Threaded
+  # in from the mothership prov body's `regions` array via
+  # .Values.sovereign.regionsJson (operator-set during provision).
+  # Read by catalyst-api's chrootEnsureDeployment → populates
+  # Request.Regions so /infrastructure/topology returns 3 Regions on
+  # a 3-region Sovereign. Without this the chroot synth falls back
+  # to live-Nodes enumeration which only sees THIS cluster (D5 ❌).
+  #
+  # Shape: a JSON array literal [{provider, cloudRegion, controlPlaneSize,
+  # workerSize, workerCount}, ...]. Empty string → chroot uses
+  # buildRegionFromLiveNodes (legacy single-region path).
+  regionsJson: {{ default "" .Values.sovereign.regionsJson | quote }}
 {{- end }}


### PR DESCRIPTION
## Summary

Sovereign-side catalyst-api in chroot mode synthesises an empty-Regions Deployment → topology loader falls into live-Nodes enumeration → only 1 region visible on /cloud?view=graph. Fix threads the canonical RegionSpec[] JSON from tofu through bp-catalyst-platform → sovereign-fqdn ConfigMap → catalyst-api env → chrootEnsureDeployment.

## Files changed

- `products/catalyst/bootstrap/api/internal/handler/jobs.go` — chrootEnsureDeployment reads SOVEREIGN_REGIONS_JSON env
- `products/catalyst/chart/templates/api-deployment.yaml` — adds SOVEREIGN_REGIONS_JSON env var (valueFrom configMapKeyRef)
- `products/catalyst/chart/templates/sovereign-fqdn-configmap.yaml` — adds `regionsJson` key
- `clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml` — adds `sovereign.regionsJson: ${SOVEREIGN_REGIONS_JSON:-}`
- `infra/hetzner/main.tf` — adds `sovereign_regions_json = jsonencode(var.regions)` to both primary + secondary templatefile calls
- `infra/hetzner/cloudinit-control-plane.tftpl` — adds `SOVEREIGN_REGIONS_JSON: '${sovereign_regions_json}'` substitute

## Test plan

- [x] go build clean, tests pass
- [ ] Next prov: console.<fqdn>/cloud?view=graph renders all N regions

🤖 Generated with [Claude Code](https://claude.com/claude-code)