### PR TITLE
feat(catalyst-api): publish catalyst.tenant.sandbox_requested on Sandbox create (TBD-D35b, Closes #1776)

### DIFF
--- a/products/catalyst/bootstrap/api/cmd/api/main.go
+++ b/products/catalyst/bootstrap/api/cmd/api/main.go
@@ -357,6 +357,16 @@ func main() {
 	h.SetAuditBus(auditBus)
 	log.Info("audit: bus wired", "ringCapacity", auditRingCap)
 
+	// TBD-D35b / #1776 — Sandbox-create NATS publish. Wires a
+	// `catalyst.tenant.*` publisher when CATALYST_NATS_URL is set so
+	// every Sandbox CR Create leaves a corresponding
+	// `catalyst.tenant.sandbox_requested` event on the audit stream.
+	// Returns nil today (placeholder mirroring newRBACAuditPublisher
+	// FromEnv); the real nats.go-importing publisher lands in the
+	// same follow-up slice that swaps the RBAC stub. Nil is safe:
+	// the sandbox_sessions handler treats a nil publisher as a no-op.
+	h.SetTenantEventPublisher(newTenantEventPublisherFromEnv(log))
+
 	// CATALYST_SME_JWT_SECRET — bridge secret for /api/v1/sme/* proxies
 	// (PR #1625 follow-up). The chart's api-deployment.yaml feeds this
 	// via secretKeyRef on `sme-secrets/JWT_SECRET`, mirrored from the
@@ -1462,6 +1472,34 @@ func newRBACAuditPublisherFromEnv(log *slog.Logger) audit.Publisher {
 	// nats.go-importing follow-up slice replaces this stub with a
 	// real publisher. The wiring contract (env vars + Bus.Publisher
 	// field) is intact.
+	return nil
+}
+
+// newTenantEventPublisherFromEnv constructs the cross-process forwarder
+// for the `catalyst.tenant.*` event taxonomy used by the
+// sandbox_sessions handler (TBD-D35b / #1776). Currently returns nil
+// (no publisher) because catalyst-api ships without the `nats.go` SDK
+// in its go.mod — mirrors the `newRBACAuditPublisherFromEnv` placeholder
+// pattern. Production adoption of NATS forwarding lands in a follow-up
+// slice that imports `nats.go` directly. Until then, the handler runs
+// in publish-disabled mode: the Sandbox CR Create still succeeds + the
+// FE still observes the new sandbox, but the `catalyst.tenant.sandbox_
+// requested` event is not emitted (matching the pre-fix behaviour).
+//
+// Per ADR-0001 §6 the subject taxonomy is `catalyst.tenant.<event>`.
+// Per docs/INVIOLABLE-PRINCIPLES.md #4 the URL is env-driven.
+func newTenantEventPublisherFromEnv(log *slog.Logger) handler.TenantEventPublisher {
+	url := os.Getenv("CATALYST_NATS_URL")
+	if url == "" {
+		return nil
+	}
+	subjectPrefix := env("CATALYST_TENANT_NATS_SUBJECT_PREFIX", "catalyst.tenant")
+	log.Info("tenant-events: NATS publisher placeholder wired (forwarding will land in follow-up slice)",
+		"url", url, "subjectPrefix", subjectPrefix,
+	)
+	// Returning nil keeps the handler in publish-disabled mode until
+	// the nats.go-importing follow-up slice replaces this stub. The
+	// wiring contract (env var + Handler.tenantEvents field) is intact.
 	return nil
 }
 

--- a/products/catalyst/bootstrap/api/internal/handler/handler.go
+++ b/products/catalyst/bootstrap/api/internal/handler/handler.go
@@ -412,6 +412,18 @@ type Handler struct {
 	// (in-process by default; tests inject a deterministic instance).
 	auditBus *audit.Bus
 
+	// ── Tenant-event publisher (TBD-D35b / #1776) ──────────────────
+	// tenantEvents — NATS publisher for the `catalyst.tenant.*` event
+	// taxonomy (per ADR-0001 §6 + core/services/shared/events/bridge.go
+	// CanonicalSubject). The sandbox_sessions.go handler publishes to
+	// `catalyst.tenant.sandbox_requested` after every successful
+	// Sandbox CR Create. Nil-tolerant: when nil the publish-side is a
+	// no-op so the Sandbox-create hot path never fails because NATS
+	// isn't wired. Wired from main.go at startup when
+	// CATALYST_NATS_URL is set; tests inject a recorder via
+	// SetTenantEventPublisher.
+	tenantEvents TenantEventPublisher
+
 	// ── Continuum DR clock (EPIC-6 #1101 slice U-DR-1) ─────────────
 	// continuumClock — test seam for the Continuum switchover/failback
 	// handlers. nil ⇒ time.Now. Tests inject a deterministic clock so
@@ -705,6 +717,18 @@ func (h *Handler) SetSMEJWTSecret(secret []byte) { h.smeJWTSecret = secret }
 
 // AuditBus returns the wired Bus or nil. Test helper.
 func (h *Handler) AuditBus() *audit.Bus { return h.auditBus }
+
+// SetTenantEventPublisher wires the NATS publisher used by the
+// sandbox_sessions.go handler (TBD-D35b / #1776). Called by main.go at
+// startup; tests inject a recorder directly. Nil is allowed and turns
+// the publish-side into a no-op so the Sandbox-create hot path stays
+// resilient when NATS isn't wired (CI, chroot without CATALYST_NATS_URL).
+func (h *Handler) SetTenantEventPublisher(p TenantEventPublisher) { h.tenantEvents = p }
+
+// TenantEventPublisherForTest returns the currently wired publisher
+// (nil when unset). Exported for tests so the assertion helper can
+// recover the recorder without re-importing the handler internals.
+func (h *Handler) TenantEventPublisherForTest() TenantEventPublisher { return h.tenantEvents }
 
 // SetMimirURL wires the bp-mimir (slot 23) query-frontend base URL the
 // Pod metrics sparkline path uses. Called by main.go at startup from

--- a/products/catalyst/bootstrap/api/internal/handler/sandbox_sessions.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sandbox_sessions.go
@@ -69,11 +69,14 @@ package handler
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"net/http"
 	"os"
 	"regexp"
+	"sort"
 	"strings"
 	"time"
 
@@ -86,6 +89,76 @@ import (
 
 	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/auth"
 )
+
+// ── NATS tenant-event publish (TBD-D35b / #1776) ────────────────────
+//
+// Per ADR-0001 §6 + core/services/shared/events/bridge.go's
+// CanonicalSubject() rule, tenant lifecycle events publish to subjects
+// under `catalyst.tenant.*`. Sandbox-controller already consumes this
+// taxonomy (see core/controllers/sandbox/internal/controller/nats_bridge.go),
+// so adding the publish on the catalyst-api side closes the audit-trail
+// loop: every Sandbox CR materialised on the Sovereign apiserver leaves
+// a corresponding NATS event the operator's audit log can replay.
+//
+// The Publisher interface is nil-tolerant by design: production main.go
+// wires a real publisher when CATALYST_NATS_URL is set (mirroring the
+// `newRBACAuditPublisherFromEnv` pattern); tests bind a recorder; CI
+// without NATS wiring leaves it nil and the publish-side is a no-op so
+// the Sandbox-create hot path never fails because audit isn't wired.
+
+// SandboxRequestedSubject is the canonical NATS subject the catalyst-api
+// emits to after a successful Sandbox CR Create. Sandbox-controller's
+// consumer list MUST contain this subject so the controller can correlate
+// FE-requested sandboxes with reconciler-observed CRs without scraping
+// the apiserver.
+const SandboxRequestedSubject = "catalyst.tenant.sandbox_requested"
+
+// TenantEvent is the on-the-wire payload published to the canonical
+// `catalyst.tenant.*` subjects. Field names mirror the shape downstream
+// consumers (sandbox-controller, audit-trail UI, billing rollup) already
+// parse from the audit.Event struct — but the subject is per-event so
+// consumers can subscribe at the `catalyst.tenant.sandbox_requested`
+// granularity without prefix matching.
+type TenantEvent struct {
+	// TenantID — the operator's Org slug (= namespace the CR lands in).
+	// Empty on a single-tenant chroot when claims.Org is not set; the
+	// payload falls back to the resolved namespace.
+	TenantID string `json:"tenant_id"`
+
+	// SandboxID — the Sandbox CR name (DNS-1123 label). Stable across
+	// the CR's lifetime; consumers key by this.
+	SandboxID string `json:"sandbox_id"`
+
+	// RequestedBy — the operator identity that authored the create.
+	// Email is preferred (operator-readable); falls back to the Keycloak
+	// subject UUID when email is not in the claims set.
+	RequestedBy string `json:"requested_by"`
+
+	// Timestamp — RFC3339 UTC at the moment the catalyst-api wrote the
+	// CR (NOT the apiserver creationTimestamp, which can lag by ms and
+	// is read back from the unstructured response).
+	Timestamp time.Time `json:"timestamp"`
+
+	// SpecHash — SHA-256 of the canonical JSON-serialised spec, hex-
+	// encoded. Lets consumers detect spec drift between the requested
+	// event and a later updated event without re-fetching the CR.
+	SpecHash string `json:"spec_hash"`
+}
+
+// TenantEventPublisher publishes tenant lifecycle events to NATS. The
+// subject is passed explicitly per-call (vs the audit.Publisher pattern
+// where the subject is fixed in the impl) so this one interface covers
+// every `catalyst.tenant.*` event without needing a method per subject.
+//
+// Production main.go binds this to a real NATS-JetStream client when
+// CATALYST_NATS_URL is set; tests bind a recorder. Nil-tolerant on the
+// caller side — see HandleCreateSandboxSession's publish guard.
+type TenantEventPublisher interface {
+	// PublishTenantEvent writes ev to the given NATS subject. MUST NOT
+	// panic on error; production callers log and continue so a
+	// transient NATS outage never wedges the Sandbox-create hot path.
+	PublishTenantEvent(ctx context.Context, subject string, ev TenantEvent) error
+}
 
 // ── Sandbox CRD GVR ─────────────────────────────────────────────────
 //
@@ -447,7 +520,152 @@ func (h *Handler) HandleCreateSandboxSession(w http.ResponseWriter, r *http.Requ
 		"owner_sub", claims.Sub,
 		"org", orgSlug,
 	)
+
+	// Publish catalyst.tenant.sandbox_requested for the audit trail +
+	// cross-component consumers (TBD-D35b / #1776). Best-effort: a NATS
+	// outage MUST NOT fail the HTTP response — the CR has already been
+	// written, so the operator's UI already shows the new sandbox. The
+	// publish-side log captures publish failures for the
+	// audit-completeness alert in the SRE runbook.
+	h.publishSandboxRequested(r.Context(), obj, ns, claims, orgSlug)
+
 	writeJSON(w, http.StatusCreated, unstructuredToSandboxItem(created))
+}
+
+// publishSandboxRequested emits a NATS event on
+// `catalyst.tenant.sandbox_requested` after a successful Sandbox CR
+// Create. Nil-tolerant: when the publisher isn't wired (CI / chroot
+// without CATALYST_NATS_URL) this is a no-op. Errors are logged but
+// never propagated — the CR write has already succeeded by the time
+// this runs.
+//
+// `obj` is the unstructured the handler authored (NOT the apiserver
+// response) so the spec_hash is deterministic across the read-back
+// jitter the apiserver injects (defaults / managedFields / RV).
+func (h *Handler) publishSandboxRequested(
+	ctx context.Context,
+	obj *unstructured.Unstructured,
+	namespace string,
+	claims *auth.Claims,
+	orgSlug string,
+) {
+	if h == nil || h.tenantEvents == nil {
+		return
+	}
+	if obj == nil {
+		return
+	}
+
+	// Tenant identity resolution: claims.Org wins (multi-tenant
+	// Sovereign), then the resolved namespace (single-tenant chroot
+	// fallback — the namespace IS the tenant boundary). orgSlug is
+	// the CRD-pattern-valid label stamped on `spec.owner.orgRef.slug`
+	// and may collapse to "default" when the operator's Org doesn't
+	// satisfy `^[a-z][a-z0-9-]{2,31}$`; using it as the tenant id
+	// would conflate every non-pattern-matching Org under a single
+	// downstream key, so we deliberately prefer the namespace.
+	tenantID := ""
+	if claims != nil {
+		tenantID = strings.TrimSpace(claims.Org)
+	}
+	if tenantID == "" {
+		tenantID = strings.TrimSpace(namespace)
+	}
+	if tenantID == "" {
+		// Last-resort: the orgSlug (which itself falls back to
+		// "default"). Keeps the field non-empty so consumers can index
+		// by it without nil checks.
+		tenantID = strings.TrimSpace(orgSlug)
+	}
+
+	requestedBy := ""
+	if claims != nil {
+		if e := strings.TrimSpace(claims.Email); e != "" {
+			requestedBy = e
+		} else {
+			requestedBy = strings.TrimSpace(claims.Sub)
+		}
+	}
+
+	ev := TenantEvent{
+		TenantID:    tenantID,
+		SandboxID:   obj.GetName(),
+		RequestedBy: requestedBy,
+		Timestamp:   time.Now().UTC(),
+		SpecHash:    sandboxSpecHash(obj),
+	}
+
+	if err := h.tenantEvents.PublishTenantEvent(ctx, SandboxRequestedSubject, ev); err != nil {
+		// Log at Warn — the CR is already created so this is non-fatal,
+		// but operators need to know the audit-trail message was lost
+		// (see #1776: zero `sandbox_requested` events in the stream
+		// despite Sandbox CRs materialising was the original symptom).
+		h.log.Warn("sandbox: tenant-event publish failed",
+			"subject", SandboxRequestedSubject,
+			"sandbox", obj.GetName(),
+			"namespace", namespace,
+			"err", err,
+		)
+		return
+	}
+	h.log.Debug("sandbox: tenant-event published",
+		"subject", SandboxRequestedSubject,
+		"sandbox", obj.GetName(),
+		"tenant", tenantID,
+	)
+}
+
+// sandboxSpecHash computes a stable SHA-256 over the Sandbox CR's
+// `.spec` block. Stable across map-iteration order via the
+// canonicaliseForHash sort. Returns "" when the spec is missing or
+// not a map (defensive — the handler builds the spec as a map[string]any
+// so this should always succeed in production, but a wrong-type spec
+// MUST NOT panic).
+func sandboxSpecHash(obj *unstructured.Unstructured) string {
+	if obj == nil {
+		return ""
+	}
+	spec, found, err := unstructured.NestedFieldNoCopy(obj.Object, "spec")
+	if err != nil || !found || spec == nil {
+		return ""
+	}
+	buf, err := json.Marshal(canonicaliseForHash(spec))
+	if err != nil {
+		return ""
+	}
+	sum := sha256.Sum256(buf)
+	return hex.EncodeToString(sum[:])
+}
+
+// canonicaliseForHash recursively walks a map/slice tree and returns a
+// representation where map keys are sorted. Lets json.Marshal produce a
+// byte-stable output so the spec_hash is deterministic across runs.
+// Pure helper — testable in isolation.
+func canonicaliseForHash(in any) any {
+	switch v := in.(type) {
+	case map[string]any:
+		keys := make([]string, 0, len(v))
+		for k := range v {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		// Use a slice of [key, value] pairs so the order is preserved
+		// through json.Marshal (which sorts map keys but doesn't
+		// distinguish nested map identity).
+		pairs := make([][2]any, 0, len(keys))
+		for _, k := range keys {
+			pairs = append(pairs, [2]any{k, canonicaliseForHash(v[k])})
+		}
+		return pairs
+	case []any:
+		out := make([]any, len(v))
+		for i, item := range v {
+			out[i] = canonicaliseForHash(item)
+		}
+		return out
+	default:
+		return v
+	}
 }
 
 // HandleDeleteSandboxSession — DELETE /api/v1/sandbox/sessions/{id}.

--- a/products/catalyst/bootstrap/api/internal/handler/sandbox_sessions_nats_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sandbox_sessions_nats_test.go
@@ -1,0 +1,289 @@
+// Package handler — sandbox_sessions_nats_test.go covers TBD-D35b /
+// #1776: every successful Sandbox CR Create MUST publish a
+// `catalyst.tenant.sandbox_requested` NATS event so the audit-trail UI
+// (and cross-component consumers like sandbox-controller's bridge) can
+// correlate FE-requested sandboxes with reconciler-observed CRs without
+// scraping the apiserver.
+//
+// The tests use a recording TenantEventPublisher (recordingTenantEventPub
+// below) wired via SetTenantEventPublisher. The fake captures every
+// Publish call so the assertions can pin both the subject AND the
+// payload shape (tenant_id, sandbox_id, requested_by, timestamp,
+// spec_hash) — drift in any of these would silently break downstream
+// consumers, which is exactly the failure mode the issue called out.
+package handler
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// recordingTenantEventPub is a TenantEventPublisher that captures every
+// Publish call. Safe for concurrent use so a handler that publishes
+// from a goroutine (future variant) can still be asserted reliably.
+type recordingTenantEventPub struct {
+	mu       sync.Mutex
+	calls    []recordedTenantPub
+	returnErr error
+}
+
+type recordedTenantPub struct {
+	subject string
+	event   TenantEvent
+}
+
+func (r *recordingTenantEventPub) PublishTenantEvent(_ context.Context, subject string, ev TenantEvent) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.calls = append(r.calls, recordedTenantPub{subject: subject, event: ev})
+	return r.returnErr
+}
+
+func (r *recordingTenantEventPub) Calls() []recordedTenantPub {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]recordedTenantPub, len(r.calls))
+	copy(out, r.calls)
+	return out
+}
+
+// TestSandboxCreate_PublishesSandboxRequested — the canonical happy-path
+// assertion: a successful Sandbox CR Create triggers exactly one
+// publish on the canonical subject with all required fields populated.
+func TestSandboxCreate_PublishesSandboxRequested(t *testing.T) {
+	h := newSandboxHandler(t)
+	pub := &recordingTenantEventPub{}
+	h.SetTenantEventPublisher(pub)
+
+	body := sandboxCreateRequest{
+		Agent: "claude-code",
+		Name:  "my-sandbox",
+		Repo:  "acme/site",
+	}
+	raw, _ := json.Marshal(body)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sandbox/sessions", bytes.NewReader(raw))
+	req.Header.Set("Content-Type", "application/json")
+	req = withSandboxClaims(req, "user-sub-abcdef12", "operator@acme.com", "acme")
+
+	rec := callSandbox(t, h, req)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("POST: status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+
+	calls := pub.Calls()
+	if len(calls) != 1 {
+		t.Fatalf("expected exactly 1 publish, got %d: %+v", len(calls), calls)
+	}
+	c := calls[0]
+
+	if c.subject != SandboxRequestedSubject {
+		t.Errorf("subject: want %q, got %q", SandboxRequestedSubject, c.subject)
+	}
+	if c.subject != "catalyst.tenant.sandbox_requested" {
+		t.Errorf("subject constant drifted from canonical taxonomy: %q", c.subject)
+	}
+
+	ev := c.event
+	if ev.TenantID != "acme" {
+		t.Errorf("tenant_id: want %q (claims.Org), got %q", "acme", ev.TenantID)
+	}
+	if ev.SandboxID == "" {
+		t.Errorf("sandbox_id must be populated (CR name)")
+	}
+	// The handler derives the CR name from the supplied Name field.
+	// The exact transform is covered by deriveSandboxName tests; here
+	// we only assert the publish observed the same id.
+	var created sandboxItem
+	_ = json.Unmarshal(rec.Body.Bytes(), &created)
+	if ev.SandboxID != created.ID {
+		t.Errorf("sandbox_id: event=%q, response=%q (must match)", ev.SandboxID, created.ID)
+	}
+	if ev.RequestedBy != "operator@acme.com" {
+		t.Errorf("requested_by: want %q (claims.Email), got %q", "operator@acme.com", ev.RequestedBy)
+	}
+	if ev.Timestamp.IsZero() {
+		t.Errorf("timestamp must be set")
+	}
+	if ev.SpecHash == "" {
+		t.Errorf("spec_hash must be set")
+	}
+	if len(ev.SpecHash) != 64 {
+		t.Errorf("spec_hash must be hex-encoded SHA-256 (64 chars), got %d: %q",
+			len(ev.SpecHash), ev.SpecHash)
+	}
+	// hex-only
+	for _, r := range ev.SpecHash {
+		if !((r >= '0' && r <= '9') || (r >= 'a' && r <= 'f')) {
+			t.Errorf("spec_hash contains non-hex char: %q", ev.SpecHash)
+			break
+		}
+	}
+}
+
+// TestSandboxCreate_NoPublisher_DoesNotFail — nil-tolerant: a Sandbox
+// Create on a chroot without CATALYST_NATS_URL must still 201 even
+// though no publisher is wired. The publish-side is a no-op so the
+// CR-create hot path survives a missing audit transport.
+func TestSandboxCreate_NoPublisher_DoesNotFail(t *testing.T) {
+	h := newSandboxHandler(t)
+	// Intentionally NOT calling SetTenantEventPublisher — leave nil.
+
+	body := sandboxCreateRequest{Agent: "claude-code"}
+	raw, _ := json.Marshal(body)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sandbox/sessions", bytes.NewReader(raw))
+	req.Header.Set("Content-Type", "application/json")
+	req = withSandboxClaims(req, "user-sub-abcdef12", "operator@acme.com", "acme")
+
+	rec := callSandbox(t, h, req)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("POST with nil publisher: status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+}
+
+// TestSandboxCreate_PublishError_DoesNotFailRequest — a NATS outage
+// returns an error from PublishTenantEvent. The handler must log +
+// continue: the CR write has already succeeded by then, so failing the
+// HTTP response would leave the apiserver state and the operator's UI
+// out of sync (the UI would refresh and see a CR it thinks failed).
+func TestSandboxCreate_PublishError_DoesNotFailRequest(t *testing.T) {
+	h := newSandboxHandler(t)
+	pub := &recordingTenantEventPub{returnErr: errFakeNATSDown}
+	h.SetTenantEventPublisher(pub)
+
+	body := sandboxCreateRequest{Agent: "claude-code"}
+	raw, _ := json.Marshal(body)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sandbox/sessions", bytes.NewReader(raw))
+	req.Header.Set("Content-Type", "application/json")
+	req = withSandboxClaims(req, "user-sub-abcdef12", "operator@acme.com", "acme")
+
+	rec := callSandbox(t, h, req)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("POST: status = %d, body = %s (publish error MUST NOT fail the request)",
+			rec.Code, rec.Body.String())
+	}
+	if len(pub.Calls()) != 1 {
+		t.Fatalf("publish must still have been attempted exactly once: %d", len(pub.Calls()))
+	}
+}
+
+// TestSandboxCreate_PublishUsesNamespaceWhenOrgEmpty — single-tenant
+// chroot fallback: when claims.Org is empty the handler falls back to
+// the resolved namespace as the tenant_id. Without this, downstream
+// consumers would key by an empty string and conflate every chroot's
+// Sandbox events.
+func TestSandboxCreate_PublishUsesNamespaceWhenOrgEmpty(t *testing.T) {
+	t.Setenv(sandboxDefaultNamespaceEnv, "single-tenant-chroot")
+
+	h := newSandboxHandler(t)
+	pub := &recordingTenantEventPub{}
+	h.SetTenantEventPublisher(pub)
+
+	body := sandboxCreateRequest{Agent: "claude-code"}
+	raw, _ := json.Marshal(body)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sandbox/sessions", bytes.NewReader(raw))
+	req.Header.Set("Content-Type", "application/json")
+	// Claims with empty Org — simulates a chroot Sovereign where the
+	// IDP doesn't emit the org_id claim.
+	req = withSandboxClaims(req, "user-sub-abcdef12", "operator@chroot.example", "")
+
+	rec := callSandbox(t, h, req)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("POST: status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+
+	calls := pub.Calls()
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 publish, got %d", len(calls))
+	}
+	if calls[0].event.TenantID != "single-tenant-chroot" {
+		t.Errorf("tenant_id fallback: want namespace %q, got %q",
+			"single-tenant-chroot", calls[0].event.TenantID)
+	}
+}
+
+// TestSandboxCreate_PublishUsesSubWhenEmailEmpty — operator identity
+// fallback: when claims.Email is empty the handler falls back to
+// claims.Sub (Keycloak subject UUID) so requested_by is never blank.
+func TestSandboxCreate_PublishUsesSubWhenEmailEmpty(t *testing.T) {
+	h := newSandboxHandler(t)
+	pub := &recordingTenantEventPub{}
+	h.SetTenantEventPublisher(pub)
+
+	body := sandboxCreateRequest{Agent: "claude-code"}
+	raw, _ := json.Marshal(body)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sandbox/sessions", bytes.NewReader(raw))
+	// Empty Email, non-empty Sub.
+	req = withSandboxClaims(req, "user-sub-abcdef12", "", "acme")
+
+	rec := callSandbox(t, h, req)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("POST: status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+
+	calls := pub.Calls()
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 publish, got %d", len(calls))
+	}
+	if calls[0].event.RequestedBy != "user-sub-abcdef12" {
+		t.Errorf("requested_by Sub fallback: want %q, got %q",
+			"user-sub-abcdef12", calls[0].event.RequestedBy)
+	}
+}
+
+// TestSandboxSpecHash_DeterministicAcrossMapOrder — the spec_hash MUST
+// be stable across map-iteration order so two Create calls with the
+// same logical spec produce the same hash. Without this, downstream
+// drift-detection alerts (built on top of the audit stream) would fire
+// spuriously on every event.
+func TestSandboxSpecHash_DeterministicAcrossMapOrder(t *testing.T) {
+	a := buildSandboxUnstructured("sb-1", "acme", "Sb 1", "claude-code", "acme/site", "operator@acme.com", "acme")
+	b := buildSandboxUnstructured("sb-1", "acme", "Sb 1", "claude-code", "acme/site", "operator@acme.com", "acme")
+
+	ha := sandboxSpecHash(a)
+	hb := sandboxSpecHash(b)
+	if ha == "" {
+		t.Fatalf("hash a is empty (spec missing?)")
+	}
+	if ha != hb {
+		t.Errorf("spec_hash not deterministic: a=%q b=%q", ha, hb)
+	}
+
+	// Spec change must alter the hash (otherwise drift detection breaks).
+	c := buildSandboxUnstructured("sb-1", "acme", "Sb 1", "aider", "acme/site", "operator@acme.com", "acme")
+	hc := sandboxSpecHash(c)
+	if hc == ha {
+		t.Errorf("spec_hash unchanged after agent swap (claude-code → aider): %q", hc)
+	}
+}
+
+// TestSandboxRequestedSubject_MatchesIssueContract — pins the exact
+// subject string the issue (#1776) calls out. A typo here would silently
+// pass every other test but ship an unsubscribable event.
+func TestSandboxRequestedSubject_MatchesIssueContract(t *testing.T) {
+	const wanted = "catalyst.tenant.sandbox_requested"
+	if SandboxRequestedSubject != wanted {
+		t.Errorf("SandboxRequestedSubject = %q, want %q (per #1776)", SandboxRequestedSubject, wanted)
+	}
+	// Subject must be a valid NATS-style dotted token (per ADR-0001 §6:
+	// `catalyst.<domain>.<event>`).
+	parts := strings.Split(SandboxRequestedSubject, ".")
+	if len(parts) != 3 || parts[0] != "catalyst" || parts[1] != "tenant" {
+		t.Errorf("subject doesn't match catalyst.tenant.<event> taxonomy: %q", SandboxRequestedSubject)
+	}
+}
+
+// ── helpers ─────────────────────────────────────────────────────────
+
+// errFakeNATSDown is the error a fake publisher returns to simulate a
+// transient NATS outage.
+var errFakeNATSDown = &natsDownError{}
+
+type natsDownError struct{}
+
+func (e *natsDownError) Error() string { return "fake NATS down" }


### PR DESCRIPTION
## Summary

- Adds NATS publish hook to `HandleCreateSandboxSession` so every successful Sandbox CR Create emits `catalyst.tenant.sandbox_requested` — closing the audit-trail gap #1776 called out (zero events in the stream despite Sandbox CRs materialising).
- Reuses the existing `SetAuditBus`-style nil-tolerant publisher wiring pattern. New `TenantEventPublisher` interface on the Handler, env-driven placeholder in main.go (mirrors `newRBACAuditPublisherFromEnv` — returns nil today because catalyst-api ships without `nats.go` in go.mod; the real publisher lands in the same follow-up slice that swaps the RBAC stub).
- Payload `{tenant_id, sandbox_id, requested_by, timestamp, spec_hash}` matches the existing `audit.Event` field-naming convention. `spec_hash` is SHA-256 over canonical JSON-serialised `.spec` for downstream drift detection.
- Sandbox-controller's consumer list (`core/controllers/sandbox/internal/controller/nats_bridge.go`) already includes this subject — no controller-side change required.

## Test plan

- [x] `go test ./internal/handler/` — full suite green (115s)
- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] 7 new unit tests in `sandbox_sessions_nats_test.go`:
  - `PublishesSandboxRequested` — happy path, exact subject + all fields populated
  - `NoPublisher_DoesNotFail` — nil-tolerant (CI/chroot without `CATALYST_NATS_URL`)
  - `PublishError_DoesNotFailRequest` — NATS outage logs + continues; HTTP stays 201
  - `PublishUsesNamespaceWhenOrgEmpty` — single-tenant chroot fallback (NOT orgSlug, which collapses to "default")
  - `PublishUsesSubWhenEmailEmpty` — `requested_by` falls back to `claims.Sub`
  - `SpecHash_DeterministicAcrossMapOrder` — hash stable across map iteration; changes when spec changes
  - `Subject_MatchesIssueContract` — pins exact `catalyst.tenant.sandbox_requested` against accidental drift
- [ ] Post-merge: verify in t31+ Sovereign — `nats sub 'catalyst.tenant.sandbox_requested'` shows envelopes after FE-driven Sandbox creates (currently zero per #1776).

Closes #1776