### PR TITLE
fix(handover): PR N — fallback to per-FQDN cert when wildcard 429s

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -502,7 +502,7 @@ spec:
       # - PR #1585: D17 /app/$componentId route-collision fix (catalyst-ui 2ab8a0e)
       # Caught on t136/t138 fresh-prov runs that bootstrap-kit was
       # still pinned to 1.4.147 → none of the fixes reached the chroot.
-      version: 1.4.150
+      version: 1.4.151
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/bootstrap/api/internal/handler/phase1_watch.go
+++ b/products/catalyst/bootstrap/api/internal/handler/phase1_watch.go
@@ -1205,10 +1205,37 @@ func wildcardCertReady(ctx context.Context, dyn dynamic.Interface) (bool, string
 	u, err := dyn.Resource(certificateGVR).
 		Namespace(sovereignWildcardCertNamespace).
 		Get(ctx, sovereignWildcardCertName, metav1.GetOptions{})
-	if err != nil {
-		return false, "<not-found>", err
+	if err == nil {
+		return certificateReady(u)
 	}
-	return certificateReady(u)
+	// PR N (2026-05-17 t143 LE rate-limit incident): when the canonical
+	// `sovereign-wildcard-tls` cert is unavailable (404 / 429 LE rate
+	// limit on the parent domain / DNS01 propagation lag), fall back to
+	// ANY per-FQDN sibling cert matching `sovereign-wildcard-tls-*`
+	// that's already Ready=True. The chart renders both names in
+	// multi-zone configurations (sovereign-wildcard-tls per-zone +
+	// sovereign-wildcard-tls-<fqdn> per-FQDN); either reaching Ready
+	// proves the operator's console.<fqdn> TLS handshake will succeed.
+	// Without this fallback, handover waits the full 10-min budget
+	// before firing degraded — operator browser can't reach the new
+	// Sovereign for that whole window.
+	list, listErr := dyn.Resource(certificateGVR).
+		Namespace(sovereignWildcardCertNamespace).
+		List(ctx, metav1.ListOptions{})
+	if listErr == nil && list != nil {
+		for i := range list.Items {
+			item := &list.Items[i]
+			name := item.GetName()
+			if !strings.HasPrefix(name, sovereignWildcardCertName+"-") {
+				continue
+			}
+			ok, _, _ := certificateReady(item)
+			if ok {
+				return true, "True (via fallback " + name + ")", nil
+			}
+		}
+	}
+	return false, "<not-found>", err
 }
 
 // certificateReady — returns (ready, observedStatus, nil) for a

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -1058,8 +1058,8 @@ name: bp-catalyst-platform
 # Fix #154 (HR-timeout audit). Those bumped the HelmRelease
 # install.timeout. This bumps the chart-INTERNAL wait loop budget
 # inside the pre-install hook Job, which is a different seam.
-version: 1.4.150
-appVersion: 1.4.150
+version: 1.4.151
+appVersion: 1.4.151
 # 1.4.141 (qa-loop Fix #185, prov #38/#39/#41 recurrence — pre-install
 # hook unscheduable on saturated worker):
 #


### PR DESCRIPTION
t143 hit LE PROD rate limit (50 certs/week on omani.works exhausted). The chart renders two cert names; the canonical was 429-stuck while the per-FQDN sibling was already Ready=True. waitForWildcardCert only checked the canonical, so handover waited the full 10-min budget. Fix: fall back to any `sovereign-wildcard-tls-*` sibling that's Ready. Both wildcard \*.<fqdn> so the TLS handshake works either way. + chart 1.4.151. 🤖 Generated with [Claude Code](https://claude.com/claude-code)