### PR TITLE
fix(chart): bump organization-controller pin 72e3f08 -> c9b58ea (Closes #1997)

### DIFF
--- a/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
+++ b/clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml
@@ -736,7 +736,17 @@ spec:
       # `marketplace.<global.sovereignFQDN>` so every tenant request
       # stays on its own Sovereign instead of bouncing to the
       # mothership marketplace. Catalyst-Zero render byte-identical.
-      version: 1.4.212
+      # 1.4.213 — TBD-A68 follow-up / #1997 (2026-05-20): bump the
+      # organization-controller image pin from the 2026-05-10
+      # `72e3f08` to `c9b58ea` so the chart ships PR #1910's
+      # gitea-client fix (POST /api/v1/orgs, not /api/v1/admin/orgs).
+      # Pre-fix on t38 the controller logged `POST /api/v1/admin/orgs
+      # HTTP 405` every 30s and tenant Organization CRs were stuck
+      # Ready=False/GiteaOrgFailed. Pure pin bump, no code in this
+      # PR; the code fix is upstream in #1910. The CI auto-bump-
+      # images job skipped controller images (TBD-A69 follow-up
+      # tracks closing that gap).
+      version: 1.4.213
       sourceRef:
         kind: HelmRepository
         name: bp-catalyst-platform

--- a/products/catalyst/chart/Chart.yaml
+++ b/products/catalyst/chart/Chart.yaml
@@ -1,5 +1,25 @@
 apiVersion: v2
 name: bp-catalyst-platform
+# 1.4.213 — TBD-A68 / #1997 (2026-05-20): bump organization-controller
+# image pin 72e3f08 → c9b58ea so the chart actually ships PR #1910's
+# gitea-client fix (POST /api/v1/orgs instead of the admin-only
+# /api/v1/admin/orgs route that returns HTTP 405 to the in-cluster SA).
+# Pre-fix on t38 (2026-05-19 21:41Z, chart 1.4.211): two Organization
+# CRs walkdemo38 + walk-t38-2138 stuck Ready=False/GiteaOrgFailed
+# with `POST .../api/v1/admin/orgs: HTTP 405` in the message, and
+# organization-controller logs spewing the same 405 every 30s.
+# Root cause was deployment-time, not code: PR #1910 merged to main
+# on 2026-05-19 03:59Z and the build-organization-controller workflow
+# produced fresh images (f442c28, then c9b58ea), but the chart's pin
+# at products/catalyst/chart/values.yaml:369 was never updated. The
+# CI auto-bump-images job covers SME images only; controller images
+# fall through the gap (TBD-A69 follow-up tracks closing that gap so
+# this class of stale-pin bug stops happening). This bump is a pure
+# pin update — no code change in this PR; the code fix is upstream in
+# #1910. Validation: `helm template products/catalyst/chart | grep
+# organization-controller` shows c9b58ea, not 72e3f08; post-deploy
+# controller logs show `POST /orgs 201`, the two stuck Organization
+# CRs on t38 auto-recover.
 # 1.4.212 — TBD-A68 (issue #1994, 2026-05-19): purge five `.openova.io`
 # leaks that sent tenant users to the mothership instead of THEIR
 # Sovereign. Five surgical fixes:
@@ -1831,8 +1851,8 @@ name: bp-catalyst-platform
 # was already shipped on 1.4.197 (PR #1820 lineage); this completes
 # the data-layer side so the dropdown finally appears on multi-region
 # Sovereigns. Refs #1821, DoD D20.
-version: 1.4.212
-appVersion: 1.4.212
+version: 1.4.213
+appVersion: 1.4.213
 # 1.4.183 — fix(httproute): omit default sectionName so multi-zone
 # Sovereigns attach via Cilium Gateway hostname matcher (Closes #1884,
 # TBD-A30). Pre-1.4.183 every catalyst-system HTTPRoute pinned

--- a/products/catalyst/chart/values.yaml
+++ b/products/catalyst/chart/values.yaml
@@ -364,9 +364,24 @@ controllers:
     enabled: true
     image:
       repository: "ghcr.io/openova-io/openova/organization-controller"
-      # 72e3f08 = qa-loop iter-8 Fix #42 (#1252 + Containerfile fix-up
-      # #1253) — fixes Bug 1 (UserAccess Claim namespace).
-      tag: "72e3f08"
+      # c9b58ea = TBD-A68 fix (#1997, 2026-05-20) — picks up PR #1910's
+      # gitea-client fix (POST /api/v1/orgs instead of the admin-only
+      # /api/v1/admin/orgs endpoint that returned HTTP 405 to the
+      # in-cluster service account). Walked on t38 2026-05-19 21:41Z:
+      # two Organization CRs (walkdemo38, walk-t38-2138) stuck
+      # Ready=False / GiteaOrgFailed with the 405 in the message.
+      # Pre-fix the chart pinned 72e3f08 (2026-05-10), which predates
+      # #1910's merge to main on 2026-05-19 03:59Z. The CI auto-bump-
+      # images job covers SME images only (TBD-A69 follow-up tracks
+      # extending it to controller images), so this controller-image
+      # pin remained stale through three subsequent chart bumps.
+      # c9b58ea is the most recent main-HEAD push that successfully
+      # rebuilt this image and is the latest controller-touching SHA
+      # (run id 2026-05-19T20:58:00Z on the build-organization-
+      # controller workflow). Previously: 72e3f08 = qa-loop iter-8
+      # Fix #42 (#1252 + Containerfile fix-up #1253), fixed Bug 1
+      # (UserAccess Claim namespace).
+      tag: "c9b58ea"
       pullPolicy: IfNotPresent
     replicas: 1
     leaderElection:


### PR DESCRIPTION
## Summary

- **Closes #1997** (TBD-A68 organization-controller gitea 405).
- Bumps `products/catalyst/chart/values.yaml:369` organization-controller image tag from `72e3f08` (2026-05-10) to `c9b58ea` (current main HEAD, post-#1910) so the chart finally ships PR #1910's `POST /api/v1/orgs` fix.
- Chart version 1.4.212 -> 1.4.213, bootstrap-kit pin updated symmetrically.
- **No code change** — the code fix is upstream in #1910 (merged 2026-05-19 03:59Z). This PR is a pure deployment-pin update.

## Background

t38 walkthrough on 2026-05-19 21:41Z (chart `bp-catalyst-platform@1.4.211`) put two tenant Organization CRs (`walkdemo38`, `walk-t38-2138`) into `Ready=False`/`GiteaOrgFailed` with:

```
gitea.EnsureOrg: create: gitea: POST http://gitea-http.gitea.svc.cluster.local:3000/api/v1/admin/orgs: HTTP 405:
```

PR #1910 already changed `gitea.EnsureOrg` to hit `POST /api/v1/orgs` (the user-token endpoint) instead of `/api/v1/admin/orgs` (admin-only, returns 405 to the in-cluster SA). The `build-organization-controller` workflow built fresh images at `f442c28` (the merge of #1910) and then again at `c9b58ea` (latest main HEAD).

The bug on t38 was deployment-time only: the chart's pin at `values.yaml:369` was last bumped on 2026-05-10 (`72e3f08`) and the CI auto-bump-images job covers SME images only — controller images fall through the gap. The 1.4.210 / 1.4.211 / 1.4.212 chart bumps all shipped with the stale controller pin.

## Files changed

| File | Change |
|---|---|
| `products/catalyst/chart/values.yaml:369` | `tag: \"72e3f08\"` -> `tag: \"c9b58ea\"` + changelog comment |
| `products/catalyst/chart/Chart.yaml` | version + appVersion `1.4.212` -> `1.4.213` + changelog entry |
| `clusters/_template/bootstrap-kit/13-bp-catalyst-platform.yaml:739` | bp-catalyst-platform pin `1.4.212` -> `1.4.213` + changelog entry |

## Validation

- ``helm template products/catalyst/chart | grep organization-controller`` renders:
  ``image: \"ghcr.io/openova-io/openova/organization-controller:c9b58ea\"``
- Full ``helm template`` exits 0, 50 manifests, zero `72e3f08` references remain.
- GHCR manifest probe (`HEAD /v2/openova-io/openova/organization-controller/manifests/c9b58ea`) returns HTTP 200 with `application/vnd.docker.distribution.manifest.v2+json` — the image exists and is pullable by the in-cluster `ghcr-pull` secret.

## Test plan

- [x] `helm template products/catalyst/chart` renders cleanly with the new pin.
- [x] No remaining `72e3f08` substring in helm output.
- [x] GHCR registry confirms `c9b58ea` tag is published.
- [ ] CI green on this PR (chart-publish workflow republishes 1.4.213 to GHCR HelmRepository).
- [ ] After merge + ~1 min Flux reconcile on t38: `kubectl -n catalyst-system get deploy organization-controller -o jsonpath='{.spec.template.spec.containers[0].image}'` shows `:c9b58ea`.
- [ ] Controller logs flip from repeating `POST /api/v1/admin/orgs HTTP 405` to `POST /api/v1/orgs 201`.
- [ ] Stuck CRs `walkdemo38` + `walk-t38-2138` auto-recover to `Ready=True` (gitea EnsureOrg is idempotent; reconcile re-fires).

## Follow-up

Filing **TBD-A69** separately for the structural CI gap: `auto-bump-images` job covers SME images but skips controller images. Closing that gap will prevent the next controller-image stale-pin slip.

## Refs

- Closes #1997 — TBD-A68 organization-controller gitea 405
- Refs #1910 — upstream code fix this PR finally ships
- Refs #1829 — D29 tenant onboarding (unblocked by this fix)
- Refs #1842, #1945 — adjacent tenant-provisioning issues