### PR TITLE
fix(self-sovereign-cutover): harborPublicURL → registry.<sov> (was harbor.<sov> — chicken-and-egg unblock)

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -285,6 +285,15 @@ spec:
     sovereign:
       fqdn: ${SOVEREIGN_FQDN}
       harborInternalURL: http://harbor-core.harbor.svc.cluster.local
-      harborPublicURL: https://harbor.${SOVEREIGN_FQDN}
+      # NB: Harbor HTTPRoute publishes at `registry.<sov>` (see
+      # `clusters/_template/bootstrap-kit/19-harbor.yaml` gateway.host),
+      # NOT `harbor.<sov>`. Step-06 phase-1 rewrites every HelmRepository
+      # to `oci://${harbor_host}/openova-io`, so this MUST be the public
+      # hostname that actually answers — `registry.${SOVEREIGN_FQDN}`.
+      # Pre-2026-05-18 this said `harbor.${SOVEREIGN_FQDN}`, which no
+      # HTTPRoute matched → all post-pivot OCI pulls EOF → bp-sandbox HR
+      # never Ready → bootstrap-kit Ks stuck (chicken-and-egg). See
+      # t20 debug matrix.
+      harborPublicURL: https://registry.${SOVEREIGN_FQDN}
       giteaInternalURL: http://gitea-http.gitea.svc.cluster.local:3000
       giteaPublicURL: https://gitea.${SOVEREIGN_FQDN}

--- a/platform/self-sovereign-cutover/chart/README.md
+++ b/platform/self-sovereign-cutover/chart/README.md
@@ -52,7 +52,7 @@ See [`values.yaml`](./values.yaml). The required overlay-supplied keys are:
 | Key | Purpose |
 |---|---|
 | `sovereign.fqdn` | The Sovereign's base FQDN (e.g. `otech.omani.works`). Drives every public URL in this chart. |
-| `sovereign.harborPublicURL` | `https://harbor.<sovereign.fqdn>`. Routed to by registries.yaml v2 + step 06. |
+| `sovereign.harborPublicURL` | `https://registry.<sovereign.fqdn>`. The bp-harbor HTTPRoute publishes at `registry.<sov>`, NOT `harbor.<sov>` — see `clusters/_template/bootstrap-kit/19-harbor.yaml` `gateway.host`. Routed to by registries.yaml v2 + step 06. |
 | `sovereign.giteaPublicURL` | `https://gitea.<sovereign.fqdn>`. Informational; jobs reach Gitea via the in-cluster Service URL. |
 
 Per `docs/INVIOLABLE-PRINCIPLES.md` #4 (never hardcode), the chart ships
@@ -86,7 +86,7 @@ where appropriate.
 helm dependency build platform/self-sovereign-cutover/chart   # no-op (no upstream subchart)
 helm template smoke platform/self-sovereign-cutover/chart \
   --set sovereign.fqdn=otechN.omani.works \
-  --set sovereign.harborPublicURL=https://harbor.otechN.omani.works \
+  --set sovereign.harborPublicURL=https://registry.otechN.omani.works \
   --set sovereign.giteaPublicURL=https://gitea.otechN.omani.works
 ```
 

--- a/platform/self-sovereign-cutover/chart/values.yaml
+++ b/platform/self-sovereign-cutover/chart/values.yaml
@@ -32,16 +32,20 @@ sovereign:
   fqdn: "example.local"
   # Local Harbor URL (in-cluster Service form). Used by step 02
   # (harbor-projects) and step 03 (harbor-prewarm). The PUBLIC
-  # harbor.<sovereign.fqdn> URL is what registries.yaml v2 + step 06
+  # `registry.<sovereign.fqdn>` URL is what registries.yaml v2 + step 06
   # (helmrepository-patches) rewrite to (since containerd + Flux
   # source-controller resolve through public DNS, not in-cluster
-  # CoreDNS).
+  # CoreDNS). NB: the HTTPRoute hostname is `registry.<sov>`, NOT
+  # `harbor.<sov>` — see `clusters/_template/bootstrap-kit/19-harbor.yaml`
+  # `gateway.host`. Pre-2026-05-18 this said `harbor.<sov>` which no
+  # HTTPRoute matched → bp-sandbox stuck forever (t20 debug matrix).
   # Service name on bp-harbor is `harbor-core` (NOT `harbor-harbor-core`)
   # — caught live on otech103 2026-05-04. Verified via
   # `kubectl get svc -n harbor` returns harbor-core ClusterIP.
   harborInternalURL: "http://harbor-core.harbor.svc.cluster.local"
   # ↓ overlay required for real cutover (uses ${SOVEREIGN_FQDN}).
-  harborPublicURL: "https://harbor.example.local"
+  #    MUST be `registry.<sov-fqdn>` to match the bp-harbor HTTPRoute.
+  harborPublicURL: "https://registry.example.local"
   giteaInternalURL: "http://gitea-http.gitea.svc.cluster.local:3000"
   # ↓ overlay supplies https://gitea.${SOVEREIGN_FQDN} (informational; jobs use internal URL).
   giteaPublicURL: "https://gitea.example.local"


### PR DESCRIPTION
## Summary

CRITICAL t20 convergence unblocker. `bp-self-sovereign-cutover` step-06 phase-1 rewrites every OCI HelmRepository URL to `oci://${harbor_host}/openova-io`, where `harbor_host` is derived from `sovereign.harborPublicURL`. Pre-fix that value was `https://harbor.${SOVEREIGN_FQDN}`, but the bp-harbor HTTPRoute actually publishes at `registry.${SOVEREIGN_FQDN}` (see `clusters/_template/bootstrap-kit/19-harbor.yaml` line 167 `gateway.host`). No HTTPRoute matches `harbor.<sov>` → post-pivot every OCI chart pull EOFs → bp-sandbox HR never Ready → bootstrap-kit Ks stuck.

## What changed

- `clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml` — overlay value flipped `harbor.${SOVEREIGN_FQDN}` → `registry.${SOVEREIGN_FQDN}` (the only deploy-impacting change).
- `platform/self-sovereign-cutover/chart/values.yaml` — default placeholder flipped `harbor.example.local` → `registry.example.local` so smoke render + docs line up.
- `platform/self-sovereign-cutover/chart/README.md` — Values table + smoke command updated.

No Chart.yaml bump for bp-catalyst-platform — chart-level fix in bp-self-sovereign-cutover.

## Test plan

- [x] `helm template smoke platform/self-sovereign-cutover/chart` clean (1851 lines, env carries `https://registry.example.local`).
- [x] `helm template smoke ... --set sovereign.harborPublicURL=https://registry.otechN.omani.works` clean (overlay-style render carries new host).
- [x] `kubectl kustomize clusters/_template/bootstrap-kit/` clean (2926 lines, overlay shows `harborPublicURL: https://registry.${SOVEREIGN_FQDN}`).
- [x] `bash platform/self-sovereign-cutover/chart/tests/cutover-contract.sh` — all gates green. Phase-0 ghcr-pull auth merge still works because `harbor_host` is derived from `HARBOR_PUBLIC_URL` env at runtime, so the script now correctly merges auth for `registry.<sov-fqdn>` instead of `harbor.<sov-fqdn>`.
- [ ] Next fresh prov (t21+): bp-sandbox HR reconciles Ready, bootstrap-kit Ks converges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)