### PR TITLE
fix(notification): exponential backoff + circuit breaker on 503 5.5.1 SMTP rate-limit (TBD-X1)

### DIFF
--- a/core/services/notification/handlers/smtp.go
+++ b/core/services/notification/handlers/smtp.go
@@ -9,81 +9,204 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 )
 
-// defaultRetryBackoff is the wait between retries when the SMTP server
-// responds with "503 5.5.1" — Stalwart's rate-limit trip. The window is
-// chosen to outlast Stalwart's default 30s rate-limit bucket; 60s gives
-// the bucket enough headroom that a retry lands on a fresh quota even
-// when wall-clock drift is involved (Refs #1793).
-const defaultRetryBackoff = 60 * time.Second
+// defaultBaseBackoff is the FIRST wait between retries when the SMTP
+// server responds with "503 5.5.1" — Stalwart's rate-limit trip. The
+// 30s floor is set by the issue spec (TBD-X1, Refs #1793) so the
+// Stalwart bucket has time to drain (default 5 req / 1000 ms). Each
+// subsequent retry doubles the wait (exponential backoff) capped at
+// defaultMaxBackoff so a permanently misconfigured upstream cannot
+// hold a worker hostage for hours.
+const defaultBaseBackoff = 30 * time.Second
+
+// defaultMaxBackoff caps the exponential backoff growth so a worker
+// thread is never stuck waiting >5 minutes per attempt. 30s -> 60s ->
+// 120s -> 240s -> 300s (cap). Combined with the circuit-breaker
+// (defaultBreakerTrip-consecutive 503s) this bounds total wall time
+// per failed send to ~2 minutes.
+const defaultMaxBackoff = 5 * time.Minute
 
 // defaultMaxRetries caps total attempts at 3 (initial + 2 retries) so a
 // permanently mis-credentialed Stalwart cannot hold a worker hostage.
 const defaultMaxRetries = 3
 
+// Circuit-breaker tuning (Refs #1793 deliverable PR A):
+//
+//   defaultBreakerTrip      — consecutive 503 5.5.1 responses required
+//                             to open the breaker. The issue spec
+//                             calls for 3.
+//   defaultBreakerWindow    — sliding window over which the trip count
+//                             accumulates. The issue spec calls for
+//                             90s. Older 503s age out so a slow drip
+//                             of rate-limits across minutes does not
+//                             trip the breaker.
+//   defaultBreakerCooldown  — once open, the breaker rejects every
+//                             Send immediately for this duration. The
+//                             cooldown gives Stalwart's rate-limiter
+//                             time to fully drain so the first
+//                             post-cooldown send has a chance to
+//                             succeed and reset the breaker.
+const (
+	defaultBreakerTrip     = 3
+	defaultBreakerWindow   = 90 * time.Second
+	defaultBreakerCooldown = 120 * time.Second
+)
+
+// ErrCircuitOpen is returned by Send when the SMTP circuit breaker is
+// open — i.e. the Mailer has seen defaultBreakerTrip consecutive 503
+// 5.5.1 responses within defaultBreakerWindow. Callers (the events
+// consumer) can match on this error to NACK + dead-letter the message
+// instead of tight-looping on the same upstream that's already known
+// to be rate-limited.
+var ErrCircuitOpen = errors.New("smtp circuit breaker open: too many consecutive 503 5.5.1 responses; not sending until cooldown elapses")
+
 // sendMailFunc is the indirection that lets unit tests substitute the
 // real net/smtp.SendMail without touching production wiring.
 type sendMailFunc func(addr string, a smtp.Auth, from string, to []string, msg []byte) error
 
-// sleepFunc lets unit tests collapse the 60s backoff to zero wall time.
+// sleepFunc lets unit tests collapse the exponential-backoff sleeps to
+// zero wall time.
 type sleepFunc func(time.Duration)
 
