### PR TITLE
fix(hetzner): sweep orphan SSH keys by public_key comment (TBD-A16)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/hetzner/purge.go
+++ b/products/catalyst/bootstrap/api/internal/hetzner/purge.go
@@ -360,7 +360,199 @@ func Purge(ctx context.Context, token, sovereignFQDN string, progress func(msg s
 		purgeByNamePrefix(ctx, token, fqdnSlugPrefix, &report, progress)
 	}
 
+	// Third pass — SSH-key public_key comment sweep (TBD-A16).
+	//
+	// The label-pass and name-prefix-pass above both rely on the Hetzner
+	// SSH key object's own metadata (label and name) matching the Tofu
+	// module's canonical emission. In production we observed (t24 orphan,
+	// 2026-05-18) SSH keys that survived every previous wipe pass because
+	// either:
+	//
+	//   - the operator renamed the key in the Hetzner Console (name drift)
+	//   - a partial `tofu apply` race-condition left the key in a state
+	//     where the label was never applied
+	//   - the SSH key was created OUTSIDE tofu by a manual `hcloud
+	//     ssh-key create` call during incident response and never
+	//     received the canonical name/label
+	//
+	// The one piece of metadata that resists every drift vector is the
+	// `public_key` field's RFC 4716 *comment*: the trailing whitespace-
+	// delimited token after the key data, e.g. `catalyst-t25-fresh@bastion`.
+	// The Catalyst bootstrap-cli stamps this comment at key generation
+	// time so even orphans created out-of-band carry the stem. This pass
+	// lists every SSH key, parses the comment, and deletes any whose
+	// comment begins with the canonical `catalyst-<fqdn-dashes>` prefix.
+	//
+	// Idempotent against earlier passes via the same `already` set.
+	purgeSSHKeysByPublicKeyComment(ctx, token, prefix, &report, progress)
+
 	return report, nil
+}
+
+// purgeSSHKeysByPublicKeyComment deletes SSH keys whose `public_key` comment
+// begins with the canonical per-Sovereign prefix (TBD-A16). This is the
+// third match vector — after label-selector and name-prefix — and catches
+// keys whose name AND label both drifted from the Tofu module's canonical
+// emission. Idempotent against the earlier passes.
+//
+// The "comment" of an OpenSSH-format public key is the trailing whitespace-
+// delimited token after the key data, e.g. given:
+//
+//	ssh-ed25519 AAAAC3NzaC1l... catalyst-t25-fresh@bastion-vmi3305700
+//
+// the comment is `catalyst-t25-fresh@bastion-vmi3305700`. Keys without a
+// comment field (or whose key data doesn't tokenise to 3 parts) are skipped
+// — there's no way to attribute them to a Sovereign without a label or name
+// match, and we don't want this fallback to delete random unrelated keys.
+//
+// Boundary safety: the prefix MUST match at the start of the comment AND
+// be followed by either end-of-string or a non-alphanumeric separator
+// (`-`, `.`, `@`, ` `, …). Without this guard, wiping `catalyst-t2` would
+// match `catalyst-t20-*` comments — the same P0 safety regression class
+// pinned by TestPurge_NamePrefixFallback_DoesNotTouchOtherCustomers.
+func purgeSSHKeysByPublicKeyComment(ctx context.Context, token, prefix string, report *PurgeReport, progress func(string)) {
+	if progress == nil {
+		progress = func(string) {}
+	}
+	if strings.TrimSpace(prefix) == "" {
+		return
+	}
+
+	already := sliceToSet(report.SSHKeys)
+
+	keys, err := listAllSSHKeysWithPublicKey(ctx, token)
+	if err != nil {
+		report.Errors = append(report.Errors, "public-key-comment list ssh_keys: "+err.Error())
+		return
+	}
+	for _, k := range keys {
+		comment := publicKeyComment(k.PublicKey)
+		if !commentMatchesPrefix(comment, prefix) {
+			continue
+		}
+		if _, seen := already[k.Name]; seen {
+			continue
+		}
+		if err := deleteResource(ctx, token, "/v1/ssh_keys/"+strconv.FormatInt(k.ID, 10)); err != nil {
+			report.Errors = append(report.Errors, fmt.Sprintf("delete ssh_key %s (public-key-comment): %s", k.Name, err.Error()))
+			continue
+		}
+		report.SSHKeys = append(report.SSHKeys, k.Name)
+		progress(fmt.Sprintf("deleted ssh-key %s (public-key-comment fallback)", k.Name))
+	}
+}
+
+// publicKeyComment extracts the RFC-4716 / OpenSSH-format comment field
+// from a public key string. The OpenSSH format is:
+//
+//	<type> <base64-data> <comment>
+//
+// where the comment may itself contain whitespace (e.g. `user@host with
+// spaces`). We split off the key type, then the key data, and return
+// everything after as the comment. Returns "" when the key has fewer than
+// 3 whitespace-separated fields.
+func publicKeyComment(publicKey string) string {
+	trimmed := strings.TrimSpace(publicKey)
+	if trimmed == "" {
+		return ""
+	}
+	// First whitespace split: drop the key type (`ssh-ed25519`, `ssh-rsa`, …).
+	typeAndRest := strings.SplitN(trimmed, " ", 2)
+	if len(typeAndRest) < 2 {
+		return ""
+	}
+	rest := strings.TrimSpace(typeAndRest[1])
+	// Second whitespace split: separate base64 key data from comment.
+	dataAndComment := strings.SplitN(rest, " ", 2)
+	if len(dataAndComment) < 2 {
+		return ""
+	}
+	return strings.TrimSpace(dataAndComment[1])
+}
+
+// commentMatchesPrefix returns true iff the comment starts with prefix AND
+// the next rune (if any) is a non-alphanumeric separator. This is the
+// boundary guard that prevents `catalyst-t2` from spuriously matching
+// `catalyst-t20-fresh@host`. Symmetric with the HasPrefix-with-suffix-dash
+// contract pinned by TestPurge_NamePrefixFallback_DoesNotTouchOtherCustomers.
+func commentMatchesPrefix(comment, prefix string) bool {
+	if comment == "" || prefix == "" {
+		return false
+	}
+	if !strings.HasPrefix(comment, prefix) {
+		return false
+	}
+	if len(comment) == len(prefix) {
+		return true
+	}
+	next := comment[len(prefix)]
+	// Allow `-`, `.`, `@`, ` `, `_` as boundary separators. A digit or
+	// letter after the prefix means we're matching a longer stem (e.g.
+	// `catalyst-t20-…` when prefix is `catalyst-t2`) and must be rejected.
+	switch next {
+	case '-', '.', '@', ' ', '_':
+		return true
+	}
+	return false
+}
+
+// hetznerSSHKey is the SSH-key shape extending hetznerResource with the
+// `public_key` field needed by the comment-match sweep. Hetzner returns
+// the full OpenSSH-format key string in this field.
+type hetznerSSHKey struct {
+	ID        int64  `json:"id"`
+	Name      string `json:"name"`
+	PublicKey string `json:"public_key"`
+}
+
+// listAllSSHKeysWithPublicKey enumerates every SSH key in the Hetzner
+// project with the `public_key` field populated. Used by the public-key
+// comment-match sweep — listAllResources / listResources drop `public_key`
+// because their shape is the minimal hetznerResource.
+func listAllSSHKeysWithPublicKey(ctx context.Context, token string) ([]hetznerSSHKey, error) {
+	var out []hetznerSSHKey
+	page := 1
+	for {
+		q := url.Values{}
+		q.Set("page", strconv.Itoa(page))
+		q.Set("per_page", "50")
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet,
+			"https://api.hetzner.cloud/v1/ssh_keys?"+q.Encode(), nil)
+		if err != nil {
+			return nil, err
+		}
+		req.Header.Set("Authorization", "Bearer "+token)
+
+		resp, err := purgeHTTPClient.Do(req)
+		if err != nil {
+			return nil, err
+		}
+		body := decodeBody(resp)
+		_ = resp.Body.Close()
+		if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+			return nil, fmt.Errorf("hetzner auth failed (status %d) — token may have been rotated or scope revoked", resp.StatusCode)
+		}
+		if resp.StatusCode != http.StatusOK {
+			return nil, fmt.Errorf("hetzner list-all ssh_keys: unexpected status %d: %s", resp.StatusCode, body.errMsg())
+		}
+
+		raw, ok := body.raw["ssh_keys"]
+		if ok {
+			var entries []hetznerSSHKey
+			if err := json.Unmarshal(raw, &entries); err == nil {
+				out = append(out, entries...)
+			}
+		}
+		if !body.hasNextPage() {
+			break
+		}
+		page++
+		if page > 50 {
+			break // sanity bound
+		}
+	}
+	return out, nil
 }
 
 // purgeByNamePrefix is the unlabeled fallback half of Purge. Lists every

