### PR TITLE
fix(controllers): NATS consume-leg for D35 (organization + sandbox)

### DIFF
--- a/core/controllers/go.mod
+++ b/core/controllers/go.mod
@@ -7,6 +7,8 @@ go 1.23
 
 require (
 	github.com/go-logr/logr v1.4.2
+	github.com/nats-io/nats.go v1.37.0
+	github.com/prometheus/client_golang v1.19.1
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
 	github.com/stretchr/testify v1.9.0
 	k8s.io/api v0.31.1
@@ -43,12 +45,10 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
-	github.com/nats-io/nats.go v1.37.0 // indirect
 	github.com/nats-io/nkeys v0.4.7 // indirect
 	github.com/nats-io/nuid v1.0.1 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/prometheus/client_golang v1.19.1 // indirect
 	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.55.0 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect

--- a/core/controllers/organization/cmd/main.go
+++ b/core/controllers/organization/cmd/main.go
@@ -11,6 +11,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"os"
@@ -22,11 +23,13 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	"github.com/openova-io/openova/core/controllers/organization/internal/controller"
 	orgapi "github.com/openova-io/openova/core/controllers/organization/internal/orgapi"
 	"github.com/openova-io/openova/core/controllers/pkg/gitea"
+	"github.com/openova-io/openova/core/controllers/pkg/natsbus"
 )
 
 var scheme = runtime.NewScheme()
