### PR TITLE
fix(marketplace): post-purchase redirect to Sovereign-local console (was hardcoded to mothership)

### DIFF
--- a/core/marketplace/src/layouts/Layout.astro
+++ b/core/marketplace/src/layouts/Layout.astro
@@ -102,7 +102,22 @@ const { title, step = 0 } = Astro.props;
       function redirect() {
         var token = localStorage.getItem('sme-token') || '';
         var refresh = localStorage.getItem('sme-refresh-token') || '';
-        var url = 'https://console.openova.io/nova/?token=' + encodeURIComponent(token);
+        // Derive console URL from the current host. Logic mirrors
+        // src/lib/config.ts::deriveConsoleURL — kept inline so the redirect
+        // fires before the Svelte bundle loads.
+        //   marketplace.openova.io      → console.openova.io/nova  (mothership)
+        //   marketplace.<sov-fqdn>      → console.<sov-fqdn>       (Sovereign, no /nova)
+        //   anything else (partner host)→ mothership fallback
+        // Bug 2026-05-18: this used to hardcode console.openova.io/nova so
+        // every Sovereign post-purchase redirect bounced users back to the
+        // mothership and re-prompted sign-in.
+        var host = (window.location.hostname || '').toLowerCase();
+        var base = 'https://console.openova.io/nova';
+        if (host && host !== 'marketplace.openova.io' && host.indexOf('marketplace.') === 0) {
+          var sovFqdn = host.substring('marketplace.'.length);
+          if (sovFqdn) base = 'https://console.' + sovFqdn;
+        }
+        var url = base + '/?token=' + encodeURIComponent(token);
         if (refresh) url += '&refresh_token=' + encodeURIComponent(refresh);
         window.location.replace(url);
       }

--- a/core/marketplace/src/lib/config.ts
+++ b/core/marketplace/src/lib/config.ts
@@ -6,12 +6,65 @@
 const _rawBase = import.meta.env.BASE_URL;
 export const BASE: string = _rawBase.endsWith('/') ? _rawBase : `${_rawBase}/`;
 
-/** API root (served at marketplace.openova.io/api/). */
+/** API root (served at marketplace.<host>/api/). */
 export const API_BASE: string = `${BASE}api`;
+
+/**
+ * Mothership console URL — used when the marketplace runs on
+ * `marketplace.openova.io` (or in SSR / non-browser contexts).
+ *
+ * Mothership ingress strips a `/nova` path prefix before forwarding to the
+ * console service (see products/catalyst/chart/templates/sme-services/
+ * ingress.yaml — `strip-nova` middleware), so the customer console lives at
+ * `https://console.openova.io/nova/...`.
+ */
+const MOTHERSHIP_CONSOLE_URL = 'https://console.openova.io/nova';
+
+/**
+ * Derive the customer console URL from the current marketplace host.
+ *
+ * Bug fix (2026-05-18): post-purchase redirect was always sending the user
+ * to `console.openova.io/nova` even when they signed up on a Sovereign's
+ * `marketplace.<sov-fqdn>` host. That bounced them back to the mothership
+ * and re-prompted sign-in. The Sovereign console is at
+ * `console.<sov-fqdn>` (Cilium Gateway `*.<sov-fqdn>` wildcard route in
+ * `marketplace-routes.yaml`) — NO `/nova` prefix because the Sovereign
+ * ingress doesn't have the `strip-nova` middleware.
+ *
+ * Rules:
+ *   - SSR / no `window`              → mothership URL (safe fallback for
+ *                                       static page render)
+ *   - host === 'marketplace.openova.io' → mothership URL (preserves
+ *                                       existing behaviour, /nova prefix)
+ *   - host starts with `marketplace.`   → `https://console.<rest-of-host>`
+ *                                       (Sovereign — strip `marketplace.`,
+ *                                       prepend `console.`, NO /nova)
+ *   - anything else (partner-branded
+ *     vanity host e.g. `omantel.openova.io`,
+ *     dev `localhost:4321`)             → mothership URL fallback
+ */
+function deriveConsoleURL(): string {
+  if (typeof window === 'undefined') return MOTHERSHIP_CONSOLE_URL;
+  const host = (window.location.hostname || '').toLowerCase();
+  if (!host) return MOTHERSHIP_CONSOLE_URL;
+  // Mothership marketplace keeps the canonical /nova prefix.
+  if (host === 'marketplace.openova.io') return MOTHERSHIP_CONSOLE_URL;
+  // Sovereign pattern: marketplace.<sov-fqdn> → console.<sov-fqdn>
+  if (host.startsWith('marketplace.')) {
+    const sovFqdn = host.slice('marketplace.'.length);
+    if (sovFqdn) return `https://console.${sovFqdn}`;
+  }
+  // Partner-branded vanity hosts (omantel.openova.io) and dev/preview hosts
+  // fall back to mothership. Demo tenants set skipConsoleRedirect anyway, so
+  // this only matters when an authenticated user clicks an explicit
+  // "Go to Console" link there — sending them to mothership is the
+  // least-bad option (better than constructing a bogus `console.omantel.openova.io`).
+  return MOTHERSHIP_CONSOLE_URL;
+}
 
 /** Post-auth Nova customer console. All references to the customer dashboard
  *  go through here so the marketplace never hardcodes a cross-host URL. */
