### PR TITLE
chore(release): chart 1.4.162→1.4.163 — Wave 16 collector (all post-Wave 14 template+template changes baked)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -550,7 +550,20 @@ spec:
       #   Resources/Logs tab namespace+label fix (HR.spec.target-
       #   Namespace + chart-name label) + "Bootstrap blueprint"
       #   chip for bp-* (founder bug #4, C4-003/004/005/007/013).
-      version: 1.4.162
+      # 1.4.163 (Wave 16 collector, 2026-05-18): republishes the chart
+      # OCI artifact so it actually contains every chart-template change
+      # merged after the 1.4.162 publish (commit 0ad78790). Without the
+      # republish, bootstrap-kit pin 1.4.162 pulls an artifact missing
+      # the new templates and Sovereigns boot with stale chart bytes.
+      # Baked: #1644 tenantPublic HTTPRoute reconciler + #1650
+      # tenantPublic setter on product-install + #1640 Cilium Gateway
+      # per-zone listener pairs + #1654 bp-newapi attestation gate +
+      # sandbox-controller post-handover refinements (D31 HS env vars,
+      # sovereign-fqdn ConfigMap keys, cutover-driver sandboxes RBAC,
+      # values.yaml sovereign.{enableHotStandby,primaryRegion,
+      # replicaRegion} defaults). See Chart.yaml header comment for
+      # the full change list.
+      version: 1.4.163
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -1,5 +1,57 @@
 apiVersion: v2
 name: bp-catalyst-platform
+# 1.4.163 — Wave 16 collector. Bumps chart version so the next Blueprint
+# Release republishes the OCI artifact with every chart-template change
+# that landed since the 1.4.162 publish (commit 0ad78790). The 1.4.162
+# OCI bytes pre-date these template additions; without this republish,
+# Sovereigns sourcing bootstrap-kit 1.4.163 download an artifact missing
+# the new templates → tenant HTTPRoute / Cilium per-zone listeners /
+# bp-newapi attestation gate never reach the chroot.
+#
+# Baked in 1.4.163:
+# - #1644 organization-controller renders per-tenant HTTPRoute so
+#   <slug>.<parentDomain> serves the tenant's installed product
+#   (was falling through to the marketplace tenant-wildcard route).
+#   Adds crds/organization.yaml tenantPublic field +
+#   templates/sme-services/tenant-public-routes.yaml + values.yaml
+#   tenantRoutes[] static-fixture path.
+# - #1650 provisioning service patches Organization.spec.tenantPublic
+#   on product-install (both initial workflow and day-2 install path)
+#   so the #1644 HTTPRoute reconciler has parentDomain/subdomain/
+#   backend to render. Pre-#1650 every Org had zero-value
+#   TenantPublic → reconciler short-circuited at empty-ParentDomain
+#   guard.
+# - #1640 Cilium Gateway renders one listener pair (HTTPS:30443 +
+#   HTTP:30080) per parent zone (sovereign-tls Kustomization).
+#   Tenants under non-primary parent zones (e.g. wp-foo.omani.homes
+#   when omani.homes is the SME pool) no longer TLS-handshake-
+#   mismatch on the wildcard cert.
+# - #1654 bp-newapi attestation gate — chart now skips channel
+#   render when ATTESTATION_ACCOUNT_ID env is empty (was blocking
+#   install with bogus channel CR pointing at empty account).
+# - Sandbox-controller post-handover refinements:
+#   - api-deployment.yaml SOVEREIGN_ENABLE_HOT_STANDBY +
+#     SOVEREIGN_PRIMARY_REGION + SOVEREIGN_REPLICA_REGION env vars
+#     (D31 wiring; SME tenant gitops writer reads at render time so
+#     every freshly-rendered bp-wordpress-tenant HR carries
+#     pg.activeHotStandby block when toggle is true).
+#   - sovereign-fqdn-configmap.yaml exposes enableHotStandby /
+#     primaryRegion / replicaRegion keys (populated from
+#     .Values.sovereign.* via bootstrap-kit slot 13 envsubst).
+#   - clusterrole-cutover-driver.yaml grants sandbox.openova.io/
+#     sandboxes verbs (create split into its own Rule per
+#     feedback_rbac_create_no_resourcenames.md) so the Sovereign
+#     Console's /sandbox surface + /api/v1/sandbox/sessions handler
+#     read/write Sandbox CRs via the cutover-driver SA.
+#   - values.yaml sovereign.enableHotStandby / primaryRegion /
+#     replicaRegion defaults (all empty — zero regression on
+#     Sovereigns that have not opted into the active-hot-standby
+#     shape).
+#
+# Pairs with bootstrap-kit/13-bp-catalyst-platform.yaml pin
+# 1.4.162→1.4.163 in this same PR so the next fresh prov pulls
+# the republished artifact.
+#
 # 1.4.153 (D17 Wave-1 Family A — /cloud?view=list&kind=<X> no longer
 # drifts to /dashboard on Sovereign Console):
 #
