### PR TITLE
feat(wizard): default marketplaceEnabled=true for D27 zero-touch

### DIFF
--- a/products/catalyst/bootstrap/ui/src/entities/deployment/model.ts
+++ b/products/catalyst/bootstrap/ui/src/entities/deployment/model.ts
@@ -489,11 +489,11 @@ export const INITIAL_WIZARD_STATE: WizardState = {
   // explicitly for solo dev/POC topologies.
   regions: [], controlPlaneSize: '', workerSize: '', workerCount: 2,
   haEnabled: false, selectedComponents: [...computeDefaultSelection()].sort(),
-  // Marketplace mode (issue #710 wave 3a) — opt-in. Defaults off so a
-  // first-run wizard provisions a private Sovereign; the operator can
-  // flip the toggle on StepMarketplace before launch, and a future
-  // settings page can flip it post-launch without touching the wizard.
-  marketplaceEnabled: false,
+  // Marketplace mode (issue #710 wave 3a) — DEFAULT ON for D27 zero-touch.
+  // Founder ruling 2026-05-16: a Sovereign is provisioned ready to host
+  // tenant organizations (D27-D31). Operator can still flip the toggle
+  // off on StepMarketplace if they explicitly want a private Sovereign.
+  marketplaceEnabled: true,
   marketplaceBrand: { name: '', tagline: '', primaryColor: '' },
   airgap: false,
   currentStep: 1, completedSteps: [], deploymentId: null,

--- a/products/catalyst/bootstrap/ui/src/entities/deployment/store.ts
+++ b/products/catalyst/bootstrap/ui/src/entities/deployment/store.ts
@@ -782,10 +782,11 @@ export const useWizardStore = create<WizardStore>()(
             p.lastProvisionResult = null
           }
           // Marketplace fields added in #710 wave 3a — coerce missing
-          // values on a legacy persisted payload so StepMarketplace and
-          // StepReview never crash on undefined.
+          // values on a legacy persisted payload. D27 zero-touch ruling
+          // 2026-05-16: default true so a fresh wizard hydration provisions
+          // a Sovereign that's ready to host tenant orgs (D29).
           if (typeof p.marketplaceEnabled !== 'boolean') {
-            p.marketplaceEnabled = false
+            p.marketplaceEnabled = true
           }
           if (
             !p.marketplaceBrand ||


### PR DESCRIPTION
## Summary
Founder ruling 2026-05-16: D27 mandates that a fresh wizard provisions a Sovereign already ready to host tenant orgs (D29).

- Wizard store default flipped from `false` → `true`
- Legacy-payload hydration coerces missing field to `true`

Operator can still flip the toggle off on StepMarketplace if they explicitly want a private Sovereign.

## Test plan
- [ ] Validate t132 (next reprov) lands at handover with `marketplace.enabled=true` baked into bp-catalyst-platform postBuild substitute
- [ ] `marketplace.<fqdn>` route returns 200 on t132 chroot

🤖 Generated with [Claude Code](https://claude.com/claude-code)