### PR TITLE
fix(sovereign-tls): bare https/http listener names when single parent zone (collision with chart HTTPRoutes sectionName)

### DIFF
--- a/clusters/_template/sovereign-tls/cilium-gateway.yaml
+++ b/clusters/_template/sovereign-tls/cilium-gateway.yaml
@@ -51,15 +51,32 @@
 # console unreachable" gap during every Helm upgrade. envsubst-driven
 # pre-rendered YAML is the canonical pattern for this slot.
 #
-# Listener naming convention:
-#   - https-<sanitised-zone> / http-<sanitised-zone>
-#   - sanitised-zone = zone name with '.' → '-' (e.g. omani-works,
-#     omani-homes). MUST match the cert resource naming in
-#     products/catalyst/chart/templates/sovereign-wildcard-certs.yaml
-#     so certificateRefs resolve. Each listener distinct so the Gateway
-#     controller programs them all (duplicate `name: https` would
-#     produce a Conflicting status condition and skip all but the
-#     first).
+# Listener naming convention (t20 critical fix #3):
+#   - SINGLE parent zone (the common case) → bare names `https` /
+#     `http`. Every platform chart's HTTPRoute (harbor, keycloak,
+#     grafana, gitea, openbao, powerdns, stalwart-tenant) hardcodes
+#     `parentRefs[0].sectionName: https`. If we rename the listener to
+#     `https-<sanitised-zone>` for a single-zone Sovereign, every
+#     HTTPRoute reports `Accepted=False NoMatchingListener` and the
+#     Sovereign Console / Harbor / Keycloak etc. are unreachable at
+#     the Gateway. Keeping bare names for the single-zone case is the
+#     safer rollback. (Was broken between PR #1640 and the t20 fix.)
+#   - MULTIPLE parent zones → unique names `https-<sanitised-zone>` /
+#     `http-<sanitised-zone>` where sanitised-zone = zone name with
+#     '.' → '-' (e.g. omani-works, omani-homes). Distinct names per
+#     listener so the Gateway controller programs them all (duplicate
+#     `name: https` produces a Conflicting status condition and skips
+#     all but the first). For multi-zone Sovereigns whose HTTPRoutes
+#     must attach under a non-primary zone, override `sectionName` via
+#     values.yaml at the chart level.
+#   - The certificateRefs.name is ALWAYS the per-zone
+#     `sovereign-wildcard-tls-<sanitised-zone>` (see
+#     products/catalyst/chart/templates/sovereign-wildcard-certs.yaml)
+#     — independent of the listener-name choice above.
+#
+# The listener block is rendered by infra/hetzner/main.tf locals.
+# parent_domains_listeners_yaml using local.parent_domains_single_zone
+# to switch between the two naming schemes.
 
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway

