### PR TITLE
fix(bp-mimir): PrometheusRule guard checks specific CRD not API group (Closes #1759)

### DIFF
--- a/platform/mimir/chart/Chart.yaml
+++ b/platform/mimir/chart/Chart.yaml
@@ -13,7 +13,7 @@ description: |
   overlays scale per-component replicas + flip zone-aware-replication on
   for HA Sovereigns.
 type: application
-version: 1.0.3
+version: 1.0.4
 appVersion: "3.0.4"
 keywords: [catalyst, blueprint, mimir, observability, metrics, prometheus]
 maintainers:

--- a/platform/mimir/chart/templates/prometheusrule-compliance.yaml
+++ b/platform/mimir/chart/templates/prometheusrule-compliance.yaml
@@ -33,7 +33,7 @@ Helm install would fail with `no matches for kind PrometheusRule`.
 The Capabilities check skips this template until the observability
 tier is reconciled.
 */}}
-{{- if and (.Values.complianceRules.enabled | default true) (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") }}
+{{- if and (.Values.complianceRules.enabled | default true) (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1/PrometheusRule") }}
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:


### PR DESCRIPTION
## Summary

bp-mimir's PrometheusRule template guard checked the API GROUP `monitoring.coreos.com/v1`, which Helm reports as present whenever ANY v1 CRD in that group is registered — even if PrometheusRule itself is absent. On a fresh Sovereign, the bp-kube-prometheus-stack CRDs aren't installed yet, but the group registers early enough that the guard evaluates true. Helm then attempts to install a PrometheusRule object and bombs with `no matches for kind PrometheusRule`.

## Cascade impact (CRITICAL fresh-prov blocker)

t23 fresh-prov evidence:

```
bp-mimir HelmRelease  → install fails
bootstrap-kit Kustomization → blocked (depends-on bp-mimir)
sovereign-tls Kustomization → blocked (depends-on bootstrap-kit)
cilium-gateway Gateway CR → never deploys
console.<fqdn> / auth.<fqdn> / api.<fqdn> → connection-refused
```

ALL public TLS endpoints unreachable on a fresh prov → operators cannot reach the Sovereign Console after handover → D0 gate fails.

## Fix

`platform/mimir/chart/templates/prometheusrule-compliance.yaml:36`

```diff
-{{- if and (.Values.complianceRules.enabled | default true) (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") }}
+{{- if and (.Values.complianceRules.enabled | default true) (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1/PrometheusRule") }}
```

The `<group>/<version>/<kind>` form only matches when that specific CRD is registered on the apiserver — exactly what we need. The doc comment above the guard already states the intent ("until the observability tier is reconciled"); this fix makes the code match the doc.

Chart version bumped `1.0.3 → 1.0.4` so blueprint-release republishes the OCI artifact. The A6 auto-bump in CI will lift the bootstrap-kit pin to the new bp-mimir version, so this fix propagates to fresh provs without a manual chart-pin PR.

## Test plan

- [ ] Blueprint Release CI republishes bp-mimir 1.0.4 OCI artifact
- [ ] A6 auto-bump opens follow-up PR pinning bootstrap-kit to bp-mimir 1.0.4
- [ ] Next fresh prov: bp-mimir HelmRelease Ready=True without PrometheusRule CRD present
- [ ] sovereign-tls Kustomization reconciles → cilium-gateway Gateway Programmed=True
- [ ] console.<fqdn> serves TLS within handover window

Closes #1759

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>