### PR TITLE
feat(sandbox+bootstrap-kit): slot 61 bp-sandbox HR (deploys sandbox-controller on Sovereigns, gated SANDBOX_ENABLED)

### DIFF
--- a/clusters/_template/bootstrap-kit/61-bp-sandbox.yaml
+++ b/clusters/_template/bootstrap-kit/61-bp-sandbox.yaml
@@ -1,0 +1,123 @@
+# bp-sandbox — Catalyst bootstrap-kit Blueprint slot 61.
+#
+# Deploys the Wave 1 sandbox-controller on a Sovereign so that
+# `sandbox.openova.io/v1.Sandbox` CRs (shipped by the catalyst umbrella
+# at products/catalyst/chart/crds/sandbox.yaml, PR #1615) are actually
+# reconciled. Without this slot, every Sandbox CR a user creates sits
+# unhandled — sandbox-controller never deploys.
+#
+# Per products/sandbox/docs/architecture.md §7: the sandbox-controller
+# is the sister of organization-controller (one-CR-per-Sandbox-user,
+# per-Org-vcluster materialization). Wave 1 installs the Deployment +
+# ClusterRole + ClusterRoleBinding + ServiceAccount; Wave 2 adds the
+# pty-server + openova-sandbox-mcp Deployments inside each Sandbox
+# namespace.
+#
+# Wrapper chart: platform/sandbox/chart/ (PR #1622)
+#   Chart name `sandbox` (chart-published artifact lives at
+#   oci://ghcr.io/openova-io/sandbox — i.e. Chart.yaml `name: sandbox`,
+#   not `bp-sandbox`). The HR + HelmRepository here follow the
+#   bootstrap-kit naming convention (`bp-sandbox`) — the upstream chart
+#   reference (`chart: sandbox`) matches what the blueprint-release
+#   workflow publishes.
+#
+# Reconciled by: Flux on the Sovereign's k3s control plane.
+#
+# Slot 61 chosen as the first free slot after bp-vcluster-helmrepo
+# (slot 60). The sandbox-controller is sequenced AFTER:
+#   - bp-vcluster-helmrepo (slot 60) — Wave 2 will register
+#     per-Sandbox HelmReleases that reference the upstream vcluster
+#     chart through this Flux source; pinning the dep now means the
+#     Wave 2 follow-up does not need to revisit slot ordering.
+#   - bp-catalyst-platform (slot 13) — the controller authenticates
+#     to Gitea using the `catalyst-gitea-token` Secret materialised
+#     by the catalyst umbrella in `catalyst-system`. Without the
+#     umbrella Ready, the Secret is absent and the controller
+#     CrashLoopBackoffs on env wiring (mustEnv on CATALYST_GITEA_TOKEN
+#     valueFrom secretKeyRef).
+#
+# Gated default-OFF via ${SANDBOX_ENABLED:-false} on the bootstrap-kit
+# Kustomization substitute — matches the chart's `values.enabled`
+# default at platform/sandbox/chart/values.yaml. Operators flip
+# `SANDBOX_ENABLED=true` on the per-Sovereign overlay once Wave 1
+# image is SHA-stamped and Wave 2 pty-server / token issuance is
+# ready (per the chart README).
+
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: bp-sandbox
+  namespace: flux-system
+spec:
+  type: oci
+  interval: 15m
+  url: oci://ghcr.io/openova-io
+  secretRef:
+    name: ghcr-pull
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: bp-sandbox
+  namespace: flux-system
+  labels:
+    catalyst.openova.io/slot: "61"
+    catalyst.openova.io/component: sandbox-controller
+spec:
+  interval: 15m
+  releaseName: sandbox
+  # Controller lives in catalyst-system alongside organization-controller
+  # so the chart's hardcoded SA name (sandbox-controller) does not
+  # collide and the Gitea-token Secret (`catalyst-gitea-token`) the
+  # catalyst umbrella ships is co-located — `secretKeyRef` lookups
+  # resolve in-namespace.
+  targetNamespace: catalyst-system
+  dependsOn:
+    # bp-vcluster-helmrepo (slot 60) — Wave 2 wires per-Sandbox
+    # HelmReleases that resolve through this Flux source.
+    - name: bp-vcluster-helmrepo
+    # bp-catalyst-platform (slot 13) — provides `catalyst-system`
+    # Namespace + the `catalyst-gitea-token` Secret the controller
+    # uses to PutFile manifests into the per-Org `catalyst-tenant`
+    # Gitea repo.
+    - name: bp-catalyst-platform
+  chart:
+    spec:
+      # Chart name from platform/sandbox/chart/Chart.yaml — `name: sandbox`.
+      # The blueprint-release workflow publishes the artifact under that
+      # exact name (oci://ghcr.io/openova-io/sandbox:<semver>). Pinned
+      # to 0.1.0 (Wave 1 scaffold version). Bump only when chart
+      # Chart.yaml bumps.
+      chart: sandbox
+      version: 0.1.0
+      sourceRef:
+        kind: HelmRepository
+        name: bp-sandbox
+        namespace: flux-system
+  install:
+    timeout: 10m
+    disableWait: true
+    remediation:
+      retries: 3
+  upgrade:
+    timeout: 10m
+    disableWait: true
+    remediation:
+      retries: 3
+  # Per-Sovereign overlay surface.
+  #
+  # enabled — gated default-OFF via ${SANDBOX_ENABLED:-false} on the
+  # bootstrap-kit Kustomization substitute. Matches the chart's
+  # `values.enabled` default at platform/sandbox/chart/values.yaml.
+  # Wave 2 (pty-server + token issuance + HTTPRoutes) flips this on
+  # via per-Sovereign overlay.
+  #
+  # env.hostCluster / env.sovereignFQDN — required at install time
+  # per the chart's `required` template guards. Fed from the
+  # canonical bootstrap-kit substitute variables.
+  values:
+    enabled: ${SANDBOX_ENABLED:-false}
+    env:
+      hostCluster: ${SOVEREIGN_REGION_CANONICAL_LABEL}
+      sovereignFQDN: ${SOVEREIGN_FQDN}

