### PR TITLE
fix(bp-newapi): consume CNPG-managed app secret instead of stale DSN (TBD-A39, Closes #1834)

### DIFF
--- a/clusters/_template/bootstrap-kit/80-newapi.yaml
+++ b/clusters/_template/bootstrap-kit/80-newapi.yaml
@@ -143,7 +143,17 @@ spec:
       # connection pool's first wire write completed. Probe budget:
       # 30 × 10s = 5 min, comfortably above the observed 60-120s
       # ceiling on cpx21/cpx31 nodes with sslmode=require.
-      version: 1.4.26
+      # TBD-A39 #1834 (2026-05-19): bp-newapi 1.4.27 replaces the
+      # Helm-`lookup`-based DSN Secret render (which raced CNPG on
+      # first install and committed an empty password — t32 newapi
+      # Pod was 21x CrashLoopBackOff with `password authentication
+      # failed for user "newapi"`) with a post-install Job that polls
+      # `<cluster>-app` and PATCHes the SQL_DSN bytes. Canonical
+      # database-secret-sync-job pattern lifted from
+      # platform/gitea/chart/templates/database-secret-sync-job.yaml
+      # (issue #830 Bug 2) + platform/wordpress-tenant/chart/templates/
+      # database-secret-sync-job.yaml (issue #1786).
+      version: 1.4.27
       sourceRef:
         kind: HelmRepository
         name: bp-newapi

--- a/platform/newapi/blueprint.yaml
+++ b/platform/newapi/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/category: ai-runtime
     catalyst.openova.io/section: pts-4-6-llm-serving
 spec:
-  version: 1.4.26
+  version: 1.4.27
   card:
     title: NewAPI
     summary: |

--- a/platform/newapi/chart/Chart.yaml
+++ b/platform/newapi/chart/Chart.yaml
@@ -1,5 +1,54 @@
 apiVersion: v2
 name: bp-newapi
+# 1.4.27 (TBD-A39 #1834, 2026-05-19): replace the Helm-`lookup`-based
+# DSN Secret render with a post-install/post-upgrade Job that polls
+# CNPG's `<cluster>-app` Secret until populated, composes the SQL_DSN
+# string, and PATCHes it into the chart-managed
+# `<release>-newapi-db-dsn` Secret in place.
+#
+# ROOT CAUSE (#1834 D34 close-audit on t32 2026-05-19):
+#   The pre-1.4.27 cnpg-cluster.yaml rendered the DSN Secret via Helm
+#   `lookup "v1" "Secret" .Release.Namespace <cluster>-app` at template
+#   time. On every freshly-franchised Sovereign CNPG materialises the
+#   `<cluster>-app` source Secret only AFTER bp-newapi's HelmRelease
+#   applies, so the first render's lookup returns nil and the Secret
+#   was committed with an empty password — literally
+#   `postgres://newapi:@newapi-bp-newapi-newapi-pg-rw.newapi.svc.cluster.local:5432/newapi?sslmode=require`.
+#   The chart annotated the rendered Secret `helm.sh/resource-policy:
+#   keep`, so Flux never overwrote the empty bytes on subsequent
+#   reconciles even after CNPG had populated the source. Result on
+#   t32: newapi Pod in 21x CrashLoopBackOff with `password
+#   authentication failed for user "newapi"`. Public probe to
+#   `newapi.t32.omani.works` returned envoy 503 "no healthy upstream".
+#   The chart's own header comment claimed "the 1-minute Flux
+#   reconcile picks it up on the next tick" — verified false in
+#   production; the `resource-policy: keep` annotation pinned the
+#   empty bytes across every subsequent reconcile.
+#
+# FIX (canonical seam — issue #830 Bug 2 + ADR-0001 §11.3
+# anti-duplication):
+#   - cnpg-cluster.yaml: drop the Helm `lookup` / DSN composition. The
+#     DSN Secret now renders as an empty-value placeholder so kubelet
+#     can satisfy the Deployment's secretKeyRef on first schedule.
+#   - NEW templates/database-secret-sync-job.yaml: Helm
+#     post-install/post-upgrade Job that polls `<cluster>-app` (up to
+#     10 min), reads the `password` bytes, composes the canonical
+#     `postgres://<user>:<password>@<host>:5432/<db>?sslmode=<mode>`
+#     string, and strategic-merge PATCHes it into the placeholder
+#     Secret. Hook-weight 5 (after the SA/Role/RoleBinding at 0).
+#     ServiceAccount + Role (get/create/update/patch/apply on
+#     secrets) + RoleBinding bound to the same hook lifecycle.
+#   - Pattern mirrors platform/gitea/chart/templates/database-secret-
+#     sync-job.yaml (proven on otech30, issue #830 Bug 2) and
+#     platform/wordpress-tenant/chart/templates/database-secret-sync-
+#     job.yaml (proven on t26).
+#
+# TEMPLATABILITY (Inviolable Principle #4):
+#   Every knob (cnpg.cluster.owner, cnpg.database, cnpg.sslMode,
+#   cnpg.dsnSecretName) flows through to the Job's env vars, so an
+#   operator override on any of those updates the composed DSN on the
+#   next helm upgrade without forking the chart.
+#
 # 1.4.19 (TBD-A12 #1798, 2026-05-18): add `startupProbe` to the newapi
 # container to gate liveness + readiness until GORM AutoMigrate
 # finishes on first-boot.
@@ -261,7 +310,7 @@ name: bp-newapi
 # blueprint's NS); the prior rule could never reach them and the
 # newapi container looped 1/2 Ready with DB-connect timeouts on
 # fresh prov.
-version: 1.4.26
+version: 1.4.27
 appVersion: "0.13.2"
 description: |
   Catalyst Blueprint scratch chart for NewAPI — multi-tenant LLM

--- a/platform/newapi/chart/templates/cnpg-cluster.yaml
+++ b/platform/newapi/chart/templates/cnpg-cluster.yaml
@@ -1,32 +1,41 @@
 {{- /*
-CNPG Cluster + DSN Secret for bp-newapi (issue #943).
+CNPG Cluster + DSN-placeholder Secret for bp-newapi (issue #943, #1834).
 
 NewAPI persists users, credits, channels, tokens, and an audit log to
-PostgreSQL. Pre-#943 the chart REQUIRED an operator-supplied
-`database.existingSecret` to render the Deployment — the deployment
-template silently skipped Pod render if it was empty. On a freshly
-franchised Sovereign installing bp-newapi via Flux from the bootstrap-kit
-slot 80 overlay nothing populated this Secret, so the Deployment never
-materialised, NewAPI never came up, and alice signup gate 5 (LLM)
-timed out waiting for `api.<sov-fqdn>` to respond.
-
-Fix (issue #943, 2026-05-05): auto-provision the backing Postgres via
-CNPG when `cnpg.enabled=true` (DEFAULT). The chart renders:
+PostgreSQL. The chart auto-provisions the backing Postgres via CNPG
+when `cnpg.enabled=true` (DEFAULT). The chart renders:
 
   - postgresql.cnpg.io/v1.Cluster `<release>-newapi-pg` with the
     operator-configured size + storage from .Values.cnpg.cluster.*.
     CNPG auto-creates `<cluster>-app` Secret (basic-auth shape:
     username + password keys) and `<cluster>-rw` Service.
 
-  - Secret `<release>-newapi-db-dsn` with the SQL_DSN key the chart's
-    deployment.yaml reads. The DSN is materialised via Helm `lookup`
-    against the CNPG-emitted Secret so the bytes are stable across
-    reinstalls. Persistent across reconciles per the same lookup-and-
-    persist pattern as platform/gitea/chart/templates/admin-secret.yaml
-    (issue #830 Bug 2 + feedback_passwords.md). On first install the
-    lookup returns nil — the Cluster is still warming — and the DSN
-    Secret renders with an empty password. The 1-minute Flux reconcile
-    picks it up on the next tick once CNPG has materialised the bytes.
+  - Placeholder Secret `<release>-newapi-db-dsn` with EMPTY SQL_DSN
+    key, materialised at install time so the deployment.yaml
+    secretKeyRef references a Secret that already exists (kubelet
+    won't trip CreateContainerConfigError). The companion
+    `database-secret-sync-job.yaml` Helm post-install Job then
+    composes the full DSN string from CNPG's `<cluster>-app`
+    password (polled until ready) and PATCHes the SQL_DSN key
+    into this Secret in place.
+
+TBD-A39 / Issue #1834 (2026-05-19, root-cause): The previous
+implementation rendered the DSN via Helm `lookup` against
+`<cluster>-app` at template-render time. On every freshly-franchised
+Sovereign CNPG materialises that Secret only AFTER bp-newapi's
+HelmRelease applies, so the first render's lookup returns nil and
+the Secret committed an empty password — `postgres://newapi:@.../`.
+The chart annotated the rendered Secret `helm.sh/resource-policy: keep`,
+so Flux never overwrote the empty bytes on subsequent reconciles
+even after CNPG had populated the source. Result on t32: newapi Pod
+in 21x CrashLoopBackOff with `password authentication failed for
+user "newapi"`. Switched to the canonical sync-job pattern lifted
+from platform/gitea/chart/templates/database-secret-sync-job.yaml
+(issue #830 Bug 2) + platform/wordpress-tenant/chart/templates/
+database-secret-sync-job.yaml (issue #1786) — both proven on
+otech30/t26. The sync-job is event-deterministic (polls until source
+ready, PATCHes destination, exits 0) and idempotent across helm
+upgrade.
 
   - `database.existingSecret` and `database.existingSecretKey` default
     to the chart-emitted Secret name and key when cnpg.enabled=true,
@@ -40,14 +49,9 @@ where bp-cnpg has not yet registered the `postgresql.cnpg.io/v1` CRD.
 Without the gate, a cold install fails with "no matches for kind
 Cluster". Same pattern the bp-external-dns chart uses (issue #190) and
 the platform/powerdns/chart/templates/cnpg-cluster.yaml mirror.
-
-Lockstep with bp-newapi 1.4.0 — paired with deployment.yaml change to
-read the chart-emitted DSN by default + the existingSecret value
-defaulting in values.yaml.
 */}}
 {{- if .Values.cnpg.enabled -}}
 {{- $clusterName := printf "%s-newapi-pg" (include "bp-newapi.fullname" .) -}}
-{{- $cnpgSecretName := printf "%s-app" $clusterName -}}
 {{- $dsnSecretName := default (printf "%s-newapi-db-dsn" (include "bp-newapi.fullname" .)) .Values.cnpg.dsnSecretName -}}
 {{- $database := .Values.cnpg.database | default "newapi" -}}
 {{- if .Capabilities.APIVersions.Has "postgresql.cnpg.io/v1" -}}
@@ -82,36 +86,30 @@ spec:
 {{- end }}
 ---
 {{- /*
-DSN Secret — read CNPG's auto-emitted basic-auth Secret via Helm lookup
-and re-emit the canonical SQL_DSN string the deployment.yaml expects.
-On first install the lookup returns nil; the DSN renders with empty
-password and the Pod stays in CrashLoopBackOff until the next 1-minute
-Flux reconcile picks up the materialised bytes. Same first-install race
-as templates/sme-services/sme-secrets.yaml (issue #859) and
-templates/sme-services/valkey-cross-ns-secret.yaml (issue #863) — both
-proven to recover on the second reconcile in production.
+DSN placeholder Secret — populated by templates/database-secret-sync-
+job.yaml at runtime. Rendered as a regular chart-managed resource (NOT
+a Helm hook) so it remains owned by the bp-newapi HelmRelease and Flux
+re-applies it on every reconcile. The post-install/post-upgrade
+sync-job PATCHes the SQL_DSN bytes in place — Flux's strategic-merge
+re-apply preserves those patched bytes because the chart-managed
+template renders SQL_DSN: "" only as a placeholder; the sync-job's
+strategic-merge PATCH wins server-side until the next chart render,
+which then immediately fires the sync-job again. Idempotent.
+
+Empty data.SQL_DSN value prevents CreateContainerConfigError on first
+Pod schedule (kubelet only checks that the named key EXISTS, not that
+it has non-empty content). The Pod will fail Postgres authentication
+once and CrashLoop until the post-install sync-job completes — about
+30-90s on a cold install — then come up Ready on the next kubelet
+restart.
 */ -}}
-{{- $cnpgSecret := lookup "v1" "Secret" .Release.Namespace $cnpgSecretName -}}
-{{- $pgUser := .Values.cnpg.cluster.owner | default "newapi" -}}
-{{- $pgPass := "" -}}
-{{- $pgHost := printf "%s-rw.%s.svc.cluster.local" $clusterName .Release.Namespace -}}
-{{- if and $cnpgSecret $cnpgSecret.data $cnpgSecret.data.password -}}
-  {{- $pgPass = $cnpgSecret.data.password | b64dec -}}
-{{- end -}}
-{{- $sslMode := .Values.cnpg.sslMode | default "require" -}}
-{{- $dsn := printf "postgres://%s:%s@%s:5432/%s?sslmode=%s" $pgUser $pgPass $pgHost $database $sslMode -}}
 apiVersion: v1
 kind: Secret
 metadata:
   name: {{ $dsnSecretName }}
   labels:
     {{- include "bp-newapi.labels" . | nindent 4 }}
-  annotations:
-    # Keep the Secret across helm uninstall — re-install picks the
-    # bytes back up via lookup, so external consumers (debug Pods,
-    # backup scripts) keep a stable reference.
-    helm.sh/resource-policy: keep
 type: Opaque
 data:
-  SQL_DSN: {{ $dsn | b64enc | quote }}
+  SQL_DSN: ""
 {{- end }}

--- a/platform/newapi/chart/templates/database-secret-sync-job.yaml
+++ b/platform/newapi/chart/templates/database-secret-sync-job.yaml
@@ -1,0 +1,216 @@
+{{- if .Values.cnpg.enabled }}
+{{- /*
+Helm post-install/post-upgrade Job that composes the canonical SQL_DSN
+string from the CNPG-emitted `<cluster>-app` Secret (which holds the
+rotating Postgres password) and PATCHes it into the chart-managed
+DSN-placeholder Secret `<release>-newapi-db-dsn`.
+
+WHY A JOB INSTEAD OF HELM `lookup`
+----------------------------------
+Pre-#1834 the chart rendered the DSN at template time via `lookup`
+against `<cluster>-app`. On every freshly-franchised Sovereign CNPG
+materialises that source Secret only AFTER bp-newapi's HelmRelease
+applies, so the first render's lookup returns nil and the Secret was
+committed with an empty password — `postgres://newapi:@.../`. The
+chart annotated the rendered Secret `helm.sh/resource-policy: keep`,
+so Flux never overwrote the empty bytes on subsequent reconciles even
+after CNPG had populated the source. Result on t32: newapi Pod in
+21x CrashLoopBackOff with `password authentication failed for user
+"newapi"`. Probe to `newapi.t32.omani.works` returned envoy 503
+"no healthy upstream".
+
+A post-install Job avoids the lookup race entirely:
+  1. Polls until CNPG has provisioned `<cluster>-app`.
+  2. Reads `password` from it.
+  3. Composes SQL_DSN = `postgres://<user>:<password>@<host>:5432/<db>?sslmode=<mode>`
+  4. PATCHes `<release>-newapi-db-dsn` with the SQL_DSN bytes.
+  5. Exits 0; Helm marks the post-install hook complete.
+
+The Job is idempotent — re-running it overwrites with the same data,
+which CNPG never rotates without operator action.
+
+Pattern lifted from platform/gitea/chart/templates/database-secret-sync
+-job.yaml (canonical seam — issue #830 Bug 2 + feedback_passwords.md
++ ADR-0001 §11.3 anti-duplication) + platform/wordpress-tenant/chart/
+templates/database-secret-sync-job.yaml (issue #1786).
+
+Fix #1834 (TBD-A39, 2026-05-19): D34 newapi LLM gateway crashed in 21x
+CrashLoopBackOff on t32 because the chart's DSN secret carried an
+empty password (Helm `lookup` race with CNPG's first-install). Replaced
+the lookup pattern with this sync-job.
+
+URL-ENCODING NOTE
+-----------------
+CNPG's auto-generated password is alphanumeric (no special chars), so
+URL-encoding it in the DSN is a no-op. If the operator overrides
+.Values.cnpg.cluster.owner to a name with shell-special characters or
+sets a custom password with `+`, `@`, `:`, etc. via a forked path, this
+script will not encode them. Within scope of #943 (CNPG-owned password
+only) URL-encoding is unnecessary; deferred to a follow-up if the
+operator-supplied-password path resurfaces.
+*/}}
+{{- $clusterName := printf "%s-newapi-pg" (include "bp-newapi.fullname" .) }}
+{{- $cnpgSecretName := printf "%s-app" $clusterName }}
+{{- $dsnSecretName := default (printf "%s-newapi-db-dsn" (include "bp-newapi.fullname" .)) .Values.cnpg.dsnSecretName }}
+{{- $pgUser := .Values.cnpg.cluster.owner | default "newapi" }}
+{{- $pgHost := printf "%s-rw.%s.svc.cluster.local" $clusterName .Release.Namespace }}
+{{- $database := .Values.cnpg.database | default "newapi" }}
+{{- $sslMode := .Values.cnpg.sslMode | default "require" }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "bp-newapi.fullname" . }}-db-dsn-sync
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "bp-newapi.labels" . | nindent 4 }}
+    catalyst.openova.io/component: newapi-db-dsn-sync
+  annotations:
+    "helm.sh/hook": "post-install,post-upgrade"
+    "helm.sh/hook-weight": "5"
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
+spec:
+  backoffLimit: 6
+  ttlSecondsAfterFinished: 300
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: newapi-db-dsn-sync
+        catalyst.openova.io/blueprint: bp-newapi
+    spec:
+      restartPolicy: OnFailure
+      serviceAccountName: {{ include "bp-newapi.fullname" . }}-db-dsn-sync
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: sync
+          # Fix #163 (2026-05-11, MIRROR-EVERYTHING): explicit
+          # harbor.openova.io/proxy-dockerhub prefix per CLAUDE.md
+          # inviolable rule. curlimages/curl is the canonical image
+          # used by platform/gitea + platform/wordpress-tenant sync
+          # jobs — no kubectl required (apiserver via in-pod token).
+          image: harbor.openova.io/proxy-dockerhub/curlimages/curl:8.10.1
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: SOURCE_SECRET
+              value: {{ $cnpgSecretName | quote }}
+            - name: DEST_SECRET
+              value: {{ $dsnSecretName | quote }}
+            - name: NAMESPACE
+              value: {{ .Release.Namespace | quote }}
+            - name: PG_USER
+              value: {{ $pgUser | quote }}
+            - name: PG_HOST
+              value: {{ $pgHost | quote }}
+            - name: PG_DB
+              value: {{ $database | quote }}
+            - name: PG_SSLMODE
+              value: {{ $sslMode | quote }}
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -eu
+              APISERVER="https://kubernetes.default.svc"
+              TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
+              CA=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+              echo "Waiting for ${SOURCE_SECRET} in ${NAMESPACE}..."
+              for i in $(seq 1 120); do
+                code=$(curl -s -o /tmp/src.json -w '%{http_code}' --cacert "${CA}" \
+                  -H "Authorization: Bearer ${TOKEN}" \
+                  "${APISERVER}/api/v1/namespaces/${NAMESPACE}/secrets/${SOURCE_SECRET}")
+                if [ "${code}" = "200" ]; then
+                  echo "Found ${SOURCE_SECRET}"; break
+                fi
+                if [ "$i" = "120" ]; then
+                  echo "Timeout: ${SOURCE_SECRET} not present after 10 min" >&2
+                  exit 1
+                fi
+                sleep 5
+              done
+              # Extract base64 password from possibly multi-line JSON.
+              PWD_B64=$(tr -d '\n' < /tmp/src.json | grep -oE '"password"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*"\([^"]*\)"$/\1/')
+              if [ -z "${PWD_B64}" ]; then
+                echo "Source ${SOURCE_SECRET} has empty password" >&2
+                exit 1
+              fi
+              PWD=$(echo -n "${PWD_B64}" | base64 -d)
+              if [ -z "${PWD}" ]; then
+                echo "Source ${SOURCE_SECRET} decoded to empty password" >&2
+                exit 1
+              fi
+              DSN="postgres://${PG_USER}:${PWD}@${PG_HOST}:5432/${PG_DB}?sslmode=${PG_SSLMODE}"
+              DSN_B64=$(echo -n "${DSN}" | base64 -w 0)
+              PATCH=$(printf '{"data":{"SQL_DSN":"%s"}}' "${DSN_B64}")
+              code=$(curl -s -o /tmp/patch.json -w '%{http_code}' --cacert "${CA}" \
+                -H "Authorization: Bearer ${TOKEN}" \
+                -H "Content-Type: application/strategic-merge-patch+json" \
+                -X PATCH --data "${PATCH}" \
+                "${APISERVER}/api/v1/namespaces/${NAMESPACE}/secrets/${DEST_SECRET}")
+              if [ "${code}" != "200" ] && [ "${code}" != "201" ]; then
+                echo "PATCH ${DEST_SECRET} returned HTTP ${code}:" >&2
+                cat /tmp/patch.json >&2
+                exit 1
+              fi
+              echo "Synced ${DEST_SECRET} SQL_DSN from ${SOURCE_SECRET} password"
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              cpu: 100m
+              memory: 64Mi
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "bp-newapi.fullname" . }}-db-dsn-sync
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "bp-newapi.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": "post-install,post-upgrade"
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": "before-hook-creation"
+  {{- with .Values.imagePullSecrets }}
+imagePullSecrets:
+  {{- toYaml . | nindent 2 }}
+  {{- end }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "bp-newapi.fullname" . }}-db-dsn-sync
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "bp-newapi.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": "post-install,post-upgrade"
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": "before-hook-creation"
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "create", "update", "patch", "apply"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "bp-newapi.fullname" . }}-db-dsn-sync
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "bp-newapi.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": "post-install,post-upgrade"
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": "before-hook-creation"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "bp-newapi.fullname" . }}-db-dsn-sync
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "bp-newapi.fullname" . }}-db-dsn-sync
+    namespace: {{ .Release.Namespace }}
+{{- end }}


