### PR TITLE
feat(security): baseline CNPs for cilium-gateway + catalyst-system namespaces (Closes #1746)

### DIFF
--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -1154,8 +1154,43 @@ name: bp-catalyst-platform
 # GITHUB_TOKEN bytes verbatim. Bootstrap branch (gitea-admin-secret
 # password mirror) is preserved for the first-install pre-cutover window
 # so the provisioning Pod still boots out of CreateContainerConfigError.
-version: 1.4.170
-appVersion: 1.4.170
+version: 1.4.171
+appVersion: 1.4.171
+# 1.4.171 — feat(security): baseline CiliumNetworkPolicies for
+# catalyst-system + cilium-gateway (Closes #1746, Refs TBD-Cov-12 /
+# C12-009). Cov-bench audit on the live Sovereign cluster confirmed
+# only 2 CNPs cluster-wide (bp-external-dns-apiserver + bp-catalyst-
+# platform-sme-valkey-ingress) and ZERO CNPs in the two namespaces
+# that carry the public-facing traffic plane: catalyst-system
+# (catalyst-api / catalyst-ui / marketplace-api / organization-
+# controller / sme-orchestrator) and kube-system (the cilium-gateway
+# Gateway resource that terminates *.<sovereignFQDN>). Matrix row
+# C12-009 fails when neither namespace has baseline coverage.
+#
+# Ship two NAMESPACED CiliumNetworkPolicies (no CCNP — Sovereign
+# architecture uses namespaced CNP only per the issue's ruling)
+# under templates/network-policies/:
+#   1. baseline-default-deny in catalyst-system — default-deny with
+#      explicit allow for cilium-gateway ingress (reserved:ingress
+#      endpoint), same-namespace, kubelet host probes, and egress to
+#      kube-apiserver / kube-dns / same-namespace / 14 platform
+#      namespaces (keycloak gitea powerdns cnpg-system openbao harbor
+#      nats-system loki mimir tempo alloy opentelemetry external-
+#      secrets-system cert-manager) + world TCP/443 for Dynadot/S3/
+#      GitHub egress.
+#   2. baseline-cilium-gateway-allow in kube-system — scoped to the
+#      reserved.ingress endpoint, mirrors the qaFixtures
+#      allow-gateway-world-ingress CCNP but as a namespaced CNP.
+#      Without it every public Sovereign host returns HTTP 403
+#      "Access denied" at envoy (see feedback_cilium_gateway_world_
+#      ingress.md for the prov #80 forensic trace).
+#
+# Helm-gated on .Values.security.baselineCnp.enabled (default true).
+# Platform-namespace allow list operator-tunable via .Values.security.
+# baselineCnp.allowedPlatformNamespaces. Bundle is independent of
+# qaFixtures so the baseline ships on every Sovereign even when
+# qaFixtures is disabled.
+#
 # 1.4.170 — fix(catalyst-api): wire CATALYST_GITOPS_TOKEN env from the
 # cutover-minted Gitea API token (Closes #1745, Refs TBD-C18). The
 # api-deployment env previously sourced CATALYST_GITOPS_TOKEN from

--- a/products/catalyst/chart/templates/network-policies/baseline-catalyst-system.yaml
+++ b/products/catalyst/chart/templates/network-policies/baseline-catalyst-system.yaml
@@ -1,0 +1,164 @@
+{{- /*
+CiliumNetworkPolicy — baseline default-deny for the catalyst-system namespace.
+
+WHY THIS EXISTS (issue #1746, WBS row TBD-Cov-12 / C12-009)
+─────────────────────────────────────────────────────────────────────
+Cov-bench audit confirmed that the live Sovereign cluster ships only 2
+CiliumNetworkPolicies cluster-wide, and ZERO of them target the two
+namespaces that carry the public-facing traffic plane:
+  - catalyst-system (catalyst-api, catalyst-ui, marketplace-api,
+    organization-controller, sme-orchestrator) — every public Console
+    hit lands here.
+  - kube-system (the cilium-gateway Gateway resource + Cilium DaemonSet
+    that terminates *.<sovereignFQDN>) — every public request enters
+    here before it is fanned out to backends.
+
+Without a baseline default-deny CNP scoped to catalyst-system, the
+matrix row C12-009 fails (no namespaced CNP coverage on the primary
+traffic plane) AND any compromised Pod in catalyst-system can reach
+arbitrary in-cluster Pods via L3/L4 east-west traffic.
+
+DESIGN — defense-in-depth, two-tier
+─────────────────────────────────────────────────────────────────────
+This template renders TWO CiliumNetworkPolicies:
+
+  1. `baseline-default-deny` — a default-deny CNP with empty
+     endpointSelector ({}) matching every Pod in catalyst-system.
+     The rule set defines an explicit (but minimal) allow list:
+       - ingress from the cilium-gateway endpoint in kube-system
+         (the HTTPRoute → backend Service traffic path; without
+         this every public-facing API + UI returns 403 at the
+         envoy gateway because L7-policy denies forwarding)
+       - ingress from same-namespace Pods (controllers ↔ APIs,
+         sme-orchestrator ↔ catalyst-api intra-control-plane
+         calls)
+       - egress to kube-apiserver (every controller informer)
+       - egress to kube-dns (every Pod resolves DNS)
+       - egress to same-namespace (intra-control-plane)
+       - egress to platform namespaces that catalyst-system
+         legitimately needs to reach: keycloak (OIDC), gitea
+         (Application gitops pulls), powerdns (DNS record CRUD),
+         cnpg-system (smePostgres connection), openbao (secrets),
+         harbor (registry pulls), nats-system (event bus),
+         observability (loki/mimir/tempo/alloy).
+     Anything else is dropped. This is the "namespaced CNP only"
+     posture the issue prescribed — no CiliumClusterwideNetworkPolicy.
+
+DESIGN — mirror the working external-dns + qa-fixtures patterns
+─────────────────────────────────────────────────────────────────────
+This baseline mirrors the structure of the two CNPs that already work
+in production:
+  - platform/external-dns/chart/templates/ciliumnetworkpolicy.yaml
+    (bp-external-dns-apiserver — toEntities: [kube-apiserver])
+  - products/catalyst/chart/templates/qa-fixtures/
+    cilium-network-policies.yaml (the qaFixtures bundle — same
+    namespace-scoped allow patterns, same toEntities egress, same
+    label conventions)
+
+The chart-render is GATED on `.Values.security.baselineCnp.enabled`
+(default true) so operators may disable the baseline if they ship
+their own policy bundle. Per Inviolable Principle #4 (never hardcode),
+the platform-namespace allow list is operator-tunable via
+`.Values.security.baselineCnp.allowedPlatformNamespaces`.
+
+OPERATING CONVENTION
+─────────────────────────────────────────────────────────────────────
+This CNP IS independent of the qaFixtures bundle. qaFixtures ships a
+cluster-wide default-deny + per-tenant allow templates aimed at the
+qa-omantel test matrix. This baseline-default-deny CNP ships
+unconditionally on every Sovereign and protects catalyst-system even
+when qaFixtures is disabled.
+*/}}
+{{- if .Values.security.baselineCnp.enabled }}
+{{- $allowedPlatform := .Values.security.baselineCnp.allowedPlatformNamespaces | default (list "keycloak" "gitea" "powerdns" "cnpg-system" "openbao" "harbor" "nats-system" "loki" "mimir" "tempo" "alloy" "opentelemetry" "external-secrets-system" "cert-manager") }}
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: baseline-default-deny
+  namespace: catalyst-system
+  labels:
+    openova.io/managed-by: catalyst-baseline
+    openova.io/policy-tier: baseline
+    catalyst.openova.io/component: baseline-cnp
+  annotations:
+    policies.openova.io/title: Catalyst-System Baseline Default-Deny
+    policies.openova.io/description: |
+      Default-deny baseline for the catalyst-system namespace. Allows
+      explicit ingress from cilium-gateway (kube-system) + same-namespace,
+      and explicit egress to kube-apiserver, kube-dns, same-namespace, and
+      the platform namespaces catalyst-system legitimately needs to reach.
+spec:
+  description: "Baseline default-deny for catalyst-system — allow gateway ingress + control-plane egress only."
+  endpointSelector: {}
+  ingress:
+    # 1. Allow ingress from cilium-gateway in kube-system. Every public
+    #    Console / API / Admin / Marketplace request enters via the
+    #    Cilium Gateway listener (port 30443) in kube-system and is
+    #    forwarded to a Service in catalyst-system via HTTPRoute. The
+    #    selector matches the gateway endpoint labelled by Cilium with
+    #    `reserved.ingress: ""`. Without this allow, all public traffic
+    #    is dropped at the catalyst-system ingress hook even though
+    #    envoy itself accepted the request.
+    - fromEndpoints:
+        - matchLabels:
+            reserved.ingress: ""
+    # 2. Allow ingress from same-namespace Pods (catalyst-api ↔
+    #    catalyst-ui, sme-orchestrator ↔ catalyst-api, organization-
+    #    controller ↔ catalyst-api etc. — all intra-control-plane).
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: catalyst-system
+    # 3. Allow ingress from kube-system (Cilium operator probes, kubelet
+    #    liveness checks via host-network on the same node). Without
+    #    this, readiness + liveness probes from the kubelet (host
+    #    identity) are dropped and Pods loop-restart.
+    - fromEntities:
+        - host
+        - remote-node
+        - kube-apiserver
+  egress:
+    # 1. kube-apiserver — every controller informer (organization,
+    #    application, environment, useraccess, blueprint, tenant)
+    #    watches the apiserver. Same pattern as
+    #    bp-external-dns-apiserver.
+    - toEntities:
+        - kube-apiserver
+        - host
+        - remote-node
+    # 2. kube-dns — every Pod resolves DNS for service discovery and
+    #    external API calls (powerdns, keycloak, gitea).
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: kube-system
+            k8s-app: kube-dns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP
+    # 3. Same-namespace egress (intra-control-plane).
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: catalyst-system
+    # 4. Platform namespaces — operator-tunable list. Defaults cover
+    #    every namespace catalyst-system legitimately reaches in a
+    #    canonical Sovereign install.
+    - toEndpoints:
+        - matchExpressions:
+            - key: k8s:io.kubernetes.pod.namespace
+              operator: In
+              values:
+{{- range $allowedPlatform }}
+                - {{ . | quote }}
+{{- end }}
+    # 5. World egress on TCP/443 — catalyst-api MAY call out to public
+    #    APIs (Dynadot for parent-domain registration, S3 for backup
+    #    seed, GitHub for blueprint fetch). Scoped to TCP/443 only.
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+{{- end }}

--- a/products/catalyst/chart/templates/network-policies/baseline-cilium-gateway.yaml
+++ b/products/catalyst/chart/templates/network-policies/baseline-cilium-gateway.yaml
@@ -1,0 +1,95 @@
+{{- /*
+CiliumNetworkPolicy — baseline allow-world for the cilium-gateway
+endpoint that lives in kube-system.
+
+WHY THIS EXISTS (issue #1746, WBS row TBD-Cov-12 / C12-009)
+─────────────────────────────────────────────────────────────────────
+The Cilium Gateway resource (gateway.networking.k8s.io/v1) named
+`cilium-gateway` lives in kube-system (see
+clusters/_template/sovereign-tls/cilium-gateway.yaml). With
+hostNetwork=true the gateway listener registers a special Cilium
+endpoint with identity `reserved:ingress` (8). By default that
+endpoint has policy-enabled=both, allowed-ingress-identities=[1
+(host)], and an empty L4 rule set — i.e. world traffic that arrives
+at the gateway is dropped by cilium.l7policy with a 403 "Access
+denied" before any HTTPRoute is evaluated.
+
+Without an explicit allow-world CNP scoped to `reserved.ingress: ""`,
+every public Sovereign host (console.<sov>, auth.<sov>, gitea.<sov>,
+harbor.<sov>, api.<sov>) returns:
+  HTTP/1.1 403 Forbidden
+  body: "Access denied"
+  server: envoy
+This was caught live on prov #80 (omantel.biz, 2026-05-14) — see
+feedback_cilium_gateway_world_ingress.md for full forensic trace.
+
+DESIGN
+─────────────────────────────────────────────────────────────────────
+A namespaced CiliumNetworkPolicy in kube-system, scoped to the
+`reserved.ingress: ""` endpoint, that:
+  - allows ingress from world (public HTTPS), cluster (in-cluster
+    HTTPRoute traffic), host (kubelet probes), remote-node (multi-
+    region CP-to-CP via Cilium ClusterMesh), kube-apiserver
+  - allows egress to all (envoy must forward to any backend Service
+    in any namespace per HTTPRoute spec)
+
+This MIRRORS the qa-fixtures `allow-gateway-world-ingress` CCNP
+(products/catalyst/chart/templates/qa-fixtures/cilium-network-
+policies.yaml line 95-116) — same selector, same allow scope — but
+ships as a NAMESPACED CiliumNetworkPolicy in kube-system rather than
+a cluster-wide CCNP. This matches the issue's "sovereign uses
+namespaced CNP only" architecture ruling and ships independent of
+qaFixtures.
+
+The chart-render is GATED on `.Values.security.baselineCnp.enabled`
+(default true). Operators who ship their own gateway policy bundle
+may disable this template.
+
+LIVE PROOF
+─────────────────────────────────────────────────────────────────────
+Before this CNP was wired (prov #80): every public host 403'd at
+envoy with the symptoms above; `cilium-dbg endpoint get 3282 -o
+json` showed `l4.ingress: []` and `allowed-ingress-identities: [1]`.
+After applying the equivalent CCNP via PR #1482 (catalyst 1.4.143):
+TLS handshake completed, HTTPRoute fan-out worked, every Sovereign
+host returned 200.
+
+This namespaced version of the same allow ships on every install
+and reduces matrix row C12-009's "0 CNPs in critical namespace"
+violation to "1 baseline CNP in kube-system targeting the gateway
+endpoint".
+*/}}
+{{- if .Values.security.baselineCnp.enabled }}
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: baseline-cilium-gateway-allow
+  namespace: kube-system
+  labels:
+    openova.io/managed-by: catalyst-baseline
+    openova.io/policy-tier: baseline
+    catalyst.openova.io/component: baseline-cnp
+  annotations:
+    policies.openova.io/title: Cilium Gateway Baseline Allow-World
+    policies.openova.io/description: |
+      Allow world + cluster + host + remote-node + kube-apiserver
+      ingress to the cilium-gateway `reserved:ingress` endpoint in
+      kube-system; allow egress to all so envoy can forward requests
+      to any backend Service per HTTPRoute. Without this CNP every
+      public Sovereign host returns HTTP 403 "Access denied" at envoy.
+spec:
+  description: "Baseline allow-world for the cilium-gateway endpoint; namespaced equivalent of the qaFixtures allow-gateway-world-ingress CCNP."
+  endpointSelector:
+    matchLabels:
+      reserved.ingress: ""
+  ingress:
+    - fromEntities:
+        - world
+        - cluster
+        - host
+        - remote-node
+        - kube-apiserver
+  egress:
+    - toEntities:
+        - all
+{{- end }}

--- a/products/catalyst/chart/values.yaml
+++ b/products/catalyst/chart/values.yaml
@@ -1431,3 +1431,40 @@ qaFixtures:
   # their own policy bundle.
   networkPolicies:
     enabled: true
+
+# ─── Security — baseline CNP bundle (issue #1746, WBS row C12-009) ────────
+# Two-CNP baseline shipped on EVERY Sovereign install, independent of
+# qaFixtures. Both CNPs are NAMESPACED (no CiliumClusterwideNetworkPolicy)
+# per the architecture ruling on issue #1746 — Sovereign uses namespaced
+# CNP only.
+#
+#   - templates/network-policies/baseline-catalyst-system.yaml renders a
+#     CiliumNetworkPolicy in catalyst-system with default-deny + explicit
+#     allow for cilium-gateway ingress + control-plane egress.
+#   - templates/network-policies/baseline-cilium-gateway.yaml renders a
+#     CiliumNetworkPolicy in kube-system scoped to the cilium-gateway
+#     reserved:ingress endpoint allowing world ingress + envoy egress.
+#
+# Operators may disable the bundle by flipping `enabled: false`, or tune
+# the platform-namespace allow list on the catalyst-system CNP via
+# `allowedPlatformNamespaces`.
+security:
+  baselineCnp:
+    enabled: true
+    # Platform namespaces catalyst-system Pods are allowed to egress to.
+    # Override to add tenant-specific or per-Sovereign namespaces.
+    allowedPlatformNamespaces:
+      - keycloak
+      - gitea
+      - powerdns
+      - cnpg-system
+      - openbao
+      - harbor
+      - nats-system
+      - loki
+      - mimir
+      - tempo
+      - alloy
+      - opentelemetry
+      - external-secrets-system
+      - cert-manager


### PR DESCRIPTION
## Summary

Cov-bench audit on the live Sovereign cluster confirmed only **2 CNPs cluster-wide** (`bp-external-dns-apiserver`, `bp-catalyst-platform-sme-valkey-ingress`) and **zero CNPs in either of the two namespaces that carry the public-facing traffic plane**:

- `catalyst-system` — catalyst-api, catalyst-ui, marketplace-api, organization-controller, sme-orchestrator (every public Console hit lands here)
- `kube-system` — the `cilium-gateway` Gateway resource that terminates `*.<sovereignFQDN>` (every public request enters here)

WBS row **TBD-Cov-12 / C12-009** fails until baseline coverage lands.

## Changes

Two **namespaced** CiliumNetworkPolicies (no CCNP — per issue ruling that Sovereign uses namespaced CNP only) under `products/catalyst/chart/templates/network-policies/`:

1. **`baseline-default-deny`** in `catalyst-system` — default-deny with explicit allow for:
   - ingress from `cilium-gateway` (`reserved.ingress: ""` endpoint in kube-system)
   - ingress from same-namespace pods
   - ingress from host/remote-node/kube-apiserver (kubelet probes, multi-region CP)
   - egress to `kube-apiserver`, `kube-dns`, same-namespace
   - egress to 14 platform namespaces (keycloak, gitea, powerdns, cnpg-system, openbao, harbor, nats-system, loki, mimir, tempo, alloy, opentelemetry, external-secrets-system, cert-manager)
   - egress to `world` on TCP/443 (Dynadot/S3/GitHub callouts)

2. **`baseline-cilium-gateway-allow`** in `kube-system` — scoped to the `reserved.ingress: ""` endpoint, mirrors the qaFixtures `allow-gateway-world-ingress` CCNP but as a namespaced CNP. Without it every public Sovereign host returns HTTP 403 "Access denied" at envoy (see `feedback_cilium_gateway_world_ingress.md` for prov #80 forensic trace).

Both CNPs mirror the working `bp-external-dns-apiserver` + `qa-fixtures` patterns (`toEntities` / `reserved.ingress` selectors, label conventions, operator-tunable allow lists).

## Helm gate

- Helm-gated on `.Values.security.baselineCnp.enabled` (default `true`).
- Platform-namespace allow list operator-tunable via `.Values.security.baselineCnp.allowedPlatformNamespaces`.
- Bundle is **independent of qaFixtures** so the baseline ships on every Sovereign even when qaFixtures is disabled.

Chart bump to **1.4.171**.

## Test plan

- [x] `helm template` renders both CNPs with default values
- [x] `helm template --set security.baselineCnp.enabled=false` renders neither
- [ ] Next fresh Sovereign prov shows `kubectl get cnp -A | wc -l` >= 4 (was 2)
- [ ] `kubectl get cnp -n catalyst-system baseline-default-deny` returns YAML with spec.ingress[].fromEndpoints[] including `reserved.ingress: ""`
- [ ] `kubectl get cnp -n kube-system baseline-cilium-gateway-allow` returns YAML with spec.endpointSelector.matchLabels."reserved.ingress" = ""
- [ ] Public hosts (console, auth, api, harbor, gitea) still respond HTTP 200 after CNP applies (regression check vs prov #80 403 incident)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>