### PR TITLE
feat(sandbox-mcp): marketplace.domain.* + flux.* real impls (proxy + dynamic client)

### DIFF
--- a/products/sandbox/mcp-server/internal/tools/env.go
+++ b/products/sandbox/mcp-server/internal/tools/env.go
@@ -22,6 +22,9 @@
 //	KEYCLOAK_ADMIN_URL          = "http://keycloak.keycloak.svc.cluster.local:8080"
 //	KEYCLOAK_ADMIN_TOKEN        = "<admin bearer>" (sandbox-controller-injected)
 //	KEYCLOAK_PARENT_REALM       = "master"  (default; controller may override)
+//	SANDBOX_DOMAIN_API_URL      = "http://domain.sme.svc.cluster.local:8086"
+//	SANDBOX_MARKETPLACE_API_URL = "http://marketplace-api.marketplace.svc.cluster.local:8082"
+//	SANDBOX_TENANT_ID           = "<tenant-uuid>" (scopes domain/byod calls)
 //
 // SANDBOX_JWT_SECRET empty AND SANDBOX_ORG_ID empty = test mode
 // (the registry skips its auth gate so unit tests don't need to mint a
@@ -54,6 +57,9 @@ func NewEnvFromOS() *Env {
 		KeycloakAdminURL:    os.Getenv("KEYCLOAK_ADMIN_URL"),
 		KeycloakAdminToken:  os.Getenv("KEYCLOAK_ADMIN_TOKEN"),
 		KeycloakParentRealm: os.Getenv("KEYCLOAK_PARENT_REALM"),
+		DomainAPIURL:        os.Getenv("SANDBOX_DOMAIN_API_URL"),
+		MarketplaceAPIURL:   os.Getenv("SANDBOX_MARKETPLACE_API_URL"),
+		TenantID:            os.Getenv("SANDBOX_TENANT_ID"),
 	}
 	if env.KeycloakParentRealm == "" {
 		env.KeycloakParentRealm = "master"

--- a/products/sandbox/mcp-server/internal/tools/flux.go
+++ b/products/sandbox/mcp-server/internal/tools/flux.go
@@ -1,0 +1,476 @@
+// flux.go — real handlers for flux.status / flux.reconcile /
+// flux.suspend / flux.resume.
+//
+// Scope (architecture.md §3 + line 104): agents shipping apps from a
+// Sandbox routinely need to inspect + nudge Flux's reconcile loop in
+// the Sandbox's tenant namespaces — "is my HelmRelease ready", "force
+// a reconcile of my Kustomization", "suspend that drifting HR before
+// I patch the values". The canonical Flux v2 API surfaces this via
+// HelmRelease (`helm.toolkit.fluxcd.io/v2`) and Kustomization
+// (`kustomize.toolkit.fluxcd.io/v1`) custom resources.
+//
+// Tools shipped here:
+//
+//   - flux.status               → LIST HRs + Kustomizations across the
+//                                 Sandbox's tenant namespaces, distil
+//                                 the Ready condition + last applied
+//                                 revision into a flat table the agent
+//                                 can iterate.
+//   - flux.reconcile {kind, name, namespace}
+//                               → Annotate the resource with
+//                                 `reconcile.fluxcd.io/requestedAt=<now>`.
+//                                 Flux's controller picks this up on
+//                                 the next watch tick and re-runs the
+//                                 reconcile loop. Idempotent: the
+//                                 annotation is a timestamp, so a
+//                                 second call simply refreshes it.
+//   - flux.suspend {kind, name, namespace}
+//                               → Patch `spec.suspend=true`.
+//                                 Flux stops reconciling until the
+//                                 field is flipped back.
+//   - flux.resume {kind, name, namespace}
+//                               → Patch `spec.suspend=false`.
+//
+// Hard-rule note (Wave 12 task brief): the broader k8s.write.* surface
+// stays READ-ONLY, but the flux.reconcile/suspend/resume trio is
+// explicitly carved out because each mutation targets the agent's OWN
+// tenant namespaces and the mutated fields are the canonical Flux
+// "kick" / "pause" knobs every operator already uses.
+//
+// Namespace scoping:
+//
+//   - Every mutation tool defaults `namespace` to env.SandboxNamespace
+//     when the caller omits it. An explicit namespace argument is
+//     accepted (a Sandbox often sees multiple workload namespaces
+//     inside the Org vcluster) but the SA's RoleBinding gates which
+//     namespaces it can actually touch — we don't second-guess it
+//     client-side.
+//   - flux.status enumerates the well-known set of tenant namespaces
+//     (the Sandbox's own ns + every entry the caller passes as
+//     `namespaces`). We do NOT list cluster-wide HRs/Kustomizations
+//     because that leaks across tenants on a multi-tenant vcluster.
+//
+// Auth: same shape as sandbox.db.* — claims.OrgID must match env.OrgID,
+// RequiredCapability = "flux", and every mutation is gated by the
+// dynamic client's per-namespace RBAC (the SA can only patch what its
+// RoleBinding allows).
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// Flux GVRs. Pinned to the latest stable (v2 for HelmRelease per the
+// flux 2.4 release, v1 for Kustomization). Centralised so a future
+// API-version bump is a one-line edit.
+var (
+	fluxHelmReleaseGVR   = schema.GroupVersionResource{Group: "helm.toolkit.fluxcd.io", Version: "v2", Resource: "helmreleases"}
+	fluxKustomizationGVR = schema.GroupVersionResource{Group: "kustomize.toolkit.fluxcd.io", Version: "v1", Resource: "kustomizations"}
+)
+
+// fluxReconcileAnnotation is the canonical "kick" annotation Flux's
+// notification controller honours to force-run a reconcile loop. The
+// value MUST be a fresh timestamp (any RFC3339 / Unix-seconds string
+// works in practice — the controller only checks for a delta).
+const fluxReconcileAnnotation = "reconcile.fluxcd.io/requestedAt"
+
+// fluxKindRE constrains the `kind` arg of flux.reconcile / suspend /
+// resume to the two we support.
+var fluxKindRE = regexp.MustCompile(`^(?i)(helmrelease|kustomization)$`)
+
+// fluxNameRE matches RFC-1123 labels (k8s metadata.name format).
+var fluxNameRE = regexp.MustCompile(`^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$`)
+
+// fluxKindToGVR resolves the user-friendly kind string to a GVR.
+// Case-insensitive; returns an error on anything outside the supported
+// set so an unknown kind is rejected before we touch the API server.
+func fluxKindToGVR(kind string) (schema.GroupVersionResource, string, error) {
+	switch strings.ToLower(strings.TrimSpace(kind)) {
+	case "helmrelease":
+		return fluxHelmReleaseGVR, "HelmRelease", nil
+	case "kustomization":
+		return fluxKustomizationGVR, "Kustomization", nil
+	default:
+		return schema.GroupVersionResource{}, "", fmt.Errorf("flux: unknown kind %q (must be one of: HelmRelease, Kustomization)", kind)
+	}
+}
+
+// fluxScopedNamespace mirrors scopeNamespace from k8s_read.go but is
+// kept local so a future change to flux's defaulting (e.g. "all tenant
+// namespaces by default") doesn't leak into the broader k8s.read.*
+// surface.
+func fluxScopedNamespace(env *Env, want string) (string, error) {
+	if want == "" {
+		want = env.SandboxNamespace
+	}
+	if want == "" {
+		return "", errors.New("flux: namespace not supplied and Sandbox Env has no SANDBOX_NAMESPACE default")
+	}
+	return want, nil
+}
+
+// fluxResourceSummary is the per-row shape flux.status returns. We
+// distil the Ready condition + last applied revision into stable
+// snake_case keys so the agent doesn't have to parse the noisy
+// Unstructured status sub-object.
+type fluxResourceSummary struct {
+	Kind        string `json:"kind"`
+	Name        string `json:"name"`
+	Namespace   string `json:"namespace"`
+	Ready       string `json:"ready"` // "True" | "False" | "Unknown"
+	Suspended   bool   `json:"suspended"`
+	Reason      string `json:"reason,omitempty"`
+	Message     string `json:"message,omitempty"`
+	Revision    string `json:"revision,omitempty"` // status.lastAppliedRevision
+	LastApplied string `json:"last_applied_at,omitempty"`
+	Age         string `json:"age,omitempty"`
+}
+
+// extractReadyCondition pulls the Ready condition out of the standard
+// metav1.Condition slice on Flux resources. Returns ("Unknown", "", "")
+// when the slice is empty (resource still admitted, controller hasn't
+// observed it yet).
+func extractReadyCondition(obj map[string]any) (status, reason, message string) {
+	conds, found, _ := unstructured.NestedSlice(obj, "status", "conditions")
+	if !found {
+		return "Unknown", "", ""
+	}
+	for _, c := range conds {
+		cm, ok := c.(map[string]any)
+		if !ok {
+			continue
+		}
+		if cm["type"] == "Ready" {
+			status, _ = cm["status"].(string)
+			reason, _ = cm["reason"].(string)
+			message, _ = cm["message"].(string)
+			return
+		}
+	}
+	return "Unknown", "", ""
+}
+
+// summariseFluxResource renders one Unstructured into the flat
+// fluxResourceSummary shape.
+func summariseFluxResource(kind string, obj *unstructured.Unstructured) fluxResourceSummary {
+	status, reason, message := extractReadyCondition(obj.Object)
+	suspended, _, _ := unstructured.NestedBool(obj.Object, "spec", "suspend")
+	revision, _, _ := unstructured.NestedString(obj.Object, "status", "lastAppliedRevision")
+	lastApplied, _, _ := unstructured.NestedString(obj.Object, "status", "lastHandledReconcileAt")
+	age := ""
+	if ts := obj.GetCreationTimestamp().Time; !ts.IsZero() {
+		age = ts.UTC().Format(time.RFC3339)
+	}
+	return fluxResourceSummary{
+		Kind:        kind,
+		Name:        obj.GetName(),
+		Namespace:   obj.GetNamespace(),
+		Ready:       status,
+		Suspended:   suspended,
+		Reason:      reason,
+		Message:     message,
+		Revision:    revision,
+		LastApplied: lastApplied,
+		Age:         age,
+	}
+}
+
+// --- flux.status -------------------------------------------------------
+
+type fluxStatusArgs struct {
+	// Namespaces — optional list to expand the scan beyond the
+	// Sandbox's own namespace. When empty we scan only
+	// env.SandboxNamespace; otherwise the union of the supplied
+	// names + the Sandbox namespace.
+	Namespaces []string `json:"namespaces,omitempty"`
+}
+
+func fluxStatus(ctx context.Context, raw json.RawMessage) (any, error) {
+	var args fluxStatusArgs
+	if len(raw) > 0 {
+		if err := json.Unmarshal(raw, &args); err != nil {
+			return nil, fmt.Errorf("flux.status: invalid arguments: %w", err)
+		}
+	}
+	env := EnvFrom(ctx)
+	if env == nil {
+		return nil, errors.New("flux.status: server env missing on context")
+	}
+	// Build the deduped namespace set (Sandbox NS + caller-supplied).
+	nsSet := map[string]struct{}{}
+	if env.SandboxNamespace != "" {
+		nsSet[env.SandboxNamespace] = struct{}{}
+	}
+	for _, n := range args.Namespaces {
+		n = strings.TrimSpace(n)
+		if n != "" {
+			nsSet[n] = struct{}{}
+		}
+	}
+	if len(nsSet) == 0 {
+		return nil, errors.New("flux.status: no namespaces in scope (env.SandboxNamespace empty and `namespaces` not supplied)")
+	}
+	namespaces := make([]string, 0, len(nsSet))
+	for n := range nsSet {
+		namespaces = append(namespaces, n)
+	}
+	sort.Strings(namespaces)
+
+	client, err := dynamicClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+	summaries := make([]fluxResourceSummary, 0, 32)
+	// We swallow per-namespace 404s on the GVR (e.g. Flux CRDs not
+	// installed in a fresh ns) — surfacing an empty result is friendlier
+	// to the agent than a noisy multi-error response. Any other error
+	// (RBAC, transport) aborts the call.
+	listOne := func(ns string, gvr schema.GroupVersionResource, kind string) error {
+		list, err := client.Resource(gvr).Namespace(ns).List(ctx, metav1.ListOptions{})
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				return nil
+			}
+			return fmt.Errorf("flux.status: LIST %s in %s: %w", gvr.Resource, ns, err)
+		}
+		for i := range list.Items {
+			summaries = append(summaries, summariseFluxResource(kind, &list.Items[i]))
+		}
+		return nil
+	}
+	for _, ns := range namespaces {
+		if err := listOne(ns, fluxHelmReleaseGVR, "HelmRelease"); err != nil {
+			return nil, err
+		}
+		if err := listOne(ns, fluxKustomizationGVR, "Kustomization"); err != nil {
+			return nil, err
+		}
+	}
+	// Stable sort: namespace, kind, name. Lets the agent diff status
+	// across calls without re-ordering noise.
+	sort.SliceStable(summaries, func(i, j int) bool {
+		if summaries[i].Namespace != summaries[j].Namespace {
+			return summaries[i].Namespace < summaries[j].Namespace
+		}
+		if summaries[i].Kind != summaries[j].Kind {
+			return summaries[i].Kind < summaries[j].Kind
+		}
+		return summaries[i].Name < summaries[j].Name
+	})
+	return map[string]any{
+		"namespaces": namespaces,
+		"count":      len(summaries),
+		"items":      summaries,
+	}, nil
+}
+
+func schemaFluxStatus() map[string]any {
+	return map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"namespaces": map[string]any{
+				"type":        "array",
+				"description": "Optional extra namespaces to scan. The Sandbox namespace is always included.",
+				"items":       map[string]any{"type": "string"},
+			},
+		},
+		"additionalProperties": false,
+	}
+}
+
+// --- flux.reconcile ----------------------------------------------------
+
+type fluxMutationArgs struct {
+	Kind      string `json:"kind"`
+	Name      string `json:"name"`
+	Namespace string `json:"namespace,omitempty"`
+}
+
+func validateFluxMutationArgs(a *fluxMutationArgs) error {
+	if a.Kind == "" {
+		return errors.New("`kind` is required (HelmRelease | Kustomization)")
+	}
+	if !fluxKindRE.MatchString(a.Kind) {
+		return fmt.Errorf("`kind` must match %s", fluxKindRE.String())
+	}
+	if a.Name == "" {
+		return errors.New("`name` is required")
+	}
+	if !fluxNameRE.MatchString(a.Name) {
+		return fmt.Errorf("`name` must be a valid RFC-1123 label (matched %s)", fluxNameRE.String())
+	}
+	return nil
+}
+
+// patchFluxAnnotation applies the kick annotation as a strategic-merge
+// patch. We use Patch rather than Update so a concurrent reconcile
+// loop doesn't race us on resourceVersion.
+func patchFluxAnnotation(ctx context.Context, env *Env, args fluxMutationArgs) (any, error) {
+	ns, err := fluxScopedNamespace(env, args.Namespace)
+	if err != nil {
+		return nil, err
+	}
+	gvr, canonicalKind, err := fluxKindToGVR(args.Kind)
+	if err != nil {
+		return nil, err
+	}
+	client, err := dynamicClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+	now := time.Now().UTC().Format(time.RFC3339)
+	patch := map[string]any{
+		"metadata": map[string]any{
+			"annotations": map[string]any{
+				fluxReconcileAnnotation: now,
+			},
+		},
+	}
+	patchBytes, _ := json.Marshal(patch)
+	patched, err := client.Resource(gvr).Namespace(ns).
+		Patch(ctx, args.Name, types.MergePatchType, patchBytes, metav1.PatchOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("flux.reconcile: PATCH %s/%s in %s: %w", canonicalKind, args.Name, ns, err)
+	}
+	return map[string]any{
+		"status":           "Reconciling",
+		"kind":             canonicalKind,
+		"name":             args.Name,
+		"namespace":        ns,
+		"requested_at":     now,
+		"resource_version": patched.GetResourceVersion(),
+		"note":             "Flux's controller will pick up the annotation on the next watch tick.",
+	}, nil
+}
+
+func fluxReconcile(ctx context.Context, raw json.RawMessage) (any, error) {
+	var args fluxMutationArgs
+	if err := json.Unmarshal(raw, &args); err != nil {
+		return nil, fmt.Errorf("flux.reconcile: invalid arguments: %w", err)
+	}
+	if err := validateFluxMutationArgs(&args); err != nil {
+		return nil, fmt.Errorf("flux.reconcile: %w", err)
+	}
+	env := EnvFrom(ctx)
+	if env == nil {
+		return nil, errors.New("flux.reconcile: server env missing on context")
+	}
+	return patchFluxAnnotation(ctx, env, args)
+}
+
+// --- flux.suspend / flux.resume ----------------------------------------
+
+// patchFluxSuspend applies the spec.suspend=<want> patch. Same
+// rationale as patchFluxAnnotation — strategic-merge to avoid the
+// resourceVersion race on a concurrent reconcile loop.
+func patchFluxSuspend(ctx context.Context, env *Env, args fluxMutationArgs, want bool) (any, error) {
+	ns, err := fluxScopedNamespace(env, args.Namespace)
+	if err != nil {
+		return nil, err
+	}
+	gvr, canonicalKind, err := fluxKindToGVR(args.Kind)
+	if err != nil {
+		return nil, err
+	}
+	client, err := dynamicClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+	patch := map[string]any{
+		"spec": map[string]any{
+			"suspend": want,
+		},
+	}
+	patchBytes, _ := json.Marshal(patch)
+	patched, err := client.Resource(gvr).Namespace(ns).
+		Patch(ctx, args.Name, types.MergePatchType, patchBytes, metav1.PatchOptions{})
+	if err != nil {
+		verb := "suspend"
+		if !want {
+			verb = "resume"
+		}
+		return nil, fmt.Errorf("flux.%s: PATCH %s/%s in %s: %w", verb, canonicalKind, args.Name, ns, err)
+	}
+	verb := "Suspended"
+	note := "Flux will stop reconciling this resource until spec.suspend is flipped to false."
+	if !want {
+		verb = "Resumed"
+		note = "Flux will resume reconciling on the next watch tick."
+	}
+	return map[string]any{
+		"status":           verb,
+		"kind":             canonicalKind,
+		"name":             args.Name,
+		"namespace":        ns,
+		"suspend":          want,
+		"resource_version": patched.GetResourceVersion(),
+		"note":             note,
+	}, nil
+}
+
+func fluxSuspend(ctx context.Context, raw json.RawMessage) (any, error) {
+	var args fluxMutationArgs
+	if err := json.Unmarshal(raw, &args); err != nil {
+		return nil, fmt.Errorf("flux.suspend: invalid arguments: %w", err)
+	}
+	if err := validateFluxMutationArgs(&args); err != nil {
+		return nil, fmt.Errorf("flux.suspend: %w", err)
+	}
+	env := EnvFrom(ctx)
+	if env == nil {
+		return nil, errors.New("flux.suspend: server env missing on context")
+	}
+	return patchFluxSuspend(ctx, env, args, true)
+}
+
+func fluxResume(ctx context.Context, raw json.RawMessage) (any, error) {
+	var args fluxMutationArgs
+	if err := json.Unmarshal(raw, &args); err != nil {
+		return nil, fmt.Errorf("flux.resume: invalid arguments: %w", err)
+	}
+	if err := validateFluxMutationArgs(&args); err != nil {
+		return nil, fmt.Errorf("flux.resume: %w", err)
+	}
+	env := EnvFrom(ctx)
+	if env == nil {
+		return nil, errors.New("flux.resume: server env missing on context")
+	}
+	return patchFluxSuspend(ctx, env, args, false)
+}
+
+func schemaFluxMutation() map[string]any {
+	return map[string]any{
+		"type":     "object",
+		"required": []string{"kind", "name"},
+		"properties": map[string]any{
+			"kind": map[string]any{
+				"type":        "string",
+				"description": "Flux resource kind. One of: HelmRelease, Kustomization.",
+				"pattern":     fluxKindRE.String(),
+			},
+			"name": map[string]any{
+				"type":        "string",
+				"description": "metadata.name of the Flux resource.",
+				"pattern":     fluxNameRE.String(),
+			},
+			"namespace": map[string]any{
+				"type":        "string",
+				"description": "Defaults to the Sandbox namespace.",
+			},
+		},
+		"additionalProperties": false,
+	}
+}

