### PR TITLE
fix(billing): /redeem-preview + plans + addons bypass JWT (D29)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -473,13 +473,18 @@ spec:
       # from bitnamilegacy/kubectl:1.29.3 → alpine/k8s:1.31.4 in same
       # commit (rule-17 MIRROR-EVERYTHING hygiene; bitnamilegacy is
       # the Docker-Hub redirect for deprecated Bitnami 2025-08 cutover).
+      # 1.4.145 (D29 gateway public routes for redeem flow):
+      # - PR #1559 makes /api/billing/{vouchers/redeem-preview,plans,addons}
+      #   public so the marketplace /redeem?code=XXX landing can validate
+      #   codes without auth (the entire D29 voucher-redeem zero-touch
+      #   flow is broken without this)
       # 1.4.144 (D27 admin tag override + D28 voucher email wire):
       # - PR #1557 decouples admin tag from smeTag bundle (admin image
       #   may not publish for every SME services CI SHA — caught t132
       #   2026-05-16 with admin:b0ed216 stuck in ImagePullBackOff)
       # - PR #1556 adds the billing→notification wire so the voucher
       #   issuance flow emails the recipient (D28 zero-touch contract)
-      version: 1.4.144
+      version: 1.4.145
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/core/services/billing/main.go
+++ b/core/services/billing/main.go
@@ -160,9 +160,21 @@ func main() {
 	billingRoutes := h.Routes()
 	jwtMiddleware := middleware.JWTAuth(jwtSecret)
 
+	// Public paths that bypass JWT validation. These match the gateway's
+	// public routes (D29 voucher-redeem zero-touch flow). The gateway
+	// passes these through with no auth header; this service must accept
+	// them OR the marketplace /redeem landing returns 401 to unauth visitors.
+	// Caught live on t132 2026-05-16 after PR #1559 made the gateway public —
+	// the billing service was still JWT-gating internally.
+	publicBillingPaths := map[string]bool{
+		"/billing/webhook":                  true, // Stripe (sig-verified)
+		"/billing/vouchers/redeem-preview":  true, // D29 voucher landing
+		"/billing/plans":                    true, // marketplace pricing
+		"/billing/addons":                   true, // marketplace add-on pricing
+	}
+
 	mux.Handle("/billing/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Webhook endpoint is public (Stripe signature verification handles auth).
-		if r.URL.Path == "/billing/webhook" && r.Method == http.MethodPost {
+		if publicBillingPaths[r.URL.Path] {
 			billingRoutes.ServeHTTP(w, r)
 			return
 		}


### PR DESCRIPTION
Mirror PR #1559's gateway public routes in the billing service's own middleware chain. Without this, redeem-preview / plans / addons still get 401 from billing service's internal JWT gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)