### PR TITLE
fix(router): chroot /app/<name> only-redirect mothership-only sub-paths (D17/D17b)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -654,6 +654,21 @@ spec:
       # on every multi-region Sovereign. Caught on t131 2026-05-16.
       # Single-quoted so embedded double-quotes in the JSON are literal.
       regionsJson: '${SOVEREIGN_REGIONS_JSON:-}'
+      # ─── D22 (settings empty values) sovereign-side identity ──────────
+      # ORG_EMAIL / ORG_NAME / SOVEREIGN_CONTROL_PLANE_IP / GITOPS_REPO_URL
+      # threaded from cloud-init (provisioner.go::writeTfvars + Hetzner
+      # tofu cloudinit-control-plane.tftpl). Chart's sovereign-fqdn
+      # ConfigMap exposes these as keys; catalyst-api reads via env in
+      # api-deployment.yaml (PR #1569); chrootEnsureDeployment populates
+      # the deployment record so Sovereign Console Settings page renders
+      # real ownerEmail/region/controlPlaneIP/gitopsRepoURL/consoleURL
+      # instead of `—` placeholders. Empty default = same as today,
+      # backwards-compatible for charts that don't have the cloud-init
+      # placeholders wired yet.
+      orgEmail: '${ORG_EMAIL:-}'
+      orgName: '${ORG_NAME:-}'
+      controlPlaneIP: '${SOVEREIGN_CONTROL_PLANE_IP:-}'
+      gitopsRepoURL: '${GITOPS_REPO_URL:-}'
     # ─── QA fixtures (qa-loop iter-6 Cluster-F + EPIC-6 iter-6) ────────
     # Default-OFF on production; flipped to true via envsubst
     # QA_FIXTURES_ENABLED=true on the per-Sovereign overlay for any

--- a/infra/hetzner/cloudinit-control-plane.tftpl
+++ b/infra/hetzner/cloudinit-control-plane.tftpl
@@ -1040,6 +1040,26 @@ write_files:
             # "1 cluster 1 region" because chroot fell back to
             # live-Nodes enumeration.
             SOVEREIGN_REGIONS_JSON: '${sovereign_regions_json}'
+            # D22 (settings empty values) — sovereign-side identity wired
+            # into the bp-catalyst-platform slot 13 sovereign.* values
+            # (clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+            # PR #1570 added the ${ORG_EMAIL:-}/${ORG_NAME:-}/...
+            # placeholders). Chart's sovereign-fqdn ConfigMap (PR #1569)
+            # exposes them as ConfigMap keys; catalyst-api reads via env
+            # (api-deployment.yaml); chrootEnsureDeployment populates the
+            # deployment record so Sovereign Console Settings page renders
+            # real ownerEmail/region/controlPlaneIP/gitopsRepoURL/consoleURL.
+            # control_plane_ip is NOT templated here — see
+            # main.tf:691 ("would create a dependency cycle" — the
+            # hcloud_server.cp resource doesn't exist yet at cloudinit
+            # render time). The chart's SOVEREIGN_CONTROL_PLANE_IP env
+            # stays empty until a future PR wires it via either (a)
+            # hcloud metadata-service lookup at runtime by catalyst-api,
+            # or (b) a cloud-init post-create step that writes it into
+            # the sovereign-fqdn ConfigMap.
+            ORG_EMAIL: "${org_email}"
+            ORG_NAME: "${org_name}"
+            GITOPS_REPO_URL: "${gitops_repo_url}"
             # QA fixtures auto-enable (Fix #73 — qa-loop bounded-cycle
             # iter-16). Default "false" so a customer-facing zero-touch
             # provision lands a Sovereign with NO qaFixtures stack