--- a/infra/hetzner/main.tf
+++ b/infra/hetzner/main.tf
@@ -340,10 +340,25 @@ locals {
   #   - HTTP  listener on port 30080 hostnamed `*.<zone>` for /.well-known/
   #     and ACME HTTP-01 challenge paths.
   #
-  # Each listener has a unique `name` field (https-<sanitised-zone> /
-  # http-<sanitised-zone>) so the Gateway controller programs them all
-  # (duplicate listener names produce a Conflicting status condition and
-  # silently skip every duplicate but the first).
+  # Listener-NAMING contract (t20 critical fix #3):
+  #   - SINGLE parent zone (the common case)  → listener names are the
+  #     bare strings `https` / `http`. Every platform chart's HTTPRoute
+  #     (harbor, keycloak, grafana, gitea, openbao, powerdns, stalwart-
+  #     tenant) hardcodes `parentRefs[0].sectionName: https`. If the
+  #     listener is renamed to `https-<sanitised-zone>` for a single-zone
+  #     Sovereign, every HTTPRoute reports `Accepted=False
+  #     NoMatchingListener` and the Sovereign Console / Harbor / Keycloak
+  #     etc. are unreachable at the Gateway. Keeping the bare names for
+  #     the single-zone case is the safer rollback. (Was broken between
+  #     PR #1640 and this fix.)
+  #   - MULTIPLE parent zones (SME pool present) → unique names per zone
+  #     (`https-<sanitised-zone>` / `http-<sanitised-zone>`) so the
+  #     Gateway controller programs all of them (duplicate listener names
+  #     produce a Conflicting status condition and silently skip every
+  #     duplicate but the first). For multi-zone Sovereigns, charts whose
+  #     HTTPRoutes must attach under a non-primary zone need their
+  #     sectionName overridden via values.yaml — that is a per-tenant
+  #     concern and out of scope here.
   #
   # Why inline-flow not block-style:
   #   - clusters/_template/sovereign-tls/cilium-gateway.yaml uses the
@@ -361,10 +376,11 @@ locals {
   # substitute map. JSON-encoded scalars are valid YAML; this avoids
   # quoting hell when the listener data contains characters cloud-init
   # YAML would otherwise mis-parse.
+  parent_domains_single_zone = length(local.parent_domains_decoded) == 1
   parent_domains_listeners_yaml = jsonencode(flatten([
     for entry in local.parent_domains_decoded : [
       {
-        name     = format("https-%s", replace(entry.name, ".", "-"))
+        name     = local.parent_domains_single_zone ? "https" : format("https-%s", replace(entry.name, ".", "-"))
         port     = 30443
         protocol = "HTTPS"
         hostname = format("*.%s", entry.name)
@@ -384,7 +400,7 @@ locals {
         }
       },
       {
-        name     = format("http-%s", replace(entry.name, ".", "-"))
+        name     = local.parent_domains_single_zone ? "http" : format("http-%s", replace(entry.name, ".", "-"))
         port     = 30080
         protocol = "HTTP"
         hostname = format("*.%s", entry.name)


### PR DESCRIPTION
## Summary
- PR #1640 renamed the Cilium Gateway listeners to `https-<sanitised-zone>` / `http-<sanitised-zone>` to support multi-zone Sovereigns. That broke **single-zone Sovereigns** (the common case): every platform chart's HTTPRoute hardcodes `parentRefs[0].sectionName: https`, so HTTPRoutes now report `Accepted=False NoMatchingListener` and the Sovereign Console / Harbor / Keycloak / Grafana / Gitea / OpenBao / PowerDNS / Stalwart are unreachable through the Gateway.
- Fix: in `infra/hetzner/main.tf` `locals.parent_domains_listeners_yaml`, when `len(parent_domains_decoded) == 1` render listener names as the **bare strings** `https` / `http`. When `> 1`, keep the unique per-zone naming for the multi-zone case (avoids the duplicate-name Conflicting condition).
- Per-zone `certificateRefs.name` (`sovereign-wildcard-tls-<sanitised-zone>`) is unchanged — independent of listener name.
- Comments in `clusters/_template/sovereign-tls/cilium-gateway.yaml` lines 54-62 rewritten to document the contract.

Chart HTTPRoutes that pin `sectionName: https` (all single-string today):
- `platform/harbor/chart/values.yaml:437`
- `platform/keycloak/chart/values.yaml:482`
- `platform/grafana/chart/values.yaml:124`
- `platform/gitea/chart/values.yaml:168`
- `platform/openbao/chart/values.yaml:72`
- `platform/powerdns/chart/values.yaml:407`
- `platform/stalwart-tenant/chart/values.yaml:297`

Multi-zone tenants whose HTTPRoutes must attach under a non-primary zone override `sectionName` via values.yaml — out of scope here.

## Test plan
- [x] `kubectl kustomize clusters/_template/sovereign-tls/` exits 0 and emits `listeners: ${PARENT_DOMAINS_LISTENERS_YAML}` unchanged (placeholder still scalar, Flux postBuild.substitute will swap at apply-time).
- [ ] Next fresh prov: confirm `kubectl get gateway -n kube-system cilium-gateway -o jsonpath='{.spec.listeners[*].name}'` → `https http` (not `https-<fqdn-dashed>`).
- [ ] HTTPRoute Status.Conditions: `Accepted=True` on every chart HTTPRoute (no more `NoMatchingListener`).
- [ ] `curl -sI https://console.<sov-fqdn>/auth` returns 200/302 (not envoy-403 / TLS-mismatch).
- [ ] If multi-zone (`parent_domains_yaml` populated with > 1 entry): listener names become `https-<zone>` / `http-<zone>` and chart HTTPRoutes pinned to a non-primary zone need a values.yaml `sectionName` override (out-of-band tenant config).

NO Chart.yaml bump, NO clusters/* mutations beyond the `_template/` documentation.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

Generated with Claude Code (Anthropic)