### PR TITLE
fix(catalyst-ui): wire onClick on inner treemap tiles for drill-down (TBD-V1, Closes #1927)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -635,7 +635,16 @@ spec:
       # every successful Sandbox CR Create emits
       # `catalyst.tenant.sandbox_requested` — closing the D35 round-trip
       # sandbox-controller's NATSBridge already consumes against.
-      version: 1.4.194
+      # 1.4.195 (TBD-V1, issue #1927, 2026-05-19): treemap inner-tile
+      # drill — fixes the trust-recovery regression where the depth-1
+      # application tiles on the Sovereign dashboard rendered with
+      # `cursor: default` and silently dropped clicks. Inner leaf cells
+      # that carry an `id` now advertise pointer cursor and deep-link to
+      # /app/$componentId via the same router.navigate path the hover
+      # tooltip's "Open" link already used. Parent (with-children)
+      # cells keep their existing drill-down semantics so this change
+      # is purely additive.
+      version: 1.4.195
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/Dashboard.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/Dashboard.test.tsx
@@ -202,3 +202,62 @@ describe('Dashboard — drill-down breadcrumb', () => {
     expect(screen.queryByTestId('dashboard-breadcrumb-0')).toBeNull()
   })
 })
+
+describe('Dashboard — inner-tile drill (issue #1927)', () => {
+  /**
+   * Trust-recovery regression test for issue #1927.
+   *
+   * Before the fix the depth-1 application tiles rendered with
+   * `cursor: default` and silently dropped clicks — 84/85 cells in the
+   * canonical Cluster→Application layer pair were dead. The fix wires
+   * leaf cells with an `id` to navigate to /app/$componentId and flips
+   * their cursor to `pointer`.
+   *
+   * JSDOM does NOT lay out SVG (width is 0, the gated branch in
+   * SquarifiedSurface never renders cells) so this test mocks the
+   * container width via clientWidth + a ResizeObserver that fires its
+   * callback synchronously, then asserts that the rendered cells carry
+   * the new `cursor: pointer` style.
+   */
+  beforeEach(() => {
+    // Force every <div> we measure to report a non-zero width so the
+    // SquarifiedSurface clears its `width > 0` gate and mounts cells.
+    Object.defineProperty(HTMLDivElement.prototype, 'clientWidth', {
+      configurable: true,
+      get() {
+        return 800
+      },
+    })
+    // ResizeObserver that fires once on observe so setWidth(800) lands.
+    class SyncResizeObserver {
+      private cb: ResizeObserverCallback
+      constructor(cb: ResizeObserverCallback) {
+        this.cb = cb
+      }
+      observe() {
+        // Invoke synchronously — no real DOMRect needed; setWidth reads
+        // from clientWidth, not from the entries.
+        this.cb([], this as unknown as ResizeObserver)
+      }
+      unobserve() {}
+      disconnect() {}
+    }
+    ;(globalThis as unknown as { ResizeObserver: typeof SyncResizeObserver }).ResizeObserver =
+      SyncResizeObserver
+  })
+
+  it('renders leaf cells with cursor:pointer when application id is set', async () => {
+    const { container } = renderDashboard('d-1', TWELVE_CELL_FIXTURE)
+    await screen.findByTestId('dashboard-treemap-frame')
+    await waitFor(() => {
+      const svg = container.querySelector('[data-testid="dashboard-treemap-surface"] svg')
+      expect(svg).toBeTruthy()
+    })
+    // Every cell <g> that wraps an item.id MUST advertise pointer cursor
+    // so the operator gets the affordance back. (Pre-fix the inline
+    // style read `cursor: default` for every leaf.)
+    const surface = container.querySelector('[data-testid="dashboard-treemap-surface"] svg')
+    const pointerGroups = surface?.querySelectorAll('g[style*="pointer"]') ?? []
+    expect(pointerGroups.length).toBeGreaterThan(0)
+  })
+})

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/Dashboard.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/Dashboard.tsx
@@ -250,14 +250,38 @@ export function Dashboard({
 
   useEffect(() => {
     _onCellClick = (item) => {
-      if (!item.children || item.children.length === 0) return
+      // Inner-tile drill-down (issue #1927):
+      //   • Parent cell (children.length > 0)  → push onto breadcrumb
+      //     stack so the operator drills one layer deeper without a
+      //     refetch.
+      //   • Leaf cell whose CURRENT dimension is `application` and that
+      //     carries a real `id` → deep-link to /app/$componentId so the
+      //     operator can inspect the underlying Helm release. Before
+      //     this fix the inner tiles rendered with `cursor: default`
+      //     and dropped the click silently, leaving 84/85 cells dead
+      //     on the canonical Cluster→Application layer pair.
+      //   • Leaf cell on any other dimension (cluster header, namespace,
+      //     family, sovereign, region, vcluster) without children stays
+      //     a no-op — those rows don't have a stable detail target yet.
       const dimension = layers[drillPath.length] ?? layers[layers.length - 1]
-      setDrillPath((prev) => [
-        ...prev,
-        { dimension, id: item.id, name: item.name },
-      ])
+      if (item.children && item.children.length > 0) {
+        setDrillPath((prev) => [
+          ...prev,
+          { dimension, id: item.id, name: item.name },
+        ])
+        return
+      }
+      if (dimension === 'application' && item.id) {
+        // Inline the navigation so this effect's deps don't have to
+        // carry the outer `navigateToApp` closure (whose identity
+        // changes on every render via the `router` reference).
+        router.navigate({
+          to: '/app/$componentId' as never,
+          params: { componentId: item.id } as never,
+        })
+      }
     }
-  }, [layers, drillPath.length])
+  }, [layers, drillPath.length, router])
 
   useEffect(() => {
     return () => {
@@ -718,7 +742,11 @@ function SquarifiedCell({ rect, colorFn, onHover, onClick }: SquarifiedCellProps
       : colorFn(pct)
 
   const showLabel = w >= LABEL_MIN_WIDTH_PX && h >= LABEL_MIN_HEIGHT_PX
-  const cursor = item.children?.length ? 'pointer' : 'default'
+  // Issue #1927: leaf cells with an `id` are clickable too (handler in
+  // Dashboard decides whether to drill or deep-link to /app/$id). Only
+  // truly inert tiles (synthetic rollups with no id and no children)
+  // stay on the default cursor.
+  const cursor = item.children?.length || item.id ? 'pointer' : 'default'
 
   function handleEnter(e: React.MouseEvent) {
     onHover({ item, x: e.clientX, y: e.clientY })
@@ -727,7 +755,11 @@ function SquarifiedCell({ rect, colorFn, onHover, onClick }: SquarifiedCellProps
     onHover(null)
   }
   function handleClick() {
-    if (item.children?.length) onClick(item)
+    // Issue #1927: forward every click on a cell that carries either
+    // children (drill) or an id (deep-link). The decision of WHAT to do
+    // lives in the page-level _onCellClick mailbox, which knows the
+    // current layer dimension.
+    if (item.children?.length || item.id) onClick(item)
   }
 
   if (isParent) {

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -1,5 +1,16 @@
 apiVersion: v2
 name: bp-catalyst-platform
+# 1.4.195 — TBD-V1 (issue #1927) treemap inner-tile drill. Fixes the
+# trust-recovery regression where the depth-1 application tiles on the
+# Sovereign dashboard rendered with `cursor: default` and silently
+# dropped clicks — 84/85 cells in the canonical Cluster→Application
+# layer pair were dead. Inner leaf cells that carry an `id` now
+# advertise pointer cursor and deep-link to /app/$componentId via the
+# same router.navigate path the hover-tooltip "Open" link already used.
+# Parent (with-children) cells keep their existing drill-down semantics
+# so this change is purely additive — no regressions on the depth-0
+# cluster header click that founder verified GREEN on 2026-05-19.
+# Refs #1927.
 # 1.4.194 — TBD-D35c (issue #1776) catalyst-api concrete NATS publisher
 # binding. Templates/api-deployment.yaml now exports CATALYST_NATS_URL
 # (default `nats://nats-jetstream.nats-system.svc.cluster.local:4222`,
@@ -1413,7 +1424,7 @@ name: bp-catalyst-platform
 # 25/TCP (legacy SMTP fallback). All three are explicitly scoped to
 # `toEntities: world`, matching the existing 443/TCP allow. No other
 # rule semantics change. (Fixes PIN-issue 502 regression from #1785.)
-version: 1.4.194
+version: 1.4.195
 appVersion: 1.4.194
 # 1.4.183 — fix(httproute): omit default sectionName so multi-zone
 # Sovereigns attach via Cilium Gateway hostname matcher (Closes #1884,


### PR DESCRIPTION
## Summary
- The Sovereign dashboard treemap's depth-1 cluster header has been interactive since #1599, but every inner application tile rendered with `cursor: default` and silently dropped its click — 84/85 cells in the canonical Cluster→Application layer pair were dead surface. Founder verified the gap on t32 at 2026-05-19 07:14Z (#1927).
- Parent cells (with children) keep their existing drill-down semantics; leaf cells on the `application` dimension carrying an `id` now deep-link to `/app/$componentId` via the same `router.navigate` the hover-tooltip "Open" link already used. Cells without an id stay inert. Cursor in `SquarifiedCell` flips to `pointer` for any cell that has children OR an id.
- Chart bp-catalyst-platform `1.4.194 → 1.4.195`; `clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml` pin bumped to match.

## Files
- `products/catalyst/bootstrap/ui/src/pages/sovereign/Dashboard.tsx` — `_onCellClick` mailbox now branches on `dimension==='application' && item.id`; `SquarifiedCell.cursor` and `handleClick` accept either children or id.
- `products/catalyst/bootstrap/ui/src/pages/sovereign/Dashboard.test.tsx` — new test (#1927 regression) mocks ResizeObserver + clientWidth to clear `SquarifiedSurface`'s `width > 0` gate and asserts leaf cells advertise `cursor: pointer`.
- `products/catalyst/chart/Chart.yaml` — version bump + change-log note.
- `clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml` — bootstrap-kit pin bump.

## Test plan
- [x] `npx vitest run src/pages/sovereign/Dashboard.test.tsx` — 7/7 pass (1 new + 6 pre-existing).
- [x] `npx tsc --noEmit` clean (no Dashboard.tsx errors).
- [x] `npx eslint src/pages/sovereign/Dashboard.tsx src/pages/sovereign/Dashboard.test.tsx` — identical warning count to origin/main (2 pre-existing react-hooks/exhaustive-deps).
- [ ] CI green on `product/catalyst` workflow.
- [ ] Post-merge Playwright/operator-walkthrough on next provisioning prov: open `/dashboard`, confirm `seaweedfs`/`mimir`/... tiles show `cursor: pointer` and click navigates to `/app/<id>`.

Closes #1927
Refs #1094

🤖 Generated with [Claude Code](https://claude.com/claude-code)