### PR TITLE
chore(bootstrap-kit): flush 13 pre-existing chart-pin drifts (Refs TBD-A6b)

### DIFF
--- a/clusters/_template/bootstrap-kit/04-crossplane.yaml
+++ b/clusters/_template/bootstrap-kit/04-crossplane.yaml
@@ -41,7 +41,7 @@ spec:
   chart:
     spec:
       chart: bp-crossplane
-      version: 1.1.3
+      version: 1.1.4
       sourceRef:
         kind: HelmRepository
         name: bp-crossplane

--- a/clusters/_template/bootstrap-kit/05-sealed-secrets.yaml
+++ b/clusters/_template/bootstrap-kit/05-sealed-secrets.yaml
@@ -36,7 +36,7 @@ spec:
   chart:
     spec:
       chart: bp-sealed-secrets
-      version: 1.1.1
+      version: 1.1.2
       sourceRef:
         kind: HelmRepository
         name: bp-sealed-secrets

--- a/clusters/_template/bootstrap-kit/07-nats-jetstream.yaml
+++ b/clusters/_template/bootstrap-kit/07-nats-jetstream.yaml
@@ -42,7 +42,7 @@ spec:
   chart:
     spec:
       chart: bp-nats-jetstream
-      version: 1.1.1
+      version: 1.2.0
       sourceRef:
         kind: HelmRepository
         name: bp-nats-jetstream

--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -588,7 +588,7 @@ spec:
       # to the admin password byte, so every subsequent SME provisioning
       # call to Gitea returned 401 "user does not exist" and journey
       # step 16 (tenant repo creation) silently stuck.
-      version: 1.4.168
+      version: 1.4.169
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/clusters/_template/bootstrap-kit/15-external-secrets.yaml
+++ b/clusters/_template/bootstrap-kit/15-external-secrets.yaml
@@ -59,7 +59,7 @@ spec:
   chart:
     spec:
       chart: bp-external-secrets
-      version: 1.1.0
+      version: 1.1.1
       sourceRef:
         kind: HelmRepository
         name: bp-external-secrets

--- a/clusters/_template/bootstrap-kit/16-cnpg.yaml
+++ b/clusters/_template/bootstrap-kit/16-cnpg.yaml
@@ -57,7 +57,7 @@ spec:
   chart:
     spec:
       chart: bp-cnpg
-      version: 1.0.0
+      version: 1.0.1
       sourceRef:
         kind: HelmRepository
         name: bp-cnpg

--- a/clusters/_template/bootstrap-kit/17-valkey.yaml
+++ b/clusters/_template/bootstrap-kit/17-valkey.yaml
@@ -48,7 +48,7 @@ spec:
   chart:
     spec:
       chart: bp-valkey
-      version: 1.0.0
+      version: 1.0.1
       sourceRef:
         kind: HelmRepository
         name: bp-valkey

--- a/clusters/_template/bootstrap-kit/23-mimir.yaml
+++ b/clusters/_template/bootstrap-kit/23-mimir.yaml
@@ -55,7 +55,7 @@ spec:
   chart:
     spec:
       chart: bp-mimir
-      version: 1.0.2
+      version: 1.0.3
       sourceRef:
         kind: HelmRepository
         name: bp-mimir

--- a/clusters/_template/bootstrap-kit/25-grafana.yaml
+++ b/clusters/_template/bootstrap-kit/25-grafana.yaml
@@ -65,7 +65,7 @@ spec:
   chart:
     spec:
       chart: bp-grafana
-      version: 1.0.0
+      version: 1.0.1
       sourceRef:
         kind: HelmRepository
         name: bp-grafana

--- a/clusters/_template/bootstrap-kit/27-kyverno.yaml
+++ b/clusters/_template/bootstrap-kit/27-kyverno.yaml
@@ -54,7 +54,7 @@ spec:
   chart:
     spec:
       chart: bp-kyverno
-      version: 1.0.0
+      version: 1.1.0
       sourceRef:
         kind: HelmRepository
         name: bp-kyverno

--- a/clusters/_template/bootstrap-kit/34-velero.yaml
+++ b/clusters/_template/bootstrap-kit/34-velero.yaml
@@ -67,7 +67,7 @@ spec:
   chart:
     spec:
       chart: bp-velero
-      version: 1.2.0
+      version: 1.2.1
       sourceRef:
         kind: HelmRepository
         name: bp-velero

