### PR TITLE
fix(catalyst-platform): stop clobbering cutover-minted Gitea token (Refs TBD-C18b)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -575,7 +575,20 @@ spec:
       # bp-prometheus, bp-loki, bp-redis, bp-clickhouse, bp-opensearch,
       # bp-temporal, bp-n8n, bp-langfuse, bp-llm-gateway) which the
       # chained catalog client surfaces via in-cluster LIST fallback.
-      version: 1.4.167
+      # 1.4.168 (TBD-C18b, 2026-05-18): stop clobbering the cutover-minted
+      # Gitea API token. templates/sme-services/provisioning-github-
+      # token.yaml gains a lookup-persistence guard — if the destination
+      # Secret carries annotation `catalyst.openova.io/token-source:
+      # self-sovereign-cutover-step-09` (stamped by Step 09 of bp-self-
+      # sovereign-cutover when it mints the real Gitea API token), the
+      # template preserves the existing GITHUB_TOKEN bytes instead of
+      # mirroring gitea-admin-secret.password over them on every Flux
+      # reconcile. Pre-fix on t22: Step 09 minted a real token at
+      # 13:43:33Z; ~5 min later helm reconcile rewrote GITHUB_TOKEN back
+      # to the admin password byte, so every subsequent SME provisioning
+      # call to Gitea returned 401 "user does not exist" and journey
+      # step 16 (tenant repo creation) silently stuck.
+      version: 1.4.168
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -1138,8 +1138,24 @@ name: bp-catalyst-platform
 # Fix #154 (HR-timeout audit). Those bumped the HelmRelease
 # install.timeout. This bumps the chart-INTERNAL wait loop budget
 # inside the pre-install hook Job, which is a different seam.
-version: 1.4.167
-appVersion: 1.4.166
+# 1.4.168 (TBD-C18b, 2026-05-18): stop clobbering the cutover-minted
+# Gitea API token. Pre-fix, templates/sme-services/provisioning-github-
+# token.yaml unconditionally mirrored gitea-admin-secret.password into
+# Secret sme/provisioning-github-token.GITHUB_TOKEN on every reconcile,
+# overwriting the real API token that bp-self-sovereign-cutover Step 09
+# patched in. Live evidence on t22 (2026-05-18): Step 09 ran at
+# 13:43:33Z and stamped a working token; ~5 min later helm reconcile
+# rewrote GITHUB_TOKEN back to the 8-char admin password — every
+# subsequent SME provisioning API call to Gitea 401'd with
+# "user does not exist", journey step 16 (tenant repo creation) silently
+# stuck. Fix: lookup the destination Secret first; if it carries
+# annotation `catalyst.openova.io/token-source: self-sovereign-cutover-
+# step-09` (stamped by Step 09's kubectl patch), preserve the existing
+# GITHUB_TOKEN bytes verbatim. Bootstrap branch (gitea-admin-secret
+# password mirror) is preserved for the first-install pre-cutover window
+# so the provisioning Pod still boots out of CreateContainerConfigError.
+version: 1.4.168
+appVersion: 1.4.167
 # 1.4.166 — fix(catalog): seed 13 published Blueprints on Sovereign
 # handover (WBS row TBD-E8, C4-015). Adds templates/catalog-seed/
 # rendering an always-on baseline of 13 Blueprint CRs (bp-wordpress-

--- a/products/catalyst/chart/templates/sme-services/provisioning-github-token.yaml
+++ b/products/catalyst/chart/templates/sme-services/provisioning-github-token.yaml
@@ -76,6 +76,37 @@ manifests on disk.
 Per #4 (never hardcode): source/destination namespace + Secret names
 flow through .Values.smeServices.provisioning.gitToken.* with sensible
 defaults that match the upstream gitea + provisioning shapes.
