### PR TITLE
fix(sovereign-tls): cilium-gateway listeners per parentZone (was only *.<SOVEREIGN_FQDN>; tenant URLs at *.omani.homes were TLS-mismatch)

### DIFF
--- a/clusters/_template/sovereign-tls/cilium-gateway.yaml
+++ b/clusters/_template/sovereign-tls/cilium-gateway.yaml
@@ -4,6 +4,62 @@
 # whole Kustomization before applying any HR, so Gateway dry-run fails on
 # a fresh cluster. The sovereign-tls Kustomization dependsOn bootstrap-kit
 # Ready, so by the time Gateway is applied here, Cilium has installed.
+#
+# Multi-zone listeners (issue #831, parent epic #827)
+# ---------------------------------------------------
+# Before this change the Gateway declared a single listener pair (HTTPS +
+# HTTP) on `*.${SOVEREIGN_FQDN}`. That worked for legacy single-zone
+# Sovereigns but BROKE every tenant URL under a non-primary parent zone:
+#   - Primary zone: omani.works   → console.omani.works  ✅ TLS terminates
+#   - SME pool:    omani.homes    → wp-foo.omani.homes  ❌ TLS handshake
+#                                                       mismatch (cert
+#                                                       exists per chart's
+#                                                       sovereign-wildcard-
+#                                                       certs.yaml but no
+#                                                       Gateway listener
+#                                                       claims the
+#                                                       hostname).
+# Symptom: cilium-envoy serves the default fallback cert, browser shows
+# NET::ERR_CERT_COMMON_NAME_INVALID, marketplace WordPress tenants on
+# omani.homes are unreachable.
+#
+# Fix: render one listener pair per parent zone. The listener block is
+# materialised at Terraform plan time (infra/hetzner/main.tf
+# locals.parent_domains_listeners_yaml — jsonencode of the listener
+# objects), threaded through Flux postBuild.substitute as
+# ${PARENT_DOMAINS_LISTENERS_YAML}, and consumed BELOW as a YAML inline-
+# flow array value on `spec.listeners`. Each pair's certificateRefs
+# target the per-zone Secret rendered by products/catalyst/chart/
+# templates/sovereign-wildcard-certs.yaml (PR #827) so the Gateway
+# listener and the cert resource are always in lockstep.
+#
+# Why a scalar placeholder, not a multi-line block:
+#   - kustomize-build PARSES the YAML before Flux runs envsubst. A
+#     placeholder on its own line at column 0 is rejected by the YAML
+#     parser ("could not find expected ':'"), and kustomize fails. A
+#     scalar like `listeners: ${VAR}` parses cleanly — kustomize sees
+#     the value as the literal string `${VAR}` and emits it unchanged.
+#     Flux's envsubst step then swaps it for the JSON-flow array string
+#     `[{name: https-omani-works, ...}, ...]`, which the apiserver
+#     parses as the real listener list.
+#
+# Why not a Helm template here: the Cilium Gateway resource lives in the
+# Kustomize-managed sovereign-tls path (not the chart) because its
+# Kustomization dependsOn bootstrap-kit Ready — i.e. it lands BEFORE
+# bp-catalyst-platform reconciles. Moving it into the chart would invert
+# the ordering and produce a transient "no Gateway → no envoy listener →
+# console unreachable" gap during every Helm upgrade. envsubst-driven
+# pre-rendered YAML is the canonical pattern for this slot.
+#
+# Listener naming convention:
+#   - https-<sanitised-zone> / http-<sanitised-zone>
+#   - sanitised-zone = zone name with '.' → '-' (e.g. omani-works,
+#     omani-homes). MUST match the cert resource naming in
+#     products/catalyst/chart/templates/sovereign-wildcard-certs.yaml
+#     so certificateRefs resolve. Each listener distinct so the Gateway
+#     controller programs them all (duplicate `name: https` would
+#     produce a Conflicting status condition and skip all but the
+#     first).
 
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
@@ -32,23 +88,4 @@ spec:
   #
   # See infra/hetzner/main.tf hcloud_load_balancer_service.{http,https}
   # destination_port settings — they MUST match these listener ports.
