### PR TITLE
chore(release): chart 1.4.155→1.4.156 — Wave 9 collector republishes with fresh UI bytes (post Wave 8 hotfix)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -550,7 +550,7 @@ spec:
       #   Resources/Logs tab namespace+label fix (HR.spec.target-
       #   Namespace + chart-name label) + "Bootstrap blueprint"
       #   chip for bp-* (founder bug #4, C4-003/004/005/007/013).
-      version: 1.4.155
+      version: 1.4.156
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -1086,8 +1086,8 @@ name: bp-catalyst-platform
 # Fix #154 (HR-timeout audit). Those bumped the HelmRelease
 # install.timeout. This bumps the chart-INTERNAL wait loop budget
 # inside the pre-install hook Job, which is a different seam.
-version: 1.4.155
-appVersion: 1.4.155
+version: 1.4.156
+appVersion: 1.4.156
 # 1.4.141 (qa-loop Fix #185, prov #38/#39/#41 recurrence — pre-install
 # hook unscheduable on saturated worker):
 #


### PR DESCRIPTION
Companion to Wave 8 #1616. Chart 1.4.155 published with stale catalyst-ui:898305f because UI build was failing on TS2739 since #1602. Wave 8 unblocked → deploy-bot bumped to catalyst-ui:d08cc92. This bumps chart+pin so fresh provs see Wave 5+6+7 changes baked in.

🤖 Generated with Claude Code