### PR TITLE
feat(k8s-metrics): mimir-backed 5-min Pod sparkline with metrics-server fallback (Closes #1753)

### DIFF
--- a/products/catalyst/bootstrap/api/cmd/api/main.go
+++ b/products/catalyst/bootstrap/api/cmd/api/main.go
@@ -274,6 +274,17 @@ func main() {
 		"clusterFallback", homeDyn != nil,
 	)
 
+	// Issue #1753 (slice G3b) — bp-mimir (slot 23) query-frontend URL
+	// for the Pod metrics sparkline. Per docs/INVIOLABLE-PRINCIPLES.md
+	// #4 the URL is env-overridable; empty disables the mimir path and
+	// the Pod metrics handler falls back to the metrics-server single
+	// point so clusters without bp-mimir still render (degraded).
+	mimirURL := env("CATALYST_MIMIR_URL", "http://mimir-query-frontend.mimir.svc.cluster.local:8080")
+	h.SetMimirURL(mimirURL)
+	log.Info("mimir: query-frontend url wired",
+		"url", mimirURL,
+	)
+
 	// EPIC-2 #1097 slice T+O+P — Blueprint publishing + Curate.
 	// Per ADR-0001 §4.3 Gitea is the source-of-truth for Blueprints;
 	// the publish + curate handlers are thin wrappers over the unified

--- a/products/catalyst/bootstrap/api/internal/handler/handler.go
+++ b/products/catalyst/bootstrap/api/internal/handler/handler.go
@@ -441,6 +441,23 @@ type Handler struct {
 	// executor; tests bind a fake duplex pipe.
 	execStreamMu      sync.RWMutex
 	execStreamFactory ExecStreamFactory
+
+	// ── Mimir-backed Pod sparkline (issue #1753, slice G3b) ────────
+	// mimirURL — base URL of the bp-mimir (slot 23) query-frontend
+	// HTTP API. The Pod metrics endpoint
+	// (`/api/v1/sovereigns/{id}/k8s/metrics/pod/{ns}/{name}`) issues
+	// a Prometheus `query_range` against this base to build a 5-min
+	// sparkline at 5s step (60 buckets). Empty ⇒ the handler falls
+	// back to the legacy metrics-server single-point path so the
+	// sparkline degrades gracefully on clusters where bp-mimir is
+	// disabled (e.g. a stripped-down Catalyst-Zero flavor). Wired
+	// from main.go via SetMimirURL from CATALYST_MIMIR_URL env var;
+	// tests inject a httptest.Server URL directly.
+	//
+	// mimirHTTPClient — HTTP client the mimir path uses. Empty ⇒ a
+	// shared 5s-timeout http.Client. Tests inject a stub.
+	mimirURL        string
+	mimirHTTPClient *http.Client
 }
 
 // powerdnsZoneClient is the narrow interface the parent-zone handler
@@ -688,6 +705,18 @@ func (h *Handler) SetSMEJWTSecret(secret []byte) { h.smeJWTSecret = secret }
 
 // AuditBus returns the wired Bus or nil. Test helper.
 func (h *Handler) AuditBus() *audit.Bus { return h.auditBus }
+
+// SetMimirURL wires the bp-mimir (slot 23) query-frontend base URL the
+// Pod metrics sparkline path uses. Called by main.go at startup from
+// CATALYST_MIMIR_URL; tests pass a httptest.Server URL directly.
+// Empty disables the mimir path — the handler falls back to the
+// metrics-server single-point shape so clusters without bp-mimir
+// continue rendering a (degraded) Pod metrics response.
+func (h *Handler) SetMimirURL(u string) { h.mimirURL = u }
+
+// SetMimirHTTPClient is a test seam — production leaves this empty and
+// the handler uses a shared 5s-timeout http.Client.
+func (h *Handler) SetMimirHTTPClient(c *http.Client) { h.mimirHTTPClient = c }
 
 // writeJSON serializes v as JSON with the given status code.
 //

--- a/products/catalyst/bootstrap/api/internal/handler/k8s_resource_metrics.go
+++ b/products/catalyst/bootstrap/api/internal/handler/k8s_resource_metrics.go
@@ -9,11 +9,23 @@
 // for the focused resource. Roll-ups for Deployment / StatefulSet sum
 // metrics across owned Pods.
 //
+// For the `pod` kind we prefer Grafana Mimir (bp-mimir, bootstrap-kit
+// slot 23) as the upstream — a single `query_range` yields a 5-minute,
+// 5-second-step sparkline (60 buckets) instead of the single point
+// metrics-server returns. Mimir scrapes every Pod via Alloy, so the
+// PromQL `rate(container_cpu_usage_seconds_total[1m])` +
+// `container_memory_working_set_bytes` pair is sufficient to drive a
+// real time-series. When mimir isn't wired (CATALYST_MIMIR_URL empty)
+// or the upstream query fails, the handler degrades gracefully to the
+// metrics-server single-point shape so existing FE consumers keep
+// rendering. See k8s_resource_metrics_mimir.go for the client.
+//
 // The wire response bundles a "current" snapshot + a "series" sparkline
 // frame so the UI can render a sparkline without a second round-trip.
-// The series is populated from the in-process k8scache (PodMetrics is
-// already a registered watch target — see kinds.go) so no additional
-// scrape work happens here.
+// On the metrics-server fallback path the series collapses to a single
+// frame populated from the in-process k8scache (PodMetrics is already
+// a registered watch target — see kinds.go) so no additional scrape
+// work happens here.
 //
 // Architecture rules:
 //
@@ -42,11 +54,14 @@ type metricsResponse struct {
 	// Current — point-in-time CPU / memory totals (across owned Pods
 	// for workload kinds).
 	Current map[string]any `json:"current"`
-	// Series — sparkline samples. Single-frame today; future slices
-	// can layer Prometheus-backed history when bp-prometheus ships.
+	// Series — sparkline samples. 60-bucket 5-minute window on the
+	// mimir-backed Pod path; single-frame on the metrics-server
+	// fallback path (and on Deployment/StatefulSet roll-ups).
 	Series []map[string]any `json:"series"`
-	// Source — "metrics.k8s.io" or "unavailable" when the API isn't
-	// served on the target cluster (UI surfaces a friendly empty state).
+	// Source — "mimir" (bp-mimir query-frontend, preferred for Pod
+	// kind), "metrics.k8s.io" (metrics-server single-point fallback),
+	// or "unavailable" when neither upstream is reachable. The UI
+	// surfaces a friendly empty state on "unavailable".
 	Source string `json:"source"`
 }
 
@@ -107,6 +122,41 @@ func (h *Handler) HandleK8sResourceMetrics(w http.ResponseWriter, r *http.Reques
 		Source:    "metrics.k8s.io",
 		Current:   emptyCurrent,
 		Series:    []map[string]any{},
+	}
+
+	// For Pod kind, prefer mimir (5-min, 5s-step sparkline). Mimir
+	// is the bp-mimir (slot 23) Prometheus-compatible store fed by
+	// Alloy — it scrapes cAdvisor for every Pod, so a single
+	// query_range yields a real time-series instead of the single
+	// point metrics-server returns. Fall back to metrics-server
+	// when mimir isn't wired (CATALYST_MIMIR_URL empty / bp-mimir
+	// disabled) OR the upstream query fails. See
+	// k8s_resource_metrics_mimir.go for the client.
+	if strings.EqualFold(kindName, "pod") {
+		if series, ferr := h.fetchPodSparkline(r.Context(), ns, name); ferr == nil && len(series) > 0 {
+			resp.Source = "mimir"
+			last := series[len(series)-1]
+			resp.Current = map[string]any{
+				"cpu":       last.CPU,
+				"memory":    last.Memory,
+				"cpuMilli":  last.CPUMilli,
+				"memBytes":  last.MemBytes,
+				"timestamp": last.Timestamp,
+			}
+			resp.Series = make([]map[string]any, 0, len(series))
+			for _, b := range series {
+				resp.Series = append(resp.Series, map[string]any{
+					"cpu":       b.CPU,
+					"memory":    b.Memory,
+					"cpuMilli":  b.CPUMilli,
+					"memBytes":  b.MemBytes,
+					"timestamp": b.Timestamp,
+				})
+			}
+			writeJSON(w, http.StatusOK, resp)
+			return
+		}
+		// fall through — metrics-server fallback below.
 	}
 
 	// PodMetrics is registered as kind "podmetrics" (see kinds.go).

--- a/products/catalyst/bootstrap/api/internal/handler/k8s_resource_metrics_mimir.go
+++ b/products/catalyst/bootstrap/api/internal/handler/k8s_resource_metrics_mimir.go
@@ -1,0 +1,219 @@
+// Package handler — k8s_resource_metrics_mimir.go: mimir-backed Pod
+// sparkline (issue #1753, slice G3b).
+//
+// The legacy metrics-server path (k8s_resource_metrics.go) returns a
+// single point-in-time CPU+memory snapshot. Operators want a short
+// time-series so the Pod detail panel can render a sparkline that
+// distinguishes "spiky but healthy" from "steady saturation". Mimir
+// (bp-mimir, bootstrap-kit slot 23) is the Prometheus-compatible
+// metrics store the LGTM stack ships with, and it scrapes every Pod
+// via Alloy. We can therefore drive a 5-minute / 5-second-step
+// sparkline (60 buckets) by issuing a single `query_range` against
+// Mimir's query-frontend.
+//
+// Wire contract:
+//
+//   GET <mimirURL>/prometheus/api/v1/query_range
+//     ?query=<promql>&start=<unix>&end=<unix>&step=5s
+//
+// Response shape (Prometheus matrix):
+//
+//   {
+//     status: "success",
+//     data: {
+//       resultType: "matrix",
+//       result: [
+//         { metric: {...}, values: [[ts, "val"], ...] }
+//       ]
+//     }
+//   }
+//
+// Per docs/INVIOLABLE-PRINCIPLES.md #4 (never hardcode) the base URL
+// is configuration: CATALYST_MIMIR_URL → Handler.mimirURL. Empty URL
+// causes the caller to fall back to the metrics-server single-point
+// path; an HTTP error from the upstream mimir does the same so a
+// transient query-frontend hiccup never blanks the panel.
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// promRangeResponse mirrors the Prometheus query_range matrix shape we
+// care about. Extra fields the upstream emits are deliberately ignored.
+type promRangeResponse struct {
+	Status string `json:"status"`
+	Data   struct {
+		ResultType string `json:"resultType"`
+		Result     []struct {
+			Metric map[string]string `json:"metric"`
+			// Values — Prometheus emits `[timestamp_float, "value"]`
+			// 2-tuples. Decode into `[]any` so we can pick the string
+			// half without fighting the upstream's mixed-type array.
+			Values [][]any `json:"values"`
+		} `json:"result"`
+	} `json:"data"`
+	ErrorType string `json:"errorType,omitempty"`
+	Error     string `json:"error,omitempty"`
+}
+
+// mimirPodSeries — output bucket shape consumed by the FE sparkline.
+// Aligned with the per-bucket payload the metrics-server path emits
+// for the single-point case so the FE can render either response.
+type mimirPodSeries struct {
+	Timestamp string `json:"timestamp"`
+	CPUMilli  int64  `json:"cpuMilli"`
+	MemBytes  int64  `json:"memBytes"`
+	CPU       string `json:"cpu"`
+	Memory    string `json:"memory"`
+}
+
+// mimirSparklineWindow is the operator-visible window for the Pod
+// sparkline. 5 minutes at 5-second resolution → 60 buckets, the same
+// rule-of-thumb the Grafana node-overview dashboard uses.
+const (
+	mimirSparklineWindow = 5 * time.Minute
+	mimirSparklineStep   = 5 * time.Second
+)
+
+// fetchPodSparkline issues two query_range calls (CPU + memory) against
+// the wired Mimir query-frontend and returns the merged per-bucket
+// series. Returns (nil, err) on any upstream failure so the caller
+// falls back to the metrics-server single-point path.
+func (h *Handler) fetchPodSparkline(ctx context.Context, ns, name string) ([]mimirPodSeries, error) {
+	if h.mimirURL == "" {
+		return nil, fmt.Errorf("mimir url not wired")
+	}
+	end := time.Now().UTC()
+	start := end.Add(-mimirSparklineWindow)
+
+	cpuQ := fmt.Sprintf(`rate(container_cpu_usage_seconds_total{pod=%q,namespace=%q}[1m])`, name, ns)
+	memQ := fmt.Sprintf(`container_memory_working_set_bytes{pod=%q,namespace=%q}`, name, ns)
+
+	cpuMatrix, err := h.mimirQueryRange(ctx, cpuQ, start, end, mimirSparklineStep)
+	if err != nil {
+		return nil, fmt.Errorf("mimir cpu: %w", err)
+	}
+	memMatrix, err := h.mimirQueryRange(ctx, memQ, start, end, mimirSparklineStep)
+	if err != nil {
+		return nil, fmt.Errorf("mimir mem: %w", err)
+	}
+
+	// Mimir returns one series per container; sum to a per-Pod total.
+	cpuByTS := sumMatrixByTimestamp(cpuMatrix)
+	memByTS := sumMatrixByTimestamp(memMatrix)
+
+	// Emit one bucket per step across the window so the FE sees a
+	// stable 60-element series even when a container was briefly
+	// missing — gaps render as zero rather than collapsing the X axis.
+	buckets := int(mimirSparklineWindow / mimirSparklineStep)
+	out := make([]mimirPodSeries, 0, buckets)
+	for i := 0; i < buckets; i++ {
+		t := start.Add(time.Duration(i) * mimirSparklineStep)
+		key := t.Unix()
+		cpuCores := cpuByTS[key]
+		memBytes := memByTS[key]
+		cpuMilli := int64(cpuCores * 1000)
+		out = append(out, mimirPodSeries{
+			Timestamp: t.Format(time.RFC3339),
+			CPUMilli:  cpuMilli,
+			MemBytes:  int64(memBytes),
+			CPU:       formatCPUMilli(cpuMilli),
+			Memory:    formatMemBytes(int64(memBytes)),
+		})
+	}
+	return out, nil
+}
+
+// mimirQueryRange issues a single query_range and decodes the matrix
+// response. Returns the decoded series slice so the caller can sum
+// across containers.
+func (h *Handler) mimirQueryRange(ctx context.Context, query string, start, end time.Time, step time.Duration) (*promRangeResponse, error) {
+	base := strings.TrimRight(h.mimirURL, "/")
+	u, err := url.Parse(base + "/prometheus/api/v1/query_range")
+	if err != nil {
+		return nil, fmt.Errorf("parse mimir url: %w", err)
+	}
+	q := u.Query()
+	q.Set("query", query)
+	q.Set("start", strconv.FormatInt(start.Unix(), 10))
+	q.Set("end", strconv.FormatInt(end.Unix(), 10))
+	q.Set("step", fmt.Sprintf("%ds", int(step.Seconds())))
+	u.RawQuery = q.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+	// Mimir multi-tenant mode requires a tenant header; the
+	// Catalyst-Zero bp-mimir overlay disables multi-tenancy so the
+	// default `anonymous` tenant accepts every query. We still
+	// stamp `X-Scope-OrgID: catalyst` so a Sovereign that flips
+	// auth_enabled=true later only needs to mirror the tenant config
+	// (no API change here).
+	req.Header.Set("X-Scope-OrgID", "catalyst")
+
+	client := h.mimirHTTPClient
+	if client == nil {
+		client = &http.Client{Timeout: 5 * time.Second}
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("http: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode/100 != 2 {
+		// Drain a small slice of the body for the log; do not pass
+		// the upstream's error envelope through to the caller —
+		// fallback-to-metrics-server is the recovery path here.
+		_, _ = io.CopyN(io.Discard, resp.Body, 4<<10)
+		return nil, fmt.Errorf("upstream status %d", resp.StatusCode)
+	}
+	var pr promRangeResponse
+	if err := json.NewDecoder(resp.Body).Decode(&pr); err != nil {
+		return nil, fmt.Errorf("decode: %w", err)
+	}
+	if pr.Status != "success" {
+		return nil, fmt.Errorf("mimir error: %s (%s)", pr.Error, pr.ErrorType)
+	}
+	return &pr, nil
+}
+
+// sumMatrixByTimestamp folds a Prometheus matrix down to a map keyed
+// by epoch-second. When multiple series (one per container) share a
+// timestamp, the values are summed — yielding a Pod-level total.
+func sumMatrixByTimestamp(pr *promRangeResponse) map[int64]float64 {
+	out := map[int64]float64{}
+	if pr == nil {
+		return out
+	}
+	for _, s := range pr.Data.Result {
+		for _, v := range s.Values {
+			if len(v) != 2 {
+				continue
+			}
+			tsFloat, ok := v[0].(float64)
+			if !ok {
+				continue
+			}
+			valStr, ok := v[1].(string)
+			if !ok {
+				continue
+			}
+			val, err := strconv.ParseFloat(valStr, 64)
+			if err != nil {
+				continue
+			}
+			out[int64(tsFloat)] += val
+		}
+	}
+	return out
+}

--- a/products/catalyst/bootstrap/api/internal/handler/k8s_resource_metrics_mimir_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/k8s_resource_metrics_mimir_test.go
@@ -1,0 +1,178 @@
+// k8s_resource_metrics_mimir_test.go — coverage for the mimir-backed
+// Pod sparkline path added in issue #1753 (slice G3b).
+//
+// Test strategy: stand up a httptest.Server that fakes Mimir's
+// `query_range` endpoint, point Handler.mimirURL at it, and assert the
+// handler returns `source=mimir` plus a multi-bucket series. A second
+// test asserts the fallback path: when mimirURL is empty (or upstream
+// errors) the handler falls through to the metrics-server single-point
+// shape with source=metrics.k8s.io / unavailable.
+package handler
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// fakeMimirQueryRange returns a httptest.Server that emits a 60-bucket
+// matrix response shaped like Prometheus' query_range. Both the CPU
+// and memory queries hit the same handler; the metric label set
+// distinguishes the two so the response is appropriate.
+func fakeMimirQueryRange(t *testing.T, wantNS, wantPod string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/prometheus/api/v1/query_range" {
+			http.Error(w, "wrong path", http.StatusNotFound)
+			return
+		}
+		q := r.URL.Query().Get("query")
+		// Sanity-check the namespace + pod labels made it into the
+		// PromQL — if the handler ever drops them the matrix would
+		// span every Pod in the cluster.
+		if !strings.Contains(q, fmt.Sprintf("namespace=%q", wantNS)) {
+			http.Error(w, "missing ns label", http.StatusBadRequest)
+			return
+		}
+		if !strings.Contains(q, fmt.Sprintf("pod=%q", wantPod)) {
+			http.Error(w, "missing pod label", http.StatusBadRequest)
+			return
+		}
+		// Emit a 60-bucket matrix at the start/end the caller sent.
+		startStr := r.URL.Query().Get("start")
+		var start int64
+		fmt.Sscanf(startStr, "%d", &start)
+		// Two containers per Pod to exercise the sum-by-timestamp
+		// fold. The query-shape distinguishes CPU vs Memory; for the
+		// test we emit different magnitudes so the assertion can tell
+		// which is which.
+		var value string
+		if strings.HasPrefix(q, "rate(") {
+			// CPU — 0.25 cores per container → 500m total per bucket.
+			value = "0.25"
+		} else {
+			// Memory — 128Mi per container → 256Mi total per bucket.
+			value = "134217728"
+		}
+		values := [][]any{}
+		for i := int64(0); i < 60; i++ {
+			ts := float64(start + i*5)
+			values = append(values, []any{ts, value})
+		}
+		resp := map[string]any{
+			"status": "success",
+			"data": map[string]any{
+				"resultType": "matrix",
+				"result": []any{
+					map[string]any{
+						"metric": map[string]string{"container": "a"},
+						"values": values,
+					},
+					map[string]any{
+						"metric": map[string]string{"container": "b"},
+						"values": values,
+					},
+				},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+}
+
+func TestHandleK8sResourceMetrics_PodMimirSparkline(t *testing.T) {
+	pod := newPodObj("default", "wp-1")
+	rig := newResourceRig(t, pod)
+	defer rig.stop()
+
+	srv := fakeMimirQueryRange(t, "default", "wp-1")
+	defer srv.Close()
+	rig.h.SetMimirURL(srv.URL)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/sovereigns/alpha/k8s/metrics/pod/default/wp-1", nil)
+	rec := httptest.NewRecorder()
+	rig.router().ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	var resp metricsResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if resp.Source != "mimir" {
+		t.Fatalf("source: got %q want mimir; body=%s", resp.Source, rec.Body.String())
+	}
+	if len(resp.Series) != 60 {
+		t.Fatalf("series len: got %d want 60", len(resp.Series))
+	}
+	// First + last bucket should both carry the per-Pod (summed) totals.
+	// CPU: 0.25 cores × 2 containers → 0.5 cores → 500m.
+	// Mem: 128Mi × 2 containers → 256Mi → 268435456 bytes.
+	first := resp.Series[0]
+	if got := first["cpuMilli"]; got != float64(500) {
+		t.Fatalf("series[0].cpuMilli: got %v want 500", got)
+	}
+	if got := first["memBytes"]; got != float64(268435456) {
+		t.Fatalf("series[0].memBytes: got %v want 268435456", got)
+	}
+	if got := resp.Current["cpuMilli"]; got != float64(500) {
+		t.Fatalf("current.cpuMilli: got %v want 500", got)
+	}
+	if !strings.Contains(fmt.Sprintf("%v", resp.Current["cpu"]), "500m") {
+		t.Fatalf("current.cpu: got %v want 500m", resp.Current["cpu"])
+	}
+}
+
+func TestHandleK8sResourceMetrics_PodMimirFallsBackOnUpstreamError(t *testing.T) {
+	pod := newPodObj("default", "wp-1")
+	rig := newResourceRig(t, pod)
+	defer rig.stop()
+
+	// Upstream that always 500s — handler must fall through to the
+	// metrics-server path (which here also has no PodMetrics
+	// indexer → resp.Source must NOT be "mimir").
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "mimir down", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+	rig.h.SetMimirURL(srv.URL)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/sovereigns/alpha/k8s/metrics/pod/default/wp-1", nil)
+	rec := httptest.NewRecorder()
+	rig.router().ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	var resp metricsResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if resp.Source == "mimir" {
+		t.Fatalf("source: must NOT be mimir after upstream 500; got %q", resp.Source)
+	}
+}
+
+func TestHandleK8sResourceMetrics_PodMimirSkippedWhenUnwired(t *testing.T) {
+	pod := newPodObj("default", "wp-1")
+	rig := newResourceRig(t, pod)
+	defer rig.stop()
+	// Deliberately do NOT call SetMimirURL — the handler must skip
+	// the mimir attempt and fall through to the metrics-server path.
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/sovereigns/alpha/k8s/metrics/pod/default/wp-1", nil)
+	rec := httptest.NewRecorder()
+	rig.router().ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	var resp metricsResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if resp.Source == "mimir" {
+		t.Fatalf("source: must NOT be mimir when CATALYST_MIMIR_URL is empty; got %q", resp.Source)
+	}
+}

--- a/products/catalyst/chart/templates/api-deployment.yaml
+++ b/products/catalyst/chart/templates/api-deployment.yaml
@@ -1178,6 +1178,19 @@ spec:
             # in the manifest itself rather than only in Go source.
             - name: CATALYST_CATALOG_URL
               value: "http://catalyst-catalog.catalyst-system.svc.cluster.local:8080"
+            # CATALYST_MIMIR_URL — bp-mimir (bootstrap-kit slot 23)
+            # query-frontend HTTP API base. Consumed by
+            # internal/handler/k8s_resource_metrics_mimir.go to drive a
+            # 5-min / 5-second-step Pod sparkline via Prometheus
+            # query_range. Empty value disables the mimir path and the
+            # Pod metrics handler falls back to metrics-server's single
+            # point. The default literal matches the Service rendered
+            # by bp-mimir: name `mimir-query-frontend`, namespace
+            # `mimir`, port 8080. Per Inviolable Principle #4
+            # per-Sovereign overlays MAY override via `catalystApi.env`
+            # when bp-mimir ships in a different namespace.
+            - name: CATALYST_MIMIR_URL
+              value: "http://mimir-query-frontend.mimir.svc.cluster.local:8080"
             # CATALYST_TEST_SESSION_ENABLED — gates POST /api/v1/auth/test-session
             # (qa-loop iter-11 Cluster-A). Default empty/false → endpoint
             # returns 404 to the public, indistinguishable from "this


### PR DESCRIPTION
## Summary
- Pod-detail metrics endpoint now queries Grafana Mimir (`bp-mimir`, slot 23) via `query_range` for a 5-min window at 5-sec step (60 buckets) instead of the single-point metrics-server snapshot
- Falls back to the existing metrics-server `source=metrics.k8s.io` path when `CATALYST_MIMIR_URL` is empty OR the upstream query fails, so clusters without bp-mimir continue rendering (degraded)
- Multi-container Pods are summed by timestamp into a Pod-level total; the most recent bucket populates `current` so the FE headline read-out keeps working without walking the array

## PromQL
- CPU:    `rate(container_cpu_usage_seconds_total{pod=<name>,namespace=<ns>}[1m])`
- Memory: `container_memory_working_set_bytes{pod=<name>,namespace=<ns>}`

## Wire surface
- new field `Handler.mimirURL` + `mimirHTTPClient`
- new setter `SetMimirURL` / `SetMimirHTTPClient` (test seam)
- new file `k8s_resource_metrics_mimir.go` (Prometheus query_range client + matrix→bucket fold)
- env wiring `cmd/api/main.go` reads `CATALYST_MIMIR_URL` (defaults to in-cluster Service FQDN)
- chart wiring `api-deployment.yaml` stamps the env var

## Test plan
- [x] `TestHandleK8sResourceMetrics_PodMimirSparkline` — httptest mock returns 60-bucket matrix, handler emits 60-element series with `source=mimir`, summed cpuMilli=500 + memBytes=268435456
- [x] `TestHandleK8sResourceMetrics_PodMimirFallsBackOnUpstreamError` — mock 500s → handler must NOT surface `source=mimir`
- [x] `TestHandleK8sResourceMetrics_PodMimirSkippedWhenUnwired` — empty `mimirURL` → handler must NOT surface `source=mimir`
- [x] `TestHandleK8sResourceMetrics_ReturnsUnavailableWhenPodMetricsAbsent` — existing fallback unchanged
- [x] full `go build ./...` clean
- [x] `helm template` renders `CATALYST_MIMIR_URL` env var

Closes #1753

🤖 Generated with [Claude Code](https://claude.com/claude-code)