### PR TITLE
feat(api): /api/v1/sme/bss/overview handler (Refs #1949, D-BSS)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -685,7 +685,11 @@ spec:
       # strategy-flip-regression CI workflow on every PR that
       # touches `api-deployment.yaml`. Zero behavioural change at
       # runtime.
-      version: 1.4.202
+      # 1.4.203 (Refs #1949, TBD-A58, D-BSS): add
+      # /api/v1/sme/bss/overview handler so the BSS landing renders
+      # real zeros (full target-state surface) instead of the "API
+      # pending" pill caused by the pre-fix 404.
+      version: 1.4.203
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/bootstrap/api/cmd/api/main.go
+++ b/products/catalyst/bootstrap/api/cmd/api/main.go
@@ -1282,6 +1282,20 @@ func main() {
 		rg.Post("/api/v1/sme/tenants/{id}/reconcile", h.HandleReconcileSMETenant)
 		rg.Delete("/api/v1/sme/tenants/{id}", h.HandleDeleteSMETenant)
 
+		// BSS landing KPI rollup (Refs #1949, TBD-A58). Read-only feed
+		// for the /console/bss landing surface (BssLandingPage.tsx →
+		// getBssOverview() in ui/src/lib/bss.api.ts). Pre-fix the path
+		// returned 404 and the FE flipped `pendingApi=true`, so every
+		// tile rendered the "API pending" pill instead of real zeros.
+		// Today the handler returns a zero-filled payload — the FE
+		// renders the full target-state surface (0 revenue / 0
+		// customers — truthful on a fresh Sovereign) from first paint
+		// (INVIOLABLE-PRINCIPLES.md #1). The non-zero projection lands
+		// with the marketplace/billing wire (siblings:
+		// /api/v1/sme/billing/revenue, /api/v1/sme/orders,
+		// /api/v1/sme/billing/vouchers/list, /api/v1/sme/tenants).
+		rg.Get("/api/v1/sme/bss/overview", h.HandleGetSMEBssOverview)
+
 		// BSS Orders rollup (Wave 6 PR 3). Read-only feed for the
 		// /console/bss/orders native React table. Today the handler
 		// returns an empty list — the FE renders its full empty-state

--- a/products/catalyst/bootstrap/api/internal/handler/sme_bss_overview.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sme_bss_overview.go
@@ -1,0 +1,102 @@
+// Package handler — sme_bss_overview.go: read-only stub for the BSS
+// landing KPI rollup (Refs #1949, D-BSS / TBD-A58).
+//
+// Backs the /console/bss landing page (BssLandingPage.tsx) which calls
+// getBssOverview() in ui/src/lib/bss.api.ts. Pre-fix the wire path
+// /api/v1/sme/bss/overview returned 404 (no handler registered) and the
+// FE's try/catch flipped `pendingApi=true`, so every tile rendered the
+// honest-but-noisy "API pending" placeholder. After this PR the handler
+// returns 200 with a fully-shaped zero payload so the operator sees the
+// full target-state surface ("0 revenue / 0 customers" — the truthful
+// answer on a fresh Sovereign with no marketplace orders yet) instead
+// of the "API pending" pill (INVIOLABLE-PRINCIPLES.md #1 — first paint
+// is the full target surface).
+//
+// Wire contract (mirrors BssOverview in ui/src/lib/bss.api.ts:27-64):
+//
+//	{
+//	  "billing":  { "mrrCents": int64,        "deltaPct": float64|null },
+//	  "orders":   { "pending":  int,          "oldestDays": int|null  },
+//	  "vouchers": { "active":   int,          "redeemRate": float64|null },
+//	  "tenants":  { "active":   int,          "newThisWeek": int      },
+//	  "revenue":  { "last30dCents": int64,    "deltaPct": float64|null,
+//	                "sparkline": []int64 }
+//	}
+//
+// The FE only sets `pendingApi=true` when the HTTP call fails OR the
+// response body is not a JSON object — a zero-filled 200 returns
+// `pendingApi=false` and the tiles render real (zero) numbers.
+//
+// The real implementation will project per-tenant rollups from the
+// billing / marketplace / orders ledgers once those wires are plumbed
+// (siblings: sme_billing_revenue.go, sme_orders.go, sme_billing_vouchers.go,
+// sme_tenant.go). Until then zero is the truthful answer.
+package handler
+
+import (
+	"net/http"
+)
+
+// smeBssBillingKpi mirrors the FE BssOverview.billing shape.
+type smeBssBillingKpi struct {
+	MrrCents int64    `json:"mrrCents"`
+	DeltaPct *float64 `json:"deltaPct"`
+}
+
+// smeBssOrdersKpi mirrors the FE BssOverview.orders shape.
+type smeBssOrdersKpi struct {
+	Pending    int  `json:"pending"`
+	OldestDays *int `json:"oldestDays"`
+}
+
+// smeBssVouchersKpi mirrors the FE BssOverview.vouchers shape.
+type smeBssVouchersKpi struct {
+	Active     int      `json:"active"`
+	RedeemRate *float64 `json:"redeemRate"`
+}
+
+// smeBssTenantsKpi mirrors the FE BssOverview.tenants shape.
+type smeBssTenantsKpi struct {
+	Active      int `json:"active"`
+	NewThisWeek int `json:"newThisWeek"`
+}
+
+// smeBssRevenueKpi mirrors the FE BssOverview.revenue shape. Sparkline
+// is always a non-nil slice so the FE's Array.isArray guard passes;
+// empty is a valid signal (no revenue yet).
+type smeBssRevenueKpi struct {
+	Last30dCents int64    `json:"last30dCents"`
+	DeltaPct     *float64 `json:"deltaPct"`
+	Sparkline    []int64  `json:"sparkline"`
+}
+
+// smeBssOverviewResponse mirrors the FE BssOverview shape end-to-end.
+// `pendingApi` is intentionally NOT serialised by the BE — the FE
+// derives it from the HTTP status / parse outcome.
+type smeBssOverviewResponse struct {
+	Billing  smeBssBillingKpi  `json:"billing"`
+	Orders   smeBssOrdersKpi   `json:"orders"`
+	Vouchers smeBssVouchersKpi `json:"vouchers"`
+	Tenants  smeBssTenantsKpi  `json:"tenants"`
+	Revenue  smeBssRevenueKpi  `json:"revenue"`
+}
+
+// HandleGetSMEBssOverview — GET /api/v1/sme/bss/overview.
+//
+// Returns the zero-filled payload today. When the marketplace / billing
+// / orders wires are plumbed this handler will join the per-tenant
+// rollups and project the live KPIs; the FE renders the same shape
+// with no change required.
+func (h *Handler) HandleGetSMEBssOverview(w http.ResponseWriter, r *http.Request) {
+	writeJSON(w, http.StatusOK, smeBssOverviewResponse{
+		Billing:  smeBssBillingKpi{MrrCents: 0, DeltaPct: nil},
+		Orders:   smeBssOrdersKpi{Pending: 0, OldestDays: nil},
+		Vouchers: smeBssVouchersKpi{Active: 0, RedeemRate: nil},
+		Tenants:  smeBssTenantsKpi{Active: 0, NewThisWeek: 0},
+		Revenue: smeBssRevenueKpi{
+			Last30dCents: 0,
+			DeltaPct:     nil,
+			Sparkline:    []int64{},
+		},
+	})
+}

--- a/products/catalyst/bootstrap/api/internal/handler/sme_bss_overview_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/sme_bss_overview_test.go
@@ -1,0 +1,101 @@
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestHandleGetSMEBssOverview_Returns200WithFullShape pins the wire
+// shape — the FE getBssOverview() in ui/src/lib/bss.api.ts expects a
+// fully-shaped BssOverview object. A missing key would parse as 0 /
+// null on the FE side (the JS Number()/?? guards tolerate it), but the
+// contract test asserts the BE emits the full shape so the operator
+// sees real zeros rather than the "API pending" fallback (Refs #1949).
+func TestHandleGetSMEBssOverview_Returns200WithFullShape(t *testing.T) {
+	h := &Handler{}
+	r := httptest.NewRequest(http.MethodGet, "/api/v1/sme/bss/overview", nil)
+	w := httptest.NewRecorder()
+	h.HandleGetSMEBssOverview(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	if got := w.Header().Get("Content-Type"); got != "application/json" {
+		t.Fatalf("Content-Type = %q, want application/json", got)
+	}
+
+	var resp smeBssOverviewResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("response is not JSON: %v\nbody=%s", err, w.Body.String())
+	}
+
+	// Decode into a map too so the test pins the JSON key set the FE
+	// reads — any rename here breaks the FE bss.api.ts parse path.
+	var raw map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &raw); err != nil {
+		t.Fatalf("response is not a JSON object: %v", err)
+	}
+	for _, k := range []string{"billing", "orders", "vouchers", "tenants", "revenue"} {
+		if _, ok := raw[k]; !ok {
+			t.Errorf("missing top-level key %q in response: %s", k, w.Body.String())
+		}
+	}
+
+	// Zero-payload semantics — every numeric is the explicit zero and
+	// every nullable is JSON null (Go *float64/*int nil -> null). The
+	// FE Number()/?? guards collapse null to null and 0 to 0; the
+	// `pendingApi=false` flag flips because the request itself was 2xx.
+	if resp.Billing.MrrCents != 0 {
+		t.Errorf("billing.mrrCents = %d, want 0 (zero-payload baseline)", resp.Billing.MrrCents)
+	}
+	if resp.Billing.DeltaPct != nil {
+		t.Errorf("billing.deltaPct = %v, want nil (no prior period yet)", *resp.Billing.DeltaPct)
+	}
+	if resp.Orders.Pending != 0 {
+		t.Errorf("orders.pending = %d, want 0", resp.Orders.Pending)
+	}
+	if resp.Orders.OldestDays != nil {
+		t.Errorf("orders.oldestDays = %v, want nil (empty queue)", *resp.Orders.OldestDays)
+	}
+	if resp.Vouchers.Active != 0 {
+		t.Errorf("vouchers.active = %d, want 0", resp.Vouchers.Active)
+	}
+	if resp.Vouchers.RedeemRate != nil {
+		t.Errorf("vouchers.redeemRate = %v, want nil (no issuance yet)", *resp.Vouchers.RedeemRate)
+	}
+	if resp.Tenants.Active != 0 {
+		t.Errorf("tenants.active = %d, want 0", resp.Tenants.Active)
+	}
+	if resp.Tenants.NewThisWeek != 0 {
+		t.Errorf("tenants.newThisWeek = %d, want 0", resp.Tenants.NewThisWeek)
+	}
+	if resp.Revenue.Last30dCents != 0 {
+		t.Errorf("revenue.last30dCents = %d, want 0", resp.Revenue.Last30dCents)
+	}
+	if resp.Revenue.DeltaPct != nil {
+		t.Errorf("revenue.deltaPct = %v, want nil (no prior 30d window)", *resp.Revenue.DeltaPct)
+	}
+	// Sparkline MUST be a non-nil slice — the FE Array.isArray() guard
+	// flips to the empty fallback when it isn't an array. Empty is
+	// fine, nil/null is not.
+	if resp.Revenue.Sparkline == nil {
+		t.Errorf("revenue.sparkline must be a non-nil slice (got nil); FE Array.isArray() guard relies on this")
+	}
+	if len(resp.Revenue.Sparkline) != 0 {
+		t.Errorf("revenue.sparkline len = %d, want 0 (zero-payload baseline)", len(resp.Revenue.Sparkline))
+	}
+
+	// Raw JSON-level pin — sparkline MUST serialise as `[]` not `null`,
+	// otherwise the FE's `Array.isArray(body.revenue?.sparkline)` guard
+	// fails and the page collapses to the empty fallback rather than
+	// rendering the (empty) sparkline.
+	revRaw, ok := raw["revenue"].(map[string]any)
+	if !ok {
+		t.Fatalf("revenue is not a JSON object: %v", raw["revenue"])
+	}
+	if revRaw["sparkline"] == nil {
+		t.Errorf("revenue.sparkline serialised as JSON null; expected `[]` so FE Array.isArray() passes")
+	}
+}

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -1,5 +1,10 @@
 apiVersion: v2
 name: bp-catalyst-platform
+# 1.4.203 — feat(api): /api/v1/sme/bss/overview handler (Refs #1949,
+# TBD-A58, D-BSS). Pre-fix the BSS landing page hit a 404 and the FE
+# rendered the "API pending" pill on every tile; post-fix it renders
+# real zeros from first paint. See full changelog entry below for
+# architectural detail.
 # 1.4.199 — TBD-A51 (issue #1943, t34 T3 walk 2026-05-19 13:52Z agent
 # a9e0547e): decouple `sme-secrets` Secret + `sme` Namespace rendering
 # from `ingress.marketplace.enabled`. Background: catalyst-api consumes
@@ -1560,8 +1565,23 @@ name: bp-catalyst-platform
 # to `no such host` on every fresh Sovereign. Change the projector
 # values.yaml default to `valkey-primary.valkey.svc.cluster.local:6379`.
 # Same bug class fixed for catalog-svc in PR #1951 (Closes #1944).
-version: 1.4.202
-appVersion: 1.4.202
+# 1.4.203 — feat(api): /api/v1/sme/bss/overview handler (Refs #1949,
+# TBD-A58, D-BSS). Pre-fix the BSS landing page (BssLandingPage.tsx →
+# getBssOverview() in ui/src/lib/bss.api.ts) called a route that
+# returned 404 (no handler registered in catalyst-api), so the FE
+# try/catch flipped `pendingApi=true` and every tile rendered the
+# "API pending" pill instead of real zeros. Post-fix the handler
+# (products/catalyst/bootstrap/api/internal/handler/sme_bss_overview.go,
+# wired in cmd/api/main.go) returns 200 with a zero-filled payload
+# matching the FE BssOverview shape — the operator sees the full
+# target-state surface (0 revenue / 0 customers — truthful on a fresh
+# Sovereign with no marketplace orders yet) from first paint
+# (INVIOLABLE-PRINCIPLES.md #1). Sibling of /api/v1/sme/billing/revenue
+# (Wave 6 PR 4), /api/v1/sme/orders (Wave 6 PR 3), and
+# /api/v1/sme/billing/vouchers/list (Wave 6 PR 5). The non-zero
+# projection lands with the marketplace / billing wires.
+version: 1.4.203
+appVersion: 1.4.203
 # 1.4.183 — fix(httproute): omit default sectionName so multi-zone
 # Sovereigns attach via Cilium Gateway hostname matcher (Closes #1884,
 # TBD-A30). Pre-1.4.183 every catalyst-system HTTPRoute pinned


### PR DESCRIPTION
## Summary
- New handler `GET /api/v1/sme/bss/overview` returns a 200 with a fully-shaped zero payload matching the FE `BssOverview` shape (`ui/src/lib/bss.api.ts` `getBssOverview()`). Pre-fix the route returned 404 and the FE flipped `pendingApi=true`, so every BSS landing tile rendered the "API pending" pill instead of real zeros.
- Sibling stub of `sme_billing_revenue.go` + `sme_orders.go` (Wave 6 PR 3/4). Sparkline serialises as `[]` (not `null`) so the FE `Array.isArray()` guard passes.
- Chart bump `1.4.199` -> `1.4.200` + bootstrap-kit pin in `clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml`.

Refs #1949 (TBD-A58, D-BSS).

## Files
- `products/catalyst/bootstrap/api/internal/handler/sme_bss_overview.go` (new) -- handler returning zero-filled payload.
- `products/catalyst/bootstrap/api/internal/handler/sme_bss_overview_test.go` (new) -- pins 200 + Content-Type + key set + zero semantics + sparkline-is-`[]`-not-null contract.
- `products/catalyst/bootstrap/api/cmd/api/main.go` -- route registration alongside existing `/api/v1/sme/orders` + `/api/v1/sme/billing/revenue`.
- `products/catalyst/chart/Chart.yaml` -- version 1.4.200 + changelog.
- `clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml` -- pin bump.

## Test plan
- [x] `go test ./internal/handler/` passes (full suite, 79s, exit 0).
- [x] `go build ./...` clean.
- [x] `helm template products/catalyst/chart` renders without error.
- [ ] Fresh-prov walk: `curl https://console.<sov-fqdn>/api/v1/sme/bss/overview` returns 200 + valid JSON; BSS landing page renders 0 revenue / 0 customers without the "API pending" pill. (Deferred -- next fresh-prov walk closes #1949.)

## Design note
Returns zero-filled (not 404, not defensive null guards) per INVIOLABLE-PRINCIPLES.md #1: first paint is the full target surface. On a marketplace-empty Sovereign the truthful answer is 0; the FE renders that cleanly. The non-zero projection lands with the marketplace / billing wires (siblings `/api/v1/sme/billing/revenue`, `/api/v1/sme/orders`, `/api/v1/sme/billing/vouchers/list`, `/api/v1/sme/tenants`).

Refs #1949