### PR TITLE
fix(catalyst-api): handler test baseline GREEN — TBD-A19 (Closes #1853)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/auth.go
+++ b/products/catalyst/bootstrap/api/internal/handler/auth.go
@@ -252,8 +252,16 @@ func (h *Handler) HandlePinIssue(w http.ResponseWriter, r *http.Request) {
 	// Rate-limit-first means losers in the race get 429 immediately,
 	// the winner reaches Keycloak alone, and the rate limiter is
 	// honoured even under concurrency.
+	//
+	// tryReserve (not canIssue) is used so check-and-reserve is atomic
+	// under a single mutex acquisition. The earlier canIssue+put split
+	// allowed three concurrent goroutines to all observe "no entry",
+	// pass the gate, and then race EnsureUser. tryReserve stamps a
+	// placeholder entry on success; put(...) below overwrites it with
+	// the actual PIN, and drop(...) rolls back the cooldown on a
+	// downstream failure.
 	store := h.pinStoreFor()
-	if ok, retry := store.canIssue(email); !ok {
+	if ok, retry := store.tryReserve(email); !ok {
 		retryAfterSec := int(retry.Seconds()) + 1
 		w.Header().Set("Retry-After", fmt.Sprintf("%d", retryAfterSec))
 		writeJSON(w, http.StatusTooManyRequests, map[string]any{
@@ -267,6 +275,10 @@ func (h *Handler) HandlePinIssue(w http.ResponseWriter, r *http.Request) {
 	// ── 2. EnsureUser in openova realm ──────────────────────────────────────
 	kc := h.openovaKCClient()
 	if kc == nil {
+		// Rollback the reservation: this gate's failure isn't the
+		// operator's fault and a follow-up retry must not be punished by
+		// the 60s cooldown.
+		store.drop(email)
 		writeJSON(w, http.StatusServiceUnavailable, map[string]string{
 			"error":  "auth-unconfigured",
 			"detail": "CATALYST_OPENOVA_KC_SA_CLIENT_SECRET not set",
@@ -274,6 +286,9 @@ func (h *Handler) HandlePinIssue(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if _, err := kc.EnsureUser(r.Context(), email, "openova-users"); err != nil {
+		// Rollback so a Keycloak transient (502 from KC, etc) doesn't
+		// punish the operator for the next 60 seconds.
+		store.drop(email)
 		h.log.Error("pin/issue: EnsureUser failed", "email", email, "err", err)
 		writeJSON(w, http.StatusBadGateway, map[string]string{
 			"error":  "user-provisioning-failed",
@@ -285,6 +300,9 @@ func (h *Handler) HandlePinIssue(w http.ResponseWriter, r *http.Request) {
 	// ── 3. Generate PIN + requestId ─────────────────────────────────────────
 	pin, err := generatePin()
 	if err != nil {
+		// Rollback: a crypto/rand failure is a server-side issue, not an
+		// operator-driven retry storm.
+		store.drop(email)
 		h.log.Error("pin/issue: generatePin failed", "err", err)
 		writeJSON(w, http.StatusInternalServerError, map[string]string{
 			"error":  "pin-generation-failed",
@@ -893,14 +911,21 @@ type whoamiRealmAccess struct {
 }
 
 type whoamiResponse struct {
-	Email         string            `json:"email"`
-	Sub           string            `json:"sub"`
-	Verified      bool              `json:"verified"`
-	DeploymentID  string            `json:"deploymentId,omitempty"`
-	SovereignFQDN string            `json:"sovereignFQDN,omitempty"`
-	Mode          string            `json:"mode,omitempty"`
-	Tier          string            `json:"tier,omitempty"`
-	RealmAccess   whoamiRealmAccess `json:"realm_access,omitempty"`
+	Email         string             `json:"email"`
+	Sub           string             `json:"sub"`
+	Verified      bool               `json:"verified"`
+	DeploymentID  string             `json:"deploymentId,omitempty"`
+	SovereignFQDN string             `json:"sovereignFQDN,omitempty"`
+	Mode          string             `json:"mode,omitempty"`
+	Tier          string             `json:"tier,omitempty"`
+	// RealmAccess is a pointer so `omitempty` actually drops the key when
+	// the operator's session carries no RBAC claims. A struct value would
+	// always serialize as `{}` regardless of omitempty (Go encoding/json
+	// honours omitempty for structs only via `omitzero` in Go 1.24+, and
+	// the catalyst-api still builds against earlier toolchains). Without
+	// the pointer, pre-RBAC clients that decode the response into a typed
+	// struct see `realm_access:{roles:null}` and break.
+	RealmAccess *whoamiRealmAccess `json:"realm_access,omitempty"`
 }
 
 // HandleWhoami handles GET /api/v1/whoami.
@@ -951,7 +976,9 @@ func (h *Handler) HandleWhoami(w http.ResponseWriter, r *http.Request) {
 		Tier:     strings.ToLower(strings.TrimSpace(claims.Tier)),
 	}
 	if len(claims.RealmAccess.Roles) > 0 {
-		resp.RealmAccess.Roles = append([]string(nil), claims.RealmAccess.Roles...)
+		resp.RealmAccess = &whoamiRealmAccess{
+			Roles: append([]string(nil), claims.RealmAccess.Roles...),
+		}
 	}
 	// EPIC-3 (#1184) tier→catalyst-* role projection: when the operator
 	// holds a `tier` claim but the realm-access role list lacks the
@@ -960,7 +987,21 @@ func (h *Handler) HandleWhoami(w http.ResponseWriter, r *http.Request) {
 	// through the protocol mapper), synthesize them so downstream UI
 	// authorization checks (which look at realm_access.roles) work
 	// regardless of how the session was minted.
-	whoamiInjectTierRoles(&resp.RealmAccess, resp.Tier)
+	//
+	// Pre-RBAC sessions (no tier, no realm_access roles) skip this entire
+	// step so the `omitempty` on resp.RealmAccess drops the field — old
+	// callers parsing the legacy {email,sub,verified} shape stay clean.
+	if resp.Tier != "" || resp.RealmAccess != nil {
+		if resp.RealmAccess == nil {
+			resp.RealmAccess = &whoamiRealmAccess{}
+		}
+		whoamiInjectTierRoles(resp.RealmAccess, resp.Tier)
+		// If the projection ended up empty (unknown tier, no upstream
+		// roles), drop the field so the omitempty contract holds.
+		if len(resp.RealmAccess.Roles) == 0 {
+			resp.RealmAccess = nil
+		}
+	}
 
 	// Sovereign-context enrichment — same precedence as HandleSovereignSelf
 	// so the two endpoints never disagree about which sovereign this is.
@@ -1036,6 +1077,19 @@ func whoamiInjectTierRoles(ra *whoamiRealmAccess, tier string) {
 	have := map[string]struct{}{}
 	for _, r := range ra.Roles {
 		have[strings.ToLower(strings.TrimSpace(r))] = struct{}{}
+	}
+	// If the operator's own tier role is already present, the upstream
+	// (Keycloak protocol mapper, PIN-minted JWT, etc) authoritatively
+	// shaped the role list — don't synthesize lower-tier inherited
+	// entries on top of it. This preserves the TC-R-089-style PIN flow
+	// where the JWT is minted with `[catalyst-owner]` only and the SPA
+	// route-guard reads exactly that list. The inheritance projection
+	// only fires when the caller passed a `tier` claim *without* the
+	// matching catalyst-<tier> role (typical of chroot-internal JWTs
+	// that set tier= but skip the role-list projection).
+	tierRole := "catalyst-" + tier
+	if _, ok := have[tierRole]; ok {
+		return
 	}
 	for i := 0; i <= tierIdx; i++ {
 		want := "catalyst-" + whoamiTierInheritance[i]

--- a/products/catalyst/bootstrap/api/internal/handler/handover_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/handover_test.go
@@ -127,10 +127,13 @@ func TestFinaliseHandover_FullFlow(t *testing.T) {
 	// Pretend the OpenTofu workdir exists on disk with one file. The
 	// finalise handler builds the provisioner via provisioner.New() so
 	// it picks up the env-default workdir. We override via env var.
+	//
+	// Workdir is keyed by DeploymentID per PR #1487
+	// (provisioner.Request.workdirKey) — match what
+	// FinaliseHandover does with `filepath.Join(prov.WorkDir, id)`.
 	tmp := t.TempDir()
 	t.Setenv("CATALYST_TOFU_WORKDIR", tmp)
-	sovereignName := "tenant-y-omani-works"
-	workdir := filepath.Join(tmp, sovereignName)
+	workdir := filepath.Join(tmp, "dep-full")
 	if err := os.MkdirAll(workdir, 0o700); err != nil {
 		t.Fatalf("mkdir workdir: %v", err)
 	}
@@ -254,7 +257,8 @@ func TestFinaliseHandover_ReceiverFailureKeepsLocalState(t *testing.T) {
 
 	tmp := t.TempDir()
 	t.Setenv("CATALYST_TOFU_WORKDIR", tmp)
-	workdir := filepath.Join(tmp, "tenant-z-omani-works")
+	// Workdir keyed by DeploymentID per PR #1487.
+	workdir := filepath.Join(tmp, "dep-fail")
 	if err := os.MkdirAll(workdir, 0o700); err != nil {
 		t.Fatalf("mkdir: %v", err)
 	}

--- a/products/catalyst/bootstrap/api/internal/handler/pinstore.go
+++ b/products/catalyst/bootstrap/api/internal/handler/pinstore.go
@@ -97,6 +97,12 @@ func newPinStoreNoSweeper() *pinStore {
 func (s *pinStore) canIssue(email string) (bool, time.Duration) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	return s.canIssueLocked(email)
+}
+
+// canIssueLocked is the lock-free variant of canIssue. Caller MUST hold
+// s.mu. Used by tryReserve to check-and-reserve atomically.
+func (s *pinStore) canIssueLocked(email string) (bool, time.Duration) {
 	key := normalizePinKey(email)
 	e, ok := s.entries[key]
 	if !ok {
@@ -107,6 +113,36 @@ func (s *pinStore) canIssue(email string) (bool, time.Duration) {
 		return true, 0
 	}
 	return false, pinIssueCooldown - elapsed
+}
+
+// tryReserve atomically check-and-reserves the per-email rate-limit slot.
+// Returns (true, 0) if the caller may proceed with PIN issuance and stamps
+// a placeholder entry (`issuedAt = now`) so concurrent callers see the
+// slot as taken. Returns (false, retryAfter) when the slot is already
+// reserved.
+//
+// The placeholder entry has empty pin/requestId; the caller MUST follow
+// up with put(...) once the actual PIN is generated, or drop(...) if the
+// downstream step (EnsureUser, sendPinEmail) fails and the cooldown
+// should not punish the operator. This is the canonical fix for TC-R-089
+// — without it, three concurrent /pin/issue goroutines all pass canIssue
+// before any of them stamps the cooldown, then all three race EnsureUser
+// against Keycloak.
+func (s *pinStore) tryReserve(email string) (bool, time.Duration) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if ok, retry := s.canIssueLocked(email); !ok {
+		return false, retry
+	}
+	now := s.now()
+	s.entries[normalizePinKey(email)] = &pinEntry{
+		pin:       "",
+		expiresAt: now.Add(pinTTL),
+		issuedAt:  now,
+		attempts:  0,
+		requestID: "",
+	}
+	return true, 0
 }
 
 // put writes a fresh entry for the given email, replacing any existing

--- a/products/catalyst/bootstrap/api/internal/handler/user_access.go
+++ b/products/catalyst/bootstrap/api/internal/handler/user_access.go
@@ -623,8 +623,17 @@ func userAccessToUnstructured(req userAccessRequest) *unstructured.Unstructured 
 }
 
 func unstructuredToUserAccess(u *unstructured.Unstructured) userAccessItem {
+	// Initialize Applications to an empty slice (not nil) so the JSON
+	// encoder emits `"applications":[]` rather than `"applications":null`
+	// even when the CR has no spec.applications field. The React UI's
+	// `items.map(...)` throws `TypeError: Cannot read properties of null
+	// (reading 'map')` on null — qa-loop iter-4 cluster
+	// `users-page-null-map-and-open-redirect`.
 	out := userAccessItem{
 		Name: u.GetName(),
+		Spec: userAccessSpecBody{
+			Applications: []userAccessAppGrantBody{},
+		},
 	}
 	if ts := u.GetCreationTimestamp(); !ts.IsZero() {
 		out.CreationTimestamp = ts.UTC().Format("2006-01-02T15:04:05Z")

--- a/products/catalyst/bootstrap/api/internal/handler/user_access_owner_seed_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/user_access_owner_seed_test.go
@@ -40,7 +40,10 @@ func TestEnsureOwnerUserAccess_CreatesCanonicalCR(t *testing.T) {
 		t.Fatalf("EnsureOwnerUserAccess: unexpected err %v", err)
 	}
 
-	got, err := client.Resource(UserAccessGVR()).Namespace("").
+	// The owner CR is created in userAccessOwnerNamespace (catalyst-system)
+	// per the D21 fix on t134 2026-05-17 — useraccesses.access.openova.io
+	// is NAMESPACED (Claim semantics from the XRD claimNames block).
+	got, err := client.Resource(UserAccessGVR()).Namespace(userAccessOwnerNamespace).
 		Get(context.Background(), ownerUserAccessName(email), metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("get after seed: %v", err)
@@ -70,17 +73,17 @@ func TestEnsureOwnerUserAccess_CreatesCanonicalCR(t *testing.T) {
 		t.Errorf("spec.sovereignRef: got %q want %q", gotRef, "omantel")
 	}
 
-	// spec.applications: single wildcard "*" → admin.
-	apps, ok, _ := unstructured.NestedSlice(got.Object, "spec", "applications")
-	if !ok || len(apps) != 1 {
-		t.Fatalf("spec.applications: want 1 entry, got %v", apps)
+	// D21 fix on t135 2026-05-17: the owner CR uses spec.tierRoleRef
+	// (not per-application entries). The XRD's CRD rejects `app: "*"`
+	// (pattern `^[a-z0-9][a-z0-9-]{0,62}$`), so the owner-tier semantic
+	// is conveyed via the canonical `openova:tier-owner` ClusterRole
+	// reference per platform/crossplane-claims/.../xrds/useraccess.yaml.
+	gotTier, _, _ := unstructured.NestedString(got.Object, "spec", "tierRoleRef")
+	if gotTier != "openova:tier-owner" {
+		t.Errorf("spec.tierRoleRef: got %q want %q", gotTier, "openova:tier-owner")
 	}
-	first, _ := apps[0].(map[string]any)
-	if first["app"] != "*" {
-		t.Errorf("applications[0].app: got %v want \"*\"", first["app"])
-	}
-	if first["role"] != "admin" {
-		t.Errorf("applications[0].role: got %v want \"admin\"", first["role"])
+	if _, present, _ := unstructured.NestedSlice(got.Object, "spec", "applications"); present {
+		t.Errorf("spec.applications: must be absent (XRD pattern rejects `app: \"*\"`); use tierRoleRef instead")
 	}
 
 	// apiVersion + kind.


### PR DESCRIPTION
## Summary

Six failing tests in `products/catalyst/bootstrap/api/internal/handler` on `origin/main` are blocking every catalyst PR merge regardless of what each PR touches (PR #1851's A16-hetzner-only diff went RED with these same six). This PR turns the baseline GREEN with real fixes — no skips, no test-removal.

## Per-test root cause + one-line fix

| Test | Root cause | Fix |
|---|---|---|
| `TestPinIssue_ConcurrentRapidFireRateLimit` | TOCTOU race: `canIssue` + `put` ran under separate locks; 3 concurrent goroutines all passed the gate and raced Keycloak. | Added atomic `pinStore.tryReserve()`; HandlePinIssue calls `drop()` on EnsureUser/generatePin failure to roll back the reservation. |
| `TestFinaliseHandover_FullFlow` | Test fixture drift after PR #1487 keyed tofu workdir by `DeploymentID` (not FQDN). | Test now writes workdir at `filepath.Join(tmp, "dep-full")` to match production lookup. |
| `TestEnsureOwnerUserAccess_CreatesCanonicalCR` | Two drifts: test queried `Namespace("")` after CR moved to `catalyst-system`; test asserted `spec.applications=[{app:"*",role:"admin"}]` after t135 D21 fix switched to `spec.tierRoleRef="openova:tier-owner"`. | Query `userAccessOwnerNamespace`; assert `tierRoleRef` + applications must be absent. |
| `TestUnstructuredToUserAccess_NilApplicationsBecomesEmpty` | `unstructuredToUserAccess` left `Spec.Applications=nil` → JSON `null` → React `items.map()` crash. | Initialize `Spec.Applications = []userAccessAppGrantBody{}` in the struct literal. |
| `TestHandleWhoami_PinSessionRBACClaims` | `whoamiInjectTierRoles` unconditionally appended every inherited tier role even when upstream JWT already shaped the list. | If the operator's own `catalyst-<tier>` role is already present, return early and preserve the upstream list. |
| `TestHandleWhoami_NoRBACOmitsFields` | `whoamiResponse.RealmAccess` was a struct value with `omitempty`, which `encoding/json` does NOT honour for structs. | Changed to `*whoamiRealmAccess`; HandleWhoami only allocates when claims carry roles, drops to nil if projection ended up empty. |

## Local verification (worktree off `origin/main`)

- All 6 target tests PASS (was 5 FAIL + 1 timing-sensitive pre-fix).
- Full surrounding suites PASS: `TestPin*` (19), `TestHandleWhoami*` (7), `TestWhoamiInjectTierRoles*` (1), `TestEnsureOwnerUserAccess*` (6), `TestOwnerUserAccessName*` (2), `TestListUserAccess*` (4), `TestFinaliseHandover*` (5), `TestUnstructuredToUserAccess*` (1), `TestPinStore*` (12) = 57 tests.
- `go test ./... -p 1` across entire catalyst-api PASS.

Pre-existing parallelism flakes (`TestGetKubeconfig_ReadsFromPathPointer`, `TestPhase1Started_GuardPreventsDoubleWatch`, `TestPodRestart_Phase1WatchingResumesWithKubeconfig`) exist on baseline too — write to `/var/lib/catalyst/` from goroutines that outlive test scope, "TempDir RemoveAll cleanup: directory not empty". Out of scope; tracked separately.

## Test plan

- [x] Reproduce 5 failures + 1 flake on `origin/main` baseline.
- [x] Diagnose each (race, fixture drift, schema drift, JSON encoding bug, projection over-eager).
- [x] Real fixes (no `t.Skip`).
- [x] Re-run target tests 5× — all GREEN.
- [x] Run full `internal/handler` package + sibling packages — no new regressions.
- [ ] Chart auto-bump fires after merge (A6 system).
- [ ] Next catalyst PR's CI test job goes GREEN.

Closes #1853

🤖 Generated with [Claude Code](https://claude.com/claude-code)