### PR TITLE
fix(ci): blueprint.yaml spec.version lockstep in auto-bump (Closes #1856)

### DIFF
--- a/.github/workflows/blueprint-release.yaml
+++ b/.github/workflows/blueprint-release.yaml
@@ -633,13 +633,129 @@ jobs:
           echo "pin_file=${pin_file}" >> "$GITHUB_OUTPUT"
           echo "prev_version=${current}" >> "$GITHUB_OUTPUT"
 
-      - name: "Commit + push bootstrap-kit pin bump"
-        if: steps.chart.outputs.skip != 'true' && steps.bump_pin.outputs.bumped == 'true'
+      # ──────────────────────────────────────────────────────────────
+      # LOCKSTEP — platform/<bp>/blueprint.yaml `spec.version`
+      # ──────────────────────────────────────────────────────────────
+      # TBD-A20 (issue #1856, 2026-05-18): the auto-bump hook above only
+      # touched clusters/_template/bootstrap-kit/*.yaml. The upstream
+      # blueprint manifest (platform/<bp>/blueprint.yaml) ALSO carries
+      # a `spec.version` field that must equal the Chart.yaml `version`
+      # by convergence contract:
+      #
+      #   TestBootstrapKit_BlueprintCardsHaveRequiredFields
+      #     (tests/e2e/bootstrap-kit/main_test.go)
+      #
+      # asserts `Chart.yaml.version == blueprint.yaml.spec.version` for
+      # every kit blueprint. Six blueprints (cilium, cert-manager, flux,
+      # openbao, keycloak, gitea) silently drifted between Chart.yaml
+      # and blueprint.yaml until the test started failing — A17 (#1855)
+      # hot-patched the six drifts; this lockstep step removes the
+      # structural recurrence pattern.
+      #
+      # Location convention:
+      #   - Leaf platform blueprints live at  ${matrix.path}/blueprint.yaml
+      #     (e.g. platform/cilium/blueprint.yaml)
+      #   - Umbrella product blueprints live at ${matrix.path}/chart/blueprint.yaml
+      #     (e.g. products/continuum/chart/blueprint.yaml)
+      #
+      # Some charts have no blueprint.yaml at all (e.g. products/catalyst —
+      # the chart-only umbrella for bp-catalyst-platform). This is fine —
+      # the lockstep is a graceful no-op when no blueprint.yaml exists.
+      #
+      # The `spec.version` line is at exactly 2-space indent in every
+      # blueprint.yaml (audited 2026-05-18 across all 71 files in
+      # platform/ + products/). We key on `^  version:` with a defensive
+      # parse + post-write verify.
+      - name: "Lockstep-bump blueprint.yaml spec.version for ${{ steps.chart.outputs.name }}"
+        if: steps.chart.outputs.skip != 'true'
+        id: bump_blueprint
+        env:
+          CHART_NAME: ${{ steps.chart.outputs.name }}
+          CHART_VERSION: ${{ steps.chart.outputs.version }}
+          CHART_PATH: ${{ matrix.path }}
+        run: |
+          set -euo pipefail
+
+          # Try the two canonical blueprint.yaml locations in order.
+          # Each Blueprint folder uses exactly one shape; never both.
+          bp_file=""
+          for candidate in "${CHART_PATH}/blueprint.yaml" "${CHART_PATH}/chart/blueprint.yaml"; do
+            if [ -f "$candidate" ]; then
+              bp_file="$candidate"
+              break
+            fi
+          done
+
+          if [ -z "$bp_file" ]; then
+            echo "INFO: no blueprint.yaml at ${CHART_PATH}/blueprint.yaml or ${CHART_PATH}/chart/blueprint.yaml — graceful no-op (chart has no Blueprint manifest, e.g. the products/catalyst umbrella)."
+            echo "bumped=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Sanity: this file must actually be a Blueprint manifest (kind:
+          # Blueprint), not some other YAML co-located in the folder.
+          # Without this guard, a stray non-Blueprint blueprint.yaml (the
+          # CRD definition file we saw at products/catalyst/chart/crds/
+          # is an example of a generic name-collision) would be rewritten
+          # incorrectly.
+          bp_kind=$(awk '/^kind:/{print $2; exit}' "$bp_file" | tr -d '"')
+          if [ "$bp_kind" != "Blueprint" ]; then
+            echo "INFO: ${bp_file} kind='${bp_kind}' — not a Blueprint manifest, graceful no-op."
+            echo "bumped=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Read current spec.version. The blueprint.yaml convention is:
+          #
+          #   spec:
+          #     version: <semver>     ← 2 spaces, single `version:` line
+          #
+          # The 2-space indent is anchored start-of-line so any deeper-
+          # indented `version:` (inside spec.upgrades.from[], etc.) cannot
+          # accidentally match.
+          current=$(awk '/^  version:/{print $2; exit}' "$bp_file" | tr -d '"')
+          if [ -z "$current" ]; then
+            echo "::error title=Unparseable blueprint.yaml spec.version::No '  version:' line at 2-space indent in $bp_file. The Blueprint manifest shape changed under TBD-A20's lockstep hook; refusing to write."
+            exit 1
+          fi
+
+          if [ "$current" = "$CHART_VERSION" ]; then
+            echo "INFO: ${bp_file} already at spec.version=${CHART_VERSION} — no-op."
+            echo "bumped=false" >> "$GITHUB_OUTPUT"
+            # Still emit the path so downstream steps know about it.
+            echo "bp_file=${bp_file}" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "Lockstep-bumping ${bp_file}: spec.version ${current} → ${CHART_VERSION}"
+          sed -i -E "s|^  version: .*\$|  version: ${CHART_VERSION}|" "$bp_file"
+
+          # Verify the sed actually flipped the line.
+          new=$(awk '/^  version:/{print $2; exit}' "$bp_file" | tr -d '"')
+          if [ "$new" != "$CHART_VERSION" ]; then
+            echo "::error title=blueprint.yaml sed failed::After rewrite, ${bp_file} still has spec.version='${new}', expected '${CHART_VERSION}'."
+            exit 1
+          fi
+
+          echo "bumped=true" >> "$GITHUB_OUTPUT"
+          echo "bp_file=${bp_file}" >> "$GITHUB_OUTPUT"
+          echo "prev_version=${current}" >> "$GITHUB_OUTPUT"
+
+      - name: "Commit + push bootstrap-kit pin bump + blueprint.yaml lockstep"
+        # Run if either side has staged changes — usually they bump in
+        # tandem, but a kit-only chart (no blueprint.yaml) or a non-kit
+        # leaf (no pin file) might bump only one. Either is sufficient
+        # to commit.
+        if: steps.chart.outputs.skip != 'true' && (steps.bump_pin.outputs.bumped == 'true' || steps.bump_blueprint.outputs.bumped == 'true')
         env:
           CHART_NAME: ${{ steps.chart.outputs.name }}
           CHART_VERSION: ${{ steps.chart.outputs.version }}
           PIN_FILE: ${{ steps.bump_pin.outputs.pin_file }}
           PREV_VERSION: ${{ steps.bump_pin.outputs.prev_version }}
+          BP_FILE: ${{ steps.bump_blueprint.outputs.bp_file }}
+          BP_PREV_VERSION: ${{ steps.bump_blueprint.outputs.prev_version }}
+          PIN_BUMPED: ${{ steps.bump_pin.outputs.bumped }}
+          BP_BUMPED: ${{ steps.bump_blueprint.outputs.bumped }}
         run: |
           set -euo pipefail
           git config user.name "hatiyildiz"
@@ -648,49 +764,103 @@ jobs:
           # Idempotent reset-and-rewrite on push conflict — parallel
           # matrix jobs (multiple Blueprints bumped in one push) can race
           # on the same branch. On conflict we re-fetch, re-sed against
-          # whatever pin is currently on origin/main, and re-commit. The
-          # operation is convergent: every retry produces the same final
-          # pin value (CHART_VERSION), so the only failure mode is the
-          # remote already at that version → no-op skip.
+          # whatever state is currently on origin/main, and re-commit.
+          # The operation is convergent: every retry produces the same
+          # final state (pin=CHART_VERSION, blueprint=CHART_VERSION).
           rewrite_pin() {
             local pf="$1"
             local cur
             cur=$(awk '/^      version:/{print $2; exit}' "$pf" | tr -d '"')
             if [ "$cur" = "${CHART_VERSION}" ]; then
-              return 1  # already there — caller decides whether to skip
+              return 1  # already there
             fi
             sed -i -E "s|^      version: .*\$|      version: ${CHART_VERSION}|" "$pf"
             return 0
           }
+          rewrite_blueprint() {
+            local bp="$1"
+            local cur
+            cur=$(awk '/^  version:/{print $2; exit}' "$bp" | tr -d '"')
+            if [ "$cur" = "${CHART_VERSION}" ]; then
+              return 1
+            fi
+            sed -i -E "s|^  version: .*\$|  version: ${CHART_VERSION}|" "$bp"
+            return 0
+          }
 
-          git add "${PIN_FILE}"
+          # Stage whichever files were rewritten.
+          if [ "${PIN_BUMPED}" = "true" ] && [ -n "${PIN_FILE}" ]; then
+            git add "${PIN_FILE}"
+          fi
+          if [ "${BP_BUMPED}" = "true" ] && [ -n "${BP_FILE}" ]; then
+            git add "${BP_FILE}"
+          fi
+
           if git diff --staged --quiet; then
             echo "no staged changes — already in sync"
             exit 0
           fi
-          git commit -m "deploy(${CHART_NAME}): bump bootstrap-kit pin ${PREV_VERSION} -> ${CHART_VERSION} (auto, Refs TBD-A6)"
+
+          # Compose commit message. Pin bump remains the primary subject
+          # (preserves the existing `deploy(<chart>): bump bootstrap-kit
+          # pin X -> Y (auto, Refs TBD-A6)` shape used by every existing
+          # automation). The blueprint.yaml lockstep is mentioned as a
+          # secondary line so consumers parsing recent log subjects
+          # don't see a format change. When ONLY blueprint.yaml bumps
+          # (chart not in the kit), the subject acknowledges TBD-A20.
+          if [ "${PIN_BUMPED}" = "true" ] && [ "${BP_BUMPED}" = "true" ]; then
+            msg="deploy(${CHART_NAME}): bump bootstrap-kit pin ${PREV_VERSION} -> ${CHART_VERSION} (auto, Refs TBD-A6)
+
+Also locksteps platform blueprint.yaml spec.version ${BP_PREV_VERSION} -> ${CHART_VERSION} (Refs TBD-A20, #1856)."
+          elif [ "${PIN_BUMPED}" = "true" ]; then
+            msg="deploy(${CHART_NAME}): bump bootstrap-kit pin ${PREV_VERSION} -> ${CHART_VERSION} (auto, Refs TBD-A6)"
+          else
+            # Only blueprint.yaml moved — chart is not in the bootstrap kit
+            # (e.g. an opt-in Application Blueprint like bp-velero, bp-vllm).
+            msg="deploy(${CHART_NAME}): lockstep blueprint.yaml spec.version ${BP_PREV_VERSION} -> ${CHART_VERSION} (auto, Refs TBD-A20, #1856)"
+          fi
+          git commit -m "${msg}"
 
           for i in 1 2 3; do
             if git push origin HEAD:main; then
-              echo "Pushed bootstrap-kit pin bump for ${CHART_NAME}=${CHART_VERSION}"
+              echo "Pushed lockstep bump for ${CHART_NAME}=${CHART_VERSION} (pin=${PIN_BUMPED}, blueprint=${BP_BUMPED})"
               exit 0
             fi
-            echo "push attempt $i failed — re-fetching origin/main and re-applying pin bump"
+            echo "push attempt $i failed — re-fetching origin/main and re-applying lockstep"
             git fetch origin main
             git reset --hard origin/main
-            if rewrite_pin "${PIN_FILE}"; then
-              git add "${PIN_FILE}"
-              if git diff --staged --quiet; then
-                echo "no changes after re-fetch — pin already at ${CHART_VERSION} on origin/main"
-                exit 0
+
+            did_pin=0
+            did_bp=0
+            if [ "${PIN_BUMPED}" = "true" ] && [ -n "${PIN_FILE}" ]; then
+              if rewrite_pin "${PIN_FILE}"; then
+                git add "${PIN_FILE}"
+                did_pin=1
               fi
-              git commit -m "deploy(${CHART_NAME}): bump bootstrap-kit pin -> ${CHART_VERSION} (auto, Refs TBD-A6, retry $i)"
-            else
+            fi
+            if [ "${BP_BUMPED}" = "true" ] && [ -n "${BP_FILE}" ]; then
+              if rewrite_blueprint "${BP_FILE}"; then
+                git add "${BP_FILE}"
+                did_bp=1
+              fi
+            fi
+            if [ "$did_pin" -eq 0 ] && [ "$did_bp" -eq 0 ]; then
               echo "origin/main already at ${CHART_VERSION} — nothing to push"
               exit 0
             fi
+            if git diff --staged --quiet; then
+              echo "no changes after re-fetch — already at ${CHART_VERSION} on origin/main"
+              exit 0
+            fi
+            if [ "$did_pin" -eq 1 ] && [ "$did_bp" -eq 1 ]; then
+              git commit -m "deploy(${CHART_NAME}): bump bootstrap-kit pin -> ${CHART_VERSION} + blueprint.yaml lockstep (auto, Refs TBD-A6 + TBD-A20, retry $i)"
+            elif [ "$did_pin" -eq 1 ]; then
+              git commit -m "deploy(${CHART_NAME}): bump bootstrap-kit pin -> ${CHART_VERSION} (auto, Refs TBD-A6, retry $i)"
+            else
+              git commit -m "deploy(${CHART_NAME}): lockstep blueprint.yaml spec.version -> ${CHART_VERSION} (auto, Refs TBD-A20, retry $i)"
+            fi
           done
-          echo "::error title=Pin bump push failed::3 attempts exhausted for ${CHART_NAME}=${CHART_VERSION}."
+          echo "::error title=Lockstep push failed::3 attempts exhausted for ${CHART_NAME}=${CHART_VERSION}."
           exit 1
 
       - name: Summary
@@ -709,4 +879,11 @@ jobs:
             echo "- **Bootstrap-kit pin:** ✓ auto-bumped \`${{ steps.bump_pin.outputs.pin_file }}\` ${{ steps.bump_pin.outputs.prev_version }} → ${{ steps.chart.outputs.version }} (TBD-A6 meta-fix)" >> "$GITHUB_STEP_SUMMARY"
           else
             echo "- **Bootstrap-kit pin:** (chart is not in the kit — opt-in Application Blueprint, no pin to bump)" >> "$GITHUB_STEP_SUMMARY"
+          fi
+          if [ "${{ steps.bump_blueprint.outputs.bumped }}" = "true" ]; then
+            echo "- **Blueprint.yaml lockstep:** ✓ auto-bumped \`${{ steps.bump_blueprint.outputs.bp_file }}\` spec.version ${{ steps.bump_blueprint.outputs.prev_version }} → ${{ steps.chart.outputs.version }} (TBD-A20, #1856)" >> "$GITHUB_STEP_SUMMARY"
+          elif [ -n "${{ steps.bump_blueprint.outputs.bp_file }}" ]; then
+            echo "- **Blueprint.yaml lockstep:** (already at ${{ steps.chart.outputs.version }}, no-op)" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "- **Blueprint.yaml lockstep:** (chart has no platform/<bp>/blueprint.yaml — e.g. products/catalyst umbrella)" >> "$GITHUB_STEP_SUMMARY"
           fi

--- a/platform/alloy/blueprint.yaml
+++ b/platform/alloy/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-3-observability
 spec:
-  version: 1.0.0
+  version: 1.0.1
   card:
     title: Alloy
     family: insights

--- a/platform/cert-manager-dynadot-webhook/blueprint.yaml
+++ b/platform/cert-manager-dynadot-webhook/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-3-3-security-and-policy
 spec:
-  version: 1.0.0
+  version: 1.1.2
   card:
     title: cert-manager-dynadot-webhook
     summary: |

--- a/platform/cert-manager-powerdns-webhook/blueprint.yaml
+++ b/platform/cert-manager-powerdns-webhook/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-3-3-security-and-policy
 spec:
-  version: 1.0.0
+  version: 1.1.0
   card:
     title: cert-manager-powerdns-webhook
     summary: |

--- a/platform/cluster-autoscaler-hcloud/blueprint.yaml
+++ b/platform/cluster-autoscaler-hcloud/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-3-2-scaling-and-resilience
 spec:
-  version: 1.0.0
+  version: 1.3.0
   card:
     title: Cluster Autoscaler (Hetzner)
     family: surge

--- a/platform/cnpg/blueprint.yaml
+++ b/platform/cnpg/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-4-1-data-services
 spec:
-  version: 1.0.0
+  version: 1.0.1
   card:
     title: CloudNativePG
     summary: |

--- a/platform/crossplane-claims/blueprint.yaml
+++ b/platform/crossplane-claims/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-3-2-gitops-and-iac
 spec:
-  version: 1.1.0
+  version: 1.1.5
   card:
     title: crossplane-claims
     summary: |

--- a/platform/external-secrets-stores/blueprint.yaml
+++ b/platform/external-secrets-stores/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-3-3-security-and-policy
 spec:
-  version: 1.0.0
+  version: 1.0.5
   card:
     title: External Secrets — Stores
     summary: |

--- a/platform/external-secrets/blueprint.yaml
+++ b/platform/external-secrets/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-3-3-security-and-policy
 spec:
-  version: 1.1.0
+  version: 1.1.1
   card:
     title: External Secrets Operator
     summary: |

--- a/platform/falco/blueprint.yaml
+++ b/platform/falco/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-3-3-security-and-policy
 spec:
-  version: 1.0.0
+  version: 1.0.1
   card:
     title: Falco
     family: guardian

--- a/platform/grafana/blueprint.yaml
+++ b/platform/grafana/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-3-observability
 spec:
-  version: 1.0.0
+  version: 1.0.1
   card:
     title: Grafana
     family: insights

--- a/platform/guacamole/blueprint.yaml
+++ b/platform/guacamole/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-3-1-networking-and-service-mesh
     catalyst.openova.io/category: platform
 spec:
-  version: 0.1.0
+  version: 0.1.24
   card:
     title: Apache Guacamole
     summary: Clientless HTML5 remote-desktop gateway. Browser-based RDP / VNC / SSH and kubectl-exec into Pods, with Keycloak SSO and full session recording to SeaweedFS. One Guacamole per Sovereign per ADR-0001 §11.

--- a/platform/harbor/blueprint.yaml
+++ b/platform/harbor/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-3-5-storage-and-data
 spec:
-  version: 1.1.0
+  version: 1.2.17
   card:
     title: Harbor
     family: foundation

--- a/platform/hcloud-csi/blueprint.yaml
+++ b/platform/hcloud-csi/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-3-5-storage-and-data
 spec:
-  version: 1.0.0
+  version: 1.1.0
   card:
     title: Hetzner Cloud CSI
     summary: |

--- a/platform/k8s-ws-proxy/blueprint.yaml
+++ b/platform/k8s-ws-proxy/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-3-3-security-and-policy
     catalyst.openova.io/category: platform
 spec:
-  version: 0.1.0
+  version: 0.1.11
   card:
     title: k8s-ws-proxy
     summary: Per-node WebSocket exec proxy that bridges HMAC-signed upstream callers (catalyst-api, Guacamole) onto the local kube-apiserver pods/exec stream. DaemonSet with internalTrafficPolicy=Local for node-local sessions.

--- a/platform/mimir/blueprint.yaml
+++ b/platform/mimir/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-3-observability
 spec:
-  version: 1.0.0
+  version: 1.0.4
   card:
     title: Mimir
     family: insights

--- a/platform/netbird/blueprint.yaml
+++ b/platform/netbird/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-3-1-networking-and-service-mesh
     catalyst.openova.io/category: platform
 spec:
-  version: 0.1.0
+  version: 0.1.1
   card:
     title: NetBird
     summary: WireGuard-based zero-trust mesh + remote-access overlay. Operators / engineers / customer admins enroll devices via Keycloak SSO and reach Sovereign-internal services from any laptop. Includes management + signal + coturn (TURN/STUN). One NetBird per Sovereign per ADR-0001 §11.

--- a/platform/newapi/blueprint.yaml
+++ b/platform/newapi/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/category: ai-runtime
     catalyst.openova.io/section: pts-4-6-llm-serving
 spec:
-  version: 1.1.0
+  version: 1.4.20
   card:
     title: NewAPI
     summary: |

--- a/platform/openclaw/blueprint.yaml
+++ b/platform/openclaw/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/category: ai-runtime
     catalyst.openova.io/section: pts-4-7-agentic-workspace
 spec:
-  version: 0.1.0
+  version: 0.2.0
   card:
     title: OpenClaw
     summary: |

--- a/platform/powerdns/blueprint.yaml
+++ b/platform/powerdns/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/category: per-host-cluster-infrastructure
     catalyst.openova.io/section: pts-3-2-gitops-and-iac
 spec:
-  version: 1.1.8
+  version: 1.2.3
   card:
     title: PowerDNS
     summary: |

--- a/platform/seaweedfs/blueprint.yaml
+++ b/platform/seaweedfs/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-3-5-storage-and-data
 spec:
-  version: 1.0.0
+  version: 1.2.0
   card:
     title: SeaweedFS
     family: foundation

--- a/platform/self-sovereign-cutover/blueprint.yaml
+++ b/platform/self-sovereign-cutover/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
 spec:
-  version: 0.1.14
+  version: 0.1.31
   card:
     title: self-sovereignty-cutover
     summary: |

--- a/platform/trivy/blueprint.yaml
+++ b/platform/trivy/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-3-3-security-and-policy
 spec:
-  version: 1.0.0
+  version: 1.0.3
   card:
     title: Trivy
     family: guardian

--- a/platform/valkey/blueprint.yaml
+++ b/platform/valkey/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-4-1-data-services
 spec:
-  version: 1.0.0
+  version: 1.0.1
   card:
     title: Valkey
     summary: |

--- a/platform/velero/blueprint.yaml
+++ b/platform/velero/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-3-observability
 spec:
-  version: 1.0.0
+  version: 1.2.2
   card:
     title: Velero
     family: insights

--- a/platform/vpa/blueprint.yaml
+++ b/platform/vpa/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-3-3-security-and-policy
 spec:
-  version: 1.0.0
+  version: 1.0.1
   card:
     title: Vertical Pod Autoscaler
     family: guardian

--- a/products/dmz-vcluster/chart/blueprint.yaml
+++ b/products/dmz-vcluster/chart/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-3-1-networking-and-service-mesh
     openova.io/category: customer-facing-capability
 spec:
-  version: 0.1.0
+  version: 0.1.1
   card:
     title: DMZ vCluster
     summary: |

--- a/tests/e2e/bootstrap-kit/main_test.go
+++ b/tests/e2e/bootstrap-kit/main_test.go
@@ -208,6 +208,142 @@ func TestBootstrapKit_BlueprintCardsHaveRequiredFields(t *testing.T) {
 	}
 }
 
+// TestBootstrapKit_BlueprintVersionLockstepSweep asserts the TBD-A20
+// convergence contract (issue #1856) for EVERY Blueprint manifest in the
+// repository — not just the canonical 10 in the bootstrap kit. The
+// convergence contract is:
+//
+//	For every platform/<bp>/blueprint.yaml (and products/<bp>/chart/blueprint.yaml)
+//	whose folder contains a sibling chart/Chart.yaml,
+//	the blueprint.yaml spec.version MUST equal the Chart.yaml version.
+//
+// Why broaden coverage beyond the 10 canonical blueprints?
+//
+// TestBootstrapKit_BlueprintCardsHaveRequiredFields only checks the 10
+// kit blueprints. The 2026-05-18 drift incident (6 blueprints out of sync
+// — cilium, cert-manager, flux, openbao, keycloak, gitea — patched by
+// PR #1855) showed the problem also exists for non-kit Application
+// Blueprints (e.g. bp-velero, bp-temporal, bp-wordpress-tenant). The
+// extended auto-bump hook in blueprint-release.yaml (this PR) handles
+// the lockstep for every chart bump; this test is the static regression
+// gate that catches a missed write before merge.
+//
+// Discovery rule:
+//   - Walk platform/* — every direct subdirectory whose blueprint.yaml is
+//     kind: Blueprint and whose sibling chart/Chart.yaml exists is in scope.
+//   - Walk products/* — every direct subdirectory whose chart/blueprint.yaml
+//     is kind: Blueprint and whose sibling chart/Chart.yaml exists is in
+//     scope. (products/catalyst is excluded because its blueprint.yaml is
+//     at chart/crds/blueprint.yaml — a CRD definition, not a Blueprint
+//     manifest; the kind: filter naturally rejects it.)
+//
+// Each in-scope folder gets a subtest; a failure names the file and the
+// drift direction so the fix is mechanical.
+func TestBootstrapKit_BlueprintVersionLockstepSweep(t *testing.T) {
+	root := repoRoot(t)
+
+	type pair struct {
+		name      string // subtest name (e.g. "platform/cilium")
+		bpFile    string // path to blueprint.yaml
+		chartFile string // path to sibling Chart.yaml
+	}
+	var pairs []pair
+
+	for _, tree := range []string{"platform", "products"} {
+		treeRoot := filepath.Join(root, tree)
+		entries, err := os.ReadDir(treeRoot)
+		if err != nil {
+			t.Fatalf("read %s: %v", treeRoot, err)
+		}
+		for _, e := range entries {
+			if !e.IsDir() {
+				continue
+			}
+			// Two canonical locations: platform/<x>/blueprint.yaml and
+			// products/<x>/chart/blueprint.yaml. The corresponding
+			// Chart.yaml is always at <folder>/chart/Chart.yaml.
+			for _, bpRel := range []string{
+				filepath.Join(tree, e.Name(), "blueprint.yaml"),
+				filepath.Join(tree, e.Name(), "chart", "blueprint.yaml"),
+			} {
+				bpAbs := filepath.Join(root, bpRel)
+				if _, err := os.Stat(bpAbs); err != nil {
+					continue
+				}
+				// Filter to kind: Blueprint. Co-located non-Blueprint YAML
+				// (e.g. CRD definitions) is silently skipped.
+				raw, err := os.ReadFile(bpAbs)
+				if err != nil {
+					continue
+				}
+				var head struct {
+					Kind string `yaml:"kind"`
+				}
+				if err := yaml.Unmarshal(raw, &head); err != nil || head.Kind != "Blueprint" {
+					continue
+				}
+				chartAbs := filepath.Join(root, tree, e.Name(), "chart", "Chart.yaml")
+				if _, err := os.Stat(chartAbs); err != nil {
+					// Blueprint without a co-located chart — out of scope
+					// (e.g. metadata-only references). Skip silently.
+					continue
+				}
+				pairs = append(pairs, pair{
+					name:      filepath.Join(tree, e.Name()),
+					bpFile:    bpAbs,
+					chartFile: chartAbs,
+				})
+			}
+		}
+	}
+
+	if len(pairs) == 0 {
+		t.Fatal("discovered zero Blueprint/Chart pairs — sweep is broken (expected dozens under platform/ and products/)")
+	}
+
+	for _, p := range pairs {
+		t.Run(p.name, func(t *testing.T) {
+			bpRaw, err := os.ReadFile(p.bpFile)
+			if err != nil {
+				t.Fatalf("read blueprint: %v", err)
+			}
+			var bp struct {
+				Spec struct {
+					Version string `yaml:"version"`
+				} `yaml:"spec"`
+			}
+			if err := yaml.Unmarshal(bpRaw, &bp); err != nil {
+				t.Fatalf("unmarshal blueprint: %v", err)
+			}
+			chartRaw, err := os.ReadFile(p.chartFile)
+			if err != nil {
+				t.Fatalf("read chart: %v", err)
+			}
+			var chart struct {
+				Version string `yaml:"version"`
+			}
+			if err := yaml.Unmarshal(chartRaw, &chart); err != nil {
+				t.Fatalf("unmarshal chart: %v", err)
+			}
+			if bp.Spec.Version == "" {
+				t.Errorf("blueprint.yaml at %s has empty spec.version", p.bpFile)
+				return
+			}
+			if chart.Version == "" {
+				t.Errorf("Chart.yaml at %s has empty version", p.chartFile)
+				return
+			}
+			if chart.Version != bp.Spec.Version {
+				t.Errorf("LOCKSTEP DRIFT (TBD-A20, #1856):\n  %s\n    spec.version = %q\n  %s\n    version      = %q\n  → the auto-bump hook in .github/workflows/blueprint-release.yaml should have kept these in sync. If you bumped Chart.yaml manually, run:\n    sed -i 's/^  version: .*/  version: %s/' %s",
+					p.bpFile, bp.Spec.Version,
+					p.chartFile, chart.Version,
+					chart.Version, p.bpFile,
+				)
+			}
+		})
+	}
+}
+
 // TestBootstrapKit_TemplateClusterParses verifies that the template
 // directory clusters/_template/ contains valid Flux manifests and that all
 // SOVEREIGN_FQDN_PLACEHOLDER substitutions can be made consistently.


### PR DESCRIPTION
## Summary

- Extends the TBD-A6 auto-bump hook in `.github/workflows/blueprint-release.yaml` to also rewrite `platform/<bp>/blueprint.yaml` (or `products/<bp>/chart/blueprint.yaml`) `spec.version` whenever Chart.yaml `version` bumps — both file edits in the same auto-bump commit. Removes the structural recurrence pattern that A17 (#1855) hot-patched.
- Adds `TestBootstrapKit_BlueprintVersionLockstepSweep` (Go), an exhaustive PR-time gate that asserts the convergence contract for ALL ~70 Blueprint manifests, not just the canonical 10 in `TestBootstrapKit_BlueprintCardsHaveRequiredFields`. Failure output names the file, drift direction, and the exact `sed` command to fix.
- Drift cleanup of 26 Application-Blueprint manifests whose `spec.version` had been left at the original `1.0.0`/`0.1.0` while `Chart.yaml` moved on. Mandatory companion — without it the new sweep test blocks every subsequent PR. Same shape as A17 (#1855).

## Mechanism

The new step `bump_blueprint` runs after `bump_pin`:

1. Tries `${matrix.path}/blueprint.yaml` then `${matrix.path}/chart/blueprint.yaml` — covers both leaf (platform/) and umbrella (products/) conventions.
2. Filters to `kind: Blueprint` (rejects co-located CRD YAML at `products/catalyst/chart/crds/blueprint.yaml`).
3. Reads `spec.version` at 2-space indent (anchored `^  version:` — won't touch deeper `version:` under `spec.upgrades.from[]`).
4. `sed -i -E "s|^  version: .*$|  version: ${CHART_VERSION}|"` and post-verify the rewrite landed.

The commit step renames to `Commit + push bootstrap-kit pin bump + blueprint.yaml lockstep`. Commit subject preserved as `deploy(<chart>): bump bootstrap-kit pin X -> Y (auto, Refs TBD-A6)`; a secondary line notes the blueprint lockstep when both moved. When only blueprint.yaml moves (chart not in bootstrap kit — opt-in Application Blueprints like bp-velero/bp-vllm/bp-temporal), the subject acknowledges TBD-A20.

Idempotent reset-and-rewrite retry preserved for the parallel-matrix race case.

## Why a separate Go sweep test?

`TestBootstrapKit_BlueprintCardsHaveRequiredFields` only checks the 10 kit blueprints (`cilium, cert-manager, flux, crossplane, sealed-secrets, spire, nats-jetstream, openbao, keycloak, gitea`). The new sweep extends coverage to all ~70 Blueprint manifests across `platform/` and `products/`, including non-kit Application Blueprints where drift had been accumulating for months.

## Test plan

- [x] `go test -run TestBootstrapKit_BlueprintVersionLockstepSweep -count=1` GREEN on this branch (70/70 pairs in sync).
- [x] `go test -run TestBootstrapKit_BlueprintCardsHaveRequiredFields -count=1` stays GREEN (10/10 canonical kit blueprints in sync — A17 #1855 work preserved).
- [x] `go test -count=1` full suite GREEN.
- [x] Manual `awk`/`sed` walkthrough on 4 chart shapes (platform leaf with bp-cilium, platform leaf with qa-app, products/continuum umbrella, products/catalyst chart-only with no Blueprint manifest) — confirms graceful no-op for the last case.
- [x] YAML parse check on 4 patched files via `python3 yaml.safe_load` — all OK.
- [ ] **Post-merge**: next chart-version bump triggers blueprint-release; verify single commit subject `deploy(<chart>): bump bootstrap-kit pin X -> Y (auto, Refs TBD-A6)` plus the secondary blueprint.yaml line. Drift never reappears on `TestBootstrapKit_BlueprintVersionLockstepSweep`.

Closes #1856.

Refs #1855 (A17 hot-patch superseded structurally), #1713 (original TBD-A6 hook).

🤖 Generated with [Claude Code](https://claude.com/claude-code)