### PR TITLE
feat(dashboard): multi-cluster fan-out when group_by=cluster|region (D16 PR C)

### DIFF
--- a/infra/hetzner/cloudinit-control-plane.tftpl
+++ b/infra/hetzner/cloudinit-control-plane.tftpl
@@ -1043,7 +1043,7 @@ write_files:
             # D22 (settings empty values) — sovereign-side identity wired
             # into the bp-catalyst-platform slot 13 sovereign.* values
             # (clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
-            # PR #1570 added the ${ORG_EMAIL:-}/${ORG_NAME:-}/...
+            # PR #1570 added the $${ORG_EMAIL:-}/$${ORG_NAME:-}/...
             # placeholders). Chart's sovereign-fqdn ConfigMap (PR #1569)
             # exposes them as ConfigMap keys; catalyst-api reads via env
             # (api-deployment.yaml); chrootEnsureDeployment populates the

--- a/products/catalyst/bootstrap/api/cmd/api/main.go
+++ b/products/catalyst/bootstrap/api/cmd/api/main.go
@@ -1188,6 +1188,13 @@ func main() {
 		rg.Post("/api/v1/sovereign/parent-domains", h.AddParentDomain)
 		rg.Delete("/api/v1/sovereign/parent-domains/{name}", h.DeleteParentDomain)
 		rg.Get("/api/v1/sovereign/parent-domains/{name}/propagation", h.GetPropagation)
+		// D16 fan-out (gate D16 multi-region dashboard cluster grouping):
+		// mothership POSTs each secondary region's kubeconfig at handover
+		// so the chroot's k8sCache.Factory can register all clusters +
+		// dashboard handler's per-cluster List() fan-out enumerates all
+		// 3 regions' pods (Layer-1=Cluster renders 3 bubbles, not 1).
+		// Handler at handler/sovereign_secondary_kubeconfig.go.
+		rg.Post("/api/v1/sovereign/secondary-kubeconfig", h.HandleSovereignSecondaryKubeconfig)
 	})
 
 	log.Info("catalyst api listening", "port", port)

--- a/products/catalyst/bootstrap/api/internal/handler/dashboard.go
+++ b/products/catalyst/bootstrap/api/internal/handler/dashboard.go
@@ -175,13 +175,44 @@ func (h *Handler) GetDashboardTreemap(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	pods, _, _ := h.k8sCache.List(clusterID, "pod", labels.Everything())
-	pvcs, _, _ := h.k8sCache.List(clusterID, "persistentvolumeclaim", labels.Everything())
-	// PodMetrics is Optional — list may error when metrics-server is
-	// absent. Treat as nil and the utilization path emits null.
-	podMetrics, _, _ := h.k8sCache.List(clusterID, "podmetrics", labels.Everything())
+	// D16 multi-cluster fan-out (caught on t132 2026-05-16): when
+	// group_by includes "cluster" or "region", enumerate ALL registered
+	// clusters (primary + each secondary's kubeconfig synced via PR
+	// #1579) so Layer-1=Cluster renders N bubbles on an N-region
+	// Sovereign instead of 1. For group_by that ONLY contains
+	// {namespace,family,application,vcluster,sovereign} the primary
+	// clusterID's pods are sufficient and faster.
+	wantFanOut := false
+	for _, g := range groupBy {
+		if g == "cluster" || g == "region" {
+			wantFanOut = true
+			break
+		}
+	}
+	clusterIDs := []string{clusterID}
+	if wantFanOut {
+		// h.k8sCache.Clusters() returns every registered ID. Primary
+		// is included; deduplicate via the local map. When PR B ships
+		// the mothership handover hook, secondaries land here.
+		seen := map[string]struct{}{clusterID: {}}
+		for _, cid := range h.k8sCache.Clusters() {
+			if _, ok := seen[cid]; ok {
+				continue
+			}
+			seen[cid] = struct{}{}
+			clusterIDs = append(clusterIDs, cid)
+		}
+	}
 
-	rows := buildPodRows(pods, pvcs, podMetrics, clusterID)
+	var rows []podRow
+	for _, cid := range clusterIDs {
+		pods, _, _ := h.k8sCache.List(cid, "pod", labels.Everything())
+		pvcs, _, _ := h.k8sCache.List(cid, "persistentvolumeclaim", labels.Everything())
+		// PodMetrics is Optional — list may error when metrics-server is
+		// absent. Treat as nil and the utilization path emits null.
+		podMetrics, _, _ := h.k8sCache.List(cid, "podmetrics", labels.Everything())
+		rows = append(rows, buildPodRows(pods, pvcs, podMetrics, cid)...)
+	}
 	resp := aggregateRows(rows, groupBy, colorBy, sizeBy)
 	writeJSON(w, http.StatusOK, resp)
 }

