### PR TITLE
fix(bp-catalyst-platform): default MARKETPLACE_ENABLED=true on franchised Sovereigns (Closes #1966)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -706,7 +706,17 @@ spec:
       # to /app/$componentId lands on AppDetail's CR-keyed lookup
       # rather than 404'ing at "App not found". See Chart.yaml comment
       # block + Dashboard.test.tsx regression guards. Refs #1927.
-      version: 1.4.205
+      # 1.4.206 (TBD-A62 #1966, 2026-05-19): bootstrap-kit slot default
+      # flip — MARKETPLACE_ENABLED `false` → `true`. Same default-flip
+      # rationale as SANDBOX_ENABLED in slot 19a (TBD-D11): once the
+      # underlying chart gates workloads gracefully on missing operator
+      # creds, default-OFF only blocks the operator's first-run UX.
+      # Operator may still opt-OUT by overriding MARKETPLACE_ENABLED=false
+      # on the per-Sovereign bootstrap-kit overlay's postBuild.substitute
+      # map. Unblocks D29 customer-journey: marketplace.<sov> 404 →
+      # storefront; voucher endpoint 503 → 2xx; SME tenant pipeline
+      # reconciliation. Refs #1966 #1741 #1949 #1943.
+      version: 1.4.206
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform
@@ -811,14 +821,25 @@ spec:
           host: marketplace.${SOVEREIGN_FQDN}
         api:
           host: api.${SOVEREIGN_FQDN}
-      # Marketplace mode (issue #710). Toggle to true via envsubst
-      # MARKETPLACE_ENABLED in the per-Sovereign overlay (catalyst-api
-      # writes this when the wizard's "Enable Marketplace" component is
-      # checked). When true, bp-catalyst-platform 1.3.0+ renders the
-      # marketplace + tenant-wildcard HTTPRoutes and the cross-namespace
+      # Marketplace mode (issue #710). Default-ON since TBD-A62 (issue
+      # #1966, 2026-05-19) — the customer-journey D29 chain (marketplace
+      # storefront, sme-secrets reflection for voucher endpoint,
+      # marketplace.<sov> HTTPRoute) was unreachable on every fresh
+      # franchised Sovereign because this defaulted to `false`. Same
+      # default-flip rationale as `SANDBOX_ENABLED` in slot 19a
+      # (TBD-D11): once the underlying chart gates the workloads
+      # gracefully on missing operator creds (newapi 1.4.10 silently
+      # skips qwenBankDhofar without LLM_BANK_DHOFAR_* attestation,
+      # marketplace-api self-generates its JWT via sprig randAlphaNum,
+      # smeSecrets auto-bootstraps via Helm lookup), defaulting OFF
+      # only blocks the operator's first-run UX. Operator may opt-OUT
+      # by overriding `MARKETPLACE_ENABLED=false` on the per-Sovereign
+      # bootstrap-kit overlay's postBuild.substitute map. When true,
+      # bp-catalyst-platform 1.3.0+ renders the marketplace +
+      # tenant-wildcard HTTPRoutes and the cross-namespace
       # ReferenceGrant.
       marketplace:
-        enabled: ${MARKETPLACE_ENABLED:-false}
+        enabled: ${MARKETPLACE_ENABLED:-true}
     # ─── Multi-zone parent domains (issue #827, parent epic #825) ──────
     # One wildcard Certificate per parent zone, rendered by chart 1.4.0+
     # into kube-system. Each cert renews independently; a stalled

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -1,5 +1,70 @@
 apiVersion: v2
 name: bp-catalyst-platform
+# 1.4.206 — TBD-A62 (issue #1966, 2026-05-19): default-flip
+# `MARKETPLACE_ENABLED` from `false` to `true` in
+# clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml so every
+# fresh franchised Sovereign renders the marketplace storefront +
+# SME microservice mesh out of the box. This is a bootstrap-kit slot
+# default-flip only — no chart template changes. Chart version bump
+# (1.4.205 → 1.4.206) is the canonical signal that the bootstrap-kit
+# pin moved, paired with the matching `version:` bump in the same
+# bp-catalyst-platform slot.
+#
+# Background — D29 customer-journey chain-breaker:
+# PR #1954 (TBD-A51) decoupled `sme-secrets` + `sme` namespace from
+# `ingress.marketplace.enabled` so catalyst-api could mint voucher
+# JWTs even on non-marketplace Sovereigns; the marketplace Deployment,
+# storefront HTTPRoute (marketplace.<sov>), and SME gateway Service
+# itself remained gated behind the flag. With the bootstrap-kit slot
+# defaulting `MARKETPLACE_ENABLED=false`, every fresh prov landed with:
+#   - marketplace Deployment NOT rendered → marketplace.<sov> 404
+#     (founder-reported as "missing /redeem page" on t34 — the page is
+#     served by the marketplace Pod, which was absent)
+#   - tenant.yaml + marketplace-routes.yaml NOT rendered → SME gateway
+#     unreachable → POST /api/v1/sme/billing/vouchers/issue still 503
+#     (post-#1954 error band: "sme gateway unreachable" instead of
+#     "CATALYST_SME_JWT_SECRET not set")
+#   - sme-tenants-kustomization.yaml NOT rendered → SME tenant
+#     pipeline silently skipped on every customer-journey start
+#
+# Net behavioural effect of the flip — 4 chain-broken behaviours
+# unblocked on every fresh franchised Sovereign:
+#   1. marketplace Deployment + Service render in `sme` ns
+#      (templates/sme-services/marketplace.yaml)
+#   2. marketplace.<sov> HTTPRoute attached to cilium-gateway
+#      (templates/sme-services/marketplace-routes.yaml)
+#   3. sme-secrets reflection to catalyst-system unblocks the JWT
+#      bridge (PR #1954 already merged) — paired with the gateway
+#      Service rendering now, the voucher endpoint can ACTUALLY reach
+#      the upstream SME microservice mesh
+#   4. SME microservice mesh (auth/billing/catalog/console/domain/
+#      gateway/provisioning/tenant/admin/notification + sme-tenants-
+#      kustomization + sme-tenants-gitrepository) renders so the
+#      orchestrator's POST /api/v1/sme/tenants reconciles for real
+#
+# Backward-compat: operators that explicitly OPT-OUT by setting
+# `MARKETPLACE_ENABLED=false` on the per-Sovereign overlay's
+# bootstrap-kit Kustomization postBuild.substitute map still get the
+# old "no SME mesh" behaviour. PR #1954's unconditional `sme-secrets`
+# + `sme` namespace render stays intact in either mode (the JWT
+# bridge byte source is preserved independently of the marketplace
+# storefront).
+#
+# Why this was off-by-default originally: chart 1.3.0 (issue #710)
+# introduced the marketplace HTTPRoutes + SME microservice mesh as
+# operator opt-in because (a) marketplace-api-secrets did not yet
+# auto-generate via sprig randAlphaNum (added in 1.4.15, issue #887),
+# (b) the qwenBankDhofar slot in newapi hard-failed without an
+# operator-supplied LLM_BANK_DHOFAR_ACCOUNT_ID + CONTRACT_REF (gracefully
+# skipped since newapi 1.4.10, this repo), and (c) marketplace branding
+# fields (logo, brand color, primary color, Stripe keys) were required
+# rather than having safe placeholder defaults (placeholders shipped in
+# values.yaml `marketplace.brand` block, line ~969). All three blockers
+# are resolved on `main`, so the original rationale for default-OFF no
+# longer holds. Same default-flip pattern as bp-sandbox slot 19a's
+# SANDBOX_ENABLED (TBD-D11 #1798, 2026-05-18 — once the chart gates the
+# workloads gracefully on missing config, the default flips ON).
+# Refs #1966 #1741 #1949 #1943.
 # 1.4.203 — feat(api): /api/v1/sme/bss/overview handler (Refs #1949,
 # TBD-A58, D-BSS). Pre-fix the BSS landing page hit a 404 and the FE
 # rendered the "API pending" pill on every tile; post-fix it renders
@@ -1640,8 +1705,8 @@ name: bp-catalyst-platform
 # was already shipped on 1.4.197 (PR #1820 lineage); this completes
 # the data-layer side so the dropdown finally appears on multi-region
 # Sovereigns. Refs #1821, DoD D20.
-version: 1.4.205
-appVersion: 1.4.205
+version: 1.4.206
+appVersion: 1.4.206
 # 1.4.183 — fix(httproute): omit default sectionName so multi-zone
 # Sovereigns attach via Cilium Gateway hostname matcher (Closes #1884,
 # TBD-A30). Pre-1.4.183 every catalyst-system HTTPRoute pinned


### PR DESCRIPTION
## Summary

- **TBD-A62 / Closes #1966** — flip the bootstrap-kit slot 13 default `MARKETPLACE_ENABLED` from `false` to `true` so every fresh franchised Sovereign renders the marketplace storefront, SME microservice mesh, and tenant-orchestration pipeline out of the box.
- Chart 1.4.205 → 1.4.206 + bootstrap-kit slot 13 pin synced (no chart template changes — bootstrap-kit slot default-flip only).
- 2-file change: `clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml` + `products/catalyst/chart/Chart.yaml`.

## Why this was off-by-default originally

Chart 1.3.0 (issue #710) introduced the marketplace HTTPRoutes + SME microservice mesh as **operator opt-in** because:

1. `marketplace-api-secrets` did not yet auto-generate via sprig randAlphaNum — added in chart 1.4.15 (#887).
2. The `qwenBankDhofar` slot in newapi hard-failed without an operator-supplied `LLM_BANK_DHOFAR_ACCOUNT_ID` + `CONTRACT_REF` — gracefully skipped since newapi 1.4.10 (this repo).
3. Marketplace branding fields (logo, brand color, Stripe keys) were required rather than having safe placeholder defaults — placeholders now ship in values.yaml `marketplace.brand` block (line ~969).

All three blockers are resolved on `main`. PR #1954 (TBD-A51) explicitly noted that "default marketplace ON for customer-journey Sovereigns is a separate operator-policy decision" — this is that decision.

Same default-flip pattern as `SANDBOX_ENABLED` in slot 19a (TBD-D11 #1798, 2026-05-18): once the chart gates the workloads gracefully on missing config, the default flips ON.

## Chain-broken behaviours unblocked

1. **marketplace Deployment renders** in `sme` ns (`templates/sme-services/marketplace.yaml`) → `marketplace.<sov>` 404 → storefront.
2. **`marketplace.<sov>` HTTPRoute** attached to cilium-gateway (`templates/sme-services/marketplace-routes.yaml`).
3. **SME gateway Service** materialises → voucher endpoint 503 → 2xx (paired with PR #1954's sme-secrets reflection — the JWT bridge tokens now have an upstream to reach).
4. **SME microservice mesh** (auth/billing/catalog/console/domain/gateway/provisioning/tenant/admin/notification + sme-tenants-kustomization + sme-tenants-gitrepository) → POST `/api/v1/sme/tenants` reconciles for real.

## Investigation: gated templates audit

`git grep` of `marketplace.enabled` / `MARKETPLACE_ENABLED` (49 templates):

- `products/catalyst/chart/templates/marketplace-api/{deployment,service,secret}.yaml`
- `products/catalyst/chart/templates/sme-services/{admin,auth,billing,catalog,configmap,console,domain,ferretdb,gateway,marketplace-reference-grant,marketplace-routes,marketplace,notification,provisioning,serviceaccounts,sme-tenants-gitrepository,sme-tenants-kustomization,tenant,cnpg-cluster,valkey-cross-ns-policy,valkey-cross-ns-secret,provisioning-github-token}.yaml`
- `clusters/_template/bootstrap-kit/80-newapi.yaml` (qwenBankDhofar defaultChannel)

**Verified none require external operator creds at render time** — every credential-bearing template either (a) auto-generates via sprig randAlphaNum + Helm `lookup` (jwt-secret, gitea-token, JWT_SECRET, ADMIN_PASSWORD) or (b) gracefully skips when the operator hasn't supplied attestation (newapi qwenBankDhofar 1.4.10+).

## The diff

\`\`\`diff
-      marketplace:
-        enabled: \${MARKETPLACE_ENABLED:-false}
+      marketplace:
+        enabled: \${MARKETPLACE_ENABLED:-true}
\`\`\`

Plus chart 1.4.205 → 1.4.206 bump with changelog entry.

## Test plan

- [x] `helm lint` clean (only `icon is recommended` info)
- [x] `helm template` with default (now `marketplace.enabled=true`) → **103 K8s objects** rendered (full SME mesh + storefront)
- [x] `helm template` with explicit `--set ingress.marketplace.enabled=false` → **54 objects** rendered (no marketplace/sme-services workloads; sme-namespace + sme-secrets still render per #1954) — backward-compat for operators that opt OUT.
- [x] All other templates gated on the same flag verified renderable.
- [ ] Next T3 customer-journey walk on a fresh franchised Sovereign (post-merge + chart-publish CI): `marketplace.<sov>` 200, voucher endpoint 2xx, SME tenant POST reconciles to real K8s resources.

Closes #1966. Refs #1741 #1949 #1943.

🤖 Generated with [Claude Code](https://claude.com/claude-code)