### PR TITLE
fix(marketplace): resolve _template path on chroot (Closes #1790)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/marketplace_settings.go
+++ b/products/catalyst/bootstrap/api/internal/handler/marketplace_settings.go
@@ -20,8 +20,14 @@
 //      docs/SECRET-ROTATION.md). The repo URL + branch reuse the same
 //      env vars as the provisioner cloud-init plumbing
 //      (CATALYST_GITOPS_REPO_URL, CATALYST_GITOPS_BRANCH).
-//   4. Open clusters/<sovereignFQDN>/bootstrap-kit/13-bp-catalyst-platform.yaml
-//      and patch:
+//   4. Open the bootstrap-kit overlay file 13-bp-catalyst-platform.yaml.
+//      Path resolution (resolveBootstrapKitDir, issue #1790):
+//        - Mothership / pre-cutover: clusters/<sovereignFQDN>/bootstrap-kit/
+//        - Sovereign chroot (SOVEREIGN_FQDN env set, post-cutover):
+//          clusters/_template/bootstrap-kit/ (the chroot Gitea only
+//          carries the canonical _template subtree)
+//        - CATALYST_BOOTSTRAP_KIT_PATH overrides both for tests.
+//      Patch:
 //        ingress.marketplace.enabled: bool
 //        marketplace.brand.name / tagline / primaryColor
 //      The yaml.v3 round-trip preserves comments + ordering — Flux on
@@ -253,6 +259,42 @@ func envOr(key, fallback string) string {
 	return fallback
 }
 
+// resolveBootstrapKitDir returns the GitOps-repo-relative path to the
+// bootstrap-kit directory for the marketplace overlay. The path depends
+// on which catalyst-api Pod is serving the request:
+//
+//   - Mothership / Catalyst-Zero (pre-cutover):
+//       clusters/<sovereignFQDN>/bootstrap-kit/
+//     Each Sovereign has its own per-FQDN subtree carved out of the
+//     openova-io/openova repo by the provisioner.
+//
+//   - Sovereign chroot (post-cutover):
+//       clusters/_template/bootstrap-kit/
+//     The chroot Gitea is seeded with the canonical _template subtree
+//     only (see clusters/_template/* and openova_flow_proxy.go's
+//     "clusters/_template/bootstrap-kit/56-bp-openova-flow-server.yaml"
+//     reference). The per-FQDN materialisation never happens on the
+//     chroot's Gitea — Flux on the chroot reads directly from
+//     _template/ with kustomize overlays. Issue #1790 (Wave 34): the
+//     handler hardcoded the mothership path and silently 500'd with
+//     "no such file or directory" when the marketplace toggle was
+//     pushed through the post-cutover Sovereign Console.
+//
+// Detection rule: SOVEREIGN_FQDN env is set on every chroot catalyst-api
+// Pod (cloud-init stamps it; see auth_handover.go:390 and rbac_matrix.go).
+// The mother never sets it. CATALYST_BOOTSTRAP_KIT_PATH is a runtime
+// override per INVIOLABLE-PRINCIPLES.md #4 so a future repository
+// re-layout doesn't require a code change.
+func resolveBootstrapKitDir(sovereignFQDN string) string {
+	if override := strings.TrimSpace(os.Getenv("CATALYST_BOOTSTRAP_KIT_PATH")); override != "" {
+		return override
+	}
+	if strings.TrimSpace(os.Getenv("SOVEREIGN_FQDN")) != "" {
+		return filepath.Join("clusters", "_template", "bootstrap-kit")
+	}
+	return filepath.Join("clusters", sovereignFQDN, "bootstrap-kit")
+}
+
 // writeMarketplaceOverlay clones the GitOps repo, edits the per-Sovereign
 // overlay file, commits, and pushes. Returns the new commit SHA on
 // success. The clone uses a t.TempDir-style scratch dir under
@@ -303,7 +345,8 @@ func writeMarketplaceOverlay(ctx context.Context, cfg gitOpsConfig, sovereignFQD
 		return "", fmt.Errorf("git config user.email: %w", err)
 	}
 
-	overlayPath := filepath.Join(repoDir, "clusters", sovereignFQDN, "bootstrap-kit", "13-bp-catalyst-platform.yaml")
+	relDir := resolveBootstrapKitDir(sovereignFQDN)
+	overlayPath := filepath.Join(repoDir, relDir, "13-bp-catalyst-platform.yaml")
 	raw, err := os.ReadFile(overlayPath)
 	if err != nil {
 		return "", fmt.Errorf("read overlay %s: %w", overlayPath, err)
@@ -328,7 +371,7 @@ func writeMarketplaceOverlay(ctx context.Context, cfg gitOpsConfig, sovereignFQD
 		return "", fmt.Errorf("write overlay: %w", err)
 	}
 
-	relPath := filepath.Join("clusters", sovereignFQDN, "bootstrap-kit", "13-bp-catalyst-platform.yaml")
+	relPath := filepath.Join(relDir, "13-bp-catalyst-platform.yaml")
 	if err := runGit(ctx, repoDir, "add", relPath); err != nil {
 		return "", fmt.Errorf("git add: %w", err)
 	}

--- a/products/catalyst/bootstrap/api/internal/handler/marketplace_settings_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/marketplace_settings_test.go
@@ -5,6 +5,88 @@ import (
 	"testing"
 )
 
+// TestResolveBootstrapKitDir locks in the fix for issue #1790 (Wave 34
+// cov-bench): on the Sovereign chroot the GitOps repo (chroot-local
+// Gitea) only carries clusters/_template/bootstrap-kit/, while the
+// mothership / Catalyst-Zero repo carries clusters/<fqdn>/bootstrap-kit/
+// per-Sovereign. The marketplace settings handler must pick the right
+// one or the toggle POST fails with 500 "no such file or directory".
+//
+// Detection rule:
+//   - SOVEREIGN_FQDN env set            -> chroot, use _template
+//   - SOVEREIGN_FQDN unset / whitespace -> mother,  use <fqdn>
+//   - CATALYST_BOOTSTRAP_KIT_PATH       -> runtime override, beats both
+func TestResolveBootstrapKitDir(t *testing.T) {
+	const fqdn = "omantel.omani.works"
+
+	cases := []struct {
+		name              string
+		sovereignFQDNEnv  string
+		setSovereignFQDN  bool
+		bootstrapKitPath  string
+		setBootstrapKit   bool
+		want              string
+	}{
+		{
+			name: "mother_no_envs",
+			want: "clusters/omantel.omani.works/bootstrap-kit",
+		},
+		{
+			name:             "mother_empty_sov_env_explicit",
+			sovereignFQDNEnv: "",
+			setSovereignFQDN: true,
+			want:             "clusters/omantel.omani.works/bootstrap-kit",
+		},
+		{
+			name:             "chroot_sov_set",
+			sovereignFQDNEnv: fqdn,
+			setSovereignFQDN: true,
+			want:             "clusters/_template/bootstrap-kit",
+		},
+		{
+			name:             "whitespace_sov_treated_as_unset",
+			sovereignFQDNEnv: "   ",
+			setSovereignFQDN: true,
+			want:             "clusters/omantel.omani.works/bootstrap-kit",
+		},
+		{
+			name:             "runtime_override_beats_chroot",
+			sovereignFQDNEnv: fqdn,
+			setSovereignFQDN: true,
+			bootstrapKitPath: "custom/path/bootstrap-kit",
+			setBootstrapKit:  true,
+			want:             "custom/path/bootstrap-kit",
+		},
+		{
+			name:             "runtime_override_beats_mother",
+			bootstrapKitPath: "alt/bootstrap-kit",
+			setBootstrapKit:  true,
+			want:             "alt/bootstrap-kit",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			// t.Setenv unsets the var on test end if it wasn't set
+			// before, so each subtest starts from the package-level
+			// state and gets a clean restore.
+			if c.setSovereignFQDN {
+				t.Setenv("SOVEREIGN_FQDN", c.sovereignFQDNEnv)
+			} else {
+				t.Setenv("SOVEREIGN_FQDN", "")
+			}
+			if c.setBootstrapKit {
+				t.Setenv("CATALYST_BOOTSTRAP_KIT_PATH", c.bootstrapKitPath)
+			} else {
+				t.Setenv("CATALYST_BOOTSTRAP_KIT_PATH", "")
+			}
+			if got := resolveBootstrapKitDir(fqdn); got != c.want {
+				t.Errorf("resolveBootstrapKitDir(%q)=%q, want %q", fqdn, got, c.want)
+			}
+		})
+	}
+}
+
 // TestPatchMarketplaceYAML_EnableSetsValues confirms the YAML patcher
 // flips ingress.marketplace.enabled to true and writes the brand fields
 // into the existing overlay structure used by every Sovereign.


### PR DESCRIPTION
## Summary

The marketplace_settings handler hardcoded `clusters/<sovereignFQDN>/bootstrap-kit/13-bp-catalyst-platform.yaml`. That path exists in the **mothership** GitOps repo (provisioner carves out a per-FQDN subtree) but **NOT** in the **chroot** Gitea, which only carries the canonical `clusters/_template/bootstrap-kit/` subtree (consistent with `openova_flow_proxy.go`, `phase1_watch.go`, and `sme_tenant_gitops.go` — all reference `clusters/_template/bootstrap-kit/...`).

Wave 34 v2 cov-bench surfaced this: after PR #1779 wired `GITOPS_TOKEN` through to the chroot Pod, the toggle reaches the chroot's Gitea but the push 500s with `no such file or directory`.

## Fix

Introduce `resolveBootstrapKitDir(sovereignFQDN)`:

| Condition | Returned path |
|---|---|
| `CATALYST_BOOTSTRAP_KIT_PATH` set (runtime override) | env value |
| `SOVEREIGN_FQDN` env set (chroot Pod) | `clusters/_template/bootstrap-kit` |
| `SOVEREIGN_FQDN` unset (mothership / Catalyst-Zero) | `clusters/<sovereignFQDN>/bootstrap-kit` |

`SOVEREIGN_FQDN` is the canonical chroot signal already used across this package (`auth_handover.go`, `deployments.go`, `jobs.go`, `rbac_matrix.go`). `CATALYST_BOOTSTRAP_KIT_PATH` honours INVIOLABLE-PRINCIPLES.md #4 — never hardcode a path that a future repo re-layout would force a code ship.

## Test plan

- [x] `go build ./products/catalyst/bootstrap/api/...` clean
- [x] `go vet ./internal/handler/` clean
- [x] `TestResolveBootstrapKitDir` covers mother / chroot / whitespace-as-unset / runtime override (6 subtests)
- [x] Pre-existing `TestPatchMarketplaceYAML_*`, `TestIsValidHexColor`, `TestInjectTokenIntoURL`, `TestRedactString` still green
- [ ] Wave 34 v3 cov-bench: marketplace POST on chroot returns 200 with commit_sha (verify with re-run after merge + image bake)

Closes #1790. Refs WBS TBD-C8b.