@@ -115,6 +118,57 @@ func main() {
 	if err := r.SetupWithManager(mgr); err != nil {
 		log.Error(err, "setup reconciler")
 		os.Exit(1)
+	}
+
+	// D35 consume-leg — subscribe to the two canonical Catalyst NATS
+	// subjects so a `tenant.created` / `order.placed` envelope nudges
+	// the matching Organization CR into a fresh Reconcile within ~50ms
+	// of the publish. Best-effort wiring: when NATS_URL is unset (e.g.
+	// Catalyst-Zero contabo path where NATS is not deployed) we log
+	// "NATS not wired" and continue — the existing 30s informer
+	// requeue fallback inside r.Reconcile keeps the controller correct.
+	natsURL := strings.TrimSpace(os.Getenv("NATS_URL"))
+	if natsURL != "" {
+		if err := mgr.Add(manager.RunnableFunc(func(ctx context.Context) error {
+			sub, err := natsbus.Connect(natsURL)
+			if err != nil {
+				log.Error(err, "natsbus: connect failed — D35 consume-leg disabled",
+					"nats_url", natsURL)
+				return nil // non-fatal — informer requeue is the canonical fallback
+			}
+			bridge := &controller.NATSBridge{
+				Client: mgr.GetClient(),
+				Log:    log.WithName("natsbridge"),
+			}
+			if err := sub.Subscribe(ctx,
+				natsbus.SubjectTenantCreated,
+				"organization-controller-tenant-created",
+				bridge.HandleTenantCreated,
+				natsbus.SubscribeOptions{},
+			); err != nil {
+				log.Error(err, "natsbus: subscribe tenant.created failed")
+			}
+			if err := sub.Subscribe(ctx,
+				natsbus.SubjectOrderPlaced,
+				"organization-controller-order-placed",
+				bridge.HandleOrderPlaced,
+				natsbus.SubscribeOptions{},
+			); err != nil {
+				log.Error(err, "natsbus: subscribe order.placed failed")
+			}
+			<-ctx.Done()
+			sub.Close()
+			return nil
+		})); err != nil {
+			log.Error(err, "natsbus: add runnable failed")
+			os.Exit(1)
+		}
+		log.Info("natsbus: D35 consume-leg wired",
+			"nats_url", natsURL,
+			"subjects", []string{natsbus.SubjectTenantCreated, natsbus.SubjectOrderPlaced},
+		)
+	} else {
+		log.Info("natsbus: NATS_URL unset — D35 consume-leg disabled (informer-requeue fallback only)")
 	}
 
 	log.Info("starting manager",

--- a/core/controllers/organization/internal/controller/nats_bridge.go
+++ b/core/controllers/organization/internal/controller/nats_bridge.go
@@ -1,0 +1,202 @@
+// nats_bridge wires the canonical Catalyst NATS subjects (D35 consume
+// leg) into the organization-controller's reconcile loop.
+//
+// PR #1626 closed the publish-side of D35 — tenant + billing services
+// now emit `catalyst.tenant.created` + `catalyst.billing.order.placed`
+// on the NATS JetStream `CATALYST_SME` stream per ADR-0001 §6. The
+// consume-side was missing: no in-cluster controller subscribed, so the
+// envelopes accumulated on the broker and the only path that
+// reconciled an Organization CR was the 30s informer requeue plus
+// whatever wrote the CR in the first place. D35 (gate: "NATS broker
+// round-trips end-to-end") therefore stayed yellow even though the
+// publish leg shipped.
+//
+// This bridge subscribes to both subjects and, on each envelope:
+//
+//  1. Decodes the Event body into the tenant_id / slug fields the
+//     publishers stamp (see core/services/tenant/handlers/handlers.go +
+//     core/services/billing/handlers/handlers.go dispatchOrderPlaced).
+//  2. Looks up the Organization CR whose `spec.slug` matches the event's
+//     slug. The CR may not exist yet (e.g. tenant.created arrives
+//     before the operator wrote the CR) — that's a soft miss, we log
+//     and Ack so JetStream advances.
+//  3. Stamps `openova.io/last-event-observed-at` (RFC3339) +
+//     `openova.io/last-event-subject` on the CR via a patch. The
+//     annotation patch is treated as a generation-2 mutation by
+//     controller-runtime, which enqueues a fresh Reconcile within
+//     ~50ms — far faster than the 30s informer requeue fallback. The
+//     30s requeue is RETAINED inside Reconcile so a missed NATS message
+//     never strands a CR; subscription is an accelerator, not the only
+//     path.
+//
+// The bridge is intentionally idempotent — JetStream guarantees
+// at-least-once delivery, so the same envelope may arrive twice on a
+// broker rebalance. Stamping an annotation with the broker-side
+// Event.Timestamp keeps the patch byte-stable on duplicate delivery,
+// so controller-runtime does NOT enqueue a redundant Reconcile.
+//
+// Per HARD CONSTRAINT: no credential write-paths. The bridge reads
+// only the Event envelope + the matching CR; it never touches Secrets
+// or Keycloak service-account creds.
+
+package controller
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/go-logr/logr"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	orgapi "github.com/openova-io/openova/core/controllers/organization/internal/orgapi"
+	"github.com/openova-io/openova/core/controllers/pkg/natsbus"
+)
+
+// Annotation keys stamped on the matching Organization CR when a
+// canonical NATS envelope is observed. Stable across pod restarts so
+// duplicate JetStream delivery does NOT trigger a redundant
+// Reconcile (Event.Timestamp is a stable per-event value).
+const (
+	AnnotationLastNATSObservedAt = "openova.io/last-event-observed-at"
+	AnnotationLastNATSSubject    = "openova.io/last-event-subject"
+)
+
+// NATSBridge is the consume-leg adapter for the organization-controller.
+// One bridge instance per canonical subject; the bridge handles all
+// envelopes that match its handler shape.
+type NATSBridge struct {
+	Client client.Client
+	Log    logr.Logger
+}
+
+// HandleTenantCreated reacts to a `catalyst.tenant.created` envelope.
+// The publish-side (PR #1626) ships the tenant doc as the Data payload
+// — we read `slug` (canonical Org slug) and `id` (tenant id, used for
+// the audit log). When the matching Organization CR exists, we stamp
+// the observation annotation so controller-runtime enqueues a fresh
+// Reconcile. When it does not exist, we log + Ack — the operator (or a
+// future provisioning controller) is responsible for creating the CR.
+func (b *NATSBridge) HandleTenantCreated(ctx context.Context, ev *natsbus.Event) error {
+	if ev == nil {
+		return nil
+	}
+	var payload struct {
+		ID    string `json:"id"`
+		Slug  string `json:"slug"`
+		TenID string `json:"tenant_id"`
+	}
+	if err := json.Unmarshal(ev.Data, &payload); err != nil {
+		// Malformed inside the envelope — log and Ack via the
+		// natsbus dispatcher (returning nil acks). Don't Nak; the
+		// next delivery would fail identically.
+		b.Log.Error(err, "tenant.created: malformed Data payload — ack to skip",
+			"event_id", ev.ID)
+		return nil
+	}
+	slug := strings.TrimSpace(payload.Slug)
+	if slug == "" {
+		// PR #1626 stamps `slug` on the tenant doc; if it's missing
+		// the publish side regressed. Log loudly so the operator
+		// notices but Ack so the subscriber doesn't hot-loop.
+		b.Log.Error(fmt.Errorf("missing slug"), "tenant.created: payload has no slug — ack to skip",
+			"event_id", ev.ID, "tenant_id", payload.TenID)
+		return nil
+	}
+	return b.stampObservation(ctx, slug, natsbus.SubjectTenantCreated, ev)
+}
+
+// HandleOrderPlaced reacts to a `catalyst.billing.order.placed`
+// envelope. The publish-side (PR #1626 dispatchOrderPlaced) ships a
+// payload enriched with the tenant's subdomain — we read `subdomain`
+// (matches Org slug on the Sovereign-side wildcard tenancy model) and
+// `tenant_id` for the audit trail.
+func (b *NATSBridge) HandleOrderPlaced(ctx context.Context, ev *natsbus.Event) error {
+	if ev == nil {
+		return nil
+	}
+	var payload struct {
+		TenantID  string `json:"tenant_id"`
+		Subdomain string `json:"subdomain"`
+		OrgSlug   string `json:"org_slug"`
+	}
+	if err := json.Unmarshal(ev.Data, &payload); err != nil {
+		b.Log.Error(err, "order.placed: malformed Data payload — ack to skip",
+			"event_id", ev.ID)
+		return nil
+	}
+	// Prefer the explicit org_slug field when present (forward-compat);
+	// fall back to subdomain which dispatchOrderPlaced currently stamps.
+	slug := strings.TrimSpace(payload.OrgSlug)
+	if slug == "" {
+		slug = strings.TrimSpace(payload.Subdomain)
+	}
+	if slug == "" {
+		b.Log.Error(fmt.Errorf("missing slug"), "order.placed: payload has neither org_slug nor subdomain — ack to skip",
+			"event_id", ev.ID, "tenant_id", payload.TenantID)
+		return nil
+	}
+	return b.stampObservation(ctx, slug, natsbus.SubjectOrderPlaced, ev)
+}
+
+// stampObservation looks up the Organization CR by slug and patches in
+// the two observation annotations. The patch is byte-stable on
+// duplicate delivery (Event.Timestamp is the broker-side timestamp,
+// which is fixed per envelope), so controller-runtime does NOT enqueue
+// a redundant Reconcile.
+//
+// Missing CR is not an error — log + return nil so the natsbus
+// dispatcher Acks. A Nak on a soft miss would hot-loop the subscriber
+// against a permanently-absent CR.
+func (b *NATSBridge) stampObservation(ctx context.Context, slug, subject string, ev *natsbus.Event) error {
+	var org orgapi.Organization
+	// Organization is cluster-scoped (see orgapi/types.go), name == slug.
+	if err := b.Client.Get(ctx, types.NamespacedName{Name: slug}, &org); err != nil {
+		if apierrors.IsNotFound(err) {
+			b.Log.Info("nats observation: no matching Organization CR — ack and skip",
+				"subject", subject, "slug", slug, "event_id", ev.ID)
+			return nil
+		}
+		// Transient API-server error — return so the dispatcher Naks
+		// and JetStream redelivers after backoff.
+		return fmt.Errorf("get organization %s: %w", slug, err)
+	}
+
+	observedAt := ev.Timestamp.UTC().Format(time.RFC3339Nano)
+	if observedAt == "" || ev.Timestamp.IsZero() {
+		observedAt = time.Now().UTC().Format(time.RFC3339Nano)
+	}
+
+	// Skip the patch when the annotations already match — JetStream's
+	// at-least-once delivery means we will see the same envelope on
+	// broker rebalance, and a redundant patch would churn the informer.
+	cur := org.GetAnnotations()
+	if cur != nil &&
+		cur[AnnotationLastNATSObservedAt] == observedAt &&
+		cur[AnnotationLastNATSSubject] == subject {
+		b.Log.V(1).Info("nats observation: duplicate envelope — skip patch",
+			"subject", subject, "slug", slug, "event_id", ev.ID)
+		return nil
+	}
+
+	desired := &orgapi.Organization{}
+	org.DeepCopyInto(desired)
+	anns := desired.GetAnnotations()
+	if anns == nil {
+		anns = map[string]string{}
+	}
+	anns[AnnotationLastNATSObservedAt] = observedAt
+	anns[AnnotationLastNATSSubject] = subject
+	desired.SetAnnotations(anns)
+
+	if err := b.Client.Patch(ctx, desired, client.MergeFrom(&org)); err != nil {
+		return fmt.Errorf("patch organization %s: %w", slug, err)
+	}
+	b.Log.Info("nats observation stamped — reconcile enqueued",
+		"subject", subject, "slug", slug, "event_id", ev.ID, "observed_at", observedAt)
+	return nil
+}

--- a/core/controllers/organization/internal/controller/nats_bridge_test.go
+++ b/core/controllers/organization/internal/controller/nats_bridge_test.go
@@ -1,0 +1,261 @@
+// Unit tests for the NATS consume-leg bridge (D35).
+//
+// The handler is wired through a fake controller-runtime client so we
+// can assert:
+//
+//   - tenant.created envelope with a matching CR → annotations stamped.
+//   - order.placed envelope with the legacy subdomain field → CR found
+//     and annotated (back-compat with PR #1626 publish-side).
+//   - envelope with no matching CR → handler returns nil (Ack-to-skip),
+//     no patch attempted (assert via list count).
+//   - duplicate envelope (same timestamp) → no redundant patch.
+//   - malformed Data payload → handler returns nil so dispatcher Acks
+//     instead of hot-looping.
+//
+// The bridge is decoupled from JetStream by construction — the
+// natsbus.Handler signature is `func(ctx, *Event) error`, so these
+// tests exercise the same surface the live subscriber drives.
+
+package controller
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr/testr"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	orgapi "github.com/openova-io/openova/core/controllers/organization/internal/orgapi"
+	"github.com/openova-io/openova/core/controllers/pkg/natsbus"
+)
+
+func newBridgeFixture(t *testing.T, objs ...runtime.Object) *NATSBridge {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(scheme); err != nil {
+		t.Fatalf("clientgo addtoscheme: %v", err)
+	}
+	if err := orgapi.AddToScheme(scheme); err != nil {
+		t.Fatalf("orgapi addtoscheme: %v", err)
+	}
+	cb := fake.NewClientBuilder().WithScheme(scheme)
+	if len(objs) > 0 {
+		cb = cb.WithRuntimeObjects(objs...)
+	}
+	return &NATSBridge{
+		Client: cb.Build(),
+		Log:    testr.New(t),
+	}
+}
+
+// TestNATSBridge_TenantCreated_HappyPath pins: an envelope on
+// catalyst.tenant.created with a matching Organization CR results in
+// both observation annotations being patched. This is the D35 happy
+// path proof.
+func TestNATSBridge_TenantCreated_HappyPath(t *testing.T) {
+	org := &orgapi.Organization{
+		ObjectMeta: metav1.ObjectMeta{Name: "acme"},
+		Spec:       orgapi.OrganizationSpec{Slug: "acme"},
+	}
+	bridge := newBridgeFixture(t, org)
+
+	ts := time.Date(2026, 5, 18, 12, 34, 56, 789012345, time.UTC)
+	body, _ := json.Marshal(map[string]any{
+		"id":   "tnt-1",
+		"slug": "acme",
+	})
+	ev := &natsbus.Event{
+		ID:        "evt-tc-1",
+		Type:      "tenant.created",
+		Source:    "tenant-service",
+		Timestamp: ts,
+		TenantID:  "tnt-1",
+		Data:      body,
+	}
+	if err := bridge.HandleTenantCreated(context.Background(), ev); err != nil {
+		t.Fatalf("HandleTenantCreated: %v", err)
+	}
+
+	var got orgapi.Organization
+	if err := bridge.Client.Get(context.Background(), types.NamespacedName{Name: "acme"}, &got); err != nil {
+		t.Fatalf("get organization: %v", err)
+	}
+	anns := got.GetAnnotations()
+	if anns[AnnotationLastNATSSubject] != natsbus.SubjectTenantCreated {
+		t.Errorf("subject annotation: got %q want %q",
+			anns[AnnotationLastNATSSubject], natsbus.SubjectTenantCreated)
+	}
+	wantObservedAt := ts.Format(time.RFC3339Nano)
+	if anns[AnnotationLastNATSObservedAt] != wantObservedAt {
+		t.Errorf("observed-at annotation: got %q want %q",
+			anns[AnnotationLastNATSObservedAt], wantObservedAt)
+	}
+}
+
+// TestNATSBridge_OrderPlaced_BackCompatSubdomain pins the back-compat
+// path: when org_slug is absent, the bridge falls back to the
+// `subdomain` field PR #1626's dispatchOrderPlaced enriches in.
+// Bodyguard against the publish-side renaming the field without the
+// consume-side noticing.
+func TestNATSBridge_OrderPlaced_BackCompatSubdomain(t *testing.T) {
+	org := &orgapi.Organization{
+		ObjectMeta: metav1.ObjectMeta{Name: "globex"},
+		Spec:       orgapi.OrganizationSpec{Slug: "globex"},
+	}
+	bridge := newBridgeFixture(t, org)
+
+	body, _ := json.Marshal(map[string]any{
+		"tenant_id": "tnt-2",
+		"subdomain": "globex",
+	})
+	ev := &natsbus.Event{
+		ID:        "evt-op-1",
+		Type:      "order.placed",
+		Source:    "billing-service",
+		Timestamp: time.Date(2026, 5, 18, 13, 0, 0, 0, time.UTC),
+		TenantID:  "tnt-2",
+		Data:      body,
+	}
+	if err := bridge.HandleOrderPlaced(context.Background(), ev); err != nil {
+		t.Fatalf("HandleOrderPlaced: %v", err)
+	}
+
+	var got orgapi.Organization
+	if err := bridge.Client.Get(context.Background(), types.NamespacedName{Name: "globex"}, &got); err != nil {
+		t.Fatalf("get organization: %v", err)
+	}
+	if got.GetAnnotations()[AnnotationLastNATSSubject] != natsbus.SubjectOrderPlaced {
+		t.Errorf("subject annotation: got %q want %q",
+			got.GetAnnotations()[AnnotationLastNATSSubject], natsbus.SubjectOrderPlaced)
+	}
+}
+
+// TestNATSBridge_NoMatchingCR pins: an envelope referencing a slug
+// that doesn't exist returns nil (Ack-to-skip) and does NOT churn the
+// API server. Critical for cold-start ordering — tenant.created may
+// arrive before the operator's Organization CR write.
+func TestNATSBridge_NoMatchingCR(t *testing.T) {
+	bridge := newBridgeFixture(t) // empty fake client
+
+	body, _ := json.Marshal(map[string]any{"slug": "nonexistent"})
+	ev := &natsbus.Event{
+		ID:        "evt-miss",
+		Type:      "tenant.created",
+		Timestamp: time.Now().UTC(),
+		Data:      body,
+	}
+	if err := bridge.HandleTenantCreated(context.Background(), ev); err != nil {
+		t.Fatalf("HandleTenantCreated on missing CR returned error (should soft-miss): %v", err)
+	}
+}
+
+// TestNATSBridge_DuplicateEnvelope_NoChurn pins: replaying the same
+// envelope (same Timestamp) does not mutate the CR a second time. The
+// gen-2 controller-runtime informer enqueues on annotation drift; a
+// byte-stable patch keeps the reconcile queue clean.
+func TestNATSBridge_DuplicateEnvelope_NoChurn(t *testing.T) {
+	org := &orgapi.Organization{
+		ObjectMeta: metav1.ObjectMeta{Name: "dup", ResourceVersion: "1"},
+		Spec:       orgapi.OrganizationSpec{Slug: "dup"},
+	}
+	bridge := newBridgeFixture(t, org)
+	ts := time.Date(2026, 5, 18, 14, 0, 0, 0, time.UTC)
+	body, _ := json.Marshal(map[string]any{"slug": "dup"})
+	ev := &natsbus.Event{
+		ID:        "evt-dup",
+		Type:      "tenant.created",
+		Timestamp: ts,
+		Data:      body,
+	}
+
+	// First delivery — patches.
+	if err := bridge.HandleTenantCreated(context.Background(), ev); err != nil {
+		t.Fatalf("first delivery: %v", err)
+	}
+	var afterFirst orgapi.Organization
+	if err := bridge.Client.Get(context.Background(), types.NamespacedName{Name: "dup"}, &afterFirst); err != nil {
+		t.Fatalf("get after first: %v", err)
+	}
+	rvAfterFirst := afterFirst.GetResourceVersion()
+
+	// Second delivery (same envelope, same timestamp) — skip path.
+	if err := bridge.HandleTenantCreated(context.Background(), ev); err != nil {
+		t.Fatalf("second delivery: %v", err)
+	}
+	var afterSecond orgapi.Organization
+	if err := bridge.Client.Get(context.Background(), types.NamespacedName{Name: "dup"}, &afterSecond); err != nil {
+		t.Fatalf("get after second: %v", err)
+	}
+	if afterSecond.GetResourceVersion() != rvAfterFirst {
+		t.Errorf("duplicate envelope mutated CR — rv went %q → %q",
+			rvAfterFirst, afterSecond.GetResourceVersion())
+	}
+}
+
+// TestNATSBridge_MalformedData pins: a Data blob that fails
+// json.Unmarshal returns nil so the natsbus dispatcher Acks-to-skip.
+// A Nak would hot-loop the consumer against a poison pill.
+func TestNATSBridge_MalformedData(t *testing.T) {
+	bridge := newBridgeFixture(t)
+	ev := &natsbus.Event{
+		ID:        "evt-bad",
+		Type:      "tenant.created",
+		Timestamp: time.Now().UTC(),
+		Data:      []byte("{not-json"),
+	}
+	if err := bridge.HandleTenantCreated(context.Background(), ev); err != nil {
+		t.Errorf("malformed Data should NOT return error (would Nak + hot-loop), got: %v", err)
+	}
+}
+
+// TestNATSBridge_OrderPlaced_PreferOrgSlug pins: when both org_slug and
+// subdomain are present, org_slug wins. Forward-compat with the
+// publish-side normalizing to the explicit field.
+func TestNATSBridge_OrderPlaced_PreferOrgSlug(t *testing.T) {
+	org := &orgapi.Organization{
+		ObjectMeta: metav1.ObjectMeta{Name: "winner"},
+		Spec:       orgapi.OrganizationSpec{Slug: "winner"},
+	}
+	loser := &orgapi.Organization{
+		ObjectMeta: metav1.ObjectMeta{Name: "loser"},
+		Spec:       orgapi.OrganizationSpec{Slug: "loser"},
+	}
+	bridge := newBridgeFixture(t, org, loser)
+
+	body, _ := json.Marshal(map[string]any{
+		"tenant_id": "tnt-99",
+		"org_slug":  "winner",
+		"subdomain": "loser",
+	})
+	ev := &natsbus.Event{
+		ID:        "evt-pref",
+		Type:      "order.placed",
+		Timestamp: time.Now().UTC(),
+		Data:      body,
+	}
+	if err := bridge.HandleOrderPlaced(context.Background(), ev); err != nil {
+		t.Fatalf("HandleOrderPlaced: %v", err)
+	}
+
+	var winner orgapi.Organization
+	if err := bridge.Client.Get(context.Background(), types.NamespacedName{Name: "winner"}, &winner); err != nil {
+		t.Fatalf("get winner: %v", err)
+	}
+	if _, ok := winner.GetAnnotations()[AnnotationLastNATSSubject]; !ok {
+		t.Error("winner Organization was not annotated despite org_slug match")
+	}
+
+	var loserGot orgapi.Organization
+	if err := bridge.Client.Get(context.Background(), types.NamespacedName{Name: "loser"}, &loserGot); err != nil {
+		t.Fatalf("get loser: %v", err)
+	}
+	if _, ok := loserGot.GetAnnotations()[AnnotationLastNATSSubject]; ok {
+		t.Error("loser Organization was unexpectedly annotated; org_slug should outrank subdomain")
+	}
+}

