### PR TITLE
fix(guacamole): unblock guacamole-server boot (Refs TBD-G4, C5-009)

### DIFF
--- a/clusters/_template/bootstrap-kit/52-bp-guacamole.yaml
+++ b/clusters/_template/bootstrap-kit/52-bp-guacamole.yaml
@@ -102,7 +102,18 @@ spec:
       # Blueprint Release dispatched on the bump commit failed render.sh
       # → 0.1.13–0.1.18 were never published to GHCR → bootstrap-kit
       # HRs wedged at "ghcr.io/openova-io/bp-guacamole:0.1.17: not found".
-      version: 0.1.19
+      # 0.1.21 (Refs TBD-G4 / C5-009, 2026-05-18): pulls in PR #1684
+      # (guacamole-deployment.yaml mount /home/guacamole instead of
+      # /home/guacamole/.guacamole). The official Apache Guacamole
+      # image entrypoint runs `rm -rf $GUACAMOLE_HOME` before
+      # repopulating the directory on every start; when the emptyDir
+      # was mounted directly at /home/guacamole/.guacamole the path
+      # was a mount point and `rm` failed with `Read-only file
+      # system`, crash-looping the webapp before Tomcat ever booted
+      # (observed on t22, 16 restarts). Mounting the parent dir
+      # makes .guacamole a regular subdirectory the entrypoint can
+      # freely rm and recreate.
+      version: 0.1.21
       sourceRef:
         kind: HelmRepository
         name: bp-guacamole


### PR DESCRIPTION
## Summary

Bumps the bp-guacamole bootstrap-kit pin `0.1.19` → `0.1.21` so every Sovereign (and t22 on the next Gitea-mirror + Flux reconcile) installs the chart that contains PR #1684's mount-path fix.

## Root cause on t22

`catalyst-system/guacamole-server-5dc8987df6-gdz7h` was in CrashLoopBackOff with 16 restarts in 61 minutes. Previous-container logs:

```
rm: cannot remove '/home/guacamole/.guacamole': Read-only file system
```

The Apache Guacamole image entrypoint runs `rm -rf $GUACAMOLE_HOME` (== `/home/guacamole/.guacamole`) before repopulating the directory on every start. Chart `0.1.19` mounted the emptyDir directly at `/home/guacamole/.guacamole`; from the kernel's perspective that path was a mount point, so `rm` failed and the entrypoint exited `1` before Tomcat ever booted.

Chart `0.1.21` already contains the fix (PR #1684, commit `7bfb6540`): mount the PARENT directory `/home/guacamole` instead. `.guacamole` becomes a regular subdirectory inside the emptyDir, which the entrypoint can freely `rm -rf` and recreate.

The chart was published to GHCR at `2026-05-18T10:54:55Z` (verified via `gh api /orgs/openova-io/packages/container/bp-guacamole/versions`). What was missing was the bootstrap-kit pin bump — that's all this PR does.

## Diff

`clusters/_template/bootstrap-kit/52-bp-guacamole.yaml`: `version: 0.1.19` → `version: 0.1.21` + history comment.

## Scope

- Single-line version bump + provenance comment.
- No chart/template changes (those landed in PR #1684).
- No new UI, no controller changes, no new APIs.
- Unrelated: the orphan-HTTPRoute issue tracked in C12-004 (guacamole-server HTTPRoute parent in wrong namespace) is a separate fix and is NOT touched here.

## Test plan

- [ ] PR merges to main → `bp-catalyst-platform` Gitea mirror sync pulls the commit into the in-cluster Gitea on t22 → Flux GitRepository reconciles → `bp-guacamole` HelmRelease upgrades from `0.1.19` to `0.1.21`.
- [ ] `kubectl -n catalyst-system get pod -l app.kubernetes.io/name=bp-guacamole,catalyst.openova.io/component=webapp` shows Running, 0 restarts.
- [ ] `kubectl -n catalyst-system get deployment guacamole-server -o jsonpath='{.spec.template.spec.containers[0].volumeMounts[?(@.name=="guacamole-home")].mountPath}'` returns `/home/guacamole` (was `/home/guacamole/.guacamole`).
- [ ] Future fresh provs install chart `0.1.21` directly at handover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)