### PR TITLE
fix(tenant-route): restore console.<slug>.<parent> prefix + drop .openova.io hardcode (Closes #1990)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -716,7 +716,17 @@ spec:
       # map. Unblocks D29 customer-journey: marketplace.<sov> 404 →
       # storefront; voucher endpoint 503 → 2xx; SME tenant pipeline
       # reconciliation. Refs #1966 #1741 #1949 #1943.
-      version: 1.4.209
+      # 1.4.210 — TBD-A67 (issue #1990): restore canonical `console.`
+      # infix on per-tenant HTTPRoute hostname + drop `.openova.io`
+      # hardcode from notification WorkspaceURL. Three surgical fixes
+      # in tenant_route.go:113, tenant-public-routes.yaml:82, and
+      # enrich.go (now reads TENANT_PARENT_DOMAIN env for per-Sovereign
+      # parent zone). Without this, runtime reconciler emitted
+      # `<slug>.<parent>` while the chart-side overlay emitted
+      # `console.<slug>.<parent>` and the two drifted; tenant
+      # onboarding emails on every non-openova.io Sovereign leaked the
+      # platform marketing host. Refs #1990 TBD-A67.
+      version: 1.4.210
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/core/controllers/organization/internal/controller/organization_controller_test.go
+++ b/core/controllers/organization/internal/controller/organization_controller_test.go
@@ -753,12 +753,14 @@ func TestUpsertUserAccess_DefaultsToCatalystSystem(t *testing.T) {
 }
 
 // TestReconcile_TenantPublic_RendersHTTPRoute covers the issue #1629
-// follow-up: when spec.tenantPublic.parentDomain is set, the reconciler
-// MUST render an HTTPRoute in the Org's namespace pointing at the
-// supplied backend Service. Without this, PowerDNS-resolved tenant
-// hostnames (e.g. `acme.omani.homes`) fall through to the marketplace
-// `tenant-wildcard` route and 404 instead of hitting the tenant's
-// installed WordPress.
+// follow-up + TBD-A67 issue #1990: when spec.tenantPublic.parentDomain
+// is set, the reconciler MUST render an HTTPRoute in the Org's
+// namespace pointing at the supplied backend Service AND the
+// HTTPRoute hostname MUST carry the canonical `console.` infix
+// (`console.<slug>.<parentDomain>`, e.g. `console.acme.omani.homes`).
+// Without this, PowerDNS-resolved tenant hostnames fall through to
+// the marketplace `tenant-wildcard` route and 404 instead of hitting
+// the tenant's installed WordPress.
 func TestReconcile_TenantPublic_RendersHTTPRoute(t *testing.T) {
 	t.Parallel()
 	org := sampleOrg()
@@ -794,8 +796,17 @@ func TestReconcile_TenantPublic_RendersHTTPRoute(t *testing.T) {
 		t.Fatalf("get HTTPRoute acme/acme: %v", err)
 	}
 	hostnames, _, _ := unstructured.NestedSlice(hr.Object, "spec", "hostnames")
-	if len(hostnames) != 1 || hostnames[0] != "acme.omani.homes" {
-		t.Errorf("hostnames: got %v, want [acme.omani.homes]", hostnames)
+	if len(hostnames) != 1 || hostnames[0] != "console.acme.omani.homes" {
+		t.Errorf("hostnames: got %v, want [console.acme.omani.homes]", hostnames)
+	}
+	// TBD-A67 issue #1990 regression guard: the `console.` infix is
+	// non-negotiable. Asserting it directly (in addition to the full-
+	// hostname check above) makes the future-debug-trail obvious when
+	// any refactor of tenant_route.go drops the prefix.
+	if got := hostnames[0]; got != nil {
+		if s, ok := got.(string); !ok || !strings.HasPrefix(s, "console.") {
+			t.Errorf("hostname must carry canonical console. prefix per CLAUDE.md §0, got %v", got)
+		}
 	}
 	parents, _, _ := unstructured.NestedSlice(hr.Object, "spec", "parentRefs")
 	if len(parents) != 1 {

--- a/core/controllers/organization/internal/controller/tenant_route.go
+++ b/core/controllers/organization/internal/controller/tenant_route.go
@@ -1,14 +1,14 @@
 // tenant_route.go — per-Organization HTTPRoute reconciler.
 //
-// Issue #1629 follow-up. PowerDNS now resolves `<slug>.<parentDomain>`
-// (e.g. `acme.omani.homes`) for every Org whose Sovereign has a
-// parent_domains entry with role=sme-pool, but no HTTPRoute attaches
-// that hostname to the Org's installed product Service. Result: the
-// Cilium Gateway happily terminates TLS on the wildcard cert, then
-// returns the storefront landing page (the only HTTPRoute attached
-// to `*.<sovFQDN>` is the `tenant-wildcard` route → marketplace
-// console Service) instead of the tenant's WordPress / Nextcloud /
-// GitLab install.
+// Issue #1629 follow-up. PowerDNS now resolves
+// `console.<slug>.<parentDomain>` (e.g. `console.acme.omani.homes`) for
+// every Org whose Sovereign has a parent_domains entry with role=sme-
+// pool, but no HTTPRoute attaches that hostname to the Org's installed
+// product Service. Result: the Cilium Gateway happily terminates TLS
+// on the wildcard cert, then returns the storefront landing page (the
+// only HTTPRoute attached to `*.<sovFQDN>` is the `tenant-wildcard`
+// route → marketplace console Service) instead of the tenant's
+// WordPress / Nextcloud / GitLab install.
 //
 // The fix is reconciler-side: when `spec.tenantPublic.parentDomain`
 // is set on an Organization, the controller renders a per-tenant
@@ -16,9 +16,14 @@
 // supplied BackendService. The route attaches to the canonical
 // `cilium-gateway/kube-system` parent — the same parent the
 // marketplace, back-office, and tenant-wildcard routes already attach
-// to — and surfaces `<subdomain>.<parentDomain>` as its hostname so
-// the Cilium Gateway hostname matcher picks the per-tenant route
-// over the wildcard for any request matching the exact host.
+// to — and surfaces `console.<subdomain>.<parentDomain>` as its
+// hostname so the Cilium Gateway hostname matcher picks the per-
+// tenant route over the wildcard for any request matching the exact
+// host. The `console.` prefix is the canonical per-tenant console
+// hostname per CLAUDE.md §0 and matches sme_tenant_gitops.go:536
+// (chart-side host derivation for bp-wordpress-tenant et al.) so the
+// runtime reconciler and the GitOps overlay agree byte-for-byte.
+// TBD-A67 issue #1990.
 //
 // Design notes:
 //
@@ -110,7 +115,12 @@ func (r *Reconciler) reconcileTenantRoute(ctx context.Context, org *orgapi.Organ
 		port = tenantRouteDefaultBackendPort
 	}
 
-	hostname := fmt.Sprintf("%s.%s", subdomain, parentDomain)
+	// TBD-A67 issue #1990: hostname is `console.<subdomain>.<parentDomain>`
+	// — the `console.` infix is the canonical per-tenant console host
+	// per CLAUDE.md §0 + sme_tenant_gitops.go:536. Without it, the
+	// runtime reconciler emitted `<slug>.<parent>` while the chart-side
+	// overlay emitted `console.<slug>.<parent>` and the two drifted.
+	hostname := fmt.Sprintf("console.%s.%s", subdomain, parentDomain)
 	ns := org.Spec.Slug
 	name := org.Spec.Slug
 

--- a/core/services/notification/handlers/consumer_test.go
+++ b/core/services/notification/handlers/consumer_test.go
@@ -87,7 +87,7 @@ func handlerWithMocks(t *testing.T) (*Handler, *captureMailer, *httptest.Server,
 		})
 	}))
 