-// Mailer sends HTML emails via SMTP with bounded retry on Stalwart
-// rate-limit (503 5.5.1) responses.
+// nowFunc lets unit tests advance the breaker's notion of "now"
+// without sleeping for the breaker window.
+type nowFunc func() time.Time
+
+// Mailer sends HTML emails via SMTP with bounded exponential-backoff
+// retry on Stalwart rate-limit (503 5.5.1) responses + a sliding-
+// window circuit breaker that short-circuits Send once Stalwart is
+// clearly overwhelmed (Refs #1793).
 type Mailer struct {
 	Host string
 	Port string
 	From string
 
-	// RetryBackoff is the wait between retries when Stalwart returns
-	// "503 5.5.1" (rate-limit). Configurable via the SMTP_RETRY_BACKOFF
-	// environment variable; see NewMailer for parse rules.
-	RetryBackoff time.Duration
+	// Auth holds the SMTP-PLAIN credentials passed to net/smtp on
+	// every send. When nil, net/smtp.SendMail dials without
+	// authentication — which is exactly the pre-#1793 bug: Stalwart
+	// then rejects the submission with 503 5.5.1 "You must
+	// authenticate first" and the retry storm trips Stalwart's
+	// 5-req/1000ms rate-limiter for every other tenant on the same
+	// relay.
+	Auth smtp.Auth
+
+	// BaseBackoff is the FIRST wait between retries when Stalwart
+	// returns "503 5.5.1" (rate-limit). Each subsequent retry
+	// doubles the wait up to MaxBackoff (exponential). Configurable
+	// via the SMTP_RETRY_BACKOFF environment variable; see NewMailer
+	// for parse rules.
+	BaseBackoff time.Duration
+	// MaxBackoff caps the exponential growth so a worker thread is
+	// never stuck >MaxBackoff between attempts.
+	MaxBackoff time.Duration
 	// MaxRetries caps total attempts at MaxRetries (initial + retries).
 	MaxRetries int
 
-	// sendMail and sleep are unexported test seams. Production code
-	// always uses smtp.SendMail and time.Sleep.
+	// BreakerTrip / BreakerWindow / BreakerCooldown tune the circuit
+	// breaker. Default 3 consecutive 503 5.5.1 responses inside a
+	// 90s sliding window open the breaker; while open Send returns
+	// ErrCircuitOpen immediately for BreakerCooldown so we don't
+	// keep slamming a known-rate-limited upstream.
+	BreakerTrip     int
+	BreakerWindow   time.Duration
+	BreakerCooldown time.Duration
+
+	// breaker holds the rolling-window state. Internal — callers
+	// drive it only through Send.
+	breaker breakerState
+
+	// sendMail, sleep, now are unexported test seams. Production
+	// code uses smtp.SendMail / time.Sleep / time.Now.
 	sendMail sendMailFunc
 	sleep    sleepFunc
+	now      nowFunc
+}
+
+// breakerState holds the sliding window of 503 5.5.1 timestamps plus
+// the openedAt instant. Guarded by mu so concurrent Send calls (the
+// events consumer fans out per-message) share a single breaker.
+type breakerState struct {
+	mu        sync.Mutex
+	hits      []time.Time
+	openedAt  time.Time
 }
 
 // NewMailer creates a Mailer configured for the given SMTP server. The
-// retry-backoff window can be overridden by the SMTP_RETRY_BACKOFF
+// base retry-backoff window can be overridden by the SMTP_RETRY_BACKOFF
 // environment variable. Accepted forms:
 //
 //   - Go duration string: "60s", "2m", "500ms"
 //   - Bare integer: treated as seconds (e.g., "30" -> 30s)
 //
-// Invalid values fall back to defaultRetryBackoff (60s). The minimum
-// is clamped to 30s — the task spec calls for >=30s so the rate-limiter
+// Invalid values fall back to defaultBaseBackoff (30s). The minimum is
+// clamped to 30s — the task spec calls for >=30s so the rate-limiter
 // has time to drain.
+//
+// SMTP auth is read from the SMTP_USER + SMTP_PASS env vars when both
+// are non-empty. Either-or-neither: setting one without the other is
+// surfaced as a slog warn and treated as no-auth (preserves the
+// pre-#1793 behaviour rather than constructing half-broken creds).
 func NewMailer(host, port, from string) *Mailer {
 	return &Mailer{
-		Host:         host,
-		Port:         port,
-		From:         from,
-		RetryBackoff: parseRetryBackoff(os.Getenv("SMTP_RETRY_BACKOFF")),
-		MaxRetries:   defaultMaxRetries,
-		sendMail:     smtp.SendMail,
-		sleep:        time.Sleep,
+		Host:            host,
+		Port:            port,
+		From:            from,
+		Auth:            buildAuth(host),
+		BaseBackoff:     parseRetryBackoff(os.Getenv("SMTP_RETRY_BACKOFF")),
+		MaxBackoff:      defaultMaxBackoff,
+		MaxRetries:      defaultMaxRetries,
+		BreakerTrip:     defaultBreakerTrip,
+		BreakerWindow:   defaultBreakerWindow,
+		BreakerCooldown: defaultBreakerCooldown,
+		sendMail:        smtp.SendMail,
+		sleep:           time.Sleep,
+		now:             time.Now,
 	}
 }
 
+// buildAuth pulls SMTP_USER / SMTP_PASS from the environment and
+// constructs an smtp.PlainAuth bound to the given SMTP host. Both
+// values must be non-empty; otherwise Auth stays nil (no-auth) so
+// Stalwart's misconfig detection is loud — the operator sees 503 5.5.1
+// "You must authenticate first" exactly once before the circuit
+// breaker opens, instead of a silent retry storm.
+//
+// host carries the SMTP server hostname (e.g. mail.openova.io); the
+// stdlib net/smtp PlainAuth pins the credential exchange to that
+// hostname so an MX redirection cannot harvest creds.
+func buildAuth(host string) smtp.Auth {
+	user := os.Getenv("SMTP_USER")
+	pass := os.Getenv("SMTP_PASS")
+	if user == "" && pass == "" {
+		return nil
+	}
+	if user == "" || pass == "" {
+		slog.Warn(
+			"smtp auth half-configured: one of SMTP_USER/SMTP_PASS is empty; falling back to no-auth (likely causes Stalwart 503 5.5.1)",
+			"hasUser", user != "",
+			"hasPass", pass != "",
+			"host", host,
+		)
+		return nil
+	}
+	return smtp.PlainAuth("", user, pass, host)
+}
+
 // parseRetryBackoff turns an env-var string into a duration with sane
