### PR TITLE
chore(release): chart 1.4.153→1.4.154 — Wave 2 collector (B/C/D/E/F/G)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -506,7 +506,33 @@ spec:
       # no longer drifts to /dashboard (kind-alias map in
       # router.tsx validateSearch). Caught on t10.omantel.biz
       # test agents E/C2 2026-05-17.
-      version: 1.4.153
+      # 1.4.154 — Wave 2 collector PR. Bundles 6 Fix-Author PRs that
+      # landed AFTER the 1.4.153 Wave-1 roll, all from the same t10
+      # test sweep:
+      # - #1598 Family F: BSS menu in Sovereign Console
+      #   (Billing/Orders/Revenue/Vouchers/Tenants iframe-embed of
+      #   marketplace.<fqdn>/back-office/*). Founder bug #1.
+      # - #1599 Family D: dashboard treemap fan-out for cluster /
+      #   region / vcluster / family + Layer-1 cluster default.
+      #   Founder bug #2.
+      # - #1600 Family C: ResourceDetailPage real-data rewrite —
+      #   per-kind summary, owner chain, navigate (not assign).
+      #   Founder bug #5.
+      # - #1601 Family G: 6 singletons — hcloud-volumes StorageClass
+      #   (C9-006), /fleet/applications aggregator (C10-002),
+      #   secondary install-* Job bridge backfill (C10-003), legacy
+      #   wildcard-tls cert cleanup (C7-007), D22 settings em-dash
+      #   placeholder lift (C8-001), /jobs region filter (C8-005).
+      # - #1602 Family E: Compliance UI — Falco runtime alerts +
+      #   SBOM/CVE tab + framework filter chip strip + policy
+      #   drilldown live-cluster fallback + PolicyReport /
+      #   ClusterPolicyReport list kinds (C11-003/005/006/007/008/
+      #   009/010).
+      # - #1603 Family B: AppDetail HR-overlay status sync +
+      #   Resources/Logs tab namespace+label fix (HR.spec.target-
+      #   Namespace + chart-name label) + "Bootstrap blueprint"
+      #   chip for bp-* (founder bug #4, C4-003/004/005/007/013).
+      version: 1.4.154
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -1086,8 +1086,8 @@ name: bp-catalyst-platform
 # Fix #154 (HR-timeout audit). Those bumped the HelmRelease
 # install.timeout. This bumps the chart-INTERNAL wait loop budget
 # inside the pre-install hook Job, which is a different seam.
-version: 1.4.153
-appVersion: 1.4.153
+version: 1.4.154
+appVersion: 1.4.154
 # 1.4.141 (qa-loop Fix #185, prov #38/#39/#41 recurrence — pre-install
 # hook unscheduable on saturated worker):
 #


### PR DESCRIPTION
## Summary

Wave 2 collector PR — bumps `products/catalyst/chart/Chart.yaml` **AND** `clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml` from `1.4.153` → `1.4.154` so the 6 Fix-Author PRs that merged after the Wave-1 roll reach the chroot Sovereign on the next Flux reconcile.

## Bundled fixes

| PR | Family | Founder bug / TC | Summary |
|---|---|---|---|
| #1598 | F | **#1 BSS-in-console** | `/bss/{billing,orders,revenue,vouchers,tenants}` iframes `marketplace.<fqdn>/back-office/*` under Sovereign Console chrome |
| #1599 | D | **#2 treemap groupings** | dashboard buildPodRows joins namespaces+nodes for cluster/region/vcluster/family fan-out; DETECTED_MODE synchronous Layer-1=cluster default |
| #1600 | C | **#5 ResourceDetail rubbish text** | full rewrite (539+/218-) — sr-only glossary, per-kind KindSummary, OwnerChainPanel, navigate() not assign() |
| #1601 | G | C8-001/005, C9-006, C10-002/003, C7-007 | 6 singletons: hcloud-volumes SC, fleet aggregator AdoptedAt drop, secondary bridge backfill, legacy wildcard-tls cleanup, D22 lift, jobs region filter |
| #1602 | E | C11-003/005/006/007/008/009/010 | Compliance UI — Falco runtime, SBOM/CVE tab, framework filter chip strip, policy drilldown live fallback, PolicyReport/ClusterPolicyReport first-class list kinds |
| #1603 | B | **#4 AppDetail status sync** + C4-003/004/005/007/013 | HR Ready=True overlays stale CR phase; Resources/Logs tabs use HR.spec.targetNamespace + chart-name label; bootstrap-blueprint chip for bp-* |

## Why both files?

Per the `session_2026_05_17_t142_6_of_6_GREEN.md` rule: **chart `Chart.yaml` bump ≠ bootstrap-kit pin bump — need BOTH.** Bumping only one means the chroot Flux either re-pulls the old artifact (pin not bumped) or never re-renders (Chart.yaml not bumped because OCI digest matches).

## Test plan

- [ ] CI green on this branch
- [ ] `blueprint-release` republishes `oci://ghcr.io/openova-io/bp-catalyst-platform:1.4.154`
- [ ] Fresh t11.omantel.biz prov → all 6 fixes verified at handover (no live-patches)

🤖 Generated with [Claude Code](https://claude.com/claude-code)