### PR TITLE
fix(marketplace): persist subdomain TLD across wizard steps (.omani.homes was dropping to .rest default)

### DIFF
--- a/core/marketplace/src/components/AddonsStep.svelte
+++ b/core/marketplace/src/components/AddonsStep.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { getAddons, getApps, checkSlug, type AddOn, type App } from '../lib/api';
-  import { readCart, toggleAddon, setOrgDetails, writeCart } from '../lib/cart';
+  import { readCart, toggleAddon, setOrgDetails, setTLD, writeCart, DEFAULT_TLD } from '../lib/cart';
   import { formatOMR } from '../lib/currency';
 
   let addons = $state<AddOn[]>([]);
@@ -26,10 +26,18 @@
     return out;
   });
   let subdomain = $state(cart.subdomain);
-  let selectedTLD = $state('omani.rest');
+  // Hydrate TLD from cart so a user who picked .omani.homes, navigated
+  // forward, then came back, sees their choice — not the default. The
+  // change handler below persists every flip immediately (no blur required)
+  // so /review + /checkout always read the latest value.
+  let selectedTLD = $state(cart.tld || DEFAULT_TLD);
   let byodDomain = $state('');
 
   const tlds = ['omani.rest', 'omani.works', 'omani.trade', 'omani.homes'];
+
+  function persistTLD() {
+    cart = setTLD(selectedTLD);
+  }
 
   // Subdomain availability check (same logic as CheckoutStep so the state is
   // consistent — user doesn't re-learn at checkout that their subdomain is taken).
@@ -90,6 +98,10 @@
 
   function saveSubdomain() {
     cart = setOrgDetails(cart.orgName, subdomain, cart.email);
+    // Belt-and-braces: TLD is already persisted on <select> onchange, but
+    // also flush here so a leftover stale value in localStorage from a
+    // pre-fix session can't outlive a fresh subdomain save.
+    if (cart.tld !== selectedTLD) cart = setTLD(selectedTLD);
   }
 
   // #85 — shared helper renders "OMR 3.000". Previously we rounded to whole
@@ -132,7 +144,7 @@
               placeholder="my-company"
               class="domain-input"
             />