+
+Cutover ownership handover (TBD-C18b, 2026-05-18):
+  bp-self-sovereign-cutover Step 09 (09-gitea-token-mint-job.yaml) mints
+  a REAL Gitea API token via POST /api/v1/users/{user}/tokens, then
+  PATCHes this Secret's GITHUB_TOKEN field with the new bytes and stamps
+  two annotations onto the Secret:
+    catalyst.openova.io/token-minted-at:  <RFC3339 timestamp>
+    catalyst.openova.io/token-source:     "self-sovereign-cutover-step-09"
+  The Gitea ADMIN PASSWORD is NOT a valid API token (Gitea treats Bearer
+  credentials as sha1-hashed access-token rows in the `users` table, not
+  as the admin password) — so the password placeholder this template
+  writes on first install is enough to boot the Pod past
+  CreateContainerConfigError but NOT enough to actually mint tenant repos
+  in Gitea. Step 09's minted token is the canonical credential.
+
+  Without the lookup-persistence guard added below, every chart reconcile
+  (every 15 min by default Flux interval) overwrites the minted token
+  back to the admin password, undoing Step 09 silently. Verified live
+  on t22 (2026-05-18): Step 09 ran 13:43:33Z setting GITHUB_TOKEN to a
+  real API token, then ~5 min later helm reconcile of catalyst-platform
+  rewrote GITHUB_TOKEN back to the admin password byte. C18 fix was
+  ephemeral until this guard landed.
+
+  Guard semantics: lookup the destination Secret first. If it exists
+  AND has the `catalyst.openova.io/token-source` annotation set to
+  "self-sovereign-cutover-step-09", preserve the existing GITHUB_TOKEN
+  bytes verbatim (re-emit the b64 byte string from the live Secret).
+  Otherwise fall through to the first-install bootstrap branch that
+  mirrors gitea-admin-secret.password (so a freshly-franchised Sovereign
+  still boots the provisioning Pod past CreateContainerConfigError
+  before Step 09 has had a chance to run).
 */}}
 {{- if and .Values.ingress .Values.ingress.marketplace .Values.ingress.marketplace.enabled -}}
 {{- $sourceNamespace := .Values.smeServices.provisioning.gitToken.sourceNamespace | default "gitea" -}}
@@ -84,8 +115,32 @@ defaults that match the upstream gitea + provisioning shapes.
 {{- $destNamespace := .Values.smeServices.provisioning.gitToken.destNamespace | default "sme" -}}
 {{- $destSecretName := .Values.smeServices.provisioning.gitToken.destSecretName | default "provisioning-github-token" -}}
 {{- $destKey := .Values.smeServices.provisioning.gitToken.destKey | default "GITHUB_TOKEN" -}}
