### PR TITLE
feat(sandbox+bootstrap-kit): newapi Sovereign install (Bank Dhofar Qwen wired for Sandbox)

### DIFF
--- a/clusters/_template/bootstrap-kit/80-newapi.yaml
+++ b/clusters/_template/bootstrap-kit/80-newapi.yaml
@@ -209,11 +209,27 @@ spec:
     # operators that run their own bp-vllm + open-weight model in-
     # cluster; it composes after `qwenBankDhofar` and any operator
     # `.Values.channels`.
+    # Sandbox Wave 4 (2026-05-18, retry of sandbox-wave4-newapi-sovereign-install):
+    # qwenBankDhofar is now gated on `${MARKETPLACE_ENABLED:-false}` — the
+    # same envsubst variable bp-catalyst-platform (slot 13) reads to flip
+    # marketplace.enabled on the Catalyst control plane. This lets a
+    # franchised Sovereign with `MARKETPLACE_ENABLED=true` auto-seed the
+    # default Bank Dhofar Qwen3.6 channel without the operator having to
+    # supply per-Sovereign overlay values. The endpoint defaults to the
+    # canonical first-otech relay; `LLM_BANK_DHOFAR_BASE_URL` overrides
+    # it (e.g. for staging at https://omtd.bankdhofar.com). The upstream
+    # API key MUST be present in the Secret `newapi-channel-qwen-bankdhofar`
+    # under key `API_KEY` — either pre-seeded by cloud-init or pulled from
+    # OpenBao via the operator's ExternalSecret at path
+    # `sovereign/<fqdn>/newapi/channel-qwen-bankdhofar`. Sandbox agents
+    # (sandbox-wave4) depend on this channel being live on every Sovereign
+    # that opted in to marketplace; without it the agents fall back to
+    # mothership newapi, defeating the per-Sovereign sandboxing.
     defaultChannels:
       qwenBankDhofar:
-        enabled: false
+        enabled: ${MARKETPLACE_ENABLED:-false}
         name: qwen3.6-bankdhofar
-        endpoint: ""
+        endpoint: ${LLM_BANK_DHOFAR_BASE_URL:-https://llm-api.omtd.bankdhofar.com}
         models:
           - qwen3.6
           - qwen3-coder
@@ -221,8 +237,8 @@ spec:
         existingSecretKey: API_KEY
         attestation:
           kind: commercial-contract
-          accountId: ""
-          contractRef: ""
+          accountId: ${LLM_BANK_DHOFAR_ACCOUNT_ID:-}
+          contractRef: ${LLM_BANK_DHOFAR_CONTRACT_REF:-}
       vllm:
         enabled: false
         name: qwen


### PR DESCRIPTION
## Summary
- Wires the `qwenBankDhofar` default channel in `clusters/_template/bootstrap-kit/80-newapi.yaml` to the same envsubst flag (`${MARKETPLACE_ENABLED:-false}`) the Catalyst control plane uses to flip marketplace mode on a fresh franchised Sovereign.
- Defaults `endpoint` to the canonical first-otech relay (`https://llm-api.omtd.bankdhofar.com`) with override via `${LLM_BANK_DHOFAR_BASE_URL}`; adds attestation envsubst hooks (`LLM_BANK_DHOFAR_ACCOUNT_ID`, `LLM_BANK_DHOFAR_CONTRACT_REF`) for legal-team-supplied values.
- No chart version bump — chart 1.4.6 (slot 80) already supports gating qwenBankDhofar via `.Values.defaultChannels.qwenBankDhofar.enabled` and reading endpoint/secret from those values. Only the bootstrap-kit overlay was shipping with the wrong defaults.

## Why
Sandbox-wave4 agents on franchised Sovereigns need a per-Sovereign newapi channel — pre-PR they came up with `qwenBankDhofar.enabled: false` and empty endpoint, so all agents fell back to mothership newapi and defeated the per-Sovereign sandboxing.

## API key
The upstream API key MUST be present in the Secret `newapi-channel-qwen-bankdhofar` (key `API_KEY`) — either pre-seeded by cloud-init OR pulled from OpenBao via the operator's ExternalSecret at `sovereign/<fqdn>/newapi/channel-qwen-bankdhofar`. This contract is unchanged from chart 1.4.6.

## Test plan
- [ ] `helm lint platform/newapi/chart` clean
- [ ] Bake on next fresh Sovereign prov with `MARKETPLACE_ENABLED=true`: confirm `kubectl -n newapi logs job/newapi-channel-seed` shows `qwen3.6-bankdhofar` posted via admin API and `kubectl -n newapi exec deploy/newapi -- curl -s http://localhost:3000/api/channel/?keyword=qwen3.6-bankdhofar` returns the channel.
- [ ] Sandbox agent /v1/chat/completions on the Sovereign returns 200 from Qwen3.6.

Slot: 80 (`clusters/_template/bootstrap-kit/80-newapi.yaml`)

Branch: `sandbox-wave4-newapi-sovereign-install-v2`