### PR TITLE
fix(ci): deploy-bot auto-bumps bootstrap-kit pin when chart version bumps (Refs TBD-A6 meta-fix)

### DIFF
--- a/.github/workflows/blueprint-release.yaml
+++ b/.github/workflows/blueprint-release.yaml
@@ -69,7 +69,16 @@ on:
           - products
 
 permissions:
-  contents: read
+  # contents: write — the auto-bump-pin step (added 2026-05-18, TBD-A6
+  # meta-fix) writes back the `version:` line in
+  # clusters/_template/bootstrap-kit/<NN>-<chart>.yaml so the bootstrap-
+  # kit pin moves in lockstep with the published OCI artifact. Before
+  # this, every chart bump required a SEPARATE manual collector PR to
+  # bump the pin (PRs #1666, #1687, #1695, #1698, #1707 in the
+  # 2026-05-17/18 wave alone). The bot-author commit does NOT re-trigger
+  # workflows (GITHUB_TOKEN convention), so we can safely push without
+  # looping the publish pipeline.
+  contents: write
   packages: write
   id-token: write              # for cosign keyless signing
 
@@ -497,6 +506,181 @@ jobs:
           cosign attest --yes --predicate /tmp/sbom/sbom.spdx.json --type spdxjson \
             "${{ steps.push.outputs.ref }}@${{ steps.push.outputs.digest }}"
 
