### PR TITLE
fix(chroot): populate deployment Result + Request fields for D22 settings

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -473,6 +473,11 @@ spec:
       # from bitnamilegacy/kubectl:1.29.3 → alpine/k8s:1.31.4 in same
       # commit (rule-17 MIRROR-EVERYTHING hygiene; bitnamilegacy is
       # the Docker-Hub redirect for deprecated Bitnami 2025-08 cutover).
+      # 1.4.147 (D31 wordpress-tenant activeHotStandby + D21 owner auto-seed):
+      # - PR #1562 wires bp-cnpg-pair Primary+Replica pattern into
+      #   wordpress-tenant chart via pg.activeHotStandby knob
+      # - PR #1564 baked into catalyst-api:8d2a947 — handover now
+      #   auto-seeds the operator's UserAccess CR (D21 zero-touch)
       # 1.4.146 (D29 billing internal JWT bypass for public routes):
       # - PR #1561 mirrors PR #1559's gateway public routes in the billing
       #   service's own JWT middleware. Without this, the gateway passed
@@ -488,7 +493,7 @@ spec:
       #   2026-05-16 with admin:b0ed216 stuck in ImagePullBackOff)
       # - PR #1556 adds the billing→notification wire so the voucher
       #   issuance flow emails the recipient (D28 zero-touch contract)
-      version: 1.4.146
+      version: 1.4.147
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/bootstrap/api/internal/handler/auth_handover.go
+++ b/products/catalyst/bootstrap/api/internal/handler/auth_handover.go
@@ -239,6 +239,18 @@ func (h *Handler) AuthHandover(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// ── 5b. Auto-seed owner UserAccess CR (D21) ─────────────────────────
+	// D21 (docs/SOVEREIGN-MULTI-REGION-DOD.md) requires Sovereign Console
+	// /users to list the operator who PIN-logged-in as tier=owner. The
+	// useraccess Composition (issue #322) reconciles the CR into
+	// per-app RoleBindings on the Sovereign cluster.
+	//
+	// Best-effort: any error here MUST NOT fail the handover — the
+	// operator's session is more important than the CR. If the
+	// access.openova.io CRD has not rolled yet, the next handover will
+	// succeed once the chart catches up. See user_access_owner_seed.go.
+	h.seedOwnerUserAccess(r.Context(), claims.Email, claims.SovereignFQDN, claims.DeploymentID)
+
 	// ── 6. Mint local session JWT ───────────────────────────────────────
 	// Keycloak v26 dropped the legacy `requested_subject` token-exchange
 	// flow ("Parameter 'requested_subject' is not supported for standard
@@ -312,6 +324,47 @@ func (h *Handler) AuthHandover(w http.ResponseWriter, r *http.Request) {
 		redirectTarget = "/dashboard"
 	}
 	http.Redirect(w, r, redirectTarget, http.StatusFound)
+}
+
+// seedOwnerUserAccess upserts a tier=owner UserAccess CR for the
+// operator who just completed handover (D21).
+//
+// Best-effort: every failure mode logs a Warn and returns; the handover
+// itself is never failed because the operator's session is more
+// important than this CR. The next handover will retry idempotently.
+//
+// On the Sovereign chroot, `lookupDeploymentForInfra(depID)` synthesises
+// an in-memory Deployment from SOVEREIGN_FQDN when one isn't already
+// loaded (see infrastructure.go:1776 `chrootEnsureDeployment`), so
+// `sovereignDynamicClient(dep)` routes through the in-cluster client.
+func (h *Handler) seedOwnerUserAccess(ctx context.Context, email, sovereignFQDN, depID string) {
+	if email == "" {
+		h.log.Debug("user-access: owner seed skipped — empty email")
+		return
+	}
+	if depID == "" {
+		h.log.Debug("user-access: owner seed skipped — empty deployment id")
+		return
+	}
+	dep, ok := h.lookupDeploymentForInfra(depID)
+	if !ok || dep == nil {
+		h.log.Warn("user-access: owner seed skipped — deployment not resolvable",
+			"depId", depID)
+		return
+	}
+	client, err := h.sovereignDynamicClient(dep)
+	if err != nil {
+		h.log.Warn("user-access: owner seed dynamic client unavailable",
+			"depId", depID, "err", err)
+		return
+	}
+	if err := EnsureOwnerUserAccess(ctx, client, email, sovereignFQDN); err != nil {
+		h.log.Warn("user-access: owner seed failed",
+			"depId", depID, "email", email, "err", err)
+		return
+	}
+	h.log.Info("user-access: owner auto-seeded",
+		"depId", depID, "email", email)
 }
 
 // ────────────────────────────────────────────────────────────────────────────

