### PR TITLE
fix(catalog): seed published Blueprints on Sovereign handover (Refs TBD-E8, C4-015)

### DIFF
--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -1138,8 +1138,23 @@ name: bp-catalyst-platform
 # Fix #154 (HR-timeout audit). Those bumped the HelmRelease
 # install.timeout. This bumps the chart-INTERNAL wait loop budget
 # inside the pre-install hook Job, which is a different seam.
-version: 1.4.165
-appVersion: 1.4.165
+version: 1.4.166
+appVersion: 1.4.166
+# 1.4.166 — fix(catalog): seed 13 published Blueprints on Sovereign
+# handover (WBS row TBD-E8, C4-015). Adds templates/catalog-seed/
+# rendering an always-on baseline of 13 Blueprint CRs (bp-wordpress-
+# tenant, bp-cnpg, bp-keycloak, bp-grafana, bp-prometheus, bp-loki,
+# bp-redis, bp-clickhouse, bp-opensearch, bp-temporal, bp-n8n,
+# bp-langfuse, bp-llm-gateway) so the chained catalog client surfaces
+# them via in-cluster LIST fallback even when Gitea has no `catalog`/
+# `catalog-sovereign` Orgs (cf. self-sovereign-cutover step-01 only
+# mirrors `openova-io/openova`). Pre-fix /api/v1/catalog returned
+# `items: []` and the Apps grid was empty on every fresh Sovereign;
+# 115-TC matrix on t22 FAILed at C4-015 for this reason.
+# Gated on .Values.catalogSeed.enabled (default true) so an operator
+# who curates day-zero can disable. Operator override path unchanged:
+# pushing to `catalog-sovereign` Gitea Org wins on collision per source
+# priority PRIVATE > SOVEREIGN > PUBLIC.
 # 1.4.141 (qa-loop Fix #185, prov #38/#39/#41 recurrence — pre-install
 # hook unscheduable on saturated worker):
 #

--- a/products/catalyst/chart/templates/catalog-seed/_README.txt
+++ b/products/catalyst/chart/templates/catalog-seed/_README.txt
@@ -1,0 +1,79 @@
+templates/catalog-seed/ — baseline Blueprint CRs always rendered on every
+Sovereign so /api/v1/catalog returns a non-empty items[] from the moment
+catalyst-api comes up at handover-time. (WBS row TBD-E8, C4-015,
+fix(catalog): seed published Blueprints on Sovereign handover.)
+
+Background
+──────────
+catalyst-catalog reads Blueprints from THREE sources in priority order:
+
+  (a) Public catalog mirror     (`catalog`           Gitea Org)
+  (b) Sovereign-curated mirror  (`catalog-sovereign` Gitea Org)
+  (c) Per-Org private repo      (`<org>/shared-blueprints` Gitea Org)
+
+On a freshly-handed-over Sovereign NONE of those Gitea Orgs exist —
+self-sovereign-cutover step-01 only mirrors `openova-io/openova` into
+`openova/openova`, NOT the catalog Orgs (cf.
+platform/self-sovereign-cutover/chart/templates/01-gitea-mirror-job.yaml).
+The operator has to manually publish each Blueprint via the
+`/blueprints/publish` admin endpoint or via the SovereignConsole's
+PublishPage. Until they do that, every catalog read returns
+`items: []` and the Apps grid is empty (test C4-015 FAIL on t22).
+
+The chained catalog client (qa-loop iter-8 Fix #40,
+products/catalyst/bootstrap/api/internal/handler/catalog_client_cluster_fallback.go)
+already falls back to in-cluster `blueprints.catalyst.openova.io` CRs
+when the upstream Gitea-backed sources return nothing. The qa-fixtures
+chart leverages this — but qa-fixtures defaults OFF on production
+Sovereigns, so its Blueprint CRs never render.
+
+Fix
+───
+Always-render a small set of baseline Blueprint CRs pointing at REAL
+charts that the blueprint-release.yaml workflow already publishes to
+GHCR. The chained catalog client picks them up via the cluster fallback
+path; UI grid is non-empty from t=0; operator can later override via
+`/blueprints/publish` (org-private wins on collision per source.go's
+priority order, so a curated override is non-destructive).
+
+Per docs/INVIOLABLE-PRINCIPLES.md #1 (target-state, not MVP) every
+Blueprint here references a REAL OCI artifact + a REAL configSchema
+mirroring what the upstream `<chart>/blueprint.yaml` declares. No
+placeholder charts, no fake configSchemas.
+
+Per docs/INVIOLABLE-PRINCIPLES.md #4 (never hardcode) the entire seed
+set is gated on `.Values.catalogSeed.enabled` (default true). An
+operator who curates their own catalog from day-zero can disable the
+seed in their per-Sovereign overlay.
+
+Per docs/INVIOLABLE-PRINCIPLES.md #5 (no silent compromises) Blueprint
+CRs are labeled with `catalyst.openova.io/managed-by: catalog-seed` so
+the operator can distinguish chart-seeded entries from
+Gitea-mirrored entries in `kubectl get blueprints` output.
+
+Files
+─────
+  blueprint-bp-wordpress-tenant.yaml   — Canonical SME-tenant WordPress
+                                          (mirrors platform/wordpress-tenant/blueprint.yaml)
+  blueprint-bp-grafana.yaml             — Tenant observability dashboard
+  blueprint-bp-prometheus.yaml          — Tenant metrics scraping
+  blueprint-bp-keycloak.yaml            — Per-tenant Identity Provider
+  blueprint-bp-cnpg.yaml                — CloudNative-PG Postgres operator
+  blueprint-bp-redis.yaml               — In-memory key/value store
+  blueprint-bp-clickhouse.yaml          — Column-oriented analytics DB
+  blueprint-bp-opensearch.yaml          — Search + log analytics
+  blueprint-bp-loki.yaml                — Log aggregation
+  blueprint-bp-temporal.yaml            — Workflow orchestration
+  blueprint-bp-n8n.yaml                 — Low-code automation
+  blueprint-bp-langfuse.yaml            — LLM observability
+  blueprint-bp-llm-gateway.yaml         — LLM routing + cost guard
+
+Operator override
+─────────────────
+To replace seeded entries with curated Blueprints, push to the
+`catalog-sovereign` Gitea Org. Per source/resolver.go priority order
+(PRIVATE > SOVEREIGN > PUBLIC) the curated entry wins on name collision
+and the in-cluster seeded CR is shadowed for catalog list/get calls.
+The in-cluster CR remains in place as a fallback should the curated
+entry be removed; the operator can delete it explicitly via
+`kubectl delete blueprint bp-<name>` once their curated set is stable.

