### PR TITLE
feat(openova-flow): Sandbox node type on flow canvas (CR + pty/MCP Pod lifecycle visible)

### DIFF
--- a/products/openova-flow/adapter-flux/internal/informer/hr_informer.go
+++ b/products/openova-flow/adapter-flux/internal/informer/hr_informer.go
@@ -24,7 +24,9 @@ import (
 	"github.com/openova-io/openova/products/openova-flow/adapter-flux/internal/config"
 	"github.com/openova-io/openova/products/openova-flow/adapter-flux/internal/emit"
 	"github.com/openova-io/openova/products/openova-flow/adapter-flux/internal/types"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/dynamic/dynamicinformer"
@@ -48,6 +50,27 @@ var HCGVR = schema.GroupVersionResource{
 	Resource: "helmcharts",
 }
 
+// SandboxGVR — sandbox.openova.io/v1 Sandbox CR. The sandbox-controller
+// reconciles per-user agent-coding workspaces inside an Org's vcluster
+// (products/sandbox/docs/architecture.md §7). Watching this GVR makes
+// every Sandbox lifecycle visible on the flow canvas alongside the
+// Flux HRs.
+var SandboxGVR = schema.GroupVersionResource{
+	Group:    "sandbox.openova.io",
+	Version:  "v1",
+	Resource: "sandboxes",
+}
+
+// PodGVR — core/v1 Pod. The adapter only emits FlowNodes for Pods
+// whose `app.kubernetes.io/component` label marks them as part of a
+// Sandbox (pty-server / openova-sandbox-mcp). Everything else is
+// dropped at the mapper boundary.
+var PodGVR = schema.GroupVersionResource{
+	Group:    "",
+	Version:  "v1",
+	Resource: "pods",
+}
+
 // idSepBytes — must match mapper.go's idSep. Kept here only for the
 // delete path that needs to reconstruct the leaf id without going
 // through BuildFromHR.
@@ -61,6 +84,14 @@ type Runtime struct {
 	emit    *emit.Client
 	log     *slog.Logger
 	factory dynamicinformer.DynamicSharedInformerFactory
+	// sandboxFactory — separate cluster-scoped factory for the
+	// Sandbox CR + sandbox-component Pods. Sandboxes land in Org
+	// vcluster namespaces (not `flux-system`), so the canonical
+	// NamespaceFilter-scoped `factory` cannot see them. Using a
+	// second factory with empty namespace keeps the HR watcher
+	// scoped tightly while still letting the Sandbox watcher see
+	// every Org vcluster's CRs.
+	sandboxFactory dynamicinformer.DynamicSharedInformerFactory
 
 	// dedupe — last-emitted status keyed by node ID. The informer
 	// fires on every Update including no-op resyncs; dedupe collapses
@@ -77,12 +108,13 @@ func NewRuntime(cfg config.Config, restCfg *rest.Config, log *slog.Logger) (*Run
 		return nil, err
 	}
 	return &Runtime{
-		cfg:        cfg,
-		dyn:        dyn,
-		emit:       emit.NewClient(cfg.FlowServerURL, cfg.FlowID, cfg.PostTimeout, log),
-		log:        log,
-		factory:    dynamicinformer.NewFilteredDynamicSharedInformerFactory(dyn, 0, cfg.NamespaceFilter, nil),
-		lastStatus: map[string]string{},
+		cfg:            cfg,
+		dyn:            dyn,
+		emit:           emit.NewClient(cfg.FlowServerURL, cfg.FlowID, cfg.PostTimeout, log),
+		log:            log,
+		factory:        dynamicinformer.NewFilteredDynamicSharedInformerFactory(dyn, 0, cfg.NamespaceFilter, nil),
+		sandboxFactory: dynamicinformer.NewFilteredDynamicSharedInformerFactory(dyn, 0, "", nil),
+		lastStatus:     map[string]string{},
 	}, nil
 }
 
@@ -91,35 +123,60 @@ func NewRuntime(cfg config.Config, restCfg *rest.Config, log *slog.Logger) (*Run
 // NewRuntime.
 func NewRuntimeForTest(cfg config.Config, dyn dynamic.Interface, log *slog.Logger) *Runtime {
 	return &Runtime{
-		cfg:        cfg,
-		dyn:        dyn,
-		emit:       emit.NewClient(cfg.FlowServerURL, cfg.FlowID, cfg.PostTimeout, log),
-		log:        log,
-		factory:    dynamicinformer.NewFilteredDynamicSharedInformerFactory(dyn, 0, cfg.NamespaceFilter, nil),
-		lastStatus: map[string]string{},
+		cfg:            cfg,
+		dyn:            dyn,
+		emit:           emit.NewClient(cfg.FlowServerURL, cfg.FlowID, cfg.PostTimeout, log),
+		log:            log,
+		factory:        dynamicinformer.NewFilteredDynamicSharedInformerFactory(dyn, 0, cfg.NamespaceFilter, nil),
+		sandboxFactory: dynamicinformer.NewFilteredDynamicSharedInformerFactory(dyn, 0, "", nil),
+		lastStatus:     map[string]string{},
 	}
 }
 
-// Start kicks off the HR informer. Blocks on the supplied context —
-// returns when ctx is cancelled.
+// Start kicks off the HR + Sandbox + sandbox-Pod informers. Blocks
+// on the supplied context — returns when ctx is cancelled.
 //
 // No bootstrap emit — the canvas now does its own force layout and
 // does not need synthetic region/phase parents. The first HR event
 // drives the first upsert-nodes envelope.
+//
+// Sandbox + Pod informers are wired on a SECOND factory that watches
+// across all namespaces (Sandboxes live inside Org vclusters, not in
+// `flux-system`). The factories share the dynamic client + REST
+// QPS/Burst tuning.
 func (r *Runtime) Start(ctx context.Context) error {
 	hrInf := r.factory.ForResource(HRGVR).Informer()
-	_, err := hrInf.AddEventHandler(cache.ResourceEventHandlerFuncs{
+	if _, err := hrInf.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    func(obj any) { r.handle(ctx, obj, false) },
 		UpdateFunc: func(_, obj any) { r.handle(ctx, obj, false) },
 		DeleteFunc: func(obj any) { r.handle(ctx, obj, true) },
-	})
-	if err != nil {
+	}); err != nil {
+		return err
+	}
+
+	sbInf := r.sandboxFactory.ForResource(SandboxGVR).Informer()
+	if _, err := sbInf.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    func(obj any) { r.handleSandbox(ctx, obj, false) },
+		UpdateFunc: func(_, obj any) { r.handleSandbox(ctx, obj, false) },
+		DeleteFunc: func(obj any) { r.handleSandbox(ctx, obj, true) },
+	}); err != nil {
+		return err
+	}
+
+	podInf := r.sandboxFactory.ForResource(PodGVR).Informer()
+	if _, err := podInf.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    func(obj any) { r.handleSandboxPod(ctx, obj, false) },
+		UpdateFunc: func(_, obj any) { r.handleSandboxPod(ctx, obj, false) },
+		DeleteFunc: func(obj any) { r.handleSandboxPod(ctx, obj, true) },
+	}); err != nil {
 		return err
 	}
 
 	stop := make(chan struct{})
 	r.factory.Start(stop)
