### PR TITLE
feat(catalyst-ui): admin sidebar — add Domains/Billing/Team nav (Refs #1976, A65)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -716,7 +716,7 @@ spec:
       # map. Unblocks D29 customer-journey: marketplace.<sov> 404 →
       # storefront; voucher endpoint 503 → 2xx; SME tenant pipeline
       # reconciliation. Refs #1966 #1741 #1949 #1943.
-      version: 1.4.209
+      version: 1.4.210
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/bootstrap/ui/src/app/router.tsx
+++ b/products/catalyst/bootstrap/ui/src/app/router.tsx
@@ -89,6 +89,12 @@ import { PolicyDrilldownPage } from '@/pages/admin/compliance/PolicyDrilldownPag
 // Wave-2 Family-E (#1583, C11-008): standalone Falco runtime-alerts page.
 import { RuntimeAlertsPage } from '@/pages/admin/compliance/RuntimeAlertsPage'
 import { SettingsPage } from '@/pages/sovereign/SettingsPage'
+// A65 (Refs #1976) — admin sidebar nav stubs for Domains / Billing /
+// Team. The pages render an honest "API pending" empty state; the
+// canonical sidebar entries mirror core/console/src/components/Sidebar.svelte.
+import { DomainsPage } from '@/pages/sovereign/DomainsPage'
+import { BillingPage } from '@/pages/sovereign/BillingPage'
+import { TeamPage } from '@/pages/sovereign/TeamPage'
 import { NotificationsPage } from '@/pages/sovereign/NotificationsPage'
 // Sovereign-mode /console/* routes use the same canonical components as
 // /provision/$deploymentId/* — see the SovereignConsoleRedirect helper
@@ -1062,6 +1068,37 @@ const provisionSettingsRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: '/provision/$deploymentId/settings',
   component: SettingsPage,
+  beforeLoad: provisionAuthGuard,
+})
+
+/* ── A65 admin sidebar nav stubs (Refs #1976) ────────────────────
+ *
+ * cosmetic-guards CANONICAL_SIDEBAR_LABELS asserts the admin sidebar
+ * exposes Domains / Billing / Team nav items mirrored from
+ * core/console/src/components/Sidebar.svelte. These three routes are
+ * the destinations for those nav items; each component renders an
+ * honest "API pending" empty state until the real surface ships.
+ *
+ *   /provision/$deploymentId/domains  → ParentDomain pool (Refs #1830)
+ *   /provision/$deploymentId/billing  → Deployment billing oversight
+ *   /provision/$deploymentId/team     → Operator team roster
+ */
+const provisionDomainsRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/provision/$deploymentId/domains',
+  component: DomainsPage,
+  beforeLoad: provisionAuthGuard,
+})
+const provisionBillingRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/provision/$deploymentId/billing',
+  component: BillingPage,
+  beforeLoad: provisionAuthGuard,
+})
+const provisionTeamRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/provision/$deploymentId/team',
+  component: TeamPage,
   beforeLoad: provisionAuthGuard,
 })
 
