### PR TITLE
fix(helmwatch): transition install Jobs to Complete when HR reports Ready=True (Refs TBD-B6, TBD-B7)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/jobs/helmwatch_bridge.go
+++ b/products/catalyst/bootstrap/api/internal/jobs/helmwatch_bridge.go
@@ -365,9 +365,42 @@ func (b *Bridge) SeedJobsFromInformerList(seeds []InformerSeed) (jobsWritten, ex
 			// transition emitted earlier in the same Pod's life. For
 			// non-terminal states we keep the cursor live so subsequent
 			// raw-log forwards land on the same Execution; for terminal
-			// states we clear the cursor (the Execution has already
-			// been finished by the prior call).
+			// states we clear the cursor.
+			//
+			// Stale-state class bug (TBD-B6/B7, t131 sin-2 install Jobs
+			// stuck "running"): a Pod restart between OnHelmReleaseEvent
+			// allocating an Execution (non-terminal) and the HR reaching
+			// Ready=True wipes activeExecID + lastState but leaves the
+			// prior Execution in StatusRunning on disk. On resume, the
+			// seed observes the HR's terminal state and lands here. Prior
+			// to this fix the branch ONLY cleared the cursor — the
+			// orphan Execution was never FinishExecution'd, so its row
+			// stayed `running` forever (and Job.FinishedAt / DurationMs
+			// stayed nil/0 because the UpsertJob above does not stamp
+			// finishedAt). FinishExecution is the canonical terminal
+			// transition: it stamps Execution.Status + FinishedAt AND
+			// Job.Status + Job.FinishedAt + DurationMs in one call. We
+			// check the prior Execution's current status before calling
+			// so an already-finished Execution is left alone (idempotency
+			// for the seed-twice path covered by
+			// TestSeedJobsFromInformerList_idempotent).
 			if isTerminalHelmState(s.State) {
+				priorExec, findErr := b.store.FindExecution(b.deploymentID, job.LatestExecutionID)
+				if findErr == nil && !IsTerminal(priorExec.Status) {
+					final := StatusSucceeded
+					if s.State == HelmStateFailed {
+						final = StatusFailed
+					}
+					t := s.ObservedAt
+					if t.IsZero() {
+						t = time.Now().UTC()
+					} else {
+						t = t.UTC()
+					}
+					if finishErr := b.store.FinishExecution(b.deploymentID, job.LatestExecutionID, final, t); finishErr != nil {
+						return jobsWritten, executionsSeeded, finishErr
+					}
+				}
 				b.activeExecID[comp] = ""
 			} else {
 				b.activeExecID[comp] = job.LatestExecutionID

--- a/products/catalyst/bootstrap/api/internal/jobs/helmwatch_bridge_test.go
+++ b/products/catalyst/bootstrap/api/internal/jobs/helmwatch_bridge_test.go
@@ -844,3 +844,165 @@ func TestBridge_SeedThenRuntimeTransitions(t *testing.T) {
 		t.Errorf("install-cert-manager executions: %+v", cmExecs)
 	}
 }
+
+// TestSeedJobsFromInformerList_resumeFinishesOrphanedExecution covers the
+// TBD-B6/B7 stale-state class bug. Sequence (matches the t131 sin-2
+// "install Jobs stuck running" incident captured in MEMORY.md):
+//
+//  1. First seed observes the HR as "installing" — bridge writes a
+//     Status=running Job and allocates an open Execution.
+//  2. Pod restart (simulated by NewBridge against the same Store): the
+//     in-memory activeExecID + lastState are wiped, but the persisted
+//     Job + Execution stay on disk. The Execution is still
+//     Status=running, the Job still has a non-nil LatestExecutionID.
+//  3. Resume seed observes the HR as "installed" (Ready=True flipped on
+//     the cluster while the Pod was down).
+//
+// Pre-fix: the resume branch in SeedJobsFromInformerList only cleared
+// the cursor — Execution stayed Status=running forever, Job.FinishedAt
+// remained nil, DurationMs stayed 0. The JobsTable showed status=succeeded
+// (because UpsertJob wrote that field) but the per-job detail page
+// rendered an Execution row with a running spinner that never resolved.
+// Founder caught this on t131.
+//
+// Post-fix: the resume branch detects the orphan Execution + calls
+// FinishExecution which stamps both Execution.Status and Job.FinishedAt
+// + DurationMs from a single canonical transition.
+func TestSeedJobsFromInformerList_resumeFinishesOrphanedExecution(t *testing.T) {
+	st, br, depID := newBridgeFixture(t)
+	t0 := time.Date(2026, 5, 16, 12, 0, 0, 0, time.UTC)
+
+	// First seed: HR is mid-install. Bridge allocates a non-terminal
+	// Execution that stays open.
+	_, _, err := br.SeedJobsFromInformerList([]InformerSeed{
+		{Component: "cilium", State: HelmStateInstalling, Message: "reconciling", ObservedAt: t0},
+	})
+	if err != nil {
+		t.Fatalf("first seed: %v", err)
+	}
+	jobID := JobID(depID, JobNamePrefix+"cilium")
+	job, execs, err := st.GetJob(depID, jobID)
+	if err != nil {
+		t.Fatalf("GetJob after first seed: %v", err)
+	}
+	if job.Status != StatusRunning {
+		t.Fatalf("first-seed Job.Status: want %q, got %q", StatusRunning, job.Status)
+	}
+	if job.LatestExecutionID == "" {
+		t.Fatalf("first-seed: LatestExecutionID must be set")
+	}
+	if len(execs) != 1 || execs[0].Status != StatusRunning {
+		t.Fatalf("first-seed executions: %+v", execs)
+	}
+	orphanExecID := execs[0].ID
+
+	// Simulate Pod restart: fresh Bridge against the same persisted
+	// Store. activeExecID + lastState start empty.
+	br2 := NewBridge(st, depID)
+
+	// Resume seed: HR transitioned to installed while the Pod was down.
+	t1 := t0.Add(45 * time.Second)
+	_, _, err = br2.SeedJobsFromInformerList([]InformerSeed{
+		{Component: "cilium", State: HelmStateInstalled, Message: "Ready=True", ObservedAt: t1},
+	})
+	if err != nil {
+		t.Fatalf("resume seed: %v", err)
+	}
+
+	// Post-resume invariants — the bug fix makes ALL of these hold.
+	job, execs, err = st.GetJob(depID, jobID)
+	if err != nil {
+		t.Fatalf("GetJob after resume seed: %v", err)
+	}
+	if job.Status != StatusSucceeded {
+		t.Errorf("resume Job.Status: want %q, got %q", StatusSucceeded, job.Status)
+	}
+	if job.FinishedAt == nil {
+		t.Errorf("resume Job.FinishedAt: want non-nil after terminal seed, got nil")
+	} else if !job.FinishedAt.Equal(t1) {
+		t.Errorf("resume Job.FinishedAt: want %v, got %v", t1, *job.FinishedAt)
+	}
+	if job.DurationMs <= 0 {
+		t.Errorf("resume Job.DurationMs: want >0 after terminal seed, got %d", job.DurationMs)
+	}
+	// The original orphan Execution must now be finished — not a fresh
+	// one. This is the load-bearing assertion: the fix MUST close the
+	// orphan, not paper over by allocating a new Execution.
+	if job.LatestExecutionID != orphanExecID {
+		t.Errorf("resume Job.LatestExecutionID drifted: want %q (orphan), got %q",
+			orphanExecID, job.LatestExecutionID)
+	}
+	if len(execs) != 1 {
+		t.Errorf("resume executions: want 1 (the original, now finished), got %d", len(execs))
+	}
+	if execs[0].Status != StatusSucceeded {
+		t.Errorf("resume Execution.Status: want %q, got %q", StatusSucceeded, execs[0].Status)
+	}
+	if execs[0].FinishedAt == nil {
+		t.Errorf("resume Execution.FinishedAt: want non-nil, got nil")
+	}
+
+	// Re-running the resume seed with the same terminal state MUST be a
+	// no-op (idempotency — covers the secondary-watcher restart-twice
+	// path on a flaky chroot-side catalyst-api).
+	_, _, err = br2.SeedJobsFromInformerList([]InformerSeed{
+		{Component: "cilium", State: HelmStateInstalled, Message: "Ready=True", ObservedAt: t1.Add(time.Second)},
+	})
+	if err != nil {
+		t.Fatalf("second resume seed: %v", err)
+	}
+	_, execs, _ = st.GetJob(depID, jobID)
+	if len(execs) != 1 {
+		t.Errorf("after idempotent re-resume: want 1 execution, got %d", len(execs))
+	}
+	if execs[0].Status != StatusSucceeded {
+		t.Errorf("after idempotent re-resume Execution.Status: want %q, got %q",
+			StatusSucceeded, execs[0].Status)
+	}
+}
+
+// TestSeedJobsFromInformerList_resumeFailedTerminalFinishesOrphan covers
+// the failed-terminal variant of the stale-state bug — same Pod-restart
+// race, but the HR flipped to InstallFailed instead of Ready=True. The
+// orphan Execution must end up Status=failed (not running, not
+// succeeded).
+func TestSeedJobsFromInformerList_resumeFailedTerminalFinishesOrphan(t *testing.T) {
+	st, br, depID := newBridgeFixture(t)
+	t0 := time.Date(2026, 5, 16, 12, 0, 0, 0, time.UTC)
+
+	// First seed: installing.
+	if _, _, err := br.SeedJobsFromInformerList([]InformerSeed{
+		{Component: "crossplane", State: HelmStateInstalling, Message: "reconciling", ObservedAt: t0},
+	}); err != nil {
+		t.Fatalf("first seed: %v", err)
+	}
+	jobID := JobID(depID, JobNamePrefix+"crossplane")
+	_, execs, _ := st.GetJob(depID, jobID)
+	orphanExecID := execs[0].ID
+
+	// Pod restart + resume with failed terminal state.
+	br2 := NewBridge(st, depID)
+	t1 := t0.Add(30 * time.Second)
+	if _, _, err := br2.SeedJobsFromInformerList([]InformerSeed{
+		{Component: "crossplane", State: HelmStateFailed, Message: "InstallFailed: timeout", ObservedAt: t1},
+	}); err != nil {
+		t.Fatalf("resume seed: %v", err)
+	}
+
+	job, execs, err := st.GetJob(depID, jobID)
+	if err != nil {
+		t.Fatalf("GetJob: %v", err)
+	}
+	if job.Status != StatusFailed {
+		t.Errorf("Job.Status: want %q, got %q", StatusFailed, job.Status)
+	}
+	if job.FinishedAt == nil {
+		t.Errorf("Job.FinishedAt: want non-nil, got nil")
+	}
+	if job.LatestExecutionID != orphanExecID {
+		t.Errorf("LatestExecutionID drifted: want orphan %q, got %q", orphanExecID, job.LatestExecutionID)
+	}
+	if len(execs) != 1 || execs[0].Status != StatusFailed {
+		t.Errorf("Execution after resume: want 1×failed, got %+v", execs)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes the stale-state class bug captured in MEMORY (`session_2026_05_16_t131_dod_progress.md`): install Jobs stuck `running` in `helmwatch.Bridge` though HRs reported `Ready=True` in `kubectl`.

### Root cause

`SeedJobsFromInformerList` had a Pod-restart race. When the persisted Job had a `LatestExecutionID` (allocated by the prior Pod's `OnHelmReleaseEvent` on a non-terminal state) AND the resume seed observed the HR in a terminal state (`installed`|`failed`), the branch only cleared the in-memory cursor — the orphan Execution row was never `FinishExecution`'d. Result: `Execution.Status` stayed `running` forever; `Job.FinishedAt` nil; `DurationMs` 0; the per-job detail page rendered a spinner that never resolved.

### Fix

Detect the orphan via `Store.FindExecution` and, when it's still non-terminal, call `Store.FinishExecution` — which canonically stamps `Execution.Status` + `FinishedAt` AND `Job.Status` + `Job.FinishedAt` + `DurationMs` in one atomic store write. An `IsTerminal` pre-check preserves the seed-twice idempotency invariant.

### Verification

- t22 chroot store inspected (`30dbef8b238c2d84`): 50/50 HRs `Ready=True`, 55/55 leaf jobs `Status=succeeded`, 0 stuck-running executions. The bug surface only manifests on multi-region provs under Pod-restart races; t22 single-region prov didn't reproduce.
- Mother store for t22: 155 succeeded jobs, 205+57 executions (failed = prior attempts), 0 executions without `finishedAt`.
- New regression tests fail without the fix (verified via local stash):
  - `resume Job.FinishedAt: want non-nil after terminal seed, got nil`
  - `resume Execution.Status: want "succeeded", got "running"`

## Test plan

- [x] `go test ./internal/jobs/... -count=1` — all green (20.4s)
- [x] `go build ./...` — clean
- [x] New tests `TestSeedJobsFromInformerList_resumeFinishesOrphanedExecution` + `TestSeedJobsFromInformerList_resumeFailedTerminalFinishesOrphan` exercise both `installed` and `failed` resume paths
- [x] `TestSeedJobsFromInformerList_idempotent` still green (no double-finish)
- [ ] Smoke on next multi-region prov: confirm secondary-region install Jobs never stick in `running` after a mid-flight Pod restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)