### PR TITLE
deploy(bp-catalyst-platform): bump pin 1.4.164 → 1.4.165 (TBD-A1 follow-up)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -563,7 +563,17 @@ spec:
       # values.yaml sovereign.{enableHotStandby,primaryRegion,
       # replicaRegion} defaults). See Chart.yaml header comment for
       # the full change list.
-      version: 1.4.164
+      #
+      # 1.4.165 (#1691 follow-up): chart-version-only republish to
+      # bake sme-services image SHA 8878938 (the Containerfile
+      # golang 1.22 → 1.26 fix that unblocked services-build after
+      # tenant/go.mod required go 1.26.0). Without this pin bump,
+      # fresh provs would install 1.4.164 which still references the
+      # pre-PR #1683 billing image — billing Pod CrashLoopBackOff
+      # with NATS subject-overlap on catalyst.usage stream. PR #1683
+      # itself was on main since 2026-05-18 but the image never
+      # built until #1691 fixed the matrix.
+      version: 1.4.165
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform


### PR DESCRIPTION
## Summary

Follow-up to PR #1691.

PR #1691 fixed the matrix-poison caused by `core/services/tenant/go.mod requires go >= 1.26.0` running in a `golang:1.22-alpine` container. After merge, services-build run **26033883319** went green across all 10 legs and the deploy-bot pushed commit 93fa6c53:

- `products/catalyst/chart/values.yaml`: `images.smeTag: "8878938"`
- `products/catalyst/chart/Chart.yaml`: `version: 1.4.164` → `1.4.165`

Chart 1.4.165 published to GHCR. But `clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml` still pins `version: 1.4.164`, so Flux on every existing Sovereign cannot upgrade.

This is the canonical "Chart.yaml bump ≠ bootstrap-kit pin bump" pattern (memory entry: `feedback_chart_vs_bootstrap_pin.md`). Both bumps are needed for the new image to land on running clusters.

## Change

Single-line version bump in `clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml` with a comment paragraph documenting the #1691 → #1683 chain for the next operator who reads this file.

## Live impact (t22)

After this merges and chart 1.4.165 reconciles on `t22.omantel.biz`:

- `sme/billing` Pod transitions out of `CrashLoopBackOff` (currently 18 restarts in 107s)
- NATS subject-overlap error on `catalyst.usage` stream stops appearing in logs
- Voucher endpoints return 200 instead of 502:
  - `GET /api/v1/sme/billing/vouchers/list`
  - `POST /api/v1/sme/billing/vouchers/issue`
  - `POST /api/v1/sme/billing/vouchers/revoke`

Unblocks marketplace customer-journey steps 9, 10, 15.

## Test plan

- [ ] PR merges + cluster-template-drift workflow stays green
- [ ] Flux on t22 reconciles bp-catalyst-platform HR from `1.4.164` → `1.4.165` within 15m
- [ ] `sme/billing` Pod on t22 rolls to a new ReplicaSet pulling image SHA `8878938`
- [ ] New billing Pod reaches `Running` with `0` restarts
- [ ] `curl https://console.t22.omantel.biz/api/v1/sme/billing/vouchers/list` returns 200
- [ ] `curl -X POST https://console.t22.omantel.biz/api/v1/sme/billing/vouchers/issue` returns 200

Refs TBD-A1, TBD-C9, TBD-C10, TBD-C15.

🤖 Generated with [Claude Code](https://claude.com/claude-code)