--- a/products/catalyst/bootstrap/api/internal/handler/jobs.go
+++ b/products/catalyst/bootstrap/api/internal/handler/jobs.go
@@ -93,18 +93,48 @@ func (h *Handler) chrootEnsureDeployment(depID string) *Deployment {
 	// canonical Sovereign ingress LB being allocated and serving
 	// console/auth/gitea hostnames.
 	lbIP := strings.TrimSpace(os.Getenv("SOVEREIGN_LB_IP"))
+	// D22 (settings empty values) — populate ConsoleURL + GitOpsRepoURL +
+	// ControlPlaneIP from env vars threaded in by bp-catalyst-platform.
+	// Without these, the chroot's GET /api/v1/deployments/<id> returns
+	// empty strings and the Sovereign Console Settings page renders `—`
+	// placeholders for every Sovereign field. ConsoleURL is derived
+	// (canonical `https://console.<fqdn>`); the rest come from env (empty
+	// when chart hasn't wired them yet, which is no worse than today).
+	consoleURL := ""
+	if selfFQDN != "" {
+		consoleURL = "https://console." + selfFQDN
+	}
+	gitopsRepoURL := strings.TrimSpace(os.Getenv("GITOPS_REPO_URL"))
+	cpIP := strings.TrimSpace(os.Getenv("SOVEREIGN_CONTROL_PLANE_IP"))
 	var result *provisioner.Result
-	if lbIP != "" || selfFQDN != "" {
+	if lbIP != "" || selfFQDN != "" || consoleURL != "" || gitopsRepoURL != "" || cpIP != "" {
 		result = &provisioner.Result{
 			SovereignFQDN:  selfFQDN,
 			LoadBalancerIP: lbIP,
+			ConsoleURL:     consoleURL,
+			GitOpsRepoURL:  gitopsRepoURL,
+			ControlPlaneIP: cpIP,
 		}
+	}
+	// D22 — populate Request fields that flow into the Settings page
+	// (OrgEmail / OrgName / Region). OrgEmail + OrgName from env;
+	// Region from regions[0].CloudRegion when regions is non-empty so
+	// the top-level legacy field matches the canonical multi-region
+	// shape's primary region.
+	orgEmail := strings.TrimSpace(os.Getenv("OPERATOR_EMAIL"))
+	orgName := strings.TrimSpace(os.Getenv("ORG_NAME"))
+	primaryRegion := ""
+	if len(regions) > 0 {
+		primaryRegion = regions[0].CloudRegion
 	}
 	dep := &Deployment{
 		ID: depID,
 		Request: provisioner.Request{
 			SovereignFQDN: selfFQDN,
 			Regions:       regions,
+			Region:        primaryRegion,
+			OrgEmail:      orgEmail,
+			OrgName:       orgName,
 		},
 		Result:   result,
 		Status:   "ready",

--- a/products/catalyst/bootstrap/api/internal/handler/user_access_owner_seed.go
+++ b/products/catalyst/bootstrap/api/internal/handler/user_access_owner_seed.go
@@ -1,0 +1,190 @@
+// user_access_owner_seed.go — auto-seed owner UserAccess CR on chroot
+// at handover (DoD gate D21).
+//
+// D21 (docs/SOVEREIGN-MULTI-REGION-DOD.md):
+//
+//	"Sovereign Console /users MUST list the operator who completed
+//	 PIN-login as tier=owner with their email."
+//
+// Verified on t132 (2026-05-16) that a fresh Sovereign returns
+// `{"items":[]}` from /admin/user-access — Keycloak group membership in
+// `sovereign-admins` is established by the handover flow, but no
+// UserAccess CR exists for the operator, so the /users page is empty.
+//
+// This helper closes the gap: after auth_handover.go's
+// `keycloak.EnsureUser` succeeds, it upserts a UserAccess CR that the
+// existing useraccess Composition (issue #322) reconciles into per-app
+// RoleBindings on the Sovereign cluster, so the operator surfaces in
+// /users as the canonical owner-tier identity.
+//
+// # Architect-first
+//
+// The CR shape mirrors `userAccessToUnstructured` in user_access.go
+// verbatim — same group/version/kind, same `spec.user`,
+// `spec.sovereignRef`, `spec.applications` keys, same dynamic-client
+// seam used by `CreateUserAccess`. The CR's owner-tier hint is stamped
+// via `catalyst.openova.io/user-email` annotation, matching the read
+// pattern at rbac_matrix.go:309-315 (rbacAssignReadEmailHint).
+//
+// # Tier mapping
+//
+// The 5-tier RBAC model (rbac_matrix.go:282 canonicalTierOrder) places
+// `owner` at level 50, but the UserAccess CRD's per-application grant
+// (user_access.go:86-90 userAccessRoles) only accepts admin|editor|viewer.
+// The same lossy mapping `userAccessTierToRole("owner") → "admin"`
+// (user_access.go:379-387) is used here for the wildcard "*" app entry.
+// The /rbac/assign path remains the canonical way to bind the owner
+// tier ClusterRole directly; this helper is just enough to make the
+// operator visible in /users on first handover.
+//
+// # Idempotency
+//
+// Multiple handovers of the same operator (e.g. re-handover after a
+// browser session expires) MUST NOT error. AlreadyExists on Create is
+// folded to a nil return. The helper is safe to call on every handover.
+//
+// # Best-effort
+//
+// If the UserAccess CRD is not installed yet (the access.openova.io
+// chart may roll later than catalyst-api), or the dynamic client is
+// unavailable for any other reason, the helper returns an error. The
+// caller (auth_handover.go) MUST log and continue — the operator's
+// session is more important than this CR, and D21 will be satisfied on
+// the next handover after the CRD rolls.
+package handler
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/dynamic"
+)
+
+// userAccessOwnerEmailAnnotation is the canonical key the rbac_matrix
+// reader (rbac_matrix.go:309-315) looks up to surface a UserAccess CR's
+// human-readable email on the /users page.
+const userAccessOwnerEmailAnnotation = "catalyst.openova.io/user-email"
+
+// userAccessOwnerNamePrefix is the deterministic name prefix for the
+// auto-seeded owner CR. The full name is
+// `useraccess-owner-<sanitized-email>` truncated to RFC 1123's 63-char
+// limit (the apiserver rejects longer names with a 422).
+const userAccessOwnerNamePrefix = "useraccess-owner-"
+
+// EnsureOwnerUserAccess creates an owner-tier UserAccess CR for the
+// operator who just completed PIN-login + handover, if one does not
+// already exist. Idempotent: AlreadyExists is folded to a nil return.
+//
+// The CR shape:
+//
+//	apiVersion: access.openova.io/v1alpha1
+//	kind: UserAccess
+//	metadata:
+//	  name: useraccess-owner-<sanitized-email>
+//	  annotations:
+//	    catalyst.openova.io/user-email: <email>
+//	spec:
+//	  user:
+//	    keycloakSubject: <email>        # realm uses email-as-username
+//	  sovereignRef: <fqdn-first-label>  # rbacAssignSlug-equivalent
+//	  applications:
+//	    - app: "*"                      # wildcard: every Application
+//	      role: admin                   # owner → admin per tierToRole
+//
+// sovereignRef is derived from sovereignFQDN's first DNS label, matching
+// rbacAssignSlug at rbac_assign.go:986-995 so the same provider-kubernetes
+// ProviderConfig (`sovereign-<slug>`) resolves the Claim.
+//
+// Per docs/INVIOLABLE-PRINCIPLES.md #10 (credential hygiene) the
+// operator's email is logged at Info, never the JWT contents.
+func EnsureOwnerUserAccess(ctx context.Context, client dynamic.Interface, email, sovereignFQDN string) error {
+	email = strings.TrimSpace(email)
+	if email == "" {
+		return fmt.Errorf("EnsureOwnerUserAccess: email is required")
+	}
+	if client == nil {
+		return fmt.Errorf("EnsureOwnerUserAccess: dynamic client is nil")
+	}
+
+	name := ownerUserAccessName(email)
+	sovRef := rbacAssignSlug(sovereignFQDN)
+
+	obj := buildOwnerUserAccessUnstructured(name, email, sovRef)
+
+	_, err := client.Resource(UserAccessGVR()).
+		Namespace("").
+		Create(ctx, obj, metav1.CreateOptions{})
+	if err != nil {
+		if apierrors.IsAlreadyExists(err) {
+			// Re-handover for the same operator: nothing to do.
+			return nil
+		}
+		return fmt.Errorf("create owner UserAccess %q: %w", name, err)
+	}
+	return nil
+}
+
+// ownerUserAccessName builds the deterministic owner-CR name. The full
+// pattern is `useraccess-owner-<sanitized-email>` truncated to 63 chars
+// per RFC 1123 (the apiserver rejects longer names with a 422). The
+// sanitized email is lowercase alphanumeric + hyphens, hyphen-trimmed
+// at both ends (sanitizeK8sNameSegment from rbac_assign.go:936-951).
+func ownerUserAccessName(email string) string {
+	lower := strings.ToLower(strings.TrimSpace(email))
+	// Translate the structural separators into hyphens BEFORE
+	// sanitizeK8sNameSegment strips them — otherwise
+	// `emrah.baysal@openova.io` collapses to `emrahbaysalopenovaio`
+	// and loses every token boundary that makes the resulting CR name
+	// human-scannable.
+	lower = strings.ReplaceAll(lower, "@", "-at-")
+	lower = strings.ReplaceAll(lower, ".", "-")
+	emailSegment := sanitizeK8sNameSegment(lower)
+	full := userAccessOwnerNamePrefix + emailSegment
+	if len(full) > 63 {
+		full = full[:63]
+	}
+	// After truncation a trailing hyphen is illegal; trim any.
+	full = strings.TrimRight(full, "-")
+	if full == strings.TrimRight(userAccessOwnerNamePrefix, "-") {
+		// Pathological: email sanitized to empty string. Fall back to a
+		// stable literal so the CR still gets created (matches the
+		// `sanitizeK8sNameSegment → "user"` fallback in rbacAssignName).
+		full = userAccessOwnerNamePrefix + "operator"
+	}
+	return full
+}
+
+// buildOwnerUserAccessUnstructured composes the dynamic-client payload
+// for the owner CR. Shape mirrors userAccessToUnstructured exactly so
+// the existing Composition (issue #322) reconciles it without surprise.
+func buildOwnerUserAccessUnstructured(name, email, sovereignRef string) *unstructured.Unstructured {
+	obj := &unstructured.Unstructured{}
+	obj.SetAPIVersion(userAccessGroup + "/" + userAccessVersion)
+	obj.SetKind("UserAccess")
+	obj.SetName(name)
+	obj.SetAnnotations(map[string]string{
+		userAccessOwnerEmailAnnotation: email,
+	})
+
+	spec := map[string]any{
+		"user": map[string]any{
+			// Keycloak issues subjects equal to the email when the realm
+			// uses email-as-username, which is the default for
+			// OpenOva-shipped Sovereigns (see user_access.go:103-105).
+			"keycloakSubject": email,
+		},
+		"sovereignRef": sovereignRef,
+		"applications": []any{
+			map[string]any{
+				"app":  "*",
+				"role": "admin", // owner → admin per userAccessTierToRole
+			},
+		},
+	}
+	_ = unstructured.SetNestedMap(obj.Object, spec, "spec")
+	return obj
+}

--- a/products/catalyst/bootstrap/api/internal/handler/user_access_owner_seed_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/user_access_owner_seed_test.go
@@ -1,0 +1,219 @@
+// user_access_owner_seed_test.go — coverage for EnsureOwnerUserAccess
+// (D21). Mirrors user_access_test.go's fake-dynamic-client pattern:
+// register the UserAccess GVR's list-kind on a scheme, seed (or don't)
+// an existing CR, call the helper, assert the CR's shape via the same
+// dynamic client.
+package handler
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	clienttesting "k8s.io/client-go/testing"
+)
+
+func newOwnerSeedFakeClient(seed ...runtime.Object) *dynamicfake.FakeDynamicClient {
+	scheme := runtime.NewScheme()
+	return dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, map[schema.GroupVersionResource]string{
+		UserAccessGVR(): "UserAccessList",
+	}, seed...)
+}
+
+// TestEnsureOwnerUserAccess_CreatesCanonicalCR proves a fresh seed
+// produces a CR with the canonical shape (correct name, email
+// annotation, keycloakSubject, sovereignRef, wildcard app entry,
+// admin role).
+func TestEnsureOwnerUserAccess_CreatesCanonicalCR(t *testing.T) {
+	client := newOwnerSeedFakeClient()
+
+	const email = "emrah.baysal@openova.io"
+	const sov = "omantel.omani.works"
+	if err := EnsureOwnerUserAccess(context.Background(), client, email, sov); err != nil {
+		t.Fatalf("EnsureOwnerUserAccess: unexpected err %v", err)
+	}
+
+	got, err := client.Resource(UserAccessGVR()).Namespace("").
+		Get(context.Background(), ownerUserAccessName(email), metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get after seed: %v", err)
+	}
+
+	// Name.
+	wantName := "useraccess-owner-emrah-baysal-at-openova-io"
+	if got.GetName() != wantName {
+		t.Errorf("name: got %q want %q", got.GetName(), wantName)
+	}
+
+	// Annotation surfaces the email for /users page rendering.
+	if a := got.GetAnnotations()[userAccessOwnerEmailAnnotation]; a != email {
+		t.Errorf("annotation %q: got %q want %q",
+			userAccessOwnerEmailAnnotation, a, email)
+	}
+
+	// spec.user.keycloakSubject = email (realm uses email-as-username).
+	gotSub, _, _ := unstructured.NestedString(got.Object, "spec", "user", "keycloakSubject")
+	if gotSub != email {
+		t.Errorf("spec.user.keycloakSubject: got %q want %q", gotSub, email)
+	}
+
+	// spec.sovereignRef = first DNS label (rbacAssignSlug).
+	gotRef, _, _ := unstructured.NestedString(got.Object, "spec", "sovereignRef")
+	if gotRef != "omantel" {
+		t.Errorf("spec.sovereignRef: got %q want %q", gotRef, "omantel")
+	}
+
+	// spec.applications: single wildcard "*" → admin.
+	apps, ok, _ := unstructured.NestedSlice(got.Object, "spec", "applications")
+	if !ok || len(apps) != 1 {
+		t.Fatalf("spec.applications: want 1 entry, got %v", apps)
+	}
+	first, _ := apps[0].(map[string]any)
+	if first["app"] != "*" {
+		t.Errorf("applications[0].app: got %v want \"*\"", first["app"])
+	}
+	if first["role"] != "admin" {
+		t.Errorf("applications[0].role: got %v want \"admin\"", first["role"])
+	}
+
+	// apiVersion + kind.
+	if got.GetAPIVersion() != "access.openova.io/v1alpha1" {
+		t.Errorf("apiVersion: got %q want access.openova.io/v1alpha1", got.GetAPIVersion())
+	}
+	if got.GetKind() != "UserAccess" {
+		t.Errorf("kind: got %q want UserAccess", got.GetKind())
+	}
+}
+
+// TestEnsureOwnerUserAccess_IdempotentOnAlreadyExists proves a second
+// call (after the CR already exists) returns nil and does NOT mutate.
+// Mirrors the production case of a re-handover for the same operator.
+func TestEnsureOwnerUserAccess_IdempotentOnAlreadyExists(t *testing.T) {
+	const email = "emrah.baysal@openova.io"
+	const sov = "omantel.omani.works"
+
+	client := newOwnerSeedFakeClient()
+
+	// Seed once.
+	if err := EnsureOwnerUserAccess(context.Background(), client, email, sov); err != nil {
+		t.Fatalf("first seed: %v", err)
+	}
+	// Second call MUST return nil even though the CR already exists.
+	if err := EnsureOwnerUserAccess(context.Background(), client, email, sov); err != nil {
+		t.Fatalf("second seed (idempotent): got err %v want nil", err)
+	}
+	// Confirm only one CR exists.
+	list, err := client.Resource(UserAccessGVR()).Namespace("").
+		List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(list.Items) != 1 {
+		t.Fatalf("expected 1 CR after idempotent re-seed; got %d", len(list.Items))
+	}
+}
+
+// TestEnsureOwnerUserAccess_WrapsNonAlreadyExistsError proves any error
+// other than AlreadyExists is wrapped and returned (so the caller can
+// log a structured Warn).
+func TestEnsureOwnerUserAccess_WrapsNonAlreadyExistsError(t *testing.T) {
+	client := newOwnerSeedFakeClient()
+	wantErr := errors.New("synthetic apiserver outage")
+	client.PrependReactor("create", "useraccesses", func(_ clienttesting.Action) (bool, runtime.Object, error) {
+		return true, nil, wantErr
+	})
+
+	err := EnsureOwnerUserAccess(context.Background(), client,
+		"emrah.baysal@openova.io", "omantel.omani.works")
+	if err == nil {
+		t.Fatalf("expected error from helper; got nil")
+	}
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("expected wrapped wantErr; got %v", err)
+	}
+	if !strings.Contains(err.Error(), "useraccess-owner-") {
+		t.Errorf("wrap should include CR name; got %q", err.Error())
+	}
+}
+
+// TestEnsureOwnerUserAccess_RejectsEmptyEmail proves an empty email
+// returns an error rather than creating a malformed CR.
+func TestEnsureOwnerUserAccess_RejectsEmptyEmail(t *testing.T) {
+	client := newOwnerSeedFakeClient()
+	if err := EnsureOwnerUserAccess(context.Background(), client, "  ", "x.example"); err == nil {
+		t.Fatalf("expected error on empty email; got nil")
+	}
+}
+
+// TestEnsureOwnerUserAccess_RejectsNilClient proves a nil dynamic
+// client returns an error rather than panicking.
+func TestEnsureOwnerUserAccess_RejectsNilClient(t *testing.T) {
+	if err := EnsureOwnerUserAccess(context.Background(), nil,
+		"emrah.baysal@openova.io", "x.example"); err == nil {
+		t.Fatalf("expected error on nil client; got nil")
+	}
+}
+
+// TestEnsureOwnerUserAccess_AlreadyExistsFoldedNoErrSentinel proves the
+// helper folds k8s apierrors.IsAlreadyExists to nil specifically (and
+// not via a generic "ignore all errors" path).
+func TestEnsureOwnerUserAccess_AlreadyExistsFoldedNoErrSentinel(t *testing.T) {
+	client := newOwnerSeedFakeClient()
+	client.PrependReactor("create", "useraccesses", func(_ clienttesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewAlreadyExists(
+			UserAccessGVR().GroupResource(),
+			"useraccess-owner-emrah-baysal-at-openova-io",
+		)
+	})
+	if err := EnsureOwnerUserAccess(context.Background(), client,
+		"emrah.baysal@openova.io", "x.example"); err != nil {
+		t.Fatalf("AlreadyExists should fold to nil; got %v", err)
+	}
+}
+
+/* ── name-derivation unit tests ─────────────────────────────────── */
+
+func TestOwnerUserAccessName_Sanitizes(t *testing.T) {
+	cases := []struct {
+		email string
+		want  string
+	}{
+		{"emrah.baysal@openova.io", "useraccess-owner-emrah-baysal-at-openova-io"},
+		{"  EMRAH.BAYSAL@openova.io  ", "useraccess-owner-emrah-baysal-at-openova-io"},
+		{"a@b.c", "useraccess-owner-a-at-b-c"},
+		// Pathological: punctuation-only sanitizes to empty → fallback.
+		{"!!!", "useraccess-owner-operator"},
+	}
+	for _, c := range cases {
+		t.Run(c.email, func(t *testing.T) {
+			got := ownerUserAccessName(strings.TrimSpace(c.email))
+			if got != c.want {
+				t.Errorf("ownerUserAccessName(%q): got %q want %q", c.email, got, c.want)
+			}
+			if len(got) > 63 {
+				t.Errorf("ownerUserAccessName(%q): exceeded RFC 1123 limit (got %d chars)", c.email, len(got))
+			}
+		})
+	}
+}
+
+func TestOwnerUserAccessName_TruncatesLongEmail(t *testing.T) {
+	long := strings.Repeat("a", 60) + "@openova.io"
+	got := ownerUserAccessName(long)
+	if len(got) > 63 {
+		t.Errorf("name exceeded 63 chars: %q (%d)", got, len(got))
+	}
+	if !strings.HasPrefix(got, userAccessOwnerNamePrefix) {
+		t.Errorf("name lost prefix after truncation: %q", got)
+	}
+	if strings.HasSuffix(got, "-") {
+		t.Errorf("truncation left trailing hyphen: %q", got)
+	}
+}

