### PR TITLE
feat(sandbox): Wave 2 — pty-server + openova-sandbox-mcp scaffold

### DIFF
--- a/products/sandbox/mcp-server/Dockerfile
+++ b/products/sandbox/mcp-server/Dockerfile
@@ -1,0 +1,22 @@
+# syntax=docker/dockerfile:1.7
+#
+# openova-sandbox-mcp — stdio MCP server, one sidecar per Sandbox pod.
+# Talks JSON-RPC to the agent (claude / cursor-agent / qwen-code /
+# aider / opencode) over stdin/stdout. See architecture.md §3.
+
+FROM golang:1.23-alpine AS build
+WORKDIR /src
+RUN apk add --no-cache git
+COPY go.mod go.sum* ./
+RUN go mod download || true
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 \
+    go build -trimpath -ldflags="-s -w" \
+    -o /out/openova-sandbox-mcp ./cmd/openova-sandbox-mcp
+
+FROM gcr.io/distroless/static-debian12:nonroot
+USER nonroot:nonroot
+COPY --from=build /out/openova-sandbox-mcp /usr/local/bin/openova-sandbox-mcp
+# stdio server — no port. The orchestrator wires stdin/stdout to the
+# agent process.
+ENTRYPOINT ["/usr/local/bin/openova-sandbox-mcp"]

--- a/products/sandbox/mcp-server/README.md
+++ b/products/sandbox/mcp-server/README.md
@@ -1,0 +1,67 @@
+# openova-sandbox-mcp
+
+Per-Sandbox MCP server. One sidecar in every Sandbox pod. Speaks
+JSON-RPC 2.0 over stdio to the local agent process
+(`claude`, `cursor-agent`, `qwen-code`, `aider`, `opencode`). Speaks
+HTTPS to the Sovereign control plane using the Sandbox-scoped token.
+
+See `products/sandbox/docs/architecture.md` §3 for the full namespace
+list and §4 for how this server connects the static / procedural / live
+/ corpus knowledge layers.
+
+## Wave 2 (this PR) — scaffold
+
+- JSON-RPC plumbing (Content-Length framing, `initialize`, `tools/list`,
+  `tools/call`, `ping`, init/cancel notifications).
+- Tool catalogue stubs across the four required namespaces:
+  - `gitea.*`
+  - `k8s.read.*`
+  - `sandbox.db.*`
+  - `sandbox.auth.*`
+- Plus `sandbox.session.*` (whoami / info) for agent self-discovery.
+
+Every Wave 2 tool returns `{"status":"not_implemented", "tool":"<name>",
+"wave":2}` so the agent can list, dispatch, and reason about the surface
+end-to-end before any backend is wired.
+
+## Wave 3+ (next)
+
+- Real handlers wired against:
+  - Gitea API (per-Org Org URL from `core/services/domain`).
+  - Sovereign k8s read API (vcluster-scoped client).
+  - CNPG provisioning via `Cluster.postgresql.cnpg.io`
+    (`platform/cnpg/`).
+  - Keycloak Admin REST against the per-Sandbox realm.
+- MCP `resources/subscribe` for JetStream-backed live updates
+  (architecture.md §3 / ADR-0001 §6).
+- RBAC enforcement on every call against the Sandbox JWT claims
+  (`sovereign_id`, `org_id`, `sandbox_id`, `roles[]`).
+
+## Build & run
+
+```bash
+cd products/sandbox/mcp-server
+go build ./cmd/openova-sandbox-mcp
+./openova-sandbox-mcp        # waits for JSON-RPC on stdin
+```
+
+Local smoke (one-shot `initialize` then exit):
+
+```bash
+{
+  printf 'Content-Length: 81\r\n\r\n'
+  printf '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"x"}}'
+} | ./openova-sandbox-mcp
+```
+
+You should see a `Content-Length: ...` framed JSON-RPC response on
+stdout with `serverInfo.name = "openova-sandbox-mcp"`.
+
+## Container
+
+```bash
+docker build -t ghcr.io/openova-io/openova/sandbox-mcp:dev .
+```
+
+The image has no port — the orchestrator pipes stdin/stdout into the
+agent's child process.

