### PR TITLE
fix(bootstrap-kit): bp-sandbox slot move/remove to break harbor chicken-and-egg (was blocking bootstrap-kit Ready)

### DIFF
--- a/clusters/_template/bootstrap-kit/19a-bp-sandbox.yaml
+++ b/clusters/_template/bootstrap-kit/19a-bp-sandbox.yaml
@@ -1,10 +1,30 @@
-# bp-sandbox — Catalyst bootstrap-kit Blueprint slot 61.
+# bp-sandbox — Catalyst bootstrap-kit Blueprint slot 19a (post-harbor).
 #
 # Deploys the sandbox-controller (Wave 1 + Wave 8) on a Sovereign so
 # that `sandbox.openova.io/v1.Sandbox` CRs are actually reconciled.
 # Wave 8 extends the controller to ALSO render per-Sandbox pty-server
 # StatefulSet + MCP Deployment + Service + HTTPRoute (architecture.md
 # §7) — without this slot enabled, every Sandbox CR sits unreconciled.
+#
+# ─── Slot history: 61 → 19a (Wave 11 convergence fix, 2026-05-18) ────
+# Originally slot 61. Caught live on t16.omantel.biz: bp-sandbox HR
+# stuck Reconciling because its chart pull went through
+# harbor.<sov-fqdn> (bp-self-sovereign-cutover Step-06 phase-1 rewrites
+# every HelmRepository URL `oci://ghcr.io/openova-io` →
+# `oci://harbor.<sov-fqdn>/openova-io` after handover), but harbor.<sov
+# -fqdn> wasn't reachable yet because bp-harbor itself hadn't reached
+# Ready — chicken-and-egg. Same failure shape as Wave 7 #1610 with
+# bp-hcloud-csi (REMOVED — see kustomization.yaml comment block).
+#
+# Fix here is the cleaner long-term cousin of the Wave 7 hotfix:
+# instead of removing the slot, sequence it AFTER bp-harbor (slot 19)
+# by renumbering to 19a + adding `bp-harbor` to dependsOn. Once
+# bp-harbor is Ready (its chart pull goes through harbor.openova.io,
+# the mothership-warmed proxy-cache wired into k3s registries.yaml at
+# cloud-init time — NOT through harbor.<sov-fqdn>, so no cycle there),
+# this slot's chart pull can resolve against either ghcr.io
+# (pre-cutover) or harbor.<sov-fqdn> (post-cutover) and find the
+# artifact. The cutover Step-06 phase-1 URL rewrite is safe by then.
 
 ---
 apiVersion: source.toolkit.fluxcd.io/v1beta2
@@ -25,7 +45,7 @@ metadata:
   name: bp-sandbox
   namespace: flux-system
   labels:
-    catalyst.openova.io/slot: "61"
+    catalyst.openova.io/slot: "19a"
     catalyst.openova.io/component: sandbox-controller
 spec:
   interval: 15m
@@ -34,6 +54,17 @@ spec:
   dependsOn:
     - name: bp-vcluster-helmrepo
     - name: bp-catalyst-platform
+    # bp-harbor (slot 19, Wave 11 convergence fix 2026-05-18) — sandbox's
+    # chart pull goes through harbor.<sov-fqdn> after the post-handover
+    # cutover Step-06 phase-1 HelmRepository URL rewrite. Without this
+    # edge, source-controller hits harbor.<sov-fqdn> before bp-harbor
+    # is Ready, the OCI fetch 503s, and bp-sandbox sits Reconciling for
+    # the entire bootstrap-kit timeout window — preventing the umbrella
+    # Kustomization from ever reaching Ready. Same chicken-and-egg as
+    # Wave 7 #1610 (bp-hcloud-csi, REMOVED) but resolved by sequencing
+    # rather than removal so the slot remains available for Wave 11
+    # Sandbox MVP without manual Day-2 add-app re-introduction.
+    - name: bp-harbor
   chart:
     spec:
       chart: sandbox

--- a/clusters/_template/bootstrap-kit/kustomization.yaml
+++ b/clusters/_template/bootstrap-kit/kustomization.yaml
@@ -40,6 +40,26 @@ resources:
   # OR fix the pull path to bypass the registry pivot during bootstrap.
   - 18-seaweedfs.yaml
   - 19-harbor.yaml
+  # bp-sandbox (slot 19a) — sandbox-controller Wave 1 (PR #1622) + Wave 8
+  # pty-server / MCP / NEWAPI runtime wiring. Reconciles
+  # `sandbox.openova.io/v1.Sandbox` CRs into per-Sandbox manifests
+  # written into the per-Org `catalyst-tenant` Gitea repo.
+  #
+  # Wave 11 convergence fix (2026-05-18, caught on t16.omantel.biz):
+  # originally slot 61 — moved here after bp-harbor (slot 19) because the
+  # post-handover cutover (slot 06a, Step-06 phase-1) rewrites every
+  # HelmRepository URL `oci://ghcr.io/openova-io` →
+  # `oci://harbor.<sov-fqdn>/openova-io`, and the bp-sandbox chart pull
+  # then hits harbor.<sov-fqdn> BEFORE bp-harbor is Ready — chicken-and-
+  # egg. Same failure shape as Wave 7 #1610 with bp-hcloud-csi (REMOVED,
+  # see the slot-17a comment block above) but resolved here by
+  # sequencing rather than removal so the slot remains available for
+  # the Wave 11 Sandbox MVP without manual Day-2 add-app re-introduction.
+  # HR's dependsOn pins ordering to AFTER bp-harbor + bp-vcluster-
+  # helmrepo + bp-catalyst-platform. Gated default-OFF via
+  # ${SANDBOX_ENABLED:-false} on the bootstrap-kit Kustomization
+  # substitute — matches the chart's values.enabled default.
+  - 19a-bp-sandbox.yaml
   # 06a — Post-handover Self-Sovereignty Cutover (issue #791). Filename
   # carries the 06a prefix to colocate cohorts visually, but the slot's
   # dependsOn pins actual install order to AFTER bp-gitea (slot 10) and
