### PR TITLE
fix: openova-flow-server DNS — references .catalyst-system not .catalyst (Refs #1948)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -670,7 +670,12 @@ spec:
       # set `spec.releaseName` to the bare upstream name (`harbor`,
       # `alloy`, `cert-manager`, ...) so the selector is always
       # release-name-bare, never bp-prefixed. Refs #1928.
-      version: 1.4.199
+      #
+      # 1.4.200 — TBD-A56 / #1948 fix: catalyst-api OPENOVA_FLOW_SERVER_URL
+      # env corrected from `.catalyst.svc.cluster.local` to
+      # `.catalyst-system.svc.cluster.local` (Service's actual namespace
+      # per slot 56 targetNamespace). Refs #1948.
+      version: 1.4.200
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/bootstrap/api/internal/handler/handler.go
+++ b/products/catalyst/bootstrap/api/internal/handler/handler.go
@@ -589,9 +589,10 @@ func New(log *slog.Logger) *Handler {
 	// flowemit — POST events to openova-flow-server's CNPG-backed
 	// store. URL from OPENOVA_FLOW_SERVER_URL env (same var the
 	// snapshot/stream proxy uses). Empty → no-op client; production
-	// chart wires this to http://openova-flow-server.catalyst.svc
-	// .cluster.local on mothership, in-cluster service DNS on
-	// Sovereigns.
+	// chart wires this to http://openova-flow-server.catalyst-system
+	// .svc.cluster.local on mothership (Service lives in catalyst-system
+	// per bootstrap-kit slot 56 targetNamespace), in-cluster service
+	// DNS on Sovereigns.
 	h.flowEmit = flowemit.NewClient(os.Getenv("OPENOVA_FLOW_SERVER_URL"), log)
 
 	return h

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -1522,8 +1522,22 @@ name: bp-catalyst-platform
 # 25/TCP (legacy SMTP fallback). All three are explicitly scoped to
 # `toEntities: world`, matching the existing 443/TCP allow. No other
 # rule semantics change. (Fixes PIN-issue 502 regression from #1785.)
-version: 1.4.199
-appVersion: 1.4.199
+#
+# 1.4.200 — TBD-A56 / #1948 (t34 T3 walk, 2026-05-19): catalyst-api
+# `OPENOVA_FLOW_SERVER_URL` env in api-deployment.yaml hardcoded the
+# upstream as `http://openova-flow-server.catalyst.svc.cluster.local`
+# but the Service is installed by bootstrap-kit slot 56 with
+# `spec.targetNamespace: catalyst-system`. In-cluster DNS resolution
+# failed on every Sovereign + mothership → /api/v1/flows/{id}/snapshot
+# returned 502 and the operator's Flow canvas stayed empty. Fix
+# updates the env to the correct namespace and aligns the comment in
+# bootstrap/api/internal/handler/handler.go. Also aligns with the Go
+# default constant `defaultFlowServerURL` already pointing at
+# `.catalyst-system.svc.cluster.local:8080` and the
+# 57-bp-openova-flow-emitter overlay (`flowServerUrl: http://
+# openova-flow-server.catalyst-system.svc.cluster.local`).
+version: 1.4.200
+appVersion: 1.4.200
 # 1.4.183 — fix(httproute): omit default sectionName so multi-zone
 # Sovereigns attach via Cilium Gateway hostname matcher (Closes #1884,
 # TBD-A30). Pre-1.4.183 every catalyst-system HTTPRoute pinned

--- a/products/catalyst/chart/templates/api-deployment.yaml
+++ b/products/catalyst/chart/templates/api-deployment.yaml
@@ -185,7 +185,13 @@ spec:
             # exists on a Sovereign that has installed bootstrap-kit
             # slot 56 with httproute.enabled=true.
             - name: OPENOVA_FLOW_SERVER_URL
-              value: "http://openova-flow-server.catalyst.svc.cluster.local"
+              # Service lives in catalyst-system namespace (see
+              # clusters/_template/bootstrap-kit/56-bp-openova-flow-server.yaml
+              # `spec.targetNamespace: catalyst-system`). The previous
+              # value `.catalyst.svc.cluster.local` failed DNS resolution
+              # (TBD-A56 / #1948, t34 T3 walk 2026-05-19) because that
+              # Service does not exist in the `catalyst` namespace.
+              value: "http://openova-flow-server.catalyst-system.svc.cluster.local"
             # CATALYST_BUILD_SHA / CATALYST_CHART_VERSION — qa-loop iter-3
             # Fix #18 (TC-261). The /api/v1/version handler resolves these
             # env vars first (envOrTrim) before falling back to the ldflag


### PR DESCRIPTION
## Summary

The catalyst-api Deployment hardcodes `OPENOVA_FLOW_SERVER_URL` as `http://openova-flow-server.catalyst.svc.cluster.local`, but the Service is installed by bootstrap-kit slot 56 (`56-bp-openova-flow-server.yaml`) with `spec.targetNamespace: catalyst-system`. In-cluster DNS resolution of the `.catalyst.svc.cluster.local` hostname therefore failed on every mothership + Sovereign — `/api/v1/flows/{id}/snapshot|stream|events` returned 502 and the Sovereign Console Flow canvas stayed empty.

Discovered on t34 T3 walk by agent a9e0547e (TBD-A56).

## Fix

- `products/catalyst/chart/templates/api-deployment.yaml` — env value `.catalyst.svc.cluster.local` → `.catalyst-system.svc.cluster.local`
- `products/catalyst/bootstrap/api/internal/handler/handler.go` — stale comment aligned (no behavior change; the Go default constant `defaultFlowServerURL` in `openova_flow_proxy.go:94` already used the correct namespace)
- `products/catalyst/chart/Chart.yaml` — version 1.4.198 → 1.4.199
- `clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml` — chart pin bumped to 1.4.199

This is option (B) from the audit — surgical client-side update with the smallest blast radius. The 57-bp-openova-flow-emitter overlay's `flowServerUrl` already uses `.catalyst-system` so it stays consistent.

## Test plan

- [x] `helm template products/catalyst/chart` parses; rendered env emits `http://openova-flow-server.catalyst-system.svc.cluster.local`
- [x] `go build ./...` in `products/catalyst/bootstrap/api` passes
- [x] `git grep 'openova-flow-server\.catalyst\.'` returns only the descriptive comment in `Chart.yaml` documenting the previous bug — zero live references remain
- [ ] CI green
- [ ] Next fresh-prov walk: Flow canvas no longer empty, /api/v1/flows/{id}/snapshot returns 200

Refs #1948