+	r.sandboxFactory.Start(stop)
 	r.factory.WaitForCacheSync(stop)
+	r.sandboxFactory.WaitForCacheSync(stop)
 
 	r.log.Info("informer: started",
 		"namespace", r.cfg.NamespaceFilter,
@@ -206,4 +263,167 @@ func (r *Runtime) handle(ctx context.Context, obj any, deleted bool) {
 			r.log.Warn("informer: rel emit failed", "err", err)
 		}
 	}
+}
+
+// handleSandbox is the Sandbox CR informer callback. Mirrors handle()
+// — converts unstructured → FlowNode via BuildFromSandbox, dedupes on
+// (id, status), POSTs upsert-nodes + upsert-rels (or delete-nodes on
+// removal).
+func (r *Runtime) handleSandbox(ctx context.Context, obj any, deleted bool) {
+	if d, ok := obj.(cache.DeletedFinalStateUnknown); ok {
+		obj = d.Obj
+	}
+	u, ok := obj.(*unstructured.Unstructured)
+	if !ok {
+		r.log.Warn("informer: non-unstructured Sandbox event payload")
+		return
+	}
+
+	if deleted {
+		region := r.cfg.RegionKey
+		if region == "" {
+			region = "default"
+		}
+		nodeID := sandboxNodeID(region, u.GetName())
+		r.mu.Lock()
+		delete(r.lastStatus, nodeID)
+		r.mu.Unlock()
+		if err := r.emit.Emit(ctx, types.FlowMessage{
+			Type: types.TypeDeleteNodes,
+			IDs:  []string{nodeID},
+		}); err != nil {
+			r.log.Warn("informer: sandbox delete emit failed", "err", err, "id", nodeID)
+		}
+		return
+	}
+
+	res, ok := BuildFromSandbox(u, r.cfg.RegionKey)
+	if !ok {
+		return
+	}
+	res.Node.FlowID = r.cfg.FlowID
+
+	r.mu.Lock()
+	last, seen := r.lastStatus[res.Node.ID]
+	if seen && last == res.Node.Status {
+		r.mu.Unlock()
+		// Re-emit relationships unconditionally (server is idempotent).
+		if len(res.Relationships) > 0 {
+			if err := r.emit.Emit(ctx, types.FlowMessage{
+				Type:          types.TypeUpsertRels,
+				Relationships: res.Relationships,
+			}); err != nil {
+				r.log.Warn("informer: sandbox rel emit failed", "err", err)
+			}
+		}
+		return
+	}
+	r.lastStatus[res.Node.ID] = res.Node.Status
+	r.mu.Unlock()
+
+	if err := r.emit.Emit(ctx, types.FlowMessage{
+		Type:  types.TypeUpsertNodes,
+		Nodes: []types.FlowNode{res.Node},
+	}); err != nil {
+		r.log.Warn("informer: sandbox node emit failed", "err", err, "id", res.Node.ID)
+	}
+	if len(res.Relationships) > 0 {
+		if err := r.emit.Emit(ctx, types.FlowMessage{
+			Type:          types.TypeUpsertRels,
+			Relationships: res.Relationships,
+		}); err != nil {
+			r.log.Warn("informer: sandbox rel emit failed", "err", err)
+		}
+	}
+}
+
+// handleSandboxPod is the Pod informer callback. Filters out any Pod
+// that is not a sandbox component (pty-server / openova-sandbox-mcp)
+// at the mapper boundary, so the dedupe map is not polluted by every
+// Pod in the cluster.
+func (r *Runtime) handleSandboxPod(ctx context.Context, obj any, deleted bool) {
+	if d, ok := obj.(cache.DeletedFinalStateUnknown); ok {
+		obj = d.Obj
+	}
+	u, ok := obj.(*unstructured.Unstructured)
+	if !ok {
+		r.log.Warn("informer: non-unstructured Pod event payload")
+		return
+	}
+	pod, err := podFromUnstructured(u)
+	if err != nil {
+		r.log.Warn("informer: pod decode", "err", err, "name", u.GetName())
+		return
+	}
+
+	if deleted {
+		if !isSandboxComponentPod(pod) {
+			return
+		}
+		region := r.cfg.RegionKey
+		if region == "" {
+			region = "default"
+		}
+		nodeID := sandboxPodNodeID(region, pod.Namespace, pod.Name)
+		r.mu.Lock()
+		delete(r.lastStatus, nodeID)
+		r.mu.Unlock()
+		if err := r.emit.Emit(ctx, types.FlowMessage{
+			Type: types.TypeDeleteNodes,
+			IDs:  []string{nodeID},
+		}); err != nil {
+			r.log.Warn("informer: sandbox-pod delete emit failed", "err", err, "id", nodeID)
+		}
+		return
+	}
+
+	res, ok := BuildFromSandboxPod(pod, r.cfg.RegionKey)
+	if !ok {
+		return
+	}
+	res.Node.FlowID = r.cfg.FlowID
+
+	r.mu.Lock()
+	last, seen := r.lastStatus[res.Node.ID]
+	if seen && last == res.Node.Status {
+		r.mu.Unlock()
+		if len(res.Relationships) > 0 {
+			if err := r.emit.Emit(ctx, types.FlowMessage{
+				Type:          types.TypeUpsertRels,
+				Relationships: res.Relationships,
+			}); err != nil {
+				r.log.Warn("informer: sandbox-pod rel emit failed", "err", err)
+			}
+		}
+		return
+	}
+	r.lastStatus[res.Node.ID] = res.Node.Status
+	r.mu.Unlock()
+
+	if err := r.emit.Emit(ctx, types.FlowMessage{
+		Type:  types.TypeUpsertNodes,
+		Nodes: []types.FlowNode{res.Node},
+	}); err != nil {
+		r.log.Warn("informer: sandbox-pod node emit failed", "err", err, "id", res.Node.ID)
+	}
+	if len(res.Relationships) > 0 {
+		if err := r.emit.Emit(ctx, types.FlowMessage{
+			Type:          types.TypeUpsertRels,
+			Relationships: res.Relationships,
+		}); err != nil {
+			r.log.Warn("informer: sandbox-pod rel emit failed", "err", err)
+		}
+	}
+}
+
+// podFromUnstructured re-decodes an unstructured Pod into the typed
+// corev1.Pod shape — needed so the mapper can read the strongly-typed
+// Status.Phase + ContainerStatuses without re-implementing the
+// unstructured-path dance for each field.
+func podFromUnstructured(u *unstructured.Unstructured) (*corev1.Pod, error) {
+	pod := &corev1.Pod{}
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(u.UnstructuredContent(), pod); err != nil {
+		return nil, err
+	}
+	return pod, nil
 }

