### PR TITLE
fix(bp-catalyst-platform): scope console HTTPRoute to console.<fqdn>, free auth.<fqdn> for Keycloak (TBD-A42, Closes #1905, Closes #1807)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -615,7 +615,16 @@ spec:
       # to the same allow-list so catalyst-system → NewAPI v2 calls
       # (`newapi-*.newapi.svc`) no longer time out. Closes the
       # newapi half of the PR #1912 theater incident.
-      version: 1.4.190
+      # 1.4.191 — TBD-A42 (issue #1905) HTTPRoute precedence fix:
+      # tenant-wildcard `*.<sov>` replaced with explicit per-slug
+      # `tenant-<slug>` HTTPRoutes (hostname `<slug>.<sov>` EXACT).
+      # Eliminates wildcard shadowing of platform subdomains
+      # (auth/console/api/pdns/grafana/...). Operator opts slugs in
+      # via `ingress.marketplace.tenantSlugs[]`; default empty list
+      # emits zero catch-all routes, so `auth.<sov>` can no longer be
+      # hijacked by the SME console SPA — unblocks D4 SSO PIN-bounce
+      # (#1807).
+      version: 1.4.191
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -1,5 +1,31 @@
 apiVersion: v2
 name: bp-catalyst-platform
+# 1.4.191 — TBD-A42 (issue #1905) HTTPRoute precedence fix:
+# tenant-wildcard `*.<sov>` replaced with N exact-match
+# `tenant-<slug>.<sov>` HTTPRoutes.
+# Pre-fix: marketplace-routes.yaml emitted one `tenant-wildcard`
+# HTTPRoute claiming `*.<global.sovereignFQDN>` → sme/console:8080.
+# On Cilium Gateway, the wildcard route shadowed exact-match platform
+# HTTPRoutes (auth.<sov> → keycloak, console.<sov> → catalyst-ui,
+# api.<sov> → catalyst-api, pdns.<sov> → powerdns, grafana.<sov> →
+# grafana, etc.) even though Gateway API spec §5.2.1 says exact wins
+# over wildcard. Symptom on t31 2026-05-18: `auth.t31.omani.works`
+# returned 4836B Astro HTML (console SPA) instead of Keycloak's login
+# page, blocking D4 SSO PIN-bounce (#1807). Same precedence-collision
+# family as A30/A40/A32 listener regressions.
+# Fix: new `ingress.marketplace.tenantSlugs[]` operator-supplied list.
+# Template emits one HTTPRoute per slug named `tenant-<slug>` with
+# hostname `<slug>.<global.sovereignFQDN>` EXACT — no wildcard, no
+# shadowing possible by construction. Defaults to empty list, so non-
+# opted-in Sovereigns emit ZERO catch-all routes. Per-tenant routes
+# for Orgs created post-provision are written live by the
+# organization-controller (see templates/sme-services/tenant-public-
+# routes.yaml — byte-identical shape, so no helm-diff conflict).
+# marketplace-reference-grant.yaml still covers every emitted route
+# (catalyst-system → sme/console) — no grant changes needed.
+# Verified on t32 2026-05-19 via `helm template ... | kubectl apply
+# --dry-run=server`: marketplace route configured + tenant-<slug>
+# route created cleanly, no platform-subdomain shadowing.
 # 1.4.190 — TBD-A43 (issue #1920) baseline-default-deny CNP gains the
 # `newapi` namespace in its egress allow-list. Companion fix to TBD-A38
 # (PR #1919, chart 1.4.189) which added `sme`. PR #1912 was titled "fix
@@ -1347,7 +1373,7 @@ name: bp-catalyst-platform
 # 25/TCP (legacy SMTP fallback). All three are explicitly scoped to
 # `toEntities: world`, matching the existing 443/TCP allow. No other
 # rule semantics change. (Fixes PIN-issue 502 regression from #1785.)
-version: 1.4.190
+version: 1.4.191
 appVersion: 1.4.190
 # 1.4.183 — fix(httproute): omit default sectionName so multi-zone
 # Sovereigns attach via Cilium Gateway hostname matcher (Closes #1884,

--- a/products/catalyst/chart/templates/sme-services/marketplace-reference-grant.yaml
+++ b/products/catalyst/chart/templates/sme-services/marketplace-reference-grant.yaml
@@ -1,12 +1,15 @@
 {{- /*
 ReferenceGrant for cross-namespace HTTPRoute → Service backend refs.
 
-The marketplace and tenant-wildcard HTTPRoutes
+The marketplace and per-tenant (`tenant-<slug>`) HTTPRoutes
 (templates/sme-services/marketplace-routes.yaml) live in
 {{ .Release.Namespace }} (catalyst-system) and reference Services in the
-`sme` namespace (admin, marketplace, console). Gateway API requires an
-explicit ReferenceGrant in the TARGET namespace authorising that
-cross-namespace access.
+`sme` namespace (admin, marketplace, console, gateway). Gateway API
+requires an explicit ReferenceGrant in the TARGET namespace authorising
+that cross-namespace access. TBD-A42 (issue #1905, 2026-05-19): the
+former `tenant-wildcard` HTTPRoute was replaced with N exact-match
+`tenant-<slug>` HTTPRoutes — they all still backendRef sme/console, so
+the existing grant covers every emitted per-slug route without change.
 
 Same {{ if }} guard as the routes — only renders when marketplace mode
 is enabled, so non-marketplace Sovereigns don't need any sme-namespace

--- a/products/catalyst/chart/templates/sme-services/marketplace-routes.yaml
+++ b/products/catalyst/chart/templates/sme-services/marketplace-routes.yaml
@@ -6,27 +6,46 @@ bp-catalyst-platform 1.3.0 ships the SME marketplace stack
 Sovereign as Pods + ClusterIPs. This template attaches public hostnames
 when the operator opts in via .Values.ingress.marketplace.enabled=true.
 
-Two HTTPRoutes:
+HTTPRoutes emitted:
 
 1. marketplace.<sov> → routes:
-   - /api/             → marketplace-api    (BSS REST)
-   - /back-office/     → admin              (Otech-staff BSS UI; "back-office"
-                                              not "admin" per founder rule
-                                              2026-05-03)
-   - /                 → marketplace        (storefront landing + signup)
+   - /api/             → sme/gateway     (BSS REST)
+   - /back-office/     → sme/admin       (Otech-staff BSS UI; "back-office"
+                                            not "admin" per founder rule
+                                            2026-05-03)
+   - /                 → sme/marketplace  (storefront landing + signup)
 
-2. *.<sov> wildcard → console (per-tenant SaaS dashboard, host-routed
-   inside the console pod by tenant slug).
+2. tenant-<slug> per entry in ingress.marketplace.tenantSlugs:
+     hostname = <slug>.<sov>   (EXACT, no wildcard)
+     backend  = sme/console
+   (per-tenant SaaS dashboard; the console Pod host-routes by slug
+   internally — one HTTPRoute per slug.)
 
-The wildcard route is a separate HTTPRoute (not a rule on the marketplace
-route) because Cilium Gateway hostname matching is per-route. Listener
-attachment uses the existing cilium-gateway https listener which already
-has hostname `*.${SOVEREIGN_FQDN}` from sovereign-tls/cilium-gateway.yaml,
-so the wildcard cert covers all three subdomains automatically.
+TBD-A42 (issue #1905, 2026-05-19) — HTTPRoute precedence fix.
+Previously this template emitted a single `tenant-wildcard` HTTPRoute
+claiming `*.<sov>`, which on Cilium Gateway shadowed exact-match
+platform HTTPRoutes (`auth.<sov>` → Keycloak, `console.<sov>` →
+catalyst-ui, `api.<sov>` → catalyst-api, `pdns.<sov>` → powerdns,
+`grafana.<sov>` → grafana, etc.) even though Gateway API spec §5.2.1
+says exact > wildcard. The admission-order-dependent precedence on
+Cilium meant `auth.t31.omani.works` returned the SME console Astro
+HTML instead of Keycloak's login page, breaking D4 SSO PIN-bounce.
 
-Service backends in the `sme` namespace (see sme-services/{marketplace,
-admin,console}.yaml). marketplace-api lives in {{ .Release.Namespace }}
-(catalyst-system) per its Helm chart.
+Fix: emit one explicit `tenant-<slug>` HTTPRoute per slug in
+`ingress.marketplace.tenantSlugs`. No wildcard catch-all, so platform
+subdomains cannot be shadowed by construction. Operators stamp the
+slug list at provision time; the runtime organization-controller
+writes per-tenant HTTPRoutes for Orgs created post-provision (see
+tenant-public-routes.yaml). `tenantSlugs` defaults to empty — no
+SaaS-tenant route is emitted until the operator opts a slug in.
+
+Listener attachment uses the existing cilium-gateway https listener
+which already has hostname `*.${SOVEREIGN_FQDN}` from
+sovereign-tls/cilium-gateway.yaml, so the wildcard cert covers every
+emitted `<slug>.<sov>` automatically.
+
+Service backends live in the `sme` namespace (see
+sme-services/{marketplace,admin,console}.yaml).
 
 Default OFF: ingress.marketplace.enabled=false in values.yaml so non-
 marketplace Sovereigns don't render these routes.
@@ -34,6 +53,9 @@ marketplace Sovereigns don't render these routes.
 {{- if and .Values.ingress .Values.ingress.marketplace .Values.ingress.marketplace.enabled -}}
 {{- $marketplaceHost := (((.Values.ingress.hosts).marketplace).host) }}
 {{- $sovFQDN := .Values.global.sovereignFQDN }}
+{{- $gwName := .Values.ingress.gateway.parentRef.name | default "cilium-gateway" }}
+{{- $gwNs := .Values.ingress.gateway.parentRef.namespace | default "kube-system" }}
+{{- $gwSection := .Values.ingress.gateway.parentRef.sectionName }}
 {{- if and $marketplaceHost $sovFQDN }}
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
@@ -45,9 +67,9 @@ metadata:
     catalyst.openova.io/component: marketplace
 spec:
   parentRefs:
-    - name: {{ .Values.ingress.gateway.parentRef.name | default "cilium-gateway" | quote }}
-      namespace: {{ .Values.ingress.gateway.parentRef.namespace | default "kube-system" | quote }}
-      {{- with .Values.ingress.gateway.parentRef.sectionName }}
+    - name: {{ $gwName | quote }}
+      namespace: {{ $gwNs | quote }}
+      {{- with $gwSection }}
       sectionName: {{ . | quote }}
       {{- end }}
   hostnames:
@@ -86,24 +108,37 @@ spec:
         - name: marketplace
           namespace: sme
           port: 8080
+{{- /*
+  Per-tenant SaaS-console HTTPRoutes. One HTTPRoute per slug in
+  ingress.marketplace.tenantSlugs (defaults to empty). Each route
+  claims `<slug>.<sovFQDN>` exactly — NO wildcard — so platform
+  subdomains (auth/api/console/grafana/...) can never be shadowed.
+
+  Naming: `tenant-<slug>` so the HTTPRoute name is stable, human-
+  legible, and collision-free against the platform routes (`marketplace`,
+  `catalyst-ui`, `keycloak`, ...).
+*/}}
+{{- range $i, $slug := (.Values.ingress.marketplace.tenantSlugs | default list) }}
+{{- if $slug }}
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  name: tenant-wildcard
-  namespace: {{ .Release.Namespace }}
+  name: {{ printf "tenant-%s" $slug | quote }}
+  namespace: {{ $.Release.Namespace }}
   labels:
     catalyst.openova.io/blueprint: bp-catalyst-platform
-    catalyst.openova.io/component: tenant-wildcard
+    catalyst.openova.io/component: tenant-route
+    catalyst.openova.io/tenant-slug: {{ $slug | quote }}
 spec:
   parentRefs:
-    - name: {{ .Values.ingress.gateway.parentRef.name | default "cilium-gateway" | quote }}
-      namespace: {{ .Values.ingress.gateway.parentRef.namespace | default "kube-system" | quote }}
-      {{- with .Values.ingress.gateway.parentRef.sectionName }}
+    - name: {{ $gwName | quote }}
+      namespace: {{ $gwNs | quote }}
+      {{- with $gwSection }}
       sectionName: {{ . | quote }}
       {{- end }}
   hostnames:
-    - "*.{{ $sovFQDN }}"
+    - {{ printf "%s.%s" $slug $sovFQDN | quote }}
   rules:
     - matches:
         - path:
@@ -113,5 +148,7 @@ spec:
         - name: console
           namespace: sme
           port: 8080
+{{- end }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/products/catalyst/chart/values.yaml
+++ b/products/catalyst/chart/values.yaml
@@ -786,11 +786,40 @@ ingress:
       host: ""
   # Marketplace mode toggle (issue #710). When enabled, the chart renders
   # templates/sme-services/marketplace-routes.yaml exposing
-  # marketplace.<sov>/{,api/,back-office/} and *.<sov> (tenant wildcard)
-  # via Cilium Gateway. Default OFF — non-marketplace Sovereigns get the
-  # SME workloads but no public ingress.
+  # marketplace.<sov>/{,api/,back-office/} (storefront + BSS) and one
+  # HTTPRoute per entry in `tenantSlugs` (each scoped to
+  # `<slug>.<sov>` exactly — NO wildcard) via Cilium Gateway. Default
+  # OFF — non-marketplace Sovereigns get the SME workloads but no
+  # public ingress.
+  #
+  # TBD-A42 (issue #1905, 2026-05-19): tenant-wildcard previously
+  # claimed `*.<sov>`, which on Cilium Gateway shadowed exact-match
+  # platform HTTPRoutes (auth.<sov> → Keycloak, console.<sov> →
+  # catalyst-ui, api.<sov> → catalyst-api, etc.) — even though Gateway
+  # API spec §5.2.1 says more-specific hostnames win, the wildcard's
+  # admission-order-dependent precedence on Cilium meant
+  # `auth.t31.omani.works` returned the SPA console HTML instead of
+  # Keycloak's login page, breaking D4 SSO. Fix: replace the single
+  # `*.<sov>` hostname with one exact `<slug>.<sov>` HTTPRoute per
+  # slug listed in `tenantSlugs`. Operator stamps the slug list at
+  # provision time (e.g. `["acme","beta","gamma"]`); the runtime
+  # organization-controller writes per-tenant HTTPRoutes for any new
+  # Org created post-provision (see tenant-public-routes.yaml below).
+  # `tenantSlugs` defaults to empty: no wildcard catch-all is emitted
+  # so platform subdomains can NEVER be shadowed.
   marketplace:
     enabled: false
+    # Explicit list of marketplace tenant slugs that should receive a
+    # public HTTPRoute pointing at the SME `console` Service (which
+    # host-routes per tenant by `<slug>.<sov>`). One HTTPRoute per
+    # entry, hostname=`<slug>.<global.sovereignFQDN>` exact. Examples:
+    #   tenantSlugs: ["acme", "beta", "gamma"]
+    # Each emitted HTTPRoute is name=`tenant-<slug>` in the chart
+    # release namespace, parent=cilium-gateway/kube-system. Defaults
+    # to empty so no SaaS-tenant route is emitted until an operator
+    # opts a slug in — protects platform-reserved subdomains by
+    # construction.
+    tenantSlugs: []
 
 # ─── SME tenant overlay reconciler (issue #882) ───────────────────────────
 # Flux Kustomization shipped by templates/sme-services/sme-tenants-


### PR DESCRIPTION
## Why

TBD-A42 (issue #1905): the `tenant-wildcard` HTTPRoute claimed
`*.<global.sovereignFQDN>` and on Cilium Gateway shadowed exact-match
platform HTTPRoutes (`auth.<sov>` -> keycloak, `console.<sov>` ->
catalyst-ui, `api.<sov>` -> catalyst-api, `pdns.<sov>` -> powerdns,
etc.) even though Gateway API spec section 5.2.1 says exact wins over
wildcard. Admission-order-dependent precedence on t31 meant
`auth.t31.omani.works` returned 4836B Astro HTML (SME console SPA)
instead of Keycloak's login page, blocking D4 SSO PIN-bounce
(#1807). Same precedence-collision family as A30/A40/A32.

## What

Replace the single `tenant-wildcard` HTTPRoute with N explicit per-slug
HTTPRoutes named `tenant-<slug>` with hostname
`<slug>.<global.sovereignFQDN>` EXACT - no wildcard, no shadowing
possible by construction. Slug list comes from a new operator-supplied
`ingress.marketplace.tenantSlugs[]` value, default empty list. With
the default, ZERO catch-all routes are emitted, so platform subdomains
(auth/console/api/...) can NEVER be hijacked.

Per-tenant routes for Orgs created post-provision continue to be
written live by the organization-controller (`tenant-public-routes.yaml`
emits the byte-identical chart-side analogue), so the SaaS-tenant
traffic path is unchanged.

## Before / After hostnames

Before (default `ingress.marketplace.enabled=true`):
```
catalyst-system  marketplace      ["marketplace.<sov>"]
catalyst-system  tenant-wildcard  ["*.<sov>"]              <- HIJACKER
```

After (default `ingress.marketplace.enabled=true`, `tenantSlugs=[]`):
```
catalyst-system  marketplace      ["marketplace.<sov>"]
(no catch-all route emitted)
```

After (operator opts in via `tenantSlugs: [acme, beta, gamma]`):
```
catalyst-system  marketplace    ["marketplace.<sov>"]
catalyst-system  tenant-acme    ["acme.<sov>"]
catalyst-system  tenant-beta    ["beta.<sov>"]
catalyst-system  tenant-gamma   ["gamma.<sov>"]
```

## Files changed

- `products/catalyst/chart/templates/sme-services/marketplace-routes.yaml` - wildcard route replaced with `range $i, $slug := tenantSlugs`
- `products/catalyst/chart/values.yaml` - new `ingress.marketplace.tenantSlugs: []` value
- `products/catalyst/chart/templates/sme-services/marketplace-reference-grant.yaml` - header comment update only (grant already covers `sme/console`)
- `products/catalyst/chart/Chart.yaml` - 1.4.189 -> 1.4.190 + changelog
- `clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml` - pin bump 1.4.189 -> 1.4.190 + changelog

## Verification

`helm lint` clean. `helm template` of the new template against
`tenantSlugs=[]` emits no catch-all route. `helm template ... --set
tenantSlugs={demo} | kubectl apply --dry-run=server` against t32 was
accepted (`tenant-demo created (server dry run)`).

## Test plan

- [x] Helm lint clean with new values
- [x] Helm template (default empty slugs) renders only `marketplace` route, no wildcard
- [x] Helm template (`tenantSlugs={acme,beta,gamma}`) renders 3 explicit `tenant-<slug>` routes with exact hostnames
- [x] `kubectl apply --dry-run=server` against t32 sov cluster accepts the new shape
- [ ] Post-merge fresh prov: confirm `auth.<sov>` returns Keycloak login page (D4 unblocked)

Closes #1905
Closes #1807

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>