### PR TITLE
deploy(bp-guacamole): bump bootstrap-kit pin 0.1.21 -> 0.1.22 (Refs TBD-G6, C12-004)

### DIFF
--- a/clusters/_template/bootstrap-kit/52-bp-guacamole.yaml
+++ b/clusters/_template/bootstrap-kit/52-bp-guacamole.yaml
@@ -113,7 +113,15 @@ spec:
       # (observed on t22, 16 restarts). Mounting the parent dir
       # makes .guacamole a regular subdirectory the entrypoint can
       # freely rm and recreate.
-      version: 0.1.21
+      # 0.1.22 (Refs TBD-G6 / C12-004, 2026-05-18): pulls in PR #1692
+      # (values default guacamole.httproute.parentRef.namespace
+      # gateway-system -> kube-system). The
+      # catalyst-system/guacamole-server HTTPRoute on t22 went
+      # Accepted=False because gateway-system/cilium-gateway does not
+      # exist on any Sovereign — the canonical gateway is
+      # kube-system/cilium-gateway installed by 01-cilium.yaml and
+      # used by every other Sovereign HTTPRoute.
+      version: 0.1.22
       sourceRef:
         kind: HelmRepository
         name: bp-guacamole


### PR DESCRIPTION
## Summary
Pull in the chart fix from PR #1692 (bp-guacamole chart 0.1.22 published by Blueprint Release at c1a364b6) so t22's `catalyst-system/guacamole-server` HTTPRoute reparents to `kube-system/cilium-gateway` and flips `Accepted=True`.

Follow-up to PR #1692 — the chart values default fix only lands on Sovereigns once the bootstrap-kit pin is bumped to the published chart version. PR #1693 just bumped the same pin to 0.1.21 to pull in the read-only-fs fix; this bumps to 0.1.22 to additionally pull in the parentRef-namespace fix.

## Test plan
- [ ] After Flux reconcile on t22, `kubectl get httproute -n catalyst-system guacamole-server -o yaml` shows `parentRefs[0].namespace: kube-system` and `Accepted=True`.
- [ ] All 15 HTTPRoutes on t22 are `Accepted=True`.