### PR TITLE
test(sandbox): integration tests for orchestrator + sessions API status reflection

### DIFF
--- a/core/services/tenant/handlers/sandbox_consumer_integration_test.go
+++ b/core/services/tenant/handlers/sandbox_consumer_integration_test.go
@@ -1,0 +1,475 @@
+// Sandbox orchestrator — integration tests (Wave 15).
+//
+// Where unit tests in sandbox_consumer_test.go drive the dispatcher
+// through a hand-rolled fakeSandboxClient at the
+// handleSandboxRequested() level, this file exercises the FULL
+// event-flow seam end-to-end:
+//
+//   tenant.sandbox_requested envelope
+//     → events.BrokerSubscriber (in-process fake)
+//     → SandboxOrchestrator.Start (Subscribe + dispatch)
+//     → SandboxClient (recording fake)
+//     → Sandbox CR shape verified per architecture.md §7
+//
+// The fake BrokerSubscriber substitutes for events.MultiSubscriber's
+// NATS + Kafka legs without standing up real brokers. Asserting on
+// the CR a real sandbox-controller would Watch proves the
+// orchestrator wires every field (agents, plan, quota, labels,
+// annotations, sovereign) through correctly — the regression we
+// want to catch when nobody has a Sovereign available to run the
+// loop against.
+//
+// The SandboxClient interface seam (defined in sandbox_consumer.go)
+// keeps production main.go free of test fakes: production wraps
+// dynamic.Interface, tests inject a recording fake; both satisfy
+// the same Get/Create contract. The dynamic-client integration is
+// already covered by core/controllers/sandbox/internal/controller's
+// envtest suite, so duplicating that here would be redundant.
+
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/openova-io/openova/core/services/shared/events"
+)
+
+// ── recordingSandboxClient — fake apiserver that records every Get
+// + Create and serves Get from a tiny in-memory index keyed by
+// (namespace, name). This is the seam where the sandbox-controller
+// would otherwise Watch; tests use the readback to assert on the
+// CR shape exactly as the controller's informer would observe it.
+//
+// Distinct from the simpler fakeSandboxClient in sandbox_consumer_test.go:
+// that fake stages a single canned response; THIS one is a tiny
+// in-memory apiserver so a Create is observable on the next Get
+// (proving idempotency under redelivery, where the second Get
+// finds the CR the first delivery materialised).
+type recordingSandboxClient struct {
+	mu      sync.Mutex
+	store   map[string]*unstructured.Unstructured // key = "ns/name"
+	creates int
+	gets    int
+}
+
+func newRecordingSandboxClient() *recordingSandboxClient {
+	return &recordingSandboxClient{store: map[string]*unstructured.Unstructured{}}
+}
+
+func (c *recordingSandboxClient) Get(_ context.Context, ns, name string) (*unstructured.Unstructured, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.gets++
+	if obj, ok := c.store[ns+"/"+name]; ok {
+		return obj, nil
+	}
+	return nil, apierrors.NewNotFound(
+		schema.GroupResource{Group: SandboxGVR.Group, Resource: SandboxGVR.Resource},
+		name,
+	)
+}
+
+func (c *recordingSandboxClient) Create(_ context.Context, ns string, obj *unstructured.Unstructured) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	key := ns + "/" + obj.GetName()
+	if _, exists := c.store[key]; exists {
+		return apierrors.NewAlreadyExists(
+			schema.GroupResource{Group: SandboxGVR.Group, Resource: SandboxGVR.Resource},
+			obj.GetName(),
+		)
+	}
+	// Deep-copy so the caller's mutations after Create don't show up
+	// on the readback — mirrors apiserver storage semantics.
+	c.store[key] = obj.DeepCopy()
+	c.creates++
+	return nil
+}
+
+func (c *recordingSandboxClient) sandboxAt(ns, name string) *unstructured.Unstructured {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.store[ns+"/"+name]
+}
+
+func (c *recordingSandboxClient) sandboxCount() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return len(c.store)
+}
+
+// ── fakeBrokerSubscriber — in-process events.BrokerSubscriber.
+//
+// Subscribe captures the orchestrator's handler closure; Emit
+// invokes it synchronously so each test drives deterministic
+// delivery. Mimics MultiSubscriber's contract: handler returning
+// non-nil → nak (broker would redeliver); nil → ack.
+
+type fakeBrokerSubscriber struct {
+	handler func(*events.Event) error
+}
+
+func (f *fakeBrokerSubscriber) Subscribe(_ context.Context, handler func(*events.Event) error) error {
+	f.handler = handler
+	// MultiSubscriber blocks until ctx cancellation; here we return
+	// immediately after capturing the handler so the test driver can
+	// call Emit. The orchestrator's Start exits cleanly because we
+	// return nil from Subscribe.
+	return nil
+}
+
+func (f *fakeBrokerSubscriber) Close() {}
+
+func (f *fakeBrokerSubscriber) Emit(evt *events.Event) error {
+	if f.handler == nil {
+		return errors.New("fakeBrokerSubscriber: no handler registered — Start() must run before Emit()")
+	}
+	return f.handler(evt)
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────
+
+func mkRequestedEnvelope(t *testing.T, payload SandboxRequestedPayload) *events.Event {
+	t.Helper()
+	body, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	return &events.Event{
+		ID:        "evt-integ-001",
+		Type:      "tenant.sandbox_requested",
+		Source:    "tenant-service",
+		Timestamp: time.Now().UTC(),
+		TenantID:  payload.TenantID,
+		Data:      body,
+	}
+}
+
+// ── Integration tests ───────────────────────────────────────────────
+
+// TestSandboxIntegration_FullEventFlow_MaterialisesCR walks the
+// canonical event flow end-to-end:
+//
+//  1. operator submits a marketplace cart with the "sandbox" product
+//  2. tenant.CreateOrg publishes tenant.sandbox_requested
+//  3. SandboxOrchestrator.Start consumes via the subscriber
+//  4. a Sandbox CR lands in catalyst-system, fully shaped per
+//     architecture.md §7
+//
+// Asserts on the recordingSandboxClient's readback (what the
+// sandbox-controller's informer would see) prove the orchestrator
+// wires agents, plan, quota, labels, AND annotations through.
+func TestSandboxIntegration_FullEventFlow_MaterialisesCR(t *testing.T) {
+	client := newRecordingSandboxClient()
+	sub := &fakeBrokerSubscriber{}
+	o := &SandboxOrchestrator{
+		Client:    client,
+		Namespace: "catalyst-system",
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := o.Start(ctx, sub); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	evt := mkRequestedEnvelope(t, SandboxRequestedPayload{
+		TenantID:    "tenant-omega",
+		OrgSlug:     "acme",
+		OwnerID:     "user-uuid-1",
+		OwnerEmail:  "emrah@acme.com",
+		Agents:      []string{"claude-code", "cursor-agent"},
+		Sovereign:   "rzk7.openova.io",
+		PlanID:      "sandbox-pro",
+		RequestedAt: "2026-05-18T10:00:00Z",
+	})
+
+	if err := sub.Emit(evt); err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+
+	if client.creates != 1 {
+		t.Fatalf("Create call count = %d, want 1", client.creates)
+	}
+
+	got := client.sandboxAt("catalyst-system", "sandbox-emrah-at-acme-com")
+	if got == nil {
+		t.Fatalf("Sandbox CR not found in fake apiserver after Emit")
+	}
+
+	if got.GetAPIVersion() != "sandbox.openova.io/v1" {
+		t.Errorf("apiVersion = %q, want sandbox.openova.io/v1", got.GetAPIVersion())
+	}
+	if got.GetKind() != "Sandbox" {
+		t.Errorf("kind = %q, want Sandbox", got.GetKind())
+	}
+
+	// Labels — used by the controller's per-Org selector AND by
+	// operators eyeballing kubectl get sandbox -l openova.io/organization=acme.
+	labels := got.GetLabels()
+	if labels["openova.io/organization"] != "acme" {
+		t.Errorf("label openova.io/organization = %q, want acme", labels["openova.io/organization"])
+	}
+	if labels["openova.io/owner-id"] != "user-uuid-1" {
+		t.Errorf("label openova.io/owner-id = %q, want user-uuid-1", labels["openova.io/owner-id"])
+	}
+	if labels["openova.io/managed-by"] != "tenant-service" {
+		t.Errorf("label openova.io/managed-by = %q, want tenant-service", labels["openova.io/managed-by"])
+	}
+	if labels["openova.io/sovereign"] != "rzk7.openova.io" {
+		t.Errorf("label openova.io/sovereign = %q, want rzk7.openova.io", labels["openova.io/sovereign"])
+	}
+
+	// Annotations — source-of-truth pointer back to the envelope.
+	ann := got.GetAnnotations()
+	if ann["openova.io/source-event"] != "tenant.sandbox_requested" {
+		t.Errorf("annotation openova.io/source-event = %q", ann["openova.io/source-event"])
+	}
+	if ann["openova.io/source-tenant-id"] != "tenant-omega" {
+		t.Errorf("annotation openova.io/source-tenant-id = %q", ann["openova.io/source-tenant-id"])
+	}
+	if ann["openova.io/plan-id"] != "sandbox-pro" {
+		t.Errorf("annotation openova.io/plan-id = %q, want sandbox-pro", ann["openova.io/plan-id"])
+	}
+
+	// Spec — the contract the controller reconciles against.
+	spec, ok := got.Object["spec"].(map[string]any)
+	if !ok {
+		t.Fatalf("spec missing or wrong shape: %#v", got.Object["spec"])
+	}
+	if spec["planId"] != "sandbox-pro" {
+		t.Errorf("spec.planId = %v, want sandbox-pro", spec["planId"])
+	}
+
+	owner, _ := spec["owner"].(map[string]any)
+	if owner["email"] != "emrah@acme.com" {
+		t.Errorf("spec.owner.email = %v, want emrah@acme.com", owner["email"])
+	}
+	orgRef, _ := owner["orgRef"].(map[string]any)
+	if orgRef["slug"] != "acme" {
+		t.Errorf("spec.owner.orgRef.slug = %v, want acme", orgRef["slug"])
+	}
+
+	// Quota — sandbox-pro tier per quotaForPlan.
+	quota, _ := spec["quota"].(map[string]any)
+	if quota["cpu"] != "2" || quota["memory"] != "4Gi" || quota["storage"] != "50Gi" {
+		t.Errorf("spec.quota = %#v, want pro tier (2 / 4Gi / 50Gi)", quota)
+	}
+	cs, _ := quota["concurrentSessions"].(int64)
+	if cs != 3 {
+		t.Errorf("spec.quota.concurrentSessions = %v, want 3", cs)
+	}
+
+	// Agent catalogue — mirrors the cart's picker.
+	agents, _ := spec["agentCatalogue"].([]any)
+	if len(agents) != 2 || agents[0] != "claude-code" || agents[1] != "cursor-agent" {
+		t.Errorf("spec.agentCatalogue = %#v, want [claude-code, cursor-agent]", agents)
+	}
+}
+
+// TestSandboxIntegration_RedeliveryIsIdempotent — NATS JetStream's
+// at-least-once contract means the broker WILL redeliver after a
+// transient handler failure or a Sovereign-side restart that
+// hasn't fully ack'd. The orchestrator must absorb redeliveries
+// without ever overwriting a controller-tweaked CR.
+//
+// Drives: Emit the same envelope twice through the subscriber.
+// First call goes Get(NotFound) → Create; second call goes
+// Get(found) → no-op. Only one CR ends up in the fake apiserver
+// and Create was only invoked once.
+func TestSandboxIntegration_RedeliveryIsIdempotent(t *testing.T) {
+	client := newRecordingSandboxClient()
+	sub := &fakeBrokerSubscriber{}
+	o := &SandboxOrchestrator{Client: client, Namespace: "catalyst-system"}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := o.Start(ctx, sub); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	evt := mkRequestedEnvelope(t, SandboxRequestedPayload{
+		TenantID:   "tenant-omega",
+		OrgSlug:    "acme",
+		OwnerID:    "user-uuid-1",
+		OwnerEmail: "emrah@acme.com",
+		Agents:     []string{"claude-code"},
+		PlanID:     "sandbox-free",
+	})
+
+	// First delivery — creates.
+	if err := sub.Emit(evt); err != nil {
+		t.Fatalf("first Emit: %v", err)
+	}
+	// Second delivery — must be a no-op.
+	if err := sub.Emit(evt); err != nil {
+		t.Fatalf("second Emit (redelivery): %v", err)
+	}
+
+	if client.creates != 1 {
+		t.Fatalf("Create count = %d after redelivery, want 1", client.creates)
+	}
+	if client.sandboxCount() != 1 {
+		t.Fatalf("Sandbox count = %d, want exactly 1", client.sandboxCount())
+	}
+	// Both deliveries must have gone through Get first (idempotency
+	// check). Two Gets prove the orchestrator ALWAYS checks for an
+	// existing CR before issuing Create.
+	if client.gets != 2 {
+		t.Fatalf("Get count = %d, want 2 (one per delivery)", client.gets)
+	}
+}
+
+// TestSandboxIntegration_PlanTiersFanOutCorrectly — drives 3 envelopes
+// (free / pro / ent) through the orchestrator and asserts the
+// readback carries the per-tier quota verbatim. This is the
+// regression that catches "every Sandbox got Free quota regardless
+// of paid tier" — the bug PR #1633 originally shipped with before
+// quotaForPlan landed.
+func TestSandboxIntegration_PlanTiersFanOutCorrectly(t *testing.T) {
+	type planExpect struct {
+		planID  string
+		ownerID string
+		ownerEm string
+		crName  string
+		wantCPU string
+		wantMem string
+		wantStr string
+		wantCS  int64
+	}
+	cases := []planExpect{
+		{"sandbox-free", "u-free", "free@acme.com", "sandbox-free-at-acme-com", "500m", "1Gi", "5Gi", 1},
+		{"sandbox-pro", "u-pro", "pro@acme.com", "sandbox-pro-at-acme-com", "2", "4Gi", "50Gi", 3},
+		{"sandbox-ent", "u-ent", "ent@acme.com", "sandbox-ent-at-acme-com", "8", "16Gi", "500Gi", 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.planID, func(t *testing.T) {
+			client := newRecordingSandboxClient()
+			sub := &fakeBrokerSubscriber{}
+			o := &SandboxOrchestrator{Client: client, Namespace: "catalyst-system"}
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			if err := o.Start(ctx, sub); err != nil {
+				t.Fatalf("Start: %v", err)
+			}
+
+			evt := mkRequestedEnvelope(t, SandboxRequestedPayload{
+				TenantID:   "tenant-omega",
+				OrgSlug:    "acme",
+				OwnerID:    tc.ownerID,
+				OwnerEmail: tc.ownerEm,
+				Agents:     []string{"claude-code"},
+				PlanID:     tc.planID,
+			})
+			if err := sub.Emit(evt); err != nil {
+				t.Fatalf("Emit: %v", err)
+			}
+
+			got := client.sandboxAt("catalyst-system", tc.crName)
+			if got == nil {
+				t.Fatalf("%s: Sandbox CR %q not created", tc.planID, tc.crName)
+			}
+			spec, _ := got.Object["spec"].(map[string]any)
+			quota, _ := spec["quota"].(map[string]any)
+			if quota["cpu"] != tc.wantCPU {
+				t.Errorf("%s: quota.cpu = %v, want %q", tc.planID, quota["cpu"], tc.wantCPU)
+			}
+			if quota["memory"] != tc.wantMem {
+				t.Errorf("%s: quota.memory = %v, want %q", tc.planID, quota["memory"], tc.wantMem)
+			}
+			if quota["storage"] != tc.wantStr {
+				t.Errorf("%s: quota.storage = %v, want %q", tc.planID, quota["storage"], tc.wantStr)
+			}
+			if cs, _ := quota["concurrentSessions"].(int64); cs != tc.wantCS {
+				t.Errorf("%s: quota.concurrentSessions = %v, want %d", tc.planID, cs, tc.wantCS)
+			}
+			if ann := got.GetAnnotations(); ann["openova.io/plan-id"] != tc.planID {
+				t.Errorf("%s: annotation openova.io/plan-id = %q", tc.planID, ann["openova.io/plan-id"])
+			}
+		})
+	}
+}
+
+// TestSandboxIntegration_NonSandboxEventsIgnored — the subscriber may
+// be configured to multiplex multiple event types onto the same
+// subject (the bridge_subscriber filters at the NATS level, but
+// EventTypes is operator-tweakable). The handler MUST ignore any
+// envelope whose Type is not tenant.sandbox_requested without
+// touching the apiserver.
+func TestSandboxIntegration_NonSandboxEventsIgnored(t *testing.T) {
+	client := newRecordingSandboxClient()
+	sub := &fakeBrokerSubscriber{}
+	o := &SandboxOrchestrator{Client: client, Namespace: "catalyst-system"}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := o.Start(ctx, sub); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	other := &events.Event{
+		ID:       "evt-other",
+		Type:     "tenant.org_created",
+		TenantID: "tenant-omega",
+		Data:     json.RawMessage(`{"org_slug":"acme"}`),
+	}
+	if err := sub.Emit(other); err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+
+	if client.creates != 0 {
+		t.Fatalf("non-sandbox event triggered Create %d times, want 0", client.creates)
+	}
+	if client.gets != 0 {
+		t.Fatalf("non-sandbox event triggered Get %d times, want 0", client.gets)
+	}
+}
+
+// TestSandboxIntegration_AgentsEmptyStringsFilteredAtCRBoundary —
+// the cart's picker MAY emit a trailing empty string when the
+// operator deletes the last entry but the FE doesn't trim. The
+// orchestrator must strip empties so the CR's agentCatalogue
+// stays validate-able against the CRD's `items.enum` matcher
+// (an empty string would always 422).
+func TestSandboxIntegration_AgentsEmptyStringsFilteredAtCRBoundary(t *testing.T) {
+	client := newRecordingSandboxClient()
+	sub := &fakeBrokerSubscriber{}
+	o := &SandboxOrchestrator{Client: client, Namespace: "catalyst-system"}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := o.Start(ctx, sub); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	evt := mkRequestedEnvelope(t, SandboxRequestedPayload{
+		TenantID:   "tenant-omega",
+		OrgSlug:    "acme",
+		OwnerID:    "u-1",
+		OwnerEmail: "a@acme.com",
+		Agents:     []string{"claude-code", "", "  ", "cursor-agent"},
+	})
+	if err := sub.Emit(evt); err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+
+	got := client.sandboxAt("catalyst-system", "sandbox-a-at-acme-com")
+	if got == nil {
+		t.Fatalf("Sandbox not materialised")
+	}
+	spec, _ := got.Object["spec"].(map[string]any)
+	agents, _ := spec["agentCatalogue"].([]any)
+	if len(agents) != 2 || agents[0] != "claude-code" || agents[1] != "cursor-agent" {
+		t.Errorf("agentCatalogue = %#v, want only [claude-code, cursor-agent] (empties dropped)", agents)
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/handler/sandbox_sessions_integration_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sandbox_sessions_integration_test.go
@@ -1,0 +1,508 @@
+// Package handler — sandbox_sessions_integration_test.go drives the
+// /api/v1/sandbox/sessions REST surface end-to-end against a
+// dynamic/fake apiserver. Where sandbox_sessions_test.go pins the
+// unstructured→sandboxItem projection in isolation, this file
+// exercises the full HTTP round-trip:
+//
+//   chi router → HandleCreateSandboxSession → fake apiserver Create
+//   chi router → HandleGetSandboxSession    → fake apiserver Get + .status reflection
+//
+// The fake dynamic client is wired via SetSovereignDepsFactory so
+// the handler's resolution path mirrors what a chroot Sovereign
+// runs in production (sandbox_sessions.go's "Path 2" — in-cluster
+// fallback). The dynamic-client-backed seam means the readback
+// after Create is functionally identical to what a real
+// sandbox-controller informer would observe.
+//
+// Wave 15 follow-up to PR #1637 (sessions API) + PR #1673
+// (status-reflect): the FE's actionable-failure rendering depends
+// on the wire shape preserving Failed/{TokenMintFailed,
+// GitopsWriteFailed, ManifestRenderFailed} conditions verbatim.
+// These tests cover the canonical failure-reason taxonomy from
+// core/controllers/sandbox/internal/controller/sandbox_controller.go.
+
+package handler
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	fakek8s "k8s.io/client-go/kubernetes/fake"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/auth"
+)
+
+// ── Fixtures ────────────────────────────────────────────────────────
+
+// newSandboxHandler wires a Handler with a fake dynamic client
+// seeded with the supplied Sandbox CRs. The SandboxGVR's list-kind
+// is registered so List/Get calls land on a typed
+// *unstructured.UnstructuredList rather than panicking.
+//
+// Seeding happens via direct Create on the dynamic interface (rather
+// than the objects-arg of NewSimpleDynamicClientWithCustomListKinds)
+// because the tracker's Add path requires the non-list GVK to be
+// scheme-registered with UnsafeGuessKindToResource agreeing — for a
+// CRD like sandbox.openova.io/v1 Sandboxes the heuristic doesn't
+// align cleanly. Create-based seeding sidesteps the entire scheme
+// resolution by passing the GVR through the action explicitly.
+func newSandboxHandler(t *testing.T, seed ...*unstructured.Unstructured) *Handler {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	gvrToList := map[schema.GroupVersionResource]string{
+		SandboxGVR(): "SandboxList",
+	}
+	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrToList)
+	for _, obj := range seed {
+		if _, err := dyn.Resource(SandboxGVR()).Namespace(obj.GetNamespace()).Create(
+			context.Background(), obj, metav1.CreateOptions{},
+		); err != nil {
+			t.Fatalf("seed Sandbox %s/%s: %v", obj.GetNamespace(), obj.GetName(), err)
+		}
+	}
+	core := fakek8s.NewSimpleClientset()
+
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	h.SetSovereignDepsFactory(func() (*sovereignDeps, error) {
+		return &sovereignDeps{core: core, dyn: dyn}, nil
+	})
+	return h
+}
+
+// withSandboxClaims injects the Sandbox-specific claim shape into
+// the request context: Sub (required) + Email (stamped on
+// spec.owner.email) + Org (the namespace the CR lands in).
+func withSandboxClaims(req *http.Request, sub, email, org string) *http.Request {
+	claims := &auth.Claims{Sub: sub, Email: email, Org: org}
+	ctx := context.WithValue(req.Context(), auth.ClaimsKey, claims)
+	return req.WithContext(ctx)
+}
+
+// registerSandboxRoutes mirrors main.go's RequireSession group so
+// the chi URL params ({id}) resolve the same way as production.
+func registerSandboxRoutes(r chi.Router, h *Handler) {
+	r.Get("/api/v1/sandbox/sessions", h.HandleListSandboxSessions)
+	r.Post("/api/v1/sandbox/sessions", h.HandleCreateSandboxSession)
+	r.Get("/api/v1/sandbox/sessions/{id}", h.HandleGetSandboxSession)
+	r.Delete("/api/v1/sandbox/sessions/{id}", h.HandleDeleteSandboxSession)
+}
+
+// callSandbox executes a single request through a fresh router so
+// each test starts with a clean URL-param dispatcher.
+func callSandbox(t *testing.T, h *Handler, req *http.Request) *httptest.ResponseRecorder {
+	t.Helper()
+	r := chi.NewRouter()
+	registerSandboxRoutes(r, h)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	return rec
+}
+
+// mkSandboxCR builds a Sandbox unstructured for seeding the fake
+// apiserver. Optional status block lets a test simulate the
+// controller having already reconciled (or hit a Failed condition).
+func mkSandboxCR(name, ns, agent string, status map[string]any) *unstructured.Unstructured {
+	u := &unstructured.Unstructured{}
+	u.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "sandbox.openova.io",
+		Version: "v1",
+		Kind:    "Sandbox",
+	})
+	u.SetName(name)
+	u.SetNamespace(ns)
+	u.SetCreationTimestamp(metav1.NewTime(time.Now().Add(-30 * time.Minute).UTC().Truncate(time.Second)))
+	_ = unstructured.SetNestedSlice(u.Object, []any{agent}, "spec", "agentCatalogue")
+	if status != nil {
+		u.Object["status"] = status
+	}
+	return u
+}
+
+// ── POST → GET round-trip ───────────────────────────────────────────
+
+// TestSandboxIntegration_PostThenGet — drives the canonical FE flow:
+//
+//  1. POST /api/v1/sandbox/sessions with {agent: claude-code}
+//  2. fake apiserver stores the unstructured CR
+//  3. GET /api/v1/sandbox/sessions/{id} reads it back
+//  4. response shape matches the FE's expected sandboxItem wire
+//
+// Proves the dynamic-client wiring (Create + Get) round-trips
+// through the same fake without losing fields — what a real chroot
+// Sovereign would do at runtime, without needing one to exist.
+func TestSandboxIntegration_PostThenGet(t *testing.T) {
+	h := newSandboxHandler(t)
+
+	body := sandboxCreateRequest{
+		Agent: "claude-code",
+		Name:  "my-sandbox",
+		Repo:  "acme/site",
+	}
+	raw, _ := json.Marshal(body)
+	postReq := httptest.NewRequest(http.MethodPost, "/api/v1/sandbox/sessions", bytes.NewReader(raw))
+	postReq.Header.Set("Content-Type", "application/json")
+	postReq = withSandboxClaims(postReq, "user-sub-abcdef12", "operator@acme.com", "acme")
+
+	postRec := callSandbox(t, h, postReq)
+	if postRec.Code != http.StatusCreated {
+		t.Fatalf("POST: status = %d, body = %s", postRec.Code, postRec.Body.String())
+	}
+
+	var created sandboxItem
+	if err := json.Unmarshal(postRec.Body.Bytes(), &created); err != nil {
+		t.Fatalf("decode POST body: %v", err)
+	}
+	if created.ID == "" {
+		t.Fatalf("POST response missing ID: %+v", created)
+	}
+	if created.Agent != "claude-code" {
+		t.Errorf("POST response Agent = %q, want claude-code", created.Agent)
+	}
+
+	// GET the just-created sandbox — round-trips through the same
+	// fake apiserver Create wrote to.
+	getReq := httptest.NewRequest(http.MethodGet, "/api/v1/sandbox/sessions/"+created.ID, nil)
+	getReq = withSandboxClaims(getReq, "user-sub-abcdef12", "operator@acme.com", "acme")
+	getRec := callSandbox(t, h, getReq)
+	if getRec.Code != http.StatusOK {
+		t.Fatalf("GET: status = %d, body = %s", getRec.Code, getRec.Body.String())
+	}
+
+	var fetched sandboxItem
+	if err := json.Unmarshal(getRec.Body.Bytes(), &fetched); err != nil {
+		t.Fatalf("decode GET body: %v", err)
+	}
+
+	if fetched.ID != created.ID {
+		t.Errorf("GET ID = %q, want %q", fetched.ID, created.ID)
+	}
+	if fetched.Agent != "claude-code" {
+		t.Errorf("GET Agent = %q, want claude-code", fetched.Agent)
+	}
+	if fetched.Repo != "acme/site" {
+		t.Errorf("GET Repo = %q, want acme/site", fetched.Repo)
+	}
+	// Display-name preserved across the round-trip via the
+	// catalyst.openova.io/sandbox-display-name annotation.
+	if fetched.Name != "my-sandbox" {
+		t.Errorf("GET Name = %q, want my-sandbox", fetched.Name)
+	}
+	// No controller has touched status yet, so Phase is empty and
+	// the FE-facing Status projects to "pending" (spinner).
+	if fetched.Status != "pending" {
+		t.Errorf("GET Status = %q, want pending (no phase yet)", fetched.Status)
+	}
+	// Defensive contract: Previews / Conditions must be empty
+	// slices (not nil) so the FE never has to `?? []`.
+	if fetched.Previews == nil {
+		t.Errorf("GET Previews must be empty slice, not nil")
+	}
+	if fetched.Conditions == nil {
+		t.Errorf("GET Conditions must be empty slice, not nil")
+	}
+}
+
+// ── GET reflects controller status ──────────────────────────────────
+
+// TestSandboxIntegration_GetReflectsReadyStatus — seed a Sandbox CR
+// with status.phase=Ready + sessions=2 + storage + spend + previews
+// + a Ready=True condition. GET projects the live runtime back to
+// the FE wire shape verbatim.
+func TestSandboxIntegration_GetReflectsReadyStatus(t *testing.T) {
+	seed := mkSandboxCR("sandbox-ready", "acme", "claude-code", map[string]any{
+		"phase":       "Ready",
+		"sessions":    int64(2),
+		"storageUsed": "12Gi",
+		"spend30d":    "$4.21",
+		"previews": []any{
+			map[string]any{
+				"prNumber": int64(42),
+				"url":      "https://pr-42.preview.acme.example",
+				"sha":      "abc1234",
+			},
+		},
+		"conditions": []any{
+			map[string]any{
+				"type":               "Ready",
+				"status":             "True",
+				"reason":             "GitopsReconciled",
+				"message":            "manifests written and applied",
+				"lastTransitionTime": "2026-05-18T11:00:00Z",
+			},
+		},
+	})
+	h := newSandboxHandler(t, seed)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/sandbox/sessions/sandbox-ready", nil)
+	req = withSandboxClaims(req, "user-sub-aaa", "ops@acme.com", "acme")
+	rec := callSandbox(t, h, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+
+	var got sandboxItem
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	if got.Phase != "Ready" {
+		t.Errorf("Phase = %q, want Ready", got.Phase)
+	}
+	if got.Status != "running" {
+		t.Errorf("Status = %q, want running (Ready → running)", got.Status)
+	}
+	if got.Sessions != 2 {
+		t.Errorf("Sessions = %d, want 2", got.Sessions)
+	}
+	if got.StorageUsed != "12Gi" {
+		t.Errorf("StorageUsed = %q, want 12Gi", got.StorageUsed)
+	}
+	if got.Spend30d != "$4.21" {
+		t.Errorf("Spend30d = %q, want $4.21", got.Spend30d)
+	}
+	if len(got.Previews) != 1 || got.Previews[0].PRNumber != 42 ||
+		got.Previews[0].URL != "https://pr-42.preview.acme.example" {
+		t.Errorf("Previews = %#v", got.Previews)
+	}
+	if len(got.Conditions) != 1 ||
+		got.Conditions[0].Type != "Ready" ||
+		got.Conditions[0].Status != "True" ||
+		got.Conditions[0].Reason != "GitopsReconciled" {
+		t.Errorf("Conditions = %#v", got.Conditions)
+	}
+}
+
+// TestSandboxIntegration_FailedConditionsTaxonomy — drives each of
+// the canonical controller failure reasons through the round-trip
+// and asserts the FE-facing wire shape (Status=failed, Phase=Failed,
+// Conditions[0].Reason preserved verbatim).
+//
+// Sources for the reason list: sandbox_controller.go's fail()
+// calls — TokenMintFailed, ManifestRenderFailed, GitopsWriteFailed.
+// The FE renders these as actionable error states ("Token mint
+// failed — retrying" inline) instead of a generic red pill, so
+// drift here is user-visible.
+func TestSandboxIntegration_FailedConditionsTaxonomy(t *testing.T) {
+	reasons := []struct {
+		name    string
+		reason  string
+		message string
+	}{
+		{"TokenMintFailed", "TokenMintFailed", "newapi bridge unreachable"},
+		{"GitopsWriteFailed", "GitopsWriteFailed", "gitea: 502 Bad Gateway"},
+		{"ManifestRenderFailed", "ManifestRenderFailed", "helm template: parse error at line 42"},
+	}
+	for _, tc := range reasons {
+		t.Run(tc.reason, func(t *testing.T) {
+			crName := "sandbox-fail-" + tc.reason
+			seed := mkSandboxCR(crName, "acme", "claude-code", map[string]any{
+				"phase": "Failed",
+				"conditions": []any{
+					map[string]any{
+						"type":               "Ready",
+						"status":             "False",
+						"reason":             tc.reason,
+						"message":            tc.message,
+						"lastTransitionTime": "2026-05-18T11:00:00Z",
+					},
+				},
+			})
+			h := newSandboxHandler(t, seed)
+
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/sandbox/sessions/"+crName, nil)
+			req = withSandboxClaims(req, "user-sub-zzz", "ops@acme.com", "acme")
+			rec := callSandbox(t, h, req)
+			if rec.Code != http.StatusOK {
+				t.Fatalf("%s: status = %d, body = %s", tc.reason, rec.Code, rec.Body.String())
+			}
+
+			var got sandboxItem
+			if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+				t.Fatalf("%s: decode: %v", tc.reason, err)
+			}
+
+			if got.Phase != "Failed" {
+				t.Errorf("%s: Phase = %q, want Failed", tc.reason, got.Phase)
+			}
+			if got.Status != "failed" {
+				t.Errorf("%s: Status = %q, want failed (FE projection)", tc.reason, got.Status)
+			}
+			if len(got.Conditions) != 1 {
+				t.Fatalf("%s: Conditions count = %d, want 1", tc.reason, len(got.Conditions))
+			}
+			c := got.Conditions[0]
+			if c.Reason != tc.reason {
+				t.Errorf("%s: Conditions[0].Reason = %q, want %q", tc.reason, c.Reason, tc.reason)
+			}
+			if c.Message != tc.message {
+				t.Errorf("%s: Conditions[0].Message = %q, want %q", tc.reason, c.Message, tc.message)
+			}
+			if c.Status != "False" {
+				t.Errorf("%s: Conditions[0].Status = %q, want False", tc.reason, c.Status)
+			}
+		})
+	}
+}
+
+// TestSandboxIntegration_PostInvalidAgent — agent not in the
+// canonical catalogue must 400 before any apiserver call. Protects
+// the FE from CRs that would always fail openAPIV3Schema validation
+// at the apiserver and surface as confusing 422s on the next list.
+func TestSandboxIntegration_PostInvalidAgent(t *testing.T) {
+	h := newSandboxHandler(t)
+	body := sandboxCreateRequest{Agent: "rogue-agent-9000"}
+	raw, _ := json.Marshal(body)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sandbox/sessions", bytes.NewReader(raw))
+	req.Header.Set("Content-Type", "application/json")
+	req = withSandboxClaims(req, "user-sub-x", "x@acme.com", "acme")
+
+	rec := callSandbox(t, h, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 (invalid agent); body = %s", rec.Code, rec.Body.String())
+	}
+	var resp map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp["error"] != "invalid-agent" {
+		t.Errorf("error = %v, want invalid-agent", resp["error"])
+	}
+}
+
+// TestSandboxIntegration_GetUnknownSandbox — 404 with a clear
+// "sandbox-not-found" error code so the FE can render an
+// actionable empty state instead of a generic toast.
+func TestSandboxIntegration_GetUnknownSandbox(t *testing.T) {
+	h := newSandboxHandler(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/sandbox/sessions/sandbox-ghost", nil)
+	req = withSandboxClaims(req, "user-sub-z", "z@acme.com", "acme")
+	rec := callSandbox(t, h, req)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404; body = %s", rec.Code, rec.Body.String())
+	}
+	var resp map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp["error"] != "sandbox-not-found" {
+		t.Errorf("error = %v, want sandbox-not-found", resp["error"])
+	}
+}
+
+// TestSandboxIntegration_ListThenDelete — POST 3 sandboxes, LIST
+// returns all 3, DELETE one, LIST returns 2.
+//
+// The list ordering check is intentionally lenient (count-only)
+// because the fake apiserver's List ordering matches its insertion
+// order but the FE doesn't depend on that — the FE sorts by
+// createdAt itself.
+func TestSandboxIntegration_ListThenDelete(t *testing.T) {
+	h := newSandboxHandler(t)
+
+	for _, name := range []string{"a", "b", "c"} {
+		body := sandboxCreateRequest{Agent: "claude-code", Name: "sb-" + name}
+		raw, _ := json.Marshal(body)
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/sandbox/sessions", bytes.NewReader(raw))
+		req.Header.Set("Content-Type", "application/json")
+		req = withSandboxClaims(req, "user-sub-"+name, name+"@acme.com", "acme")
+		rec := callSandbox(t, h, req)
+		if rec.Code != http.StatusCreated {
+			t.Fatalf("POST %s: status %d, body=%s", name, rec.Code, rec.Body.String())
+		}
+	}
+
+	listReq := httptest.NewRequest(http.MethodGet, "/api/v1/sandbox/sessions", nil)
+	listReq = withSandboxClaims(listReq, "user-sub-list", "list@acme.com", "acme")
+	listRec := callSandbox(t, h, listReq)
+	if listRec.Code != http.StatusOK {
+		t.Fatalf("LIST: status %d, body=%s", listRec.Code, listRec.Body.String())
+	}
+	var listResp sandboxListResponse
+	if err := json.Unmarshal(listRec.Body.Bytes(), &listResp); err != nil {
+		t.Fatalf("decode list: %v", err)
+	}
+	if len(listResp.Sandboxes) != 3 {
+		t.Fatalf("LIST sandbox count = %d, want 3", len(listResp.Sandboxes))
+	}
+
+	delReq := httptest.NewRequest(http.MethodDelete, "/api/v1/sandbox/sessions/sb-a", nil)
+	delReq = withSandboxClaims(delReq, "user-sub-list", "list@acme.com", "acme")
+	delRec := callSandbox(t, h, delReq)
+	if delRec.Code != http.StatusNoContent {
+		t.Fatalf("DELETE: status %d, body=%s", delRec.Code, delRec.Body.String())
+	}
+
+	listRec2 := callSandbox(t, h, withSandboxClaims(
+		httptest.NewRequest(http.MethodGet, "/api/v1/sandbox/sessions", nil),
+		"user-sub-list", "list@acme.com", "acme"))
+	if listRec2.Code != http.StatusOK {
+		t.Fatalf("LIST after delete: status %d, body=%s", listRec2.Code, listRec2.Body.String())
+	}
+	var listResp2 sandboxListResponse
+	if err := json.Unmarshal(listRec2.Body.Bytes(), &listResp2); err != nil {
+		t.Fatalf("decode list2: %v", err)
+	}
+	if len(listResp2.Sandboxes) != 2 {
+		t.Fatalf("LIST after delete count = %d, want 2", len(listResp2.Sandboxes))
+	}
+}
+
+// TestSandboxIntegration_OrgScopeIsolation — sandboxes in
+// org-acme MUST NOT leak into org-beta's list. The handler scopes
+// the apiserver Resource(...).Namespace(...) call by claims.Org;
+// the fake namespacing enforces the boundary the same way the
+// real apiserver does.
+func TestSandboxIntegration_OrgScopeIsolation(t *testing.T) {
+	h := newSandboxHandler(t,
+		mkSandboxCR("sandbox-acme-1", "acme", "claude-code", nil),
+		mkSandboxCR("sandbox-acme-2", "acme", "cursor-agent", nil),
+		mkSandboxCR("sandbox-beta-1", "beta", "claude-code", nil),
+	)
+
+	// org=acme MUST see exactly the 2 acme sandboxes.
+	acmeReq := httptest.NewRequest(http.MethodGet, "/api/v1/sandbox/sessions", nil)
+	acmeReq = withSandboxClaims(acmeReq, "user-acme", "ops@acme.com", "acme")
+	acmeRec := callSandbox(t, h, acmeReq)
+	if acmeRec.Code != http.StatusOK {
+		t.Fatalf("acme LIST: status %d, body=%s", acmeRec.Code, acmeRec.Body.String())
+	}
+	var acmeResp sandboxListResponse
+	if err := json.Unmarshal(acmeRec.Body.Bytes(), &acmeResp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(acmeResp.Sandboxes) != 2 {
+		t.Errorf("acme sandbox count = %d, want 2", len(acmeResp.Sandboxes))
+	}
+	for _, s := range acmeResp.Sandboxes {
+		if s.ID == "sandbox-beta-1" {
+			t.Errorf("beta sandbox leaked into acme list: %+v", s)
+		}
+	}
+
+	// org=beta MUST see exactly the 1 beta sandbox.
+	betaReq := httptest.NewRequest(http.MethodGet, "/api/v1/sandbox/sessions", nil)
+	betaReq = withSandboxClaims(betaReq, "user-beta", "ops@beta.com", "beta")
+	betaRec := callSandbox(t, h, betaReq)
+	if betaRec.Code != http.StatusOK {
+		t.Fatalf("beta LIST: status %d, body=%s", betaRec.Code, betaRec.Body.String())
+	}
+	var betaResp sandboxListResponse
+	if err := json.Unmarshal(betaRec.Body.Bytes(), &betaResp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(betaResp.Sandboxes) != 1 || betaResp.Sandboxes[0].ID != "sandbox-beta-1" {
+		t.Errorf("beta sandboxes = %#v, want exactly [sandbox-beta-1]", betaResp.Sandboxes)
+	}
+}


### PR DESCRIPTION
## Summary

Adds regression coverage so the Sandbox event flow + REST surface can be exercised without a live Sovereign — the convergence loop the qa-loop's last 5 iterations relied on.

### Tenant orchestrator (`core/services/tenant/handlers/sandbox_consumer_integration_test.go`)

5 test functions / 8 runs covering the full event-flow seam:
- **Full event flow** — `tenant.sandbox_requested` envelope → in-process `events.BrokerSubscriber` → `SandboxOrchestrator.Start` → `recordingSandboxClient` (tiny in-memory apiserver) materialises a CR shaped per architecture.md §7 (labels, annotations, `spec.owner/quota/agentCatalogue/planId`)
- **NATS-style redelivery is idempotent** — second `Emit()` goes Get(found) → no-op, Create count stays at 1, Gets count = 2
- **Plan tiers fan out** — `sandbox-free`/`sandbox-pro`/`sandbox-ent` each stamp the right quota tier (catches the PR #1633 regression where every CR got Free quota)
- **Non-sandbox event types ignored** — dispatcher-level filter
- **agentCatalogue strips empties** — `["claude-code", "", "  ", "cursor-agent"]` → `[claude-code, cursor-agent]` before persist (avoids CRD `items.enum` 422s)

### Catalyst sessions API (`products/catalyst/bootstrap/api/internal/handler/sandbox_sessions_integration_test.go`)

7 test functions / 10 runs covering the REST round-trip:
- **POST → GET round-trip** through a `dynamic/fake` apiserver wired via `SetSovereignDepsFactory` (mirrors chroot Sovereign "Path 2")
- **GET reflects controller status** — `sessions` / `storageUsed` / `spend30d` / `previews` / `conditions` projected into the FE wire shape verbatim
- **Failed condition taxonomy** — `TokenMintFailed`, `GitopsWriteFailed`, `ManifestRenderFailed` each preserved so the FE renders actionable error states instead of a generic red pill (canonical list from `sandbox_controller.go` `fail()`)
- **POST invalid-agent** → 400 before any apiserver call
- **GET unknown sandbox** → 404 `sandbox-not-found`
- **LIST → DELETE → LIST** round-trip
- **Org-scope isolation** — `claims.Org`-scoped namespace boundary blocks cross-Org leak

### Hard rules followed
- READ-ONLY fake clients (no apiserver write)
- No chart bump
- No production code changes — only new `_test.go` files
- `go build` + `go test` clean on both modules

## Test plan

- [x] `go test -count=1 -run TestSandboxIntegration ./handlers/` in `core/services/tenant` — all 5 functions / 8 runs pass
- [x] `go test -count=1 -run TestSandboxIntegration ./internal/handler/` in `products/catalyst/bootstrap/api` — all 7 functions / 10 runs pass
- [x] `go build ./...` clean for both modules
- [x] Existing `TestSandbox` unit tests still pass (no shared-fixture collisions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)