### PR TITLE
feat(sandbox): Wave 1 controller + chart scaffold

### DIFF
--- a/core/controllers/sandbox/Dockerfile
+++ b/core/controllers/sandbox/Dockerfile
@@ -1,0 +1,53 @@
+# sandbox-controller — Wave 1 of the Sandbox product.
+#
+# A Catalyst-built Go binary that reconciles Sandbox.sandbox.openova.io/v1
+# CRs into per-Sandbox namespace + RBAC + PVCs + placeholder Secret
+# manifests written to the per-Org `catalyst-tenant` Gitea repo. Flux on
+# the host cluster picks up the manifests and reconciles them into the
+# Org vcluster (sister of organization-controller — same patterns).
+#
+# Build context: invoked with the repository ROOT as the build context.
+# Mirrors core/controllers/organization/Containerfile (slice CC1 layout:
+# shared go.mod at core/controllers/, shared pkg at core/controllers/pkg).
+#
+# Two stages:
+#   build  — golang:1.23-alpine
+#   final  — alpine:3.20 minimal runtime (CA certs + the binary)
+
+FROM docker.io/library/golang:1.23-alpine AS build
+WORKDIR /workspace
+
+# Stage 1: cache module downloads — go.mod/go.sum at the shared root.
+COPY core/controllers/go.mod core/controllers/go.sum core/controllers/
+WORKDIR /workspace/core/controllers
+RUN go mod download
+
+# Stage 2: copy source + build. Same layout the organization-controller
+# Containerfile uses (Fix #42 follow-up — shared internal + pkg dirs
+# MUST be copied before the per-controller dir, else `go build` fails
+# resolving the github.com/openova-io/openova/core/controllers/pkg/gitea
+# import.
+WORKDIR /workspace
+COPY core/controllers/internal /workspace/core/controllers/internal
+COPY core/controllers/pkg /workspace/core/controllers/pkg
+COPY core/controllers/sandbox /workspace/core/controllers/sandbox
+
+WORKDIR /workspace/core/controllers/sandbox
+RUN CGO_ENABLED=0 GOOS=linux go build \
+    -ldflags="-s -w" \
+    -o /sandbox-controller ./cmd/sandbox-controller
+
+# Stage 3: minimal runtime.
+FROM docker.io/library/alpine:3.20
+RUN apk add --no-cache ca-certificates tzdata
+
+COPY --from=build /sandbox-controller /sandbox-controller
+
+# Alpine 3.20 already ships UID 65534 as `nobody`. The numeric form
+# satisfies runAsNonRoot=true + runAsUser=65534 in the chart's
+# Deployment.
+USER 65534:65534
+
+EXPOSE 8080 8081
+
+ENTRYPOINT ["/sandbox-controller"]

--- a/core/controllers/sandbox/cmd/sandbox-controller/main.go
+++ b/core/controllers/sandbox/cmd/sandbox-controller/main.go
@@ -1,0 +1,133 @@
+// sandbox-controller — Wave 1 of the Sandbox product
+// (products/sandbox/docs/architecture.md §7).
+//
+// Production entry point. Reads configuration from environment vars,
+// constructs the controller-runtime manager, and starts the Sandbox
+// reconciler with leader election. SIGTERM / SIGINT are honored via
+// signals.SetupSignalHandler() so a Pod-eviction triggers a clean
+// shutdown.
+//
+// Per Inviolable Principle #4 every knob is an env var — no hardcoded
+// URLs / versions / regions in code. Shape mirrors
+// core/controllers/organization/cmd/main.go.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+
+	"github.com/openova-io/openova/core/controllers/pkg/gitea"
+	"github.com/openova-io/openova/core/controllers/sandbox/internal/controller"
+	sandboxapi "github.com/openova-io/openova/core/controllers/sandbox/internal/sandboxapi"
+)
+
+var scheme = runtime.NewScheme()
+
+func init() {
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	utilruntime.Must(sandboxapi.AddToScheme(scheme))
+}
+
+func main() {
+	var (
+		metricsAddr          string
+		probeAddr            string
+		enableLeaderElection bool
+	)
+	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
+	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
+	flag.BoolVar(&enableLeaderElection, "leader-elect", true,
+		"Enable leader election for controller manager. Defaults to true so HA replicas don't double-write.")
+
+	opts := zap.Options{Development: false}
+	opts.BindFlags(flag.CommandLine)
+	flag.Parse()
+
+	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
+	log := ctrl.Log.WithName("sandbox-controller")
+
+	// Required env.
+	giteaURL := mustEnv("CATALYST_GITEA_URL", log)
+	giteaToken := mustEnv("CATALYST_GITEA_TOKEN", log)
+	hostCluster := mustEnv("CATALYST_HOST_CLUSTER", log)
+	sovereignFQDN := mustEnv("CATALYST_SOVEREIGN_FQDN", log)
+
+	branch := envOr("CATALYST_GITEA_BRANCH", "main")
+	tenantRepo := envOr("CATALYST_TENANT_REPO_NAME", "catalyst-tenant")
+
+	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
+		Scheme:                 scheme,
+		Metrics:                metricsserver.Options{BindAddress: metricsAddr},
+		HealthProbeBindAddress: probeAddr,
+		LeaderElection:         enableLeaderElection,
+		LeaderElectionID:       "sandbox-controller.sandbox.openova.io",
+	})
+	if err != nil {
+		log.Error(err, "manager init")
+		os.Exit(1)
+	}
+
+	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
+		log.Error(err, "healthz")
+		os.Exit(1)
+	}
+	if err := mgr.AddReadyzCheck("readyz", healthz.Ping); err != nil {
+		log.Error(err, "readyz")
+		os.Exit(1)
+	}
+
+	r := &controller.Reconciler{
+		Client:         mgr.GetClient(),
+		Log:            log.WithName("reconciler"),
+		GiteaClient:    gitea.New(giteaURL, giteaToken),
+		HostCluster:    hostCluster,
+		SovereignFQDN:  sovereignFQDN,
+		Branch:         branch,
+		TenantRepoName: tenantRepo,
+	}
+	if err := r.SetupWithManager(mgr); err != nil {
+		log.Error(err, "setup reconciler")
+		os.Exit(1)
+	}
+
+	log.Info("starting manager",
+		"host_cluster", hostCluster,
+		"sovereign_fqdn", sovereignFQDN,
+		"gitea_url", giteaURL,
+		"tenant_repo", tenantRepo,
+	)
+	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
+		log.Error(err, "manager start")
+		os.Exit(1)
+	}
+}
+
+func mustEnv(key string, log interface {
+	Error(err error, msg string, kvs ...any)
+},
+) string {
+	v := strings.TrimSpace(os.Getenv(key))
+	if v == "" {
+		log.Error(fmt.Errorf("missing env"), "required env var unset", "key", key)
+		os.Exit(2)
+	}
+	return v
+}
+
+func envOr(key, fallback string) string {
+	v := strings.TrimSpace(os.Getenv(key))
+	if v == "" {
+		return fallback
+	}
+	return v
+}

