### PR TITLE
fix(clustermesh-lb): use-private-ip=true for LB→backend transit (D11)

### DIFF
--- a/clusters/_template/bootstrap-kit/01-cilium.yaml
+++ b/clusters/_template/bootstrap-kit/01-cilium.yaml
@@ -212,7 +212,25 @@ spec:
             annotations:
               load-balancer.hetzner.cloud/location: "${HCLOUD_LB_LOCATION}"
               load-balancer.hetzner.cloud/type: "lb11"
-              load-balancer.hetzner.cloud/use-private-ip: "false"
+              # use-private-ip: true so the LB → backend connection
+              # transits the per-region private network (10.0.1.0/24)
+              # — bypasses the Sovereign firewall which only permits
+              # public ingress on 80/443/6443/53/icmp/wg-udp and
+              # blocks the NodePort range (30000-32767). Caught on
+              # t129 (6cddff7ef4432bdc, 2026-05-16): all 3 clustermesh
+              # LB targets reported `health_status=unhealthy` because
+              # Hetzner LB health checks probe `<node-ip>:<destination_port>`
+              # — `<destination_port>` is the NodePort which the
+              # firewall blocks. LB rejects connections from external
+              # clients with "unexpected eof while reading" at TLS
+              # handshake → cilium clustermesh agent stays
+              # `0/N remote clusters ready`.
+              #
+              # External clients (other regions' Cilium agents) still
+              # connect to the LB's PUBLIC IP — this annotation only
+              # controls the LB→backend transit, which stays
+              # in-region.
+              load-balancer.hetzner.cloud/use-private-ip: "true"
               # 2026-05-16: per-region LB name suffix. Without
               # ${SOVEREIGN_REGION_KEY} interpolated, all 3 regions'
               # clustermesh-apiserver Services adopted the FIRST LB


### PR DESCRIPTION
All 3 clustermesh LB targets unhealthy because Hetzner firewall blocks NodePort range. use-private-ip=true routes LB→backend over per-region private network, bypassing the firewall. External clients still connect to public LB IP. Caught on t129.