### PR TITLE
fix(infra): fail-fast on missing Hetzner public IP + post-install ExternalIP assertion (Refs #1941, A2 invariant)

### DIFF
--- a/infra/hetzner/cloudinit-control-plane.tftpl
+++ b/infra/hetzner/cloudinit-control-plane.tftpl
@@ -1594,11 +1594,105 @@ runcmd:
   # packet flow over Cilium WireGuard which requires non-overlapping
   # CIDRs end-to-end. Values are interpolated by OpenTofu from
   # local.region_cluster_cidr / local.region_service_cidr in main.tf.
-  - 'CP_PUBLIC_IPV4=$(curl -fsSL --retry 30 --retry-delay 2 http://169.254.169.254/hetzner/v1/metadata/public-ipv4) && curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION=${k3s_version} K3S_TOKEN=${k3s_token} INSTALL_K3S_EXEC="server --cluster-init --flannel-backend=none --disable-network-policy --disable=traefik --disable=servicelb --cluster-cidr=${cluster_cidr} --service-cidr=${service_cidr} --node-ip=${cp_private_ip} --node-external-ip=$${CP_PUBLIC_IPV4} --advertise-address=${cp_private_ip} --kubelet-arg=max-pods=220 --tls-san=${sovereign_fqdn} --tls-san=${cp_private_ip} --tls-san=$${CP_PUBLIC_IPV4} --kube-apiserver-arg=oidc-issuer-url=https://auth.${sovereign_fqdn}/realms/sovereign --kube-apiserver-arg=oidc-client-id=kubectl --kube-apiserver-arg=oidc-username-claim=preferred_username --kube-apiserver-arg=oidc-username-prefix=oidc: --kube-apiserver-arg=oidc-groups-claim=groups --kube-apiserver-arg=oidc-groups-prefix=oidc: --node-label catalyst.openova.io/role=control-plane --node-label openova.io/region=${region_canonical_label} --disable-cloud-controller ${worker_count > 0 ? "--node-taint node-role.kubernetes.io/control-plane=true:NoSchedule " : ""}--write-kubeconfig-mode=0644" sh -'
+  # ── Layer 1 (TBD-A50 / #1941): fail-fast on empty Hetzner public IP ─────
+  #
+  # The previous one-liner combined the metadata curl AND the k3s install
+  # in a single `&&` chain, with two silent-failure modes:
+  #
+  #   (a) `curl` exits 0 even when the metadata endpoint returns an EMPTY
+  #       body (HTTP 200, zero bytes — observed on t34, 2026-05-19). The
+  #       chain then runs `--node-external-ip=` (empty value) and k3s
+  #       happily installs without any ExternalIP on the Node object →
+  #       Cilium tunnel endpoint stays at the locally-scoped 10.0.1.2 →
+  #       inter-region pod traffic blackholes (DoD A2 invariant VIOLATED).
+  #   (b) PR #1715 added `--node-external-ip` but did not guard against
+  #       this empty-body case, so the fix landed in template but never
+  #       took effect on t34 (chart 1.4.198) — Issue #1941.
+  #
+  # Fix: split metadata fetch into its own runcmd item, validate the
+  # response is non-empty, persist to /etc/openova/cp-public-ipv4 so the
+  # next runcmd item (install) can read it without re-curl'ing. Exit 87
+  # if empty so cloud-init.log surfaces the root cause instead of silent
+  # ClusterMesh blackhole hours later.
+  - |
+    mkdir -p /etc/openova
+    CP_PUBLIC_IPV4=$(curl -fsSL --retry 30 --retry-delay 2 http://169.254.169.254/hetzner/v1/metadata/public-ipv4 || true)
+    if [ -z "$${CP_PUBLIC_IPV4}" ]; then
+      echo "[k3s-install] FATAL: Hetzner metadata public-ipv4 returned EMPTY — refusing to install k3s without ExternalIP" >&2
+      echo "[k3s-install]   DoD A2 invariant: inter-region link MUST run over PUBLIC IPs. Without ExternalIP the node enrolls with InternalIP=${cp_private_ip} only, Cilium tunnel endpoint blackholes cross-region traffic (Issue #1941 / TBD-A50)." >&2
+      echo "[k3s-install]   Diagnostics:" >&2
+      curl -v --max-time 5 http://169.254.169.254/hetzner/v1/metadata/public-ipv4 >&2 2>&1 || true
+      exit 87
+    fi
+    printf '%s' "$${CP_PUBLIC_IPV4}" > /etc/openova/cp-public-ipv4
+    chmod 0644 /etc/openova/cp-public-ipv4
+    echo "[k3s-install] CP_PUBLIC_IPV4=$${CP_PUBLIC_IPV4} persisted to /etc/openova/cp-public-ipv4"
+
+  - 'CP_PUBLIC_IPV4=$(cat /etc/openova/cp-public-ipv4) && [ -n "$${CP_PUBLIC_IPV4}" ] && curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION=${k3s_version} K3S_TOKEN=${k3s_token} INSTALL_K3S_EXEC="server --cluster-init --flannel-backend=none --disable-network-policy --disable=traefik --disable=servicelb --cluster-cidr=${cluster_cidr} --service-cidr=${service_cidr} --node-ip=${cp_private_ip} --node-external-ip=$${CP_PUBLIC_IPV4} --advertise-address=${cp_private_ip} --kubelet-arg=max-pods=220 --tls-san=${sovereign_fqdn} --tls-san=${cp_private_ip} --tls-san=$${CP_PUBLIC_IPV4} --kube-apiserver-arg=oidc-issuer-url=https://auth.${sovereign_fqdn}/realms/sovereign --kube-apiserver-arg=oidc-client-id=kubectl --kube-apiserver-arg=oidc-username-claim=preferred_username --kube-apiserver-arg=oidc-username-prefix=oidc: --kube-apiserver-arg=oidc-groups-claim=groups --kube-apiserver-arg=oidc-groups-prefix=oidc: --node-label catalyst.openova.io/role=control-plane --node-label openova.io/region=${region_canonical_label} --disable-cloud-controller ${worker_count > 0 ? "--node-taint node-role.kubernetes.io/control-plane=true:NoSchedule " : ""}--write-kubeconfig-mode=0644" sh -'
 
   # Wait for the API server to be reachable. Cilium needs to come up before
   # nodes Ready, so we wait specifically for the API endpoint.
   - 'until kubectl --kubeconfig=/etc/rancher/k3s/k3s.yaml get --raw /healthz; do sleep 5; done'
+
+  # ── Layer 2 (TBD-A50 / #1941): post-install ExternalIP assertion ────────
+  #
+  # Belt-and-braces verification that the Node object actually carries an
+  # ExternalIP after k3s install. Even with Layer 1's fail-fast, an edge
+  # case can leave the Node ExternalIP empty:
+  #   - k3s service crashed/restarted mid-install before the flag took
+  #     effect, OR
+  #   - the install ran with an older binary that ignored --node-external-ip
+  # Without ExternalIP on the Node object, Cilium picks the InternalIP
+  # (10.0.1.2) as its tunnel endpoint → cross-region pod traffic blackholes
+  # (DoD A2 invariant). Issue #1941 root-cause guard.
+  #
+  # Strategy: poll node.status.addresses[ExternalIP] up to 60s; if empty,
+  # restart k3s ONCE (with the same install args still on disk under
+  # /etc/systemd/system/k3s.service) and recheck for another 60s. If
+  # STILL empty after restart, exit 88 so cloud-init.log surfaces it.
+  # The Hetzner public IP we already validated in Layer 1 is on disk at
+  # /etc/openova/cp-public-ipv4 — we log it for cross-reference.
+  - |
+    NODE_NAME=$(hostname)
+    EXPECTED_PUBLIC_IP=$(cat /etc/openova/cp-public-ipv4 2>/dev/null || echo "")
+    KCFG=/etc/rancher/k3s/k3s.yaml
+    get_ext_ip() {
+      kubectl --kubeconfig=$${KCFG} get node "$${NODE_NAME}" \
+        -o jsonpath='{.status.addresses[?(@.type=="ExternalIP")].address}' 2>/dev/null || true
+    }
+    EXT_IP=""
+    for i in $(seq 1 30); do
+      EXT_IP=$(get_ext_ip)
+      if [ -n "$${EXT_IP}" ]; then
+        echo "[external-ip-assert] OK iter=$${i} node=$${NODE_NAME} ExternalIP=$${EXT_IP} (expected $${EXPECTED_PUBLIC_IP})"
+        break
+      fi
+      sleep 2
+    done
+    if [ -z "$${EXT_IP}" ]; then
+      echo "[external-ip-assert] WARN: node $${NODE_NAME} has empty ExternalIP after 60s; restarting k3s once and re-checking" >&2
+      kubectl --kubeconfig=$${KCFG} get node "$${NODE_NAME}" -o yaml >&2 2>&1 || true
+      systemctl restart k3s || true
+      for i in $(seq 1 60); do
+        if kubectl --kubeconfig=$${KCFG} get --raw /healthz >/dev/null 2>&1; then
+          break
+        fi
+        sleep 2
+      done
+      for i in $(seq 1 30); do
+        EXT_IP=$(get_ext_ip)
+        if [ -n "$${EXT_IP}" ]; then
+          echo "[external-ip-assert] RECOVERED iter=$${i} ExternalIP=$${EXT_IP} after k3s restart"
+          break
+        fi
+        sleep 2
+      done
+    fi
+    if [ -z "$${EXT_IP}" ]; then
+      echo "[external-ip-assert] FATAL: node $${NODE_NAME} still has empty ExternalIP after restart — DoD A2 invariant VIOLATED, cross-region ClusterMesh would blackhole. See Issue #1941 / TBD-A50." >&2
+      kubectl --kubeconfig=$${KCFG} get node "$${NODE_NAME}" -o yaml >&2 2>&1 || true
+      exit 88
+    fi
 
   # ── Patch node providerID — DoD A3/D10/D11/D12 unblocker (2026-05-16) ───
   #

--- a/infra/hetzner/main.tf
+++ b/infra/hetzner/main.tf
@@ -867,19 +867,19 @@ locals {
     # off here — secondary regions flip RTZ on. The bp-dmz-vcluster slot
     # 54 chart-side default already enables DMZ everywhere, so no flag
     # for DMZ here. See clusters/_template/bootstrap-kit/54,58,59-*.yaml.
-    mgmt_vcluster_enabled          = "true"
-    rtz_vcluster_enabled           = "false"
-    ha_enabled                     = var.ha_enabled
-    worker_count                   = var.worker_count
-    k3s_version                    = var.k3s_version
-    k3s_token                      = local.k3s_token
-    gitops_repo_url                = var.gitops_repo_url
-    gitops_branch                  = var.gitops_branch
-    enable_unattended_upgrades     = var.enable_unattended_upgrades
-    enable_fail2ban                = var.enable_fail2ban
-    ghcr_pull_username             = local.ghcr_pull_username
-    ghcr_pull_token                = var.ghcr_pull_token
-    ghcr_pull_auth_b64             = local.ghcr_pull_auth_b64
+    mgmt_vcluster_enabled      = "true"
+    rtz_vcluster_enabled       = "false"
+    ha_enabled                 = var.ha_enabled
+    worker_count               = var.worker_count
+    k3s_version                = var.k3s_version
+    k3s_token                  = local.k3s_token
+    gitops_repo_url            = var.gitops_repo_url
+    gitops_branch              = var.gitops_branch
+    enable_unattended_upgrades = var.enable_unattended_upgrades
+    enable_fail2ban            = var.enable_fail2ban
+    ghcr_pull_username         = local.ghcr_pull_username
+    ghcr_pull_token            = var.ghcr_pull_token
+    ghcr_pull_auth_b64         = local.ghcr_pull_auth_b64
 
     # Object Storage credentials — interpolated into the Sovereign's
     # `object-storage` K8s Secret at cloud-init time so Harbor (#383)
@@ -1417,38 +1417,38 @@ locals {
       # Per-role vCluster enable flags (DoD A4). Secondary region
       # renders DMZ+RTZ vCluster → rtz_vcluster_enabled=true. MGMT
       # stays off on secondaries (single MGMT vCluster on primary).
-      mgmt_vcluster_enabled          = "false"
-      rtz_vcluster_enabled           = "true"
-      ha_enabled                     = false # secondary regions land single-CP in slice G1; G3 introduces per-region HA
-      worker_count                   = r.workerCount
-      k3s_version                    = var.k3s_version
-      k3s_token                      = local.k3s_token
-      gitops_repo_url                = var.gitops_repo_url
-      gitops_branch                  = var.gitops_branch
-      enable_unattended_upgrades     = var.enable_unattended_upgrades
-      enable_fail2ban                = var.enable_fail2ban
-      ghcr_pull_username             = local.ghcr_pull_username
-      ghcr_pull_token                = var.ghcr_pull_token
-      ghcr_pull_auth_b64             = local.ghcr_pull_auth_b64
-      object_storage_endpoint        = local.object_storage_endpoint
-      object_storage_region          = var.object_storage_region
-      object_storage_bucket_name     = var.object_storage_bucket_name
-      object_storage_access_key      = var.object_storage_access_key
-      object_storage_secret_key      = var.object_storage_secret_key
-      hcloud_token                   = var.hcloud_token
-      dynadot_key                    = var.dynadot_key
-      dynadot_secret                 = var.dynadot_secret
-      dynadot_managed_domains        = coalesce(var.dynadot_managed_domains, join(".", slice(split(".", var.sovereign_fqdn), 1, length(split(".", var.sovereign_fqdn)))))
-      harbor_robot_token             = var.harbor_robot_token
-      powerdns_api_key               = var.powerdns_api_key
-      pdm_basic_auth_user            = var.pdm_basic_auth_user
-      pdm_basic_auth_pass            = var.pdm_basic_auth_pass
-      deployment_id                  = var.deployment_id
-      kubeconfig_bearer_token        = var.kubeconfig_bearer_token
-      catalyst_api_url               = var.catalyst_api_url
-      handover_jwt_public_key        = var.handover_jwt_public_key
-      load_balancer_ipv4             = hcloud_load_balancer.secondary[k].ipv4
-      worker_cloud_init_b64          = base64encode(local.secondary_region_worker_cloud_init[k])
+      mgmt_vcluster_enabled      = "false"
+      rtz_vcluster_enabled       = "true"
+      ha_enabled                 = false # secondary regions land single-CP in slice G1; G3 introduces per-region HA
+      worker_count               = r.workerCount
+      k3s_version                = var.k3s_version
+      k3s_token                  = local.k3s_token
+      gitops_repo_url            = var.gitops_repo_url
+      gitops_branch              = var.gitops_branch
+      enable_unattended_upgrades = var.enable_unattended_upgrades
+      enable_fail2ban            = var.enable_fail2ban
+      ghcr_pull_username         = local.ghcr_pull_username
+      ghcr_pull_token            = var.ghcr_pull_token
+      ghcr_pull_auth_b64         = local.ghcr_pull_auth_b64
+      object_storage_endpoint    = local.object_storage_endpoint
+      object_storage_region      = var.object_storage_region
+      object_storage_bucket_name = var.object_storage_bucket_name
+      object_storage_access_key  = var.object_storage_access_key
+      object_storage_secret_key  = var.object_storage_secret_key
+      hcloud_token               = var.hcloud_token
+      dynadot_key                = var.dynadot_key
+      dynadot_secret             = var.dynadot_secret
+      dynadot_managed_domains    = coalesce(var.dynadot_managed_domains, join(".", slice(split(".", var.sovereign_fqdn), 1, length(split(".", var.sovereign_fqdn)))))
+      harbor_robot_token         = var.harbor_robot_token
+      powerdns_api_key           = var.powerdns_api_key
+      pdm_basic_auth_user        = var.pdm_basic_auth_user
+      pdm_basic_auth_pass        = var.pdm_basic_auth_pass
+      deployment_id              = var.deployment_id
+      kubeconfig_bearer_token    = var.kubeconfig_bearer_token
+      catalyst_api_url           = var.catalyst_api_url
+      handover_jwt_public_key    = var.handover_jwt_public_key
+      load_balancer_ipv4         = hcloud_load_balancer.secondary[k].ipv4
+      worker_cloud_init_b64      = base64encode(local.secondary_region_worker_cloud_init[k])
 
       # Issue #1778 (F7 multi-region completion) — same hcloud_*_name
       # threading as the primary CP templatefile call so the secondary


### PR DESCRIPTION
## Summary

PR #1715 added `--node-external-ip=\$CP_PUBLIC_IPV4` to the k3s server install line, but the metadata curl was chained with `&&` to the install command in a single shell. If Hetzner metadata returns **HTTP 200 with EMPTY body** (observed live on t34 chart 1.4.198, 2026-05-19), `curl -fsSL` exits 0, `CP_PUBLIC_IPV4=""`, and the chain proceeds to install k3s with `--node-external-ip=` (empty). k3s happily enrolls the node with `InternalIP=10.0.1.2` and **no** `ExternalIP` → Cilium picks the locally-scoped private IP as its tunnel endpoint → every cross-region VXLAN tunnel resolves to `10.0.1.2` on the peer side → **inter-region pod traffic blackholes**.

DoD A2 invariant ("inter-region link = DMZ WireGuard over PUBLIC IPs ALWAYS") **VIOLATED**. Blocks D31 (CNPG hot-standby), G5 (Hubble inter-region), all multi-region pod-to-pod. Issue #1941 / TBD-A50.

## What this PR adds

### Layer 1 — fail-fast guard in cloud-init

- Split the metadata curl into its own `runcmd` item with `|| true` so the script can inspect the result without aborting.
- Validate the returned value is non-empty; if empty, dump `curl -v` diagnostics and `exit 87` — `cloud-init.log` surfaces the FATAL immediately instead of a silent ClusterMesh blackhole hours later.
- Persist the validated IP to `/etc/openova/cp-public-ipv4` so the next `runcmd` item (the k3s install) and downstream items can read it without re-curl'ing.

### Layer 2 — post-install ExternalIP assertion

- After `until kubectl get --raw /healthz`, poll `node.status.addresses[type=ExternalIP]` for 60s.
- If empty, restart k3s ONCE (the systemd unit on disk already carries `--node-external-ip` from the install line) and recheck for another 60s.
- If still empty after restart, `exit 88` with the full node YAML in stderr — `cloud-init.log` surfaces the regression and the operator knows D11 / D31 / G5 will fail BEFORE any application workload tries to schedule.

### Layer 3 (deferred)

An idempotent periodic reconciler that re-asserts ExternalIP post-boot is filed as a separate follow-up — bigger scope (needs a systemd timer + image roll), not blocking #1941 closure.

## Validation

- `tofu validate` against `infra/hetzner/` → "Success! The configuration is valid." (OpenTofu v1.8.5)
- Inline bash tests for both paths:
  - mock curl returns empty body + exit 0 → script exits 87 (verified)
  - mock curl returns `49.13.123.45` + exit 0 → script persists IP and continues (verified)
- Rendered cloud-init size (after comment-strip in `main.tf:997`) = **25 443 bytes**, well under the 30 720 B guardrail at `main.tf:1037` (Hetzner hard cap 32 768).

## Test plan

- [ ] Fresh 3-region Sovereign provision (omantel.biz / omani.works) on chart 1.4.199+
- [ ] On each region's CP: `kubectl get nodes -o wide` shows both `INTERNAL-IP` AND `EXTERNAL-IP` populated
- [ ] On each region's CP: `kubectl get ciliumnodes -o yaml | grep -A1 addresses` lists both IP types
- [ ] DoD D11 — inter-region pod-to-pod ping passes 6/6
- [ ] DoD D31 — CNPG hot-standby replication catches up across regions

## Hard rule

DO NOT close #1941 with this merge. Closure requires the fresh 3-region prov walk + cross-region pod-to-pod ping. This PR ships the cloud-init guards; the convergence walk validates end-to-end.

Refs #1941