### PR TITLE
fix(ui): Wave 8 critical-path hotfix — CloudPage kindCounts adds policyreports + clusterpolicyreports (unblocks UI build)

### DIFF
--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/CloudPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/CloudPage.tsx
@@ -416,6 +416,16 @@ export function CloudPage({
       'nodes': null,
       'persistentvolumes': null,
       'endpointslices': null,
+      // Wave 8 hotfix 2026-05-18: Family E PR #1602 added these two as
+      // first-class CloudListKinds (PolicyReports + ClusterPolicyReports)
+      // for EPIC-1 Compliance, but never updated this counts seed object.
+      // tsc failed for every subsequent UI build, the deploy-bot couldn't
+      // auto-bump values.yaml, and chart 1.4.155 published with stale UI
+      // image SHA 898305f (PR #1600 Family C era). Wave 5+6 UI changes
+      // never reached fresh provs t11/t12 — caught on the t12 5-agent
+      // test scorecard (W5-1/2/3/4 + W6-1 all FAIL).
+      'policyreports': null,
+      'clusterpolicyreports': null,
     }
     if (data) {
       let clusters = 0


### PR DESCRIPTION
## Critical-path hotfix

Family E PR #1602 added policyreports + clusterpolicyreports as first-class CloudListKinds, but CloudPage.tsx:395 kindCounts seed object was never updated. tsc fails:

```
src/pages/sovereign/CloudPage.tsx(395,11): error TS2739: Type '{...}' is missing the following properties from type 'Record<CloudListKind, number | null>': policyreports, clusterpolicyreports
```

Cascade: every catalyst-ui build after #1602 FAILED → deploy-bot couldn't bump values.yaml → chart 1.4.155 shipped with UI image SHA 898305f (Family C era), zero Wave 5/6 UX changes baked.

t12 5-agent test scorecard PROVED it: W5-1/2/3/4 + W6-1 all FAIL.

## Test plan
- [ ] catalyst-ui CI build green
- [ ] deploy-bot auto-bump fires
- [ ] Next fresh prov sees all Wave 5+6 UI changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)