### PR TITLE
feat(ui): Family F — BSS in Sovereign Console (/console/bss/*) (founder #1)

### DIFF
--- a/products/catalyst/bootstrap/ui/src/app/router.tsx
+++ b/products/catalyst/bootstrap/ui/src/app/router.tsx
@@ -117,6 +117,19 @@ import { ResourcesSearchPage } from '@/pages/sovereign/resources/ResourcesSearch
 import { ResourcesListPage } from '@/pages/sovereign/resources/ResourcesListPage'
 import { ResourceDetailNoTabPage } from '@/pages/sovereign/stubs/ResourceDetailNoTabPage'
 import { PodLogsPage } from '@/pages/sovereign/resources/PodLogsPage'
+// Family F (Wave 3, t10 C6-003/004/005) — BSS-in-console.
+// Founder #1 requirement: "the backed of the the mark place mutst be
+// just aotnerh menu under console like https://console.<sov>/bss".
+// BssLayout shells the 5 sub-sections (Billing/Orders/Revenue/Vouchers/
+// Tenants) and iframes the canonical back-office served by the admin
+// Pod in the sme namespace. See pages/sovereign/bss/BssLayout.tsx for
+// the architecture rationale (option B — iframe over re-port).
+import { BssLayout } from '@/pages/sovereign/bss/BssLayout'
+import { BillingPage as BssBillingPage } from '@/pages/sovereign/bss/BillingPage'
+import { OrdersPage as BssOrdersPage } from '@/pages/sovereign/bss/OrdersPage'
+import { RevenuePage as BssRevenuePage } from '@/pages/sovereign/bss/RevenuePage'
+import { VouchersPage as BssVouchersPage } from '@/pages/sovereign/bss/VouchersPage'
+import { TenantsPage as BssTenantsPage } from '@/pages/sovereign/bss/TenantsPage'
 import {
   canonicalisePath,
   hasCatalystSession,
@@ -1471,6 +1484,79 @@ const consoleNotificationsRoute = createRoute({
   component: NotificationsPage,
 })
 
+/* ── Family F (Wave 3) — BSS-in-console routes ─────────────────────────
+ *
+ * Founder #1 requirement (2026-05-17 family-F brief):
+ *   "the backed of the the mark place mutst be just aotnerh menu under
+ *    console like https://console.<sov>/bss"
+ *   "it is just matter of roles based access ... where we give the
+ *    billing access they see the billign etc."
+ *
+ * Replaces the external "Marketplace Admin ↗" sidebar link (PR M,
+ * 2026-05-17 t142 follow-up #2) that punted operators out of the
+ * Sovereign Console SPA to marketplace.<sov-fqdn>/back-office/. Founder
+ * called that URL "rubbish" — the canonical surface is /console/bss/*.
+ *
+ * Route shape:
+ *
+ *   /bss                → redirect to /bss/billing (default landing)
+ *   /bss/billing        → BillingPage (iframes back-office/billing/)
+ *   /bss/orders         → OrdersPage  (iframes back-office/orders/)
+ *   /bss/revenue        → RevenuePage (iframes back-office/revenue/)
+ *   /bss/vouchers       → VouchersPage(iframes back-office/vouchers/)
+ *   /bss/tenants        → TenantsPage (iframes back-office/tenants/)
+ *
+ * RBAC: gated at TWO layers — the SovereignSidebar groups BSS under an
+ * admin-visible heading (unconditional for v1; future RBAC sprint adds
+ * tier in whoami) and the SME gateway's session-tier check enforces
+ * /back-office/* access server-side. The route registrations themselves
+ * are always present so a deep-link from a billing-engineer welcome
+ * email resolves cleanly to the SovereignConsoleLayout auth gate.
+ *
+ * Implementation note: BssLayout owns the tab-strip chrome + iframe
+ * wrapper. The 5 section pages are 3-line wrappers that select the
+ * back-office sub-path. Per docs/INVIOLABLE-PRINCIPLES.md #4 the
+ * back-office host is derived at runtime from DETECTED_MODE.sovereignFQDN.
+ */
+const consoleBssLayoutRoute = createRoute({
+  getParentRoute: () => consoleLayoutRoute,
+  id: '_bss_layout',
+  component: BssLayout,
+})
+const consoleBssIndexRoute = createRoute({
+  getParentRoute: () => consoleLayoutRoute,
+  path: '/bss',
+  component: NoopRedirectComponent,
+  beforeLoad: () => {
+    throw redirect({ to: '/bss/billing' as never, replace: true })
+  },
+})
+const consoleBssBillingRoute = createRoute({
+  getParentRoute: () => consoleBssLayoutRoute,
+  path: '/bss/billing',
+  component: BssBillingPage,
+})
+const consoleBssOrdersRoute = createRoute({
+  getParentRoute: () => consoleBssLayoutRoute,
+  path: '/bss/orders',
+  component: BssOrdersPage,
+})
+const consoleBssRevenueRoute = createRoute({
+  getParentRoute: () => consoleBssLayoutRoute,
+  path: '/bss/revenue',
+  component: BssRevenuePage,
+})
+const consoleBssVouchersRoute = createRoute({
+  getParentRoute: () => consoleBssLayoutRoute,
+  path: '/bss/vouchers',
+  component: BssVouchersPage,
+})
+const consoleBssTenantsRoute = createRoute({
+  getParentRoute: () => consoleBssLayoutRoute,
+  path: '/bss/tenants',
+  component: BssTenantsPage,
+})
+
 /* ── Sovereign-mode cloud legacy redirects (TC-090..092 / 2026-05-07) ─
  *
  * Sister set to LEGACY_CLOUD_REDIRECTS (which is mounted under the
@@ -1962,6 +2048,17 @@ const routeTree = rootRoute.addChildren([
     consoleSecComplianceRoute,
     consoleCompliancePolicyDrilldownRoute,
     consoleNotificationsRoute,
+    // Family F (Wave 3, t10 C6-003/004/005) — BSS-in-console.
+    // /bss → redirect to /bss/billing; section pages live under
+    // a pathless BssLayout wrapper (provides tab strip + iframe shell).
+    consoleBssIndexRoute,
+    consoleBssLayoutRoute.addChildren([
+      consoleBssBillingRoute,
+      consoleBssOrdersRoute,
+      consoleBssRevenueRoute,
+      consoleBssVouchersRoute,
+      consoleBssTenantsRoute,
+    ]),
   ]),
 ])
 

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/SovereignSidebar.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/SovereignSidebar.tsx
@@ -34,7 +34,7 @@ const CLOUD_ICON =
   'M6.657 18c-2.572 0 -4.657 -2.007 -4.657 -4.483c0 -2.475 2.085 -4.482 4.657 -4.482c.393 -1.762 1.794 -3.2 3.675 -3.773c1.88 -.572 3.956 -.193 5.444 1c1.488 1.19 2.162 3.007 1.77 4.769h.99c1.913 0 3.464 1.56 3.464 3.486c0 1.927 -1.551 3.487 -3.465 3.487h-11.878'
 
 interface FlatNavItem {
-  id: 'apps' | 'jobs' | 'dashboard' | 'cloud' | 'users' | 'settings'
+  id: 'apps' | 'jobs' | 'dashboard' | 'cloud' | 'users' | 'bss' | 'settings'
   label: string
   to: string
   icon: string
@@ -71,6 +71,27 @@ const FLAT_NAV: FlatNavItem[] = [
     to: '/users',
     icon: 'M9 7a4 4 0 100 8 4 4 0 000-8zM3 21v-2a4 4 0 014-4h4a4 4 0 014 4v2M16 3.13a4 4 0 010 7.75M21 21v-2a4 4 0 00-3-3.87',
   },
+  // BSS — Business Support (Family F, Wave 3, founder #1 / 2026-05-17).
+  // Replaces the external "Marketplace Admin ↗" link added by PR M
+  // which punted operators out of the Sovereign Console to
+  // marketplace.<sov-fqdn>/back-office/. Founder ruling: "the backed
+  // of the the mark place mutst be just aotnerh menu under console
+  // like https://console.<sov>/bss". The /bss entry redirects to
+  // /bss/billing (default landing); the BssLayout tab strip surfaces
+  // Billing / Orders / Revenue / Vouchers / Tenants.
+  //
+  // RBAC: this entry is always visible for v1 — the whoami payload
+  // doesn't expose tier yet, and the SME gateway's session-tier check
+  // server-side enforces /back-office/* access for the iframe. When
+  // whoami grows a `tier` field the sidebar can hide for tier=user.
+  {
+    id: 'bss',
+    label: 'BSS',
+    to: '/bss',
+    // Receipt / paper icon — distinct from cart (which connotes the
+    // public storefront customers see, not the BSS admin surface).
+    icon: 'M9 2h6a1 1 0 011 1v18l-2-1.5L13 21l-1.5-1.5L10 21l-1.5-1.5L7 21l-1-1-2 1.5V3a1 1 0 011-1h4zM9 7h6M9 11h6M9 15h4',
+  },
 ]
 
 const SETTINGS_ITEM: FlatNavItem = {
@@ -106,7 +127,7 @@ const SETTINGS_SUB_NAV: SubNavItem[] = [
 
 // ── Active-state derivation ───────────────────────────────────────────────────
 
-type ActiveSection = 'apps' | 'jobs' | 'dashboard' | 'cloud' | 'users' | 'settings'
+type ActiveSection = 'apps' | 'jobs' | 'dashboard' | 'cloud' | 'users' | 'bss' | 'settings'
 
 const CLOUD_PATH_RE = /^\/(cloud|infrastructure)(\/|$)/
 
@@ -115,6 +136,10 @@ function deriveActiveSection(pathname: string): ActiveSection {
   if (/^\/dashboard(\/|$)/.test(pathname)) return 'dashboard'
   if (/^\/jobs(\/|$)/.test(pathname)) return 'jobs'
   if (/^\/users(\/|$)/.test(pathname)) return 'users'
+  // /bss(/*) → 'bss' so the BSS nav item highlights for every BSS
+  // sub-tab (billing/orders/revenue/vouchers/tenants). Family F
+  // (Wave 3, 2026-05-17, founder #1).
+  if (/^\/bss(\/|$)/.test(pathname)) return 'bss'
   // /settings/* OR /parent-domains → 'settings' so the Settings nav
   // item highlights and the sub-nav (Marketplace + Parent Domains)
   // expands. Per inviolable principle #4, the path list is pulled
@@ -251,25 +276,12 @@ export function SovereignSidebar({ sovereignFQDN }: SovereignSidebarProps) {
 
       {/* Navigation */}
       <nav className="flex-1 overflow-y-auto py-3" data-testid="sov-console-nav">
