### PR TITLE
fix(catalyst-api): wire CATALYST_GITOPS_TOKEN env from cutover-minted token (Closes #1745)

### DIFF
--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -1154,8 +1154,32 @@ name: bp-catalyst-platform
 # GITHUB_TOKEN bytes verbatim. Bootstrap branch (gitea-admin-secret
 # password mirror) is preserved for the first-install pre-cutover window
 # so the provisioning Pod still boots out of CreateContainerConfigError.
-version: 1.4.169
-appVersion: 1.4.169
+version: 1.4.170
+appVersion: 1.4.170
+# 1.4.170 — fix(catalyst-api): wire CATALYST_GITOPS_TOKEN env from the
+# cutover-minted Gitea API token (Closes #1745, Refs TBD-C18). The
+# api-deployment env previously sourced CATALYST_GITOPS_TOKEN from
+# `gitea-admin-secret.password`, but (a) the admin password is NOT a
+# valid Gitea Bearer/token credential (Gitea resolves `Authorization:
+# token <X>` as a sha1 access-token lookup), and (b) the source Secret
+# reflects into `catalyst`, NOT `catalyst-system`, so the catalyst-api
+# Pod's same-namespace secretKeyRef silently resolved to empty. Net
+# effect on t22: POST /api/v1/sovereigns/{id}/marketplace returned 503
+# "gitops token unconfigured — set CATALYST_GITOPS_TOKEN" and every
+# SME tenant gitops commit failed the same way (cov-bench C8-003).
+#
+# Fix: repoint the secretKeyRef to `provisioning-github-token`.GITHUB_TOKEN
+# — the destination Secret bp-self-sovereign-cutover Step 09 writes the
+# minted Gitea API token into (annotated `catalyst.openova.io/token-source:
+# self-sovereign-cutover-step-09`). Add reflector annotations on
+# templates/sme-services/provisioning-github-token.yaml mirroring
+# `sme/provisioning-github-token` into `catalyst-system` so the
+# catalyst-api Pod can secretKeyRef the minted token from its own
+# namespace. CATALYST_GITOPS_USER becomes a literal "gitea_admin" (the
+# minted token's owning account) — no separate cross-namespace mirror
+# needed for a static string. optional=true preserves Catalyst-Zero
+# behaviour (no Gitea, no cutover; env stays empty; handler returns 503
+# as intended).
 # 1.4.166 — fix(catalog): seed 13 published Blueprints on Sovereign
 # handover (WBS row TBD-E8, C4-015). Adds templates/catalog-seed/
 # rendering an always-on baseline of 13 Blueprint CRs (bp-wordpress-

--- a/products/catalyst/chart/templates/api-deployment.yaml
+++ b/products/catalyst/chart/templates/api-deployment.yaml
@@ -888,28 +888,60 @@ spec:
                   key: qaApplications
                   optional: true
             # CATALYST_GITOPS_USER + CATALYST_GITOPS_TOKEN — basic-auth
-            # credentials embedded in the GitOps clone URL (issue #878).
+            # credentials embedded in the GitOps clone URL (issue #878,
+            # TBD-C18 token-source chain, issue #1745).
+            #
             # Pre-cutover (Catalyst-Zero): User=x-access-token, Token=GitHub
             # PAT (already wired via separate CATALYST_GITOPS_TOKEN secret on
-            # contabo). Post-cutover (Sovereign): User=gitea_admin,
-            # Token=<gitea-admin-password> from the local Gitea admin secret.
-            # The same secret (`gitea-admin-secret`) is mirrored into
-            # catalyst-system via the bp-reflector annotation block on
-            # bp-gitea (issue #866), so this Sovereign-side wiring works
-            # post-Day-2-Independence without a manual mirror step.
-            # optional=true: Catalyst-Zero (contabo) does not run the SME
-            # tenant pipeline.
+            # contabo).
+            #
+            # Post-cutover (Sovereign): User=gitea_admin, Token=<minted
+            # Gitea API token from bp-self-sovereign-cutover Step 09>.
+            # The Step 09 Job (platform/self-sovereign-cutover/chart/
+            # templates/09-gitea-token-mint-job.yaml) calls Gitea's
+            # POST /api/v1/users/gitea_admin/tokens at handover and
+            # writes the raw sha1 into Secret
+            # `sme/provisioning-github-token`.`GITHUB_TOKEN` with the
+            # provenance annotation `catalyst.openova.io/token-source=
+            # self-sovereign-cutover-step-09`. The same chart's
+            # templates/sme-services/provisioning-github-token.yaml
+            # carries reflector annotations mirroring that Secret into
+            # `catalyst-system` so this secretKeyRef resolves on the
+            # catalyst-api Pod (which lives in catalyst-system, not
+            # `sme`). K8s secretKeyRef is same-namespace-only — the
+            # reflector mirror is the canonical cross-namespace seam.
+            #
+            # WHY NOT gitea-admin-secret.password (the previous wiring):
+            # Gitea treats `Authorization: token <X>` as an API access
+            # token lookup (sha1 against `users` table), not as a
+            # password — so the admin PASSWORD authenticates over Basic
+            # but always 401s as a Bearer/token. Pre-#1745 this caused
+            # both /api/v1/sovereigns/{id}/marketplace AND every SME
+            # tenant gitops commit to return 503 "gitops token
+            # unconfigured" because the gitea-admin-secret reflection
+            # target is `catalyst` (not `catalyst-system`) — the
+            # secretKeyRef silently resolved to empty and the catalyst-
+            # api `loadGitOpsConfig()` returned Token="".
+            #
+            # CATALYST_GITOPS_USER stays a hardcoded `gitea_admin`
+            # literal (the Gitea admin owns the minted token; clone URLs
+            # of the form https://gitea_admin:<token>@gitea.../repo.git
+            # authenticate cleanly). No secretKeyRef needed for the
+            # user — keeping it literal avoids a second cross-namespace
+            # mirror just to ship a static account name.
+            #
+            # optional=true: Catalyst-Zero (contabo) does not run a
+            # local Gitea / Step 09 cutover Job — the env stays empty
+            # on the mothership, marketplace_settings.go returns 503
+            # there (intended behaviour, only Sovereigns persist
+            # marketplace overlays back to git).
             - name: CATALYST_GITOPS_USER
-              valueFrom:
-                secretKeyRef:
-                  name: gitea-admin-secret
-                  key: username
-                  optional: true
+              value: "gitea_admin"
             - name: CATALYST_GITOPS_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: gitea-admin-secret
-                  key: password
+                  name: provisioning-github-token
+                  key: GITHUB_TOKEN
                   optional: true
             # POOL_DOMAIN_MANAGER_URL — base URL of the central Pool Domain
             # Manager (PDM) ingress on Catalyst-Zero (contabo). Sovereign-

--- a/products/catalyst/chart/templates/sme-services/provisioning-github-token.yaml
+++ b/products/catalyst/chart/templates/sme-services/provisioning-github-token.yaml
@@ -160,6 +160,23 @@ metadata:
     # the provisioning Pod stays Running across reinstalls without a
     # restart-storm.
     helm.sh/resource-policy: keep
+    # Reflector mirror into `catalyst-system` (TBD-C18, issue #1745):
+    # the catalyst-api Pod (in catalyst-system) reads GITHUB_TOKEN via
+    # secretKeyRef to source CATALYST_GITOPS_TOKEN — the real Gitea
+    # API token minted by bp-self-sovereign-cutover Step 09. Without
+    # this mirror, catalyst-api's POST /api/v1/sovereigns/{id}/
+    # marketplace and the SME tenant gitops writer both return 503
+    # "gitops token unconfigured — set CATALYST_GITOPS_TOKEN" because
+    # K8s secretKeyRef is same-namespace-only and Step 09's destination
+    # lives in `sme`.
+    #
+    # Pattern mirrors sme-secrets.yaml's reflector block (same chart,
+    # same destination namespace) — see that file for the field-by-
+    # field rationale.
+    reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
+    reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "catalyst-system"
+    reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
+    reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: "catalyst-system"
     {{- if $cutoverOwned }}
     # bp-self-sovereign-cutover Step 09 has minted a real Gitea API
     # token and patched this Secret. Preserve the token-source +


### PR DESCRIPTION
## Summary

Cov-bench C8-003 on t22: operator toggle of `/settings/marketplace` returns `503 gitops token unconfigured — set CATALYST_GITOPS_TOKEN`. Same handler chain (sme_tenant_gitops.go) 503s identically when the SME tenant pipeline tries to commit overlays.

Two stacked bugs in `products/catalyst/chart/templates/api-deployment.yaml`:

1. `CATALYST_GITOPS_TOKEN` was sourced from `gitea-admin-secret.password`. Gitea resolves `Authorization: token <X>` as a sha1 access-token lookup — the admin password is not an access token. **PR #1704 (TBD-C18, Step 09)** already minted a real Gitea API token at cutover into `sme/provisioning-github-token`.GITHUB_TOKEN with annotation `catalyst.openova.io/token-source: self-sovereign-cutover-step-09`.
2. catalyst-api Pod lives in `catalyst-system`; `gitea-admin-secret` reflector mirror only targets `catalyst` (not `catalyst-system`). K8s `secretKeyRef` is same-namespace-only → silent resolve to empty (optional=true) → `loadGitOpsConfig()` returns Token="" → handler 503s.

## Fix

- Repoint `CATALYST_GITOPS_TOKEN` to `secretKeyRef: provisioning-github-token.GITHUB_TOKEN` (the destination of cutover Step 09's mint — the canonical C18 token-source destination).
- Add reflector annotations on `templates/sme-services/provisioning-github-token.yaml` mirroring `sme/provisioning-github-token` into `catalyst-system`. Pattern mirrors `sme-secrets.yaml`'s reflector block (same chart, same destination ns, same precedent set by PR #1625).
- Switch `CATALYST_GITOPS_USER` from a (broken) cross-namespace secretKeyRef to a hardcoded literal `gitea_admin` — Gitea clone URLs of the form `https://gitea_admin:<token>@gitea.../repo.git` authenticate cleanly.

Pre-cutover Catalyst-Zero behaviour unchanged: no Gitea, no Step 09, `optional=true` keeps env empty, handler returns 503 (intended).

Chart `1.4.169 → 1.4.170`.

## Test plan

- [ ] `helm lint products/catalyst/chart` passes
- [ ] `helm template` emits `CATALYST_GITOPS_TOKEN` `secretKeyRef.name: provisioning-github-token` + literal `CATALYST_GITOPS_USER: gitea_admin`
- [ ] Fresh prov runs Step 09; `kubectl -n catalyst-system get secret provisioning-github-token` exists (mirrored)
- [ ] `kubectl -n catalyst-system describe pod catalyst-api-* | grep CATALYST_GITOPS_TOKEN` resolves
- [ ] POST `/api/v1/sovereigns/{id}/marketplace` returns 200 + commitSha
- [ ] cov-bench C8-003 GREEN

Closes #1745
Refs TBD-C18

Generated with [Claude Code](https://claude.com/claude-code)