### PR TITLE
fix: omit HTTPRoute sectionName across blueprint charts — match PR #1888 pattern (Closes #1902)

### DIFF
--- a/platform/gitea/blueprint.yaml
+++ b/platform/gitea/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
 spec:
-  version: 1.2.7
+  version: 1.2.8
   card:
     title: gitea
     summary: Gitea — per-Sovereign Git server. Catalyst control plane. Hosts catalog (public Blueprint mirror), catalog-sovereign (Sovereign-curated private Blueprints), one Gitea Org per Catalyst Organization, and system (sovereign-admin scope).

--- a/platform/gitea/chart/Chart.yaml
+++ b/platform/gitea/chart/Chart.yaml
@@ -4,7 +4,11 @@ name: bp-gitea
 # hook image switched from curlimages/curl:8.10.1 to
 # harbor.openova.io/proxy-dockerhub/curlimages/curl:8.10.1 per CLAUDE.md
 # inviolable rule.
-version: 1.2.7
+# 1.2.8 (Fix #1902, TBD-A40, 2026-05-19): omit HTTPRoute parentRef
+# sectionName by default — multi-zone Sovereigns rename HTTPS listeners
+# to https-<sanitised-zone>, breaking NoMatchingListener with the prior
+# pinned sectionName: https. Matches the catalyst-system fix in PR #1888.
+version: 1.2.8
 description: |
   Catalyst-curated Blueprint umbrella chart for Gitea. Depends on the
   upstream `gitea` chart (dl.gitea.com) as a Helm subchart so

--- a/platform/gitea/chart/values.yaml
+++ b/platform/gitea/chart/values.yaml
@@ -165,4 +165,8 @@ gateway:
   parentRef:
     name: cilium-gateway
     namespace: kube-system
-    sectionName: https
+    # sectionName intentionally empty — multi-zone Sovereigns rename HTTPS
+    # listeners to https-<sanitised-zone> (e.g. https-omani-works), so
+    # pinning sectionName: https breaks NoMatchingListener. Cilium Gateway
+    # matches by hostname filter. See PR #1888 / TBD-A40 / issue #1902.
+    sectionName: ""

--- a/platform/grafana/blueprint.yaml
+++ b/platform/grafana/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-3-observability
 spec:
-  version: 1.0.1
+  version: 1.0.2
   card:
     title: Grafana
     family: insights

--- a/platform/grafana/chart/Chart.yaml
+++ b/platform/grafana/chart/Chart.yaml
@@ -11,7 +11,11 @@ description: |
   (logs), bp-tempo (traces), bp-mimir (metrics), and bp-alloy or
   bp-opentelemetry (collection).
 type: application
-version: 1.0.1
+# 1.0.2 (Fix #1902, TBD-A40, 2026-05-19): omit HTTPRoute parentRef
+# sectionName by default — multi-zone Sovereigns rename HTTPS listeners
+# to https-<sanitised-zone>, breaking NoMatchingListener with the prior
+# pinned sectionName: https. Matches the catalyst-system fix in PR #1888.
+version: 1.0.2
 appVersion: "12.3.1"
 keywords: [catalyst, blueprint, grafana, observability, dashboards]
 maintainers:

--- a/platform/grafana/chart/values.yaml
+++ b/platform/grafana/chart/values.yaml
@@ -121,4 +121,8 @@ gateway:
   parentRef:
     name: cilium-gateway
     namespace: kube-system
-    sectionName: https
+    # sectionName intentionally empty — multi-zone Sovereigns rename HTTPS
+    # listeners to https-<sanitised-zone> (e.g. https-omani-works), so
+    # pinning sectionName: https breaks NoMatchingListener. Cilium Gateway
+    # matches by hostname filter. See PR #1888 / TBD-A40 / issue #1902.
+    sectionName: ""

--- a/platform/harbor/blueprint.yaml
+++ b/platform/harbor/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-3-5-storage-and-data
 spec:
-  version: 1.2.17
+  version: 1.2.18
   card:
     title: Harbor
     family: foundation

--- a/platform/harbor/chart/Chart.yaml
+++ b/platform/harbor/chart/Chart.yaml
@@ -42,7 +42,11 @@ type: application
 # hook image switched from curlimages/curl:8.10.1 to
 # harbor.openova.io/proxy-dockerhub/curlimages/curl:8.10.1 per CLAUDE.md
 # inviolable rule.
