### PR TITLE
fix(bp-kyverno): install 19 compliance ClusterPolicies on fresh Sovereign (TBD-V3, Closes #1929)

### DIFF
--- a/clusters/_template/bootstrap-kit/27-kyverno.yaml
+++ b/clusters/_template/bootstrap-kit/27-kyverno.yaml
@@ -54,7 +54,7 @@ spec:
   chart:
     spec:
       chart: bp-kyverno
-      version: 1.1.0
+      version: 1.2.0
       sourceRef:
         kind: HelmRepository
         name: bp-kyverno

--- a/platform/kyverno/blueprint.yaml
+++ b/platform/kyverno/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-3-3-security-and-policy
 spec:
-  version: 1.1.0
+  version: 1.2.0
   card:
     title: Kyverno
     family: guardian

--- a/platform/kyverno/chart/Chart.yaml
+++ b/platform/kyverno/chart/Chart.yaml
@@ -12,7 +12,7 @@ description: |
   HA mode runs four controllers (admission, background, cleanup, reports);
   solo-Sovereign default is replicas=1 each.
 type: application
-version: 1.1.0
+version: 1.2.0
 appVersion: "v1.18.0"
 keywords: [catalyst, blueprint, kyverno, policy, admission, security]
 maintainers:

--- a/platform/kyverno/chart/templates/policies/baseline/11-harbor-proxy.yaml
+++ b/platform/kyverno/chart/templates/policies/baseline/11-harbor-proxy.yaml
@@ -68,7 +68,7 @@ spec:
             deny:
               conditions:
                 all:
-                  - key: '{{ `{{ element.image }}` }}'
-                    operator: NotMatch
-                    value: {{ .Values.compliancePolicies.harborProxyPull.allowedRegistryRegex | quote }}
+                  - key: '{{ printf `{{ regex_match(%q, element.image) }}` .Values.compliancePolicies.harborProxyPull.allowedRegistryRegex }}'
+                    operator: Equals
+                    value: false
 {{- end -}}

--- a/platform/kyverno/chart/templates/policies/baseline/12-image-tag-pinned.yaml
+++ b/platform/kyverno/chart/templates/policies/baseline/12-image-tag-pinned.yaml
@@ -61,10 +61,12 @@ spec:
             deny:
               conditions:
                 any:
-                  - key: '{{ `{{ element.image }}` }}'
-                    operator: Match
-                    value: "*:latest"
-                  - key: '{{ `{{ element.image }}` }}'
-                    operator: NotMatch
-                    value: "*:*"
+                  # Reject `:latest` tag (any registry/path).
+                  - key: '{{ `{{ regex_match(''(:latest$|^[^@]*latest$)'', element.image) }}` }}'
+                    operator: Equals
+                    value: true
+                  # Reject images with no tag and no @sha256: digest.
+                  - key: '{{ `{{ regex_match(''^[^:@]+$'', element.image) }}` }}'
+                    operator: Equals
+                    value: true
 {{- end -}}

--- a/platform/kyverno/chart/templates/policies/baseline/19-secret-not-in-env.yaml
+++ b/platform/kyverno/chart/templates/policies/baseline/19-secret-not-in-env.yaml
@@ -71,7 +71,7 @@ spec:
                       - key: '{{ `{{ element.value || '''' }}` }}'
                         operator: NotEquals
                         value: ""
-                      - key: '{{ `{{ element.name }}` }}'
-                        operator: Match
-                        value: "*(?i)(PASSWORD|TOKEN|KEY|SECRET)*"
+                      - key: '{{ `{{ regex_match(''(?i)(PASSWORD|TOKEN|KEY|SECRET)'', element.name) }}` }}'
+                        operator: Equals
+                        value: true
 {{- end -}}

--- a/platform/kyverno/chart/values.yaml
+++ b/platform/kyverno/chart/values.yaml
@@ -218,8 +218,25 @@ kyvernoOverlay:
 # Per docs/INVIOLABLE-PRINCIPLES.md #4 — every value is overridable.
 compliancePolicies:
   # K1 baseline policies
+  #
+  # Default = enabled: true with action: Audit (permissive). Per #1929 the
+  # Compliance scorecard was empty on fresh Sovereigns because every policy
+  # gate defaulted to false — only `useraccess-boundary` was installed.
+  # Audit mode is non-blocking (admission still passes) so flipping defaults
+  # to true is safe: every Sovereign immediately has 18 baseline policies
+  # emitting PolicyReport rows, and operators can flip individual policies
+  # to enabled: false or action: Enforce per Sovereign overlay.
+  #
+  # The 2 exceptions:
+  #   - hubbleFlowsSeen — comment-only stub (W2 evaluator does the real
+  #     check). Setting enabled=true renders nothing. Left false for
+  #     symmetry with its DEFERRED status; future W2 cutover flips it.
+  #   - cosignVerified  — verifyImages rule requires an operator-supplied
+  #     publicKey. Empty default would render an INVALID policy that fails
+  #     to install. Left false; operator opts in per Sovereign once cosign
+  #     key bundle is supplied.
   multiReplica:
-    enabled: false
+    enabled: true
     action: Audit
     excludeNamespaces: &complianceDefaultExcludes
       - kube-system
@@ -234,52 +251,52 @@ compliancePolicies:
       - ingress
 
   pdb:
-    enabled: false
+    enabled: true
     action: Audit
     excludeNamespaces: *complianceDefaultExcludes
 
   topologySpread:
-    enabled: false
+    enabled: true
     action: Audit
     excludeNamespaces: *complianceDefaultExcludes
 
   probesPresent:
-    enabled: false
+    enabled: true
     action: Audit
     excludeNamespaces: *complianceDefaultExcludes
 
   resourceRequests:
-    enabled: false
+    enabled: true
     action: Audit
     excludeNamespaces: *complianceDefaultExcludes
 
   resourceLimits:
-    enabled: false
+    enabled: true
     action: Audit
     excludeNamespaces: *complianceDefaultExcludes
 
   pvcExpansion:
-    enabled: false
+    enabled: true
     action: Audit
     excludeNamespaces: *complianceDefaultExcludes
 
   hpaEffective:
-    enabled: false
+    enabled: true
     action: Audit
     excludeNamespaces: *complianceDefaultExcludes
 
   ciliumL7Mtls:
-    enabled: false
+    enabled: true
     action: Audit
     excludeNamespaces: *complianceDefaultExcludes
 
   fluxManaged:
-    enabled: false
+    enabled: true
     action: Audit
     excludeNamespaces: *complianceDefaultExcludes
 
   harborProxyPull:
-    enabled: false
+    enabled: true
     action: Audit
     excludeNamespaces: *complianceDefaultExcludes
     # Operator overrides per-Sovereign (e.g.
@@ -291,18 +308,18 @@ compliancePolicies:
     allowedRegistryRegex: "^harbor\\..+/proxy-(ghcr|dockerhub|quay|registry-1\\.docker\\.io)/.*"
 
   imageTagPinned:
-    enabled: false
+    enabled: true
     action: Audit
     excludeNamespaces: *complianceDefaultExcludes
 
   prometheusScrape:
-    enabled: false
+    enabled: true
     action: Audit
     excludeNamespaces: *complianceDefaultExcludes
 
   # K2 added policies
   networkpolicyPresent:
-    enabled: false
+    enabled: true
     action: Audit
     # Match on Namespace kind — `excludeNamespaces` here is consumed via
     # `resources.names` (the namespace IS the resource). Same default
@@ -310,7 +327,7 @@ compliancePolicies:
     excludeNamespaces: *complianceDefaultExcludes
 
   otelInjected:
-    enabled: false
+    enabled: true
     action: Audit
     excludeNamespaces: *complianceDefaultExcludes
 
@@ -324,11 +341,16 @@ compliancePolicies:
     excludeNamespaces: *complianceDefaultExcludes
 
   runAsNonRootReadonlyRootFs:
-    enabled: false
+    enabled: true
     action: Audit
     excludeNamespaces: *complianceDefaultExcludes
 
   cosignVerified:
+    # OFF by default — verifyImages rule requires an operator-supplied
+    # cosign publicKey (PEM). Empty publicKey renders an INVALID policy
+    # that fails to install. Per docs/INVIOLABLE-PRINCIPLES.md #4 we
+    # surface the config gap rather than silently passing. Operator
+    # opts in per Sovereign once the cosign key bundle is supplied.
     enabled: false
     action: Audit
     excludeNamespaces: *complianceDefaultExcludes
@@ -345,11 +367,11 @@ compliancePolicies:
     rekorURL: "https://rekor.sigstore.dev"
 
   secretNotInEnv:
-    enabled: false
+    enabled: true
     action: Audit
     excludeNamespaces: *complianceDefaultExcludes
 
   backupConfigured:
-    enabled: false
+    enabled: true
     action: Audit
     excludeNamespaces: *complianceDefaultExcludes


### PR DESCRIPTION
## Summary

- **Root cause** — PR #1138 shipped 19 compliance ClusterPolicy template slots in `platform/kyverno/chart/templates/policies/baseline/` (20 files; `16-hubble-flows-seen.yaml` is a W2-deferred stub that renders nothing). But every policy gate defaulted to `enabled: false` in `values.yaml`, so on a fresh Sovereign only `useraccess-boundary` (from the separate label-vocab template) ever landed. The Compliance scorecard XHR `/api/v1/sovereigns/<id>/compliance/scorecard` returned `policyCount=0` for `baseline`/`security`/`sre` — see #1929 evidence.

- **Fix** — Flip `compliancePolicies.<name>.enabled` from `false` to `true` for 18 policies (action: `Audit`, non-blocking). `hubbleFlowsSeen` (no-op stub) and `cosignVerified` (needs operator-supplied publicKey) remain disabled by design. Also fixed three real Kyverno-operator bugs caught by server-side dry-run on t32: `Match`/`NotMatch` are not valid Kyverno conditional operators (the validating webhook rejects them). Rewrote conditions in `11-harbor-proxy.yaml`, `12-image-tag-pinned.yaml`, `19-secret-not-in-env.yaml` to use JMESPath `regex_match()` with `operator: Equals` and `value: true|false`. Without these, those three policies would have failed to install at runtime even with `enabled: true`.

- **Chart bump** — `bp-kyverno` 1.1.0 → 1.2.0 (Chart.yaml + bootstrap-kit pin in `clusters/_template/bootstrap-kit/27-kyverno.yaml`).

## Validation

- `helm template bp-kyverno platform/kyverno/chart/` renders 18 `ClusterPolicy` CRs.
- Each rendered policy passes `kubectl apply --dry-run=server` against the **live Kyverno validating admission webhook on Sovereign t32**.

## Test plan

- [x] Server-side dry-run all 18 renderable policies against t32 admission webhook
- [ ] Provision fresh Sovereign on chart 1.2.0
- [ ] `kubectl get clusterpolicy` shows 19 policies (18 compliance + useraccess-boundary)
- [ ] Compliance tab scorecard: `policyCount > 0` for baseline/security/sre

Closes #1929. Refs #1096 (EPIC-1 trust-recovery).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>