### PR TITLE
fix(newapi): gate channel render on attestation present (was blocking install when accountId env empty)

### DIFF
--- a/clusters/_template/bootstrap-kit/80-newapi.yaml
+++ b/clusters/_template/bootstrap-kit/80-newapi.yaml
@@ -104,7 +104,19 @@ spec:
       # for service "external-secrets-webhook"` on every fresh provision,
       # blocking the chart from reaching Ready and the Catalyst signup
       # hook (ADR-0003 §3.2) from finding the admin-token Secret.
-      version: 1.4.6
+      # 1.4.10 (fix-convergence-wave11, 2026-05-18): gate the
+      # defaultChannels.qwenBankDhofar entry on attestation-complete
+      # rather than hard-failing the helm template. Pre-1.4.10 the
+      # chart raised `commercial-contract attestation requires accountId`
+      # on every Sovereign that opted in to marketplace
+      # (MARKETPLACE_ENABLED=true) without ALSO supplying a signed
+      # commercial contract's `LLM_BANK_DHOFAR_ACCOUNT_ID` /
+      # `LLM_BANK_DHOFAR_CONTRACT_REF` envsubst variables. Post-1.4.10
+      # the chart silently skips the qwenBankDhofar channel when
+      # attestation is incomplete; once the operator overlay supplies
+      # the attestation values the channel composes on the next
+      # reconcile.
+      version: 1.4.10
       sourceRef:
         kind: HelmRepository
         name: bp-newapi

--- a/platform/newapi/chart/Chart.yaml
+++ b/platform/newapi/chart/Chart.yaml
@@ -126,7 +126,27 @@ name: bp-newapi
 # webhook-readiness-job hook image switched from curlimages/curl:8.10.1
 # to harbor.openova.io/proxy-dockerhub/curlimages/curl:8.10.1 per
 # CLAUDE.md inviolable rule.
-version: 1.4.9
+#
+# 1.4.10 (fix-convergence-wave11, 2026-05-18): gate the
+# defaultChannels.qwenBankDhofar entry on attestation-complete instead
+# of hard-failing the helm template when commercial-contract attestation
+# fields are empty. PR #1631 added envsubst placeholders
+# `${LLM_BANK_DHOFAR_ACCOUNT_ID:-}` / `${LLM_BANK_DHOFAR_CONTRACT_REF:-}`
+# in the bootstrap-kit overlay so franchised Sovereigns can opt in to
+# marketplace without supplying real attestation; but the chart's
+# `assertChannelAttestation` helper still raised `commercial-contract
+# attestation requires accountId` and the install crashed on every
+# Sovereign that flipped `MARKETPLACE_ENABLED=true` without a signed
+# commercial contract. Fix: in `bp-newapi.effectiveChannels` (and the
+# matching `channel-seed-job.yaml` gate), SKIP composing the
+# qwenBankDhofar channel when attestation.kind=commercial-contract AND
+# either accountId or contractRef is empty. NewAPI installs with zero
+# default channels; operator-supplied channels still compose. Once
+# the operator overlay supplies the attestation values the channel
+# composes on the next reconcile. helm template renders cleanly with
+# BOTH the missing-attestation state (no channel) AND the
+# fully-populated state (channel composed normally).
+version: 1.4.10
 appVersion: "0.13.2"
 description: |
   Catalyst Blueprint scratch chart for NewAPI — multi-tenant LLM

--- a/platform/newapi/chart/templates/_helpers.tpl
+++ b/platform/newapi/chart/templates/_helpers.tpl
@@ -79,19 +79,40 @@ channel-seed-job.yaml operate on the same materialised list.
 {{- define "bp-newapi.effectiveChannels" -}}
 {{- $channels := list -}}
 {{- $dc := .Values.defaultChannels | default dict -}}
-{{/* ── Channel #1: Qwen3.6 @ BankDhofar (#915) ───────────────── */}}
+{{/* ── Channel #1: Qwen3.6 @ BankDhofar (#915) ─────────────────
+     Attestation gate (PR #1631 follow-up, 2026-05-18): franchised
+     Sovereigns set `MARKETPLACE_ENABLED=true` to flip qbd.enabled true,
+     but cloud-init may not yet have `LLM_BANK_DHOFAR_ACCOUNT_ID` /
+     `LLM_BANK_DHOFAR_CONTRACT_REF` set (no commercial contract signed
+     yet for that Sovereign). The envsubst defaults leave accountId /
+     contractRef as empty strings, which makes `assertChannelAttestation`
+     fail the install with `commercial-contract attestation requires
+     accountId`.
+
+     Fix: SKIP composing the qwenBankDhofar channel when
+     attestation.kind=commercial-contract AND accountId/contractRef are
+     empty. The Sovereign installs newapi with zero default channels
+     (operator-supplied channels still compose). Once the commercial
+     contract lands, the operator overlays the attestation values and
+     the channel composes on the next reconcile. */}}
 {{- $qbd := $dc.qwenBankDhofar | default dict -}}
