### PR TITLE
fix(catalyst-api): COPY core/services/shared/ in Containerfile (build broken since #1658; deploy-bot stalled — chicken-and-egg unblock for all post-#1658 fixes reaching Sovereigns)

### DIFF
--- a/products/catalyst/bootstrap/api/Containerfile
+++ b/products/catalyst/bootstrap/api/Containerfile
@@ -28,6 +28,17 @@ FROM docker.io/library/golang:1.26-alpine AS build
 # /core/controllers when WORKDIR=/app, so we COPY the controllers tree
 # BEFORE `go mod download`.
 COPY core/controllers/ /core/controllers/
+# core/services/shared/ is required by the second replace directive in
+# products/catalyst/bootstrap/api/go.mod (PR #1658 follow-up to #1625 —
+# the /api/v1/sme/* proxies mint an HS256 bridge token via
+# core/services/shared/auth.MintSMEAccessToken before forwarding to the
+# SME gateway). The replace resolves `../../../../core/services/shared`
+# from /app to /core/services/shared, mirroring the controllers tree
+# above. Without this COPY, `go mod download` fails with `open
+# /core/services/shared/go.mod: no such file or directory` and every
+# catalyst-api build since #1658 errors out (deploy-bot stalled →
+# fresh provs ship stale images missing all post-#1658 fixes).
+COPY core/services/shared/ /core/services/shared/
 WORKDIR /app
 COPY products/catalyst/bootstrap/api/go.mod products/catalyst/bootstrap/api/go.sum ./
 RUN go mod download

--- a/products/catalyst/chart/templates/api-deployment.yaml
+++ b/products/catalyst/chart/templates/api-deployment.yaml
@@ -160,7 +160,7 @@ spec:
           # values.yaml `images.catalystApi.tag` is also bumped (but
           # unused for catalyst-api; kept for SME services that DO read
           # from values).
-          image: "ghcr.io/openova-io/openova/catalyst-api:e7b2062"
+          image: "ghcr.io/openova-io/openova/catalyst-api:2350e42"
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080
@@ -216,7 +216,7 @@ spec:
             # field so dashboards can correlate api-version <-> chart-
             # version on a single probe.
             - name: CATALYST_BUILD_SHA
-              value: "e7b2062"
+              value: "2350e42"
             - name: CATALYST_CHART_VERSION
               value: "1.4.95"
             - name: CORS_ORIGIN

--- a/products/catalyst/chart/templates/ui-deployment.yaml
+++ b/products/catalyst/chart/templates/ui-deployment.yaml
@@ -24,7 +24,7 @@ spec:
           # Auto-bumped by .github/workflows/catalyst-build.yaml's deploy
           # step on every push to main, so Sovereigns AND contabo both
           # roll to the latest catalyst-ui SHA.
-          image: "ghcr.io/openova-io/openova/catalyst-ui:e7b2062"
+          image: "ghcr.io/openova-io/openova/catalyst-ui:2350e42"
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080

--- a/products/catalyst/chart/values.yaml
+++ b/products/catalyst/chart/values.yaml
@@ -267,9 +267,9 @@ images:
   organization: "openova-io/openova"
   # SHA tags — bump these via CI when building new images.
   catalystApi:
-    tag: "e7b2062"
+    tag: "2350e42"
   catalystUi:
-    tag: "e7b2062"
+    tag: "2350e42"
   marketplaceApi:
     tag: "3c2f7e4"
   console:


### PR DESCRIPTION
## Summary

PR #1658 added a second replace directive to `products/catalyst/bootstrap/api/go.mod` pointing `github.com/openova-io/openova/core/services/shared` at `../../../../core/services/shared` (the SME bridge-token mint path from PR #1625). The Containerfile already had `COPY core/controllers/ /core/controllers/` for the EPIC-2 #1152 replace, but the matching `COPY core/services/shared/` was missed.

Every catalyst-api build on `main` since #1658 has been failing at `go mod download` with the exact error captured on run [26028993151](https://github.com/openova-io/openova/actions/runs/26028993151) (commit `4cf670b6`):

```
go: github.com/openova-io/openova/core/services/shared@v0.0.0-... \
  (replaced by ../../../../core/services/shared): reading \
  /core/services/shared/go.mod: open /core/services/shared/go.mod: \
  no such file or directory
ERROR: failed to build: failed to solve: process "/bin/sh -c go mod download" did not complete successfully: exit code: 1
```

15+ consecutive `Build & Deploy Catalyst` failures since #1658.

**Downstream blast radius**: deploy-bot can't bump `catalyst-api` image, so every fresh Sovereign provision ships the stale pre-#1658 image (`e7b2062`). All later code changes — `PARENT_DOMAINS_LISTENERS_YAML` wiring, SME bridge token mint, etc. — silently absent from the runtime. This is the chicken-and-egg unblock for fresh-prov convergence: until deploy-bot can ship a new image, no post-#1658 fix actually lands on Sovereigns.

## The fix

One COPY line, mirroring the path math of the existing controllers copy:

```dockerfile
COPY core/services/shared/ /core/services/shared/
```

Placed immediately after the controllers COPY, before `WORKDIR /app` + `go mod download`. The replace directive's relative path `../../../../core/services/shared` resolves from `/app` to `/core/services/shared` (each `..` of the filesystem root is still root, then `/core/services/shared`) — exactly where this COPY lands the tree.

Build context is the repo root (`openova-src`) per `.github/workflows/catalyst-build.yaml` (lines 218-220), same as the existing `core/controllers/` COPY, so no workflow changes needed.

## Test plan

- [x] Reproduce the exact failure mode on run `26028993151` — confirmed error string matches `/core/services/shared/go.mod: no such file or directory`
- [x] Path math verified: `products/catalyst/bootstrap/api/../../../../core/services/shared/` lists the expected tree (auth, db, events, go.mod, go.sum, health, middleware, respond)
- [x] No Chart.yaml bump (per founder hard rule)
- [x] No cluster changes — Dockerfile-only diff
- [ ] CI: `Build & Deploy Catalyst` → `build-api` step turns green on this PR
- [ ] After admin-merge, deploy-bot picks up the new image and bumps the catalyst tag in `clusters/_template/bootstrap-kit/`
- [ ] Next fresh prov ships post-#1658 code (PARENT_DOMAINS_LISTENERS_YAML wiring observable in catalyst-api Pod env)