--- a/clusters/_template/bootstrap-kit/kustomization.yaml
+++ b/clusters/_template/bootstrap-kit/kustomization.yaml
@@ -124,6 +124,16 @@ resources:
   # this slot registers a live Flux source so per-TENANT vClusters can
   # be spawned by the Organization controller at runtime). Default-ON.
   - 60-bp-vcluster-helmrepo.yaml
+  # bp-sandbox (slot 61) — sandbox-controller Wave 1 (PR #1622). Reconciles
+  # `sandbox.openova.io/v1.Sandbox` CRs into per-Sandbox manifests written
+  # into the per-Org `catalyst-tenant` Gitea repo. Without this slot,
+  # Sandbox CRs sit unhandled — the controller never deploys. dependsOn
+  # bp-vcluster-helmrepo (slot 60, Wave 2 per-Sandbox vCluster source)
+  # and bp-catalyst-platform (slot 13, catalyst-system Namespace +
+  # catalyst-gitea-token Secret). Gated default-OFF via
+  # ${SANDBOX_ENABLED:-false} on the bootstrap-kit Kustomization
+  # substitute — matches the chart's values.enabled default.
+  - 61-bp-sandbox.yaml
   # bp-newapi (slot 80) — multi-tenant LLM marketplace gateway. Sequenced
   # after the W2.K1 dependency wave (cnpg/keycloak/openbao Ready) so
   # NewAPI's ExternalSecret + DSN dependencies resolve on first reconcile.

--- a/scripts/expected-bootstrap-deps.yaml
+++ b/scripts/expected-bootstrap-deps.yaml
@@ -463,6 +463,25 @@ slots:
       - bp-flux
     wave: present
 
+  # ---- Slot 61 — bp-sandbox sandbox-controller Wave 1 (PR #1622). Reconciles
+  # `sandbox.openova.io/v1.Sandbox` CRs into per-Sandbox manifests written
+  # to the per-Org `catalyst-tenant` Gitea repo (sister of organization-
+  # controller). Without this slot, Sandbox CRs sit unhandled — the
+  # controller never deploys on Sovereigns. Gated default-OFF via
+  # ${SANDBOX_ENABLED:-false} on the bootstrap-kit Kustomization substitute.
+  # dependsOn:
+  #   - bp-vcluster-helmrepo (slot 60) — Wave 2 wires per-Sandbox
+  #     HelmReleases that resolve through this Flux source.
+  #   - bp-catalyst-platform (slot 13) — provides `catalyst-system`
+  #     Namespace + the `catalyst-gitea-token` Secret the controller's
+  #     CATALYST_GITEA_TOKEN env reads via secretKeyRef.
+  - slot: 61
+    name: bp-sandbox
+    depends_on:
+      - bp-vcluster-helmrepo
+      - bp-catalyst-platform
+    wave: present
+
   # ---- Slot 80 — bp-newapi multi-tenant LLM marketplace gateway. Issue #799.
   # Sequenced past the W2.K4 numbering plan (slots 36-48) so it never
   # collides with the AI-runtime / observability / livekit cohort. The


