### PR TITLE
deploy(self-sovereign-cutover): bump bootstrap-kit pin 0.1.29 -> 0.1.30 (Refs TBD-C18)

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -263,7 +263,22 @@ spec:
       # platform-wide migration off bitnami/kubectl (deleted from
       # Docker Hub 2025-08). This Blueprint already uses alpine/k8s
       # + alpine since 0.1.10; no functional image change here.
-      version: 0.1.29
+      # 0.1.30 (TBD-C18, 2026-05-18): NEW step 09 (gitea-token-mint)
+      # mints a real Gitea API token at cutover + patches Secret
+      # sme/provisioning-github-token.GITHUB_TOKEN. The catalyst-
+      # platform chart's provisioning-github-token.yaml template
+      # previously mirrored the Gitea admin PASSWORD verbatim into
+      # that Secret; SME provisioning then sent `Authorization: token
+      # <PWD>` to Gitea which 401s ("user does not exist [uid: 0]").
+      # On t22 2026-05-18: voucher checkout completed 200 + /jobs
+      # redirect fired, but no Organization CR was ever created.
+      # Step 09 closes the loop: DELETE-then-POST /api/v1/users/
+      # gitea_admin/tokens, capture .sha1, GET /api/v1/user validate,
+      # kubectl patch dest Secret, rollout-restart provisioning
+      # Deployment. Order=9 (last) is fine — none of steps 02-08 read
+      # the Secret and the SME provisioning service first consumes
+      # the token at voucher checkout time (always postdates cutover).
+      version: 0.1.30
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover


### PR DESCRIPTION
## Summary

Bumps the bootstrap-kit pin so fresh + already-handed-over Sovereigns pick up Step-09 (gitea-token-mint) from chart 0.1.30 next Flux reconcile.

Without this pin bump, the chart artifact is published to GHCR but no HelmRelease consumes it — t22 (and every existing prov) keeps sending `Authorization: token <admin-password>` to Gitea, which 401s "user does not exist [uid: 0, name: ]", blocking tenant voucher checkout at journey step 16.

Companion to PR #1704 (the chart fix itself).

## Test plan

- [ ] t22 Flux reconciles `bp-self-sovereign-cutover` HR with version 0.1.30 within ~1 min
- [ ] `kubectl -n catalyst get cm cutover-step-09-gitea-token-mint` shows the new step ConfigMap
- [ ] Operator re-runs cutover via CTA OR auto-trigger fires (Step-09 runs at handover)
- [ ] `sme/provisioning-github-token.GITHUB_TOKEN` last-8 changes away from `ChxCejmH`
- [ ] `curl -H "Authorization: token <new>" /api/v1/user` returns 200 from inside the cluster
- [ ] Re-run journey step 16 → ≥1 Organization CR appears within 5 minutes

🤖 Generated with [Claude Code](https://claude.com/claude-code)