### PR TITLE
feat(chart): wire OPERATOR_EMAIL/CONTROL_PLANE_IP/GITOPS_REPO_URL/ORG_NAME (D22)

### DIFF
--- a/products/catalyst/chart/templates/api-deployment.yaml
+++ b/products/catalyst/chart/templates/api-deployment.yaml
@@ -669,6 +669,37 @@ spec:
                   name: sovereign-fqdn
                   key: regionsJson
                   optional: true
+            # D22 (settings empty values) — three env vars chrootEnsureDeployment
+            # reads to populate the deployment record. Without these, the
+            # Sovereign Console Settings page renders `—` placeholders for
+            # ownerEmail, controlPlaneIP, and gitopsRepoURL. Sourced from
+            # `sovereign-fqdn` ConfigMap keys wired by sovereign-fqdn-configmap.yaml
+            # from .Values.sovereign.{orgEmail,controlPlaneIP,gitopsRepoURL}.
+            # optional=true so an unwired chart bring-up doesn't crash.
+            - name: OPERATOR_EMAIL
+              valueFrom:
+                configMapKeyRef:
+                  name: sovereign-fqdn
+                  key: orgEmail
+                  optional: true
+            - name: SOVEREIGN_CONTROL_PLANE_IP
+              valueFrom:
+                configMapKeyRef:
+                  name: sovereign-fqdn
+                  key: controlPlaneIP
+                  optional: true
+            - name: GITOPS_REPO_URL
+              valueFrom:
+                configMapKeyRef:
+                  name: sovereign-fqdn
+                  key: gitopsRepoURL
+                  optional: true
+            - name: ORG_NAME
+              valueFrom:
+                configMapKeyRef:
+                  name: sovereign-fqdn
+                  key: orgName
+                  optional: true
             # CATALYST_OTECH_FQDN — same value as SOVEREIGN_FQDN, but read by
             # the SME tenant create handler (sme_tenant.go) and the
             # sovereign-parent-domains seed (sovereign_parent_domains.go).

--- a/products/catalyst/chart/templates/sovereign-fqdn-configmap.yaml
+++ b/products/catalyst/chart/templates/sovereign-fqdn-configmap.yaml
@@ -132,4 +132,14 @@ data:
   # valid JSON. Caught on t132 chart 1.4.147 — env var rendered as
   # `[map[cloudRegion:hel1 ...]]` despite PR #1551 single-quote fix.
   regionsJson: {{ toJson (default (list) .Values.sovereign.regionsJson) | quote }}
+  # D22 (settings empty values) — operator-identity + control-plane + gitops
+  # fields chrootEnsureDeployment reads to populate the deployment record so
+  # the Sovereign Console Settings page renders real values instead of `—`.
+  # All four are optional (empty default) — operator wires them per
+  # Sovereign via .Values.sovereign.{orgEmail,orgName,controlPlaneIP,gitopsRepoURL}
+  # OR via cloud-init postBuild substitute (mirrors regionsJson pattern).
+  orgEmail: {{ default "" .Values.sovereign.orgEmail | quote }}
+  orgName: {{ default "" .Values.sovereign.orgName | quote }}
+  controlPlaneIP: {{ default "" .Values.sovereign.controlPlaneIP | quote }}
+  gitopsRepoURL: {{ default "" .Values.sovereign.gitopsRepoURL | quote }}
 {{- end }}


### PR DESCRIPTION
Companion to #1567 + #1568. Adds 4 sovereign-fqdn ConfigMap keys + catalyst-api env vars from .Values.sovereign.* with empty defaults. Per-Sovereign overlays wire from cloud-init.

🤖 Generated with [Claude Code](https://claude.com/claude-code)