### PR TITLE
fix(catalyst-api): seed full 4-entry .omani.X sme-pool (D30 / #1830)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/handler/sme_tenant_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sme_tenant_test.go
@@ -1220,8 +1220,14 @@ func TestCreateSMETenant_MultiDomain_RejectsNotReady(t *testing.T) {
 
 // TestLoadSMETenantParentDomainsFromEnv_StubFallback — when the env
 // knob is unset and OTECH_FQDN is set, the env loader returns the
-// hardcoded 2-domain stub (omani.works + omani.trade) per the #828
-// constraint while MD-1 (#826) is in flight.
+// hardcoded 4-domain stub (omani.homes + omani.rest + omani.trade +
+// omani.works) per DoD D30 (issue #1830). The pool entries mirror
+// core/services/domain/store.AllowedTLDs and the marketplace
+// /addons subdomain picker. The historical 2-entry stub (#828, MD-1
+// in flight) was widened on 2026-05-18 to surface every TLD the
+// customer-facing UI offers — keeping seed + UI + AllowedTLDs locked
+// together prevents 422s on signup when the picker lists a TLD the
+// catalyst-api validator doesn't recognise.
 func TestLoadSMETenantParentDomainsFromEnv_StubFallback(t *testing.T) {
 	t.Setenv("CATALYST_SME_POOL_DOMAINS", "")
 	t.Setenv("CATALYST_OTECH_FQDN", "otech.example")
@@ -1240,8 +1246,8 @@ func TestLoadSMETenantParentDomainsFromEnv_StubFallback(t *testing.T) {
 	if primary != 1 {
 		t.Errorf("primary: want 1 got %d (%v)", primary, got)
 	}
-	if pool != 2 {
-		t.Errorf("sme-pool: want 2 got %d (%v)", pool, got)
+	if pool != 4 {
+		t.Errorf("sme-pool: want 4 got %d (%v)", pool, got)
 	}
 }
 

--- a/products/catalyst/bootstrap/api/internal/handler/sovereign_parent_domains.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sovereign_parent_domains.go
@@ -33,9 +33,21 @@ import (
 // FQDNs; primary role marker is `<fqdn>:primary`, default role is
 // sme-pool). When the env knob is unset and CATALYST_OTECH_FQDN is
 // set, returns the otech FQDN as the implicit primary entry plus the
-// canonical-but-stub `omani.works` and `omani.trade` sme-pool entries
-// — covering the #828 constraint "stub returning a 2-domain hardcoded
-// list with TODO" while MD-1 (#826) is in flight.
+// four canonical sme-pool entries (omani.homes, omani.rest,
+// omani.trade, omani.works) — the operator-curated free-subdomain
+// pool offered to SME tenants per DoD D30 (issue #1830).
+//
+// Pool composition note (2026-05-18):
+// The four .omani.X TLDs are the canonical OpenOva-managed
+// sme-pool — they are already delegated to the Sovereign's PowerDNS
+// (no Dynadot flip needed; nsAlreadyMatches short-circuit in
+// pdmFlipNS covers Day-2 re-adds) and the cert-manager DNS-01
+// solver is wired for *.X.<chosen>.<pool>. The marketplace UI
+// (core/marketplace/src/components/AddonsStep.svelte) hard-codes
+// the same four entries; this seed keeps the backend pool aligned
+// with what the customer-facing /addons subdomain picker shows.
+// core/services/domain/store.AllowedTLDs has the same authoritative
+// list and is the central registry.
 //
 // Forward-compat: when MD-1 lands the catalyst-api startup wiring
 // switches to read from the Sovereign's deployment record. The
@@ -52,9 +64,16 @@ func LoadSMETenantParentDomainsFromEnv() []SMETenantParentDomain {
 				Name: strings.ToLower(otech), Role: "primary", NSFlipReady: true,
 			})
 		}
+		// DoD D30 (issue #1830) — the four canonical .omani.X
+		// sme-pool entries. Match core/services/domain/store.AllowedTLDs
+		// and core/marketplace/src/components/AddonsStep.svelte's
+		// picker so backend validation accepts every TLD the customer
+		// UI offers.
 		out = append(out,
-			SMETenantParentDomain{Name: "omani.works", Role: "sme-pool", NSFlipReady: true},
+			SMETenantParentDomain{Name: "omani.homes", Role: "sme-pool", NSFlipReady: true},
+			SMETenantParentDomain{Name: "omani.rest", Role: "sme-pool", NSFlipReady: true},
 			SMETenantParentDomain{Name: "omani.trade", Role: "sme-pool", NSFlipReady: true},
+			SMETenantParentDomain{Name: "omani.works", Role: "sme-pool", NSFlipReady: true},
 		)
 		return out
 	}

--- a/products/catalyst/bootstrap/api/internal/handler/sovereign_parent_domains_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sovereign_parent_domains_test.go
@@ -1,0 +1,127 @@
+// sovereign_parent_domains_test.go — guards the canonical four-entry
+// sme-pool seed surfaced by LoadSMETenantParentDomainsFromEnv. This is
+// the regression boundary for DoD D30 (issue #1830 — "free-subdomain
+// selection from operator-curated pool").
+//
+// Why the test matters:
+// The marketplace UI (core/marketplace/src/components/AddonsStep.svelte)
+// hard-codes the four .omani.X TLDs (homes / rest / trade / works) in
+// the subdomain picker. The customer-journey Playwright spec asserts
+// every option is present (test "07 subdomain picker shows omani.homes
+// pool"). If the backend seed drifts, the SME tenant create handler's
+// FindParentDomain check rejects the operator-supplied parent_domain
+// → the customer sees a 422 right at signup despite the UI option
+// being shown. Keeping seed + UI + AllowedTLDs locked together is the
+// only way the four-domain contract survives across the stack.
+package handler
+
+import (
+	"os"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// TestLoadSMETenantParentDomainsFromEnv_CanonicalFourEntryPool guards
+// the hardcoded fallback path (CATALYST_SME_POOL_DOMAINS unset). The
+// returned slice must carry every .omani.X TLD from
+// core/services/domain/store.AllowedTLDs so the marketplace /addons
+// picker, the catalyst-api SME tenant create validator, and the
+// store-side TLD allowlist all agree on the pool.
+//
+// DoD D30 (issue #1830): all four entries (omani.homes, omani.rest,
+// omani.trade, omani.works) must be present with Role=sme-pool and
+// NSFlipReady=true. NSFlipReady=true reflects that these zones are
+// already delegated to the Sovereign's PowerDNS at gTLD level — no
+// Day-2 Dynadot flip is needed (pdmFlipNS nsAlreadyMatches
+// short-circuits).
+func TestLoadSMETenantParentDomainsFromEnv_CanonicalFourEntryPool(t *testing.T) {
+	// Defensively isolate from the caller's env. Tests may run in
+	// parallel; CATALYST_SME_POOL_DOMAINS and CATALYST_OTECH_FQDN
+	// must be unset to exercise the hardcoded fallback path.
+	t.Setenv("CATALYST_SME_POOL_DOMAINS", "")
+	t.Setenv("CATALYST_OTECH_FQDN", "")
+	got := LoadSMETenantParentDomainsFromEnv()
+
+	want := []string{"omani.homes", "omani.rest", "omani.trade", "omani.works"}
+	names := make([]string, 0, len(got))
+	for _, p := range got {
+		if !strings.EqualFold(p.Role, "sme-pool") {
+			// Skip the (none-on-this-path) primary entry if it
+			// somehow leaks in — the test's contract is only on
+			// the sme-pool subset.
+			continue
+		}
+		if !p.NSFlipReady {
+			t.Errorf("seed entry %q must be NSFlipReady=true (zone already delegated to Sovereign PowerDNS)", p.Name)
+		}
+		names = append(names, p.Name)
+	}
+	sort.Strings(names)
+	if len(names) != len(want) {
+		t.Fatalf("seed must contain %d sme-pool entries, got %d (%v)", len(want), len(names), names)
+	}
+	for i := range want {
+		if names[i] != want[i] {
+			t.Fatalf("seed sme-pool entries mismatch.\nwant: %v\n got: %v", want, names)
+		}
+	}
+}
+
+// TestLoadSMETenantParentDomainsFromEnv_OTECHFQDNPrimary verifies that
+// when CATALYST_OTECH_FQDN is set on the hardcoded-fallback path, the
+// otech FQDN is prepended as the role=primary entry. This is the
+// post-handover catalyst-api topology where the Sovereign's own FQDN
+// becomes the implicit primary and the four .omani.X TLDs are the
+// sme-pool offered to SME tenants registering through the marketplace.
+func TestLoadSMETenantParentDomainsFromEnv_OTECHFQDNPrimary(t *testing.T) {
+	t.Setenv("CATALYST_SME_POOL_DOMAINS", "")
+	t.Setenv("CATALYST_OTECH_FQDN", "t99.example.io")
+	got := LoadSMETenantParentDomainsFromEnv()
+	if len(got) == 0 || got[0].Name != "t99.example.io" || got[0].Role != "primary" {
+		t.Fatalf("first entry must be the OTECH primary, got %+v", got)
+	}
+	// And the four sme-pool entries still follow.
+	smePoolCount := 0
+	for _, p := range got {
+		if p.Role == "sme-pool" {
+			smePoolCount++
+		}
+	}
+	if smePoolCount != 4 {
+		t.Fatalf("OTECH primary + 4 sme-pool entries expected; got %d sme-pool (%+v)", smePoolCount, got)
+	}
+}
+
+// TestLoadSMETenantParentDomainsFromEnv_EnvOverride checks that the
+// CATALYST_SME_POOL_DOMAINS env-var override path still works (operator
+// can swap the pool wholesale on a non-omani Sovereign). The hardcoded
+// fallback only kicks in when this env var is unset.
+func TestLoadSMETenantParentDomainsFromEnv_EnvOverride(t *testing.T) {
+	t.Setenv("CATALYST_SME_POOL_DOMAINS", "first.example:primary,second.example,third.example")
+	t.Setenv("CATALYST_OTECH_FQDN", "")
+	got := LoadSMETenantParentDomainsFromEnv()
+	if len(got) != 3 {
+		t.Fatalf("env override should produce 3 entries, got %d (%+v)", len(got), got)
+	}
+	if got[0].Name != "first.example" || got[0].Role != "primary" {
+		t.Errorf("first env entry mismatch: %+v", got[0])
+	}
+	for _, p := range got[1:] {
+		if p.Role != "sme-pool" {
+			t.Errorf("entries without :role suffix should default to sme-pool, got %+v", p)
+		}
+	}
+	// Belt-and-braces: env override must not leak the hardcoded four-entry
+	// fallback (regression guard for a confused refactor that double-seeds).
+	for _, p := range got {
+		if strings.HasSuffix(p.Name, ".omani.homes") || p.Name == "omani.homes" ||
+			p.Name == "omani.rest" || p.Name == "omani.trade" || p.Name == "omani.works" {
+			t.Errorf("env override path leaked hardcoded fallback entry %q", p.Name)
+		}
+	}
+	// Also assert clean env state.
+	if v := os.Getenv("CATALYST_SME_POOL_DOMAINS"); v == "" {
+		t.Fatalf("test setup: env var should be set")
+	}
+}


### PR DESCRIPTION
## Summary

- `LoadSMETenantParentDomainsFromEnv`'s hardcoded fallback only seeded 2 entries (omani.works + omani.trade), but the marketplace UI subdomain picker lists 4 (omani.homes/rest/trade/works) — a customer who picked .omani.homes or .omani.rest sailed through the picker only to hit a 422 `invalid-parent-domain` at signup.
- Widens the seed to all 4 canonical .omani.X TLDs so the backend pool, `core/marketplace/src/components/AddonsStep.svelte`, and `core/services/domain/store.AllowedTLDs` all agree. NSFlipReady=true on every entry — these zones are already delegated to the Sovereign's PowerDNS at gTLD level (pdmFlipNS short-circuits via `nsAlreadyMatches` on Day-2 re-adds).
- Updated `TestLoadSMETenantParentDomainsFromEnv_StubFallback` (`pool != 4`) and added 3 new tests covering: canonical 4-entry seed, OTECH primary + 4 sme-pool composition, env-override path without fallback leakage.

Closes #1830 (Part 1 — Day-1 pool seed).

## Part 2 status (UI subdomain picker)

The customer-facing marketplace already hard-codes all 4 TLDs in `AddonsStep.svelte` (line 36: `const tlds = ['omani.rest', 'omani.works', 'omani.trade', 'omani.homes']`). The Playwright spec `07 subdomain picker shows omani.homes pool` already asserts this. No UI fix-author dispatch was needed.

## Test plan

- [x] `go test ./products/catalyst/bootstrap/api/internal/handler/ -run "TestLoadSMETenantParentDomainsFromEnv|TestAddParentDomain|TestListParentDomains|TestDeleteParentDomain"` — all GREEN
- [x] `go build ./...` — clean
- [ ] Fresh prov: confirm `LoadSMETenantParentDomainsFromEnv` seed visible via `GET /api/v1/sovereign/parent-domains` (4 sme-pool rows) and SME tenant create accepts `parent_domain=omani.homes`/`omani.rest`.

Refs #1830

🤖 Generated with [Claude Code](https://claude.com/claude-code)