### PR TITLE
fix(store): PR P — preserve MarketplaceEnabled through Redact (t144 founder bug #5 deep fix)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -502,7 +502,7 @@ spec:
       # - PR #1585: D17 /app/$componentId route-collision fix (catalyst-ui 2ab8a0e)
       # Caught on t136/t138 fresh-prov runs that bootstrap-kit was
       # still pinned to 1.4.147 → none of the fixes reached the chroot.
-      version: 1.4.151
+      version: 1.4.152
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/bootstrap/api/internal/store/store.go
+++ b/products/catalyst/bootstrap/api/internal/store/store.go
@@ -191,6 +191,15 @@ type RedactedRequest struct {
 	ObjectStorageBucket    string `json:"objectStorageBucket,omitempty"`
 	ObjectStorageAccessKey string `json:"objectStorageAccessKey,omitempty"`
 	ObjectStorageSecretKey string `json:"objectStorageSecretKey,omitempty"`
+
+	// MarketplaceEnabled — PR P (2026-05-17 t144 founder bug #5 deep fix):
+	// preserve the prov-body flag through persistence + export so the
+	// chroot's GET /api/v1/sovereigns/{id}/marketplace endpoint
+	// (PR J #1590) returns the actual value instead of false. Without
+	// this field on the RedactedRequest, every export-then-load cycle
+	// stripped the bit and /settings/marketplace toggle defaulted to
+	// disabled even on a marketplace-enabled Sovereign.
+	MarketplaceEnabled bool `json:"marketplaceEnabled,omitempty"`
 }
 
 // Redact returns a RedactedRequest derived from req with every
@@ -225,6 +234,8 @@ func Redact(req provisioner.Request) RedactedRequest {
 		// Secret stringData on every reconciliation. Persisted verbatim.
 		ObjectStorageRegion: req.ObjectStorageRegion,
 		ObjectStorageBucket: req.ObjectStorageBucket,
+		// PR P (2026-05-17): MarketplaceEnabled preserved through redact path.
+		MarketplaceEnabled: req.MarketplaceEnabled,
 	}
 	// Credentials: present-and-non-empty → redactedMarker; empty → empty.
 	// This is the test-load-bearing branch for TestRedact_OmitsAllSecrets.
@@ -289,6 +300,7 @@ func (r RedactedRequest) ToProvisionerRequest() provisioner.Request {
 		ObjectStorageBucket:    r.ObjectStorageBucket,
 		ObjectStorageAccessKey: r.ObjectStorageAccessKey,
 		ObjectStorageSecretKey: r.ObjectStorageSecretKey,
+		MarketplaceEnabled:     r.MarketplaceEnabled,
 	}
 }
 

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -1058,8 +1058,8 @@ name: bp-catalyst-platform
 # Fix #154 (HR-timeout audit). Those bumped the HelmRelease
 # install.timeout. This bumps the chart-INTERNAL wait loop budget
 # inside the pre-install hook Job, which is a different seam.
-version: 1.4.151
-appVersion: 1.4.151
+version: 1.4.152
+appVersion: 1.4.152
 # 1.4.141 (qa-loop Fix #185, prov #38/#39/#41 recurrence — pre-install
 # hook unscheduable on saturated worker):
 #


### PR DESCRIPTION
Founder t144 bug #5 deep fix. RedactedRequest struct was missing MarketplaceEnabled field — Save/Export stripped the bit, GET endpoint (PR J) read zero value. Fix: add the field + carry through Redact() + ToProvisionerRequest(). Chart 1.4.152. 🤖 Generated with [Claude Code](https://claude.com/claude-code)