### PR TITLE
feat(rbac): implement /sovereign/rbac/matrix endpoint + UI page (Refs TBD-F4, C6-007)

### DIFF
--- a/products/catalyst/bootstrap/api/cmd/api/main.go
+++ b/products/catalyst/bootstrap/api/cmd/api/main.go
@@ -1278,6 +1278,16 @@ func main() {
 		// SME catalog service.
 		rg.Patch("/api/v1/sovereign/apps/{slug}/publish", h.HandleSovereignAppPublish)
 
+		// EPIC-3 (#1098) — Sovereign-prefix RBAC access-matrix surface
+		// (TBD-F4 / C6-007). Chroot-friendly mirror of
+		// /api/v1/sovereigns/{id}/rbac/access-matrix; the id is resolved
+		// server-side from SOVEREIGN_FQDN + the catalyst_session cookie
+		// (same chain as HandleSovereignSelf). Same query-param filters
+		// and response shape as the per-deployment endpoint, so the
+		// AccessMatrixPage in the chroot can call this path without
+		// first round-tripping to /sovereign/self.
+		rg.Get("/api/v1/sovereign/rbac/matrix", h.HandleSovereignRBACMatrix)
+
 		// Self-Sovereignty Cutover (issue #792 — parent epic #790). The
 		// post-handover step that severs a Sovereign's remaining
 		// tethers to the openova-io mothership: gitea-mirror,

--- a/products/catalyst/bootstrap/api/internal/handler/rbac_matrix.go
+++ b/products/catalyst/bootstrap/api/internal/handler/rbac_matrix.go
@@ -19,6 +19,7 @@ package handler
 
 import (
 	"net/http"
+	"os"
 	"sort"
 	"strings"
 
@@ -80,6 +81,49 @@ func (h *Handler) HandleRBACAccessMatrix(w http.ResponseWriter, r *http.Request)
 		writeNotFound(w, depID)
 		return
 	}
+	h.serveRBACAccessMatrix(w, r, dep, depID)
+}
+
+// HandleSovereignRBACMatrix — GET /api/v1/sovereign/rbac/matrix
+//
+// Chroot-friendly Sovereign-prefix wrapper around HandleRBACAccessMatrix
+// (TBD-F4 / C6-007). Same response shape; resolves the active Sovereign
+// deployment from the in-cluster context (SOVEREIGN_FQDN +
+// CATALYST_SELF_DEPLOYMENT_ID, with the synthesised "sovereign-<fqdn>"
+// fallback that the rest of the /api/v1/sovereign/* family uses).
+//
+// Mirrors the canonical chroot-side seam established by
+// HandleSovereignStatus / HandleSovereignApps / HandleSovereignCloud —
+// no {id} path param, server-side resolution of the active deployment.
+// This is what an operator-side Playwright probe to the Sovereign
+// Console / users / rbac matrix view hits without first having to
+// resolve `/api/v1/sovereign/self`.
+func (h *Handler) HandleSovereignRBACMatrix(w http.ResponseWriter, r *http.Request) {
+	depID := resolveSovereignDeploymentID(r)
+	if depID == "" {
+		// Mothership (no SOVEREIGN_FQDN env, no handover cookie). The
+		// per-deployment surface at /api/v1/sovereigns/{id}/rbac/access-matrix
+		// is the right entry point on that side; emit a structured 404
+		// so the UI can fall back to the mothership form.
+		writeJSON(w, http.StatusNotFound, map[string]string{
+			"error":  "not-a-sovereign",
+			"detail": "this catalyst-api Pod is not running on a Sovereign cluster; use /api/v1/sovereigns/{id}/rbac/access-matrix instead",
+		})
+		return
+	}
+	dep, ok := h.lookupDeploymentForInfra(depID)
+	if !ok {
+		writeNotFound(w, depID)
+		return
+	}
+	h.serveRBACAccessMatrix(w, r, dep, depID)
+}
+
+// serveRBACAccessMatrix is the shared body of the per-deployment and the
+// Sovereign-prefix RBAC matrix handlers. Both surfaces use identical
+// query-param filters (?org, ?application) and identical response
+// shape (AccessMatrixResponse).
+func (h *Handler) serveRBACAccessMatrix(w http.ResponseWriter, r *http.Request, dep *Deployment, depID string) {
 	orgFilter := strings.TrimSpace(r.URL.Query().Get("org"))
 	appFilter := strings.TrimSpace(r.URL.Query().Get("application"))
 
@@ -114,6 +158,36 @@ func (h *Handler) HandleRBACAccessMatrix(w http.ResponseWriter, r *http.Request)
 	resp.OrgFilter = orgFilter
 	resp.ApplicationFilter = appFilter
 	writeJSON(w, http.StatusOK, resp)
+}
+
+// resolveSovereignDeploymentID mirrors HandleSovereignSelf's resolution
+// chain so /api/v1/sovereign/* endpoints converge on the same active
+// deployment id without having to round-trip through /sovereign/self
+// first. Returns "" when no chroot context is detectable (= mothership
+// process). Order:
+//
+//  1. catalyst_session cookie claims (deployment_id) — authoritative
+//     post-handover.
+//  2. CATALYST_SELF_DEPLOYMENT_ID env (orchestrator chart-values
+//     overlay).
+//  3. Synthesised "sovereign-<fqdn>" from SOVEREIGN_FQDN /
+//     CATALYST_OTECH_FQDN — matches the rest of the /sovereign/*
+//     family and the k8scache.factory.go cluster-id convention.
+func resolveSovereignDeploymentID(r *http.Request) string {
+	if _, jwtDepID, ok := readSessionClaimsFromCookie(r); ok && jwtDepID != "" {
+		return jwtDepID
+	}
+	if v := strings.TrimSpace(os.Getenv("CATALYST_SELF_DEPLOYMENT_ID")); v != "" {
+		return v
+	}
+	fqdn := strings.TrimSpace(os.Getenv("SOVEREIGN_FQDN"))
+	if fqdn == "" {
+		fqdn = strings.TrimSpace(os.Getenv("CATALYST_OTECH_FQDN"))
+	}
+	if fqdn == "" {
+		return ""
+	}
+	return "sovereign-" + fqdn
 }
 
 // ── Pure aggregator (extracted for testability) ──────────────────────

