### PR TITLE
feat(ui): PR M — dashboard default Layer-1=cluster + Marketplace Admin link + chart 1.4.150

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -502,7 +502,7 @@ spec:
       # - PR #1585: D17 /app/$componentId route-collision fix (catalyst-ui 2ab8a0e)
       # Caught on t136/t138 fresh-prov runs that bootstrap-kit was
       # still pinned to 1.4.147 → none of the fixes reached the chroot.
-      version: 1.4.149
+      version: 1.4.150
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/Dashboard.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/Dashboard.tsx
@@ -143,8 +143,21 @@ export function Dashboard({
   })
   const sovereignFQDN = snapshot?.sovereignFQDN ?? snapshot?.result?.sovereignFQDN ?? null
 
+  // PR M (2026-05-17 t142 founder follow-up #1): default Layer-1 = `cluster`
+  // on multi-region Sovereigns so the operator sees the 3-cluster grouping
+  // immediately. Previously default was `['family', 'application']` —
+  // founder opened /dashboard, saw family-grouped bubbles, concluded the
+  // multi-cluster fix was broken.
+  //
+  // Heuristic: snapshot reports the SovereignFQDN at adopt time. If we're
+  // on a Sovereign Console (sovereignFQDN present) default to cluster
+  // grouping; otherwise keep the historical family+application default
+  // for Catalyst-Zero (single-tenant mothership view).
+  const defaultLayers: readonly TreemapDimension[] = sovereignFQDN
+    ? ['cluster', 'application']
+    : ['family', 'application']
   const [layers, setLayers] = useState<readonly TreemapDimension[]>(
-    initialLayers ?? ['family', 'application'],
+    initialLayers ?? defaultLayers,
   )
   const [colorBy, setColorBy] = useState<TreemapColorBy>(initialColorBy ?? 'utilization')
   const [sizeBy, setSizeBy] = useState<TreemapSizeBy>(initialSizeBy ?? 'cpu_request')

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/SovereignSidebar.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/SovereignSidebar.tsx
@@ -251,6 +251,25 @@ export function SovereignSidebar({ sovereignFQDN }: SovereignSidebarProps) {
 
       {/* Navigation */}
       <nav className="flex-1 overflow-y-auto py-3" data-testid="sov-console-nav">
+        {/* PR M (2026-05-17 t142 founder follow-up #2): Marketplace Admin
+            link to the BSS back-office (billing/orders/revenue/vouchers).
+            Lives at marketplace.<sov-fqdn>/back-office/ (Astro storefront
+            with admin sub-app). External nav so opens in new tab. Founder
+            asked: "where is the console for the marketplace admin related
+            actions such as billing etc". */}
+        {resolvedFQDN ? (
+          <a
+            href={`https://marketplace.${resolvedFQDN}/back-office/`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="mx-2 flex items-center gap-3 rounded-lg px-3 py-2 text-sm no-underline transition-colors text-[var(--color-text-dim)] hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text)]"
+            data-testid="sov-console-nav-marketplace-admin"
+          >
+            <NavIcon d="M3 3h18l-2 14H5L3 3zM7 21a2 2 0 100-4 2 2 0 000 4zM17 21a2 2 0 100-4 2 2 0 000 4z" />
+            Marketplace Admin
+            <span className="ml-auto text-[var(--color-text-dimmer)]">↗</span>
+          </a>
+        ) : null}
         {FLAT_NAV.map((item) => {
           const isActive = activeSection === item.id
           const cls = isActive

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -1058,8 +1058,8 @@ name: bp-catalyst-platform
 # Fix #154 (HR-timeout audit). Those bumped the HelmRelease
 # install.timeout. This bumps the chart-INTERNAL wait loop budget
 # inside the pre-install hook Job, which is a different seam.
-version: 1.4.149
-appVersion: 1.4.149
+version: 1.4.150
+appVersion: 1.4.150
 # 1.4.141 (qa-loop Fix #185, prov #38/#39/#41 recurrence — pre-install
 # hook unscheduable on saturated worker):
 #


### PR DESCRIPTION
Two founder t142 follow-ups: (1) dashboard defaults Layer-1=cluster on Sovereign mode so 3-cluster grouping is the FIRST view (not buried behind toggle); (2) add 'Marketplace Admin' link to sidebar pointing to marketplace.<sov>/back-office/ where billing/orders/revenue BSS lives. 🤖 Generated with [Claude Code](https://claude.com/claude-code)