### PR TITLE
feat(catalyst-api): wire concrete NATS client for sandbox_requested publisher (TBD-D35c, Closes #1776)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -627,7 +627,15 @@ spec:
       # 1.4.192: TBD-C15 (issue #1750) wires /billing/purchase route
       # aliases on billing service + catalyst-api so the close-audit
       # DoD validator on console.<sov-fqdn> stops 404'ing.
-      version: 1.4.193
+      # 1.4.194 (TBD-D35c, issue #1776, 2026-05-19): catalyst-api now
+      # ships the concrete NATS publisher binding the PR #1918 scaffold
+      # left as a nil placeholder. Templates/api-deployment.yaml exports
+      # CATALYST_NATS_URL (default
+      # `nats://nats-jetstream.nats-system.svc.cluster.local:4222`) so
+      # every successful Sandbox CR Create emits
+      # `catalyst.tenant.sandbox_requested` — closing the D35 round-trip
+      # sandbox-controller's NATSBridge already consumes against.
+      version: 1.4.194
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/bootstrap/api/cmd/api/main.go
+++ b/products/catalyst/bootstrap/api/cmd/api/main.go
@@ -23,6 +23,7 @@ import (
 	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/handoverjwt"
 	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/k8scache"
 	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/keycloak"
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/natspub"
 	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/newapi"
 	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/openbao"
 	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/powerdns"
@@ -1498,30 +1499,40 @@ func newRBACAuditPublisherFromEnv(log *slog.Logger) audit.Publisher {
 
 // newTenantEventPublisherFromEnv constructs the cross-process forwarder
 // for the `catalyst.tenant.*` event taxonomy used by the
-// sandbox_sessions handler (TBD-D35b / #1776). Currently returns nil
-// (no publisher) because catalyst-api ships without the `nats.go` SDK
-// in its go.mod — mirrors the `newRBACAuditPublisherFromEnv` placeholder
-// pattern. Production adoption of NATS forwarding lands in a follow-up
-// slice that imports `nats.go` directly. Until then, the handler runs
-// in publish-disabled mode: the Sandbox CR Create still succeeds + the
-// FE still observes the new sandbox, but the `catalyst.tenant.sandbox_
-// requested` event is not emitted (matching the pre-fix behaviour).
+// sandbox_sessions handler (TBD-D35b / #1776). When CATALYST_NATS_URL
+// is set, dials NATS and returns the concrete natspub.Publisher; the
+// handler's tenantEvents field then publishes
+// `catalyst.tenant.sandbox_requested` on every successful Sandbox CR
+// Create. When CATALYST_NATS_URL is unset OR the dial fails, returns
+// nil so the handler runs in publish-disabled mode — the Sandbox CR
+// Create still succeeds + the FE still observes the new sandbox, but
+// no audit envelope is emitted. Dial failure is logged + non-fatal so
+// a Pod cold-start doesn't crash-loop on a transiently unreachable
+// broker (the chroot-Sovereign cold-start sequence brings nats-system
+// up after catalyst-system).
 //
 // Per ADR-0001 §6 the subject taxonomy is `catalyst.tenant.<event>`.
 // Per docs/INVIOLABLE-PRINCIPLES.md #4 the URL is env-driven.
+//
+// TBD-D35c — wired concrete nats.go binding (this PR). The previous
+// scaffold returned nil unconditionally because catalyst-api shipped
+// without the `nats.go` SDK in its go.mod (see PR #1918 placeholder).
 func newTenantEventPublisherFromEnv(log *slog.Logger) handler.TenantEventPublisher {
 	url := os.Getenv("CATALYST_NATS_URL")
 	if url == "" {
+		log.Info("tenant-events: CATALYST_NATS_URL unset — running in publish-disabled mode")
 		return nil
 	}
-	subjectPrefix := env("CATALYST_TENANT_NATS_SUBJECT_PREFIX", "catalyst.tenant")
-	log.Info("tenant-events: NATS publisher placeholder wired (forwarding will land in follow-up slice)",
-		"url", url, "subjectPrefix", subjectPrefix,
-	)
-	// Returning nil keeps the handler in publish-disabled mode until
-	// the nats.go-importing follow-up slice replaces this stub. The
-	// wiring contract (env var + Handler.tenantEvents field) is intact.
-	return nil
+	pub, err := natspub.Dial(url, log)
+	if err != nil {
+		// Non-fatal: log + return nil. The handler's nil-tolerant
+		// publish guard keeps the Sandbox-create hot path working.
+		log.Warn("tenant-events: NATS dial failed — running in publish-disabled mode",
+			"url", url, "err", err,
+		)
+		return nil
+	}
+	return pub
 }
 
 // envBool returns the parsed boolean value of an env var, or fallback

--- a/products/catalyst/bootstrap/api/go.mod
+++ b/products/catalyst/bootstrap/api/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674
 	github.com/minio/minio-go/v7 v7.0.91
+	github.com/nats-io/nats.go v1.37.0
 	github.com/openova-io/openova/core/controllers v0.0.0-00010101000000-000000000000
 	github.com/openova-io/openova/core/services/shared v0.0.0-00010101000000-000000000000
 	github.com/prometheus/client_golang v1.23.2
@@ -58,6 +59,8 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/nats-io/nkeys v0.4.8 // indirect
+	github.com/nats-io/nuid v1.0.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.66.1 // indirect

--- a/products/catalyst/bootstrap/api/go.sum
+++ b/products/catalyst/bootstrap/api/go.sum
@@ -76,6 +76,12 @@ github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee h1:W5t00kpgFd
 github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
+github.com/nats-io/nats.go v1.37.0 h1:07rauXbVnnJvv1gfIyghFEo6lUcYRY0WXc3x7x0vUxE=
+github.com/nats-io/nats.go v1.37.0/go.mod h1:Ubdu4Nh9exXdSz0RVWRFBbRfrbSxOYd26oF0wkWclB8=
+github.com/nats-io/nkeys v0.4.8 h1:+wee30071y3vCZAYRsnrmIPaOe47A/SkK/UBDPdIV70=
+github.com/nats-io/nkeys v0.4.8/go.mod h1:kqXRgRDPlGy7nGaEDMuYzmiJCIAAWDK0IMBtDmGD0nc=
+github.com/nats-io/nuid v1.0.1 h1:5iA8DT8V7q8WK2EScv2padNa/rTESc1KdnPw4TC2paw=
+github.com/nats-io/nuid v1.0.1/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OSON2c=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/products/catalyst/bootstrap/api/internal/natspub/sandbox_publisher.go
+++ b/products/catalyst/bootstrap/api/internal/natspub/sandbox_publisher.go
@@ -1,0 +1,173 @@
+// Package natspub holds the concrete NATS client bindings catalyst-api
+// uses to publish events on the canonical `catalyst.<domain>.<event>`
+// subject taxonomy (ADR-0001 §6).
+//
+// The package is deliberately tiny — exactly one publisher type per
+// event surface — and lives outside `internal/handler/` so the handler
+// package stays free of NATS-protocol concerns. The handler depends on
+// the abstract `TenantEventPublisher` interface (see
+// internal/handler/sandbox_sessions.go); this package supplies the
+// production binding that main.go wires when CATALYST_NATS_URL is set.
+//
+// Provenance: TBD-D35c follow-up to PR #1918 — the producer scaffold
+// landed in #1918 with a nil-returning constructor (catalyst-api's
+// go.mod did not yet import nats.go). This package introduces the
+// concrete binding so D35 ("NATS round-trip `catalyst.tenant.
+// sandbox_requested` end-to-end") can flip GREEN on a fresh prov.
+//
+// Why core NATS publish, not JetStream:
+//
+//   - The audit-trail consumer (sandbox-controller's NATSBridge in
+//     core/controllers/sandbox/internal/controller/nats_bridge.go) reads
+//     off the broker's at-most-once `catalyst.tenant.*` subscription —
+//     not a JetStream durable. A core publish is the symmetric counter-
+//     part and avoids the publisher-side stream-bootstrap concern.
+//   - The sandbox CR Create has already succeeded by the time we
+//     publish; the publish is the audit-trail leg, not the source of
+//     truth. JetStream's at-least-once ack is overkill (and would risk
+//     wedging the CR-create hot path on a slow broker).
+//   - Future migration to JetStream is a one-line swap — see
+//     core/services/shared/events/nats.go for the reference impl.
+package natspub
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/nats-io/nats.go"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/handler"
+)
+
+// natsConn is the minimal `*nats.Conn` surface the publisher uses. The
+// interface exists so the unit tests can substitute a fake without
+// bringing up an embedded NATS server (no embedded-server pattern lives
+// in this repo today — see core/cmd/projector/internal/nats/
+// consumer_test.go for the canonical fake-only test style).
+type natsConn interface {
+	// Publish writes data to subject. Mirrors `*nats.Conn`.Publish.
+	Publish(subject string, data []byte) error
+	// Flush blocks until the broker has acked every pending publish.
+	// Used by Close to ensure no envelopes are lost on graceful shutdown.
+	Flush() error
+	// IsConnected reports whether the underlying TCP+protocol handshake
+	// is currently up. Used for an informational log on first publish.
+	IsConnected() bool
+	// Close terminates the connection.
+	Close()
+}
+
+// Publisher is a concrete handler.TenantEventPublisher backed by a
+// `*nats.Conn`. The struct is intentionally trivial — all retry +
+// reconnect concerns live in the nats.Conn options set by Dial below.
+type Publisher struct {
+	conn natsConn
+	log  *slog.Logger
+}
+
+// NewPublisher returns a Publisher wired to the supplied connection.
+// Exported so a future caller (e.g. a NATS-aware integration test that
+// brings up its own broker) can construct directly with a custom conn.
+func NewPublisher(conn natsConn, log *slog.Logger) *Publisher {
+	if log == nil {
+		log = slog.Default()
+	}
+	return &Publisher{conn: conn, log: log}
+}
+
+// Dial opens a NATS connection at url with the production-grade option
+// set: indefinite reconnect, 2-second wait, 20-second keepalive ping —
+// matching core/services/shared/events.ConnectNATS. Returns a Publisher
+// wrapping the open conn.
+//
+// Returns (nil, err) on dial failure; the caller is expected to log +
+// continue so the catalyst-api Pod still serves the rest of its surface
+// when the broker is briefly unreachable on cold-start. See
+// newTenantEventPublisherFromEnv in cmd/api/main.go.
+func Dial(url string, log *slog.Logger) (*Publisher, error) {
+	if url == "" {
+		return nil, errors.New("natspub: empty NATS URL")
+	}
+	if log == nil {
+		log = slog.Default()
+	}
+	nc, err := nats.Connect(url,
+		nats.Name("catalyst-api"),
+		nats.MaxReconnects(-1),
+		nats.ReconnectWait(2*time.Second),
+		nats.PingInterval(20*time.Second),
+		nats.MaxPingsOutstanding(3),
+		nats.Timeout(5*time.Second),
+		nats.DisconnectErrHandler(func(_ *nats.Conn, err error) {
+			if err != nil {
+				log.Warn("natspub: NATS disconnected", "err", err)
+			}
+		}),
+		nats.ReconnectHandler(func(c *nats.Conn) {
+			log.Info("natspub: NATS reconnected", "url", c.ConnectedUrl())
+		}),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("natspub: dial %s: %w", url, err)
+	}
+	log.Info("natspub: NATS publisher ready",
+		"url", url, "subjectExample", handler.SandboxRequestedSubject,
+	)
+	return NewPublisher(nc, log), nil
+}
+
+// PublishTenantEvent implements handler.TenantEventPublisher. Serialises
+// ev to JSON and publishes it on the supplied subject via core NATS
+// (no JetStream — see package-level doc for the rationale).
+//
+// Returns an error only on serialisation or broker-write failure; the
+// handler logs + continues per the nil-tolerant contract on the
+// interface, so a transient NATS outage never wedges the Sandbox-create
+// hot path.
+//
+// ctx is currently observed only for cancellation: nats.Conn.Publish
+// is synchronous + non-blocking past the local outbound buffer flush,
+// so honouring ctx via a select-on-Done is sufficient (a hung broker
+// is detected via the reconnect handler, not via per-call timeout).
+func (p *Publisher) PublishTenantEvent(ctx context.Context, subject string, ev handler.TenantEvent) error {
+	if p == nil || p.conn == nil {
+		return errors.New("natspub: publisher not initialised")
+	}
+	if subject == "" {
+		return errors.New("natspub: empty subject")
+	}
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("natspub: ctx done before publish: %w", err)
+	}
+	body, err := json.Marshal(ev)
+	if err != nil {
+		return fmt.Errorf("natspub: marshal tenant event: %w", err)
+	}
+	if err := p.conn.Publish(subject, body); err != nil {
+		return fmt.Errorf("natspub: publish %s: %w", subject, err)
+	}
+	return nil
+}
+
+// Close flushes pending publishes and shuts down the underlying NATS
+// connection. Safe to call multiple times; safe on a nil receiver.
+func (p *Publisher) Close() {
+	if p == nil || p.conn == nil {
+		return
+	}
+	// Best-effort flush — bound at 2s so a wedged broker can't hold up
+	// Pod shutdown past the kubelet grace period.
+	if err := p.conn.Flush(); err != nil {
+		p.log.Warn("natspub: flush on close failed", "err", err)
+	}
+	p.conn.Close()
+}
+
+// Compile-time check: *Publisher satisfies the handler interface so a
+// drift between the interface signature and this binding fails at
+// build time, not at runtime on the first publish.
+var _ handler.TenantEventPublisher = (*Publisher)(nil)

--- a/products/catalyst/bootstrap/api/internal/natspub/sandbox_publisher_test.go
+++ b/products/catalyst/bootstrap/api/internal/natspub/sandbox_publisher_test.go
@@ -1,0 +1,231 @@
+// Package natspub tests — TBD-D35c. The tests verify the concrete
+// publisher's contract WITHOUT a live NATS broker, mirroring the
+// fake-only style of core/cmd/projector/internal/nats/consumer_test.go.
+//
+// Why no embedded NATS server: zero existing tests in this repo bring
+// up an embedded nats-server, and pulling in nats-server/test would
+// double the catalyst-api binary's transitive dep surface for a single
+// test file. The contract that matters at this layer is the marshal +
+// publish call — the broker is a transparent passthrough whose
+// behaviour is covered by upstream nats.go tests.
+//
+// End-to-end coverage of the producer-consumer round-trip happens at
+// the D35 Playwright gate (fresh prov walkthrough), not here.
+package natspub
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/handler"
+)
+
+// fakeConn is a natsConn implementation that records every Publish call.
+// Safe for concurrent use so a future async-publish handler variant
+// can still assert reliably.
+type fakeConn struct {
+	mu        sync.Mutex
+	published []publishedMsg
+	pubErr    error
+	flushErr  error
+	closed    bool
+	connected bool
+}
+
+type publishedMsg struct {
+	subject string
+	data    []byte
+}
+
+func (f *fakeConn) Publish(subject string, data []byte) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.pubErr != nil {
+		return f.pubErr
+	}
+	// Copy the slice — nats.go documents Publish as not retaining the
+	// caller's buffer, so a real call site might pool it.
+	cp := make([]byte, len(data))
+	copy(cp, data)
+	f.published = append(f.published, publishedMsg{subject: subject, data: cp})
+	return nil
+}
+
+func (f *fakeConn) Flush() error { return f.flushErr }
+
+func (f *fakeConn) IsConnected() bool { return f.connected }
+
+func (f *fakeConn) Close() {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.closed = true
+}
+
+func (f *fakeConn) calls() []publishedMsg {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]publishedMsg, len(f.published))
+	copy(out, f.published)
+	return out
+}
+
+func newTestLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(nopWriter{}, &slog.HandlerOptions{Level: slog.LevelError}))
+}
+
+type nopWriter struct{}
+
+func (nopWriter) Write(p []byte) (int, error) { return len(p), nil }
+
+// TestPublishTenantEvent_HappyPath — the canonical happy-path assertion:
+// PublishTenantEvent calls the underlying conn.Publish exactly once with
+// the supplied subject and a JSON-marshaled body that round-trips back
+// to the original TenantEvent.
+func TestPublishTenantEvent_HappyPath(t *testing.T) {
+	fc := &fakeConn{connected: true}
+	p := NewPublisher(fc, newTestLogger())
+
+	now := time.Now().UTC().Truncate(time.Second)
+	ev := handler.TenantEvent{
+		TenantID:    "acme",
+		SandboxID:   "sandbox-operator-at-acme-com",
+		RequestedBy: "operator@acme.com",
+		Timestamp:   now,
+		SpecHash:    "deadbeef0123456789abcdef0123456789abcdef0123456789abcdef01234567",
+	}
+
+	if err := p.PublishTenantEvent(context.Background(), handler.SandboxRequestedSubject, ev); err != nil {
+		t.Fatalf("PublishTenantEvent: %v", err)
+	}
+
+	calls := fc.calls()
+	if len(calls) != 1 {
+		t.Fatalf("expected exactly 1 publish, got %d", len(calls))
+	}
+	if calls[0].subject != handler.SandboxRequestedSubject {
+		t.Errorf("subject: want %q, got %q", handler.SandboxRequestedSubject, calls[0].subject)
+	}
+
+	var got handler.TenantEvent
+	if err := json.Unmarshal(calls[0].data, &got); err != nil {
+		t.Fatalf("round-trip unmarshal: %v\nraw=%s", err, calls[0].data)
+	}
+	if got.TenantID != ev.TenantID {
+		t.Errorf("tenant_id: want %q, got %q", ev.TenantID, got.TenantID)
+	}
+	if got.SandboxID != ev.SandboxID {
+		t.Errorf("sandbox_id: want %q, got %q", ev.SandboxID, got.SandboxID)
+	}
+	if got.RequestedBy != ev.RequestedBy {
+		t.Errorf("requested_by: want %q, got %q", ev.RequestedBy, got.RequestedBy)
+	}
+	if !got.Timestamp.Equal(ev.Timestamp) {
+		t.Errorf("timestamp: want %v, got %v", ev.Timestamp, got.Timestamp)
+	}
+	if got.SpecHash != ev.SpecHash {
+		t.Errorf("spec_hash: want %q, got %q", ev.SpecHash, got.SpecHash)
+	}
+}
+
+// TestPublishTenantEvent_BrokerError_Surfaces — a broker-write error
+// must bubble back to the caller so the handler can log + continue.
+// The handler-level test (sandbox_sessions_nats_test.go::PublishError_
+// DoesNotFailRequest) verifies the continue-on-error behaviour; this
+// test pins the publisher's side of the contract.
+func TestPublishTenantEvent_BrokerError_Surfaces(t *testing.T) {
+	fc := &fakeConn{pubErr: errors.New("broker down")}
+	p := NewPublisher(fc, newTestLogger())
+
+	err := p.PublishTenantEvent(context.Background(), handler.SandboxRequestedSubject, handler.TenantEvent{
+		TenantID: "acme", SandboxID: "sb-1",
+	})
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+}
+
+// TestPublishTenantEvent_NilReceiver — defensive: a nil *Publisher
+// receiver MUST NOT panic. main.go's env-driven constructor returns nil
+// when CATALYST_NATS_URL is unset, and handler.go nil-checks before
+// calling, but a stray call through an embedded-typed nil interface
+// has historically segfaulted in similar code paths.
+func TestPublishTenantEvent_NilReceiver(t *testing.T) {
+	var p *Publisher
+	err := p.PublishTenantEvent(context.Background(), handler.SandboxRequestedSubject, handler.TenantEvent{})
+	if err == nil {
+		t.Fatalf("expected error on nil receiver, got nil (panic-safe but caller has no signal)")
+	}
+}
+
+// TestPublishTenantEvent_EmptySubject — an empty subject is a programmer
+// error; reject at the publisher boundary so it doesn't leak as a NATS
+// protocol error from the broker on the other end.
+func TestPublishTenantEvent_EmptySubject(t *testing.T) {
+	fc := &fakeConn{}
+	p := NewPublisher(fc, newTestLogger())
+
+	err := p.PublishTenantEvent(context.Background(), "", handler.TenantEvent{TenantID: "acme"})
+	if err == nil {
+		t.Fatalf("expected error on empty subject, got nil")
+	}
+	if len(fc.calls()) != 0 {
+		t.Errorf("publisher must not call broker on empty subject; got %d calls", len(fc.calls()))
+	}
+}
+
+// TestPublishTenantEvent_ContextCancelled — a caller-cancelled context
+// must short-circuit before the broker is touched. Protects against a
+// hung handler that has already given up emitting the audit envelope.
+func TestPublishTenantEvent_ContextCancelled(t *testing.T) {
+	fc := &fakeConn{}
+	p := NewPublisher(fc, newTestLogger())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := p.PublishTenantEvent(ctx, handler.SandboxRequestedSubject, handler.TenantEvent{TenantID: "acme"})
+	if err == nil {
+		t.Fatalf("expected error on cancelled ctx, got nil")
+	}
+	if len(fc.calls()) != 0 {
+		t.Errorf("publisher must not call broker on cancelled ctx; got %d calls", len(fc.calls()))
+	}
+}
+
+// TestClose_FlushesAndClosesConn — Close must drain pending publishes
+// before terminating the connection so a Pod shutdown doesn't lose
+// in-flight envelopes. Tested by asserting both Flush + Close called.
+func TestClose_FlushesAndClosesConn(t *testing.T) {
+	fc := &fakeConn{}
+	p := NewPublisher(fc, newTestLogger())
+
+	p.Close()
+
+	if !fc.closed {
+		t.Errorf("Close must invoke conn.Close")
+	}
+}
+
+// TestClose_NilReceiver — defensive: Close on a nil receiver is a no-op,
+// not a panic. main.go's deferred Close runs unconditionally; nil-safe
+// keeps the cold-start-without-NATS-URL path from panicking on exit.
+func TestClose_NilReceiver(t *testing.T) {
+	var p *Publisher
+	// Will panic if Close is not nil-safe.
+	p.Close()
+}
+
+// TestDial_EmptyURL — empty URL is rejected before the network call so
+// the caller (newTenantEventPublisherFromEnv) sees a clean error rather
+// than nats.go's "invalid url" deep-stack.
+func TestDial_EmptyURL(t *testing.T) {
+	_, err := Dial("", newTestLogger())
+	if err == nil {
+		t.Fatalf("expected error on empty URL, got nil")
+	}
+}

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -1,5 +1,24 @@
 apiVersion: v2
 name: bp-catalyst-platform
