### PR TITLE
fix(infra): PR O — cilium-gateway TLS references per-zone wildcard cert (LE rate-limit fix)

### DIFF
--- a/clusters/_template/sovereign-tls/cilium-gateway.yaml
+++ b/clusters/_template/sovereign-tls/cilium-gateway.yaml
@@ -41,7 +41,7 @@ spec:
         mode: Terminate
         certificateRefs:
           - kind: Secret
-            name: sovereign-wildcard-tls
+            name: sovereign-wildcard-tls-${SOVEREIGN_FQDN_DASHED}
       allowedRoutes:
         namespaces:
           from: All

--- a/infra/hetzner/cloudinit-control-plane.tftpl
+++ b/infra/hetzner/cloudinit-control-plane.tftpl
@@ -926,6 +926,18 @@ write_files:
         postBuild:
           substitute:
             SOVEREIGN_FQDN: ${sovereign_fqdn}
+            # SOVEREIGN_FQDN_DASHED (2026-05-17 t143 incident): periods → dashes for K8s resource names.
+            # Used by sovereign-tls/cilium-gateway.yaml to reference the chart-rendered per-zone
+            # wildcard secret (sovereign-wildcard-tls-<dashed-fqdn>) instead of the legacy collision-prone name.
+            SOVEREIGN_FQDN_DASHED: ${replace(sovereign_fqdn, ".", "-")}
+            # SOVEREIGN_FQDN_DASHED — periods replaced with dashes for K8s resource
+            # name compliance. Used by sovereign-tls/cilium-gateway.yaml to
+            # reference the chart-rendered per-zone wildcard secret
+            # (sovereign-wildcard-tls-<dashed-fqdn>) instead of the legacy
+            # `sovereign-wildcard-tls` Secret name. Eliminates the LE rate-limit
+            # collision between legacy SAN cert + chart per-zone cert (2026-05-17
+            # t143 incident — both compete for omani.works quota).
+            SOVEREIGN_FQDN_DASHED: ${replace(sovereign_fqdn, ".", "-")}
             # SOVEREIGN_LB_IP — Hetzner load balancer's public IPv4 (issue
             # #900). Threaded into bp-catalyst-platform's
             # `global.sovereignLBIP` so catalyst-api can pre-register glue
@@ -1145,6 +1157,18 @@ write_files:
         postBuild:
           substitute:
             SOVEREIGN_FQDN: ${sovereign_fqdn}
+            # SOVEREIGN_FQDN_DASHED (2026-05-17 t143 incident): periods → dashes for K8s resource names.
+            # Used by sovereign-tls/cilium-gateway.yaml to reference the chart-rendered per-zone
+            # wildcard secret (sovereign-wildcard-tls-<dashed-fqdn>) instead of the legacy collision-prone name.
+            SOVEREIGN_FQDN_DASHED: ${replace(sovereign_fqdn, ".", "-")}
+            # SOVEREIGN_FQDN_DASHED — periods replaced with dashes for K8s resource
+            # name compliance. Used by sovereign-tls/cilium-gateway.yaml to
+            # reference the chart-rendered per-zone wildcard secret
+            # (sovereign-wildcard-tls-<dashed-fqdn>) instead of the legacy
+            # `sovereign-wildcard-tls` Secret name. Eliminates the LE rate-limit
+            # collision between legacy SAN cert + chart per-zone cert (2026-05-17
+            # t143 incident — both compete for omani.works quota).
+            SOVEREIGN_FQDN_DASHED: ${replace(sovereign_fqdn, ".", "-")}
             # SOVEREIGN_LB_IP — Hetzner load balancer's public IPv4 (issue
             # #900). Threaded into bp-catalyst-platform's
             # `global.sovereignLBIP` so catalyst-api can pre-register glue
@@ -1196,6 +1220,18 @@ write_files:
         postBuild:
           substitute:
             SOVEREIGN_FQDN: ${sovereign_fqdn}
+            # SOVEREIGN_FQDN_DASHED (2026-05-17 t143 incident): periods → dashes for K8s resource names.
+            # Used by sovereign-tls/cilium-gateway.yaml to reference the chart-rendered per-zone
+            # wildcard secret (sovereign-wildcard-tls-<dashed-fqdn>) instead of the legacy collision-prone name.
+            SOVEREIGN_FQDN_DASHED: ${replace(sovereign_fqdn, ".", "-")}
+            # SOVEREIGN_FQDN_DASHED — periods replaced with dashes for K8s resource
+            # name compliance. Used by sovereign-tls/cilium-gateway.yaml to
+            # reference the chart-rendered per-zone wildcard secret
+            # (sovereign-wildcard-tls-<dashed-fqdn>) instead of the legacy
+            # `sovereign-wildcard-tls` Secret name. Eliminates the LE rate-limit
+            # collision between legacy SAN cert + chart per-zone cert (2026-05-17
+            # t143 incident — both compete for omani.works quota).
+            SOVEREIGN_FQDN_DASHED: ${replace(sovereign_fqdn, ".", "-")}
             # SOVEREIGN_LB_IP — Hetzner load balancer's public IPv4 (issue
             # #900). Threaded into bp-catalyst-platform's
             # `global.sovereignLBIP` so catalyst-api can pre-register glue


### PR DESCRIPTION
t143 hit LE rate limit; legacy + chart cert templates competed for the same omani.works quota. Gateway hardcoded the legacy Secret name; when 429 hits, HTTPS breaks. Fix: gateway references chart's per-zone Secret name via SOVEREIGN_FQDN_DASHED substitution. 🤖 Generated with [Claude Code](https://claude.com/claude-code)