### PR TITLE
fix(ui): FleetTreemap uses x0/y0/x1/y1 from SquarifiedRect (#1718 follow-up)

### DIFF
--- a/products/catalyst/bootstrap/ui/src/pages/dashboard/FleetTreemap.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/dashboard/FleetTreemap.tsx
@@ -323,6 +323,14 @@ function FleetTreemapSurface({ items, colorBy, sovById }: FleetTreemapSurfacePro
           style={{ display: 'block' }}
         >
           {rects.map((r) => {
+            // SquarifiedRect exposes (x0,y0,x1,y1) — derive (x,y,w,h)
+            // for SVG `<rect>` + `<text>` consumption. Keeping the
+            // local aliases at the top of the cell avoids littering
+            // the JSX with `r.x1 - r.x0` arithmetic.
+            const rx = r.x0
+            const ry = r.y0
+            const rw = r.x1 - r.x0
+            const rh = r.y1 - r.y0
             const pct = r.item.percentage
             const fill = pct == null ? '#475569' /* slate-600 */ : colorFn(pct)
             return (
@@ -332,18 +340,18 @@ function FleetTreemapSurface({ items, colorBy, sovById }: FleetTreemapSurfacePro
                 onClick={() => onCellClick(r.item)}
               >
                 <rect
-                  x={r.x}
-                  y={r.y}
-                  width={r.width}
-                  height={r.height}
+                  x={rx}
+                  y={ry}
+                  width={rw}
+                  height={rh}
                   fill={fill}
                   stroke="#0f172a"
                   strokeWidth={1.5}
                 />
-                {r.width > 60 && r.height > 24 && (
+                {rw > 60 && rh > 24 && (
                   <text
-                    x={r.x + 8}
-                    y={r.y + 18}
+                    x={rx + 8}
+                    y={ry + 18}
                     fill="#0f172a"
                     fontSize={12}
                     fontWeight={600}
@@ -351,10 +359,10 @@ function FleetTreemapSurface({ items, colorBy, sovById }: FleetTreemapSurfacePro
                     {r.item.name}
                   </text>
                 )}
-                {r.width > 60 && r.height > 44 && (
+                {rw > 60 && rh > 44 && (
                   <text
-                    x={r.x + 8}
-                    y={r.y + 36}
+                    x={rx + 8}
+                    y={ry + 36}
                     fill="#0f172a"
                     fontSize={10}
                   >


### PR DESCRIPTION
## Summary

PR #1718 introduced `FleetTreemap.tsx` which read `.x/.y/.width/.height`
off `SquarifiedRect`, but the actual `lib/treemap-squarified.ts` shape
exports `x0/y0/x1/y1`. `tsc -b` errored TS2339 on 12 references and the
Catalyst Build & Deploy CI failed → `catalyst-api` + `catalyst-ui` never
rolled past `6685bd7` and the mothership `/dashboard/treemap` route
returns 404 (image still pre-#1718).

Fix: alias `rx = r.x0`, `ry = r.y0`, `rw = r.x1 - r.x0`,
`rh = r.y1 - r.y0` at the top of each cell render and consume those in
the SVG `<rect>` + `<text>`. Same visual output, types satisfied.

## Wave 28-D "hel region missing" investigation

Re-walked t22 `/dashboard` via Playwright this session:

| Layer | Cells rendered | Hel visible |
|---|---|---|
| Region | 3: `hz-hel-rtz-prod`, `hz-fsn-rtz-prod`, `hz-sin-rtz-prod` | yes |
| Cluster (default in Sovereign mode) | 3: `30dbef8b238c2d84` (primary=hel), `30dbef8b238c2d84-fsn1-1`, `30dbef8b238c2d84-sin-2` | yes (under primary id) |

API returns 3 regions with proper `size_value` + `percentage`; UI
renders 3 cells. Wave 28-D's "2/3 regions" was a UX confusion at
Layer=Cluster where the hel cluster's name is the bare deployment-id
hex (no `hz-hel` prefix) — the operator couldn't recognise it as hel.
NO backend or rendering bug; the cell IS there.

Screenshots:
- `.playwright-mcp/treemap-region-layer-t22-3regions.png` (Layer=Region, size=cpu_request — 3 regions)
- `.playwright-mcp/treemap-region-cpu-usage-3regions.png` (Layer=Region, size=cpu_usage — 3 regions)

## Test plan

- [x] `npm run --workspace products/catalyst/bootstrap/ui build` → clean (tsc + vite)
- [x] Sovereign treemap re-verified GREEN on t22 at Layer=Region (3 cells, all colour-coded)
- [ ] Mothership `/dashboard/treemap` verified GREEN post-merge (deferred until image rolls)

## Refs

- Refs TBD-E14 (mothership treemap unblock)
- Refs TBD-E2 (Sovereign treemap verified GREEN at Layer=Region)
- Closes the Wave 28-D "hel region missing" partial finding as a UX-not-bug

🤖 Generated with [Claude Code](https://claude.com/claude-code)