--- a/products/sandbox/mcp-server/cmd/openova-sandbox-mcp/main.go
+++ b/products/sandbox/mcp-server/cmd/openova-sandbox-mcp/main.go
@@ -1,0 +1,195 @@
+// openova-sandbox-mcp is the per-Sandbox MCP server.
+//
+// Wire model: the agent process (claude, cursor-agent, qwen-code,
+// aider, opencode) launches this binary as a stdio MCP server. JSON-RPC
+// 2.0 frames (Content-Length-prefixed, one per message) flow over
+// stdin/stdout. Logging goes to stderr only — anything written to
+// stdout outside an RPC frame breaks the protocol.
+//
+// Wave 2 ships the protocol skeleton + the tool catalogue stubs from
+// products/sandbox/docs/architecture.md §3. Wave 3+ swaps the
+// not_implemented handlers for real Sovereign API calls.
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"net/textproto"
+	"os"
+	"strconv"
+
+	"github.com/openova-io/openova/products/sandbox/mcp-server/internal/tools"
+)
+
+const (
+	// protocolVersion is the MCP wire revision this scaffold targets.
+	// The number is informational; clients negotiate via `initialize`.
+	protocolVersion = "2024-11-05"
+	serverName      = "openova-sandbox-mcp"
+	serverVersion   = "0.1.0-wave2"
+)
+
+// JSON-RPC 2.0 envelopes.
+
+type rpcRequest struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id,omitempty"`
+	Method  string          `json:"method"`
+	Params  json.RawMessage `json:"params,omitempty"`
+}
+
+type rpcResponse struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id,omitempty"`
+	Result  any             `json:"result,omitempty"`
+	Error   *rpcError       `json:"error,omitempty"`
+}
+
+type rpcError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+	Data    any    `json:"data,omitempty"`
+}
+
+func main() {
+	// Logging to stderr — never to stdout (stdout is the JSON-RPC wire).
+	log.SetOutput(os.Stderr)
+	log.SetFlags(log.LstdFlags | log.Lmicroseconds | log.LUTC)
+	log.Printf("%s %s starting (protocol %s)", serverName, serverVersion, protocolVersion)
+
+	reg := tools.NewRegistry()
+	srv := &server{tools: reg, out: os.Stdout}
+
+	in := bufio.NewReader(os.Stdin)
+	for {
+		msg, err := readFrame(in)
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				log.Printf("stdin EOF — exiting")
+				return
+			}
+			log.Printf("read frame: %v", err)
+			return
+		}
+		if err := srv.dispatch(msg); err != nil {
+			log.Printf("dispatch: %v", err)
+		}
+	}
+}
+
+// server handles a single MCP peer over stdio.
+type server struct {
+	tools *tools.Registry
+	out   io.Writer
+}
+
+func (s *server) dispatch(raw []byte) error {
+	var req rpcRequest
+	if err := json.Unmarshal(raw, &req); err != nil {
+		return s.writeError(nil, -32700, "parse error", err.Error())
+	}
+	switch req.Method {
+	case "initialize":
+		return s.handleInitialize(req)
+	case "tools/list":
+		return s.handleToolsList(req)
+	case "tools/call":
+		return s.handleToolsCall(req)
+	case "ping":
+		return s.writeResult(req.ID, map[string]any{"pong": true})
+	case "notifications/initialized", "notifications/cancelled":
+		return nil // notifications: no response
+	default:
+		return s.writeError(req.ID, -32601, "method not found", req.Method)
+	}
+}
+
+func (s *server) handleInitialize(req rpcRequest) error {
+	return s.writeResult(req.ID, map[string]any{
+		"protocolVersion": protocolVersion,
+		"serverInfo": map[string]any{
+			"name":    serverName,
+			"version": serverVersion,
+		},
+		"capabilities": map[string]any{
+			"tools": map[string]any{"listChanged": false},
+		},
+	})
+}
+
+func (s *server) handleToolsList(req rpcRequest) error {
+	return s.writeResult(req.ID, map[string]any{"tools": s.tools.List()})
+}
+
+func (s *server) handleToolsCall(req rpcRequest) error {
+	var params struct {
+		Name      string          `json:"name"`
+		Arguments json.RawMessage `json:"arguments"`
+	}
+	if err := json.Unmarshal(req.Params, &params); err != nil {
+		return s.writeError(req.ID, -32602, "invalid params", err.Error())
+	}
+	result, err := s.tools.Call(params.Name, params.Arguments)
+	if err != nil {
+		return s.writeError(req.ID, -32000, "tool error", err.Error())
+	}
+	// MCP wraps tool results in {content:[{type:"text", text:"..."}]}
+	// but for Wave 2 stubs the JSON blob is sufficient — the agent's
+	// MCP client tolerates either.
+	body, _ := json.Marshal(result)
+	return s.writeResult(req.ID, map[string]any{
+		"content": []map[string]any{{"type": "text", "text": string(body)}},
+		"isError": false,
+	})
+}
+
+func (s *server) writeResult(id json.RawMessage, result any) error {
+	return s.writeFrame(rpcResponse{JSONRPC: "2.0", ID: id, Result: result})
+}
+
+func (s *server) writeError(id json.RawMessage, code int, msg string, data any) error {
+	return s.writeFrame(rpcResponse{
+		JSONRPC: "2.0",
+		ID:      id,
+		Error:   &rpcError{Code: code, Message: msg, Data: data},
+	})
+}
+
+func (s *server) writeFrame(resp rpcResponse) error {
+	body, err := json.Marshal(resp)
+	if err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(s.out, "Content-Length: %d\r\n\r\n", len(body)); err != nil {
+		return err
+	}
+	_, err = s.out.Write(body)
+	return err
+}
+
+// readFrame reads one Content-Length-prefixed MCP message from r.
+// Returns the raw body bytes.
+func readFrame(r *bufio.Reader) ([]byte, error) {
+	tp := textproto.NewReader(r)
+	header, err := tp.ReadMIMEHeader()
+	if err != nil {
+		return nil, err
+	}
+	clStr := header.Get("Content-Length")
+	if clStr == "" {
+		return nil, errors.New("missing Content-Length")
+	}
+	cl, err := strconv.Atoi(clStr)
+	if err != nil {
+		return nil, fmt.Errorf("bad Content-Length: %w", err)
+	}
+	body := make([]byte, cl)
+	if _, err := io.ReadFull(r, body); err != nil {
+		return nil, err
+	}
+	return body, nil
+}

--- a/products/sandbox/mcp-server/go.mod
+++ b/products/sandbox/mcp-server/go.mod
@@ -1,0 +1,3 @@
+module github.com/openova-io/openova/products/sandbox/mcp-server
+
+go 1.22

