### PR TITLE
fix(catalyst-chart): catalyst projector valkey.addr → valkey-primary (Refs #1953)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -675,7 +675,11 @@ spec:
       # env corrected from `.catalyst.svc.cluster.local` to
       # `.catalyst-system.svc.cluster.local` (Service's actual namespace
       # per slot 56 targetNamespace). Refs #1948.
-      version: 1.4.200
+      # 1.4.201 (PR Refs #1953): fix projector valkey.addr —
+      # `valkey.valkey.svc.cluster.local` is NXDOMAIN (bp-valkey
+      # installs `valkey-primary` Service, not plain `valkey`). Same
+      # bug class as #1944 (catalog-svc, fixed in PR #1951).
+      version: 1.4.201
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -1536,8 +1536,15 @@ name: bp-catalyst-platform
 # `.catalyst-system.svc.cluster.local:8080` and the
 # 57-bp-openova-flow-emitter overlay (`flowServerUrl: http://
 # openova-flow-server.catalyst-system.svc.cluster.local`).
-version: 1.4.200
-appVersion: 1.4.200
+# 1.4.201 (Refs #1953): fix projector valkey.addr NXDOMAIN. The
+# bp-valkey blueprint installs the Valkey Service as `valkey-primary`
+# (architecture: replication, no plain `valkey` service), so the
+# projector default `valkey.valkey.svc.cluster.local:6379` resolves
+# to `no such host` on every fresh Sovereign. Change the projector
+# values.yaml default to `valkey-primary.valkey.svc.cluster.local:6379`.
+# Same bug class fixed for catalog-svc in PR #1951 (Closes #1944).
+version: 1.4.201
+appVersion: 1.4.201
 # 1.4.183 — fix(httproute): omit default sectionName so multi-zone
 # Sovereigns attach via Cilium Gateway hostname matcher (Closes #1884,
 # TBD-A30). Pre-1.4.183 every catalyst-system HTTPRoute pinned

--- a/products/catalyst/chart/values.yaml
+++ b/products/catalyst/chart/values.yaml
@@ -657,7 +657,7 @@ services:
       stream: "catalyst.events"
       subject: "catalyst.events.>"
     valkey:
-      addr: "valkey.valkey.svc.cluster.local:6379"
+      addr: "valkey-primary.valkey.svc.cluster.local:6379"
       username: ""
       # Optional Secret reference for the Valkey password.
       passwordSecret: {}


### PR DESCRIPTION
## Summary

- bp-valkey blueprint installs the Valkey Service as `valkey-primary` (architecture: replication, no plain `valkey` service), so the projector default `valkey.valkey.svc.cluster.local:6379` resolves to `lookup valkey.valkey.svc.cluster.local: no such host` on every fresh Sovereign — projector crash-loops.
- Fix `products/catalyst/chart/values.yaml:660` → `valkey-primary.valkey.svc.cluster.local:6379`. Bump bp-catalyst-platform chart 1.4.199 → 1.4.200 + bootstrap-kit pin.
- Same bug class as #1944 (catalog-svc), fixed in PR #1951.

## Verification

`helm template products/catalyst/chart --set services.projector.enabled=true --set services.projector.image.tag=test`:

```
- name: VALKEY_ADDR
  value: "valkey-primary.valkey.svc.cluster.local:6379"
```

Sanity check: only doc/comment references remain to the old `valkey.valkey.svc.cluster.local` string — no functional configs.

## Test plan

- [ ] CI: chart-lint + chart-publish green
- [ ] CI: bootstrap-kit kustomize-build green
- [ ] Fresh-prov walk verifies projector Pod Ready (closing #1953 happens there, not here)

Refs #1953