### PR TITLE
chore(slot-13): add D22 sovereign-side identity placeholders

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -654,6 +654,21 @@ spec:
       # on every multi-region Sovereign. Caught on t131 2026-05-16.
       # Single-quoted so embedded double-quotes in the JSON are literal.
       regionsJson: '${SOVEREIGN_REGIONS_JSON:-}'
+      # ─── D22 (settings empty values) sovereign-side identity ──────────
+      # ORG_EMAIL / ORG_NAME / SOVEREIGN_CONTROL_PLANE_IP / GITOPS_REPO_URL
+      # threaded from cloud-init (provisioner.go::writeTfvars + Hetzner
+      # tofu cloudinit-control-plane.tftpl). Chart's sovereign-fqdn
+      # ConfigMap exposes these as keys; catalyst-api reads via env in
+      # api-deployment.yaml (PR #1569); chrootEnsureDeployment populates
+      # the deployment record so Sovereign Console Settings page renders
+      # real ownerEmail/region/controlPlaneIP/gitopsRepoURL/consoleURL
+      # instead of `—` placeholders. Empty default = same as today,
+      # backwards-compatible for charts that don't have the cloud-init
+      # placeholders wired yet.
+      orgEmail: '${ORG_EMAIL:-}'
+      orgName: '${ORG_NAME:-}'
+      controlPlaneIP: '${SOVEREIGN_CONTROL_PLANE_IP:-}'
+      gitopsRepoURL: '${GITOPS_REPO_URL:-}'
     # ─── QA fixtures (qa-loop iter-6 Cluster-F + EPIC-6 iter-6) ────────
     # Default-OFF on production; flipped to true via envsubst
     # QA_FIXTURES_ENABLED=true on the per-Sovereign overlay for any

--- a/products/catalyst/chart/templates/api-deployment.yaml
+++ b/products/catalyst/chart/templates/api-deployment.yaml
@@ -669,6 +669,37 @@ spec:
                   name: sovereign-fqdn
                   key: regionsJson
                   optional: true
+            # D22 (settings empty values) — three env vars chrootEnsureDeployment
+            # reads to populate the deployment record. Without these, the
+            # Sovereign Console Settings page renders `—` placeholders for
+            # ownerEmail, controlPlaneIP, and gitopsRepoURL. Sourced from
+            # `sovereign-fqdn` ConfigMap keys wired by sovereign-fqdn-configmap.yaml
+            # from .Values.sovereign.{orgEmail,controlPlaneIP,gitopsRepoURL}.
+            # optional=true so an unwired chart bring-up doesn't crash.
+            - name: OPERATOR_EMAIL
+              valueFrom:
+                configMapKeyRef:
+                  name: sovereign-fqdn
+                  key: orgEmail
+                  optional: true
+            - name: SOVEREIGN_CONTROL_PLANE_IP
+              valueFrom:
+                configMapKeyRef:
+                  name: sovereign-fqdn
+                  key: controlPlaneIP
+                  optional: true
+            - name: GITOPS_REPO_URL
+              valueFrom:
+                configMapKeyRef:
+                  name: sovereign-fqdn
+                  key: gitopsRepoURL
+                  optional: true
+            - name: ORG_NAME
+              valueFrom:
+                configMapKeyRef:
+                  name: sovereign-fqdn
+                  key: orgName
+                  optional: true
             # CATALYST_OTECH_FQDN — same value as SOVEREIGN_FQDN, but read by
             # the SME tenant create handler (sme_tenant.go) and the
             # sovereign-parent-domains seed (sovereign_parent_domains.go).

--- a/products/catalyst/chart/templates/sovereign-fqdn-configmap.yaml
+++ b/products/catalyst/chart/templates/sovereign-fqdn-configmap.yaml
@@ -132,4 +132,14 @@ data:
   # valid JSON. Caught on t132 chart 1.4.147 — env var rendered as
   # `[map[cloudRegion:hel1 ...]]` despite PR #1551 single-quote fix.
   regionsJson: {{ toJson (default (list) .Values.sovereign.regionsJson) | quote }}
+  # D22 (settings empty values) — operator-identity + control-plane + gitops
+  # fields chrootEnsureDeployment reads to populate the deployment record so
+  # the Sovereign Console Settings page renders real values instead of `—`.
+  # All four are optional (empty default) — operator wires them per
+  # Sovereign via .Values.sovereign.{orgEmail,orgName,controlPlaneIP,gitopsRepoURL}
+  # OR via cloud-init postBuild substitute (mirrors regionsJson pattern).
+  orgEmail: {{ default "" .Values.sovereign.orgEmail | quote }}
+  orgName: {{ default "" .Values.sovereign.orgName | quote }}
+  controlPlaneIP: {{ default "" .Values.sovereign.controlPlaneIP | quote }}
+  gitopsRepoURL: {{ default "" .Values.sovereign.gitopsRepoURL | quote }}
 {{- end }}


### PR DESCRIPTION
Add ORG_EMAIL/ORG_NAME/SOVEREIGN_CONTROL_PLANE_IP/GITOPS_REPO_URL envsubst placeholders to slot 13. No-op until cloud-init + provisioner tfvars wire them (companion PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)