--- a/products/sandbox/mcp-server/internal/tools/registry.go
+++ b/products/sandbox/mcp-server/internal/tools/registry.go
@@ -1,0 +1,136 @@
+// Package tools is the MCP tool catalogue for openova-sandbox-mcp.
+//
+// Each tool is registered with a fully-qualified name (matching the
+// namespaces enumerated in products/sandbox/docs/architecture.md §3)
+// plus a short description. Wave 2 ships stubs only — every Call()
+// returns {"status":"not_implemented"} so the agent can list, dispatch,
+// and reason about the surface end-to-end before any backend is wired.
+//
+// Real implementations land in Wave 3+ and replace the Handler func on
+// each Tool record without touching the registry shape.
+package tools
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"sync"
+)
+
+// Tool is one MCP tool the server advertises over stdio JSON-RPC.
+type Tool struct {
+	// Name is the MCP tool name (the catalogue ID). Dotted; lowercased.
+	Name string `json:"name"`
+
+	// Description is the one-line summary the agent sees during
+	// MCP `tools/list`.
+	Description string `json:"description"`
+
+	// InputSchema is a JSON Schema fragment for the tool's arguments.
+	// Wave 2 uses {} (any) for stubs; Wave 3 tightens.
+	InputSchema map[string]any `json:"inputSchema"`
+
+	// Handler runs the tool. Wave 2 stubs return not_implemented.
+	Handler func(args json.RawMessage) (any, error) `json:"-"`
+}
+
+// Registry is the in-process catalogue. Safe for concurrent reads.
+type Registry struct {
+	mu    sync.RWMutex
+	tools map[string]Tool
+}
+
+// NewRegistry returns a registry pre-populated with every namespace
+// stub from architecture.md §3.
+func NewRegistry() *Registry {
+	r := &Registry{tools: make(map[string]Tool)}
+	for _, t := range defaultCatalogue() {
+		r.tools[t.Name] = t
+	}
+	return r
+}
+
+// Register adds (or replaces) a tool by name. Used by tests + Wave 3
+// to swap stubs for real handlers.
+func (r *Registry) Register(t Tool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.tools[t.Name] = t
+}
+
+// List returns every tool, sorted by name (stable for MCP `tools/list`).
+func (r *Registry) List() []Tool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := make([]Tool, 0, len(r.tools))
+	for _, t := range r.tools {
+		out = append(out, t)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out
+}
+
+// Call invokes the named tool with the supplied argument blob.
+func (r *Registry) Call(name string, args json.RawMessage) (any, error) {
+	r.mu.RLock()
+	t, ok := r.tools[name]
+	r.mu.RUnlock()
+	if !ok {
+		return nil, fmt.Errorf("tools/call: unknown tool %q", name)
+	}
+	if t.Handler == nil {
+		return notImplemented(name), nil
+	}
+	return t.Handler(args)
+}
+
+// notImplemented is the canonical Wave 2 stub response.
+func notImplemented(name string) map[string]any {
+	return map[string]any{
+		"status": "not_implemented",
+		"tool":   name,
+		"wave":   2,
+		"note":   "scaffold; real handler lands in Wave 3+",
+	}
+}
+
+// defaultCatalogue enumerates the four namespaces required for Wave 2
+// (gitea, k8s.read, sandbox.db, sandbox.auth) plus a thin
+// sandbox.session.* for the MCP server's own session metadata. Adding
+// the remaining namespaces (sandbox.deploy, marketplace, flux, rag,
+// etc.) is a stub list extension only — Wave 3 work.
+func defaultCatalogue() []Tool {
+	any := map[string]any{"type": "object", "additionalProperties": true}
+	return []Tool{
+		// gitea.*
+		{Name: "gitea.repos.list", Description: "List repos in the Org's Gitea Org.", InputSchema: any},
+		{Name: "gitea.repos.get", Description: "Get a single repo by owner/name.", InputSchema: any},
+		{Name: "gitea.pr.list", Description: "List PRs on a repo.", InputSchema: any},
+		{Name: "gitea.pr.create", Description: "Open a PR (branch -> base) with title and body.", InputSchema: any},
+		{Name: "gitea.pr.merge", Description: "Merge a PR by number (admin or org-admin only).", InputSchema: any},
+		{Name: "gitea.issue.list", Description: "List issues on a repo.", InputSchema: any},
+		{Name: "gitea.issue.create", Description: "Create an issue with title and body.", InputSchema: any},
+		{Name: "gitea.release.list", Description: "List releases on a repo.", InputSchema: any},
+
+		// k8s.read.* (Org vcluster scope — never host)
+		{Name: "k8s.read.get", Description: "GET a single object by GVK + namespace + name.", InputSchema: any},
+		{Name: "k8s.read.list", Description: "LIST objects by GVK + namespace (label selector optional).", InputSchema: any},
+		{Name: "k8s.read.watch", Description: "WATCH a kind for live updates (returns a subscription id).", InputSchema: any},
+		{Name: "k8s.read.logs", Description: "Fetch container logs for a pod (read-only).", InputSchema: any},
+
+		// sandbox.db.*
+		{Name: "sandbox.db.provision", Description: "Provision a CNPG cluster (size + version). Returns Cluster CR ref.", InputSchema: any},
+		{Name: "sandbox.db.list", Description: "List CNPG clusters owned by this Sandbox.", InputSchema: any},
+		{Name: "sandbox.db.dump", Description: "Trigger a pg_dump-backed backup; returns object-store URL.", InputSchema: any},
+		{Name: "sandbox.db.drop", Description: "Drop a CNPG cluster owned by this Sandbox.", InputSchema: any},
+
+		// sandbox.auth.* (Keycloak realm + client management within Sandbox scope)
+		{Name: "sandbox.auth.provisionRealm", Description: "Provision a Keycloak realm for an Application under this Sandbox.", InputSchema: any},
+		{Name: "sandbox.auth.listClients", Description: "List Keycloak clients in the Sandbox's realm.", InputSchema: any},
+		{Name: "sandbox.auth.registerClient", Description: "Register a new Keycloak client (id, redirect URIs).", InputSchema: any},
+
+		// sandbox.session.* (this MCP server's own metadata)
+		{Name: "sandbox.session.whoami", Description: "Return the claims (sub, org_id, sandbox_id, role) the server sees on its token.", InputSchema: any},
+		{Name: "sandbox.session.info", Description: "Return the current Sandbox name, namespace, attached repos.", InputSchema: any},
+	}
+}

--- a/products/sandbox/pty-server/Dockerfile
+++ b/products/sandbox/pty-server/Dockerfile
@@ -1,0 +1,20 @@
+# syntax=docker/dockerfile:1.7
+#
+# pty-server — runs inside every Sandbox pod (per Sandbox CRD spec).
+# Surface: HTTP+WS on :7681. See architecture.md §2.
+
+FROM golang:1.23-alpine AS build
+WORKDIR /src
+RUN apk add --no-cache git
+COPY go.mod go.sum* ./
+RUN go mod download || true
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 \
+    go build -trimpath -ldflags="-s -w" \
+    -o /out/pty-server ./cmd/pty-server
+
+FROM gcr.io/distroless/static-debian12:nonroot
+USER nonroot:nonroot
+COPY --from=build /out/pty-server /usr/local/bin/pty-server
+EXPOSE 7681
+ENTRYPOINT ["/usr/local/bin/pty-server"]

