### PR TITLE
fix(catalyst-api): seed owner UserAccess at bake-time (TBD-A34, Closes #1891)

### DIFF
--- a/products/catalyst/bootstrap/api/cmd/api/main.go
+++ b/products/catalyst/bootstrap/api/cmd/api/main.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -273,6 +274,43 @@ func main() {
 		"url", env("CATALYST_CATALOG_URL", "http://catalyst-catalog.openova-system.svc.cluster.local:8080"),
 		"clusterFallback", homeDyn != nil,
 	)
+
+	// TBD-A34 (#1891) — bake-time owner UserAccess seed (D21).
+	//
+	// auth_handover.go's seedOwnerUserAccess() was the ONLY caller of
+	// EnsureOwnerUserAccess before this slice; D21 therefore only
+	// converged after a PIN-login + handover. Zero-touch verification
+	// probes (the convergence verifier) cannot drive a live PIN-login
+	// from CI, so D21 was reported RED on every fresh prov until the
+	// operator manually logged in — even though all the inputs
+	// (SOVEREIGN_FQDN + OPERATOR_EMAIL + the UserAccess CRD) were
+	// stable on the chroot from bake-time onward.
+	//
+	// This goroutine closes that gap. When the catalyst-api boots on a
+	// chroot Sovereign (SOVEREIGN_FQDN env set per the chart's
+	// sovereign-fqdn ConfigMap) AND the operator email is wired
+	// (OPERATOR_EMAIL env set per the same ConfigMap's orgEmail key,
+	// stamped by the orchestrator's overlay writer at handover-prepare),
+	// we call EnsureOwnerUserAccess against the in-cluster dynamic
+	// client with capped backoff so the UserAccess CRD has time to
+	// roll behind us.
+	//
+	// Idempotency: EnsureOwnerUserAccess folds AlreadyExists to nil,
+	// so this is safe to run before, after, or alongside the existing
+	// handover-fired path. A subsequent /auth/handover for the same
+	// operator is also a no-op (re-handover for the same email).
+	//
+	// Skip conditions (each becomes a single Info log + return):
+	//   - homeDyn nil (out-of-cluster — CI / smoke / local dev)
+	//   - SOVEREIGN_FQDN unset (mother mode — contabo Catalyst-Zero)
+	//   - OPERATOR_EMAIL unset (chroot but orgEmail not yet stamped;
+	//     bp-catalyst-platform's sovereign-fqdn ConfigMap renders the
+	//     key empty until the operator's email is wired — next Pod
+	//     restart picks it up once the overlay writer commits).
+	//
+	// Per docs/INVIOLABLE-PRINCIPLES.md #10 the email is logged at
+	// Info; nothing else (no JWTs, no secrets) is logged.
+	go runBakeTimeOwnerSeed(context.Background(), log, homeDyn)
 
 	// Issue #1753 (slice G3b) — bp-mimir (slot 23) query-frontend URL
 	// for the Pod metrics sparkline. Per docs/INVIOLABLE-PRINCIPLES.md
@@ -1491,6 +1529,82 @@ func runTierRoleBootstrap(ctx context.Context, log *slog.Logger, kc *keycloak.Cl
 	}
 	log.Error("kc-bootstrap: tier-role bootstrap gave up after all retries",
 		"realm", realm,
+		"err", lastErr,
+	)
+}
+
+// runBakeTimeOwnerSeed converges D21 (owner UserAccess CR) at bake-time
+// when the catalyst-api boots on a chroot Sovereign. See the call site
+// in main() above (TBD-A34 / issue #1891) for the full rationale.
+//
+// Skip conditions:
+//   - dyn is nil (out-of-cluster catalyst-api; CI / smoke / local dev).
+//   - SOVEREIGN_FQDN env is empty (mother mode; contabo Catalyst-Zero).
+//   - OPERATOR_EMAIL env is empty (chroot but orgEmail not yet stamped
+//     into the sovereign-fqdn ConfigMap; the next Pod restart picks
+//     it up once the orchestrator overlay writer commits).
+//
+// Backoff: same shape as runTierRoleBootstrap — 0s, 5s, 10s, 20s, 40s.
+// The UserAccess CRD comes from bp-crossplane-claims (claim XRD) which
+// Flux reconciles in parallel with bp-catalyst-platform; the apiserver
+// may return NotFound for several seconds on a freshly-rolled chroot.
+// The capped backoff keeps us quiet behind the CRD roll while still
+// converging in under ~75 s on the typical case.
+//
+// Idempotency: EnsureOwnerUserAccess folds AlreadyExists to nil, so
+// this is safe to run before, after, or alongside the existing
+// auth_handover.go-fired path.
+func runBakeTimeOwnerSeed(ctx context.Context, log *slog.Logger, dyn dynamic.Interface) {
+	if dyn == nil {
+		log.Info("user-access: bake-time owner seed skipped — out-of-cluster (no dynamic client)")
+		return
+	}
+	fqdn := strings.TrimSpace(os.Getenv("SOVEREIGN_FQDN"))
+	if fqdn == "" {
+		log.Info("user-access: bake-time owner seed skipped — SOVEREIGN_FQDN unset (mother mode)")
+		return
+	}
+	email := strings.TrimSpace(os.Getenv("OPERATOR_EMAIL"))
+	if email == "" {
+		log.Info("user-access: bake-time owner seed skipped — OPERATOR_EMAIL unset (orgEmail not yet stamped on chroot)",
+			"sovereignFQDN", fqdn,
+		)
+		return
+	}
+
+	delays := []time.Duration{0, 5 * time.Second, 10 * time.Second, 20 * time.Second, 40 * time.Second}
+	var lastErr error
+	for i, d := range delays {
+		if d > 0 {
+			select {
+			case <-ctx.Done():
+				log.Warn("user-access: bake-time owner seed cancelled during backoff",
+					"attempt", i+1,
+				)
+				return
+			case <-time.After(d):
+			}
+		}
+		err := handler.EnsureOwnerUserAccess(ctx, dyn, email, fqdn)
+		if err == nil {
+			// Per docs/INVIOLABLE-PRINCIPLES.md #10 the email is the
+			// only operator-derived value logged here.
+			log.Info("user-access: owner auto-seeded at bake-time (TBD-A34)",
+				"attempt", i+1,
+				"email", email,
+				"sovereignFQDN", fqdn,
+			)
+			return
+		}
+		lastErr = err
+		log.Warn("user-access: bake-time owner seed failed; will retry",
+			"attempt", i+1,
+			"err", err,
+		)
+	}
+	log.Error("user-access: bake-time owner seed gave up after all retries",
+		"email", email,
+		"sovereignFQDN", fqdn,
 		"err", lastErr,
 	)
 }

