### PR TITLE
fix(cutover): RBAC + sovereign-fqdn ConfigMap + kubeconfig?region path — 3 t24 zero-touch P1 blockers (Closes #1843, #1844, #1845)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -588,7 +588,22 @@ spec:
       # to the admin password byte, so every subsequent SME provisioning
       # call to Gitea returned 401 "user does not exist" and journey
       # step 16 (tenant repo creation) silently stuck.
-      version: 1.4.178
+      # 1.4.179 (TBD-A14/A15/A10b, 2026-05-18): three t24 zero-touch
+      # Wave 36 P1 fresh-prov blockers — see chart Chart.yaml header for
+      # the full diagnostic + fix description per gate.
+      #   - A14 issue #1843: networkpolicies (networking.k8s.io) RBAC
+      #     get/list/watch verbs added to clusterrole-cutover-driver.
+      #   - A15 issue #1844: sovereign-fqdn ConfigMap empty fields
+      #     populated end-to-end via the cloud-init → bootstrap-kit →
+      #     chart substitute chain (configuredRegions / controlPlaneIP /
+      #     primaryRegion / replicaRegion / selfDeploymentId /
+      #     enableHotStandby / qaApplications). This Kustomization gains
+      #     3 new value mappings: global.sovereignSelfDeploymentId,
+      #     sovereign.configuredRegions, sovereign.qaApplications.
+      #   - A10b issue #1845: GET kubeconfig?region=<cloudRegion>
+      #     resolves the slot-suffixed on-disk shape
+      #     `<id>-<region>-<i>.yaml` (handler-side glob fallback).
+      version: 1.4.179
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform
@@ -674,6 +689,15 @@ spec:
       # then short-circuits the glue registration and falls back to plain
       # set_ns (legacy behaviour).
       sovereignLBIP: ${SOVEREIGN_LB_IP}
+      # sovereignSelfDeploymentId — the catalyst-api deployment-record id
+      # this Sovereign was provisioned under on the contabo mothership.
+      # Threaded from cloud-init's SOVEREIGN_DEPLOYMENT_ID Kustomization
+      # postBuild substitute. Consumed by the chart's sovereign-fqdn
+      # ConfigMap `selfDeploymentId` key so the chroot catalyst-api's
+      # GET /api/v1/sovereign/self answers with the correct id at
+      # handover-time (no wait for the orchestrator's chart-values
+      # overlay write). TBD-A15 (t24 zero-touch, 2026-05-18, issue #1844).
+      sovereignSelfDeploymentId: '${SOVEREIGN_DEPLOYMENT_ID:-}'
     ingress:
       hosts:
         console:
@@ -786,6 +810,23 @@ spec:
       enableHotStandby: '${SOVEREIGN_ENABLE_HOT_STANDBY:-}'
       primaryRegion: '${SOVEREIGN_PRIMARY_REGION:-}'
       replicaRegion: '${SOVEREIGN_REPLICA_REGION:-}'
+      # configuredRegions — YAML list of region keys this Sovereign was
+      # provisioned with (e.g. ["fsn1", "hel1"]). Threaded from cloud-init's
+      # SOVEREIGN_CONFIGURED_REGIONS_YAML Kustomization postBuild substitute
+      # which the tofu module renders as a YAML inline list literal from
+      # var.regions[*].cloudRegion. The chart's sovereign-fqdn ConfigMap
+      # joins this list into a comma-separated `configuredRegions` key for
+      # the catalyst-ui Dashboard SovereignCard + Networking → ClusterMesh
+      # tab to render configured-but-not-active chips. Defaults to empty
+      # list so non-multi-region Sovereigns surface only their live region.
+      # TBD-A15 (t24 zero-touch, 2026-05-18, issue #1844).
+      configuredRegions: ${SOVEREIGN_CONFIGURED_REGIONS_YAML:-[]}
+      # qaApplications — YAML list of qa-fixtures applicationRef literals
+      # the chroot Sovereign's /compliance/scorecard surface emits via
+      # appRefs[]. Default empty so production Sovereigns surface only
+      # PolicyReport-observed apps. QA Sovereigns set via QA_APPLICATIONS_YAML.
+      # TBD-A15 (t24 zero-touch, 2026-05-18, issue #1844).
+      qaApplications: ${QA_APPLICATIONS_YAML:-[]}
     # ─── QA fixtures (qa-loop iter-6 Cluster-F + EPIC-6 iter-6) ────────
     # Default-OFF on production; flipped to true via envsubst
     # QA_FIXTURES_ENABLED=true on the per-Sovereign overlay for any

--- a/infra/hetzner/cloudinit-control-plane.tftpl
+++ b/infra/hetzner/cloudinit-control-plane.tftpl
@@ -1072,6 +1072,51 @@ write_files:
             ORG_EMAIL: "${org_email}"
             ORG_NAME: "${org_name}"
             GITOPS_REPO_URL: "${gitops_repo_url}"
+            # TBD-A15 (t24 zero-touch, 2026-05-18, issue #1844) — wire the
+            # remaining sovereign-fqdn ConfigMap fields the chart's bootstrap-
+            # kit slot 13 expects via envsubst. Previously these placeholders
+            # resolved to empty on every fresh prov because nothing was
+            # writing them into the Kustomization substitute map → catalyst-
+            # api on the Sovereign read empty strings → Dashboard "configured
+            # regions" chips, settings page, D31 hot-standby gating, and
+            # /api/v1/sovereign/self all silently returned defaults.
+            #
+            # SOVEREIGN_CONTROL_PLANE_IP — Sovereign's CP public IPv4. We
+            # cannot reference hcloud_server.control_plane.ipv4_address here
+            # (dep cycle), but the load balancer IP IS the canonical control-
+            # plane address operators interact with (kubectl, console, API).
+            # Same value as SOVEREIGN_LB_IP — duplicating intentionally so a
+            # future split (separate CP-direct IP vs LB-IP) can rewire only
+            # this key without breaking the SOVEREIGN_LB_IP consumers.
+            SOVEREIGN_CONTROL_PLANE_IP: "${load_balancer_ipv4}"
+            # SOVEREIGN_PRIMARY_REGION / SOVEREIGN_REPLICA_REGION — canonical
+            # 4-segment region labels (e.g. `hz-fsn-rtz-prod`, `hz-hel-rtz-
+            # prod`). Threaded into bootstrap-kit slot 13's
+            # `sovereign.primaryRegion/replicaRegion` substitutes which feed
+            # the chart's sovereign-fqdn ConfigMap. replicaRegion is the
+            # first non-primary region's label; empty on single-region
+            # Sovereigns (the D31 ReplicaCluster shape is skipped when
+            # replicaRegion is empty per sme_tenant_gitops.go contract).
+            SOVEREIGN_PRIMARY_REGION: "${primary_region_canonical_label}"
+            SOVEREIGN_REPLICA_REGION: "${replica_region_canonical_label}"
+            # SOVEREIGN_ENABLE_HOT_STANDBY — D31 opt-in. Default empty
+            # (= disabled) on every fresh prov; operators / wizard flip via
+            # per-Sovereign overlay write. Reserved here so a future tofu
+            # variable can populate without a chart-side change.
+            SOVEREIGN_ENABLE_HOT_STANDBY: ""
+            # SOVEREIGN_CONFIGURED_REGIONS_YAML — YAML inline-list literal of
+            # the cloudRegions this Sovereign was provisioned with
+            # (e.g. `["fsn1","hel1"]`). Chart joins into the comma-separated
+            # `configuredRegions` ConfigMap key for the Dashboard
+            # SovereignCard + Networking → ClusterMesh tab chips. Single-
+            # quoted so YAML treats the JSON braces as literal — same
+            # pattern as PARENT_DOMAINS_YAML above.
+            SOVEREIGN_CONFIGURED_REGIONS_YAML: '${sovereign_configured_regions_yaml}'
+            # QA_APPLICATIONS_YAML — Reserved placeholder for the QA
+            # appRefs list. Default empty so production Sovereigns surface
+            # only PolicyReport-observed apps; QA Sovereigns will populate
+            # via a future tofu variable.
+            QA_APPLICATIONS_YAML: "[]"
             # QA fixtures auto-enable (Fix #73 — qa-loop bounded-cycle
             # iter-16). Default "false" so a customer-facing zero-touch
             # provision lands a Sovereign with NO qaFixtures stack

--- a/infra/hetzner/main.tf
+++ b/infra/hetzner/main.tf
@@ -689,6 +689,19 @@ locals {
     # chroot Deployment so /infrastructure/topology returns the
     # full multi-region tree (DoD D5).
     sovereign_regions_json = jsonencode(var.regions)
+    # sovereign_configured_regions_yaml — YAML inline-list literal of the
+    # cloudRegions this Sovereign was provisioned with (e.g. `["fsn1","hel1"]`).
+    # Threaded into bootstrap-kit slot 13's
+    # `sovereign.configuredRegions: ${SOVEREIGN_CONFIGURED_REGIONS_YAML:-[]}`
+    # substitute (PR for issue #1844). The chart's sovereign-fqdn ConfigMap
+    # joins this list into a comma-separated `configuredRegions` key for the
+    # catalyst-ui Dashboard's SovereignCard + Networking → ClusterMesh tab.
+    # When var.regions is empty (back-compat singular-region path) the
+    # rendered YAML is `[]` so the chart's `default (list)` keeps the
+    # ConfigMap key empty (no regression).
+    sovereign_configured_regions_yaml = jsonencode([
+      for r in var.regions : r.cloudRegion
+    ])
     org_name  = var.org_name
     org_email = var.org_email
     region    = var.region
@@ -705,6 +718,16 @@ locals {
     # primaryRegion follows the actual Sovereign primary, never the
     # chart's hardcoded `hz-fsn-rtz-prod` default.
     primary_region_canonical_label = local.region_canonical_label["primary"]
+    # First non-primary canonical region label (used as the D31
+    # active-hot-standby `replicaRegion` default). Threaded into the
+    # bootstrap-kit Kustomization's SOVEREIGN_REPLICA_REGION substitute
+    # so the chart's `sovereign.replicaRegion` is populated on every
+    # multi-region Sovereign without a per-overlay write. Empty when
+    # the Sovereign is single-region (var.regions length <= 1). TBD-A15
+    # (issue #1844, 2026-05-18).
+    replica_region_canonical_label = length(local.secondary_regions) > 0 ? (
+      local.region_canonical_label[keys(local.secondary_regions)[0]]
+    ) : ""
     # Per-role vCluster enable flags (DoD A4 topology). Primary region
     # renders MGMT+DMZ vClusters → mgmt_vcluster_enabled=true. RTZ stays
     # off here — secondary regions flip RTZ on. The bp-dmz-vcluster slot
@@ -1233,6 +1256,11 @@ locals {
       # bp-catalyst-platform renders the same sovereign.regionsJson value
       # (the cluster topology is Sovereign-wide, not per-region).
       sovereign_regions_json = jsonencode(var.regions)
+      # Same SOVEREIGN_CONFIGURED_REGIONS_YAML as the primary — chart-wide
+      # configuredRegions list is Sovereign-wide invariant. TBD-A15.
+      sovereign_configured_regions_yaml = jsonencode([
+        for rr in var.regions : rr.cloudRegion
+      ])
       org_name  = var.org_name
       org_email = var.org_email
       region    = r.cloudRegion
@@ -1247,6 +1275,11 @@ locals {
       # Sovereign-wide primary region (qaFixtures.primaryRegion is
       # singular per the chart contract).
       primary_region_canonical_label = local.region_canonical_label["primary"]
+      # Same as primary CP — Sovereign-wide D31 active-hot-standby
+      # replicaRegion default (first non-primary region's canonical label).
+      replica_region_canonical_label = length(local.secondary_regions) > 0 ? (
+        local.region_canonical_label[keys(local.secondary_regions)[0]]
+      ) : ""
       # Per-role vCluster enable flags (DoD A4). Secondary region
       # renders DMZ+RTZ vCluster → rtz_vcluster_enabled=true. MGMT
       # stays off on secondaries (single MGMT vCluster on primary).

--- a/products/catalyst/bootstrap/api/internal/handler/kubeconfig.go
+++ b/products/catalyst/bootstrap/api/internal/handler/kubeconfig.go
@@ -90,6 +90,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -150,6 +151,22 @@ func (h *Handler) GetKubeconfig(w http.ResponseWriter, r *http.Request) {
 	// id-region.yaml. Empty region falls through to the primary path
 	// stamped on Result.KubeconfigPath (preserves backwards-compat for
 	// every caller that doesn't pass the query).
+	//
+	// TBD-A10b (t24 zero-touch, 2026-05-18, issue #1845): the cloud-init
+	// PUT-back uses the tofu secondary-region key shape
+	// `<cloudRegion>-<i>` (e.g. `hel1-1`, `nbg1-2`) — see
+	// infra/hetzner/main.tf:509-513 + local.secondary_region_cloud_init's
+	// kubeconfig_postback_region. The mothership-to-chroot D16 fan-out in
+	// deployment_handover_export.go's regionKeysForExport ALSO emits
+	// `<cloudRegion>-<i>` so the on-disk filename is
+	// `<id>-<cloudRegion>-<i>.yaml`. Operators + verifiers commonly call
+	// with just the bare `cloudRegion` (`?region=hel1`) because that's
+	// the matrix-doc-friendly form (`hetzner` provider's
+	// `regions.cloudRegion`). Pre-fix the bare form 409'd because the
+	// exact filename wasn't on disk. Fall-back resolution order:
+	//   1. <id>-<region>.yaml exact match (legacy + manual operator PUT)
+	//   2. <id>-<region>-<digit>.yaml first alphabetically (covers the
+	//      cloud-init/handover-fan-out naming convention)
 	if region != "" {
 		if h.kubeconfigsDir == "" {
 			writeJSON(w, http.StatusServiceUnavailable, map[string]string{
@@ -159,6 +176,21 @@ func (h *Handler) GetKubeconfig(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		path = filepath.Join(h.kubeconfigsDir, id+"-"+region+".yaml")
+		if _, statErr := os.Stat(path); errors.Is(statErr, os.ErrNotExist) {
+			// Fall back to the tofu/handover slot-suffixed shape:
+			// `<id>-<region>-<i>.yaml`. We accept the lexicographically
+			// first match — slot indices start at 1 and are stable per
+			// Sovereign so there's never more than one match in practice,
+			// but the sort ordering keeps the choice deterministic.
+			matches, _ := filepath.Glob(filepath.Join(h.kubeconfigsDir, id+"-"+region+"-*.yaml"))
+			if len(matches) > 0 {
+				sort.Strings(matches)
+				path = matches[0]
+				h.log.Info("kubeconfig per-region resolved via slot-suffix glob",
+					"id", id, "region", region, "matchedPath", path, "candidates", len(matches),
+				)
+			}
+		}
 	}
 
 	if path == "" {

--- a/products/catalyst/bootstrap/api/internal/handler/kubeconfig_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/kubeconfig_test.go
@@ -1084,3 +1084,105 @@ func TestGetKubeconfig_UsesSubdomainAsContextName(t *testing.T) {
 		t.Errorf("Content-Disposition = %q, want filename=otech94.yaml", cd)
 	}
 }
+
+// TBD-A10b — t24 zero-touch (issue #1845).
+//
+// GET /kubeconfig?region=<cloudRegion> must resolve to the on-disk
+// secondary kubeconfig even when the file uses the tofu
+// `<cloudRegion>-<slotIndex>` naming convention (e.g. `hel1-1`,
+// `nbg1-2`). Pre-fix the bare `cloudRegion` form 409'd because the
+// handler only looked at `<id>-<region>.yaml` exactly.
+//
+// Walks the two on-disk shapes we ship with today:
+//
+//	A) exact match  — operator-manual PUT at `?region=hel1`
+//	   → file `<dir>/<id>-hel1.yaml` → exact-name resolution wins.
+//	B) glob fallback — cloud-init / mothership fan-out at
+//	   `?region=hel1-1` → file `<dir>/<id>-hel1-1.yaml`. GET caller
+//	   passes the bare `?region=hel1` → exact match misses, glob
+//	   `<id>-hel1-*.yaml` resolves to `<id>-hel1-1.yaml`.
+func TestGetKubeconfig_PerRegion_SlotSuffixGlobFallback(t *testing.T) {
+	kubeconfigsDir := t.TempDir()
+	deploymentsDir := t.TempDir()
+	st, _ := store.New(deploymentsDir)
+	h := NewWithStoreAndKubeconfigsDir(silentLogger(), &fakePDM{}, st, kubeconfigsDir)
+
+	id := "a10b-region-fallback"
+	dep := &Deployment{
+		ID:        id,
+		Status:    "ready",
+		StartedAt: time.Now(),
+		eventsCh:  make(chan provisioner.Event, 256),
+		done:      make(chan struct{}),
+		Request: provisioner.Request{
+			SovereignFQDN: "test." + id + ".example",
+		},
+		Result: &provisioner.Result{
+			SovereignFQDN: "test." + id + ".example",
+		},
+	}
+	h.deployments.Store(id, dep)
+
+	// Path A — write the legacy exact-match file for region "fsn1".
+	exactRegion := "fsn1"
+	exactPath := filepath.Join(kubeconfigsDir, id+"-"+exactRegion+".yaml")
+	if err := os.WriteFile(exactPath, []byte(validKubeconfigYAML), 0o600); err != nil {
+		t.Fatalf("write exact-name file: %v", err)
+	}
+
+	// Path B — write the cloud-init slot-suffix file for cloudRegion
+	// "hel1" (slot index 1 in the tofu secondary_regions map).
+	cloudRegion := "hel1"
+	slotPath := filepath.Join(kubeconfigsDir, id+"-"+cloudRegion+"-1.yaml")
+	if err := os.WriteFile(slotPath, []byte(validKubeconfigYAML), 0o600); err != nil {
+		t.Fatalf("write slot-suffix file: %v", err)
+	}
+
+	cases := []struct {
+		name        string
+		regionQuery string
+		wantFile    string
+	}{
+		{"exact-match", exactRegion, exactPath},
+		{"slot-suffix-fallback", cloudRegion, slotPath},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			r := httptest.NewRequest(http.MethodGet,
+				"/api/v1/deployments/"+id+"/kubeconfig?region="+c.regionQuery, nil)
+			rctx := chi.NewRouteContext()
+			rctx.URLParams.Add("id", id)
+			r = r.WithContext(context.WithValue(r.Context(), chi.RouteCtxKey, rctx))
+			h.GetKubeconfig(w, r)
+
+			if w.Code != http.StatusOK {
+				t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
+			}
+			// Sanity: the served payload retains the CA + token
+			// markers from the fixture (rewriter preserves them).
+			if !strings.Contains(w.Body.String(), "TEST-CA-MARKER") {
+				t.Errorf("served body missing TEST-CA-MARKER:\n%s", w.Body.String())
+			}
+		})
+	}
+
+	// Path C — missing region returns 409 (preserves the
+	// kubeconfig-file-missing contract for the operator's "wrong region
+	// name" path).
+	t.Run("unknown-region-still-409", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodGet,
+			"/api/v1/deployments/"+id+"/kubeconfig?region=does-not-exist", nil)
+		rctx := chi.NewRouteContext()
+		rctx.URLParams.Add("id", id)
+		r = r.WithContext(context.WithValue(r.Context(), chi.RouteCtxKey, rctx))
+		h.GetKubeconfig(w, r)
+		if w.Code != http.StatusConflict {
+			t.Fatalf("status = %d, want 409; body=%s", w.Code, w.Body.String())
+		}
+		if !strings.Contains(w.Body.String(), "kubeconfig-file-missing") {
+			t.Errorf("body should mention kubeconfig-file-missing; got %s", w.Body.String())
+		}
+	})
+}

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -1192,6 +1192,54 @@ name: bp-catalyst-platform
 # is operator-tunable via `.Values.security.baselineCnp.allowedIngressNamespaces`,
 # mirroring the existing allowedPlatformNamespaces pattern on the egress
 # side. Refs PR #1785 (1.4.171), t24 zero-touch finding.
+# 1.4.179 (TBD-A14 / TBD-A15 / TBD-A10b, 2026-05-18): three t24 zero-touch
+# (Wave 36) P1 fresh-prov blockers ship together as one chart + bootstrap-
+# kit + cloud-init bump.
+#
+#  - TBD-A14 (issue #1843): clusterrole-cutover-driver gains
+#    networking.k8s.io/networkpolicies get/list/watch verbs. Pre-fix the
+#    chroot in-cluster fallback's k8sCache.Factory reflector emitted
+#    continuous `networkpolicies is forbidden` errors at the cluster
+#    scope because only update/patch/delete were granted (existing
+#    mutation block) — the read path was never wired. Mirrors the
+#    cilium.io/ciliumnetworkpolicies entry below; the two CRDs co-exist
+#    (k8s NetworkPolicy = baseline L3/L4, CiliumNetworkPolicy = tier-3 L7
+#    + DNS/HTTP).
+#
+#  - TBD-A15 (issue #1844): sovereign-fqdn ConfigMap fields configured
+#    Regions / controlPlaneIP / primaryRegion / replicaRegion /
+#    selfDeploymentId / enableHotStandby / qaApplications populated on
+#    every fresh prov. Pre-fix these envsubst placeholders resolved to
+#    empty because nothing wrote them into the bootstrap-kit
+#    Kustomization postBuild substitute map → the chart rendered empty
+#    strings → Dashboard SovereignCard configured-regions chips,
+#    Settings page operator-identity, /api/v1/sovereign/self, and the
+#    D31 active-hot-standby gating ALL silently fell through to default
+#    behaviour. Wired via three coordinated changes:
+#       (a) Chart values.yaml — new global.sovereignSelfDeploymentId
+#           default "" with full inline doc.
+#       (b) clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+#           — global.sovereignSelfDeploymentId, sovereign.configuredRegions,
+#           sovereign.qaApplications added with YAML inline-list shape
+#           (`${SOVEREIGN_CONFIGURED_REGIONS_YAML:-[]}`).
+#       (c) infra/hetzner/cloudinit-control-plane.tftpl — substitutes
+#           map gains SOVEREIGN_CONTROL_PLANE_IP / SOVEREIGN_PRIMARY_REGION /
+#           SOVEREIGN_REPLICA_REGION / SOVEREIGN_ENABLE_HOT_STANDBY /
+#           SOVEREIGN_CONFIGURED_REGIONS_YAML / QA_APPLICATIONS_YAML.
+#           SOVEREIGN_CONTROL_PLANE_IP uses load_balancer_ipv4 (the
+#           canonical operator-facing CP IP); replicaRegion derives
+#           from the first non-primary canonical label.
+#
+#  - TBD-A10b (issue #1845): GET /api/v1/deployments/{id}/kubeconfig?region=
+#    <cloudRegion> resolves the on-disk secondary kubeconfig even when
+#    callers pass the bare `cloudRegion` (`?region=hel1`) and the file
+#    is at the tofu slot-suffixed shape `<id>-hel1-1.yaml`. Pre-fix the
+#    handler 409'd because it only looked for `<id>-hel1.yaml` exactly.
+#    Resolution order: exact match first (legacy + manual PUT), then
+#    `<id>-<region>-*.yaml` glob fallback (deterministic via
+#    sort.Strings, first wins). Closes the regression introduced when
+#    PR #1763 (mothership→chroot kubeconfig handover hook) started
+#    using the cloud-init naming convention for fan-out exports.
 # 1.4.177 (TBD-CNP-SMTP-Egress, 2026-05-18): fix regression introduced by
 # #1785 (1.4.171 baseline CNPs). The catalyst-system default-deny CNP
 # limited world egress to TCP/443 only, which silently broke SMTP
@@ -1209,8 +1257,8 @@ name: bp-catalyst-platform
 # 25/TCP (legacy SMTP fallback). All three are explicitly scoped to
 # `toEntities: world`, matching the existing 443/TCP allow. No other
 # rule semantics change. (Fixes PIN-issue 502 regression from #1785.)
-version: 1.4.178
-appVersion: 1.4.178
+version: 1.4.179
+appVersion: 1.4.179
 # 1.4.172 — feat(security): baseline CiliumNetworkPolicies for
 # catalyst-system + cilium-gateway (Closes #1746, Refs TBD-Cov-12 /
 # C12-009). Cov-bench audit on the live Sovereign cluster confirmed

--- a/products/catalyst/chart/templates/clusterrole-cutover-driver.yaml
+++ b/products/catalyst/chart/templates/clusterrole-cutover-driver.yaml
@@ -150,6 +150,20 @@ rules:
   - apiGroups: ["networking.k8s.io"]
     resources: ["ingresses"]
     verbs: ["get", "list", "watch"]
+  # NetworkPolicy (networking.k8s.io) — TBD-A14 (t24 zero-touch, 2026-05-18,
+  # issue #1843). Without these read verbs the chroot in-cluster fallback
+  # (k8sCache.Factory reflector + the /networking-policies aggregator) gets
+  # continuous `networkpolicies.networking.k8s.io is forbidden: User
+  # system:serviceaccount:catalyst-system:catalyst-api-cutover-driver cannot
+  # list resource networkpolicies in API group networking.k8s.io at the
+  # cluster scope` errors. Mirrors the cilium.io/ciliumnetworkpolicies block
+  # in the QA-loop iter-11 Fix #48 section below — the two CRDs co-exist
+  # (k8s NetworkPolicy = baseline L3/L4, CiliumNetworkPolicy = tier-3 L7).
+  # Read-only verbs only — NetworkPolicies are authored by the qa-fixtures
+  # chart + customer overlays, never by catalyst-api at runtime.
+  - apiGroups: ["networking.k8s.io"]
+    resources: ["networkpolicies"]
+    verbs: ["get", "list", "watch"]
   - apiGroups: ["gateway.networking.k8s.io"]
     resources: ["httproutes", "gateways"]
     verbs: ["get", "list", "watch"]

--- a/products/catalyst/chart/values.yaml
+++ b/products/catalyst/chart/values.yaml
@@ -27,6 +27,19 @@ global:
   # registrars never need it. Per docs/INVIOLABLE-PRINCIPLES.md #4 the
   # value is fully runtime-configurable.
   sovereignLBIP: ""
+  # sovereignSelfDeploymentId — the catalyst-api deployment-record id this
+  # Sovereign was provisioned under on the contabo mothership. Wired by
+  # bootstrap-kit slot 13 from the ${SOVEREIGN_DEPLOYMENT_ID} cloud-init
+  # postBuild substitute. Consumed by the chart's sovereign-fqdn ConfigMap
+  # `selfDeploymentId` key so the chroot catalyst-api's
+  # GET /api/v1/sovereign/self answers with the correct id at handover-
+  # time, without waiting for the orchestrator's chart-values overlay
+  # write. Empty when the chart was rendered outside the bootstrap-kit
+  # slot 13 flow (e.g. contabo Catalyst-Zero / local dev) — the chroot
+  # self handler returns 503 deployment-id-not-yet-stamped until the
+  # orchestrator writes the per-Sovereign overlay. TBD-A15 (t24 zero-
+  # touch, 2026-05-18, issue #1844).
+  sovereignSelfDeploymentId: ""
 
 # ─── Sovereign-side defaults (issue #901) ──────────────────────────────
 # Knobs that exclusively affect the franchised-Sovereign install path


### PR DESCRIPTION
## Summary

Three Wave 36 t24 zero-touch P1 fresh-prov blockers ship together as one chart 1.4.179 + bootstrap-kit pin bump + cloud-init substitute extension, because each fix is small and they share the same fresh-prov verification cycle.

### TBD-A14 (#1843) — networkpolicies RBAC

catalyst-api-cutover-driver SA could not list `networkpolicies.networking.k8s.io` cluster-scope; the chroot in-cluster fallback's k8sCache.Factory reflector emitted continuous `is forbidden` errors. Only mutation verbs were granted; the read path was never wired.

Fix: add `networking.k8s.io/networkpolicies` `get,list,watch` to `clusterrole-cutover-driver.yaml`. Mirrors the existing `cilium.io/ciliumnetworkpolicies` block.

### TBD-A15 (#1844) — sovereign-fqdn ConfigMap empty fields

On fresh prov, ConfigMap fields `configuredRegions / controlPlaneIP / primaryRegion / replicaRegion / selfDeploymentId / enableHotStandby / qaApplications` were all empty. The envsubst placeholders the chart consumes resolved to defaults because nothing wrote them into the bootstrap-kit Kustomization substitute map.

Fix — three coordinated changes:
- `products/catalyst/chart/values.yaml` — new `global.sovereignSelfDeploymentId` default
- `clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml` — new `global.sovereignSelfDeploymentId`, `sovereign.configuredRegions`, `sovereign.qaApplications` mappings (YAML inline-list shape, e.g. `${SOVEREIGN_CONFIGURED_REGIONS_YAML:-[]}`)
- `infra/hetzner/cloudinit-control-plane.tftpl` — substitute map gains `SOVEREIGN_CONTROL_PLANE_IP` (load_balancer_ipv4), `SOVEREIGN_PRIMARY_REGION` / `SOVEREIGN_REPLICA_REGION` (canonical 4-segment labels), `SOVEREIGN_ENABLE_HOT_STANDBY` (reserved, default empty), `SOVEREIGN_CONFIGURED_REGIONS_YAML` (JSON-encoded cloudRegion list), `QA_APPLICATIONS_YAML` (reserved, default `[]`)
- `infra/hetzner/main.tf` — new template inputs `sovereign_configured_regions_yaml` + `replica_region_canonical_label` (derived from `local.secondary_regions`), threaded into primary CP AND per-secondary-region cloud-init templatefile calls

### TBD-A10b (#1845) — kubeconfig?region= 409

GET `/api/v1/deployments/{id}/kubeconfig?region=hel1` returned 409 kubeconfig-file-missing on fresh prov. The handler only resolved `<id>-<region>.yaml` exactly, but the cloud-init PUT-back + mothership→chroot D16 fan-out use the tofu secondary-region key shape `<cloudRegion>-<i>` (e.g. `hel1-1`). On-disk filenames look like `<id>-hel1-1.yaml` — bare `?region=hel1` never matched.

Fix: GetKubeconfig fall-back resolution order — exact match first (legacy + manual PUT), then `<id>-<region>-*.yaml` glob (sort.Strings deterministic). Regression introduced by PR #1763 (mothership→chroot kubeconfig handover hook).

## Files modified

- `products/catalyst/chart/templates/clusterrole-cutover-driver.yaml` — networkpolicies verbs
- `products/catalyst/chart/templates/sovereign-fqdn-configmap.yaml` — already had the consumer block (no change), but verified renders correctly with new bootstrap-kit values
- `products/catalyst/chart/values.yaml` — global.sovereignSelfDeploymentId default
- `products/catalyst/chart/Chart.yaml` — 1.4.178 → 1.4.179 + diagnostic header comment
- `clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml` — 3 new value mappings + version pin 1.4.177 → 1.4.179
- `infra/hetzner/cloudinit-control-plane.tftpl` — 6 new substitute keys
- `infra/hetzner/main.tf` — 2 new template inputs (primary + secondary)
- `products/catalyst/bootstrap/api/internal/handler/kubeconfig.go` — glob fallback resolver
- `products/catalyst/bootstrap/api/internal/handler/kubeconfig_test.go` — new TestGetKubeconfig_PerRegion_SlotSuffixGlobFallback (3 sub-cases: exact match, slot-suffix glob, unknown-region 409)

## Test plan

- [x] Unit: `go test ./internal/handler/ -run TestGetKubeconfig_PerRegion_SlotSuffixGlobFallback` — 3/3 PASS
- [x] Unit: `go test ./internal/handler/ -run "TestGetKubeconfig|TestPutKubeconfig"` — full kubeconfig suite GREEN
- [x] Helm template: `helm template products/catalyst/chart --set global.sovereignFQDN=test.example --set global.sovereignSelfDeploymentId=abc123def456 --set 'sovereign.configuredRegions={fsn1,hel1,nbg1}' --set sovereign.controlPlaneIP=203.0.113.10 --set sovereign.primaryRegion=hz-fsn-rtz-prod --set sovereign.replicaRegion=hz-hel-rtz-prod --set sovereign.enableHotStandby=true --show-only templates/sovereign-fqdn-configmap.yaml` — all fields render
- [x] Helm template: `--show-only templates/clusterrole-cutover-driver.yaml` — networkpolicies rule renders
- [ ] Fresh prov t25 (next zero-touch cycle): verify sovereign-fqdn ConfigMap has every field populated + GET /kubeconfig?region=hel1 returns 200 + cutover-driver SA can list NetworkPolicies cluster-scope

🤖 Generated with [Claude Code](https://claude.com/claude-code)