### PR TITLE
feat(sandbox-mcp): sandbox.db.* real impl (CNPG provision/list/get/drop/dump)

### DIFF
--- a/products/sandbox/mcp-server/internal/tools/registry.go
+++ b/products/sandbox/mcp-server/internal/tools/registry.go
@@ -3,17 +3,21 @@
 // Each tool is registered with a fully-qualified name (matching the
 // namespaces enumerated in products/sandbox/docs/architecture.md §3)
 // plus a short description. Wave 2 shipped stubs only — every Call()
-// returned {"status":"not_implemented"}. Wave 8 (this file's current
-// shape) replaces the stubs for:
+// returned {"status":"not_implemented"}. Wave 8 replaced the stubs
+// for the read surface; Wave 11 (this file's current shape) extends
+// to per-Sandbox CNPG provisioning:
 //
 //   - gitea.repo.list / gitea.repo.get
 //   - gitea.pr.list / gitea.pr.get
 //   - k8s.read.get / k8s.read.list / k8s.read.watch
+//   - sandbox.db.provision / sandbox.db.list / sandbox.db.get /
+//     sandbox.db.drop / sandbox.db.dump
 //   - sandbox.session.whoami / sandbox.session.info
 //
-// All other namespaces (sandbox.db.*, sandbox.auth.*, sandbox.stripe.*,
-// sandbox.preview.*, k8s.write.*) remain stubbed and continue to return
-// not_implemented until Wave 8+ ships their backends.
+// All other namespaces (sandbox.auth.*, sandbox.stripe.*,
+// sandbox.preview.*, k8s.write.*, remaining gitea write surface)
+// remain stubbed and continue to return not_implemented until later
+// waves ship their backends.
 //
 // Wire model recap (architecture.md §3):
 //
@@ -341,11 +345,45 @@ func defaultCatalogue(env *Env) []Tool {
 		},
 		{Name: "k8s.read.logs", Description: "Fetch container logs for a pod (read-only).", InputSchema: anyObj},
 
-		// sandbox.db.* — Wave 8+ (CNPG provisioning).
-		{Name: "sandbox.db.provision", Description: "Provision a CNPG cluster (size + version). Returns Cluster CR ref.", InputSchema: anyObj},
-		{Name: "sandbox.db.list", Description: "List CNPG clusters owned by this Sandbox.", InputSchema: anyObj},
-		{Name: "sandbox.db.dump", Description: "Trigger a pg_dump-backed backup; returns object-store URL.", InputSchema: anyObj},
-		{Name: "sandbox.db.drop", Description: "Drop a CNPG cluster owned by this Sandbox.", InputSchema: anyObj},
+		// sandbox.db.* — CNPG provisioning (Wave 11 — sandbox_db.go).
+		// Every handler addresses env.SandboxNamespace; the agent
+		// cannot pass a namespace argument. RequiredCapability gates
+		// each call to bearers whose claims carry `sandbox.db`.
+		{
+			Name:               "sandbox.db.provision",
+			Description:        "Provision a CNPG Postgres Cluster CR in this Sandbox's namespace (default plan: 1 instance, 5Gi, postgres 16). Returns the connection envelope.",
+			InputSchema:        schemaSandboxDBProvision(),
+			Handler:            sandboxDBProvision,
+			RequiredCapability: "sandbox.db",
+		},
+		{
+			Name:               "sandbox.db.list",
+			Description:        "List CNPG Clusters provisioned by this Sandbox (filtered to openova.io/managed-by=openova-sandbox-mcp).",
+			InputSchema:        map[string]any{"type": "object", "additionalProperties": false},
+			Handler:            sandboxDBList,
+			RequiredCapability: "sandbox.db",
+		},
+		{
+			Name:               "sandbox.db.get",
+			Description:        "Get a single Sandbox-managed CNPG Cluster's status + connection envelope by name.",
+			InputSchema:        schemaSandboxDBNameOnly(),
+			Handler:            sandboxDBGet,
+			RequiredCapability: "sandbox.db",
+		},
+		{
+			Name:               "sandbox.db.drop",
+			Description:        "Delete a Sandbox-managed CNPG Cluster (CNPG operator cascades PVC/Service/Secret cleanup).",
+			InputSchema:        schemaSandboxDBNameOnly(),
+			Handler:            sandboxDBDrop,
+			RequiredCapability: "sandbox.db",
+		},
+		{
+			Name:               "sandbox.db.dump",
+			Description:        "Create a one-shot CNPG Backup CR (barman-cloud or volumeSnapshot per cluster config). Returns the Backup CR ref + configured S3 destinationPath.",
+			InputSchema:        schemaSandboxDBNameOnly(),
+			Handler:            sandboxDBDump,
+			RequiredCapability: "sandbox.db",
+		},
 
 		// sandbox.auth.* — Wave 8+ (Keycloak management).
 		{Name: "sandbox.auth.provisionRealm", Description: "Provision a Keycloak realm for an Application under this Sandbox.", InputSchema: anyObj},

