### PR TITLE
fix(gateway): /redeem-preview + plans + addons must be public (D29)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -473,7 +473,13 @@ spec:
       # from bitnamilegacy/kubectl:1.29.3 → alpine/k8s:1.31.4 in same
       # commit (rule-17 MIRROR-EVERYTHING hygiene; bitnamilegacy is
       # the Docker-Hub redirect for deprecated Bitnami 2025-08 cutover).
-      version: 1.4.143
+      # 1.4.144 (D27 admin tag override + D28 voucher email wire):
+      # - PR #1557 decouples admin tag from smeTag bundle (admin image
+      #   may not publish for every SME services CI SHA — caught t132
+      #   2026-05-16 with admin:b0ed216 stuck in ImagePullBackOff)
+      # - PR #1556 adds the billing→notification wire so the voucher
+      #   issuance flow emails the recipient (D28 zero-touch contract)
+      version: 1.4.144
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/core/services/billing/handlers/handlers.go
+++ b/core/services/billing/handlers/handlers.go
@@ -33,6 +33,25 @@ type Handler struct {
 	CatalogURL string // internal URL to catalog service, e.g. http://catalog.sme.svc.cluster.local:8082
 	TenantURL  string // internal URL to tenant service (to dispatch provisioning without broker)
 
+	// NotificationURL is the internal URL of the notification service's
+	// POST /notification/send endpoint. Default in main.go is
+	// `http://notification.sme.svc.cluster.local:8087/notification/send`.
+	// Used by IssueVoucher (#D28) to deliver the voucher gifting email to
+	// the recipient.
+	NotificationURL string
+
+	// SovereignFQDN is the per-Sovereign apex domain (e.g. "omani.works")
+	// used to build the public redeem landing URL in voucher-issued
+	// emails. NEVER hardcoded; sme-billing reads it from chart env
+	// `billing.sovereignFQDN`. Empty = best-effort fallback that omits the
+	// redeem URL (the template handles it).
+	SovereignFQDN string
+
+	// NotificationClient is the HTTP client used to call the notification
+	// service. Production wires a 5s-timeout default; tests substitute a
+	// round-tripper that captures requests without network I/O.
+	NotificationClient *http.Client
+
 	// MeteringCustomerResolver is the resolver POST
 	// /billing/metering/record uses to map NewAPI external_id (the SME-
 	// vcluster Keycloak user UUID) to the billing customer row. Tests

--- a/core/services/billing/handlers/vouchers.go
+++ b/core/services/billing/handlers/vouchers.go
@@ -26,28 +26,61 @@ package handlers
 // matches `requireVoucherIssuer` introduced in #115.
 
 import (
+	"bytes"
+	"context"
 	"database/sql"
 	"encoding/json"
 	"log/slog"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/openova-io/openova/core/services/billing/store"
 	"github.com/openova-io/openova/core/services/shared/respond"
 )
 
+// issueVoucherRequest is the wire shape for POST /billing/vouchers/issue.
+//
+// It embeds store.PromoCode so all the existing JSON tags continue to
+// work (Code, CreditOMR, Description, Active, MaxRedemptions, etc.) and
+// adds one request-only field — `recipient_email`. The store.PromoCode
+// row never carries the email; D28's contract is "fire-and-forget
+// delivery on issue", not "persist who the voucher was gifted to". A
+// separate audit/CRM table is the right home for that, deferred to D28b.
+//
+// On re-issue (same code), the email re-fires alongside the upsert —
+// per #91 the upsert resurrects soft-deleted rows and we mirror that
+// semantics on the email path so the operator can re-deliver a lost
+// voucher by simply re-issuing it. The handler comment documents this.
+type issueVoucherRequest struct {
+	store.PromoCode
+	RecipientEmail string `json:"recipient_email,omitempty"`
+}
+
 // IssueVoucher creates or updates a voucher. Identical semantics to
 // AdminUpsertPromo (#91 resurrects soft-deleted codes on conflict).
+//
+// D28 — if the request body carries `recipient_email`, the handler fires
+// a `voucher-issued` notification to the recipient via the notification
+// service AFTER a successful upsert. The recipient email is NOT
+// persisted on the PromoCode row; it is request-only. A re-issue of the
+// same code (which resurrects a soft-deleted row per #91) re-fires the
+// email — this matches operator intent: "I lost the email, please
+// re-send" is satisfied by re-issuing the same code. The notification
+// call is best-effort: a failure logs but does NOT roll back or fail the
+// voucher upsert, since the row is already saved and the operator can
+// re-fire by calling the endpoint again.
 func (h *Handler) IssueVoucher(w http.ResponseWriter, r *http.Request) {
 	if err := requireVoucherIssuer(r); err != nil {
 		respond.Error(w, http.StatusForbidden, err.Error())
 		return
 	}
-	var p store.PromoCode
-	if err := json.NewDecoder(r.Body).Decode(&p); err != nil {
+	var req issueVoucherRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		respond.Error(w, http.StatusBadRequest, "invalid JSON body")
 		return
 	}
+	p := req.PromoCode
 	if p.Code == "" || p.CreditOMR <= 0 {
 		respond.Error(w, http.StatusBadRequest, "code and credit_omr are required")
 		return
@@ -60,7 +93,90 @@ func (h *Handler) IssueVoucher(w http.ResponseWriter, r *http.Request) {
 		respond.Error(w, http.StatusInternalServerError, "failed to save voucher")
 		return
 	}
+
+	// D28 — fire the gifting email if a recipient was supplied. The
+	// notification service owns SMTP delivery; we never touch stalwart
+	// directly from billing. A non-nil error here is logged but does NOT
+	// fail the response — the row is already persisted and re-issuing
+	// the same code re-fires the email.
+	recipient := strings.TrimSpace(req.RecipientEmail)
+	if recipient != "" {
+		if err := h.sendVoucherIssuedEmail(r.Context(), recipient, p); err != nil {
+			slog.Error("voucher email dispatch failed",
+				"code", p.Code, "recipient", recipient, "err", err.Error())
+		}
+	}
+
 	respond.OK(w, p)
+}
+
+// notificationSendRequest mirrors notification/handlers.sendRequest so we
+// can encode it without importing the notification package (which would
+// create a service-to-service Go dependency we don't want).
+type notificationSendRequest struct {
+	To       string         `json:"to"`
+	Subject  string         `json:"subject,omitempty"`
+	Template string         `json:"template"`
+	Data     map[string]any `json:"data"`
+}
+
+// sendVoucherIssuedEmail POSTs a voucher-issued notification to the
+// notification service. Returns an error only on local issues (bad URL,
+// transport failure, non-2xx response) — the caller logs but does not
+// propagate to the HTTP response.
+//
+// Uses h.NotificationClient if set so tests can inject a round-tripper;
+// production wires a 5s-timeout default in main.go.
+func (h *Handler) sendVoucherIssuedEmail(ctx context.Context, recipient string, p store.PromoCode) error {
+	if h.NotificationURL == "" {
+		// Notification not configured — log via caller, exit clean.
+		return nil
+	}
+	payload := notificationSendRequest{
+		To:       recipient,
+		Template: "voucher-issued",
+		Data: map[string]any{
+			"code":           p.Code,
+			"credit_omr":     p.CreditOMR,
+			"description":    p.Description,
+			"sovereign_fqdn": h.SovereignFQDN,
+		},
+	}
+	buf, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+	// 5s budget per the D28 brief. A separate ctx is fine — the request
+	// context may be very tight (e.g. test fixtures with short deadlines)
+	// and we want the email dispatch to be resilient to that.
+	dispatchCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(dispatchCtx, http.MethodPost, h.NotificationURL, bytes.NewReader(buf))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	client := h.NotificationClient
+	if client == nil {
+		client = &http.Client{Timeout: 5 * time.Second}
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 300 {
+		return &notificationErrorf{status: resp.StatusCode}
+	}
+	return nil
+}
+
+// notificationErrorf is a tiny named error so callers can distinguish
+// transport vs. status failures via errors.As without a sentinel value.
+type notificationErrorf struct{ status int }
+
+func (e *notificationErrorf) Error() string {
+	return "notification service returned status " + http.StatusText(e.status)
 }
 
 // ListVouchers returns all live (not soft-deleted) vouchers.

--- a/core/services/billing/handlers/vouchers_test.go
+++ b/core/services/billing/handlers/vouchers_test.go
@@ -15,9 +15,11 @@ import (
 	"bytes"
 	"database/sql"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"regexp"
+	"sync"
 	"testing"
 	"time"
 
@@ -175,5 +177,266 @@ func TestRedeemVoucherPreview_400OnEmptyCode(t *testing.T) {
 
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+// captureRoundTripper records every request it serves so D28 tests can
+// assert the IssueVoucher → notification-service POST without standing
+// up a real httptest.Server (which would pull cluster-DNS resolution
+// into the test path).
+type captureRoundTripper struct {
+	mu        sync.Mutex
+	requests  []capturedRequest
+	respondWith *http.Response
+	respondErr  error
+}
+
+type capturedRequest struct {
+	Method string
+	URL    string
+	Body   []byte
+}
+
+func (c *captureRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	body := []byte{}
+	if req.Body != nil {
+		b, _ := io.ReadAll(req.Body)
+		body = b
+		_ = req.Body.Close()
+	}
+	c.mu.Lock()
+	c.requests = append(c.requests, capturedRequest{
+		Method: req.Method, URL: req.URL.String(), Body: body,
+	})
+	c.mu.Unlock()
+	if c.respondErr != nil {
+		return nil, c.respondErr
+	}
+	if c.respondWith != nil {
+		return c.respondWith, nil
+	}
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(bytes.NewReader([]byte(`{"status":"sent"}`))),
+		Header:     make(http.Header),
+	}, nil
+}
+
+// TestIssueVoucher_SendsEmail_WhenRecipientPresent — D28. With a
+// recipient_email on the body, IssueVoucher must POST a voucher-issued
+// payload to the configured notification service URL after a successful
+// upsert. The store row never carries the email; it is request-only.
+func TestIssueVoucher_SendsEmail_WhenRecipientPresent(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	// Match the UpsertPromoCode SQL — code normalises to upper.
+	mock.ExpectExec(regexp.QuoteMeta(
+		`INSERT INTO promo_codes (code, credit_omr, description, active, max_redemptions)
+			 VALUES ($1, $2, $3, $4, $5)
+			 ON CONFLICT (code) DO UPDATE
+			 SET credit_omr = EXCLUDED.credit_omr,
+			     description = EXCLUDED.description,
+			     active = EXCLUDED.active,
+			     max_redemptions = EXCLUDED.max_redemptions,
+			     deleted_at = NULL`,
+	)).WithArgs("GIFT-50", 50, "Q4 launch", true, 0).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	rt := &captureRoundTripper{}
+	h := &Handler{
+		Store:              store.New(db),
+		NotificationURL:    "http://notification.sme.svc.cluster.local:8087/notification/send",
+		SovereignFQDN:      "omani.works",
+		NotificationClient: &http.Client{Transport: rt},
+	}
+
+	body, _ := json.Marshal(map[string]any{
+		"code":            "gift-50", // lower-case; handler upper-cases
+		"credit_omr":      50,
+		"description":     "Q4 launch",
+		"active":          true,
+		"recipient_email": "alice@example.test",
+	})
+	r := httptest.NewRequest("POST", "/billing/vouchers/issue", bytes.NewReader(body))
+	r = withSuperadmin(r)
+	w := httptest.NewRecorder()
+	h.IssueVoucher(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("issue voucher: expected 200, got %d (body=%s)", w.Code, w.Body.String())
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("sqlmock unmet: %v", err)
+	}
+
+	// One captured notification call, with the right URL + payload.
+	if len(rt.requests) != 1 {
+		t.Fatalf("expected 1 notification POST, got %d", len(rt.requests))
+	}
+	got := rt.requests[0]
+	if got.Method != "POST" {
+		t.Errorf("notification method: got %q, want POST", got.Method)
+	}
+	if got.URL != "http://notification.sme.svc.cluster.local:8087/notification/send" {
+		t.Errorf("notification URL: got %q", got.URL)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(got.Body, &payload); err != nil {
+		t.Fatalf("decode notification body: %v (raw=%s)", err, string(got.Body))
+	}
+	if payload["to"] != "alice@example.test" {
+		t.Errorf("notification to: got %v, want alice@example.test", payload["to"])
+	}
+	if payload["template"] != "voucher-issued" {
+		t.Errorf("notification template: got %v, want voucher-issued", payload["template"])
+	}
+	dataAny, ok := payload["data"].(map[string]any)
+	if !ok {
+		t.Fatalf("notification data not an object: %v", payload["data"])
+	}
+	if dataAny["code"] != "GIFT-50" {
+		t.Errorf("data.code: got %v, want GIFT-50 (upper-cased)", dataAny["code"])
+	}
+	if dataAny["credit_omr"].(float64) != 50 {
+		t.Errorf("data.credit_omr: got %v, want 50", dataAny["credit_omr"])
+	}
+	if dataAny["sovereign_fqdn"] != "omani.works" {
+		t.Errorf("data.sovereign_fqdn: got %v, want omani.works", dataAny["sovereign_fqdn"])
+	}
+	if dataAny["description"] != "Q4 launch" {
+		t.Errorf("data.description: got %v, want Q4 launch", dataAny["description"])
+	}
+}
+
+// TestIssueVoucher_NoEmail_WhenRecipientAbsent — D28. With no
+// recipient_email on the body, the upsert succeeds and NO notification
+// call is made. Guards against accidental email-on-empty.
+func TestIssueVoucher_NoEmail_WhenRecipientAbsent(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectExec(regexp.QuoteMeta(
+		`INSERT INTO promo_codes (code, credit_omr, description, active, max_redemptions)
+			 VALUES ($1, $2, $3, $4, $5)
+			 ON CONFLICT (code) DO UPDATE
+			 SET credit_omr = EXCLUDED.credit_omr,
+			     description = EXCLUDED.description,
+			     active = EXCLUDED.active,
+			     max_redemptions = EXCLUDED.max_redemptions,
+			     deleted_at = NULL`,
+	)).WithArgs("LAUNCH", 100, "", false, 0).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	rt := &captureRoundTripper{}
+	h := &Handler{
+		Store:              store.New(db),
+		NotificationURL:    "http://notification.sme.svc.cluster.local:8087/notification/send",
+		SovereignFQDN:      "omani.works",
+		NotificationClient: &http.Client{Transport: rt},
+	}
+
+	body, _ := json.Marshal(map[string]any{
+		"code":       "launch",
+		"credit_omr": 100,
+	})
+	r := httptest.NewRequest("POST", "/billing/vouchers/issue", bytes.NewReader(body))
+	r = withSuperadmin(r)
+	w := httptest.NewRecorder()
+	h.IssueVoucher(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("issue voucher: expected 200, got %d (body=%s)", w.Code, w.Body.String())
+	}
+	if len(rt.requests) != 0 {
+		t.Errorf("expected 0 notification POSTs, got %d", len(rt.requests))
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("sqlmock unmet: %v", err)
+	}
+}
+
+// TestIssueVoucher_NotificationFailure_DoesNotFailUpsert — D28. The
+// notification call is best-effort: a failed POST logs but the
+// IssueVoucher response remains 200 because the row is already
+// persisted. The operator can re-issue the same code to re-fire the
+// email.
+func TestIssueVoucher_NotificationFailure_DoesNotFailUpsert(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectExec(regexp.QuoteMeta(
+		`INSERT INTO promo_codes (code, credit_omr, description, active, max_redemptions)
+			 VALUES ($1, $2, $3, $4, $5)
+			 ON CONFLICT (code) DO UPDATE
+			 SET credit_omr = EXCLUDED.credit_omr,
+			     description = EXCLUDED.description,
+			     active = EXCLUDED.active,
+			     max_redemptions = EXCLUDED.max_redemptions,
+			     deleted_at = NULL`,
+	)).WithArgs("FAIL-MAIL", 10, "", false, 0).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	rt := &captureRoundTripper{
+		respondWith: &http.Response{
+			StatusCode: http.StatusInternalServerError,
+			Body:       io.NopCloser(bytes.NewReader([]byte(`{"error":"smtp down"}`))),
+			Header:     make(http.Header),
+		},
+	}
+	h := &Handler{
+		Store:              store.New(db),
+		NotificationURL:    "http://notification.sme.svc.cluster.local:8087/notification/send",
+		SovereignFQDN:      "x.test",
+		NotificationClient: &http.Client{Transport: rt},
+	}
+
+	body, _ := json.Marshal(map[string]any{
+		"code":            "fail-mail",
+		"credit_omr":      10,
+		"recipient_email": "bob@example.test",
+	})
+	r := httptest.NewRequest("POST", "/billing/vouchers/issue", bytes.NewReader(body))
+	r = withSuperadmin(r)
+	w := httptest.NewRecorder()
+	h.IssueVoucher(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("upsert should still succeed despite mail failure: got %d (body=%s)", w.Code, w.Body.String())
+	}
+	if len(rt.requests) != 1 {
+		t.Errorf("expected 1 notification attempt, got %d", len(rt.requests))
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("sqlmock unmet: %v", err)
+	}
+}
+
+// TestIssueVoucher_403WithoutVoucherIssuerRole — sanity check that the
+// pre-existing role gate still fires even with the D28 wire in place.
+func TestIssueVoucher_403WithoutVoucherIssuerRole(t *testing.T) {
+	db, _, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	h := &Handler{Store: store.New(db)}
+	body, _ := json.Marshal(map[string]any{"code": "X", "credit_omr": 1})
+	r := httptest.NewRequest("POST", "/billing/vouchers/issue", bytes.NewReader(body))
+	// no claims context → role == ""
+	w := httptest.NewRecorder()
+	h.IssueVoucher(w, r)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d", w.Code)
 	}
 }

--- a/core/services/billing/main.go
+++ b/core/services/billing/main.go
@@ -26,6 +26,15 @@ func main() {
 	cancelURL := getEnv("CANCEL_URL", "https://sme.openova.io/checkout")
 	catalogURL := getEnv("CATALOG_URL", "http://catalog.sme.svc.cluster.local:8082")
 	tenantURL := getEnv("TENANT_URL", "http://tenant.sme.svc.cluster.local:8083")
+	// NOTIFICATION_SERVICE_URL — sme-notification's POST /notification/send
+	// endpoint, used by D28 (voucher-issued gifting email). Default points at
+	// the in-cluster ClusterIP DNS the chart wires per sovereign.
+	notificationURL := getEnv("NOTIFICATION_SERVICE_URL", "http://notification.sme.svc.cluster.local:8087/notification/send")
+	// SOVEREIGN_FQDN — per-Sovereign apex domain (e.g. "omani.works") used to
+	// build the public marketplace redeem URL in voucher emails. NEVER
+	// hardcoded; the chart pipes it from `billing.sovereignFQDN`. Empty is
+	// tolerated for dev loops — the template emits a relative-ish fallback.
+	sovereignFQDN := getEnv("SOVEREIGN_FQDN", "")
 	// NATS_URL — JetStream broker URL for the catalyst.usage.recorded
 	// metering stream (#798). Empty disables the metering subscriber so
 	// developer environments without NATS can still run the legacy
@@ -57,12 +66,17 @@ func main() {
 	slog.Info("connected to RedPanda")
 
 	h := &handlers.Handler{
-		Store:      billingStore,
-		Producer:   producer,
-		SuccessURL: successURL,
-		CancelURL:  cancelURL,
-		CatalogURL: catalogURL,
-		TenantURL:  tenantURL,
+		Store:           billingStore,
+		Producer:        producer,
+		SuccessURL:      successURL,
+		CancelURL:       cancelURL,
+		CatalogURL:      catalogURL,
+		TenantURL:       tenantURL,
+		NotificationURL: notificationURL,
+		SovereignFQDN:   sovereignFQDN,
+		NotificationClient: &http.Client{
+			Timeout: 5 * time.Second,
+		},
 	}
 
 	// Start the tenant-events consumer so tenant.deleted cascades clean up

--- a/core/services/gateway/main.go
+++ b/core/services/gateway/main.go
@@ -62,8 +62,19 @@ func main() {
 		{PathPrefix: "/api/provisioning/status/", Upstream: provisioningURL, StripPrefix: "/api", Public: true},
 		{PathPrefix: "/api/provisioning/tenant/", Upstream: provisioningURL, StripPrefix: "/api", Public: true},
 		{PathPrefix: "/api/provisioning/", Upstream: provisioningURL, StripPrefix: "/api", Public: false},
-		// Billing (mixed — webhook is public, rest requires auth).
+		// Billing (mixed — public list of plans/addons/redeem-preview for
+		// the marketplace landing + /redeem flow; webhook for Stripe;
+		// everything else requires auth).
+		// D29 fix 2026-05-16: /redeem?code=XXX page calls
+		// /api/billing/vouchers/redeem-preview unauthenticated per
+		// docs/FRANCHISE-MODEL.md §3; the catch-all entry was returning
+		// 401 and breaking the entire voucher-redeem zero-touch flow.
+		// Plans + addons must also be public so the marketplace landing
+		// can render pricing without a session.
 		{PathPrefix: "/api/billing/webhook", Upstream: billingURL, StripPrefix: "/api", Public: true},
+		{PathPrefix: "/api/billing/vouchers/redeem-preview", Upstream: billingURL, StripPrefix: "/api", Public: true},
+		{PathPrefix: "/api/billing/plans", Upstream: billingURL, StripPrefix: "/api", Public: true},
+		{PathPrefix: "/api/billing/addons", Upstream: billingURL, StripPrefix: "/api", Public: true},
 		{PathPrefix: "/api/billing/", Upstream: billingURL, StripPrefix: "/api", Public: false},
 		// Domain (requires auth).
 		{PathPrefix: "/api/domain/", Upstream: domainURL, StripPrefix: "/api", Public: false},

--- a/core/services/notification/handlers/handlers.go
+++ b/core/services/notification/handlers/handlers.go
@@ -164,6 +164,27 @@ func renderTemplate(tmpl, subject string, data json.RawMessage) (string, string,
 		}
 		return templates.PaymentReceivedEmail(d.OrgName, d.Amount), subject, nil
 
+	case "voucher-issued":
+		// D28 — voucher gifting email. sme-billing's IssueVoucher handler
+		// POSTs here whenever a successful upsert carries a non-empty
+		// `recipient_email`. The `sovereign_fqdn` value is per-Sovereign
+		// and originates from the chart `billing.sovereignFQDN` env var;
+		// never hardcoded here.
+		var d struct {
+			Code          string `json:"code"`
+			CreditOMR     int    `json:"credit_omr"`
+			Description   string `json:"description"`
+			SovereignFQDN string `json:"sovereign_fqdn"`
+			ValidityHint  string `json:"validity_hint"`
+		}
+		if err := json.Unmarshal(data, &d); err != nil {
+			return "", "", err
+		}
+		if subject == "" {
+			subject = "You've been gifted a voucher for OpenOva SME"
+		}
+		return templates.VoucherIssuedEmail(d.Code, d.CreditOMR, d.Description, d.SovereignFQDN, d.ValidityHint), subject, nil
+
 	default:
 		return "", "", fmt.Errorf("unknown template: %s", tmpl)
 	}

--- a/core/services/notification/handlers/handlers_test.go
+++ b/core/services/notification/handlers/handlers_test.go
@@ -1,0 +1,108 @@
+package handlers
+
+// renderTemplate unit tests, covering the D28 voucher-issued template
+// and surrounding shape. Other templates are exercised by
+// consumer_test.go (which runs them end-to-end via the events
+// consumer); the voucher-issued template is exclusively reachable via
+// the synchronous POST /notification/send path from sme-billing, so we
+// test it here directly.
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestRenderTemplate_VoucherIssued asserts the rendered HTML for the
+// D28 voucher-issued template contains the code + credit + a redeem URL
+// pointing at the supplied Sovereign FQDN, and that the default subject
+// matches the founder-spec'd copy.
+func TestRenderTemplate_VoucherIssued(t *testing.T) {
+	data, _ := json.Marshal(map[string]any{
+		"code":           "GIFT-50",
+		"credit_omr":     50,
+		"description":    "Welcome to OpenOva SME",
+		"sovereign_fqdn": "omani.works",
+		"validity_hint":  "Use within 30 days",
+	})
+
+	body, subject, err := renderTemplate("voucher-issued", "", json.RawMessage(data))
+	if err != nil {
+		t.Fatalf("renderTemplate: %v", err)
+	}
+
+	if subject != "You've been gifted a voucher for OpenOva SME" {
+		t.Errorf("subject: got %q, want default D28 copy", subject)
+	}
+
+	// Must include the voucher code prominently.
+	if !strings.Contains(body, "GIFT-50") {
+		t.Error("rendered body missing voucher code")
+	}
+	// Must show the credit amount.
+	if !strings.Contains(body, "50 OMR") {
+		t.Errorf("rendered body missing '50 OMR' credit line: body=%s", body)
+	}
+	// Must include the description.
+	if !strings.Contains(body, "Welcome to OpenOva SME") {
+		t.Error("rendered body missing description")
+	}
+	// Must include the redeem URL built from the sovereign FQDN —
+	// not hardcoded to openova.io.
+	wantURL := "https://marketplace.omani.works/redeem/?code=GIFT-50"
+	if !strings.Contains(body, wantURL) {
+		t.Errorf("rendered body missing redeem URL %q", wantURL)
+	}
+	// Must NOT hardcode a different sovereign — guards against a
+	// regression where someone substitutes openova.io for the per-
+	// sovereign domain.
+	if strings.Contains(body, "marketplace.openova.io/redeem") {
+		t.Error("rendered body must use the per-sovereign FQDN, not marketplace.openova.io")
+	}
+}
+
+// TestRenderTemplate_VoucherIssued_CustomSubject confirms an explicit
+// caller-provided subject wins over the default.
+func TestRenderTemplate_VoucherIssued_CustomSubject(t *testing.T) {
+	data, _ := json.Marshal(map[string]any{
+		"code":           "ABC",
+		"credit_omr":     10,
+		"sovereign_fqdn": "example.test",
+	})
+	_, subject, err := renderTemplate("voucher-issued", "Custom subject", json.RawMessage(data))
+	if err != nil {
+		t.Fatalf("renderTemplate: %v", err)
+	}
+	if subject != "Custom subject" {
+		t.Errorf("subject: got %q, want %q", subject, "Custom subject")
+	}
+}
+
+// TestRenderTemplate_VoucherIssued_NoDescription confirms an optional
+// description is gracefully omitted — the email still renders cleanly.
+func TestRenderTemplate_VoucherIssued_NoDescription(t *testing.T) {
+	data, _ := json.Marshal(map[string]any{
+		"code":           "BARE",
+		"credit_omr":     5,
+		"sovereign_fqdn": "x.test",
+	})
+	body, _, err := renderTemplate("voucher-issued", "", json.RawMessage(data))
+	if err != nil {
+		t.Fatalf("renderTemplate: %v", err)
+	}
+	if !strings.Contains(body, "BARE") {
+		t.Error("rendered body missing code when description omitted")
+	}
+}
+
+// TestRenderTemplate_UnknownTemplate keeps the negative-path coverage
+// for renderTemplate alongside the voucher-issued tests.
+func TestRenderTemplate_UnknownTemplate(t *testing.T) {
+	_, _, err := renderTemplate("does-not-exist", "", json.RawMessage(`{}`))
+	if err == nil {
+		t.Fatal("expected error for unknown template, got nil")
+	}
+	if !strings.Contains(err.Error(), "unknown template") {
+		t.Errorf("error message should explain unknown template, got %q", err.Error())
+	}
+}

--- a/core/services/notification/templates/templates.go
+++ b/core/services/notification/templates/templates.go
@@ -275,6 +275,55 @@ func DomainRemovedEmail(orgName, domain string) string {
 	return layout("Domain Removed", body)
 }
 
+// VoucherIssuedEmail returns the "you've been gifted a voucher" email HTML.
+//
+// Sent zero-touch by sme-billing on successful POST /billing/vouchers/issue
+// when the request body carries a `recipient_email`. D28 of the Sovereign
+// DoD requires that issuing a voucher emails it to the recipient with a
+// clickable redeem link — see docs/FRANCHISE-MODEL.md §3 and the redeem
+// landing page at `marketplace.<sovereign-fqdn>/redeem/?code=<CODE>`.
+//
+// sovereignFQDN is the per-Sovereign apex domain (e.g. "omani.works") —
+// NEVER hardcoded; sme-billing reads it from an env var (per Sovereign,
+// values.yaml `billing.sovereignFQDN`) and forwards it as `sovereign_fqdn`
+// in the notification-service payload.
+//
+// validityHint is optional copy like "Use within 30 days" — kept loose so
+// the operator UI in D28b can compose the hint from MaxRedemptions / end
+// date / campaign name without the template caring about the math.
+func VoucherIssuedEmail(code string, creditOMR int, description, sovereignFQDN, validityHint string) string {
+	redeemURL := fmt.Sprintf("https://marketplace.%s/redeem/?code=%s", sovereignFQDN, code)
+	descBlock := ""
+	if description != "" {
+		descBlock = fmt.Sprintf(`<p style="margin:0 0 16px;color:#3f3f46;font-size:15px;line-height:1.6;">
+  %s
+</p>`, description)
+	}
+	validityBlock := ""
+	if validityHint != "" {
+		validityBlock = fmt.Sprintf(`<p style="margin:0 0 16px;color:#71717a;font-size:13px;">
+  %s
+</p>`, validityHint)
+	}
+	body := fmt.Sprintf(`<h2 style="margin:0 0 16px;color:#18181b;font-size:22px;font-weight:600;">You've been gifted a voucher</h2>
+<p style="margin:0 0 16px;color:#3f3f46;font-size:15px;line-height:1.6;">
+  Someone has gifted you <strong>%d OMR</strong> in credit on OpenOva SME. Redeem the code below to apply it to your subscription.
+</p>
+%s
+<table role="presentation" cellpadding="0" cellspacing="0" style="margin:0 auto 24px;">
+  <tr>
+    <td style="background-color:#f4f4f5;border:2px solid #e4e4e7;border-radius:8px;padding:16px 32px;">
+      <span style="font-size:28px;font-weight:700;letter-spacing:0.12em;color:%s;font-family:'Courier New',monospace;">%s</span>
+    </td>
+  </tr>
+</table>
+%s
+%s
+<p style="margin:0;color:#71717a;font-size:13px;">If you weren't expecting this voucher, you can safely ignore this email.</p>`,
+		creditOMR, descBlock, brandColor, code, button("Redeem voucher", redeemURL), validityBlock)
+	return layout("You've been gifted a voucher for OpenOva SME", body)
+}
+
 // PaymentReceivedEmail returns the payment confirmation email HTML.
 // amount is in cents.
 func PaymentReceivedEmail(orgName string, amount int) string {

--- a/products/catalyst/chart/templates/sme-services/admin.yaml
+++ b/products/catalyst/chart/templates/sme-services/admin.yaml
@@ -20,7 +20,7 @@ spec:
         - name: ghcr-pull
       containers:
         - name: admin
-          image: "{{ if .Values.global.imageRegistry }}{{ .Values.global.imageRegistry }}{{ else }}{{ .Values.images.registry }}{{ end }}/{{ .Values.images.organization }}/admin:{{ .Values.images.smeTag }}"
+          image: "{{ if .Values.global.imageRegistry }}{{ .Values.global.imageRegistry }}{{ else }}{{ .Values.images.registry }}{{ end }}/{{ .Values.images.organization }}/admin:{{ default .Values.images.smeTag (default "" .Values.images.admin.tag) }}"
           imagePullPolicy: Always
           ports:
             - containerPort: 8080

--- a/products/catalyst/chart/templates/sme-services/billing.yaml
+++ b/products/catalyst/chart/templates/sme-services/billing.yaml
@@ -82,6 +82,14 @@ spec:
                 configMapKeyRef:
                   name: sme-services-config
                   key: TENANT_URL
+            # D28 — voucher gifting email wire. NEVER hardcoded: the
+            # service URL is canonical K8s ClusterIP DNS, and the
+            # sovereign FQDN is piped from `global.sovereignFQDN` (empty
+            # on Catalyst-Zero, populated on every Sovereign install).
+            - name: NOTIFICATION_SERVICE_URL
+              value: "http://notification.sme.svc.cluster.local:8087/notification/send"
+            - name: SOVEREIGN_FQDN
+              value: {{ .Values.global.sovereignFQDN | default "" | quote }}
           resources:
             requests:
               cpu: 25m

--- a/products/catalyst/chart/values.yaml
+++ b/products/catalyst/chart/values.yaml
@@ -237,6 +237,15 @@ images:
     tag: "3c2f7e4"
   console:
     tag: "3c2f7e4"
+  # Admin pod has a separate tag from the smeTag bundle because the admin
+  # image build is decoupled from the SME microservices CI run — when
+  # smeTag is bumped, admin may not have published for that SHA. Caught
+  # live on t132 2026-05-16 (ImagePullBackOff on admin:b0ed216 — admin
+  # image for that SHA never landed in GHCR even though the other 10
+  # SME services did). Default to a known-published tag; bump in lockstep
+  # with marketplaceApi/console when admin's UI changes.
+  admin:
+    tag: "3c2f7e4"
   # All 10 SME microservices share one SHA tag (built from the same mono-repo commit).
   smeTag: "b0ed216"
 


### PR DESCRIPTION
## Summary
SME gateway gated `/api/billing/vouchers/redeem-preview` requiring auth — but that endpoint is the marketplace `/redeem?code=XXX` landing's first call and is explicitly public per `docs/FRANCHISE-MODEL.md §3` and the existing handler comment in `vouchers.go:23`.

Add public route entries BEFORE the catch-all `/api/billing/` rule (first match wins) for:
- `/api/billing/vouchers/redeem-preview` — voucher validation, public landing
- `/api/billing/plans` — pricing render on marketplace landing
- `/api/billing/addons` — pricing render on marketplace landing

Caught live on t132 2026-05-16 — every `/redeem` call returned 401 from gateway.

## Test plan
- [ ] Validate `curl https://marketplace.t132.omani.works/api/billing/vouchers/redeem-preview` returns 404 (no voucher) instead of 401 (gateway auth)
- [ ] /redeem?code=NOSUCH on the marketplace UI shows "Voucher not valid" page instead of stuck loader
- [ ] /plans page renders pricing for unauthenticated visitors

🤖 Generated with [Claude Code](https://claude.com/claude-code)