### PR TITLE
chore(release): chart 1.4.163→1.4.164 — Wave 17 collector (all 7 t20 root-cause fixes baked)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -563,7 +563,7 @@ spec:
       # values.yaml sovereign.{enableHotStandby,primaryRegion,
       # replicaRegion} defaults). See Chart.yaml header comment for
       # the full change list.
-      version: 1.4.163
+      version: 1.4.164
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -1138,8 +1138,8 @@ name: bp-catalyst-platform
 # Fix #154 (HR-timeout audit). Those bumped the HelmRelease
 # install.timeout. This bumps the chart-INTERNAL wait loop budget
 # inside the pre-install hook Job, which is a different seam.
-version: 1.4.163
-appVersion: 1.4.163
+version: 1.4.164
+appVersion: 1.4.164
 # 1.4.141 (qa-loop Fix #185, prov #38/#39/#41 recurrence — pre-install
 # hook unscheduable on saturated worker):
 #


### PR DESCRIPTION
Bakes 7 PRs (#1681-#1686) + deploy-bot bumps. Fresh t21 prov should converge cleanly with this chart.

🤖 Generated with Claude Code