--- a/products/catalyst/bootstrap/api/internal/handler/parent_domains.go
+++ b/products/catalyst/bootstrap/api/internal/handler/parent_domains.go
@@ -933,6 +933,20 @@ func (h *Handler) pdmFlipNS(ctx context.Context, registrarKind, domain, token st
 	if len(nameservers) == 0 {
 		return fmt.Errorf("expected-ns-unavailable: cannot compute nameservers (primary domain unknown)")
 	}
+	// D30 short-circuit (caught on t134 2026-05-17): when the domain's
+	// current NS records already match the expected nameservers, the
+	// PDM registrar-flip step is a no-op — there's nothing to flip.
+	// Skipping avoids burning the registrar API credit + sidesteps the
+	// Dynadot pdm-status-401 blocker for sme-pool domains already
+	// delegated to OpenOva (e.g. omani.homes which already points at
+	// ns1/2/3.openova.io). When the lookup fails or returns a different
+	// NS set, fall through to the original pipeline so PDM does the
+	// flip via the registrar API.
+	if h.nsAlreadyMatches(ctx, domain, nameservers) {
+		h.log.Info("pdm-flip-ns: NS already matches expected, skipping registrar-flip",
+			"domain", domain, "registrarKind", registrarKind)
+		return nil
+	}
 	// glueIP — Sovereign's load-balancer public IPv4 (issue #900). When
 	// non-empty PDM pre-registers each NS hostname against the customer's
 	// account before the set_ns flip, unblocking Dynadot's "needs to be
@@ -1028,6 +1042,39 @@ func (h *Handler) lookupSovereignLBIP() string {
 		return true
 	})
 	return picked
+}
+
+// nsAlreadyMatches returns true when domain's current NS records (per
+// the public DNS) already include EVERY name in expected. Case-
+// insensitive, trailing-dot tolerant. Used by pdmFlipNS to short-circuit
+// the registrar-flip step for sme-pool domains already delegated to
+// OpenOva's PowerDNS (D30 — t134 2026-05-17). Returns false on lookup
+// error or partial match so the original PDM pipeline still runs.
+func (h *Handler) nsAlreadyMatches(ctx context.Context, domain string, expected []string) bool {
+	if len(expected) == 0 {
+		return false
+	}
+	lookupCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	resolver := net.DefaultResolver
+	got, err := resolver.LookupNS(lookupCtx, domain)
+	if err != nil {
+		return false
+	}
+	have := make(map[string]struct{}, len(got))
+	for _, ns := range got {
+		have[strings.ToLower(strings.TrimSuffix(ns.Host, "."))] = struct{}{}
+	}
+	for _, want := range expected {
+		w := strings.ToLower(strings.TrimSuffix(strings.TrimSpace(want), "."))
+		if w == "" {
+			continue
+		}
+		if _, ok := have[w]; !ok {
+			return false
+		}
+	}
+	return true
 }
 
 // pdmBasicAuth reads the basic-auth credentials for the PDM public

