### PR TITLE
fix(sme-secrets): reflect into catalyst-system on fresh prov (Refs #1943)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -670,7 +670,7 @@ spec:
       # set `spec.releaseName` to the bare upstream name (`harbor`,
       # `alloy`, `cert-manager`, ...) so the selector is always
       # release-name-bare, never bp-prefixed. Refs #1928.
-      version: 1.4.198
+      version: 1.4.199
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -1,5 +1,59 @@
 apiVersion: v2
 name: bp-catalyst-platform
+# 1.4.199 — TBD-A51 (issue #1943, t34 T3 walk 2026-05-19 13:52Z agent
+# a9e0547e): decouple `sme-secrets` Secret + `sme` Namespace rendering
+# from `ingress.marketplace.enabled`. Background: catalyst-api consumes
+# CATALYST_SME_JWT_SECRET via secretKeyRef on the emberstack/reflector
+# mirror of `sme-secrets` (source in `sme` namespace → mirror in
+# `catalyst-system`) to mint short-lived HS256 bridge tokens on every
+# /api/v1/sme/billing/vouchers/* proxy call (PR #1625 + #1630). Pre-fix
+# the source Secret + its namespace were gated behind
+# ingress.marketplace.enabled, so every Sovereign provisioned with
+# the default marketplace_enabled=false (every customer-journey start)
+# had:
+#   - `kubectl get ns sme` → NotFound
+#   - `kubectl get secret -A sme-secrets` → NotFound
+#   - catalyst-api Pod env CATALYST_SME_JWT_SECRET unset
+#   - POST /api/v1/sme/billing/vouchers/issue → 503 with response body
+#     `CATALYST_SME_JWT_SECRET is not set on this catalyst-api Pod;
+#     the chart's sme-secrets Secret may not be reflected into
+#     catalyst-system yet`
+# Caught live on t34 (3-region cpx52 fsn1/hel1/nbg1, chart 1.4.198),
+# blocking the entire D28 voucher → D29 customer-journey →
+# D34 WordPress install chain (Refs #1842 #1829 #1723 #1741).
+# Fix: drop the `if .Values.ingress.marketplace.enabled` wrapper from
+# both `templates/sme-services/sme-namespace.yaml` and
+# `templates/sme-services/sme-secrets.yaml`. The SME *microservice
+# mesh* (billing.yaml, auth.yaml, gateway.yaml, catalog.yaml,
+# console.yaml, marketplace.yaml, notification.yaml, provisioning.yaml,
+# domain.yaml, admin.yaml, ferretdb.yaml, cnpg-cluster.yaml +
+# routes/grants/policies) remains gated on the same flag — only the
+# namespace + reflector-source Secret materialise unconditionally.
+# Net effect on a fresh prov with marketplace_enabled=false:
+#   - `kubectl get ns sme` → Active
+#   - `kubectl -n sme get secret sme-secrets` → 11 keys (with empty
+#     SMTP/OAuth/admin defaults that come from .Values.smeSecrets.*)
+#   - reflector copies the Secret to `catalyst-system` on first
+#     reconcile (sole namespace listed in the
+#     reflection-allowed-namespaces / reflection-auto-namespaces
+#     allow-list)
+#   - catalyst-api Pod env CATALYST_SME_JWT_SECRET populated on next
+#     restart (kubelet re-reads optional secretKeyRef when the Secret
+#     transitions from NotFound to present)
+# What this does NOT fix (intentional scope, per issue #1943 hard rule
+# "ship the smaller fix alone"): the SME microservice mesh still needs
+# `marketplace_enabled=true` on a prov body to render its Deployments
+# and Gateway routes — without those upstream Pods, voucher issuance
+# still surfaces as 503 from the catalyst-api proxy, just with the
+# next error band (`sme gateway unreachable`) rather than the JWT-
+# bridge-unwired error band. The broader "default marketplace ON for
+# customer-journey Sovereigns" is a separate operator-policy decision
+# tracked in a follow-up issue.
+# Kustomize-mode contabo build unchanged: both templates remain
+# excluded from `templates/sme-services/kustomization.yaml`'s
+# `resources:` list, so contabo continues to source the `sme`
+# namespace + secrets from clusters/contabo-mkt/apps/sme/.
+# Refs #1943.
 # 1.4.198 — issue #1928 residual (t34 chart 1.4.197 walk, 2026-05-19
 # 12:21Z agent aced939b): the Resources tab still rendered 0/0/0 across
 # every kind for the bootstrap-kit `bp-harbor` Application even after
@@ -1468,8 +1522,8 @@ name: bp-catalyst-platform
 # 25/TCP (legacy SMTP fallback). All three are explicitly scoped to
 # `toEntities: world`, matching the existing 443/TCP allow. No other
 # rule semantics change. (Fixes PIN-issue 502 regression from #1785.)
-version: 1.4.198
-appVersion: 1.4.198
+version: 1.4.199
+appVersion: 1.4.199
 # 1.4.183 — fix(httproute): omit default sectionName so multi-zone
 # Sovereigns attach via Cilium Gateway hostname matcher (Closes #1884,
 # TBD-A30). Pre-1.4.183 every catalyst-system HTTPRoute pinned

--- a/products/catalyst/chart/templates/sme-services/sme-namespace.yaml
+++ b/products/catalyst/chart/templates/sme-services/sme-namespace.yaml
@@ -12,18 +12,23 @@ provisions the `sme` namespace, so without this template Helm install
 fails 23 times with `failed to create resource: namespaces "sme" not
 found` (live blocker on otech105 — 2026-05-05).
 
-Same dual-mode contract as the rest of templates/sme-services/* — gated
-on `ingress.marketplace.enabled` so non-marketplace Sovereigns and the
-Kustomize-mode contabo build skip this entirely. Kustomize-mode build
-does NOT include `templates/sme-services/sme-namespace.yaml` in
-`templates/sme-services/kustomization.yaml`'s `resources:` list (the
-contabo build manages the `sme` namespace via
-clusters/contabo-mkt/apps/sme/namespace.yaml).
+Kustomize-mode contabo build is unaffected: this template is
+excluded from `templates/sme-services/kustomization.yaml`'s
+`resources:` list (the contabo build manages the `sme` namespace
+via clusters/contabo-mkt/apps/sme/namespace.yaml).
 
 helm.sh/resource-policy: keep — never delete the namespace on a
 chart uninstall (would cascade-delete every SME workload + tenant).
+
+Issue #1943 (TBD-A51, 2026-05-19): the marketplace.enabled gate
+removed here so `sme-secrets` (sibling template) has a namespace
+to land in on every fresh prov. The SME microservice mesh
+(billing.yaml, auth.yaml, gateway.yaml, ...) remains gated behind
+`ingress.marketplace.enabled` (operator opt-in); only the
+namespace + reflector-source Secret materialise unconditionally,
+which is what catalyst-api's CATALYST_SME_JWT_SECRET secretKeyRef
+mirror needs.
 */ -}}
