### PR TITLE
fix(ci): TBD-A6 auto-bump-pin must trigger after chart-publish commits even when TBD-A20 lockstep ran (Refs #1864)

### DIFF
--- a/.github/workflows/blueprint-release.yaml
+++ b/.github/workflows/blueprint-release.yaml
@@ -808,10 +808,20 @@ jobs:
           # secondary line so consumers parsing recent log subjects
           # don't see a format change. When ONLY blueprint.yaml bumps
           # (chart not in the kit), the subject acknowledges TBD-A20.
+          #
+          # IMPORTANT YAML/SHELL SEAM (TBD-A23 root cause, issue #1864):
+          # The bash multi-line string MUST NOT span literal newlines in
+          # this `run: |` block-scalar. The previous shape used a real
+          # newline inside `msg="..."` with the continuation line at
+          # column 1, which YAML interpreted as the END of the block
+          # scalar — every push since cf35b4a (PR #1858) failed with
+          # `startup_failure / jobs: []` until the workflow was reverted
+          # to a parseable shape. Use printf with `\n` escapes so the
+          # multi-line commit message body is built at shell time
+          # without disturbing the surrounding YAML indent.
           if [ "${PIN_BUMPED}" = "true" ] && [ "${BP_BUMPED}" = "true" ]; then
-            msg="deploy(${CHART_NAME}): bump bootstrap-kit pin ${PREV_VERSION} -> ${CHART_VERSION} (auto, Refs TBD-A6)
-
-Also locksteps platform blueprint.yaml spec.version ${BP_PREV_VERSION} -> ${CHART_VERSION} (Refs TBD-A20, #1856)."
+            msg=$(printf 'deploy(%s): bump bootstrap-kit pin %s -> %s (auto, Refs TBD-A6)\n\nAlso locksteps platform blueprint.yaml spec.version %s -> %s (Refs TBD-A20, #1856).' \
+              "${CHART_NAME}" "${PREV_VERSION}" "${CHART_VERSION}" "${BP_PREV_VERSION}" "${CHART_VERSION}")
           elif [ "${PIN_BUMPED}" = "true" ]; then
             msg="deploy(${CHART_NAME}): bump bootstrap-kit pin ${PREV_VERSION} -> ${CHART_VERSION} (auto, Refs TBD-A6)"
           else


### PR DESCRIPTION
Refs #1864 (closed structurally by this PR — PR #1865 was the manual catch-up for the bp-newapi 1.4.20 -> 1.4.21 drift).

## Summary

The Blueprint Release workflow has been in `startup_failure` since PR #1858 (commit `cf35b4a`) merged at 21:04:22Z. The lockstep step's multi-line shell heredoc inside a `run: |` block-scalar broke YAML parsing at lines 812-814:

```yaml
      run: |
        ...
        if [ ... ]; then
          msg="deploy(...) (auto, Refs TBD-A6)
                                                          <-- blank line, column 1
Also locksteps platform blueprint.yaml ..."               <-- text, column 1
```

YAML treats the column-1 blank line as the END of the indented block-scalar and the next column-1 text line as a new mapping key, which doesn't parse. Result: every push since `cf35b4a` has produced a workflow run with `conclusion=failure, status=completed, jobs=[]` (zero jobs spun up — GH Actions startup_failure signature).

Consequence: no chart bump since `cf35b4a` triggered the TBD-A6 auto-bump-pin or the TBD-A20 blueprint.yaml lockstep. PR #1865 was the manual catch-up for bp-newapi 1.4.20 -> 1.4.21; this PR fixes the structural cause so every future chart bump auto-converges again.

## Fix

Build the multi-line commit message with `printf '%s\n\n%s'` so the source string stays on physically-indented lines that YAML accepts. Behaviour is identical — same subject, same blank line, same body — only the construction shape changes. Added a 9-line comment naming the seam so future authors don't reintroduce the same trap.

## Verified locally

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/blueprint-release.yaml'))"` succeeds (24 build-job steps).
- The `printf` shape emits the canonical "deploy(bp-newapi): bump bootstrap-kit pin 1.4.20 -> 1.4.21 (auto, Refs TBD-A6)\n\nAlso locksteps platform blueprint.yaml spec.version 1.4.20 -> 1.4.21 (Refs TBD-A20, #1856)." body when invoked with the same env vars the workflow sets.

## Validation after merge

- Push of this PR itself will be the first run since `cf35b4a` to enter the `build` job — workflow detection should emit no matrix (no chart changed), but workflow startup must succeed (`status=completed, jobs > 0`).
- Next chart bump in `platform/<bp>/chart/Chart.yaml` should auto-bump both the pin and the blueprint.yaml in a single bot commit.

Refs #1864.
Refs PR #1858 (TBD-A20 lockstep that introduced the YAML defect).