### PR TITLE
fix(cutover): pivot openova-catalog HelmRepository at step 06 (Refs TBD-C19, step 08 regression)

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -278,7 +278,18 @@ spec:
       # Deployment. Order=9 (last) is fine — none of steps 02-08 read
       # the Secret and the SME provisioning service first consumes
       # the token at voucher checkout time (always postdates cutover).
-      version: 0.1.30
+      # 0.1.31 (TBD-C19, 2026-05-18): step-06 now also pivots
+      # openova-catalog HelmRepository (rendered by bp-catalyst-
+      # platform chart, not directly from bootstrap-kit). Adds
+      # `openova-catalog` to helmRepositories.names; new Phase-1.6
+      # patches the parent HelmRelease's spec.values.catalog.
+      # helmRepository.url; new Phase-2.5 injects same override
+      # into 13-bp-catalyst-platform.yaml in local Gitea so
+      # bootstrap-kit Kustomization reconcile preserves it. Without
+      # this pin bump, step-08 catches openova-catalog as the lone
+      # OFFENDER ~1m after step-06 (chart re-render reverts the
+      # live HR patch). Caught live on t22.omantel.biz 2026-05-18.
+      version: 0.1.31
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -32,7 +32,21 @@ name: bp-self-sovereign-cutover
 # Secret, and the SME provisioning service first consumes the token at
 # voucher checkout time (always postdates cutover). Order 9 avoids
 # renumbering 01..08 which would invalidate operator history.
-version: 0.1.30
+#
+# 0.1.31 (TBD-C19, 2026-05-18): step-06 now also pivots the
+# `openova-catalog` HelmRepository. The HR is rendered by the bp-
+# catalyst-platform Helm chart (not directly from a bootstrap-kit slot
+# file) from `.Values.catalog.helmRepository.url`. Phase-1 patches the
+# live HR; new Phase-1.6 patches the parent HelmRelease's
+# spec.values.catalog.helmRepository.url so the next chart reconcile
+# preserves the local URL; new Phase-2.5 injects (or rewrites) the
+# same override into 13-bp-catalyst-platform.yaml in the local Gitea
+# repo so bootstrap-kit Kustomization reconcile doesn't revert it.
+# Without this fix step-08's egress-block-test catches
+# `openova-catalog` as the lone OFFENDER ~1 min after step-06
+# completes (chart re-render reverts phase-1). Caught live on
+# t22.omantel.biz 2026-05-18.
+version: 0.1.31
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/templates/06-helmrepository-patches-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/06-helmrepository-patches-job.yaml
@@ -279,6 +279,46 @@ data:
             echo "[helmrepository-patches] live-K8s ok=${ok} skip=${skip} fail=${fail}"
             [ "${fail}" -eq 0 ] || exit 1
 