--- a/products/catalyst/bootstrap/api/internal/handler/sovereign_secondary_kubeconfig.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sovereign_secondary_kubeconfig.go
@@ -1,0 +1,160 @@
+// sovereign_secondary_kubeconfig.go — chroot endpoint for D16
+// multi-cluster fan-out (docs/SOVEREIGN-MULTI-REGION-DOD.md gate D16).
+//
+// POST /api/v1/sovereign/secondary-kubeconfig
+//
+// Accepts a secondary region's kubeconfig bytes + region key + deploymentID,
+// writes the kubeconfig to /var/lib/catalyst/kubeconfigs/<depID>-<region>.yaml
+// (the canonical location FactoryFromEnv reads at startup), and calls
+// k8sCache.Factory.AddCluster so the dashboard handler's per-cluster
+// h.k8sCache.List(clusterID, ...) fan-out can immediately enumerate all
+// 3 regions' pods.
+//
+// Why this exists (D16 root cause):
+//
+//   The Sovereign Console's /dashboard?group_by=cluster handler reads
+//   ONE clusterID from the query string and lists pods from THAT cluster
+//   only — Layer-1=Cluster renders 1 bubble instead of 3 on a 3-region
+//   Sovereign. The fix requires the chroot to register the secondary
+//   regions' kubeconfigs in k8sCache so fan-out enumerates them.
+//
+//   The chroot has its OWN in-cluster kubeconfig auto-registered, but
+//   secondary kubeconfigs live on the mothership's PVC and aren't
+//   replicated to the chroot. This handler bridges that — mothership
+//   POSTs each secondary kubeconfig to the chroot's catalyst-api at
+//   handover, the chroot writes them to disk and registers each one.
+//
+// Auth: requires sovereign-admin role (matches /admin/* surface).
+//
+// Idempotent: re-POSTing the same {depID, region} overwrites the file
+// + AddCluster on a duplicate ID is a no-op per k8sCache contract.
+
+package handler
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/k8scache"
+)
+
+// kubeconfigsDir is the canonical on-disk path FactoryFromEnv reads at
+// startup. Mirrored from k8scache/factory.go:982 default. Overridable
+// via CATALYST_K8SCACHE_KUBECONFIGS_DIR for tests + dev.
+func kubeconfigsDir() string {
+	if v := strings.TrimSpace(os.Getenv("CATALYST_K8SCACHE_KUBECONFIGS_DIR")); v != "" {
+		return v
+	}
+	return "/var/lib/catalyst/kubeconfigs"
+}
+
+// secondaryKubeconfigRequest is the POST body schema. RegionKey MUST
+// match the on-disk filename suffix convention `<depID>-<region>.yaml`
+// (e.g. depID="abc123", region="nbg1-1" → /var/lib/catalyst/kubeconfigs/
+// abc123-nbg1-1.yaml). KubeconfigYAML is the raw kubeconfig bytes.
+type secondaryKubeconfigRequest struct {
+	DeploymentID   string `json:"deploymentId"`
+	RegionKey      string `json:"regionKey"`
+	KubeconfigYAML string `json:"kubeconfigYaml"`
+}
+
+// safeIDPattern rejects path-traversal + shell-meta in deploymentId
+// and regionKey. Both come from authenticated callers but defense-in-
+// depth — the filename is composed from these and written to a
+// shared-PVC directory.
+var safeIDPattern = regexp.MustCompile(`^[a-z0-9][a-z0-9-]{0,62}$`)
+
+// HandleSovereignSecondaryKubeconfig handles POST
+// /api/v1/sovereign/secondary-kubeconfig.
+//
+// Per docs/INVIOLABLE-PRINCIPLES.md #10 the kubeconfig bytes are
+// written 0o600 and the directory inherits 0o700 from FactoryFromEnv's
+// initial mkdir. The bytes never enter a logged struct.
+func (h *Handler) HandleSovereignSecondaryKubeconfig(w http.ResponseWriter, r *http.Request) {
+	if h.k8sCache == nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]string{
+			"error":  "k8scache-unavailable",
+			"detail": "catalyst-api was started without k8sCache; cannot register a new cluster",
+		})
+		return
+	}
+	var body secondaryKubeconfigRequest
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{
+			"error":  "invalid-body",
+			"detail": "expect JSON {deploymentId, regionKey, kubeconfigYaml}",
+		})
+		return
+	}
+	body.DeploymentID = strings.TrimSpace(body.DeploymentID)
+	body.RegionKey = strings.TrimSpace(body.RegionKey)
+	if !safeIDPattern.MatchString(body.DeploymentID) {
+		writeJSON(w, http.StatusBadRequest, map[string]string{
+			"error":  "invalid-deploymentId",
+			"detail": "must match ^[a-z0-9][a-z0-9-]{0,62}$",
+		})
+		return
+	}
+	if !safeIDPattern.MatchString(body.RegionKey) {
+		writeJSON(w, http.StatusBadRequest, map[string]string{
+			"error":  "invalid-regionKey",
+			"detail": "must match ^[a-z0-9][a-z0-9-]{0,62}$",
+		})
+		return
+	}
+	raw := strings.TrimSpace(body.KubeconfigYAML)
+	if raw == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{
+			"error":  "kubeconfigYaml-required",
+			"detail": "kubeconfigYaml is required",
+		})
+		return
+	}
+	dir := kubeconfigsDir()
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		h.log.Warn("secondary-kubeconfig: mkdir failed", "dir", dir, "err", err)
+		writeJSON(w, http.StatusInternalServerError, map[string]string{
+			"error":  "dir-create-failed",
+			"detail": err.Error(),
+		})
+		return
+	}
+	clusterID := fmt.Sprintf("%s-%s", body.DeploymentID, body.RegionKey)
+	path := filepath.Join(dir, clusterID+".yaml")
+	if err := os.WriteFile(path, []byte(raw), 0o600); err != nil {
+		h.log.Warn("secondary-kubeconfig: write failed", "path", path, "err", err)
+		writeJSON(w, http.StatusInternalServerError, map[string]string{
+			"error":  "write-failed",
+			"detail": err.Error(),
+		})
+		return
+	}
+	if err := h.k8sCache.AddCluster(k8scache.ClusterRef{
+		ID:             clusterID,
+		KubeconfigPath: path,
+	}); err != nil {
+		// Best-effort: file persists so a catalyst-api restart will
+		// re-register the cluster via FactoryFromEnv's LoadClustersFromDir.
+		h.log.Warn("secondary-kubeconfig: AddCluster failed", "id", clusterID, "err", err)
+		writeJSON(w, http.StatusInternalServerError, map[string]string{
+			"error":  "add-cluster-failed",
+			"detail": err.Error(),
+		})
+		return
+	}
+	h.log.Info("secondary-kubeconfig: registered",
+		"depId", body.DeploymentID,
+		"region", body.RegionKey,
+		"clusterID", clusterID,
+	)
+	writeJSON(w, http.StatusCreated, map[string]string{
+		"status":    "registered",
+		"clusterID": clusterID,
+		"path":      path,
+	})
+}

