### PR TITLE
fix(sandbox-controller): default-ON enabled gate (TBD-D11)

### DIFF
--- a/clusters/_template/bootstrap-kit/19a-bp-sandbox.yaml
+++ b/clusters/_template/bootstrap-kit/19a-bp-sandbox.yaml
@@ -85,25 +85,41 @@ spec:
       retries: 3
   # Per-Sovereign overlay surface.
   #
-  # enabled — gated default-OFF via ${SANDBOX_ENABLED:-false} on the
-  # bootstrap-kit Kustomization substitute. Operators flip
-  # `SANDBOX_ENABLED=true` on the per-Sovereign overlay once Wave 8
-  # images are SHA-stamped.
+  # enabled — default-ON via ${SANDBOX_ENABLED:-true} on the
+  # bootstrap-kit Kustomization substitute. Wave 11 convergence fix
+  # (TBD-D11, t22.omantel.biz 2026-05-18): every Sandbox CR sat
+  # unreconciled because the bootstrap-kit Kustomization's substitute
+  # map never wires SANDBOX_ENABLED, so the envsubst resolved to the
+  # `:-false` fallback and the chart skip-rendered the entire
+  # controller Deployment. With Wave 8 pty-server + MCP images now
+  # SHA-stamped in chart values.yaml (auto-bumped by .github/workflows/
+  # build-sandbox-{pty-server,mcp-server}.yaml), the gate's original
+  # purpose is satisfied — flip default-ON so the controller materialises
+  # on every fresh prov. Operators may still opt-OUT by setting
+  # `SANDBOX_ENABLED=false` on the per-Sovereign overlay's substitute
+  # map (mirrors how MARKETPLACE_ENABLED works in slot 13).
   #
   # runtime.* — Wave 8 pty-server / MCP / NEWAPI wiring. The
   # controller surfaces these to its per-Sandbox renderer (manifests
   # rendered into the per-Org `catalyst-tenant` Gitea repo at
-  # sandbox/<owner-uid>/). Image refs are SHA-pinned via the standard
-  # bootstrap-kit substitute variables; newapi URL derives from
-  # ${SOVEREIGN_FQDN}.
+  # sandbox/<owner-uid>/).
+  #
+  # Image overrides are OMITTED from this slot's HR values — the
+  # chart's values.yaml already SHA-pins both images (auto-bumped by
+  # CI) and exposing them as substitute vars without the corresponding
+  # entries in the bootstrap-kit Kustomization postBuild.substitute
+  # map causes Flux to substitute empty strings → null → the chart's
+  # `required` guard would fail render once enabled=true. Day-2 SHA
+  # overrides remain available via Sovereign-overlay HelmRelease
+  # patches under spec.values.runtime.{ptyServerImage,mcpImage} — but
+  # the canonical path is bumping chart values.yaml + bootstrap-kit
+  # pin (single source of truth, INVIOLABLE-PRINCIPLES.md #4a).
   values:
-    enabled: ${SANDBOX_ENABLED:-false}
+    enabled: ${SANDBOX_ENABLED:-true}
     env:
       hostCluster: ${SOVEREIGN_REGION_CANONICAL_LABEL}
       sovereignFQDN: ${SOVEREIGN_FQDN}
     runtime:
-      ptyServerImage: ${SANDBOX_PTY_SERVER_IMAGE}
-      mcpImage: ${SANDBOX_MCP_IMAGE}
       newapiURL: https://newapi.${SOVEREIGN_FQDN}/v1
     # D31 active-hot-standby — when SOVEREIGN_ENABLE_HOT_STANDBY=true on
     # the per-Sovereign overlay (and both regions are non-empty AND

--- a/clusters/_template/bootstrap-kit/kustomization.yaml
+++ b/clusters/_template/bootstrap-kit/kustomization.yaml
@@ -56,9 +56,15 @@ resources:
   # sequencing rather than removal so the slot remains available for
   # the Wave 11 Sandbox MVP without manual Day-2 add-app re-introduction.
   # HR's dependsOn pins ordering to AFTER bp-harbor + bp-vcluster-
