### PR TITLE
fix(ui): t129 SPA routing — bp-bp- prefix, PIN /wizard leak, /app/dashboard fleet leak

### DIFF
--- a/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
+++ b/products/catalyst/bootstrap/api/internal/catalog/blueprints.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-16T15:45:13.271Z",
+  "generatedAt": "2026-05-16T15:58:28.106Z",
   "blueprints": [
     {
       "id": "bp-anthropic-adapter",
@@ -881,9 +881,9 @@
       "order": 12
     },
     {
-      "id": "bp-bp-catalyst-platform",
-      "slug": "bp-catalyst-platform",
-      "label": "bp-catalyst-platform",
+      "id": "bp-catalyst-platform",
+      "slug": "catalyst-platform",
+      "label": "catalyst-platform",
       "file": "13-bp-catalyst-platform.yaml",
       "order": 13
     },
@@ -1035,9 +1035,9 @@
       "order": 35
     },
     {
-      "id": "bp-bp-cert-manager-powerdns-webhook",
-      "slug": "bp-cert-manager-powerdns-webhook",
-      "label": "bp-cert-manager-powerdns-webhook",
+      "id": "bp-cert-manager-powerdns-webhook",
+      "slug": "cert-manager-powerdns-webhook",
+      "label": "cert-manager-powerdns-webhook",
       "file": "49-bp-cert-manager-powerdns-webhook.yaml",
       "order": 49
     },
@@ -1049,58 +1049,58 @@
       "order": 50
     },
     {
-      "id": "bp-bp-k8s-ws-proxy",
-      "slug": "bp-k8s-ws-proxy",
-      "label": "bp-k8s-ws-proxy",
+      "id": "bp-k8s-ws-proxy",
+      "slug": "k8s-ws-proxy",
+      "label": "k8s-ws-proxy",
       "file": "51-bp-k8s-ws-proxy.yaml",
       "order": 51
     },
     {
-      "id": "bp-bp-guacamole",
-      "slug": "bp-guacamole",
-      "label": "bp-guacamole",
+      "id": "bp-guacamole",
+      "slug": "guacamole",
+      "label": "guacamole",
       "file": "52-bp-guacamole.yaml",
       "order": 52
     },
     {
-      "id": "bp-bp-dmz-vcluster",
-      "slug": "bp-dmz-vcluster",
-      "label": "bp-dmz-vcluster",
+      "id": "bp-dmz-vcluster",
+      "slug": "dmz-vcluster",
+      "label": "dmz-vcluster",
       "file": "54-bp-dmz-vcluster.yaml",
       "order": 54
     },
     {
-      "id": "bp-bp-hcloud-ccm",
-      "slug": "bp-hcloud-ccm",
-      "label": "bp-hcloud-ccm",
+      "id": "bp-hcloud-ccm",
+      "slug": "hcloud-ccm",
+      "label": "hcloud-ccm",
       "file": "55-bp-hcloud-ccm.yaml",
       "order": 55
     },
     {
-      "id": "bp-bp-openova-flow-server",
-      "slug": "bp-openova-flow-server",
-      "label": "bp-openova-flow-server",
+      "id": "bp-openova-flow-server",
+      "slug": "openova-flow-server",
+      "label": "openova-flow-server",
       "file": "56-bp-openova-flow-server.yaml",
       "order": 56
     },
     {
-      "id": "bp-bp-openova-flow-emitter",
-      "slug": "bp-openova-flow-emitter",
-      "label": "bp-openova-flow-emitter",
+      "id": "bp-openova-flow-emitter",
+      "slug": "openova-flow-emitter",
+      "label": "openova-flow-emitter",
       "file": "57-bp-openova-flow-emitter.yaml",
       "order": 57
     },
     {
-      "id": "bp-bp-mgmt-vcluster",
-      "slug": "bp-mgmt-vcluster",
-      "label": "bp-mgmt-vcluster",
+      "id": "bp-mgmt-vcluster",
+      "slug": "mgmt-vcluster",
+      "label": "mgmt-vcluster",
       "file": "58-bp-mgmt-vcluster.yaml",
       "order": 58
     },
     {
-      "id": "bp-bp-rtz-vcluster",
-      "slug": "bp-rtz-vcluster",
-      "label": "bp-rtz-vcluster",
+      "id": "bp-rtz-vcluster",
+      "slug": "rtz-vcluster",
+      "label": "rtz-vcluster",
       "file": "59-bp-rtz-vcluster.yaml",
       "order": 59
     },

