### PR TITLE
fix(charts): resolve bp-dmz-vcluster duplicate-name pseudo-drift (Closes A6c)

### DIFF
--- a/clusters/_template/bootstrap-kit/54-bp-dmz-vcluster.yaml
+++ b/clusters/_template/bootstrap-kit/54-bp-dmz-vcluster.yaml
@@ -16,7 +16,11 @@
 # scripts/expected-bootstrap-deps.yaml since qa-loop iter-12 Fix #53C
 # (the chart was authored at products/dmz-vcluster but never wired
 # into the bootstrap kit). The chart at products/dmz-vcluster
-# remains the per-tenant marketplace deliverable — different artifact.
+# remains the per-tenant marketplace deliverable — different artifact,
+# now also a different chart name: `bp-dmz-vcluster-tenant` (renamed
+# 2026-05-18 per TBD-A6c, issue #1719, so the pin-sync audit can
+# disambiguate the two). This slot pins THIS chart (platform/) at
+# the version declared in platform/bp-dmz-vcluster/chart/Chart.yaml.
 #
 # Wrapper chart: platform/bp-dmz-vcluster/chart/
 #   Bundles loft-sh/vcluster 0.20.0 as a Helm subchart.

--- a/platform/bp-dmz-vcluster/README.md
+++ b/platform/bp-dmz-vcluster/README.md
@@ -21,7 +21,7 @@ WG endpoint, ClusterMesh apiserver Service, and HTTPRoutes are
 installed AS WORKLOADS into this vCluster via subsequent slots /
 per-Sovereign overlay paths.
 
-## Relationship to `products/dmz-vcluster`
+## Relationship to `products/dmz-vcluster` (`bp-dmz-vcluster-tenant`)
 
 This `platform/bp-dmz-vcluster` is the **bootstrap topology** piece —
 it lands on every Sovereign region by design (slot 54).
@@ -31,6 +31,15 @@ customer-facing capability operators install via the Sovereign Console
 when a customer requests a DMZ for their workloads. The two charts
 serve different layers and may coexist; this Blueprint takes priority
 for the bootstrap topology.