--- a/products/openova-flow/adapter-flux/internal/informer/sandbox_mapper.go
+++ b/products/openova-flow/adapter-flux/internal/informer/sandbox_mapper.go
@@ -1,0 +1,382 @@
+// sandbox_mapper.go — PURE TRANSFORM for Sandbox CR + sandbox-related
+// Pod events. Mirrors mapper.go (HelmRelease side) but for the per-Org
+// agent-coding workspace introduced in products/sandbox/.
+//
+// What lands on the canvas:
+//
+//   - One FlowNode per `sandbox.openova.io/v1 Sandbox` CR. The bubble
+//     shows the owner email (Sandbox.metadata.name) and groups under
+//     `family = "sandbox"`. Status maps `.status.phase`:
+//
+//     Pending      → "pending"
+//     Provisioning → "running"
+//     Ready        → "succeeded"
+//     Failed       → "failed"
+//     (missing)    → "pending"
+//
+//   - One FlowNode per pty-server / openova-sandbox-mcp Pod inside the
+//     Sandbox's namespace. Each Pod carries
+//     `meta.kind = "SandboxPod"`; its parent (via `contains`) is the
+//     owning Sandbox node so the canvas groups them under the Sandbox
+//     bubble.
+//
+// `meta.kind` is the discriminator the UI consults to swap the bubble
+// glyph (terminal SVG for Sandbox; small "›_" for SandboxPod). Existing
+// HR-derived nodes continue to carry NO `meta.kind` so the canvas
+// falls back to the legacy status-glyph rendering — backwards
+// compatible.
+//
+// `meta.parent` carries the tenant-org node id so the canvas can pull
+// the Sandbox bubble under the tenant-org cluster (the task brief
+// `parent=<tenant-org>`). The canvas treats this advisory; the
+// `contains` Relationship is the load-bearing edge.
+//
+// Pure: no I/O, no clock, deterministic given the input.
+package informer
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/openova-io/openova/products/openova-flow/adapter-flux/internal/types"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// Sandbox node-id format: "<regionKey>:sandbox:<sandbox-name>" — the
+// extra "sandbox:" segment keeps the id from colliding with HR node
+// ids (which are "<regionKey>:<hr-name>") even when the operator
+// names a HelmRelease the same string as a Sandbox.
+const sandboxIDPrefix = "sandbox" + idSep
+
+// Pod node-id format: "<regionKey>:sandbox-pod:<namespace>/<pod-name>".
+// Namespace is required for stable identity because two Orgs can run
+// pty-server pods with identical generated names.
+const sandboxPodIDPrefix = "sandbox-pod" + idSep
+
+// FamilySandbox — fixed family for Sandbox CR + its Pods, so the
+// canvas colour-bands every sandbox-y bubble identically. Operators
+// can still override via the `catalyst.openova.io/family` label per
+// LabelFamily in mapper.go.
+const FamilySandbox = "sandbox"
+
+// KindSandbox / KindSandboxPod — `meta.kind` values the canvas reads
+// to pick the bubble glyph. Open vocabulary: any future K8s object
+// type the adapter supports adds a new constant here.
+const (
+	KindSandbox    = "Sandbox"
+	KindSandboxPod = "SandboxPod"
+)
+
+// LabelSandboxOwnerNS — namespace label that marks "this namespace
+// belongs to Sandbox <name>". The sandbox-controller stamps this so
+// the adapter can group Pods back under the parent Sandbox without
+// re-parsing the namespace stem.
+const LabelSandboxOwnerNS = "sandbox.openova.io/owner-namespace"
+
+// LabelSandboxName — Pod label set by the sandbox-controller
+// referencing the parent Sandbox CR name. When present, the Pod's
+// FlowNode emits a `contains` edge to that Sandbox.
+const LabelSandboxName = "sandbox.openova.io/name"
+
+// SandboxPodComponentLabel — component-classifier the
+// sandbox-controller stamps on its Deployments. The adapter watches
+// Pods carrying any of the values below.
+const SandboxPodComponentLabel = "app.kubernetes.io/component"
+
+var sandboxPodComponents = map[string]struct{}{
+	"pty-server":            {},
+	"openova-sandbox-mcp":   {},
+	"sandbox-pty":           {}, // historic alias; keep until Wave 2 lock-in
+	"sandbox-mcp":           {}, // historic alias; keep until Wave 2 lock-in
+}
+
+// BuildFromSandbox converts one Sandbox CR (unstructured) into a
+// FlowNode + a contains Relationship pulling the bubble under the
+// tenant-org node (when spec.owner.orgRef.slug is set).
+//
+// Region behaviour mirrors HR mapping — empty regionKey falls back to
+// "default" so unit tests stay terse.
+func BuildFromSandbox(sb *unstructured.Unstructured, regionKey string) (MapResult, bool) {
+	if sb == nil {
+		return MapResult{}, false
+	}
+	name := sb.GetName()
+	if name == "" {
+		return MapResult{}, false
+	}
+	region := strings.TrimSpace(regionKey)
+	if region == "" {
+		region = "default"
+	}
+
+	id := sandboxNodeID(region, name)
+	status := sandboxStatusFromPhase(sb)
+
+	meta := map[string]interface{}{
+		"kind":      KindSandbox,
+		"namespace": sb.GetNamespace(),
+	}
+	if owner, ok := sandboxOwnerEmail(sb); ok {
+		meta["ownerEmail"] = owner
+	}
+	orgSlug, _ := sandboxOrgSlug(sb)
+	if orgSlug != "" {
+		meta["orgSlug"] = orgSlug
+		// parent advisory — canvas may inspect this when no explicit
+		// contains edge has been received yet (e.g. tenant-org node
+		// emitted by a different adapter).
+		meta["parent"] = tenantOrgNodeID(region, orgSlug)
+	}
+	if sess, found, _ := unstructured.NestedInt64(sb.Object, "status", "sessions"); found {
+		meta["sessions"] = sess
+	}
+	if su, found, _ := unstructured.NestedString(sb.Object, "status", "storageUsed"); found && su != "" {
+		meta["storageUsed"] = su
+	}
+
+	label := name
+	if owner, ok := sandboxOwnerEmail(sb); ok && owner != "" {
+		label = owner
+	}
+
+	node := types.FlowNode{
+		ID:     id,
+		FlowID: "", // populated by emitter with the deployment id
+		Label:  label,
+		Status: status,
+		Family: ptr(familyForSandbox(sb)),
+		Region: ptr(region),
+		Meta:   meta,
+	}
+
+	rels := make([]types.Relationship, 0, 1)
+	if orgSlug != "" {
+		// contains: tenant-org node (parent) contains this Sandbox node
+		// (child). Per the locked contract — fromId=child, toId=parent.
+		rels = append(rels, types.Relationship{
+			FromID:    id,
+			ToID:      tenantOrgNodeID(region, orgSlug),
+			Type:      "contains",
+			Condition: "always",
+		})
+	}
+	return MapResult{Node: node, Relationships: rels}, true
+}
+
+// BuildFromSandboxPod converts a sandbox-component Pod into a FlowNode
+// + contains edge to its parent Sandbox. Returns ok=false for Pods
+// that are not part of a Sandbox (caller should ignore them).
+//
+// Parent identity is resolved in priority order:
+//  1. Pod label `LabelSandboxName` — explicit reference set by the
+//     sandbox-controller.
+//  2. Namespace stem `sandbox-<sanitized-email>` — falls out of the
+//     CRD's namespace-naming convention.
+//
+// When neither resolves, the Pod is treated as standalone and emits
+// no contains edge.
+func BuildFromSandboxPod(pod *corev1.Pod, regionKey string) (MapResult, bool) {
+	if pod == nil {
+		return MapResult{}, false
+	}
+	if !isSandboxComponentPod(pod) {
+		return MapResult{}, false
+	}
+	region := strings.TrimSpace(regionKey)
+	if region == "" {
+		region = "default"
+	}
+
+	component := pod.Labels[SandboxPodComponentLabel]
+	id := sandboxPodNodeID(region, pod.Namespace, pod.Name)
+	status := sandboxPodStatus(pod)
+
+	meta := map[string]interface{}{
+		"kind":      KindSandboxPod,
+		"component": component,
+		"namespace": pod.Namespace,
+		"podName":   pod.Name,
+	}
+
+	parentSandboxName := strings.TrimSpace(pod.Labels[LabelSandboxName])
+	if parentSandboxName == "" {
+		// Fallback: derive from namespace stem `sandbox-<name>`. The
+		// sandbox-controller stamps namespaces in this form per the
+		// CRD's namespace-naming convention, so the stem-strip is
+		// safe even without the LabelSandboxOwnerNS marker.
+		if strings.HasPrefix(pod.Namespace, "sandbox-") {
+			parentSandboxName = strings.TrimPrefix(pod.Namespace, "sandbox-")
+		}
+	}
+
+	rels := make([]types.Relationship, 0, 1)
+	if parentSandboxName != "" {
+		parentID := sandboxNodeID(region, parentSandboxName)
+		meta["parent"] = parentID
+		rels = append(rels, types.Relationship{
+			FromID:    id,
+			ToID:      parentID,
+			Type:      "contains",
+			Condition: "always",
+		})
+	}
+
+	node := types.FlowNode{
+		ID:     id,
+		FlowID: "",
+		Label:  podShortLabel(pod, component),
+		Status: status,
+		Family: ptr(FamilySandbox),
+		Region: ptr(region),
+		Meta:   meta,
+	}
+	return MapResult{Node: node, Relationships: rels}, true
+}
+
+// isSandboxComponentPod returns true when the Pod's
+// `app.kubernetes.io/component` label is one of the known sandbox
+// components.
+func isSandboxComponentPod(pod *corev1.Pod) bool {
+	if pod == nil {
+		return false
+	}
+	c, ok := pod.Labels[SandboxPodComponentLabel]
+	if !ok || c == "" {
+		return false
+	}
+	_, isComponent := sandboxPodComponents[c]
+	return isComponent
+}
+
+// sandboxStatusFromPhase maps the CR's `.status.phase` enum to the
+// canvas palette. Mirrors statusFromConditions on the HR side — both
+// terminate in the same 4-tone palette.
+func sandboxStatusFromPhase(sb *unstructured.Unstructured) string {
+	phase, _, _ := unstructured.NestedString(sb.Object, "status", "phase")
+	switch phase {
+	case "Ready":
+		return "succeeded"
+	case "Provisioning":
+		return "running"
+	case "Failed":
+		return "failed"
+	default:
+		return "pending"
+	}
+}
+
+// sandboxPodStatus collapses the standard Pod lifecycle into the same
+// 4-tone palette the canvas uses for every other bubble. Crash-loop
+// surfaces as "failed"; container-creating / pulling-image stays
+// "running" so an operator can SEE the bubble light up before the
+// pod is fully Ready.
+func sandboxPodStatus(pod *corev1.Pod) string {
+	switch pod.Status.Phase {
+	case corev1.PodSucceeded:
+		return "succeeded"
+	case corev1.PodFailed:
+		return "failed"
+	case corev1.PodPending:
+		// Distinguish ImagePull/CrashLoop from genuine queue wait.
+		for _, cs := range pod.Status.ContainerStatuses {
+			if cs.State.Waiting != nil {
+				switch cs.State.Waiting.Reason {
+				case "CrashLoopBackOff", "ImagePullBackOff", "ErrImagePull",
+					"CreateContainerConfigError", "RunContainerError":
+					return "failed"
+				}
+			}
+		}
+		return "pending"
+	case corev1.PodRunning:
+		// All containers Ready → succeeded; otherwise "running" (the
+		// pod's containers are warming up — pty-server typically takes
+		// 5-10s to bind its listener after the container starts).
+		allReady := true
+		hasContainers := false
+		for _, cs := range pod.Status.ContainerStatuses {
+			hasContainers = true
+			if !cs.Ready {
+				allReady = false
+				break
+			}
+		}
+		if hasContainers && allReady {
+			return "succeeded"
+		}
+		return "running"
+	default:
+		return "pending"
+	}
+}
+
+// sandboxOwnerEmail reads spec.owner.email defensively (the schema
+// requires it, but unstructured paths still need ok-checks for
+// hand-constructed test fixtures).
+func sandboxOwnerEmail(sb *unstructured.Unstructured) (string, bool) {
+	v, found, err := unstructured.NestedString(sb.Object, "spec", "owner", "email")
+	if err != nil || !found {
+		return "", false
+	}
+	return v, v != ""
+}
+
+// sandboxOrgSlug reads spec.owner.orgRef.slug — the parent
+// Organization's slug. Used to wire the contains edge into the
+// tenant-org node.
+func sandboxOrgSlug(sb *unstructured.Unstructured) (string, bool) {
+	v, found, err := unstructured.NestedString(sb.Object, "spec", "owner", "orgRef", "slug")
+	if err != nil || !found {
+		return "", false
+	}
+	return v, v != ""
+}
+
+// familyForSandbox honours the operator-set LabelFamily override,
+// otherwise hardcodes FamilySandbox. Mirrors familyFor on HR side.
+func familyForSandbox(sb *unstructured.Unstructured) string {
+	labels := sb.GetLabels()
+	if v, ok := labels[LabelFamily]; ok && strings.TrimSpace(v) != "" {
+		return strings.TrimSpace(v)
+	}
+	return FamilySandbox
+}
+
+// sandboxNodeID — canonical FlowNode.id for a Sandbox CR.
+func sandboxNodeID(region, name string) string {
+	return region + idSep + sandboxIDPrefix + name
+}
+
+// sandboxPodNodeID — canonical FlowNode.id for a sandbox-component Pod.
+func sandboxPodNodeID(region, namespace, podName string) string {
+	return region + idSep + sandboxPodIDPrefix + namespace + "/" + podName
+}
+
+// tenantOrgNodeID — id the canvas uses for the tenant-org bubble.
+// Convention: "<region>:org:<slug>" — keeps the namespace
+// orthogonal to HR ids ("<region>:bp-*") and Sandbox ids
+// ("<region>:sandbox:*"). When the tenant-org node has not yet been
+// emitted by another adapter the canvas will still render the
+// contains edge to a "ghost" id; the d3-force layout drops dangling
+// edges in computeLayout.
+func tenantOrgNodeID(region, slug string) string {
+	return region + idSep + "org" + idSep + slug
+}
+
+// podShortLabel collapses long generated pod names to "<component>
+// (<pod suffix>)" — fits the canvas's 18-char label cap.
+func podShortLabel(pod *corev1.Pod, component string) string {
+	if component == "" {
+		return pod.Name
+	}
+	// Strip the deployment-hash + replica-set-suffix to keep the most
+	// human-readable bit: e.g. "pty-server-7d4f8" → "(7d4f8)".
+	parts := strings.Split(pod.Name, "-")
+	if len(parts) > 2 {
+		tail := parts[len(parts)-1]
+		return fmt.Sprintf("%s (%s)", component, tail)
+	}
+	return component
+}
+

