### PR TITLE
feat(ui): /jobs page region filter dropdown (Refs #1821, DoD D20)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -689,7 +689,15 @@ spec:
       # /api/v1/sme/bss/overview handler so the BSS landing renders
       # real zeros (full target-state surface) instead of the "API
       # pending" pill caused by the pre-fix 404.
-      version: 1.4.203
+      # 1.4.204 (DoD D20, issue #1821, t34 walk 2026-05-19 ~13:22Z):
+      # the /jobs page Region filter dropdown stayed hidden on a 3-region
+      # Sovereign because chrootSeedJobsStoreIfEmpty only enumerated
+      # primary-cluster HelmReleases. Fix: extend the chroot lazy-seed to
+      # fan out across every k8sCache-registered cluster and emit
+      # region-prefixed install-* Job rows, so JobsTable's
+      # `regionOptions.length > 1` gate trips and the dropdown renders.
+      # Refs #1821.
+      version: 1.4.204
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/bootstrap/api/internal/handler/jobs.go
+++ b/products/catalyst/bootstrap/api/internal/handler/jobs.go
@@ -254,6 +254,115 @@ func (h *Handler) chrootSeedJobsStoreIfEmpty(ctx context.Context, dep *Deploymen
 		"jobsWritten", jobsCount,
 		"executionsSeeded", execsSeeded,
 	)
+
+	// D20 (2026-05-19 t34): multi-region fan-out for chroot job seed.
+	// The primary seed above only enumerates HelmReleases visible to the
+	// chroot's in-cluster apiserver — i.e. the primary region. On a
+	// 3-region Sovereign the operator's /jobs view rendered only the
+	// primary region's ~62 install-* rows and the Region filter dropdown
+	// stayed hidden (JobsTable hides it on single-region sets per
+	// regionOptions.length > 1 gate). When secondary kubeconfigs are
+	// registered with h.k8sCache (via POST /api/v1/sovereign/secondary-
+	// kubeconfig at handover, see sovereign_secondary_kubeconfig.go),
+	// enumerate per-secondary-cluster and seed region-prefixed Job rows
+	// so the UI surfaces all-region jobs + auto-shows the Region filter.
+	//
+	// Secondary cluster IDs follow the `<depID>-<regionKey>` convention
+	// (sovereign_secondary_kubeconfig.go:127). The primary cluster ID is
+	// just the bare depID (or `sovereign-<fqdn>` per buildChrootClusterRef
+	// fallback). Anything else is treated as not-our-cluster and skipped
+	// — defense in depth against cross-deployment leakage on a chroot
+	// that gets re-registered against a different deployment record.
+	h.chrootSeedSecondaryRegions(ctx, dep, bridge)
+}
+
+// regionFromSecondaryClusterID — pure helper: given a k8sCache cluster ID
+// and the two possible primary-cluster IDs the chroot uses (the deployment
+// ID and the SOVEREIGN_FQDN-derived fallback), return the region key for a
+// secondary cluster registration, or "" when the cluster is either the
+// primary itself, alien (not "<primaryID>-..."), or has an empty suffix.
+//
+// Secondary cluster IDs follow the `<primaryID>-<regionKey>` convention
+// established by HandleSovereignSecondaryKubeconfig (see
+// sovereign_secondary_kubeconfig.go:127). Region keys like "hel1-1",
+// "nbg1-2" contain hyphens themselves, so the helper uses HasPrefix with
+// the trailing dash to split on the boundary correctly.
+//
+// Exposed package-private so jobs_d20_secondary_test.go can lock in the
+// contract independently of a real k8sCache.Factory.
+func regionFromSecondaryClusterID(clusterID, depID, chrootFallbackID string) string {
+	if clusterID == "" || clusterID == depID || clusterID == chrootFallbackID {
+		return ""
+	}
+	if depID != "" && strings.HasPrefix(clusterID, depID+"-") {
+		return strings.TrimPrefix(clusterID, depID+"-")
+	}
+	// The fallback id is "sovereign-<fqdn>" — only match when the suffix
+	// looks like a real fqdn-derived cluster (i.e. chrootFallbackID is
+	// not the bare "sovereign-" empty-fqdn marker).
+	if chrootFallbackID != "" && chrootFallbackID != "sovereign-" &&
+		strings.HasPrefix(clusterID, chrootFallbackID+"-") {
+		return strings.TrimPrefix(clusterID, chrootFallbackID+"-")
+	}
+	return ""
+}
+
+// chrootSeedSecondaryRegions — D20 fan-out: enumerate HelmReleases from
+// every secondary cluster the chroot has registered in h.k8sCache and
+// feed region-prefixed seeds into the SAME jobs Bridge used by the
+// primary seed above. Region key is derived from the cluster ID by
+// stripping the depID prefix (cluster id "<depID>-<region>" → region).
+//
+// No-op when:
+//   - h.k8sCache is nil (single-cluster Sovereign / CI),
+//   - no secondary clusters registered (single-region Sovereign), or
+//   - DynamicClientFor returns an error (cluster registered but client
+//     not yet built — best-effort, the next /jobs read retries).
+//
+// Idempotent — bridge.SeedJobsFromInformerList monotonic-merges so a
+// re-read after a re-attached watch doesn't dup Job rows.
+func (h *Handler) chrootSeedSecondaryRegions(ctx context.Context, dep *Deployment, bridge *jobs.Bridge) {
+	if h.k8sCache == nil || bridge == nil {
+		return
+	}
+	primaryID := dep.ID
+	chrootPrimaryID := "sovereign-" + strings.TrimSpace(os.Getenv("SOVEREIGN_FQDN"))
+	for _, cid := range h.k8sCache.Clusters() {
+		region := regionFromSecondaryClusterID(cid, primaryID, chrootPrimaryID)
+		if region == "" {
+			continue
+		}
+		dyn, err := h.k8sCache.DynamicClientFor(cid)
+		if err != nil || dyn == nil {
+			h.log.Debug("chroot seed: secondary DynamicClientFor unavailable",
+				"depId", dep.ID, "clusterID", cid, "err", err)
+			continue
+		}
+		snap, err := helmwatch.ListAndSnapshotHelmReleases(ctx, dyn)
+		if err != nil {
+			h.log.Warn("chroot seed: secondary list HelmReleases failed",
+				"depId", dep.ID, "region", region, "err", err)
+			continue
+		}
+		if len(snap) == 0 {
+			continue
+		}
+		seeds := snapshotsToSeedsForRegion(snap, region)
+		jobsCount, execsSeeded, err := bridge.SeedJobsFromInformerList(seeds)
+		if err != nil {
+			h.log.Warn("chroot seed: secondary bridge seed failed",
+				"depId", dep.ID, "region", region, "err", err)
+			continue
+		}
+		h.log.Info("chroot seed: secondary region jobs.Store populated",
+			"depId", dep.ID,
+			"region", region,
+			"clusterID", cid,
+			"helmReleases", len(snap),
+			"jobsWritten", jobsCount,
+			"executionsSeeded", execsSeeded,
+		)
+	}
 }
 
 // jobsStore returns the Handler's jobs.Store. Returns nil when

