### PR TITLE
fix(sovereign-tls): wire Gateway listener at per-prov cert; stop parent-zone wildcard render (Closes #1883)

### DIFF
--- a/infra/hetzner/main.tf
+++ b/infra/hetzner/main.tf
@@ -377,6 +377,44 @@ locals {
   # quoting hell when the listener data contains characters cloud-init
   # YAML would otherwise mis-parse.
   parent_domains_single_zone = length(local.parent_domains_decoded) == 1
+
+  # Per-prov dashed FQDN, e.g. "t28.omani.works" → "t28-omani-works".
+  # This is the SAME suffix clusters/_template/sovereign-tls/cilium-gateway-
+  # cert.yaml uses for its per-prov Certificate (`sovereign-wildcard-tls-
+  # ${SOVEREIGN_FQDN_DASHED}`) and the same one cilium-envoy-tls-restart-
+  # job.yaml grants the cert-manager CSR-signing job RBAC for. Keeping a
+  # single named local here so every listener block stays in lockstep with
+  # the cert resource without re-deriving the dashed form inline.
+  sovereign_fqdn_dashed = replace(var.sovereign_fqdn, ".", "-")
+
+  # TBD-A29 (issue #1883) — wildcard cert LE rate-limit on parent zone.
+  # Each listener's certificateRefs now points at the PER-PROV cert
+  # (`sovereign-wildcard-tls-${SOVEREIGN_FQDN_DASHED}`) rendered by
+  # clusters/_template/sovereign-tls/cilium-gateway-cert.yaml, NOT the
+  # parent-zone wildcard `sovereign-wildcard-tls-<sanitised(parent)>`
+  # the chart's templates/sovereign-wildcard-certs.yaml used to mint.
+  #
+  # Why: Let's Encrypt's "5 New Certificates per Exact Set of Identifiers
+  # per 168h" caps the parent-zone identifier set `[*.omani.works,
+  # omani.works]` across EVERY prov on that parent. After ~5 wipe+reprov
+  # cycles on omani.works the Gateway listener pinned to a `Ready=False`
+  # Certificate (cert-manager spun the order forever, LE returned
+  # `urn:ietf:params:acme:error:rateLimited`). Per-prov identifier sets
+  # (`[console.t28.omani.works, auth.t28.omani.works, ...]`) get their
+  # OWN 5/168h bucket per Sovereign, so reprovs no longer share the LE
+  # ceiling with sibling Sovereigns under the same parent zone. This is
+  # the same per-name model the legacy cilium-gateway-cert.yaml already
+  # codified in 2026-05-15 — the listener was the last piece still
+  # tied to the parent-zone wildcard.
+  #
+  # Hostname semantics: the listener hostname stays `*.<parent>` so any
+  # FQDN under the parent matches the listener selector. cilium-envoy's
+  # SNI dispatch picks the per-prov cert whose SAN list includes the
+  # requested hostname (`console.<sovereign-fqdn>`, `auth.<sovereign-
+  # fqdn>`, etc., per the explicit SAN list in cilium-gateway-cert.yaml).
+  # Tenant URLs under non-primary parent zones (e.g. wp-foo.omani.homes)
+  # remain out of scope here — that path needs explicit per-tenant
+  # cert wiring under #831, not parent-zone wildcards.
   parent_domains_listeners_yaml = jsonencode(flatten([
     for entry in local.parent_domains_decoded : [
       {
@@ -389,7 +427,7 @@ locals {
           certificateRefs = [
             {
               kind = "Secret"
-              name = format("sovereign-wildcard-tls-%s", replace(entry.name, ".", "-"))
+              name = format("sovereign-wildcard-tls-%s", local.sovereign_fqdn_dashed)
             }
           ]
         }

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -1,5 +1,21 @@
 apiVersion: v2
 name: bp-catalyst-platform
+# 1.4.184 — TBD-A29 (issue #1883) wildcard cert LE rate-limit fix.
+# templates/sovereign-wildcard-certs.yaml now skip-renders unconditionally
+# (the parent-zone wildcards it minted — e.g. *.omani.works — share LE's
+# 5-certs/168h identifier bucket across every Sovereign on the same
+# parent zone, locking the listener at Ready=False after ~5 reprovs).
+# The Cilium Gateway listener now references the PER-PROV cert
+# sovereign-wildcard-tls-${SOVEREIGN_FQDN_DASHED} from clusters/
+# _template/sovereign-tls/cilium-gateway-cert.yaml (per-prov SAN list,
+# per-Sovereign LE bucket). Terraform local
+# parent_domains_listeners_yaml in infra/hetzner/main.tf updated in
+# lockstep — listener.certificateRefs.name now derives from sovereign
+# _fqdn_dashed, not the parent-zone-sanitised label. Verified via
+# helm template: zero sovereign-wildcard-cert Certificates emitted
+# under parentZones=[omani.works,omani.homes] + sovereignFQDN=
+# t28.omani.works (was 2 under origin/main).
+#
 # 1.4.163 — Wave 16 collector. Bumps chart version so the next Blueprint
 # Release republishes the OCI artifact with every chart-template change
 # that landed since the 1.4.162 publish (commit 0ad78790). The 1.4.162
@@ -1257,8 +1273,8 @@ name: bp-catalyst-platform
 # 25/TCP (legacy SMTP fallback). All three are explicitly scoped to
 # `toEntities: world`, matching the existing 443/TCP allow. No other
 # rule semantics change. (Fixes PIN-issue 502 regression from #1785.)
-version: 1.4.183
-appVersion: 1.4.183
+version: 1.4.184
+appVersion: 1.4.184
 # 1.4.183 — fix(httproute): omit default sectionName so multi-zone
 # Sovereigns attach via Cilium Gateway hostname matcher (Closes #1884,
 # TBD-A30). Pre-1.4.183 every catalyst-system HTTPRoute pinned

--- a/products/catalyst/chart/templates/sovereign-wildcard-certs.yaml
+++ b/products/catalyst/chart/templates/sovereign-wildcard-certs.yaml
@@ -50,6 +50,39 @@ Resource naming:
     clusters/_template/sovereign-tls/cilium-gateway.yaml's
     `certificateRefs[0].name: sovereign-wildcard-tls`.
 */}}
+{{- /*
+TBD-A29 (issue #1883) — wildcard cert LE rate-limit on parent zone.
+
+This template historically minted ONE cert-manager Certificate per
+.Values.parentZones entry, each requesting `*.<parent>` + `<parent>`
+(e.g. `*.omani.works` + `omani.works`). That hit Let's Encrypt's
+"5 New Certificates per Exact Set of Identifiers per 168h" cap across
+every Sovereign sharing the same parent zone: after ~5 wipe+reprov
+cycles on omani.works the Gateway listener pinned to a
+`Ready=False` Certificate (cert-manager spun the order forever, LE
+returned `urn:ietf:params:acme:error:rateLimited`).
+
+A29 ruling (2026-05-19 t28 evidence): the Cilium Gateway listener
+now references the PER-PROV cert
+`sovereign-wildcard-tls-${SOVEREIGN_FQDN_DASHED}` minted by
+clusters/_template/sovereign-tls/cilium-gateway-cert.yaml with an
+explicit SAN list under `*.<sovereign-fqdn>` (per-prov identifier
+set → per-Sovereign 5/168h bucket, never shared across reprovs). The
+parent-zone wildcard the chart minted here is unused by the listener
+AND burns LE budget on every install → skip-render unconditionally
+until #831 (multi-listener per-zone tenant TLS) re-introduces an
+explicit, per-tenant-aware cert path.
+
+Keeping the template body intact under `false` guard so the
+historical render shape is preserved for `git blame` / future
+revival; remove entirely once #831 lands and the parent-zone cert
+need is re-established with a non-wildcard SAN-list approach.
+
+Skip-render takes precedence over `.Values.wildcardCert.enabled` —
+operators that opt OUT (enabled=false) still get zero output, and
+operators that opt IN (enabled=true) now get zero output too.
+*/}}
+{{- if false }}
 {{- if .Values.wildcardCert.enabled }}
 {{- $ns := .Values.wildcardCert.namespace | default "kube-system" }}
 {{/*
@@ -144,3 +177,4 @@ spec:
   {{- end }}
 {{- end }}
 {{- end }}
+{{- end }}{{/* end A29 skip-render guard */}}


### PR DESCRIPTION
## Summary

- **TBD-A29 (issue #1883)** — Cilium Gateway listener `https-<parent-zone>` referenced parent-zone wildcard Secret `sovereign-wildcard-tls-<sanitised(parent)>` (e.g. `*.omani.works`), which shares LE's 5-certs/168h identifier bucket across every Sovereign on that parent. ~5 reprovs on `omani.works` pinned the listener at `Ready=False` (`urn:ietf:params:acme:error:rateLimited`).
- Listener now references the PER-PROV cert `sovereign-wildcard-tls-${SOVEREIGN_FQDN_DASHED}` minted by `clusters/_template/sovereign-tls/cilium-gateway-cert.yaml` (explicit SAN list `[console.<fqdn>, auth.<fqdn>, ..., sandbox.<fqdn>]`). Per-prov identifier sets get their own LE bucket per Sovereign.
- Chart template `products/catalyst/chart/templates/sovereign-wildcard-certs.yaml` skip-renders unconditionally (template body kept for blame / future revival under #831). Chart 1.4.182 -> 1.4.183.

## Helm-template verification

Before (origin/main):

```
$ helm template products/catalyst/chart \
    --set parentZones[0].name=omani.works --set parentZones[0].role=primary \
    --set global.sovereignFQDN=t28.omani.works \
  | grep -B 1 -A 12 'sovereign-wildcard-cert'

---
# Source: bp-catalyst-platform/templates/sovereign-wildcard-certs.yaml
apiVersion: cert-manager.io/v1
kind: Certificate
metadata:
  name: sovereign-wildcard-tls-omani-works            # PARENT zone -- rate-limited!
  namespace: kube-system
  ...
spec:
  secretName: sovereign-wildcard-tls-omani-works
  commonName: "*.omani.works"
  dnsNames:
    - "*.omani.works"
    - "omani.works"
```

After (this PR):

```
$ helm template products/catalyst/chart \
    --set parentZones[0].name=omani.works --set parentZones[0].role=primary \
    --set parentZones[1].name=omani.homes --set parentZones[1].role=sme-pool \
    --set global.sovereignFQDN=t28.omani.works \
    --set wildcardCert.enabled=true \
  | grep -c 'sovereign-wildcard-cert'

0    # zero parent-zone Certificates rendered
```

Terraform listener block now emits (post-substitute, single-zone parent=omani.works):

```yaml
- name: https-omani-works
  port: 30443
  protocol: HTTPS
  hostname: "*.omani.works"
  tls:
    mode: Terminate
    certificateRefs:
      - kind: Secret
        name: sovereign-wildcard-tls-t28-omani-works   # PER-PROV -- not rate-limited
```

## Test plan

- [ ] Fresh prov on `omani.works` (next available label) confirms `kubectl -n kube-system get certificate` shows ONLY per-prov `sovereign-wildcard-tls-<dashed-fqdn>` Ready=True (no parent-zone cert).
- [ ] `kubectl -n kube-system get gateway cilium-gateway -o yaml` shows listener `certificateRefs[].name` = per-prov cert name.
- [ ] `curl -v https://console.<fqdn>/` succeeds with TLS chain rooted at production LE (verified via SNI dispatch on cilium-envoy).
- [ ] After 5 consecutive reprovs on the same parent, the 6th still succeeds (per-prov bucket, not shared with siblings).

Generated with [Claude Code](https://claude.com/claude-code)