### PR TITLE
fix(chart): wrap Helm-templated value: fields in quotes — unblock strategy-flip-regression (Closes #1930)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -679,7 +679,13 @@ spec:
       # `valkey.valkey.svc.cluster.local` is NXDOMAIN (bp-valkey
       # installs `valkey-primary` Service, not plain `valkey`). Same
       # bug class as #1944 (catalog-svc, fixed in PR #1951).
-      version: 1.4.201
+      # 1.4.202 (Closes #1930, TBD-A46): wrap the Helm-templated
+      # `value: {{ ... }}` line in api-deployment.yaml so the raw
+      # chart manifest parses as YAML — unblocks the
+      # strategy-flip-regression CI workflow on every PR that
+      # touches `api-deployment.yaml`. Zero behavioural change at
+      # runtime.
+      version: 1.4.202
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -1536,6 +1536,23 @@ name: bp-catalyst-platform
 # `.catalyst-system.svc.cluster.local:8080` and the
 # 57-bp-openova-flow-emitter overlay (`flowServerUrl: http://
 # openova-flow-server.catalyst-system.svc.cluster.local`).
+# 1.4.202 (Closes #1930, TBD-A46): wrap the bare `value: {{ ... }}`
+# Helm-templated field in single quotes so the raw chart manifest
+# parses as YAML before Helm renders it. The
+# `strategy-flip-regression` CI workflow shells out to
+# `kubectl apply --dry-run=server -f
+# products/catalyst/chart/templates/api-deployment.yaml`, which
+# means kubectl is the YAML parser — not Helm. With the line
+# unquoted, YAML 1.1 sees `{{` as the start of a flow-mapping and
+# fails the file at `did not find expected key`, blocking the test
+# step on every PR that touches `api-deployment.yaml`. Switching to
+# single-quoted scalar form `'{{ .Values.catalystApi.natsURL |
+# default "..." }}'` (and dropping the `| quote` filter so we don't
+# end up with double-quoting after render) keeps Helm output
+# identical (single-quoted string scalar carrying the rendered URL)
+# while letting the raw chart manifest parse cleanly. Net effect: 0
+# behavioural change at runtime, unblocks every chart-touching PR's
+# strategy-flip-regression check.
 # 1.4.201 (Refs #1953): fix projector valkey.addr NXDOMAIN. The
 # bp-valkey blueprint installs the Valkey Service as `valkey-primary`
 # (architecture: replication, no plain `valkey` service), so the
@@ -1543,8 +1560,8 @@ name: bp-catalyst-platform
 # to `no such host` on every fresh Sovereign. Change the projector
 # values.yaml default to `valkey-primary.valkey.svc.cluster.local:6379`.
 # Same bug class fixed for catalog-svc in PR #1951 (Closes #1944).
-version: 1.4.201
-appVersion: 1.4.201
+version: 1.4.202
+appVersion: 1.4.202
 # 1.4.183 — fix(httproute): omit default sectionName so multi-zone
 # Sovereigns attach via Cilium Gateway hostname matcher (Closes #1884,
 # TBD-A30). Pre-1.4.183 every catalyst-system HTTPRoute pinned

--- a/products/catalyst/chart/templates/api-deployment.yaml
+++ b/products/catalyst/chart/templates/api-deployment.yaml
@@ -357,7 +357,7 @@ spec:
             # allowedPlatformNamespaces (see network-policies/
             # baseline-catalyst-system.yaml) so no extra CNP is needed.
             - name: CATALYST_NATS_URL
-              value: {{ .Values.catalystApi.natsURL | default "nats://nats-jetstream.nats-system.svc.cluster.local:4222" | quote }}
+              value: '{{ .Values.catalystApi.natsURL | default "nats://nats-jetstream.nats-system.svc.cluster.local:4222" }}'
             # CATALYST_K8SCACHE_KUBECONFIGS_DIR — issue #321. Directory
             # the k8scache.Factory reads kubeconfigs from at startup.
             # The data-plane SharedInformerFactory opens one informer


### PR DESCRIPTION
## Summary

- `strategy-flip-regression` CI workflow has been red on every PR that touches `products/catalyst/chart/templates/api-deployment.yaml` since PR #1926 introduced a bare `value: {{ ... }}` field in the `CATALYST_NATS_URL` env. The workflow shells out to `kubectl apply --dry-run=server -f api-deployment.yaml` — kubectl is the YAML parser, not Helm, so YAML 1.1 sees `{{` as a flow-mapping opener and fails the file with `did not find expected key`.
- Fix: switch the line to a single-quoted scalar `value: '{{ .Values.catalystApi.natsURL | default "..." }}'` and drop the `| quote` filter (the outer single quotes carry it). Raw manifest parses as YAML; rendered Helm output is identical aside from being a single-quoted scalar instead of an unquoted one. Zero behavioural change at runtime.
- Chart `1.4.201` → `1.4.202`; bootstrap-kit pin in `clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml` bumped to match. Surgical change — only the offending line + version bumps + change-history comments.

## Test plan

- [x] `python3 -c "import yaml; list(yaml.safe_load_all(open('products/catalyst/chart/templates/api-deployment.yaml')))"` parses cleanly (pre-fix: `did not find expected key`)
- [x] `helm template products/catalyst/chart | grep -B1 -A2 CATALYST_NATS_URL` renders to `value: 'nats://nats-jetstream.nats-system.svc.cluster.local:4222'` (clean single-quoted scalar)
- [ ] CI `strategy-flip-regression` transitions to PASS on this PR
- [ ] All other CI checks green
- [ ] Merge non-admin

Closes #1930

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>