### PR TITLE
deploy(bp-catalyst-platform): catch-up pin to chart 1.4.181 (post #1866 fix)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -603,7 +603,7 @@ spec:
       #   - A10b issue #1845: GET kubeconfig?region=<cloudRegion>
       #     resolves the slot-suffixed on-disk shape
       #     `<id>-<region>-<i>.yaml` (handler-side glob fallback).
-      version: 1.4.179
+      version: 1.4.181
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform


### PR DESCRIPTION
Closes #1867

## Summary

One-line manual catch-up of the bootstrap-kit pin so chart 1.4.181 (latest of two bumps published during the broken workflow window) is actually consumed by fresh Sovereigns.

Two chart bumps landed inside the workflow startup_failure window (PR #1858 21:04:22Z -> PR #1866 22:07:49Z):

- a6b5752 (21:28:12Z) — 1.4.179 -> 1.4.180 (SME image b214566)
- 6b11734 (21:48:56Z) — 1.4.180 -> 1.4.181 (SME image 4a61543)

TBD-A6 auto-bump-pin did not fire for either, so origin/main still pins 1.4.179.

## Files changed

- clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml — version: 1.4.179 -> 1.4.181

bp-catalyst-platform is an umbrella chart with no Blueprint CR manifest, so only the bootstrap-kit pin needs touching.

## Evidence

```
$ git show origin/main:products/catalyst/chart/Chart.yaml | grep version
version: 1.4.181
$ git show origin/main:clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml | grep 'version:'
      version: 1.4.179
```

## Verification post-merge

After this PR merges, fresh Sovereigns will pull bp-catalyst-platform 1.4.181 (latest SME images) instead of the stale 1.4.179.