### PR TITLE
fix(tenant+sandbox): wire K8s client SA + NEWAPI_DEFAULT_CHANNELS default (Closes #1775, #1777)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -588,7 +588,7 @@ spec:
       # to the admin password byte, so every subsequent SME provisioning
       # call to Gitea returned 401 "user does not exist" and journey
       # step 16 (tenant repo creation) silently stuck.
-      version: 1.4.170
+      version: 1.4.171
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/clusters/_template/bootstrap-kit/19a-bp-sandbox.yaml
+++ b/clusters/_template/bootstrap-kit/19a-bp-sandbox.yaml
@@ -119,6 +119,17 @@ spec:
     env:
       hostCluster: ${SOVEREIGN_REGION_CANONICAL_LABEL}
       sovereignFQDN: ${SOVEREIGN_FQDN}
+      # TBD-D35c (Wave 32 verifier fix) — comma-separated list of
+      # NewAPI channel names the controller stamps as `allowed_channels`
+      # on every per-Sandbox token mint. Default `qwen` matches the
+      # only channel bp-newapi's channel-seed-job.yaml writes on a
+      # fresh Sovereign install (alias for `qwen3.6-bankdhofar`,
+      # products/sandbox/docs/newapi-proxy-contract.md §2). Per-
+      # Sovereign overlays MUST extend this list to mirror their
+      # channel rollout (e.g. `qwen,anthropic,openai`) — the chart's
+      # NoAllowedChannels guard fails every mint if this resolves to
+      # empty.
+      newapiDefaultChannels: ${SANDBOX_DEFAULT_CHANNELS:-qwen}
     runtime:
       newapiURL: https://newapi.${SOVEREIGN_FQDN}/v1
     # D31 active-hot-standby — when SOVEREIGN_ENABLE_HOT_STANDBY=true on

--- a/platform/sandbox/chart/values.yaml
+++ b/platform/sandbox/chart/values.yaml
@@ -42,12 +42,21 @@ env:
   # operator may override via per-Sovereign overlay.
   newapiBaseURL: "http://newapi.newapi.svc.cluster.local:3000"
   # Comma-separated list of NewAPI channel names every freshly-minted
-  # Sandbox token is allowed to target. Empty disables the token-mint
-  # path (controller logs + emits a NoAllowedChannels condition on
-  # affected Sandbox CRs). Operator MUST set this to the channels
-  # surfaced by the per-Sovereign NewAPI rollout (`qwen` today —
-  # products/sandbox/docs/newapi-proxy-contract.md §2).
-  newapiDefaultChannels: ""
+  # Sandbox token is allowed to target. The controller refuses to mint
+  # tokens with an empty channel set (NoAllowedChannels condition on
+  # the affected Sandbox CR — sandbox_controller.go:191), so Wave 32
+  # D35c verifier caught every Sandbox stuck on NoAllowedChannels
+  # because this defaulted to "".
+  #
+  # Default `qwen` per products/sandbox/docs/newapi-proxy-contract.md
+  # §2 — the only channel name surfaced today is the alias `qwen`
+  # backed by the `qwen3.6-bankdhofar` seed entry that bp-newapi's
+  # channel-seed-job.yaml writes on every Sovereign install. Operators
+  # MUST override on per-Sovereign overlays the moment they wire
+  # additional channels (e.g. `qwen,anthropic,openai`) — bootstrap-kit
+  # slot 19a substitutes `${SANDBOX_DEFAULT_CHANNELS:-qwen}` so the
+  # canonical knob lives on the Sovereign overlay's substitute map.
+  newapiDefaultChannels: "qwen"
 # runtime — Wave 8 per-Sandbox pty-server / MCP / NEWAPI wiring.
 # Surfaced as env on the controller; the controller renders these into
 # the per-Sandbox StatefulSet + Deployment + HTTPRoute.

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -1154,8 +1154,32 @@ name: bp-catalyst-platform
 # GITHUB_TOKEN bytes verbatim. Bootstrap branch (gitea-admin-secret
 # password mirror) is preserved for the first-install pre-cutover window
 # so the provisioning Pod still boots out of CreateContainerConfigError.
-version: 1.4.170
-appVersion: 1.4.170
+version: 1.4.171
+appVersion: 1.4.171
+# 1.4.171 — fix(tenant): TBD-D35a wire ServiceAccount token + narrow
+# RBAC for the SandboxOrchestrator. The tenant service's in-cluster
+# dynamic client built by main.go buildDynamicClient was silently
+# disabled on every Sovereign because the tenant SA carried
+# automountServiceAccountToken=false AND no Role granted verbs on
+# sandbox.openova.io. Result: every tenant.sandbox_requested event
+# ack-skipped and the Sandbox CR never materialised — Wave 32 D35a
+# verifier caught the WARN log
+# (`sandbox-orchestrator: kubernetes client unavailable —
+# orchestrator disabled`). Fix: flip
+# automountServiceAccountToken=true on both the SA + the pod spec,
+# plus a narrow Role+RoleBinding granting get+create on
+# sandboxes.sandbox.openova.io scoped to the `catalyst-system`
+# namespace (handlers.DefaultSandboxNamespace). Companion PR also
+# defaults the sandbox chart's NEWAPI_DEFAULT_CHANNELS env to `qwen`
+# (TBD-D35c) so the controller no longer fails per-Sandbox token mint
+# with NoAllowedChannels (sandbox_controller.go:191) — single channel
+# `qwen` is the alias for `qwen3.6-bankdhofar` per
+# products/sandbox/docs/newapi-proxy-contract.md §2, the only channel
+# bp-newapi's channel-seed-job.yaml writes on a fresh install.
+# Bootstrap-kit slot 19a substitutes ${SANDBOX_DEFAULT_CHANNELS:-qwen}
+# so per-Sovereign overlays may extend (e.g. `qwen,anthropic,openai`)
+# without forking the chart. Closes #1775, #1777.
+#
 # 1.4.170 — fix(catalyst-api): wire CATALYST_GITOPS_TOKEN env from the
 # cutover-minted Gitea API token (Closes #1745, Refs TBD-C18). The
 # api-deployment env previously sourced CATALYST_GITOPS_TOKEN from

--- a/products/catalyst/chart/templates/sme-services/serviceaccounts.yaml
+++ b/products/catalyst/chart/templates/sme-services/serviceaccounts.yaml
@@ -39,12 +39,55 @@ metadata:
   namespace: sme
 automountServiceAccountToken: false
 ---
+# tenant SA — TBD-D35a: tenant service hosts the SandboxOrchestrator
+# (core/services/tenant/handlers/sandbox_consumer.go) which materialises
+# Sandbox.sandbox.openova.io CRs in `catalyst-system` on every
+# `tenant.sandbox_requested` event. The orchestrator builds an in-cluster
+# dynamic client via rest.InClusterConfig() (main.go buildDynamicClient)
+# and silently disables itself with a WARN log when no SA token is
+# mounted — the exact symptom Wave 32 D35a verifier caught
+# (`kubernetes client unavailable — orchestrator disabled`). Flip
+# automountServiceAccountToken=true here (mirrored at pod spec in
+# tenant.yaml) so the in-cluster config path succeeds. The
+# tenant-sandbox-orchestrator Role + RoleBinding below grants the
+# narrow get+create verbs the orchestrator actually uses (issue #1775).
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: tenant
   namespace: sme
-automountServiceAccountToken: false
+automountServiceAccountToken: true
+---
+# TBD-D35a — narrow RBAC for the SandboxOrchestrator in the tenant
+# service. Only verbs the orchestrator actually exercises against the
+# dynamic.Interface in core/services/tenant/main.go: Get (idempotency
+# pre-check, ignored on NotFound) + Create (Sandbox CR materialisation).
+# Scoped to the `catalyst-system` namespace where every Sandbox CR
+# lands (handlers.DefaultSandboxNamespace) — a leaked tenant SA token
+# can NOT touch Sandbox CRs in other namespaces or any other CRD group.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: tenant-sandbox-orchestrator
+  namespace: catalyst-system
+rules:
+  - apiGroups: ["sandbox.openova.io"]
+    resources: ["sandboxes"]
+    verbs: ["get", "create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: tenant-sandbox-orchestrator
+  namespace: catalyst-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: tenant-sandbox-orchestrator
+subjects:
+  - kind: ServiceAccount
+    name: tenant
+    namespace: sme
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/products/catalyst/chart/templates/sme-services/tenant.yaml
+++ b/products/catalyst/chart/templates/sme-services/tenant.yaml
@@ -15,7 +15,17 @@ spec:
         app: sme-tenant
     spec:
       serviceAccountName: tenant
-      automountServiceAccountToken: false
+      # TBD-D35a — must be true so the SandboxOrchestrator
+      # (core/services/tenant/handlers/sandbox_consumer.go) can build an
+      # in-cluster dynamic client and materialise Sandbox CRs in
+      # `catalyst-system`. The companion narrow RBAC (Role +
+      # RoleBinding in serviceaccounts.yaml, verbs get/create on
+      # sandboxes.sandbox.openova.io scoped to catalyst-system) bounds
+      # the blast radius. Without this flip, main.go logs
+      # `sandbox-orchestrator: kubernetes client unavailable —
+      # orchestrator disabled` and silently skips the consumer, which
+      # Wave 32 D35a verifier caught on t26.
+      automountServiceAccountToken: true
       imagePullSecrets:
         - name: ghcr-pull
       containers:


### PR DESCRIPTION
## Summary

Wave 32 D35 verifier on t26 caught two adjacent Sandbox-plane bugs:

- **TBD-D35a (#1775)** — tenant service's SandboxOrchestrator logs `kubernetes client unavailable — orchestrator disabled` and silently skips every `tenant.sandbox_requested` event because the tenant SA carries `automountServiceAccountToken: false` (zero blast-radius default from #76) AND no Role grants verbs on `sandbox.openova.io`.
- **TBD-D35c (#1777)** — sandbox-controller fails every per-Sandbox token mint with `NoAllowedChannels` (`sandbox_controller.go:191`) because `NEWAPI_DEFAULT_CHANNELS` env defaulted to `""`.

## Fix

### #1775 (D35a)
- `products/catalyst/chart/templates/sme-services/serviceaccounts.yaml`: flip tenant SA `automountServiceAccountToken=true`; add Role `tenant-sandbox-orchestrator` (verbs: `get,create` on `sandboxes.sandbox.openova.io`) + RoleBinding scoped to `catalyst-system` namespace (matches `handlers.DefaultSandboxNamespace`).
- `products/catalyst/chart/templates/sme-services/tenant.yaml`: flip pod spec `automountServiceAccountToken=true` (defence-in-depth mirror of SA flag).
- Verbs `get,create` match exactly what `main.go newDynamicSandboxClient` exercises (Get for idempotency pre-check, Create for materialisation) — leaked SA token still cannot patch/delete Sandbox CRs or touch any other CRD group.

### #1777 (D35c)
- `platform/sandbox/chart/values.yaml`: default `env.newapiDefaultChannels` to `"qwen"` — the only channel alias `bp-newapi`'s `channel-seed-job.yaml` writes on a fresh Sovereign install (alias for `qwen3.6-bankdhofar` per `products/sandbox/docs/newapi-proxy-contract.md` §2).
- `clusters/_template/bootstrap-kit/19a-bp-sandbox.yaml`: wire `${SANDBOX_DEFAULT_CHANNELS:-qwen}` envsubst placeholder so per-Sovereign overlays can extend (e.g. `SANDBOX_DEFAULT_CHANNELS=qwen,anthropic,openai`) without forking the chart.

### Versioning
- `products/catalyst/chart/Chart.yaml` 1.4.170 → 1.4.171.
- `clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml` pin 1.4.170 → 1.4.171.

## Test plan

- [x] `helm lint products/catalyst/chart` clean
- [x] `helm lint platform/sandbox/chart` clean
- [x] `helm template ... products/catalyst/chart --set ingress.marketplace.enabled=true` — tenant SA renders with `automountServiceAccountToken: true`; Role + RoleBinding `tenant-sandbox-orchestrator` render in `catalyst-system`; tenant pod spec renders `automountServiceAccountToken: true`
- [x] `helm template ... platform/sandbox/chart --set enabled=true ...` — `NEWAPI_DEFAULT_CHANNELS` env renders with value `"qwen"`
- [ ] On next fresh prov: confirm tenant service log says `starting sandbox-orchestrator consumer` (not `kubernetes client unavailable`)
- [ ] On next fresh prov: confirm sandbox-controller no longer emits `NoAllowedChannels` Condition on freshly-minted Sandbox CRs

Closes #1775
Closes #1777

🤖 Generated with [Claude Code](https://claude.com/claude-code)