-version: 1.2.17
+# 1.2.18 (Fix #1902, TBD-A40, 2026-05-19): omit HTTPRoute parentRef
+# sectionName by default — multi-zone Sovereigns rename HTTPS listeners
+# to https-<sanitised-zone>, breaking NoMatchingListener with the prior
+# pinned sectionName: https. Matches the catalyst-system fix in PR #1888.
+version: 1.2.18
 appVersion: "2.14.3"
 keywords: [catalyst, blueprint, harbor, oci, registry, container]
 maintainers:

--- a/platform/harbor/chart/values.yaml
+++ b/platform/harbor/chart/values.yaml
@@ -434,7 +434,11 @@ gateway:
   parentRef:
     name: cilium-gateway
     namespace: kube-system
-    sectionName: https
+    # sectionName intentionally empty — multi-zone Sovereigns rename HTTPS
+    # listeners to https-<sanitised-zone> (e.g. https-omani-works), so
+    # pinning sectionName: https breaks NoMatchingListener. Cilium Gateway
+    # matches by hostname filter. See PR #1888 / TBD-A40 / issue #1902.
+    sectionName: ""
 
 # ─── Vendor-agnostic Object Storage backend config (issue #383 / #425) ───
 #

--- a/platform/keycloak/blueprint.yaml
+++ b/platform/keycloak/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
 spec:
-  version: 1.4.5
+  version: 1.4.6
   card:
     title: keycloak
     summary: Keycloak — user identity. Topology decided by Sovereign CRD spec.keycloakTopology (per-organization for SME, shared-sovereign for corporate).

--- a/platform/keycloak/chart/Chart.yaml
+++ b/platform/keycloak/chart/Chart.yaml
@@ -1,6 +1,10 @@
 apiVersion: v2
 name: bp-keycloak
-version: 1.4.5
+# 1.4.6 (Fix #1902, TBD-A40, 2026-05-19): omit HTTPRoute parentRef
+# sectionName by default — multi-zone Sovereigns rename HTTPS listeners
+# to https-<sanitised-zone>, breaking NoMatchingListener with the prior
+# pinned sectionName: https. Matches the catalyst-system fix in PR #1888.
+version: 1.4.6
 description: |
   Catalyst-curated Blueprint umbrella chart for Keycloak. Depends on the
   upstream `keycloak` chart (bitnami) as a Helm subchart so

--- a/platform/keycloak/chart/values.yaml
+++ b/platform/keycloak/chart/values.yaml
@@ -479,4 +479,8 @@ gateway:
   parentRef:
     name: cilium-gateway
     namespace: kube-system
-    sectionName: https
+    # sectionName intentionally empty — multi-zone Sovereigns rename HTTPS
+    # listeners to https-<sanitised-zone> (e.g. https-omani-works), so
+    # pinning sectionName: https breaks NoMatchingListener. Cilium Gateway
+    # matches by hostname filter. See PR #1888 / TBD-A40 / issue #1902.
+    sectionName: ""

--- a/platform/newapi/blueprint.yaml
+++ b/platform/newapi/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/category: ai-runtime
     catalyst.openova.io/section: pts-4-6-llm-serving
 spec:
-  version: 1.4.22
+  version: 1.4.23
   card:
     title: NewAPI
     summary: |

--- a/platform/newapi/chart/Chart.yaml
+++ b/platform/newapi/chart/Chart.yaml
@@ -245,7 +245,14 @@ name: bp-newapi
 # composes on the next reconcile. helm template renders cleanly with
 # BOTH the missing-attestation state (no channel) AND the
 # fully-populated state (channel composed normally).
-version: 1.4.22
+# 1.4.23 (Fix #1902, TBD-A40, 2026-05-19): omit HTTPRoute parentRef
+# sectionName by default — multi-zone Sovereigns rename HTTPS listeners
+# to https-<sanitised-zone>, breaking NoMatchingListener with the prior
+# `default "https"` fallback in templates/httproute.yaml. The template
+# now uses `{{- with $parent.sectionName }}` to drop the field entirely
+# when blank, and values.yaml defaults sectionName to "". Matches the
+# catalyst-system fix in PR #1888.
+version: 1.4.23
 appVersion: "0.13.2"
 description: |
   Catalyst Blueprint scratch chart for NewAPI — multi-tenant LLM

--- a/platform/newapi/chart/templates/httproute.yaml
+++ b/platform/newapi/chart/templates/httproute.yaml
@@ -38,7 +38,12 @@ operator-overridable via values.yaml.
 {{- $parent := .Values.ingress.httpRoute.parentRef | default dict -}}
 {{- $parentName := default "cilium-gateway" $parent.name -}}
 {{- $parentNs := default "kube-system" $parent.namespace -}}