--- a/products/catalyst/bootstrap/api/cmd/api/main_test.go
+++ b/products/catalyst/bootstrap/api/cmd/api/main_test.go
@@ -1,0 +1,191 @@
+// main_test.go — coverage for the bake-time owner UserAccess seed
+// goroutine wired into main() (TBD-A34 / issue #1891). The goroutine
+// converges D21 (owner UserAccess CR) at catalyst-api boot WITHOUT
+// requiring an operator PIN-login + /auth/handover.
+//
+// The runBakeTimeOwnerSeed function is exercised directly here — the
+// goroutine wrapper in main() is just `go runBakeTimeOwnerSeed(...)`
+// so a synchronous unit test against the function covers the same
+// code path without the goroutine-scheduling surface.
+package main
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"log/slog"
+	"strings"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/handler"
+)
+
+// newBakeTimeSeedFakeClient — mirrors the fake-dynamic-client pattern
+// in handler/user_access_owner_seed_test.go::newOwnerSeedFakeClient
+// (UserAccess GVR + UserAccessList list-kind on a fresh Scheme). Lives
+// here so this _test.go file is self-contained and doesn't depend on
+// any unexported handler-package helpers.
+func newBakeTimeSeedFakeClient(seed ...runtime.Object) *dynamicfake.FakeDynamicClient {
+	scheme := runtime.NewScheme()
+	return dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, map[schema.GroupVersionResource]string{
+		handler.UserAccessGVR(): "UserAccessList",
+	}, seed...)
+}
+
+// captureLogger returns a slog.Logger that writes JSON lines into the
+// returned buffer. Tests assert on the buffer's content to confirm the
+// goroutine logged the expected skip / converged / error message.
+func captureLogger() (*slog.Logger, *bytes.Buffer) {
+	var buf bytes.Buffer
+	l := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	return l, &buf
+}
+
+// TestRunBakeTimeOwnerSeed_SeedsWhenChrootEnvsSet proves the canonical
+// happy path: chroot mode (SOVEREIGN_FQDN set) + OPERATOR_EMAIL set +
+// in-cluster dynamic client present → an owner UserAccess CR is
+// created in catalyst-system within the first attempt.
+func TestRunBakeTimeOwnerSeed_SeedsWhenChrootEnvsSet(t *testing.T) {
+	t.Setenv("SOVEREIGN_FQDN", "omantel.omani.works")
+	t.Setenv("OPERATOR_EMAIL", "emrah.baysal@openova.io")
+
+	client := newBakeTimeSeedFakeClient()
+	log, buf := captureLogger()
+
+	runBakeTimeOwnerSeed(context.Background(), log, client)
+
+	// Assert: a UserAccess CR exists in catalyst-system with the
+	// canonical owner-seed name. We re-use the same lookup path the
+	// handler tests do — the CR shape is covered exhaustively over
+	// there; this test only proves the boot wiring fires.
+	const wantName = "useraccess-owner-emrah-baysal-at-openova-io"
+	got, err := client.Resource(handler.UserAccessGVR()).
+		Namespace("catalyst-system").
+		Get(context.Background(), wantName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("expected owner UserAccess %q after bake-time seed; got err %v", wantName, err)
+	}
+	if got.GetName() != wantName {
+		t.Errorf("CR name: got %q want %q", got.GetName(), wantName)
+	}
+
+	// Log should carry the converged Info line so an operator can
+	// confirm bake-time seeding fired without scraping the CR.
+	if !strings.Contains(buf.String(), "owner auto-seeded at bake-time") {
+		t.Errorf("expected converged Info log; got %s", buf.String())
+	}
+}
+
+// TestRunBakeTimeOwnerSeed_SkipsOnNilDynamicClient proves the
+// out-of-cluster path (CI / smoke / local dev) is a clean no-op.
+func TestRunBakeTimeOwnerSeed_SkipsOnNilDynamicClient(t *testing.T) {
+	t.Setenv("SOVEREIGN_FQDN", "omantel.omani.works")
+	t.Setenv("OPERATOR_EMAIL", "emrah.baysal@openova.io")
+
+	log, buf := captureLogger()
+	runBakeTimeOwnerSeed(context.Background(), log, nil)
+
+	if !strings.Contains(buf.String(), "out-of-cluster") {
+		t.Errorf("expected out-of-cluster skip log; got %s", buf.String())
+	}
+}
+
+// TestRunBakeTimeOwnerSeed_SkipsOnMotherMode proves the contabo
+// (Catalyst-Zero) catalyst-api boot path — SOVEREIGN_FQDN unset —
+// surfaces a structured skip and does NOT attempt the seed.
+func TestRunBakeTimeOwnerSeed_SkipsOnMotherMode(t *testing.T) {
+	t.Setenv("SOVEREIGN_FQDN", "")
+	t.Setenv("OPERATOR_EMAIL", "emrah.baysal@openova.io")
+
+	client := newBakeTimeSeedFakeClient()
+	log, buf := captureLogger()
+	runBakeTimeOwnerSeed(context.Background(), log, client)
+
+	// No CR should have been created.
+	list, err := client.Resource(handler.UserAccessGVR()).
+		Namespace("").
+		List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(list.Items) != 0 {
+		t.Fatalf("expected 0 CRs in mother mode; got %d", len(list.Items))
+	}
+
+	if !strings.Contains(buf.String(), "SOVEREIGN_FQDN unset") {
+		t.Errorf("expected mother-mode skip log; got %s", buf.String())
+	}
+}
+
+// TestRunBakeTimeOwnerSeed_SkipsOnEmptyOperatorEmail proves the
+// chroot-but-orgEmail-not-yet-stamped path is a clean no-op (the
+// orchestrator overlay writer can stamp orgEmail later — the next
+// Pod restart picks it up).
+func TestRunBakeTimeOwnerSeed_SkipsOnEmptyOperatorEmail(t *testing.T) {
+	t.Setenv("SOVEREIGN_FQDN", "omantel.omani.works")
+	t.Setenv("OPERATOR_EMAIL", "")
+
+	client := newBakeTimeSeedFakeClient()
+	log, buf := captureLogger()
+	runBakeTimeOwnerSeed(context.Background(), log, client)
+
+	list, err := client.Resource(handler.UserAccessGVR()).
+		Namespace("").
+		List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(list.Items) != 0 {
+		t.Fatalf("expected 0 CRs when OPERATOR_EMAIL empty; got %d", len(list.Items))
+	}
+
+	if !strings.Contains(buf.String(), "OPERATOR_EMAIL unset") {
+		t.Errorf("expected OPERATOR_EMAIL-unset skip log; got %s", buf.String())
+	}
+}
+
+// TestRunBakeTimeOwnerSeed_IdempotentReRun proves a second invocation
+// (simulating Pod restart) returns cleanly without error or duplicate
+// CR. Covers the production case where catalyst-api rolls and the
+// goroutine fires a second time over an already-seeded chroot.
+func TestRunBakeTimeOwnerSeed_IdempotentReRun(t *testing.T) {
+	t.Setenv("SOVEREIGN_FQDN", "omantel.omani.works")
+	t.Setenv("OPERATOR_EMAIL", "emrah.baysal@openova.io")
+
+	client := newBakeTimeSeedFakeClient()
+	logA, _ := captureLogger()
+	runBakeTimeOwnerSeed(context.Background(), logA, client)
+
+	// Second run — must be a no-op (AlreadyExists folded to nil).
+	logB, bufB := captureLogger()
+	runBakeTimeOwnerSeed(context.Background(), logB, client)
+
+	list, err := client.Resource(handler.UserAccessGVR()).
+		Namespace("").
+		List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(list.Items) != 1 {
+		t.Fatalf("expected exactly 1 CR after idempotent re-run; got %d", len(list.Items))
+	}
+	// Second run still logs the Info converged line (because
+	// EnsureOwnerUserAccess folds AlreadyExists to nil and returns
+	// success — the second goroutine reports it auto-seeded too).
+	if !strings.Contains(bufB.String(), "owner auto-seeded at bake-time") {
+		t.Errorf("expected converged log on second run; got %s", bufB.String())
+	}
+}
+
+// silentLogger is a convenience for tests that don't care about log
+// output (e.g. the import-only ensure-the-helpers-compile sanity).
+//
+//lint:ignore U1000 helper kept for future tests that should suppress log noise
+func silentLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}


