### PR TITLE
feat(catalyst-api): /api/v1/sandbox/sessions exposes live controller status (was spec-only)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/sandbox_sessions.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sandbox_sessions.go
@@ -157,6 +157,13 @@ type sandboxListResponse struct {
 // sandboxItem — one Sandbox row as the FE consumes it. The FE
 // re-normalises every field defensively so the BE may omit unknown
 // fields without breaking older clients.
+//
+// The list/get responses reflect controller-managed `.status` fields
+// (Wave 14 follow-up to PR #1637 which shipped spec-only). Phase
+// mapping is documented on `mapSandboxStatus` — the canonical CRD
+// vocabulary (Pending|Provisioning|Ready|Failed) is preserved on
+// `Phase` while the FE-facing `Status` carries the projected
+// pending|running|stopped|failed|unknown.
 type sandboxItem struct {
 	// ID — the Sandbox CR name (DNS-1123 label, e.g. `sandbox-emrah`).
 	ID string `json:"id"`
@@ -170,11 +177,65 @@ type sandboxItem struct {
 	// the CRD vocabulary is {Pending, Provisioning, Ready, Failed}.
 	// mapSandboxStatus handles the projection.
 	Status string `json:"status"`
+	// Phase — raw controller phase (Pending|Provisioning|Ready|Failed).
+	// Surfaced alongside the projected `Status` so the FE can render
+	// finer-grained progress (e.g. "Provisioning" spinner vs. "Pending"
+	// queued state) without re-implementing the mapping.
+	Phase string `json:"phase,omitempty"`
 	// CreatedAt — RFC3339 metadata.creationTimestamp.
 	CreatedAt string `json:"createdAt"`
 	// Repo — first repo entry's giteaRepo (`<org>/<repo>`). Empty
 	// when no repos are configured.
 	Repo string `json:"repo"`
+	// Sessions — number of pty-server sessions live on the Sandbox.
+	// Mirrors `.status.sessions`. Zero when the controller hasn't
+	// reconciled yet OR when no sessions are open (the FE distinguishes
+	// via `Phase`).
+	Sessions int64 `json:"sessions"`
+	// StorageUsed — human-readable storage usage (e.g. "12Gi"). Mirrors
+	// `.status.storageUsed`. Empty when unknown.
+	StorageUsed string `json:"storageUsed,omitempty"`
+	// Spend30d — 30-day rolling spend in the operator's currency (e.g.
+	// "$4.21"). Mirrors `.status.spend30d`. Empty when unknown.
+	Spend30d string `json:"spend30d,omitempty"`
+	// Previews — list of preview URLs (one per PR/branch). Mirrors
+	// `.status.previews`. Empty slice when no previews are alive.
+	Previews []sandboxPreview `json:"previews"`
+	// Conditions — controller-managed K8s-style conditions. Surfaces
+	// the `Type|Status|Reason|Message` tuple verbatim so the FE can
+	// render actionable error states (e.g. `Ready=False` +
+	// `Reason=TokenMintFailed` + `Message=...`) without
+	// re-implementing the reconciler's failure taxonomy. Empty slice
+	// when the controller hasn't observed the CR yet.
+	Conditions []sandboxCondition `json:"conditions"`
+}
+
+// sandboxPreview mirrors sandboxapi.SandboxPreview (one preview URL
+// per PR/branch, see core/controllers/sandbox/internal/sandboxapi/
+// types.go). camelCase to match the FE wire convention.
+type sandboxPreview struct {
+	// PRNumber — the Gitea pull-request number that authored this
+	// preview. Zero for the trunk preview.
+	PRNumber int64 `json:"prNumber"`
+	// URL — the public HTTPS URL serving the preview.
+	URL string `json:"url"`
+	// SHA — short commit SHA the preview was built from.
+	SHA string `json:"sha,omitempty"`
+}
+
+// sandboxCondition mirrors sandboxapi.SandboxCondition. Reason +
+// Message are operator-facing strings (see fail() in
+// sandbox_controller.go for the canonical list:
+// OwnerOrgRefMissing|OwnerEmailMissing|OwnerEmailInvalid|
+// NoAllowedChannels|TokenMintFailed|ManifestRenderFailed|
+// GitopsWriteFailed). LastTransitionTime is RFC3339 to match the
+// rest of the catalyst-api wire format.
+type sandboxCondition struct {
+	Type               string `json:"type"`
+	Status             string `json:"status"`
+	Reason             string `json:"reason,omitempty"`
+	Message            string `json:"message,omitempty"`
+	LastTransitionTime string `json:"lastTransitionTime,omitempty"`
 }
 
 // sandboxCreateRequest — POST /sandbox/sessions body. Mirrors
@@ -622,15 +683,29 @@ func buildSandboxUnstructured(name, ns, displayName, agent, repo, ownerEmail, or
 // tolerates a nil / wrong-type intermediate so a partial CR (e.g. one
 // authored outside this handler by an operator's kubectl apply) still
 // renders.
+//
+// Wave 14 (PR sandbox-wave14-sessions-status-reflect): reads
+// controller-managed `.status` fields so list/get reflect the LIVE
+// runtime (Ready/Provisioning/Failed + sessions + storage + spend +
+// previews + conditions), not just the spec the handler authored.
+// Empty slices (`previews`, `conditions`) are always materialised so
+// the FE never has to `?? []` defensively.
 func unstructuredToSandboxItem(u *unstructured.Unstructured) sandboxItem {
 	if u == nil {
-		return sandboxItem{}
+		return sandboxItem{
+			Previews:   []sandboxPreview{},
+			Conditions: []sandboxCondition{},
+		}
 	}
+	rawPhase := readSandboxPhase(u)
 	item := sandboxItem{
-		ID:        u.GetName(),
-		Name:      u.GetName(),
-		Status:    mapSandboxStatus(u),
-		CreatedAt: u.GetCreationTimestamp().UTC().Format(time.RFC3339),
+		ID:         u.GetName(),
+		Name:       u.GetName(),
+		Status:     mapSandboxStatus(rawPhase),
+		Phase:      rawPhase,
+		CreatedAt:  u.GetCreationTimestamp().UTC().Format(time.RFC3339),
+		Previews:   []sandboxPreview{},
+		Conditions: []sandboxCondition{},
 	}
 
 	// Display name lives on metadata.annotations when the operator
@@ -659,21 +734,114 @@ func unstructuredToSandboxItem(u *unstructured.Unstructured) sandboxItem {
 		}
 	}
 
+	// ── .status reflection ──────────────────────────────────────
+	//
+	// All accessors tolerate type drift: the apiserver may serialise
+	// an int as float64 (JSON round-trip) so we route every numeric
+	// read through unstructured.NestedInt64 which handles the
+	// float→int coercion.
+
+	if sessions, found, _ := unstructured.NestedInt64(u.Object, "status", "sessions"); found {
+		item.Sessions = sessions
+	}
+	if storage, found, _ := unstructured.NestedString(u.Object, "status", "storageUsed"); found {
+		item.StorageUsed = strings.TrimSpace(storage)
+	}
+	if spend, found, _ := unstructured.NestedString(u.Object, "status", "spend30d"); found {
+		item.Spend30d = strings.TrimSpace(spend)
+	}
+
+	if previews, found, _ := unstructured.NestedSlice(u.Object, "status", "previews"); found {
+		for _, raw := range previews {
+			m, ok := raw.(map[string]any)
+			if !ok {
+				continue
+			}
+			p := sandboxPreview{}
+			// prNumber may arrive as int64 (controller) OR float64
+			// (post-JSON round-trip through the apiserver). Try both.
+			switch v := m["prNumber"].(type) {
+			case int64:
+				p.PRNumber = v
+			case float64:
+				p.PRNumber = int64(v)
+			case int:
+				p.PRNumber = int64(v)
+			}
+			if u, ok := m["url"].(string); ok {
+				p.URL = strings.TrimSpace(u)
+			}
+			if s, ok := m["sha"].(string); ok {
+				p.SHA = strings.TrimSpace(s)
+			}
+			if p.URL == "" {
+				// Drop incomplete entries — the FE keys rows by URL
+				// for the preview list.
+				continue
+			}
+			item.Previews = append(item.Previews, p)
+		}
+	}
+
+	if conds, found, _ := unstructured.NestedSlice(u.Object, "status", "conditions"); found {
+		for _, raw := range conds {
+			m, ok := raw.(map[string]any)
+			if !ok {
+				continue
+			}
+			c := sandboxCondition{}
+			if v, ok := m["type"].(string); ok {
+				c.Type = strings.TrimSpace(v)
+			}
+			if v, ok := m["status"].(string); ok {
+				c.Status = strings.TrimSpace(v)
+			}
+			if v, ok := m["reason"].(string); ok {
+				c.Reason = strings.TrimSpace(v)
+			}
+			if v, ok := m["message"].(string); ok {
+				c.Message = strings.TrimSpace(v)
+			}
+			if v, ok := m["lastTransitionTime"].(string); ok {
+				// Already RFC3339 from metav1.Time JSON marshal.
+				c.LastTransitionTime = strings.TrimSpace(v)
+			}
+			if c.Type == "" {
+				continue
+			}
+			item.Conditions = append(item.Conditions, c)
+		}
+	}
+
 	return item
 }
 
-// mapSandboxStatus projects status.phase (CRD vocabulary:
-// Pending|Provisioning|Ready|Failed) to the FE vocabulary
-// (pending|running|stopped|failed|unknown). Empty / unknown phases
-// surface as `pending` so the FE renders the spinner rather than the
-// red-text "unknown" pill — a fresh Sandbox typically transits
-// Pending → Provisioning → Ready in <10s.
-func mapSandboxStatus(u *unstructured.Unstructured) string {
+// readSandboxPhase reads `.status.phase` verbatim, trimming
+// whitespace. Returns "" when unset OR the controller hasn't observed
+// the CR yet.
+func readSandboxPhase(u *unstructured.Unstructured) string {
 	if u == nil {
-		return "unknown"
+		return ""
 	}
 	phase, _, _ := unstructured.NestedString(u.Object, "status", "phase")
-	switch strings.ToLower(strings.TrimSpace(phase)) {
+	return strings.TrimSpace(phase)
+}
+
+// mapSandboxStatus projects a raw `.status.phase` value (CRD
+// vocabulary: Pending|Provisioning|Ready|Failed) to the FE vocabulary
+// (pending|running|stopped|failed|unknown) per
+// products/catalyst/bootstrap/ui/src/lib/sandbox.api.ts:normalizeStatus.
+//
+// Empty / unknown phases surface as `pending` so the FE renders the
+// spinner rather than the red-text "unknown" pill — a fresh Sandbox
+// typically transits Pending → Provisioning → Ready in <10s.
+//
+// Wave 14: signature takes the raw phase string (was: *Unstructured).
+// The caller reads via readSandboxPhase exactly once and reuses the
+// value for both the projected Status AND the raw Phase field on the
+// wire payload.
+func mapSandboxStatus(rawPhase string) string {
+	switch strings.ToLower(rawPhase) {
 	case "pending", "provisioning":
 		return "pending"
 	case "ready":

--- a/products/catalyst/bootstrap/api/internal/handler/sandbox_sessions_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sandbox_sessions_test.go
@@ -1,0 +1,207 @@
+// Package handler — sandbox_sessions_test.go covers the
+// unstructured-to-wire projection that the Wave 14
+// /api/v1/sandbox/sessions handlers depend on for status reflection.
+//
+// The handler itself is exercised end-to-end by the FE Playwright
+// suite (products/catalyst/bootstrap/ui/e2e/sandbox.spec.ts); these
+// tests pin the projection contract so the wire shape can't silently
+// drift away from the controller's .status fields.
+package handler
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestUnstructuredToSandboxItem_StatusReflection(t *testing.T) {
+	creationTime := metav1.Now()
+	u := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "sandbox.openova.io/v1",
+			"kind":       "Sandbox",
+			"metadata": map[string]any{
+				"name":              "sandbox-emrah",
+				"namespace":         "acme",
+				"creationTimestamp": creationTime.Format("2006-01-02T15:04:05Z"),
+				"annotations": map[string]any{
+					"catalyst.openova.io/sandbox-display-name": "Emrah's box",
+				},
+			},
+			"spec": map[string]any{
+				"agentCatalogue": []any{"claude-code"},
+				"repos": []any{
+					map[string]any{"giteaRepo": "acme/site"},
+				},
+			},
+			"status": map[string]any{
+				"phase":       "Ready",
+				"sessions":    int64(2),
+				"storageUsed": "12Gi",
+				"spend30d":    "$4.21",
+				"previews": []any{
+					map[string]any{
+						"prNumber": int64(42),
+						"url":      "https://pr-42.preview.example",
+						"sha":      "abc1234",
+					},
+					// missing-URL row → must be dropped
+					map[string]any{
+						"prNumber": int64(99),
+					},
+				},
+				"conditions": []any{
+					map[string]any{
+						"type":               "Ready",
+						"status":             "True",
+						"reason":             "GitopsReconciled",
+						"message":            "all good",
+						"lastTransitionTime": "2026-05-18T11:00:00Z",
+					},
+					// missing-type row → must be dropped
+					map[string]any{"status": "True"},
+				},
+			},
+		},
+	}
+
+	item := unstructuredToSandboxItem(u)
+
+	if item.ID != "sandbox-emrah" {
+		t.Errorf("ID: want sandbox-emrah, got %q", item.ID)
+	}
+	if item.Name != "Emrah's box" {
+		t.Errorf("Name: want display-name annotation, got %q", item.Name)
+	}
+	if item.Agent != "claude-code" {
+		t.Errorf("Agent: want claude-code, got %q", item.Agent)
+	}
+	if item.Repo != "acme/site" {
+		t.Errorf("Repo: want acme/site, got %q", item.Repo)
+	}
+	if item.Phase != "Ready" {
+		t.Errorf("Phase: want Ready (raw), got %q", item.Phase)
+	}
+	if item.Status != "running" {
+		t.Errorf("Status (FE projection): want running, got %q", item.Status)
+	}
+	if item.Sessions != 2 {
+		t.Errorf("Sessions: want 2, got %d", item.Sessions)
+	}
+	if item.StorageUsed != "12Gi" {
+		t.Errorf("StorageUsed: want 12Gi, got %q", item.StorageUsed)
+	}
+	if item.Spend30d != "$4.21" {
+		t.Errorf("Spend30d: want $4.21, got %q", item.Spend30d)
+	}
+	if len(item.Previews) != 1 {
+		t.Fatalf("Previews: want 1 valid row (URL-bearing), got %d", len(item.Previews))
+	}
+	if item.Previews[0].PRNumber != 42 || item.Previews[0].URL != "https://pr-42.preview.example" || item.Previews[0].SHA != "abc1234" {
+		t.Errorf("Previews[0]: bad projection: %+v", item.Previews[0])
+	}
+	if len(item.Conditions) != 1 {
+		t.Fatalf("Conditions: want 1 valid row (Type-bearing), got %d", len(item.Conditions))
+	}
+	c := item.Conditions[0]
+	if c.Type != "Ready" || c.Status != "True" || c.Reason != "GitopsReconciled" || c.Message != "all good" || c.LastTransitionTime != "2026-05-18T11:00:00Z" {
+		t.Errorf("Conditions[0]: bad projection: %+v", c)
+	}
+}
+
+func TestUnstructuredToSandboxItem_PhaseProjection(t *testing.T) {
+	cases := []struct {
+		rawPhase   string
+		wantStatus string
+		wantPhase  string
+	}{
+		{"Pending", "pending", "Pending"},
+		{"Provisioning", "pending", "Provisioning"},
+		{"Ready", "running", "Ready"},
+		{"Failed", "failed", "Failed"},
+		{"", "pending", ""},        // no phase yet → pending (spinner)
+		{"WeirdValue", "unknown", "WeirdValue"},
+	}
+	for _, tc := range cases {
+		u := &unstructured.Unstructured{
+			Object: map[string]any{
+				"metadata": map[string]any{
+					"name": "sandbox-x",
+				},
+				"status": map[string]any{
+					"phase": tc.rawPhase,
+				},
+			},
+		}
+		item := unstructuredToSandboxItem(u)
+		if item.Status != tc.wantStatus {
+			t.Errorf("phase=%q → Status: want %q, got %q", tc.rawPhase, tc.wantStatus, item.Status)
+		}
+		if item.Phase != tc.wantPhase {
+			t.Errorf("phase=%q → Phase (raw): want %q, got %q", tc.rawPhase, tc.wantPhase, item.Phase)
+		}
+	}
+}
+
+func TestUnstructuredToSandboxItem_FailedSurfacesConditions(t *testing.T) {
+	// Failed Sandbox with a TokenMintFailed condition — the FE relies
+	// on this so it can render "Token mint failed — retrying" inline
+	// instead of a generic red pill.
+	u := &unstructured.Unstructured{
+		Object: map[string]any{
+			"metadata": map[string]any{"name": "sandbox-tokenfail"},
+			"status": map[string]any{
+				"phase": "Failed",
+				"conditions": []any{
+					map[string]any{
+						"type":    "Ready",
+						"status":  "False",
+						"reason":  "TokenMintFailed",
+						"message": "newapi bridge unreachable",
+					},
+				},
+			},
+		},
+	}
+	item := unstructuredToSandboxItem(u)
+	if item.Status != "failed" || item.Phase != "Failed" {
+		t.Errorf("Failed projection wrong: status=%q phase=%q", item.Status, item.Phase)
+	}
+	if len(item.Conditions) != 1 || item.Conditions[0].Reason != "TokenMintFailed" {
+		t.Fatalf("expected TokenMintFailed condition, got %+v", item.Conditions)
+	}
+}
+
+func TestUnstructuredToSandboxItem_NilInputDoesNotPanic(t *testing.T) {
+	item := unstructuredToSandboxItem(nil)
+	if item.Previews == nil {
+		t.Errorf("nil input: Previews must be empty slice, not nil")
+	}
+	if item.Conditions == nil {
+		t.Errorf("nil input: Conditions must be empty slice, not nil")
+	}
+}
+
+func TestUnstructuredToSandboxItem_PreviewFloat64Coercion(t *testing.T) {
+	// JSON round-trip through the apiserver may serialise int as
+	// float64. The projection MUST coerce both forms or the FE sees
+	// prNumber=0 for every preview after a SSE refresh.
+	u := &unstructured.Unstructured{
+		Object: map[string]any{
+			"metadata": map[string]any{"name": "sandbox-floats"},
+			"status": map[string]any{
+				"previews": []any{
+					map[string]any{
+						"prNumber": float64(7),
+						"url":      "https://pr-7.preview.example",
+					},
+				},
+			},
+		},
+	}
+	item := unstructuredToSandboxItem(u)
+	if len(item.Previews) != 1 || item.Previews[0].PRNumber != 7 {
+		t.Errorf("float64→int64 coercion failed: %+v", item.Previews)
+	}
+}


### PR DESCRIPTION
## Summary
- PR #1637 shipped `/api/v1/sandbox/sessions` CRUD returning only the spec the handler authored — every controller-managed `.status` field was ignored, so the FE had nothing to render past the FE-side "queued" pill.
- This wires the list/get projection to read `.status.{phase,sessions,storageUsed,spend30d,previews,conditions}` so the wire payload reflects the LIVE runtime (Ready/Provisioning/Failed + sessions + storage + spend + previews + controller failure conditions).
- Phase→FE-status mapping unchanged (matches `sandbox.api.ts:normalizeStatus`). Added `phase` field (raw) alongside the existing FE-projected `status` so the FE can render finer-grained progress states.

## What the FE gets back (per row)
- `phase` (raw: `Pending|Provisioning|Ready|Failed`)
- `status` (FE-projected: `pending|running|stopped|failed|unknown`) — unchanged contract
- `sessions` (int — pty-server count)
- `storageUsed` (string — human-readable, e.g. `12Gi`)
- `spend30d` (string — currency, e.g. `$4.21`)
- `previews[]` (array of `{prNumber, url, sha}` — drops URL-less rows)
- `conditions[]` (array of `{type, status, reason, message, lastTransitionTime}` — surfaces `TokenMintFailed`, `GitopsWriteFailed`, `ManifestRenderFailed`, `OwnerEmailMissing/Invalid`, `OwnerOrgRefMissing`, `NoAllowedChannels`)

## Why this matters
The controller (`core/controllers/sandbox/internal/controller/sandbox_controller.go`) calls `r.fail(...)` with one of seven canonical Reasons on every failure path; surfacing the condition tuple lets the FE render an actionable inline error ("Token mint failed — retrying") instead of a generic red pill.

## Notes for FE consumers
- All list slices (`previews`, `conditions`) are always materialised (never `nil`) — the FE never has to `?? []` defensively.
- `prNumber` is coerced from both `int64` and `float64` (apiserver JSON round-trips serialise ints as floats).
- `mapSandboxStatus` signature refactored from `(*Unstructured)` to `(rawPhase string)` so `readSandboxPhase` reads `.status.phase` exactly once per row.

## Test plan
- [x] `go build ./...` clean across the repo
- [x] `go vet ./internal/handler/...` clean
- [x] New handler tests pass: `TestUnstructuredToSandboxItem_{StatusReflection,PhaseProjection,FailedSurfacesConditions,NilInputDoesNotPanic,PreviewFloat64Coercion}`
- [x] Pre-existing handler-package failures (`TestHandleWhoami_*`, `user_access_test.go`) reproduce on origin/main — unrelated to this change
- [ ] Validate on next fresh prov: GET /api/v1/sandbox/sessions returns conditions on a real Failed Sandbox (TokenMintFailed path)
- [ ] FE-side: catalyst-ui Sandbox surface renders the new fields without target-state regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)