### PR TITLE
fix(handover): D21 owner seed uses tierRoleRef not wildcard app

### DIFF
--- a/infra/hetzner/cloudinit-control-plane.tftpl
+++ b/infra/hetzner/cloudinit-control-plane.tftpl
@@ -1043,7 +1043,7 @@ write_files:
             # D22 (settings empty values) — sovereign-side identity wired
             # into the bp-catalyst-platform slot 13 sovereign.* values
             # (clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
-            # PR #1570 added the ${ORG_EMAIL:-}/${ORG_NAME:-}/...
+            # PR #1570 added the $${ORG_EMAIL:-}/$${ORG_NAME:-}/...
             # placeholders). Chart's sovereign-fqdn ConfigMap (PR #1569)
             # exposes them as ConfigMap keys; catalyst-api reads via env
             # (api-deployment.yaml); chrootEnsureDeployment populates the

--- a/products/catalyst/bootstrap/api/internal/handler/parent_domains.go
+++ b/products/catalyst/bootstrap/api/internal/handler/parent_domains.go
@@ -933,6 +933,20 @@ func (h *Handler) pdmFlipNS(ctx context.Context, registrarKind, domain, token st
 	if len(nameservers) == 0 {
 		return fmt.Errorf("expected-ns-unavailable: cannot compute nameservers (primary domain unknown)")
 	}
+	// D30 short-circuit (caught on t134 2026-05-17): when the domain's
+	// current NS records already match the expected nameservers, the
+	// PDM registrar-flip step is a no-op — there's nothing to flip.
+	// Skipping avoids burning the registrar API credit + sidesteps the
+	// Dynadot pdm-status-401 blocker for sme-pool domains already
+	// delegated to OpenOva (e.g. omani.homes which already points at
+	// ns1/2/3.openova.io). When the lookup fails or returns a different
+	// NS set, fall through to the original pipeline so PDM does the
+	// flip via the registrar API.
+	if h.nsAlreadyMatches(ctx, domain, nameservers) {
+		h.log.Info("pdm-flip-ns: NS already matches expected, skipping registrar-flip",
+			"domain", domain, "registrarKind", registrarKind)
+		return nil
+	}
 	// glueIP — Sovereign's load-balancer public IPv4 (issue #900). When
 	// non-empty PDM pre-registers each NS hostname against the customer's
 	// account before the set_ns flip, unblocking Dynadot's "needs to be
@@ -1028,6 +1042,39 @@ func (h *Handler) lookupSovereignLBIP() string {
 		return true
 	})
 	return picked
+}
+
+// nsAlreadyMatches returns true when domain's current NS records (per
+// the public DNS) already include EVERY name in expected. Case-
+// insensitive, trailing-dot tolerant. Used by pdmFlipNS to short-circuit
+// the registrar-flip step for sme-pool domains already delegated to
+// OpenOva's PowerDNS (D30 — t134 2026-05-17). Returns false on lookup
+// error or partial match so the original PDM pipeline still runs.
+func (h *Handler) nsAlreadyMatches(ctx context.Context, domain string, expected []string) bool {
+	if len(expected) == 0 {
+		return false
+	}
+	lookupCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	resolver := net.DefaultResolver
+	got, err := resolver.LookupNS(lookupCtx, domain)
+	if err != nil {
+		return false
+	}
+	have := make(map[string]struct{}, len(got))
+	for _, ns := range got {
+		have[strings.ToLower(strings.TrimSuffix(ns.Host, "."))] = struct{}{}
+	}
+	for _, want := range expected {
+		w := strings.ToLower(strings.TrimSuffix(strings.TrimSpace(want), "."))
+		if w == "" {
+			continue
+		}
+		if _, ok := have[w]; !ok {
+			return false
+		}
+	}
+	return true
 }
 
 // pdmBasicAuth reads the basic-auth credentials for the PDM public

--- a/products/catalyst/bootstrap/api/internal/handler/user_access_owner_seed.go
+++ b/products/catalyst/bootstrap/api/internal/handler/user_access_owner_seed.go
@@ -193,12 +193,23 @@ func buildOwnerUserAccessUnstructured(name, email, sovereignRef string) *unstruc
 			"keycloakSubject": email,
 		},
 		"sovereignRef": sovereignRef,