-	enricher := NewEnricher(tenantSvc.URL, authSvc.URL, []byte("test-secret"))
+	enricher := NewEnricher(tenantSvc.URL, authSvc.URL, "omani.homes", []byte("test-secret"))
 
 	h := &Handler{
 		Mailer:   cap,

--- a/core/services/notification/handlers/enrich.go
+++ b/core/services/notification/handlers/enrich.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
@@ -24,19 +25,33 @@ import (
 type Enricher struct {
 	TenantURL string // e.g. http://tenant.sme.svc.cluster.local:8083
 	AuthURL   string // e.g. http://auth.sme.svc.cluster.local:8081
-	JWTSecret []byte
-	HTTP      *http.Client
+	// ParentZone is the Sovereign's sme-pool parent domain (e.g.
+	// "omani.homes" / "talents.scope") used to render WorkspaceURL.
+	// TBD-A67 issue #1990 removed the hardcoded `.openova.io` suffix —
+	// the parent zone is per-Sovereign and the notification service
+	// reads it from the TENANT_PARENT_DOMAIN env (same env name the
+	// provisioning service uses via Handler.TenantParentDomain). Empty
+	// disables the WorkspaceURL field so the email template can fall
+	// back to a bare-org-name body rather than emit a wrong URL.
+	ParentZone string
+	JWTSecret  []byte
+	HTTP       *http.Client
 }
 
 // NewEnricher constructs an Enricher. Leave URLs empty to disable — in
 // that case Lookup returns zero values without error and the caller
-// will skip the email.
-func NewEnricher(tenantURL, authURL string, jwtSecret []byte) *Enricher {
+// will skip the email. parentZone is the Sovereign's sme-pool parent
+// domain used to build per-tenant WorkspaceURL strings; empty parent
+// zone results in an empty WorkspaceURL (template-side guard).
+// TBD-A67 issue #1990: NEVER hardcode `.openova.io` here — every
+// Sovereign owns its own parent zone.
+func NewEnricher(tenantURL, authURL, parentZone string, jwtSecret []byte) *Enricher {
 	return &Enricher{
-		TenantURL: tenantURL,
-		AuthURL:   authURL,
-		JWTSecret: jwtSecret,
-		HTTP:      &http.Client{Timeout: 5 * time.Second},
+		TenantURL:  tenantURL,
+		AuthURL:    authURL,
+		ParentZone: parentZone,
+		JWTSecret:  jwtSecret,
+		HTTP:       &http.Client{Timeout: 5 * time.Second},
 	}
 }
 
@@ -78,10 +93,32 @@ func (e *Enricher) Lookup(ctx context.Context, tenantID string) (*TenantInfo, er
 		TenantID:     tenant.ID,
 		OrgName:      tenant.Name,
 		Subdomain:    tenant.Subdomain,
-		WorkspaceURL: "https://" + tenant.Subdomain + ".openova.io",
+		WorkspaceURL: workspaceURL(tenant.Subdomain, e.ParentZone),
 		OwnerEmail:   owner.Email,
 		OwnerName:    owner.Name,
 	}, nil
+}
+
+// workspaceURL renders the canonical per-tenant console URL using the
+// Sovereign's parent zone — `https://console.<subdomain>.<parentZone>`.
+// Mirrors sme_tenant_gitops.go:536 (chart-side host derivation) and
+// tenant_route.go:113 (controller-side HTTPRoute hostname) so the
+// notification email's clickable link lands on the exact host the
+// Cilium Gateway routes to the tenant's console Service.
+//
+// TBD-A67 issue #1990: empty parent zone returns "" (caller / template
+// is expected to omit the URL line). NEVER falls back to `.openova.io`
+// — that hostname is the platform marketing domain, not a tenant
+// console host, and hardcoding it leaked into email bodies on every
+// non-openova.io Sovereign (omani.homes, talents.scope, …) violating
+// the "never touch openova.io" rule.
+func workspaceURL(subdomain, parentZone string) string {
+	subdomain = strings.TrimSpace(subdomain)
+	parentZone = strings.TrimSpace(parentZone)
+	if subdomain == "" || parentZone == "" {
+		return ""
+	}
+	return "https://console." + subdomain + "." + parentZone
 }
 
 // serviceToken mints a short-lived superadmin JWT that the tenant and

--- a/core/services/notification/handlers/enrich_test.go
+++ b/core/services/notification/handlers/enrich_test.go
@@ -1,0 +1,186 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestWorkspaceURL_ConsolePrefix_PerSovereignParentZone is the TBD-A67
+// regression guard for issue #1990. The pure-function `workspaceURL`
+// helper MUST emit `https://console.<subdomain>.<parentZone>` for every
+// non-empty subdomain + parent zone pair, and MUST NEVER reach for the
+// hardcoded `.openova.io` host the previous implementation appended.
+// The canonical shape mirrors:
+//
+//   - products/catalyst/bootstrap/api/internal/handler/
+//     sme_tenant_gitops.go:536 (chart-side host derivation)
+//   - core/controllers/organization/internal/controller/
+//     tenant_route.go:113 (per-Org HTTPRoute hostname)
+//
+// Drift between any of the three would surface as "email points at a
+// host that does not 200" — a class of bug we cannot afford for
+// onboarding-day-1 outbound mail.
+func TestWorkspaceURL_ConsolePrefix_PerSovereignParentZone(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name       string
+		subdomain  string
+		parentZone string
+		want       string
+	}{
+		{
+			name:       "omani.homes sovereign",
+			subdomain:  "acme",
+			parentZone: "omani.homes",
+			want:       "https://console.acme.omani.homes",
+		},
+		{
+			name:       "talents.scope sovereign — proves zero coupling to openova.io",
+			subdomain:  "delta",
+			parentZone: "talents.scope",
+			want:       "https://console.delta.talents.scope",
+		},
+		{
+			name:       "whitespace is trimmed on both sides",
+			subdomain:  " acme ",
+			parentZone: " omani.homes ",
+			want:       "https://console.acme.omani.homes",
+		},
+		{
+			name:       "empty parent zone yields empty URL (no openova.io fallback)",
+			subdomain:  "acme",
+			parentZone: "",
+			want:       "",
+		},
+		{
+			name:       "empty subdomain yields empty URL",
+			subdomain:  "",
+			parentZone: "omani.homes",
+			want:       "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := workspaceURL(tc.subdomain, tc.parentZone)
+			if got != tc.want {
+				t.Errorf("workspaceURL(%q, %q) = %q, want %q",
+					tc.subdomain, tc.parentZone, got, tc.want)
+			}
+			// Hard regression check: ANY non-empty output must contain
+			// the canonical `console.` infix immediately after the
+			// scheme. Without this, a future refactor that drops the
+			// prefix produces a valid-looking URL that 404s on the
+			// Cilium Gateway.
+			if got != "" && !strings.HasPrefix(got, "https://console.") {
+				t.Errorf("rendered URL %q missing required `console.` infix per CLAUDE.md §0", got)
+			}
+			// TBD-A67 regression guard: the platform marketing domain
+			// `openova.io` must NEVER appear in a per-tenant
+			// WorkspaceURL. The old enrich.go:81 hardcode leaked it
+			// onto every non-openova.io Sovereign.
+			if strings.Contains(got, "openova.io") {
+				t.Errorf("workspaceURL leaked .openova.io into output %q — must use per-Sovereign parent zone only", got)
+			}
+		})
+	}
+}
+
+// TestEnricher_Lookup_WorkspaceURL_UsesParentZone covers the end-to-end
+// path inside Lookup: when the enricher is constructed with a per-
+// Sovereign parent zone, the returned TenantInfo.WorkspaceURL MUST
+// render `https://console.<subdomain>.<parentZone>` from the tenant's
+// subdomain field. The fake tenant + auth servers stub the upstream
+// admin endpoints so we exercise only the enrichment seam.
+func TestEnricher_Lookup_WorkspaceURL_UsesParentZone(t *testing.T) {
+	t.Parallel()
+
+	tenantSvc := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasPrefix(r.URL.Path, "/tenant/admin/tenants/") {
+			http.NotFound(w, r)
+			return
+		}
+		id := strings.TrimPrefix(r.URL.Path, "/tenant/admin/tenants/")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id":        id,
+			"name":      "Acme Inc",
+			"owner_id":  "user-1",
+			"subdomain": "acme",
+		})
+	}))
+	defer tenantSvc.Close()
+	authSvc := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasPrefix(r.URL.Path, "/auth/admin/users/") {
+			http.NotFound(w, r)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"user": map[string]any{
+				"id":    "user-1",
+				"email": "owner@acme.example",
+				"name":  "Alice Owner",
+			},
+		})
+	}))
+	defer authSvc.Close()
+
+	e := NewEnricher(tenantSvc.URL, authSvc.URL, "omani.homes", []byte("test-secret"))
+	info, err := e.Lookup(context.Background(), "tenant-abc")
+	if err != nil {
+		t.Fatalf("Lookup: %v", err)
+	}
+	if info == nil {
+		t.Fatal("Lookup returned nil TenantInfo")
+	}
+	if got, want := info.WorkspaceURL, "https://console.acme.omani.homes"; got != want {
+		t.Errorf("WorkspaceURL: got %q, want %q", got, want)
+	}
+	// TBD-A67 regression guard: rendered body MUST NOT contain the
+	// platform marketing host. The previous implementation appended
+	// `.openova.io` unconditionally.
+	if strings.Contains(info.WorkspaceURL, "openova.io") {
+		t.Errorf("WorkspaceURL leaked .openova.io into per-tenant URL %q", info.WorkspaceURL)
+	}
+}
+
+// TestEnricher_Lookup_WorkspaceURL_EmptyParentZone covers the no-op
+// degrade path: when the operator hasn't wired TENANT_PARENT_DOMAIN
+// (or set it empty), WorkspaceURL renders to the empty string rather
+// than fall back to a hardcoded host. The email template treats empty
+// as "omit the URL line" instead of emit a wrong link.
+func TestEnricher_Lookup_WorkspaceURL_EmptyParentZone(t *testing.T) {
+	t.Parallel()
+
+	tenantSvc := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		id := strings.TrimPrefix(r.URL.Path, "/tenant/admin/tenants/")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id":        id,
+			"name":      "Acme Inc",
+			"owner_id":  "user-1",
+			"subdomain": "acme",
+		})
+	}))
+	defer tenantSvc.Close()
+	authSvc := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"user": map[string]any{
+				"id":    "user-1",
+				"email": "owner@acme.example",
+				"name":  "Alice Owner",
+			},
+		})
+	}))
+	defer authSvc.Close()
+
+	e := NewEnricher(tenantSvc.URL, authSvc.URL, "", []byte("test-secret"))
+	info, err := e.Lookup(context.Background(), "tenant-abc")
+	if err != nil {
+		t.Fatalf("Lookup: %v", err)
+	}
+	if info.WorkspaceURL != "" {
+		t.Errorf("WorkspaceURL with empty parent zone: got %q, want empty string", info.WorkspaceURL)
+	}
+}

