### PR TITLE
fix(guacamole): readinessProbe path /guacamole/ matches webapp deploy root (Refs TBD-G4)

### DIFF
--- a/platform/guacamole/chart/Chart.yaml
+++ b/platform/guacamole/chart/Chart.yaml
@@ -40,7 +40,15 @@ name: bp-guacamole
 # 0.1.17 (Fix #163, 2026-05-11, MIRROR-EVERYTHING): migrationImage AND
 # oidc-secret-bootstrap-job both gain explicit
 # harbor.openova.io/proxy-dockerhub prefix per CLAUDE.md inviolable rule.
-version: 0.1.22
+# 0.1.23 (Refs TBD-G4 phase 2, 2026-05-18): readiness + liveness probe
+# paths flipped from `/` to `/guacamole/`. The Apache Guacamole webapp
+# deploys at Tomcat's context path /guacamole/ (the WAR file is
+# `guacamole.war` so Tomcat exposes it at /<warname>/). The container
+# root path `/` returns 404 from Tomcat's empty ROOT context, so
+# probing `/` made kubelet restart the Pod every ~60s and the kube-
+# system Cilium gateway returned 503 to `https://guacamole.<sov>/`
+# because no endpoint was ever Ready (observed on t22, 5 restarts).
+version: 0.1.23
 appVersion: "1.5.5"
 description: |
   Catalyst-authored Blueprint chart for Apache Guacamole — a clientless

--- a/platform/guacamole/chart/templates/guacamole-deployment.yaml
+++ b/platform/guacamole/chart/templates/guacamole-deployment.yaml
@@ -100,15 +100,27 @@ spec:
             {{- toYaml .Values.guacamole.webapp.resources | nindent 12 }}
           securityContext:
             {{- toYaml .Values.guacamole.containerSecurityContext | nindent 12 }}
+          # The Apache Guacamole webapp deploys under Tomcat's context
+          # path `/guacamole/` (the WAR is `guacamole.war` so Tomcat
+          # exposes it at `/<warname>/`). The container root path `/`
+          # is NOT served by the webapp — it returns 404 from Tomcat's
+          # ROOT context. Probing `/` previously caused liveness +
+          # readiness probes to fail with HTTP 404, the kubelet to
+          # restart the Pod every ~60s, and the kube-system Cilium
+          # gateway to return 503 to the public hostname because no
+          # endpoint was ever Ready (observed on t22, 5 restarts).
+          # Probing `/guacamole/` matches the actual webapp root.
+          # Operator-visible /guacamole.html → /guacamole/ redirect is
+          # handled by the HTTPRoute (separate PR / TBD-G6 follow-up).
           livenessProbe:
             httpGet:
-              path: /
+              path: /guacamole/
               port: http
             initialDelaySeconds: 30
             periodSeconds: 30
           readinessProbe:
             httpGet:
-              path: /
+              path: /guacamole/
               port: http
             initialDelaySeconds: 10
             periodSeconds: 10


### PR DESCRIPTION
## Summary

Phase 2 of TBD-G4. After PR #1684 (emptyDir mount fix) the
Guacamole webapp boots cleanly, but `kube-system` gateway still
returns 503 to `https://guacamole.t22.omantel.biz/` because the
Pod is never Ready (5 restarts in 8m of uptime on t22).

Root cause: the Apache Guacamole webapp deploys under Tomcat's
context path `/guacamole/` (the WAR file is `guacamole.war` so
Tomcat exposes it at `/<warname>/`). Tomcat's ROOT context at `/`
returns 404. Liveness + readiness probes were hitting `/` so:

- readiness probe → HTTP 404 → Endpoint never added to Service
- liveness probe → HTTP 404 → kubelet restarts the Pod every ~60s

Both probes flipped to `/guacamole/`.

## What changed
- `platform/guacamole/chart/templates/guacamole-deployment.yaml` — liveness + readiness `httpGet.path: /guacamole/`
- `platform/guacamole/chart/Chart.yaml` — 0.1.22 → 0.1.23 with changelog note

## Bootstrap-kit pin
Follow-up PR will bump `clusters/_template/bootstrap-kit/52-bp-guacamole.yaml` from 0.1.22 → 0.1.23 (matches the #1693 + #1694 split).

## Verification
- on t22 (chart 1.4.166 with this patch baked):
  ```
  curl -sI https://guacamole.t22.omantel.biz/guacamole/  # expect 200/302 from OIDC redirect, not 503
  kubectl -n catalyst-system get pods -l app.kubernetes.io/name=bp-guacamole  # expect 1/1 Ready, 0 restarts
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)