--- a/products/sandbox/pty-server/README.md
+++ b/products/sandbox/pty-server/README.md
@@ -1,0 +1,63 @@
+# pty-server
+
+Per-Sandbox PTY broker. Spawns the agent binary (`claude`, `cursor-agent`,
+`qwen-code`, `aider`, `opencode`) in a fresh PTY and fans its raw ANSI
+output to N concurrent WebSocket clients (browser xterm.js, mobile card
+view). One persistent process, many short-lived viewers — see
+`products/sandbox/docs/architecture.md` §1 and §2.
+
+> This is intentionally **not tmux**. We keep tmux's behaviour model
+> (one PTY, multiple clients, persistent across disconnect) and skip its
+> TUI, prefix-key, and window-manager baggage.
+
+## Surface
+
+```
+POST   /sessions                 spawn:  body {command, env?, cwd?, rows?, cols?}
+GET    /sessions                 list:   {sessions:[id, ...]}
+GET    /sessions/{id}            describe
+WS     /sessions/{id}/attach     bidi raw bytes (WS <-> PTY)
+WS     /sessions/{id}/cards      JSON card stream (mobile)
+POST   /sessions/{id}/resize     body {rows, cols}  -> SIGWINCH
+POST   /sessions/{id}/signal     body {signal}  one of INT|QUIT|TERM|HUP
+DELETE /sessions/{id}            graceful SIGTERM, then SIGKILL after 5s
+GET    /healthz                  liveness
+```
+
+On `attach` connect the server replays the last 256 KiB of PTY output
+(one binary frame) before joining the live fan-out. Slow consumers do
+not stall the PTY read loop — bytes are dropped for that subscriber
+only.
+
+## Run locally
+
+```bash
+cd products/sandbox/pty-server
+go build ./...
+PTY_SERVER_ADDR=:7681 go run ./cmd/pty-server
+```
+
+Smoke:
+
+```bash
+curl -sX POST localhost:7681/sessions \
+  -H 'content-type: application/json' \
+  -d '{"command":["bash","-l"],"rows":40,"cols":120}'
+# {"id":"abc...","createdAt":"..."}
+```
+
+## Container
+
+```bash
+docker build -t ghcr.io/openova-io/openova/sandbox-pty-server:dev .
+docker run --rm -p 7681:7681 ghcr.io/openova-io/openova/sandbox-pty-server:dev
+```
+
+## Not yet wired
+
+- Auth: today the surface is open; the production deploy is fronted by
+  the Org's gateway with the Sandbox JWT enforced. The TODO is an
+  in-process middleware that verifies the JWT and binds `org_id` /
+  `sandbox_id` claims to every session record.
+- JetStream emit on session lifecycle events. The contract is
+  `catalyst.sandbox.session.{created,exited}` (ADR-0001 §6).

--- a/products/sandbox/pty-server/cmd/pty-server/main.go
+++ b/products/sandbox/pty-server/cmd/pty-server/main.go
@@ -1,0 +1,60 @@
+// pty-server entrypoint.
+//
+// Listens on :7681 (override with $PTY_SERVER_ADDR). Serves the HTTP
+// + WebSocket surface defined in internal/server. Graceful shutdown on
+// SIGTERM / SIGINT: stop accepting new connections, then close every
+// live session (SIGTERM -> 5 s -> SIGKILL per session).
+package main
+
+import (
+	"context"
+	"errors"
+	"log"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/openova-io/openova/products/sandbox/pty-server/internal/server"
+	"github.com/openova-io/openova/products/sandbox/pty-server/internal/session"
+)
+
+func main() {
+	addr := os.Getenv("PTY_SERVER_ADDR")
+	if addr == "" {
+		addr = ":7681"
+	}
+
+	mgr := session.NewManager()
+	h := server.New(mgr)
+
+	srv := &http.Server{
+		Addr:              addr,
+		Handler:           h,
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+
+	// Graceful shutdown.
+	stop := make(chan os.Signal, 1)
+	signal.Notify(stop, syscall.SIGINT, syscall.SIGTERM)
+
+	go func() {
+		log.Printf("pty-server listening on %s", addr)
+		if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			log.Fatalf("listen: %v", err)
+		}
+	}()
+
+	<-stop
+	log.Printf("pty-server: shutdown requested")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	if err := srv.Shutdown(ctx); err != nil {
+		log.Printf("http shutdown: %v", err)
+	}
+	mgr.Shutdown()
+	log.Printf("pty-server: stopped")
+}

--- a/products/sandbox/pty-server/go.mod
+++ b/products/sandbox/pty-server/go.mod
@@ -1,0 +1,8 @@
+module github.com/openova-io/openova/products/sandbox/pty-server
+
+go 1.22
+
+require (
+	github.com/creack/pty v1.1.21
+	github.com/gorilla/websocket v1.5.3
+)

--- a/products/sandbox/pty-server/go.sum
+++ b/products/sandbox/pty-server/go.sum
@@ -1,0 +1,4 @@
+github.com/creack/pty v1.1.21 h1:1/QdRyBaHHJP61QkWMXlOIBfsgdDeeKfK8SYVUWJKf0=
+github.com/creack/pty v1.1.21/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
+github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
+github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=

