### PR TITLE
fix(catalyst-chart): restore Chart.yaml apiVersion+name corrupted by PR #1932; bump 1.4.196→1.4.197

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -654,7 +654,7 @@ spec:
       # `cert-manager`/...) reaches ResourcesTab + LogsTab +
       # TopologyTab. Backend already populated targetNamespace
       # correctly for both App-CR and HR-synth paths. Closes #1928.
-      version: 1.4.196
+      version: 1.4.197
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -1,3 +1,5 @@
+apiVersion: v2
+name: bp-catalyst-platform
 # 1.4.196 — TBD-V2 (issue #1928, 2026-05-19): plumb App targetNamespace
 # into Resources tab URL. AppDetail Resources tab rendered empty for
 # every operator because the SPA hardcoded `?namespace=default` in
@@ -1438,8 +1440,8 @@
 # 25/TCP (legacy SMTP fallback). All three are explicitly scoped to
 # `toEntities: world`, matching the existing 443/TCP allow. No other
 # rule semantics change. (Fixes PIN-issue 502 regression from #1785.)
-version: 1.4.196
-appVersion: 1.4.196
+version: 1.4.197
+appVersion: 1.4.197
 # 1.4.183 — fix(httproute): omit default sectionName so multi-zone
 # Sovereigns attach via Cilium Gateway hostname matcher (Closes #1884,
 # TBD-A30). Pre-1.4.183 every catalyst-system HTTPRoute pinned


### PR DESCRIPTION
## Root cause (BLOCKER-A49)

PR #1932 prepended a 14-line changelog comment block to `products/catalyst/chart/Chart.yaml` but **pushed `apiVersion: v2` and `name: bp-catalyst-platform` OUT of the file**. The file now starts with `# 1.4.196 — TBD-V2 ...` (comment) and has neither `apiVersion:` nor `name:` anywhere.

```yaml
# CURRENT broken state at 9fd79355
# 1.4.196 — TBD-V2 (issue #1928, 2026-05-19): plumb App targetNamespace ...
# (14 lines of comments)
version: 1.4.196
appVersion: 1.4.196
description: |
  ...
```

`helm dependency build` requires `chart.metadata.name`:

```
Error: validation: chart.metadata.name is required
```

Blueprint Release run [26085426872](https://github.com/openova-io/openova/actions/runs/26085426872) failed with this exact error at 08:25:03Z. Subsequent runs all fail the same way.

## Cascade

1. `bp-catalyst-platform@1.4.196` chart never published to GHCR
2. Bootstrap-kit pin in `clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml` references 1.4.196 (nonexistent)
3. Sovereign HR False → no Gateway → no HTTPRoutes → `console.t34.omani.works` HTTP 000
4. t34 fresh-prov walk (verification agent a72e4e7e, 2026-05-19 11:35Z) caught the cascade

Documented in `docs/TRUST.md` BLOCKER-A49 row.

## Fix

1. Restore `apiVersion: v2` and `name: bp-catalyst-platform` as the first two lines of Chart.yaml (they belong above the changelog comments)
2. Bump version `1.4.196 → 1.4.197` + appVersion bump (1.4.196 is abandoned because the OCI artifact never published — GHCR may have partial state)
3. Bump bootstrap-kit pin `1.4.196 → 1.4.197`

The UI fix (AppDetail.tsx targetNamespace plumbing) shipped by PR #1932 stays intact — this PR only repairs the metadata corruption.

## Verification

```
$ helm show chart products/catalyst/chart | head -5
annotations:
  catalyst.openova.io/no-upstream: "true"
apiVersion: v2
appVersion: 1.4.197
description: ...
```

Local parse clean. **Blueprint Release on this branch will verify the publish path before merge** — this is the only way to validate, per new CLAUDE.md anti-theater rule (no server-dry-run substitute for a real publish).

## Anti-pattern to add to CLAUDE.md catalogue

When an agent prepends to Chart.yaml or any metadata-headed YAML file:
- The agent MUST insert below the metadata lines (`apiVersion`, `name`, `kind`)
- NEVER prepend blindly to the top of the file
- Reviewer-fatigue defense kicks in here — read the first 5 lines of EVERY chart file change

## Receipts

This is the **third** theater pattern caught in 24h:
- PR #1933 (Kyverno CRD-ordering regression): reverted by PR #1935
- PR #1932 (Chart.yaml metadata corruption): fixed by this PR
- PR #1918 (NATS scaffold-not-binding): re-shipped binding as PR #1926

Refs #1928. Resolves BLOCKER-A49 in TRUST.md. After merge: re-run T1 walks on t34 (still running) once `bp-catalyst-platform@1.4.197` propagates via Flux.