### PR TITLE
fix(provisioning-rbac): grant create organizations.orgs.openova.io (TBD-A38, Closes #1900)

### DIFF
--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -1,5 +1,11 @@
 apiVersion: v2
 name: bp-catalyst-platform
+# 1.4.185 — TBD-A38 (issue #1900) provisioning SA grant create
+# organizations.orgs.openova.io. The tenant.created Kafka consumer (Go
+# code shipped in PR #1860) creates one Organization CR per voucher
+# checkout (D29 step 5); without this RBAC entry it 403s in a 5s
+# NAK-retry loop forever and steps 6/7/8 of the customer journey are
+# blocked. Validated via `kubectl auth can-i` post-apply (see PR body).
 # 1.4.184 — TBD-A29 (issue #1883) wildcard cert LE rate-limit fix.
 # templates/sovereign-wildcard-certs.yaml now skip-renders unconditionally
 # (the parent-zone wildcards it minted — e.g. *.omani.works — share LE's
@@ -1273,7 +1279,7 @@ name: bp-catalyst-platform
 # 25/TCP (legacy SMTP fallback). All three are explicitly scoped to
 # `toEntities: world`, matching the existing 443/TCP allow. No other
 # rule semantics change. (Fixes PIN-issue 502 regression from #1785.)
-version: 1.4.184
+version: 1.4.185
 appVersion: 1.4.184
 # 1.4.183 — fix(httproute): omit default sectionName so multi-zone
 # Sovereigns attach via Cilium Gateway hostname matcher (Closes #1884,

--- a/products/catalyst/chart/templates/sme-services/provisioning.yaml
+++ b/products/catalyst/chart/templates/sme-services/provisioning.yaml
@@ -71,6 +71,14 @@ rules:
   - apiGroups: [""]
     resources: ["secrets"]
     verbs: ["get", "list", "watch"]
+  # Organizations (orgs.openova.io): the tenant.created Kafka consumer
+  # creates one Organization CR per voucher checkout (D29 step 5). Without
+  # this rule the consumer 403s in a 5s NAK-retry loop forever and the
+  # rest of the customer journey (steps 6/7/8) is blocked. Issue #1900,
+  # consumer code shipped in PR #1860.
+  - apiGroups: ["orgs.openova.io"]
+    resources: ["organizations"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
## Why
A143 D29 walk on t31 caught the `tenant.created` Kafka consumer 403ing in a 5s NAK-retry loop forever:

```
403 Forbidden: system:serviceaccount:sme:provisioning cannot create resource "organizations" in API group "orgs.openova.io"
```

A29 PR #1860 shipped the Go consumer code that creates one Organization CR per voucher checkout (D29 step 5) but did NOT bump the chart RBAC. Step 5 fails → steps 6/7/8 of the customer journey blocked. Same theater pattern flagged in the session memory: code shipped without corresponding RBAC.

## What
- `products/catalyst/chart/templates/sme-services/provisioning.yaml` — append rule for `orgs.openova.io/organizations` with `get/list/watch/create/update/patch/delete` to ClusterRole `sme-provisioning`.
- `products/catalyst/chart/Chart.yaml` — bump 1.4.184 → 1.4.185 with header memo.

## Validation per Principle #15 (real `kubectl auth can-i`, not jq grep)

Render → extract ClusterRole → apply to live t31 → re-run can-i:

```
$ helm template products/catalyst/chart -n sme --set ingress.marketplace.enabled=true \
    --show-only templates/sme-services/provisioning.yaml \
    | yq 'select(.kind=="ClusterRole" and .metadata.name=="sme-provisioning")' \
    | kubectl --kubeconfig=/tmp/t31-primary.kubeconfig apply -f -
clusterrole.rbac.authorization.k8s.io/sme-provisioning configured
```

**Pre-fix baseline:**
```
$ kubectl --kubeconfig=/tmp/t31-primary.kubeconfig auth can-i create organizations.orgs.openova.io \
    --as=system:serviceaccount:sme:provisioning
Warning: resource 'organizations' is not namespace scoped in group 'orgs.openova.io'
no
```
exit code: 1

**Post-fix:**
```
$ kubectl --kubeconfig=/tmp/t31-primary.kubeconfig auth can-i create organizations.orgs.openova.io \
    --as=system:serviceaccount:sme:provisioning
Warning: resource 'organizations' is not namespace scoped in group 'orgs.openova.io'
yes
```
exit code: 0

Same `yes` for get / list / watch / update / patch / delete — all seven verbs the rule grants.

## Closes
Closes #1900

🤖 Generated with [Claude Code](https://claude.com/claude-code)