### PR TITLE
fix(guacamole): mount /home/guacamole instead of /home/guacamole/.guacamole (entrypoint rm fails on mount point)

### DIFF
--- a/platform/guacamole/chart/templates/guacamole-deployment.yaml
+++ b/platform/guacamole/chart/templates/guacamole-deployment.yaml
@@ -81,12 +81,21 @@ spec:
             # state (logback marker file, optional auth state) to
             # ~/.guacamole on first start. With readOnlyRootFilesystem
             # the container cannot mkdir under $HOME unless we mount
-            # a writable emptyDir there. Pre-Fix-#39 follow-up the
-            # chart hadn't included this mount; pods crash-looped
-            # with `mkdir: cannot create directory
-            # '/home/guacamole/.guacamole': Read-only file system`.
+            # a writable emptyDir there.
+            #
+            # IMPORTANT: we mount the PARENT directory (/home/guacamole)
+            # rather than /home/guacamole/.guacamole itself. The official
+            # guacamole image entrypoint runs
+            # `rm -rf $GUACAMOLE_HOME` (== `/home/guacamole/.guacamole`)
+            # before re-populating it on every start. If we mounted the
+            # emptyDir at $GUACAMOLE_HOME directly the entrypoint would
+            # fail with `rm: cannot remove '/home/guacamole/.guacamole':
+            # Read-only file system` because you cannot unlink a mount
+            # point from inside the container. Mounting the parent
+            # makes .guacamole a regular subdirectory of the emptyDir
+            # which the entrypoint can freely rm and recreate.
             - name: guacamole-home
-              mountPath: /home/guacamole/.guacamole
+              mountPath: /home/guacamole
           resources:
             {{- toYaml .Values.guacamole.webapp.resources | nindent 12 }}
           securityContext:


### PR DESCRIPTION
## Summary

The Apache Guacamole image entrypoint runs `rm -rf $GUACAMOLE_HOME`
(== `/home/guacamole/.guacamole`) before re-populating the dir on every
start. Our chart was mounting an emptyDir directly at that path, so the
`rm` saw a kernel mount point and failed with:

```
rm: cannot remove '/home/guacamole/.guacamole': Read-only file system
```

The Pod CrashLoopBackOff'd before the webapp ever started. (t20 debug
matrix — Fix #5.)

Fix: mount the emptyDir at the PARENT directory (`/home/guacamole`).
`.guacamole` becomes a regular subdirectory inside the writable
emptyDir — `rm -rf` succeeds, the entrypoint repopulates as designed,
and first-start writes still land on a writable FS under
`readOnlyRootFilesystem`.

## Test plan

- [x] `helm template` renders cleanly with the new mountPath
- [x] `bash platform/guacamole/chart/tests/render.sh` — all 9 PASS lines:
  - default-OFF renders 0 resources
  - empty image.tag fails fast
  - full-ON renders 19 resources
  - every required kind present
  - keycloak realm-config wires OIDC client
  - canonical resource names present
  - realm-patch ConfigMap lands in keycloak namespace
  - recordings storageClass-migration hook wired correctly
  - allowMigration=false suppresses the migration hook
- [ ] Next fresh prov: webapp Pod reaches Ready (no rm/CrashLoopBackOff)

Per t20 hard-rules: NO `Chart.yaml` version bump in this PR — chart
release rolls in the next blueprint-release wave.

🤖 Generated with [Claude Code](https://claude.com/claude-code)