### PR TITLE
fix(openova-flow): serve UI descriptor at / instead of 404 (Refs TBD-G7)

### DIFF
--- a/products/openova-flow/server/internal/api/router.go
+++ b/products/openova-flow/server/internal/api/router.go
@@ -3,6 +3,9 @@
 //
 // Wire contract — locked across the three OpenovaFlow agents:
 //
+//	GET    /                                   API root — JSON descriptor
+//	                                           of the surface (no UI is
+//	                                           served from this binary).
 //	POST   /v1/flows/{flowId}/events           ingest one FlowMessage
 //	GET    /v1/flows/{flowId}/snapshot         current FlowInstance + nodes + rels
 //	GET    /v1/flows/{flowId}/stream           SSE: replay snapshot + tail
@@ -20,11 +23,51 @@ import (
 	"github.com/openova-io/openova/products/openova-flow/server/internal/store"
 )
 
+// rootDescriptor is the JSON body returned for GET / so an operator
+// (or smoke test) hitting the bare hostname gets a 200 with a
+// machine-readable description of the API surface, instead of a bare
+// HTTP 404 from net/http.ServeMux.
+const rootDescriptor = `{` +
+	`"service":"openova-flow-server",` +
+	`"description":"OpenovaFlow HTTP+SSE event router. No UI is served from this binary — the React canvas library is consumed by the openova-console product.",` +
+	`"docs":"https://docs.openova.io/openova-flow",` +
+	`"endpoints":{` +
+	`"healthz":"GET /healthz",` +
+	`"readyz":"GET /readyz",` +
+	`"ingest":"POST /v1/flows/{flowId}/events",` +
+	`"snapshot":"GET /v1/flows/{flowId}/snapshot",` +
+	`"stream":"GET /v1/flows/{flowId}/stream (SSE)",` +
+	`"logLinesAppend":"POST /v1/flows/{flowId}/log-lines",` +
+	`"logLinesList":"GET /v1/flows/{flowId}/log-lines",` +
+	`"delete":"DELETE /v1/flows/{flowId}"` +
+	`}` +
+	`}` + "\n"
+
 // NewRouter returns an http.Handler routing the OpenovaFlow surface.
 // The backend is a long-lived process-global (in-memory Store for
 // tests/dev, PGStore for production).
 func NewRouter(s store.Backend) http.Handler {
 	mux := http.NewServeMux()
+
+	// `/` is the catch-all in Go's net/http.ServeMux. Guard against
+	// unintended fall-through with an exact-path check so unrelated
+	// paths still 404 (instead of getting the descriptor body) and a
+	// method check so accidental POSTs to `/` 405 loudly.
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/" {
+			http.NotFound(w, r)
+			return
+		}
+		if r.Method != http.MethodGet && r.Method != http.MethodHead {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(http.StatusOK)
+		if r.Method == http.MethodGet {
+			_, _ = w.Write([]byte(rootDescriptor))
+		}
+	})
 
 	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)


### PR DESCRIPTION
## Summary

`https://openova-flow.t22.omantel.biz/` returned bare HTTP 404 because the openova-flow-server is an **API-only** binary with no UI mounted at `/`. The React canvas (`@openova/flow-canvas`) is a library consumed by openova-console, not a standalone deployment.

Before:
```
GET / -> 404 page not found  (from net/http.ServeMux — no handler registered)
GET /healthz -> 200
```
After:
```
GET / -> 200 application/json (descriptor with all endpoints listed)
GET /healthz -> 200
GET /v1/flows/<id>/snapshot -> 200
GET /foo/bar -> 404 (exact-path guard prevents catch-all fallthrough)
POST / -> 405 (method guard)
```

## Why a descriptor and not a redirect to a UI

There is no standalone openova-flow UI deployment to redirect to — the canvas is a React library imported into openova-console. Returning a JSON descriptor at `/` gives operators a useful 200 surface to discover the API instead of a confusing 404 that masks healthy infrastructure.

## What changed

- `products/openova-flow/server/internal/api/router.go` — register a `/` handler with exact-path + method guards

Tests pass; no test asserted on the previous 404 behaviour.

## Verification

Once the build promotes a new image and Flux reconciles:
```
curl -sI https://openova-flow.<sov>/                        # 200 application/json
curl -s  https://openova-flow.<sov>/ | jq .endpoints.snapshot
curl -sI https://openova-flow.<sov>/healthz                 # 200 (unchanged)
curl -sI https://openova-flow.<sov>/foo                     # 404 (catch-all guard)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)