@@ -124,16 +144,12 @@ resources:
   # this slot registers a live Flux source so per-TENANT vClusters can
   # be spawned by the Organization controller at runtime). Default-ON.
   - 60-bp-vcluster-helmrepo.yaml
-  # bp-sandbox (slot 61) — sandbox-controller Wave 1 (PR #1622). Reconciles
-  # `sandbox.openova.io/v1.Sandbox` CRs into per-Sandbox manifests written
-  # into the per-Org `catalyst-tenant` Gitea repo. Without this slot,
-  # Sandbox CRs sit unhandled — the controller never deploys. dependsOn
-  # bp-vcluster-helmrepo (slot 60, Wave 2 per-Sandbox vCluster source)
-  # and bp-catalyst-platform (slot 13, catalyst-system Namespace +
-  # catalyst-gitea-token Secret). Gated default-OFF via
-  # ${SANDBOX_ENABLED:-false} on the bootstrap-kit Kustomization
-  # substitute — matches the chart's values.enabled default.
-  - 61-bp-sandbox.yaml
+  # bp-sandbox MOVED 2026-05-18 (Wave 11 convergence fix) from slot 61
+  # to slot 19a (above, after bp-harbor) to break a chicken-and-egg
+  # cycle with harbor.<sov-fqdn> chart pulls during bootstrap. See the
+  # slot-19a comment block + 19a-bp-sandbox.yaml header for full
+  # diagnostic chain. No functional difference for operators — the
+  # SANDBOX_ENABLED knob still gates rendering identically.
   # bp-newapi (slot 80) — multi-tenant LLM marketplace gateway. Sequenced
   # after the W2.K1 dependency wave (cnpg/keycloak/openbao Ready) so
   # NewAPI's ExternalSecret + DSN dependencies resolve on first reconcile.


### PR DESCRIPTION
## Summary

- Caught live on t16.omantel.biz convergence: bp-sandbox HR stuck Reconciling because its chart pull goes through `harbor.<sov-fqdn>` (post-handover cutover slot 06a Step-06 phase-1 rewrites every HelmRepository URL `oci://ghcr.io/openova-io` → `oci://harbor.<sov-fqdn>/openova-io`), but `harbor.<sov-fqdn>` is not reachable yet because bp-harbor itself has not reached Ready — chicken-and-egg.
- Same failure shape as Wave 7 #1610 with bp-hcloud-csi (REMOVED). Chose the cleaner long-term cousin path (**Option B**): rather than remove the slot, sequence it AFTER bp-harbor (slot 19) by renumbering to 19a + adding `bp-harbor` to the HR's dependsOn graph. The Sandbox MVP Wave 11 slot stays available with no manual Day-2 add-app re-introduction needed.

## Why slot 19a (not removal)

bp-harbor itself does not hit the cycle because its chart pull goes through `harbor.openova.io` (the mothership-warmed proxy-cache wired into k3s `registries.yaml` at cloud-init time) — NOT through `harbor.<sov-fqdn>`. Once bp-harbor is Ready, this slot's chart pull can resolve against either `ghcr.io` (pre-cutover) or `harbor.<sov-fqdn>` (post-cutover) and find the artifact safely.

## Diff

- `clusters/_template/bootstrap-kit/61-bp-sandbox.yaml` renamed → `19a-bp-sandbox.yaml`; slot label `"61"` → `"19a"`; `dependsOn` adds `bp-harbor`; header documents the move + chicken-and-egg context.
- `clusters/_template/bootstrap-kit/kustomization.yaml`: `19a` slot inserted right after `19-harbor.yaml` with post-cutover URL-rewrite rationale inline; old slot-61 entry replaced with a back-pointer comment.

## Validation

`kubectl kustomize clusters/_template/bootstrap-kit/` renders clean:
- bp-sandbox HR keeps slot label (now `19a`)
- gains `- name: bp-harbor` in dependsOn (alongside existing bp-vcluster-helmrepo + bp-catalyst-platform)
- all other fields unchanged
- HelmRepository for bp-sandbox unchanged

No Chart.yaml bump (this is a bootstrap-kit Kustomization-only fix, not a chart change). READ-ONLY clusters per hard rules.

## Test plan

- [x] `kubectl kustomize clusters/_template/bootstrap-kit/` exit 0
- [x] bp-sandbox HR present with `slot: 19a`
- [x] `dependsOn` includes `bp-harbor`
- [x] Old slot-61 reference removed from kustomization resources list
- [ ] Verify on next fresh prov: bp-sandbox no longer blocks bootstrap-kit Ready
- [ ] Verify bp-harbor reaches Ready before bp-sandbox starts pulling (Flux dependsOn ordering)

🤖 Generated with [Claude Code](https://claude.com/claude-code)