--- a/core/controllers/sandbox/internal/controller/sandbox_controller.go
+++ b/core/controllers/sandbox/internal/controller/sandbox_controller.go
@@ -1,0 +1,261 @@
+// Package controller hosts the Sandbox reconciler — the Wave 1 slice
+// of the Sandbox product (#1615 brief + products/sandbox/docs/
+// architecture.md §7).
+//
+// Per architecture.md §7 the sandbox-controller is the sister of
+// organization-controller. It reconciles a Sandbox CR into manifests
+// the per-Org Flux Kustomization (host cluster) materializes inside
+// the Org vcluster:
+//
+//   1. Namespace `sandbox-<owner-uid>` inside the Org vcluster.
+//   2. ResourceQuota mirroring spec.quota.
+//   3. ServiceAccount `sandbox` + namespace-scoped Role + RoleBinding
+//      so Wave 2's pty-server / openova-sandbox-mcp Deployments have
+//      JUST the verbs they need inside the Sandbox namespace.
+//   4. PVCs per spec.repos[] entry (repo clone target — initContainer
+//      lands in Wave 2 alongside the pty-server StatefulSet).
+//   5. Placeholder Secret `sandbox-tokens` — filled in Wave 2 by the
+//      long-lived org-scoped token issuance flow (architecture.md §6).
+//
+// The reconciler writes its desired-state manifests into the per-Org
+// `catalyst-tenant` Gitea repo at `sandbox/<owner-uid>/` — the EXACT
+// same idiom organization-controller already uses for vcluster
+// manifests (organization_controller.go:188-225). Flux on the host
+// picks it up.
+//
+// Wave 2 will add the pty-server StatefulSet + openova-sandbox-mcp
+// Deployment + HTTPRoutes. Wave 3 ships the UI scaffold.
+//
+// Idempotency: every "ensure" step is find-or-create + byte-equal
+// short-circuit. Re-reconciling on a steady-state CR writes nothing
+// downstream.
+
+package controller
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/go-logr/logr"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/openova-io/openova/core/controllers/pkg/gitea"
+	"github.com/openova-io/openova/core/controllers/sandbox/internal/gitops"
+	sandboxapi "github.com/openova-io/openova/core/controllers/sandbox/internal/sandboxapi"
+)
+
+// Reconciler reconciles Sandbox CRs. Field shape mirrors
+// organization-controller's Reconciler — fewer knobs because Wave 1
+// only touches Gitea (no Keycloak, no vcluster chart version).
+type Reconciler struct {
+	client.Client
+	Log logr.Logger
+
+	// GiteaClient is the Gitea Admin client used to PutFile manifests
+	// into the per-Org `catalyst-tenant` repo. Same client + token
+	// organization-controller uses (CATALYST_GITEA_* env).
+	GiteaClient *gitea.Client
+
+	// HostCluster is the canonical host-cluster name (e.g.
+	// hz-fsn-rtz-prod) — surfaced in logs + may go onto labels in
+	// future waves. Not yet written into any rendered manifest because
+	// Sandbox lives inside the Org vcluster, not on the host.
+	HostCluster string
+
+	// SovereignFQDN is the Sovereign domain (e.g. omantel.omani.works).
+	// Goes onto the openova.io/sovereign label of every rendered
+	// resource so fleet-wide queries work without label-graph lookup.
+	SovereignFQDN string
+
+	// Branch is the Gitea branch the controller writes manifests to.
+	// Defaults to "main" — matches organization-controller.
+	Branch string
+
+	// TenantRepoName is the per-Org "shared blueprints" repo
+	// organization-controller already wrote vcluster manifests into.
+	// Defaults to "catalyst-tenant".
+	TenantRepoName string
+}
+
+// SetupWithManager registers the reconciler. The manager's scheme must
+// already have sandboxapi registered.
+func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&sandboxapi.Sandbox{}).
+		Complete(r)
+}
+
+// Reconcile is the controller-runtime entry point.
+func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	log := r.Log.WithValues("sandbox", req.NamespacedName.String())
+	log.Info("reconcile")
+
+	var sb sandboxapi.Sandbox
+	if err := r.Get(ctx, req.NamespacedName, &sb); err != nil {
+		if apierrors.IsNotFound(err) {
+			// CR deleted — delete-handling is out of scope for Wave 1.
+			// A future wave may add a finalizer that purges the
+			// per-Sandbox namespace + Gitea-repo path. For now we
+			// leave them in place (matches organization-controller's
+			// founder direction on "retain customer data unless
+			// explicit purge").
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, fmt.Errorf("get sandbox: %w", err)
+	}
+
+	// Drift check: Wave 1 requires spec.owner.orgRef.slug present + a
+	// non-empty owner email. Mirrors organization-controller's
+	// SlugMetadataMismatch handling — surface as a Failed condition
+	// instead of silently producing broken downstream artifacts.
+	if strings.TrimSpace(sb.Spec.Owner.OrgRef.Slug) == "" {
+		return r.fail(ctx, &sb, "OwnerOrgRefMissing",
+			"spec.owner.orgRef.slug must be non-empty (the parent Organization slug)")
+	}
+	if strings.TrimSpace(sb.Spec.Owner.Email) == "" {
+		return r.fail(ctx, &sb, "OwnerEmailMissing",
+			"spec.owner.email must be non-empty")
+	}
+
+	ownerUID := sanitizeEmail(sb.Spec.Owner.Email)
+	if ownerUID == "" {
+		return r.fail(ctx, &sb, "OwnerEmailInvalid",
+			fmt.Sprintf("spec.owner.email %q did not yield a DNS-safe owner UID", sb.Spec.Owner.Email))
+	}
+
+	// Render Wave 1 manifests.
+	in := gitops.Inputs{
+		Name:          sb.Name,
+		OwnerUID:      ownerUID,
+		OwnerEmail:    sb.Spec.Owner.Email,
+		OrgSlug:       sb.Spec.Owner.OrgRef.Slug,
+		SovereignFQDN: r.SovereignFQDN,
+		Quota:         sb.Spec.Quota,
+		Repos:         sb.Spec.Repos,
+		PreviewDomain: sb.Spec.PreviewDomain,
+	}
+	manifests, err := gitops.Render(in)
+	if err != nil {
+		return r.fail(ctx, &sb, "ManifestRenderFailed", err.Error())
+	}
+
+	branch := r.Branch
+	if branch == "" {
+		branch = "main"
+	}
+	repo := r.TenantRepoName
+	if repo == "" {
+		repo = "catalyst-tenant"
+	}
+
+	// Write under sandbox/<owner-uid>/ in the per-Org repo. The repo
+	// already exists — organization-controller's reconcile loop
+	// EnsureRepo's it. We never auto-create it (Sandbox depends on
+	// Organization having been reconciled first; if the operator
+	// applied a Sandbox before its Organization the PutFile errors
+	// surface as a Failed condition rather than silently bootstrapping
+	// a half-configured Org-level repo).
+	prefix := fmt.Sprintf("sandbox/%s", ownerUID)
+	for path, data := range manifests {
+		fullPath := fmt.Sprintf("%s/%s", prefix, path)
+		if _, _, err := r.GiteaClient.PutFile(ctx,
+			sb.Spec.Owner.OrgRef.Slug, repo, branch, fullPath, data,
+			fmt.Sprintf("sandbox-controller: reconcile %s for sandbox %s/%s",
+				fullPath, sb.Namespace, sb.Name)); err != nil {
+			return r.fail(ctx, &sb, "GitopsWriteFailed",
+				fmt.Sprintf("write %s: %s", fullPath, err))
+		}
+	}
+
+	// Status update — Ready=True + Provisioning phase. Flux on the host
+	// is what actually creates the namespace / RBAC / PVCs inside the
+	// Org vcluster; the controller only certifies that the desired
+	// state has landed in Git. Wave 2 will add the cluster-side
+	// readiness condition.
+	desired := sandboxapi.SandboxStatus{
+		Phase:      "Provisioning",
+		GitopsPath: prefix,
+		Conditions: []sandboxapi.SandboxCondition{
+			{
+				Type:               "Ready",
+				Status:             "True",
+				Reason:             "GitopsReconciled",
+				Message:            fmt.Sprintf("Wave 1 manifests reconciled to gitea %s/%s@%s:%s", sb.Spec.Owner.OrgRef.Slug, repo, branch, prefix),
+				LastTransitionTime: metav1.NewTime(time.Now()),
+			},
+		},
+		ObservedGeneration: sb.Generation,
+	}
+	if err := r.patchStatus(ctx, &sb, desired); err != nil {
+		return ctrl.Result{}, fmt.Errorf("patch status: %w", err)
+	}
+
+	log.Info("reconcile ok",
+		"org", sb.Spec.Owner.OrgRef.Slug,
+		"owner_uid", ownerUID,
+		"gitops_path", prefix,
+		"files", len(manifests),
+	)
+	return ctrl.Result{}, nil
+}
+
+// fail records a Failed condition + the non-zero observedGeneration so
+// the operator console can surface the error. Drift errors (missing
+// orgRef / invalid email) DO NOT requeue — they require operator
+// action. Other errors requeue after 30s (matches
+// organization-controller's cadence).
+func (r *Reconciler) fail(ctx context.Context, sb *sandboxapi.Sandbox, reason, message string) (ctrl.Result, error) {
+	r.Log.Error(errors.New(reason), message,
+		"sandbox", sb.Namespace+"/"+sb.Name,
+		"owner", sb.Spec.Owner.Email)
+	st := sandboxapi.SandboxStatus{
+		Phase: "Failed",
+		Conditions: []sandboxapi.SandboxCondition{
+			{
+				Type:               "Ready",
+				Status:             "False",
+				Reason:             reason,
+				Message:            message,
+				LastTransitionTime: metav1.NewTime(time.Now()),
+			},
+		},
+		ObservedGeneration: sb.Generation,
+	}
+	_ = r.patchStatus(ctx, sb, st)
+	switch reason {
+	case "OwnerOrgRefMissing", "OwnerEmailMissing", "OwnerEmailInvalid":
+		return ctrl.Result{}, nil
+	}
+	return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
+}
+
+func (r *Reconciler) patchStatus(ctx context.Context, sb *sandboxapi.Sandbox, desired sandboxapi.SandboxStatus) error {
+	updated := sb.DeepCopyObject().(*sandboxapi.Sandbox)
+	updated.Status = desired
+	return r.Status().Update(ctx, updated)
+}
+
+// sanitizeEmail converts an email into a DNS-label-safe leaf:
+// "ceo@acme.com" → "ceo-at-acme-com". Identical convention to
+// organization-controller's sanitizeEmail
+// (organization_controller.go:424-438) — keeping the two
+// implementations in lockstep means the same owner email produces the
+// same UID across both controllers' rendered resources.
+func sanitizeEmail(email string) string {
+	out := strings.ToLower(strings.TrimSpace(email))
+	out = strings.ReplaceAll(out, "@", "-at-")
+	out = strings.ReplaceAll(out, ".", "-")
+	out = strings.ReplaceAll(out, "+", "-plus-")
+	out = strings.ReplaceAll(out, "_", "-")
+	if len(out) > 200 {
+		out = out[:200]
+	}
+	out = strings.Trim(out, "-")
+	return out
+}