--- a/core/services/notification/main.go
+++ b/core/services/notification/main.go
@@ -37,6 +37,15 @@ func main() {
 	natsURL := getEnv("NATS_URL", "")
 	tenantURL := getEnv("TENANT_URL", "http://tenant.sme.svc.cluster.local:8083")
 	authURL := getEnv("AUTH_URL", "http://auth.sme.svc.cluster.local:8081")
+	// TBD-A67 issue #1990: the per-Sovereign parent zone (e.g.
+	// "omani.homes") drives WorkspaceURL rendering. Same env name the
+	// provisioning service uses for Handler.TenantParentDomain so the
+	// Sovereign operator wires it once via bootstrap-kit slot 13 and
+	// every back-end service reads the same value. Empty disables the
+	// URL field rather than fall back to a hardcoded domain — the old
+	// `.openova.io` fallback leaked the platform marketing host into
+	// tenant onboarding emails on every non-openova.io Sovereign.
+	parentZone := getEnv("TENANT_PARENT_DOMAIN", "")
 
 	mailer := handlers.NewMailer(smtpHost, smtpPort, smtpFrom)
 
@@ -66,7 +75,7 @@ func main() {
 			slog.Info("connected to RedPanda (legacy)", "brokers", redpandaBrokersRaw)
 		}
 	}
