### PR TITLE
fix(catalyst-cnp): add newapi NS to baseline-default-deny egress (TBD-A43, companion to #1919, Closes #1920)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -608,7 +608,14 @@ spec:
       # during the YAML scanner break introduced by PR #1858 and fixed
       # by PR #1866. Auto-bump-pin step didn't fire during the outage,
       # so this pin lagged by 2 versions. Refs #1864.
-      version: 1.4.189
+      # 1.4.189: TBD-A38 (issue #1917, PR #1919) baseline-default-deny
+      # CNP egress allow-list extended with `sme` (voucher list / issue /
+      # redeem unblocked).
+      # 1.4.190: TBD-A43 (issue #1920) companion fix — adds `newapi`
+      # to the same allow-list so catalyst-system → NewAPI v2 calls
+      # (`newapi-*.newapi.svc`) no longer time out. Closes the
+      # newapi half of the PR #1912 theater incident.
+      version: 1.4.190
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -1,5 +1,22 @@
 apiVersion: v2
 name: bp-catalyst-platform
+# 1.4.190 — TBD-A43 (issue #1920) baseline-default-deny CNP gains the
+# `newapi` namespace in its egress allow-list. Companion fix to TBD-A38
+# (PR #1919, chart 1.4.189) which added `sme`. PR #1912 was titled "fix
+# catalyst-system → sme/newapi egress" but only touched the world-egress
+# TCP/6443 block — `sme` was retroactively covered by #1919 and this PR
+# closes the `newapi` half of the theater. catalyst-system controllers
+# reach the NewAPI v2 service plane (`newapi-*.newapi.svc`) for the
+# customer-journey D29 flows; without `newapi` in the egress allow-list
+# every catalyst-system → NewAPI v2 call times out at the CNP. Fix:
+# append `newapi` to the values default + the template fallback list,
+# and add Case 5c + Case 5d to tests/baseline-cnp-allowlist.sh so any
+# future narrowing of the sme/newapi allow fails Blueprint Release CI
+# before the OCI artifact ships. Attack surface bounded — sme/newapi
+# NS gateways are the canonical traffic destinations for the customer
+# journey. Per Inviolable Principle #4, the list is values-driven so
+# operators can still narrow per-Sovereign.
+#
 # 1.4.189 — TBD-A38 (issue #1917) baseline-default-deny CNP egress
 # allow-list extended with `sme` namespace. The bp-sme-platform chart
 # deploys the SME control-plane (auth, billing, catalog, console,
@@ -1330,8 +1347,8 @@ name: bp-catalyst-platform
 # 25/TCP (legacy SMTP fallback). All three are explicitly scoped to
 # `toEntities: world`, matching the existing 443/TCP allow. No other
 # rule semantics change. (Fixes PIN-issue 502 regression from #1785.)
-version: 1.4.189
-appVersion: 1.4.188
+version: 1.4.190
+appVersion: 1.4.190
 # 1.4.183 — fix(httproute): omit default sectionName so multi-zone
 # Sovereigns attach via Cilium Gateway hostname matcher (Closes #1884,
 # TBD-A30). Pre-1.4.183 every catalyst-system HTTPRoute pinned

--- a/products/catalyst/chart/templates/network-policies/baseline-catalyst-system.yaml
+++ b/products/catalyst/chart/templates/network-policies/baseline-catalyst-system.yaml
@@ -70,7 +70,7 @@ unconditionally on every Sovereign and protects catalyst-system even
 when qaFixtures is disabled.
 */}}
 {{- if .Values.security.baselineCnp.enabled }}
-{{- $allowedPlatform := .Values.security.baselineCnp.allowedPlatformNamespaces | default (list "keycloak" "gitea" "powerdns" "cnpg-system" "openbao" "harbor" "nats-system" "loki" "mimir" "tempo" "alloy" "opentelemetry" "external-secrets-system" "cert-manager" "sme") }}
+{{- $allowedPlatform := .Values.security.baselineCnp.allowedPlatformNamespaces | default (list "keycloak" "gitea" "powerdns" "cnpg-system" "openbao" "harbor" "nats-system" "loki" "mimir" "tempo" "alloy" "opentelemetry" "external-secrets-system" "cert-manager" "sme" "newapi") }}
 {{- $allowedIngressNs := .Values.security.baselineCnp.allowedIngressNamespaces | default (list "catalyst" "flux-system" "kube-system") }}
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy

--- a/products/catalyst/chart/tests/baseline-cnp-allowlist.sh
+++ b/products/catalyst/chart/tests/baseline-cnp-allowlist.sh
@@ -129,6 +129,31 @@ if ! awk '/egress:/,0' "$TMP/cnp.yaml" | grep -B30 'port: "6443"' | grep -q '\- 
 fi
 echo "  PASS (egress TCP/6443 to world allowed — secondary CP fan-out unblocked)"
 
+echo "[baseline-cnp] Case 5c: egress allow-list includes 'sme' namespace — #1917/#1920 regression guard (TBD-A38/A43)"
+# catalyst-ui (catalyst-system) → gateway.sme.svc:8080 carries every
+# tenant-facing SME action (admin, auth, billing, catalog, console,
+# domain, marketplace). Without `sme` in the egress allow-list, the
+# baseline-default-deny CNP drops the traffic and the Console returns
+# 503 `context deadline exceeded`. Caught LIVE on t32 fresh-prov walk
+# 2026-05-19 — PR #1912 was theater (only added world TCP/6443) and
+# never extended the namespace allow-list. Re-narrowing must fail here.
+if ! awk '/egress:/,0' "$TMP/cnp.yaml" | grep -q '"sme"'; then
+  echo "FAIL: egress allow-list missing 'sme' namespace — Console → gateway.sme.svc will 503 (#1920 regression)" >&2
+  exit 1
+fi
+echo "  PASS (egress to 'sme' namespace allowed — Console → gateway.sme.svc unblocked)"
+
+echo "[baseline-cnp] Case 5d: egress allow-list includes 'newapi' namespace — #1920 regression guard (TBD-A43)"
+# catalyst-system controllers reach the NewAPI v2 service plane in the
+# `newapi` namespace for the customer-journey D29 flows. Without
+# `newapi` in the egress allow-list, every catalyst-system → NewAPI v2
+# call times out.
+if ! awk '/egress:/,0' "$TMP/cnp.yaml" | grep -q '"newapi"'; then
+  echo "FAIL: egress allow-list missing 'newapi' namespace — catalyst-system → NewAPI v2 will time out (#1920 regression)" >&2
+  exit 1
+fi
+echo "  PASS (egress to 'newapi' namespace allowed — NewAPI v2 plane reachable)"
+
 echo "[baseline-cnp] Case 6: egress allow-list includes DNS (53/UDP + 53/TCP) to kube-dns"
 # Without DNS, every name lookup in catalyst-system fails. The CNP
 # explicitly allows kube-dns endpoints in kube-system on 53/UDP +

--- a/products/catalyst/chart/values.yaml
+++ b/products/catalyst/chart/values.yaml
@@ -1569,7 +1569,18 @@ security:
       - opentelemetry
       - external-secrets-system
       - cert-manager
+      # TBD-A38 (issue #1917, PR #1919): catalyst-system → sme east-west
+      # for voucher list / issue / redeem + tenant onboarding. The
+      # bp-sme-platform stack lives in `sme`; Console hits
+      # `gateway.sme.svc:8080`. Without the entry the CNP dropped the
+      # traffic and the Console 503'd with `context deadline exceeded`.
       - sme
+      # TBD-A43 (issue #1920): catalyst-system → newapi east-west for
+      # the customer-journey D29 NewAPI v2 calls (`newapi-*.newapi.svc`).
+      # Companion fix to #1919 — PR #1912 was titled "fix catalyst-system
+      # → sme/newapi egress" but only touched the world-egress TCP/6443
+      # block; this PR closes the `newapi` half of that theater.
+      - newapi
     # Adjacent namespaces whose Pods are allowed to INGRESS into
     # catalyst-system. Defaults cover:
     #   - catalyst — bp-self-sovereign-cutover Jobs (incl. the


### PR DESCRIPTION
## Summary

Theater fix of PR #1912 — `newapi` half. **Companion to PR #1919** (TBD-A38) which already shipped the `sme` half at chart 1.4.189.