--- a/products/catalyst/bootstrap/api/internal/hetzner/purge_ssh_key_comment_test.go
+++ b/products/catalyst/bootstrap/api/internal/hetzner/purge_ssh_key_comment_test.go
@@ -1,0 +1,408 @@
+// purge_ssh_key_comment_test.go — regression sentinel for TBD-A16.
+//
+// The bug: orphan SSH keys whose `name` and `label` both drifted from the
+// Tofu module's canonical emission were surviving every wipe pass because
+// the label-pass and name-prefix-pass had no signal to attribute the key
+// to the Sovereign being wiped. Observed in production on 2026-05-18 with
+// `catalyst-t24-omantel-biz` blocking fresh t25 provs.
+//
+// The fix: a third match vector — the OpenSSH-format `public_key`
+// comment. The Catalyst bootstrap-cli stamps the canonical prefix into
+// the comment at key generation time, so even keys whose name + label
+// drifted carry it. This test pins the third pass:
+//
+//   1. TestPurge_SSHKey_PublicKeyCommentFallback_DeletesUnlabeled — when
+//      a key's name/label are wrong but its public_key comment matches
+//      the canonical prefix, Purge deletes it via the third pass.
+//
+//   2. TestPurge_SSHKey_PublicKeyCommentFallback_BoundarySafety — CRITICAL
+//      P0 safety guard. Wiping `t2.omantel.biz` must NOT delete a
+//      `t20.omantel.biz` SSH key whose comment is
+//      `catalyst-t20-fresh@host`. The comment-prefix match must enforce
+//      a boundary separator after the prefix.
+//
+//   3. TestPurge_SSHKey_PublicKeyCommentFallback_NoDoubleCount — when
+//      the label or name pass already deleted a key, the comment pass
+//      MUST NOT add it to the report again.
+//
+//   4. TestPurge_SSHKey_PublicKeyCommentFallback_LeavesOtherKeys — keys
+//      with no comment OR with a comment for a different Sovereign are
+//      left strictly alone.
+
+package hetzner
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// fakeHetznerSSHKeyComment is a Hetzner Cloud API stub for the SSH-key
+// public-key-comment fallback path. Returns NO entries for the
+// label_selector pass and a configurable set for the unlabeled (full-list)
+// pass.
+type fakeHetznerSSHKeyComment struct {
+	t *testing.T
+
+	// unlabeled is the per-kind entries returned when no label_selector
+	// is sent. SSH keys include the public_key field.
+	unlabeled map[string][]map[string]any
+
+	mu       sync.Mutex
+	deletes  map[string][]int64
+	listHits map[string]int // how many unlabeled list calls hit each kind
+}
+
+func newFakeHetznerSSHKeyComment(t *testing.T) *fakeHetznerSSHKeyComment {
+	return &fakeHetznerSSHKeyComment{
+		t:         t,
+		unlabeled: map[string][]map[string]any{},
+		deletes:   map[string][]int64{},
+		listHits:  map[string]int{},
+	}
+}
+
+func (f *fakeHetznerSSHKeyComment) handler() http.Handler {
+	mux := http.NewServeMux()
+	for _, kind := range []string{"servers", "load_balancers", "firewalls", "networks", "ssh_keys", "volumes", "primary_ips", "floating_ips"} {
+		kind := kind
+		path := "/v1/" + kind
+		mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodGet {
+				http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+				return
+			}
+			selector := r.URL.Query().Get("label_selector")
+			var entries []map[string]any
+			if selector == "" {
+				f.mu.Lock()
+				f.listHits[kind]++
+				f.mu.Unlock()
+				entries = f.unlabeled[kind]
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"meta": map[string]any{"pagination": map[string]any{"next_page": nil}},
+				kind:   entries,
+			})
+		})
+		mux.HandleFunc(path+"/", func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodDelete {
+				http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+				return
+			}
+			tail := strings.TrimPrefix(r.URL.Path, path+"/")
+			var id int64
+			fmt.Sscanf(tail, "%d", &id)
+			f.mu.Lock()
+			defer f.mu.Unlock()
+			f.deletes[kind] = append(f.deletes[kind], id)
+			w.WriteHeader(http.StatusNoContent)
+		})
+	}
+	return mux
+}
+
+func sshKeyCommentTestSetup(t *testing.T, fake *fakeHetznerSSHKeyComment) func() {
+	t.Helper()
+	srv := httptest.NewServer(fake.handler())
+	srvURL, err := url.Parse(srv.URL)
+	if err != nil {
+		srv.Close()
+		t.Fatalf("parse test server url: %v", err)
+	}
+	origClient := purgeHTTPClient
+	purgeHTTPClient = &http.Client{
+		Transport: &rewriteTransport{from: "api.hetzner.cloud", to: srvURL, base: http.DefaultTransport},
+		Timeout:   5 * time.Second,
+	}
+	origBackoff := firewallRetryInitialBackoff
+	firewallRetryInitialBackoff = 1 * time.Millisecond
+	return func() {
+		srv.Close()
+		purgeHTTPClient = origClient
+		firewallRetryInitialBackoff = origBackoff
+	}
+}
+
+// TestPurge_SSHKey_PublicKeyCommentFallback_DeletesUnlabeled — when the
+// key's name AND label both drift but the public_key comment carries the
+// canonical prefix, Purge MUST delete it via the third pass.
+func TestPurge_SSHKey_PublicKeyCommentFallback_DeletesUnlabeled(t *testing.T) {
+	const fqdn = "t25.omantel.biz"
+	const prefix = "catalyst-t25-omantel-biz"
+
+	fake := newFakeHetznerSSHKeyComment(t)
+	// Production-shape orphan: name was renamed to a non-canonical form
+	// (e.g. operator clicked Rename in Hetzner Console) and the label was
+	// stripped. Only the public_key comment still carries the prefix.
+	fake.unlabeled["ssh_keys"] = []map[string]any{
+		{
+			"id":         5005,
+			"name":       "operator-renamed-this-key",
+			"public_key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINnoumhQZ/ZEfnTv4cH8Kdz7N4JqeYNeKapCJelzDLHP " + prefix + "-fresh@bastion-vmi3305700",
+		},
+	}
+	cleanup := sshKeyCommentTestSetup(t, fake)
+	defer cleanup()
+
+	report, err := Purge(context.Background(), "fake-token", fqdn, nil)
+	if err != nil {
+		t.Fatalf("Purge: %v", err)
+	}
+
+	if len(report.SSHKeys) != 1 {
+		t.Fatalf("expected 1 ssh key in report (via public-key-comment fallback), got %v", report.SSHKeys)
+	}
+	if report.SSHKeys[0] != "operator-renamed-this-key" {
+		t.Errorf("report.SSHKeys[0] = %q, want %q", report.SSHKeys[0], "operator-renamed-this-key")
+	}
+	if len(fake.deletes["ssh_keys"]) != 1 || fake.deletes["ssh_keys"][0] != 5005 {
+		t.Errorf("fake DELETE ssh_keys = %v, want [5005]", fake.deletes["ssh_keys"])
+	}
+}
+
+// TestPurge_SSHKey_PublicKeyCommentFallback_BoundarySafety — CRITICAL P0
+// safety guard. Wiping `t2.omantel.biz` must NOT touch a `t20.omantel.biz`
+// SSH key whose comment is `catalyst-t20-fresh@host`. Without the
+// boundary-separator check this would be a P0: a tenant numerically-
+// neighbouring the wipe target loses their SSH key silently.
+func TestPurge_SSHKey_PublicKeyCommentFallback_BoundarySafety(t *testing.T) {
+	const fqdn = "t2.omantel.biz"
+	const prefix = "catalyst-t2-omantel-biz"
+
+	fake := newFakeHetznerSSHKeyComment(t)
+	// Neighbouring tenant's key — its comment is `catalyst-t20-omantel-biz-...`
+	// which has the SAME prefix string when naively HasPrefix'd. The
+	// boundary check must reject because the next rune is a digit, not a
+	// separator.
+	fake.unlabeled["ssh_keys"] = []map[string]any{
+		{
+			"id":         9999,
+			"name":       "catalyst-t20-omantel-biz",
+			"public_key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINnoumhQZ/ZEfnTv4cH8Kdz7N4JqeYNeKapCJelzDLHP catalyst-t20-omantel-biz-fresh@bastion",
+		},
+	}
+	cleanup := sshKeyCommentTestSetup(t, fake)
+	defer cleanup()
+
+	report, err := Purge(context.Background(), "fake-token", fqdn, nil)
+	if err != nil {
+		t.Fatalf("Purge: %v", err)
+	}
+
+	if len(report.SSHKeys) != 0 {
+		t.Fatalf("PURGE TOUCHED ANOTHER TENANT'S SSH KEY — P0 safety regression. report.SSHKeys=%v", report.SSHKeys)
+	}
+	if len(fake.deletes["ssh_keys"]) > 0 {
+		t.Fatalf("fake recorded DELETE ssh_keys %v against another tenant — P0 safety regression", fake.deletes["ssh_keys"])
+	}
+	_ = prefix // documentation
+}
+
+// TestPurge_SSHKey_PublicKeyCommentFallback_NoDoubleCount — when the
+// label or name-prefix pass already deleted a key, the comment pass MUST
+// NOT add it to the report a second time. Production case: most keys
+// carry both name + label (deleted by passes 1/2); the comment pass runs
+// against an already-empty result set.
+func TestPurge_SSHKey_PublicKeyCommentFallback_NoDoubleCount(t *testing.T) {
+	const fqdn = "t-mixed.omani.works"
+	const prefix = "catalyst-t-mixed-omani-works"
+	const fqdnLabel = "t-mixed.omani.works"
+
+	mux := http.NewServeMux()
+	deletedSSH := map[int64]int{}
+
+	// For every kind except ssh_keys, return empty.
+	for _, kind := range []string{"servers", "load_balancers", "firewalls", "networks", "volumes", "primary_ips", "floating_ips"} {
+		kind := kind
+		path := "/v1/" + kind
+		mux.HandleFunc(path, func(w http.ResponseWriter, _ *http.Request) {
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"meta": map[string]any{"pagination": map[string]any{"next_page": nil}},
+				kind:   []any{},
+			})
+		})
+	}
+	// ssh_keys — the label pass returns one key with a matching name +
+	// comment. The unlabeled pass (name-prefix + comment) ALSO returns
+	// the SAME key (Hetzner doesn't strip it between calls; it's listed
+	// regardless of selector). The third pass must NOT re-add it because
+	// it's already in report.SSHKeys.
+	mux.HandleFunc("/v1/ssh_keys", func(w http.ResponseWriter, r *http.Request) {
+		entries := []map[string]any{
+			{
+				"id":         5005,
+				"name":       prefix,
+				"public_key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINnoumhQZ/ZEfnTv4cH8Kdz7N4JqeYNeKapCJelzDLHP " + prefix + "-fresh@bastion",
+				"labels":     map[string]string{"catalyst.openova.io/sovereign": fqdnLabel},
+			},
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"meta":     map[string]any{"pagination": map[string]any{"next_page": nil}},
+			"ssh_keys": entries,
+		})
+	})
+	mux.HandleFunc("/v1/ssh_keys/", func(w http.ResponseWriter, r *http.Request) {
+		var id int64
+		fmt.Sscanf(strings.TrimPrefix(r.URL.Path, "/v1/ssh_keys/"), "%d", &id)
+		deletedSSH[id]++
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	srvURL, _ := url.Parse(srv.URL)
+	orig := purgeHTTPClient
+	purgeHTTPClient = &http.Client{
+		Transport: &rewriteTransport{from: "api.hetzner.cloud", to: srvURL, base: http.DefaultTransport},
+		Timeout:   5 * time.Second,
+	}
+	defer func() { purgeHTTPClient = orig }()
+
+	origBackoff := firewallRetryInitialBackoff
+	firewallRetryInitialBackoff = 1 * time.Millisecond
+	defer func() { firewallRetryInitialBackoff = origBackoff }()
+
+	report, err := Purge(context.Background(), "fake-token", fqdn, nil)
+	if err != nil {
+		t.Fatalf("Purge: %v", err)
+	}
+
+	if len(report.SSHKeys) != 1 || report.SSHKeys[0] != prefix {
+		t.Errorf("report.SSHKeys = %v, want exactly [%s] (no double-count)", report.SSHKeys, prefix)
+	}
+	// Hetzner DELETE 5005 may be called multiple times across passes
+	// because the fake returns the same row to every selector; what
+	// matters is the report doesn't double-count. (Hetzner real API
+	// would 404 on the second call which deleteResource treats as
+	// success — exercised by purge_name_prefix_test's NoDoubleCount.)
+}
+
+// TestPurge_SSHKey_PublicKeyCommentFallback_LeavesOtherKeys — defensive:
+// keys with NO comment, or with a comment that doesn't carry the prefix,
+// MUST be left strictly alone.
+func TestPurge_SSHKey_PublicKeyCommentFallback_LeavesOtherKeys(t *testing.T) {
+	const fqdn = "t25.omantel.biz"
+	const prefix = "catalyst-t25-omantel-biz"
+
+	fake := newFakeHetznerSSHKeyComment(t)
+	fake.unlabeled["ssh_keys"] = []map[string]any{
+		// Other Sovereign — comment doesn't match.
+		{
+			"id":         5001,
+			"name":       "operator-personal-key",
+			"public_key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINnoumhQZ/ZEfnTv4cH8Kdz7N4JqeYNeKapCJelzDLHP catalyst-t22-omantel-biz-fresh@bastion",
+		},
+		// No comment at all (only key type + data).
+		{
+			"id":         5002,
+			"name":       "operator-no-comment",
+			"public_key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINnoumhQZ/ZEfnTv4cH8Kdz7N4JqeYNeKapCJelzDLHP",
+		},
+		// Empty public_key field.
+		{
+			"id":         5003,
+			"name":       "operator-empty-pubkey",
+			"public_key": "",
+		},
+		// Matching key — MUST be deleted.
+		{
+			"id":         5004,
+			"name":       "renamed-orphan",
+			"public_key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINnoumhQZ/ZEfnTv4cH8Kdz7N4JqeYNeKapCJelzDLHP " + prefix + "@bastion",
+		},
+	}
+	cleanup := sshKeyCommentTestSetup(t, fake)
+	defer cleanup()
+
+	report, err := Purge(context.Background(), "fake-token", fqdn, nil)
+	if err != nil {
+		t.Fatalf("Purge: %v", err)
+	}
+
+	if len(report.SSHKeys) != 1 || report.SSHKeys[0] != "renamed-orphan" {
+		t.Errorf("report.SSHKeys = %v, want [renamed-orphan]", report.SSHKeys)
+	}
+	if len(fake.deletes["ssh_keys"]) != 1 || fake.deletes["ssh_keys"][0] != 5004 {
+		t.Errorf("fake DELETE ssh_keys = %v, want [5004] only — other keys must be untouched", fake.deletes["ssh_keys"])
+	}
+}
+
+// TestPublicKeyComment_ParsesFormats — unit-level pin for the OpenSSH
+// public-key comment parser. The comment field is everything after the
+// second whitespace run; we must handle keys with no comment and keys
+// whose comment itself contains whitespace.
+func TestPublicKeyComment_ParsesFormats(t *testing.T) {
+	cases := []struct {
+		name    string
+		key     string
+		comment string
+	}{
+		{"standard ed25519 with simple comment",
+			"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINnoumhQZ catalyst-t24-fresh@bastion",
+			"catalyst-t24-fresh@bastion"},
+		{"comment with whitespace",
+			"ssh-rsa AAAAsomethingsomething_b64== this is my key",
+			"this is my key"},
+		{"no comment",
+			"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINnoumhQZ",
+			""},
+		{"empty key",
+			"",
+			""},
+		{"only key type",
+			"ssh-ed25519",
+			""},
+		{"leading whitespace tolerated",
+			"  ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINnoumhQZ catalyst-t25-orphan@host  ",
+			"catalyst-t25-orphan@host"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := publicKeyComment(tc.key)
+			if got != tc.comment {
+				t.Errorf("publicKeyComment(%q) = %q, want %q", tc.key, got, tc.comment)
+			}
+		})
+	}
+}
+
+// TestCommentMatchesPrefix_BoundaryRules — unit-level pin for the
+// boundary-aware prefix match used by the third SSH-key pass. The
+// next-rune-after-prefix MUST be a separator (`-`, `.`, `@`, ` `, `_`)
+// OR end-of-string. A digit/letter means we're crossing a stem boundary
+// (e.g. t2 vs t20) and must be rejected.
+func TestCommentMatchesPrefix_BoundaryRules(t *testing.T) {
+	cases := []struct {
+		comment string
+		prefix  string
+		want    bool
+	}{
+		{"catalyst-t25-omantel-biz", "catalyst-t25-omantel-biz", true},   // exact match
+		{"catalyst-t25-omantel-biz-cp1", "catalyst-t25-omantel-biz", true}, // separator '-'
+		{"catalyst-t25-omantel-biz@host", "catalyst-t25-omantel-biz", true}, // separator '@'
+		{"catalyst-t25-omantel-biz host", "catalyst-t25-omantel-biz", true}, // separator ' '
+		{"catalyst-t25-omantel-biz.suffix", "catalyst-t25-omantel-biz", true}, // separator '.'
+		{"catalyst-t20-omantel-biz", "catalyst-t2-omantel-biz", false},   // digit boundary breach
+		{"catalyst-t25-omantel-bizUNRELATED", "catalyst-t25-omantel-biz", false}, // letter boundary breach
+		{"catalyst-t25", "catalyst-t2", false},                            // would-be P0
+		{"", "catalyst-t25-omantel-biz", false},                           // empty comment
+		{"catalyst-t25-omantel-biz", "", false},                           // empty prefix
+		{"otherprefix-catalyst-t25-omantel-biz", "catalyst-t25-omantel-biz", false}, // prefix not at start
+	}
+	for _, tc := range cases {
+		got := commentMatchesPrefix(tc.comment, tc.prefix)
+		if got != tc.want {
+			t.Errorf("commentMatchesPrefix(%q, %q) = %v, want %v",
+				tc.comment, tc.prefix, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Extends `hetzner.Purge` with a third match vector — SSH keys whose `public_key` comment field starts with the canonical `catalyst-<fqdn-dashes>` prefix.
- Catches orphans whose **name AND label** both drifted from the Tofu module's canonical emission (Console rename, partial tofu apply, manual hcloud-cli edits).
- Boundary-aware HasPrefix check enforces a separator rune after the prefix so wiping `t2.omantel.biz` cannot touch `t20.omantel.biz`'s key (same P0 safety guard as the name-prefix pass).

## Why

Caught in production 2026-05-18: `catalyst-t24-omantel-biz` SSH key persisted through every prior wipe cycle and blocked fresh t25 provs. The label-pass + name-prefix-pass had no signal once the metadata drifted. The OpenSSH `public_key` comment is stamped by bootstrap-cli at key generation and resists every drift vector.

## Test plan

- [x] `TestPurge_SSHKey_PublicKeyCommentFallback_DeletesUnlabeled` — third pass deletes a renamed/unlabeled orphan
- [x] `TestPurge_SSHKey_PublicKeyCommentFallback_BoundarySafety` — P0 pin: wiping `t2` does NOT delete `t20`'s key
- [x] `TestPurge_SSHKey_PublicKeyCommentFallback_NoDoubleCount` — idempotent vs label + name-prefix passes
- [x] `TestPurge_SSHKey_PublicKeyCommentFallback_LeavesOtherKeys` — other tenants' keys untouched
- [x] `TestPublicKeyComment_ParsesFormats` — OpenSSH parser handles no-comment, whitespace-in-comment, malformed input
- [x] `TestCommentMatchesPrefix_BoundaryRules` — separator-rune table guards against numeric extension breaches
- [x] Full `./internal/hetzner/...` test suite green; full `./...` build green

Cleanup of the actual orphan `catalyst-t24-omantel-biz` + the partial t25 deployment (15ef8e2218c4ba2a) was completed out-of-band via direct Hetzner API DELETE + the canonical wipe endpoint while this PR was authored.

Refs TBD-A16

🤖 Generated with [Claude Code](https://claude.com/claude-code)