-        {/* PR M (2026-05-17 t142 founder follow-up #2): Marketplace Admin
-            link to the BSS back-office (billing/orders/revenue/vouchers).
-            Lives at marketplace.<sov-fqdn>/back-office/ (Astro storefront
-            with admin sub-app). External nav so opens in new tab. Founder
-            asked: "where is the console for the marketplace admin related
-            actions such as billing etc". */}
-        {resolvedFQDN ? (
-          <a
-            href={`https://marketplace.${resolvedFQDN}/back-office/`}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="mx-2 flex items-center gap-3 rounded-lg px-3 py-2 text-sm no-underline transition-colors text-[var(--color-text-dim)] hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-text)]"
-            data-testid="sov-console-nav-marketplace-admin"
-          >
-            <NavIcon d="M3 3h18l-2 14H5L3 3zM7 21a2 2 0 100-4 2 2 0 000 4zM17 21a2 2 0 100-4 2 2 0 000 4z" />
-            Marketplace Admin
-            <span className="ml-auto text-[var(--color-text-dimmer)]">↗</span>
-          </a>
-        ) : null}
+        {/* Family F (Wave 3, 2026-05-17): the external "Marketplace Admin ↗"
+            link added by PR M (t142 follow-up #2) was deleted here per
+            founder #1 ruling — "this url is rubbish, the backed of the
+            the mark place mutst be just aotnerh menu under console
+            like https://console.<sov>/bss". The BSS group below is the
+            new canonical surface (in-SPA, RBAC-gated, no external tab). */}
         {FLAT_NAV.map((item) => {
           const isActive = activeSection === item.id
           const cls = isActive

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/bss/BillingPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/bss/BillingPage.tsx
@@ -1,0 +1,16 @@
+/**
+ * BillingPage — /console/bss/billing.
+ *
+ * Iframes the canonical back-office Billing surface from the admin Pod
+ * (sme namespace, served via marketplace.<sov-fqdn>/back-office/billing/).
+ * The Sovereign Console URL stays clean (`/bss/billing`) so the founder
+ * #1 requirement — "another menu under console like console.<sov>/bss" —
+ * is met while reusing the existing production back-office UI.
+ *
+ * See BssLayout.tsx for the architecture rationale (option B — iframe).
+ */
+import { BssIframe } from './BssLayout'
+
+export function BillingPage() {
+  return <BssIframe path="billing" title="BSS — Billing" />
+}

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/bss/BssLayout.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/bss/BssLayout.tsx
@@ -1,0 +1,201 @@
+/**
+ * BssLayout — shared chrome for /console/bss/* (founder #1 requirement).
+ *
+ * Founder ruling (2026-05-17, family-F brief):
+ *   "the backed of the the mark place mutst be just aotnerh menu under
+ *    console like https://console.<sov>/bss"
+ *   "it is just matter of roles based access ... where we give the
+ *    billing access they see the billign etc."
+ *
+ * Architecture (option B — iframe embed):
+ *
+ *   Public URL the operator sees   : console.<sov-fqdn>/bss/<section>
+ *   Iframe src (server-rendered UI): https://marketplace.<sov-fqdn>/back-office/<section>/
+ *
+ * The admin Pod in the sme namespace (chart template
+ * templates/sme-services/admin.yaml) already serves the BSS UI on the
+ * marketplace HTTPRoute's /back-office/ prefix; this layout keeps the
+ * Sovereign Console URL canonical while reusing the existing,
+ * production-ready back-office surfaces (billing, orders, revenue,
+ * vouchers, tenants).
+ *
+ * Why iframe and not a fresh port:
+ *
+ *   1. The back-office is its own SPA + service surface; re-implementing
+ *      5 admin pages in React would be a ~3k-line port that drifts away
+ *      from the canonical Astro storefront. Iframe is the lowest-drift
+ *      shipping pattern.
+ *   2. Authentication: same-origin cookies on `*.<sov-fqdn>` cover the
+ *      iframe's cross-subdomain XHR. The admin Pod still gates on the
+ *      SME gateway's session.
+ *   3. RBAC gating happens at TWO layers — sidebar visibility (this PR;
+ *      always-on for v1 since the whoami payload doesn't yet expose
+ *      tier — pattern matches /rbac/* and /sre/compliance which are
+ *      similarly unconditional today) and the SME gateway's
+ *      session-tier check on /back-office/* requests (already shipped).
+ *      When whoami grows a `tier` field we add a beforeLoad gate.
+ *
+ * Per docs/INVIOLABLE-PRINCIPLES.md #4 (never hardcode): the back-office
+ * host is derived from `DETECTED_MODE.sovereignFQDN` at runtime, never
+ * baked at build time.
+ */
+
+import { Link, Outlet, useRouterState } from '@tanstack/react-router'
+import { DETECTED_MODE } from '@/shared/lib/detectMode'
+
+interface BssTab {
+  id: 'billing' | 'orders' | 'revenue' | 'vouchers' | 'tenants'
+  label: string
+  to: string
+  /** Sub-path under the admin Pod's `/back-office/` mount. */
+  backOfficePath: string
+}
+
+export const BSS_TABS: BssTab[] = [
+  { id: 'billing', label: 'Billing', to: '/bss/billing', backOfficePath: 'billing' },
+  { id: 'orders', label: 'Orders', to: '/bss/orders', backOfficePath: 'orders' },
+  { id: 'revenue', label: 'Revenue', to: '/bss/revenue', backOfficePath: 'revenue' },
+  { id: 'vouchers', label: 'Vouchers', to: '/bss/vouchers', backOfficePath: 'vouchers' },
+  { id: 'tenants', label: 'Tenants', to: '/bss/tenants', backOfficePath: 'tenants' },
+]
+
+function deriveActiveTab(pathname: string): BssTab['id'] | null {
+  for (const tab of BSS_TABS) {
+    if (pathname === tab.to || pathname.startsWith(tab.to + '/')) return tab.id
+  }
+  return null
+}
+
+/**
+ * Resolve the back-office base URL.
+ *
+ * On Sovereign clusters (console.<sov-fqdn>) the marketplace storefront
+ * sits at marketplace.<sov-fqdn>. On Catalyst-Zero (contabo) the
+ * marketplace isn't deployed — render an explanatory placeholder
+ * instead of an iframe that would 404.
+ */
+export function resolveBackOfficeBase(): string | null {
+  const fqdn = DETECTED_MODE.sovereignFQDN
+  if (!fqdn) return null
+  return `https://marketplace.${fqdn}/back-office`
+}
+
+export function BssLayout() {
+  const pathname = useRouterState({ select: (s) => s.location.pathname })
+  const activeTab = deriveActiveTab(pathname)
+  const backOfficeBase = resolveBackOfficeBase()
+
+  return (
+    <div
+      className="flex h-full min-h-0 flex-col bg-[var(--color-bg)]"
+      data-testid="sov-bss-layout"
+    >
+      {/* Header — section title + sub-nav tab strip */}
+      <header className="border-b border-[var(--color-border)] bg-[var(--color-bg-2)] px-6 pt-5">
+        <div className="mb-3 flex items-baseline justify-between">
+          <h1
+            className="text-xl font-semibold text-[var(--color-text-strong)]"
+            data-testid="sov-bss-page-title"
+          >
+            BSS — Business Support
+          </h1>
+          <p className="text-xs text-[var(--color-text-dim)]">
+            Billing, orders, revenue, vouchers, and tenant administration
+          </p>
+        </div>
+        <nav
+          className="flex flex-wrap gap-1"
+          data-testid="sov-bss-tab-strip"
+          role="tablist"
+          aria-label="BSS sections"
+        >
+          {BSS_TABS.map((tab) => {
+            const isActive = activeTab === tab.id
+            const cls = isActive
+              ? 'border-[var(--color-accent)] text-[var(--color-accent)]'
+              : 'border-transparent text-[var(--color-text-dim)] hover:text-[var(--color-text)]'
+            return (
+              <Link
+                key={tab.id}
+                to={tab.to as never}
+                role="tab"
+                aria-selected={isActive}
+                aria-current={isActive ? 'page' : undefined}
+                className={`-mb-px border-b-2 px-3 py-2 text-sm font-medium no-underline transition-colors ${cls}`}
+                data-testid={`sov-bss-tab-${tab.id}`}
+              >
+                {tab.label}
+              </Link>
+            )
+          })}
+        </nav>
+      </header>
+
+      {/* Body — the active sub-page renders the iframe via <Outlet/> */}
+      <div className="flex flex-1 min-h-0 flex-col">
+        {backOfficeBase ? (
+          <Outlet />
+        ) : (
+          <NoMarketplaceHint />
+        )}
+      </div>
+    </div>
+  )
+}
+
+/**
+ * NoMarketplaceHint — rendered when DETECTED_MODE has no Sovereign FQDN
+ * (Catalyst-Zero mothership preview). The back-office UI doesn't exist
+ * outside a Sovereign cluster, so we surface that instead of iframing
+ * a 404.
+ */
+function NoMarketplaceHint() {
+  return (
+    <div
+      className="m-6 rounded-md border border-[var(--color-border)] bg-[var(--color-bg-2)] p-6 text-sm text-[var(--color-text-dim)]"
+      data-testid="sov-bss-no-marketplace"
+    >
+      <p className="font-medium text-[var(--color-text)]">
+        BSS is a Sovereign-only surface.
+      </p>
+      <p className="mt-2">
+        Open a deployed Sovereign Console (e.g.&nbsp;
+        <span className="font-mono">https://console.&lt;your-sov-fqdn&gt;/bss/billing</span>) to
+        manage billing, orders, revenue, vouchers, and tenants.
+      </p>
+    </div>
+  )
+}
+
+/**
+ * BssIframe — shared iframe wrapper for the per-section pages.
+ *
+ * Each section page (BillingPage, OrdersPage, …) is a 3-line wrapper
+ * that calls this with its `path`. Centralising the iframe attributes
+ * keeps sandbox/referrer/title consistent and means we only update the
+ * iframe contract in one place.
+ *
+ * `sandbox` is intentionally permissive — the back-office is FIRST-party
+ * content served from a sibling subdomain of the same Sovereign, NOT
+ * untrusted third-party UI. We allow scripts + same-origin (so cookie
+ * auth works), forms + popups (so order-detail drill-downs can open
+ * external receipts), and downloads (so Revenue CSV export works).
+ */
+export function BssIframe({ path, title }: { path: string; title: string }) {
+  const base = resolveBackOfficeBase()
+  if (!base) return null
+  const src = `${base}/${path}/`
+  return (
+    <iframe
+      key={src}
+      src={src}
+      title={title}
+      className="h-full w-full flex-1 border-0 bg-[var(--color-bg)]"
+      sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-downloads allow-modals"
+      referrerPolicy="same-origin"
+      loading="eager"
+      data-testid={`sov-bss-iframe-${path}`}
+      data-back-office-src={src}
+    />
+  )
+}

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/bss/OrdersPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/bss/OrdersPage.tsx
@@ -1,0 +1,11 @@
+/**
+ * OrdersPage — /console/bss/orders.
+ *
+ * Iframes the canonical back-office Orders surface. See BssLayout.tsx
+ * for the architecture rationale (option B — iframe).
+ */
+import { BssIframe } from './BssLayout'
+
+export function OrdersPage() {
+  return <BssIframe path="orders" title="BSS — Orders" />
+}

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/bss/RevenuePage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/bss/RevenuePage.tsx
@@ -1,0 +1,11 @@
+/**
+ * RevenuePage — /console/bss/revenue.
+ *
+ * Iframes the canonical back-office Revenue surface. See BssLayout.tsx
+ * for the architecture rationale (option B — iframe).
+ */
+import { BssIframe } from './BssLayout'
+
+export function RevenuePage() {
+  return <BssIframe path="revenue" title="BSS — Revenue" />
+}

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/bss/TenantsPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/bss/TenantsPage.tsx
@@ -1,0 +1,12 @@
+/**
+ * TenantsPage — /console/bss/tenants.
+ *
+ * Iframes the canonical back-office Tenants admin surface (SME tenant
+ * roster, suspend / resume / impersonate, billing-account linkage).
+ * See BssLayout.tsx for the architecture rationale (option B — iframe).
+ */
+import { BssIframe } from './BssLayout'
+
+export function TenantsPage() {
+  return <BssIframe path="tenants" title="BSS — Tenants" />
+}

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/bss/VouchersPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/bss/VouchersPage.tsx
@@ -1,0 +1,15 @@
+/**
+ * VouchersPage — /console/bss/vouchers.
+ *
+ * Iframes the canonical back-office Vouchers surface. See BssLayout.tsx
+ * for the architecture rationale (option B — iframe).
+ *
+ * Backend already shipped (issue #828): /billing/vouchers/{issue,list,
+ * revoke,redeem-preview}. The UI surface for issuing + revoking lives
+ * in the back-office Pod.
+ */
+import { BssIframe } from './BssLayout'
+
+export function VouchersPage() {
+  return <BssIframe path="vouchers" title="BSS — Vouchers" />
+}


### PR DESCRIPTION
## Summary

Family F (Wave 3, Fix-Author) — moves BSS admin (billing/orders/revenue/vouchers/tenants) from `marketplace.<sov-fqdn>/back-office/` INTO the Sovereign Console SPA as `/console/bss/*`, per founder #1 ruling 2026-05-17:

> "this url is rubbish, the backed of the the mark place mutst be just aotnerh menu under console like `https://console.<sov>/bss`"
> "it is just matter of roles based access to implatement there. So people where we give the billing access they see the billign etc."

Fixes test agent D failures on t10: **C6-003** (/bss redirects to /cloud), **C6-004** (BSS routes not in console SPA — cannot RBAC-gate what doesn't exist), **C6-005** (sidebar regrouping not implemented).

## Architecture decision — Option B (iframe embed)

- The `admin` Pod in the `sme` namespace (chart template `templates/sme-services/admin.yaml`, already shipped) already serves the BSS UI under `marketplace.<sov-fqdn>/back-office/`
- Iframing reuses the production back-office SPA verbatim instead of re-porting 5 admin pages into React (~3k-line port that would drift away from canonical Astro storefront)
- Cookies on `*.<sov-fqdn>` cover the iframe's cross-subdomain XHR; the SME gateway's session-tier check on `/back-office/*` requests is already shipped server-side
- `BssLayout` owns the shared chrome (page title + 5-tab strip + iframe wrapper); the 5 section pages are 3-line wrappers that select the back-office sub-path
- Per INVIOLABLE-PRINCIPLES #4 (never hardcode), the back-office host is derived at runtime from `DETECTED_MODE.sovereignFQDN`, never baked at build time

## Routes added (all under `consoleLayoutRoute`)

| Path | Component | Iframe src |
|---|---|---|
| `/bss` | (redirect) | → `/bss/billing` |
| `/bss/billing` | `BillingPage` | `marketplace.<sov>/back-office/billing/` |
| `/bss/orders` | `OrdersPage` | `marketplace.<sov>/back-office/orders/` |
| `/bss/revenue` | `RevenuePage` | `marketplace.<sov>/back-office/revenue/` |
| `/bss/vouchers` | `VouchersPage` | `marketplace.<sov>/back-office/vouchers/` |
| `/bss/tenants` | `TenantsPage` | `marketplace.<sov>/back-office/tenants/` |

## RBAC gating (two layers)

1. **Sidebar visibility** — BSS appears as a top-level nav item (replacing the external "Marketplace Admin ↗" anchor PR M added). Unconditional for v1 since `/api/v1/whoami` doesn't yet expose tier — pattern matches existing `/rbac/*` and `/sre/compliance` routes which are similarly unconditional today. When whoami grows a `tier` field the sidebar can hide for `tier=user`.
2. **SME gateway session-tier check** on `/back-office/*` requests — already shipped server-side; iframe XHR cannot bypass it.

## Files touched

- `products/catalyst/bootstrap/ui/src/app/router.tsx` — 6 new route defs + imports + wired into `consoleLayoutRoute.addChildren([...])`
- `products/catalyst/bootstrap/ui/src/pages/sovereign/SovereignSidebar.tsx` — added BSS to `FLAT_NAV`, extended `deriveActiveSection`, removed the external "Marketplace Admin ↗" link
- `products/catalyst/bootstrap/ui/src/pages/sovereign/bss/BssLayout.tsx` (new) — tab strip + iframe shell
- `products/catalyst/bootstrap/ui/src/pages/sovereign/bss/{Billing,Orders,Revenue,Vouchers,Tenants}Page.tsx` (new, 5 files) — 3-line section wrappers

## Hard-rule compliance

- READ-ONLY clusters — no kubectl, no Flux suspend
- No Chart.yaml or bootstrap-kit pin bump (per family-F brief)
- No modifications to other route definitions besides adding the BSS routes (rebases clean on Wave 1 PR #1597)
- `tsc -b --noEmit` clean — no errors on `router.tsx`, `SovereignSidebar.tsx`, or `bss/*`

## Test plan

- [ ] Wave 4 t11 fresh prov: visit `https://console.<t11-fqdn>/bss` → expect 302 to `/bss/billing`
- [ ] Sidebar shows "BSS" item with receipt icon (no external Marketplace Admin link)
- [ ] Click each of Billing / Orders / Revenue / Vouchers / Tenants tabs → iframe loads back-office sub-page at `marketplace.<t11-fqdn>/back-office/<section>/`
- [ ] URL bar stays `console.<t11-fqdn>/bss/<section>` (founder #1 contract)
- [ ] BSS tab highlights when on any `/bss/*` deep-link (deriveActiveSection regression test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)