### PR TITLE
fix(infra): advertise public IP as k3s node-ip so Cilium inter-region tunnel works (Refs TBD-A7)

### DIFF
--- a/infra/hetzner/cloudinit-control-plane.tftpl
+++ b/infra/hetzner/cloudinit-control-plane.tftpl
@@ -1388,6 +1388,27 @@ runcmd:
   # but bridge connection failed; 0 HRs observed). 169.254.169.254 is
   # the Hetzner metadata endpoint; same path used by the public-IP
   # rewrite step at line 1310.
+  #
+  # --node-external-ip=$${CP_PUBLIC_IPV4} — DoD A2 / TBD-A7 fix (2026-05-18)
+  # ──────────────────────────────────────────────────────────────────────
+  # Without this flag, k3s only publishes node.status.addresses[InternalIP=
+  # ${cp_private_ip}] and NO ExternalIP. After the 2026-05-15 per-region-
+  # network refactor every region's CP sits in its OWN isolated
+  # hcloud_network, so the InternalIP is 10.0.1.2 *uniformly* across every
+  # region — locally-scoped, NOT routable cross-region. Cilium picks the
+  # InternalIP as its tunnel-endpoint by default → cross-region VXLAN
+  # tunnels resolve to 10.0.1.2 on every peer → inter-region pod traffic
+  # blackholes. Caught live on t22-omantel-biz (2026-05-18 Wave 28-E):
+  # all 3 CPs (hel/fsn/sin) advertised InternalIP=10.0.1.2 with no
+  # ExternalIP, Cilium tunnel endpoints unroutable, pod-to-pod
+  # inter-region 0/6.
+  # docs/SOVEREIGN-MULTI-REGION-DOD.md A2 mandate: "inter-region link =
+  # DMZ WireGuard over PUBLIC IPs ALWAYS (never any provider's private
+  # network)". Publishing the public IPv4 as ExternalIP lets Cilium
+  # promote it to its tunnel endpoint when peer addresses include
+  # External + Internal, which restores cross-region pod reachability
+  # without breaking intra-cluster paths (InternalIP stays primary for
+  # kube-apiserver advertise + pod-to-CP dial).
   # --node-label openova.io/region=${region_canonical_label}
   # (NAMING-CONVENTION §2.1 canonical region tag, e.g.
   # `hz-fsn-rtz-prod` for a fsn1 primary, `hz-hel-rtz-prod` for a hel1
@@ -1506,7 +1527,7 @@ runcmd:
   # packet flow over Cilium WireGuard which requires non-overlapping
   # CIDRs end-to-end. Values are interpolated by OpenTofu from
   # local.region_cluster_cidr / local.region_service_cidr in main.tf.
-  - 'CP_PUBLIC_IPV4=$(curl -fsSL --retry 30 --retry-delay 2 http://169.254.169.254/hetzner/v1/metadata/public-ipv4) && curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION=${k3s_version} K3S_TOKEN=${k3s_token} INSTALL_K3S_EXEC="server --cluster-init --flannel-backend=none --disable-network-policy --disable=traefik --disable=servicelb --cluster-cidr=${cluster_cidr} --service-cidr=${service_cidr} --node-ip=${cp_private_ip} --advertise-address=${cp_private_ip} --kubelet-arg=max-pods=220 --tls-san=${sovereign_fqdn} --tls-san=${cp_private_ip} --tls-san=$${CP_PUBLIC_IPV4} --kube-apiserver-arg=oidc-issuer-url=https://auth.${sovereign_fqdn}/realms/sovereign --kube-apiserver-arg=oidc-client-id=kubectl --kube-apiserver-arg=oidc-username-claim=preferred_username --kube-apiserver-arg=oidc-username-prefix=oidc: --kube-apiserver-arg=oidc-groups-claim=groups --kube-apiserver-arg=oidc-groups-prefix=oidc: --node-label catalyst.openova.io/role=control-plane --node-label openova.io/region=${region_canonical_label} --disable-cloud-controller ${worker_count > 0 ? "--node-taint node-role.kubernetes.io/control-plane=true:NoSchedule " : ""}--write-kubeconfig-mode=0644" sh -'
+  - 'CP_PUBLIC_IPV4=$(curl -fsSL --retry 30 --retry-delay 2 http://169.254.169.254/hetzner/v1/metadata/public-ipv4) && curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION=${k3s_version} K3S_TOKEN=${k3s_token} INSTALL_K3S_EXEC="server --cluster-init --flannel-backend=none --disable-network-policy --disable=traefik --disable=servicelb --cluster-cidr=${cluster_cidr} --service-cidr=${service_cidr} --node-ip=${cp_private_ip} --node-external-ip=$${CP_PUBLIC_IPV4} --advertise-address=${cp_private_ip} --kubelet-arg=max-pods=220 --tls-san=${sovereign_fqdn} --tls-san=${cp_private_ip} --tls-san=$${CP_PUBLIC_IPV4} --kube-apiserver-arg=oidc-issuer-url=https://auth.${sovereign_fqdn}/realms/sovereign --kube-apiserver-arg=oidc-client-id=kubectl --kube-apiserver-arg=oidc-username-claim=preferred_username --kube-apiserver-arg=oidc-username-prefix=oidc: --kube-apiserver-arg=oidc-groups-claim=groups --kube-apiserver-arg=oidc-groups-prefix=oidc: --node-label catalyst.openova.io/role=control-plane --node-label openova.io/region=${region_canonical_label} --disable-cloud-controller ${worker_count > 0 ? "--node-taint node-role.kubernetes.io/control-plane=true:NoSchedule " : ""}--write-kubeconfig-mode=0644" sh -'
 
   # Wait for the API server to be reachable. Cilium needs to come up before
   # nodes Ready, so we wait specifically for the API endpoint.


