### PR TITLE
fix(catalyst-ui): plumb App targetNamespace into Resources tab URL (TBD-V2, Closes #1928)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -644,7 +644,17 @@ spec:
       # tooltip's "Open" link already used. Parent (with-children)
       # cells keep their existing drill-down semantics so this change
       # is purely additive.
-      version: 1.4.195
+      # 1.4.196 (TBD-V2, issue #1928, 2026-05-19): AppDetail Resources
+      # tab rendered empty because the SPA hardcoded `?namespace=default`
+      # in every K8s list URL. `apiAppQuery` was gated on `!wizardApp`
+      # so `apiApp.targetNamespace` stayed undefined whenever a
+      # wizardApp was populated → namespace fell through to "default".
+      # Fix drops the gate so the API detail fetch always runs and the
+      # authoritative install namespace (`harbor`/`alloy`/
+      # `cert-manager`/...) reaches ResourcesTab + LogsTab +
+      # TopologyTab. Backend already populated targetNamespace
+      # correctly for both App-CR and HR-synth paths. Closes #1928.
+      version: 1.4.196
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail.tsx
@@ -129,11 +129,26 @@ export function AppDetail({ disableStream = false }: AppDetailProps = {}) {
   // the fly. Prior to this fallback every chroot-installed Application
   // surfaced the misleading "App not found" page even though the
   // Application CR + HelmRelease were both Ready=True.
+  //
+  // TBD-V2 (issue #1928, 2026-05-19): the query was previously gated on
+  // `!wizardApp` — but the wizardApp descriptor carries blueprint
+  // identity ONLY, NOT the runtime install location. When the operator
+  // lands on AppDetail with a wizardApp populated (e.g. they kicked off
+  // the install minutes earlier and the wizard store still holds the
+  // selection), the apiApp stayed undefined → `apiApp?.targetNamespace`
+  // resolved to undefined → `appTargetNamespace` fell through to
+  // `appNamespace` which defaults to `"default"` → ResourcesTab queried
+  // `?namespace=default` and got 0 items (the workload lives in
+  // `harbor`/`alloy`/`cert-manager`/…). Founder proof:
+  // `?namespace=default` → 163 bytes empty; `?namespace=harbor` → 66kB
+  // of real K8s objects. Fix: always fetch the API detail so
+  // `apiApp.targetNamespace` is populated regardless of wizard state.
+  // The synthesisedApp path remains gated on `!wizardApp` below.
   const needsApiFallback = !wizardApp && !!deploymentId && !!componentId
   const apiAppQuery = useQuery({
     queryKey: ['sov-application', deploymentId, componentId],
     queryFn: async () => getApplication(deploymentId, componentId),
-    enabled: needsApiFallback,
+    enabled: !!deploymentId && !!componentId,
     staleTime: 30_000,
     refetchInterval: 30_000,
     retry: 1,

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/ResourcesTab.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/AppDetail/ResourcesTab.test.tsx
@@ -1,0 +1,128 @@
+/**
+ * ResourcesTab.test.tsx — TBD-V2 (issue #1928) regression lock.
+ *
+ * Founder report (2026-05-19): Application detail Resources tab empty
+ * because the SPA built `?namespace=default` into every kind list URL
+ * regardless of where the workload actually installed (e.g. `harbor`,
+ * `alloy`, `cert-manager`). Proof: `?namespace=default` returned 163
+ * bytes (empty), `?namespace=harbor` returned 66272 bytes (real data).
+ *
+ * This test asserts the URL the ResourcesTab fires contains the
+ * `namespace` prop value verbatim, so a future refactor of the URL
+ * builder cannot silently re-introduce the hardcoded default.
+ */
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { render, cleanup, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+const fetchCalls: string[] = []
+
+vi.mock('@/shared/lib/authedFetch', () => ({
+  authedFetch: (url: string) => {
+    fetchCalls.push(url)
+    return Promise.resolve({
+      ok: true,
+      status: 200,
+      json: async () => ({ items: [] }),
+    } as Response)
+  },
+}))
+
+vi.mock('@/shared/lib/useResolvedDeploymentId', () => ({
+  useResolvedDeploymentId: () => ({ deploymentId: 'test-sov' }),
+}))
+
+vi.mock('@/shared/lib/detectMode', () => ({
+  DETECTED_MODE: { mode: 'sovereign' },
+}))
+
+vi.mock('@/shared/config/urls', () => ({
+  API_BASE: '/api',
+}))
+
+import { ResourcesTab } from './ResourcesTab'
+
+function withProviders(node: React.ReactNode) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return <QueryClientProvider client={qc}>{node}</QueryClientProvider>
+}
+
+afterEach(() => {
+  cleanup()
+  fetchCalls.length = 0
+})
+
+describe('ResourcesTab — namespace plumbing (TBD-V2 #1928)', () => {
+  it('builds list URL with the supplied namespace (not "default")', async () => {
+    render(
+      withProviders(
+        <ResourcesTab
+          applicationName="alloy"
+          sovereignId="test-sov"
+          namespace="harbor"
+        />,
+      ),
+    )
+    await waitFor(() => {
+      expect(fetchCalls.length).toBeGreaterThan(0)
+    })
+    // Every fired list URL must carry namespace=harbor, NOT namespace=default.
+    for (const url of fetchCalls) {
+      expect(url).toContain('namespace=harbor')
+      expect(url).not.toMatch(/[?&]namespace=default(&|$)/)
+    }
+  })
+
+  it('encodes the namespace correctly when it contains special chars', async () => {
+    render(
+      withProviders(
+        <ResourcesTab
+          applicationName="legal-co"
+          sovereignId="test-sov"
+          namespace="tenant/legal"
+        />,
+      ),
+    )
+    await waitFor(() => {
+      expect(fetchCalls.length).toBeGreaterThan(0)
+    })
+    for (const url of fetchCalls) {
+      expect(url).toContain('namespace=tenant%2Flegal')
+    }
+  })
+
+  it('passes the labelSelector prop verbatim through to the URL', async () => {
+    render(
+      withProviders(
+        <ResourcesTab
+          applicationName="alloy"
+          sovereignId="test-sov"
+          namespace="alloy"
+          labelSelector="app.kubernetes.io/name=alloy"
+        />,
+      ),
+    )
+    await waitFor(() => {
+      expect(fetchCalls.length).toBeGreaterThan(0)
+    })
+    for (const url of fetchCalls) {
+      // labelSelector URL-encoded by URLSearchParams style:
+      // app.kubernetes.io%2Fname%3Dalloy
+      expect(url).toContain('labelSelector=app.kubernetes.io%2Fname%3Dalloy')
+    }
+  })
+
+  it('disableNetwork seam suppresses all list calls', () => {
+    render(
+      withProviders(
+        <ResourcesTab
+          applicationName="alloy"
+          sovereignId="test-sov"
+          namespace="alloy"
+          disableNetwork
+        />,
+      ),
+    )
+    expect(fetchCalls.length).toBe(0)
+  })
+})

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -1,5 +1,19 @@
-apiVersion: v2
-name: bp-catalyst-platform
+# 1.4.196 — TBD-V2 (issue #1928, 2026-05-19): plumb App targetNamespace
+# into Resources tab URL. AppDetail Resources tab rendered empty for
+# every operator because the SPA hardcoded `?namespace=default` in
+# every K8s list URL regardless of where the workload actually
+# installed. Root cause: `apiAppQuery` was gated on `!wizardApp`, so
+# when the operator landed on the page with a wizardApp populated, the
+# `apiApp` object stayed undefined → `apiApp?.targetNamespace`
+# resolved to undefined → `appTargetNamespace` fell through to
+# `appNamespace` which defaults to `"default"`. Founder proof:
+# `?namespace=default` → 163 bytes empty; `?namespace=harbor` → 66kB
+# of real K8s objects. Fix: drop the gate so the API detail fetch
+# always runs and `apiApp.targetNamespace` is populated regardless of
+# wizard state. ResourcesTab + LogsTab + TopologyTab now all see the
+# authoritative install namespace. Backend already populates the
+# field correctly (applications.go:1105-1109 for App CR,
+# applications.go:1242-1249 for HR-synth path). Closes #1928.
 # 1.4.195 — TBD-V1 (issue #1927) treemap inner-tile drill. Fixes the
 # trust-recovery regression where the depth-1 application tiles on the
 # Sovereign dashboard rendered with `cursor: default` and silently
@@ -1424,8 +1438,8 @@ name: bp-catalyst-platform
 # 25/TCP (legacy SMTP fallback). All three are explicitly scoped to
 # `toEntities: world`, matching the existing 443/TCP allow. No other
 # rule semantics change. (Fixes PIN-issue 502 regression from #1785.)
-version: 1.4.195
-appVersion: 1.4.194
+version: 1.4.196
+appVersion: 1.4.196
 # 1.4.183 — fix(httproute): omit default sectionName so multi-zone
 # Sovereigns attach via Cilium Gateway hostname matcher (Closes #1884,
 # TBD-A30). Pre-1.4.183 every catalyst-system HTTPRoute pinned


### PR DESCRIPTION
## Summary

**Founder report (2026-05-19)**: Application detail "Resources" tab empty for every operator. Root cause: SPA hardcoded `?namespace=default` in every K8s list URL regardless of where the workload actually installed.

**Proof**:
- `?namespace=default` → 163 bytes (empty)
- `?namespace=harbor` → 66272 bytes (real K8s objects)

## Root Cause

`AppDetail.tsx` gated `apiAppQuery.enabled` on `!wizardApp` (qa-loop iter-11 Fix #45 Cluster-C, intended to suppress redundant API calls when the wizard store already held the descriptor).

The `wizardApp` descriptor carries blueprint identity ONLY — not runtime install location. When an operator lands on AppDetail with a `wizardApp` populated, `apiApp` stayed `undefined` → `apiApp?.targetNamespace` resolved to `undefined` → `appTargetNamespace` fell through to `appNamespace` which defaults to `"default"` → ResourcesTab + LogsTab + TopologyTab all queried `?namespace=default` and got 0 items.

## Fix

Drop the `!wizardApp` gate on `apiAppQuery.enabled`:

```ts
// Before
const needsApiFallback = !wizardApp && !!deploymentId && !!componentId
const apiAppQuery = useQuery({
  ...
  enabled: needsApiFallback,
})

// After
const needsApiFallback = !wizardApp && !!deploymentId && !!componentId
const apiAppQuery = useQuery({
  ...
  enabled: !!deploymentId && !!componentId,  // always fetch when we have IDs
})
```

`apiApp.targetNamespace` is now populated regardless of wizard state, and the existing fallback chain
```ts
const appTargetNamespace =
  apiApp?.targetNamespace?.trim() || apiApp?.namespace?.trim() || appNamespace
```
resolves to the authoritative install namespace (`harbor`/`alloy`/`cert-manager`/…).

`needsApiFallback` retained as a local for the `synthesisedApp` gate + the loading-state branch in the "App not found" path.

## Backend (no changes)

Already populates `targetNamespace` correctly:
- **App-CR path** (`applications.go:1105-1109`) — reads `spec.targetNamespace`, falls back to CR's own namespace.
- **HR-synth path** (`applications.go:1242-1249`) — reads HR `spec.targetNamespace`, falls back to HR's namespace.

## Chart bump

- `products/catalyst/chart/Chart.yaml`: 1.4.194 → 1.4.195
- `clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml`: pin → 1.4.195

## Test plan

- [x] `vitest run src/pages/sovereign/AppDetail/ResourcesTab.test.tsx` — 4/4 passing (new file)
- [x] `vitest run src/pages/sovereign/AppDetail/` — 7/7 passing (no regressions)
- [x] `tsc --noEmit -p tsconfig.app.json` — 0 errors
- [ ] Post-merge: AppDetail Resources tab on `console.<sov>.omani.works/app/<id>/resources` renders real K8s objects from the app's namespace.

Closes #1928.
Refs #1099.

Generated with [Claude Code](https://claude.com/claude-code)