### PR TITLE
fix(ci): bump sme-services Containerfiles golang 1.22→1.26 — unblock 5 stranded fixes (Refs TBD-A1)

### DIFF
--- a/core/services/auth/Containerfile
+++ b/core/services/auth/Containerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22-alpine AS build
+FROM golang:1.26-alpine AS build
 WORKDIR /src
 COPY shared/ shared/
 COPY auth/go.mod auth/go.sum auth/

--- a/core/services/billing/Containerfile
+++ b/core/services/billing/Containerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22-alpine AS build
+FROM golang:1.26-alpine AS build
 WORKDIR /src
 COPY shared/ shared/
 COPY billing/go.mod billing/go.sum billing/

--- a/core/services/catalog/Containerfile
+++ b/core/services/catalog/Containerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22-alpine AS build
+FROM golang:1.26-alpine AS build
 WORKDIR /src
 COPY shared/ shared/
 COPY catalog/go.mod catalog/go.sum catalog/

--- a/core/services/catalyst-catalog/Containerfile
+++ b/core/services/catalyst-catalog/Containerfile
@@ -10,7 +10,7 @@
 # tree alongside the unified Gitea client at core/controllers/pkg/gitea
 # referenced via a `replace` directive in catalyst-catalog/go.mod).
 
-FROM golang:1.23-alpine AS build
+FROM golang:1.26-alpine AS build
 WORKDIR /src
 
 # Pre-stage the controllers module (Gitea client + shared helpers).

--- a/core/services/domain/Containerfile
+++ b/core/services/domain/Containerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22-alpine AS build
+FROM golang:1.26-alpine AS build
 WORKDIR /src
 COPY shared/ shared/
 COPY domain/go.mod domain/go.sum domain/

--- a/core/services/gateway/Containerfile
+++ b/core/services/gateway/Containerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22-alpine AS build
+FROM golang:1.26-alpine AS build
 WORKDIR /src
 COPY shared/ shared/
 COPY gateway/go.mod gateway/go.sum gateway/

--- a/core/services/metering-sidecar/Containerfile
+++ b/core/services/metering-sidecar/Containerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22-alpine AS build
+FROM golang:1.26-alpine AS build
 WORKDIR /src
 COPY shared/ shared/
 COPY metering-sidecar/go.mod metering-sidecar/go.sum metering-sidecar/

--- a/core/services/notification/Containerfile
+++ b/core/services/notification/Containerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22-alpine AS build
+FROM golang:1.26-alpine AS build
 WORKDIR /src
 COPY shared/ shared/
 COPY notification/go.mod notification/go.sum notification/

--- a/core/services/provisioning/Containerfile
+++ b/core/services/provisioning/Containerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22-alpine AS build
+FROM golang:1.26-alpine AS build
 WORKDIR /src
 COPY shared/ shared/
 COPY provisioning/go.mod provisioning/go.sum provisioning/

--- a/core/services/tenant/Containerfile
+++ b/core/services/tenant/Containerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22-alpine AS build
+FROM golang:1.26-alpine AS build
 WORKDIR /src
 COPY shared/ shared/
 COPY tenant/go.mod tenant/go.sum tenant/


### PR DESCRIPTION
## Summary
Every services-build run since 2026-05-18 06:32 UTC has failed at the `build (tenant)` matrix leg with `fail-fast: true`, cancelling every other build (auth/billing/catalog/domain/gateway/metering-sidecar/notification/provisioning) and **skipping deploy** so no new image SHAs are published. The five fixes below were merged to main but never produced container images and never reached t22.

Root cause (verbatim from run 26033556078 → build (tenant) → step 11):

```
#11 0.170 go: go.mod requires go >= 1.26.0 (running go 1.22.12; GOTOOLCHAIN=local)
```

`core/services/tenant/go.mod` was bumped to `go 1.26.0` but `core/services/tenant/Containerfile` still pinned `golang:1.22-alpine`. Because tenant fails first with `fail-fast: true`, the entire matrix is poisoned and `billing` (which only needs go 1.22) is silently **cancelled** — so the PR #1683 fix for the NATS subject-overlap that crashes the billing Pod on every fresh prov never built either.

## Five stranded fixes that never produced new image SHAs

| # | PR | Title |
|---|----|-------|
| 1 | #1683 | fix(billing): consume catalyst.usage.recorded from CATALYST_SME stream (was creating overlapping CATALYST_USAGE) |
| 2 | #1684 | fix(provisioning): set Organization.spec.tenantPublic on product-install path |
| 3 | #1685 | feat(catalog+billing): Sandbox Free/Pro/Ent plans + quota wire |
| 4 | #1686 | feat(sandbox): orchestrator listens tenant.sandbox_requested → SandboxSession |
| 5 | #1690 | feat(sandbox): tier-bound MCP capabilities |

## Live impact (t22 marketplace customer journey)

The `sme/billing` Pod on `t22.omantel.biz` is in `CrashLoopBackOff` because it still runs the **pre-#1683** image with the broken subject layout:

```
ERROR failed to ensure JetStream catalyst.usage stream
error="events: ensure usage stream: nats: API error: code=400 err_code=10065 description=subjects overlap with an existing stream"
```

Three voucher endpoints return 502 through the gateway as a direct consequence (steps 9, 10, 15 of `/tmp/t22-marketplace-customer-journey.jsonl`):
- `GET /api/v1/sme/billing/vouchers/list`
- `POST /api/v1/sme/billing/vouchers/issue`
- `POST /api/v1/sme/billing/vouchers/revoke`

## Change

Bumps all 10 `core/services/*/Containerfile` base images:

- `golang:1.22-alpine` → `golang:1.26-alpine` (9 services: auth, billing, catalog, domain, gateway, metering-sidecar, notification, provisioning, tenant)
- `golang:1.23-alpine` → `golang:1.26-alpine` (catalyst-catalog)

This matches the highest go.mod requirement across the tree (`core/services/tenant/go.mod` → `go 1.26.0`). Forward-compatible: every other service's go.mod still allows go 1.22 build, and 1.26 builds them fine.

## Test plan

- [ ] services-build workflow on `main` returns to **success** (matrix conclusion = success across all 10 legs)
- [ ] Deploy bot pushes new image tags for sme-services-billing (+ all sme-services siblings)
- [ ] Chart 1.4.165 publishes with new `images.smeTag`
- [ ] Flux on t22 reconciles → billing Pod transitions out of CrashLoopBackOff → Running, 0 restarts
- [ ] `GET /api/v1/sme/billing/vouchers/list` returns 200 on t22 (was 502)
- [ ] `POST /api/v1/sme/billing/vouchers/issue` returns 200 on t22 (was 502)

Refs TBD-A1, TBD-C9/C10/C15.

🤖 Generated with [Claude Code](https://claude.com/claude-code)