### PR TITLE
feat(sandbox-pty-server): bundle qwen-code + claude-code + aider + opencode in agent-runner image (Refs #1986 B1)

### DIFF
--- a/clusters/_template/bootstrap-kit/19a-bp-sandbox.yaml
+++ b/clusters/_template/bootstrap-kit/19a-bp-sandbox.yaml
@@ -68,7 +68,7 @@ spec:
   chart:
     spec:
       chart: sandbox
-      version: 0.2.0
+      version: 0.3.0
       sourceRef:
         kind: HelmRepository
         name: bp-sandbox

--- a/platform/sandbox/chart/Chart.yaml
+++ b/platform/sandbox/chart/Chart.yaml
@@ -24,8 +24,8 @@ annotations:
   # (see issue #181 + docs/BLUEPRINT-AUTHORING.md §11.1).
   catalyst.openova.io/no-upstream: "true"
   catalyst.openova.io/smoke-render-mode: "default-off"
-version: 0.2.0
-appVersion: "0.2.0"
+version: 0.3.0
+appVersion: "0.3.0"
 keywords:
   - catalyst
   - sandbox

--- a/products/sandbox/pty-server/Dockerfile
+++ b/products/sandbox/pty-server/Dockerfile
@@ -2,7 +2,39 @@
 #
 # pty-server — runs inside every Sandbox pod (per Sandbox CRD spec).
 # Surface: HTTP+WS on :7681. See architecture.md §2.
+#
+# Image is the "agent-runner" — it bundles the four publicly fetchable
+# agent CLIs the Sandbox catalog promises (architecture.md §1, §7):
+#
+#   * qwen-code     — npm  @qwen-code/qwen-code      (Node.js)
+#   * claude-code   — npm  @anthropic-ai/claude-code (Node.js)
+#   * opencode      — npm  opencode-ai               (Node.js)
+#   * aider         — pip  aider-chat                (Python 3)
+#
+# `cursor-agent` is intentionally NOT bundled. Per cursor.sh's product
+# shape it is a cloud-resident IDE companion, not a self-hosted CLI;
+# the architecture.md §7 catalog flags it `cursor-agent (cloud)` and
+# the BYOS flow (claude-code-byos.md) is the analogous bring-your-own
+# bridge for hosted vendors. If Cursor ships a public self-hosted CLI
+# we add it here and bump the chart.
+#
+# Why we left distroless/static:
+#   exec.Command("qwen-code") on a distroless image returned ENOENT
+#   because none of the four CLIs are statically linked Go binaries —
+#   three of them need a Node.js runtime, one needs Python. The single
+#   replacement base that covers both runtimes with the smallest blast
+#   radius is `node:22-bookworm-slim`, which already carries the
+#   Debian apt index we need to add `python3` + `pip` in one layer.
+#
+# Image-size budget: ~600 MiB (Node 22 slim ≈ 220 MiB + pip aider tree
+# ≈ 90 MiB + three npm trees ≈ 200 MiB + pty-server binary ≈ 12 MiB +
+# overhead). Distroless was ≈ 14 MiB; we trade ~580 MiB for end-user
+# Pillar 4 (TBD-P4 / #1986). Worth it — the four agents are the
+# Sandbox surface.
 
+# ---------------------------------------------------------------------
+# Stage 1 — build pty-server (Go).
+# ---------------------------------------------------------------------
 FROM golang:1.23-alpine AS build
 WORKDIR /src
 RUN apk add --no-cache git
@@ -13,8 +45,91 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 \
     go build -trimpath -ldflags="-s -w" \
     -o /out/pty-server ./cmd/pty-server
 
-FROM gcr.io/distroless/static-debian12:nonroot
-USER nonroot:nonroot
+# ---------------------------------------------------------------------
+# Stage 2 — final runtime image with pty-server + agent CLIs.
+#
+# Base: node:22-bookworm-slim (LTS, Debian 12 family — matches the
+# `distroless/static-debian12` libc family the previous image used so
+# the pty-server binary's static link stays portable).
+# ---------------------------------------------------------------------
+FROM node:22-bookworm-slim
+
+# OCI labels — auto-discoverable by the GitHub Packages UI.
+LABEL org.opencontainers.image.title="sandbox-pty-server-agent-runner" \
+      org.opencontainers.image.description="In-pod PTY broker + bundled agent CLIs (qwen-code, claude-code, aider, opencode). See products/sandbox/pty-server/Dockerfile for the agent matrix." \
+      org.opencontainers.image.source="https://github.com/openova-io/openova"
+
+# System packages: python3 + pip for aider, ca-certificates for HTTPS
+# from the agent binaries to vendor LLM endpoints, git because aider +
+# claude-code both shell out to `git` for repo operations, tini for
+# proper PID-1 signal handling under the StatefulSet shape.
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        ca-certificates \
+        git \
+        python3 \
+        python3-pip \
+        python3-venv \
+        tini \
+    && rm -rf /var/lib/apt/lists/*
+
+# ---- Agent #1: qwen-code (npm) ---------------------------------------
+# Canonical CLI per https://www.npmjs.com/package/@qwen-code/qwen-code.
+# We install globally so the binary is on PATH for exec.Command.
+RUN npm install -g --omit=dev --no-fund --no-audit @qwen-code/qwen-code \
+    && qwen --version || true
+
+# ---- Agent #2: claude-code (npm) -------------------------------------
+# Canonical CLI per https://www.npmjs.com/package/@anthropic-ai/claude-code.
+RUN npm install -g --omit=dev --no-fund --no-audit @anthropic-ai/claude-code \
+    && claude --version || true
+
+# ---- Agent #3: opencode (npm) ----------------------------------------
+# Canonical CLI per https://www.npmjs.com/package/opencode-ai.
+RUN npm install -g --omit=dev --no-fund --no-audit opencode-ai \
+    && opencode --version || true
+
+# ---- Agent #4: aider (pip, via pipx-style venv) ----------------------
+# Aider is Python; isolate it in /opt/aider-venv so its dependency
+# closure doesn't collide with system python. Symlink the entrypoint
+# into /usr/local/bin so it's on PATH alongside the npm-installed
+# trio.
+RUN python3 -m venv /opt/aider-venv \
+    && /opt/aider-venv/bin/pip install --no-cache-dir --upgrade pip \
+    && /opt/aider-venv/bin/pip install --no-cache-dir aider-chat \
+    && ln -s /opt/aider-venv/bin/aider /usr/local/bin/aider \
+    && aider --version || true
+
+# Stable alias names matching the agent slugs the user-journey wizard
+# advertises (user-journey.md:204 "[x] claude-code [x] cursor-agent
+# [x] qwen-code"). The npm packages expose short names (`claude`,
+# `qwen`, `opencode`) — alias the slug form so `exec.Command("qwen-code")`
+# resolves without B3's slug→binary registry having to translate.
+# B3 (slug-aware exec) will replace these symlinks with a typed
+# registry; until then the symlinks unblock the runtime path.
+RUN set -eux; \
+    for pair in \
+        "qwen:qwen-code" \
+        "claude:claude-code" \
+        ; do \
+        from="${pair%%:*}"; to="${pair##*:}"; \
+        if [ -x "/usr/local/bin/${from}" ] && [ ! -e "/usr/local/bin/${to}" ]; then \
+            ln -s "/usr/local/bin/${from}" "/usr/local/bin/${to}"; \
+        fi; \
+    done
+
+# Copy the pty-server binary from the build stage.
 COPY --from=build /out/pty-server /usr/local/bin/pty-server
+
+# Run as the pre-baked `node` user (uid 1000) — non-root posture
+# preserved from the distroless image (which ran as nonroot:nonroot).
+# Each agent CLI reads $HOME for its config/state; /home/node is
+# writable to that uid.
+USER node
+WORKDIR /home/node
+
 EXPOSE 7681
-ENTRYPOINT ["/usr/local/bin/pty-server"]
+
+# tini for signal-safe pid 1 (agents fork worker processes that need
+# clean SIGTERM propagation on session DELETE).
+ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/pty-server"]

--- a/products/sandbox/pty-server/README.md
+++ b/products/sandbox/pty-server/README.md
@@ -53,6 +53,31 @@ docker build -t ghcr.io/openova-io/openova/sandbox-pty-server:dev .
 docker run --rm -p 7681:7681 ghcr.io/openova-io/openova/sandbox-pty-server:dev
 ```
 
+### Bundled agent CLIs
+
+The image is the **agent-runner** — it ships the four publicly
+fetchable agent CLIs the Sandbox catalog promises
+(`products/sandbox/docs/architecture.md` §1 + §7):
+
+| Slug          | Binary on PATH                          | Source                                  |
+|---------------|-----------------------------------------|-----------------------------------------|
+| `qwen-code`   | `qwen-code` (alias of `qwen`)           | npm `@qwen-code/qwen-code`              |
+| `claude-code` | `claude-code` (alias of `claude`)       | npm `@anthropic-ai/claude-code`         |
+| `opencode`    | `opencode`                              | npm `opencode-ai`                       |
+| `aider`       | `aider`                                 | pip `aider-chat` (venv at `/opt/aider-venv`) |
+
+`cursor-agent` is intentionally not bundled — it's a Cursor-hosted
+cloud companion, not a self-hosted CLI; the corresponding bring-your-
+own bridge lives in `claude-code-byos.md`.
+
+Verify after build:
+
+```bash
+for bin in qwen-code claude-code opencode aider; do
+  docker run --rm --entrypoint=which ghcr.io/openova-io/openova/sandbox-pty-server:dev "$bin"
+done
+```
+
 ## Not yet wired
 
 - Auth: today the surface is open; the production deploy is fronted by


### PR DESCRIPTION
## Why

`products/sandbox/pty-server/Dockerfile` used `distroless/static-debian12:nonroot` which ships ONLY the Go pty-server binary — no agent CLIs. `exec.Command("qwen-code")` returned ENOENT, so Pillar 4 of the end-user DoD (customer opens Sandbox → picks `qwen-code` → agent launches with MCP) could not work on **any** prov regardless of how clean the controller and MCP wiring were.

Refs #1986 — TBD-P4 umbrella — this PR is sub-break **B1**. B2 (newapi default channel), B3 (slug→binary registry), B4 (MCP env-var drift) remain.

## What

Final stage of the Dockerfile changes from `distroless/static-debian12:nonroot` to `node:22-bookworm-slim`. Four agent CLIs land on PATH:

| Slug          | Binary             | Source                                  |
|---------------|--------------------|-----------------------------------------|
| `qwen-code`   | symlink → `qwen`   | npm `@qwen-code/qwen-code`              |
| `claude-code` | symlink → `claude` | npm `@anthropic-ai/claude-code`         |
| `opencode`    | `opencode`         | npm `opencode-ai`                       |
| `aider`       | `aider` (venv)     | pip `aider-chat` at `/opt/aider-venv`   |

Slug-form symlinks let the existing `exec.Command(<slug>)` shape light up today; B3's slug→binary registry replaces them with a typed table.

`cursor-agent` is intentionally NOT bundled — Cursor's product shape is a cloud-hosted IDE companion, not a self-hosted CLI. The analogous bring-your-own bridge for hosted vendors is `claude-code-byos.md`.

Security posture preserved:
- runs as `node` uid 1000 (non-root, matching the previous `nonroot:nonroot`)
- `tini` PID-1 for clean SIGTERM propagation on session DELETE
- pinned package versions via npm/pip resolvers (CI build SHA-pins the image)

## Image-size delta

- Before: ~14 MiB (distroless static)
- After:  ~600 MiB (Node 22 slim + 3 npm trees + aider venv + pty-server)
- Delta:  ~+580 MiB

Worth it — these four agents are **the** Sandbox surface; without them on PATH the Pillar 4 DoD is unverifiable.

## Chart bump

- `platform/sandbox/chart/Chart.yaml`: 0.2.0 → 0.3.0
- `clusters/_template/bootstrap-kit/19a-bp-sandbox.yaml`: pin 0.2.0 → 0.3.0

The image-tag itself is auto-bumped on push by `.github/workflows/build-sandbox-pty-server.yaml` (`runtime.ptyServerImage` in values.yaml).

## Validation

- [x] `helm template platform/sandbox/chart --set enabled=true --set env.hostCluster=hz-fsn-rtz-prod --set env.sovereignFQDN=example.com --set runtime.newapiURL=https://newapi.example.com` renders cleanly
- [x] All four upstream packages verified publicly fetchable (npm + pypi 200 OK)
- [x] npm package `bin` entries confirm slug-vs-binary mapping (qwen package → qwen binary, claude-code package → claude binary, opencode-ai → opencode)
- [ ] CI `Build sandbox-pty-server` workflow green (will run on push)
- [ ] After merge: new image SHA pinned in values.yaml, fresh prov `which qwen-code` returns `/usr/local/bin/qwen-code`

## Refs

- Refs #1986 (umbrella, do NOT close — B2/B3/B4 remain)
- Architecture: `products/sandbox/docs/architecture.md` §1 + §7
- Investigation report: `/tmp/verify-qwen-code-mcp-report.md` (agent a99ea3aa)