### PR TITLE
chore(release): bootstrap-kit pin 1.4.164→1.4.165 — Wave 18 collector (sme-services unblock + 4 PRs baked)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -563,7 +563,7 @@ spec:
       # values.yaml sovereign.{enableHotStandby,primaryRegion,
       # replicaRegion} defaults). See Chart.yaml header comment for
       # the full change list.
-      version: 1.4.164
+      version: 1.4.165
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/clusters/_template/bootstrap-kit/52-bp-guacamole.yaml
+++ b/clusters/_template/bootstrap-kit/52-bp-guacamole.yaml
@@ -113,7 +113,15 @@ spec:
       # (observed on t22, 16 restarts). Mounting the parent dir
       # makes .guacamole a regular subdirectory the entrypoint can
       # freely rm and recreate.
-      version: 0.1.21
+      # 0.1.22 (Refs TBD-G6 / C12-004, 2026-05-18): pulls in PR #1692
+      # (values default guacamole.httproute.parentRef.namespace
+      # gateway-system -> kube-system). The
+      # catalyst-system/guacamole-server HTTPRoute on t22 went
+      # Accepted=False because gateway-system/cilium-gateway does not
+      # exist on any Sovereign — the canonical gateway is
+      # kube-system/cilium-gateway installed by 01-cilium.yaml and
+      # used by every other Sovereign HTTPRoute.
+      version: 0.1.22
       sourceRef:
         kind: HelmRepository
         name: bp-guacamole


### PR DESCRIPTION
Bumps bootstrap-kit pin to roll chart 1.4.165 onto Sovereigns. Bakes PR #1689 + #1690 + #1691 + #1692. **Critical: unblocks t22 billing CrashLoopBackOff (18 restarts) → voucher 502 chain.** Refs TBD-A1/A3/G6/C9/C10/C15/D6/D7 in openova-private/docs/WBS.md.