### PR TITLE
fix(sovereign-tls): cilium-gateway propagates Hetzner LB annotations (Closes #1885, TBD-A31)

### DIFF
--- a/clusters/_template/sovereign-tls/cilium-gateway.yaml
+++ b/clusters/_template/sovereign-tls/cilium-gateway.yaml
@@ -88,6 +88,61 @@ metadata:
     catalyst.openova.io/component: cilium-gateway
 spec:
   gatewayClassName: cilium
+  # ── TBD-A31 (#1885): Hetzner LB annotations for the gateway Service ──
+  #
+  # The Gateway-API spec (`spec.infrastructure.annotations`) is the canonical
+  # mechanism for declaring annotations that the controller MUST propagate
+  # to any infrastructure resources it creates in response to this Gateway —
+  # in Cilium's case, the auto-generated `cilium-gateway-cilium-gateway`
+  # Service in kube-system. Cilium 1.16+ honours this block and forwards
+  # the annotations onto the Service `metadata.annotations`, where
+  # hcloud-cloud-controller-manager (bp-hcloud-ccm slot 55) picks them up
+  # at Service reconcile time and provisions a Hetzner LB.
+  #
+  # Why this matters operationally:
+  #   - A98+A107 evidence on t28 (76fdffb42532e6cc): the gateway Service
+  #     showed `type=ClusterIP` with no Hetzner LB attached → public TLS
+  #     to console.t28.omani.works:443 reset at the handshake. Even with
+  #     the tofu-provisioned `hcloud_load_balancer.main` (infra/hetzner/
+  #     main.tf:955) carrying 443→30443 service-port, operators inspecting
+  #     `kubectl get svc -n kube-system cilium-gateway-cilium-gateway`
+  #     saw a non-LoadBalancer Service and concluded the LB chain was
+  #     broken. Without these annotations, hcloud-CCM has no signal to
+  #     materialise a parallel Service-level LB (the tofu LB at the
+  #     infra layer is invisible to the cluster-side CCM).
+  #   - For multi-region Sovereigns the per-region cilium-gateway in each
+  #     secondary cluster ALSO needs a public LB so external clients can
+  #     reach region-local listeners directly (the omani.homes / omani.rest
+  #     SME-pool subdomains attach to the secondary region's gateway).
+  #     `${SOVEREIGN_REGION_KEY:=primary}` segments the LB name per region
+  #     (mirrors the clustermesh-apiserver LB naming in
+  #     clusters/_template/bootstrap-kit/01-cilium.yaml:237).
+  #
+  # use-private-ip: "false" — per docs/SOVEREIGN-MULTI-REGION-DOD.md A2
+  # (inter-region link = PUBLIC IPs ALWAYS) AND the empirical lesson from
+  # PR #1538: the Hetzner per-region LB has no private-network attachment
+  # by default so CCM rejects `use private ip: missing network id`. The
+  # firewall already opens 30000-32767/tcp (infra/hetzner/main.tf:233) so
+  # the public-IP LB health checks pass against node:30443.
+  #
+  # health-check pinned to TCP:30443 — without this annotation, hcloud-CCM
+  # defaults the health check to the Service's nodePort (which Cilium
+  # allocates randomly when hostNetwork=true). Pinning to 30443 (the
+  # actual host-bound cilium-envoy HTTPS listener) ensures the CCM LB
+  # marks targets healthy AS SOON AS envoy is listening — without this,
+  # the LB stayed `unhealthy` indefinitely on prov #76 (2026-05-14).
+  infrastructure:
+    annotations:
+      load-balancer.hetzner.cloud/name: "${SOVEREIGN_FQDN_SLUG:=catalyst}-${SOVEREIGN_REGION_KEY:=primary}-gateway"
+      load-balancer.hetzner.cloud/location: "${HCLOUD_LB_LOCATION}"
+      load-balancer.hetzner.cloud/type: "lb11"
+      load-balancer.hetzner.cloud/use-private-ip: "false"
+      load-balancer.hetzner.cloud/disable-private-ingress: "true"
+      load-balancer.hetzner.cloud/health-check-protocol: "tcp"
+      load-balancer.hetzner.cloud/health-check-port: "30443"
+      load-balancer.hetzner.cloud/health-check-interval: "15s"
+      load-balancer.hetzner.cloud/health-check-timeout: "10s"
+      load-balancer.hetzner.cloud/health-check-retries: "3"
   # NOTE: ports 30080/30443 (not 80/443) — even with hostNetwork=true,
   # cilium-envoy refuses to bind privileged ports because cilium-agent
   # gates that bind through its `envoy-keep-cap-netbindservice` flag and

--- a/infra/hetzner/cloudinit-control-plane.tftpl
+++ b/infra/hetzner/cloudinit-control-plane.tftpl
@@ -1256,6 +1256,28 @@ write_files:
             # (no 5/168h limit); default → PROD. Locals in main.tf
             # render the final string so this template stays declarative.
             WILDCARD_CERT_ISSUER: "${wildcard_cert_issuer}"
+            # TBD-A31 (#1885) — Hetzner LB annotations on cilium-gateway
+            # Gateway resource (spec.infrastructure.annotations). These
+            # substitute vars name and locate the LB hcloud-CCM provisions
+            # for the auto-generated `cilium-gateway-cilium-gateway`
+            # Service in kube-system. Mirrors the same 3 vars threaded
+            # into the bootstrap-kit Kustomization for the clustermesh-
+            # apiserver LB (see 01-cilium.yaml apiserver.service.annotations).
+            #   - SOVEREIGN_FQDN_SLUG: short, DNS-safe Sovereign identifier
+            #     used as the LB name prefix so operators can spot the
+            #     gateway LB in the Hetzner Console.
+            #   - SOVEREIGN_REGION_KEY: per-region suffix so each
+            #     multi-region peer's cilium-gateway gets its own LB
+            #     (Hetzner LBs are unique by name — duplicates collapse to
+            #     the first-created instance, hiding the LB for every
+            #     subsequent region).
+            #   - HCLOUD_LB_LOCATION: Hetzner datacenter location for the
+            #     LB. Per-region rendered (primary CP renders var.region,
+            #     secondary CPs render each.value.cloudRegion) so the LB
+            #     and its backend node are co-located.
+            SOVEREIGN_FQDN_SLUG: "${sovereign_fqdn_slug}"
+            SOVEREIGN_REGION_KEY: ${sovereign_region_key}
+            HCLOUD_LB_LOCATION: "${region}"
       ---
       apiVersion: kustomize.toolkit.fluxcd.io/v1
       kind: Kustomization


### PR DESCRIPTION
## Summary
- Add `spec.infrastructure.annotations` to the cilium-gateway Gateway resource so Cilium 1.16+ propagates Hetzner LB annotations to the auto-generated `cilium-gateway-cilium-gateway` Service in kube-system.
- hcloud-CCM (slot 55) materialises a Hetzner LB for the Service, satisfying issue acceptance: `kubectl get svc -n kube-system cilium-gateway-cilium-gateway` will show `type=LoadBalancer` with external IP after handover.
- Thread `SOVEREIGN_FQDN_SLUG`, `SOVEREIGN_REGION_KEY`, `HCLOUD_LB_LOCATION` through the sovereign-tls Kustomization's postBuild.substitute (mirrors the same 3 vars threaded into bootstrap-kit for clustermesh-apiserver in 01-cilium.yaml).

## Root cause (A98 + A107 evidence on t28 76fdffb42532e6cc)
`console.t28.omani.works:443` accepts TCP but TLS resets. `kubectl get svc -n kube-system cilium-gateway-cilium-gateway` showed `type=ClusterIP` with no Hetzner LB attached. Even with the tofu-provisioned `hcloud_load_balancer.main` carrying 443→30443 at the infra layer, the cluster-side hcloud-CCM had no signal to materialise a parallel Service-level LB for the auto-generated gateway Service.

## Annotations applied (mirrors 01-cilium.yaml clustermesh apiserver block)
- `load-balancer.hetzner.cloud/name = ${SOVEREIGN_FQDN_SLUG:=catalyst}-${SOVEREIGN_REGION_KEY:=primary}-gateway`
- `load-balancer.hetzner.cloud/location = ${HCLOUD_LB_LOCATION}`
- `load-balancer.hetzner.cloud/type = lb11`
- `load-balancer.hetzner.cloud/use-private-ip = "false"` (DoD A2 — public IPs always)
- `load-balancer.hetzner.cloud/disable-private-ingress = "true"`
- `load-balancer.hetzner.cloud/health-check-protocol = tcp`
- `load-balancer.hetzner.cloud/health-check-port = "30443"`
- `load-balancer.hetzner.cloud/health-check-interval = 15s`
- `load-balancer.hetzner.cloud/health-check-timeout = 10s`
- `load-balancer.hetzner.cloud/health-check-retries = "3"`

## helm-template / kustomize-build verification
```
$ kubectl kustomize clusters/_template/sovereign-tls/ | grep -A 30 'kind: Gateway'
kind: Gateway
metadata:
  labels:
    catalyst.openova.io/component: cilium-gateway
    catalyst.openova.io/sovereign: ${SOVEREIGN_FQDN}
  name: cilium-gateway
  namespace: kube-system
spec:
  gatewayClassName: cilium
  infrastructure:
    annotations:
      load-balancer.hetzner.cloud/disable-private-ingress: "true"
      load-balancer.hetzner.cloud/health-check-interval: 15s
      load-balancer.hetzner.cloud/health-check-port: "30443"
      load-balancer.hetzner.cloud/health-check-protocol: tcp
      load-balancer.hetzner.cloud/health-check-retries: "3"
      load-balancer.hetzner.cloud/health-check-timeout: 10s
      load-balancer.hetzner.cloud/location: ${HCLOUD_LB_LOCATION}
      load-balancer.hetzner.cloud/name: ${SOVEREIGN_FQDN_SLUG:=catalyst}-${SOVEREIGN_REGION_KEY:=primary}-gateway
      load-balancer.hetzner.cloud/type: lb11
      load-balancer.hetzner.cloud/use-private-ip: "false"
  listeners: ${PARENT_DOMAINS_LISTENERS_YAML}
```

## Test plan
- [x] Static — `kubectl kustomize clusters/_template/sovereign-tls/` renders the Gateway with all 10 annotations and the listeners substitute scalar
- [x] Substitute vars threaded for both primary (region 1) and secondary (region 2/3) CPs (main.tf:644-657 + main.tf:1222-1232 confirm `region` + `sovereign_region_key` + `sovereign_fqdn_slug` are passed to both templatefile() calls)
- [ ] Runtime — next fresh prov: `kubectl get svc -n kube-system cilium-gateway-cilium-gateway -o yaml` shows `type=LoadBalancer` + populated `status.loadBalancer.ingress`
- [ ] Runtime — `curl -skI https://console.<fqdn>/` returns HTTP 200 after handover

Closes #1885

🤖 Generated with [Claude Code](https://claude.com/claude-code)