--- a/core/controllers/pkg/natsbus/subscriber.go
+++ b/core/controllers/pkg/natsbus/subscriber.go
@@ -1,0 +1,300 @@
+// Package natsbus is a minimal NATS JetStream subscriber for the
+// in-cluster Group-C controllers (organization-controller,
+// sandbox-controller). It exists to close the consume-leg of DoD D35
+// (`catalyst.tenant.created` / `catalyst.order.placed` /
+// `catalyst.tenant.sandbox_requested` round-trip end-to-end) when the
+// publish-leg PR #1626 wired into core/services/shared/events landed.
+//
+// The package is deliberately self-contained inside core/controllers/
+// (separate Go module from core/services/shared/events) — copying the
+// ~80 LOC of JetStream connect + durable-consumer attach is cheaper
+// than dragging the entire core/services/shared/events package
+// (BrokerPublisher / MultiSubscriber / Kafka transport) into a
+// controller binary that only needs to subscribe.
+//
+// What the controllers do with each envelope is up to the caller —
+// the package surface is intentionally narrow:
+//
+//   - Connect(url) → *Subscriber, Close() teardown.
+//   - Subscriber.Subscribe(ctx, subject, durable, handler) starts a
+//     durable JetStream consumer and dispatches every envelope to
+//     handler. Handler returning nil → Ack; non-nil → Nak (5s
+//     backoff so transient downstream blips don't hot-loop).
+//   - Event mirrors core/services/shared/events.Event so the JSON
+//     wire format is identical (id / type / source / timestamp /
+//     tenant_id / data / metadata).
+//
+// The expected operational pattern is:
+//
+//	r.Reconcile is the canonical path for steady-state convergence.
+//	NATS subscribers in main.go observe domain events as they fire
+//	and enqueue the corresponding CR for reconcile (so the controller
+//	responds within ~50ms instead of waiting up to 30s for the next
+//	requeue). The 30s RequeueAfter inside r.Reconcile remains the
+//	fallback — NATS message loss never strands a CR; the next
+//	informer-driven Reconcile picks it up.
+//
+// Connection options mirror core/cmd/projector/internal/nats:
+// MaxReconnects=-1 (retry forever — JetStream rollouts shouldn't
+// crash-loop the controller), 2s ReconnectWait, 20s PingInterval.
+//
+// Per Inviolable Principle #4 every knob is env-driven; this package
+// reads nothing from os.Getenv directly — main.go owns the env
+// surface and passes URL + StreamName + DurableName into Connect /
+// Subscribe.
+package natsbus
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+// StreamCatalystSME is the canonical JetStream Stream backing every
+// SME convergence event (catalyst.tenant.*, catalyst.billing.*,
+// catalyst.domain.*, catalyst.provision.*). Mirrors
+// core/services/shared/events.StreamCatalystSME — kept in sync by the
+// constant lifting up to the chart / per-Sovereign overlay.
+const StreamCatalystSME = "CATALYST_SME"
+
+// Canonical subjects the Group-C controllers consume. Each constant
+// matches the publish-side subject derived by
+// core/services/shared/events.CanonicalSubject — kept in sync by the
+// D35 test plan.
+const (
+	// SubjectTenantCreated fires when tenant-service finalises a new
+	// tenant (publish-side PR #1626). organization-controller subscribes
+	// so the corresponding Organization CR converges within ~50ms of
+	// the marketplace checkout instead of waiting on the 30s fallback.
+	SubjectTenantCreated = "catalyst.tenant.created"
+
+	// SubjectOrderPlaced fires when billing-service records a paid
+	// order (publish-side PR #1626). organization-controller subscribes
+	// to observe the round-trip and trigger reconcile of the per-tenant
+	// Organization CR (so day-1 app installs in the basket land on the
+	// per-Org Gitea repo without the operator polling catalyst-api).
+	SubjectOrderPlaced = "catalyst.billing.order.placed"
+
+	// SubjectTenantSandboxRequested fires when the marketplace cart
+	// contained the sandbox product (publish-side tenant-service in
+	// PR #1633). sandbox-controller subscribes so the per-Sandbox
+	// reconcile loop runs immediately on cart completion.
+	SubjectTenantSandboxRequested = "catalyst.tenant.sandbox_requested"
+)
+
+// Event is the JSON envelope on every catalyst.* subject. The shape
+// mirrors core/services/shared/events.Event exactly — fields are
+// duplicated here (rather than imported) to keep the controllers
+// module free of a dependency on core/services/shared, which pulls
+// in franz-go + Kafka transports the controllers never touch.
+type Event struct {
+	ID        string            `json:"id"`
+	Type      string            `json:"type"`
+	Source    string            `json:"source"`
+	Timestamp time.Time         `json:"timestamp"`
+	TenantID  string            `json:"tenant_id"`
+	Data      json.RawMessage   `json:"data"`
+	Metadata  map[string]string `json:"metadata,omitempty"`
+}
+
+// Subscriber holds an open NATS+JetStream connection. Construct via
+// Connect; close via Close. Subscribe may be called from multiple
+// goroutines — each call attaches an independent durable consumer.
+type Subscriber struct {
+	nc *nats.Conn
+	js jetstream.JetStream
+}
+
+// Connect opens a NATS connection at url and binds a JetStream client
+// on top. Empty url falls back to nats.DefaultURL so unit tests can
+// exercise the package against a local nats-server without env wiring.
+//
+// Returns an error if the broker is unreachable; the caller (main.go)
+// is expected to either bail out (NATS is canonical on Sovereigns) or
+// log and continue (Catalyst-Zero / contabo, where REDPANDA_BROKERS
+// is the authoritative bus).
+func Connect(url string) (*Subscriber, error) {
+	if url == "" {
+		url = nats.DefaultURL
+	}
+	nc, err := nats.Connect(url,
+		nats.Name("catalyst-controllers"),
+		nats.MaxReconnects(-1),
+		nats.ReconnectWait(2*time.Second),
+		nats.PingInterval(20*time.Second),
+		nats.MaxPingsOutstanding(3),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("natsbus: connect %s: %w", url, err)
+	}
+	js, err := jetstream.New(nc)
+	if err != nil {
+		nc.Close()
+		return nil, fmt.Errorf("natsbus: jetstream init: %w", err)
+	}
+	return &Subscriber{nc: nc, js: js}, nil
+}
+
+// Handler is the per-message callback. Returning a nil error Acks the
+// message (JetStream advances the consumer cursor); returning a
+// non-nil error Naks with a 5s backoff so transient handler failures
+// redeliver instead of stranding the envelope.
+//
+// Implementations SHOULD be idempotent — JetStream guarantees
+// at-least-once delivery, so the same Event.ID may arrive twice on a
+// broker rebalance.
+type Handler func(ctx context.Context, ev *Event) error
+
+// SubscribeOptions tunes Subscribe behaviour. Zero values yield sane
+// production defaults (Stream=CATALYST_SME, AckWait=30s, no MaxDeliver
+// cap so a permanently-failing handler does NOT silently drop events
+// — operator-visible nak loops are the right failure mode).
+type SubscribeOptions struct {
+	// Stream is the JetStream Stream the FilterSubject lives on.
+	// Defaults to StreamCatalystSME.
+	Stream string
+	// AckWait bounds how long JetStream waits for Ack before redeliver.
+	// Defaults to 30 seconds.
+	AckWait time.Duration
+	// NakBackoff is the backoff inserted before redelivery when the
+	// Handler returns a non-nil error. Defaults to 5 seconds.
+	NakBackoff time.Duration
+}
+
+// Subscribe attaches a durable consumer to subject on options.Stream
+// (default StreamCatalystSME) under the supplied durable name, and
+// dispatches every envelope to handler.
+//
+// Subscribe is non-blocking: it returns once the consumer has been
+// created AND the underlying Consume loop has been started. The
+// loop runs until ctx is cancelled. To stop, cancel ctx — the
+// underlying JetStream ConsumeContext is then stopped automatically.
+//
+// Durable names are stable across pod restarts so JetStream resumes
+// from the committed sequence after a controller-manager rollout.
+// MaxDeliver=-1 (retry forever) matches the
+// core/services/shared/events.MultiSubscriber convention: operator-
+// visible nak loops are the right failure mode for unrecoverable
+// handler errors, not silent drops.
+func (s *Subscriber) Subscribe(
+	ctx context.Context,
+	subject, durable string,
+	handler Handler,
+	opts SubscribeOptions,
+) error {
+	if s == nil || s.js == nil {
+		return errors.New("natsbus: subscriber not initialised")
+	}
+	if subject == "" {
+		return errors.New("natsbus: Subscribe requires subject")
+	}
+	if durable == "" {
+		return errors.New("natsbus: Subscribe requires durable name")
+	}
+	if handler == nil {
+		return errors.New("natsbus: Subscribe requires handler")
+	}
+	stream := opts.Stream
+	if stream == "" {
+		stream = StreamCatalystSME
+	}
+	ackWait := opts.AckWait
+	if ackWait <= 0 {
+		ackWait = 30 * time.Second
+	}
+	nakBackoff := opts.NakBackoff
+	if nakBackoff <= 0 {
+		nakBackoff = 5 * time.Second
+	}
+
+	cons, err := s.js.CreateOrUpdateConsumer(ctx, stream, jetstream.ConsumerConfig{
+		Durable:       durable,
+		Description:   fmt.Sprintf("controllers natsbus %s on %s", durable, subject),
+		AckPolicy:     jetstream.AckExplicitPolicy,
+		AckWait:       ackWait,
+		FilterSubject: subject,
+		DeliverPolicy: jetstream.DeliverAllPolicy,
+		MaxDeliver:    -1,
+	})
+	if err != nil {
+		return fmt.Errorf("natsbus: create consumer %s on %s/%s: %w", durable, stream, subject, err)
+	}
+
+	cc, err := cons.Consume(func(msg jetstream.Msg) {
+		dispatchOne(ctx, msg, handler, subject, durable, nakBackoff)
+	})
+	if err != nil {
+		return fmt.Errorf("natsbus: start consume %s: %w", durable, err)
+	}
+
+	slog.Info("natsbus: subscribed",
+		"subject", subject, "durable", durable, "stream", stream)
+
+	// Stop the JetStream consume context when ctx is cancelled. We do
+	// this in a goroutine so Subscribe returns immediately — the caller
+	// (main.go) wires the same ctx to manager.Start so SIGTERM unwinds
+	// every Subscribe at once.
+	go func() {
+		<-ctx.Done()
+		cc.Stop()
+		slog.Info("natsbus: stopped", "subject", subject, "durable", durable)
+	}()
+	return nil
+}
+
+// dispatchOne parses one JetStream message into an Event, invokes the
+// handler with a per-message timeout, and Acks / Naks per the result.
+// Malformed JSON is Ack'd-skipped (with an error log) so a poison-pill
+// envelope cannot hot-loop the consumer.
+func dispatchOne(
+	parent context.Context,
+	msg jetstream.Msg,
+	handler Handler,
+	subject, durable string,
+	nakBackoff time.Duration,
+) {
+	var ev Event
+	if err := json.Unmarshal(msg.Data(), &ev); err != nil {
+		slog.Error("natsbus: malformed envelope — ack to skip",
+			"subject", subject, "durable", durable,
+			"err", err, "body_size", len(msg.Data()))
+		_ = msg.Ack()
+		return
+	}
+
+	// Per-message timeout — 25s leaves 5s of slack inside the 30s
+	// default AckWait so the broker does not redeliver while the handler
+	// is still running.
+	hctx, cancel := context.WithTimeout(parent, 25*time.Second)
+	defer cancel()
+
+	if err := handler(hctx, &ev); err != nil {
+		slog.Warn("natsbus: handler error — nak for retry",
+			"subject", subject, "durable", durable,
+			"event_id", ev.ID, "event_type", ev.Type, "err", err)
+		if nakErr := msg.NakWithDelay(nakBackoff); nakErr != nil {
+			slog.Error("natsbus: nak failed",
+				"subject", subject, "durable", durable, "err", nakErr)
+		}
+		return
+	}
+	if ackErr := msg.Ack(); ackErr != nil {
+		slog.Error("natsbus: ack failed",
+			"subject", subject, "durable", durable,
+			"event_id", ev.ID, "err", ackErr)
+	}
+}
+
+// Close drains the underlying NATS connection. Idempotent.
+func (s *Subscriber) Close() {
+	if s == nil || s.nc == nil {
+		return
+	}
+	_ = s.nc.Drain()
+}

