### PR TITLE
fix(bp-newapi): dedicated HTTPRoute for newapi.<fqdn> (Closes #1778)

### DIFF
--- a/clusters/_template/bootstrap-kit/80-newapi.yaml
+++ b/clusters/_template/bootstrap-kit/80-newapi.yaml
@@ -132,7 +132,7 @@ spec:
       # default so reflector mirrors into `catalyst-system` too.
       # 1.4.14 (current main, 2026-05-18): latest upstream-tracking
       # chart cut — includes 1.4.12's reflector fix.
-      version: 1.4.16
+      version: 1.4.17
       sourceRef:
         kind: HelmRepository
         name: bp-newapi
@@ -178,6 +178,20 @@ spec:
       tls:
         enabled: true
         issuer: letsencrypt-prod
+      # Cilium Gateway HTTPRoute for `newapi.<fqdn>` (TBD-D35d, issue
+      # #1778). Sandbox runtimes hit the LLM gateway at the URL the
+      # sandbox controller mints into their environment
+      # (`NEWAPI_BASE_URL=https://newapi.${SOVEREIGN_FQDN}/v1`). Without
+      # this HTTPRoute the marketplace `tenant-wildcard` (hostnames=
+      # `*.${SOVEREIGN_FQDN}`) absorbs every newapi.${SOVEREIGN_FQDN}
+      # request and forwards to the storefront `console` Service —
+      # blocking the entire BYOS Claude Code journey at the LLM gate.
+      # An exact-hostname HTTPRoute outranks the wildcard per Gateway
+      # API spec, so enabling this on every Sovereign restores LLM
+      # reachability without touching the marketplace wildcard.
+      httpRoute:
+        enabled: true
+        host: newapi.${SOVEREIGN_FQDN}
     auth:
       adminUI:
         mode: keycloak

--- a/platform/newapi/chart/Chart.yaml
+++ b/platform/newapi/chart/Chart.yaml
@@ -1,5 +1,17 @@
 apiVersion: v2
 name: bp-newapi
+# 1.4.17 (TBD-D35d #1778, 2026-05-18): add `httproute.yaml` template +
+# `ingress.httpRoute` values block so a Sovereign install can render a
+# Cilium Gateway HTTPRoute for `newapi.<sovereign-fqdn>` that outranks
+# the marketplace `tenant-wildcard` (`*.<sovereign-fqdn>`). Without this
+# the sandbox runtime's `NEWAPI_BASE_URL=https://newapi.<fqdn>/v1` hit
+# the wildcard, was forwarded to the storefront `console` Service, and
+# 502'd the entire BYOS Claude Code journey. The chart-managed HTTPRoute
+# lives in the `newapi` namespace (same as the Service backend), so no
+# cross-namespace ReferenceGrant is required. Default OFF (`ingress.
+# httpRoute.enabled: false`); the bootstrap-kit slot 80 overlay flips
+# it to true and supplies `host: newapi.${SOVEREIGN_FQDN}`.
+#
 # 1.4.15 (TBD-A11 #1765, 2026-05-18): fix `mkdir /data/logs: permission
 # denied` CrashLoopBackOff on every fresh Sovereign. The upstream
 # Calcium-Ion/new-api v0.13.2 binary writes ephemeral logs to
@@ -172,7 +184,7 @@ name: bp-newapi
 # composes on the next reconcile. helm template renders cleanly with
 # BOTH the missing-attestation state (no channel) AND the
 # fully-populated state (channel composed normally).
-version: 1.4.16
+version: 1.4.17
 appVersion: "0.13.2"
 description: |
   Catalyst Blueprint scratch chart for NewAPI — multi-tenant LLM

--- a/platform/newapi/chart/templates/httproute.yaml
+++ b/platform/newapi/chart/templates/httproute.yaml
@@ -1,0 +1,65 @@
+{{- /*
+Cilium Gateway HTTPRoute for `newapi.<sovereign-fqdn>` (TBD-D35d, issue
+#1778).
+
+Sandbox runtimes hit the LLM gateway at the URL the sandbox controller
+mints into their environment:
+
+  NEWAPI_BASE_URL=https://newapi.<sovereign-fqdn>/v1
+
+On a Sovereign with the Catalyst marketplace enabled, the catalyst chart
+ships a `tenant-wildcard` HTTPRoute (hostnames=`*.<fqdn>`) that backend-
+refs to the `console` Service in the `sme` namespace. Without a dedicated
+HTTPRoute for `newapi.<fqdn>`, every Sandbox request to the LLM gateway
+got absorbed by the wildcard and 502'd at the storefront — blocking the
+entire BYOS Claude Code journey (D35d).
+
+Gateway API hostname-matching prefers the most specific listener: an
+exact `newapi.<fqdn>` HTTPRoute wins over `*.<fqdn>`, so this template
+restores newapi's public reachability without modifying the marketplace
+wildcard.
+
+Same skip-render gate pattern as ingress.yaml: when the HTTPRoute is not
+enabled OR no hostname can be derived, the template emits nothing — the
+`helm template` smoke render still passes with default values, and a
+Sovereign overlay forgetting to set the host surfaces as "no HTTPRoute
+materialised" (caught by the bootstrap-kit smoke test).
+
+Per docs/INVIOLABLE-PRINCIPLES.md #4 every operationally-meaningful
+value (hostname, parentRef name/namespace/sectionName, backend port) is
+operator-overridable via values.yaml.
+*/ -}}
+{{- if and .Values.newapi.enabled .Values.ingress.httpRoute .Values.ingress.httpRoute.enabled -}}
+{{- $host := .Values.ingress.httpRoute.host -}}
+{{- if and (not $host) .Values.sovereignFQDN -}}
+{{- $host = printf "newapi.%s" .Values.sovereignFQDN -}}
+{{- end -}}
+{{- if $host -}}
+{{- $parent := .Values.ingress.httpRoute.parentRef | default dict -}}
+{{- $parentName := default "cilium-gateway" $parent.name -}}
+{{- $parentNs := default "kube-system" $parent.namespace -}}
+{{- $sectionName := default "https" $parent.sectionName -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "bp-newapi.fullname" . }}-public
+  labels:
+    {{- include "bp-newapi.labels" . | nindent 4 }}
+    catalyst.openova.io/component: newapi-public-route
+spec:
+  parentRefs:
+    - name: {{ $parentName | quote }}
+      namespace: {{ $parentNs | quote }}
+      sectionName: {{ $sectionName | quote }}
+  hostnames:
+    - {{ $host | quote }}
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: "/"
+      backendRefs:
+        - name: {{ include "bp-newapi.fullname" . }}
+          port: {{ .Values.service.port }}
+{{- end }}
+{{- end }}

--- a/platform/newapi/chart/values.yaml
+++ b/platform/newapi/chart/values.yaml
@@ -638,6 +638,41 @@ ingress:
   middleware:
     enabled: false
   annotations: {}
+  # ─── Cilium Gateway HTTPRoute (TBD-D35d / issue #1778) ─────────────────
+  # Dedicated HTTPRoute for `newapi.<sovereign-fqdn>` (the LLM-gateway
+  # public hostname Sandbox runtimes hit via MintSandboxToken-emitted
+  # `NEWAPI_BASE_URL=https://newapi.<fqdn>/v1`).
+  #
+  # Why a chart-managed HTTPRoute on Sovereigns: Catalyst's marketplace
+  # chart ships a `tenant-wildcard` HTTPRoute with `hostnames=*.<fqdn>`
+  # that backendRefs to `console`. Gateway API hostname matching prefers
+  # the most specific listener — an exact `newapi.<fqdn>` HTTPRoute wins
+  # over the `*.<fqdn>` wildcard — so this template restores newapi's
+  # public reachability without modifying the marketplace wildcard.
+  #
+  # Backend lives in the SAME `newapi` namespace as this chart (Service
+  # `newapi.newapi.svc:3000`), so no cross-namespace ReferenceGrant is
+  # required. parentRef defaults to `kube-system/cilium-gateway` (the
+  # Sovereign canonical Gateway shipped by sovereign-tls/cilium-gateway.yaml).
+  #
+  # Default OFF (`enabled: false`) — contabo-style Traefik clusters
+  # remain on the Traefik Ingress above. The Catalyst bootstrap-kit
+  # overlay (`clusters/_template/bootstrap-kit/80-newapi.yaml`) flips
+  # this to true for Sovereign installs.
+  httpRoute:
+    enabled: false
+    # Hostname for the HTTPRoute. Defaults to "newapi.<sovereignFQDN>"
+    # when empty AND .Values.sovereignFQDN is set; otherwise template
+    # render skips.
+    host: ""
+    parentRef:
+      name: cilium-gateway
+      namespace: kube-system
+      # Listener sectionName — single-zone Sovereigns use bare "https"
+      # per the t20 listener-naming convention; multi-zone Sovereigns
+      # override to "https-<sanitised-zone>" via the bootstrap-kit
+      # overlay.
+      sectionName: https
 # ─── NetworkPolicy ───────────────────────────────────────────────────────
 # Default-allow ingress from the platform's gateway namespace; egress
 # to Postgres, Valkey, Keycloak, in-cluster vLLM, DNS, and the operator-


### PR DESCRIPTION
## Summary

- **Issue**: TBD-D35d / #1778 — sandbox runtimes hit `https://newapi.<sov-fqdn>/v1` (the URL the sandbox controller mints into `NEWAPI_BASE_URL`), but the marketplace `tenant-wildcard` HTTPRoute (`*.<fqdn>` → `console`) absorbed every newapi.<fqdn> request and returned the storefront. The entire BYOS Claude Code journey 502'd at the LLM gate.
- **Fix**: add a chart-managed HTTPRoute to `bp-newapi` (`platform/newapi/chart/templates/httproute.yaml`) attached to the canonical `kube-system/cilium-gateway` Gateway. Gateway API hostname-matching prefers the most specific listener — an exact `newapi.<fqdn>` HTTPRoute outranks the `*.<fqdn>` wildcard without touching the marketplace template.
- **No ReferenceGrant**: HTTPRoute lives in the `newapi` namespace, same as the `newapi.newapi.svc:3000` Service backend.
- **Default OFF** (`ingress.httpRoute.enabled: false`). Bootstrap-kit slot 80 (`clusters/_template/bootstrap-kit/80-newapi.yaml`) flips it to true for Sovereigns, supplies `host: newapi.${SOVEREIGN_FQDN}`, and bumps the chart pin 1.4.16 → 1.4.17. Contabo-style Traefik clusters remain on the existing Traefik Ingress.

## Test plan

- [x] `helm template` with default values → 0 HTTPRoutes rendered (no behaviour change for Traefik installs).
- [x] `helm template` with `ingress.httpRoute.enabled=true` + `sovereignFQDN=t99.example.com` → 1 HTTPRoute with `hostnames: [newapi.t99.example.com]`.
- [x] `helm template` with `ingress.httpRoute.enabled=true` + explicit `ingress.httpRoute.host=custom.example.com` → 1 HTTPRoute with that host.
- [x] `helm template` with `ingress.httpRoute.enabled=true` but neither host nor sovereignFQDN → 0 HTTPRoutes (skip-render guard).
- [ ] Verify on fresh prov t23+: `kubectl -n newapi get httproute newapi-bp-newapi-public -o yaml` shows `Accepted=True`, `curl -k https://newapi.<sov-fqdn>/v1/models` no longer hits the storefront.

🤖 Generated with [Claude Code](https://claude.com/claude-code)