--- a/products/catalyst/bootstrap/api/internal/handler/user_access_owner_seed.go
+++ b/products/catalyst/bootstrap/api/internal/handler/user_access_owner_seed.go
@@ -193,12 +193,23 @@ func buildOwnerUserAccessUnstructured(name, email, sovereignRef string) *unstruc
 			"keycloakSubject": email,
 		},
 		"sovereignRef": sovereignRef,
-		"applications": []any{
-			map[string]any{
-				"app":  "*",
-				"role": "admin", // owner → admin per userAccessTierToRole
-			},
-		},
+		// D21 fix on t135 2026-05-17: the prior seed used
+		// applications=[{app:"*", role:"admin"}] but the XRD schema
+		// rejects `app: "*"` (pattern `^[a-z0-9][a-z0-9-]{0,62}$`).
+		// `tierRoleRef` is the canonical owner-tier semantic per
+		// platform/crossplane-claims/chart/templates/xrds/useraccess.yaml
+		// — when set, the useraccess-controller binds the named
+		// ClusterRole on the target via RoleBinding/ClusterRoleBinding.
+		// `openova:tier-owner` is the canonical owner-tier ClusterRole
+		// shipped by EPIC-3 (#1098) slice T1's tier-clusterroles.yaml.
+		// Documented at user_access_owner_seed.go:103-104 as the right
+		// way to grant owner-tier without per-app entries.
+		"tierRoleRef": "openova:tier-owner",
+		// applications[] intentionally omitted — XRD pattern rejects
+		// `app: "*"`. tierRoleRef provides the owner-tier semantic
+		// directly; useraccess-controller binds openova:tier-owner
+		// ClusterRole + the operator's Keycloak subject via
+		// ClusterRoleBinding (since `scopes` is also empty/cluster-wide).
 	}
 	_ = unstructured.SetNestedMap(obj.Object, spec, "spec")
 	return obj

