### PR TITLE
chore(slot-13): pin bp-catalyst-platform to 1.4.146 (D29 billing JWT bypass)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -473,6 +473,10 @@ spec:
       # from bitnamilegacy/kubectl:1.29.3 → alpine/k8s:1.31.4 in same
       # commit (rule-17 MIRROR-EVERYTHING hygiene; bitnamilegacy is
       # the Docker-Hub redirect for deprecated Bitnami 2025-08 cutover).
+      # 1.4.146 (D29 billing internal JWT bypass for public routes):
+      # - PR #1561 mirrors PR #1559's gateway public routes in the billing
+      #   service's own JWT middleware. Without this, the gateway passed
+      #   through but billing still 401-d.
       # 1.4.145 (D29 gateway public routes for redeem flow):
       # - PR #1559 makes /api/billing/{vouchers/redeem-preview,plans,addons}
       #   public so the marketplace /redeem?code=XXX landing can validate
@@ -484,7 +488,7 @@ spec:
       #   2026-05-16 with admin:b0ed216 stuck in ImagePullBackOff)
       # - PR #1556 adds the billing→notification wire so the voucher
       #   issuance flow emails the recipient (D28 zero-touch contract)
-      version: 1.4.145
+      version: 1.4.146
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform


### PR DESCRIPTION
PR #1561 mirrored #1559 in billing-service. Pin slot so future provs inherit full D29 unblocker chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)