### PR TITLE
fix(billing): consume catalyst.usage.recorded from CATALYST_SME stream (was creating overlapping CATALYST_USAGE)

### DIFF
--- a/core/services/billing/main.go
+++ b/core/services/billing/main.go
@@ -79,20 +79,31 @@ func main() {
 			slog.Error("failed to connect to NATS", "url", natsURL, "error", err)
 			os.Exit(1)
 		}
-		// EnsureUsageStream is idempotent — safe to call on every
-		// startup. sme-billing owns the Stream lifecycle because it is
-		// the canonical consumer; publishers (the NewAPI metering
-		// sidecar) rely on the Stream existing.
+		// Bootstrap the canonical CATALYST_SME Stream (subjects
+		// `catalyst.>`) at startup so the metering sidecar can publish
+		// immediately on a fresh Sovereign cold-start. We previously
+		// created a separate CATALYST_USAGE Stream here, but on t20
+		// (2026-05-18) that crashed billing with NATS error code 10065
+		// "subjects overlap with an existing stream" — by the time
+		// billing started, CATALYST_SME (subject filter `catalyst.>`)
+		// had already been created by the tenant / provisioning
+		// MultiSubscribers, and JetStream rejects overlapping subject
+		// filters across Streams. The fix is to share CATALYST_SME and
+		// scope billing's reads via a consumer-side FilterSubject
+		// below (SubscribeUsageRecordedOnSME).
+		//
+		// EnsureCatalystSMEStream is idempotent — first-writer-wins
+		// with whatever subscriber bootstraps the Stream first.
 		ensureCtx, ensureCancel := context.WithTimeout(context.Background(), 10*time.Second)