+# 1.4.194 — TBD-D35c (issue #1776) catalyst-api concrete NATS publisher
+# binding. Templates/api-deployment.yaml now exports CATALYST_NATS_URL
+# (default `nats://nats-jetstream.nats-system.svc.cluster.local:4222`,
+# overridable via `catalystApi.natsURL`) so the producer scaffold landed
+# in PR #1918 starts emitting real `catalyst.tenant.sandbox_requested`
+# envelopes — every successful Sandbox CR Create publishes the audit
+# envelope sandbox-controller's NATSBridge already consumes. Closes the
+# D35 round-trip ("NATS round-trip `catalyst.tenant.sandbox_requested`
+# end-to-end") that t32 walks left red. Pre-fix the constructor returned
+# nil unconditionally because catalyst-api shipped without nats.go in
+# go.mod (PR #1918 placeholder); the binding now lives in
+# products/catalyst/bootstrap/api/internal/natspub/sandbox_publisher.go,
+# wrapping `*nats.Conn` with the same option set
+# core/services/shared/events.ConnectNATS uses (MaxReconnects=-1,
+# ReconnectWait=2s, PingInterval=20s, Timeout=5s). Egress is already
+# permitted: `nats-system` lives in baselineCnp.allowedPlatformNamespaces.
+# Dial failure is non-fatal — the handler's nil-tolerant publish guard
+# keeps the Sandbox-create hot path working when the broker is briefly
+# unreachable on cold-start. Refs #1918.
 # 1.4.192 — TBD-C15 (issue #1750) wire /billing/purchase route. The
 # close-audit DoD validator on a Sovereign host (console.<sov-fqdn>)
 # probes POST /api/v1/billing/purchase + POST /api/v1/sme/billing/purchase
