### PR TITLE
fix(catalyst-api+catalog): SME bridge token for publish toggle + chroot RBAC assign wrapper

### DIFF
--- a/core/services/catalog/handlers/handlers.go
+++ b/core/services/catalog/handlers/handlers.go
@@ -17,15 +17,37 @@ type Handler struct {
 	Producer *events.Producer
 }
 
-// requireAdmin checks that the request was made by a superadmin.
+// requireAdmin checks that the request was made by a superadmin or a
+// Sovereign-admin.
+//
+// Two roles are accepted:
+//
+//   - "superadmin"      — direct OpenOva operations (Catalyst-Zero
+//     operators). Mints a token with role=superadmin via
+//     sharedauth.SMERoleFor when the bearer holds the `catalyst-owner`
+//     realm role.
+//   - "sovereign-admin" — franchisee operations on a franchised
+//     Sovereign. The chroot's catalyst-api bridges an operator's
+//     RS256 session into the SME mesh's HS256 wire contract
+//     (sme_billing_vouchers.go::mintSMEBridgeToken) and stamps the
+//     SME-vocabulary role from the operator's realm roles (per
+//     docs/FRANCHISE-MODEL.md §3 — sovereign-admin owns the franchise's
+//     marketplace catalog). Without this widening the chroot's bridge
+//     token is rejected with 403 on every publish toggle (C4-012 /
+//     #1735), even though the operator is the rightful admin of that
+//     Sovereign's catalog.
+//
+// "member" still 403s — read-only operators cannot mutate the
+// catalog.
 func requireAdmin(r *http.Request) error {
-	if middleware.RoleFromContext(r.Context()) != "superadmin" {
-		return errForbidden
+	switch middleware.RoleFromContext(r.Context()) {
+	case "superadmin", "sovereign-admin":
+		return nil
 	}
-	return nil
+	return errForbidden
 }
 
-var errForbidden = &httpError{status: http.StatusForbidden, msg: "superadmin role required"}
+var errForbidden = &httpError{status: http.StatusForbidden, msg: "superadmin or sovereign-admin role required"}
 
 type httpError struct {
 	status int

--- a/products/catalyst/bootstrap/api/cmd/api/main.go
+++ b/products/catalyst/bootstrap/api/cmd/api/main.go
@@ -1303,6 +1303,18 @@ func main() {
 		// first round-tripping to /sovereign/self.
 		rg.Get("/api/v1/sovereign/rbac/matrix", h.HandleSovereignRBACMatrix)
 
+		// C6-006 / #1739 — Sovereign-prefix RBAC assign surface. Same
+		// wire contract as /api/v1/sovereigns/{id}/rbac/assign but the
+		// active deployment id is resolved server-side from
+		// SOVEREIGN_FQDN + the catalyst_session cookie (mirrors
+		// HandleSovereignRBACMatrix one line above). The Sovereign
+		// Console's Members UI hits this seam directly so it doesn't
+		// have to round-trip /sovereign/self → /sovereigns/{id}/rbac/assign
+		// per click; without it every chroot-side assign 404'd or
+		// stamped a generic 500 `rbac-assign-failed: resource not
+		// found` when the FE constructed the path with an empty id.
+		rg.Post("/api/v1/sovereign/rbac/assign", h.HandleSovereignRBACAssign)
+
 		// TBD-E16 — Sovereign-prefix UserAccess listing. Chroot-friendly
 		// mirror of /api/v1/deployments/{depId}/admin/user-access; the
 		// depId is resolved server-side from SOVEREIGN_FQDN +

--- a/products/catalyst/bootstrap/api/internal/handler/rbac_assign.go
+++ b/products/catalyst/bootstrap/api/internal/handler/rbac_assign.go
@@ -326,7 +326,53 @@ func (h *Handler) HandleRBACAssign(w http.ResponseWriter, r *http.Request) {
 		writeNotFound(w, depID)
 		return
 	}
+	h.serveRBACAssign(w, r, dep, depID)
+}
 
+// HandleSovereignRBACAssign — POST /api/v1/sovereign/rbac/assign
+//
+// Chroot-friendly Sovereign-prefix wrapper around HandleRBACAssign
+// (C6-006 / #1739). Same request + response shape; resolves the active
+// Sovereign deployment from the in-cluster context via
+// resolveSovereignDeploymentID, mirroring the canonical seam established
+// by HandleSovereignRBACMatrix / HandleSovereignUsers / HandleSovereignSelf —
+// no {id} path param, server-side resolution of the active deployment.
+//
+// This is the seam the Sovereign Console's Members UI hits (the FE
+// previously round-tripped through /sovereign/self then constructed
+// /sovereigns/{id}/rbac/assign — one extra hop per click, and on a
+// chroot the path-with-{id} would have to use the synthesised
+// "sovereign-<fqdn>" id, which the wizard's persisted Deployment row
+// doesn't necessarily match). Without this wrapper every chroot-side
+// publish/assign click 404'd, or — when the wrapper was incorrectly
+// pointed at /sovereigns/{id}/rbac/assign with a missing id — 500'd
+// with `rbac-assign-failed: resource not found`.
+//
+// Mothership process (no SOVEREIGN_FQDN env, no handover cookie):
+// emit a structured 404 pointing at the per-deployment surface so
+// the UI can fall back gracefully.
+func (h *Handler) HandleSovereignRBACAssign(w http.ResponseWriter, r *http.Request) {
+	depID := resolveSovereignDeploymentID(r)
+	if depID == "" {
+		writeJSON(w, http.StatusNotFound, map[string]string{
+			"error":  "not-a-sovereign",
+			"detail": "this catalyst-api Pod is not running on a Sovereign cluster; use /api/v1/sovereigns/{id}/rbac/assign instead",
+		})
+		return
+	}
+	dep, ok := h.lookupDeploymentForInfra(depID)
+	if !ok {
+		writeNotFound(w, depID)
+		return
+	}
+	h.serveRBACAssign(w, r, dep, depID)
+}
+
+// serveRBACAssign is the shared body of the per-deployment and the
+// Sovereign-prefix RBAC assign handlers. Both surfaces consume the
+// identical request body (rbacAssignRequest) and emit the identical
+// response envelope (rbacAssignResponse).
+func (h *Handler) serveRBACAssign(w http.ResponseWriter, r *http.Request, dep *Deployment, depID string) {
 	// Authorization MUST happen before body decode so that callers with
 	// insufficient tier (viewer / developer) get a 403 even when they
 	// POST an empty body. Otherwise the body decoder rejects with 400
@@ -362,6 +408,21 @@ func (h *Handler) HandleRBACAssign(w http.ResponseWriter, r *http.Request) {
 	}
 	resp, status, prevTier, err := rbacAssignFindOrCreate(r.Context(), client, body, dep)
 	if err != nil {
+		// CRD-not-installed on the Sovereign side surfaces from the
+		// dynamic client as a NotFound with the literal "the server
+		// could not find the requested resource" — the
+		// useraccess-controller CRD ships separately from catalyst-api
+		// and may legitimately not be reconciled yet on a fresh
+		// Sovereign. C6-006 / #1739 hit this path: the handler used to
+		// stamp a generic 500 + `rbac-assign-failed`, hiding the real
+		// gap. Surface 503 + the canonical sovereign-cluster-unavailable
+		// envelope so the FE can render a "RBAC not provisioned yet —
+		// retry once useraccess CRD reconciles" hint, matching the
+		// shape every other UserAccess handler emits.
+		if apierrors.IsNotFound(err) {
+			writeUserAccessUnavailable(w, fmt.Errorf("useraccess CRD not installed on Sovereign cluster (yet); reconcile useraccess-controller and retry: %w", err))
+			return
+		}
 		h.log.Warn("rbac.assign: find-or-create failed", "depId", depID, "err", err)
 		writeJSON(w, status, map[string]string{
 			"error":  "rbac-assign-failed",

--- a/products/catalyst/bootstrap/api/internal/handler/sme_catalog_client.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sme_catalog_client.go
@@ -130,17 +130,41 @@ func (c *smeCatalogClient) PublishedBySlug(ctx context.Context) (map[string]bool
 // SetPublished — proxy PATCH /catalog/admin/apps/{slug}/publish to the
 // SME catalog. Used by HandleSovereignAppPublish. Returns the upstream
 // HTTP status verbatim (so a 404 from SME catalog stays 404, etc.).
-func (c *smeCatalogClient) SetPublished(ctx context.Context, slug string, published bool) (int, error) {
+//
+// Wire-shape: the SME catalog's SetAppPublished
+// (core/services/catalog/handlers/handlers.go:293) accepts the new
+// state via the `?value=true|false` query param — no JSON body. The
+// request body is therefore empty; passing one would be ignored.
+//
+// Auth: the SME catalog mounts JWTAuth on every /catalog/admin/* path
+// (core/services/catalog/main.go:79-85) and requireAdmin then enforces
+// role=superadmin. Without an Authorization header the upstream
+// returns 401 from JWTAuth ("missing or invalid authorization header")
+// — that's the C4-012 / #1735 symptom. The bearer is minted by the
+// caller (HandleSovereignAppPublish) via the canonical SME bridge
+// (sme_billing_vouchers.go's mintSMEBridgeToken — same HS256
+// `sme-secrets/JWT_SECRET` the gateway + billing service use) and
+// passed in here as the `bearer` argument. Empty bearer signals the
+// caller has no session; the SME catalog will then return 401 and the
+// chroot surfaces it verbatim so the UI shows the auth gap rather
+// than a silent success.
+func (c *smeCatalogClient) SetPublished(ctx context.Context, slug string, published bool, bearer string) (int, error) {
 	if strings.TrimSpace(slug) == "" {
 		return 0, fmt.Errorf("sme-catalog: slug is required")
 	}
-	url := fmt.Sprintf("%s/catalog/admin/apps/%s/publish", c.baseURL, slug)
-	body := strings.NewReader(fmt.Sprintf(`{"published":%v}`, published))
-	req, err := http.NewRequestWithContext(ctx, http.MethodPatch, url, body)
+	value := "false"
+	if published {
+		value = "true"
+	}
+	url := fmt.Sprintf("%s/catalog/admin/apps/%s/publish?value=%s", c.baseURL, slug, value)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPatch, url, nil)
 	if err != nil {
 		return 0, err
 	}
-	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	if strings.TrimSpace(bearer) != "" {
+		req.Header.Set("Authorization", "Bearer "+bearer)
+	}
 	resp, err := c.http.Do(req)
 	if err != nil {
 		return 0, err

--- a/products/catalyst/bootstrap/api/internal/handler/sovereign.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sovereign.go
@@ -733,9 +733,29 @@ func (h *Handler) HandleSovereignAppPublish(w http.ResponseWriter, r *http.Reque
 		})
 		return
 	}
+	// Mint the canonical SME bridge token so the upstream catalog's
+	// JWTAuth + requireAdmin admit this hop. Pre-bridge state (no
+	// Authorization header) ⇒ JWTAuth rejects with 401 "missing or
+	// invalid authorization header" — that's the C4-012 / #1735
+	// symptom. The bridge mirrors sme_billing_vouchers.go's
+	// mintSMEBridgeToken pattern: RS256 operator session → HS256
+	// token signed with sme-secrets/JWT_SECRET, role mapped via
+	// sharedauth.SMERoleFor. The upstream catalog's requireAdmin was
+	// widened in the same PR to accept "sovereign-admin" so a
+	// franchisee operator can manage their own Sovereign's
+	// marketplace catalog without a Catalyst-Zero ("superadmin")
+	// role. When the bridge is unwired (Sovereign without
+	// marketplace, or stale chart) the helper returns 503 which we
+	// surface verbatim so the FE renders an actionable
+	// "marketplace not enabled" message.
+	bearer, status, errResp := h.mintSMEBridgeToken(r)
+	if errResp != nil {
+		writeJSON(w, status, errResp)
+		return
+	}
 	ctx, cancel := context.WithTimeout(r.Context(), smeCatalogProbeBudget)
 	defer cancel()
-	status, err := smeCatalog().SetPublished(ctx, slug, body.Published)
+	status, err := smeCatalog().SetPublished(ctx, slug, body.Published, bearer)
 	if err != nil {
 		writeJSON(w, http.StatusServiceUnavailable, map[string]string{
 			"error":  "sme-catalog-unreachable",


### PR DESCRIPTION
## Summary

Ships two Cov-bench fixes in one PR (overlapping scope on the chroot-side `/api/v1/sovereign/*` surface + the SME services seam).

- **C4-012 / #1735 — Publish toggle 401**: chroot's `smeCatalog.SetPublished` did not send an `Authorization` header, so `catalog.sme`'s `JWTAuth` middleware short-circuited with 401 (surfaced to the FE as `sme-catalog-rejected: upstream returned 401`). Mint the canonical SME bridge token in `HandleSovereignAppPublish` (mirrors `sme_billing_vouchers.go::mintSMEBridgeToken`), forward as `Bearer`, and widen the catalog's `requireAdmin` to also admit `sovereign-admin` so franchisee operators can manage their own Sovereign's catalog per `docs/FRANCHISE-MODEL.md §3`. Also fixed: `SetPublished` now uses `?value=true|false` query param (matching the SME catalog's `SetAppPublished` route shape) rather than a JSON body the upstream silently ignored.
- **C6-006 / #1739 — RBAC assign 500**: add `HandleSovereignRBACAssign` at `POST /api/v1/sovereign/rbac/assign`, the chroot-friendly mirror of `/api/v1/sovereigns/{id}/rbac/assign` (resolves deployment id via `resolveSovereignDeploymentID`, mirrors `HandleSovereignRBACMatrix`). Extracted the existing handler body into `serveRBACAssign` so both surfaces share the wire contract. Also surface CRD-not-installed (`apierrors.IsNotFound`) from the dynamic create as 503 + `sovereign-cluster-unavailable` instead of a misleading generic 500 `rbac-assign-failed: resource not found`.

Closes #1735
Closes #1739

## Test plan

- [x] `go build ./...` clean in `products/catalyst/bootstrap/api` + `core/services/catalog`
- [x] `go test ./internal/handler -run "TestRBAC|TestRbac" -count=1` — all 12 RBAC tests PASS
- [x] `go test ./...` in `core/services/catalog/handlers` — PASS
- [ ] Runtime verify on next Sovereign provision: `curl PATCH /api/v1/sovereign/apps/wordpress/publish` returns 200 with bridge token; `curl POST /api/v1/sovereign/rbac/assign` returns the same wire envelope as the per-deployment surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)