### PR TITLE
fix(catalyst-cnp): allow egress TCP/6443 for multi-region fan-out (TBD-A45 #1908)

### DIFF
--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -1,5 +1,20 @@
 apiVersion: v2
 name: bp-catalyst-platform
+# 1.4.186 — TBD-A45 (issue #1908) catalyst-api egress to secondary CP
+# :6443 unblocked. baseline-default-deny CNP world-egress block
+# previously allowed only 443/587/465/25 — catalyst-api fan-out to
+# secondary-region kube-apiservers (D5/D16/D20) silently timed out on
+# the informer reflector List() call, returning primary-only results.
+# A152 diagnostic on t31 isolated the cause via `nc -zvw 3 49.12.210.78
+# 6443` from inside the catalyst-api Pod (timeout) vs. from the bastion
+# (open). Added TCP/6443 to the world-egress allow-list. World-scope is
+# correct per the OpenOva ClusterMesh model (inter-region link =
+# DMZ over PUBLIC IPs ALWAYS; secondary api-server LB FQDNs are
+# per-prov and not predictable at chart-render time). Attack surface is
+# bounded — :6443 requires TLS client-cert auth and only the
+# secondary-region kubeconfigs hold valid certs. chart-tests fixture
+# `tests/baseline-cnp-allowlist.sh` extended (Case 5b) so any future
+# narrowing of this block fails Blueprint Release publish.
 # 1.4.185 — TBD-A38 (issue #1900) provisioning SA grant create
 # organizations.orgs.openova.io. The tenant.created Kafka consumer (Go
 # code shipped in PR #1860) creates one Organization CR per voucher
@@ -1279,7 +1294,7 @@ name: bp-catalyst-platform
 # 25/TCP (legacy SMTP fallback). All three are explicitly scoped to
 # `toEntities: world`, matching the existing 443/TCP allow. No other
 # rule semantics change. (Fixes PIN-issue 502 regression from #1785.)
-version: 1.4.185
+version: 1.4.186
 appVersion: 1.4.184
 # 1.4.183 — fix(httproute): omit default sectionName so multi-zone
 # Sovereigns attach via Cilium Gateway hostname matcher (Closes #1884,

--- a/products/catalyst/chart/templates/network-policies/baseline-catalyst-system.yaml
+++ b/products/catalyst/chart/templates/network-policies/baseline-catalyst-system.yaml
@@ -199,7 +199,9 @@ spec:
     #    AND submit PIN-issue / notification emails to the operator
     #    Stalwart SMTP relay (mail.openova.io) over TCP/587
     #    (submission, the production path) with TCP/465 (SMTPS) and
-    #    TCP/25 (legacy SMTP) as fallbacks.
+    #    TCP/25 (legacy SMTP) as fallbacks
+    #    AND reach SECONDARY-REGION kube-apiservers on TCP/6443 for
+    #    multi-region fan-out (D5/D16/D20 cloud-nodes treemap dashboard).
     #
     #    Regression context — DO NOT NARROW THIS BLOCK WITHOUT REVIEW
     #    ────────────────────────────────────────────────────────────
@@ -213,6 +215,40 @@ spec:
     #    `nc 45.151.123.50 587` (timeout) while a default-namespace
     #    Pod on the SAME node connects fine (220 Stalwart ESMTP banner).
     #    See chart 1.4.177 changelog above and the fix PR body.
+    #
+    #    TCP/6443 regression context — issue #1908 (TBD-A45)
+    #    ────────────────────────────────────────────────────────────
+    #    After PRs #1579/#1580/#1581/#1800 implemented multi-region
+    #    fan-out, `/api/v1/sovereign/cloud?kind=nodes` (D5),
+    #    `/api/v1/sovereign/dashboard` (D16), and per-region jobs
+    #    queries (D20) all returned PRIMARY-ONLY results on a fresh
+    #    multi-region prov (t31, 3 regions). A152 diagnostic isolated
+    #    the cause:
+    #
+    #      kubectl -n catalyst-system exec deploy/catalyst-api -- \
+    #        nc -zvw 3 49.12.210.78 6443
+    #      nc: connect to 49.12.210.78 port 6443 (tcp) timed out
+    #
+    #    while the SAME endpoint from the bastion connected fine.
+    #    The k8sCache.Factory registered the secondary-region API
+    #    servers from the kubeconfig PVC but the informer reflector
+    #    silently failed on the first apiserver List() because this
+    #    baseline CNP blocked egress to non-443 world. Fan-out
+    #    returned len(clusters)==1 (primary only) and the dashboard
+    #    silently grouped everything under the primary region.
+    #
+    #    The inter-region apiserver path matches the OpenOva
+    #    ClusterMesh model (memory: "inter-region link = DMZ
+    #    WireGuard over PUBLIC IPs ALWAYS") — every secondary
+    #    api-server is reachable only over its public LB IP (Hetzner
+    #    or AWS or Huawei). FQDN-scoping is impractical because the
+    #    LB FQDNs are per-prov (`api.<region>.<sovereign-fqdn>`) and
+    #    not predictable at chart-render time; world-on-6443 matches
+    #    the public-IP exposure surface the ClusterMesh already
+    #    requires. Attack surface is bounded — :6443 only accepts
+    #    TLS client-cert-authenticated requests, and only the
+    #    secondary-region kubeconfigs (mounted on the catalyst-api
+    #    Pod's PVC) hold valid client certs.
     - toEntities:
         - world
       toPorts:
@@ -224,5 +260,7 @@ spec:
             - port: "465"
               protocol: TCP
             - port: "25"
+              protocol: TCP
+            - port: "6443"
               protocol: TCP
 {{- end }}

--- a/products/catalyst/chart/tests/baseline-cnp-allowlist.sh
+++ b/products/catalyst/chart/tests/baseline-cnp-allowlist.sh
@@ -104,6 +104,31 @@ if ! grep -E '^\s*-\s+port:\s+"443"' "$TMP/cnp.yaml" >/dev/null; then
 fi
 echo "  PASS (egress TCP/443 HTTPS allowed)"
 
+echo "[baseline-cnp] Case 5b: egress allow-list includes kube-apiserver (TCP/6443) to world — #1908 regression guard"
+# catalyst-api fans out to SECONDARY-REGION kube-apiservers on TCP/6443
+# (D5 nodes endpoint, D16 dashboard treemap, D20 per-region jobs queries).
+# A152 diagnostic on t31 isolated the symptom:
+#   kubectl -n catalyst-system exec deploy/catalyst-api -- \
+#     nc -zvw 3 49.12.210.78 6443
+#   nc: connect to 49.12.210.78 port 6443 (tcp) timed out
+# while the SAME endpoint from the bastion connected. The baseline
+# CNP world-egress block only allowed 443/587/465/25 — secondary CP
+# api-server List() calls timed out silently and fan-out returned
+# primary-only. Re-narrowing this block — even "for security
+# hardening" — must fail CI here.
+if ! grep -E '^\s*-\s+port:\s+"6443"' "$TMP/cnp.yaml" >/dev/null; then
+  echo "FAIL: egress port 6443/TCP missing — multi-region fan-out (D5/D16/D20) will silently return primary-only (#1908 regression)" >&2
+  exit 1
+fi
+# Confirm 6443 is on a toEntities:[world] rule (the secondary CPs are
+# reachable only via public LB IPs per ClusterMesh model), not on a
+# kube-dns or kube-apiserver-entity block.
+if ! awk '/egress:/,0' "$TMP/cnp.yaml" | grep -B30 'port: "6443"' | grep -q '\- world'; then
+  echo "FAIL: port 6443/TCP exists but not scoped to toEntities:[world] (#1908)" >&2
+  exit 1
+fi
+echo "  PASS (egress TCP/6443 to world allowed — secondary CP fan-out unblocked)"
+
 echo "[baseline-cnp] Case 6: egress allow-list includes DNS (53/UDP + 53/TCP) to kube-dns"
 # Without DNS, every name lookup in catalyst-system fails. The CNP
 # explicitly allows kube-dns endpoints in kube-system on 53/UDP +


### PR DESCRIPTION
## Summary

Root cause of D5/D16/D20 multi-region fan-out RED (issue #1904).

The `baseline-default-deny` CiliumNetworkPolicy in `catalyst-system` previously allowed only **443/587/465/25 TCP** in its world-egress block. catalyst-api fan-out to secondary-region kube-apiservers on **TCP/6443** silently timed out on the informer reflector `List()` call, so `k8sCache.Factory` registered the secondaries but never populated them and fan-out returned **primary-only** results.

A152 diagnostic on t31 (3-region fresh prov) isolated the cause: from inside the catalyst-api Pod `nc` to a secondary CP IP times out; from the bastion the same IP connects.

## What changed

- `products/catalyst/chart/templates/network-policies/baseline-catalyst-system.yaml` — add `port: "6443" protocol: TCP` to the `toEntities: [world]` egress rule. Extensive inline comment explains the regression context and why `world` (vs. `toFQDNs`) is the right scope per the OpenOva ClusterMesh model.
- `products/catalyst/chart/tests/baseline-cnp-allowlist.sh` — new **Case 5b** asserting TCP/6443 is allowed under `toEntities: [world]`, so any future narrowing fails Blueprint Release CI before the OCI artifact ships.
- `products/catalyst/chart/Chart.yaml` — bump 1.4.185 → 1.4.186 with full changelog header.

## Real-cluster validation (t31 primary, Cilium)

Verbatim `nc` BEFORE the fix:
```
$ kubectl --kubeconfig=$KC -n catalyst-system exec catalyst-api-85bcd69bcb-f9dvq -- nc -zvw 5 49.12.210.78 6443
nc: 49.12.210.78 (49.12.210.78:6443): Operation timed out
command terminated with exit code 1
$ kubectl --kubeconfig=$KC -n catalyst-system exec catalyst-api-85bcd69bcb-f9dvq -- nc -zvw 5 5.223.74.173 6443
nc: 5.223.74.173 (5.223.74.173:6443): Operation timed out
command terminated with exit code 1
```

Bastion control nc (same endpoints, no CNP in path):
```
$ nc -zvw 5 49.12.210.78 6443
Connection to 49.12.210.78 6443 port [tcp/*] succeeded!
$ nc -zvw 5 5.223.74.173 6443
Connection to 5.223.74.173 6443 port [tcp/*] succeeded!
```

After applying the rendered CNP (`kubectl apply` → `ciliumnetworkpolicy.cilium.io/baseline-default-deny configured`):

Verbatim `nc` AFTER the fix, from the original Pod:
```
$ kubectl --kubeconfig=$KC -n catalyst-system exec catalyst-api-85bcd69bcb-f9dvq -- nc -zvw 5 49.12.210.78 6443
49.12.210.78 (49.12.210.78:6443) open
$ kubectl --kubeconfig=$KC -n catalyst-system exec catalyst-api-85bcd69bcb-f9dvq -- nc -zvw 5 5.223.74.173 6443
5.223.74.173 (5.223.74.173:6443) open
```

Persistence after `rollout restart` (fresh Pod, same node, new sandbox):
```
$ kubectl --kubeconfig=$KC -n catalyst-system exec catalyst-api-67d7766677-n6z9p -- nc -zvw 5 49.12.210.78 6443
49.12.210.78 (49.12.210.78:6443) open
```

## chart-tests

`bash tests/baseline-cnp-allowlist.sh` — **13/13** cases pass (was 12; new Case 5b green):
```
[baseline-cnp] Case 5b: egress allow-list includes kube-apiserver (TCP/6443) to world — #1908 regression guard
  PASS (egress TCP/6443 to world allowed — secondary CP fan-out unblocked)
...
[baseline-cnp] All gates green.
```

## Test plan
- [x] `helm template` renders new `port: "6443"` under `toEntities: [world]`
- [x] `kubectl apply` rendered CNP to live t31 cluster (Cilium present)
- [x] `nc` from inside catalyst-api Pod to both secondary CP IPs returns open (was: timed out)
- [x] `nc` survives `rollout restart` of catalyst-api Deployment
- [x] `tests/baseline-cnp-allowlist.sh` — 13/13 cases green
- [ ] Next fresh prov: `/api/v1/sovereign/cloud?kind=nodes` returns 3 nodes (D5), dashboard treemap returns 3 groups (D16)

Closes #1908
Refs #1904