--- a/core/controllers/pkg/natsbus/subscriber_test.go
+++ b/core/controllers/pkg/natsbus/subscriber_test.go
@@ -1,0 +1,223 @@
+// Unit tests for natsbus. Verifies the per-message dispatch contract
+// (Ack on handler success, Nak on handler error, Ack-to-skip on
+// malformed JSON) without spinning up an embedded NATS server. Live-
+// broker integration is covered by the D35 fresh-prov verifier.
+package natsbus
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+// fakeMsg implements just enough of jetstream.Msg for dispatchOne to
+// drive Ack / Nak / NakWithDelay outcomes. Method set mirrors the
+// interface so a typecheck against jetstream.Msg keeps the fake honest.
+type fakeMsg struct {
+	data []byte
+
+	mu          sync.Mutex
+	ackCount    int
+	nakCount    int
+	termCount   int
+	nakDelay    time.Duration
+	inProgress  int
+	headers     map[string][]string
+	subject     string
+	reply       string
+}
+
+var _ jetstream.Msg = (*fakeMsg)(nil)
+
+func (f *fakeMsg) Data() []byte { return f.data }
+func (f *fakeMsg) Headers() nats.Header {
+	out := nats.Header{}
+	for k, vs := range f.headers {
+		out[k] = vs
+	}
+	return out
+}
+func (f *fakeMsg) Subject() string { return f.subject }
+func (f *fakeMsg) Reply() string   { return f.reply }
+func (f *fakeMsg) Ack() error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.ackCount++
+	return nil
+}
+func (f *fakeMsg) DoubleAck(context.Context) error {
+	return f.Ack()
+}
+func (f *fakeMsg) Nak() error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.nakCount++
+	return nil
+}
+func (f *fakeMsg) NakWithDelay(d time.Duration) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.nakCount++
+	f.nakDelay = d
+	return nil
+}
+func (f *fakeMsg) InProgress() error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.inProgress++
+	return nil
+}
+func (f *fakeMsg) Term() error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.termCount++
+	return nil
+}
+func (f *fakeMsg) TermWithReason(string) error { return f.Term() }
+func (f *fakeMsg) Metadata() (*jetstream.MsgMetadata, error) {
+	return &jetstream.MsgMetadata{}, nil
+}
+
+// TestDispatchOne_HandlerSuccess pins: a handler returning nil Acks
+// the message exactly once and never Naks. Bodyguard for the D35
+// happy path — every successful round-trip moves the consumer cursor.
+func TestDispatchOne_HandlerSuccess(t *testing.T) {
+	payload := Event{
+		ID:        "evt-1",
+		Type:      "tenant.created",
+		Source:    "tenant-service",
+		Timestamp: time.Now().UTC(),
+		TenantID:  "tnt-abc",
+		Data:      json.RawMessage(`{"id":"tnt-abc","slug":"acme"}`),
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	msg := &fakeMsg{data: body, subject: SubjectTenantCreated}
+
+	var seen *Event
+	handler := Handler(func(_ context.Context, ev *Event) error {
+		seen = ev
+		return nil
+	})
+
+	dispatchOne(context.Background(), msg, handler, SubjectTenantCreated, "test-d", 5*time.Second)
+
+	if msg.ackCount != 1 {
+		t.Errorf("want Ack count 1, got %d", msg.ackCount)
+	}
+	if msg.nakCount != 0 {
+		t.Errorf("want Nak count 0, got %d", msg.nakCount)
+	}
+	if seen == nil || seen.ID != "evt-1" || seen.Type != "tenant.created" {
+		t.Errorf("handler did not receive the parsed envelope: %+v", seen)
+	}
+	if seen.TenantID != "tnt-abc" {
+		t.Errorf("envelope tenant_id mismatch: got %q want %q", seen.TenantID, "tnt-abc")
+	}
+}
+
+// TestDispatchOne_HandlerError pins: a handler returning a non-nil
+// error Naks (with the configured backoff) and does NOT Ack. Bodyguard
+// for transient downstream failures — JetStream must redeliver.
+func TestDispatchOne_HandlerError(t *testing.T) {
+	body, _ := json.Marshal(Event{ID: "evt-err", Type: "order.placed"})
+	msg := &fakeMsg{data: body, subject: SubjectOrderPlaced}
+
+	handler := Handler(func(context.Context, *Event) error {
+		return errors.New("downstream API unreachable")
+	})
+
+	const backoff = 7 * time.Second
+	dispatchOne(context.Background(), msg, handler, SubjectOrderPlaced, "test-d", backoff)
+
+	if msg.ackCount != 0 {
+		t.Errorf("want Ack count 0 on handler error, got %d", msg.ackCount)
+	}
+	if msg.nakCount != 1 {
+		t.Errorf("want Nak count 1 on handler error, got %d", msg.nakCount)
+	}
+	if msg.nakDelay != backoff {
+		t.Errorf("want Nak delay %v, got %v", backoff, msg.nakDelay)
+	}
+}
+
+// TestDispatchOne_MalformedJSON pins: a payload that fails json.Unmarshal
+// is Ack'd-skipped (the consumer cursor advances) so a poison pill cannot
+// hot-loop the subscriber. Caught by the operator log line, not the
+// transport.
+func TestDispatchOne_MalformedJSON(t *testing.T) {
+	msg := &fakeMsg{data: []byte("not-json{"), subject: SubjectTenantSandboxRequested}
+
+	called := false
+	handler := Handler(func(context.Context, *Event) error {
+		called = true
+		return nil
+	})
+
+	dispatchOne(context.Background(), msg, handler, SubjectTenantSandboxRequested, "test-d", 5*time.Second)
+
+	if called {
+		t.Error("handler should NOT be invoked on malformed JSON")
+	}
+	if msg.ackCount != 1 {
+		t.Errorf("want Ack count 1 to skip poison pill, got %d", msg.ackCount)
+	}
+	if msg.nakCount != 0 {
+		t.Errorf("want Nak count 0 on poison pill (Term/Ack only), got %d", msg.nakCount)
+	}
+}
+
+// TestDispatchOne_SandboxRequestedPayload pins the exact wire format
+// the publish-side (PR #1633 tenant.handlers.CreateOrg) emits — the
+// downstream sandbox-controller handler reads tenant_id, org_slug,
+// owner_id, owner_email, agent_catalogue out of the Data blob. If
+// the publish-side renames a field this test goes red so the consumer
+// stays in lockstep.
+func TestDispatchOne_SandboxRequestedPayload(t *testing.T) {
+	payload := Event{
+		ID:        "evt-sb",
+		Type:      "tenant.sandbox_requested",
+		Source:    "tenant-service",
+		Timestamp: time.Now().UTC(),
+		TenantID:  "tnt-sb",
+		Data: json.RawMessage(`{
+			"tenant_id":"tnt-sb",
+			"org_slug":"acme",
+			"owner_id":"u-1",
+			"owner_email":"ceo@acme.com",
+			"agent_catalogue":["qwen","claude"]
+		}`),
+	}
+	body, _ := json.Marshal(payload)
+	msg := &fakeMsg{data: body, subject: SubjectTenantSandboxRequested}
+
+	var got struct {
+		TenantID       string   `json:"tenant_id"`
+		OrgSlug        string   `json:"org_slug"`
+		OwnerEmail     string   `json:"owner_email"`
+		AgentCatalogue []string `json:"agent_catalogue"`
+	}
+	handler := Handler(func(_ context.Context, ev *Event) error {
+		return json.Unmarshal(ev.Data, &got)
+	})
+
+	dispatchOne(context.Background(), msg, handler, SubjectTenantSandboxRequested, "test-d", 5*time.Second)
+
+	if msg.ackCount != 1 {
+		t.Fatalf("expected Ack=1 on success, got Ack=%d Nak=%d", msg.ackCount, msg.nakCount)
+	}
+	if got.OrgSlug != "acme" || got.OwnerEmail != "ceo@acme.com" {
+		t.Errorf("payload fields not surfaced: %+v", got)
+	}
+	if len(got.AgentCatalogue) != 2 || got.AgentCatalogue[0] != "qwen" {
+		t.Errorf("agent_catalogue not surfaced: %+v", got.AgentCatalogue)
+	}
+}

--- a/core/controllers/sandbox/cmd/sandbox-controller/main.go
+++ b/core/controllers/sandbox/cmd/sandbox-controller/main.go
@@ -7,6 +7,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"os"
@@ -19,9 +20,11 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	"github.com/openova-io/openova/core/controllers/pkg/gitea"
+	"github.com/openova-io/openova/core/controllers/pkg/natsbus"
 	"github.com/openova-io/openova/core/controllers/sandbox/internal/controller"
 	"github.com/openova-io/openova/core/controllers/sandbox/internal/idlescaler"
 	"github.com/openova-io/openova/core/controllers/sandbox/internal/newapi"
@@ -170,6 +173,50 @@ func main() {
 	if err := mgr.Add(scaler); err != nil {
 		log.Error(err, "add idle-scaler to manager")
 		os.Exit(1)
+	}
+
+	// D35 consume-leg — subscribe to `catalyst.tenant.sandbox_requested`
+	// so the publish from tenant-service nudges the matching Sandbox CR
+	// into a fresh Reconcile within ~50ms. Same wiring shape as the
+	// organization-controller's NATS bridge. Best-effort: NATS_URL
+	// unset → log + continue (informer requeue fallback intact).
+	natsURL := strings.TrimSpace(os.Getenv("NATS_URL"))
+	sandboxNs := envOr("SANDBOX_NAMESPACE", "catalyst-system")
+	if natsURL != "" {
+		if err := mgr.Add(manager.RunnableFunc(func(ctx context.Context) error {
+			sub, err := natsbus.Connect(natsURL)
+			if err != nil {
+				log.Error(err, "natsbus: connect failed — D35 consume-leg disabled",
+					"nats_url", natsURL)
+				return nil
+			}
+			bridge := &controller.NATSBridge{
+				Client:    mgr.GetClient(),
+				Log:       log.WithName("natsbridge"),
+				Namespace: sandboxNs,
+			}
+			if err := sub.Subscribe(ctx,
+				natsbus.SubjectTenantSandboxRequested,
+				"sandbox-controller-sandbox-requested",
+				bridge.HandleSandboxRequested,
+				natsbus.SubscribeOptions{},
+			); err != nil {
+				log.Error(err, "natsbus: subscribe tenant.sandbox_requested failed")
+			}
+			<-ctx.Done()
+			sub.Close()
+			return nil
+		})); err != nil {
+			log.Error(err, "natsbus: add runnable failed")
+			os.Exit(1)
+		}
+		log.Info("natsbus: D35 consume-leg wired",
+			"nats_url", natsURL,
+			"subjects", []string{natsbus.SubjectTenantSandboxRequested},
+			"sandbox_namespace", sandboxNs,
+		)
+	} else {
+		log.Info("natsbus: NATS_URL unset — D35 consume-leg disabled (informer-requeue fallback only)")
 	}
 
 	log.Info("starting manager",

--- a/core/controllers/sandbox/internal/controller/nats_bridge.go
+++ b/core/controllers/sandbox/internal/controller/nats_bridge.go
@@ -1,0 +1,223 @@
+// nats_bridge wires the canonical Catalyst NATS subject
+// `catalyst.tenant.sandbox_requested` (D35 consume leg, sandbox-controller side)
+// into the sandbox-controller's reconcile loop.
+//
+// Why this lives in sandbox-controller, not just in tenant-service:
+// the tenant-service SandboxOrchestrator (PR #1633) already consumes
+// `catalyst.tenant.sandbox_requested` and creates the Sandbox CR. The
+// missing leg was an in-cluster controller that, after the CR
+// materialised, OBSERVES the same envelope on its broker side and
+// triggers a fresh Reconcile within ~50ms instead of waiting for the
+// 30s informer requeue. That tightens the cart-completion → CR-Ready
+// loop end-to-end and closes D35: NATS round-trips end-to-end with
+// the controllers as the consume-side leg.
+//
+// The bridge looks up the matching Sandbox CR by the same name
+// derivation tenant-service uses (sanitised owner email/UID inside the
+// sandbox namespace) and stamps two annotations:
+//
+//   - openova.io/last-event-observed-at: RFC3339 timestamp from the
+//     broker envelope. Stable across duplicate JetStream delivery so
+//     the annotation patch is byte-equal on replay.
+//   - openova.io/last-event-subject: the canonical subject string.
+//
+// Patching either annotation triggers an informer event →
+// controller-runtime enqueues the CR's NamespacedName → Reconcile
+// runs within ~50ms.
+//
+// The 30s RequeueAfter in r.Reconcile remains untouched — this bridge
+// is an accelerator, not the only path. NATS message loss never
+// strands a CR.
+//
+// Per HARD CONSTRAINT: no credential write-paths. The bridge reads
+// only the Event envelope + the matching CR; it never touches Secrets
+// or NewAPI bearer tokens.
+
+package controller
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/go-logr/logr"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/openova-io/openova/core/controllers/pkg/natsbus"
+	sandboxapi "github.com/openova-io/openova/core/controllers/sandbox/internal/sandboxapi"
+)
+
+// Annotation keys stamped on the matching Sandbox CR when a canonical
+// NATS envelope is observed. Identical to the organization-controller
+// keys for operator-visible symmetry across the two Group-C
+// controllers — `kubectl get sandboxes,organizations -o jsonpath`
+// surfaces the same field across both kinds.
+const (
+	AnnotationLastNATSObservedAt = "openova.io/last-event-observed-at"
+	AnnotationLastNATSSubject    = "openova.io/last-event-subject"
+)
+
+// DefaultSandboxNamespace is the namespace tenant-service writes
+// Sandbox CRs into when SANDBOX_NAMESPACE is unset. Mirrors the
+// publish-side default in core/services/tenant/handlers/sandbox_consumer.go.
+const DefaultSandboxNamespace = "catalyst-system"
+
+// NATSBridge is the consume-leg adapter for the sandbox-controller.
+type NATSBridge struct {
+	Client client.Client
+	Log    logr.Logger
+
+	// Namespace is the sandbox-namespace tenant-service writes Sandbox
+	// CRs into. Defaults to DefaultSandboxNamespace when empty.
+	Namespace string
+}
+
+// HandleSandboxRequested reacts to a `catalyst.tenant.sandbox_requested`
+// envelope. The publish-side (tenant.handlers.CreateOrg in PR #1633)
+// stamps owner_email + owner_id + org_slug + agents on the Data
+// payload. We derive the deterministic Sandbox CR name using the same
+// rules tenant-service applies (sanitised email leaf, "sandbox-"
+// prefix, RFC1123-bounded) and patch the observation annotations.
+func (b *NATSBridge) HandleSandboxRequested(ctx context.Context, ev *natsbus.Event) error {
+	if ev == nil {
+		return nil
+	}
+	var payload struct {
+		TenantID   string `json:"tenant_id"`
+		OrgSlug    string `json:"org_slug"`
+		OwnerID    string `json:"owner_id"`
+		OwnerEmail string `json:"owner_email"`
+	}
+	if err := json.Unmarshal(ev.Data, &payload); err != nil {
+		b.Log.Error(err, "sandbox_requested: malformed Data payload — ack to skip",
+			"event_id", ev.ID)
+		return nil
+	}
+
+	name := sandboxCRNameFromEvent(payload.OwnerEmail, payload.OwnerID)
+	if name == "" {
+		b.Log.Error(fmt.Errorf("empty derived name"),
+			"sandbox_requested: payload has neither owner_email nor owner_id — ack to skip",
+			"event_id", ev.ID, "tenant_id", payload.TenantID)
+		return nil
+	}
+
+	ns := b.Namespace
+	if ns == "" {
+		ns = DefaultSandboxNamespace
+	}
+
+	var sb sandboxapi.Sandbox
+	if err := b.Client.Get(ctx, types.NamespacedName{Namespace: ns, Name: name}, &sb); err != nil {
+		if apierrors.IsNotFound(err) {
+			// Cold-start ordering: the broker delivered our copy of
+			// the envelope before the tenant-service orchestrator
+			// finished writing the CR. Soft-miss; tenant-service's
+			// Sandbox CR Create will fire an informer event of its
+			// own when it lands, so we don't need to retry.
+			b.Log.Info("nats observation: no matching Sandbox CR — ack and skip",
+				"subject", natsbus.SubjectTenantSandboxRequested,
+				"namespace", ns, "name", name, "event_id", ev.ID)
+			return nil
+		}
+		return fmt.Errorf("get sandbox %s/%s: %w", ns, name, err)
+	}
+
+	observedAt := ev.Timestamp.UTC().Format(time.RFC3339Nano)
+	if observedAt == "" || ev.Timestamp.IsZero() {
+		observedAt = time.Now().UTC().Format(time.RFC3339Nano)
+	}
+
+	// Byte-stable patch on duplicate JetStream delivery: skip when
+	// the annotations already match.
+	cur := sb.GetAnnotations()
+	if cur != nil &&
+		cur[AnnotationLastNATSObservedAt] == observedAt &&
+		cur[AnnotationLastNATSSubject] == natsbus.SubjectTenantSandboxRequested {
+		b.Log.V(1).Info("nats observation: duplicate envelope — skip patch",
+			"subject", natsbus.SubjectTenantSandboxRequested,
+			"namespace", ns, "name", name, "event_id", ev.ID)
+		return nil
+	}
+
+	desired := &sandboxapi.Sandbox{}
+	sb.DeepCopyInto(desired)
+	anns := desired.GetAnnotations()
+	if anns == nil {
+		anns = map[string]string{}
+	}
+	anns[AnnotationLastNATSObservedAt] = observedAt
+	anns[AnnotationLastNATSSubject] = natsbus.SubjectTenantSandboxRequested
+	desired.SetAnnotations(anns)
+
+	if err := b.Client.Patch(ctx, desired, client.MergeFrom(&sb)); err != nil {
+		return fmt.Errorf("patch sandbox %s/%s: %w", ns, name, err)
+	}
+	b.Log.Info("nats observation stamped — reconcile enqueued",
+		"subject", natsbus.SubjectTenantSandboxRequested,
+		"namespace", ns, "name", name,
+		"event_id", ev.ID, "observed_at", observedAt)
+	return nil
+}
+
+// sandboxCRNameFromEvent mirrors core/services/tenant/handlers/sandbox_consumer.go
+// `sandboxCRName(email, ownerID)`. The two functions MUST stay in
+// sync — tenant-service writes the CR under this name, and
+// sandbox-controller's NATSBridge looks it up by the same name.
+//
+// Rules (verbatim from the publish-side):
+//
+//  1. Prefer the email; fall back to ownerID when email is empty.
+//  2. Sanitise to a DNS-1123 leaf via sanitizeSandboxLeaf.
+//  3. Empty post-sanitise → literal "user" so the consumer never
+//     returns an empty-name lookup.
+//  4. Final name = "sandbox-" + leaf, truncated to 63 chars and
+//     trailing-hyphen-stripped.
+func sandboxCRNameFromEvent(email, ownerID string) string {
+	candidate := strings.TrimSpace(email)
+	if candidate == "" {
+		candidate = strings.TrimSpace(ownerID)
+	}
+	leaf := sanitizeSandboxLeaf(candidate)
+	if leaf == "" {
+		leaf = "user"
+	}
+	name := "sandbox-" + leaf
+	if len(name) > 63 {
+		name = name[:63]
+	}
+	name = strings.TrimRight(name, "-")
+	return name
+}
+
+// sanitizeSandboxLeaf mirrors core/services/tenant/handlers/sandbox_consumer.go
+// `sanitizeSandboxLeaf`. Lowercases, replaces @ + . + + + _ with -,
+// strips everything outside [a-z0-9-], collapses double-hyphens, and
+// trims leading/trailing hyphens.
+func sanitizeSandboxLeaf(in string) string {
+	out := strings.ToLower(in)
+	out = strings.ReplaceAll(out, "@", "-at-")
+	out = strings.ReplaceAll(out, ".", "-")
+	out = strings.ReplaceAll(out, "+", "-plus-")
+	out = strings.ReplaceAll(out, "_", "-")
+	var b strings.Builder
+	b.Grow(len(out))
+	for _, r := range out {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9', r == '-':
+			b.WriteRune(r)
+		default:
+			b.WriteRune('-')
+		}
+	}
+	out = b.String()
+	for strings.Contains(out, "--") {
+		out = strings.ReplaceAll(out, "--", "-")
+	}
+	out = strings.Trim(out, "-")
+	return out
+}

--- a/core/controllers/sandbox/internal/controller/nats_bridge_test.go
+++ b/core/controllers/sandbox/internal/controller/nats_bridge_test.go
@@ -1,0 +1,193 @@
+// Unit tests for the sandbox-controller NATS consume-leg bridge (D35).
+//
+// Mirrors organization/internal/controller/nats_bridge_test.go for
+// `catalyst.tenant.sandbox_requested`. The bridge surface is the same
+// signature the live JetStream subscriber drives, so these tests
+// exercise the same code path the runtime uses.
+
+package controller
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr/testr"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/openova-io/openova/core/controllers/pkg/natsbus"
+	sandboxapi "github.com/openova-io/openova/core/controllers/sandbox/internal/sandboxapi"
+)
+
+func newSandboxBridgeFixture(t *testing.T, ns string, objs ...runtime.Object) *NATSBridge {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(scheme); err != nil {
+		t.Fatalf("clientgo addtoscheme: %v", err)
+	}
+	if err := sandboxapi.AddToScheme(scheme); err != nil {
+		t.Fatalf("sandboxapi addtoscheme: %v", err)
+	}
+	cb := fake.NewClientBuilder().WithScheme(scheme)
+	if len(objs) > 0 {
+		cb = cb.WithRuntimeObjects(objs...)
+	}
+	return &NATSBridge{
+		Client:    cb.Build(),
+		Log:       testr.New(t),
+		Namespace: ns,
+	}
+}
+
+// TestNATSBridge_SandboxRequested_HappyPath pins the D35 sandbox round-trip:
+// an envelope with owner_email matching a real Sandbox CR results in
+// both observation annotations being patched.
+func TestNATSBridge_SandboxRequested_HappyPath(t *testing.T) {
+	const ns = "catalyst-system"
+	// tenant-service derives sandbox name as "sandbox-" + sanitised
+	// email → ceo@acme.com → "sandbox-ceo-at-acme-com".
+	sb := &sandboxapi.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: ns,
+			Name:      "sandbox-ceo-at-acme-com",
+		},
+	}
+	bridge := newSandboxBridgeFixture(t, ns, sb)
+
+	ts := time.Date(2026, 5, 18, 15, 0, 0, 123456789, time.UTC)
+	body, _ := json.Marshal(map[string]any{
+		"tenant_id":   "tnt-9",
+		"org_slug":    "acme",
+		"owner_id":    "u-1",
+		"owner_email": "ceo@acme.com",
+	})
+	ev := &natsbus.Event{
+		ID:        "evt-sb-1",
+		Type:      "tenant.sandbox_requested",
+		Source:    "tenant-service",
+		Timestamp: ts,
+		TenantID:  "tnt-9",
+		Data:      body,
+	}
+	if err := bridge.HandleSandboxRequested(context.Background(), ev); err != nil {
+		t.Fatalf("HandleSandboxRequested: %v", err)
+	}
+
+	var got sandboxapi.Sandbox
+	if err := bridge.Client.Get(context.Background(),
+		types.NamespacedName{Namespace: ns, Name: "sandbox-ceo-at-acme-com"}, &got); err != nil {
+		t.Fatalf("get sandbox: %v", err)
+	}
+	anns := got.GetAnnotations()
+	if anns[AnnotationLastNATSSubject] != natsbus.SubjectTenantSandboxRequested {
+		t.Errorf("subject annotation: got %q want %q",
+			anns[AnnotationLastNATSSubject], natsbus.SubjectTenantSandboxRequested)
+	}
+	wantObservedAt := ts.Format(time.RFC3339Nano)
+	if anns[AnnotationLastNATSObservedAt] != wantObservedAt {
+		t.Errorf("observed-at annotation: got %q want %q",
+			anns[AnnotationLastNATSObservedAt], wantObservedAt)
+	}
+}
+
+// TestNATSBridge_SandboxRequested_OwnerIDFallback pins: when owner_email
+// is absent, the bridge falls back to owner_id for the CR name
+// derivation. Mirrors tenant-service's sandboxCRName fallback rule
+// (PR #1633) — both sides must stay in lockstep.
+func TestNATSBridge_SandboxRequested_OwnerIDFallback(t *testing.T) {
+	const ns = "catalyst-system"
+	sb := &sandboxapi.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: ns,
+			Name:      "sandbox-u-1",
+		},
+	}
+	bridge := newSandboxBridgeFixture(t, ns, sb)
+
+	body, _ := json.Marshal(map[string]any{
+		"tenant_id": "tnt-no-email",
+		"owner_id":  "u-1",
+	})
+	ev := &natsbus.Event{
+		ID:        "evt-sb-no-email",
+		Type:      "tenant.sandbox_requested",
+		Timestamp: time.Now().UTC(),
+		Data:      body,
+	}
+	if err := bridge.HandleSandboxRequested(context.Background(), ev); err != nil {
+		t.Fatalf("HandleSandboxRequested: %v", err)
+	}
+
+	var got sandboxapi.Sandbox
+	if err := bridge.Client.Get(context.Background(),
+		types.NamespacedName{Namespace: ns, Name: "sandbox-u-1"}, &got); err != nil {
+		t.Fatalf("get sandbox: %v", err)
+	}
+	if _, ok := got.GetAnnotations()[AnnotationLastNATSSubject]; !ok {
+		t.Error("owner_id fallback failed — CR not annotated")
+	}
+}
+
+// TestNATSBridge_SandboxRequested_NoMatchingCR pins: cold-start ordering
+// (broker delivered before tenant-service finished creating the CR)
+// is a soft miss — return nil so the dispatcher Acks, do not Nak.
+func TestNATSBridge_SandboxRequested_NoMatchingCR(t *testing.T) {
+	bridge := newSandboxBridgeFixture(t, "catalyst-system")
+	body, _ := json.Marshal(map[string]any{
+		"owner_email": "ghost@nowhere.io",
+	})
+	ev := &natsbus.Event{
+		ID:        "evt-miss-sb",
+		Type:      "tenant.sandbox_requested",
+		Timestamp: time.Now().UTC(),
+		Data:      body,
+	}
+	if err := bridge.HandleSandboxRequested(context.Background(), ev); err != nil {
+		t.Fatalf("HandleSandboxRequested on missing CR returned error (should soft-miss): %v", err)
+	}
+}
+
+// TestNATSBridge_SandboxRequested_MalformedData pins poison-pill
+// behaviour: malformed JSON returns nil so the dispatcher Acks-to-skip.
+func TestNATSBridge_SandboxRequested_MalformedData(t *testing.T) {
+	bridge := newSandboxBridgeFixture(t, "catalyst-system")
+	ev := &natsbus.Event{
+		ID:        "evt-bad-sb",
+		Type:      "tenant.sandbox_requested",
+		Timestamp: time.Now().UTC(),
+		Data:      []byte("not-json{"),
+	}
+	if err := bridge.HandleSandboxRequested(context.Background(), ev); err != nil {
+		t.Errorf("malformed Data should not Nak, got: %v", err)
+	}
+}
+
+// TestSandboxCRName_MatchesTenantServiceConvention pins the name
+// derivation rules verbatim against the publish-side convention. If
+// tenant-service changes its naming rule, this test goes red so the
+// bridge stays in lockstep.
+func TestSandboxCRName_MatchesTenantServiceConvention(t *testing.T) {
+	cases := []struct {
+		email, ownerID, want string
+	}{
+		{"ceo@acme.com", "u-1", "sandbox-ceo-at-acme-com"},
+		{"", "u-99", "sandbox-u-99"},
+		{"Mixed.Case+User@Globex.io", "", "sandbox-mixed-case-plus-user-at-globex-io"},
+		{"", "", "sandbox-user"},
+		{"a@b", "", "sandbox-a-at-b"},
+	}
+	for _, c := range cases {
+		t.Run(c.email+"|"+c.ownerID, func(t *testing.T) {
+			got := sandboxCRNameFromEvent(c.email, c.ownerID)
+			if got != c.want {
+				t.Errorf("sandboxCRNameFromEvent(%q,%q) = %q, want %q",
+					c.email, c.ownerID, got, c.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- **PR #1626 wired the publish-leg** (tenant + billing → NATS JetStream `catalyst.<domain>.<event>`). The **consume-leg** was missing: no in-cluster controller subscribed, so D35 (NATS round-trip end-to-end) stayed yellow even though the publish leg shipped.
- **Adds `core/controllers/pkg/natsbus`** — minimal JetStream subscriber shared by Group-C controllers. Self-contained (no dep on `core/services/shared` which pulls in franz-go/Kafka the controllers never touch). Mirrors `core/cmd/projector/internal/nats` style: durable consumer, Ack/Nak/Ack-to-skip semantics, byte-stable patches on duplicate JetStream delivery.
- **`organization-controller`** subscribes to `catalyst.tenant.created` + `catalyst.billing.order.placed`, patches `openova.io/last-event-observed-at` + `openova.io/last-event-subject` annotations on the matching Organization CR. The annotation patch triggers an informer event → controller-runtime enqueues Reconcile within ~50ms instead of waiting for the 30s RequeueAfter fallback.
- **`sandbox-controller`** subscribes to `catalyst.tenant.sandbox_requested` with the same pattern. Looks up the Sandbox CR using the same `sandbox-<sanitised-email>` naming convention that `tenant-service`'s SandboxOrchestrator (PR #1633) writes under — verbatim copy of `sandboxCRName` rules with a lockstep test.
- **Best-effort wiring**: `NATS_URL` unset → log "consume-leg disabled" + continue. The 30s `RequeueAfter` inside `r.Reconcile` is unchanged — NATS is an accelerator, not the only path. Catalyst-Zero / contabo path stays correct.

## Idempotency / no-churn guarantee

`ev.Timestamp` is the broker-side timestamp (fixed per-envelope). Duplicate JetStream delivery on broker rebalance produces a byte-stable annotation patch and controller-runtime does **not** enqueue a redundant Reconcile. Verified by `TestNATSBridge_DuplicateEnvelope_NoChurn` (asserts ResourceVersion is unchanged after second delivery).

## HARD CONSTRAINT respected

No credential mutations — bridges read only the envelope + the target CR, never Secrets or Keycloak SA creds. `NATS_URL` is read from env; no creds fabricated.

## Test plan

- [x] `go test ./pkg/natsbus/...` — 4 tests: handler-success Ack, handler-error Nak with backoff, malformed JSON ack-to-skip, sandbox_requested payload shape lockstep.
- [x] `go test ./organization/internal/controller/...` — 6 NATSBridge tests + existing 7 reconciler tests all green.
- [x] `go test ./sandbox/internal/controller/...` — 5 NATSBridge tests + 5 CR-name-derivation lockstep cases + existing sandbox-controller tests all green.
- [x] `go build ./...` clean across the entire `core/controllers` module.
- [x] `go vet ./...` clean.
- [ ] Live-broker integration covered by the D35 fresh-prov verifier (next prov).

## Files

- `core/controllers/pkg/natsbus/subscriber.go` + `subscriber_test.go`
- `core/controllers/organization/internal/controller/nats_bridge.go` + `nats_bridge_test.go`
- `core/controllers/organization/cmd/main.go` (wire-up)
- `core/controllers/sandbox/internal/controller/nats_bridge.go` + `nats_bridge_test.go`
- `core/controllers/sandbox/cmd/sandbox-controller/main.go` (wire-up)
- `core/controllers/go.mod` (`nats.go` promoted from indirect)

Refs #1835 (D35 round-trip end-to-end)
Refs #1776 (D35b sandbox audit trail consumer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)