### PR DESCRIPTION
## Summary

D34 close-audit on t32 (2026-05-19) found `newapi-bp-newapi-*` in **21× CrashLoopBackOff** with `SASL auth: FATAL: password authentication failed for user "newapi"`. Public probe to `https://newapi.t32.omani.works/v1/models` returned envoy **503 no healthy upstream**.

**Root cause** (confirmed by inspecting the actual rendered Secret on t32):

The chart's `templates/cnpg-cluster.yaml` rendered the DSN Secret via Helm `lookup "v1" "Secret" .Release.Namespace <cluster>-app` at **template time**. On every freshly-franchised Sovereign CNPG materialises the `<cluster>-app` source Secret only **AFTER** bp-newapi's HelmRelease applies, so the first render's lookup returns nil and the chart commits the Secret with an empty password — literally:

```
postgres://newapi:@newapi-bp-newapi-newapi-pg-rw.newapi.svc.cluster.local:5432/newapi?sslmode=require
```

The Secret carries `helm.sh/resource-policy: keep`, so Flux **never** overwrites the empty bytes on subsequent reconciles even after CNPG populates the source. The chart's own header comment claimed "the 1-minute Flux reconcile picks it up on the next tick" — verified **false** in production; `resource-policy: keep` pins the empty bytes.

