### PR TITLE
fix: default MARKETPLACE_ENABLED=true at source (TBD-V4) — Closes #1968, Refs #1966

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -716,7 +716,7 @@ spec:
       # map. Unblocks D29 customer-journey: marketplace.<sov> 404 →
       # storefront; voucher endpoint 503 → 2xx; SME tenant pipeline
       # reconciliation. Refs #1966 #1741 #1949 #1943.
-      version: 1.4.206
+      version: 1.4.207
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/infra/hetzner/variables.tf
+++ b/infra/hetzner/variables.tf
@@ -38,7 +38,7 @@ variable "sovereign_deployment_id" {
 
 variable "marketplace_enabled" {
   type        = string
-  description = "When 'true', bp-catalyst-platform 1.3.0+ renders the marketplace + tenant-wildcard HTTPRoutes exposing marketplace.<sov> + *.<sov>. Default 'true' as of TBD-V4 (issue #1968, 2026-05-19) — franchised Sovereigns provision marketplace-enabled out of the box; operator opts OUT via the wizard's StepMarketplace toggle. Paired with the chart-side `${MARKETPLACE_ENABLED:-true}` slot fallback shipped in PR #1967."
+  description = "When 'true', bp-catalyst-platform 1.3.0+ renders the marketplace + tenant-wildcard HTTPRoutes exposing marketplace.<sov> + *.<sov>. Default 'true' as of TBD-V4 (issue #1968, 2026-05-19) — franchised Sovereigns provision marketplace-enabled out of the box; operator opts OUT via the wizard's StepMarketplace toggle. Paired with the chart-side $${MARKETPLACE_ENABLED:-true} slot fallback shipped in PR #1967."
   default     = "true"
   validation {
     condition     = contains(["true", "false"], var.marketplace_enabled)

--- a/infra/hetzner/variables.tf
+++ b/infra/hetzner/variables.tf
@@ -38,8 +38,8 @@ variable "sovereign_deployment_id" {
 
 variable "marketplace_enabled" {
   type        = string
-  description = "When 'true', bp-catalyst-platform 1.3.0+ renders the marketplace + tenant-wildcard HTTPRoutes exposing marketplace.<sov> + *.<sov>. Operator opt-in (issue #710). Default 'false' for non-marketplace Sovereigns."
-  default     = "false"
+  description = "When 'true', bp-catalyst-platform 1.3.0+ renders the marketplace + tenant-wildcard HTTPRoutes exposing marketplace.<sov> + *.<sov>. Default 'true' as of TBD-V4 (issue #1968, 2026-05-19) — franchised Sovereigns provision marketplace-enabled out of the box; operator opts OUT via the wizard's StepMarketplace toggle. Paired with the chart-side `${MARKETPLACE_ENABLED:-true}` slot fallback shipped in PR #1967."
+  default     = "true"
   validation {
     condition     = contains(["true", "false"], var.marketplace_enabled)
     error_message = "marketplace_enabled must be the string 'true' or 'false'."

--- a/products/catalyst/bootstrap/api/internal/handler/deployments.go
+++ b/products/catalyst/bootstrap/api/internal/handler/deployments.go
@@ -881,7 +881,17 @@ func (d *Deployment) State() map[string]any {
 }
 
 func (h *Handler) CreateDeployment(w http.ResponseWriter, r *http.Request) {
-	var req provisioner.Request
+	// TBD-V4 (issue #1968, 2026-05-19) — pre-initialise Request defaults
+	// BEFORE json.Decode so a body that OMITS `marketplaceEnabled`
+	// (legacy API caller, hand-crafted curl, future automation that
+	// doesn't know about the field) lands with MarketplaceEnabled=true.
+	// The encoding/json package only assigns fields present in the body,
+	// so an explicit `"marketplaceEnabled": false` from the wizard still
+	// wins (canonical pointer-bool-emulation pattern for default-true
+	// bool fields without changing the struct shape). Paired with the
+	// chart-side `${MARKETPLACE_ENABLED:-true}` slot fallback (PR #1967)
+	// and the matching variables.tf default flip.
+	req := provisioner.Request{MarketplaceEnabled: true}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		http.Error(w, "invalid request body: "+err.Error(), http.StatusBadRequest)
 		return

--- a/products/catalyst/bootstrap/api/internal/handler/deployments_test.go
+++ b/products/catalyst/bootstrap/api/internal/handler/deployments_test.go
@@ -211,6 +211,79 @@ func TestCreateDeployment_DerivesObjectStorageBucketFromFQDN(t *testing.T) {
 	}
 }
 
+// TBD-V4 (issue #1968, 2026-05-19): a deployment POST that OMITS the
+// `marketplaceEnabled` field MUST land with Request.MarketplaceEnabled=true.
+// CreateDeployment pre-initialises the Request before json.Decode (the
+// canonical Go pattern for default-true bool fields without a struct shape
+// change), so the encoding/json package's "absent key leaves field
+// untouched" semantics fall through to the pre-init value. The matching
+// chart-side slot fallback `${MARKETPLACE_ENABLED:-true}` shipped in PR
+// #1967; this handler-side flip closes the trace-end-to-end gap so a
+// franchised Sovereign provisions marketplace-enabled out of the box.
+// Test asserts both the canonical "field omitted" case (defaults true)
+// AND the "wizard explicitly disables" case (false survives the decode).
+func TestCreateDeployment_MarketplaceEnabledDefaultsTrue(t *testing.T) {
+	t.Setenv("DYNADOT_MANAGED_DOMAINS", "omani.works")
+	t.Setenv("CATALYST_GHCR_PULL_TOKEN", "ghp_TEST_PLACEHOLDER_NOT_REAL")
+	t.Setenv("CATALYST_HARBOR_ROBOT_TOKEN", "harbor_TEST_PLACEHOLDER")
+
+	cases := []struct {
+		name           string
+		marketplaceKey bool // include the key in the body
+		marketplaceVal bool // value when included
+		want           bool // expected dep.Request.MarketplaceEnabled
+	}{
+		{name: "omitted-defaults-true", marketplaceKey: false, want: true},
+		{name: "explicit-true-passes-through", marketplaceKey: true, marketplaceVal: true, want: true},
+		{name: "explicit-false-wizard-opt-out-survives", marketplaceKey: true, marketplaceVal: false, want: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			pdm.ResetManagedDomains()
+			fake := &fakePDM{}
+			h := NewWithPDM(slog.Default(), fake)
+
+			body := map[string]any{
+				"sovereignFQDN":          "k8s.acme.io",
+				"sovereignDomainMode":    "byo",
+				"sovereignSubdomain":     "k8s",
+				"hetznerToken":           "tok",
+				"hetznerProjectID":       "proj",
+				"region":                 "fsn1",
+				"orgName":                "Acme",
+				"orgEmail":               "ops@acme.io",
+				"sshPublicKey":           "ssh-ed25519 AAAA test",
+				"objectStorageRegion":    "fsn1",
+				"objectStorageAccessKey": "TESTACCESSKEY1234567",
+				"objectStorageSecretKey": "TESTSECRETKEY1234567890123456789012345678",
+			}
+			if tc.marketplaceKey {
+				body["marketplaceEnabled"] = tc.marketplaceVal
+			}
+			raw, _ := json.Marshal(body)
+
+			w := httptest.NewRecorder()
+			r := httptest.NewRequest(http.MethodPost, "/api/v1/deployments", bytes.NewReader(raw))
+			h.CreateDeployment(w, r)
+			if w.Code != http.StatusCreated {
+				t.Fatalf("status=%d body=%s", w.Code, w.Body.String())
+			}
+			var resp struct {
+				ID string `json:"id"`
+			}
+			_ = json.Unmarshal(w.Body.Bytes(), &resp)
+			val, ok := h.deployments.Load(resp.ID)
+			if !ok {
+				t.Fatalf("deployment %s missing from sync.Map", resp.ID)
+			}
+			dep := val.(*Deployment)
+			if dep.Request.MarketplaceEnabled != tc.want {
+				t.Fatalf("MarketplaceEnabled = %v, want %v (TBD-V4 default-flip semantics)", dep.Request.MarketplaceEnabled, tc.want)
+			}
+		})
+	}
+}
+
 // Issue #748 — orgEmail must match the authenticated session. A signed-in
 // operator who tries to POST a deployment whose req.OrgEmail belongs to
 // some OTHER identity must receive 403, NEVER 201. The session header

--- a/products/catalyst/bootstrap/ui/src/entities/deployment/store.test.ts
+++ b/products/catalyst/bootstrap/ui/src/entities/deployment/store.test.ts
@@ -91,9 +91,15 @@ describe('wizard store — registrar credentials', () => {
 })
 
 describe('wizard store — marketplace mode (#710 wave 3a)', () => {
-  it('defaults marketplaceEnabled to false and brand to empty strings', () => {
+  // TBD-V4 (issue #1968, 2026-05-19): default flipped false → true at source
+  // so franchised Sovereigns provision marketplace-enabled out of the box.
+  // The wizard's StepMarketplace toggle is now an opt-OUT control. PR #1967
+  // already flipped the chart-side slot fallback to `${MARKETPLACE_ENABLED:-
+  // true}`; this test mirrors the matching source-side default flip on the
+  // wizard store + INITIAL_WIZARD_STATE (model.ts:496).
+  it('defaults marketplaceEnabled to true and brand to empty strings', () => {
     const s = useWizardStore.getState()
-    expect(s.marketplaceEnabled).toBe(false)
+    expect(s.marketplaceEnabled).toBe(true)
     expect(s.marketplaceBrand).toEqual({ name: '', tagline: '', primaryColor: '' })
   })
 

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -1,5 +1,21 @@
 apiVersion: v2
 name: bp-catalyst-platform
+# 1.4.207 — TBD-V4 (issue #1968, 2026-05-19): source-side default flip
+# for `marketplaceEnabled` (handler pre-init Request{MarketplaceEnabled:
+# true} before json.Decode + variables.tf default "true" + wizard store
+# test). PR #1967 changed only the chart slot fallback to
+# `${MARKETPLACE_ENABLED:-true}`; provisioner.go:1213 was still writing
+# `MARKETPLACE_ENABLED: "false"` literal substituting through, so
+# franchised Sovereigns came up marketplace-disabled. This bump pairs
+# the source-side defaults flip so omitting `marketplaceEnabled` from
+# the deployment POST (legacy API caller, hand-crafted curl) defaults
+# the bool to true via Go's canonical "pre-init before Decode" pattern.
+# Wizard's explicit `false` still wins (StepMarketplace opt-OUT toggle).
+# Chart version bump (1.4.206 → 1.4.207) is the canonical signal that
+# the bootstrap-kit pin moved, paired with the matching version: bump
+# in clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml.
+# Refs #1968 #1966 #1741.
+#
 # 1.4.206 — TBD-A62 (issue #1966, 2026-05-19): default-flip
 # `MARKETPLACE_ENABLED` from `false` to `true` in
 # clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml so every
@@ -1705,8 +1721,8 @@ name: bp-catalyst-platform
 # was already shipped on 1.4.197 (PR #1820 lineage); this completes
 # the data-layer side so the dropdown finally appears on multi-region
 # Sovereigns. Refs #1821, DoD D20.
-version: 1.4.206
-appVersion: 1.4.206
+version: 1.4.207
+appVersion: 1.4.207
 # 1.4.183 — fix(httproute): omit default sectionName so multi-zone
 # Sovereigns attach via Cilium Gateway hostname matcher (Closes #1884,
 # TBD-A30). Pre-1.4.183 every catalyst-system HTTPRoute pinned


### PR DESCRIPTION
## Summary

PR #1967 changed only the bootstrap-kit slot fallback to `${MARKETPLACE_ENABLED:-true}`, but `provisioner.go:1213` was still writing the literal string `MARKETPLACE_ENABLED: "false"` (because `Request.MarketplaceEnabled bool` zero-value = `false`) — substituting through the envsubst-replaced default and leaving franchised Sovereigns marketplace-disabled. This PR flips the default at all three source-side layers so the chain converges.

Three single-line defaults flipped:

1. **`handler/deployments.go` `CreateDeployment`** — pre-initialise `provisioner.Request{MarketplaceEnabled: true}` BEFORE `json.Decode`. Canonical Go pattern for default-true bool fields: `encoding/json` only assigns fields present in the body, so an OMITTED `marketplaceEnabled` keeps the pre-init `true`; an EXPLICIT `marketplaceEnabled: false` (StepMarketplace opt-OUT) still wins. No struct-shape change.
2. **`infra/hetzner/variables.tf`** — `marketplace_enabled` default `"false"` → `"true"` so `tofu plan` outside catalyst-api (CI mocks, manual replays) matches the new semantics.
3. **UI `store.test.ts`** — update the stale assertion to `expect(s.marketplaceEnabled).toBe(true)`. `INITIAL_WIZARD_STATE.marketplaceEnabled` has been `true` since the D27 zero-touch ruling on 2026-05-16; the persist-rehydrate path already defaults missing values to true (`store.ts:789`). This test was the last remnant of the pre-D27 default.

Bumps `bp-catalyst-platform` Chart.yaml `1.4.206 → 1.4.207` and the matching bootstrap-kit pin so the chart-pin-versus-GHCR CI gate accepts the new release.

New unit test `TestCreateDeployment_MarketplaceEnabledDefaultsTrue` covers all three semantics:
- `omitted-defaults-true` → `MarketplaceEnabled=true`
- `explicit-true-passes-through` → `MarketplaceEnabled=true`
- `explicit-false-wizard-opt-out-survives` → `MarketplaceEnabled=false`

Closes #1968
Refs #1966 #1741

## Test plan

- [x] `go build ./...` clean (api package)
- [x] `go test ./internal/handler/ -run TestCreateDeployment_MarketplaceEnabledDefaultsTrue` — 3/3 subtests PASS
- [x] `go test ./internal/provisioner/` — unchanged tests pass (writeTfvars line 1213 logic intact for explicit-false-from-wizard path)
- [ ] CI runs vitest on `store.test.ts` — new assertion passes
- [ ] CI runs `tofu validate infra/hetzner/` — `default = "true"` satisfies the `contains(["true","false"], var.marketplace_enabled)` validation block

🤖 Generated with [Claude Code](https://claude.com/claude-code)