### PR TITLE
fix(sandbox): per-Sandbox disable idle-scaling (Closes #1725)

### DIFF
--- a/core/controllers/sandbox/internal/controller/sandbox_controller.go
+++ b/core/controllers/sandbox/internal/controller/sandbox_controller.go
@@ -256,6 +256,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		LLMGatewayTokenSecret: r.LLMGatewayTokenSecret,
 		BYOSSecretPrefix:      r.BYOSSecretPrefix,
 		IdleTimeoutMinutes:    r.IdleTimeoutMinutes,
+		IdleScalingDisabled:   sb.Spec.IdleScaling != nil && !sb.Spec.IdleScaling.Enabled,
 		NewAPIToken:           tokenValue,
 		NewAPITokenSecretName: fmt.Sprintf("sandbox-%s-newapi-token", ownerUID),
 		NewAPITokenExpiresAt:  tokenExpiresAt,

--- a/core/controllers/sandbox/internal/gitops/manifests.go
+++ b/core/controllers/sandbox/internal/gitops/manifests.go
@@ -59,6 +59,14 @@ type Inputs struct {
 	BYOSSecretPrefix      string
 	IdleTimeoutMinutes    int
 
+	// IdleScalingDisabled (TBD-D8b #1725) — when true the renderer
+	// stamps `openova.io/sandbox-idle-scaling-disabled=true` on the
+	// pty-server StatefulSet so the cluster-wide idle scaler skips it
+	// on every pass. Default false preserves the existing scale-to-zero
+	// policy. Sourced from Sandbox.spec.idleScaling.enabled (false →
+	// disabled true; nil OR true → disabled false).
+	IdleScalingDisabled bool
+
 	// Wave 9 — per-Sandbox NewAPI bearer rendered into a dedicated
 	// Secret manifest. When NewAPIToken is non-empty the renderer
 	// emits secret-newapi-token.yaml carrying stringData
@@ -246,6 +254,9 @@ metadata:
     app.kubernetes.io/component: pty-server
   annotations:
     openova.io/sandbox-idle-timeout-minutes: {{ .IdleTimeoutMinutes | quote }}
+{{- if .IdleScalingDisabled }}
+    openova.io/sandbox-idle-scaling-disabled: "true"
+{{- end }}
 spec:
   serviceName: pty-server
   replicas: {{ .Replicas }}

--- a/core/controllers/sandbox/internal/idlescaler/idlescaler.go
+++ b/core/controllers/sandbox/internal/idlescaler/idlescaler.go
@@ -76,6 +76,12 @@ const (
 	// External observers (operators, dashboards) can read this without
 	// hitting the pty-server endpoint directly.
 	AnnLastActivityAt = "openova.io/sandbox-last-activity-at"
+	// AnnIdleScalingDisabled — set by the renderer when Sandbox CR
+	// carries `spec.idleScaling.enabled=false`. The IdleScaler skips
+	// the StatefulSet on every pass (TBD-D8b #1725 — long-running
+	// agent workloads that idle for hours but must stay Running).
+	// Truthy values: 1, t, true (case-insensitive).
+	AnnIdleScalingDisabled = "openova.io/sandbox-idle-scaling-disabled"
 
 	// NamespacePrefix limits the scaler to namespaces the renderer
 	// creates (`sandbox-<owner-uid>`). Any StatefulSet that somehow
@@ -245,6 +251,14 @@ func (s *Scaler) runOnce(ctx context.Context) error {
 func (s *Scaler) processOne(ctx context.Context, ss *appsv1.StatefulSet, now time.Time) (bool, error) {
 	log := s.log.WithValues("namespace", ss.Namespace, "name", ss.Name)
 
+	// TBD-D8b #1725 — per-Sandbox opt-out. The renderer stamps the
+	// disabled annotation when Sandbox.spec.idleScaling.enabled=false.
+	// Skip entirely: no probe, no annotation patch, no scale decision.
+	if isIdleScalingDisabled(ss) {
+		log.V(1).Info("idle-scaler: skipping (idle-scaling disabled per CR)")
+		return false, nil
+	}
+
 	timeout := s.timeoutFor(ss)
 
 	// Probe the in-cluster service for the in-memory activity counter.
@@ -325,6 +339,25 @@ func (s *Scaler) processOne(ctx context.Context, ss *appsv1.StatefulSet, now tim
 	// `sum by (namespace) (rate(...))` aggregation.
 	idleTimeoutEvents.WithLabelValues(ss.Namespace).Inc()
 	return true, nil
+}
+
+// isIdleScalingDisabled reports whether the StatefulSet carries the
+// `openova.io/sandbox-idle-scaling-disabled` annotation set to a truthy
+// value (TBD-D8b #1725). The annotation is renderer-stamped from
+// Sandbox.spec.idleScaling.enabled=false; absence (or any other value)
+// keeps the StatefulSet subject to the scaler. The check is
+// quote-tolerant for the same reason timeoutFor is.
+func isIdleScalingDisabled(ss *appsv1.StatefulSet) bool {
+	v, ok := ss.Annotations[AnnIdleScalingDisabled]
+	if !ok {
+		return false
+	}
+	v = strings.Trim(strings.TrimSpace(v), "\"'")
+	switch strings.ToLower(v) {
+	case "1", "t", "true", "yes", "y":
+		return true
+	}
+	return false
 }
 
 func (s *Scaler) timeoutFor(ss *appsv1.StatefulSet) time.Duration {

--- a/core/controllers/sandbox/internal/idlescaler/idlescaler_test.go
+++ b/core/controllers/sandbox/internal/idlescaler/idlescaler_test.go
@@ -405,3 +405,84 @@ func testutilCounterValue(t *testing.T, namespace string) float64 {
 	t.Helper()
 	return prometheustestutil.ToFloat64(idleTimeoutEvents.WithLabelValues(namespace))
 }
+
+// (10) TBD-D8b #1725 — `openova.io/sandbox-idle-scaling-disabled=true`
+// annotation prevents scale-to-zero even when the StatefulSet has been
+// idle for far past its timeout window.
+func TestProcessOne_IdleScalingDisabled_NeverScales(t *testing.T) {
+	t.Parallel()
+	ss := ptyStatefulSet("sandbox-emrah", "pty-server", 2, map[string]string{
+		AnnIdleTimeoutMinutes:  "5",
+		AnnIdleScalingDisabled: "true",
+	})
+
+	c := newFakeClient(t, ss)
+	now := time.Now().UTC()
+	// Probe should never be called when scaling is disabled — return an
+	// implausibly-stale lastActivity to prove that even if it WERE called
+	// the scaler still wouldn't act.
+	_, probe := newProbeServer(t, func(_ string) (idleDTO, bool) {
+		return idleDTO{
+			LastActivityAt: now.Add(-24 * time.Hour),
+			ActiveSessions: 0,
+		}, true
+	})
+
+	s := New(c, logr.Discard(), Options{
+		DefaultIdleTimeoutMinutes: 5,
+		ProbeURL:                  probe,
+		Now:                       func() time.Time { return now },
+	})
+
+	if err := s.runOnce(context.Background()); err != nil {
+		t.Fatalf("runOnce: %v", err)
+	}
+
+	var got appsv1.StatefulSet
+	if err := c.Get(context.Background(),
+		client.ObjectKey{Namespace: "sandbox-emrah", Name: "pty-server"}, &got); err != nil {
+		t.Fatalf("get post-pass: %v", err)
+	}
+	if got.Spec.Replicas == nil || *got.Spec.Replicas != 2 {
+		t.Errorf("replicas: got %v want 2 (idle-scaling disabled)", got.Spec.Replicas)
+	}
+	// AnnLastActivityAt must NOT have been stamped — disabled path
+	// skips the entire process pipeline.
+	if _, stamped := got.Annotations[AnnLastActivityAt]; stamped {
+		t.Errorf("AnnLastActivityAt unexpectedly stamped on disabled Sandbox")
+	}
+}
+
+// (11) `false` / "0" / unset → scaler still active. Confirms the
+// truthy-only matcher (architecture.md §1 idle policy default-on).
+func TestIsIdleScalingDisabled_TruthyOnly(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		val  string
+		want bool
+	}{
+		{"true", true},
+		{"True", true},
+		{"TRUE", true},
+		{"1", true},
+		{"yes", true},
+		{"\"true\"", true},
+		{"false", false},
+		{"0", false},
+		{"", false},
+		{"maybe", false},
+	}
+	for _, tc := range cases {
+		ss := ptyStatefulSet("sandbox-x", "pty-server", 1,
+			map[string]string{AnnIdleScalingDisabled: tc.val})
+		got := isIdleScalingDisabled(ss)
+		if got != tc.want {
+			t.Errorf("isIdleScalingDisabled(%q) = %v, want %v", tc.val, got, tc.want)
+		}
+	}
+	// Annotation absent → never disabled.
+	bare := ptyStatefulSet("sandbox-x", "pty-server", 1, nil)
+	if isIdleScalingDisabled(bare) {
+		t.Errorf("isIdleScalingDisabled(no annotation) = true, want false")
+	}
+}

--- a/core/controllers/sandbox/internal/sandboxapi/types.go
+++ b/core/controllers/sandbox/internal/sandboxapi/types.go
@@ -77,6 +77,32 @@ type SandboxSpec struct {
 	// CapabilitiesForPlan. Wildcards (`sandbox.db.*`) are honoured
 	// by the matcher so the plan map can carry coarse grants.
 	Capabilities []string `json:"capabilities,omitempty"`
+
+	// IdleScaling lets a Sandbox opt out of the cluster-wide idle
+	// scaler (core/controllers/sandbox/internal/idlescaler). When
+	// IdleScaling.Enabled is false the renderer stamps the
+	// `openova.io/sandbox-idle-scaling-disabled=true` annotation on
+	// the pty-server StatefulSet and the idle scaler skips it on
+	// every pass (long-running agent tasks that idle for hours but
+	// must remain Running). Default behaviour (nil pointer OR
+	// Enabled=true) preserves the existing scale-to-zero policy so
+	// the tier-cap economics still hold for the free/pro paths.
+	//
+	// Tier policy lives upstream — the orchestrator may reject
+	// Enabled=false for Free plans before the CR is created. The
+	// controller itself does NOT police tier caps; it honours the
+	// field verbatim. See TBD-D8b #1725.
+	IdleScaling *SandboxIdleScaling `json:"idleScaling,omitempty"`
+}
+
+// SandboxIdleScaling is spec.idleScaling. A nil pointer is equivalent
+// to {Enabled: true} (the safe default — every Sandbox is subject to
+// idle scaling unless explicitly opted out).
+type SandboxIdleScaling struct {
+	// Enabled gates the idle scaler. true (or nil parent) = scale-to-zero
+	// after the timeout; false = pty-server StatefulSet stays at the
+	// renderer's Replicas value regardless of inactivity.
+	Enabled bool `json:"enabled"`
 }
 
 // SandboxOwner is spec.owner.
@@ -182,6 +208,9 @@ func (s *SandboxSpec) DeepCopyInto(out *SandboxSpec) {
 	if s.Capabilities != nil {
 		out.Capabilities = make([]string, len(s.Capabilities))
 		copy(out.Capabilities, s.Capabilities)
+	}
+	if s.IdleScaling != nil {
+		out.IdleScaling = &SandboxIdleScaling{Enabled: s.IdleScaling.Enabled}
 	}
 }
 

--- a/products/catalyst/chart/crds/sandbox.yaml
+++ b/products/catalyst/chart/crds/sandbox.yaml
@@ -181,6 +181,27 @@ spec:
                     `tenant.sandbox_requested` event payload. Empty
                     plan slug leaves the sandbox on the operator
                     DefaultQuota (Wave 1 baseline = Sandbox Free shape).
+                idleScaling:
+                  type: object
+                  description: |
+                    Per-Sandbox idle-scaling opt-out (TBD-D8b #1725).
+                    Default behaviour (omitted OR enabled=true) keeps
+                    the Sandbox subject to the cluster-wide idle scaler
+                    (scale pty-server to 0 after the configured timeout).
+                    Set enabled=false for long-running agent workloads
+                    that idle for hours but must remain Running.
+
+                    Tier policy lives upstream — the orchestrator may
+                    reject enabled=false on Free plans before the CR is
+                    created. The controller honours the field verbatim.
+                  properties:
+                    enabled:
+                      type: boolean
+                      description: |
+                        true (or parent omitted) = scale-to-zero after
+                        timeout (default); false = pty-server StatefulSet
+                        stays at the renderer's Replicas value regardless
+                        of activity.
                 capabilities:
                   type: array
                   description: |


### PR DESCRIPTION
## Summary
- Add `spec.idleScaling.enabled` to the Sandbox CR — `false` opts the Sandbox out of the cluster-wide idle scaler so long-running agent workloads stay Running through hours of inactivity (TBD-D8b #1725).
- Renderer stamps `openova.io/sandbox-idle-scaling-disabled=true` on the pty-server StatefulSet when the field is false; IdleScaler short-circuits in `processOne` (no probe, no last-activity stamp, no scale-to-zero).
- Default behaviour (field omitted OR `enabled=true`) preserves existing tier-cap economics — free/pro paths still scale-to-zero after the timeout window.

## Files
- `core/controllers/sandbox/internal/sandboxapi/types.go` — new `SandboxIdleScaling` type + DeepCopy.
- `products/catalyst/chart/crds/sandbox.yaml` — schema entry for `spec.idleScaling.enabled`.
- `core/controllers/sandbox/internal/gitops/manifests.go` — `IdleScalingDisabled` Inputs field + conditional annotation render.
- `core/controllers/sandbox/internal/controller/sandbox_controller.go` — thread `spec.idleScaling` to renderer.
- `core/controllers/sandbox/internal/idlescaler/idlescaler.go` — `AnnIdleScalingDisabled` constant + `isIdleScalingDisabled` helper + skip in `processOne`.

## Test plan
- [x] `go build ./sandbox/...` clean.
- [x] `go test ./sandbox/internal/idlescaler/...` — all existing tests pass; new `TestProcessOne_IdleScalingDisabled_NeverScales` + `TestIsIdleScalingDisabled_TruthyOnly` cover the disable annotation path.
- [x] `go test ./sandbox/internal/sandboxapi/...` — DeepCopy round-trip unaffected.
- [ ] Runtime verify on next fresh prov: create a Sandbox with `spec.idleScaling.enabled=false`, idle past timeout, confirm replicas stay > 0.

Closes #1725

🤖 Generated with [Claude Code](https://claude.com/claude-code)