### PR TITLE
fix(catalyst-chart): propagate SMTP_USER/SMTP_PASS into notification Pod (TBD-X1)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -608,7 +608,7 @@ spec:
       # during the YAML scanner break introduced by PR #1858 and fixed
       # by PR #1866. Auto-bump-pin step didn't fire during the outage,
       # so this pin lagged by 2 versions. Refs #1864.
-      version: 1.4.186
+      version: 1.4.187
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -1,5 +1,19 @@
 apiVersion: v2
 name: bp-catalyst-platform
+# 1.4.187 — TBD-X1 (issue #1793) notification.yaml SMTP_USER / SMTP_PASS
+# env wiring. Pre-fix the notification Pod read only SMTP_HOST / PORT /
+# FROM from sme-secrets, so the Go net/smtp client dialed Stalwart
+# without authentication. After every sme stack redeploy the missing
+# auth path returned 503 5.5.1 "You must authenticate first"; the old
+# fixed-60s retry loop (now upgraded to exponential backoff + circuit
+# breaker in services-notification, Refs PR companion) slammed the
+# relay 3x per message x 5 tenants and tripped Stalwart's
+# [5 requests, 1000ms] rate-limiter for every tenant on the same relay.
+# Fix is one-symmetry-line with auth.yaml which has consumed SMTP_USER
+# + SMTP_PASS from sme-secrets since chart 1.4.20 (#934). The
+# sme-secrets template's source-wins lookup against catalyst-system/
+# sovereign-smtp-credentials already populates the values from the
+# mothership-relay (Phase-1) or bp-stalwart-sovereign (Phase-2).
 # 1.4.186 — TBD-A45 (issue #1908) catalyst-api egress to secondary CP
 # :6443 unblocked. baseline-default-deny CNP world-egress block
 # previously allowed only 443/587/465/25 — catalyst-api fan-out to
@@ -1294,7 +1308,7 @@ name: bp-catalyst-platform
 # 25/TCP (legacy SMTP fallback). All three are explicitly scoped to
 # `toEntities: world`, matching the existing 443/TCP allow. No other
 # rule semantics change. (Fixes PIN-issue 502 regression from #1785.)
-version: 1.4.186
+version: 1.4.187
 appVersion: 1.4.184
 # 1.4.183 — fix(httproute): omit default sectionName so multi-zone
 # Sovereigns attach via Cilium Gateway hostname matcher (Closes #1884,

--- a/products/catalyst/chart/templates/sme-services/notification.yaml
+++ b/products/catalyst/chart/templates/sme-services/notification.yaml
@@ -64,6 +64,33 @@ spec:
                 secretKeyRef:
                   name: sme-secrets
                   key: SMTP_FROM
+            # SMTP_USER / SMTP_PASS — added per TBD-X1 (Refs #1793).
+            # Pre-fix the notification Pod read only HOST/PORT/FROM
+            # which meant the Go net/smtp client dialed Stalwart
+            # without authentication; Stalwart's submission listener
+            # then rejected every message with 503 5.5.1 "You must
+            # authenticate first". The tight retry storm tripped
+            # Stalwart's [5 requests, 1000ms] rate-limiter for every
+            # tenant on the same relay.
+            #
+            # The auth.yaml template has consumed these two keys
+            # from sme-secrets since chart 1.4.20 (issue #934); this
+            # template was an oversight from the same change-set.
+            # The sme-secrets template's source-wins lookup against
+            # catalyst-system/sovereign-smtp-credentials already
+            # populates SMTP_USER + SMTP_PASS with the canonical
+            # mothership-relay credentials (Phase-1) or the
+            # bp-stalwart-sovereign-minted credentials (Phase-2).
+            - name: SMTP_USER
+              valueFrom:
+                secretKeyRef:
+                  name: sme-secrets
+                  key: SMTP_USER
+            - name: SMTP_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: sme-secrets
+                  key: SMTP_PASS
             - name: CORS_ORIGIN
               value: "https://sme.openova.io"
           resources:


### PR DESCRIPTION
## Summary

Wave 35 SMTP diagnostic root cause: \`notification.yaml\` only mounted \`SMTP_HOST\` / \`SMTP_PORT\` / \`SMTP_FROM\` from \`sme-secrets\`, so the Go \`net/smtp\` client dialed Stalwart without authentication. Stalwart's submission listener rejected every message with \`503 5.5.1\` "You must authenticate first" -> the (pre-companion-PR) fixed-60s retry storm slammed the relay 3x per message x 5 tenants and tripped Stalwart's \`[5 requests, 1000ms]\` rate-limiter for every tenant on the same relay.

Fix is a one-symmetry-line with \`auth.yaml\`, which has consumed \`SMTP_USER\` and \`SMTP_PASS\` from \`sme-secrets\` since chart 1.4.20 (#934). The notification template was an oversight from the same change-set.

### Canonical SMTP credential propagation chain (unchanged here)

\`\`\`
mothership catalyst-openova-kc-credentials (keys: smtp-user/smtp-pass)
  -> sovereign_smtp_seed.go SeedSovereignSMTPCredentials creates
     catalyst-system/sovereign-smtp-credentials on the new Sovereign
     (Phase-1, idempotent)
  -> sme-secrets.yaml lookup with source-wins precedence reads
     smtp-user / smtp-pass and emits SMTP_USER / SMTP_PASS keys in
     the per-tenant sme-secrets Secret
  -> auth.yaml AND (now, this PR) notification.yaml mount those two
     keys via secretKeyRef -> notification main.go reads SMTP_USER +
     SMTP_PASS via getEnv() -> buildAuth wires smtp.PlainAuth on every
     Send (companion PR services-notification smtp.go #1914).
\`\`\`

### Verification

\`\`\`bash
helm template test-render products/catalyst/chart \\
  --set ingress.marketplace.enabled=true | grep SMTP_USER -A2
\`\`\`

Shows both \`auth.yaml\` AND \`notification.yaml\` mount \`SMTP_USER\` from \`sme-secrets\` keyed \`SMTP_USER\` (verified locally with helm 3.20.2).

### Chart version

Bump \`1.4.186\` -> \`1.4.187\` per chart-release discipline. Header comment block records the TBD-X1 reason.

### Test plan
- [x] \`helm template ... | grep SMTP_USER\` shows notification env mounts SMTP_USER + SMTP_PASS
- [x] \`auth.yaml\` env block unchanged (already had SMTP_USER + SMTP_PASS)
- [x] \`sme-secrets.yaml\` template unchanged (source-wins lookup already produces SMTP_USER + SMTP_PASS keys)
- [ ] Runtime verification on fresh prov: confirm notification Pod \`env\` shows both vars; \`smtp.PlainAuth\` succeeds against mothership relay (no 503 5.5.1 in slog)

Refs #1793

Companion: \`services-notification\` smtp.go upgrade to exponential backoff + 3-in-90s circuit breaker -> PR #1914.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>