### PR TITLE
fix(sandbox-ci): mcp-server Dockerfile repo-root context + pty/mcp auto-bump wiring (chart was half-deployable)

### DIFF
--- a/.github/workflows/build-sandbox-mcp-server.yaml
+++ b/.github/workflows/build-sandbox-mcp-server.yaml
@@ -8,10 +8,17 @@ name: Build sandbox-mcp-server
 # Per docs/INVIOLABLE-PRINCIPLES.md #4a (GitHub Actions is the only
 # build path) every image that runs on OpenOva infra MUST be produced
 # by a CI workflow from a committed git SHA. Shape mirrors
-# build-sandbox-pty-server.yaml — same Buildx + cosign keyless sign +
-# SBOM attestation. No chart values.yaml bump yet: the controller's
-# manifest generator does not reference this image until Wave 2 wires
-# the sidecar template.
+# build-sandbox-controller.yaml — same Buildx + cosign keyless sign +
+# SBOM attestation + auto-bump of the chart values.yaml so the next
+# Sovereign install picks up the SHA-pinned image without an operator
+# manually editing the file.
+#
+# Wave 8 / PR #1658 wired this module's go.mod to depend on
+# core/controllers + core/services/shared via `replace` directives
+# (canonical Gitea client + auth.Claims). The Dockerfile therefore
+# requires the repository ROOT as the build context, mirroring
+# build-sandbox-controller.yaml. Paths-filter widens to the dep trees
+# so a change to those sources re-triggers the build.
 #
 # Per `feedback_inviolable_principles.md`: event-driven only, NO cron.
 
@@ -19,23 +26,33 @@ on:
   push:
     paths:
       - 'products/sandbox/mcp-server/**'
+      - 'core/controllers/**'
+      - 'core/services/shared/**'
       - '.github/workflows/build-sandbox-mcp-server.yaml'
     branches: [main]
   pull_request:
     paths:
       - 'products/sandbox/mcp-server/**'
+      - 'core/controllers/**'
+      - 'core/services/shared/**'
       - '.github/workflows/build-sandbox-mcp-server.yaml'
   workflow_dispatch:
 
 env:
   REGISTRY: ghcr.io
   IMAGE: ghcr.io/openova-io/openova/sandbox-mcp-server
+  CHART_VALUES: platform/sandbox/chart/values.yaml
 
 jobs:
   build:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      # contents: write — the deploy step below pushes a values.yaml SHA
+      # bump back to main so the platform/sandbox chart picks up the
+      # newly-built image without an operator manually editing the file
+      # (per `feedback_no_mvp_no_workarounds.md` rule 1: target-state,
+      # never "manual follow-up bump").
+      contents: write
       packages: write
       # id-token write is required by cosign keyless signing (Sigstore).
       id-token: write
@@ -53,10 +70,11 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
-          # mcp-server is stdlib-only at Wave 2 → no go.sum file.
-          # actions/setup-go's cache step is skipped when the path
-          # doesn't exist, so we leave cache-dependency-path off.
+          go-version: '1.23'
+          cache-dependency-path: |
+            products/sandbox/mcp-server/go.sum
+            core/controllers/go.sum
+            core/services/shared/go.sum
 
       - name: go vet
         working-directory: products/sandbox/mcp-server
@@ -64,9 +82,6 @@ jobs:
 
       - name: Run unit tests
         working-directory: products/sandbox/mcp-server
-        # Empty `go test ./...` is harmless: prints "no test files" and
-        # exits 0. Wave-2 follow-ups will add unit tests under
-        # internal/tools/.
         run: go test -count=1 -race ./...
 
       # On pull_request runs we stop here — image push requires
@@ -88,11 +103,11 @@ jobs:
         if: github.event_name != 'pull_request'
         uses: docker/build-push-action@v6
         with:
-          # mcp-server's Dockerfile uses `COPY . .` so the build context
-          # is the mcp-server directory itself (its own go.mod root —
-          # NOT the repo root, unlike core/controllers which share a
-          # parent go.mod).
-          context: products/sandbox/mcp-server
+          # Build context is the repository root so the Dockerfile's
+          # COPY paths can reach core/controllers + core/services/shared
+          # (PR #1658 `replace` targets) alongside products/sandbox/
+          # mcp-server. Mirrors build-sandbox-controller.yaml.
+          context: .
           file: products/sandbox/mcp-server/Dockerfile
           push: true
           tags: |
@@ -129,3 +144,50 @@ jobs:
             --predicate <(echo '{"sbom":"in-toto-spdx attached at build time"}') \
             --type spdx \
             "${IMAGE}@${DIGEST}"
