### PR TITLE
deploy(bp-newapi): bump bootstrap-kit pin 1.4.20 -> 1.4.21 (catch-up after TBD-A23 / TBD-A20 race)

### DIFF
--- a/clusters/_template/bootstrap-kit/80-newapi.yaml
+++ b/clusters/_template/bootstrap-kit/80-newapi.yaml
@@ -143,7 +143,7 @@ spec:
       # connection pool's first wire write completed. Probe budget:
       # 30 × 10s = 5 min, comfortably above the observed 60-120s
       # ceiling on cpx21/cpx31 nodes with sslmode=require.
-      version: 1.4.20
+      version: 1.4.21
       sourceRef:
         kind: HelmRepository
         name: bp-newapi

--- a/platform/newapi/blueprint.yaml
+++ b/platform/newapi/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/category: ai-runtime
     catalyst.openova.io/section: pts-4-6-llm-serving
 spec:
-  version: 1.4.20
+  version: 1.4.21
   card:
     title: NewAPI
     summary: |


### PR DESCRIPTION
Closes #1864

## Summary

One-line manual catch-up of the bootstrap-kit pin so the chart 1.4.21 published at commit 8b33188 is actually consumed by fresh Sovereigns.

The TBD-A6 auto-bump-pin hook did NOT fire for the 1.4.20 -> 1.4.21 chart bump because the Blueprint Release workflow has been in **startup_failure** since PR #1858 (commit cf35b4a) merged at 21:04:22Z. The lockstep PR introduced a multi-line shell heredoc inside a run-block-scalar at workflow lines 812-814, with continuation lines unindented — YAML aborts parsing at line 815. Result: every push since cf35b4a produces a run with conclusion=failure, status=completed, jobs=[] (zero jobs spun up; this is the GH Actions startup_failure signature). The chart-publish commit 8b33188 was a follow-on bot commit AFTER the lockstep PR, so it itself didn't even create a workflow run.

## Files changed

- clusters/_template/bootstrap-kit/80-newapi.yaml — version: 1.4.20 -> 1.4.21
- platform/newapi/blueprint.yaml — spec.version: 1.4.20 -> 1.4.21 (same drift, lockstep convention per PR #1858 / TBD-A20)

## Evidence

- git show 8b33188 -> +version: 1.4.21 on platform/newapi/chart/Chart.yaml, no matching pin bump anywhere on main
- gh api repos/openova-io/openova/actions/runs/26060392136 -> display_title "fix(ci): blueprint.yaml spec.version lockstep ..." and run page says "This run likely failed because of a workflow file issue."
- python3 -c "yaml.safe_load(open('.github/workflows/blueprint-release.yaml'))" raises ScannerError ... could not find expected ':' line 815

## Follow-up

A companion PR will fix the workflow YAML so the next chart bump auto-bumps both the pin and the blueprint manifest again. Without that fix every future chart publish drifts the same way.