--- a/products/sandbox/mcp-server/internal/tools/registry_test.go
+++ b/products/sandbox/mcp-server/internal/tools/registry_test.go
@@ -50,6 +50,7 @@ func TestRegistry_ListContainsCatalogue(t *testing.T) {
 		"sandbox.auth.registerClient",
 		"sandbox.db.drop",
 		"sandbox.db.dump",
+		"sandbox.db.get",
 		"sandbox.db.list",
 		"sandbox.db.provision",
 		"sandbox.session.info",
@@ -73,15 +74,23 @@ func TestRegistry_ListContainsCatalogue(t *testing.T) {
 }
 
 // TestRegistry_StubsReturnNotImplemented covers every tool we explicitly
-// kept stubbed for Wave 8.
+// kept stubbed.
+//
+// sandbox.db.* dropped out of this list in Wave 11 when sandbox_db.go
+// wired real handlers; sandbox.auth.*, k8s.read.logs, and the
+// remaining gitea write surface stay stubbed until later waves.
 func TestRegistry_StubsReturnNotImplemented(t *testing.T) {
 	r := NewRegistry(&Env{})
 	stubs := []string{
-		"sandbox.db.provision",
-		"sandbox.db.list",
 		"sandbox.auth.provisionRealm",
+		"sandbox.auth.listClients",
+		"sandbox.auth.registerClient",
 		"k8s.read.logs",
 		"gitea.pr.merge",
+		"gitea.pr.create",
+		"gitea.issue.list",
+		"gitea.issue.create",
+		"gitea.release.list",
 	}
 	for _, name := range stubs {
 		res, err := r.Call(context.Background(), name, nil, CallOpts{})

--- a/products/sandbox/mcp-server/internal/tools/sandbox_db.go
+++ b/products/sandbox/mcp-server/internal/tools/sandbox_db.go
@@ -1,0 +1,561 @@
+// sandbox_db.go — real handlers for sandbox.db.* (CNPG provisioning).
+//
+// Scope (architecture.md §3 + §5 + §7): apps the agent ships from inside
+// a Sandbox occasionally need their own Postgres. Rather than per-Org
+// shared databases (which would couple every app's downtime + tenancy
+// surface), Sandbox provides ON-DEMAND CNPG Cluster CRs in the Sandbox's
+// OWN namespace (`sandbox-<owner-uid>`). The upstream CNPG operator (the
+// `bp-cnpg` Application Blueprint, `platform/cnpg/README.md`) reconciles
+// those CRs into a real Postgres StatefulSet + Services + Secrets — the
+// MCP server only mutates the CR; it never touches the underlying Pods.
+//
+// PR #1645 (Wave 8) wired gitea.* + k8s.read.* + session.* but left
+// sandbox.db.* as not_implemented stubs. This file (Wave 11) ships the
+// real handlers using the same dynamic-client pattern as k8s_read.go.
+//
+// Tools shipped here:
+//
+//   - sandbox.db.provision {name, plan?} → POST a Cluster CR
+//   - sandbox.db.list                    → LIST Cluster CRs (sandbox ns)
+//   - sandbox.db.get {name}              → GET one Cluster CR
+//   - sandbox.db.drop {name}             → DELETE one Cluster CR
+//   - sandbox.db.dump {name}             → POST a one-shot Backup CR
+//
+// All five are scoped to env.SandboxNamespace — the agent CANNOT direct
+// the call at any other namespace inside the Org vcluster, even though
+// the k8s SA the pod runs as may have broader read powers.
+//
+// Auth: same shape as PR #1645 (gitea.* + k8s.read.*) — the bearer's
+// claims.OrgID must match env.OrgID, and every tool declares
+// RequiredCapability="sandbox.db" so claims without that capability
+// receive 403 from Registry.Call before reaching the handler.
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// CNPG GVRs (group=postgresql.cnpg.io, version=v1). Centralised so a
+// future operator version bump (v1 → v1beta1, etc.) is a one-line edit.
+var (
+	cnpgClusterGVR = schema.GroupVersionResource{Group: "postgresql.cnpg.io", Version: "v1", Resource: "clusters"}
+	cnpgBackupGVR  = schema.GroupVersionResource{Group: "postgresql.cnpg.io", Version: "v1", Resource: "backups"}
+)
+
+// cnpgManagedByLabel marks every Cluster CR the MCP server creates so
+// `sandbox.db.list` returns ONLY agent-provisioned databases (not
+// e.g. a per-Sandbox metadata Cluster the controller might own later).
+const (
+	cnpgManagedByLabel = "openova.io/managed-by"
+	cnpgManagedByValue = "openova-sandbox-mcp"
+	cnpgSandboxIDLabel = "openova.io/sandbox-id"
+)
+
+// cnpgNameRE enforces a conservative naming surface. CNPG itself accepts
+// any RFC-1123 label; we narrow to lowercase alnum + hyphen + 4..40 chars
+// so collisions with the operator's own status-resources
+// (`<cluster>-rw`, `<cluster>-r`, `<cluster>-1`) stay obvious.
+var cnpgNameRE = regexp.MustCompile(`^[a-z][a-z0-9-]{2,39}$`)
+
+// cnpgPlan binds the agent's `plan` argument to a CNPG resource shape.
+// Wave 11 ships ONE plan (`default`); future waves can map plan IDs to
+// instance count / storage / image without changing the tool surface.
+type cnpgPlan struct {
+	Instances    int    `json:"instances"`
+	StorageSize  string `json:"storage_size"`
+	StorageClass string `json:"storage_class,omitempty"`
+	Image        string `json:"image"`
+	Database     string `json:"database"`
+}
+
+// defaultCNPGPlan is the only plan Wave 11 honours: a single Pod, 5Gi
+// PVC, postgres 16 from CNPG's published image, with a default app DB.
+// Sized to be the cheapest useful sidecar — apps that need more should
+// graduate to a per-Org bp-cnpg-pair via the marketplace.
+func defaultCNPGPlan() cnpgPlan {
+	return cnpgPlan{
+		Instances:   1,
+		StorageSize: "5Gi",
+		Image:       "ghcr.io/cloudnative-pg/postgresql:16",
+		Database:    "app",
+	}
+}
+
+// --- argument types ----------------------------------------------------
+
+type sandboxDBProvisionArgs struct {
+	Name string `json:"name"`
+	Plan string `json:"plan,omitempty"`
+}
+
+type sandboxDBNameOnlyArgs struct {
+	Name string `json:"name"`
+}
+
+// --- helpers -----------------------------------------------------------
+
+// requireSandboxNS is the canonical scope-gate: every sandbox.db.* tool
+// MUST address the Sandbox's OWN namespace. The agent cannot pass a
+// `namespace` argument; we read it from env.
+func requireSandboxNS(ctx context.Context) (*Env, string, error) {
+	env := EnvFrom(ctx)
+	if env == nil {
+		return nil, "", errors.New("sandbox.db: server env missing on context")
+	}
+	if env.SandboxNamespace == "" {
+		return nil, "", errors.New("sandbox.db: server env has no SANDBOX_NAMESPACE")
+	}
+	return env, env.SandboxNamespace, nil
+}
+
+// validateCNPGName rejects names that would clash with operator-managed
+// child resources (`<name>-rw`, `<name>-1`) or that aren't valid
+// RFC-1123 labels.
+func validateCNPGName(name string) error {
+	if name == "" {
+		return errors.New("`name` is required")
+	}
+	if !cnpgNameRE.MatchString(name) {
+		return fmt.Errorf("`name` must match %s (lowercase alnum + hyphen, 4-40 chars, leading letter)", cnpgNameRE.String())
+	}
+	// CNPG sticks `-1`, `-2`, ... + `-rw`/`-ro`/`-r` on Service names; we
+	// already cap at 40 so a 4-char suffix won't exceed the 63-char DNS
+	// label limit.
+	return nil
+}
+
+// connectionEnvelope is the structured response sandbox.db.provision and
+// sandbox.db.get return so the agent can paste it directly into the
+// app's env (`postgres://app:<pw>@<host>:<port>/<dbname>`). CNPG writes
+// the password into Secret `<cluster>-app` (key=`password`) at install
+// time — the MCP server NEVER returns the password itself; the agent
+// mounts the Secret into its app pod.
+type connectionEnvelope struct {
+	Host       string `json:"host"`
+	Port       int    `json:"port"`
+	Database   string `json:"dbname"`
+	User       string `json:"user"`
+	SecretName string `json:"secretName"`
+	SecretKey  string `json:"secretKey"`
+	Cluster    string `json:"cluster"`
+	Namespace  string `json:"namespace"`
+}
+
+// connectionFor renders the canonical envelope for a Cluster named `name`
+// in `ns`. CNPG's defaults: write-Service = `<name>-rw`, port 5432, app
+// Secret = `<name>-app` (keys: `username`, `password`, `pgpass`, `uri`).
+func connectionFor(name, ns, database string) connectionEnvelope {
+	return connectionEnvelope{
+		Host:       fmt.Sprintf("%s-rw.%s.svc.cluster.local", name, ns),
+		Port:       5432,
+		Database:   database,
+		User:       database, // CNPG default: owner == database name.
+		SecretName: name + "-app",
+		SecretKey:  "password",
+		Cluster:    name,
+		Namespace:  ns,
+	}
+}
+
+// buildClusterCR constructs the Unstructured Cluster CR. Kept in its own
+// function so the unit tests can assert the rendered shape without
+// running against a live API server.
+func buildClusterCR(env *Env, name string, plan cnpgPlan) *unstructured.Unstructured {
+	labels := map[string]any{
+		cnpgManagedByLabel: cnpgManagedByValue,
+	}
+	if env.SandboxID != "" {
+		labels[cnpgSandboxIDLabel] = env.SandboxID
+	}
+	storage := map[string]any{
+		"size": plan.StorageSize,
+	}
+	if plan.StorageClass != "" {
+		storage["storageClass"] = plan.StorageClass
+	}
+	cr := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "postgresql.cnpg.io/v1",
+			"kind":       "Cluster",
+			"metadata": map[string]any{
+				"name":      name,
+				"namespace": env.SandboxNamespace,
+				"labels":    labels,
+				"annotations": map[string]any{
+					"openova.io/created-by": "sandbox.db.provision",
+				},
+			},
+			"spec": map[string]any{
+				"instances": int64(plan.Instances),
+				"imageName": plan.Image,
+				"storage":   storage,
+				"bootstrap": map[string]any{
+					"initdb": map[string]any{
+						"database": plan.Database,
+						"owner":    plan.Database,
+					},
+				},
+				"enableSuperuserAccess": false,
+			},
+		},
+	}
+	return cr
+}
+
+// buildBackupCR constructs the on-demand Backup CR sandbox.db.dump
+// submits. The CNPG operator picks it up, runs `barman-cloud-backup`
+// against the Cluster's `spec.backup.barmanObjectStore`, and writes the
+// resulting URL into `status.destinationPath`. With no barmanObjectStore
+// configured on a default-plan Cluster, the operator falls back to a
+// volumeSnapshot — either way the Backup CR's status carries the result
+// so the agent gets the same wire shape.
+func buildBackupCR(ns, clusterName string) *unstructured.Unstructured {
+	// Backup names must be unique per ns; tag with a UTC timestamp.
+	name := fmt.Sprintf("%s-dump-%s", clusterName, time.Now().UTC().Format("20060102-150405"))
+	return &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "postgresql.cnpg.io/v1",
+			"kind":       "Backup",
+			"metadata": map[string]any{
+				"name":      name,
+				"namespace": ns,
+				"labels": map[string]any{
+					cnpgManagedByLabel: cnpgManagedByValue,
+				},
+				"annotations": map[string]any{
+					"openova.io/created-by": "sandbox.db.dump",
+				},
+			},
+			"spec": map[string]any{
+				"cluster": map[string]any{
+					"name": clusterName,
+				},
+			},
+		},
+	}
+}
+
+// readCNPGStatusSummary distils the bits of Cluster.status the agent
+// usually wants: phase, readyInstances, conditions[type=Ready], the
+// rw/r/ro service names, and the bottom-line `currentPrimary`.
+// We deliberately do NOT echo the entire status sub-object — it's
+// noisy + version-volatile.
+func readCNPGStatusSummary(obj map[string]any) map[string]any {
+	st, _, _ := unstructured.NestedMap(obj, "status")
+	if st == nil {
+		return map[string]any{"phase": "Pending"}
+	}
+	out := map[string]any{}
+	for _, k := range []string{
+		"phase", "phaseReason", "instances", "readyInstances",
+		"currentPrimary", "targetPrimary", "writeService", "readService",
+	} {
+		if v, ok := st[k]; ok {
+			out[k] = v
+		}
+	}
+	// Conditions: surface only [Ready] for brevity.
+	if conds, found, _ := unstructured.NestedSlice(st, "conditions"); found {
+		for _, c := range conds {
+			cm, ok := c.(map[string]any)
+			if !ok {
+				continue
+			}
+			if cm["type"] == "Ready" {
+				out["ready"] = cm
+				break
+			}
+		}
+	}
+	return out
+}
+
+// --- sandbox.db.provision ----------------------------------------------
+
+func sandboxDBProvision(ctx context.Context, raw json.RawMessage) (any, error) {
+	var args sandboxDBProvisionArgs
+	if err := json.Unmarshal(raw, &args); err != nil {
+		return nil, fmt.Errorf("sandbox.db.provision: invalid arguments: %w", err)
+	}
+	if err := validateCNPGName(args.Name); err != nil {
+		return nil, fmt.Errorf("sandbox.db.provision: %w", err)
+	}
+	plan := defaultCNPGPlan()
+	// Wave 11 honours `plan` only as a free-form tag (only "default"
+	// implemented). Future waves can plug a plan registry here.
+	if args.Plan != "" && strings.ToLower(args.Plan) != "default" {
+		return nil, fmt.Errorf("sandbox.db.provision: unknown plan %q (only `default` available)", args.Plan)
+	}
+	env, ns, err := requireSandboxNS(ctx)
+	if err != nil {
+		return nil, err
+	}
+	client, err := dynamicClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+	cr := buildClusterCR(env, args.Name, plan)
+	created, err := client.Resource(cnpgClusterGVR).Namespace(ns).
+		Create(ctx, cr, metav1.CreateOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("sandbox.db.provision: create Cluster %s/%s: %w", ns, args.Name, err)
+	}
+	conn := connectionFor(args.Name, ns, plan.Database)
+	return map[string]any{
+		"status":     "Provisioning",
+		"connection": conn,
+		"plan": map[string]any{
+			"name":          "default",
+			"instances":     plan.Instances,
+			"storage_size":  plan.StorageSize,
+			"image":         plan.Image,
+			"database":      plan.Database,
+			"storage_class": plan.StorageClass,
+		},
+		"resourceVersion": created.GetResourceVersion(),
+		"uid":             string(created.GetUID()),
+		"note":            "CNPG operator will reconcile this CR; poll `sandbox.db.get name=<n>` until status.phase == \"Cluster in healthy state\".",
+	}, nil
+}
+
+func schemaSandboxDBProvision() map[string]any {
+	return map[string]any{
+		"type":     "object",
+		"required": []string{"name"},
+		"properties": map[string]any{
+			"name": map[string]any{
+				"type":        "string",
+				"description": "Cluster name (lowercase alnum + hyphen, 4-40 chars). Used as the Service prefix; `<name>-rw` is the writer endpoint.",
+				"pattern":     cnpgNameRE.String(),
+			},
+			"plan": map[string]any{
+				"type":        "string",
+				"description": "Plan ID. Wave 11 only ships `default` (1 instance, 5Gi, postgres 16).",
+				"enum":        []string{"default"},
+			},
+		},
+		"additionalProperties": false,
+	}
+}
+
+// --- sandbox.db.list ---------------------------------------------------
+
+func sandboxDBList(ctx context.Context, _ json.RawMessage) (any, error) {
+	_, ns, err := requireSandboxNS(ctx)
+	if err != nil {
+		return nil, err
+	}
+	client, err := dynamicClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+	list, err := client.Resource(cnpgClusterGVR).Namespace(ns).
+		List(ctx, metav1.ListOptions{
+			LabelSelector: cnpgManagedByLabel + "=" + cnpgManagedByValue,
+		})
+	if err != nil {
+		return nil, fmt.Errorf("sandbox.db.list: %w", err)
+	}
+	items := make([]map[string]any, 0, len(list.Items))
+	for i := range list.Items {
+		obj := list.Items[i].Object
+		name, _, _ := unstructured.NestedString(obj, "metadata", "name")
+		database, _, _ := unstructured.NestedString(obj, "spec", "bootstrap", "initdb", "database")
+		if database == "" {
+			database = "app"
+		}
+		items = append(items, map[string]any{
+			"name":              name,
+			"namespace":         ns,
+			"creationTimestamp": list.Items[i].GetCreationTimestamp().Time.UTC().Format(time.RFC3339),
+			"status":            readCNPGStatusSummary(obj),
+			"connection":        connectionFor(name, ns, database),
+		})
+	}
+	return map[string]any{
+		"namespace": ns,
+		"count":     len(items),
+		"items":     items,
+	}, nil
+}
+
+// --- sandbox.db.get ----------------------------------------------------
+
+func sandboxDBGet(ctx context.Context, raw json.RawMessage) (any, error) {
+	var args sandboxDBNameOnlyArgs
+	if err := json.Unmarshal(raw, &args); err != nil {
+		return nil, fmt.Errorf("sandbox.db.get: invalid arguments: %w", err)
+	}
+	if err := validateCNPGName(args.Name); err != nil {
+		return nil, fmt.Errorf("sandbox.db.get: %w", err)
+	}
+	_, ns, err := requireSandboxNS(ctx)
+	if err != nil {
+		return nil, err
+	}
+	client, err := dynamicClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+	obj, err := client.Resource(cnpgClusterGVR).Namespace(ns).
+		Get(ctx, args.Name, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("sandbox.db.get %s/%s: %w", ns, args.Name, err)
+	}
+	// Defence in depth: refuse to surface a Cluster that wasn't created
+	// by the MCP server (e.g. operator-internal pair clusters), even if
+	// the SA's RBAC let us read it. This stops a malicious sandbox from
+	// fishing for credentials of a per-Org shared DB by guessing names.
+	if obj.GetLabels()[cnpgManagedByLabel] != cnpgManagedByValue {
+		return nil, fmt.Errorf("sandbox.db.get: Cluster %s/%s is not Sandbox-managed (no %s=%s label)",
+			ns, args.Name, cnpgManagedByLabel, cnpgManagedByValue)
+	}
+	database, _, _ := unstructured.NestedString(obj.Object, "spec", "bootstrap", "initdb", "database")
+	if database == "" {
+		database = "app"
+	}
+	return map[string]any{
+		"name":              obj.GetName(),
+		"namespace":         ns,
+		"creationTimestamp": obj.GetCreationTimestamp().Time.UTC().Format(time.RFC3339),
+		"resourceVersion":   obj.GetResourceVersion(),
+		"uid":               string(obj.GetUID()),
+		"status":            readCNPGStatusSummary(obj.Object),
+		"connection":        connectionFor(args.Name, ns, database),
+	}, nil
+}
+
+func schemaSandboxDBNameOnly() map[string]any {
+	return map[string]any{
+		"type":     "object",
+		"required": []string{"name"},
+		"properties": map[string]any{
+			"name": map[string]any{
+				"type":    "string",
+				"pattern": cnpgNameRE.String(),
+			},
+		},
+		"additionalProperties": false,
+	}
+}
+
+// --- sandbox.db.drop ---------------------------------------------------
+
+func sandboxDBDrop(ctx context.Context, raw json.RawMessage) (any, error) {
+	var args sandboxDBNameOnlyArgs
+	if err := json.Unmarshal(raw, &args); err != nil {
+		return nil, fmt.Errorf("sandbox.db.drop: invalid arguments: %w", err)
+	}
+	if err := validateCNPGName(args.Name); err != nil {
+		return nil, fmt.Errorf("sandbox.db.drop: %w", err)
+	}
+	_, ns, err := requireSandboxNS(ctx)
+	if err != nil {
+		return nil, err
+	}
+	client, err := dynamicClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+	// Refuse to delete Clusters we didn't create (parity with get).
+	obj, err := client.Resource(cnpgClusterGVR).Namespace(ns).
+		Get(ctx, args.Name, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("sandbox.db.drop: lookup Cluster %s/%s: %w", ns, args.Name, err)
+	}
+	if obj.GetLabels()[cnpgManagedByLabel] != cnpgManagedByValue {
+		return nil, fmt.Errorf("sandbox.db.drop: refusing to delete non-Sandbox Cluster %s/%s", ns, args.Name)
+	}
+	// Foreground deletion so the operator finalises cleanup (PVCs,
+	// Services, Secrets) before the API server returns. Otherwise the
+	// agent could race a `provision` with the same name and hit a
+	// "PVC still exists" reconcile loop.
+	policy := metav1.DeletePropagationForeground
+	err = client.Resource(cnpgClusterGVR).Namespace(ns).
+		Delete(ctx, args.Name, metav1.DeleteOptions{
+			PropagationPolicy: &policy,
+		})
+	if err != nil {
+		return nil, fmt.Errorf("sandbox.db.drop: delete Cluster %s/%s: %w", ns, args.Name, err)
+	}
+	return map[string]any{
+		"status":    "Deleting",
+		"name":      args.Name,
+		"namespace": ns,
+		"note":      "CNPG operator is cascading the delete (Pods, PVCs, Services, app Secret). Use `sandbox.db.list` to confirm removal.",
+	}, nil
+}
+
+// --- sandbox.db.dump ---------------------------------------------------
+
+// sandboxDBDumpResponse is the structured envelope the dump tool returns.
+// `backup_name` lets the agent poll Backup status separately;
+// `destination_path` is the configured S3 prefix (when set on the
+// Cluster) so the agent can find the resulting WAL+base files without
+// the Backup status hop on a successful run.
+type sandboxDBDumpResponse struct {
+	Status          string `json:"status"`
+	Cluster         string `json:"cluster"`
+	BackupName      string `json:"backupName"`
+	Namespace       string `json:"namespace"`
+	DestinationPath string `json:"destinationPath,omitempty"`
+	Note            string `json:"note"`
+}
+
+func sandboxDBDump(ctx context.Context, raw json.RawMessage) (any, error) {
+	var args sandboxDBNameOnlyArgs
+	if err := json.Unmarshal(raw, &args); err != nil {
+		return nil, fmt.Errorf("sandbox.db.dump: invalid arguments: %w", err)
+	}
+	if err := validateCNPGName(args.Name); err != nil {
+		return nil, fmt.Errorf("sandbox.db.dump: %w", err)
+	}
+	_, ns, err := requireSandboxNS(ctx)
+	if err != nil {
+		return nil, err
+	}
+	client, err := dynamicClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+	// Same Sandbox-managed guard as drop/get — the dump endpoint reads
+	// from a real Cluster, and a malicious sandbox could otherwise force
+	// a backup against a per-Org pair Cluster (cheap CPU/IO attack).
+	cluster, err := client.Resource(cnpgClusterGVR).Namespace(ns).
+		Get(ctx, args.Name, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("sandbox.db.dump: lookup Cluster %s/%s: %w", ns, args.Name, err)
+	}
+	if cluster.GetLabels()[cnpgManagedByLabel] != cnpgManagedByValue {
+		return nil, fmt.Errorf("sandbox.db.dump: refusing to dump non-Sandbox Cluster %s/%s", ns, args.Name)
+	}
+	destPath, _, _ := unstructured.NestedString(cluster.Object,
+		"spec", "backup", "barmanObjectStore", "destinationPath")
+
+	backupCR := buildBackupCR(ns, args.Name)
+	created, err := client.Resource(cnpgBackupGVR).Namespace(ns).
+		Create(ctx, backupCR, metav1.CreateOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("sandbox.db.dump: create Backup %s/%s: %w", ns, args.Name, err)
+	}
+	return sandboxDBDumpResponse{
+		Status:          "Started",
+		Cluster:         args.Name,
+		BackupName:      created.GetName(),
+		Namespace:       ns,
+		DestinationPath: destPath,
+		Note: "CNPG operator will execute the backup via barman-cloud (or volumeSnapshot if no barmanObjectStore is configured). " +
+			"Poll the Backup CR's status.phase via k8s.read.get group=postgresql.cnpg.io version=v1 resource=backups.",
+	}, nil
+}
+

