### PR TITLE
fix(provisioning): write tenant commits to sme-tenants branch (Closes #1794 — 5th C18 layer)

### DIFF
--- a/core/services/provisioning/github/client.go
+++ b/core/services/provisioning/github/client.go
@@ -287,9 +287,29 @@ func (c *Client) commitOnceGitData(ctx context.Context, branch, message string, 
 func (c *Client) commitOnceContents(ctx context.Context, branch, message string, files map[string]string, prunePrefixes []string) error {
 	// 1. Get current branch ref SHA — used for prune listing AND for an
 	// optional concurrency probe before the atomic batch commit.
+	//
+	// TBD-C18e (2026-05-18): when the target branch doesn't exist yet
+	// (first tenant commit after switching from `main` to a dedicated
+	// `sme-tenants` branch), Gitea returns 404 here. Auto-create the
+	// branch from the repo's default branch (typically `main`) and
+	// retry the ref lookup so the rest of the commit flow can proceed.
+	// This makes the customer-journey fix self-bootstrapping — no
+	// out-of-band branch seeding required.
 	refSHA, err := c.getRef(ctx, branch)
 	if err != nil {
-		return fmt.Errorf("get ref: %w", err)
+		if isBranchMissingError(err) {
+			if createErr := c.ensureBranchExists(ctx, branch); createErr != nil {
+				return fmt.Errorf("auto-create branch %q: %w", branch, createErr)
+			}
+			// Retry the ref lookup — the branch should now exist.
+			refSHA, err = c.getRef(ctx, branch)
+			if err != nil {
+				return fmt.Errorf("get ref after auto-create: %w", err)
+			}
+			slog.Info("auto-created branch for tenant commits", "branch", branch)
+		} else {
+			return fmt.Errorf("get ref: %w", err)
+		}
 	}
 	slog.Debug("got branch ref", "branch", branch, "sha", refSHA)
 
@@ -412,6 +432,66 @@ func (c *Client) commitOnceContents(ctx context.Context, branch, message string,
 		"ops", len(ops),
 		"prune_prefixes", len(prunePrefixes),
 	)
+	return nil
+}
+
+// isBranchMissingError returns true iff the wrapped error from c.getRef
+// indicates the target branch simply doesn't exist yet (a fresh
+// `sme-tenants` branch on a Sovereign that has only ever had a `main`).
+// Two shapes are accepted: the Gitea/GitHub 404 ("Not Found") and the
+// empty-array case getRef reports for an array response with zero
+// elements. TBD-C18e (2026-05-18).
+func isBranchMissingError(err error) bool {
+	if err == nil {
+		return false
+	}
+	s := err.Error()
+	return strings.Contains(s, " 404 ") ||
+		strings.Contains(s, "Not Found") ||
+		strings.Contains(s, "empty refs array")
+}
+
+// ensureBranchExists creates `branch` on the remote by branching from
+// the repository's default branch. Used by commitOnceContents when the
+// first tenant commit lands on a branch that hasn't been seeded yet.
+// The two-step (read default branch SHA → POST /branches) pattern is
+// supported by both Gitea (>= 1.13) and api.github.com.
+//
+// Gitea endpoint: POST /repos/{owner}/{repo}/branches with body
+// `{old_branch_name, new_branch_name}` OR `{old_ref_name, new_branch_name}`.
+// We use the second shape since it accepts an arbitrary commit-ish.
+//
+// Failure modes propagated as errors:
+//   - default branch lookup fails (repo is empty or token lacks read).
+//   - branch creation rejected (token lacks write or branch already
+//     exists — which is a benign race we treat as success).
+func (c *Client) ensureBranchExists(ctx context.Context, branch string) error {
+	// Identify the source branch to fork from. Default to `main` (the
+	// chart's bootstrap branch) — operators who run a different default
+	// can flip the source branch by pre-creating `sme-tenants` manually
+	// once, after which this auto-create path is a no-op.
+	const sourceBranch = "main"
+	sourceSHA, err := c.getRef(ctx, sourceBranch)
+	if err != nil {
+		return fmt.Errorf("read source branch %q: %w", sourceBranch, err)
+	}
+
+	// Gitea + GitHub both accept `{ref: "refs/heads/<branch>", sha: "<sha>"}`
+	// on POST /git/refs to create a new ref. Stick to that shape so this
+	// path stays portable across both targets.
+	_, err = c.doRequest(ctx, http.MethodPost, c.apiURL("/git/refs"), map[string]any{
+		"ref": "refs/heads/" + branch,
+		"sha": sourceSHA,
+	})
+	if err != nil {
+		// 422 with "already exists" body means we lost a race with a
+		// concurrent provisioner — treat as success.
+		if strings.Contains(err.Error(), "already exists") ||
+			strings.Contains(err.Error(), "Reference already exists") {
+			return nil
+		}
+		return err
+	}
 	return nil
 }
 

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -1154,8 +1154,23 @@ name: bp-catalyst-platform
 # GITHUB_TOKEN bytes verbatim. Bootstrap branch (gitea-admin-secret
 # password mirror) is preserved for the first-install pre-cutover window
 # so the provisioning Pod still boots out of CreateContainerConfigError.
-version: 1.4.174
-appVersion: 1.4.174
+# 1.4.175 (TBD-C18e, 2026-05-18): isolate per-tenant overlay commits onto
+# a dedicated `sme-tenants` branch so the cutover-gitea-mirror Job's
+# every-≤10-min `git push --mirror --force` on `main` cannot clobber
+# them. Ships a new Flux GitRepository (templates/sme-services/
+# sme-tenants-gitrepository.yaml) tracking the protected branch; the
+# existing sme-tenants Kustomization is repointed at it. Provisioning
+# Deployment env GITHUB_BRANCH default flipped from `main` to
+# `sme-tenants` on Sovereign installs (Catalyst-Zero keeps `main`).
+# Provisioning Go client gains an auto-create-branch fallback so the
+# first tenant commit on a fresh Sovereign self-bootstraps the branch
+# from `main`. Live root cause on t22 (2026-05-18): provisioning commit
+# 69d64e48 (clusters/t22.omantel.biz/sme-tenants/...) at 17:46:13Z was
+# overwritten by the mirror rerun at 17:54:55Z, Organization CR never
+# materialised, customer-journey step 16 hung indefinitely. (Closes
+# #1794 — 5th C18 layer, the last customer-journey blocker.)
+version: 1.4.175
+appVersion: 1.4.175
 # 1.4.172 — feat(security): baseline CiliumNetworkPolicies for
 # catalyst-system + cilium-gateway (Closes #1746, Refs TBD-Cov-12 /
 # C12-009). Cov-bench audit on the live Sovereign cluster confirmed

--- a/products/catalyst/chart/templates/sme-services/provisioning.yaml
+++ b/products/catalyst/chart/templates/sme-services/provisioning.yaml
@@ -293,8 +293,26 @@ spec:
             {{- end }}
             - name: GITHUB_REPO
               value: {{ .Values.smeServices.provisioning.git.repo | default "openova" | quote }}
+            # ── Tenant-write branch isolation (TBD-C18e, 2026-05-18) ─────
+            # Provisioning writes per-tenant overlays to a DEDICATED branch
+            # so the cutover-gitea-mirror Job (which force-pushes main from
+            # upstream every ≤10 min) cannot clobber tenant commits. The
+            # paired Flux GitRepository (openova-sme-tenants) + Kustomization
+            # both read from this branch. Default: `sme-tenants` on Sovereign,
+            # `main` on contabo (no in-cluster mirror exists there).
+            #
+            # Journey v5b root cause: provisioning commit 69d64e48 at
+            # 17:46:13Z (clusters/t22.omantel.biz/sme-tenants/...) was
+            # OVERWRITTEN by the mirror rerun at 17:54:55Z — Org CR never
+            # materialised, customer journey step 16 hung indefinitely.
             - name: GITHUB_BRANCH
-              value: {{ .Values.smeServices.provisioning.git.branch | default "main" | quote }}
+            {{- if .Values.smeServices.provisioning.git.branch }}
+              value: {{ .Values.smeServices.provisioning.git.branch | quote }}
+            {{- else if .Values.global.sovereignFQDN }}
+              value: "sme-tenants"
+            {{- else }}
+              value: "main"
+            {{- end }}
           resources:
             requests:
               cpu: 25m

--- a/products/catalyst/chart/templates/sme-services/sme-tenants-gitrepository.yaml
+++ b/products/catalyst/chart/templates/sme-services/sme-tenants-gitrepository.yaml
@@ -1,0 +1,119 @@
+{{- /*
+Flux GitRepository tracking the dedicated `sme-tenants` branch
+(TBD-C18e, 2026-05-18).
+
+WHY THIS FILE EXISTS
+--------------------
+The SME-tenant provisioning service writes per-tenant Kustomize overlays
+to `clusters/<sovereignFQDN>/sme-tenants/<sme_tenant_id>/` on every
+successful `POST /api/v1/sme/tenants`. Before this PR all writes landed
+on the same `main` branch the rest of the Sovereign reconciles from.
+
+Journey v5b (2026-05-18) discovery: the `cutover-gitea-mirror` Job runs
+every ≤10 min and executes `git push --mirror --force` from the upstream
+github.com mirror into the in-cluster Gitea. That force-push OVERWRITES
+Gitea's `main` with whatever upstream main looks like AT THAT INSTANT —
+clobbering every tenant commit provisioning landed in between mirror
+runs. Live evidence: commit `69d64e48` at 17:46:13Z (containing the
+clusters/t22.omantel.biz/sme-tenants/ tree) was gone from Gitea main by
+17:54:55Z, the very next mirror tick. The Organization CR never
+materialised, `Flux Kustomization sme-tenants` went ArtifactFailed, and
+the customer journey hung indefinitely at step 16.
+
+FIX
+---
+Tenant commits land on a DEDICATED branch (`sme-tenants`) that the
+mirror Job never touches (it only force-pushes `main`). This template
+ships a NEW Flux GitRepository named `openova-sme-tenants` tracking that
+branch. The paired Flux Kustomization
+(templates/sme-services/sme-tenants-kustomization.yaml) is repointed at
+this GitRepository instead of the shared `openova` one, so the tenant
+reconcile loop reads from the protected branch.
+
+WHY A SEPARATE GitRepository (NOT JUST A NEW REF ON THE EXISTING ONE)
+---------------------------------------------------------------------
+The existing `flux-system/openova` GitRepository serves three roles:
+  1. Bootstrap-kit + infrastructure reconciliation
+     (clusters/_template/{bootstrap-kit,infrastructure})
+  2. Per-Sovereign cluster manifests
+     (clusters/<sovereignFQDN>/) — anything checked into the public repo
+     for this Sovereign.
+  3. (Pre-fix) SME tenant overlays under sme-tenants/.
+
+Roles 1 and 2 MUST stay on `main` (that's where chart upgrades, infra
+fixes, and operator overlays land). Only role 3 needs the protected
+branch. Splitting it out into a second GitRepository keeps the existing
+loop unmodified and makes the new contract additive — operators can
+revert the kustomization sourceRef with one value override if they
+prefer the unified branch for a debug session.
+
+CONTRACT
+--------
+  url:      same Gitea URL the bootstrap GitRepository converges to
+            (http://gitea-http.gitea.svc.cluster.local:3000/<org>/<repo>)
+            — the cutover step's flux-gitrepository-patch sets the same
+            URL on `openova`; we hardcode the same shape here so this
+            CR is correct on first apply (no second cutover step needed).
+  ref.branch: .Values.smeTenants.gitRepository.branch (default
+              "sme-tenants"). Operator may override if the provisioning
+              service is also flipped to a different branch.
+  interval: matches the bootstrap GitRepository (1m) so the tenant
+            reconcile latency is identical pre/post-fix.
+  ignore:   carries the same shape as the cutover-patched openova ignore
+            filter (issue #891) so per-Sovereign overlays and shared
+            templates remain reachable. Source-controller's `ignore` is
+            evaluated server-side BEFORE materialising the artifact, so
+            unused prefixes don't bloat the artifact and don't get
+            propagated to downstream kustomizations.
+
+GATING
+------
+Rendered when:
+  - .Values.ingress.marketplace.enabled = true (same flag as the rest of
+    the SME bundle — non-marketplace Sovereigns don't run the tenant
+    pipeline so they don't need this GitRepository).
+  - .Values.global.sovereignFQDN non-empty (contabo path keeps writing
+    to `main`; no mirror Job exists there so the clobber risk is absent).
+
+Per Inviolable Principle #4, every operationally-meaningful value is
+operator-overridable via .Values.smeTenants.gitRepository.*.
+
+References:
+  - Issue #1794 (TBD-C18e — 5th C18 layer, customer-journey blocker)
+  - Journey v5b root-cause memo (mirror clobbers main every ≤10 min)
+  - sme_tenant_gitops.go (write target)
+  - sme-tenants-kustomization.yaml (consumer of this GitRepository)
+*/}}
+{{- if and .Values.ingress .Values.ingress.marketplace .Values.ingress.marketplace.enabled -}}
+{{- $sovFQDN := .Values.global.sovereignFQDN -}}
+{{- if $sovFQDN -}}
+{{- $gr := (.Values.smeTenants).gitRepository | default dict -}}
+{{- $apiURL := ($gr.apiURL | default "http://gitea-http.gitea.svc.cluster.local:3000") -}}
+{{- $org := ($gr.org | default "openova") -}}
+{{- $repo := ($gr.repo | default "openova") -}}
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: {{ $gr.name | default "openova-sme-tenants" | quote }}
+  namespace: {{ $gr.namespace | default "flux-system" | quote }}
+  labels:
+    catalyst.openova.io/blueprint: bp-catalyst-platform
+    catalyst.openova.io/component: sme-tenants-source
+    app.kubernetes.io/part-of: sme
+spec:
+  interval: {{ $gr.interval | default "1m" | quote }}
+  url: {{ printf "%s/%s/%s" $apiURL $org $repo | quote }}
+  ref:
+    branch: {{ $gr.branch | default "sme-tenants" | quote }}
+  ignore: |
+    /*
+    !/clusters/_template
+    !/clusters/{{ $sovFQDN }}
+    !/platform
+    !/products
+  {{- if $gr.secretRef }}
+  secretRef:
+    name: {{ $gr.secretRef.name | quote }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/products/catalyst/chart/templates/sme-services/sme-tenants-kustomization.yaml
+++ b/products/catalyst/chart/templates/sme-services/sme-tenants-kustomization.yaml
@@ -109,9 +109,19 @@ spec:
   # tenant orchestrator. Blocking this Kustomization on every tenant's
   # full readiness would let one stuck tenant gate every other tenant.
   wait: {{ $kt.wait | default false }}
+  # TBD-C18e (2026-05-18): default sourceRef.name flipped from "openova"
+  # to "openova-sme-tenants". The new GitRepository (sibling template
+  # sme-tenants-gitrepository.yaml) tracks a dedicated `sme-tenants`
+  # branch that the cutover-gitea-mirror Job's force-push of main cannot
+  # clobber. Without this isolation, every per-tenant overlay written by
+  # provisioning was overwritten within ≤10 min by the next mirror tick,
+  # leaving the Org CR un-materialised and the customer journey hung at
+  # step 16. Operator may override back to the unified `openova`
+  # GitRepository (single-branch debug mode) via
+  # .Values.smeTenants.kustomization.sourceRef.name.
   sourceRef:
     kind: GitRepository
-    name: {{ $sourceRef.name | default "openova" | quote }}
+    name: {{ $sourceRef.name | default "openova-sme-tenants" | quote }}
     namespace: {{ $sourceRef.namespace | default "flux-system" | quote }}
 {{- end }}
 {{- end }}

--- a/products/catalyst/chart/values.yaml
+++ b/products/catalyst/chart/values.yaml
@@ -775,15 +775,16 @@ smeTenants:
     # (bootstrap-kit, sovereign-tls, infrastructure-config) so operator
     # tooling can discover it via the standard `-n flux-system` flag.
     namespace: flux-system
-    # The same GitRepository the cluster bootstraps from. Cutover
-    # Step 5 patches its .spec.url from github.com to the local
-    # in-cluster Gitea (http://gitea-http.gitea.svc.cluster.local:3000/
-    # openova/openova) — exactly the URL sme_tenant_gitops.go pushes
-    # via CATALYST_GITOPS_REPO_URL. Operator overlays MAY repoint at
-    # a different GitRepository name (e.g. an SME-tenants-only repo
-    # split out of the monorepo) without forking the chart.
+    # TBD-C18e (2026-05-18): default flipped from `openova` to the
+    # dedicated `openova-sme-tenants` GitRepository (rendered by sibling
+    # template sme-tenants-gitrepository.yaml), tracking the
+    # `sme-tenants` branch. The bootstrap GitRepository (`openova`)
+    # continues to read `main` so chart upgrades + infra fixes reconcile
+    # as before — only this Kustomization reads from the protected
+    # branch. Operator may flip back to `openova` for a single-branch
+    # debug session without losing the rest of the SME-tenant pipeline.
     sourceRef:
-      name: openova
+      name: openova-sme-tenants
       namespace: flux-system
     # Reconcile cadence. 1m matches the orchestrator's documented
     # "Flux on the OTECH cluster reconciles within ~1 min" SLA at the
@@ -809,6 +810,37 @@ smeTenants:
     # reconcile — a single CrashLooping bp-keycloak in tenant A would
     # prevent tenant B from being created.
     wait: false
+  # ─── Dedicated GitRepository for tenant overlays (TBD-C18e) ─────────
+  # Rendered by templates/sme-services/sme-tenants-gitrepository.yaml.
+  # Tracks a SEPARATE branch from the bootstrap GitRepository so the
+  # cutover-gitea-mirror Job (which `git push --mirror --force`s `main`
+  # from upstream every ≤10 min) cannot clobber per-tenant overlays
+  # committed by the provisioning service. The sme-tenants Kustomization
+  # above defaults to sourceRef.name = `openova-sme-tenants` to consume
+  # this CR; flip it back to `openova` for a single-branch debug session.
+  gitRepository:
+    name: openova-sme-tenants
+    namespace: flux-system
+    # Branch the provisioning service writes per-tenant overlays to and
+    # this GitRepository pulls from. MUST stay in sync with the
+    # provisioning Deployment's GITHUB_BRANCH env (see
+    # templates/sme-services/provisioning.yaml — defaults to
+    # `sme-tenants` on Sovereign install, `main` on Catalyst-Zero).
+    branch: sme-tenants
+    # In-cluster Gitea base URL. Matches what
+    # platform/self-sovereign-cutover/chart/templates/
+    # 05-flux-gitrepository-patch-job.yaml patches into the existing
+    # `openova` GitRepository at cutover time. Hardcoded here so the
+    # new CR is correct on first apply (no second cutover step
+    # required).
+    apiURL: "http://gitea-http.gitea.svc.cluster.local:3000"
+    org: openova
+    repo: openova
+    interval: 1m
+    # secretRef: name: gitea-credentials  # uncomment + populate if the
+    # in-cluster Gitea repo becomes private. For the public repo path
+    # source-controller does an unauthenticated clone, matching the
+    # bootstrap GitRepository's secret-less shape.
 
 # ─── Per-Organization public HTTPRoutes (issue #1629 follow-up) ───────
 # PowerDNS now resolves `<slug>.<parentDomain>` for every Org that maps
@@ -1143,7 +1175,16 @@ smeServices:
       apiURL: ""
       owner: ""
       repo: openova
-      branch: main
+      # branch: leave empty to inherit topology-aware default from the
+      # provisioning Deployment template (TBD-C18e, 2026-05-18):
+      #   - Sovereign install (global.sovereignFQDN non-empty) → "sme-tenants"
+      #   - Catalyst-Zero install (global.sovereignFQDN empty)  → "main"
+      # The dedicated `sme-tenants` branch on Sovereigns prevents the
+      # cutover-gitea-mirror Job's force-push of main from clobbering
+      # per-tenant overlays committed by this service. The paired
+      # Flux GitRepository (openova-sme-tenants) + Kustomization read
+      # the same branch.
+      branch: ""
 
 # ─── Catalog (qa-loop iter-16 Fix #65) ─────────────────────────────────
 # `openova-catalog` Flux HelmRepository — the named source ref every


### PR DESCRIPTION
## Summary

5th and last C18 layer — the customer-journey blocker. Provisioning's per-tenant overlay commits now land on a dedicated `sme-tenants` branch instead of `main`, so the `cutover-gitea-mirror` Job's every-≤10-min `git push --mirror --force` cannot clobber them.

## Root cause (Journey v5b, 2026-05-18)

- Live evidence on t22: provisioning commit `69d64e48` at 17:46:13Z (writing `clusters/t22.omantel.biz/sme-tenants/...`) was OVERWRITTEN by the mirror rerun at 17:54:55Z — the next tick.
- Current Gitea main had no `clusters/t22.omantel.biz/sme-tenants/` directory.
- Flux Kustomization `sme-tenants` → `ArtifactFailed`.
- Organization CR never materialised → customer journey step 16 hung indefinitely.

## Changes

- `core/services/provisioning/github/client.go` — `commitOnceContents` auto-creates the target branch from `main` on first commit if it doesn't exist (404), so the fix self-bootstraps without an out-of-band seeding step.
- `products/catalyst/chart/templates/sme-services/sme-tenants-gitrepository.yaml` — **NEW** Flux GitRepository `openova-sme-tenants` tracking the protected `sme-tenants` branch.
- `products/catalyst/chart/templates/sme-services/sme-tenants-kustomization.yaml` — `sourceRef.name` default flipped from `openova` to `openova-sme-tenants`.
- `products/catalyst/chart/templates/sme-services/provisioning.yaml` — `GITHUB_BRANCH` env now topology-aware: `sme-tenants` on Sovereign installs, `main` on Catalyst-Zero (operator-overridable).
- `products/catalyst/chart/values.yaml` — defaults for new `smeTenants.gitRepository.*` block + flipped `smeTenants.kustomization.sourceRef.name` + cleared `smeServices.provisioning.git.branch` to inherit template default.
- `products/catalyst/chart/Chart.yaml` — version bump 1.4.174 → 1.4.175 with notes.

## Test plan

- [x] `go build ./...` in `core/services/provisioning/` passes.
- [x] `go test ./...` in `core/services/provisioning/` passes (github / gitguard / gitops / handlers).
- [x] `helm lint` passes.
- [x] `helm template` with `global.sovereignFQDN=test.example.com --set ingress.marketplace.enabled=true` renders:
  - `GitRepository/openova-sme-tenants` in `flux-system` with `ref.branch: sme-tenants` and correct ignore filter.
  - `Kustomization/sme-tenants` with `sourceRef.name: openova-sme-tenants`.
  - Provisioning Deployment env `GITHUB_BRANCH=sme-tenants`.
- [x] `helm template` without `global.sovereignFQDN` (Catalyst-Zero) still renders `GITHUB_BRANCH=main` (no regression on contabo).
- [ ] On next Sovereign fresh-prov: verify Organization CR materialises and customer journey progresses past step 16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)