### PR TITLE
feat(sandbox+tenant): CNPG active-hot-standby (ReplicaCluster) default for marketplace tenants when SOVEREIGN_ENABLE_HOT_STANDBY=true

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -726,6 +726,28 @@ spec:
       orgName: '${ORG_NAME:-}'
       controlPlaneIP: '${SOVEREIGN_CONTROL_PLANE_IP:-}'
       gitopsRepoURL: '${GITOPS_REPO_URL:-}'
+      # ─── D31 active-hot-standby (cross-region CNPG) ──────────────────
+      # Sovereign-level opt-in for the active-hot-standby Postgres shape
+      # on every CNPG-backed tenant app the marketplace installs.
+      # Default-OFF — every Sovereign that has not flipped
+      # SOVEREIGN_ENABLE_HOT_STANDBY=true on the per-Sovereign overlay
+      # keeps rendering single-Cluster CNPG (no regression). When ON
+      # AND both region keys are non-empty AND distinct, the SME-tenant
+      # gitops writer injects pg.activeHotStandby.* into every fresh
+      # bp-wordpress-tenant HelmRelease so the chart's
+      # cnpg-cluster.yaml template renders a primary + replica
+      # Cluster.postgresql.cnpg.io pair across the two regions, WAL
+      # streaming over Cilium ClusterMesh (DoD D11 + D31). Same wiring
+      # extends to any future tenant product chart (gitlab-tenant,
+      # nextcloud-tenant) that adopts the same value contract.
+      #
+      # Region keys MUST match the canonical openova.io/region node
+      # label value (e.g. `hz-fsn-rtz-prod`, `hz-hel-rtz-prod`) — the
+      # WordPress chart's cnpg-cluster.yaml uses nodeAffinity on that
+      # label to pin the primary + replica Pods to the right regions.
+      enableHotStandby: '${SOVEREIGN_ENABLE_HOT_STANDBY:-}'
+      primaryRegion: '${SOVEREIGN_PRIMARY_REGION:-}'
+      replicaRegion: '${SOVEREIGN_REPLICA_REGION:-}'
     # ─── QA fixtures (qa-loop iter-6 Cluster-F + EPIC-6 iter-6) ────────
     # Default-OFF on production; flipped to true via envsubst
     # QA_FIXTURES_ENABLED=true on the per-Sovereign overlay for any

--- a/clusters/_template/bootstrap-kit/19a-bp-sandbox.yaml
+++ b/clusters/_template/bootstrap-kit/19a-bp-sandbox.yaml
@@ -105,3 +105,20 @@ spec:
       ptyServerImage: ${SANDBOX_PTY_SERVER_IMAGE}
       mcpImage: ${SANDBOX_MCP_IMAGE}
       newapiURL: https://newapi.${SOVEREIGN_FQDN}/v1
+    # D31 active-hot-standby — when SOVEREIGN_ENABLE_HOT_STANDBY=true on
+    # the per-Sovereign overlay (and both regions are non-empty AND
+    # distinct), sandbox.db.provision materialises a primary + replica
+    # Cluster.postgresql.cnpg.io pair instead of a single Cluster
+    # (mirrors the bp-cnpg-pair pattern + bp-wordpress-tenant chart
+    # 0.2.0+). Same trio of envsubst placeholders bp-catalyst-platform
+    # slot 13 consumes for the marketplace tenant path — flipping one
+    # knob on the per-Sovereign overlay covers BOTH paths so HA stays
+    # consistent across the marketplace tenant install and the
+    # sandbox.db plane. Default empty = single-Cluster CNPG (zero
+    # regression). Region keys MUST match the canonical openova.io/
+    # region node label value (e.g. `hz-fsn-rtz-prod`).
+    cnpg:
+      activeHotStandby:
+        enabled: ${SOVEREIGN_ENABLE_HOT_STANDBY:-}
+        primaryRegion: ${SOVEREIGN_PRIMARY_REGION:-}
+        replicaRegion: ${SOVEREIGN_REPLICA_REGION:-}