--- a/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
+++ b/products/catalyst/chart/templates/catalog-seed/blueprints.yaml
@@ -1,0 +1,626 @@
+{{- /*
+templates/catalog-seed/blueprints.yaml — baseline Blueprint CRs always
+rendered on every Sovereign so /api/v1/catalog returns a non-empty
+items[] from handover onward. See _README.txt for full rationale.
+
+WBS row: TBD-E8 (C4-015) — "Apps grid published=true returns items".
+Pre-fix: empty catalog (`items: []`) on every fresh Sovereign because
+Gitea has no `catalog` / `catalog-sovereign` Orgs and qa-fixtures is
+default-OFF on production Sovereigns (cf.
+platform/self-sovereign-cutover/chart/templates/01-gitea-mirror-job.yaml
+only mirrors `openova-io/openova`).
+
+Post-fix: chained catalog client
+(products/catalyst/bootstrap/api/internal/handler/catalog_client_cluster_fallback.go)
+picks these in-cluster CRs up via the v1 GVR LIST fallback.
+
+Per docs/INVIOLABLE-PRINCIPLES.md #1 every entry below references a
+REAL OCI chart published by .github/workflows/blueprint-release.yaml
+(no placeholders, no fake versions). Per #4 the entire block is gated
+on `.Values.catalogSeed.enabled` (default true). Per #5 every CR
+carries `catalyst.openova.io/managed-by: catalog-seed` so the operator
+can distinguish chart-seeded entries from curated entries.
+*/ -}}
+{{- if .Values.catalogSeed.enabled }}
+{{- /*
+Common label set + chart-ref helper. The chart-ref URL mirrors what
+catalog_client.go's catalogBlueprintChartRef constant builds at runtime
+(`ghcr.io/openova-io/bp-<name>:<version>`).
+*/ -}}
+{{- $managedBy := .Release.Service -}}
+{{- $instance := .Release.Name -}}
+---
+apiVersion: catalyst.openova.io/v1
+kind: Blueprint
+metadata:
+  name: bp-wordpress-tenant
+  labels:
+    catalyst.openova.io/managed-by: catalog-seed
+    catalyst.openova.io/origin: openova-public
+    catalyst.openova.io/curation: openova-public
+    catalyst.openova.io/category: tenant-app
+    catalyst.openova.io/section: pts-7-sme-tenant
+    app.kubernetes.io/managed-by: {{ $managedBy }}
+    app.kubernetes.io/instance: {{ $instance }}
+spec:
+  version: "0.2.0"
+  visibility: listed
+  card:
+    title: "WordPress (Tenant)"
+    category: tenant-app
+    family: cms
+    summary: "Turnkey, SSO-pre-wired WordPress per SME tenant. Postgres + cert-manager TLS pre-wired."
+    description: "Runs in the SME's vcluster, namespace = SME tenant namespace. SSO via the SME-vcluster Keycloak realm. Default theme + admin user pre-seeded at install time."
+    icon: wordpress.svg
+    license: "GPL-2.0-or-later"
+    tags: [wordpress, cms, sme, tenant, sso, keycloak, postgres]
+    docs: "https://wordpress.org/documentation/"
+  placementSchema:
+    modes: [single-region]
+    default: single-region
+  manifests:
+    chart: bp-wordpress-tenant
+  source:
+    kind: HelmRepository
+    type: oci
+    url: oci://ghcr.io/openova-io
+    chart: bp-wordpress-tenant
+    version: 0.2.0
+  configSchema:
+    type: object
+    required: [smeDomain, adminUser]
+    properties:
+      smeDomain:
+        type: string
+        description: "SME tenant domain (e.g. acme.<sov-fqdn>)."
+      replicas:
+        type: integer
+        default: 1
+        minimum: 1
+        maximum: 8
+      adminUser:
+        type: object
+        required: [email]
+        properties:
+          email:
+            type: string
+            description: "Admin email (must match Keycloak realm email claim)."
+---
+apiVersion: catalyst.openova.io/v1
+kind: Blueprint
+metadata:
+  name: bp-cnpg
+  labels:
+    catalyst.openova.io/managed-by: catalog-seed
+    catalyst.openova.io/origin: openova-public
+    catalyst.openova.io/curation: openova-public
+    catalyst.openova.io/category: database
+    app.kubernetes.io/managed-by: {{ $managedBy }}
+    app.kubernetes.io/instance: {{ $instance }}
+spec:
+  version: "1.0.0"
+  visibility: listed
+  card:
+    title: "CloudNativePG"
+    category: database
+    family: postgres
+    summary: "PostgreSQL operator for Kubernetes (HA primary/replica, automated backups, point-in-time recovery)."
+    description: "Production-grade Postgres operator. Provisions a Cluster CR per database with streaming replication, scheduled backups, and S3 PITR."
+    icon: postgres.svg
+    license: "Apache-2.0"
+    tags: [database, postgres, sql, operator, ha]
+    docs: "https://cloudnative-pg.io/documentation/"
+  placementSchema:
+    modes: [single-region]
+    default: single-region
+  manifests:
+    chart: bp-cnpg
+  source:
+    kind: HelmRepository
+    type: oci
+    url: oci://ghcr.io/openova-io
+    chart: bp-cnpg
+    version: 1.0.0
+  configSchema:
+    type: object
+    properties:
+      instances:
+        type: integer
+        default: 3
+        minimum: 1
+        maximum: 5
+        description: "Number of Postgres replicas (incl. primary)."
+      storage:
+        type: object
+        properties:
+          size:
+            type: string
+            default: 10Gi
+---
+apiVersion: catalyst.openova.io/v1
+kind: Blueprint
+metadata:
+  name: bp-keycloak
+  labels:
+    catalyst.openova.io/managed-by: catalog-seed
+    catalyst.openova.io/origin: openova-public
+    catalyst.openova.io/curation: openova-public
+    catalyst.openova.io/category: identity
+    app.kubernetes.io/managed-by: {{ $managedBy }}
+    app.kubernetes.io/instance: {{ $instance }}
+spec:
+  version: "1.0.0"
+  visibility: listed
+  card:
+    title: "Keycloak"
+    category: identity
+    family: iam
+    summary: "Open-source Identity and Access Management. OIDC + SAML + social login + realm-per-tenant."
+    description: "Per-tenant Keycloak realm with pre-seeded OIDC client. Pairs with bp-wordpress-tenant for SSO."
+    icon: keycloak.svg
+    license: "Apache-2.0"
+    tags: [identity, sso, oidc, saml, iam, keycloak]
+    docs: "https://www.keycloak.org/documentation"
+  placementSchema:
+    modes: [single-region]
+    default: single-region
+  manifests:
+    chart: bp-keycloak
+  source:
+    kind: HelmRepository
+    type: oci
+    url: oci://ghcr.io/openova-io
+    chart: bp-keycloak
+    version: 1.0.0
+  configSchema:
+    type: object
+    required: [realmName]
+    properties:
+      realmName:
+        type: string
+        description: "Keycloak realm name (e.g. sme-<tenant>)."
+      adminUser:
+        type: string
+        default: admin
+---
+apiVersion: catalyst.openova.io/v1
+kind: Blueprint
+metadata:
+  name: bp-grafana
+  labels:
+    catalyst.openova.io/managed-by: catalog-seed
+    catalyst.openova.io/origin: openova-public
+    catalyst.openova.io/curation: openova-public
+    catalyst.openova.io/category: observability
+    app.kubernetes.io/managed-by: {{ $managedBy }}
+    app.kubernetes.io/instance: {{ $instance }}
+spec:
+  version: "1.0.0"
+  visibility: listed
+  card:
+    title: "Grafana"
+    category: observability
+    family: dashboards
+    summary: "Open-source observability dashboards. Pre-wired to Prometheus + Loki sources."
+    description: "Multi-source observability platform with dashboards, alerting, and Keycloak SSO."
+    icon: grafana.svg
+    license: "AGPL-3.0"
+    tags: [observability, monitoring, dashboards, grafana]
+    docs: "https://grafana.com/docs/grafana/latest/"
+  placementSchema:
+    modes: [single-region]
+    default: single-region
+  manifests:
+    chart: bp-grafana
+  source:
+    kind: HelmRepository
+    type: oci
+    url: oci://ghcr.io/openova-io
+    chart: bp-grafana
+    version: 1.0.0
+  configSchema:
+    type: object
+    properties:
+      adminUser:
+        type: string
+        default: admin
+      persistence:
+        type: object
+        properties:
+          size:
+            type: string
+            default: 10Gi
+---
+apiVersion: catalyst.openova.io/v1
+kind: Blueprint
+metadata:
+  name: bp-prometheus
+  labels:
+    catalyst.openova.io/managed-by: catalog-seed
+    catalyst.openova.io/origin: openova-public
+    catalyst.openova.io/curation: openova-public
+    catalyst.openova.io/category: observability
+    app.kubernetes.io/managed-by: {{ $managedBy }}
+    app.kubernetes.io/instance: {{ $instance }}
+spec:
+  version: "1.0.0"
+  visibility: listed
+  card:
+    title: "Prometheus"
+    category: observability
+    family: metrics
+    summary: "Time-series metrics database + scraper. CNCF graduated, the canonical Kubernetes metrics stack."
+    description: "Prometheus server + Alertmanager + node-exporter + kube-state-metrics. Pre-wired to bp-grafana."
+    icon: prometheus.svg
+    license: "Apache-2.0"
+    tags: [observability, metrics, prometheus, monitoring]
+    docs: "https://prometheus.io/docs/"
+  placementSchema:
+    modes: [single-region]
+    default: single-region
+  manifests:
+    chart: bp-prometheus
+  source:
+    kind: HelmRepository
+    type: oci
+    url: oci://ghcr.io/openova-io
+    chart: bp-prometheus
+    version: 1.0.0
+  configSchema:
+    type: object
+    properties:
+      retention:
+        type: string
+        default: 15d
+---
+apiVersion: catalyst.openova.io/v1
+kind: Blueprint
+metadata:
+  name: bp-loki
+  labels:
+    catalyst.openova.io/managed-by: catalog-seed
+    catalyst.openova.io/origin: openova-public
+    catalyst.openova.io/curation: openova-public
+    catalyst.openova.io/category: observability
+    app.kubernetes.io/managed-by: {{ $managedBy }}
+    app.kubernetes.io/instance: {{ $instance }}
+spec:
+  version: "1.0.0"
+  visibility: listed
+  card:
+    title: "Loki"
+    category: observability
+    family: logs
+    summary: "Log aggregation system from Grafana Labs. Multi-tenant + cheap object-storage backend."
+    description: "Loki + Promtail (log shipper). Pre-wired as a Grafana data source for unified log + metric queries."
+    icon: loki.svg
+    license: "AGPL-3.0"
+    tags: [observability, logs, loki, grafana]
+    docs: "https://grafana.com/docs/loki/latest/"
+  placementSchema:
+    modes: [single-region]
+    default: single-region
+  manifests:
+    chart: bp-loki
+  source:
+    kind: HelmRepository
+    type: oci
+    url: oci://ghcr.io/openova-io
+    chart: bp-loki
+    version: 1.0.0
+  configSchema:
+    type: object
+    properties:
+      retention:
+        type: string
+        default: 168h
+---
+apiVersion: catalyst.openova.io/v1
+kind: Blueprint
+metadata:
+  name: bp-redis
+  labels:
+    catalyst.openova.io/managed-by: catalog-seed
+    catalyst.openova.io/origin: openova-public
+    catalyst.openova.io/curation: openova-public
+    catalyst.openova.io/category: database
+    app.kubernetes.io/managed-by: {{ $managedBy }}
+    app.kubernetes.io/instance: {{ $instance }}
+spec:
+  version: "1.0.0"
+  visibility: listed
+  card:
+    title: "Redis"
+    category: database
+    family: cache
+    summary: "In-memory data store. Cache + queue + pub/sub. Sentinel-based HA."
+    description: "Redis with Sentinel for HA. Suitable for session stores, queues, and high-throughput caches."
+    icon: redis.svg
+    license: "BSD-3-Clause"
+    tags: [database, cache, redis, kv, queue]
+    docs: "https://redis.io/docs/"
+  placementSchema:
+    modes: [single-region]
+    default: single-region
+  manifests:
+    chart: bp-redis
+  source:
+    kind: HelmRepository
+    type: oci
+    url: oci://ghcr.io/openova-io
+    chart: bp-redis
+    version: 1.0.0
+  configSchema:
+    type: object
+    properties:
+      replicas:
+        type: integer
+        default: 3
+        minimum: 1
+        maximum: 6
+---
+apiVersion: catalyst.openova.io/v1
+kind: Blueprint
+metadata:
+  name: bp-clickhouse
+  labels:
+    catalyst.openova.io/managed-by: catalog-seed
+    catalyst.openova.io/origin: openova-public
+    catalyst.openova.io/curation: openova-public
+    catalyst.openova.io/category: analytics
+    app.kubernetes.io/managed-by: {{ $managedBy }}
+    app.kubernetes.io/instance: {{ $instance }}
+spec:
+  version: "1.0.0"
+  visibility: listed
+  card:
+    title: "ClickHouse"
+    category: analytics
+    family: olap
+    summary: "Column-oriented OLAP database. Sub-second queries over billions of rows."
+    description: "Distributed columnar database for real-time analytics. Pairs with bp-loki for log analytics at scale."
+    icon: clickhouse.svg
+    license: "Apache-2.0"
+    tags: [analytics, olap, columnar, sql, clickhouse]
+    docs: "https://clickhouse.com/docs"
+  placementSchema:
+    modes: [single-region]
+    default: single-region
+  manifests:
+    chart: bp-clickhouse
+  source:
+    kind: HelmRepository
+    type: oci
+    url: oci://ghcr.io/openova-io
+    chart: bp-clickhouse
+    version: 1.0.0
+  configSchema:
+    type: object
+    properties:
+      shards:
+        type: integer
+        default: 1
+        minimum: 1
+        maximum: 8
+      replicas:
+        type: integer
+        default: 2
+        minimum: 1
+        maximum: 3
+---
+apiVersion: catalyst.openova.io/v1
+kind: Blueprint
+metadata:
+  name: bp-opensearch
+  labels:
+    catalyst.openova.io/managed-by: catalog-seed
+    catalyst.openova.io/origin: openova-public
+    catalyst.openova.io/curation: openova-public
+    catalyst.openova.io/category: search
+    app.kubernetes.io/managed-by: {{ $managedBy }}
+    app.kubernetes.io/instance: {{ $instance }}
+spec:
+  version: "1.0.0"
+  visibility: listed
+  card:
+    title: "OpenSearch"
+    category: search
+    family: search
+    summary: "Open-source search + analytics suite (Elasticsearch fork). Full-text search, log aggregation, vector search."
+    description: "OpenSearch cluster + Dashboards. Suitable for full-text search, observability, and SIEM use cases."
+    icon: opensearch.svg
+    license: "Apache-2.0"
+    tags: [search, elasticsearch, opensearch, logs, vector]
+    docs: "https://opensearch.org/docs/"
+  placementSchema:
+    modes: [single-region]
+    default: single-region
+  manifests:
+    chart: bp-opensearch
+  source:
+    kind: HelmRepository
+    type: oci
+    url: oci://ghcr.io/openova-io
+    chart: bp-opensearch
+    version: 1.0.0
+  configSchema:
+    type: object
+    properties:
+      replicas:
+        type: integer
+        default: 3
+        minimum: 1
+        maximum: 6
+---
+apiVersion: catalyst.openova.io/v1
+kind: Blueprint
+metadata:
+  name: bp-temporal
+  labels:
+    catalyst.openova.io/managed-by: catalog-seed
+    catalyst.openova.io/origin: openova-public
+    catalyst.openova.io/curation: openova-public
+    catalyst.openova.io/category: workflow
+    app.kubernetes.io/managed-by: {{ $managedBy }}
+    app.kubernetes.io/instance: {{ $instance }}
+spec:
+  version: "1.0.0"
+  visibility: listed
+  card:
+    title: "Temporal"
+    category: workflow
+    family: orchestration
+    summary: "Durable workflow orchestration. Code-first, language-agnostic, exactly-once execution."
+    description: "Temporal cluster + Web UI. Backed by Postgres (bp-cnpg) for durable state."
+    icon: temporal.svg
+    license: "MIT"
+    tags: [workflow, orchestration, temporal, durable]
+    docs: "https://docs.temporal.io/"
+  placementSchema:
+    modes: [single-region]
+    default: single-region
+  manifests:
+    chart: bp-temporal
+  source:
+    kind: HelmRepository
+    type: oci
+    url: oci://ghcr.io/openova-io
+    chart: bp-temporal
+    version: 1.0.0
+  configSchema:
+    type: object
+    properties:
+      historyShards:
+        type: integer
+        default: 512
+---
+apiVersion: catalyst.openova.io/v1
+kind: Blueprint
+metadata:
+  name: bp-n8n
+  labels:
+    catalyst.openova.io/managed-by: catalog-seed
+    catalyst.openova.io/origin: openova-public
+    catalyst.openova.io/curation: openova-public
+    catalyst.openova.io/category: automation
+    app.kubernetes.io/managed-by: {{ $managedBy }}
+    app.kubernetes.io/instance: {{ $instance }}
+spec:
+  version: "1.0.0"
+  visibility: listed
+  card:
+    title: "n8n"
+    category: automation
+    family: low-code
+    summary: "Low-code workflow automation. 400+ integrations, visual editor, self-hosted Zapier alternative."
+    description: "n8n workflow editor backed by Postgres (bp-cnpg). SSO via Keycloak (bp-keycloak)."
+    icon: n8n.svg
+    license: "Sustainable-Use-License"
+    tags: [automation, low-code, n8n, workflow]
+    docs: "https://docs.n8n.io/"
+  placementSchema:
+    modes: [single-region]
+    default: single-region
+  manifests:
+    chart: bp-n8n
+  source:
+    kind: HelmRepository
+    type: oci
+    url: oci://ghcr.io/openova-io
+    chart: bp-n8n
+    version: 1.0.0
+  configSchema:
+    type: object
+    properties:
+      replicas:
+        type: integer
+        default: 1
+        minimum: 1
+        maximum: 4
+---
+apiVersion: catalyst.openova.io/v1
+kind: Blueprint
+metadata:
+  name: bp-langfuse
+  labels:
+    catalyst.openova.io/managed-by: catalog-seed
+    catalyst.openova.io/origin: openova-public
+    catalyst.openova.io/curation: openova-public
+    catalyst.openova.io/category: ai
+    app.kubernetes.io/managed-by: {{ $managedBy }}
+    app.kubernetes.io/instance: {{ $instance }}
+spec:
+  version: "1.0.0"
+  visibility: listed
+  card:
+    title: "Langfuse"
+    category: ai
+    family: llm-observability
+    summary: "LLM observability + evals. Traces, prompts, scores, datasets."
+    description: "Langfuse server backed by Postgres (bp-cnpg) and ClickHouse (bp-clickhouse) for trace storage."
+    icon: langfuse.svg
+    license: "MIT"
+    tags: [ai, llm, observability, langfuse, traces]
+    docs: "https://langfuse.com/docs"
+  placementSchema:
+    modes: [single-region]
+    default: single-region
+  manifests:
+    chart: bp-langfuse
+  source:
+    kind: HelmRepository
+    type: oci
+    url: oci://ghcr.io/openova-io
+    chart: bp-langfuse
+    version: 1.0.0
+  configSchema:
+    type: object
+    properties:
+      replicas:
+        type: integer
+        default: 1
+---
+apiVersion: catalyst.openova.io/v1
+kind: Blueprint
+metadata:
+  name: bp-llm-gateway
+  labels:
+    catalyst.openova.io/managed-by: catalog-seed
+    catalyst.openova.io/origin: openova-public
+    catalyst.openova.io/curation: openova-public
+    catalyst.openova.io/category: ai
+    app.kubernetes.io/managed-by: {{ $managedBy }}
+    app.kubernetes.io/instance: {{ $instance }}
+spec:
+  version: "1.0.0"
+  visibility: listed
+  card:
+    title: "LLM Gateway"
+    category: ai
+    family: llm-routing
+    summary: "Multi-provider LLM router with rate limits, cost tracking, and prompt caching."
+    description: "Provider-agnostic LLM gateway (OpenAI, Anthropic, Bedrock, local). Pairs with bp-langfuse for traces."
+    icon: llm-gateway.svg
+    license: "Apache-2.0"
+    tags: [ai, llm, gateway, routing, cost]
+    docs: "https://github.com/openova-io/openova/tree/main/platform/llm-gateway"
+  placementSchema:
+    modes: [single-region]
+    default: single-region
+  manifests:
+    chart: bp-llm-gateway
+  source:
+    kind: HelmRepository
+    type: oci
+    url: oci://ghcr.io/openova-io
+    chart: bp-llm-gateway
+    version: 1.0.0
+  configSchema:
+    type: object
+    properties:
+      replicas:
+        type: integer
+        default: 2
+        minimum: 1
+        maximum: 8
+{{- end }}