--- a/products/catalyst/bootstrap/api/internal/handler/rbac_matrix_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/rbac_matrix_test.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/go-chi/chi/v5"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -291,5 +292,109 @@ func TestHandleRBACAccessMatrix_EmptyOnNoCRD(t *testing.T) {
 	}
 	if len(resp.Users) != 0 {
 		t.Fatalf("expected no users; got %+v", resp.Users)
+	}
+}
+
+// ── Sovereign-prefix wrapper (TBD-F4 / C6-007) ────────────────────────
+
+func registerSovereignRBACMatrixRoute(r chi.Router, h *Handler) {
+	r.Get("/api/v1/sovereign/rbac/matrix", h.HandleSovereignRBACMatrix)
+}
+
+// TestHandleSovereignRBACMatrix_Happy verifies the Sovereign-prefix
+// chroot wrapper resolves the deployment id from CATALYST_SELF_DEPLOYMENT_ID
+// and serves the same AccessMatrixResponse shape as the per-deployment
+// surface. Without this endpoint a Sovereign-side operator (or the QA
+// test executor probing the canonical chroot path) gets a 404.
+//
+// Test uses CATALYST_SELF_DEPLOYMENT_ID (precedence 2 in
+// resolveSovereignDeploymentID) so the dep's SovereignFQDN can be set
+// to something distinct from the SOVEREIGN_FQDN env — that way
+// sovereignDynamicClient's chroot-env-match check falls through and
+// the test's dynamicFactory fake intercepts via the kubeconfig path.
+func TestHandleSovereignRBACMatrix_Happy(t *testing.T) {
+	t.Setenv("CATALYST_SELF_DEPLOYMENT_ID", "dep-sov-rbac")
+	t.Setenv("SOVEREIGN_FQDN", "") // keep env-match path off for the fake client
+
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	seed := []runtime.Object{
+		rbacUserAccessFromAssign(
+			"rbac-alice-1", "alice", "admin",
+			[]rbacAssignScopeBody{{Key: scopeKeyApplication, Value: "wordpress"}},
+		),
+	}
+	factory, _ := fakeUserAccessDynamicFactory(seed...)
+	h.dynamicFactory = factory
+	_ = installUserAccessDeployment(t, h, "dep-sov-rbac")
+
+	rec := callUserAccess(t, h, http.MethodGet,
+		"/api/v1/sovereign/rbac/matrix", nil, registerSovereignRBACMatrixRoute)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	var resp AccessMatrixResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Users) != 1 || resp.Users[0].ID != "alice" {
+		t.Fatalf("users: got %+v want [{ID:alice ...}]", resp.Users)
+	}
+	if !reflect.DeepEqual(resp.Tiers, []string{"viewer", "developer", "operator", "admin", "owner"}) {
+		t.Fatalf("tiers: got %+v", resp.Tiers)
+	}
+}
+
+// TestHandleSovereignRBACMatrix_404OffMothership verifies the wrapper
+// returns a structured 404 on the mothership (no SOVEREIGN_FQDN /
+// CATALYST_OTECH_FQDN / handover cookie) instead of leaking a 500 or
+// silently dispatching to a synthetic deployment id that has no
+// underlying cluster.
+func TestHandleSovereignRBACMatrix_404OffMothership(t *testing.T) {
+	t.Setenv("SOVEREIGN_FQDN", "")
+	t.Setenv("CATALYST_OTECH_FQDN", "")
+	t.Setenv("CATALYST_SELF_DEPLOYMENT_ID", "")
+
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	factory, _ := fakeUserAccessDynamicFactory()
+	h.dynamicFactory = factory
+
+	rec := callUserAccess(t, h, http.MethodGet,
+		"/api/v1/sovereign/rbac/matrix", nil, registerSovereignRBACMatrixRoute)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status: got %d want 404; body=%s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "not-a-sovereign") {
+		t.Fatalf("body should reference not-a-sovereign error code; got %s", rec.Body.String())
+	}
+}
+
+// TestHandleSovereignRBACMatrix_EmptyOnNoCRD verifies a fresh
+// Sovereign with the deployment record but no UserAccess CRs yet (D21
+// chain still bootstrapping) serves an empty-matrix shape with 200, so
+// the AccessMatrixPage renders "no grants yet" instead of an error
+// toast.
+func TestHandleSovereignRBACMatrix_EmptyOnNoCRD(t *testing.T) {
+	t.Setenv("CATALYST_SELF_DEPLOYMENT_ID", "dep-sov-rbac-empty")
+	t.Setenv("SOVEREIGN_FQDN", "")
+
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	factory, _ := fakeUserAccessDynamicFactory()
+	h.dynamicFactory = factory
+	_ = installUserAccessDeployment(t, h, "dep-sov-rbac-empty")
+
+	rec := callUserAccess(t, h, http.MethodGet,
+		"/api/v1/sovereign/rbac/matrix", nil, registerSovereignRBACMatrixRoute)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	var resp AccessMatrixResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Users) != 0 {
+		t.Fatalf("expected no users; got %+v", resp.Users)
+	}
+	if len(resp.Tiers) != 5 {
+		t.Fatalf("tiers: expected canonical 5; got %+v", resp.Tiers)
 	}
 }