-            <select bind:value={selectedTLD} class="domain-tld">
+            <select bind:value={selectedTLD} onchange={persistTLD} class="domain-tld">
               {#each tlds as tld}
                 <option value={tld}>.{tld}</option>
               {/each}

--- a/core/marketplace/src/components/CheckoutStep.svelte
+++ b/core/marketplace/src/components/CheckoutStep.svelte
@@ -545,7 +545,7 @@
                 <a href="/addons" class="text-xs text-[var(--color-accent)] no-underline hover:underline">Change</a>
               </div>
               <div class="mt-1 rounded-lg border border-[var(--color-border)] bg-[var(--color-bg)] px-3 py-2 font-mono text-sm text-[var(--color-text)]">
-                {cart.subdomain}.omani.rest
+                {cart.subdomain}.{cart.tld}
               </div>
               <p class="mt-1 text-[11px] text-[var(--color-text-dimmer)]">Already validated — you can change this during add-ons.</p>
             </div>
@@ -560,15 +560,15 @@
                   placeholder="my-company"
                   class="w-full rounded-l-lg border border-r-0 border-[var(--color-border)] bg-[var(--color-bg)] px-3 py-2 text-sm text-[var(--color-text)] outline-none focus:border-[var(--color-accent)]"
                 />
-                <span class="rounded-r-lg border border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-2 text-sm text-[var(--color-text-dim)]">.omani.rest</span>
+                <span class="rounded-r-lg border border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-2 text-sm text-[var(--color-text-dim)]">.{cart.tld}</span>
               </div>
               <div class="mt-1 text-xs h-4">
                 {#if slugStatus === 'checking'}
                   <span class="text-[var(--color-text-dim)]">Checking availability…</span>
                 {:else if slugStatus === 'available'}
-                  <span class="text-[var(--color-success)]">✓ {slugChecked}.omani.rest is available</span>
+                  <span class="text-[var(--color-success)]">✓ {slugChecked}.{cart.tld} is available</span>
                 {:else if slugStatus === 'taken'}
-                  <span class="text-[var(--color-danger)]">✗ {slugChecked}.omani.rest is already taken</span>
+                  <span class="text-[var(--color-danger)]">✗ {slugChecked}.{cart.tld} is already taken</span>
                 {:else if slugStatus === 'invalid'}
                   <span class="text-[var(--color-danger)]">Subdomain must be at least 3 characters</span>
                 {:else}

--- a/core/marketplace/src/components/ReviewStep.svelte
+++ b/core/marketplace/src/components/ReviewStep.svelte
@@ -300,7 +300,7 @@
                 <a href="/addons" class="rv-link">Edit</a>
               </div>
               <div class="ws-preview">
-                <div class="ws-row"><span>URL</span><strong class="font-mono">{cart.subdomain}.omani.rest</strong></div>
+                <div class="ws-row"><span>URL</span><strong class="font-mono">{cart.subdomain}.{cart.tld}</strong></div>
               </div>
             </section>
           {/if}

--- a/core/marketplace/src/lib/cart.ts
+++ b/core/marketplace/src/lib/cart.ts
@@ -5,10 +5,20 @@ export interface CartState {
   addons: string[];
   orgName: string;
   subdomain: string;
+  // Parent domain (TLD) chosen on /addons. Persisted across wizard steps
+  // so /review and /checkout don't fall back to the default. Convergence
+  // bug: previously local to AddonsStep, so a user picking .omani.homes
+  // would see .omani.rest on Review + Checkout.
+  tld: string;
   email: string;
 }
 
 const STORAGE_KEY = 'sme-cart';
+
+// Default parent domain — kept in sync with the picker in AddonsStep.svelte
+// (`tlds` array). Single source of truth so a future change to the default
+// is a one-liner.
+export const DEFAULT_TLD = 'omani.rest';
 
 const defaultCart: CartState = {
   plan: null,
@@ -17,6 +27,7 @@ const defaultCart: CartState = {
   addons: [],
   orgName: '',
   subdomain: '',
+  tld: DEFAULT_TLD,
   email: '',
 };
 
@@ -74,6 +85,16 @@ export function setOrgDetails(orgName: string, subdomain: string, email: string)
   cart.orgName = orgName;
   cart.subdomain = subdomain;
   cart.email = email;
+  writeCart(cart);
+  return cart;
+}
+
+// Persist the parent domain (TLD) chosen on /addons. Separate setter from
+// setOrgDetails so the TLD picker can save immediately on change (no need
+// to wait for the subdomain input to blur).
+export function setTLD(tld: string): CartState {
+  const cart = readCart();
+  cart.tld = tld;
   writeCart(cart);
   return cart;
 }


### PR DESCRIPTION
## Root cause (one line)
TLD picker on `/addons` wrote to a component-local `selectedTLD` state that was never persisted to the cart store; `/review` + `/checkout` hardcoded `.omani.rest` instead of reading from cart — so any pick (.omani.homes / .omani.works / .omani.trade) silently fell back to the default on the next step.

## Summary
- Add `tld` field to `CartState` (with `DEFAULT_TLD = 'omani.rest'` single-source const in `cart.ts`).
- Add `setTLD(tld)` cart helper so the `<select>` can persist on every change without waiting for the subdomain input to blur.
- `AddonsStep.svelte`: hydrate `selectedTLD` from `cart.tld`, wire `onchange={persistTLD}`, and flush again on subdomain blur (belt-and-braces against stale pre-fix localStorage).
- `ReviewStep.svelte`: workspace URL row reads `cart.tld`.
- `CheckoutStep.svelte`: tenant URL preview, fallback subdomain suffix, and slug-availability status messages all read `cart.tld`.

## Files
- `core/marketplace/src/lib/cart.ts` — `tld` field + `setTLD` + `DEFAULT_TLD` const
- `core/marketplace/src/components/AddonsStep.svelte` — hydrate + persist on change/blur
- `core/marketplace/src/components/ReviewStep.svelte` — read `cart.tld`
- `core/marketplace/src/components/CheckoutStep.svelte` — read `cart.tld` (4 sites)

## Design-system inheritance
No new components/styles — only data-binding fixes inside the existing wizard step layouts. All existing design tokens (`var(--color-*)`) preserved.

## Test plan
- [ ] `/plans` → pick a plan → `/apps` → pick apps → `/addons` → type subdomain `acme` → pick `.omani.homes` from TLD select
- [ ] Click `Review Order →` — Workspace URL row shows `acme.omani.homes` (not `.rest`)
- [ ] Click `Proceed to Checkout →` — Subdomain block shows `acme.omani.homes` (not `.rest`)
- [ ] Refresh `/checkout` directly — still shows `acme.omani.homes` (state persists in localStorage)
- [ ] Go back to `/addons`, switch TLD to `.omani.works`, navigate forward — Review + Checkout reflect `.omani.works`

## Verification
- `astro build` clean (full Svelte + TS template pass against 4 changed files + their transitive imports).
- No backend wiring (tenant API has no `parent_domain` field today; this PR is UI persistence only, consistent with the bug report scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)