### PR TITLE
fix(gitea-client): use POST /api/v1/orgs not /admin/orgs for org create (TBD-A43, Closes #1906)

### DIFF
--- a/core/controllers/organization/internal/controller/organization_controller_test.go
+++ b/core/controllers/organization/internal/controller/organization_controller_test.go
@@ -174,8 +174,8 @@ func (g *giteaServer) handle(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// POST /api/v1/admin/orgs
-	if r.Method == http.MethodPost && p == "/api/v1/admin/orgs" {
+	// POST /api/v1/orgs
+	if r.Method == http.MethodPost && p == "/api/v1/orgs" {
 		var body struct {
 			Username    string `json:"username"`
 			FullName    string `json:"full_name"`

--- a/core/controllers/pkg/gitea/client.go
+++ b/core/controllers/pkg/gitea/client.go
@@ -27,7 +27,9 @@
 // Endpoints (Gitea Admin REST API, version 1.22):
 //
 //	GET    /api/v1/orgs/{org}
-//	POST   /api/v1/admin/orgs
+//	POST   /api/v1/orgs                          (org-create-as-self;
+//	                                             admin-owned token →
+//	                                             admin owns the new org)
 //	GET    /api/v1/repos/{owner}/{repo}
 //	POST   /api/v1/orgs/{org}/repos
 //	GET    /api/v1/repos/{owner}/{repo}/branches/{branch}
@@ -245,8 +247,12 @@ type Org struct {
 	Visibility  string `json:"visibility,omitempty"`
 }
 
-// adminOrgCreate is the payload for POST /admin/orgs.
-type adminOrgCreate struct {
+// orgCreate is the payload for POST /orgs. The authenticated user
+// (the bearer of the admin access-token) becomes the new Org's owner.
+// In Gitea 1.22+, the legacy POST /admin/orgs/{user} endpoint is no
+// longer routed (returns 405 with `Allow: GET`); /orgs is the only
+// supported create path for both admin- and user-owned tokens.
+type orgCreate struct {
 	Username    string `json:"username"`
 	FullName    string `json:"full_name,omitempty"`
 	Description string `json:"description,omitempty"`
@@ -288,21 +294,31 @@ func (c *Client) GetOrg(ctx context.Context, slug string) (Org, error) {
 	return out, nil
 }
 
-// CreateOrg creates a Gitea Org via the admin endpoint. Returns
-// errAlreadyExists (internal sentinel) on 422/409 so EnsureOrg can
-// re-find idempotently.
+// CreateOrg creates a Gitea Org via POST /orgs (the org-create-as-self
+// endpoint). The authenticated principal owns the new Org. Because the
+// controller authenticates with a Gitea admin token, the admin user
+// owns each created tenant Org — same semantic as the legacy
+// /admin/orgs path. Returns errAlreadyExists (internal sentinel) on
+// 422/409 so EnsureOrg can re-find idempotently.
+//
+// NOTE: Gitea 1.22+ no longer routes POST /api/v1/admin/orgs (returns
+// HTTP 405 `Allow: GET`); the admin-namespaced create path is
+// /api/v1/admin/users/{user}/orgs but is order-of-magnitude clunkier
+// (requires knowing the admin username). /orgs covers every realistic
+// production deployment because the controller's token is always
+// owned by a sufficiently-privileged user.
 func (c *Client) CreateOrg(ctx context.Context, slug, fullName, description, visibility string) (Org, error) {
 	if visibility == "" {
 		visibility = "private"
 	}
-	body := adminOrgCreate{
+	body := orgCreate{
 		Username:    slug,
 		FullName:    fullName,
 		Description: description,
 		Visibility:  visibility,
 	}
 	var out Org
-	status, _, err := c.do(ctx, http.MethodPost, "/admin/orgs", body, &out)
+	status, _, err := c.do(ctx, http.MethodPost, "/orgs", body, &out)
 	if err != nil {
 		if status == http.StatusUnprocessableEntity || status == http.StatusConflict {
 			return Org{}, errAlreadyExists

--- a/core/controllers/pkg/gitea/client_test.go
+++ b/core/controllers/pkg/gitea/client_test.go
@@ -84,9 +84,9 @@ func (f *fakeGitea) handler() http.Handler {
 			return
 		}
 
-		// POST /api/v1/admin/orgs
-		if r.Method == http.MethodPost && p == "/api/v1/admin/orgs" {
-			var body adminOrgCreate
+		// POST /api/v1/orgs
+		if r.Method == http.MethodPost && p == "/api/v1/orgs" {
+			var body orgCreate
 			_ = json.NewDecoder(r.Body).Decode(&body)
 			f.mu.Lock()
 			defer f.mu.Unlock()
@@ -472,7 +472,7 @@ func TestEnsureOrg_FindHits(t *testing.T) {
 	if got := fake.callCount(http.MethodGet, "/api/v1/orgs/acme"); got != 1 {
 		t.Errorf("expected 1 GET, got %d", got)
 	}
-	if got := fake.callCount(http.MethodPost, "/api/v1/admin/orgs"); got != 0 {
+	if got := fake.callCount(http.MethodPost, "/api/v1/orgs"); got != 0 {
 		t.Errorf("expected 0 POST when org pre-exists, got %d", got)
 	}
 }
@@ -489,7 +489,7 @@ func TestEnsureOrg_CreatesWhenMissing(t *testing.T) {
 	if o.Username != "newone" || o.ID == 0 {
 		t.Errorf("expected created org, got %+v", o)
 	}
-	if got := fake.callCount(http.MethodPost, "/api/v1/admin/orgs"); got != 1 {
+	if got := fake.callCount(http.MethodPost, "/api/v1/orgs"); got != 1 {
 		t.Errorf("expected 1 POST, got %d", got)
 	}
 }
@@ -506,7 +506,7 @@ func TestEnsureOrg_422Race(t *testing.T) {
 				return
 			}
 			_ = json.NewEncoder(w).Encode(Org{ID: 99, Username: "raced"})
-		case "POST /api/v1/admin/orgs":
+		case "POST /api/v1/orgs":
 			http.Error(w, "duplicate", http.StatusUnprocessableEntity)
 		default:
 			http.Error(w, "unhandled", http.StatusInternalServerError)


### PR DESCRIPTION
## Why

`catalyst-organization-controller` on t31 was looping on `gitea.EnsureOrg`:

```
gitea.EnsureOrg: create: gitea: POST http://gitea-http.gitea.svc.cluster.local:3000/api/v1/admin/orgs: HTTP 405
```

This blocks **D29 Step 7** (tenant Gitea Org provisioning) — every Organization CR fails before its `giteaOrg` status field is populated.

## Root cause

Gitea 1.22+ does not route `POST /api/v1/admin/orgs`. That URL is now **GET-only** (admin list of all orgs). The supported create endpoint is `POST /api/v1/orgs` (org-create-as-self): the authenticated principal owns the new Org. Because the controller authenticates with the Gitea admin token (`catalyst-gitea-token`, owner `gitea_admin`), the admin user owns each tenant Org — semantic-equivalent to the legacy admin path.

405 returns `Allow: GET` header confirming POST is unsupported on `/admin/orgs` (it's the listing endpoint).

## Fix

`core/controllers/pkg/gitea/client.go::CreateOrg` now hits `POST /api/v1/orgs`. Test fakes in `pkg/gitea/client_test.go` and `organization/internal/controller/organization_controller_test.go` updated to match. Doc comments + the rename `adminOrgCreate` → `orgCreate` annotate the migration.

## Verbatim curl proof (t31, Gitea 1.22.3, via port-forward + admin token)

```
=== Gitea version on t31 ===
Gitea version 1.22.3 built with GNU Make 4.4.1, go1.22.8 : bindata, timetzdata, sqlite, sqlite_unlock_notify

=== BEFORE FIX: POST /api/v1/admin/orgs (current main, 405) ===
HTTP/1.1 405 Method Not Allowed
Allow: GET
Cache-Control: max-age=0, private, must-revalidate, no-transform
X-Content-Type-Options: nosniff
X-Frame-Options: SAMEORIGIN
Date: Tue, 19 May 2026 03:57:41 GMT
Content-Length: 0


=== AFTER FIX: POST /api/v1/orgs (new path, 201) ===
HTTP/1.1 201 Created
Cache-Control: max-age=0, private, must-revalidate, no-transform
Content-Type: application/json;charset=utf-8
X-Content-Type-Options: nosniff
X-Frame-Options: SAMEORIGIN
Date: Tue, 19 May 2026 03:57:41 GMT
Content-Length: 290

{"id":6,"name":"d29proof-new","full_name":"d29proof-new","email":"","avatar_url":"https://gitea.t31.omani.works/avatars/ece766c82980c8464018e7d9aa8b7d18","description":"test","website":"","location":"","visibility":"private","repo_admin_change_team_access":false,"username":"d29proof-new"}

=== Cleanup ===
DELETE proof: 204
```

422 on duplicate-username path is unchanged (real Gitea returns 422 → still mapped to `errAlreadyExists` → `EnsureOrg` re-finds idempotently). Confirmed in repro:

```
=== POST /api/v1/orgs (re-create duplicate) ===
HTTP/1.1 422 Unprocessable Entity
{"message":"user already exists [name: d29test-final]","url":"https://gitea.t31.omani.works/api/swagger"}
```

## Test plan

- [x] `go test ./pkg/gitea/...` → PASS (2.696s)
- [x] `go test ./organization/...` → PASS (0.554s)
- [x] Real-Gitea curl proof above (POST /orgs returns 201, POST /admin/orgs returns 405)
- [ ] Post-merge: rolling-restart `catalyst-organization-controller` on t31 with new image, watch logs for first Organization CR → `Gitea Org created` log line.

Closes #1906
Refs TBD-A43