-  listeners:
-    - name: https
-      port: 30443
-      protocol: HTTPS
-      hostname: "*.${SOVEREIGN_FQDN}"
-      tls:
-        mode: Terminate
-        certificateRefs:
-          - kind: Secret
-            name: sovereign-wildcard-tls-${SOVEREIGN_FQDN_DASHED}
-      allowedRoutes:
-        namespaces:
-          from: All
-    - name: http
-      port: 30080
-      protocol: HTTP
-      hostname: "*.${SOVEREIGN_FQDN}"
-      allowedRoutes:
-        namespaces:
-          from: All
+  listeners: ${PARENT_DOMAINS_LISTENERS_YAML}

--- a/infra/hetzner/cloudinit-control-plane.tftpl
+++ b/infra/hetzner/cloudinit-control-plane.tftpl
@@ -1188,6 +1188,22 @@ write_files:
             # bp-catalyst-platform into clusters/_template/sovereign-tls/
             # has access to the parent-zone list without a config copy.
             PARENT_DOMAINS_YAML: '${parent_domains_yaml}'
+            # PARENT_DOMAINS_LISTENERS_YAML (issue #831 follow-on to #827).
+            # JSON-flow array literal listing one Gateway listener pair
+            # (HTTPS:30443 + HTTP:30080) per parent zone. Consumed as a
+            # scalar value at `listeners: $${PARENT_DOMAINS_LISTENERS_YAML}`
+            # in clusters/_template/sovereign-tls/cilium-gateway.yaml.
+            # kustomize-build accepts the unsubstituted scalar; Flux's
+            # postBuild.substitute then swaps it for the materialised
+            # array, which YAML parses as the actual listener list.
+            # The double jsonencode is intentional — the inner one
+            # (locals.parent_domains_listeners_yaml) renders the array;
+            # the outer one wraps it as a JSON-encoded string so the
+            # value-in-YAML embedding works regardless of the array's
+            # internal characters. See infra/hetzner/main.tf
+            # locals.parent_domains_listeners_yaml for rationale +
+            # listener-naming convention.
+            PARENT_DOMAINS_LISTENERS_YAML: ${jsonencode(parent_domains_listeners_yaml)}
             # WILDCARD_CERT_ISSUER (Fix #176 — qa-loop iter-1 LE
             # rate-limit unblock). cilium-gateway-cert.yaml references
             # this via $${WILDCARD_CERT_ISSUER}. When

