### PR TITLE
fix(ci): sme-demo.spec.ts:135 — visit /sme/users not /console/sme/users

### DIFF
--- a/products/catalyst/bootstrap/ui/e2e/sme-demo.spec.ts
+++ b/products/catalyst/bootstrap/ui/e2e/sme-demo.spec.ts
@@ -115,9 +115,18 @@ test.describe('@sme-demo SME end-to-end happy path (issue #805)', () => {
 
   test('step 3 — SME admin dashboard renders (1440×900)', async ({ page }, testInfo) => {
     // Tenant discovery resolves to tenant_kind=sme, whoami returns an
-    // already-authenticated session, so navigating to /console/dashboard
+    // already-authenticated session, so navigating to the dashboard
     // bypasses the OIDC redirect and renders directly.
-    await page.goto('/console/dashboard')
+    //
+    // Note: the Sovereign Console layout is mounted via a pathless route
+    // (`consoleLayoutRoute` has `id: '_sovereign_console'`, no `path`),
+    // so its child paths resolve at the root, NOT under `/console/*`.
+    // The narrative docstrings in router.tsx still mention
+    // `/console/dashboard`, but the registered TanStack path is
+    // `/dashboard`. Visiting `/console/dashboard` lands on the TanStack
+    // notFoundComponent ("Not Found"), which silently passed step 3
+    // (screenshot-only) but fails step 4 the moment a testId is asserted.
+    await page.goto('/dashboard')
     await page.waitForLoadState('networkidle')
 
     // The SovereignConsoleLayout renders a dashboard shell. Screenshot
@@ -128,7 +137,10 @@ test.describe('@sme-demo SME end-to-end happy path (issue #805)', () => {
   /* ── STEP 4 — Create user "alice" via unified-rbac console ──── */
 
   test('step 4 — create alice + 3-step progress (1440×900)', async ({ page }, testInfo) => {
-    await page.goto('/console/sme/users')
+    // SMEUsersPage is mounted under the pathless `consoleLayoutRoute`
+    // at `path: '/sme/users'` — see router.tsx `consoleSMEUsersRoute`.
+    // The route is at `/sme/users`, NOT `/console/sme/users`.
+    await page.goto('/sme/users')
     await page.waitForLoadState('networkidle')
 
     // Empty list (no users seeded yet).
@@ -214,7 +226,7 @@ test.describe('@sme-demo SME end-to-end happy path (issue #805)', () => {
       // post-#804. The fixme step activates once the pipeline
       // lands; it will drive an OpenClaw prompt and poll
       // /sme/billing/ledger for the negative spend entry.
-      await page.goto('/console/dashboard')
+      await page.goto('/dashboard')
       await snap(page, 5, 'usage-flows-to-billing', testInfo)
     },
   )
@@ -230,7 +242,7 @@ test.describe('@sme-demo SME end-to-end happy path (issue #805)', () => {
       // admin.<fqdn>/billing/vouchers/new for the cross-domain flow.
       // The fixme step activates once an in-SPA /console/sme/billing
       // route lands and asserts the ledger entry for alice.
-      await page.goto('/console/sme/billing' as never)
+      await page.goto('/sme/billing' as never)
       await snap(page, 6, 'sme-admin-billing-ledger', testInfo)
     },
   )


### PR DESCRIPTION
## Failure surface

Workflow [`SME demo end-to-end (issue #805)`](https://github.com/openova-io/openova/actions/workflows/sme-demo-e2e.yaml) has been red on `main` for 5+ consecutive pushes, blocking the merge of [PR #1939](https://github.com/openova-io/openova/pull/1939) (treemap layer-0 fix) per the founder anti-theater rule "no admin-merge through red CI".

The failing assertion is `e2e/sme-demo.spec.ts:135`:

```
Error: expect(locator).toBeVisible() failed

Locator: getByTestId('sme-users-page')
Expected: visible
Timeout: 5000ms
Error: element(s) not found
```

The Playwright artefact (`error-context.md`) captured the rendered DOM:

```yaml
# Page snapshot
- paragraph [ref=e3]: Not Found
```

— i.e. the SPA landed on TanStack Router's `notFoundComponent`, not on `SMEUsersPage`.

## Root cause

The Sovereign Console routes (`consoleDashboardRoute`, `consoleSMEUsersRoute`, `consoleSMERolesRoute`, …) hang under a **pathless** layout route:

```ts
// products/catalyst/bootstrap/ui/src/app/router.tsx:1218
const consoleLayoutRoute = createRoute({
  getParentRoute: () => rootRoute,
  id: '_sovereign_console',          // <-- no `path` field
  component: SovereignConsoleLayout,
})
const consoleSMEUsersRoute = createRoute({
  getParentRoute: () => consoleLayoutRoute,
  path: '/sme/users',                // <-- mounts at /sme/users
  component: SMEUsersPage,
})
```

A pathless parent does NOT contribute a URL segment, so `consoleSMEUsersRoute` resolves to `/sme/users` (and `consoleDashboardRoute` to `/dashboard`), **not** `/console/sme/users` / `/console/dashboard` as the surrounding narrative docstrings still suggest.

Why this only surfaced now: steps 1-3 of the spec only assert weak signals (document `title` regex, screenshot capture). Step 3 navigates to the broken `/console/dashboard`, the SPA renders "Not Found", and the screenshot-only assertion passes. **Step 4 (line 135) is the first place an actual testId is asserted**, so the broken nav blows up there.

## Decision: fix the test (Option A)

This is a stale test, not a real product bug — the routes are correctly registered, `SMEUsersPage` correctly exports the asserted testIds (`sme-users-page`, `sme-users-empty`, `sme-users-new-cta`, `sme-users-create-form`, `sme-users-progress`, etc — see `pages/sme/UsersPage.tsx` lines 103/175/113/130/157). The test just visits the wrong URL.

Surgical change: swap the four `/console/X` URLs in `sme-demo.spec.ts` for their actually-registered counterparts:

- `/console/dashboard`  → `/dashboard`           (step 3 + step 5d fixme)
- `/console/sme/users`  → `/sme/users`           (step 4 — the load-bearing fix)
- `/console/sme/billing` → `/sme/billing`        (step 6 fixme — keeps intent consistent)

No product code touched. Added an inline comment on step 3 documenting the pathless-layout-route gotcha so the next reader doesn't re-introduce `/console/*` URLs from the surrounding docstrings.

## Verification

- Local `npx playwright test` requires `npm ci` + dev server boot which exceeds the wall-time budget; CI will exercise this on push.
- Grep confirms the four URL strings touched are the only `/console/*` literals in the spec; no other tests share these URLs.

## Hard rules adhered to

- READ-ONLY on cluster
- No `--no-verify`, no admin-merge
- `Refs #805` (parent epic) — not `Closes` because the spec itself is a single load-bearing demo guard, not the closing of #805.

Refs #805