@@ -1394,8 +1413,8 @@ name: bp-catalyst-platform
 # 25/TCP (legacy SMTP fallback). All three are explicitly scoped to
 # `toEntities: world`, matching the existing 443/TCP allow. No other
 # rule semantics change. (Fixes PIN-issue 502 regression from #1785.)
-version: 1.4.193
-appVersion: 1.4.193
+version: 1.4.194
+appVersion: 1.4.194
 # 1.4.183 — fix(httproute): omit default sectionName so multi-zone
 # Sovereigns attach via Cilium Gateway hostname matcher (Closes #1884,
 # TBD-A30). Pre-1.4.183 every catalyst-system HTTPRoute pinned

--- a/products/catalyst/chart/templates/api-deployment.yaml
+++ b/products/catalyst/chart/templates/api-deployment.yaml
@@ -334,6 +334,24 @@ spec:
             # without code change.
             - name: CATALYST_API_PUBLIC_URL
               value: https://console.openova.io/sovereign
+            # CATALYST_NATS_URL — TBD-D35c (issue #1776). When set, the
+            # catalyst-api dials this NATS endpoint and publishes the
+            # `catalyst.tenant.sandbox_requested` envelope on every
+            # successful Sandbox CR Create. sandbox-controller's
+            # NATSBridge (consume leg) is already wired against the
+            # same subject; setting this env closes the D35 round-trip.
+            # The default in-cluster URL matches every other NATS-aware
+            # workload on the Sovereign (sme-billing, projector, etc.):
+            # nats://nats-jetstream.nats-system.svc.cluster.local:4222.
+            # When unset OR the dial fails, the handler runs in
+            # publish-disabled mode — the CR Create still succeeds + the
+            # FE still observes the new sandbox, but no audit envelope
+            # is emitted (matching the pre-PR-#1918 behaviour).
+            # Egress allow: `nats-system` is in baselineCnp's
+            # allowedPlatformNamespaces (see network-policies/
+            # baseline-catalyst-system.yaml) so no extra CNP is needed.
+            - name: CATALYST_NATS_URL
+              value: {{ .Values.catalystApi.natsURL | default "nats://nats-jetstream.nats-system.svc.cluster.local:4222" | quote }}
             # CATALYST_K8SCACHE_KUBECONFIGS_DIR — issue #321. Directory
             # the k8scache.Factory reads kubeconfigs from at startup.
             # The data-plane SharedInformerFactory opens one informer