--- a/products/sandbox/mcp-server/internal/tools/flux_test.go
+++ b/products/sandbox/mcp-server/internal/tools/flux_test.go
@@ -1,0 +1,223 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	sharedauth "github.com/openova-io/openova/core/services/shared/auth"
+)
+
+// TestFluxKindToGVR covers the kind → GVR routing for the two
+// supported Flux kinds plus the rejection of unknown kinds.
+func TestFluxKindToGVR(t *testing.T) {
+	cases := map[string]struct {
+		kind      string
+		wantGroup string
+		wantRes   string
+		errSub    string
+	}{
+		"hr lower":      {"helmrelease", "helm.toolkit.fluxcd.io", "helmreleases", ""},
+		"hr camel":      {"HelmRelease", "helm.toolkit.fluxcd.io", "helmreleases", ""},
+		"ks lower":      {"kustomization", "kustomize.toolkit.fluxcd.io", "kustomizations", ""},
+		"ks upper":      {"Kustomization", "kustomize.toolkit.fluxcd.io", "kustomizations", ""},
+		"unknown":       {"deployment", "", "", "unknown kind"},
+		"empty":         {"", "", "", "unknown kind"},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			gvr, _, err := fluxKindToGVR(tc.kind)
+			if tc.errSub != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.errSub) {
+					t.Errorf("err=%v want %q", err, tc.errSub)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("err=%v", err)
+			}
+			if gvr.Group != tc.wantGroup || gvr.Resource != tc.wantRes {
+				t.Errorf("gvr=%+v", gvr)
+			}
+		})
+	}
+}
+
+// TestFluxScopedNamespace covers the default-to-Sandbox-namespace
+// rule.
+func TestFluxScopedNamespace(t *testing.T) {
+	t.Run("explicit", func(t *testing.T) {
+		ns, err := fluxScopedNamespace(&Env{SandboxNamespace: "sb"}, "other")
+		if err != nil || ns != "other" {
+			t.Errorf("ns=%q err=%v", ns, err)
+		}
+	})
+	t.Run("default", func(t *testing.T) {
+		ns, err := fluxScopedNamespace(&Env{SandboxNamespace: "sb"}, "")
+		if err != nil || ns != "sb" {
+			t.Errorf("ns=%q err=%v", ns, err)
+		}
+	})
+	t.Run("missing", func(t *testing.T) {
+		_, err := fluxScopedNamespace(&Env{}, "")
+		if err == nil || !strings.Contains(err.Error(), "SANDBOX_NAMESPACE") {
+			t.Errorf("err=%v", err)
+		}
+	})
+}
+
+// TestValidateFluxMutationArgs covers the per-call arg gate.
+func TestValidateFluxMutationArgs(t *testing.T) {
+	cases := map[string]struct {
+		args   fluxMutationArgs
+		errSub string
+	}{
+		"no kind":    {fluxMutationArgs{Name: "x"}, "kind"},
+		"bad kind":   {fluxMutationArgs{Kind: "Deployment", Name: "x"}, "must match"},
+		"no name":    {fluxMutationArgs{Kind: "HelmRelease"}, "name"},
+		"bad name":   {fluxMutationArgs{Kind: "HelmRelease", Name: "Bad-NAME"}, "RFC-1123"},
+		"happy hr":   {fluxMutationArgs{Kind: "HelmRelease", Name: "my-app"}, ""},
+		"happy ks":   {fluxMutationArgs{Kind: "Kustomization", Name: "my-app-0"}, ""},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			err := validateFluxMutationArgs(&tc.args)
+			if tc.errSub == "" {
+				if err != nil {
+					t.Errorf("err=%v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tc.errSub) {
+				t.Errorf("err=%v want %q", err, tc.errSub)
+			}
+		})
+	}
+}
+
+// TestExtractReadyCondition covers the condition-extraction helper
+// over the canonical Flux status shape.
+func TestExtractReadyCondition(t *testing.T) {
+	t.Run("ready true", func(t *testing.T) {
+		obj := map[string]any{
+			"status": map[string]any{
+				"conditions": []any{
+					map[string]any{"type": "Ready", "status": "True", "reason": "ReconciliationSucceeded", "message": "ok"},
+				},
+			},
+		}
+		st, r, m := extractReadyCondition(obj)
+		if st != "True" || r != "ReconciliationSucceeded" || m != "ok" {
+			t.Errorf("st=%q r=%q m=%q", st, r, m)
+		}
+	})
+	t.Run("ready false", func(t *testing.T) {
+		obj := map[string]any{
+			"status": map[string]any{
+				"conditions": []any{
+					map[string]any{"type": "Ready", "status": "False", "reason": "UpgradeFailed", "message": "values invalid"},
+				},
+			},
+		}
+		st, r, _ := extractReadyCondition(obj)
+		if st != "False" || r != "UpgradeFailed" {
+			t.Errorf("st=%q r=%q", st, r)
+		}
+	})
+	t.Run("no conditions", func(t *testing.T) {
+		st, _, _ := extractReadyCondition(map[string]any{})
+		if st != "Unknown" {
+			t.Errorf("st=%q want Unknown", st)
+		}
+	})
+	t.Run("other conditions only", func(t *testing.T) {
+		obj := map[string]any{
+			"status": map[string]any{
+				"conditions": []any{
+					map[string]any{"type": "Released", "status": "True"},
+				},
+			},
+		}
+		st, _, _ := extractReadyCondition(obj)
+		if st != "Unknown" {
+			t.Errorf("st=%q want Unknown", st)
+		}
+	})
+}
+
+// TestSummariseFluxResource covers the per-row distillation logic
+// against a realistic HelmRelease shape.
+func TestSummariseFluxResource(t *testing.T) {
+	obj := &unstructured.Unstructured{Object: map[string]any{
+		"metadata": map[string]any{
+			"name":      "my-app",
+			"namespace": "sandbox-u1",
+		},
+		"spec": map[string]any{
+			"suspend": true,
+		},
+		"status": map[string]any{
+			"conditions": []any{
+				map[string]any{"type": "Ready", "status": "True", "reason": "Ok"},
+			},
+			"lastAppliedRevision":   "1.2.3",
+			"lastHandledReconcileAt": "2026-05-18T12:00:00Z",
+		},
+	}}
+	s := summariseFluxResource("HelmRelease", obj)
+	if s.Kind != "HelmRelease" || s.Name != "my-app" || s.Namespace != "sandbox-u1" {
+		t.Errorf("identity=%+v", s)
+	}
+	if s.Ready != "True" || s.Suspended != true || s.Revision != "1.2.3" {
+		t.Errorf("body=%+v", s)
+	}
+}
+
+// TestFluxStatus_NoNamespacesInScope ensures the tool errors early when
+// neither env.SandboxNamespace nor caller-supplied namespaces is set.
+func TestFluxStatus_NoNamespacesInScope(t *testing.T) {
+	ctx := WithEnv(context.Background(), &Env{})
+	_, err := fluxStatus(ctx, json.RawMessage(`{}`))
+	if err == nil || !strings.Contains(err.Error(), "no namespaces in scope") {
+		t.Errorf("err=%v", err)
+	}
+}
+
+// TestFluxMutation_Validation covers the validation surface common to
+// reconcile / suspend / resume.
+func TestFluxMutation_Validation(t *testing.T) {
+	ctx := WithEnv(context.Background(), &Env{SandboxNamespace: "sb"})
+	for _, fn := range []HandlerFunc{fluxReconcile, fluxSuspend, fluxResume} {
+		_, err := fn(ctx, json.RawMessage(`{}`))
+		if err == nil || !strings.Contains(err.Error(), "kind") {
+			t.Errorf("err=%v want kind", err)
+		}
+		_, err = fn(ctx, json.RawMessage(`{"kind":"HelmRelease"}`))
+		if err == nil || !strings.Contains(err.Error(), "name") {
+			t.Errorf("err=%v want name", err)
+		}
+	}
+}
+
+// TestFluxCapabilityGate confirms the registry rejects flux.* calls
+// whose claims lack the `flux` capability.
+func TestFluxCapabilityGate(t *testing.T) {
+	r := NewRegistry(&Env{
+		OrgID:            "acme",
+		JWTSecret:        []byte("x"),
+		SandboxNamespace: "sandbox-u1",
+	})
+	for _, name := range []string{"flux.status", "flux.reconcile", "flux.suspend", "flux.resume"} {
+		t.Run(name, func(t *testing.T) {
+			cl := &sharedauth.Claims{OrgID: "acme", Capabilities: []string{"sandbox.db"}}
+			args := json.RawMessage(`{"kind":"HelmRelease","name":"x"}`)
+			_, err := r.Call(context.Background(), name, args, CallOpts{Claims: cl})
+			if err == nil || !strings.Contains(err.Error(), "forbidden") {
+				t.Errorf("missing cap: err=%v want forbidden", err)
+			}
+		})
+	}
+}