--- a/products/openova-flow/adapter-flux/test/sandbox_mapper_test.go
+++ b/products/openova-flow/adapter-flux/test/sandbox_mapper_test.go
@@ -1,0 +1,372 @@
+// sandbox_mapper_test.go — coverage for the Sandbox CR + sandbox-Pod
+// mapper introduced 2026-05-18. Mirrors the HR-mapper coverage matrix
+// (every status transition + family/region fallbacks + parent-org
+// contains edge).
+package test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/openova-io/openova/products/openova-flow/adapter-flux/internal/informer"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/yaml"
+)
+
+func parseSandbox(t *testing.T, raw string) *unstructured.Unstructured {
+	t.Helper()
+	js, err := yaml.YAMLToJSON([]byte(strings.TrimSpace(raw)))
+	if err != nil {
+		t.Fatalf("yaml->json: %v", err)
+	}
+	u := &unstructured.Unstructured{}
+	if err := u.UnmarshalJSON(js); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	return u
+}
+
+func TestSandbox_Phase_Ready(t *testing.T) {
+	sb := parseSandbox(t, `
+apiVersion: sandbox.openova.io/v1
+kind: Sandbox
+metadata:
+  name: emrah-at-acme-io
+  namespace: acme
+spec:
+  owner:
+    email: emrah@acme.io
+    orgRef:
+      slug: acme
+  quota:
+    cpu: "4"
+    memory: 8Gi
+    storage: 50Gi
+    concurrentSessions: 3
+status:
+  phase: Ready
+  sessions: 2
+  storageUsed: 8.2Gi
+`)
+	res, ok := informer.BuildFromSandbox(sb, "fsn1")
+	if !ok {
+		t.Fatal("BuildFromSandbox returned not-ok")
+	}
+	if res.Node.Status != "succeeded" {
+		t.Fatalf("status: %s", res.Node.Status)
+	}
+	if res.Node.ID != "fsn1:sandbox:emrah-at-acme-io" {
+		t.Fatalf("id: %s", res.Node.ID)
+	}
+	if res.Node.Label != "emrah@acme.io" {
+		t.Fatalf("label: %s", res.Node.Label)
+	}
+	if res.Node.Family == nil || *res.Node.Family != "sandbox" {
+		t.Fatalf("family: %+v", res.Node.Family)
+	}
+	if res.Node.Region == nil || *res.Node.Region != "fsn1" {
+		t.Fatalf("region: %+v", res.Node.Region)
+	}
+	if kind, _ := res.Node.Meta["kind"].(string); kind != "Sandbox" {
+		t.Fatalf("meta.kind: %+v", res.Node.Meta["kind"])
+	}
+	if owner, _ := res.Node.Meta["ownerEmail"].(string); owner != "emrah@acme.io" {
+		t.Fatalf("meta.ownerEmail: %+v", res.Node.Meta["ownerEmail"])
+	}
+	if slug, _ := res.Node.Meta["orgSlug"].(string); slug != "acme" {
+		t.Fatalf("meta.orgSlug: %+v", res.Node.Meta["orgSlug"])
+	}
+	// One contains edge pointing at the tenant-org node.
+	if len(res.Relationships) != 1 {
+		t.Fatalf("rels=%d want 1: %+v", len(res.Relationships), res.Relationships)
+	}
+	r := res.Relationships[0]
+	if r.Type != "contains" || r.FromID != "fsn1:sandbox:emrah-at-acme-io" || r.ToID != "fsn1:org:acme" {
+		t.Fatalf("unexpected rel: %+v", r)
+	}
+}
+
+func TestSandbox_Phase_Provisioning(t *testing.T) {
+	sb := parseSandbox(t, `
+apiVersion: sandbox.openova.io/v1
+kind: Sandbox
+metadata:
+  name: alice-at-zeta-io
+spec:
+  owner:
+    email: alice@zeta.io
+    orgRef:
+      slug: zeta
+  quota:
+    cpu: "2"
+    memory: 4Gi
+    storage: 20Gi
+    concurrentSessions: 1
+status:
+  phase: Provisioning
+`)
+	res, _ := informer.BuildFromSandbox(sb, "hel1")
+	if res.Node.Status != "running" {
+		t.Fatalf("status: %s", res.Node.Status)
+	}
+}
+
+func TestSandbox_Phase_Failed(t *testing.T) {
+	sb := parseSandbox(t, `
+apiVersion: sandbox.openova.io/v1
+kind: Sandbox
+metadata:
+  name: x
+spec:
+  owner:
+    email: x@x.io
+    orgRef:
+      slug: x
+  quota:
+    cpu: "1"
+    memory: 1Gi
+    storage: 1Gi
+    concurrentSessions: 1
+status:
+  phase: Failed
+`)
+	res, _ := informer.BuildFromSandbox(sb, "fsn1")
+	if res.Node.Status != "failed" {
+		t.Fatalf("status: %s", res.Node.Status)
+	}
+}
+
+func TestSandbox_Phase_Pending_When_Missing(t *testing.T) {
+	sb := parseSandbox(t, `
+apiVersion: sandbox.openova.io/v1
+kind: Sandbox
+metadata:
+  name: pending
+spec:
+  owner:
+    email: y@y.io
+    orgRef:
+      slug: y
+  quota:
+    cpu: "1"
+    memory: 1Gi
+    storage: 1Gi
+    concurrentSessions: 1
+`)
+	res, _ := informer.BuildFromSandbox(sb, "fsn1")
+	if res.Node.Status != "pending" {
+		t.Fatalf("status: %s", res.Node.Status)
+	}
+}
+
+func TestSandbox_FamilyLabelOverride(t *testing.T) {
+	sb := parseSandbox(t, `
+apiVersion: sandbox.openova.io/v1
+kind: Sandbox
+metadata:
+  name: sb-with-label
+  labels:
+    catalyst.openova.io/family: dev-experience
+spec:
+  owner:
+    email: a@a.io
+    orgRef:
+      slug: a
+  quota:
+    cpu: "1"
+    memory: 1Gi
+    storage: 1Gi
+    concurrentSessions: 1
+status:
+  phase: Ready
+`)
+	res, _ := informer.BuildFromSandbox(sb, "fsn1")
+	if res.Node.Family == nil || *res.Node.Family != "dev-experience" {
+		t.Fatalf("family: %+v", res.Node.Family)
+	}
+}
+
+func TestSandbox_RegionFallback(t *testing.T) {
+	sb := parseSandbox(t, `
+apiVersion: sandbox.openova.io/v1
+kind: Sandbox
+metadata:
+  name: no-region
+spec:
+  owner:
+    email: z@z.io
+    orgRef:
+      slug: z
+  quota:
+    cpu: "1"
+    memory: 1Gi
+    storage: 1Gi
+    concurrentSessions: 1
+`)
+	res, _ := informer.BuildFromSandbox(sb, "")
+	if res.Node.ID != "default:sandbox:no-region" {
+		t.Fatalf("id: %s", res.Node.ID)
+	}
+	if res.Node.Region == nil || *res.Node.Region != "default" {
+		t.Fatalf("region: %+v", res.Node.Region)
+	}
+	// contains edge still points at tenant-org node in `default` region.
+	if len(res.Relationships) != 1 || res.Relationships[0].ToID != "default:org:z" {
+		t.Fatalf("rels: %+v", res.Relationships)
+	}
+}
+
+func TestSandbox_NoOrgSlug_NoContainsEdge(t *testing.T) {
+	// Hand-crafted unstructured (the CRD requires orgRef but a
+	// malformed CR shouldn't crash the mapper).
+	u := &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "sandbox.openova.io/v1",
+		"kind":       "Sandbox",
+		"metadata":   map[string]interface{}{"name": "orphan"},
+		"spec": map[string]interface{}{
+			"owner": map[string]interface{}{"email": "orphan@x.io"},
+		},
+		"status": map[string]interface{}{"phase": "Ready"},
+	}}
+	res, ok := informer.BuildFromSandbox(u, "fsn1")
+	if !ok {
+		t.Fatal("not-ok")
+	}
+	if len(res.Relationships) != 0 {
+		t.Fatalf("rels=%d want 0: %+v", len(res.Relationships), res.Relationships)
+	}
+	if _, hasParent := res.Node.Meta["parent"]; hasParent {
+		t.Fatalf("meta.parent should be absent when org slug missing: %+v", res.Node.Meta)
+	}
+}
+
+func TestSandboxPod_PtyServer_Running_All_Ready(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pty-server-abc123-xyz",
+			Namespace: "sandbox-emrah-at-acme-io",
+			Labels: map[string]string{
+				informer.SandboxPodComponentLabel: "pty-server",
+				informer.LabelSandboxName:         "emrah-at-acme-io",
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			ContainerStatuses: []corev1.ContainerStatus{
+				{Ready: true},
+			},
+		},
+	}
+	res, ok := informer.BuildFromSandboxPod(pod, "fsn1")
+	if !ok {
+		t.Fatal("not-ok")
+	}
+	if res.Node.Status != "succeeded" {
+		t.Fatalf("status: %s", res.Node.Status)
+	}
+	if res.Node.ID != "fsn1:sandbox-pod:sandbox-emrah-at-acme-io/pty-server-abc123-xyz" {
+		t.Fatalf("id: %s", res.Node.ID)
+	}
+	if kind, _ := res.Node.Meta["kind"].(string); kind != "SandboxPod" {
+		t.Fatalf("meta.kind: %+v", res.Node.Meta["kind"])
+	}
+	if comp, _ := res.Node.Meta["component"].(string); comp != "pty-server" {
+		t.Fatalf("meta.component: %+v", res.Node.Meta["component"])
+	}
+	if len(res.Relationships) != 1 || res.Relationships[0].Type != "contains" {
+		t.Fatalf("expected one contains edge: %+v", res.Relationships)
+	}
+	if res.Relationships[0].ToID != "fsn1:sandbox:emrah-at-acme-io" {
+		t.Fatalf("parent: %s", res.Relationships[0].ToID)
+	}
+}
+
+func TestSandboxPod_McpServer_NotReady_Yet(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "openova-sandbox-mcp-7d4f8-q9k2",
+			Namespace: "sandbox-alice",
+			Labels: map[string]string{
+				informer.SandboxPodComponentLabel: "openova-sandbox-mcp",
+				informer.LabelSandboxName:         "alice",
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			ContainerStatuses: []corev1.ContainerStatus{
+				{Ready: false},
+			},
+		},
+	}
+	res, _ := informer.BuildFromSandboxPod(pod, "fsn1")
+	if res.Node.Status != "running" {
+		t.Fatalf("status: %s", res.Node.Status)
+	}
+}
+
+func TestSandboxPod_CrashLoopBackOff_IsFailed(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pty-server-broken",
+			Namespace: "sandbox-bob",
+			Labels: map[string]string{
+				informer.SandboxPodComponentLabel: "pty-server",
+				informer.LabelSandboxName:         "bob",
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodPending,
+			ContainerStatuses: []corev1.ContainerStatus{
+				{State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{Reason: "CrashLoopBackOff"}}},
+			},
+		},
+	}
+	res, _ := informer.BuildFromSandboxPod(pod, "fsn1")
+	if res.Node.Status != "failed" {
+		t.Fatalf("status: %s", res.Node.Status)
+	}
+}
+
+func TestSandboxPod_NonSandboxComponent_IsSkipped(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "nginx-abc",
+			Namespace: "default",
+			Labels: map[string]string{
+				informer.SandboxPodComponentLabel: "nginx",
+			},
+		},
+		Status: corev1.PodStatus{Phase: corev1.PodRunning},
+	}
+	_, ok := informer.BuildFromSandboxPod(pod, "fsn1")
+	if ok {
+		t.Fatalf("non-sandbox pod should not be mapped")
+	}
+}
+
+func TestSandboxPod_FallbackParent_FromNamespaceStem(t *testing.T) {
+	// No explicit LabelSandboxName — mapper should derive parent from
+	// the `sandbox-<name>` namespace.
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pty-server-no-label",
+			Namespace: "sandbox-derived-name",
+			Labels: map[string]string{
+				informer.SandboxPodComponentLabel: "pty-server",
+			},
+		},
+		Status: corev1.PodStatus{Phase: corev1.PodRunning},
+	}
+	res, ok := informer.BuildFromSandboxPod(pod, "fsn1")
+	if !ok {
+		t.Fatal("not-ok")
+	}
+	if len(res.Relationships) != 1 {
+		t.Fatalf("rels=%d want 1: %+v", len(res.Relationships), res.Relationships)
+	}
+	if res.Relationships[0].ToID != "fsn1:sandbox:derived-name" {
+		t.Fatalf("parent: %s", res.Relationships[0].ToID)
+	}
+}

