### PR TITLE
fix(bp-velero): bump 1.2.1 -> 1.2.2 to force a publish (Closes #1799)

### DIFF
--- a/clusters/_template/bootstrap-kit/34-velero.yaml
+++ b/clusters/_template/bootstrap-kit/34-velero.yaml
@@ -67,7 +67,7 @@ spec:
   chart:
     spec:
       chart: bp-velero
-      version: 1.2.1
+      version: 1.2.2
       sourceRef:
         kind: HelmRepository
         name: bp-velero

--- a/platform/velero/chart/Chart.yaml
+++ b/platform/velero/chart/Chart.yaml
@@ -24,7 +24,13 @@ description: |
   Sovereign requires only a sibling `infra/<provider>/` Tofu module —
   this chart Just Works.
 type: application
-version: 1.2.1
+# 1.2.2 (TBD-A13, #1799): force a republish. The 1.2.1 bump shipped only in
+# Chart.yaml's initial-fill commit and never triggered blueprint-release, so
+# `ghcr.io/openova-io/bp-velero:1.2.1` returns not-found and every fresh
+# Sovereign's HR stuck InProgress. Bumping to 1.2.2 forces the workflow to
+# fire and the auto-bump hook to keep clusters/_template/bootstrap-kit in
+# sync. No chart-payload changes.
+version: 1.2.2
 appVersion: "1.18.0"
 keywords: [catalyst, blueprint, velero, backup, disaster-recovery]
 maintainers:


### PR DESCRIPTION
## Summary

- `ghcr.io/openova-io/bp-velero:1.2.1` returns **not-found** in GHCR — the 1.2.1 bump in `platform/velero/chart/Chart.yaml` only shipped via the initial-fill commit (`e5c2797c`) and never triggered the blueprint-release workflow. Verified via `/orgs/openova-io/packages/container/bp-velero/versions`: only 1.0.0, 1.1.0, 1.2.0 are published.
- Every fresh Sovereign's bp-velero HelmRelease (slot 34) is stuck `InProgress`, failing the bootstrap-kit kustomization health check (TBD-A13 / #1799).
- Bump chart + bootstrap-kit pin to **1.2.2** in lockstep — A6 sync gate stays GREEN, blueprint-release fires on push, the A6 auto-bump-pin step becomes a no-op (pin already matches).
- No payload changes — same upstream `vmware-tanzu/velero 12.0.1` subchart, same templates, same values.

## Test plan

- [x] `bash scripts/check-bootstrap-kit-pin-sync.sh --changed-only --base origin/main` → PASS (bp-velero: chart=1.2.2 pin=1.2.2)
- [x] `bash scripts/check-bootstrap-kit-pin-sync.sh` (full sweep) → PASS (50/50 chart→pin pairs sync'd)
- [ ] Blueprint Release CI green on merge — publishes `ghcr.io/openova-io/bp-velero:1.2.2`
- [ ] Next fresh Sovereign: slot-34 HR reconciles Ready=True

Closes #1799

🤖 Generated with [Claude Code](https://claude.com/claude-code)