### PR TITLE
fix: align Application CR watcher to apps.openova.io/v1 (Refs #1946)

### DIFF
--- a/products/catalyst/bootstrap/api/internal/k8scache/k8scache_test.go
+++ b/products/catalyst/bootstrap/api/internal/k8scache/k8scache_test.go
@@ -224,6 +224,41 @@ func TestDefaultKinds_GraphAndDashboardSurface(t *testing.T) {
 	}
 }
 
+// TestDefaultKinds_OpenovaCRDsPinnedToStorageVersion guards against a
+// regression of TBD-A54 (#1946) where the dashboard k8scache watcher's
+// GVR (`apps.openova.io/v1alpha1`) drifted out of sync with the CRD
+// served version (`v1`). A mismatch returns zero events from the
+// apiserver — the watcher silently stalls and the `/apps`,
+// `/blueprints`, `/organizations`, `/environments` pages stay empty.
+//
+// The CRDs shipped at products/catalyst/chart/crds/{application,
+// blueprint, organization, environment}.yaml all expose v1 as the
+// storage version. If the chart ever flips one back to v1alpha1 the
+// kind registry MUST be updated in the same PR. This test fails fast
+// if a future edit re-introduces the drift.
+func TestDefaultKinds_OpenovaCRDsPinnedToStorageVersion(t *testing.T) {
+	r := NewRegistry()
+	for _, k := range DefaultKinds {
+		_ = r.Add(k)
+	}
+	want := map[string]schema.GroupVersionResource{
+		"application":  {Group: "apps.openova.io", Version: "v1", Resource: "applications"},
+		"blueprint":    {Group: "catalyst.openova.io", Version: "v1", Resource: "blueprints"},
+		"organization": {Group: "orgs.openova.io", Version: "v1", Resource: "organizations"},
+		"environment":  {Group: "catalyst.openova.io", Version: "v1", Resource: "environments"},
+	}
+	for name, wantGVR := range want {
+		got, ok := r.Get(name)
+		if !ok {
+			t.Errorf("DefaultKinds missing %q — required by EPIC-2 (#1097) read surface", name)
+			continue
+		}
+		if got.GVR != wantGVR {
+			t.Errorf("%s GVR drift (#1946): got %v, want %v — must match storage version of CRD at products/catalyst/chart/crds/%s.yaml", name, got.GVR, wantGVR, name)
+		}
+	}
+}
+
 func TestRegistry_AllAndNames(t *testing.T) {
 	r := NewRegistry()
 	for _, k := range DefaultKinds {

--- a/products/catalyst/bootstrap/api/internal/k8scache/kinds.go
+++ b/products/catalyst/bootstrap/api/internal/k8scache/kinds.go
@@ -177,19 +177,34 @@ var DefaultKinds = []Kind{
 	// access.openova.io/v1alpha1 UserAccess — RBAC binding CRD
 	// surfaced on the /users page.
 	{Name: "useraccess", GVR: schema.GroupVersionResource{Group: "access.openova.io", Version: "v1alpha1", Resource: "useraccesses"}, Namespaced: true},
-	// apps.openova.io/v1alpha1 Application — workload CRD owning the
+	// apps.openova.io/v1 Application — workload CRD owning the
 	// `/apps` and AppDetail pages (EPIC-2 slice T+O+P).
-	{Name: "application", GVR: schema.GroupVersionResource{Group: "apps.openova.io", Version: "v1alpha1", Resource: "applications"}, Namespaced: true},
-	// catalyst.openova.io/v1alpha1 Blueprint — published blueprint
-	// records the curate/publish handlers operate on.
-	{Name: "blueprint", GVR: schema.GroupVersionResource{Group: "catalyst.openova.io", Version: "v1alpha1", Resource: "blueprints"}, Namespaced: true},
-	// orgs.openova.io/v1alpha1 Organization — top-level tenancy CRD
-	// surfaced on the /organizations page.
-	{Name: "organization", GVR: schema.GroupVersionResource{Group: "orgs.openova.io", Version: "v1alpha1", Resource: "organizations"}, Namespaced: false},
-	// catalyst.openova.io/v1alpha1 Environment — logical environment
+	//
+	// TBD-A54 (#1946): the served CRD at
+	// products/catalyst/chart/crds/application.yaml exposes ONLY v1
+	// (storage:true). A previous v1alpha1 GVR here returned zero events
+	// from the apiserver because the version is not served, which broke
+	// every read of `/k8s/application` and silently stalled the
+	// application controller's UI consumers (#1097 EPIC reopened).
+	// Keep this pinned to the storage version of the CRD shipped with
+	// the catalyst chart — see also handler/applications.go
+	// (ApplicationGVR()) and controllers/application/internal/controller
+	// (ApplicationGVR) which both already use v1.
+	{Name: "application", GVR: schema.GroupVersionResource{Group: "apps.openova.io", Version: "v1", Resource: "applications"}, Namespaced: true},
+	// catalyst.openova.io/v1 Blueprint — published blueprint records
+	// the curate/publish handlers operate on. The CRD serves both
+	// v1alpha1 (deprecated, storage:false) and v1 (storage:true); pin
+	// the watcher to the storage version so events are not silently
+	// missed. Refs #1946.
+	{Name: "blueprint", GVR: schema.GroupVersionResource{Group: "catalyst.openova.io", Version: "v1", Resource: "blueprints"}, Namespaced: true},
+	// orgs.openova.io/v1 Organization — top-level tenancy CRD
+	// surfaced on the /organizations page. CRD ships v1 only. Refs #1946.
+	{Name: "organization", GVR: schema.GroupVersionResource{Group: "orgs.openova.io", Version: "v1", Resource: "organizations"}, Namespaced: false},
+	// catalyst.openova.io/v1 Environment — logical environment
 	// dimension (one Environment realised by N Clusters per
 	// docs/NAMING-CONVENTION.md). Surfaced on the /environments page.
-	{Name: "environment", GVR: schema.GroupVersionResource{Group: "catalyst.openova.io", Version: "v1alpha1", Resource: "environments"}, Namespaced: true},
+	// CRD ships v1 only. Refs #1946.
+	{Name: "environment", GVR: schema.GroupVersionResource{Group: "catalyst.openova.io", Version: "v1", Resource: "environments"}, Namespaced: true},
 
 	// QA-loop iter-3 Fix #18 — RBAC ClusterRole + ClusterRoleBinding
 	// surfaced through GET /api/v1/sovereigns/{id}/k8s/clusterroles and


### PR DESCRIPTION
## Summary

TBD-A54 (#1946): the dashboard k8scache watcher in `products/catalyst/bootstrap/api/internal/k8scache/kinds.go` pinned `application`, `blueprint`, `organization`, and `environment` to `v1alpha1`, but the CRDs shipped at `products/catalyst/chart/crds/` serve only `v1` (`storage: true`). A version that is not served returns zero events from the apiserver, silently stalling the EPIC-2 (#1097) UI read surface — `/apps`, `/blueprints`, `/organizations`, `/environments` all appear empty on freshly-provisioned Sovereigns (confirmed on t34, agent a9e0547e 2026-05-19).

The Application controller (`core/controllers/application`) and the handler-side `ApplicationGVR()` builder already use v1; only `kinds.go` drifted.

## Changes

- `products/catalyst/bootstrap/api/internal/k8scache/kinds.go` — flip 4 GVRs to v1 (`application`, `blueprint`, `organization`, `environment`), with TBD-A54 comments referencing the CRDs and #1946 for future readers.
- `products/catalyst/bootstrap/api/internal/k8scache/k8scache_test.go` — new regression test `TestDefaultKinds_OpenovaCRDsPinnedToStorageVersion` that fails fast if a future edit reintroduces the drift.

`useraccess` deliberately stays on `v1alpha1` — it is a Crossplane composite XRD whose served version is `access.openova.io/v1alpha1` (verified in `platform/crossplane-claims/chart/templates/xrds/useraccess.yaml`).

## Why no chart pin bump

The catalyst chart's `values.yaml` SHAs auto-bump via `.github/workflows/catalyst-build.yaml` -> `blueprint-release.yaml` on merge. No edit of `clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml` is required from this PR (bp-catalyst-platform pin is in active race per memory note).

## Validation

- `go build ./...` PASS for `products/catalyst/bootstrap/api`
- `go test ./internal/k8scache/...` PASS — including the new regression test
- `helm template products/catalyst/chart --skip-tests` PASS
- `kubectl --kubeconfig=sov-t34 get crd applications.apps.openova.io -o jsonpath='{.spec.versions[*].name}'` returns `v1` (confirms drift)
- Cluster check (read-only): `kubectl get applications.apps.openova.io -A` returns `No resources found` on t34, consistent with the watcher receiving zero events.

## Test plan

- [ ] CI green on the new branch
- [ ] Next fresh-prov walk closes #1946 (per ticket: "Do not close — next fresh-prov walk closes it")
- [ ] `/apps`, `/blueprints`, `/organizations`, `/environments` populate after chart release lands in bp-catalyst-platform pin

Refs #1946
Refs #1097