### PR TITLE
feat(sandbox): sandbox.<sov-fqdn> public URL — DNS + Gateway listener wire (HTTPRoute from #1641 had nothing to attach to)

### DIFF
--- a/clusters/_template/sovereign-tls/cilium-gateway-cert.yaml
+++ b/clusters/_template/sovereign-tls/cilium-gateway-cert.yaml
@@ -74,3 +74,14 @@ spec:
     - "openova-flow.${SOVEREIGN_FQDN}"
     - "guacamole.${SOVEREIGN_FQDN}"
     - "marketplace.${SOVEREIGN_FQDN}"
+    # sandbox.<sov-fqdn> — public URL for the per-Sandbox pty-server (PR #1641).
+    # The sandbox-controller renders an HTTPRoute on sandbox.<sov-fqdn>/
+    # sessions/<owner-uid>/* attached to the cilium-gateway. The wildcard
+    # `*.<sov-fqdn>` Gateway listener already matches the hostname, but the
+    # per-name SAN cert here must include `sandbox.<sov-fqdn>` for
+    # cilium-envoy to serve the right cert (otherwise browsers see
+    # NET::ERR_CERT_COMMON_NAME_INVALID). Matches the entry in
+    # products/catalyst/bootstrap/api/internal/handler/sovereign_dns_records.go
+    # CanonicalSovereignSubdomains so the parent-zone A-record set + cert
+    # SAN list stay aligned.
+    - "sandbox.${SOVEREIGN_FQDN}"

--- a/core/controllers/sandbox/internal/controller/sandbox_controller_test.go
+++ b/core/controllers/sandbox/internal/controller/sandbox_controller_test.go
@@ -488,8 +488,13 @@ func TestReconcile_Wave8RuntimeShape(t *testing.T) {
 		"kind: HTTPRoute",
 		`- "sandbox.omantel.omani.works"`,
 		"value: /sessions/ceo-at-acme-com/",
-		"name: catalyst-public",
-		"namespace: catalyst-system",
+		// Sandbox HTTPRoute now attaches to the canonical Cilium Gateway
+		// (cilium-gateway/kube-system) so the wildcard *.<sov-fqdn>
+		// listener serves traffic to sandbox.<sov-fqdn>. The previous
+		// "catalyst-public/catalyst-system/https" parentRefs pointed at a
+		// Gateway that doesn't exist on a Sovereign.
+		"name: cilium-gateway",
+		"namespace: kube-system",
 		"name: pty-server",
 		"port: 7681",
 	} {

--- a/core/controllers/sandbox/internal/gitops/manifests.go
+++ b/core/controllers/sandbox/internal/gitops/manifests.go
@@ -440,10 +440,20 @@ metadata:
     openova.io/sandbox: {{ .Name }}
     openova.io/managed-by: catalyst
 spec:
+  # Attach to the canonical Cilium Gateway on the host cluster. PR #1641
+  # originally targeted "catalyst-public/catalyst-system/https" — that
+  # Gateway does not exist on a Sovereign. The real public Gateway is
+  # cilium-gateway/kube-system (clusters/_template/sovereign-tls/
+  # cilium-gateway.yaml), matching the placement organization-controller's
+  # tenant_route.go and products/catalyst/chart/templates/httproute.yaml
+  # already use. sectionName is intentionally omitted so the HTTPRoute
+  # attaches to every listener whose hostname matches "sandbox.<sov-fqdn>"
+  # — currently the wildcard *.${SOVEREIGN_FQDN} HTTPS listener
+  # (https-<sov-fqdn-dashed>) per infra/hetzner/main.tf
+  # locals.parent_domains_listeners_yaml fallback path.
   parentRefs:
-    - name: catalyst-public
-      namespace: catalyst-system
-      sectionName: https
+    - name: cilium-gateway
+      namespace: kube-system
   hostnames:
     - "sandbox.{{ .SovereignFQDN }}"
   rules:

--- a/products/catalyst/bootstrap/api/internal/handler/sovereign_dns_records.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sovereign_dns_records.go
@@ -64,6 +64,13 @@ var CanonicalSovereignSubdomains = []string{
 	"marketplace",
 	"api",
 	"guacamole",
+	// sandbox — public URL for the Sandbox product's per-Sandbox
+	// pty-server StatefulSet (PR #1641 rendered the per-Sandbox
+	// HTTPRoute at sandbox.<sov-fqdn>/sessions/<owner-uid>/*; without
+	// this entry the parent zone returns NXDOMAIN and browsers cannot
+	// reach the URL even though the Gateway listener + HTTPRoute exist).
+	// Matches the cilium-gateway-cert.yaml SAN list (sandbox.<sov-fqdn>).
+	"sandbox",
 }
 
 // upsertSovereignParentZoneRecords PATCHes the parent zone with A


### PR DESCRIPTION
## Summary

PR #1641 introduced a per-Sandbox HTTPRoute on `sandbox.<sov-fqdn>/sessions/<owner-uid>/*` but three independent gaps blocked the URL from resolving end-to-end:

1. **HTTPRoute parentRefs were wrong**: `catalyst-public/catalyst-system/https` Gateway does not exist on a Sovereign. The canonical public Gateway is `cilium-gateway/kube-system` (same parent the org-controller's `tenant_route.go` and the chart's `httproute.yaml` attach to). Switched parentRefs to `cilium-gateway/kube-system` with `sectionName` omitted so the route auto-attaches to every listener whose hostname matches `sandbox.<sov-fqdn>`.
2. **Cert SAN was missing `sandbox.<sov-fqdn>`**: `clusters/_template/sovereign-tls/cilium-gateway-cert.yaml` is a per-name SAN cert (not wildcard) — without `sandbox` in the dnsNames list cilium-envoy serves the default fallback cert and browsers see `NET::ERR_CERT_COMMON_NAME_INVALID`.
3. **No DNS A record for `sandbox.<sov-fqdn>`**: `CanonicalSovereignSubdomains` in `sovereign_dns_records.go` drives the parent-zone PowerDNS PATCH that creates per-Sovereign A records → primary LB IP. Without `sandbox` in the list the URL resolves NXDOMAIN.

No Gateway listener change is needed: the existing wildcard listener `*.${SOVEREIGN_FQDN}` (rendered by `infra/hetzner/main.tf locals.parent_domains_listeners_yaml` fallback when `parent_domains_yaml` is empty — the universal path the catalyst-api provisioner takes today) already matches the `sandbox.<sov-fqdn>` hostname.

## End-to-end resolution chain after this PR

```
Browser → sandbox.<sov-fqdn>/sessions/<owner-uid>/
  ↓ (PowerDNS A record points at primary LB IPv4)
Hetzner LB :443 → cp-node :30443 (cilium-envoy)
  ↓ (Gateway listener https-<sov-fqdn-dashed> on *.<sov-fqdn> matches hostname;
     cert SAN includes sandbox.<sov-fqdn> so TLS terminates cleanly)
HTTPRoute pty-server in sandbox-<owner-uid> namespace matches hostname +
  /sessions/<owner-uid>/ path prefix; URLRewrite strips → /sessions/
  ↓ backendRef pty-server:7681
pty-server StatefulSet (PR #1641)
```

## Files changed

- `core/controllers/sandbox/internal/gitops/manifests.go` — HTTPRoute parentRefs
- `core/controllers/sandbox/internal/controller/sandbox_controller_test.go` — assertion updated
- `clusters/_template/sovereign-tls/cilium-gateway-cert.yaml` — `sandbox.${SOVEREIGN_FQDN}` SAN
- `products/catalyst/bootstrap/api/internal/handler/sovereign_dns_records.go` — `sandbox` in CanonicalSovereignSubdomains

## Hard rules respected

- READ-ONLY clusters (no live patching)
- NO Chart.yaml bump (only template content + Go renderer + Go handler list)
- `helm template products/catalyst/chart` clean (verified locally)
- `kubectl kustomize clusters/_template/sovereign-tls` clean (verified locally; cert renders with `sandbox.${SOVEREIGN_FQDN}` SAN at the end of dnsNames)
- `go test ./core/controllers/sandbox/internal/controller/...` passes under go 1.23 with the updated HTTPRoute parentRefs assertion

## Test plan

- [ ] Fresh prov a Sovereign with SANDBOX_ENABLED=true
- [ ] Verify `dig sandbox.<sov-fqdn>` returns primary LB IPv4
- [ ] Verify `curl -sk https://sandbox.<sov-fqdn>/` returns 404 from cilium-envoy (no matching route at `/`) AND that the cert chain CN/SAN includes `sandbox.<sov-fqdn>` (not the default-fallback cert)
- [ ] Issue a Sandbox CR; verify `sandbox.<sov-fqdn>/sessions/<owner-uid>/` 200s with the pty-server response

🤖 Generated with [Claude Code](https://claude.com/claude-code)