-		if err := nc.EnsureUsageStream(ensureCtx); err != nil {
+		if err := nc.EnsureCatalystSMEStream(ensureCtx); err != nil {
 			ensureCancel()
-			slog.Error("failed to ensure JetStream catalyst.usage stream", "error", err)
+			slog.Error("failed to ensure JetStream CATALYST_SME stream", "error", err)
 			os.Exit(1)
 		}
 		ensureCancel()
 		natsConn = nc
 		slog.Info("connected to NATS JetStream", "url", natsURL,
-			"stream", events.StreamCatalystUsage,
+			"stream", events.StreamCatalystSME,
 			"subject", events.SubjectUsageRecorded)
 	}
 	if redpandaBrokersRaw != "" {
@@ -171,11 +182,16 @@ func main() {
 	// opened for the publisher above so we have a single TCP socket per
 	// process. When NATS_URL is unset the subscriber is skipped (HTTP
 	// path POST /billing/metering/record still works for dev loops).
+	//
+	// t20 fix (2026-05-18): consume off CATALYST_SME with a FilterSubject
+	// scoped to `catalyst.usage.recorded` instead of a separate
+	// CATALYST_USAGE Stream — JetStream rejects overlapping subject
+	// filters across Streams. See EnsureCatalystSMEStream above.
 	if natsConn != nil {
 		subCtx := context.Background()
-		usageSub, err := natsConn.SubscribeUsageRecorded(subCtx)
+		usageSub, err := natsConn.SubscribeUsageRecordedOnSME(subCtx)
 		if err != nil {
-			slog.Error("failed to subscribe to catalyst.usage.recorded", "error", err)
+			slog.Error("failed to subscribe to catalyst.usage.recorded on CATALYST_SME", "error", err)
 			os.Exit(1)
 		}
 		defer usageSub.Close()

--- a/core/services/shared/events/nats.go
+++ b/core/services/shared/events/nats.go
@@ -157,12 +157,26 @@ func ConnectNATS(url string) (*NATSConn, error) {
 	return &NATSConn{nc: nc, js: js}, nil
 }
 
-// EnsureUsageStream creates the StreamCatalystUsage stream if it does
-// not already exist. Idempotent — calling it on a Sovereign whose
-// Stream was provisioned in a prior startup is a no-op. 14-day max-age
-// matches the billing reconciliation window. File storage is the only
-// reasonable choice for billing data. Replicas defaults to 1 (single-
-// node K3s) and the chart bumps it to 3 on multi-node Sovereigns.
+// EnsureUsageStream is DEPRECATED — kept only as a back-compat shim for
+// any caller that has not yet migrated to the canonical CATALYST_SME
+// Stream (subjects `catalyst.>`). t20 (2026-05-18) caught the bug this
+// deprecation exists to prevent: when CATALYST_SME already exists with
+// subject filter `catalyst.>` (created by the tenant / notification /
+// provisioning MultiSubscribers — any consumer of `catalyst.tenant.*`),
+// creating CATALYST_USAGE with subject `catalyst.usage.recorded` fails
+// with NATS error code 10065 "subjects overlap with an existing stream".
+// JetStream forbids two Streams from owning overlapping subject filters.
+//
+// New code MUST NOT call EnsureUsageStream. Billing now consumes
+// `catalyst.usage.recorded` directly off CATALYST_SME via
+// SubscribeUsageRecordedOnSME, which uses a consumer-side FilterSubject
+// to scope reads to the metering envelopes only. The metering sidecar
+// publishes to the same subject — JetStream routes the envelope to
+// CATALYST_SME on the basis of its `catalyst.>` filter.
+//
+// Use EnsureCatalystSMEStream instead.
+//
+// Deprecated: use EnsureCatalystSMEStream + SubscribeUsageRecordedOnSME.
 func (c *NATSConn) EnsureUsageStream(ctx context.Context) error {
 	_, err := c.js.CreateOrUpdateStream(ctx, jetstream.StreamConfig{
 		Name:        StreamCatalystUsage,
@@ -177,6 +191,31 @@ func (c *NATSConn) EnsureUsageStream(ctx context.Context) error {
 		return fmt.Errorf("events: ensure usage stream: %w", err)
 	}
 	return nil
+}
+
+// EnsureCatalystSMEStream creates the canonical CATALYST_SME Stream
+// (subjects `catalyst.>`) if it does not already exist. Idempotent — safe
+// to call on every startup.
+//
+// CATALYST_SME backs every `catalyst.<domain>.<event>` subject on a
+// Sovereign — tenant events, billing events, domain events, AND the
+// `catalyst.usage.recorded` metering envelopes that previously lived on
+// the now-deprecated CATALYST_USAGE Stream (see EnsureUsageStream
+// comment above for the t20 incident).
+//
+// This is the public wrapper around the package-private ensureSMEStream
+// helper used by NewMultiSubscriber. Exposed so services that own a
+// publish OR consume relationship to `catalyst.*` subjects can bootstrap
+// the Stream at process start — first-writer-wins is fine because the
+// underlying CreateOrUpdateStream call is a no-op on second invocation.
+//
+// Specifically: sme-billing calls this at startup so the metering sidecar
+// (which deliberately does NOT call any Ensure* — see
+// services/metering-sidecar/main.go) can begin publishing immediately
+// after a fresh Sovereign cold-start, with billing-side bootstrap
+// guaranteeing the Stream exists.
+func (c *NATSConn) EnsureCatalystSMEStream(ctx context.Context) error {
+	return c.ensureSMEStream(ctx, StreamCatalystSME, []string{"catalyst.>"})
 }
 
 // PublishUsage publishes one usage envelope on SubjectUsageRecorded
@@ -272,12 +311,13 @@ type natsSub struct {
 	cc   jetstream.ConsumeContext
 }
 
-// SubscribeUsageRecorded creates (or attaches to) the durable consumer
-// ConsumerSMEBillingMetering on StreamCatalystUsage and returns a
-// NATSSubscription ready to Consume. The consumer is configured for
-// at-least-once delivery with a 30-second AckWait (gives the handler
-// ample time for the DB write); MaxDeliver is unbounded so transient
-// DB outages eventually drain.
+// SubscribeUsageRecorded is DEPRECATED — kept only as a back-compat
+// shim for the legacy CATALYST_USAGE Stream layout. New code MUST call
+// SubscribeUsageRecordedOnSME instead. See the comment on
+// EnsureUsageStream for the t20 stream-overlap incident this deprecation
+// prevents.
+//
+// Deprecated: use SubscribeUsageRecordedOnSME.
 func (c *NATSConn) SubscribeUsageRecorded(ctx context.Context) (NATSSubscription, error) {
 	cons, err := c.js.CreateOrUpdateConsumer(ctx, StreamCatalystUsage, jetstream.ConsumerConfig{
 		Durable:       ConsumerSMEBillingMetering,
@@ -290,6 +330,38 @@ func (c *NATSConn) SubscribeUsageRecorded(ctx context.Context) (NATSSubscription
 	})
 	if err != nil {
 		return nil, fmt.Errorf("events: subscribe usage: %w", err)
+	}
+	return &natsSub{cons: cons}, nil
+}
+
+// SubscribeUsageRecordedOnSME creates (or attaches to) the durable
+// consumer ConsumerSMEBillingMetering on the canonical CATALYST_SME
+// Stream and returns a NATSSubscription ready to Consume. The consumer
+// uses FilterSubject = `catalyst.usage.recorded` so it ONLY receives
+// metering envelopes even though CATALYST_SME also carries tenant,
+// billing, domain, and provisioning events.
+//
+// AckPolicy + AckWait + MaxDeliver match SubscribeUsageRecorded so the
+// observed delivery semantics are identical to the deprecated path.
+//
+// Stream ownership: CATALYST_SME is bootstrapped by
+// EnsureCatalystSMEStream (which sme-billing calls at startup) AND by
+// NewMultiSubscriber (which every other SME service's tenant-events
+// consumer calls). First-writer-wins is fine because the underlying
+// CreateOrUpdateStream call is idempotent on the (`catalyst.>` subject
+// filter, file storage, 14d retention) tuple.
+func (c *NATSConn) SubscribeUsageRecordedOnSME(ctx context.Context) (NATSSubscription, error) {
+	cons, err := c.js.CreateOrUpdateConsumer(ctx, StreamCatalystSME, jetstream.ConsumerConfig{
+		Durable:       ConsumerSMEBillingMetering,
+		Description:   "sme-billing metering consumer (#798) — CATALYST_SME filter scope.",
+		AckPolicy:     jetstream.AckExplicitPolicy,
+		AckWait:       30 * time.Second,
+		FilterSubject: SubjectUsageRecorded,
+		DeliverPolicy: jetstream.DeliverAllPolicy,
+		MaxDeliver:    -1,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("events: subscribe usage on CATALYST_SME: %w", err)
 	}
 	return &natsSub{cons: cons}, nil
 }


### PR DESCRIPTION
## Summary

t20 fix #7. Billing crashed at startup with NATS error code 10065 \`subjects overlap with an existing stream\` because by the time billing tried to create the dedicated \`CATALYST_USAGE\` stream (subject \`catalyst.usage.recorded\`), the canonical \`CATALYST_SME\` stream — subject filter \`catalyst.>\` — had already been created by the tenant/notification/provisioning MultiSubscribers. JetStream forbids two Streams from owning overlapping subject filters.

**Option B (cleaner)**: have billing share \`CATALYST_SME\` and scope its metering reads via a consumer-side \`FilterSubject = catalyst.usage.recorded\` instead of owning a separate Stream. This is the same architecture every other SME service (tenant, notification, provisioning) already uses for catalyst.* events.

## Changes

- \`core/services/shared/events/nats.go\`:
  - Add \`EnsureCatalystSMEStream\` — public wrapper around the existing package-private \`ensureSMEStream\` helper used by \`NewMultiSubscriber\`. Bootstraps \`CATALYST_SME\` (subjects \`catalyst.>\`) idempotently. Used by billing at startup so the metering sidecar (which deliberately calls no Ensure*) can publish immediately on a fresh Sovereign cold-start.
  - Add \`SubscribeUsageRecordedOnSME\` — durable consumer (\`sme-billing-metering\`) on \`CATALYST_SME\` with \`FilterSubject\` scoped to \`catalyst.usage.recorded\`. Same Ack semantics as the legacy method.
  - Mark \`EnsureUsageStream\` + \`SubscribeUsageRecorded\` \`Deprecated:\` (kept for back-compat with any Catalyst-Zero / dev loop wired before t20 — no caller in this repo remains).

- \`core/services/billing/main.go\`:
  - Replace \`nc.EnsureUsageStream\` with \`nc.EnsureCatalystSMEStream\`.
  - Replace \`natsConn.SubscribeUsageRecorded\` with \`natsConn.SubscribeUsageRecordedOnSME\`.
  - Comments capture the t20 root cause + bootstrap-order rationale so the next reader doesn't re-introduce the dedicated stream.

The consumer-side subject filter (\`catalyst.usage.recorded\`) lives in \`core/services/shared/events/nats.go\` inside \`SubscribeUsageRecordedOnSME\`.

## Test plan

- [x] \`go build ./...\` clean for \`core/services/billing\` and \`core/services/shared\`
- [x] \`go test ./...\` clean for \`core/services/billing\` (handlers + store) and \`core/services/shared\` (auth + events)
- [x] \`go vet ./...\` clean for both
- [ ] Next fresh prov: billing pod reaches Ready without 10065; \`catalyst.usage.recorded\` envelopes from the metering sidecar are observed by the billing metering consumer

Hard rules respected: READ-ONLY clusters, no chart bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)