-{{- if and .Values.ingress .Values.ingress.marketplace .Values.ingress.marketplace.enabled -}}
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -35,4 +40,3 @@ metadata:
   annotations:
     helm.sh/resource-policy: keep
     catalyst.openova.io/created-by: bp-catalyst-platform
-{{- end -}}

--- a/products/catalyst/chart/templates/sme-services/sme-secrets.yaml
+++ b/products/catalyst/chart/templates/sme-services/sme-secrets.yaml
@@ -53,8 +53,29 @@ Per #4 (never hardcode): every static value is overridable via
 .Values.smeSecrets.* / .Values.marketplace.signupPolicy.googleOAuth.*
 with placeholder defaults (operator brings real values via the
 per-Sovereign overlay or admin-console signup form).
+
+Issue #1943 (TBD-A51, 2026-05-19): the marketplace.enabled gate
+removed here. catalyst-api (in catalyst-system) reads
+CATALYST_SME_JWT_SECRET via secretKeyRef on the reflector mirror
+of `sme-secrets`. Before this fix, every Sovereign provisioned
+with the default marketplace_enabled=false (i.e. every customer
+journey start) had `sme-secrets` skipped entirely → the
+catalyst-api proxySMEVoucher path 503'd with
+`CATALYST_SME_JWT_SECRET is not set on this catalyst-api Pod;
+the chart's sme-secrets Secret may not be reflected into
+catalyst-system yet`, breaking the D28 voucher chain (#1842),
+D29 customer journey (#1829), and D34 WordPress install
+(#1723). Decoupling this Secret + its sibling namespace from
+the marketplace ingress gate restores the JWT bridge on every
+fresh prov; the SME microservice mesh itself remains gated
+behind ingress.marketplace.enabled (operator opt-in).
+
+Kustomize-mode contabo build is unaffected: this template is
+excluded from templates/sme-services/kustomization.yaml's
+resources list (per the dual-mode pattern), so contabo's
+hand-rolled clusters/contabo-mkt/apps/sme/data/secrets.yaml
+remains the source of truth there.
 */}}
-{{- if and .Values.ingress .Values.ingress.marketplace .Values.ingress.marketplace.enabled -}}
 {{- $secretName := .Values.smeSecrets.secretName | default "sme-secrets" -}}
 {{- $namespace := .Values.smeSecrets.namespace | default "sme" -}}
 {{- /* ---- Persistent randoms via lookup ---- */ -}}
@@ -225,4 +246,3 @@ data:
   # ---- Admin bootstrap (email static, password persistent random) ----
   ADMIN_EMAIL: {{ .Values.smeSecrets.admin.email | default "admin@openova.io" | b64enc | quote }}
   ADMIN_PASSWORD: {{ $adminPassword | b64enc | quote }}
-{{- end }}


### PR DESCRIPTION
## Summary

- TBD-A51 surgical fix: drop `ingress.marketplace.enabled` gate on `sme-namespace.yaml` + `sme-secrets.yaml` so catalyst-api's `CATALYST_SME_JWT_SECRET` secretKeyRef has a reflector-source Secret on every fresh prov (not just marketplace-enabled ones).
- Chart bumped 1.4.198 → 1.4.199; bootstrap-kit pin synced.
- SME microservice mesh (48 other templates under `templates/sme-services/`) REMAINS gated behind the same flag — only namespace + reflector source materialise unconditionally.

## Root cause (live evidence from t34, 2026-05-19 13:52Z, chart 1.4.198)

t34 prov body had `marketplace_enabled: false` (the default for customer-journey starts). The chart's `templates/sme-services/sme-namespace.yaml` + `sme-secrets.yaml` both opened with `{{- if and .Values.ingress .Values.ingress.marketplace .Values.ingress.marketplace.enabled -}}`, so neither rendered on a fresh prov:

```
kubectl --insecure-skip-tls-verify -n flux-system get kustomization bootstrap-kit \
  -o jsonpath='{.spec.postBuild.substitute.MARKETPLACE_ENABLED}'
# false

kubectl --insecure-skip-tls-verify get hr -n flux-system bp-catalyst-platform \
  -o jsonpath='{.spec.values.ingress.marketplace}'
# {"enabled":false}

kubectl --insecure-skip-tls-verify get ns sme
# Error from server (NotFound): namespaces "sme" not found

kubectl --insecure-skip-tls-verify -A get secret sme-secrets
# NotFound across all namespaces
```

catalyst-api Pod env:
```yaml
- name: CATALYST_SME_JWT_SECRET
  valueFrom:
    secretKeyRef:
      name: sme-secrets
      key: JWT_SECRET
      optional: true
```

Without the Secret, the env stays empty -> `proxySMEVoucher` short-circuits with:
```
POST /api/v1/sme/billing/vouchers/issue -> 503
"CATALYST_SME_JWT_SECRET is not set on this catalyst-api Pod;
 the chart's sme-secrets Secret may not be reflected into catalyst-system yet"
```

Reflector controller IS installed on t34 (slot 05a `bp-reflector` 7.1.288, Pod `reflector-5f6d58fdbb-z4krm` Running 161m) - it just had no source Secret to mirror.

## Why this scope (and what's NOT in scope)

Issue #1943 acceptance:
> `kubectl -n catalyst-system get secret sme-secrets` returns the Secret + catalyst-api Pod env shows CATALYST_SME_JWT_SECRET populated, voucher endpoint returns 2xx.

This PR delivers items 1 + 2 by unconditionally rendering the source Secret. **Item 3 (voucher endpoint 2xx) is NOT delivered** - the voucher endpoint proxies to the SME gateway Pod, which only deploys when `marketplace.enabled=true`. With this fix the error band shifts from "JWT bridge unwired" -> "upstream SME gateway unreachable", which is the intended chart-design behaviour for non-marketplace Sovereigns (see comment in `api-deployment.yaml:614`).

The broader "default marketplace ON for customer-journey provisioning" is an operator-policy decision tracked separately. Per the issue's hard rule "ship the smaller fix alone if wider than chart values".

## Test plan

- [x] `helm template` with `ingress.marketplace.enabled=false` renders `sme-namespace.yaml` + `sme-secrets.yaml` only (2 templates, not 50)
- [x] `helm template` with `ingress.marketplace.enabled=true` still renders all 48 SME-mesh templates (regression check)
- [x] `helm lint` clean (only `icon is recommended` info, no warn/error)
- [ ] Next fresh prov (post-merge + chart-publish CI): `kubectl get ns sme` Active, `kubectl -n sme get secret sme-secrets` 11 keys, `kubectl -n catalyst-system get secret sme-secrets` 11 keys (reflector-mirrored), catalyst-api Pod env `CATALYST_SME_JWT_SECRET` populated
- [ ] Next T3 customer-journey walk: closes #1943 when the voucher endpoint's error band changes from "JWT bridge unwired" to upstream-gateway-related (or 2xx when run on a marketplace-enabled Sovereign)

Refs #1943.

Generated with Claude Code