### PR TITLE
feat(LogViewer): add Previous-container toggle (Closes #1752)

### DIFF
--- a/products/catalyst/bootstrap/ui/src/widgets/cloud-list/LogViewer.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/widgets/cloud-list/LogViewer.test.tsx
@@ -217,6 +217,41 @@ describe('LogViewer', () => {
     expect(ws.closed).toBe(true)
   })
 
+  it('toggles `previous=true` on the WebSocket URL when the Previous button is clicked', () => {
+    const factory = (url: string) => new FakeWebSocket(url) as unknown as WebSocket
+    render(
+      <LogViewer
+        deploymentId="dep"
+        ns="default"
+        pod="wp-1"
+        obj={podSingle}
+        websocketFactory={factory}
+        disableTerminal
+      />,
+    )
+    // Initial WS has no previous flag and is in follow mode.
+    expect(FakeWebSocket.lastUrl).not.toContain('previous=true')
+    expect(FakeWebSocket.lastUrl).toContain('follow=true')
+    const toggle = screen.getByTestId('log-viewer-previous-toggle')
+    expect(toggle.getAttribute('aria-pressed')).toBe('false')
+    act(() => {
+      fireEvent.click(toggle)
+    })
+    // Re-connected with previous=true and follow=false (kubelet returns
+    // the crashed container's buffer once, then closes).
+    expect(toggle.getAttribute('aria-pressed')).toBe('true')
+    const reconnected = FakeWebSocket.instances[FakeWebSocket.instances.length - 1]
+    expect(reconnected.url).toContain('previous=true')
+    expect(reconnected.url).toContain('follow=false')
+    // Toggling off drops the previous flag again.
+    act(() => {
+      fireEvent.click(toggle)
+    })
+    const final = FakeWebSocket.instances[FakeWebSocket.instances.length - 1]
+    expect(final.url).not.toContain('previous=true')
+    expect(final.url).toContain('follow=true')
+  })
+
   it('does not reconnect on clean close (1000)', () => {
     const factory = (url: string) => new FakeWebSocket(url) as unknown as WebSocket
     render(

--- a/products/catalyst/bootstrap/ui/src/widgets/cloud-list/LogViewer.tsx
+++ b/products/catalyst/bootstrap/ui/src/widgets/cloud-list/LogViewer.tsx
@@ -64,6 +64,7 @@ export function LogViewer(props: LogViewerProps) {
   const containers = useMemo<string[]>(() => discoverContainers(obj), [obj])
   const defaultContainer = initialContainer ?? containers[0] ?? ''
   const [container, setContainer] = useState(defaultContainer)
+  const [previous, setPrevious] = useState(false)
   const [searchOpen, setSearchOpen] = useState(false)
   const [searchTerm, setSearchTerm] = useState('')
   const [status, setStatus] = useState<'connecting' | 'open' | 'closed' | 'error'>('connecting')
@@ -140,9 +141,14 @@ export function LogViewer(props: LogViewerProps) {
     function open() {
       const since = lastTimestampRef.current ?? undefined
       const url = logsWebSocketURL(deploymentId, ns, pod, container, {
-        follow: true,
+        // `previous=true` asks the kubelet for the prior container's
+        // log buffer (post-crash forensics). It implies `follow=false`
+        // server-side, so the WS will close cleanly once the buffer
+        // drains — that's the only correct shape.
+        follow: !previous,
         tailLines: 100,
         ...(since ? { since } : {}),
+        ...(previous ? { previous: true } : {}),
       })
       let ws: WebSocket
       try {
@@ -204,7 +210,7 @@ export function LogViewer(props: LogViewerProps) {
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [container, deploymentId, ns, pod, websocketFactory])
+  }, [container, deploymentId, ns, pod, previous, websocketFactory])
 
   // Keyboard shortcut: ⌃F / ⌘F → toggle search box.
   useEffect(() => {
@@ -260,6 +266,26 @@ export function LogViewer(props: LogViewerProps) {
             </select>
           </label>
         )}
+        <button
+          type="button"
+          data-testid="log-viewer-previous-toggle"
+          onClick={() => {
+            setPrevious((p) => !p)
+            lastTimestampRef.current = null
+            setRetries(0)
+            termRef.current?.clear()
+          }}
+          className={
+            'rounded border px-2 py-1 text-xs ' +
+            (previous
+              ? 'border-amber-500 bg-amber-500/20 text-amber-200'
+              : 'border-[var(--color-border)] bg-[var(--color-bg-2)] text-[var(--color-text)]')
+          }
+          aria-pressed={previous}
+          title="Show logs from the previous (crashed) container instance"
+        >
+          {previous ? 'Previous: on' : 'Previous'}
+        </button>
         <button
           type="button"
           data-testid="log-viewer-search-toggle"


### PR DESCRIPTION
## Summary

Wave 30-B G2 verification proved that the backend supports `?previous=true` on the Pod-log WebSocket — kubelet returns the **prior (crashed) container instance's** log buffer, which is essential post-crash forensics. The `LogViewer` widget had no UI affordance to flip this.

This PR adds a small toggle button in the existing controls row.

### What changed

- `products/catalyst/bootstrap/ui/src/widgets/cloud-list/LogViewer.tsx`
  - New `previous` state, threaded into `logsWebSocketURL({ ..., previous, follow: !previous })`.
  - `previous` added to the WS effect's deps → toggling reconnects with the new URL.
  - Toggle button alongside the existing Search toggle. Uses design tokens (`--color-border`, `--color-bg-2`, `--color-text`); active state in amber to signal forensic mode. `aria-pressed` on the button.
  - When toggled, clears the terminal, resets `lastTimestampRef`, and resets retries (mirrors what container-switch already does).
- `products/catalyst/bootstrap/ui/src/widgets/cloud-list/LogViewer.test.tsx`
  - Vitest: clicking the toggle re-opens the WS with `previous=true&follow=false`; clicking again drops it.

### Notes

- `previous=true` implies `follow=false` server-side (the kubelet returns the buffer once then closes — that's the only correct shape for prior-container logs).
- No new bespoke styling; reuses the same Tailwind utility classes already in the file.
- 9/9 Vitest tests in `LogViewer.test.tsx` pass.

## Test plan

- [x] `npx vitest run src/widgets/cloud-list/LogViewer.test.tsx` — all 9 tests pass (8 existing + 1 new for the toggle).
- [ ] Manual Playwright in next prov cycle: open a pod whose container has restarted, click `Previous`, verify the WS URL includes `previous=true&follow=false` and the crashed-container payload renders.

Closes #1752