### PR TITLE
fix(infra/hetzner): drop tuple-shape conditional in per_prov_listeners (TBD-A35, Closes #1886)

### DIFF
--- a/infra/hetzner/main.tf
+++ b/infra/hetzner/main.tf
@@ -465,7 +465,16 @@ locals {
     [for e in local.parent_domains_decoded : e.name],
     var.sovereign_fqdn
   )
-  per_prov_listeners = local.parent_domains_includes_sovereign_fqdn ? [] : [
+  # NOTE (TBD-A35 hotfix, Closes #1886): the conditional that suppresses
+  # this pair when sovereign_fqdn collides with a declared parent zone now
+  # lives on the consumer line in `parent_domains_listeners_yaml` below
+  # (concat() at line ~503). Keeping the conditional here as
+  # `... ? [] : [<HTTPS_obj>, <HTTP_obj>]` triggers tofu/terraform
+  # "Inconsistent conditional result types" — the true arm is an empty
+  # tuple `tuple([])` while the false arm is `tuple([obj_with_tls,
+  # obj_without_tls])` and HCL cannot unify the two. Always emit the pair
+  # at this local; suppress at the consumer.
+  per_prov_listeners = [
     {
       name     = format("https-%s", local.sovereign_fqdn_dashed)
       port     = 30443
@@ -535,7 +544,7 @@ locals {
         },
       ]
     ]),
-    local.per_prov_listeners
+    [for l in local.per_prov_listeners : l if !local.parent_domains_includes_sovereign_fqdn]
   ))
 
   # ── Effective singular-path SKU selection (Fix #157) ─────────────────────


### PR DESCRIPTION
## Summary

Hotfix for the tofu HCL type-mismatch introduced by PR #1892 that blocks every fresh prov at tofu plan (~23s).

- **Bug**: `infra/hetzner/main.tf` line 468 defined `per_prov_listeners` with a conditional whose arms had incompatible tuple types — `tuple([])` (length 0) vs `tuple([obj_with_tls, obj_without_tls])` (length 2). OpenTofu/Terraform cannot unify these → `Error: Inconsistent conditional result types`.
- **First seen**: A127 t29 attempt, deployment `4afd9ebceea92547`, 2026-05-19 01:08:41Z.
- **Fix**: emit `per_prov_listeners` unconditionally as the 2-element tuple. Suppress at the `concat()` consumer line with a `[for ... : l if !<collides>]` iteration filter — this ALWAYS produces a list (length 0 or 2 same element type), so HCL never needs to unify two tuple types.

## Validation (REAL tofu, not Python sim)

Installed OpenTofu v1.8.5 binary, ran against a minimal tfvars fixture in `infra/hetzner/`.

```
$ tofu validate
Success! The configuration is valid.
```

Semantic check via `tofu console`:
- `sovereign_fqdn="t29.omani.works"`, parent `omani.works` → 4 listeners: parent `https`/`http` for `*.omani.works` + per-prov `https-t29-omani-works`/`http-t29-omani-works` for `*.t29.omani.works`. Matches PR #1892's intent.
- `sovereign_fqdn="omani.works"` (collision) → 2 listeners only: parent `https`/`http` for `*.omani.works`. Collision guard preserved per #1892.

## Test plan

- [x] `tofu validate` returns Success
- [x] `tofu console local.parent_domains_listeners_yaml` evaluates without error in both non-collision and collision cases
- [ ] Next fresh prov (A128) passes tofu plan and progresses to apply
- [ ] Verify the same 4 listeners (3 parent + 1 per-prov pair) materialize on the Sovereign Gateway

## Notes

- Tofu-only change. No chart bump.
- Re-closes #1886 after #1892 re-opened it via the type-mismatch regression.

Closes #1886
Refs #1892