--- a/products/sandbox/mcp-server/internal/tools/sandbox_db_test.go
+++ b/products/sandbox/mcp-server/internal/tools/sandbox_db_test.go
@@ -1,0 +1,271 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	sharedauth "github.com/openova-io/openova/core/services/shared/auth"
+)
+
+// TestSandboxDBProvision_NameValidation covers the input-validation
+// guard rails before any RBAC / API hop. The handler runs WITHOUT a
+// live API server because it never gets past validation.
+func TestSandboxDBProvision_NameValidation(t *testing.T) {
+	cases := map[string]struct {
+		args    string
+		wantErr string
+	}{
+		"missing name":     {`{}`, "is required"},
+		"too short":        {`{"name":"db"}`, "must match"},
+		"uppercase":        {`{"name":"MyDB1"}`, "must match"},
+		"leading digit":    {`{"name":"1db"}`, "must match"},
+		"underscore":       {`{"name":"my_db"}`, "must match"},
+		"too long":         {`{"name":"` + strings.Repeat("a", 41) + `"}`, "must match"},
+		"unknown plan":     {`{"name":"mydb1","plan":"xxl"}`, "unknown plan"},
+		"trailing hyphen":  {`{"name":"mydb-"}`, ""}, // legal per CNPG, our regex allows it
+		"valid minimum":    {`{"name":"abcd"}`, ""},
+		"valid with plan":  {`{"name":"mydb1","plan":"default"}`, ""},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			// No env / no real client — the validation runs first.
+			// For valid names the call will progress to requireSandboxNS
+			// (which fails because we passed an empty ctx); that's a
+			// different error string, so we only assert the validation
+			// error when expected.
+			ctx := WithEnv(context.Background(), &Env{SandboxNamespace: "sandbox-uid-1"})
+			_, err := sandboxDBProvision(ctx, json.RawMessage(tc.args))
+			if tc.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+					t.Errorf("err = %v, want substring %q", err, tc.wantErr)
+				}
+				return
+			}
+			// Valid-name path: we expect the call to fall through to the
+			// dynamicClient build (no kubeconfig + no SA → some build
+			// error). The point is validation did NOT trip.
+			if err == nil {
+				return
+			}
+			// Validation errors carry "sandbox.db.provision:" but not
+			// "must match" / "is required" / "unknown plan".
+			low := err.Error()
+			for _, bad := range []string{"must match", "is required", "unknown plan"} {
+				if strings.Contains(low, bad) {
+					t.Errorf("unexpected validation error for valid input: %v", err)
+				}
+			}
+		})
+	}
+}
+
+// TestBuildClusterCR_DefaultPlanShape asserts the rendered CR matches
+// what the CNPG operator expects (postgresql.cnpg.io/v1 Cluster +
+// bootstrap.initdb.database).
+func TestBuildClusterCR_DefaultPlanShape(t *testing.T) {
+	env := &Env{
+		SandboxID:        "emrah",
+		SandboxNamespace: "sandbox-uid-1",
+	}
+	cr := buildClusterCR(env, "mydb1", defaultCNPGPlan())
+	if got := cr.GetAPIVersion(); got != "postgresql.cnpg.io/v1" {
+		t.Errorf("apiVersion=%q want postgresql.cnpg.io/v1", got)
+	}
+	if got := cr.GetKind(); got != "Cluster" {
+		t.Errorf("kind=%q want Cluster", got)
+	}
+	if got := cr.GetName(); got != "mydb1" {
+		t.Errorf("name=%q want mydb1", got)
+	}
+	if got := cr.GetNamespace(); got != "sandbox-uid-1" {
+		t.Errorf("namespace=%q want sandbox-uid-1", got)
+	}
+	labels := cr.GetLabels()
+	if labels[cnpgManagedByLabel] != cnpgManagedByValue {
+		t.Errorf("managed-by label=%q want %q", labels[cnpgManagedByLabel], cnpgManagedByValue)
+	}
+	if labels[cnpgSandboxIDLabel] != "emrah" {
+		t.Errorf("sandbox-id label=%q want emrah", labels[cnpgSandboxIDLabel])
+	}
+	spec, ok := cr.Object["spec"].(map[string]any)
+	if !ok {
+		t.Fatalf("spec type %T", cr.Object["spec"])
+	}
+	if spec["instances"].(int64) != 1 {
+		t.Errorf("instances=%v want 1", spec["instances"])
+	}
+	if !strings.Contains(spec["imageName"].(string), "postgresql:16") {
+		t.Errorf("imageName=%v want postgres 16", spec["imageName"])
+	}
+	storage := spec["storage"].(map[string]any)
+	if storage["size"] != "5Gi" {
+		t.Errorf("storage.size=%v want 5Gi", storage["size"])
+	}
+	bootstrap := spec["bootstrap"].(map[string]any)
+	initdb := bootstrap["initdb"].(map[string]any)
+	if initdb["database"] != "app" || initdb["owner"] != "app" {
+		t.Errorf("initdb=%+v want database+owner=app", initdb)
+	}
+	if spec["enableSuperuserAccess"] != false {
+		t.Errorf("enableSuperuserAccess=%v want false", spec["enableSuperuserAccess"])
+	}
+}
+
+// TestConnectionFor_CNPGDefaults asserts the canonical envelope agents
+// receive — host = `<name>-rw.<ns>.svc.cluster.local`, port 5432, secret
+// = `<name>-app`.
+func TestConnectionFor_CNPGDefaults(t *testing.T) {
+	conn := connectionFor("mydb1", "sandbox-uid-1", "app")
+	want := connectionEnvelope{
+		Host:       "mydb1-rw.sandbox-uid-1.svc.cluster.local",
+		Port:       5432,
+		Database:   "app",
+		User:       "app",
+		SecretName: "mydb1-app",
+		SecretKey:  "password",
+		Cluster:    "mydb1",
+		Namespace:  "sandbox-uid-1",
+	}
+	if conn != want {
+		t.Errorf("conn=%+v want %+v", conn, want)
+	}
+}
+
+// TestBuildBackupCR_LabelsAndRef asserts the on-demand Backup CR carries
+// the cluster ref + the managed-by label so it sweeps cleanly when the
+// agent later drops the Cluster.
+func TestBuildBackupCR_LabelsAndRef(t *testing.T) {
+	cr := buildBackupCR("sandbox-uid-1", "mydb1")
+	if got := cr.GetKind(); got != "Backup" {
+		t.Errorf("kind=%q want Backup", got)
+	}
+	if got := cr.GetNamespace(); got != "sandbox-uid-1" {
+		t.Errorf("ns=%q want sandbox-uid-1", got)
+	}
+	if !strings.HasPrefix(cr.GetName(), "mydb1-dump-") {
+		t.Errorf("name=%q want prefix mydb1-dump-", cr.GetName())
+	}
+	if cr.GetLabels()[cnpgManagedByLabel] != cnpgManagedByValue {
+		t.Errorf("managed-by label missing")
+	}
+	spec := cr.Object["spec"].(map[string]any)
+	cluster := spec["cluster"].(map[string]any)
+	if cluster["name"] != "mydb1" {
+		t.Errorf("spec.cluster.name=%v want mydb1", cluster["name"])
+	}
+}
+
+// TestRequireSandboxNS_GuardsEmpty makes sure no sandbox.db.* handler
+// can race past namespace-resolution into a default-namespace call.
+func TestRequireSandboxNS_GuardsEmpty(t *testing.T) {
+	t.Run("no env on ctx", func(t *testing.T) {
+		_, _, err := requireSandboxNS(context.Background())
+		if err == nil || !strings.Contains(err.Error(), "server env missing") {
+			t.Errorf("err = %v, want missing env", err)
+		}
+	})
+	t.Run("env with empty namespace", func(t *testing.T) {
+		ctx := WithEnv(context.Background(), &Env{OrgID: "acme"})
+		_, _, err := requireSandboxNS(ctx)
+		if err == nil || !strings.Contains(err.Error(), "no SANDBOX_NAMESPACE") {
+			t.Errorf("err = %v, want missing namespace", err)
+		}
+	})
+	t.Run("env populated", func(t *testing.T) {
+		ctx := WithEnv(context.Background(), &Env{SandboxNamespace: "sandbox-uid-1"})
+		env, ns, err := requireSandboxNS(ctx)
+		if err != nil {
+			t.Fatalf("err = %v, want nil", err)
+		}
+		if ns != "sandbox-uid-1" || env == nil {
+			t.Errorf("got env=%v ns=%q", env, ns)
+		}
+	})
+}
+
+// TestSandboxDBCapabilityGate confirms the registry rejects sandbox.db.*
+// calls whose claims lack the `sandbox.db` capability. Uses a registry
+// in production mode (JWTSecret set) so the cap check fires.
+func TestSandboxDBCapabilityGate(t *testing.T) {
+	r := NewRegistry(&Env{
+		OrgID:            "acme",
+		JWTSecret:        []byte("x"),
+		SandboxNamespace: "sandbox-uid-1",
+	})
+	for _, name := range []string{
+		"sandbox.db.provision", "sandbox.db.list", "sandbox.db.get",
+		"sandbox.db.drop", "sandbox.db.dump",
+	} {
+		t.Run(name, func(t *testing.T) {
+			// Caller missing sandbox.db cap → 403.
+			cl := &sharedauth.Claims{OrgID: "acme", Capabilities: []string{"sandbox.session"}}
+			args := json.RawMessage(`{"name":"mydb1"}`)
+			_, err := r.Call(context.Background(), name, args, CallOpts{Claims: cl})
+			if err == nil || !strings.Contains(err.Error(), "forbidden") {
+				t.Errorf("missing cap: err = %v, want forbidden", err)
+			}
+		})
+	}
+}
+
+// TestSandboxDBProvision_PlanRejection asserts unknown plan names error
+// before any cluster call. Runs against the registry so the auth gate +
+// the validation gate both fire.
+func TestSandboxDBProvision_PlanRejection(t *testing.T) {
+	r := NewRegistry(&Env{
+		OrgID:            "acme",
+		JWTSecret:        []byte("x"),
+		SandboxNamespace: "sandbox-uid-1",
+	})
+	cl := &sharedauth.Claims{OrgID: "acme", Capabilities: []string{"sandbox.db"}}
+	args := json.RawMessage(`{"name":"mydb1","plan":"xxl"}`)
+	_, err := r.Call(context.Background(), "sandbox.db.provision", args, CallOpts{Claims: cl})
+	if err == nil || !strings.Contains(err.Error(), "unknown plan") {
+		t.Errorf("err = %v, want unknown plan", err)
+	}
+}
+
+// TestReadCNPGStatusSummary_PendingFallback covers the empty-status path
+// (newly created Cluster before the operator's first reconcile).
+func TestReadCNPGStatusSummary_PendingFallback(t *testing.T) {
+	out := readCNPGStatusSummary(map[string]any{})
+	if out["phase"] != "Pending" {
+		t.Errorf("empty status: phase=%v want Pending", out["phase"])
+	}
+}
+
+// TestReadCNPGStatusSummary_ReadyCondition asserts the helper surfaces
+// the operator's terminal Ready condition without echoing the full
+// status sub-tree.
+func TestReadCNPGStatusSummary_ReadyCondition(t *testing.T) {
+	in := map[string]any{
+		"status": map[string]any{
+			"phase":          "Cluster in healthy state",
+			"readyInstances": int64(1),
+			"instances":      int64(1),
+			"currentPrimary": "mydb1-1",
+			"writeService":   "mydb1-rw",
+			"conditions": []any{
+				map[string]any{
+					"type":   "Ready",
+					"status": "True",
+					"reason": "ClusterIsReady",
+				},
+				map[string]any{
+					"type":   "ContinuousArchiving",
+					"status": "False",
+				},
+			},
+		},
+	}
+	out := readCNPGStatusSummary(in)
+	if out["phase"] != "Cluster in healthy state" {
+		t.Errorf("phase=%v", out["phase"])
+	}
+	ready, ok := out["ready"].(map[string]any)
+	if !ok || ready["status"] != "True" || ready["type"] != "Ready" {
+		t.Errorf("ready cond not surfaced: %+v", out)
+	}
+}


