### PR TITLE
feat(sandbox): tier-bound MCP capabilities (Free/Pro/Ent plans gate tool access)

### DIFF
--- a/core/controllers/sandbox/internal/controller/sandbox_controller.go
+++ b/core/controllers/sandbox/internal/controller/sandbox_controller.go
@@ -198,11 +198,20 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 				// stable namespace/name pair.
 				sandboxID = fmt.Sprintf("%s/%s", sb.Namespace, sb.Name)
 			}
+			// Tier-bound MCP capabilities (PR #1671) — derived from
+			// spec.capabilities (operator override) or spec.planId via
+			// sandboxapi.ResolveCapabilities. Empty list is permitted by
+			// the bridge handler and produces an introspection-only
+			// token; the controller never short-circuits on a missing
+			// capability list because the operator can grant on-demand
+			// by patching spec.capabilities.
+			caps := sandboxapi.ResolveCapabilities(&sb.Spec)
 			mint, mintErr := r.NewAPIClient.MintSandboxToken(ctx, newapi.MintRequest{
 				OrgID:           sb.Spec.Owner.OrgRef.Slug,
 				UserID:          sb.Spec.Owner.Email,
 				SandboxID:       sandboxID,
 				AllowedChannels: channels,
+				Capabilities:    caps,
 			})
 			if mintErr != nil {
 				r.Log.Error(mintErr, "newapi mint failed",

--- a/core/controllers/sandbox/internal/controller/sandbox_controller_test.go
+++ b/core/controllers/sandbox/internal/controller/sandbox_controller_test.go
@@ -789,6 +789,89 @@ func TestReconcile_NewAPI_NoChannelsConfigured(t *testing.T) {
 	}
 }
 
+// TestReconcile_NewAPI_CapabilitiesFromPlan exercises the tier-bound
+// capability path (PR #1671): when the CR carries spec.planId without
+// an explicit spec.capabilities overlay, the controller resolves the
+// plan's capability allowlist and threads it into the MintRequest.
+func TestReconcile_NewAPI_CapabilitiesFromPlan(t *testing.T) {
+	t.Parallel()
+	sb := sampleSandbox()
+	sb.Spec.PlanID = sandboxapi.PlanSandboxPro
+
+	r, _ := makeReconciler(t, sb)
+	stub := &stubNewAPI{resp: newapi.MintResponse{
+		Token: "jwt-pro", ExpiresAt: time.Now().Add(7 * 24 * time.Hour),
+	}}
+	r.NewAPIClient = stub
+	r.DefaultChannels = []string{"qwen"}
+
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: sb.Name, Namespace: sb.Namespace},
+	}); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	if stub.callCount() != 1 {
+		t.Fatalf("mint calls: got %d want 1", stub.callCount())
+	}
+	gotCaps := stub.calls[0].Capabilities
+	wantSubset := []string{
+		"gitea.repo.list",     // Free baseline.
+		"sandbox.db.*",        // Pro extra.
+		"sandbox.storage.*",   // Pro extra.
+		"flux.status",         // Pro extra.
+	}
+	got := make(map[string]bool, len(gotCaps))
+	for _, c := range gotCaps {
+		got[c] = true
+	}
+	for _, w := range wantSubset {
+		if !got[w] {
+			t.Errorf("Pro plan capability %q missing from MintRequest: %v", w, gotCaps)
+		}
+	}
+	// Pro plan MUST NOT grant Ent-only capabilities.
+	for _, forbidden := range []string{
+		"sandbox.deploy.production", "sandbox.stripe.*", "flux.reconcile",
+	} {
+		if got[forbidden] {
+			t.Errorf("Pro plan unexpectedly granted Ent capability %q: %v", forbidden, gotCaps)
+		}
+	}
+}
+
+// TestReconcile_NewAPI_CapabilitiesSpecOverride asserts that an explicit
+// spec.capabilities overlay wins over the plan default — the operator
+// can tighten or widen the per-Sandbox grant by patching the CR.
+func TestReconcile_NewAPI_CapabilitiesSpecOverride(t *testing.T) {
+	t.Parallel()
+	sb := sampleSandbox()
+	sb.Spec.PlanID = sandboxapi.PlanSandboxEnt
+	// Override: drop every Ent grant down to read-only intersect.
+	sb.Spec.Capabilities = []string{"gitea.repo.list", "k8s.read.get"}
+
+	r, _ := makeReconciler(t, sb)
+	stub := &stubNewAPI{resp: newapi.MintResponse{
+		Token: "jwt-override", ExpiresAt: time.Now().Add(7 * 24 * time.Hour),
+	}}
+	r.NewAPIClient = stub
+	r.DefaultChannels = []string{"qwen"}
+
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: sb.Name, Namespace: sb.Namespace},
+	}); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	gotCaps := stub.calls[0].Capabilities
+	if len(gotCaps) != 2 {
+		t.Fatalf("override caps len: got %d (%v) want 2", len(gotCaps), gotCaps)
+	}
+	if gotCaps[0] != "gitea.repo.list" || gotCaps[1] != "k8s.read.get" {
+		t.Errorf("override caps: got %v want [gitea.repo.list k8s.read.get]", gotCaps)
+	}
+}
+
 func gsKeys(gs *giteaServer) []string {
 	gs.mu.Lock()
 	defer gs.mu.Unlock()

--- a/core/controllers/sandbox/internal/newapi/client.go
+++ b/core/controllers/sandbox/internal/newapi/client.go
@@ -63,6 +63,17 @@ type MintRequest struct {
 	// AllowedChannels is the list of NewAPI channels the issued token
 	// is restricted to. Empty rejected with 400 by the handler.
 	AllowedChannels []string `json:"allowed_channels"`
+
+	// Capabilities is the MCP capability allowlist the issued token's
+	// `capabilities` claim carries. Sourced from the Sandbox CR's
+	// spec.capabilities (falling back to the plan→capabilities map via
+	// sandboxapi.ResolveCapabilities). Encoded by the bridge handler
+	// as the JWT `capabilities` claim which `Claims.HasCapability`
+	// reads on every MCP tool call. Wildcards (`sandbox.db.*`) are
+	// supported by the matcher so this list can carry coarse grants.
+	// Empty list is allowed (downgrades the token to the introspection
+	// surface only, matching a pre-PR-#1671 token).
+	Capabilities []string `json:"capabilities,omitempty"`
 }
 
 // MintResponse is the wire body for the 200 OK reply.

--- a/core/controllers/sandbox/internal/sandboxapi/capabilities.go
+++ b/core/controllers/sandbox/internal/sandboxapi/capabilities.go
@@ -1,0 +1,179 @@
+// capabilities.go — plan→MCP-capabilities map for the Sandbox CR.
+//
+// The sandbox-controller stamps the resolved capability allowlist onto
+// every minted NewAPI token; the MCP server's tools.Registry gates each
+// tool call against the bearer's Claims.Capabilities via
+// HasCapability (architecture.md §3 RBAC).
+//
+// This file is the source of truth for the plan-to-capability shape.
+// `core/services/tenant/handlers/sandbox_consumer.go` carries an exact
+// duplicate (`capabilitiesForPlan`) so the tenant-service has no
+// compile-time dep on the controllers module (same isolation pattern
+// `quotaForPlan` already uses). If either side changes, the other MUST
+// change in the same PR.
+//
+// Plan ladder (matches catalog seed `expectedSandboxPlans`):
+//
+//   - sandbox-free: read-only k8s + gitea read + session/rag/skills.
+//   - sandbox-pro:  Free + sandbox.db.* + sandbox.storage.* +
+//     sandbox.preview.* + sandbox.auth.* + sandbox.secrets.* +
+//     marketplace.* + flux.status.
+//   - sandbox-ent:  Pro + sandbox.deploy.{staging,production} +
+//     sandbox.stripe.* + flux.{reconcile,suspend,resume} +
+//     gitea.pr.{create,merge} + gitea.issue.*.
+//
+// An unknown / empty plan slug falls through to the Free shape so a
+// misconfigured CR never silently inherits Pro/Ent grants.
+//
+// Wildcards (`sandbox.db.*`) are honoured by the MCP server's
+// HasCapability matcher (products/sandbox/mcp-server/internal/tools/
+// registry.go via Claims.HasCapability extension). The plan map can
+// therefore carry coarse grants without enumerating every per-tool
+// capability string.
+
+package sandboxapi
+
+import "strings"
+
+// Plan slugs (mirrors core/services/catalog/handlers/seed.go).
+const (
+	PlanSandboxFree = "sandbox-free"
+	PlanSandboxPro  = "sandbox-pro"
+	PlanSandboxEnt  = "sandbox-ent"
+)
+
+// freePlanCapabilities is the read-only-by-default surface every
+// Sandbox owner gets. Sized to let the agent discover the namespace,
+// browse repos + PRs + issues, pull logs/objects, and ask the
+// session-introspection tools who they are. NO write surface; NO
+// per-Sandbox provisioning (db / storage / preview / deploy / stripe).
+var freePlanCapabilities = []string{
+	// gitea read surface.
+	"gitea.repo.list",
+	"gitea.repo.get",
+	"gitea.pr.list",
+	"gitea.pr.get",
+
+	// k8s read surface (Org vcluster only — the MCP server's tool
+	// implementations reject any GVK/namespace outside the Sandbox's
+	// vcluster regardless of this grant).
+	"k8s.read.get",
+	"k8s.read.list",
+
+	// Session introspection — the MCP server's exempt-from-org-scope
+	// allowlist also covers these tools but the capability gate runs
+	// FIRST, so we still need an explicit grant.
+	"sandbox.session.*",
+
+	// RAG + skills catalogue (read-only).
+	"rag.search",
+	"skills.list",
+	"skills.get",
+}
+
+// proPlanCapabilities extends Free with the per-Sandbox provisioning
+// surface (db, storage, preview, auth, secrets) + marketplace domain
+// reservation + Flux read-only status.
+var proPlanCapabilities = func() []string {
+	out := make([]string, 0, len(freePlanCapabilities)+16)
+	out = append(out, freePlanCapabilities...)
+	out = append(out,
+		// Per-Sandbox provisioning (mutating in the Sandbox's own
+		// vcluster namespace only — the MCP server scopes every call
+		// to env.SandboxNamespace).
+		"sandbox.db.*",
+		"sandbox.storage.*",
+		"sandbox.preview.*",
+		"sandbox.auth.*",
+		"sandbox.secrets.*",
+
+		// Marketplace domain reservation (proxied to core/services/domain;
+		// the canonical auth + WHOIS + uniqueness checks live there).
+		"marketplace.*",
+
+		// Flux: read-only status only at Pro. Reconcile/suspend/resume
+		// are mutating ops on tenant HRs — Ent-tier.
+		"flux.status",
+	)
+	return out
+}()
+
+// entPlanCapabilities extends Pro with the staging+production deploy
+// surface, Stripe binding, Flux mutating ops, and the gitea write
+// surface (PR create/merge + issue create/comment).
+var entPlanCapabilities = func() []string {
+	out := make([]string, 0, len(proPlanCapabilities)+12)
+	out = append(out, proPlanCapabilities...)
+	out = append(out,
+		// Staging + production deploys via Flux HelmReleases written
+		// to the tenant Gitea repo. The MCP server's deploy.production
+		// handler ALSO gates on a second capability
+		// `sandbox.deploy.production` so Ent operators can issue staging
+		// PATs scoped to staging-only by dropping the production grant.
+		"sandbox.deploy.staging",
+		"sandbox.deploy.production",
+		"sandbox.deploy.status",
+		"sandbox.deploy.rollback",
+
+		// Stripe — bound to the Sandbox's own Secret store; per-call
+		// outbound to api.stripe.com.
+		"sandbox.stripe.*",
+
+		// Flux mutating ops on tenant-scoped HRs / Kustomizations. The
+		// MCP server's dynamic client RBAC also gates which namespaces
+		// the SA can patch.
+		"flux.reconcile",
+		"flux.suspend",
+		"flux.resume",
+
+		// Gitea write surface — PR open/merge + issue lifecycle.
+		"gitea.pr.create",
+		"gitea.pr.merge",
+		"gitea.issue.*",
+	)
+	return out
+}()
+
+// CapabilitiesForPlan returns the MCP capability allowlist a freshly
+// minted Sandbox token should carry given the customer-picked plan
+// slug. Unknown / empty plan slug falls through to the Free shape so
+// every Sandbox always carries at least the read-only surface.
+//
+// The returned slice is a fresh copy on every call — callers may
+// append/mutate without affecting the package-level templates.
+func CapabilitiesForPlan(planID string) []string {
+	switch strings.TrimSpace(planID) {
+	case PlanSandboxEnt:
+		return append([]string(nil), entPlanCapabilities...)
+	case PlanSandboxPro:
+		return append([]string(nil), proPlanCapabilities...)
+	case PlanSandboxFree:
+		return append([]string(nil), freePlanCapabilities...)
+	default:
+		return append([]string(nil), freePlanCapabilities...)
+	}
+}
+
+// ResolveCapabilities returns the effective capability allowlist for a
+// Sandbox CR — the explicit spec.capabilities when non-empty,
+// otherwise the plan-derived default via CapabilitiesForPlan. The
+// returned slice is always a fresh copy.
+func ResolveCapabilities(spec *SandboxSpec) []string {
+	if spec == nil {
+		return CapabilitiesForPlan("")
+	}
+	if len(spec.Capabilities) > 0 {
+		out := make([]string, 0, len(spec.Capabilities))
+		for _, c := range spec.Capabilities {
+			c = strings.TrimSpace(c)
+			if c == "" {
+				continue
+			}
+			out = append(out, c)
+		}
+		if len(out) > 0 {
+			return out
+		}
+	}
+	return CapabilitiesForPlan(spec.PlanID)
+}

--- a/core/controllers/sandbox/internal/sandboxapi/capabilities_test.go
+++ b/core/controllers/sandbox/internal/sandboxapi/capabilities_test.go
@@ -1,0 +1,175 @@
+// capabilities_test.go — coverage for the plan→MCP-capabilities map +
+// ResolveCapabilities. The tenant orchestrator carries an exact
+// duplicate of CapabilitiesForPlan so the assertions here pin the
+// shape both call-sites must agree on.
+
+package sandboxapi
+
+import (
+	"sort"
+	"testing"
+)
+
+// containsAll returns true when every entry in `want` appears in `have`.
+func containsAll(have, want []string) bool {
+	idx := make(map[string]struct{}, len(have))
+	for _, h := range have {
+		idx[h] = struct{}{}
+	}
+	for _, w := range want {
+		if _, ok := idx[w]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func TestCapabilitiesForPlan_Shape(t *testing.T) {
+	free := CapabilitiesForPlan(PlanSandboxFree)
+	pro := CapabilitiesForPlan(PlanSandboxPro)
+	ent := CapabilitiesForPlan(PlanSandboxEnt)
+
+	// Every plan carries the read-only Free baseline (the agent can
+	// always discover what it sees).
+	freeBaseline := []string{
+		"gitea.repo.list", "gitea.repo.get", "gitea.pr.list", "gitea.pr.get",
+		"k8s.read.get", "k8s.read.list",
+		"sandbox.session.*",
+		"rag.search", "skills.list", "skills.get",
+	}
+	for _, plan := range [][]string{free, pro, ent} {
+		if !containsAll(plan, freeBaseline) {
+			t.Errorf("plan missing Free baseline: %v", plan)
+		}
+	}
+
+	// Free MUST NOT carry any write or per-Sandbox provisioning grant.
+	forbiddenOnFree := []string{
+		"sandbox.db.*", "sandbox.storage.*", "sandbox.preview.*",
+		"sandbox.deploy.staging", "sandbox.deploy.production",
+		"sandbox.stripe.*", "marketplace.*",
+		"flux.reconcile", "flux.suspend", "flux.resume",
+		"gitea.pr.create", "gitea.pr.merge", "gitea.issue.*",
+	}
+	freeSet := make(map[string]struct{}, len(free))
+	for _, c := range free {
+		freeSet[c] = struct{}{}
+	}
+	for _, bad := range forbiddenOnFree {
+		if _, ok := freeSet[bad]; ok {
+			t.Errorf("Free plan unexpectedly grants %q", bad)
+		}
+	}
+
+	// Pro extends Free with the per-Sandbox provisioning surface.
+	proExtras := []string{
+		"sandbox.db.*", "sandbox.storage.*", "sandbox.preview.*",
+		"sandbox.auth.*", "sandbox.secrets.*", "marketplace.*",
+		"flux.status",
+	}
+	if !containsAll(pro, proExtras) {
+		t.Errorf("Pro plan missing extras %v: %v", proExtras, pro)
+	}
+	// Pro MUST NOT carry Ent-only deploy/stripe/flux-mutation grants.
+	forbiddenOnPro := []string{
+		"sandbox.deploy.staging", "sandbox.deploy.production",
+		"sandbox.stripe.*",
+		"flux.reconcile", "flux.suspend", "flux.resume",
+		"gitea.pr.create", "gitea.pr.merge", "gitea.issue.*",
+	}
+	proSet := make(map[string]struct{}, len(pro))
+	for _, c := range pro {
+		proSet[c] = struct{}{}
+	}
+	for _, bad := range forbiddenOnPro {
+		if _, ok := proSet[bad]; ok {
+			t.Errorf("Pro plan unexpectedly grants %q", bad)
+		}
+	}
+
+	// Ent extends Pro with the deploy / stripe / flux-mutation / gitea-write surface.
+	entExtras := []string{
+		"sandbox.deploy.staging", "sandbox.deploy.production",
+		"sandbox.deploy.status", "sandbox.deploy.rollback",
+		"sandbox.stripe.*",
+		"flux.reconcile", "flux.suspend", "flux.resume",
+		"gitea.pr.create", "gitea.pr.merge", "gitea.issue.*",
+	}
+	if !containsAll(ent, entExtras) {
+		t.Errorf("Ent plan missing extras %v: %v", entExtras, ent)
+	}
+
+	// Unknown plan slug falls through to Free.
+	unknown := CapabilitiesForPlan("sandbox-xxl")
+	sort.Strings(unknown)
+	sortedFree := append([]string(nil), free...)
+	sort.Strings(sortedFree)
+	if len(unknown) != len(sortedFree) {
+		t.Errorf("unknown plan length=%d want %d", len(unknown), len(sortedFree))
+	}
+	for i := range unknown {
+		if unknown[i] != sortedFree[i] {
+			t.Errorf("unknown[%d]=%q want %q", i, unknown[i], sortedFree[i])
+		}
+	}
+
+	// Empty slug behaves identically.
+	if got := CapabilitiesForPlan(""); !containsAll(got, freeBaseline) {
+		t.Errorf("empty plan missing free baseline: %v", got)
+	}
+}
+
+func TestCapabilitiesForPlan_ReturnsFreshSlice(t *testing.T) {
+	// Mutating the returned slice MUST NOT poison the package-level
+	// template — callers (controller, orchestrator) trim or append in
+	// place.
+	first := CapabilitiesForPlan(PlanSandboxPro)
+	first[0] = "MUTATED"
+	second := CapabilitiesForPlan(PlanSandboxPro)
+	if second[0] == "MUTATED" {
+		t.Fatalf("CapabilitiesForPlan leaks a shared backing array: second=%v", second)
+	}
+}
+
+func TestResolveCapabilities_PrefersSpecOverride(t *testing.T) {
+	spec := &SandboxSpec{
+		PlanID:       PlanSandboxFree,
+		Capabilities: []string{"sandbox.db.*", "k8s.read.list", " ", ""},
+	}
+	got := ResolveCapabilities(spec)
+	// Whitespace + empty entries are stripped.
+	for _, c := range got {
+		if c == "" || c == " " {
+			t.Errorf("ResolveCapabilities leaked empty entry: %v", got)
+		}
+	}
+	// Spec override wins over the plan default.
+	if len(got) != 2 || got[0] != "sandbox.db.*" || got[1] != "k8s.read.list" {
+		t.Errorf("ResolveCapabilities did not honour spec override: %v", got)
+	}
+}
+
+func TestResolveCapabilities_FallsBackToPlan(t *testing.T) {
+	spec := &SandboxSpec{PlanID: PlanSandboxPro}
+	got := ResolveCapabilities(spec)
+	if !containsAll(got, []string{"sandbox.db.*", "sandbox.storage.*"}) {
+		t.Errorf("fallback to plan default missing Pro grants: %v", got)
+	}
+}
+
+func TestResolveCapabilities_NilSpec(t *testing.T) {
+	got := ResolveCapabilities(nil)
+	if !containsAll(got, []string{"gitea.repo.list", "rag.search"}) {
+		t.Errorf("nil spec did not return Free baseline: %v", got)
+	}
+}
+
+func TestResolveCapabilities_EmptySpecCapsFallsBack(t *testing.T) {
+	// Empty spec.Capabilities (e.g. only whitespace) MUST NOT lock out
+	// the bearer — fall through to plan default.
+	spec := &SandboxSpec{PlanID: PlanSandboxEnt, Capabilities: []string{"  ", ""}}
+	got := ResolveCapabilities(spec)
+	if !containsAll(got, []string{"sandbox.deploy.production"}) {
+		t.Errorf("whitespace-only override did not fall back to plan default: %v", got)
+	}
+}

--- a/core/controllers/sandbox/internal/sandboxapi/types.go
+++ b/core/controllers/sandbox/internal/sandboxapi/types.go
@@ -60,6 +60,23 @@ type SandboxSpec struct {
 	Repos          []SandboxRepo  `json:"repos,omitempty"`
 	AgentCatalogue []string       `json:"agentCatalogue,omitempty"`
 	PreviewDomain  string         `json:"previewDomain,omitempty"`
+
+	// PlanID is the catalog plan slug the customer selected
+	// (`sandbox-free` | `sandbox-pro` | `sandbox-ent`). Stamped by the
+	// tenant-service orchestrator from the `tenant.sandbox_requested`
+	// event. The sandbox-controller falls back to this when
+	// spec.capabilities is empty so the operator gets the plan's
+	// default capability allowlist without an explicit overlay.
+	PlanID string `json:"planId,omitempty"`
+
+	// Capabilities is the MCP capability allowlist the
+	// sandbox-controller stamps onto every minted NewAPI token. The
+	// MCP server gates every tool call against these strings via
+	// Claims.HasCapability (architecture.md §3 RBAC). Empty list →
+	// the controller derives the list from spec.planId via
+	// CapabilitiesForPlan. Wildcards (`sandbox.db.*`) are honoured
+	// by the matcher so the plan map can carry coarse grants.
+	Capabilities []string `json:"capabilities,omitempty"`
 }
 
 // SandboxOwner is spec.owner.
@@ -161,6 +178,10 @@ func (s *SandboxSpec) DeepCopyInto(out *SandboxSpec) {
 	if s.AgentCatalogue != nil {
 		out.AgentCatalogue = make([]string, len(s.AgentCatalogue))
 		copy(out.AgentCatalogue, s.AgentCatalogue)
+	}
+	if s.Capabilities != nil {
+		out.Capabilities = make([]string, len(s.Capabilities))
+		copy(out.Capabilities, s.Capabilities)
 	}
 }
 

--- a/core/services/shared/auth/claims.go
+++ b/core/services/shared/auth/claims.go
@@ -137,13 +137,48 @@ type Claims struct {
 //
 // Returns false on a nil receiver so unauthenticated request paths can
 // `if claims.HasCapability("...")` without a nil check.
+//
+// Match rules (PR #1671 — tier-bound MCP capabilities):
+//
+//  1. Exact match. `sandbox.db.provision` (held) satisfies
+//     `sandbox.db.provision` (want).
+//  2. Wildcard prefix. A held capability ending in `.*` matches the
+//     stem AND every dotted-prefix descendant. `sandbox.db.*` (held)
+//     satisfies `sandbox.db`, `sandbox.db.provision`,
+//     `sandbox.db.list`, … (want).
+//
+// Stem matches WITHOUT a trailing wildcard are intentionally NOT
+// honoured — a token carrying `sandbox.deploy` does NOT open
+// `sandbox.deploy.production`. This keeps the second-gate pattern in
+// sandbox_deploy.go (the Ent-tier production check) honest: callers
+// must hold the granular `sandbox.deploy.production` capability or a
+// wildcard that explicitly covers it.
 func (c *Claims) HasCapability(want string) bool {
-	if c == nil {
+	if c == nil || want == "" {
 		return false
 	}
 	for _, got := range c.Capabilities {
+		if got == "" {
+			continue
+		}
+		// Exact match — fast-path.
 		if got == want {
 			return true
+		}
+		// Wildcard prefix: `sandbox.db.*` matches `sandbox.db` AND
+		// `sandbox.db.<anything>`. Strip the trailing `.*` once for
+		// the dotted-prefix check.
+		if len(got) >= 2 && got[len(got)-2:] == ".*" {
+			stem := got[:len(got)-2]
+			if stem == "" {
+				continue
+			}
+			if want == stem {
+				return true
+			}
+			if len(want) > len(stem) && want[:len(stem)] == stem && want[len(stem)] == '.' {
+				return true
+			}
 		}
 	}
 	return false

--- a/core/services/shared/auth/claims_test.go
+++ b/core/services/shared/auth/claims_test.go
@@ -1,0 +1,75 @@
+// claims_test.go — table-driven coverage for Claims.HasCapability,
+// extended in PR #1671 to honour wildcard prefixes (`sandbox.db.*`)
+// so tier-bound MCP capability grants can be coarse without
+// enumerating every per-tool RequiredCapability.
+
+package auth
+
+import "testing"
+
+func TestClaims_HasCapability_ExactAndWildcard(t *testing.T) {
+	cases := []struct {
+		name string
+		held []string
+		want string
+		ok   bool
+	}{
+		{"nil-claims-rejects", nil, "sandbox.db.provision", false},
+		{"empty-want-rejects", []string{"sandbox.db.*"}, "", false},
+		{"empty-held-rejects", []string{""}, "sandbox.db.provision", false},
+
+		// Exact match.
+		{"exact-match", []string{"sandbox.db.provision"}, "sandbox.db.provision", true},
+		{"exact-miss", []string{"sandbox.db.provision"}, "sandbox.db.list", false},
+
+		// Wildcard prefix matches the stem.
+		{"wildcard-matches-stem", []string{"sandbox.db.*"}, "sandbox.db", true},
+		// Wildcard prefix matches dotted descendants.
+		{"wildcard-matches-descendant", []string{"sandbox.db.*"}, "sandbox.db.provision", true},
+		{"wildcard-matches-deep-descendant", []string{"sandbox.db.*"}, "sandbox.db.list.x", true},
+
+		// Wildcard prefix does NOT match an unrelated namespace.
+		{"wildcard-isolated-namespace", []string{"sandbox.db.*"}, "sandbox.deploy.production", false},
+		// Wildcard does NOT match a name that shares a prefix-string but
+		// crosses the dotted-component boundary (`sandbox.db` vs
+		// `sandbox.dbz`).
+		{"wildcard-boundary-respected", []string{"sandbox.db.*"}, "sandbox.dbz.provision", false},
+
+		// Plain stem (no `.*`) does NOT widen to descendants — the
+		// production gate in sandbox_deploy.go depends on this.
+		{"plain-stem-no-widen", []string{"sandbox.deploy"}, "sandbox.deploy.production", false},
+		// …but the same plain stem still matches itself.
+		{"plain-stem-exact-self", []string{"sandbox.deploy"}, "sandbox.deploy", true},
+
+		// Multiple held caps — first-hit wins.
+		{
+			"multiple-held-first-wins",
+			[]string{"k8s.read.get", "sandbox.db.*"},
+			"sandbox.db.list",
+			true,
+		},
+		{
+			"multiple-held-none-match",
+			[]string{"k8s.read.get", "rag.search"},
+			"sandbox.deploy.production",
+			false,
+		},
+
+		// `*` alone (no leading stem) is a malformed grant and MUST NOT
+		// open every namespace.
+		{"bare-wildcard-rejects", []string{"*"}, "sandbox.deploy.production", false},
+		{"bare-dotwildcard-rejects", []string{".*"}, "sandbox.deploy.production", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var c *Claims
+			if tc.name != "nil-claims-rejects" {
+				c = &Claims{Capabilities: tc.held}
+			}
+			if got := c.HasCapability(tc.want); got != tc.ok {
+				t.Errorf("HasCapability(held=%v, want=%q) = %v, want %v",
+					tc.held, tc.want, got, tc.ok)
+			}
+		})
+	}
+}

--- a/core/services/tenant/handlers/sandbox_consumer.go
+++ b/core/services/tenant/handlers/sandbox_consumer.go
@@ -301,6 +301,21 @@ func (o *SandboxOrchestrator) buildSandbox(name, ns, email string, p SandboxRequ
 	if strings.TrimSpace(p.PlanID) != "" {
 		spec["planId"] = strings.TrimSpace(p.PlanID)
 	}
+	// PR #1671 — tier-bound MCP capabilities. Stamp the plan-derived
+	// allowlist onto spec.capabilities so the sandbox-controller threads
+	// it into the per-Sandbox NewAPI token's `capabilities` claim. The
+	// controller falls back to its own ResolveCapabilities helper when
+	// this field is absent (e.g. CR created by hand), so this stamp is
+	// belt-and-suspenders — surfacing the resolved list on the CR makes
+	// the operator's `kubectl get sandbox -o yaml` self-documenting.
+	caps := capabilitiesForPlan(p.PlanID)
+	if len(caps) > 0 {
+		out := make([]any, 0, len(caps))
+		for _, c := range caps {
+			out = append(out, c)
+		}
+		spec["capabilities"] = out
+	}
 	if len(p.Agents) > 0 {
 		// Copy into []any so json.Marshal renders a plain JSON list
 		// rather than a typed []string (unstructured accepts both but
@@ -381,6 +396,73 @@ func sandboxCRName(email, ownerID string) string {
 	}
 	name = strings.TrimRight(name, "-")
 	return name
+}
+
+// capabilitiesForPlan maps a catalog Sandbox plan slug to the MCP
+// capability allowlist the orchestrator stamps on spec.capabilities.
+//
+// Mirror of sandboxapi.CapabilitiesForPlan in
+// core/controllers/sandbox/internal/sandboxapi/capabilities.go —
+// duplicated here for the SAME reason quotaForPlan is duplicated
+// (tenant-service has no compile-time dep on the controllers module
+// to keep the dep graph free of controller-runtime). If either side
+// changes, the other MUST change in the same PR.
+//
+// Plan ladder:
+//
+//   - sandbox-free: read-only k8s + gitea read + session/rag/skills
+//   - sandbox-pro:  Free + sandbox.db.* + sandbox.storage.* +
+//     sandbox.preview.* + sandbox.auth.* + sandbox.secrets.* +
+//     marketplace.* + flux.status
+//   - sandbox-ent:  Pro + sandbox.deploy.{staging,production,status,rollback}
+//     + sandbox.stripe.* + flux.{reconcile,suspend,resume} +
+//     gitea.pr.{create,merge} + gitea.issue.*
+//
+// Unknown / empty plan slug falls through to the Free shape so a
+// misconfigured event never silently inherits Pro/Ent grants.
+func capabilitiesForPlan(planID string) []string {
+	free := []string{
+		"gitea.repo.list",
+		"gitea.repo.get",
+		"gitea.pr.list",
+		"gitea.pr.get",
+		"k8s.read.get",
+		"k8s.read.list",
+		"sandbox.session.*",
+		"rag.search",
+		"skills.list",
+		"skills.get",
+	}
+	switch strings.TrimSpace(planID) {
+	case "sandbox-ent":
+		out := make([]string, 0, len(free)+24)
+		out = append(out, free...)
+		out = append(out,
+			// Pro tier additions:
+			"sandbox.db.*", "sandbox.storage.*", "sandbox.preview.*",
+			"sandbox.auth.*", "sandbox.secrets.*", "marketplace.*",
+			"flux.status",
+			// Ent tier additions:
+			"sandbox.deploy.staging", "sandbox.deploy.production",
+			"sandbox.deploy.status", "sandbox.deploy.rollback",
+			"sandbox.stripe.*",
+			"flux.reconcile", "flux.suspend", "flux.resume",
+			"gitea.pr.create", "gitea.pr.merge", "gitea.issue.*",
+		)
+		return out
+	case "sandbox-pro":
+		out := make([]string, 0, len(free)+8)
+		out = append(out, free...)
+		out = append(out,
+			"sandbox.db.*", "sandbox.storage.*", "sandbox.preview.*",
+			"sandbox.auth.*", "sandbox.secrets.*", "marketplace.*",
+			"flux.status",
+		)
+		return out
+	default:
+		// sandbox-free + unknown/empty fall through to Free shape.
+		return free
+	}
 }
 
 // quotaForPlan maps a catalog Sandbox plan slug to the SandboxQuota the

--- a/core/services/tenant/handlers/sandbox_consumer_test.go
+++ b/core/services/tenant/handlers/sandbox_consumer_test.go
@@ -481,3 +481,117 @@ func TestSandboxCRName_PathologicalEmpty(t *testing.T) {
 		t.Fatalf("want sandbox-user, got %q", got)
 	}
 }
+
+// TestCapabilitiesForPlan_Mirror locks the tenant orchestrator's mirror
+// of sandboxapi.CapabilitiesForPlan against the documented per-plan
+// shape (PR #1671). The controllers-module version
+// (core/controllers/sandbox/internal/sandboxapi/capabilities_test.go)
+// MUST stay in lockstep — both implementations are wired into the
+// Sandbox CR's spec.capabilities and the per-Sandbox NewAPI token.
+func TestCapabilitiesForPlan_Mirror(t *testing.T) {
+	free := capabilitiesForPlan("sandbox-free")
+	pro := capabilitiesForPlan("sandbox-pro")
+	ent := capabilitiesForPlan("sandbox-ent")
+
+	// Free baseline appears on every plan.
+	for _, plan := range [][]string{free, pro, ent} {
+		if !containsString(plan, "gitea.repo.list") || !containsString(plan, "sandbox.session.*") {
+			t.Errorf("plan missing free baseline: %v", plan)
+		}
+	}
+
+	// Free MUST NOT grant write or per-Sandbox provisioning.
+	for _, forbidden := range []string{
+		"sandbox.db.*", "sandbox.deploy.production", "sandbox.stripe.*", "marketplace.*",
+	} {
+		if containsString(free, forbidden) {
+			t.Errorf("Free plan unexpectedly grants %q", forbidden)
+		}
+	}
+
+	// Pro adds the per-Sandbox provisioning surface.
+	for _, want := range []string{"sandbox.db.*", "sandbox.storage.*", "marketplace.*", "flux.status"} {
+		if !containsString(pro, want) {
+			t.Errorf("Pro plan missing %q: %v", want, pro)
+		}
+	}
+	// Pro MUST NOT grant Ent-only deploy/stripe/flux-mutation.
+	for _, forbidden := range []string{
+		"sandbox.deploy.production", "sandbox.stripe.*", "flux.reconcile", "gitea.pr.create",
+	} {
+		if containsString(pro, forbidden) {
+			t.Errorf("Pro plan unexpectedly grants %q", forbidden)
+		}
+	}
+
+	// Ent adds the deploy/stripe/flux-mutation/gitea-write surface.
+	for _, want := range []string{
+		"sandbox.deploy.production", "sandbox.stripe.*", "flux.reconcile", "gitea.pr.create",
+		"gitea.issue.*",
+	} {
+		if !containsString(ent, want) {
+			t.Errorf("Ent plan missing %q: %v", want, ent)
+		}
+	}
+
+	// Unknown plan slug falls through to Free.
+	unknown := capabilitiesForPlan("sandbox-xxl")
+	if !containsString(unknown, "gitea.repo.list") || containsString(unknown, "sandbox.db.*") {
+		t.Errorf("unknown plan should fall back to Free: %v", unknown)
+	}
+}
+
+// TestSandboxHandle_StampsCapabilities asserts the orchestrator writes
+// the plan-derived MCP capability allowlist into spec.capabilities so
+// `kubectl get sandbox -o yaml` is self-documenting and the
+// sandbox-controller's ResolveCapabilities helper can read it directly
+// without re-deriving from spec.planId.
+func TestSandboxHandle_StampsCapabilities(t *testing.T) {
+	client := &fakeSandboxClient{getErr: notFoundErr()}
+	o := &SandboxOrchestrator{Client: client}
+	evt := mkSandboxRequestedEvent(t, SandboxRequestedPayload{
+		TenantID:   "tenant-1",
+		OrgSlug:    "acme",
+		OwnerID:    "u-1",
+		OwnerEmail: "ceo@acme.com",
+		PlanID:     "sandbox-pro",
+	})
+	if err := o.handleSandboxRequested(context.Background(), evt); err != nil {
+		t.Fatalf("handleSandboxRequested: %v", err)
+	}
+	got := client.createObjs[0]
+	spec, _ := got.Object["spec"].(map[string]any)
+	caps, ok := spec["capabilities"].([]any)
+	if !ok || len(caps) == 0 {
+		t.Fatalf("spec.capabilities missing or empty: %#v", spec["capabilities"])
+	}
+	gotSet := make(map[string]bool, len(caps))
+	for _, v := range caps {
+		if s, ok := v.(string); ok {
+			gotSet[s] = true
+		}
+	}
+	// Spot-check Pro grants.
+	for _, want := range []string{"gitea.repo.list", "sandbox.db.*", "marketplace.*"} {
+		if !gotSet[want] {
+			t.Errorf("spec.capabilities missing Pro grant %q: %v", want, caps)
+		}
+	}
+	// And confirm Ent-only grants are NOT stamped.
+	for _, forbidden := range []string{"sandbox.stripe.*", "sandbox.deploy.production"} {
+		if gotSet[forbidden] {
+			t.Errorf("Pro Sandbox unexpectedly has Ent grant %q", forbidden)
+		}
+	}
+}
+
+// containsString — local helper (kept in this file so the tenant test
+// file has no implicit dep on a shared helper package).
+func containsString(in []string, want string) bool {
+	for _, s := range in {
+		if s == want {
+			return true
+		}
+	}
+	return false
+}

--- a/platform/newapi/internal/handler/sandbox_token.go
+++ b/platform/newapi/internal/handler/sandbox_token.go
@@ -148,6 +148,17 @@ type sandboxTokenRequest struct {
 	// may target. Empty list is rejected (a Sandbox with no channels
 	// cannot reach an LLM, almost always a misconfiguration).
 	AllowedChannels []string `json:"allowed_channels"`
+
+	// Capabilities — MCP capability allowlist that ends up as the JWT
+	// `capabilities` claim. The sandbox-controller derives this from the
+	// per-Sandbox CR's spec.capabilities (falling back to a plan→caps
+	// map via sandboxapi.ResolveCapabilities). The MCP server's
+	// `Claims.HasCapability` matcher reads it on every tool call.
+	// Wildcards (`sandbox.db.*`) are honoured by the matcher so a Pro
+	// plan's grants can stay coarse without enumerating every per-tool
+	// RequiredCapability. Empty list is allowed — produces a token with
+	// no MCP write surface (intentional fallback for pre-PR-#1671 callers).
+	Capabilities []string `json:"capabilities,omitempty"`
 }
 
 // sandboxTokenResponse is what POST /admin/tokens/sandbox returns.
@@ -266,6 +277,24 @@ func (h *Handler) SandboxToken(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Capabilities: empty list is permitted (downgrades the token to
+	// the introspection-only surface, matching pre-PR-#1671 callers).
+	// Trim + de-dup so a controller bug that double-stamps a wildcard
+	// doesn't bloat the JWT.
+	cleanedCaps := make([]string, 0, len(req.Capabilities))
+	seenCap := make(map[string]struct{}, len(req.Capabilities))
+	for _, c := range req.Capabilities {
+		c = strings.TrimSpace(c)
+		if c == "" {
+			continue
+		}
+		if _, ok := seenCap[c]; ok {
+			continue
+		}
+		seenCap[c] = struct{}{}
+		cleanedCaps = append(cleanedCaps, c)
+	}
+
 	// ── 3. Mint HS256 token ─────────────────────────────────────────────
 	now := time.Now
 	if h.Now != nil {
@@ -274,12 +303,13 @@ func (h *Handler) SandboxToken(w http.ResponseWriter, r *http.Request) {
 	issuedAt := now()
 	exp := issuedAt.Add(SandboxTokenTTL)
 	tok, err := mintSandboxToken(h.SigningKey, sandboxClaims{
-		Sub:      req.SandboxID,
-		Org:      req.OrgID,
-		User:     req.UserID,
-		Channels: cleaned,
-		IssuedAt: issuedAt,
-		ExpireAt: exp,
+		Sub:          req.SandboxID,
+		Org:          req.OrgID,
+		User:         req.UserID,
+		Channels:     cleaned,
+		Capabilities: cleanedCaps,
+		IssuedAt:     issuedAt,
+		ExpireAt:     exp,
 	})
 	if err != nil {
 		h.logSafe("sandbox-token: mint failed", "err", err.Error())
@@ -295,6 +325,7 @@ func (h *Handler) SandboxToken(w http.ResponseWriter, r *http.Request) {
 		"org_id", req.OrgID,
 		"user_id", req.UserID,
 		"channels", strings.Join(cleaned, ","),
+		"capabilities_count", len(cleanedCaps),
 		"expires_at", exp.Format(time.RFC3339),
 	)
 
@@ -309,17 +340,25 @@ func (h *Handler) SandboxToken(w http.ResponseWriter, r *http.Request) {
 // separate from sandboxTokenRequest so the wire shape can evolve
 // without changing how we lay out the JWT.
 type sandboxClaims struct {
-	Sub      string
-	Org      string
-	User     string
-	Channels []string
-	IssuedAt time.Time
-	ExpireAt time.Time
+	Sub          string
+	Org          string
+	User         string
+	Channels     []string
+	Capabilities []string
+	IssuedAt     time.Time
+	ExpireAt     time.Time
 }
 
 // mintSandboxToken signs an HS256 JWT with the documented claim shape.
 // Exposed as a package-private function so the unit test can verify
 // the round-trip without invoking the HTTP handler.
+//
+// The `capabilities` claim is the tier-bound MCP allowlist the MCP
+// server reads on every tool call via Claims.HasCapability (PR #1671).
+// An empty list is encoded as an absent claim — the MCP server's
+// HasCapability matcher returns false on every check, which downgrades
+// the bearer to the introspection surface only (the registry's
+// RequiredCapability-empty tools).
 func mintSandboxToken(secret []byte, c sandboxClaims) (string, error) {
 	if len(secret) == 0 {
 		return "", errors.New("signing key empty")
@@ -332,6 +371,9 @@ func mintSandboxToken(secret []byte, c sandboxClaims) (string, error) {
 		"iat":      c.IssuedAt.Unix(),
 		"exp":      c.ExpireAt.Unix(),
 		"typ":      SandboxTokenType,
+	}
+	if len(c.Capabilities) > 0 {
+		claims["capabilities"] = c.Capabilities
 	}
 	t := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
 	out, err := t.SignedString(secret)

--- a/platform/newapi/internal/handler/sandbox_token_test.go
+++ b/platform/newapi/internal/handler/sandbox_token_test.go
@@ -246,6 +246,76 @@ func TestMintSandboxToken_RoundTrip(t *testing.T) {
 	}
 }
 
+// PR #1671 — tier-bound MCP capabilities. The bridge handler accepts a
+// `capabilities` field on the request body and encodes it as the JWT
+// `capabilities` claim the MCP server reads via Claims.HasCapability.
+// Empty / missing field is permitted (downgrades the token to the
+// introspection-only surface).
+func TestSandboxToken_CapabilitiesRoundTrip(t *testing.T) {
+	h := newTestHandler()
+	body := `{
+		"org_id": "acme",
+		"user_id": "ceo@acme.com",
+		"sandbox_id": "sb-uid-1",
+		"allowed_channels": ["qwen"],
+		"capabilities": ["sandbox.db.*", "gitea.repo.list", "  ", "sandbox.db.*", ""]
+	}`
+	rr := doRequest(t, h, http.MethodPost, body, string(h.AdminSecret))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status: got %d want 200, body=%s", rr.Code, rr.Body.String())
+	}
+	var resp sandboxTokenResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	parsed, err := jwt.Parse(resp.Token, func(*jwt.Token) (any, error) { return h.SigningKey, nil })
+	if err != nil || !parsed.Valid {
+		t.Fatalf("parse: err=%v valid=%v", err, parsed != nil && parsed.Valid)
+	}
+	claims, _ := parsed.Claims.(jwt.MapClaims)
+	rawCaps, _ := claims["capabilities"].([]any)
+	got := make([]string, 0, len(rawCaps))
+	for _, v := range rawCaps {
+		if s, ok := v.(string); ok {
+			got = append(got, s)
+		}
+	}
+	// De-duplicated + whitespace-scrubbed list — order matches insertion.
+	want := []string{"sandbox.db.*", "gitea.repo.list"}
+	if len(got) != len(want) {
+		t.Fatalf("capabilities len: got %d (%v) want %d (%v)", len(got), got, len(want), want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("capabilities[%d]: got %q want %q", i, got[i], want[i])
+		}
+	}
+}
+
+// Empty / missing capabilities ⇒ the JWT carries NO `capabilities`
+// claim (the MCP server's HasCapability matcher returns false on every
+// check, downgrading the bearer to the introspection surface).
+func TestSandboxToken_NoCapabilitiesOmitsClaim(t *testing.T) {
+	h := newTestHandler()
+	body := `{
+		"org_id": "acme",
+		"user_id": "u@acme.com",
+		"sandbox_id": "sb-uid-2",
+		"allowed_channels": ["qwen"]
+	}`
+	rr := doRequest(t, h, http.MethodPost, body, string(h.AdminSecret))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status: got %d want 200, body=%s", rr.Code, rr.Body.String())
+	}
+	var resp sandboxTokenResponse
+	_ = json.Unmarshal(rr.Body.Bytes(), &resp)
+	parsed, _ := jwt.Parse(resp.Token, func(*jwt.Token) (any, error) { return h.SigningKey, nil })
+	claims, _ := parsed.Claims.(jwt.MapClaims)
+	if _, present := claims["capabilities"]; present {
+		t.Fatalf("capabilities claim leaked on empty list: claims=%v", claims)
+	}
+}
+
 // Sanity check that we don't leak the admin secret in the response on a
 // successful mint — the response should ONLY carry the minted JWT, not
 // echo any inbound credential.

--- a/products/catalyst/chart/crds/sandbox.yaml
+++ b/products/catalyst/chart/crds/sandbox.yaml
@@ -172,6 +172,37 @@ spec:
                     `<pr>.<app>.<previewDomain>`. Wired in Wave 3 (HTTPRoute
                     + Gateway). Wave 1 only records it on status.
                   pattern: '^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+$'
+                planId:
+                  type: string
+                  description: |
+                    Catalog plan slug the customer selected at checkout
+                    (`sandbox-free` | `sandbox-pro` | `sandbox-ent`).
+                    Stamped by the tenant-service orchestrator from the
+                    `tenant.sandbox_requested` event payload. Empty
+                    plan slug leaves the sandbox on the operator
+                    DefaultQuota (Wave 1 baseline = Sandbox Free shape).
+                capabilities:
+                  type: array
+                  description: |
+                    MCP capability allowlist the sandbox-controller stamps
+                    onto every per-Sandbox NewAPI token. The MCP server
+                    gates every tool call against these strings via
+                    Claims.HasCapability (architecture.md §3 RBAC).
+
+                    Bound to spec.planId via the tenant orchestrator's
+                    plan→capabilities map (handlers/sandbox_consumer.go
+                    capabilitiesForPlan). Empty list defaults to the Free
+                    plan capabilities (read-only k8s + gitea read + the
+                    session/rag/skills surface). Operators may override
+                    on a per-Sandbox basis by patching this field; the
+                    controller propagates the list into newapi on the
+                    next reconcile.
+
+                    Wildcards (`sandbox.db.*`, `gitea.issue.*`) are
+                    honoured by the MCP server's HasCapability matcher
+                    so the plan map can carry coarse grants.
+                  items:
+                    type: string
               x-kubernetes-preserve-unknown-fields: true
             status:
               type: object

--- a/products/sandbox/mcp-server/internal/tools/registry.go
+++ b/products/sandbox/mcp-server/internal/tools/registry.go
@@ -426,134 +426,160 @@ func defaultCatalogue(env *Env) []Tool {
 
 	return []Tool{
 		// gitea.* — read surface backed by core/controllers/pkg/gitea.
+		// Tier-bound (PR #1671): every read tool requires the granular
+		// `gitea.repo.list` / `gitea.pr.list` capability so Free-tier
+		// tokens (which carry exactly those grants) can browse without
+		// inheriting the write surface gitea.pr.create / gitea.issue.*.
 		{
-			Name:        "gitea.repo.list",
-			Description: "List repos in the Org's Gitea Org.",
-			InputSchema: schemaGiteaRepoList(),
-			Handler:     giteaRepoList,
+			Name:               "gitea.repo.list",
+			Description:        "List repos in the Org's Gitea Org.",
+			InputSchema:        schemaGiteaRepoList(),
+			Handler:            giteaRepoList,
+			RequiredCapability: "gitea.repo.list",
 		},
 		{
-			Name:        "gitea.repo.get",
-			Description: "Get a single repo by owner/name.",
-			InputSchema: schemaGiteaRepoGet(),
-			Handler:     giteaRepoGet,
+			Name:               "gitea.repo.get",
+			Description:        "Get a single repo by owner/name.",
+			InputSchema:        schemaGiteaRepoGet(),
+			Handler:            giteaRepoGet,
+			RequiredCapability: "gitea.repo.get",
 		},
 		{
-			Name:        "gitea.pr.list",
-			Description: "List PRs on a repo (state=open|closed|all).",
-			InputSchema: schemaGiteaPRList(),
-			Handler:     giteaPRList,
+			Name:               "gitea.pr.list",
+			Description:        "List PRs on a repo (state=open|closed|all).",
+			InputSchema:        schemaGiteaPRList(),
+			Handler:            giteaPRList,
+			RequiredCapability: "gitea.pr.list",
 		},
 		{
-			Name:        "gitea.pr.get",
-			Description: "Get a single PR by repo + number.",
-			InputSchema: schemaGiteaPRGet(),
-			Handler:     giteaPRGet,
+			Name:               "gitea.pr.get",
+			Description:        "Get a single PR by repo + number.",
+			InputSchema:        schemaGiteaPRGet(),
+			Handler:            giteaPRGet,
+			RequiredCapability: "gitea.pr.get",
 		},
 
 		// gitea.* — write surface (Wave 11 wired pr.create/merge + issue.*).
+		// Tier-bound (PR #1671): gated to Ent-tier grants (`gitea.pr.create`,
+		// `gitea.pr.merge`, `gitea.issue.*`) so Free + Pro tokens cannot
+		// open PRs / file issues.
 		{
-			Name:        "gitea.pr.create",
-			Description: "Open a PR (branch -> base) with title and body.",
-			InputSchema: schemaGiteaPRCreate(),
-			Handler:     giteaPRCreate,
+			Name:               "gitea.pr.create",
+			Description:        "Open a PR (branch -> base) with title and body.",
+			InputSchema:        schemaGiteaPRCreate(),
+			Handler:            giteaPRCreate,
+			RequiredCapability: "gitea.pr.create",
 		},
 		{
-			Name:        "gitea.pr.merge",
-			Description: "Merge a PR by number (style=merge|rebase|rebase-merge|squash; default merge).",
-			InputSchema: schemaGiteaPRMerge(),
-			Handler:     giteaPRMerge,
+			Name:               "gitea.pr.merge",
+			Description:        "Merge a PR by number (style=merge|rebase|rebase-merge|squash; default merge).",
+			InputSchema:        schemaGiteaPRMerge(),
+			Handler:            giteaPRMerge,
+			RequiredCapability: "gitea.pr.merge",
 		},
 		{
-			Name:        "gitea.issue.list",
-			Description: "List issues on a repo (state=open|closed|all, type=issues|pulls).",
-			InputSchema: schemaGiteaIssueList(),
-			Handler:     giteaIssueList,
+			Name:               "gitea.issue.list",
+			Description:        "List issues on a repo (state=open|closed|all, type=issues|pulls).",
+			InputSchema:        schemaGiteaIssueList(),
+			Handler:            giteaIssueList,
+			RequiredCapability: "gitea.issue.list",
 		},
 		{
-			Name:        "gitea.issue.get",
-			Description: "Get a single issue by repo + number.",
-			InputSchema: schemaGiteaIssueGet(),
-			Handler:     giteaIssueGet,
+			Name:               "gitea.issue.get",
+			Description:        "Get a single issue by repo + number.",
+			InputSchema:        schemaGiteaIssueGet(),
+			Handler:            giteaIssueGet,
+			RequiredCapability: "gitea.issue.get",
 		},
 		{
-			Name:        "gitea.issue.create",
-			Description: "Create an issue with title and body.",
-			InputSchema: schemaGiteaIssueCreate(),
-			Handler:     giteaIssueCreate,
+			Name:               "gitea.issue.create",
+			Description:        "Create an issue with title and body.",
+			InputSchema:        schemaGiteaIssueCreate(),
+			Handler:            giteaIssueCreate,
+			RequiredCapability: "gitea.issue.create",
 		},
 		{
-			Name:        "gitea.issue.comment",
-			Description: "Add a comment to an issue (or PR — Gitea conflates).",
-			InputSchema: schemaGiteaIssueComment(),
-			Handler:     giteaIssueComment,
+			Name:               "gitea.issue.comment",
+			Description:        "Add a comment to an issue (or PR — Gitea conflates).",
+			InputSchema:        schemaGiteaIssueComment(),
+			Handler:            giteaIssueComment,
+			RequiredCapability: "gitea.issue.comment",
 		},
 		{Name: "gitea.release.list", Description: "List releases on a repo.", InputSchema: anyObj},
 
-		// k8s.read.* — Org vcluster scope (NEVER host).
+		// k8s.read.* — Org vcluster scope (NEVER host). Tier-bound
+		// (PR #1671): get/list are Free-tier grants, watch/logs are
+		// Pro-tier grants (heavier read surface — log streams + watch
+		// streams hold cluster resources).
 		{
-			Name:        "k8s.read.get",
-			Description: "GET a single object by GVK + namespace + name (Org vcluster).",
-			InputSchema: schemaK8sReadGet(),
-			Handler:     k8sReadGet,
+			Name:               "k8s.read.get",
+			Description:        "GET a single object by GVK + namespace + name (Org vcluster).",
+			InputSchema:        schemaK8sReadGet(),
+			Handler:            k8sReadGet,
+			RequiredCapability: "k8s.read.get",
 		},
 		{
-			Name:        "k8s.read.list",
-			Description: "LIST objects by GVK + namespace (Org vcluster; label selector optional).",
-			InputSchema: schemaK8sReadList(),
-			Handler:     k8sReadList,
+			Name:               "k8s.read.list",
+			Description:        "LIST objects by GVK + namespace (Org vcluster; label selector optional).",
+			InputSchema:        schemaK8sReadList(),
+			Handler:            k8sReadList,
+			RequiredCapability: "k8s.read.list",
 		},
 		{
-			Name:        "k8s.read.watch",
-			Description: "WATCH a kind for live updates (returns a window of events, then closes).",
-			InputSchema: schemaK8sReadWatch(),
-			Handler:     k8sReadWatch,
+			Name:               "k8s.read.watch",
+			Description:        "WATCH a kind for live updates (returns a window of events, then closes).",
+			InputSchema:        schemaK8sReadWatch(),
+			Handler:            k8sReadWatch,
+			RequiredCapability: "k8s.read.watch",
 		},
 		{
-			Name:        "k8s.read.logs",
-			Description: "Fetch the recent N log lines for a pod container (bounded; read-only).",
-			InputSchema: schemaK8sReadLogs(),
-			Handler:     k8sReadLogs,
+			Name:               "k8s.read.logs",
+			Description:        "Fetch the recent N log lines for a pod container (bounded; read-only).",
+			InputSchema:        schemaK8sReadLogs(),
+			Handler:            k8sReadLogs,
+			RequiredCapability: "k8s.read.logs",
 		},
 
 		// sandbox.db.* — CNPG provisioning (Wave 11 — sandbox_db.go).
 		// Every handler addresses env.SandboxNamespace; the agent
-		// cannot pass a namespace argument. RequiredCapability gates
-		// each call to bearers whose claims carry `sandbox.db`.
+		// cannot pass a namespace argument. Tier-bound (PR #1671):
+		// each tool's per-handler RequiredCapability is the granular
+		// dotted name; Pro-tier tokens carry `sandbox.db.*` which the
+		// HasCapability matcher resolves to the per-tool grants.
 		{
 			Name:               "sandbox.db.provision",
 			Description:        "Provision a CNPG Postgres Cluster CR in this Sandbox's namespace (default plan: 1 instance, 5Gi, postgres 16). Returns the connection envelope.",
 			InputSchema:        schemaSandboxDBProvision(),
 			Handler:            sandboxDBProvision,
-			RequiredCapability: "sandbox.db",
+			RequiredCapability: "sandbox.db.provision",
 		},
 		{
 			Name:               "sandbox.db.list",
 			Description:        "List CNPG Clusters provisioned by this Sandbox (filtered to openova.io/managed-by=openova-sandbox-mcp).",
 			InputSchema:        map[string]any{"type": "object", "additionalProperties": false},
 			Handler:            sandboxDBList,
-			RequiredCapability: "sandbox.db",
+			RequiredCapability: "sandbox.db.list",
 		},
 		{
 			Name:               "sandbox.db.get",
 			Description:        "Get a single Sandbox-managed CNPG Cluster's status + connection envelope by name.",
 			InputSchema:        schemaSandboxDBNameOnly(),
 			Handler:            sandboxDBGet,
-			RequiredCapability: "sandbox.db",
+			RequiredCapability: "sandbox.db.get",
 		},
 		{
 			Name:               "sandbox.db.drop",
 			Description:        "Delete a Sandbox-managed CNPG Cluster (CNPG operator cascades PVC/Service/Secret cleanup).",
 			InputSchema:        schemaSandboxDBNameOnly(),
 			Handler:            sandboxDBDrop,
-			RequiredCapability: "sandbox.db",
+			RequiredCapability: "sandbox.db.drop",
 		},
 		{
 			Name:               "sandbox.db.dump",
 			Description:        "Create a one-shot CNPG Backup CR (barman-cloud or volumeSnapshot per cluster config). Returns the Backup CR ref + configured S3 destinationPath.",
 			InputSchema:        schemaSandboxDBNameOnly(),
 			Handler:            sandboxDBDump,
-			RequiredCapability: "sandbox.db",
+			RequiredCapability: "sandbox.db.dump",
 		},
 
 		// sandbox.auth.* — Keycloak realm + OIDC client management
@@ -567,21 +593,21 @@ func defaultCatalogue(env *Env) []Tool {
 			Description:        "Provision a per-Sandbox Keycloak realm under the Sovereign Keycloak instance. Idempotent: returns AlreadyExists on re-call.",
 			InputSchema:        schemaSandboxAuthProvisionRealm(),
 			Handler:            sandboxAuthProvisionRealm,
-			RequiredCapability: "sandbox.auth",
+			RequiredCapability: "sandbox.auth.provisionRealm",
 		},
 		{
 			Name:               "sandbox.auth.listClients",
 			Description:        "List OIDC clients in this Sandbox's realm (`sandbox-<org>-<id>`).",
 			InputSchema:        map[string]any{"type": "object", "additionalProperties": false},
 			Handler:            sandboxAuthListClients,
-			RequiredCapability: "sandbox.auth",
+			RequiredCapability: "sandbox.auth.listClients",
 		},
 		{
 			Name:               "sandbox.auth.registerClient",
 			Description:        "Register a new OIDC client in this Sandbox's realm (`sandbox-<org>-<id>`). Idempotent: returns AlreadyExists on re-call.",
 			InputSchema:        schemaSandboxAuthRegisterClient(),
 			Handler:            sandboxAuthRegisterClient,
-			RequiredCapability: "sandbox.auth",
+			RequiredCapability: "sandbox.auth.registerClient",
 		},
 
 		// sandbox.secrets.* — per-Sandbox Secret store
@@ -595,14 +621,14 @@ func defaultCatalogue(env *Env) []Tool {
 			Description:        "Read a key from the Sandbox's Secret store (`sandbox-<owner-uid>-secrets`). Returns status=NotFound when the store hasn't been created yet.",
 			InputSchema:        schemaSandboxSecretsRead(),
 			Handler:            sandboxSecretsRead,
-			RequiredCapability: "sandbox.secrets",
+			RequiredCapability: "sandbox.secrets.read",
 		},
 		{
 			Name:               "sandbox.secrets.write",
 			Description:        "Write a key/value into the Sandbox's Secret store (auto-creates the Secret on first write). Encrypted at rest via K8s Secret encryption-at-rest.",
 			InputSchema:        schemaSandboxSecretsWrite(),
 			Handler:            sandboxSecretsWrite,
-			RequiredCapability: "sandbox.secrets",
+			RequiredCapability: "sandbox.secrets.write",
 		},
 
 		// marketplace.domain.* — Wave 12 thin proxy to
@@ -615,14 +641,14 @@ func defaultCatalogue(env *Env) []Tool {
 			Description:        "Register a Bring-Your-Own-Domain (BYOD) FQDN for the Sandbox's tenant. Returns the CNAME target the operator points at their registrar.",
 			InputSchema:        schemaMarketplaceDomainBYOD(),
 			Handler:            marketplaceDomainBYOD,
-			RequiredCapability: "marketplace",
+			RequiredCapability: "marketplace.domain.byod",
 		},
 		{
 			Name:               "marketplace.domain.subdomain",
 			Description:        "Reserve a `<subdomain>.<parent_zone>` under the Sovereign-managed subdomain pool (parent_zone defaults to the configured pool TLD).",
 			InputSchema:        schemaMarketplaceDomainSubdomain(),
 			Handler:            marketplaceDomainSubdomain,
-			RequiredCapability: "marketplace",
+			RequiredCapability: "marketplace.domain.subdomain",
 		},
 
 		// flux.* — Wave 12 Flux read/kick surface (flux.go). status is
@@ -637,28 +663,28 @@ func defaultCatalogue(env *Env) []Tool {
 			Description:        "List HelmReleases + Kustomizations in the Sandbox's tenant namespaces with their Ready condition + last applied revision.",
 			InputSchema:        schemaFluxStatus(),
 			Handler:            fluxStatus,
-			RequiredCapability: "flux",
+			RequiredCapability: "flux.status",
 		},
 		{
 			Name:               "flux.reconcile",
 			Description:        "Force-run a Flux reconcile on a tenant-scoped HelmRelease or Kustomization by setting the `reconcile.fluxcd.io/requestedAt` annotation.",
 			InputSchema:        schemaFluxMutation(),
 			Handler:            fluxReconcile,
-			RequiredCapability: "flux",
+			RequiredCapability: "flux.reconcile",
 		},
 		{
 			Name:               "flux.suspend",
 			Description:        "Set spec.suspend=true on a tenant-scoped HelmRelease or Kustomization so Flux stops reconciling it.",
 			InputSchema:        schemaFluxMutation(),
 			Handler:            fluxSuspend,
-			RequiredCapability: "flux",
+			RequiredCapability: "flux.suspend",
 		},
 		{
 			Name:               "flux.resume",
 			Description:        "Set spec.suspend=false on a tenant-scoped HelmRelease or Kustomization so Flux resumes reconciling.",
 			InputSchema:        schemaFluxMutation(),
 			Handler:            fluxResume,
-			RequiredCapability: "flux",
+			RequiredCapability: "flux.resume",
 		},
 
 		// rag.search — Wave 12 lean text-grep stub over /repo PVC
@@ -707,35 +733,35 @@ func defaultCatalogue(env *Env) []Tool {
 			Description:        "Create a per-PR preview triple (Deployment + Service + HTTPRoute) in this Sandbox's namespace. Hostname pattern: `pr-<num>.<app>.sandbox.<sov-fqdn>`.",
 			InputSchema:        schemaSandboxPreviewCreate(),
 			Handler:            sandboxPreviewCreate,
-			RequiredCapability: "sandbox.preview",
+			RequiredCapability: "sandbox.preview.create",
 		},
 		{
 			Name:               "sandbox.preview.list",
 			Description:        "List active per-PR previews in this Sandbox (filtered to openova.io/managed-by=openova-sandbox-mcp + openova.io/preview-pr label).",
 			InputSchema:        map[string]any{"type": "object", "additionalProperties": false},
 			Handler:            sandboxPreviewList,
-			RequiredCapability: "sandbox.preview",
+			RequiredCapability: "sandbox.preview.list",
 		},
 		{
 			Name:               "sandbox.preview.status",
 			Description:        "Fetch a per-PR preview's Deployment status + Pod readiness (containerStatuses with waiting reason, restartCount).",
 			InputSchema:        schemaSandboxPreviewPRNumber(),
 			Handler:            sandboxPreviewStatus,
-			RequiredCapability: "sandbox.preview",
+			RequiredCapability: "sandbox.preview.status",
 		},
 		{
 			Name:               "sandbox.preview.teardown",
 			Description:        "Delete a per-PR preview (Deployment + Service + HTTPRoute). Foreground propagation on the Deployment so Pods + ReplicaSets are fully reaped.",
 			InputSchema:        schemaSandboxPreviewPRNumber(),
 			Handler:            sandboxPreviewTeardown,
-			RequiredCapability: "sandbox.preview",
+			RequiredCapability: "sandbox.preview.teardown",
 		},
 		{
 			Name:               "sandbox.preview.rebuild",
 			Description:        "Update a per-PR preview's container image + bump kubectl.kubernetes.io/restartedAt to force a rollout (works even when the image tag is unchanged).",
 			InputSchema:        schemaSandboxPreviewRebuild(),
 			Handler:            sandboxPreviewRebuild,
-			RequiredCapability: "sandbox.preview",
+			RequiredCapability: "sandbox.preview.rebuild",
 		},
 
 		// sandbox.deploy.* — per-app staging + production rollouts via
@@ -752,28 +778,28 @@ func defaultCatalogue(env *Env) []Tool {
 			Description:        "Patch the staging HelmRelease (`<app>-staging`) image in the Org's tenant Gitea repo. Flux on the host reconciles into the Org vcluster.",
 			InputSchema:        schemaSandboxDeployImage(),
 			Handler:            sandboxDeployStaging,
-			RequiredCapability: "sandbox.deploy",
+			RequiredCapability: "sandbox.deploy.staging",
 		},
 		{
 			Name:               "sandbox.deploy.production",
 			Description:        "Patch the production HelmRelease (`<app>-production`) image. Demands an extra `sandbox.deploy.production` capability on top of `sandbox.deploy`.",
 			InputSchema:        schemaSandboxDeployImage(),
 			Handler:            sandboxDeployProduction,
-			RequiredCapability: "sandbox.deploy",
+			RequiredCapability: "sandbox.deploy.production",
 		},
 		{
 			Name:               "sandbox.deploy.status",
 			Description:        "Read the HelmRelease status (`Ready` condition + observed_image vs requested_image) for the given env.",
 			InputSchema:        schemaSandboxDeployEnv(),
 			Handler:            sandboxDeployStatus,
-			RequiredCapability: "sandbox.deploy",
+			RequiredCapability: "sandbox.deploy.status",
 		},
 		{
 			Name:               "sandbox.deploy.rollback",
 			Description:        "Revert the HR image to the previously-deployed value (read from `openova.io/last-deployed-image` annotation). Production rollbacks also require `sandbox.deploy.production`.",
 			InputSchema:        schemaSandboxDeployEnv(),
 			Handler:            sandboxDeployRollback,
-			RequiredCapability: "sandbox.deploy",
+			RequiredCapability: "sandbox.deploy.rollback",
 		},
 
 		// sandbox.storage.* — per-Sandbox SeaweedFS S3 buckets
@@ -789,35 +815,35 @@ func defaultCatalogue(env *Env) []Tool {
 			Description:        "Create (idempotent) a SeaweedFS S3 bucket owned by this Sandbox. Bucket name defaults to `sandbox-<owner-uid>-default`; explicit names are auto-prefixed with `sandbox-<owner-uid>-`.",
 			InputSchema:        schemaSandboxStorageBindBucket(),
 			Handler:            sandboxStorageBindBucket,
-			RequiredCapability: "sandbox.storage",
+			RequiredCapability: "sandbox.storage.bindBucket",
 		},
 		{
 			Name:               "sandbox.storage.signedUploadURL",
 			Description:        "Mint a presigned S3 PUT URL for {bucket, key}. Defaults to a 15-minute expiry; max 7 days. Bucket must be owned by this Sandbox.",
 			InputSchema:        schemaSandboxStorageSignedURL(),
 			Handler:            sandboxStorageSignedUploadURL,
-			RequiredCapability: "sandbox.storage",
+			RequiredCapability: "sandbox.storage.signedUploadURL",
 		},
 		{
 			Name:               "sandbox.storage.signedDownloadURL",
 			Description:        "Mint a presigned S3 GET URL for {bucket, key}. Defaults to a 15-minute expiry; max 7 days. Bucket must be owned by this Sandbox.",
 			InputSchema:        schemaSandboxStorageSignedURL(),
 			Handler:            sandboxStorageSignedDownloadURL,
-			RequiredCapability: "sandbox.storage",
+			RequiredCapability: "sandbox.storage.signedDownloadURL",
 		},
 		{
 			Name:               "sandbox.storage.listBuckets",
 			Description:        "List SeaweedFS buckets owned by this Sandbox (filtered to the `sandbox-<owner-uid>-` prefix).",
 			InputSchema:        map[string]any{"type": "object", "additionalProperties": false},
 			Handler:            sandboxStorageListBuckets,
-			RequiredCapability: "sandbox.storage",
+			RequiredCapability: "sandbox.storage.listBuckets",
 		},
 		{
 			Name:               "sandbox.storage.deleteBucket",
 			Description:        "Delete a SeaweedFS bucket owned by this Sandbox. The bucket must be empty; SeaweedFS rejects non-empty deletes (drain objects first).",
 			InputSchema:        schemaSandboxStorageDeleteBucket(),
 			Handler:            sandboxStorageDeleteBucket,
-			RequiredCapability: "sandbox.storage",
+			RequiredCapability: "sandbox.storage.deleteBucket",
 		},
 
 		// sandbox.stripe.* — per-Sandbox Stripe account binding + Product /
@@ -834,42 +860,46 @@ func defaultCatalogue(env *Env) []Tool {
 			Description:        "Bind a Stripe API key (`sk_live_…` / `sk_test_…` / `rk_live_…` / `rk_test_…`) to this Sandbox. Stored in the Sandbox Secret store; subsequent sandbox.stripe.* calls read it implicitly. Returns a MASKED confirmation.",
 			InputSchema:        schemaSandboxStripeBindAccount(),
 			Handler:            sandboxStripeBindAccount,
-			RequiredCapability: "sandbox.stripe",
+			RequiredCapability: "sandbox.stripe.bindAccount",
 		},
 		{
 			Name:               "sandbox.stripe.listProducts",
 			Description:        "List Stripe Products via the bound key. Supports `limit` (1-100, default 20), `active` (filter), `starting_after` (cursor).",
 			InputSchema:        schemaSandboxStripeListProducts(),
 			Handler:            sandboxStripeListProducts,
-			RequiredCapability: "sandbox.stripe",
+			RequiredCapability: "sandbox.stripe.listProducts",
 		},
 		{
 			Name:               "sandbox.stripe.listPrices",
 			Description:        "List Stripe Prices via the bound key. Optional `product_id` filters to one Product; same paging flags as listProducts.",
 			InputSchema:        schemaSandboxStripeListPrices(),
 			Handler:            sandboxStripeListPrices,
-			RequiredCapability: "sandbox.stripe",
+			RequiredCapability: "sandbox.stripe.listPrices",
 		},
 		{
 			Name:               "sandbox.stripe.createCheckoutSession",
 			Description:        "Create a Stripe Checkout Session for {price_id, success_url, cancel_url}. Default mode=payment, quantity=1. Returns the hosted Checkout URL.",
 			InputSchema:        schemaSandboxStripeCreateCheckoutSession(),
 			Handler:            sandboxStripeCreateCheckoutSession,
-			RequiredCapability: "sandbox.stripe",
+			RequiredCapability: "sandbox.stripe.createCheckoutSession",
 		},
 
 		// sandbox.session.* — this MCP server's own metadata (Wave 8).
+		// Tier-bound (PR #1671): Free tokens carry `sandbox.session.*`
+		// so the whoami/info introspection tools work on every plan.
 		{
-			Name:        "sandbox.session.whoami",
-			Description: "Return the claims (sub, org_id, sandbox_id, role) the server sees on the per-call bearer.",
-			InputSchema: anyObj,
-			Handler:     sessionWhoami,
+			Name:               "sandbox.session.whoami",
+			Description:        "Return the claims (sub, org_id, sandbox_id, role) the server sees on the per-call bearer.",
+			InputSchema:        anyObj,
+			Handler:            sessionWhoami,
+			RequiredCapability: "sandbox.session.whoami",
 		},
 		{
-			Name:        "sandbox.session.info",
-			Description: "Return the Sandbox's name, namespace, attached repos, Sovereign FQDN.",
-			InputSchema: anyObj,
-			Handler:     sessionInfo,
+			Name:               "sandbox.session.info",
+			Description:        "Return the Sandbox's name, namespace, attached repos, Sovereign FQDN.",
+			InputSchema:        anyObj,
+			Handler:            sessionInfo,
+			RequiredCapability: "sandbox.session.info",
 		},
 	}
 }

--- a/products/sandbox/mcp-server/internal/tools/registry_test.go
+++ b/products/sandbox/mcp-server/internal/tools/registry_test.go
@@ -133,6 +133,10 @@ func TestRegistry_AuthGate_NoClaimsRejects(t *testing.T) {
 
 // TestRegistry_AuthGate_OrgMismatch — claim org_id != env.OrgID = 403,
 // EXCEPT for sandbox.session.* which is exempt.
+//
+// PR #1671 — capability gate runs BEFORE the org-scope gate, so the
+// test fixture must grant the granular `gitea.repo.list` and
+// `sandbox.session.*` capabilities to reach the org-scope branch.
 func TestRegistry_AuthGate_OrgMismatch(t *testing.T) {
 	r := NewRegistry(&Env{
 		OrgID:        "acme",
@@ -141,8 +145,9 @@ func TestRegistry_AuthGate_OrgMismatch(t *testing.T) {
 		GiteaToken:   "tok",
 	})
 	cl := &sharedauth.Claims{
-		Email: "u@x",
-		OrgID: "bankdhofar",
+		Email:        "u@x",
+		OrgID:        "bankdhofar",
+		Capabilities: []string{"gitea.repo.list", "sandbox.session.*"},
 	}
 	_, err := r.Call(context.Background(), "gitea.repo.list", nil, CallOpts{Claims: cl})
 	if err == nil || !strings.Contains(err.Error(), "org_id mismatch") {
@@ -190,7 +195,7 @@ func TestSessionWhoami_AuthenticatedShape(t *testing.T) {
 		Role:         "member",
 		OrgID:        "acme",
 		Groups:       []string{"/acme/admins"},
-		Capabilities: []string{"sandbox:db:list"},
+		Capabilities: []string{"sandbox:db:list", "sandbox.session.whoami"},
 		Typ:          "pat",
 	}
 	res, err := r.Call(context.Background(), "sandbox.session.whoami", nil, CallOpts{Claims: cl})

--- a/products/sandbox/mcp-server/internal/tools/sandbox_db_test.go
+++ b/products/sandbox/mcp-server/internal/tools/sandbox_db_test.go
@@ -219,7 +219,9 @@ func TestSandboxDBProvision_PlanRejection(t *testing.T) {
 		JWTSecret:        []byte("x"),
 		SandboxNamespace: "sandbox-uid-1",
 	})
-	cl := &sharedauth.Claims{OrgID: "acme", Capabilities: []string{"sandbox.db"}}
+	// PR #1671 — Pro plan grants `sandbox.db.*` which the wildcard
+	// matcher resolves to the per-tool `sandbox.db.provision` grant.
+	cl := &sharedauth.Claims{OrgID: "acme", Capabilities: []string{"sandbox.db.*"}}
 	args := json.RawMessage(`{"name":"mydb1","plan":"xxl"}`)
 	_, err := r.Call(context.Background(), "sandbox.db.provision", args, CallOpts{Claims: cl})
 	if err == nil || !strings.Contains(err.Error(), "unknown plan") {

--- a/products/sandbox/mcp-server/internal/tools/sandbox_deploy_test.go
+++ b/products/sandbox/mcp-server/internal/tools/sandbox_deploy_test.go
@@ -388,9 +388,15 @@ func TestSandboxDeployRollback_Production_RequiresCapability(t *testing.T) {
 	env := deployEnv(srv)
 	env.JWTSecret = []byte("sekret")
 	r := NewRegistry(env)
+	// Holds the rollback grant (Registry's first-gate is satisfied) but
+	// NOT the production grant (handler's second-gate must reject).
+	// PR #1671 — under tier-bound capabilities the rollback grant is
+	// granular `sandbox.deploy.rollback`; production rollbacks still
+	// require the extra `sandbox.deploy.production` capability the
+	// handler enforces in `sandbox_deploy.go`.
 	claims := &sharedauth.Claims{
 		OrgID:        "acme",
-		Capabilities: []string{"sandbox.deploy"},
+		Capabilities: []string{"sandbox.deploy.rollback"},
 	}
 	_, err := r.Call(context.Background(), "sandbox.deploy.rollback",
 		json.RawMessage(`{"env":"production"}`), CallOpts{Claims: claims})
@@ -494,15 +500,17 @@ func TestRequireSandboxDeployScope_MissingEnv(t *testing.T) {
 	}
 }
 
-// Smoke: ensure the 4 new tools appear in the registry catalogue with
-// their RequiredCapability set.
+// Smoke: ensure the 4 deploy tools appear in the registry catalogue with
+// their granular tier-bound RequiredCapability set (PR #1671 — Pro/Ent
+// plans grant `sandbox.deploy.*` and the wildcard matcher resolves to
+// these per-tool grants).
 func TestRegistry_AdvertisesDeployTools(t *testing.T) {
 	r := NewRegistry(&Env{})
 	want := map[string]string{
-		"sandbox.deploy.staging":    "sandbox.deploy",
-		"sandbox.deploy.production": "sandbox.deploy",
-		"sandbox.deploy.status":     "sandbox.deploy",
-		"sandbox.deploy.rollback":   "sandbox.deploy",
+		"sandbox.deploy.staging":    "sandbox.deploy.staging",
+		"sandbox.deploy.production": "sandbox.deploy.production",
+		"sandbox.deploy.status":     "sandbox.deploy.status",
+		"sandbox.deploy.rollback":   "sandbox.deploy.rollback",
 	}
 	got := map[string]string{}
 	for _, t := range r.List() {

--- a/products/sandbox/mcp-server/internal/tools/sandbox_preview_test.go
+++ b/products/sandbox/mcp-server/internal/tools/sandbox_preview_test.go
@@ -292,29 +292,31 @@ func TestSandboxPreviewCapabilityGate(t *testing.T) {
 }
 
 // TestSandboxPreviewRegistered makes sure every Wave-12 tool name is
-// registered AND carries the canonical RequiredCapability.
+// registered AND carries its granular tier-bound RequiredCapability
+// (PR #1671 — Pro plan grants `sandbox.preview.*` which the wildcard
+// matcher resolves to these per-tool grants).
 func TestSandboxPreviewRegistered(t *testing.T) {
 	r := NewRegistry(&Env{})
-	expected := []string{
-		"sandbox.preview.create",
-		"sandbox.preview.list",
-		"sandbox.preview.status",
-		"sandbox.preview.teardown",
-		"sandbox.preview.rebuild",
+	expected := map[string]string{
+		"sandbox.preview.create":   "sandbox.preview.create",
+		"sandbox.preview.list":     "sandbox.preview.list",
+		"sandbox.preview.status":   "sandbox.preview.status",
+		"sandbox.preview.teardown": "sandbox.preview.teardown",
+		"sandbox.preview.rebuild":  "sandbox.preview.rebuild",
 	}
 	seen := map[string]bool{}
 	for _, tool := range r.List() {
 		if strings.HasPrefix(tool.Name, "sandbox.preview.") {
 			seen[tool.Name] = true
-			if tool.RequiredCapability != "sandbox.preview" {
-				t.Errorf("%s RequiredCapability=%q want sandbox.preview", tool.Name, tool.RequiredCapability)
+			if want, ok := expected[tool.Name]; ok && tool.RequiredCapability != want {
+				t.Errorf("%s RequiredCapability=%q want %q", tool.Name, tool.RequiredCapability, want)
 			}
 			if tool.Handler == nil {
 				t.Errorf("%s has nil Handler — still a stub", tool.Name)
 			}
 		}
 	}
-	for _, want := range expected {
+	for want := range expected {
 		if !seen[want] {
 			t.Errorf("tool %q not registered", want)
 		}

--- a/products/sandbox/mcp-server/internal/tools/sandbox_storage_test.go
+++ b/products/sandbox/mcp-server/internal/tools/sandbox_storage_test.go
@@ -284,16 +284,19 @@ func TestSandboxStorageCapabilityGate(t *testing.T) {
 }
 
 // TestSandboxStorageCatalogueWiredIn ensures all five tools are in
-// the catalogue with non-nil Handler + the right RequiredCapability.
+// the catalogue with non-nil Handler + their granular tier-bound
+// RequiredCapability (PR #1671 — Pro plan grants `sandbox.storage.*`
+// which the wildcard matcher resolves to these per-tool grants).
 func TestSandboxStorageCatalogueWiredIn(t *testing.T) {
 	r := NewRegistry(&Env{OrgID: "acme", OwnerUID: "u1"})
-	want := map[string]bool{
-		"sandbox.storage.bindBucket":        false,
-		"sandbox.storage.signedUploadURL":   false,
-		"sandbox.storage.signedDownloadURL": false,
-		"sandbox.storage.listBuckets":       false,
-		"sandbox.storage.deleteBucket":      false,
+	want := map[string]string{
+		"sandbox.storage.bindBucket":        "sandbox.storage.bindBucket",
+		"sandbox.storage.signedUploadURL":   "sandbox.storage.signedUploadURL",
+		"sandbox.storage.signedDownloadURL": "sandbox.storage.signedDownloadURL",
+		"sandbox.storage.listBuckets":       "sandbox.storage.listBuckets",
+		"sandbox.storage.deleteBucket":      "sandbox.storage.deleteBucket",
 	}
+	seen := map[string]bool{}
 	for _, tool := range r.List() {
 		if _, ok := want[tool.Name]; !ok {
 			continue
@@ -301,13 +304,13 @@ func TestSandboxStorageCatalogueWiredIn(t *testing.T) {
 		if tool.Handler == nil {
 			t.Errorf("%s: Handler is nil", tool.Name)
 		}
-		if tool.RequiredCapability != "sandbox.storage" {
-			t.Errorf("%s: RequiredCapability=%q want sandbox.storage", tool.Name, tool.RequiredCapability)
+		if tool.RequiredCapability != want[tool.Name] {
+			t.Errorf("%s: RequiredCapability=%q want %q", tool.Name, tool.RequiredCapability, want[tool.Name])
 		}
-		want[tool.Name] = true
+		seen[tool.Name] = true
 	}
-	for name, found := range want {
-		if !found {
+	for name := range want {
+		if !seen[name] {
 			t.Errorf("%s: missing from catalogue", name)
 		}
 	}

--- a/products/sandbox/mcp-server/internal/tools/sandbox_stripe_test.go
+++ b/products/sandbox/mcp-server/internal/tools/sandbox_stripe_test.go
@@ -204,15 +204,18 @@ func TestReadStripeKey_BareEncoding(t *testing.T) {
 }
 
 // TestSandboxStripeCatalogueWiredIn ensures all four tools are in the
-// catalogue with non-nil Handler + the right RequiredCapability.
+// catalogue with non-nil Handler + their granular tier-bound
+// RequiredCapability (PR #1671 — Ent plan grants `sandbox.stripe.*`
+// which the wildcard matcher resolves to these per-tool grants).
 func TestSandboxStripeCatalogueWiredIn(t *testing.T) {
 	r := NewRegistry(&Env{OrgID: "acme", OwnerUID: "u1"})
-	want := map[string]bool{
-		"sandbox.stripe.bindAccount":           false,
-		"sandbox.stripe.listProducts":          false,
-		"sandbox.stripe.listPrices":            false,
-		"sandbox.stripe.createCheckoutSession": false,
+	want := map[string]string{
+		"sandbox.stripe.bindAccount":           "sandbox.stripe.bindAccount",
+		"sandbox.stripe.listProducts":          "sandbox.stripe.listProducts",
+		"sandbox.stripe.listPrices":            "sandbox.stripe.listPrices",
+		"sandbox.stripe.createCheckoutSession": "sandbox.stripe.createCheckoutSession",
 	}
+	seen := map[string]bool{}
 	for _, tool := range r.List() {
 		if _, ok := want[tool.Name]; !ok {
 			continue
@@ -220,13 +223,13 @@ func TestSandboxStripeCatalogueWiredIn(t *testing.T) {
 		if tool.Handler == nil {
 			t.Errorf("%s: Handler is nil", tool.Name)
 		}
-		if tool.RequiredCapability != "sandbox.stripe" {
-			t.Errorf("%s: RequiredCapability=%q want sandbox.stripe", tool.Name, tool.RequiredCapability)
+		if tool.RequiredCapability != want[tool.Name] {
+			t.Errorf("%s: RequiredCapability=%q want %q", tool.Name, tool.RequiredCapability, want[tool.Name])
 		}
-		want[tool.Name] = true
+		seen[tool.Name] = true
 	}
-	for name, found := range want {
-		if !found {
+	for name := range want {
+		if !seen[name] {
 			t.Errorf("%s: missing from catalogue", name)
 		}
 	}


### PR DESCRIPTION
## Summary

- Every Sandbox session previously got ALL MCP capabilities (sandbox.db.*, sandbox.auth.*, sandbox.stripe.*, sandbox.deploy.production, etc.). This PR makes them tier-bound — the customer's catalog plan slug (`sandbox-free` | `sandbox-pro` | `sandbox-ent`) gates which MCP tools the per-Sandbox NewAPI token can call.
- The plan→capabilities map lives in `core/controllers/sandbox/internal/sandboxapi/capabilities.go` (SoT) with an exact-mirror duplicate in `core/services/tenant/handlers/sandbox_consumer.go` (kept duplicated to preserve the tenant-service → controllers-module dependency isolation, same pattern `quotaForPlan` already uses).
- `Claims.HasCapability` learns wildcard prefix matching so a single grant (`sandbox.db.*`) covers every per-tool capability (`sandbox.db.provision`, `sandbox.db.list`, …). Plain stem matches WITHOUT a wildcard are intentionally rejected so the `sandbox.deploy.production` second-gate in `sandbox_deploy.go` stays honest.

## Capability ladder

| Plan | Capabilities |
|------|--------------|
| Free | `gitea.repo.list`, `gitea.repo.get`, `gitea.pr.list`, `gitea.pr.get`, `k8s.read.get`, `k8s.read.list`, `sandbox.session.*`, `rag.search`, `skills.list`, `skills.get` |
| Pro  | Free + `sandbox.db.*`, `sandbox.storage.*`, `sandbox.preview.*`, `sandbox.auth.*`, `sandbox.secrets.*`, `marketplace.*`, `flux.status` |
| Ent  | Pro + `sandbox.deploy.{staging,production,status,rollback}`, `sandbox.stripe.*`, `flux.{reconcile,suspend,resume}`, `gitea.pr.{create,merge}`, `gitea.issue.*` |

Unknown / empty plan slug falls through to the Free shape — a misconfigured CR never silently inherits Pro/Ent grants.

## Wiring (end-to-end)

```
tenant.sandbox_requested
  ↓ (plan_id)
core/services/tenant/handlers/sandbox_consumer.go capabilitiesForPlan
  ↓ stamps spec.capabilities + spec.planId on Sandbox CR
sandbox.openova.io/v1 Sandbox (CRD spec)
  ↓ sandbox-controller reads via sandboxapi.ResolveCapabilities
core/controllers/sandbox/internal/controller/sandbox_controller.go
  ↓ threads into newapi.MintRequest.Capabilities[]
catalyst-api POST /admin/tokens/sandbox (handler)
  ↓ encodes as JWT "capabilities" claim
HS256 token → SANDBOX_TOKEN env on MCP pod
  ↓ parsed via jwt.ParseWithClaims(&sharedauth.Claims{})
products/sandbox/mcp-server tools.Registry.Call
  ↓ claims.HasCapability(tool.RequiredCapability)
  → 403 forbidden  OR  handler runs
```

## Files

- **CRD**: `products/catalyst/chart/crds/sandbox.yaml` — adds spec.planId + spec.capabilities[].
- **Go types**: `core/controllers/sandbox/internal/sandboxapi/types.go` — same.
- **Plan map**: `core/controllers/sandbox/internal/sandboxapi/capabilities.go` (new) + mirror in `core/services/tenant/handlers/sandbox_consumer.go`.
- **Matcher**: `core/services/shared/auth/claims.go` — wildcard prefix support.
- **Bridge**: `platform/newapi/internal/handler/sandbox_token.go` — accepts capabilities[] on wire, encodes JWT claim (omit on empty).
- **Controller**: `core/controllers/sandbox/internal/controller/sandbox_controller.go` + `internal/newapi/client.go` — threads Capabilities into MintRequest.
- **Orchestrator**: `core/services/tenant/handlers/sandbox_consumer.go` — stamps spec.capabilities from plan.
- **MCP registry**: `products/sandbox/mcp-server/internal/tools/registry.go` — every gated tool now carries its granular dotted RequiredCapability (replaces the previous coarse `sandbox.db` / `sandbox.auth` / … strings); read-only / session tools previously ungated also get granular grants so Free tokens can browse without inheriting the write surface.

## Tests

- `core/services/shared/auth/claims_test.go` — exact + wildcard + boundary + nil + bare-`*`-rejects matrix.
- `core/controllers/sandbox/internal/sandboxapi/capabilities_test.go` — plan ladder + spec override + fresh-slice + nil-spec.
- `core/services/tenant/handlers/sandbox_consumer_test.go` — orchestrator stamps spec.capabilities; mirror parity vs sandboxapi.
- `platform/newapi/internal/handler/sandbox_token_test.go` — capabilities round-trip via JWT; empty list omits the claim.
- `core/controllers/sandbox/internal/controller/sandbox_controller_test.go` — plan-derived caps reach MintRequest; spec override wins.
- Updated every per-namespace MCP registry test for the new granular RequiredCapability values (`sandbox.deploy.staging` instead of `sandbox.deploy`, …).

## Compatibility

- No Chart.yaml bump — CRD additions are additive (existing Sandbox CRs parse fine).
- Empty `capabilities[]` ⇒ JWT omits the `capabilities` claim ⇒ MCP HasCapability returns false on every check ⇒ token downgrades to the introspection-only surface. Pre-PR-#1671 tokens carrying no `capabilities` claim land in the same downgrade path (safe-by-default; never grants more than the token explicitly carries).
- Legacy claim values like `sandbox:db:provision` (colon-separated) still match exactly — the wildcard matcher only fires on `.*` suffix.

## Test plan

- [x] go build + go test clean on all 5 touched modules (shared/auth, tenant, newapi/handler, controllers/sandbox, sandbox/mcp-server).
- [ ] (deploy) verify a fresh sandbox-pro Sandbox carries `sandbox.db.*` in the JWT capabilities claim, sandbox-free carries only the read surface.
- [ ] (deploy) verify a Free-token call to `sandbox.db.provision` returns 403 forbidden via `Claims.HasCapability` rejection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)