### PR TITLE
fix(catalyst-ui): Mothership auto-redirect on ?token= to Sovereign handover (Closes #1773)

### DIFF
--- a/products/catalyst/bootstrap/ui/src/main.tsx
+++ b/products/catalyst/bootstrap/ui/src/main.tsx
@@ -2,56 +2,73 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { RouterProvider } from '@tanstack/react-router'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { runMothershipTokenRedirect } from './shared/lib/mothershipTokenRedirect'
 import { router } from './app/router'
 import { bootstrapTenant } from './shared/lib/tenantDiscover'
 import { installFetchAuthInterceptor } from './shared/lib/authedFetch'
 import './app/globals.css'
 
-// Install the OIDC bearer-token fetch interceptor BEFORE any module
-// touches fetch(). Sovereign Console (chroot) holds the access_token
-// in sessionStorage after its own PKCE OIDC flow; without this
-// interceptor every /api/v1/ fetch would 401 because the SPA can't
-// set the catalyst_session cookie that the BE's session middleware
-// expects on mother. Mother itself keeps using cookies — the
-// interceptor is a transparent no-op when sessionStorage has no OIDC
-// tokens.
-installFetchAuthInterceptor()
-
-const queryClient = new QueryClient({
-  defaultOptions: {
-    queries: { staleTime: 30_000, retry: 1 },
-  },
-})
-
-const root = document.getElementById('root')
-if (!root) throw new Error('Root element not found')
-
 /**
- * Tenant discovery (issue #802, #795 [Q-mine-1]).
+ * Issue #1773 — DoD gate D0 (the founder's #1 pinned gate per
+ * `feedback_handover_redirect_is_critical_d0.md`).
  *
- * The same SPA bundle serves both otech-admin (`console.<otech-fqdn>`)
- * and SME-admin (`console.<sme-domain>` — free-subdomain
- * `console.acme.<otech-fqdn>` OR BYO domain `console.acme.com`).
- * Tenant context is discovered from `window.location.host` against
- * the back-end registry — NOT from path/subdomain string parsing —
- * so a BYO CNAME-fronted domain resolves the same way as a
- * platform-hosted subdomain.
+ * If the operator lands on the Mothership with a handover JWT
+ * (`?token=<JWT>`) on the URL — e.g. fresh tab from the wizard
+ * SuccessPage, share-link, browser history paste — bounce them
+ * straight to the Sovereign chroot's `/auth/handover` BEFORE we
+ * boot the router, install fetch interceptors, or render the DOM.
  *
- * Discovery is fire-and-forget at boot — the result is cached in
- * the tenantDiscover module so any component that needs it (sidebar
- * nav, OIDC bootstrap) reads `getTenantContext()` synchronously after
- * the promise settles. Failure modes (404 / 503 / network error) all
- * fall through to the catalyst-zero default surface — no throw, no
- * boot block.
+ * If `runMothershipTokenRedirect()` returns true the browser is
+ * already navigating away (window.location.replace). The remainder
+ * of bootstrap is skipped to avoid:
+ *
+ *   - flashing the Mothership Jobs UI before the navigation lands
+ *   - triggering the rootRoute auth gate on a host that is not
+ *     the operator's Sovereign (would redirect to /login pointlessly)
+ *   - racing fetch interceptors against the navigation
+ *
+ * On non-Mothership hosts and on Mothership-without-?token=, the
+ * function is a no-op and bootstrap proceeds normally.
  */
-void bootstrapTenant().catch(() => {
-  /* discovery failures are surfaced via getTenantContext().status; no boot abort. */
-})
+if (!runMothershipTokenRedirect()) {
+  installFetchAuthInterceptor()
 
-createRoot(root).render(
-  <StrictMode>
-    <QueryClientProvider client={queryClient}>
-      <RouterProvider router={router} />
-    </QueryClientProvider>
-  </StrictMode>
-)
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { staleTime: 30_000, retry: 1 },
+    },
+  })
+
+  const root = document.getElementById('root')
+  if (!root) throw new Error('Root element not found')
+
+  /**
+   * Tenant discovery (issue #802, #795 [Q-mine-1]).
+   *
+   * The same SPA bundle serves both otech-admin (`console.<otech-fqdn>`)
+   * and SME-admin (`console.<sme-domain>` — free-subdomain
+   * `console.acme.<otech-fqdn>` OR BYO domain `console.acme.com`).
+   * Tenant context is discovered from `window.location.host` against
+   * the back-end registry — NOT from path/subdomain string parsing —
+   * so a BYO CNAME-fronted domain resolves the same way as a
+   * platform-hosted subdomain.
+   *
+   * Discovery is fire-and-forget at boot — the result is cached in
+   * the tenantDiscover module so any component that needs it (sidebar
+   * nav, OIDC bootstrap) reads `getTenantContext()` synchronously after
+   * the promise settles. Failure modes (404 / 503 / network error) all
+   * fall through to the catalyst-zero default surface — no throw, no
+   * boot block.
+   */
+  void bootstrapTenant().catch(() => {
+    /* discovery failures are surfaced via getTenantContext().status; no boot abort. */
+  })
+
+  createRoot(root).render(
+    <StrictMode>
+      <QueryClientProvider client={queryClient}>
+        <RouterProvider router={router} />
+      </QueryClientProvider>
+    </StrictMode>,
+  )
+}