--- a/infra/hetzner/main.tf
+++ b/infra/hetzner/main.tf
@@ -307,6 +307,96 @@ locals {
   # rate limit pins the Gateway to a `Ready=False` Certificate.
   wildcard_cert_issuer = var.wildcard_cert_use_staging == "true" ? "letsencrypt-dns01-staging-powerdns" : "letsencrypt-dns01-prod-powerdns"
 
+  # ── Cilium Gateway listeners per parent zone (issue #831, parent #827) ───
+  # The Sovereign supports N parent zones (primary + 0..N sme-pool). For
+  # each zone the Cilium Gateway must declare a listener pair (HTTPS:30443
+  # + HTTP:30080) hostnamed `*.<zone>` so cilium-envoy programs the SDS
+  # subscription against the per-zone cert. Without these listeners,
+  # tenant URLs under non-primary parent zones (e.g. wp-foo.omani.homes)
+  # hit the envoy default fallback cert and TLS-mismatch.
+  #
+  # parent_domains_yaml is a YAML inline-array literal (see variables.tf).
+  # yamldecode() turns it into a list of objects we can iterate at plan
+  # time. The result is a JSON-flow array string injected verbatim into
+  # clusters/_template/sovereign-tls/cilium-gateway.yaml via Flux
+  # postBuild.substitute ${PARENT_DOMAINS_LISTENERS_YAML}. YAML accepts
+  # JSON-flow syntax (`[{...}, {...}]`) as a native inline-flow array,
+  # so the substituted value parses correctly under spec.listeners.
+  #
+  # The single-zone fallback (var.parent_domains_yaml empty) renders one
+  # pair derived from sovereign_fqdn — keeps legacy single-zone
+  # provisioning paths plan-clean (one zone → two listeners).
+  parent_domains_decoded = yamldecode(coalesce(
+    var.parent_domains_yaml,
+    format("[{name: \"%s\", role: \"primary\"}]", var.sovereign_fqdn)
+  ))
+
+  # Render the Gateway listeners block as a YAML inline-flow array (JSON-
+  # compatible syntax — `[{key: val, ...}, {...}]`). Each parent zone
+  # produces two entries:
+  #   - HTTPS listener on port 30443 hostnamed `*.<zone>` with certificateRefs
+  #     targeting `sovereign-wildcard-tls-<sanitised-zone>` (the chart's
+  #     sovereign-wildcard-certs.yaml writes a Secret of that exact name).
+  #   - HTTP  listener on port 30080 hostnamed `*.<zone>` for /.well-known/
+  #     and ACME HTTP-01 challenge paths.
+  #
+  # Each listener has a unique `name` field (https-<sanitised-zone> /
+  # http-<sanitised-zone>) so the Gateway controller programs them all
+  # (duplicate listener names produce a Conflicting status condition and
+  # silently skip every duplicate but the first).
+  #
+  # Why inline-flow not block-style:
+  #   - clusters/_template/sovereign-tls/cilium-gateway.yaml uses the
+  #     placeholder as a SCALAR value (`listeners: ${PARENT_DOMAINS_
+  #     LISTENERS_YAML}`). A block-style multi-line value would break
+  #     kustomize's pre-substitute YAML parse (the placeholder lands
+  #     mid-document and kustomize doesn't see the structure yet).
+  #   - Inline-flow is YAML-spec valid AND kustomize-build accepts the
+  #     scalar `${VAR}` until Flux's postBuild.substitute swaps it for
+  #     the materialised list. Same pattern PARENT_DOMAINS_YAML uses
+  #     (bp-powerdns slot 11 zones field).
+  #
+  # jsonencode() is used downstream (in cloudinit-control-plane.tftpl)
+  # to wrap this string for safe storage inside the Flux Kustomization's
+  # substitute map. JSON-encoded scalars are valid YAML; this avoids
+  # quoting hell when the listener data contains characters cloud-init
+  # YAML would otherwise mis-parse.
+  parent_domains_listeners_yaml = jsonencode(flatten([
+    for entry in local.parent_domains_decoded : [
+      {
+        name     = format("https-%s", replace(entry.name, ".", "-"))
+        port     = 30443
+        protocol = "HTTPS"
+        hostname = format("*.%s", entry.name)
+        tls = {
+          mode = "Terminate"
+          certificateRefs = [
+            {
+              kind = "Secret"
+              name = format("sovereign-wildcard-tls-%s", replace(entry.name, ".", "-"))
+            }
+          ]
+        }
+        allowedRoutes = {
+          namespaces = {
+            from = "All"
+          }
+        }
+      },
+      {
+        name     = format("http-%s", replace(entry.name, ".", "-"))
+        port     = 30080
+        protocol = "HTTP"
+        hostname = format("*.%s", entry.name)
+        allowedRoutes = {
+          namespaces = {
+            from = "All"
+          }
+        }
+      },
+    ]
+  ]))
+
   # ── Effective singular-path SKU selection (Fix #157) ─────────────────────
   # When qa_fixtures_enabled='true', the Sovereign is a QA-loop matrix
   # consumer carrying the full bp-* stack PLUS qaFixtures (Continuum +
@@ -568,6 +658,12 @@ locals {
       var.parent_domains_yaml,
       format("[{name: \"%s\", role: \"primary\"}]", var.sovereign_fqdn)
     )
+    # Cilium Gateway listeners per parent zone (issue #831). Multi-line
+    # YAML block iterating local.parent_domains_decoded. Threaded into
+    # clusters/_template/sovereign-tls/cilium-gateway.yaml via Flux
+    # postBuild.substitute as ${PARENT_DOMAINS_LISTENERS_YAML}. See
+    # locals.parent_domains_listeners_yaml above for shape + rationale.
+    parent_domains_listeners_yaml = local.parent_domains_listeners_yaml
     # sovereign_regions_json — canonical multi-region RegionSpec[]
     # JSON literal. Threaded into bp-catalyst-platform's
     # .Values.sovereign.regionsJson via the bootstrap-kit slot 13
@@ -1111,6 +1207,12 @@ locals {
         var.parent_domains_yaml,
         format("[{name: \"%s\", role: \"primary\"}]", var.sovereign_fqdn)
       )
+      # Cilium Gateway listeners per parent zone (issue #831). Same
+      # rendered multi-line YAML as the primary CP — secondary regions
+      # also reconcile sovereign-tls into THEIR own cluster, so the
+      # listeners block must be present there too. See
+      # locals.parent_domains_listeners_yaml in this file.
+      parent_domains_listeners_yaml = local.parent_domains_listeners_yaml
       # Same JSON-encoded RegionSpec[] as the primary CP — every region's
       # bp-catalyst-platform renders the same sovereign.regionsJson value
       # (the cluster topology is Sovereign-wide, not per-region).


### PR DESCRIPTION
## Summary

Convergence gap from #831 (follow-on to #827): the Cilium Gateway in
`clusters/_template/sovereign-tls/cilium-gateway.yaml` declared a single
listener pair on `*.${SOVEREIGN_FQDN}`. Tenant URLs under non-primary
parent zones (e.g. `wp-foo.omani.homes` when the operator brings
`omani.homes` as the SME pool zone) hit cilium-envoy's default fallback
cert and TLS-handshake-mismatched — the per-zone wildcard Secret
rendered by `products/catalyst/chart/templates/sovereign-wildcard-certs.yaml`
(PR #827) existed but had no Gateway listener claiming the hostname.

This PR renders **one listener pair (HTTPS:30443 + HTTP:30080) per
parent zone** by iterating `parent_domains_yaml`. Listener + cert stay
in lockstep — same naming convention (`sovereign-wildcard-tls-<sanitised-zone>`),
same source of truth.

- `clusters/_template/sovereign-tls/cilium-gateway.yaml` — placeholder
  changed from inline `listeners:` block to scalar `listeners: ${PARENT_DOMAINS_LISTENERS_YAML}`.
  Comment block explains the why (kustomize parses YAML before envsubst,
  so a multi-line block at column 0 fails YAML parse; scalar placeholder
  parses cleanly and envsubst swaps it for a JSON-flow array).
- `infra/hetzner/main.tf` — `locals.parent_domains_decoded` (yamldecode
  of parent_domains_yaml with single-zone fallback) and
  `locals.parent_domains_listeners_yaml` (jsonencode of the listener
  list). Threaded into both primary CP and secondary regions'
  templatefile() calls.
- `infra/hetzner/cloudinit-control-plane.tftpl` — adds
  `PARENT_DOMAINS_LISTENERS_YAML` to the `sovereign-tls` Kustomization's
  `postBuild.substitute` block.

## Verification

### kustomize clean
```
$ kubectl kustomize clusters/_template/sovereign-tls/
... (clean render, Gateway emits `listeners: ${PARENT_DOMAINS_LISTENERS_YAML}` as scalar)
```

### Listener rendering (end-to-end simulation)

Two-zone provision (`primary omani.works` + `sme-pool omani.homes`):

| Listener name         | Port  | Protocol | Hostname        | certificateRefs                        |
|-----------------------|-------|----------|-----------------|----------------------------------------|
| `https-omani-works`   | 30443 | HTTPS    | `*.omani.works` | `sovereign-wildcard-tls-omani-works` |
| `http-omani-works`    | 30080 | HTTP     | `*.omani.works` | n/a                                    |
| `https-omani-homes`   | 30443 | HTTPS    | `*.omani.homes` | `sovereign-wildcard-tls-omani-homes` |
| `http-omani-homes`    | 30080 | HTTP     | `*.omani.homes` | n/a                                    |

Single-zone fallback (`var.parent_domains_yaml` empty → derived from
`sovereign_fqdn`): renders 2 listeners (1 HTTPS + 1 HTTP) — legacy
provisioning paths remain plan-clean.

## Test plan

- [x] kubectl kustomize clusters/_template/sovereign-tls/ → clean
- [x] Listener naming uniqueness verified (`https-<sanitised>` /
      `http-<sanitised>` — no duplicate `name` field which would
      produce Conflicting status condition)
- [x] certificateRefs target matches the chart's per-zone Secret name
- [x] Single-zone fallback verified (2 listeners)
- [x] Multi-zone verified (N zones → 2N listeners)
- [ ] Next fresh prov with 2+ parent zones: `curl -vk https://wp-foo.<sme-pool-zone>` returns the per-zone wildcard cert (not the envoy default)
- [ ] Tenant URL like `wp-foo.omani.homes` TLS handshake terminates without `NET::ERR_CERT_COMMON_NAME_INVALID`

Cites issue #831 (multi-listener Gateway), parent epic #827 (multi-zone Sovereign).

🤖 Generated with [Claude Code](https://claude.com/claude-code)