--- a/products/catalyst/bootstrap/api/internal/handler/jobs_d20_secondary_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/jobs_d20_secondary_test.go
@@ -1,0 +1,162 @@
+// jobs_d20_secondary_test.go — unit coverage for the D20 multi-region
+// chroot seed fan-out (issue #1821).
+//
+// The Sovereign /jobs page hides the Region filter dropdown on
+// single-region sets (regionOptions.length > 1 gate in
+// products/catalyst/bootstrap/ui/src/pages/sovereign/JobsTable.tsx).
+// On a 3-region Sovereign the dropdown only appears when the per-
+// deployment jobs.Store carries region-prefixed install-* rows for
+// every secondary region. Before this test landed,
+// chrootSeedJobsStoreIfEmpty only enumerated the primary cluster's
+// HelmReleases — secondary regions' rows never made it to the store,
+// the dropdown stayed hidden, and DoD D20 failed on every fresh prov.
+//
+// The fan-out is wired up in chrootSeedSecondaryRegions which walks
+// h.k8sCache.Clusters() and consults regionFromSecondaryClusterID to
+// derive the region key from each registered cluster id. The two
+// tests below cover (a) the cluster-id → region key derivation
+// contract and (b) the end-to-end seed write into the bridge.
+
+package handler
+
+import (
+	"testing"
+
+	"github.com/openova-io/openova/products/catalyst/bootstrap/api/internal/helmwatch"
+)
+
+// TestRegionFromSecondaryClusterID_Contract locks in the rules the
+// chroot fan-out relies on:
+//   - empty cluster id → no region
+//   - cluster id == primary depID → no region (primary already seeded)
+//   - cluster id == chroot fallback (sovereign-<fqdn>) → no region
+//   - "<depID>-<region>" → region
+//   - "<chrootFallback>-<region>" → region
+//   - alien / cross-deployment ids → no region (no leakage)
+//   - empty SOVEREIGN_FQDN ("sovereign-" fallback) does NOT match any
+//     ".*-..." cluster id (defense in depth)
+func TestRegionFromSecondaryClusterID_Contract(t *testing.T) {
+	cases := []struct {
+		name       string
+		clusterID  string
+		depID      string
+		fallbackID string
+		want       string
+	}{
+		{
+			name:       "primary depID — no region",
+			clusterID:  "dep123",
+			depID:      "dep123",
+			fallbackID: "sovereign-t34.omani.works",
+			want:       "",
+		},
+		{
+			name:       "chroot fallback id — no region",
+			clusterID:  "sovereign-t34.omani.works",
+			depID:      "dep123",
+			fallbackID: "sovereign-t34.omani.works",
+			want:       "",
+		},
+		{
+			name:       "depID-prefixed secondary — extracts region",
+			clusterID:  "dep123-hel1-1",
+			depID:      "dep123",
+			fallbackID: "sovereign-t34.omani.works",
+			want:       "hel1-1",
+		},
+		{
+			name:       "fallback-prefixed secondary — extracts region",
+			clusterID:  "sovereign-t34.omani.works-nbg1-2",
+			depID:      "dep123",
+			fallbackID: "sovereign-t34.omani.works",
+			want:       "nbg1-2",
+		},
+		{
+			name:       "alien cluster id — no region (no leakage)",
+			clusterID:  "other-deployment-fsn1",
+			depID:      "dep123",
+			fallbackID: "sovereign-t34.omani.works",
+			want:       "",
+		},
+		{
+			name:       "empty cluster id — no region",
+			clusterID:  "",
+			depID:      "dep123",
+			fallbackID: "sovereign-t34.omani.works",
+			want:       "",
+		},
+		{
+			name:       "bare sovereign- fallback marker does NOT match arbitrary ids",
+			clusterID:  "sovereign-fsn1",
+			depID:      "dep123",
+			fallbackID: "sovereign-",
+			want:       "",
+		},
+		{
+			name:       "depID with hyphenated region — preserves region key",
+			clusterID:  "abc-123-fsn1-2",
+			depID:      "abc-123",
+			fallbackID: "sovereign-t34.omani.works",
+			want:       "fsn1-2",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := regionFromSecondaryClusterID(tc.clusterID, tc.depID, tc.fallbackID)
+			if got != tc.want {
+				t.Fatalf("regionFromSecondaryClusterID(%q, %q, %q) = %q; want %q",
+					tc.clusterID, tc.depID, tc.fallbackID, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestSnapshotsToSeedsForRegion_PrefixesAppID verifies that the seed
+// shape the chroot fan-out feeds into the Bridge produces region-
+// prefixed jobs that the FE regionFromJob() helper picks up. Without
+// the "<region>:" prefix on the resulting Job.AppID the UI's
+// regionOptions set stays size 1 and the Region dropdown never
+// renders. Locks in the pipe from ComponentSnapshot → InformerSeed →
+// Job.AppID without standing up the full helmwatch.Bridge.
+//
+// snapshotsToSeedsForRegion already has direct coverage in
+// jobs_backfill_test.go for the bare-region case; this test pins the
+// hyphenated-region (hel1-1, nbg1-2) case the D20 fan-out exercises
+// in production.
+func TestSnapshotsToSeedsForRegion_HyphenatedRegion(t *testing.T) {
+	// Synthesise two snapshots — chroot fan-out path uses the same
+	// helmwatch.ComponentSnapshot shape ListAndSnapshotHelmReleases
+	// returns from a fake apiserver.
+	snaps := []helmwatch.ComponentSnapshot{
+		{AppID: "bp-cilium", Status: "succeeded"},
+		{AppID: "bp-flux", Status: "running", DependsOn: []string{"bp-cilium"}},
+	}
+	seeds := snapshotsToSeedsForRegion(snaps, "hel1-1")
+	if len(seeds) != 2 {
+		t.Fatalf("got %d seeds; want 2", len(seeds))
+	}
+	wantBy := map[string]struct {
+		state string
+		deps  []string
+	}{
+		"hel1-1:bp-cilium": {state: "succeeded", deps: nil},
+		"hel1-1:bp-flux":   {state: "running", deps: []string{"hel1-1:bp-cilium"}},
+	}
+	for _, s := range seeds {
+		want, ok := wantBy[s.Component]
+		if !ok {
+			t.Fatalf("unexpected seed component %q", s.Component)
+		}
+		if s.State != want.state {
+			t.Fatalf("seed %q: state=%q want %q", s.Component, s.State, want.state)
+		}
+		if len(want.deps) != len(s.DependsOn) {
+			t.Fatalf("seed %q: deps=%v want %v", s.Component, s.DependsOn, want.deps)
+		}
+		for i, d := range s.DependsOn {
+			if d != want.deps[i] {
+				t.Fatalf("seed %q: deps[%d]=%q want %q", s.Component, i, d, want.deps[i])
+			}
+		}
+	}
+}

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -1580,8 +1580,27 @@ name: bp-catalyst-platform
 # (Wave 6 PR 4), /api/v1/sme/orders (Wave 6 PR 3), and
 # /api/v1/sme/billing/vouchers/list (Wave 6 PR 5). The non-zero
 # projection lands with the marketplace / billing wires.
-version: 1.4.203
-appVersion: 1.4.203
+# 1.4.204 — DoD D20 (issue #1821, t34 walk 2026-05-19 ~13:22Z agent
+# a49a48dd): the /jobs page rendered 62 rows on a 3-region Sovereign
+# but the Region filter dropdown was hidden (only STATUS / APP /
+# PARENT visible). Root cause: chrootSeedJobsStoreIfEmpty only
+# enumerated HelmReleases via the in-cluster sovereignDynamicClient
+# (primary region only). Secondary regions' install-* rows never made
+# it to the per-deployment jobs.Store, so JobsTable's regionOptions
+# Set stayed size-1 and the UI's `regionOptions.length > 1` gate
+# correctly hid the dropdown. Fix: after the primary seed, fan out
+# across every cluster registered with h.k8sCache (the chroot picks
+# up secondary kubeconfigs via POST /api/v1/sovereign/secondary-
+# kubeconfig at handover — see sovereign_secondary_kubeconfig.go) and
+# feed region-prefixed seeds (snapshotsToSeedsForRegion) into the
+# same jobs Bridge. Region key derives from the cluster ID via the
+# new pure helper regionFromSecondaryClusterID, which is locked in by
+# jobs_d20_secondary_test.go's 8-case contract. The UI region filter
+# was already shipped on 1.4.197 (PR #1820 lineage); this completes
+# the data-layer side so the dropdown finally appears on multi-region
+# Sovereigns. Refs #1821, DoD D20.
+version: 1.4.204
+appVersion: 1.4.204
 # 1.4.183 — fix(httproute): omit default sectionName so multi-zone
 # Sovereigns attach via Cilium Gateway hostname matcher (Closes #1884,
 # TBD-A30). Pre-1.4.183 every catalyst-system HTTPRoute pinned


### PR DESCRIPTION
## Summary

DoD D20 (issue #1821) — T2 walk on t34 (2026-05-19 ~13:22Z, agent a49a48dd) flagged that the Sovereign `/jobs` page rendered 62 rows on a 3-region prov but the Region filter dropdown stayed hidden. Only STATUS / APP / PARENT filters were visible.

### Root cause

`chrootSeedJobsStoreIfEmpty` in `products/catalyst/bootstrap/api/internal/handler/jobs.go` only enumerated HelmReleases via the in-cluster `sovereignDynamicClient` (primary region). On a 3-region Sovereign, secondary-region install-* rows never reached the per-deployment `jobs.Store`, so:
- The Sovereign /jobs view rendered only the primary region's install rows.
- `JobsTable.regionOptions` Set stayed size-1.
- The existing `regionOptions.length > 1` gate correctly hid the Region dropdown (the UI shipped this conditional rendering in chart 1.4.197 / PR #1820 lineage; the bug is fully on the data-layer side).

### Fix scope

- New `chrootSeedSecondaryRegions` walks `h.k8sCache.Clusters()` after the primary seed, derives the region key per registered cluster via the new pure helper `regionFromSecondaryClusterID`, and feeds region-prefixed seeds (`snapshotsToSeedsForRegion`) into the SAME jobs Bridge the primary seed uses. Idempotent (Bridge `SeedJobsFromInformerList` is monotonic).
- Secondary cluster IDs follow the `<depID>-<regionKey>` convention established by `HandleSovereignSecondaryKubeconfig`; the new helper handles both the `<depID>-...` form AND the `sovereign-<fqdn>-...` fallback used when `CATALYST_SELF_DEPLOYMENT_ID` is unset.
- Cross-deployment / alien cluster registrations are skipped (defense in depth).
- Chart bump 1.4.198 -> 1.4.199 + bootstrap-kit pin update.

### What this PR does NOT change

The UI region filter (`regionFromJob` helper, dropdown rendering, region predicate, unit tests) was shipped on chart 1.4.197 (PR #1820 lineage). This PR is data-layer only — it completes the fan-out so the dropdown finally appears on multi-region Sovereigns.

## Validation

- `go test ./internal/handler/ -count=1 -timeout 120s` — all handler tests GREEN (95s).
- `TestRegionFromSecondaryClusterID_Contract` — 8/8 sub-cases PASS (primary skip, both fallback forms, alien rejection, hyphenated region preservation, empty input rejection, bare `sovereign-` marker rejection).
- `TestSnapshotsToSeedsForRegion_HyphenatedRegion` — PASS (covers `hel1-1:bp-cilium` / `hel1-1:bp-flux` with dep edges remapped to the region prefix).
- `helm template products/catalyst/chart/` parses.

## Test plan

- [ ] Next T2 walk on a fresh 3-region prov confirms:
  - Region dropdown is visible on /jobs page.
  - Selecting a region narrows the table to that region's rows only.
  - Result count updates correctly.
  - All 3 regions appear in the dropdown options.
- [ ] CI green on this PR.

Refs #1821 (NOT `Closes` — next T2 walk on a fresh prov closes the issue per founder closure rule).