### PR DESCRIPTION
## Summary
- Replaces the not_implemented stubs PR #1645 left for `sandbox.db.*` with real handlers backed by the upstream CNPG operator.
- Five tools — `provision`, `list`, `get`, `drop`, `dump` — all scoped to the Sandbox's own namespace, all gated on `RequiredCapability=sandbox.db` + `claims.OrgID==env.OrgID` (same shape PR #1645 uses for gitea + k8s.read).
- New tool `sandbox.db.get` added (was absent from the catalogue).

## Tools

| Tool | Args | Effect | Returns |
|---|---|---|---|
| `sandbox.db.provision` | `{name, plan?}` | POSTs a `postgresql.cnpg.io/v1 Cluster` CR in `env.SandboxNamespace` with 1 instance, 5Gi PVC, postgres 16, `bootstrap.initdb.database=app`. | `{host:"<name>-rw.<ns>.svc.cluster.local", port:5432, dbname, user, secretName:"<name>-app", secretKey:"password"}` + plan + resourceVersion/uid |
| `sandbox.db.list` | _none_ | LIST filtered to `openova.io/managed-by=openova-sandbox-mcp` so per-Org pair DBs never leak. | per-item connection envelope + distilled status (phase, readyInstances, Ready condition) |
| `sandbox.db.get` | `{name}` | GET one Cluster; refuses non-Sandbox-managed Clusters. | full envelope + status summary |
| `sandbox.db.drop` | `{name}` | DELETE with `PropagationPolicy=Foreground` so the operator cascades PVCs/Services/Secrets. Same managed-by guard. | `{status:"Deleting", name, namespace}` |
| `sandbox.db.dump` | `{name}` | POSTs a one-shot `Backup` CR (`<cluster>-dump-<UTC>`). | `{backupName, destinationPath}` (the cluster's barmanObjectStore prefix when configured) |

## Why CNPG Cluster CRs (not a shared per-Org DB)
Per architecture.md §3 + §5 + §7. Per-app DBs keep tenancy / backup / restart blast-radius per-app. Cluster CRs land in the Sandbox's OWN namespace (`sandbox-<owner-uid>`); the agent cannot pass `namespace` — it's read from `env.SandboxNamespace`. The MCP server never touches Pods/PVCs/Services — bp-cnpg owns those.

## Auth shape (parity with PR #1645)
- `claims.OrgID == env.OrgID` or 403.
- `RequiredCapability=sandbox.db` on every tool — bearers without that cap get `forbidden` from `Registry.Call` before reaching the handler.
- Defence-in-depth: `get`/`drop`/`dump` refuse any Cluster lacking `openova.io/managed-by=openova-sandbox-mcp`, even if the SA's RBAC permits read.

## Hard rules respected
- READ-ONLY at the host cluster — every CR write happens inside the Sandbox's own namespace via the same SA the sandbox-controller already wires.
- NO chart bump.
- `go build` + `go vet` + `go test` clean (28 tests pass, 9 new + 19 existing).

## Test plan
- [x] `go test ./internal/tools/...` (locally, go 1.23.4): 28 tests pass.
- [x] `go vet ./...`: clean.
- [x] Catalogue test updated for new `sandbox.db.get`.
- [x] Stub-test list updated: `sandbox.db.*` removed, `sandbox.auth.*` + remaining gitea write stubs kept.
- [ ] Integration verification on a live Sovereign: `mcp-client tools/call sandbox.db.provision name=mydb1` → CNPG operator reconciles → `kubectl -n sandbox-<uid> get cluster mydb1` shows `Cluster in healthy state`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)