--- a/products/catalyst/bootstrap/ui/src/app/router.tsx
+++ b/products/catalyst/bootstrap/ui/src/app/router.tsx
@@ -392,21 +392,28 @@ const appRoute = createRoute({
   component: AppLayout,
   beforeLoad: ({ location }) => {
     if (DETECTED_MODE.mode === 'sovereign') {
-      // Strip the `/app` prefix; the rest is the path the chroot's
-      // consoleAppDetailRoute / consoleAppsRoute expect (e.g.
-      // `/app/bp-cnpg` → `/bp-cnpg`, which matches
-      // consoleAppDetailRoute with $componentId=bp-cnpg).
-      // If the path after `/app` is empty or `/`, send the operator
-      // to the canonical apps grid.
-      const remainder = location.pathname.replace(/^\/app/, '') || '/apps'
-      // Mothership-only sub-paths (e.g. `/app/dashboard`, `/app/install`,
-      // `/app/sre/compliance`) are NOT valid on the Sovereign Console —
-      // redirect those to the Sovereign dashboard so the operator
-      // doesn't land on a 404. AppDetail handles `/app/<componentId>`
-      // verbatim.
+      // D17/D17b walkthrough on t132 2026-05-17: the previous
+      // strip-`/app`-prefix-and-redirect logic broke /app/<componentId>
+      // because no chroot route matches `/<componentId>` directly —
+      // consoleAppDetailRoute is registered at `/app/$componentId` under
+      // consoleLayoutRoute, so we must NOT strip the prefix. Instead,
+      // only redirect when the sub-path is a mothership-only surface
+      // (Fleet view dashboard, install wizard, SRE/SEC consoles,
+      // blueprint catalog) — those have no Sovereign Console equivalent
+      // and would 404. For any other sub-path (component name like
+      // `/app/bp-cnpg`, or bare `/app`) leave routing alone so the
+      // child consoleAppDetailRoute / consoleAppsRoute can claim it.
+      const remainder = location.pathname.replace(/^\/app/, '')
       const motherOnly = ['/dashboard', '/install', '/sre', '/sec', '/blueprints']
-      const target = motherOnly.some(p => remainder.startsWith(p)) ? '/dashboard' : remainder
-      throw redirect({ to: target as never })
+      if (motherOnly.some(p => remainder.startsWith(p))) {
+        throw redirect({ to: '/dashboard' as never })
+      }
+      // bare `/app` with nothing after → canonical apps grid
+      if (remainder === '' || remainder === '/') {
+        throw redirect({ to: '/apps' as never })
+      }
+      // Otherwise: let TanStack match the most-specific child route
+      // (consoleAppDetailRoute at `/app/$componentId`). No redirect.
     }
   },
 })

--- a/products/catalyst/chart/templates/api-deployment.yaml
+++ b/products/catalyst/chart/templates/api-deployment.yaml
@@ -669,6 +669,37 @@ spec:
                   name: sovereign-fqdn
                   key: regionsJson
                   optional: true
+            # D22 (settings empty values) — three env vars chrootEnsureDeployment
+            # reads to populate the deployment record. Without these, the
+            # Sovereign Console Settings page renders `—` placeholders for
+            # ownerEmail, controlPlaneIP, and gitopsRepoURL. Sourced from
+            # `sovereign-fqdn` ConfigMap keys wired by sovereign-fqdn-configmap.yaml
+            # from .Values.sovereign.{orgEmail,controlPlaneIP,gitopsRepoURL}.
+            # optional=true so an unwired chart bring-up doesn't crash.
+            - name: OPERATOR_EMAIL
+              valueFrom:
+                configMapKeyRef:
+                  name: sovereign-fqdn
+                  key: orgEmail
+                  optional: true
+            - name: SOVEREIGN_CONTROL_PLANE_IP
+              valueFrom:
+                configMapKeyRef:
+                  name: sovereign-fqdn
+                  key: controlPlaneIP
+                  optional: true
+            - name: GITOPS_REPO_URL
+              valueFrom:
+                configMapKeyRef:
+                  name: sovereign-fqdn
+                  key: gitopsRepoURL
+                  optional: true
+            - name: ORG_NAME
+              valueFrom:
+                configMapKeyRef:
+                  name: sovereign-fqdn
+                  key: orgName
+                  optional: true
             # CATALYST_OTECH_FQDN — same value as SOVEREIGN_FQDN, but read by
             # the SME tenant create handler (sme_tenant.go) and the
             # sovereign-parent-domains seed (sovereign_parent_domains.go).

--- a/products/catalyst/chart/templates/sovereign-fqdn-configmap.yaml
+++ b/products/catalyst/chart/templates/sovereign-fqdn-configmap.yaml
@@ -132,4 +132,14 @@ data:
   # valid JSON. Caught on t132 chart 1.4.147 — env var rendered as
   # `[map[cloudRegion:hel1 ...]]` despite PR #1551 single-quote fix.
   regionsJson: {{ toJson (default (list) .Values.sovereign.regionsJson) | quote }}
+  # D22 (settings empty values) — operator-identity + control-plane + gitops
+  # fields chrootEnsureDeployment reads to populate the deployment record so
+  # the Sovereign Console Settings page renders real values instead of `—`.
+  # All four are optional (empty default) — operator wires them per
+  # Sovereign via .Values.sovereign.{orgEmail,orgName,controlPlaneIP,gitopsRepoURL}
+  # OR via cloud-init postBuild substitute (mirrors regionsJson pattern).
+  orgEmail: {{ default "" .Values.sovereign.orgEmail | quote }}
+  orgName: {{ default "" .Values.sovereign.orgName | quote }}
+  controlPlaneIP: {{ default "" .Values.sovereign.controlPlaneIP | quote }}
+  gitopsRepoURL: {{ default "" .Values.sovereign.gitopsRepoURL | quote }}
 {{- end }}


### PR DESCRIPTION
PR #1552 had inverted logic — stripped /app prefix universally; consoleAppDetailRoute never matched. Playwright walkthrough on t132 2026-05-17 caught this regression. Only redirect mothership-only sub-paths now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)