### PR TITLE
fix(catalyst-api): publish body→query translation + rbac/assign CRD-NotFound detection (Refs TBD-C4-fup, TBD-C6-006-followup)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/rbac_assign.go
+++ b/products/catalyst/bootstrap/api/internal/handler/rbac_assign.go
@@ -50,6 +50,30 @@ import (
 	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/auth"
 )
 
+// isCRDNotInstalledErr — string-fallback detector for the
+// "CRD not installed on the Sovereign cluster" condition.
+//
+// Defense-in-depth complement to apierrors.IsNotFound: when the
+// apiserver returns 404 for a missing CRD/route (vs a missing
+// instance), the error chain can lose the StatusReasonNotFound tag
+// through wrapping, but the canonical apimachinery message survives
+// verbatim. catalog_client_cluster_fallback.go's isVersionNotServed
+// uses the same pattern; we mirror it here so PR #1789's
+// CRD-NotFound→503 envelope fires even when the typed assertion
+// misses. Refs TBD-C6-006-followup.
+func isCRDNotInstalledErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	if apierrors.IsNotFound(err) {
+		return true
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "no matches for kind") ||
+		strings.Contains(msg, "the server could not find the requested resource") ||
+		strings.Contains(msg, "could not find requested resource")
+}
+
 // ── Canonical label keys + role names ────────────────────────────────
 
 const (
@@ -419,7 +443,7 @@ func (h *Handler) serveRBACAssign(w http.ResponseWriter, r *http.Request, dep *D
 		// envelope so the FE can render a "RBAC not provisioned yet —
 		// retry once useraccess CRD reconciles" hint, matching the
 		// shape every other UserAccess handler emits.
-		if apierrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) || isCRDNotInstalledErr(err) {
 			writeUserAccessUnavailable(w, fmt.Errorf("useraccess CRD not installed on Sovereign cluster (yet); reconcile useraccess-controller and retry: %w", err))
 			return
 		}
@@ -642,11 +666,31 @@ func (h *Handler) publishRBACAssignAudit(
 // on a hot-path CR.
 const rbacAssignMaxRetries = 2
 
-// rbacAssignNamespace — namespace for UserAccess CRs. Empty string =
-// cluster-scoped (matches the platform/crossplane-claims xRD which is
-// cluster-scoped per the iam-composition family). Test seeders pass
-// this to client.Resource(...).Namespace(rbacAssignNamespace).
-const rbacAssignNamespace = ""
+// rbacAssignNamespace — namespace for UserAccess CRs.
+//
+// CRITICAL: useraccesses.access.openova.io is a Crossplane Claim
+// (claimNames in platform/crossplane-claims/chart/templates/xrds/
+// useraccess.yaml). Crossplane Claims are NAMESPACED by construction —
+// only the underlying XR (xuseraccesses) is cluster-scoped. The earlier
+// `const rbacAssignNamespace = ""` comment was wrong (mistook the
+// composition family for "cluster-scoped"). With an empty namespace,
+// the dynamic client routes Create to the apiserver's cluster-wide
+// path /apis/access.openova.io/v1alpha1/useraccesses, which is NOT
+// registered for a namespaced resource — the apiserver returns 404
+// with "the server could not find the requested resource". That's the
+// C6-006 / TBD-C6-006-followup symptom on t22 cov-bench: POST
+// /api/v1/sovereign/rbac/assign 500'd despite PR #1789's
+// CRD-NotFound→503 wrapper, because the IsNotFound branch never fired
+// (the 404 was for the route, not the resource — same wire shape, but
+// it's the namespace-stripping that fooled the apiserver into 404'ing).
+//
+// Fix: stamp catalyst-system on every Create + use it on the Resource
+// client, mirroring user_access_owner_seed.go's t134 D21 fix
+// (userAccessOwnerNamespace = "catalyst-system"). The List path keeps
+// Namespace("") for cross-namespace listing (that IS valid against a
+// namespaced CRD — the apiserver routes /apis/<g>/<v>/<r> as
+// list-all-namespaces and returns the union).
+const rbacAssignNamespace = "catalyst-system"
 
 // rbacAssignFindOrCreate runs the 3-path logic:
 //
@@ -780,6 +824,11 @@ func rbacAssignCreate(
 	obj.SetAPIVersion(userAccessGroup + "/" + userAccessVersion)
 	obj.SetKind("UserAccess")
 	obj.SetName(name)
+	// Pin the namespace on the object so the apiserver routes the
+	// Create to the namespaced REST path (see rbacAssignNamespace doc
+	// for the t22 cov-bench symptom this fixes). Mirrors the
+	// owner-seed pattern in user_access_owner_seed.go.
+	obj.SetNamespace(rbacAssignNamespace)
 	obj.SetLabels(map[string]string{
 		labelTier:                          wantTier,
 		"catalyst.openova.io/managed-by":   "rbac-assign",
@@ -806,7 +855,7 @@ func rbacAssignCreate(
 	}
 	_ = unstructured.SetNestedMap(obj.Object, spec, "spec")
 
-	created, err := client.Resource(UserAccessGVR()).Namespace("").Create(ctx, obj, metav1.CreateOptions{})
+	created, err := client.Resource(UserAccessGVR()).Namespace(rbacAssignNamespace).Create(ctx, obj, metav1.CreateOptions{})
 	if err != nil {
 		// Caller distinguishes IsAlreadyExists for the retry loop.
 		return rbacAssignResponse{}, http.StatusInternalServerError, err
@@ -843,7 +892,17 @@ func rbacAssignUpdateTier(
 		tierClusterRolePrefix+wantTier,
 		"spec", "tierRoleRef",
 	)
-	return client.Resource(UserAccessGVR()).Namespace("").Update(ctx, desired, metav1.UpdateOptions{})
+	// Update uses the CR's own namespace (rbacAssignNamespace for new
+	// CRs we created; the apiserver also returns the canonical ns on
+	// every List item). Empty namespace would route to the cluster-
+	// scoped REST path which the apiserver doesn't serve for a
+	// namespaced CRD (404 "the server could not find the requested
+	// resource") — see rbacAssignNamespace doc.
+	ns := desired.GetNamespace()
+	if ns == "" {
+		ns = rbacAssignNamespace
+	}
+	return client.Resource(UserAccessGVR()).Namespace(ns).Update(ctx, desired, metav1.UpdateOptions{})
 }
 
 // ── Helpers ──────────────────────────────────────────────────────────

--- a/products/catalyst/bootstrap/api/internal/handler/rbac_assign_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/rbac_assign_test.go
@@ -44,11 +44,15 @@ func registerRBACAccessMatrixRoute(r chi.Router, h *Handler) {
 
 // rbacUserAccessFromAssign composes a UserAccess CR shaped the way
 // HandleRBACAssign emits it — tier label, tierRoleRef, scopes[].
+// Stamps rbacAssignNamespace on the CR to match the on-cluster shape
+// (UserAccess is a namespaced Crossplane Claim per
+// platform/crossplane-claims/chart/templates/xrds/useraccess.yaml).
 func rbacUserAccessFromAssign(name, subject, tier string, scopes []rbacAssignScopeBody) *unstructured.Unstructured {
 	u := &unstructured.Unstructured{}
 	u.SetAPIVersion("access.openova.io/v1alpha1")
 	u.SetKind("UserAccess")
 	u.SetName(name)
+	u.SetNamespace(rbacAssignNamespace)
 	u.SetLabels(map[string]string{
 		labelTier:                        tier,
 		"catalyst.openova.io/managed-by": "rbac-assign",
@@ -108,7 +112,10 @@ func TestHandleRBACAssign_CreatesNewWhenNoMatch(t *testing.T) {
 		t.Fatalf("tierClusterRole: got %q", resp.TierClusterRole)
 	}
 	// Verify the CR was actually created with the right shape.
-	got, err := client.Resource(UserAccessGVR()).Namespace("").Get(
+	// Read via rbacAssignNamespace — the Create path now stamps
+	// catalyst-system on the CR (TBD-C6-006-followup fix). Reading
+	// with the wrong namespace returns NotFound on a real apiserver.
+	got, err := client.Resource(UserAccessGVR()).Namespace(rbacAssignNamespace).Get(
 		context.Background(), resp.UserAccess.Name, metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("get: %v", err)
@@ -193,8 +200,9 @@ func TestHandleRBACAssign_UpdatesTierOnSameScope(t *testing.T) {
 	if resp.TierClusterRole != "openova:tier-admin" {
 		t.Fatalf("tierClusterRole: got %q", resp.TierClusterRole)
 	}
-	// Verify the CR was actually mutated.
-	got, err := client.Resource(UserAccessGVR()).Namespace("").Get(
+	// Verify the CR was actually mutated. Read from the canonical
+	// namespace (TBD-C6-006-followup: UserAccess is namespaced).
+	got, err := client.Resource(UserAccessGVR()).Namespace(rbacAssignNamespace).Get(
 		context.Background(), existing.GetName(), metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("get after update: %v", err)
@@ -259,12 +267,16 @@ func TestHandleRBACAssign_RetriesOn409(t *testing.T) {
 			// On the second list (after the first Create returned 409),
 			// inject the racing CR via the tracker so the matcher finds
 			// it. We do this by side-effecting the tracker directly.
+			// Seed with the canonical namespace so the subsequent
+			// rbacAssignCreate sees AlreadyExists on its tracker.Create
+			// (Tracker.Create's last arg is the namespace it routes the
+			// stored object into). Refs TBD-C6-006-followup.
 			_ = client.Tracker().Create(
 				schema.GroupVersionResource{
 					Group: userAccessGroup, Version: userAccessVersion, Resource: userAccessResource,
 				},
 				rbacUserAccessFromAssign(existingName, "alice", "admin", scopes),
-				"",
+				rbacAssignNamespace,
 			)
 		}
 		return false, nil, nil
@@ -588,3 +600,85 @@ func TestHandleRBACAssign_RejectsUnknownTierWith400(t *testing.T) {
 		t.Fatalf("expected httpStatus:400 echo; got %s", rec.Body.String())
 	}
 }
+
+// TestHandleRBACAssign_CreateStampsNamespace pins the rbacAssignNamespace
+// fix for TBD-C6-006-followup. The UserAccess Claim is namespaced (XRD
+// claimNames per platform/crossplane-claims/chart/templates/xrds/
+// useraccess.yaml); creating with an empty namespace routes to the
+// cluster-scoped REST path which the apiserver doesn't serve, returning
+// 404 "the server could not find the requested resource". The fix
+// stamps catalyst-system on every Create — this test asserts the stamp
+// is on the wire.
+func TestHandleRBACAssign_CreateStampsNamespace(t *testing.T) {
+	h := NewWithPDM(silentLogger(), &fakePDM{})
+	factory, client := fakeUserAccessDynamicFactory()
+	h.dynamicFactory = factory
+	dep := installUserAccessDeployment(t, h, "dep-rbac-ns-stamp")
+
+	var createdNs atomic.Value // string
+	var objNs atomic.Value     // string
+	client.PrependReactor("create", "useraccesses", func(a clienttesting.Action) (bool, runtime.Object, error) {
+		ca, ok := a.(clienttesting.CreateAction)
+		if !ok {
+			return false, nil, nil
+		}
+		createdNs.Store(ca.GetNamespace())
+		if u, ok := ca.GetObject().(*unstructured.Unstructured); ok {
+			objNs.Store(u.GetNamespace())
+		}
+		return false, nil, nil
+	})
+
+	body := rbacAssignRequest{
+		User: rbacAssignUserBody{KeycloakSubject: "alice-ns-stamp"},
+		Tier: "developer",
+		Scope: []rbacAssignScopeBody{
+			{Key: "openova.io/application", Value: "wordpress"},
+		},
+	}
+	rec := callUserAccess(t, h, http.MethodPost,
+		"/api/v1/sovereigns/"+dep.ID+"/rbac/assign", body, registerRBACAssignRoute)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status: got %d want 201; body=%s", rec.Code, rec.Body.String())
+	}
+	if got, want := createdNs.Load(), rbacAssignNamespace; got != want {
+		t.Errorf("Create action namespace: got %q want %q (regression: empty NS routes to cluster-scoped REST path, apiserver 404s — C6-006-followup symptom)", got, want)
+	}
+	if got, want := objNs.Load(), rbacAssignNamespace; got != want {
+		t.Errorf("object metadata.namespace: got %q want %q (must be stamped on the unstructured so kubectl get -n <ns> finds it)", got, want)
+	}
+	if rbacAssignNamespace == "" {
+		t.Fatal("rbacAssignNamespace must be non-empty — UserAccess is a namespaced Crossplane Claim")
+	}
+}
+
+// TestIsCRDNotInstalledErr_StringFallback pins the string-fallback
+// detector that PR for TBD-C6-006-followup added. apierrors.IsNotFound
+// can lose the StatusReasonNotFound tag through error-chain wrapping;
+// the canonical apimachinery message "the server could not find the
+// requested resource" still surfaces verbatim. Mirrors
+// catalog_client_cluster_fallback.isVersionNotServed.
+func TestIsCRDNotInstalledErr_StringFallback(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil-no", nil, false},
+		{"unrelated-no", errString("connection refused"), false},
+		{"server-could-not-find-yes", errString("the server could not find the requested resource"), true},
+		{"no-matches-for-kind-yes", errString("no matches for kind \"UserAccess\" in version \"access.openova.io/v1alpha1\""), true},
+		{"alt-could-not-find-yes", errString("operation failed: could not find requested resource"), true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := isCRDNotInstalledErr(c.err); got != c.want {
+				t.Errorf("isCRDNotInstalledErr(%v): got %v want %v", c.err, got, c.want)
+			}
+		})
+	}
+}
+
+type errString string
+
+func (e errString) Error() string { return string(e) }

--- a/products/catalyst/bootstrap/api/internal/handler/sme_catalog_client_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sme_catalog_client_test.go
@@ -1,0 +1,123 @@
+// Regression guard for smeCatalogClient.SetPublished — the upstream
+// SME catalog at core/services/catalog/handlers/handlers.go:303-313
+// (SetAppPublished) reads the new published state via the
+// `?value=true|false` query param ONLY. Any future regression that
+// reverts SetPublished to send a JSON body would re-introduce the
+// C4-012 / TBD-C4-fup symptom on t22 cov-bench v3 (400 with
+// "value query param must be 'true' or 'false'", catalyst-api proxy
+// shipped JSON body the upstream ignored). This test pins the wire
+// shape so the bug can't silently come back.
+package handler
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestSetPublished_SendsQueryParamNotBody(t *testing.T) {
+	cases := []struct {
+		name      string
+		published bool
+		wantValue string
+	}{
+		{"true", true, "true"},
+		{"false", false, "false"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var gotMethod, gotPath, gotQuery, gotAuth, gotBody string
+			var gotContentType string
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotMethod = r.Method
+				gotPath = r.URL.Path
+				gotQuery = r.URL.RawQuery
+				gotAuth = r.Header.Get("Authorization")
+				gotContentType = r.Header.Get("Content-Type")
+				b, _ := io.ReadAll(r.Body)
+				gotBody = string(b)
+				w.WriteHeader(http.StatusOK)
+			}))
+			defer srv.Close()
+
+			c := &smeCatalogClient{
+				baseURL: srv.URL,
+				http:    &http.Client{Timeout: 2 * time.Second},
+			}
+			status, err := c.SetPublished(context.Background(), "wordpress-tenant", tc.published, "test-bearer")
+			if err != nil {
+				t.Fatalf("SetPublished: %v", err)
+			}
+			if status != http.StatusOK {
+				t.Fatalf("status: got %d want 200", status)
+			}
+			if gotMethod != http.MethodPatch {
+				t.Errorf("method: got %s want PATCH", gotMethod)
+			}
+			if gotPath != "/catalog/admin/apps/wordpress-tenant/publish" {
+				t.Errorf("path: got %q want /catalog/admin/apps/wordpress-tenant/publish", gotPath)
+			}
+			// PIN: the query MUST carry value=<bool>. If a future refactor
+			// reverts to a JSON body, this assertion fires immediately.
+			wantQuery := "value=" + tc.wantValue
+			if gotQuery != wantQuery {
+				t.Errorf("query: got %q want %q (regression: PATCH body→query translation lost — C4-012/TBD-C4-fup symptom)", gotQuery, wantQuery)
+			}
+			// PIN: the body MUST be empty. The upstream SME catalog
+			// SetAppPublished doesn't decode a body — but a non-empty
+			// body with the wrong content-type would still tell us the
+			// caller is shipping the wrong wire shape.
+			if strings.TrimSpace(gotBody) != "" {
+				t.Errorf("body: got %q want empty (regression: published bool must travel as query, not JSON)", gotBody)
+			}
+			// Content-Type should NOT be set to application/json — the
+			// upstream rejects unknown content types on some paths.
+			if strings.Contains(strings.ToLower(gotContentType), "application/json") {
+				t.Errorf("content-type: got %q want non-JSON (no body shipped)", gotContentType)
+			}
+			if gotAuth != "Bearer test-bearer" {
+				t.Errorf("auth: got %q want %q", gotAuth, "Bearer test-bearer")
+			}
+		})
+	}
+}
+
+func TestSetPublished_EmptyBearerSkipsAuthHeader(t *testing.T) {
+	var sawAuthHeader atomic.Bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "" {
+			sawAuthHeader.Store(true)
+		}
+		// Upstream returns 401 when no auth — surface verbatim.
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	c := &smeCatalogClient{
+		baseURL: srv.URL,
+		http:    &http.Client{Timeout: 2 * time.Second},
+	}
+	status, err := c.SetPublished(context.Background(), "x", true, "")
+	if err != nil {
+		t.Fatalf("SetPublished: %v", err)
+	}
+	if status != http.StatusUnauthorized {
+		t.Fatalf("status: got %d want 401 (upstream surface verbatim)", status)
+	}
+	if sawAuthHeader.Load() {
+		t.Error("Authorization header sent despite empty bearer — caller must omit, not stamp 'Bearer '")
+	}
+}
+
+func TestSetPublished_EmptySlugRejected(t *testing.T) {
+	c := &smeCatalogClient{baseURL: "http://unused", http: http.DefaultClient}
+	if _, err := c.SetPublished(context.Background(), "  ", true, "x"); err == nil {
+		t.Fatal("expected error on empty slug; got nil")
+	}
+}

--- a/products/catalyst/bootstrap/api/internal/handler/user_access.go
+++ b/products/catalyst/bootstrap/api/internal/handler/user_access.go
@@ -202,12 +202,13 @@ func (h *Handler) serveUserAccessList(w http.ResponseWriter, r *http.Request, de
 		writeUserAccessUnavailable(w, err)
 		return
 	}
-	// UserAccess Claims are cluster-scoped per the CRD definition
-	// (`spec.scope` is the default `Namespaced`-equivalent for
-	// Crossplane Claims, but the XRD declares it cluster-scoped via
-	// the absence of a `Namespaced` claim type — see the chart's
-	// xrds/useraccess.yaml). We list across the cluster and namespace
-	// is preserved in the metadata for any caller that wants it.
+	// UserAccess Claims are NAMESPACED per the XRD's claimNames block
+	// (Crossplane Claims are namespaced by construction — only the
+	// underlying XR xuseraccesses is cluster-scoped). Listing with
+	// Namespace("") asks the apiserver for all-namespaces and works
+	// against a namespaced CRD; metadata.namespace is preserved on
+	// every item for any caller that wants to filter. Refs t134 D21
+	// fix in user_access_owner_seed.go + TBD-C6-006-followup.
 	listIface, err := client.Resource(UserAccessGVR()).Namespace("").List(r.Context(), metav1.ListOptions{})
 	if err != nil {
 		// CRD not installed → return empty list, not 500. The
@@ -256,7 +257,16 @@ func (h *Handler) CreateUserAccess(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	obj := userAccessToUnstructured(body)
-	created, err := client.Resource(UserAccessGVR()).Namespace("").Create(r.Context(), obj, metav1.CreateOptions{})
+	// Stamp the canonical namespace on the Claim — Crossplane Claims
+	// are namespaced; an empty namespace routes to the cluster-scoped
+	// REST path which the apiserver doesn't serve for a namespaced
+	// CRD (404 "the server could not find the requested resource").
+	// Mirrors rbacAssignNamespace + userAccessOwnerNamespace.
+	// Refs TBD-C6-006-followup.
+	if obj.GetNamespace() == "" {
+		obj.SetNamespace(rbacAssignNamespace)
+	}
+	created, err := client.Resource(UserAccessGVR()).Namespace(obj.GetNamespace()).Create(r.Context(), obj, metav1.CreateOptions{})
 	if err != nil {
 		if apierrors.IsAlreadyExists(err) {
 			writeJSON(w, http.StatusConflict, map[string]string{
@@ -307,9 +317,13 @@ func (h *Handler) UpdateUserAccess(w http.ResponseWriter, r *http.Request) {
 		writeUserAccessUnavailable(w, err)
 		return
 	}
-	current, err := client.Resource(UserAccessGVR()).Namespace("").Get(r.Context(), name, metav1.GetOptions{})
+	// Find the existing Claim across all namespaces. UserAccess Claims
+	// are namespaced; we walk the all-namespaces list to discover the
+	// canonical namespace before issuing the Update against that exact
+	// REST path. Refs TBD-C6-006-followup.
+	current, currentNs, err := findUserAccessByName(r.Context(), client, name)
 	if err != nil {
-		if apierrors.IsNotFound(err) {
+		if errors.Is(err, errUserAccessNotFound) {
 			writeJSON(w, http.StatusNotFound, map[string]string{
 				"error":  "user-access-not-found",
 				"detail": "no useraccess with name " + name,
@@ -325,7 +339,8 @@ func (h *Handler) UpdateUserAccess(w http.ResponseWriter, r *http.Request) {
 	desired := userAccessToUnstructured(body)
 	desired.SetResourceVersion(current.GetResourceVersion())
 	desired.SetUID(current.GetUID())
-	updated, err := client.Resource(UserAccessGVR()).Namespace("").Update(r.Context(), desired, metav1.UpdateOptions{})
+	desired.SetNamespace(currentNs)
+	updated, err := client.Resource(UserAccessGVR()).Namespace(currentNs).Update(r.Context(), desired, metav1.UpdateOptions{})
 	if err != nil {
 		if apierrors.IsConflict(err) {
 			writeJSON(w, http.StatusConflict, map[string]string{
@@ -383,14 +398,48 @@ func (h *Handler) DeleteUserAccess(w http.ResponseWriter, r *http.Request) {
 
 var errUserAccessNotFound = errors.New("user-access: not found")
 
-// tryDeleteUserAccess deletes the named cluster-scoped Claim.
-// Returns errUserAccessNotFound on miss so the caller can map onto
-// HTTP 404. We do not need to walk the list since the Claim is
-// cluster-scoped — the apiserver returns NotFound directly for an
-// unknown name.
+// findUserAccessByName walks the all-namespaces list and returns the
+// first UserAccess Claim whose metadata.name matches. Returns the
+// CR + its namespace, or errUserAccessNotFound on miss. Used by
+// UpdateUserAccess and tryDeleteUserAccess to discover the canonical
+// namespace before issuing a per-namespace REST call.
+//
+// UserAccess Claims are namespaced; an empty-namespace Get/Update/
+// Delete routes to the cluster-scoped REST path which the apiserver
+// returns 404 for ("the server could not find the requested
+// resource"). Walk the list once to discover the namespace, then
+// route the mutation to the canonical path. Refs TBD-C6-006-followup.
+func findUserAccessByName(ctx context.Context, client dynamic.Interface, name string) (*unstructured.Unstructured, string, error) {
+	listIface, err := client.Resource(UserAccessGVR()).Namespace("").List(ctx, metav1.ListOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, "", errUserAccessNotFound
+		}
+		return nil, "", err
+	}
+	for i := range listIface.Items {
+		it := &listIface.Items[i]
+		if it.GetName() == name {
+			return it, it.GetNamespace(), nil
+		}
+	}
+	return nil, "", errUserAccessNotFound
+}
+
+// tryDeleteUserAccess deletes the named namespaced Claim. Walks the
+// all-namespaces list to discover the canonical namespace before
+// issuing the Delete (UserAccess Claims are namespaced per the XRD
+// claimNames block — an empty-namespace Delete routes to the
+// cluster-scoped REST path which the apiserver doesn't serve for a
+// namespaced CRD). Returns errUserAccessNotFound on miss so the
+// caller can map onto HTTP 404. Refs TBD-C6-006-followup.
 func tryDeleteUserAccess(ctx context.Context, client dynamic.Interface, name string) error {
+	_, ns, err := findUserAccessByName(ctx, client, name)
+	if err != nil {
+		return err
+	}
 	policy := metav1.DeletePropagationForeground
-	err := client.Resource(UserAccessGVR()).Namespace("").Delete(ctx, name, metav1.DeleteOptions{
+	err = client.Resource(UserAccessGVR()).Namespace(ns).Delete(ctx, name, metav1.DeleteOptions{
 		PropagationPolicy: &policy,
 	})
 	if err != nil {

--- a/products/catalyst/bootstrap/api/internal/handler/user_access_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/user_access_test.go
@@ -67,12 +67,15 @@ func installUserAccessDeployment(t *testing.T, h *Handler, id string) *Deploymen
 
 // newUserAccessUnstructured composes a sample UserAccess Claim
 // matching the canonical #322 shape — sovereignRef + applications
-// list with one app/role/namespaces grant.
+// list with one app/role/namespaces grant. Stamps rbacAssignNamespace
+// since UserAccess is a namespaced Crossplane Claim (XRD claimNames,
+// TBD-C6-006-followup).
 func newUserAccessUnstructured(name, sovereign, subject, app, role, ns string) *unstructured.Unstructured {
 	u := &unstructured.Unstructured{}
 	u.SetAPIVersion("access.openova.io/v1alpha1")
 	u.SetKind("UserAccess")
 	u.SetName(name)
+	u.SetNamespace(rbacAssignNamespace)
 	user := map[string]any{}
 	if subject != "" {
 		user["keycloakSubject"] = subject
@@ -290,7 +293,10 @@ func TestCreateUserAccess_Happy(t *testing.T) {
 	if rec.Code != http.StatusCreated {
 		t.Fatalf("status: got %d want 201; body=%s", rec.Code, rec.Body.String())
 	}
-	got, err := client.Resource(UserAccessGVR()).Namespace("").Get(context.Background(), "alice-helmwatch", metav1.GetOptions{})
+	// UserAccess Claims are namespaced; CreateUserAccess stamps
+	// rbacAssignNamespace on the CR — read from the canonical
+	// namespace (TBD-C6-006-followup).
+	got, err := client.Resource(UserAccessGVR()).Namespace(rbacAssignNamespace).Get(context.Background(), "alice-helmwatch", metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("get after create: %v", err)
 	}
@@ -436,7 +442,9 @@ func TestUpdateUserAccess_Happy(t *testing.T) {
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status: got %d want 200; body=%s", rec.Code, rec.Body.String())
 	}
-	got, err := client.Resource(UserAccessGVR()).Namespace("").Get(context.Background(), "alice-helmwatch", metav1.GetOptions{})
+	// Read from rbacAssignNamespace — UpdateUserAccess preserves the
+	// CR's namespace (TBD-C6-006-followup).
+	got, err := client.Resource(UserAccessGVR()).Namespace(rbacAssignNamespace).Get(context.Background(), "alice-helmwatch", metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("get after update: %v", err)
 	}
@@ -489,7 +497,9 @@ func TestDeleteUserAccess_Happy(t *testing.T) {
 	if rec.Code != http.StatusNoContent {
 		t.Fatalf("status: got %d want 204; body=%s", rec.Code, rec.Body.String())
 	}
-	if _, err := client.Resource(UserAccessGVR()).Namespace("").Get(context.Background(), "alice-helmwatch", metav1.GetOptions{}); err == nil {
+	// Read from rbacAssignNamespace — DeleteUserAccess routes to the
+	// CR's canonical namespace (TBD-C6-006-followup).
+	if _, err := client.Resource(UserAccessGVR()).Namespace(rbacAssignNamespace).Get(context.Background(), "alice-helmwatch", metav1.GetOptions{}); err == nil {
 		t.Fatalf("expected error after delete; got nil")
 	}
 }


### PR DESCRIPTION
Wave 35 Cov-bench v3 surfaced two follow-ups from PR #1789. This PR
addresses both.

## TBD-C4-fup — publish body→query regression guard

PR #1789 translated the chroot's `{\"published\":true}` JSON body into
the upstream catalog's `?value=true|false` query param shape
(matches services-catalog `SetAppPublished` at
core/services/catalog/handlers/handlers.go:303-313). Wave 35 cov-bench
v3 saw 400 on the publish toggle because the deploy bot hadn't bumped
catalyst-api past `e2c56c3` (PR #1787) when the bench ran — PR #1789's
translation was already in the merged code but not yet in the live
image. The fix is now live in `2964930` (bumped via #1792 deploy).

This PR adds **regression-guard unit tests** so any future revert to
the JSON-body shape fires immediately:
- `TestSetPublished_SendsQueryParamNotBody` — pins URL +
  `?value=<bool>` + empty body + correct Authorization header
- `TestSetPublished_EmptyBearerSkipsAuthHeader` — pins the
  401-surface-verbatim contract
- `TestSetPublished_EmptySlugRejected` — pins the early-exit

services-catalog is upstream-canonical per task brief — not changed.

## TBD-C6-006-followup — RBAC assign 500 → 503 root cause

The symptom on t22 cov-bench v3: `POST /sovereigns/{id}/rbac/assign`
returned 500 `rbac-assign-failed \"the server could not find the
requested resource\"` despite PR #1789's `apierrors.IsNotFound`→503
wrapper.

**Root cause**: `useraccesses.access.openova.io` is a NAMESPACED
Crossplane Claim (XRD `claimNames` block in
`platform/crossplane-claims/chart/templates/xrds/useraccess.yaml` — only
the underlying XR `xuseraccesses` is cluster-scoped).
`rbacAssignNamespace = \"\"` routed the dynamic Create to
`/apis/access.openova.io/v1alpha1/useraccesses` (cluster-scoped REST
path), which the apiserver doesn't serve for a namespaced CRD —
returns 404 with the canonical message. PR #1789's `IsNotFound`
branch never fired because the 404 was for the **route**, not the
**resource** (same wire shape; apiserver's typed Reason differs by
context and the error-chain wrapping can lose the
`StatusReasonNotFound` tag).

This was already the lesson learned in `user_access_owner_seed.go`'s
t134 D21 fix (`userAccessOwnerNamespace = \"catalyst-system\"`); the
rbac_assign + user_access surfaces hadn't been swept yet.

**Fix**:
1. `rbacAssignNamespace = \"catalyst-system\"` (was `\"\"`); stamp on
   every Create + Update; Lists keep `Namespace(\"\")` for
   cross-namespace listing (valid against a namespaced CRD —
   apiserver returns the union).
2. `isCRDNotInstalledErr()` string-fallback (defense in depth) so
   any future error-chain wrapping that loses
   `StatusReasonNotFound` still routes to the 503 surface.
   Mirrors `catalog_client_cluster_fallback.isVersionNotServed`.
3. `user_access.go` — same defect class. `CreateUserAccess` now
   stamps `rbacAssignNamespace`; `UpdateUserAccess` /
   `tryDeleteUserAccess` walk all-namespaces via new
   `findUserAccessByName()` helper, then issue the mutation against
   the canonical namespace.

## Tests

- `TestHandleRBACAssign_CreateStampsNamespace` — pins both the
  Create action namespace AND the `metadata.namespace` on the wire
- `TestIsCRDNotInstalledErr_StringFallback` — exercises the
  string-fallback table
- Existing tests updated to read from `rbacAssignNamespace` (no
  behavioural change — the fake dynamic client routes accurately
  now)
- Pre-existing failures unrelated to this PR remain:
  `TestEnsureOwnerUserAccess_CreatesCanonicalCR`,
  `TestUnstructuredToUserAccess_NilApplicationsBecomesEmpty`,
  `TestHandleWhoami_PinSessionRBACClaims`,
  `TestHandleWhoami_NoRBACOmitsFields`,
  `TestFinaliseHandover_FullFlow`

## Test plan

- [x] `go test ./internal/handler/` — only pre-existing failures
- [x] `go vet` clean
- [x] All new tests PASS
- [ ] Deploy bot bumps catalyst-api image; verify Wave 36 cov-bench
  C6-006 FAIL→PASS on a chroot without UserAccess CRD installed
  (expect 503 sovereign-cluster-unreachable, not 500
  rbac-assign-failed)

Refs TBD-C4-fup
Refs TBD-C6-006-followup

🤖 Generated with [Claude Code](https://claude.com/claude-code)