### PR TITLE
fix(cnp): allow SMTP egress (587/465/25) from catalyst-system — fixes PIN-issue 502 regression from #1785

### DIFF
--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -1169,8 +1169,25 @@ name: bp-catalyst-platform
 # overwritten by the mirror rerun at 17:54:55Z, Organization CR never
 # materialised, customer-journey step 16 hung indefinitely. (Closes
 # #1794 — 5th C18 layer, the last customer-journey blocker.)
-version: 1.4.176
-appVersion: 1.4.176
+# 1.4.177 (TBD-CNP-SMTP-Egress, 2026-05-18): fix regression introduced by
+# #1785 (1.4.171 baseline CNPs). The catalyst-system default-deny CNP
+# limited world egress to TCP/443 only, which silently broke SMTP
+# submission from catalyst-api to mail.openova.io. Diagnostic agent
+# confirmed on the live Sovereign: a catalyst-system Pod cannot
+# `nc 45.151.123.50 587` (timeout) while a default-namespace Pod on the
+# SAME node connects fine (220 Stalwart ESMTP banner). The catalyst-
+# system CNP `baseline-default-deny` was created at 18:13:09Z — the
+# exact moment chart 1.4.171 rolled out — and its egress block reads
+# `toEntities:[world] toPorts:[443/TCP]`. Customer journey step 11/12
+# (PIN-issue email delivery) consequently 502s at /api/v1/auth/pin-
+# request, gating every fresh onboarding flow. Fix: extend the world
+# egress block to additionally permit 587/TCP (SMTP submission, the
+# production path to mail.openova.io), 465/TCP (SMTPS fallback), and
+# 25/TCP (legacy SMTP fallback). All three are explicitly scoped to
+# `toEntities: world`, matching the existing 443/TCP allow. No other
+# rule semantics change. (Fixes PIN-issue 502 regression from #1785.)
+version: 1.4.177
+appVersion: 1.4.177
 # 1.4.172 — feat(security): baseline CiliumNetworkPolicies for
 # catalyst-system + cilium-gateway (Closes #1746, Refs TBD-Cov-12 /
 # C12-009). Cov-bench audit on the live Sovereign cluster confirmed

--- a/products/catalyst/chart/templates/network-policies/baseline-catalyst-system.yaml
+++ b/products/catalyst/chart/templates/network-policies/baseline-catalyst-system.yaml
@@ -152,13 +152,36 @@ spec:
 {{- range $allowedPlatform }}
                 - {{ . | quote }}
 {{- end }}
-    # 5. World egress on TCP/443 — catalyst-api MAY call out to public
-    #    APIs (Dynadot for parent-domain registration, S3 for backup
-    #    seed, GitHub for blueprint fetch). Scoped to TCP/443 only.
+    # 5. World egress — catalyst-api MAY call out to public APIs
+    #    (Dynadot for parent-domain registration, S3 for backup seed,
+    #    GitHub for blueprint fetch, ghcr/harbor pulls) on TCP/443
+    #    AND submit PIN-issue / notification emails to the operator
+    #    Stalwart SMTP relay (mail.openova.io) over TCP/587
+    #    (submission, the production path) with TCP/465 (SMTPS) and
+    #    TCP/25 (legacy SMTP) as fallbacks.
+    #
+    #    Regression context — DO NOT NARROW THIS BLOCK WITHOUT REVIEW
+    #    ────────────────────────────────────────────────────────────
+    #    The original CNP (chart 1.4.171, PR #1785) allowed only
+    #    443/TCP world. The catalyst-api PIN-issue handler reaches
+    #    mail.openova.io:587 to send the verification email at
+    #    customer-journey step 11/12 — that call timed out as soon
+    #    as this CNP rolled out, surfacing as a 502 at
+    #    /api/v1/auth/pin-request and blocking every fresh onboarding
+    #    flow. Diagnostic evidence: a catalyst-system Pod cannot
+    #    `nc 45.151.123.50 587` (timeout) while a default-namespace
+    #    Pod on the SAME node connects fine (220 Stalwart ESMTP banner).
+    #    See chart 1.4.177 changelog above and the fix PR body.
     - toEntities:
         - world
       toPorts:
         - ports:
             - port: "443"
+              protocol: TCP
+            - port: "587"
+              protocol: TCP
+            - port: "465"
+              protocol: TCP
+            - port: "25"
               protocol: TCP
 {{- end }}


### PR DESCRIPTION
## Summary

PR #1785 (chart 1.4.171) shipped a `baseline-default-deny` CiliumNetworkPolicy in `catalyst-system` whose world-egress block was scoped to **TCP/443 only**. That silently broke SMTP submission from `catalyst-api` to the operator Stalwart relay (`mail.openova.io`), surfacing as **502s at `/api/v1/auth/pin-request`** — customer-journey **step 11/12 (PIN-issue email delivery) is blocked on every fresh Sovereign onboarding flow**.

This is a self-inflicted regression from my own #1785; landing the widening as a focused, single-PR follow-up.

## Diagnostic evidence (live Sovereign)

The diagnostic agent confirmed the policy-driven block:

- CNP `baseline-default-deny` in `catalyst-system` was **created at 2026-05-18 18:13:09Z** — the exact moment chart 1.4.171 rolled out.
- The egress block reads:
  ```
  toEntities: [world]
  toPorts:    [443/TCP]
  ```
  i.e. only HTTPS world egress is permitted; SMTP submission is dropped.
- A Pod in `catalyst-system` **cannot** `nc 45.151.123.50 587` (timeout).
- A Pod in the `default` namespace **on the SAME node** connects fine and receives the `220 Stalwart ESMTP` banner.

That same-node A/B isolates the failure to the namespaced CNP — not the host firewall, not the Stalwart relay, not Cilium ClusterMesh.

## Fix

Extend the world-egress block in `products/catalyst/chart/templates/network-policies/baseline-catalyst-system.yaml` to permit, in addition to the existing `443/TCP`:

| Port | Protocol | Purpose |
|------|----------|---------|
| 587  | TCP      | SMTP submission (the production path to `mail.openova.io`) |
| 465  | TCP      | SMTPS (fallback) |
| 25   | TCP      | Legacy SMTP (fallback only — production is on 587) |

All four ports are scoped to `toEntities: [world]`, matching the existing 443 allow. No other rule semantics change — same-namespace, cluster-DNS, kube-apiserver, and platform-namespace allows are byte-identical to 1.4.176.

A `Regression context — DO NOT NARROW THIS BLOCK WITHOUT REVIEW` comment is added inline so the next reviewer who tightens the block sees the failure mode that drove the widening.

## Chart bump

`1.4.176 → 1.4.177`. Changelog entry added in `Chart.yaml` above the version line, describing the regression + fix.

## Verification

`helm template products/catalyst/chart` renders the updated CNP with four ports (443/587/465/25) under the world egress block; all other rules byte-identical to the 1.4.176 render.

## Test plan

- [ ] CI: chart-lint / helm-template green
- [ ] Post-chart-roll on a live Sovereign: `kubectl exec -n catalyst-system <catalyst-api-pod> -- nc -zv mail.openova.io 587` returns connected (was timeout).
- [ ] `curl -X POST https://api.<fqdn>/api/v1/auth/pin-request -d '{"email":"..."}'` returns 200 (was 502).
- [ ] Stalwart inbox receives the test PIN email.
- [ ] Customer-journey step 12 (PIN paste) succeeds end-to-end.

## Refs

- Regression source: #1785 (the baseline CNP introduction)
- Original issue: #1746 (the baseline-CNP coverage requirement)

🤖 Generated with [Claude Code](https://claude.com/claude-code)