### PR TITLE
feat(sandbox-ui): provisioning progress panel + conditions display

### DIFF
--- a/products/catalyst/bootstrap/ui/src/lib/sandbox.api.ts
+++ b/products/catalyst/bootstrap/ui/src/lib/sandbox.api.ts
@@ -77,6 +77,43 @@ export const SANDBOX_AGENTS: readonly SandboxAgent[] = [
 
 export type SandboxStatus = 'pending' | 'running' | 'stopped' | 'failed' | 'unknown'
 
+/**
+ * Raw CRD phase vocabulary as the sandbox-controller emits it on
+ * `.status.phase`. Surfaced verbatim alongside the FE-projected
+ * `SandboxStatus` so the provisioning UI can render finer-grained
+ * progress (e.g. "Provisioning" spinner vs. "Pending" queued state)
+ * without re-implementing the controller's projection rules.
+ *
+ * The catalyst-api projection lives in
+ * `products/catalyst/bootstrap/api/internal/handler/sandbox_sessions.go`
+ * (PR #1673 — `mapSandboxStatus` + `readSandboxPhase`).
+ */
+export type SandboxPhase = 'Pending' | 'Provisioning' | 'Ready' | 'Failed' | ''
+
+/**
+ * K8s-style condition tuple — surfaced verbatim from
+ * `.status.conditions[]` so the FE can render actionable failure
+ * reasons (TokenMintFailed | ManifestRenderFailed | GitopsWriteFailed
+ * | OwnerEmailInvalid | NoAllowedChannels) inline. The full list of
+ * canonical reason strings lives on the controller's `fail()` helper —
+ * see `core/controllers/sandbox/internal/sandboxapi/types.go`.
+ *
+ * Mirrors the catalyst-api wire shape verbatim (`sandboxCondition` in
+ * sandbox_sessions.go).
+ */
+export interface SandboxCondition {
+  /** Condition type (e.g. `Ready`, `Provisioning`, `TokenMintFailed`). */
+  type: string
+  /** Condition status (`True` | `False` | `Unknown`). */
+  status: string
+  /** Operator-facing reason code (e.g. `TokenMintFailed`). */
+  reason?: string
+  /** Free-form operator-facing message. */
+  message?: string
+  /** RFC3339 transition timestamp. */
+  lastTransitionTime?: string
+}
+
 export interface Sandbox {
   /** Stable Sandbox CR name (sandbox-<slug>). */
   id: string
@@ -85,10 +122,24 @@ export interface Sandbox {
   /** Agent binary id chosen at create time. */
   agent: SandboxAgent['id']
   status: SandboxStatus
+  /**
+   * Raw controller phase (Pending|Provisioning|Ready|Failed). Empty
+   * when the controller hasn't observed the CR yet. Always available
+   * post-PR #1673; older catalyst-api builds omit this field, in which
+   * case the FE falls back to `status` for the phase badge.
+   */
+  phase: SandboxPhase
   /** ISO-8601 creation timestamp. */
   createdAt: string
   /** Repo path mounted at /repo (e.g. 'org/site'); empty when none. */
   repo: string
+  /**
+   * Controller-managed K8s-style conditions. Empty slice when the
+   * controller hasn't observed the CR yet OR when no conditions have
+   * been recorded. Always materialised as an array (never undefined)
+   * so the FE never has to defensively `?? []`.
+   */
+  conditions: SandboxCondition[]
 }
 
 export interface SandboxesResponse {
@@ -131,17 +182,7 @@ export async function getSandboxes(): Promise<SandboxesResponse> {
     const sandboxes: Sandbox[] = body.sandboxes
       .map((raw): Sandbox | null => {
         if (!raw || typeof raw !== 'object') return null
-        const r = raw as Record<string, unknown>
-        const id = typeof r.id === 'string' ? r.id : ''
-        if (id === '') return null
-        return {
-          id,
-          name: typeof r.name === 'string' && r.name !== '' ? r.name : id,
-          agent: normalizeAgent(r.agent),
-          status: normalizeStatus(r.status),
-          createdAt: typeof r.createdAt === 'string' ? r.createdAt : '',
-          repo: typeof r.repo === 'string' ? r.repo : '',
-        }
+        return normalizeSandbox(raw as Record<string, unknown>)
       })
       .filter((s): s is Sandbox => s !== null)
     return { pendingApi: false, sandboxes }
@@ -182,13 +223,94 @@ export async function createSandbox(req: CreateSandboxRequest): Promise<Sandbox>
     throw new Error(`create sandbox: ${detail}`)
   }
   const raw = (await res.json()) as Record<string, unknown>
+  const normalised = normalizeSandbox(raw)
+  if (!normalised) {
+    throw new Error('create sandbox: invalid response body')
+  }
+  return normalised
+}
+
+/**
+ * getSandbox — GET /v1/sandbox/sessions/{id}. Fetches a single Sandbox
+ * row by name; returns `null` on 404 (operator deleted the sandbox in
+ * another tab) so the SandboxSession provisioning panel can short-
+ * circuit its poll loop without surfacing a misleading "still
+ * provisioning" spinner.
+ *
+ * Other non-2xx responses throw with the server-side `detail` /
+ * `error` field so the FE can surface them in a retry banner.
+ *
+ * Used by the SandboxProvisioningPanel to poll Phase + Conditions
+ * until `phase==='Ready'` (terminal-success) or `phase==='Failed'`
+ * (terminal-failure → surface conditions[] + retry CTA).
+ */
+export async function getSandbox(id: string): Promise<Sandbox | null> {
+  const res = await authedFetch(
+    `${SANDBOX_BASE}/sessions/${encodeURIComponent(id)}`,
+    { headers: { Accept: 'application/json' } },
+  )
+  if (res.status === 404) return null
+  if (!res.ok) {
+    let detail = `HTTP ${res.status}`
+    try {
+      const body = (await res.json()) as { detail?: string; error?: string }
+      detail = body.detail ?? body.error ?? detail
+    } catch {
+      // non-JSON body — keep the status-line message
+    }
+    throw new Error(`get sandbox: ${detail}`)
+  }
+  const raw = (await res.json()) as Record<string, unknown>
+  const normalised = normalizeSandbox(raw)
+  if (!normalised) {
+    throw new Error('get sandbox: invalid response body')
+  }
+  return normalised
+}
+
+/**
+ * deleteSandbox — DELETE /v1/sandbox/sessions/{id}. The catalyst-api
+ * handler is idempotent (204 even when the CR is already gone) so the
+ * FE can retry safely. Used by the "Delete + retry" flow when a
+ * provisioning attempt lands in `Failed`.
+ */
+export async function deleteSandbox(id: string): Promise<void> {
+  const res = await authedFetch(
+    `${SANDBOX_BASE}/sessions/${encodeURIComponent(id)}`,
+    { method: 'DELETE', headers: { Accept: 'application/json' } },
+  )
+  if (!res.ok && res.status !== 204 && res.status !== 404) {
+    let detail = `HTTP ${res.status}`
+    try {
+      const body = (await res.json()) as { detail?: string; error?: string }
+      detail = body.detail ?? body.error ?? detail
+    } catch {
+      // non-JSON body — keep the status-line message
+    }
+    throw new Error(`delete sandbox: ${detail}`)
+  }
+}
+
+/**
+ * normalizeSandbox — single defensive projection from the catalyst-api
+ * wire shape to the FE `Sandbox` type. Shared by `getSandboxes`,
+ * `getSandbox`, and `createSandbox` so they cannot drift.
+ *
+ * Returns `null` when the row is missing the `id` field (the FE keys
+ * every list/lookup by id; an unkeyed row is unusable).
+ */
+function normalizeSandbox(raw: Record<string, unknown>): Sandbox | null {
+  const id = typeof raw.id === 'string' ? raw.id : ''
+  if (id === '') return null
   return {
-    id: typeof raw.id === 'string' ? raw.id : '',
-    name: typeof raw.name === 'string' ? raw.name : '',
+    id,
+    name: typeof raw.name === 'string' && raw.name !== '' ? raw.name : id,
     agent: normalizeAgent(raw.agent),
     status: normalizeStatus(raw.status),
+    phase: normalizePhase(raw.phase),
     createdAt: typeof raw.createdAt === 'string' ? raw.createdAt : '',
     repo: typeof raw.repo === 'string' ? raw.repo : '',
+    conditions: normalizeConditions(raw.conditions),
   }
 }
 
@@ -375,6 +497,35 @@ function normalizeStatus(raw: unknown): SandboxStatus {
   const s = raw.toLowerCase()
   if (s === 'pending' || s === 'running' || s === 'stopped' || s === 'failed') return s
   return 'unknown'
+}
+
+function normalizePhase(raw: unknown): SandboxPhase {
+  if (typeof raw !== 'string') return ''
+  const s = raw.trim()
+  if (s === 'Pending' || s === 'Provisioning' || s === 'Ready' || s === 'Failed') return s
+  return ''
+}
+
+function normalizeConditions(raw: unknown): SandboxCondition[] {
+  if (!Array.isArray(raw)) return []
+  const out: SandboxCondition[] = []
+  for (const entry of raw) {
+    if (!entry || typeof entry !== 'object') continue
+    const r = entry as Record<string, unknown>
+    const type = typeof r.type === 'string' ? r.type.trim() : ''
+    if (type === '') continue
+    out.push({
+      type,
+      status: typeof r.status === 'string' ? r.status.trim() : '',
+      reason: typeof r.reason === 'string' ? r.reason.trim() : undefined,
+      message: typeof r.message === 'string' ? r.message.trim() : undefined,
+      lastTransitionTime:
+        typeof r.lastTransitionTime === 'string'
+          ? r.lastTransitionTime.trim()
+          : undefined,
+    })
+  }
+  return out
 }
 
 function normalizeByosStatus(raw: unknown): ByosStatus {

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/sandbox/SandboxLanding.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/sandbox/SandboxLanding.tsx
@@ -25,7 +25,7 @@
  */
 
 import { useState } from 'react'
-import { Link } from '@tanstack/react-router'
+import { Link, useNavigate } from '@tanstack/react-router'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { useResolvedDeploymentId } from '@/shared/lib/useResolvedDeploymentId'
 import { PortalShell } from '../PortalShell'
@@ -260,15 +260,36 @@ interface StartSandboxModalProps {
 
 function StartSandboxModal({ agent, onClose }: StartSandboxModalProps) {
   const qc = useQueryClient()
+  const navigate = useNavigate()
   const [name, setName] = useState('')
   const [repo, setRepo] = useState('')
   const [error, setError] = useState<string | null>(null)
 
+  // Wave 15 (PR sandbox-wave15-provisioning-ui): on successful create
+  // we navigate the operator straight to /sandbox/$id. The session
+  // page polls GET /sessions/{id} every 2s via SandboxProvisioningPanel
+  // until phase===Ready, then auto-attaches the xterm.js panel. The
+  // landing's recent-sessions list still picks up the new row via the
+  // ['sandbox-sessions'] invalidation so a returning operator can re-
+  // attach later.
   const create = useMutation({
     mutationFn: createSandbox,
-    onSuccess: () => {
+    onSuccess: (sandbox) => {
       void qc.invalidateQueries({ queryKey: ['sandbox-sessions'] })
+      // Seed the per-session cache with the freshly-created row so the
+      // SandboxProvisioningPanel renders the canonical 6-stage
+      // waterfall on first paint without waiting for the first 2s
+      // poll tick to land.
+      qc.setQueryData(['sandbox-session', sandbox.id], sandbox)
       onClose()
+      // Navigate to /sandbox/$id. TanStack params are typed via the
+      // route's param shape; the `as never` mirrors the existing
+      // Link({ to: '/sandbox/$id', params: { id } }) pattern used by
+      // the Recent sessions rail above.
+      navigate({
+        to: '/sandbox/$id' as never,
+        params: { id: sandbox.id } as never,
+      })
     },
     onError: (err) => setError((err as Error).message),
   })

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/sandbox/SandboxProvisioningPanel.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/sandbox/SandboxProvisioningPanel.tsx
@@ -1,0 +1,602 @@
+/**
+ * SandboxProvisioningPanel — real-time provisioning progress panel
+ * shown on `/sandbox/$id` while the sandbox-controller materialises the
+ * Sandbox CR. Replaces the prior "blank until xterm.js attaches"
+ * behaviour that PR #1670 left in place (the WebSocket reconnect loop
+ * fired ~6 retries against a non-existent ingress before giving up).
+ *
+ * Wire path:
+ *
+ *   browser ──GET /api/v1/sandbox/sessions/{id}──▶ catalyst-api
+ *           (polled every 2s via TanStack Query)
+ *
+ * The handler projects `.status.{phase, conditions[]}` from the Sandbox
+ * CR (PR #1673). The phase progression is:
+ *
+ *   Pending → Provisioning → Ready
+ *                          ↘ Failed
+ *
+ * Each stage maps to a concrete controller side-effect; we mirror the
+ * canonical six-stage shape from `core/controllers/sandbox/internal/
+ * controller.go` so the operator sees the same waterfall the controller
+ * walks:
+ *
+ *   1. Namespace      — sandbox-<owner-uid> ns + labels
+ *   2. RBAC           — ServiceAccount + Role + RoleBinding
+ *   3. PVCs           — repo + claude-memory + cache volumes
+ *   4. pty Pod        — pty-server pod + Service
+ *   5. MCP Pod        — sandbox-mcp-server pod + Service
+ *   6. newapi Token   — minted via newapi.User then secret-bound
+ *
+ * Stage detection is by Condition Type:
+ *
+ *   - `NamespaceReady`           → stage 1 done
+ *   - `RBACReady`                → stage 2 done
+ *   - `PVCsReady`                → stage 3 done
+ *   - `PtyReady`                 → stage 4 done
+ *   - `McpReady`                 → stage 5 done
+ *   - `TokenReady`               → stage 6 done
+ *   - `Ready` (status=True)      → terminal success
+ *
+ * Failure detection is by:
+ *
+ *   - `phase === 'Failed'`       → render conditions[] + retry CTA
+ *   - any condition with status='False' AND a reason → red-row inline
+ *
+ * Per docs/INVIOLABLE-PRINCIPLES.md:
+ *   #1 (target-state) — every stage chip renders from first paint,
+ *      flipping from "Waiting" to "In progress" to "Done" as the
+ *      controller observes each side-effect. Operator never sees an
+ *      empty surface.
+ *   #4 (never hardcode) — colour tokens come from the design system
+ *      (emerald/amber/rose ramps matching AppDetail's phase chip).
+ *
+ * Design-system inheritance (per founder ruling 2026-05-17
+ * feedback_subagents_inherit_design_system.md): no bespoke layout, no
+ * hex colours, no new card components. Card chrome mirrors
+ * SandboxSession's `sandbox-session-card` shell verbatim (rounded-xl,
+ * var(--color-bg-2) on var(--color-border), 5-unit padding). Badge
+ * tones reuse the same emerald/amber/rose Tailwind classes the
+ * ConnectionBadge + AppDetail phase chip already use.
+ */
+
+import type { Sandbox, SandboxCondition, SandboxPhase } from '@/lib/sandbox.api'
+
+/**
+ * Canonical provisioning stage shape. Each stage maps to one
+ * controller-managed Condition Type; the FE infers stage status from
+ * the matching condition (presence + `status` field).
+ */
+export interface ProvisioningStage {
+  /** Stage id — also the condition type the controller emits. */
+  id: string
+  /** Operator-facing label. */
+  label: string
+  /** Optional sub-label hint. */
+  hint?: string
+}
+
+export const PROVISIONING_STAGES: readonly ProvisioningStage[] = [
+  {
+    id: 'NamespaceReady',
+    label: 'Namespace',
+    hint: 'sandbox-<owner> namespace + labels',
+  },
+  {
+    id: 'RBACReady',
+    label: 'RBAC',
+    hint: 'ServiceAccount + Role + RoleBinding',
+  },
+  {
+    id: 'PVCsReady',
+    label: 'Storage',
+    hint: 'repo + claude-memory + cache PVCs',
+  },
+  {
+    id: 'PtyReady',
+    label: 'pty Pod',
+    hint: 'pty-server Pod + Service',
+  },
+  {
+    id: 'McpReady',
+    label: 'MCP Pod',
+    hint: 'sandbox-mcp-server Pod + Service',
+  },
+  {
+    id: 'TokenReady',
+    label: 'newapi Token',
+    hint: 'minted + secret-bound',
+  },
+] as const
+
+/** Per-stage status — drives the chip colour + icon. */
+export type StageStatus = 'waiting' | 'in-progress' | 'done' | 'failed'
+
+/**
+ * deriveStageStatus — projects the controller's flat conditions[] list
+ * onto the canonical 6-stage shape so the panel can render a stable
+ * waterfall regardless of the order conditions arrive in.
+ *
+ * Rules:
+ *   - condition.status='True'  + matching type → 'done'
+ *   - condition.status='False' + matching type → 'failed'
+ *   - no condition with this type, but a prior stage is 'done' or
+ *     the overall phase is Provisioning → 'in-progress'
+ *   - otherwise → 'waiting'
+ */
+export function deriveStageStatuses(
+  phase: SandboxPhase,
+  conditions: readonly SandboxCondition[],
+  stages: readonly ProvisioningStage[] = PROVISIONING_STAGES,
+): StageStatus[] {
+  const byType = new Map<string, SandboxCondition>()
+  for (const c of conditions) {
+    if (c.type) byType.set(c.type, c)
+  }
+  // Walk the canonical stage list once. The first stage without a
+  // matching True/False condition is the "active" one — render it as
+  // in-progress (Provisioning) / failed (Failed) / waiting (Pending) /
+  // done (Ready). Every stage AFTER the active one stays waiting until
+  // the next condition arrives.
+  const out: StageStatus[] = []
+  let foundActive = false
+  for (const stage of stages) {
+    const cond = byType.get(stage.id)
+    if (cond) {
+      const s = cond.status.toLowerCase()
+      if (s === 'true') {
+        out.push('done')
+        continue
+      }
+      if (s === 'false') {
+        out.push('failed')
+        // The first failed stage halts the waterfall — every stage
+        // after it stays 'waiting'.
+        foundActive = true
+        continue
+      }
+    }
+    // No condition for this stage yet — it's either the active one or
+    // still queued.
+    if (!foundActive) {
+      if (phase === 'Provisioning') {
+        out.push('in-progress')
+      } else if (phase === 'Failed') {
+        // Phase=Failed without a per-stage False — surface as failed
+        // on the first un-done stage so the operator sees where the
+        // controller stopped.
+        out.push('failed')
+      } else if (phase === 'Ready') {
+        // Phase=Ready with no per-stage True condition is a contract
+        // bug — treat as done so the panel doesn't deadlock the UI.
+        out.push('done')
+      } else {
+        // Pending / empty — first stage is the one the controller
+        // will pick up next, so render it as in-progress; later
+        // stages stay waiting.
+        out.push(out.length === 0 ? 'in-progress' : 'waiting')
+      }
+      foundActive = true
+    } else {
+      out.push('waiting')
+    }
+  }
+  return out
+}
+
+/**
+ * Returns true when the provisioning panel should hide itself and let
+ * the parent surface render the terminal (xterm.js). The session is
+ * Ready when phase is explicitly 'Ready' OR all six stages have a
+ * matching True condition (defensive fallback for older controller
+ * versions that may not write `.status.phase=Ready` yet).
+ */
+export function isSandboxReady(sandbox: Sandbox | null | undefined): boolean {
+  if (!sandbox) return false
+  if (sandbox.phase === 'Ready') return true
+  const statuses = deriveStageStatuses(sandbox.phase, sandbox.conditions)
+  return statuses.length > 0 && statuses.every((s) => s === 'done')
+}
+
+/** Returns true when the panel should show the failure detail + retry. */
+export function isSandboxFailed(sandbox: Sandbox | null | undefined): boolean {
+  if (!sandbox) return false
+  if (sandbox.phase === 'Failed') return true
+  return sandbox.conditions.some(
+    (c) => c.status.toLowerCase() === 'false' && !!c.reason,
+  )
+}
+
+export interface SandboxProvisioningPanelProps {
+  /**
+   * Last-known Sandbox row from the poll. `null` when the row has been
+   * deleted (404) — the panel renders a "Session no longer exists"
+   * state pointing the operator back to the landing page.
+   */
+  sandbox: Sandbox | null
+  /**
+   * Polling lifecycle — surfaces a small spinner next to the phase
+   * badge so the operator can tell the data is live.
+   */
+  isPolling: boolean
+  /**
+   * Network-level error from the poll (not a controller failure). When
+   * set, surfaces a small warning row above the stages without
+   * disturbing the waterfall.
+   */
+  pollError?: string | null
+  /** Operator action — clicked when phase===Failed. Optional; when
+   *  omitted the retry button hides. */
+  onRetry?: () => void
+  /** Operator action — clicked from the "no longer exists" state. */
+  onBackToLanding?: () => void
+  /** Indicates a retry is in-flight (disables the retry button). */
+  isRetrying?: boolean
+}
+
+export function SandboxProvisioningPanel({
+  sandbox,
+  isPolling,
+  pollError,
+  onRetry,
+  onBackToLanding,
+  isRetrying = false,
+}: SandboxProvisioningPanelProps) {
+  // Session gone (deleted in another tab or by an operator) — short-
+  // circuit before computing stage statuses on a null row.
+  if (!sandbox) {
+    return (
+      <section
+        data-testid="sandbox-provisioning-panel"
+        data-state="missing"
+        className="rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-2)] p-5"
+      >
+        <header className="mb-4 flex items-start justify-between gap-3">
+          <div>
+            <h2 className="text-base font-semibold text-[var(--color-text-strong)]">
+              Session no longer exists
+            </h2>
+            <p className="mt-0.5 text-xs text-[var(--color-text-dim)]">
+              The Sandbox session has been deleted. Start a new session
+              from the landing page.
+            </p>
+          </div>
+          <PhaseBadge phase="" isPolling={isPolling} state="missing" />
+        </header>
+        {onBackToLanding ? (
+          <button
+            type="button"
+            onClick={onBackToLanding}
+            data-testid="sandbox-provisioning-back-to-landing"
+            className="rounded-md border border-[var(--color-border)] bg-[var(--color-bg)] px-3 py-1.5 text-xs text-[var(--color-text)] hover:border-[var(--color-accent)] hover:text-[var(--color-accent)]"
+          >
+            Back to sandbox
+          </button>
+        ) : null}
+      </section>
+    )
+  }
+
+  const phase = sandbox.phase
+  const stageStatuses = deriveStageStatuses(phase, sandbox.conditions)
+  const failed = isSandboxFailed(sandbox)
+  // Surface only the False conditions that have a reason — the True
+  // ones are the per-stage progress markers, not actionable errors.
+  const failureConditions = sandbox.conditions.filter(
+    (c) => c.status.toLowerCase() === 'false' && !!c.reason,
+  )
+
+  return (
+    <section
+      data-testid="sandbox-provisioning-panel"
+      data-state={failed ? 'failed' : phase ? phase.toLowerCase() : 'pending'}
+      data-phase={phase}
+      className="rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-2)] p-5"
+    >
+      <header className="mb-4 flex items-start justify-between gap-3">
+        <div>
+          <h2 className="text-base font-semibold text-[var(--color-text-strong)]">
+            Provisioning Sandbox
+          </h2>
+          <p className="mt-0.5 text-xs text-[var(--color-text-dim)]">
+            The sandbox-controller is reconciling{' '}
+            <span className="font-mono">{sandbox.id}</span>. The terminal
+            attaches automatically once every stage is ready.
+          </p>
+        </div>
+        <PhaseBadge
+          phase={phase}
+          isPolling={isPolling}
+          state={failed ? 'failed' : undefined}
+        />
+      </header>
+
+      {pollError ? (
+        <div
+          data-testid="sandbox-provisioning-poll-error"
+          className="mb-3 rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-xs text-amber-300"
+        >
+          <span className="font-medium">Polling glitched</span>: {pollError}.
+          The panel will retry on the next tick — no action required.
+        </div>
+      ) : null}
+
+      <ol
+        aria-label="Sandbox provisioning stages"
+        data-testid="sandbox-provisioning-stages"
+        className="flex flex-col gap-2"
+      >
+        {PROVISIONING_STAGES.map((stage, i) => (
+          <StageRow
+            key={stage.id}
+            stage={stage}
+            status={stageStatuses[i] ?? 'waiting'}
+            condition={sandbox.conditions.find((c) => c.type === stage.id)}
+          />
+        ))}
+      </ol>
+
+      {failed && failureConditions.length > 0 ? (
+        <div
+          data-testid="sandbox-provisioning-failure"
+          className="mt-4 rounded-md border border-rose-500/40 bg-rose-500/10 px-3 py-3 text-xs text-rose-200"
+        >
+          <p className="mb-2 font-semibold text-rose-300">
+            Provisioning failed
+          </p>
+          <ul
+            data-testid="sandbox-provisioning-failure-conditions"
+            className="flex flex-col gap-1.5"
+          >
+            {failureConditions.map((c) => (
+              <li
+                key={`${c.type}-${c.reason ?? ''}`}
+                data-testid={`sandbox-provisioning-failure-${c.type}`}
+                className="flex flex-col gap-0.5"
+              >
+                <span className="font-mono text-[11px] uppercase tracking-wide text-rose-300">
+                  {c.type}
+                  {c.reason ? ` · ${c.reason}` : ''}
+                </span>
+                {c.message ? (
+                  <span className="text-rose-100/90">{c.message}</span>
+                ) : null}
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+
+      {failed && onRetry ? (
+        <div className="mt-4 flex items-center justify-end gap-2">
+          <button
+            type="button"
+            onClick={onRetry}
+            disabled={isRetrying}
+            data-testid="sandbox-provisioning-retry"
+            className="rounded-md border border-[var(--color-accent)] bg-[var(--color-accent)]/10 px-3 py-1.5 text-xs font-medium text-[var(--color-accent)] hover:bg-[var(--color-accent)]/20 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {isRetrying ? 'Retrying…' : 'Delete + retry'}
+          </button>
+        </div>
+      ) : null}
+    </section>
+  )
+}
+
+/* ── Phase badge ─────────────────────────────────────────────────── */
+
+interface PhaseBadgeProps {
+  phase: SandboxPhase
+  isPolling: boolean
+  /** Optional override state (e.g. 'missing' for the deleted-row card). */
+  state?: 'failed' | 'missing'
+}
+
+/**
+ * PhaseBadge — pill mirroring the controller phase. Colour ramps stick
+ * to the AppDetail phase chip palette (PR #1581 + earlier) so the
+ * design system stays coherent across surfaces:
+ *
+ *   - Ready          → emerald (steady-state success)
+ *   - Provisioning   → amber + spinner (transient)
+ *   - Pending        → amber (queued, controller hasn't picked it up)
+ *   - Failed         → rose (terminal failure)
+ *   - missing        → neutral grey (session deleted)
+ */
+function PhaseBadge({ phase, isPolling, state }: PhaseBadgeProps) {
+  let label: string
+  let tone: string
+  let showSpinner = false
+
+  if (state === 'failed' || phase === 'Failed') {
+    label = 'Failed'
+    tone = 'border-rose-500/40 bg-rose-500/10 text-rose-300'
+  } else if (state === 'missing') {
+    label = 'Missing'
+    tone =
+      'border-[var(--color-border)] bg-transparent text-[var(--color-text-dim)]'
+  } else if (phase === 'Ready') {
+    label = 'Ready'
+    tone = 'border-emerald-500/40 bg-emerald-500/10 text-emerald-300'
+  } else if (phase === 'Provisioning') {
+    label = 'Provisioning'
+    tone = 'border-amber-500/40 bg-amber-500/10 text-amber-300'
+    showSpinner = true
+  } else if (phase === 'Pending' || phase === '') {
+    label = 'Pending'
+    tone = 'border-amber-500/40 bg-amber-500/10 text-amber-300'
+    showSpinner = isPolling
+  } else {
+    label = phase
+    tone =
+      'border-[var(--color-border)] bg-transparent text-[var(--color-text-dim)]'
+  }
+
+  return (
+    <span
+      data-testid="sandbox-provisioning-phase-badge"
+      data-phase={phase || 'unknown'}
+      className={
+        'inline-flex items-center gap-1.5 rounded-full border px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide ' +
+        tone
+      }
+    >
+      {showSpinner ? <Spinner /> : null}
+      {label}
+    </span>
+  )
+}
+
+/* ── Stage row ───────────────────────────────────────────────────── */
+
+interface StageRowProps {
+  stage: ProvisioningStage
+  status: StageStatus
+  condition?: SandboxCondition
+}
+
+/**
+ * StageRow — one row in the six-step waterfall. The icon column flips
+ * between a check (done), spinner (in-progress), error glyph (failed),
+ * and a hollow circle (waiting). The text + hint row stays stable so
+ * the operator can read it before, during, and after each transition.
+ *
+ * data-testid + data-status pair lets Playwright assert per-stage
+ * progress: `[data-testid="sandbox-provisioning-stage-NamespaceReady"]
+ *           [data-status="done"]`.
+ */
+function StageRow({ stage, status, condition }: StageRowProps) {
+  let icon: React.ReactNode
+  let labelTone: string
+
+  switch (status) {
+    case 'done':
+      icon = <CheckIcon />
+      labelTone = 'text-emerald-300'
+      break
+    case 'in-progress':
+      icon = <Spinner />
+      labelTone = 'text-amber-300'
+      break
+    case 'failed':
+      icon = <FailIcon />
+      labelTone = 'text-rose-300'
+      break
+    case 'waiting':
+    default:
+      icon = <HollowCircle />
+      labelTone = 'text-[var(--color-text-dim)]'
+      break
+  }
+
+  // Per-stage condition hint — surfaced as a small secondary line so
+  // an operator who's debugging a specific stage can see the
+  // reason/message without scrolling to the failure block.
+  const hint = condition?.message || condition?.reason || stage.hint
+
+  return (
+    <li
+      data-testid={`sandbox-provisioning-stage-${stage.id}`}
+      data-status={status}
+      className="flex items-start gap-3 rounded-md border border-[var(--color-border)] bg-[var(--color-bg)] px-3 py-2"
+    >
+      <span className="mt-0.5 inline-flex h-4 w-4 shrink-0 items-center justify-center">
+        {icon}
+      </span>
+      <div className="min-w-0 flex-1">
+        <p
+          className={`text-sm font-medium ${labelTone}`}
+          data-testid={`sandbox-provisioning-stage-${stage.id}-label`}
+        >
+          {stage.label}
+        </p>
+        {hint ? (
+          <p
+            className="truncate text-xs text-[var(--color-text-dim)]"
+            data-testid={`sandbox-provisioning-stage-${stage.id}-hint`}
+          >
+            {hint}
+          </p>
+        ) : null}
+      </div>
+    </li>
+  )
+}
+
+/* ── Icons — single-stroke SVGs matching the SovereignSidebar family ── */
+
+function CheckIcon() {
+  return (
+    <svg
+      className="h-4 w-4 text-emerald-300"
+      fill="none"
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      strokeWidth={2}
+      aria-hidden
+    >
+      <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+    </svg>
+  )
+}
+
+function FailIcon() {
+  return (
+    <svg
+      className="h-4 w-4 text-rose-300"
+      fill="none"
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      strokeWidth={2}
+      aria-hidden
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M6 6l12 12M18 6L6 18"
+      />
+    </svg>
+  )
+}
+
+function HollowCircle() {
+  return (
+    <svg
+      className="h-3 w-3 text-[var(--color-text-dim)]"
+      fill="none"
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      strokeWidth={2}
+      aria-hidden
+    >
+      <circle cx="12" cy="12" r="9" />
+    </svg>
+  )
+}
+
+function Spinner() {
+  // Same spin animation Token/AppDetail use; defined inline so the
+  // panel works without depending on tailwind plugin keyframes.
+  return (
+    <span
+      data-testid="sandbox-provisioning-spinner"
+      className="inline-block h-3 w-3 rounded-full border-2 border-current border-t-transparent"
+      style={{ animation: 'sov-sandbox-spin 0.7s linear infinite' }}
+    />
+  )
+}
+
+/* Keyframes — registered once via the component module so the spinner
+ * works without touching global.css. Mirrors the inline `<style>`
+ * pattern AppDetail uses (APP_DETAIL_CSS). */
+if (
+  typeof document !== 'undefined' &&
+  !document.getElementById('sandbox-provisioning-keyframes')
+) {
+  const el = document.createElement('style')
+  el.id = 'sandbox-provisioning-keyframes'
+  el.textContent =
+    '@keyframes sov-sandbox-spin { to { transform: rotate(360deg); } }'
+  document.head.appendChild(el)
+}

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/sandbox/SandboxSession.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/sandbox/SandboxSession.tsx
@@ -53,7 +53,8 @@
  */
 
 import { useEffect, useRef, useState } from 'react'
-import { Link, useParams } from '@tanstack/react-router'
+import { Link, useNavigate, useParams } from '@tanstack/react-router'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { Terminal } from 'xterm'
 import { FitAddon } from '@xterm/addon-fit'
 import 'xterm/css/xterm.css'
@@ -61,6 +62,15 @@ import 'xterm/css/xterm.css'
 import { useResolvedDeploymentId } from '@/shared/lib/useResolvedDeploymentId'
 import { PortalShell } from '../PortalShell'
 import { useDeploymentEvents } from '../useDeploymentEvents'
+import {
+  deleteSandbox,
+  getSandbox,
+  type Sandbox,
+} from '@/lib/sandbox.api'
+import {
+  SandboxProvisioningPanel,
+  isSandboxReady,
+} from './SandboxProvisioningPanel'
 
 /** ConnectionPhase — state the small header banner reflects. */
 export type SandboxConnectionPhase =
@@ -77,6 +87,14 @@ export type SandboxConnectionPhase =
  * monkey-patching setTimeout.
  */
 const RECONNECT_BACKOFF_MS = [1_000, 2_000, 4_000, 8_000, 16_000, 30_000]
+
+/**
+ * SANDBOX_POLL_INTERVAL_MS — poll cadence for the provisioning panel
+ * while the Sandbox CR is still reconciling. 2s matches the
+ * sandbox-controller's reconcile resyncPeriod (so a status flip on the
+ * apiserver lands in the FE within one poll cycle in the typical case).
+ */
+const SANDBOX_POLL_INTERVAL_MS = 2_000
 
 export interface SandboxSessionProps {
   /** Test seam — disables the live SSE attach. */
@@ -113,6 +131,19 @@ export interface SandboxSessionProps {
    * close does not schedule a retry. Production never sets this.
    */
   disableReconnect?: boolean
+  /**
+   * Test seam — bypass the React Query fetcher for the
+   * provisioning-status poll with synthetic data. When set, the
+   * provisioning panel renders against this value and `getSandbox` is
+   * not called. Production never sets this.
+   */
+  initialSandboxOverride?: Sandbox | null
+  /**
+   * Test seam — disable the provisioning poll entirely. Used by the
+   * existing WebSocket-contract tests so they don't have to mock the
+   * `/sessions/{id}` endpoint. Defaults to false in production.
+   */
+  disableProvisioningPoll?: boolean
 }
 
 export function SandboxSession({
@@ -122,12 +153,17 @@ export function SandboxSession({
   resizeFetcher,
   reconnectBackoffMs = RECONNECT_BACKOFF_MS,
   disableReconnect = false,
+  initialSandboxOverride,
+  disableProvisioningPoll = false,
 }: SandboxSessionProps = {}) {
   const params = useParams({ strict: false }) as { id?: string }
   const sessionId = params.id ?? ''
 
   const { deploymentId: resolvedId } = useResolvedDeploymentId()
   const deploymentId = resolvedId ?? ''
+
+  const navigate = useNavigate()
+  const qc = useQueryClient()
 
   const { snapshot } = useDeploymentEvents({
     deploymentId,
@@ -136,6 +172,96 @@ export function SandboxSession({
   })
   const sovereignFQDN =
     snapshot?.sovereignFQDN ?? snapshot?.result?.sovereignFQDN ?? null
+
+  /* ── Provisioning poll ─────────────────────────────────────────
+   *
+   * Polls GET /api/v1/sandbox/sessions/{id} every 2s while the
+   * controller is still reconciling. Once `phase==='Ready'` the
+   * `refetchInterval` short-circuits (returns `false`) so we stop
+   * polling the apiserver — at that point the xterm.js panel renders
+   * the WebSocket-attached terminal and the row's status is updated
+   * lazily via the existing recent-sessions list refresh on the
+   * landing page.
+   *
+   * The query tolerates 404 by returning `null` from `getSandbox` —
+   * the provisioning panel surfaces a "session no longer exists" state
+   * with a back-to-landing CTA in that case.
+   */
+  const sandboxQuery = useQuery<Sandbox | null>({
+    queryKey: ['sandbox-session', sessionId],
+    queryFn: () => getSandbox(sessionId),
+    enabled:
+      !disableProvisioningPoll &&
+      initialSandboxOverride === undefined &&
+      sessionId !== '',
+    refetchInterval: (query) => {
+      const data = query.state.data
+      // Stop polling once we hit a terminal phase. The terminal
+      // surface re-mounts when phase flips to Ready; if it flips back
+      // to Failed (controller marks the sandbox dead), polling stays
+      // off — operator's "Delete + retry" mutation refetches.
+      if (data && (data.phase === 'Ready' || data.phase === 'Failed')) {
+        return false
+      }
+      return SANDBOX_POLL_INTERVAL_MS
+    },
+    refetchIntervalInBackground: false,
+    placeholderData: (prev) => prev,
+    // Retry-once on transient errors; the panel surfaces the message
+    // and the next poll tick re-tries automatically.
+    retry: 1,
+    staleTime: 0,
+  })
+
+  const sandbox: Sandbox | null =
+    initialSandboxOverride !== undefined
+      ? initialSandboxOverride
+      : sandboxQuery.data ?? null
+  const pollError = sandboxQuery.error
+    ? (sandboxQuery.error as Error).message
+    : null
+  // While the very first request is in flight we still want the panel
+  // to render the target-state chrome (per docs/INVIOLABLE-PRINCIPLES.md
+  // #1) — pass an empty Sandbox so the stage list shows the canonical
+  // 6-row waterfall with the first row as "in progress".
+  const placeholderSandbox: Sandbox = {
+    id: sessionId,
+    name: sessionId,
+    agent: 'claude-code',
+    status: 'pending',
+    phase: '',
+    createdAt: '',
+    repo: '',
+    conditions: [],
+  }
+  const isInitialLoad =
+    initialSandboxOverride === undefined &&
+    !disableProvisioningPoll &&
+    sandboxQuery.isLoading
+  const displaySandbox: Sandbox | null =
+    sandbox ?? (isInitialLoad ? placeholderSandbox : null)
+  const ready = isSandboxReady(displaySandbox)
+  // While provisioning we hide the xterm.js panel — but keep its host
+  // div mounted (display:none) so the WebSocket effect's element ref
+  // resolution doesn't crash if a snapshot arrives mid-provisioning.
+  const showTerminal = disableProvisioningPoll || ready
+
+  /* ── Retry mutation ────────────────────────────────────────────
+   *
+   * "Delete + retry" — fires DELETE /sessions/{id} then bounces the
+   * operator back to the landing page where they re-pick an agent.
+   * The mutation re-uses the existing deleteSandbox endpoint (the
+   * handler is idempotent; repeated DELETEs return 204 even when the
+   * CR is gone).
+   */
+  const retryMutation = useMutation({
+    mutationFn: () => deleteSandbox(sessionId),
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: ['sandbox-sessions'] })
+      void qc.invalidateQueries({ queryKey: ['sandbox-session', sessionId] })
+      navigate({ to: '/sandbox' as never })
+    },
+  })
 
   const hostRef = useRef<HTMLDivElement | null>(null)
   const termRef = useRef<Terminal | null>(null)
@@ -150,6 +276,12 @@ export function SandboxSession({
   // re-mounting the terminal.
   useEffect(() => {
     if (disableTerminal) return
+    // While the provisioning panel is up, the xterm host is hidden
+    // (display:none) — skip the heavy Terminal mount + WS connect
+    // until the controller flips phase to Ready. This avoids the
+    // ~6-retry reconnect storm against a non-existent ingress that
+    // the previous PR #1670 build exhibited on a fresh sandbox.
+    if (!showTerminal) return
     const host = hostRef.current
     if (!host) return
 
@@ -216,14 +348,24 @@ export function SandboxSession({
       termRef.current = null
       fitRef.current = null
     }
-  }, [disableTerminal, sessionId, sovereignFQDN, resizeFetcher])
+  }, [disableTerminal, sessionId, sovereignFQDN, resizeFetcher, showTerminal])
 
   // WebSocket connect + auto-reconnect loop. Re-runs when sessionId or
   // sovereignFQDN changes (the snapshot arrives async after first
   // paint; once it lands the URL is stable for the rest of the
-  // session).
+  // session). Gated on `showTerminal` so we don't reconnect-storm a
+  // sandbox.<fqdn> ingress that doesn't exist yet while the controller
+  // is still provisioning the Sandbox CR.
   useEffect(() => {
     if (!sessionId || !sovereignFQDN) {
+      setPhase('idle')
+      return
+    }
+    if (!showTerminal) {
+      // Still provisioning — keep the connection state idle so the
+      // banner stays clean. The effect re-runs when showTerminal flips
+      // true (via sandboxQuery's refetchInterval) and the WS dial
+      // happens then.
       setPhase('idle')
       return
     }
@@ -375,6 +517,7 @@ export function SandboxSession({
     resizeFetcher,
     reconnectBackoffMs,
     disableReconnect,
+    showTerminal,
     // disableTerminal isn't in the dep array on purpose — the WS pump
     // runs regardless so the connect / message contract is exercised
     // in tests that disable the visual terminal.
@@ -396,11 +539,39 @@ export function SandboxSession({
       }
     >
       <div className="mx-auto max-w-7xl" data-testid="sandbox-session-page">
+        {/*
+          Provisioning panel — shown while the sandbox-controller is
+          still reconciling the Sandbox CR. Polls /sessions/{id} every
+          2s, surfaces phase + per-stage progress, flips to a failure
+          card + retry CTA when phase===Failed. Hidden once
+          phase===Ready so the xterm.js panel takes over.
+
+          Skipped entirely when `disableProvisioningPoll` is set
+          (existing WebSocket-contract tests). The xterm host always
+          stays mounted (display:none while provisioning) so the
+          WebSocket effect's hostRef stays stable across the gate flip.
+        */}
+        {!disableProvisioningPoll && !showTerminal ? (
+          <SandboxProvisioningPanel
+            sandbox={displaySandbox}
+            isPolling={sandboxQuery.isFetching}
+            pollError={pollError}
+            onRetry={() => retryMutation.mutate()}
+            onBackToLanding={() => navigate({ to: '/sandbox' as never })}
+            isRetrying={retryMutation.isPending}
+          />
+        ) : null}
+
         <section
           aria-label="Sandbox terminal"
           data-testid="sandbox-session-card"
           data-connection-phase={phase}
+          data-show-terminal={showTerminal ? 'true' : 'false'}
           className="rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-2)] p-5"
+          // Keep the section in the DOM so the xterm host's ref + the
+          // resize listener stay attached across provisioning → ready
+          // transitions; toggle visibility instead of unmounting.
+          style={showTerminal ? undefined : { display: 'none' }}
         >
           <header className="mb-4 flex items-start justify-between gap-3">
             <div>


### PR DESCRIPTION
## Summary

- New SandboxProvisioningPanel — phase badge + spinner + 6-stage waterfall (Namespace → RBAC → Storage → pty Pod → MCP Pod → newapi Token) inferred from `conditions[]`. Renders target-state on first paint; flips chips Done as each per-stage True condition lands.
- SandboxSession now polls `GET /api/v1/sandbox/sessions/{id}` every 2s via TanStack Query while phase isn't terminal, then auto-hides the panel + reveals the xterm.js terminal once `phase==='Ready'`.
- On `phase==='Failed'` the panel surfaces every False condition's {Type, Reason, Message} verbatim (TokenMintFailed, ManifestRenderFailed, GitopsWriteFailed, OwnerEmailInvalid, NoAllowedChannels) plus a **Delete + retry** CTA.
- SandboxLanding's create-session flow navigates straight to `/sandbox/$id` on POST success and seeds the per-session query cache so the panel paints the 6-stage waterfall instantly (no 2s gap).

## Wire path

```
browser ──GET /api/v1/sandbox/sessions/{id}──▶ catalyst-api ──▶ Sandbox CRD
        (polled every 2s, stops once phase∈{Ready,Failed})
```

Consumes the `.status.{phase, conditions[]}` fields PR #1673 added to the catalyst-api list/get projection.

## API surface (sandbox.api.ts)

- New types: `SandboxPhase`, `SandboxCondition`
- Extended `Sandbox` shape: `phase: SandboxPhase`, `conditions: SandboxCondition[]`
- New endpoints: `getSandbox(id)` (returns null on 404), `deleteSandbox(id)` (idempotent)
- Single shared `normalizeSandbox` projection keeps getSandboxes/getSandbox/createSandbox from drifting

## Behaviour fix

Pre-PR: a freshly-created Sandbox CR takes 8-15s to reconcile. During that window the public `sandbox.<sov-fqdn>` ingress doesn't exist yet, so the WebSocket effect looped through ~6 reconnect attempts against a non-existent host before giving up — operator saw a blank \"Connecting…\" banner with no insight.

Post-PR: the WS effect is gated on `showTerminal = ready` so it doesn't fire until the controller flips `phase=Ready`. The xterm host stays mounted (display:none) across the gate flip so the hostRef + resize listeners survive without remount.

## Design-system inheritance

Per feedback_subagents_inherit_design_system:
- PortalShell wrapper (no bespoke chrome)
- Emerald/amber/rose ramps mirror AppDetail's phase chip + the existing ConnectionBadge
- Card chrome mirrors sandbox-session-card verbatim (rounded-xl, var(--color-bg-2) on var(--color-border), 5-unit padding)
- No new hex colours, no new card components

## Test plan

- [ ] Manual: visit `/sandbox`, click \"Start session\" on any agent card, fill the modal, submit → expect immediate redirect to `/sandbox/<id>` with the 6-stage waterfall visible (first row \"in-progress\")
- [ ] Manual: watch chips flip to Done in order as the sandbox-controller reconciles (~8-15s total on a warm cluster)
- [ ] Manual: at terminal-Ready, expect the terminal panel to take over (ConnectionBadge flips through Connecting → Connected)
- [ ] Manual: kubectl delete the Sandbox CR mid-provision → expect \"Session no longer exists\" card + back-to-landing CTA
- [ ] Manual: force a TokenMintFailed condition (e.g. revoke newapi RBAC) → expect rose Failed badge + condition reason + \"Delete + retry\" button
- [ ] `tsc --noEmit -p tsconfig.json` clean (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)