--- a/clusters/_template/bootstrap-kit/51-bp-k8s-ws-proxy.yaml
+++ b/clusters/_template/bootstrap-kit/51-bp-k8s-ws-proxy.yaml
@@ -82,7 +82,7 @@ spec:
       # because the Job (weight -10, lower=earlier in Helm) was
       # applied before its SA (weight 0). Bumps Chart.yaml 0.1.7 ->
       # 0.1.8; CI promote auto-bumps to 0.1.9 with new image SHA.
-      version: 0.1.10
+      version: 0.1.11
       sourceRef:
         kind: HelmRepository
         name: bp-k8s-ws-proxy

--- a/clusters/_template/bootstrap-kit/52-bp-guacamole.yaml
+++ b/clusters/_template/bootstrap-kit/52-bp-guacamole.yaml
@@ -128,7 +128,7 @@ spec:
       # made kubelet restart the Pod every ~60s and the kube-system
       # Cilium gateway returned 503 to the public hostname because
       # the Endpoint was never Ready (observed on t22, 5 restarts).
-      version: 0.1.23
+      version: 0.1.24
       sourceRef:
         kind: HelmRepository
         name: bp-guacamole


### PR DESCRIPTION
## Summary

The TBD-A6 auto-bump hook keeps every **new** chart bump in lockstep with its `clusters/_template/bootstrap-kit/<NN>-<chart>.yaml` pin. Before A6 landed, however, 13 chart bumps had already shipped **without** a matching pin update — fresh Sovereigns silently installed the OLD pinned version from the bootstrap-kit while the OCI artifact published the NEW chart version.

This PR flushes that pre-existing drift in one squash commit so the `scripts/check-bootstrap-kit-pin-sync.sh` gate ships GREEN.

## Pin bumps (chart → new pin version)

| chart | old pin | new pin |
|---|---|---|
| `bp-cnpg` | 1.0.0 | **1.0.1** |
| `bp-crossplane` | 1.1.3 | **1.1.4** |
| `bp-external-secrets` | 1.1.0 | **1.1.1** |
| `bp-grafana` | 1.0.0 | **1.0.1** |
| `bp-guacamole` | 0.1.23 | **0.1.24** |
| `bp-k8s-ws-proxy` | 0.1.10 | **0.1.11** |
| `bp-kyverno` | 1.0.0 | **1.1.0** |
| `bp-mimir` | 1.0.2 | **1.0.3** |
| `bp-nats-jetstream` | 1.1.1 | **1.2.0** |
| `bp-sealed-secrets` | 1.1.1 | **1.1.2** |
| `bp-valkey` | 1.0.0 | **1.0.1** |
| `bp-velero` | 1.2.0 | **1.2.1** |
| `bp-catalyst-platform` | 1.4.168 | **1.4.169** |

13 files changed, 13 insertions(+), 13 deletions(-) — every edit is a single `version:` line bump under `chart.spec` of a `clusters/_template/bootstrap-kit/<NN>-bp-X.yaml`.

## Audit-after status

`bash scripts/check-bootstrap-kit-pin-sync.sh` exit code on this branch: still **1** because of a single residual pseudo-drift on `bp-dmz-vcluster` (see below). The 13 chart-pin lags listed in the audit on `origin/main` are all gone after this PR.

## Out of scope (residual `bp-dmz-vcluster` pseudo-drift)

`bp-dmz-vcluster` has two `Chart.yaml` files in the source tree:
- `platform/bp-dmz-vcluster/chart/Chart.yaml` (`version: 0.1.0`) — the bootstrap-topology piece consumed by slot 54 (per its own in-file comment)
- `products/dmz-vcluster/chart/Chart.yaml` (`version: 0.1.1`) — a per-tenant marketplace artifact

Both declare chart name `bp-dmz-vcluster`. The audit script keys by chart-name and cannot disambiguate the two, so it will report one of them as drifted no matter which version we pin. The pin is kept at `0.1.0` to match the platform/ chart that the bootstrap-kit actually consumes; renaming the products/ chart is a separate ship and outside the TBD-A6b "flush pre-existing pin drifts" scope.

## Why this is safe

Each new pin version is the version already published on `ghcr.io/openova-io/<chart>:<new-ver>` (the chart bump merged successfully, only the pin lagged). Bumping the pin merely tells fresh Sovereigns to install the version that's already the source of truth — no chart code changes, no OCI republish, no Sovereign migration.

## Test plan

- [x] `git diff --stat` shows exactly 13 files modified, +13/-13 lines.
- [x] Local `bash scripts/check-bootstrap-kit-pin-sync.sh` reports only the residual `bp-dmz-vcluster` drift (pseudo, duplicate-name).
- [ ] CI smoke-render gate green on every touched slot.
- [ ] Build & Deploy Catalyst CI green on merge.

Refs TBD-A6b.