--- a/products/catalyst/chart/templates/sovereign-fqdn-configmap.yaml
+++ b/products/catalyst/chart/templates/sovereign-fqdn-configmap.yaml
@@ -119,5 +119,17 @@ data:
   # Shape: a JSON array literal [{provider, cloudRegion, controlPlaneSize,
   # workerSize, workerCount}, ...]. Empty string → chroot uses
   # buildRegionFromLiveNodes (legacy single-region path).
-  regionsJson: {{ default "" .Values.sovereign.regionsJson | quote }}
+  #
+  # toJson is load-bearing — depending on how Flux Kustomize postBuild
+  # substitutes ${SOVEREIGN_REGIONS_JSON:-} into the HelmRelease values
+  # block, the resulting JSON-shaped string may be re-parsed as a YAML
+  # flow-sequence. In that case .Values.sovereign.regionsJson becomes
+  # a Go []interface{} of map[interface{}]interface{} and `| quote`
+  # alone prints Go syntax (`[map[cloudRegion:hel1 ...]]`) — then
+  # catalyst-api's json.Unmarshal of the env var fails and Request.Regions
+  # is empty → /cloud canvas falls back to single-region (D5 ❌).
+  # toJson normalises both "JSON string" and "YAML list" inputs to
+  # valid JSON. Caught on t132 chart 1.4.147 — env var rendered as
+  # `[map[cloudRegion:hel1 ...]]` despite PR #1551 single-quote fix.
+  regionsJson: {{ toJson (default (list) .Values.sovereign.regionsJson) | quote }}
 {{- end }}


### PR DESCRIPTION
## Summary
Settings page on Sovereign Console renders \`—\` for Region / Sovereign / Created / DeploymentID / Pool subdomain because chroot's GET /api/v1/deployments/<id> returns empty strings.

Populate from existing env vars (best-effort — empty when chart hasn't wired them yet, no regression):
- Result.ConsoleURL = derived from selfFQDN
- Result.GitOpsRepoURL from GITOPS_REPO_URL env
- Result.ControlPlaneIP from SOVEREIGN_CONTROL_PLANE_IP env
- Request.Region = regions[0].CloudRegion
- Request.OrgEmail from OPERATOR_EMAIL env
- Request.OrgName from ORG_NAME env

Caught live on t132 2026-05-16. Companion chart PR will wire env vars.

## Test plan
- [ ] curl on t133 (next prov) /api/v1/deployments/sovereign-t133... returns non-empty consoleURL
- [ ] Settings page no longer shows \`—\` for Region + ConsoleURL

🤖 Generated with [Claude Code](https://claude.com/claude-code)