### PR TITLE
fix(catalyst-ui): JobsTable batch chip — restore element/testid (Refs #1976)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -716,7 +716,7 @@ spec:
       # map. Unblocks D29 customer-journey: marketplace.<sov> 404 →
       # storefront; voucher endpoint 503 → 2xx; SME tenant pipeline
       # reconciliation. Refs #1966 #1741 #1949 #1943.
-      version: 1.4.209
+      version: 1.4.210
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/JobsTable.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/JobsTable.tsx
@@ -477,9 +477,27 @@ function useJobLinkBuilder(): (jobId: string) => string {
   }
 }
 
+/**
+ * useFlowLinkBuilder — chroot-correct Link `to` for the per-batch flow
+ * canvas. Mirrors useJobLinkBuilder routing (mother vs Sovereign). The
+ * `?scope=batch:<id>` query filters the canvas to a single batch
+ * swimlane (issue #1976 cosmetic-guard test 33; FlowPage scope handling
+ * is TBD-A66).
+ */
+function useFlowLinkBuilder(): (batchId: string) => string {
+  const params = useParams({ strict: false }) as { deploymentId?: string }
+  const isSovereign = DETECTED_MODE.mode === 'sovereign'
+  const depId = params.deploymentId ?? ''
+  return (batchId: string) => {
+    const qs = `?scope=batch:${encodeURIComponent(batchId)}`
+    return isSovereign || !depId ? `/flow${qs}` : `/provision/${depId}/flow${qs}`
+  }
+}
+
 function JobRow({ job, parentLabel }: JobRowProps) {
   const started = formatRelative(job.startedAt)
   const jobLink = useJobLinkBuilder()
+  const flowLink = useFlowLinkBuilder()
   return (
     <tr
       className="jobs-row"
@@ -514,18 +532,29 @@ function JobRow({ job, parentLabel }: JobRowProps) {
         )}
       </td>
       <td className="jobs-cell jobs-cell-parent">
-        {/* Parent chip — links to that parent group's home page,
-            which renders the same canvas + log pane scoped to the
-            group as its host job (issue #351). */}
+        {/* Parent chip → parent group's home page (issue #351).
+            Sibling batch chip → per-batch flow canvas (issue #1976
+            test 33). Both share this cell to preserve the [name, app,
+            deps, parent, status, started, duration] header set. */}
         {job.parentId ? (
-          <Link
-            to={jobLink(job.parentId) as never}
-            className="jobs-chip jobs-chip-parent jobs-chip-link"
-            data-testid={`jobs-cell-parent-${job.id}`}
-            title={parentLabel}
-          >
-            {parentLabel}
-          </Link>
+          <div className="jobs-chip-row">
+            <Link
+              to={jobLink(job.parentId) as never}
+              className="jobs-chip jobs-chip-parent jobs-chip-link"
+              data-testid={`jobs-cell-parent-${job.id}`}
+              title={parentLabel}
+            >
+              {parentLabel}
+            </Link>
+            <Link
+              to={flowLink(job.jobName) as never}
+              className="jobs-chip jobs-chip-batch jobs-chip-link"
+              data-testid={`jobs-cell-batch-${job.jobName}`}
+              title={`Open batch ${job.jobName} on the flow canvas`}
+            >
+              batch
+            </Link>
+          </div>
         ) : (
           <span className="jobs-empty-cell">—</span>
         )}
@@ -753,6 +782,7 @@ const JOBS_TABLE_CSS = `
 }
 .jobs-chip-app    { color: #38BDF8; border-color: rgba(56,189,248,0.25); }
 .jobs-chip-parent { color: #C084FC; border-color: rgba(192,132,252,0.25); }
+.jobs-chip-batch  { color: #FD6F00; border-color: rgba(253,111,0,0.25); }
 .jobs-chip-dep    { color: var(--color-text-dim); }
 .jobs-chip-link {
   text-decoration: none;

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -1,5 +1,14 @@
 apiVersion: v2
 name: bp-catalyst-platform
+# 1.4.210 — TBD-A70 (issue #1976, 2026-05-19): restore JobsTable batch
+# chip. JobsTable.tsx JobRow now renders a sibling `<Link>` next to the
+# parent chip with `data-testid=jobs-cell-batch-<jobName>` pointing at
+# the chroot-correct `/provision/<depId>/flow?scope=batch:<jobName>`
+# (mother) / `/flow?scope=batch:<jobName>` (Sovereign). The chip stays
+# inline in the existing parent column so the [name, app, deps, parent,
+# status, started, duration] header set is preserved (issue #204).
+# FlowPage `?scope=batch:` handling itself remains deferred (TBD-A66) —
+# this PR only restores the cosmetic-guard test 33 testid + href shape.
 # 1.4.209 — TBD-A64 PR γ (issue #1976, 2026-05-19): cosmetic regressions
 # caught by the cosmetic-guards e2e suite. THREE surgical fixes:
 #   1. wizard/steps/logoTone.ts — alloy tile background flipped from
@@ -1765,7 +1774,7 @@ name: bp-catalyst-platform
 # was already shipped on 1.4.197 (PR #1820 lineage); this completes
 # the data-layer side so the dropdown finally appears on multi-region
 # Sovereigns. Refs #1821, DoD D20.
-version: 1.4.209
+version: 1.4.210
 appVersion: 1.4.208
 # 1.4.183 — fix(httproute): omit default sectionName so multi-zone
 # Sovereigns attach via Cilium Gateway hostname matcher (Closes #1884,


### PR DESCRIPTION
## Summary

Restores the per-row **batch chip** the `@cosmetic-guard "JobsTable batch chip → /flow link"` e2e test asserts (cosmetic-guards.spec.ts test 33). One of the 8 regressions deferred after PR γ (#1980) shipped only 3 of 11.

`JobRow` now renders a sibling `<Link>` next to the parent chip in the existing `jobs-cell-parent` cell:

- `data-testid="jobs-cell-batch-<jobName>"`
- href `/provision/<deploymentId>/flow?scope=batch:<jobName>` (mother monitoring surface) / `/flow?scope=batch:<jobName>` (Sovereign chroot)

The chip stays inline (no new `<th>` / `<td>`) so the canonical `[name, app, deps, parent, status, started, duration]` header set is preserved (issue #204 polish).

`useFlowLinkBuilder()` mirrors the existing `useJobLinkBuilder()` chroot logic (mother vs Sovereign hostname → mother path keeps `/provision/<id>` prefix; Sovereign collapses to root `/flow`).

**FlowPage `?scope=batch:` filter handling itself remains deferred (TBD-A66 in the #1976 triage); this PR only restores the cosmetic-guard test 33 testid + href shape so the regression flips green. Per the triage, the LARGE deferred items (AppDetail layout, `/flow` route, FloatingLogPane, StatusStrip mode toggle, JobDetail v3) remain open under TBD-A65/A66/A67/A68/A69.**

## Chart

- `products/catalyst/chart/Chart.yaml`: `1.4.209 → 1.4.210`
- `clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml`: pin bumped

## Test plan

- [x] `tsc -b --noEmit` clean (exit 0)
- [x] `eslint src/pages/sovereign/JobsTable.tsx` introduces zero new errors (the 6 pre-existing `react-refresh/only-export-components` errors on lines 47/65/94/121/143/160 are unchanged from `main`)
- [ ] Cosmetic-guard test 33 `JobsTable batch chip [data-testid=jobs-cell-batch-bp-cilium]` flips GREEN
- [ ] Cosmetic-guard test 4 (header set `[name, app, deps, parent, status, started, duration]`) stays GREEN — chip is inline in parent cell, no new column

Refs #1976

🤖 Generated with [Claude Code](https://claude.com/claude-code)