### PR TITLE
fix(treemap): primary cluster label shows (region) postfix (Closes #1756)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/dashboard.go
+++ b/products/catalyst/bootstrap/api/internal/handler/dashboard.go
@@ -573,6 +573,17 @@ func dimensionKey(r podRow, dim string) (string, string) {
 		}
 		return r.cluster, r.cluster
 	case "cluster":
+		// TBD-E4b (#1756): operators see the bare deployment-id hex on the
+		// primary cluster cell (e.g. `30dbef8b238c2d84`) and cannot tell
+		// which region it represents. When the row carries a region label
+		// (populated by buildPodRows from the host node's
+		// `openova.io/region` label), postfix it onto the name so the
+		// label reads `30dbef8b238c2d84 (hz-hel-rtz-prod)`. The bucket id
+		// stays the cluster id so all rows for the same cluster still
+		// merge into one cell.
+		if r.region != "" {
+			return r.cluster, r.cluster + " (" + r.region + ")"
+		}
 		return r.cluster, r.cluster
 	case "vcluster":
 		// vCluster name derives from the pod's host-namespace

--- a/products/catalyst/bootstrap/api/internal/handler/dashboard_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/dashboard_test.go
@@ -767,6 +767,45 @@ func TestDashboardTreemap_VClusterFromNamespaceLabel(t *testing.T) {
 	}
 }
 
+// TestDashboardTreemap_ClusterLabelPostfixesRegion — TBD-E4b (#1756).
+// Grouping by `cluster` should not surface the bare deployment-id hex
+// (e.g. `alpha` in tests / `30dbef8b238c2d84` in prod) on the cell
+// label; when the row carries a region, postfix `(<region>)` so the
+// label reads `alpha (hz-hel-rtz-prod)`. Bucket id stays the cluster
+// id so all rows still merge into one cell.
+func TestDashboardTreemap_ClusterLabelPostfixesRegion(t *testing.T) {
+	h := newDashHandlerWithCache(t, "alpha", false,
+		mkDashNode("node-hel-1", "hz-hel-rtz-prod", ""),
+		mkDashPodOnNode("ns1", "p1", "bp-cilium", "node-hel-1"),
+		mkDashPodOnNode("ns1", "p2", "bp-cilium", "node-hel-1"),
+	)
+	out := dashGet(t, h, "deployment_id=alpha&group_by=cluster&color_by=health&size_by=cpu_request")
+	if len(out.Items) != 1 {
+		t.Fatalf("expected 1 cluster bucket; got %d (%+v)", len(out.Items), out)
+	}
+	got := out.Items[0].Name
+	want := "alpha (hz-hel-rtz-prod)"
+	if got != want {
+		t.Errorf("cluster label = %q; want %q", got, want)
+	}
+}
+
+// TestDashboardTreemap_ClusterLabelNoRegion — when no row carries a
+// region label (single-region Sovereign with no node-label
+// enrichment), the cluster cell falls back to the bare cluster id.
+func TestDashboardTreemap_ClusterLabelNoRegion(t *testing.T) {
+	h := newDashHandlerWithCache(t, "alpha", false,
+		mkDashPodOnNode("ns1", "p1", "bp-cilium", ""),
+	)
+	out := dashGet(t, h, "deployment_id=alpha&group_by=cluster&color_by=health&size_by=cpu_request")
+	if len(out.Items) != 1 {
+		t.Fatalf("expected 1 cluster bucket; got %d (%+v)", len(out.Items), out)
+	}
+	if got, want := out.Items[0].Name, "alpha"; got != want {
+		t.Errorf("cluster label = %q; want %q", got, want)
+	}
+}
+
 // TestDashboardTreemap_RegionFromNodeLabel — when the Pod has no
 // openova.io/region label but its host Node does, region grouping
 // reads from the Node's label set. Both `openova.io/region` and the


### PR DESCRIPTION
## Summary
- TBD-E4b (#1756): Sovereign `/dashboard` with default Layer=Cluster surfaced the primary cluster as the bare deployment-id hex (e.g. `30dbef8b238c2d84`) — operator-confusing.
- Fix: in `dimensionKey` for the `cluster` dim, when the podRow carries a region (already populated by `buildPodRows` from the host Node's `openova.io/region` / `topology.kubernetes.io/region` label), postfix the region onto the bucket name so the cell label reads `30dbef8b238c2d84 (hz-hel-rtz-prod)`.
- Bucket id stays the cluster id so all rows for the same cluster still merge into one cell. Selected **Option A** (label postfix) per the WBS scope; minimal patch, no schema change to the treemap payload.

## Test plan
- [x] `go test ./internal/handler/ -run TestDashboard -count=1` — all green (incl. 2 new tests)
- [x] `TestDashboardTreemap_ClusterLabelPostfixesRegion` — region present → name = `<cluster> (<region>)`
- [x] `TestDashboardTreemap_ClusterLabelNoRegion` — no region → falls back to bare cluster id (back-compat)
- [x] `go vet ./internal/handler/` — clean
- [ ] Visual verification on next fresh prov: open Sovereign `/dashboard`, confirm Layer-1 cell labels read `<hex> (<region>)`.

Closes #1756

🤖 Generated with [Claude Code](https://claude.com/claude-code)