--- a/products/sandbox/mcp-server/internal/tools/marketplace.go
+++ b/products/sandbox/mcp-server/internal/tools/marketplace.go
@@ -1,0 +1,359 @@
+// marketplace.go — real handlers for marketplace.domain.byod +
+// marketplace.domain.subdomain.
+//
+// Scope (architecture.md §3 + line 164): an agent shipping an app from
+// inside a Sandbox routinely needs to bind a public hostname to the
+// per-Org workload — either a custom domain the operator already owns
+// (BYOD) or a free subdomain under one of the Sovereign-managed pools
+// (sme.openova.io / openova.cloud / etc.). The canonical implementation
+// lives in `core/services/domain/handlers/handlers.go`:
+//
+//   - POST /domain/byod        registerBYODRequest{tenant_id, domain}
+//                              → 201 {domain, cname_target, registrar, instructions}
+//   - POST /domain/subdomains  registerSubdomainRequest{tenant_id, subdomain, tld}
+//                              → 201 *store.Domain
+//
+// The Sandbox MCP server is a thin proxy: validate args, look up the
+// Sandbox's tenant_id from env.TenantID, forward the call with the
+// SANDBOX_TOKEN as the Authorization bearer, and shape the response
+// into a structured envelope the agent can paste into its app config.
+//
+// This is consistent with sandbox.auth.* (which proxies Keycloak admin)
+// and sandbox.db.* (which manipulates k8s CRs) — every cross-service
+// surface is a thin wrapper over the canonical service handler.
+//
+// Wire contract:
+//
+//   - marketplace.domain.byod {fqdn} → POST <DomainAPIURL>/domain/byod
+//     with body {tenant_id: env.TenantID, domain: fqdn}. Response carries
+//     CNAMETarget the agent points its registrar at.
+//
+//   - marketplace.domain.subdomain {subdomain, parent_zone?} →
+//     POST <DomainAPIURL>/domain/subdomains with body
+//     {tenant_id: env.TenantID, subdomain, tld: parent_zone}. The
+//     parent_zone defaults to the Sovereign's primary pool (typically
+//     `openova.cloud` or `sme.openova.io`); the canonical allow-list
+//     lives in core/services/domain/store.AllowedTLDs).
+//
+// Auth: same shape as sandbox.db.* — claims.OrgID must match env.OrgID,
+// RequiredCapability = "marketplace", and every call requires
+// env.DomainAPIURL + env.TenantID + env.SandboxToken to be set or the
+// handler returns a clear "controller didn't wire marketplace" error.
+package tools
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"regexp"
+	"strings"
+	"time"
+)
+
+// mpHTTPTimeout caps every marketplace-proxy call. The domain service
+// runs in-cluster and a healthy WHOIS / DB write completes in <300ms;
+// anything slower is a degraded backend and the agent wants a fast
+// error, not a 60s hang.
+const mpHTTPTimeout = 15 * time.Second
+
+// mpFQDNRE constrains the `fqdn` arg of marketplace.domain.byod.
+// Mirrors core/services/domain's validation surface (lowercase
+// alnum + hyphen labels separated by dots, at least one dot, no
+// leading/trailing dot or hyphen). Strict enough to reject obvious
+// junk before we burn an HTTP roundtrip on the domain service.
+var mpFQDNRE = regexp.MustCompile(`^([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z]{2,63}$`)
+
+// mpSubdomainRE matches the same surface core/services/domain's
+// subdomainRe enforces server-side. We pre-validate here so a bad
+// argument doesn't cost a 400 round-trip.
+var mpSubdomainRE = regexp.MustCompile(`^[a-z0-9][a-z0-9-]{0,30}[a-z0-9]$`)
+
+// mpParentZoneRE constrains the `parent_zone` arg — must look like a
+// public DNS suffix (`openova.cloud`, `sme.openova.io`). Same shape as
+// mpFQDNRE.
+var mpParentZoneRE = mpFQDNRE
+
+// requireMarketplaceProxy is the canonical gate every marketplace.*
+// handler runs first: the controller must have wired BOTH the domain
+// service URL AND the tenant id. If either is empty we surface a
+// well-typed error rather than letting an unauthenticated POST leak
+// past as a confusing 401/404 from the domain service.
+func requireMarketplaceProxy(env *Env) error {
+	if env == nil {
+		return errors.New("marketplace: server env missing on context")
+	}
+	if strings.TrimSpace(env.DomainAPIURL) == "" {
+		return errors.New("marketplace: SANDBOX_DOMAIN_API_URL not set (sandbox-controller didn't wire the domain service URL)")
+	}
+	if strings.TrimSpace(env.TenantID) == "" {
+		return errors.New("marketplace: SANDBOX_TENANT_ID not set (sandbox-controller didn't wire the tenant id)")
+	}
+	if strings.TrimSpace(env.SandboxToken) == "" {
+		return errors.New("marketplace: SANDBOX_TOKEN not set (no bearer available to proxy to the domain service)")
+	}
+	return nil
+}
+
+// mpHTTPClient returns the per-process HTTP client used for every
+// marketplace-proxy call. Centralised so the timeout + the Authorization
+// header are applied uniformly.
+func mpHTTPClient() *http.Client {
+	return &http.Client{Timeout: mpHTTPTimeout}
+}
+
+// mpDo runs a JSON POST against the domain service. Body is closed
+// before return; the response payload is returned verbatim so the
+// caller can decode into a per-endpoint envelope.
+func mpDo(ctx context.Context, env *Env, urlStr string, payload any) ([]byte, int, error) {
+	b, err := json.Marshal(payload)
+	if err != nil {
+		return nil, 0, fmt.Errorf("marshal payload: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, urlStr, bytes.NewReader(b))
+	if err != nil {
+		return nil, 0, err
+	}
+	req.Header.Set("Authorization", "Bearer "+env.SandboxToken)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := mpHTTPClient().Do(req)
+	if err != nil {
+		return nil, 0, fmt.Errorf("domain %s: %w", urlStr, err)
+	}
+	defer resp.Body.Close()
+	out, _ := io.ReadAll(resp.Body)
+	return out, resp.StatusCode, nil
+}
+
+// --- marketplace.domain.byod ------------------------------------------
+
+type marketplaceDomainBYODArgs struct {
+	// FQDN — the operator-owned domain to bind (`acme.com`,
+	// `app.example.org`). Must look like a public FQDN (at least one
+	// dot, valid TLD-shaped suffix). The domain service performs WHOIS
+	// + uniqueness checks server-side; we pre-validate the shape.
+	FQDN string `json:"fqdn"`
+}
+
+// marketplaceDomainBYODResponse is the structured envelope the BYOD
+// proxy returns. Mirrors `registerBYODResponse` in
+// core/services/domain/handlers but renames the wire keys to a
+// stable snake_case surface decoupled from any future domain-service
+// refactor.
+type marketplaceDomainBYODResponse struct {
+	Status       string         `json:"status"`
+	FQDN         string         `json:"fqdn"`
+	CNAMETarget  string         `json:"cname_target"`
+	Registrar    string         `json:"registrar,omitempty"`
+	Instructions string         `json:"instructions,omitempty"`
+	Domain       map[string]any `json:"domain,omitempty"`
+	Note         string         `json:"note,omitempty"`
+}
+
+func marketplaceDomainBYOD(ctx context.Context, raw json.RawMessage) (any, error) {
+	var args marketplaceDomainBYODArgs
+	if err := json.Unmarshal(raw, &args); err != nil {
+		return nil, fmt.Errorf("marketplace.domain.byod: invalid arguments: %w", err)
+	}
+	args.FQDN = strings.ToLower(strings.TrimSpace(args.FQDN))
+	if args.FQDN == "" {
+		return nil, errors.New("marketplace.domain.byod: `fqdn` is required")
+	}
+	if !mpFQDNRE.MatchString(args.FQDN) {
+		return nil, fmt.Errorf("marketplace.domain.byod: `fqdn` must be a valid lowercase FQDN (matched against %s)", mpFQDNRE.String())
+	}
+	env := EnvFrom(ctx)
+	if err := requireMarketplaceProxy(env); err != nil {
+		return nil, err
+	}
+	payload := map[string]any{
+		"tenant_id": env.TenantID,
+		"domain":    args.FQDN,
+	}
+	urlStr := strings.TrimRight(env.DomainAPIURL, "/") + "/domain/byod"
+	body, status, err := mpDo(ctx, env, urlStr, payload)
+	if err != nil {
+		return nil, fmt.Errorf("marketplace.domain.byod: %w", err)
+	}
+	switch status {
+	case http.StatusCreated:
+		// Decode the canonical response. We surface the same fields back
+		// to the agent under stable, snake_case keys so the wire shape
+		// is decoupled from any future domain-service refactor.
+		var resp struct {
+			Domain       map[string]any `json:"domain"`
+			CNAMETarget  string         `json:"cname_target"`
+			Registrar    string         `json:"registrar"`
+			Instructions string         `json:"instructions"`
+		}
+		if err := json.Unmarshal(body, &resp); err != nil {
+			return nil, fmt.Errorf("marketplace.domain.byod: decode response: %w", err)
+		}
+		return marketplaceDomainBYODResponse{
+			Status:       "Registered",
+			FQDN:         args.FQDN,
+			CNAMETarget:  resp.CNAMETarget,
+			Registrar:    resp.Registrar,
+			Instructions: resp.Instructions,
+			Domain:       resp.Domain,
+			Note:         "Set a CNAME at your registrar pointing the FQDN at `cname_target`, then call POST /domain/verify/{id} (or wait for the auto-verify cron).",
+		}, nil
+	case http.StatusConflict:
+		// Idempotent re-call: surface the same shape with a non-Created
+		// status so the agent can branch.
+		return map[string]any{
+			"status": "AlreadyExists",
+			"fqdn":   args.FQDN,
+			"note":   "Domain is already registered (idempotent no-op). Inspect via the domain service for the existing record.",
+		}, nil
+	case http.StatusForbidden, http.StatusUnauthorized:
+		return nil, fmt.Errorf("marketplace.domain.byod: domain service rejected the Sandbox bearer (HTTP %d): %s", status, body)
+	default:
+		return nil, fmt.Errorf("marketplace.domain.byod: domain service returned %d: %s", status, body)
+	}
+}
+
+func schemaMarketplaceDomainBYOD() map[string]any {
+	return map[string]any{
+		"type":     "object",
+		"required": []string{"fqdn"},
+		"properties": map[string]any{
+			"fqdn": map[string]any{
+				"type":        "string",
+				"description": "Operator-owned fully-qualified domain (e.g. `acme.com`, `app.example.org`). Lowercased; must contain at least one dot.",
+				"pattern":     mpFQDNRE.String(),
+			},
+		},
+		"additionalProperties": false,
+	}
+}
+
+// --- marketplace.domain.subdomain --------------------------------------
+
+type marketplaceDomainSubdomainArgs struct {
+	// Subdomain — the per-pool label (`acme`, `dashboard`, `staging`).
+	// 2-32 chars, lowercase alnum + hyphen. Must not contain
+	// consecutive hyphens.
+	Subdomain string `json:"subdomain"`
+
+	// ParentZone — optional override for the parent pool zone
+	// (`openova.cloud`, `sme.openova.io`). When empty we leave the
+	// `tld` field off the proxied request and let the domain service
+	// apply its own AllowedTLDs default.
+	ParentZone string `json:"parent_zone,omitempty"`
+}
+
+// marketplaceDomainSubdomainResponse mirrors the canonical
+// store.Domain shape returned by POST /domain/subdomains but adds
+// the convenience `fqdn` field the agent typically wants
+// (`<subdomain>.<parent_zone>`) without re-concatenating client-side.
+type marketplaceDomainSubdomainResponse struct {
+	Status     string         `json:"status"`
+	FQDN       string         `json:"fqdn"`
+	Subdomain  string         `json:"subdomain"`
+	ParentZone string         `json:"parent_zone"`
+	Domain     map[string]any `json:"domain,omitempty"`
+	Note       string         `json:"note,omitempty"`
+}
+
+func marketplaceDomainSubdomain(ctx context.Context, raw json.RawMessage) (any, error) {
+	var args marketplaceDomainSubdomainArgs
+	if err := json.Unmarshal(raw, &args); err != nil {
+		return nil, fmt.Errorf("marketplace.domain.subdomain: invalid arguments: %w", err)
+	}
+	args.Subdomain = strings.ToLower(strings.TrimSpace(args.Subdomain))
+	args.ParentZone = strings.ToLower(strings.TrimSpace(args.ParentZone))
+	if args.Subdomain == "" {
+		return nil, errors.New("marketplace.domain.subdomain: `subdomain` is required")
+	}
+	if !mpSubdomainRE.MatchString(args.Subdomain) {
+		return nil, fmt.Errorf("marketplace.domain.subdomain: `subdomain` must match %s", mpSubdomainRE.String())
+	}
+	if strings.Contains(args.Subdomain, "--") {
+		return nil, errors.New("marketplace.domain.subdomain: `subdomain` must not contain consecutive hyphens")
+	}
+	if args.ParentZone != "" && !mpParentZoneRE.MatchString(args.ParentZone) {
+		return nil, fmt.Errorf("marketplace.domain.subdomain: `parent_zone` must be a valid FQDN (matched against %s)", mpParentZoneRE.String())
+	}
+	env := EnvFrom(ctx)
+	if err := requireMarketplaceProxy(env); err != nil {
+		return nil, err
+	}
+	// When the caller omits parent_zone we leave the TLD field empty
+	// and let the domain service apply its allow-list default. That
+	// keeps Sandbox-side decisions out of the way of the per-Sovereign
+	// pool config (which lives in core/services/domain/store.AllowedTLDs
+	// + the chart-level config, NOT in the MCP server).
+	payload := map[string]any{
+		"tenant_id": env.TenantID,
+		"subdomain": args.Subdomain,
+	}
+	if args.ParentZone != "" {
+		payload["tld"] = args.ParentZone
+	}
+	urlStr := strings.TrimRight(env.DomainAPIURL, "/") + "/domain/subdomains"
+	body, status, err := mpDo(ctx, env, urlStr, payload)
+	if err != nil {
+		return nil, fmt.Errorf("marketplace.domain.subdomain: %w", err)
+	}
+	switch status {
+	case http.StatusCreated:
+		var record map[string]any
+		if err := json.Unmarshal(body, &record); err != nil {
+			return nil, fmt.Errorf("marketplace.domain.subdomain: decode response: %w", err)
+		}
+		parent, _ := record["tld"].(string)
+		if parent == "" {
+			parent = args.ParentZone
+		}
+		full, _ := record["domain"].(string)
+		if full == "" {
+			full = args.Subdomain
+			if parent != "" {
+				full = full + "." + parent
+			}
+		}
+		return marketplaceDomainSubdomainResponse{
+			Status:     "Registered",
+			FQDN:       full,
+			Subdomain:  args.Subdomain,
+			ParentZone: parent,
+			Domain:     record,
+			Note:       "Subdomain reserved + DNS verified at the pool zone. HTTPRoute / Gateway publication is the operator's downstream step.",
+		}, nil
+	case http.StatusConflict:
+		return map[string]any{
+			"status":      "AlreadyExists",
+			"subdomain":   args.Subdomain,
+			"parent_zone": args.ParentZone,
+			"note":        "Subdomain is already taken (idempotent no-op).",
+		}, nil
+	case http.StatusForbidden, http.StatusUnauthorized:
+		return nil, fmt.Errorf("marketplace.domain.subdomain: domain service rejected the Sandbox bearer (HTTP %d): %s", status, body)
+	default:
+		return nil, fmt.Errorf("marketplace.domain.subdomain: domain service returned %d: %s", status, body)
+	}
+}
+
+func schemaMarketplaceDomainSubdomain() map[string]any {
+	return map[string]any{
+		"type":     "object",
+		"required": []string{"subdomain"},
+		"properties": map[string]any{
+			"subdomain": map[string]any{
+				"type":        "string",
+				"description": "Per-pool subdomain label (2-32 chars, lowercase alnum + hyphen).",
+				"pattern":     mpSubdomainRE.String(),
+			},
+			"parent_zone": map[string]any{
+				"type":        "string",
+				"description": "Optional parent pool zone (`openova.cloud`, `sme.openova.io`). When omitted the domain service uses its configured AllowedTLDs default.",
+				"pattern":     mpParentZoneRE.String(),
+			},
+		},
+		"additionalProperties": false,
+	}
+}

--- a/products/sandbox/mcp-server/internal/tools/marketplace_test.go
+++ b/products/sandbox/mcp-server/internal/tools/marketplace_test.go
@@ -1,0 +1,246 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	sharedauth "github.com/openova-io/openova/core/services/shared/auth"
+)
+
+// TestRequireMarketplaceProxy covers the canonical gate every
+// marketplace.* handler runs first.
+func TestRequireMarketplaceProxy(t *testing.T) {
+	cases := map[string]struct {
+		env    *Env
+		errSub string
+	}{
+		"nil env":      {nil, "server env missing"},
+		"no api url":   {&Env{TenantID: "t", SandboxToken: "x"}, "SANDBOX_DOMAIN_API_URL"},
+		"no tenant":    {&Env{DomainAPIURL: "http://d", SandboxToken: "x"}, "SANDBOX_TENANT_ID"},
+		"no token":     {&Env{DomainAPIURL: "http://d", TenantID: "t"}, "SANDBOX_TOKEN"},
+		"populated":    {&Env{DomainAPIURL: "http://d", TenantID: "t", SandboxToken: "x"}, ""},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			err := requireMarketplaceProxy(tc.env)
+			if tc.errSub == "" {
+				if err != nil {
+					t.Errorf("err=%v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tc.errSub) {
+				t.Errorf("err=%v want substring %q", err, tc.errSub)
+			}
+		})
+	}
+}
+
+// TestMPFQDNRE covers the FQDN pre-validation regex.
+func TestMPFQDNRE(t *testing.T) {
+	good := []string{"acme.com", "app.example.org", "foo.bar.baz", "a-b.c-d.io"}
+	bad := []string{"", "single", ".leadingdot.com", "trailingdot.", "UPPER.com", "x..y.com", "-leading.com"}
+	for _, s := range good {
+		if !mpFQDNRE.MatchString(s) {
+			t.Errorf("expected match: %q", s)
+		}
+	}
+	for _, s := range bad {
+		if mpFQDNRE.MatchString(s) {
+			t.Errorf("expected NO match: %q", s)
+		}
+	}
+}
+
+// TestMPSubdomainRE covers the subdomain pre-validation regex.
+func TestMPSubdomainRE(t *testing.T) {
+	good := []string{"ab", "acme", "dash-board", "x9", "0to9"}
+	bad := []string{"", "a", "-leading", "trailing-", "UPPER", "with.dot", strings.Repeat("x", 33)}
+	for _, s := range good {
+		if !mpSubdomainRE.MatchString(s) {
+			t.Errorf("expected match: %q", s)
+		}
+	}
+	for _, s := range bad {
+		if mpSubdomainRE.MatchString(s) {
+			t.Errorf("expected NO match: %q", s)
+		}
+	}
+}
+
+// TestMarketplaceDomainBYOD_Validation covers arg validation before any
+// network call. We use `WithEnv` without populating DomainAPIURL/TenantID/
+// SandboxToken so the requireMarketplaceProxy gate also asserts pre-call.
+// Cases below all FAIL before any HTTP attempt.
+func TestMarketplaceDomainBYOD_Validation(t *testing.T) {
+	ctx := WithEnv(context.Background(), &Env{}) // requireMarketplaceProxy will fire on populated calls
+	cases := map[string]string{
+		`{}`:                "is required",
+		`{"fqdn":""}`:       "is required",
+		`{"fqdn":"no-dot"}`: "must be a valid lowercase",
+		`{"fqdn":"-bad.com"}`: "must be a valid lowercase",
+	}
+	for args, want := range cases {
+		_, err := marketplaceDomainBYOD(ctx, json.RawMessage(args))
+		if err == nil || !strings.Contains(err.Error(), want) {
+			t.Errorf("args=%s err=%v want %q", args, err, want)
+		}
+	}
+}
+
+// TestMarketplaceDomainSubdomain_Validation covers arg validation
+// before any HTTP roundtrip.
+func TestMarketplaceDomainSubdomain_Validation(t *testing.T) {
+	ctx := WithEnv(context.Background(), &Env{})
+	cases := map[string]string{
+		`{}`:                  "is required",
+		`{"subdomain":""}`:    "is required",
+		`{"subdomain":"-x"}`:  "must match",
+		`{"subdomain":"x.y"}`: "must match",
+		`{"subdomain":"a--b"}`: "consecutive hyphens",
+		`{"subdomain":"ok","parent_zone":"single"}`: "must be a valid FQDN",
+	}
+	for args, want := range cases {
+		_, err := marketplaceDomainSubdomain(ctx, json.RawMessage(args))
+		if err == nil || !strings.Contains(err.Error(), want) {
+			t.Errorf("args=%s err=%v want %q", args, err, want)
+		}
+	}
+}
+
+// TestMarketplaceDomainBYOD_Proxy verifies the proxy round-trip:
+// validates that body fields + bearer + URL path land correctly on the
+// domain service, and that a 201 response is shaped into the
+// marketplaceDomainBYODResponse envelope.
+func TestMarketplaceDomainBYOD_Proxy(t *testing.T) {
+	var gotMethod, gotPath, gotAuth string
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		gotAuth = r.Header.Get("Authorization")
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{
+			"domain": {"id": 42, "domain": "acme.com", "type": "byod"},
+			"cname_target": "sme.openova.io",
+			"registrar": "godaddy",
+			"instructions": "Set CNAME at GoDaddy..."
+		}`))
+	}))
+	defer srv.Close()
+
+	ctx := WithEnv(context.Background(), &Env{
+		DomainAPIURL: srv.URL,
+		TenantID:     "tenant-1",
+		SandboxToken: "tok-abc",
+	})
+	out, err := marketplaceDomainBYOD(ctx, json.RawMessage(`{"fqdn":"acme.com"}`))
+	if err != nil {
+		t.Fatalf("err=%v", err)
+	}
+	if gotMethod != "POST" || gotPath != "/domain/byod" {
+		t.Errorf("method=%q path=%q", gotMethod, gotPath)
+	}
+	if gotAuth != "Bearer tok-abc" {
+		t.Errorf("auth=%q", gotAuth)
+	}
+	if gotBody["tenant_id"] != "tenant-1" || gotBody["domain"] != "acme.com" {
+		t.Errorf("body=%v", gotBody)
+	}
+	resp, ok := out.(marketplaceDomainBYODResponse)
+	if !ok {
+		t.Fatalf("out type=%T want marketplaceDomainBYODResponse", out)
+	}
+	if resp.Status != "Registered" || resp.CNAMETarget != "sme.openova.io" || resp.Registrar != "godaddy" {
+		t.Errorf("resp=%+v", resp)
+	}
+}
+
+// TestMarketplaceDomainBYOD_Conflict verifies the idempotent 409 path.
+func TestMarketplaceDomainBYOD_Conflict(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusConflict)
+		_, _ = w.Write([]byte(`{"error":"domain already registered"}`))
+	}))
+	defer srv.Close()
+
+	ctx := WithEnv(context.Background(), &Env{
+		DomainAPIURL: srv.URL,
+		TenantID:     "tenant-1",
+		SandboxToken: "tok-abc",
+	})
+	out, err := marketplaceDomainBYOD(ctx, json.RawMessage(`{"fqdn":"acme.com"}`))
+	if err != nil {
+		t.Fatalf("err=%v", err)
+	}
+	m, ok := out.(map[string]any)
+	if !ok || m["status"] != "AlreadyExists" {
+		t.Errorf("out=%v", out)
+	}
+}
+
+// TestMarketplaceDomainSubdomain_Proxy verifies the subdomain proxy
+// round-trip including the optional parent_zone → tld translation.
+func TestMarketplaceDomainSubdomain_Proxy(t *testing.T) {
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{
+			"id": 7,
+			"domain": "dashboard.openova.cloud",
+			"type": "subdomain",
+			"tld": "openova.cloud",
+			"subdomain": "dashboard"
+		}`))
+	}))
+	defer srv.Close()
+	ctx := WithEnv(context.Background(), &Env{
+		DomainAPIURL: srv.URL,
+		TenantID:     "tenant-1",
+		SandboxToken: "tok-abc",
+	})
+	out, err := marketplaceDomainSubdomain(ctx, json.RawMessage(`{"subdomain":"dashboard","parent_zone":"openova.cloud"}`))
+	if err != nil {
+		t.Fatalf("err=%v", err)
+	}
+	if gotBody["tenant_id"] != "tenant-1" || gotBody["subdomain"] != "dashboard" || gotBody["tld"] != "openova.cloud" {
+		t.Errorf("body=%v", gotBody)
+	}
+	resp, ok := out.(marketplaceDomainSubdomainResponse)
+	if !ok {
+		t.Fatalf("type=%T", out)
+	}
+	if resp.Status != "Registered" || resp.FQDN != "dashboard.openova.cloud" || resp.ParentZone != "openova.cloud" {
+		t.Errorf("resp=%+v", resp)
+	}
+}
+
+// TestMarketplaceCapabilityGate confirms the registry rejects
+// marketplace.* calls whose claims lack the `marketplace` capability.
+func TestMarketplaceCapabilityGate(t *testing.T) {
+	r := NewRegistry(&Env{
+		OrgID:        "acme",
+		JWTSecret:    []byte("x"),
+		DomainAPIURL: "http://d",
+		TenantID:     "t",
+		SandboxToken: "tok",
+	})
+	for _, name := range []string{"marketplace.domain.byod", "marketplace.domain.subdomain"} {
+		t.Run(name, func(t *testing.T) {
+			cl := &sharedauth.Claims{OrgID: "acme", Capabilities: []string{"sandbox.db"}}
+			args := json.RawMessage(`{"fqdn":"acme.com","subdomain":"x"}`)
+			_, err := r.Call(context.Background(), name, args, CallOpts{Claims: cl})
+			if err == nil || !strings.Contains(err.Error(), "forbidden") {
+				t.Errorf("missing cap: err=%v want forbidden", err)
+			}
+		})
+	}
+}

