### PR TITLE
chore(release): chart 1.4.166→1.4.167 + bootstrap-kit pin — Wave 24 (PR #1705 cloud fan-out)

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -263,7 +263,22 @@ spec:
       # platform-wide migration off bitnami/kubectl (deleted from
       # Docker Hub 2025-08). This Blueprint already uses alpine/k8s
       # + alpine since 0.1.10; no functional image change here.
-      version: 0.1.29
+      # 0.1.30 (TBD-C18, 2026-05-18): NEW step 09 (gitea-token-mint)
+      # mints a real Gitea API token at cutover + patches Secret
+      # sme/provisioning-github-token.GITHUB_TOKEN. The catalyst-
+      # platform chart's provisioning-github-token.yaml template
+      # previously mirrored the Gitea admin PASSWORD verbatim into
+      # that Secret; SME provisioning then sent `Authorization: token
+      # <PWD>` to Gitea which 401s ("user does not exist [uid: 0]").
+      # On t22 2026-05-18: voucher checkout completed 200 + /jobs
+      # redirect fired, but no Organization CR was ever created.
+      # Step 09 closes the loop: DELETE-then-POST /api/v1/users/
+      # gitea_admin/tokens, capture .sha1, GET /api/v1/user validate,
+      # kubectl patch dest Secret, rollout-restart provisioning
+      # Deployment. Order=9 (last) is fine — none of steps 02-08 read
+      # the Secret and the SME provisioning service first consumes
+      # the token at voucher checkout time (always postdates cutover).
+      version: 0.1.30
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -575,7 +575,7 @@ spec:
       # bp-prometheus, bp-loki, bp-redis, bp-clickhouse, bp-opensearch,
       # bp-temporal, bp-n8n, bp-langfuse, bp-llm-gateway) which the
       # chained catalog client surfaces via in-cluster LIST fallback.
-      version: 1.4.166
+      version: 1.4.167
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -1138,7 +1138,7 @@ name: bp-catalyst-platform
 # Fix #154 (HR-timeout audit). Those bumped the HelmRelease
 # install.timeout. This bumps the chart-INTERNAL wait loop budget
 # inside the pre-install hook Job, which is a different seam.
-version: 1.4.166
+version: 1.4.167
 appVersion: 1.4.166
 # 1.4.166 — fix(catalog): seed 13 published Blueprints on Sovereign
 # handover (WBS row TBD-E8, C4-015). Adds templates/catalog-seed/


### PR DESCRIPTION
Republishes the chart bytes with PR #1705 catalyst-api image SHA `7adc8f1` (cloud list fan-out across registered clusters). Same-version OCI re-publish does NOT propagate — need Chart.yaml + pin bump. Refs TBD-A3, TBD-E6.