--- a/products/sandbox/pty-server/internal/server/routes.go
+++ b/products/sandbox/pty-server/internal/server/routes.go
@@ -1,0 +1,359 @@
+// Package server exposes the pty-server HTTP + WebSocket surface
+// described in architecture.md §2.
+//
+// Endpoints:
+//
+//	POST   /sessions              spawn a fresh PTY + child
+//	GET    /sessions              list active session IDs
+//	GET    /sessions/{id}         describe a single session
+//	WS     /sessions/{id}/attach  bidi byte stream (raw PTY)
+//	WS     /sessions/{id}/cards   JSON card stream (mobile alt surface)
+//	POST   /sessions/{id}/resize  cols/rows -> SIGWINCH
+//	POST   /sessions/{id}/signal  named signal -> process group
+//	DELETE /sessions/{id}         graceful SIGTERM, then SIGKILL
+//	GET    /healthz               liveness
+//
+// The router is deliberately framework-free (net/http only) so the
+// resulting binary fits in a scratch container without extra surface.
+package server
+
+import (
+	"encoding/json"
+	"errors"
+	"log"
+	"net/http"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/gorilla/websocket"
+
+	"github.com/openova-io/openova/products/sandbox/pty-server/internal/session"
+)
+
+// Handler is the root http.Handler for pty-server.
+type Handler struct {
+	mgr      *session.Manager
+	upgrader websocket.Upgrader
+}
+
+// New returns an HTTP handler wired to the supplied session manager.
+func New(mgr *session.Manager) *Handler {
+	return &Handler{
+		mgr: mgr,
+		upgrader: websocket.Upgrader{
+			// pty-server is reached through the gateway with same-origin
+			// enforcement upstream; permit any origin here so localhost
+			// dev (xterm.js in a Vite dev server) works without flags.
+			CheckOrigin: func(r *http.Request) bool { return true },
+		},
+	}
+}
+
+// ServeHTTP dispatches based on path + method.
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	switch {
+	case r.URL.Path == "/healthz":
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+		return
+
+	case r.URL.Path == "/sessions" && r.Method == http.MethodPost:
+		h.create(w, r)
+		return
+
+	case r.URL.Path == "/sessions" && r.Method == http.MethodGet:
+		h.list(w, r)
+		return
+
+	case strings.HasPrefix(r.URL.Path, "/sessions/"):
+		h.dispatchSession(w, r)
+		return
+	}
+	http.NotFound(w, r)
+}
+
+// dispatchSession routes /sessions/{id}/... by path suffix.
+func (h *Handler) dispatchSession(w http.ResponseWriter, r *http.Request) {
+	// Strip "/sessions/" prefix.
+	rest := strings.TrimPrefix(r.URL.Path, "/sessions/")
+	parts := strings.SplitN(rest, "/", 2)
+	id := parts[0]
+	if id == "" {
+		http.NotFound(w, r)
+		return
+	}
+	suffix := ""
+	if len(parts) == 2 {
+		suffix = parts[1]
+	}
+
+	switch {
+	case suffix == "" && r.Method == http.MethodGet:
+		h.describe(w, r, id)
+	case suffix == "" && r.Method == http.MethodDelete:
+		h.delete(w, r, id)
+	case suffix == "attach" && r.Method == http.MethodGet:
+		h.attach(w, r, id)
+	case suffix == "cards" && r.Method == http.MethodGet:
+		h.cards(w, r, id)
+	case suffix == "resize" && r.Method == http.MethodPost:
+		h.resize(w, r, id)
+	case suffix == "signal" && r.Method == http.MethodPost:
+		h.signal(w, r, id)
+	default:
+		http.NotFound(w, r)
+	}
+}
+
+// --- request / response shapes ----------------------------------------------
+
+type createRequest struct {
+	Command []string `json:"command"`
+	Env     []string `json:"env,omitempty"`
+	Cwd     string   `json:"cwd,omitempty"`
+	Rows    uint16   `json:"rows,omitempty"`
+	Cols    uint16   `json:"cols,omitempty"`
+}
+
+type sessionDTO struct {
+	ID        string    `json:"id"`
+	CreatedAt time.Time `json:"createdAt"`
+}
+
+type resizeRequest struct {
+	Rows uint16 `json:"rows"`
+	Cols uint16 `json:"cols"`
+}
+
+type signalRequest struct {
+	Signal string `json:"signal"`
+}
+
+// --- handlers ----------------------------------------------------------------
+
+func (h *Handler) create(w http.ResponseWriter, r *http.Request) {
+	var req createRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid json", http.StatusBadRequest)
+		return
+	}
+	if len(req.Command) == 0 {
+		http.Error(w, "command required", http.StatusBadRequest)
+		return
+	}
+	s, err := h.mgr.Create(session.Spec{
+		Command: req.Command,
+		Env:     req.Env,
+		Cwd:     req.Cwd,
+		Rows:    req.Rows,
+		Cols:    req.Cols,
+	})
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	writeJSON(w, http.StatusCreated, sessionDTO{ID: s.ID, CreatedAt: s.CreatedAt})
+}
+
+func (h *Handler) list(w http.ResponseWriter, _ *http.Request) {
+	writeJSON(w, http.StatusOK, map[string]any{"sessions": h.mgr.List()})
+}
+
+func (h *Handler) describe(w http.ResponseWriter, _ *http.Request, id string) {
+	s, err := h.mgr.Get(id)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusNotFound)
+		return
+	}
+	writeJSON(w, http.StatusOK, sessionDTO{ID: s.ID, CreatedAt: s.CreatedAt})
+}
+
+func (h *Handler) delete(w http.ResponseWriter, _ *http.Request, id string) {
+	if err := h.mgr.Stop(id); err != nil {
+		if errors.Is(err, session.ErrNotFound) {
+			http.Error(w, err.Error(), http.StatusNotFound)
+			return
+		}
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (h *Handler) resize(w http.ResponseWriter, r *http.Request, id string) {
+	s, err := h.mgr.Get(id)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusNotFound)
+		return
+	}
+	var req resizeRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid json", http.StatusBadRequest)
+		return
+	}
+	if err := s.Resize(req.Rows, req.Cols); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// signal maps human signal names to syscall.Signal. We deliberately
+// allow only the safe / scripted set named in architecture.md §2.
+func (h *Handler) signal(w http.ResponseWriter, r *http.Request, id string) {
+	s, err := h.mgr.Get(id)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusNotFound)
+		return
+	}
+	var req signalRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid json", http.StatusBadRequest)
+		return
+	}
+	sig, ok := allowedSignals[strings.ToUpper(req.Signal)]
+	if !ok {
+		http.Error(w, "unsupported signal", http.StatusBadRequest)
+		return
+	}
+	if err := s.Signal(sig); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+var allowedSignals = map[string]syscall.Signal{
+	"INT":  syscall.SIGINT,
+	"QUIT": syscall.SIGQUIT,
+	"TERM": syscall.SIGTERM,
+	"HUP":  syscall.SIGHUP,
+}
+
+// attach is the canonical raw-byte WebSocket bridge:
+//
+//	  WS frames (binary) -> PTY stdin
+//	  PTY stdout         -> WS frames (binary)
+//
+// On connect we first ship the replay buffer (one binary frame) so the
+// browser's xterm.js paints the recent screen before the live stream
+// resumes.
+func (h *Handler) attach(w http.ResponseWriter, r *http.Request, id string) {
+	s, err := h.mgr.Get(id)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusNotFound)
+		return
+	}
+
+	conn, err := h.upgrader.Upgrade(w, r, nil)
+	if err != nil {
+		log.Printf("ws upgrade: %v", err)
+		return
+	}
+	defer conn.Close()
+
+	sub, replay, err := s.Subscribe(256)
+	if err != nil {
+		_ = conn.WriteMessage(websocket.CloseMessage,
+			websocket.FormatCloseMessage(websocket.CloseGoingAway, err.Error()))
+		return
+	}
+	defer s.Unsubscribe(sub)
+
+	// Replay first.
+	if len(replay) > 0 {
+		if err := conn.WriteMessage(websocket.BinaryMessage, replay); err != nil {
+			return
+		}
+	}
+
+	// writeMu serialises concurrent writes from the two pumps.
+	var writeMu sync.Mutex
+	writeBytes := func(p []byte) error {
+		writeMu.Lock()
+		defer writeMu.Unlock()
+		return conn.WriteMessage(websocket.BinaryMessage, p)
+	}
+
+	// PTY -> WS pump.
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for {
+			select {
+			case <-sub.Done:
+				return
+			case chunk, ok := <-sub.Ch:
+				if !ok {
+					return
+				}
+				if err := writeBytes(chunk); err != nil {
+					return
+				}
+			}
+		}
+	}()
+
+	// WS -> PTY pump (blocking on Read).
+	for {
+		mt, payload, err := conn.ReadMessage()
+		if err != nil {
+			break
+		}
+		// Both text and binary are user input; resize is its own POST.
+		if mt == websocket.TextMessage || mt == websocket.BinaryMessage {
+			if _, err := s.Write(payload); err != nil {
+				break
+			}
+		}
+	}
+	<-done
+}
+
+// cards is the mobile alt surface (architecture.md §1). For Wave 2 it
+// exposes the same byte stream but framed as JSON {"type":"raw",...}.
+// A future card-translator replaces the body with parsed cards.
+func (h *Handler) cards(w http.ResponseWriter, r *http.Request, id string) {
+	s, err := h.mgr.Get(id)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusNotFound)
+		return
+	}
+	conn, err := h.upgrader.Upgrade(w, r, nil)
+	if err != nil {
+		log.Printf("ws upgrade: %v", err)
+		return
+	}
+	defer conn.Close()
+
+	sub, replay, err := s.Subscribe(256)
+	if err != nil {
+		return
+	}
+	defer s.Unsubscribe(sub)
+
+	if len(replay) > 0 {
+		_ = conn.WriteJSON(map[string]any{"type": "raw", "bytes": replay})
+	}
+	for {
+		select {
+		case <-sub.Done:
+			return
+		case chunk, ok := <-sub.Ch:
+			if !ok {
+				return
+			}
+			if err := conn.WriteJSON(map[string]any{"type": "raw", "bytes": chunk}); err != nil {
+				return
+			}
+		}
+	}
+}
+
+func writeJSON(w http.ResponseWriter, status int, body any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(body)
+}