--- a/products/openova-flow/canvas/src/FlowCanvas.tsx
+++ b/products/openova-flow/canvas/src/FlowCanvas.tsx
@@ -1452,6 +1452,9 @@ function FlowNodeView({
       data-family={node.family}
       data-flow={node.flowId}
       data-kind={node.isGroup ? 'group' : 'leaf'}
+      data-meta-kind={
+        (node.node.meta && (node.node.meta as Record<string, unknown>)['kind']) as string | undefined ?? ''
+      }
       data-folded={node.isFolded ? 'true' : 'false'}
       data-open={isOpen ? 'true' : 'false'}
       data-host={isHost ? 'true' : 'false'}
@@ -1511,18 +1514,7 @@ function FlowNodeView({
           {node.childCount}
         </text>
       ) : (
-        <text
-          x={0}
-          y={6}
-          textAnchor="middle"
-          fontSize={node.isGroup ? 16 : 18}
-          fontWeight={700}
-          fill={tone.glyph}
-          fontFamily="ui-sans-serif, system-ui, sans-serif"
-          pointerEvents="none"
-        >
-          {node.isGroup ? '◇' : glyphFor(node.status)}
-        </text>
+        <NodeGlyph node={node} tone={tone} />
       )}
       <text
         x={0}
@@ -1615,6 +1607,97 @@ function glyphFor(status: string): string {
   if (status === 'failed') return '✗'
   if (status === 'running') return '◐'
   return '○'
+}
+
+/* ─── NodeGlyph — kind-aware bubble glyph ──────────────────────────────
+ *
+ * Per the FlowNode schema, `meta.kind` is the open discriminator the
+ * canvas consults to pick a kind-specific glyph. Adapters that ship
+ * new K8s object types add their kind here; everything else falls back
+ * to the legacy status glyph (◇ for groups, ✓/✗/◐/○ for leaves).
+ *
+ * Sandbox glyph: a single-stroke "terminal/monitor" SVG that matches
+ * the icon used in the Sovereign sidebar's Sandbox nav item
+ * (products/catalyst/bootstrap/ui/src/pages/sovereign/SovereignSidebar.tsx).
+ * Keeping the two glyphs identical means the operator's eye can map
+ * "the sandbox icon I clicked in the sidebar" → "this bubble on the
+ * flow canvas" instantly.
+ *
+ * SandboxPod glyph: a compact "›_" prompt-character shape — derived
+ * from the same icon family but trimmed to fit the smaller pod
+ * bubble alongside the parent Sandbox.
+ */
+interface NodeGlyphProps {
+  node: PositionedNode
+  tone: StatusTone
+}
+
+const SANDBOX_ICON_PATH =
+  'M3 4a1 1 0 011-1h16a1 1 0 011 1v12a1 1 0 01-1 1H4a1 1 0 01-1-1V4zm5 5l3 3-3 3m5 0h4M8 21h8'
+
+function NodeGlyph({ node, tone }: NodeGlyphProps) {
+  const kind = (node.node.meta && (node.node.meta as Record<string, unknown>)['kind']) as
+    | string
+    | undefined
+
+  if (kind === 'Sandbox' && !node.isGroup) {
+    // Terminal-monitor SVG centred on (0,0). The tabler icon natively
+    // lives on a 24×24 canvas with stroke-only paths; we scale to
+    // 18×18 and translate to (-9,-9) so the glyph centres on the
+    // bubble origin.
+    return (
+      <g
+        data-testid={`flow-node-glyph-${node.id}`}
+        data-kind="Sandbox"
+        pointerEvents="none"
+        transform="translate(-9, -9) scale(0.75)"
+      >
+        <path
+          d={SANDBOX_ICON_PATH}
+          stroke={tone.glyph}
+          strokeWidth={1.75}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          fill="none"
+        />
+      </g>
+    )
+  }
+
+  if (kind === 'SandboxPod' && !node.isGroup) {
+    // Compact "›_" prompt — drawn as two strokes centred on (0,0).
+    return (
+      <g
+        data-testid={`flow-node-glyph-${node.id}`}
+        data-kind="SandboxPod"
+        pointerEvents="none"
+      >
+        <path
+          d="M-5,-4 L-1,0 L-5,4 M1,5 L6,5"
+          stroke={tone.glyph}
+          strokeWidth={2}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          fill="none"
+        />
+      </g>
+    )
+  }
+
+  return (
+    <text
+      x={0}
+      y={6}
+      textAnchor="middle"
+      fontSize={node.isGroup ? 16 : 18}
+      fontWeight={700}
+      fill={tone.glyph}
+      fontFamily="ui-sans-serif, system-ui, sans-serif"
+      pointerEvents="none"
+    >
+      {node.isGroup ? '◇' : glyphFor(node.status)}
+    </text>
+  )
 }
 
 function hashSeed(id: string): { fx: number; fy: number } {

--- a/products/openova-flow/canvas/test/FlowCanvas.test.tsx
+++ b/products/openova-flow/canvas/test/FlowCanvas.test.tsx
@@ -399,6 +399,62 @@ describe('FlowCanvas — triggeredBy banner + cross-flow nav (Agent #9)', () => 
     expect(screen.queryByTestId('flow-triggered-by-banner')).toBeNull()
   })
 
+  it('renders a Sandbox terminal-glyph SVG when meta.kind = Sandbox', () => {
+    // FlowNodes carry kind via `meta.kind` per the post-2026-05-18
+    // sandbox-node contract. The canvas swaps the bubble glyph from
+    // the legacy ○/◐/✓/✗ text-based status pip to a tabler
+    // terminal-monitor SVG so the operator can pick out sandbox
+    // bubbles at a glance — same icon as the Sovereign sidebar.
+    const sandbox: FlowNode = {
+      id: 'fsn1:sandbox:emrah-at-acme',
+      flowId: FLOW.id,
+      label: 'emrah@acme.io',
+      status: 'succeeded',
+      meta: { kind: 'Sandbox', ownerEmail: 'emrah@acme.io' },
+    }
+    render(
+      <FlowCanvas
+        flow={FLOW}
+        nodes={[sandbox]}
+        relationships={[]}
+        folded={new Set()}
+      />,
+    )
+    const glyph = screen.getByTestId(`flow-node-glyph-${sandbox.id}`)
+    expect(glyph).toBeTruthy()
+    expect(glyph.getAttribute('data-kind')).toBe('Sandbox')
+    // The bubble itself surfaces the kind via data-meta-kind for any
+    // downstream e2e selector.
+    const node = screen.getByTestId(`flow-node-${sandbox.id}`)
+    expect(node.getAttribute('data-meta-kind')).toBe('Sandbox')
+  })
+
+  it('renders a SandboxPod prompt-glyph when meta.kind = SandboxPod', () => {
+    const pod: FlowNode = {
+      id: 'fsn1:sandbox-pod:sb-emrah/pty-server-abc',
+      flowId: FLOW.id,
+      label: 'pty-server (abc)',
+      status: 'running',
+      meta: { kind: 'SandboxPod', component: 'pty-server' },
+    }
+    render(
+      <FlowCanvas flow={FLOW} nodes={[pod]} relationships={[]} folded={new Set()} />,
+    )
+    const glyph = screen.getByTestId(`flow-node-glyph-${pod.id}`)
+    expect(glyph.getAttribute('data-kind')).toBe('SandboxPod')
+  })
+
+  it('falls back to the legacy status glyph when meta.kind is absent', () => {
+    const plain: FlowNode = leaf('plain', 'succeeded')
+    render(
+      <FlowCanvas flow={FLOW} nodes={[plain]} relationships={[]} folded={new Set()} />,
+    )
+    // No glyph wrapper → the bubble renders the legacy ✓ text node.
+    expect(screen.queryByTestId(`flow-node-glyph-${plain.id}`)).toBeNull()
+    const node = screen.getByTestId(`flow-node-${plain.id}`)
+    expect(node.getAttribute('data-meta-kind')).toBe('')
+  })
+
   it('renders a cross-flow "→ flow" tag on a node whose Relationship targets another flow', () => {
     const onNavigateFlow = vi.fn()
     const nodes: FlowNode[] = [leaf('a')]


### PR DESCRIPTION
## Summary

- **Adapter (adapter-flux)**: Sandbox + sandbox-component Pod informers wire `sandbox.openova.io/v1 Sandbox` CRs and their `pty-server` / `openova-sandbox-mcp` Pods onto the openova-flow canvas. Each Sandbox renders as a bubble pulled under its tenant-org via a `contains` edge to `<region>:org:<slug>`. Pods render under their parent Sandbox (resolved via `sandbox.openova.io/name` label or `sandbox-<name>` namespace stem).
- **Canvas (FlowCanvas.tsx)**: `NodeGlyph` swaps the bubble glyph by `node.meta.kind` — `Sandbox` → terminal/monitor SVG matching the Sovereign sidebar's Sandbox nav icon; `SandboxPod` → compact "›_" prompt; otherwise the legacy ◇/✓/✗/◐/○ text glyph. Bubbles now expose `data-meta-kind` for e2e selectors.
- **Phase mapping**: Sandbox `.status.phase` `{Pending|Provisioning|Ready|Failed}` → canvas palette `{pending|running|succeeded|failed}`. Pod `CrashLoopBackOff` / `ImagePullBackOff` → `failed`; container-creating → `running`.
- **No Chart.yaml bump** — the new GVRs are reconciled in-process at the next adapter-flux DaemonSet Pod roll.

## Files

- `products/openova-flow/adapter-flux/internal/informer/sandbox_mapper.go` — new pure transform (BuildFromSandbox, BuildFromSandboxPod).
- `products/openova-flow/adapter-flux/internal/informer/hr_informer.go` — second factory + handleSandbox / handleSandboxPod handlers.
- `products/openova-flow/adapter-flux/test/sandbox_mapper_test.go` — 11 new mapper tests.
- `products/openova-flow/canvas/src/FlowCanvas.tsx` — NodeGlyph component + data-meta-kind attribute.
- `products/openova-flow/canvas/test/FlowCanvas.test.tsx` — 3 new canvas tests.

## Test plan

- [x] `go build ./...` clean across `products/openova-flow/{server,adapter-flux}`
- [x] `go vet ./...` clean (adapter-flux)
- [x] `go test ./...` GREEN — adapter-flux 22 tests (11→22), server unchanged
- [x] `tsc --noEmit -p products/openova-flow/canvas/tsconfig.json` clean
- [x] `vitest run` GREEN — canvas 25 tests (22→25)
- [ ] Smoke: after adapter-flux Pod roll on a Sovereign, create a Sandbox CR and verify a bubble appears on the deployment's flow canvas with the terminal icon, then watch pty-server Pod come up as a child bubble
- [ ] Visual: confirm the Sandbox glyph matches the Sovereign sidebar's Sandbox nav icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)