@@ -1086,8 +1138,8 @@ name: bp-catalyst-platform
 # Fix #154 (HR-timeout audit). Those bumped the HelmRelease
 # install.timeout. This bumps the chart-INTERNAL wait loop budget
 # inside the pre-install hook Job, which is a different seam.
-version: 1.4.162
-appVersion: 1.4.162
+version: 1.4.163
+appVersion: 1.4.163
 # 1.4.141 (qa-loop Fix #185, prov #38/#39/#41 recurrence — pre-install
 # hook unscheduable on saturated worker):
 #


### PR DESCRIPTION
## Summary

- Bump `products/catalyst/chart/Chart.yaml` version + appVersion **1.4.162 → 1.4.163** (chart-version-only republish so the OCI artifact contains every chart-template change merged after the 1.4.162 publish at commit `0ad78790`).
- Bump `clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml` pin **1.4.162 → 1.4.163** so the next fresh prov pulls the republished bytes.
- Header changelog entry in `Chart.yaml` summarising what 1.4.163 contains.

## Why

The 1.4.162 OCI artifact pre-dates the post-Wave-14 template additions. Sovereigns sourcing bootstrap-kit pin 1.4.162 download stale bytes and never get the new templates → tenant HTTPRoute / Cilium per-zone listeners / bp-newapi attestation gate / sandbox-controller D31 wiring never reach the chroot. Same OCI pipeline race documented in the 1.4.6 / 1.4.14 / 1.4.16 / 1.4.116 / 1.4.118 changelog entries.

## What's in 1.4.163

- **#1644** organization-controller renders per-tenant HTTPRoute so `<slug>.<parentDomain>` serves the tenant's installed product (adds `crds/organization.yaml` tenantPublic field + `templates/sme-services/tenant-public-routes.yaml` + `values.yaml` tenantRoutes[] static-fixture path).
- **#1650** provisioning service patches `Organization.spec.tenantPublic` on product-install so the #1644 HTTPRoute reconciler has a non-empty parentDomain to render.
- **#1640** Cilium Gateway one listener pair (HTTPS:30443 + HTTP:30080) per parent zone.
- **#1654** bp-newapi attestation gate — channel CR render skipped when `ATTESTATION_ACCOUNT_ID` env empty (was blocking install with bogus channel pointing at empty account).
- **Sandbox-controller post-handover refinements**:
  - `api-deployment.yaml` SOVEREIGN_ENABLE_HOT_STANDBY + SOVEREIGN_PRIMARY_REGION + SOVEREIGN_REPLICA_REGION env vars (D31 wiring).
  - `sovereign-fqdn-configmap.yaml` exposes enableHotStandby / primaryRegion / replicaRegion keys.
  - `clusterrole-cutover-driver.yaml` grants `sandbox.openova.io/sandboxes` verbs (create split into its own Rule per `feedback_rbac_create_no_resourcenames.md`).
  - `values.yaml` `sovereign.{enableHotStandby,primaryRegion,replicaRegion}` defaults (all empty — zero regression).

## Hard rules honoured

- `clusters/` READ-ONLY for non-`_template` paths (only the bootstrap-kit pin under `_template/` is bumped).
- `helm template bp-catalyst-platform products/catalyst/chart/` → exit 0, 3009 lines rendered.
- `helm lint products/catalyst/chart/` → `0 chart(s) failed`.

## Test plan

- [x] `helm template bp-catalyst-platform products/catalyst/chart/` exit 0
- [x] `helm lint products/catalyst/chart/` clean
- [ ] Blueprint Release pipeline republishes 1.4.163 OCI artifact post-merge
- [ ] Next fresh prov bootstrap-kit pulls 1.4.163 (verify `helm get values catalyst-platform -n catalyst-system` shows tenantRoutes / SOVEREIGN_*_REGION wiring)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>