### PR TITLE
fix(bp-vcluster): install vcluster.com CRDs on fresh prov (Refs #1945)

### DIFF
--- a/clusters/_template/bootstrap-kit/60-bp-vcluster-helmrepo.yaml
+++ b/clusters/_template/bootstrap-kit/60-bp-vcluster-helmrepo.yaml
@@ -76,7 +76,12 @@ spec:
   chart:
     spec:
       chart: bp-vcluster-helmrepo
-      version: 0.1.0
+      # 0.2.0 — adds the `vclusters.vcluster.com` CRD so Catalyst's
+      # networking + dashboard read paths can LIST VClusters on a
+      # fresh Sovereign (issue #1945, TBD-A53). Pre-0.2.0 charts only
+      # registered the HelmRepository CR; the CRD itself was absent
+      # on every fresh prov.
+      version: 0.2.0
       sourceRef:
         kind: HelmRepository
         name: bp-vcluster-helmrepo

--- a/platform/bp-vcluster-helmrepo/blueprint.yaml
+++ b/platform/bp-vcluster-helmrepo/blueprint.yaml
@@ -6,7 +6,9 @@ metadata:
     catalyst.openova.io/section: pts-3-1-networking-and-service-mesh
     catalyst.openova.io/category: platform
 spec:
-  version: 0.1.0
+  # 0.2.0 — adds the `vclusters.vcluster.com` CRD alongside the existing
+  # HelmRepository + namespace pre-staging (issue #1945, TBD-A53).
+  version: 0.2.0
   card:
     title: vCluster HelmRepository
     summary: |

--- a/platform/bp-vcluster-helmrepo/chart/Chart.yaml
+++ b/platform/bp-vcluster-helmrepo/chart/Chart.yaml
@@ -1,5 +1,20 @@
 apiVersion: v2
 name: bp-vcluster-helmrepo
+# 0.2.0 — adds the `vclusters.vcluster.com` CustomResourceDefinition
+# alongside the existing HelmRepository + namespace pre-staging.
+# Caught on t34 walk 2026-05-19 (issue #1945, TBD-A53): the upstream
+# loft-sh/vcluster chart does NOT register any CRD with apiGroup
+# `vcluster.com` (it just installs a StatefulSet cohort), so `kubectl
+# api-resources --api-group=vcluster.com` was returning empty on every
+# fresh Sovereign. Catalyst's networking + dashboard read paths LIST
+# `vcluster.com/v1alpha1 VClusters` to render the DMZ tab + dashboard
+# utilization overlay — without the CRD they fall back to "not
+# installed" panels and block D29 zero-touch tenant materialisation
+# (issue #1829). The CRD is namespaced, served at v1alpha1, with
+# `.status.phase` populated and the spec block preserve-unknown-fields
+# so operator-attached values round-trip cleanly. See
+# templates/vcluster-crd.yaml for the full rationale and shape.
+#
 # 0.1.0 — initial implementation. Pre-stages the upstream loft-sh
 # vcluster Helm chart source on the Sovereign cluster so the
 # Organization controller (core/controllers/organization) can render
@@ -14,7 +29,7 @@ name: bp-vcluster-helmrepo
 # \"loft\" not found" — convergence blocker #2 (vCluster CRD-equivalent
 # install on Sovereign). Spawning any tenant org's vCluster gates on
 # this slot.
-version: 0.1.0
+version: 0.2.0
 appVersion: "0.33.0"
 description: |
   Catalyst Blueprint that pre-stages the upstream loft-sh vcluster

--- a/platform/bp-vcluster-helmrepo/chart/templates/vcluster-crd.yaml
+++ b/platform/bp-vcluster-helmrepo/chart/templates/vcluster-crd.yaml
@@ -1,0 +1,137 @@
+{{- if .Values.vclusterCRD.enabled -}}
+# vclusters.vcluster.com — Catalyst-authored CustomResourceDefinition.
+#
+# Why this CRD ships from THIS chart (bp-vcluster-helmrepo) instead of
+# the upstream loft-sh/vcluster chart:
+#
+#   - The upstream `vcluster` chart (loft-sh) installs a vCluster as a
+#     plain StatefulSet + Service + Secret cohort. It does NOT register
+#     any CRD with apiGroup `vcluster.com`. See
+#     https://github.com/loft-sh/vcluster/tree/main/chart/templates —
+#     no `crds/` dir, no CustomResourceDefinition templates.
+#
+#   - Catalyst's networking + dashboard read paths
+#     (products/catalyst/bootstrap/api/internal/handler/networking.go
+#     `HandleNetworkingDMZ`, internal/k8scache/kinds.go registry entry
+#     `{Group:"vcluster.com", Version:"v1alpha1", Resource:"vclusters"}`)
+#     LIST `vcluster.com/v1alpha1 VClusters` to render the Sovereign
+#     console's DMZ tab + dashboard utilization overlay.
+#
+#   - Without this CRD on a fresh Sovereign, every `kubectl
+#     api-resources --api-group=vcluster.com` returns empty (issue
+#     #1945, t34 walk 2026-05-19) → the k8scache dynamicinformer logs
+#     soft NotFound on the LIST → the DMZ tab renders an empty
+#     "not installed" panel → D29 zero-touch tenant materialisation
+#     is permanently blocked.
+#
+# bp-vcluster-helmrepo is the canonical home: it already pre-stages
+# the vcluster-system namespace + the loft HelmRepository CR. Adding
+# the CRD here means the SAME bootstrap-kit slot delivers both halves
+# of "vcluster-related cluster-scoped registration", and the slot's
+# `dependsOn: bp-flux` keeps the Flux source-controller up before
+# either CR lands.
+#
+# Ordering — per docs/INVIOLABLE-PRINCIPLES.md #14 (cross-Kind
+# dependencies must use Kustomization.dependsOn, NEVER HelmRelease.
+# dependsOn, which is silently ignored for non-HelmRelease deps):
+# downstream HelmReleases that materialise VCluster CRs (e.g. a
+# future bp-sme-tenant slot) must be sequenced AFTER slot 60
+# (60-bp-vcluster-helmrepo.yaml) in the bootstrap-kit
+# kustomization.yaml — same way they're sequenced after slot 03
+# (bp-flux) today. No HR-level dependsOn needed.
+#
+# Schema shape — the read path consumes ONLY .status.phase (string)
+# and standard ObjectMeta. We expose those explicitly + keep the
+# spec block permissive (x-kubernetes-preserve-unknown-fields) so
+# any operator-attached fields survive a round-trip without the
+# CRD's schema rejecting them. helm.sh/resource-policy: keep makes
+# uninstall a no-op on the CRD (matches platform/gateway-api
+# convention — deleting CRDs would orphan every VCluster CR
+# simultaneously).
+#
+# Refs:
+#   - issue #1945 — TBD-A53: vcluster.com CRDs absent on fresh prov
+#   - issue #1829 — D29 voucher-based tenant provisioning
+#   - PR  #1289  — original removal of bp-dmz-vcluster from default
+#                   bootstrap kit (the UI's iter-16 Fix #68 comment
+#                   in NetworkingPage.tsx documents that this CRD has
+#                   been absent since)
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: vclusters.vcluster.com
+  labels:
+    {{- include "bp-vcluster-helmrepo.labels" . | nindent 4 }}
+    catalyst.openova.io/tenant-spawn: vcluster
+  annotations:
+    # Helm uninstall MUST NOT delete the CRD — see header comment.
+    helm.sh/resource-policy: keep
+spec:
+  group: vcluster.com
+  scope: Namespaced
+  names:
+    kind: VCluster
+    listKind: VClusterList
+    plural: vclusters
+    singular: vcluster
+    shortNames:
+      - vc
+    categories:
+      - catalyst
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      additionalPrinterColumns:
+        - name: Phase
+          type: string
+          jsonPath: .status.phase
+        - name: Age
+          type: date
+          jsonPath: .metadata.creationTimestamp
+      schema:
+        openAPIV3Schema:
+          type: object
+          description: |
+            VCluster represents a virtual Kubernetes cluster running on
+            top of a host k3s/k8s cluster. The host-side artifacts (the
+            actual StatefulSet + Service + Secrets that materialise the
+            vCluster) are managed by the upstream loft-sh/vcluster Helm
+            chart referenced via the bp-vcluster-helmrepo HelmRepository
+            (see clusters/_template/bootstrap-kit/60-bp-vcluster-helmrepo.yaml).
+            This CR is the operator-visible projection of that cohort —
+            read-only for the Sovereign console's DMZ / dashboard tabs.
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              type: object
+              description: |
+                Spec fields are operator-defined and forwarded verbatim
+                to the host-side HelmRelease values block (no Catalyst
+                schema enforcement — operators MAY add upstream-shape
+                fields without re-vendoring this CRD).
+              x-kubernetes-preserve-unknown-fields: true
+            status:
+              type: object
+              properties:
+                phase:
+                  type: string
+                  description: |
+                    Lifecycle phase — one of `Pending`, `Running`,
+                    `Failed`, `Deleting`. The networking handler's
+                    `dmzVCluster.Running` field is set true iff phase
+                    equals `Running` (case-insensitive).
+                message:
+                  type: string
+                  description: |
+                    Free-form status message (operator-readable, never
+                    parsed by Catalyst code paths).
+              x-kubernetes-preserve-unknown-fields: true
+      subresources:
+        status: {}
+{{- end }}

--- a/platform/bp-vcluster-helmrepo/chart/values.yaml
+++ b/platform/bp-vcluster-helmrepo/chart/values.yaml
@@ -34,3 +34,25 @@ vclusterHelmRepo:
   # operator-MAY turn it off to manage the namespace via a separate
   # Kustomization.
   createNamespace: true
+
+# CRD installation gate (issue #1945, TBD-A53). When true, this chart
+# also installs the `vclusters.vcluster.com` CustomResourceDefinition.
+# That CRD is consumed by the Catalyst-API networking handler
+# (`HandleNetworkingDMZ` at
+# products/catalyst/bootstrap/api/internal/handler/networking.go) and
+# by the k8scache dynamicinformer registry
+# (products/catalyst/bootstrap/api/internal/k8scache/kinds.go) — both
+# LIST `vcluster.com/v1alpha1 VClusters` to feed the Sovereign console
+# DMZ tab + dashboard utilization overlay.
+#
+# Without the CRD on the cluster, `kubectl api-resources
+# --api-group=vcluster.com` returns empty (caught on t34 walk
+# 2026-05-19) and D29 zero-touch tenant materialisation cannot
+# complete. See templates/vcluster-crd.yaml for the full rationale.
+#
+# Default-ON because every Sovereign needs the read surface to render
+# its console panels. Operator MAY turn off in environments that
+# install the CRD via a separate operator (e.g. cluster-api-provider-
+# vcluster) to avoid duplicate-registration.
+vclusterCRD:
+  enabled: true


### PR DESCRIPTION
## Summary

- Adds `vclusters.vcluster.com` CustomResourceDefinition (v1alpha1, namespaced) to the `bp-vcluster-helmrepo` chart (bootstrap-kit slot 60) so the Catalyst-API networking handler can LIST `vcluster.com/v1alpha1 VClusters` on a fresh Sovereign.
- Unblocks D29 zero-touch tenant materialisation (#1829) — `kubectl api-resources --api-group=vcluster.com` was returning empty on every fresh prov because no upstream chart or Catalyst chart was installing this CRD.

## Root cause

The upstream `loft-sh/vcluster` chart installs a vCluster as a plain StatefulSet + Service + Secret cohort. It does NOT register any CRD with apiGroup `vcluster.com` (verified by inspecting the upstream `chart/templates/` dir — no `crds/` dir, no CustomResourceDefinition templates). PR #1624 "install vcluster CRDs + controller on Sovereign" only added the loft HelmRepository CR, NOT the CRD itself.

Catalyst's networking + dashboard read paths LIST `vcluster.com/v1alpha1 VClusters` to render the Sovereign console's DMZ tab + dashboard utilization overlay:
- `products/catalyst/bootstrap/api/internal/handler/networking.go` `HandleNetworkingDMZ`
- `products/catalyst/bootstrap/api/internal/k8scache/kinds.go` registry entry `{Group:"vcluster.com", Version:"v1alpha1", Resource:"vclusters"}`

Without the CRD on the cluster the dynamicinformer logs soft NotFound on the LIST -> DMZ tab renders empty -> D29 zero-touch tenant materialisation blocks.

## Layering — why `bp-vcluster-helmrepo`

This chart is the canonical home for "vcluster-related cluster-scoped registration" — it already pre-stages:
1. The `vcluster-system` namespace
2. The `loft` HelmRepository CR

Adding the CRD here means the SAME bootstrap-kit slot delivers both halves of the registration, and slot 60's existing `dependsOn: bp-flux` keeps Flux's source-controller up before either CR lands. Per Principle #14 (cross-Kind deps must use Kustomization.dependsOn, not HelmRelease.dependsOn), downstream HRs that materialise VCluster CRs must be sequenced AFTER slot 60 in the bootstrap-kit `kustomization.yaml` — the same way they're sequenced after slot 03 (bp-flux) today. No HR-level dependsOn needed.

## Schema shape

- `vclusters.vcluster.com`, namespaced, v1alpha1 (served + storage)
- `.status.phase` (string) + `.status.message` (string) — the only fields Catalyst code reads
- `.spec` is permissive (`x-kubernetes-preserve-unknown-fields: true`) so operator-attached values round-trip cleanly
- `helm.sh/resource-policy: keep` prevents a chart uninstall from orphaning every VCluster CR (matches platform/gateway-api convention)

## Files

- `platform/bp-vcluster-helmrepo/chart/templates/vcluster-crd.yaml` — NEW, the CRD itself + full rationale header
- `platform/bp-vcluster-helmrepo/chart/values.yaml` — adds `vclusterCRD.enabled: true` toggle
- `platform/bp-vcluster-helmrepo/chart/Chart.yaml` — version 0.1.0 -> 0.2.0 with changelog header
- `platform/bp-vcluster-helmrepo/blueprint.yaml` — `spec.version` 0.1.0 -> 0.2.0
- `clusters/_template/bootstrap-kit/60-bp-vcluster-helmrepo.yaml` — pin bump to 0.2.0
- `bp-catalyst-platform` is NOT touched (per task Hard Rules — that chart is in rebase race).

## Validation

- `helm template` renders the CRD with the expected GVR + names + `v1alpha1` served=true storage=true + status.phase/message properties (3 docs total: Namespace + CRD + HelmRepository).
- `kubectl apply --dry-run=server` accepts the rendered CRD against the live mothership apiserver (no `vcluster.com` group present before this fix — verified empty pre-apply, group registers post-apply).
- A VCluster CR fixture matching `networking_test.go` shape (`status.phase: Running`, arbitrary spec fields) passes server-side validation against the applied CRD.
- `--set vclusterCRD.enabled=false` correctly renders only the Namespace + HelmRepository (CRD omitted).

## Test plan

- [ ] CI build-and-test passes on this PR
- [ ] Blueprint Release workflow publishes `bp-vcluster-helmrepo@0.2.0` to `oci://ghcr.io/openova-io`
- [ ] Next fresh Sovereign prov: `kubectl api-resources --api-group=vcluster.com` returns `vclusters` (not empty)
- [ ] DMZ tab on Sovereign console renders DMZ vCluster state instead of "not installed" panel (with bp-dmz-vcluster enabled via overlay)
- [ ] D29 customer-journey re-walk: voucher -> tenant org -> vCluster materialises end-to-end (issue #1829)

Refs #1945
Refs #1829

Generated with Claude Code