### PR TITLE
chore(release): bootstrap-kit pin 1.4.156→1.4.162 (Wave 14 collector — all post-Wave 9 fixes baked)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -550,7 +550,7 @@ spec:
       #   Resources/Logs tab namespace+label fix (HR.spec.target-
       #   Namespace + chart-name label) + "Bootstrap blueprint"
       #   chip for bp-* (founder bug #4, C4-003/004/005/007/013).
-      version: 1.4.156
+      version: 1.4.162
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform


### PR DESCRIPTION
Companion to deploy-bot auto-bumps. t13-t19 provs all baked chart 1.4.156 because bootstrap-kit pin lags. This bumps pin so t20+ get Wave 10-13 hotfixes (sandbox controller, Gateway listeners, tenantPublic, slot move, attestation gate, CNPG cross-region).

🤖 Generated with Claude Code