### PR TITLE
fix(sandbox-controller): wire newapi admin secret for pty-server token minting (Refs TBD-D14)

### DIFF
--- a/clusters/_template/bootstrap-kit/80-newapi.yaml
+++ b/clusters/_template/bootstrap-kit/80-newapi.yaml
@@ -116,7 +116,23 @@ spec:
       # attestation is incomplete; once the operator overlay supplies
       # the attestation values the channel composes on the next
       # reconcile.
-      version: 1.4.10
+      # 1.4.12 (PR #1677, 2026-05-18): default
+      # `.Values.sandboxTokenSigningKey.reflectorNamespaces` flipped
+      # from `"sandbox"` → `"catalyst-system,sandbox"`. Pre-1.4.12 the
+      # chart-emitted `newapi-bp-newapi-token-signing-key` Secret was
+      # mirrored only into a `sandbox` namespace (which does NOT exist
+      # on a stock Sovereign — bp-sandbox installs into
+      # `catalyst-system` per slot 19a `targetNamespace`); the sandbox-
+      # controller's `NEWAPI_ADMIN_SECRET` env var (secretKeyRef
+      # `optional: true`) landed EMPTY, the controller silently dropped
+      # into gitops-only mode, and zero per-Sandbox LLM-gateway tokens
+      # were ever minted (operator-visible only via the controller's
+      # `newapi_admin_secret_set=false` startup log). Caught on t22
+      # 2026-05-18 (TBD-D14). Bumping the pin pulls the post-#1677
+      # default so reflector mirrors into `catalyst-system` too.
+      # 1.4.14 (current main, 2026-05-18): latest upstream-tracking
+      # chart cut — includes 1.4.12's reflector fix.
+      version: 1.4.14
       sourceRef:
         kind: HelmRepository
         name: bp-newapi


### PR DESCRIPTION
## Summary

- t22.omantel.biz sandbox-controller starts with `newapi_admin_secret_set=false` — pty-server Pods will boot without an LLM_GATEWAY_TOKEN once Organization controller emits the first Org CR (post-C18 fix).
- Root cause: `clusters/_template/bootstrap-kit/80-newapi.yaml` pins `bp-newapi` chart at `1.4.10`, which has `reflectorNamespaces: \"sandbox\"` only. Reflector mirrors the chart-emitted `newapi-bp-newapi-token-signing-key` Secret into a nonexistent `sandbox` namespace — NOT into `catalyst-system` where the sandbox-controller runs. PR #1677 already fixed the chart default (`\"catalyst-system,sandbox\"`) and Chart.yaml is now at 1.4.14 — but deploy-bot auto-bumps Chart.yaml only, never the bootstrap-kit pin (same pattern as Wave 14 PR #1666).
- Fix: bump the pin `1.4.10` → `1.4.14`. No code change required; the sandbox-controller Deployment + sandbox-token-signing-key Secret templates were already correct.

## Evidence

t22 cluster (read-only inspection):

```
$ kubectl -n newapi get secret newapi-bp-newapi-token-signing-key -o yaml | grep reflection-
reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: sandbox
reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: sandbox

$ kubectl -n catalyst-system get secret newapi-bp-newapi-token-signing-key
Error from server (NotFound)

$ kubectl -n catalyst-system logs deploy/sandbox-controller | grep newapi
\"newapi bridge not wired — sandbox-controller running in gitops-only mode\"
\"newapi_admin_secret_set\"=false
```

Chart render on `main` HEAD:

```
$ helm template platform/newapi/chart [...] | grep reflection-allowed-namespaces
reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: \"catalyst-system,sandbox\"
```

## Test plan

- [ ] CI green (only file touched is the bootstrap-kit pin — no Go/UI build needed).
- [ ] Next fresh prov: `kubectl -n catalyst-system get secret newapi-bp-newapi-token-signing-key` returns the reflected copy.
- [ ] `kubectl -n catalyst-system logs deploy/sandbox-controller | grep newapi_wired=true` after ~1 min from sandbox-controller Pod start.
- [ ] First Sandbox CR reconciled by sandbox-controller produces a per-Sandbox Secret carrying a non-empty `LLM_GATEWAY_TOKEN`.

Refs TBD-D14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)