### PR TITLE
deploy: catch-up pins for bp-catalyst-platform 1.4.181 + bp-guacamole 0.1.25 (post #1866 fix)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -603,7 +603,12 @@ spec:
       #   - A10b issue #1845: GET kubeconfig?region=<cloudRegion>
       #     resolves the slot-suffixed on-disk shape
       #     `<id>-<region>-<i>.yaml` (handler-side glob fallback).
-      version: 1.4.179
+      # 1.4.181 (catch-up for Blueprint Release workflow outage,
+      # 2026-05-18 21:04Z → 22:07Z): chart published 1.4.180 → 1.4.181
+      # during the YAML scanner break introduced by PR #1858 and fixed
+      # by PR #1866. Auto-bump-pin step didn't fire during the outage,
+      # so this pin lagged by 2 versions. Refs #1864.
+      version: 1.4.181
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/clusters/_template/bootstrap-kit/52-bp-guacamole.yaml
+++ b/clusters/_template/bootstrap-kit/52-bp-guacamole.yaml
@@ -128,7 +128,12 @@ spec:
       # made kubelet restart the Pod every ~60s and the kube-system
       # Cilium gateway returned 503 to the public hostname because
       # the Endpoint was never Ready (observed on t22, 5 restarts).
-      version: 0.1.24
+      # 0.1.25 (catch-up for Blueprint Release workflow outage,
+      # 2026-05-18 21:04Z → 22:07Z): chart published 0.1.24 → 0.1.25
+      # during the YAML scanner break introduced by PR #1858 and fixed
+      # by PR #1866. Auto-bump-pin step didn't fire during the outage.
+      # Refs #1864.
+      version: 0.1.25
       sourceRef:
         kind: HelmRepository
         name: bp-guacamole

--- a/platform/guacamole/blueprint.yaml
+++ b/platform/guacamole/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/section: pts-3-1-networking-and-service-mesh
     catalyst.openova.io/category: platform
 spec:
-  version: 0.1.24
+  version: 0.1.25
   card:
     title: Apache Guacamole
     summary: Clientless HTML5 remote-desktop gateway. Browser-based RDP / VNC / SSH and kubectl-exec into Pods, with Keycloak SSO and full session recording to SeaweedFS. One Guacamole per Sovereign per ADR-0001 §11.


### PR DESCRIPTION
Catch-up for drift introduced during the Blueprint Release workflow outage
21:04:22Z (PR #1858 merge with YAML scanner break) → 22:07:49Z (PR #1866 fix).

Charts published in that window:
- bp-catalyst-platform 1.4.180 → 1.4.181 (umbrella)
- bp-guacamole 0.1.24 → 0.1.25

Auto-bump-pin step didn't fire during the outage. A39 already caught up bp-newapi
(PR #1865). This PR catches up the remaining 2.

Refs #1864, PR #1866 (workflow fix), PR #1858 (root cause).