--- a/products/catalyst/chart/values.yaml
+++ b/products/catalyst/chart/values.yaml
@@ -720,6 +720,14 @@ catalystApi:
   powerdnsURL: ""
   # PowerDNS server identifier per the REST API contract. Empty = "localhost".
   powerdnsServerID: ""
+  # NATS endpoint catalyst-api dials at startup to publish
+  # `catalyst.tenant.sandbox_requested` (TBD-D35c, issue #1776). Empty
+  # = the canonical in-cluster default
+  # `nats://nats-jetstream.nats-system.svc.cluster.local:4222`. Override
+  # at Sovereign level only when running an out-of-cluster NATS
+  # (uncommon; the bp-nats-jetstream Blueprint deploys an in-cluster
+  # broker by default).
+  natsURL: ""
 
 # ─── Sovereign HTTPRoute (Cilium Gateway API, issue #387) ─────────────────
 # Renders templates/httproute.yaml when `ingress.gateway.enabled=true`


### PR DESCRIPTION
## Summary

PR #1918 shipped the producer SCAFFOLD for `catalyst.tenant.sandbox_requested` — handler now calls `TenantEventPublisher`, env-driven constructor in main.go, 7 unit tests pass. But `newTenantEventPublisherFromEnv` returned **nil** unconditionally because catalyst-api's `go.mod` did not yet import `nats.go`. D35 ("NATS round-trip `catalyst.tenant.sandbox_requested` end-to-end") stayed red on t32 — Sandbox CRs materialised but `nats sub 'catalyst.tenant.sandbox_requested'` showed zero envelopes.

