### PR TITLE
fix(catalyst-api): return 503 useraccess-crd-not-installed on /rbac/assign when CRD missing (Closes #1739)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/rbac_assign.go
+++ b/products/catalyst/bootstrap/api/internal/handler/rbac_assign.go
@@ -362,6 +362,29 @@ func (h *Handler) HandleRBACAssign(w http.ResponseWriter, r *http.Request) {
 	}
 	resp, status, prevTier, err := rbacAssignFindOrCreate(r.Context(), client, body, dep)
 	if err != nil {
+		// Closes #1739: when the chroot Sovereign hasn't installed the
+		// UserAccess CRD yet (catalyst-controller / useraccess slice not
+		// rolled out, qa-fixtures off + bootstrap-kit pin predating the
+		// CRD ship, etc.) the apiserver returns NotFound on every List
+		// AND Create against the missing GVR. Pre-fix the raw apierror
+		// surfaced as a 500 with body
+		// `{"error":"rbac-assign-failed","detail":"... the server could
+		// not find the requested resource"}` — operator-visible noise
+		// with no actionable hint. Surface a 503 with an explicit
+		// "useraccess-crd-not-installed" code + the GVR the controller
+		// would need to install, so the matrix runner + the operator
+		// see a stable token and a clear cause.
+		if apierrors.IsNotFound(err) {
+			h.log.Warn("rbac.assign: UserAccess CRD missing on Sovereign",
+				"depId", depID,
+				"gvr", UserAccessGVR().String(),
+			)
+			writeJSON(w, http.StatusServiceUnavailable, map[string]string{
+				"error":  "useraccess-crd-not-installed",
+				"detail": "UserAccess CRD (" + UserAccessGVR().String() + ") is not installed on this Sovereign; bp-catalyst-platform must roll out the catalyst-useraccess controller + CRD before /rbac/assign can author UserAccess CRs",
+			})
+			return
+		}
 		h.log.Warn("rbac.assign: find-or-create failed", "depId", depID, "err", err)
 		writeJSON(w, status, map[string]string{
 			"error":  "rbac-assign-failed",

--- a/products/catalyst/bootstrap/api/internal/handler/rbac_assign_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/rbac_assign_test.go
@@ -372,6 +372,65 @@ func TestHandleRBACAssign_404OnUnknownDeployment(t *testing.T) {
 	}
 }
 
+// TestHandleRBACAssign_503WhenCRDMissing — Closes #1739. When the chroot
+// Sovereign hasn't installed the UserAccess CRD (catalyst-controller /
+// useraccess slice not rolled out yet, bp-catalyst-platform pin predating
+// the CRD ship) the apiserver returns NotFound on every List + Create
+// against the missing GVR. Pre-fix the raw apierror leaked as a
+// 500 `{"error":"rbac-assign-failed","detail":"... the server could not
+// find the requested resource"}` — operator-visible noise with no
+// actionable hint. Post-fix the handler returns 503 with
+// `{"error":"useraccess-crd-not-installed",...}` carrying the GVR the
+// controller needs to install.
+func TestHandleRBACAssign_503WhenCRDMissing(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	factory, client := fakeUserAccessDynamicFactory()
+	h.dynamicFactory = factory
+	dep := installUserAccessDeployment(t, h, "dep-rbac-no-crd")
+
+	// Simulate "CRD not installed" by intercepting BOTH list AND create
+	// with apierrors.NewNotFound — the same shape the apiserver returns
+	// when the GroupVersionResource is unknown (e.g. bp-catalyst-platform
+	// not yet rolled out on this Sovereign).
+	gr := schema.GroupResource{Group: userAccessGroup, Resource: userAccessResource}
+	client.PrependReactor("list", "useraccesses", func(a clienttesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewNotFound(gr, "")
+	})
+	client.PrependReactor("create", "useraccesses", func(a clienttesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewNotFound(gr, "")
+	})
+
+	body := rbacAssignRequest{
+		User: rbacAssignUserBody{KeycloakSubject: "alice"},
+		Tier: "developer",
+		Scope: []rbacAssignScopeBody{
+			{Key: "openova.io/application", Value: "wordpress"},
+		},
+	}
+	rec := callUserAccess(t, h, http.MethodPost,
+		"/api/v1/sovereigns/"+dep.ID+"/rbac/assign", body, registerRBACAssignRoute)
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status: got %d want 503; body=%s", rec.Code, rec.Body.String())
+	}
+	// writeJSON's enrichErrorBody injects `status: 503` (int) + `code: "503"`
+	// on 4xx/5xx bodies, so decode into map[string]any not map[string]string.
+	var resp map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v; body=%s", err, rec.Body.String())
+	}
+	if resp["error"] != "useraccess-crd-not-installed" {
+		t.Fatalf("error code: got %v want useraccess-crd-not-installed; body=%s",
+			resp["error"], rec.Body.String())
+	}
+	detail, _ := resp["detail"].(string)
+	if !strings.Contains(detail, "UserAccess CRD") {
+		t.Fatalf("detail should reference UserAccess CRD; got %q", detail)
+	}
+	if !strings.Contains(detail, "bp-catalyst-platform") {
+		t.Fatalf("detail should mention bp-catalyst-platform rollout; got %q", detail)
+	}
+}
+
 // ── A1: pure helpers ──────────────────────────────────────────────────
 
 func TestNormalizeScopeSlice_TrimsSortsDropsEmpty(t *testing.T) {


### PR DESCRIPTION
## Summary

When a chroot Sovereign hasn't installed the UserAccess CRD yet (catalyst-controller / useraccess slice not rolled out, `bp-catalyst-platform` pin predating the CRD ship, qa-fixtures off, etc.) the apiserver returns NotFound on every dynamic-client List + Create against the missing GroupVersionResource. Pre-fix the raw apierror leaked through `rbacAssignFindOrCreate` → handler as a 500:

```
POST /api/v1/sovereigns/{id}/rbac/assign
→ 500 {"error":"rbac-assign-failed","detail":"... the server could not find the requested resource"}
```

— operator-visible noise with no actionable hint. Caught live on the t22 wbs-cov runner (#1739 comment).

## Fix

Detect `apierrors.IsNotFound` on the `rbacAssignFindOrCreate` return path and emit a 503 with an actionable envelope:

```
→ 503 {"error":"useraccess-crd-not-installed",
       "detail":"UserAccess CRD (access.openova.io/v1alpha1, Resource=useraccesses) is not installed on this Sovereign; bp-catalyst-platform must roll out the catalyst-useraccess controller + CRD before /rbac/assign can author UserAccess CRs",
       "status":503, "code":"503"}
```

`apierrors.IsNotFound` supports wrapped errors (per `k8s.io/apimachinery@v0.36.1` docstring) so the `fmt.Errorf("list useraccesses: %w", err)` wrap in the List path is preserved.

Adds `TestHandleRBACAssign_503WhenCRDMissing` using fake dynamic-client reactors returning `apierrors.NewNotFound` on both list+create — the same shape the real apiserver emits when the GVR is unknown.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./internal/handler/ -run RBACAssign` passes (new test + all 30 existing)
- [ ] On a Sovereign without the UserAccess CRD: `POST /api/v1/sovereigns/{id}/rbac/assign` returns 503 with `useraccess-crd-not-installed`
- [ ] On a Sovereign WITH the CRD: existing happy-paths unaffected

Closes #1739

🤖 Generated with [Claude Code](https://claude.com/claude-code)