-// defaults and a 30s floor.
+// defaults and a 30s floor (issue TBD-X1 explicit spec).
 func parseRetryBackoff(raw string) time.Duration {
 	if raw == "" {
-		return defaultRetryBackoff
+		return defaultBaseBackoff
 	}
 	// Go duration string first ("60s", "2m"). A bare "0" parses as a
 	// valid duration of 0 — treat that (and any non-positive) as
 	// "value missing" so the default kicks in.
 	if d, err := time.ParseDuration(raw); err == nil {
 		if d <= 0 {
-			return defaultRetryBackoff
+			return defaultBaseBackoff
 		}
 		if d < 30*time.Second {
 			return 30 * time.Second
@@ -98,14 +221,28 @@ func parseRetryBackoff(raw string) time.Duration {
 		}
 		return d
 	}
-	return defaultRetryBackoff
+	return defaultBaseBackoff
 }
 
 // Send delivers an HTML email to the given recipient. Stalwart
-// rate-limit responses (503 5.5.1) trigger a bounded retry loop with
-// RetryBackoff between attempts; all other errors return immediately
-// to the caller so the consumer can NACK / dead-letter as appropriate.
+// rate-limit responses (503 5.5.1) trigger a bounded exponential-
+// backoff retry loop; all other errors return immediately to the
+// caller so the consumer can NACK / dead-letter as appropriate.
+//
+// If the circuit breaker is open (defaultBreakerTrip consecutive 503
+// 5.5.1 responses within BreakerWindow), Send returns ErrCircuitOpen
+// immediately for the duration of BreakerCooldown.
 func (m *Mailer) Send(to, subject, htmlBody string) error {
+	if open, untilWall := m.breakerStateNow(); open {
+		slog.Warn(
+			"smtp circuit breaker open; skipping send",
+			"to", to,
+			"subject", subject,
+			"reopensIn", untilWall.String(),
+		)
+		return ErrCircuitOpen
+	}
+
 	addr := m.Host + ":" + m.Port
 
 	headers := []string{
@@ -130,15 +267,20 @@ func (m *Mailer) Send(to, subject, htmlBody string) error {
 	if maxRetries < 1 {
 		maxRetries = defaultMaxRetries
 	}
-	backoff := m.RetryBackoff
-	if backoff <= 0 {
-		backoff = defaultRetryBackoff
+	base := m.BaseBackoff
+	if base <= 0 {
+		base = defaultBaseBackoff
+	}
+	maxBackoff := m.MaxBackoff
+	if maxBackoff <= 0 {
+		maxBackoff = defaultMaxBackoff
 	}
 
 	var lastErr error
 	for attempt := 1; attempt <= maxRetries; attempt++ {
-		err := sendMail(addr, nil, m.From, []string{to}, msg)
+		err := sendMail(addr, m.Auth, m.From, []string{to}, msg)
 		if err == nil {
+			m.breakerResetOnSuccess()
 			return nil
 		}
 		lastErr = err
@@ -149,11 +291,33 @@ func (m *Mailer) Send(to, subject, htmlBody string) error {
 			// operator.
 			return err
 		}
+
+		// Rate-limit: record into the breaker window. If the
+		// breaker now trips, abort the remaining retry budget
+		// rather than wait through more exponential sleeps for an
+		// upstream we know is overwhelmed.
+		if m.breakerRecordRateLimit() {
+			slog.Warn(
+				"smtp circuit breaker tripped during retry; abandoning send",
+				"to", to,
+				"subject", subject,
+				"trip", m.breakerTripCount(),
+				"window", m.breakerWindowDuration().String(),
+			)
+			return fmt.Errorf("smtp send to %s: circuit opened after %d attempts: %w", to, attempt, errors.Join(lastErr, ErrCircuitOpen))
+		}
+
 		if attempt == maxRetries {
 			break
 		}
+
+		// Exponential backoff: base * 2^(attempt-1), capped.
+		backoff := base << (attempt - 1)
+		if backoff > maxBackoff || backoff < base /* overflow guard */ {
+			backoff = maxBackoff
+		}
 		slog.Warn(
-			"smtp rate-limit backoff",
+			"smtp rate-limit backoff (exponential)",
 			"to", to,
 			"subject", subject,
 			"backoff", backoff.String(),
@@ -163,6 +327,110 @@ func (m *Mailer) Send(to, subject, htmlBody string) error {
 		sleep(backoff)
 	}
 	return fmt.Errorf("smtp send to %s: rate-limited after %d attempts: %w", to, maxRetries, lastErr)
+}
+
+// breakerStateNow reports whether the breaker is currently open. When
+// open, it returns the remaining cooldown so callers can log a useful
+// message; once cooldown has elapsed it auto-clears.
+func (m *Mailer) breakerStateNow() (open bool, remaining time.Duration) {
+	m.breaker.mu.Lock()
+	defer m.breaker.mu.Unlock()
+	if m.breaker.openedAt.IsZero() {
+		return false, 0
+	}
+	cooldown := m.BreakerCooldown
+	if cooldown <= 0 {
+		cooldown = defaultBreakerCooldown
+	}
+	now := m.nowFn()
+	elapsed := now.Sub(m.breaker.openedAt)
+	if elapsed >= cooldown {
+		// Cooldown elapsed — clear breaker. Hits stay so the next
+		// transient 503 cluster can still trip again quickly.
+		m.breaker.openedAt = time.Time{}
+		// Drop hits older than the window so the next trip count
+		// starts fresh from a clean slate after cooldown.
+		m.breaker.hits = nil
+		return false, 0
+	}
+	return true, cooldown - elapsed
+}
+
+// breakerRecordRateLimit appends a 503-5.5.1 timestamp to the sliding
+// window and returns true if the recorded event tripped the breaker
+// (i.e. trip-count consecutive 503s within BreakerWindow). When it
+// returns true the openedAt clock is set so subsequent Send calls
+// short-circuit to ErrCircuitOpen until cooldown elapses.
+func (m *Mailer) breakerRecordRateLimit() bool {
+	m.breaker.mu.Lock()
+	defer m.breaker.mu.Unlock()
+
+	window := m.BreakerWindow
+	if window <= 0 {
+		window = defaultBreakerWindow
+	}
+	trip := m.BreakerTrip
+	if trip <= 0 {
+		trip = defaultBreakerTrip
+	}
+
+	now := m.nowFn()
+	cutoff := now.Add(-window)
+
+	// Drop hits older than the window. O(n) per insert is fine —
+	// trip count is small (3) and 90s window holds at most a few
+	// dozen entries even under storm conditions.
+	kept := m.breaker.hits[:0]
+	for _, t := range m.breaker.hits {
+		if t.After(cutoff) {
+			kept = append(kept, t)
+		}
+	}
+	m.breaker.hits = append(kept, now)
+
+	if len(m.breaker.hits) >= trip {
+		m.breaker.openedAt = now
+		return true
+	}
+	return false
+}
+
+// breakerResetOnSuccess clears the in-window hit count after a
+// successful send. This implements "consecutive 503s" semantics: a
+// single 250 OK between rate-limit storms restarts the trip counter.
+//
+// The openedAt instant is NOT cleared here — once the breaker has
+// opened, only the cooldown elapsing in breakerStateNow re-enables
+// sends. This avoids a thundering-herd retry the moment one tenant's
+// send happens to succeed in a parallel goroutine.
+func (m *Mailer) breakerResetOnSuccess() {
+	m.breaker.mu.Lock()
+	defer m.breaker.mu.Unlock()
+	m.breaker.hits = nil
+}
+
+// breakerTripCount + breakerWindowDuration are read-side helpers used
+// by structured logs; both take the lock briefly.
+func (m *Mailer) breakerTripCount() int {
+	m.breaker.mu.Lock()
+	defer m.breaker.mu.Unlock()
+	return len(m.breaker.hits)
+}
+
+func (m *Mailer) breakerWindowDuration() time.Duration {
+	if m.BreakerWindow <= 0 {
+		return defaultBreakerWindow
+	}
+	return m.BreakerWindow
+}
+
+// nowFn returns the (test-overridable) current time. Production wires
+// time.Now via NewMailer.
+func (m *Mailer) nowFn() time.Time {
+	if m.now != nil {
+		return m.now()
+	}
+	return time.Now()
 }
 
 // isRateLimit reports whether err is Stalwart's "503 5.5.1" rate-limit

--- a/core/services/notification/handlers/smtp_test.go
+++ b/core/services/notification/handlers/smtp_test.go
@@ -45,25 +45,62 @@ func (r *recordingSleep) sleep(d time.Duration) {
 	r.wallSum += d
 }
 
+// fixedNow returns a controllable now() seam for breaker tests. Each
+// call returns the t value, which the caller advances explicitly via
+// the returned advance() closure. Used to step past BreakerCooldown
+// without sleeping.
+func fixedNow() (now func() time.Time, advance func(time.Duration), set func(time.Time)) {
+	var (
+		mu sync.Mutex
+		t  = time.Date(2026, 5, 19, 12, 0, 0, 0, time.UTC)
+	)
+	now = func() time.Time {
+		mu.Lock()
+		defer mu.Unlock()
+		return t
+	}
+	advance = func(d time.Duration) {
+		mu.Lock()
+		defer mu.Unlock()
+		t = t.Add(d)
+	}
+	set = func(v time.Time) {
+		mu.Lock()
+		defer mu.Unlock()
+		t = v
+	}
+	return
+}
+
+// newTestMailer builds a Mailer with all seams wired for unit tests.
+// Defaults: 3 retries, 30s base / 5min max backoff, breaker 3-in-90s.
+func newTestMailer(fs *fakeSendMail, rs *recordingSleep, now func() time.Time) *Mailer {
+	return &Mailer{
+		Host:            "stalwart.test",
+		Port:            "25",
+		From:            "noreply@openova.io",
+		BaseBackoff:     30 * time.Second,
+		MaxBackoff:      5 * time.Minute,
+		MaxRetries:      3,
+		BreakerTrip:     3,
+		BreakerWindow:   90 * time.Second,
+		BreakerCooldown: 120 * time.Second,
+		sendMail:        fs.send,
+		sleep:           rs.sleep,
+		now:             now,
+	}
+}
+
 // TestMailerSend_RateLimitRetrySucceeds asserts that when Stalwart
-// returns 503 5.5.1 on the first attempt and then 250 OK on the second,
-// Send retries with the configured backoff and returns nil. Verifies
-// the slog "rate-limit backoff" log line by way of the call count +
-// recorded backoff waits.
+// returns 503 5.5.1 on the first attempt and then 250 OK on the
+// second, Send retries with the base backoff and returns nil.
 func TestMailerSend_RateLimitRetrySucceeds(t *testing.T) {
 	rateLimitErr := &textproto.Error{Code: 503, Msg: "5.5.1 Too many messages"}
 	fs := &fakeSendMail{errs: []error{rateLimitErr, nil}}
 	rs := &recordingSleep{}
+	now, _, _ := fixedNow()
 
-	m := &Mailer{
-		Host:         "stalwart.test",
-		Port:         "25",
-		From:         "noreply@openova.io",
-		RetryBackoff: 60 * time.Second,
-		MaxRetries:   3,
-		sendMail:     fs.send,
-		sleep:        rs.sleep,
-	}
+	m := newTestMailer(fs, rs, now)
 
 	if err := m.Send("to@example.test", "Subject", "<p>body</p>"); err != nil {
 		t.Fatalf("Send returned error after successful retry: %v", err)
@@ -74,50 +111,184 @@ func TestMailerSend_RateLimitRetrySucceeds(t *testing.T) {
 	if len(rs.waits) != 1 {
 		t.Fatalf("sleep called %d times, want exactly 1 backoff", len(rs.waits))
 	}
-	if rs.waits[0] != 60*time.Second {
-		t.Errorf("backoff = %v, want 60s", rs.waits[0])
+	if rs.waits[0] != 30*time.Second {
+		t.Errorf("backoff = %v, want 30s (base, attempt 1)", rs.waits[0])
 	}
 }
 
-// TestMailerSend_RateLimitExhaustsRetries asserts that after MaxRetries
-// 503 5.5.1 responses, Send returns a wrapped error and the total
-// number of backoff sleeps is MaxRetries-1 (no sleep after the final
-// failed attempt).
-func TestMailerSend_RateLimitExhaustsRetries(t *testing.T) {
-	rateLimitErr := &textproto.Error{Code: 503, Msg: "5.5.1 Rate limit exceeded"}
-	fs := &fakeSendMail{errs: []error{rateLimitErr, rateLimitErr, rateLimitErr}}
+// TestMailerSend_ExponentialBackoff asserts that when the upstream
+// returns 503 5.5.1 then 503 5.5.1 then 250 OK, two backoffs are
+// recorded and the second is double the first (exponential).
+func TestMailerSend_ExponentialBackoff(t *testing.T) {
+	rateLimitErr := &textproto.Error{Code: 503, Msg: "5.5.1 Too many messages"}
+	fs := &fakeSendMail{errs: []error{rateLimitErr, rateLimitErr, nil}}
 	rs := &recordingSleep{}
+	now, _, _ := fixedNow()
 
-	m := &Mailer{
-		Host:         "stalwart.test",
-		Port:         "25",
-		From:         "noreply@openova.io",
-		RetryBackoff: 30 * time.Second,
-		MaxRetries:   3,
-		sendMail:     fs.send,
-		sleep:        rs.sleep,
+	// Allow 4 attempts so we observe the doubling without tripping
+	// the 3-in-window breaker on the second 503.
+	m := newTestMailer(fs, rs, now)
+	m.MaxRetries = 4
+	m.BreakerTrip = 99 // disable breaker for this test
+
+	if err := m.Send("to@example.test", "Subject", "<p>body</p>"); err != nil {
+		t.Fatalf("Send returned error after successful retry: %v", err)
 	}
+	if fs.calls != 3 {
+		t.Errorf("sendMail called %d times, want 3 (two fail, one ok)", fs.calls)
+	}
+	if len(rs.waits) != 2 {
+		t.Fatalf("sleep called %d times, want 2 backoffs", len(rs.waits))
+	}
+	if rs.waits[0] != 30*time.Second {
+		t.Errorf("backoff[0] = %v, want 30s (base)", rs.waits[0])
+	}
+	if rs.waits[1] != 60*time.Second {
+		t.Errorf("backoff[1] = %v, want 60s (2x base — exponential)", rs.waits[1])
+	}
+}
+
+// TestMailerSend_BackoffCapped asserts that exponential growth is
+// capped at MaxBackoff so a long-running storm never sleeps for more
+// than MaxBackoff per attempt.
+func TestMailerSend_BackoffCapped(t *testing.T) {
+	rateLimitErr := &textproto.Error{Code: 503, Msg: "5.5.1 Too many messages"}
+	// Many 503s; eventually a success so the loop exits cleanly.
+	fs := &fakeSendMail{errs: []error{
+		rateLimitErr, rateLimitErr, rateLimitErr, rateLimitErr, rateLimitErr, nil,
+	}}
+	rs := &recordingSleep{}
+	now, _, _ := fixedNow()
+
+	m := newTestMailer(fs, rs, now)
+	m.MaxRetries = 6
+	m.MaxBackoff = 90 * time.Second
+	m.BreakerTrip = 99 // disable breaker
+
+	if err := m.Send("to@example.test", "Subject", "<p>body</p>"); err != nil {
+		t.Fatalf("Send returned error after successful retry: %v", err)
+	}
+	// 5 backoffs expected (between 5 fails and 1 success).
+	if len(rs.waits) != 5 {
+		t.Fatalf("got %d backoffs, want 5: %v", len(rs.waits), rs.waits)
+	}
+	// 30, 60, 90 (cap), 90 (cap), 90 (cap)
+	wantWaits := []time.Duration{30 * time.Second, 60 * time.Second, 90 * time.Second, 90 * time.Second, 90 * time.Second}
+	for i, w := range rs.waits {
+		if w != wantWaits[i] {
+			t.Errorf("backoff[%d] = %v, want %v", i, w, wantWaits[i])
+		}
+	}
+}
+
+// TestMailerSend_CircuitBreakerTrips asserts that after BreakerTrip
+// consecutive 503 5.5.1s within BreakerWindow the breaker opens and
+// the in-flight Send aborts the rest of its retry budget.
+func TestMailerSend_CircuitBreakerTrips(t *testing.T) {
+	rateLimitErr := &textproto.Error{Code: 503, Msg: "5.5.1 Rate limit exceeded"}
+	fs := &fakeSendMail{errs: []error{rateLimitErr, rateLimitErr, rateLimitErr, rateLimitErr}}
+	rs := &recordingSleep{}
+	now, _, _ := fixedNow()
+
+	m := newTestMailer(fs, rs, now)
+	m.MaxRetries = 5
 
 	err := m.Send("to@example.test", "Subject", "<p>body</p>")
 	if err == nil {
-		t.Fatal("Send returned nil after exhausted retries; want wrapped error")
+		t.Fatal("Send returned nil after breaker tripped; want wrapped error")
 	}
-	if !strings.Contains(err.Error(), "rate-limited after 3 attempts") {
-		t.Errorf("error %q missing rate-limit summary", err.Error())
-	}
-	// Underlying *textproto.Error must remain reachable via errors.Is/As.
-	var te *textproto.Error
-	if !errors.As(err, &te) {
-		t.Error("returned error does not unwrap to *textproto.Error")
+	if !errors.Is(err, ErrCircuitOpen) {
+		t.Errorf("error %q does not unwrap to ErrCircuitOpen", err.Error())
 	}
 	if fs.calls != 3 {
-		t.Errorf("sendMail called %d times, want 3 (= MaxRetries)", fs.calls)
+		t.Errorf("sendMail called %d times, want exactly 3 (breaker trips at trip-th hit)", fs.calls)
 	}
-	if len(rs.waits) != 2 {
-		t.Errorf("sleep called %d times, want 2 (between attempts 1->2 and 2->3)", len(rs.waits))
+}
+
+// TestMailerSend_CircuitBreakerShortCircuits asserts that once the
+// breaker is open, subsequent Send calls return ErrCircuitOpen
+// immediately without calling sendMail.
+func TestMailerSend_CircuitBreakerShortCircuits(t *testing.T) {
+	rateLimitErr := &textproto.Error{Code: 503, Msg: "5.5.1 Rate limit exceeded"}
+	fs := &fakeSendMail{errs: []error{rateLimitErr, rateLimitErr, rateLimitErr, rateLimitErr}}
+	rs := &recordingSleep{}
+	now, _, _ := fixedNow()
+
+	m := newTestMailer(fs, rs, now)
+	m.MaxRetries = 5
+
+	// Trip the breaker.
+	if err := m.Send("to1@example.test", "S", "<p>b</p>"); err == nil {
+		t.Fatal("first Send should fail with breaker open")
 	}
-	if rs.wallSum != 60*time.Second {
-		t.Errorf("total backoff = %v, want 60s (2 * 30s)", rs.wallSum)
+	openedCalls := fs.calls
+
+	// Second Send: should short-circuit immediately, sendMail count
+	// must not advance.
+	err := m.Send("to2@example.test", "S", "<p>b</p>")
+	if !errors.Is(err, ErrCircuitOpen) {
+		t.Errorf("second Send returned %v, want ErrCircuitOpen", err)
+	}
+	if fs.calls != openedCalls {
+		t.Errorf("sendMail called %d more times after breaker open; want 0 more", fs.calls-openedCalls)
+	}
+}
+
+// TestMailerSend_CircuitBreakerCooldownElapses asserts that after the
+// cooldown window the breaker re-closes and a subsequent send hits
+// the upstream again.
+func TestMailerSend_CircuitBreakerCooldownElapses(t *testing.T) {
+	rateLimitErr := &textproto.Error{Code: 503, Msg: "5.5.1 Rate limit exceeded"}
+	// First call: 3 503s → trip breaker. Next call after cooldown:
+	// 250 OK on the first attempt.
+	fs := &fakeSendMail{errs: []error{rateLimitErr, rateLimitErr, rateLimitErr, nil}}
+	rs := &recordingSleep{}
+	now, advance, _ := fixedNow()
+
+	m := newTestMailer(fs, rs, now)
+	m.MaxRetries = 3
+
+	// Trip.
+	if err := m.Send("to1@example.test", "S", "<p>b</p>"); err == nil {
+		t.Fatal("first Send should fail with breaker open")
+	}
+
+	// Mid-cooldown: still short-circuited.
+	advance(60 * time.Second)
+	if err := m.Send("to2@example.test", "S", "<p>b</p>"); !errors.Is(err, ErrCircuitOpen) {
+		t.Errorf("mid-cooldown Send = %v, want ErrCircuitOpen", err)
+	}
+
+	// Past cooldown (120s): breaker re-closes, sendMail runs again.
+	advance(61 * time.Second) // total 121s past trip
+	if err := m.Send("to3@example.test", "S", "<p>b</p>"); err != nil {
+		t.Fatalf("post-cooldown Send returned %v; want nil after breaker reset", err)
+	}
+}
+
+// TestMailerSend_BreakerWindowAgesOut asserts that 503s older than
+// BreakerWindow do not count toward the trip — a slow drip of one
+// rate-limit every minute should never open the breaker.
+func TestMailerSend_BreakerWindowAgesOut(t *testing.T) {
+	rateLimitErr := &textproto.Error{Code: 503, Msg: "5.5.1"}
+	// 3 alternating fail/success — each fail ages out the prior one
+	// because we advance >window between calls.
+	fs := &fakeSendMail{errs: []error{rateLimitErr, nil, rateLimitErr, nil, rateLimitErr, nil}}
+	rs := &recordingSleep{}
+	now, advance, _ := fixedNow()
+
+	m := newTestMailer(fs, rs, now)
+	m.MaxRetries = 2
+
+	for i := 0; i < 3; i++ {
+		if err := m.Send("to@example.test", "S", "<p>b</p>"); err != nil {
+			t.Fatalf("iter %d: Send returned %v; want nil (retry succeeded)", i, err)
+		}
+		advance(2 * time.Minute) // > 90s window
+	}
+	// Breaker must not be open at the end.
+	if open, _ := m.breakerStateNow(); open {
+		t.Error("breaker is open; want closed after slow-drip 503s aged out of window")
 	}
 }
 
@@ -128,16 +299,9 @@ func TestMailerSend_NonRateLimitErrorReturnsImmediately(t *testing.T) {
 	authErr := &textproto.Error{Code: 535, Msg: "5.7.8 Authentication credentials invalid"}
 	fs := &fakeSendMail{errs: []error{authErr, nil}}
 	rs := &recordingSleep{}
+	now, _, _ := fixedNow()
 
-	m := &Mailer{
-		Host:         "stalwart.test",
-		Port:         "25",
-		From:         "noreply@openova.io",
-		RetryBackoff: 60 * time.Second,
-		MaxRetries:   3,
-		sendMail:     fs.send,
-		sleep:        rs.sleep,
-	}
+	m := newTestMailer(fs, rs, now)
 
 	err := m.Send("to@example.test", "Subject", "<p>body</p>")
 	if err == nil {
@@ -148,6 +312,36 @@ func TestMailerSend_NonRateLimitErrorReturnsImmediately(t *testing.T) {
 	}
 	if len(rs.waits) != 0 {
 		t.Errorf("sleep called %d times, want 0 (no backoff for non-rate-limit)", len(rs.waits))
+	}
+}
+
+// TestMailerSend_RateLimitExhaustsRetries — with breaker disabled,
+// MaxRetries 503s in a row return the rate-limited wrap error.
+func TestMailerSend_RateLimitExhaustsRetries(t *testing.T) {
+	rateLimitErr := &textproto.Error{Code: 503, Msg: "5.5.1 Rate limit exceeded"}
+	fs := &fakeSendMail{errs: []error{rateLimitErr, rateLimitErr, rateLimitErr}}
+	rs := &recordingSleep{}
+	now, _, _ := fixedNow()
+
+	m := newTestMailer(fs, rs, now)
+	m.BreakerTrip = 99 // disable breaker to isolate retry-exhaustion path
+
+	err := m.Send("to@example.test", "Subject", "<p>body</p>")
+	if err == nil {
+		t.Fatal("Send returned nil after exhausted retries; want wrapped error")
+	}
+	if !strings.Contains(err.Error(), "rate-limited after 3 attempts") {
+		t.Errorf("error %q missing rate-limit summary", err.Error())
+	}
+	if fs.calls != 3 {
+		t.Errorf("sendMail called %d times, want 3 (= MaxRetries)", fs.calls)
+	}
+	if len(rs.waits) != 2 {
+		t.Errorf("sleep called %d times, want 2 (between attempts 1->2 and 2->3)", len(rs.waits))
+	}
+	// Exponential: 30s + 60s = 90s total.
+	if rs.wallSum != 90*time.Second {
+		t.Errorf("total backoff = %v, want 90s (30 + 60 exponential)", rs.wallSum)
 	}
 }
 
@@ -183,15 +377,15 @@ func TestParseRetryBackoff(t *testing.T) {
 		raw  string
 		want time.Duration
 	}{
-		{"", 60 * time.Second},             // unset -> default
-		{"60s", 60 * time.Second},          // explicit Go duration
-		{"2m", 2 * time.Minute},            // larger duration
-		{"45", 45 * time.Second},           // bare integer = seconds
-		{"10s", 30 * time.Second},          // below floor -> floor
-		{"5", 30 * time.Second},            // bare-int below floor -> floor
-		{"garbage", 60 * time.Second},      // unparseable -> default
-		{"-1", 60 * time.Second},           // negative bare-int -> default
-		{"0", 60 * time.Second},            // zero bare-int -> default (n>0 guard)
+		{"", 30 * time.Second},        // unset -> default base
+		{"60s", 60 * time.Second},     // explicit Go duration
+		{"2m", 2 * time.Minute},       // larger duration
+		{"45", 45 * time.Second},      // bare integer = seconds
+		{"10s", 30 * time.Second},     // below floor -> floor
+		{"5", 30 * time.Second},       // bare-int below floor -> floor
+		{"garbage", 30 * time.Second}, // unparseable -> default
+		{"-1", 30 * time.Second},      // negative bare-int -> default
+		{"0", 30 * time.Second},       // zero bare-int -> default (n>0 guard)
 	}
 	for _, tc := range cases {
 		t.Run(tc.raw, func(t *testing.T) {
@@ -201,4 +395,22 @@ func TestParseRetryBackoff(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestBuildAuth covers SMTP auth construction across the
+// neither / user-only / pass-only / both cases.
+func TestBuildAuth(t *testing.T) {
+	withEnv := func(t *testing.T, user, pass string, want bool) {
+		t.Helper()
+		t.Setenv("SMTP_USER", user)
+		t.Setenv("SMTP_PASS", pass)
+		got := buildAuth("stalwart.test")
+		if (got != nil) != want {
+			t.Errorf("buildAuth(user=%q, pass=%q) returned non-nil=%v, want %v", user, pass, got != nil, want)
+		}
+	}
+	t.Run("neither", func(t *testing.T) { withEnv(t, "", "", false) })
+	t.Run("user-only", func(t *testing.T) { withEnv(t, "u", "", false) })
+	t.Run("pass-only", func(t *testing.T) { withEnv(t, "", "p", false) })
+	t.Run("both", func(t *testing.T) { withEnv(t, "u", "p", true) })
 }


### PR DESCRIPTION
## Summary

Wave 35 SMTP diagnostic root cause: \`sme-secrets\` lost \`SMTP_USERNAME\` / \`SMTP_PASSWORD\` after sme stack redeploy. Notification pod's \`net/smtp\` falls back to no-auth (Mailer.Auth was always nil, and main.go never read SMTP_USER/SMTP_PASS from env) -> Stalwart 503 5.5.1 "You must authenticate first" -> fixed-60s retry loop slammed the relay 3x per message x 5 tenants and tripped Stalwart's [5 requests, 1000ms] rate-limiter for the whole submission listener.

This PR is the **notification-side** half of the TBD-X1 fix (chart-side wiring + SMTP_USER/PASS plumbing into the notification Deployment ships in a separate PR).

### Changes
1. **Mailer.Auth wired** via \`smtp.PlainAuth(SMTP_USER, SMTP_PASS, host)\` read from env in \`NewMailer\`. Either-or-neither half-config -> \`slog.Warn\` + fall back to no-auth (loud-fail on next 503 instead of silent half-broken creds).
2. **Exponential backoff** with 30s floor (issue spec) and 5-min cap: 30s -> 60s -> 120s -> 240s -> 300s. Replaces the prior fixed 60s wait.
3. **Circuit breaker** (issue spec): 3 consecutive 503 5.5.1s inside a 90s sliding window open the breaker. While open, \`Send()\` short-circuits to \`ErrCircuitOpen\` for 120s cooldown. Window aging means slow drips never trip; a successful send resets the consecutive counter.

### Test plan
- [x] \`go test ./core/services/notification/...\` (PASS — 11 test cases incl. new exponential-backoff, breaker-trips, breaker-cooldown-elapses, window-ages-out)
- [x] \`go vet ./...\` clean
- [x] Backward-compat: existing TestMailerSend_NonRateLimitErrorReturnsImmediately + TestIsRateLimit_TextprotoError still pass
- [ ] Runtime verification: deploy services-notification image with new code, force Stalwart 503 5.5.1 storm via missing creds + observe breaker opens after 3rd 503 within 90s, NACK count climbs, and after cooldown the breaker re-closes on first 250 OK

Refs #1793

Companion: notification.yaml chart template adds SMTP_USER + SMTP_PASS env wiring (separate PR for atomic, reviewable scope).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>