### PR TITLE
fix(cloudinit): escape $${ORG_EMAIL:-}/$${ORG_NAME:-} in comment (D22)

### DIFF
--- a/infra/hetzner/cloudinit-control-plane.tftpl
+++ b/infra/hetzner/cloudinit-control-plane.tftpl
@@ -1043,7 +1043,7 @@ write_files:
             # D22 (settings empty values) — sovereign-side identity wired
             # into the bp-catalyst-platform slot 13 sovereign.* values
             # (clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
-            # PR #1570 added the ${ORG_EMAIL:-}/${ORG_NAME:-}/...
+            # PR #1570 added the $${ORG_EMAIL:-}/$${ORG_NAME:-}/...
             # placeholders). Chart's sovereign-fqdn ConfigMap (PR #1569)
             # exposes them as ConfigMap keys; catalyst-api reads via env
             # (api-deployment.yaml); chrootEnsureDeployment populates the


### PR DESCRIPTION
PR #1571 added an unescaped ${ORG_EMAIL:-} in a comment. tofu templatefile parses comments and tried to interpolate it, failing tofu plan with "Extra characters after interpolation expression". Caught live on t133 fad01d84f5655004.

🤖 Generated with [Claude Code](https://claude.com/claude-code)