## Fix

- **`platform/newapi/chart/templates/cnpg-cluster.yaml`**: drop the Helm `lookup` + DSN composition. The DSN Secret now renders as a chart-managed **empty placeholder** so kubelet can satisfy the Deployment's `secretKeyRef` on first schedule (kubelet only checks the key EXISTS, not that it has non-empty content).
- **`platform/newapi/chart/templates/database-secret-sync-job.yaml` (NEW)**: Helm `post-install,post-upgrade` Job + ServiceAccount + Role + RoleBinding. The Job polls `<cluster>-app` (up to 10 min via `curl` + in-pod SA token), reads the `password` bytes, composes the canonical `postgres://<user>:<password>@<host>:5432/<db>?sslmode=<mode>` string, and strategic-merge PATCHes it into the placeholder Secret. Idempotent across `helm upgrade`.
- **`platform/newapi/chart/Chart.yaml`**: `1.4.26` → `1.4.27` with full changelog block (Inviolable Principle #15 — header changelog comment).
- **`clusters/_template/bootstrap-kit/80-newapi.yaml`**: bp-newapi pin `1.4.26` → `1.4.27` with a TBD-A39 #1834 comment block.

Pattern lifted from `platform/gitea/chart/templates/database-secret-sync-job.yaml` (canonical seam — issue #830 Bug 2, proven on otech30) and `platform/wordpress-tenant/chart/templates/database-secret-sync-job.yaml` (issue #1786, proven on t26). ADR-0001 §11.3 anti-duplication.

## Test plan

- [x] `helm dep update && helm template newapi .` renders cleanly with the placeholder Secret + Job + SA + Role + RoleBinding.
- [x] `kubectl apply --dry-run=server` against the t32 apiserver accepts all 11 rendered objects.
- [x] Rendered placeholder Secret has `data.SQL_DSN: ""` (kubelet-satisfiable).
- [x] Rendered Job env vars resolve to the correct `SOURCE_SECRET=newapi-bp-newapi-newapi-pg-app`, `DEST_SECRET=newapi-bp-newapi-newapi-db-dsn`, `PG_HOST=newapi-bp-newapi-newapi-pg-rw.newapi.svc.cluster.local`.
- [ ] Next fresh Sovereign provision: verify `newapi-bp-newapi-*` Pod reaches Ready 2/2 within ~3 min of CNPG `<cluster>-app` materialising, and `curl https://newapi.<sov-fqdn>/v1/models` returns the channel list (no envoy 503).
- [ ] D34 verification on next prov.

## Refs

Closes #1834
Refs: TBD-A39

🤖 Generated with [Claude Code](https://claude.com/claude-code)