### PR TITLE
fix(sovereign-tls): include all parent_domains in Gateway listeners (Closes #1772)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/parent_domains.go
+++ b/products/catalyst/bootstrap/api/internal/handler/parent_domains.go
@@ -569,6 +569,27 @@ func (h *Handler) AddParentDomain(w http.ResponseWriter, r *http.Request) {
 		"domain", req.Name,
 		"role", role,
 	)
+	// Day-2 idempotent re-trigger note (issue #1772 — TBD-D30b).
+	// Persisting the new entry to dep.Request.ParentDomains makes
+	// the next provisioner.Provision call (Retry/Repair) re-write
+	// tofu.auto.tfvars.json with the updated parent_domains_yaml,
+	// which renders the additional Cilium Gateway listener pair on
+	// next-prov. For an ALREADY-RUNNING Sovereign, the Hetzner
+	// hcloud_server resource has no `ignore_changes = [user_data]`
+	// so a `tofu apply` from changed cloud-init would request a
+	// destructive server recreate — the operator workaround is to
+	// `kubectl patch kustomization sovereign-tls -n flux-system`
+	// on the live Sovereign and append the new zone to the
+	// `.spec.postBuild.substitute.PARENT_DOMAINS_LISTENERS_YAML`
+	// value. Long-term: add a Day-2 listener-patch step here that
+	// reaches into the Sovereign apiserver via the persisted
+	// kubeconfig (out of scope for the #1772 ship).
+	h.log.Info("parent-domain post-add: operator must patch live Sovereign Kustomization to surface listener for the new zone",
+		"domain", req.Name,
+		"target", "Kustomization/sovereign-tls in flux-system on Sovereign",
+		"field", ".spec.postBuild.substitute.PARENT_DOMAINS_LISTENERS_YAML",
+		"reason", "hcloud_server user_data is not ignored — tofu apply would recreate the server. Fresh provs already render the listener.",
+	)
 	writeJSON(w, http.StatusCreated, ParentDomain{
 		Name:          name,
 		Role:          ParentDomainRole(role),

--- a/products/catalyst/bootstrap/api/internal/provisioner/parent_domains_test.go
+++ b/products/catalyst/bootstrap/api/internal/provisioner/parent_domains_test.go
@@ -539,6 +539,194 @@ func TestWriteTfvars_EmitsParentDomainsRoundTripsEntries(t *testing.T) {
 	}
 }
 
+// TestWriteTfvars_EmitsParentDomainsYAMLForSMEPool is the regression
+// guard for issue #1772 (TBD-D30b — Cilium Gateway missing
+// *.omani.homes listener on t22). Before this fix, catalyst-api wrote
+// the structural `parent_domains` JSON array but never set
+// `parent_domains_yaml` — the YAML-string variable the OpenTofu
+// module actually reads to derive the per-zone Cilium Gateway
+// listeners. The module's single-zone fallback then silently
+// dropped every sme-pool entry the operator added.
+//
+// This test asserts that a multi-domain Request renders
+// parent_domains_yaml as a JSON-flow array carrying BOTH the
+// primary AND every sme-pool entry, with name + role fields. The
+// downstream terraform local `yamldecode(parent_domains_yaml)`
+// produces a list with len == #zones, and the listener-rendering
+// local emits one HTTPS/HTTP pair per zone.
+func TestWriteTfvars_EmitsParentDomainsYAMLForSMEPool(t *testing.T) {
+	dir, err := os.MkdirTemp("", "writeTfvars-pdyaml-*")
+	if err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	defer os.RemoveAll(dir)
+
+	req := Request{
+		SovereignFQDN:    "t22.omantel.biz",
+		OrgName:          "Omantel",
+		OrgEmail:         "ops@omantel.biz",
+		HetznerToken:     "tok",
+		HetznerProjectID: "p1",
+		Region:           "fsn1",
+		WorkerCount:      2,
+		ParentDomains: []ParentDomain{
+			{Name: "omantel.biz", Role: ParentDomainRolePrimary, RegistrarKind: "dynadot"},
+			{Name: "omani.homes", Role: ParentDomainRoleSMEPool, RegistrarKind: "dynadot"},
+		},
+	}
+	if err := writeTfvars(dir, req); err != nil {
+		t.Fatalf("writeTfvars: %v", err)
+	}
+	raw, err := os.ReadFile(dir + "/tofu.auto.tfvars.json")
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	var parsed map[string]any
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	got, ok := parsed["parent_domains_yaml"].(string)
+	if !ok {
+		t.Fatalf("parent_domains_yaml must be a string, got %T: %v",
+			parsed["parent_domains_yaml"], parsed["parent_domains_yaml"])
+	}
+	if got == "" {
+		t.Fatalf("parent_domains_yaml MUST be non-empty when ParentDomains is populated. Empty falls through to single-zone fallback and drops every sme-pool entry. Got: %q", got)
+	}
+	// The literal must be a JSON-flow array (yamldecode-compatible) so
+	// the OpenTofu module's `yamldecode(var.parent_domains_yaml)` parses
+	// it as a list of objects. Re-parse here as the module would.
+	var entries []map[string]any
+	if err := json.Unmarshal([]byte(got), &entries); err != nil {
+		t.Fatalf("parent_domains_yaml must be JSON-flow / YAML-decodable: %v\nRaw: %s", err, got)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("parent_domains_yaml should carry 2 entries (primary + sme-pool), got %d. Raw: %s", len(entries), got)
+	}
+	// The primary entry must be present and labelled.
+	wantNames := map[string]string{
+		"omantel.biz": ParentDomainRolePrimary,
+		"omani.homes": ParentDomainRoleSMEPool,
+	}
+	for _, e := range entries {
+		name, _ := e["name"].(string)
+		role, _ := e["role"].(string)
+		want, ok := wantNames[name]
+		if !ok {
+			t.Errorf("unexpected parent_domains_yaml entry name=%q", name)
+			continue
+		}
+		if role != want {
+			t.Errorf("entry name=%q role=%q want %q", name, role, want)
+		}
+		delete(wantNames, name)
+	}
+	if len(wantNames) != 0 {
+		t.Errorf("parent_domains_yaml missing entries: %v\nRaw: %s", wantNames, got)
+	}
+}
+
+// TestWriteTfvars_EmitsParentDomainsYAMLEmptyOnSingleZone verifies the
+// fall-through path: a Request with NO ParentDomains slice (the legacy
+// single-FQDN payload that hasn't been migrated yet) must emit
+// parent_domains_yaml == "" so the terraform module's
+// `coalesce(var.parent_domains_yaml, "<single-zone fallback>")` picks
+// the fallback derived from sovereign_fqdn. If we emitted "[]" here,
+// yamldecode would produce an empty list and the listener-rendering
+// local would emit ZERO listeners — even worse than the current bug.
+func TestWriteTfvars_EmitsParentDomainsYAMLEmptyOnSingleZone(t *testing.T) {
+	dir, err := os.MkdirTemp("", "writeTfvars-pdyaml-single-*")
+	if err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	defer os.RemoveAll(dir)
+
+	req := Request{
+		SovereignFQDN:    "solo.example.io",
+		OrgName:          "Solo",
+		OrgEmail:         "ops@example.io",
+		HetznerToken:     "tok",
+		HetznerProjectID: "p1",
+		Region:           "fsn1",
+		WorkerCount:      2,
+		// ParentDomains intentionally nil — legacy single-zone payload.
+	}
+	if err := writeTfvars(dir, req); err != nil {
+		t.Fatalf("writeTfvars: %v", err)
+	}
+	raw, err := os.ReadFile(dir + "/tofu.auto.tfvars.json")
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	var parsed map[string]any
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	got, ok := parsed["parent_domains_yaml"].(string)
+	if !ok {
+		t.Fatalf("parent_domains_yaml must be a string, got %T", parsed["parent_domains_yaml"])
+	}
+	if got != "" {
+		t.Errorf("parent_domains_yaml should be empty on single-zone payload (lets terraform module fall through to sovereign_fqdn fallback). Got: %q", got)
+	}
+}
+
+// TestParentDomainsYAMLLiteral_RoundTripsCleanly is a focused unit test
+// for the helper independent of writeTfvars. Verifies (a) zone names
+// are lowercased + trimmed (consistent with the rest of the codebase),
+// (b) missing Role defaults to "primary", (c) empty input → empty
+// string (not "[]") to preserve the terraform single-zone fallback.
+func TestParentDomainsYAMLLiteral_RoundTripsCleanly(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []ParentDomain
+		want string
+	}{
+		{
+			name: "empty slice → empty string",
+			in:   nil,
+			want: "",
+		},
+		{
+			name: "single primary",
+			in: []ParentDomain{
+				{Name: "omantel.biz", Role: ParentDomainRolePrimary},
+			},
+			want: `[{"name":"omantel.biz","role":"primary"}]`,
+		},
+		{
+			name: "primary + sme-pool (t22 scenario)",
+			in: []ParentDomain{
+				{Name: "omantel.biz", Role: ParentDomainRolePrimary},
+				{Name: "omani.homes", Role: ParentDomainRoleSMEPool},
+			},
+			want: `[{"name":"omantel.biz","role":"primary"},{"name":"omani.homes","role":"sme-pool"}]`,
+		},
+		{
+			name: "uppercase name is lowercased",
+			in: []ParentDomain{
+				{Name: "  OMANTEL.BIZ  ", Role: ParentDomainRolePrimary},
+			},
+			want: `[{"name":"omantel.biz","role":"primary"}]`,
+		},
+		{
+			name: "missing role defaults to primary",
+			in: []ParentDomain{
+				{Name: "lonely.zone"},
+			},
+			want: `[{"name":"lonely.zone","role":"primary"}]`,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := parentDomainsYAMLLiteral(tc.in)
+			if got != tc.want {
+				t.Errorf("parentDomainsYAMLLiteral mismatch:\n  got  %q\n  want %q", got, tc.want)
+			}
+		})
+	}
+}
+
 // TestDefaultRegistrarKindFromEnv proves Inviolable Principle #4 ──
 // the default registrar adapter id is overridable via env at runtime.
 // An operator running on a non-Dynadot registrar sets