+            # ---- Phase 1.6: parent HelmRelease values override for openova-catalog (TBD-C19) ----
+            #
+            # `openova-catalog` is rendered by the bp-catalyst-platform Helm
+            # chart (products/catalyst/chart/templates/openova-catalog-
+            # helmrepository.yaml) from `.Values.catalog.helmRepository.url`.
+            # Phase-1's live HR patch above is reverted within ~1 min when
+            # helm-controller's next reconcile re-runs `helm upgrade` and
+            # re-emits the HR from the chart's default URL (oci://ghcr.io/
+            # openova-io). Step-08's egress-block-test then catches
+            # `openova-catalog` as the lone OFFENDER and FAILs cutover.
+            #
+            # Fix: patch the parent HelmRelease's `spec.values.catalog.
+            # helmRepository.url` so the NEXT chart reconcile re-renders
+            # the HR with the local Harbor URL — durable across the chart
+            # upgrade cycle. Merge-patch preserves any other
+            # spec.values.catalog.* siblings (e.g. catalog.helmRepository.
+            # interval, .name, .namespace).
+            #
+            # Caught live on t22.omantel.biz 2026-05-18.
+            cur_catalog_url=$(kubectl get helmrelease bp-catalyst-platform -n "${HELMREPO_NAMESPACE}" \
+              -o jsonpath='{.spec.values.catalog.helmRepository.url}' 2>/dev/null || echo "")
+            if [ "${cur_catalog_url}" = "${local_prefix}" ]; then
+              echo "[helmrepository-patches] Phase-1.6 skip: bp-catalyst-platform already has catalog.helmRepository.url=${local_prefix}"
+            else
+              merge_patch=$(printf '{"spec":{"values":{"catalog":{"helmRepository":{"url":"%s"}}}}}' "${local_prefix}")
+              if kubectl patch helmrelease bp-catalyst-platform \
+                  -n "${HELMREPO_NAMESPACE}" \
+                  --type=merge --patch "${merge_patch}" >/dev/null 2>&1; then
+                echo "[helmrepository-patches] Phase-1.6 OK: bp-catalyst-platform spec.values.catalog.helmRepository.url -> ${local_prefix}"
+                # Trigger immediate Flux reconcile so the chart re-
+                # renders openova-catalog HR with the new URL before
+                # step-08's window opens.
+                kubectl annotate --overwrite helmrelease bp-catalyst-platform \
+                  -n "${HELMREPO_NAMESPACE}" \
+                  "reconcile.fluxcd.io/requestedAt=$(date +%s)" >/dev/null 2>&1 || true
+              else
+                echo "[helmrepository-patches] Phase-1.6 FAIL: kubectl patch helmrelease bp-catalyst-platform failed (continuing — phase-2 git push is the durable fix)" >&2
+              fi
+            fi
+
             # ---- Phase 2: push YAML edit to local Gitea (#970) ----
             #
             # The kubectl patches above flip the live HelmRepository
@@ -357,6 +397,89 @@ data:
               echo "[helmrepository-patches] edited ${f}"
             done
             echo "[helmrepository-patches] sed edited ${edited} files"