--- a/core/controllers/sandbox/internal/controller/sandbox_controller_test.go
+++ b/core/controllers/sandbox/internal/controller/sandbox_controller_test.go
@@ -1,0 +1,388 @@
+// sandbox_controller_test.go — Wave 1 happy-path + drift + idempotency
+// coverage for the sandbox reconciler. Mirrors the shape of
+// organization_controller_test.go so future maintainers can move
+// helpers between the two without re-learning a different convention.
+//
+//   1. Happy-path reconcile: clean Sandbox → all Wave 1 manifests land
+//      in the per-Org Gitea repo at sandbox/<owner-uid>/, status
+//      surfaces Ready=True + Phase=Provisioning + GitopsPath.
+//   2. Idempotency: a second reconcile on the steady-state CR makes
+//      ZERO net writes (PutFile byte-equal short-circuits).
+//   3. Drift detection: empty spec.owner.orgRef.slug → Failed
+//      condition (OwnerOrgRefMissing) + no Gitea writes.
+//   4. Drift detection: empty spec.owner.email → Failed condition
+//      (OwnerEmailMissing) + no Gitea writes.
+//   5. Missing CR → no error + no requeue.
+
+package controller
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/openova-io/openova/core/controllers/pkg/gitea"
+	sandboxapi "github.com/openova-io/openova/core/controllers/sandbox/internal/sandboxapi"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// giteaServer is a tiny in-process Gitea API stub that implements just
+// the endpoints sandbox-controller's PutFile path uses. Cloned from
+// organization-controller's test stub (organization_controller_test.go
+// :141-332) and trimmed — sandbox-controller does not create Orgs /
+// Repos, only writes files into an existing Org's repo.
+type giteaServer struct {
+	t *testing.T
+
+	mu sync.Mutex
+
+	files map[string]fileEntry // key: "{owner}/{repo}/{path}"
+
+	createFiles int
+	updateFiles int
+
+	server *httptest.Server
+}
+
+type fileEntry struct {
+	sha     string
+	content []byte
+}
+
+func newGiteaServer(t *testing.T) *giteaServer {
+	gs := &giteaServer{
+		t:     t,
+		files: map[string]fileEntry{},
+	}
+	gs.server = httptest.NewServer(http.HandlerFunc(gs.handle))
+	t.Cleanup(gs.server.Close)
+	return gs
+}
+
+func (g *giteaServer) URL() string { return g.server.URL }
+
+func (g *giteaServer) handle(w http.ResponseWriter, r *http.Request) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	if r.Header.Get("Authorization") == "" {
+		http.Error(w, "no auth", http.StatusUnauthorized)
+		return
+	}
+	p := r.URL.Path
+
+	if strings.HasPrefix(p, "/api/v1/repos/") && strings.Contains(p, "/contents/") {
+		const prefix = "/api/v1/repos/"
+		rest := p[len(prefix):]
+		idx := strings.Index(rest, "/contents/")
+		if idx < 0 {
+			http.Error(w, "bad path", http.StatusBadRequest)
+			return
+		}
+		ownerRepo := rest[:idx]
+		filePath := rest[idx+len("/contents/"):]
+		key := ownerRepo + "/" + filePath
+
+		switch r.Method {
+		case http.MethodGet:
+			f, ok := g.files[key]
+			if !ok {
+				http.Error(w, "not found", http.StatusNotFound)
+				return
+			}
+			writeJSON(w, http.StatusOK, gitea.File{
+				Path:          filePath,
+				SHA:           f.sha,
+				Type:          "file",
+				ContentBase64: base64.StdEncoding.EncodeToString(f.content),
+			})
+			return
+		case http.MethodPost, http.MethodPut:
+			var body struct {
+				Message string `json:"message"`
+				Content string `json:"content"`
+				Branch  string `json:"branch"`
+				SHA     string `json:"sha"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			data, err := base64.StdEncoding.DecodeString(body.Content)
+			if err != nil {
+				http.Error(w, "bad b64", http.StatusBadRequest)
+				return
+			}
+			if r.Method == http.MethodPost {
+				if _, exists := g.files[key]; exists {
+					http.Error(w, "exists", http.StatusUnprocessableEntity)
+					return
+				}
+				g.createFiles++
+			} else {
+				g.updateFiles++
+			}
+			g.files[key] = fileEntry{
+				sha:     fmt.Sprintf("sha-%d", g.createFiles+g.updateFiles),
+				content: data,
+			}
+			writeJSON(w, http.StatusCreated, map[string]any{
+				"content": gitea.File{
+					Path: filePath,
+					SHA:  g.files[key].sha,
+					Type: "file",
+				},
+			})
+			return
+		}
+	}
+
+	g.t.Logf("giteaServer: unhandled %s %s", r.Method, r.URL.Path)
+	http.Error(w, "not found", http.StatusNotFound)
+}
+
+func writeJSON(w http.ResponseWriter, code int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+func makeReconciler(t *testing.T, objs ...client.Object) (*Reconciler, *giteaServer) {
+	t.Helper()
+
+	scheme := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(scheme); err != nil {
+		t.Fatalf("add clientgo scheme: %v", err)
+	}
+	if err := sandboxapi.AddToScheme(scheme); err != nil {
+		t.Fatalf("add sandboxapi scheme: %v", err)
+	}
+
+	cl := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&sandboxapi.Sandbox{}).
+		WithObjects(objs...).
+		Build()
+
+	gs := newGiteaServer(t)
+
+	r := &Reconciler{
+		Client:         cl,
+		Log:            logr.Discard(),
+		GiteaClient:    gitea.New(gs.URL(), "test-token"),
+		HostCluster:    "ct-eu-mgt-prod",
+		SovereignFQDN:  "omantel.omani.works",
+		Branch:         "main",
+		TenantRepoName: "catalyst-tenant",
+	}
+	return r, gs
+}
+
+func sampleSandbox() *sandboxapi.Sandbox {
+	return &sandboxapi.Sandbox{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: sandboxapi.GroupVersion.String(),
+			Kind:       "Sandbox",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "emrah",
+			Namespace:  "acme",
+			Generation: 1,
+			UID:        "00000000-0000-0000-0000-000000000001",
+		},
+		Spec: sandboxapi.SandboxSpec{
+			Owner: sandboxapi.SandboxOwner{
+				Email:  "ceo@acme.com",
+				OrgRef: sandboxapi.SandboxOrgRef{Slug: "acme"},
+			},
+			Quota: sandboxapi.SandboxQuota{
+				CPU:                "4",
+				Memory:             "8Gi",
+				Storage:            "50Gi",
+				ConcurrentSessions: 3,
+			},
+			Repos: []sandboxapi.SandboxRepo{
+				{GiteaRepo: "acme/eventforge"},
+				{GiteaRepo: "acme/internal-tools"},
+			},
+			AgentCatalogue: []string{"claude-code", "cursor-agent"},
+			PreviewDomain:  "sb-emrah.rzk7.openova.io",
+		},
+	}
+}
+
+func TestReconcile_HappyPath(t *testing.T) {
+	t.Parallel()
+	sb := sampleSandbox()
+	r, gs := makeReconciler(t, sb)
+
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: sb.Name, Namespace: sb.Namespace},
+	})
+	if err != nil {
+		t.Fatalf("reconcile error: %v", err)
+	}
+	if res.RequeueAfter != 0 {
+		t.Errorf("happy path should not requeue: got %v", res)
+	}
+
+	// Wave 1 renders: namespace + resourcequota + serviceaccount + role
+	// + rolebinding + secret + kustomization + 2 PVCs (one per repo).
+	expectedFiles := 6 /* fixed */ + 1 /* kust */ + 2 /* repo PVCs */
+	if gs.createFiles != expectedFiles {
+		t.Errorf("expected %d file creates, got %d", expectedFiles, gs.createFiles)
+	}
+	if gs.updateFiles != 0 {
+		t.Errorf("expected 0 file updates on first reconcile, got %d", gs.updateFiles)
+	}
+
+	// Every rendered file must live under sandbox/<owner-uid>/ in the
+	// per-Org repo. The owner UID for ceo@acme.com is ceo-at-acme-com.
+	wantPrefix := "acme/catalyst-tenant/sandbox/ceo-at-acme-com/"
+	for key := range gs.files {
+		if !strings.HasPrefix(key, wantPrefix) {
+			t.Errorf("file %q not under expected prefix %q", key, wantPrefix)
+		}
+	}
+
+	// Status: Phase=Provisioning, Ready=True, observedGeneration=1.
+	var got sandboxapi.Sandbox
+	if err := r.Get(context.Background(),
+		client.ObjectKey{Name: sb.Name, Namespace: sb.Namespace}, &got); err != nil {
+		t.Fatalf("get post-reconcile: %v", err)
+	}
+	if got.Status.ObservedGeneration != 1 {
+		t.Errorf("observedGeneration: got %d want 1", got.Status.ObservedGeneration)
+	}
+	if got.Status.Phase != "Provisioning" {
+		t.Errorf("phase: got %q want %q", got.Status.Phase, "Provisioning")
+	}
+	if got.Status.GitopsPath != "sandbox/ceo-at-acme-com" {
+		t.Errorf("gitopsPath: got %q", got.Status.GitopsPath)
+	}
+	if len(got.Status.Conditions) != 1 ||
+		got.Status.Conditions[0].Type != "Ready" ||
+		got.Status.Conditions[0].Status != "True" ||
+		got.Status.Conditions[0].Reason != "GitopsReconciled" {
+		t.Errorf("expected Ready=True/GitopsReconciled, got %+v", got.Status.Conditions)
+	}
+}
+
+func TestReconcile_Idempotent(t *testing.T) {
+	t.Parallel()
+	sb := sampleSandbox()
+	r, gs := makeReconciler(t, sb)
+
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: sb.Name, Namespace: sb.Namespace},
+	}); err != nil {
+		t.Fatalf("first reconcile: %v", err)
+	}
+	firstCreates := gs.createFiles
+	firstUpdates := gs.updateFiles
+
+	// Second reconcile should be a byte-equal no-op (PutFile's GET
+	// hits, SHA matches, no write).
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: sb.Name, Namespace: sb.Namespace},
+	}); err != nil {
+		t.Fatalf("second reconcile: %v", err)
+	}
+
+	if delta := gs.createFiles - firstCreates; delta != 0 {
+		t.Errorf("idempotency: expected zero new creates, got %d", delta)
+	}
+	if delta := gs.updateFiles - firstUpdates; delta != 0 {
+		t.Errorf("idempotency: expected zero file updates, got %d", delta)
+	}
+}
+
+func TestReconcile_OwnerOrgRefMissing(t *testing.T) {
+	t.Parallel()
+	sb := sampleSandbox()
+	sb.Spec.Owner.OrgRef.Slug = ""
+	r, gs := makeReconciler(t, sb)
+
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: sb.Name, Namespace: sb.Namespace},
+	})
+	if err != nil {
+		t.Fatalf("reconcile (drift): %v", err)
+	}
+	if res.RequeueAfter != 0 {
+		t.Errorf("drift should not requeue: got %v", res)
+	}
+	if gs.createFiles != 0 || gs.updateFiles != 0 {
+		t.Errorf("drift: no Gitea writes expected, got creates=%d updates=%d",
+			gs.createFiles, gs.updateFiles)
+	}
+
+	var got sandboxapi.Sandbox
+	if err := r.Get(context.Background(),
+		client.ObjectKey{Name: sb.Name, Namespace: sb.Namespace}, &got); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.Status.Phase != "Failed" {
+		t.Errorf("phase: got %q want Failed", got.Status.Phase)
+	}
+	if len(got.Status.Conditions) != 1 ||
+		got.Status.Conditions[0].Status != "False" ||
+		got.Status.Conditions[0].Reason != "OwnerOrgRefMissing" {
+		t.Errorf("expected OwnerOrgRefMissing False condition, got %+v", got.Status.Conditions)
+	}
+}
+
+func TestReconcile_OwnerEmailMissing(t *testing.T) {
+	t.Parallel()
+	sb := sampleSandbox()
+	sb.Spec.Owner.Email = ""
+	r, gs := makeReconciler(t, sb)
+
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: sb.Name, Namespace: sb.Namespace},
+	}); err != nil {
+		t.Fatalf("reconcile (drift): %v", err)
+	}
+	if gs.createFiles != 0 {
+		t.Errorf("drift: no Gitea writes expected, got %d creates", gs.createFiles)
+	}
+
+	var got sandboxapi.Sandbox
+	if err := r.Get(context.Background(),
+		client.ObjectKey{Name: sb.Name, Namespace: sb.Namespace}, &got); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if len(got.Status.Conditions) != 1 ||
+		got.Status.Conditions[0].Reason != "OwnerEmailMissing" {
+		t.Errorf("expected OwnerEmailMissing False condition, got %+v", got.Status.Conditions)
+	}
+}
+
+func TestReconcile_Missing_NoError(t *testing.T) {
+	t.Parallel()
+	r, _ := makeReconciler(t /* no objects */)
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "ghost", Namespace: "acme"},
+	})
+	if err != nil {
+		t.Fatalf("reconcile of missing CR should be a no-op, got: %v", err)
+	}
+	if res.RequeueAfter != 0 {
+		t.Errorf("missing CR should not requeue, got %v", res)
+	}
+}

--- a/core/controllers/sandbox/internal/gitops/manifests.go
+++ b/core/controllers/sandbox/internal/gitops/manifests.go
@@ -1,0 +1,382 @@
+// Package gitops renders the per-Sandbox manifests the sandbox-controller
+// writes into the per-Org `catalyst-tenant` Gitea repo under
+// `sandbox/<owner-uid>/`.
+//
+// Per products/sandbox/docs/architecture.md §7 the sandbox-controller
+// is the sister of organization-controller — it reconciles a
+// per-Sandbox namespace + RBAC + PVCs + placeholder Secret INSIDE the
+// Org vcluster (not the host cluster). The controller writes manifests
+// to the per-Org Gitea repo following the SAME idiom
+// organization-controller uses for vcluster manifests
+// (core/controllers/organization/internal/gitops/manifests.go) — Flux
+// on the host picks them up and reconciles into the Org vcluster.
+//
+// Wave 1 (this slice) materializes only:
+//   - Namespace `sandbox-<owner-uid>` (uniquely scoped per Sandbox owner)
+//   - ResourceQuota (mirrors spec.quota)
+//   - ServiceAccount `sandbox`
+//   - Role + RoleBinding scoping the SA to the sandbox namespace
+//   - One PVC per spec.repos[] entry (repo clone target)
+//   - Placeholder Secret `sandbox-tokens` (filled in Wave 2 by the
+//     long-lived org-scoped token issuance flow — architecture.md §6)
+//
+// Wave 2 will add the pty-server StatefulSet + openova-sandbox-mcp
+// Deployment + HTTPRoutes for `<pr>.<app>.<sb-<owner>>.<sov>.openova.io`.
+//
+// Per Inviolable Principle #4 (no hardcoded values) every knob comes
+// from Inputs — nothing in the template literals encodes a cluster /
+// region / version.
+package gitops
+
+import (
+	"bytes"
+	"fmt"
+	"sort"
+	"strings"
+	"text/template"
+
+	sandboxapi "github.com/openova-io/openova/core/controllers/sandbox/internal/sandboxapi"
+)
+
+// Inputs is the subset of Sandbox spec + controller-level metadata the
+// renderer needs. The reconciler builds this from the CR + reconciler
+// configuration. Mirrors the shape of organization/internal/gitops.Inputs
+// so future maintainers can move helpers between the two without
+// re-learning a different convention.
+type Inputs struct {
+	// Name is the Sandbox resource name (used as a stable suffix when
+	// the controller writes manifest filenames).
+	Name string
+
+	// OwnerUID is the DNS-1123-safe label derived from
+	// spec.owner.email (e.g. "ceo-at-acme-com"). Drives the per-Sandbox
+	// namespace `sandbox-<OwnerUID>` so two Sandboxes in the same Org
+	// stay isolated.
+	OwnerUID string
+
+	// OwnerEmail is the authoritative owner email (stored verbatim on
+	// the Namespace as an annotation for operator-debug; not used in
+	// any DNS-bound name).
+	OwnerEmail string
+
+	// OrgSlug is the parent Organization slug. Drives the
+	// openova.io/organization label so the Sovereign UI can filter
+	// Sandbox resources per-Org without a label-graph lookup.
+	OrgSlug string
+
+	// SovereignFQDN is the Sovereign domain (e.g. omantel.omani.works).
+	// Goes onto the openova.io/sovereign label for fleet-wide queries.
+	SovereignFQDN string
+
+	// Quota mirrors spec.quota — surfaced as a ResourceQuota CR.
+	Quota sandboxapi.SandboxQuota
+
+	// Repos is the (deterministically-ordered) list of repo entries the
+	// reconciler renders PVCs for.
+	Repos []sandboxapi.SandboxRepo
+
+	// PreviewDomain is spec.previewDomain — written as an annotation on
+	// the Namespace so Wave 2's HTTPRoute renderer can find it without
+	// re-reading the CR.
+	PreviewDomain string
+}
+
+const namespaceTemplate = `apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .NamespaceName }}
+  labels:
+    openova.io/organization: {{ .OrgSlug }}
+    openova.io/sovereign: {{ .SovereignFQDN }}
+    openova.io/sandbox: {{ .Name }}
+    openova.io/sandbox-owner: {{ .OwnerUID }}
+    openova.io/managed-by: catalyst
+  annotations:
+    openova.io/sandbox-owner-email: {{ .OwnerEmail | quote }}
+{{- if .PreviewDomain }}
+    openova.io/sandbox-preview-domain: {{ .PreviewDomain | quote }}
+{{- end }}
+`
+
+const resourceQuotaTemplate = `apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: sandbox-quota
+  namespace: {{ .NamespaceName }}
+  labels:
+    openova.io/sandbox: {{ .Name }}
+    openova.io/managed-by: catalyst
+spec:
+  hard:
+    requests.cpu: {{ .Quota.CPU | quote }}
+    limits.cpu: {{ .Quota.CPU | quote }}
+    requests.memory: {{ .Quota.Memory | quote }}
+    limits.memory: {{ .Quota.Memory | quote }}
+    requests.storage: {{ .Quota.Storage | quote }}
+    count/pods: {{ .Quota.ConcurrentSessions | quote }}
+`
+
+const serviceAccountTemplate = `apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sandbox
+  namespace: {{ .NamespaceName }}
+  labels:
+    openova.io/sandbox: {{ .Name }}
+    openova.io/managed-by: catalyst
+`
+
+const roleTemplate = `apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: sandbox
+  namespace: {{ .NamespaceName }}
+  labels:
+    openova.io/sandbox: {{ .Name }}
+    openova.io/managed-by: catalyst
+rules:
+  # Wave 1 RBAC: the sandbox ServiceAccount can see + manage its own
+  # namespace's workloads. Pty-server + MCP Deployments + per-session
+  # Pods (Wave 2) live here. Per architecture.md §3 the MCP server's
+  # k8s.write.* tools are restricted to this namespace — RBAC enforces
+  # that boundary.
+  - apiGroups: [""]
+    resources: ["pods", "pods/log", "pods/exec", "services", "configmaps", "secrets", "persistentvolumeclaims", "events"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["apps"]
+    resources: ["deployments", "statefulsets", "replicasets"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["batch"]
+    resources: ["jobs", "cronjobs"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+`
+
+const roleBindingTemplate = `apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: sandbox
+  namespace: {{ .NamespaceName }}
+  labels:
+    openova.io/sandbox: {{ .Name }}
+    openova.io/managed-by: catalyst
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: sandbox
+subjects:
+  - kind: ServiceAccount
+    name: sandbox
+    namespace: {{ .NamespaceName }}
+`
+
+// pvcTemplate renders one PVC per repo. The repo clone (initContainer
+// driven by the pty-server pod spec) lands in Wave 2; Wave 1 only
+// reserves the storage.
+const pvcTemplate = `apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ .PVCName }}
+  namespace: {{ .NamespaceName }}
+  labels:
+    openova.io/sandbox: {{ .Name }}
+    openova.io/sandbox-repo: {{ .RepoSlug | quote }}
+    openova.io/managed-by: catalyst
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .RepoStorage | quote }}
+`
+
+// secretTemplate renders the placeholder Secret architecture.md §7
+// calls out as "Sandbox-scoped secrets (never echoes)". Wave 2 fills
+// it with the long-lived org-scoped token (architecture.md §6) and the
+// MCP server's bearer credentials.
+const secretTemplate = `apiVersion: v1
+kind: Secret
+metadata:
+  name: sandbox-tokens
+  namespace: {{ .NamespaceName }}
+  labels:
+    openova.io/sandbox: {{ .Name }}
+    openova.io/managed-by: catalyst
+type: Opaque
+stringData:
+  placeholder: ""
+`
+
+// kustomizationTemplate stitches every rendered manifest into one
+// Kustomization the host-cluster Flux Kustomization picks up.
+const kustomizationTemplate = `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - resourcequota.yaml
+  - serviceaccount.yaml
+  - role.yaml
+  - rolebinding.yaml
+  - secret.yaml
+{{- range .RepoPaths }}
+  - {{ . }}
+{{- end }}
+`
+
+// pvcRepoStorageDefault is the per-repo PVC size when SandboxQuota does
+// not budget per-repo storage explicitly. Wave 2's storage allocator
+// will split spec.quota.storage across repos; Wave 1 uses a sane
+// fixed default so the PVC schema is well-formed.
+const pvcRepoStorageDefault = "5Gi"
+
+// Render returns (path, bytes) tuples the reconciler writes into the
+// per-Org Gitea repo under `sandbox/<owner-uid>/`. The caller prepends
+// that prefix — the renderer returns repo-relative paths.
+//
+// Idempotency: the output is deterministic for a given Inputs (sorted
+// repo iteration, no time.Now() / rand). Re-rendering on a steady-state
+// CR produces byte-equal output, which the Gitea PutFile path
+// short-circuits without a write.
+func Render(in Inputs) (map[string][]byte, error) {
+	if strings.TrimSpace(in.Name) == "" {
+		return nil, fmt.Errorf("Inputs.Name is required")
+	}
+	if strings.TrimSpace(in.OwnerUID) == "" {
+		return nil, fmt.Errorf("Inputs.OwnerUID is required")
+	}
+	if strings.TrimSpace(in.OrgSlug) == "" {
+		return nil, fmt.Errorf("Inputs.OrgSlug is required")
+	}
+	ns := fmt.Sprintf("sandbox-%s", in.OwnerUID)
+
+	// Deterministic repo ordering by GiteaRepo string — guarantees the
+	// kustomization.yaml + PVC filenames don't churn between reconciles.
+	repos := make([]sandboxapi.SandboxRepo, len(in.Repos))
+	copy(repos, in.Repos)
+	sort.SliceStable(repos, func(i, j int) bool {
+		return repos[i].GiteaRepo < repos[j].GiteaRepo
+	})
+
+	type baseCtx struct {
+		Inputs
+		NamespaceName string
+	}
+	base := baseCtx{Inputs: in, NamespaceName: ns}
+
+	out := make(map[string][]byte, 7+len(repos))
+
+	// Non-repo templates.
+	for path, raw := range map[string]string{
+		"namespace.yaml":      namespaceTemplate,
+		"resourcequota.yaml":  resourceQuotaTemplate,
+		"serviceaccount.yaml": serviceAccountTemplate,
+		"role.yaml":           roleTemplate,
+		"rolebinding.yaml":    roleBindingTemplate,
+		"secret.yaml":         secretTemplate,
+	} {
+		buf, err := renderTemplate(path, raw, base)
+		if err != nil {
+			return nil, err
+		}
+		out[path] = buf
+	}
+
+	// PVC per repo. RepoSlug is the gitea slug with "/" replaced by
+	// "-" — DNS-label safe and stable across renames (rename would
+	// produce a new CR anyway).
+	type pvcCtx struct {
+		Inputs
+		NamespaceName string
+		PVCName       string
+		RepoSlug      string
+		RepoStorage   string
+	}
+	repoPaths := make([]string, 0, len(repos))
+	for _, repo := range repos {
+		slug := sanitizeRepoSlug(repo.GiteaRepo)
+		pvcName := fmt.Sprintf("repo-%s", slug)
+		path := fmt.Sprintf("pvc-%s.yaml", slug)
+		ctx := pvcCtx{
+			Inputs:        in,
+			NamespaceName: ns,
+			PVCName:       pvcName,
+			RepoSlug:      repo.GiteaRepo,
+			RepoStorage:   pvcRepoStorageDefault,
+		}
+		buf, err := renderTemplate(path, pvcTemplate, ctx)
+		if err != nil {
+			return nil, err
+		}
+		out[path] = buf
+		repoPaths = append(repoPaths, path)
+	}
+
+	// Kustomization stitching — sorted repoPaths keeps output stable.
+	sort.Strings(repoPaths)
+	type kustCtx struct {
+		Inputs
+		NamespaceName string
+		RepoPaths     []string
+	}
+	kustBuf, err := renderTemplate("kustomization.yaml", kustomizationTemplate, kustCtx{
+		Inputs:        in,
+		NamespaceName: ns,
+		RepoPaths:     repoPaths,
+	})
+	if err != nil {
+		return nil, err
+	}
+	out["kustomization.yaml"] = kustBuf
+
+	return out, nil
+}
+
+func renderTemplate(name, raw string, data any) ([]byte, error) {
+	t, err := template.New(name).Funcs(funcs()).Parse(raw)
+	if err != nil {
+		return nil, fmt.Errorf("template parse %s: %w", name, err)
+	}
+	var buf bytes.Buffer
+	if err := t.Execute(&buf, data); err != nil {
+		return nil, fmt.Errorf("template execute %s: %w", name, err)
+	}
+	return buf.Bytes(), nil
+}
+
+func funcs() template.FuncMap {
+	return template.FuncMap{
+		// quote stringifies and double-quotes any value. Accepts `any`
+		// so int fields (e.g. SandboxQuota.ConcurrentSessions) work the
+		// same as strings — matching helm's `quote` pipe semantics.
+		"quote": func(v any) string { return fmt.Sprintf("%q", fmt.Sprintf("%v", v)) },
+	}
+}
+
+// sanitizeRepoSlug converts "acme/eventforge" → "acme-eventforge" and
+// trims any character that isn't [a-z0-9-]. The result is RFC 1123
+// DNS-label-safe so it can be embedded in resource names. Reversibility
+// is not required — the authoritative slug is on the PVC label
+// openova.io/sandbox-repo.
+func sanitizeRepoSlug(s string) string {
+	s = strings.ToLower(strings.TrimSpace(s))
+	var b strings.Builder
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9':
+			b.WriteRune(r)
+		case r == '/' || r == '_' || r == '.' || r == ' ':
+			b.WriteRune('-')
+		case r == '-':
+			b.WriteRune('-')
+		}
+	}
+	out := b.String()
+	// Collapse runs of dashes, trim leading/trailing.
+	for strings.Contains(out, "--") {
+		out = strings.ReplaceAll(out, "--", "-")
+	}
+	out = strings.Trim(out, "-")
+	if len(out) > 200 {
+		out = strings.Trim(out[:200], "-")
+	}
+	return out
+}

--- a/core/controllers/sandbox/internal/sandboxapi/types.go
+++ b/core/controllers/sandbox/internal/sandboxapi/types.go
@@ -1,0 +1,181 @@
+// Package sandboxapi defines the Go types mirroring the
+// sandbox.openova.io/v1 Sandbox CRD that sandbox-controller reconciles.
+// These mirror products/catalyst/chart/crds/sandbox.yaml 1:1; if either
+// side changes, both sides must change in the same PR.
+//
+// Per products/sandbox/docs/architecture.md §7 the Sandbox is the
+// per-user, per-Organization coding-agent plane. Wave 1 (this slice)
+// only materializes the namespace + RBAC + PVCs + placeholder Secret —
+// pty-server + openova-sandbox-mcp + preview HTTPRoutes land in Waves
+// 2/3. The CRD lives at sandbox.openova.io/v1 — a SIBLING group to
+// orgs.openova.io/v1 so RBAC + watch caches stay per-domain isolated
+// (ADR-0001 §6: `catalyst.<domain>.<event>` convention).
+package sandboxapi
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// GroupVersion is the API group/version for the Sandbox kind.
+var GroupVersion = schema.GroupVersion{Group: "sandbox.openova.io", Version: "v1"}
+
+// SchemeBuilder is used to add the Sandbox types to a runtime.Scheme.
+var SchemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)
+
+// AddToScheme registers Sandbox{,List} with the supplied Scheme so the
+// controller-runtime manager and its caches can serialize the kind.
+var AddToScheme = SchemeBuilder.AddToScheme
+
+func addKnownTypes(scheme *runtime.Scheme) error {
+	scheme.AddKnownTypes(GroupVersion, &Sandbox{}, &SandboxList{})
+	metav1.AddToGroupVersion(scheme, GroupVersion)
+	return nil
+}
+
+// Sandbox is the namespace-scoped CR. See architecture.md §7 +
+// products/catalyst/chart/crds/sandbox.yaml.
+//
+// +kubebuilder:resource:scope=Namespaced
+type Sandbox struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+
+	Spec   SandboxSpec   `json:"spec"`
+	Status SandboxStatus `json:"status,omitempty"`
+}
+
+// SandboxList is the standard list wrapper.
+type SandboxList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty"`
+	Items           []Sandbox `json:"items"`
+}
+
+// SandboxSpec mirrors the CRD's spec block.
+type SandboxSpec struct {
+	Owner          SandboxOwner   `json:"owner"`
+	Quota          SandboxQuota   `json:"quota"`
+	Repos          []SandboxRepo  `json:"repos,omitempty"`
+	AgentCatalogue []string       `json:"agentCatalogue,omitempty"`
+	PreviewDomain  string         `json:"previewDomain,omitempty"`
+}
+
+// SandboxOwner is spec.owner.
+type SandboxOwner struct {
+	Email  string          `json:"email"`
+	OrgRef SandboxOrgRef   `json:"orgRef"`
+}
+
+// SandboxOrgRef references the parent Organization by slug.
+type SandboxOrgRef struct {
+	Slug string `json:"slug"`
+}
+
+// SandboxQuota mirrors the ResourceQuota the reconciler renders.
+type SandboxQuota struct {
+	CPU                string `json:"cpu"`
+	Memory             string `json:"memory"`
+	Storage            string `json:"storage"`
+	ConcurrentSessions int    `json:"concurrentSessions"`
+}
+
+// SandboxRepo names a Gitea repo to auto-clone (PVC + initContainer in
+// Wave 2; Wave 1 only writes the PVC manifest).
+type SandboxRepo struct {
+	GiteaRepo string `json:"giteaRepo"`
+}
+
+// SandboxStatus is controller-managed.
+type SandboxStatus struct {
+	Phase              string             `json:"phase,omitempty"` // Pending|Provisioning|Ready|Failed
+	Sessions           int                `json:"sessions,omitempty"`
+	StorageUsed        string             `json:"storageUsed,omitempty"`
+	Spend30d           string             `json:"spend30d,omitempty"`
+	Previews           []SandboxPreview   `json:"previews,omitempty"`
+	GitopsPath         string             `json:"gitopsPath,omitempty"`
+	Conditions         []SandboxCondition `json:"conditions,omitempty"`
+	ObservedGeneration int64              `json:"observedGeneration,omitempty"`
+}
+
+// SandboxPreview is one element of status.previews.
+type SandboxPreview struct {
+	PRNumber int    `json:"prNumber"`
+	URL      string `json:"url"`
+	SHA      string `json:"sha"`
+}
+
+// SandboxCondition is the standard K8s-style condition.
+type SandboxCondition struct {
+	Type               string      `json:"type"`
+	Status             string      `json:"status"` // True|False|Unknown
+	Reason             string      `json:"reason,omitempty"`
+	Message            string      `json:"message,omitempty"`
+	LastTransitionTime metav1.Time `json:"lastTransitionTime,omitempty"`
+}
+
+// DeepCopyObject implements runtime.Object.
+func (s *Sandbox) DeepCopyObject() runtime.Object {
+	if s == nil {
+		return nil
+	}
+	out := &Sandbox{}
+	s.DeepCopyInto(out)
+	return out
+}
+
+// DeepCopyInto copies the receiver into out.
+func (s *Sandbox) DeepCopyInto(out *Sandbox) {
+	*out = *s
+	out.TypeMeta = s.TypeMeta
+	s.ObjectMeta.DeepCopyInto(&out.ObjectMeta)
+	s.Spec.DeepCopyInto(&out.Spec)
+	s.Status.DeepCopyInto(&out.Status)
+}
+
+// DeepCopyObject for SandboxList.
+func (l *SandboxList) DeepCopyObject() runtime.Object {
+	if l == nil {
+		return nil
+	}
+	out := &SandboxList{}
+	out.TypeMeta = l.TypeMeta
+	l.ListMeta.DeepCopyInto(&out.ListMeta)
+	if l.Items != nil {
+		out.Items = make([]Sandbox, len(l.Items))
+		for i := range l.Items {
+			l.Items[i].DeepCopyInto(&out.Items[i])
+		}
+	}
+	return out
+}
+
+// DeepCopyInto for SandboxSpec.
+func (s *SandboxSpec) DeepCopyInto(out *SandboxSpec) {
+	*out = *s
+	if s.Repos != nil {
+		out.Repos = make([]SandboxRepo, len(s.Repos))
+		copy(out.Repos, s.Repos)
+	}
+	if s.AgentCatalogue != nil {
+		out.AgentCatalogue = make([]string, len(s.AgentCatalogue))
+		copy(out.AgentCatalogue, s.AgentCatalogue)
+	}
+}
+
+// DeepCopyInto for SandboxStatus.
+func (s *SandboxStatus) DeepCopyInto(out *SandboxStatus) {
+	*out = *s
+	if s.Conditions != nil {
+		out.Conditions = make([]SandboxCondition, len(s.Conditions))
+		for i := range s.Conditions {
+			out.Conditions[i] = s.Conditions[i]
+			out.Conditions[i].LastTransitionTime = *s.Conditions[i].LastTransitionTime.DeepCopy()
+		}
+	}
+	if s.Previews != nil {
+		out.Previews = make([]SandboxPreview, len(s.Previews))
+		copy(out.Previews, s.Previews)
+	}
+}

