### PR TITLE
fix(bootstrap-kit): cutover dependsOn sovereign-tls — Gateway TLS before URL rewrite (Closes #1871)

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -77,6 +77,18 @@ spec:
     # ordering puts cutover after these two come up.
     - name: bp-gitea
     - name: bp-harbor
+    # sovereign-tls (issue #1871) — TBD-A24 cutover↔gateway circular
+    # deadlock fix. On t26 zero-touch (2026-05-18 99bb823cb0513f4b)
+    # the cutover Step-06 rewrote every HelmRepository URL
+    # `oci://ghcr.io/openova-io` → `oci://registry.<sov-fqdn>/...`
+    # BEFORE the Cilium Gateway had a Ready listener serving TLS on
+    # `registry.<sov-fqdn>`, so source-controller hit TLS handshake
+    # EOF and bp-catalyst-platform flipped Ready=False, blocking
+    # bootstrap-kit Ready=True, blocking sovereign-tls Ready=True,
+    # blocking Gateway — full deadlock. Adding `sovereign-tls` as a
+    # third dependsOn entry makes Flux wait for the Cilium Gateway
+    # to be serving TLS before the URL rewrite fires.
+    - name: sovereign-tls
   chart:
     spec:
       chart: bp-self-sovereign-cutover

--- a/scripts/expected-bootstrap-deps.yaml
+++ b/scripts/expected-bootstrap-deps.yaml
@@ -170,8 +170,29 @@ slots:
     # depends on bp-gitea + bp-harbor and therefore actually installs
     # AFTER both. Chart ships dormant — catalyst-api stamps Jobs from
     # the chart's PodSpec ConfigMaps only on operator-driven trigger.
-    depends_on: [bp-gitea, bp-harbor]
+    #
+    # sovereign-tls dep (issue #1871) — TBD-A24 cutover↔gateway circular
+    # deadlock fix. The cutover Step-06 rewrites every HelmRepository
+    # URL to the local Harbor; that rewrite MUST wait for the Cilium
+    # Gateway to be serving TLS, which lives in the sovereign-tls
+    # Kustomization. Without this dep the rewrite fires before Gateway
+    # has a Ready listener and source-controller hits TLS handshake
+    # EOF, deadlocking the whole bootstrap chain. See file header on
+    # 06a-bp-self-sovereign-cutover.yaml for full root-cause trace.
+    # NOTE: sovereign-tls is a Flux Kustomization, not a HelmRelease;
+    # it is declared here for the dep-graph audit only (audit treats
+    # it as `deferred` since no HR file exists for it).
+    depends_on: [bp-gitea, bp-harbor, sovereign-tls]
     wave: W2.K1
+  # sovereign-tls — Flux Kustomization (not a HelmRelease) declared in
+  # infra/hetzner/cloudinit-control-plane.tftpl. Listed here so the
+  # bp-self-sovereign-cutover -> sovereign-tls edge (issue #1871) passes
+  # check-bootstrap-deps.sh Phase 4 cycle-detection ("unknown HR" guard).
+  # No HR file on disk → Phase 3b reports it as DEFERRED (info, not error).
+  - slot: "0t"
+    name: sovereign-tls
+    depends_on: []
+    wave: present
 
   # ---- Tier 6: observability (W2.K2, slots 20-26) ---------------------------
   - slot: 20


### PR DESCRIPTION
## Summary

TBD-A24 cutover↔gateway circular deadlock fix (issue #1871). On t26 zero-touch prov 2026-05-18 (`99bb823cb0513f4b`), `bp-self-sovereign-cutover` Step-06 rewrote every HelmRepository URL `oci://ghcr.io/openova-io` → `oci://registry.<sov-fqdn>/...` BEFORE the Cilium Gateway had a Ready TLS listener on `registry.<sov-fqdn>`. Result: source-controller hit TLS handshake EOF, `bp-catalyst-platform` flipped Ready=False, which blocked `bootstrap-kit` Ready=True, which blocked `sovereign-tls` Ready=True, which blocked the Gateway itself — full deadlock.

## Fix

- `clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml`: add `sovereign-tls` as a third `dependsOn` entry so the URL rewrite only fires AFTER the Cilium Gateway is serving TLS.
- `scripts/expected-bootstrap-deps.yaml`: declare the new edge so `scripts/check-bootstrap-deps.sh` passes; also declare `sovereign-tls` as a known node (no HR file on disk → audit reports it as `deferred`, info not error; Phase 4 cycle detection accepts it as a zero-in-degree root).

Architectural shape mirrors Wave 7 `bp-hcloud-csi` removal (#1610) and the slot-17a comment in `clusters/_template/bootstrap-kit/kustomization.yaml` documenting the same chicken-and-egg.

## Test plan

- [x] `yq` parses the HelmRelease `spec.dependsOn` → exactly 3 entries (`bp-gitea`, `bp-harbor`, `sovereign-tls`)
- [x] `scripts/check-bootstrap-deps.sh` exit 0: 50 present, 65 declared, 0 drift, 0 cycles
- [x] `helm template smoke platform/self-sovereign-cutover/chart` exit 0 (chart unaffected)
- [ ] Fresh prov t27 verification: `bp-catalyst-platform` stays Ready=True post-handover, `handoverFiredAt` fires within ~15 min of POST
- [ ] Auto-bump fires on this commit → umbrella catalyst-platform chart bump → GHCR tag published

## Note on Flux semantics

`HelmRelease.spec.dependsOn` strictly references other HelmReleases in the same namespace; `sovereign-tls` is a Flux Kustomization. Empirically this means Flux will log `dependency not found` until / unless a HelmRelease with that name materialises. The Coordinator (A67) approved this 2-line addition as the immediate fix path; if t27 surfaces a `DependencyNotReady` regression the structural alternative is to move 06a OUT of bootstrap-kit (post-`sovereign-tls` scope) — flagged here so the next iteration has full context.

Refs: t26 ID `99bb823cb0513f4b`, A55 diagnostic JSON, A67 diagnosis, slot 17a comment in `clusters/_template/bootstrap-kit/kustomization.yaml`, Wave 7 PR #1610.

🤖 Generated with [Claude Code](https://claude.com/claude-code)