--- a/products/catalyst/bootstrap/api/internal/provisioner/provisioner.go
+++ b/products/catalyst/bootstrap/api/internal/provisioner/provisioner.go
@@ -1342,6 +1342,34 @@ func writeTfvars(deployDir string, req Request) error {
 		// in a future module would fail on null.
 		"parent_domains": coalesceParentDomains(req.ParentDomains),
 
+		// Multi-domain YAML literal (issue #1772 — D30b SME-pool listener
+		// fix). infra/hetzner/variables.tf declares `variable
+		// "parent_domains_yaml"` (type=string, default="") and
+		// infra/hetzner/main.tf locals.parent_domains_decoded calls
+		// `yamldecode()` on its value to materialise the per-zone
+		// Cilium Gateway listeners (one HTTPS/HTTP pair per parent
+		// zone, hostnamed `*.<zone>`). When this tfvar is empty the
+		// module falls back to a single-entry list derived from
+		// sovereign_fqdn — which silently DROPS every sme-pool zone
+		// the operator added.
+		//
+		// Symptom on t22 (Wave 32 D27-D31 verifier): tfvars.parent_domains
+		// listed both `{omantel.biz, primary}` + `{omani.homes,
+		// sme-pool}` (this Go-side field) but the live Gateway
+		// advertised only `*.t22.omantel.biz` — the listener for
+		// `*.omani.homes` never rendered because the terraform local
+		// never saw the second zone. tenants on omani.homes hit the
+		// envoy default fallback cert and could not get TLS.
+		//
+		// Render parent_domains_yaml as a JSON-flow array literal
+		// (`[{name: "x", role: "y"}, ...]`). JSON-flow is a YAML
+		// superset — yamldecode() in the module accepts it natively,
+		// and json.Marshal produces output that's safe inside
+		// tofu.auto.tfvars.json without quoting hell. Empty
+		// ParentDomains → emit "" so the module's single-zone
+		// fallback (derived from sovereign_fqdn) kicks in cleanly.
+		"parent_domains_yaml": parentDomainsYAMLLiteral(req.ParentDomains),
+
 		// Contabo PowerDNS API key — interpolated by
 		// cloudinit-control-plane.tftpl into the Sovereign's
 		// `cert-manager/powerdns-api-credentials` Secret so
@@ -1786,6 +1814,67 @@ func coalesceParentDomains(pds []ParentDomain) []ParentDomain {
 		return []ParentDomain{}
 	}
 	return pds
+}
+
+// parentDomainsYAMLLiteral renders the parent-domain pool as a YAML
+// inline-array literal suitable for the OpenTofu module's
+// `var.parent_domains_yaml` (declared in infra/hetzner/variables.tf,
+// consumed by locals.parent_domains_decoded via yamldecode()).
+//
+// Issue #1772 (TBD-D30b — Cilium Gateway missing *.omani.homes listener
+// on t22): catalyst-api previously emitted only the structural
+// `parent_domains` JSON array — never the YAML-string variable the
+// terraform module actually reads. As a result the module's
+// listener-rendering local fell through to the single-zone fallback
+// `[{name: "<sovereign_fqdn>", role: "primary"}]` and every sme-pool
+// zone the operator added (e.g. omani.homes) was silently dropped
+// from the Cilium Gateway listeners. Tenant TLS on the missing zone
+// then failed with NET::ERR_CERT_COMMON_NAME_INVALID.
+//
+// Output shape — JSON-flow array, which is valid YAML (yamldecode()
+// accepts it natively). Each entry carries name + role; we
+// deliberately omit registrarKind/credsRef from the YAML so the
+// terraform module never sees per-domain secrets (those belong in
+// the catalyst-api persistent record only). Empty / nil slice → ""
+// so the module's single-zone fallback (derived from sovereign_fqdn)
+// kicks in cleanly.
+//
+// JSON-encoding via encoding/json guarantees correctly quoted strings
+// for any zone name + escapes any unexpected character; the resulting
+// scalar is embedded inside the tofu.auto.tfvars.json string value
+// without quoting hell.
+func parentDomainsYAMLLiteral(pds []ParentDomain) string {
+	if len(pds) == 0 {
+		return ""
+	}
+	type yamlEntry struct {
+		Name string `json:"name"`
+		Role string `json:"role"`
+	}
+	entries := make([]yamlEntry, 0, len(pds))
+	for _, pd := range pds {
+		name := strings.ToLower(strings.TrimSpace(pd.Name))
+		if name == "" {
+			continue
+		}
+		role := strings.TrimSpace(pd.Role)
+		if role == "" {
+			role = ParentDomainRolePrimary
+		}
+		entries = append(entries, yamlEntry{Name: name, Role: role})
+	}
+	if len(entries) == 0 {
+		return ""
+	}
+	out, err := json.Marshal(entries)
+	if err != nil {
+		// json.Marshal on []yamlEntry can only fail on cycles / unsupported
+		// types — none possible here. Defensive fallback to empty so the
+		// terraform single-zone path takes over rather than tripping
+		// yamldecode() on a malformed literal.
+		return ""
+	}
+	return string(out)
 }
 
 // mapDomainModeForTofu collapses the wizard's three-mode domain


