### PR TITLE
fix(domain): per-tenant DNS reconciler — <slug>.<pool-domain> resolves to Sovereign LB (was mothership)

### DIFF
--- a/products/catalyst/chart/templates/api-deployment.yaml
+++ b/products/catalyst/chart/templates/api-deployment.yaml
@@ -753,6 +753,31 @@ spec:
                   name: sovereign-fqdn
                   key: lbIP
                   optional: true
+            # CATALYST_OTECH_INGRESS_IPV4 — Sovereign's load-balancer public
+            # IPv4, consumed by the SME tenant pipeline's DNS provisioner
+            # (sme_tenant_dns.go DefaultSMETenantDNSProvisioner.ProvisionFreeSubdomain).
+            # main.go reads this into SMETenantDeps.OTECHIngressIPv4 and the
+            # per-tenant flow PATCHes `console|wordpress|openclaw|mail|keycloak.<slug>.<pool>`
+            # A records pointing here so a fresh tenant signup on Sovereign t<N>
+            # resolves to t<N>'s LB instead of falling back to the mothership IP
+            # (convergence blocker: without this env, ProvisionFreeSubdomain returns
+            # "otech ingress IPv4 unconfigured" and no per-tenant DNS records are
+            # ever written — the pool zone's apex record then routes tenants at
+            # whatever IP the apex was last delegated to, which on a multi-Sovereign
+            # setup is the mothership).
+            #
+            # Sourced from the same `sovereign-fqdn` ConfigMap key `lbIP` already
+            # used by SOVEREIGN_LB_IP above (chart renders from `global.sovereignLBIP`).
+            # optional=true: Catalyst-Zero (contabo) doesn't run the SME tenant
+            # pipeline; the env stays empty and the DNS step degrades to the
+            # "otech ingress IPv4 unconfigured" transient error that the
+            # orchestrator retries until handover stamps the value.
+            - name: CATALYST_OTECH_INGRESS_IPV4
+              valueFrom:
+                configMapKeyRef:
+                  name: sovereign-fqdn
+                  key: lbIP
+                  optional: true
             # CATALYST_CONFIGURED_REGIONS — comma-separated Hetzner regions
             # the operator declared at provision time (qa-loop iter-16
             # Fix #88, Path B). The fleet handler reads this when the


### PR DESCRIPTION
## Summary

**Convergence blocker**: tenant subdomain `<name>.omani.homes` resolves to mothership (49.12.16.160), NOT the Sovereign LB. Per-tenant DNS reconciler existed but never fired because its IP source env was never wired in the chart.

### Root cause

- `DefaultSMETenantDNSProvisioner.ProvisionFreeSubdomain` (sme_tenant_dns.go:146) already PATCHes `console|wordpress|openclaw|mail|keycloak.<slug>.<pool>` A records into PowerDNS for every tenant.
- main.go:514 reads its IP source from env: `OTECHIngressIPv4: os.Getenv("CATALYST_OTECH_INGRESS_IPV4")`.
- The catalyst-api Deployment **never set that env**. The pool zone (e.g. `omani.homes`) was left with only the apex/wildcard records inherited from the mothership tofu, so a tenant signing up on Sovereign `t15` got DNS that resolved to mothership.
- ProvisionFreeSubdomain silently returned `errors.New("otech ingress IPv4 unconfigured")` on every signup — the failTransient path retried forever, but with empty env it could never converge.

### Fix

Wire `CATALYST_OTECH_INGRESS_IPV4` from the **same** `sovereign-fqdn` ConfigMap key `lbIP` already consumed by `SOVEREIGN_LB_IP` a few lines above. One env var, zero new chart values, optional=true so Catalyst-Zero (contabo) stays unaffected.

### Why per-tenant (not `*.omani.homes` wildcard)

1. Each tenant materialises five distinct hostnames (`console|wordpress|openclaw|mail|keycloak`) — a wildcard wouldn't disambiguate.
2. The pool zone hosts Sovereign-owned subdomains too; a blanket wildcard would shadow them.
3. The reconciler exists end-to-end already — only the env was missing.

## Test plan

- [ ] Helm template renders the new env block (verified locally: `helm template t-test products/catalyst/chart --set global.sovereignLBIP=1.2.3.4 --show-only templates/api-deployment.yaml | grep CATALYST_OTECH_INGRESS_IPV4` returns 2 occurrences — comment + env)
- [ ] Fresh prov: sign up a tenant `acme` on Sovereign `tN.omani.works` with pool `omani.homes`, dig `console.acme.omani.homes` — expect `tN`'s LB IP, not mothership
- [ ] Existing tenant on same pool keeps resolving (idempotent PATCH REPLACE)

🤖 Generated with [Claude Code](https://claude.com/claude-code)