-	enricher := handlers.NewEnricher(tenantURL, authURL, []byte(jwtSecret))
+	enricher := handlers.NewEnricher(tenantURL, authURL, parentZone, []byte(jwtSecret))
 
 	h := &handlers.Handler{
 		Mailer:   mailer,

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -1,5 +1,38 @@
 apiVersion: v2
 name: bp-catalyst-platform
+# 1.4.210 — TBD-A67 (issue #1990, 2026-05-19): restore canonical
+# `console.<slug>.<parent>` infix on per-tenant HTTPRoute hostnames +
+# drop the hardcoded `.openova.io` suffix on notification-service
+# WorkspaceURL rendering. THREE surgical fixes for the tenant org URL
+# drift (founder's CLAUDE.md §0 spec vs runtime emit):
+#   1. core/controllers/organization/internal/controller/
+#      tenant_route.go:113 — runtime reconciler now emits
+#      `console.<subdomain>.<parentDomain>` (e.g.
+#      `console.acme.omani.homes`), matching the chart-side template
+#      AND sme_tenant_gitops.go:536 host derivation. Pre-fix the
+#      controller emitted `<slug>.<parent>` while the bp-wordpress-
+#      tenant overlay emitted `console.<slug>.<parent>` — the two
+#      drifted and the founder caught it on the t34 walkthrough.
+#   2. products/catalyst/chart/templates/sme-services/
+#      tenant-public-routes.yaml:82 — chart-side static-fixture
+#      template mirrors the runtime reconciler so byte-identical
+#      HTTPRoute shapes are produced via either path.
+#   3. core/services/notification/handlers/enrich.go — WorkspaceURL
+#      no longer hardcodes `https://<subdomain>.openova.io`. Instead
+#      reads the per-Sovereign parent zone from a new TENANT_PARENT_
+#      DOMAIN env (matches the provisioning service's
+#      Handler.TenantParentDomain wiring) and renders
+#      `https://console.<subdomain>.<parentZone>` — empty parent
+#      zone yields empty URL (template skips). Restores compliance
+#      with the "never touch openova.io" rule on every non-openova.io
+#      Sovereign (omani.homes, talents.scope, …).
+# Tests: enrich_test.go covers 5 truth-table cases on the pure helper
+# + 2 end-to-end Lookup cases (parent-zone present and empty); the
+# existing organization_controller_test.go TenantPublic_RendersHTTPRoute
+# assertion bumped from "acme.omani.homes" to "console.acme.omani.homes"
+# + a HasPrefix("console.") regression guard.
+# Refs #1990 TBD-A67.
+#
 # 1.4.209 — TBD-A64 PR γ (issue #1976, 2026-05-19): cosmetic regressions
 # caught by the cosmetic-guards e2e suite. THREE surgical fixes:
 #   1. wizard/steps/logoTone.ts — alloy tile background flipped from
@@ -1765,7 +1798,7 @@ name: bp-catalyst-platform
 # was already shipped on 1.4.197 (PR #1820 lineage); this completes
 # the data-layer side so the dropdown finally appears on multi-region
 # Sovereigns. Refs #1821, DoD D20.
-version: 1.4.209
+version: 1.4.210
 appVersion: 1.4.208
 # 1.4.183 — fix(httproute): omit default sectionName so multi-zone
 # Sovereigns attach via Cilium Gateway hostname matcher (Closes #1884,

--- a/products/catalyst/chart/templates/sme-services/tenant-public-routes.yaml
+++ b/products/catalyst/chart/templates/sme-services/tenant-public-routes.yaml
@@ -1,14 +1,16 @@
 {{- /*
 Per-Organization public HTTPRoutes (issue #1629 follow-up).
 
-PowerDNS now resolves `<slug>.<parentDomain>` for every Org that
-maps onto a Sovereign's role=sme-pool parent domain. Without an
+PowerDNS now resolves `console.<slug>.<parentDomain>` for every Org
+that maps onto a Sovereign's role=sme-pool parent domain. Without an
 attached HTTPRoute the Cilium Gateway terminates TLS on the
 wildcard cert and falls through to the marketplace `tenant-wildcard`
 route — which sends the request to the marketplace `console` Service
 instead of the tenant's installed product. The end result is
-`acme.omani.homes` rendering the storefront landing page rather than
-the tenant's WordPress.
+`console.acme.omani.homes` rendering the storefront landing page
+rather than the tenant's WordPress. TBD-A67 issue #1990 restored the
+`console.` infix; without it the runtime reconciler and the chart-
+side overlay drifted (controller emitted bare `<slug>.<parent>`).
 
 This template renders ONE HTTPRoute per entry in `.Values.tenantRoutes`
 attached to the canonical Cilium Gateway (`cilium-gateway` in
@@ -79,7 +81,14 @@ spec:
     - name: {{ $gwName | quote }}
       namespace: {{ $gwNs | quote }}
   hostnames:
-    - {{ printf "%s.%s" $sub $parent | quote }}
+    # TBD-A67 issue #1990: emit `console.<subdomain>.<parentDomain>`.
+    # The `console.` infix is the canonical per-tenant console hostname
+    # (CLAUDE.md §0 + products/catalyst/bootstrap/api/internal/handler/
+    # sme_tenant_gitops.go:536). Mirrors the runtime reconciler in
+    # core/controllers/organization/internal/controller/tenant_route.go
+    # so static-fixture Helm values and the live controller produce
+    # byte-identical HTTPRoute shapes.
+    - {{ printf "console.%s.%s" $sub $parent | quote }}
   rules:
     - matches:
         - path:


### PR DESCRIPTION
## Summary

TBD-A67 (issue #1990) — surgical 3-file fix for the tenant org URL drift between the founder's CLAUDE.md §0 spec (`console.<slug>.<parent>`) and the runtime emit. Pre-fix the per-tenant HTTPRoute reconciler emitted `<slug>.<parent>` while the chart-side overlay and `sme_tenant_gitops.go:536` emitted the console-prefixed shape; tenant onboarding emails on every non-openova.io Sovereign leaked the platform marketing host into the WorkspaceURL.

- `core/controllers/organization/internal/controller/tenant_route.go:113` — emits `console.<subdomain>.<parentDomain>` so the runtime reconciler and the chart-side overlay produce byte-identical HTTPRoute shapes.
- `products/catalyst/chart/templates/sme-services/tenant-public-routes.yaml:82` — chart-side analogue mirrors the new console-prefixed shape.
- `core/services/notification/handlers/enrich.go` — WorkspaceURL now `https://console.<sub>.<parentZone>` where parentZone comes from a new `TENANT_PARENT_DOMAIN` env (same name the provisioning service uses for `Handler.TenantParentDomain`). Empty parent zone yields empty URL — NEVER falls back to `.openova.io`.

## Tests

- New `enrich_test.go`: 5 truth-table cases on the pure `workspaceURL` helper + 2 end-to-end `Lookup` cases. Hard regression guard that the rendered URL carries the `console.` prefix AND contains no `openova.io` substring.
- Updated `organization_controller_test.go::TestReconcile_TenantPublic_RendersHTTPRoute`: assertion bumped from `acme.omani.homes` to `console.acme.omani.homes` + `strings.HasPrefix("console.")` regression guard.

## Chart

- `bp-catalyst-platform` `1.4.209` → `1.4.210`.
- `clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml` pin bumped to match.

## Test plan

- [x] `go test ./core/services/notification/...` — green
- [x] `go test ./core/controllers/organization/...` — green
- [x] `go test ./core/services/provisioning/handlers/...` — green (unchanged behaviour around `subdomain` patch)
- [x] `helm lint products/catalyst/chart` — clean
- [x] `helm template products/catalyst/chart -f tenantRoutes-fixture | grep hostnames -A1` confirms rendered hostname is `console.acme.omani.homes`
- [x] `git grep '\.openova\.io"' -- '*.go'` audit: only legitimate platform-control-plane usages remain (CRD groups, cert-manager-dynadot-webhook group name, DNS quorum lease domain) — zero tenant-URL leaks.

## References

- Closes #1990 (TBD-A67)
- Unblocks #1949 (TBD-A57 `/redeem` page customer redirect flow URL)