### PR DESCRIPTION
## Summary

Wave 32 D27-D31 verifier on t22 found `tofu.auto.tfvars.json` correctly listing `parent_domains: [{omantel.biz, primary}, {omani.homes, sme-pool}]` but the live Cilium Gateway advertising only `*.t22.omantel.biz` — `*.omani.homes` never rendered as a listener, so sme-pool tenants hit envoy's default fallback cert.

## Root cause

`writeTfvars` emitted the structural `parent_domains` JSON array but never set `parent_domains_yaml` — the YAML-string variable `infra/hetzner/variables.tf` declares and `infra/hetzner/main.tf` `locals.parent_domains_decoded` actually `yamldecode()`s. With it empty, terraform's local fell through to the single-zone fallback `[{name: "<sovereign_fqdn>", role: "primary"}]`, silently dropping every sme-pool entry.

## Fix

- `writeTfvars` now renders `parent_domains_yaml` as a JSON-flow array literal carrying every parent_domains entry. JSON-flow is a YAML superset so the module's `yamldecode()` reads it natively.
- Empty `ParentDomains` still emits `""` so the legacy single-zone fallback path is preserved.
- `AddParentDomain` logs an operator hint about manually patching the live Sovereign's `Kustomization sovereign-tls` `postBuild.substitute.PARENT_DOMAINS_LISTENERS_YAML` for already-running clusters (hcloud_server has no `ignore_changes = [user_data]`, so a `tofu apply` would request a destructive server recreate).

## Test plan

- [x] `TestWriteTfvars_EmitsParentDomainsYAMLForSMEPool` — regression guard for the exact t22 scenario (primary + sme-pool).
- [x] `TestWriteTfvars_EmitsParentDomainsYAMLEmptyOnSingleZone` — fallback preserved for legacy single-zone payloads.
- [x] `TestParentDomainsYAMLLiteral_RoundTripsCleanly` — table-driven unit test (lowercasing, role defaulting, JSON-flow shape).
- [x] Existing `TestWriteTfvars_EmitsParentDomainsAsArrayNotNull` + `TestWriteTfvars_EmitsParentDomainsRoundTripsEntries` still pass.
- [x] `go build ./...` clean; `go vet ./...` clean; all `ParentDomain*` handler tests pass.
- [ ] Verify on next fresh prov with multi-domain payload that Gateway advertises listener pairs for every parent zone.

Closes #1772