--- a/products/sandbox/mcp-server/internal/tools/registry.go
+++ b/products/sandbox/mcp-server/internal/tools/registry.go
@@ -20,6 +20,11 @@
 //   - sandbox.secrets.read / sandbox.secrets.write
 //   - sandbox.session.whoami / sandbox.session.info
 //
+// Wave 12 extends to marketplace.domain.* + flux.*:
+//
+//   - marketplace.domain.byod / marketplace.domain.subdomain
+//   - flux.status / flux.reconcile / flux.suspend / flux.resume
+//
 // All other namespaces (sandbox.stripe.*, sandbox.preview.*,
 // k8s.write.*, gitea.release.list) remain stubbed and continue to
 // return not_implemented until later waves ship them.
@@ -154,6 +159,38 @@ type Env struct {
 	// PARENT (admin auth target) for realm CRUD; the per-Sandbox
 	// realm itself is a sibling under the same Keycloak instance.
 	KeycloakParentRealm string
+
+	// DomainAPIURL — root URL of the canonical domain service
+	// (`core/services/domain`), e.g.
+	// `http://domain.sme.svc.cluster.local:8086`. The marketplace.*
+	// tool family proxies POST /domain/byod + POST /domain/subdomains
+	// here. Empty → marketplace.* surfaces a clear "not configured"
+	// error rather than failing on a bad URL.
+	//
+	// Wired by sandbox-controller as SANDBOX_DOMAIN_API_URL on the
+	// MCP Deployment env. The same value flows into the per-Sovereign
+	// gateway service as DOMAIN_URL — kept separate here so the MCP
+	// server can target the domain service DIRECTLY rather than via
+	// the gateway (one fewer hop on a tool call).
+	DomainAPIURL string
+
+	// MarketplaceAPIURL — root URL of the marketplace-api service
+	// (`core/marketplace-api`), e.g.
+	// `http://marketplace-api.marketplace.svc.cluster.local:8082`.
+	// Reserved for future marketplace.* tools that drive provisioning
+	// (e.g. marketplace.app.deploy). Empty today on every Sandbox; the
+	// Wave 12 marketplace.domain.* tools target DomainAPIURL instead.
+	MarketplaceAPIURL string
+
+	// TenantID — the tenant identifier the canonical domain service
+	// uses to scope BYOD / subdomain registrations
+	// (`core/services/domain/handlers/handlers.go` checkTenantMembership).
+	// Distinct from OrgID because the SME tenant service identifies
+	// orgs by a separate `tenant_id` UUID — sandbox-controller injects
+	// it as SANDBOX_TENANT_ID once the chroot Organization controller
+	// has minted the tenant row. Empty → marketplace.domain.* surfaces
+	// a clear "not configured" error.
+	TenantID string
 }
 
 // claimsCtxKey is the unexported context key under which the