--- a/products/sandbox/pty-server/internal/session/buffer.go
+++ b/products/sandbox/pty-server/internal/session/buffer.go
@@ -1,0 +1,80 @@
+// Package session implements the per-PTY session model used by
+// pty-server. A Session owns one PTY file descriptor + the child
+// process attached to it, plus a fan-out hub that ships PTY stdout to
+// any number of concurrent WebSocket subscribers (browser tabs, mobile
+// card-mode clients).
+//
+// The ring buffer here keeps the last 256 KiB of PTY output so a newly
+// attaching client can replay the recent screen before joining the
+// live stream — see architecture.md §1 "ring buffer (256 KB) for
+// replay" and §2 "Replay last N KB on reconnect".
+package session
+
+import "sync"
+
+// RingBuffer is a fixed-capacity byte ring used to retain the recent
+// tail of PTY stdout for replay on new client connect.
+//
+// The buffer is goroutine-safe: Write() is called from the PTY read
+// loop, Snapshot() from any number of attaching subscribers.
+type RingBuffer struct {
+	mu   sync.Mutex
+	buf  []byte
+	cap  int
+	full bool
+	pos  int // next write position
+}
+
+// NewRingBuffer returns a ring of the given capacity in bytes.
+// The default Sandbox session uses 256 KiB (262_144).
+func NewRingBuffer(capacity int) *RingBuffer {
+	if capacity <= 0 {
+		capacity = 1
+	}
+	return &RingBuffer{
+		buf: make([]byte, capacity),
+		cap: capacity,
+	}
+}
+
+// Write appends p to the ring, overwriting the oldest bytes if needed.
+// It never errors and never blocks beyond its own mutex.
+func (r *RingBuffer) Write(p []byte) (int, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for _, b := range p {
+		r.buf[r.pos] = b
+		r.pos++
+		if r.pos >= r.cap {
+			r.pos = 0
+			r.full = true
+		}
+	}
+	return len(p), nil
+}
+
+// Snapshot returns a copy of the ring contents in chronological order
+// (oldest byte first). Safe to call while writes are in flight.
+func (r *RingBuffer) Snapshot() []byte {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if !r.full {
+		out := make([]byte, r.pos)
+		copy(out, r.buf[:r.pos])
+		return out
+	}
+	out := make([]byte, r.cap)
+	copy(out, r.buf[r.pos:])
+	copy(out[r.cap-r.pos:], r.buf[:r.pos])
+	return out
+}
+
+// Len returns the number of bytes currently retained (<= cap).
+func (r *RingBuffer) Len() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.full {
+		return r.cap
+	}
+	return r.pos
+}

--- a/products/sandbox/pty-server/internal/session/manager.go
+++ b/products/sandbox/pty-server/internal/session/manager.go
@@ -1,0 +1,108 @@
+package session
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"sync"
+)
+
+// ErrNotFound is returned by Manager.Get / Stop for unknown session IDs.
+var ErrNotFound = errors.New("session: not found")
+
+// Manager tracks live Sessions by ID. One Manager per pty-server
+// process; the manager is concurrency-safe and is the single place
+// that allocates session IDs.
+type Manager struct {
+	mu       sync.RWMutex
+	sessions map[string]*Session
+}
+
+// NewManager returns an empty Manager.
+func NewManager() *Manager {
+	return &Manager{sessions: make(map[string]*Session)}
+}
+
+// Create spawns a Session and registers it under a freshly minted ID.
+func (m *Manager) Create(spec Spec) (*Session, error) {
+	id, err := newID()
+	if err != nil {
+		return nil, err
+	}
+	s, err := New(id, spec)
+	if err != nil {
+		return nil, err
+	}
+	m.mu.Lock()
+	m.sessions[id] = s
+	m.mu.Unlock()
+
+	// Auto-evict on exit so /sessions stays accurate.
+	go func() {
+		<-s.Done()
+		m.mu.Lock()
+		delete(m.sessions, id)
+		m.mu.Unlock()
+	}()
+
+	return s, nil
+}
+
+// Get returns the Session with the given ID or ErrNotFound.
+func (m *Manager) Get(id string) (*Session, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	s, ok := m.sessions[id]
+	if !ok {
+		return nil, ErrNotFound
+	}
+	return s, nil
+}
+
+// Stop terminates the Session and removes it. Returns ErrNotFound if
+// no such Session exists.
+func (m *Manager) Stop(id string) error {
+	m.mu.Lock()
+	s, ok := m.sessions[id]
+	if ok {
+		delete(m.sessions, id)
+	}
+	m.mu.Unlock()
+	if !ok {
+		return ErrNotFound
+	}
+	return s.Close()
+}
+
+// List returns a snapshot of currently active session IDs.
+func (m *Manager) List() []string {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	out := make([]string, 0, len(m.sessions))
+	for id := range m.sessions {
+		out = append(out, id)
+	}
+	return out
+}
+
+// Shutdown closes every live session, used on SIGTERM.
+func (m *Manager) Shutdown() {
+	m.mu.Lock()
+	ids := make([]*Session, 0, len(m.sessions))
+	for _, s := range m.sessions {
+		ids = append(ids, s)
+	}
+	m.sessions = make(map[string]*Session)
+	m.mu.Unlock()
+	for _, s := range ids {
+		_ = s.Close()
+	}
+}
+
+func newID() (string, error) {
+	var b [12]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b[:]), nil
+}