PR #1912 was titled "fix catalyst-system → sme/newapi egress" but only touched the world-egress TCP/6443 block and never extended `.Values.security.baselineCnp.allowedPlatformNamespaces`. t32 fresh-prov walk (af1da1e7, 2026-05-19) confirmed Console → `gateway.sme.svc:8080` still returned **503 `context deadline exceeded`**. PR #1919 fixed the `sme` half during a parallel session; this PR closes the `newapi` half so catalyst-system → NewAPI v2 (`newapi-*.newapi.svc`) is also unblocked.

## What changed (rebased onto post-#1919 main)

- `products/catalyst/chart/values.yaml` — append `newapi` to `security.baselineCnp.allowedPlatformNamespaces` (next to the `sme` entry shipped by #1919) with full inline regression context.
- `products/catalyst/chart/templates/network-policies/baseline-catalyst-system.yaml` — append `"newapi"` to the template fallback list `default (list "keycloak" ... "sme")` so a `--reset-values` install still renders the allow.
- `products/catalyst/chart/tests/baseline-cnp-allowlist.sh` — new **Case 5c** (sme — regression guard for #1917 + #1920) + **Case 5d** (newapi — regression guard for #1920). Any future narrowing fails Blueprint Release CI before the OCI artifact ships.
- `products/catalyst/chart/Chart.yaml` — bump 1.4.189 → **1.4.190** with full changelog block referencing #1920, #1919, and the theater incident on #1912.
- `clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml` — pin bump 1.4.189 → **1.4.190**.

## Current allow-list (live on t32 primary, BEFORE this PR)

```
$ kubectl --kubeconfig=/home/openova/.kube/sov-t32.yaml -n catalyst-system get cnp baseline-default-deny -o yaml
...
        values:
        - keycloak
        - gitea
        - powerdns
        - cnpg-system
        - openbao
        - harbor
        - nats-system
        - loki
        - mimir
        - tempo
        - alloy
        - opentelemetry
        - external-secrets-system
        - cert-manager
```

`sme` and `newapi` both absent. (#1919 chart 1.4.189 had not yet rolled out to t32 at the time of capture.)

## Fixed allow-list (rendered from this PR, chart 1.4.190)

```
$ helm template smoke products/catalyst/chart --show-only \
    templates/network-policies/baseline-catalyst-system.yaml
...
              values:
                - "keycloak"
                - "gitea"
                - "powerdns"
                - "cnpg-system"
                - "openbao"
                - "harbor"
                - "nats-system"
                - "loki"
                - "mimir"
                - "tempo"
                - "alloy"
                - "opentelemetry"
                - "external-secrets-system"
                - "cert-manager"
                - "sme"
                - "newapi"
```

## Validation

### chart-tests — 15/15 green (was 13 pre-#1919, plus my 2 new Cases 5c/5d)

```
[baseline-cnp] Case 5c: egress allow-list includes 'sme' namespace — #1917/#1920 regression guard (TBD-A38/A43)
  PASS (egress to 'sme' namespace allowed — Console → gateway.sme.svc unblocked)
[baseline-cnp] Case 5d: egress allow-list includes 'newapi' namespace — #1920 regression guard (TBD-A43)
  PASS (egress to 'newapi' namespace allowed — NewAPI v2 plane reachable)
...
[baseline-cnp] All gates green.
```

### kubectl --dry-run=server against live t32 primary

```
$ kubectl --kubeconfig=/home/openova/.kube/sov-t32.yaml apply --dry-run=server \
    -f /tmp/cnp-rendered.yaml
ciliumnetworkpolicy.cilium.io/baseline-default-deny configured (server dry run)
```

## Test plan
- [x] `helm template` renders both `"sme"` and `"newapi"` under egress `matchExpressions.values`
- [x] `tests/baseline-cnp-allowlist.sh` — 15/15 cases green
- [x] `kubectl apply --dry-run=server` against live t32 — `configured`
- [x] Rebased cleanly onto post-#1919 main (chart 1.4.189 → 1.4.190)
- [ ] Next fresh prov: catalyst-system → `newapi-*.newapi.svc` calls succeed (no 503/timeout)
- [ ] Customer journey D29 walk-through GREEN end-to-end

Closes #1920
Refs #1912 #1919