### PR TITLE
fix(ci): update expected-bootstrap-deps DAG with bp-sandbox slot 19a edges (Closes #1755)

### DIFF
--- a/scripts/expected-bootstrap-deps.yaml
+++ b/scripts/expected-bootstrap-deps.yaml
@@ -463,7 +463,9 @@ slots:
       - bp-flux
     wave: present
 
-  # ---- Slot 61 — bp-sandbox sandbox-controller Wave 1 (PR #1622). Reconciles
+  # ---- Slot 19a — bp-sandbox sandbox-controller (PR #1622, originally slot 61).
+  # Renumbered 61 → 19a in Wave 11 convergence fix (PR #1652, 2026-05-18)
+  # to sequence AFTER bp-harbor (slot 19). Reconciles
   # `sandbox.openova.io/v1.Sandbox` CRs into per-Sandbox manifests written
   # to the per-Org `catalyst-tenant` Gitea repo (sister of organization-
   # controller). Without this slot, Sandbox CRs sit unhandled — the
@@ -475,11 +477,21 @@ slots:
   #   - bp-catalyst-platform (slot 13) — provides `catalyst-system`
   #     Namespace + the `catalyst-gitea-token` Secret the controller's
   #     CATALYST_GITEA_TOKEN env reads via secretKeyRef.
-  - slot: 61
+  #   - bp-harbor (slot 19) — Wave 11 convergence fix (PR #1652).
+  #     After bp-self-sovereign-cutover Step-06 phase-1 rewrites every
+  #     HelmRepository URL `oci://ghcr.io/openova-io` →
+  #     `oci://harbor.<sov-fqdn>/openova-io`, source-controller fetches
+  #     the sandbox chart through harbor.<sov-fqdn>. Without this edge,
+  #     bp-sandbox tries to resolve before bp-harbor is Ready and sits
+  #     Reconciling for the full bootstrap-kit timeout. Chicken-and-egg
+  #     same shape as Wave 7 #1610 (bp-hcloud-csi REMOVED), resolved by
+  #     sequencing rather than removal so the slot remains available.
+  - slot: "19a"
     name: bp-sandbox
     depends_on:
       - bp-vcluster-helmrepo
       - bp-catalyst-platform
+      - bp-harbor
     wave: present
 
   # ---- Slot 80 — bp-newapi multi-tenant LLM marketplace gateway. Issue #799.


### PR DESCRIPTION
## Summary

The `dependency-graph-audit` CI job has been failing on every push to `main` for days. Surfaced by Wave 30-A A6 verification report (PR #1751).

**Root cause:** Wave 11 convergence fix PR #1652 renumbered `bp-sandbox` from slot 61 → 19a and added `bp-harbor` to its `dependsOn` (chicken-and-egg fix for post-handover OCI URL rewrite to `harbor.<sov-fqdn>`). The expected DAG in `scripts/expected-bootstrap-deps.yaml` was not updated in lockstep.

**Failing run evidence** (run [26043971208](https://github.com/openova-io/openova/actions/runs/26043971208)):

```
ERROR: HR 'bp-sandbox' (file clusters/_template/bootstrap-kit/19a-bp-sandbox.yaml): dependsOn drift
       extra edges   (in HR, NOT declared expected):   bp-harbor
ERROR: 1 drift(s) detected.
```

**Fix:** Sync the expected DAG to match the actual HR file's `dependsOn`:

- Add `bp-harbor` to `bp-sandbox`'s `depends_on` list.
- Update the slot field from `61` to `"19a"` to reflect the renumbering.
- Expand the comment block to document the Wave 11 rationale.

The new edge is legitimate (Wave 11 sequencing intentional, not a regression to revert).

## Test plan

- [x] Local: `bash scripts/check-bootstrap-deps.sh` → `OK: bootstrap-kit dependency graph audit PASSED` (50 HRs on disk, 64 declared, 0 drift, 0 cycles).
- [ ] CI: `dependency-graph-audit` job passes on this PR.
- [ ] CI: Next push to `main` after merge runs `dependency-graph-audit` GREEN.

Refs PR #1652 (Wave 11 chicken-and-egg fix that introduced the new edge).

Closes #1755

🤖 Generated with [Claude Code](https://claude.com/claude-code)