### PR TITLE
docs(principles): clarify #14 — HelmRelease.dependsOn cannot reference Kustomizations (empirical t27 finding)

### DIFF
--- a/docs/INVIOLABLE-PRINCIPLES.md
+++ b/docs/INVIOLABLE-PRINCIPLES.md
@@ -204,6 +204,17 @@ If a future ticket, agent, or operator session tries to ship a Sovereign without
 - The cutover chart must publish a rollback Job — flipping HelmRepository URLs is destructive in the same sense `tofu destroy` is; treat it accordingly.
 - Never sequence "flip URLs" before "prove Gateway TLS works" inside the same blueprint. If they share a slot, the slot is wrong.
 
+**Critical sub-rule (empirical 2026-05-19 on t27 — PR #1875 incident)**:
+`HelmRelease.spec.dependsOn` references ONLY other HelmReleases. It CANNOT
+reference Flux Kustomizations or other resource kinds. If you need to gate
+a HelmRelease on a Kustomization, ship a "wait-HelmRelease" (tiny chart
+with a Job that runs `kubectl wait …`) and depend on THAT HR. Or move the
+gated workload into a Kustomization with cross-kind `dependsOn`.
+
+Empirical verbatim from helm-controller when this rule was violated:
+`unable to get 'flux-system/<name>' dependency: helmreleases.helm.toolkit.fluxcd.io "<name>" not found`
+→ retries every 30s forever, never resolves.
+
 ---
 
 ## Self-check before every commit


### PR DESCRIPTION
## Summary

A84 empirical finding (t27 / PR #1875): `HelmRelease.spec.dependsOn` strictly references OTHER HelmReleases — it CANNOT reference Flux Kustomizations or other resource kinds. PR #1875 added the `sovereign-tls` Kustomization to a HelmRelease's `dependsOn`; helm-controller logged `helmreleases "sovereign-tls" not found` and retried every 30s forever.

Adds a critical sub-rule to principle #14 documenting:

- The cross-kind limitation (HR `dependsOn` is HR-only).
- Recommended workarounds: ship a tiny "wait-HelmRelease" shim that runs `kubectl wait …` and depend on THAT, OR move the gated workload into a Kustomization which does support cross-kind `dependsOn`.
- Verbatim helm-controller error message so the next regression is greppable.

Doc-only.

## Test plan

- [x] `git diff` shows only `docs/INVIOLABLE-PRINCIPLES.md` changed (+11/-0).
- [x] Post-merge: `git show origin/main:docs/INVIOLABLE-PRINCIPLES.md | grep -c "PR #1875 incident"` returns 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)