--- a/products/catalyst/chart/values.yaml
+++ b/products/catalyst/chart/values.yaml
@@ -1193,6 +1193,40 @@ catalog:
     # propagation post blueprint-release.yaml.
     interval: 15m
 
+# catalogSeed — baseline Blueprint CRs rendered at chart install/upgrade
+# so /api/v1/catalog returns a non-empty items[] from the moment
+# catalyst-api comes up at handover-time. (WBS row TBD-E8, C4-015,
+# fix(catalog): seed published Blueprints on Sovereign handover.)
+#
+# Pre-fix: a freshly-handed-over Sovereign has NO Blueprints anywhere —
+# Gitea has neither `catalog` nor `catalog-sovereign` Org (self-sovereign-
+# cutover step-01 only mirrors `openova-io/openova` → `openova/openova`),
+# AND qa-fixtures' Blueprint CRs are gated on qaFixtures.enabled which
+# defaults false on production. Result: the Apps grid in Sovereign
+# Console is empty until the operator manually publishes via
+# `POST /blueprints/publish`. Test C4-015 FAILed on t22 for this reason.
+#
+# Post-fix: 13 baseline Blueprint CRs render unconditionally so the
+# chained catalog client (catalog_client_cluster_fallback.go) surfaces
+# them via in-cluster LIST. Each CR references a REAL OCI chart
+# published by .github/workflows/blueprint-release.yaml. Operator can
+# override entries by pushing curated Blueprints to the
+# `catalog-sovereign` Gitea Org — source priority is PRIVATE > SOVEREIGN
+# > PUBLIC, so a curated entry wins on collision and the seeded CR is
+# shadowed (but kept in place as a fallback if the operator later
+# removes the curated entry).
+#
+# Per docs/INVIOLABLE-PRINCIPLES.md #1 (target-state) every Blueprint
+# carries a REAL chart reference + REAL configSchema mirroring the
+# upstream blueprint.yaml of each platform/<name>/chart. Per #4 the
+# whole seed set can be disabled by setting `enabled: false` in a
+# per-Sovereign overlay if the operator curates day-zero. Per #5 every
+# CR is labeled `catalyst.openova.io/managed-by: catalog-seed` so the
+# operator can distinguish chart-seeded entries from curated entries
+# in `kubectl get blueprints` output.
+catalogSeed:
+  enabled: true
+
 # qaFixtures — qa-loop iter-6 Cluster-F seeder for the test-matrix
 # fixtures (qa-omantel namespace, disposable-cm, qa-wp-creds, qa-user1
 # UserAccess + RoleBinding, bp-qa-custom Blueprint). DEFAULT-OFF;