+
+> **Chart-name disambiguation (TBD-A6c, 2026-05-18, issue #1719):** The
+> `products/dmz-vcluster` chart's `name:` field is `bp-dmz-vcluster-tenant`
+> (NOT `bp-dmz-vcluster`). They were the same name historically, which
+> made `scripts/check-bootstrap-kit-pin-sync.sh` unable to map each
+> bootstrap-kit pin to exactly one source chart. The per-tenant
+> marketplace variant was renamed to `bp-dmz-vcluster-tenant`; this
+> chart (the bootstrap topology piece pinned at slot 54) keeps the
+> canonical `bp-dmz-vcluster` name.
 
 ## Resources rendered (full-ON)
 

--- a/products/dmz-vcluster/chart/Chart.yaml
+++ b/products/dmz-vcluster/chart/Chart.yaml
@@ -1,5 +1,15 @@
 apiVersion: v2
-name: bp-dmz-vcluster
+# RENAMED 2026-05-18 (TBD-A6c, issue #1719): was `bp-dmz-vcluster` — same
+# chart name as `platform/bp-dmz-vcluster/chart/Chart.yaml` made
+# scripts/check-bootstrap-kit-pin-sync.sh unable to disambiguate the two
+# charts when comparing source-tree version against the bootstrap-kit
+# pin (slot 54 pins the platform/ chart at 0.1.0; this products/ chart
+# at 0.1.1 always looked drifted). Renaming this per-tenant marketplace
+# variant lets the audit map each name -> exactly one Chart.yaml and
+# reach 0 reported drifts. The platform/bp-dmz-vcluster chart at slot 54
+# is unchanged — it remains the canonical bootstrap-topology chart per
+# docs/SOVEREIGN-MULTI-REGION-DOD.md A4.
+name: bp-dmz-vcluster-tenant
 version: 0.1.1
 appVersion: "0.20.0"
 description: |
@@ -25,7 +35,12 @@ description: |
   (resource limits, pod-security, auth) without forking the upstream
   chart. Per ADR-0001 §3.2.8 + the EPIC-5 leftovers brief, DMZ
   vCluster is a customer-facing capability under products/, NOT
-  platform/.
+  platform/. The chart name (`bp-dmz-vcluster-tenant`) is distinct
+  from `platform/bp-dmz-vcluster` (the per-region DMZ topology piece)
+  so the bootstrap-kit pin-sync audit can disambiguate the two —
+  this chart never appears in clusters/_template/bootstrap-kit/, only
+  in per-tenant marketplace overlays under
+  clusters/<sovereign>/products/dmz-vcluster/release.yaml.
 
   Default-OFF gate: `dmz.enabled: false`. Operators flip true on a
   per-Sovereign overlay once Cilium ClusterMesh (EPIC-6 C-DB-1) and

--- a/products/dmz-vcluster/chart/README.md
+++ b/products/dmz-vcluster/chart/README.md
@@ -1,4 +1,12 @@
-# bp-dmz-vcluster
+# bp-dmz-vcluster-tenant
+
+> **Note (TBD-A6c rename, 2026-05-18):** This chart was previously named
+> `bp-dmz-vcluster` — same as `platform/bp-dmz-vcluster/chart/`, which
+> prevented `scripts/check-bootstrap-kit-pin-sync.sh` from
+> disambiguating the two charts. The per-tenant marketplace chart is
+> now named `bp-dmz-vcluster-tenant`; the platform/ bootstrap-topology
+> chart keeps its canonical `bp-dmz-vcluster` name (slot 54, DoD A4).
+> See issue #1719 for the rename rationale.
 
 Catalyst-authored Blueprint chart for a DMZ vCluster — an isolated
 customer-internet-facing virtual Kubernetes cluster running inside the
@@ -47,7 +55,7 @@ ClusterMesh + the egress gateway are ready.
 
 Per `docs/INVIOLABLE-PRINCIPLES.md` #4a, `dmz.vcluster.image.tag` is
 empty in `values.yaml` and the helm-template render fails-fast when an
-overlay leaves it empty (see `_helpers.tpl::bp-dmz-vcluster.image`). CI
+overlay leaves it empty (see `_helpers.tpl::bp-dmz-vcluster-tenant.image`). CI
 populates the SHA tag via `yq eval -i .image.tag = "<sha>"` when
 promoting a build into `clusters/<sovereign>/`.
 
@@ -73,7 +81,7 @@ Sovereign's bootstrap-kit.
 
 1. **Default-OFF**: zero K8s resources rendered (CC3 default-OFF gate).
 2. **Fail-fast on empty image tag**: render aborts with the exact
-   `bp-dmz-vcluster: ... image.tag is empty` message when
+   `bp-dmz-vcluster-tenant: ... image.tag is empty` message when
    `enabled: true` without a SHA stamp.
 3. **Full-ON canonical bundle**: HelmRelease + 2 NetworkPolicies +
    Service (+ HTTPRoute when hostname is set).

--- a/products/dmz-vcluster/chart/blueprint.yaml
+++ b/products/dmz-vcluster/chart/blueprint.yaml
@@ -1,7 +1,7 @@
 apiVersion: catalyst.openova.io/v1alpha1
 kind: Blueprint
 metadata:
-  name: bp-dmz-vcluster
+  name: bp-dmz-vcluster-tenant
   labels:
     catalyst.openova.io/section: pts-3-1-networking-and-service-mesh
     openova.io/category: customer-facing-capability

--- a/products/dmz-vcluster/chart/templates/_helpers.tpl
+++ b/products/dmz-vcluster/chart/templates/_helpers.tpl
@@ -1,14 +1,14 @@
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "bp-dmz-vcluster.name" -}}
+{{- define "bp-dmz-vcluster-tenant.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*
 Fully qualified app name. Used as the K8s resource name root.
 */}}
-{{- define "bp-dmz-vcluster.fullname" -}}
+{{- define "bp-dmz-vcluster-tenant.fullname" -}}
 {{- if .Values.fullnameOverride }}
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
 {{- else }}
@@ -24,15 +24,15 @@ Fully qualified app name. Used as the K8s resource name root.
 {{/*
 Common labels — Catalyst convention.
 */}}
-{{- define "bp-dmz-vcluster.labels" -}}
+{{- define "bp-dmz-vcluster-tenant.labels" -}}
 helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
-app.kubernetes.io/name: {{ include "bp-dmz-vcluster.name" . }}
+app.kubernetes.io/name: {{ include "bp-dmz-vcluster-tenant.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
-catalyst.openova.io/blueprint: bp-dmz-vcluster
+catalyst.openova.io/blueprint: bp-dmz-vcluster-tenant
 openova.io/product: dmz-vcluster
 {{- end }}
 
@@ -41,7 +41,7 @@ Selector labels — used by the host-namespace NetworkPolicy to target
 all DMZ vCluster pods. The `vcluster.loft.sh/managed-by:
 <vclusterName>` label is the upstream vCluster's canonical pod label.
 */}}
