### PR TITLE
fix(sovereign-tls): cap Gateway annotations at 8 to satisfy gateway-api CRD (TBD-A36)

### DIFF
--- a/clusters/_template/sovereign-tls/cilium-gateway.yaml
+++ b/clusters/_template/sovereign-tls/cilium-gateway.yaml
@@ -158,6 +158,33 @@ spec:
   # actual host-bound cilium-envoy HTTPS listener) ensures the CCM LB
   # marks targets healthy AS SOON AS envoy is listening — without this,
   # the LB stayed `unhealthy` indefinitely on prov #76 (2026-05-14).
+  #
+  # TBD-A36 (#1896) — Gateway-API CRD annotations cap = 8 entries
+  # -------------------------------------------------------------
+  # `gateways.gateway.networking.k8s.io` (CRD published by the Cilium
+  # Gateway-API support) declares `spec.infrastructure.annotations` as a
+  # map with `maxProperties: 8`. The 10-annotation list that landed in
+  # #1889 (TBD-A31) tripped the CRD validator at Flux SSA time:
+  #   spec.infrastructure.annotations: Too many: 10: must have at most 8 items
+  # → Gateway never reconciled → cilium-gateway-cilium-gateway Service
+  # never reached `type=LoadBalancer` → no Hetzner LB at the Service
+  # layer → public TLS at console.<fqdn>:443 reset at the handshake.
+  # Blocked t28/t29/t30 since 2026-05-19 00:50:35Z.
+  #
+  # Resolution (Option A per A130): drop the two health-check timing
+  # annotations (`health-check-interval`, `health-check-timeout`). hcloud-
+  # CCM defaults are reasonable (15s interval, 10s timeout) and identical
+  # to the values we were declaring, so the runtime behaviour of the
+  # health check is unchanged. The remaining 8 annotations (name,
+  # location, type, use-private-ip, disable-private-ingress,
+  # health-check-protocol, health-check-port, health-check-retries) are
+  # the minimum set required to materialise a public-IP TCP-health-checked
+  # Hetzner LB on the correct location/type with the correct backend port.
+  #
+  # Validated with `kubectl apply --dry-run=server` against a live cluster
+  # before merge (Principle #15 — IaC evaluator over text grep). DO NOT
+  # add a 9th annotation here without first checking the CRD limit and
+  # re-running the server-side dry-run.
   infrastructure:
     annotations:
       load-balancer.hetzner.cloud/name: "${SOVEREIGN_FQDN_SLUG:=catalyst}-${SOVEREIGN_REGION_KEY:=primary}-gateway"
@@ -167,8 +194,6 @@ spec:
       load-balancer.hetzner.cloud/disable-private-ingress: "true"
       load-balancer.hetzner.cloud/health-check-protocol: "tcp"
       load-balancer.hetzner.cloud/health-check-port: "30443"
-      load-balancer.hetzner.cloud/health-check-interval: "15s"
-      load-balancer.hetzner.cloud/health-check-timeout: "10s"
       load-balancer.hetzner.cloud/health-check-retries: "3"
   # NOTE: ports 30080/30443 (not 80/443) — even with hostNetwork=true,
   # cilium-envoy refuses to bind privileged ports because cilium-agent


### PR DESCRIPTION
## Summary

PR #1889 (TBD-A31) added 10 Hetzner-LB annotations to `Gateway/cilium-gateway` `spec.infrastructure.annotations`. The `gateways.gateway.networking.k8s.io` CRD declares `maxProperties: 8` on that field, so Flux SSA rejected the rendered manifest:

```
spec.infrastructure.annotations: Too many: 10: must have at most 8 items
```

→ Gateway never reconciled → `cilium-gateway-cilium-gateway` Service stayed `ClusterIP` → no Hetzner LB at the Service layer → public TLS at `console.<fqdn>:443` reset at the handshake. Blocked t28/t29/t30 since 2026-05-19 00:50:35Z.

**Fix (Option A per A130 recommendation):** drop the two health-check timing annotations (`health-check-interval`, `health-check-timeout`). hcloud-CCM defaults are reasonable (15s interval, 10s timeout — identical to the values we were declaring), so runtime health-check behaviour is unchanged. The remaining 8 annotations are the minimum set required to materialise a public-IP TCP-health-checked Hetzner LB on the correct location/type with the correct backend port:

1. `load-balancer.hetzner.cloud/name`
2. `load-balancer.hetzner.cloud/location`
3. `load-balancer.hetzner.cloud/type`
4. `load-balancer.hetzner.cloud/use-private-ip`
5. `load-balancer.hetzner.cloud/disable-private-ingress`
6. `load-balancer.hetzner.cloud/health-check-protocol`
7. `load-balancer.hetzner.cloud/health-check-port`
8. `load-balancer.hetzner.cloud/health-check-retries`

## Validation — Principle #15 (server-side dry-run, not text grep)

Pre-fix (10 annotations, origin/main HEAD before this PR) — **REJECTED**:

```
$ kubectl --insecure-skip-tls-verify apply --dry-run=server -f /tmp/rendered-cilium-gateway-1896-pre-final.yaml
The Gateway "cilium-gateway" is invalid:
* spec.infrastructure.annotations: Too many: 10: must have at most 8 items
* <nil>: Invalid value: null: some validation rules were not checked because the object was invalid; correct the existing errors to complete validation
```

Post-fix (8 annotations, this PR) — **ACCEPTED**:

```
$ kubectl --insecure-skip-tls-verify apply --dry-run=server -f /tmp/rendered-cilium-gateway-1896-final.yaml
gateway.gateway.networking.k8s.io/cilium-gateway created (server dry run)
```

CRD constraint confirmed on the cluster:

```
$ kubectl --insecure-skip-tls-verify get crd gateways.gateway.networking.k8s.io -o yaml | grep -B2 -A2 maxProperties | head -8
                      Support: Extended
                    maxProperties: 8
                    type: object
                    x-kubernetes-validations:
```

Run against mothership cluster (`https://45.151.123.50:6443`, `vmi3116389  Ready  control-plane  v1.34.4+k3s1`), Gateway CRD installed `2026-03-01T12:55:01Z`.

## Test plan

- [x] Pre-fix manifest rejected by server-side dry-run with the exact CRD-cap error from the issue.
- [x] Post-fix manifest accepted by server-side dry-run.
- [x] CRD `maxProperties: 8` confirmed on live cluster.
- [ ] Next fresh prov (t31+) reconciles `cilium-gateway` → `cilium-gateway-cilium-gateway` Service flips to `LoadBalancer` → public TLS at `console.<fqdn>:443` succeeds.

## Notes

- No chart bump needed — `sovereign-tls` Kustomization picks up the new template on next reconcile.
- The comment block on the manifest is extended with the TBD-A36 incident summary and a hard reminder to not exceed 8 annotations without re-running the server-side dry-run.

Closes #1896
Refs #1897

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>