### PR TITLE
fix(httproute): omit default sectionName so multi-zone Sovereigns attach via Cilium Gateway hostname matcher (Closes #1884, TBD-A30)

### DIFF
--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -1257,8 +1257,30 @@ name: bp-catalyst-platform
 # 25/TCP (legacy SMTP fallback). All three are explicitly scoped to
 # `toEntities: world`, matching the existing 443/TCP allow. No other
 # rule semantics change. (Fixes PIN-issue 502 regression from #1785.)
-version: 1.4.182
-appVersion: 1.4.182
+version: 1.4.183
+appVersion: 1.4.183
+# 1.4.183 — fix(httproute): omit default sectionName so multi-zone
+# Sovereigns attach via Cilium Gateway hostname matcher (Closes #1884,
+# TBD-A30). Pre-1.4.183 every catalyst-system HTTPRoute pinned
+# `sectionName: https`, but the Cilium Gateway names HTTPS listeners
+# `https-<sanitised-zone>` whenever the Sovereign has multiple parent
+# zones (e.g. omani.works primary + omani.homes SME pool — t28 layout).
+# Result: every public route on t28 reported `Accepted=False
+# NoMatchingListener` and console.<sov> / api.<sov> / marketplace.<sov>
+# / *.<sov> returned 404 / connection-refused. Single-zone Sovereigns
+# were unaffected because Gateway used bare `https` listener name in
+# that case. Fix: default `ingress.gateway.parentRef.sectionName=""`
+# in values.yaml; the existing `{{- with .Values.ingress.gateway.
+# parentRef.sectionName }}` guard in templates/httproute.yaml,
+# templates/services/catalog/httproute.yaml, and templates/sme-services/
+# marketplace-routes.yaml skips the sectionName field entirely.
+# Cilium Gateway then matches routes to listeners by hostname filter
+# (`*.<zone>` on each per-zone listener), which is exactly the pattern
+# already used by tenant_route.go, sandbox manifests, and
+# tenant-public-routes.yaml. Preflight workflow that overrides
+# `--set ingress.gateway.parentRef.sectionName=http` is unaffected
+# (overrides still take precedence). See products/catalyst/chart/
+# values.yaml inline rationale for the full design note.
 # 1.4.172 — feat(security): baseline CiliumNetworkPolicies for
 # catalyst-system + cilium-gateway (Closes #1746, Refs TBD-Cov-12 /
 # C12-009). Cov-bench audit on the live Sovereign cluster confirmed

--- a/products/catalyst/chart/values.yaml
+++ b/products/catalyst/chart/values.yaml
@@ -734,7 +734,43 @@ ingress:
     parentRef:
       name: cilium-gateway
       namespace: kube-system
-      sectionName: https
+      # sectionName intentionally EMPTY (issue #1884, TBD-A30).
+      #
+      # The Cilium Gateway template
+      # (clusters/_template/sovereign-tls/cilium-gateway.yaml +
+      # infra/hetzner/main.tf locals.parent_domains_listeners_yaml)
+      # names HTTPS listeners as follows:
+      #   - SINGLE parent zone → bare `https` / `http`
+      #   - MULTIPLE parent zones (SME pool present) → unique
+      #     `https-<sanitised-zone>` / `http-<sanitised-zone>`
+      #     (e.g. `https-omani-works`, `https-omani-homes`)
+      # Pinning `sectionName: https` here broke every catalyst-system
+      # HTTPRoute on multi-zone Sovereigns because the listener name was
+      # `https-<sanitised-primary-zone>`, never bare `https` →
+      # `Accepted=False NoMatchingListener` → 404 / connection refused
+      # on console.<sov>, api.<sov>, marketplace.<sov>, *.<sov>
+      # (caught on t28 by A107 D29 walk, 2026-05-19).
+      #
+      # Leaving `sectionName` empty delegates listener attachment to the
+      # Cilium Gateway hostname matcher: each listener carries
+      # `hostname: *.<zone>` so a route hostname like `console.<sov-fqdn>`
+      # auto-attaches to exactly the listener(s) whose hostname filter
+      # matches. This is the canonical pattern already in use by
+      # core/controllers/sandbox/internal/gitops/manifests.go (sandbox),
+      # core/controllers/organization/internal/controller/tenant_route.go
+      # (per-tenant routes), and the chart's own
+      # templates/sme-services/tenant-public-routes.yaml — every other
+      # Cilium Gateway HTTPRoute on a Sovereign omits sectionName.
+      #
+      # Operators with an unusual topology (e.g. internal-only Gateway,
+      # preflight workflow with HTTP-only listener named `http`) may
+      # still override via per-Sovereign values:
+      #   --set ingress.gateway.parentRef.sectionName=http
+      # The httproute.yaml / services/catalog/httproute.yaml /
+      # sme-services/marketplace-routes.yaml templates all guard with
+      # `{{- with .Values.ingress.gateway.parentRef.sectionName }}`,
+      # so the field renders only when explicitly set.
+      sectionName: ""
   # Hosts populated by the bootstrap-kit slot
   # (clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml).
   # Empty here so `helm template` without a per-Sovereign overlay fails


### PR DESCRIPTION
Closes #1884.

## Summary
- All five catalyst-system HTTPRoutes (catalyst-ui, catalyst-api, catalyst-catalog, marketplace, tenant-wildcard) defaulted `parentRefs[].sectionName: https`, but the Cilium Gateway template renames listeners to `https-<sanitised-zone>` on every multi-zone Sovereign (e.g. `https-omani-works`, `https-omani-homes` on t28). Result: `Accepted=False NoMatchingListener` -> 404 / connection-refused for `console.<sov>`, `api.<sov>`, `marketplace.<sov>`, `*.<sov>`. (Caught on t28 by A107 D29 walk, 2026-05-19.)
- Fix is Option C (omit `sectionName`): set the default to `""` in `values.yaml`. The existing `{{- with .Values.ingress.gateway.parentRef.sectionName }}` guards in `templates/httproute.yaml`, `templates/services/catalog/httproute.yaml`, and `templates/sme-services/marketplace-routes.yaml` already skip the field when empty. Cilium then attaches each route to the listener(s) whose `hostname: *.<zone>` filter matches the route hostname.
- This is the canonical pattern already used by `core/controllers/sandbox/internal/gitops/manifests.go`, `core/controllers/organization/internal/controller/tenant_route.go`, and `templates/sme-services/tenant-public-routes.yaml`.
- Preflight CI override (`--set ingress.gateway.parentRef.sectionName=http`) still works because explicit `--set` overrides the empty default.

## Helm-template verification (multi-zone parity)
```
$ helm template test products/catalyst/chart \
    --set global.sovereignFQDN=t28.omani.works \
    --set ingress.hosts.console.host=console.t28.omani.works \
    --set ingress.hosts.api.host=api.t28.omani.works \
    --set ingress.hosts.admin.host=admin.t28.omani.works \
    --set ingress.hosts.marketplace.host=marketplace.t28.omani.works \
    --set ingress.marketplace.enabled=true \
    --show-only templates/httproute.yaml \
  | grep -A2 parentRefs

  parentRefs:
    - name: "cilium-gateway"
      namespace: "kube-system"
  hostnames:
```
No `sectionName` line. Same shape for catalyst-api, catalyst-catalog, marketplace, tenant-wildcard. `helm lint` clean.

## Override path preserved (preflight)
```
$ helm template ... --set ingress.gateway.parentRef.sectionName=http ...
  parentRefs:
    - name: "cilium-gateway"
      namespace: "kube-system"
      sectionName: "http"
```

Chart bumped 1.4.182 -> 1.4.183.

## Test plan
- [ ] Next fresh prov with `parent_domains_yaml` containing both primary + sme-pool zones (e.g. omani.works + omani.homes): `kubectl get httproute -n catalyst-system -o yaml` shows `Accepted=True` on every route, no `NoMatchingListener` condition.
- [ ] `curl -sk https://console.<sov-fqdn>/readyz` returns 200 (proves catalyst-ui route attached + `/readyz` rule reaches catalyst-api backend).
- [ ] Single-zone Sovereign still works: Gateway listener stays bare `https`, routes with empty `sectionName` still attach via hostname matcher.

Refs: A107 D29 report on t28 (76fdffb42532e6cc).

Generated with [Claude Code](https://claude.com/claude-code)