-{{- define "bp-dmz-vcluster.podSelectorLabel" -}}
+{{- define "bp-dmz-vcluster-tenant.podSelectorLabel" -}}
 vcluster.loft.sh/managed-by: {{ .Values.dmz.vclusterName | quote }}
 {{- end }}
 
@@ -51,10 +51,10 @@ empty `:tag` MUST fail the helm template render — we never want
 floating `:latest` shipping into production. Honours
 `.Values.global.imageRegistry` rewrite when set.
 */}}
-{{- define "bp-dmz-vcluster.image" -}}
+{{- define "bp-dmz-vcluster-tenant.image" -}}
 {{- $tag := .Values.dmz.vcluster.image.tag -}}
 {{- if not $tag -}}
-{{- fail "bp-dmz-vcluster: .Values.dmz.vcluster.image.tag is empty — SHA-pinned image required (CI populates this) per docs/INVIOLABLE-PRINCIPLES.md #4a" -}}
+{{- fail "bp-dmz-vcluster-tenant: .Values.dmz.vcluster.image.tag is empty — SHA-pinned image required (CI populates this) per docs/INVIOLABLE-PRINCIPLES.md #4a" -}}
 {{- end -}}
 {{- $repo := .Values.dmz.vcluster.image.repository -}}
 {{- $globalRegistry := .Values.global.imageRegistry | default "" -}}
@@ -72,10 +72,10 @@ Host namespace fail-fast — every resource the chart renders is
 namespaced into this. Refusing to render at all when empty prevents
 the chart from accidentally landing in the `default` namespace.
 */}}
-{{- define "bp-dmz-vcluster.hostNamespace" -}}
+{{- define "bp-dmz-vcluster-tenant.hostNamespace" -}}
 {{- $ns := .Values.dmz.hostNamespace -}}
 {{- if not $ns -}}
-{{- fail "bp-dmz-vcluster: .Values.dmz.hostNamespace is empty — set per Sovereign overlay (canonical: 'dmz' for single-DMZ Sovereigns)" -}}
+{{- fail "bp-dmz-vcluster-tenant: .Values.dmz.hostNamespace is empty — set per Sovereign overlay (canonical: 'dmz' for single-DMZ Sovereigns)" -}}
 {{- end -}}
 {{- $ns -}}
 {{- end }}

--- a/products/dmz-vcluster/chart/templates/httproute.yaml
+++ b/products/dmz-vcluster/chart/templates/httproute.yaml
@@ -12,10 +12,10 @@
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  name: {{ include "bp-dmz-vcluster.fullname" . }}
-  namespace: {{ include "bp-dmz-vcluster.hostNamespace" . }}
+  name: {{ include "bp-dmz-vcluster-tenant.fullname" . }}
+  namespace: {{ include "bp-dmz-vcluster-tenant.hostNamespace" . }}
   labels:
-    {{- include "bp-dmz-vcluster.labels" . | nindent 4 }}
+    {{- include "bp-dmz-vcluster-tenant.labels" . | nindent 4 }}
 spec:
   parentRefs:
     - name: {{ .Values.dmz.httproute.parentRef.name }}
@@ -31,6 +31,6 @@ spec:
         # The synced tenant apiserver Service. Operators ADD per-tenant
         # path matches by overlay — extend rules[] with workload-Service
         # backends as needed.
-        - name: {{ include "bp-dmz-vcluster.fullname" . }}-apiserver
+        - name: {{ include "bp-dmz-vcluster-tenant.fullname" . }}-apiserver
           port: {{ .Values.dmz.vcluster.apiPort }}
 {{- end }}

--- a/products/dmz-vcluster/chart/templates/networkpolicy-isolation.yaml
+++ b/products/dmz-vcluster/chart/templates/networkpolicy-isolation.yaml
@@ -23,10 +23,10 @@
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: {{ include "bp-dmz-vcluster.fullname" . }}-default-deny
-  namespace: {{ include "bp-dmz-vcluster.hostNamespace" . }}
+  name: {{ include "bp-dmz-vcluster-tenant.fullname" . }}-default-deny
+  namespace: {{ include "bp-dmz-vcluster-tenant.hostNamespace" . }}
   labels:
-    {{- include "bp-dmz-vcluster.labels" . | nindent 4 }}
+    {{- include "bp-dmz-vcluster-tenant.labels" . | nindent 4 }}
 spec:
   podSelector: {}
   policyTypes:
@@ -42,10 +42,10 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: {{ include "bp-dmz-vcluster.fullname" . }}-allow-essentials
-  namespace: {{ include "bp-dmz-vcluster.hostNamespace" . }}
+  name: {{ include "bp-dmz-vcluster-tenant.fullname" . }}-allow-essentials
+  namespace: {{ include "bp-dmz-vcluster-tenant.hostNamespace" . }}
   labels:
-    {{- include "bp-dmz-vcluster.labels" . | nindent 4 }}
+    {{- include "bp-dmz-vcluster-tenant.labels" . | nindent 4 }}
 spec:
   # Apply to every pod in the namespace (including upstream vCluster
   # syncer Pods that don't carry the vcluster.loft.sh label until they

--- a/products/dmz-vcluster/chart/templates/service.yaml
+++ b/products/dmz-vcluster/chart/templates/service.yaml
@@ -12,15 +12,15 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "bp-dmz-vcluster.fullname" . }}-apiserver
-  namespace: {{ include "bp-dmz-vcluster.hostNamespace" . }}
+  name: {{ include "bp-dmz-vcluster-tenant.fullname" . }}-apiserver
+  namespace: {{ include "bp-dmz-vcluster-tenant.hostNamespace" . }}
   labels:
-    {{- include "bp-dmz-vcluster.labels" . | nindent 4 }}
+    {{- include "bp-dmz-vcluster-tenant.labels" . | nindent 4 }}
     catalyst.openova.io/component: apiserver
 spec:
   type: ClusterIP
   selector:
-    {{- include "bp-dmz-vcluster.podSelectorLabel" . | nindent 4 }}
+    {{- include "bp-dmz-vcluster-tenant.podSelectorLabel" . | nindent 4 }}
   ports:
     - name: apiserver
       port: {{ .Values.dmz.vcluster.apiPort }}

--- a/products/dmz-vcluster/chart/templates/vcluster-helmrelease.yaml
+++ b/products/dmz-vcluster/chart/templates/vcluster-helmrelease.yaml
@@ -12,10 +12,10 @@
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
-  name: {{ include "bp-dmz-vcluster.fullname" . }}
-  namespace: {{ include "bp-dmz-vcluster.hostNamespace" . }}
+  name: {{ include "bp-dmz-vcluster-tenant.fullname" . }}
+  namespace: {{ include "bp-dmz-vcluster-tenant.hostNamespace" . }}
   labels:
-    {{- include "bp-dmz-vcluster.labels" . | nindent 4 }}
+    {{- include "bp-dmz-vcluster-tenant.labels" . | nindent 4 }}
 spec:
   interval: 5m
   chart:
@@ -36,9 +36,9 @@ spec:
   # The upstream vcluster chart is SHA-pinned via `image.tag` here —
   # Catalyst's fail-fast helper aborts render if CI didn't stamp it.
   values:
-    image: {{ include "bp-dmz-vcluster.image" . | quote }}
+    image: {{ include "bp-dmz-vcluster-tenant.image" . | quote }}
     syncer:
-      image: {{ include "bp-dmz-vcluster.image" . | quote }}
+      image: {{ include "bp-dmz-vcluster-tenant.image" . | quote }}
       resources:
         {{- toYaml .Values.dmz.vcluster.resources | nindent 8 }}
     storage:

--- a/products/dmz-vcluster/chart/tests/render.sh
+++ b/products/dmz-vcluster/chart/tests/render.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
-# bp-dmz-vcluster helm-render smoke test (EPIC-5 leftovers DMZ, #1100).
+# bp-dmz-vcluster-tenant helm-render smoke test (EPIC-5 leftovers DMZ,
+# #1100). Chart was renamed from bp-dmz-vcluster -> bp-dmz-vcluster-tenant
+# on 2026-05-18 (TBD-A6c, issue #1719) so the bootstrap-kit pin-sync
+# audit can disambiguate this per-tenant marketplace variant from the
+# platform/bp-dmz-vcluster bootstrap-topology chart.
 #
 # Verifies three INVIOLABLE-PRINCIPLES contracts at chart-render time:
 #
