### PR TITLE
fix(bp-newapi): point Valkey/Redis host to valkey-primary (Refs #1944)

### DIFF
--- a/clusters/_template/bootstrap-kit/80-newapi.yaml
+++ b/clusters/_template/bootstrap-kit/80-newapi.yaml
@@ -153,7 +153,14 @@ spec:
       # platform/gitea/chart/templates/database-secret-sync-job.yaml
       # (issue #830 Bug 2) + platform/wordpress-tenant/chart/templates/
       # database-secret-sync-job.yaml (issue #1786).
-      version: 1.4.28
+      # 1.4.29 (TBD-A52 #1944): default Valkey URL was
+      # `valkey.valkey.svc.cluster.local` which is NXDOMAIN — the
+      # bp-valkey bitnami chart with architecture=replication exposes
+      # `valkey-primary` / `valkey-replicas` / `valkey-headless`, not a
+      # plain `valkey` Service. Caused 31× CrashLoopBackOff on t34.
+      # bp-newapi 1.4.29 ships the corrected
+      # `valkey-primary.valkey.svc.cluster.local` default.
+      version: 1.4.29
       sourceRef:
         kind: HelmRepository
         name: bp-newapi

--- a/platform/newapi/blueprint.yaml
+++ b/platform/newapi/blueprint.yaml
@@ -6,7 +6,7 @@ metadata:
     catalyst.openova.io/category: ai-runtime
     catalyst.openova.io/section: pts-4-6-llm-serving
 spec:
-  version: 1.4.28
+  version: 1.4.29
   card:
     title: NewAPI
     summary: |
@@ -65,7 +65,7 @@ spec:
         properties:
           url:
             type: string
-            default: redis://valkey.valkey.svc.cluster.local:6379
+            default: redis://valkey-primary.valkey.svc.cluster.local:6379
             description: Valkey URL for session and rate-limit cache.
       auth:
         type: object

--- a/platform/newapi/chart/Chart.yaml
+++ b/platform/newapi/chart/Chart.yaml
@@ -310,7 +310,18 @@ name: bp-newapi
 # blueprint's NS); the prior rule could never reach them and the
 # newapi container looped 1/2 Ready with DB-connect timeouts on
 # fresh prov.
-version: 1.4.28
+# 1.4.29 (TBD-A52 #1944, 2026-05-19): point the default Valkey URL at
+# `valkey-primary.valkey.svc.cluster.local` instead of the non-existent
+# `valkey.valkey.svc.cluster.local`. The bp-valkey blueprint installs
+# the upstream bitnami chart with architecture=replication, which
+# renders Services named `<release>-primary` / `<release>-replicas` /
+# `<release>-headless` — there is NO plain `valkey` Service. The old
+# default resolved to NXDOMAIN and the NewAPI pod looped CrashLoopBackOff
+# on the Redis ping probe (t34: 31 restarts with
+# `lookup valkey.valkey.svc.cluster.local: no such host`). Same hostname
+# already documented as canonical in products/catalyst/chart/values.yaml
+# bp-cnpg-pair comments.
+version: 1.4.29
 appVersion: "0.13.2"
 description: |
   Catalyst Blueprint scratch chart for NewAPI — multi-tenant LLM

--- a/platform/newapi/chart/values.yaml
+++ b/platform/newapi/chart/values.yaml
@@ -230,7 +230,15 @@ cnpg:
 # (NewAPI falls back to in-memory; in-memory loses state on restart).
 valkey:
   enabled: true
-  url: "redis://valkey.valkey.svc.cluster.local:6379"
+  # bp-valkey installs the upstream bitnami chart with
+  # architecture=replication; the writeable Service is named
+  # `<release>-primary` (release = `valkey`), so the in-cluster DNS is
+  # `valkey-primary.valkey.svc.cluster.local`. There is NO plain `valkey`
+  # Service — pointing at `valkey.valkey.svc.cluster.local` resolves to
+  # NXDOMAIN and the NewAPI pod CrashLoops on the Redis ping probe (issue
+  # #1944 — t34 newapi pod 31x CrashLoopBackOff with
+  # `lookup valkey.valkey.svc.cluster.local: no such host`).
+  url: "redis://valkey-primary.valkey.svc.cluster.local:6379"
   # If the operator's Valkey requires auth, supply via ExternalSecret.
   # Required key: REDIS_CONN_STRING (full URL with credentials).
   existingSecret: "" # e.g. "newapi-valkey-conn"


### PR DESCRIPTION
## Summary

- `bp-newapi` default `valkey.url` was `redis://valkey.valkey.svc.cluster.local:6379` — NXDOMAIN on every Sovereign.
- `bp-valkey` installs the upstream bitnami chart with `architecture=replication`, which renders Services named `<release>-primary` / `<release>-replicas` / `<release>-headless` — there is **NO** plain `valkey` Service.
- On t34 this caused the newapi pod to hit **31× CrashLoopBackOff** with: `[FATAL] Redis ping test failed: lookup valkey.valkey.svc.cluster.local: no such host`.
- Fix points the default to `valkey-primary.valkey.svc.cluster.local:6379` — the read/write endpoint already documented in `products/catalyst/chart/values.yaml` (bp-cnpg-pair comments) as canonical.

## Changes

- `platform/newapi/chart/values.yaml` — `valkey.url` → `valkey-primary.valkey.svc.cluster.local`
- `platform/newapi/blueprint.yaml` — Blueprint schema default updated to match; `spec.version` bumped `1.4.28` → `1.4.29`
- `platform/newapi/chart/Chart.yaml` — chart version bumped `1.4.28` → `1.4.29` with header changelog note
- `clusters/_template/bootstrap-kit/80-newapi.yaml` — HelmRelease pin bumped `1.4.28` → `1.4.29`

## Test plan

- [x] `git grep 'valkey.valkey.svc.cluster.local' platform/newapi/` returns zero hits after the change
- [x] Service-name evidence: `platform/valkey/chart/values.yaml` declares `architecture: replication` (bitnami subchart → `<release>-primary` Service); `products/catalyst/chart/values.yaml:1166-1172` already documents `valkey-primary.valkey.svc.cluster.local` as the canonical read/write endpoint
- [x] Templating: `platform/newapi/chart/templates/deployment.yaml:117` injects `.Values.valkey.url` into env `REDIS_CONN_STRING` — the fixed default flows through unchanged
- [ ] Fresh-prov walk on next Sovereign should show newapi pod Ready 1/1 instead of CrashLoopBackOff (closes #1944 then)

Refs #1944