### PR TITLE
fix(notification): retry-backoff on Stalwart 503 5.5.1 rate-limit (Refs #1793)

### DIFF
--- a/core/services/notification/handlers/smtp.go
+++ b/core/services/notification/handlers/smtp.go
@@ -1,28 +1,110 @@
 package handlers
 
 import (
+	"errors"
 	"fmt"
+	"log/slog"
 	"net/smtp"
+	"net/textproto"
+	"os"
+	"strconv"
 	"strings"
+	"time"
 )
 
-// Mailer sends HTML emails via SMTP.
+// defaultRetryBackoff is the wait between retries when the SMTP server
+// responds with "503 5.5.1" — Stalwart's rate-limit trip. The window is
+// chosen to outlast Stalwart's default 30s rate-limit bucket; 60s gives
+// the bucket enough headroom that a retry lands on a fresh quota even
+// when wall-clock drift is involved (Refs #1793).
+const defaultRetryBackoff = 60 * time.Second
+
+// defaultMaxRetries caps total attempts at 3 (initial + 2 retries) so a
+// permanently mis-credentialed Stalwart cannot hold a worker hostage.
+const defaultMaxRetries = 3
+
+// sendMailFunc is the indirection that lets unit tests substitute the
+// real net/smtp.SendMail without touching production wiring.
+type sendMailFunc func(addr string, a smtp.Auth, from string, to []string, msg []byte) error
+
+// sleepFunc lets unit tests collapse the 60s backoff to zero wall time.
+type sleepFunc func(time.Duration)
+
+// Mailer sends HTML emails via SMTP with bounded retry on Stalwart
+// rate-limit (503 5.5.1) responses.
 type Mailer struct {
 	Host string
 	Port string
 	From string
+
+	// RetryBackoff is the wait between retries when Stalwart returns
+	// "503 5.5.1" (rate-limit). Configurable via the SMTP_RETRY_BACKOFF
+	// environment variable; see NewMailer for parse rules.
+	RetryBackoff time.Duration
+	// MaxRetries caps total attempts at MaxRetries (initial + retries).
+	MaxRetries int
+
+	// sendMail and sleep are unexported test seams. Production code
+	// always uses smtp.SendMail and time.Sleep.
+	sendMail sendMailFunc
+	sleep    sleepFunc
 }
 
-// NewMailer creates a Mailer configured for the given SMTP server.
+// NewMailer creates a Mailer configured for the given SMTP server. The
+// retry-backoff window can be overridden by the SMTP_RETRY_BACKOFF
+// environment variable. Accepted forms:
+//
+//   - Go duration string: "60s", "2m", "500ms"
+//   - Bare integer: treated as seconds (e.g., "30" -> 30s)
+//
+// Invalid values fall back to defaultRetryBackoff (60s). The minimum
+// is clamped to 30s — the task spec calls for >=30s so the rate-limiter
+// has time to drain.
 func NewMailer(host, port, from string) *Mailer {
 	return &Mailer{
-		Host: host,
-		Port: port,
-		From: from,
+		Host:         host,
+		Port:         port,
+		From:         from,
+		RetryBackoff: parseRetryBackoff(os.Getenv("SMTP_RETRY_BACKOFF")),
+		MaxRetries:   defaultMaxRetries,
+		sendMail:     smtp.SendMail,
+		sleep:        time.Sleep,
 	}
 }
 
-// Send delivers an HTML email to the given recipient.
+// parseRetryBackoff turns an env-var string into a duration with sane
+// defaults and a 30s floor.
+func parseRetryBackoff(raw string) time.Duration {
+	if raw == "" {
+		return defaultRetryBackoff
+	}
+	// Go duration string first ("60s", "2m"). A bare "0" parses as a
+	// valid duration of 0 — treat that (and any non-positive) as
+	// "value missing" so the default kicks in.
+	if d, err := time.ParseDuration(raw); err == nil {
+		if d <= 0 {
+			return defaultRetryBackoff
+		}
+		if d < 30*time.Second {
+			return 30 * time.Second
+		}
+		return d
+	}
+	// Fall back to bare-integer seconds ("30").
+	if n, err := strconv.Atoi(raw); err == nil && n > 0 {
+		d := time.Duration(n) * time.Second
+		if d < 30*time.Second {
+			return 30 * time.Second
+		}
+		return d
+	}
+	return defaultRetryBackoff
+}
+
+// Send delivers an HTML email to the given recipient. Stalwart
+// rate-limit responses (503 5.5.1) trigger a bounded retry loop with
+// RetryBackoff between attempts; all other errors return immediately
+// to the caller so the consumer can NACK / dead-letter as appropriate.
 func (m *Mailer) Send(to, subject, htmlBody string) error {
 	addr := m.Host + ":" + m.Port
 
@@ -36,5 +118,70 @@ func (m *Mailer) Send(to, subject, htmlBody string) error {
 
 	msg := []byte(strings.Join(headers, "\r\n") + "\r\n\r\n" + htmlBody)
 
-	return smtp.SendMail(addr, nil, m.From, []string{to}, msg)
+	sendMail := m.sendMail
+	if sendMail == nil {
+		sendMail = smtp.SendMail
+	}
+	sleep := m.sleep
+	if sleep == nil {
+		sleep = time.Sleep
+	}
+	maxRetries := m.MaxRetries
+	if maxRetries < 1 {
+		maxRetries = defaultMaxRetries
+	}
+	backoff := m.RetryBackoff
+	if backoff <= 0 {
+		backoff = defaultRetryBackoff
+	}
+
+	var lastErr error
+	for attempt := 1; attempt <= maxRetries; attempt++ {
+		err := sendMail(addr, nil, m.From, []string{to}, msg)
+		if err == nil {
+			return nil
+		}
+		lastErr = err
+		if !isRateLimit(err) {
+			// Non-rate-limit errors are not retried — return to
+			// caller immediately so the consumer can decide
+			// whether to NACK, dead-letter, or surface to the
+			// operator.
+			return err
+		}
+		if attempt == maxRetries {
+			break
+		}
+		slog.Warn(
+			"smtp rate-limit backoff",
+			"to", to,
+			"subject", subject,
+			"backoff", backoff.String(),
+			"retry", fmt.Sprintf("%d/%d", attempt, maxRetries),
+			"error", err.Error(),
+		)
+		sleep(backoff)
+	}
+	return fmt.Errorf("smtp send to %s: rate-limited after %d attempts: %w", to, maxRetries, lastErr)
+}
+
+// isRateLimit reports whether err is Stalwart's "503 5.5.1" rate-limit
+// response. net/smtp surfaces SMTP-level errors as *textproto.Error,
+// but legacy code paths (and some auth-failure branches in net/smtp
+// itself) wrap the wire response in a plain error.New, so we also fall
+// back to a substring match against the canonical 5.5.1 enhanced code.
+func isRateLimit(err error) bool {
+	if err == nil {
+		return false
+	}
+	var te *textproto.Error
+	if errors.As(err, &te) {
+		if te.Code == 503 && strings.Contains(te.Msg, "5.5.1") {
+			return true
+		}
+	}
+	msg := err.Error()
+	// Match both "503 5.5.1 ..." and "503-5.5.1 ..." (multiline reply
+	// continuation form per RFC 5321).
+	return strings.Contains(msg, "503 5.5.1") || strings.Contains(msg, "503-5.5.1")
 }

--- a/core/services/notification/handlers/smtp_test.go
+++ b/core/services/notification/handlers/smtp_test.go
@@ -1,0 +1,204 @@
+package handlers
+
+import (
+	"errors"
+	"net/smtp"
+	"net/textproto"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// fakeSendMail is a stub of net/smtp.SendMail. It returns errs[i] for
+// the i-th call (saturating to the last entry if calls > len(errs)),
+// and records every invocation under the mutex.
+type fakeSendMail struct {
+	mu    sync.Mutex
+	calls int
+	errs  []error
+}
+
+func (f *fakeSendMail) send(addr string, a smtp.Auth, from string, to []string, msg []byte) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	i := f.calls
+	f.calls++
+	if i >= len(f.errs) {
+		i = len(f.errs) - 1
+	}
+	return f.errs[i]
+}
+
+// recordingSleep captures every backoff request so tests can assert on
+// total wall-time without actually sleeping.
+type recordingSleep struct {
+	mu      sync.Mutex
+	waits   []time.Duration
+	wallSum time.Duration
+}
+
+func (r *recordingSleep) sleep(d time.Duration) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.waits = append(r.waits, d)
+	r.wallSum += d
+}
+
+// TestMailerSend_RateLimitRetrySucceeds asserts that when Stalwart
+// returns 503 5.5.1 on the first attempt and then 250 OK on the second,
+// Send retries with the configured backoff and returns nil. Verifies
+// the slog "rate-limit backoff" log line by way of the call count +
+// recorded backoff waits.
+func TestMailerSend_RateLimitRetrySucceeds(t *testing.T) {
+	rateLimitErr := &textproto.Error{Code: 503, Msg: "5.5.1 Too many messages"}
+	fs := &fakeSendMail{errs: []error{rateLimitErr, nil}}
+	rs := &recordingSleep{}
+
+	m := &Mailer{
+		Host:         "stalwart.test",
+		Port:         "25",
+		From:         "noreply@openova.io",
+		RetryBackoff: 60 * time.Second,
+		MaxRetries:   3,
+		sendMail:     fs.send,
+		sleep:        rs.sleep,
+	}
+
+	if err := m.Send("to@example.test", "Subject", "<p>body</p>"); err != nil {
+		t.Fatalf("Send returned error after successful retry: %v", err)
+	}
+	if fs.calls != 2 {
+		t.Errorf("sendMail called %d times, want 2 (one fail, one ok)", fs.calls)
+	}
+	if len(rs.waits) != 1 {
+		t.Fatalf("sleep called %d times, want exactly 1 backoff", len(rs.waits))
+	}
+	if rs.waits[0] != 60*time.Second {
+		t.Errorf("backoff = %v, want 60s", rs.waits[0])
+	}
+}
+
+// TestMailerSend_RateLimitExhaustsRetries asserts that after MaxRetries
+// 503 5.5.1 responses, Send returns a wrapped error and the total
+// number of backoff sleeps is MaxRetries-1 (no sleep after the final
+// failed attempt).
+func TestMailerSend_RateLimitExhaustsRetries(t *testing.T) {
+	rateLimitErr := &textproto.Error{Code: 503, Msg: "5.5.1 Rate limit exceeded"}
+	fs := &fakeSendMail{errs: []error{rateLimitErr, rateLimitErr, rateLimitErr}}
+	rs := &recordingSleep{}
+
+	m := &Mailer{
+		Host:         "stalwart.test",
+		Port:         "25",
+		From:         "noreply@openova.io",
+		RetryBackoff: 30 * time.Second,
+		MaxRetries:   3,
+		sendMail:     fs.send,
+		sleep:        rs.sleep,
+	}
+
+	err := m.Send("to@example.test", "Subject", "<p>body</p>")
+	if err == nil {
+		t.Fatal("Send returned nil after exhausted retries; want wrapped error")
+	}
+	if !strings.Contains(err.Error(), "rate-limited after 3 attempts") {
+		t.Errorf("error %q missing rate-limit summary", err.Error())
+	}
+	// Underlying *textproto.Error must remain reachable via errors.Is/As.
+	var te *textproto.Error
+	if !errors.As(err, &te) {
+		t.Error("returned error does not unwrap to *textproto.Error")
+	}
+	if fs.calls != 3 {
+		t.Errorf("sendMail called %d times, want 3 (= MaxRetries)", fs.calls)
+	}
+	if len(rs.waits) != 2 {
+		t.Errorf("sleep called %d times, want 2 (between attempts 1->2 and 2->3)", len(rs.waits))
+	}
+	if rs.wallSum != 60*time.Second {
+		t.Errorf("total backoff = %v, want 60s (2 * 30s)", rs.wallSum)
+	}
+}
+
+// TestMailerSend_NonRateLimitErrorReturnsImmediately asserts that
+// non-503-5.5.1 errors are NOT retried — they bubble up to the caller
+// so the events consumer can NACK or dead-letter as appropriate.
+func TestMailerSend_NonRateLimitErrorReturnsImmediately(t *testing.T) {
+	authErr := &textproto.Error{Code: 535, Msg: "5.7.8 Authentication credentials invalid"}
+	fs := &fakeSendMail{errs: []error{authErr, nil}}
+	rs := &recordingSleep{}
+
+	m := &Mailer{
+		Host:         "stalwart.test",
+		Port:         "25",
+		From:         "noreply@openova.io",
+		RetryBackoff: 60 * time.Second,
+		MaxRetries:   3,
+		sendMail:     fs.send,
+		sleep:        rs.sleep,
+	}
+
+	err := m.Send("to@example.test", "Subject", "<p>body</p>")
+	if err == nil {
+		t.Fatal("Send returned nil for non-rate-limit auth error; want pass-through")
+	}
+	if fs.calls != 1 {
+		t.Errorf("sendMail called %d times, want exactly 1 (no retry for non-rate-limit)", fs.calls)
+	}
+	if len(rs.waits) != 0 {
+		t.Errorf("sleep called %d times, want 0 (no backoff for non-rate-limit)", len(rs.waits))
+	}
+}
+
+// TestIsRateLimit_TextprotoError asserts detection of the canonical
+// SMTP rate-limit reply when returned as *textproto.Error.
+func TestIsRateLimit_TextprotoError(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"rate-limit", &textproto.Error{Code: 503, Msg: "5.5.1 Too many messages"}, true},
+		{"503-without-5.5.1", &textproto.Error{Code: 503, Msg: "5.5.0 Generic"}, false},
+		{"535-auth-failure", &textproto.Error{Code: 535, Msg: "5.7.8 Auth invalid"}, false},
+		{"plain-error-with-503-5.5.1-substring", errors.New("smtp: 503 5.5.1 rate limit"), true},
+		{"plain-error-with-multiline-form", errors.New("smtp: 503-5.5.1 continuation form"), true},
+		{"nil", nil, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := isRateLimit(tc.err)
+			if got != tc.want {
+				t.Errorf("isRateLimit(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestParseRetryBackoff covers env-var parsing including the 30s floor
+// and bare-integer-seconds form.
+func TestParseRetryBackoff(t *testing.T) {
+	cases := []struct {
+		raw  string
+		want time.Duration
+	}{
+		{"", 60 * time.Second},             // unset -> default
+		{"60s", 60 * time.Second},          // explicit Go duration
+		{"2m", 2 * time.Minute},            // larger duration
+		{"45", 45 * time.Second},           // bare integer = seconds
+		{"10s", 30 * time.Second},          // below floor -> floor
+		{"5", 30 * time.Second},            // bare-int below floor -> floor
+		{"garbage", 60 * time.Second},      // unparseable -> default
+		{"-1", 60 * time.Second},           // negative bare-int -> default
+		{"0", 60 * time.Second},            // zero bare-int -> default (n>0 guard)
+	}
+	for _, tc := range cases {
+		t.Run(tc.raw, func(t *testing.T) {
+			got := parseRetryBackoff(tc.raw)
+			if got != tc.want {
+				t.Errorf("parseRetryBackoff(%q) = %v, want %v", tc.raw, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- When Stalwart returns ``503 5.5.1`` (rate-limit trip), notification service previously kept hammering on the next event and prolonged the rate-limit window.
- ``Mailer.Send`` now detects 503 5.5.1 specifically and retries up to 3 times with a 60s backoff between attempts.
- Backoff configurable via ``SMTP_RETRY_BACKOFF`` (Go duration like ``60s``/``2m`` OR bare integer seconds; 30s floor).
- Non-rate-limit errors (auth failure, transient I/O) bubble up unchanged so the events consumer can NACK / dead-letter.

## Scope

This is a code-side hardening follow-up to A80's diagnosis on #1793. The chart-side SMTP creds path is already GREEN — this PR only addresses the retry-backoff hygiene.

**No credential touches.** No new passwords generated, no admin-API writes, no Secret-key rotation. Per memory ``feedback_never_touch_emrah_baysal_email.md``.

## Detection

- ``*textproto.Error`` unwrap matching ``Code == 503 && Msg contains "5.5.1"``.
- Substring fallback for ``503 5.5.1`` and the multiline ``503-5.5.1`` continuation form (RFC 5321).

## Test plan

- [x] ``go test ./handlers/...`` — all existing tests green, 4 new test funcs added (smtp_test.go)
- [x] ``TestMailerSend_RateLimitRetrySucceeds`` — 503-then-OK → 2 calls, 1 sleep of 60s
- [x] ``TestMailerSend_RateLimitExhaustsRetries`` — 3× 503 → wrapped error preserving ``*textproto.Error``, 2 sleeps totaling 60s
- [x] ``TestMailerSend_NonRateLimitErrorReturnsImmediately`` — 535 auth-fail → 1 call, 0 sleeps
- [x] ``TestIsRateLimit_TextprotoError`` — table covering positive + negative cases incl. multiline form
- [x] ``TestParseRetryBackoff`` — duration string, bare integer, floor enforcement, garbage fallback
- [x] ``go vet ./...`` clean
- [x] ``go build ./...`` clean

## Files

- ``core/services/notification/handlers/smtp.go`` — Mailer fields, retry loop, ``parseRetryBackoff``, ``isRateLimit``
- ``core/services/notification/handlers/smtp_test.go`` — new file, all retry-path coverage

Refs #1793

🤖 Generated with [Claude Code](https://claude.com/claude-code)