### PR TITLE
fix(scripts): scrub stale sovereign-tls from expected-bootstrap-deps.yaml (post #1879 cleanup, fixes dep-graph-audit) (Refs #1871)

### DIFF
--- a/scripts/expected-bootstrap-deps.yaml
+++ b/scripts/expected-bootstrap-deps.yaml
@@ -171,28 +171,15 @@ slots:
     # AFTER both. Chart ships dormant — catalyst-api stamps Jobs from
     # the chart's PodSpec ConfigMaps only on operator-driven trigger.
     #
-    # sovereign-tls dep (issue #1871) — TBD-A24 cutover↔gateway circular
-    # deadlock fix. The cutover Step-06 rewrites every HelmRepository
-    # URL to the local Harbor; that rewrite MUST wait for the Cilium
-    # Gateway to be serving TLS, which lives in the sovereign-tls
-    # Kustomization. Without this dep the rewrite fires before Gateway
-    # has a Ready listener and source-controller hits TLS handshake
-    # EOF, deadlocking the whole bootstrap chain. See file header on
-    # 06a-bp-self-sovereign-cutover.yaml for full root-cause trace.
-    # NOTE: sovereign-tls is a Flux Kustomization, not a HelmRelease;
-    # it is declared here for the dep-graph audit only (audit treats
-    # it as `deferred` since no HR file exists for it).
-    depends_on: [bp-gitea, bp-harbor, sovereign-tls]
+    # NOTE: PR #1875 attempted to add `sovereign-tls` to this list
+    # but that was reverted by PR #1879 — `sovereign-tls` is a Flux
+    # Kustomization, not a HelmRelease, so HelmRelease.dependsOn
+    # cannot reference it (helm-controller logged "not found", chart
+    # parked Stalled, handover never fired). The cross-kind ordering
+    # is now enforced upstream by the cloud-init / Kustomization
+    # graph rather than by an entry in this list.
+    depends_on: [bp-gitea, bp-harbor]
     wave: W2.K1
-  # sovereign-tls — Flux Kustomization (not a HelmRelease) declared in
-  # infra/hetzner/cloudinit-control-plane.tftpl. Listed here so the
-  # bp-self-sovereign-cutover -> sovereign-tls edge (issue #1871) passes
-  # check-bootstrap-deps.sh Phase 4 cycle-detection ("unknown HR" guard).
-  # No HR file on disk → Phase 3b reports it as DEFERRED (info, not error).
-  - slot: "0t"
-    name: sovereign-tls
-    depends_on: []
-    wave: present
 
   # ---- Tier 6: observability (W2.K2, slots 20-26) ---------------------------
   - slot: 20


### PR DESCRIPTION
## Summary

PR #1875 added `sovereign-tls` to the `bp-self-sovereign-cutover` `dependsOn` in BOTH the chart and `scripts/expected-bootstrap-deps.yaml`. PR #1879 reverted the chart half (because `HelmRelease.dependsOn` cannot reference a Flux `Kustomization` — helm-controller logs `not found`, chart parks Stalled, handover never fires).

The `scripts/expected-bootstrap-deps.yaml` half was left behind, so the **dep-graph-audit** job on PR #1879 (and now on origin/main) fails with drift between the declared expectation (`bp-gitea bp-harbor sovereign-tls`) and the chart on disk (`bp-gitea bp-harbor`).

## Changes

- Remove `sovereign-tls` from the cutover's `depends_on` list (now `[bp-gitea, bp-harbor]`, matching the chart).
- Remove the stale `sovereign-tls` slot `0t` placeholder (no HR file exists for it).
- Replace the obsolete comment block with a short note explaining the PR #1875 / #1879 history so the next reader doesn't re-add it.

## Verification (local clone of origin/main)

- `bash scripts/check-bootstrap-deps.sh` -> `OK: bootstrap-kit dependency graph audit PASSED` with `Drift: 0`, `Cycles: 0`.
- `helm template platform/self-sovereign-cutover/chart` -> exit 0.

## Test plan

- [x] dep-graph-audit script passes locally
- [x] cutover chart helm-templates clean
- [ ] CI dep-graph-audit job green

Refs #1871