@@ -499,6 +536,62 @@ func defaultCatalogue(env *Env) []Tool {
 			InputSchema:        schemaSandboxSecretsWrite(),
 			Handler:            sandboxSecretsWrite,
 			RequiredCapability: "sandbox.secrets",
+		},
+
+		// marketplace.domain.* — Wave 12 thin proxy to
+		// core/services/domain (marketplace.go). Every call forwards the
+		// Sandbox PAT to the domain service which performs the canonical
+		// auth + WHOIS + uniqueness checks. RequiredCapability="marketplace"
+		// gates the bearer.
+		{
+			Name:               "marketplace.domain.byod",
+			Description:        "Register a Bring-Your-Own-Domain (BYOD) FQDN for the Sandbox's tenant. Returns the CNAME target the operator points at their registrar.",
+			InputSchema:        schemaMarketplaceDomainBYOD(),
+			Handler:            marketplaceDomainBYOD,
+			RequiredCapability: "marketplace",
+		},
+		{
+			Name:               "marketplace.domain.subdomain",
+			Description:        "Reserve a `<subdomain>.<parent_zone>` under the Sovereign-managed subdomain pool (parent_zone defaults to the configured pool TLD).",
+			InputSchema:        schemaMarketplaceDomainSubdomain(),
+			Handler:            marketplaceDomainSubdomain,
+			RequiredCapability: "marketplace",
+		},
+
+		// flux.* — Wave 12 Flux read/kick surface (flux.go). status is
+		// pure-read; reconcile/suspend/resume mutate exactly one
+		// well-known annotation or spec field on a tenant-scoped HR /
+		// Kustomization. The dynamic client's RBAC gates which
+		// namespaces the SA can patch — the MCP server itself does
+		// not maintain a separate allow-list. RequiredCapability="flux"
+		// gates every call regardless of read vs write.
+		{
+			Name:               "flux.status",
+			Description:        "List HelmReleases + Kustomizations in the Sandbox's tenant namespaces with their Ready condition + last applied revision.",
+			InputSchema:        schemaFluxStatus(),
+			Handler:            fluxStatus,
+			RequiredCapability: "flux",
+		},
+		{
+			Name:               "flux.reconcile",
+			Description:        "Force-run a Flux reconcile on a tenant-scoped HelmRelease or Kustomization by setting the `reconcile.fluxcd.io/requestedAt` annotation.",
+			InputSchema:        schemaFluxMutation(),
+			Handler:            fluxReconcile,
+			RequiredCapability: "flux",
+		},
+		{
+			Name:               "flux.suspend",
+			Description:        "Set spec.suspend=true on a tenant-scoped HelmRelease or Kustomization so Flux stops reconciling it.",
+			InputSchema:        schemaFluxMutation(),
+			Handler:            fluxSuspend,
+			RequiredCapability: "flux",
+		},
+		{
+			Name:               "flux.resume",
+			Description:        "Set spec.suspend=false on a tenant-scoped HelmRelease or Kustomization so Flux resumes reconciling.",
+			InputSchema:        schemaFluxMutation(),
+			Handler:            fluxResume,
+			RequiredCapability: "flux",
 		},
 
 		// sandbox.session.* — this MCP server's own metadata (Wave 8).