--- a/products/catalyst/bootstrap/api/internal/handler/user_access_owner_seed.go
+++ b/products/catalyst/bootstrap/api/internal/handler/user_access_owner_seed.go
@@ -75,6 +75,16 @@ const userAccessOwnerEmailAnnotation = "catalyst.openova.io/user-email"
 // limit (the apiserver rejects longer names with a 422).
 const userAccessOwnerNamePrefix = "useraccess-owner-"
 
+// userAccessOwnerNamespace is the namespace the auto-seeded owner CR
+// lives in. useraccesses.access.openova.io is a NAMESPACED Crossplane
+// Claim per platform/crossplane-claims/chart/templates/xrds/useraccess.yaml
+// (`claimNames` block). catalyst-system is canonical — every other
+// Catalyst-authored CR lives there too, and the listing/admin handler
+// at user_access.go::ListUserAccess uses `Namespace("")` which surfaces
+// CRs from every namespace, so the operator entry surfaces on /users
+// without per-namespace filtering. Caught on t134 2026-05-17.
+const userAccessOwnerNamespace = "catalyst-system"
+
 // EnsureOwnerUserAccess creates an owner-tier UserAccess CR for the
 // operator who just completed PIN-login + handover, if one does not
 // already exist. Idempotent: AlreadyExists is folded to a nil return.
@@ -114,9 +124,14 @@ func EnsureOwnerUserAccess(ctx context.Context, client dynamic.Interface, email,
 	sovRef := rbacAssignSlug(sovereignFQDN)
 
 	obj := buildOwnerUserAccessUnstructured(name, email, sovRef)
-
+	// D21 fix on t134 2026-05-17: the prior Namespace("") call returned
+	// "the server could not find the requested resource" because
+	// useraccesses.access.openova.io is NAMESPACED (Claim semantics per
+	// the XRD's claimNames block). Pin to catalyst-system + stamp the
+	// namespace on the CR object so the apiserver routes the Create.
+	obj.SetNamespace(userAccessOwnerNamespace)
 	_, err := client.Resource(UserAccessGVR()).
-		Namespace("").
+		Namespace(userAccessOwnerNamespace).
 		Create(ctx, obj, metav1.CreateOptions{})
 	if err != nil {
 		if apierrors.IsAlreadyExists(err) {


### PR DESCRIPTION
Dashboard handler now enumerates all registered k8sCache clusters when group_by includes cluster/region. Layer-1=Cluster renders N bubbles on N-region Sovereign. Pairs with PR #1579 (chroot kubeconfig endpoint) + future PR B (mothership handover sync hook).

🤖 Generated with [Claude Code](https://claude.com/claude-code)