### PR TITLE
feat(sandbox-ui): disable Connect Claude Max button when OAuth client_id is placeholder (clear founder-action signal)

### DIFF
--- a/products/catalyst/bootstrap/api/cmd/api/main.go
+++ b/products/catalyst/bootstrap/api/cmd/api/main.go
@@ -656,6 +656,12 @@ func main() {
 		rg.Get("/api/v1/sandbox/byos/claude-code/callback", h.HandleByosClaudeCodeCallback)
 		rg.Delete("/api/v1/sandbox/byos/claude-code", h.HandleByosClaudeCodeDisconnect)
 		rg.Get("/api/v1/sandbox/byos/claude-code/status", h.HandleByosClaudeCodeStatus)
+		// /config — FE pre-flight: reports whether the chart's OAuth
+		// client_id is the placeholder (PR #1619). The SandboxSettings
+		// card uses this to disable the Connect button + show an amber
+		// "pending operator setup" tooltip instead of letting the user
+		// click a button whose OAuth URL would 400 at Anthropic.
+		rg.Get("/api/v1/sandbox/byos/claude-code/config", h.HandleByosClaudeCodeConfig)
 
 		// Sandbox sessions — Wave 7 CRUD on the Sandbox CRD
 		// (sandbox.openova.io/v1). The FE in

--- a/products/catalyst/bootstrap/api/internal/handler/byos_claude_code.go
+++ b/products/catalyst/bootstrap/api/internal/handler/byos_claude_code.go
@@ -1,7 +1,9 @@
 // byos_claude_code.go — POST /api/v1/sandbox/byos/claude-code/start,
-//                       GET  /api/v1/sandbox/byos/claude-code/callback,
-//                       DELETE /api/v1/sandbox/byos/claude-code,
-//                       GET  /api/v1/sandbox/byos/claude-code/status
+//
+//	GET  /api/v1/sandbox/byos/claude-code/callback,
+//	DELETE /api/v1/sandbox/byos/claude-code,
+//	GET  /api/v1/sandbox/byos/claude-code/status,
+//	GET  /api/v1/sandbox/byos/claude-code/config
 //
 // Wave 1b SCAFFOLD ONLY — design + handler shape. The actual outbound
 // OAuth client + Secret-store writes land in Wave 4 alongside the
@@ -367,6 +369,54 @@ func (h *Handler) HandleByosClaudeCodeStatus(w http.ResponseWriter, r *http.Requ
 	// Wave 4: read Secret/catalyst-system/sandbox-byos-claude-code-<sub>.
 	// When present + not RevokedAtProvider, set Connected=true and
 	// populate AnthropicAccountEmail + ConnectedAt.
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// byosConfigResponse is what GET /config returns. The SandboxSettings UI
+// reads it before showing the Connect button so the placeholder client_id
+// state surfaces as a disabled-with-tooltip control instead of letting the
+// user fire an OAuth URL that would 400 at Anthropic. See PR #1619 chart
+// wire + claude-code-byos.md §8.
+type byosConfigResponse struct {
+	// ClientIDConfigured is true when the chart's
+	// SANDBOX_BYOS_CLAUDE_CODE_CLIENT_ID env var is set to a non-empty,
+	// non-placeholder value. The Settings card MUST disable the
+	// "Connect Claude Max" button when this is false.
+	ClientIDConfigured bool `json:"clientIdConfigured"`
+
+	// OauthAuthorizeURL is the canonical Anthropic OAuth authorization
+	// URL the FE will hit via POST /start. Returned as an informational
+	// hint only when ClientIDConfigured=true; omitted from the JSON
+	// otherwise (`omitempty`) so the UI cannot accidentally fall back
+	// to it when the client_id is still the placeholder.
+	OauthAuthorizeURL string `json:"oauthAuthorizeURL,omitempty"`
+}
+
+// ── HandleByosClaudeCodeConfig — GET /api/v1/sandbox/byos/claude-code/config
+//
+// Returns the configuration-state the SandboxSettings card needs to
+// render its Connect button correctly:
+//
+//   - When the chart's client_id is still the placeholder
+//     (`PLACEHOLDER-AWAITING-FOUNDER-REGISTRATION` per PR #1619), the FE
+//     renders the button as DISABLED with the amber "API pending" pill +
+//     tooltip "Anthropic OAuth client_id not yet registered — contact
+//     your Sovereign operator". This avoids letting the user click a
+//     button whose OAuth URL would 400 at Anthropic.
+//   - When the operator has set the real client_id, the FE shows the
+//     button as enabled and POSTing /start returns the authorization URL
+//     the popup opens.
+//
+// This endpoint is intentionally read-only and unauthenticated by virtue
+// of sitting inside RequireSession — the response carries no secrets
+// (the client_id itself is a public OAuth identifier; we just gate
+// surface based on whether it's been registered yet).
+func (h *Handler) HandleByosClaudeCodeConfig(w http.ResponseWriter, r *http.Request) {
+	configured := byosClientID() != byosPlaceholderClientID
+	resp := byosConfigResponse{ClientIDConfigured: configured}
+	if configured {
+		resp.OauthAuthorizeURL = byosAuthorizationURL()
+	}
 	writeJSON(w, http.StatusOK, resp)
 }
 

--- a/products/catalyst/bootstrap/ui/src/lib/sandbox.api.ts
+++ b/products/catalyst/bootstrap/ui/src/lib/sandbox.api.ts
@@ -282,6 +282,65 @@ export async function connectByosClaudeCode(): Promise<{ authorizeUrl: string }>
 }
 
 /**
+ * BYOS config shape — the pre-flight the SandboxSettings card runs
+ * before showing the Connect button. When `clientIdConfigured` is false
+ * the chart's `SANDBOX_BYOS_CLAUDE_CODE_CLIENT_ID` is still the
+ * `PLACEHOLDER-AWAITING-FOUNDER-REGISTRATION` sentinel (PR #1619) and
+ * the FE MUST render the button as DISABLED with the amber pendingApi
+ * pill + a tooltip pointing the operator at the founder action.
+ */
+export interface ByosClaudeCodeConfig {
+  /** True when the FE was unable to reach `/config` — treated as
+   *  pending operator setup so the UI never offers a button that would
+   *  fail at Anthropic. */
+  pendingApi: boolean
+  clientIdConfigured: boolean
+  /** Optional informational hint; only populated when configured. */
+  oauthAuthorizeURL: string
+}
+
+const PENDING_BYOS_CONFIG: ByosClaudeCodeConfig = {
+  pendingApi: true,
+  clientIdConfigured: false,
+  oauthAuthorizeURL: '',
+}
+
+/**
+ * getByosClaudeCodeConfig — GET /v1/sandbox/byos/claude-code/config.
+ *
+ * The SandboxSettings card calls this before rendering the Connect
+ * button. On 404 / 5xx / network error returns
+ * `{pendingApi: true, clientIdConfigured: false, ...}` so the UI defaults
+ * to the safer "disabled with pending tooltip" state — never the
+ * "enabled but the OAuth URL will 400" state.
+ */
+export async function getByosClaudeCodeConfig(): Promise<ByosClaudeCodeConfig> {
+  let res: Response
+  try {
+    res = await authedFetch(`${SANDBOX_BASE}/byos/claude-code/config`, {
+      headers: { Accept: 'application/json' },
+    })
+  } catch {
+    return PENDING_BYOS_CONFIG
+  }
+  if (!res.ok) {
+    return PENDING_BYOS_CONFIG
+  }
+  try {
+    const body = (await res.json()) as Partial<ByosClaudeCodeConfig> | null
+    if (!body || typeof body !== 'object') return PENDING_BYOS_CONFIG
+    return {
+      pendingApi: false,
+      clientIdConfigured: body.clientIdConfigured === true,
+      oauthAuthorizeURL:
+        typeof body.oauthAuthorizeURL === 'string' ? body.oauthAuthorizeURL : '',
+    }
+  } catch {
+    return PENDING_BYOS_CONFIG
+  }
+}
+
+/**
  * disconnectByosClaudeCode — DELETE /v1/sandbox/byos/claude-code/
  * disconnect. Drops the stored OAuth tokens. Surfaces the BE's `detail` /
  * `error` field on non-2xx.

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/sandbox/SandboxSettings.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/sandbox/SandboxSettings.tsx
@@ -30,7 +30,9 @@ import { useDeploymentEvents } from '../useDeploymentEvents'
 import {
   connectByosClaudeCode,
   disconnectByosClaudeCode,
+  getByosClaudeCodeConfig,
   getByosStatus,
+  type ByosClaudeCodeConfig,
   type ByosClaudeCodeStatus,
 } from '@/lib/sandbox.api'
 
@@ -41,11 +43,16 @@ export interface SandboxSettingsProps {
   disableStream?: boolean
   /** Test seam — bypass the React Query fetcher with synthetic data. */
   initialByosOverride?: ByosClaudeCodeStatus
+  /** Test seam — bypass the React Query fetcher for the BYOS config
+   *  pre-flight (`/config` endpoint). Lets tests assert both the
+   *  placeholder-disabled and configured-enabled branches without HTTP. */
+  initialByosConfigOverride?: ByosClaudeCodeConfig
 }
 
 export function SandboxSettings({
   disableStream = false,
   initialByosOverride,
+  initialByosConfigOverride,
 }: SandboxSettingsProps = {}) {
   const { deploymentId: resolvedId } = useResolvedDeploymentId()
   const deploymentId = resolvedId ?? ''
@@ -74,7 +81,10 @@ export function SandboxSettings({
       }
     >
       <div className="mx-auto max-w-7xl" data-testid="sandbox-settings-page">
-        <ClaudeCodeByosCard initialByosOverride={initialByosOverride} />
+        <ClaudeCodeByosCard
+          initialByosOverride={initialByosOverride}
+          initialByosConfigOverride={initialByosConfigOverride}
+        />
       </div>
     </PortalShell>
   )
@@ -84,9 +94,13 @@ export function SandboxSettings({
 
 interface ClaudeCodeByosCardProps {
   initialByosOverride?: ByosClaudeCodeStatus
+  initialByosConfigOverride?: ByosClaudeCodeConfig
 }
 
-function ClaudeCodeByosCard({ initialByosOverride }: ClaudeCodeByosCardProps) {
+function ClaudeCodeByosCard({
+  initialByosOverride,
+  initialByosConfigOverride,
+}: ClaudeCodeByosCardProps) {
   const qc = useQueryClient()
   const [error, setError] = useState<string | null>(null)
 
@@ -98,8 +112,27 @@ function ClaudeCodeByosCard({ initialByosOverride }: ClaudeCodeByosCardProps) {
     placeholderData: (prev) => prev,
   })
 
+  // Pre-flight: /config tells us whether the chart's OAuth client_id is
+  // still the `PLACEHOLDER-AWAITING-FOUNDER-REGISTRATION` sentinel from
+  // PR #1619. When it is, the Connect button MUST be disabled — clicking
+  // it would fire an OAuth URL that 400s at Anthropic and confuse the
+  // operator about whether BYOS is genuinely broken vs awaiting setup.
+  const configQuery = useQuery<ByosClaudeCodeConfig>({
+    queryKey: ['sandbox-byos-claude-code-config'],
+    queryFn: getByosClaudeCodeConfig,
+    staleTime: QUERY_STALE_MS,
+    enabled: !initialByosConfigOverride,
+    placeholderData: (prev) => prev,
+  })
+
   const data = initialByosOverride ?? query.data ?? null
-  const pendingApi = data?.pendingApi ?? true
+  const config = initialByosConfigOverride ?? configQuery.data ?? null
+  // Default to "not configured" while the pre-flight is in-flight so we
+  // never momentarily render an enabled button against an un-registered
+  // client_id (would 400 at Anthropic on click).
+  const clientIdConfigured = config?.clientIdConfigured ?? false
+  const configPendingApi = config?.pendingApi ?? true
+  const pendingApi = (data?.pendingApi ?? true) || configPendingApi
   const status = data?.status ?? 'disconnected'
   const accountLabel = data?.accountLabel ?? ''
   const connectedAt = data?.connectedAt ?? ''
@@ -149,9 +182,15 @@ function ClaudeCodeByosCard({ initialByosOverride }: ClaudeCodeByosCardProps) {
           <span
             data-testid="sandbox-byos-claude-code-pending-api"
             className="rounded-full border border-amber-500/40 bg-amber-500/10 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide text-amber-300"
-            title="Backend API not yet wired — display only"
+            title={
+              !clientIdConfigured && !configPendingApi
+                ? 'Anthropic OAuth client_id not yet registered — contact your Sovereign operator'
+                : 'Backend API not yet wired — display only'
+            }
           >
-            API pending
+            {!clientIdConfigured && !configPendingApi
+              ? 'Operator setup pending'
+              : 'API pending'}
           </span>
         ) : null}
       </header>
@@ -188,6 +227,14 @@ function ClaudeCodeByosCard({ initialByosOverride }: ClaudeCodeByosCardProps) {
                 </span>
               ) : null}
             </p>
+          ) : !clientIdConfigured && !configPendingApi ? (
+            <p
+              className="text-xs text-[var(--color-text-dim)]"
+              data-testid="sandbox-byos-claude-code-operator-pending"
+            >
+              Anthropic OAuth client_id not yet registered — contact your
+              Sovereign operator to enable BYOS.
+            </p>
           ) : (
             <p className="text-xs text-[var(--color-text-dim)]">
               No Anthropic account linked.
@@ -210,8 +257,19 @@ function ClaudeCodeByosCard({ initialByosOverride }: ClaudeCodeByosCardProps) {
             <button
               type="button"
               onClick={() => connect.mutate()}
-              disabled={connect.isPending}
+              disabled={connect.isPending || !clientIdConfigured}
               data-testid="sandbox-byos-claude-code-connect"
+              data-clientid-configured={clientIdConfigured ? 'true' : 'false'}
+              title={
+                !clientIdConfigured
+                  ? 'Anthropic OAuth client_id not yet registered — contact your Sovereign operator'
+                  : undefined
+              }
+              aria-label={
+                !clientIdConfigured
+                  ? 'Connect Claude Max — disabled, Anthropic OAuth client_id not yet registered'
+                  : undefined
+              }
               className="rounded-md bg-[var(--color-accent)] px-3 py-1.5 text-xs font-medium text-white hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
             >
               {connect.isPending ? 'Opening…' : 'Connect Claude Max'}


### PR DESCRIPTION
## Summary
- Adds **`GET /api/v1/sandbox/byos/claude-code/config`** returning `{clientIdConfigured: bool, oauthAuthorizeURL?: string}` — handler refuses to leak the placeholder OAuth URL when the chart's `SANDBOX_BYOS_CLAUDE_CODE_CLIENT_ID` is still the `PLACEHOLDER-AWAITING-FOUNDER-REGISTRATION` sentinel set by PR #1619.
- **SandboxSettings.tsx** (PR #1621) now pre-flights `/config` and renders the *Connect Claude Max* button as **DISABLED** with the amber pendingApi pill + tooltip *"Anthropic OAuth client_id not yet registered — contact your Sovereign operator"* when the operator hasn't yet completed the founder action in `products/sandbox/docs/claude-code-byos.md` §8.
- Inline status copy flips from *"No Anthropic account linked."* to a clear *"Anthropic OAuth client_id not yet registered — contact your Sovereign operator to enable BYOS."* so the user understands WHY the button is greyed out vs guessing.

Closes the operator-confusion gap: before this PR clicking *Connect Claude Max* on a fresh Sovereign would hit `/start`, which would 503 with a JSON error the FE swallowed into a toast — looked indistinguishable from a backend outage. After this PR the disabled button + tooltip + amber pill points squarely at the one founder TODO that flips BYOS live.

## Design-system inheritance
- Amber pill: `border-amber-500/40 bg-amber-500/10 text-amber-300 text-[10px] uppercase` — **verbatim** from SettingsPage's pendingApi pill.
- Button disabled state: `disabled:cursor-not-allowed disabled:opacity-50` — same treatment as the page's other buttons.
- Operator-pending paragraph: `text-xs text-[var(--color-text-dim)]` token.
- Zero new bespoke components, zero new colors outside design tokens, zero chart bumps.

## Test plan
- [ ] When chart env `SANDBOX_BYOS_CLAUDE_CODE_CLIENT_ID=PLACEHOLDER-AWAITING-FOUNDER-REGISTRATION`, `curl /api/v1/sandbox/byos/claude-code/config` returns `{"clientIdConfigured":false}` (no `oauthAuthorizeURL` field).
- [ ] When chart env `SANDBOX_BYOS_CLAUDE_CODE_CLIENT_ID=anthropic-public-abc123`, `curl /config` returns `{"clientIdConfigured":true,"oauthAuthorizeURL":"https://console.anthropic.com/oauth/authorize"}`.
- [ ] Sovereign Console `/sandbox/settings` — Connect Claude Max button is disabled, shows amber "Operator setup pending" pill, hovering surfaces the tooltip; clicking does nothing.
- [ ] After operator pastes the real client_id and Flux rolls catalyst-api, the page (or a hard refresh) flips to the enabled-button + "No Anthropic account linked." copy.
- [ ] `npx tsc --noEmit` clean (validated locally).
- [ ] `go build ./...` clean (validated locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)