### PR TITLE
deploy(bp-guacamole): catch-up pin + blueprint to chart 0.1.25 (post #1866 fix)

### DIFF
--- a/clusters/_template/bootstrap-kit/52-bp-guacamole.yaml
+++ b/clusters/_template/bootstrap-kit/52-bp-guacamole.yaml
@@ -128,7 +128,7 @@ spec:
       # made kubelet restart the Pod every ~60s and the kube-system
       # Cilium gateway returned 503 to the public hostname because
       # the Endpoint was never Ready (observed on t22, 5 restarts).
-      version: 0.1.24
+      version: 0.1.25
       sourceRef:
         kind: HelmRepository
         name: bp-guacamole

--- a/platform/guacamole/blueprint.yaml
+++ b/platform/guacamole/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-3-1-networking-and-service-mesh
     catalyst.openova.io/category: platform
 spec:
-  version: 0.1.24
+  version: 0.1.25
   card:
     title: Apache Guacamole
     summary: Clientless HTML5 remote-desktop gateway. Browser-based RDP / VNC / SSH and kubectl-exec into Pods, with Keycloak SSO and full session recording to SeaweedFS. One Guacamole per Sovereign per ADR-0001 §11.


### PR DESCRIPTION
Closes #1867

## Summary

One-line manual catch-up of the bootstrap-kit pin and Blueprint CR spec.version so the chart 0.1.25 published at commit de53b39 is actually consumed by fresh Sovereigns.

The TBD-A6 auto-bump-pin hook did NOT fire for the 0.1.24 -> 0.1.25 chart bump because the Blueprint Release workflow was in startup_failure from 21:04:22Z (PR #1858 merge) to 22:07:49Z (PR #1866 fix). de53b39 landed at 21:05:49Z, inside that ~1h window.

## Files changed

- clusters/_template/bootstrap-kit/52-bp-guacamole.yaml — version: 0.1.24 -> 0.1.25
- platform/guacamole/blueprint.yaml — spec.version: 0.1.24 -> 0.1.25 (TBD-A20 lockstep)

## Evidence

```
$ git show origin/main:platform/guacamole/chart/Chart.yaml | grep version
version: 0.1.25
$ git show origin/main:clusters/_template/bootstrap-kit/52-bp-guacamole.yaml | grep 'version:'
      version: 0.1.24
$ git show origin/main:platform/guacamole/blueprint.yaml | head -10 | grep version
  version: 0.1.24
```

## Verification post-merge

After this PR merges, fresh Sovereigns will pull bp-guacamole 0.1.25 (upstream Guacamole 1.5.5) instead of the stale 0.1.24.