-		"applications": []any{
-			map[string]any{
-				"app":  "*",
-				"role": "admin", // owner → admin per userAccessTierToRole
-			},
-		},
+		// D21 fix on t135 2026-05-17: the prior seed used
+		// applications=[{app:"*", role:"admin"}] but the XRD schema
+		// rejects `app: "*"` (pattern `^[a-z0-9][a-z0-9-]{0,62}$`).
+		// `tierRoleRef` is the canonical owner-tier semantic per
+		// platform/crossplane-claims/chart/templates/xrds/useraccess.yaml
+		// — when set, the useraccess-controller binds the named
+		// ClusterRole on the target via RoleBinding/ClusterRoleBinding.
+		// `openova:tier-owner` is the canonical owner-tier ClusterRole
+		// shipped by EPIC-3 (#1098) slice T1's tier-clusterroles.yaml.
+		// Documented at user_access_owner_seed.go:103-104 as the right
+		// way to grant owner-tier without per-app entries.
+		"tierRoleRef": "openova:tier-owner",
+		// applications[] intentionally omitted — XRD pattern rejects
+		// `app: "*"`. tierRoleRef provides the owner-tier semantic
+		// directly; useraccess-controller binds openova:tier-owner
+		// ClusterRole + the operator's Keycloak subject via
+		// ClusterRoleBinding (since `scopes` is also empty/cluster-wide).
 	}
 	_ = unstructured.SetNestedMap(obj.Object, spec, "spec")
 	return obj

--- a/products/catalyst/bootstrap/api/internal/handler/user_access_owner_seed.go
+++ b/products/catalyst/bootstrap/api/internal/handler/user_access_owner_seed.go
@@ -75,6 +75,16 @@ const userAccessOwnerEmailAnnotation = "catalyst.openova.io/user-email"
 // limit (the apiserver rejects longer names with a 422).
 const userAccessOwnerNamePrefix = "useraccess-owner-"
 
+// userAccessOwnerNamespace is the namespace the auto-seeded owner CR
+// lives in. useraccesses.access.openova.io is a NAMESPACED Crossplane
+// Claim per platform/crossplane-claims/chart/templates/xrds/useraccess.yaml
+// (`claimNames` block). catalyst-system is canonical — every other
+// Catalyst-authored CR lives there too, and the listing/admin handler
+// at user_access.go::ListUserAccess uses `Namespace("")` which surfaces
+// CRs from every namespace, so the operator entry surfaces on /users
+// without per-namespace filtering. Caught on t134 2026-05-17.
+const userAccessOwnerNamespace = "catalyst-system"
+
 // EnsureOwnerUserAccess creates an owner-tier UserAccess CR for the
 // operator who just completed PIN-login + handover, if one does not
 // already exist. Idempotent: AlreadyExists is folded to a nil return.
@@ -114,9 +124,14 @@ func EnsureOwnerUserAccess(ctx context.Context, client dynamic.Interface, email,
 	sovRef := rbacAssignSlug(sovereignFQDN)
 
 	obj := buildOwnerUserAccessUnstructured(name, email, sovRef)
-
+	// D21 fix on t134 2026-05-17: the prior Namespace("") call returned
+	// "the server could not find the requested resource" because
+	// useraccesses.access.openova.io is NAMESPACED (Claim semantics per
+	// the XRD's claimNames block). Pin to catalyst-system + stamp the
+	// namespace on the CR object so the apiserver routes the Create.
+	obj.SetNamespace(userAccessOwnerNamespace)
 	_, err := client.Resource(UserAccessGVR()).
-		Namespace("").
+		Namespace(userAccessOwnerNamespace).
 		Create(ctx, obj, metav1.CreateOptions{})
 	if err != nil {
 		if apierrors.IsAlreadyExists(err) {


### PR DESCRIPTION
Third D21 root cause: CRD pattern rejects app:"\*". Use tierRoleRef=openova:tier-owner instead. Verified live on t135 2026-05-17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)