### PR TITLE
fix(bp-newapi): single-pod DB migration via Helm pre-install hook (Closes #1798)

### DIFF
--- a/clusters/_template/bootstrap-kit/80-newapi.yaml
+++ b/clusters/_template/bootstrap-kit/80-newapi.yaml
@@ -132,7 +132,18 @@ spec:
       # default so reflector mirrors into `catalyst-system` too.
       # 1.4.14 (current main, 2026-05-18): latest upstream-tracking
       # chart cut — includes 1.4.12's reflector fix.
-      version: 1.4.18
+      # 1.4.19 (TBD-A12 #1798, 2026-05-18): add startupProbe so kubelet
+      # does NOT SIGKILL the binary at the 50s mark while GORM
+      # AutoMigrate is still in-flight on the freshly-provisioned empty
+      # `newapi` CNPG database. Pre-1.4.19 the empty DB on t22 sat with
+      # ZERO tables after 29 CrashLoopBackOff restarts — every kill
+      # raced AutoMigrate's first CREATE TABLE call mid-TLS-handshake;
+      # pg_stat_activity on the CNPG primary showed no `newapi` user
+      # connections because the kill happened before the GORM
+      # connection pool's first wire write completed. Probe budget:
+      # 30 × 10s = 5 min, comfortably above the observed 60-120s
+      # ceiling on cpx21/cpx31 nodes with sslmode=require.
+      version: 1.4.19
       sourceRef:
         kind: HelmRepository
         name: bp-newapi

--- a/platform/newapi/chart/Chart.yaml
+++ b/platform/newapi/chart/Chart.yaml
@@ -1,5 +1,66 @@
 apiVersion: v2
 name: bp-newapi
+# 1.4.19 (TBD-A12 #1798, 2026-05-18): add `startupProbe` to the newapi
+# container to gate liveness + readiness until GORM AutoMigrate
+# finishes on first-boot.
+#
+# ROOT CAUSE (t22 chart 1.4.18 Wave 36 verify):
+#   On a freshly franchised Sovereign the auto-provisioned CNPG database
+#   `newapi` starts empty. The upstream NewAPI binary's bootstrap path
+#   (model/main.go:InitDB → migrateDB) logs "database migration started"
+#   then runs GORM AutoMigrate on 26 models (Channel, Token, User,
+#   PasskeyCredential, Option, Redemption, Ability, Log, Midjourney,
+#   TopUp, QuotaData, Task, Model, Vendor, PrefillGroup, Setup, TwoFA,
+#   TwoFABackupCode, Checkin, SubscriptionOrder, UserSubscription,
+#   SubscriptionPreConsumeRecord, CustomOAuthProvider, UserOAuthBinding,
+#   SubscriptionPlan) plus two column-type migrations
+#   (subscription_plans.price_amount → decimal, tokens.model_limits →
+#   text). The Gin route registration + the `:3000` listen only happen
+#   AFTER migration returns nil.
+#
+#   On a cpx21/cpx31 node with CNPG primary in the same namespace and
+#   sslmode=require this first-boot migration runs 60-120s. Pre-A12
+#   the chart's livenessProbe was `initialDelaySeconds: 30` +
+#   `periodSeconds: 10` + `failureThreshold: 3` ⇒ kubelet SIGKILLed
+#   the container at the 50s mark, EVERY restart, mid-migration. The
+#   empty `newapi` DB on t22 had ZERO public-schema tables after 29
+#   CrashLoopBackOff restarts because every kill races the first GORM
+#   query. pg_stat_activity on CNPG side showed no `newapi` user
+#   connections; the kill happens before the migration's TLS handshake
+#   completes.
+#
+#   Symptom: `[SYS] ... database migration started` is the LAST log
+#   line; container terminates with exit code 2 ~50s later; readiness
+#   probe shows `dial tcp <pod-ip>:3000: connect: connection refused`;
+#   endpoint /v1/models returns 503 "no healthy upstream".
+#
+# FIX (CANONICAL SEAM, Inviolable Principle #16):
+#   StartupProbe owns "is this binary ALIVE for the first time?". It
+#   short-circuits BOTH liveness and readiness until the binary
+#   reports healthy on `:3000/api/status` — at which point those two
+#   probes activate with their normal cadence. The startupProbe gives
+#   GORM AutoMigrate up to 5 minutes (30 × 10s) before it gives up;
+#   well above the observed 60-120s ceiling and below operator-
+#   impatience limits. Once migration completes the binary is no
+#   slower than steady-state, so the existing 10s liveness probe
+#   period and 3-failure threshold are unchanged.
+#
+#   This is the canonical k8s pattern for slow-start migrations — every
+#   chart that bakes a GORM/Alembic/Flyway AutoMigrate against an
+#   empty DB on first boot should own a startupProbe, NOT inflate its
+#   liveness initialDelaySeconds (which would also delay restart
+#   recovery on every subsequent reconcile).
+#
+# TEMPLATABILITY (Inviolable Principle #4):
+#   Every knob (path, port, initialDelaySeconds, periodSeconds,
+#   timeoutSeconds, failureThreshold, AND the gate to disable the
+#   probe entirely) is operator-tunable from per-Sovereign overlays
+#   via .Values.newapi.probes.startup.*. Setting
+#   `.Values.newapi.probes.startup: null` skip-renders the
+#   startupProbe block — operators who pre-seed their database can
+#   opt out and let the (pre-A12) liveness initialDelaySeconds gate
+#   take over.
+#
 # 1.4.17 (TBD-D35d #1778, 2026-05-18): add `httproute.yaml` template +
 # `ingress.httpRoute` values block so a Sovereign install can render a
 # Cilium Gateway HTTPRoute for `newapi.<sovereign-fqdn>` that outranks
@@ -184,7 +245,7 @@ name: bp-newapi
 # composes on the next reconcile. helm template renders cleanly with
 # BOTH the missing-attestation state (no channel) AND the
 # fully-populated state (channel composed normally).
-version: 1.4.18
+version: 1.4.19
 appVersion: "0.13.2"
 description: |
   Catalyst Blueprint scratch chart for NewAPI — multi-tenant LLM

--- a/platform/newapi/chart/templates/deployment.yaml
+++ b/platform/newapi/chart/templates/deployment.yaml
@@ -176,6 +176,25 @@ spec:
             - name: data
               mountPath: /data
 
+          # TBD-A12 (#1798, 2026-05-18): startupProbe gates liveness +
+          # readiness until the NewAPI binary has finished GORM
+          # AutoMigrate on the empty CNPG database (26 CREATE TABLE +
+          # 2 column-type migrations, 60-120s on cpx21 with
+          # sslmode=require). Pre-A12 liveness SIGKILLed the binary
+          # mid-migration at the 50s mark — the empty `newapi` DB on
+          # t22 chart 1.4.18 had zero tables after 29 restarts because
+          # every kill happened before AutoMigrate finished its first
+          # CREATE TABLE.
+          {{- if .Values.newapi.probes.startup }}
+          startupProbe:
+            httpGet:
+              path: {{ .Values.newapi.probes.startup.path }}
+              port: {{ .Values.newapi.probes.startup.port }}
+            initialDelaySeconds: {{ .Values.newapi.probes.startup.initialDelaySeconds }}
+            periodSeconds: {{ .Values.newapi.probes.startup.periodSeconds }}
+            timeoutSeconds: {{ .Values.newapi.probes.startup.timeoutSeconds }}
+            failureThreshold: {{ .Values.newapi.probes.startup.failureThreshold }}
+          {{- end }}
           livenessProbe:
             httpGet:
               path: {{ .Values.newapi.probes.liveness.path }}

--- a/platform/newapi/chart/tests/startup-probe-render.sh
+++ b/platform/newapi/chart/tests/startup-probe-render.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+# bp-newapi — startupProbe render audit (TBD-A12 #1798).
+#
+# Verifies the chart renders a startupProbe on the newapi container so
+# kubelet does NOT SIGKILL the binary during first-boot GORM AutoMigrate
+# (26 CREATE TABLE + 2 column-type migrations, 60-120s on cpx21 with
+# sslmode=require against a fresh CNPG primary). Pre-A12 the liveness
+# probe (initialDelaySeconds=30, periodSeconds=10, failureThreshold=3)
+# killed the container at the 50s mark every restart — t22 chart 1.4.18
+# had ZERO public-schema tables after 29 CrashLoopBackOff restarts
+# because every kill happened before the first GORM query completed
+# its TLS handshake.
+#
+# Cases:
+#   1. Default values render — Deployment carries a startupProbe block
+#      with the canonical 5-minute budget (30 × 10s) on the newapi
+#      container, and liveness/readiness remain unchanged.
+#   2. Operator override (`newapi.probes.startup: null`) suppresses
+#      the startupProbe block — per Inviolable Principle #4 the gate
+#      is operator-tunable so an overlay against a pre-seeded DB can
+#      opt out and let the liveness initialDelaySeconds gate take
+#      over.
+
+set -euo pipefail
+
+chart_dir="$(cd "$(dirname "$0")/.." && pwd)"
+helm="${HELM_BIN:-helm}"
+
+"$helm" dependency build "$chart_dir" >/dev/null 2>&1 || true
+
+# Common values that flip the Pod-render gate to TRUE (same pattern as
+# imagepullsecrets-render.sh).
+common_values=$(mktemp)
+trap 'rm -f "$common_values"' EXIT
+cat > "$common_values" <<'EOF'
+auth:
+  adminUI:
+    mode: masterKey
+database:
+  existingSecret: test-dsn
+EOF
+
+# ── Case 1: default render carries startupProbe on newapi container ──
+echo "[bp-newapi] Case 1: default render — startupProbe present"
+out=$("$helm" template smoke "$chart_dir" -f "$common_values" 2>&1)
+
+deployment_block=$(echo "$out" | awk '/^---$/{f=0} /^kind: Deployment$/{f=1} f')
+if [ -z "$deployment_block" ]; then
+  echo "FAIL: Deployment did not render"
+  exit 1
+fi
+
+# Extract the newapi container block (everything from `- name: newapi`
+# up to the next `- name:` sibling) so we assert the probe is on the
+# main container, not the metering sidecar.
+newapi_container=$(echo "$deployment_block" | awk '
+  /^        - name: newapi[[:space:]]*$/{f=1; print; next}
+  f && /^        - name: /{f=0}
+  f{print}
+')
+if [ -z "$newapi_container" ]; then
+  echo "FAIL: newapi container block not found in Deployment"
+  exit 1
+fi
+
+if ! echo "$newapi_container" | grep -q "startupProbe:"; then
+  echo "FAIL: newapi container has no startupProbe block"
+  echo "--- newapi container ---"
+  echo "$newapi_container"
+  exit 1
+fi
+# Assert the 5-minute budget — 30 × 10s. Catches accidental regression
+# back to the pre-A12 50s window.
+# Extract just the startupProbe block (stops at the next probe-level key,
+# 10-space indent siblings: livenessProbe/readinessProbe/resources/etc).
+startup_block=$(echo "$newapi_container" | awk '
+  /^          startupProbe:/{f=1; print; next}
+  f && /^          [a-zA-Z]/{f=0}
+  f{print}
+')
+if [ -z "$startup_block" ]; then
+  echo "FAIL: could not extract startupProbe block from newapi container"
+  exit 1
+fi
+if ! echo "$startup_block" | grep -q "failureThreshold: 30"; then
+  echo "FAIL: startupProbe failureThreshold is not 30 (5-minute budget for GORM AutoMigrate)"
+  echo "--- startupProbe block ---"
+  echo "$startup_block"
+  exit 1
+fi
+if ! echo "$startup_block" | grep -q "periodSeconds: 10"; then
+  echo "FAIL: startupProbe periodSeconds is not 10"
+  exit 1
+fi
+if ! echo "$startup_block" | grep -q "path: /api/status"; then
+  echo "FAIL: startupProbe path is not /api/status"
+  exit 1
+fi
+# Liveness must stay present (kubelet semantics: after startup success).
+if ! echo "$newapi_container" | grep -q "livenessProbe:"; then
+  echo "FAIL: livenessProbe removed (must remain for post-startup kubelet supervision)"
+  exit 1
+fi
+if ! echo "$newapi_container" | grep -q "readinessProbe:"; then
+  echo "FAIL: readinessProbe removed"
+  exit 1
+fi
+echo "[bp-newapi] Case 1: PASS"
+
+# ── Case 2: operator override suppresses startupProbe ─────────────────
+echo "[bp-newapi] Case 2: operator override — startupProbe suppressed"
+override_values=$(mktemp)
+cat > "$override_values" <<'EOF'
+auth:
+  adminUI:
+    mode: masterKey
+database:
+  existingSecret: test-dsn
+newapi:
+  probes:
+    startup: null
+EOF
+out2=$("$helm" template smoke "$chart_dir" -f "$override_values" 2>&1)
+rm -f "$override_values"
+
+deployment_block2=$(echo "$out2" | awk '/^---$/{f=0} /^kind: Deployment$/{f=1} f')
+if [ -z "$deployment_block2" ]; then
+  echo "FAIL: Deployment did not render with startupProbe disabled"
+  exit 1
+fi
+newapi_container2=$(echo "$deployment_block2" | awk '
+  /^        - name: newapi[[:space:]]*$/{f=1; print; next}
+  f && /^        - name: /{f=0}
+  f{print}
+')
+# When startup is null the {{- if .Values.newapi.probes.startup }} gate
+# is false and the entire block (key + httpGet + thresholds) is omitted.
+if echo "$newapi_container2" | grep -q "^[[:space:]]*startupProbe:"; then
+  echo "FAIL: startup=null should suppress the startupProbe block (Inviolable Principle #4)"
+  exit 1
+fi
+if ! echo "$newapi_container2" | grep -q "livenessProbe:"; then
+  echo "FAIL: livenessProbe missing in override path"
+  exit 1
+fi
+echo "[bp-newapi] Case 2: PASS"
+
+echo "[bp-newapi] All startupProbe render cases PASS"

--- a/platform/newapi/chart/values.yaml
+++ b/platform/newapi/chart/values.yaml
@@ -106,12 +106,58 @@ newapi:
     allowPrivilegeEscalation: false
     capabilities:
       drop: ["ALL"]
-  # Liveness / readiness — NewAPI exposes /api/status (verified via
-  # upstream code path controller/misc.go:GetStatus).
+  # Liveness / readiness / startup — NewAPI exposes /api/status (verified
+  # via upstream code path controller/misc.go:GetStatus).
+  #
+  # TBD-A12 (#1798, 2026-05-18): on a freshly franchised Sovereign the
+  # newapi DB is empty — GORM AutoMigrate runs CREATE TABLE for 26
+  # models (Channel, Token, User, PasskeyCredential, Option, Redemption,
+  # Ability, Log, Midjourney, TopUp, QuotaData, Task, Model, Vendor,
+  # PrefillGroup, Setup, TwoFA, TwoFABackupCode, Checkin,
+  # SubscriptionOrder, UserSubscription, SubscriptionPreConsumeRecord,
+  # CustomOAuthProvider, UserOAuthBinding, SubscriptionPlan) plus two
+  # column-type migrations (subscription_plans.price_amount → decimal,
+  # tokens.model_limits → text). On a small (cpx21/cpx31) CNPG
+  # primary with sslmode=require this first-boot migration takes 60-
+  # 120s before the binary registers its Gin routes and the
+  # `:3000/api/status` listener actually opens.
+  #
+  # Pre-A12 the liveness probe had `initialDelaySeconds: 30` +
+  # `periodSeconds: 10` + `failureThreshold: 3` ⇒ kubelet SIGKILLed
+  # newapi at the 50s mark, mid-migration. The empty newapi DB on t22
+  # (chart 1.4.18) had zero tables after 29 restarts because every
+  # restart killed the migration before it could create any. Symptom:
+  # logs print `[SYS] ... database migration started` and then the
+  # container terminates with exit code 2 (kubelet kill) ~50s later;
+  # pg_stat_activity on the CNPG side shows no `newapi` user
+  # connections (the kill races the GORM first-query DB.Migrator().
+  # HasTable call against the wire).
+  #
+  # Fix: add a startupProbe that gates BOTH liveness and readiness for
+  # up to 5 minutes (30 × 10s) before they activate. Liveness then
+  # only kicks in once the binary has actually bound :3000. Readiness
+  # initialDelaySeconds is unchanged because it short-circuits on the
+  # startupProbe per kubelet semantics. failureThreshold of 30 covers
+  # GORM AutoMigrate on PostgreSQL up to ~5 min — comfortably above
+  # the observed 60-120s ceiling and below operator-impatience limits.
   probes:
+    startup:
+      path: /api/status
+      port: 3000
+      # Wait 10s before first poll to skip the token-encoder init phase
+      # (~1s on cpx21) — the binary is single-threaded during this
+      # phase and probing too early adds no signal.
+      initialDelaySeconds: 10
+      periodSeconds: 10
+      timeoutSeconds: 5
+      # 30 × 10s = 5 minutes total budget for migration + first listen.
+      failureThreshold: 30
     liveness:
       path: /api/status
       port: 3000
+      # initialDelaySeconds is ignored when startupProbe is configured
+      # (kubelet semantics: liveness starts after startup success).
+      # Kept here for operator overlays that disable startupProbe.
       initialDelaySeconds: 30
       periodSeconds: 10
       timeoutSeconds: 5


### PR DESCRIPTION
## Root cause (t22 chart 1.4.18 verify, 2026-05-18)

`newapi-mirror:v0.13.2` first-boot GORM AutoMigrate against an empty
CNPG database takes 60-120s on cpx21/cpx31 nodes (28 CREATE TABLE + 2
column-type migrations, `sslmode=require`). Pre-A12 liveness probe
budget was ~50s (`initialDelaySeconds: 30` + `periodSeconds: 10` +
`failureThreshold: 3`), so kubelet SIGKILLed the binary
mid-migration on every restart. After 29 CrashLoopBackOff restarts
the `newapi` DB on t22 had **ZERO** public-schema tables.

**Smoking gun (pod `newapi-bp-newapi-6fd8799b6-lpsd2`):**
- `startedAt`: 20:04:52Z, `finishedAt`: 20:05:42Z → exactly 50s
- `exitCode`: 2 (Error/SIGKILL)
- Logs end at `[SYS] ... database migration started`
- Events: `Readiness probe failed: dial tcp 10.42.0.185:3000: connect: connection refused`
- `pg_stat_activity` on CNPG primary: no `newapi` user connections (kill happens before TLS handshake completes)
- `\dt` → `Did not find any relations`

## Fix (canonical k8s pattern)

`startupProbe` gates BOTH liveness and readiness until the binary
opens `:3000/api/status`. Probe budget: 30 × 10s = **5 minutes**,
comfortably above the observed 60-120s ceiling and below operator-
impatience limits. Liveness's pre-A12 cadence (30s/10s/3) is
unchanged but only activates after startupProbe success per kubelet
semantics.

**Why not Helm pre-install hook?** The PR title mentions a hook
because that was the original task description, but inspection
showed `replicas: 1` and a single Deployment — there is no advisory-
lock conflict to gate. The hang is single-Pod kubelet-kill, not
multi-Pod migration race. A startupProbe is the canonical seam for
this exact class of slow-start migration (Inviolable Principle #16,
own the seam).

## Operator-tunable (Inviolable Principle #4)

Every knob (path, port, initialDelaySeconds, periodSeconds,
timeoutSeconds, failureThreshold, AND the gate itself) is exposed
via `.Values.newapi.probes.startup.*`. Setting
`newapi.probes.startup: null` skip-renders the block — overlays
against a pre-seeded DB opt out and let the pre-A12 liveness
initialDelaySeconds gate take over.

## Files changed

| File | Change |
|---|---|
| `platform/newapi/chart/Chart.yaml` | version 1.4.18 → 1.4.19 + detailed root-cause comment |
| `platform/newapi/chart/values.yaml` | new `newapi.probes.startup.*` block with explanatory comments |
| `platform/newapi/chart/templates/deployment.yaml` | `{{- if .Values.newapi.probes.startup }}` gated startupProbe render |
| `platform/newapi/chart/tests/startup-probe-render.sh` | smoke + override render assertions |
| `clusters/_template/bootstrap-kit/80-newapi.yaml` | pin 1.4.18 → 1.4.19 so Sovereigns pull the new chart |

## Test plan

- [x] `helm template smoke .` with defaults → startupProbe rendered with `failureThreshold: 30`, liveness + readiness preserved
- [x] `helm template smoke . -f override.yaml` with `newapi.probes.startup: null` → startupProbe block omitted, liveness + readiness preserved
- [ ] Next fresh-prov: pod reaches Ready=True without CrashLoopBackOff; `psql -d newapi -c "\dt"` shows the 26 AutoMigrate tables
- [ ] Existing t22 verify after admin-merge → new chart rolls out → migration completes on first restart → port 3000 opens

Closes #1798