--- a/platform/sandbox/chart/Chart.yaml
+++ b/platform/sandbox/chart/Chart.yaml
@@ -1,0 +1,31 @@
+apiVersion: v2
+name: sandbox
+description: |
+  Wave 1 deployment chart for sandbox-controller — the Catalyst-built
+  reconciler for `sandbox.openova.io/v1.Sandbox` CRs.
+
+  Per products/sandbox/docs/architecture.md §7 the sandbox-controller
+  is the sister of organization-controller (one-CR-per-Sandbox-user,
+  per-Org-vcluster materialization). Wave 1 installs the Deployment +
+  ClusterRole + ClusterRoleBinding + ServiceAccount; Wave 2 adds the
+  pty-server + openova-sandbox-mcp Deployments inside each Sandbox
+  namespace.
+
+  The `Sandbox` CRD itself ships separately under
+  products/catalyst/chart/crds/sandbox.yaml (PR #1615).
+
+  This chart is opt-in via `.Values.enabled` (default false) so an
+  operator can keep Sandbox off-by-default on a Sovereign until the
+  Wave 2 pty-server + token issuance flow is also rolled in.
+type: application
+version: 0.1.0
+appVersion: "0.1.0"
+keywords:
+  - catalyst
+  - sandbox
+  - controller
+  - reconciler
+  - openova
+maintainers:
+  - name: OpenOva Catalyst
+    email: catalyst@openova.io

--- a/platform/sandbox/chart/README.md
+++ b/platform/sandbox/chart/README.md
@@ -1,0 +1,73 @@
+# sandbox-controller chart (Wave 1)
+
+Helm chart for the Catalyst-built **sandbox-controller**, the
+reconciler for `sandbox.openova.io/v1.Sandbox` CRs (architecture
+spec: `products/sandbox/docs/architecture.md` §7).
+
+## What it deploys
+
+| Resource | Purpose |
+|---|---|
+| `Deployment/sandbox-controller` | controller-runtime manager, leader-election on by default |
+| `ServiceAccount/sandbox-controller` | identity used to read Sandbox CRs + patch status |
+| `ClusterRole/sandbox-controller` | least-privilege grants — `sandboxes`, `sandboxes/status`, `sandboxes/finalizers`, `leases`, `events` |
+| `ClusterRoleBinding/sandbox-controller` | binds the SA to the ClusterRole |
+
+The `Sandbox` CRD ships separately at
+`products/catalyst/chart/crds/sandbox.yaml` (PR #1615).
+
+## What Wave 1 reconciles
+
+For each `Sandbox` CR, the controller renders + PutFile-s the
+following manifests into the per-Org `catalyst-tenant` Gitea repo at
+`sandbox/<owner-uid>/`:
+
+```
+sandbox/<owner-uid>/
+├── namespace.yaml         # sandbox-<owner-uid>
+├── resourcequota.yaml     # mirrors spec.quota
+├── serviceaccount.yaml    # the in-namespace `sandbox` SA
+├── role.yaml              # pods/deployments/pvc CRUD inside the ns
+├── rolebinding.yaml
+├── secret.yaml            # placeholder `sandbox-tokens` (filled in Wave 2)
+├── pvc-<repo-slug>.yaml   # one per spec.repos[]
+└── kustomization.yaml
+```
+
+Flux on the host cluster picks them up and reconciles them inside the
+Org vcluster (the existing per-Org Flux Kustomization that
+organization-controller's vcluster manifests already live under).
+
+## What Wave 1 does NOT do (deferred to Wave 2+)
+
+- pty-server StatefulSet
+- openova-sandbox-mcp Deployment
+- HTTPRoute / Gateway publishing `<pr>.<app>.<sb-<owner>>.<sov>.openova.io`
+- Long-lived org-scoped token issuance + Secret population
+- per-repo git-clone initContainer
+
+## Install
+
+The chart is opt-in. In a per-Sovereign overlay:
+
+```yaml
+sandbox:
+  enabled: true
+  image:
+    tag: "<git-sha>"       # CI-stamped per Inviolable Principle #4a
+  env:
+    hostCluster: "hz-fsn-rtz-prod"
+    sovereignFQDN: "omantel.omani.works"
+```
+
+The chart reuses `Secret/catalyst-gitea-token` (key `token`) that
+organization-controller already consumes — single source of truth per
+issues #957 / #1052.
+
+## Reference
+
+- Architecture: `products/sandbox/docs/architecture.md` §7
+- Template controller: `core/controllers/organization/internal/controller/organization_controller.go`
+- Template gitops renderer: `core/controllers/organization/internal/gitops/manifests.go`
+- CRD: `products/catalyst/chart/crds/sandbox.yaml` (PR #1615)
+- Go types: `core/controllers/sandbox/internal/sandboxapi/types.go`

--- a/platform/sandbox/chart/templates/_helpers.tpl
+++ b/platform/sandbox/chart/templates/_helpers.tpl
@@ -1,0 +1,47 @@
+{{/*
+Helpers for the sandbox-controller chart (Wave 1).
+
+Conventions match products/catalyst/chart/templates/controllers/_helpers.tpl
+so future maintainers can move the chart into the catalyst umbrella without
+renaming a single resource.
+*/}}
+
+{{/* Canonical chart name (used as Deployment / SA / ClusterRole /
+     ClusterRoleBinding name). Honors nameOverride / fullnameOverride
+     per the upstream Helm convention. */}}
+{{- define "sandbox.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default "sandbox-controller" .Values.nameOverride -}}
+{{- printf "%s" $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{/* Common labels applied to every resource. */}}
+{{- define "sandbox.labels" -}}
+app.kubernetes.io/name: sandbox-controller
+app.kubernetes.io/component: controller
+app.kubernetes.io/part-of: catalyst
+app.kubernetes.io/managed-by: {{ .Release.Service | default "Helm" }}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+catalyst.openova.io/controller: sandbox
+{{- end -}}
+
+{{/* Selector labels (subset that does not change between releases). */}}
+{{- define "sandbox.selectorLabels" -}}
+app.kubernetes.io/name: sandbox-controller
+app.kubernetes.io/component: controller
+catalyst.openova.io/controller: sandbox
+{{- end -}}
+
+{{/* Resolve the controller image reference. Fails-fast when tag is
+     empty so the operator catches the misconfig at `helm template`
+     time rather than from a CrashLoopBackoff. */}}
+{{- define "sandbox.image" -}}
+{{- $tag := .Values.image.tag | default "" -}}
+{{- if eq $tag "" -}}
+{{- fail "platform/sandbox/chart values.image.tag is empty — CI must stamp a SHA before render. Per docs/INVIOLABLE-PRINCIPLES.md #4a no :latest is permitted." -}}
+{{- end -}}
+{{- printf "%s:%s" .Values.image.repository $tag -}}
+{{- end -}}

--- a/platform/sandbox/chart/templates/clusterrole.yaml
+++ b/platform/sandbox/chart/templates/clusterrole.yaml
@@ -1,0 +1,42 @@
+{{- /*
+ClusterRole for sandbox-controller (Wave 1).
+
+Least-privilege grants — modelled on
+products/catalyst/chart/templates/controllers/organization-controller-clusterrole.yaml.
+
+  - sandboxes / sandboxes/status / sandboxes/finalizers — primary watch +
+    status writes + finalizer add/remove (finalizer wired in Wave 2).
+  - leases — controller-runtime leader election.
+  - events — controller-runtime emits Events on the parent CR for
+    operator-visible reconcile errors.
+  - secrets get (Sovereign-wide, cache-scoped) — Wave 1 does NOT yet
+    read the Gitea PAT via this rule (we use a `secretKeyRef` env-var
+    mount in the Deployment, which the kubelet resolves without the
+    controller calling secrets:get). The rule is intentionally OMITTED
+    until Wave 2 needs it for the per-Sandbox token issuance flow —
+    matches Inviolable Principle #4's "minimal blast radius" rule.
+*/ -}}
+{{- if .Values.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "sandbox.fullname" . }}
+  labels:
+    {{- include "sandbox.labels" . | nindent 4 }}
+rules:
+  - apiGroups: ["sandbox.openova.io"]
+    resources: ["sandboxes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["sandbox.openova.io"]
+    resources: ["sandboxes/status"]
+    verbs: ["get", "update", "patch"]
+  - apiGroups: ["sandbox.openova.io"]
+    resources: ["sandboxes/finalizers"]
+    verbs: ["update"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create", "patch"]
+{{- end }}

--- a/platform/sandbox/chart/templates/clusterrolebinding.yaml
+++ b/platform/sandbox/chart/templates/clusterrolebinding.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "sandbox.fullname" . }}
+  labels:
+    {{- include "sandbox.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "sandbox.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "sandbox.fullname" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/platform/sandbox/chart/templates/deployment.yaml
+++ b/platform/sandbox/chart/templates/deployment.yaml
@@ -1,0 +1,118 @@
+{{- /*
+sandbox-controller Deployment (Wave 1).
+
+Reconciles Sandbox.sandbox.openova.io/v1 CRs into per-Sandbox manifests
+(namespace + RBAC + PVCs + placeholder Secret) written to the per-Org
+`catalyst-tenant` Gitea repo at `sandbox/<owner-uid>/`. Flux on the
+host cluster picks them up and reconciles into the Org vcluster.
+
+Modelled on
+products/catalyst/chart/templates/controllers/organization-controller-deployment.yaml.
+
+Configuration (no hardcoded values per docs/INVIOLABLE-PRINCIPLES.md #4):
+  - hostCluster / sovereignFQDN come from `.Values.env.*` in the
+    per-Sovereign overlay.
+  - Gitea coords default to the same in-cluster URL +
+    `catalyst-gitea-token` Secret organization-controller uses.
+*/ -}}
+{{- if .Values.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "sandbox.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "sandbox.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicas | default 1 }}
+  selector:
+    matchLabels:
+      {{- include "sandbox.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "sandbox.labels" . | nindent 8 }}
+    spec:
+      serviceAccountName: {{ include "sandbox.fullname" . }}
+      automountServiceAccountToken: true
+      {{- with .Values.image.pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: controller
+          image: {{ include "sandbox.image" . | quote }}
+          imagePullPolicy: {{ .Values.image.pullPolicy | default "IfNotPresent" }}
+          args:
+            - "--leader-elect={{ .Values.leaderElection.enabled }}"
+            - "--metrics-bind-address=:8080"
+            - "--health-probe-bind-address=:8081"
+          env:
+            - name: CATALYST_HOST_CLUSTER
+              value: {{ required "values.env.hostCluster MUST be set for sandbox-controller (e.g. hz-fsn-rtz-prod)" .Values.env.hostCluster | quote }}
+            - name: CATALYST_SOVEREIGN_FQDN
+              value: {{ required "values.env.sovereignFQDN MUST be set for sandbox-controller (e.g. omantel.omani.works)" .Values.env.sovereignFQDN | quote }}
+            - name: CATALYST_GITEA_URL
+              # Gitea client (core/controllers/pkg/gitea/client.go) appends
+              # `/api/v1/<endpoint>` to BaseURL — the env value MUST NOT
+              # include `/api/v1` itself (matches the Fix #40 / qa-loop
+              # iter-8 invariant on organization-controller-deployment.yaml).
+              value: {{ .Values.env.giteaURL | default "http://gitea-http.gitea.svc.cluster.local:3000" | quote }}
+            - name: CATALYST_GITEA_BRANCH
+              value: {{ .Values.env.giteaBranch | default "main" | quote }}
+            - name: CATALYST_TENANT_REPO_NAME
+              value: {{ .Values.env.tenantRepoName | default "catalyst-tenant" | quote }}
+            - name: CATALYST_GITEA_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.giteaTokenSecret.name | default "catalyst-gitea-token" | quote }}
+                  key: {{ .Values.giteaTokenSecret.key | default "token" | quote }}
+                  optional: true
+            {{- range $k, $v := .Values.extraEnv }}
+            - name: {{ $k | quote }}
+              value: {{ $v | quote }}
+            {{- end }}
+          ports:
+            - name: metrics
+              containerPort: 8080
+            - name: health
+              containerPort: 8081
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: health
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: health
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+            readOnlyRootFilesystem: true
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      terminationGracePeriodSeconds: 15
+{{- end }}

--- a/platform/sandbox/chart/templates/serviceaccount.yaml
+++ b/platform/sandbox/chart/templates/serviceaccount.yaml
@@ -1,0 +1,17 @@
+{{- /*
+ServiceAccount for sandbox-controller (Wave 1).
+
+Sister of organization-controller's ServiceAccount
+(products/catalyst/chart/templates/controllers/organization-controller-serviceaccount.yaml).
+Default off — operator flips `.Values.enabled=true` per-Sovereign once
+Wave 2's pty-server + token issuance flow is ready.
+*/ -}}
+{{- if .Values.enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "sandbox.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "sandbox.labels" . | nindent 4 }}
+{{- end }}

--- a/platform/sandbox/chart/values.yaml
+++ b/platform/sandbox/chart/values.yaml
@@ -1,0 +1,84 @@
+# Wave 1 sandbox-controller values.
+#
+# Default-off per the chart README — flip `enabled: true` in a
+# per-Sovereign overlay once the controller's image tag is SHA-stamped
+# by CI and the per-Org `catalyst-tenant` Gitea repo exists (i.e.
+# organization-controller has reconciled at least once).
+
+# enabled gates EVERY templated resource. Default off.
+enabled: false
+
+# nameOverride / fullnameOverride mirror the upstream-chart convention —
+# left empty so the rendered names follow the chart's canonical
+# "sandbox-controller" without per-install drift.
+nameOverride: ""
+fullnameOverride: ""
+
+# replicas — 1 is fine for Wave 1 (leader-election on, so 2+ is safe
+# but unneeded).
+replicas: 1
+
+image:
+  # Image repository for the Catalyst-built sandbox-controller binary.
+  # The tag MUST be SHA-stamped by CI on every push to main per
+  # docs/INVIOLABLE-PRINCIPLES.md #4a — empty tag fails-fast at render
+  # rather than silently shipping :latest.
+  repository: ghcr.io/openova-io/openova/sandbox-controller
+  tag: ""
+  pullPolicy: IfNotPresent
+  pullSecrets:
+    - name: ghcr-pull
+
+# leaderElection — controller-runtime leases. Default on so HA replicas
+# don't double-write Gitea.
+leaderElection:
+  enabled: true
+
+# Resource limits / requests — same envelope as organization-controller.
+# Sandbox reconciles are lighter (no Keycloak round-trips), but keeping
+# the shape parallel makes capacity-planning easier.
+resources:
+  requests:
+    cpu: 50m
+    memory: 128Mi
+  limits:
+    cpu: 500m
+    memory: 512Mi
+
+# Pod placement. Empty by default — operator pins to a node pool per
+# Sovereign overlay.
+nodeSelector: {}
+tolerations: []
+affinity: {}
+
+# Env wiring — every knob is an env var per Inviolable Principle #4.
+# Values below feed the controller's main.go mustEnv() calls.
+env:
+  # Required at install time — fed from the per-Sovereign overlay /
+  # global values. The Wave 1 deployment template surfaces these as
+  # explicit env entries instead of a `range` so the operator can see
+  # which inputs are wired without grepping values.yaml.
+  hostCluster: ""           # CATALYST_HOST_CLUSTER (e.g. hz-fsn-rtz-prod)
+  sovereignFQDN: ""         # CATALYST_SOVEREIGN_FQDN (e.g. omantel.omani.works)
+
+  # Gitea coords default to the in-cluster URL the catalyst-api /
+  # organization-controller already use (single source of truth for
+  # the Gitea URL per #957 / #1052).
+  giteaURL: "http://gitea-http.gitea.svc.cluster.local:3000"
+  giteaBranch: "main"
+
+  # Per-Org `catalyst-tenant` repo (organization-controller's
+  # EnsureRepo target) — Sandbox writes its manifests under
+  # `sandbox/<owner-uid>/` inside this repo.
+  tenantRepoName: "catalyst-tenant"
+
+# Secret holding the Gitea PAT the controller authenticates with.
+# Defaults to the same Secret organization-controller uses
+# (catalyst-gitea-token / key=token) — single source of truth per
+# #957/#1052.
+giteaTokenSecret:
+  name: "catalyst-gitea-token"
+  key: "token"
+
+# extraEnv: arbitrary extra envs (rare — knobs above cover Wave 1).
+extraEnv: {}


### PR DESCRIPTION
## Summary

Wires the **sandbox-controller** binary + standalone Helm chart for the Wave 1 slice of the Sandbox product (companion to the CRD shipped in PR #1615).

- New Go controller under `core/controllers/sandbox/` reconciles `sandbox.openova.io/v1.Sandbox` CRs into per-Sandbox manifests (namespace + RBAC + PVCs + placeholder Secret) and writes them into the per-Org `catalyst-tenant` Gitea repo under `sandbox/<owner-uid>/`.
- New standalone Helm chart under `platform/sandbox/chart/` deploys the controller (Deployment + ServiceAccount + ClusterRole + ClusterRoleBinding), opt-in via `.Values.enabled` (default off).
- Wave 1 deliberately stops here: pty-server / openova-sandbox-mcp Deployments, HTTPRoutes for preview subdomains, long-lived org-scoped token issuance, and per-repo git-clone initContainers land in Wave 2.

## Spec + template citations

- Architecture: `products/sandbox/docs/architecture.md` §7 — *"The `sandbox-controller` (new — sister to `organization-controller`) reconciles … A namespace `sandbox-<owner-uid>` inside the Org vcluster, PVCs for each `spec.repos[]` entry, … placeholder Secrets for newapi/BYOS tokens."*
- Controller template: `core/controllers/organization/internal/controller/organization_controller.go:188-225` — the Render-then-PutFile loop sandbox-controller mirrors verbatim.
- Renderer template: `core/controllers/organization/internal/gitops/manifests.go:65-184` — text/template Render with deterministic iteration; sandbox-controller follows the same shape.
- CRD: `products/catalyst/chart/crds/sandbox.yaml` (PR #1615).
- Chart helpers template: `products/catalyst/chart/templates/controllers/_helpers.tpl` + `organization-controller-deployment.yaml`.

## Wave 1 boundary

| Renders | Defers to Wave 2 |
|---|---|
| Namespace `sandbox-<owner-uid>` | pty-server StatefulSet |
| ResourceQuota mirroring spec.quota | openova-sandbox-mcp Deployment |
| ServiceAccount `sandbox` + namespaced Role + RoleBinding | HTTPRoute / Gateway for `<pr>.<app>.<sb>.<sov>.openova.io` |
| 1 PVC per `spec.repos[]` (initContainer git-clone deferred) | Long-lived org-scoped token issuance |
| Placeholder Secret `sandbox-tokens` | per-repo git-clone initContainer |
| Kustomization stitching | secrets:get ClusterRole grant |

## Hard rules respected

- READ-ONLY clusters — no kubectl apply / no live cluster mutation
- NO chart 1.4.156 bump — Wave 1 controller chart is standalone under `platform/sandbox/chart/`, not under catalyst umbrella yet
- NO UI files touched
- NO npm install / no full tsc

## Test plan

- [x] `go build ./sandbox/...` clean (go 1.23.4 locally)
- [x] `go test -count=1 ./sandbox/...` — 5/5 pass (happy-path + idempotency + drift x 2 + missing-CR)
- [x] `go vet ./sandbox/...` clean
- [x] `helm lint platform/sandbox/chart` clean (1 INFO: icon recommended)
- [x] `helm template t platform/sandbox/chart --set enabled=true --set image.tag=abc123 --set env.hostCluster=hz-fsn-rtz-prod --set env.sovereignFQDN=omantel.omani.works` renders 4 resources cleanly
- [x] `helm template t platform/sandbox/chart` (defaults) renders zero resources (opt-in gate works)
- [x] `helm template ... --set enabled=true --set env.hostCluster=x --set env.sovereignFQDN=y` (no image.tag) fails-fast with the canonical "no :latest permitted" error
- [ ] Wave 2: pty-server + MCP Deployments + HTTPRoutes
- [ ] Wave 2: long-lived org-scoped token + Secret population
- [ ] Wave 2: per-repo git-clone initContainer

🤖 Generated with [Claude Code](https://claude.com/claude-code)