### PR TITLE
deploy(bp-guacamole): bump bootstrap-kit pin 0.1.22 -> 0.1.23 (Refs TBD-G4 phase 2)

### DIFF
--- a/clusters/_template/bootstrap-kit/52-bp-guacamole.yaml
+++ b/clusters/_template/bootstrap-kit/52-bp-guacamole.yaml
@@ -121,7 +121,14 @@ spec:
       # exist on any Sovereign — the canonical gateway is
       # kube-system/cilium-gateway installed by 01-cilium.yaml and
       # used by every other Sovereign HTTPRoute.
-      version: 0.1.22
+      # 0.1.23 (Refs TBD-G4 phase 2 / C12-005, 2026-05-18): pulls in
+      # PR #1699 (liveness + readiness probe paths flipped from `/`
+      # to `/guacamole/`). The Apache Guacamole webapp deploys under
+      # Tomcat's context path /guacamole/, not /, so probing `/`
+      # made kubelet restart the Pod every ~60s and the kube-system
+      # Cilium gateway returned 503 to the public hostname because
+      # the Endpoint was never Ready (observed on t22, 5 restarts).
+      version: 0.1.23
       sourceRef:
         kind: HelmRepository
         name: bp-guacamole


### PR DESCRIPTION
## Summary

Pulls in PR #1699 — Guacamole liveness + readiness probe paths
flipped from `/` to `/guacamole/`. Without it, the kube-system
gateway returns 503 to `https://guacamole.<sov>/` because the
webapp Pod is never Ready.

Mirrors the #1693/#1694 split — chart fix + bootstrap-kit pin
bump always ship as two PRs.

## Verification on next t<n>+1 fresh prov (or t22 after Flux reconcile)
```
kubectl -n catalyst-system get pods -l app.kubernetes.io/name=bp-guacamole  # expect 1/1 Ready, 0 restarts
curl -sI https://guacamole.<sov>/guacamole/  # expect 200/302
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)