### PR TITLE
fix(cutover): Step-06 Job waits for Cilium Gateway TLS before HelmRepository URL rewrite (real fix for #1871, supersedes #1875)

### DIFF
--- a/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
+++ b/clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml
@@ -77,18 +77,23 @@ spec:
     # ordering puts cutover after these two come up.
     - name: bp-gitea
     - name: bp-harbor
-    # sovereign-tls (issue #1871) — TBD-A24 cutover↔gateway circular
-    # deadlock fix. On t26 zero-touch (2026-05-18 99bb823cb0513f4b)
-    # the cutover Step-06 rewrote every HelmRepository URL
-    # `oci://ghcr.io/openova-io` → `oci://registry.<sov-fqdn>/...`
-    # BEFORE the Cilium Gateway had a Ready listener serving TLS on
-    # `registry.<sov-fqdn>`, so source-controller hit TLS handshake
-    # EOF and bp-catalyst-platform flipped Ready=False, blocking
-    # bootstrap-kit Ready=True, blocking sovereign-tls Ready=True,
-    # blocking Gateway — full deadlock. Adding `sovereign-tls` as a
-    # third dependsOn entry makes Flux wait for the Cilium Gateway
-    # to be serving TLS before the URL rewrite fires.
-    - name: sovereign-tls
+    # NB on issue #1871 (TBD-A24 cutover↔gateway circular deadlock):
+    # PR #1875 initially added `- name: sovereign-tls` to this list.
+    # That fix was UNRESOLVABLE in Flux: HelmRelease.dependsOn can
+    # only reference other HelmReleases (helm.toolkit.fluxcd.io/v2),
+    # but `sovereign-tls` is a Flux Kustomization. helm-controller
+    # logged `helmreleases.helm.toolkit.fluxcd.io "sovereign-tls" not
+    # found` on t27 fresh-prov 2026-05-18, and bp-self-sovereign-
+    # cutover sat forever in dependency-wait — cutover never fired,
+    # handover never fired (A84 empirical test). The dependsOn entry
+    # was reverted in chart 0.1.32; the real fix moved INTO the
+    # chart's Step-06 helmrepository-patches Job, which now waits for
+    # `gateway.networking.k8s.io/cilium-gateway` in `kube-system` to
+    # report `Programmed=True` BEFORE rewriting any HelmRepository
+    # URL. That ordering breaks the deadlock without needing a cross-
+    # kind dependsOn. See platform/self-sovereign-cutover/chart/
+    # templates/06-helmrepository-patches-job.yaml (Phase -1 gateway-
+    # wait block) for the implementation.
   chart:
     spec:
       chart: bp-self-sovereign-cutover
@@ -301,7 +306,26 @@ spec:
       # this pin bump, step-08 catches openova-catalog as the lone
       # OFFENDER ~1m after step-06 (chart re-render reverts the
       # live HR patch). Caught live on t22.omantel.biz 2026-05-18.
-      version: 0.1.31
+      # 0.1.32 (issue #1871, 2026-05-19): Step-06 helmrepository-
+      # patches Job gains a NEW Phase -1 (gateway-wait) that runs
+      # BEFORE Phase-0's ghcr-pull merge and Phase-1's URL rewrite.
+      # The Job blocks until `gateway.networking.k8s.io/v1.Gateway
+      # cilium-gateway` in `kube-system` reports `Programmed=True`,
+      # which proves the Cilium Gateway has a listener serving TLS
+      # on `registry.<sov-fqdn>` (the listener bp-harbor's HTTPRoute
+      # attaches to). Closes the cutover↔gateway circular deadlock
+      # discovered on t26 99bb823cb0513f4b (A55 diagnostic) where
+      # the URL rewrite fired BEFORE the Gateway was Programmed
+      # and source-controller hit TLS handshake EOF against the
+      # not-yet-listening `registry.<sov-fqdn>`. Supersedes the bad
+      # PR #1875 fix (which added `sovereign-tls` to dependsOn —
+      # unresolvable cross-kind reference, see the dependsOn block
+      # comment above). RBAC: ClusterRole gains a Rule for
+      # gateway.networking.k8s.io.gateways {get,list,watch}.
+      # Configurable via `.Values.gateway.{namespace,name,
+      # waitTimeoutSeconds}`; default 30 min timeout safely covers
+      # the slowest Hetzner cold-start observed (≈18 min).
+      version: 0.1.32
       sourceRef:
         kind: HelmRepository
         name: bp-self-sovereign-cutover

--- a/platform/self-sovereign-cutover/chart/Chart.yaml
+++ b/platform/self-sovereign-cutover/chart/Chart.yaml
@@ -46,7 +46,36 @@ name: bp-self-sovereign-cutover
 # `openova-catalog` as the lone OFFENDER ~1 min after step-06
 # completes (chart re-render reverts phase-1). Caught live on
 # t22.omantel.biz 2026-05-18.
-version: 0.1.31
+#
+# 0.1.32 (issue #1871, 2026-05-19): Step-06 helmrepository-patches Job
+# gains a NEW Phase -1 (gateway-wait) that runs BEFORE Phase-0
+# (ghcr-pull auth merge) and Phase-1 (URL rewrite). The Job blocks
+# until `gateway.networking.k8s.io/v1.Gateway cilium-gateway` in
+# `kube-system` reports `Programmed=True`, which proves the Cilium
+# Gateway has a listener on *.<SOVEREIGN_FQDN>:443 serving TLS
+# against the wildcard cert — i.e. `registry.<SOVEREIGN_FQDN>` will
+# answer 200, not TLS-handshake EOF. Closes the cutover↔gateway
+# circular deadlock discovered on t26 zero-touch
+# (99bb823cb0513f4b, A55 diagnostic JSON):
+#   1) cutover Step-06 rewrote 50 HelmRepository URLs to
+#      oci://registry.t26.omani.works/openova-io
+#   2) source-controller pull → TLS handshake EOF
+#      (Gateway not yet Programmed)
+#   3) bp-catalyst-platform HR Ready=False
+#   4) bootstrap-kit Ks Reconciling
+#   5) sovereign-tls Ks DependencyNotReady on bootstrap-kit
+#   6) Gateway never installed → loop forever
+# Adding the Phase -1 wait inside the Job (rather than as a cross-
+# kind dependsOn) is the only viable seam: Flux HR dependsOn can only
+# reference HelmReleases, NOT Kustomizations, so the natural
+# `dependsOn: sovereign-tls` (PR #1875, superseded by this version)
+# never resolved — helm-controller logged "helmreleases.helm.toolkit.
+# fluxcd.io \"sovereign-tls\" not found" forever (t27 A84 empirical
+# test). RBAC: ClusterRole gains gateway.networking.k8s.io.gateways
+# {get,list,watch}. Configurable via `.Values.gateway.{namespace,
+# name,waitTimeoutSeconds}`; default 30 min timeout safely covers
+# the slowest Hetzner cold-start observed (≈18 min).
+version: 0.1.32
 description: |
   Catalyst Self-Sovereignty Cutover Blueprint. Installs DORMANT — this
   chart ships eight step ConfigMaps (PodSpec ConfigMaps, one per step),

--- a/platform/self-sovereign-cutover/chart/templates/06-helmrepository-patches-job.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/06-helmrepository-patches-job.yaml
@@ -99,6 +99,18 @@ data:
             value: {{ .Values.harbor.ghcrSecretRef.namespace | quote }}
           - name: GHCR_PULL_SECRET_KEY
             value: {{ .Values.harbor.ghcrSecretRef.dockerConfigKey | quote }}
+          # Phase -1 gateway-wait inputs (issue #1871, chart 0.1.32).
+          # The cutover URL rewrite (Phase 1 below) MUST NOT fire until
+          # the Cilium Gateway in kube-system is Programmed=True; that
+          # condition is the operator-facing proxy for "registry.<sov-
+          # fqdn> serves TLS, source-controller pulls won't EOF". See
+          # the Phase -1 block in args: below for the full wait loop.
+          - name: GATEWAY_NAMESPACE
+            value: {{ .Values.gateway.namespace | quote }}
+          - name: GATEWAY_NAME
+            value: {{ .Values.gateway.name | quote }}
+          - name: GATEWAY_WAIT_TIMEOUT_SECONDS
+            value: {{ .Values.gateway.waitTimeoutSeconds | quote }}
         volumeMounts:
           - name: helmrepository-list
             mountPath: /work
@@ -113,6 +125,76 @@ data:
             local_prefix="oci://${harbor_host}/openova-io"
 
             echo "[helmrepository-patches] upstream=${UPSTREAM_PREFIX} -> local=${local_prefix}"
+
+            # ---- Phase -1: wait for Cilium Gateway Programmed=True (issue #1871) ----
+            #
+            # The URL rewrite in Phase 1 below makes every HelmRepository
+            # OCI pull dependent on `registry.${SOVEREIGN_FQDN}` answering
+            # TLS. That hostname is served by bp-harbor's HTTPRoute
+            # attached to `gateway.networking.k8s.io/v1.Gateway
+            # cilium-gateway` in `kube-system` (installed by
+            # `clusters/_template/sovereign-tls/cilium-gateway.yaml`).
+            # If we rewrite URLs BEFORE the Gateway is Programmed=True
+            # (= listener bound, wildcard cert wired), source-controller
+            # hits TLS handshake EOF on every reconcile, bp-catalyst-
+            # platform flips Ready=False, bootstrap-kit Ks Reconciling,
+            # sovereign-tls Ks DependencyNotReady on bootstrap-kit,
+            # Gateway never installed → infinite deadlock.
+            #
+            # Discovered on t26 zero-touch 2026-05-18 (99bb823cb0513f4b,
+            # A55 diagnostic). The previous attempt (PR #1875) added
+            # `sovereign-tls` to the HR dependsOn but Flux HR.dependsOn
+            # cannot reference Kustomizations — helm-controller logged
+            # `helmreleases.helm.toolkit.fluxcd.io "sovereign-tls" not
+            # found` forever (A84 test on t27). This in-Job wait is the
+            # correct seam: cross-kind ordering enforced by polling, not
+            # by Flux's HR-only dependsOn graph.
+            #
+            # `kubectl wait` would suffice in principle but does not
+            # tolerate the resource being absent at start (only Not-Yet-
+            # Condition). The Gateway CR is itself installed by the
+            # sovereign-tls Kustomization that only fires AFTER
+            # bootstrap-kit reconciles Ready — and bootstrap-kit lists
+            # this chart, so the Gateway CR genuinely does NOT exist
+            # when catalyst-api stamps this Job in the trigger path. We
+            # therefore poll in a shell loop with a get-or-skip prelude
+            # before transitioning to `kubectl wait` once the resource
+            # is materialised.
+            echo "[helmrepository-patches] Phase -1: waiting for Gateway ${GATEWAY_NAMESPACE}/${GATEWAY_NAME} Programmed=True (timeout ${GATEWAY_WAIT_TIMEOUT_SECONDS}s)"
+            gw_deadline=$(( $(date +%s) + GATEWAY_WAIT_TIMEOUT_SECONDS ))
+            gw_ready="false"
+            while [ "$(date +%s)" -lt "${gw_deadline}" ]; do
+              # Check existence first — `kubectl wait` errors out on
+              # a missing resource rather than waiting for it.
+              if kubectl get gateway.gateway.networking.k8s.io "${GATEWAY_NAME}" \
+                   -n "${GATEWAY_NAMESPACE}" >/dev/null 2>&1; then
+                # Resource exists — read the Programmed condition status
+                # directly. Avoid `kubectl wait --for=condition=` because
+                # the gateway.networking.k8s.io API uses condition.type=
+                # `Programmed` (capital P, per Gateway API v1) and some
+                # kubectl builds compare case-insensitively, masking real
+                # status. jsonpath read is unambiguous.
+                programmed=$(kubectl get gateway.gateway.networking.k8s.io "${GATEWAY_NAME}" \
+                  -n "${GATEWAY_NAMESPACE}" \
+                  -o jsonpath='{.status.conditions[?(@.type=="Programmed")].status}' \
+                  2>/dev/null || echo "")
+                if [ "${programmed}" = "True" ]; then
+                  gw_ready="true"
+                  echo "[helmrepository-patches] Phase -1 OK: Gateway ${GATEWAY_NAMESPACE}/${GATEWAY_NAME} Programmed=True"
+                  break
+                fi
+                echo "[helmrepository-patches] Phase -1: Gateway exists but Programmed=${programmed:-<unset>}; retrying in 15s"
+              else
+                echo "[helmrepository-patches] Phase -1: Gateway ${GATEWAY_NAMESPACE}/${GATEWAY_NAME} not yet present; retrying in 15s"
+              fi
+              sleep 15
+            done
+            if [ "${gw_ready}" != "true" ]; then
+              echo "[helmrepository-patches] FATAL: Gateway ${GATEWAY_NAMESPACE}/${GATEWAY_NAME} did not reach Programmed=True within ${GATEWAY_WAIT_TIMEOUT_SECONDS}s — refusing to rewrite HelmRepository URLs into a Gateway that won't answer TLS" >&2
+              kubectl get gateway.gateway.networking.k8s.io -A 2>&1 >&2 || true
+              kubectl get kustomization -A 2>&1 >&2 || true
+              exit 1
+            fi
 
             # ---- Phase 0: merge harbor.<sov-fqdn> auth into ghcr-pull (#1184) ----
             #

--- a/platform/self-sovereign-cutover/chart/templates/rbac.yaml
+++ b/platform/self-sovereign-cutover/chart/templates/rbac.yaml
@@ -87,6 +87,9 @@ rules:
   - apiGroups: [""]
     resources: ["nodes"]   # registry-pivot DaemonSet reports node status into the status ConfigMap
     verbs: ["get", "list", "watch"]
+  - apiGroups: ["gateway.networking.k8s.io"]
+    resources: ["gateways"]   # step 06 Phase -1 (#1871, chart 0.1.32): wait for cilium-gateway Programmed=True before URL rewrite
+    verbs: ["get", "list", "watch"]
 
   # ───────────────────────────────────────────────────────────────
   # UPDATE / PATCH / DELETE — separate from create per RBAC rule.

--- a/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
+++ b/platform/self-sovereign-cutover/chart/tests/cutover-contract.sh
@@ -24,6 +24,10 @@
 #      WITHOUT resourceNames (feedback_rbac_create_no_resourcenames.md
 #      auto-memory anchor — combining create + resourceNames produces
 #      403 every POST).
+#   20. Step-06 Phase -1 (#1871, chart 0.1.32) MUST wait for the
+#       Cilium Gateway in kube-system to report Programmed=True before
+#       rewriting any HelmRepository URL. RBAC MUST grant get/list/watch
+#       on gateway.networking.k8s.io/gateways so the poll resolves.
 #
 # Usage: bash tests/cutover-contract.sh [CHART_DIR]
 
@@ -416,5 +420,51 @@ if ! grep -A15 'cutover-step-09-gitea-token-mint' "$TMP/render.yaml" | grep -q '
   exit 1
 fi
 echo "  PASS (Step-09 mints Gitea API token + patches provisioning-github-token)"
+
+echo "[cutover-contract] Case 20: Step-06 Phase -1 waits for Cilium Gateway Programmed=True (#1871)"
+# Chart <0.1.32 fired the Step-06 URL rewrite the instant catalyst-api
+# stamped the Job. If the Cilium Gateway in kube-system had not yet
+# reached Programmed=True (= listener bound + wildcard cert wired),
+# every subsequent source-controller pull from `registry.<sov-fqdn>`
+# hit TLS handshake EOF, bp-catalyst-platform flipped Ready=False,
+# bootstrap-kit + sovereign-tls Kustomizations deadlocked, and the
+# Gateway was never installed → infinite chicken-and-egg loop. Hit
+# live on t26 zero-touch 2026-05-18 (99bb823cb0513f4b, A55 diag).
+#
+# Chart 0.1.32 inserts a Phase -1 gateway-wait at the top of the
+# Step-06 Job's args script. The Job polls
+# `gateway.networking.k8s.io/v1.Gateway cilium-gateway` in
+# `kube-system` until status.conditions[Programmed]=True, with a
+# 30 min default deadline. If the Gateway never programs, the Job
+# exits 1 (surfacing the block to the operator) rather than rewriting
+# URLs into a Gateway that won't answer.
+#
+# The previous fix attempt (PR #1875) added `sovereign-tls` to
+# bp-self-sovereign-cutover.dependsOn but Flux HR.dependsOn can ONLY
+# reference HelmReleases; sovereign-tls is a Kustomization, so
+# helm-controller logged `helmreleases.helm.toolkit.fluxcd.io
+# "sovereign-tls" not found` forever (A84 test on t27). Guard against
+# any future revival of the cross-kind dependsOn shape.
+if ! grep -q 'Phase -1: waiting for Gateway' "$TMP/render.yaml"; then
+  echo "FAIL: Step-06 Phase -1 gateway-wait block missing (#1871)" >&2
+  exit 1
+fi
+if ! grep -q 'gateway.gateway.networking.k8s.io' "$TMP/render.yaml"; then
+  echo "FAIL: Step-06 Phase -1 missing Gateway CR get/poll (#1871)" >&2
+  exit 1
+fi
+if ! grep -q 'GATEWAY_NAMESPACE' "$TMP/render.yaml" \
+   || ! grep -q 'GATEWAY_WAIT_TIMEOUT_SECONDS' "$TMP/render.yaml"; then
+  echo "FAIL: Step-06 Phase -1 missing configurable namespace/name/timeout env (#1871)" >&2
+  exit 1
+fi
+# RBAC: ClusterRole must allow get/list/watch on
+# gateway.networking.k8s.io/gateways so the in-Job poll resolves.
+if ! grep -B0 -A2 'apiGroups: \["gateway.networking.k8s.io"\]' "$TMP/render.yaml" \
+     | grep -q 'resources: \["gateways"\]'; then
+  echo "FAIL: ClusterRole missing gateway.networking.k8s.io.gateways read verbs (#1871)" >&2
+  exit 1
+fi
+echo "  PASS (Step-06 Phase -1 gateway-wait + RBAC wired)"
 
 echo "[cutover-contract] All gates green."

--- a/platform/self-sovereign-cutover/chart/values.yaml
+++ b/platform/self-sovereign-cutover/chart/values.yaml
@@ -321,6 +321,42 @@ egressTest:
 status:
   configMapName: "self-sovereign-cutover-status"
 
+# Gateway readiness gate (issue #1871, chart 0.1.32).
+#
+# Step-06 (helmrepository-patches) rewrites every HelmRepository URL
+# `oci://ghcr.io/openova-io` → `oci://registry.<sov-fqdn>/openova-io`.
+# That rewrite MUST NOT fire until the Cilium Gateway in `kube-system`
+# is `Programmed=True` (= listener bound to `*.<sov-fqdn>:443` with a
+# valid TLS cert). Without the wait, source-controller's very next
+# pull hits TLS handshake EOF against `registry.<sov-fqdn>` and the
+# whole bootstrap-kit Kustomization deadlocks — see Chart.yaml 0.1.32
+# header for the full chicken-and-egg chain (t26 99bb823cb0513f4b
+# A55 diagnostic).
+#
+# The wait is implemented inside the Step-06 Job (Phase -1) rather
+# than as a Flux HelmRelease `dependsOn` because dependsOn can only
+# reference other HelmReleases — sovereign-tls is a Kustomization, so
+# the previous attempt (PR #1875) was an unresolvable cross-kind
+# reference and helm-controller logged
+# `helmreleases.helm.toolkit.fluxcd.io "sovereign-tls" not found`
+# forever (A84 empirical test on t27).
+gateway:
+  # The single per-Sovereign Gateway lives in `kube-system` — installed
+  # by `clusters/_template/sovereign-tls/cilium-gateway.yaml`. Every
+  # other bootstrap-kit HTTPRoute (gitea, auth, grafana, harbor, openbao,
+  # powerdns, console/catalyst-platform) attaches here; this is the same
+  # Gateway whose TLS listener Step-06 implicitly depends on.
+  namespace: "kube-system"
+  name: "cilium-gateway"
+  # 30 min covers the slowest observed cold-start (Hetzner ≈18 min:
+  # bootstrap-kit Ks reconcile → sovereign-tls Ks reconcile → cert-
+  # manager issues wildcard cert → cilium-agent wires listener) with
+  # comfortable headroom. Exceeding the timeout exits the Job with a
+  # clear failure (NOT exit-0-and-continue) — better to surface the
+  # Gateway block to operators than silently rewrite URLs that won't
+  # answer.
+  waitTimeoutSeconds: 1800
+
 # Per-step Job-stamp tuning. Each value lands inside the corresponding
 # PodSpec ConfigMap; catalyst-api copies it onto the stamped Job.
 stepTimeouts:


### PR DESCRIPTION
## Why — A84 empirical test on t27 shows PR #1875 was unresolvable

PR #1875 closed #1871 by adding ``- name: sovereign-tls`` to ``bp-self-sovereign-cutover.dependsOn``. That fix was UNRESOLVABLE in Flux:

```
helmreleases.helm.toolkit.fluxcd.io "sovereign-tls" not found
```

Flux ``HelmRelease.dependsOn`` can only reference other HelmReleases, but ``sovereign-tls`` is a Flux Kustomization. ``bp-self-sovereign-cutover`` sat forever in dependency-wait on t27 zero-touch → cutover never fired → handover never fired.

Issue #1871 reopened.

## What — Phase -1 gateway-wait inside Step-06

Chart ``platform/self-sovereign-cutover/chart/`` bumped **0.1.31 → 0.1.32**. Step-06 (``helmrepository-patches``) gains a NEW **Phase -1** at the top of its Job args (BEFORE Phase 0 ghcr-pull auth merge, BEFORE Phase 1 URL rewrite). The Job polls

```
gateway.networking.k8s.io/v1.Gateway cilium-gateway
  in kube-system
  status.conditions[type=Programmed].status == True
```

with a 30 min default deadline (configurable via ``.Values.gateway.{namespace,name,waitTimeoutSeconds}``). If the Gateway never programs, the Job exits 1 — surfacing the block to the operator rather than rewriting URLs into a Gateway that won't answer TLS.

This breaks the cutover↔gateway deadlock without needing a cross-kind dependsOn:

```
chart Step-06 Phase-1 URL rewrite
  └─ now waits for ─→ Gateway Programmed=True
                          └─ installed by ─→ sovereign-tls Kustomization
                                              └─ depends on ─→ bootstrap-kit Ks Ready
                                                                  └─ depends on ─→ bp-catalyst-platform HR Ready
                                                                                     └─ pulls from ─→ ghcr.io (PRE-rewrite, safe)
```

## Helm-template fragment showing the wait step

```yaml
# rendered cutover-step-06-helmrepository-patches ConfigMap.podSpec args:
            echo "[helmrepository-patches] Phase -1: waiting for Gateway ${GATEWAY_NAMESPACE}/${GATEWAY_NAME} Programmed=True (timeout ${GATEWAY_WAIT_TIMEOUT_SECONDS}s)"
            gw_deadline=$(( $(date +%s) + GATEWAY_WAIT_TIMEOUT_SECONDS ))
            gw_ready="false"
            while [ "$(date +%s)" -lt "${gw_deadline}" ]; do
              if kubectl get gateway.gateway.networking.k8s.io "${GATEWAY_NAME}" \
                   -n "${GATEWAY_NAMESPACE}" >/dev/null 2>&1; then
                programmed=$(kubectl get gateway.gateway.networking.k8s.io "${GATEWAY_NAME}" \
                  -n "${GATEWAY_NAMESPACE}" \
                  -o jsonpath='{.status.conditions[?(@.type=="Programmed")].status}' \
                  2>/dev/null || echo "")
                if [ "${programmed}" = "True" ]; then
                  gw_ready="true"
                  echo "[helmrepository-patches] Phase -1 OK: Gateway ${GATEWAY_NAMESPACE}/${GATEWAY_NAME} Programmed=True"
                  break
                fi
                ...
              fi
              sleep 15
            done
            if [ "${gw_ready}" != "true" ]; then
              echo "[helmrepository-patches] FATAL: Gateway ${GATEWAY_NAMESPACE}/${GATEWAY_NAME} did not reach Programmed=True within ${GATEWAY_WAIT_TIMEOUT_SECONDS}s — refusing to rewrite HelmRepository URLs into a Gateway that won't answer TLS" >&2
              exit 1
            fi
```

Env (default values rendered):

```yaml
- name: GATEWAY_NAMESPACE
  value: "kube-system"
- name: GATEWAY_NAME
  value: "cilium-gateway"
- name: GATEWAY_WAIT_TIMEOUT_SECONDS
  value: "1800"
```

## Bootstrap-kit slot changes

``clusters/_template/bootstrap-kit/06a-bp-self-sovereign-cutover.yaml``:
- reverts PR #1875 ``- name: sovereign-tls`` dependsOn entry (unresolvable cross-kind reference) with explanatory comment
- bumps chart pin ``0.1.31 → 0.1.32``

## RBAC

ClusterRole gains:
```yaml
- apiGroups: ["gateway.networking.k8s.io"]
  resources: ["gateways"]
  verbs: ["get", "list", "watch"]
```

## Tests

- ``platform/self-sovereign-cutover/chart/tests/cutover-contract.sh`` Case 20 (new): asserts the Phase -1 wait block + RBAC rule render. **All 20 contract gates green locally.**
- Existing Case 7 (RBAC split create verbs) still passes.

## Test plan

- [ ] Fresh prov as t28 reaches handoverFiredAt
- [ ] Step-06 Job logs ``Phase -1 OK: Gateway kube-system/cilium-gateway Programmed=True`` BEFORE Phase 0/1 output
- [ ] ``bp-catalyst-platform`` HR stays Ready=True post-handover (no TLS handshake EOF)
- [ ] All 50 HelmRepository URLs rewritten to ``oci://registry.t28.<domain>/openova-io``
- [ ] Step-08 egress-block-test PASS (no regressions caught)

Closes #1871
Refs #1875 (supersedes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)