### PR DESCRIPTION
## Summary
- Ships **six previously-stub MCP tools** as real handlers: `marketplace.domain.byod`, `marketplace.domain.subdomain`, `flux.status`, `flux.reconcile`, `flux.suspend`, `flux.resume`.
- `marketplace.domain.*` proxies the canonical `POST /domain/byod` + `POST /domain/subdomains` on `core/services/domain` with the Sandbox PAT as bearer (`SANDBOX_DOMAIN_API_URL` + `SANDBOX_TENANT_ID` env vars wired through the sandbox-controller).
- `flux.*` uses the same in-cluster dynamic client every `k8s.read.*` tool already builds. `flux.status` distils HelmRelease + Kustomization Ready conditions into a flat snake_case table; `reconcile/suspend/resume` issue strategic-merge patches against the canonical `reconcile.fluxcd.io/requestedAt` annotation + `spec.suspend` field.

## Scope guardrails
- READ-ONLY hard rule on `k8s.write.*` is preserved. The flux reconcile/suspend/resume trio is the explicitly-carved-out exception (task brief): each mutates exactly one well-known field on a tenant-scoped HR / Kustomization.
- Tenant scoping: `flux.status` enumerates the Sandbox namespace + caller-supplied extras only (never cluster-wide). Mutations default `namespace` to `env.SandboxNamespace`; the SA's RBAC is the actual gate.
- Auth: HS256 bearer + `claims.OrgID == env.OrgID` + `RequiredCapability="marketplace"` (or `"flux"`) — same shape as `sandbox.db.*` / `sandbox.auth.*` / `sandbox.secrets.*`.