+      # ──────────────────────────────────────────────────────────────
+      # AUTO-BUMP — clusters/_template/bootstrap-kit/<NN>-<chart>.yaml
+      # ──────────────────────────────────────────────────────────────
+      # TBD-A6 meta-fix (2026-05-18): every chart-publishing wave in this
+      # session required a SEPARATE manual collector PR to bump the
+      # bootstrap-kit pin so Sovereigns would actually install the new
+      # OCI artifact. Without the pin bump, the chart at e.g.
+      # bp-catalyst-platform:1.4.166 gets published to GHCR but
+      # clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+      # still pins `version: 1.4.165` and fresh Sovereigns silently
+      # install the OLD artifact.
+      #
+      # Manual collector PRs from this session ALONE (eliminated by
+      # this hook):
+      #   - #1676 chart 1.4.162→1.4.163 — Wave 16 collector
+      #   - #1687 chart 1.4.163→1.4.164 — Wave 17 collector
+      #   - #1694 bp-guacamole 0.1.21 → 0.1.22 (TBD-G6)
+      #   - #1695 chart 1.4.164→1.4.165 — Wave 18 collector
+      #   - #1698 chart 1.4.165→1.4.166 (TBD-E8)
+      #   - #1700 bp-guacamole 0.1.22 → 0.1.23 (TBD-G4 phase 2)
+      #   - #1706 self-sovereign-cutover 0.1.29→0.1.30 (TBD-C18)
+      #   - #1707 chart 1.4.166→1.4.167 — Wave 24 collector
+      #
+      # Mechanism: the canonical chart name comes from Chart.yaml `name:`
+      # (already read into ${{ steps.chart.outputs.name }} above). The
+      # corresponding bootstrap-kit pin file is identified by grepping
+      # for `^      chart: <name>$` (6-space indent matches the
+      # HelmRelease.spec.chart.spec.chart shape in every existing slot).
+      # If no pin file matches, the chart is NOT in the bootstrap kit
+      # (e.g. it's an optional Application Blueprint that Sovereigns
+      # opt into via overlay) — this is a graceful no-op, NOT a failure.
+      #
+      # The bot-author commit does NOT re-trigger blueprint-release per
+      # the GITHUB_TOKEN convention. So this hook converges in ONE pass:
+      # publish → bump pin → push. The next Sovereign provisioned will
+      # pick up the new pin via the standard Flux reconciliation.
+      #
+      # Idempotent reset-and-rewrite: parallel matrix jobs (multiple
+      # changed Blueprints in the same push) could race on the same
+      # branch. Retry up to 3 times with `git fetch + reset --hard
+      # origin/main + re-sed` so concurrent runs produce strictly
+      # ordered commits instead of clobbering each other.
+      - name: "Auto-bump bootstrap-kit pin for ${{ steps.chart.outputs.name }}"
+        if: steps.chart.outputs.skip != 'true'
+        id: bump_pin
+        env:
+          CHART_NAME: ${{ steps.chart.outputs.name }}
+          CHART_VERSION: ${{ steps.chart.outputs.version }}
+        run: |
+          set -euo pipefail
+
+          # Locate the bootstrap-kit slot pinning this chart, if any.
+          # The 6-space indent matches every existing slot's chart
+          # directive:
+          #
+          #     spec:
+          #       chart:
+          #         spec:
+          #           chart: bp-<name>        ← 6 spaces
+          #           version: <semver>       ← 6 spaces, same scope
+          pin_file=$(grep -lE "^      chart: ${CHART_NAME}\$" \
+            clusters/_template/bootstrap-kit/*.yaml 2>/dev/null || true)
+
+          if [ -z "$pin_file" ]; then
+            echo "INFO: no bootstrap-kit slot pins ${CHART_NAME} — graceful no-op (chart is an opt-in Application Blueprint, not part of the kit)."
+            echo "bumped=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Defensive: refuse to operate if multiple slots reference the
+          # same chart name — bootstrap-kit invariant is one slot per
+          # chart, and a violation would mean the schema changed under
+          # us and the hook would write wrong things.
+          slot_count=$(echo "$pin_file" | wc -l)
+          if [ "$slot_count" -ne 1 ]; then
+            echo "::error title=Multiple bootstrap-kit slots for ${CHART_NAME}::Expected exactly one slot file pinning chart '${CHART_NAME}', found ${slot_count}: $pin_file"
+            exit 1
+          fi
+
+          # Read current pin. The HelmRelease.spec.chart.spec.version is
+          # at exactly 6 spaces of indent in every slot (audited 2026-
+          # 05-18 across all 51 files). If the shape ever changes we
+          # fail loudly rather than write the wrong line.
+          current=$(awk '/^      version:/{print $2; exit}' "$pin_file" | tr -d '"')
+          if [ -z "$current" ]; then
+            echo "::error title=Unparseable bootstrap-kit pin::No '      version:' line at 6-space indent in $pin_file. The HelmRelease.spec.chart.spec.version shape changed under TBD-A6's auto-bump hook; refusing to write."
+            exit 1
+          fi
+
+          if [ "$current" = "$CHART_VERSION" ]; then
+            echo "INFO: ${pin_file} already pins ${CHART_NAME}=${CHART_VERSION} — no-op."
+            echo "bumped=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "Bumping ${pin_file}: ${CHART_NAME} ${current} → ${CHART_VERSION}"
+          # sed targets the single 6-space `      version:` line at the
+          # chart-pin scope. There is exactly one such line per slot
+          # (audited 2026-05-18); the regex is anchored to start-of-line
+          # so a deeper-indented `version:` (e.g. inside .values.xxx)
+          # cannot accidentally match.
+          sed -i -E "s|^      version: .*\$|      version: ${CHART_VERSION}|" "$pin_file"
+
+          # Verify the sed actually flipped the line — defence against
+          # a future indent change shipping silently.
+          new=$(awk '/^      version:/{print $2; exit}' "$pin_file" | tr -d '"')
+          if [ "$new" != "$CHART_VERSION" ]; then
+            echo "::error title=sed failed::After rewrite, ${pin_file} still pins '${new}', expected '${CHART_VERSION}'."
+            exit 1
+          fi
+
+          echo "bumped=true" >> "$GITHUB_OUTPUT"
+          echo "pin_file=${pin_file}" >> "$GITHUB_OUTPUT"
+          echo "prev_version=${current}" >> "$GITHUB_OUTPUT"
+
+      - name: "Commit + push bootstrap-kit pin bump"
+        if: steps.chart.outputs.skip != 'true' && steps.bump_pin.outputs.bumped == 'true'
+        env:
+          CHART_NAME: ${{ steps.chart.outputs.name }}
+          CHART_VERSION: ${{ steps.chart.outputs.version }}
+          PIN_FILE: ${{ steps.bump_pin.outputs.pin_file }}
+          PREV_VERSION: ${{ steps.bump_pin.outputs.prev_version }}
+        run: |
+          set -euo pipefail
+          git config user.name "hatiyildiz"
+          git config user.email "hatiyildiz@users.noreply.github.com"
+
+          # Idempotent reset-and-rewrite on push conflict — parallel
+          # matrix jobs (multiple Blueprints bumped in one push) can race
+          # on the same branch. On conflict we re-fetch, re-sed against
+          # whatever pin is currently on origin/main, and re-commit. The
+          # operation is convergent: every retry produces the same final
+          # pin value (CHART_VERSION), so the only failure mode is the
+          # remote already at that version → no-op skip.
+          rewrite_pin() {
+            local pf="$1"
+            local cur
+            cur=$(awk '/^      version:/{print $2; exit}' "$pf" | tr -d '"')
+            if [ "$cur" = "${CHART_VERSION}" ]; then
+              return 1  # already there — caller decides whether to skip
+            fi
+            sed -i -E "s|^      version: .*\$|      version: ${CHART_VERSION}|" "$pf"
+            return 0
+          }
+
+          git add "${PIN_FILE}"
+          if git diff --staged --quiet; then
+            echo "no staged changes — already in sync"
+            exit 0
+          fi
+          git commit -m "deploy(${CHART_NAME}): bump bootstrap-kit pin ${PREV_VERSION} -> ${CHART_VERSION} (auto, Refs TBD-A6)"
+
+          for i in 1 2 3; do
+            if git push origin HEAD:main; then
+              echo "Pushed bootstrap-kit pin bump for ${CHART_NAME}=${CHART_VERSION}"
+              exit 0
+            fi
+            echo "push attempt $i failed — re-fetching origin/main and re-applying pin bump"
+            git fetch origin main
+            git reset --hard origin/main
+            if rewrite_pin "${PIN_FILE}"; then
+              git add "${PIN_FILE}"
+              if git diff --staged --quiet; then
+                echo "no changes after re-fetch — pin already at ${CHART_VERSION} on origin/main"
+                exit 0
+              fi
+              git commit -m "deploy(${CHART_NAME}): bump bootstrap-kit pin -> ${CHART_VERSION} (auto, Refs TBD-A6, retry $i)"
+            else
+              echo "origin/main already at ${CHART_VERSION} — nothing to push"
+              exit 0
+            fi
+          done
+          echo "::error title=Pin bump push failed::3 attempts exhausted for ${CHART_NAME}=${CHART_VERSION}."
+          exit 1
+
       - name: Summary
         if: steps.chart.outputs.skip != 'true'
         run: |
@@ -509,3 +693,8 @@ jobs:
           echo "- **Cosigned:** ✓ (keyless via GitHub OIDC)" >> "$GITHUB_STEP_SUMMARY"
           echo "- **SBOM attested:** ✓ (SPDX-JSON)" >> "$GITHUB_STEP_SUMMARY"
           echo "- **Subchart guards:** ✓ working tree, ✓ packaged tgz, ✓ pulled OCI artifact, ✓ helm template smoke" >> "$GITHUB_STEP_SUMMARY"
+          if [ "${{ steps.bump_pin.outputs.bumped }}" = "true" ]; then
+            echo "- **Bootstrap-kit pin:** ✓ auto-bumped \`${{ steps.bump_pin.outputs.pin_file }}\` ${{ steps.bump_pin.outputs.prev_version }} → ${{ steps.chart.outputs.version }} (TBD-A6 meta-fix)" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "- **Bootstrap-kit pin:** (chart is not in the kit — opt-in Application Blueprint, no pin to bump)" >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/.github/workflows/test-bootstrap-kit.yaml
+++ b/.github/workflows/test-bootstrap-kit.yaml
@@ -12,8 +12,10 @@ on:
       - 'tests/e2e/bootstrap-kit/**'
       - 'platform/**/blueprint.yaml'
       - 'platform/**/chart/**'
+      - 'products/**/chart/**'
       - 'clusters/**'
       - 'scripts/check-bootstrap-deps.sh'
+      - 'scripts/check-bootstrap-kit-pin-sync.sh'
       - 'scripts/expected-bootstrap-deps.yaml'
       - '.github/workflows/test-bootstrap-kit.yaml'
     branches: [main]
@@ -22,8 +24,10 @@ on:
       - 'tests/e2e/bootstrap-kit/**'
       - 'platform/**/blueprint.yaml'
       - 'platform/**/chart/**'
+      - 'products/**/chart/**'
       - 'clusters/**'
       - 'scripts/check-bootstrap-deps.sh'
+      - 'scripts/check-bootstrap-kit-pin-sync.sh'
       - 'scripts/expected-bootstrap-deps.yaml'
       - '.github/workflows/test-bootstrap-kit.yaml'
   workflow_dispatch:
@@ -50,6 +54,42 @@ jobs:
 
       - name: Run bootstrap-kit dependency audit
         run: bash scripts/check-bootstrap-deps.sh
+
+  pin-sync-audit:
+    # TBD-A6 regression test. Asserts every Chart.yaml in platform/* or
+    # products/* whose chart is pinned in clusters/_template/bootstrap-
+    # kit/ has the SAME version on both sides.
+    #
+    # On `pull_request` we use --changed-only --base <base-ref> so a PR
+    # is only blocked on chart→pin pairs IT modified. This keeps the
+    # gate effective (every new chart bump must update the pin) without
+    # forcing pre-existing drifts (13 charts as of 2026-05-18) to be
+    # fixed before any unrelated PR can land. The auto-bump hook in
+    # blueprint-release.yaml will heal those drifts on the next bump
+    # of each lagging chart.
+    #
+    # On `push` to main and `workflow_dispatch` we run the FULL sweep
+    # so post-merge drift is observable on the run summary even if the
+    # PR gate let it through.
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # Need history back to the PR base for the --changed-only diff.
+          fetch-depth: 0
+
+      - name: Run pin-sync audit (changed-only on PR, full sweep otherwise)
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            base="${{ github.event.pull_request.base.sha }}"
+            echo "Running --changed-only against base ${base}"
+            bash scripts/check-bootstrap-kit-pin-sync.sh --changed-only --base "${base}"
+          else
+            echo "Running full sweep (event=${{ github.event_name }})"
+            bash scripts/check-bootstrap-kit-pin-sync.sh
+          fi
 
   manifest-validation:
     # Static-only validation: blueprint.yaml + chart Chart.yaml + clusters/_template

--- a/scripts/check-bootstrap-kit-pin-sync.sh
+++ b/scripts/check-bootstrap-kit-pin-sync.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+# check-bootstrap-kit-pin-sync.sh — TBD-A6 regression test.
+#
+# Convergence contract (asserted by this script):
+#
+#   For every chart name that appears in BOTH
+#     (a) platform/<x>/chart/Chart.yaml          OR  products/<x>/chart/Chart.yaml
+#     AND
+#     (b) clusters/_template/bootstrap-kit/*.yaml as `      chart: <name>`
+#
+#   the bootstrap-kit `      version:` line MUST equal the source chart's
+#   Chart.yaml `version:` field.
+#
+# Why this matters: before TBD-A6's auto-bump hook in
+# .github/workflows/blueprint-release.yaml, every chart bump required a
+# SEPARATE manual collector PR to bump the bootstrap-kit pin. Six such
+# PRs shipped in the 2026-05-17/18 wave alone (#1666, #1687, #1695,
+# #1698, #1706, #1707). When the pin lagged, the OCI artifact at
+# `ghcr.io/openova-io/<chart>:<new-ver>` was published but fresh
+# Sovereigns silently installed the OLD <previous-ver> pinned in the
+# bootstrap-kit slot.
+#
+# This script protects against:
+#   - A future workflow author breaking the auto-bump hook (the convergence
+#     would silently regress; this CI test would catch it on the next push
+#     that touches a chart).
+#   - A human-authored manual PR that bumps Chart.yaml but forgets the pin
+#     (the test fails the build BEFORE blueprint-release publishes).
+#
+# Charts in platform/products without a bootstrap-kit pin (e.g. opt-in
+# Application Blueprints like bp-vllm, bp-temporal) are explicitly out of
+# scope — they have no pin to lag.
+#
+# Exit codes:
+#   0  — every bootstrap-kit pin matches its source-tree Chart.yaml version.
+#   1  — at least one pin lags (or, less likely, leads) the source chart.
+#   2  — input/parse/usage error.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+KIT_DIR="${REPO_ROOT}/clusters/_template/bootstrap-kit"
+
+CHANGED_ONLY=""
+BASE_REF=""
+
+# Two modes:
+#   - Full sweep (default): check every chart in the working tree.
+#   - --changed-only --base <ref>: only check charts whose Chart.yaml
+#     was modified between <ref> and HEAD. This is the CI-gate mode —
+#     it lets a PR ship without first fixing 13 pre-existing drifts
+#     (the auto-bump hook will heal those over time).
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --changed-only)
+      CHANGED_ONLY=1
+      shift
+      ;;
+    --base)
+      BASE_REF="$2"
+      shift 2
+      ;;
+    -h|--help)
+      sed -n '2,40p' "$0"
+      exit 0
+      ;;
+    *)
+      echo "error: unknown argument '$1'" >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [ -n "${CHANGED_ONLY}" ] && [ -z "${BASE_REF}" ]; then
+  echo "error: --changed-only requires --base <ref>" >&2
+  exit 2
+fi
+
+if [ ! -d "${KIT_DIR}" ]; then
+  echo "error: bootstrap-kit directory not found at ${KIT_DIR}" >&2
+  exit 2
+fi
+
+# Build the list of Chart.yaml paths to scan.
+declare -a CHART_YAMLS=()
+if [ -n "${CHANGED_ONLY}" ]; then
+  # Only Chart.yaml files modified between BASE_REF and HEAD.
+  while IFS= read -r line; do
+    [ -n "${line}" ] && CHART_YAMLS+=("${REPO_ROOT}/${line}")
+  done < <(cd "${REPO_ROOT}" && git diff --name-only "${BASE_REF}" -- \
+    'platform/*/chart/Chart.yaml' 'products/*/chart/Chart.yaml' 2>/dev/null | sort)
+  if [ "${#CHART_YAMLS[@]}" -eq 0 ]; then
+    echo "No platform/products Chart.yaml files changed since ${BASE_REF} — nothing to check."
+    exit 0
+  fi
+  echo "Scanning ${#CHART_YAMLS[@]} Chart.yaml file(s) changed since ${BASE_REF}:"
+  for c in "${CHART_YAMLS[@]}"; do echo "  ${c#${REPO_ROOT}/}"; done
+  echo
+else
+  while IFS= read -r line; do
+    CHART_YAMLS+=("${line}")
+  done < <(find "${REPO_ROOT}/platform" "${REPO_ROOT}/products" \
+    -path '*/chart/Chart.yaml' 2>/dev/null | sort)
+fi
+
+drift=0
+checked=0
+skipped=0
+
+# Walk every Chart.yaml in platform/* and products/*. Reading from
+# Chart.yaml lets us follow a Chart.yaml `name:` rename without needing
+# folder-basename heuristics (e.g. products/catalyst/chart/Chart.yaml is
+# `bp-catalyst-platform`, NOT `catalyst`).
+for chart_yaml in "${CHART_YAMLS[@]}"; do
+  name=$(awk '/^name:/{print $2; exit}' "${chart_yaml}" | tr -d '"')
+  version=$(awk '/^version:/{print $2; exit}' "${chart_yaml}" | tr -d '"')
+
+  if [ -z "${name}" ] || [ -z "${version}" ]; then
+    echo "error: ${chart_yaml} has malformed name= or version=" >&2
+    exit 2
+  fi
+
+  # Look for a bootstrap-kit slot pinning this chart. The 6-space indent
+  # matches the canonical HelmRelease.spec.chart.spec.chart shape across
+  # all 51 slot files (audited 2026-05-18). If a future slot file uses a
+  # different shape the regex would silently miss it; we tolerate this
+  # because the auto-bump hook uses the same regex (any shape skew would
+  # surface in CI on the next chart bump).
+  pin_files=$(grep -lE "^      chart: ${name}\$" "${KIT_DIR}"/*.yaml 2>/dev/null || true)
+
+  if [ -z "${pin_files}" ]; then
+    # Chart is not in the bootstrap kit — opt-in Application Blueprint
+    # (e.g. bp-vllm, bp-temporal, bp-stalwart-sovereign). Out of scope
+    # for this contract — there is no pin to lag.
+    skipped=$((skipped + 1))
+    continue
+  fi
+
+  slot_count=$(echo "${pin_files}" | wc -l)
+  if [ "${slot_count}" -gt 1 ]; then
+    echo "error: multiple bootstrap-kit slots pin chart '${name}':" >&2
+    echo "${pin_files}" >&2
+    echo "       (bootstrap-kit invariant: one slot per chart name)" >&2
+    exit 2
+  fi
+
+  pin_file="${pin_files}"
+  pinned_version=$(awk '/^      version:/{print $2; exit}' "${pin_file}" | tr -d '"')
+
+  if [ -z "${pinned_version}" ]; then
+    echo "error: ${pin_file} has no '      version:' line at 6-space indent" >&2
+    exit 2
+  fi
+
+  checked=$((checked + 1))
+
+  if [ "${pinned_version}" = "${version}" ]; then
+    echo "  OK   ${name}: chart=${version} pin=${pinned_version}"
+  else
+    echo "  DRIFT ${name}: chart=${version} pin=${pinned_version} (file: ${pin_file#${REPO_ROOT}/})"
+    drift=$((drift + 1))
+  fi
+done
+
+echo
+echo "Checked ${checked} chart→pin pair(s), skipped ${skipped} chart(s) not in the bootstrap kit."
+
+if [ "${drift}" -gt 0 ]; then
+  echo
+  echo "FAIL: ${drift} bootstrap-kit pin(s) drifted from their source chart."
+  echo
+  echo "Root cause: the chart's Chart.yaml \`version:\` was bumped but the"
+  echo "matching clusters/_template/bootstrap-kit/<NN>-<chart>.yaml"
+  echo "\`      version:\` line was NOT bumped in lockstep."
+  echo
+  echo "Fix: either (a) update the bootstrap-kit pin in this PR to match"
+  echo "the chart version, or (b) verify the blueprint-release.yaml"
+  echo "\"Auto-bump bootstrap-kit pin\" step ran on the previous chart-"
+  echo "bumping merge commit. The auto-bump hook (TBD-A6) was designed"
+  echo "to make this manual step unnecessary."
+  exit 1
+fi
+
+echo "PASS: all bootstrap-kit pins are in sync with their source charts."
+exit 0


### PR DESCRIPTION
## Summary — TBD-A6 META-FIX

Every chart-publishing wave in the 2026-05-17/18 session required a SEPARATE manual collector PR to bump the bootstrap-kit pin so Sovereigns would actually install the freshly published OCI artifact. Without the pin bump, the chart at e.g. `bp-catalyst-platform:1.4.166` gets published to GHCR but `clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml` still pins `version: 1.4.165` and fresh Sovereigns silently install the OLD artifact.

This PR eliminates the pattern: the deploy-bot now auto-bumps the bootstrap-kit pin in lockstep with the chart publish.

## Manual collector PRs eliminated by this hook (one session sample)

| PR | What it did |
|---|---|
| #1676 | chart 1.4.162 → 1.4.163 (Wave 16 collector) |
| #1687 | chart 1.4.163 → 1.4.164 (Wave 17 collector) |
| #1694 | bp-guacamole 0.1.21 → 0.1.22 (TBD-G6) |
| #1695 | chart 1.4.164 → 1.4.165 (Wave 18 collector) |
| #1698 | chart 1.4.165 → 1.4.166 (TBD-E8) |
| #1700 | bp-guacamole 0.1.22 → 0.1.23 (TBD-G4 phase 2) |
| #1706 | bp-self-sovereign-cutover 0.1.29 → 0.1.30 (TBD-C18) |
| #1707 | chart 1.4.166 → 1.4.167 (Wave 24 collector) |

That is ~6+ PRs in one session — a recurring tax that this single workflow patch eliminates.

## Mechanism

The fix lives in **one** workflow — `.github/workflows/blueprint-release.yaml` — the single workflow that publishes every chart's OCI artifact regardless of which upstream workflow triggered it (`services-build`, `catalyst-build`, `build-bp-*`, manual `workflow_dispatch`, or any future chart's auto-build).

After a successful `helm push` + cosign sign + SBOM attest, a new step:

1. Reads `${{ steps.chart.outputs.name }}` (e.g. `bp-newapi`) — already canonical, pulled from `Chart.yaml`'s `name:` field.
2. Greps `clusters/_template/bootstrap-kit/*.yaml` for the canonical `      chart: <name>` line. The 6-space indent matches every existing slot's `HelmRelease.spec.chart.spec.chart` shape (audited across all 51 slot files 2026-05-18).
3. If a matching slot file is found, sed-replaces the slot's `      version: <old>` with `version: <new>` and commits + pushes back to `main` as `hatiyildiz <hatiyildiz@users.noreply.github.com>`.
4. **Graceful no-op** if no slot file matches — the chart is an opt-in Application Blueprint (e.g. `bp-vllm`, `bp-temporal`, `bp-stalwart-sovereign`) and has no pin to lag.
5. **Conflict-tolerant** retry up to 3 times with idempotent `git fetch + reset --hard origin/main + re-sed` for the parallel-matrix case (multiple Blueprints bumped in the same push).

The bot-author commit does **NOT** re-trigger workflows (GitHub Actions `GITHUB_TOKEN` convention), so the chain converges in ONE pass:

```
chart bump → blueprint-release → publish OCI artifact → bump bootstrap-kit pin
```

No loop.

## Why `blueprint-release.yaml` (not each `build-bp-*` workflow)

- It runs after **every** chart publish, regardless of upstream trigger.
- It already has the canonical chart name + version in `${{ steps.chart.outputs.name }}` + `${{ steps.chart.outputs.version }}`.
- **One** file changed, one hook covers all 51 bootstrap-kit slots plus any future additions.

## Regression test

`scripts/check-bootstrap-kit-pin-sync.sh` asserts the convergence contract: every `Chart.yaml` in `platform/*` or `products/*` whose chart name is pinned in `clusters/_template/bootstrap-kit/` MUST have the same version on both sides.

The `.github/workflows/test-bootstrap-kit.yaml` workflow now runs this audit:

- **`pull_request`** — `--changed-only --base <pr-base>` so a PR is only blocked on chart→pin pairs IT modified. This avoids forcing pre-existing drifts (13 charts as of 2026-05-18, observable in a full-sweep run) to be fixed before any unrelated PR can land. The auto-bump hook will heal those drifts on the next bump of each lagging chart.
- **`push` to main / `workflow_dispatch`** — full sweep so post-merge drift is observable on the run summary even if the PR gate let it through.

## Local validation

```bash
$ bash scripts/check-bootstrap-kit-pin-sync.sh
…
Checked 51 chart→pin pair(s), skipped 29 chart(s) not in the bootstrap kit.

FAIL: 13 bootstrap-kit pin(s) drifted from their source chart.
```

Those 13 drifts are pre-existing on `origin/main` — proof the bug class exists and that the regression test correctly detects it. The auto-bump hook in this PR prevents new drift from accumulating.

```bash
$ bash scripts/check-bootstrap-kit-pin-sync.sh --changed-only --base origin/main
No platform/products Chart.yaml files changed since origin/main — nothing to check.
```

`--changed-only` correctly limits the gate to PR-touched charts only.

## Files changed

- `.github/workflows/blueprint-release.yaml` — `contents: write` + auto-bump step + commit-and-push step + summary line.
- `.github/workflows/test-bootstrap-kit.yaml` — new `pin-sync-audit` job (full sweep on push, `--changed-only` on PR); add `products/**/chart/**` to path triggers.
- `scripts/check-bootstrap-kit-pin-sync.sh` — new audit script (full sweep + `--changed-only --base <ref>` modes).

## Test plan

- [x] YAML syntax: `python3 -c 'import yaml; yaml.safe_load(open(...))'` passes on both workflows.
- [x] Mapping audit: verified `grep -lE "^      chart: <name>$"` correctly resolves `bp-newapi`, `bp-catalyst-platform`, `sandbox`, `bp-guacamole`, `bp-self-sovereign-cutover`, `bp-flux`, `bp-cilium`, `bp-keycloak` to their slot files; returns empty (graceful no-op) for `bp-vllm`, `bp-temporal`, `bp-bge`.
- [x] Indent invariant: audited all 51 slot files — every one has exactly one `      version:` line at 6-space indent (or is `sandbox` whose pin uses the same shape).
- [x] Sed dry-run: ran the auto-bump logic locally against `clusters/_template/bootstrap-kit/05-sealed-secrets.yaml` (pre-existing drift `1.1.1` → source `1.1.2`); confirmed the single targeted line flipped, restored to original.
- [x] Regression test full-sweep mode: correctly reports 13 existing drifts on `origin/main`.
- [x] Regression test `--changed-only` mode: correctly reports "nothing to check" against `origin/main`.
- [ ] Next chart-publishing merge to main observes the new "Auto-bump bootstrap-kit pin" step in the blueprint-release run summary and a follow-on `deploy(<chart>): bump bootstrap-kit pin … (auto, Refs TBD-A6)` commit on `main`.
- [ ] Future PR that bumps Chart.yaml without touching the pin: pin-sync-audit job blocks the merge.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>