### PR TITLE
fix(bp-flux-stuck-hr-recovery): detect+correct deployed-but-unknown-Ready HRs (Refs #1989)

### DIFF
--- a/clusters/_template/bootstrap-kit/03-flux.yaml
+++ b/clusters/_template/bootstrap-kit/03-flux.yaml
@@ -64,7 +64,14 @@ spec:
       # 1.2.1 (Fix #158): stuckHelmReleaseRecovery image switched from
       # bitnami/kubectl:1.31 (deleted from Docker Hub 2025-08) to
       # bitnamilegacy/kubectl:1.31.4. (Catches up from 1.1.3 → 1.2.1.)
-      version: 1.2.2
+      # 1.2.2 (Fix #163): explicit harbor.openova.io proxy-dockerhub
+      # prefix on the kubectl image (MIRROR-EVERYTHING).
+      # 1.2.3 (TBD-A66, #1989): stuckHelmReleaseRecovery script gains
+      # a SECOND detection branch for `Ready=Unknown +
+      # status.history[0].status=deployed` (apiserver-flap on slow
+      # secondary CPs). Direct status-subresource patch with audit
+      # annotation, RBAC extended for helmreleases/status patch verb.
+      version: 1.2.3
       sourceRef:
         kind: HelmRepository
         name: bp-flux

--- a/platform/flux/blueprint.yaml
+++ b/platform/flux/blueprint.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     catalyst.openova.io/section: pts-3-2-gitops-and-iac
 spec:
-  version: 1.2.2
+  version: 1.2.3
   card:
     title: flux
     summary: GitOps reconciler. One per vcluster (source + kustomize + helm controllers); host-level Flux per host cluster watches its bp-* OCI sources.

--- a/platform/flux/chart/Chart.yaml
+++ b/platform/flux/chart/Chart.yaml
@@ -11,7 +11,20 @@ name: bp-flux
 # harbor.openova.io/proxy-dockerhub/bitnamilegacy/kubectl:1.31.4.
 # Per CLAUDE.md inviolable rule, ALL chart-hook references MUST be
 # explicit Harbor proxy-cache form.
-version: 1.2.2
+#
+# 1.2.3 (TBD-A66, issue #1989, 2026-05-19): stuckHelmReleaseRecovery
+# script gains a SECOND detection branch for HRs stuck in
+# Ready=Unknown despite `.status.history[0].status=deployed`. This is
+# the slow-secondary-CP apiserver-flap failure mode (nbg1-2 / hel1-1 in
+# the t37 canonical walk) where the existing suspend-toggle branch
+# does NOT help because helm-controller's "release in storage" short-
+# circuit never re-evaluates Ready. The new branch patches the status
+# subresource directly to flip Ready=True with audit annotation
+# `stuck-hr-recovery.openova.io/auto-corrected-at=<RFC3339>`. RBAC
+# extended with `helmreleases/status` patch+update verbs (status
+# subresource is a separate RBAC target). Idempotent: annotation
+# guards re-runs.
+version: 1.2.3
 description: |
   Catalyst-curated Blueprint umbrella chart for Flux. Depends on the
   upstream `flux2` chart (fluxcd-community) as a Helm subchart so

--- a/platform/flux/chart/templates/helm-release-stuck-recovery.yaml
+++ b/platform/flux/chart/templates/helm-release-stuck-recovery.yaml
@@ -1,9 +1,13 @@
 {{- /*
 Catalyst overlay: detect-and-recover CronJob for HelmReleases stuck in
-Ready=Unknown after a helm-controller leader-election loss.
+Ready=Unknown after a helm-controller leader-election loss OR after an
+apiserver flap on a slow secondary CP dropped the Ready=True write.
 
-WHY THIS EXISTS (issue #925)
-----------------------------
+WHY THIS EXISTS — TWO FAILURE MODES
+------------------------------------
+
+(A) ISSUE #925 — leader-election loss recovery
+    -------------------------------------------
 helm-controller's reconcile loop has a known soft bug: when leadership
 is lost mid-install (transient kube-apiserver pressure / pod restart /
 OOMKill), the new leader takes over an in-flight Helm install whose
@@ -19,13 +23,29 @@ Ready=Unknown for 10+ minutes → blocked bootstrap-kit Kustomization →
 blocked sovereign-tls Kustomization → cilium-gateway never deployed →
 every HTTPRoute returned TLS handshake failure.
 
-The primary mitigation (extended leader-election lease durations + memory
-headroom in values.yaml) reduces the frequency of the trigger. This
-CronJob is the recovery safety net: every 2 minutes it scans every
-HelmRelease in the cluster, finds those stuck in Ready=Unknown for >5
-min where the underlying Helm release secret already shows Status=deployed,
-and force-toggles spec.suspend to make helm-controller re-evaluate the
-HR's Ready status on next reconcile (the only known workaround per #925).
+Recovery: suspend-toggle. Detects via `helm release secret label
+status=deployed` + Ready=Unknown for >threshold.
+
+(B) TBD-A66 / ISSUE #1989 — slow secondary CP apiserver-flap recovery
+    -----------------------------------------------------------------
+On embedded-etcd k3s secondary CPs (nbg1-2 / hel1-1 in the t37
+canonical walk) apiserver flaps during the bootstrap cascade. helm-
+controller completes the install — the HR's OWN
+`.status.history[0].status` transitions to "deployed" — but the
+apiserver write that flips `.status.conditions[type=Ready]` from
+Unknown → True is lost. suspend-toggling (branch A) does NOT recover
+this state because helm-controller's "is the release in storage?"
+short-circuit returns yes on the next reconcile, so it never re-
+evaluates Ready.
+
+Recovery: direct status-subresource patch flipping Ready=True, stamped
+with `stuck-hr-recovery.openova.io/auto-corrected-at=<RFC3339>` for
+audit + idempotency.
+
+The primary mitigation (extended leader-election lease durations +
+memory headroom in values.yaml) reduces the frequency of the trigger.
+This CronJob is the recovery safety net: every 2 minutes it scans every
+HelmRelease in the cluster and applies whichever branch matches.
 
 WHY A CRONJOB AND NOT A WEBHOOK / OPERATOR
 ------------------------------------------
@@ -69,6 +89,7 @@ metadata:
     catalyst.openova.io/blueprint: bp-flux
   annotations:
     catalyst.openova.io/issue: "https://github.com/openova-io/openova/issues/925"
+    catalyst.openova.io/issue-tbd-a66: "https://github.com/openova-io/openova/issues/1989"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -86,14 +107,26 @@ rules:
   - apiGroups: ["helm.toolkit.fluxcd.io"]
     resources: ["helmreleases"]
     verbs: ["get", "list", "watch"]
-  # Patch spec.suspend on stuck HRs to force re-evaluation. We need this
-  # cluster-wide because tenant HRs live in tenant namespaces, not flux-system.
+  # Patch spec.suspend on stuck HRs to force re-evaluation (issue #925
+  # branch). Cluster-wide because tenant HRs live in tenant namespaces.
+  # Also `patch` here covers metadata-only patches like our audit
+  # annotation `stuck-hr-recovery.openova.io/auto-corrected-at`.
   - apiGroups: ["helm.toolkit.fluxcd.io"]
     resources: ["helmreleases"]
     verbs: ["patch"]
+  # TBD-A66 branch: patch .status.conditions.Ready directly when the
+  # HR's own .status.history[0].status proves the install completed but
+  # apiserver flap on a slow secondary CP dropped the Ready=True write.
+  # The status subresource is a separate RBAC target from the main
+  # resource — without this rule `kubectl patch --subresource=status`
+  # returns 403.
+  - apiGroups: ["helm.toolkit.fluxcd.io"]
+    resources: ["helmreleases/status"]
+    verbs: ["patch", "update"]
   # Read Helm release secrets to confirm Status=deployed (the precondition
-  # that distinguishes "stuck Ready=Unknown after leader-election loss"
-  # from "actually still installing").
+  # for the issue #925 fallback branch). The TBD-A66 branch uses the HR's
+  # own .status.history[0].status instead, so secret reads aren't needed
+  # for it — but the fallback path still uses them.
   - apiGroups: [""]
     resources: ["secrets"]
     verbs: ["get", "list"]
@@ -134,22 +167,46 @@ data:
   stuck-threshold: {{ $stuckThreshold | quote }}
   recover.sh: |
     #!/bin/sh
-    # Detect HelmReleases stuck in Ready=Unknown after a helm-controller
-    # leader-election loss (issue #925) and force-toggle spec.suspend to
-    # make the controller re-evaluate Ready on next reconcile.
+    # Detect HelmReleases stuck in Ready=Unknown and recover them.
+    #
+    # Two distinct stuck-state failure modes are handled:
+    #
+    # (A) Leader-election loss recovery (issue #925)
+    #     ─────────────────────────────────────────
+    #     helm-controller lost leadership mid-install. The Helm release
+    #     SECRET shows Status=deployed (storage write committed by the
+    #     previous leader) but the Ready condition was never flipped.
+    #     Fix: toggle spec.suspend=true → false to force re-evaluation.
+    #
+    # (B) Slow-secondary-CP apiserver-flap recovery (TBD-A66, issue #1989)
+    #     ─────────────────────────────────────────────────────────
+    #     On embedded-etcd k3s secondary CPs (nbg1-2/hel1-1 in t37 walk)
+    #     apiserver flaps during the bootstrap cascade. helm-controller
+    #     completes the install — the HR's OWN .status.history[0].Status
+    #     transitions to "deployed" — but the apiserver write that flips
+    #     .status.conditions[Ready] from Unknown → True is lost. suspend-
+    #     toggling (branch A) does NOT recover this state because
+    #     helm-controller's "is the release in storage?" short-circuit
+    #     returns yes on the next reconcile, so it never re-evaluates
+    #     Ready. The only safe recovery is a direct status-subresource
+    #     patch that flips Ready=True and stamps an audit annotation.
     #
     # Algorithm:
     #   1. List every HelmRelease cluster-wide.
-    #   2. For each: read .status.conditions[type=Ready].
-    #      - If status != "Unknown" → skip.
-    #      - If lastTransitionTime is within the stuck threshold → skip
+    #   2. For each: read .status.conditions[type=Ready] + history[0].
+    #      - If Ready.status != "Unknown" → skip.
+    #      - If Ready.lastTransitionTime within threshold → skip
     #        (still might be a real in-flight install).
-    #   3. Read the corresponding Helm release secret in the HR's
-    #      storageNamespace (defaults to HR's namespace).
-    #      - If secret missing or label `status` != "deployed" → skip
-    #        (HR really IS still installing; not stuck).
-    #   4. Patch spec.suspend=true, sleep 5s, patch spec.suspend=false.
-    #      This is the only known workaround for the upstream bug.
+    #      - If already annotated stuck-hr-recovery.openova.io/
+    #        auto-corrected-at → skip (idempotent re-runs).
+    #   3. Decision tree:
+    #      (B) If .status.history[0].status == "deployed" → status-patch
+    #          Ready=True with audit annotation. PREFERRED branch — the
+    #          HR itself confirms install succeeded.
+    #      (A) Else fall back: read the Helm release secret in the HR's
+    #          storageNamespace. If secret label status=deployed →
+    #          suspend-toggle (legacy issue #925 recovery).
+    #      Else skip (HR really IS still installing; not stuck).
     #
     # Guardrail: if more than 10 HRs would be acted on in a single run,
     # log and exit non-zero — that signals a cluster-wide problem (real
@@ -164,25 +221,72 @@ data:
       *)  THRESHOLD_SEC="$THRESHOLD_HUMAN" ;;
     esac
     NOW="$(date -u +%s)"
+    NOW_ISO="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
     ACTED=0
     SCANNED=0
 
-    # Build a list of "ns/name|storageNs|releaseName|readyStatus|readyTransition"
+    # Build a list of
+    # "ns|name|storageNs|releaseName|readyStatus|readyTransition|historyStatus|autoCorrectedAt"
     # in a single kubectl call (cheap — JSONPath does the work server-side).
-    HRS="$(kubectl get hr -A -o jsonpath='{range .items[*]}{.metadata.namespace}|{.metadata.name}|{.spec.storageNamespace}|{.spec.releaseName}|{range .status.conditions[?(@.type=="Ready")]}{.status}|{.lastTransitionTime}{end}{"\n"}{end}')" || HRS=""
+    # NOTE: jsonpath dot-escape on the annotation key — `\.` segments are
+    # required because the annotation contains literal dots (RFC1123 host
+    # name segment style). kubectl jsonpath supports `\.` as a literal
+    # dot since v1.16.
+    HRS="$(kubectl get hr -A -o jsonpath='{range .items[*]}{.metadata.namespace}|{.metadata.name}|{.spec.storageNamespace}|{.spec.releaseName}|{range .status.conditions[?(@.type=="Ready")]}{.status}|{.lastTransitionTime}{end}|{.status.history[0].status}|{.metadata.annotations.stuck-hr-recovery\.openova\.io/auto-corrected-at}{"\n"}{end}')" || HRS=""
 
-    echo "$HRS" | while IFS='|' read -r NS NAME STORAGE_NS RELEASE_NAME READY_STATUS READY_TRANSITION; do
+    echo "$HRS" | while IFS='|' read -r NS NAME STORAGE_NS RELEASE_NAME READY_STATUS READY_TRANSITION HISTORY_STATUS AUTO_CORRECTED_AT; do
       [ -z "$NAME" ] && continue
       SCANNED=$((SCANNED+1))
       # Only act on Ready=Unknown.
       [ "$READY_STATUS" = "Unknown" ] || continue
       [ -n "$READY_TRANSITION" ] || continue
+      # Idempotency: if we've already auto-corrected this HR (annotation
+      # present), skip — either the correction stuck and Ready won't be
+      # Unknown anymore (so we wouldn't be here), or helm-controller
+      # re-flipped it back to Unknown which means there's a genuine
+      # ongoing problem and operator should investigate.
+      [ -z "$AUTO_CORRECTED_AT" ] || { echo "skip $NS/$NAME: already auto-corrected at $AUTO_CORRECTED_AT"; continue; }
       # Has the Unknown state persisted past the threshold?
       TRANSITION_SEC="$(date -u -d "$READY_TRANSITION" +%s 2>/dev/null || echo 0)"
       [ "$TRANSITION_SEC" -gt 0 ] || continue
       AGE=$((NOW - TRANSITION_SEC))
       [ "$AGE" -ge "$THRESHOLD_SEC" ] || continue
 
+      # ── Branch B (TBD-A66): HR's own history says deployed ─────────
+      # The HR controller already wrote history[0].status=deployed,
+      # which proves the install completed. Ready=Unknown is therefore
+      # a lost-write on the conditions subresource (apiserver flap on
+      # slow secondary CP). Direct status patch is the safe recovery.
+      if [ "$HISTORY_STATUS" = "deployed" ]; then
+        ACTED=$((ACTED+1))
+        if [ "$ACTED" -gt 10 ]; then
+          echo "GUARDRAIL: more than 10 stuck HRs detected — refusing to mass-recover. Investigate cluster-wide outage."
+          exit 1
+        fi
+        echo "RECOVER $NS/$NAME (Ready=Unknown for ${AGE}s, history[0].status=deployed) — patching status.conditions.Ready=True (TBD-A66 branch)"
+        # Step 1: stamp audit annotation on the object's metadata so
+        # idempotency works regardless of whether the status patch
+        # below races against a helm-controller reconcile.
+        kubectl annotate hr -n "$NS" "$NAME" --overwrite "stuck-hr-recovery.openova.io/auto-corrected-at=${NOW_ISO}" >/dev/null
+        # Step 2: patch the status subresource. We use a JSON-merge
+        # patch on the entire status object replacing only conditions
+        # — the helm-controller's next reconcile will re-render the
+        # rest of status from the HR spec + history without loss.
+        # `--subresource=status` requires kubectl ≥ v1.24 (we ship
+        # 1.31.4 in this CronJob image, so safe).
+        PATCH_BODY='{"status":{"conditions":[{"type":"Ready","status":"True","reason":"ReconciliationSucceeded","message":"auto-corrected from deployed-but-unknown-Ready by stuck-hr-recovery (TBD-A66)","lastTransitionTime":"'"$NOW_ISO"'"}]}}'
+        if kubectl patch hr -n "$NS" "$NAME" --subresource=status --type=merge -p "$PATCH_BODY" >/dev/null 2>&1; then
+          echo "RECOVERED $NS/$NAME (TBD-A66 branch)"
+        else
+          echo "WARN $NS/$NAME: status-subresource patch failed; will retry next run"
+          # Roll back the annotation so the next run isn't blocked by
+          # idempotency guard on a half-applied recovery.
+          kubectl annotate hr -n "$NS" "$NAME" "stuck-hr-recovery.openova.io/auto-corrected-at-" >/dev/null 2>&1 || true
+        fi
+        continue
+      fi
+
+      # ── Branch A (issue #925): fall back to helm-secret + suspend toggle ──
       # Resolve storage ns + release name (defaults match upstream HR semantics).
       EFFECTIVE_STORAGE_NS="${STORAGE_NS:-$NS}"
       EFFECTIVE_RELEASE="${RELEASE_NAME:-$NAME}"
@@ -195,7 +299,7 @@ data:
       SECRET_STATUS="$(kubectl get secret -n "$EFFECTIVE_STORAGE_NS" "$LATEST_SECRET" -o jsonpath='{.metadata.labels.status}' 2>/dev/null || echo "")"
       # Only act if Helm itself thinks the release is deployed; if it's
       # pending-install / failed / etc the HR really IS still in flight.
-      [ "$SECRET_STATUS" = "deployed" ] || { echo "skip $NS/$NAME: helm secret status=$SECRET_STATUS"; continue; }
+      [ "$SECRET_STATUS" = "deployed" ] || { echo "skip $NS/$NAME: helm secret status=$SECRET_STATUS history=$HISTORY_STATUS"; continue; }
 
       ACTED=$((ACTED+1))
       if [ "$ACTED" -gt 10 ]; then
@@ -203,11 +307,11 @@ data:
         exit 1
       fi
 
-      echo "RECOVER $NS/$NAME (Ready=Unknown for ${AGE}s, helm secret $LATEST_SECRET status=deployed) — toggling spec.suspend"
+      echo "RECOVER $NS/$NAME (Ready=Unknown for ${AGE}s, helm secret $LATEST_SECRET status=deployed) — toggling spec.suspend (issue #925 branch)"
       kubectl patch hr -n "$NS" "$NAME" --type=merge -p '{"spec":{"suspend":true}}' >/dev/null
       sleep 5
       kubectl patch hr -n "$NS" "$NAME" --type=merge -p '{"spec":{"suspend":false}}' >/dev/null
-      echo "RECOVERED $NS/$NAME"
+      echo "RECOVERED $NS/$NAME (issue #925 branch)"
     done
 
     echo "scan complete: scanned=$SCANNED acted=$ACTED threshold=${THRESHOLD_SEC}s"
@@ -226,6 +330,7 @@ metadata:
     catalyst.openova.io/blueprint: bp-flux
   annotations:
     catalyst.openova.io/issue: "https://github.com/openova-io/openova/issues/925"
+    catalyst.openova.io/issue-tbd-a66: "https://github.com/openova-io/openova/issues/1989"
 spec:
   schedule: {{ $schedule | quote }}
   concurrencyPolicy: Forbid

--- a/platform/flux/chart/tests/leader-election-and-recovery.sh
+++ b/platform/flux/chart/tests/leader-election-and-recovery.sh
@@ -156,4 +156,42 @@ if ! grep -q '"15m"' "$TMP/render-15m.yaml"; then
 fi
 echo "  PASS: stuckThreshold operator override flows through"
 
-echo "[leader-election-925] All issue #925 mitigation gates green."
+# ── Case 7 — TBD-A66 deployed-but-unknown-Ready branch is present ────────
+# The recovery script must include the second detection branch added in
+# bp-flux 1.2.3 (TBD-A66 / issue #1989): HRs where Ready=Unknown but
+# `.status.history[0].status=deployed` get a direct status-subresource
+# patch instead of suspend-toggle (which doesn't work on slow-secondary-
+# CP apiserver-flap stuck state).
+echo "[leader-election-925] Case 7: TBD-A66 deployed-but-unknown-Ready branch present in recovery script"
+# 7a — the ConfigMap script references the history[0].status check.
+if ! grep -q '\.status\.history\[0\]\.status' "$TMP/render.yaml"; then
+  echo "FAIL: recovery script missing .status.history[0].status check (TBD-A66 branch removed?)." >&2
+  exit 1
+fi
+echo "  PASS: history[0].status check present"
+# 7b — the script issues a status-subresource patch.
+if ! grep -q -- '--subresource=status' "$TMP/render.yaml"; then
+  echo "FAIL: recovery script missing 'kubectl patch --subresource=status' (TBD-A66 fix path broken)." >&2
+  exit 1
+fi
+echo "  PASS: status-subresource patch present"
+# 7c — the script stamps the audit/idempotency annotation.
+if ! grep -q 'stuck-hr-recovery.openova.io/auto-corrected-at' "$TMP/render.yaml"; then
+  echo "FAIL: audit annotation 'stuck-hr-recovery.openova.io/auto-corrected-at' missing (idempotency guard removed?)." >&2
+  exit 1
+fi
+echo "  PASS: audit/idempotency annotation present"
+# 7d — RBAC grants helmreleases/status patch verb.
+if ! grep -q '"helmreleases/status"' "$TMP/render.yaml"; then
+  echo "FAIL: ClusterRole missing helmreleases/status resource (status subresource patch will 403)." >&2
+  exit 1
+fi
+echo "  PASS: ClusterRole grants helmreleases/status verbs"
+# 7e — Ready=True message references TBD-A66 (audit trail traceability).
+if ! grep -q 'auto-corrected from deployed-but-unknown-Ready' "$TMP/render.yaml"; then
+  echo "FAIL: Ready=True message doesn't carry the TBD-A66 audit string (operators won't be able to grep)." >&2
+  exit 1
+fi
+echo "  PASS: Ready=True message carries TBD-A66 audit string"
+
+echo "[leader-election-925] All issue #925 + TBD-A66 mitigation gates green."


### PR DESCRIPTION
## Summary

Refs #1989 (TBD-A66). Extends the `bp-flux-stuck-hr-recovery` CronJob's recovery script with a SECOND detection branch for the t37-canonical-walk failure mode: HRs stuck at `Ready=Unknown` despite `.status.history[0].status=deployed`. Existing suspend-toggle (issue #925) does NOT fix this because helm-controller short-circuits on "release in storage" and never re-evaluates Ready.

## What changes

- **`platform/flux/chart/templates/helm-release-stuck-recovery.yaml`** — recovery script grows a new branch (B) ahead of the existing suspend-toggle branch (A). New branch:
  - filters by `.status.conditions[type=Ready].status=Unknown` + age > threshold + `.status.history[0].status=deployed` + no prior `stuck-hr-recovery.openova.io/auto-corrected-at` annotation
  - stamps the annotation FIRST (audit + idempotency guard)
  - issues `kubectl patch hr --subresource=status --type=merge` flipping Ready=True with `reason=ReconciliationSucceeded`, message `auto-corrected from deployed-but-unknown-Ready by stuck-hr-recovery (TBD-A66)`, and current RFC3339 timestamp
  - rolls back the annotation if the status patch fails so the next CronJob run retries
- **ClusterRole RBAC** — adds `helmreleases/status` with verbs `[patch, update]`. The status subresource is a separate RBAC target in K8s; without this rule `--subresource=status` returns 403.
- **`platform/flux/chart/Chart.yaml`** — version 1.2.2 → 1.2.3 with full changelog comment.
- **`clusters/_template/bootstrap-kit/03-flux.yaml`** — bp-flux HR pin 1.2.2 → 1.2.3 (the live `omantel.omani.works` / `otech.omani.works` cluster pins sit at 1.1.3 — unchanged here, those are pre-#925 baseline).
- **`platform/flux/chart/tests/leader-election-and-recovery.sh`** — adds Case 7 covering the TBD-A66 branch (history[0].status check, status-subresource patch, audit annotation, `helmreleases/status` ClusterRole verb, audit-string greppability).

## Decision tree

```
hr where Ready.status=Unknown AND age(Unknown) > 5m AND auto-corrected-at NOT SET:
  history[0].status == "deployed"
    → BRANCH B (TBD-A66): stamp annotation, status-subresource patch Ready=True
  else if helm-secret label status == "deployed"
    → BRANCH A (#925): suspend-toggle to force re-evaluation
  else
    → SKIP (genuine in-flight install)
```

## Safety / idempotency

- Annotation = audit + dedup. Re-runs over an already-corrected HR skip at the JSONPath stage (no patch issued).
- Status patch wraps in success/failure: rollback annotation on failure to keep retry path open.
- Existing 10-HR guardrail unchanged; now spans both branches combined (a mass-stuck event still trips it).
- Idempotent at the kubectl layer: re-running on a Ready=True HR is filtered out at the `READY_STATUS=Unknown` check.

## Test plan

- [x] Existing chart test still PASSES (Cases 1-6 issue #925 mitigation gates green)
- [x] New chart test Case 7 PASSES (5 sub-assertions for TBD-A66 branch)
- [x] Mock JSONPath replay over 4 synthetic HRs routes correctly:
  - `stuck-on-secondary` (Ready=Unknown + history[0]=deployed) → BRANCH B status patch
  - `stuck-leader-election` (Ready=Unknown + history[0]=pending-install) → BRANCH A fallback
  - `already-fixed` (Ready=Unknown + history[0]=deployed + annotation set) → SKIP idempotent
  - `healthy-hr` (Ready=True) → SKIP no-op
- [x] Status patch body is valid JSON (jq round-trip)
- [ ] Live verification — re-run t37 canonical walk; nbg1-2 secondary CP's 5 stuck HRs should auto-correct within 2 min of bootstrap-kit landing. Closure when full walk reaches handover.

## Issue / closure

`Refs #1989` (not `Closes`) per founder rule — closure happens on the t37 canonical walk reaching handover successfully on a fresh prov.

🤖 Generated with [Claude Code](https://claude.com/claude-code)