### PR TITLE
feat(ui): Wave 6 PR 6 — BSS Tenants native (drops iframe, native table)

### DIFF
--- a/products/catalyst/bootstrap/ui/src/lib/bss.api.ts
+++ b/products/catalyst/bootstrap/ui/src/lib/bss.api.ts
@@ -4,15 +4,21 @@
  * Wire paths:
  *
  *   browser ──/api/v1/sme/bss/overview──▶ catalyst-api ──▶ per-tenant rollups
+ *   browser ──/api/v1/sme/billing/revenue──▶ catalyst-api ──▶ rollup
  *   browser ──/api/v1/sme/billing/vouchers/{issue,list,revoke}──▶ catalyst-api
  *           ──▶ billing service (#117 — core/services/billing/handlers/vouchers.go)
+ *   browser ──/api/v1/sme/orders──▶ catalyst-api ──▶ sme orders rollup
+ *   browser ──/api/v1/sme/tenants──▶ catalyst-api ──▶ HandleListSMETenants
  *
- * The overview endpoint is the FE-facing rollup for the BSS landing KPI
- * cards. The vouchers endpoints back Wave 6 PR 5's native vouchers
- * surface. Both gracefully tolerate 404 / 5xx so the page still renders
- * its target-state chrome on first paint (per INVIOLABLE-PRINCIPLES.md
- * #1) — overview returns zero-filled with `pendingApi: true`; voucher
- * list throws so the page can surface the API error inline.
+ * The overview / revenue / orders endpoints are FE-facing rollups for
+ * the matching BSS sections. The vouchers endpoints back the Wave 6 PR 5
+ * vouchers surface. The tenants endpoint backs Wave 6 PR 6 and ships
+ * today via HandleListSMETenants in sme_tenant.go. All endpoints
+ * gracefully tolerate 404 / 5xx so the page still renders its target-
+ * state chrome on first paint (per INVIOLABLE-PRINCIPLES.md #1) —
+ * overview / revenue / orders / tenants return zero-filled / empty
+ * with the FE flagging "API pending" where the page wants that pill;
+ * voucher list throws so the page can surface the API error inline.
  */
 
 import { API_BASE } from '@/shared/config/urls'
@@ -575,4 +581,171 @@ function normalizeSubscriptionStatus(raw: unknown): SubscriptionStatus {
     return s
   }
   return 'paid'
+}
+
+/* ── Tenants — Wave 6 PR 6 ───────────────────────────────────────────
+ *
+ * Source-of-truth: GET /api/v1/sme/tenants (HandleListSMETenants in
+ * products/catalyst/bootstrap/api/internal/handler/sme_tenant.go).
+ * That handler returns `{items: [smeTenantResponse, ...]}` where each
+ * row mirrors store.SMETenantProvisionRecord — id, state, subdomain,
+ * domain mode, parent domain, admin email, company name, OTECH FQDN,
+ * vCluster name, console host, timestamps.
+ *
+ * Wave 6 maps that wire shape onto a flatter `Tenant` UI type that the
+ * native TenantsPage table consumes. Per ADR-0001 §2.7 (K8s-native
+ * tenancy) the same orchestrator also reconciles an Organization CR
+ * (orgs.openova.io/v1), but for the operator's BSS landing view the
+ * provisioning-pipeline record is the richer + already-listed source.
+ *
+ * `plan` and `region` are sourced from the response where the backend
+ * populates them; on the current pipeline they are not yet wired so the
+ * UI treats them as optional and renders "—" when empty. The list
+ * endpoint never 5xxs on an empty store (returns `{items: []}`), so the
+ * client returns `[]` on transport failure rather than a zero-filled
+ * row to avoid faking presence.
+ */
+
+/** Provisioning lifecycle state mirroring store.SMETenantProvisionState. */
+export type TenantStatus =
+  | 'active'
+  | 'trial'
+  | 'provisioning'
+  | 'suspended'
+  | 'failed'
+  | 'unknown'
+
+export interface Tenant {
+  /** Stable identifier (sme_tenant_id from the orchestrator). */
+  id: string
+  /** Display name, falling back to the slug when company name absent. */
+  orgName: string
+  /** Console FQDN (e.g. console.acme.omani.homes). */
+  consoleHost: string
+  /**
+   * Subdomain leaf (e.g. "acme" → acme.omani.homes). Empty for BYO
+   * tenants whose console FQDN doesn't decompose into the pool form.
+   */
+  subdomain: string
+  /** Parent zone (e.g. omani.homes) used to compose the subdomain. */
+  parentDomain: string
+  /** Plan tier (free|pro|enterprise|...) — null until BE wires it. */
+  plan: string | null
+  /** Lifecycle status normalized to the UI vocabulary. */
+  status: TenantStatus
+  /** Hetzner region key (fsn1 / hel1 / ...) — null until BE wires it. */
+  region: string | null
+  /** Owner email (admin_email from the create call). */
+  ownerEmail: string
+  /** Provisioned timestamp (ISO 8601). */
+  createdAt: string
+  /** Last reconcile / update timestamp (ISO 8601). */
+  updatedAt: string
+  /** Failure detail surfaced for the Status column tooltip. */
+  lastError: string
+}
+
+/**
+ * mapStateToStatus — collapse the pipeline's 9-state machine onto the
+ * operator-facing 5-state vocabulary the BSS table renders. The
+ * mapping mirrors what an operator wants to see at a glance:
+ *
+ *   pending|*_provisioned|*_installed|*_created|*_issued → provisioning
+ *   tenant_registered|done                                → active
+ *   failed                                                → failed
+ *   deleted                                               → suspended
+ *   anything else                                         → unknown
+ */
+export function mapStateToStatus(state: string): TenantStatus {
+  switch (state) {
+    case 'done':
+    case 'tenant_registered':
+      return 'active'
+    case 'failed':
+      return 'failed'
+    case 'deleted':
+      return 'suspended'
+    case 'pending':
+    case 'vcluster_created':
+    case 'bp_charts_installed':
+    case 'dns_provisioned':
+    case 'certs_issued':
+    case 'keycloak_clients_provisioned':
+      return 'provisioning'
+    default:
+      return 'unknown'
+  }
+}
+
+/** Wire-shape mirror of smeTenantResponse — Partial so future BE
+ *  additions don't break the FE parse. */
+interface RawTenant {
+  sme_tenant_id?: string
+  state?: string
+  subdomain?: string
+  domain_mode?: string
+  byo_domain?: string
+  parent_domain?: string
+  admin_email?: string
+  company_name?: string
+  otech_fqdn?: string
+  vcluster_name?: string
+  tenant_namespace?: string
+  console_host?: string
+  plan?: string
+  region?: string
+  last_error?: string
+  created_at?: string
+  updated_at?: string
+}
+
+function mapTenant(raw: RawTenant): Tenant {
+  const subdomain = String(raw.subdomain ?? '')
+  const parentDomain = String(raw.parent_domain ?? '')
+  const companyName = String(raw.company_name ?? '').trim()
+  const orgName = companyName !== '' ? companyName : subdomain || String(raw.sme_tenant_id ?? '')
+  return {
+    id: String(raw.sme_tenant_id ?? ''),
+    orgName,
+    consoleHost: String(raw.console_host ?? ''),
+    subdomain,
+    parentDomain,
+    plan: raw.plan && raw.plan !== '' ? String(raw.plan) : null,
+    status: mapStateToStatus(String(raw.state ?? '')),
+    region: raw.region && raw.region !== '' ? String(raw.region) : null,
+    ownerEmail: String(raw.admin_email ?? ''),
+    createdAt: String(raw.created_at ?? ''),
+    updatedAt: String(raw.updated_at ?? ''),
+    lastError: String(raw.last_error ?? ''),
+  }
+}
+
+/**
+ * listTenants — fetch the tenant roster for the BSS Tenants table.
+ *
+ * Returns `[]` on network failure or non-2xx so the table renders its
+ * empty state rather than crashing the surface (per
+ * INVIOLABLE-PRINCIPLES.md #1 — waterfall, target-state shape first
+ * time). The handler already returns `{items: []}` on an empty store,
+ * so the empty array is the natural happy-path signal too.
+ */
+export async function listTenants(): Promise<Tenant[]> {
+  let res: Response
+  try {
+    res = await authedFetch(`${API_BASE}/v1/sme/tenants`, {
+      headers: { Accept: 'application/json' },
+    })
+  } catch {
+    return []
+  }
+  if (!res.ok) {
+    return []
+  }
+  try {
+    const body = (await res.json()) as { items?: RawTenant[] } | null
+    if (!body || !Array.isArray(body.items)) return []
+    return body.items.map(mapTenant)
+  } catch {
+    return []
+  }
 }

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/bss/TenantsPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/bss/TenantsPage.tsx
@@ -1,11 +1,441 @@
 /**
  * TenantsPage — /console/bss/tenants.
  *
- * Wave 6 PR 1 (Option B step 1): wraps in PortalShell via
- * BssSectionShell. Iframe content preserved; Wave 6 PR 6 native-ports.
+ * Wave 6 PR 6 (2026-05-17 founder UX review): native React replacement
+ * for the iframe-wrapped BssSectionShell. Inherits PortalShell chrome +
+ * design tokens from sibling surfaces (JobsPage / AppsPage /
+ * ParentDomainsPage) — no bespoke chrome, no hex colours outside the
+ * documented amber/rose/emerald exceptions for status pills.
+ *
+ * Wire path:
+ *
+ *   browser ──/api/v1/sme/tenants──▶ catalyst-api (HandleListSMETenants)
+ *
+ * Wave 6 PR 1 (#1606, 393116355d6e30b1382e843142ad3bbc15d25f51) landed
+ * the BSS landing + per-section iframe shell; this PR drops the iframe
+ * for /bss/tenants and replaces it with a filterable table of tenant
+ * organisations sourced from the existing SME provisioning store.
+ *
+ * Layout (PortalShell body):
+ *   • Header band: "Tenants" via PortalShell + tagline beneath
+ *   • Filter row: search, status / plan / region dropdowns
+ *   • Table: Org | Subdomain | Plan | Status | Region | Provisioned |
+ *            Last active
+ *
+ * Per docs/INVIOLABLE-PRINCIPLES.md #1 (waterfall) every row renders
+ * from mount — loading + empty states match JobsPage / ParentDomainsPage
+ * shape so the surface reads as a sibling.
  */
-import { BssSectionShell } from './BssSectionShell'
 
-export function TenantsPage() {
-  return <BssSectionShell path="tenants" title="BSS — Tenants" />
+import { useMemo, useState } from 'react'
+import { Link } from '@tanstack/react-router'
+import { useQuery } from '@tanstack/react-query'
+import { useResolvedDeploymentId } from '@/shared/lib/useResolvedDeploymentId'
+import { PortalShell } from '../PortalShell'
+import { useDeploymentEvents } from '../useDeploymentEvents'
+import { listTenants, type Tenant, type TenantStatus } from '@/lib/bss.api'
+
+const QUERY_STALE_MS = 30_000
+
+const STATUS_VALUES: readonly TenantStatus[] = [
+  'active',
+  'trial',
+  'provisioning',
+  'suspended',
+  'failed',
+]
+
+export interface TenantsPageProps {
+  /** Test seam — disables the live SSE attach. */
+  disableStream?: boolean
+  /** Test seam — bypass the React Query fetcher with synthetic data. */
+  initialTenantsOverride?: readonly Tenant[]
+}
+
+export function TenantsPage({
+  disableStream = false,
+  initialTenantsOverride,
+}: TenantsPageProps = {}) {
+  const { deploymentId: resolvedId } = useResolvedDeploymentId()
+  const deploymentId = resolvedId ?? ''
+
+  const { snapshot } = useDeploymentEvents({
+    deploymentId,
+    applicationIds: [],
+    disableStream,
+  })
+  const sovereignFQDN =
+    snapshot?.sovereignFQDN ?? snapshot?.result?.sovereignFQDN ?? null
+
+  const query = useQuery<Tenant[]>({
+    queryKey: ['bss-tenants', deploymentId],
+    queryFn: listTenants,
+    staleTime: QUERY_STALE_MS,
+    enabled: !initialTenantsOverride,
+    placeholderData: (prev) => prev,
+  })
+
+  const tenants: readonly Tenant[] =
+    initialTenantsOverride ?? query.data ?? []
+  const loading = !initialTenantsOverride && query.isLoading
+  const error =
+    !initialTenantsOverride && query.isError ? (query.error as Error).message : null
+
+  const [search, setSearch] = useState<string>('')
+  const [statusFilter, setStatusFilter] = useState<'' | TenantStatus>('')
+  const [planFilter, setPlanFilter] = useState<string>('')
+  const [regionFilter, setRegionFilter] = useState<string>('')
+
+  const planOptions = useMemo<string[]>(() => {
+    const set = new Set<string>()
+    for (const t of tenants) if (t.plan) set.add(t.plan)
+    return [...set].sort((a, b) => a.localeCompare(b))
+  }, [tenants])
+
+  const regionOptions = useMemo<string[]>(() => {
+    const set = new Set<string>()
+    for (const t of tenants) if (t.region) set.add(t.region)
+    return [...set].sort((a, b) => a.localeCompare(b))
+  }, [tenants])
+
+  const visibleTenants = useMemo<Tenant[]>(() => {
+    const q = search.trim().toLowerCase()
+    return tenants.filter((t) => {
+      if (statusFilter && t.status !== statusFilter) return false
+      if (planFilter && t.plan !== planFilter) return false
+      if (regionFilter && t.region !== regionFilter) return false
+      if (q) {
+        const hay =
+          `${t.orgName} ${t.consoleHost} ${t.subdomain} ${t.ownerEmail} ${t.status}`.toLowerCase()
+        if (!hay.includes(q)) return false
+      }
+      return true
+    })
+  }, [tenants, search, statusFilter, planFilter, regionFilter])
+
+  return (
+    <PortalShell
+      deploymentId={deploymentId}
+      sovereignFQDN={sovereignFQDN}
+      pageTitle="Tenants"
+      headerSlotLeft={
+        <Link
+          to={'/bss' as never}
+          className="text-[11px] text-[var(--color-text-dim)] hover:text-[var(--color-text)] no-underline"
+          data-testid="sov-bss-back-to-landing-tenants"
+        >
+          ← Back to BSS overview
+        </Link>
+      }
+    >
+      <div data-testid="bss-tenants-page">
+        <p className="mb-4 text-sm text-[var(--color-text-dim)]">
+          Tenant organisations provisioned via marketplace signup. Each row is
+          one Organization CR + per-tenant vCluster on this Sovereign.
+        </p>
+
+        {/* Filter row — mirrors JobsTable.toolbar shape but uses the
+            tenant axes (status / plan / region). Plan + Region filters
+            hide themselves when only zero or one option appears so a
+            fresh Sovereign with no tenants doesn't show stub dropdowns. */}
+        <div
+          className="mb-3 flex flex-wrap items-end gap-3"
+          data-testid="bss-tenants-toolbar"
+        >
+          <label className="flex flex-1 min-w-[240px] max-w-md flex-col gap-1">
+            <span className="text-[0.62rem] uppercase tracking-wide text-[var(--color-text-dim)]">
+              Search
+            </span>
+            <input
+              type="search"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder="Search by org, subdomain, owner email, or status…"
+              data-testid="bss-tenants-search"
+              aria-label="Search tenants"
+              className="rounded-md border border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-1.5 text-sm text-[var(--color-text)] focus:border-[var(--color-accent)] focus:outline-none"
+            />
+          </label>
+          <label className="flex flex-col gap-1">
+            <span className="text-[0.62rem] uppercase tracking-wide text-[var(--color-text-dim)]">
+              Status
+            </span>
+            <select
+              value={statusFilter}
+              onChange={(e) => setStatusFilter(e.target.value as '' | TenantStatus)}
+              data-testid="bss-tenants-filter-status"
+              aria-label="Filter by status"
+              className="rounded-md border border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-1.5 text-sm text-[var(--color-text)] focus:border-[var(--color-accent)] focus:outline-none"
+            >
+              <option value="">All</option>
+              {STATUS_VALUES.map((s) => (
+                <option key={s} value={s}>
+                  {STATUS_TONE[s].label}
+                </option>
+              ))}
+            </select>
+          </label>
+          {planOptions.length > 0 ? (
+            <label className="flex flex-col gap-1">
+              <span className="text-[0.62rem] uppercase tracking-wide text-[var(--color-text-dim)]">
+                Plan
+              </span>
+              <select
+                value={planFilter}
+                onChange={(e) => setPlanFilter(e.target.value)}
+                data-testid="bss-tenants-filter-plan"
+                aria-label="Filter by plan"
+                className="rounded-md border border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-1.5 text-sm text-[var(--color-text)] focus:border-[var(--color-accent)] focus:outline-none"
+              >
+                <option value="">All</option>
+                {planOptions.map((p) => (
+                  <option key={p} value={p}>
+                    {p}
+                  </option>
+                ))}
+              </select>
+            </label>
+          ) : null}
+          {regionOptions.length > 0 ? (
+            <label className="flex flex-col gap-1">
+              <span className="text-[0.62rem] uppercase tracking-wide text-[var(--color-text-dim)]">
+                Region
+              </span>
+              <select
+                value={regionFilter}
+                onChange={(e) => setRegionFilter(e.target.value)}
+                data-testid="bss-tenants-filter-region"
+                aria-label="Filter by region"
+                className="rounded-md border border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-1.5 text-sm text-[var(--color-text)] focus:border-[var(--color-accent)] focus:outline-none"
+              >
+                <option value="">All</option>
+                {regionOptions.map((r) => (
+                  <option key={r} value={r}>
+                    {r}
+                  </option>
+                ))}
+              </select>
+            </label>
+          ) : null}
+          <span
+            data-testid="bss-tenants-result-count"
+            aria-live="polite"
+            className="ml-auto pb-1 font-mono text-xs tabular-nums text-[var(--color-text-dim)]"
+          >
+            {visibleTenants.length}/{tenants.length}
+          </span>
+        </div>
+
+        {error ? (
+          <div
+            data-testid="bss-tenants-error"
+            className="mb-3 rounded-md border border-rose-500/40 bg-rose-500/10 px-3 py-2 text-sm text-rose-300"
+          >
+            {error}
+          </div>
+        ) : null}
+
+        {loading ? (
+          <div
+            data-testid="bss-tenants-loading"
+            className="text-sm text-[var(--color-text-dim)]"
+          >
+            Loading…
+          </div>
+        ) : tenants.length === 0 ? (
+          <div
+            data-testid="bss-tenants-empty"
+            className="rounded-md border border-[var(--color-border)] bg-[var(--color-bg-2)] px-4 py-8 text-center text-sm text-[var(--color-text-dim)]"
+          >
+            No tenants provisioned yet. Marketplace signups land here once the
+            tenant-provisioning pipeline (vCluster + Keycloak + DNS + certs)
+            reaches the registered state.
+          </div>
+        ) : visibleTenants.length === 0 ? (
+          <div
+            data-testid="bss-tenants-no-matches"
+            className="rounded-md border border-[var(--color-border)] bg-[var(--color-bg-2)] px-4 py-8 text-center text-sm text-[var(--color-text-dim)]"
+          >
+            No tenants match the current filters.
+          </div>
+        ) : (
+          <div className="overflow-x-auto rounded-xl border border-[var(--color-border)] bg-[var(--color-surface)]">
+            <table
+              data-testid="bss-tenants-table"
+              className="w-full border-collapse text-sm"
+            >
+              <thead>
+                <tr className="border-b border-[var(--color-border)] text-left text-[0.7rem] uppercase tracking-wide text-[var(--color-text-dim)]">
+                  <th className="px-3 py-2 font-semibold">Org</th>
+                  <th className="px-3 py-2 font-semibold">Subdomain</th>
+                  <th className="px-3 py-2 font-semibold">Plan</th>
+                  <th className="px-3 py-2 font-semibold">Status</th>
+                  <th className="px-3 py-2 font-semibold">Region</th>
+                  <th className="px-3 py-2 font-semibold">Provisioned</th>
+                  <th className="px-3 py-2 font-semibold">Last active</th>
+                </tr>
+              </thead>
+              <tbody>
+                {visibleTenants.map((t) => (
+                  <TenantRow key={t.id || t.consoleHost} tenant={t} />
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </PortalShell>
+  )
+}
+
+interface TenantRowProps {
+  tenant: Tenant
+}
+
+/**
+ * TenantRow — a single row. A future tenant-detail page is out-of-scope
+ * for this PR; the row is non-navigable today so we don't ship a dead-
+ * end click target. The Org cell carries the `data-href-todo` attribute
+ * for the next Wave 6 PR to wire a Link without re-doing the row.
+ */
+function TenantRow({ tenant }: TenantRowProps) {
+  const subdomainLabel =
+    tenant.subdomain && tenant.parentDomain
+      ? `${tenant.subdomain}.${tenant.parentDomain}`
+      : tenant.consoleHost || tenant.subdomain || '—'
+  return (
+    <tr
+      data-testid={`bss-tenants-row-${tenant.id}`}
+      data-status={tenant.status}
+      className="border-b border-[var(--color-border)] last:border-b-0 hover:bg-[var(--color-surface-hover)]"
+    >
+      <td className="px-3 py-2 align-middle">
+        <div
+          data-testid={`bss-tenants-cell-org-${tenant.id}`}
+          data-href-todo={tenant.id ? `/bss/tenants/${tenant.id}` : undefined}
+          className="flex flex-col"
+        >
+          <span className="text-[var(--color-text-strong)]">
+            {tenant.orgName}
+          </span>
+          {tenant.ownerEmail ? (
+            <span className="text-[11px] text-[var(--color-text-dim)]">
+              {tenant.ownerEmail}
+            </span>
+          ) : null}
+        </div>
+      </td>
+      <td
+        className="px-3 py-2 align-middle font-mono text-xs text-[var(--color-text)]"
+        data-testid={`bss-tenants-cell-subdomain-${tenant.id}`}
+      >
+        {subdomainLabel}
+      </td>
+      <td
+        className="px-3 py-2 align-middle text-xs text-[var(--color-text)]"
+        data-testid={`bss-tenants-cell-plan-${tenant.id}`}
+      >
+        {tenant.plan ?? '—'}
+      </td>
+      <td className="px-3 py-2 align-middle">
+        <StatusPill status={tenant.status} tenantId={tenant.id} title={tenant.lastError} />
+      </td>
+      <td
+        className="px-3 py-2 align-middle text-xs text-[var(--color-text)]"
+        data-testid={`bss-tenants-cell-region-${tenant.id}`}
+      >
+        {tenant.region ?? '—'}
+      </td>
+      <td
+        className="px-3 py-2 align-middle text-xs text-[var(--color-text-dim)]"
+        data-testid={`bss-tenants-cell-provisioned-${tenant.id}`}
+        title={tenant.createdAt}
+      >
+        {formatDate(tenant.createdAt)}
+      </td>
+      <td
+        className="px-3 py-2 align-middle text-xs text-[var(--color-text-dim)]"
+        data-testid={`bss-tenants-cell-last-active-${tenant.id}`}
+        title={tenant.updatedAt}
+      >
+        {formatRelative(tenant.updatedAt)}
+      </td>
+    </tr>
+  )
+}
+
+/** Status pill — tone palette mirrors JobsTable badges + ParentDomains
+ *  flip-status badges (amber for in-flight, rose for failure, emerald
+ *  for happy). These three families are the documented design-system
+ *  exception to "tokens only". */
+const STATUS_TONE: Record<TenantStatus, { label: string; className: string }> = {
+  active: {
+    label: 'Active',
+    className: 'border-emerald-500/40 bg-emerald-500/10 text-emerald-300',
+  },
+  trial: {
+    label: 'Trial',
+    className: 'border-amber-500/40 bg-amber-500/10 text-amber-300',
+  },
+  provisioning: {
+    label: 'Provisioning',
+    className: 'border-amber-500/40 bg-amber-500/10 text-amber-300',
+  },
+  suspended: {
+    label: 'Suspended',
+    className: 'border-rose-500/40 bg-rose-500/10 text-rose-300',
+  },
+  failed: {
+    label: 'Failed',
+    className: 'border-rose-500/40 bg-rose-500/10 text-rose-300',
+  },
+  unknown: {
+    label: 'Unknown',
+    className:
+      'border-[var(--color-border)] bg-[var(--color-bg-2)] text-[var(--color-text-dim)]',
+  },
+}
+
+interface StatusPillProps {
+  status: TenantStatus
+  tenantId: string
+  title?: string
+}
+
+function StatusPill({ status, tenantId, title }: StatusPillProps) {
+  const tone = STATUS_TONE[status]
+  return (
+    <span
+      data-testid={`bss-tenants-cell-status-${tenantId}`}
+      data-status={status}
+      title={title || tone.label}
+      className={`inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide ${tone.className}`}
+    >
+      {tone.label}
+    </span>
+  )
+}
+
+/** formatDate — `2026-05-17` style for the Provisioned column. Returns
+ *  "—" for the Go zero-time sentinel and for unparseable input. */
+function formatDate(iso: string): string {
+  if (!iso || iso.startsWith('0001')) return '—'
+  const t = new Date(iso).getTime()
+  if (!Number.isFinite(t) || t <= 0) return '—'
+  return new Date(t).toLocaleDateString()
+}
+
+/** formatRelative — short "5m ago" style for the Last-active column.
+ *  Falls back to the absolute date past 24h, mirroring JobsTable's
+ *  formatRelative shape so the two surfaces read consistently. */
+function formatRelative(iso: string): string {
+  if (!iso || iso.startsWith('0001')) return '—'
+  const t = new Date(iso).getTime()
+  if (!Number.isFinite(t) || t <= 0) return '—'
+  const dSec = Math.floor((Date.now() - t) / 1000)
+  if (dSec < 5) return 'just now'
+  if (dSec < 60) return `${dSec}s ago`
+  if (dSec < 3600) return `${Math.floor(dSec / 60)}m ago`
+  if (dSec < 86_400) return `${Math.floor(dSec / 3600)}h ago`
+  return new Date(t).toLocaleDateString(undefined, { month: 'short', day: 'numeric' })
 }


### PR DESCRIPTION
## Summary

- Replaces the iframe-wrapped `BssSectionShell` at `/console/bss/tenants` with a NATIVE React table that inherits PortalShell chrome + design tokens from sibling surfaces (JobsPage / AppsPage / ParentDomainsPage / BssLandingPage).
- Extends `bss.api.ts` with `listTenants()` + `Tenant` + `TenantStatus` wired against the existing `GET /api/v1/sme/tenants` endpoint (`HandleListSMETenants`) — no backend change required.
- Closes the iframe seam for Wave 6 PR 6; aligns with Wave 6 PR 1 (#1606, merge commit `393116355d6e30b1382e843142ad3bbc15d25f51`).

## What's in the table

`Org | Subdomain | Plan | Status | Region | Provisioned | Last active`

- Filter row: search (org / subdomain / owner email / status) + Status dropdown + Plan + Region dropdowns (auto-hide on zero options so a fresh Sovereign with no tenants doesn't see stub dropdowns)
- Status pills: amber for Trial / Provisioning, rose for Failed / Suspended, emerald for Active — same documented design-system exception families as JobsTable badges + ParentDomainsPage flip badges
- Loading + empty + no-matches + error states all match JobsPage / ParentDomainsPage shape

## Design-system inheritance

- **PortalShell** wrapper — same as JobsPage / AppsPage / SettingsPage / BssLandingPage
- **Table** — copies ParentDomainsPage table chrome (border-radius, bg tokens, row hover)
- **Toolbar** — copies JobsTable.toolbar shape (caption above select, flex-end alignment, result count on the right)
- **Tokens** — `var(--color-text-strong | text | text-dim | border | surface | surface-hover | bg-2 | accent)` plus the 3 documented status families
- **NO** hex colours, **NO** new components, **NO** new card chrome

## Backend

The wire endpoint already exists — `products/catalyst/bootstrap/api/internal/handler/sme_tenant.go:579` (`HandleListSMETenants`) returns `{items: [smeTenantResponse]}`. The smeTenantResponse fields (`sme_tenant_id`, `state`, `subdomain`, `parent_domain`, `admin_email`, `company_name`, `console_host`, `created_at`, `updated_at`, `last_error`) are mapped onto the flatter `Tenant` UI type. No Go handler changes shipped in this PR.

`plan` and `region` are wire-optional and not currently emitted by the backend — the UI treats them as `string | null` and renders `—` until the BE wires them.

## Test plan

- [ ] `tsc -b --noEmit` clean for `TenantsPage.tsx` + `bss.api.ts` (the pre-existing CloudPage.tsx `policyreports/clusterpolicyreports` error is unrelated and exists on main)
- [ ] Color audit grep: no hex colours, no bespoke Tailwind palette outside the amber/rose/emerald exception families
- [ ] Side-by-side with AppsPage / JobsPage / ParentDomainsPage reads as a sibling
- [ ] On a Sovereign with 0 tenants: `bss-tenants-empty` empty state renders
- [ ] On a Sovereign with N tenants: table populates from `GET /api/v1/sme/tenants` and status pills colour by lifecycle state
- [ ] Filters narrow visible rows; `bss-tenants-result-count` aria-live updates

References: Wave 6 PR 1 #1606 (`393116355d6e30b1382e843142ad3bbc15d25f51`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)