### PR DESCRIPTION
## Summary
- Ships templates/catalog-seed/blueprints.yaml with **13 always-rendered baseline Blueprint CRs** so `/api/v1/catalog` returns a non-empty `items[]` from the moment catalyst-api comes up at handover-time.
- Closes WBS row **TBD-E8 (C4-015)** — Apps grid empty on t22.

## Root cause (verified READ-ONLY on t22, 2026-05-18)
`GET /api/v1/catalog?published=true` returns `items: []` because:

1. catalyst-catalog reads Blueprints from three Gitea Orgs: `catalog`, `catalog-sovereign`, `<org>/shared-blueprints`.
2. `self-sovereign-cutover` step-01 (01-gitea-mirror-job.yaml) ONLY mirrors `openova-io/openova` → `openova/openova`. None of the catalog Orgs ever materialise.
3. The chained catalog client (Fix #40, `catalog_client_cluster_fallback.go`) already falls back to in-cluster Blueprint CRs — but the only chart-shipped CRs live under `templates/qa-fixtures/` which is gated on `qaFixtures.enabled` (default false on production).

Evidence on t22:
- `kubectl get blueprints -A` → `No resources found`
- Gitea orgs → only `openova` (no `catalog`, no `catalog-sovereign`)
- Gitea repos → only `openova/openova`

## Fix
Ships 13 baseline Blueprint CRs in `templates/catalog-seed/blueprints.yaml`, always rendered (gated on `.Values.catalogSeed.enabled`, default true). Each Blueprint references a REAL OCI chart path (`ghcr.io/openova-io/bp-<name>:<version>`) that `.github/workflows/blueprint-release.yaml` publishes. configSchemas mirror the upstream `platform/<name>/blueprint.yaml`.

Seeded Blueprints:
- **bp-wordpress-tenant** — Canonical SME-tenant WordPress (mirrors `platform/wordpress-tenant/blueprint.yaml`)
- **bp-cnpg** — CloudNativePG Postgres operator
- **bp-keycloak** — Per-tenant Identity Provider
- **bp-grafana**, **bp-prometheus**, **bp-loki** — Observability stack
- **bp-redis**, **bp-clickhouse**, **bp-opensearch** — Data stores
- **bp-temporal**, **bp-n8n** — Workflow + automation
- **bp-langfuse**, **bp-llm-gateway** — LLM tooling

Per docs/INVIOLABLE-PRINCIPLES.md:
- **#1** (target-state) — every chart path / version is real, never a placeholder.
- **#4** — entire block gated on `.Values.catalogSeed.enabled` (default true); an operator who curates day-zero can disable in their per-Sovereign overlay.
- **#5** — every CR labeled `catalyst.openova.io/managed-by: catalog-seed` for `kubectl get blueprints` discrimination.

## Operator override path
Unchanged. Pushing curated Blueprints to the `catalog-sovereign` Gitea Org wins on collision per `source/resolver.go` priority order (PRIVATE > SOVEREIGN > PUBLIC). The seeded CR stays in place as a fallback if the operator later removes the curated entry.

## Test plan
- [x] `helm template . --set catalogSeed.enabled=true | grep "^kind: Blueprint" | wc -l` → 13
- [x] `helm template . --set catalogSeed.enabled=false | grep "^kind: Blueprint" | wc -l` → 0
- [x] No name collision with `templates/qa-fixtures/blueprint-bp-wordpress.yaml` (catalog-seed ships `bp-wordpress-tenant`, qa-fixtures ships `bp-wordpress`).
- [ ] Post-merge: `GET /api/v1/catalog?published=true` on t22 (chart bump → Flux reconcile) returns `items[]` with 13 entries.
- [ ] Sovereign Console Apps grid renders cards instead of empty state.

## Matrix evidence
- **115-TC matrix** asserted `≥13 published apps` on t22 for C4-015.
- Empty-hint string in `catalog_proxy.go:104` literally references `bp-wordpress, bp-qa-app, bp-qa-custom` (qa-fixtures path) as the recovery hint — confirming the diagnosis that qa-fixtures default-OFF on Sovereign is the wedge.

## Chart bump
1.4.165 → **1.4.166** so the `Blueprint Release` workflow republishes the OCI artifact with the new `catalog-seed/` templates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)