### PR DESCRIPTION
## Summary

D21 (owner UserAccess CR) was only seeded by `auth_handover.go::seedOwnerUserAccess` after a live PIN-login. Zero-touch convergence verifiers cannot drive a PIN-login from CI, so D21 stayed RED on every fresh prov until an operator manually authenticated, even though `SOVEREIGN_FQDN` + `OPERATOR_EMAIL` + the UserAccess CRD are stable from bake-time.

This PR adds a bake-time goroutine in `cmd/api/main.go` that calls the existing `handler.EnsureOwnerUserAccess` against the in-cluster dynamic client when:

- the dynamic client is non-nil (in-cluster mode),
- `SOVEREIGN_FQDN` env is set (chroot mode), and
- `OPERATOR_EMAIL` env is set (orgEmail stamped via the `sovereign-fqdn` ConfigMap).

Capped backoff (0/5/10/20/40s) tolerates the UserAccess CRD rolling behind us. Idempotent — `EnsureOwnerUserAccess` folds `AlreadyExists` to nil, so the existing handover-fired path still works without regression.

## Files touched

- `products/catalyst/bootstrap/api/cmd/api/main.go` — added call site + `runBakeTimeOwnerSeed` helper (no chart changes; existing `OPERATOR_EMAIL` + `SOVEREIGN_FQDN` envs are already wired by `api-deployment.yaml`).
- `products/catalyst/bootstrap/api/cmd/api/main_test.go` — new test file with 5 cases (happy path, 3 skip branches, idempotent re-run).

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./cmd/api/ -run TestRunBakeTimeOwnerSeed -v` — 5/5 PASS
- [x] `go test ./internal/handler/ -run TestEnsureOwnerUserAccess -v` — 6/6 PASS (no regression)
- [ ] On next fresh prov: `kubectl get useraccess -A` returns `useraccess-owner-<email>` within 60s of catalyst-api Ready, WITHOUT a PIN-login
- [ ] Existing handover-fired path still works (re-login same operator → no error, no duplicate CR)

Refs A116 diagnostic.

Closes #1891

🤖 Generated with [Claude Code](https://claude.com/claude-code)