### PR TITLE
fix(httproutes): retarget guacamole-server + openova-flow-server to cilium-gateway in kube-system (Refs TBD-G6, C12-004)

### DIFF
--- a/clusters/_template/bootstrap-kit/56-bp-openova-flow-server.yaml
+++ b/clusters/_template/bootstrap-kit/56-bp-openova-flow-server.yaml
@@ -101,6 +101,13 @@ spec:
         # overlay disables when only the in-cluster Service is needed.
         enabled: true
         hostname: openova-flow.${SOVEREIGN_FQDN}
+        # Canonical Sovereign Gateway — every other HTTPRoute
+        # (catalyst-api, catalyst-ui, marketplace, gitea, harbor,
+        # keycloak, …) parents to kube-system/cilium-gateway installed
+        # by bootstrap-kit/01-cilium.yaml. Fix (TBD-G6 / C12-004):
+        # the previous value `catalyst-gateway` does not exist on any
+        # Sovereign — the HTTPRoute went Accepted=False with "no
+        # matching parent" on t22.
         gatewayRef:
-          name: catalyst-gateway
+          name: cilium-gateway
           namespace: kube-system

--- a/platform/guacamole/chart/values.yaml
+++ b/platform/guacamole/chart/values.yaml
@@ -137,12 +137,17 @@ guacamole:
   # ── HTTPRoute (Cilium Gateway) ─────────────────────────────────
   httproute:
     enabled: true
-    # Gateway reference. Defaults to the Sovereign's well-known
-    # `cilium-gateway` in namespace `gateway-system`; per-Sovereign
-    # overlay can rebind.
+    # Gateway reference. Defaults to the Sovereign's canonical
+    # `cilium-gateway` in namespace `kube-system` (installed by
+    # bootstrap-kit/01-cilium.yaml — every other Sovereign HTTPRoute
+    # in catalyst-system/gitea/keycloak/harbor/grafana/openbao/etc.
+    # parents to this gateway). Per-Sovereign overlay can rebind.
+    # Fix (TBD-G6 / C12-004): previously defaulted to namespace
+    # `gateway-system`, which has no Gateway on any Sovereign — the
+    # HTTPRoute went Accepted=False with "no matching parent" on t22.
     parentRef:
       name: cilium-gateway
-      namespace: gateway-system
+      namespace: kube-system
     # Hostname this Guacamole answers on. Empty value fails the
     # helm template render (see _helpers.tpl `bp-guacamole.host`).
     hostname: ""


### PR DESCRIPTION
## Summary
- On t22 (fresh omantel.biz Sovereign, chart bp-guacamole-0.1.19, bp-openova-flow-server-0.2.0) 2 of 15 HTTPRoutes went `Accepted=False`:
  - `catalyst-system/guacamole-server` parented `gateway-system/cilium-gateway` (no such namespace/gateway on any Sovereign).
  - `catalyst-system/openova-flow-server` parented `kube-system/catalyst-gateway` (gateway does not exist anywhere).
- The canonical Sovereign Gateway is `kube-system/cilium-gateway`, installed by `bootstrap-kit/01-cilium.yaml`; every other working HTTPRoute (`catalyst-api`, `catalyst-ui`, `marketplace`, `gitea`, `harbor`, `keycloak`, `grafana`, `hubble-ui`, `openbao`, `powerdns`, `tenant-wildcard`) parents to it.

## Changes
- `platform/guacamole/chart/values.yaml` — default `guacamole.httproute.parentRef.namespace: gateway-system -> kube-system`.
- `clusters/_template/bootstrap-kit/56-bp-openova-flow-server.yaml` — `flowServer.httproute.gatewayRef.name: catalyst-gateway -> cilium-gateway` (namespace already `kube-system`).

## Cluster verification (before)
```
catalyst-system/guacamole-server      gateway-system/cilium-gateway   False
catalyst-system/openova-flow-server   kube-system/catalyst-gateway    False
```
(13/15 others Accepted=True parenting kube-system/cilium-gateway.)

## Test plan
- [x] `helm template` of bp-guacamole + bp-openova-flow-server render with the new defaults — parentRefs land in `kube-system/cilium-gateway`.
- [ ] After chart bump (bp-guacamole 0.1.20 + bp-openova-flow-server 0.2.1) lands on t22 via Flux, confirm `kubectl get httproutes -A` shows 15/15 `Accepted=True`.

Refs: TBD-G6 (WBS row C12-004).