-export const CONSOLE_URL = 'https://console.openova.io/nova';
+export const CONSOLE_URL: string = deriveConsoleURL();
 
 /** Build a URL into the Nova console with optional token/refresh handoff
  *  query params — used when marketplace hands a signed-in session to the


### PR DESCRIPTION
## Summary

Post-purchase + returning-user redirects in the marketplace were hardcoded to `https://console.openova.io/nova` (mothership). On a Sovereign — e.g. `marketplace.t15.omantel.biz` — that bounced the user back to the mothership and re-prompted sign-in against the wrong identity provider, instead of landing them on their own tenant's console at `console.<sov-fqdn>/dashboard`.

## Root Cause

The marketplace pod is shared one-deployment-many-ingresses (`marketplace.openova.io` + `marketplace.<sov-fqdn>` + partner vanity hosts — see `products/catalyst/chart/templates/sme-services/marketplace-routes.yaml`). A build-time constant for `CONSOLE_URL` can never name the right console, so the lookup must happen client-side from `window.location.hostname`.

Two files hardcoded the mothership URL:

- `core/marketplace/src/lib/config.ts` — `CONSOLE_URL = 'https://console.openova.io/nova'` (used by `consoleHref()` from `CheckoutStep.svelte`'s `redirectToConsole()` + the "Go to Console" link + `Header.svelte` Portal link).
- `core/marketplace/src/layouts/Layout.astro` — the inline returning-user auto-redirect (fires before any Svelte bundle loads, so it has to be patched inline too).

## Fix

Runtime derivation from `window.location.hostname`:

| Host pattern                  | Resolved console URL                 | Notes |
|-------------------------------|--------------------------------------|-------|
| `marketplace.openova.io`      | `https://console.openova.io/nova`    | Mothership unchanged; `/nova` prefix preserved (Traefik `strip-nova` middleware) |
| `marketplace.<sov-fqdn>`      | `https://console.<sov-fqdn>`         | Sovereign; matches Cilium Gateway `*.<sov-fqdn>` wildcard HTTPRoute that targets the in-cluster `console` Service. No `/nova` prefix on Sovereign — no `strip-nova` middleware exists there. |
| `omantel.openova.io` + others | mothership fallback                  | Partner-branded vanity hosts set `skipConsoleRedirect=true` and don't reach this code path anyway; sending them to mothership is the least-bad fallback if they do. |
| SSR / no `window`             | mothership fallback                  | Safe default for static page render. |

Implemented twice in lockstep — once in `src/lib/config.ts` (consumed by Svelte components), once inline in `src/layouts/Layout.astro` because the returning-user redirect must fire before the Svelte bundle loads.

## Diff

- `core/marketplace/src/lib/config.ts` — `CONSOLE_URL` becomes the result of a new `deriveConsoleURL()` helper that does the host-based switch.
- `core/marketplace/src/layouts/Layout.astro` — inline `redirect()` performs the same `marketplace.` to `console.` rewrite.

## Test Plan

- [x] `npm run build` in `core/marketplace` — clean, 9 static pages emitted, no warnings.
- [x] Inline detector present in built HTML: `grep "indexOf('marketplace.')" dist/checkout/index.html` returns 1.
- [ ] (post-merge) Sovereign smoke: open `marketplace.<sov-fqdn>/checkout`, complete checkout with voucher, confirm browser redirects to `https://console.<sov-fqdn>/jobs?token=...` (not `console.openova.io/nova/jobs?...`).
- [ ] (post-merge) Mothership regression: open `marketplace.openova.io/checkout`, confirm redirect still goes to `https://console.openova.io/nova/jobs?token=...`.

## Hard Rules

- [x] No chart bump.
- [x] No cluster writes.
- [x] Branch `fix-convergence-post-purchase-return-url`.
- [x] Astro build passes.

Generated with [Claude Code](https://claude.com/claude-code)