+
+      # Auto-bump the chart values.yaml runtime.mcpImage so the next
+      # Sovereign chart rollout picks up this image without a manual
+      # edit. Per `feedback_no_mvp_no_workarounds.md` rule 1
+      # (target-state, no operator-action gates) and
+      # `feedback_inviolable_principles.md` (event-driven, never cron).
+      # The chart's deployment.yaml `required` guard fails-fast when
+      # runtime.mcpImage is empty (Inviolable Principle #4a), so an
+      # un-bumped values.yaml = un-deployable chart. Mirrors the
+      # build-sandbox-controller.yaml auto-bump shape, just targeting a
+      # different yq path and writing a fully-qualified `<repo>:<sha>`
+      # string (the consumer reads runtime.mcpImage as a single image
+      # reference, not a {repository,tag} pair).
+      - name: Install yq
+        if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
+        run: |
+          sudo wget -qO /usr/local/bin/yq \
+            https://github.com/mikefarah/yq/releases/download/v4.44.3/yq_linux_amd64
+          sudo chmod +x /usr/local/bin/yq
+
+      - name: Bump runtime.mcpImage in values.yaml
+        if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
+        env:
+          SHA_SHORT: ${{ steps.vars.outputs.sha_short }}
+        run: |
+          set -euo pipefail
+          yq eval -i ".runtime.mcpImage = \"${IMAGE}:${SHA_SHORT}\"" "${CHART_VALUES}"
+          echo "values.yaml after bump:"
+          yq eval '.runtime.mcpImage' "${CHART_VALUES}"
+
+      - name: Commit and push values.yaml bump
+        if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
+        env:
+          SHA_SHORT: ${{ steps.vars.outputs.sha_short }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          if git diff --quiet "${CHART_VALUES}"; then
+            echo "no values.yaml change — already pinned to ${SHA_SHORT}"
+            exit 0
+          fi
+          git add "${CHART_VALUES}"
+          git commit -m "deploy: bump sandbox-mcp-server image to ${SHA_SHORT}"
+          # Pull-rebase to avoid races with parallel build commits.
+          git pull --rebase --autostash origin main || true
+          git push origin HEAD:main

--- a/.github/workflows/build-sandbox-pty-server.yaml
+++ b/.github/workflows/build-sandbox-pty-server.yaml
@@ -9,10 +9,9 @@ name: Build sandbox-pty-server
 # build path) every image that runs on OpenOva infra MUST be produced
 # by a CI workflow from a committed git SHA. Shape mirrors
 # build-sandbox-controller.yaml — same Buildx + cosign keyless sign +
-# SBOM attestation. No chart values.yaml bump yet: the controller's
-# manifest generator does not reference this image until Wave 2 wires
-# the StatefulSet template (#1618 is Wave-2 scaffold; Wave-5 will
-# parametrise the image reference once the StatefulSet ships).
+# SBOM attestation + auto-bump of the chart values.yaml so the next
+# Sovereign install picks up the SHA-pinned image without an operator
+# manually editing the file.
 #
 # Per `feedback_inviolable_principles.md`: event-driven only, NO cron.
 
@@ -31,12 +30,18 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE: ghcr.io/openova-io/openova/sandbox-pty-server
+  CHART_VALUES: platform/sandbox/chart/values.yaml
 
 jobs:
   build:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      # contents: write — the deploy step below pushes a values.yaml SHA
+      # bump back to main so the platform/sandbox chart picks up the
+      # newly-built image without an operator manually editing the file
+      # (per `feedback_no_mvp_no_workarounds.md` rule 1: target-state,
+      # never "manual follow-up bump").
+      contents: write
       packages: write
       # id-token write is required by cosign keyless signing (Sigstore).
       id-token: write
@@ -91,7 +96,8 @@ jobs:
           # pty-server's Dockerfile uses `COPY . .` so the build context
           # is the pty-server directory itself (its own go.mod root —
           # NOT the repo root, unlike core/controllers which share a
-          # parent go.mod).
+          # parent go.mod). pty-server has no cross-tree `replace`
+          # directives so a narrow context still resolves cleanly.
           context: products/sandbox/pty-server
           file: products/sandbox/pty-server/Dockerfile
           push: true
@@ -129,3 +135,50 @@ jobs:
             --predicate <(echo '{"sbom":"in-toto-spdx attached at build time"}') \
             --type spdx \
             "${IMAGE}@${DIGEST}"
+
+      # Auto-bump the chart values.yaml runtime.ptyServerImage so the
+      # next Sovereign chart rollout picks up this image without a
+      # manual edit. Per `feedback_no_mvp_no_workarounds.md` rule 1
+      # (target-state, no operator-action gates) and
+      # `feedback_inviolable_principles.md` (event-driven, never cron).
+      # The chart's deployment.yaml `required` guard fails-fast when
+      # runtime.ptyServerImage is empty (Inviolable Principle #4a), so
+      # an un-bumped values.yaml = un-deployable chart. Mirrors the
+      # build-sandbox-controller.yaml auto-bump shape, just targeting a
+      # different yq path and writing a fully-qualified `<repo>:<sha>`
+      # string (the consumer reads runtime.ptyServerImage as a single
+      # image reference, not a {repository,tag} pair).
+      - name: Install yq
+        if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
+        run: |
+          sudo wget -qO /usr/local/bin/yq \
+            https://github.com/mikefarah/yq/releases/download/v4.44.3/yq_linux_amd64
+          sudo chmod +x /usr/local/bin/yq
+
+      - name: Bump runtime.ptyServerImage in values.yaml
+        if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
+        env:
+          SHA_SHORT: ${{ steps.vars.outputs.sha_short }}
+        run: |
+          set -euo pipefail
+          yq eval -i ".runtime.ptyServerImage = \"${IMAGE}:${SHA_SHORT}\"" "${CHART_VALUES}"
+          echo "values.yaml after bump:"
+          yq eval '.runtime.ptyServerImage' "${CHART_VALUES}"
+
+      - name: Commit and push values.yaml bump
+        if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
+        env:
+          SHA_SHORT: ${{ steps.vars.outputs.sha_short }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          if git diff --quiet "${CHART_VALUES}"; then
+            echo "no values.yaml change — already pinned to ${SHA_SHORT}"
+            exit 0
+          fi
+          git add "${CHART_VALUES}"
+          git commit -m "deploy: bump sandbox-pty-server image to ${SHA_SHORT}"
+          # Pull-rebase to avoid races with parallel build commits.
+          git pull --rebase --autostash origin main || true
+          git push origin HEAD:main

--- a/platform/sandbox/chart/values.yaml
+++ b/platform/sandbox/chart/values.yaml
@@ -54,9 +54,13 @@ env:
 runtime:
   # SHA-pinned pty-server image. Empty default fails-fast via the
   # deployment.yaml `required` guard (Inviolable Principle #4a).
-  ptyServerImage: ""
-  # SHA-pinned openova-sandbox-mcp image.
-  mcpImage: ""
+  # Auto-bumped by .github/workflows/build-sandbox-pty-server.yaml.
+  ptyServerImage: "ghcr.io/openova-io/openova/sandbox-pty-server:ad5163e"
+  # SHA-pinned openova-sandbox-mcp image. Auto-bumped by
+  # .github/workflows/build-sandbox-mcp-server.yaml. 1b0e86c is the
+  # last pre-#1658 green build; the rebuilt workflow (repo-root context)
+  # will land the next real SHA on the next push to main.
+  mcpImage: "ghcr.io/openova-io/openova/sandbox-mcp-server:1b0e86c"
   # Sovereign LLM gateway endpoint (newapi-proxy-contract.md §1).
   # Bootstrap-kit overlay sets `https://newapi.${SOVEREIGN_FQDN}/v1`.
   newapiURL: ""

--- a/products/sandbox/mcp-server/Dockerfile
+++ b/products/sandbox/mcp-server/Dockerfile
@@ -3,13 +3,40 @@
 # openova-sandbox-mcp — stdio MCP server, one sidecar per Sandbox pod.
 # Talks JSON-RPC to the agent (claude / cursor-agent / qwen-code /
 # aider / opencode) over stdin/stdout. See architecture.md §3.
+#
+# Build context: invoked with the repository ROOT as the build context.
+# Wave-8 / PR #1658 added `replace` directives in this module's go.mod
+# pointing at ../../../core/controllers + ../../../core/services/shared
+# (re-using the canonical Gitea client + auth.Claims shape per Slice CC1
+# + the rest of the repo). That means the build context MUST cover the
+# repo root so the Dockerfile can COPY the replace targets into place,
+# mirroring core/controllers/sandbox/Dockerfile (same Slice-CC1 layout).
+#
+# Two stages:
+#   build  — golang:1.23-alpine
+#   final  — distroless/static-debian12:nonroot (scratch-equivalent)
 
-FROM golang:1.23-alpine AS build
-WORKDIR /src
+FROM docker.io/library/golang:1.23-alpine AS build
+WORKDIR /repo
 RUN apk add --no-cache git
-COPY go.mod go.sum* ./
-RUN go mod download || true
-COPY . .
+
+# Stage 1: pre-stage every go.mod/go.sum the build will need so
+# `go mod download` can resolve the replace directives without first
+# copying every source file. Order matters: copy the replace targets'
+# module roots before the dependent module so the resolver sees the
+# replacement modules at the paths the go.mod points at.
+COPY core/controllers/go.mod core/controllers/go.sum /repo/core/controllers/
+COPY core/services/shared/go.mod core/services/shared/go.sum /repo/core/services/shared/
+COPY products/sandbox/mcp-server/go.mod products/sandbox/mcp-server/go.sum /repo/products/sandbox/mcp-server/
+
+# Stage 2: copy source for the dependent modules (the replace targets
+# must be on disk in full for `go build` to compile the imported pkgs).
+COPY core/controllers /repo/core/controllers
+COPY core/services/shared /repo/core/services/shared
+COPY products/sandbox/mcp-server /repo/products/sandbox/mcp-server
+
+WORKDIR /repo/products/sandbox/mcp-server
+RUN go mod download
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 \
     go build -trimpath -ldflags="-s -w" \
     -o /out/openova-sandbox-mcp ./cmd/openova-sandbox-mcp


### PR DESCRIPTION
## Summary

Sandbox chart was un-deployable end-to-end because three CI-side gaps compounded after PR #1658 wired the mcp-server module to depend on `core/controllers` + `core/services/shared` via `replace` directives.

- **mcp-server Dockerfile rewritten for repo-root build context.** Wave-8 / #1658 added `replace ../../../core/controllers` + `replace ../../../core/services/shared` to the mcp-server `go.mod`. The old workflow passed `context: products/sandbox/mcp-server` and the Dockerfile did `COPY . .` from that narrow root — `go build` failed with `module not found`. New Dockerfile mirrors `core/controllers/sandbox/Dockerfile` (Slice-CC1 layout): COPY the replace targets' module roots + sources, then build with `WORKDIR /repo/products/sandbox/mcp-server`. Final stage stays `gcr.io/distroless/static-debian12:nonroot` (scratch-equivalent).
- **mcp-server workflow now auto-bumps `runtime.mcpImage` in `platform/sandbox/chart/values.yaml`.** Mirrors the `build-sandbox-controller.yaml` yq-bump + bot-commit pattern. Widens `paths` filter to include `core/controllers/**` + `core/services/shared/**` so changes to replace targets re-trigger the build.
- **pty-server workflow gets the same auto-bump step** targeting `runtime.ptyServerImage`. Build context stays narrow (pty-server has no cross-tree `replace` directives).
- **Stop-gap SHA pins in `values.yaml`** so the chart's `required` guards (deployment.yaml L70/L72) don't fail-fast before the rebuilt workflows land their first bumps:
  - `runtime.ptyServerImage` → `ghcr.io/openova-io/openova/sandbox-pty-server:ad5163e` (current latest)
  - `runtime.mcpImage` → `ghcr.io/openova-io/openova/sandbox-mcp-server:1b0e86c` (last pre-#1658 green; the rebuilt workflow will land the next real SHA on the next push to main)

No `Chart.yaml` bump. Read-only clusters. Per `feedback_inviolable_principles.md` (event-driven, no cron) + `feedback_no_mvp_no_workarounds.md` rule 1 (target-state, never manual follow-up).

## Test plan
- [x] `go build ./products/sandbox/mcp-server/...` clean on host — 43.8 MB statically-linked ELF at `/tmp/openova-sandbox-mcp` (validates the same `go build` invocation the Dockerfile's build stage runs).
- [x] `helm template test platform/sandbox/chart --set enabled=true --set env.hostCluster=hz-fsn-rtz-prod --set env.sovereignFQDN=test --set env.newapiDefaultChannels=qwen --set runtime.newapiURL=https://newapi.test/v1` renders cleanly; both `PTY_SERVER_IMAGE` + `MCP_IMAGE` env vars carry the SHA-pinned `<repo>:<sha>` strings. (Without this PR, the `required` guard refused to render with empty `runtime.{ptyServerImage,mcpImage}`.)
- [ ] CI: next push touching `products/sandbox/mcp-server/**` (or `core/controllers/**` / `core/services/shared/**`) triggers a green `Build sandbox-mcp-server` run and lands a `deploy: bump sandbox-mcp-server image to <sha>` follow-up commit.
- [ ] CI: next push touching `products/sandbox/pty-server/**` triggers a green `Build sandbox-pty-server` run and lands a `deploy: bump sandbox-pty-server image to <sha>` follow-up commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)