### PR DESCRIPTION
## Summary

Wires PR #1622's `platform/sandbox/chart/` into bootstrap-kit at **slot 61** so the **sandbox-controller** actually deploys on Sovereigns. Without this slot, the chart ships but no HelmRelease installs it — every `Sandbox` CR a user creates sits unhandled because the controller never reaches a Sovereign.

- **NEW** `clusters/_template/bootstrap-kit/61-bp-sandbox.yaml` — `HelmRepository` + `HelmRelease`.
  - `chart: sandbox` (name from `platform/sandbox/chart/Chart.yaml`, not `bp-sandbox` — the blueprint-release workflow publishes under whatever `name:` Chart.yaml carries; PR #1622 shipped it as `sandbox`).
  - **dependsOn**:
    - `bp-vcluster-helmrepo` (slot 60) — Wave 2 wires per-Sandbox HelmReleases through this Flux source.
    - `bp-catalyst-platform` (slot 13) — provides `catalyst-system` Namespace + `catalyst-gitea-token` Secret the controller's `CATALYST_GITEA_TOKEN` env consumes via `secretKeyRef`.
  - `targetNamespace: catalyst-system` — colocates with `organization-controller`; Gitea-token Secret resolves in-namespace.
  - **Gated default-OFF** via `values.enabled: ${SANDBOX_ENABLED:-false}` on the bootstrap-kit Kustomization substitute. Matches `platform/sandbox/chart/values.yaml` `enabled: false` default. Operator flips on per-Sovereign overlay when Wave 2 is ready.
  - `env.hostCluster` / `env.sovereignFQDN` fed from canonical `${SOVEREIGN_REGION_CANONICAL_LABEL}` / `${SOVEREIGN_FQDN}` substitutes (mirrors slots 54/58/59).
- **MODIFY** `clusters/_template/bootstrap-kit/kustomization.yaml` — register `61-bp-sandbox.yaml` immediately after slot 60.
- **MODIFY** `scripts/expected-bootstrap-deps.yaml` — declare slot 61 with `depends_on: [bp-vcluster-helmrepo, bp-catalyst-platform]`. `scripts/check-bootstrap-deps.sh` reports `drift=0`, `cycles=0`, slot 61 `[P]`.

## Hard rules respected

- READ-ONLY clusters — no live cluster mutation.
- NO chart `Chart.yaml` bump — Wave 1 chart stays at `0.1.0`, `appVersion: 0.1.0`. Chart image tag remains the `1b0e86c` already committed at HEAD.
- NO UI files touched.
- `kubectl kustomize clusters/_template/bootstrap-kit/` renders clean.
- `helm template t platform/sandbox/chart` renders 0 resources at defaults (opt-in gate intact); with `--set enabled=true --set env.hostCluster=x --set env.sovereignFQDN=y` renders Deployment + SA + ClusterRole + ClusterRoleBinding cleanly.

## Test plan

- [x] `kubectl kustomize clusters/_template/bootstrap-kit/` clean exit
- [x] `bash scripts/check-bootstrap-deps.sh` — drift=0, cycles=0, slot 61 [P]resent
- [x] `helm template t platform/sandbox/chart` (defaults) → 0 resources
- [x] `helm template t platform/sandbox/chart --set enabled=true ...` → 4 resources
- [ ] Fresh prov: `kubectl -n flux-system get hr bp-sandbox` shows Ready=True when `SANDBOX_ENABLED=true` flipped on overlay
- [ ] Fresh prov with `SANDBOX_ENABLED` unset: `bp-sandbox` HR Ready=True (chart renders nothing — opt-in gate intact); no Deployment in `catalyst-system`

🤖 Generated with [Claude Code](https://claude.com/claude-code)