@@ -2063,6 +2100,10 @@ const routeTree = rootRoute.addChildren([
   provisionBlueprintsPublishRoute,
   provisionBlueprintsCurateRoute,
   provisionSettingsRoute,
+  // A65 (Refs #1976) — admin sidebar nav stubs.
+  provisionDomainsRoute,
+  provisionBillingRoute,
+  provisionTeamRoute,
   provisionNotificationsRoute,
   // Compliance — slice U (#1096). Mother-side admin routes.
   adminComplianceSREDashboardRoute,

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/BillingPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/BillingPage.tsx
@@ -1,0 +1,78 @@
+/**
+ * BillingPage — Sovereign admin billing oversight surface.
+ *
+ * Refs #1976 (TBD-A64, A65 deferred sub-bug) — cosmetic-guards
+ * CANONICAL_SIDEBAR_LABELS asserts the admin sidebar exposes a
+ * `Billing` nav item mirrored from
+ * core/console/src/components/Sidebar.svelte. This page is the
+ * destination for that nav item.
+ *
+ * Scope: STUB. The real billing surface lives under the Sovereign
+ * Console chroot at /bss/billing (Family F, Wave 3). This page is the
+ * deployment-scoped landing for billing oversight from the catalyst
+ * admin sidebar; the actual invoice/payment-method/usage panels are
+ * tracked as a follow-up issue.
+ *
+ * Per docs/INVIOLABLE-PRINCIPLES.md (honest empty state) — this stub
+ * surfaces a clearly-labelled "API pending" message + a
+ * `data-testid="pending-api"` hook so the operator sees the surface
+ * but cannot mistake it for a wired feature.
+ */
+
+import { PortalShell } from './PortalShell'
+import { useDeploymentEvents } from './useDeploymentEvents'
+import { useResolvedDeploymentId } from '@/shared/lib/useResolvedDeploymentId'
+
+export interface BillingPageProps {
+  /** Test seam — disables the live SSE attach. */
+  disableStream?: boolean
+}
+
+export function BillingPage({ disableStream = false }: BillingPageProps = {}) {
+  const { deploymentId: resolvedId } = useResolvedDeploymentId()
+  const deploymentId = resolvedId ?? ''
+
+  const { snapshot } = useDeploymentEvents({
+    deploymentId,
+    applicationIds: [],
+    disableStream,
+  })
+  const sovereignFQDN =
+    snapshot?.sovereignFQDN ?? snapshot?.result?.sovereignFQDN ?? null
+
+  return (
+    <PortalShell
+      deploymentId={deploymentId}
+      sovereignFQDN={sovereignFQDN}
+      pageTitle="Billing"
+    >
+      <div className="mx-auto max-w-3xl" data-testid="billing-page">
+        <header className="mb-4">
+          <p className="text-sm text-[var(--color-text-dim)]">
+            Review invoices, payment methods, and usage for this Sovereign.
+          </p>
+        </header>
+        <section
+          className="rounded-lg border border-[var(--color-border)] bg-[var(--color-bg-2)] p-6"
+          data-testid="billing-pending-api"
+        >
+          <h2 className="text-base font-semibold text-[var(--color-text-strong)]">
+            API pending
+          </h2>
+          <p className="mt-2 text-sm text-[var(--color-text-dim)]">
+            The deployment-scoped billing surface is not yet wired in this
+            build. Full BSS billing surfaces live under the Sovereign Console
+            chroot at <code>/bss/billing</code>; the deployment-scoped
+            invoice/usage panels ship in a follow-up release.
+          </p>
+          <p
+            className="mt-3 text-xs text-[var(--color-text-dim)]"
+            data-testid="pending-api"
+          >
+            pending-api
+          </p>
+        </section>
+      </div>
+    </PortalShell>
+  )
+}

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/DomainsPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/DomainsPage.tsx
@@ -1,0 +1,81 @@
+/**
+ * DomainsPage — Sovereign admin parent-domain pool management surface.
+ *
+ * Refs #1976 (TBD-A64, A65 deferred sub-bug) — cosmetic-guards
+ * CANONICAL_SIDEBAR_LABELS asserts the admin sidebar exposes a
+ * `Domains` nav item mirrored from
+ * core/console/src/components/Sidebar.svelte. This page is the
+ * destination for that nav item.
+ *
+ * Scope: STUB. The real ParentDomain CRD wiring + DNS propagation
+ * panels + registrar-token rotation surface is tracked separately
+ * (Refs #1830 ParentDomain CRD pool population; #829 parent-domain
+ * admin surface). A follow-up issue will replace this stub with the
+ * full pool-management UI.
+ *
+ * Per docs/INVIOLABLE-PRINCIPLES.md (honest empty state) — this stub
+ * surfaces a clearly-labelled "API pending" message + a
+ * `data-testid="pending-api"` hook so the operator sees the surface
+ * but cannot mistake it for a wired feature. The stub is NOT hidden
+ * behind a null-guard or a feature flag; the route + the chrome are
+ * live so the canonical sidebar nav resolves cleanly.
+ */
+
+import { PortalShell } from './PortalShell'
+import { useDeploymentEvents } from './useDeploymentEvents'
+import { useResolvedDeploymentId } from '@/shared/lib/useResolvedDeploymentId'
+
+export interface DomainsPageProps {
+  /** Test seam — disables the live SSE attach. */
+  disableStream?: boolean
+}
+
+export function DomainsPage({ disableStream = false }: DomainsPageProps = {}) {
+  const { deploymentId: resolvedId } = useResolvedDeploymentId()
+  const deploymentId = resolvedId ?? ''
+
+  const { snapshot } = useDeploymentEvents({
+    deploymentId,
+    applicationIds: [],
+    disableStream,
+  })
+  const sovereignFQDN =
+    snapshot?.sovereignFQDN ?? snapshot?.result?.sovereignFQDN ?? null
+
+  return (
+    <PortalShell
+      deploymentId={deploymentId}
+      sovereignFQDN={sovereignFQDN}
+      pageTitle="Domains"
+    >
+      <div className="mx-auto max-w-3xl" data-testid="domains-page">
+        <header className="mb-4">
+          <p className="text-sm text-[var(--color-text-dim)]">
+            Manage the parent-domain pool. New tenant subdomains are minted
+            against the active pool; rotate registrar credentials and review
+            DNS propagation status here.
+          </p>
+        </header>
+        <section
+          className="rounded-lg border border-[var(--color-border)] bg-[var(--color-bg-2)] p-6"
+          data-testid="domains-pending-api"
+        >
+          <h2 className="text-base font-semibold text-[var(--color-text-strong)]">
+            API pending
+          </h2>
+          <p className="mt-2 text-sm text-[var(--color-text-dim)]">
+            The ParentDomain CRD pool-management surface is not yet wired in
+            this build. The canonical admin entry-point now resolves; full
+            functionality ships in a follow-up release (Refs #1830, #829).
+          </p>
+          <p
+            className="mt-3 text-xs text-[var(--color-text-dim)]"
+            data-testid="pending-api"
+          >
+            pending-api
+          </p>
+        </section>
+      </div>
+    </PortalShell>
+  )
+}

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/Sidebar.test.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/Sidebar.test.tsx
@@ -5,8 +5,11 @@
  *   • Renders the OpenOva mark inside the 56px logo header
  *   • Surfaces the deployment id (or sovereignFQDN when supplied) as
  *     the "tenant" label in place of the canonical Tenant switcher
- *   • Renders Apps + Jobs + Dashboard + Cloud + Settings nav items
- *     (the explicit subset for the Sovereign-provision surface)
+ *   • Renders Apps + Jobs + Dashboard + Cloud + Users + Domains +
+ *     Billing + Team + Settings nav items. Domains / Billing / Team
+ *     were added in A65 (Refs #1976) so the cosmetic-guards
+ *     CANONICAL_SIDEBAR_LABELS spec resolves; the corresponding pages
+ *     are stubs that render an honest "API pending" empty state.
  *   • Active item carries `aria-current="page"`
  *   • Cloud is a SINGLE flat <Link> (no accordion, no chevron, no
  *     sub-items) that navigates to /provision/$id/cloud
@@ -79,6 +82,22 @@ function renderSidebarAt(initialPath: string, sovereignFQDN?: string | null) {
     path: '/provision/$deploymentId/settings',
     component: SidebarHost,
   })
+  // A65 (Refs #1976) — Domains / Billing / Team admin nav stubs.
+  const domainsRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/provision/$deploymentId/domains',
+    component: SidebarHost,
+  })
+  const billingRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/provision/$deploymentId/billing',
+    component: SidebarHost,
+  })
+  const teamRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/provision/$deploymentId/team',
+    component: SidebarHost,
+  })
   const tree = rootRoute.addChildren([
     provisionRoute,
     jobsRoute,
@@ -86,6 +105,9 @@ function renderSidebarAt(initialPath: string, sovereignFQDN?: string | null) {
     cloudRoute.addChildren([cloudArchitectureRoute, cloudComputeClustersRoute]),
     wizardRoute,
     settingsRoute,
+    domainsRoute,
+    billingRoute,
+    teamRoute,
   ])
   const router = createRouter({
     routeTree: tree,
@@ -130,19 +152,57 @@ describe('Sidebar — chrome', () => {
 })
 
 describe('Sidebar — top-level navigation', () => {
-  it('renders Apps + Jobs + Dashboard + Cloud + Settings nav items', async () => {
+  it('renders Apps + Jobs + Dashboard + Cloud + Users + Domains + Billing + Team + Settings nav items', async () => {
     renderSidebarAt('/provision/d-test-1234')
     expect(await screen.findByTestId('sov-nav-apps')).toBeTruthy()
     expect(await screen.findByTestId('sov-nav-jobs')).toBeTruthy()
     expect(await screen.findByTestId('sov-nav-dashboard')).toBeTruthy()
     expect(await screen.findByTestId('sov-nav-cloud')).toBeTruthy()
+    expect(await screen.findByTestId('sov-nav-users')).toBeTruthy()
     expect(await screen.findByTestId('sov-nav-settings')).toBeTruthy()
-    // Canonical-but-omitted items must NOT render.
-    expect(screen.queryByTestId('sov-nav-domains')).toBeNull()
-    expect(screen.queryByTestId('sov-nav-billing')).toBeNull()
-    expect(screen.queryByTestId('sov-nav-team')).toBeNull()
+    // A65 (Refs #1976) — canonical core/console nav labels now mirrored
+    // here so cosmetic-guards CANONICAL_SIDEBAR_LABELS resolves.
+    expect(await screen.findByTestId('sov-nav-domains')).toBeTruthy()
+    expect(await screen.findByTestId('sov-nav-billing')).toBeTruthy()
+    expect(await screen.findByTestId('sov-nav-team')).toBeTruthy()
     // Legacy flat Infrastructure entry remains gone.
     expect(screen.queryByTestId('sov-nav-infrastructure')).toBeNull()
+  })
+
+  it('Domains / Billing / Team links target /provision/$id/{domains,billing,team}', async () => {
+    renderSidebarAt('/provision/d-test-1234')
+    const domains = (await screen.findByTestId('sov-nav-domains')) as HTMLAnchorElement
+    expect(domains.getAttribute('href') ?? '').toMatch(
+      /\/provision\/d-test-1234\/domains$/,
+    )
+    const billing = (await screen.findByTestId('sov-nav-billing')) as HTMLAnchorElement
+    expect(billing.getAttribute('href') ?? '').toMatch(
+      /\/provision\/d-test-1234\/billing$/,
+    )
+    const team = (await screen.findByTestId('sov-nav-team')) as HTMLAnchorElement
+    expect(team.getAttribute('href') ?? '').toMatch(
+      /\/provision\/d-test-1234\/team$/,
+    )
+  })
+
+  it('marks Domains active on /provision/.../domains', async () => {
+    renderSidebarAt('/provision/d-test-1234/domains')
+    const domains = await screen.findByTestId('sov-nav-domains')
+    expect(domains.getAttribute('aria-current')).toBe('page')
+    const apps = screen.getByTestId('sov-nav-apps')
+    expect(apps.getAttribute('aria-current')).toBeNull()
+  })
+
+  it('marks Billing active on /provision/.../billing', async () => {
+    renderSidebarAt('/provision/d-test-1234/billing')
+    const billing = await screen.findByTestId('sov-nav-billing')
+    expect(billing.getAttribute('aria-current')).toBe('page')
+  })
+
+  it('marks Team active on /provision/.../team', async () => {
+    renderSidebarAt('/provision/d-test-1234/team')
+    const team = await screen.findByTestId('sov-nav-team')
+    expect(team.getAttribute('aria-current')).toBe('page')
   })
 
   it('marks Apps active when on the provision root', async () => {

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/Sidebar.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/Sidebar.tsx
@@ -14,7 +14,18 @@
  *       — dashboard               → /sovereign/provision/$deploymentId/dashboard
  *       — cloud                   → /sovereign/provision/$deploymentId/cloud
  *       — users                   → /sovereign/provision/$deploymentId/users
+ *       — domains                 → /sovereign/provision/$deploymentId/domains
+ *       — billing                 → /sovereign/provision/$deploymentId/billing
+ *       — team                    → /sovereign/provision/$deploymentId/team
  *       — settings                → /sovereign/provision/$deploymentId/settings
+ *
+ *     Domains / Billing / Team (Refs #1976, A65 — cosmetic-guards
+ *     CANONICAL_SIDEBAR_LABELS parity): admin surfaces mirrored from
+ *     core/console/src/components/Sidebar.svelte. The corresponding
+ *     page components today render an honest "API pending" empty
+ *     state — full backend wiring is tracked in follow-up issues
+ *     (Domains → Refs #1830 ParentDomain CRD; Billing → BSS chroot;
+ *     Team → operator roster surface).
  *
  *     The Cloud entry is a single flat <Link> (no accordion, no
  *     chevron, no sub-items). The parent CloudPage owns the in-page
@@ -48,7 +59,16 @@ interface SidebarProps {
 /* ── Top-level (flat) nav items ─────────────────────────────────── */
 
 interface FlatNavItem {
-  id: 'apps' | 'jobs' | 'dashboard' | 'cloud' | 'users' | 'settings'
+  id:
+    | 'apps'
+    | 'jobs'
+    | 'dashboard'
+    | 'cloud'
+    | 'users'
+    | 'domains'
+    | 'billing'
+    | 'team'
+    | 'settings'
   label: string
   to:
     | '/provision/$deploymentId'
@@ -56,6 +76,9 @@ interface FlatNavItem {
     | '/provision/$deploymentId/dashboard'
     | '/provision/$deploymentId/cloud'
     | '/provision/$deploymentId/users'
+    | '/provision/$deploymentId/domains'
+    | '/provision/$deploymentId/billing'
+    | '/provision/$deploymentId/team'
     | '/provision/$deploymentId/settings'
   /** SVG path data — same `d` strings as core/console for visual parity. */
   icon: string
@@ -103,6 +126,42 @@ const FLAT_NAV: FlatNavItem[] = [
     // Tabler IconUsers — verbatim path data, viewBox 24x24.
     icon: 'M9 7a4 4 0 100 8 4 4 0 000-8zM3 21v-2a4 4 0 014-4h4a4 4 0 014 4v2M16 3.13a4 4 0 010 7.75M21 21v-2a4 4 0 00-3-3.87',
   },
+  // Domains — admin surface for parent-domain pool management. Mirrors
+  // the canonical core/console Sidebar.svelte nav array
+  // (Refs #1976 cosmetic-guards CANONICAL_SIDEBAR_LABELS; A65). Backed
+  // by /provision/$deploymentId/domains; the page is a stub for now
+  // and surfaces an honest "API pending" empty state — the real
+  // ParentDomain CRD wiring is tracked separately (Refs #1830).
+  {
+    id: 'domains',
+    label: 'Domains',
+    to: '/provision/$deploymentId/domains',
+    // Tabler IconWorld — verbatim path data, viewBox 24x24.
+    icon: 'M3 12a9 9 0 1 0 18 0a9 9 0 0 0 -18 0M3.6 9h16.8M3.6 15h16.8M11.5 3a17 17 0 0 0 0 18M12.5 3a17 17 0 0 1 0 18',
+  },
+  // Billing — admin billing oversight surface. Mirrors canonical
+  // core/console Sidebar.svelte nav array (Refs #1976; A65). Stub page
+  // for now — real BSS billing surfaces live under /bss/billing on the
+  // SovereignConsoleLayout chroot. Tracked separately as a follow-up.
+  {
+    id: 'billing',
+    label: 'Billing',
+    to: '/provision/$deploymentId/billing',
+    // Tabler IconReceipt — verbatim path data, viewBox 24x24.
+    icon: 'M5 21V5a2 2 0 0 1 2 -2h10a2 2 0 0 1 2 2v16l-3 -2l-2 2l-2 -2l-2 2l-2 -2l-3 2M9 7h6M9 11h6M9 15h4',
+  },
+  // Team — operator team management surface. Mirrors canonical
+  // core/console Sidebar.svelte nav array (Refs #1976; A65). Distinct
+  // from /users (deployment-scoped user-access list); Team is the
+  // organisation-level operator roster. Stub for now — real Team
+  // surface tracked separately.
+  {
+    id: 'team',
+    label: 'Team',
+    to: '/provision/$deploymentId/team',
+    // Tabler IconUsersGroup — verbatim path data, viewBox 24x24.
+    icon: 'M10 13a2 2 0 1 0 -4 0a2 2 0 0 0 4 0M8 21v-1a2 2 0 0 1 2 -2M16 13a2 2 0 1 0 -4 0a2 2 0 0 0 4 0M12 21v-1a2 2 0 0 0 -2 -2h-4a2 2 0 0 0 -2 2v1M22 13a2 2 0 1 0 -4 0a2 2 0 0 0 4 0M20 21v-1a2 2 0 0 0 -2 -2h-4a2 2 0 0 0 -2 2v1',
+  },
 ]
 
 const SETTINGS_ITEM: FlatNavItem = {
@@ -114,7 +173,16 @@ const SETTINGS_ITEM: FlatNavItem = {
 
 /* ── Active-state derivation ────────────────────────────────────── */
 
-type ActiveSection = 'apps' | 'jobs' | 'dashboard' | 'cloud' | 'users' | 'settings'
+type ActiveSection =
+  | 'apps'
+  | 'jobs'
+  | 'dashboard'
+  | 'cloud'
+  | 'users'
+  | 'domains'
+  | 'billing'
+  | 'team'
+  | 'settings'
 
 // Cloud section is active when the path matches any of the
 // `/cloud[/...]` or legacy `/infrastructure[/...]` segments. We use a
@@ -129,6 +197,11 @@ function deriveActiveSection(pathname: string): ActiveSection {
   if (pathname.endsWith('/jobs')) return 'jobs'
   // Users surface — list, /new, and /<name> all count.
   if (/\/users(\/|$)/.test(pathname)) return 'users'
+  // Domains / Billing / Team — admin surfaces added in A65 (Refs #1976).
+  // Stub pages today; full surfaces tracked as follow-up issues.
+  if (/\/domains(\/|$)/.test(pathname)) return 'domains'
+  if (/\/billing(\/|$)/.test(pathname)) return 'billing'
+  if (/\/team(\/|$)/.test(pathname)) return 'team'
   // Settings — deployment-scoped settings page (issue #516). The
   // legacy `/wizard` divert was the bug being fixed.
   if (/\/settings(\/|$)/.test(pathname)) return 'settings'

--- a/products/catalyst/bootstrap/ui/src/pages/sovereign/TeamPage.tsx
+++ b/products/catalyst/bootstrap/ui/src/pages/sovereign/TeamPage.tsx
@@ -1,0 +1,77 @@
+/**
+ * TeamPage — Sovereign admin operator team management surface.
+ *
+ * Refs #1976 (TBD-A64, A65 deferred sub-bug) — cosmetic-guards
+ * CANONICAL_SIDEBAR_LABELS asserts the admin sidebar exposes a `Team`
+ * nav item mirrored from core/console/src/components/Sidebar.svelte.
+ * This page is the destination for that nav item.
+ *
+ * Scope: STUB. Distinct from the deployment-scoped /users surface
+ * (UserAccessListPage — per-deployment user-access list); Team is the
+ * organisation-level operator roster (who owns this Sovereign, invite
+ * flow, member roles). Tracked as a follow-up issue.
+ *
+ * Per docs/INVIOLABLE-PRINCIPLES.md (honest empty state) — this stub
+ * surfaces a clearly-labelled "API pending" message + a
+ * `data-testid="pending-api"` hook so the operator sees the surface
+ * but cannot mistake it for a wired feature.
+ */
+
+import { PortalShell } from './PortalShell'
+import { useDeploymentEvents } from './useDeploymentEvents'
+import { useResolvedDeploymentId } from '@/shared/lib/useResolvedDeploymentId'
+
+export interface TeamPageProps {
+  /** Test seam — disables the live SSE attach. */
+  disableStream?: boolean
+}
+
+export function TeamPage({ disableStream = false }: TeamPageProps = {}) {
+  const { deploymentId: resolvedId } = useResolvedDeploymentId()
+  const deploymentId = resolvedId ?? ''
+
+  const { snapshot } = useDeploymentEvents({
+    deploymentId,
+    applicationIds: [],
+    disableStream,
+  })
+  const sovereignFQDN =
+    snapshot?.sovereignFQDN ?? snapshot?.result?.sovereignFQDN ?? null
+
+  return (
+    <PortalShell
+      deploymentId={deploymentId}
+      sovereignFQDN={sovereignFQDN}
+      pageTitle="Team"
+    >
+      <div className="mx-auto max-w-3xl" data-testid="team-page">
+        <header className="mb-4">
+          <p className="text-sm text-[var(--color-text-dim)]">
+            Manage the operator roster for this Sovereign. Invite operators,
+            assign roles, and audit team-level access.
+          </p>
+        </header>
+        <section
+          className="rounded-lg border border-[var(--color-border)] bg-[var(--color-bg-2)] p-6"
+          data-testid="team-pending-api"
+        >
+          <h2 className="text-base font-semibold text-[var(--color-text-strong)]">
+            API pending
+          </h2>
+          <p className="mt-2 text-sm text-[var(--color-text-dim)]">
+            The organisation-level operator roster surface is not yet wired
+            in this build. The deployment-scoped per-user access list is
+            available at <code>/users</code>; the org-level Team surface
+            ships in a follow-up release.
+          </p>
+          <p
+            className="mt-3 text-xs text-[var(--color-text-dim)]"
+            data-testid="pending-api"
+          >
+            pending-api
+          </p>
+        </section>
+      </div>
+    </PortalShell>
+  )
+}

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -1,5 +1,19 @@
 apiVersion: v2
 name: bp-catalyst-platform
+# 1.4.210 — TBD-A65 (Refs #1976, 2026-05-19): admin sidebar nav parity
+# with canonical core/console/src/components/Sidebar.svelte. Adds
+# Domains / Billing / Team entries to the Sovereign-provision Sidebar
+# (FLAT_NAV) so e2e/cosmetic-guards.spec.ts CANONICAL_SIDEBAR_LABELS
+# resolves. Each entry routes to an honest "API pending" stub
+# (DomainsPage / BillingPage / TeamPage) under
+# /provision/$deploymentId/{domains,billing,team}; real surfaces
+# tracked as follow-up issues (Domains → Refs #1830 ParentDomain CRD;
+# Billing → BSS chroot /bss/billing; Team → org-level operator
+# roster). Vitest Sidebar.test.tsx updated to assert the three new
+# entries; Chart.yaml bump pairs the matching version bump in
+# clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml.
+# Refs #1976.
+#
 # 1.4.209 — TBD-A64 PR γ (issue #1976, 2026-05-19): cosmetic regressions
 # caught by the cosmetic-guards e2e suite. THREE surgical fixes:
 #   1. wizard/steps/logoTone.ts — alloy tile background flipped from
@@ -1765,7 +1779,7 @@ name: bp-catalyst-platform
 # was already shipped on 1.4.197 (PR #1820 lineage); this completes
 # the data-layer side so the dropdown finally appears on multi-region
 # Sovereigns. Refs #1821, DoD D20.
-version: 1.4.209
+version: 1.4.210
 appVersion: 1.4.208
 # 1.4.183 — fix(httproute): omit default sectionName so multi-zone
 # Sovereigns attach via Cilium Gateway hostname matcher (Closes #1884,


### PR DESCRIPTION
## Summary

- Adds `Domains` / `Billing` / `Team` entries to the Sovereign-provision admin Sidebar (`products/catalyst/bootstrap/ui/src/pages/sovereign/Sidebar.tsx`), mirroring the canonical `core/console/src/components/Sidebar.svelte` nav array so `e2e/cosmetic-guards.spec.ts` `CANONICAL_SIDEBAR_LABELS` resolves.
- Three new stub pages (`DomainsPage` / `BillingPage` / `TeamPage`) under `/provision/$deploymentId/{domains,billing,team}` render an honest "API pending" empty state with a `data-testid="pending-api"` hook — no hidden surfaces, no null-guards. The real surfaces are tracked as follow-ups (Domains → Refs #1830 ParentDomain CRD; Billing → BSS chroot `/bss/billing`; Team → org-level operator roster).
- Vitest `Sidebar.test.tsx` flipped: the three `sov-nav-{domains,billing,team}` testids are now asserted present, with active-state coverage for each route (20/20 tests pass locally via `vitest --pool=forks`).
- Chart bumped 1.4.208 → 1.4.209; bootstrap-kit pin at `clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml` moved with it.

`Refs #1976` (NOT `Closes` — many other deferred regressions from TBD-A64 are still in flight as separate PRs).

## Test plan

- [x] `npm run lint` — no new lint errors (pre-existing fast-refresh warning at router.tsx unchanged)
- [x] `vitest run src/pages/sovereign/Sidebar.test.tsx` — 20/20 pass
- [ ] CI build green
- [ ] Cosmetic-guards spec Test 12 (`admin sidebar parity`) green on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)