-{{- $sectionName := default "https" $parent.sectionName -}}
+{{- /*
+sectionName intentionally omitted when empty/unset — pinning to "https"
+broke multi-zone Sovereigns whose Cilium Gateway renames HTTPS listeners
+to https-<sanitised-zone> (PR #1888 / TBD-A40 / issue #1902). Gateway API
+hostname-matching attaches the route to the right listener anyway.
+*/ -}}
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
@@ -50,7 +55,9 @@ spec:
   parentRefs:
     - name: {{ $parentName | quote }}
       namespace: {{ $parentNs | quote }}
-      sectionName: {{ $sectionName | quote }}
+      {{- with $parent.sectionName }}
+      sectionName: {{ . | quote }}
+      {{- end }}
   hostnames:
     - {{ $host | quote }}
   rules:

--- a/platform/newapi/chart/values.yaml
+++ b/platform/newapi/chart/values.yaml
@@ -714,11 +714,15 @@ ingress:
     parentRef:
       name: cilium-gateway
       namespace: kube-system
-      # Listener sectionName — single-zone Sovereigns use bare "https"
-      # per the t20 listener-naming convention; multi-zone Sovereigns
-      # override to "https-<sanitised-zone>" via the bootstrap-kit
-      # overlay.
-      sectionName: https
+      # sectionName intentionally empty — multi-zone Sovereigns rename
+      # HTTPS listeners to https-<sanitised-zone> (e.g. https-omani-works,
+      # https-omani-homes), so pinning sectionName: https breaks every
+      # public HTTPRoute with NoMatchingListener. Cilium Gateway selects
+      # the listener by hostname filter when sectionName is omitted. See
+      # PR #1888 (catalyst-system) / TBD-A40 / issue #1902. Operators may
+      # still override via a bootstrap-kit overlay for non-Cilium
+      # gateways that REQUIRE an explicit sectionName.
+      sectionName: ""
 # ─── NetworkPolicy ───────────────────────────────────────────────────────
 # Default-allow ingress from the platform's gateway namespace; egress
 # to Postgres, Valkey, Keycloak, in-cluster vLLM, DNS, and the operator-

--- a/platform/openbao/blueprint.yaml
+++ b/platform/openbao/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-2-3-per-sovereign-supporting-services
 spec:
-  version: 1.2.16
+  version: 1.2.17
   card:
     title: openbao
     summary: OpenBao secret backend. 3-node Raft per region (independent quorum, async perf-replication across regions). MPL 2.0 — drop-in Vault replacement.

--- a/platform/openbao/chart/Chart.yaml
+++ b/platform/openbao/chart/Chart.yaml
@@ -1,6 +1,10 @@
 apiVersion: v2
 name: bp-openbao
-version: 1.2.16
+# 1.2.17 (Fix #1902, TBD-A40, 2026-05-19): omit HTTPRoute parentRef
+# sectionName by default — multi-zone Sovereigns rename HTTPS listeners
+# to https-<sanitised-zone>, breaking NoMatchingListener with the prior
+# pinned sectionName: https. Matches the catalyst-system fix in PR #1888.
+version: 1.2.17
 description: |
   Catalyst-curated Blueprint umbrella chart for OpenBao. Depends on the
   upstream `openbao` chart as a Helm subchart so `helm dependency build`

--- a/platform/openbao/chart/values.yaml
+++ b/platform/openbao/chart/values.yaml
@@ -69,7 +69,11 @@ gateway:
   parentRef:
     name: cilium-gateway
     namespace: kube-system
-    sectionName: https
+    # sectionName intentionally empty — multi-zone Sovereigns rename HTTPS
+    # listeners to https-<sanitised-zone> (e.g. https-omani-works), so
+    # pinning sectionName: https breaks NoMatchingListener. Cilium Gateway
+    # matches by hostname filter. See PR #1888 / TBD-A40 / issue #1902.
+    sectionName: ""
 
 # ─── Auto-unseal flow (issue #316) ─────────────────────────────────────────
 # Catalyst-curated post-install Job that runs `bao operator init` on a

--- a/platform/powerdns/blueprint.yaml
+++ b/platform/powerdns/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/category: per-host-cluster-infrastructure
     catalyst.openova.io/section: pts-3-2-gitops-and-iac
 spec:
-  version: 1.2.3
+  version: 1.2.4
   card:
     title: PowerDNS
     summary: |

--- a/platform/powerdns/chart/Chart.yaml
+++ b/platform/powerdns/chart/Chart.yaml
@@ -1,6 +1,10 @@
 apiVersion: v2
 name: bp-powerdns