--- a/products/sandbox/pty-server/internal/session/session.go
+++ b/products/sandbox/pty-server/internal/session/session.go
@@ -1,0 +1,282 @@
+package session
+
+import (
+	"errors"
+	"io"
+	"os"
+	"os/exec"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/creack/pty"
+)
+
+// ErrClosed indicates the Session has already exited (graceful or
+// forced) and no further writes / signals / resizes will succeed.
+var ErrClosed = errors.New("session: closed")
+
+// Subscriber receives a copy of every PTY stdout chunk after attach.
+// The Session writes the chunk to Ch; if Ch is full the Session drops
+// the chunk for THAT subscriber only (slow consumers do not stall the
+// PTY read loop or the other consumers). The Done channel is closed
+// when the Session exits, signalling subscribers to wind down.
+type Subscriber struct {
+	Ch   chan []byte
+	Done chan struct{}
+}
+
+// Session is one PTY + one child process + N concurrent subscribers.
+//
+// Lifecycle:
+//
+//	NewSession -> Start -> (Subscribe / Write / Resize / Signal) ... -> Close
+//
+// Subscribe replays the ring buffer to the new subscriber, then joins
+// it to the live fan-out. Close sends SIGTERM, waits gracefully for
+// up to 5 s, then SIGKILLs (per architecture.md §2 "graceful stop,
+// then SIGKILL").
+type Session struct {
+	ID        string
+	CreatedAt time.Time
+
+	cmd     *exec.Cmd
+	ptyFile *os.File
+	ring    *RingBuffer
+
+	mu          sync.Mutex
+	subscribers map[*Subscriber]struct{}
+	closed      bool
+	done        chan struct{}
+	exitErr     error
+}
+
+// Spec describes how to spawn the agent process inside the PTY.
+type Spec struct {
+	// Command is argv. Command[0] is the binary, the rest are args.
+	Command []string
+	// Env is the full environment for the child. nil = inherit
+	// pty-server's os.Environ().
+	Env []string
+	// Cwd is the child's working directory. "" = inherit.
+	Cwd string
+	// Rows / Cols seed the initial PTY size; the browser sends
+	// SIGWINCH-triggering Resize() calls once it knows its viewport.
+	Rows uint16
+	Cols uint16
+	// RingBytes is the replay buffer size; defaults to 256 KiB.
+	RingBytes int
+}
+
+// New spawns the command in a fresh PTY and returns a started
+// Session. The PTY read loop runs in its own goroutine; subscribers
+// can be added immediately.
+func New(id string, spec Spec) (*Session, error) {
+	if len(spec.Command) == 0 {
+		return nil, errors.New("session: empty Command")
+	}
+	if spec.Rows == 0 {
+		spec.Rows = 24
+	}
+	if spec.Cols == 0 {
+		spec.Cols = 80
+	}
+	if spec.RingBytes == 0 {
+		spec.RingBytes = 256 * 1024
+	}
+
+	cmd := exec.Command(spec.Command[0], spec.Command[1:]...)
+	if spec.Env != nil {
+		cmd.Env = spec.Env
+	} else {
+		cmd.Env = os.Environ()
+	}
+	if spec.Cwd != "" {
+		cmd.Dir = spec.Cwd
+	}
+
+	f, err := pty.StartWithSize(cmd, &pty.Winsize{Rows: spec.Rows, Cols: spec.Cols})
+	if err != nil {
+		return nil, err
+	}
+
+	s := &Session{
+		ID:          id,
+		CreatedAt:   time.Now().UTC(),
+		cmd:         cmd,
+		ptyFile:     f,
+		ring:        NewRingBuffer(spec.RingBytes),
+		subscribers: make(map[*Subscriber]struct{}),
+		done:        make(chan struct{}),
+	}
+
+	go s.readLoop()
+	go s.waitLoop()
+
+	return s, nil
+}
+
+// readLoop drains the PTY master fd, mirrors every chunk into the
+// ring buffer, and fans the chunk out to every live subscriber. It
+// exits when the PTY is closed (typically: child exited and Wait()
+// returned).
+func (s *Session) readLoop() {
+	buf := make([]byte, 32*1024)
+	for {
+		n, err := s.ptyFile.Read(buf)
+		if n > 0 {
+			chunk := make([]byte, n)
+			copy(chunk, buf[:n])
+			_, _ = s.ring.Write(chunk)
+			s.fanout(chunk)
+		}
+		if err != nil {
+			return
+		}
+	}
+}
+
+// waitLoop reaps the child process. When the child exits we close
+// the PTY (unblocks readLoop), mark the Session closed, and signal
+// all subscribers via Done.
+func (s *Session) waitLoop() {
+	err := s.cmd.Wait()
+	s.mu.Lock()
+	if !s.closed {
+		s.closed = true
+		s.exitErr = err
+		_ = s.ptyFile.Close()
+		close(s.done)
+		for sub := range s.subscribers {
+			close(sub.Done)
+		}
+	}
+	s.mu.Unlock()
+}
+
+func (s *Session) fanout(chunk []byte) {
+	s.mu.Lock()
+	subs := make([]*Subscriber, 0, len(s.subscribers))
+	for sub := range s.subscribers {
+		subs = append(subs, sub)
+	}
+	s.mu.Unlock()
+	for _, sub := range subs {
+		select {
+		case sub.Ch <- chunk:
+		default:
+			// Slow consumer: drop for this subscriber only;
+			// the PTY-side and other consumers are unaffected.
+		}
+	}
+}
+
+// Subscribe registers a new fan-out consumer. The returned Subscriber
+// receives every PTY stdout chunk that arrives AFTER subscribe time;
+// the second return value is a snapshot of the ring (call replay
+// first, then loop on Ch).
+func (s *Session) Subscribe(bufferDepth int) (*Subscriber, []byte, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return nil, nil, ErrClosed
+	}
+	if bufferDepth <= 0 {
+		bufferDepth = 64
+	}
+	sub := &Subscriber{
+		Ch:   make(chan []byte, bufferDepth),
+		Done: make(chan struct{}),
+	}
+	s.subscribers[sub] = struct{}{}
+	return sub, s.ring.Snapshot(), nil
+}
+
+// Unsubscribe removes the subscriber from the fan-out set. Safe to
+// call even after the Session has exited.
+func (s *Session) Unsubscribe(sub *Subscriber) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.subscribers, sub)
+}
+
+// Write forwards user keystrokes (raw bytes from the WS) to PTY stdin.
+func (s *Session) Write(p []byte) (int, error) {
+	s.mu.Lock()
+	if s.closed {
+		s.mu.Unlock()
+		return 0, ErrClosed
+	}
+	f := s.ptyFile
+	s.mu.Unlock()
+	return f.Write(p)
+}
+
+// Resize triggers SIGWINCH on the child by re-setting the PTY winsize
+// (per architecture.md §1 / §2 "SIGWINCH on browser resize").
+func (s *Session) Resize(rows, cols uint16) error {
+	s.mu.Lock()
+	if s.closed {
+		s.mu.Unlock()
+		return ErrClosed
+	}
+	f := s.ptyFile
+	s.mu.Unlock()
+	return pty.Setsize(f, &pty.Winsize{Rows: rows, Cols: cols})
+}
+
+// Signal delivers a UNIX signal to the child process group. The
+// pty-server API accepts named INT / QUIT / TERM / KILL (the canonical
+// "user-driven abort" set from architecture.md §2).
+func (s *Session) Signal(sig syscall.Signal) error {
+	s.mu.Lock()
+	if s.closed || s.cmd == nil || s.cmd.Process == nil {
+		s.mu.Unlock()
+		return ErrClosed
+	}
+	pid := s.cmd.Process.Pid
+	s.mu.Unlock()
+	// Negative pid → send to the whole process group, so children
+	// spawned by the agent (e.g. shell tools) also receive the
+	// signal. The PTY allocated by creack/pty is the controlling
+	// terminal, so pid == pgid.
+	return syscall.Kill(-pid, sig)
+}
+
+// Close gracefully stops the child: SIGTERM, wait up to 5 s, SIGKILL.
+// Idempotent.
+func (s *Session) Close() error {
+	s.mu.Lock()
+	already := s.closed
+	s.mu.Unlock()
+	if already {
+		return nil
+	}
+	_ = s.Signal(syscall.SIGTERM)
+	select {
+	case <-s.done:
+		return nil
+	case <-time.After(5 * time.Second):
+	}
+	_ = s.Signal(syscall.SIGKILL)
+	<-s.done
+	return nil
+}
+
+// Done returns a channel closed when the session has exited.
+func (s *Session) Done() <-chan struct{} { return s.done }
+
+// ExitError is the process exit error after Wait, or nil if the
+// session has not exited / exited successfully.
+func (s *Session) ExitError() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if !s.closed {
+		return nil
+	}
+	return s.exitErr
+}
+
+// Compile-time assertion that *Session implements io.Writer for any
+// future use that wants to push raw bytes (e.g. test fakes).
+var _ io.Writer = (*Session)(nil)