-  # helmrepo + bp-catalyst-platform. Gated default-OFF via
-  # ${SANDBOX_ENABLED:-false} on the bootstrap-kit Kustomization
-  # substitute — matches the chart's values.enabled default.
+  # helmrepo + bp-catalyst-platform. Wave 11 convergence fix (TBD-D11,
+  # 2026-05-18): now gated default-ON via ${SANDBOX_ENABLED:-true} on
+  # the bootstrap-kit Kustomization substitute so the controller
+  # materialises on every fresh prov (Wave 8 pty-server + MCP images
+  # are SHA-stamped in chart values.yaml). Operators may opt-OUT via
+  # SANDBOX_ENABLED=false on the per-Sovereign overlay's substitute
+  # map. The chart's own values.enabled default remains false (defence
+  # in depth — a stale per-Sovereign overlay that hand-installs the
+  # HR without our envsubst layer still default-OFFs gracefully).
   - 19a-bp-sandbox.yaml
   # 06a — Post-handover Self-Sovereignty Cutover (issue #791). Filename
   # carries the 06a prefix to colocate cohorts visually, but the slot's


### PR DESCRIPTION
## Summary

Wave 11 convergence fix — `bp-sandbox` HelmRelease was installing on every fresh prov, but with `enabled: false`, so the sandbox-controller Deployment never rendered. Sandbox CRs sat unreconciled forever.

Caught live on **t22.omantel.biz**: Sandbox CR `catalyst-system/aider-emrah-ba` existed for 79+ minutes with no `.status`, no events, no pty-server / MCP / Service / HTTPRoute children. The bootstrap-kit Kustomization's substitute map doesn't carry `SANDBOX_ENABLED`, so `enabled: ${SANDBOX_ENABLED:-false}` in slot 19a resolved to `false`.

## Root cause

- Slot 19a's HR values default to `false` via envsubst fallback.
- Neither the bootstrap-kit Kustomization manifest (rendered by `cloudinit-control-plane.tftpl`) nor `provisioner.go` ever write `SANDBOX_ENABLED` into the substitute map — comment says "operators flip this to true once Wave 8 images are SHA-stamped", but nobody is flipping it.
- Wave 8 pty-server + MCP images ARE SHA-stamped today in `platform/sandbox/chart/values.yaml` (auto-bumped by `build-sandbox-{pty-server,mcp-server}.yaml`). The gate's original purpose is satisfied.

## Changes

- `clusters/_template/bootstrap-kit/19a-bp-sandbox.yaml`:
  - `enabled: ${SANDBOX_ENABLED:-false}` → `enabled: ${SANDBOX_ENABLED:-true}` (default-ON; operators can still opt-OUT)
  - Drop `runtime.ptyServerImage` / `runtime.mcpImage` envsubst overrides — those substitute keys don't exist in the bootstrap-kit map either, so they'd evaluate to empty strings and trip the chart's `required` guard once `enabled=true`. Chart values.yaml's SHA-pinned defaults (canonical, CI-bumped) flow through instead. Day-2 SHA overrides remain available via per-Sovereign overlay HR patches.
- `clusters/_template/bootstrap-kit/kustomization.yaml`: comment block resync.

## Verification (post-merge, ~5 min after bootstrap-kit reconcile on t22)

- [ ] `kubectl -n flux-system get hr bp-sandbox -o yaml` shows `spec.values.enabled: true`
- [ ] `kubectl -n catalyst-system get deploy sandbox-controller` Ready 1/1
- [ ] `kubectl -n catalyst-system get sandbox aider-emrah-ba -o yaml` has `.status.phase` populated
- [ ] Controller logs show `reconciling sandbox aider-emrah-ba`
- [ ] Per-Sandbox manifests pushed to gitea `catalyst-tenant/sandbox/<owner-uid>/`

Refs TBD-D11.

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>