@@ -9,7 +13,7 @@
 #                      hostname is set).
 #
 #   #4a (SHA-pinned) — when enabled with empty .image.tag, render fails
-#                      fast with the exact `bp-dmz-vcluster: ...
+#                      fast with the exact `bp-dmz-vcluster-tenant: ...
 #                      image.tag is empty` message from _helpers.tpl.
 #
 #   CC3 default-OFF  — when default-OFF, render produces ZERO
@@ -37,7 +41,7 @@ fi
 # 1. Default-OFF: zero K8s resources rendered.
 # ─────────────────────────────────────────────────────────────────────
 render_off="$TMP/off.yaml"
-helm template bp-dmz-vcluster . > "$render_off"
+helm template bp-dmz-vcluster-tenant . > "$render_off"
 off_count="$(grep -cE '^kind:' "$render_off" || true)"
 if [[ "$off_count" != "0" ]]; then
   echo "FAIL: default-OFF rendered $off_count resources, want 0"
@@ -49,7 +53,7 @@ echo "PASS: default-OFF renders 0 resources"
 # ─────────────────────────────────────────────────────────────────────
 # 2. Fail-fast on empty image tag.
 # ─────────────────────────────────────────────────────────────────────
-if helm template bp-dmz-vcluster . \
+if helm template bp-dmz-vcluster-tenant . \
     --set dmz.enabled=true \
     >/dev/null 2>"$TMP/empty-tag.err"; then
   echo "FAIL: empty image.tag did not abort render"
@@ -66,7 +70,7 @@ echo "PASS: empty image.tag fails fast"
 # 3. Full-ON without HTTPRoute hostname.
 # ─────────────────────────────────────────────────────────────────────
 render_on="$TMP/on.yaml"
-helm template bp-dmz-vcluster . \
+helm template bp-dmz-vcluster-tenant . \
   --set dmz.enabled=true \
   --set dmz.vcluster.image.tag=0.20.0 \
   > "$render_on"
@@ -103,7 +107,7 @@ echo "PASS: HTTPRoute omitted when hostname empty (internal-mesh-only DMZ)"
 # 4. Full-ON WITH HTTPRoute hostname.
 # ─────────────────────────────────────────────────────────────────────
 render_on_host="$TMP/on-host.yaml"
-helm template bp-dmz-vcluster . \
+helm template bp-dmz-vcluster-tenant . \
   --set dmz.enabled=true \
   --set dmz.vcluster.image.tag=0.20.0 \
   --set dmz.httproute.hostname=tenant.test \
@@ -119,4 +123,4 @@ fi
 echo "PASS: HTTPRoute renders when hostname set"
 
 echo ""
-echo "All bp-dmz-vcluster render tests passed."
+echo "All bp-dmz-vcluster-tenant render tests passed."

--- a/products/dmz-vcluster/chart/values.yaml
+++ b/products/dmz-vcluster/chart/values.yaml
@@ -1,5 +1,9 @@
-# Catalyst Blueprint values for bp-dmz-vcluster (slice EPIC-5
-# leftovers DMZ #1100).
+# Catalyst Blueprint values for bp-dmz-vcluster-tenant (slice EPIC-5
+# leftovers DMZ #1100). Chart was renamed from bp-dmz-vcluster ->
+# bp-dmz-vcluster-tenant on 2026-05-18 (TBD-A6c, issue #1719) so
+# scripts/check-bootstrap-kit-pin-sync.sh can disambiguate this
+# per-tenant marketplace chart from platform/bp-dmz-vcluster
+# (the bootstrap-topology chart pinned at slot 54).
 #
 # Per docs/INVIOLABLE-PRINCIPLES.md:
 #   #1   waterfall — chart ships the full target shape (HelmRelease

--- a/scripts/expected-bootstrap-deps.yaml
+++ b/scripts/expected-bootstrap-deps.yaml
@@ -378,7 +378,11 @@ slots:
   # supersedes the inert entry that was declared at qa-loop iter-12 Fix
   # #53C but never landed as a real chart at platform/. The chart at
   # products/dmz-vcluster remains the per-tenant marketplace artifact —
-  # different layer.
+  # different layer. Per TBD-A6c (2026-05-18, issue #1719) the
+  # products/dmz-vcluster chart's `name:` is now `bp-dmz-vcluster-tenant`
+  # (was `bp-dmz-vcluster`) so scripts/check-bootstrap-kit-pin-sync.sh
+  # can disambiguate the two source-tree Chart.yaml files when comparing
+  # against this slot's pin.
   - slot: 54
     name: bp-dmz-vcluster
     depends_on:


### PR DESCRIPTION
## Summary

Two source-tree `Chart.yaml` files both declared `name: bp-dmz-vcluster`:

- `platform/bp-dmz-vcluster/chart/Chart.yaml` (`version: 0.1.0`) — bootstrap-topology chart consumed by `clusters/_template/bootstrap-kit/54-bp-dmz-vcluster.yaml` per `docs/SOVEREIGN-MULTI-REGION-DOD.md` A4.
- `products/dmz-vcluster/chart/Chart.yaml` (`version: 0.1.1`) — per-tenant marketplace artifact (the customer-facing DMZ vCluster).

`scripts/check-bootstrap-kit-pin-sync.sh` keys by chart name and so could not disambiguate the two: slot 54 pins the platform chart at 0.1.0, but the products chart at 0.1.1 always looked drifted. After PR #1716 flushed every real chart-pin drift, this single pseudo-drift was the only remaining red on the audit.

## Resolution — Option A (rename the products/ chart)

The platform/ chart is the canonical `bp-dmz-vcluster` per slot 54's in-file comment block (it is the bootstrap-topology DMZ vCluster, present on every Sovereign region). The products/ chart is a per-tenant marketplace variant operators install per customer.

`products/dmz-vcluster/chart/Chart.yaml` `name:` field renamed to `bp-dmz-vcluster-tenant`. Helper templates (`_helpers.tpl`) renamed from `bp-dmz-vcluster.*` to `bp-dmz-vcluster-tenant.*` along with every include site. Blueprint manifest (`blueprint.yaml`) `metadata.name` updated to match. Labels on every rendered resource carry `catalyst.openova.io/blueprint: bp-dmz-vcluster-tenant`. README + test-render.sh + values.yaml comments updated to reflect the rename. Cross-references in `platform/bp-dmz-vcluster/README.md` + slot 54 comment + `scripts/expected-bootstrap-deps.yaml` note the disambiguation.

Option B (delete the products/ chart) was NOT chosen — `products/dmz-vcluster/DESIGN.md` documents a deliberate ADR-0001 §3.2.8 separation (customer-facing capabilities live under `products/`, operator-facing under `platform/`) and the chart is intended to ship via per-Sovereign overlay at `clusters/<sovereign>/products/dmz-vcluster/release.yaml`. Renaming preserves that contract.

## Audit-after verification

```
$ bash scripts/check-bootstrap-kit-pin-sync.sh
...
Checked 50 chart→pin pair(s), skipped 30 chart(s) not in the bootstrap kit.
PASS: all bootstrap-kit pins are in sync with their source charts.
```

Compare against the residual drift documented in PR #1716:
```
DRIFT bp-dmz-vcluster: chart=0.1.1 pin=0.1.0
```
— now gone.

## Helm-render verification

```
cd products/dmz-vcluster/chart
helm dependency update
helm template tenant-x . --set dmz.enabled=true \
  --set dmz.vcluster.image.tag=0.20.0 \
  --set dmz.httproute.hostname=tenant.test
```
Renders 2 NetworkPolicies + Service + HTTPRoute + HelmRelease with every label = `bp-dmz-vcluster-tenant` and resource names `tenant-x-bp-dmz-vcluster-tenant-*`.

`helm lint` clean.

## Files modified

13 files: products/dmz-vcluster/chart/{Chart.yaml, README.md, blueprint.yaml, values.yaml, templates/_helpers.tpl, templates/httproute.yaml, templates/networkpolicy-isolation.yaml, templates/service.yaml, templates/vcluster-helmrelease.yaml, tests/render.sh}, plus platform/bp-dmz-vcluster/README.md, clusters/_template/bootstrap-kit/54-bp-dmz-vcluster.yaml, scripts/expected-bootstrap-deps.yaml (cross-reference notes).

## Test plan

- [x] `scripts/check-bootstrap-kit-pin-sync.sh` reports PASS (0 drifts).
- [x] `helm lint products/dmz-vcluster/chart` clean.
- [x] `helm template` renders all rendered objects under the new chart name.
- [ ] Blueprint Release smoke-render CI green.
- [ ] Bootstrap-kit deps audit CI green.

Closes #1719
Refs TBD-A6c

🤖 Generated with [Claude Code](https://claude.com/claude-code)