-version: 1.2.3
+# 1.2.4 (Fix #1902, TBD-A40, 2026-05-19): omit HTTPRoute parentRef
+# sectionName by default — multi-zone Sovereigns rename HTTPS listeners
+# to https-<sanitised-zone>, breaking NoMatchingListener with the prior
+# pinned sectionName: https. Matches the catalyst-system fix in PR #1888.
+version: 1.2.4
 description: |
   Catalyst-curated Blueprint wrapper for PowerDNS Authoritative.
   Carries Catalyst-specific values.yaml + templates (CNPG cluster, dnsdist

--- a/platform/powerdns/chart/values.yaml
+++ b/platform/powerdns/chart/values.yaml
@@ -404,7 +404,11 @@ api:
     parentRef:
       name: cilium-gateway
       namespace: kube-system
-      sectionName: https
+      # sectionName intentionally empty — multi-zone Sovereigns rename HTTPS
+      # listeners to https-<sanitised-zone> (e.g. https-omani-works), so
+      # pinning sectionName: https breaks NoMatchingListener. Cilium Gateway
+      # matches by hostname filter. See PR #1888 / TBD-A40 / issue #1902.
+      sectionName: ""
     # Backend defaults to the existing powerdns subchart Service
     backendService: ""    # default: powerdns
     backendPort: 8081     # matches powerdns.powerdns.webserver.bindPort default

--- a/platform/stalwart-tenant/blueprint.yaml
+++ b/platform/stalwart-tenant/blueprint.yaml
@@ -15,7 +15,7 @@ spec:
   # `claimName`, `claimGroups`). setupJob defaults to enabled so a
   # fresh tenant has working OIDC at t=0.
   # Per #817 Chart.yaml version MUST equal blueprint.yaml spec.version.
-  version: 0.1.2
+  version: 0.1.3
   card:
     title: Stalwart (per-tenant)
     summary: |

--- a/platform/stalwart-tenant/chart/Chart.yaml
+++ b/platform/stalwart-tenant/chart/Chart.yaml
@@ -51,7 +51,11 @@ name: bp-stalwart-tenant
 #      `stalwart-cli` + `curl` — no new image needed.
 #
 # Per #817 Chart.yaml version MUST equal blueprint.yaml spec.version.
-version: 0.1.2
+# 0.1.3 (Fix #1902, TBD-A40, 2026-05-19): omit HTTPRoute parentRef
+# sectionName by default — multi-zone Sovereigns rename HTTPS listeners
+# to https-<sanitised-zone>, breaking NoMatchingListener with the prior
+# pinned sectionName: https. Matches the catalyst-system fix in PR #1888.
+version: 0.1.3
 appVersion: "0.16.3"
 description: |
   Catalyst Blueprint scratch chart for a per-SME (per-vcluster) dedicated

--- a/platform/stalwart-tenant/chart/values.yaml
+++ b/platform/stalwart-tenant/chart/values.yaml
@@ -294,7 +294,11 @@ ingress:
     parentRef:
       name: cilium-gateway
       namespace: kube-system
-      sectionName: https
+      # sectionName intentionally empty — multi-zone Sovereigns rename HTTPS
+      # listeners to https-<sanitised-zone> (e.g. https-omani-works), so
+      # pinning sectionName: https breaks NoMatchingListener. Cilium Gateway
+      # matches by hostname filter. See PR #1888 / TBD-A40 / issue #1902.
+      sectionName: ""
     # cert-manager Certificate (mode=ingress only). Gateway mode relies
     # on the gateway's wildcard cert.
     tls:

--- a/products/catalyst/bootstrap/api/internal/handler/sme_tenant_gitops.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sme_tenant_gitops.go
@@ -799,7 +799,12 @@ spec:
       parentRef:
         name: cilium-gateway
         namespace: kube-system
-        sectionName: https
+        # sectionName omitted — multi-zone Sovereigns rename HTTPS listeners
+        # to https-<sanitised-zone> (e.g. https-omani-works). The bp-keycloak
+        # chart template guards `{{- with .Values.gateway.parentRef.sectionName }}`
+        # so a blank value drops the field entirely; Cilium Gateway then
+        # matches by hostname filter. See PR #1888 / TBD-A40 / issue #1902.
+        sectionName: ""
     # Outbound realm email — Phase-1 mothership relay. Operator overlay
     # (or future tenant-Stalwart sub-issue) overrides host/port once
     # tenant-local SMTP is shipped.


### PR DESCRIPTION
## Summary

PR #1888 (TBD-A30) fixed catalyst-system HTTPRoutes for multi-zone Sovereigns whose Cilium Gateway renames HTTPS listeners from `https` to `https-<sanitised-zone>` (e.g. `https-omani-works`, `https-omani-homes`) when more than one parent zone is enabled.

That fix only touched `products/catalyst/chart`. Per-blueprint HTTPRoutes shipped the same `sectionName: https` default in `values.yaml`, so on a multi-zone Sovereign every blueprint route — **gitea, grafana, harbor, keycloak, newapi, openbao, powerdns, stalwart-tenant** — silently failed to attach (`Accepted=False NoMatchingListener`). Issue #1902 / TBD-A40.

## Sweep (verbatim, pre-fix)

```
platform/gitea/chart/values.yaml:168:        sectionName: https
platform/grafana/chart/values.yaml:124:      sectionName: https
platform/harbor/chart/values.yaml:437:       sectionName: https
platform/keycloak/chart/values.yaml:482:     sectionName: https
platform/newapi/chart/values.yaml:721:       sectionName: https
platform/openbao/chart/values.yaml:72:       sectionName: https
platform/powerdns/chart/values.yaml:407:     sectionName: https
platform/stalwart-tenant/chart/values.yaml:297: sectionName: https
products/catalyst/bootstrap/api/internal/handler/sme_tenant_gitops.go:802: sectionName: https
```

## Fix (Option C — omit `sectionName`, same as PR #1888)

- 8 blueprint `values.yaml` defaults flipped from `sectionName: https` to `sectionName: ""`. Chart templates already guard with `{{- with .Values...sectionName }}` so blank → field omitted → Cilium Gateway matches by hostname filter.
- `platform/newapi/chart/templates/httproute.yaml` was the outlier — it used `default "https" $parent.sectionName` (fell back to `https` even when values.yaml said empty). Rewritten to `{{- with $parent.sectionName }}` to match the other 7 blueprints.
- `products/catalyst/bootstrap/api/internal/handler/sme_tenant_gitops.go` (per-tenant bp-keycloak HelmRelease render): flipped its inlined `sectionName: https` to `sectionName: ""`.

## Validation (Principle #15 — real `helm template`)

```
gitea            : sectionName lines in rendered output = 0
grafana          : sectionName lines in rendered output = 0
harbor           : sectionName lines in rendered output = 0
keycloak         : sectionName lines in rendered output = 0
openbao          : sectionName lines in rendered output = 0
powerdns         : sectionName lines in rendered output = 0
newapi           : sectionName lines in rendered output = 0
stalwart-tenant  : sectionName lines in rendered output = 0
```

Override path preserved — `--set ...parentRef.sectionName=https-omani-works` on each chart still renders `sectionName: "https-omani-works"`, so operators can still pin explicitly via bootstrap-kit overlay for single-zone clusters or non-Cilium gateways.

`helm lint` clean on all 8 blueprints (newapi `cnpg-cluster.yaml` lint error is pre-existing on `origin/main`, unrelated to this fix).

## Chart bumps (Chart.yaml + blueprint.yaml lockstep per #817)

| Blueprint | Was | Now |
|-----------|-----|-----|
| bp-gitea | 1.2.7 | 1.2.8 |
| bp-grafana | 1.0.1 | 1.0.2 |
| bp-harbor | 1.2.17 | 1.2.18 |
| bp-keycloak | 1.4.5 | 1.4.6 |
| bp-newapi | 1.4.22 | 1.4.23 |
| bp-openbao | 1.2.16 | 1.2.17 |
| bp-powerdns | 1.2.3 | 1.2.4 |
| bp-stalwart-tenant | 0.1.2 | 0.1.3 |

## Test plan

- [x] `git grep` confirms zero `sectionName: https` defaults remain in `platform/`, `products/`, `clusters/`, `core/` (excluding upstream `platform/gateway-api/chart/templates/` CRD definitions)
- [x] `helm template` default-values render of all 8 blueprints emits zero `sectionName` lines
- [x] `helm template` with `--set ...parentRef.sectionName=https-omani-works` still emits `sectionName: "https-omani-works"` (override path preserved)
- [x] `helm lint` clean on all 8 blueprints
- [ ] Fresh prov on multi-zone Sovereign (omani.works + omani.homes) confirms all blueprint HTTPRoutes report `Accepted=True` and the hosted services are reachable

Closes #1902. Refs TBD-A40, PR #1888 (catalyst-system precedent).

Co-authored-by: hatiyildiz <hatice.yildiz@openova.io>

🤖 Generated with [Claude Code](https://claude.com/claude-code)