## Wire env additions (NewEnvFromOS)
- `SANDBOX_DOMAIN_API_URL` — proxy target (e.g. `http://domain.sme.svc.cluster.local:8086`)
- `SANDBOX_MARKETPLACE_API_URL` — reserved for future marketplace.* tools
- `SANDBOX_TENANT_ID` — scopes the domain service calls

## Test plan
- [x] `go build ./...` clean (Go 1.23.4)
- [x] `go vet ./...` clean
- [x] `go test ./...` clean — adds `marketplace_test.go` (requireMarketplaceProxy gate, FQDN/subdomain regex, validation surface, httptest-backed proxy round-trip, 409 idempotent branch, capability-gate matrix) + `flux_test.go` (kind → GVR routing, namespace defaulting, Ready-condition extraction, summary distillation, mutation arg validation, capability-gate matrix).
- [ ] Runtime smoke: with controller-wired env vars, invoke `marketplace.domain.byod fqdn=acme.com` from the Sandbox; verify the domain service records the row + CNAME target is returned.
- [ ] Runtime smoke: `flux.status` + `flux.reconcile kind=HelmRelease name=<my-hr>` against a live tenant ns.

Branch: `sandbox-wave12-mcp-marketplace-flux`  •  No chart bump (the controller wave handles the env wiring + admin-merge).