-{{- if $qbd.enabled -}}
+{{- $qbdAtt := $qbd.attestation | default (dict "kind" "commercial-contract") -}}
+{{- $qbdAttReady := true -}}
+{{- if and $qbd.enabled (eq (default "" $qbdAtt.kind) "commercial-contract") -}}
+  {{- if or (not $qbdAtt.accountId) (not $qbdAtt.contractRef) -}}
+    {{- $qbdAttReady = false -}}
+  {{- end -}}
+{{- end -}}
+{{- if and $qbd.enabled $qbdAttReady -}}
   {{- if not $qbd.endpoint -}}
     {{- fail "defaultChannels.qwenBankDhofar.enabled=true but defaultChannels.qwenBankDhofar.endpoint is empty — supply the upstream relay URL in the per-Sovereign bootstrap-kit overlay (canonical: https://llm-api.omtd.bankdhofar.com)" -}}
   {{- end -}}
-  {{- $att := $qbd.attestation | default (dict "kind" "commercial-contract") -}}
   {{- $composed := dict
         "name"      (default "qwen3.6-bankdhofar" $qbd.name)
         "type"      "openai-compatible"
         "endpoint"  $qbd.endpoint
         "models"    (default (list "qwen3.6" "qwen3-coder") $qbd.models)
-        "attestation" $att -}}
+        "attestation" $qbdAtt -}}
   {{- if $qbd.existingSecret -}}
     {{- $_ := set $composed "existingSecret" $qbd.existingSecret -}}
   {{- end -}}

--- a/platform/newapi/chart/templates/channel-seed-job.yaml
+++ b/platform/newapi/chart/templates/channel-seed-job.yaml
@@ -56,7 +56,18 @@ Issue #915, 2026-05-05.
 */}}
 {{- $cs := .Values.channelSeed | default dict -}}
 {{- $qbd := (.Values.defaultChannels | default dict).qwenBankDhofar | default dict -}}
-{{- $hasDefaults := $qbd.enabled -}}
+{{- /* Mirror the attestation gate from _helpers.tpl effectiveChannels:
+       skip seeding when commercial-contract attestation is incomplete.
+       Otherwise the Job would POST a channel whose ConfigMap row was
+       omitted from /etc/newapi/channels.yaml. */}}
+{{- $qbdAtt := $qbd.attestation | default (dict "kind" "commercial-contract") -}}
+{{- $qbdAttReady := true -}}
+{{- if and $qbd.enabled (eq (default "" $qbdAtt.kind) "commercial-contract") -}}
+  {{- if or (not $qbdAtt.accountId) (not $qbdAtt.contractRef) -}}
+    {{- $qbdAttReady = false -}}
+  {{- end -}}
+{{- end -}}
+{{- $hasDefaults := and $qbd.enabled $qbdAttReady -}}
 {{- $masterKeySecret := .Values.auth.adminUI.masterKeySecret | default "" -}}
 {{- if and $cs.enabled $hasDefaults $masterKeySecret -}}
 {{- $jobName := include "bp-newapi.channelSeedJobName" . -}}


### PR DESCRIPTION
## Summary

- Convergence wave 11 blocker on t16: `bp-newapi` HR install crashed on every Sovereign that opted in to marketplace (`MARKETPLACE_ENABLED=true`) without ALSO supplying signed-commercial-contract envsubst variables — the chart's `assertChannelAttestation` helper hard-failed with `channel[0] (qwen3.6-bankdhofar): commercial-contract attestation requires accountId`.
- **Option A** (smallest change): in `bp-newapi.effectiveChannels` and the mirrored gate in `channel-seed-job.yaml`, SKIP composing the qwenBankDhofar channel when `attestation.kind=commercial-contract` AND either `accountId` or `contractRef` is empty. NewAPI installs with zero default channels (operator-supplied `.Values.channels` still compose); the channel auto-composes on the next reconcile once the operator overlay supplies the attestation values.
- Chart bumped `1.4.9 → 1.4.10`; bootstrap-kit overlay pin bumped `1.4.6 → 1.4.10` so franchised Sovereigns immediately pick up the fix.

## Verification (`helm template platform/newapi/chart`)

All three states render cleanly:

| State | qbd.enabled | accountId | contractRef | Result |
|---|---|---|---|---|
| default | false | — | — | no qbd channel, no seed Job |
| **post-fix (was crashing)** | true | `""` | `""` | no qbd channel, no seed Job |
| fully configured | true | `BD-123456` | `internal://...` | qbd channel composed, seed Job emitted |

Pre-1.4.10 row 2 hard-failed with `commercial-contract attestation requires accountId`.

## Test plan

- [x] `helm template platform/newapi/chart` (default values) — renders 0 default channels, no seed Job
- [x] `helm template -f attestation-empty.yaml` (qbd.enabled=true, accountId/contractRef both `""`) — renders 0 default channels, no seed Job (NEW path that was broken)
- [x] `helm template -f attestation-full.yaml` (qbd.enabled=true, accountId+contractRef present) — qbd channel composed, channel-seed Job + RBAC + ConfigMap emitted
- [ ] Post-merge: `build-bp-newapi.yaml` CI triggers, publishes `bp-newapi:1.4.10` (or `1.4.11` after CI's auto-bump) to GHCR OCI
- [ ] Post-merge: t16 (and future Sovereigns at `MARKETPLACE_ENABLED=true` without commercial contract) progress past the bp-newapi install crash; channel #1 absent until operator overlay supplies attestation values

## Hard rules respected

- READ-ONLY clusters
- NO Chart.yaml bump on `bp-catalyst-platform`
- helm template renders clean in BOTH states (with + without accountId)

Branch: `fix-convergence-wave11-newapi-attestation-optional`

🤖 Generated with [Claude Code](https://claude.com/claude-code)