### PR TITLE
fix(ci): Playwright cosmetic + step-flow guards — skip 19 tests drifted from current product (Refs #1952)

### DIFF
--- a/products/catalyst/bootstrap/ui/e2e/cosmetic-guards.spec.ts
+++ b/products/catalyst/bootstrap/ui/e2e/cosmetic-guards.spec.ts
@@ -252,7 +252,11 @@ test.describe('@cosmetic-guard StepComponents card geometry', () => {
     await page.goto('wizard')
   })
 
-  test('card resting height matches canonical 108px (NOT 130px)', async ({ page }) => {
+  // SKIPPED — Refs #1952. Wizard reorder shipped Marketplace step at id=5;
+  // StepComponents now lives at id=4. The beforeEach seeds currentStep:5
+  // → lands on StepMarketplace which has no [data-testid^="component-card-"].
+  // Re-author against new step index in follow-up PR.
+  test.skip('card resting height matches canonical 108px (NOT 130px) [Refs #1952]', async ({ page }) => {
     const firstCard = page.locator('[data-testid^="component-card-"]').first()
     await expect(
       firstCard,
@@ -271,7 +275,8 @@ test.describe('@cosmetic-guard StepComponents card geometry', () => {
     ).toBe(108)
   })
 
-  test('card body description spans full width (NO reserved right padding)', async ({ page }) => {
+  // SKIPPED — Refs #1952. Same wizard step reorder as above.
+  test.skip('card body description spans full width (NO reserved right padding) [Refs #1952]', async ({ page }) => {
     const card = page.locator('[data-testid^="component-card-"]').first()
     await expect(card).toBeVisible({ timeout: 10_000 })
 
@@ -306,7 +311,8 @@ test.describe('@cosmetic-guard StepComponents card geometry', () => {
     ).toBeGreaterThanOrEqual(bodyBox!.width - 4)
   })
 
-  test('logo tiles use canonical brand surface (NOT default white)', async ({ page }) => {
+  // SKIPPED — Refs #1952. Same wizard step reorder as above; lands on StepMarketplace.
+  test.skip('logo tiles use canonical brand surface (NOT default white) [Refs #1952]', async ({ page }) => {
     // The default StepComponents tab is the non-mandatory "choose"
     // pool; mandatory components (cilium, cert-manager) live on Tab 2
     // (data-testid="tab-always") at the moment this test was written.
@@ -378,7 +384,8 @@ test.describe('@cosmetic-guard StepComponents card geometry', () => {
     ).toEqual([])
   })
 
-  test('Temporal + FerretDB logo glyphs are visible in dark + light themes', async ({ page }) => {
+  // SKIPPED — Refs #1952. Same wizard step reorder as above.
+  test.skip('Temporal + FerretDB logo glyphs are visible in dark + light themes [Refs #1952]', async ({ page }) => {
     // Reference luminances are derived analytically from each brand
     // surface hex, treating an "invisible glyph" as a tile that is
     // a flat block of that hex:
@@ -429,7 +436,10 @@ test.describe('@cosmetic-guard StepComponents card geometry', () => {
  * ────────────────────────────────────────────────────────────────── */
 
 test.describe('@cosmetic-guard wizard step flow', () => {
-  test('step order is Org -> Topology -> Provider -> Credentials -> Components -> Domain -> Review', async ({
+  // SKIPPED — Refs #1952. WIZARD_STEPS now has 8 steps (Marketplace inserted at id=5,
+  // Credentials moved from id=4 to id=7). Test assertion list (7 steps) is stale.
+  // Follow-up PR will re-author CANONICAL_STEP_LABELS to match new canonical order.
+  test.skip('step order is Org -> Topology -> Provider -> Credentials -> Components -> Domain -> Review [Refs #1952]', async ({
     browser,
   }) => {
     // Use a fresh browser context per iteration so the
@@ -487,7 +497,9 @@ test.describe('@cosmetic-guard wizard step flow', () => {
     ).toBe(0)
   })
 
-  test('operator cannot reach Domain before Components', async ({ page }) => {
+  // SKIPPED — Refs #1952. Same wizard reorder; wizard-step-5 is now Marketplace,
+  // wizard-step-6 is Domain (Domain is still after Components, which is now step 4).
+  test.skip('operator cannot reach Domain before Components [Refs #1952]', async ({ page }) => {
     await seedWizardStore(page, { currentStep: 1 })
     await page.goto('wizard')
 
@@ -682,7 +694,11 @@ test.describe('@cosmetic-guard provision page', () => {
  * ────────────────────────────────────────────────────────────────── */
 
 test.describe('@cosmetic-guard admin sidebar parity', () => {
-  test('Sovereign admin sidebar is w-56 and mirrors core/console nav labels', async ({ page }) => {
+  // SKIPPED — Refs #1952. Current Sovereign nav labels are
+  // Apps/Jobs/Dashboard/Cloud/Users/Settings, not the
+  // Dashboard/Apps/Jobs/Domains/Billing/Team/Settings the test asserts.
+  // Follow-up PR will re-author CANONICAL_SIDEBAR_LABELS.
+  test.skip('Sovereign admin sidebar is w-56 and mirrors core/console nav labels [Refs #1952]', async ({ page }) => {
     await page.goto('provision/test-deployment-id')
     await page.waitForLoadState('domcontentloaded')
 
@@ -719,7 +735,9 @@ test.describe('@cosmetic-guard admin sidebar parity', () => {
  * ────────────────────────────────────────────────────────────────── */
 
 test.describe('@cosmetic-guard app-detail layout', () => {
-  test('AppDetail renders the canonical sections (Jobs is now also a tab — issue #204)', async ({ page }) => {
+  // SKIPPED — Refs #1952. AppDetail layout was overhauled and no longer
+  // exposes the canonical section testids the test reads.
+  test.skip('AppDetail renders the canonical sections (Jobs is now also a tab — issue #204) [Refs #1952]', async ({ page }) => {
     await page.goto('provision/test-deployment-id/app/temporal')
     await page.waitForLoadState('domcontentloaded')
 
@@ -793,7 +811,8 @@ test.describe('@cosmetic-guard jobs surface (issue #204 — table view)', () => 
     ).toBe(0)
   })
 
-  test('2. table headers are name / app / deps / batch / status / started / duration', async ({ page }) => {
+  // SKIPPED — Refs #1952. JobsTable column set / data-testids changed.
+  test.skip('2. table headers are name / app / deps / batch / status / started / duration [Refs #1952]', async ({ page }) => {
     await page.goto('provision/test-deployment-id/jobs')
     await page.waitForLoadState('domcontentloaded')
 
@@ -843,7 +862,8 @@ test.describe('@cosmetic-guard jobs surface (issue #204 — table view)', () => 
     ).toBeGreaterThan(0)
   })
 
-  test('4. AppDetail page has a tab labelled "Jobs"', async ({ page }) => {
+  // SKIPPED — Refs #1952. AppDetail layout overhauled; Jobs tab selector changed.
+  test.skip('4. AppDetail page has a tab labelled "Jobs" [Refs #1952]', async ({ page }) => {
     await page.goto('provision/test-deployment-id/app/temporal')
     await page.waitForLoadState('domcontentloaded')
 
@@ -882,7 +902,8 @@ test.describe('@cosmetic-guard jobs surface (issue #204 — table view)', () => 
    * in test 5 below.
    * ──────────────────────────────────────────────────────────────── */
 
-  test('5. JobsPage has NO tab strip and exposes a "Show as Flow" button', async ({ page }) => {
+  // SKIPPED — Refs #1952. JobsPage layout / "Show as Flow" affordance changed.
+  test.skip('5. JobsPage has NO tab strip and exposes a "Show as Flow" button [Refs #1952]', async ({ page }) => {
     await page.goto('provision/test-deployment-id/jobs')
     await page.waitForLoadState('domcontentloaded')
 
@@ -916,7 +937,8 @@ test.describe('@cosmetic-guard jobs surface (issue #204 — table view)', () => 
     ).toBe(true)
   })
 
-  test('6. /flow?scope=all renders the canvas SVG with at least one batch + bubble', async ({ page }) => {
+  // SKIPPED — Refs #1952. /flow canvas selectors changed.
+  test.skip('6. /flow?scope=all renders the canvas SVG with at least one batch + bubble [Refs #1952]', async ({ page }) => {
     await page.goto('provision/test-deployment-id/flow?scope=all')
     await page.waitForLoadState('domcontentloaded')
 
@@ -941,7 +963,8 @@ test.describe('@cosmetic-guard jobs surface (issue #204 — table view)', () => 
     ).toBeGreaterThan(0)
   })
 
-  test('7. single-click on a job bubble opens the FloatingLogPane (25vw)', async ({ page }) => {
+  // SKIPPED — Refs #1952. FloatingLogPane affordance / selectors changed.
+  test.skip('7. single-click on a job bubble opens the FloatingLogPane (25vw) [Refs #1952]', async ({ page }) => {
     await page.goto('provision/test-deployment-id/flow?scope=all')
     await page.waitForLoadState('domcontentloaded')
 
@@ -964,7 +987,8 @@ test.describe('@cosmetic-guard jobs surface (issue #204 — table view)', () => 
     ).toBe('25vw')
   })
 
-  test('8. StatusStrip mode toggle (Jobs ↔ Batches) updates URL ?view=', async ({ page }) => {
+  // SKIPPED — Refs #1952. StatusStrip toggle / URL contract changed.
+  test.skip('8. StatusStrip mode toggle (Jobs ↔ Batches) updates URL ?view= [Refs #1952]', async ({ page }) => {
     await page.goto('provision/test-deployment-id/flow?scope=all')
     await page.waitForLoadState('domcontentloaded')
 
@@ -990,7 +1014,8 @@ test.describe('@cosmetic-guard jobs surface (issue #204 — table view)', () => 
 })
 
 test.describe('@cosmetic-guard JobDetail v3 (Flow + Exec Log only)', () => {
-  test('JobDetail tab strip has EXACTLY 2 tabs: Flow + Exec Log', async ({ page }) => {
+  // SKIPPED — Refs #1952. JobDetail v3 tab strip overhaul.
+  test.skip('JobDetail tab strip has EXACTLY 2 tabs: Flow + Exec Log [Refs #1952]', async ({ page }) => {
     // Pick a known job id from the default catalog. bp-cilium is in
     // the bootstrap-kit batch; its detail page must mount with the
     // v3 two-tab layout regardless of any live SSE replay.
@@ -1027,7 +1052,8 @@ test.describe('@cosmetic-guard JobDetail v3 (Flow + Exec Log only)', () => {
 })
 
 test.describe('@cosmetic-guard JobsTable batch chip → /flow link', () => {
-  test('batch chip in a JobsTable row is an <a> linking to /flow?scope=batch:<id>', async ({ page }) => {
+  // SKIPPED — Refs #1952. JobsTable batch chip → /flow link contract changed.
+  test.skip('batch chip in a JobsTable row is an <a> linking to /flow?scope=batch:<id> [Refs #1952]', async ({ page }) => {
     await page.goto('provision/test-deployment-id/jobs')
     await page.waitForLoadState('domcontentloaded')
 
@@ -1180,7 +1206,8 @@ test.describe('@cosmetic-guard StepComponents card description', () => {
     await page.goto('wizard')
   })
 
-  test('every component card has min-h:108px and 2-line description', async ({ page }) => {
+  // SKIPPED — Refs #1952. Same wizard step reorder; seeds StepMarketplace, not StepComponents.
+  test.skip('every component card has min-h:108px and 2-line description [Refs #1952]', async ({ page }) => {
     const cards = page.locator('[data-testid^="component-card-"]')
     await expect(cards.first()).toBeVisible({ timeout: 10_000 })
     const n = await cards.count()
@@ -1286,7 +1313,11 @@ test.describe('@cosmetic-guard StepComponents card description', () => {
  * ────────────────────────────────────────────────────────────────── */
 
 test.describe('@cosmetic-guard cloud section', () => {
-  test('Bare /cloud redirects to /cloud/architecture', async ({ page }) => {
+  // SKIPPED — Refs #1952. Cloud routing was consolidated to a single
+  // /cloud?view=graph|list&kind=… surface (see LEGACY_CLOUD_REDIRECTS in
+  // src/app/router.tsx). The old per-path /cloud/architecture etc. no
+  // longer exist. Follow-up PR will re-author against the ?view= shape.
+  test.skip('Bare /cloud redirects to /cloud/architecture [Refs #1952]', async ({ page }) => {
     await page.goto('provision/test-deployment-id/cloud')
     await page.waitForLoadState('domcontentloaded')
 
@@ -1302,7 +1333,8 @@ test.describe('@cosmetic-guard cloud section', () => {
     ).toBe(true)
   })
 
-  test('Legacy /infrastructure/* paths redirect to /cloud/* equivalents', async ({ page }) => {
+  // SKIPPED — Refs #1952. Same cloud routing consolidation as above.
+  test.skip('Legacy /infrastructure/* paths redirect to /cloud/* equivalents [Refs #1952]', async ({ page }) => {
     const cases: Array<{ from: string; to: string }> = [
       { from: 'provision/test-deployment-id/infrastructure', to: '/cloud/architecture' },
       { from: 'provision/test-deployment-id/infrastructure/topology', to: '/cloud/architecture' },


### PR DESCRIPTION
## Failure message (verbatim from CI)

```
✘   1 [chromium] › e2e/cosmetic-guards.spec.ts:255:3 › @cosmetic-guard StepComponents card geometry › card resting height matches canonical 108px (NOT 130px)
    Error: StepComponents card grid renders at least one component card
    expect(locator).toBeVisible() failed
    Error: element(s) not found
```

+ 18 more in the same run.
Full failed run: https://github.com/openova-io/openova/actions/runs/26101491390/job/76753430738 (19 of 31 tests failed; 12 passed).

The workflow has been failing on every push to `main` since 2026-05-18, blocking merge of PRs #1939 (treemap fix) and #1940 (SME demo route fix).

## Root cause

Test contract drift from product. 19 tests assert UI shapes that have been deliberately changed on `main`:

### 1. Wizard step reorder + Marketplace step added (8 steps now, not 7)

`src/app/layouts/WizardLayout.tsx`:
```ts
export const WIZARD_STEPS = [
  { id: 1, label: 'Organisation', ... },
  { id: 2, label: 'Topology',     ... },
  { id: 3, label: 'Provider',     ... },
  { id: 4, label: 'Components',   ... },  // was id=5
  { id: 5, label: 'Marketplace',  ... },  // NEW step
  { id: 6, label: 'Domain',       ... },
  { id: 7, label: 'Credentials',  ... },  // was id=4
  { id: 8, label: 'Review',       ... },
]
```

Test still has `CANONICAL_STEP_LABELS = ['Organisation', 'Topology', 'Provider', 'Credentials', 'Components', 'Domain', 'Review']` (7 entries, Credentials before Components). Tests that `seedWizardStore({ currentStep: 5 })` expecting StepComponents now land on StepMarketplace which has no `[data-testid^=\"component-card-\"]` — every card-geometry assertion fails.

### 2. Cloud routing consolidated to `?view=graph|list&kind=…`

`src/app/router.tsx` defines `LEGACY_CLOUD_REDIRECTS` that turn `/cloud/architecture`, `/cloud/compute/*`, `/cloud/network/*`, `/cloud/storage/*` and `/infrastructure/*` into the new query-string shape. Tests still assert the old pathname.

### 3. AppDetail / JobsPage / JobDetail / JobsTable / sidebar overhaul

The Jobs surface and AppDetail were rebuilt; selectors the test reads (tab labels, batch chips, FloatingLogPane, StatusStrip toggle) no longer exist on the current surface. Sovereign nav labels are now `Apps/Jobs/Dashboard/Cloud/Users/Settings`, not the `Dashboard/Apps/Jobs/Domains/Billing/Team/Settings` the test expects.

## Decision — skip-with-tracking

Per CLAUDE.md \"DON'T use test.skip unless filing a TBD-* issue tracking the real fix\", filed tracking issue **#1952** first. A surgical re-author of all 19 tests is too large for one PR (4 distinct contract families, deliberate product changes that need the wizard team's sign-off on the new canonical labels).

This PR:
- Keeps every test BODY intact (the contracts they describe survive in source)
- Marks each failing test with `test.skip(... [Refs #1952])` + a one-line root-cause comment
- Leaves 12 tests still LIVE and asserting

## What's still LIVE (12 tests)

- wizard step flow: \"Choose Your Stack\" / \"Always Included\" retired; CPX32 recommended tag; SKU catalog switch on provider change
- provision page: SPA route shape; no legacy DAG SVG markup
- jobs surface: `jobs-table` testid present + no legacy accordion; `jobs-search` filters rows
- admin page: no Phase 0 banners
- PortalShell theme toggle (2 tests)
- cloud section: flat Cloud sidebar entry; Per-Sovereign switcher in header

## Verification

The fix targets exactly the 19 tests that failed in run 26101491390. Each was confirmed against the live dev server (lands on StepMarketplace when seeded with `currentStep:5`; `/cloud` redirects to `?view=graph` not `/cloud/architecture`; etc.). CI on this PR will confirm the workflow goes GREEN.

## Hard rules followed

- READ-ONLY on cluster ✓
- No emrah.baysal email touched ✓
- No Secrets written ✓
- Branched from `origin/main`, validated against fresh clone ✓
- No `--no-verify`, no admin-merge ✓
- `test.skip` with `Refs #1952` tracking the real fix ✓
- `Refs #1952` (not `Closes`) — the tests are skipped not fixed ✓

Refs #1952