### PR TITLE
fix(build-organization-controller): add missing auto-bump pipeline + pkg/** path filter (Refs #1997)

### DIFF
--- a/.github/workflows/build-organization-controller.yaml
+++ b/.github/workflows/build-organization-controller.yaml
@@ -20,6 +20,15 @@ on:
     paths:
       - 'core/controllers/organization/**'
       - 'core/controllers/internal/**'
+      # core/controllers/pkg/** is the shared HTTP-client tree (gitea,
+      # keycloak, kc-mappers, …) consumed by every Group C controller's
+      # Containerfile via `COPY core/controllers/pkg`. Without this path
+      # entry a change like PR #1910 (gitea-client /admin/orgs → /orgs)
+      # rebuilds the image only if the same PR also happens to touch
+      # files under organization/ — which silently held the t38 #1997
+      # gitea-405 fix in main for ~12h. Mirror in every sibling
+      # build-*-controller.yaml.
+      - 'core/controllers/pkg/**'
       - 'core/controllers/go.mod'
       - 'core/controllers/go.sum'
       - '.github/workflows/build-organization-controller.yaml'
@@ -28,6 +37,7 @@ on:
     paths:
       - 'core/controllers/organization/**'
       - 'core/controllers/internal/**'
+      - 'core/controllers/pkg/**'
       - 'core/controllers/go.mod'
       - 'core/controllers/go.sum'
       - '.github/workflows/build-organization-controller.yaml'
@@ -41,9 +51,23 @@ jobs:
   build:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      # contents: write — the deploy job below pushes a values.yaml SHA
+      # bump back to main so the bp-catalyst-platform chart picks up the
+      # newly-built image without an operator manually editing the file
+      # (per `feedback_no_mvp_no_workarounds.md` rule 1: target-state,
+      # never "manual follow-up bump"). Pre-#1997 this workflow shipped
+      # WITHOUT this auto-bump, so PR #1910's gitea-client /admin/orgs
+      # → /orgs fix sat in main for ~12h while the chart pin stayed
+      # frozen at 72e3f08, leaving t38's organization-controller
+      # looping HTTP 405 and blocking D29 end-to-end. Mirrors the
+      # shape of build-application-controller.yaml.
+      contents: write
       packages: write
+      # id-token write is required by cosign keyless signing (Sigstore).
       id-token: write
+      # actions: write — required for `gh workflow run` to dispatch the
+      # downstream blueprint-release chart re-publish workflow.
+      actions: write
     outputs:
       sha_short: ${{ steps.vars.outputs.sha_short }}
       digest: ${{ steps.build.outputs.digest }}
@@ -124,3 +148,67 @@ jobs:
             --predicate <(echo '{"sbom":"in-toto-spdx attached at build time"}') \
             --type spdx \
             "${IMAGE}@${DIGEST}"
+
+      # Auto-bump the chart values.yaml tag so the next Sovereign chart
+      # rollout picks up this image without a manual edit. Per
+      # `feedback_no_mvp_no_workarounds.md` rule 1 (target-state, no
+      # operator-action gates) and `feedback_inviolable_principles.md`
+      # (event-driven, never cron). Mirrors the pattern in
+      # build-application-controller.yaml. Added as part of #1997 —
+      # without this step, PR #1910's gitea-client /admin/orgs → /orgs
+      # fix sat frozen in main while t38 organization-controller looped
+      # HTTP 405 on every Organization reconcile.
+      - name: Bump controllers.organization.image.tag in values.yaml
+        if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
+        env:
+          SHA_SHORT: ${{ steps.vars.outputs.sha_short }}
+        run: |
+          VALUES="products/catalyst/chart/values.yaml"
+          # awk: find `  organization:` under `controllers:`, then update
+          # the next `tag: "..."` line. Stops at the next top-level key
+          # so we don't accidentally bump a sibling controller's tag.
+          awk -v sha="${SHA_SHORT}" '
+            /^controllers:/ { in_ctrls=1 }
+            in_ctrls && /^  organization:/ { print; in_org=1; next }
+            in_ctrls && /^  [a-z]/ && !/^  organization:/ { in_org=0 }
+            in_org && /^      tag:/ { sub(/"[^"]*"/, "\"" sha "\""); in_org=0 }
+            { print }
+          ' "${VALUES}" > "${VALUES}.tmp" && mv "${VALUES}.tmp" "${VALUES}"
+          echo "values.yaml after bump:"
+          grep -A4 "^  organization:" "${VALUES}" | head -10
+
+      - name: Commit and push values.yaml bump
+        id: deploy_commit
+        if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
+        env:
+          SHA_SHORT: ${{ steps.vars.outputs.sha_short }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          if git diff --quiet products/catalyst/chart/values.yaml; then
+            echo "no values.yaml change — already pinned to ${SHA_SHORT}"
+            echo "pushed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          git add products/catalyst/chart/values.yaml
+          git commit -m "deploy: bump organization-controller image to ${SHA_SHORT}"
+          # Pull-rebase to avoid races with parallel build commits.
+          git pull --rebase --autostash origin main || true
+          git push origin HEAD:main
+          echo "pushed=true" >> "$GITHUB_OUTPUT"
+
+      # GitHub Actions does NOT trigger workflows from bot pushes by
+      # default (anti-recursion safeguard). Without this dispatch the
+      # rebuilt image is NEVER baked into a new chart version, so
+      # Sovereigns keep installing the previous chart with the previous
+      # image tag (`feedback_no_mvp_no_workarounds.md` rule 1 violation).
+      - name: Dispatch blueprint-release for chart re-publish
+        if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main' && steps.deploy_commit.outputs.pushed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh workflow run blueprint-release.yaml \
+            --repo "${GITHUB_REPOSITORY}" \
+            --ref main \
+            -f blueprint=catalyst \
+            -f tree=products

--- a/core/controllers/pkg/gitea/client_test.go
+++ b/core/controllers/pkg/gitea/client_test.go
@@ -1197,3 +1197,80 @@ func TestCreatePullRequest_409ReFetchesExisting(t *testing.T) {
 		t.Errorf("re-fetched PR head/base wrong: %+v", pr)
 	}
 }
+
+// TestCreateOrg_HitsOrgsEndpointWithAuth — explicit regression test for
+// issue #1997 (TBD-A68 followup of PR #1910 / issue #1906). On t38 the
+// organization-controller looped on
+//
+//	gitea.EnsureOrg: create: gitea: POST http://gitea.../api/v1/admin/orgs: HTTP 405
+//
+// even after PR #1910 fixed the gitea client source — because the
+// chart's controllers.organization.image.tag was frozen at 72e3f08
+// (no auto-bump step in build-organization-controller.yaml) so the
+// running Pod predated the fix. This test ASSERTS the canonical wire-
+// level invariants so the bug cannot silently regress regardless of
+// the deploy pipeline state:
+//
+//  1. CreateOrg POSTs `/api/v1/orgs` exactly once (never the legacy
+//     `/api/v1/admin/orgs` which returns 405 on Gitea 1.22+).
+//  2. The request carries `Authorization: token <hex>` — Gitea's
+//     canonical admin-token auth scheme. Without this header, even the
+//     correct endpoint returns 405 (Gitea's router treats the
+//     unauthenticated POST as "method not allowed for anonymous
+//     visitors").
+//
+// Coverage rationale: the existing TestEnsureOrg_CreatesWhenMissing
+// covers the happy path through fakeGitea which already rejects empty
+// auth via its 401 stub (client_test.go:66-69). This standalone test
+// additionally pins the exact endpoint string + the exact Authorization
+// header VALUE so a refactor cannot accidentally switch the URL or
+// drop the token prefix.
+func TestCreateOrg_HitsOrgsEndpointWithAuth(t *testing.T) {
+	t.Parallel()
+	var (
+		gotPath string
+		gotAuth string
+		hits    int
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Regression guard: any request to the legacy admin route is a
+		// hard test failure. Gitea 1.22+ returns 405 on this path which
+		// is exactly the symptom of #1997 in the wild.
+		if strings.HasPrefix(r.URL.Path, "/api/v1/admin/orgs") {
+			t.Errorf("client used legacy /api/v1/admin/orgs route — must POST /api/v1/orgs (Gitea 1.22+ returns 405 on admin/orgs)")
+			http.Error(w, "405 admin/orgs is the bug", http.StatusMethodNotAllowed)
+			return
+		}
+		if r.Method != http.MethodPost || r.URL.Path != "/api/v1/orgs" {
+			http.Error(w, "unhandled "+r.Method+" "+r.URL.Path, http.StatusInternalServerError)
+			return
+		}
+		hits++
+		gotPath = r.URL.Path
+		gotAuth = r.Header.Get("Authorization")
+		_ = json.NewEncoder(w).Encode(Org{ID: 42, Username: "acme"})
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "deadbeefcafef00d")
+	c.HTTP = srv.Client()
+
+	out, err := c.CreateOrg(context.Background(), "acme", "ACME", "desc", "private")
+	if err != nil {
+		t.Fatalf("CreateOrg: %v", err)
+	}
+	if out.ID != 42 || out.Username != "acme" {
+		t.Errorf("CreateOrg returned unexpected Org: %+v", out)
+	}
+
+	// Wire-level assertions: exact endpoint, exact auth scheme.
+	if hits != 1 {
+		t.Errorf("expected 1 POST hit, got %d", hits)
+	}
+	if gotPath != "/api/v1/orgs" {
+		t.Errorf("endpoint: got %q, want %q", gotPath, "/api/v1/orgs")
+	}
+	if want := "token deadbeefcafef00d"; gotAuth != want {
+		t.Errorf("Authorization header: got %q, want %q", gotAuth, want)
+	}
+}


### PR DESCRIPTION
## Summary

- PR #2004 caught up the organization-controller chart pin (72e3f08 → c9b58ea) to ship PR #1910's gitea-client `/admin/orgs` → `/orgs` fix on t38. That unblocks D29 today, but the underlying deploy gap that produced #1997 is still live: `build-organization-controller.yaml` has no auto-bump step (every sibling does), and its path filter misses `core/controllers/pkg/**`. The next shared-client fix would silently re-strand exactly like PR #1910 did for 18h.
- This PR closes both gaps so #1997 cannot recur: adds the application-controller-shaped auto-bump pipeline (awk-scoped tag bump + commit/push + `blueprint-release` dispatch), promotes `permissions.contents` to write, and adds `core/controllers/pkg/**` to both push and pull_request path filters.
- Adds a wire-level regression test `TestCreateOrg_HitsOrgsEndpointWithAuth` that fails hard if the client ever hits `/api/v1/admin/orgs` or drops the `Authorization: token <hex>` header — pinning the contract regardless of which chart pin is deployed.

## What this PR is NOT

- It does NOT bump any chart pins or controller image tags. PR #2004 already did the catch-up; the workflow added here ensures future bumps happen automatically on every `build-organization-controller` build push.
- It does NOT touch sibling controllers (environment, blueprint, useraccess, …) — they likely have the same missing-auto-bump and missing-pkg/** gaps but fixing them in this PR would explode blast radius. Recommend a follow-up audit issue.

## Files touched (2)

| File | Change |
|---|---|
| `.github/workflows/build-organization-controller.yaml` | + auto-bump pipeline mirroring `build-application-controller.yaml` (permissions: write + awk-scoped tag bump + commit/push + `blueprint-release` dispatch) + `core/controllers/pkg/**` in push and pull_request path filters |
| `core/controllers/pkg/gitea/client_test.go` | + `TestCreateOrg_HitsOrgsEndpointWithAuth` — fails the test if the client hits `/admin/orgs` or drops the `token <hex>` header |

## Test plan

- [x] `go vet ./pkg/gitea/...` — clean (go 1.23)
- [x] `go test -race ./pkg/gitea/...` — `ok` 1.573s, all pre-existing tests + `TestCreateOrg_HitsOrgsEndpointWithAuth` PASS
- [x] `go test -run TestCreateOrg_HitsOrgsEndpointWithAuth -v` — PASS in 0.02s
- [ ] CI green (this PR): build-organization-controller workflow validates the new path filter + dry-run auto-bump paths
- [ ] Post-merge: a touch-only change under `core/controllers/pkg/gitea/` should trigger build-organization-controller AND auto-update values.yaml + dispatch blueprint-release

## References

- Refs #1997 (PR #2004 closed the immediate symptom; this PR closes the deploy gap so #1997 cannot recur)
- Refs #1910 (the original `/admin/orgs` → `/orgs` code fix)
- Refs #1829 (D29 customer journey hardening)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>