--- a/core/controllers/sandbox/cmd/sandbox-controller/main.go
+++ b/core/controllers/sandbox/cmd/sandbox-controller/main.go
@@ -82,6 +82,19 @@ func main() {
 	newapiAdmin := strings.TrimSpace(os.Getenv("NEWAPI_ADMIN_SECRET"))
 	defaultChannels := splitAndTrim(envOr("NEWAPI_DEFAULT_CHANNELS", ""), ",")
 
+	// D31 active-hot-standby — Sovereign-level toggle + region pair the
+	// controller threads into every per-Sandbox MCP Pod. The MCP
+	// server's sandbox.db.provision handler reads these at call time
+	// and, when valid, materialises a primary + replica Cluster.
+	// postgresql.cnpg.io pair instead of a single Cluster (DoD D31).
+	// Default-empty keeps every existing Sandbox on single-Cluster
+	// CNPG (zero regression). Bootstrap-kit slot 61 wires these from
+	// the per-Sovereign overlay's envsubst placeholders into the
+	// bp-sandbox HelmRelease values.
+	enableHotStandby := envOr("SOVEREIGN_ENABLE_HOT_STANDBY", "")
+	primaryRegion := envOr("SOVEREIGN_PRIMARY_REGION", "")
+	replicaRegion := envOr("SOVEREIGN_REPLICA_REGION", "")
+
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:                 scheme,
 		Metrics:                metricsserver.Options{BindAddress: metricsAddr},
@@ -134,6 +147,9 @@ func main() {
 		IdleTimeoutMinutes:    idleTimeoutMinutes,
 		NewAPIClient:          newapiClient,
 		DefaultChannels:       defaultChannels,
+		EnableHotStandby:      enableHotStandby,
+		PrimaryRegion:         primaryRegion,
+		ReplicaRegion:         replicaRegion,
 	}
 	if err := r.SetupWithManager(mgr); err != nil {
 		log.Error(err, "setup reconciler")

--- a/core/controllers/sandbox/internal/controller/sandbox_controller.go
+++ b/core/controllers/sandbox/internal/controller/sandbox_controller.go
@@ -77,6 +77,20 @@ type Reconciler struct {
 	BYOSSecretPrefix      string
 	IdleTimeoutMinutes    int
 
+	// D31 active-hot-standby — Sovereign-level toggle + region pair the
+	// controller threads from its chart env (SOVEREIGN_ENABLE_HOT_STANDBY,
+	// SOVEREIGN_PRIMARY_REGION, SOVEREIGN_REPLICA_REGION) into every
+	// per-Sandbox MCP Pod via gitops.Inputs. The MCP server's
+	// sandbox.db.provision handler reads them at call time and renders a
+	// primary + replica Cluster.postgresql.cnpg.io pair when valid.
+	// Default-empty keeps every existing Sandbox on single-Cluster CNPG
+	// (zero regression). Bootstrap-kit slot 61 wires the per-Sovereign
+	// overlay's envsubst placeholders into the bp-sandbox HelmRelease
+	// values; the chart surfaces them as the controller's env.
+	EnableHotStandby string
+	PrimaryRegion    string
+	ReplicaRegion    string
+
 	// Wave 9 — NewAPI bridge client used by Reconcile to mint
 	// per-Sandbox LLM-gateway tokens (POST /admin/tokens/sandbox,
 	// PR #1638). When nil the reconciler renders the Wave 1+8
@@ -237,6 +251,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		NewAPITokenSecretName: fmt.Sprintf("sandbox-%s-newapi-token", ownerUID),
 		NewAPITokenExpiresAt:  tokenExpiresAt,
 		NewAPITokenRotatedAt:  tokenRotatedAt,
+		EnableHotStandby:      r.EnableHotStandby,
+		PrimaryRegion:         r.PrimaryRegion,
+		ReplicaRegion:         r.ReplicaRegion,
 	}
 	manifests, err := gitops.Render(in)
 	if err != nil {

--- a/core/controllers/sandbox/internal/gitops/manifests.go
+++ b/core/controllers/sandbox/internal/gitops/manifests.go
@@ -71,6 +71,21 @@ type Inputs struct {
 	NewAPITokenSecretName string
 	NewAPITokenExpiresAt  string
 	NewAPITokenRotatedAt  string
+
+	// D31 active-hot-standby — Sovereign-level toggle + region pair the
+	// sandbox-controller propagates into every per-Sandbox MCP Pod via
+	// SOVEREIGN_ENABLE_HOT_STANDBY / SOVEREIGN_PRIMARY_REGION /
+	// SOVEREIGN_REPLICA_REGION env. The MCP server's sandbox.db.provision
+	// handler reads them at call time and, when valid, materialises a
+	// primary + replica Cluster.postgresql.cnpg.io pair instead of a
+	// single Cluster (mirrors the bp-cnpg-pair pattern). Default empty
+	// (zero regression): every Sandbox stays on single-Cluster CNPG.
+	// Sourced from the sandbox-controller's own env (chart values
+	// `cnpg.activeHotStandby.*` plumbed by bootstrap-kit slot 61 from
+	// the per-Sovereign overlay's envsubst placeholders).
+	EnableHotStandby string
+	PrimaryRegion    string
+	ReplicaRegion    string
 }
 
 const namespaceTemplate = `apiVersion: v1
@@ -395,6 +410,23 @@ spec:
                   name: {{ .LLMGatewayTokenSecret | quote }}
                   key: llm-gateway-token
                   optional: true
+            # ── D31 active-hot-standby — Sovereign-level toggle + region
+            # pair. When SOVEREIGN_ENABLE_HOT_STANDBY parses truthy AND
+            # both region values are non-empty AND distinct, sandbox.db.
+            # provision materialises a primary + replica Cluster.
+            # postgresql.cnpg.io pair instead of a single Cluster (DoD
+            # D31). Default-off keeps every existing Sandbox on single-
+            # Cluster CNPG (zero regression). The values flow:
+            #   bootstrap-kit slot 19a envsubst (per-Sovereign overlay)
+            #   -> bp-sandbox HelmRelease values
+            #   -> sandbox-controller env (host cluster)
+            #   -> here, into every per-Sandbox MCP Pod
+            - name: SOVEREIGN_ENABLE_HOT_STANDBY
+              value: {{ .EnableHotStandby | quote }}
+            - name: SOVEREIGN_PRIMARY_REGION
+              value: {{ .PrimaryRegion | quote }}
+            - name: SOVEREIGN_REPLICA_REGION
+              value: {{ .ReplicaRegion | quote }}
           resources:
             requests:
               cpu: "50m"

--- a/platform/sandbox/chart/templates/deployment.yaml
+++ b/platform/sandbox/chart/templates/deployment.yaml
@@ -95,6 +95,23 @@ spec:
                   optional: true
             - name: NEWAPI_DEFAULT_CHANNELS
               value: {{ .Values.env.newapiDefaultChannels | default "" | quote }}
+            # D31 active-hot-standby — Sovereign-level toggle + region
+            # pair the controller threads into every per-Sandbox MCP
+            # Pod. When the toggle parses truthy AND both regions are
+            # non-empty AND distinct, sandbox.db.provision materialises
+            # a primary + replica Cluster.postgresql.cnpg.io pair
+            # instead of a single Cluster (mirrors the bp-cnpg-pair
+            # pattern). Default empty (zero regression) — every
+            # Sandbox stays on single-Cluster CNPG until the operator
+            # flips SOVEREIGN_ENABLE_HOT_STANDBY=true on the per-
+            # Sovereign overlay. Bootstrap-kit slot 61 wires those
+            # envsubst placeholders into `.Values.cnpg.activeHotStandby.*`.
+            - name: SOVEREIGN_ENABLE_HOT_STANDBY
+              value: {{ (.Values.cnpg).activeHotStandby.enabled | default "" | quote }}
+            - name: SOVEREIGN_PRIMARY_REGION
+              value: {{ (.Values.cnpg).activeHotStandby.primaryRegion | default "" | quote }}
+            - name: SOVEREIGN_REPLICA_REGION
+              value: {{ (.Values.cnpg).activeHotStandby.replicaRegion | default "" | quote }}
             {{- range $k, $v := .Values.extraEnv }}
             - name: {{ $k | quote }}
               value: {{ $v | quote }}

--- a/platform/sandbox/chart/values.yaml
+++ b/platform/sandbox/chart/values.yaml
@@ -99,4 +99,33 @@ giteaTokenSecret:
 newapiAdminSecret:
   name: "newapi-bp-newapi-token-signing-key"
   key: "ADMIN_SECRET"
+# D31 active-hot-standby — Sovereign-level opt-in for the cross-region
+# CNPG ReplicaCluster shape on every Sandbox-provisioned database. When
+# `cnpg.activeHotStandby.enabled` parses truthy (true/1/yes/on) AND
+# both region keys are non-empty AND distinct, the MCP server's
+# `sandbox.db.provision` handler materialises a primary + replica
+# Cluster.postgresql.cnpg.io pair (one each in the two regions) instead
+# of a single Cluster. Mirrors the bp-cnpg-pair pattern + the
+# bp-wordpress-tenant `pg.activeHotStandby.*` value contract (PR
+# #1562). Default-off keeps every existing Sandbox on single-Cluster
+# CNPG (zero regression).
+#
+# The chart surfaces this stanza to the sandbox-controller as three
+# env vars (SOVEREIGN_ENABLE_HOT_STANDBY, SOVEREIGN_PRIMARY_REGION,
+# SOVEREIGN_REPLICA_REGION) which the controller in turn propagates
+# into every per-Sandbox MCP Pod via gitops.Inputs. Bootstrap-kit slot
+# 61 (clusters/_template/bootstrap-kit/61-bp-sandbox.yaml) wires
+# operator overrides from the per-Sovereign overlay's envsubst
+# placeholders — flip one knob and BOTH the marketplace tenant path
+# (sme_tenant_gitops.go) AND the sandbox.db plane render the HA shape.
+#
+# Region keys MUST match the canonical openova.io/region node label
+# value (e.g. `hz-fsn-rtz-prod`, `hz-hel-rtz-prod`). The CNPG operator's
+# nodeAffinity matches on this label to pin the primary + replica
+# StatefulSet Pods to the right regions.
+cnpg:
+  activeHotStandby:
+    enabled: ""
+    primaryRegion: ""
+    replicaRegion: ""
 extraEnv: {}

--- a/products/catalyst/bootstrap/api/internal/handler/sme_tenant_active_hot_standby_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sme_tenant_active_hot_standby_test.go
@@ -1,0 +1,124 @@
+// sme_tenant_active_hot_standby_test.go — D31 active-hot-standby
+// regression tests for the SME-tenant gitops writer.
+//
+// The render path reads three Pod-env vars at template time:
+//
+//   SOVEREIGN_ENABLE_HOT_STANDBY  (true/false/empty)
+//   SOVEREIGN_PRIMARY_REGION      (canonical openova.io/region label)
+//   SOVEREIGN_REPLICA_REGION      (canonical openova.io/region label)
+//
+// When the toggle is on AND both regions are non-empty AND distinct, the
+// rendered bp-wordpress-tenant HelmRelease emits a
+// `values.pg.activeHotStandby.{enabled,primaryRegion,replicaRegion}`
+// block — bp-wordpress-tenant chart 0.2.0+ then renders a primary +
+// replica Cluster.postgresql.cnpg.io pair (templates/cnpg-cluster.yaml).
+// In every other shape (toggle off, missing region, identical regions)
+// the writer falls back to the single-Cluster shape — defence-in-depth
+// against malformed inputs that would otherwise break the entire
+// tenant overlay reconcile via the chart's
+// `validateActiveHotStandbyRegions` helper's hard `fail`.
+
+package handler
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/store"
+)
+
+func d31TestRec() store.SMETenantProvisionRecord {
+	return store.SMETenantProvisionRecord{
+		SMETenantID:     "t-acme",
+		Subdomain:       "acme",
+		DomainMode:      store.SMEDomainFreeSubdomain,
+		AdminEmail:      "admin@acme.test",
+		OTECHFQDN:       "otech.example",
+		VClusterName:    "vc-acme",
+		TenantNamespace: "sme-t-acme",
+	}
+}
+
+// Without SOVEREIGN_ENABLE_HOT_STANDBY set the WordPress HelmRelease
+// MUST NOT carry a pg.activeHotStandby block — the chart falls through
+// to its values.yaml default (enabled=false → single-Cluster CNPG).
+// Backward-compat gate.
+func TestRenderSMETenantOverlay_HotStandby_Off_NoBlock(t *testing.T) {
+	t.Setenv("SOVEREIGN_ENABLE_HOT_STANDBY", "")
+	t.Setenv("SOVEREIGN_PRIMARY_REGION", "")
+	t.Setenv("SOVEREIGN_REPLICA_REGION", "")
+	files, err := renderSMETenantOverlay(d31TestRec(), SMETenantChartVersions{})
+	if err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	wp := files["bp-wordpress-tenant.yaml"]
+	if strings.Contains(wp, "activeHotStandby") {
+		t.Fatalf("expected no activeHotStandby block when toggle is off:\n%s", wp)
+	}
+}
+
+// With the canonical happy-path env triple, the HelmRelease MUST carry
+// the chart's pg.activeHotStandby.{enabled,primaryRegion,replicaRegion}
+// block so bp-wordpress-tenant chart 0.2.0+ renders the primary +
+// replica Cluster CR pair (DoD D31).
+func TestRenderSMETenantOverlay_HotStandby_On_EmitsBlock(t *testing.T) {
+	t.Setenv("SOVEREIGN_ENABLE_HOT_STANDBY", "true")
+	t.Setenv("SOVEREIGN_PRIMARY_REGION", "hz-fsn-rtz-prod")
+	t.Setenv("SOVEREIGN_REPLICA_REGION", "hz-hel-rtz-prod")
+	files, err := renderSMETenantOverlay(d31TestRec(), SMETenantChartVersions{})
+	if err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	wp := files["bp-wordpress-tenant.yaml"]
+	for _, want := range []string{
+		"pg:",
+		"activeHotStandby:",
+		"enabled: true",
+		"primaryRegion: hz-fsn-rtz-prod",
+		"replicaRegion: hz-hel-rtz-prod",
+	} {
+		if !strings.Contains(wp, want) {
+			t.Errorf("missing %q in HA WordPress overlay:\n%s", want, wp)
+		}
+	}
+}
+
+// Defence-in-depth: the writer falls back to single-cluster shape when
+// the operator opts in but the region pair is degenerate (empty primary,
+// empty replica, primary==replica). The alternative — emitting the
+// block anyway — would let the chart's validateActiveHotStandbyRegions
+// helper `fail` at template time and gate the entire tenant overlay
+// reconcile, which is far worse than degrading silently to non-HA.
+func TestRenderSMETenantOverlay_HotStandby_Degenerate_FallsBackToSingle(t *testing.T) {
+	cases := []struct {
+		name        string
+		enable      string
+		primary     string
+		replica     string
+		wantHABlock bool
+	}{
+		{"toggle-on-no-regions", "true", "", "", false},
+		{"toggle-on-empty-primary", "true", "", "hz-hel-rtz-prod", false},
+		{"toggle-on-empty-replica", "true", "hz-fsn-rtz-prod", "", false},
+		{"toggle-on-same-region", "true", "hz-fsn-rtz-prod", "hz-fsn-rtz-prod", false},
+		{"toggle-off-with-regions", "false", "hz-fsn-rtz-prod", "hz-hel-rtz-prod", false},
+		{"toggle-on-distinct-regions", "true", "hz-fsn-rtz-prod", "hz-hel-rtz-prod", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("SOVEREIGN_ENABLE_HOT_STANDBY", tc.enable)
+			t.Setenv("SOVEREIGN_PRIMARY_REGION", tc.primary)
+			t.Setenv("SOVEREIGN_REPLICA_REGION", tc.replica)
+			files, err := renderSMETenantOverlay(d31TestRec(), SMETenantChartVersions{})
+			if err != nil {
+				t.Fatalf("render: %v", err)
+			}
+			wp := files["bp-wordpress-tenant.yaml"]
+			has := strings.Contains(wp, "activeHotStandby:")
+			if has != tc.wantHABlock {
+				t.Fatalf("activeHotStandby presence=%v, want %v\noverlay:\n%s",
+					has, tc.wantHABlock, wp)
+			}
+		})
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/handler/sme_tenant_gitops.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sme_tenant_gitops.go
@@ -465,6 +465,47 @@ type smeTenantTemplateData struct {
 	IsBYO         bool
 	ChartVersions SMETenantChartVersions
 	GeneratedAt   string
+
+	// D31 active-hot-standby — opt-in cross-region CNPG ReplicaCluster
+	// for CNPG-backed tenant apps. The bp-wordpress-tenant chart
+	// (platform/wordpress-tenant/chart/templates/cnpg-cluster.yaml,
+	// PR #1562) already supports a `pg.activeHotStandby.{enabled,
+	// primaryRegion,replicaRegion}` block: when enabled it renders a
+	// primary + replica `Cluster.postgresql.cnpg.io` pair pinned to two
+	// distinct openova.io/region values, with WAL streaming over
+	// Cilium ClusterMesh via the `service.cilium.io/global` Service the
+	// CNPG operator provisions on the primary. Single-cluster
+	// (legacy) shape stays the default for every tenant that hasn't
+	// opted in.
+	//
+	// Source: the trio is sourced from the catalyst-api Pod env at
+	// render time (env keys: SOVEREIGN_ENABLE_HOT_STANDBY,
+	// SOVEREIGN_PRIMARY_REGION, SOVEREIGN_REPLICA_REGION). Bootstrap-
+	// kit slot 13 (clusters/_template/bootstrap-kit/13-bp-catalyst-
+	// platform.yaml) wires those envsubst placeholders from
+	// per-Sovereign overlays so an operator flips one knob and every
+	// future tenant install gets the HA shape.
+	//
+	// Default behaviour (EnableHotStandby=false): the rendered
+	// HelmRelease omits the `pg.activeHotStandby` block entirely so the
+	// chart falls back to its values.yaml default (enabled=false). Zero
+	// regression for any Sovereign that has not opted in.
+	//
+	// When EnableHotStandby=true at render time we additionally enforce:
+	//   - PrimaryRegion non-empty
+	//   - ReplicaRegion non-empty AND distinct from PrimaryRegion
+	// If any of those fail we fall back to single-cluster shape rather
+	// than emitting a HelmRelease the chart's
+	// `validateActiveHotStandbyRegions` helper would `fail` at template
+	// time — a failed template render blocks the entire tenant overlay
+	// reconcile, which is far worse than degrading silently to non-HA.
+	// Same shape applies to any future tenant product chart (gitlab-
+	// tenant, nextcloud-tenant) that adopts the same value contract;
+	// today those charts do not exist in this monorepo so this wiring
+	// is exercised only by bp-wordpress-tenant.
+	EnableHotStandby bool
+	PrimaryRegion    string
+	ReplicaRegion    string
 }
 
 // renderSMETenantOverlay turns a record into a map<filename, contents>
@@ -498,24 +539,49 @@ func renderSMETenantOverlay(rec store.SMETenantProvisionRecord, versions SMETena
 	owHost := strings.Replace(host, "console.", "openclaw.", 1)
 	mailHost := strings.Replace(host, "console.", "mail.", 1)
 
+	// D31 active-hot-standby — read the Sovereign-level toggle + region
+	// pair from the catalyst-api Pod env at render time. Wired by
+	// bootstrap-kit slot 13 (clusters/_template/bootstrap-kit/13-bp-
+	// catalyst-platform.yaml) from envsubst placeholders the operator
+	// sets at provision time. Default-off keeps every existing tenant
+	// rendering single-cluster CNPG (no regression).
+	enableHotStandby := false
+	switch strings.ToLower(strings.TrimSpace(envOr("SOVEREIGN_ENABLE_HOT_STANDBY", ""))) {
+	case "true", "1", "yes", "on":
+		enableHotStandby = true
+	}
+	primaryRegion := strings.TrimSpace(envOr("SOVEREIGN_PRIMARY_REGION", ""))
+	replicaRegion := strings.TrimSpace(envOr("SOVEREIGN_REPLICA_REGION", ""))
+	// Defence-in-depth: if the operator opted in to HA but didn't wire
+	// distinct regions, fall back to single-cluster mode rather than
+	// rendering a HelmRelease the WordPress chart's
+	// validateActiveHotStandbyRegions helper would reject at template
+	// time (which would block the entire tenant overlay reconcile).
+	if enableHotStandby && (primaryRegion == "" || replicaRegion == "" || primaryRegion == replicaRegion) {
+		enableHotStandby = false
+	}
+
 	data := smeTenantTemplateData{
-		TenantID:      rec.SMETenantID,
-		Subdomain:     rec.Subdomain,
-		Namespace:     rec.TenantNamespace,
-		VClusterName:  rec.VClusterName,
-		OTECHFQDN:     rec.OTECHFQDN,
-		ParentDomain:  parentZone,
-		ConsoleHost:   host,
-		WordPressHost: wpHost,
-		OpenClawHost:  owHost,
-		MailHost:      mailHost,
-		AdminEmail:    rec.AdminEmail,
-		CompanyName:   rec.CompanyName,
-		DomainMode:    string(rec.DomainMode),
-		BYODomain:     rec.BYODomain,
-		IsBYO:         rec.DomainMode == store.SMEDomainBYO,
-		ChartVersions: versions,
-		GeneratedAt:   time.Now().UTC().Format(time.RFC3339),
+		TenantID:         rec.SMETenantID,
+		Subdomain:        rec.Subdomain,
+		Namespace:        rec.TenantNamespace,
+		VClusterName:     rec.VClusterName,
+		OTECHFQDN:        rec.OTECHFQDN,
+		ParentDomain:     parentZone,
+		ConsoleHost:      host,
+		WordPressHost:    wpHost,
+		OpenClawHost:     owHost,
+		MailHost:         mailHost,
+		AdminEmail:       rec.AdminEmail,
+		CompanyName:      rec.CompanyName,
+		DomainMode:       string(rec.DomainMode),
+		BYODomain:        rec.BYODomain,
+		IsBYO:            rec.DomainMode == store.SMEDomainBYO,
+		ChartVersions:    versions,
+		GeneratedAt:      time.Now().UTC().Format(time.RFC3339),
+		EnableHotStandby: enableHotStandby,
+		PrimaryRegion:    primaryRegion,
+		ReplicaRegion:    replicaRegion,
 	}
 
 	out := map[string]string{}
@@ -1041,9 +1107,26 @@ spec:
       host: {{.WordPressHost}}
       tls:
         issuer: letsencrypt-prod
+{{- if .EnableHotStandby }}
+    # D31 active-hot-standby — primary + replica Cluster CR pair across
+    # the Sovereign's two declared regions, WAL streaming over Cilium
+    # ClusterMesh (DoD D11 — clustermesh apiserver via LoadBalancer +
+    # peer cert exchange). Toggled at the bootstrap-kit slot 13 layer
+    # via SOVEREIGN_ENABLE_HOT_STANDBY=true on the per-Sovereign
+    # overlay; the catalyst-api Pod reads SOVEREIGN_PRIMARY_REGION /
+    # SOVEREIGN_REPLICA_REGION env at render time and writes them
+    # through here. Chart contract: bp-wordpress-tenant chart 0.2.0+'s
+    # pg.activeHotStandby.* block (see platform/wordpress-tenant/chart/
+    # templates/cnpg-cluster.yaml).
+    pg:
+      activeHotStandby:
+        enabled: true
+        primaryRegion: {{ .PrimaryRegion }}
+        replicaRegion: {{ .ReplicaRegion }}
+{{- end }}
 `
 
-const smeTenantBPOpenClaw = `# bp-openclaw (#803, #915) — workspace controller pre-wired to the
+const smeTenantBPOpenClaw =`# bp-openclaw (#803, #915) — workspace controller pre-wired to the
 # per-tenant Keycloak realm (SSO) and the per-tenant NewAPI gateway
 # (OpenAI-compatible LLM endpoint, NOT direct OpenAI).
 #

--- a/products/catalyst/chart/templates/api-deployment.yaml
+++ b/products/catalyst/chart/templates/api-deployment.yaml
@@ -828,6 +828,45 @@ spec:
                   name: sovereign-fqdn
                   key: configuredRegions
                   optional: true
+            # ── D31 active-hot-standby toggle + region pair ────────────
+            # Read by the SME tenant gitops writer (sme_tenant_gitops.go
+            # renderSMETenantOverlay) at render time. When the toggle is
+            # `true` AND both regions are non-empty AND distinct, every
+            # freshly-created tenant's bp-wordpress-tenant HelmRelease
+            # carries `pg.activeHotStandby.{enabled,primaryRegion,
+            # replicaRegion}` so the chart renders a primary + replica
+            # Cluster.postgresql.cnpg.io pair (DoD D31). Future tenant
+            # product charts (gitlab-tenant, nextcloud-tenant) that
+            # adopt the same value contract inherit this wiring for
+            # free — no further chart bump required.
+            #
+            # Sourced from sovereign-fqdn ConfigMap keys
+            # `enableHotStandby`, `primaryRegion`, `replicaRegion` —
+            # populated from .Values.sovereign.{enableHotStandby,
+            # primaryRegion,replicaRegion} (bootstrap-kit slot 13's
+            # envsubst placeholders SOVEREIGN_ENABLE_HOT_STANDBY,
+            # SOVEREIGN_PRIMARY_REGION, SOVEREIGN_REPLICA_REGION).
+            # optional=true: every Sovereign that has not opted into HA
+            # leaves all three empty and the gitops writer falls through
+            # to the single-Cluster shape — zero regression.
+            - name: SOVEREIGN_ENABLE_HOT_STANDBY
+              valueFrom:
+                configMapKeyRef:
+                  name: sovereign-fqdn
+                  key: enableHotStandby
+                  optional: true
+            - name: SOVEREIGN_PRIMARY_REGION
+              valueFrom:
+                configMapKeyRef:
+                  name: sovereign-fqdn
+                  key: primaryRegion
+                  optional: true
+            - name: SOVEREIGN_REPLICA_REGION
+              valueFrom:
+                configMapKeyRef:
+                  name: sovereign-fqdn
+                  key: replicaRegion
+                  optional: true
             # CATALYST_QA_APPLICATIONS — comma-separated literal app
             # names the chroot Sovereign's /compliance/scorecard
             # surface emits via `appRefs[]` (qa-loop iter-16 Fix #167).

--- a/products/catalyst/chart/templates/sovereign-fqdn-configmap.yaml
+++ b/products/catalyst/chart/templates/sovereign-fqdn-configmap.yaml
@@ -142,4 +142,25 @@ data:
   orgName: {{ default "" .Values.sovereign.orgName | quote }}
   controlPlaneIP: {{ default "" .Values.sovereign.controlPlaneIP | quote }}
   gitopsRepoURL: {{ default "" .Values.sovereign.gitopsRepoURL | quote }}
+  # D31 active-hot-standby — Sovereign-level opt-in for the cross-
+  # region CNPG ReplicaCluster shape on CNPG-backed tenant apps. Read
+  # by the catalyst-api SME-tenant pipeline (sme_tenant_gitops.go
+  # renderSMETenantOverlay) at render time. When `enableHotStandby`
+  # parses truthy AND both region keys are non-empty AND distinct,
+  # every fresh tenant's bp-wordpress-tenant HelmRelease carries
+  # `pg.activeHotStandby.{enabled,primaryRegion,replicaRegion}`. The
+  # chart then renders a primary + replica Cluster.postgresql.cnpg.io
+  # pair across the two regions, WAL streaming over Cilium ClusterMesh
+  # (DoD D11 + D31). Same wiring will be picked up by future tenant
+  # product charts (gitlab-tenant, nextcloud-tenant) that adopt the
+  # same value contract — no further chart bump required.
+  #
+  # All three default to empty so a Sovereign that hasn't opted in
+  # stays on the single-Cluster shape. Bootstrap-kit slot 13 wires
+  # operator overrides from the envsubst placeholders
+  # SOVEREIGN_ENABLE_HOT_STANDBY / SOVEREIGN_PRIMARY_REGION /
+  # SOVEREIGN_REPLICA_REGION the per-Sovereign overlay carries.
+  enableHotStandby: {{ default "" .Values.sovereign.enableHotStandby | quote }}
+  primaryRegion: {{ default "" .Values.sovereign.primaryRegion | quote }}
+  replicaRegion: {{ default "" .Values.sovereign.replicaRegion | quote }}
 {{- end }}

--- a/products/catalyst/chart/values.yaml
+++ b/products/catalyst/chart/values.yaml
@@ -96,6 +96,43 @@ sovereign:
   # passes without requiring a real bp-wordpress install.
   qaApplications: []
 
+  # ── D31 active-hot-standby (cross-region CNPG ReplicaCluster) ──────
+  # Sovereign-level opt-in for the active-hot-standby Postgres shape
+  # on every CNPG-backed tenant app the marketplace installs. When
+  # `enableHotStandby` is truthy AND both region keys are non-empty
+  # AND distinct, the SME-tenant gitops writer (sme_tenant_gitops.go
+  # renderSMETenantOverlay) injects a
+  # `pg.activeHotStandby.{enabled,primaryRegion,replicaRegion}` block
+  # into every freshly-rendered bp-wordpress-tenant HelmRelease. The
+  # chart then materialises a primary + replica Cluster.postgresql.
+  # cnpg.io pair across the two regions, WAL streaming over Cilium
+  # ClusterMesh (DoD D11 + D31). Same wiring extends to any future
+  # tenant chart (gitlab-tenant, nextcloud-tenant) that adopts the
+  # same value contract — no further chart bump required.
+  #
+  # The Sandbox plane reads the same Sovereign-level toggle to decide
+  # whether `sandbox.db.provision` materialises single-Cluster CNPG
+  # (today's default) or graduates to bp-cnpg-pair (D31 follow-up,
+  # tracked in products/sandbox/docs/architecture.md §7); the chart
+  # plumbing for that path lives in platform/sandbox/chart/values.yaml
+  # under `cnpg.activeHotStandby.*` and is consumed by the
+  # sandbox-controller's per-Sandbox renderer.
+  #
+  # Default empty: every Sovereign that has not opted in stays on the
+  # single-Cluster CNPG shape (zero regression). Bootstrap-kit slot 13
+  # (clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml)
+  # wires operator overrides from the envsubst placeholders
+  # SOVEREIGN_ENABLE_HOT_STANDBY, SOVEREIGN_PRIMARY_REGION,
+  # SOVEREIGN_REPLICA_REGION the per-Sovereign overlay carries.
+  #
+  # Region keys MUST match the canonical openova.io/region node label
+  # value (e.g. `hz-fsn-rtz-prod`, `hz-hel-rtz-prod`) — the chart's
+  # cnpg-cluster.yaml uses nodeAffinity on that label to pin the
+  # primary + replica StatefulSet Pods to the right regions.
+  enableHotStandby: ""
+  primaryRegion: ""
+  replicaRegion: ""
+
 # ─── Gitea-API wait budget (qa-loop Wave 27 Fix #184) ──────────────────
 # Knobs consumed by templates/catalyst-gitea-token-secret.yaml's pre-
 # install hook (catalyst-gitea-token-mint Job), which waits for the

--- a/products/sandbox/mcp-server/internal/tools/env.go
+++ b/products/sandbox/mcp-server/internal/tools/env.go
@@ -29,6 +29,18 @@
 // SANDBOX_JWT_SECRET empty AND SANDBOX_ORG_ID empty = test mode
 // (the registry skips its auth gate so unit tests don't need to mint a
 // JWT per call).
+//
+// D31 active-hot-standby — three additional env vars threaded by the
+// sandbox-controller from its chart values (platform/sandbox/chart/
+// values.yaml `cnpg.activeHotStandby.*`). When the Sovereign opts in,
+// sandbox.db.provision emits a primary + replica Cluster CR pair
+// instead of a single Cluster (matching the bp-cnpg-pair pattern under
+// platform/cnpg-pair/chart/templates/). Default-off keeps existing
+// Sandbox DBs on the single-Cluster shape (zero regression).
+//
+//	SOVEREIGN_ENABLE_HOT_STANDBY = "true"               (default empty/false)
+//	SOVEREIGN_PRIMARY_REGION     = "hz-fsn-rtz-prod"    (openova.io/region label)
+//	SOVEREIGN_REPLICA_REGION     = "hz-hel-rtz-prod"    (openova.io/region label)
 package tools
 
 import (
@@ -76,5 +88,17 @@ func NewEnvFromOS() *Env {
 			}
 		}
 	}
+	// D31 active-hot-standby. Toggle parses truthy on {true, 1, yes, on}
+	// (case-insensitive); every other value (including empty) leaves the
+	// flag false. PrimaryRegion / ReplicaRegion are stored verbatim;
+	// sandbox.db.provision applies the same defence-in-depth rule the
+	// SME-tenant gitops writer does (block is rendered only when toggle
+	// is true AND both regions are non-empty AND distinct).
+	switch strings.ToLower(strings.TrimSpace(os.Getenv("SOVEREIGN_ENABLE_HOT_STANDBY"))) {
+	case "true", "1", "yes", "on":
+		env.EnableHotStandby = true
+	}
+	env.PrimaryRegion = strings.TrimSpace(os.Getenv("SOVEREIGN_PRIMARY_REGION"))
+	env.ReplicaRegion = strings.TrimSpace(os.Getenv("SOVEREIGN_REPLICA_REGION"))
 	return env
 }

--- a/products/sandbox/mcp-server/internal/tools/registry.go
+++ b/products/sandbox/mcp-server/internal/tools/registry.go
@@ -191,6 +191,24 @@ type Env struct {
 	// has minted the tenant row. Empty → marketplace.domain.* surfaces
 	// a clear "not configured" error.
 	TenantID string
+
+	// D31 active-hot-standby — Sovereign-level toggle + region pair for
+	// the cross-region CNPG ReplicaCluster shape on every Sandbox-
+	// provisioned database. When EnableHotStandby is true AND both
+	// regions are non-empty AND distinct, sandbox.db.provision emits a
+	// primary + replica Cluster.postgresql.cnpg.io pair (the same
+	// shape platform/cnpg-pair/chart/templates/{primary,replica}-cluster.yaml
+	// renders for tenant marketplace apps under DoD D31). Default-off
+	// keeps every existing Sandbox on single-Cluster CNPG (zero
+	// regression). Wired from the sandbox-controller's chart values
+	// (platform/sandbox/chart/values.yaml `cnpg.activeHotStandby.*`)
+	// which in turn flows from bootstrap-kit slot 61 envsubst
+	// placeholders (SOVEREIGN_ENABLE_HOT_STANDBY, SOVEREIGN_PRIMARY_REGION,
+	// SOVEREIGN_REPLICA_REGION) — so one operator-flipped knob covers
+	// both the marketplace tenant path AND the sandbox.db plane.
+	EnableHotStandby bool
+	PrimaryRegion    string
+	ReplicaRegion    string
 }
 
 // claimsCtxKey is the unexported context key under which the

--- a/products/sandbox/mcp-server/internal/tools/sandbox_db.go
+++ b/products/sandbox/mcp-server/internal/tools/sandbox_db.go
@@ -212,6 +212,304 @@ func buildClusterCR(env *Env, name string, plan cnpgPlan) *unstructured.Unstruct
 	return cr
 }
 
+// hotStandbyActive reports whether the Sovereign-level toggle + region
+// pair is in the valid happy-path shape (toggle on AND both regions
+// non-empty AND distinct). Mirrors the defence-in-depth rule the
+// SME-tenant gitops writer applies (renderSMETenantOverlay): if the
+// operator opted in but the region pair is degenerate we fall back to
+// single-Cluster shape rather than rendering a Cluster CR pair that
+// can't schedule (replica's nodeAffinity wouldn't match anywhere).
+func hotStandbyActive(env *Env) bool {
+	if env == nil || !env.EnableHotStandby {
+		return false
+	}
+	if env.PrimaryRegion == "" || env.ReplicaRegion == "" {
+		return false
+	}
+	if env.PrimaryRegion == env.ReplicaRegion {
+		return false
+	}
+	return true
+}
+
+// replicaClusterName is the canonical name suffix the replica Cluster
+// CR carries. Mirrors bp-wordpress-tenant.cnpgPairReplicaName + the
+// bp-cnpg-pair chart pattern. Truncated to the 53-char ceiling so the
+// CNPG operator's `<name>-replication-XX` Secret names stay inside the
+// 63-char RFC-1123 label limit.
+func replicaClusterName(primary string) string {
+	const ceiling = 53
+	out := primary + "-replica"
+	if len(out) > ceiling {
+		out = out[:ceiling]
+	}
+	return out
+}
+
+// replicationServiceName is the canonical ClusterMesh-global Service
+// alias the primary Cluster CR exposes (annotated
+// `service.cilium.io/global: "true"`). The replica's externalCluster
+// resolves the primary via this name — local-affinity routing falls
+// through to the remote region because the replica region has zero
+// local backends matching the selector. Mirrors
+// bp-wordpress-tenant.cnpgPairReplicationServiceName + bp-cnpg-pair.
+func replicationServiceName(primary string) string {
+	const ceiling = 53
+	out := primary + "-mesh"
+	if len(out) > ceiling {
+		out = out[:ceiling]
+	}
+	return out
+}
+
+// buildClusterCRPair renders the primary + replica Cluster.postgresql.
+// cnpg.io pair the D31 active-hot-standby shape requires. The primary
+// is pinned to env.PrimaryRegion (openova.io/region nodeAffinity) and
+// exposes its read-replica endpoint as a ClusterMesh-global Service
+// (`spec.managed.services.additional[].selectorType=r`, annotated
+// `service.cilium.io/global: "true"`). The replica is pinned to
+// env.ReplicaRegion, configured with `replica.enabled: true` +
+// `bootstrap.pg_basebackup` source pointing at the primary via the
+// mesh-global Service alias, with WAL streaming over the same
+// connection. Mirrors platform/wordpress-tenant/chart/templates/
+// cnpg-cluster.yaml (PR #1562) line-for-line so the operator-side
+// observability + failover behaviour stays consistent between the
+// marketplace tenant path and the sandbox.db plane.
+//
+// The shape only renders when hotStandbyActive(env) — sandbox.db.
+// provision falls back to buildClusterCR (single Cluster) for every
+// other configuration to keep the legacy/back-compat path exercised
+// on every Sovereign that hasn't opted in.
+func buildClusterCRPair(env *Env, name string, plan cnpgPlan) []*unstructured.Unstructured {
+	primaryLabels := map[string]any{
+		cnpgManagedByLabel:               cnpgManagedByValue,
+		"openova.io/cnpg-role":           "primary",
+		"openova.io/region":              env.PrimaryRegion,
+		"catalyst.openova.io/cnpg-pair":  name,
+	}
+	replicaLabels := map[string]any{
+		cnpgManagedByLabel:               cnpgManagedByValue,
+		"openova.io/cnpg-role":           "replica",
+		"openova.io/region":              env.ReplicaRegion,
+		"catalyst.openova.io/cnpg-pair":  name,
+	}
+	if env.SandboxID != "" {
+		primaryLabels[cnpgSandboxIDLabel] = env.SandboxID
+		replicaLabels[cnpgSandboxIDLabel] = env.SandboxID
+	}
+	storage := map[string]any{
+		"size": plan.StorageSize,
+	}
+	if plan.StorageClass != "" {
+		storage["storageClass"] = plan.StorageClass
+	}
+	replicaName := replicaClusterName(name)
+	meshSvc := replicationServiceName(name)
+
+	// PostgreSQL parameters identical between primary + replica per the
+	// bp-wordpress-tenant rationale: `hot_standby` is INTENTIONALLY
+	// omitted (Postgres 16 hard-pins it to `on` and CNPG rejects any
+	// explicit set with phase "Unable to create required cluster
+	// objects" — caught live on omantel-fsn 2026-05-09, Phase-2
+	// multi-region incident #3).
+	pgParams := map[string]any{
+		"max_wal_senders":      "10",
+		"max_replication_slots": "10",
+		"wal_level":            "logical",
+	}
+
+	primary := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "postgresql.cnpg.io/v1",
+			"kind":       "Cluster",
+			"metadata": map[string]any{
+				"name":      name,
+				"namespace": env.SandboxNamespace,
+				"labels":    primaryLabels,
+				"annotations": map[string]any{
+					"openova.io/created-by":                  "sandbox.db.provision",
+					"catalyst.openova.io/cnpg-pair-role":     "primary",
+					"catalyst.openova.io/cnpg-pair-name":     name,
+				},
+			},
+			"spec": map[string]any{
+				"instances":             int64(plan.Instances),
+				"imageName":             plan.Image,
+				"storage":               storage,
+				"primaryUpdateMethod":   "switchover",
+				"enableSuperuserAccess": false,
+				"bootstrap": map[string]any{
+					"initdb": map[string]any{
+						"database": plan.Database,
+						"owner":    plan.Database,
+					},
+				},
+				"postgresql": map[string]any{
+					"parameters": pgParams,
+				},
+				"affinity": map[string]any{
+					"nodeAffinity": map[string]any{
+						"requiredDuringSchedulingIgnoredDuringExecution": map[string]any{
+							"nodeSelectorTerms": []any{
+								map[string]any{
+									"matchExpressions": []any{
+										map[string]any{
+											"key":      "openova.io/region",
+											"operator": "In",
+											"values":   []any{env.PrimaryRegion},
+										},
+									},
+								},
+							},
+						},
+					},
+					"podAntiAffinityType": "required",
+				},
+				// Cilium ClusterMesh global replication Service — the
+				// replica's externalCluster resolves the primary via
+				// this alias. CNPG owns the Service (cannot hand-create
+				// or the operator rejects with "not owned by the
+				// cluster"); we declare it via spec.managed.services.
+				// additional[] (CNPG >= 1.22) so the operator
+				// reconciles it AND publishes the ClusterMesh-global
+				// annotation. Mirrors bp-cnpg-pair chart 0.1.1 +
+				// bp-wordpress-tenant cnpgPairReplicationServiceName.
+				"managed": map[string]any{
+					"services": map[string]any{
+						"additional": []any{
+							map[string]any{
+								"selectorType": "r",
+								"serviceTemplate": map[string]any{
+									"metadata": map[string]any{
+										"name": meshSvc,
+										"labels": map[string]any{
+											cnpgManagedByLabel:                   cnpgManagedByValue,
+											"catalyst.openova.io/cnpg-pair":      name,
+											"catalyst.openova.io/role":           "replication-source",
+										},
+										"annotations": map[string]any{
+											"service.cilium.io/global":           "true",
+											"service.cilium.io/affinity":         "local",
+											"catalyst.openova.io/blueprint":      "sandbox-db",
+										},
+									},
+									"spec": map[string]any{
+										"type": "ClusterIP",
+										"ports": []any{
+											map[string]any{
+												"name":       "postgres",
+												"port":       int64(5432),
+												"targetPort": int64(5432),
+												"protocol":   "TCP",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				// Mirror the bp-reflector annotation pattern so the
+				// CNPG-emitted `<cluster>-app` Secret is reachable
+				// across namespaces (no-op when reflector isn't
+				// installed; harmless metadata otherwise).
+				"inheritedMetadata": map[string]any{
+					"annotations": map[string]any{
+						"reflector.v1.k8s.emberstack.com/reflection-allowed":            "true",
+						"reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces": env.SandboxNamespace,
+					},
+				},
+			},
+		},
+	}
+
+	replica := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "postgresql.cnpg.io/v1",
+			"kind":       "Cluster",
+			"metadata": map[string]any{
+				"name":      replicaName,
+				"namespace": env.SandboxNamespace,
+				"labels":    replicaLabels,
+				"annotations": map[string]any{
+					"openova.io/created-by":                  "sandbox.db.provision",
+					"catalyst.openova.io/cnpg-pair-role":     "replica",
+					"catalyst.openova.io/cnpg-pair-name":     name,
+				},
+			},
+			"spec": map[string]any{
+				"instances":             int64(plan.Instances),
+				"imageName":             plan.Image,
+				"storage":               storage,
+				"enableSuperuserAccess": false,
+				"affinity": map[string]any{
+					"nodeAffinity": map[string]any{
+						"requiredDuringSchedulingIgnoredDuringExecution": map[string]any{
+							"nodeSelectorTerms": []any{
+								map[string]any{
+									"matchExpressions": []any{
+										map[string]any{
+											"key":      "openova.io/region",
+											"operator": "In",
+											"values":   []any{env.ReplicaRegion},
+										},
+									},
+								},
+							},
+						},
+					},
+					"podAntiAffinityType": "required",
+				},
+				// Replica-cluster mode — bootstraps via streaming
+				// replication from the named externalCluster. CNPG
+				// REQUIRES an explicit bootstrap stanza on a replica
+				// Cluster (replica.enabled: true alone leaves the
+				// Cluster phase stuck at "Setting up primary").
+				"replica": map[string]any{
+					"enabled": true,
+					"source":  name,
+				},
+				"bootstrap": map[string]any{
+					"pg_basebackup": map[string]any{
+						"source":   name,
+						"database": plan.Database,
+						"owner":    plan.Database,
+					},
+				},
+				"externalClusters": []any{
+					map[string]any{
+						"name": name,
+						"connectionParameters": map[string]any{
+							"host":    meshSvc,
+							"port":    "5432",
+							"user":    "streaming_replica",
+							"sslmode": "require",
+							"dbname":  plan.Database,
+						},
+						"sslKey": map[string]any{
+							"name": name + "-replication",
+							"key":  "tls.key",
+						},
+						"sslCert": map[string]any{
+							"name": name + "-replication",
+							"key":  "tls.crt",
+						},
+						"sslRootCert": map[string]any{
+							"name": name + "-ca",
+							"key":  "ca.crt",
+						},
+					},
+				},
+				"postgresql": map[string]any{
+					"parameters": pgParams,
+				},
+			},
+		},
+	}
+
+	return []*unstructured.Unstructured{primary, replica}
+}
+
 // buildBackupCR constructs the on-demand Backup CR sandbox.db.dump
 // submits. The CNPG operator picks it up, runs `barman-cloud-backup`
 // against the Cluster's `spec.backup.barmanObjectStore`, and writes the
@@ -304,6 +602,58 @@ func sandboxDBProvision(ctx context.Context, raw json.RawMessage) (any, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	// D31 — render a primary + replica Cluster pair when the Sovereign
+	// has opted into active-hot-standby AND the region pair is valid.
+	// Falls back to single-Cluster shape for every other configuration
+	// (toggle off, missing region, identical regions) so legacy
+	// Sandboxes keep the same behaviour.
+	if hotStandbyActive(env) {
+		pair := buildClusterCRPair(env, args.Name, plan)
+		createdPrimary, err := client.Resource(cnpgClusterGVR).Namespace(ns).
+			Create(ctx, pair[0], metav1.CreateOptions{})
+		if err != nil {
+			return nil, fmt.Errorf("sandbox.db.provision: create primary Cluster %s/%s: %w", ns, args.Name, err)
+		}
+		replicaName := replicaClusterName(args.Name)
+		createdReplica, err := client.Resource(cnpgClusterGVR).Namespace(ns).
+			Create(ctx, pair[1], metav1.CreateOptions{})
+		if err != nil {
+			// Best-effort rollback so we don't leave the operator
+			// staring at an orphan primary. Errors here are surfaced
+			// to the agent so they can retry idempotently.
+			_ = client.Resource(cnpgClusterGVR).Namespace(ns).
+				Delete(ctx, args.Name, metav1.DeleteOptions{})
+			return nil, fmt.Errorf("sandbox.db.provision: create replica Cluster %s/%s: %w (primary rolled back)", ns, replicaName, err)
+		}
+		conn := connectionFor(args.Name, ns, plan.Database)
+		return map[string]any{
+			"status":     "Provisioning",
+			"connection": conn,
+			"plan": map[string]any{
+				"name":          "default",
+				"instances":     plan.Instances,
+				"storage_size":  plan.StorageSize,
+				"image":         plan.Image,
+				"database":      plan.Database,
+				"storage_class": plan.StorageClass,
+			},
+			"activeHotStandby": map[string]any{
+				"enabled":                  true,
+				"primaryRegion":            env.PrimaryRegion,
+				"replicaRegion":            env.ReplicaRegion,
+				"primaryClusterName":       args.Name,
+				"replicaClusterName":       replicaName,
+				"replicationServiceName":   replicationServiceName(args.Name),
+				"primaryUID":               string(createdPrimary.GetUID()),
+				"replicaUID":               string(createdReplica.GetUID()),
+				"primaryResourceVersion":   createdPrimary.GetResourceVersion(),
+				"replicaResourceVersion":   createdReplica.GetResourceVersion(),
+			},
+			"note": "CNPG operator will reconcile both Cluster CRs; poll `sandbox.db.get name=<n>` until status.phase == \"Cluster in healthy state\". Replica streams WAL from primary over Cilium ClusterMesh.",
+		}, nil
+	}
+
 	cr := buildClusterCR(env, args.Name, plan)
 	created, err := client.Resource(cnpgClusterGVR).Namespace(ns).
 		Create(ctx, cr, metav1.CreateOptions{})

--- a/products/sandbox/mcp-server/internal/tools/sandbox_db_hot_standby_test.go
+++ b/products/sandbox/mcp-server/internal/tools/sandbox_db_hot_standby_test.go
@@ -1,0 +1,221 @@
+// sandbox_db_hot_standby_test.go — D31 active-hot-standby regression
+// tests for the sandbox.db plane.
+//
+// When the Sovereign opts in via SOVEREIGN_ENABLE_HOT_STANDBY=true AND
+// both SOVEREIGN_PRIMARY_REGION + SOVEREIGN_REPLICA_REGION are non-empty
+// AND distinct, sandbox.db.provision materialises a primary + replica
+// Cluster.postgresql.cnpg.io pair (one each in the two regions) instead
+// of a single Cluster. The rendered shape mirrors bp-wordpress-tenant
+// chart 0.2.0+ + bp-cnpg-pair so failover / observability / WAL
+// streaming behave identically across the marketplace tenant path and
+// the sandbox.db plane.
+//
+// Defence-in-depth: if the operator enables the toggle but the region
+// pair is degenerate (empty primary, empty replica, primary==replica),
+// hotStandbyActive() returns false and the legacy single-Cluster shape
+// is rendered instead. Same rule as the SME-tenant gitops writer's
+// renderSMETenantOverlay defence — better to degrade silently to non-
+// HA than to render unschedulable resources.
+
+package tools
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func d31SandboxEnv(toggle bool, primary, replica string) *Env {
+	return &Env{
+		SandboxID:        "emrah",
+		SandboxNamespace: "sandbox-uid-1",
+		EnableHotStandby: toggle,
+		PrimaryRegion:    primary,
+		ReplicaRegion:    replica,
+	}
+}
+
+// hotStandbyActive embodies the defence-in-depth rule: toggle ON,
+// distinct non-empty regions ⇒ true; any degenerate case ⇒ false.
+func TestHotStandbyActive_Matrix(t *testing.T) {
+	cases := []struct {
+		name    string
+		env     *Env
+		want    bool
+	}{
+		{"toggle-off", d31SandboxEnv(false, "hz-fsn-rtz-prod", "hz-hel-rtz-prod"), false},
+		{"toggle-on-empty-primary", d31SandboxEnv(true, "", "hz-hel-rtz-prod"), false},
+		{"toggle-on-empty-replica", d31SandboxEnv(true, "hz-fsn-rtz-prod", ""), false},
+		{"toggle-on-both-empty", d31SandboxEnv(true, "", ""), false},
+		{"toggle-on-same-region", d31SandboxEnv(true, "hz-fsn-rtz-prod", "hz-fsn-rtz-prod"), false},
+		{"toggle-on-distinct", d31SandboxEnv(true, "hz-fsn-rtz-prod", "hz-hel-rtz-prod"), true},
+		{"nil-env", nil, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := hotStandbyActive(tc.env); got != tc.want {
+				t.Errorf("hotStandbyActive=%v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestReplicaClusterName_Suffix asserts the canonical `<primary>-replica`
+// suffix + 53-char ceiling so the CNPG operator's
+// `<name>-replication-XX` Secret names stay inside the 63-char RFC-1123
+// label limit.
+func TestReplicaClusterName_Suffix(t *testing.T) {
+	if got := replicaClusterName("mydb"); got != "mydb-replica" {
+		t.Errorf("replicaClusterName(mydb)=%q want mydb-replica", got)
+	}
+	long := "abcdefghijabcdefghijabcdefghijabcdefghijabcdefghij" // 50 chars
+	got := replicaClusterName(long)
+	if len(got) > 53 {
+		t.Errorf("len(replicaClusterName) = %d, want <= 53; got=%q", len(got), got)
+	}
+}
+
+// TestReplicationServiceName_Suffix asserts the canonical `<primary>-mesh`
+// suffix used by the primary Cluster's spec.managed.services.additional
+// entry — the ClusterMesh-global Service the replica's externalCluster
+// resolves through.
+func TestReplicationServiceName_Suffix(t *testing.T) {
+	if got := replicationServiceName("mydb"); got != "mydb-mesh" {
+		t.Errorf("replicationServiceName(mydb)=%q want mydb-mesh", got)
+	}
+}
+
+// TestBuildClusterCRPair_PrimaryShape asserts the primary Cluster CR
+// carries the canonical D31 shape: openova.io/region nodeAffinity
+// pinned to primaryRegion, primaryUpdateMethod=switchover, and a
+// ClusterMesh-global Service via spec.managed.services.additional[].
+func TestBuildClusterCRPair_PrimaryShape(t *testing.T) {
+	env := d31SandboxEnv(true, "hz-fsn-rtz-prod", "hz-hel-rtz-prod")
+	pair := buildClusterCRPair(env, "mydb1", defaultCNPGPlan())
+	if len(pair) != 2 {
+		t.Fatalf("buildClusterCRPair returned %d CRs, want 2", len(pair))
+	}
+	primary := pair[0]
+	if got := primary.GetName(); got != "mydb1" {
+		t.Errorf("primary.name=%q want mydb1", got)
+	}
+	primaryLabels := primary.GetLabels()
+	if primaryLabels["openova.io/cnpg-role"] != "primary" {
+		t.Errorf("primary cnpg-role=%q want primary", primaryLabels["openova.io/cnpg-role"])
+	}
+	if primaryLabels["openova.io/region"] != "hz-fsn-rtz-prod" {
+		t.Errorf("primary region label=%q want hz-fsn-rtz-prod", primaryLabels["openova.io/region"])
+	}
+	if primaryLabels["catalyst.openova.io/cnpg-pair"] != "mydb1" {
+		t.Errorf("primary cnpg-pair label=%q want mydb1", primaryLabels["catalyst.openova.io/cnpg-pair"])
+	}
+
+	spec := primary.Object["spec"].(map[string]any)
+	if got, ok := spec["primaryUpdateMethod"].(string); !ok || got != "switchover" {
+		t.Errorf("primaryUpdateMethod=%v want switchover", spec["primaryUpdateMethod"])
+	}
+	// nodeAffinity → openova.io/region IN [hz-fsn-rtz-prod]
+	regionVal := primaryRegionAffinityValue(t, primary)
+	if regionVal != "hz-fsn-rtz-prod" {
+		t.Errorf("primary nodeAffinity region=%q want hz-fsn-rtz-prod", regionVal)
+	}
+	// managed.services.additional[0] → name=mydb1-mesh, global annotation
+	managed := spec["managed"].(map[string]any)
+	services := managed["services"].(map[string]any)
+	additional := services["additional"].([]any)
+	if len(additional) != 1 {
+		t.Fatalf("primary managed.services.additional len=%d want 1", len(additional))
+	}
+	svc := additional[0].(map[string]any)
+	svcTpl := svc["serviceTemplate"].(map[string]any)
+	svcMeta := svcTpl["metadata"].(map[string]any)
+	if got := svcMeta["name"]; got != "mydb1-mesh" {
+		t.Errorf("replication svc name=%v want mydb1-mesh", got)
+	}
+	svcAnn := svcMeta["annotations"].(map[string]any)
+	if svcAnn["service.cilium.io/global"] != "true" {
+		t.Errorf("missing service.cilium.io/global=true annotation; got=%v", svcAnn)
+	}
+}
+
+// TestBuildClusterCRPair_ReplicaShape asserts the replica Cluster CR
+// carries the canonical D31 shape: openova.io/region nodeAffinity
+// pinned to replicaRegion, replica.enabled=true, externalClusters[]
+// resolves to the primary via the ClusterMesh-global Service.
+func TestBuildClusterCRPair_ReplicaShape(t *testing.T) {
+	env := d31SandboxEnv(true, "hz-fsn-rtz-prod", "hz-hel-rtz-prod")
+	pair := buildClusterCRPair(env, "mydb1", defaultCNPGPlan())
+	replica := pair[1]
+	if got := replica.GetName(); got != "mydb1-replica" {
+		t.Errorf("replica.name=%q want mydb1-replica", got)
+	}
+	replicaLabels := replica.GetLabels()
+	if replicaLabels["openova.io/cnpg-role"] != "replica" {
+		t.Errorf("replica cnpg-role=%q want replica", replicaLabels["openova.io/cnpg-role"])
+	}
+	if replicaLabels["openova.io/region"] != "hz-hel-rtz-prod" {
+		t.Errorf("replica region label=%q want hz-hel-rtz-prod", replicaLabels["openova.io/region"])
+	}
+	if replicaLabels["catalyst.openova.io/cnpg-pair"] != "mydb1" {
+		t.Errorf("replica cnpg-pair label=%q want mydb1", replicaLabels["catalyst.openova.io/cnpg-pair"])
+	}
+
+	spec := replica.Object["spec"].(map[string]any)
+	regionVal := primaryRegionAffinityValue(t, replica)
+	if regionVal != "hz-hel-rtz-prod" {
+		t.Errorf("replica nodeAffinity region=%q want hz-hel-rtz-prod", regionVal)
+	}
+	rep := spec["replica"].(map[string]any)
+	if rep["enabled"] != true {
+		t.Errorf("replica.enabled=%v want true", rep["enabled"])
+	}
+	if rep["source"] != "mydb1" {
+		t.Errorf("replica.source=%v want mydb1", rep["source"])
+	}
+	ext := spec["externalClusters"].([]any)
+	if len(ext) != 1 {
+		t.Fatalf("externalClusters len=%d want 1", len(ext))
+	}
+	extC := ext[0].(map[string]any)
+	if extC["name"] != "mydb1" {
+		t.Errorf("externalClusters[0].name=%v want mydb1", extC["name"])
+	}
+	connParams := extC["connectionParameters"].(map[string]any)
+	if connParams["host"] != "mydb1-mesh" {
+		t.Errorf("externalClusters host=%v want mydb1-mesh", connParams["host"])
+	}
+	if connParams["user"] != "streaming_replica" {
+		t.Errorf("externalClusters user=%v want streaming_replica", connParams["user"])
+	}
+}
+
+// primaryRegionAffinityValue is a small helper that dives through the
+// nested affinity/nodeAffinity/required... structure to extract the
+// single openova.io/region match value. Fails the test if the shape
+// doesn't match (Cluster CRs without it are unschedulable on a multi-
+// region Sovereign so this is the right place to be strict).
+func primaryRegionAffinityValue(t *testing.T, cr *unstructured.Unstructured) string {
+	t.Helper()
+	spec := cr.Object["spec"].(map[string]any)
+	aff := spec["affinity"].(map[string]any)
+	na := aff["nodeAffinity"].(map[string]any)
+	req := na["requiredDuringSchedulingIgnoredDuringExecution"].(map[string]any)
+	terms := req["nodeSelectorTerms"].([]any)
+	if len(terms) == 0 {
+		t.Fatalf("no nodeSelectorTerms on %s", cr.GetName())
+	}
+	term := terms[0].(map[string]any)
+	matches := term["matchExpressions"].([]any)
+	for _, m := range matches {
+		mm := m.(map[string]any)
+		if mm["key"] == "openova.io/region" {
+			vals := mm["values"].([]any)
+			if len(vals) == 0 {
+				t.Fatalf("openova.io/region match has no values on %s", cr.GetName())
+			}
+			return vals[0].(string)
+		}
+	}
+	t.Fatalf("no openova.io/region matchExpression on %s", cr.GetName())
+	return ""
+}


### PR DESCRIPTION
## Summary

Sovereign DoD **D31** — CNPG-backed apps must replicate across the Sovereign's regions when the operator opts in. PR #1562 wired this into bp-wordpress-tenant chart-level. This PR extends the same toggle across **both** user-facing paths:

1. **Marketplace tenant flow** (sme_tenant_gitops.go) — `bp-wordpress-tenant` HelmRelease now carries `pg.activeHotStandby.{enabled,primaryRegion,replicaRegion}` whenever the catalyst-api Pod env carries `SOVEREIGN_ENABLE_HOT_STANDBY=true` + a valid distinct region pair. Future tenant product charts (gitlab-tenant, nextcloud-tenant) that adopt the same value contract inherit the wiring for free.

2. **Sandbox plane** (`sandbox.db.provision`) — emits a primary + replica `Cluster.postgresql.cnpg.io` pair (mirrors `bp-cnpg-pair` + bp-wordpress-tenant cnpg-cluster.yaml). WAL streams over Cilium ClusterMesh via the primary's `spec.managed.services.additional[]` `service.cilium.io/global=true` Service; the replica's `externalClusters[]` resolves the primary through that mesh alias.

3. **Plumbing (one knob, both paths)** — bootstrap-kit slot 13 (bp-catalyst-platform) + slot 19a (bp-sandbox) wire `SOVEREIGN_ENABLE_HOT_STANDBY` / `SOVEREIGN_PRIMARY_REGION` / `SOVEREIGN_REPLICA_REGION` envsubst placeholders into **both** chart paths. Operator flips one knob on the per-Sovereign overlay; HA configuration stays consistent across the marketplace tenant install and the sandbox.db plane.

Defence-in-depth: **degenerate inputs** (empty primary, empty replica, primary==replica) fall back to single-Cluster shape on both paths rather than emitting a HelmRelease the bp-wordpress-tenant chart's `validateActiveHotStandbyRegions` helper would `fail` at template time (blocking the entire tenant overlay reconcile).

**Default empty/false**: every Sovereign that has not opted in keeps rendering single-Cluster CNPG. **Zero regression**.

`gitlab-tenant` + `nextcloud-tenant` charts: NOT shipped in this repo today, so they are out of scope. The gitops writer wiring will pick them up when they land.

## Files

- `clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml` — envsubst placeholders → catalyst-api values
- `clusters/_template/bootstrap-kit/19a-bp-sandbox.yaml` — envsubst placeholders → sandbox controller values
- `products/catalyst/chart/values.yaml` — `sovereign.{enableHotStandby,primaryRegion,replicaRegion}`
- `products/catalyst/chart/templates/sovereign-fqdn-configmap.yaml` — new ConfigMap keys
- `products/catalyst/chart/templates/api-deployment.yaml` — new env vars on the catalyst-api Pod
- `products/catalyst/bootstrap/api/internal/handler/sme_tenant_gitops.go` — render `pg.activeHotStandby.*` on the WordPress HelmRelease + defence-in-depth fallback
- `platform/sandbox/chart/values.yaml` — `cnpg.activeHotStandby.*`
- `platform/sandbox/chart/templates/deployment.yaml` — new env vars on the controller Pod
- `core/controllers/sandbox/cmd/sandbox-controller/main.go` + `internal/controller/sandbox_controller.go` — propagate the trio into `gitops.Inputs`
- `core/controllers/sandbox/internal/gitops/manifests.go` — render new env vars on every per-Sandbox MCP Pod
- `products/sandbox/mcp-server/internal/tools/registry.go` + `env.go` — `Env` struct reads `SOVEREIGN_*` env at MCP startup
- `products/sandbox/mcp-server/internal/tools/sandbox_db.go` — `buildClusterCRPair` + `hotStandbyActive` + primary/replica naming helpers; `sandboxDBProvision` switches to pair mode when active (with primary rollback on replica-create failure)

## Tests

- `products/catalyst/bootstrap/api/internal/handler/sme_tenant_active_hot_standby_test.go` — **8 cases** (off/no-block, on/emits-block, degenerate matrix incl. empty primary, empty replica, identical regions, toggle off with regions).
- `products/sandbox/mcp-server/internal/tools/sandbox_db_hot_standby_test.go` — **11 cases** covering hotStandbyActive matrix + `replicaClusterName`/`replicationServiceName` suffix rules + full primary CR shape (nodeAffinity, primaryUpdateMethod=switchover, managed.services.additional with service.cilium.io/global) + full replica CR shape (nodeAffinity, replica.enabled, externalClusters resolving via -mesh Service).
- Existing `platform/wordpress-tenant/chart/tests/active-hot-standby-render.sh` (5/5 gates) — still GREEN.

## Test plan

- [x] `go test ./internal/handler/ -run "HotStandby|SMETenant"` (catalyst-api) — ALL GREEN
- [x] `go test ./internal/tools/...` (sandbox mcp-server) — ALL GREEN
- [x] `go test ./sandbox/...` (sandbox-controller) — ALL GREEN
- [x] `helm template` clean: sandbox chart (HA on + default-off), catalyst chart (sovereign-fqdn-configmap + api-deployment)
- [x] `platform/wordpress-tenant/chart/tests/active-hot-standby-render.sh` — 5/5 gates green
- [ ] Runtime verification on next fresh prov with `SOVEREIGN_ENABLE_HOT_STANDBY=true SOVEREIGN_PRIMARY_REGION=hz-fsn-rtz-prod SOVEREIGN_REPLICA_REGION=hz-hel-rtz-prod` on the per-Sovereign overlay: `kubectl get cluster.postgresql.cnpg.io -n sme-<id>` returns 2 Clusters (primary + replica) with the right nodeAffinity each
- [ ] Runtime: `kubectl get cluster.postgresql.cnpg.io -n sandbox-<uid>` after `sandbox.db.provision` returns 2 Clusters

## Hard rules respected

- READ-ONLY clusters: zero `kubectl apply` / cluster mutation outside the chart-level seam
- No `Chart.yaml` bump on `bp-catalyst-platform` (envsubst-only wiring change in slot 13)
- Branch: `fix-convergence-tenant-cnpg-cross-region`

Refs DoD D31: `docs/SOVEREIGN-MULTI-REGION-DOD.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)