### PR TITLE
revert(bootstrap-kit): bp-kyverno pin 1.2.0 → 1.1.0 (PR #1933 CRD-ordering regression)

### DIFF
--- a/clusters/_template/bootstrap-kit/27-kyverno.yaml
+++ b/clusters/_template/bootstrap-kit/27-kyverno.yaml
@@ -54,7 +54,7 @@ spec:
   chart:
     spec:
       chart: bp-kyverno
-      version: 1.2.0
+      version: 1.1.0
       sourceRef:
         kind: HelmRepository
         name: bp-kyverno


### PR DESCRIPTION
## Why

PR #1933 (TBD-V3 — "install 19 compliance ClusterPolicies on fresh Sovereign") shipped chart `bp-kyverno@1.2.0` with 18 policy-enable-flag flips. Fresh-prov verification on t33 (agent a81cd26a, 2026-05-19 10:13Z) caught a fatal install regression:

```
no matches for kind "ClusterPolicy" in version "kyverno.io/v1"
```

## Root cause

ClusterPolicy templates live in `platform/kyverno/chart/templates/policies/baseline/` while Kyverno's CRDs live in subchart `charts/crds/templates/`. Helm renders both in the SAME pass. On a fresh Sovereign with no prior Kyverno install, manifest-build aborts before any object lands.

**The bug was hidden by stable-state validation.** PR #1933's `kubectl apply --dry-run=server` passed only because t32 already had Kyverno 1.1.0 installed — CRDs were already on the cluster. `--dry-run=server` LIES when CRDs are pre-installed.

## Cascade observed on t33

1. `bp-kyverno@1.2.0` HelmRelease: 56 failures with the CRD-not-found error
2. `bp-crossplane-claims@1.1.5` blocked on the missing `useraccess-boundary` ClusterPolicy: 31 downstream failures
3. `bp-catalyst-platform` never installs
4. `cilium-gateway` HTTPRoutes never reconcile
5. `handoverFiredAt` never set
6. `console.t33.omani.works` TLS handshake fails — operator can't even log in

## What this revert does

- Bootstrap-kit pin in `clusters/_template/bootstrap-kit/27-kyverno.yaml`: `1.2.0` → `1.1.0`
- Compliance scorecard returns to `policyCount=0` (the *honestly* broken state, pre-#1933)
- Fresh prov can reach handover again
- Chart 1.2.0 stays published on GHCR — just unpinned. 1.2.1+ will carry the proper redesign.

## What still needs to happen (TBD-A48, to be filed)

Proper Kyverno install design:
- Engine + CRDs as `bp-kyverno@1.2.1` (one HR)
- Policies as `bp-kyverno-policies@1.0.0` (separate HR)
- `Kustomization.dependsOn` (NOT `HelmRelease.dependsOn` — per Principle #14, HR.dependsOn → Kustomization is silently ignored)
- Validation: `helm install` from a Kind cluster with no Kyverno pre-installed before merge

## Verification

- [x] `git diff` shows only the pin line change
- [ ] Fresh-prov walk after merge — pending t34 provision
- [ ] Compliance UI returns to honest `policyCount=0` (no theater)

## Discipline note

This is the FIRST PR under the new CLAUDE.md anti-theater rules (committed to openova-private 88b73d23). Specifically:
- `Refs #1929`, NOT `Closes #1929` — issue stays open until fresh-prov walk shows the path forward
- No admin-merge if any CI check is red
- Reverting before re-fixing, per the "revert-before-fix" rule

Refs #1929. Refs #1096 (Compliance EPIC). Cross-link: #1934 (TBD-A47, single-region Cilium blocker — discovered on the same run).