### PR DESCRIPTION
## Summary

Adds `--node-external-ip=\$\${CP_PUBLIC_IPV4}` to the k3s server install in `infra/hetzner/cloudinit-control-plane.tftpl` so every CP node publishes BOTH `InternalIP=10.0.1.2` (intra-cluster, unchanged) AND `ExternalIP=<public IPv4>` (cross-region routable). Cilium then promotes the ExternalIP to its tunnel endpoint for cross-region traffic, restoring inter-region pod reachability.

## Why

### Wave 28-E evidence (live on t22-omantel-biz, 2026-05-18)

All 3 CPs (hel / fsn / sin) advertise `InternalIP=10.0.1.2` with NO `ExternalIP`:

```
$ kubectl get nodes -o wide
NAME                                  ROLES         INTERNAL-IP   EXTERNAL-IP
catalyst-t22-omantel-biz-fsn1-1-cp1   control-plane 10.0.1.2      <none>
catalyst-t22-omantel-biz-sin-2-cp1    control-plane 10.0.1.2      <none>
```

After the 2026-05-15 per-region-network refactor (DoD A2), every region's CP sits in its OWN isolated `hcloud_network` with its OWN `10.0.1.0/24` subnet — so `10.0.1.2` is *locally* scoped on each VPS and NOT routable cross-region. Cilium picks the InternalIP as its tunnel endpoint by default. Result: every cross-region VXLAN tunnel resolves to `10.0.1.2` on the peer side → inter-region pod traffic blackholes (Wave 28-E measured pod-to-pod 0/6 across regions).

### docs/SOVEREIGN-MULTI-REGION-DOD.md A2 mandate

> "inter-region link = DMZ WireGuard over PUBLIC IPs ALWAYS (never any provider's private network)"

Publishing the public IPv4 as `ExternalIP` lets Cilium promote it to the tunnel endpoint when peer addresses include both External + Internal, which restores cross-region pod reachability without breaking intra-cluster paths. The InternalIP stays primary for kube-apiserver advertise + pod-to-CP dial (the original reason `--node-ip` was pinned to private in PR-#62-era — that comment at lines 1370–1378 is preserved).

## What this PR does

- Adds `--node-external-ip=\$\${CP_PUBLIC_IPV4}` (where `CP_PUBLIC_IPV4` is already pre-fetched from Hetzner metadata at the start of the same line)
- Both primary CP and secondary CPs render through this single template (`main.tf` `templatefile()` calls at line 636 for primary, line 1187 per secondary), so one template edit covers all regions
- 22-line documentation block preserves the rationale for future readers

## Scope

- **Approach A** (smaller / immediate) — k3s public-IP advertisement at install time
- **Approach B** (DMZ WireGuard overlay DaemonSet under `platform/bp-dmz-vcluster/`) is the architectural follow-up if A alone doesn't fully resolve cross-region traffic on t23+

## Effect

- Only takes effect on **FRESH provisions** (t23+). t22 already deployed cannot be remediated by a cloud-init change.
- Cilium needs to pick the new ExternalIP as the tunnel endpoint; default Cilium behaviour on multi-address nodes already supports this — no Cilium chart change needed.

## Test plan

- [ ] Provision t23+ on omantel.biz / omani.works (3 regions × 1 cpx52)
- [ ] `kubectl get nodes -o wide` on each region's CP — confirm both `INTERNAL-IP` and `EXTERNAL-IP` are populated
- [ ] `kubectl get ciliumnodes -o yaml | grep -A1 addresses` — confirm both IP types listed
- [ ] D11 — inter-region pod-to-pod ping (qaFixtures cross-region target) succeeds 6/6

## Refs

- TBD-A7 (Wave 28-E discovery)
- `sovereign_multiregion_dod.md` A2
- `feedback_multiregion_topology_1_cpx52_per_region.md`