+{{- /* Lookup the destination Secret first to detect whether Step 09 of
+       bp-self-sovereign-cutover has already taken ownership. If yes,
+       preserve the minted token bytes verbatim — the chart MUST NOT
+       clobber the cutover-issued credential. */ -}}
+{{- $destSecret := lookup "v1" "Secret" $destNamespace $destSecretName -}}
+{{- $cutoverOwned := false -}}
+{{- $existingTokenB64 := "" -}}
+{{- $preservedMintedAt := "" -}}
+{{- if and $destSecret $destSecret.metadata $destSecret.metadata.annotations -}}
+  {{- $tokenSource := index $destSecret.metadata.annotations "catalyst.openova.io/token-source" -}}
+  {{- if eq $tokenSource "self-sovereign-cutover-step-09" -}}
+    {{- if and $destSecret.data (index $destSecret.data $destKey) -}}
+      {{- $cutoverOwned = true -}}
+      {{- $existingTokenB64 = index $destSecret.data $destKey -}}
+      {{- $preservedMintedAt = index $destSecret.metadata.annotations "catalyst.openova.io/token-minted-at" -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
 {{- $sourceSecret := lookup "v1" "Secret" $sourceNamespace $sourceSecretName -}}
+{{- $haveBootstrap := false -}}
+{{- $bootstrapTokenB64 := "" -}}
 {{- if and $sourceSecret $sourceSecret.data (index $sourceSecret.data $sourcePasswordKey) -}}
+  {{- $haveBootstrap = true -}}
+  {{- $bootstrapTokenB64 = index $sourceSecret.data $sourcePasswordKey -}}
+{{- end -}}
+{{- if or $cutoverOwned $haveBootstrap -}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -105,12 +160,32 @@ metadata:
     # the provisioning Pod stays Running across reinstalls without a
     # restart-storm.
     helm.sh/resource-policy: keep
+    {{- if $cutoverOwned }}
+    # bp-self-sovereign-cutover Step 09 has minted a real Gitea API
+    # token and patched this Secret. Preserve the token-source +
+    # token-minted-at annotations so subsequent reconciles continue to
+    # honour the cutover ownership (the cutoverOwned branch below
+    # re-emits the existing token bytes verbatim).
+    catalyst.openova.io/token-source: "self-sovereign-cutover-step-09"
+    {{- if $preservedMintedAt }}
+    catalyst.openova.io/token-minted-at: {{ $preservedMintedAt | quote }}
+    {{- end }}
+    {{- end }}
 type: Opaque
 data:
-  # Re-emit the gitea admin password verbatim under the env-name the
-  # provisioning service reads. The provisioning service treats this
-  # as a bearer token for whichever Git host it's pointed at via
-  # GITHUB_OWNER + GITHUB_REPO + (future) GITHUB_API_BASE_URL.
-  {{ $destKey }}: {{ index $sourceSecret.data $sourcePasswordKey | quote }}
+  {{- if $cutoverOwned }}
+  # Preserve the cutover-minted token bytes verbatim. Do NOT overwrite
+  # with gitea-admin-secret.password — that placeholder is only useful
+  # for first-install bootstrap before Step 09 has had a chance to run.
+  # See TBD-C18b for the live regression this guard prevents.
+  {{ $destKey }}: {{ $existingTokenB64 | quote }}
+  {{- else }}
+  # First-install bootstrap: emit the gitea admin password verbatim under
+  # the env-name the provisioning service reads. This lets the
+  # provisioning Pod reach Running before bp-self-sovereign-cutover
+  # Step 09 mints the real API token. The bytes here are NOT a valid
+  # Gitea API token — they only unblock the Pod's CreateContainer phase.
+  {{ $destKey }}: {{ $bootstrapTokenB64 | quote }}
+  {{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
## Summary
- catalyst-platform chart template `templates/sme-services/provisioning-github-token.yaml` was unconditionally mirroring `gitea-admin-secret.password` into Secret `sme/provisioning-github-token.GITHUB_TOKEN` on every Flux reconcile (every 15 min), overwriting the real Gitea API token that `bp-self-sovereign-cutover` Step 09 (PR #1704) patched in.
- Verified live on t22 (2026-05-18): Step 09 ran at 13:43:33Z and stamped a working token (`5261e09a...`); ~5 min later helm reconcile rewrote `GITHUB_TOKEN` back to the 8-char admin password byte (`ChxCejmH`). Every subsequent SME provisioning call to Gitea returned 401 "user does not exist", and journey step 16 (tenant repo creation) silently stuck. The C18 fix was ephemeral until this guard landed.

## Root cause
The chart template used `lookup` on the SOURCE (`gitea/gitea-admin-secret`) only, never on the DESTINATION. So even after Step 09 patched the destination Secret with a real API token, the next helm reconcile re-mirrored the admin password byte over the top.

## Fix (Approach A — lookup-persistence guard)
1. Lookup the destination Secret `sme/provisioning-github-token` first.
2. If it carries annotation `catalyst.openova.io/token-source: self-sovereign-cutover-step-09` (stamped by Step 09's `kubectl patch`), preserve the existing `GITHUB_TOKEN` bytes verbatim. Also preserve the `catalyst.openova.io/token-minted-at` provenance annotation so forensic visibility survives reconciles.
3. Otherwise fall through to the first-install bootstrap branch that mirrors `gitea-admin-secret.password` — so a freshly-franchised Sovereign still boots the provisioning Pod past `CreateContainerConfigError` BEFORE Step 09 has had a chance to run.

Chart bump: `1.4.167 → 1.4.168` so the OCI artifact republishes. Bootstrap-kit pin bumped in lockstep in `clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml`.

## Test plan
- [x] `helm template` renders cleanly (no template syntax errors).
- [ ] After chart bump + Blueprint Release + re-mirror, verify on t22:
  ```
  TOK=$(kubectl --kubeconfig=/tmp/t22.kubeconfig --insecure-skip-tls-verify \
    -n sme get secret provisioning-github-token \
    -o jsonpath='{.data.GITHUB_TOKEN}' | base64 -d)
  echo "token last8: ${TOK: -8}"   # MUST NOT be ChxCejmH
  ```
- [ ] Wait ≥15 min (one Flux reconcile interval) and re-verify the token bytes are STABLE (not rewritten by chart reconcile).

Refs: TBD-C18b (discovered while verifying TBD-C18 / PR #1704).

🤖 Generated with [Claude Code](https://claude.com/claude-code)