### PR DESCRIPTION
## Summary
- Adds the chroot-friendly Sovereign-prefix wrapper `GET /api/v1/sovereign/rbac/matrix` around the existing `/api/v1/sovereigns/{id}/rbac/access-matrix` endpoint. Mirrors the canonical `/api/v1/sovereign/{status,jobs,apps,cloud}` family so the QA executor's probe (and a future chroot-side AccessMatrixPage simplification) hits a stable path without round-tripping through `/api/v1/sovereign/self`.
- Same `AccessMatrixResponse` shape, same `?org` / `?application` filters, same UserAccess-CR aggregator — only the deployment-id resolution differs (env + cookie chain via the new `resolveSovereignDeploymentID` helper that mirrors `HandleSovereignSelf`'s precedence: cookie -> `CATALYST_SELF_DEPLOYMENT_ID` -> `sovereign-<fqdn>` synthesis from `SOVEREIGN_FQDN` / `CATALYST_OTECH_FQDN`).
- Extracted the per-deployment handler body into a shared `serveRBACAccessMatrix` helper so both surfaces stay in lock-step on every future tweak.
- UI unchanged — `AccessMatrixPage` at `/rbac/matrix` continues to consume the per-deployment endpoint via `useResolvedDeploymentId`. New sovereign-prefix surface is the seam for chroot-side operator probes (incl. the C6-007 Playwright check) and a future drop of the `useResolvedDeploymentId` round-trip on chroot.

## Why
WBS row **TBD-F4** / matrix row **C6-007** flagged `GET /api/v1/sovereign/rbac/matrix` as 404 on t22, blocking the C6-007 Playwright verify (`/rbac/matrix` as `tier=user`: forbidden fields not in DOM). Backend handler + UI page both existed under the per-deployment shape; the missing piece was the canonical Sovereign-prefix path the executor expected.

## Test plan
- [x] `go build ./products/catalyst/bootstrap/api/...` green
- [x] `go test ./products/catalyst/bootstrap/api/internal/handler/ -run "TestHandleSovereignRBACMatrix|TestHandleRBACAccessMatrix"` — 6/6 pass (3 new sovereign-prefix tests + 3 pre-existing access-matrix tests)
- [x] Sovereign-prefix `Happy` test asserts 200 + matrix shape via fake dynamic client (env-resolution path)
- [x] `404OffMothership` test asserts 404 + structured `not-a-sovereign` body when no `SOVEREIGN_FQDN` / `CATALYST_OTECH_FQDN` / handover cookie is detectable
- [x] `EmptyOnNoCRD` test asserts 200 + empty matrix on a fresh chroot whose UserAccess CRD hasn't bootstrapped yet (D21 chain in flight)
- [ ] On t22 after chart bump + reconcile: `curl --cookie <session> https://console.t22.omantel.biz/api/v1/sovereign/rbac/matrix` returns 200 with `AccessMatrixResponse`
- [ ] Playwright `/rbac/matrix` as `tier=user` renders without forbidden tier-leak fields (the C6-007 acceptance check)

Refs: TBD-F4, C6-007.

🤖 Generated with [Claude Code](https://claude.com/claude-code)