### PR TITLE
chore(ci): re-enable cosmetic-guards workflow after PR α + β (Closes #1956)

### DIFF
--- a/.github/workflows/cosmetic-guards.yaml
+++ b/.github/workflows/cosmetic-guards.yaml
@@ -40,12 +40,6 @@ jobs:
     name: Playwright cosmetic + step-flow guards
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    # TEMPORARILY DISABLED — 38/50 tests failing on main due to UI
-    # regression that breaks wizard StepComponents grid + multiple
-    # canonical surfaces. Re-enable after root-cause fix.
-    # Tracking issue: https://github.com/openova-io/openova/issues/1956
-    # Blocking PRs unblocked by this disable: #1939, #1940, #1942, #1955
-    if: false
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

PR #1957 temporarily disabled the **Cosmetic + step-flow regression guards** workflow with `if: false` as an emergency unblock for #1939, #1940, #1942, #1955 while the underlying UI regression was being root-caused in #1956.

Both companion PRs that address the test failures have now merged:

| PR | Title | Tests fixed |
|----|-------|-------------|
| #1957 | (disable, this PR reverts) | n/a |
| #1970 | PR α — spec re-alignment, wizard step drift + cloud query routes + jobs header | 8 |
| #1973 | PR β — provision route mocks for `/provision/test-deployment-id` | 11 |

Total: 19/19 in-scope tests across Categories A/B/C/D/E per the #1956 diagnosis ([root-cause comment](https://github.com/openova-io/openova/issues/1956#issuecomment-4489515173)).

## Change

Surgical revert of the 6 lines PR #1957 added: drop the `if: false` guard + tracking comment block. No other workflow modifications.

```diff
-    # TEMPORARILY DISABLED — 38/50 tests failing on main due to UI
-    # regression that breaks wizard StepComponents grid + multiple
-    # canonical surfaces. Re-enable after root-cause fix.
-    # Tracking issue: https://github.com/openova-io/openova/issues/1956
-    # Blocking PRs unblocked by this disable: #1939, #1940, #1942, #1955
-    if: false
```

## Test plan

- [ ] CI on this PR: the `Playwright cosmetic + step-flow guards` check (re-enabled here) runs and **passes**
- [ ] After merge: same check passes on `main` push event

If the check **fails** on this PR, that means PR α + β did **not** fully address the regression — do not merge; reopen #1956 with the new failure set.

Closes #1956