--- a/products/catalyst/bootstrap/ui/src/shared/lib/mothershipTokenRedirect.test.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/lib/mothershipTokenRedirect.test.ts
@@ -1,0 +1,207 @@
+/**
+ * Tests for mothershipTokenRedirect.ts — issue #1773, DoD gate D0.
+ *
+ * The pure-function `decideMothershipTokenRedirect` is the only thing
+ * we can unit-test in jsdom — `runMothershipTokenRedirect()` calls
+ * `window.location.replace()` which jsdom flags as a navigation we
+ * can't actually fire from a test. The decision function is the
+ * behaviour worth pinning down.
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  decideMothershipTokenRedirect,
+  extractChrootConsoleURL,
+} from './mothershipTokenRedirect'
+
+/**
+ * Build a minimal, non-signed JWT with the given payload for testing.
+ * Mirrors `buildFakeJWT` in `oidc.test.ts`.
+ */
+function buildFakeJWT(payload: Record<string, unknown>): string {
+  const header = btoa(JSON.stringify({ alg: 'none', typ: 'JWT' }))
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=/g, '')
+  const body = btoa(JSON.stringify(payload))
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=/g, '')
+  return `${header}.${body}.`
+}
+
+describe('extractChrootConsoleURL', () => {
+  it('returns origin from a string aud pointing at a chroot console', () => {
+    expect(extractChrootConsoleURL('https://console.t22.omantel.biz')).toBe(
+      'https://console.t22.omantel.biz',
+    )
+  })
+
+  it('returns origin from a single-entry array aud', () => {
+    expect(
+      extractChrootConsoleURL(['https://console.otech23.omani.works']),
+    ).toBe('https://console.otech23.omani.works')
+  })
+
+  it('strips path/query/hash and returns origin only', () => {
+    expect(
+      extractChrootConsoleURL('https://console.t22.omantel.biz/auth?x=y#z'),
+    ).toBe('https://console.t22.omantel.biz')
+  })
+
+  it('returns null for missing aud', () => {
+    expect(extractChrootConsoleURL(undefined)).toBeNull()
+    expect(extractChrootConsoleURL(null)).toBeNull()
+  })
+
+  it('returns null when aud points back at the Mothership (self-loop guard)', () => {
+    expect(extractChrootConsoleURL('https://console.openova.io')).toBeNull()
+  })
+
+  it('returns null for non-https schemes', () => {
+    expect(extractChrootConsoleURL('http://console.t22.omantel.biz')).toBeNull()
+  })
+
+  it('returns null when hostname does not start with console.', () => {
+    expect(extractChrootConsoleURL('https://auth.t22.omantel.biz')).toBeNull()
+  })
+
+  it('returns null for non-URL strings', () => {
+    expect(extractChrootConsoleURL('not-a-url')).toBeNull()
+    expect(extractChrootConsoleURL('')).toBeNull()
+  })
+
+  it('returns null for non-string non-array shapes', () => {
+    expect(extractChrootConsoleURL(42)).toBeNull()
+    expect(extractChrootConsoleURL({ aud: 'x' })).toBeNull()
+  })
+})
+
+describe('decideMothershipTokenRedirect', () => {
+  it('returns the chroot /auth/handover URL when ?token= carries an aud pointing at a Sovereign chroot', () => {
+    const token = buildFakeJWT({
+      aud: ['https://console.t22.omantel.biz'],
+      sovereign_fqdn: 't22.omantel.biz',
+      exp: 9999999999,
+    })
+    const url = decideMothershipTokenRedirect({
+      hostname: 'console.openova.io',
+      search: `?token=${token}`,
+    })
+    expect(url).toBe(
+      `https://console.t22.omantel.biz/auth/handover?token=${encodeURIComponent(token)}`,
+    )
+  })
+
+  it('also accepts a string aud (non-array)', () => {
+    const token = buildFakeJWT({
+      aud: 'https://console.acme.example.com',
+    })
+    const url = decideMothershipTokenRedirect({
+      hostname: 'console.openova.io',
+      search: `?token=${token}`,
+    })
+    expect(url).toBe(
+      `https://console.acme.example.com/auth/handover?token=${encodeURIComponent(token)}`,
+    )
+  })
+
+  it('returns null when there is no ?token= query param', () => {
+    expect(
+      decideMothershipTokenRedirect({
+        hostname: 'console.openova.io',
+        search: '?other=value',
+      }),
+    ).toBeNull()
+    expect(
+      decideMothershipTokenRedirect({
+        hostname: 'console.openova.io',
+        search: '',
+      }),
+    ).toBeNull()
+  })
+
+  it('returns null when the hostname is not the Mothership', () => {
+    const token = buildFakeJWT({
+      aud: ['https://console.t22.omantel.biz'],
+    })
+    expect(
+      decideMothershipTokenRedirect({
+        hostname: 'console.t22.omantel.biz',
+        search: `?token=${token}`,
+      }),
+    ).toBeNull()
+  })
+
+  it('returns null when the JWT is malformed (not 3 parts)', () => {
+    expect(
+      decideMothershipTokenRedirect({
+        hostname: 'console.openova.io',
+        search: '?token=not.a.valid.jwt.with.too.many.dots',
+      }),
+    ).toBeNull()
+    expect(
+      decideMothershipTokenRedirect({
+        hostname: 'console.openova.io',
+        search: '?token=garbage',
+      }),
+    ).toBeNull()
+  })
+
+  it('returns null when the JWT has no aud claim', () => {
+    const token = buildFakeJWT({ sub: 'user-1', exp: 9999999999 })
+    expect(
+      decideMothershipTokenRedirect({
+        hostname: 'console.openova.io',
+        search: `?token=${token}`,
+      }),
+    ).toBeNull()
+  })
+
+  it('returns null when aud points back at the Mothership (self-loop guard)', () => {
+    const token = buildFakeJWT({
+      aud: ['https://console.openova.io'],
+    })
+    expect(
+      decideMothershipTokenRedirect({
+        hostname: 'console.openova.io',
+        search: `?token=${token}`,
+      }),
+    ).toBeNull()
+  })
+
+  it('returns null when aud is not a chroot console URL', () => {
+    const token = buildFakeJWT({
+      aud: ['https://auth.t22.omantel.biz/realms/sovereign'],
+    })
+    expect(
+      decideMothershipTokenRedirect({
+        hostname: 'console.openova.io',
+        search: `?token=${token}`,
+      }),
+    ).toBeNull()
+  })
+
+  it('preserves the JWT verbatim across the redirect (no claim mutation)', () => {
+    // Sovereign-side /auth/handover does its own RS256 signature
+    // verification — we MUST forward the raw token without
+    // re-encoding the payload. Use a token whose body contains
+    // characters that would round-trip badly under naive base64
+    // mangling and assert the URL still contains it.
+    const token = buildFakeJWT({
+      aud: ['https://console.t22.omantel.biz'],
+      email: 'op+tag@example.com',
+      deployment_id: 'dep-123_ABC',
+    })
+    const url = decideMothershipTokenRedirect({
+      hostname: 'console.openova.io',
+      search: `?token=${token}`,
+    })
+    expect(url).not.toBeNull()
+    // The token in the URL is encodeURIComponent'd; reverse it and
+    // compare to the original to assert bit-for-bit preservation.
+    const u = new URL(url as string)
+    expect(u.searchParams.get('token')).toBe(token)
+    expect(u.pathname).toBe('/auth/handover')
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/shared/lib/mothershipTokenRedirect.ts
+++ b/products/catalyst/bootstrap/ui/src/shared/lib/mothershipTokenRedirect.ts
@@ -1,0 +1,174 @@
+/**
+ * mothershipTokenRedirect — Mothership UI bootstrap hook that intercepts
+ * a handover JWT carried as `?token=<JWT>` on any Mothership URL and
+ * redirects the browser to the Sovereign chroot's `/auth/handover` route.
+ *
+ * # Why this exists (issue #1773, DoD gate D0)
+ *
+ * The mothership exposes POST /api/v1/deployments/{id}/mint-handover-token
+ * which returns:
+ *
+ *   {
+ *     "token":       "<JWT>",
+ *     "redirectURL": "https://console.<sovereignFqdn>/auth/handover?token=<JWT>"
+ *   }
+ *
+ * The wizard's success page links the operator to that `redirectURL`. But
+ * when the operator opens the link in a fresh tab WHILE STILL POINTING
+ * AT the mothership (e.g. share-link, browser history, or any flow that
+ * pastes `?token=` onto a `console.openova.io/sovereign/*` URL), the
+ * mothership UI has historically just rendered its own page and stranded
+ * the operator on the Mothership Jobs / Apps view. Memory file
+ * `feedback_handover_redirect_is_critical_d0.md` calls this the #1 pinned
+ * gate above all other DoD verifications:
+ *
+ *   "Without auto-redirect to Sovereign Console after handoverFiredAt,
+ *    every other gate is invisible to the operator."
+ *
+ * # Contract
+ *
+ * On Mothership (console.openova.io) ONLY, examine `window.location.search`
+ * for a `token` query param.
+ *
+ *   1. If absent → no-op.
+ *   2. If present but malformed (not 3 dot-separated base64url parts, or
+ *      payload fails to JSON-parse) → no-op (leave the page to render).
+ *   3. If valid and the `aud` claim looks like a Sovereign chroot console
+ *      (string `https://console.<host>` OR an array containing one), then
+ *      construct `https://console.<host>/auth/handover?token=<JWT>` and
+ *      `window.location.replace()` it. The replace (not assign) means the
+ *      back button doesn't bounce the operator straight back into the
+ *      same redirect loop.
+ *   4. If the `aud` claim is missing OR doesn't match the chroot console
+ *      pattern → no-op (the token belongs to something else; let the page
+ *      render normally).
+ *
+ * This module is purely Mothership-side; on Sovereign hosts (basepath '/',
+ * hostname starts with `console.<sov-fqdn>` ≠ `console.openova.io`) the
+ * /auth/handover route in router.tsx owns the JWT — we don't want to
+ * double-redirect or interfere with it. The `isMothershipHost` check in
+ * `runMothershipTokenRedirect()` is the gate.
+ *
+ * # Why this lives separately from the existing HandoverRedirectBanner
+ *
+ * HandoverRedirectBanner (pages/sovereign/HandoverRedirectBanner.tsx)
+ * fires AFTER the user has logged into the Mothership and the deployment
+ * record's `handoverFiredAt` propagates via SSE — that's the "happy path"
+ * for an operator watching their own provisioning. This module covers
+ * the orthogonal case where the operator arrives with a raw `?token=`
+ * URL (e.g. clicking a wizard SuccessPage's "Open your Sovereign console"
+ * link in a fresh tab, or following a paste-back from email/Slack). The
+ * two paths are independent; both are needed.
+ */
+
+import { parseJWTClaims } from '@/shared/lib/oidc'
+
+/** The one hardcoded Mothership hostname. Mirrors detectMode.ts. */
+const MOTHERSHIP_HOSTNAME = 'console.openova.io'
+
+/**
+ * Extract the canonical Sovereign chroot console URL from the JWT's
+ * `aud` claim. The handover JWT contract (catalyst-api
+ * handover_jwt.go) sets aud to either:
+ *
+ *   - a single string  "https://console.<sovereignFqdn>"
+ *   - or an array      ["https://console.<sovereignFqdn>"]
+ *
+ * We accept both shapes. Anything else (missing, wrong scheme, host
+ * not starting with `console.`, host equal to the Mothership itself)
+ * returns null so the caller falls through to a no-op render.
+ */
+export function extractChrootConsoleURL(aud: unknown): string | null {
+  let candidate: string | null = null
+  if (typeof aud === 'string') {
+    candidate = aud
+  } else if (Array.isArray(aud)) {
+    // Find the first string entry that smells like a console URL.
+    for (const a of aud) {
+      if (typeof a === 'string') {
+        candidate = a
+        break
+      }
+    }
+  }
+  if (!candidate) return null
+
+  // Must be an absolute https URL whose host starts with "console." —
+  // anything else is not a Sovereign chroot console.
+  let parsed: URL
+  try {
+    parsed = new URL(candidate)
+  } catch {
+    return null
+  }
+  if (parsed.protocol !== 'https:') return null
+  if (!parsed.hostname.startsWith('console.')) return null
+  // Never self-redirect — if aud points to the Mothership we'd loop.
+  if (parsed.hostname === MOTHERSHIP_HOSTNAME) return null
+  // Strip path/query/hash — we only want the origin.
+  return `${parsed.protocol}//${parsed.host}`
+}
+
+/**
+ * Pure decision function — given the raw query string and a hostname,
+ * return the URL to redirect to, or null to skip. Extracted from
+ * `runMothershipTokenRedirect` so it can be unit-tested without
+ * mutating jsdom's window.location.
+ */
+export function decideMothershipTokenRedirect(params: {
+  hostname: string
+  search: string
+}): string | null {
+  if (params.hostname !== MOTHERSHIP_HOSTNAME) return null
+  let qs: URLSearchParams
+  try {
+    qs = new URLSearchParams(params.search)
+  } catch {
+    return null
+  }
+  const token = qs.get('token')
+  if (!token) return null
+  const claims = parseJWTClaims(token)
+  // parseJWTClaims returns {} on parse failure — defensively check
+  // that we got at least one well-formed key. The handover JWT
+  // always carries aud + exp + sovereign_fqdn; if none are present
+  // the token is malformed and we should not redirect.
+  if (
+    typeof claims !== 'object' ||
+    claims === null ||
+    Object.keys(claims).length === 0
+  ) {
+    return null
+  }
+  const chrootOrigin = extractChrootConsoleURL(claims.aud)
+  if (!chrootOrigin) return null
+  // Forward the raw JWT verbatim — the Sovereign-side
+  // /auth/handover handler (Agent C / catalyst-api) does full RS256
+  // signature verification, exp check, and aud-binding before
+  // accepting the session. We are purely a transport.
+  return `${chrootOrigin}/auth/handover?token=${encodeURIComponent(token)}`
+}
+
+/**
+ * Bootstrap-time side-effecting hook — call ONCE from main.tsx before
+ * any router state is initialised. If the current URL carries a
+ * handover JWT, we hard-replace the browser to the Sovereign chroot.
+ *
+ * Returns true if a redirect was kicked off (caller can short-circuit
+ * the rest of bootstrap if desired). Returns false on no-op.
+ *
+ * Safe to call in SSR / non-browser contexts — short-circuits to false.
+ */
+export function runMothershipTokenRedirect(): boolean {
+  if (typeof window === 'undefined') return false
+  const target = decideMothershipTokenRedirect({
+    hostname: window.location.hostname,
+    search: window.location.search,
+  })
+  if (!target) return false
+  // `replace` (not assign) — the original ?token= URL on the
+  // Mothership is not a useful history entry; bouncing the back
+  // button onto it would just re-fire the redirect.
+  window.location.replace(target)
+  return true
+}


### PR DESCRIPTION
## Summary

Closes #1773 — **DoD gate D0**, the founder's #1 pinned gate (memory: `feedback_handover_redirect_is_critical_d0.md`).

When the operator lands on `console.openova.io/sovereign/jobs?token=<JWT>` (fresh tab from wizard SuccessPage, share-link, browser history), the Mothership UI had **no `?token=` handler** and stranded the operator on the Mothership Jobs page indefinitely. The bundle had zero references to `mint-handover-token`, `redirectURL`, or any redirect logic.

## Wave 32 evidence (verified live on t22 chart 1.4.168)

1. `POST /sovereign/api/v1/deployments/{id}/mint-handover-token` returns `{ redirectURL, token }` as expected.
2. Navigating to `https://console.openova.io/sovereign/jobs?token=<JWT>` stays on Mothership — never redirects to `console.t22.omantel.biz/auth/handover`.
3. Without this redirect, every other DoD gate is invisible to the operator (memory: *"the fucking successful handover is still not there ... end user is not even aware if the sovereign environment is provisioned"*).

## Fix

New module `products/catalyst/bootstrap/ui/src/shared/lib/mothershipTokenRedirect.ts` runs at bootstrap **before** the router, fetch interceptor, or DOM render:

- Only fires on Mothership host (`console.openova.io`).
- Reads `?token=<JWT>` from `window.location.search`.
- Decodes the JWT payload (no signature verification — Sovereign-side `/auth/handover` does full RS256 verify + aud-binding via `catalyst-api/handover_jwt.go`).
- Extracts the `aud` claim. Per the Go contract, aud is `["https://console.<sovereignFqdn>"]` (array) or string form; both accepted.
- Constructs `https://console.<sovereignFqdn>/auth/handover?token=<JWT>` and `window.location.replace()` to it.
- Self-loop guard: refuses to redirect if aud points back at the Mothership.
- Malformed-JWT / missing-`?token=` / wrong-host all no-op.

`main.tsx` calls `runMothershipTokenRedirect()` first; if it returns true the rest of bootstrap (fetch interceptor, router, tenant discovery, DOM render) is skipped to avoid a Mothership UI flash during the hard-nav.

## Files changed

- **NEW** `products/catalyst/bootstrap/ui/src/shared/lib/mothershipTokenRedirect.ts` — decision function + bootstrap hook.
- **NEW** `products/catalyst/bootstrap/ui/src/shared/lib/mothershipTokenRedirect.test.ts` — 18 unit tests.
- `products/catalyst/bootstrap/ui/src/main.tsx` — guard the bootstrap side-effects on `runMothershipTokenRedirect()`.

## Test plan

- [x] `npx vitest run src/shared/lib/mothershipTokenRedirect.test.ts` — **18/18 pass**
- [x] `npx tsc --noEmit` — **clean**
- [x] `npx eslint src/` — **clean**
- [x] Pre-existing failures in `StepComponents.test.tsx` (CORTEX cascade, 29 tests) verified to ALSO fail on `origin/main` without these changes — not introduced here.
- [ ] **Operator verification on next prov:** POST `/mint-handover-token`, take the returned `token`, visit `https://console.openova.io/sovereign/jobs?token=<token>` — browser should hard-replace to `https://console.<sov-fqdn>/auth/handover?token=<token>` within 100ms (no Mothership flash).

## References

- Memory: `~/.claude/projects/-home-openova-repos-openova-private/memory/feedback_handover_redirect_is_critical_d0.md`
- Server-side contract: `products/catalyst/bootstrap/api/internal/handler/handover_jwt.go`
- Sovereign-side `/auth/handover` route: `products/catalyst/bootstrap/ui/src/app/router.tsx` lines 350-378

🤖 Generated with [Claude Code](https://claude.com/claude-code)