+
+            # Phase-2.5 (TBD-C19, 2026-05-18): inject openova-catalog URL
+            # override into 13-bp-catalyst-platform.yaml's
+            # `spec.values.sovereign:` block. Why this seam: the
+            # openova-catalog HelmRepository is rendered by the catalyst-
+            # platform Helm chart (see Phase-1.6 above) so the durable URL
+            # lives in the parent HelmRelease's spec.values rather than as
+            # its own `url:` line in bootstrap-kit. Without this injection
+            # the bootstrap-kit Kustomization reconciles the HelmRelease
+            # YAML from Gitea every minute and reverts Phase-1.6's live
+            # patch — chart re-render then puts openova-catalog HR back
+            # at oci://ghcr.io/openova-io and Step-08 catches it.
+            #
+            # Idempotency: if the file already declares
+            # `catalog.helmRepository.url:` under spec.values, replace
+            # the URL value with the current local prefix (handles
+            # re-runs with a different harbor host). Otherwise inject the
+            # full 3-line block above the existing `sovereign:` key
+            # (every chart >= 1.4.117 ships that key under spec.values
+            # — the catalyst-platform values.yaml `sovereign:` block was
+            # added in PR #1569 for D22 settings identity fields).
+            catalyst_yaml="${target_dir}/13-bp-catalyst-platform.yaml"
+            if [ -f "${catalyst_yaml}" ]; then
+              # The catalyst-platform HelmRelease has:
+              #   spec:
+              #     values:
+              #       sovereign:   <-- 4 spaces
+              #         orgEmail:  <-- 6 spaces
+              # So a `catalog:` block under spec.values lives at 4
+              # spaces, `helmRepository:` at 6, `url:` at 8.
+              if grep -qE '^[[:space:]]{4}catalog:[[:space:]]*$' "${catalyst_yaml}" \
+                 && grep -A 3 -E '^[[:space:]]{4}catalog:[[:space:]]*$' "${catalyst_yaml}" \
+                    | grep -qE '^[[:space:]]{6}helmRepository:[[:space:]]*$'; then
+                # Existing block — rewrite the url: value at 8-space
+                # indent within the catalog: block boundary.
+                if sed -i -E "/^[[:space:]]{4}catalog:[[:space:]]*\$/,/^[[:space:]]{0,4}[a-zA-Z]/{s,^([[:space:]]{8}url:[[:space:]]*).*\$,\1${local_prefix}," "${catalyst_yaml}" 2>/dev/null; then
+                  echo "[helmrepository-patches] Phase-2.5 OK: rewrote existing catalog.helmRepository.url in ${catalyst_yaml} -> ${local_prefix}"
+                  edited=$((edited+1))
+                else
+                  echo "[helmrepository-patches] Phase-2.5 WARN: sed rewrite of existing block failed; Phase-1.6 K8s patch remains durable for one upgrade cycle"
+                fi
+              else
+                # No existing block — inject above the `sovereign:` key
+                # under spec.values. The catalyst-platform HR layout
+                # (PR #1569 +) has:
+                #   spec:
+                #     values:
+                #       global: {...}
+                #       ingress: {...}
+                #       parentZones: ...
+                #       wildcardCert: {...}
+                #       sovereign:        <-- inject before this line
+                # The `sovereign:` key sits at 4-space indent (under
+                # spec.values which is 2-space). Match the 4-space form
+                # specifically to avoid the unrelated
+                # `catalyst.openova.io/sovereign:` label at 4-space.
+                if grep -qE '^[[:space:]]{4}sovereign:[[:space:]]*$' "${catalyst_yaml}"; then
+                  awk -v prefix="${local_prefix}" '
+                    /^[[:space:]]{4}sovereign:[[:space:]]*$/ && !done {
+                      print "    # ─── openova-catalog HelmRepository URL (TBD-C19, 2026-05-18) ──"
+                      print "    # Pivoted by self-sovereign-cutover step-06 phase-2.5 from"
+                      print "    # oci://ghcr.io/openova-io → local Harbor mirror so the"
+                      print "    # catalyst-platform chart re-renders openova-catalog HR with"
+                      print "    # the post-cutover URL on every reconcile. Bootstrap-kit"
+                      print "    # Kustomization preserves this override across reconciles —"
+                      print "    # without it Step-08 catches `openova-catalog` regressing"
+                      print "    # back to ghcr.io ~1 min after Phase-1 patch."
+                      print "    catalog:"
+                      print "      helmRepository:"
+                      print "        url: " prefix
+                      done = 1
+                    }
+                    { print }
+                  ' "${catalyst_yaml}" > "${catalyst_yaml}.new" && mv "${catalyst_yaml}.new" "${catalyst_yaml}"
+                  echo "[helmrepository-patches] Phase-2.5 OK: injected catalog.helmRepository.url block into ${catalyst_yaml}"
+                  edited=$((edited+1))
+                else
+                  echo "[helmrepository-patches] Phase-2.5 WARN: ${catalyst_yaml} has no spec.values.sovereign anchor (chart older than 1.4.117?) — Phase-1.6 K8s patch remains durable for one upgrade cycle"
+                fi
+              fi
+            else
+              echo "[helmrepository-patches] Phase-2.5 SKIP: ${catalyst_yaml} not present in local mirror"
+            fi
 
             if [ "${edited}" -eq 0 ]; then
               echo "[helmrepository-patches] no edits — already pivoted in Gitea or upstream prefix not present"

--- a/platform/self-sovereign-cutover/chart/values.yaml
+++ b/platform/self-sovereign-cutover/chart/values.yaml
@@ -234,6 +234,23 @@ helmRepositories:
     - "bp-coraza"
     - "bp-cert-manager-powerdns-webhook"
     - "bp-cluster-autoscaler-hcloud"
