### PR TITLE
feat(cloudinit): wire ORG_EMAIL/ORG_NAME/GITOPS_REPO_URL substitutes (D22)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -654,6 +654,21 @@ spec:
       # on every multi-region Sovereign. Caught on t131 2026-05-16.
       # Single-quoted so embedded double-quotes in the JSON are literal.
       regionsJson: '${SOVEREIGN_REGIONS_JSON:-}'
+      # ─── D22 (settings empty values) sovereign-side identity ──────────
+      # ORG_EMAIL / ORG_NAME / SOVEREIGN_CONTROL_PLANE_IP / GITOPS_REPO_URL
+      # threaded from cloud-init (provisioner.go::writeTfvars + Hetzner
+      # tofu cloudinit-control-plane.tftpl). Chart's sovereign-fqdn
+      # ConfigMap exposes these as keys; catalyst-api reads via env in
+      # api-deployment.yaml (PR #1569); chrootEnsureDeployment populates
+      # the deployment record so Sovereign Console Settings page renders
+      # real ownerEmail/region/controlPlaneIP/gitopsRepoURL/consoleURL
+      # instead of `—` placeholders. Empty default = same as today,
+      # backwards-compatible for charts that don't have the cloud-init
+      # placeholders wired yet.
+      orgEmail: '${ORG_EMAIL:-}'
+      orgName: '${ORG_NAME:-}'
+      controlPlaneIP: '${SOVEREIGN_CONTROL_PLANE_IP:-}'
+      gitopsRepoURL: '${GITOPS_REPO_URL:-}'
     # ─── QA fixtures (qa-loop iter-6 Cluster-F + EPIC-6 iter-6) ────────
     # Default-OFF on production; flipped to true via envsubst
     # QA_FIXTURES_ENABLED=true on the per-Sovereign overlay for any

--- a/infra/hetzner/cloudinit-control-plane.tftpl
+++ b/infra/hetzner/cloudinit-control-plane.tftpl
@@ -1040,6 +1040,26 @@ write_files:
             # "1 cluster 1 region" because chroot fell back to
             # live-Nodes enumeration.
             SOVEREIGN_REGIONS_JSON: '${sovereign_regions_json}'
+            # D22 (settings empty values) — sovereign-side identity wired
+            # into the bp-catalyst-platform slot 13 sovereign.* values
+            # (clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+            # PR #1570 added the ${ORG_EMAIL:-}/${ORG_NAME:-}/...
+            # placeholders). Chart's sovereign-fqdn ConfigMap (PR #1569)
+            # exposes them as ConfigMap keys; catalyst-api reads via env
+            # (api-deployment.yaml); chrootEnsureDeployment populates the
+            # deployment record so Sovereign Console Settings page renders
+            # real ownerEmail/region/controlPlaneIP/gitopsRepoURL/consoleURL.
+            # control_plane_ip is NOT templated here — see
+            # main.tf:691 ("would create a dependency cycle" — the
+            # hcloud_server.cp resource doesn't exist yet at cloudinit
+            # render time). The chart's SOVEREIGN_CONTROL_PLANE_IP env
+            # stays empty until a future PR wires it via either (a)
+            # hcloud metadata-service lookup at runtime by catalyst-api,
+            # or (b) a cloud-init post-create step that writes it into
+            # the sovereign-fqdn ConfigMap.
+            ORG_EMAIL: "${org_email}"
+            ORG_NAME: "${org_name}"
+            GITOPS_REPO_URL: "${gitops_repo_url}"
             # QA fixtures auto-enable (Fix #73 — qa-loop bounded-cycle
             # iter-16). Default "false" so a customer-facing zero-touch
             # provision lands a Sovereign with NO qaFixtures stack

--- a/products/catalyst/chart/templates/api-deployment.yaml
+++ b/products/catalyst/chart/templates/api-deployment.yaml
@@ -669,6 +669,37 @@ spec:
                   name: sovereign-fqdn
                   key: regionsJson
                   optional: true
+            # D22 (settings empty values) — three env vars chrootEnsureDeployment
+            # reads to populate the deployment record. Without these, the
+            # Sovereign Console Settings page renders `—` placeholders for
+            # ownerEmail, controlPlaneIP, and gitopsRepoURL. Sourced from
+            # `sovereign-fqdn` ConfigMap keys wired by sovereign-fqdn-configmap.yaml
+            # from .Values.sovereign.{orgEmail,controlPlaneIP,gitopsRepoURL}.
+            # optional=true so an unwired chart bring-up doesn't crash.
+            - name: OPERATOR_EMAIL
+              valueFrom:
+                configMapKeyRef:
+                  name: sovereign-fqdn
+                  key: orgEmail
+                  optional: true
+            - name: SOVEREIGN_CONTROL_PLANE_IP
+              valueFrom:
+                configMapKeyRef:
+                  name: sovereign-fqdn
+                  key: controlPlaneIP
+                  optional: true
+            - name: GITOPS_REPO_URL
+              valueFrom:
+                configMapKeyRef:
+                  name: sovereign-fqdn
+                  key: gitopsRepoURL
+                  optional: true
+            - name: ORG_NAME
+              valueFrom:
+                configMapKeyRef:
+                  name: sovereign-fqdn
+                  key: orgName
+                  optional: true
             # CATALYST_OTECH_FQDN — same value as SOVEREIGN_FQDN, but read by
             # the SME tenant create handler (sme_tenant.go) and the
             # sovereign-parent-domains seed (sovereign_parent_domains.go).

--- a/products/catalyst/chart/templates/sovereign-fqdn-configmap.yaml
+++ b/products/catalyst/chart/templates/sovereign-fqdn-configmap.yaml
@@ -132,4 +132,14 @@ data:
   # valid JSON. Caught on t132 chart 1.4.147 — env var rendered as
   # `[map[cloudRegion:hel1 ...]]` despite PR #1551 single-quote fix.
   regionsJson: {{ toJson (default (list) .Values.sovereign.regionsJson) | quote }}
+  # D22 (settings empty values) — operator-identity + control-plane + gitops
+  # fields chrootEnsureDeployment reads to populate the deployment record so
+  # the Sovereign Console Settings page renders real values instead of `—`.
+  # All four are optional (empty default) — operator wires them per
+  # Sovereign via .Values.sovereign.{orgEmail,orgName,controlPlaneIP,gitopsRepoURL}
+  # OR via cloud-init postBuild substitute (mirrors regionsJson pattern).
+  orgEmail: {{ default "" .Values.sovereign.orgEmail | quote }}
+  orgName: {{ default "" .Values.sovereign.orgName | quote }}
+  controlPlaneIP: {{ default "" .Values.sovereign.controlPlaneIP | quote }}
+  gitopsRepoURL: {{ default "" .Values.sovereign.gitopsRepoURL | quote }}
 {{- end }}


### PR DESCRIPTION
Completes the D22 chain end-to-end for next-prov auto-population. Pairs with #1567+#1568+#1569+#1570. CONTROL_PLANE_IP omitted due to dependency cycle (separate PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)