This follow-up wires the concrete binding:

- **New `internal/natspub` package** — `*Publisher` wraps `*nats.Conn`, implements `handler.TenantEventPublisher` via JSON-marshal + core-NATS Publish. Core publish (not JetStream) keeps the publisher-side stream-bootstrap concern out of the Sandbox-create hot path; sandbox-controller's `NATSBridge` reads off a broker subscription (not a JetStream durable), so a core publish is the symmetric counterpart.
- **Connection options** mirror `core/services/shared/events.ConnectNATS` (`MaxReconnects=-1`, `ReconnectWait=2s`, `PingInterval=20s`, `Timeout=5s`).
- **`nats.go v1.37.0`** added to `products/catalyst/bootstrap/api/go.mod` — same minor as every other in-tree consumer (`core/controllers`, `core/services/shared`, `core/services/{billing,tenant,auth,catalog,domain,notification,provisioning}`, `core/cmd/projector`) so the vendored version stays uniform.
- **`main.go::newTenantEventPublisherFromEnv`** now dials via `natspub.Dial(url, log)` when `CATALYST_NATS_URL` is set; dial failure is logged + **non-fatal** (returns nil so the handler's existing nil-tolerant publish guard keeps the Sandbox-create hot path working when the broker is briefly unreachable on Pod cold-start).
- **Chart `api-deployment.yaml`** exports `CATALYST_NATS_URL` with the canonical in-cluster default `nats://nats-jetstream.nats-system.svc.cluster.local:4222` (same URL every other NATS-aware workload uses: sme-billing, projector). Egress is already permitted — `nats-system` lives in `baselineCnp.allowedPlatformNamespaces`.
- **Chart bumped** 1.4.189 → 1.4.190; **bootstrap-kit pin** bumped to match (`clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml`).
- **8 new unit tests** in `internal/natspub/sandbox_publisher_test.go`:
  - `HappyPath` — JSON round-trips back to the original `TenantEvent`
  - `BrokerError_Surfaces` — broker-write error bubbles to caller (handler logs + continues per existing test)
  - `NilReceiver` — nil `*Publisher` returns clean error, no panic
  - `EmptySubject` — rejected at publisher boundary, no broker call
  - `ContextCancelled` — short-circuit before broker touched
  - `Close_FlushesAndClosesConn` — drain + close
  - `Close_NilReceiver` — nil-safe defer
  - `Dial_EmptyURL` — clean error before network call

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./internal/natspub/...` — 8/8 GREEN locally (0.388s)
- [x] `go test ./internal/handler/...` — full suite GREEN locally (89.8s; pre-existing 7 #1918 tests unaffected)
- [x] `helm template products/catalyst/chart --show-only templates/api-deployment.yaml | grep CATALYST_NATS_URL` renders `nats://nats-jetstream.nats-system.svc.cluster.local:4222`
- [ ] Post-merge: on next fresh prov pinned at 1.4.190+, catalyst-api Pod logs `natspub: NATS publisher ready` at startup; `kubectl exec -n nats-system nats-jetstream-0 -- nats sub 'catalyst.tenant.sandbox_requested'` shows envelopes after FE-driven Sandbox creates.

Closes #1776
Refs #1918