### PR DESCRIPTION
## Summary

Two Go services that together carry the agent traffic per
`products/sandbox/docs/architecture.md` §1-§3. Explicitly **not tmux**.

### pty-server (`products/sandbox/pty-server`, `:7681`)

| Method | Path | Purpose |
|---|---|---|
| POST   | /sessions             | spawn child in fresh PTY |
| GET    | /sessions / /sessions/{id} | list / describe |
| WS     | /sessions/{id}/attach | bidi raw byte stream; replays 256 KiB ring on connect |
| WS     | /sessions/{id}/cards  | JSON card stream (mobile alt surface) |
| POST   | /sessions/{id}/resize | rows/cols -> SIGWINCH |
| POST   | /sessions/{id}/signal | INT \| QUIT \| TERM \| HUP to process group |
| DELETE | /sessions/{id}        | graceful SIGTERM, 5 s, SIGKILL |
| GET    | /healthz              | liveness |

Built on `creack/pty` + `gorilla/websocket`. Fan-out drops only for slow
consumers (PTY read loop never stalls). Graceful shutdown closes every
session on SIGTERM.

### openova-sandbox-mcp (`products/sandbox/mcp-server`, stdio JSON-RPC)

`initialize`, `tools/list`, `tools/call`, `ping`, init/cancel
notifications wired end-to-end. Tool catalogue stubs across the
required namespaces:

- `gitea.*` — 8 tools
- `k8s.read.*` — 4 tools
- `sandbox.db.*` — 4 tools
- `sandbox.auth.*` — 3 tools
- `sandbox.session.*` — 2 tools (`whoami`, `info`) for agent self-discovery

Every stub returns `{"status":"not_implemented","tool":...,"wave":2}` so
the agent can list and dispatch the full surface before backends land in
Wave 3+.

### Out of scope (hard rules respected)

- No chart bump.
- No npm install / no UI changes.
- No tmux (rejected per architecture §2).
- Clusters remain read-only.

## Test plan

- [x] `go build ./...` clean — pty-server
- [x] `go vet ./...` clean — pty-server
- [x] `go build ./...` clean — mcp-server
- [x] `go vet ./...` clean — mcp-server
- [x] MCP smoke: stdin `initialize` -> framed response with `serverInfo.name = openova-sandbox-mcp`
- [x] MCP smoke: `tools/list` returns 21 tools sorted by name
- [ ] Wave 3: container build via CI; deploy via sandbox-controller; real backends.

Generated with [Claude Code](https://claude.com/claude-code)