--- a/products/catalyst/bootstrap/ui/scripts/build-catalog.mjs
+++ b/products/catalyst/bootstrap/ui/scripts/build-catalog.mjs
@@ -279,7 +279,20 @@ function listBootstrapKit() {
     const m = name.match(/^(\d+)-(.+)\.yaml$/)
     if (!m) continue
     const order = Number(m[1])
-    const slug = m[2]
+    // Strip the optional `bp-` prefix from the captured filename remainder
+    // BEFORE forming the canonical Blueprint id. Some bootstrap-kit files
+    // are named with the `bp-` already present (e.g.
+    // `13-bp-catalyst-platform.yaml`) for historical reasons — without
+    // this strip, the captured slug would be `bp-catalyst-platform` and
+    // the emitted id would be `bp-bp-catalyst-platform`, which:
+    //   (a) produces doubled `/app/bp-bp-*` hrefs on the AppsPage card
+    //       grid (BUG-001 / D19 on t129.omani.works, 2026-05-16)
+    //   (b) breaks the FE↔BE join in /api/v1/sovereign/apps where HR
+    //       name `bp-<slug>` is matched against blueprint id `bp-<slug>`
+    //   (c) prints `bp-` twice in the operator-facing card title fallback
+    // Canonical contract: filename `NN[-bp]-<slug>.yaml` → id `bp-<slug>`
+    // → slug `<slug>` (no bp- prefix), matching the blueprint.yaml side.
+    const slug = m[2].replace(/^bp-/, '')
     out.push({
       id: `bp-${slug}`,
       slug,

--- a/products/catalyst/bootstrap/ui/src/app/router.tsx
+++ b/products/catalyst/bootstrap/ui/src/app/router.tsx
@@ -362,7 +362,27 @@ const authHandoverErrorRoute = createRoute({
 
 // App routes
 const appRoute = createRoute({ getParentRoute: () => rootRoute, path: '/app', component: AppLayout })
-const dashboardRoute = createRoute({ getParentRoute: () => appRoute, path: '/dashboard', component: DashboardPage })
+// /app/dashboard renders the mothership multi-Sovereign Fleet view
+// (DashboardPage). On a Sovereign Console (chroot, console.<sov-fqdn>)
+// this surface MUST NOT be reachable — the Sovereign owns a single
+// deployment, the "fleet" concept belongs to the mothership only.
+// Caught live on t129.omani.works (2026-05-16, BUG-016 / D24): the
+// fleet view rendered "7 Sovereigns" with duplicate t129.omani.works
+// rows and "APPS 0, ORGS 0" despite 44 apps installed.
+//
+// Beforeload-redirect to the canonical Sovereign dashboard at
+// `/dashboard` (consoleDashboardRoute, the per-Sovereign landing).
+// Mothership-side (`catalyst-zero`) keeps the fleet view as today.
+const dashboardRoute = createRoute({
+  getParentRoute: () => appRoute,
+  path: '/dashboard',
+  component: DashboardPage,
+  beforeLoad: () => {
+    if (DETECTED_MODE.mode === 'sovereign') {
+      throw redirect({ to: '/dashboard' as never, replace: true })
+    }
+  },
+})
 
 // EPIC-6 (#1101) slice U-Fleet-3 — cross-Sovereign Applications view.
 // Pivot from the Sovereign-card grid to the Application × Sovereign

--- a/products/catalyst/bootstrap/ui/src/pages/auth/VerifyPinPage.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/auth/VerifyPinPage.test.tsx
@@ -1,0 +1,151 @@
+/**
+ * VerifyPinPage.test.tsx — coverage for the post-PIN-verify redirect
+ * destination, especially the Sovereign-mode default (BUG-015 / D23).
+ *
+ * On chroot Sovereign Console (DETECTED_MODE.mode === 'sovereign'),
+ * a PIN-verify that returns {ok:true} with no `next=` param MUST land
+ * the operator on `/dashboard` (the per-Sovereign landing page), NOT
+ * on `/wizard` (the mothership new-prov wizard). Sending an operator
+ * who just completed handover to the wizard re-prompts for org details
+ * on an already-converged Sovereign — directly contradicting D0.
+ *
+ * Caught live on t129.omani.works (2026-05-16, BUG-015).
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, cleanup, fireEvent, waitFor } from '@testing-library/react'
+
+const navigateSpy = vi.fn<(opts: unknown) => void>()
+const searchState: { current: Record<string, string | undefined> } = { current: {} }
+
+vi.mock('@tanstack/react-router', async (importOriginal) => {
+  const actual = (await importOriginal()) as object
+  return {
+    ...actual,
+    useNavigate: () => navigateSpy,
+    useSearch: () => searchState.current,
+  }
+})
+
+vi.mock('@/app/layouts/AuthLayout', () => ({
+  AuthShell: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}))
+
+// Mode mock — overridden per test via `mockMode`. The module-level
+// `DETECTED_MODE` export is read via a getter so each test sees the
+// current value without needing module-cache shenanigans.
+let mockMode: 'sovereign' | 'catalyst-zero' = 'sovereign'
+vi.mock('@/shared/lib/detectMode', () => ({
+  get DETECTED_MODE() {
+    return { mode: mockMode, sovereignFQDN: 't129.omani.works' }
+  },
+}))
+
+// PinInput6 is heavy + has hooks we don't need for this test — replace
+// with a minimal seam that exposes onComplete via a hidden button so
+// the test can fire it deterministically.
+vi.mock('@/components/PinInput6', () => ({
+  PinInput6: (props: {
+    onChange?: (v: string) => void
+    onComplete?: (v: string) => void
+    disabled?: boolean
+    testId?: string
+  }) => (
+    <button
+      type="button"
+      data-testid="pin-complete-stub"
+      onClick={() => {
+        props.onChange?.('123456')
+        props.onComplete?.('123456')
+      }}
+    >
+      stub-complete
+    </button>
+  ),
+}))
+
+import { VerifyPinPage } from './VerifyPinPage'
+
+let replaceSpy: ReturnType<typeof vi.fn>
+
+beforeEach(() => {
+  navigateSpy.mockClear()
+  searchState.current = { email: 'emrah.baysal@openova.io', requestId: 'req-1' }
+  replaceSpy = vi.fn()
+  Object.defineProperty(window, 'location', {
+    configurable: true,
+    writable: true,
+    value: {
+      ...window.location,
+      pathname: '/',
+      href: 'http://test/login/verify',
+      replace: replaceSpy,
+    },
+  })
+})
+
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+})
+
+describe('VerifyPinPage — post-PIN-verify default landing (BUG-015 / D23)', () => {
+  it('redirects to /dashboard on Sovereign mode when no next= is given', async () => {
+    mockMode = 'sovereign'
+    const fetchSpy = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ ok: true }),
+    })
+    vi.stubGlobal('fetch', fetchSpy)
+
+    const { getByTestId } = render(<VerifyPinPage />)
+    fireEvent.click(getByTestId('pin-complete-stub'))
+
+    await waitFor(() => {
+      expect(replaceSpy).toHaveBeenCalledTimes(1)
+    })
+    expect(replaceSpy).toHaveBeenCalledWith('/dashboard')
+  })
+
+  it('redirects to /wizard on Catalyst-Zero mode when no next= is given', async () => {
+    mockMode = 'catalyst-zero'
+    const fetchSpy = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ ok: true }),
+    })
+    vi.stubGlobal('fetch', fetchSpy)
+
+    const { getByTestId } = render(<VerifyPinPage />)
+    fireEvent.click(getByTestId('pin-complete-stub'))
+
+    await waitFor(() => {
+      expect(replaceSpy).toHaveBeenCalledTimes(1)
+    })
+    expect(replaceSpy).toHaveBeenCalledWith('/wizard')
+  })
+
+  it('honours the explicit next= param over the mode-default (Sovereign)', async () => {
+    mockMode = 'sovereign'
+    searchState.current = {
+      email: 'emrah.baysal@openova.io',
+      requestId: 'req-1',
+      next: '/apps',
+    }
+    const fetchSpy = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ ok: true }),
+    })
+    vi.stubGlobal('fetch', fetchSpy)
+
+    const { getByTestId } = render(<VerifyPinPage />)
+    fireEvent.click(getByTestId('pin-complete-stub'))
+
+    await waitFor(() => {
+      expect(replaceSpy).toHaveBeenCalledTimes(1)
+    })
+    expect(replaceSpy).toHaveBeenCalledWith('/apps')
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/pages/auth/VerifyPinPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/auth/VerifyPinPage.tsx
@@ -20,6 +20,7 @@ import { Button } from '@/shared/ui/button'
 import { PinInput6 } from '@/components/PinInput6'
 import { API_BASE } from '@/shared/config/urls'
 import { sanitizeNextParam } from '@/app/auth-gate'
+import { DETECTED_MODE } from '@/shared/lib/detectMode'
 
 type State = 'idle' | 'verifying' | 'error'
 
@@ -99,7 +100,20 @@ export function VerifyPinPage() {
         // sanitizes `next`, we sanitize again here in case a future
         // caller bypasses the route's validateSearch. qa-loop iter-4
         // cluster `users-page-null-map-and-open-redirect`.
-        let target = sanitizeNextParam(next) ?? '/wizard'
+        //
+        // Default landing depends on operating mode:
+        //   • Sovereign Console (chroot, post-handover) → `/dashboard`.
+        //     The operator has just been redirected from the mothership
+        //     handover URL; their Sovereign is converged. Sending them
+        //     to `/wizard` (the mothership new-prov wizard) would
+        //     re-prompt for organisation details on an already-built
+        //     Sovereign and violate D0/D23.  Caught live on t129
+        //     (2026-05-16, BUG-015).
+        //   • Catalyst-Zero (mothership) → keep `/wizard` so PIN-login
+        //     drops the operator into a new-prov flow.
+        const sovereignDefault =
+          DETECTED_MODE.mode === 'sovereign' ? '/dashboard' : '/wizard'
+        let target = sanitizeNextParam(next) ?? sovereignDefault
         if (typeof window !== 'undefined') {
           // window.location.replace is a HARD navigation — it bypasses
           // the TanStack Router's basepath config. On contabo the SPA

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/applicationCatalog.ts
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/applicationCatalog.ts
@@ -81,7 +81,7 @@ export function resolveApplications(
     seen.add(b.id)
     // Look up by bare slug so descriptions / family come from componentGroups
     // when available; fall back to the catalog summary if the component
-    // isn't represented in componentGroups (e.g. bp-bp-catalyst-platform).
+    // isn't represented in componentGroups (e.g. catalyst-platform).
     const bare = b.slug
     const compEntry = findComponent(bare)
     out.push(makeDescriptor({

--- a/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts
@@ -1015,9 +1015,9 @@ export const BOOTSTRAP_KIT: readonly BootstrapKitEntry[] = [
     "order": 12
   },
   {
-    "id": "bp-bp-catalyst-platform",
-    "slug": "bp-catalyst-platform",
-    "label": "bp-catalyst-platform",
+    "id": "bp-catalyst-platform",
+    "slug": "catalyst-platform",
+    "label": "catalyst-platform",
     "file": "13-bp-catalyst-platform.yaml",
     "order": 13
   },
@@ -1169,9 +1169,9 @@ export const BOOTSTRAP_KIT: readonly BootstrapKitEntry[] = [
     "order": 35
   },
   {
-    "id": "bp-bp-cert-manager-powerdns-webhook",
-    "slug": "bp-cert-manager-powerdns-webhook",
-    "label": "bp-cert-manager-powerdns-webhook",
+    "id": "bp-cert-manager-powerdns-webhook",
+    "slug": "cert-manager-powerdns-webhook",
+    "label": "cert-manager-powerdns-webhook",
     "file": "49-bp-cert-manager-powerdns-webhook.yaml",
     "order": 49
   },
@@ -1183,58 +1183,58 @@ export const BOOTSTRAP_KIT: readonly BootstrapKitEntry[] = [
     "order": 50
   },
   {
-    "id": "bp-bp-k8s-ws-proxy",
-    "slug": "bp-k8s-ws-proxy",
-    "label": "bp-k8s-ws-proxy",
+    "id": "bp-k8s-ws-proxy",
+    "slug": "k8s-ws-proxy",
+    "label": "k8s-ws-proxy",
     "file": "51-bp-k8s-ws-proxy.yaml",
     "order": 51
   },
   {
-    "id": "bp-bp-guacamole",
-    "slug": "bp-guacamole",
-    "label": "bp-guacamole",
+    "id": "bp-guacamole",
+    "slug": "guacamole",
+    "label": "guacamole",
     "file": "52-bp-guacamole.yaml",
     "order": 52
   },
   {
-    "id": "bp-bp-dmz-vcluster",
-    "slug": "bp-dmz-vcluster",
-    "label": "bp-dmz-vcluster",
+    "id": "bp-dmz-vcluster",
+    "slug": "dmz-vcluster",
+    "label": "dmz-vcluster",
     "file": "54-bp-dmz-vcluster.yaml",
     "order": 54
   },
   {
-    "id": "bp-bp-hcloud-ccm",
-    "slug": "bp-hcloud-ccm",
-    "label": "bp-hcloud-ccm",
+    "id": "bp-hcloud-ccm",
+    "slug": "hcloud-ccm",
+    "label": "hcloud-ccm",
     "file": "55-bp-hcloud-ccm.yaml",
     "order": 55
   },
   {
-    "id": "bp-bp-openova-flow-server",
-    "slug": "bp-openova-flow-server",
-    "label": "bp-openova-flow-server",
+    "id": "bp-openova-flow-server",
+    "slug": "openova-flow-server",
+    "label": "openova-flow-server",
     "file": "56-bp-openova-flow-server.yaml",
     "order": 56
   },
   {
-    "id": "bp-bp-openova-flow-emitter",
-    "slug": "bp-openova-flow-emitter",
-    "label": "bp-openova-flow-emitter",
+    "id": "bp-openova-flow-emitter",
+    "slug": "openova-flow-emitter",
+    "label": "openova-flow-emitter",
     "file": "57-bp-openova-flow-emitter.yaml",
     "order": 57
   },
   {
-    "id": "bp-bp-mgmt-vcluster",
-    "slug": "bp-mgmt-vcluster",
-    "label": "bp-mgmt-vcluster",
+    "id": "bp-mgmt-vcluster",
+    "slug": "mgmt-vcluster",
+    "label": "mgmt-vcluster",
     "file": "58-bp-mgmt-vcluster.yaml",
     "order": 58
   },
   {
-    "id": "bp-bp-rtz-vcluster",
-    "slug": "bp-rtz-vcluster",
-    "label": "bp-rtz-vcluster",
+    "id": "bp-rtz-vcluster",
+    "slug": "rtz-vcluster",
+    "label": "rtz-vcluster",
     "file": "59-bp-rtz-vcluster.yaml",
     "order": 59
   },


### PR DESCRIPTION
Closes #1546.

## Summary

Three operator-visible SPA routing bugs caught on live t129 Sovereign Console (`t129.omani.works`, 2026-05-16). Shipping in a single PR.

| Bug | DoD | One-line root cause |
|---|---|---|
| BUG-001 | D19 | `build-catalog.mjs::listBootstrapKit` did not strip an optional `bp-` already present on some bootstrap-kit filenames; the captured slug was then re-prefixed → `bp-bp-*` ids in 10 of 44 entries. |
| BUG-015 | D23 (extends D0) | `VerifyPinPage` defaulted to `/wizard` regardless of mode → post-handover PIN-login on a Sovereign Console re-prompted the operator for org details on an already-converged Sovereign. |
| BUG-016 | D24 | `appRoute`'s `/dashboard` child mounted the mothership multi-Sovereign Fleet view (`DashboardPage`). On a Sovereign Console (fleet concept = mothership-only) this surface MUST not be reachable. |

## Changes

**BUG-001** — `products/catalyst/bootstrap/ui/scripts/build-catalog.mjs`
- `listBootstrapKit()` now strips a leading `bp-` from the captured slug before forming the canonical id, so `13-bp-catalyst-platform.yaml` → `id: bp-catalyst-platform, slug: catalyst-platform` (not `bp-bp-catalyst-platform`).
- Regenerated `products/catalyst/bootstrap/ui/src/shared/constants/catalog.generated.ts` + `products/catalyst/bootstrap/api/internal/catalog/blueprints.json`. 10 entries collapse to their canonical single-prefix form: `bp-catalyst-platform`, `bp-cert-manager-powerdns-webhook`, `bp-k8s-ws-proxy`, `bp-guacamole`, `bp-dmz-vcluster`, `bp-hcloud-ccm`, `bp-openova-flow-server`, `bp-openova-flow-emitter`, `bp-mgmt-vcluster`, `bp-rtz-vcluster`. Matches the actual HelmRelease names in `clusters/_template/bootstrap-kit/*.yaml`.
- Removed stale comment referencing `bp-bp-catalyst-platform` in `applicationCatalog.ts`.

**BUG-015** — `products/catalyst/bootstrap/ui/src/pages/auth/VerifyPinPage.tsx`
- After a successful `POST /api/v1/auth/pin/verify`, the default redirect now depends on `DETECTED_MODE.mode`:
  - `'sovereign'` (chroot, post-handover) → `/dashboard` (per-Sovereign landing).
  - `'catalyst-zero'` (mothership) → `/wizard` (unchanged).
- Explicit `?next=` param still takes precedence over both — open-redirect defense via `sanitizeNextParam` unchanged.
- Added `VerifyPinPage.test.tsx` covering all three cases.

**BUG-016** — `products/catalyst/bootstrap/ui/src/app/router.tsx`
- `dashboardRoute` (`/app/dashboard`) now has a `beforeLoad` guard that throws `redirect({ to: '/dashboard' })` when `DETECTED_MODE.mode === 'sovereign'`. Mothership behaviour unchanged.

## Trace-the-chain verification

For each bug we walked back to the deepest layer:

- BUG-001: matrix expected `/app/bp-catalyst-platform`; FE built `\`/app/${app.id}\`` from `applicationCatalog.resolveApplications` → `BOOTSTRAP_KIT` (`catalog.generated.ts`) → `listBootstrapKit()` regex extraction. Fix at the regex layer, not at the AppCard.
- BUG-015: matrix expected post-PIN URL = `/dashboard`; FE used `sanitizeNextParam(next) ?? '/wizard'`. Fix at the redirect-target resolver, branching on mode.
- BUG-016: matrix expected `/app/dashboard` to not expose mothership fleet; route mounting was unconditional. Fix at the route definition with a beforeLoad guard.

## Test plan

- [x] Unit: `VerifyPinPage.test.tsx` — sovereign default → `/dashboard`, catalyst-zero default → `/wizard`, explicit `next=/apps` → `/apps`.
- [x] Catalog regen: `node scripts/build-catalog.mjs` from `products/catalyst/bootstrap/ui/` — no `bp-bp-*` entries remain in JSON output.
- [ ] CI: full vitest + Go test suite (validates the regenerated catalog).
- [ ] Live t129 (post-deploy):
  - [ ] `GET https://console.t129.omani.works/apps` — every `a[href^=\"/app/\"]` has single-prefix form; no `bp-bp-*`.
  - [ ] PIN-login on `https://console.t129.omani.works/login` — successful verify lands on `/dashboard`, not `/wizard`.
  - [ ] `GET https://console.t129.omani.works/app/dashboard` — redirects to `/dashboard` (no fleet view).
- [ ] Mothership regression: `https://console.openova.io/sovereign/provision/<id>/apps` cards still link to `/sovereign/provision/<id>/app/<bp-name>` (unchanged code path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)