+    # openova-catalog (TBD-C19, 2026-05-18) — the named Flux v1
+    # HelmRepository the application-controller renders every
+    # per-Application HelmRelease against (catalogSourceRef default).
+    # Unlike the bp-* HRs above which are rendered directly from
+    # clusters/_template/bootstrap-kit/*.yaml slot files, this HR is
+    # rendered by the bp-catalyst-platform Helm chart itself
+    # (products/catalyst/chart/templates/openova-catalog-helmrepository
+    # .yaml) from `.Values.catalog.helmRepository.url`. Step-06 phase-1
+    # patches the live HR; phase-1.6 patches the parent HelmRelease's
+    # spec.values override; phase-2 makes the override durable in
+    # local Gitea by sed-injecting it into
+    # clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml.
+    # Without this entry step-08 catches `openova-catalog` as the only
+    # remaining ghcr.io offender ~1 min after step-06 (the catalyst-
+    # platform chart's next reconcile re-renders the HR back to
+    # ghcr.io). Caught live on t22.omantel.biz 2026-05-18.
+    - "openova-catalog"
 
 # catalyst-api Deployment to patch in step 07 (catalyst-api-env-patch).
 # Sovereign-side namespace is `catalyst-system`, NOT `catalyst-platform`


### PR DESCRIPTION
## Summary

Surfaced on t22.omantel.biz 2026-05-18: self-sovereign-cutover step 06 succeeds but step 08 fails with exactly one OFFENDER — `flux-system/openova-catalog=oci://ghcr.io/openova-io`.

**Root cause** (two-fold):
1. `openova-catalog` is not in step 06's `helmRepositories.names` (the loop only iterates the 38 bp-* names).
2. Even when added, the live HR patch is reverted because `openova-catalog` is rendered by the **bp-catalyst-platform** Helm chart (`products/catalyst/chart/templates/openova-catalog-helmrepository.yaml`) from `.Values.catalog.helmRepository.url`. Phase-2's sed only rewrites `clusters/_template/bootstrap-kit/*.yaml` slot files, which never carries this URL. Helm-controller's next reconcile re-renders the HR back to `oci://ghcr.io/openova-io`.

## Fix

Three surgical edits, no new abstractions:

- `chart/values.yaml`: add `openova-catalog` to `helmRepositories.names` so step 06 phase-1 patches it.
- `chart/templates/06-helmrepository-patches-job.yaml`:
  - **Phase-1.6**: merge-patches the parent `bp-catalyst-platform` HelmRelease's `spec.values.catalog.helmRepository.url` so the next chart reconcile preserves the local URL (durable across helm-controller).
  - **Phase-2.5**: injects (or in-place rewrites) the same override into `13-bp-catalyst-platform.yaml` in local Gitea so bootstrap-kit Kustomization reconcile doesn't revert the HelmRelease.
  - Both phases idempotent; existing skip/rewrite logic.
- `clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml`: chart pin `0.1.30 → 0.1.31`.
- `chart/Chart.yaml`: version `0.1.30 → 0.1.31` with full changelog comment.

## Test plan

- [x] `helm template platform/self-sovereign-cutover/chart --set sovereign.fqdn=t22.omantel.biz` renders cleanly.
- [x] Rendered `helmrepository-names.txt` ConfigMap includes `openova-catalog` at the end of the list.
- [x] `bash -n` on the extracted step 06 script (full template-rendered) — clean.
- [ ] Fresh prov (t23+) cutover completes 0/9 → 9/9; step 08 reports `external HelmRepositories still pointing at ghcr.io/openova-io: 0`.
- [ ] Post-cutover `kubectl get helmrepository openova-catalog -n flux-system -o jsonpath='{.spec.url}'` returns `oci://harbor.<sov-fqdn>/openova-io` even 30+ min after cutover (across 2× helm-controller reconciles).

## Evidence from t22

```
step.helmrepository-patches.result: success
step.egress-block-test.result: failed
lastError: Job catalyst/cutover-egress-block-test-1779111561 reported Failed condition
```

Step 08 log:
```
[egress-block-test] verifying post-cutover URLs are local
  gitrepository.openova.url=http://gitea-http.gitea.svc.cluster.local:3000/openova/openova
  external HelmRepositories still pointing at ghcr.io/openova-io (excluding slot-managed self-refs): 1
    OFFENDER flux-system/openova-catalog=oci://ghcr.io/openova-io
  FAIL — at least one HelmRepository did not pivot
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)